### PR TITLE
Implementation Plan: Research Recipe — Add Troubleshoot/Diagnose Skill for Experiment Failures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,7 +296,7 @@ src/autoskillit/
     ├── audit-impl/           ├── smoke-task/
     ├── report-bug/           ├── pipeline-summary/
     ├── diagnose-ci/          ├── verify-diag/
-    └── troubleshoot-experiment/   # diagnoses implement_phase/run_experiment failures
+    └── troubleshoot-experiment/   # diagnoses implement_phase failures
 ```
 
 **Session diagnostics logs** are stored globally at `~/.local/share/autoskillit/logs/` (Linux) or `~/Library/Application Support/autoskillit/logs/` (macOS). Override with `linux_tracing.log_dir` in config. Session directories are named by Claude Code session UUID when available (preferred: parsed from stdout, fallback: discovered from JSONL filename via Channel B). When no session ID is available from either source, directories use `no_session_{timestamp}` naming. Query the index: `jq 'select(.success == false)' ~/.local/share/autoskillit/logs/sessions.jsonl`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Mandatory instructions for AI-assisted development in this repository.
 
 ## **1. Core Project Goal**
 
-A Claude Code plugin that orchestrates automated skill-driven workflows using headless sessions. It provides 42 MCP tools (run_cmd, run_python, run_skill, test_check, merge_worktree, reset_test_dir, classify_fix, reset_workspace, read_db, migrate_recipe, clone_repo, remove_clone, push_to_remote, register_clone_status, batch_cleanup_clones, report_bug, prepare_issue, enrich_issues, claim_issue, release_issue, wait_for_ci, wait_for_merge_queue, toggle_auto_merge, create_unique_branch, check_pr_mergeable, write_telemetry_files, get_pr_reviews, bulk_close_issues, set_commit_status, get_quota_events, kitchen_status, list_recipes, load_recipe, validate_recipe, get_pipeline_report, get_token_summary, get_timing_summary, fetch_github_issue, get_issue_title, get_ci_status, open_kitchen, close_kitchen) with 40 tools tagged `kitchen` and hidden at startup via FastMCP v3 `mcp.disable(tags={'kitchen'})`, 1 tool additionally tagged `headless` (test_check) and revealed in headless sessions via `mcp.enable(tags={'headless'})`, and 2 Free Range tools (open_kitchen, close_kitchen) always visible. Revealed per-session via `open_kitchen` tool, and 90 bundled skills (89 slash commands + 1 internal) registered as `/autoskillit:*` slash commands.
+A Claude Code plugin that orchestrates automated skill-driven workflows using headless sessions. It provides 42 MCP tools (run_cmd, run_python, run_skill, test_check, merge_worktree, reset_test_dir, classify_fix, reset_workspace, read_db, migrate_recipe, clone_repo, remove_clone, push_to_remote, register_clone_status, batch_cleanup_clones, report_bug, prepare_issue, enrich_issues, claim_issue, release_issue, wait_for_ci, wait_for_merge_queue, toggle_auto_merge, create_unique_branch, check_pr_mergeable, write_telemetry_files, get_pr_reviews, bulk_close_issues, set_commit_status, get_quota_events, kitchen_status, list_recipes, load_recipe, validate_recipe, get_pipeline_report, get_token_summary, get_timing_summary, fetch_github_issue, get_issue_title, get_ci_status, open_kitchen, close_kitchen) with 40 tools tagged `kitchen` and hidden at startup via FastMCP v3 `mcp.disable(tags={'kitchen'})`, 1 tool additionally tagged `headless` (test_check) and revealed in headless sessions via `mcp.enable(tags={'headless'})`, and 2 Free Range tools (open_kitchen, close_kitchen) always visible. Revealed per-session via `open_kitchen` tool, and 91 bundled skills (90 slash commands + 1 internal) registered as `/autoskillit:*` slash commands.
 
 ## **2. General Principles**
 
@@ -295,7 +295,8 @@ src/autoskillit/
     ├── retry-worktree/       ├── resolve-merge-conflicts/
     ├── audit-impl/           ├── smoke-task/
     ├── report-bug/           ├── pipeline-summary/
-    ├── diagnose-ci/          └── verify-diag/
+    ├── diagnose-ci/          ├── verify-diag/
+    └── troubleshoot-experiment/   # diagnoses implement_phase/run_experiment failures
 ```
 
 **Session diagnostics logs** are stored globally at `~/.local/share/autoskillit/logs/` (Linux) or `~/Library/Application Support/autoskillit/logs/` (macOS). Override with `linux_tracing.log_dir` in config. Session directories are named by Claude Code session UUID when available (preferred: parsed from stdout, fallback: discovered from JSONL filename via Channel B). When no session ID is available from either source, directories use `no_session_{timestamp}` naming. Query the index: `jq 'select(.success == false)' ~/.local/share/autoskillit/logs/sessions.jsonl`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@ How AutoSkillit works under the hood.
 
 ## Overview
 
