### PR TITLE
Rectify: Sub-Skill Refusal Handling and Diagram Styling Contract Enforcement

### DIFF
--- a/src/autoskillit/skills_extended/arch-lens-c4-container/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-c4-container/SKILL.md
@@ -36,6 +36,7 @@ hooks:
 - Show technology choices for each container
 - Identify external systems and integrations
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
+- If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
 - After writing the diagram file, emit the **absolute path** as a structured output
   token immediately before `%%ORDER_UP%%`. Resolve the relative `temp/arch-lens-c4-container/...`
   save path to absolute by prepending the full CWD:

--- a/src/autoskillit/skills_extended/arch-lens-concurrency/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-concurrency/SKILL.md
@@ -37,6 +37,7 @@ hooks:
 - Identify thread safety guarantees
 - Document the concurrency MODEL used
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
+- If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
 - After writing the diagram file, emit the **absolute path** as a structured output
   token immediately before `%%ORDER_UP%%`. Resolve the relative `temp/arch-lens-concurrency/...`
   save path to absolute by prepending the full CWD:

--- a/src/autoskillit/skills_extended/arch-lens-data-lineage/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-data-lineage/SKILL.md
@@ -37,6 +37,7 @@ hooks:
 - Identify the single source of truth
 - Distinguish read vs write operations
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
+- If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
 - After writing the diagram file, emit the **absolute path** as a structured output
   token immediately before `%%ORDER_UP%%`. Resolve the relative `temp/arch-lens-data-lineage/...`
   save path to absolute by prepending the full CWD:

--- a/src/autoskillit/skills_extended/arch-lens-deployment/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-deployment/SKILL.md
@@ -37,6 +37,7 @@ hooks:
 - Include network/communication protocols
 - Document storage locations
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
+- If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
 - After writing the diagram file, emit the **absolute path** as a structured output
   token immediately before `%%ORDER_UP%%`. Resolve the relative `temp/arch-lens-deployment/...`
   save path to absolute by prepending the full CWD:

--- a/src/autoskillit/skills_extended/arch-lens-development/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-development/SKILL.md
@@ -37,6 +37,7 @@ hooks:
 - Document test framework setup
 - Include entry points
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
+- If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
 - After writing the diagram file, emit the **absolute path** as a structured output
   token immediately before `%%ORDER_UP%%`. Resolve the relative `temp/arch-lens-development/...`
   save path to absolute by prepending the full CWD:

--- a/src/autoskillit/skills_extended/arch-lens-error-resilience/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-error-resilience/SKILL.md
@@ -37,6 +37,7 @@ hooks:
 - Document retry limits and circuit breakers
 - Include exception hierarchy if present
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
+- If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
 - After writing the diagram file, emit the **absolute path** as a structured output
   token immediately before `%%ORDER_UP%%`. Resolve the relative `temp/arch-lens-error-resilience/...`
   save path to absolute by prepending the full CWD:

--- a/src/autoskillit/skills_extended/arch-lens-module-dependency/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-module-dependency/SKILL.md
@@ -37,6 +37,7 @@ hooks:
 - Flag circular dependencies and violations
 - Calculate fan-in for key modules
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
+- If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
 - After writing the diagram file, emit the **absolute path** as a structured output
   token immediately before `%%ORDER_UP%%`. Resolve the relative `temp/arch-lens-module-dependency/...`
   save path to absolute by prepending the full CWD:

--- a/src/autoskillit/skills_extended/arch-lens-operational/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-operational/SKILL.md
@@ -37,6 +37,7 @@ hooks:
 - Document configuration hierarchy
 - Include monitoring and logging outputs
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
+- If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
 - After writing the diagram file, emit the **absolute path** as a structured output
   token immediately before `%%ORDER_UP%%`. Resolve the relative `temp/arch-lens-operational/...`
   save path to absolute by prepending the full CWD:

--- a/src/autoskillit/skills_extended/arch-lens-process-flow/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-process-flow/SKILL.md
@@ -36,6 +36,7 @@ hooks:
 - Show decision points as diamonds
 - Include loop mechanisms and retry logic
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
+- If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
 - After writing the diagram file, emit the **absolute path** as a structured output
   token immediately before `%%ORDER_UP%%`. Resolve the relative `temp/arch-lens-process-flow/...`
   save path to absolute by prepending the full CWD:

--- a/src/autoskillit/skills_extended/arch-lens-repository-access/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-repository-access/SKILL.md
@@ -37,6 +37,7 @@ hooks:
 - Document key query patterns
 - Identify format conversion boundaries
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
+- If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
 - After writing the diagram file, emit the **absolute path** as a structured output
   token immediately before `%%ORDER_UP%%`. Resolve the relative `temp/arch-lens-repository-access/...`
   save path to absolute by prepending the full CWD:

--- a/src/autoskillit/skills_extended/arch-lens-scenarios/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-scenarios/SKILL.md
@@ -37,6 +37,7 @@ hooks:
 - Select 3-5 representative scenarios
 - Validate components work together
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
+- If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
 - After writing the diagram file, emit the **absolute path** as a structured output
   token immediately before `%%ORDER_UP%%`. Resolve the relative `temp/arch-lens-scenarios/...`
   save path to absolute by prepending the full CWD:

--- a/src/autoskillit/skills_extended/arch-lens-security/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-security/SKILL.md
@@ -37,6 +37,7 @@ hooks:
 - Document path contracts and restrictions
 - Include process isolation mechanisms
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
+- If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
 - After writing the diagram file, emit the **absolute path** as a structured output
   token immediately before `%%ORDER_UP%%`. Resolve the relative `temp/arch-lens-security/...`
   save path to absolute by prepending the full CWD:

--- a/src/autoskillit/skills_extended/arch-lens-state-lifecycle/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-state-lifecycle/SKILL.md
@@ -37,6 +37,7 @@ hooks:
 - Document validation gates
 - Include resume detection strategy
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
+- If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
 - After writing the diagram file, emit the **absolute path** as a structured output
   token immediately before `%%ORDER_UP%%`. Resolve the relative `temp/arch-lens-state-lifecycle/...`
   save path to absolute by prepending the full CWD:

--- a/src/autoskillit/skills_extended/exp-lens-benchmark-representativeness/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-benchmark-representativeness/SKILL.md
@@ -37,6 +37,7 @@ hooks:
 - Document the relationship between benchmark selection and generalization claims
 - Include a coverage matrix mapping scenarios to metrics
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
+- If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
 - Write output to `.autoskillit/temp/exp-lens-benchmark-representativeness/exp_diag_benchmark_representativeness_{YYYY-MM-DD_HHMMSS}.md`
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):

--- a/src/autoskillit/skills_extended/exp-lens-causal-assumptions/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-causal-assumptions/SKILL.md
@@ -37,6 +37,7 @@ hooks:
 - Flag all unblocked backdoor paths explicitly
 - Document the identification strategy with testable assumptions
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
+- If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
 - Write output to `.autoskillit/temp/exp-lens-causal-assumptions/exp_diag_causal_assumptions_{YYYY-MM-DD_HHMMSS}.md`
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):

--- a/src/autoskillit/skills_extended/exp-lens-comparator-construction/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-comparator-construction/SKILL.md
@@ -38,6 +38,7 @@ hooks:
 - Assess whether each comparator is the best available alternative at the time of the experiment
 - Identify temporal drift in baseline relevance
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
+- If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
 - Write output to `.autoskillit/temp/exp-lens-comparator-construction/exp_diag_comparator_construction_{YYYY-MM-DD_HHMMSS}.md`
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):

