### PR TITLE
Implementation Plan: Migrate to Rust-based api-simulator (PyO3 Rewrite)

### DIFF
--- a/.github/workflows/patch-bump-integration.yml
+++ b/.github/workflows/patch-bump-integration.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           uv-version: "0.9.21"
 
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Compute new patch version
         id: version
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,9 @@ jobs:
         with:
           uv-version: "0.9.21"
 
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Verify lockfile is up to date
         run: uv lock --check
 
@@ -74,6 +77,9 @@ jobs:
 
       - name: Configure git auth for private deps
         run: git config --global url."https://${{ secrets.GH_USER }}:${{ secrets.GH_PAT }}@github.com/TalonT-Org/".insteadOf "https://github.com/TalonT-Org/"
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install dependencies
         run: uv sync --locked --extra dev

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -26,6 +26,9 @@ jobs:
         with:
           uv-version: "0.9.21"
 
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Compute new minor version
         id: version
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -226,4 +226,4 @@ forbidden_modules = [
 ]
 
 [tool.uv.sources]
-api-simulator = { git = "https://github.com/TalonT-Org/api-simulator", branch = "main" }
+api-simulator = { git = "https://github.com/TalonT-Org/api-simulator", branch = "main", subdirectory = "crates/api-simulator-py" }

--- a/tests/execution/test_quota_http.py
+++ b/tests/execution/test_quota_http.py
@@ -6,14 +6,17 @@ They complement the unit tests in test_quota.py which mock at the function level
 
 from __future__ import annotations
 
-import pytest
-
-pytest.skip("api_simulator API change — see #643", allow_module_level=True)
-
 import json
 import time
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
+
+import pytest
+from api_simulator._api_simulator_py import PyResponseSpec
+
+from autoskillit.execution.quota import check_and_sleep_if_needed
+
+pytestmark = pytest.mark.anyio
 
 QUOTA_ENDPOINT = "/api/oauth/usage"
 
