### PR TITLE
Recipe requires_packs Schema Extension (Issue #524)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,7 @@ src/autoskillit/
 │   ├── rules_graph.py       #   Semantic rules for step graph reachability and cycles
 │   ├── rules_inputs.py      #   Semantic rules for ingredient/version validation
 │   ├── rules_merge.py       #   Semantic rules for merge_worktree routing completeness
+│   ├── rules_packs.py       #   Semantic rules for unknown pack names in requires_packs (unknown-required-pack)
 │   ├── rules_recipe.py      #   Semantic rules for unknown sub-recipe references (unknown-sub-recipe rule)
 │   ├── rules_skill_content.py #  Semantic rules for SKILL.md bash-block placeholder validation (undefined-bash-placeholder)
 │   ├── rules_skills.py      #   Semantic rules for skill_command resolvability (unknown-skill-command)

--- a/src/autoskillit/recipe/__init__.py
+++ b/src/autoskillit/recipe/__init__.py
@@ -15,6 +15,7 @@ from autoskillit.recipe import rules_dataflow as _rules_dataflow  # noqa: E402 F
 from autoskillit.recipe import rules_graph as _rules_graph  # noqa: E402 F401
 from autoskillit.recipe import rules_inputs as _rules_inputs  # noqa: E402 F401
 from autoskillit.recipe import rules_merge as _rules_merge  # noqa: E402 F401
+from autoskillit.recipe import rules_packs as _rules_packs  # noqa: E402 F401
 from autoskillit.recipe import rules_recipe as _rules_recipe  # noqa: E402 F401
 from autoskillit.recipe import rules_skill_content as _rules_skill_content  # noqa: E402 F401
 from autoskillit.recipe import rules_skills as _rules_skills  # noqa: E402 F401

--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -367,11 +367,20 @@ def _merge_sub_recipe(parent: Any, placeholder_name: str, sub: Any) -> Any:
             merged_rules.append(rule)
             seen_rules.add(rule)
 
+    # Merge requires_packs: union (parent first, then sub-recipe additions)
+    seen_packs: set[str] = set(parent.requires_packs)
+    merged_packs = list(parent.requires_packs)
+    for pack in sub.requires_packs:
+        if pack not in seen_packs:
+            merged_packs.append(pack)
+            seen_packs.add(pack)
+
     return dataclasses.replace(
         parent,
         steps=new_steps,
         ingredients=merged_ingredients,
         kitchen_rules=merged_rules,
+        requires_packs=merged_packs,
     )
 
 

--- a/src/autoskillit/recipe/rules_packs.py
+++ b/src/autoskillit/recipe/rules_packs.py
@@ -14,8 +14,10 @@ from autoskillit.recipe.registry import RuleFinding, semantic_rule
 )
 def _check_unknown_required_pack(ctx: ValidationContext) -> list[RuleFinding]:
     findings = []
+    seen_reported: set[str] = set()
     for pack_name in ctx.recipe.requires_packs:
-        if pack_name not in PACK_REGISTRY:
+        if pack_name not in PACK_REGISTRY and pack_name not in seen_reported:
+            seen_reported.add(pack_name)
             findings.append(
                 RuleFinding(
                     rule="unknown-required-pack",

--- a/src/autoskillit/recipe/rules_packs.py
+++ b/src/autoskillit/recipe/rules_packs.py
@@ -1,0 +1,30 @@
+"""Semantic rules for pack validation in recipe pipelines."""
+
+from __future__ import annotations
+
+from autoskillit.core import PACK_REGISTRY, Severity
+from autoskillit.recipe._analysis import ValidationContext
+from autoskillit.recipe.registry import RuleFinding, semantic_rule
+
+
+@semantic_rule(
+    name="unknown-required-pack",
+    description="Pack name in requires_packs is not in PACK_REGISTRY",
+    severity=Severity.WARNING,
+)
+def _check_unknown_required_pack(ctx: ValidationContext) -> list[RuleFinding]:
+    findings = []
+    for pack_name in ctx.recipe.requires_packs:
+        if pack_name not in PACK_REGISTRY:
+            findings.append(
+                RuleFinding(
+                    rule="unknown-required-pack",
+                    severity=Severity.WARNING,
+                    step_name="(top-level)",
+                    message=(
+                        f"Pack {pack_name!r} in requires_packs is not in PACK_REGISTRY. "
+                        f"Known packs: {sorted(PACK_REGISTRY)}"
+                    ),
+                )
+            )
+    return findings

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -642,7 +642,8 @@ def test_no_subpackage_exceeds_10_files() -> None:
         tools_kitchen, helpers, git, _factory, _state, __init__); each file is a
         thin routing layer. Exempt at 16 files.
       recipe/ — REQ-CNST-003-E2: recipe/ hosts one file per semantic-rule domain
-        (rules_bypass, rules_ci, rules_clone, etc.) for independent testability.
+        (rules_bypass, rules_ci, rules_clone, rules_packs, etc.) for independent testability.
+        Adding rules_packs.py for requires_packs validation brings the count to 28.
       execution/ — REQ-CNST-003-E3: execution/ decomposes process lifecycle into
         focused single-concern modules (_process_io, _process_kill, _process_race,
         etc.) that cannot be merged without re-introducing the coupling they isolate.
@@ -666,7 +667,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
     """
     EXEMPTIONS: dict[str, int] = {
         "server": 17,
-        "recipe": 27,
+        "recipe": 28,
         "execution": 23,
         "core": 15,
         "cli": 15,

--- a/tests/recipe/test_merge_sub_recipe_hidden.py
+++ b/tests/recipe/test_merge_sub_recipe_hidden.py
@@ -4,7 +4,9 @@ from autoskillit.recipe._api import _merge_sub_recipe
 from autoskillit.recipe.schema import Recipe, RecipeIngredient, RecipeStep
 
 
-def _recipe(ingredients: dict, steps: dict | None = None) -> Recipe:
+def _recipe(
+    ingredients: dict, steps: dict | None = None, requires_packs: list[str] | None = None
+) -> Recipe:
     return Recipe(
         name="test",
         description="",
@@ -12,6 +14,7 @@ def _recipe(ingredients: dict, steps: dict | None = None) -> Recipe:
         steps=steps or {},
         kitchen_rules=[],
         version=None,
+        requires_packs=requires_packs or [],
     )
 
 
@@ -50,3 +53,43 @@ def test_merge_sub_recipe_keeps_non_hidden_ingredients():
     )
     merged = _merge_sub_recipe(parent, "sub_entry", sub)
     assert "shared_param" in merged.ingredients
+
+
+def test_merge_sub_recipe_unions_requires_packs():
+    """_merge_sub_recipe unions requires_packs parent-first, no duplicates."""
+    parent = _recipe(
+        {},
+        steps={"sub_entry": RecipeStep(sub_recipe="sub", on_success="done")},
+        requires_packs=["github"],
+    )
+    sub = _recipe(
+        {
+            "shared_param": RecipeIngredient(description="Shared across sub-recipes", default="v"),
+        },
+        requires_packs=["research", "github"],  # "github" is a duplicate
+    )
+    merged = _merge_sub_recipe(parent, "sub_entry", sub)
+    assert merged.requires_packs == ["github", "research"]
+
+
+def test_merge_sub_recipe_requires_packs_empty_sub():
+    """When sub-recipe has no requires_packs, parent's list is preserved."""
+    parent = _recipe(
+        {},
+        steps={"sub_entry": RecipeStep(sub_recipe="sub", on_success="done")},
+        requires_packs=["telemetry"],
+    )
+    sub = _recipe({})
+    merged = _merge_sub_recipe(parent, "sub_entry", sub)
+    assert merged.requires_packs == ["telemetry"]
+
+
+def test_merge_sub_recipe_requires_packs_empty_parent():
+    """When parent has no requires_packs, sub-recipe's list is adopted."""
+    parent = _recipe(
+        {},
+        steps={"sub_entry": RecipeStep(sub_recipe="sub", on_success="done")},
+    )
+    sub = _recipe({}, requires_packs=["research"])
+    merged = _merge_sub_recipe(parent, "sub_entry", sub)
+    assert merged.requires_packs == ["research"]

--- a/tests/recipe/test_rule_decomposition.py
+++ b/tests/recipe/test_rule_decomposition.py
@@ -24,7 +24,7 @@ def test_no_deferred_validator_imports_in_rule_modules() -> None:
 
 
 def test_all_rules_registered_across_submodules() -> None:
-    """T2: All 27 rules registered, distributed across sub-modules."""
+    """T2: All 28 rules registered, distributed across sub-modules."""
     import autoskillit.recipe  # noqa: F401 -- triggers rule registration
     from autoskillit.recipe.registry import _RULE_REGISTRY
 
@@ -57,6 +57,7 @@ def test_all_rules_registered_across_submodules() -> None:
         "unknown-skill-command",
         "missing-output-patterns",
         "ci-failure-missing-conflict-gate",
+        "unknown-required-pack",
     }
     assert expected <= rule_names
 

