### PR TITLE
Implementation Plan: Research Recipe — Post-Completion Archival and Artifact Merge Phase

### DIFF
--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -562,8 +562,7 @@ steps:
         --head "${ARTIFACT}"
         --base '${{ inputs.base_branch }}'
         --title "Research artifacts: ${EXPERIMENT}"
-        --body "${PR_BODY}"
-        --json url --jq '.url') &&
+        --body "${PR_BODY}") &&
         echo "artifact_pr_url=${PR_URL}"
       cwd: "${{ context.worktree_path }}"
       step_name: open_artifact_pr

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -526,7 +526,9 @@ steps:
         SLUG=$(printf '%s' "${EXPERIMENT_BRANCH}" | sed 's/^research-//') &&
         ARTIFACT_BRANCH="research-artifacts-${SLUG}" &&
         ARTIFACT_DIR="$(mktemp -d)" &&
+        trap 'git -C "${{ context.worktree_path }}" worktree remove "${ARTIFACT_DIR}" --force 2>/dev/null; rm -rf "${ARTIFACT_DIR}"' EXIT &&
         git -C '${{ context.worktree_path }}' fetch origin '${{ inputs.base_branch }}' &&
+        (git -C '${{ context.worktree_path }}' branch -D "${ARTIFACT_BRANCH}" 2>/dev/null || true) &&
         git -C '${{ context.worktree_path }}' worktree add "${ARTIFACT_DIR}" -b "${ARTIFACT_BRANCH}" "origin/${{ inputs.base_branch }}" &&
         git -C "${ARTIFACT_DIR}" checkout "${EXPERIMENT_BRANCH}" -- research/ &&
         cd "${ARTIFACT_DIR}" &&

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -8,8 +8,11 @@ description: >
   Supports a skippable design review loop (bounded by retries: 2), review
   resolution routing after PR open, and a post-review re-validation loop that
   re-runs affected benchmarks when resolve-research-review produces rerun_required
-  escalations. No auto-merge.
-summary: scope > plan > [review?] > worktree > decompose > phases > experiment > report > open-pr > [review? > resolve > [re-run?] > push]
+  escalations. After the final push (or when review completes), an archival
+  phase separates research artifacts from experimental code: opens a clean
+  artifact-only PR, tags the experiment branch, and closes the original PR.
+  No auto-merge.
+summary: scope > plan > [review?] > worktree > decompose > phases > experiment > report > open-pr > [review? > resolve > [re-run?] > push] > archive
 
 ingredients:
   task:
@@ -70,6 +73,12 @@ kitchen_rules:
     PERMANENT ARTIFACTS: create_worktree commits the experiment plan
     to research/ and supporting artifacts (scope report, design evaluation)
     to research/artifacts/. These are permanent records in the PR.
+  - >
+    ARCHIVAL PHASE: After all review and re-validation cycles complete,
+    the pipeline extracts research/ into a clean artifact PR, tags the full
+    experiment branch under archive/research/, and closes the original PR.
+    Every archival step degrades gracefully — failures route to
+    research_complete without blocking the pipeline.
 
 steps:
   # --- DESIGN PHASE ---
@@ -390,18 +399,19 @@ steps:
       cwd: "${{ context.worktree_path }}"
       step_name: review_research_pr
     skip_when_false: inputs.review_pr
-    on_context_limit: research_complete
-    on_failure: research_complete
+    on_context_limit: begin_archival
+    on_failure: begin_archival
     on_result:
       - when: "${{ result.verdict }} == changes_requested"
         route: resolve_research_review
       - when: "${{ result.verdict }} == needs_human"
-        route: research_complete
-      - route: research_complete
+        route: begin_archival
+      - route: begin_archival
     note: >
       Optional research PR review step, gated by the review_pr ingredient.
       on_result handles verdict-based routing; changes_requested triggers
