### PR TITLE
Init — Require Explicit Opt-in to Bypass Missing Secret Scanning Hook

### DIFF
--- a/src/autoskillit/cli/_doctor.py
+++ b/src/autoskillit/cli/_doctor.py
@@ -146,6 +146,32 @@ def _check_gitignore_completeness(project_dir: Path) -> DoctorResult:
     return DoctorResult(Severity.OK, "gitignore_completeness", "All .autoskillit/ files covered.")
 
 
+def _check_secret_scanning_hook(project_dir: Path) -> DoctorResult:
+    """Check that .pre-commit-config.yaml includes a known secret scanning hook."""
+    from autoskillit.cli._init_helpers import _KNOWN_SCANNERS, _detect_secret_scanner
+
+    if _detect_secret_scanner(project_dir):
+        return DoctorResult(
+            Severity.OK,
+            "secret_scanning_hook",
+            "Secret scanning hook detected in .pre-commit-config.yaml.",
+        )
+    pre_commit_path = project_dir / ".pre-commit-config.yaml"
+    if not pre_commit_path.exists():
+        msg = (
+            "No .pre-commit-config.yaml found. AutoSkillit commits code automatically — "
+            "add a secret scanner (gitleaks, detect-secrets, trufflehog, or git-secrets) "
+            "to prevent credential leaks."
+        )
+    else:
+        scanners = ", ".join(sorted(_KNOWN_SCANNERS))
+        msg = (
+            f".pre-commit-config.yaml exists but contains no known secret scanner "
+            f"({scanners}). Add one to prevent credential leaks."
+        )
+    return DoctorResult(Severity.ERROR, "secret_scanning_hook", msg)
+
+
 def run_doctor(*, output_json: bool = False) -> None:
     """Check project setup for common issues."""
     from autoskillit.cli._marketplace import _clear_plugin_cache
@@ -343,6 +369,9 @@ def run_doctor(*, output_json: bool = False) -> None:
 
     # Check 9: gitignore completeness
     results.append(_check_gitignore_completeness(Path.cwd()))
+
+    # Check 10: Secret scanning hook
+    results.append(_check_secret_scanning_hook(Path.cwd()))
 
     # Output
     if output_json:

--- a/src/autoskillit/cli/_doctor.py
+++ b/src/autoskillit/cli/_doctor.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from autoskillit.cli._hooks import _claude_settings_path, _load_settings_data
+from autoskillit.cli._init_helpers import _KNOWN_SCANNERS, _detect_secret_scanner
 from autoskillit.core import Severity
 from autoskillit.hook_registry import HOOK_REGISTRY
 
@@ -148,8 +149,6 @@ def _check_gitignore_completeness(project_dir: Path) -> DoctorResult:
 
 def _check_secret_scanning_hook(project_dir: Path) -> DoctorResult:
     """Check that .pre-commit-config.yaml includes a known secret scanning hook."""
-    from autoskillit.cli._init_helpers import _KNOWN_SCANNERS, _detect_secret_scanner
-
     if _detect_secret_scanner(project_dir):
         return DoctorResult(
             Severity.OK,

--- a/src/autoskillit/cli/_init_helpers.py
+++ b/src/autoskillit/cli/_init_helpers.py
@@ -26,6 +26,13 @@ def _colors() -> tuple[str, str, str, str, str, str]:
     )
 
 
