### PR TITLE
[FIX] Remove release_issue_success from implementation and remediation recipes

### DIFF
--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -469,7 +469,7 @@ steps:
     capture:
       ci_conclusion: "${{ result.conclusion }}"
       ci_failed_jobs: "${{ result.failed_jobs }}"
-    on_success: release_issue_success
+    on_success: confirm_cleanup
     on_failure: diagnose_ci
     optional: true
     skip_when_false: "inputs.open_pr"
@@ -478,10 +478,10 @@ steps:
       using the wait_for_ci MCP tool (timeout: 300 s). Captures structured output
       (conclusion + failed job names) for downstream resolve_ci.
       Skipped when open_pr=false — no remote feature branch is opened in that mode.
-      On success, routes to release_issue_success to remove the in-progress label
-      before confirm_cleanup. On failure, routes to diagnose_ci which fetches CI
-      logs and writes a diagnosis before routing to resolve_ci for targeted
-      remediation.
+      On success, routes directly to confirm_cleanup — the in-progress label is NOT
+      released here because the PR is still open. On failure, routes to diagnose_ci
+      which fetches CI logs and writes a diagnosis before routing to resolve_ci for
+      targeted remediation.
 
   diagnose_ci:
     tool: run_skill
@@ -532,16 +532,6 @@ steps:
       Pushes the CI-fixed feature branch back to the remote after resolve_ci succeeds.
       Routes back to ci_watch to verify the fix resolves CI. On push failure, escalates
       via cleanup_failure.
-
-  release_issue_success:
-    description: "Release the in-progress claim after successful completion"
-    tool: release_issue
-    optional: true
-    skip_when_false: inputs.issue_url
-    with:
-      issue_url: ${{ inputs.issue_url }}
-    on_success: confirm_cleanup
-    on_failure: confirm_cleanup
 
   release_issue_failure:
     description: "Release the in-progress claim after pipeline failure"

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -452,7 +452,7 @@ steps:
     capture:
       ci_conclusion: "${{ result.conclusion }}"
       ci_failed_jobs: "${{ result.failed_jobs }}"
-    on_success: release_issue_success
+    on_success: confirm_cleanup
     on_failure: diagnose_ci
     optional: true
     skip_when_false: "inputs.open_pr"
@@ -461,9 +461,9 @@ steps:
       using the wait_for_ci MCP tool (timeout: 300 s). Captures structured output
       (conclusion + failed job names) for downstream resolve_ci.
       Skipped when open_pr=false — no remote feature branch is opened in that mode.
-      On success, routes to release_issue_success to remove the in-progress label
-      before confirm_cleanup. On failure, routes to diagnose_ci which fetches CI
-      logs before resolve_ci.
+      On success, routes directly to confirm_cleanup — the in-progress label is NOT
+      released here because the PR is still open. On failure, routes to diagnose_ci
+      which fetches CI logs before resolve_ci.
 
   diagnose_ci:
     tool: run_skill
@@ -514,16 +514,6 @@ steps:
       Pushes the CI-fixed feature branch back to the remote after resolve_ci succeeds.
       Routes back to ci_watch to verify the fix resolves CI. On push failure, escalates
       via cleanup_failure.
-
-  release_issue_success:
-    description: "Release the in-progress claim after successful completion"
-    tool: release_issue
-    optional: true
-    skip_when_false: inputs.issue_url
-    with:
-      issue_url: ${{ inputs.issue_url }}
-    on_success: confirm_cleanup
-    on_failure: confirm_cleanup
 
   release_issue_failure:
     description: "Release the in-progress claim after pipeline failure"

--- a/tests/recipe/test_bundled_recipes.py
+++ b/tests/recipe/test_bundled_recipes.py
@@ -354,11 +354,11 @@ class TestImplementationPipelineStructure:
         assert step.with_args.get("timeout_seconds") == 300
 
     def test_ip_ci_watch_routing(self, recipe) -> None:
-        """T_CI2: ci_watch on_success -> release_issue_success; on_failure -> diagnose_ci."""
+        """T_CI2: ci_watch on_success -> confirm_cleanup; on_failure -> diagnose_ci."""
         step = recipe.steps["ci_watch"]
-        assert step.on_success == "release_issue_success"
+        assert step.on_success == "confirm_cleanup"
         assert step.on_failure == "diagnose_ci"
-        assert "release_issue_success" in recipe.steps
+        assert "release_issue_success" not in recipe.steps
 
     def test_ip_ci_watch_uses_merge_target(self, recipe) -> None:
         """T_CI3: ci_watch uses branch param with context.merge_target, no inline shell."""
@@ -766,11 +766,11 @@ class TestInvestigateFirstStructure:
         assert step.with_args.get("timeout_seconds") == 300
 
     def test_if_ci_watch_routing(self, recipe) -> None:
-        """T_CI2: ci_watch on_success -> release_issue_success; on_failure -> diagnose_ci."""
+        """T_CI2: ci_watch on_success -> confirm_cleanup; on_failure -> diagnose_ci."""
         step = recipe.steps["ci_watch"]