--- a/src/autoskillit/skills_extended/exp-lens-error-budget/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-error-budget/SKILL.md
@@ -38,6 +38,7 @@ hooks:
 - Flag any sequential peeking without a formal stopping rule as a critical defect
 - Evaluate whether the minimum detectable effect is practically meaningful, not just statistically chosen
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
+- If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
 - Write output to `.autoskillit/temp/exp-lens-error-budget/exp_diag_error_budget_{YYYY-MM-DD_HHMMSS}.md`
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):

--- a/src/autoskillit/skills_extended/exp-lens-estimand-clarity/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-estimand-clarity/SKILL.md
@@ -37,6 +37,7 @@ hooks:
 - Identify the aggregation level (unit, group, time) explicitly
 - Document how complications (missing data, failures, exclusions) are handled
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
+- If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
 - Write output to `.autoskillit/temp/exp-lens-estimand-clarity/exp_diag_estimand_clarity_{YYYY-MM-DD_HHMMSS}.md`
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):

--- a/src/autoskillit/skills_extended/exp-lens-exploratory-confirmatory/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-exploratory-confirmatory/SKILL.md
@@ -36,6 +36,7 @@ hooks:
 - Distinguish genuine exploration (hypothesis-generating) from HARKing (hypothesis-after-results)
 - Flag absent preregistration as a finding without assuming bad faith
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
+- If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
 - Write output to `.autoskillit/temp/exp-lens-exploratory-confirmatory/exp_diag_exploratory_confirmatory_{YYYY-MM-DD_HHMMSS}.md`
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):

--- a/src/autoskillit/skills_extended/exp-lens-fair-comparison/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-fair-comparison/SKILL.md
@@ -37,6 +37,7 @@ hooks:
 - Flag undisclosed compute or tuning as a finding, not an assumption
 - Assess the winner's curse: did the proposed method benefit from more selection pressure?
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
+- If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
 - Write output to `.autoskillit/temp/exp-lens-fair-comparison/exp_diag_fair_comparison_{YYYY-MM-DD_HHMMSS}.md`
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):

--- a/src/autoskillit/skills_extended/exp-lens-governance-risk/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-governance-risk/SKILL.md
@@ -36,6 +36,7 @@ hooks:
 - Treat absent limitation disclosure as a finding requiring explicit flagging
 - Distinguish risks that are monitored from risks that are merely acknowledged
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
+- If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
 - Write output to `.autoskillit/temp/exp-lens-governance-risk/exp_diag_governance_risk_{YYYY-MM-DD_HHMMSS}.md`
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):

--- a/src/autoskillit/skills_extended/exp-lens-iterative-learning/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-iterative-learning/SKILL.md
@@ -37,6 +37,7 @@ hooks:
 - Assess whether the stopping rule is principled or arbitrary
 - Surface interaction structure that one-factor-at-a-time designs would miss
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
+- If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
 - Write output to `.autoskillit/temp/exp-lens-iterative-learning/exp_diag_iterative_learning_{YYYY-MM-DD_HHMMSS}.md`
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):

--- a/src/autoskillit/skills_extended/exp-lens-measurement-validity/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-measurement-validity/SKILL.md
@@ -37,6 +37,7 @@ hooks:
 - Assess reliability (stability under reruns) and sensitivity (ability to distinguish meaningful differences) for each metric
 - Identify where metric-construct alignment is weak or unsupported by evidence
 - BEFORE creating any optional diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
+- If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
 - Write output to `.autoskillit/temp/exp-lens-measurement-validity/exp_diag_measurement_validity_{YYYY-MM-DD_HHMMSS}.md`
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):

--- a/src/autoskillit/skills_extended/exp-lens-pipeline-integrity/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-pipeline-integrity/SKILL.md
@@ -37,6 +37,7 @@ hooks:
 - Flag all label-touching feature engineering steps
 - Document pipeline invariants that guard against leakage
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
+- If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
 - Write output to `.autoskillit/temp/exp-lens-pipeline-integrity/exp_diag_pipeline_integrity_{YYYY-MM-DD_HHMMSS}.md`
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):

--- a/src/autoskillit/skills_extended/exp-lens-randomization-blocking/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-randomization-blocking/SKILL.md
@@ -37,6 +37,7 @@ hooks:
 - Flag pseudoreplication risks (replicating at the wrong unit)
 - Verify that replication is adequate for the claimed inferential precision
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
+- If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
 - Write output to `.autoskillit/temp/exp-lens-randomization-blocking/exp_diag_randomization_blocking_{YYYY-MM-DD_HHMMSS}.md`
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):

--- a/src/autoskillit/skills_extended/exp-lens-reproducibility-artifacts/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-reproducibility-artifacts/SKILL.md
@@ -37,6 +37,7 @@ hooks:
 - Identify the weakest link in the reproduction chain
 - Flag all silent non-determinism risks
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
+- If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
 - Write output to `.autoskillit/temp/exp-lens-reproducibility-artifacts/exp_diag_reproducibility_artifacts_{YYYY-MM-DD_HHMMSS}.md`
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):

--- a/src/autoskillit/skills_extended/exp-lens-sensitivity-robustness/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-sensitivity-robustness/SKILL.md
@@ -38,6 +38,7 @@ hooks:
 - Flag cases where the most impactful choices are the least tested
 - Distinguish between ablations that were run and choices that were simply fixed
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
+- If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
 - Write output to `.autoskillit/temp/exp-lens-sensitivity-robustness/exp_diag_sensitivity_robustness_{YYYY-MM-DD_HHMMSS}.md`
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):

--- a/src/autoskillit/skills_extended/exp-lens-severity-testing/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-severity-testing/SKILL.md
@@ -36,6 +36,7 @@ hooks:
 - Rate severity before reporting conclusions, not after
 - Flag confirmatory theater: experiments designed to confirm rather than risk refutation
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
+- If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
 - Write output to `.autoskillit/temp/exp-lens-severity-testing/exp_diag_severity_testing_{YYYY-MM-DD_HHMMSS}.md`
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):

--- a/src/autoskillit/skills_extended/exp-lens-unit-interference/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-unit-interference/SKILL.md
@@ -37,6 +37,7 @@ hooks:
 - Identify every shared resource that could transmit treatment effects across groups
 - Distinguish direct spillover (shared cache) from indirect spillover (market equilibrium)
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
+- If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
 - Write output to `.autoskillit/temp/exp-lens-unit-interference/exp_diag_unit_interference_{YYYY-MM-DD_HHMMSS}.md`
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):

--- a/src/autoskillit/skills_extended/exp-lens-validity-threats/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-validity-threats/SKILL.md
@@ -36,6 +36,7 @@ hooks:
 - Assess mitigation strength honestly — "partially mitigated" is better than false confidence
 - Distinguish threats that are ruled out by design from those that remain plausible
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
+- If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
 - Write output to `.autoskillit/temp/exp-lens-validity-threats/exp_diag_validity_threats_{YYYY-MM-DD_HHMMSS}.md`
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):

--- a/src/autoskillit/skills_extended/exp-lens-variance-stability/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-variance-stability/SKILL.md
@@ -37,6 +37,7 @@ hooks:
 - Identify all sources of nondeterminism, not just random seeds
 - Report when confidence intervals are absent — absence is a finding, not an omission
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
+- If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
 - Write output to `.autoskillit/temp/exp-lens-variance-stability/exp_diag_variance_stability_{YYYY-MM-DD_HHMMSS}.md`
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):

--- a/src/autoskillit/skills_extended/make-arch-diag/SKILL.md
+++ b/src/autoskillit/skills_extended/make-arch-diag/SKILL.md
@@ -103,6 +103,7 @@ Choose appropriate diagram types:
 ### Step 5: Create Diagrams
 
 Use `/autoskillit:mermaid` skill to create each diagram:
+- Using ONLY classDef styles from the mermaid skill (no invented colors)
 - Follow standard color palette
 - Include legends
 - Add clear labels and descriptions

--- a/src/autoskillit/skills_extended/make-experiment-diag/SKILL.md
+++ b/src/autoskillit/skills_extended/make-experiment-diag/SKILL.md
@@ -90,6 +90,8 @@ Based on the user's description, match to the most appropriate lens using the se
 
 Use the Skill tool to load the selected `/autoskillit:exp-lens-{slug}` skill.
 
+If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with the exp-lens analysis. Abort this step and inform the user that the lens skill is unavailable.
+
 ### Step 4: Execute the Loaded Skill
 
 The loaded lens skill takes over and runs its full analysis workflow.

--- a/src/autoskillit/skills_extended/make-plan/SKILL.md
+++ b/src/autoskillit/skills_extended/make-plan/SKILL.md
@@ -150,6 +150,8 @@ call is mandatory at the start of every headless session that uses code-index to
 | State Lifecycle | `/autoskillit:arch-lens-state-lifecycle` |
 | Deployment | `/autoskillit:arch-lens-deployment` |
 
+If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, skip the diagram step and proceed without the architectural diagram.
+
 **5d. Create the diagram following the loaded skill's instructions:**
 - Focus on the PROPOSED changes (use `newComponent` class for new elements)
 - Show how new components integrate with existing architecture

--- a/src/autoskillit/skills_extended/make-plan/SKILL.md
+++ b/src/autoskillit/skills_extended/make-plan/SKILL.md
@@ -150,7 +150,7 @@ call is mandatory at the start of every headless session that uses code-index to
 | State Lifecycle | `/autoskillit:arch-lens-state-lifecycle` |
 | Deployment | `/autoskillit:arch-lens-deployment` |
 
-If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, skip the diagram step and proceed without the architectural diagram.
+If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, proceed without the architectural diagram.
 
 **5d. Create the diagram following the loaded skill's instructions:**
 - Focus on the PROPOSED changes (use `newComponent` class for new elements)

--- a/src/autoskillit/skills_extended/migrate-recipes/SKILL.md
+++ b/src/autoskillit/skills_extended/migrate-recipes/SKILL.md
@@ -51,6 +51,7 @@ The orchestrator provides all context in the prompt:
    - `missing_field`: The field that should be added if absent
 3. If changes are needed, use `/autoskillit:write-recipe` in edit mode:
    - Load the skill: invoke `/autoskillit:write-recipe` via the Skill tool
+   - If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, skip the recipe update and log a warning; proceed with remaining validation steps.
    - Provide the current YAML content
    - Describe all needed changes with the `instruction` text and before/after examples
 4. Validate the result with `validate_recipe`

--- a/src/autoskillit/skills_extended/open-integration-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/open-integration-pr/SKILL.md
@@ -241,7 +241,13 @@ This diagram is for a Pull Request. Focus the diagram on the areas of the codeba
 **2. Immediately call the Skill tool to load the arch-lens skill** (e.g., `/autoskillit:arch-lens-module-dependency`).
 The loaded skill will read the PR context file written in step 1 above.
 
+**If the Skill tool returns an error containing "disable-model-invocation" or "cannot be used",
+do NOT write a diagram freehand. Discard this lens iteration silently. If ALL arch-lens
+invocations fail this way, set `validated_diagrams = []` (the Architecture Impact section is
+omitted per Step 7 behavior).**
+
 **3. Follow the loaded skill's instructions** to explore the codebase and generate the diagram.
+Using ONLY classDef styles from the mermaid skill (no invented colors).
 
 The arch-lens skills write their output to `.autoskillit/temp/arch-lens-{lens-name}/` (relative to the current working directory). After each skill
 runs, read the generated markdown file and extract the mermaid code block(s).

--- a/src/autoskillit/skills_extended/open-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/open-pr/SKILL.md
@@ -222,6 +222,11 @@ This diagram is for a Pull Request. Focus the diagram on the areas of the codeba
 **2. Immediately call the Skill tool to load the arch-lens skill** (e.g., `/autoskillit:arch-lens-module-dependency`).
 The loaded skill will read the PR context file written in step 1 above.
 
+**If the Skill tool returns an error containing "disable-model-invocation" or "cannot be used",
+do NOT write a diagram freehand. Discard this lens iteration silently. If ALL arch-lens
+invocations fail this way, set `validated_diagrams = []` (the Architecture Impact section is
+omitted per Step 6 behavior).**
+
 **3. Follow the loaded skill's instructions** to explore the codebase and generate the diagram.
 
 The arch-lens skills write their output to `.autoskillit/temp/arch-lens-{lens-name}/` (relative to the current working directory). After each skill

--- a/src/autoskillit/skills_extended/open-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/open-pr/SKILL.md
@@ -228,6 +228,7 @@ invocations fail this way, set `validated_diagrams = []` (the Architecture Impac
 omitted per Step 6 behavior).**
 
 **3. Follow the loaded skill's instructions** to explore the codebase and generate the diagram.
+Using ONLY classDef styles from the mermaid skill (no invented colors).
 
 The arch-lens skills write their output to `.autoskillit/temp/arch-lens-{lens-name}/` (relative to the current working directory). After each skill
 runs, read the generated markdown file and extract the mermaid code block(s).

--- a/src/autoskillit/skills_extended/open-research-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/open-research-pr/SKILL.md
@@ -138,6 +138,13 @@ For each lens in `selected_lenses`:
    The lens skill reads the context, runs its analysis, and emits:
    `diagram_path = /absolute/path/to/.autoskillit/temp/exp-lens-{lens_slug}/exp_diag_{lens_slug}_{ts}.md`
 
+   **If the Skill tool returns an error containing "disable-model-invocation" or "cannot be used",
+   do NOT attempt to write a diagram freehand. Discard this lens iteration silently and continue
+   to the next lens_slug. If ALL lens invocations are refused this way, write a diagnostic note
+   to `.autoskillit/temp/open-research-pr/lens_unavailable_{timestamp}.txt` listing which lenses
+   were blocked, set `validated_diagrams = []`, and proceed to Step 5 (the Experiment Design
+   section will be omitted per Step 6 omission rules).**
+
 3. Capture `diagram_path` from the skill's output token. Read the file at that path.
    Extract the mermaid block.
 
