### PR TITLE
fix: add git auth for private deps in version-bump workflows

### DIFF
--- a/.github/workflows/patch-bump-integration.yml
+++ b/.github/workflows/patch-bump-integration.yml
@@ -75,6 +75,9 @@ jobs:
         env:
           NEW_VERSION: ${{ steps.version.outputs.new }}
 
+      - name: Configure git auth for private deps
+        run: git config --global url."https://${{ secrets.GH_USER }}:${{ secrets.GH_PAT }}@github.com/TalonT-Org/".insteadOf "https://github.com/TalonT-Org/"
+
       - name: Regenerate uv.lock
         run: uv lock
 

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -68,6 +68,9 @@ jobs:
         env:
           NEW_VERSION: ${{ steps.version.outputs.new_main }}
 
+      - name: Configure git auth for private deps
+        run: git config --global url."https://${{ secrets.GH_USER }}:${{ secrets.GH_PAT }}@github.com/TalonT-Org/".insteadOf "https://github.com/TalonT-Org/"
+
       - name: Regenerate uv.lock (main)
         run: uv lock
 


### PR DESCRIPTION
## Summary

- Add `Configure git auth for private deps` step to `patch-bump-integration.yml` and `version-bump.yml` before `uv lock` runs
- Fixes authentication failure when resolving the private `api-simulator` git dependency added in PR #613
- Mirrors the existing auth pattern already present in `tests.yml` (line 76)

## Root Cause

PR #613 added `api-simulator` as a private git dependency in `pyproject.toml`. The `tests.yml` workflow was updated with git auth, but both version-bump workflows were missed. Every PR merged to `integration` since then fails at the `uv lock` step with:

```
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

## Test plan

- [ ] This PR's own CI passes (tests.yml)
- [ ] After merge, the patch-bump workflow should succeed — verify by checking the `bump-patch` check on this PR's merge commit
- [ ] Re-run a recent failed bump-patch workflow to confirm the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)