### PR TITLE
Workspace clean safety guards

### DIFF
--- a/src/autoskillit/cli/_workspace.py
+++ b/src/autoskillit/cli/_workspace.py
@@ -1,0 +1,78 @@
+"""Workspace clean helpers: age partitioning, display, and confirmation."""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import time
+from pathlib import Path
+
+
+def _format_age(seconds: float) -> str:
+    """Convert an age in seconds to a human-readable string."""
+    if seconds < 3600:
+        return f"{int(seconds // 60)}m ago"
+    if seconds < 86400:
+        h = int(seconds // 3600)
+        m = int((seconds % 3600) // 60)
+        return f"{h}h {m}m ago" if m else f"{h}h ago"
+    return f"{int(seconds // 86400)}d ago"
+
+
+def run_workspace_clean(*, dir: str | None = None, force: bool = False) -> None:
+    """Core logic for ``workspace clean`` — partitions, displays, confirms, deletes."""
+    base = Path(dir).resolve() if dir else Path.cwd().parent
+    runs_dir = base / "autoskillit-runs"
+
+    if not runs_dir.is_dir():
+        print(f"No autoskillit-runs/ directory found under: {base}")
+        return
+
+    now = time.time()
+    threshold = 5 * 3600  # 5 hours in seconds
+    stale: list[tuple[Path, float]] = []
+    recent: list[tuple[Path, float]] = []
+    for entry in sorted(runs_dir.iterdir()):
+        if entry.is_dir():
+            age = now - entry.stat().st_mtime
+            if age >= threshold:
+                stale.append((entry, age))
+            else:
+                recent.append((entry, age))
+
+    if recent:
+        print("Skipped (modified < 5h ago):")
+        for path, age in recent:
+            print(f"  {path.relative_to(runs_dir.parent)}  ({_format_age(age)})")
+        print()
+
+    if not stale:
+        print(f"Nothing to clean in {runs_dir}")
+        return
+
+    print("Will remove:")
+    for path, age in stale:
+        print(f"  {path.relative_to(runs_dir.parent)}  ({_format_age(age)})")
+    print()
+
+    if not force:
+        suffix = "ies" if len(stale) != 1 else "y"
+        answer = input(f"Remove {len(stale)} director{suffix}? [y/N]: ")
+        if answer.strip().lower() != "y":
+            print("Aborted.")
+            return
+
+    count = 0
+    errors = 0
+    for path, _ in stale:
+        try:
+            shutil.rmtree(path)
+            print(f"Removed: {path}")
+            count += 1
+        except OSError as exc:
+            print(f"Failed to remove {path}: {exc}", file=sys.stderr)
+            errors += 1
+
+    suffix = "ies" if count != 1 else "y"
+    err_note = f" ({errors} error(s))" if errors else ""
+    print(f"\nCleaned {count} director{suffix}{err_note}")

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -8,7 +8,6 @@ import os
 import shutil
 import subprocess
 import sys
-import time
 from datetime import UTC
 from pathlib import Path
 from typing import Annotated
@@ -300,17 +299,6 @@ def workspace_init(path: str):
     print(f"Reset guard marker created: {marker}")
 
 
-def _format_age(seconds: float) -> str:
-    """Convert an age in seconds to a human-readable string."""
-    if seconds < 3600:
-        return f"{int(seconds // 60)}m ago"
-    if seconds < 86400:
-        h = int(seconds // 3600)
-        m = int((seconds % 3600) // 60)
-        return f"{h}h {m}m ago" if m else f"{h}h ago"
-    return f"{int(seconds // 86400)}d ago"
-
-
 @workspace_app.command(name="clean")
 def workspace_clean(
     *,
@@ -330,61 +318,9 @@ def workspace_clean(
     force
         Skip the confirmation prompt and delete stale directories immediately.
     """
-    base = Path(dir).resolve() if dir else Path.cwd().parent
-    runs_dir = base / "autoskillit-runs"
+    from autoskillit.cli._workspace import run_workspace_clean
 
-    if not runs_dir.is_dir():
-        print(f"No autoskillit-runs/ directory found under: {base}")
-        return
-
-    now = time.time()
-    threshold = 5 * 3600  # 5 hours in seconds
-    stale: list[tuple[Path, float]] = []
-    recent: list[tuple[Path, float]] = []
-    for entry in sorted(runs_dir.iterdir()):
-        if entry.is_dir():
-            age = now - entry.stat().st_mtime
-            if age >= threshold:
-                stale.append((entry, age))
-            else:
-                recent.append((entry, age))
-
-    if recent:
-        print("Skipped (modified < 5h ago):")
-        for path, age in recent:
-            print(f"  {path.relative_to(runs_dir.parent)}  ({_format_age(age)})")
-        print()
-
-    if not stale:
-        print(f"Nothing to clean in {runs_dir}")
-        return
-
-    print("Will remove:")
-    for path, age in stale:
-        print(f"  {path.relative_to(runs_dir.parent)}  ({_format_age(age)})")
-    print()
-
-    if not force:
-        suffix = "ies" if len(stale) != 1 else "y"
-        answer = input(f"Remove {len(stale)} director{suffix}? [y/N]: ")
-        if answer.strip().lower() != "y":
-            print("Aborted.")
-            return
-
-    count = 0
-    errors = 0
-    for path, _ in stale:
-        try:
-            shutil.rmtree(path)
-            print(f"Removed: {path}")
-            count += 1
-        except OSError as exc:
-            print(f"Failed to remove {path}: {exc}", file=sys.stderr)
-            errors += 1
-
-    suffix = "ies" if count != 1 else "y"
-    err_note = f" ({errors} error(s))" if errors else ""
-    print(f"\nCleaned {count} director{suffix}{err_note}")
+    run_workspace_clean(dir=dir, force=force)
 
 
 @recipes_app.command(name="list")

--- a/tests/arch/_rules.py
+++ b/tests/arch/_rules.py
@@ -61,6 +61,7 @@ _PRINT_EXEMPT = frozenset(
         "_doctor.py",
         "_marketplace.py",
         "_prompts.py",
+        "_workspace.py",
         "quota_check.py",
         "native_tool_guard.py",
         "remove_clone_guard.py",

--- a/tests/cli/test_cook.py
+++ b/tests/cli/test_cook.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from autoskillit import cli
-from autoskillit.cli.app import _format_age
+from autoskillit.cli._workspace import _format_age
 
 _SCRIPT_YAML = """\
 name: test-script


### PR DESCRIPTION
## Summary

Add safety guards to `autoskillit workspace clean` so it no longer blindly deletes all run directories. The command now partitions directories into "stale" (>=5h old by `st_mtime`) and "recent" (<5h), displays both lists with human-readable ages, requires explicit `y/N` confirmation before deletion (default N), and accepts `--force`/`-f` to skip the prompt for scripted use. Core logic extracted to `cli/_workspace.py` to respect file line limits.

Closes #128

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    START([START: workspace clean])
    DONE([DONE])
    ABORT([ABORT: nothing removed])

    subgraph Resolve ["Resolve runs directory"]
        direction TB
        R1["Resolve base dir<br/>━━━━━━━━━━<br/>--dir or CWD parent"]
        R2{"runs_dir<br/>exists?"}
    end

    subgraph Partition ["Partition by age"]
        direction TB
        P1["Iterate subdirs<br/>━━━━━━━━━━<br/>Read st_mtime per dir"]
        P2["Classify<br/>━━━━━━━━━━<br/>stale: age >= 5h<br/>recent: age < 5h"]
    end

    subgraph Display ["Display & Confirm"]
        direction TB
        D1["Print skipped<br/>━━━━━━━━━━<br/>recent dirs + ages"]
        D2["Print will-remove<br/>━━━━━━━━━━<br/>stale dirs + ages"]
        D3{"Any stale<br/>dirs?"}
        D4{"--force<br/>or confirm?"}
    end

    subgraph Delete ["Delete stale dirs"]
        direction TB
        DEL["shutil.rmtree<br/>━━━━━━━━━━<br/>Only stale dirs"]
        SUM["Print summary<br/>━━━━━━━━━━<br/>count + errors"]
    end

    START --> R1
    R1 --> R2
    R2 -->|"no"| ABORT
    R2 -->|"yes"| P1
    P1 --> P2
    P2 --> D1
    D1 --> D2
    D2 --> D3
    D3 -->|"none stale"| ABORT
    D3 -->|"has stale"| D4
    D4 -->|"denied / N"| ABORT
    D4 -->|"--force or y"| DEL
    DEL --> SUM
    SUM --> DONE

    class START,DONE,ABORT terminal;
    class R1 handler;
    class R2 stateNode;
    class P1,P2 handler;
    class D1,D2 phase;
    class D3,D4 stateNode;
    class DEL handler;
    class SUM phase;
```

### Operational Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart LR
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;

    subgraph CLI ["CLI Interface"]
        direction TB
        CMD["autoskillit workspace clean"]
        DIR["--dir PATH<br/>━━━━━━━━━━<br/>Base directory<br/>default: CWD parent"]
        FORCE["--force / -f<br/>━━━━━━━━━━<br/>Skip confirmation"]
    end

    subgraph Core ["Core Logic (_workspace.py)"]
        direction TB
        AGE["Age Partitioning<br/>━━━━━━━━━━<br/>5h threshold<br/>st_mtime based"]
        CONFIRM["Interactive Confirm<br/>━━━━━━━━━━<br/>y/N prompt<br/>default: N (safe)"]
    end

    subgraph Output ["User Output"]
        direction TB
        SKIP["Skipped list<br/>━━━━━━━━━━<br/>Recent dirs + ages"]
        REMOVE["Will-remove list<br/>━━━━━━━━━━<br/>Stale dirs + ages"]
        SUMMARY["Cleanup summary<br/>━━━━━━━━━━<br/>count + errors"]
    end

    CMD --> DIR
    CMD --> FORCE
    DIR --> AGE
    FORCE --> CONFIRM
    AGE --> SKIP
    AGE --> REMOVE
    CONFIRM --> SUMMARY

    class CMD,DIR,FORCE cli;
    class AGE,CONFIRM handler;
    class SKIP,REMOVE,SUMMARY output;
```

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;

    subgraph CLI ["cli/ package (L3)"]
        direction TB
        APP["app.py<br/>━━━━━━━━━━<br/>workspace_clean()<br/>thin CLI wrapper"]
        WS["★ _workspace.py<br/>━━━━━━━━━━<br/>run_workspace_clean()<br/>_format_age()"]
    end

    subgraph Stdlib ["Python stdlib"]
        direction LR
        SHUTIL["shutil"]
        TIME["time"]
        PATH["pathlib.Path"]
    end

    subgraph Tests ["tests/"]
        direction TB
        TC["cli/test_cook.py<br/>━━━━━━━━━━<br/>T_WC1–T_WC14"]
        TR["arch/_rules.py<br/>━━━━━━━━━━<br/>line-count rules"]
    end

    APP -->|"lazy import"| WS
    WS --> SHUTIL
    WS --> TIME
    WS --> PATH
    TC -->|"tests"| APP
    TR -->|"validates"| APP

    class APP cli;
    class WS newComponent;
    class SHUTIL,TIME,PATH stateNode;
    class TC,TR handler;
```

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/issue-128-workspace-clean-guards-20260304-183849-700780/temp/make-plan/workspace_clean_guards_plan_2026-03-04_184500.md`

## Token Usage Summary

## Token Usage Summary
| Step | input | output | cache_create | cache_read |
|------|-------|--------|--------------|------------|
| plan | 24 | 6,456 | 44,478 | 494,168 |
| verify | 19 | 6,030 | 31,018 | 395,354 |
| implement | 38 | 11,119 | 52,468 | 1,314,151 |
| fix | 29 | 6,685 | 64,056 | 1,058,142 |
| audit_impl | 13 | 6,467 | 39,009 | 214,770 |
| **Total** | **123** | **36,757** | **231,029** | **3,476,585** |

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
