### PR TITLE
Fix autoskillit: namespace prefix in arch-lens output paths

### DIFF
--- a/src/autoskillit/skills_extended/arch-lens-c4-container/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-c4-container/SKILL.md
@@ -125,7 +125,7 @@ Use the mermaid skill conventions to create a diagram with:
 
 ### Step 5: Write Output
 
-Write the diagram to: `temp/autoskillit:arch-lens-c4-container/arch_diag_c4_container_{YYYY-MM-DD_HHMMSS}.md` (relative to the current working directory)
+Write the diagram to: `temp/arch-lens-c4-container/arch_diag_c4_container_{YYYY-MM-DD_HHMMSS}.md` (relative to the current working directory)
 
 After writing the diagram file, emit a structured output line:
 

--- a/src/autoskillit/skills_extended/arch-lens-concurrency/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-concurrency/SKILL.md
@@ -131,7 +131,7 @@ Use flowchart with:
 
 ### Step 5: Write Output
 
-Write the diagram to: `temp/autoskillit:arch-lens-concurrency/arch_diag_concurrency_{YYYY-MM-DD_HHMMSS}.md` (relative to the current working directory)
+Write the diagram to: `temp/arch-lens-concurrency/arch_diag_concurrency_{YYYY-MM-DD_HHMMSS}.md` (relative to the current working directory)
 
 After writing the diagram file, emit a structured output line:
 

--- a/src/autoskillit/skills_extended/arch-lens-data-lineage/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-data-lineage/SKILL.md
@@ -134,7 +134,7 @@ Use flowchart with:
 
 ### Step 5: Write Output
 
-Write the diagram to: `temp/autoskillit:arch-lens-data-lineage/arch_diag_data_lineage_{YYYY-MM-DD_HHMMSS}.md` (relative to the current working directory)
+Write the diagram to: `temp/arch-lens-data-lineage/arch_diag_data_lineage_{YYYY-MM-DD_HHMMSS}.md` (relative to the current working directory)
 
 After writing the diagram file, emit a structured output line:
 

--- a/src/autoskillit/skills_extended/arch-lens-deployment/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-deployment/SKILL.md
@@ -129,7 +129,7 @@ Use flowchart with:
 
 ### Step 5: Write Output
 
-Write the diagram to: `temp/autoskillit:arch-lens-deployment/arch_diag_deployment_{YYYY-MM-DD_HHMMSS}.md` (relative to the current working directory)
+Write the diagram to: `temp/arch-lens-deployment/arch_diag_deployment_{YYYY-MM-DD_HHMMSS}.md` (relative to the current working directory)
 
 After writing the diagram file, emit a structured output line:
 

--- a/src/autoskillit/skills_extended/arch-lens-development/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-development/SKILL.md
@@ -135,7 +135,7 @@ Use flowchart with:
 
 ### Step 5: Write Output
 
-Write the diagram to: `temp/autoskillit:arch-lens-development/arch_diag_development_{YYYY-MM-DD_HHMMSS}.md` (relative to the current working directory)
+Write the diagram to: `temp/arch-lens-development/arch_diag_development_{YYYY-MM-DD_HHMMSS}.md` (relative to the current working directory)
 
 After writing the diagram file, emit a structured output line:
 

--- a/src/autoskillit/skills_extended/arch-lens-error-resilience/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-error-resilience/SKILL.md
@@ -132,7 +132,7 @@ Use flowchart with:
 
 ### Step 5: Write Output
 
-Write the diagram to: `temp/autoskillit:arch-lens-error-resilience/arch_diag_error_resilience_{YYYY-MM-DD_HHMMSS}.md` (relative to the current working directory)
+Write the diagram to: `temp/arch-lens-error-resilience/arch_diag_error_resilience_{YYYY-MM-DD_HHMMSS}.md` (relative to the current working directory)
 
 After writing the diagram file, emit a structured output line:
 

