### PR TITLE
feat: skip audit_impl when no implementation plans were generated

### DIFF
--- a/.autoskillit/recipes/pr-merge-pipeline.yaml
+++ b/.autoskillit/recipes/pr-merge-pipeline.yaml
@@ -1,6 +1,6 @@
 name: pr-merge-pipeline
 description: Analyze open PRs, determine merge order, collapse them sequentially into an integration branch, and open a single review PR for human approval. Handles conflict resolution via plan+implement for complex PRs.
-summary: "clone > setup_remote > analyze_prs > create_integration_branch > [loop per PR: merge_pr or (plan > verify > implement > test > merge_to_integration)] > push_integration_branch > collect_artifacts > audit_impl > create_review_pr > cleanup"
+summary: "clone > setup_remote > analyze_prs > create_integration_branch > [loop per PR: merge_pr or (plan > verify > implement > test > merge_to_integration)] > push_integration_branch > collect_artifacts > check_impl_plans > (audit_impl?) > create_review_pr > cleanup"
 autoskillit_version: "0.2.0"
 
 ingredients:
@@ -270,13 +270,30 @@ steps:
     with:
       cmd: "mkdir -p ${{ inputs.plans_dir }} && find temp/make-plan/ -name '*_plan_*.md' -exec cp {} ${{ inputs.plans_dir }}/ \\; 2>/dev/null || true"
       cwd: "${{ context.work_dir }}"
-    on_success: audit_impl
+    on_success: check_impl_plans
+    on_failure: check_impl_plans
+    note: >
+      Copies plan files generated during the pipeline (from temp/make-plan/) into
+      temp/pr-merge-pipeline/ alongside any conflict reports already there.
+      Always routes to check_impl_plans, which determines whether audit_impl
+      is meaningful.
+
+  check_impl_plans:
+    tool: run_cmd
+    with:
+      cmd: "find ${{ inputs.plans_dir }} -maxdepth 1 -name '*_plan_*.md' ! -name 'pr_analysis_plan_*.md' 2>/dev/null | wc -l | tr -d ' \n'"
+      cwd: "${{ context.work_dir }}"
+    on_result:
+      - when: "${{ result.stdout | trim }} == 0"
+        route: create_review_pr
+      - route: audit_impl
     on_failure: audit_impl
     note: >
-      Copies any plan files generated during the pipeline into
-      temp/pr-merge-pipeline/ alongside the PR analysis and conflict reports.
-      Always proceeds to audit_impl even if no plan files exist — the PR
-      analysis plan file (pr_analysis_plan_*.md) is always present.
+      Counts implementation plan files in plans_dir — excludes pr_analysis_plan_*.md,
+      which is always written by analyze-prs but is not an implementation plan.
+      Routes to create_review_pr when zero implementation plans exist (all PRs merged
+      cleanly, make-plan was never invoked — "No plans generated; all PRs merged cleanly").
+      Routes to audit_impl when conflict reports or make-plan outputs are present.
 
   audit_impl:
     tool: run_skill
@@ -296,10 +313,10 @@ steps:
     optional: true
     skip_when_false: "inputs.audit"
     note: >
-      Only execute if inputs.audit is 'true'. If false, skip directly to
+      Gated by check_impl_plans — only reached when implementation plan files exist in
+      plans_dir. Only execute if inputs.audit is 'true'; if false, skip directly to
       create_review_pr. Passes temp/pr-merge-pipeline/ as plans_input — audit-impl
-      discovers all *_plan_*.md files there (PR analysis + conflict reports + any
-      make-plan output files copied by collect_artifacts).
+      discovers all *_plan_*.md files there (conflict reports + make-plan outputs).
       implementation_ref is context.integration_branch (no worktree remains).
       GO → create_review_pr. NO GO → remediate (re-enters plan with remediation file).
 

