### PR TITLE
Implementation Plan: Clone Contamination Guard — Detect and Revert Direct Changes

### DIFF
--- a/src/autoskillit/core/_type_enums.py
+++ b/src/autoskillit/core/_type_enums.py
@@ -38,6 +38,7 @@ class RetryReason(StrEnum):
     CONTRACT_RECOVERY = (
         "contract_recovery"  # marker present + write evidence — omission not structural
     )
+    CLONE_CONTAMINATION = "clone_contamination"
 
 
 class MergeFailedStep(StrEnum):

--- a/src/autoskillit/execution/clone_guard.py
+++ b/src/autoskillit/execution/clone_guard.py
@@ -149,17 +149,24 @@ async def revert_contamination(
         direct_commits=report.direct_commits,
         uncommitted_file_count=len(report.uncommitted_files),
     )
-    await runner(
+    reset_result = await runner(
         ["git", "reset", "--hard", snapshot.head_sha],
         cwd=Path(cwd),
         timeout=_GIT_TIMEOUT,
     )
-    await runner(
+    clean_result = await runner(
         ["git", "clean", "-fd"],
         cwd=Path(cwd),
         timeout=_GIT_TIMEOUT,
     )
-    return dataclasses.replace(report, reverted=True)
+    reverted = reset_result.returncode == 0 and clean_result.returncode == 0
+    if not reverted:
+        logger.warning(
+            "revert_contamination_failed",
+            reset_rc=reset_result.returncode,
+            clean_rc=clean_result.returncode,
+        )
+    return dataclasses.replace(report, reverted=reverted)
 
 
 async def check_and_revert_clone_contamination(

--- a/src/autoskillit/execution/clone_guard.py
+++ b/src/autoskillit/execution/clone_guard.py
@@ -1,0 +1,209 @@
+"""Clone contamination guard — detect and revert direct changes to clone CWD.
+
+L1 module (execution/). Detects when a worktree-based skill session modified
+the clone directory directly (without creating a worktree) and reverts those
+changes to prevent contamination from propagating to retry sessions.
+
+Public API:
+    is_worktree_skill(skill_command) -> bool
+    snapshot_clone_state(cwd, runner) -> CloneSnapshot | None
+    check_and_revert_clone_contamination(
+        snapshot, skill_result, cwd, runner, audit
+    ) -> tuple[SkillResult, bool]
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from autoskillit.core import (
+    FailureRecord,
+    RetryReason,
+    SkillResult,
+    get_logger,
+)
+
+if TYPE_CHECKING:
+    from autoskillit.core import AuditStore, SubprocessRunner
+
+logger = get_logger(__name__)
+
+WORKTREE_SKILLS: frozenset[str] = frozenset(
+    {
+        "implement-worktree-no-merge",
+        "retry-worktree",
+    }
+)
+
+_GIT_TIMEOUT: float = 10.0
+
+
+@dataclass(frozen=True)
+class CloneSnapshot:
+    """Pre-session state of the clone directory."""
+
+    head_sha: str
+
+
+@dataclass(frozen=True)
+class ContaminationReport:
+    """Details of detected clone contamination."""
+
+    pre_sha: str
+    post_sha: str
+    uncommitted_files: list[str]
+    direct_commits: bool
+    reverted: bool
+
+
+def is_worktree_skill(skill_command: str) -> bool:
+    """Return True if skill_command invokes a worktree-creating skill."""
+    return any(name in skill_command for name in WORKTREE_SKILLS)
+
+
+async def snapshot_clone_state(cwd: str, runner: SubprocessRunner) -> CloneSnapshot | None:
+    """Capture the clone's HEAD SHA before a worktree-skill session.
+
+    Returns None on failure (graceful degradation — guard simply won't activate).
+    """
+    result = await runner(
+        ["git", "rev-parse", "HEAD"],
+        cwd=Path(cwd),
+        timeout=_GIT_TIMEOUT,
+    )
+    if result.returncode != 0:
+        logger.debug("snapshot_clone_state_failed", returncode=result.returncode)
+        return None
+    head_sha = result.stdout.strip()
+    if not head_sha:
+        logger.debug("snapshot_clone_state_empty_sha")
+        return None
+    logger.debug("snapshot_clone_state_captured", head_sha=head_sha)
+    return CloneSnapshot(head_sha=head_sha)
+
+
+async def detect_contamination(
+    snapshot: CloneSnapshot, cwd: str, runner: SubprocessRunner
+) -> ContaminationReport | None:
+    """Check whether the clone directory was contaminated during the session.
+
+    Returns None if no contamination detected, otherwise a ContaminationReport.
+    """
+    head_result = await runner(
+        ["git", "rev-parse", "HEAD"],
+        cwd=Path(cwd),
+        timeout=_GIT_TIMEOUT,
+    )
+    post_sha = head_result.stdout.strip() if head_result.returncode == 0 else ""
+
+    status_result = await runner(
+        ["git", "status", "--porcelain"],
+        cwd=Path(cwd),
+        timeout=_GIT_TIMEOUT,
+    )
+    status_lines = [line for line in status_result.stdout.splitlines() if line.strip()]
+
+    direct_commits = bool(post_sha and post_sha != snapshot.head_sha)
+    uncommitted = len(status_lines) > 0
+
+    if not direct_commits and not uncommitted:
+        logger.debug("detect_contamination_clean")
+        return None
+
+    logger.warning(
+        "clone_contamination_detected",
+        pre_sha=snapshot.head_sha,
+        post_sha=post_sha,
+        uncommitted_file_count=len(status_lines),
+        direct_commits=direct_commits,
+    )
+    return ContaminationReport(
+        pre_sha=snapshot.head_sha,
+        post_sha=post_sha,
+        uncommitted_files=status_lines,
+        direct_commits=direct_commits,
+        reverted=False,
+    )
+
+
+async def revert_contamination(
+    snapshot: CloneSnapshot,
+    report: ContaminationReport,
+    cwd: str,
+    runner: SubprocessRunner,
+) -> ContaminationReport:
+    """Revert the clone to its pre-session state."""
+    logger.info(
+        "reverting_clone_contamination",
+        pre_sha=snapshot.head_sha,
+        direct_commits=report.direct_commits,
+        uncommitted_file_count=len(report.uncommitted_files),
+    )
+    await runner(
+        ["git", "reset", "--hard", snapshot.head_sha],
+        cwd=Path(cwd),
+        timeout=_GIT_TIMEOUT,
+    )
+    await runner(
+        ["git", "clean", "-fd"],
+        cwd=Path(cwd),
+        timeout=_GIT_TIMEOUT,
+    )
+    return dataclasses.replace(report, reverted=True)
+
+
+async def check_and_revert_clone_contamination(
+    snapshot: CloneSnapshot | None,
+    skill_result: SkillResult,
+    cwd: str,
+    runner: SubprocessRunner,
+    audit: AuditStore | None,
+    skill_command: str = "",
+) -> tuple[SkillResult, bool]:
+    """Top-level guard: detect and revert clone contamination after a failed session.
+
+    Returns (skill_result, reverted) where reverted is True if contamination
+    was found and cleaned up.
+    """
+    if snapshot is None:
+        return skill_result, False
+    if skill_result.success:
+        return skill_result, False
+    if skill_result.worktree_path is not None:
+        return skill_result, False
+
+    report = await detect_contamination(snapshot, cwd, runner)
+    if report is None:
+        return skill_result, False
+
+    report = await revert_contamination(snapshot, report, cwd, runner)
+
+    if audit is not None:
+        audit.record_failure(
+            FailureRecord(
+                timestamp=datetime.now(UTC).isoformat(),
+                skill_command=skill_command,
+                exit_code=skill_result.exit_code,
+                subtype="clone_contamination",
+                needs_retry=skill_result.needs_retry,
+                retry_reason=RetryReason.CLONE_CONTAMINATION.value,
+                stderr=(
+                    f"pre_sha={report.pre_sha} post_sha={report.post_sha} "
+                    f"files={len(report.uncommitted_files)} "
+                    f"direct_commits={report.direct_commits}"
+                ),
+            )
+        )
+
+    logger.warning(
+        "clone_contamination_reverted",
+        pre_sha=report.pre_sha,
+        post_sha=report.post_sha,
+        files=len(report.uncommitted_files),
+        direct_commits=report.direct_commits,
+    )
+    return skill_result, True

--- a/src/autoskillit/execution/clone_guard.py
+++ b/src/autoskillit/execution/clone_guard.py
@@ -98,13 +98,19 @@ async def detect_contamination(
         cwd=Path(cwd),
         timeout=_GIT_TIMEOUT,
     )
-    post_sha = head_result.stdout.strip() if head_result.returncode == 0 else ""
+    if head_result.returncode != 0:
+        logger.debug("detect_contamination_rev_parse_failed", returncode=head_result.returncode)
+        return None
+    post_sha = head_result.stdout.strip()
 
     status_result = await runner(
         ["git", "status", "--porcelain"],
         cwd=Path(cwd),
         timeout=_GIT_TIMEOUT,
     )
+    if status_result.returncode != 0:
+        logger.debug("detect_contamination_status_failed", returncode=status_result.returncode)
+        return None
     status_lines = [line for line in status_result.stdout.splitlines() if line.strip()]
 
     direct_commits = bool(post_sha and post_sha != snapshot.head_sha)

--- a/src/autoskillit/execution/headless.py
+++ b/src/autoskillit/execution/headless.py
@@ -633,9 +633,7 @@ def _build_skill_result(
     if completion_marker:
         result_text = result_text.replace(completion_marker, "").strip()
 
-    extracted_worktree_path: str | None = None
-    if needs_retry:
-        extracted_worktree_path = _extract_worktree_path(session.assistant_messages)
+    extracted_worktree_path = _extract_worktree_path(session.assistant_messages)
 
     # Path contamination detection
     path_contamination: str | None = None

--- a/src/autoskillit/execution/headless.py
+++ b/src/autoskillit/execution/headless.py
@@ -34,8 +34,14 @@ from autoskillit.core import (
     WriteBehaviorSpec,
     claude_code_project_dir,
     get_logger,
+    is_git_worktree,
     load_yaml,
     pkg_root,
+)
+from autoskillit.execution.clone_guard import (
+    check_and_revert_clone_contamination,
+    is_worktree_skill,
+    snapshot_clone_state,
 )
 from autoskillit.execution.commands import build_full_headless_cmd
 from autoskillit.execution.process import _marker_is_standalone
@@ -807,6 +813,11 @@ async def run_headless_core(
         _start_ts = datetime.now(UTC).isoformat()
         _start_mono = time.monotonic()
 
+        # Clone contamination guard: snapshot before worktree-skill sessions
+        _clone_snapshot = None
+        if is_worktree_skill(original_skill_command) and not is_git_worktree(Path(cwd)):
+            _clone_snapshot = await snapshot_clone_state(cwd, runner)
+
         _result: SubprocessResult | None = None
         try:
             _result = await runner(
@@ -863,6 +874,18 @@ async def run_headless_core(
             write_behavior=write_behavior,
         )
 
+        # Clone contamination guard: detect and revert if session failed without worktree
+        _clone_reverted = False
+        if _clone_snapshot is not None:
+            skill_result, _clone_reverted = await check_and_revert_clone_contamination(
+                _clone_snapshot,
+                skill_result,
+                cwd,
+                runner,
+                ctx.audit,
+                skill_command=original_skill_command,
+            )
+
         # Use monotonic elapsed_seconds — authoritative wall-clock timing set by time.monotonic()
         # brackets in run_managed_async. Never re-derive from ISO strings (backward-clock risk).
         timing_seconds: float = result.elapsed_seconds
@@ -899,6 +922,7 @@ async def run_headless_core(
                     audit_record=audit_record,
                     write_path_warnings=skill_result.write_path_warnings,
                     write_call_count=skill_result.write_call_count,
+                    clone_contamination_reverted=_clone_reverted,
                 )
             except Exception:
                 logger.debug("session_log_flush_failed", exc_info=True)

--- a/src/autoskillit/execution/headless.py
+++ b/src/autoskillit/execution/headless.py
@@ -813,7 +813,6 @@ async def run_headless_core(
         _start_ts = datetime.now(UTC).isoformat()
         _start_mono = time.monotonic()
 
-        # Clone contamination guard: snapshot before worktree-skill sessions
         _clone_snapshot = None
         if is_worktree_skill(original_skill_command) and not is_git_worktree(Path(cwd)):
             _clone_snapshot = await snapshot_clone_state(cwd, runner)
@@ -874,7 +873,6 @@ async def run_headless_core(
             write_behavior=write_behavior,
         )
 
-        # Clone contamination guard: detect and revert if session failed without worktree
         _clone_reverted = False
         if _clone_snapshot is not None:
             skill_result, _clone_reverted = await check_and_revert_clone_contamination(

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -88,6 +88,7 @@ def flush_session_log(
     cli_subtype: str = "",
     write_path_warnings: list[str] | None = None,
     write_call_count: int = 0,
+    clone_contamination_reverted: bool = False,
 ) -> None:
     """Flush session diagnostics to disk.
 
@@ -199,6 +200,7 @@ def flush_session_log(
         "termination_reason": termination_reason,
         "write_path_warnings": effective_write_path_warnings,
         "write_call_count": write_call_count,
+        "clone_contamination_reverted": clone_contamination_reverted,
     }
     summary_path = session_dir / "summary.json"
     atomic_write(summary_path, json.dumps(summary, sort_keys=True, indent=2) + "\n")

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -668,7 +668,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
     EXEMPTIONS: dict[str, int] = {
         "server": 17,
         "recipe": 28,
-        "execution": 23,
+        "execution": 24,
         "core": 15,
         "cli": 15,
         "hooks": 12,

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -29,6 +29,7 @@ def test_retry_reason_values():
         RetryReason.PATH_CONTAMINATION,
         RetryReason.CONTRACT_RECOVERY,
         RetryReason.STALE,
+        RetryReason.CLONE_CONTAMINATION,
     }
     assert RetryReason.NONE.value == "none"
 

--- a/tests/execution/test_clone_guard.py
+++ b/tests/execution/test_clone_guard.py
@@ -117,6 +117,17 @@ async def test_snapshot_clone_state_returns_none_on_failure():
 
 
 # ---------------------------------------------------------------------------
+# T4b: snapshot_clone_state returns None when stdout is empty after rc=0
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_snapshot_clone_state_returns_none_on_empty_stdout():
+    runner = MockSubprocessRunner()
+    runner.push(_git_result(stdout="", returncode=0))
+    snapshot = await snapshot_clone_state("/tmp/clone", runner)
+    assert snapshot is None
+
+
+# ---------------------------------------------------------------------------
 # T5: detect_contamination — uncommitted changes
 # ---------------------------------------------------------------------------
 @pytest.mark.asyncio
@@ -193,8 +204,31 @@ async def test_revert_uncommitted_only():
     result = await revert_contamination(snapshot, report, "/tmp/clone", runner)
     assert result.reverted
     cmds = [call[0] for call in runner.call_args_list]
+    assert len(cmds) == 2
     assert ["git", "reset", "--hard", "abc123"] in cmds
     assert ["git", "clean", "-fd"] in cmds
+
+
+# ---------------------------------------------------------------------------
+# T9b: revert_contamination — git commands fail → reverted=False
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_revert_contamination_returns_false_when_git_fails():
+    runner = MockSubprocessRunner()
+    runner.push(_git_result(returncode=128))  # git reset --hard fails
+    runner.push(_git_result(returncode=0))  # git clean succeeds (still reverted=False)
+    snapshot = CloneSnapshot(head_sha="abc123")
+    from autoskillit.execution.clone_guard import ContaminationReport
+
+    report = ContaminationReport(
+        pre_sha="abc123",
+        post_sha="def456",
+        uncommitted_files=[],
+        direct_commits=True,
+        reverted=False,
+    )
+    result = await revert_contamination(snapshot, report, "/tmp/clone", runner)
+    assert not result.reverted
 
 
 # ---------------------------------------------------------------------------
@@ -229,7 +263,9 @@ async def test_guard_full_flow_contamination_detected():
     # detect_contamination: rev-parse HEAD (moved), status (dirty)
     runner.push(_git_result(stdout="def456\n"))
     runner.push(_git_result(stdout=" M file.py\n"))
-    # revert_contamination: reset, clean (defaults are rc=0)
+    # revert_contamination: reset --hard, clean -fd
+    runner.push(_git_result())
+    runner.push(_git_result())
 
     snapshot = CloneSnapshot(head_sha="abc123")
     skill_result = _make_skill_result(success=False, worktree_path=None)
@@ -244,6 +280,7 @@ async def test_guard_full_flow_contamination_detected():
         skill_command="/autoskillit:implement-worktree-no-merge plan.md",
     )
     assert reverted
+    assert len(runner.call_args_list) == 4  # 2 detect + 2 revert
     assert len(audit.get_report()) == 1
     record = audit.get_report()[0]
     assert record.subtype == "clone_contamination"

--- a/tests/execution/test_clone_guard.py
+++ b/tests/execution/test_clone_guard.py
@@ -1,0 +1,366 @@
+"""Tests for clone contamination guard — detect and revert direct changes."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from autoskillit.core.types import (
+    RetryReason,
+    SkillResult,
+    SubprocessResult,
+    TerminationReason,
+)
+from autoskillit.execution.clone_guard import (
+    CloneSnapshot,
+    check_and_revert_clone_contamination,
+    detect_contamination,
+    is_worktree_skill,
+    revert_contamination,
+    snapshot_clone_state,
+)
+from autoskillit.execution.headless import _build_skill_result
+from autoskillit.pipeline.audit import DefaultAuditLog
+from tests.conftest import MockSubprocessRunner
+
+
+def _git_result(stdout: str = "", returncode: int = 0) -> SubprocessResult:
+    """Build a minimal SubprocessResult simulating a git command."""
+    return SubprocessResult(
+        returncode=returncode,
+        stdout=stdout,
+        stderr="",
+        termination=TerminationReason.NATURAL_EXIT,
+        pid=99999,
+    )
+
+
+def _make_skill_result(
+    success: bool = False,
+    needs_retry: bool = True,
+    worktree_path: str | None = None,
+    exit_code: int = 1,
+) -> SkillResult:
+    """Build a minimal SkillResult for guard tests."""
+    return SkillResult(
+        success=success,
+        result="test result",
+        session_id="test-session",
+        subtype="error",
+        is_error=not success,
+        exit_code=exit_code,
+        needs_retry=needs_retry,
+        retry_reason=RetryReason.RESUME if needs_retry else RetryReason.NONE,
+        stderr="",
+        worktree_path=worktree_path,
+    )
+
+
+# ---------------------------------------------------------------------------
+# T1: is_worktree_skill positive cases
+# ---------------------------------------------------------------------------
+class TestIsWorktreeSkillPositive:
+    def test_slash_command_implement(self):
+        assert is_worktree_skill("/autoskillit:implement-worktree-no-merge /path/to/plan.md")
+
+    def test_slash_command_retry(self):
+        assert is_worktree_skill("/autoskillit:retry-worktree /path/to/worktree")
+
+    def test_bare_name(self):
+        assert is_worktree_skill("implement-worktree-no-merge")
+
+    def test_full_path(self):
+        assert is_worktree_skill(
+            "/path/to/skills_extended/implement-worktree-no-merge/SKILL.md some args"
+        )
+
+
+# ---------------------------------------------------------------------------
+# T2: is_worktree_skill negative cases
+# ---------------------------------------------------------------------------
+class TestIsWorktreeSkillNegative:
+    def test_investigate(self):
+        assert not is_worktree_skill("/autoskillit:investigate")
+
+    def test_make_plan(self):
+        assert not is_worktree_skill("/autoskillit:make-plan")
+
+    def test_open_pr(self):
+        assert not is_worktree_skill("/autoskillit:open-pr")
+
+    def test_implement_worktree_without_no_merge(self):
+        assert not is_worktree_skill("implement-worktree")
+
+
+# ---------------------------------------------------------------------------
+# T3: snapshot_clone_state captures SHA
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_snapshot_clone_state_captures_sha():
+    runner = MockSubprocessRunner()
+    runner.push(_git_result(stdout="abc123\n"))
+    snapshot = await snapshot_clone_state("/tmp/clone", runner)
+    assert snapshot is not None
+    assert snapshot.head_sha == "abc123"
+
+
+# ---------------------------------------------------------------------------
+# T4: snapshot_clone_state returns None on failure
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_snapshot_clone_state_returns_none_on_failure():
+    runner = MockSubprocessRunner()
+    runner.push(_git_result(returncode=128))
+    snapshot = await snapshot_clone_state("/tmp/clone", runner)
+    assert snapshot is None
+
+
+# ---------------------------------------------------------------------------
+# T5: detect_contamination — uncommitted changes
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_detect_contamination_uncommitted_changes():
+    runner = MockSubprocessRunner()
+    runner.push(_git_result(stdout="abc123\n"))  # git rev-parse HEAD (same)
+    runner.push(_git_result(stdout=" M src/main.py\n?? new_file.txt\n"))  # git status
+    snapshot = CloneSnapshot(head_sha="abc123")
+    report = await detect_contamination(snapshot, "/tmp/clone", runner)
+    assert report is not None
+    assert len(report.uncommitted_files) == 2
+    assert not report.direct_commits
+
+
+# ---------------------------------------------------------------------------
+# T6: detect_contamination — direct commits
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_detect_contamination_direct_commits():
+    runner = MockSubprocessRunner()
+    runner.push(_git_result(stdout="def456\n"))  # HEAD moved
+    runner.push(_git_result(stdout=""))  # clean status
+    snapshot = CloneSnapshot(head_sha="abc123")
+    report = await detect_contamination(snapshot, "/tmp/clone", runner)
+    assert report is not None
+    assert report.direct_commits
+    assert len(report.uncommitted_files) == 0
+
+
+# ---------------------------------------------------------------------------
+# T7: detect_contamination — both
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_detect_contamination_both():
+    runner = MockSubprocessRunner()
+    runner.push(_git_result(stdout="def456\n"))  # HEAD moved
+    runner.push(_git_result(stdout=" M dirty.py\n"))  # dirty
+    snapshot = CloneSnapshot(head_sha="abc123")
+    report = await detect_contamination(snapshot, "/tmp/clone", runner)
+    assert report is not None
+    assert report.direct_commits
+    assert len(report.uncommitted_files) == 1
+
+
+# ---------------------------------------------------------------------------
+# T8: detect_contamination — clean
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_detect_contamination_clean():
+    runner = MockSubprocessRunner()
+    runner.push(_git_result(stdout="abc123\n"))  # same HEAD
+    runner.push(_git_result(stdout=""))  # clean status
+    snapshot = CloneSnapshot(head_sha="abc123")
+    report = await detect_contamination(snapshot, "/tmp/clone", runner)
+    assert report is None
+
+
+# ---------------------------------------------------------------------------
+# T9: revert_contamination — uncommitted only
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_revert_uncommitted_only():
+    runner = MockSubprocessRunner()
+    snapshot = CloneSnapshot(head_sha="abc123")
+    from autoskillit.execution.clone_guard import ContaminationReport
+
+    report = ContaminationReport(
+        pre_sha="abc123",
+        post_sha="abc123",
+        uncommitted_files=[" M src/main.py"],
+        direct_commits=False,
+        reverted=False,
+    )
+    result = await revert_contamination(snapshot, report, "/tmp/clone", runner)
+    assert result.reverted
+    cmds = [call[0] for call in runner.call_args_list]
+    assert ["git", "reset", "--hard", "abc123"] in cmds
+    assert ["git", "clean", "-fd"] in cmds
+
+
+# ---------------------------------------------------------------------------
+# T10: revert_contamination — direct commits
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_revert_direct_commits():
+    runner = MockSubprocessRunner()
+    snapshot = CloneSnapshot(head_sha="abc123")
+    from autoskillit.execution.clone_guard import ContaminationReport
+
+    report = ContaminationReport(
+        pre_sha="abc123",
+        post_sha="def456",
+        uncommitted_files=[],
+        direct_commits=True,
+        reverted=False,
+    )
+    result = await revert_contamination(snapshot, report, "/tmp/clone", runner)
+    assert result.reverted
+    cmds = [call[0] for call in runner.call_args_list]
+    assert ["git", "reset", "--hard", "abc123"] in cmds
+    assert ["git", "clean", "-fd"] in cmds
+
+
+# ---------------------------------------------------------------------------
+# T11: guard full flow — contamination detected
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_guard_full_flow_contamination_detected():
+    runner = MockSubprocessRunner()
+    # detect_contamination: rev-parse HEAD (moved), status (dirty)
+    runner.push(_git_result(stdout="def456\n"))
+    runner.push(_git_result(stdout=" M file.py\n"))
+    # revert_contamination: reset, clean (defaults are rc=0)
+
+    snapshot = CloneSnapshot(head_sha="abc123")
+    skill_result = _make_skill_result(success=False, worktree_path=None)
+    audit = DefaultAuditLog()
+
+    result, reverted = await check_and_revert_clone_contamination(
+        snapshot,
+        skill_result,
+        "/tmp/clone",
+        runner,
+        audit,
+        skill_command="/autoskillit:implement-worktree-no-merge plan.md",
+    )
+    assert reverted
+    assert len(audit.get_report()) == 1
+    record = audit.get_report()[0]
+    assert record.subtype == "clone_contamination"
+    assert "pre_sha=abc123" in record.stderr
+    assert "post_sha=def456" in record.stderr
+
+
+# ---------------------------------------------------------------------------
+# T12: guard skipped when success
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_guard_skipped_when_success():
+    runner = MockSubprocessRunner()
+    snapshot = CloneSnapshot(head_sha="abc123")
+    skill_result = _make_skill_result(success=True, worktree_path=None)
+
+    result, reverted = await check_and_revert_clone_contamination(
+        snapshot, skill_result, "/tmp/clone", runner, None
+    )
+    assert not reverted
+    assert len(runner.call_args_list) == 0
+
+
+# ---------------------------------------------------------------------------
+# T13: guard skipped when worktree created
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_guard_skipped_when_worktree_created():
+    runner = MockSubprocessRunner()
+    snapshot = CloneSnapshot(head_sha="abc123")
+    skill_result = _make_skill_result(success=False, worktree_path="/some/worktree")
+
+    result, reverted = await check_and_revert_clone_contamination(
+        snapshot, skill_result, "/tmp/clone", runner, None
+    )
+    assert not reverted
+    assert len(runner.call_args_list) == 0
+
+
+# ---------------------------------------------------------------------------
+# T14: guard skipped when no snapshot
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_guard_skipped_when_no_snapshot():
+    runner = MockSubprocessRunner()
+    skill_result = _make_skill_result(success=False, worktree_path=None)
+
+    result, reverted = await check_and_revert_clone_contamination(
+        None, skill_result, "/tmp/clone", runner, None
+    )
+    assert not reverted
+    assert len(runner.call_args_list) == 0
+
+
+# ---------------------------------------------------------------------------
+# T15: worktree_path always extracted (even when needs_retry=False)
+# ---------------------------------------------------------------------------
+def test_worktree_path_always_extracted():
+    """worktree_path should be extracted regardless of needs_retry status."""
+    assistant = json.dumps(
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": "worktree_path = /tmp/wt\nbranch_name = impl-test",
+            },
+        }
+    )
+    result_json = json.dumps(
+        {
+            "type": "result",
+            "subtype": "success",
+            "result": "Task completed.",
+            "session_id": "test-session",
+            "is_error": False,
+        }
+    )
+    stdout = f"{assistant}\n{result_json}\n"
+    sr = SubprocessResult(
+        returncode=0,
+        stdout=stdout,
+        stderr="",
+        termination=TerminationReason.NATURAL_EXIT,
+        pid=12345,
+    )
+    skill = _build_skill_result(sr)
+    assert skill.worktree_path == "/tmp/wt"
+
+
+# ---------------------------------------------------------------------------
+# T16: audit log records contamination
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_audit_log_records_contamination():
+    runner = MockSubprocessRunner()
+    runner.push(_git_result(stdout="def456\n"))
+    runner.push(_git_result(stdout=" M a.py\n M b.py\n"))
+
+    snapshot = CloneSnapshot(head_sha="abc123")
+    skill_result = _make_skill_result(success=False, worktree_path=None)
+    audit = DefaultAuditLog()
+
+    await check_and_revert_clone_contamination(
+        snapshot,
+        skill_result,
+        "/tmp/clone",
+        runner,
+        audit,
+        skill_command="/autoskillit:implement-worktree-no-merge plan.md",
+    )
+
+    records = audit.get_report()
+    assert len(records) == 1
+    record = records[0]
+    assert record.subtype == "clone_contamination"
+    assert record.retry_reason == RetryReason.CLONE_CONTAMINATION.value
+    assert "pre_sha=abc123" in record.stderr
+    assert "post_sha=def456" in record.stderr
+    assert "files=2" in record.stderr
+    assert "direct_commits=True" in record.stderr

--- a/tests/server/test_tools_run_skill_retry.py
+++ b/tests/server/test_tools_run_skill_retry.py
@@ -47,7 +47,7 @@ class TestRunSkillSessionOutcome:
             }
         )
         tool_ctx.runner.push(_make_result(1, stdout, ""))
-        result = json.loads(await run_skill("/retry-worktree plan.md", "/tmp"))
+        result = json.loads(await run_skill("/investigate plan.md", "/tmp"))
         assert result["needs_retry"] is True
         assert result["retry_reason"] == RetryReason.RESUME
 
@@ -64,7 +64,7 @@ class TestRunSkillSessionOutcome:
             }
         )
         tool_ctx.runner.push(_make_result(1, stdout, ""))
-        result = json.loads(await run_skill("/retry-worktree plan.md", "/tmp"))
+        result = json.loads(await run_skill("/investigate plan.md", "/tmp"))
         assert result["needs_retry"] is True
         assert result["retry_reason"] == RetryReason.RESUME
 
@@ -88,7 +88,7 @@ class TestRunSkillSessionOutcome:
         )
         stdout = assistant + "\n" + result_record
         tool_ctx.runner.push(_make_result(0, stdout, ""))
-        result = json.loads(await run_skill("/retry-worktree plan.md", "/tmp"))
+        result = json.loads(await run_skill("/investigate plan.md", "/tmp"))
         assert result["needs_retry"] is False
         assert result["retry_reason"] == RetryReason.NONE
 
@@ -105,14 +105,14 @@ class TestRunSkillSessionOutcome:
             }
         )
         tool_ctx.runner.push(_make_result(1, stdout, ""))
-        result = json.loads(await run_skill("/retry-worktree plan.md", "/tmp"))
+        result = json.loads(await run_skill("/investigate plan.md", "/tmp"))
         assert result["needs_retry"] is False
 
     @pytest.mark.anyio
     async def test_unparseable_stdout_not_retriable(self, tool_ctx):
         """Non-JSON stdout -> needs_retry=False."""
         tool_ctx.runner.push(_make_result(1, "crash dump", "segfault"))
-        result = json.loads(await run_skill("/retry-worktree plan.md", "/tmp"))
+        result = json.loads(await run_skill("/investigate plan.md", "/tmp"))
         assert result["needs_retry"] is False
 
 
@@ -149,7 +149,7 @@ class TestRunSkillAgentResult:
             }
         )
         tool_ctx.runner.push(_make_result(0, stdout, ""))
-        result = json.loads(await run_skill("/retry-worktree plan.md", "/tmp"))
+        result = json.loads(await run_skill("/investigate plan.md", "/tmp"))
         assert result["result"] == "Done."
 
 


### PR DESCRIPTION
## Summary

When `implement-worktree-no-merge` runs and the model ignores instructions to create a worktree (via `git worktree add`), it edits files directly in the clone directory. This leaves dirty uncommitted changes (or direct commits) on the clone's branch. On retry, the next session inherits a contaminated working tree.

This plan adds a **clone contamination guard** to the headless execution pipeline. The guard:
1. Snapshots the clone's HEAD SHA before each worktree-based skill session
2. After a failed session where no worktree was created, detects contamination (uncommitted changes or direct commits)
3. Reverts the clone to its pre-session state
4. Logs the cleanup for pipeline observability

Key architectural insight: `EnterWorktree` does not exist in this codebase. Worktree creation uses standard `git worktree add` via Bash, and success is signaled by emitting `worktree_path = <path>` tokens in assistant messages. Detection of "no worktree created" is therefore: no `worktree_path` token in `session.assistant_messages`.

## Requirements

### Snapshot (SNAP)

- **REQ-SNAP-001:** The system must capture the clone HEAD SHA before each `run_skill` invocation for worktree-based skills (implement-worktree-no-merge, retry-worktree).
- **REQ-SNAP-002:** The system must capture the clone working tree cleanliness state (clean/dirty) before each `run_skill` invocation for worktree-based skills.

### Detection (DET)

- **REQ-DET-001:** The system must detect uncommitted changes in the clone CWD after a worktree-based skill session that was adjudicated as failure.
- **REQ-DET-002:** The system must detect direct commits in the clone (HEAD differs from pre-session SHA) after a worktree-based skill session that was adjudicated as failure.
- **REQ-DET-003:** The system must verify whether `EnterWorktree` was called during the session by inspecting tool_uses in the session result.

### Revert (REV)

- **REQ-REV-001:** The system must revert uncommitted changes in the clone when contamination is detected (git checkout + git clean).
- **REQ-REV-002:** The system must revert direct commits in the clone when contamination is detected (git reset to pre-session SHA).
- **REQ-REV-003:** The revert must only execute when all three conditions are met: worktree-based skill, adjudicated failure, and no EnterWorktree call in tool_uses.

### Observability (OBS)

- **REQ-OBS-001:** The system must log all contamination detection and revert actions in the audit log with sufficient detail for pipeline visibility.
- **REQ-OBS-002:** The audit log entry must include the pre-session SHA, post-session SHA, list of contaminated files, and revert action taken.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    START(["● run_headless_core()"])

    subgraph PreSession ["★ Pre-Session Snapshot"]
        direction TB
        IS_WT{"★ is_worktree_skill?<br/>━━━━━━━━━━<br/>implement-worktree-no-merge<br/>or retry-worktree in cmd"}
        IS_CLONE{"★ not is_git_worktree?<br/>━━━━━━━━━━<br/>cwd is clone root,<br/>not a worktree"}
        SNAP["★ snapshot_clone_state()<br/>━━━━━━━━━━<br/>git rev-parse HEAD<br/>→ CloneSnapshot(head_sha)"]
    end

    subgraph Session ["Existing Session Lifecycle"]
        direction TB
        RUN["● runner() subprocess<br/>━━━━━━━━━━<br/>Headless Claude CLI"]
        BUILD["● _build_skill_result()<br/>━━━━━━━━━━<br/>Adjudication + gates<br/>worktree_path always extracted"]
    end

    subgraph PostGuard ["★ Post-Session Clone Guard"]
        direction TB
        CHK_SNAP{"★ snapshot captured?<br/>━━━━━━━━━━<br/>_clone_snapshot is not None"}
        CHK_SUCC{"★ skill_result.success?"}
        CHK_WT{"★ worktree_path set?<br/>━━━━━━━━━━<br/>skill_result.worktree_path<br/>is not None"}
        DETECT["★ detect_contamination()<br/>━━━━━━━━━━<br/>git rev-parse HEAD → post_sha<br/>git status --porcelain → files"]
        CHK_DIRTY{"★ contamination found?<br/>━━━━━━━━━━<br/>post_sha ≠ pre_sha<br/>OR dirty files"}
        REVERT["★ revert_contamination()<br/>━━━━━━━━━━<br/>git reset --hard pre_sha<br/>git clean -fd"]
        AUDIT["★ audit.record_failure()<br/>━━━━━━━━━━<br/>subtype=clone_contamination<br/>RetryReason.CLONE_CONTAMINATION"]
    end

    FLUSH["● flush_session_log()<br/>━━━━━━━━━━<br/>★ clone_contamination_reverted<br/>→ summary.json"]
    RETURN(["● return skill_result"])
    SKIP_SNAP(["skip → _clone_snapshot=None"])

    START --> IS_WT
    IS_WT -->|"no: not a worktree skill"| SKIP_SNAP
    IS_WT -->|"yes"| IS_CLONE
    IS_CLONE -->|"already a worktree CWD"| SKIP_SNAP
    IS_CLONE -->|"clone root CWD"| SNAP
    SNAP --> RUN
    SKIP_SNAP --> RUN
    RUN --> BUILD
    BUILD --> CHK_SNAP
    CHK_SNAP -->|"no snapshot"| FLUSH
    CHK_SNAP -->|"snapshot exists"| CHK_SUCC
    CHK_SUCC -->|"success=True"| FLUSH
    CHK_SUCC -->|"success=False"| CHK_WT
    CHK_WT -->|"worktree created"| FLUSH
    CHK_WT -->|"no worktree"| DETECT
    DETECT --> CHK_DIRTY
    CHK_DIRTY -->|"clean"| FLUSH
    CHK_DIRTY -->|"contaminated"| REVERT
    REVERT --> AUDIT
    AUDIT --> FLUSH
    FLUSH --> RETURN

    class START,RETURN,SKIP_SNAP terminal;
    class IS_WT,IS_CLONE,CHK_SNAP,CHK_SUCC,CHK_WT,CHK_DIRTY stateNode;
    class RUN,BUILD,FLUSH handler;
    class SNAP,DETECT,REVERT,AUDIT newComponent;
```

**Color Legend:**
| Color | Category | Description |
|-------|----------|-------------|
| Dark Blue | Terminal | Entry/exit points of `run_headless_core` |
| Teal | State/Decision | Routing decisions that control guard activation |
| Orange | Handler | Existing subprocess, adjudication, and telemetry nodes |
| Green | New Component | New clone contamination guard components (★) |

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;

    subgraph L3 ["L3 — SERVER (existing, unchanged)"]
        direction LR
        SERVER["server/tools_execution.py<br/>━━━━━━━━━━<br/>run_skill, run_cmd handlers"]
    end

    subgraph L1 ["L1 — EXECUTION"]
        direction TB
        HEADLESS["● execution/headless.py<br/>━━━━━━━━━━<br/>run_headless_core()<br/>_build_skill_result()"]
        CLONE_GUARD["★ execution/clone_guard.py<br/>━━━━━━━━━━<br/>is_worktree_skill()<br/>snapshot_clone_state()<br/>check_and_revert_clone_contamination()"]
        SESSION_LOG["● execution/session_log.py<br/>━━━━━━━━━━<br/>flush_session_log()<br/>★ clone_contamination_reverted"]
        COMMANDS["execution/commands.py<br/>━━━━━━━━━━<br/>build_full_headless_cmd()"]
        SESSION["execution/session.py<br/>━━━━━━━━━━<br/>ClaudeSessionResult"]
    end

    subgraph L0 ["L0 — CORE (zero autoskillit imports)"]
        direction TB
        ENUMS["● core/_type_enums.py<br/>━━━━━━━━━━<br/>RetryReason enum<br/>★ CLONE_CONTAMINATION added"]
        TYPES["core/types.py<br/>━━━━━━━━━━<br/>SkillResult, FailureRecord<br/>AuditStore, SubprocessRunner"]
        PATHS["core/paths.py<br/>━━━━━━━━━━<br/>is_git_worktree()"]
        LOGGING["core/logging.py<br/>━━━━━━━━━━<br/>get_logger()"]
        CORE_INIT["core/__init__.py<br/>━━━━━━━━━━<br/>Re-exports all L0 surface"]
    end

    subgraph Ext ["EXTERNAL (stdlib)"]
        STDLIB["dataclasses, pathlib<br/>datetime, typing"]
    end

    SERVER -->|"imports run_headless"| HEADLESS
    HEADLESS -->|"★ imports 3 functions"| CLONE_GUARD
    HEADLESS -->|"imports"| COMMANDS
    HEADLESS -->|"imports"| SESSION
    HEADLESS -->|"imports"| SESSION_LOG
    HEADLESS -->|"imports core surface"| CORE_INIT
    CLONE_GUARD -->|"★ imports FailureRecord<br/>RetryReason, SkillResult<br/>get_logger, is_git_worktree"| CORE_INIT
    SESSION_LOG -->|"imports"| LOGGING
    CORE_INIT -->|"re-exports"| ENUMS
    CORE_INIT -->|"re-exports"| TYPES
    CORE_INIT -->|"re-exports"| PATHS
    CORE_INIT -->|"re-exports"| LOGGING
    TYPES -->|"imports RetryReason"| ENUMS
    CLONE_GUARD -->|"stdlib only"| STDLIB
    ENUMS -->|"stdlib only"| STDLIB

    class SERVER cli;
    class HEADLESS,SESSION_LOG,COMMANDS,SESSION handler;
    class CLONE_GUARD newComponent;
    class ENUMS,TYPES,PATHS,LOGGING,CORE_INIT stateNode;
    class STDLIB integration;
```

**Color Legend:**
| Color | Category | Description |
|-------|----------|-------------|
| Dark Blue | Server (L3) | MCP tool handlers — top application layer |
| Orange | Execution (L1) | Service/orchestration layer modules |
| Green | New Module | `clone_guard.py` — new L1 execution module (★) |
| Teal | Core (L0) | Stable vocabulary/type layer — high fan-in |
| Red | External | Standard library dependencies |

Closes #617

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-617-20260405-085643-202786/.autoskillit/temp/make-plan/clone_contamination_guard_plan_2026-04-05_090600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 6.9k | 23.4k | 1.7M | 82.7k | 1 | 10m 39s |
| verify | 33 | 20.7k | 1.4M | 55.6k | 1 | 8m 39s |
| implement | 81 | 24.3k | 4.4M | 89.7k | 1 | 10m 6s |
| fix | 40 | 14.4k | 1.7M | 62.9k | 1 | 9m 17s |
| audit_impl | 13 | 11.0k | 288.2k | 45.3k | 1 | 4m 14s |
| open_pr | 28 | 20.1k | 1.0M | 55.4k | 1 | 7m 18s |
| **Total** | 7.1k | 113.9k | 10.5M | 391.6k | | 50m 15s |