### PR TITLE
Implementation Plan: Fix False Stale Kills During Long-Running Background Bash Tasks

### DIFF
--- a/src/autoskillit/execution/_process_monitor.py
+++ b/src/autoskillit/execution/_process_monitor.py
@@ -107,7 +107,7 @@ def _has_active_child_processes(pid: int) -> bool:
                     return True
             except (psutil.NoSuchProcess, psutil.ZombieProcess, psutil.AccessDenied):
                 continue
-    except psutil.NoSuchProcess:
+    except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
         pass
     return False
 

--- a/src/autoskillit/execution/_process_monitor.py
+++ b/src/autoskillit/execution/_process_monitor.py
@@ -87,6 +87,31 @@ def _has_active_api_connection(pid: int) -> bool:
     return False
 
 
+_CPU_ACTIVE_THRESHOLD: float = 10.0  # percent; evidence of actual computational work
+
+
+def _has_active_child_processes(pid: int) -> bool:
+    """Return True if any child process in the tree exceeds the CPU activity threshold.
+
+    Used by _session_log_monitor to suppress stale-kill when background Bash tasks
+    (launched via run_in_background: true) are actively running despite LLM/API being idle.
+
+    cpu_percent(interval=0) returns usage since the last call per-process; on repeated
+    stale-check cycles this reflects actual sustained activity, not momentary bursts.
+    """
+    try:
+        parent = psutil.Process(pid)
+        for child in parent.children(recursive=True):
+            try:
+                if child.cpu_percent(interval=0) > _CPU_ACTIVE_THRESHOLD:
+                    return True
+            except (psutil.NoSuchProcess, psutil.ZombieProcess, psutil.AccessDenied):
+                continue
+    except psutil.NoSuchProcess:
+        pass
+    return False
+
+
 async def _session_log_monitor(
     session_log_dir: Path,
     completion_marker: str,
@@ -226,6 +251,14 @@ async def _session_log_monitor(
                     last_change = _time.monotonic()
                     logger.warning(
                         "JSONL silent for %.0fs but ESTABLISHED port-443 connection — "
+                        "suppressing stale kill (pid=%d)",
+                        elapsed,
+                        pid,
+                    )
+                elif pid is not None and _has_active_child_processes(pid):
+                    last_change = _time.monotonic()
+                    logger.warning(
+                        "JSONL silent for %.0fs but child processes are CPU-active — "
                         "suppressing stale kill (pid=%d)",
                         elapsed,
                         pid,

--- a/src/autoskillit/execution/process.py
+++ b/src/autoskillit/execution/process.py
@@ -32,6 +32,7 @@ from autoskillit.execution._process_kill import (
 )
 from autoskillit.execution._process_monitor import (
     _has_active_api_connection,
+    _has_active_child_processes,
     _heartbeat,
     _session_log_monitor,
 )
@@ -62,6 +63,7 @@ __all__ = [
     "RaceAccumulator",
     "RaceSignals",
     "_has_active_api_connection",
+    "_has_active_child_processes",
     "_heartbeat",
     "_jsonl_contains_marker",
     "_jsonl_has_record_type",

--- a/src/autoskillit/recipe/io.py
+++ b/src/autoskillit/recipe/io.py
@@ -124,6 +124,7 @@ _PARSE_STEP_HANDLED_FIELDS: frozenset[str] = frozenset(
         "sub_recipe",
         "gate",
         "optional_context_refs",
+        "stale_threshold",
     }
 )
 if _PARSE_STEP_HANDLED_FIELDS != frozenset(RecipeStep.__dataclass_fields__):
@@ -229,6 +230,7 @@ def _parse_step(data: dict[str, Any]) -> RecipeStep:
         sub_recipe=data.get("sub_recipe"),
         gate=data.get("gate"),
         optional_context_refs=data.get("optional_context_refs", []),
+        stale_threshold=data.get("stale_threshold"),
     )
 
 

--- a/src/autoskillit/recipe/rules_tools.py
+++ b/src/autoskillit/recipe/rules_tools.py
@@ -12,7 +12,9 @@ _ALL_TOOLS: frozenset[str] = GATED_TOOLS | UNGATED_TOOLS | HEADLESS_TOOLS
 # Intentionally hardcoded — recipe validation runs without a live MCP server.
 _TOOL_PARAMS: dict[str, frozenset[str]] = {
     # --- Execution tools ---
-    "run_skill": frozenset({"skill_command", "cwd", "model", "step_name", "order_id"}),
+    "run_skill": frozenset(
+        {"skill_command", "cwd", "model", "step_name", "order_id", "stale_threshold"}
+    ),
     "run_cmd": frozenset({"cmd", "cwd", "timeout", "step_name"}),
     "run_python": frozenset({"callable", "args", "timeout"}),
     # --- Workspace tools ---

--- a/src/autoskillit/recipe/schema.py
+++ b/src/autoskillit/recipe/schema.py
@@ -88,6 +88,7 @@ class RecipeStep:
     optional_context_refs: list[str] = field(
         default_factory=list
     )  # Context variable names that may be referenced before they are captured (cyclic routes)
+    stale_threshold: int | None = None  # None means use global RunSkillConfig.stale_threshold
 
 
 @dataclass

--- a/src/autoskillit/recipe/validator.py
+++ b/src/autoskillit/recipe/validator.py
@@ -153,6 +153,14 @@ def validate_recipe(recipe: Recipe) -> list[str]:
                 f"Step '{step_name}'.retries must be a non-negative integer, got {step.retries!r}."
             )
 
+        if step.stale_threshold is not None and (
+            not isinstance(step.stale_threshold, int) or step.stale_threshold <= 0
+        ):
+            errors.append(
+                f"Step {step_name!r}: 'stale_threshold' must be a positive integer "
+                f"when set, got {step.stale_threshold!r}"
+            )
+
         if step.on_result is not None:
             if step.on_success is not None:
                 errors.append(

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -284,6 +284,7 @@ steps:
 
   implement:
     tool: run_skill
+    stale_threshold: 2400
     with:
       skill_command: "/autoskillit:implement-worktree-no-merge ${{ context.plan_path }}"
       cwd: "${{ context.work_dir }}"
@@ -298,6 +299,7 @@ steps:
 
   retry_worktree:
     tool: run_skill
+    stale_threshold: 2400
     with:
       skill_command: "/autoskillit:retry-worktree ${{ context.plan_path }} ${{ context.worktree_path }}"
       cwd: "${{ context.worktree_path }}"

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -294,6 +294,7 @@ steps:
 
   implement:
     tool: run_skill
+    stale_threshold: 2400
     with:
       skill_command: "/autoskillit:implement-worktree-no-merge ${{ context.plan_path }}"
       cwd: "${{ context.work_dir }}"
@@ -308,6 +309,7 @@ steps:
 
   retry_worktree:
     tool: run_skill
+    stale_threshold: 2400
     with:
       skill_command: "/autoskillit:retry-worktree ${{ context.plan_path }} ${{ context.worktree_path }}"
       cwd: "${{ context.worktree_path }}"

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -433,6 +433,7 @@ steps:
 
   implement:
     tool: run_skill
+    stale_threshold: 2400
     with:
       skill_command: "/autoskillit:implement-worktree-no-merge ${{ context.pr_plan_path }}"
       cwd: "${{ context.work_dir }}"
@@ -448,6 +449,7 @@ steps:
 
   retry_worktree:
     tool: run_skill
+    stale_threshold: 2400
     with:
       skill_command: "/autoskillit:retry-worktree ${{ context.pr_plan_path }} ${{ context.worktree_path }}"
       cwd: "${{ context.worktree_path }}"

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -277,6 +277,7 @@ steps:
 
   implement:
     tool: run_skill
+    stale_threshold: 2400
     with:
       skill_command: "/autoskillit:implement-worktree-no-merge ${{ context.plan_path }}"
       cwd: "${{ context.work_dir }}"
@@ -292,6 +293,7 @@ steps:
 
   retry_worktree:
     tool: run_skill
+    stale_threshold: 2400
     with:
       skill_command: "/autoskillit:retry-worktree ${{ context.plan_path }} ${{ context.worktree_path }}"
       cwd: "${{ context.worktree_path }}"

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -244,6 +244,7 @@ steps:
 
   implement_phase:
     tool: run_skill
+    stale_threshold: 2400
     with:
       skill_command: "/autoskillit:retry-worktree ${{ context.phase_plan_path }} ${{ context.worktree_path }}"
       cwd: "${{ context.worktree_path }}"
@@ -270,6 +271,7 @@ steps:
   # --- EXPERIMENT + REPORT PHASE ---
   run_experiment:
     tool: run_skill
+    stale_threshold: 2400
     with:
       skill_command: "/autoskillit:run-experiment ${{ context.worktree_path }}"
       cwd: "${{ context.worktree_path }}"
@@ -283,6 +285,7 @@ steps:
 
   adjust_experiment:
     tool: run_skill
+    stale_threshold: 2400
     with:
       skill_command: "/autoskillit:run-experiment ${{ context.worktree_path }} --adjust"
       cwd: "${{ context.worktree_path }}"
@@ -442,6 +445,7 @@ steps:
 
   re_run_experiment:
     tool: run_skill
+    stale_threshold: 2400
     with:
       skill_command: "/autoskillit:run-experiment ${{ context.worktree_path }} --adjust"
       cwd: "${{ context.worktree_path }}"

--- a/src/autoskillit/server/tools_execution.py
+++ b/src/autoskillit/server/tools_execution.py
@@ -150,6 +150,7 @@ async def run_skill(
     model: str = "",
     step_name: str = "",
     order_id: str = "",
+    stale_threshold: int | None = None,
     ctx: Context = CurrentContext(),
 ) -> str:
     """Run a Claude Code headless session with a skill command.
@@ -186,6 +187,9 @@ async def run_skill(
         order_id: Optional per-issue/order identifier for token telemetry scoping. When set,
             token and timing entries are keyed by this value, enabling per-issue isolation
             in get_token_summary/get_timing_summary and in the token_summary_appender hook.
+        stale_threshold: Override the staleness kill threshold in seconds. When set on
+            a RecipeStep, the recipe orchestrator passes it here. None uses the global
+            config default (RunSkillConfig.stale_threshold, default 1200s).
     """
     if (headless := _require_not_headless("run_skill")) is not None:
         return headless
@@ -285,6 +289,7 @@ async def run_skill(
             order_id=order_id,
             expected_output_patterns=expected_output_patterns,
             write_behavior=write_spec,
+            stale_threshold=float(stale_threshold) if stale_threshold is not None else None,
         )
         if skill_result.success:
             tool_ctx.audit.record_success(skill_command)

--- a/tests/execution/test_process_monitor.py
+++ b/tests/execution/test_process_monitor.py
@@ -4,15 +4,17 @@ from __future__ import annotations
 
 import sys
 import time
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import anyio
+import psutil
 import pytest
 
-from autoskillit.core.types import TerminationReason
+from autoskillit.core.types import ChannelBStatus, TerminationReason
 from autoskillit.execution.process import (
     RaceAccumulator,
     _has_active_api_connection,
+    _has_active_child_processes,
     _heartbeat,
     _session_log_monitor,
     _watch_session_log,
@@ -596,6 +598,64 @@ class TestHasActiveApiConnection:
             assert _has_active_api_connection(12345) is True
 
 
+class TestHasActiveChildProcesses:
+    """Unit tests for _has_active_child_processes."""
+
+    def _make_child(self, cpu: float | type[Exception]) -> MagicMock:
+        """Build a mock psutil child process."""
+        child = MagicMock()
+        if isinstance(cpu, type) and issubclass(cpu, Exception):
+            child.cpu_percent.side_effect = cpu(pid=999)
+        else:
+            child.cpu_percent.return_value = cpu
+        return child
+
+    def _patch_children(self, children, monkeypatch, parent_raises=None):
+        mock_proc = MagicMock()
+        if parent_raises:
+            monkeypatch.setattr(
+                "autoskillit.execution._process_monitor.psutil.Process",
+                MagicMock(side_effect=parent_raises(pid=1234)),
+            )
+            return
+        mock_proc.children.return_value = children
+        monkeypatch.setattr(
+            "autoskillit.execution._process_monitor.psutil.Process",
+            MagicMock(return_value=mock_proc),
+        )
+
+    def test_returns_true_when_child_exceeds_threshold(self, monkeypatch):
+        self._patch_children([self._make_child(15.0)], monkeypatch)
+        assert _has_active_child_processes(1234) is True
+
+    def test_returns_false_when_all_children_below_threshold(self, monkeypatch):
+        children = [self._make_child(0.0), self._make_child(5.0), self._make_child(9.9)]
+        self._patch_children(children, monkeypatch)
+        assert _has_active_child_processes(1234) is False
+
+    def test_returns_false_when_no_children(self, monkeypatch):
+        self._patch_children([], monkeypatch)
+        assert _has_active_child_processes(1234) is False
+
+    def test_returns_false_on_parent_nosuchprocess(self, monkeypatch):
+        self._patch_children([], monkeypatch, parent_raises=psutil.NoSuchProcess)
+        assert _has_active_child_processes(1234) is False
+
+    def test_skips_dead_child_gracefully(self, monkeypatch):
+        children = [self._make_child(psutil.NoSuchProcess), self._make_child(5.0)]
+        self._patch_children(children, monkeypatch)
+        assert _has_active_child_processes(1234) is False
+
+    def test_skips_zombie_child_then_finds_active(self, monkeypatch):
+        children = [self._make_child(psutil.ZombieProcess), self._make_child(20.0)]
+        self._patch_children(children, monkeypatch)
+        assert _has_active_child_processes(1234) is True
+
+    def test_skips_access_denied_gracefully(self, monkeypatch):
+        self._patch_children([self._make_child(psutil.AccessDenied)], monkeypatch)
+        assert _has_active_child_processes(1234) is False
+
+
 class TestSessionLogMonitorStaleSuppressionGate:
     """_session_log_monitor suppresses stale when process has an active port-443 connection."""
 
@@ -716,6 +776,38 @@ class TestSessionLogMonitorStaleSuppressionGate:
         assert warning_in_logs or warning_in_stdout, (
             "Suppression warning must appear in structlog capture or stdout"
         )
+
+    @pytest.mark.anyio
+    async def test_suppresses_stale_when_child_cpu_active_no_api_connection(
+        self, tmp_path, monkeypatch
+    ):
+        """Child CPU activity suppresses stale kill even when no port-443 connection."""
+        session_file = tmp_path / "session.jsonl"
+        session_file.write_text("")
+        spawn_time = time.time() - 10  # wall time — compared against st_ctime in phase 1
+        call_count: dict[str, int] = {"cpu": 0}
+
+        def fake_api_conn(pid):
+            return False  # No port-443 connection
+
+        def fake_child_cpu(pid):
+            call_count["cpu"] += 1
+            return call_count["cpu"] == 1  # True first, False second
+
+        monkeypatch.setattr(
+            "autoskillit.execution._process_monitor._has_active_api_connection",
+            fake_api_conn,
+        )
+        monkeypatch.setattr(
+            "autoskillit.execution._process_monitor._has_active_child_processes",
+            fake_child_cpu,
+        )
+        result = await _session_log_monitor(
+            tmp_path, "DONE", stale_threshold=0.05, spawn_time=spawn_time, pid=9999,
+            _phase1_poll=0.01, _phase2_poll=0.05,
+        )
+        assert result.status == ChannelBStatus.STALE
+        assert call_count["cpu"] == 2  # suppressed once, then fired
 
 
 class TestHeartbeatMarkerAwareness:

--- a/tests/execution/test_process_monitor.py
+++ b/tests/execution/test_process_monitor.py
@@ -803,8 +803,13 @@ class TestSessionLogMonitorStaleSuppressionGate:
             fake_child_cpu,
         )
         result = await _session_log_monitor(
-            tmp_path, "DONE", stale_threshold=0.05, spawn_time=spawn_time, pid=9999,
-            _phase1_poll=0.01, _phase2_poll=0.05,
+            tmp_path,
+            "DONE",
+            stale_threshold=0.05,
+            spawn_time=spawn_time,
+            pid=9999,
+            _phase1_poll=0.01,
+            _phase2_poll=0.05,
         )
         assert result.status == ChannelBStatus.STALE
         assert call_count["cpu"] == 2  # suppressed once, then fired

--- a/tests/recipe/test_io.py
+++ b/tests/recipe/test_io.py
@@ -452,6 +452,16 @@ class TestRecipeParser:
         step = _parse_step({"tool": "run_skill"})
         assert step.model is None
 
+    def test_parse_step_reads_stale_threshold(self) -> None:
+        data = {"tool": "run_skill", "stale_threshold": 2400, "on_success": "done"}
+        step = _parse_step(data)
+        assert step.stale_threshold == 2400
+
+    def test_parse_step_stale_threshold_defaults_to_none(self) -> None:
+        data = {"tool": "run_skill", "on_success": "done"}
+        step = _parse_step(data)
+        assert step.stale_threshold is None
+
     # MOD4
     def test_bundled_resolve_failures_steps_use_config_default(self) -> None:
         bd = builtin_recipes_dir()

--- a/tests/recipe/test_validator.py
+++ b/tests/recipe/test_validator.py
@@ -373,6 +373,36 @@ class TestValidateRecipe:
         errors = validate_recipe(wf)
         assert errors == []
 
+    def test_validator_rejects_zero_stale_threshold(self) -> None:
+        recipe = Recipe(
+            name="test",
+            description="test",
+            steps={"s": RecipeStep(tool="run_skill", on_success="done", stale_threshold=0)},
+            kitchen_rules=["test"],
+        )
+        errors = validate_recipe(recipe)
+        assert any("stale_threshold" in e for e in errors)
+
+    def test_validator_rejects_negative_stale_threshold(self) -> None:
+        recipe = Recipe(
+            name="test",
+            description="test",
+            steps={"s": RecipeStep(tool="run_skill", on_success="done", stale_threshold=-1)},
+            kitchen_rules=["test"],
+        )
+        errors = validate_recipe(recipe)
+        assert any("stale_threshold" in e for e in errors)
+
+    def test_validator_accepts_positive_stale_threshold(self) -> None:
+        recipe = Recipe(
+            name="test",
+            description="test",
+            steps={"s": RecipeStep(tool="run_skill", on_success="done", stale_threshold=2400)},
+            kitchen_rules=["test"],
+        )
+        errors = validate_recipe(recipe)
+        assert not any("stale_threshold" in e for e in errors)
+
 
 # ---------------------------------------------------------------------------
 # TestDataFlowQuality — migrated from test_recipe_parser.py


### PR DESCRIPTION
## Summary

Headless sessions running long-lived background Bash tasks (e.g. `cargo bench` launched via
`run_in_background: true`) are killed as stale because the staleness signal is JSONL file growth,
not actual session liveness. When the LLM goes idle waiting for a background child, the JSONL
stops growing and the 20-minute staleness threshold is breached — even though child processes are
actively running.

Three changes eliminate this class of false kill:

1. **`_has_active_child_processes`** — a second suppression gate in `_session_log_monitor` that
   checks child process CPU activity before issuing a kill. Added alongside the existing
   `_has_active_api_connection` port-443 gate.

2. **`RecipeStep.stale_threshold`** — an optional per-step threshold field that recipe authors
   can raise for steps known to run long-lived experiments, passed through `run_skill` →
   `run_headless_core` → `_session_log_monitor`.

3. **Recipe YAML overrides** — `stale_threshold: 2400` (40 min) on specific long-running steps
   in `research.yaml`, `implementation.yaml`, `remediation.yaml`, `implementation-groups.yaml`,
   and `merge-prs.yaml`.

## Requirements

### STALE — Staleness Suppression via Child Process Detection

- **REQ-STALE-001:** The system must detect active child processes in the headless session's process tree when the stale threshold is breached.
- **REQ-STALE-002:** The system must suppress the stale kill when any child process in the tree reports CPU usage exceeding ~10% via `cpu_percent(interval=0)`.
- **REQ-STALE-003:** The system must reset the staleness clock (`last_change`) when child process activity suppresses the stale kill, identical to the existing `_has_active_api_connection` suppression behavior.
- **REQ-STALE-004:** The child process detection must follow the established exception-handling pattern, silently skipping `NoSuchProcess`, `ZombieProcess`, and `AccessDenied` errors per process.
- **REQ-STALE-005:** The child process detection must only execute when the stale threshold has already been breached (zero performance impact during normal operation).
- **REQ-STALE-006:** The child process detection must emit a structured log warning when suppressing a stale kill, following the pattern established by `_has_active_api_connection`.

### SCHEMA — Per-Step Stale Threshold in RecipeStep

- **REQ-SCHEMA-001:** The `RecipeStep` dataclass must accept an optional `stale_threshold` field of type `int | None` with no default value (defaults to `None`).
- **REQ-SCHEMA-002:** When `stale_threshold` is `None` on a recipe step, the global `RunSkillConfig.stale_threshold` (1200s) must apply.
- **REQ-SCHEMA-003:** The `run_skill` MCP tool handler must accept an optional `stale_threshold` parameter and forward it to `run_headless_core`.
- **REQ-SCHEMA-004:** The recipe validator must reject `stale_threshold` values that are not positive integers when set.

### RECIPE — Research Recipe Step Overrides

- **REQ-RECIPE-001:** Research-oriented recipes must set `stale_threshold: 2400` (40 minutes) on specific long-running steps (e.g., `implement_phase`, `run_experiment`).
- **REQ-RECIPE-002:** Fast-completing steps (e.g., `plan_phase`) must not have a `stale_threshold` override, relying on the global default.

### TEST — Test Coverage

- **REQ-TEST-001:** Unit tests must verify `_has_active_child_processes` returns `True` when a child process exceeds the CPU threshold.
- **REQ-TEST-002:** Unit tests must verify `_has_active_child_processes` returns `False` when all children are idle, when no children exist, and when exceptions are raised.
- **REQ-TEST-003:** An integration test must verify stale suppression when a child process is CPU-active but has no port-443 connection.
- **REQ-TEST-004:** The existing `TestSessionLogMonitorStaleSuppressionGate` test class must be extended with the child-process-active scenario.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([SESSION LAUNCHED])
    T_COMPLETE([COMPLETION])
    T_STALE([STALE — KILL])

    %% CONFIG CHAIN %%
    subgraph Config ["● RECIPE STEP CONFIG (stale_threshold flow)"]
        direction TB
        RecipeStep["● RecipeStep YAML<br/>━━━━━━━━━━<br/>stale_threshold: 2400<br/>(or unset → None)"]
        RunSkill["● run_skill handler<br/>━━━━━━━━━━<br/>tools_execution.py<br/>stale_threshold: int | None"]
        Runner["DefaultSubprocessRunner<br/>━━━━━━━━━━<br/>process.py<br/>default: 1200s"]
    end

    %% PHASE 1 %%
    subgraph Phase1 ["PHASE 1 — JSONL File Discovery (poll 1s, timeout 30s)"]
        direction TB
        P1_Poll["Poll session_log_dir<br/>━━━━━━━━━━<br/>ctime > spawn_time?<br/>Match session_id?"]
        P1_Found{"File found<br/>within 30s?"}
    end

    %% PHASE 2 %%
    subgraph Phase2 ["● PHASE 2 — Staleness Monitor Loop (poll every 2s)"]
        direction TB
        P2_Stat["stat(session_file)<br/>━━━━━━━━━━<br/>current_size vs last_size"]
        P2_Grew{"JSONL<br/>grew?"}
        P2_Marker["Read new content<br/>━━━━━━━━━━<br/>scan for completion<br/>marker in JSONL"]
        P2_MarkerFound{"Completion<br/>marker found?"}
        P2_ResetGrow["last_size = current_size<br/>last_change = now()"]
        P2_Elapsed{"elapsed >=<br/>stale_threshold?"}
    end

    %% SUPPRESSION GATES %%
    subgraph Gates ["● SUPPRESSION GATES (only fire when stale threshold breached)"]
        direction TB
        Gate1["_has_active_api_connection<br/>━━━━━━━━━━<br/>Walk proc tree<br/>ESTABLISHED port-443?"]
        Gate1_Active{"API conn<br/>active?"}
        Gate2["● _has_active_child_processes<br/>━━━━━━━━━━<br/>Walk child procs<br/>cpu_percent > 10%?"]
        Gate2_Active{"Child CPU<br/>> 10%?"}
        ResetClock["last_change = now()<br/>━━━━━━━━━━<br/>Suppress stale kill<br/>reset staleness clock"]
    end

    %% CONNECTIONS %%
    START --> RecipeStep
    RecipeStep -->|"stale_threshold (int|None)"| RunSkill
    RunSkill -->|"float(x) or None → default 1200s"| Runner
    Runner -->|"stale_threshold, pid"| P1_Poll

    P1_Poll --> P1_Found
    P1_Found -->|"yes"| P2_Stat
    P1_Found -->|"no (30s timeout)"| T_STALE

    P2_Stat --> P2_Grew
    P2_Grew -->|"yes"| P2_ResetGrow
    P2_ResetGrow --> P2_Marker
    P2_Marker --> P2_MarkerFound
    P2_MarkerFound -->|"yes"| T_COMPLETE
    P2_MarkerFound -->|"no"| P2_Elapsed

    P2_Grew -->|"no"| P2_Elapsed
    P2_Elapsed -->|"no (wait)"| P2_Stat
    P2_Elapsed -->|"yes"| Gate1

    Gate1 --> Gate1_Active
    Gate1_Active -->|"yes"| ResetClock
    Gate1_Active -->|"no"| Gate2
    Gate2 --> Gate2_Active
    Gate2_Active -->|"yes"| ResetClock
    Gate2_Active -->|"no"| T_STALE
    ResetClock -->|"continue loop"| P2_Stat

    %% CLASS ASSIGNMENTS %%
    class START,T_COMPLETE,T_STALE terminal;
    class RecipeStep,RunSkill handler;
    class Runner stateNode;
    class P1_Poll,P2_Stat,P2_Marker,P2_ResetGrow,ResetClock phase;
    class P1_Found,P2_Grew,P2_MarkerFound,P2_Elapsed,Gate1_Active,Gate2_Active stateNode;
    class Gate1 handler;
    class Gate2 newComponent;
```

### Concurrency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([SESSION LAUNCHED])
    COMPLETE([TASK GROUP CANCELLED])

    %% MAIN THREAD: Sequential setup %%
    subgraph MainSeq ["MAIN COROUTINE — Sequential Setup"]
        direction TB
        SpawnProc["Spawn Claude Code process<br/>━━━━━━━━━━<br/>asyncio subprocess<br/>get proc.pid"]
        CreateAcc["Create RaceAccumulator + trigger<br/>━━━━━━━━━━<br/>anyio.Event (idempotent set)<br/>channel_b_ready Event"]
        OpenTG["anyio.create_task_group()<br/>━━━━━━━━━━<br/>Fork: start 4–5 coroutines<br/>as tg.start_soon(...)"]
        TrigWait["await trigger.wait()<br/>━━━━━━━━━━<br/>Block until first watcher wins<br/>(or wall-clock timeout)"]
        DrainWait["Optional drain window<br/>━━━━━━━━━━<br/>await channel_b_ready if<br/>process exited but B pending"]
        CancelTG["tg.cancel_scope.cancel()<br/>━━━━━━━━━━<br/>Tear down all remaining tasks"]
        Resolve["resolve_termination(RaceSignals)<br/>━━━━━━━━━━<br/>Priority: exit > stale > completion"]
    end

    %% TASK GROUP: Concurrent watchers %%
    subgraph TaskGroup ["anyio TASK GROUP — Concurrent Watchers (cooperative, single event loop)"]
        direction LR

        subgraph ChA ["Channel A"]
            WatchProc["_watch_process<br/>━━━━━━━━━━<br/>await proc.wait()<br/>acc.process_exited=True"]
            WatchHB["_watch_heartbeat<br/>━━━━━━━━━━<br/>poll stdout NDJSON 0.5s<br/>acc.channel_a_confirmed=True"]
        end

        subgraph ChB ["● Channel B — Session Log"]
            ExtractID["_extract_stdout_session_id<br/>━━━━━━━━━━<br/>poll stdout for type=system<br/>sets stdout_session_id_ready"]
            WatchSL["● _watch_session_log<br/>━━━━━━━━━━<br/>calls _session_log_monitor<br/>acc.channel_b_status=COMPLETION|STALE"]
        end
    end

    %% STALENESS SUPPRESSION %%
    subgraph StaleGates ["● STALENESS SUPPRESSION — Sync psutil walks (inside _session_log_monitor)"]
        direction TB
        Gate1["_has_active_api_connection(pid)<br/>━━━━━━━━━━<br/>[parent + children(recursive=True)]<br/>net_connections port-443 ESTABLISHED?"]
        Gate2["● _has_active_child_processes(pid)<br/>━━━━━━━━━━<br/>[children(recursive=True) only]<br/>cpu_percent(interval=0) > 10%?"]
        ResetClock["last_change = monotonic()<br/>━━━━━━━━━━<br/>suppress stale kill<br/>continue Phase 2 loop"]
        ReturnStale["return STALE<br/>━━━━━━━━━━<br/>acc.channel_b_status = STALE<br/>trigger.set()"]
    end

    %% FLOW %%
    START --> SpawnProc
    SpawnProc --> CreateAcc
    CreateAcc --> OpenTG

    OpenTG -->|"tg.start_soon"| WatchProc
    OpenTG -->|"tg.start_soon"| WatchHB
    OpenTG -->|"tg.start_soon"| ExtractID
    OpenTG -->|"tg.start_soon"| WatchSL

    WatchProc -->|"trigger.set()"| TrigWait
    WatchHB -->|"trigger.set()"| TrigWait
    WatchSL -->|"trigger.set() after drain"| TrigWait

    WatchSL -->|"stale threshold breached"| Gate1
    Gate1 -->|"no API conn"| Gate2
    Gate2 -->|"child CPU active"| ResetClock
    Gate2 -->|"no activity"| ReturnStale
    Gate1 -->|"API conn active"| ResetClock
    ResetClock -->|"continue loop"| WatchSL

    TrigWait --> DrainWait
    DrainWait --> CancelTG
    CancelTG --> Resolve
    Resolve --> COMPLETE

    %% CLASS ASSIGNMENTS %%
    class START,COMPLETE terminal;
    class SpawnProc,CreateAcc,TrigWait,DrainWait,CancelTG,Resolve phase;
    class OpenTG detector;
    class WatchProc,WatchHB handler;
    class ExtractID handler;
    class WatchSL handler;
    class Gate1 handler;
    class Gate2 newComponent;
    class ResetClock output;
    class ReturnStale detector;
```

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([RECIPE YAML LOADED])
    T_PASS([VALID — forwarded to run_skill])
    T_FAIL([INVALID — validation error])

    %% PARSE LAYER %%
    subgraph Parse ["● YAML → RecipeStep (io.py _parse_step)"]
        direction TB
        YAMLRead["● YAML key read<br/>━━━━━━━━━━<br/>data.get('stale_threshold')<br/>absent → None (no coercion)"]
        Construct["● RecipeStep(...)<br/>━━━━━━━━━━<br/>stale_threshold: int | None = None<br/>No __post_init__ mutations"]
        IntegrityGuard["_PARSE_STEP_HANDLED_FIELDS guard<br/>━━━━━━━━━━<br/>compile-time assert: fields == dataclass<br/>RuntimeError if diverged"]
    end

    %% VALIDATION LAYER %%
    subgraph Validation ["● STRUCTURAL VALIDATION (validator.py validate_recipe)"]
        direction TB
        IsNone{"stale_threshold<br/>is None?"}
        TypeCheck{"isinstance(int)<br/>AND > 0?"}
        AppendError["append error<br/>━━━━━━━━━━<br/>'must be positive integer<br/>when set'"]
        PassThrough["field passes<br/>━━━━━━━━━━<br/>no validation error<br/>for None or valid int"]
    end

    %% SEMANTIC LAYER %%
    subgraph Semantic ["● SEMANTIC RULE — _TOOL_PARAMS registry (rules_tools.py)"]
        direction TB
        ToolParamsCheck["_TOOL_PARAMS['run_skill']<br/>━━━━━━━━━━<br/>frozenset includes 'stale_threshold'<br/>dead-with-param rule: NO warning"]
        OtherToolWarn["Other tools<br/>━━━━━━━━━━<br/>stale_threshold not in their params<br/>dead-with-param: WARNING emitted"]
    end

    %% EXECUTION FORWARDING %%
    subgraph Execution ["EXECUTION FORWARDING (tools_execution.py run_skill)"]
        direction TB
        NullPath["stale_threshold = None<br/>━━━━━━━━━━<br/>→ DefaultSubprocessRunner default<br/>= 1200s (global config)"]
        OverridePath["stale_threshold = int<br/>━━━━━━━━━━<br/>float(stale_threshold)<br/>→ overrides global default"]
        Monitor["_session_log_monitor<br/>━━━━━━━━━━<br/>stale_threshold used as<br/>breach-detection window"]
    end

    %% FLOW %%
    START --> YAMLRead
    YAMLRead --> Construct
    Construct --> IntegrityGuard
    IntegrityGuard -->|"fields match — import OK"| IsNone

    IsNone -->|"yes (absent or None)"| PassThrough
    IsNone -->|"no (value present)"| TypeCheck
    TypeCheck -->|"valid"| PassThrough
    TypeCheck -->|"invalid (non-int or ≤ 0)"| AppendError
    AppendError --> T_FAIL
    PassThrough --> ToolParamsCheck

    ToolParamsCheck -->|"tool: run_skill"| T_PASS
    ToolParamsCheck -->|"other tool"| OtherToolWarn

    T_PASS --> NullPath
    T_PASS --> OverridePath
    NullPath --> Monitor
    OverridePath --> Monitor
    Monitor --> T_PASS

    %% CLASS ASSIGNMENTS %%
    class START,T_PASS,T_FAIL terminal;
    class YAMLRead,Construct handler;
    class IntegrityGuard detector;
    class IsNone,TypeCheck stateNode;
    class AppendError detector;
    class PassThrough output;
    class ToolParamsCheck newComponent;
    class OtherToolWarn gap;
    class NullPath,OverridePath,Monitor phase;
```

Closes #631

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260405-170436-566038/.autoskillit/temp/make-plan/fix_false_stale_kills_plan_2026-04-05_000000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 2.8k | 45.6k | 2.0M | 151.7k | 2 | 19m 31s |
| verify | 62 | 36.0k | 3.3M | 155.3k | 2 | 15m 1s |
| implement | 149 | 47.2k | 9.6M | 183.8k | 2 | 16m 24s |
| audit_impl | 102 | 20.0k | 762.1k | 90.1k | 2 | 10m 31s |
| open_pr | 69 | 39.4k | 2.6M | 116.8k | 2 | 15m 32s |
| review_pr | 38 | 57.4k | 1.8M | 103.1k | 1 | 18m 47s |
| resolve_review | 55 | 32.5k | 3.1M | 84.3k | 1 | 14m 9s |
| fix | 38 | 14.6k | 1.3M | 58.3k | 1 | 9m 9s |
| **Total** | 3.3k | 292.6k | 24.3M | 943.5k | | 1h 59m |