### PR TITLE
Implementation Plan: Auto-Merge Direct Merge Fallback (Issue #401)

### DIFF
--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -27,7 +27,9 @@ ingredients:
     description: PR instead of direct merge
     default: "true"
   auto_merge:
-    description: Enroll the PR in the merge queue automatically after checks pass
+    description: >-
+      Automatically merge the PR after required checks pass —
+      via merge queue when available, direct merge otherwise
     default: "true"
   issue_url:
     description: GitHub issue to close on merge
@@ -617,7 +619,7 @@ steps:
         route: confirm_cleanup
       - when: "${{ context.queue_available }} == 'true'"
         route: enable_auto_merge
-      - route: release_issue_success
+      - route: direct_merge
     skip_when_false: "inputs.open_pr"
 
   enable_auto_merge:
@@ -716,6 +718,92 @@ steps:
     note: >
       Re-submits the PR after conflict resolution. Routes back to wait_for_queue.
       If re-entry fails, release_issue_failure preserves the clone for debugging.
+
+  direct_merge:
+    tool: run_cmd
+    with:
+      cmd: "gh pr merge '${{ context.pr_number }}' --squash --auto"
+      cwd: "${{ context.work_dir }}"
+      step_name: "direct_merge"
+    on_success: wait_for_direct_merge
+    on_failure: confirm_cleanup
+    skip_when_false: "inputs.open_pr"
+    note: >
+      Enables GitHub native auto-merge for direct merge (no merge queue). GitHub
+      merges automatically once all required checks pass. On failure (PR already
+      merged, not mergeable), degrades gracefully to confirm_cleanup.
+
+  wait_for_direct_merge:
+    tool: run_cmd
+    with:
+      cmd: >
+        for i in $(seq 1 90); do
+          STATE=$(gh pr view '${{ context.pr_number }}' --json state --jq '.state') &&
+          if [ "$STATE" = "MERGED" ]; then echo "merged"; exit 0; fi;
+          if [ "$STATE" = "CLOSED" ]; then echo "closed"; exit 0; fi;
+          sleep 10;
+        done; echo "timeout"
+      cwd: "${{ context.work_dir }}"
+      step_name: "wait_for_direct_merge"
+    capture:
+      direct_merge_state: "${{ result.stdout | trim }}"
+    on_result:
+      - when: "${{ result.stdout | trim }} == merged"
+        route: release_issue_success
+      - when: "${{ result.stdout | trim }} == closed"
+        route: direct_merge_conflict_fix
+      - route: release_issue_timeout
+    on_failure: release_issue_timeout
+    skip_when_false: "inputs.open_pr"
+    note: >
+      Polls GitHub PR state every 10 s for up to 15 minutes (90 iterations).
+      merged → release_issue_success (issue labelled, cleanup runs).
+      closed → PR was closed (likely conflict) — route to conflict fix.
+      timeout / unexpected → release_issue_timeout.
+
+  direct_merge_conflict_fix:
+    tool: run_skill
+    with:
+      skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
+      cwd: "${{ context.work_dir }}"
+      step_name: "direct_merge_conflict_fix"
+    capture:
+      conflict_escalation_required: "${{ result.escalation_required }}"
+    on_result:
+      - when: "${{ result.escalation_required }} == true"
+        route: release_issue_failure
+      - route: re_push_direct_fix
+    on_failure: release_issue_failure
+    retries: 1
+    on_exhausted: release_issue_failure
+    skip_when_false: "inputs.open_pr"
+    note: >
+      Resolves rebase conflicts on the feature branch after direct-merge rejection.
+      escalation_required=true → release_issue_failure for human review.
+
+  re_push_direct_fix:
+    tool: push_to_remote
+    with:
+      clone_path: "${{ context.work_dir }}"
+      remote_url: "${{ context.remote_url }}"
+      branch: "${{ context.merge_target }}"
+    on_success: redirect_merge
+    on_failure: release_issue_failure
+    skip_when_false: "inputs.open_pr"
+
+  redirect_merge:
+    tool: run_cmd
+    with:
+      cmd: "gh pr merge '${{ context.pr_number }}' --squash --auto"
+      cwd: "${{ context.work_dir }}"
+      step_name: "redirect_merge"
+    on_success: wait_for_direct_merge
+    on_failure: release_issue_failure
+    skip_when_false: "inputs.open_pr"
+    note: >
+      Re-enables auto-merge after conflict resolution and re-push.
+      Routes back to wait_for_direct_merge to poll for completion.
+      On failure, release_issue_failure preserves the clone for debugging.
 
   release_issue_timeout:
     description: "Release in-progress claim after queue timeout without applying staged label"

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -738,15 +738,13 @@ steps:
     with:
       cmd: >
         for i in $(seq 1 90); do
-          STATE=$(gh pr view '${{ context.pr_number }}' --json state --jq '.state') &&
+          STATE=$(gh pr view '${{ context.pr_number }}' --json state --jq '.state');
           if [ "$STATE" = "MERGED" ]; then echo "merged"; exit 0; fi;
           if [ "$STATE" = "CLOSED" ]; then echo "closed"; exit 0; fi;
           sleep 10;
         done; echo "timeout"
       cwd: "${{ context.work_dir }}"
       step_name: "wait_for_direct_merge"
-    capture:
-      direct_merge_state: "${{ result.stdout | trim }}"
     on_result:
       - when: "${{ result.stdout | trim }} == merged"
         route: release_issue_success
@@ -767,8 +765,6 @@ steps:
       skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
       step_name: "direct_merge_conflict_fix"
-    capture:
-      conflict_escalation_required: "${{ result.escalation_required }}"
     on_result:
       - when: "${{ result.escalation_required }} == true"
         route: release_issue_failure

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -765,6 +765,8 @@ steps:
       skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
       step_name: "direct_merge_conflict_fix"
+    capture:
+      conflict_escalation_required: "${{ result.escalation_required }}"
     on_result:
       - when: "${{ result.escalation_required }} == true"
         route: release_issue_failure

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -617,7 +617,7 @@ steps:
     on_result:
       - when: "${{ inputs.auto_merge }} != 'true'"
         route: confirm_cleanup
-      - when: "${{ context.queue_available }} == 'true'"
+      - when: "${{ context.queue_available }} == true"
         route: enable_auto_merge
       - route: direct_merge
     skip_when_false: "inputs.open_pr"

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -698,6 +698,8 @@ steps:
       skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
       step_name: "direct_merge_conflict_fix"
+    capture:
+      conflict_escalation_required: "${{ result.escalation_required }}"
     on_result:
       - when: "${{ result.escalation_required }} == true"
         route: release_issue_failure

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -27,7 +27,9 @@ ingredients:
     description: PR instead of direct merge
     default: "true"
   auto_merge:
-    description: Enroll the PR in the merge queue automatically after checks pass
+    description: >-
+      Automatically merge the PR after required checks pass —
+      via merge queue when available, direct merge otherwise
     default: "true"
   issue_url:
     description: GitHub issue to close on merge
@@ -550,7 +552,7 @@ steps:
         route: confirm_cleanup
       - when: "${{ context.queue_available }} == true"
         route: enable_auto_merge
-      - route: release_issue_success
+      - route: direct_merge
     skip_when_false: "inputs.open_pr"
 
   enable_auto_merge:
@@ -649,6 +651,92 @@ steps:
     note: >
       Re-submits the PR after conflict resolution. Routes back to wait_for_queue.
       If re-entry fails, release_issue_failure preserves the clone for debugging.
+
+  direct_merge:
+    tool: run_cmd
+    with:
+      cmd: "gh pr merge '${{ context.pr_number }}' --squash --auto"
+      cwd: "${{ context.work_dir }}"
+      step_name: "direct_merge"
+    on_success: wait_for_direct_merge
+    on_failure: confirm_cleanup
+    skip_when_false: "inputs.open_pr"
+    note: >
+      Enables GitHub native auto-merge for direct merge (no merge queue). GitHub
+      merges automatically once all required checks pass. On failure (PR already
+      merged, not mergeable), degrades gracefully to confirm_cleanup.
+
+  wait_for_direct_merge:
+    tool: run_cmd
+    with:
+      cmd: >
+        for i in $(seq 1 90); do
+          STATE=$(gh pr view '${{ context.pr_number }}' --json state --jq '.state') &&
+          if [ "$STATE" = "MERGED" ]; then echo "merged"; exit 0; fi;
+          if [ "$STATE" = "CLOSED" ]; then echo "closed"; exit 0; fi;
+          sleep 10;
+        done; echo "timeout"
+      cwd: "${{ context.work_dir }}"
+      step_name: "wait_for_direct_merge"
+    capture:
+      direct_merge_state: "${{ result.stdout | trim }}"
+    on_result:
+      - when: "${{ result.stdout | trim }} == merged"
+        route: release_issue_success
+      - when: "${{ result.stdout | trim }} == closed"
+        route: direct_merge_conflict_fix
+      - route: release_issue_timeout
+    on_failure: release_issue_timeout
+    skip_when_false: "inputs.open_pr"
+    note: >
+      Polls GitHub PR state every 10 s for up to 15 minutes (90 iterations).
+      merged → release_issue_success (issue labelled, cleanup runs).
+      closed → PR was closed (likely conflict) — route to conflict fix.
+      timeout / unexpected → release_issue_timeout.
+
+  direct_merge_conflict_fix:
+    tool: run_skill
+    with:
+      skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
+      cwd: "${{ context.work_dir }}"
+      step_name: "direct_merge_conflict_fix"
+    capture:
+      conflict_escalation_required: "${{ result.escalation_required }}"
+    on_result:
+      - when: "${{ result.escalation_required }} == true"
+        route: release_issue_failure
+      - route: re_push_direct_fix
+    on_failure: release_issue_failure
+    retries: 1
+    on_exhausted: release_issue_failure
+    skip_when_false: "inputs.open_pr"
+    note: >
+      Resolves rebase conflicts on the feature branch after direct-merge rejection.
+      escalation_required=true → release_issue_failure for human review.
+
+  re_push_direct_fix:
+    tool: push_to_remote
+    with:
+      clone_path: "${{ context.work_dir }}"
+      remote_url: "${{ context.remote_url }}"
+      branch: "${{ context.merge_target }}"
+    on_success: redirect_merge
+    on_failure: release_issue_failure
+    skip_when_false: "inputs.open_pr"
+
+  redirect_merge:
+    tool: run_cmd
+    with:
+      cmd: "gh pr merge '${{ context.pr_number }}' --squash --auto"
+      cwd: "${{ context.work_dir }}"
+      step_name: "redirect_merge"
+    on_success: wait_for_direct_merge
+    on_failure: release_issue_failure
+    skip_when_false: "inputs.open_pr"
+    note: >
+      Re-enables auto-merge after conflict resolution and re-push.
+      Routes back to wait_for_direct_merge to poll for completion.
+      On failure, release_issue_failure preserves the clone for debugging.
 
   diagnose_ci:
     tool: run_skill

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -671,15 +671,13 @@ steps:
     with:
       cmd: >
         for i in $(seq 1 90); do
-          STATE=$(gh pr view '${{ context.pr_number }}' --json state --jq '.state') &&
+          STATE=$(gh pr view '${{ context.pr_number }}' --json state --jq '.state');
           if [ "$STATE" = "MERGED" ]; then echo "merged"; exit 0; fi;
           if [ "$STATE" = "CLOSED" ]; then echo "closed"; exit 0; fi;
           sleep 10;
         done; echo "timeout"
       cwd: "${{ context.work_dir }}"
       step_name: "wait_for_direct_merge"
-    capture:
-      direct_merge_state: "${{ result.stdout | trim }}"
     on_result:
       - when: "${{ result.stdout | trim }} == merged"
         route: release_issue_success
@@ -700,8 +698,6 @@ steps:
       skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
       step_name: "direct_merge_conflict_fix"
-    capture:
-      conflict_escalation_required: "${{ result.escalation_required }}"
     on_result:
       - when: "${{ result.escalation_required }} == true"
         route: release_issue_failure

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -52,7 +52,9 @@ ingredients:
     description: PR instead of direct merge
     default: "true"
   auto_merge:
-    description: Enroll the PR in the merge queue automatically after checks pass
+    description: >-
+      Automatically merge the PR after required checks pass —
+      via merge queue when available, direct merge otherwise
     default: "true"
   issue_url:
     description: GitHub issue to close on merge
@@ -535,7 +537,7 @@ steps:
         route: confirm_cleanup
       - when: "${{ context.queue_available }} == true"
         route: enable_auto_merge
-      - route: release_issue_success
+      - route: direct_merge
     skip_when_false: "inputs.open_pr"
 
   enable_auto_merge:
@@ -634,6 +636,92 @@ steps:
     note: >
       Re-submits the PR after conflict resolution. Routes back to wait_for_queue.
       If re-entry fails, release_issue_failure preserves the clone for debugging.
+
+  direct_merge:
+    tool: run_cmd
+    with:
+      cmd: "gh pr merge '${{ context.pr_number }}' --squash --auto"
+      cwd: "${{ context.work_dir }}"
+      step_name: "direct_merge"
+    on_success: wait_for_direct_merge
+    on_failure: confirm_cleanup
+    skip_when_false: "inputs.open_pr"
+    note: >
+      Enables GitHub native auto-merge for direct merge (no merge queue). GitHub
+      merges automatically once all required checks pass. On failure (PR already
+      merged, not mergeable), degrades gracefully to confirm_cleanup.
+
+  wait_for_direct_merge:
+    tool: run_cmd
+    with:
+      cmd: >
+        for i in $(seq 1 90); do
+          STATE=$(gh pr view '${{ context.pr_number }}' --json state --jq '.state') &&
+          if [ "$STATE" = "MERGED" ]; then echo "merged"; exit 0; fi;
+          if [ "$STATE" = "CLOSED" ]; then echo "closed"; exit 0; fi;
+          sleep 10;
+        done; echo "timeout"
+      cwd: "${{ context.work_dir }}"
+      step_name: "wait_for_direct_merge"
+    capture:
+      direct_merge_state: "${{ result.stdout | trim }}"
+    on_result:
+      - when: "${{ result.stdout | trim }} == merged"
+        route: release_issue_success
+      - when: "${{ result.stdout | trim }} == closed"
+        route: direct_merge_conflict_fix
+      - route: confirm_cleanup
+    on_failure: confirm_cleanup
+    skip_when_false: "inputs.open_pr"
+    note: >
+      Polls GitHub PR state every 10 s for up to 15 minutes.
+      merged → release_issue_success.
+      closed → conflict fix cycle.
+      timeout / failure → confirm_cleanup (pipeline done; human monitors merge).
+
+  direct_merge_conflict_fix:
+    tool: run_skill
+    with:
+      skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
+      cwd: "${{ context.work_dir }}"
+      step_name: "direct_merge_conflict_fix"
+    capture:
+      conflict_escalation_required: "${{ result.escalation_required }}"
+    on_result:
+      - when: "${{ result.escalation_required }} == true"
+        route: release_issue_failure
+      - route: re_push_direct_fix
+    on_failure: release_issue_failure
+    retries: 1
+    on_exhausted: release_issue_failure
+    skip_when_false: "inputs.open_pr"
+    note: >
+      Resolves rebase conflicts on the feature branch after direct-merge rejection.
+      escalation_required=true → release_issue_failure for human review.
+
+  re_push_direct_fix:
+    tool: push_to_remote
+    with:
+      clone_path: "${{ context.work_dir }}"
+      remote_url: "${{ context.remote_url }}"
+      branch: "${{ context.merge_target }}"
+    on_success: redirect_merge
+    on_failure: release_issue_failure
+    skip_when_false: "inputs.open_pr"
+
+  redirect_merge:
+    tool: run_cmd
+    with:
+      cmd: "gh pr merge '${{ context.pr_number }}' --squash --auto"
+      cwd: "${{ context.work_dir }}"
+      step_name: "redirect_merge"
+    on_success: wait_for_direct_merge
+    on_failure: release_issue_failure
+    skip_when_false: "inputs.open_pr"
+    note: >
+      Re-enables auto-merge after conflict resolution and re-push.
+      Routes back to wait_for_direct_merge to poll for completion.
+      On failure, release_issue_failure preserves the clone for debugging.
 
   diagnose_ci:
     tool: run_skill

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -809,6 +809,21 @@ steps:
       (LOW confidence conflicts) or tool failure, routes to release_issue_failure.
       retries: 1 bounds the loop; after 2 total attempts, escalates.
 
+  release_issue_timeout:
+    description: "Release in-progress claim after direct merge timeout without applying staged label"
+    tool: release_issue
+    optional: true
+    skip_when_false: inputs.issue_url
+    with:
+      issue_url: ${{ inputs.issue_url }}
+    on_success: confirm_cleanup
+    on_failure: confirm_cleanup
+    note: >
+      Called when wait_for_direct_merge times out. Releases the in-progress
+      claim without passing target_branch, so the staged label is not applied. The
+      merge is unconfirmed; a human must verify PR state independently.
+      Routes to confirm_cleanup so the pipeline completes cleanly.
+
   release_issue_success:
     description: "Transition issue from in-progress to staged after successful pipeline completion"
     tool: release_issue

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -670,14 +670,14 @@ steps:
         route: release_issue_success
       - when: "${{ result.stdout | trim }} == closed"
         route: direct_merge_conflict_fix
-      - route: confirm_cleanup
+      - route: release_issue_timeout
     on_failure: confirm_cleanup
     skip_when_false: "inputs.open_pr"
     note: >
       Polls GitHub PR state every 10 s for up to 15 minutes.
       merged → release_issue_success.
       closed → conflict fix cycle.
-      timeout / failure → confirm_cleanup (pipeline done; human monitors merge).
+      timeout → release_issue_timeout (releases claim; merge unconfirmed).
 
   direct_merge_conflict_fix:
     tool: run_skill

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -683,6 +683,8 @@ steps:
       skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
       step_name: "direct_merge_conflict_fix"
+    capture:
+      conflict_escalation_required: "${{ result.escalation_required }}"
     on_result:
       - when: "${{ result.escalation_required }} == true"
         route: release_issue_failure

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -656,15 +656,13 @@ steps:
     with:
       cmd: >
         for i in $(seq 1 90); do
-          STATE=$(gh pr view '${{ context.pr_number }}' --json state --jq '.state') &&
+          STATE=$(gh pr view '${{ context.pr_number }}' --json state --jq '.state');
           if [ "$STATE" = "MERGED" ]; then echo "merged"; exit 0; fi;
           if [ "$STATE" = "CLOSED" ]; then echo "closed"; exit 0; fi;
           sleep 10;
         done; echo "timeout"
       cwd: "${{ context.work_dir }}"
       step_name: "wait_for_direct_merge"
-    capture:
-      direct_merge_state: "${{ result.stdout | trim }}"
     on_result:
       - when: "${{ result.stdout | trim }} == merged"
         route: release_issue_success
@@ -685,8 +683,6 @@ steps:
       skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
       step_name: "direct_merge_conflict_fix"
-    capture:
-      conflict_escalation_required: "${{ result.escalation_required }}"
     on_result:
       - when: "${{ result.escalation_required }} == true"
         route: release_issue_failure

--- a/tests/recipe/test_merge_prs_queue.py
+++ b/tests/recipe/test_merge_prs_queue.py
@@ -31,6 +31,11 @@ def remed_recipe():
     return load_recipe(builtin_recipes_dir() / "remediation.yaml")
 
 
+@pytest.fixture(scope="module")
+def impl_groups_recipe():
+    return load_recipe(builtin_recipes_dir() / "implementation-groups.yaml")
+
+
 # ---------------------------------------------------------------------------
 # merge-prs.yaml — validate passes
 # ---------------------------------------------------------------------------
@@ -307,9 +312,11 @@ def test_remediation_open_pr_step_routes_to_extract_pr_number(remed_recipe) -> N
     assert step.on_success == "extract_pr_number"
 
 
-@pytest.fixture(scope="module", params=["impl", "remed"])
-def any_recipe(request, impl_recipe, remed_recipe):
-    return impl_recipe if request.param == "impl" else remed_recipe
+@pytest.fixture(scope="module", params=["impl", "remed", "impl_groups"])
+def any_recipe(request, impl_recipe, remed_recipe, impl_groups_recipe):
+    return {"impl": impl_recipe, "remed": remed_recipe, "impl_groups": impl_groups_recipe}[
+        request.param
+    ]
 
 
 def test_auto_merge_ingredient(any_recipe) -> None:
@@ -336,3 +343,102 @@ def test_auto_merge_false_routes_to_confirm_cleanup(any_recipe) -> None:
     )
     assert auto_merge_cond.when == "${{ inputs.auto_merge }} != 'true'"
     assert auto_merge_cond.route == "confirm_cleanup"