--- a/tests/recipe/test_rules_packs.py
+++ b/tests/recipe/test_rules_packs.py
@@ -1,0 +1,64 @@
+"""Tests for the unknown-required-pack semantic rule."""
+from autoskillit.core import Severity
+from autoskillit.recipe.registry import run_semantic_rules
+from autoskillit.recipe.schema import Recipe, RecipeStep
+
+
+def _make_recipe(requires_packs: list[str]) -> Recipe:
+    return Recipe(
+        name="test",
+        description="test recipe",
+        version="0.7.2",
+        requires_packs=requires_packs,
+        steps={"stop": RecipeStep(action="stop")},
+    )
+
+
+def test_unknown_pack_produces_warning():
+    """Pack name not in PACK_REGISTRY produces a WARNING finding."""
+    import autoskillit.recipe  # noqa: F401 -- triggers rule registration
+
+    recipe = _make_recipe(["nonexistent-pack"])
+    findings = [f for f in run_semantic_rules(recipe) if f.rule == "unknown-required-pack"]
+    assert findings
+    assert findings[0].severity == Severity.WARNING
+    assert "nonexistent-pack" in findings[0].message
+
+
+def test_known_pack_produces_no_finding():
+    """Known pack name (in PACK_REGISTRY) produces no finding."""
+    import autoskillit.recipe  # noqa: F401 -- triggers rule registration
+
+    recipe = _make_recipe(["research"])
+    findings = [f for f in run_semantic_rules(recipe) if f.rule == "unknown-required-pack"]
+    assert not findings
+
+
+def test_mixed_packs_flags_only_unknown():
+    """Only unknown packs are flagged; known packs pass silently."""
+    import autoskillit.recipe  # noqa: F401 -- triggers rule registration
+
+    recipe = _make_recipe(["research", "bogus-pack"])
+    findings = [f for f in run_semantic_rules(recipe) if f.rule == "unknown-required-pack"]
+    assert len(findings) == 1
+    assert "bogus-pack" in findings[0].message
+
+
+def test_empty_requires_packs_produces_no_finding():
+    """Recipes without requires_packs produce no finding."""
+    import autoskillit.recipe  # noqa: F401 -- triggers rule registration
+
+    recipe = _make_recipe([])
+    findings = [f for f in run_semantic_rules(recipe) if f.rule == "unknown-required-pack"]
+    assert not findings
+
+
+def test_all_builtin_packs_pass():
+    """Every pack in PACK_REGISTRY is a valid name (no self-flagging)."""
+    import autoskillit.recipe  # noqa: F401 -- triggers rule registration
+
+    from autoskillit.core import PACK_REGISTRY
+
+    recipe = _make_recipe(list(PACK_REGISTRY.keys()))
+    findings = [f for f in run_semantic_rules(recipe) if f.rule == "unknown-required-pack"]
+    assert not findings, f"Built-in packs must not trigger unknown-required-pack: {findings}"

--- a/tests/recipe/test_rules_packs.py
+++ b/tests/recipe/test_rules_packs.py
@@ -1,4 +1,5 @@
 """Tests for the unknown-required-pack semantic rule."""
+
 from autoskillit.core import Severity
 from autoskillit.recipe.registry import run_semantic_rules
 from autoskillit.recipe.schema import Recipe, RecipeStep
@@ -56,7 +57,6 @@ def test_empty_requires_packs_produces_no_finding():
 def test_all_builtin_packs_pass():
     """Every pack in PACK_REGISTRY is a valid name (no self-flagging)."""
     import autoskillit.recipe  # noqa: F401 -- triggers rule registration