@@ -249,3 +256,20 @@ pr_url = {url}
 ```
 
 Where `{url}` is the absolute GitHub PR URL, or an empty string when GitHub is unavailable.
+
+## Diagram Styling Reference
+
+Use the canonical 9-class mermaid classDef palette for all diagrams. Any freehand or
+fallback diagram generation **must** apply these definitions so nodes are styled correctly:
+
+```
+classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
+classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
+classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
+classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
+classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
+classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
+classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
+classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
+classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
+```

--- a/src/autoskillit/skills_extended/open-research-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/open-research-pr/SKILL.md
@@ -259,17 +259,4 @@ Where `{url}` is the absolute GitHub PR URL, or an empty string when GitHub is u
 
 ## Diagram Styling Reference
 
-Use the canonical 9-class mermaid classDef palette for all diagrams. Any freehand or
-fallback diagram generation **must** apply these definitions so nodes are styled correctly:
-
-```
-classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
-classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
-classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
-classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
-classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
-classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
-classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
-classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
-classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
-```
+Using ONLY classDef styles from the mermaid skill (no invented colors).

--- a/src/autoskillit/skills_extended/rectify/SKILL.md
+++ b/src/autoskillit/skills_extended/rectify/SKILL.md
@@ -173,6 +173,8 @@ After finalizing the plan, determine which architecture lens best illustrates th
 | State Lifecycle | `/autoskillit:arch-lens-state-lifecycle` |
 | Deployment | `/autoskillit:arch-lens-deployment` |
 
+If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, skip the diagram step and proceed without the architectural diagram.
+
 **4d. Create the diagram following the loaded skill's instructions:**
 - Focus on the PROPOSED changes (use `newComponent` class for new elements)
 - Show how new components integrate with existing architecture

--- a/src/autoskillit/skills_extended/setup-project/SKILL.md
+++ b/src/autoskillit/skills_extended/setup-project/SKILL.md
@@ -173,7 +173,7 @@ begin presenting the next workflow.
        List each conflicting skill name on its own line in the prompt.
      - Record the user's preferences and pass them as context to write-recipe
    - If yes: LOAD `/autoskillit:write-recipe` using the Skill tool to generate the script. The agent already has full context from the exploration phases (workflow name, detected variables like project_dir/work_dir/base_branch, tool call sequence, routing logic) — no explicit parameter passing is needed. write-recipe uses that context directly to produce a clean script.
-   - If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, skip recipe generation and prompt the user to create the recipe manually.
+   - If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, proceed without recipe generation and prompt the user to create the recipe manually.
    - Explain what a recipe is (discovered via `list_recipes` MCP tool, loaded via `load_recipe`, the agent interprets the YAML and executes the steps), show the generated script content
    - Track the user's approval — do NOT write to disk yet
    - Move to the next candidate workflow

--- a/src/autoskillit/skills_extended/setup-project/SKILL.md
+++ b/src/autoskillit/skills_extended/setup-project/SKILL.md
@@ -173,6 +173,7 @@ begin presenting the next workflow.
        List each conflicting skill name on its own line in the prompt.
      - Record the user's preferences and pass them as context to write-recipe
    - If yes: LOAD `/autoskillit:write-recipe` using the Skill tool to generate the script. The agent already has full context from the exploration phases (workflow name, detected variables like project_dir/work_dir/base_branch, tool call sequence, routing logic) — no explicit parameter passing is needed. write-recipe uses that context directly to produce a clean script.
+   - If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, skip recipe generation and prompt the user to create the recipe manually.
    - Explain what a recipe is (discovered via `list_recipes` MCP tool, loaded via `load_recipe`, the agent interprets the YAML and executes the steps), show the generated script content
    - Track the user's approval — do NOT write to disk yet
    - Move to the next candidate workflow

--- a/src/autoskillit/skills_extended/verify-diag/SKILL.md
+++ b/src/autoskillit/skills_extended/verify-diag/SKILL.md
@@ -71,6 +71,7 @@ For each ```` ```mermaid ```` block, validate:
 **6. Class definition syntax:**
 - `classDef` lines must end with semicolons only if using shorthand
 - `class A,B,C className;` — verify referenced node IDs exist in the diagram
+- Using ONLY classDef styles from the mermaid skill (no invented colors) — flag any non-canonical class names
 
 **7. Node ID rules:**
 - Node IDs must not start with numbers

--- a/src/autoskillit/skills_extended/write-recipe/SKILL.md
+++ b/src/autoskillit/skills_extended/write-recipe/SKILL.md
@@ -17,7 +17,7 @@ Format a workflow into a YAML recipe following the workflow schema.
 ## When to Use
 
 - **Standalone**: User wants to create a new recipe from scratch
-- **Loaded by another skill**: Another skill (e.g., setup-project) loads this via the Skill tool to format a workflow it has already discovered. If the Skill tool cannot be used (disable-model-invocation) or refuses to load this skill, the calling skill should skip recipe generation and proceed without it.
+- **Loaded by another skill**: Another skill (e.g., setup-project) loads this via the Skill tool to format a workflow it has already discovered.
 
 ## Arguments (standalone mode)
 

--- a/src/autoskillit/skills_extended/write-recipe/SKILL.md
+++ b/src/autoskillit/skills_extended/write-recipe/SKILL.md
@@ -17,7 +17,7 @@ Format a workflow into a YAML recipe following the workflow schema.
 ## When to Use
 
 - **Standalone**: User wants to create a new recipe from scratch
-- **Loaded by another skill**: Another skill (e.g., setup-project) loads this via the Skill tool to format a workflow it has already discovered
+- **Loaded by another skill**: Another skill (e.g., setup-project) loads this via the Skill tool to format a workflow it has already discovered. If the Skill tool cannot be used (disable-model-invocation) or refuses to load this skill, the calling skill should skip recipe generation and proceed without it.
 
 ## Arguments (standalone mode)
 

--- a/tests/contracts/conftest.py
+++ b/tests/contracts/conftest.py
@@ -1,0 +1,18 @@
+"""Shared constants for contract tests — avoids cross-file duplication."""
+
+REFUSAL_SIGNALS = [
+    "disable-model-invocation",
+    "cannot be used",
+    "refused",
+    "Skill tool returns",
+    "Skill tool fails",
+]
+
+ACTION_SIGNALS = [
+    "do not",
+    "do NOT",
+    "discard",
+    "skip",
+    "omit",
+    "proceed without",
+]

--- a/tests/contracts/test_mermaid_palette_contracts.py
+++ b/tests/contracts/test_mermaid_palette_contracts.py
@@ -1,0 +1,72 @@
+"""
+Contract: any SKILL.md that generates mermaid diagrams must either embed the canonical
+9-class palette or explicitly mandate loading the mermaid skill before drawing.
+Parametrized over all qualifying skills — self-updating as skills are added.
+"""
+import re
+from pathlib import Path
+import pytest
+
+_SKILLS_DIR = Path(__file__).parents[2] / "src/autoskillit/skills_extended"
+
+# Signals that a skill generates mermaid diagrams
+_MERMAID_GENERATOR_PATTERN = re.compile(
+    r"```mermaid|mermaid block|diagram_path|classDef|"
+    r"mermaid diagram|generate.{0,30}diagram|create.{0,30}diagram",
+    re.IGNORECASE,
+)
+
+# Canonical class names — at least 7 of 9 must appear
+_CANONICAL_CLASSES = frozenset({
+    "cli", "stateNode", "handler", "phase", "output",
+    "integration", "newComponent", "detector", "gap",
+})
+
+# Alternative: explicit mandate to load mermaid skill before drawing
+_MERMAID_LOAD_PATTERN = re.compile(
+    r"LOAD.{0,50}/autoskillit:mermaid|"
+    r"load.{0,50}mermaid.{0,30}Skill tool|"
+    r"Using ONLY classDef styles from the mermaid skill",
+    re.IGNORECASE,
+)
+
+
+def _find_diagram_generating_skills() -> list[tuple[str, Path]]:
+    results = []
+    for skill_dir in sorted(_SKILLS_DIR.iterdir()):
+        skill_md = skill_dir / "SKILL.md"
+        if not skill_md.exists():
+            continue
+        text = skill_md.read_text()
+        if _MERMAID_GENERATOR_PATTERN.search(text):
+            results.append((skill_dir.name, skill_md))
+    return results
+
+
+_DIAGRAM_SKILLS = _find_diagram_generating_skills()
+
+
+@pytest.mark.parametrize(
+    "skill_name,skill_md",
+    _DIAGRAM_SKILLS,
+    ids=[s[0] for s in _DIAGRAM_SKILLS],
+)
+def test_diagram_generating_skill_has_palette_or_mermaid_load(
+    skill_name: str, skill_md: Path
+):
+    """
+    Any skill that generates mermaid diagrams must either embed at least 7 of the 9
+    canonical class names OR mandate loading the mermaid skill before drawing.
+    Prevents invented class names and unstyled gray diagrams.
+    """
+    text = skill_md.read_text()
+    found = {name for name in _CANONICAL_CLASSES if name in text}
+    has_palette = len(found) >= 7
+    has_mermaid_load = bool(_MERMAID_LOAD_PATTERN.search(text))
+    assert has_palette or has_mermaid_load, (
+        f"{skill_name}/SKILL.md generates mermaid diagrams but neither embeds the "
+        f"canonical palette (found only {sorted(found)} of {len(_CANONICAL_CLASSES)}) "
+        f"nor mandates loading the mermaid skill before drawing. "
+        f"Add the 9-classDef block from mermaid/SKILL.md, or add to the checklist: "
+        f"'Using ONLY classDef styles from the mermaid skill (no invented colors)'."
+    )

