### PR TITLE
Implementation Plan: Default audit-impl to OFF in All Recipes

### DIFF
--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -22,7 +22,7 @@ ingredients:
     default: "false"
   audit:
     description: Post-merge quality gate
-    default: "true"
+    default: "false"
   open_pr:
     description: PR instead of direct merge
     default: "true"

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -22,7 +22,7 @@ ingredients:
     default: "false"
   audit:
     description: Post-merge quality gate
-    default: "true"
+    default: "false"
   open_pr:
     description: PR instead of direct merge
     default: "true"

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -17,7 +17,7 @@ ingredients:
     default: ""
   audit:
     description: Post-merge quality gate
-    default: "true"
+    default: "false"
   plans_dir:
     description: Plan files for audit
     default: ".autoskillit/temp/merge-prs"

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -44,7 +44,7 @@ ingredients:
     default: ""
   audit:
     description: Post-merge quality gate
-    default: "true"
+    default: "false"
   review_approach:
     description: Research approaches first
     default: "false"

--- a/tests/recipe/test_bundled_recipes.py
+++ b/tests/recipe/test_bundled_recipes.py
@@ -1274,6 +1274,25 @@ def test_audit_impl_on_failure_routes_to_escalation() -> None:
     assert rem.steps["audit_impl"].on_failure == "escalate_stop"
 
 
+@pytest.mark.parametrize(
+    "recipe_name,yaml_name",
+    [
+        ("implementation", "implementation.yaml"),
+        ("remediation", "remediation.yaml"),
+        ("merge-prs", "merge-prs.yaml"),
+        ("implementation-groups", "implementation-groups.yaml"),
+    ],
+)
+def test_audit_ingredient_defaults_to_false(recipe_name: str, yaml_name: str) -> None:
+    """audit must default to 'false' (OFF) in all recipes — opt-in, not opt-out."""
+    recipe = load_recipe(builtin_recipes_dir() / yaml_name)
+    audit_ing = recipe.ingredients.get("audit")
+    assert audit_ing is not None, f"{recipe_name}: 'audit' ingredient not found"
+    assert audit_ing.default == "false", (
+        f"{recipe_name}: audit.default must be 'false' (OFF by default), got {audit_ing.default!r}"
+    )
+
+
 def test_smoke_check_summary_has_error_escalation() -> None:
     """check_summary must have a result.error condition routing to a non-done step."""
     recipe = load_recipe(SMOKE_RECIPE)


### PR DESCRIPTION
## Summary

All four bundled recipes (`implementation`, `remediation`, `merge-prs`, `implementation-groups`)
currently ship with `audit: default: "true"`, meaning `audit-impl` runs unless explicitly
disabled. This plan changes all four recipes to `default: "false"` so `audit-impl` is skipped
by default and becomes opt-in. No structural changes to the step graph, routing, or test
infrastructure are needed — only the ingredient default changes.

**Scope:** 4 YAML ingredient default changes + 1 test assertion added.

## Requirements

### RCFG — Recipe Configuration

- **REQ-RCFG-001:** The `audit` input in `implementation.yaml` must default to `"false"`.
- **REQ-RCFG-002:** The `audit` input in `implementation-groups.yaml` must default to `"false"`.
- **REQ-RCFG-003:** The `audit` input in `remediation.yaml` must default to `"false"`.
- **REQ-RCFG-004:** The `audit` input in `merge-prs.yaml` must default to `"false"`.
- **REQ-RCFG-005:** The `audit_impl` step definition and its `skip_when_false: "inputs.audit"` guard must remain unchanged in all recipes.
- **REQ-RCFG-006:** Callers must still be able to opt in to audit-impl by passing `audit: "true"` at pipeline invocation time.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([Pipeline Invoked])
    CONTINUE([Continue to push / merge])
    ERROR([escalate_stop / register_clone_failure])

    subgraph Ingredient ["● Ingredient Resolution"]
        direction TB
        AuditIng["● audit ingredient<br/>━━━━━━━━━━<br/>BEFORE: default='true'<br/>AFTER: default='false'"]
    end

    subgraph Gate ["skip_when_false Gate"]
        direction TB
        SkipCheck{"inputs.audit == 'true'?"}
        SkipBypass["BYPASS<br/>━━━━━━━━━━<br/>Skip audit_impl<br/>(now default path)"]
        RunAudit["● run audit-impl skill<br/>━━━━━━━━━━<br/>runs /autoskillit:audit-impl<br/>(now opt-in path)"]
        Verdict{"GO / NO GO?"}
        Remediate["remediate<br/>━━━━━━━━━━<br/>Route to remediation<br/>or re-plan"]
    end

    %% FLOW %%
    START --> AuditIng
    AuditIng -->|"resolves to 'false'<br/>(new default)"| SkipCheck
    SkipCheck -->|"false (default — bypass)"| SkipBypass
    SkipCheck -->|"true (opt-in — explicit)"| RunAudit
    RunAudit --> Verdict
    Verdict -->|"GO"| CONTINUE
    Verdict -->|"NO GO"| Remediate
    Verdict -->|"error"| ERROR
    Remediate -->|"re-plan loop"| START
    SkipBypass --> CONTINUE

    %% CLASS ASSIGNMENTS %%
    class START,CONTINUE,ERROR terminal;
    class AuditIng handler;
    class SkipCheck,Verdict stateNode;
    class SkipBypass phase;
    class RunAudit detector;
    class Remediate phase;