-AutoSkillit is a Claude Code plugin that orchestrates automated workflows using headless sessions. It provides 42 MCP tools and 90 bundled skills, organized into a gated visibility system.
+AutoSkillit is a Claude Code plugin that orchestrates automated workflows using headless sessions. It provides 42 MCP tools and 91 bundled skills, organized into a gated visibility system.
 
 ## Core Concepts
 

--- a/docs/developer/end-turn-hazards.md
+++ b/docs/developer/end-turn-hazards.md
@@ -190,7 +190,7 @@ two detectors on every SKILL.md in the project:
 | `_check_loop_boundary()` | "For each" loops with tool invocations but no anti-prose guard |
 
 These run as part of `test_no_text_then_tool_in_any_step`, a parametrized
-test that scans all 90 bundled skills. Any new skill with an unguarded
+test that scans all 91 bundled skills. Any new skill with an unguarded
 loop fails CI automatically.
 
 ## If This Gets Fixed Upstream

--- a/docs/skill-visibility.md
+++ b/docs/skill-visibility.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-AutoSkillit's 90 bundled skills are organized into three tiers that control when and where
+AutoSkillit's 91 bundled skills are organized into three tiers that control when and where
 they appear as slash commands. The tier system is orthogonal to subset categories — you can
 disable a subset across all tiers simultaneously, or reclassify individual skills between
 tiers. See [Subset Categories](subset-categories.md) for subset configuration.

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -1,5 +1,25 @@
 version: 0.1.0
 skills:
+  troubleshoot-experiment:
+    inputs:
+    - name: worktree_path
+      type: string
+      required: true
+    - name: step_name
+      type: string
+      required: true
+    outputs:
+    - name: diagnosis_path
+      type: file_path
+    - name: failure_type
+      type: string
+    - name: is_fixable
+      type: string
+    expected_output_patterns:
+    - "is_fixable\\s*=\\s*(true|false)"
+    pattern_examples:
+    - "diagnosis_path = /tmp/diagnosis.md\nfailure_type = stale_timeout\nis_fixable = true\n%%ORDER_UP%%"
+    write_behavior: always
   diagnose-ci:
     inputs:
     - name: branch

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -258,7 +258,6 @@ steps:
       step_name: implement_phase
     capture:
       worktree_path: "${{ result.worktree_path }}"
-      branch_name: "${{ result.branch_name }}"
     on_success: next_phase_or_experiment
     on_failure: troubleshoot_implement_failure
     on_exhausted: run_experiment
@@ -276,8 +275,6 @@ steps:
       cwd: "${{ inputs.source_dir }}"
       step_name: troubleshoot_implement_failure
     capture:
-      diagnosis_path: "${{ result.diagnosis_path }}"
-      failure_type: "${{ result.failure_type }}"
       is_fixable: "${{ result.is_fixable }}"
     on_success: route_implement_failure
     on_failure: escalate_stop

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -253,16 +253,41 @@ steps:
     tool: run_skill
     stale_threshold: 2400
     with:
-      skill_command: "/autoskillit:retry-worktree ${{ context.phase_plan_path }} ${{ context.worktree_path }}"
+      skill_command: "/autoskillit:implement-experiment ${{ context.phase_plan_path }}"
       cwd: "${{ context.worktree_path }}"
       step_name: implement_phase
     capture:
       worktree_path: "${{ result.worktree_path }}"
+      branch_name: "${{ result.branch_name }}"
     on_success: next_phase_or_experiment
-    on_failure: escalate_stop
+    on_failure: troubleshoot_implement_failure
+    on_exhausted: run_experiment
+    on_context_limit: run_experiment
     note: >
-      Implements the current phase plan in the shared worktree.
-      Uses retry-worktree which implements a plan in an existing worktree.
+      Implements the current phase plan in an isolated worktree via implement-experiment.
+      Context exhaustion is a normal termination — the worktree is intact and
+      run_experiment picks up what was committed. Failures route to troubleshoot
+      for classification before re-planning or escalation.
+
+  troubleshoot_implement_failure:
+    tool: run_skill
+    with:
+      skill_command: "/autoskillit:troubleshoot-experiment ${{ context.worktree_path }} implement_phase"
+      cwd: "${{ inputs.source_dir }}"
+      step_name: troubleshoot_implement_failure
+    capture:
+      diagnosis_path: "${{ result.diagnosis_path }}"
+      failure_type: "${{ result.failure_type }}"
+      is_fixable: "${{ result.is_fixable }}"
+    on_success: route_implement_failure
+    on_failure: escalate_stop
+
+  route_implement_failure:
+    action: route
+    on_result:
+      - when: "${{ context.is_fixable }} == true"
+        route: plan_phase
+      - route: escalate_stop
 
   next_phase_or_experiment:
     action: route

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -270,6 +270,7 @@ steps:
 
   troubleshoot_implement_failure:
     tool: run_skill
