### PR TITLE
fix: prohibit git merge in conflict resolution plans

### DIFF
--- a/src/autoskillit/recipes/diagrams/pr-merge-pipeline.md
+++ b/src/autoskillit/recipes/diagrams/pr-merge-pipeline.md
@@ -1,4 +1,4 @@
-<!-- autoskillit-recipe-hash: sha256:42926db538a2683df3c802e8e7f65ec04b547f30d4da874a6d8e0ccdd5db0c9b -->
+<!-- autoskillit-recipe-hash: sha256:4f8b833faa03f4ed6154fca13d57754e21f6b634364a2f99a90c148a1da640a4 -->
 <!-- autoskillit-diagram-format: v5 -->
 ## pr-merge-pipeline
 Analyze open PRs, determine merge order, collapse them sequentially into an integration branch, and open a single review PR for human approval. Handles conflict resolution via plan+implement for complex PRs.
@@ -117,6 +117,7 @@ cleanup_failure  [remove_clone] (retry ×3)
 ### Kitchen Rules
 - NEVER use native Claude Code tools (Read, Grep, Glob, Edit, Write, Bash, Agent, WebFetch, WebSearch, NotebookEdit) from the orchestrator. All work is delegated through run_skill and run_cmd.
 - Route to on_failure when a step fails — do not investigate or fix directly.
+- LINEAR HISTORY: Conflict resolution plans must NEVER use `git merge` (including --no-ff or --no-commit variants). Use `git cherry-pick <commit>` for individual commits or `git checkout <branch> -- <file>` for specific files to apply PR changes. merge_worktree requires linear commit history for rebasing — merge commits cause WORKTREE_INTACT_MERGE_COMMITS_DETECTED failure.
 - SEQUENTIAL LOOP: Process one PR at a time through the full merge cycle before advancing to the next PR. Never batch-assess all PRs before starting merges.
 - SEQUENTIAL EXECUTION: complete full cycle (verify → implement → test → merge_to_integration) per plan part before advancing to the next part or PR.
 - INTEGRATION BRANCH: All PR merges and worktree merges target context.integration_branch, not inputs.base_branch. The base_branch is only used for the final review PR.

--- a/src/autoskillit/recipes/diagrams/remediation.md
+++ b/src/autoskillit/recipes/diagrams/remediation.md
@@ -1,4 +1,4 @@
-<!-- autoskillit-recipe-hash: sha256:57975e4a50ccdd0d9a5910e1a84df6ca0c02edbf9b8c8aa23e119f8bccf6bf5b -->
+<!-- autoskillit-recipe-hash: sha256:af817da4f1ddab4c18cc1f3f1011b8749109fc7090b287c5cd261dc9b969f3a8 -->
 <!-- autoskillit-diagram-format: v5 -->
 ## remediation
 Investigate a problem deeply, plan architectural fix, implement in a feature branch, and open a PR.

--- a/src/autoskillit/recipes/pr-merge-pipeline.yaml
+++ b/src/autoskillit/recipes/pr-merge-pipeline.yaml
@@ -29,6 +29,11 @@ kitchen_rules:
     orchestrator. All work is delegated through run_skill
     and run_cmd."
   - "Route to on_failure when a step fails — do not investigate or fix directly."
+  - "LINEAR HISTORY: Conflict resolution plans must NEVER use `git merge` (including
+    --no-ff or --no-commit variants). Use `git cherry-pick <commit>` for individual
+    commits or `git checkout <branch> -- <file>` for specific files to apply PR changes.
+    merge_worktree requires linear commit history for rebasing — merge commits cause
+    WORKTREE_INTACT_MERGE_COMMITS_DETECTED failure."
   - "SEQUENTIAL LOOP: Process one PR at a time through the full merge cycle before
     advancing to the next PR. Never batch-assess all PRs before starting merges."
   - "SEQUENTIAL EXECUTION: complete full cycle (verify → implement → test →

--- a/src/autoskillit/skills/implement-worktree-no-merge/SKILL.md
+++ b/src/autoskillit/skills/implement-worktree-no-merge/SKILL.md
@@ -37,6 +37,7 @@ The worktree is left intact for the orchestrator to test and merge separately.
 - Clean up the worktree environment
 - Re-run tests just to see failures — grep the saved output file instead
 - Pipe test output through `tail`, `head`, or other truncation commands
+- **Execute `git merge` commands** (including `--no-ff`, `--no-commit`, or any variant). All branch content must be applied via `git cherry-pick <commit>` for individual commits or `git checkout <branch> -- <file>` for specific files. `merge_worktree` requires linear commit history — merge commits cannot be rebased and will cause `WORKTREE_INTACT_MERGE_COMMITS_DETECTED` failure.
 
 **ALWAYS:**
 - Create a new worktree from the current branch

--- a/src/autoskillit/skills/make-plan/SKILL.md
+++ b/src/autoskillit/skills/make-plan/SKILL.md
@@ -192,6 +192,7 @@ Before writing the final plan, verify:
 - Choose an approach because it's easier
 - Reject an approach because it's harder
 - Create files outside `temp/make-plan/` directory
+- **Use `git merge` in implementation plans.** When a plan needs to bring in changes from another branch, use `git cherry-pick <commit>` for individual commits or `git checkout <branch> -- <file>` for specific files. `merge_worktree` requires linear commit history — merge commits cannot be rebased and will cause `WORKTREE_INTACT_MERGE_COMMITS_DETECTED` failure. See "Conflict-Resolution Plan Requirements" section for full guidance.
 
 **ALWAYS:**
 - Write to `temp/make-plan/` directory

--- a/src/autoskillit/skills/merge-pr/SKILL.md
+++ b/src/autoskillit/skills/merge-pr/SKILL.md
@@ -198,6 +198,9 @@ The implementer MUST:
 1. Resolve all Category A conflicts, preserving the intent of both this PR and earlier merges.
 2. Verify Category B files for semantic correctness after auto-merge.
 3. Carry over every Category C file exactly as the PR changed it — no omissions.
+4. **NEVER use `git merge` to apply changes.** Use `git cherry-pick <commit>` for individual
+   commits or `git checkout <branch> -- <file>` for specific files. `merge_worktree` requires
+   linear commit history — merge commits cause `WORKTREE_INTACT_MERGE_COMMITS_DETECTED` failure.
 
 If any conflict cannot be confidently resolved, do NOT guess. Set `escalation_required=true`
 in the output and describe the ambiguity for human review.


### PR DESCRIPTION
## Summary
- Adds LINEAR HISTORY constraints across 4 layers to prevent `implement-worktree` from creating merge commits that block `merge_worktree`'s rebase gate
- **make-plan SKILL.md**: Added `git merge` prohibition to NEVER block
- **implement-worktree-no-merge SKILL.md**: Added `git merge` prohibition to NEVER block
- **pr-merge-pipeline.yaml**: Added LINEAR HISTORY kitchen rule
- **merge-pr SKILL.md**: Added Resolver Contract point 4 in conflict report template

## Test plan
- [x] `task test-check` passes (3013 passed, 15 skipped)
- [ ] Re-run pr-merge-pipeline with conflicting PRs to verify plans use cherry-pick/checkout instead of merge

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)