### PR TITLE
docs: complete release documentation sprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,135 +1,105 @@
 # AutoSkillit
 
-A stateless workflow engine that turns your skills into scriptable components. Write simple YAML recipes that chain skills as reusable steps.
+<!-- banner image here (owner will add) -->
 
-Skills are focused tasks (planning, implementing, testing, investigating). Recipes are instructions that tell the AI how to chain them together. The YAML format is a convention for consistency and sharing, but there's nothing strict about it. Anything you could tell a person to do, you can put in a recipe. The only limit is whether the AI can understand what you want.
+Automated development pipelines for Claude Code. Give it a task, get back a tested PR.
 
-<!-- TODO: banner -->
+<!-- demo recording here (owner will add) -->
 
-<!-- TODO: demo -->
+## Install
 
-## Prerequisites
+```bash
+curl -fsSL https://raw.githubusercontent.com/TalonT-Org/AutoSkillit/stable/install.sh | sh
+```
 
-- Python 3.11+
-- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed and on PATH
+Or manually: `uv tool install "git+https://github.com/TalonT-Org/AutoSkillit.git@stable" && autoskillit install`
 
 ## Quick Start
 
-### 1. Install
-
 ```bash
-git clone https://github.com/talontechnologies/autoskillit.git
-cd autoskillit
-uv pip install -e .
-autoskillit install
-```
-
-`install` registers AutoSkillit as a Claude Code plugin. It loads automatically in every session after this. No per-project wiring needed.
-
-### 2. Set up your project
-
-```bash
+# 1. Set up your project
 cd your-project
 autoskillit init
-```
 
-This creates `.autoskillit/config.yaml` with your test command, the only setting most projects need. For a guided setup that detects your tools and generates tailored recipes, use `/autoskillit:setup-project` inside Claude Code.
-
-### 3. Run your first pipeline
-
-```bash
-autoskillit cook
-```
-
-This launches Claude Code with the kitchen already open. Select a recipe, provide the inputs, and the orchestrator handles the rest. You can also specify a recipe directly:
-
-```bash
+# 2. Run the implementation pipeline
 autoskillit cook implementation
 ```
 
-## How It Works
-
-AutoSkillit is a **stateless workflow engine**. The recipe defines the script. The AI is the state manager.
-
-A **skill** is a focused task: "make a plan", "implement in a worktree", "investigate test failures". Each skill runs in its own headless session with full tool access. On its own, a skill is a one-shot capability.
-
-A **recipe** turns skills into a script. It tells the AI what steps to run, what inputs to collect, and what to do when something succeeds or fails. The YAML format is a convention, not a constraint. The AI interprets the recipe and decides how to execute it.
-
-When you run `autoskillit cook`, an orchestrating agent reads the recipe and drives the workflow. It never does the actual work itself. It just passes inputs to each skill, reads the result, and moves to the next step. All the real work (reading code, writing code, running tests) happens inside separate headless skill sessions, each with their own context window.
-
-This means the orchestrator's context window stays small. It only ever holds the recipe, the current step's result, and enough routing information to decide what comes next. Workflows have run for 48+ hours without approaching context limits, because the orchestrator never accumulates the content of the skills it delegates to.
-
-### Example: The Implementation Pipeline
-
-The bundled `implementation` recipe automates the full development cycle:
+That's it. Describe what you want to build, and AutoSkillit handles the rest:
 
 ```
-clone > plan > verify > implement > test > merge > push
+Plan ─── Verify ─── Implement ─── Test ─── Merge ─── Push ─── PR ─── Review
+ │                     │            │                          │
+ │                     ▼            ▼                          ▼
+ │               Dry-walkthrough  Worktree               7 parallel
+ │               validates plan   isolation              audit bots
+ ▼
+Deep codebase
+analysis with
+arch diagrams
 ```
 
-Give it a task description or a GitHub issue URL, and it:
+## What Happens
 
-- Clones your repo into an isolated directory
-- Creates a detailed implementation plan
-- Validates the plan with a dry walkthrough
-- Implements changes in a git worktree
-- Runs your test suite
-- Merges on success, pushes, and opens a PR
+When you run `autoskillit cook implementation`:
 
-If tests fail, it automatically routes to a fix skill that diagnoses and resolves the failures before retrying.
+1. **You describe the task** — or paste a GitHub issue URL
+2. **AutoSkillit clones your repo** into an isolated directory (your working tree is never touched)
+3. **A plan is created** — deep codebase analysis, architecture diagrams, test-first design
+4. **The plan is verified** — a dry walkthrough catches gaps before any code is written
+5. **Code is implemented** in a git worktree, committed, and tested
+6. **If tests fail**, a fix skill diagnoses and resolves failures automatically
+7. **Changes are merged, pushed**, and a PR is opened
+8. **The PR is reviewed** by 7 parallel audit subagents checking architecture, tests, bugs, defense, cohesion, slop, and deletion regressions
+9. **CI is monitored** — if it fails, AutoSkillit diagnoses and fixes
+
+The orchestrator never reads or writes code itself. Every step runs in a separate
+headless session with its own context window, so pipelines can run for hours without
+hitting context limits.
+
+## Key Features
+
+**Zero Footprint by Default** — AutoSkillit exposes 36 MCP tools, but only 12 lightweight tools are visible in a normal Claude Code session. The other 24 pipeline tools stay hidden until you explicitly open the kitchen. This means AutoSkillit never pollutes your context window or wastes tokens on tool descriptions you aren't using. When you need the full pipeline, one command reveals everything.
+
+**Clone Isolation** — All pipeline work happens in a cloned copy of your repo. Your working tree and uncommitted changes are never touched.
+
+**Dry-Walkthrough Gate** — Every plan is validated against the actual codebase before implementation begins. Missing files, wrong function signatures, and broken assumptions are caught and fixed in the plan — not discovered during implementation.
+
+**7-Dimension PR Review** — The `review-pr` skill runs 7 parallel audit subagents: architecture layering, test quality, defensive coding, bug patterns, cohesion, AI slop detection, and deletion regression checks. Each posts inline GitHub comments on the PR.
+
+**Contract Cards** — Static analysis of recipe dataflow. Each skill declares its inputs and outputs; contract cards verify that every step has the data it needs before the pipeline runs.
 
 ## Bundled Recipes
 
 | Recipe | What it automates |
 |--------|-------------------|
-| `implementation` | Plan, verify, implement, test, merge, and push |
-| `bugfix-loop` | Test, investigate, plan, implement, verify, and merge |
-| `remediation` | Investigate-first approach for issues needing diagnosis |
-| `audit-and-fix` | Audit, investigate, rectify, implement, test, and merge |
-| `smoke-test` | Integration self-test of the orchestration path |
+| `implementation` | Plan → verify → implement → test → merge → PR → review |
+| `bugfix-loop` | Test → investigate → plan → implement → verify → merge |
+| `remediation` | Investigate → plan → verify → implement → test → merge → PR |
+| `audit-and-fix` | Audit → investigate → plan → implement → test → merge → PR |
+| `implementation-groups` | Decompose large docs → sequenced group implementation |
+| `batch-implementation` | Implement multiple GitHub issues sharing clone setup overhead |
+| `pr-merge-pipeline` | Analyze open PRs → merge in order → single integration PR |
+| `smoke-test` | Integration self-test of the orchestration engine |
 