@@ -60,12 +63,14 @@ async def test_normal_utilization_returns_status_and_sends_correct_headers(
     mock_http_server.register(
         "GET",
         QUOTA_ENDPOINT,
-        json={
-            "five_hour": {
-                "utilization": 50.0,
-                "resets_at": "2026-04-05T00:00:00+00:00",
+        PyResponseSpec(
+            body={
+                "five_hour": {
+                    "utilization": 50.0,
+                    "resets_at": "2026-04-05T00:00:00+00:00",
+                }
             }
-        },
+        ),
     )
 
     result = await check_and_sleep_if_needed(quota_config, base_url=mock_http_server.url)
@@ -76,8 +81,8 @@ async def test_normal_utilization_returns_status_and_sends_correct_headers(
 
     requests = mock_http_server.get_requests("GET", QUOTA_ENDPOINT)
     assert len(requests) == 1
-    assert requests[0].headers["authorization"] == "Bearer test-token-abc123"
-    assert requests[0].headers["anthropic-beta"] == "oauth-2025-04-20"
+    assert requests[0]["headers"]["authorization"] == "Bearer test-token-abc123"
+    assert requests[0]["headers"]["anthropic-beta"] == "oauth-2025-04-20"
 
 
 async def test_above_threshold_triggers_double_fetch(mock_http_server, quota_config):
@@ -85,9 +90,9 @@ async def test_above_threshold_triggers_double_fetch(mock_http_server, quota_con
     mock_http_server.register_sequence(
         "GET",
         QUOTA_ENDPOINT,
-        responses=[
-            {"json": {"five_hour": {"utilization": 95.0, "resets_at": resets_at}}},
-            {"json": {"five_hour": {"utilization": 95.0, "resets_at": resets_at}}},
+        [
+            PyResponseSpec(body={"five_hour": {"utilization": 95.0, "resets_at": resets_at}}),
+            PyResponseSpec(body={"five_hour": {"utilization": 95.0, "resets_at": resets_at}}),
         ],
     )
 
@@ -102,7 +107,7 @@ async def test_resets_at_null_blocks_with_fallback(mock_http_server, quota_confi
     mock_http_server.register(
         "GET",
         QUOTA_ENDPOINT,
-        json={"five_hour": {"utilization": 95.0, "resets_at": None}},
+        PyResponseSpec(body={"five_hour": {"utilization": 95.0, "resets_at": None}}),
     )
 
     result = await check_and_sleep_if_needed(quota_config, base_url=mock_http_server.url)
@@ -114,7 +119,7 @@ async def test_resets_at_null_blocks_with_fallback(mock_http_server, quota_confi
 
 
 async def test_http_429_fails_open(mock_http_server, quota_config):
-    mock_http_server.register("GET", QUOTA_ENDPOINT, status=429)
+    mock_http_server.register("GET", QUOTA_ENDPOINT, PyResponseSpec(status=429))
 
     result = await check_and_sleep_if_needed(quota_config, base_url=mock_http_server.url)
 
@@ -123,7 +128,7 @@ async def test_http_429_fails_open(mock_http_server, quota_config):
 
 
 async def test_http_503_fails_open(mock_http_server, quota_config):
-    mock_http_server.register("GET", QUOTA_ENDPOINT, status=503)
+    mock_http_server.register("GET", QUOTA_ENDPOINT, PyResponseSpec(status=503))
 
     result = await check_and_sleep_if_needed(quota_config, base_url=mock_http_server.url)
 
@@ -132,7 +137,7 @@ async def test_http_503_fails_open(mock_http_server, quota_config):
 
 
 async def test_network_timeout_fails_open(mock_http_server, quota_config):
-    mock_http_server.register("GET", QUOTA_ENDPOINT, json={}, delay_seconds=0.5)
+    mock_http_server.register("GET", QUOTA_ENDPOINT, PyResponseSpec(body={}, delay_ms=500))
 
     result = await check_and_sleep_if_needed(
         quota_config, base_url=mock_http_server.url, _httpx_timeout=0.1
@@ -146,12 +151,14 @@ async def test_z_suffix_resets_at_parsed_correctly(mock_http_server, quota_confi
     mock_http_server.register(
         "GET",
         QUOTA_ENDPOINT,
-        json={
-            "five_hour": {
-                "utilization": 50.0,
-                "resets_at": "2026-04-05T00:00:00Z",
+        PyResponseSpec(
+            body={
+                "five_hour": {
+                    "utilization": 50.0,
+                    "resets_at": "2026-04-05T00:00:00Z",
+                }
             }
-        },
+        ),
     )
 
     result = await check_and_sleep_if_needed(quota_config, base_url=mock_http_server.url)

--- a/tests/execution/test_quota_http.py
+++ b/tests/execution/test_quota_http.py
@@ -12,7 +12,7 @@ from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
 import pytest
-from api_simulator._api_simulator_py import PyResponseSpec
+from api_simulator.http import MockResponseSpec as PyResponseSpec
 
 from autoskillit.execution.quota import check_and_sleep_if_needed
 

--- a/tests/execution/test_session_classification_e2e.py
+++ b/tests/execution/test_session_classification_e2e.py
@@ -16,7 +16,7 @@ import signal
 import subprocess
 from collections.abc import Sequence
 
-from api_simulator.claude import ClaudeCLI
+from api_simulator.claude import FakeClaudeCLI
 
 from autoskillit.core.types import (
     RetryReason,
@@ -89,7 +89,7 @@ def _flat_assistant_msg(text: str, output_tokens: int = 0) -> dict:
 
 
 def _run_with_timeout(
-    fake_claude: ClaudeCLI,
+    fake_claude: FakeClaudeCLI,
     timeout: float = 3,
     kill_timeout: float = 5,
 ) -> str:
@@ -127,18 +127,18 @@ def _run_with_timeout(
 
 
 def _classify(
-    fake_claude: ClaudeCLI,
+    fake_claude: FakeClaudeCLI,
     termination: TerminationReason = TerminationReason.NATURAL_EXIT,
     completion_marker: str = "",
     expected_output_patterns: Sequence[str] = (),
     write_behavior: WriteBehaviorSpec | None = None,
 ) -> SkillResult:
     """Run fake_claude, parse stdout, classify through _build_skill_result."""
-    proc = fake_claude.run()
+    proc = fake_claude.run([], None)
     sr = SubprocessResult(
         returncode=proc.returncode,
         stdout=proc.stdout,
-        stderr=proc.stderr,
+        stderr="",
         termination=termination,
         pid=0,
     )
@@ -158,7 +158,7 @@ def _classify(
 class TestNdjsonStreamRobustness:
     """Verify the parser gracefully handles non-result NDJSON events."""
 
-    def test_api_retry_events_skipped(self, fake_claude: ClaudeCLI) -> None:
+    def test_api_retry_events_skipped(self, fake_claude: FakeClaudeCLI) -> None:
         """API retry system events before the result record are ignored."""
         fake_claude.inject_api_retry(at_message=0, error_status=529, attempts=3)
         fake_claude.add_message(_result_msg())
@@ -169,7 +169,7 @@ class TestNdjsonStreamRobustness:
         assert skill.subtype == "success"
         assert skill.exit_code == 0
 
-    def test_stream_corruption_skipped(self, fake_claude: ClaudeCLI) -> None:
+    def test_stream_corruption_skipped(self, fake_claude: FakeClaudeCLI) -> None:
         """A corrupted (non-JSON) line mid-stream is skipped; result still parsed."""
         fake_claude.add_message(_assistant_msg())
         fake_claude.add_message(_assistant_msg())  # placeholder to corrupt
@@ -181,7 +181,7 @@ class TestNdjsonStreamRobustness:
         assert skill.success is True
         assert skill.subtype == "success"
 
-    def test_multiple_result_records_last_wins(self, fake_claude: ClaudeCLI) -> None:
+    def test_multiple_result_records_last_wins(self, fake_claude: FakeClaudeCLI) -> None:
         """When multiple result records exist, the last one determines the outcome."""
         fake_claude.add_message(
             _result_msg("first", "success"),
@@ -196,7 +196,7 @@ class TestNdjsonStreamRobustness:
         assert skill.is_error is True
         assert "second" in skill.result
 
-    def test_api_retry_exhaustion_no_result(self, fake_claude: ClaudeCLI) -> None:
+    def test_api_retry_exhaustion_no_result(self, fake_claude: FakeClaudeCLI) -> None:
         """Exhausted retries suppress all subsequent messages — no result record."""
         fake_claude.inject_api_retry(at_message=0, error_status=529, attempts=10, exhaust=True)
         fake_claude.add_message(_result_msg())  # unreachable due to exhaust=True
@@ -217,7 +217,7 @@ class TestNdjsonStreamRobustness:
 class TestContextExhaustionEdgeCases:
     """Verify context-exhaustion detection from different NDJSON shapes."""
 
-    def test_flat_assistant_context_exhaustion(self, fake_claude: ClaudeCLI) -> None:
+    def test_flat_assistant_context_exhaustion(self, fake_claude: FakeClaudeCLI) -> None:
         """Flat assistant record with 'prompt is too long' triggers context exhaustion."""
         fake_claude.add_message(_flat_assistant_msg("prompt is too long"))
 
@@ -228,7 +228,7 @@ class TestContextExhaustionEdgeCases:
         assert skill.needs_retry is True
         assert skill.retry_reason == RetryReason.RESUME
 
-    def test_result_errors_context_exhaustion(self, fake_claude: ClaudeCLI) -> None:
+    def test_result_errors_context_exhaustion(self, fake_claude: FakeClaudeCLI) -> None:
         """Result record with 'prompt is too long' in errors triggers context exhaustion."""
         fake_claude.add_message(
             _result_msg(
@@ -254,7 +254,7 @@ class TestContextExhaustionEdgeCases:
 class TestKillBoundaryScenarios:
     """Verify classification at truncation and interrupt boundaries."""
 
-    def test_truncated_stream_mid_write(self, fake_claude: ClaudeCLI) -> None:
+    def test_truncated_stream_mid_write(self, fake_claude: FakeClaudeCLI) -> None:
         """Truncation after message index 1 exits with code 1 — classified as failure."""
         fake_claude.add_message(_assistant_msg())
         fake_claude.add_message(_result_msg())
@@ -267,7 +267,7 @@ class TestKillBoundaryScenarios:
         assert skill.success is False
         assert skill.exit_code != 0
 
-    def test_interrupted_nonzero_exit_no_retry(self, fake_claude: ClaudeCLI) -> None:
+    def test_interrupted_nonzero_exit_no_retry(self, fake_claude: FakeClaudeCLI) -> None:
         """Interrupted subtype + nonzero exit → failure without retry."""
         fake_claude.add_message(_result_msg(subtype="interrupted"))
         fake_claude.set_exit_code(1)
@@ -287,7 +287,7 @@ class TestKillBoundaryScenarios:
 class TestProcessBehaviorSimulation:
     """Verify classification with realistic process behaviors (hang, mid-exit)."""
 
-    def test_hang_after_result_emits_output(self, fake_claude: ClaudeCLI) -> None:
+    def test_hang_after_result_emits_output(self, fake_claude: FakeClaudeCLI) -> None:
         """Result record is emitted to stdout before the process hangs."""
         fake_claude.add_message(_result_msg("completed work"))
         fake_claude.hang_after_result()
@@ -297,14 +297,14 @@ class TestProcessBehaviorSimulation:
         assert session.subtype == CliSubtype.SUCCESS
         assert "completed work" in session.result
 
-    def test_inject_exit_mid_stream(self, fake_claude: ClaudeCLI) -> None:
+    def test_inject_exit_mid_stream(self, fake_claude: FakeClaudeCLI) -> None:
         """inject_exit after message 1 captures the result but exits with code 2."""
         fake_claude.add_message(_assistant_msg())
         fake_claude.add_message(_result_msg("mid-stream"))
         fake_claude.add_message(_assistant_msg())
         fake_claude.inject_exit(1, code=2)
 
-        proc = fake_claude.run()
+        proc = fake_claude.run([], None)
         assert proc.returncode == 2
 
         # Result at index 1 was emitted before exit
@@ -315,7 +315,7 @@ class TestProcessBehaviorSimulation:
         sr = SubprocessResult(
             returncode=proc.returncode,
             stdout=proc.stdout,
-            stderr=proc.stderr,
+            stderr="",
             termination=TerminationReason.NATURAL_EXIT,
             pid=0,
         )

--- a/uv.lock
+++ b/uv.lock
@@ -48,7 +48,7 @@ wheels = [
 [[package]]
 name = "api-simulator"
 version = "0.1.0"
-source = { git = "https://github.com/TalonT-Org/api-simulator?branch=main#41bed890a837de84dc40893692357cf08f360ddc" }
+source = { git = "https://github.com/TalonT-Org/api-simulator?subdirectory=crates%2Fapi-simulator-py&branch=main#e12c61404da9f9d0cfc2fafc3d4a075c7981caf1" }
 
 [[package]]
 name = "attrs"
@@ -104,7 +104,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anyio", specifier = ">=4.6.0" },
-    { name = "api-simulator", marker = "extra == 'dev'", git = "https://github.com/TalonT-Org/api-simulator?branch=main" },
+    { name = "api-simulator", marker = "extra == 'dev'", git = "https://github.com/TalonT-Org/api-simulator?subdirectory=crates%2Fapi-simulator-py&branch=main" },
     { name = "cyclopts", specifier = ">=4.0" },
     { name = "dynaconf", specifier = ">=3.2.12,<4.0" },
     { name = "fastmcp", specifier = ">=3.1.1,<4.0" },


### PR DESCRIPTION
## Summary

The `api-simulator` dependency has been rewritten in Rust with PyO3 bindings (TalonT-Org/api-simulator#74). The Python package now lives at `crates/api-simulator-py/` within a Cargo workspace, is built via maturin, and exposes a new API surface (`PyResponseSpec`, `PyFakeClaudeCLI`, `PySessionResult`). This plan migrates AutoSkillit's CI infrastructure, dependency declaration, and test code to the new API without changing any production source code.

## Requirements

### CI Infrastructure (CI)

- **REQ-CI-001:** All GitHub Actions workflows that resolve or install the `api-simulator` dev dependency (`tests.yml`, `patch-bump-integration.yml`, `version-bump.yml`) must include a Rust stable toolchain setup step before dependency installation.
- **REQ-CI-002:** The Rust toolchain step must execute before `uv sync --locked --extra dev` and `uv lock` commands in each workflow.
- **REQ-CI-003:** CI must pass on all matrix targets (ubuntu-latest, and macos-15 when targeting stable) with the Rust-based api-simulator.

### Dependency Configuration (DEP)

- **REQ-DEP-001:** `pyproject.toml` must reference the Rust-based api-simulator package such that `uv sync --extra dev` installs the maturin-built PyO3 wheel.
- **REQ-DEP-002:** `uv.lock` must be regenerated and pinned to a post-#75 commit of api-simulator.

### Test Migration (TEST)

- **REQ-TEST-001:** All imports from `api_simulator` must resolve against the Rust-based package.
- **REQ-TEST-002:** `test_quota_http.py` must be rewritten to use `PyResponseSpec` for route registration, `url()` method calls, dict-based request inspection, and `delay_ms` integer milliseconds.
- **REQ-TEST-003:** `test_session_classification_e2e.py` must be rewritten to use `run(args, env)` returning `PySessionResult`, `session_log_dir()` method, and `delay_message(n, millis)`.
- **REQ-TEST-004:** All 13 test methods in `test_session_classification_e2e.py` must pass against the Rust api-simulator.
- **REQ-TEST-005:** All 7 test functions in `test_quota_http.py` must pass against the Rust api-simulator.

## Architecture Impact

### Development Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph Deps ["DEPENDENCY LAYER"]
        PYPROJ["● pyproject.toml<br/>━━━━━━━━━━<br/>hatchling build<br/>api-simulator: git+subdir<br/>crates/api-simulator-py"]
        UVLOCK["● uv.lock<br/>━━━━━━━━━━<br/>Regenerated; pinned to<br/>post-#75 Rust commit"]
    end

    subgraph CIPreflight ["CI: preflight job (● tests.yml)"]
        RUST1["● dtolnay/rust-toolchain@stable<br/>━━━━━━━━━━<br/>Rust toolchain (new)<br/>Required for maturin build"]
        UVLOCK_CHK["uv lock --check<br/>━━━━━━━━━━<br/>Lockfile gate<br/>(fails fast on drift)"]
    end

    subgraph CITest ["CI: test job (● tests.yml)"]
        RUST2["● dtolnay/rust-toolchain@stable<br/>━━━━━━━━━━<br/>Rust toolchain (new)<br/>Compiles maturin wheel"]
        UV_SYNC["uv sync --locked --extra dev<br/>━━━━━━━━━━<br/>Installs all dev deps<br/>Builds api-simulator wheel"]
        TASK_ALL["task test-all<br/>━━━━━━━━━━<br/>lint-imports → pytest -n 4"]
    end

    subgraph CIPatchBump ["CI: patch-bump (● patch-bump-integration.yml)"]
        RUST_PB["● dtolnay/rust-toolchain@stable<br/>━━━━━━━━━━<br/>Required before uv lock"]
        UV_LOCK_PB["uv lock<br/>━━━━━━━━━━<br/>Regenerates lockfile<br/>with Rust dep resolution"]
    end

    subgraph CIVersionBump ["CI: version-bump (● version-bump.yml)"]
        RUST_VB["● dtolnay/rust-toolchain@stable<br/>━━━━━━━━━━<br/>Required before uv lock<br/>(main + integration)"]
        UV_LOCK_VB["uv lock × 2<br/>━━━━━━━━━━<br/>main branch + integration<br/>branch lockfile regeneration"]
    end

    subgraph Quality ["CODE QUALITY GATES"]
        RUFF["ruff format + check<br/>━━━━━━━━━━<br/>auto-fix on commit"]
        IMP_LINT["import-linter<br/>━━━━━━━━━━<br/>L0/L1/L2/L3 layering<br/>7 forbidden-import contracts"]
        MYPY["mypy<br/>━━━━━━━━━━<br/>type checking (py311)"]
    end

    subgraph TestFW ["TEST FRAMEWORK"]
        PYTEST["pytest -n 4 --dist worksteal<br/>━━━━━━━━━━<br/>pytest-asyncio · pytest-xdist<br/>timeout=60s (signal)"]
        MOCK_HTTP["● mock_http_server fixture<br/>━━━━━━━━━━<br/>PyResponseSpec API<br/>dict headers · url() method"]
        FAKE_CLD["● fake_claude fixture<br/>━━━━━━━━━━<br/>PyFakeClaudeCLI<br/>run([], None) · exit_code()"]
    end

    PYPROJ --> UVLOCK
    UVLOCK --> RUST1
    RUST1 --> UVLOCK_CHK
    UVLOCK --> RUST2
    RUST2 --> UV_SYNC
    UV_SYNC --> TASK_ALL
    TASK_ALL --> IMP_LINT
    IMP_LINT --> PYTEST
    PYTEST --> MOCK_HTTP
    PYTEST --> FAKE_CLD
    TASK_ALL --> RUFF
    RUFF --> MYPY

    PYPROJ --> RUST_PB
    RUST_PB --> UV_LOCK_PB

    PYPROJ --> RUST_VB
    RUST_VB --> UV_LOCK_VB

    class PYPROJ,UVLOCK stateNode;
    class RUST1,RUST2,RUST_PB,RUST_VB newComponent;
    class UV_SYNC,UV_LOCK_PB,UV_LOCK_VB phase;
    class UVLOCK_CHK,RUFF,IMP_LINT,MYPY detector;
    class TASK_ALL handler;
    class PYTEST handler;
    class MOCK_HTTP,FAKE_CLD output;
```

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph Config ["DEPENDENCY CONFIGURATION"]
        PYPROJ["● pyproject.toml<br/>━━━━━━━━━━<br/>api-simulator: git + subdirectory<br/>crates/api-simulator-py (Rust)"]
        UVLOCK["● uv.lock<br/>━━━━━━━━━━<br/>Pinned to post-#75 commit<br/>maturin wheel resolution"]
    end

    subgraph External ["EXTERNAL PACKAGE (Rust/PyO3)"]
        API_SIM["api-simulator<br/>━━━━━━━━━━<br/>TalonT-Org/api-simulator<br/>crates/api-simulator-py"]
        PY_RESP["api_simulator._api_simulator_py<br/>━━━━━━━━━━<br/>PyResponseSpec<br/>mock_http_server fixture"]
        FAKE_CLI["api_simulator.claude<br/>━━━━━━━━━━<br/>FakeClaudeCLI<br/>fake_claude fixture"]
    end

    subgraph TestL1 ["L1 TEST CONSUMERS (tests/execution/)"]
        QUOTA_HTTP["● test_quota_http.py<br/>━━━━━━━━━━<br/>imports PyResponseSpec<br/>7 test functions"]
        SESSION_E2E["● test_session_classification_e2e.py<br/>━━━━━━━━━━<br/>imports FakeClaudeCLI<br/>10 test methods"]
    end

    subgraph ProdL1 ["L1 PRODUCTION MODULE"]
        EXEC["execution/<br/>━━━━━━━━━━<br/>quota.py · session.py<br/>No api-simulator imports"]
    end

    PYPROJ --> UVLOCK
    UVLOCK --> API_SIM
    API_SIM --> PY_RESP
    API_SIM --> FAKE_CLI
    PY_RESP -->|"imports PyResponseSpec"| QUOTA_HTTP
    FAKE_CLI -->|"imports FakeClaudeCLI"| SESSION_E2E
    EXEC -.->|"tested by"| QUOTA_HTTP
    EXEC -.->|"tested by"| SESSION_E2E

    class PYPROJ,UVLOCK stateNode;
    class API_SIM integration;
    class PY_RESP,FAKE_CLI handler;
    class QUOTA_HTTP,SESSION_E2E output;
    class EXEC phase;
```

Closes #643

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260406-193330-615247/.autoskillit/temp/make-plan/migrate_rust_api_simulator_plan_2026-04-06_000000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 29 | 21.3k | 724.2k | 68.1k | 1 | 7m 48s |
| verify | 28 | 32.9k | 1.2M | 66.4k | 1 | 9m 14s |
| implement | 80 | 36.1k | 5.2M | 103.8k | 1 | 16m 22s |
| open_pr | 37 | 19.2k | 1.3M | 59.8k | 1 | 7m 53s |
| **Total** | 174 | 109.5k | 8.4M | 298.1k | | 41m 18s |