-        assert step.on_success == "release_issue_success"
+        assert step.on_success == "confirm_cleanup"
         assert step.on_failure == "diagnose_ci"
-        assert "release_issue_success" in recipe.steps
+        assert "release_issue_success" not in recipe.steps
 
     def test_if_ci_watch_uses_merge_target(self, recipe) -> None:
         """T_CI3: ci_watch uses branch param with context.merge_target, no inline shell."""

--- a/tests/recipe/test_issue_url_pipeline.py
+++ b/tests/recipe/test_issue_url_pipeline.py
@@ -328,12 +328,13 @@ class TestClaimReleaseGates:
 
     RECIPES = ["implementation", "implementation-groups", "remediation", "audit-and-fix"]
     RECIPES_WITH_RELEASE_SUCCESS = [
-        "implementation",
         "implementation-groups",
-        "remediation",
         "audit-and-fix",
     ]
-    RECIPES_WITHOUT_RELEASE_SUCCESS: list[str] = []
+    RECIPES_WITHOUT_RELEASE_SUCCESS = [
+        "implementation",
+        "remediation",
+    ]
 
     def test_split_lists_are_exhaustive(self):
         """All RECIPES must appear in exactly one of the split lists."""


### PR DESCRIPTION
## Summary

Both `implementation.yaml` and `remediation.yaml` call `release_issue` on the success path
(`release_issue_success` step), which removes the `in-progress` label from the GitHub issue
after CI passes and the PR is opened. This is incorrect — the in-progress label should stay on
the issue while there is an open PR. Only the failure path should release the label.

The fix removes the `release_issue_success` step from both recipes and routes `ci_watch.on_success`
directly to `confirm_cleanup`. The `release_issue_failure` step and all failure-path routing
remain unchanged.

## Requirements

### RECIPE

- **REQ-RECIPE-001:** The `implementation.yaml` recipe must NOT call `release_issue` on the success path when a PR has been opened.
- **REQ-RECIPE-002:** The `remediation.yaml` recipe must NOT call `release_issue` on the success path when a PR has been opened.
- **REQ-RECIPE-003:** The `ci_watch` step `on_success` must route directly to `confirm_cleanup` (bypassing `release_issue_success`) in both recipes.
- **REQ-RECIPE-004:** The `release_issue_failure` step must remain unchanged — the in-progress label is still released on pipeline failure.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    UPSTREAM(["upstream steps<br/>(review_pr / re_push / re_push_review)"])
    DONE(["done<br/>(clone preserved)"])
    DELETE_CLONE(["delete_clone<br/>(clone removed)"])
    ESCALATE(["escalate_stop"])

    %% CI WATCH — MODIFIED %%
    CW["● ci_watch<br/>━━━━━━━━━━<br/>wait_for_ci<br/>branch: merge_target<br/>timeout: 300s<br/>skip when open_pr=false"]

    subgraph SuccessPath ["SUCCESS PATH (label stays on issue — PR still open)"]
        direction TB
        CC["confirm_cleanup<br/>━━━━━━━━━━<br/>action: confirm<br/>Delete clone now?"]
    end

    subgraph FailureDiagnosis ["FAILURE PATH — CI diagnosis & retry loop"]
        direction TB
        DC["diagnose_ci<br/>━━━━━━━━━━<br/>run_skill: diagnose-ci<br/>writes diagnosis_path"]
        RC["resolve_ci<br/>━━━━━━━━━━<br/>run_skill: resolve-failures<br/>fixes CI issues"]
        RP["re_push<br/>━━━━━━━━━━<br/>push_to_remote<br/>triggers new CI run"]
    end

    subgraph FailureCleanup ["FAILURE CLEANUP — label released only on failure"]
        direction TB
        RIF["release_issue_failure<br/>━━━━━━━━━━<br/>release_issue tool<br/>skip when no issue_url<br/>removes in-progress label"]
        CLF["cleanup_failure<br/>━━━━━━━━━━<br/>remove_clone keep=true<br/>preserves clone on disk"]
    end

    %% FLOW %%
    UPSTREAM --> CW
    CW -->|"on_success"| CC
    CW -->|"on_failure"| DC

    CC -->|"yes (on_success)"| DELETE_CLONE
    CC -->|"no (on_failure)"| DONE

    DC -->|"on_success / on_failure"| RC
    RC --> RP
    RP -->|"on_success"| CW

    RP -->|"on_failure / max retries"| RIF
    RIF -->|"on_success / on_failure"| CLF
    CLF -->|"on_success / on_failure"| ESCALATE

    %% CLASS ASSIGNMENTS %%
    class UPSTREAM,DONE,DELETE_CLONE,ESCALATE terminal;
    class CW handler;
    class CC phase;
    class DC,RC,RP handler;
    class RIF,CLF detector;