+    stale_threshold: 2400
     with:
       skill_command: "/autoskillit:troubleshoot-experiment ${{ context.worktree_path }} implement_phase"
       cwd: "${{ inputs.source_dir }}"

--- a/src/autoskillit/skills_extended/troubleshoot-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/troubleshoot-experiment/SKILL.md
@@ -56,7 +56,7 @@ Query the global session index:
 ```bash
 jq -r 'select(.success == false)' \
   ~/.local/share/autoskillit/logs/sessions.jsonl \
-  | jq -r 'select(.cwd // "" | startswith("{worktree_path}"))' \
+  | jq -r --arg worktree_path "{worktree_path}" 'select(.cwd // "" | startswith($worktree_path))' \
   | tail -n 1
 ```
 

--- a/src/autoskillit/skills_extended/troubleshoot-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/troubleshoot-experiment/SKILL.md
@@ -102,7 +102,7 @@ Apply this decision table in priority order (stop at the first match):
 Create directory `.autoskillit/temp/troubleshoot-experiment/` if it does not exist.
 Write the diagnosis file to:
 
-`.autoskillit/temp/troubleshoot-experiment/diagnosis_{YYYY-MM-DD_HHMMSS}.md`
+`.autoskillit/temp/troubleshoot-experiment/diagnosis_{YYYY-MM-DD_HHMMSS}.md` (relative to the current working directory)
 
 ```markdown
 # Experiment Failure Diagnosis

--- a/src/autoskillit/skills_extended/troubleshoot-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/troubleshoot-experiment/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: troubleshoot-experiment
+categories: [research]
+hooks:
+  PreToolUse:
+    - matcher: "*"
+      hooks:
+        - type: command
+          command: "echo '[SKILL: troubleshoot-experiment] Diagnosing experiment failure...'"
+          once: true
+---
+
+# troubleshoot-experiment Skill
+
+Read session logs and process traces for a failed research pipeline step, classify
+why it failed, write a structured diagnosis artifact, and emit `is_fixable` signal
+for orchestrator routing.
+
+Called by the `research` recipe on `implement_phase` failure before routing to
+`plan_phase` (fixable) or `escalate_stop` (not fixable).
+
+## Invocation
+
+```
+/autoskillit:troubleshoot-experiment {worktree_path} {step_name}
+```
+
+**Positional args:**
+- `{worktree_path}` — absolute path to the worktree where execution failed
+- `{step_name}` — name of the failed pipeline step (e.g. `implement_phase`)
+
+## Critical Constraints
+
+**NEVER:**
+- Modify any source code files
+- Run tests
+- Write files outside `.autoskillit/temp/troubleshoot-experiment/`
+- Abort when session data is missing — emit `failure_type=unknown`, `is_fixable=false` and exit cleanly
+
+**ALWAYS:**
+- Initialize code-index before any search
+- Write the diagnosis file before emitting output tokens
+- Emit the three output tokens (`diagnosis_path`, `failure_type`, `is_fixable`) at the end
+
+## Workflow
+
+### Step 1: Initialize Code Index
+
+```
+mcp__code-index__set_project_path(path="{worktree_path}")
+```
+
+### Step 2: Locate the Most Recent Failed Session for this Worktree
+
+Query the global session index:
+```bash
+jq -r 'select(.success == false)' \
+  ~/.local/share/autoskillit/logs/sessions.jsonl \
+  | jq -r 'select(.cwd // "" | startswith("{worktree_path}"))' \
+  | tail -n 1
+```
+
+If the `cwd` field is absent from matching records, fall back to the most recent
+`success=false` entry regardless of `cwd`. Extract `session_id` from the record.
+
+If `sessions.jsonl` does not exist or no matching session is found, proceed to
+Step 5 with a minimal diagnosis noting the log lookup failure. Never abort.
+
+### Step 3: Read Session Diagnostics
+
+From `~/.local/share/autoskillit/logs/sessions/{session_id}/`:
+
+- `summary.json` — identity fields: `termination_reason`, `write_call_count`,
+  `exit_code`, `anomaly_count`, `peak_rss_kb`, `elapsed_seconds`
+- `anomalies.jsonl` — structured anomaly records (one per line): `kind`,
+  `severity`, `detail`
+
+Also read from `{worktree_path}/.autoskillit/temp/run-experiment/` any
+`results_*.md` files (if the failed step was `run_experiment` and produced
+partial results).
+
+If `summary.json` is not found, emit `failure_type=unknown`, `is_fixable=false`
+and proceed to Step 5.
+
+### Step 4: Classify Failure Type
+
+Apply this decision table in priority order (stop at the first match):
+
+| Priority | Condition | `failure_type` | `is_fixable` |
+|----------|-----------|----------------|--------------|
+| 1 | `termination_reason == "context_limit"` | `context_exhaustion` | `true` |
+| 2 | `termination_reason == "stale"` AND `write_call_count == 0` | `stale_timeout` | `true` |
+| 3 | `termination_reason == "stale"` AND `write_call_count > 0` | `stale_timeout` | `true` |
+| 4 | `exit_code != 0` AND logs contain build/compile error keywords (`SyntaxError`, `ModuleNotFoundError`, `ImportError`, `error: command`) | `build_failure` | `true` |
+| 5 | `blocked_hypotheses` token present in run-experiment results OR results file contains `## Status: FAILED` with data acquisition errors | `data_missing` | `true` |
+| 6 | Logs contain environment/infra keywords (`Permission denied`, `No such file or directory` for system paths, `Connection refused`) | `environment_error` | `false` |
+| 7 | `anomaly_count > 0` AND any anomaly `kind` in `["oom_critical", "zombie_persistent"]` | `environment_error` | `false` |
+| 8 | All other cases | `unknown` | `false` |
+
+### Step 5: Write Diagnosis Report
+
+Create directory `.autoskillit/temp/troubleshoot-experiment/` if it does not exist.
+Write the diagnosis file to:
+
+`.autoskillit/temp/troubleshoot-experiment/diagnosis_{YYYY-MM-DD_HHMMSS}.md`
+
+```markdown
+# Experiment Failure Diagnosis
+
+## Context
+- Step: {step_name}
+- Worktree: {worktree_path}
+- Session ID: {session_id}
+- Diagnosis Time: {timestamp}
+
+## Failure Classification
+- **failure_type:** {type}
+- **is_fixable:** {true|false}
+
+## Evidence
+- termination_reason: {value}
+- write_call_count: {value}
+- exit_code: {value}
+- anomaly_count: {value}
+- elapsed_seconds: {value}
+
+## Anomalies Detected
+{list anomalies from anomalies.jsonl, or "none"}
+
+## Recommended Action
+{One paragraph describing what likely happened and what the orchestrator should do next:
+
+- stale_timeout: "The agent was idle while a background task ran. Re-attempt the phase
+  with a revised plan scope or split long-running operations into separate steps."
+- context_exhaustion: "The session hit the context limit mid-implementation. Retry
+  the phase — the committed artifacts remain intact."
+- build_failure: "A code build or import error prevented completion. The next phase
+  attempt should focus on resolving the identified error."
+- data_missing: "Required experiment data was not available. Adjust experiment
+  parameters or data acquisition strategy."
+- environment_error/unknown: "Automated remediation is not feasible. Human review
+  of the session log is required."}
+```
+
+### Step 6: Emit Structured Output Tokens
+
+Emit these tokens on their own lines at the end of the response as literal plain text
+with no markdown formatting on the token names. The adjudicator performs a regex match
+on the exact token name — decorators cause match failure.
+
+```
+diagnosis_path = {absolute_path_to_report}
+failure_type = {stale_timeout|context_exhaustion|build_failure|data_missing|environment_error|unknown}
+is_fixable = {true|false}
+```
+
+## Graceful Degradation
+
+If at any point session data is unavailable (missing `sessions.jsonl`, no matching
+session, missing `summary.json`):
+- Set `failure_type = unknown`
+- Set `is_fixable = false`
+- Write a minimal diagnosis noting the specific lookup failure
+- Emit output tokens and exit cleanly — never abort
+
+## gh Unavailable Fallback
+
+This skill does not require `gh`. It reads only local session log files.