-```bash
-autoskillit recipes list              # list available recipes
-autoskillit recipes show bugfix-loop  # inspect a recipe's YAML
-```
-
-Project recipes in `.autoskillit/recipes/` override bundled ones with the same name. Generate custom recipes with `/autoskillit:write-recipe` or `/autoskillit:setup-project`.
-
-## CLI Reference
+## CLI Quick Reference
 
 | Command | Purpose |
 |---------|---------|
 | `autoskillit install` | Register plugin with Claude Code |
-| `autoskillit init` | Create project config (`.autoskillit/config.yaml`) |
+| `autoskillit init` | Create project config |
 | `autoskillit cook [recipe]` | Launch a pipeline |
-| `autoskillit doctor` | Check setup for common issues |
-| `autoskillit recipes list` | List available recipes |
-| `autoskillit skills list` | List all 24 bundled skills |
-| `autoskillit config show` | Show resolved configuration |
-| `autoskillit migrate` | Check for outdated recipes |
+| `autoskillit doctor` | Check setup health |
+| `autoskillit chefs-hat` | Launch Claude with all 36 skills as slash commands |
 
-## Configuration
+## Documentation
 
-`autoskillit init` writes a `.autoskillit/config.yaml` with your test command:
-
-```yaml
-test_check:
-  command: ["pytest", "-v"]
-```
-
-Config resolves in layers: package defaults < user config (`~/.autoskillit/config.yaml`) < project config (`.autoskillit/config.yaml`). View the result with `autoskillit config show`.
-
-See [docs/configuration.md](docs/configuration.md) for the full reference covering model selection, worktree setup, quota guard, GitHub integration, and safety settings.
-
-## Safety
-
-AutoSkillit is designed around defense in depth:
-
-- **Tool gating**: 16 tools are locked until you run the `/open_kitchen` command
-- **Test gate**: code must pass tests before merge, no bypass
-- **Dry-walkthrough gate**: plans are verified before implementation begins
-- **Clone isolation**: pipeline work happens in cloned directories, not your working tree
-- **Process cleanup**: all subprocess trees are cleaned up after sessions
+- **[Installation](docs/installation.md)** — Prerequisites, manual install, troubleshooting
+- **[Getting Started](docs/getting-started.md)** — Full tutorial with the implementation recipe
+- **[Recipes](docs/recipes.md)** — All recipes with flow diagrams and input reference
+- **[Architecture](docs/architecture.md)** — Gating, clone isolation, headless sessions, hooks
+- **[CLI Reference](docs/cli-reference.md)** — All commands and options
+- **[Configuration](docs/configuration.md)** — Layered config, all settings, examples
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,188 @@
+# Architecture
+
+AutoSkillit is a stateless workflow engine built as a Claude Code plugin. It
+orchestrates automated pipelines by delegating work to headless Claude Code
+sessions, each running a focused skill.
+
+## Core Concepts
+
+### Skills
+
+A skill is a focused task defined in a `SKILL.md` file. Skills run in their own
+headless Claude Code session with full tool access. Examples: `make-plan` (create
+an implementation plan), `implement-worktree` (implement code in a worktree),
+`review-pr` (review a PR with parallel audit subagents).
+
+AutoSkillit bundles 36 skills. Use `autoskillit skills list` to see them all.
+
+### Recipes
+
+A recipe is a YAML workflow that chains skills and MCP tools into an automated
+pipeline. Recipes define the step graph (what to run), ingredients (inputs),
+routing logic (what to do on success/failure), and kitchen rules (constraints
+for the orchestrator).
+
+### The Orchestrator
+
+When you run `autoskillit cook`, an orchestrating Claude Code session reads the
+recipe and drives the pipeline. The orchestrator never reads or writes code itself.
+It only calls MCP tools: `run_skill` to delegate to headless sessions, `run_cmd`
+for shell commands, `test_check` to run tests, etc.
+
+Because the orchestrator only holds the recipe, current step result, and routing
+state, its context window stays small. Pipelines have run 48+ hours without context
+issues.
+
+## Three-Tier Visibility System
+
+AutoSkillit uses a three-tier visibility model so that its 36 MCP tools and 36
+skills never pollute your context window when you don't need them.
+
+### Tier 0: Always Visible (12 tools)
+
+These lightweight tools are visible in every Claude Code session immediately.
+They let you inspect recipes, check status, and fetch issues without opening
+the kitchen:
+
+`kitchen_status`, `list_recipes`, `load_recipe`, `validate_recipe`,
+`get_pipeline_report`, `get_token_summary`, `get_timing_summary`,
+`fetch_github_issue`, `get_issue_title`, `get_ci_status`,
+`open_kitchen`, `close_kitchen`
+
+### Tier 1: Kitchen-Gated (24 tools)
+
+The pipeline tools — `run_skill`, `run_cmd`, `test_check`, `merge_worktree`,
+`clone_repo`, and 19 others — are hidden at startup via FastMCP's tag-based
+visibility system. They don't appear in `tools/list`, so Claude never sees
+their descriptions and never wastes tokens on them.
+
+To reveal them, call `open_kitchen` (or launch via `autoskillit cook`, which
+opens the kitchen automatically). This:
+
+1. Enables the gate (`DefaultGateState.enable()`)
+2. Dynamically reveals all 24 kitchen tools to the MCP client
+3. Writes a hook config file for the quota guard
+4. Injects orchestrator discipline rules into the response
+
+`close_kitchen` reverses this: hides tools, disables the gate, removes config.
+
+### Tier 2: Human-Only Skills
+
+A subset of skills (currently `open-kitchen` and `close-kitchen`) have
+`disable-model-invocation: true` injected when running in headless/automated
+sessions. This prevents agents from autonomously opening the kitchen or
+escalating their own privileges. In `chefs-hat` mode (human-interactive),
+this restriction is removed.
+
+### Why This Matters
+
+Most MCP servers dump all their tools into every session, consuming context
+window space with tool descriptions the model may never use. AutoSkillit's
+gating means you pay zero token cost for pipeline tools during normal coding
+sessions. The full pipeline surface only appears when you explicitly ask for it.
+
+## Clone Isolation
+
+Every pipeline that modifies code starts by cloning the source repository into
+`../autoskillit-runs/{run_name}-{timestamp}/`. This enforces a strict contract:
+
+- The source directory is never written to during a pipeline
+- All implementation happens in the clone
+- The clone's `origin` remote is rewritten to point to the real upstream
+  (not back to the local source)
+- Generated files are decontaminated from the clone's git index
+
+**Safety guards before cloning:**
+- Uncommitted changes are detected and the user is asked to choose:
+  `proceed` (clone committed state only) or `clone_local` (copy working tree)
+- Unpublished branches are detected and warned about
+
+**On failure**, clones are always preserved (`keep: "true"`) for manual inspection.
+Cleanup requires explicit user confirmation via a `confirm` action step.
+
+## Headless Session Orchestration
+
+`run_skill` launches a headless Claude Code session for each skill invocation.
+The system manages session lifecycle with several reliability mechanisms:
+
+### Completion Marker
+
+Every headless session prompt is appended with a directive to include `%%ORDER_UP%%`
+as the last line of output. The orchestrator uses this marker to reliably detect
+session completion vs. stale/interrupted sessions.
+
+Recovery paths handle two failure modes:
+- **Separate marker**: Model emits the marker as a standalone message (recovered
+  by joining all assistant messages)
+- **Stale with result**: Session goes stale but stdout contains a valid completed
+  result (recovered with `subtype: "recovered_from_stale"`)
+
+### Budget Guard
+
+Consecutive failure counting prevents infinite retry loops. After
+`max_consecutive_retries` failures of the same skill, `needs_retry` is forced to
+`false` regardless of the session outcome.
+
+### Model Resolution
+
+Three-tier priority: `config.model.override` > per-step `model` field >
+`config.model.default`. The override prevents per-step model selection from
+escaping a budget constraint.
+
+### Session Diagnostics
+
+On Linux, every headless session captures process-level snapshots (RSS, OOM score,
+file descriptors, signals, thread count) at 5-second intervals. Results are written
+to `~/.local/share/autoskillit/logs/` with anomaly detection for OOM spikes,
+zombies, and resource growth. See [Developer Guide](developer.md) for details.
+
+## Hook System
+
+AutoSkillit registers Claude Code hooks that run on tool calls:
+
+### PreToolUse Hooks (before tool execution)
+
+| Hook | Trigger | What it does |
+|------|---------|-------------|
+| `skill_cmd_check` | `run_skill` | Validates skill_command argument format |
+| `quota_check` | `run_skill` | Blocks when API quota exceeds threshold |
+| `skill_command_guard` | `run_skill` | Blocks non-slash skill commands |
+| `remove_clone_guard` | `remove_clone` | Blocks deletion unless branch is published |
+| `open_kitchen_guard` | `open_kitchen` | Blocks from headless sessions |
+
+### PostToolUse Hook (after tool execution)
+
+| Hook | Trigger | What it does |
+|------|---------|-------------|
+| `pretty_output` | All AutoSkillit tools | Reformats JSON as Markdown-KV (30-77% token reduction) |
+
+All hooks are stdlib-only (no autoskillit imports) and fail-open — a hook bug never
+blocks the user's session.
+
+## Contract Cards
+
+Each recipe has a contract card (generated YAML in `recipes/contracts/`) that
+captures the dataflow contract:
+
+- **Skill contracts**: What inputs each skill requires, what outputs it produces
+- **Dataflow entries**: Per-step tracking of available/required/produced context variables
+- **Staleness detection**: SHA256 hashes of SKILL.md files detect when a skill's
+  behavior has drifted from the contract
+
+Two validation rules:
+- `contract-unreferenced-required`: A required input is available but not referenced
+- `contract-unsatisfied-input`: A required input isn't available at that point
+
+## Safety Features Summary
+
+| Feature | What it prevents |
+|---------|-----------------|
+| Three-tier visibility | 24 pipeline tools hidden by default — zero token cost in normal sessions |
+| Clone isolation | Source repo never modified during pipelines |
+| Dry-walkthrough gate | Plans validated before implementation |
+| Test gate on merge | Tests must pass before merge is allowed |
+| Quota guard | Blocks new sessions when API usage is high |
+| Budget guard | Prevents infinite retry loops |
+| Remove-clone guard | Clones preserved unless branch is published |
+| Open-kitchen guard | Kitchen can't be opened from headless sessions |
+| Fail-open hooks | Hook failures never block user sessions |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,186 @@
+# CLI Reference
+
+## autoskillit install
+
+Register AutoSkillit as a Claude Code plugin.
+
+    autoskillit install [--scope user|project|local]
+
+**Flags:**
+- `--scope` (default: `user`) — Where to install: `user` (global), `project` (per-project), `local`
+
+**What it does:**
+1. Creates local marketplace at `~/.autoskillit/marketplace/`
+2. Registers marketplace with Claude Code
+3. Installs the plugin
+4. Syncs hooks to `settings.json`
+
+Run after every upgrade.
+
+---
+
+## autoskillit init
+
+Set up a project for AutoSkillit.
+
+    autoskillit init [--force] [--test-command CMD] [--scope user|project]
+
+**Flags:**
+- `--force` — Overwrite existing config
+- `--test-command` — Set test command non-interactively (e.g., `--test-command "pytest -v"`)
+- `--scope` (default: `user`) — Where to register hooks
+
+**Creates:**
+- `.autoskillit/config.yaml` — Project configuration
+- `temp/` — Working directory for pipeline artifacts
+- MCP server entry in `~/.claude.json`
+
+---
+
+## autoskillit cook
+
+Launch an interactive pipeline session.
+
+    autoskillit cook [recipe]
+
+**Arguments:**
+- `recipe` (optional) — Recipe name. If omitted, shows a selection menu.
+
+**Behavior:**
+- Validates the recipe YAML before launching
+- Opens a restricted Claude Code session (only `AskUserQuestion` + MCP tools)
+- Injects the recipe as the orchestrator's system prompt
+- Cannot be run from inside a Claude Code session
+
+**Examples:**
+
+    autoskillit cook                    # Show recipe menu
+    autoskillit cook implementation     # Run implementation pipeline
+    autoskillit cook bugfix-loop        # Run bugfix loop
+
+---
+
+## autoskillit doctor
+
+Run health checks on your setup.
+
+    autoskillit doctor [--output-json] [--fix]
+
+**Flags:**
+- `--output-json` — Output results as JSON
+- `--fix` — Attempt to fix issues automatically
+
+Runs 8 checks: stale MCP servers, MCP registration, PATH, project config,
+version consistency, hook health, hook registration, recipe version health.
+
+---
+
+## autoskillit chefs-hat
+
+Launch Claude Code with all skills as slash commands.
+
+    autoskillit chefs-hat
+
+Alias: `autoskillit chef`
+
+This gives you an unrestricted Claude session with all 36 bundled skills
+available as `/autoskillit:*` slash commands and the kitchen pre-opened.
+No recipe — use skills individually as needed.
+
+---
+
+## autoskillit migrate
+
+Check for outdated project recipes.
+
+    autoskillit migrate [--check]
+
+**Flags:**
+- `--check` — Exit with code 1 if any recipes need migration (for CI)
+
+Migrations are applied automatically when recipes are loaded. This command
+just reports what's pending.
+
+---
+
+## autoskillit quota-status
+
+Check current API quota utilization.
+
+    autoskillit quota-status
+
+Outputs JSON with the current 5-hour rolling utilization percentage.
+
+---
+
+## autoskillit config show
+
+Show the resolved configuration.
+
+    autoskillit config show
+
+Prints the merged result of all config layers as JSON.
+
+---
+
+## autoskillit recipes list
+
+List available recipes.
+
+    autoskillit recipes list
+
+Shows name, source (bundled or project), and description.
+
+---
+
+## autoskillit recipes show
+
+Print a recipe's raw YAML.
+
+    autoskillit recipes show <name>
+
+---
+
+## autoskillit recipes render
+
+Generate flow diagrams for recipes.
+
+    autoskillit recipes render [name]
+
+If no name given, renders all recipes. Diagrams are written to
+`recipes/diagrams/{name}.md`.
+
+---
+
+## autoskillit skills list
+
+List all bundled skills.
+
+    autoskillit skills list
+
+Shows name, source, and path for each of the 36 bundled skills.
+
+---
+
+## autoskillit workspace init
+
+Create a prep station directory for testing.
+
+    autoskillit workspace init <path>
+
+Creates the directory with a `.autoskillit-workspace` marker that authorizes
+`reset_test_dir` and `reset_workspace` to clear it.
+
+---
+
+## autoskillit workspace clean
+
+Prune old run directories.
+
+    autoskillit workspace clean [--dir DIR] [--force]
+
+**Flags:**
+- `--dir` — Directory to clean (default: `../autoskillit-runs/`)
+- `--force` — Skip confirmation prompt
+
+Removes run directories older than 5 hours.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,5 +1,18 @@
 # Configuration Reference
 