```

**Color Legend:**
| Color | Category | Description |
|-------|----------|-------------|
| Dark Blue | Terminal | Start/end states (upstream, done, escalate) |
| Orange | Handler | Recipe tool-call steps (ci_watch, diagnose_ci, resolve_ci, re_push) |
| Purple | Phase | Control/confirmation steps (confirm_cleanup) |
| Red | Detector | Failure guards and cleanup steps (release_issue_failure, cleanup_failure) |

**Modification Key:** `●` = Modified by this PR

Closes #335

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/fix-release-label-20260311-214045-907910/temp/make-plan/fix_release_label_plan_2026-03-11_214500.md`

## Token Usage Summary

# Token Summary

## fix

- input_tokens: 617
- output_tokens: 241470
- cache_creation_input_tokens: 802321
- cache_read_input_tokens: 45488590
- invocation_count: 11
- elapsed_seconds: 5789.439858307993

## resolve_review

- input_tokens: 391
- output_tokens: 168303
- cache_creation_input_tokens: 449347
- cache_read_input_tokens: 21658363
- invocation_count: 7
- elapsed_seconds: 4158.092358417003

## audit_impl

- input_tokens: 2744
- output_tokens: 159180
- cache_creation_input_tokens: 545076
- cache_read_input_tokens: 4174746
- invocation_count: 12
- elapsed_seconds: 4455.282969588996

## open_pr

- input_tokens: 213
- output_tokens: 137769
- cache_creation_input_tokens: 422276
- cache_read_input_tokens: 6866150
- invocation_count: 8
- elapsed_seconds: 3639.0721166939948

## review_pr

- input_tokens: 177
- output_tokens: 244448
- cache_creation_input_tokens: 479046
- cache_read_input_tokens: 6204544
- invocation_count: 7
- elapsed_seconds: 4626.790592216992

## plan

- input_tokens: 1665
- output_tokens: 187361
- cache_creation_input_tokens: 655841
- cache_read_input_tokens: 11017819
- invocation_count: 8
- elapsed_seconds: 3779.893521053007

## verify

- input_tokens: 8274
- output_tokens: 151282
- cache_creation_input_tokens: 664012
- cache_read_input_tokens: 12450916
- invocation_count: 10
- elapsed_seconds: 3138.836677256011

## implement

- input_tokens: 785
- output_tokens: 269097
- cache_creation_input_tokens: 876108
- cache_read_input_tokens: 61001114
- invocation_count: 10
- elapsed_seconds: 6131.576118467008

## analyze_prs

- input_tokens: 15
- output_tokens: 29915
- cache_creation_input_tokens: 67472
- cache_read_input_tokens: 374939
- invocation_count: 1
- elapsed_seconds: 524.8599999569997

## merge_pr

- input_tokens: 166
- output_tokens: 56815
- cache_creation_input_tokens: 314110
- cache_read_input_tokens: 4466380
- invocation_count: 9
- elapsed_seconds: 1805.746022643012

## create_review_pr

- input_tokens: 27
- output_tokens: 20902
- cache_creation_input_tokens: 62646
- cache_read_input_tokens: 856008
- invocation_count: 1
- elapsed_seconds: 444.64073076299974

## resolve_merge_conflicts

- input_tokens: 88
- output_tokens: 52987
- cache_creation_input_tokens: 122668
- cache_read_input_tokens: 7419558
- invocation_count: 1
- elapsed_seconds: 975.0682389580033

## Timing Summary

## fix

- total_seconds: 5789.520738078008
- invocation_count: 11

## resolve_review

- total_seconds: 4158.092358417003
- invocation_count: 7

## audit_impl

- total_seconds: 4455.326102384002
- invocation_count: 12

## open_pr

- total_seconds: 3639.0721166939948
- invocation_count: 8

## review_pr

- total_seconds: 4626.790592216992
- invocation_count: 7

## plan

- total_seconds: 3780.017026652018
- invocation_count: 8

## verify

- total_seconds: 3138.9388441649935
- invocation_count: 10

## implement

- total_seconds: 6131.693511301022
- invocation_count: 10

## analyze_prs

- total_seconds: 524.8599999569997
- invocation_count: 1

## merge_pr

- total_seconds: 1805.746022643012
- invocation_count: 9

## create_review_pr

- total_seconds: 444.64073076299974
- invocation_count: 1

## resolve_merge_conflicts

- total_seconds: 975.0682389580033
- invocation_count: 1

## clone

- total_seconds: 14.340457123005763
- invocation_count: 3

## update_ticket

- total_seconds: 1.0304174909979338
- invocation_count: 1

## capture_base_sha

- total_seconds: 0.00960076300543733
- invocation_count: 3

## create_branch

- total_seconds: 1.9964898860052926
- invocation_count: 3

## push_merge_target

- total_seconds: 2.7216036769968923
- invocation_count: 3

## test

- total_seconds: 332.84049233200494
- invocation_count: 5

## merge

- total_seconds: 395.920931871995
- invocation_count: 3

## push

- total_seconds: 0.9490148440090707
- invocation_count: 1

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