--- a/src/autoskillit/skills_extended/troubleshoot-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/troubleshoot-experiment/SKILL.md
@@ -89,13 +89,12 @@ Apply this decision table in priority order (stop at the first match):
 | Priority | Condition | `failure_type` | `is_fixable` |
 |----------|-----------|----------------|--------------|
 | 1 | `termination_reason == "context_limit"` | `context_exhaustion` | `true` |
-| 2 | `termination_reason == "stale"` AND `write_call_count == 0` | `stale_timeout` | `true` |
-| 3 | `termination_reason == "stale"` AND `write_call_count > 0` | `stale_timeout` | `true` |
-| 4 | `exit_code != 0` AND logs contain build/compile error keywords (`SyntaxError`, `ModuleNotFoundError`, `ImportError`, `error: command`) | `build_failure` | `true` |
-| 5 | `blocked_hypotheses` token present in run-experiment results OR results file contains `## Status: FAILED` with data acquisition errors | `data_missing` | `true` |
-| 6 | Logs contain environment/infra keywords (`Permission denied`, `No such file or directory` for system paths, `Connection refused`) | `environment_error` | `false` |
-| 7 | `anomaly_count > 0` AND any anomaly `kind` in `["oom_critical", "zombie_persistent"]` | `environment_error` | `false` |
-| 8 | All other cases | `unknown` | `false` |
+| 2 | `termination_reason == "stale"` | `stale_timeout` | `true` |
+| 3 | `exit_code != 0` AND logs contain build/compile error keywords (`SyntaxError`, `ModuleNotFoundError`, `ImportError`, `error: command`) | `build_failure` | `true` |
+| 4 | `blocked_hypotheses` token present in run-experiment results OR results file contains `## Status: FAILED` with data acquisition errors | `data_missing` | `true` |
+| 5 | Logs contain environment/infra keywords (`Permission denied`, `No such file or directory` for system paths, `Connection refused`) | `environment_error` | `false` |
+| 6 | `anomaly_count > 0` AND any anomaly `kind` in `["oom_critical", "zombie_persistent"]` | `environment_error` | `false` |
+| 7 | All other cases | `unknown` | `false` |
 
 ### Step 5: Write Diagnosis Report
 