--- a/tests/contracts/test_mermaid_palette_contracts.py
+++ b/tests/contracts/test_mermaid_palette_contracts.py
@@ -3,8 +3,10 @@ Contract: any SKILL.md that generates mermaid diagrams must either embed the can
 9-class palette or explicitly mandate loading the mermaid skill before drawing.
 Parametrized over all qualifying skills — self-updating as skills are added.
 """
+
 import re
 from pathlib import Path
+
 import pytest
 
 _SKILLS_DIR = Path(__file__).parents[2] / "src/autoskillit/skills_extended"
@@ -17,10 +19,19 @@ _MERMAID_GENERATOR_PATTERN = re.compile(
 )
 
 # Canonical class names — at least 7 of 9 must appear
-_CANONICAL_CLASSES = frozenset({
-    "cli", "stateNode", "handler", "phase", "output",
-    "integration", "newComponent", "detector", "gap",
-})
+_CANONICAL_CLASSES = frozenset(
+    {
+        "cli",
+        "stateNode",
+        "handler",
+        "phase",
+        "output",
+        "integration",
+        "newComponent",
+        "detector",
+        "gap",
+    }
+)
 
 # Alternative: explicit mandate to load mermaid skill before drawing
 _MERMAID_LOAD_PATTERN = re.compile(
@@ -51,9 +62,7 @@ _DIAGRAM_SKILLS = _find_diagram_generating_skills()
     _DIAGRAM_SKILLS,
     ids=[s[0] for s in _DIAGRAM_SKILLS],
 )
-def test_diagram_generating_skill_has_palette_or_mermaid_load(
-    skill_name: str, skill_md: Path
-):
+def test_diagram_generating_skill_has_palette_or_mermaid_load(skill_name: str, skill_md: Path):
     """
     Any skill that generates mermaid diagrams must either embed at least 7 of the 9
     canonical class names OR mandate loading the mermaid skill before drawing.

--- a/tests/contracts/test_mermaid_palette_contracts.py
+++ b/tests/contracts/test_mermaid_palette_contracts.py
@@ -13,7 +13,7 @@ _SKILLS_DIR = Path(__file__).parents[2] / "src/autoskillit/skills_extended"
 
 # Signals that a skill generates mermaid diagrams
 _MERMAID_GENERATOR_PATTERN = re.compile(
-    r"```mermaid|mermaid block|diagram_path|classDef|"
+    r"```mermaid|mermaid block|diagram_path|"
     r"mermaid diagram|generate.{0,30}diagram|create.{0,30}diagram",
     re.IGNORECASE,
 )
@@ -48,7 +48,7 @@ def _find_diagram_generating_skills() -> list[tuple[str, Path]]:
         skill_md = skill_dir / "SKILL.md"
         if not skill_md.exists():
             continue
-        text = skill_md.read_text()
+        text = skill_md.read_text(encoding="utf-8")
         if _MERMAID_GENERATOR_PATTERN.search(text):
             results.append((skill_dir.name, skill_md))
     return results