```

**Color Legend:**
| Color | Category | Description |
|-------|----------|-------------|
| Dark Blue | Terminal | Pipeline start, continuation, and error states |
| Teal | State | Decision gates (skip_when_false, GO/NO GO) |
| Orange | Handler | ● Audit ingredient (modified: default flipped to "false") |
| Red | Detector | ● audit-impl skill execution (now opt-in path) |
| Purple | Phase | Bypass path (now default) and remediation routing |

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([Recipe Invoked])
    GATE([skip_when_false Evaluated])

    subgraph Contracts ["● INGREDIENT CONTRACT DEFINITIONS"]
        direction TB
        ImplYaml["● implementation.yaml<br/>━━━━━━━━━━<br/>audit:<br/>  default: 'false'<br/>(was: 'true')"]
        ImplGroupsYaml["● implementation-groups.yaml<br/>━━━━━━━━━━<br/>audit:<br/>  default: 'false'<br/>(was: 'true')"]
        RemediationYaml["● remediation.yaml<br/>━━━━━━━━━━<br/>audit:<br/>  default: 'false'<br/>(was: 'true')"]
        MergePrsYaml["● merge-prs.yaml<br/>━━━━━━━━━━<br/>audit:<br/>  default: 'false'<br/>(was: 'true')"]
    end

    subgraph Resolution ["INIT_ONLY: Ingredient Resolution"]
        direction TB
        CallerSupplied["Caller-supplied value<br/>━━━━━━━━━━<br/>audit='true' (opt-in)<br/>INIT_ONLY — frozen for run"]
        DefaultApplied["● Contract default applied<br/>━━━━━━━━━━<br/>audit='false'<br/>INIT_ONLY — frozen for run"]
    end

    subgraph TestGate ["● CONTRACT VALIDATION (test_bundled_recipes.py)"]
        direction TB
        TestAssert["● test_audit_ingredient_defaults_to_false<br/>━━━━━━━━━━<br/>@pytest.mark.parametrize<br/>asserts audit.default == 'false'<br/>for all 4 recipes"]
    end

    %% FLOW %%
    START -->|"caller passes audit='true'"| CallerSupplied
    START -->|"no audit arg (default)"| DefaultApplied
    ImplYaml --> DefaultApplied
    ImplGroupsYaml --> DefaultApplied
    RemediationYaml --> DefaultApplied
    MergePrsYaml --> DefaultApplied
    CallerSupplied --> GATE
    DefaultApplied --> GATE

    Contracts -.->|"validated by"| TestAssert

    %% CLASS ASSIGNMENTS %%
    class START terminal;
    class GATE stateNode;
    class ImplYaml,ImplGroupsYaml,RemediationYaml,MergePrsYaml handler;
    class CallerSupplied detector;
    class DefaultApplied phase;
    class TestAssert gap;
```

**Color Legend:**
| Color | Category | Description |
|-------|----------|-------------|
| Dark Blue | Terminal | Pipeline invocation point |
| Teal | Gate | skip_when_false evaluation (INIT_ONLY field read) |
| Orange | Contract | ● Recipe YAML ingredient contract definitions (modified) |
| Red | Opt-in | Caller-supplied value override (explicit audit='true') |
| Purple | Default | ● Contract default applied (now 'false') |
| Yellow | Test | ● Contract validation test assertion (new) |

Closes #632

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260405-180825-135856/.autoskillit/temp/make-plan/feat_default_audit_impl_off_plan_2026-04-05_181000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 2.8k | 60.3k | 4.0M | 213.2k | 3 | 24m 25s |
| verify | 82 | 43.0k | 3.9M | 193.2k | 3 | 22m 22s |
| implement | 176 | 53.6k | 10.3M | 221.3k | 3 | 18m 51s |
| audit_impl | 117 | 25.1k | 1.0M | 114.6k | 3 | 12m 6s |
| open_pr | 101 | 60.0k | 3.7M | 168.5k | 3 | 22m 39s |
| review_pr | 71 | 112.5k | 3.4M | 189.2k | 2 | 33m 19s |
| resolve_review | 77 | 40.4k | 3.7M | 117.7k | 2 | 18m 16s |
| fix | 38 | 14.6k | 1.3M | 58.3k | 1 | 9m 9s |
| **Total** | 3.5k | 409.5k | 31.4M | 1.3M | | 2h 41m |