--- a/src/autoskillit/skills_extended/arch-lens-module-dependency/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-module-dependency/SKILL.md
@@ -126,7 +126,7 @@ Use graph with:
 
 ### Step 5: Write Output
 
-Write the diagram to: `temp/autoskillit:arch-lens-module-dependency/arch_diag_module_dependency_{YYYY-MM-DD_HHMMSS}.md` (relative to the current working directory)
+Write the diagram to: `temp/arch-lens-module-dependency/arch_diag_module_dependency_{YYYY-MM-DD_HHMMSS}.md` (relative to the current working directory)
 
 After writing the diagram file, emit a structured output line:
 

--- a/src/autoskillit/skills_extended/arch-lens-operational/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-operational/SKILL.md
@@ -134,7 +134,7 @@ Use flowchart with:
 
 ### Step 5: Write Output
 
-Write the diagram to: `temp/autoskillit:arch-lens-operational/arch_diag_operational_{YYYY-MM-DD_HHMMSS}.md` (relative to the current working directory)
+Write the diagram to: `temp/arch-lens-operational/arch_diag_operational_{YYYY-MM-DD_HHMMSS}.md` (relative to the current working directory)
 
 After writing the diagram file, emit a structured output line:
 

--- a/src/autoskillit/skills_extended/arch-lens-process-flow/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-process-flow/SKILL.md
@@ -127,7 +127,7 @@ Use flowchart with:
 
 ### Step 5: Write Output
 
-Write the diagram to: `temp/autoskillit:arch-lens-process-flow/arch_diag_process_flow_{YYYY-MM-DD_HHMMSS}.md` (relative to the current working directory)
+Write the diagram to: `temp/arch-lens-process-flow/arch_diag_process_flow_{YYYY-MM-DD_HHMMSS}.md` (relative to the current working directory)
 
 After writing the diagram file, emit a structured output line:
 

--- a/src/autoskillit/skills_extended/arch-lens-repository-access/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-repository-access/SKILL.md
@@ -133,7 +133,7 @@ Use flowchart with:
 
 ### Step 5: Write Output
 
-Write the diagram to: `temp/autoskillit:arch-lens-repository-access/arch_diag_repository_access_{YYYY-MM-DD_HHMMSS}.md` (relative to the current working directory)
+Write the diagram to: `temp/arch-lens-repository-access/arch_diag_repository_access_{YYYY-MM-DD_HHMMSS}.md` (relative to the current working directory)
 
 After writing the diagram file, emit a structured output line:
 

--- a/src/autoskillit/skills_extended/arch-lens-scenarios/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-scenarios/SKILL.md
@@ -126,7 +126,7 @@ Use flowchart with:
 
 ### Step 5: Write Output
 
-Write the diagram to: `temp/autoskillit:arch-lens-scenarios/arch_diag_scenarios_{YYYY-MM-DD_HHMMSS}.md` (relative to the current working directory)
+Write the diagram to: `temp/arch-lens-scenarios/arch_diag_scenarios_{YYYY-MM-DD_HHMMSS}.md` (relative to the current working directory)
 
 After writing the diagram file, emit a structured output line:
 

--- a/src/autoskillit/skills_extended/arch-lens-security/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-security/SKILL.md
@@ -137,7 +137,7 @@ Use flowchart with:
 
 ### Step 5: Write Output
 
-Write the diagram to: `temp/autoskillit:arch-lens-security/arch_diag_security_{YYYY-MM-DD_HHMMSS}.md` (relative to the current working directory)
+Write the diagram to: `temp/arch-lens-security/arch_diag_security_{YYYY-MM-DD_HHMMSS}.md` (relative to the current working directory)
 
 After writing the diagram file, emit a structured output line:
 

--- a/src/autoskillit/skills_extended/arch-lens-state-lifecycle/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-state-lifecycle/SKILL.md
@@ -129,7 +129,7 @@ Use flowchart with:
 
 ### Step 5: Write Output
 