+
+
+# ---------------------------------------------------------------------------
+# Direct merge fallback — all three affected recipes
+# ---------------------------------------------------------------------------
+
+
+def test_route_queue_mode_default_routes_to_direct_merge(any_recipe) -> None:
+    """Default (no-queue) condition must route to direct_merge, not release_issue_success."""
+    step = any_recipe.steps["route_queue_mode"]
+    default_cond = next(c for c in step.on_result.conditions if c.when is None)
+    assert default_cond.route == "direct_merge"
+
+
+def test_direct_merge_step_exists(any_recipe) -> None:
+    assert "direct_merge" in any_recipe.steps
+    step = any_recipe.steps["direct_merge"]
+    assert step.tool == "run_cmd"
+
+
+def test_direct_merge_routes_to_wait_for_direct_merge(any_recipe) -> None:
+    step = any_recipe.steps["direct_merge"]
+    assert step.on_success == "wait_for_direct_merge"
+
+
+def test_direct_merge_failure_routes_to_confirm_cleanup(any_recipe) -> None:
+    step = any_recipe.steps["direct_merge"]
+    assert step.on_failure == "confirm_cleanup"
+
+
+def test_wait_for_direct_merge_step_exists(any_recipe) -> None:
+    assert "wait_for_direct_merge" in any_recipe.steps
+    step = any_recipe.steps["wait_for_direct_merge"]
+    assert step.tool == "run_cmd"
+
+
+def test_wait_for_direct_merge_merged_routes_to_success(any_recipe) -> None:
+    step = any_recipe.steps["wait_for_direct_merge"]
+    merged_cond = next(c for c in step.on_result.conditions if c.when and "merged" in c.when)
+    assert merged_cond.route == "release_issue_success"
+
+
+def test_wait_for_direct_merge_closed_routes_to_conflict_fix(any_recipe) -> None:
+    step = any_recipe.steps["wait_for_direct_merge"]
+    closed_cond = next(c for c in step.on_result.conditions if c.when and "closed" in c.when)
+    assert closed_cond.route == "direct_merge_conflict_fix"
+
+
+def test_direct_merge_conflict_fix_exists(any_recipe) -> None:
+    assert "direct_merge_conflict_fix" in any_recipe.steps
+    step = any_recipe.steps["direct_merge_conflict_fix"]
+    assert step.tool == "run_skill"
+
+
+def test_re_push_direct_fix_exists(any_recipe) -> None:
+    assert "re_push_direct_fix" in any_recipe.steps
+    step = any_recipe.steps["re_push_direct_fix"]
+    assert step.tool == "push_to_remote"
+    assert step.on_success == "redirect_merge"
+
+
+def test_redirect_merge_step_exists(any_recipe) -> None:
+    assert "redirect_merge" in any_recipe.steps
+    step = any_recipe.steps["redirect_merge"]
+    assert step.tool == "run_cmd"
+    assert step.on_success == "wait_for_direct_merge"
+
+
+def test_direct_merge_steps_have_skip_when_false(any_recipe) -> None:
+    new_steps = [
+        "direct_merge",
+        "wait_for_direct_merge",
+        "direct_merge_conflict_fix",
+        "re_push_direct_fix",
+        "redirect_merge",
+    ]
+    for step_name in new_steps:
+        assert step_name in any_recipe.steps, f"Missing step: {step_name}"
+        step = any_recipe.steps[step_name]
+        assert step.skip_when_false == "inputs.open_pr", (
+            f"{step_name}.skip_when_false must be 'inputs.open_pr'"
+        )
+
+
+def test_auto_merge_ingredient_description_updated(any_recipe) -> None:
+    ing = any_recipe.ingredients["auto_merge"]
+    assert "direct merge" in ing.description.lower() or "direct" in ing.description.lower(), (
+        "auto_merge description must mention direct merge as an alternative to queue"
+    )
+
+
+def test_implementation_recipe_still_valid(impl_recipe) -> None:
+    errors = validate_recipe(impl_recipe)
+    assert errors == [], f"validate_recipe errors: {errors}"
+
+
+def test_remediation_recipe_still_valid(remed_recipe) -> None:
+    errors = validate_recipe(remed_recipe)
+    assert errors == [], f"validate_recipe errors: {errors}"

