### PR TITLE
Rectify: Per-Invocation Completion Marker Isolation

### DIFF
--- a/src/autoskillit/core/_type_protocols.py
+++ b/src/autoskillit/core/_type_protocols.py
@@ -183,6 +183,7 @@ class HeadlessExecutor(Protocol):
         stale_threshold: float | None = None,
         expected_output_patterns: Sequence[str] = (),
         write_behavior: WriteBehaviorSpec | None = None,
+        completion_marker: str = "",
     ) -> SkillResult: ...
 
 

--- a/src/autoskillit/execution/headless.py
+++ b/src/autoskillit/execution/headless.py
@@ -817,6 +817,7 @@ async def run_headless_core(
     stale_threshold: float | None = None,
     expected_output_patterns: Sequence[str] = (),
     write_behavior: WriteBehaviorSpec | None = None,
+    completion_marker: str = "",
 ) -> SkillResult:
     """Shared headless runner used by run_skill.
 
@@ -824,6 +825,7 @@ async def run_headless_core(
     Accepts explicit ToolContext so this module has no server.py dependency.
     """
     cfg = ctx.config.run_skill
+    effective_marker = completion_marker or cfg.completion_marker
     original_skill_command = skill_command
 
     with structlog.contextvars.bound_contextvars(
@@ -835,7 +837,7 @@ async def run_headless_core(
         cmd = build_full_headless_cmd(
             skill_command,
             cwd=cwd,
-            completion_marker=cfg.completion_marker,
+            completion_marker=effective_marker,
             model=resolved_model,
             plugin_dir=effective_plugin_dir,
             output_format_value=cfg.output_format.value,
@@ -876,7 +878,7 @@ async def run_headless_core(
                 timeout=effective_timeout,
                 pty_mode=True,
                 session_log_dir=_session_log_dir(cwd),
-                completion_marker=cfg.completion_marker,
+                completion_marker=effective_marker,
                 stale_threshold=effective_stale,
                 completion_drain_timeout=cfg.completion_drain_timeout,
                 linux_tracing_config=linux_tracing_cfg,
@@ -916,7 +918,7 @@ async def run_headless_core(
         audit_count_before = len(ctx.audit.get_report())
         skill_result = _build_skill_result(
             result,
-            completion_marker=cfg.completion_marker,
+            completion_marker=effective_marker,
             skill_command=original_skill_command,
             audit=ctx.audit,
             expected_output_patterns=expected_output_patterns,
@@ -1019,6 +1021,7 @@ class DefaultHeadlessExecutor:
         stale_threshold: float | None = None,
         expected_output_patterns: Sequence[str] = (),
         write_behavior: WriteBehaviorSpec | None = None,
+        completion_marker: str = "",
     ) -> SkillResult:
         cfg = self._ctx.config.run_skill
         effective_timeout = timeout if timeout is not None else cfg.timeout
@@ -1036,4 +1039,5 @@ class DefaultHeadlessExecutor:
             stale_threshold=effective_stale,
             expected_output_patterns=expected_output_patterns,
             write_behavior=write_behavior,
+            completion_marker=completion_marker,
         )

--- a/src/autoskillit/server/tools_execution.py
+++ b/src/autoskillit/server/tools_execution.py
@@ -255,6 +255,8 @@ async def run_skill(
             skill_command, tool_ctx.skill_resolver
         )
 
+    invocation_marker = f"%%ORDER_UP::{uuid4().hex[:8]}%%"
+
     skill_add_dirs: list[ValidatedAddDir] = []
     if tool_ctx.session_skill_manager is not None:
         session_id = f"headless-{uuid4().hex[:12]}"
@@ -288,6 +290,7 @@ async def run_skill(
             expected_output_patterns=expected_output_patterns,
             write_behavior=write_spec,
             stale_threshold=float(stale_threshold) if stale_threshold is not None else None,
+            completion_marker=invocation_marker,
         )
         if skill_result.success:
             tool_ctx.audit.record_success(skill_command)

--- a/src/autoskillit/workspace/session_skills.py
+++ b/src/autoskillit/workspace/session_skills.py
@@ -101,6 +101,22 @@ def _remove_disable_model_invocation(content: str) -> str:
     return f"---\n{fm_text}\n---\n{body}"
 
 
+_ORDER_UP_LINE = re.compile(r"^.*%%ORDER_UP%%.*\n?", re.MULTILINE)
+
+
+def _strip_marker_from_body(content: str, marker: str = "%%ORDER_UP%%") -> str:
+    """Remove completion marker lines from SKILL.md body content."""
+    m = _FM_PATTERN.match(content)
+    if not m:
+        return _ORDER_UP_LINE.sub("", content) if marker in content else content
+    fm_text = m.group(1)
+    body = m.group(2)
+    if marker not in body:
+        return content
+    body = _ORDER_UP_LINE.sub("", body)
+    return f"---\n{fm_text}\n---\n{body}"
+
+
 _ACTIVATE_DEPS_PATTERN = re.compile(r"^activate_deps:\s*\[([^\]]*)\]", re.MULTILINE)
 
 
@@ -341,7 +357,9 @@ class DefaultSessionSkillManager:
         activated: set[str] = set()
         return self._activate_with_deps(session_id, skill_name, activated)
 
-    def _activate_with_deps(self, session_id: str, skill_name: str, activated: set[str]) -> bool:
+    def _activate_with_deps(
+        self, session_id: str, skill_name: str, activated: set[str], *, _is_root: bool = True
+    ) -> bool:
         """Activate a single skill and recursively activate its dependencies."""
         if skill_name in activated:
             return False
@@ -353,6 +371,8 @@ class DefaultSessionSkillManager:
 
         content = skill_md.read_text()
         new_content = _remove_disable_model_invocation(content)
+        if not _is_root:
+            new_content = _strip_marker_from_body(new_content)
         if new_content != content:
             atomic_write(skill_md, new_content)
 
@@ -361,7 +381,7 @@ class DefaultSessionSkillManager:
             if dep in PACK_REGISTRY:
                 self._activate_pack_deps(session_id, dep, activated)
             else:
-                self._activate_with_deps(session_id, dep, activated)
+                self._activate_with_deps(session_id, dep, activated, _is_root=False)
 
         return True
 
@@ -378,7 +398,7 @@ class DefaultSessionSkillManager:
                 continue
             info = self._provider.resolver.resolve(name)
             if info and pack_name in info.categories:
-                self._activate_with_deps(session_id, name, activated)
+                self._activate_with_deps(session_id, name, activated, _is_root=False)
 
     def cleanup_stale(self, max_age_seconds: int = 259200) -> int:
         """Remove session dirs not accessed within max_age_seconds.

--- a/tests/execution/test_headless.py
+++ b/tests/execution/test_headless.py
@@ -3448,3 +3448,17 @@ class TestBuildSkillResultSessionIdFromSubprocess:
         )
         sr = _build_skill_result(result)
         assert sr.session_id == "ch-b-uuid-5678"
+
+
+class TestHeadlessExecutorCompletionMarker:
+    """Protocol conformance: DefaultHeadlessExecutor.run accepts completion_marker."""
+
+    def test_headless_executor_accepts_completion_marker(self) -> None:
+        import inspect
+
+        from autoskillit.execution.headless import DefaultHeadlessExecutor
+
+        sig = inspect.signature(DefaultHeadlessExecutor.run)
+        assert "completion_marker" in sig.parameters
+        param = sig.parameters["completion_marker"]
+        assert param.default == ""

--- a/tests/execution/test_process_channel_b.py
+++ b/tests/execution/test_process_channel_b.py
@@ -485,3 +485,66 @@ class TestPostExitDrainWindow:
         )
 
         assert result.channel_confirmation == ChannelConfirmation.UNMONITORED
+
+
+# Script that:
+#   (1) writes static %%ORDER_UP%% to JSONL (simulating sub-skill emission)
+#   (2) later writes %%ORDER_UP::{unique}%% to JSONL (the parent's real marker)
+#   (3) writes type=result to stdout within the drain window
+#   (4) hangs until killed
+# Pass session_dir as sys.argv[1], unique marker as sys.argv[2].
+CHANNEL_B_SUB_SKILL_COLLISION_SCRIPT = textwrap.dedent("""\
+    import sys, time, json, os
+    session_dir = sys.argv[1]
+    unique_marker = sys.argv[2]
+    os.makedirs(session_dir, exist_ok=True)
+    time.sleep(0.1)
+    with open(os.path.join(session_dir, "session.jsonl"), "w") as f:
+        # Sub-skill emits static marker — should NOT trigger completion
+        sub_skill_record = {"type": "assistant", "message": {"role": "assistant",
+                  "content": "%%ORDER_UP%%"}}
+        f.write(json.dumps(sub_skill_record) + "\\n")
+        f.flush()
+        time.sleep(0.3)
+        # Parent emits its unique marker — SHOULD trigger completion
+        parent_record = {"type": "assistant", "message": {"role": "assistant",
+                  "content": unique_marker}}
+        f.write(json.dumps(parent_record) + "\\n")
+        f.flush()
+    time.sleep(0.15)
+    result = {"type": "result", "subtype": "success", "is_error": False,
+              "result": "done", "session_id": "s1"}
+    sys.stdout.write(json.dumps(result, separators=(",", ":")) + "\\n")
+    sys.stdout.flush()
+    time.sleep(3600)
+""")
+
+
+class TestChannelBSubSkillCollision:
+    """Channel B ignores static markers when monitoring for a unique marker."""
+
+    @pytest.mark.anyio
+    async def test_channel_b_ignores_sub_skill_marker(self, tmp_path):
+        session_dir = tmp_path / "session"
+        session_dir.mkdir()
+        unique_marker = "%%ORDER_UP::test1234%%"
+        script = tmp_path / "sub_skill_collision.py"
+        script.write_text(CHANNEL_B_SUB_SKILL_COLLISION_SCRIPT)
+
+        result = await run_managed_async(
+            [sys.executable, str(script), str(session_dir), unique_marker],
+            cwd=tmp_path,
+            timeout=15,
+            session_log_dir=session_dir,
+            completion_marker=unique_marker,
+            completion_drain_timeout=2.0,
+            _phase1_poll=0.05,
+            _phase2_poll=0.05,
+            _heartbeat_poll=0.05,
+        )
+
+        assert result.termination == TerminationReason.COMPLETED
+        assert result.channel_confirmation in (
+            ChannelConfirmation.CHANNEL_A,
+            ChannelConfirmation.CHANNEL_B,
+        )

--- a/tests/execution/test_process_jsonl.py
+++ b/tests/execution/test_process_jsonl.py
@@ -316,3 +316,48 @@ class TestJsonlHasRecordTypeResultContent:
         assert not _jsonl_has_record_type(
             line, frozenset({"result"}), completion_marker="%%ORDER_UP%%"
         )
+
+
+class TestMarkerDiscrimination:
+    """Regression guards: per-invocation markers are structurally incompatible with static ones."""
+
+    def test_session_marker_does_not_match_global_marker(self):
+        """A JSONL record with static %%ORDER_UP%% must NOT match a per-invocation marker."""
+        content = (
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {"content": [{"type": "text", "text": "%%ORDER_UP%%"}]},
+                }
+            )
+            + "\n"
+        )
+        assert not _jsonl_contains_marker(
+            content, "%%ORDER_UP::abc12345%%", frozenset({"assistant"})
+        )
+
+    def test_session_marker_matches_itself(self):
+        """A per-invocation marker matches itself in JSONL detection."""
+        content = (
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {"content": [{"type": "text", "text": "%%ORDER_UP::abc12345%%"}]},
+                }
+            )
+            + "\n"
+        )
+        assert _jsonl_contains_marker(content, "%%ORDER_UP::abc12345%%", frozenset({"assistant"}))
+
+    def test_different_session_markers_dont_collide(self):
+        """Two different per-invocation markers do not cross-match."""
+        content = (
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {"content": [{"type": "text", "text": "%%ORDER_UP::aaa%%"}]},
+                }
+            )
+            + "\n"
+        )
+        assert not _jsonl_contains_marker(content, "%%ORDER_UP::bbb%%", frozenset({"assistant"}))

--- a/tests/server/test_tools_execution.py
+++ b/tests/server/test_tools_execution.py
@@ -1304,3 +1304,28 @@ class TestRunSkillCwdValidation:
         tool_ctx.runner.push(_make_result(returncode=0, stdout=success_json))
         result = json.loads(await run_skill("/investigate foo", cwd="/tmp"))
         assert result["success"] is True
+
+
+class TestRunSkillPerInvocationMarker:
+    """Per-invocation completion markers are unique across run_skill calls."""
+
+    @pytest.mark.anyio
+    async def test_run_skill_markers_are_unique_per_invocation(self, tool_ctx):
+        """Two run_skill calls must generate different completion_marker values."""
+        success_json = (
+            '{"type": "result", "subtype": "success", "is_error": false,'
+            ' "result": "done", "session_id": "s1"}'
+        )
+        tool_ctx.runner.push(_make_result(returncode=0, stdout=success_json))
+        tool_ctx.runner.push(_make_result(returncode=0, stdout=success_json))
+
+        await run_skill("/investigate a", cwd="/tmp")
+        await run_skill("/investigate b", cwd="/tmp")
+
+        calls = tool_ctx.runner.call_args_list
+        assert len(calls) >= 2
+        marker1 = calls[0][3]["completion_marker"]
+        marker2 = calls[1][3]["completion_marker"]
+        assert marker1 != marker2
+        assert "%%ORDER_UP::" in marker1
+        assert "%%ORDER_UP::" in marker2

--- a/tests/server/test_tools_execution.py
+++ b/tests/server/test_tools_execution.py
@@ -30,6 +30,19 @@ _SUCCESS_JSON = (
     ' "result": "done", "session_id": "s1"}'
 )
 
+# Deterministic UUID for tests that need to predict the per-invocation marker.
+_DETERMINISTIC_HEX = "a1b2c3d4e5f6a7b890123456"
+_DETERMINISTIC_MARKER = f"%%ORDER_UP::{_DETERMINISTIC_HEX[:8]}%%"
+
+
+class _FixedUUID:
+    hex = _DETERMINISTIC_HEX
+
+
+def _patch_uuid4(monkeypatch):
+    """Monkeypatch uuid4 to return a deterministic value for marker prediction."""
+    monkeypatch.setattr("uuid.uuid4", lambda: _FixedUUID())
+
 
 class TestRunSkillPluginDir:
     """T2: run_skill passes --plugin-dir to the claude command."""
@@ -209,7 +222,7 @@ class TestRunSkillPrefix:
         )
         await run_skill("/investigate error", "/tmp")
         cmd = tool_ctx.runner.call_args_list[0][0]
-        assert "%%ORDER_UP%%" in cmd[5]
+        assert "%%ORDER_UP::" in cmd[5]
         # cwd must propagate to the subprocess runner
         from pathlib import Path
 
@@ -318,7 +331,7 @@ class TestRunSkillInjectsCompletionDirective:
         # The prompt argument is at index 5
         # (shifted by 3 env tokens: env + AUTOSKILLIT_HEADLESS=1 + delay)
         skill_arg = cmd[5]
-        assert "%%ORDER_UP%%" in skill_arg
+        assert "%%ORDER_UP::" in skill_arg
         assert "ORCHESTRATION DIRECTIVE" in skill_arg
 
     def test_inject_completion_directive_prohibits_standalone_marker(self):
@@ -817,6 +830,7 @@ async def test_tools_execution_routes_through_executor(tool_ctx, monkeypatch) ->
             stale_threshold: float | None = None,
             expected_output_patterns: tuple[str, ...] | list[str] = (),
             write_behavior=None,
+            completion_marker: str = "",
         ) -> SkillResult:
             calls.append((skill_command, cwd))
             return SkillResult(
@@ -863,6 +877,7 @@ async def test_run_skill_passes_validated_add_dirs(tool_ctx, monkeypatch) -> Non
             stale_threshold: float | None = None,
             expected_output_patterns: tuple[str, ...] | list[str] = (),
             write_behavior=None,
+            completion_marker: str = "",
         ) -> SkillResult:
             captured["add_dirs"] = add_dirs
             captured["cwd"] = cwd
@@ -1284,22 +1299,26 @@ class TestRunSkillCwdValidation:
         assert tool_ctx.runner.call_args_list == []
 
     @pytest.mark.anyio
-    async def test_run_skill_accepts_empty_cwd(self, tool_ctx):
+    async def test_run_skill_accepts_empty_cwd(self, tool_ctx, monkeypatch):
         """Empty cwd is accepted (some skills have no specific cwd requirement)."""
+        _patch_uuid4(monkeypatch)
+        marker = _DETERMINISTIC_MARKER
         success_json = (
             '{"type": "result", "subtype": "success", "is_error": false,'
-            ' "result": "done %%ORDER_UP%%", "session_id": "s1"}'
+            f' "result": "done {marker}", "session_id": "s1"}}'
         )
         tool_ctx.runner.push(_make_result(returncode=0, stdout=success_json))
         result = json.loads(await run_skill("/investigate foo", cwd=""))
         assert result["success"] is True
 
     @pytest.mark.anyio
-    async def test_run_skill_accepts_absolute_cwd(self, tool_ctx):
+    async def test_run_skill_accepts_absolute_cwd(self, tool_ctx, monkeypatch):
         """Absolute cwd passes the boundary check and proceeds normally."""
+        _patch_uuid4(monkeypatch)
+        marker = _DETERMINISTIC_MARKER
         success_json = (
             '{"type": "result", "subtype": "success", "is_error": false,'
-            ' "result": "done %%ORDER_UP%%", "session_id": "s1"}'
+            f' "result": "done {marker}", "session_id": "s1"}}'
         )
         tool_ctx.runner.push(_make_result(returncode=0, stdout=success_json))
         result = json.loads(await run_skill("/investigate foo", cwd="/tmp"))

--- a/tests/server/test_tools_run_skill_retry.py
+++ b/tests/server/test_tools_run_skill_retry.py
@@ -11,6 +11,19 @@ from autoskillit.core.types import RetryReason, TerminationReason
 from autoskillit.server.tools_execution import run_skill
 from tests.conftest import _make_result
 
+# Deterministic UUID for tests that need to predict the per-invocation marker.
+_DETERMINISTIC_HEX = "a1b2c3d4e5f6a7b890123456"
+_DETERMINISTIC_MARKER = f"%%ORDER_UP::{_DETERMINISTIC_HEX[:8]}%%"
+
+
+class _FixedUUID:
+    hex = _DETERMINISTIC_HEX
+
+
+def _patch_uuid4(monkeypatch):
+    """Monkeypatch uuid4 to return a deterministic value for marker prediction."""
+    monkeypatch.setattr("uuid.uuid4", lambda: _FixedUUID())
+
 
 class TestRunSkillRetryRemoved:
     """run_skill_retry must not exist as a separate MCP tool."""
@@ -69,8 +82,10 @@ class TestRunSkillSessionOutcome:
         assert result["retry_reason"] == RetryReason.RESUME
 
     @pytest.mark.anyio
-    async def test_success_not_retriable(self, tool_ctx):
+    async def test_success_not_retriable(self, tool_ctx, monkeypatch):
         """Normal success -> needs_retry=False."""
+        _patch_uuid4(monkeypatch)
+        marker = _DETERMINISTIC_MARKER
         assistant = json.dumps(
             {
                 "type": "assistant",
@@ -82,7 +97,7 @@ class TestRunSkillSessionOutcome:
                 "type": "result",
                 "subtype": "success",
                 "is_error": False,
-                "result": "Done. %%ORDER_UP%%",
+                "result": f"Done. {marker}",
                 "session_id": "s1",
             }
         )
@@ -187,14 +202,16 @@ class TestRunSkillFields:
     """run_skill includes needs_retry and retry_reason."""
 
     @pytest.mark.anyio
-    async def test_includes_needs_retry_false(self, tool_ctx):
+    async def test_includes_needs_retry_false(self, tool_ctx, monkeypatch):
         """run_skill response includes needs_retry=False on normal success."""
+        _patch_uuid4(monkeypatch)
+        marker = _DETERMINISTIC_MARKER
         stdout = json.dumps(
             {
                 "type": "result",
                 "subtype": "success",
                 "is_error": False,
-                "result": "Done. %%ORDER_UP%%",
+                "result": f"Done. {marker}",
                 "session_id": "s1",
             }
         )

--- a/tests/workspace/test_session_skills.py
+++ b/tests/workspace/test_session_skills.py
@@ -743,3 +743,64 @@ class TestActivateDepsResolution:
         result = mgr.activate_skill_deps(session_id, "parent-skill")
         assert result is True
         assert not _is_gated(tmp_path, session_id, "parent-skill")
+
+    def test_activate_deps_strips_marker_from_dependency_body(self, tmp_path: Path) -> None:
+        """Dependency SKILL.md bodies must have %%ORDER_UP%% stripped after activation."""
+        from unittest.mock import MagicMock
+
+        session_id = "test-strip-marker"
+        gate = "disable-model-invocation: true"
+        marker_body = (
+            "# Sub-Skill\n\nDo the work.\n\n"
+            "ORCHESTRATION DIRECTIVE: When your task is complete, "
+            "your final text output MUST end with: %%ORDER_UP%%\n"
+            "CRITICAL: Append %%ORDER_UP%% at the very end of your substantive response, "
+            "in the SAME message. Do NOT output %%ORDER_UP%% as a separate standalone message."
+        )
+        _write_skill_md(
+            tmp_path,
+            session_id,
+            "parent-skill",
+            f"---\nname: parent-skill\nactivate_deps: [dep-skill]\n{gate}\n---\n# Parent",
+        )
+        _write_skill_md(
+            tmp_path,
+            session_id,
+            "dep-skill",
+            f"---\nname: dep-skill\n{gate}\n---\n{marker_body}",
+        )
+
+        provider = MagicMock()
+        provider.resolver.resolve.return_value = None
+
+        mgr = DefaultSessionSkillManager(provider, ephemeral_root=tmp_path)
+        mgr.activate_skill_deps(session_id, "parent-skill")
+
+        dep_md = tmp_path / session_id / ".claude" / "skills" / "dep-skill" / "SKILL.md"
+        dep_content = dep_md.read_text()
+        assert "%%ORDER_UP%%" not in dep_content
+        assert "# Sub-Skill" in dep_content
+        assert "Do the work." in dep_content
+
+    def test_activate_deps_preserves_marker_in_root_skill(self, tmp_path: Path) -> None:
+        """The root (directly targeted) skill keeps its %%ORDER_UP%% body intact."""
+        from unittest.mock import MagicMock
+
+        session_id = "test-preserve-root-marker"
+        gate = "disable-model-invocation: true"
+        _write_skill_md(
+            tmp_path,
+            session_id,
+            "root-skill",
+            f"---\nname: root-skill\n{gate}\n---\n# Root\n\n%%ORDER_UP%%",
+        )
+
+        provider = MagicMock()
+        provider.resolver.resolve.return_value = None
+
+        mgr = DefaultSessionSkillManager(provider, ephemeral_root=tmp_path)
+        mgr.activate_skill_deps(session_id, "root-skill")
+
+        root_md = tmp_path / session_id / ".claude" / "skills" / "root-skill" / "SKILL.md"
+        root_content = root_md.read_text()
+        assert "%%ORDER_UP%%" in root_content


### PR DESCRIPTION
## Summary

The completion marker `%%ORDER_UP%%` is a static global string shared across all headless sessions. When a parent skill (e.g., `open-research-pr`) invokes sub-skills inline via the built-in Skill tool, the sub-skill emits `%%ORDER_UP%%` into the parent session's JSONL as an `assistant` record. Channel B (`_session_log_monitor`) detects this as the parent's completion signal and kills the process tree — before the parent skill finishes its remaining steps.

This fix introduces per-invocation completion marker isolation via two complementary layers:
1. **Session-specific markers** — each `run_skill` invocation generates a unique `%%ORDER_UP::<uuid>%%` marker that is structurally incompatible with the static `%%ORDER_UP%%` emitted by sub-skills
2. **Dependency body stripping** — `_strip_marker_from_body` removes `%%ORDER_UP%%` emission instructions from dependency SKILL.md bodies during activation, eliminating competing instructions from the model's context

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START([START: run_skill invoked])

    subgraph MarkerGen ["● Marker Generation — tools_execution.py"]
        direction TB
        GEN_SID["session_id = headless-uuid12<br/>━━━━━━━━━━<br/>Existing per-invocation ID"]
        GEN_MARKER["● invocation_marker<br/>━━━━━━━━━━<br/>%%ORDER_UP::uuid8%%<br/>Per-invocation unique string"]
    end

    subgraph DepActivation ["● Dependency Activation — session_skills.py"]
        direction TB
        ACTIVATE["● activate_skill_deps<br/>━━━━━━━━━━<br/>Entry: _is_root=True"]
        IS_ROOT{"_is_root?"}
        STRIP["● _strip_marker_from_body<br/>━━━━━━━━━━<br/>Regex removes %%ORDER_UP%%<br/>lines from dep SKILL.md"]
    end

    subgraph Execution ["● Execution Pipeline — headless.py"]
        direction TB
        EXECUTOR["● DefaultHeadlessExecutor.run<br/>━━━━━━━━━━<br/>+ completion_marker param<br/>Forwards to run_headless_core"]
        RESOLVE{"effective_marker =<br/>━━━━━━━━━━<br/>completion_marker<br/>or cfg default?"}
        CMD["build_full_headless_cmd<br/>━━━━━━━━━━<br/>_inject_completion_directive<br/>Bakes marker into prompt"]
    end

    subgraph Race ["Dual-Channel Detection Race"]
        direction TB
        CHA["Channel A: _heartbeat<br/>━━━━━━━━━━<br/>Polls stdout NDJSON<br/>type=result records"]
        CHB["Channel B: _session_log_monitor<br/>━━━━━━━━━━<br/>Polls session JSONL<br/>type=assistant records"]
        STANDALONE{"_marker_is_standalone<br/>━━━━━━━━━━<br/>Exact line match<br/>against effective_marker"}
        RESOLVE_TERM{"resolve_termination<br/>━━━━━━━━━━<br/>Priority: process_exit<br/>> STALE > channel_win"}
    end

    subgraph SubSkill ["Sub-Skill Inline Emission"]
        direction TB
        SUB_INVOKE["Sub-skill invoked<br/>━━━━━━━━━━<br/>via built-in Skill tool<br/>Same conversation context"]
        SUB_EMIT["Sub-skill emits<br/>━━━━━━━━━━<br/>%%ORDER_UP%%<br/>Static global string"]
        SUB_CHECK{"Channel B compares<br/>━━━━━━━━━━<br/>%%ORDER_UP%% ≠<br/>%%ORDER_UP::abc%%"}
    end

    RESULT["● _build_skill_result<br/>━━━━━━━━━━<br/>Strips effective_marker<br/>from result text"]
    COMPLETE([COMPLETE: SkillResult returned])
    IMMUNE(["IMMUNE: Sub-skill marker<br/>structurally cannot match"])

    START --> GEN_SID
    GEN_SID --> GEN_MARKER
    GEN_MARKER -->|"unique marker"| ACTIVATE
    GEN_MARKER -->|"completion_marker"| EXECUTOR
    ACTIVATE --> IS_ROOT
    IS_ROOT -->|"Yes (root skill)"| EXECUTOR
    IS_ROOT -->|"No (dependency)"| STRIP
    STRIP -->|"cleaned SKILL.md"| EXECUTOR
    EXECUTOR --> RESOLVE
    RESOLVE -->|"caller-supplied wins"| CMD
    CMD -->|"marker in prompt"| CHA
    CMD -->|"marker in prompt"| CHB
    CHA --> STANDALONE
    CHB --> STANDALONE
    STANDALONE -->|"match"| RESOLVE_TERM
    RESOLVE_TERM -->|"COMPLETED"| RESULT
    RESULT --> COMPLETE
    SUB_INVOKE --> SUB_EMIT
    SUB_EMIT --> SUB_CHECK
    SUB_CHECK -->|"NO MATCH"| IMMUNE

    class START,COMPLETE terminal;
    class GEN_SID handler;
    class GEN_MARKER,STRIP,EXECUTOR,RESOLVE,RESULT newComponent;
    class ACTIVATE handler;
    class IS_ROOT,RESOLVE_TERM,SUB_CHECK stateNode;
    class CMD handler;
    class CHA,CHB handler;
    class STANDALONE detector;
    class SUB_INVOKE,SUB_EMIT phase;
    class IMMUNE newComponent;
```

**Color Legend:**

| Color | Category | Description |
|-------|----------|-------------|
| Dark Blue | Terminal | Start and completion states |
| Green | New/Modified | Components changed in this PR (marker gen, threading, stripping) |
| Orange | Handler | Existing processing components (command builder, channels) |
| Teal | State | Decision and routing points (resolve_termination, _is_root) |
| Purple | Phase | Sub-skill inline execution context |
| Red | Detector | Validation gate (_marker_is_standalone exact match) |

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph L3 ["L3 — SERVER"]
        direction LR
        TOOLS_EXEC["● server/tools_execution.py<br/>━━━━━━━━━━<br/>run_skill handler<br/>Generates invocation_marker<br/>Fan-out: 3"]
    end

    subgraph L1_EXEC ["L1 — EXECUTION"]
        direction LR
        HEADLESS["● execution/headless.py<br/>━━━━━━━━━━<br/>DefaultHeadlessExecutor<br/>run_headless_core<br/>Fan-in: 1 · Fan-out: 3"]
        COMMANDS["execution/commands.py<br/>━━━━━━━━━━<br/>build_full_headless_cmd<br/>_inject_completion_directive<br/>Fan-in: 1"]
        PROCESS["execution/process.py<br/>━━━━━━━━━━<br/>run_managed_async<br/>Subprocess race<br/>Fan-in: 1"]
        RACE["execution/_process_race.py<br/>━━━━━━━━━━<br/>resolve_termination<br/>RaceSignals<br/>Fan-in: 1"]
        MONITOR["execution/_process_monitor.py<br/>━━━━━━━━━━<br/>_session_log_monitor<br/>_heartbeat<br/>Fan-in: 1"]
        JSONL["execution/_process_jsonl.py<br/>━━━━━━━━━━<br/>_jsonl_contains_marker<br/>_marker_is_standalone<br/>Fan-in: 2"]
    end

    subgraph L1_WS ["L1 — WORKSPACE"]
        direction LR
        SESSION["● workspace/session_skills.py<br/>━━━━━━━━━━<br/>activate_skill_deps<br/>_strip_marker_from_body<br/>Fan-in: 1 · Fan-out: 1"]
    end

    subgraph L0 ["L0 — CORE (Zero Internal Imports)"]
        direction LR
        PROTO["● core/_type_protocols.py<br/>━━━━━━━━━━<br/>HeadlessExecutor Protocol<br/>+ completion_marker param<br/>Fan-in: 3"]
    end

    %% VALID DEPENDENCIES — completion_marker threading %%
    TOOLS_EXEC -->|"calls executor.run<br/>completion_marker=invocation_marker"| HEADLESS
    TOOLS_EXEC -->|"calls activate_skill_deps<br/>(strips marker from deps)"| SESSION
    TOOLS_EXEC -->|"imports Protocol"| PROTO
    HEADLESS -->|"calls build_full_headless_cmd<br/>completion_marker=effective_marker"| COMMANDS
    HEADLESS -->|"calls runner<br/>completion_marker=effective_marker"| PROCESS
    HEADLESS -->|"imports Protocol"| PROTO
    PROCESS -->|"starts task group"| RACE
    PROCESS -->|"starts _heartbeat + _session_log_monitor"| MONITOR
    MONITOR -->|"calls _jsonl_contains_marker<br/>+ _marker_is_standalone"| JSONL
    RACE -->|"reads RaceSignals"| MONITOR
    SESSION -->|"imports from core"| PROTO

    class TOOLS_EXEC cli;
    class HEADLESS,COMMANDS,PROCESS newComponent;
    class RACE,MONITOR handler;
    class JSONL detector;
    class SESSION newComponent;
    class PROTO stateNode;
```

**Color Legend:**

| Color | Category | Description |
|-------|----------|-------------|
| Dark Blue | Server | L3 application entry point (run_skill handler) |
| Green | Modified | Components with new completion_marker parameter or _strip_marker_from_body |
| Orange | Execution | Existing race/monitor infrastructure (unchanged) |
| Red | Detector | Marker validation gate (_jsonl_contains_marker) |
| Teal | High Fan-In | Core protocol — 3 modules depend on HeadlessExecutor |

Closes #646

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260406-180605-595655/.autoskillit/temp/rectify/rectify_order_up_marker_collision_2026-04-06_180605.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| investigate | 32 | 10.2k | 873.1k | 51.2k | 1 | 13m 10s |
| rectify | 26 | 12.3k | 589.6k | 52.2k | 1 | 8m 36s |
| dry_walkthrough | 531 | 16.5k | 1.2M | 60.2k | 1 | 7m 45s |
| implement | 1.9k | 23.9k | 4.1M | 79.9k | 1 | 10m 28s |
| assess | 79 | 32.5k | 4.4M | 121.1k | 2 | 18m 48s |
| open_pr | 29 | 15.8k | 895.0k | 63.0k | 1 | 6m 47s |
| **Total** | 2.6k | 111.2k | 12.0M | 427.5k | | 1h 5m |