-      resolve_research_review -> re_push_research. All other verdicts complete.
+      resolve_research_review -> re_push_research. All other verdicts and
+      failures route to begin_archival for artifact extraction.
 
   resolve_research_review:
     tool: run_skill
@@ -412,10 +422,10 @@ steps:
     capture:
       needs_rerun: "${{ result.needs_rerun }}"
     retries: 2
-    on_exhausted: research_complete
-    on_context_limit: research_complete
+    on_exhausted: begin_archival
+    on_context_limit: begin_archival
     on_success: check_escalations
-    on_failure: research_complete
+    on_failure: begin_archival
 
   check_escalations:
     action: route
@@ -482,8 +492,125 @@ steps:
       cmd: "cd '${{ context.worktree_path }}' && git push"
       cwd: "${{ context.worktree_path }}"
       step_name: re_push_research
+    on_success: begin_archival
+    on_failure: begin_archival
+
+  # --- ARCHIVAL PHASE ---
+  begin_archival:
+    action: route
+    on_result:
+      - when: "${{ context.pr_url }}"
+        route: capture_experiment_branch
+      - route: research_complete
+    note: >
+      Gate step for the archival phase. Routes to artifact extraction when
+      a research PR exists, otherwise skips directly to completion. All paths
+      from review/resolve/re-push converge here.
+
+  capture_experiment_branch:
+    tool: run_cmd
+    with:
+      cmd: "git -C '${{ context.worktree_path }}' rev-parse --abbrev-ref HEAD"
+      cwd: "${{ context.worktree_path }}"
+      step_name: capture_experiment_branch
+    capture:
+      experiment_branch: "${{ result.stdout | trim }}"
+    on_success: create_artifact_branch
+    on_failure: research_complete
+
+  create_artifact_branch:
+    tool: run_cmd
+    with:
+      cmd: >
+        EXPERIMENT_BRANCH="${{ context.experiment_branch }}" &&
+        SLUG=$(printf '%s' "${EXPERIMENT_BRANCH}" | sed 's/^research-//') &&
+        ARTIFACT_BRANCH="research-artifacts-${SLUG}" &&
+        ARTIFACT_DIR="$(mktemp -d)" &&
+        git -C '${{ context.worktree_path }}' fetch origin '${{ inputs.base_branch }}' &&
+        git -C '${{ context.worktree_path }}' worktree add "${ARTIFACT_DIR}" -b "${ARTIFACT_BRANCH}" "origin/${{ inputs.base_branch }}" &&
+        git -C "${ARTIFACT_DIR}" checkout "${EXPERIMENT_BRANCH}" -- research/ &&
+        cd "${ARTIFACT_DIR}" &&
+        git add research/ &&
+        git commit -m "Add research artifacts: ${SLUG}" &&
+        git push -u origin "${ARTIFACT_BRANCH}" &&
+        cd - > /dev/null &&
+        git -C '${{ context.worktree_path }}' worktree remove "${ARTIFACT_DIR}" --force &&
+        echo "artifact_branch=${ARTIFACT_BRANCH}"
+      cwd: "${{ context.worktree_path }}"
+      step_name: create_artifact_branch
+    capture:
+      artifact_branch: "${{ result.artifact_branch }}"
+    on_success: open_artifact_pr
+    on_failure: research_complete
+    note: >
+      Creates a temporary worktree from the base branch, checks out only the
+      research/ directory from the experiment branch, commits and pushes, then
+      removes the temporary worktree. Produces a single clean commit with zero
+      production code changes.
+
+  open_artifact_pr:
+    tool: run_cmd
+    with:
+      cmd: >
+        EXPERIMENT="${{ context.experiment_branch }}" &&
+        ARTIFACT="${{ context.artifact_branch }}" &&
+        ORIG_PR="${{ context.pr_url }}" &&
+        PR_BODY=$(printf '## Research Artifacts\n\nCherry-picked from experiment branch `%s`.\n\nOriginal experiment PR: %s\n\nContains only files under `research/` — zero production code changes.' "${EXPERIMENT}" "${ORIG_PR}") &&
+        PR_URL=$(gh pr create
+        --head "${ARTIFACT}"
+        --base '${{ inputs.base_branch }}'
+        --title "Research artifacts: ${EXPERIMENT}"
+        --body "${PR_BODY}"
+        --json url --jq '.url') &&
+        echo "artifact_pr_url=${PR_URL}"
+      cwd: "${{ context.worktree_path }}"
+      step_name: open_artifact_pr
+    capture:
+      artifact_pr_url: "${{ result.artifact_pr_url }}"
+    on_success: tag_experiment_branch
+    on_failure: research_complete
+    note: >
+      Opens a PR containing only the research/ directory. The PR body references
+      the original experiment PR. This PR is safe to merge — no production code.
+
+  tag_experiment_branch:
+    tool: run_cmd
+    with:
+      cmd: >
+        TAG="archive/research/${{ context.experiment_branch }}" &&
+        ARTIFACT_PR="${{ context.artifact_pr_url }}" &&
+        git -C '${{ context.worktree_path }}' tag -a "${TAG}" '${{ context.experiment_branch }}'
+        -m "Research experiment: ${{ context.experiment_branch }}. Report merged via artifact PR ${ARTIFACT_PR}. Variant code preserved here for reference." &&
+        git -C '${{ context.worktree_path }}' push origin "${TAG}" &&
+        echo "archive_tag=${TAG}"
+      cwd: "${{ context.worktree_path }}"
+      step_name: tag_experiment_branch
+    capture:
+      archive_tag: "${{ result.archive_tag }}"
+    on_success: close_experiment_pr
+    on_failure: research_complete
+    note: >
+      Creates an annotated tag preserving the full experiment branch (including
+      all variant code, benchmark scaffolding, etc.) under archive/research/.
+      Pushed to remote before any branch cleanup can occur.
+
+  close_experiment_pr:
+    tool: run_cmd
+    with:
+      cmd: >
+        ARTIFACT_PR="${{ context.artifact_pr_url }}" &&
+        ARCHIVE_TAG="${{ context.archive_tag }}" &&
+        CLOSE_BODY=$(printf '## Archived\n\nThis PR contained both research artifacts and experimental code.\n\n**Research record merged via:** %s\n**Full experiment branch preserved at:** `%s`\n\nThe artifact PR contains only files under `research/` (reports, scripts, results). The archive tag preserves the full experiment branch including variant code for reference.\n\nTo restore the full experiment: `git checkout %s`' "${ARTIFACT_PR}" "${ARCHIVE_TAG}" "${ARCHIVE_TAG}") &&
+        gh pr close '${{ context.pr_url }}' --comment "${CLOSE_BODY}"
+      cwd: "${{ context.worktree_path }}"
+      step_name: close_experiment_pr
     on_success: research_complete
     on_failure: research_complete