--- a/tests/recipe/test_merge_prs_queue.py
+++ b/tests/recipe/test_merge_prs_queue.py
@@ -353,7 +353,8 @@ def test_auto_merge_false_routes_to_confirm_cleanup(any_recipe) -> None:
 def test_route_queue_mode_default_routes_to_direct_merge(any_recipe) -> None:
     """Default (no-queue) condition must route to direct_merge, not release_issue_success."""
     step = any_recipe.steps["route_queue_mode"]
-    default_cond = next(c for c in step.on_result.conditions if c.when is None)
+    default_cond = next((c for c in step.on_result.conditions if c.when is None), None)
+    assert default_cond is not None, "Expected a default (when=None) condition in route_queue_mode"
     assert default_cond.route == "direct_merge"
 
 
@@ -381,13 +382,19 @@ def test_wait_for_direct_merge_step_exists(any_recipe) -> None:
 
 def test_wait_for_direct_merge_merged_routes_to_success(any_recipe) -> None:
     step = any_recipe.steps["wait_for_direct_merge"]
-    merged_cond = next(c for c in step.on_result.conditions if c.when and "merged" in c.when)
+    merged_cond = next(
+        (c for c in step.on_result.conditions if c.when and "merged" in c.when), None
+    )
+    assert merged_cond is not None, "Expected a 'merged' condition in wait_for_direct_merge"
     assert merged_cond.route == "release_issue_success"
 
 
 def test_wait_for_direct_merge_closed_routes_to_conflict_fix(any_recipe) -> None:
     step = any_recipe.steps["wait_for_direct_merge"]
