### PR TITLE
Fix PR Diagram Model — haiku → sonnet for Judgment Calls

### DIFF
--- a/src/autoskillit/skills/open-pr/SKILL.md
+++ b/src/autoskillit/skills/open-pr/SKILL.md
@@ -59,7 +59,7 @@ Split `plan_paths` by comma to get a list of plan file paths.
 Read all plan files. For each, extract the first `# ` heading line and strip the `# ` prefix.
 
 - **Single plan:** Use the heading directly as `{task_title}` (current behavior).
-- **Multiple plans:** Spawn a subagent (Task tool, model: haiku) with all extracted
+- **Multiple plans:** Spawn a subagent (Task tool, model: sonnet) with all extracted
   headings. Instruct it to synthesize a single concise PR title (under 70 characters)
   that captures the overall scope. The title should NOT enumerate every group — it
   should describe the aggregate change.
@@ -76,7 +76,7 @@ an empty file list (the PR body will note that no diff was available).
 
 ### Step 4: Select Arch-Lens Lenses
 
-Spawn a subagent (Task tool, model: haiku) with the list of changed file paths and the
+Spawn a subagent (Task tool, model: sonnet) with the list of changed file paths and the
 following lens menu:
 
 ```
@@ -154,7 +154,7 @@ Plan file: `{plan_path}`
 ## Summary
 
 {Synthesized overall summary — 2-3 sentences covering the aggregate change.
- Use a haiku subagent to produce this from all individual summaries.}
+ Use a sonnet subagent to produce this from all individual summaries.}
 
 {If closing_issue is provided and non-empty:}
 Closes #{closing_issue}


### PR DESCRIPTION
## Summary

The `open-pr` skill and the `arch-lens-mcp` lens selection pipeline both use `model: haiku` for two judgment-intensive subagent calls: lens selection (Step 4 of open-pr / `_SELECTION_MODEL` in `lens_selection.py`) and PR title synthesis for multi-plan runs (Step 2 of open-pr). Haiku is insufficiently reliable for these calls — it makes poor lens choices and produces weak titles, degrading the quality of every generated PR body. The fix is to replace all haiku model references in these judgment paths with sonnet in both the autoskillit and arch-lens-mcp repos.

## Architecture Impact

### Development Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph Structure ["PROJECT STRUCTURE"]
        direction LR
        SRC["src/autoskillit/<br/>━━━━━━━━━━<br/>89 source files<br/>10 sub-packages"]
        TESTS["tests/<br/>━━━━━━━━━━<br/>124 test files<br/>11 sub-directories"]
        SKILLS["src/autoskillit/skills/<br/>━━━━━━━━━━<br/>23 bundled skills<br/>SKILL.md per skill"]
    end

    subgraph Build ["BUILD TOOLING"]
        direction TB
        PYPROJECT["pyproject.toml<br/>━━━━━━━━━━<br/>hatchling backend<br/>uv package manager"]
        TASKFILE["Taskfile.yml<br/>━━━━━━━━━━<br/>go-task runner<br/>test-all · test-check<br/>test-smoke · install-worktree"]
        UVLOCK["uv.lock<br/>━━━━━━━━━━<br/>Pinned dependency graph<br/>uv-lock-check enforces sync"]
    end

    subgraph Quality ["CODE QUALITY GATES (pre-commit)"]
        direction LR
        FORMAT["ruff format<br/>━━━━━━━━━━<br/>Auto-formats Python<br/>READ+WRITE source"]
        LINT["ruff check --fix<br/>━━━━━━━━━━<br/>E · F · I · UP · TID251<br/>Banned: logging.getLogger"]
        TYPES["mypy src/<br/>━━━━━━━━━━<br/>--ignore-missing-imports<br/>READ only · reports errors"]
        IMPORTLINT["import-linter<br/>━━━━━━━━━━<br/>7 layered contracts<br/>L0→L1→L2→L3 enforced"]
        SECRETS["gitleaks v8.30.0<br/>━━━━━━━━━━<br/>Secret scanning<br/>READ only · blocks commit"]
    end

    subgraph Testing ["TEST FRAMEWORK"]
        direction TB
        PYTEST["pytest<br/>━━━━━━━━━━<br/>asyncio_mode=auto<br/>timeout=60s · signal method"]
        XDIST["pytest-xdist<br/>━━━━━━━━━━<br/>-n 4 parallel workers<br/>RAM tmpdir: /dev/shm"]
        MARKERS["Test Markers<br/>━━━━━━━━━━<br/>smoke: requires API key<br/>default: excludes smoke"]
        OUTPUT["temp/test-{ts}.txt<br/>━━━━━━━━━━<br/>Captured test output<br/>PASS/FAIL for automation"]
    end

    subgraph EntryPoints ["ENTRY POINTS"]
        direction LR
        CLI["autoskillit CLI<br/>━━━━━━━━━━<br/>autoskillit.cli:main<br/>serve · init · doctor · skills"]
        MCPSERVER["MCP Server<br/>━━━━━━━━━━<br/>autoskillit serve<br/>22 tools via FastMCP"]
    end

    PYPROJECT --> TASKFILE
    PYPROJECT --> UVLOCK
    SRC --> FORMAT
    FORMAT --> LINT
    LINT --> TYPES
    TYPES --> IMPORTLINT
    IMPORTLINT --> SECRETS
    SECRETS -->|"pre-commit gate"| PYTEST
    TESTS --> PYTEST
    PYTEST --> XDIST
    PYTEST --> MARKERS
    PYTEST --> OUTPUT
    TASKFILE -->|"task test-all"| PYTEST
    TASKFILE -->|"task test-check"| OUTPUT
    PYPROJECT --> CLI
    CLI --> MCPSERVER

    class SRC,TESTS,SKILLS cli;
    class PYPROJECT,TASKFILE,UVLOCK phase;
    class FORMAT detector;
    class LINT,TYPES,IMPORTLINT,SECRETS detector;
    class PYTEST,XDIST,MARKERS handler;
    class OUTPUT,CLI,MCPSERVER output;
```

**Color Legend:**
| Color | Category | Description |
|-------|----------|-------------|
| Dark Blue | Structure | Project directories and source layout |
| Purple | Build | Build config, task runner, lockfile |
| Red | Quality | Pre-commit hooks: format, lint, type check, import contracts, secrets |
| Orange | Testing | pytest, xdist parallelism, test markers |
| Dark Teal | Output | Generated artifacts, CLI entry points, MCP server |

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/fix-pr-diagram-20260304-183851-375362/temp/make-plan/fix_pr_diagram_model_plan_2026-03-04_190000.md`

## Token Usage Summary

| Step | input | output | cache_create | cache_read |
|------|-------|--------|--------------|------------|
| plan | 46 | 15,236 | 66,526 | 1,510,827 |
| verify | 22 | 8,281 | 55,076 | 648,733 |
| implement | 40 | 9,463 | 49,683 | 1,460,578 |
| audit_impl | 13 | 2,150 | 27,881 | 180,408 |
| **Total** | **121** | **35,130** | **199,166** | **3,800,546** |

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