+    note: >
+      Closes the original experiment PR with a structured comment linking to
+      the artifact PR (where research/ was merged) and the archive tag (where
+      the full experiment branch is preserved). Both success and failure route
+      to research_complete — closing the PR is best-effort.
 
   research_complete:
     action: stop

--- a/tests/recipe/test_bundled_recipes.py
+++ b/tests/recipe/test_bundled_recipes.py
@@ -2168,6 +2168,7 @@ class TestResearchRecipeStructure:
         # Default on_result route
         conditions = step.on_result.conditions
         default = next((c for c in conditions if not c.when), None)
+        assert default is not None
         assert default.route == "begin_archival"
 
     def test_resolve_research_review_routes_to_begin_archival(self, recipe) -> None:
@@ -2177,7 +2178,7 @@ class TestResearchRecipeStructure:
         assert step.on_failure == "begin_archival"
 
     def test_re_push_research_routes_to_begin_archival(self, recipe) -> None:
-        """re_push_research routes to begin_archival (was research_complete)."""
+        """re_push_research routes to begin_archival."""
         step = recipe.steps["re_push_research"]
         assert step.on_success == "begin_archival"
         assert step.on_failure == "begin_archival"

--- a/tests/recipe/test_bundled_recipes.py
+++ b/tests/recipe/test_bundled_recipes.py
@@ -1791,11 +1791,11 @@ class TestResearchRecipeStructure:
         step = recipe.steps["review_research_pr"]
         assert step.skip_when_false == "inputs.review_pr"
 