-Write the diagram to: `temp/autoskillit:arch-lens-state-lifecycle/arch_diag_state_lifecycle_{YYYY-MM-DD_HHMMSS}.md` (relative to the current working directory)
+Write the diagram to: `temp/arch-lens-state-lifecycle/arch_diag_state_lifecycle_{YYYY-MM-DD_HHMMSS}.md` (relative to the current working directory)
 
 After writing the diagram file, emit a structured output line:
 

--- a/tests/skills/test_skill_output_compliance.py
+++ b/tests/skills/test_skill_output_compliance.py
@@ -162,6 +162,20 @@ def test_no_shared_scratch_files(skill_name: str) -> None:
 
 
 @pytest.mark.parametrize("skill_name", _get_file_producing_skills())
+def test_no_namespace_prefix_in_output_paths(skill_name: str) -> None:
+    """Output paths must not include the autoskillit: namespace prefix."""
+    resolver = SkillResolver()
+    info = resolver.resolve(skill_name)
+    assert info is not None
+    content = info.path.read_text()
+
+    assert "temp/autoskillit:" not in content, (
+        f"Skill '{skill_name}' uses namespace prefix in output path.\n"
+        f"Use bare skill name: temp/{skill_name}/... (no autoskillit: prefix)."
+    )
+
+
+@pytest.mark.parametrize("skill_name", _get_file_producing_skills())
 def test_file_producing_skills_have_cwd_anchor(skill_name: str) -> None:
     """Every file-producing skill must anchor temp/ writes to the current working directory."""
     resolver = SkillResolver()


### PR DESCRIPTION
## Summary

All 13 arch-lens SKILL.md files instructed the model to write output to `temp/autoskillit:arch-lens-<name>/` — embedding the slash-command namespace prefix as a directory component. This creates directories with colons in the name and misaligns with downstream consumers (`open-pr`, `open-integration-pr`) that expect `temp/arch-lens-<name>/`. The fix removes the `autoskillit:` prefix from each output path instruction and adds a regression test to prevent reintroduction.

## Architecture Impact

### Data Lineage Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart LR
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    subgraph Producers ["● Arch-Lens Skills (13 Modified)"]
        direction TB
        AL1["● arch-lens-c4-container<br/>━━━━━━━━━━<br/>SKILL.md output path fixed"]
        AL2["● arch-lens-concurrency<br/>━━━━━━━━━━<br/>SKILL.md output path fixed"]
        ALN["● ... (11 more)<br/>━━━━━━━━━━<br/>All 13 skills modified"]
    end

    subgraph TempFS ["temp/ Filesystem"]
        direction TB
        PATH["temp/arch-lens-*/...<br/>━━━━━━━━━━<br/>Corrected path<br/>(was temp/autoskillit:arch-lens-*/)"]
    end

    subgraph Consumers ["Downstream Consumers"]
        direction TB
        OPR["open-pr<br/>━━━━━━━━━━<br/>Reads temp/arch-lens-{name}/"]
        OIPR["open-integration-pr<br/>━━━━━━━━━━<br/>Reads temp/arch-lens-{name}/"]
    end

    subgraph Guard ["● Regression Guard"]
        direction TB
        TEST["● test_no_namespace_prefix<br/>━━━━━━━━━━<br/>Asserts no temp/autoskillit:<br/>in any SKILL.md"]
    end

    AL1 -->|"write diagram"| PATH
    AL2 -->|"write diagram"| PATH
    ALN -->|"write diagram"| PATH

    PATH -->|"read & embed"| OPR
    PATH -->|"read & embed"| OIPR

    TEST -.->|"validates paths"| AL1
    TEST -.->|"validates paths"| AL2
    TEST -.->|"validates paths"| ALN

    class AL1,AL2,ALN handler;
    class PATH stateNode;
    class OPR,OIPR cli;
    class TEST detector;
```

## Implementation Plan

Plan file: `temp/make-plan/fix_autoskillit_prefix_in_output_paths_plan_2026-03-17_234500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