@@ -68,8 +68,10 @@ def test_diagram_generating_skill_has_palette_or_mermaid_load(skill_name: str, s
     canonical class names OR mandate loading the mermaid skill before drawing.
     Prevents invented class names and unstyled gray diagrams.
     """
-    text = skill_md.read_text()
-    found = {name for name in _CANONICAL_CLASSES if name in text}
+    text = skill_md.read_text(encoding="utf-8")
+    found = {
+        name for name in _CANONICAL_CLASSES if re.search(rf"classDef\s+{re.escape(name)}\b", text)
+    }
     has_palette = len(found) >= 7
     has_mermaid_load = bool(_MERMAID_LOAD_PATTERN.search(text))
     assert has_palette or has_mermaid_load, (

--- a/tests/contracts/test_open_pr_contracts.py
+++ b/tests/contracts/test_open_pr_contracts.py
@@ -94,3 +94,34 @@ def test_step2_prose_instructs_suffix_stripping(text):
     assert re.search(r"PART.*ONLY", step2_section), (
         "Step 2 prose must mention stripping the PART X ONLY suffix as a complete phrase"
     )
+
+
+def test_handles_skill_tool_refusal_for_arch_lens(text):
+    """
+    open-pr has the identical gap: arch-lens sub-skills invoked via the Skill tool
+    with no refusal handler. Enforces the same mechanism contract.
+    """
+    refusal_signals = [
+        "disable-model-invocation",
+        "cannot be used",
+        "refused",
+        "Skill tool returns",
+        "Skill tool fails",
+    ]
+    action_signals = [
+        "do not",
+        "do NOT",
+        "discard",
+        "skip",
+        "omit",
+        "proceed without",
+    ]
+    has_refusal = any(s in text for s in refusal_signals)
+    has_action = any(s in text for s in action_signals)
+    assert has_refusal, (
+        "open-pr SKILL.md must document what to do when the Skill tool refuses "
+        "an arch-lens invocation."
+    )
+    assert has_action, (
+        "open-pr SKILL.md must prescribe a concrete action when arch-lens refusal occurs."
+    )

--- a/tests/contracts/test_open_pr_contracts.py
+++ b/tests/contracts/test_open_pr_contracts.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.contracts.conftest import ACTION_SIGNALS, REFUSAL_SIGNALS
+
 SKILLS_DIR = Path(__file__).parents[2] / "src/autoskillit/skills_extended"
 SKILL = SKILLS_DIR / "open-pr/SKILL.md"
 
@@ -98,26 +100,11 @@ def test_step2_prose_instructs_suffix_stripping(text):
 
 def test_handles_skill_tool_refusal_for_arch_lens(text):
     """
-    open-pr has the identical gap: arch-lens sub-skills invoked via the Skill tool
-    with no refusal handler. Enforces the same mechanism contract.
+    SKILL.md must document what to do when the Skill tool refuses an arch-lens invocation.
+    Requires refusal detection language AND a prescribed concrete action.
     """
-    refusal_signals = [
-        "disable-model-invocation",
-        "cannot be used",
-        "refused",
-        "Skill tool returns",
-        "Skill tool fails",
-    ]
-    action_signals = [
-        "do not",
-        "do NOT",
-        "discard",
-        "skip",
-        "omit",
-        "proceed without",
-    ]
-    has_refusal = any(s in text for s in refusal_signals)
-    has_action = any(s in text for s in action_signals)
+    has_refusal = any(s in text for s in REFUSAL_SIGNALS)
+    has_action = any(s in text for s in ACTION_SIGNALS)
     assert has_refusal, (
         "open-pr SKILL.md must document what to do when the Skill tool refuses "
         "an arch-lens invocation."

--- a/tests/contracts/test_open_research_pr_contracts.py
+++ b/tests/contracts/test_open_research_pr_contracts.py
@@ -87,3 +87,63 @@ def test_output_contract():
     text = SKILL.read_text()
     assert "pr_url" in text
     assert "%%ORDER_UP%%" in text
+
+
+def test_handles_skill_tool_refusal_for_exp_lens():
+    """
+    SKILL.md must document what to do when the Skill tool refuses an exp-lens invocation.
+    Requires language explicitly addressing refusal AND prescribing a concrete action.
+    Vocabulary-only ('graceful', 'unavailable') is insufficient — mechanism is required.
+    """
+    text = SKILL.read_text()
+    refusal_signals = [
+        "disable-model-invocation",
+        "cannot be used",
+        "refused",
+        "Skill tool returns",
+        "Skill tool fails",
+    ]
+    action_signals = [
+        "do not",
+        "do NOT",
+        "discard",
+        "skip",
+        "omit",
+        "proceed without",
+    ]
+    has_refusal = any(s in text for s in refusal_signals)
+    has_action = any(s in text for s in action_signals)
+    assert has_refusal, (
+        "open-research-pr SKILL.md must document what to do when the Skill tool refuses "
+        "an exp-lens invocation. Expected: 'disable-model-invocation', 'cannot be used', "
+        "'refused', or equivalent near the lens invocation step."
+    )
+    assert has_action, (
+        "open-research-pr SKILL.md must prescribe a concrete action on refusal. "
+        "Expected: 'do NOT', 'discard', 'skip', 'omit', or equivalent."
+    )
+
+
+def test_embeds_canonical_classdef_palette():
+    """
+    SKILL.md must embed or reference the canonical 9-class mermaid palette.
+    Without this, any fallback diagram generation uses invented styling.
+    Fails if fewer than 7 of the 9 canonical class names appear in the file.
+    """
+    text = SKILL.read_text()
+    canonical_classes = {
+        "cli",
+        "stateNode",
+        "handler",
+        "phase",
+        "output",
+        "integration",
+        "newComponent",
+        "detector",
+        "gap",
+    }
+    found = {name for name in canonical_classes if name in text}
+    assert len(found) >= 7, (
+        f"open-research-pr SKILL.md must embed the canonical mermaid classDef palette "
+        f"(at least 7 of 9 names). Found only: {sorted(found)}"
+    )

--- a/tests/contracts/test_open_research_pr_contracts.py
+++ b/tests/contracts/test_open_research_pr_contracts.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+from tests.contracts.conftest import ACTION_SIGNALS, REFUSAL_SIGNALS
+
 SKILL = Path(__file__).parents[2] / "src/autoskillit/skills_extended/open-research-pr/SKILL.md"
 
 
@@ -93,26 +95,10 @@ def test_handles_skill_tool_refusal_for_exp_lens():
     """
     SKILL.md must document what to do when the Skill tool refuses an exp-lens invocation.
     Requires language explicitly addressing refusal AND prescribing a concrete action.
-    Vocabulary-only ('graceful', 'unavailable') is insufficient — mechanism is required.
     """
     text = SKILL.read_text()
-    refusal_signals = [
-        "disable-model-invocation",
-        "cannot be used",
-        "refused",
-        "Skill tool returns",
-        "Skill tool fails",
-    ]
-    action_signals = [
-        "do not",
-        "do NOT",
-        "discard",
-        "skip",
-        "omit",
-        "proceed without",
-    ]
-    has_refusal = any(s in text for s in refusal_signals)
-    has_action = any(s in text for s in action_signals)
+    has_refusal = any(s in text for s in REFUSAL_SIGNALS)
+    has_action = any(s in text for s in ACTION_SIGNALS)
     assert has_refusal, (
         "open-research-pr SKILL.md must document what to do when the Skill tool refuses "
         "an exp-lens invocation. Expected: 'disable-model-invocation', 'cannot be used', "
@@ -121,29 +107,4 @@ def test_handles_skill_tool_refusal_for_exp_lens():
     assert has_action, (
         "open-research-pr SKILL.md must prescribe a concrete action on refusal. "
         "Expected: 'do NOT', 'discard', 'skip', 'omit', or equivalent."
-    )
-
-
-def test_embeds_canonical_classdef_palette():
-    """
-    SKILL.md must embed or reference the canonical 9-class mermaid palette.
-    Without this, any fallback diagram generation uses invented styling.
-    Fails if fewer than 7 of the 9 canonical class names appear in the file.
-    """
-    text = SKILL.read_text()
-    canonical_classes = {
-        "cli",
-        "stateNode",
-        "handler",
-        "phase",
-        "output",
-        "integration",
-        "newComponent",
-        "detector",
-        "gap",
-    }
-    found = {name for name in canonical_classes if name in text}
-    assert len(found) >= 7, (
-        f"open-research-pr SKILL.md must embed the canonical mermaid classDef palette "
-        f"(at least 7 of 9 names). Found only: {sorted(found)}"
     )

--- a/tests/contracts/test_sub_skill_refusal_contracts.py
+++ b/tests/contracts/test_sub_skill_refusal_contracts.py
@@ -17,7 +17,6 @@ _SUB_SKILL_CALL_PATTERN = re.compile(
     r"/autoskillit:.{0,200}Skill tool|"
     r"LOAD.{0,100}/autoskillit:|"
     r"Load.{0,100}/autoskillit:",
-    re.DOTALL,
 )
 
 # Refusal detection language
@@ -27,10 +26,9 @@ _REFUSAL_SIGNAL_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
-# Required action on refusal
+# Required action on refusal — specific phrases unlikely to appear in non-refusal contexts
 _ACTION_SIGNAL_PATTERN = re.compile(
-    r"do NOT|do not|discard|skip|omit|proceed without|log.{0,30}warning|"
-    r"fail.{0,30}clean|abort.{0,20}step",
+    r"proceed without|discard|log.{0,30}warning|fail.{0,30}clean|abort.{0,20}step",
     re.IGNORECASE,
 )
 
@@ -41,7 +39,7 @@ def _find_sub_skill_calling_skills() -> list[tuple[str, Path]]:
         skill_md = skill_dir / "SKILL.md"
         if not skill_md.exists():
             continue
-        text = skill_md.read_text()
+        text = skill_md.read_text(encoding="utf-8")
         if _SUB_SKILL_CALL_PATTERN.search(text):
             results.append((skill_dir.name, skill_md))
     return results
@@ -61,7 +59,7 @@ def test_sub_skill_calling_skill_has_refusal_handler(skill_name: str, skill_md: 
     document what to do when the Skill tool refuses the invocation. New qualifying
     skills without this handler fail CI immediately without requiring code review.
     """
-    text = skill_md.read_text()
+    text = skill_md.read_text(encoding="utf-8")
     has_refusal = bool(_REFUSAL_SIGNAL_PATTERN.search(text))
     has_action = bool(_ACTION_SIGNAL_PATTERN.search(text))
     assert has_refusal, (
@@ -72,7 +70,7 @@ def test_sub_skill_calling_skill_has_refusal_handler(skill_name: str, skill_md: 
     )
     assert has_action, (
         f"{skill_name}/SKILL.md has refusal detection language but no prescribed action. "
-        f"Specify: discard, skip, omit, fail clean, or log warning."
+        f"Specify: proceed without, discard, fail clean, log warning, or abort step."
     )
 
 

--- a/tests/contracts/test_sub_skill_refusal_contracts.py
+++ b/tests/contracts/test_sub_skill_refusal_contracts.py
@@ -1,0 +1,85 @@
+"""
+Cross-skill contract: every SKILL.md that invokes sub-skills via the Skill tool must contain
+explicit refusal handling language. Parametrized over all qualifying skills — self-updating
+as new skills are added to skills_extended/.
+"""
+import re
+from pathlib import Path
+import pytest
+
+_SKILLS_DIR = Path(__file__).parents[2] / "src/autoskillit/skills_extended"
+
+# Identifies a SKILL.md as invoking sub-skills via the Skill tool
+_SUB_SKILL_CALL_PATTERN = re.compile(
+    r"Skill tool.{0,200}/autoskillit:|"
+    r"/autoskillit:.{0,200}Skill tool|"
+    r"LOAD.{0,100}/autoskillit:|"
+    r"Load.{0,100}/autoskillit:",
+    re.DOTALL,
+)
+
+# Refusal detection language
+_REFUSAL_SIGNAL_PATTERN = re.compile(
+    r"disable-model-invocation|cannot be used|Skill tool returns.{0,50}error|"
+    r"refused|Skill tool fails|skill.{0,50}unavailable",
+    re.IGNORECASE,
+)
+
+# Required action on refusal
+_ACTION_SIGNAL_PATTERN = re.compile(
+    r"do NOT|do not|discard|skip|omit|proceed without|log.{0,30}warning|"
+    r"fail.{0,30}clean|abort.{0,20}step",
+    re.IGNORECASE,
+)
+
+
+def _find_sub_skill_calling_skills() -> list[tuple[str, Path]]:
+    results = []
+    for skill_dir in sorted(_SKILLS_DIR.iterdir()):
+        skill_md = skill_dir / "SKILL.md"
+        if not skill_md.exists():
+            continue
+        text = skill_md.read_text()
+        if _SUB_SKILL_CALL_PATTERN.search(text):
+            results.append((skill_dir.name, skill_md))
+    return results
+
+
+_SUB_SKILL_CALLERS = _find_sub_skill_calling_skills()
+
+
+@pytest.mark.parametrize(
+    "skill_name,skill_md",
+    _SUB_SKILL_CALLERS,
+    ids=[s[0] for s in _SUB_SKILL_CALLERS],
+)
+def test_sub_skill_calling_skill_has_refusal_handler(skill_name: str, skill_md: Path):
+    """
+    Structural ratchet: any skill that invokes sub-skills via the Skill tool must
+    document what to do when the Skill tool refuses the invocation. New qualifying
+    skills without this handler fail CI immediately without requiring code review.
+    """
+    text = skill_md.read_text()
+    has_refusal = bool(_REFUSAL_SIGNAL_PATTERN.search(text))
+    has_action = bool(_ACTION_SIGNAL_PATTERN.search(text))
+    assert has_refusal, (
+        f"{skill_name}/SKILL.md invokes sub-skills via the Skill tool but contains no "
+        f"documentation of what to do when the Skill tool refuses the invocation. "
+        f"Add a refusal handler near the Skill tool call: describe what happens when the "
+        f"tool returns 'cannot be used' or 'disable-model-invocation', and what action follows."
+    )
+    assert has_action, (
+        f"{skill_name}/SKILL.md has refusal detection language but no prescribed action. "
+        f"Specify: discard, skip, omit, fail clean, or log warning."
+    )
+
+
+def test_mermaid_skill_itself_not_a_sub_skill_caller():
+    """
+    Sanity: the mermaid skill is a leaf and should not appear in the parametrized list.
+    Confirms the detector does not over-fire on leaf skills.
+    """
+    caller_names = {s[0] for s in _SUB_SKILL_CALLERS}
+    assert "mermaid" not in caller_names, (
+        "mermaid/SKILL.md was detected as a sub-skill caller — review the detection pattern."
+    )

--- a/tests/contracts/test_sub_skill_refusal_contracts.py
+++ b/tests/contracts/test_sub_skill_refusal_contracts.py
@@ -3,8 +3,10 @@ Cross-skill contract: every SKILL.md that invokes sub-skills via the Skill tool 
 explicit refusal handling language. Parametrized over all qualifying skills — self-updating
 as new skills are added to skills_extended/.
 """
+
 import re
 from pathlib import Path
+
 import pytest
 
 _SKILLS_DIR = Path(__file__).parents[2] / "src/autoskillit/skills_extended"


### PR DESCRIPTION
## Summary

When `open-research-pr` is invoked headlessly, the exp-lens sub-skills it depends on remain gated (`disable-model-invocation: true`) because `activate_tier2()` un-gates exactly one skill per session by design. The SKILL.md provides no instruction for when the Skill tool refuses a sub-skill invocation, so the model improvises freehand — inventing non-canonical class names and never applying them to nodes. All nodes render gray.

The direct bugs are: (1) no refusal handler in `open-research-pr` Step 4, and (2) no canonical palette embedded as a reference fallback. The arch-lens equivalent skill `open-pr` has the identical gap in Step 5. The root architectural weakness is that all contract tests use **vocabulary-only assertions** — checking if a word appears, not whether a mechanism exists.

Part A adds the two focused failing tests for `open-research-pr` and `open-pr`, then fixes both SKILL.md files. Part B (separate task) adds the cross-skill parametrized ratchet tests that enforce the same contract across all sub-skill-calling skills in the codebase.

## Architecture Impact

### Error/Resilience Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph Callers ["● MODIFIED SKILL CALLERS"]
        direction LR
        ORP["● open-research-pr/SKILL.md<br/>━━━━━━━━━━<br/>Step 4: exp-lens invocation<br/>+refusal handler added"]
        OP["● open-pr/SKILL.md<br/>━━━━━━━━━━<br/>Step 5: arch-lens invocation<br/>+refusal handler added"]
    end

    subgraph LensGate ["LENS INVOCATION GATE"]
        SKILL_CALL["Skill tool call<br/>━━━━━━━━━━<br/>/autoskillit:{lens-slug}"]
        GATE{"Error contains<br/>'disable-model-invocation'<br/>or 'cannot be used'?"}
    end

    subgraph RefusalPath ["● REFUSAL HANDLER (added to both skills)"]
        direction TB
        DISCARD["Discard lens silently<br/>━━━━━━━━━━<br/>do NOT write freehand<br/>Continue to next lens"]
        ALL_REFUSED{"All lens invocations<br/>refused?"}
        DIAG["● lens_unavailable_{ts}.txt<br/>━━━━━━━━━━<br/>Diagnostic artifact<br/>open-research-pr only"]
        EMPTY["validated_diagrams = []<br/>━━━━━━━━━━<br/>Diagram section omitted<br/>from PR body"]
    end

    subgraph HappyPath ["UNAFFECTED SUCCESS PATH"]
        direction TB
        EXECUTE["Lens executes<br/>━━━━━━━━━━<br/>Canonical palette applied"]
        VALIDATE["Marker validation<br/>━━━━━━━━━━<br/>★ / ● symbols checked"]
        VALIDATED["validated_diagrams<br/>━━━━━━━━━━<br/>Styled mermaid blocks added"]
    end

    subgraph ContractRatchet ["★ NEW CI CONTRACT ENFORCEMENT"]
        direction TB
        REFUSAL_RATCHET["★ test_sub_skill_refusal_contracts.py<br/>━━━━━━━━━━<br/>Auto-discovers ALL sub-skill callers<br/>Enforces refusal handler at CI time"]
        PALETTE_RATCHET["★ test_mermaid_palette_contracts.py<br/>━━━━━━━━━━<br/>Auto-discovers diagram generators<br/>Enforces palette or mermaid-load"]
        ORP_TESTS["● test_open_research_pr_contracts.py<br/>━━━━━━━━━━<br/>+test_handles_skill_tool_refusal_for_exp_lens<br/>+test_embeds_canonical_classdef_palette"]
        OP_TESTS["● test_open_pr_contracts.py<br/>━━━━━━━━━━<br/>+test_handles_skill_tool_refusal_for_arch_lens"]
    end

    T_PR_STYLED([PR: styled diagram section])
    T_PR_CLEAN([PR: section omitted — clean])
    T_CI_FAIL([CI FAIL: contract violation])
    T_CI_PASS([CI PASS: contracts satisfied])

    ORP --> SKILL_CALL
    OP --> SKILL_CALL
    SKILL_CALL --> GATE
    GATE -->|"no — ungated"| EXECUTE
    GATE -->|"yes — gated/refused"| DISCARD
    DISCARD --> ALL_REFUSED
    ALL_REFUSED -->|"no — more lenses"| SKILL_CALL
    ALL_REFUSED -->|"yes — all refused"| DIAG
    DIAG --> EMPTY
    EMPTY --> T_PR_CLEAN
    EXECUTE --> VALIDATE
    VALIDATE -->|"contains ★ or ●"| VALIDATED
    VALIDATED --> T_PR_STYLED

    ORP_TESTS --> REFUSAL_RATCHET
    OP_TESTS --> REFUSAL_RATCHET
    REFUSAL_RATCHET -->|"no handler found"| T_CI_FAIL
    PALETTE_RATCHET -->|"no palette found"| T_CI_FAIL
    REFUSAL_RATCHET -->|"all callers compliant"| T_CI_PASS
    PALETTE_RATCHET -->|"all generators compliant"| T_CI_PASS

    class ORP,OP handler;
    class SKILL_CALL phase;
    class GATE detector;
    class DISCARD,ALL_REFUSED stateNode;
    class DIAG gap;
    class EMPTY output;
    class EXECUTE,VALIDATE phase;
    class VALIDATED output;
    class REFUSAL_RATCHET,PALETTE_RATCHET newComponent;
    class ORP_TESTS,OP_TESTS handler;
    class T_PR_STYLED,T_PR_CLEAN,T_CI_FAIL,T_CI_PASS terminal;
```

### Process/Execution Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START([run_skill open-research-pr / open-pr])

    subgraph LensLoop ["● LENS ITERATION LOOP (Step 4 / Step 5)"]
        direction TB
        ITER["For each lens_slug<br/>━━━━━━━━━━<br/>Iterate exp-lens / arch-lens list"]
        INVOKE["Skill tool call<br/>━━━━━━━━━━<br/>/autoskillit:{lens-slug}"]
        GATED{"Skill tool response<br/>contains 'disable-model-invocation'<br/>or 'cannot be used'?"}
    end

    subgraph RefusalRouting ["● REFUSAL ROUTING (added to both skills)"]
        direction TB
        SKIP["Discard silently<br/>━━━━━━━━━━<br/>do NOT write freehand"]
        MORE{"More lens slugs<br/>remaining?"}
        WRITE_DIAG["Write diagnostic<br/>━━━━━━━━━━<br/>lens_unavailable_{ts}.txt<br/>(open-research-pr only)"]
        SET_EMPTY["validated_diagrams = []<br/>━━━━━━━━━━<br/>Propagate to composition step"]
    end

    subgraph SuccessRouting ["UNMODIFIED SUCCESS ROUTING"]
        direction TB
        EXECUTE["Lens executes<br/>━━━━━━━━━━<br/>Diagram generated<br/>Canonical palette applied"]
        CHECK_MARKERS{"Block contains<br/>★ or ● markers?"}
        APPEND["Append to<br/>validated_diagrams<br/>━━━━━━━━━━<br/>Styled block collected"]
    end

    subgraph Composition ["PR BODY COMPOSITION (Step 6)"]
        direction TB
        DIAGS_EMPTY{"validated_diagrams<br/>empty?"}
        INCLUDE["Include diagram section<br/>━━━━━━━━━━<br/>## Architecture Impact<br/>## Experiment Design"]
        OMIT["Omit section entirely<br/>━━━━━━━━━━<br/>No placeholder in PR body"]
    end

    subgraph CIRatchet ["★ NEW CI CONTRACT RATCHET"]
        direction TB
        DISCOVER["★ Scan skills_extended/<br/>━━━━━━━━━━<br/>Auto-discover sub-skill callers<br/>and diagram generators"]
        CHECK_REFUSAL{"★ All callers have<br/>refusal handler?"}
        CHECK_PALETTE{"★ All generators have<br/>palette or mermaid-load?"}
    end

    T_PR_STYLED([PR with styled diagram section])
    T_PR_CLEAN([PR without diagram section])
    T_CI_PASS([CI PASS])
    T_CI_FAIL([CI FAIL])

    START --> ITER
    ITER --> INVOKE
    INVOKE --> GATED
    GATED -->|"yes — refused"| SKIP
    GATED -->|"no — executes"| EXECUTE
    SKIP --> MORE
    MORE -->|"yes"| ITER
    MORE -->|"no — all refused"| WRITE_DIAG
    WRITE_DIAG --> SET_EMPTY
    EXECUTE --> CHECK_MARKERS
    CHECK_MARKERS -->|"yes — valid"| APPEND
    CHECK_MARKERS -->|"no — invalid"| ITER
    APPEND --> ITER

    SET_EMPTY --> DIAGS_EMPTY
    ITER -->|"loop exhausted"| DIAGS_EMPTY
    DIAGS_EMPTY -->|"yes — empty"| OMIT
    DIAGS_EMPTY -->|"no — has diagrams"| INCLUDE
    INCLUDE --> T_PR_STYLED
    OMIT --> T_PR_CLEAN

    DISCOVER --> CHECK_REFUSAL
    DISCOVER --> CHECK_PALETTE
    CHECK_REFUSAL -->|"all compliant"| T_CI_PASS
    CHECK_REFUSAL -->|"gap found"| T_CI_FAIL
    CHECK_PALETTE -->|"all compliant"| T_CI_PASS
    CHECK_PALETTE -->|"gap found"| T_CI_FAIL

    class START terminal;
    class ITER,INVOKE phase;
    class GATED,MORE,CHECK_MARKERS,DIAGS_EMPTY detector;
    class SKIP,WRITE_DIAG gap;
    class SET_EMPTY,APPEND stateNode;
    class EXECUTE handler;
    class INCLUDE,OMIT output;
    class DISCOVER,CHECK_REFUSAL,CHECK_PALETTE newComponent;
    class T_PR_STYLED,T_PR_CLEAN,T_CI_PASS,T_CI_FAIL terminal;
```

Closes #637

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260405-212016-569394/.autoskillit/temp/rectify/rectify_sub-skill-refusal-and-palette-contracts_2026-04-05_175800_part_a.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| investigate | 21 | 10.0k | 369.4k | 48.0k | 1 | 5m 17s |
| rectify | 24 | 36.2k | 646.6k | 119.1k | 1 | 13m 56s |
| dry_walkthrough | 41 | 56.1k | 1.7M | 134.0k | 2 | 16m 39s |
| implement | 85 | 36.7k | 4.4M | 127.9k | 2 | 15m 37s |
| assess | 32 | 10.9k | 1.1M | 46.8k | 1 | 5m 48s |
| open_pr | 37 | 26.4k | 1.5M | 71.7k | 1 | 8m 29s |
| **Total** | 240 | 176.2k | 9.7M | 547.6k | | 1h 5m |