-    def test_research_review_step_routes_to_complete_on_any_outcome(self, recipe) -> None:
-        """review_research_pr routes to research_complete on failure and context limit."""
+    def test_research_review_step_routes_to_begin_archival_on_any_outcome(self, recipe) -> None:
+        """review_research_pr routes to begin_archival on failure and context limit."""
         step = recipe.steps["review_research_pr"]
-        assert step.on_failure == "research_complete"
-        assert step.on_context_limit == "research_complete"
+        assert step.on_failure == "begin_archival"
+        assert step.on_context_limit == "begin_archival"
 
     def test_research_no_issue_number_ingredient(self, recipe) -> None:
         """Removed: issue_number is the phase-2 gate."""
@@ -1939,9 +1939,9 @@ class TestResearchRecipeStructure:
     def test_has_resolve_research_review_step(self, recipe) -> None:
         step = recipe.steps["resolve_research_review"]
         assert step.retries == 2
-        assert step.on_exhausted == "research_complete"
+        assert step.on_exhausted == "begin_archival"
         assert step.on_success == "check_escalations"
-        assert step.on_failure == "research_complete"
+        assert step.on_failure == "begin_archival"
 
     def test_has_re_push_research_step(self, recipe) -> None:
         assert "re_push_research" in recipe.steps
@@ -2049,9 +2049,135 @@ class TestResearchRecipeStructure:
         assert step.tool == "test_check"
         assert step.on_success == "re_push_research"
 
-    def test_revalidation_loop_all_paths_reach_research_complete(self, recipe) -> None:
-        """Every path from check_escalations reaches research_complete."""
+    def test_revalidation_loop_all_paths_reach_begin_archival(self, recipe) -> None:
+        """Every path from check_escalations reaches begin_archival."""
         for step_name in ("re_run_experiment", "re_write_report", "re_test"):
             step = recipe.steps[step_name]