--- a/src/autoskillit/skills_extended/troubleshoot-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/troubleshoot-experiment/SKILL.md
@@ -91,7 +91,7 @@ Apply this decision table in priority order (stop at the first match):
 | 1 | `termination_reason == "context_limit"` | `context_exhaustion` | `true` |
 | 2 | `termination_reason == "stale"` | `stale_timeout` | `true` |
 | 3 | `exit_code != 0` AND logs contain build/compile error keywords (`SyntaxError`, `ModuleNotFoundError`, `ImportError`, `error: command`) | `build_failure` | `true` |
-| 4 | `blocked_hypotheses` token present in run-experiment results OR results file contains `## Status: FAILED` with data acquisition errors | `data_missing` | `true` |
+| 4 | `step_name == "run_experiment"` AND (`blocked_hypotheses` token present in run-experiment results OR results file contains `## Status: FAILED` with data acquisition errors) | `data_missing` | `true` |
 | 5 | Logs contain environment/infra keywords (`Permission denied`, `No such file or directory` for system paths, `Connection refused`) | `environment_error` | `false` |
 | 6 | `anomaly_count > 0` AND any anomaly `kind` in `["oom_critical", "zombie_persistent"]` | `environment_error` | `false` |
 | 7 | All other cases | `unknown` | `false` |

--- a/src/autoskillit/skills_extended/write-recipe/SKILL.md
+++ b/src/autoskillit/skills_extended/write-recipe/SKILL.md
@@ -234,7 +234,7 @@ implement-experiment, implement-worktree, implement-worktree-no-merge, investiga
 make-experiment-diag, make-groups, make-plan, make-req, merge-pr, mermaid, migrate-recipes, open-integration-pr,
 open-kitchen, open-pr, open-research-pr, pipeline-summary, plan-experiment, prepare-issue, process-issues, rectify, report-bug,
 resolve-design-review, resolve-failures, resolve-merge-conflicts, resolve-research-review, resolve-review, retry-worktree, review-approach, review-design, review-pr, review-research-pr, run-experiment,
-scope, setup-project, smoke-task, sprint-planner, triage-issues, validate-audit, verify-diag, write-recipe, write-report
+scope, setup-project, smoke-task, sprint-planner, triage-issues, troubleshoot-experiment, validate-audit, verify-diag, write-recipe, write-report
 
 ## Skill Reference Disambiguation
 

--- a/tests/recipe/test_research_recipe_diag.py
+++ b/tests/recipe/test_research_recipe_diag.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 
 import pytest
 