-
     from autoskillit.core import PACK_REGISTRY
 
     recipe = _make_recipe(list(PACK_REGISTRY.keys()))


### PR DESCRIPTION
## Summary

Issue #504 (Bundle research recipe) was implemented before this prerequisite, leaving #524 partially complete. A precise gap analysis against the codebase reveals the missing pieces: `_merge_sub_recipe()` did not union `requires_packs`, and no `unknown-required-pack` semantic validation rule existed. This PR adds both — the sub-recipe merge now propagates `requires_packs` with parent-first deduplication (identical pattern to `kitchen_rules`), and a new `rules_packs.py` module registers a WARNING-severity rule that flags pack names absent from `PACK_REGISTRY`.

## Requirements

- **REQ-RPACKS-001:** `Recipe.requires_packs` parsed from YAML as `list[str]`, defaults to `[]`.
- **REQ-RPACKS-002:** Sub-recipe merge unions `requires_packs` preserving parent-first order.
- **REQ-RPACKS-003:** Unknown pack name in `requires_packs` produces WARNING finding.
- **REQ-RPACKS-004:** `LoadRecipeResult` includes `requires_packs` list.
- **REQ-RPACKS-005:** Existing recipes without `requires_packs` parse with empty list (backward compat).

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    START([load_and_validate called])

    subgraph Parse ["1 · Parse Phase (io.py)"]
        direction TB
        ParseIO["_parse_recipe()<br/>━━━━━━━━━━<br/>Reads requires_packs list<br/>Defaults to []"]
        RecipeObj["Recipe dataclass<br/>━━━━━━━━━━<br/>requires_packs: list[str]"]
    end

    subgraph Merge ["2 · ● Sub-Recipe Merge (_api.py)"]
        direction TB
        MergeGate{"sub_recipe<br/>placeholder?"}
        MergeOp["● _merge_sub_recipe()<br/>━━━━━━━━━━<br/>steps + ingredients<br/>+ kitchen_rules<br/>★ + requires_packs union"]
        PackUnion["seen_packs set<br/>━━━━━━━━━━<br/>parent-first union<br/>no duplicates"]
        WorkingRecipe["merged Recipe<br/>━━━━━━━━━━<br/>requires_packs unified"]
    end

    subgraph Validate ["3 · Semantic Validation (registry.py)"]
        direction TB
        RunRules["run_semantic_rules()<br/>━━━━━━━━━━<br/>Iterates _RULE_REGISTRY"]
        PacksRule["★ _check_unknown_required_pack()<br/>━━━━━━━━━━<br/>rules_packs.py<br/>unknown-required-pack rule"]
        PackRegistry["PACK_REGISTRY<br/>━━━━━━━━━━<br/>Known pack names<br/>(core/_type_constants.py)"]
        PackGate{"pack in<br/>PACK_REGISTRY?"}
        Findings["RuleFinding<br/>━━━━━━━━━━<br/>severity=WARNING<br/>step=(top-level)"]
    end

    subgraph Surface ["4 · Result Surfacing (_api.py)"]
        direction TB
        ResultDict["LoadRecipeResult<br/>━━━━━━━━━━<br/>requires_packs: list[str]<br/>(omitted when empty)"]
    end

    COMPLETE([LoadRecipeResult returned])

    START --> ParseIO
    ParseIO --> RecipeObj
    RecipeObj --> MergeGate
    MergeGate -->|"yes"| MergeOp
    MergeGate -->|"no"| RunRules
    MergeOp --> PackUnion
    PackUnion --> WorkingRecipe
    WorkingRecipe --> RunRules
    RunRules --> PacksRule
    PacksRule -->|"consults"| PackRegistry
    PacksRule --> PackGate
    PackGate -->|"unknown"| Findings
    PackGate -->|"known"| ResultDict
    Findings --> ResultDict
    ResultDict --> COMPLETE

    %% CLASS ASSIGNMENTS %%
    class START,COMPLETE terminal;
    class ParseIO,MergeOp handler;
    class RecipeObj,WorkingRecipe,PackRegistry stateNode;
    class MergeGate,PackGate phase;
    class RunRules phase;
    class PacksRule newComponent;
    class PackUnion handler;
    class Findings detector;
    class ResultDict output;