+_KNOWN_SCANNERS: frozenset[str] = frozenset(
+    {"gitleaks", "detect-secrets", "trufflehog", "git-secrets"}
+)
+
+_SECRET_SCAN_BYPASS_PHRASE = "I accept the risk of leaking secrets without pre-commit scanning"
+
+
 _MARKER_CONTENT = """\
 # autoskillit workspace - do not delete
 # This file authorizes reset_test_dir and reset_workspace to clear this directory.
@@ -132,6 +139,86 @@ def _create_secrets_template(project_dir: Path) -> None:
         "github:\n"
         "  token: ''  # Optional — only needed if gh auth is unavailable\n",
     )
+
+
+def _detect_secret_scanner(project_dir: Path) -> bool:
+    """Return True if .pre-commit-config.yaml references a known secret scanner."""
+    config_path = project_dir / ".pre-commit-config.yaml"
+    if not config_path.is_file():
+        return False
+    try:
+        data = load_yaml(config_path) or {}
+    except YAMLError:
+        return False
+    for repo in data.get("repos", []):
+        for hook in repo.get("hooks", []):
+            if hook.get("id") in _KNOWN_SCANNERS:
+                return True
+    return False
+
+
+def _log_secret_scan_bypass(project_dir: Path) -> None:
+    """Persist bypass acceptance timestamp to .autoskillit/config.yaml."""
+    from datetime import UTC, datetime
+
+    config_path = project_dir / ".autoskillit" / "config.yaml"
+    try:
+        data: dict = (load_yaml(config_path) or {}) if config_path.is_file() else {}
+    except YAMLError:
+        data = {}
+    data.setdefault("safety", {})["secret_scan_bypass_accepted"] = datetime.now(UTC).isoformat()
+    config_path.parent.mkdir(exist_ok=True)
+    atomic_write(config_path, dump_yaml_str(data, default_flow_style=False, allow_unicode=True))
+
+
+def _check_secret_scanning(project_dir: Path) -> bool:
+    """Gate: require secret scanning hook or explicit typed consent.
+
+    Returns True if it is safe to proceed (scanner found or bypass accepted).
+    Returns False if the check fails and init should abort (caller raises SystemExit(1)).
+    """
+    import sys
+
+    _B, _C, _D, _G, _Y, _R = _colors()
+
+    if _detect_secret_scanner(project_dir):
+        print(f"  {_Y}{'secret scanning':>12}{_R}  {_G}✓ hook detected{_R}")
+        return True
+
+    # No scanner found — require explicit opt-in
+    if not sys.stdin.isatty():
+        print(
+            f"\n  {_B}ERROR:{_R} No secret scanning hook found in .pre-commit-config.yaml.\n"
+            f"  AutoSkillit commits code automatically. Without a secret scanner,\n"
+            f"  leaked credentials are inevitable.\n\n"
+            f"  Add gitleaks, detect-secrets, trufflehog, or git-secrets to\n"
+            f"  .pre-commit-config.yaml before running 'autoskillit init'.\n"
+            f"  Non-interactive mode cannot bypass this check.\n"
+        )
+        return False
+
+    # Interactive: show warning and require consent phrase
+    border = "━" * 62
+    print(f"\n  {_Y}{border}{_R}")
+    print(f"  {_Y}  WARNING: No secret scanning hook detected{_R}")
+    print(f"  {_Y}{border}{_R}")
+    print(
+        "  AutoSkillit automates code commits at scale. Without a\n"
+        "  secret scanner in your pre-commit pipeline, leaked API\n"
+        "  keys and credentials are not a matter of if, but when.\n\n"
+        "  Recommended: add gitleaks to .pre-commit-config.yaml\n"
+        "  before proceeding.\n"
+    )
+    print("  To bypass, type exactly:\n")
+    print(f"  {_D}{_SECRET_SCAN_BYPASS_PHRASE}{_R}\n")
+    response = input("  > ").strip()
+    if response != _SECRET_SCAN_BYPASS_PHRASE:
+        print(f"\n  {_B}Aborted.{_R} Phrase did not match.")
+        return False
+
+    _log_secret_scan_bypass(project_dir)
+    print(f"  {_Y}{'bypass':>12}{_R}  {_D}accepted — logged to config.yaml{_R}")
+    return True
 
 
 def _is_plugin_installed() -> bool:

--- a/src/autoskillit/cli/_init_helpers.py
+++ b/src/autoskillit/cli/_init_helpers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+from datetime import UTC, datetime
 from pathlib import Path
 
 from autoskillit.core import YAMLError, atomic_write, dump_yaml_str, load_yaml
@@ -164,8 +165,6 @@ def _detect_secret_scanner(project_dir: Path) -> bool:
 
 def _log_secret_scan_bypass(project_dir: Path) -> None:
     """Persist bypass acceptance timestamp to .autoskillit/config.yaml."""
-    from datetime import UTC, datetime
-
     config_path = project_dir / ".autoskillit" / "config.yaml"
     try:
         raw = (load_yaml(config_path) or {}) if config_path.is_file() else {}
@@ -183,8 +182,6 @@ def _check_secret_scanning(project_dir: Path) -> bool:
     Returns True if it is safe to proceed (scanner found or bypass accepted).
     Returns False if the check fails and init should abort (caller raises SystemExit(1)).
     """