-    closed_cond = next(c for c in step.on_result.conditions if c.when and "closed" in c.when)
+    closed_cond = next(
+        (c for c in step.on_result.conditions if c.when and "closed" in c.when), None
+    )
+    assert closed_cond is not None, "Expected a 'closed' condition in wait_for_direct_merge"
     assert closed_cond.route == "direct_merge_conflict_fix"
 
 
@@ -441,4 +448,9 @@ def test_implementation_recipe_still_valid(impl_recipe) -> None:
 
 def test_remediation_recipe_still_valid(remed_recipe) -> None:
     errors = validate_recipe(remed_recipe)
+    assert errors == [], f"validate_recipe errors: {errors}"
+
+
+def test_impl_groups_recipe_still_valid(impl_groups_recipe) -> None:
+    errors = validate_recipe(impl_groups_recipe)
     assert errors == [], f"validate_recipe errors: {errors}"


### PR DESCRIPTION
## Summary

When `auto_merge == "true"` and `queue_available == "false"`, the pipeline previously dropped
the PR unmerged by routing the `route_queue_mode` default case to `release_issue_success`.
This is incorrect — GitHub's `gh pr merge --squash --auto` works without a merge queue by
merging directly once required checks pass. The fix adds a `direct_merge` step chain as
the default route, mirroring the queue path's structure (enable → poll → conflict-fix →
re-push → re-enable). The same change is applied in three recipes: `implementation.yaml`,
`remediation.yaml`, and `implementation-groups.yaml`.