```

**Color Legend:**
| Color | Category | Description |
|-------|----------|-------------|
| Dark Blue | Terminal | Start and end states |
| Orange | Handler | Processing logic (`_parse_recipe`, `_merge_sub_recipe`, pack union) |
| Teal | State | Immutable data objects (Recipe, PACK_REGISTRY) |
| Purple | Phase | Control flow gates (sub_recipe check, pack membership test) |
| Green | New Component | `★ rules_packs.py` — new semantic rule module |
| Red | Detector | `RuleFinding` — validation warnings produced by new rule |
| Dark Teal | Output | `LoadRecipeResult` — surfaced API response |

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph L2_Init ["L2 · recipe/__init__.py (Registration Driver)"]
        direction LR
        Init["● recipe/__init__.py<br/>━━━━━━━━━━<br/>Imports all rules_* modules<br/>Triggers @semantic_rule decorators"]
    end

    subgraph L2_Rules ["L2 · recipe/rules_*.py (Semantic Rule Modules)"]
        direction LR
        RulesPacks["★ rules_packs.py<br/>━━━━━━━━━━<br/>unknown-required-pack<br/>WARNING severity"]
        RulesSiblings["rules_bypass / rules_ci / rules_clone<br/>rules_contracts / rules_dataflow / rules_graph<br/>rules_inputs / rules_merge / rules_recipe<br/>rules_skill_content / rules_skills<br/>rules_tools / rules_verdict / rules_worktree<br/>━━━━━━━━━━<br/>(14 existing sibling modules)"]
    end

    subgraph L2_Internal ["L2 · recipe internals"]
        direction LR
        Registry["recipe/registry.py<br/>━━━━━━━━━━<br/>RuleFinding, semantic_rule<br/>_RULE_REGISTRY"]
        Analysis["recipe/_analysis.py<br/>━━━━━━━━━━<br/>ValidationContext"]
    end

    subgraph L0_Core ["L0 · core (zero-autoskillit imports)"]
        direction LR
        TypeConstants["core/_type_constants.py<br/>━━━━━━━━━━<br/>PACK_REGISTRY"]
        TypeEnums["core/_type_enums.py<br/>━━━━━━━━━━<br/>Severity"]
    end

    Init -->|"import rules_packs"| RulesPacks
    Init -->|"import rules_*(×14)"| RulesSiblings
    RulesPacks -->|"semantic_rule, RuleFinding"| Registry
    RulesPacks -->|"ValidationContext"| Analysis
    RulesPacks -->|"PACK_REGISTRY"| TypeConstants
    RulesPacks -->|"Severity"| TypeEnums
    RulesSiblings -->|"semantic_rule, RuleFinding"| Registry
    RulesSiblings -->|"ValidationContext"| Analysis

    %% CLASS ASSIGNMENTS %%
    class Init phase;
    class RulesPacks newComponent;
    class RulesSiblings handler;
    class Registry,Analysis stateNode;
    class TypeConstants,TypeEnums integration;
```

**Color Legend:**
| Color | Category | Description |
|-------|----------|-------------|
| Purple | Phase | `recipe/__init__.py` — registration orchestrator |
| Green | New Component | `★ rules_packs.py` — new semantic rule module |
| Orange | Handler | 14 existing sibling rule modules |
| Teal | State | High-fan-in internals: `registry.py`, `_analysis.py` |
| Red | External | L0 core constants (`PACK_REGISTRY`, `Severity`) |

Closes #524

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260403-065850-035943/.autoskillit/temp/make-plan/recipe_requires_packs_plan_2026-04-03_000000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | input | output | cached | count | time |
|------|-------|--------|--------|-------|------|
| plan | 40 | 15.3k | 1.4M | 1 | 4m 32s |
| verify | 19 | 15.6k | 908.3k | 1 | 4m 44s |
| implement | 35 | 10.4k | 1.5M | 1 | 2m 51s |
| fix | 44 | 8.0k | 1.4M | 1 | 6m 39s |
| audit_impl | 308 | 14.5k | 489.3k | 1 | 6m 44s |
| open_pr | 29 | 16.9k | 1.0M | 1 | 6m 32s |
| **Total** | 475 | 80.6k | 6.7M | | 32m 4s |