+## Quick Start
+
+Most projects only need one setting — the test command:
+
+    cd your-project
+    autoskillit init
+
+This creates `.autoskillit/config.yaml` with the test command you provide.
+Everything else has sensible defaults. See [Getting Started](getting-started.md)
+for a full tutorial.
+
+## Layered Resolution
+
 AutoSkillit uses layered YAML configuration. Resolution order (last wins):
 
 1. Package defaults (`autoskillit/config/defaults.yaml`)
@@ -18,7 +31,7 @@ AUTOSKILLIT_QUOTA_GUARD__ENABLED=false        # disables quota guard
 
 This is useful for CI pipelines or per-session overrides without touching config files.
 
-Partial configs are fine. Unset fields keep their defaults. View the resolved config with `autoskillit config show`.
+Partial configs are fine. Unset fields keep their defaults. View the resolved config with [`autoskillit config show`](cli-reference.md#autoskillit-config-show).
 
 ## Test Command
 
@@ -96,6 +109,47 @@ github:
 ```
 
 Token goes in `.autoskillit/.secrets.yaml` (never commit).
+
+## Branching
+
+```yaml
+branching:
+  default_base_branch: integration   # default base branch for recipes
+```
+
+Most projects should set this to `main`:
+
+```yaml
+branching:
+  default_base_branch: main
+```
+
+## Session Diagnostics (Linux)
+
+```yaml
+linux_tracing:
+  enabled: true           # default: true
+  proc_interval: 5.0      # seconds between snapshots
+  log_dir: ""             # empty = platform default
+  tmpfs_path: "/dev/shm"  # RAM-backed path for crash resilience
+```
+
+See [Session Diagnostics](developer.md#session-diagnostics-logging) for details on log output.
+
+## Headless Sessions
+
+```yaml
+run_skill:
+  timeout: 7200            # 2-hour session timeout (seconds)
+  stale_threshold: 1200    # 20 minutes of no output before declaring stale
+```
+
+## MCP Response Tracking
+
+```yaml
+mcp_response:
+  alert_threshold_tokens: 2000   # warn when tool responses exceed this token estimate
+```
 
 ## Safety and Gates
 

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -1,6 +1,55 @@
-# Session Diagnostics Logging
+# Developer Guide
 
-## Overview
+## Contributing
+
+### Development Setup
+
+    git clone https://github.com/TalonT-Org/AutoSkillit.git
+    cd AutoSkillit
+    uv pip install -e '.[dev]'
+    pre-commit install
+    autoskillit install
+
+> Developers work on `main`. The `stable` branch is the release branch
+> for end users.
+
+### Running Tests
+
+    task test-all
+
+Tests run in parallel via pytest-xdist (`-n 4`). All tests must be safe for
+parallel execution. Never use `pytest` directly — always use `task test-all`
+(or `task test-check` for CI/automation).
+
+### Pre-commit Hooks
+
+Hooks run automatically on commit: ruff format, ruff check, mypy, uv lock check,
+gitleaks secret scanning.
+
+    pre-commit run --all-files
+
+### Architecture Layers
+
+The codebase uses strict import layering enforced by import-linter:
+
+| Layer | Package | May import |
+|-------|---------|-----------|
+| L0 | `core/` | Nothing (foundation) |
+| L1 | `config/`, `pipeline/`, `execution/`, `workspace/` | L0 only |
+| L2 | `recipe/`, `migration/` | L0, L1 (workspace only for recipe) |
+| L3 | `server/`, `cli/` | Everything |
+
+### Version Bumps
+
+When bumping the version, update three locations:
+1. `pyproject.toml` — `version = "X.Y.Z"`
+2. `.claude-plugin/plugin.json` — `"version": "X.Y.Z"`
+3. Run `uv lock`
+4. Search tests for hardcoded version strings and update them
+
+## Session Diagnostics Logging
+
+### Overview
 
 AutoSkillit captures two kinds of diagnostic output:
 
@@ -9,18 +58,18 @@ AutoSkillit captures two kinds of diagnostic output:
 
 Session diagnostics capture process-level data (memory, OOM scores, file descriptors, signals, CPU state) at regular intervals during headless sessions, then write structured JSON files after the session completes.
 
-## Directory Structure
+### Directory Structure
 
 Logs are stored in a **global** directory (not per-project), so they persist across worktrees and clones.
 
-### Platform Defaults
+#### Platform Defaults
 
 | Platform | Default Path |
 |----------|-------------|
 | Linux | `$XDG_DATA_HOME/autoskillit/logs` (defaults to `~/.local/share/autoskillit/logs`) |
 | macOS | `~/Library/Application Support/autoskillit/logs` |
 
-### Layout
+#### Layout
 
 ```
 ~/.local/share/autoskillit/logs/
@@ -32,9 +81,9 @@ Logs are stored in a **global** directory (not per-project), so they persist acr
         └── anomalies.jsonl           # Present only if anomalies detected
 ```
 
-## What Gets Captured
+### What Gets Captured
 
-### ProcSnapshot Fields
+#### ProcSnapshot Fields
 
 | Field | Source | Description |
 |-------|--------|-------------|
@@ -51,11 +100,11 @@ Logs are stored in a **global** directory (not per-project), so they persist acr
 | `oom_score` | /proc | OOM killer score (0-1000) |
 | `wchan` | /proc | Kernel wait channel |
 
-### Session Summary Fields
+#### Session Summary Fields
 
 `summary.json` contains: `session_id`, `dir_name`, `pid`, `cwd`, `skill_command`, `success`, `subtype`, `exit_code`, `start_ts`, `snapshot_count`, `anomaly_count`, `peak_rss_kb`, `peak_oom_score`, `peak_fd_ratio`.
 
-### Anomaly Types
+#### Anomaly Types
 
 | Kind | Condition | Severity |
 |------|-----------|----------|
@@ -67,7 +116,7 @@ Logs are stored in a **global** directory (not per-project), so they persist acr
 | `rss_growth` | RSS grows > 2x initial over 5+ snapshots | warning |
 | `fd_high` | fd_count / fd_soft_limit > 0.80 | warning |
 
-## How It Works
+### How It Works
 
 1. **Accumulate**: During a headless session, `LinuxTracingHandle` collects `ProcSnapshot` objects in memory at the configured interval (default 5s)
 2. **Flush**: After the session completes, `flush_session_log()` writes all data to disk
@@ -75,7 +124,7 @@ Logs are stored in a **global** directory (not per-project), so they persist acr
 4. **Index**: Each session appends one line to `sessions.jsonl` for quick scanning
 5. **Retain**: Automatic cleanup keeps at most 500 session directories
 
-## Configuration
+### Configuration
 
 In `.autoskillit/config.yaml`:
 
@@ -86,7 +135,7 @@ linux_tracing:
   log_dir: ""            # empty = platform default, set absolute path to override
 ```
 
-## Finding Problematic Sessions
+### Finding Problematic Sessions
 
 ```bash
 # Sessions with anomalies
@@ -102,6 +151,6 @@ cat ~/.local/share/autoskillit/logs/sessions/{session_id}/anomalies.jsonl | jq .
 jq 'select(.peak_rss_kb > 1000000)' ~/.local/share/autoskillit/logs/sessions.jsonl
 ```
 
-## Disabling
+### Disabling
 
 Set `linux_tracing.enabled: false` in your config to disable all session diagnostics file output. Non-Linux platforms produce no output regardless of this setting.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,173 @@
+# Getting Started
+
+This tutorial walks through running the `implementation` recipe — AutoSkillit's
+flagship pipeline that takes a task description and produces a tested, reviewed PR.
+
+## Before You Start
+
+1. AutoSkillit is installed (`autoskillit doctor` passes)
+2. You're in a git repository with a test command configured
+3. Your project has `.autoskillit/config.yaml` (from `autoskillit init`)
+
+## Starting the Pipeline
+
+    autoskillit cook implementation
+
+This launches an interactive Claude Code session with the recipe loaded. The
+orchestrator will ask you for the required inputs.
+
+## Ingredients (Inputs)
+
+The orchestrator prompts you for these before starting:
+
+| Ingredient | Required | Default | What it does |
+|------------|----------|---------|-------------|
+| `task` | Yes | — | What to implement. Can be a description or a GitHub issue URL |
+| `source_dir` | No | (auto-detected) | Path to your repo. Usually auto-detected |
+| `base_branch` | No | `integration` | Branch to merge into (change to `main` if needed) |
+| `review_approach` | No | `false` | Research modern solutions before implementing |
+| `audit` | No | `true` | Run a quality audit before merging |
+| `open_pr` | No | `true` | Open a GitHub PR (vs. direct merge) |
+| `issue_url` | No | — | GitHub issue URL to close when done |
+
+### Example inputs
+
+**Simple task:**
+> task: "Add a --verbose flag to the export command that prints each file as it's processed"
+
+**GitHub issue:**
+> task: "https://github.com/myorg/myproject/issues/42"
+
+## What Happens Next
+
+### 1. Clone
+
+AutoSkillit clones your repository into `../autoskillit-runs/impl-{timestamp}/`.
+Your working directory is never modified. All pipeline work happens in the clone.
+
+### 2. Plan
+
+The `make-plan` skill analyzes your codebase deeply:
+- Launches parallel subagents to study affected systems
+- Researches approaches via web search
+- Designs tests first (tests that should fail now, pass after implementation)
+- Evaluates approaches on technical merit only
+- Generates architecture diagrams using the appropriate lens
+- Writes a structured plan to `temp/make-plan/`
+
+If the plan is large (>500 lines), it's automatically split into parts that are
+implemented sequentially.
+
+### 3. Verify (Dry Walkthrough)
+
+Before any code is written, the `dry-walkthrough` skill validates the plan:
+- Checks that referenced files and functions actually exist
+- Validates assumptions about current code state
+- Catches circular dependencies and hidden dependencies
+- Fixes issues directly in the plan file
+- Stamps the plan with `Dry-walkthrough verified = TRUE`
+
+Implementation cannot proceed without this stamp.
+
+### 4. Implement
+
+The `implement-worktree` skill creates a git worktree and implements the plan:
+- Creates a new branch in an isolated worktree
+- Implements changes phase by phase with commits per phase
+- Runs `pre-commit` hooks and the full test suite
+- If tests fail, automatically routes to a fix skill
+
+### 5. Test & Fix Loop
+
+If tests fail after implementation:
+- The `resolve-failures` skill diagnoses the failures
+- It applies fixes and re-runs tests
+- This loops until tests pass or the retry budget is exhausted
+- If path-prefix-sensitive files are changed, the pipeline may restart from investigation
+
+### 6. Merge
+
+Once tests pass, `merge_worktree` rebases the worktree branch onto the base branch
+and fast-forward merges. Tests must pass again after the rebase (test gate).
+
+### 7. Push & PR
+
+The merged changes are pushed to the remote, and a PR is opened. The PR body includes:
+- A summary of all plan files used
+- Token usage statistics from the pipeline
+
+### 8. Automated Code Review
+
+The `review-pr` skill reviews the PR with 7 parallel audit subagents:
+
+| Audit | What it checks |
+|-------|---------------|
+| Architecture | Import layering and architectural rule violations |
+| Tests | Over-mocking, weak assertions, xdist safety |
+| Defense | Typed boundaries, error context, late validation |
+| Bugs | Off-by-one errors, missing await, unhandled None |
+| Cohesion | Naming consistency, feature locality |
+| Slop | Dead code, useless comments, AI backward-compat hacks |
+| Deletion regression | Code reintroduced after deliberate deletion |
+
+Each finding is posted as an inline comment on the PR. If changes are requested,
+the `resolve-review` skill applies fixes and pushes.
+
+### 9. CI Watch
+
+If CI is configured, AutoSkillit monitors the CI run. If it fails:
+- `diagnose-ci` analyzes the failure
+- `resolve-failures` applies fixes
+- Changes are re-pushed and CI is re-watched
+
+## After the Pipeline
+
+When the pipeline completes, you'll be asked to confirm cleanup. The clone directory
+is preserved until you approve deletion.
+
+**If something goes wrong:** Clones are always preserved on failure (`keep: "true"`).
+You can inspect the clone, the worktree, and all artifacts in `temp/`.
+
+## Configuration Tips
+
+### Changing the base branch
+
+Most projects use `main` instead of `integration`:
+
+```yaml
+# .autoskillit/config.yaml
+branching:
+  default_base_branch: main
+```
+
+Or pass it as an ingredient: `base_branch: main`
+
+### Setting up worktree dependencies
+
+If your project needs setup after creating a worktree (e.g., installing dependencies):
+
+```yaml
+worktree_setup:
+  command: ["npm", "install"]
+```
+
+### Choosing the model
+
+By default, headless sessions use Sonnet. To use a different model:
+
+```yaml
+model:
+  default: "claude-sonnet-4-6"
+```
+
+See [Configuration Reference](configuration.md) for all options.
+
+## Alternative: Chefs-Hat Mode
+
+If you want to use individual skills interactively (without a recipe):
+
+    autoskillit chefs-hat
+
+This launches Claude Code with all 36 bundled skills available as slash commands.
+Type `/autoskillit:make-plan` to create a plan, `/autoskillit:investigate` to
+debug an issue, etc.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,121 @@
+# Installation
+
+## Prerequisites
+
+### Required
+- **Python 3.11+** — AutoSkillit uses modern Python features (StrEnum, TaskGroup, ExceptionGroup)
+- **Claude Code** — The CLI tool from Anthropic ([install guide](https://docs.anthropic.com/en/docs/claude-code/overview))
+
+### Recommended
+- **uv** — Fast Python package manager ([install](https://docs.astral.sh/uv/getting-started/installation/))
+- **Task** (go-task) — If your project uses Taskfile.yml for test commands
+
+## Quick Install
+
+The install script handles everything:
+
+    curl -fsSL https://raw.githubusercontent.com/TalonT-Org/AutoSkillit/stable/install.sh | sh
+
+What it does:
+1. Checks for Python 3.11+ (installs via brew/apt if missing)
+2. Checks for uv (installs if missing)
+3. Checks for Claude Code (fails with install link if missing)
+4. Installs AutoSkillit from the `stable` branch via `uv tool install`
+5. Registers the plugin with Claude Code via `autoskillit install`
+
+## Manual Install
+
+### Option A: uv tool from stable branch (recommended)
+
+    uv tool install "git+https://github.com/TalonT-Org/AutoSkillit.git@stable"
+    autoskillit install
+
+### Option B: pip from stable branch (into an existing venv)
+
+    pip install "git+https://github.com/TalonT-Org/AutoSkillit.git@stable"
+    autoskillit install
+
+### Option C: Development install (from main branch)
+
+    git clone https://github.com/TalonT-Org/AutoSkillit.git
+    cd AutoSkillit
+    uv pip install -e '.[dev]'
+    autoskillit install
+
+> **Note:** End users should install from the `stable` branch. The `main` branch
+> is for active development and may contain unreleased changes.
+
+## What `autoskillit install` Does
+
+1. Creates a local plugin marketplace at `~/.autoskillit/marketplace/`
+2. Symlinks the installed package into the marketplace
+3. Registers the marketplace with Claude Code: `claude plugin marketplace add`
+4. Installs the plugin: `claude plugin install autoskillit@autoskillit-local`
+5. Syncs hook scripts into Claude Code's `settings.json`
+
+After this, AutoSkillit loads automatically in every Claude Code session.
+
+## Project Setup
+
+    cd your-project
+    autoskillit init
+
+This creates `.autoskillit/config.yaml` with your test command. The only setting most
+projects need.
+
+## Post-Install Verification
+
+    autoskillit doctor
+
+Doctor runs 8 checks:
+| Check | What it verifies |
+|-------|-----------------|
+| stale_mcp_servers | No dead MCP entries in ~/.claude.json |
+| mcp_server_registered | AutoSkillit MCP server is registered |
+| autoskillit_on_path | `autoskillit` command is available |
+| project_config | `.autoskillit/config.yaml` exists |
+| version_consistency | Installed package matches plugin.json |
+| hook_health | All hook scripts exist on disk |
+| hook_registration | Hooks are registered in settings.json |
+| script_version_health | Project recipes are up to date |
+
+## Troubleshooting
+
+### "autoskillit: command not found"
+
+If you installed via `uv tool install`, ensure `~/.local/bin` is on your PATH:
+
+    export PATH="$HOME/.local/bin:$PATH"
+
+### "claude: command not found"
+
+Install Claude Code following [Anthropic's guide](https://docs.anthropic.com/en/docs/claude-code/overview).
+Then re-run `autoskillit install`.
+
+### Doctor reports "version_consistency: WARNING"
+
+Your installed package version doesn't match the plugin manifest. Re-run:
+
+    autoskillit install
+
+### Doctor reports "hook_health: ERROR"
+
+Hook scripts are missing. This usually means the package was updated but `install`
+wasn't re-run:
+
+    autoskillit install
+
+### MCP server not loading
+
+Check that `~/.claude.json` contains the `autoskillit` entry:
+
+    autoskillit config show
+
+If missing, run `autoskillit init` in your project directory.
+
+### Upgrading
+
+    uv tool install --force "git+https://github.com/TalonT-Org/AutoSkillit.git@stable"
+    autoskillit install
+
+Always run `autoskillit install` after upgrading to sync the plugin cache and hooks.

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -1,0 +1,344 @@
+# Recipes
+
+Recipes are YAML workflow definitions that chain skills into automated pipelines.
+Each recipe defines ingredients (inputs), steps (tool calls), and routing logic
+(what to do on success, failure, or specific result values).
+
+## Bundled Recipes
+
+AutoSkillit ships with 8 recipes:
+
+### implementation
+
+**Use when:** You have a task to implement from scratch — a feature, enhancement, or
+refactoring.
+
+**Flow:**
+```
+Clone ─── Plan ─── Verify ─── Implement ─── Test ─── Merge ─── Push ─── PR ─── Review ─── CI
+                                  │           │                         │
+                              Dry-walkthrough  Fix loop              7 audit bots
+```
+
+**Ingredients:**
+| Name | Required | Default | Description |
+|------|----------|---------|-------------|
+| task | Yes | — | What to implement (text or GitHub issue URL) |
+| source_dir | No | auto | Path to source repository |
+| base_branch | No | integration | Target branch for PR |
+| review_approach | No | false | Research solutions before implementing |
+| audit | No | true | Run audit-impl quality gate |
+| open_pr | No | true | Open PR vs. direct merge |
+| issue_url | No | — | GitHub issue to close |
+
+**Skills invoked:** make-plan, dry-walkthrough, implement-worktree-no-merge,
+resolve-failures, audit-impl, open-pr, review-pr, resolve-review, diagnose-ci
+
+---
+
+### bugfix-loop
+
+**Use when:** You have a failing test suite and want automated investigation
+and fixing.
+
+**Flow:**
+```
+Reset ─── Test ─── Investigate ─── Plan ─── Implement ─── Verify ─── Audit ─── Merge
+           │                                                 │
+        Pass → Done                                     Fix loop
+```
+
+**Ingredients:**
+| Name | Required | Default | Description |
+|------|----------|---------|-------------|
+| test_dir | Yes | — | Directory with the failing tests |
+| base_branch | No | integration | Target branch |
+| helper_dir | Yes | — | Directory for investigation artifacts |
+| audit | No | true | Run audit-impl quality gate |
+
+**Skills invoked:** investigate, rectify, implement-worktree-no-merge,
+resolve-failures, audit-impl
+
+---
+
+### remediation
+
+**Use when:** You have a problem that needs deep investigation before any
+implementation — e.g., a bug report, architectural weakness, or unclear failure.
+
+**Flow:**
+```
+Clone ─── Investigate ─── Plan ─── Review? ─── Verify ─── Implement ─── Test ─── Audit ─── Merge ─── PR
+                                                  │                       │
+                                           Verify fail → re-plan      Fix loop
+```
+
+**Ingredients:**
+| Name | Required | Default | Description |
+|------|----------|---------|-------------|
+| topic | Yes | — | What to investigate |
+| source_dir | No | auto | Path to source repository |
+| base_branch | No | integration | Target branch |
+| audit | No | true | Run audit-impl quality gate |
+| review_approach | No | false | Research solutions |
+| open_pr | No | true | Open PR |
+| issue_url | No | — | GitHub issue to close |
+
+**Skills invoked:** investigate, rectify, review-approach, dry-walkthrough,
+implement-worktree-no-merge, resolve-failures, make-plan, audit-impl, open-pr,
+review-pr, resolve-review, diagnose-ci
+
+---
+
+### audit-and-fix
+
+**Use when:** You want to run a code audit and automatically fix the findings.
+
+**Flow:**
+```
+Clone ─── Audit ─── Investigate ─── Plan ─── Implement ─── Test ─── Merge ─── PR
+                                                             │
+                                                          Fix loop
+```
+
+**Ingredients:**
+| Name | Required | Default | Description |
+|------|----------|---------|-------------|
+| source_dir | No | auto | Path to source repository |
+| base_branch | No | integration | Target branch |
+| audit_type | No | arch | Type: arch, tests, cohesion, defense-standards |
+| open_pr | No | true | Open PR |
+| issue_url | No | — | GitHub issue to close |
+
+**Skills invoked:** /audit-{type} (external), investigate, rectify,
+implement-worktree-no-merge, resolve-failures, open-pr, review-pr,
+resolve-review, diagnose-ci
+
+---
+
+### implementation-groups
+
+**Use when:** You have a large document (roadmap, spec, RFC) that needs to be
+broken into sequenced implementation groups.
+
+**Flow:**
+```
+Clone ─── Decompose ─── [FOR EACH GROUP] ─── Plan ─── Verify ─── Implement ─── Test ─── Merge ─── Audit ─── PR
+                              │
+                         make-groups
+```
+
+**Ingredients:**
+| Name | Required | Default | Description |
+|------|----------|---------|-------------|
+| source_doc | Yes | — | Path to the source document |
+| source_dir | No | auto | Path to source repository |
+| base_branch | No | integration | Target branch |
+| review_approach | No | false | Research solutions |
+| audit | No | true | Run audit-impl quality gate |
+| open_pr | No | true | Open PR |
+| issue_url | No | — | GitHub issue to close |
+
+**Skills invoked:** make-groups, make-plan, review-approach, dry-walkthrough,
+implement-worktree-no-merge, resolve-failures, audit-impl, open-pr,
+review-pr, resolve-review, diagnose-ci
+
+---
+
+### batch-implementation
+
+**Use when:** You have multiple GitHub issues to implement and want to share
+clone setup overhead across all of them instead of cloning once per issue.
+
+**Flow:**
+```
+Clone ─── [FOR EACH ISSUE] ─── Claim ─── Branch ─── Implement ─── Push ─── PR ─── Release
+```
+
+**Ingredients:**
+| Name | Required | Default | Description |
+|------|----------|---------|-------------|
+| issues_file | Yes | — | JSON file with issue objects (`issue_url`, `task`) |
+| source_dir | No | auto | Path to source repository |
+| run_name | No | batch-impl | Name prefix for this pipeline run |
+| base_branch | No | integration | Target branch |
+
+**Skills invoked:** make-plan, dry-walkthrough, implement-worktree-no-merge,
+resolve-failures, open-pr
+
+---
+
+### pr-merge-pipeline
+
+**Use when:** You have multiple open PRs targeting a branch and want to
+collapse them into a single integration PR with conflict resolution.
+
+**Flow:**
+```
+Clone ─── Analyze PRs ─── Create Integration Branch ─── [FOR EACH PR] ─── Merge or Resolve ─── Push ─── Review PR
+                                                              │
+                                                     Simple → squash merge
+                                                     Complex → plan + implement + test
+```
+
+**Ingredients:**
+| Name | Required | Default | Description |
+|------|----------|---------|-------------|
+| source_dir | Yes | — | Path to source repository |
+| run_name | No | pr-merge | Name prefix for this pipeline run |
+| base_branch | No | — | Branch all PRs target |
+| upstream_branch | No | main | Branch to create base_branch from if missing |
+| audit | No | true | Gate on audit-impl quality check |
+
+**Skills invoked:** analyze-prs, merge-pr, make-plan, dry-walkthrough,
+implement-worktree-no-merge, resolve-failures, audit-impl, create-review-pr,
+diagnose-ci
+
+---
+
+### smoke-test
+
+**Use when:** You want to verify that the AutoSkillit orchestration engine itself
+is working correctly. This is a self-test.
+
+**Flow:**
+```
+Setup ─── Seed ─── Investigate ─── Plan ─── Implement ─── Test ─── Merge ─── Summary?
+                                                           │
+                                                        Fix loop
+```
+
+**Ingredients:**
+| Name | Required | Default | Description |
+|------|----------|---------|-------------|
+| workspace | Yes | — | An empty directory for the test workspace |
+| base_branch | No | main | Base branch |
+| collect_on_branch | No | true | Push to feature branch |
+
+---
+
+## Recipe YAML Structure
+
+A recipe file has three top-level sections:
+
+```yaml
+# Recipe metadata
+name: my-recipe
+description: What this recipe does
+autoskillit_version: "0.3.1"      # AutoSkillit version it was written for
+
+# Inputs
+ingredients:
+  - name: task
+    description: What to implement
+    required: true
+  - name: base_branch
+    description: Target branch
+    default: main
+
+# Rules injected into the orchestrator's system prompt
+kitchen_rules:
+  - "Never use native Read/Grep/Glob/Edit/Write/Bash tools"
+  - "All investigation must go through run_skill"
+
+# The step graph
+steps:
+  step_name:
+    tool: tool_name          # MCP tool to call
+    with:                    # Arguments to pass
+      key: value
+      key2: "${{ inputs.task }}"     # Reference an ingredient
+      key3: "${{ context.plan_path }}" # Reference a captured value
+    capture:                 # Extract values from the result
+      plan_path: "result.plan_path"
+    on_success: next_step    # Where to go on success
+    on_failure: error_step   # Where to go on failure
+```
+
+### Context Variables
+
+Steps can capture values from results and pass them to later steps:
+
+- `${{ inputs.name }}` — References an ingredient value
+- `${{ context.name }}` — References a previously captured value
+- `${{ result.field }}` — References a field in the current step's result
+- `${{ result.stdout | trim }}` — Applies a filter to the result
+
+### Routing
+
+Each step declares where to go next:
+
+- `on_success: step_name` — On successful completion
+- `on_failure: step_name` — On failure
+- `on_context_limit: step_name` — When the headless session hits context limits
+- `on_exhausted: step_name` — When retry attempts are exhausted
+- `on_result:` — Multi-way routing based on result values:
+  ```yaml
+  on_result:
+    - when: "result.verdict == 'GO'"
+      goto: push
+    - when: "result.verdict == 'NO GO'"
+      goto: remediate
+  ```
+
+### Optional Steps
+
+```yaml
+step_name:
+    tool: run_skill
+    skip_when_false: "${{ inputs.review_approach }}"  # Skip if false
+    optional: true
+```
+
+`skip_when_false` evaluates the expression. If false, the step is skipped and
+routing continues to `on_success`. If the step runs and fails, `on_failure`
+routing is still followed — `optional` does not mean failures are tolerated.
+
+### Retries
+
+```yaml
+step_name:
+    tool: run_skill
+    retries: 2                    # Retry up to 2 times
+    on_exhausted: escalate        # Where to go when retries run out
+```
+
+### Confirm Steps
+
+```yaml
+confirm_cleanup:
+    action: confirm
+    note: "Delete the clone directory?"
+    on_success: delete_clone      # User said yes
+    on_failure: done              # User said no
+```
+
+These use `AskUserQuestion` to get user confirmation before proceeding.
+
+## Project Recipes
+
+Place custom recipes in `.autoskillit/recipes/` to override bundled ones or add
+new workflows:
+
+    .autoskillit/recipes/my-custom.yaml
+
+Project recipes with the same name as a bundled recipe take priority.
+
+Generate custom recipes with:
+- `/autoskillit:write-recipe` — Create a recipe from a description
+- `/autoskillit:setup-project` — Guided setup that generates tailored recipes
+
+## Inspecting Recipes
+
+    autoskillit recipes list              # List all available recipes
+    autoskillit recipes show <name>       # Print raw YAML
+    autoskillit recipes render [name]     # Generate flow diagrams
+
+## Recipe Migrations
+
+When AutoSkillit is upgraded, project recipes may need migration:
+
+    autoskillit migrate           # Show pending migrations
+    autoskillit migrate --check   # Exit 1 if any pending (for CI)
+
+Migrations are applied automatically when recipes are loaded via `load_recipe`.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env sh
+set -e
+
+# ── Color helpers ──────────────────────────────────────────
+if [ -t 1 ]; then
+    GREEN='\033[0;32m'
+    RED='\033[0;31m'
+    YELLOW='\033[0;33m'
+    BOLD='\033[1m'
+    RESET='\033[0m'
+else
+    GREEN=''
+    RED=''
+    YELLOW=''
+    BOLD=''
+    RESET=''
+fi
+
+# ── Utility functions ──────────────────────────────────────
+info()  { printf '%s[info]%s  %s\n' "$BOLD" "$RESET" "$1"; }
+ok()    { printf '%s[ok]%s    %s\n' "$GREEN" "$RESET" "$1"; }
+warn()  { printf '%s[warn]%s  %s\n' "$YELLOW" "$RESET" "$1"; }
+fail()  { printf '%s[fail]%s  %s\n' "$RED" "$RESET" "$1"; exit 1; }
+
+# ── OS detection ───────────────────────────────────────────
+detect_os() {
+    case "$(uname -s)" in
+        Darwin) OS="macos" ;;
+        Linux)
+            if [ -f /etc/os-release ]; then
+                # shellcheck disable=SC1091
+                . /etc/os-release
+                case "$ID" in
+                    ubuntu|debian) OS="ubuntu" ;;
+                    *) OS="linux-other" ;;
+                esac
+            else
+                OS="linux-other"
+            fi
+            ;;
+        *) fail "Unsupported OS: $(uname -s). AutoSkillit supports macOS and Ubuntu." ;;
+    esac
+    info "Detected OS: $OS"
+}
+
+# ── Python 3.11+ ──────────────────────────────────────────
+ensure_python() {
+    if command -v python3 >/dev/null 2>&1; then
+        py_version=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+        py_major=$(echo "$py_version" | cut -d. -f1)
+        py_minor=$(echo "$py_version" | cut -d. -f2)
+        if [ "$py_major" -ge 3 ] && [ "$py_minor" -ge 11 ]; then
+            ok "Python $py_version"
+            return
+        fi
+        warn "Python $py_version found but 3.11+ is required"
+    else
+        warn "Python 3 not found"
+    fi
+
+    info "Installing Python 3.12..."
+    case "$OS" in
+        macos)
+            if ! command -v brew >/dev/null 2>&1; then
+                fail "Homebrew is required to install Python on macOS. Install it from https://brew.sh"
+            fi
+            brew install python@3.12
+            ;;
+        ubuntu)
+            sudo apt-get update -qq
+            sudo apt-get install -y python3.12 python3.12-venv
+            ;;
+        *)
+            fail "Please install Python 3.11+ manually and re-run this script."
+            ;;
+    esac
+
+    # Re-verify
+    if command -v python3 >/dev/null 2>&1; then
+        py_version=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+        ok "Python $py_version installed"
+    else
+        fail "Python installation failed. Please install Python 3.11+ manually."
+    fi
+}
+
+# ── uv ─────────────────────────────────────────────────────
+ensure_uv() {
+    if command -v uv >/dev/null 2>&1; then
+        ok "uv $(uv --version 2>/dev/null | head -1)"
+        return
+    fi
+
+    info "Installing uv..."
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+
+    # Source the env file if it exists
+    if [ -f "$HOME/.local/bin/env" ]; then
+        # shellcheck disable=SC1091
+        . "$HOME/.local/bin/env"
+    fi
+    export PATH="$HOME/.local/bin:$PATH"
+
+    if command -v uv >/dev/null 2>&1; then
+        ok "uv installed"
+    else
+        fail "uv installation failed. See https://docs.astral.sh/uv/getting-started/installation/"
+    fi
+}
+
+# ── Claude Code ────────────────────────────────────────────
+ensure_claude() {
+    if command -v claude >/dev/null 2>&1; then
+        ok "Claude Code found"
+        return
+    fi
+
+    fail "Claude Code is not installed. Install it first:
+  https://docs.anthropic.com/en/docs/claude-code/overview
+
+Then re-run this script."
+}
+
+# ── AutoSkillit ────────────────────────────────────────────
+install_autoskillit() {
+    info "Installing AutoSkillit from stable branch..."
+    uv tool install "git+https://github.com/TalonT-Org/AutoSkillit.git@stable" 2>/dev/null \
+        || uv tool install --force "git+https://github.com/TalonT-Org/AutoSkillit.git@stable" 2>/dev/null \
+        || fail "Failed to install AutoSkillit. Check your network connection."
+    autoskillit install
+    ok "AutoSkillit installed and registered with Claude Code"
+}
+
+# ── Main ───────────────────────────────────────────────────
+main() {
+    printf '\n%sAutoSkillit Installer%s\n\n' "$BOLD" "$RESET"
+    detect_os
+    ensure_python
+    ensure_uv
+    ensure_claude
+    install_autoskillit
+    printf '\n%s✓ All done!%s\n\n' "$GREEN" "$RESET"
+    printf 'Next steps:\n'
+    printf '  cd your-project\n'
+    printf '  autoskillit init\n'
+    printf '  autoskillit cook implementation\n\n'
+}
+
+main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,12 @@ dev = [
     "packaging>=25.0",
 ]
 
