### PR TITLE
open-pr: Post-generation marker validation for arch-lens diagrams

### DIFF
--- a/src/autoskillit/skills/open-pr/SKILL.md
+++ b/src/autoskillit/skills/open-pr/SKILL.md
@@ -152,7 +152,20 @@ skill then uses this context to scope its exploration.
 The arch-lens skills write their output to `temp/arch-lens-{lens-name}/`. After each skill
 runs, read the generated markdown file and extract the mermaid code block(s).
 
+After extracting the mermaid block, inspect its content for `★` or `●` characters:
+- If the block contains at least one `★` or `●` → add it to `validated_diagrams`.
+- If the block contains neither → discard this diagram; do not add it to the list.
+
+This ensures the PR body only includes diagrams where at least one component was
+visibly modified or created by the PR.
+
 ### Step 6: Compose PR Body
+
+After generating all diagrams, check `validated_diagrams`:
+- If `validated_diagrams` is non-empty → include the `## Architecture Impact` section
+  as described below, embedding only the validated mermaid blocks.
+- If `validated_diagrams` is empty → omit the `## Architecture Impact` section entirely.
+  Do not include a placeholder or note in the PR body.
 
 Write the PR body to `temp/open-pr/pr_body_{timestamp}.md`.
 
@@ -168,9 +181,10 @@ Read `## Summary` from each plan file.
 {If closing_issue is provided and non-empty:}
 Closes #{closing_issue}
 
+{## Architecture Impact — conditional: include only if validated_diagrams is non-empty}
 ## Architecture Impact
 
-{For each lens diagram: embed the mermaid block with a heading for the lens name}
+{For each validated lens diagram: embed the mermaid block with a heading for the lens name}
 
 ### {Lens Name} Diagram
 
@@ -212,9 +226,10 @@ Closes #{closing_issue}
 
 </details>
 
+{## Architecture Impact — conditional: include only if validated_diagrams is non-empty}
 ## Architecture Impact
 
-{Same as single plan — lens diagrams are based on full diff, not plan count}
+{Same as single plan — validated lens diagrams are based on full diff, not plan count}
 
 ### {Lens Name} Diagram
 

--- a/tests/skills/test_open_pr_closing_issue.py
+++ b/tests/skills/test_open_pr_closing_issue.py
@@ -1,4 +1,4 @@
-"""Tests for open-pr skill SKILL.md closing_issue argument handling."""
+"""Tests for open-pr skill SKILL.md content assertions."""
 
 from pathlib import Path
 
@@ -24,3 +24,34 @@ def test_closing_issue_is_optional():
     content = SKILL_PATH.read_text()
     # Both the argument signature and the optional description
     assert "optional" in content.lower() or "[closing_issue]" in content
+
+
+def test_step5_marker_check_present():
+    """Step 5 must instruct the agent to check for ★ or ● in each mermaid block."""
+    content = SKILL_PATH.read_text()
+    assert "validated_diagrams" in content
+    # Both marker characters must be mentioned in the check instruction
+    assert "★" in content
+    assert "●" in content
+
+
+def test_step5_discard_path_documented():
+    """Step 5 must explicitly state that diagrams with no markers are discarded."""
+    content = SKILL_PATH.read_text()
+    assert "discard" in content.lower()
+
+
+def test_step6_conditional_section_present():
+    """Step 6 must gate the Architecture Impact section on validated_diagrams being non-empty."""
+    content = SKILL_PATH.read_text()
+    # The conditional gate language must appear in Step 6
+    assert "validated_diagrams is non-empty" in content or (
+        "validated_diagrams" in content and "non-empty" in content
+    )
+    assert "omit" in content.lower()
+
+
+def test_step4_lens_count_constraint_preserved():
+    """Step 4 must still instruct the subagent to return 1–3 lenses."""
+    content = SKILL_PATH.read_text()
+    assert "1–3" in content or "1-3" in content


### PR DESCRIPTION
## Summary

Adds post-generation validation to the open-pr skill's arch-lens diagram pipeline:

1. **Step 5 marker check**: After extracting mermaid blocks, each diagram is inspected for ★ or ● markers. Diagrams without markers (no modified/new components) are discarded.
2. **Step 6 conditional gate**: The `## Architecture Impact` section is only included when validated diagrams exist. Omitted entirely otherwise — no empty placeholder.
3. **PR body templates updated**: Both single-plan and multi-plan templates annotated with conditional behavior.

### Changed Files
- `src/autoskillit/skills/open-pr/SKILL.md` — marker check + conditional gate
- `tests/skills/test_open_pr_closing_issue.py` — 4 new structural tests

Closes #104