## Requirements

### ROUTE — Recipe Routing Updates

- **REQ-ROUTE-001:** When `auto_merge` is `"true"` and `queue_available` is `"false"`, both `implementation.yaml` and `remediation.yaml` must route to a direct-merge step instead of skipping to cleanup/release.
- **REQ-ROUTE-002:** The direct-merge step must invoke `gh pr merge --squash --auto` to enable GitHub-native auto-merge regardless of merge queue presence.
- **REQ-ROUTE-003:** The direct-merge path must poll PR state for `merged` completion rather than calling `wait_for_merge_queue`.

### FAIL — Failure Handling

- **REQ-FAIL-001:** The direct-merge path must handle merge failures (e.g., conflicts from concurrent merges) with a resolve-and-retry pattern analogous to the queue ejection path.
- **REQ-FAIL-002:** If the direct merge fails due to a non-conflict error, the recipe must route to the same cleanup/release path used by the queue timeout case.

### DESC — Ingredient Description

- **REQ-DESC-001:** The `auto_merge` ingredient description in both `implementation.yaml` and `remediation.yaml` must be updated to reflect that it controls automatic merging after checks pass, not specifically merge queue enrollment.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 45, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart TB
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;

    START([CI checks pass])

    subgraph Detection ["Queue Detection"]
        CMQ["check_merge_queue<br/>━━━━━━━━━━<br/>GraphQL: mergeQueue id?<br/>captures queue_available"]
        RQM{"● route_queue_mode<br/>━━━━━━━━━━<br/>auto_merge? queue?"}
    end

    subgraph QueuePath ["Queue Path"]
        EAM["enable_auto_merge<br/>━━━━━━━━━━<br/>gh pr merge --squash --auto<br/>→ enroll in queue"]
        WFQ["wait_for_queue<br/>━━━━━━━━━━<br/>wait_for_merge_queue<br/>900 s timeout"]
        REENROLL["reenroll_stalled_pr<br/>━━━━━━━━━━<br/>toggle_auto_merge"]
        QEF["queue_ejected_fix<br/>━━━━━━━━━━<br/>resolve-merge-conflicts"]
        RPQF["re_push_queue_fix<br/>━━━━━━━━━━<br/>push_to_remote"]
        RMQ["reenter_merge_queue<br/>━━━━━━━━━━<br/>gh pr merge --squash --auto"]
    end

    subgraph DirectPath ["★ Direct Merge Path (new)"]
        DM["★ direct_merge<br/>━━━━━━━━━━<br/>gh pr merge --squash --auto<br/>direct (no queue)"]
        WFDM["★ wait_for_direct_merge<br/>━━━━━━━━━━<br/>poll gh pr view<br/>10 s × 90 = 15 min"]
        DMCF["★ direct_merge_conflict_fix<br/>━━━━━━━━━━<br/>resolve-merge-conflicts"]
        RPDF["★ re_push_direct_fix<br/>━━━━━━━━━━<br/>push_to_remote"]
        RDM["★ redirect_merge<br/>━━━━━━━━━━<br/>gh pr merge --squash --auto<br/>re-enable after fix"]
    end

    SUCCESS["release_issue_success<br/>━━━━━━━━━━<br/>label: staged"]
    TIMEOUT["release_issue_timeout<br/>━━━━━━━━━━<br/>no staged label"]
    FAILURE["release_issue_failure<br/>━━━━━━━━━━<br/>→ cleanup_failure"]
    CONFIRM["confirm_cleanup<br/>━━━━━━━━━━<br/>delete clone? yes/no"]
    DONE([done])

    START --> CMQ
    CMQ --> RQM
    RQM -->|"auto_merge != 'true'"| CONFIRM
    RQM -->|"queue_available == true"| EAM
    RQM -->|"● default (was release_issue_success)"| DM

    EAM --> WFQ
    EAM -->|"on_failure"| CONFIRM
    WFQ -->|"merged"| SUCCESS
    WFQ -->|"ejected"| QEF
    WFQ -->|"stalled"| REENROLL
    WFQ -->|"timeout"| TIMEOUT
    REENROLL --> WFQ
    QEF -->|"resolved"| RPQF
    QEF -->|"escalation_required"| FAILURE
    RPQF --> RMQ
    RMQ --> WFQ

    DM --> WFDM
    DM -->|"on_failure"| CONFIRM
    WFDM -->|"merged"| SUCCESS
    WFDM -->|"closed"| DMCF
    WFDM -->|"timeout"| TIMEOUT
    DMCF -->|"resolved"| RPDF
    DMCF -->|"escalation_required"| FAILURE
    RPDF --> RDM
    RDM --> WFDM

    SUCCESS --> CONFIRM
    TIMEOUT --> CONFIRM
    CONFIRM -->|"yes"| DONE
    CONFIRM -->|"no"| DONE

    class START,DONE terminal;
    class CMQ phase;
    class RQM stateNode;
    class EAM,WFQ,REENROLL,QEF,RPQF,RMQ handler;
    class DM,WFDM,DMCF,RPDF,RDM newComponent;
    class CONFIRM detector;
    class SUCCESS,TIMEOUT,FAILURE output;