+[project.urls]
+Homepage = "https://github.com/TalonT-Org/AutoSkillit"
+Repository = "https://github.com/TalonT-Org/AutoSkillit"
+Documentation = "https://github.com/TalonT-Org/AutoSkillit/tree/stable/docs"
+"Bug Tracker" = "https://github.com/TalonT-Org/AutoSkillit/issues"
+
 [project.scripts]
 autoskillit = "autoskillit.cli:main"
 


### PR DESCRIPTION
## Summary

- **install.sh**: POSIX-compatible cross-platform installer for macOS and Ubuntu — checks Python 3.11+, uv, Claude Code, then installs from the `stable` branch
- **README.md**: Full rewrite as a quick-start document (~100 lines rendered). Includes all 8 recipes, ASCII pipeline diagram, key features (zero footprint, clone isolation, dry-walkthrough gate, 7-dimension PR review, contract cards), and links to all docs
- **docs/**: 5 new files (installation, getting-started, recipes, architecture, cli-reference) and 2 updates (configuration, developer) covering the full documentation surface
- **pyproject.toml**: Added `[project.urls]` section with Homepage, Repository, Documentation, and Bug Tracker links

All factual claims verified against codebase: 36 skills, 8 recipes, 24 gated tools, 12 ungated tools, 7 audit dimensions, 8 doctor checks.

## Test plan

- [x] All 3525 tests pass (`task test-all`)
- [x] Pre-commit hooks pass (ruff, mypy, uv lock, gitleaks)
- [x] `shellcheck install.sh` — script is POSIX-compatible
- [ ] Verify all internal cross-references between docs resolve
- [ ] Verify README renders correctly on GitHub (ASCII diagram, tables, links)
- [ ] Verify `uv lock` succeeds after pyproject.toml URL addition

🤖 Generated with [Claude Code](https://claude.com/claude-code)