### PR TITLE
Implementation Plan: Strict Schema Validation for config.yaml

### DIFF
--- a/src/autoskillit/config/__init__.py
+++ b/src/autoskillit/config/__init__.py
@@ -11,6 +11,7 @@ from autoskillit.config.settings import (
     BranchingConfig,
     CIConfig,
     ClassifyFixConfig,
+    ConfigSchemaError,
     GitHubConfig,
     ImplementGateConfig,
     LinuxTracingConfig,
@@ -35,6 +36,7 @@ from autoskillit.config.settings import (
 __all__ = [
     "AutomationConfig",
     "BranchingConfig",
+    "ConfigSchemaError",
     "CIConfig",
     "ClassifyFixConfig",
     "GitHubConfig",

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -436,7 +436,7 @@ def validate_layer_keys(
         if top_key not in _CONFIG_SCHEMA:
             known = sorted(_CONFIG_SCHEMA.keys())
             close = difflib.get_close_matches(top_key, known, n=1, cutoff=0.6)
-            hint = f" Did you mean '{close[0]}'?" if close else ""
+            hint = f" did you mean '{close[0]}'?" if close else ""
             raise ConfigSchemaError(
                 f"Invalid configuration in {str(layer_path)!r}: "
                 f"unrecognized key '{top_key}'.{hint}"
@@ -456,7 +456,7 @@ def validate_layer_keys(
                 if sub_key not in _CONFIG_SCHEMA[top_key]:
                     known_sub = sorted(_CONFIG_SCHEMA[top_key])
                     close = difflib.get_close_matches(sub_key, known_sub, n=1, cutoff=0.6)
-                    hint = f" Did you mean '{top_key}.{close[0]}'?" if close else ""
+                    hint = f" did you mean '{top_key}.{close[0]}'?" if close else ""
                     raise ConfigSchemaError(
                         f"Invalid configuration in {str(layer_path)!r}: "
                         f"unrecognized key '{dotted}' in section '{top_key}'.{hint}"

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -31,6 +31,14 @@ if TYPE_CHECKING:
 _logger = logging.getLogger(__name__)  # noqa: TID251
 
 
+class ConfigSchemaError(ValueError):
+    """Raised when a config YAML layer contains unrecognized or misplaced keys."""
+
+
+SECRETS_ONLY_KEYS: frozenset[str] = frozenset({"github.token"})
+_METADATA_KEYS: frozenset[str] = frozenset({"version"})
+
+
 @dataclass
 class TestCheckConfig:
     command: list[str] = field(default_factory=lambda: ["task", "test-check"])
@@ -389,6 +397,72 @@ class AutomationConfig:
         )
 
 
+def _build_config_schema() -> dict[str, frozenset[str]]:
+    """Derive a two-level schema map {section: {valid_field_names}} from AutomationConfig."""
+    schema: dict[str, frozenset[str]] = {}
+    for f in dataclasses.fields(AutomationConfig):
+        if f.default_factory is not dataclasses.MISSING:  # type: ignore[misc]
+            sub = f.default_factory()  # type: ignore[call-arg]
+            if dataclasses.is_dataclass(sub):
+                schema[f.name] = frozenset(sf.name for sf in dataclasses.fields(sub))
+            else:
+                schema[f.name] = frozenset()
+        else:
+            schema[f.name] = frozenset()
+    return schema
+
+
+_CONFIG_SCHEMA: dict[str, frozenset[str]] = _build_config_schema()
+
+
+def validate_layer_keys(
+    layer_dict: dict[str, Any],
+    layer_path: Path,
+    *,
+    is_secrets_layer: bool,
+) -> None:
+    """Validate that all keys in a YAML config layer are recognized and allowed.
+
+    Raises ConfigSchemaError for:
+    - Unrecognized top-level section name
+    - Unrecognized field name within a known section
+    - A SECRETS_ONLY_KEYS path appearing in a non-secrets layer
+    """
+    import difflib  # stdlib — safe to import here
+
+    for top_key, value in layer_dict.items():
+        if top_key in _METADATA_KEYS:
+            continue
+        if top_key not in _CONFIG_SCHEMA:
+            known = sorted(_CONFIG_SCHEMA.keys())
+            close = difflib.get_close_matches(top_key, known, n=1, cutoff=0.6)
+            hint = f" Did you mean '{close[0]}'?" if close else ""
+            raise ConfigSchemaError(
+                f"Invalid configuration in {str(layer_path)!r}: "
+                f"unrecognized key '{top_key}'.{hint}"
+            )
+        # Validate sub-keys only when the value is a dict and the section has known fields
+        if isinstance(value, dict) and _CONFIG_SCHEMA[top_key]:
+            for sub_key in value:
+                dotted = f"{top_key}.{sub_key}"
+                if dotted in SECRETS_ONLY_KEYS:
+                    if not is_secrets_layer:
+                        raise ConfigSchemaError(
+                            f"Invalid configuration in {str(layer_path)!r}: "
+                            f"'{dotted}' must not appear in config.yaml — "
+                            f"configure it in '.autoskillit/.secrets.yaml' instead."
+                        )
+                    continue  # secrets-only keys are valid in .secrets.yaml
+                if sub_key not in _CONFIG_SCHEMA[top_key]:
+                    known_sub = sorted(_CONFIG_SCHEMA[top_key])
+                    close = difflib.get_close_matches(sub_key, known_sub, n=1, cutoff=0.6)
+                    hint = f" Did you mean '{top_key}.{close[0]}'?" if close else ""
+                    raise ConfigSchemaError(
+                        f"Invalid configuration in {str(layer_path)!r}: "
+                        f"unrecognized key '{dotted}' in section '{top_key}'.{hint}"
+                    )
+
+
 def _build_subsets_config(raw: dict[str, Any]) -> SubsetsConfig:
     """Parse subsets section, emitting warnings for unknown disabled categories."""
     disabled = list(raw.get("disabled", []))
@@ -457,10 +531,10 @@ def _merge_yaml_layers(*paths: Path) -> dict[str, Any]:
 def _make_dynaconf(project_dir: Path | None = None) -> Dynaconf:
     """Create a Dynaconf instance for env-var overrides over pre-merged file layers.
 
-    File layers (defaults, user, project, secrets) are merged in advance using
-    _merge_yaml_layers(), which applies dict deep-merge + list-replace semantics.
-    The merged result is written to a temp YAML file so that Dynaconf can apply
-    env var overrides (AUTOSKILLIT_SECTION__KEY) on top.
+    File layers (defaults, user, project, secrets) are merged in advance with
+    dict deep-merge + list-replace semantics. User-writable layers are validated
+    for unrecognized keys before merging. The merged result is written to a temp
+    YAML file so that Dynaconf can apply env var overrides (AUTOSKILLIT_SECTION__KEY).
 
     Deferred import keeps dynaconf off the module-level import chain.
     """
@@ -469,12 +543,22 @@ def _make_dynaconf(project_dir: Path | None = None) -> Dynaconf:
     defaults_path = pkg_root() / "config" / "defaults.yaml"
     root = project_dir or Path.cwd()
 
-    merged = _merge_yaml_layers(
-        defaults_path,
-        Path.home() / ".autoskillit" / "config.yaml",
-        root / ".autoskillit" / "config.yaml",
-        root / ".autoskillit" / ".secrets.yaml",
-    )
+    # Layer definitions: (path, should_validate, is_secrets_layer)
+    _layers = [
+        (defaults_path, False, False),
+        (Path.home() / ".autoskillit" / "config.yaml", True, False),
+        (root / ".autoskillit" / "config.yaml", True, False),
+        (root / ".autoskillit" / ".secrets.yaml", True, True),
+    ]
+
+    merged: dict[str, Any] = {}
+    for path, should_validate, is_secrets in _layers:
+        if path.is_file():
+            data = load_yaml(path)
+            if isinstance(data, dict):
+                if should_validate:
+                    validate_layer_keys(data, path, is_secrets_layer=is_secrets)
+                _apply_layer(merged, data)
 
     # Write to a temp file so Dynaconf can load it and apply env var overrides.
     # Dynaconf reads files lazily; we trigger eager loading before the file is

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -445,8 +445,8 @@ def validate_layer_keys(
                 f"Invalid configuration in {str(layer_path)!r}: "
                 f"unrecognized key '{top_key}'.{hint}"
             )
-        # Validate sub-keys only when the value is a dict and the section has known fields
-        if isinstance(value, dict) and _CONFIG_SCHEMA[top_key]:
+        # Validate sub-keys for all dict-valued sections; empty frozenset means no valid sub-keys
+        if isinstance(value, dict):
             for sub_key in value:
                 dotted = f"{top_key}.{sub_key}"
                 if dotted in _SECRETS_ONLY_KEYS:

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -563,6 +563,12 @@ def _make_dynaconf(project_dir: Path | None = None) -> Dynaconf:
                 if should_validate:
                     validate_layer_keys(data, path, is_secrets_layer=is_secrets)
                 _apply_layer(merged, data)
+            elif data is not None:
+                raise ConfigSchemaError(
+                    f"Invalid configuration in {str(path)!r}: "
+                    f"expected a YAML mapping at the top level, "
+                    f"got {type(data).__name__!r}."
+                )
 
     # Write to a temp file so Dynaconf can load it and apply env var overrides.
     # Dynaconf reads files lazily; we trigger eager loading before the file is

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -35,7 +35,7 @@ class ConfigSchemaError(ValueError):
     """Raised when a config YAML layer contains unrecognized or misplaced keys."""
 
 
-SECRETS_ONLY_KEYS: frozenset[str] = frozenset({"github.token"})
+_SECRETS_ONLY_KEYS: frozenset[str] = frozenset({"github.token"})
 _METADATA_KEYS: frozenset[str] = frozenset({"version"})
 
 
@@ -426,7 +426,7 @@ def validate_layer_keys(
     Raises ConfigSchemaError for:
     - Unrecognized top-level section name
     - Unrecognized field name within a known section
-    - A SECRETS_ONLY_KEYS path appearing in a non-secrets layer
+    - A _SECRETS_ONLY_KEYS path appearing in a non-secrets layer
     """
     import difflib  # stdlib — safe to import here
 
@@ -445,7 +445,7 @@ def validate_layer_keys(
         if isinstance(value, dict) and _CONFIG_SCHEMA[top_key]:
             for sub_key in value:
                 dotted = f"{top_key}.{sub_key}"
-                if dotted in SECRETS_ONLY_KEYS:
+                if dotted in _SECRETS_ONLY_KEYS:
                     if not is_secrets_layer:
                         raise ConfigSchemaError(
                             f"Invalid configuration in {str(layer_path)!r}: "

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -401,14 +401,18 @@ def _build_config_schema() -> dict[str, frozenset[str]]:
     """Derive a two-level schema map {section: {valid_field_names}} from AutomationConfig."""
     schema: dict[str, frozenset[str]] = {}
     for f in dataclasses.fields(AutomationConfig):
+        sub_type: type | None = None
         if f.default_factory is not dataclasses.MISSING:  # type: ignore[misc]
-            sub = f.default_factory()  # type: ignore[call-arg]
-            if dataclasses.is_dataclass(sub):
-                schema[f.name] = frozenset(sf.name for sf in dataclasses.fields(sub))
-            else:
-                schema[f.name] = frozenset()
-        else:
-            schema[f.name] = frozenset()
+            factory = f.default_factory  # type: ignore[assignment]
+            if dataclasses.is_dataclass(factory):
+                sub_type = factory
+        elif f.default is not dataclasses.MISSING and dataclasses.is_dataclass(f.default):
+            sub_type = type(f.default)
+        schema[f.name] = (
+            frozenset(sf.name for sf in dataclasses.fields(sub_type))
+            if sub_type is not None
+            else frozenset()
+        )
     return schema
 
 

--- a/src/autoskillit/skills_extended/setup-project/SKILL.md
+++ b/src/autoskillit/skills_extended/setup-project/SKILL.md
@@ -198,6 +198,12 @@ Interactive config suggestion flow:
 
 If no config exists, present the suggested config in full. If config exists, only highlight missing or suboptimal settings.
 
+> **NEVER include `github.token`, API keys, credentials, secrets, or any
+> secret-like values in `config.yaml`.** Tokens belong exclusively in
+> `.autoskillit/.secrets.yaml`, which is gitignored. Only include fields
+> documented in the config schema — do not invent new fields or extrapolate
+> from existing ones.
+
 Suggested config template:
 ```yaml
 test_check:

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -73,6 +73,7 @@ SINGLETON_ALLOWED_MODULES: frozenset[str] = frozenset(
         "app",  # cli/app.py: app = App(...), config_app = App(...), etc.
         "store",  # migration/store.py: defensive exemption for future module-level construction
         "validator",  # recipe/validator.py: defensive exemption for decorator-based rule registry
+        "settings",  # config/settings.py: _CONFIG_SCHEMA = _build_config_schema()
     }
 )
 _SINGLETON_SAFE_CALL_NAMES: frozenset[str] = frozenset(

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -138,6 +138,19 @@ class TestCLIInit:
         assert parsed["test_check"]["command"] == ["task", "test-all"]
         assert parsed["safety"]["reset_guard_marker"] == ".autoskillit-workspace"
 
+    def test_generate_config_yaml_forbids_secret_fields(self) -> None:
+        """SEC-6: _generate_config_yaml() output contains no token, secret, or password keys."""
+        from autoskillit.cli import _generate_config_yaml
+
+        yaml_str = _generate_config_yaml(["task", "test-check"])
+        # Strip comments so only active YAML is checked
+        active_lines = [ln for ln in yaml_str.splitlines() if not ln.lstrip().startswith("#")]
+        active_yaml = "\n".join(active_lines)
+        for forbidden in ("token", "secret", "password", "credential"):
+            assert forbidden not in active_yaml.lower(), (
+                f"_generate_config_yaml() must not emit '{forbidden}' in active YAML"
+            )
+
     def test_init_writes_template_with_comments(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -10,6 +10,7 @@ import pytest
 import yaml
 
 from autoskillit import cli
+from autoskillit.cli import _generate_config_yaml
 
 
 class TestCLIInit:
@@ -115,15 +116,11 @@ class TestCLIInit:
 
     def test_generate_config_yaml_contains_test_command(self) -> None:
         """_generate_config_yaml embeds the test command in active YAML."""
-        from autoskillit.cli import _generate_config_yaml
-
         yaml_str = _generate_config_yaml(["pytest", "-v"])
         assert 'command: ["pytest", "-v"]' in yaml_str
 
     def test_generate_config_yaml_has_commented_advanced_sections(self) -> None:
         """Generated YAML includes commented-out advanced config sections."""
-        from autoskillit.cli import _generate_config_yaml
-
         yaml_str = _generate_config_yaml(["pytest", "-v"])
         assert "# classify_fix:" in yaml_str
         assert "# reset_workspace:" in yaml_str
@@ -131,8 +128,6 @@ class TestCLIInit:
 
     def test_generate_config_yaml_uncommented_parts_are_valid(self) -> None:
         """The uncommented portion of generated YAML parses as valid config."""
-        from autoskillit.cli import _generate_config_yaml
-
         yaml_str = _generate_config_yaml(["task", "test-all"])
         parsed = yaml.safe_load(yaml_str)
         assert parsed["test_check"]["command"] == ["task", "test-all"]
@@ -140,15 +135,24 @@ class TestCLIInit:
 
     def test_generate_config_yaml_forbids_secret_fields(self) -> None:
         """SEC-6: _generate_config_yaml() output contains no token, secret, or password keys."""
-        from autoskillit.cli import _generate_config_yaml
-
         yaml_str = _generate_config_yaml(["task", "test-check"])
-        # Strip comments so only active YAML is checked
+        # Strip comment lines, then parse with YAML to inspect keys and values only
         active_lines = [ln for ln in yaml_str.splitlines() if not ln.lstrip().startswith("#")]
-        active_yaml = "\n".join(active_lines)
+        parsed = yaml.safe_load("\n".join(active_lines)) or {}
+
+        def _collect_strings(obj: object) -> list[str]:
+            if isinstance(obj, dict):
+                return [str(k) for k in obj] + [
+                    s for v in obj.values() for s in _collect_strings(v)
+                ]
+            if isinstance(obj, list):
+                return [s for item in obj for s in _collect_strings(item)]
+            return [str(obj)]
+
+        all_strings = " ".join(_collect_strings(parsed)).lower()
         for forbidden in ("token", "secret", "password", "credential"):
-            assert forbidden not in active_yaml.lower(), (
-                f"_generate_config_yaml() must not emit '{forbidden}' in active YAML"
+            assert forbidden not in all_strings, (
+                f"_generate_config_yaml() must not emit '{forbidden}' in active YAML keys/values"
             )
 
     def test_init_writes_template_with_comments(

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -142,28 +142,20 @@ class TestLoadConfig:
         cfg = load_config(tmp_path)
         assert cfg.test_check.command == ["task", "test-check"]
 
-    def test_config_yaml_rejects_unrecognized_top_level_key(self, tmp_path):
-        """SCH-1: Unrecognized top-level key in config.yaml raises ConfigSchemaError."""
+    @pytest.mark.parametrize(
+        "yaml_content,match",
+        [
+            ("completely_unknown_section:\n  foo: bar\n", "unrecognized key"),  # SCH-1
+            ("github:\n  invented_field: whatever\n", "unrecognized key"),  # SCH-2
+            ("github:\n  tokn: ghp_abc\n", "did you mean"),  # SCH-3
+        ],
+    )
+    def test_config_yaml_rejects_invalid_keys(self, tmp_path, yaml_content, match):
+        """SCH-1/2/3: Unrecognized or near-miss keys in config.yaml raise ConfigSchemaError."""
         config_dir = tmp_path / ".autoskillit"
         config_dir.mkdir()
-        (config_dir / "config.yaml").write_text("completely_unknown_section:\n  foo: bar\n")
-        with pytest.raises(ConfigSchemaError, match="unrecognized key"):
-            load_config(tmp_path)
-
-    def test_config_yaml_rejects_unrecognized_sub_key(self, tmp_path):
-        """SCH-2: Unrecognized sub-key in a known section raises ConfigSchemaError."""
-        config_dir = tmp_path / ".autoskillit"
-        config_dir.mkdir()
-        (config_dir / "config.yaml").write_text("github:\n  invented_field: whatever\n")
-        with pytest.raises(ConfigSchemaError, match="unrecognized key"):
-            load_config(tmp_path)
-
-    def test_typo_in_config_key_raises_with_hint(self, tmp_path):
-        """SCH-3: A near-miss key like 'github.tokn' raises with a 'did you mean' hint."""
-        config_dir = tmp_path / ".autoskillit"
-        config_dir.mkdir()
-        (config_dir / "config.yaml").write_text("github:\n  tokn: ghp_abc\n")
-        with pytest.raises(ConfigSchemaError, match="did you mean"):
+        (config_dir / "config.yaml").write_text(yaml_content)
+        with pytest.raises(ConfigSchemaError, match=match):
             load_config(tmp_path)
 
     def test_user_config_yaml_rejects_unrecognized_key(self, tmp_path, monkeypatch):

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -2,9 +2,10 @@
 
 from dataclasses import fields as dc_fields
 
+import pytest
 import yaml
 
-from autoskillit.config import AutomationConfig, RunSkillConfig, load_config
+from autoskillit.config import AutomationConfig, ConfigSchemaError, RunSkillConfig, load_config
 
 
 class TestDefaultConfig:
@@ -49,7 +50,6 @@ class TestLoadConfig:
         config_dir = tmp_path / ".autoskillit"
         config_dir.mkdir()
         config_data = {
-            "version": 1,
             "test_check": {"command": ["pytest", "-v"], "timeout": 300},
             "classify_fix": {"path_prefixes": ["src/core/", "tests/core/"]},
             "reset_workspace": {
@@ -142,17 +142,39 @@ class TestLoadConfig:
         cfg = load_config(tmp_path)
         assert cfg.test_check.command == ["task", "test-check"]
 
-    def test_unknown_keys_ignored(self, tmp_path):
-        """C8: Extra keys in YAML -> no crash, known keys loaded."""
+    def test_config_yaml_rejects_unrecognized_top_level_key(self, tmp_path):
+        """SCH-1: Unrecognized top-level key in config.yaml raises ConfigSchemaError."""
         config_dir = tmp_path / ".autoskillit"
         config_dir.mkdir()
-        config_data = {
-            "test_check": {"command": ["pytest"], "unknown_field": "ignored"},
-            "completely_unknown_section": {"foo": "bar"},
-        }
-        (config_dir / "config.yaml").write_text(yaml.dump(config_data))
-        cfg = load_config(tmp_path)
-        assert cfg.test_check.command == ["pytest"]
+        (config_dir / "config.yaml").write_text("completely_unknown_section:\n  foo: bar\n")
+        with pytest.raises(ConfigSchemaError, match="unrecognized key"):
+            load_config(tmp_path)
+
+    def test_config_yaml_rejects_unrecognized_sub_key(self, tmp_path):
+        """SCH-2: Unrecognized sub-key in a known section raises ConfigSchemaError."""
+        config_dir = tmp_path / ".autoskillit"
+        config_dir.mkdir()
+        (config_dir / "config.yaml").write_text("github:\n  invented_field: whatever\n")
+        with pytest.raises(ConfigSchemaError, match="unrecognized key"):
+            load_config(tmp_path)
+
+    def test_typo_in_config_key_raises_with_hint(self, tmp_path):
+        """SCH-3: A near-miss key like 'github.tokn' raises with a 'did you mean' hint."""
+        config_dir = tmp_path / ".autoskillit"
+        config_dir.mkdir()
+        (config_dir / "config.yaml").write_text("github:\n  tokn: ghp_abc\n")
+        with pytest.raises(ConfigSchemaError, match="did you mean"):
+            load_config(tmp_path)
+
+    def test_user_config_yaml_rejects_unrecognized_key(self, tmp_path, monkeypatch):
+        """SCH-4: User-level config.yaml is also validated."""
+        user_home = tmp_path / "home"
+        user_config_dir = user_home / ".autoskillit"
+        user_config_dir.mkdir(parents=True)
+        (user_config_dir / "config.yaml").write_text("bogus_section:\n  k: v\n")
+        monkeypatch.setattr("pathlib.Path.home", lambda: user_home)
+        with pytest.raises(ConfigSchemaError, match="unrecognized key"):
+            load_config(tmp_path)
 
     def test_set_fields_roundtrip(self, tmp_path):
         """C9: preserve_dirs loaded from YAML list -> becomes set[str]."""
@@ -496,34 +518,67 @@ class TestDynaconfIntegration:
         assert cfg.github.token == "secret_ghp_xxx"
 
     def test_secrets_file_overrides_config_yaml(self, tmp_path, monkeypatch):
-        """SEC-2: .secrets.yaml wins over config.yaml for the same key."""
+        """SEC-2: .secrets.yaml wins over config.yaml for a shared key."""
         monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "home")
         config_dir = tmp_path / ".autoskillit"
         config_dir.mkdir()
-        (config_dir / "config.yaml").write_text(yaml.dump({"github": {"token": "from_config"}}))
-        (config_dir / ".secrets.yaml").write_text(yaml.dump({"github": {"token": "from_secrets"}}))
+        (config_dir / "config.yaml").write_text(
+            yaml.dump({"github": {"in_progress_label": "test-label"}})
+        )
+        (config_dir / ".secrets.yaml").write_text(
+            yaml.dump({"github": {"in_progress_label": "secrets-label"}})
+        )
         cfg = load_config(tmp_path)
-        assert cfg.github.token == "from_secrets"
+        assert cfg.github.in_progress_label == "secrets-label"
 
     def test_partial_section_deep_merges_across_layers(self, tmp_path, monkeypatch):
         """MERGE-1: A project config with a partial nested section does not wipe sibling
         keys from the user config.
 
-        Without merge_enabled=True, a project-level github.default_repo would wipe
-        the user-level github.token.
+        Without deep-merge semantics, a project-level github.default_repo would wipe
+        the user-level github.in_progress_label.
         """
         monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "home")
         user_dir = tmp_path / "home" / ".autoskillit"
         user_dir.mkdir(parents=True)
-        (user_dir / "config.yaml").write_text(yaml.dump({"github": {"token": "ghp_user_token"}}))
+        (user_dir / "config.yaml").write_text(
+            yaml.dump({"github": {"in_progress_label": "user-label"}})
+        )
         project_dir = tmp_path / ".autoskillit"
         project_dir.mkdir()
         (project_dir / "config.yaml").write_text(
             yaml.dump({"github": {"default_repo": "owner/repo"}})
         )
         cfg = load_config(tmp_path)
-        assert cfg.github.token == "ghp_user_token"
+        assert cfg.github.in_progress_label == "user-label"
         assert cfg.github.default_repo == "owner/repo"
+
+    def test_config_yaml_rejects_secrets_only_key(self, tmp_path, monkeypatch):
+        """SEC-3: github.token in config.yaml raises ConfigSchemaError with .secrets.yaml hint."""
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "home")
+        config_dir = tmp_path / ".autoskillit"
+        config_dir.mkdir()
+        (config_dir / "config.yaml").write_text(yaml.dump({"github": {"token": "ghp_leaked"}}))
+        with pytest.raises(ConfigSchemaError, match=r"\.secrets\.yaml"):
+            load_config(tmp_path)
+
+    def test_secrets_yaml_accepts_token(self, tmp_path, monkeypatch):
+        """SEC-4: github.token in .secrets.yaml loads without error."""
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "home")
+        config_dir = tmp_path / ".autoskillit"
+        config_dir.mkdir()
+        (config_dir / ".secrets.yaml").write_text(yaml.dump({"github": {"token": "ghp_ok"}}))
+        cfg = load_config(tmp_path)
+        assert cfg.github.token == "ghp_ok"
+
+    def test_secrets_yaml_rejects_unrecognized_keys(self, tmp_path, monkeypatch):
+        """SEC-5: Unrecognized key in .secrets.yaml raises ConfigSchemaError."""
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "home")
+        config_dir = tmp_path / ".autoskillit"
+        config_dir.mkdir()
+        (config_dir / ".secrets.yaml").write_text("bogus_secret_section:\n  key: val\n")
+        with pytest.raises(ConfigSchemaError, match="unrecognized key"):
+            load_config(tmp_path)
 
     def test_bundled_defaults_yaml_exists(self):
         """DFLT-1: The bundled defaults.yaml file is present in the package."""

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -303,14 +303,6 @@ class TestSyncConfigRemoval:
 
         assert not hasattr(cfg_mod, "SyncConfig")
 
-    def test_stale_sync_yaml_key_silently_ignored(self, tmp_path):
-        """REQ-SYNC-003: A config.yaml with a 'sync:' key does not raise."""
-        config_file = tmp_path / ".autoskillit" / "config.yaml"
-        config_file.parent.mkdir(parents=True)
-        config_file.write_text("sync:\n  excluded_recipes:\n    - some-recipe\n")
-        cfg = load_config(tmp_path)
-        assert isinstance(cfg, AutomationConfig)
-
 
 class TestRunSkillRetryConfigFields:
     def test_run_skill_retry_config_removed(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -182,6 +182,27 @@ def parse_stdout_json(capsys):
 
 
 @pytest.fixture(autouse=True)
+def _isolated_home(monkeypatch, tmp_path_factory):
+    """Redirect Path.home() to a per-test temp directory.
+
+    Prevents the developer's real ~/.autoskillit/config.yaml from being
+    loaded during tests. Without this, tests that call load_config() without
+    mocking Path.home() would fail if the real user config contains
+    secrets-only keys (e.g. github.token) that are now rejected by strict
+    schema validation.
+
+    Uses tmp_path_factory (not tmp_path) so the isolated home is created
+    outside the test's own tmp_path, avoiding pollution in tests that check
+    tmp_path is empty or operate on its contents directly.
+
+    Tests that need a specific home structure override this by calling:
+        monkeypatch.setattr("pathlib.Path.home", lambda: my_home)
+    """
+    isolated_home = tmp_path_factory.mktemp("isolated-home")
+    monkeypatch.setattr("pathlib.Path.home", lambda: isolated_home)
+
+
+@pytest.fixture(autouse=True)
 def _clear_headless_env(monkeypatch):
     """Ensure AUTOSKILLIT_HEADLESS is unset at the start of every test.
 


### PR DESCRIPTION
## Summary

Add strict schema validation to every user-writable YAML config layer so that unrecognized
keys fail loudly at load time, and a `SECRETS_ONLY_KEYS` enforcement layer ensures
`github.token` (and any future secrets) can only appear in `.secrets.yaml` — never in any
`config.yaml`. Additionally fix two misleading error messages in `execution/github.py` that
point users toward the committed file, and harden the `setup-project` skill template with an
explicit negative instruction.

## Architecture Impact

### Security Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START(["load_config()"])

    subgraph TrustedLayer ["TRUSTED LAYER (no validation)"]
        DEF["defaults.yaml<br/>━━━━━━━━━━<br/>Bundled artifact<br/>Schema source of truth"]
    end

    subgraph UserConfigBoundary ["TRUST BOUNDARY: User config.yaml"]
        UCFG["~/.autoskillit/config.yaml<br/>━━━━━━━━━━<br/>User-writable · can be committed"]
        UVAL["● validate_layer_keys()<br/>━━━━━━━━━━<br/>is_secrets_layer=False<br/>Unknown keys → hard fail"]
        USEC["● SECRETS_ONLY_KEYS check<br/>━━━━━━━━━━<br/>github.token FORBIDDEN<br/>→ ConfigSchemaError"]
    end

    subgraph ProjectConfigBoundary ["TRUST BOUNDARY: Project config.yaml"]
        PCFG[".autoskillit/config.yaml<br/>━━━━━━━━━━<br/>Project-writable · can be committed"]
        PVAL["● validate_layer_keys()<br/>━━━━━━━━━━<br/>is_secrets_layer=False<br/>Unknown keys → hard fail"]
        PSEC["● SECRETS_ONLY_KEYS check<br/>━━━━━━━━━━<br/>github.token FORBIDDEN<br/>→ ConfigSchemaError"]
    end

    subgraph SecretsBoundary ["TRUST BOUNDARY: .secrets.yaml (gitignored)"]
        SCFG[".autoskillit/.secrets.yaml<br/>━━━━━━━━━━<br/>gitignored · never committed"]
        SVAL["● validate_layer_keys()<br/>━━━━━━━━━━<br/>is_secrets_layer=True<br/>Unknown keys → hard fail"]
        SALLOW["github.token ALLOWED<br/>━━━━━━━━━━<br/>SECRETS_ONLY_KEYS gate<br/>opens for this layer"]
    end

    subgraph EnvLayer ["ENV LAYER (Dynaconf, unrestricted)"]
        ENV["AUTOSKILLIT_SECTION__KEY<br/>━━━━━━━━━━<br/>Env overrides bypass<br/>file validation"]
    end

    subgraph SchemaEnforcement ["● SCHEMA ENFORCEMENT (new)"]
        SCHEMA["● _CONFIG_SCHEMA<br/>━━━━━━━━━━<br/>Derived from AutomationConfig<br/>dataclass hierarchy"]
        SECKEYS["● SECRETS_ONLY_KEYS<br/>━━━━━━━━━━<br/>frozenset({'github.token'})"]
        ERR["● ConfigSchemaError<br/>━━━━━━━━━━<br/>Hard fail · ValueError subclass<br/>typo hint via difflib"]
    end

    subgraph TokenFlow ["TOKEN FLOW → API"]
        MERGED["● _make_dynaconf()<br/>━━━━━━━━━━<br/>Merged YAML → temp file<br/>→ Dynaconf → AutomationConfig"]
        CTX["make_context()<br/>━━━━━━━━━━<br/>token = config.github.token<br/>or GITHUB_TOKEN env var"]
        GHF["DefaultGitHubFetcher<br/>━━━━━━━━━━<br/>self._token (private)<br/>never logged"]
        HDR["_headers()<br/>━━━━━━━━━━<br/>● Error msg → .secrets.yaml<br/>Bearer only if token truthy"]
    end

    START --> DEF
    DEF --> UCFG
    UCFG --> UVAL
    UVAL -->|unknown key| ERR
    UVAL -->|valid| USEC
    USEC -->|github.token present| ERR
    USEC -->|clean| PCFG
    PCFG --> PVAL
    PVAL -->|unknown key| ERR
    PVAL -->|valid| PSEC
    PSEC -->|github.token present| ERR
    PSEC -->|clean| SCFG
    SCFG --> SVAL
    SVAL -->|unknown key| ERR
    SVAL -->|valid| SALLOW
    SALLOW --> MERGED
    ENV --> MERGED
    MERGED --> CTX
    CTX --> GHF
    GHF --> HDR

    SCHEMA -.->|informs| UVAL
    SCHEMA -.->|informs| PVAL
    SCHEMA -.->|informs| SVAL
    SECKEYS -.->|enforces| USEC
    SECKEYS -.->|enforces| PSEC
    SECKEYS -.->|gate opens| SALLOW

    class DEF stateNode;
    class UCFG,PCFG,SCFG phase;
    class UVAL,PVAL,SVAL,USEC,PSEC detector;
    class SALLOW,SCHEMA,SECKEYS,ERR newComponent;
    class ENV cli;
    class MERGED,CTX,GHF,HDR output;
    class START terminal;
```

**Color Legend:**
| Color | Category | Description |
|-------|----------|-------------|
| Dark Blue | Terminal/Entry | Entry point and env-var layer |
| Teal | Trusted | Bundled defaults (schema source of truth) |
| Purple | Config Files | User-writable YAML layers |
| Red | Validation | ● validate_layer_keys() gates and SECRETS_ONLY_KEYS checks |
| Green | New/Modified | ● New enforcement: _CONFIG_SCHEMA, SECRETS_ONLY_KEYS, ConfigSchemaError |
| Dark Teal | Token Flow | Merged config → context → API headers |

### Operational Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 45, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart TB
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph InitWorkflow ["INIT WORKFLOW"]
        INIT["autoskillit init<br/>━━━━━━━━━━<br/>--test-command<br/>--scope user|project"]
        GEN_CFG[".autoskillit/config.yaml<br/>━━━━━━━━━━<br/>Non-secret settings only<br/>github.default_repo, test_check"]
        GEN_SEC[".autoskillit/.secrets.yaml<br/>━━━━━━━━━━<br/>github.token placeholder<br/>gitignored"]
    end

    subgraph SetupGuide ["● SETUP-PROJECT GUIDANCE (modified)"]
        SKILL["● setup-project/SKILL.md<br/>━━━━━━━━━━<br/>Step 5: Config Updates<br/>NEVER put token in config.yaml"]
    end

    subgraph ConfigLoad ["● CONFIG LOAD (modified)"]
        SERVE["autoskillit serve<br/>━━━━━━━━━━<br/>MCP server start"]
        SHOWCFG["autoskillit config show<br/>━━━━━━━━━━<br/>Resolved merged JSON"]
        LOAD["● load_config()<br/>━━━━━━━━━━<br/>_make_dynaconf()<br/>4-layer merge"]
    end

    subgraph ConfigLayers ["CONFIGURATION HIERARCHY (5 layers)"]
        L1["defaults.yaml<br/>━━━━━━━━━━<br/>Layer 1 — trusted, no validation"]
        L2["~/.autoskillit/config.yaml<br/>━━━━━━━━━━<br/>Layer 2 — ● validated"]
        L3[".autoskillit/config.yaml<br/>━━━━━━━━━━<br/>Layer 3 — ● validated"]
        L4[".autoskillit/.secrets.yaml<br/>━━━━━━━━━━<br/>Layer 4 — ● validated, secrets OK"]
        L5["AUTOSKILLIT_SECTION__KEY<br/>━━━━━━━━━━<br/>Layer 5 — env vars, highest priority"]
    end

    subgraph ValidationGate ["● VALIDATION GATE (new)"]
        VALIDATE["● validate_layer_keys()<br/>━━━━━━━━━━<br/>Unknown key? → hard fail<br/>Wrong layer? → redirect"]
        SCHEMA_ERR["● ConfigSchemaError<br/>━━━━━━━━━━<br/>Typo hint via difflib<br/>Startup blocked"]
    end

    subgraph GitHubErrors ["● GITHUB ERROR MESSAGES (modified)"]
        GH_404["● github.py — HTTP 404<br/>━━━━━━━━━━<br/>'Configure github.token in<br/>.autoskillit/.secrets.yaml'"]
    end

    subgraph Output ["OPERATOR FEEDBACK"]
        OK["AutomationConfig loaded<br/>━━━━━━━━━━<br/>Server ready"]
        ERR_OUT["● ConfigSchemaError raised<br/>━━━━━━━━━━<br/>Message shows layer path<br/>+typo hint + .secrets.yaml redirect"]
    end

    INIT --> GEN_CFG
    INIT --> GEN_SEC
    SKILL -.->|"guides LLM during setup"| GEN_CFG

    SERVE --> LOAD
    SHOWCFG --> LOAD
    LOAD --> L1 --> L2 --> L3 --> L4 --> L5

    L2 --> VALIDATE
    L3 --> VALIDATE
    L4 --> VALIDATE
    VALIDATE -->|valid| OK
    VALIDATE -->|invalid key| SCHEMA_ERR
    SCHEMA_ERR --> ERR_OUT

    GH_404 -.->|"operator sees .secrets.yaml hint"| GEN_SEC

    class INIT,SERVE,SHOWCFG cli;
    class GEN_CFG,GEN_SEC,L1,L2,L3,L4 stateNode;
    class LOAD,VALIDATE,SCHEMA_ERR,GH_404,SKILL newComponent;
    class OK output;
    class ERR_OUT gap;
    class L5 phase;
```

**Color Legend:**
| Color | Category | Description |
|-------|----------|-------------|
| Dark Blue | CLI | Entry point commands |
| Teal | Config Files | YAML layer files and config state |
| Green | Modified | ● PR changes: validation, error messages, skill guidance |
| Yellow/Orange | Error | ConfigSchemaError — blocks server startup |
| Dark Teal | Success | Server ready with valid config |
| Purple | Env Layer | Environment variable overrides (highest priority) |

Closes #449

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-449-20260320-184502-060373/temp/make-plan/strict_schema_validation_config_yaml_plan_2026-03-20_000000.md`

## Token Usage Summary

| Step | input | output | cached | count | time |
|------|-------|--------|--------|-------|------|
| plan | 9.7k | 298.8k | 10.5M | 18 | 1h 56m |
| verify | 326 | 264.5k | 12.7M | 17 | 1h 34m |
| implement | 6.3k | 365.6k | 46.4M | 17 | 2h 57m |
| fix | 131 | 43.6k | 4.6M | 5 | 27m 26s |
| audit_impl | 161 | 90.0k | 3.1M | 11 | 30m 5s |
| open_pr | 435 | 237.8k | 13.3M | 16 | 1h 40m |
| review_pr | 226 | 287.1k | 6.4M | 9 | 1h 9m |
| resolve_review | 3.7k | 200.0k | 16.1M | 9 | 1h 32m |
| resolve_conflicts | 75 | 30.6k | 2.6M | 3 | 10m 44s |
| diagnose_ci | 36 | 9.0k | 670.5k | 2 | 3m 15s |
| resolve_ci | 27 | 5.9k | 482.4k | 2 | 3m 57s |
| **Total** | 21.2k | 1.8M | 117.0M | | 12h 6m |

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