```

**Color Legend:**
| Color | Category | Description |
|-------|----------|-------------|
| Dark Blue | Terminal | Pipeline start and end states |
| Purple | Phase | Queue detection and analysis nodes |
| Teal | State | `● route_queue_mode` — modified routing decision |
| Orange | Handler | Existing queue path steps |
| Green | New Component | `★` New direct-merge path steps added by this PR |
| Dark Teal | Output | Terminal release / timeout / failure states |
| Red | Detector | `confirm_cleanup` gate |

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 48, 'rankSpacing': 56, 'curve': 'basis'}}}%%
flowchart TB
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph Inputs ["INIT_ONLY — Ingredient Fields (set at recipe start)"]
        direction LR
        OPR["inputs.open_pr<br/>━━━━━━━━━━<br/>default: true<br/>SKIP_GATE for all PR steps"]
        AM["● inputs.auto_merge<br/>━━━━━━━━━━<br/>default: true<br/>● desc: direct merge fallback"]
        BB["inputs.base_branch<br/>━━━━━━━━━━<br/>merge target"]
        IU["inputs.issue_url<br/>━━━━━━━━━━<br/>optional: release gate"]
    end

    subgraph Prerequisites ["SET_ONCE — Pipeline Context (captured before merge path)"]
        direction LR
        QA["context.queue_available<br/>━━━━━━━━━━<br/>SET: check_merge_queue<br/>READ: route_queue_mode"]
        PRN["context.pr_number<br/>━━━━━━━━━━<br/>SET: extract_pr_number<br/>READ: direct_merge, wait_for_direct_merge"]
        WD["context.work_dir<br/>━━━━━━━━━━<br/>SET: clone<br/>READ: all direct-merge steps"]
        MT["context.merge_target<br/>━━━━━━━━━━<br/>SET: create_branch<br/>READ: re_push_direct_fix"]
    end

    subgraph Gate ["VALIDATION GATE — skip_when_false"]
        GATE["inputs.open_pr == true<br/>━━━━━━━━━━<br/>Guards all 5 new steps:<br/>direct_merge, wait_for_direct_merge,<br/>direct_merge_conflict_fix,<br/>re_push_direct_fix, redirect_merge"]
    end

    subgraph RoutingDecision ["● route_queue_mode — State-Based Router"]
        RQM["● route_queue_mode<br/>━━━━━━━━━━<br/>reads: inputs.auto_merge<br/>reads: context.queue_available<br/>● default → direct_merge (was: release_issue_success)"]
    end

    subgraph NewCaptures ["★ CAPTURE_RESULT — New Context Fields (direct merge path)"]
        direction TB
        DMS["★ direct_merge_state<br/>━━━━━━━━━━<br/>SET: wait_for_direct_merge<br/>values: merged | closed | timeout<br/>READ: on_result conditions"]
        CER["conflict_escalation_required<br/>━━━━━━━━━━<br/>SET: direct_merge_conflict_fix<br/>values: true | false<br/>READ: on_result conditions"]
    end

    subgraph RouteContracts ["ON_RESULT CONTRACTS — Typed routing guards"]
        direction TB
        WFDMc["wait_for_direct_merge<br/>━━━━━━━━━━<br/>merged → release_issue_success<br/>closed → direct_merge_conflict_fix<br/>default → release_issue_timeout"]
        DMCFc["direct_merge_conflict_fix<br/>━━━━━━━━━━<br/>escalation_required == true → release_issue_failure<br/>default → re_push_direct_fix"]
    end

    OPR -->|"evaluated each step"| GATE
    AM -->|"read by"| RQM
    QA -->|"read by"| RQM
    BB -->|"passed to"| DMCFc
    IU -->|"gates"| RouteContracts

    PRN -->|"passed to"| Gate
    WD -->|"passed to"| Gate
    MT -->|"passed to"| Gate

    GATE -->|"pass → execute"| RQM
    RQM -->|"default route changed"| NewCaptures

    DMS -->|"consumed by"| WFDMc
    CER -->|"consumed by"| DMCFc

    class OPR,AM,BB,IU detector;
    class QA,PRN,WD,MT stateNode;
    class GATE gap;
    class RQM phase;
    class DMS newComponent;
    class CER handler;
    class WFDMc,DMCFc output;
```

**Color Legend:**
| Color | Category | Description |
|-------|----------|-------------|
| Red | INIT_ONLY | Ingredient fields — set once at recipe start, never mutated |
| Teal | SET_ONCE | Pipeline context fields — captured before merge path, read by new steps |
| Yellow/Orange | SKIP_GATE | `inputs.open_pr` validation gate protecting all new steps |
| Purple | Modified Router | `● route_queue_mode` — routing logic changed by this PR |
| Green | New Capture | `★ direct_merge_state` — new field introduced by this PR |
| Orange | Existing Capture | `conflict_escalation_required` — existing field, also written by new step |
| Dark Teal | Route Contracts | `on_result` typed routing guards (consume captured fields) |

Closes #401

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260320-165150-373150/temp/make-plan/direct_merge_fallback_plan_2026-03-20_000001.md`

## Token Usage Summary

## Token Summary\n\n(Token data accumulated server-side)

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