-            assert step.on_failure in ("research_complete", "re_push_research")
-        assert recipe.steps["re_push_research"].on_success == "research_complete"
+            assert step.on_failure in ("begin_archival", "re_push_research")
+        assert recipe.steps["re_push_research"].on_success == "begin_archival"
+
+    # --- Archival phase tests ---
+
+    def test_archival_begin_archival_step_exists(self, recipe) -> None:
+        """begin_archival must be a route step gating archival on pr_url."""
+        assert "begin_archival" in recipe.steps
+        step = recipe.steps["begin_archival"]
+        assert step.action == "route"
+
+    def test_archival_begin_archival_routes_to_capture(self, recipe) -> None:
+        """begin_archival routes to capture_experiment_branch when pr_url is truthy."""
+        step = recipe.steps["begin_archival"]
+        assert step.on_result is not None
+        conditions = step.on_result.conditions
+        truthy_route = next((c for c in conditions if c.when and "pr_url" in c.when), None)
+        assert truthy_route is not None
+        assert truthy_route.route == "capture_experiment_branch"
+
+    def test_archival_begin_archival_default_to_complete(self, recipe) -> None:
+        """begin_archival default route goes to research_complete."""
+        step = recipe.steps["begin_archival"]
+        conditions = step.on_result.conditions
+        default = next((c for c in conditions if not c.when), None)
+        assert default is not None
+        assert default.route == "research_complete"
+
+    def test_archival_capture_experiment_branch_step(self, recipe) -> None:
+        """capture_experiment_branch captures experiment_branch from git rev-parse."""
+        assert "capture_experiment_branch" in recipe.steps
+        step = recipe.steps["capture_experiment_branch"]
+        assert step.tool == "run_cmd"
+        assert "experiment_branch" in step.capture
+        assert step.on_success == "create_artifact_branch"
+        assert step.on_failure == "research_complete"
+
+    def test_archival_create_artifact_branch_step(self, recipe) -> None:
+        """create_artifact_branch creates temp worktree and captures artifact_branch."""
+        assert "create_artifact_branch" in recipe.steps
+        step = recipe.steps["create_artifact_branch"]
+        assert step.tool == "run_cmd"
+        assert "artifact_branch" in step.capture
+        assert step.on_success == "open_artifact_pr"
+        assert step.on_failure == "research_complete"
+
+    def test_archival_create_artifact_branch_uses_research_checkout(self, recipe) -> None:
+        """create_artifact_branch must use git checkout <branch> -- research/ pattern."""
+        step = recipe.steps["create_artifact_branch"]
+        cmd = step.with_args["cmd"]
+        assert "research/" in cmd, "Must checkout research/ directory from experiment branch"
+        assert "worktree add" in cmd, "Must create a temporary worktree"
+
+    def test_archival_open_artifact_pr_step(self, recipe) -> None:
+        """open_artifact_pr creates the artifact-only PR and captures artifact_pr_url."""
+        assert "open_artifact_pr" in recipe.steps
+        step = recipe.steps["open_artifact_pr"]
+        assert step.tool == "run_cmd"
+        assert "artifact_pr_url" in step.capture
+        assert step.on_success == "tag_experiment_branch"
+        assert step.on_failure == "research_complete"
+
+    def test_archival_tag_experiment_branch_step(self, recipe) -> None:
+        """tag_experiment_branch creates annotated archive tag and captures archive_tag."""
+        assert "tag_experiment_branch" in recipe.steps
+        step = recipe.steps["tag_experiment_branch"]
+        assert step.tool == "run_cmd"
+        assert "archive_tag" in step.capture
+        assert step.on_success == "close_experiment_pr"
+        assert step.on_failure == "research_complete"
+
+    def test_archival_tag_uses_archive_prefix(self, recipe) -> None:
+        """Tag name must use archive/research/ prefix convention."""
+        step = recipe.steps["tag_experiment_branch"]
+        cmd = step.with_args["cmd"]
+        assert "archive/research/" in cmd
+
+    def test_archival_close_experiment_pr_step(self, recipe) -> None:
+        """close_experiment_pr closes the original PR and routes to research_complete."""
+        assert "close_experiment_pr" in recipe.steps
+        step = recipe.steps["close_experiment_pr"]
+        assert step.tool == "run_cmd"
+        assert step.on_success == "research_complete"
+        assert step.on_failure == "research_complete"
+
+    def test_archival_close_pr_references_artifact_and_tag(self, recipe) -> None:
+        """close_experiment_pr comment must reference both artifact PR and archive tag."""
+        step = recipe.steps["close_experiment_pr"]
+        cmd = step.with_args["cmd"]
+        assert "artifact_pr_url" in cmd, "Must reference artifact PR URL"
+        assert "archive_tag" in cmd, "Must reference archive tag"
+
+    def test_archival_graceful_degradation(self, recipe) -> None:
+        """Every archival step must route on_failure to research_complete."""
+        archival_steps = [
+            "capture_experiment_branch",
+            "create_artifact_branch",
+            "open_artifact_pr",
+            "tag_experiment_branch",
+            "close_experiment_pr",
+        ]
+        for name in archival_steps:
+            step = recipe.steps[name]
+            assert step.on_failure == "research_complete", (
+                f"{name}.on_failure must be research_complete for graceful degradation"
+            )
+
+    def test_review_research_pr_routes_to_begin_archival(self, recipe) -> None:
+        """review_research_pr non-changes verdicts and failures route to begin_archival."""
+        step = recipe.steps["review_research_pr"]
+        assert step.on_failure == "begin_archival"
+        assert step.on_context_limit == "begin_archival"
+        # Default on_result route
+        conditions = step.on_result.conditions
+        default = next((c for c in conditions if not c.when), None)
+        assert default.route == "begin_archival"
+
+    def test_resolve_research_review_routes_to_begin_archival(self, recipe) -> None:
+        """resolve_research_review exhaustion and failure route to begin_archival."""
+        step = recipe.steps["resolve_research_review"]
+        assert step.on_exhausted == "begin_archival"
+        assert step.on_failure == "begin_archival"
+
+    def test_re_push_research_routes_to_begin_archival(self, recipe) -> None:
+        """re_push_research routes to begin_archival (was research_complete)."""
+        step = recipe.steps["re_push_research"]
+        assert step.on_success == "begin_archival"
+        assert step.on_failure == "begin_archival"