--- a/tests/recipe/test_pr_merge_pipeline.py
+++ b/tests/recipe/test_pr_merge_pipeline.py
@@ -1,0 +1,104 @@
+"""Structural assertions for .autoskillit/recipes/pr-merge-pipeline.yaml."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from autoskillit.recipe.io import load_recipe
+
+
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+
+
+@pytest.fixture(scope="module")
+def recipe():
+    return load_recipe(PROJECT_ROOT / ".autoskillit" / "recipes" / "pr-merge-pipeline.yaml")
+
+
+def test_pmp_check_impl_plans_step_exists(recipe) -> None:
+    """check_impl_plans step must exist in the recipe."""
+    assert "check_impl_plans" in recipe.steps, (
+        "check_impl_plans step is missing — it gates audit_impl when no "
+        "implementation plans were generated"
+    )
+
+
+def test_pmp_collect_artifacts_routes_to_check_impl_plans(recipe) -> None:
+    """collect_artifacts.on_success must route to check_impl_plans, not audit_impl."""
+    step = recipe.steps["collect_artifacts"]
+    assert step.on_success == "check_impl_plans", (
+        "collect_artifacts.on_success must route to check_impl_plans, not audit_impl — "
+        "the check step decides whether audit is meaningful"
+    )
+
+
+def test_pmp_collect_artifacts_failure_routes_to_check_impl_plans(recipe) -> None:
+    """collect_artifacts.on_failure must also route to check_impl_plans."""
+    step = recipe.steps["collect_artifacts"]
+    assert step.on_failure == "check_impl_plans", (
+        "collect_artifacts.on_failure must route to check_impl_plans "
+        "so the gate runs even when artifact copying fails"
+    )
+
+
+def test_pmp_check_impl_plans_is_run_cmd(recipe) -> None:
+    """check_impl_plans step must use the run_cmd tool."""
+    step = recipe.steps["check_impl_plans"]
+    assert step.tool == "run_cmd"
+
+
+def test_pmp_check_impl_plans_excludes_pr_analysis_plan(recipe) -> None:
+    """check_impl_plans cmd must exclude pr_analysis_plan_*.md from its count.
+
+    pr_analysis_plan_*.md is always written by analyze-prs and is not an
+    implementation plan — including it would cause audit_impl to always run.
+    """
+    step = recipe.steps["check_impl_plans"]
+    cmd = step.with_args.get("cmd", "")
+    assert "pr_analysis_plan" in cmd, (
+        "check_impl_plans must exclude pr_analysis_plan_*.md from its count — "
+        "that file is always present and is not an implementation plan"
+    )
+
+
+def test_pmp_check_impl_plans_routes_to_create_review_pr_on_empty(recipe) -> None:
+    """check_impl_plans must route to create_review_pr when no impl plans exist."""
+    step = recipe.steps["check_impl_plans"]
+    assert step.on_result is not None, "check_impl_plans must use on_result routing"
+    conds = step.on_result.conditions
+    routes = {c.route for c in conds}
+    assert "create_review_pr" in routes, (
+        "check_impl_plans must route to create_review_pr when count is 0 — "
+        "skipping audit_impl when no implementation plans exist"
+    )
+    zero_conds = [c for c in conds if c.when is not None and "0" in (c.when or "")]
+    assert any(c.route == "create_review_pr" for c in zero_conds), (
+        "the create_review_pr route must be guarded by a zero-count condition"
+    )
+
+
+def test_pmp_check_impl_plans_has_fallthrough_to_audit_impl(recipe) -> None:
+    """check_impl_plans fallthrough (when=None) must go to audit_impl."""
+    step = recipe.steps["check_impl_plans"]
+    assert step.on_result is not None
+    conds = step.on_result.conditions
+    fallthrough = [c for c in conds if c.when is None]
+    assert len(fallthrough) == 1, "check_impl_plans must have exactly one fallthrough condition"
+    assert fallthrough[0].route == "audit_impl", (
+        "check_impl_plans fallthrough must route to audit_impl "
+        "when implementation plans exist"
+    )
+
+
+def test_pmp_audit_impl_has_skip_when_false(recipe) -> None:
+    """audit_impl must still declare skip_when_false: inputs.audit (user-level toggle)."""
+    step = recipe.steps["audit_impl"]
+    assert step.skip_when_false == "inputs.audit"
+
+
+def test_pmp_audit_impl_is_optional(recipe) -> None:
+    """audit_impl must be marked optional (required by skip_when_false rule)."""
+    step = recipe.steps["audit_impl"]
+    assert step.optional is True


### PR DESCRIPTION
## Summary

In the `pr-merge-pipeline` recipe, `audit_impl` ran unconditionally whenever `inputs.audit = "true"`, even when all PRs merged cleanly via direct git merge and no `make-plan` was ever invoked. In that scenario, `plans_dir` contains only `pr_analysis_plan_*.md` (written by `analyze-prs`) — an analysis document, not an implementation plan. Running `audit-impl` against it produces a meaningless audit that wastes tokens and can produce confusing output.

The fix adds a `check_impl_plans` step between `collect_artifacts` and `audit_impl`. This step counts implementation plan files in `plans_dir` (excluding `pr_analysis_plan_*.md`) and routes to `create_review_pr` directly when the count is zero, skipping `audit_impl` entirely.

Closes #137

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    START([START: push_integration_branch done])
    DONE([DONE: review PR opened])
    ERROR([ERROR: escalate_stop])

    subgraph PostPush ["● Post-Push Phase (pr-merge-pipeline.yaml)"]
        direction TB
        CollectArtifacts["● collect_artifacts<br/>━━━━━━━━━━<br/>find temp/make-plan/ *_plan_*.md<br/>cp → plans_dir<br/>on_success/failure → check_impl_plans"]

        CheckImplPlans["★ check_impl_plans<br/>━━━━━━━━━━<br/>find plans_dir *_plan_*.md<br/>! -name pr_analysis_plan_*.md<br/>wc -l → impl_plan_count"]

        HasPlans{"impl_plan_count == 0?"}

        AuditImpl["audit_impl<br/>━━━━━━━━━━<br/>run audit-impl skill<br/>skip_when_false: inputs.audit<br/>verdict: GO / NO GO"]

        AuditVerdict{"verdict?"}
    end

    subgraph Outcome ["Outcome"]
        direction TB
        CreateReviewPR["create_review_pr<br/>━━━━━━━━━━<br/>gh pr create<br/>integration → base_branch"]
        Remediate["remediate<br/>━━━━━━━━━━<br/>route → plan<br/>with remediation_path"]
    end

    subgraph Cleanup ["Cleanup"]
        direction TB
        CleanupSuccess["cleanup_success<br/>━━━━━━━━━━<br/>remove_clone keep=false"]
        CleanupFailure["cleanup_failure<br/>━━━━━━━━━━<br/>remove_clone keep=keep_on_failure"]
    end

    START --> CollectArtifacts
    CollectArtifacts -->|"always (success or failure)"| CheckImplPlans
    CheckImplPlans --> HasPlans
    HasPlans -->|"count == 0<br/>No impl plans — all PRs<br/>merged cleanly"| CreateReviewPR
    HasPlans -->|"count > 0<br/>Impl plans exist"| AuditImpl
    AuditImpl -->|"inputs.audit == false<br/>(skip_when_false)"| CreateReviewPR
    AuditImpl --> AuditVerdict
    AuditVerdict -->|"GO"| CreateReviewPR
    AuditVerdict -->|"NO GO"| Remediate
    Remediate -->|"re-enters plan loop"| ERROR
    CreateReviewPR -->|"success"| CleanupSuccess
    CreateReviewPR -->|"failure"| CleanupFailure
    CleanupSuccess --> DONE
    CleanupFailure --> ERROR

    %% CLASS ASSIGNMENTS %%
    class START,DONE,ERROR terminal;
    class CollectArtifacts handler;
    class CheckImplPlans newComponent;
    class HasPlans,AuditVerdict detector;
    class AuditImpl phase;
    class CreateReviewPR,Remediate output;
    class CleanupSuccess,CleanupFailure stateNode;
```

**Color Legend:**
| Color | Category | Description |
|-------|----------|-------------|
| Dark Blue | Terminal | Pipeline entry, completion, and error states |
| Orange | Handler | `● collect_artifacts` — modified routing target |
| Green | New Component | `★ check_impl_plans` — new gate step added by this PR |
| Red | Detector | Decision diamonds: count==0 and audit verdict |
| Purple | Phase | `audit_impl` — conditional execution step |
| Dark Teal | Output | `create_review_pr`, `remediate` — downstream outcomes |
| Teal | State | Cleanup steps |

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/skip-audit-no-plans-20260305-200535-694191/temp/make-plan/skip_audit_no_plans_plan_2026-03-05_120000.md`

## Token Usage Summary

| Step | input | output | cache_create | cache_read |
|------|-------|--------|--------------|------------|
| plan | 69 | 45,482 | 223,534 | 1,858,107 |
| verify | 56 | 15,937 | 108,911 | 1,326,733 |
| implement | 97 | 17,612 | 87,640 | 2,377,898 |
| audit_impl | 44 | 15,722 | 76,292 | 715,160 |
| **Total** | **266** | **94,753** | **496,377** | **6,277,898** |

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