-    import sys
-
     _B, _C, _D, _G, _Y, _R = _colors()
 
     if _detect_secret_scanner(project_dir):

--- a/src/autoskillit/cli/_init_helpers.py
+++ b/src/autoskillit/cli/_init_helpers.py
@@ -150,7 +150,12 @@ def _detect_secret_scanner(project_dir: Path) -> bool:
         data = load_yaml(config_path) or {}
     except YAMLError:
         return False
-    for repo in data.get("repos", []):
+    if not isinstance(data, dict):
+        return False
+    repos = data.get("repos", [])
+    if not isinstance(repos, list):
+        return False
+    for repo in repos:
         for hook in repo.get("hooks", []):
             if hook.get("id") in _KNOWN_SCANNERS:
                 return True
@@ -163,7 +168,8 @@ def _log_secret_scan_bypass(project_dir: Path) -> None:
 
     config_path = project_dir / ".autoskillit" / "config.yaml"
     try:
-        data: dict = (load_yaml(config_path) or {}) if config_path.is_file() else {}
+        raw = (load_yaml(config_path) or {}) if config_path.is_file() else {}
+        data: dict = raw if isinstance(raw, dict) else {}
     except YAMLError:
         data = {}
     data.setdefault("safety", {})["secret_scan_bypass_accepted"] = datetime.now(UTC).isoformat()

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -21,6 +21,7 @@ from cyclopts import App, Parameter
 from autoskillit.cli._cook import cook as cook_interactive
 from autoskillit.cli._init_helpers import (
     _MARKER_CONTENT,
+    _check_secret_scanning,
     _generate_config_yaml,
     _prompt_test_command,
     _register_all,
@@ -151,6 +152,9 @@ def init(
             cmd_parts = _prompt_test_command()
 
         atomic_write(config_path, _generate_config_yaml(cmd_parts))
+
+    if not _check_secret_scanning(project_dir):
+        raise SystemExit(1)
 
     _register_all(scope, project_dir)
 

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -142,9 +142,7 @@ def init(
     config_dir.mkdir(exist_ok=True)
     config_path = config_dir / "config.yaml"
 
-    if not _check_secret_scanning(project_dir):
-        raise SystemExit(1)
-
+    _wrote_config = False
     if config_path.exists() and not force:
         print(f"  Config already exists: {config_path}")
         print("  Use --force to overwrite.")
@@ -155,6 +153,12 @@ def init(
             cmd_parts = _prompt_test_command()
 
         atomic_write(config_path, _generate_config_yaml(cmd_parts))
+        _wrote_config = True
+
+    if not _check_secret_scanning(project_dir):
+        if _wrote_config:
+            config_path.unlink(missing_ok=True)
+        raise SystemExit(1)
 
     _register_all(scope, project_dir)
 

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -142,6 +142,9 @@ def init(
     config_dir.mkdir(exist_ok=True)
     config_path = config_dir / "config.yaml"
 
+    if not _check_secret_scanning(project_dir):
+        raise SystemExit(1)
+
     if config_path.exists() and not force:
         print(f"  Config already exists: {config_path}")
         print("  Use --force to overwrite.")
@@ -152,9 +155,6 @@ def init(
             cmd_parts = _prompt_test_command()
 
         atomic_write(config_path, _generate_config_yaml(cmd_parts))
-
-    if not _check_secret_scanning(project_dir):
-        raise SystemExit(1)
 
     _register_all(scope, project_dir)
 

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -85,6 +85,9 @@ class TestCLIDoctor:
         (tmp_path / ".autoskillit" / ".gitignore").write_text(
             "\n".join(_AUTOSKILLIT_GITIGNORE_ENTRIES) + "\n"
         )
+        (tmp_path / ".pre-commit-config.yaml").write_text(
+            "repos:\n  - repo: dummy\n    hooks:\n      - id: gitleaks\n"
+        )
         # Register hooks so hook_registration check passes
         # Use explicit path (tmp_path already monkeypatched as Path.home())
         from autoskillit.cli._hooks import (
@@ -189,6 +192,7 @@ class TestCLIDoctor:
             "hook_registration",
             "script_version_health",
             "gitignore_completeness",
+            "secret_scanning_hook",
         }
         assert expected <= check_names
 
@@ -703,3 +707,72 @@ def test_doctor_gitignore_ok_when_all_covered(
 
     result = _check_gitignore_completeness(tmp_path)
     assert result.severity == Severity.OK
+
+
+# SS-DOC-1
+def test_doctor_includes_secret_scanning_hook_check(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """doctor output includes the secret_scanning_hook check."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.chdir(tmp_path)
+    cli.doctor(output_json=True)
+    data = json.loads(capsys.readouterr().out)
+    check_names = {r["check"] for r in data["results"]}
+    assert "secret_scanning_hook" in check_names
+
+
+# SS-DOC-2
+def test_doctor_error_when_no_scanner_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """doctor reports ERROR severity for secret_scanning_hook when no scanner found."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.chdir(tmp_path)
+    # No .pre-commit-config.yaml
+    cli.doctor(output_json=True)
+    data = json.loads(capsys.readouterr().out)
+    checks = [r for r in data["results"] if r["check"] == "secret_scanning_hook"]
+    assert len(checks) == 1
+    assert checks[0]["severity"] == "error"
+
+
+# SS-DOC-3
+def test_doctor_ok_when_scanner_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """doctor reports OK for secret_scanning_hook when a known scanner is configured."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".pre-commit-config.yaml").write_text(
+        "repos:\n  - repo: https://github.com/gitleaks/gitleaks\n"
+        "    hooks:\n      - id: gitleaks\n"
+    )
+    cli.doctor(output_json=True)
+    data = json.loads(capsys.readouterr().out)
+    checks = [r for r in data["results"] if r["check"] == "secret_scanning_hook"]
+    assert len(checks) == 1
+    assert checks[0]["severity"] == "ok"
+
+
+# SS-DOC-4 (unit test for check function directly)
+def test_check_secret_scanning_hook_ok_with_gitleaks(tmp_path: Path) -> None:
+    """_check_secret_scanning_hook returns OK when gitleaks hook is present."""
+    from autoskillit.cli._doctor import _check_secret_scanning_hook
+    from autoskillit.core import Severity
+
+    (tmp_path / ".pre-commit-config.yaml").write_text(
+        "repos:\n  - repo: dummy\n    hooks:\n      - id: gitleaks\n"
+    )
+    result = _check_secret_scanning_hook(tmp_path)
+    assert result.severity == Severity.OK
+
+
+# SS-DOC-5 (unit test for check function directly)
+def test_check_secret_scanning_hook_error_without_scanner(tmp_path: Path) -> None:
+    """_check_secret_scanning_hook returns ERROR when no .pre-commit-config.yaml."""
+    from autoskillit.cli._doctor import _check_secret_scanning_hook
+    from autoskillit.core import Severity
+
+    result = _check_secret_scanning_hook(tmp_path)
+    assert result.severity == Severity.ERROR

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -467,10 +467,11 @@ def test_init_blocks_without_correct_phrase(
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
-    with patch("builtins.input", side_effect=["pytest -v", "nope"]):
+    with patch("builtins.input", side_effect=["nope"]) as mock_input:
         with pytest.raises(SystemExit) as exc_info:
             cli.init()
     assert exc_info.value.code == 1
+    assert mock_input.call_count == 1
 
 
 # SS-INIT-4
@@ -482,9 +483,10 @@ def test_init_proceeds_with_correct_phrase(
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
     phrase = "I accept the risk of leaking secrets without pre-commit scanning"
-    with patch("builtins.input", side_effect=["pytest -v", phrase, ""]):
+    with patch("builtins.input", side_effect=[phrase, "pytest -v", ""]) as mock_input:
         cli.init()
     assert (tmp_path / ".autoskillit" / "config.yaml").is_file()
+    assert mock_input.call_count == 3
 
 
 # SS-INIT-5
@@ -496,8 +498,9 @@ def test_init_bypass_logged_to_config(tmp_path: Path, monkeypatch: pytest.Monkey
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
     phrase = "I accept the risk of leaking secrets without pre-commit scanning"
-    with patch("builtins.input", side_effect=["pytest -v", phrase, ""]):
+    with patch("builtins.input", side_effect=[phrase, "pytest -v", ""]) as mock_input:
         cli.init()
+    assert mock_input.call_count == 3
     config = _yaml.safe_load((tmp_path / ".autoskillit" / "config.yaml").read_text())
     bypass_value = config.get("safety", {}).get("secret_scan_bypass_accepted")
     assert bypass_value is not None, "bypass_accepted timestamp must be persisted"

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -13,6 +13,13 @@ from autoskillit import cli
 
 
 class TestCLIInit:
+    @pytest.fixture(autouse=True)
+    def _pre_commit_with_scanner(self, tmp_path: Path) -> None:
+        """Ensure every TestCLIInit test has a scanner-present pre-commit config."""
+        (tmp_path / ".pre-commit-config.yaml").write_text(
+            "repos:\n  - repo: dummy\n    hooks:\n      - id: gitleaks\n"
+        )
+
     # CL1
     def test_serve_calls_mcp_run(self) -> None:
         mock_mcp = MagicMock()
@@ -420,3 +427,107 @@ def test_gitignore_entries_includes_temp() -> None:
     from autoskillit.core.io import _AUTOSKILLIT_GITIGNORE_ENTRIES
 
     assert "temp/" in _AUTOSKILLIT_GITIGNORE_ENTRIES
+
+
+# SS-INIT-1
+def test_init_aborts_in_noninteractive_mode_without_scanner(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """init raises SystemExit(1) when no scanner found and stdin is not a tty."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+    # No .pre-commit-config.yaml created
+    with pytest.raises(SystemExit) as exc_info:
+        cli.init(test_command="pytest -v")
+    assert exc_info.value.code == 1
+
+
+# SS-INIT-2
+def test_init_proceeds_when_scanner_found(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """init proceeds normally when .pre-commit-config.yaml contains a known scanner."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    (tmp_path / ".pre-commit-config.yaml").write_text(
+        "repos:\n  - repo: https://github.com/gitleaks/gitleaks\n"
+        "    hooks:\n      - id: gitleaks\n"
+    )
+    cli.init(test_command="pytest -v")
+    assert (tmp_path / ".autoskillit" / "config.yaml").is_file()
+
+
+# SS-INIT-3
+def test_init_blocks_without_correct_phrase(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """init raises SystemExit(1) when user types wrong phrase in interactive mode."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    with patch("builtins.input", side_effect=["pytest -v", "nope"]):
+        with pytest.raises(SystemExit) as exc_info:
+            cli.init()
+    assert exc_info.value.code == 1
+
+
+# SS-INIT-4
+def test_init_proceeds_with_correct_phrase(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """init completes when user types the exact consent phrase."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    phrase = "I accept the risk of leaking secrets without pre-commit scanning"
+    with patch("builtins.input", side_effect=["pytest -v", phrase, ""]):
+        cli.init()
+    assert (tmp_path / ".autoskillit" / "config.yaml").is_file()
+
+
+# SS-INIT-5
+def test_init_bypass_logged_to_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """When bypass is accepted, config.yaml records the bypass with a timestamp."""
+    import yaml as _yaml
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    phrase = "I accept the risk of leaking secrets without pre-commit scanning"
+    with patch("builtins.input", side_effect=["pytest -v", phrase, ""]):
+        cli.init()
+    config = _yaml.safe_load((tmp_path / ".autoskillit" / "config.yaml").read_text())
+    bypass_value = config.get("safety", {}).get("secret_scan_bypass_accepted")
+    assert bypass_value is not None, "bypass_accepted timestamp must be persisted"
+
+
+# SS-INIT-6
+def test_init_force_does_not_bypass_secret_scan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--force must NOT bypass the secret scanning check."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+    # Pre-existing config — so --force is relevant
+    (tmp_path / ".autoskillit").mkdir()
+    (tmp_path / ".autoskillit" / "config.yaml").write_text("old: true\n")
+    with pytest.raises(SystemExit) as exc_info:
+        cli.init(test_command="pytest -v", force=True)
+    assert exc_info.value.code == 1
+
+
+# SS-INIT-7 (unit test for the helper directly)
+def test_check_secret_scanning_detects_known_scanners(tmp_path: Path) -> None:
+    """_check_secret_scanning returns True without prompt when scanner is present."""
+    from autoskillit.cli._init_helpers import _check_secret_scanning
+
+    for hook_id in ("gitleaks", "detect-secrets", "trufflehog", "git-secrets"):
+        repo_dir = tmp_path / hook_id
+        repo_dir.mkdir()
+        (repo_dir / ".pre-commit-config.yaml").write_text(
+            f"repos:\n  - repo: dummy\n    hooks:\n      - id: {hook_id}\n"
+        )
+        (repo_dir / ".autoskillit").mkdir()
+        (repo_dir / ".autoskillit" / "config.yaml").write_text("")
+        result = _check_secret_scanning(repo_dir)
+        assert result is True, f"expected True for hook_id={hook_id!r}"

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -243,6 +243,9 @@ class TestCLIInit:
         """init without --scope defaults to user scope (writes to ~/.claude.json)."""
         project_dir = tmp_path / "project"
         project_dir.mkdir()
+        (project_dir / ".pre-commit-config.yaml").write_text(
+            "repos:\n  - repo: dummy\n    hooks:\n      - id: gitleaks\n"
+        )
         monkeypatch.chdir(project_dir)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         monkeypatch.setattr("autoskillit.cli._init_helpers._is_plugin_installed", lambda: False)

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -467,11 +467,11 @@ def test_init_blocks_without_correct_phrase(
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
-    with patch("builtins.input", side_effect=["nope"]) as mock_input:
+    with patch("builtins.input", side_effect=["pytest -v", "nope"]) as mock_input:
         with pytest.raises(SystemExit) as exc_info:
             cli.init()
     assert exc_info.value.code == 1
-    assert mock_input.call_count == 1
+    assert mock_input.call_count == 2
 
 
 # SS-INIT-4
@@ -483,7 +483,7 @@ def test_init_proceeds_with_correct_phrase(
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
     phrase = "I accept the risk of leaking secrets without pre-commit scanning"
-    with patch("builtins.input", side_effect=[phrase, "pytest -v", ""]) as mock_input:
+    with patch("builtins.input", side_effect=["pytest -v", phrase, ""]) as mock_input:
         cli.init()
     assert (tmp_path / ".autoskillit" / "config.yaml").is_file()
     assert mock_input.call_count == 3
@@ -498,7 +498,7 @@ def test_init_bypass_logged_to_config(tmp_path: Path, monkeypatch: pytest.Monkey
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
     phrase = "I accept the risk of leaking secrets without pre-commit scanning"
-    with patch("builtins.input", side_effect=[phrase, "pytest -v", ""]) as mock_input:
+    with patch("builtins.input", side_effect=["pytest -v", phrase, ""]) as mock_input:
         cli.init()
     assert mock_input.call_count == 3
     config = _yaml.safe_load((tmp_path / ".autoskillit" / "config.yaml").read_text())


### PR DESCRIPTION
## Summary

AutoSkillit automates code generation and commits at scale. Without a secret-scanning hook in the pre-commit pipeline, leaked credentials shift from "possible" to "inevitable." This plan adds a security gate to `autoskillit init` that checks for a known secret scanner in `.pre-commit-config.yaml` and — when absent — requires the user to type an explicit acknowledgment phrase before proceeding. The bypass decision is persisted to `.autoskillit/config.yaml` with a UTC timestamp. `autoskillit doctor` gains a new `secret_scanning_hook` check that reports `ERROR` when no scanner is detected.

## Architecture Impact

### Security Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START([autoskillit init / doctor])

    subgraph ConfigBoundary ["TRUST BOUNDARY 1: Pre-commit Config Parse"]
        PCFile["● .pre-commit-config.yaml<br/>━━━━━━━━━━<br/>Untrusted filesystem input<br/>(may be absent, malformed, or missing scanner)"]
        ParseYAML["● _detect_secret_scanner<br/>━━━━━━━━━━<br/>load_yaml() — parse repos[].hooks[].id<br/>Membership: _KNOWN_SCANNERS frozenset<br/>{gitleaks, detect-secrets, trufflehog, git-secrets}"]
        ScanFound{Scanner<br/>found?}
    end

    subgraph GreenPath ["PASS PATH"]
        GreenOK["● Print ✓ confirmation<br/>━━━━━━━━━━<br/>secret scanning: ✓ hook detected"]
    end

    subgraph TTYBoundary ["TRUST BOUNDARY 2: Interactive Session Gate"]
        TTYCheck["● sys.stdin.isatty()<br/>━━━━━━━━━━<br/>Non-interactive: fail closed<br/>(CI, pipes, headless sessions)"]
        TTYFail["ABORT — SystemExit(1)<br/>━━━━━━━━━━<br/>No scanner + non-interactive<br/>Cannot bypass this check"]
    end

    subgraph ConsentBoundary ["TRUST BOUNDARY 3: Typed Consent Gate"]
        WarnBox["● Warning box + phrase display<br/>━━━━━━━━━━<br/>Shows exact bypass phrase required"]
        UserInput["User types response<br/>━━━━━━━━━━<br/>input() → strip()"]
        PhraseMatch{Exact phrase<br/>match?}
        BadPhrase["ABORT — SystemExit(1)<br/>━━━━━━━━━━<br/>Phrase mismatch<br/>--force cannot bypass"]
    end

    subgraph AuditBoundary ["TRUST BOUNDARY 4: Bypass Audit Trail"]
        LogBypass["● _log_secret_scan_bypass<br/>━━━━━━━━━━<br/>safety.secret_scan_bypass_accepted<br/>= UTC ISO timestamp → config.yaml<br/>(atomic_write)"]
    end

    subgraph RegisterFlow ["Post-Gate: _register_all"]
        Hooks["sync_hooks_to_settings<br/>━━━━━━━━━━<br/>Hook registration"]
        MCP["Register MCP server<br/>━━━━━━━━━━<br/>~/.claude.json"]
    end

    subgraph DoctorBoundary ["TRUST BOUNDARY 5: Doctor Observability Check"]
        DocCheck["● _check_secret_scanning_hook<br/>━━━━━━━━━━<br/>Check 10 in run_doctor()<br/>Reuses _detect_secret_scanner()"]
        DocOK["DoctorResult OK<br/>━━━━━━━━━━<br/>severity=ok<br/>check=secret_scanning_hook"]
        DocError["● DoctorResult ERROR<br/>━━━━━━━━━━<br/>severity=error<br/>Message: add scanner to prevent credential leaks"]
    end

    END([Init complete / Doctor report])

    START --> PCFile
    PCFile --> ParseYAML
    ParseYAML --> ScanFound
    ScanFound -->|yes| GreenOK
    ScanFound -->|no| TTYCheck
    GreenOK --> Hooks
    TTYCheck -->|no tty| TTYFail
    TTYCheck -->|tty| WarnBox
    WarnBox --> UserInput
    UserInput --> PhraseMatch
    PhraseMatch -->|wrong| BadPhrase
    PhraseMatch -->|correct| LogBypass
    LogBypass --> Hooks
    Hooks --> MCP
    MCP --> END

    START --> DocCheck
    DocCheck --> DocOK
    DocCheck --> DocError
    DocOK --> END
    DocError --> END

    class START,END terminal;
    class PCFile phase;
    class ParseYAML,TTYCheck,PhraseMatch detector;
    class ScanFound phase;
    class GreenOK,LogBypass,DocOK newComponent;
    class WarnBox,UserInput newComponent;
    class TTYFail,BadPhrase,DocError gap;
    class Hooks,MCP handler;
    class DocCheck newComponent;
```

### Operational Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph InitCLI ["● autoskillit init  (app.py)"]
        InitCmd["● autoskillit init<br/>━━━━━━━━━━<br/>--force  --scope user|project"]
        ConfigWrite["_generate_config_yaml<br/>━━━━━━━━━━<br/>Write .autoskillit/config.yaml"]
        SecretGate["● _check_secret_scanning<br/>━━━━━━━━━━<br/>Gate: scanner present OR consent<br/>Aborts with SystemExit(1) on failure"]
        RegisterAll["_register_all<br/>━━━━━━━━━━<br/>Hooks + MCP + summary"]
    end

    subgraph DoctorCLI ["● autoskillit doctor  (_doctor.py)"]
        DoctorCmd["● autoskillit doctor<br/>━━━━━━━━━━<br/>--output-json"]
        ChecksExisting["Checks 1–9<br/>━━━━━━━━━━<br/>stale_mcp_servers, mcp_server_registered,<br/>autoskillit_on_path, project_config,<br/>version_consistency, hook_health,<br/>hook_registration, script_version_health,<br/>gitignore_completeness"]
        CheckSecret["● Check 10: _check_secret_scanning_hook<br/>━━━━━━━━━━<br/>check=secret_scanning_hook<br/>Reuses _detect_secret_scanner()"]
        DoctorOut["DoctorResult[]<br/>━━━━━━━━━━<br/>severity: ok | warning | error<br/>JSON or human-readable output"]
    end

    subgraph Config ["CONFIGURATION SOURCES (read)"]
        PreCommit[".pre-commit-config.yaml<br/>━━━━━━━━━━<br/>Scanned for hook ids:<br/>gitleaks / detect-secrets<br/>trufflehog / git-secrets"]
        ConfigYaml[".autoskillit/config.yaml<br/>━━━━━━━━━━<br/>safety.secret_scan_bypass_accepted<br/>= UTC ISO timestamp (bypass log)"]
    end

    subgraph TTYState ["RUNTIME STATE (read)"]
        Stdin["sys.stdin.isatty()<br/>━━━━━━━━━━<br/>Interactive vs non-interactive<br/>Determines consent path"]
    end

    subgraph ObsOutputs ["OBSERVABILITY OUTPUTS (write)"]
        InitOutput["● init stdout<br/>━━━━━━━━━━<br/>secret scanning: ✓ hook detected<br/>OR bypass: accepted — logged<br/>OR ERROR + SystemExit(1)"]
        DoctorJSON["● doctor JSON / text<br/>━━━━━━━━━━<br/>{ check: secret_scanning_hook,<br/>  severity: ok | error,<br/>  message: ... }"]
    end

    InitCmd --> ConfigWrite
    ConfigWrite --> SecretGate
    SecretGate --> PreCommit
    SecretGate --> Stdin
    SecretGate --> ConfigYaml
    SecretGate --> RegisterAll
    SecretGate --> InitOutput

    DoctorCmd --> ChecksExisting
    DoctorCmd --> CheckSecret
    CheckSecret --> PreCommit
    ChecksExisting --> DoctorOut
    CheckSecret --> DoctorOut
    DoctorOut --> DoctorJSON

    class InitCmd,DoctorCmd cli;
    class ConfigWrite,RegisterAll,ChecksExisting handler;
    class SecretGate,CheckSecret newComponent;
    class PreCommit,ConfigYaml,Stdin stateNode;
    class InitOutput,DoctorOut,DoctorJSON output;
```

Closes #448

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-448-20260320-180957-935972/temp/make-plan/init_secret_scanning_opt_in_plan_2026-03-20_180957.md`

## Token Usage Summary

| Step | input | output | cached | count | time |
|------|-------|--------|--------|-------|------|
| plan | 9.7k | 298.8k | 10.5M | 18 | 1h 56m |
| verify | 326 | 264.5k | 12.7M | 17 | 1h 34m |
| implement | 6.3k | 365.6k | 46.4M | 17 | 2h 57m |
| fix | 131 | 43.6k | 4.6M | 5 | 27m 26s |
| audit_impl | 146 | 82.3k | 2.8M | 10 | 27m 50s |
| open_pr | 404 | 222.9k | 12.1M | 15 | 1h 35m |
| review_pr | 226 | 287.1k | 6.4M | 9 | 1h 9m |
| resolve_review | 3.7k | 200.0k | 16.1M | 9 | 1h 32m |
| resolve_conflicts | 75 | 30.6k | 2.6M | 3 | 10m 44s |
| diagnose_ci | 36 | 9.0k | 670.5k | 2 | 3m 15s |
| resolve_ci | 13 | 3.1k | 239.8k | 1 | 2m 4s |
| **Total** | 21.1k | 1.8M | 115.2M | | 11h 57m |

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