### PR DESCRIPTION
## Summary

Add a six-step archival phase to the end of the research recipe (`research.yaml`) that separates research artifacts from experimental code before completion. After all review cycles, re-runs, and CI checks finish, the new phase: (1) captures the experiment branch name, (2) creates a clean artifact-only branch containing only `research/` from a temporary worktree, (3) opens an artifact PR targeting the base branch, (4) tags the full experiment branch under `archive/research/` for permanent reference, (5) closes the original experiment PR with cross-reference links, then (6) proceeds to `research_complete`. Every archival step degrades gracefully — `on_failure` routes to `research_complete` so the pipeline never blocks on archival failures.

## Requirements

### SPLIT — Artifact Extraction

- **REQ-SPLIT-001:** The recipe must create a new branch from the base branch (e.g., main) containing only the `research/` directory contents from the experiment branch, with no production source file changes.
- **REQ-SPLIT-002:** The artifact extraction must use `git checkout <experiment-branch> -- research/` (or equivalent) to copy only the research directory's file state, not replay commit history.
- **REQ-SPLIT-003:** The artifact-only branch must produce a single clean commit with a descriptive message referencing the experiment name.

### PR — Artifact PR

- **REQ-PR-001:** The recipe must open a PR targeting the base branch with the artifact-only branch, referencing the original experiment PR number and summarizing key findings in the body.
- **REQ-PR-002:** The artifact PR must contain zero changes to production source files — only files under `research/`.

### TAG — Branch Archival

- **REQ-TAG-001:** The recipe must create an annotated git tag with the prefix `archive/research/` capturing the final state of the experiment branch (after all reviews, re-runs, and CI pass).
- **REQ-TAG-002:** The annotated tag message must include the experiment name and a note that the report was merged via the artifact PR.
- **REQ-TAG-003:** The tag must be pushed to the remote before the experiment branch is cleaned up.

### CLOSE — Experiment PR Closure

- **REQ-CLOSE-001:** The recipe must close the original experiment PR with a comment linking to the artifact PR, the archive tag, and any follow-up implementation issues.
- **REQ-CLOSE-002:** The closure comment must explain why the PR was not merged (experimental code in production source files) and where the research record is preserved.

### ORDER — Execution Ordering

