### PR TITLE
Rectify: research recipe archives wrong experiment directory; replace find heuristic with context tracking (#655)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,6 +177,7 @@ src/autoskillit/
 │   ├── rules_bypass.py      #   Semantic rules for skip_when_false bypass routing contracts
 │   ├── rules_ci.py          #   Semantic rules for CI polling patterns (ci-polling-inline-shell)
 │   ├── rules_clone.py       #   Semantic rules for clone/push workflow validation
+│   ├── rules_cmd.py         #   Semantic rules for run_cmd echo-capture alignment (run-cmd-emit-alignment, run-cmd-find-rediscovery)
 │   ├── rules_contracts.py   #   Semantic rules for skill contract completeness (missing-output-patterns)
 │   ├── rules_dataflow.py    #   Semantic rules for capture/output dataflow analysis
 │   ├── rules_graph.py       #   Semantic rules for step graph reachability and cycles

--- a/src/autoskillit/recipe/__init__.py
+++ b/src/autoskillit/recipe/__init__.py
@@ -10,6 +10,7 @@ _logger = get_logger(__name__)
 from autoskillit.recipe import rules_bypass as _rules_bypass  # noqa: E402 F401
 from autoskillit.recipe import rules_ci as _rules_ci  # noqa: E402 F401
 from autoskillit.recipe import rules_clone as _rules_clone  # noqa: E402 F401
+from autoskillit.recipe import rules_cmd as _rules_cmd  # noqa: E402 F401
 from autoskillit.recipe import rules_contracts as _rules_contracts  # noqa: E402 F401
 from autoskillit.recipe import rules_dataflow as _rules_dataflow  # noqa: E402 F401
 from autoskillit.recipe import rules_graph as _rules_graph  # noqa: E402 F401

--- a/src/autoskillit/recipe/rules_cmd.py
+++ b/src/autoskillit/recipe/rules_cmd.py
@@ -1,0 +1,94 @@
+"""Semantic rules for run_cmd echo-capture alignment in recipe steps."""
+
+from __future__ import annotations
+
+import re
+
+from autoskillit.core import Severity
+from autoskillit.recipe._analysis import ValidationContext
+from autoskillit.recipe.contracts import _RESULT_CAPTURE_RE
+from autoskillit.recipe.registry import RuleFinding, semantic_rule
+
+# Raw tool output fields — these are populated directly from the tool JSON response,
+# no echo statement in the cmd is required to capture them.
+_RAW_RESULT_FIELDS = {"stdout", "stderr", "exit_code"}
+
+# Matches find ... | sort ... | (tail|head) patterns that indicate a step is
+# re-discovering a path that should have been captured by an upstream step.
+_FIND_HEURISTIC_RE = re.compile(r"\bfind\b.+\|\s*sort\b.+\|\s*(tail|head)\b", re.DOTALL)
+
+
+@semantic_rule(
+    name="run-cmd-emit-alignment",
+    description=(
+        "For every run_cmd step, each non-raw capture key K must have a matching "
+        'echo "K=..." in the cmd. A missing echo causes a silent empty-string capture.'
+    ),
+    severity=Severity.ERROR,
+)
+def _check_run_cmd_emit_alignment(ctx: ValidationContext) -> list[RuleFinding]:
+    findings: list[RuleFinding] = []
+    for name, step in ctx.recipe.steps.items():
+        if step.tool != "run_cmd":
+            continue
+        cmd = (step.with_args or {}).get("cmd", "")
+        if not isinstance(cmd, str):
+            continue
+        for cap_key, cap_val in step.capture.items():
+            m = _RESULT_CAPTURE_RE.search(cap_val)
+            if m is None:
+                # Cannot determine the result field — skip (e.g. pipe-filtered values).
+                continue
+            result_key = m.group(1)
+            if result_key in _RAW_RESULT_FIELDS:
+                continue
+            # Check that the cmd emits `echo "result_key=..."`.
+            echo_pattern = re.compile(rf'\becho\s+"?{re.escape(result_key)}=')
+            if not echo_pattern.search(cmd):
+                findings.append(
+                    RuleFinding(
+                        rule="run-cmd-emit-alignment",
+                        severity=Severity.ERROR,
+                        step_name=name,
+                        message=(
+                            f"Step '{name}' captures '{cap_key}' from result.{result_key} "
+                            f'but cmd contains no `echo "{result_key}=..."` statement. '
+                            f'Add `echo "{result_key}=${{...}}"` to the cmd or the '
+                            "captured value will always be empty."
+                        ),
+                    )
+                )
+    return findings
+
+
+@semantic_rule(
+    name="run-cmd-find-rediscovery",
+    description=(
+        "Flags run_cmd steps using find|sort|tail/head to select a path — this pattern "
+        "indicates an upstream step computed the path but did not echo it into context."
+    ),
+    severity=Severity.WARNING,
+)
+def _check_run_cmd_find_rediscovery(ctx: ValidationContext) -> list[RuleFinding]:
+    findings: list[RuleFinding] = []
+    for name, step in ctx.recipe.steps.items():
+        if step.tool != "run_cmd":
+            continue
+        cmd = (step.with_args or {}).get("cmd", "")
+        if not isinstance(cmd, str):
+            continue
+        if _FIND_HEURISTIC_RE.search(cmd):
+            findings.append(
+                RuleFinding(
+                    rule="run-cmd-find-rediscovery",
+                    severity=Severity.WARNING,
+                    step_name=name,
+                    message=(
+                        f"Step '{name}' uses a `find | sort | tail` heuristic to select "
+                        "a directory. This pattern indicates an upstream step computed "
+                        "the path but did not echo it into context. Capture the path via "
+                        "echo+capture in the originating step instead."
+                    ),
+                )
+            )
+    return findings

--- a/src/autoskillit/recipe/rules_cmd.py
+++ b/src/autoskillit/recipe/rules_cmd.py
@@ -15,7 +15,7 @@ _RAW_RESULT_FIELDS = {"stdout", "stderr", "exit_code"}
 
 # Matches find ... | sort ... | (tail|head) patterns that indicate a step is
 # re-discovering a path that should have been captured by an upstream step.
-_FIND_HEURISTIC_RE = re.compile(r"\bfind\b.+\|\s*sort\b.+\|\s*(tail|head)\b", re.DOTALL)
+_FIND_HEURISTIC_RE = re.compile(r"\bfind\b.+\|\s*sort\b.+\|\s*(tail|head)\b")
 
 
 @semantic_rule(

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -642,7 +642,7 @@ steps:
         RESEARCH_SUBDIR="research/$(basename "${{ context.research_dir }}")" &&
         ARTIFACT_DIR="${{ context.worktree_path }}" &&
         if [ -f "${ARTIFACT_DIR}/${RESEARCH_SUBDIR}/artifacts.tar.gz" ]; then
-          STRUCT_DETAIL="- \`artifacts.tar.gz\` — compressed artifact tree\n\nExtract:\n\`\`\`bash\ntar xzf artifacts.tar.gz\n\`\`\`";
+          STRUCT_DETAIL=$'- `artifacts.tar.gz` \xe2\x80\x94 compressed artifact tree\n\nExtract:\n```bash\ntar xzf artifacts.tar.gz\n```';
         else
           STRUCT_DETAIL="- \`artifacts/\` — uncompressed artifact tree";
         fi &&

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -640,7 +640,7 @@ steps:
         ARTIFACT="${{ context.artifact_branch }}" &&
         ORIG_PR="${{ context.pr_url }}" &&
         RESEARCH_SUBDIR="research/$(basename "${{ context.research_dir }}")" &&
-        ARTIFACT_DIR="$(git -C '${{ context.worktree_path }}' rev-parse --show-toplevel)" &&
+        ARTIFACT_DIR="${{ context.worktree_path }}" &&
         if [ -f "${ARTIFACT_DIR}/${RESEARCH_SUBDIR}/artifacts.tar.gz" ]; then
           STRUCT_DETAIL="- \`artifacts.tar.gz\` — compressed artifact tree\n\nExtract:\n\`\`\`bash\ntar xzf artifacts.tar.gz\n\`\`\`";
         else

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -198,11 +198,13 @@ steps:
         for f in "${SRC_TEMP}"/plan-experiment/experiment_plan_*.md; do [ -f "$f" ] && cp "$f" "${RESEARCH_DIR}/artifacts/plan-versions/"; done;
         for f in "${SRC_TEMP}"/resolve-design-review/*.md; do [ -f "$f" ] && cp "$f" "${RESEARCH_DIR}/artifacts/review-cycles/"; done;
         cd "${RESOLVED}" && git add research/ && git commit -m "Add experiment plan and scope to research/" &&
+        echo "research_dir=${RESEARCH_DIR}" &&
         echo "worktree_path=${RESOLVED}"
       cwd: "${{ inputs.source_dir }}"
       step_name: create_worktree
     capture:
       worktree_path: "${{ result.worktree_path }}"
+      research_dir: "${{ result.research_dir }}"
     on_success: decompose_phases
     on_failure: escalate_stop
     note: >
@@ -400,7 +402,7 @@ steps:
     tool: run_cmd
     with:
       cmd: >
-        RESEARCH_DIR=$(find "${{ context.worktree_path }}/research" -maxdepth 1 -type d -name '????-??-??-*' | sort | tail -1) &&
+        RESEARCH_DIR="${{ context.research_dir }}" &&
         if [ -n "${RESEARCH_DIR}" ] && [ -d "${RESEARCH_DIR}" ]; then
           WT_TEMP="${{ context.worktree_path }}/.autoskillit/temp" &&
           mkdir -p "${RESEARCH_DIR}/artifacts/phase-groups" &&
@@ -420,6 +422,12 @@ steps:
             cp "${RESEARCH_DIR}/report.md" "${RESEARCH_DIR}/README.md" &&
             rm "${RESEARCH_DIR}/report.md";
           fi &&
+          [ -f "${RESEARCH_DIR}/artifacts.tar.gz" ] || \
+            { echo "ERROR: artifacts.tar.gz not created in ${RESEARCH_DIR}"; exit 1; } &&
+          [ ! -d "${RESEARCH_DIR}/artifacts" ] || \
+            { echo "ERROR: uncompressed artifacts/ still present in ${RESEARCH_DIR}"; exit 1; } &&
+          [ -f "${RESEARCH_DIR}/README.md" ] || \
+            { echo "ERROR: README.md not found in ${RESEARCH_DIR}"; exit 1; } &&
           cd "${{ context.worktree_path }}" && git add research/ && git diff --cached --quiet || git commit -m "Add compressed research artifacts";
         else
           echo "commit_research_artifacts: no research directory found — artifact commit skipped";
@@ -603,7 +611,8 @@ steps:
         git -C '${{ context.worktree_path }}' fetch origin '${{ inputs.base_branch }}' &&
         (git -C '${{ context.worktree_path }}' branch -D "${ARTIFACT_BRANCH}" 2>/dev/null || true) &&
         git -C '${{ context.worktree_path }}' worktree add "${ARTIFACT_DIR}" -b "${ARTIFACT_BRANCH}" "origin/${{ inputs.base_branch }}" &&
-        git -C "${ARTIFACT_DIR}" checkout "${EXPERIMENT_BRANCH}" -- research/ &&
+        RESEARCH_SUBDIR="research/$(basename "${{ context.research_dir }}")" &&
+        git -C "${ARTIFACT_DIR}" checkout "${EXPERIMENT_BRANCH}" -- "${RESEARCH_SUBDIR}" &&
         cd "${ARTIFACT_DIR}" &&
         git add research/ &&
         git commit -m "Add research artifacts: ${SLUG}" &&
@@ -630,7 +639,14 @@ steps:
         EXPERIMENT="${{ context.experiment_branch }}" &&
         ARTIFACT="${{ context.artifact_branch }}" &&
         ORIG_PR="${{ context.pr_url }}" &&
-        PR_BODY=$(printf '## Research Artifacts\n\nFrom experiment branch `%s`.\n\nOriginal experiment PR: %s\n\n### Structure\n\n- **README.md** — Research conclusions (browsable on GitHub)\n- **artifacts.tar.gz** — Full artifact tree (experiment plan, scope report, design evaluation, review cycles, plan versions, phase groups, phase plans)\n\nTo extract the full artifact tree:\n```\ntar xzf artifacts.tar.gz\n```\n\nContains only files under `research/` — zero production code changes.' "${EXPERIMENT}" "${ORIG_PR}") &&
+        RESEARCH_SUBDIR="research/$(basename "${{ context.research_dir }}")" &&
+        ARTIFACT_DIR="$(git -C '${{ context.worktree_path }}' rev-parse --show-toplevel)" &&
+        if [ -f "${ARTIFACT_DIR}/${RESEARCH_SUBDIR}/artifacts.tar.gz" ]; then
+          STRUCT_DETAIL="- \`artifacts.tar.gz\` — compressed artifact tree\n\nExtract:\n\`\`\`bash\ntar xzf artifacts.tar.gz\n\`\`\`";
+        else
+          STRUCT_DETAIL="- \`artifacts/\` — uncompressed artifact tree";
+        fi &&
+        PR_BODY=$(printf '## Research Artifacts\n\nFrom experiment branch `%s`.\n\nOriginal experiment PR: %s\n\n### Structure\n\n- **README.md** — Research conclusions (browsable on GitHub)\n%s\n\nContains only files under `research/` — zero production code changes.' "${EXPERIMENT}" "${ORIG_PR}" "${STRUCT_DETAIL}") &&
         PR_URL=$(gh pr create
         --head "${ARTIFACT}"
         --base '${{ inputs.base_branch }}'

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -643,7 +643,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         thin routing layer. Exempt at 16 files.
       recipe/ — REQ-CNST-003-E2: recipe/ hosts one file per semantic-rule domain
         (rules_bypass, rules_ci, rules_clone, rules_packs, etc.) for independent testability.
-        Adding rules_packs.py for requires_packs validation brings the count to 28.
+        Adding rules_cmd.py for run_cmd echo-capture alignment validation brings the count to 29.
       execution/ — REQ-CNST-003-E3: execution/ decomposes process lifecycle into
         focused single-concern modules (_process_io, _process_kill, _process_race,
         etc.) that cannot be merged without re-introducing the coupling they isolate.
@@ -667,7 +667,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
     """
     EXEMPTIONS: dict[str, int] = {
         "server": 17,
-        "recipe": 28,
+        "recipe": 29,
         "execution": 24,
         "core": 15,
         "cli": 15,

--- a/tests/infra/test_claude_md_critical_rules.py
+++ b/tests/infra/test_claude_md_critical_rules.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 import pytest
 
-REPO_ROOT = Path(__file__).parent.parent.parent
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
 
 @pytest.fixture()

--- a/tests/infra/test_docstring_labels.py
+++ b/tests/infra/test_docstring_labels.py
@@ -4,22 +4,24 @@ from __future__ import annotations
 
 from pathlib import Path
 
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
 
 def test_session_py_docstring_says_l2():
     """session.py docstring must carry an L2 label."""
-    src = Path("src/autoskillit/execution/session.py").read_text()
+    src = (_REPO_ROOT / "src/autoskillit/execution/session.py").read_text()
     assert "L2" in src.split('"""')[1], "session.py docstring must say L2"
 
 
 def test_headless_py_docstring_says_l1():
     """headless.py docstring must carry an L1 label."""
-    src = Path("src/autoskillit/execution/headless.py").read_text()
+    src = (_REPO_ROOT / "src/autoskillit/execution/headless.py").read_text()
     assert "L1" in src.split('"""')[1], "headless.py docstring must say L1"
 
 
 def test_smoke_utils_documents_limitation():
     """smoke_utils.py documents its file-path coupling limitation."""
-    src = Path("src/autoskillit/smoke_utils.py").read_text()
+    src = (_REPO_ROOT / "src/autoskillit/smoke_utils.py").read_text()
     assert "limitation" in src.lower() or "known" in src.lower(), (
         "smoke_utils.py must document its path-coupling limitation"
     )
@@ -27,7 +29,7 @@ def test_smoke_utils_documents_limitation():
 
 def test_claude_md_no_stale_l3_headless_label():
     """CLAUDE.md must not contain stale 'L3 service' label for headless."""
-    src = Path("CLAUDE.md").read_text()
+    src = (_REPO_ROOT / "CLAUDE.md").read_text()
     assert "L3 service module" not in src, (
         "CLAUDE.md still contains stale 'L3 service module' label for headless"
     )

--- a/tests/recipe/test_research_artifact_archive.py
+++ b/tests/recipe/test_research_artifact_archive.py
@@ -1,7 +1,7 @@
 import pytest
 
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
-from autoskillit.recipe.validator import validate_recipe
+from autoskillit.recipe.validator import run_semantic_rules, validate_recipe
 
 RESEARCH_RECIPE_PATH = builtin_recipes_dir() / "research.yaml"
 
@@ -60,3 +60,67 @@ def test_commit_research_artifacts_routing_preserved(recipe):
     step = recipe.steps["commit_research_artifacts"]
     assert step.on_success == "push_branch"
     assert step.on_failure == "push_branch"
+
+
+def test_create_worktree_emits_research_dir(recipe):
+    """create_worktree cmd must emit echo "research_dir=..." to stdout."""
+    step = recipe.steps["create_worktree"]
+    cmd = step.with_args.get("cmd", "")
+    assert 'echo "research_dir=' in cmd, (
+        "create_worktree must emit research_dir= to stdout so it can be captured"
+    )
+
+
+def test_create_worktree_captures_research_dir(recipe):
+    """create_worktree capture block must include research_dir key."""
+    step = recipe.steps["create_worktree"]
+    assert "research_dir" in step.capture, (
+        "create_worktree must capture research_dir for downstream steps"
+    )
+
+
+def test_commit_research_artifacts_uses_context_research_dir(recipe):
+    """commit_research_artifacts must reference context.research_dir, not find."""
+    step = recipe.steps["commit_research_artifacts"]
+    cmd = step.with_args.get("cmd", "")
+    assert "context.research_dir" in cmd, (
+        "commit_research_artifacts must source RESEARCH_DIR from context"
+    )
+
+
+def test_commit_research_artifacts_no_find_heuristic(recipe):
+    """commit_research_artifacts must not use find|sort|tail -1 to pick the directory."""
+    step = recipe.steps["commit_research_artifacts"]
+    cmd = step.with_args.get("cmd", "")
+    has_heuristic = "find" in cmd and "sort" in cmd and "tail" in cmd
+    assert not has_heuristic, (
+        "commit_research_artifacts uses find|sort|tail heuristic — "
+        "replace with ${{ context.research_dir }}"
+    )
+
+
+def test_create_artifact_branch_scopes_checkout(recipe):
+    """create_artifact_branch must scope git checkout to the specific experiment subdir."""
+    step = recipe.steps["create_artifact_branch"]
+    cmd = step.with_args.get("cmd", "")
+    assert "basename" in cmd, (
+        "create_artifact_branch must scope checkout via basename of context.research_dir"
+    )
+
+
+def test_commit_research_artifacts_has_post_compression_guard(recipe):
+    """commit_research_artifacts must guard that artifacts.tar.gz exists before git commit."""
+    step = recipe.steps["commit_research_artifacts"]
+    cmd = step.with_args.get("cmd", "")
+    assert "artifacts.tar.gz" in cmd and "exit 1" in cmd, (
+        "commit_research_artifacts must fail loudly if artifacts.tar.gz is absent"
+    )
+
+
+def test_research_recipe_validates_with_new_rules(recipe):
+    """research.yaml must pass validate_recipe AND all semantic rules including run-cmd rules."""
+    errors = validate_recipe(recipe)
+    assert not errors, errors
+    findings = run_semantic_rules(recipe)
+    errors_only = [f for f in findings if f.severity.value == "error"]
+    assert not errors_only, [f.message for f in errors_only]

--- a/tests/recipe/test_research_artifact_archive.py
+++ b/tests/recipe/test_research_artifact_archive.py
@@ -103,7 +103,7 @@ def test_create_artifact_branch_scopes_checkout(recipe):
     """create_artifact_branch must scope git checkout to the specific experiment subdir."""
     step = recipe.steps["create_artifact_branch"]
     cmd = step.with_args.get("cmd", "")
-    assert "basename" in cmd, (
+    assert "basename" in cmd and "context.research_dir" in cmd, (
         "create_artifact_branch must scope checkout via basename of context.research_dir"
     )
 

--- a/tests/recipe/test_rules_cmd.py
+++ b/tests/recipe/test_rules_cmd.py
@@ -1,0 +1,119 @@
+"""Tests for run_cmd echo-capture alignment rules."""
+from __future__ import annotations
+
+from tests.recipe.conftest import _make_workflow
+from autoskillit.recipe.validator import run_semantic_rules
+
+
+def _make_recipe(steps: dict) -> object:
+    """Build a minimal Recipe from a dict of step dicts, with a terminal END step."""
+    all_steps = {**steps, "END": {"action": "stop", "message": "Done"}}
+    return _make_workflow(all_steps)
+
+
+def test_emit_alignment_errors_on_missing_echo():
+    """run_cmd with capture key K but no echo "K=..." in cmd → ERROR."""
+    recipe = _make_recipe({
+        "step_a": {
+            "tool": "run_cmd",
+            "with": {"cmd": "RESULT=$(compute_it)"},
+            "capture": {"my_path": "${{ result.my_path }}"},
+            "on_success": "END",
+        }
+    })
+    findings = run_semantic_rules(recipe)
+    codes = [f.rule for f in findings]
+    assert "run-cmd-emit-alignment" in codes
+    finding = next(f for f in findings if f.rule == "run-cmd-emit-alignment")
+    assert "step_a" in finding.step_name
+    assert "my_path" in finding.message
+
+
+def test_emit_alignment_passes_with_echo():
+    """run_cmd with matching echo "K=..." → no alignment error."""
+    recipe = _make_recipe({
+        "step_a": {
+            "tool": "run_cmd",
+            "with": {"cmd": 'RESULT=$(compute_it) && echo "my_path=${RESULT}"'},
+            "capture": {"my_path": "${{ result.my_path }}"},
+            "on_success": "END",
+        }
+    })
+    findings = run_semantic_rules(recipe)
+    codes = [f.rule for f in findings]
+    assert "run-cmd-emit-alignment" not in codes
+
+
+def test_emit_alignment_ignores_stdout_capture():
+    """capture: {K: "${{ result.stdout }}"} does not require echo."""
+    recipe = _make_recipe({
+        "step_a": {
+            "tool": "run_cmd",
+            "with": {"cmd": "git rev-parse HEAD"},
+            "capture": {"sha": "${{ result.stdout | trim }}"},
+            "on_success": "END",
+        }
+    })
+    findings = run_semantic_rules(recipe)
+    codes = [f.rule for f in findings]
+    assert "run-cmd-emit-alignment" not in codes
+
+
+def test_emit_alignment_ignores_exit_code_capture():
+    """capture: {K: "${{ result.exit_code }}"} does not require echo."""
+    recipe = _make_recipe({
+        "step_a": {
+            "tool": "run_cmd",
+            "with": {"cmd": "test -f something"},
+            "capture": {"ok": "${{ result.exit_code }}"},
+            "on_success": "END",
+        }
+    })
+    findings = run_semantic_rules(recipe)
+    assert all(f.rule != "run-cmd-emit-alignment" for f in findings)
+
+
+def test_emit_alignment_ignores_run_skill():
+    """run_skill steps are not subject to the emit-alignment rule."""
+    recipe = _make_recipe({
+        "step_a": {
+            "tool": "run_skill",
+            "with": {"skill_command": "/foo:bar"},
+            "capture": {"plan_path": "${{ result.plan_path }}"},
+            "on_success": "END",
+        }
+    })
+    findings = run_semantic_rules(recipe)
+    assert all(f.rule != "run-cmd-emit-alignment" for f in findings)
+
+
+def test_find_rediscovery_warns_on_find_sort_tail():
+    """find|sort|tail -1 in run_cmd cmd → WARNING."""
+    recipe = _make_recipe({
+        "step_a": {
+            "tool": "run_cmd",
+            "with": {
+                "cmd": (
+                    "DIR=$(find /some/path -maxdepth 1 -type d"
+                    " -name '????-??-??-*' | sort | tail -1)"
+                )
+            },
+            "on_success": "END",
+        }
+    })
+    findings = run_semantic_rules(recipe)
+    codes = [f.rule for f in findings]
+    assert "run-cmd-find-rediscovery" in codes
+
+
+def test_find_rediscovery_no_warning_without_heuristic():
+    """find without sort|tail does not trigger the warning."""
+    recipe = _make_recipe({
+        "step_a": {
+            "tool": "run_cmd",
+            "with": {"cmd": "find /path -name '*.md' | xargs wc -l"},
+            "on_success": "END",
+        }
+    })
+    findings = run_semantic_rules(recipe)
+    assert all(f.rule != "run-cmd-find-rediscovery" for f in findings)

--- a/tests/recipe/test_rules_cmd.py
+++ b/tests/recipe/test_rules_cmd.py
@@ -1,8 +1,9 @@
 """Tests for run_cmd echo-capture alignment rules."""
+
 from __future__ import annotations
 
-from tests.recipe.conftest import _make_workflow
 from autoskillit.recipe.validator import run_semantic_rules
+from tests.recipe.conftest import _make_workflow
 
 
 def _make_recipe(steps: dict) -> object:
@@ -13,14 +14,16 @@ def _make_recipe(steps: dict) -> object:
 
 def test_emit_alignment_errors_on_missing_echo():
     """run_cmd with capture key K but no echo "K=..." in cmd → ERROR."""
-    recipe = _make_recipe({
-        "step_a": {
-            "tool": "run_cmd",
-            "with": {"cmd": "RESULT=$(compute_it)"},
-            "capture": {"my_path": "${{ result.my_path }}"},
-            "on_success": "END",
+    recipe = _make_recipe(
+        {
+            "step_a": {
+                "tool": "run_cmd",
+                "with": {"cmd": "RESULT=$(compute_it)"},
+                "capture": {"my_path": "${{ result.my_path }}"},
+                "on_success": "END",
+            }
         }
-    })
+    )
     findings = run_semantic_rules(recipe)
     codes = [f.rule for f in findings]
     assert "run-cmd-emit-alignment" in codes
@@ -31,14 +34,16 @@ def test_emit_alignment_errors_on_missing_echo():
 
 def test_emit_alignment_passes_with_echo():
     """run_cmd with matching echo "K=..." → no alignment error."""
-    recipe = _make_recipe({
-        "step_a": {
-            "tool": "run_cmd",
-            "with": {"cmd": 'RESULT=$(compute_it) && echo "my_path=${RESULT}"'},
-            "capture": {"my_path": "${{ result.my_path }}"},
-            "on_success": "END",
+    recipe = _make_recipe(
+        {
+            "step_a": {
+                "tool": "run_cmd",
+                "with": {"cmd": 'RESULT=$(compute_it) && echo "my_path=${RESULT}"'},
+                "capture": {"my_path": "${{ result.my_path }}"},
+                "on_success": "END",
+            }
         }
-    })
+    )
     findings = run_semantic_rules(recipe)
     codes = [f.rule for f in findings]
     assert "run-cmd-emit-alignment" not in codes
@@ -46,14 +51,16 @@ def test_emit_alignment_passes_with_echo():
 
 def test_emit_alignment_ignores_stdout_capture():
     """capture: {K: "${{ result.stdout }}"} does not require echo."""
-    recipe = _make_recipe({
-        "step_a": {
-            "tool": "run_cmd",
-            "with": {"cmd": "git rev-parse HEAD"},
-            "capture": {"sha": "${{ result.stdout | trim }}"},
-            "on_success": "END",
+    recipe = _make_recipe(
+        {
+            "step_a": {
+                "tool": "run_cmd",
+                "with": {"cmd": "git rev-parse HEAD"},
+                "capture": {"sha": "${{ result.stdout | trim }}"},
+                "on_success": "END",
+            }
         }
-    })
+    )
     findings = run_semantic_rules(recipe)
     codes = [f.rule for f in findings]
     assert "run-cmd-emit-alignment" not in codes
@@ -61,46 +68,52 @@ def test_emit_alignment_ignores_stdout_capture():
 
 def test_emit_alignment_ignores_exit_code_capture():
     """capture: {K: "${{ result.exit_code }}"} does not require echo."""
-    recipe = _make_recipe({
-        "step_a": {
-            "tool": "run_cmd",
-            "with": {"cmd": "test -f something"},
-            "capture": {"ok": "${{ result.exit_code }}"},
-            "on_success": "END",
+    recipe = _make_recipe(
+        {
+            "step_a": {
+                "tool": "run_cmd",
+                "with": {"cmd": "test -f something"},
+                "capture": {"ok": "${{ result.exit_code }}"},
+                "on_success": "END",
+            }
         }
-    })
+    )
     findings = run_semantic_rules(recipe)
     assert all(f.rule != "run-cmd-emit-alignment" for f in findings)
 
 
 def test_emit_alignment_ignores_run_skill():
     """run_skill steps are not subject to the emit-alignment rule."""
-    recipe = _make_recipe({
-        "step_a": {
-            "tool": "run_skill",
-            "with": {"skill_command": "/foo:bar"},
-            "capture": {"plan_path": "${{ result.plan_path }}"},
-            "on_success": "END",
+    recipe = _make_recipe(
+        {
+            "step_a": {
+                "tool": "run_skill",
+                "with": {"skill_command": "/foo:bar"},
+                "capture": {"plan_path": "${{ result.plan_path }}"},
+                "on_success": "END",
+            }
         }
-    })
+    )
     findings = run_semantic_rules(recipe)
     assert all(f.rule != "run-cmd-emit-alignment" for f in findings)
 
 
 def test_find_rediscovery_warns_on_find_sort_tail():
     """find|sort|tail -1 in run_cmd cmd → WARNING."""
-    recipe = _make_recipe({
-        "step_a": {
-            "tool": "run_cmd",
-            "with": {
-                "cmd": (
-                    "DIR=$(find /some/path -maxdepth 1 -type d"
-                    " -name '????-??-??-*' | sort | tail -1)"
-                )
-            },
-            "on_success": "END",
+    recipe = _make_recipe(
+        {
+            "step_a": {
+                "tool": "run_cmd",
+                "with": {
+                    "cmd": (
+                        "DIR=$(find /some/path -maxdepth 1 -type d"
+                        " -name '????-??-??-*' | sort | tail -1)"
+                    )
+                },
+                "on_success": "END",
+            }
         }
-    })
+    )
     findings = run_semantic_rules(recipe)
     codes = [f.rule for f in findings]
     assert "run-cmd-find-rediscovery" in codes
@@ -108,12 +121,14 @@ def test_find_rediscovery_warns_on_find_sort_tail():
 
 def test_find_rediscovery_no_warning_without_heuristic():
     """find without sort|tail does not trigger the warning."""
-    recipe = _make_recipe({
-        "step_a": {
-            "tool": "run_cmd",
-            "with": {"cmd": "find /path -name '*.md' | xargs wc -l"},
-            "on_success": "END",
+    recipe = _make_recipe(
+        {
+            "step_a": {
+                "tool": "run_cmd",
+                "with": {"cmd": "find /path -name '*.md' | xargs wc -l"},
+                "on_success": "END",
+            }
         }
-    })
+    )
     findings = run_semantic_rules(recipe)
     assert all(f.rule != "run-cmd-find-rediscovery" for f in findings)


### PR DESCRIPTION
Closes #655

## Summary

Replaces the fragile `find | sort | tail -1` heuristic in `research.yaml` with deterministic `context.research_dir` tracking. Adds two new semantic rules (`run-cmd-emit-alignment`, `run-cmd-find-rediscovery`) to catch this class of bug at validation time.

## Changes

- **`research.yaml`**: `create_worktree` emits `research_dir` into context; `commit_research_artifacts` uses it directly; `create_artifact_branch` checkout scoped to specific experiment dir; post-compression guard added; `open_artifact_pr` body made dynamic
- **`src/autoskillit/recipe/rules_cmd.py`**: two new semantic rules registered in `__init__.py`
- **`tests/recipe/test_rules_cmd.py`**: 7 new tests for the semantic rules
- **`tests/recipe/test_research_artifact_archive.py`**: 7 new tests for context tracking and guard behavior