@@ -63,4 +62,6 @@ def test_research_recipe_no_validation_errors(recipe):
     test above but makes the dead-reference intent explicit.
     """
     errors = validate_recipe(recipe)
-    assert not errors, f"research.yaml has validation errors (may include dead step references): {errors}"
+    assert not errors, (
+        f"research.yaml has validation errors (may include dead step references): {errors}"
+    )

--- a/tests/recipe/test_research_recipe_diag.py
+++ b/tests/recipe/test_research_recipe_diag.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
@@ -46,11 +45,9 @@ def test_implement_phase_uses_implement_experiment(recipe):
 
 
 def test_troubleshoot_step_captures_required_tokens(recipe):
-    """troubleshoot_implement_failure must capture diagnosis_path, failure_type, is_fixable."""
+    """troubleshoot_implement_failure must capture is_fixable for downstream routing."""
     step = recipe.steps["troubleshoot_implement_failure"]
     capture = step.capture or {}
-    assert "diagnosis_path" in capture
-    assert "failure_type" in capture
     assert "is_fixable" in capture
 
 

--- a/tests/recipe/test_research_recipe_diag.py
+++ b/tests/recipe/test_research_recipe_diag.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+
+import pytest
+
+from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
+from autoskillit.recipe.validator import validate_recipe
+
+RESEARCH_RECIPE_PATH = builtin_recipes_dir() / "research.yaml"
+
+
+@pytest.fixture(scope="module")
+def recipe():
+    return load_recipe(RESEARCH_RECIPE_PATH)
+
+
+def test_research_recipe_validates_after_diag_changes(recipe):
+    """research.yaml must pass structural validation with new troubleshoot steps."""
+    errors = validate_recipe(recipe)
+    assert not errors, f"Validation errors: {errors}"
+
+
+def test_research_recipe_has_troubleshoot_step(recipe):
+    """research.yaml must contain the troubleshoot_implement_failure step."""
+    step_names = list(recipe.steps.keys())
+    assert "troubleshoot_implement_failure" in step_names
+    assert "route_implement_failure" in step_names
+
+
+def test_implement_phase_failure_routes_to_troubleshoot(recipe):
+    """implement_phase on_failure must route to troubleshoot_implement_failure."""
+    step = recipe.steps["implement_phase"]
+    assert step.on_failure == "troubleshoot_implement_failure"
+
+
+def test_implement_phase_exhausted_routes_to_run_experiment(recipe):
+    """implement_phase on_exhausted must route to run_experiment (not escalate)."""
+    step = recipe.steps["implement_phase"]
+    assert step.on_exhausted == "run_experiment"
+
+
+def test_implement_phase_uses_implement_experiment(recipe):
+    """implement_phase must use implement-experiment, not retry-worktree."""
+    step = recipe.steps["implement_phase"]
+    skill_cmd = step.with_args.get("skill_command", "")
+    assert "implement-experiment" in skill_cmd
+    assert "retry-worktree" not in skill_cmd
+
+
+def test_troubleshoot_step_captures_required_tokens(recipe):
+    """troubleshoot_implement_failure must capture diagnosis_path, failure_type, is_fixable."""
+    step = recipe.steps["troubleshoot_implement_failure"]
+    capture = step.capture or {}
+    assert "diagnosis_path" in capture
+    assert "failure_type" in capture
+    assert "is_fixable" in capture
+
+
+def test_research_recipe_no_validation_errors(recipe):
+    """All routing targets in research.yaml must be valid step names (no dead references).
+
+    Unknown step references are caught by validate_recipe as structural errors — there
+    is no separate semantic rule for them. This test is equivalent to the validation
+    test above but makes the dead-reference intent explicit.
+    """
+    errors = validate_recipe(recipe)
+    assert not errors, f"research.yaml has validation errors (may include dead step references): {errors}"

--- a/tests/recipe/test_research_recipe_diag.py
+++ b/tests/recipe/test_research_recipe_diag.py
@@ -49,16 +49,3 @@ def test_troubleshoot_step_captures_required_tokens(recipe):
     step = recipe.steps["troubleshoot_implement_failure"]
     capture = step.capture or {}
     assert "is_fixable" in capture
-
-
-def test_research_recipe_no_validation_errors(recipe):
-    """All routing targets in research.yaml must be valid step names (no dead references).
-
-    Unknown step references are caught by validate_recipe as structural errors — there
-    is no separate semantic rule for them. This test is equivalent to the validation
-    test above but makes the dead-reference intent explicit.
-    """
-    errors = validate_recipe(recipe)
-    assert not errors, (
-        f"research.yaml has validation errors (may include dead step references): {errors}"
-    )

--- a/tests/skills/test_troubleshoot_experiment_contracts.py
+++ b/tests/skills/test_troubleshoot_experiment_contracts.py
@@ -1,0 +1,16 @@
+from autoskillit.core.paths import pkg_root
+from autoskillit.workspace.skills import SkillResolver
+
+
+def test_troubleshoot_experiment_skill_is_discoverable():
+    """troubleshoot-experiment must be discoverable via SkillResolver."""
+    resolver = SkillResolver()
+    skills = resolver.list_all()
+    skill_names = [s.name for s in skills]
+    assert "troubleshoot-experiment" in skill_names
+
+
+def test_troubleshoot_experiment_skill_has_skill_md():
+    """troubleshoot-experiment directory must contain SKILL.md."""
+    skill_path = pkg_root() / "skills_extended" / "troubleshoot-experiment" / "SKILL.md"
+    assert skill_path.exists(), f"SKILL.md not found at {skill_path}"

--- a/tests/workspace/test_skills.py
+++ b/tests/workspace/test_skills.py
@@ -426,17 +426,17 @@ class TestSkillResolver:
         assert names == {"open-kitchen", "close-kitchen", "sous-chef"}
 
     def test_87_skills_in_skills_extended(self) -> None:
-        """skills_extended/ contains exactly 87 SKILL.md-carrying directories."""
+        """skills_extended/ contains exactly 88 SKILL.md-carrying directories."""
         skills = [
             d
             for d in bundled_skills_extended_dir().iterdir()
             if d.is_dir() and (d / "SKILL.md").is_file()
         ]
-        assert len(skills) == 87
+        assert len(skills) == 88
 
     def test_skill_resolver_list_all_total_count(self) -> None:
-        """list_all() returns 89 public skills (2 Tier-1 + 87 extended)."""
-        assert len(SkillResolver().list_all()) == 89
+        """list_all() returns 90 public skills (2 Tier-1 + 88 extended)."""
+        assert len(SkillResolver().list_all()) == 90
 
     def test_skill_resolver_resolve_extended_skill(self) -> None:
         """resolve() finds a skill living in skills_extended/ with BUNDLED_EXTENDED source."""


### PR DESCRIPTION
## Summary

This plan adds automated failure diagnosis to the research pipeline (issue #635). There are two distinct requirements:

**DIAG**: Create a `troubleshoot-experiment` skill that reads session logs and process traces to classify why a research step failed, then emit a structured diagnostic artifact and `is_fixable` signal. Wire this skill into `research.yaml` so that `implement_phase` failures route to it instead of dying at `escalate_stop`.

**SEP**: Fix the structural misuse of `retry-worktree` in `implement_phase`. The skill `retry-worktree` is designed to *resume* context-exhausted `implement-worktree` sessions — it is not a primary implementation driver. The research recipe already has the correct purpose-built skill: `implement-experiment`, which explicitly forbids experiment execution during implementation and routes context exhaustion directly to `run-experiment`. Switching `implement_phase` to use `implement-experiment` addresses REQ-SEP-001 and REQ-SEP-002 at the skill level, where the constraint is enforceable.

## Requirements

### DIAG — Experiment Failure Diagnosis

- **REQ-DIAG-001:** The system must provide a skill that investigates why a research recipe step failed by reading session logs and process traces.
- **REQ-DIAG-002:** The skill must classify the failure type (stale timeout, context exhaustion, build failure, data missing, parameter issue, unknown).
- **REQ-DIAG-003:** The skill must emit a structured diagnostic artifact that downstream steps or the human can act on.
- **REQ-DIAG-004:** The research recipe must route experiment failures to the diagnostic skill instead of `escalate_stop`.

### SEP — Structural Separation of Implementation and Execution

- **REQ-SEP-001:** Implementation worktree steps must not perform experiment execution (benchmarks, profiling, data collection).
- **REQ-SEP-002:** Experiment execution must route through the `run_experiment` step (or equivalent) which has appropriate timeout and retry semantics.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    START([RESEARCH PIPELINE])
    ESCALATE([escalate_stop])
    COMPLETE([research_complete])

    subgraph PhaseMgmt ["Phase Management"]
        plan_phase["● plan_phase<br/>━━━━━━━━━━<br/>make-plan skill<br/>plans current group"]
        implement_phase["● implement_phase<br/>━━━━━━━━━━<br/>implement-experiment<br/>(was: retry-worktree)<br/>stale_threshold: 2400"]
        next_phase{"next_phase_or_experiment<br/>━━━━━━━━━━<br/>more phases?"}
    end

    subgraph DiagPhase ["★ Failure Diagnosis (NEW)"]
        troubleshoot["★ troubleshoot_implement_failure<br/>━━━━━━━━━━<br/>troubleshoot-experiment skill<br/>worktree_path + implement_phase"]
        route_fix{"★ route_implement_failure<br/>━━━━━━━━━━<br/>is_fixable?"}
    end

    subgraph SkillInternals ["★ troubleshoot-experiment Internals"]
        direction TB
        init_idx["★ initialize code-index<br/>━━━━━━━━━━<br/>set_project_path(worktree_path)"]
        session_lookup["★ locate failed session<br/>━━━━━━━━━━<br/>sessions.jsonl<br/>select success=false + cwd match"]
        read_diags["★ read session diagnostics<br/>━━━━━━━━━━<br/>summary.json: termination_reason<br/>write_call_count, exit_code<br/>anomalies.jsonl: kind, severity"]
        classify{"★ classify failure type<br/>━━━━━━━━━━<br/>priority-ordered<br/>decision table"}
        write_diag["★ diagnosis_{ts}.md<br/>━━━━━━━━━━<br/>failure_type, is_fixable<br/>evidence + recommended action"]
        emit_tokens["★ emit output tokens<br/>━━━━━━━━━━<br/>diagnosis_path=<br/>failure_type=<br/>is_fixable="]
    end

    subgraph ExperimentPhase ["Experiment Phase"]
        run_experiment["run_experiment<br/>━━━━━━━━━━<br/>run-experiment skill<br/>stale_threshold: 2400, retries: 2"]
    end

    START --> plan_phase
    plan_phase --> implement_phase

    implement_phase -->|"on_success"| next_phase
    implement_phase -->|"on_failure"| troubleshoot
    implement_phase -->|"on_exhausted / on_context_limit"| run_experiment

    next_phase -->|"more_phases"| plan_phase
    next_phase -->|"done"| run_experiment

    troubleshoot --> init_idx
    init_idx --> session_lookup
    session_lookup -->|"session found"| read_diags
    session_lookup -->|"no session / missing log"| write_diag
    read_diags --> classify

    classify -->|"context_limit → context_exhaustion, fixable=true"| write_diag
    classify -->|"stale + write=0 → stale_timeout, fixable=true"| write_diag
    classify -->|"exit!=0 + build error → build_failure, fixable=true"| write_diag
    classify -->|"infra error / OOM → environment_error, fixable=false"| write_diag
    classify -->|"unknown"| write_diag

    write_diag --> emit_tokens
    emit_tokens --> route_fix

    route_fix -->|"is_fixable=true"| plan_phase
    route_fix -->|"is_fixable=false"| ESCALATE

    troubleshoot -->|"on_failure (skill crash)"| ESCALATE

    run_experiment --> COMPLETE

    class START,ESCALATE,COMPLETE terminal;
    class plan_phase,implement_phase handler;
    class next_phase,route_fix,classify stateNode;
    class troubleshoot,init_idx,session_lookup,read_diags,write_diag,emit_tokens newComponent;
```

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph L2_Recipe ["L2 — Recipe System"]
        recipe_io["recipe/io.py<br/>━━━━━━━━━━<br/>load_recipe, builtin_recipes_dir"]
        recipe_validator["recipe/validator.py<br/>━━━━━━━━━━<br/>validate_recipe"]
        recipe_contracts["recipe/contracts.py<br/>━━━━━━━━━━<br/>contract card generation"]
    end

    subgraph L1_Workspace ["L1 — Workspace"]
        workspace_skills["workspace/skills.py<br/>━━━━━━━━━━<br/>SkillResolver<br/>discovers skills_extended/"]
    end

    subgraph L0_Core ["L0 — Core"]
        core_paths["core/paths.py<br/>━━━━━━━━━━<br/>pkg_root()<br/>canonical package root"]
    end

    subgraph DataRecipes ["Data — Recipes (YAML)"]
        research_yaml["● recipes/research.yaml<br/>━━━━━━━━━━<br/>implement-experiment (was: retry-worktree)<br/>on_failure → troubleshoot_implement_failure<br/>on_exhausted → run_experiment"]
    end

    subgraph DataContracts ["Data — Contracts (YAML)"]
        skill_contracts["● recipe/skill_contracts.yaml<br/>━━━━━━━━━━<br/>★ troubleshoot-experiment entry<br/>is_fixable output pattern"]
    end

    subgraph DataSkills ["Data — Skills (SKILL.md)"]
        troubleshoot_skill["★ skills_extended/troubleshoot-experiment/<br/>━━━━━━━━━━<br/>session log reader<br/>failure classifier, is_fixable emitter"]
        implement_exp["skills_extended/implement-experiment/<br/>━━━━━━━━━━<br/>no experiment execution<br/>routes exhaustion → run-experiment"]
    end

    subgraph Tests ["Tests"]
        test_diag["★ tests/recipe/test_research_recipe_diag.py<br/>━━━━━━━━━━<br/>validates research.yaml routing<br/>asserts skill_command swap"]
        test_contracts["★ tests/skills/test_troubleshoot_experiment_contracts.py<br/>━━━━━━━━━━<br/>SkillResolver discovery<br/>SKILL.md existence"]
        test_skills_ws["● tests/workspace/test_skills.py<br/>━━━━━━━━━━<br/>skill count +1"]
    end

    recipe_io -->|"loads at runtime"| research_yaml
    recipe_validator -->|"validates"| research_yaml
    recipe_contracts -->|"loads at runtime"| skill_contracts
    research_yaml -->|"skill_command references"| troubleshoot_skill
    research_yaml -->|"skill_command references"| implement_exp
    skill_contracts -->|"contract entry for"| troubleshoot_skill
    workspace_skills -->|"discovers via pkg_root()"| troubleshoot_skill
    workspace_skills -->|"uses"| core_paths
    test_diag -->|"imports"| recipe_io
    test_diag -->|"imports"| recipe_validator
    test_contracts -->|"imports"| workspace_skills
    test_contracts -->|"imports"| core_paths
    test_skills_ws -->|"imports"| workspace_skills

    class recipe_io,recipe_validator,recipe_contracts phase;
    class workspace_skills handler;
    class core_paths stateNode;
    class research_yaml,skill_contracts output;
    class troubleshoot_skill newComponent;
    class implement_exp handler;
    class test_diag,test_contracts newComponent;
    class test_skills_ws handler;
```

Closes #635

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260405-193031-162971/.autoskillit/temp/make-plan/research_recipe_troubleshoot_plan_2026-04-05_193500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 2.9k | 93.0k | 4.6M | 271.4k | 4 | 37m 40s |
| verify | 109 | 64.2k | 5.4M | 277.1k | 4 | 28m 55s |
| implement | 224 | 71.2k | 12.5M | 282.5k | 4 | 32m 50s |
| audit_impl | 117 | 25.1k | 1.0M | 114.6k | 3 | 12m 6s |
| open_pr | 131 | 76.9k | 4.8M | 232.2k | 4 | 27m 43s |
| review_pr | 100 | 134.7k | 4.3M | 237.6k | 3 | 38m 8s |
| resolve_review | 77 | 40.4k | 3.7M | 117.7k | 2 | 18m 16s |
| fix | 91 | 32.1k | 3.8M | 120.9k | 2 | 21m 36s |
| diagnose_ci | 13 | 1.4k | 161.4k | 15.6k | 1 | 37s |
| resolve_ci | 18 | 3.7k | 293.8k | 29.1k | 1 | 3m 2s |
| **Total** | 3.8k | 542.7k | 40.5M | 1.7M | | 3h 40m |