### PR TITLE
Implementation Plan: Queue Ejection Loop Fix

### DIFF
--- a/src/autoskillit/execution/merge_queue.py
+++ b/src/autoskillit/execution/merge_queue.py
@@ -148,13 +148,18 @@ class DefaultMergeQueueWatcher:
         stall_retries_attempted: int = 0
         not_in_queue_cycles: int = 0
 
-        def _make_result(success: bool, pr_state: str, reason: str) -> dict[str, Any]:
-            return {
+        def _make_result(
+            success: bool, pr_state: str, reason: str, ejection_cause: str = ""
+        ) -> dict[str, Any]:
+            result: dict[str, Any] = {
                 "success": success,
                 "pr_state": pr_state,
                 "reason": reason,
                 "stall_retries_attempted": stall_retries_attempted,
             }
+            if ejection_cause:
+                result["ejection_cause"] = ejection_cause
+            return result
 
         while time.monotonic() < deadline:
             try:
@@ -172,6 +177,13 @@ class DefaultMergeQueueWatcher:
 
             # Terminal: closed without merge
             if state["state"] == "CLOSED":
+                if state["checks_state"] == "FAILURE":
+                    return _make_result(
+                        False,
+                        "ejected_ci_failure",
+                        "PR was closed without merging — CI checks had failed",
+                        ejection_cause="ci_failure",
+                    )
                 return _make_result(False, "ejected", "PR was closed without merging")
 
             # In queue
@@ -238,6 +250,13 @@ class DefaultMergeQueueWatcher:
 
             # Positive confirmation: checks are terminal (SUCCESS/FAILURE/ERROR) or absent (None).
             # PR confirmed not in queue, not merged, checks not pending → genuine ejection.
+            if state["checks_state"] == "FAILURE":
+                return _make_result(
+                    False,
+                    "ejected_ci_failure",
+                    "PR was ejected from merge queue — CI checks failed on merge-group commit",
+                    ejection_cause="ci_failure",
+                )
             return _make_result(
                 False,
                 "ejected",

--- a/src/autoskillit/execution/merge_queue.py
+++ b/src/autoskillit/execution/merge_queue.py
@@ -177,7 +177,7 @@ class DefaultMergeQueueWatcher:
 
             # Terminal: closed without merge
             if state["state"] == "CLOSED":
-                if state["checks_state"] == "FAILURE":
+                if state["checks_state"] in ("FAILURE", "ERROR"):
                     return _make_result(
                         False,
                         "ejected_ci_failure",
@@ -250,7 +250,7 @@ class DefaultMergeQueueWatcher:
 
             # Positive confirmation: checks are terminal (SUCCESS/FAILURE/ERROR) or absent (None).
             # PR confirmed not in queue, not merged, checks not pending → genuine ejection.
-            if state["checks_state"] == "FAILURE":
+            if state["checks_state"] in ("FAILURE", "ERROR"):
                 return _make_result(
                     False,
                     "ejected_ci_failure",

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -718,6 +718,8 @@ steps:
     on_result:
       - when: "${{ result.pr_state }} == merged"
         route: release_issue_success
+      - when: "${{ result.pr_state }} == ejected_ci_failure"
+        route: diagnose_ci
       - when: "${{ result.pr_state }} == ejected"
         route: queue_ejected_fix
       - when: "${{ result.pr_state }} == stalled"
@@ -730,6 +732,7 @@ steps:
     note: >
       Waits up to 15 minutes for the PR to merge through the queue.
       merged → release_issue_success to transition issue state then register_clone_success.
+      ejected_ci_failure → diagnose_ci (CI failure; conflict resolution cannot fix this).
       ejected → conflict fix cycle then re-enter.
       stalled → lightweight re-enrollment (disable then re-enable auto-merge).
       timeout → release_issue_timeout (release claim without staged label; merge unconfirmed).
@@ -774,9 +777,28 @@ steps:
       remote_url: "${{ context.remote_url }}"
       branch: "${{ context.merge_target }}"
       force: "true"
-    on_success: reenter_merge_queue
+    on_success: ci_watch_post_queue_fix
     on_failure: release_issue_failure
     skip_when_false: "inputs.open_pr"
+
+  ci_watch_post_queue_fix:
+    tool: wait_for_ci
+    with:
+      branch: "${{ context.merge_target }}"
+      workflow: "tests.yml"
+      timeout_seconds: 300
+      cwd: "${{ context.work_dir }}"
+      remote_url: "${{ context.remote_url }}"
+    capture:
+      ci_conclusion: "${{ result.conclusion }}"
+      ci_failed_jobs: "${{ result.failed_jobs }}"
+    on_success: reenter_merge_queue
+    on_failure: detect_ci_conflict
+    skip_when_false: "inputs.open_pr"
+    note: >
+      Validates CI on the rebased feature branch after queue ejection fix and re-push.
+      Mirrors ci_watch: routes to reenter_merge_queue on CI pass, to detect_ci_conflict
+      on CI failure. Prevents re-entering the merge queue with a broken manifest or code.
 
   reenter_merge_queue:
     tool: run_cmd

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -667,6 +667,8 @@ steps:
     on_result:
       - when: "${{ result.pr_state }} == merged"
         route: release_issue_success
+      - when: "${{ result.pr_state }} == ejected_ci_failure"
+        route: diagnose_ci
       - when: "${{ result.pr_state }} == ejected"
         route: queue_ejected_fix
       - when: "${{ result.pr_state }} == stalled"
@@ -679,6 +681,7 @@ steps:
     note: >
       Waits up to 15 minutes for the PR to merge through the queue.
       merged → release_issue_success to transition issue state then register_clone_success.
+      ejected_ci_failure → diagnose_ci (CI failure; conflict resolution cannot fix this).
       ejected → conflict fix cycle then re-enter.
       stalled → lightweight re-enrollment (disable then re-enable auto-merge).
       timeout → release_issue_timeout (release claim without staged label; merge unconfirmed).
@@ -723,9 +726,28 @@ steps:
       remote_url: "${{ context.remote_url }}"
       branch: "${{ context.merge_target }}"
       force: "true"
-    on_success: reenter_merge_queue
+    on_success: ci_watch_post_queue_fix
     on_failure: release_issue_failure
     skip_when_false: "inputs.open_pr"
+
+  ci_watch_post_queue_fix:
+    tool: wait_for_ci
+    with:
+      branch: "${{ context.merge_target }}"
+      workflow: "tests.yml"
+      timeout_seconds: 300
+      cwd: "${{ context.work_dir }}"
+      remote_url: "${{ context.remote_url }}"
+    capture:
+      ci_conclusion: "${{ result.conclusion }}"
+      ci_failed_jobs: "${{ result.failed_jobs }}"
+    on_success: reenter_merge_queue
+    on_failure: detect_ci_conflict
+    skip_when_false: "inputs.open_pr"
+    note: >
+      Validates CI on the rebased feature branch after queue ejection fix and re-push.
+      Mirrors ci_watch: routes to reenter_merge_queue on CI pass, to detect_ci_conflict
+      on CI failure. Prevents re-entering the merge queue with a broken manifest or code.
 
   reenter_merge_queue:
     tool: run_cmd

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -641,6 +641,8 @@ steps:
     on_result:
       - when: "${{ result.pr_state }} == merged"
         route: release_issue_success
+      - when: "${{ result.pr_state }} == ejected_ci_failure"
+        route: diagnose_ci
       - when: "${{ result.pr_state }} == ejected"
         route: queue_ejected_fix
       - when: "${{ result.pr_state }} == stalled"
@@ -653,6 +655,7 @@ steps:
       merged → release_issue_success to apply staged label, then register_clone_success.
       release_issue_success is optional with skip_when_false: inputs.issue_url — when
       issue_url is absent the step is silently skipped and pipeline continues to register_clone_success.
+      ejected_ci_failure → diagnose_ci (CI failure; conflict resolution cannot fix this).
       ejected → conflict fix cycle then re-enter.
       stalled → lightweight re-enrollment (disable then re-enable auto-merge).
       timeout → register_clone_success (pipeline done; human monitors queue).
@@ -697,9 +700,28 @@ steps:
       remote_url: "${{ context.remote_url }}"
       branch: "${{ context.merge_target }}"
       force: "true"
-    on_success: reenter_merge_queue
+    on_success: ci_watch_post_queue_fix
     on_failure: release_issue_failure
     skip_when_false: "inputs.open_pr"
+
+  ci_watch_post_queue_fix:
+    tool: wait_for_ci
+    with:
+      branch: "${{ context.merge_target }}"
+      workflow: "tests.yml"
+      timeout_seconds: 300
+      cwd: "${{ context.work_dir }}"
+      remote_url: "${{ context.remote_url }}"
+    capture:
+      ci_conclusion: "${{ result.conclusion }}"
+      ci_failed_jobs: "${{ result.failed_jobs }}"
+    on_success: reenter_merge_queue
+    on_failure: detect_ci_conflict
+    skip_when_false: "inputs.open_pr"
+    note: >
+      Validates CI on the rebased feature branch after queue ejection fix and re-push.
+      Mirrors ci_watch: routes to reenter_merge_queue on CI pass, to detect_ci_conflict
+      on CI failure. Prevents re-entering the merge queue with a broken manifest or code.
 
   reenter_merge_queue:
     tool: run_cmd

--- a/src/autoskillit/server/tools_ci.py
+++ b/src/autoskillit/server/tools_ci.py
@@ -123,6 +123,11 @@ async def wait_for_ci(
             cwd=cwd,
         )
 
+        # Include head_sha used for this CI check so orchestrators can verify
+        # CI results correspond to the current HEAD after a force-push.
+        if scope.head_sha:
+            result = {**result, "head_sha": scope.head_sha}
+
         conclusion = result.get("conclusion", "unknown")
         level = "info" if conclusion == "success" else "error"
         await _notify(

--- a/src/autoskillit/skills_extended/resolve-merge-conflicts/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-merge-conflicts/SKILL.md
@@ -107,7 +107,7 @@ git -C {worktree_path} rebase $REMOTE/{base_branch}
 ```
 
 **On success (clean rebase):** The integration branch advanced in a non-conflicting way
-since the last attempt. Proceed directly to Step 7 — emit output tokens and exit.
+since the last attempt. Proceed to Step 5a for manifest validation before emitting output tokens.
 
 **On conflict:** Proceed to Step 3.
 
@@ -254,6 +254,111 @@ re-run `pre-commit run --all-files` to confirm clean.
 **Do NOT run the full test suite.** Testing is handled by the pipeline's `test` step,
 which already ran and passed before `merge_to_integration` was first attempted. Running
 tests here would be redundant and is explicitly prohibited.
+
+### Step 5a — Language-aware manifest validation
+
+After `pre-commit run --all-files` succeeds, detect the project language and run a fast
+manifest validity check. This catches semantically broken merges (e.g., duplicate
+dependency keys in Cargo.toml) that produce no conflict markers and are not caught
+by pre-commit hooks.
+
+**Detection and validation commands (run the first matching check):**
+
+| Detected by | Command |
+|-------------|---------|
+| `Cargo.toml` present | `cargo metadata --no-deps --format-version 1 >/dev/null` |
+| `package.json` present | `node -e "JSON.parse(require('fs').readFileSync('package.json'))"` |
+| `uv.lock` present | `uv lock --check` |
+| `pyproject.toml` present (no uv.lock) | `python3 -c "import tomllib; tomllib.load(open('pyproject.toml','rb'))"` |
+
+Run in the worktree root:
+
+```bash
+cd {worktree_path}
+```
+
+If **no manifest files are detected**: skip this step and proceed to Step 5b.
+
+If the check **fails**: do NOT attempt to fix the manifest. The rebase produced a
+semantically invalid result. Escalate immediately:
+
+```bash
+git -C {worktree_path} rebase --abort
+```
+
+```
+escalation_required = true
+escalation_reason = Post-rebase manifest validation failed: <error output summary>. The rebase produced a semantically invalid manifest (e.g., duplicate dependency key). Manual inspection required.
+```
+
+If the check **passes**: proceed to Step 5b.
+
+### Step 5b — Duplicate key scan in cleanly-merged structured files
+
+Scan manifest files for duplicate keys. Both branches may have independently added
+the same dependency entry; git merges these without conflict markers but the result
+is semantically invalid.
+
+**Files to scan** (if present in `{worktree_path}`):
+- `Cargo.toml` — scan `[dependencies]`, `[dev-dependencies]`, `[build-dependencies]` sections
+- `pyproject.toml` — scan `[project.dependencies]`, `[tool.uv.dev-dependencies]`
+- `package.json` — scan all top-level keys
+
+**TOML duplicate detection** (for each TOML manifest file):
+
+```bash
+python3 -c "
+import re, sys
+text = open(sys.argv[1]).read()
+in_dep_section = False
+counts = {}
+for line in text.splitlines():
+    if re.match(r'^\s*\[(dependencies|dev-dependencies|build-dependencies)\]', line):
+        in_dep_section = True
+        continue
+    if re.match(r'^\s*\[', line):
+        in_dep_section = False
+    if in_dep_section:
+        m = re.match(r'^\s*([a-zA-Z0-9_-]+)\s*[=\.]', line)
+        if m:
+            k = m.group(1)
+            counts[k] = counts.get(k, 0) + 1
+dups = {k: v for k, v in counts.items() if v > 1}
+if dups:
+    print('DUPLICATE_KEYS:', dups)
+    sys.exit(1)
+" Cargo.toml
+```
+
+**JSON duplicate detection** (for `package.json`):
+
+```bash
+python3 -c "
+import json, sys
+class _Dup(Exception): pass
+def check(pairs):
+    seen = {}
+    for k, v in pairs:
+        if k in seen:
+            raise _Dup(f'duplicate key: {k!r}')
+        seen[k] = v
+    return seen
+json.loads(open('package.json').read(), object_pairs_hook=check)
+" 2>&1
+```
+
+**If duplicates are found**: escalate immediately:
+
+```bash
+git -C {worktree_path} rebase --abort
+```
+
+```
+escalation_required = true
+escalation_reason = Duplicate key detected in <file>: key '<key>' appears multiple times in section '[<section>]'. This is a semantically invalid clean merge — both branches independently added the same dependency.
+```
+
+**If no duplicates are found** (or no manifest files are present): proceed to Step 6.
 
 ### Step 6 — Write Conflict Resolution Report
 

--- a/tests/execution/test_merge_queue.py
+++ b/tests/execution/test_merge_queue.py
@@ -806,7 +806,7 @@ class TestRelatedCoverage:
 
 
 class TestEjectionEnrichment:
-    """Tests for Gap 2: enriched ejection response with CI failure cause."""
+    """Tests ejection response enrichment with CI failure cause."""
 
     @pytest.mark.anyio
     async def test_ejected_ci_failure_when_checks_state_is_failure(self):
@@ -897,6 +897,39 @@ class TestEjectionEnrichment:
         result = await watcher.wait(
             pr_number=42, target_branch="main", repo="owner/repo", poll_interval=1
         )
+        assert result["success"] is False
+        assert result["pr_state"] == "ejected_ci_failure"
+        assert result.get("ejection_cause") == "ci_failure"
+
+    @pytest.mark.anyio
+    async def test_ejected_ci_failure_after_in_queue_to_not_in_queue_transition(self):
+        """in_queue=True on first poll, then in_queue=False+FAILURE → ejected_ci_failure."""
+        watcher = _make_watcher()
+        watcher._fetch_pr_and_queue_state = AsyncMock(  # type: ignore[method-assign]
+            side_effect=[
+                _queue_state(in_queue=True, checks_state=None),
+                _queue_state(
+                    in_queue=False,
+                    checks_state="FAILURE",
+                    merge_state_status="BLOCKED",
+                    auto_merge_enabled_at=None,
+                ),
+                _queue_state(
+                    in_queue=False,
+                    checks_state="FAILURE",
+                    merge_state_status="BLOCKED",
+                    auto_merge_enabled_at=None,
+                ),
+            ]
+        )
+        with patch("autoskillit.execution.merge_queue.asyncio.sleep", new_callable=AsyncMock):
+            result = await watcher.wait(
+                pr_number=42,
+                target_branch="main",
+                repo="owner/repo",
+                poll_interval=1,
+                not_in_queue_confirmation_cycles=2,
+            )
         assert result["success"] is False
         assert result["pr_state"] == "ejected_ci_failure"
         assert result.get("ejection_cause") == "ci_failure"

--- a/tests/execution/test_merge_queue.py
+++ b/tests/execution/test_merge_queue.py
@@ -803,3 +803,100 @@ class TestRelatedCoverage:
         assert result["success"] is False
         assert result["pr_state"] == "error"
         assert "Invalid repo format" in result["reason"]
+
+
+class TestEjectionEnrichment:
+    """Tests for Gap 2: enriched ejection response with CI failure cause."""
+
+    @pytest.mark.anyio
+    async def test_ejected_ci_failure_when_checks_state_is_failure(self):
+        """When checks_state=FAILURE, wait() returns pr_state='ejected_ci_failure'."""
+        watcher = _make_watcher()
+        watcher._fetch_pr_and_queue_state = AsyncMock(  # type: ignore[method-assign]
+            return_value=_queue_state(
+                merged=False,
+                in_queue=False,
+                checks_state="FAILURE",
+                merge_state_status="BLOCKED",
+                auto_merge_enabled_at=None,
+            )
+        )
+        with patch("autoskillit.execution.merge_queue.asyncio.sleep", new_callable=AsyncMock):
+            result = await watcher.wait(
+                pr_number=42,
+                target_branch="main",
+                repo="owner/repo",
+                poll_interval=1,
+                not_in_queue_confirmation_cycles=2,
+            )
+        assert result["success"] is False
+        assert result["pr_state"] == "ejected_ci_failure"
+        assert result.get("ejection_cause") == "ci_failure"
+
+    @pytest.mark.anyio
+    async def test_ejected_when_checks_state_is_none(self):
+        """When checks_state=None at ejection, pr_state='ejected' with no ejection_cause."""
+        watcher = _make_watcher()
+        watcher._fetch_pr_and_queue_state = AsyncMock(  # type: ignore[method-assign]
+            return_value=_queue_state(
+                merged=False,
+                in_queue=False,
+                checks_state=None,
+                merge_state_status="BLOCKED",
+                auto_merge_enabled_at=None,
+            )
+        )
+        with patch("autoskillit.execution.merge_queue.asyncio.sleep", new_callable=AsyncMock):
+            result = await watcher.wait(
+                pr_number=42,
+                target_branch="main",
+                repo="owner/repo",
+                poll_interval=1,
+                not_in_queue_confirmation_cycles=2,
+            )
+        assert result["success"] is False
+        assert result["pr_state"] == "ejected"
+        assert "ejection_cause" not in result
+
+    @pytest.mark.anyio
+    async def test_ejected_when_checks_state_is_success(self):
+        """When checks_state=SUCCESS at ejection, pr_state='ejected' (no enrichment)."""
+        watcher = _make_watcher()
+        watcher._fetch_pr_and_queue_state = AsyncMock(  # type: ignore[method-assign]
+            return_value=_queue_state(
+                merged=False,
+                in_queue=False,
+                checks_state="SUCCESS",
+                merge_state_status="BLOCKED",
+                auto_merge_enabled_at=None,
+            )
+        )
+        with patch("autoskillit.execution.merge_queue.asyncio.sleep", new_callable=AsyncMock):
+            result = await watcher.wait(
+                pr_number=42,
+                target_branch="main",
+                repo="owner/repo",
+                poll_interval=1,
+                not_in_queue_confirmation_cycles=2,
+            )
+        assert result["success"] is False
+        assert result["pr_state"] == "ejected"
+        assert "ejection_cause" not in result
+
+    @pytest.mark.anyio
+    async def test_ejected_ci_failure_on_closed_pr_with_failure_checks(self):
+        """CLOSED state with checks_state=FAILURE → ejected_ci_failure."""
+        watcher = _make_watcher()
+        watcher._fetch_pr_and_queue_state = AsyncMock(  # type: ignore[method-assign]
+            return_value=_queue_state(
+                state="CLOSED",
+                merged=False,
+                checks_state="FAILURE",
+            )
+        )
+        result = await watcher.wait(
+            pr_number=42, target_branch="main", repo="owner/repo", poll_interval=1
+        )
+        assert result["success"] is False
+        assert result["pr_state"] == "ejected_ci_failure"
+        assert result.get("ejection_cause") == "ci_failure"

--- a/tests/recipe/test_merge_prs_queue.py
+++ b/tests/recipe/test_merge_prs_queue.py
@@ -790,6 +790,9 @@ def test_re_push_queue_fix_routes_to_ci_watch_post_queue_fix(recipe_fixture, req
 def test_ci_watch_post_queue_fix_routes_reenter_on_success(recipe_fixture, request):
     """ci_watch_post_queue_fix.on_success must route to reenter_merge_queue."""
     recipe = request.getfixturevalue(recipe_fixture)
+    assert "ci_watch_post_queue_fix" in recipe.steps, (
+        f"ci_watch_post_queue_fix must be a step in {recipe_fixture}"
+    )
     step = recipe.steps["ci_watch_post_queue_fix"]
     assert step.on_success == "reenter_merge_queue", (
         f"ci_watch_post_queue_fix.on_success must be 'reenter_merge_queue' in {recipe_fixture}"
@@ -800,6 +803,9 @@ def test_ci_watch_post_queue_fix_routes_reenter_on_success(recipe_fixture, reque
 def test_ci_watch_post_queue_fix_routes_detect_ci_conflict_on_failure(recipe_fixture, request):
     """ci_watch_post_queue_fix.on_failure must route to detect_ci_conflict."""
     recipe = request.getfixturevalue(recipe_fixture)
+    assert "ci_watch_post_queue_fix" in recipe.steps, (
+        f"ci_watch_post_queue_fix must be a step in {recipe_fixture}"
+    )
     step = recipe.steps["ci_watch_post_queue_fix"]
     assert step.on_failure == "detect_ci_conflict", (
         f"ci_watch_post_queue_fix.on_failure must be 'detect_ci_conflict' in {recipe_fixture}"
@@ -810,6 +816,9 @@ def test_ci_watch_post_queue_fix_routes_detect_ci_conflict_on_failure(recipe_fix
 def test_ci_watch_post_queue_fix_uses_wait_for_ci_tool(recipe_fixture, request):
     """ci_watch_post_queue_fix must use the wait_for_ci tool."""
     recipe = request.getfixturevalue(recipe_fixture)
+    assert "ci_watch_post_queue_fix" in recipe.steps, (
+        f"ci_watch_post_queue_fix must be a step in {recipe_fixture}"
+    )
     step = recipe.steps["ci_watch_post_queue_fix"]
     assert step.tool == "wait_for_ci"
 
@@ -818,6 +827,9 @@ def test_ci_watch_post_queue_fix_uses_wait_for_ci_tool(recipe_fixture, request):
 def test_ci_watch_post_queue_fix_has_skip_when_false(recipe_fixture, request):
     """ci_watch_post_queue_fix must have skip_when_false: inputs.open_pr."""
     recipe = request.getfixturevalue(recipe_fixture)
+    assert "ci_watch_post_queue_fix" in recipe.steps, (
+        f"ci_watch_post_queue_fix must be a step in {recipe_fixture}"
+    )
     step = recipe.steps["ci_watch_post_queue_fix"]
     assert step.skip_when_false == "inputs.open_pr"
 

--- a/tests/recipe/test_merge_prs_queue.py
+++ b/tests/recipe/test_merge_prs_queue.py
@@ -757,3 +757,104 @@ def test_remediation_recipe_still_valid(remed_recipe) -> None:
 def test_impl_groups_recipe_still_valid(impl_groups_recipe) -> None:
     errors = validate_recipe(impl_groups_recipe)
     assert errors == [], f"validate_recipe errors: {errors}"
+
+
+# ---------------------------------------------------------------------------
+# Gap 1 + Gap 6: ci_watch_post_queue_fix step + ejected_ci_failure routing
+# (applies to all three recipes)
+# ---------------------------------------------------------------------------
+
+QUEUE_RECIPES = ["impl_recipe", "remed_recipe", "impl_groups_recipe"]
+
+
+@pytest.mark.parametrize("recipe_fixture", QUEUE_RECIPES)
+def test_ci_watch_post_queue_fix_exists(recipe_fixture, request):
+    """ci_watch_post_queue_fix step must exist in all three queue-capable recipes."""
+    recipe = request.getfixturevalue(recipe_fixture)
+    assert "ci_watch_post_queue_fix" in recipe.steps, (
+        f"ci_watch_post_queue_fix must be a step in {recipe_fixture}"
+    )
+
+
+@pytest.mark.parametrize("recipe_fixture", QUEUE_RECIPES)
+def test_re_push_queue_fix_routes_to_ci_watch_post_queue_fix(recipe_fixture, request):
+    """re_push_queue_fix.on_success must route to ci_watch_post_queue_fix."""
+    recipe = request.getfixturevalue(recipe_fixture)
+    step = recipe.steps["re_push_queue_fix"]
+    assert step.on_success == "ci_watch_post_queue_fix", (
+        f"re_push_queue_fix.on_success must be 'ci_watch_post_queue_fix' in {recipe_fixture}"
+    )
+
+
+@pytest.mark.parametrize("recipe_fixture", QUEUE_RECIPES)
+def test_ci_watch_post_queue_fix_routes_reenter_on_success(recipe_fixture, request):
+    """ci_watch_post_queue_fix.on_success must route to reenter_merge_queue."""
+    recipe = request.getfixturevalue(recipe_fixture)
+    step = recipe.steps["ci_watch_post_queue_fix"]
+    assert step.on_success == "reenter_merge_queue", (
+        f"ci_watch_post_queue_fix.on_success must be 'reenter_merge_queue' in {recipe_fixture}"
+    )
+
+
+@pytest.mark.parametrize("recipe_fixture", QUEUE_RECIPES)
+def test_ci_watch_post_queue_fix_routes_detect_ci_conflict_on_failure(recipe_fixture, request):
+    """ci_watch_post_queue_fix.on_failure must route to detect_ci_conflict."""
+    recipe = request.getfixturevalue(recipe_fixture)
+    step = recipe.steps["ci_watch_post_queue_fix"]
+    assert step.on_failure == "detect_ci_conflict", (
+        f"ci_watch_post_queue_fix.on_failure must be 'detect_ci_conflict' in {recipe_fixture}"
+    )
+
+
+@pytest.mark.parametrize("recipe_fixture", QUEUE_RECIPES)
+def test_ci_watch_post_queue_fix_uses_wait_for_ci_tool(recipe_fixture, request):
+    """ci_watch_post_queue_fix must use the wait_for_ci tool."""
+    recipe = request.getfixturevalue(recipe_fixture)
+    step = recipe.steps["ci_watch_post_queue_fix"]
+    assert step.tool == "wait_for_ci"
+
+
+@pytest.mark.parametrize("recipe_fixture", QUEUE_RECIPES)
+def test_ci_watch_post_queue_fix_has_skip_when_false(recipe_fixture, request):
+    """ci_watch_post_queue_fix must have skip_when_false: inputs.open_pr."""
+    recipe = request.getfixturevalue(recipe_fixture)
+    step = recipe.steps["ci_watch_post_queue_fix"]
+    assert step.skip_when_false == "inputs.open_pr"
+
+
+@pytest.mark.parametrize("recipe_fixture", QUEUE_RECIPES)
+def test_wait_for_queue_routes_ejected_ci_failure_to_diagnose_ci(recipe_fixture, request):
+    """wait_for_queue.on_result must route ejected_ci_failure to diagnose_ci."""
+    recipe = request.getfixturevalue(recipe_fixture)
+    step = recipe.steps["wait_for_queue"]
+    assert step.on_result is not None, "wait_for_queue must have on_result"
+    conditions = step.on_result.conditions
+    ci_failure_routes = [
+        c
+        for c in conditions
+        if c.when is not None and "ejected_ci_failure" in c.when and c.route == "diagnose_ci"
+    ]
+    assert ci_failure_routes, (
+        f"wait_for_queue.on_result must route ejected_ci_failure to diagnose_ci"
+        f" in {recipe_fixture}"
+    )
+
+
+@pytest.mark.parametrize("recipe_fixture", QUEUE_RECIPES)
+def test_wait_for_queue_ejected_ci_failure_precedes_ejected(recipe_fixture, request):
+    """ejected_ci_failure route must precede generic ejected in wait_for_queue.on_result."""
+    recipe = request.getfixturevalue(recipe_fixture)
+    step = recipe.steps["wait_for_queue"]
+    assert step.on_result is not None, "wait_for_queue must have on_result"
+    conditions = step.on_result.conditions
+    whens = [c.when or "" for c in conditions]
+    ci_fail_idx = next((i for i, w in enumerate(whens) if "ejected_ci_failure" in w), None)
+    ejected_idx = next(
+        (i for i, w in enumerate(whens) if w.strip() == "${{ result.pr_state }} == ejected"), None
+    )
+    assert ci_fail_idx is not None, "ejected_ci_failure route must exist"
+    assert ejected_idx is not None, "ejected route must still exist"
+    assert ci_fail_idx < ejected_idx, (
+        "ejected_ci_failure route must appear before generic ejected route "
+        "to prevent CI failure ejections from being handled as conflict ejections"
+    )

--- a/tests/server/test_tools_ci.py
+++ b/tests/server/test_tools_ci.py
@@ -578,4 +578,55 @@ async def test_wait_for_merge_queue_watcher_exception_returns_structured_json(to
     assert result["success"] is False
     assert "connection refused" in result["error"]
     assert "subtype" not in result
+
+
+# ---------------------------------------------------------------------------
+# wait_for_ci head_sha enrichment (Gap 5)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_wait_for_ci_includes_head_sha_in_result(tool_ctx):
+    """wait_for_ci result includes head_sha when git rev-parse HEAD succeeds."""
+    mock_watcher = AsyncMock()
+    mock_watcher.wait = AsyncMock(
+        return_value={"run_id": 1, "conclusion": "success", "failed_jobs": []}
+    )
+    tool_ctx.ci_watcher = mock_watcher
+    tool_ctx.runner.push(
+        SubprocessResult(
+            returncode=0,
+            stdout="deadbeef1234\n",
+            stderr="",
+            termination=TerminationReason.NATURAL_EXIT,
+            pid=0,
+        )
+    )
+
+    result = json.loads(await wait_for_ci("main", cwd="/some/repo"))
+
+    assert result["head_sha"] == "deadbeef1234"
+
+
+@pytest.mark.anyio
+async def test_wait_for_ci_omits_head_sha_when_git_fails(tool_ctx):
+    """wait_for_ci result omits head_sha when git rev-parse fails."""
+    mock_watcher = AsyncMock()
+    mock_watcher.wait = AsyncMock(
+        return_value={"run_id": 1, "conclusion": "success", "failed_jobs": []}
+    )
+    tool_ctx.ci_watcher = mock_watcher
+    tool_ctx.runner.push(
+        SubprocessResult(
+            returncode=128,
+            stdout="",
+            stderr="fatal: not a git repository",
+            termination=TerminationReason.NATURAL_EXIT,
+            pid=0,
+        )
+    )
+
+    result = json.loads(await wait_for_ci("main", cwd="/some/repo"))
+
+    assert "head_sha" not in result
     assert "exit_code" not in result

--- a/tests/skills/test_conflict_resolution_guards.py
+++ b/tests/skills/test_conflict_resolution_guards.py
@@ -379,6 +379,54 @@ def test_resolve_merge_conflicts_remote_variable_is_defined(skill_md: str) -> No
     )
 
 
+def test_resolve_merge_conflicts_has_manifest_validation_step(skill_md: str) -> None:
+    """SKILL.md must document language-aware manifest validation after pre-commit (Step 5a)."""
+    assert "cargo metadata" in skill_md or "manifest validation" in skill_md.lower(), (
+        "resolve-merge-conflicts SKILL.md must include language-aware manifest validation "
+        "(Step 5a) covering at minimum 'cargo metadata --no-deps' for Rust projects"
+    )
+    assert "Step 5a" in skill_md, "Manifest validation must be documented as Step 5a in SKILL.md"
+
+
+def test_resolve_merge_conflicts_has_duplicate_key_scan(skill_md: str) -> None:
+    """SKILL.md must document duplicate key scanning in TOML/JSON manifests (Step 5b)."""
+    assert "Step 5b" in skill_md, (
+        "Duplicate key scanning must be documented as Step 5b in SKILL.md"
+    )
+    assert "duplicate" in skill_md.lower(), (
+        "SKILL.md must use the word 'duplicate' to describe the key scan"
+    )
+
+
+def test_resolve_merge_conflicts_manifest_failure_escalates(skill_md: str) -> None:
+    """SKILL.md must escalate (not auto-fix) when manifest validation fails."""
+    step_5a_idx = skill_md.find("Step 5a")
+    step_5b_idx = skill_md.find("Step 5b", step_5a_idx)
+    step_5a_section = (
+        skill_md[step_5a_idx:step_5b_idx] if step_5b_idx != -1 else skill_md[step_5a_idx:]
+    )
+    assert "escalation_required" in step_5a_section, (
+        "Step 5a must escalate (emit escalation_required=true) on manifest validation failure; "
+        "auto-fixing broken manifests is out of scope for this skill"
+    )
+
+
+def test_resolve_merge_conflicts_manifest_validation_covers_rust(skill_md: str) -> None:
+    """SKILL.md manifest validation must cover Rust (cargo metadata --no-deps)."""
+    assert "cargo metadata" in skill_md, (
+        "resolve-merge-conflicts Step 5a must include 'cargo metadata --no-deps' "
+        "as the Rust manifest validation command — this is a fast parse-only check (<1s)"
+    )
+
+
+def test_resolve_merge_conflicts_manifest_validation_covers_python(skill_md: str) -> None:
+    """SKILL.md manifest validation must cover Python (tomllib or uv lock --check)."""
+    assert "tomllib" in skill_md or "uv lock --check" in skill_md, (
+        "resolve-merge-conflicts Step 5a must include Python manifest validation "
+        "via tomllib.load() or 'uv lock --check'"
+    )
+
+
 def test_resolve_merge_conflicts_no_hardcoded_origin(skill_md: str) -> None:
     """SKILL.md must not use literal 'origin' as remote in git fetch/rebase/show/log/rev-parse."""
     bash_blocks = re.findall(r"```bash\s*\n(.*?)```", skill_md, re.DOTALL)


### PR DESCRIPTION
## Summary

Fixes a 3-iteration ejection loop in the merge queue pipeline by introducing ejection-cause enrichment (`ejected_ci_failure` state and `ejection_cause` field in `wait_for_merge_queue`), a CI gate after every force-push (`ci_watch_post_queue_fix` step), and two post-rebase manifest validation gates (language-aware validity check and duplicate key scan) in `resolve-merge-conflicts`. Closes all six gaps identified in #627: blind CI ejection routing, missing CI gate after re-push, absent manifest/semantic validation, and missing `head_sha` in CI results.

<details>
<summary>Individual Group Plans</summary>

### Group 1: Implementation Plan: Queue Ejection Loop Fix — PART A ONLY

This part addresses the Python code layer for the queue ejection loop fix (Gaps 2 and 5 from issue #627).

**Gap 2** — `execution/merge_queue.py` currently returns `pr_state="ejected"` for every ejection regardless of cause. When GitHub's CI fails on a merge-group commit, the recipe cannot distinguish a CI failure ejection from a conflict ejection, so it retries conflict resolution indefinitely (no-op rebase loop). The fix: when the ejection is confirmed and `checks_state == "FAILURE"`, return `pr_state="ejected_ci_failure"` plus an `ejection_cause="ci_failure"` field, allowing recipe `on_result` routing to send CI failures directly to `diagnose_ci` instead of `queue_ejected_fix`.

**Gap 5** — `server/tools_ci.py` infers `head_sha` from `git rev-parse HEAD` but never includes it in the JSON response. Recipe orchestrators cannot verify that CI results correspond to the current HEAD after a force-push. The fix: include `head_sha` in the `wait_for_ci` return dict when it was resolved.

### Group 2: Implementation Plan: Queue Ejection Loop Fix — PART B ONLY

This part addresses the recipe and skill layer of the queue ejection loop fix (Gaps 1, 3, 4, 6 from issue #627). Part A (code layer) must be implemented first — this part routes on `pr_state="ejected_ci_failure"` which Part A introduces.

**Gap 1** — `re_push_queue_fix` routes directly to `reenter_merge_queue` after force-push, bypassing CI. Fix: insert a new `ci_watch_post_queue_fix` step between `re_push_queue_fix` and `reenter_merge_queue`, mirroring the existing `ci_watch` step.

**Gap 6** — `wait_for_queue` routes all `ejected` states to `queue_ejected_fix` (conflict resolution), even when the ejection was caused by a CI failure that conflict resolution cannot fix. Fix: add an `ejected_ci_failure` route before `ejected` in `wait_for_queue.on_result`, routing to `diagnose_ci` instead.

**Gap 3** — `resolve-merge-conflicts` SKILL.md runs only `pre-commit run --all-files` post-rebase. Fix: add Step 5a — language-detected manifest validation using fast non-compiling checks.

**Gap 4** — Even a clean rebase can produce duplicate keys when both branches independently added the same dependency. Fix: add Step 5b — targeted duplicate key scan in TOML/JSON manifest files.

Applied to: `recipes/implementation.yaml`, `recipes/remediation.yaml`, `recipes/implementation-groups.yaml`, `skills_extended/resolve-merge-conflicts/SKILL.md`.

</details>

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([wait_for_queue\nrecipe step])
    END_OK([release_issue_success])
    END_FAIL([release_issue_failure])
    END_TIMEOUT([release_issue_timeout])
    END_DIAG([diagnose_ci])

    subgraph MQPoll ["● Merge Queue Watcher (merge_queue.py)"]
        direction TB
        POLL["poll GitHub GraphQL\n━━━━━━━━━━\nPR state + queue state\n+ checks_state"]
        MERGED{"merged?"}
        CI_FAIL{"● checks_state\n== 'FAILURE'?"}
        CONFIRM["confirmation window\n━━━━━━━━━━\nnot_in_queue_cycles++"]
        CONFIRMED{"cycles ≥ threshold?"}
        STALL{"stall retries\nexhausted?"}
        TIMEOUT{"deadline\nexceeded?"}
    end

    subgraph EjectRoute ["● Recipe Ejection Routing (implementation.yaml)"]
        direction TB
        ROUTE{"● pr_state?"}
        REENROLL["reenroll_stalled_pr\n━━━━━━━━━━\ntoggle_auto_merge tool"]
    end

    subgraph ConflictFix ["● Conflict Fix Sub-Flow (implementation.yaml)"]
        direction TB
        QFIX["queue_ejected_fix\n━━━━━━━━━━\nresolve-merge-conflicts skill"]
        ESC{"escalation_required?"}
        REPUSH["re_push_queue_fix\n━━━━━━━━━━\npush_to_remote force=true"]
        CI_WATCH["● ci_watch_post_queue_fix\n━━━━━━━━━━\nwait_for_ci tool\ntimeout=300s"]
        CI_PASS{"CI pass?"}
        DETECT["detect_ci_conflict\n━━━━━━━━━━\ndiagnose-ci skill"]
        REENTER["reenter_merge_queue\n━━━━━━━━━━\ngh pr merge --squash --auto"]
    end

    subgraph WFCITool ["● wait_for_ci tool handler (tools_ci.py)"]
        direction LR
        INFER["infer head_sha\n━━━━━━━━━━\ngit rev-parse HEAD"]
        CIWAIT["ci_watcher.wait(scope)"]
        ENRICH["● result includes head_sha\n━━━━━━━━━━\nverifies SHA matches HEAD\nafter force-push"]
    end

    %% MAIN FLOW %%
    START --> POLL
    POLL --> MERGED
    MERGED -->|"yes"| END_OK
    MERGED -->|"no"| CONFIRM
    CONFIRM --> CONFIRMED
    CONFIRMED -->|"no"| STALL
    CONFIRMED -->|"yes (not in queue)"| CI_FAIL
    STALL -->|"yes"| END_TIMEOUT
    STALL -->|"no"| TIMEOUT
    TIMEOUT -->|"yes"| END_TIMEOUT
    TIMEOUT -->|"no"| POLL

    CI_FAIL -->|"yes"| ROUTE
    CI_FAIL -->|"no"| ROUTE

    ROUTE -->|"ejected_ci_failure\n(● new route)"| END_DIAG
    ROUTE -->|"ejected"| QFIX
    ROUTE -->|"stalled"| REENROLL
    ROUTE -->|"timeout"| END_TIMEOUT
    REENROLL -->|"success"| START
    REENROLL -->|"failure"| END_FAIL

    QFIX --> ESC
    ESC -->|"true"| END_FAIL
    ESC -->|"false"| REPUSH
    REPUSH -->|"failure"| END_FAIL
    REPUSH -->|"success"| CI_WATCH

    CI_WATCH --> INFER --> CIWAIT --> ENRICH
    ENRICH --> CI_PASS
    CI_PASS -->|"failure"| DETECT
    CI_PASS -->|"success"| REENTER
    DETECT --> END_FAIL
    REENTER -->|"success"| START
    REENTER -->|"failure"| END_FAIL

    %% CLASS ASSIGNMENTS %%
    class START terminal;
    class END_OK,END_FAIL,END_TIMEOUT,END_DIAG terminal;
    class POLL,CONFIRM handler;
    class MERGED,CONFIRMED,STALL,TIMEOUT stateNode;
    class CI_FAIL,ROUTE,ESC,CI_PASS detector;
    class QFIX,REPUSH,REENTER handler;
    class REENROLL,DETECT handler;
    class CI_WATCH,INFER,CIWAIT,ENRICH newComponent;
```

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;

    subgraph MQResult ["wait_for_merge_queue Return Dict (merge_queue.py)"]
        direction TB
        PS["● pr_state : str\n━━━━━━━━━━\nmerged | ejected\nejected_ci_failure | stalled\ntimeout | error\n(bare literals, no StrEnum)"]
        SUC["success : bool\n━━━━━━━━━━\ntrue only for 'merged'"]
        REASON["reason : str\n━━━━━━━━━━\nhuman-readable\nalways present"]
        STALL["stall_retries_attempted : int\n━━━━━━━━━━\nalways present\nexcept 'error' path"]
        EC["● ejection_cause : str\n━━━━━━━━━━\n'ci_failure' only\nwhen pr_state==ejected_ci_failure\nCONDITIONAL FIELD"]
    end

    subgraph InternalPoll ["PRFetchState — Internal Polling State (not returned)"]
        direction LR
        CHECKS["checks_state : str|None\n━━━━━━━━━━\nGitHub StatusCheckRollup\nNone = no checks configured"]
        INQUEUE["in_queue : bool\n━━━━━━━━━━\nPR in mergeQueue.entries"]
        QSTATE["queue_state : str|None\n━━━━━━━━━━\nUNMERGEABLE | AWAITING_CHECKS\n| LOCKED | null"]
    end

    subgraph Gate1 ["● Ejection Decision Gate (merge_queue.py)"]
        direction TB
        CFAIL{"checks_state\n== 'FAILURE'?"}
        SET_ECI["● set pr_state='ejected_ci_failure'\n━━━━━━━━━━\nejection_cause='ci_failure'\nINJECTED into result"]
        SET_EJ["set pr_state='ejected'\n━━━━━━━━━━\nno ejection_cause field\n(absent, not null)"]
    end

    subgraph CIScope ["CIRunScope — Frozen Input Scope (core/types)"]
        direction LR
        WF["workflow : str|None\n━━━━━━━━━━\ne.g. 'tests.yml'"]
        HS["● head_sha : str|None\n━━━━━━━━━━\ngit rev-parse HEAD\nor caller-supplied"]
    end

    subgraph CIResult ["● wait_for_ci Return Dict (tools_ci.py)"]
        direction TB
        RUNID["run_id : int|None\n━━━━━━━━━━\nGitHub Actions run ID"]
        CONC["conclusion : str\n━━━━━━━━━━\nsuccess|failure|cancelled\naction_required|timed_out\nno_runs|error|unknown"]
        FJOBS["failed_jobs : list\n━━━━━━━━━━\nalways present\nempty on billing errors"]
        HSHA["● head_sha : str\n━━━━━━━━━━\nCONDITIONAL: present only\nwhen scope.head_sha truthy\ninjected by tool layer"]
    end

    subgraph ConsumerGate ["Recipe Routing Gate (on_result)"]
        direction TB
        ROUTE{"pr_state value?"}
        R1["ejected_ci_failure\n→ diagnose_ci"]
        R2["ejected\n→ queue_ejected_fix"]
        R3["merged|stalled|timeout\n→ other routes"]
    end

    %% FLOW %%
    CHECKS --> CFAIL
    INQUEUE --> CFAIL
    QSTATE --> CFAIL
    CFAIL -->|"FAILURE"| SET_ECI
    CFAIL -->|"other"| SET_EJ
    SET_ECI --> PS
    SET_ECI --> EC
    SET_EJ --> PS
    PS --> SUC
    PS --> REASON
    PS --> STALL

    HS --> CIResult
    WF --> CIResult
    RUNID --> CONC
    CONC --> FJOBS
    FJOBS --> HSHA

    PS --> ROUTE
    EC --> ROUTE
    ROUTE --> R1
    ROUTE --> R2
    ROUTE --> R3

    HSHA -.->|"verifies HEAD\nafter force-push"| R2

    %% CLASS ASSIGNMENTS %%
    class PS,EC,HSHA,SET_ECI,HS,CFAIL gap;
    class SUC,REASON,STALL,RUNID,CONC,FJOBS output;
    class CHECKS,INQUEUE,QSTATE,WF stateNode;
    class SET_EJ handler;
    class ROUTE,R1,R2,R3 detector;
    class InternalPoll phase;
```

### Error/Resilience Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;

    END_OK([release_issue_success])
    END_FAIL([release_issue_failure\n━━━━━━━━━━\nhuman escalation\nclone preserved])
    END_DIAG([diagnose_ci])

    subgraph MQLoop ["● Merge Queue Poll Loop (merge_queue.py)"]
        direction TB
        POLL["GraphQL fetch\n━━━━━━━━━━\nPR + queue state"]
        POLL_ERR{"Exception\ncaught?"}
        TIMEOUT_CHK{"deadline\nexceeded?"}
        STALL_CHK{"stall retries\n≥ max (3)?"}
    end

    subgraph EjectGate ["● Ejection Classification Gate (merge_queue.py)"]
        direction TB
        EJECT_DECISION{"● checks_state\n== 'FAILURE'?"}
        CI_EJ["● ejected_ci_failure\n━━━━━━━━━━\nejection_cause=ci_failure\nskips conflict resolution"]
        CONF_EJ["ejected\n━━━━━━━━━━\nno cause field\nconflict resolution"]
    end

    subgraph StallBreaker ["Stall Circuit Breaker (merge_queue.py)"]
        direction LR
        TOGGLE["_toggle_auto_merge\n━━━━━━━━━━\ndisable → 2s → re-enable\nbackoff: 30/60/120s"]
        TOGGLE_ERR{"Exception\ncaught?"}
    end

    subgraph ConflictPath ["Conflict Resolution Path (implementation.yaml)"]
        direction TB
        QFIX["queue_ejected_fix\n━━━━━━━━━━\nresolve-merge-conflicts skill"]
        ESC_CHK{"escalation\nrequired?"}
        REPUSH["re_push_queue_fix\n━━━━━━━━━━\nforce-push"]
        REPUSH_FAIL{"push\nfailed?"}
    end

    subgraph CIGate ["● CI Gate After Re-Push (implementation.yaml + tools_ci.py)"]
        direction TB
        CI_WATCH["● ci_watch_post_queue_fix\n━━━━━━━━━━\nwait_for_ci, timeout=300s\nincludes head_sha"]
        CI_CONC{"conclusion\n== success?"}
        DETECT["detect_ci_conflict\n━━━━━━━━━━\ngit merge-base check\n(stale base?)"]
        DETECT_CHK{"stale\nbase?"}
        CI_CF["ci_conflict_fix\n━━━━━━━━━━\nresolve-merge-conflicts"]
    end

    subgraph ManifestGates ["● Post-Rebase Manifest Validation (SKILL.md)"]
        direction TB
        STEP5A["● Step 5a: manifest validity\n━━━━━━━━━━\ncargo metadata / node JSON.parse\nuv lock --check / tomllib"]
        STEP5A_CHK{"manifest\nvalid?"}
        STEP5B["● Step 5b: duplicate key scan\n━━━━━━━━━━\nTOML dep sections\nJSON object_pairs_hook"]
        STEP5B_CHK{"duplicates\nfound?"}
        REBASE_ABORT["git rebase --abort\n━━━━━━━━━━\nescalation_required=true"]
    end

    %% POLL LOOP FLOW %%
    POLL --> POLL_ERR
    POLL_ERR -->|"yes: log + retry"| POLL
    POLL_ERR -->|"no"| TIMEOUT_CHK
    TIMEOUT_CHK -->|"yes"| END_FAIL
    TIMEOUT_CHK -->|"no"| STALL_CHK
    STALL_CHK -->|"yes: stalled"| END_FAIL
    STALL_CHK -->|"no: stall attempt"| TOGGLE
    TOGGLE --> TOGGLE_ERR
    TOGGLE_ERR -->|"yes: log + increment"| STALL_CHK
    TOGGLE_ERR -->|"no: success"| POLL

    %% EJECTION GATE %%
    STALL_CHK -->|"ejection confirmed"| EJECT_DECISION
    EJECT_DECISION -->|"FAILURE"| CI_EJ
    EJECT_DECISION -->|"other"| CONF_EJ
    CI_EJ --> END_DIAG
    CONF_EJ --> QFIX

    %% CONFLICT PATH %%
    QFIX --> STEP5A
    STEP5A --> STEP5A_CHK
    STEP5A_CHK -->|"invalid"| REBASE_ABORT
    STEP5A_CHK -->|"valid"| STEP5B
    STEP5B --> STEP5B_CHK
    STEP5B_CHK -->|"duplicates"| REBASE_ABORT
    STEP5B_CHK -->|"clean"| ESC_CHK
    REBASE_ABORT --> ESC_CHK
    ESC_CHK -->|"true"| END_FAIL
    ESC_CHK -->|"false"| REPUSH
    REPUSH --> REPUSH_FAIL
    REPUSH_FAIL -->|"yes"| END_FAIL
    REPUSH_FAIL -->|"no"| CI_WATCH

    %% CI GATE %%
    CI_WATCH --> CI_CONC
    CI_CONC -->|"yes"| END_OK
    CI_CONC -->|"no"| DETECT
    DETECT --> DETECT_CHK
    DETECT_CHK -->|"yes: stale base"| CI_CF
    DETECT_CHK -->|"no: code failure"| END_DIAG
    CI_CF --> ESC_CHK

    %% CLASS ASSIGNMENTS %%
    class END_OK,END_FAIL,END_DIAG terminal;
    class POLL,TOGGLE handler;
    class POLL_ERR,TOGGLE_ERR,TIMEOUT_CHK,STALL_CHK gap;
    class EJECT_DECISION,CI_CONC,DETECT_CHK,STEP5A_CHK,STEP5B_CHK,ESC_CHK,REPUSH_FAIL detector;
    class CI_EJ,CONF_EJ,REBASE_ABORT output;
    class QFIX,REPUSH,CI_WATCH,DETECT,CI_CF handler;
    class STEP5A,STEP5B phase;
```

Closes #627

## Implementation Plan

Plan files:
- `/home/talon/projects/autoskillit-runs/impl-20260405-122055-152199/.autoskillit/temp/make-plan/queue_ejection_loop_plan_2026-04-05_122055_part_a.md`
- `/home/talon/projects/autoskillit-runs/impl-20260405-122055-152199/.autoskillit/temp/make-plan/queue_ejection_loop_plan_2026-04-05_122055_part_b.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 37 | 31.7k | 1.9M | 113.2k | 1 | 11m 19s |
| review | 3.4k | 5.6k | 147.3k | 41.5k | 1 | 5m 45s |
| verify | 44 | 35.4k | 1.9M | 144.8k | 2 | 11m 15s |
| implement | 100 | 33.5k | 4.6M | 123.5k | 2 | 12m 17s |
| audit_impl | 15 | 14.0k | 279.5k | 44.2k | 1 | 3m 46s |
| open_pr | 33 | 30.5k | 1.2M | 68.1k | 1 | 10m 58s |
| **Total** | 3.6k | 150.8k | 9.9M | 535.3k | | 55m 23s |