- **REQ-ORDER-001:** The archival phase must execute only after all review cycles, review resolutions, experiment re-runs (per #618), and CI checks have completed successfully.
- **REQ-ORDER-002:** The archival phase must be the final phase before `research_complete`, not interleaved with review or re-validation steps.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    subgraph PostReview ["● Post-Review Phase (modified routing)"]
        direction TB
        GPR{"guard_pr_url<br/>━━━━━━━━━━<br/>pr_url set?"}
        RRP["● review_research_pr<br/>━━━━━━━━━━<br/>run_skill: review-pr<br/>skip_when_false: review_pr"]
        RRR["● resolve_research_review<br/>━━━━━━━━━━<br/>run_skill: resolve-review<br/>retries: 2"]
        CE{"check_escalations<br/>━━━━━━━━━━<br/>needs_rerun?"}
        RERUN["re_run_experiment<br/>━━━━━━━━━━<br/>run-experiment --adjust"]
        REWRITE["re_write_report<br/>━━━━━━━━━━<br/>write-report"]
        RETEST["re_test<br/>━━━━━━━━━━<br/>test_check"]
        REPUSH["● re_push_research<br/>━━━━━━━━━━<br/>git push"]
    end

    subgraph Archival ["★ Archival Phase (new)"]
        direction TB
        BA{"★ begin_archival<br/>━━━━━━━━━━<br/>pr_url truthy?"}
        CEB["★ capture_experiment_branch<br/>━━━━━━━━━━<br/>git rev-parse HEAD<br/>captures: experiment_branch"]
        CAB["★ create_artifact_branch<br/>━━━━━━━━━━<br/>worktree + checkout research/<br/>captures: artifact_branch"]
        OAP["★ open_artifact_pr<br/>━━━━━━━━━━<br/>gh pr create (research/ only)<br/>captures: artifact_pr_url"]
        TEB["★ tag_experiment_branch<br/>━━━━━━━━━━<br/>git tag -a archive/research/*<br/>captures: archive_tag"]
        CEP["★ close_experiment_pr<br/>━━━━━━━━━━<br/>gh pr close + comment"]
    end

    RC([research_complete<br/>━━━━━━━━━━<br/>action: stop])

    GPR -->|"pr_url empty"| RC
    GPR -->|"pr_url truthy"| RRP
    RRP -->|"changes_requested"| RRR
    RRP -->|"needs_human / default / fail"| BA
    RRR -->|"success"| CE
    RRR -->|"exhausted / fail"| BA
    CE -->|"needs_rerun=true"| RERUN
    CE -->|"default"| REPUSH
    RERUN --> REWRITE --> RETEST --> REPUSH
    REPUSH -->|"success / fail"| BA

    BA -->|"pr_url truthy"| CEB
    BA -->|"default"| RC
    CEB -->|"success"| CAB
    CEB -->|"fail"| RC
    CAB -->|"success"| OAP
    CAB -->|"fail"| RC
    OAP -->|"success"| TEB
    OAP -->|"fail"| RC
    TEB -->|"success"| CEP
    TEB -->|"fail"| RC
    CEP -->|"success / fail"| RC

    class GPR,CE,BA stateNode;
    class RRP,RRR,RERUN,REWRITE,RETEST,REPUSH handler;
    class CEB,CAB,OAP,TEB,CEP newComponent;
    class RC terminal;
```

**Color Legend:**

| Color | Category | Description |
|-------|----------|-------------|
| Dark Blue | Terminal | `research_complete` stop state |
| Teal | State/Route | Decision and routing steps (guard_pr_url, check_escalations, begin_archival) |
| Orange | Handler | Existing processing steps — `●` marks modified routing targets |
| Green | New Component | Six new archival steps (`★`) — linear chain with graceful degradation |

Closes #621

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260405-101015-593986/.autoskillit/temp/make-plan/research_recipe_post_completion_archival_plan_2026-04-05_101500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 2.2k | 36.6k | 1.4M | 90.3k | 1 | 16m 17s |
| verify | 32 | 25.8k | 1.2M | 55.5k | 1 | 14m 5s |
| implement | 48 | 14.0k | 1.9M | 50.5k | 1 | 5m 52s |
| audit_impl | 16 | 9.7k | 178.9k | 55.3k | 2 | 4m 31s |
| open_pr | 22 | 11.7k | 690.1k | 46.2k | 1 | 4m 26s |
| **Total** | 2.3k | 97.7k | 5.4M | 297.8k | | 45m 13s |