### PR TITLE
Rectify: Ghost Hook Registrations Survive Git Revert

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Install dependencies
         run: uv sync --locked --extra dev
 
-      - name: Generate hooks.json
+      - name: Generate hooks.json (if absent)
         run: |
           uv run python -c "
           from autoskillit.hooks import generate_hooks_json
@@ -92,8 +92,11 @@ jobs:
           from autoskillit.core.paths import pkg_root
           import json
           path = pkg_root() / 'hooks' / 'hooks.json'
-          atomic_write(path, json.dumps(generate_hooks_json(), indent=2) + '\n')
-          print(f'Generated: {path}')
+          if not path.exists():
+              atomic_write(path, json.dumps(generate_hooks_json(), indent=2) + '\n')
+              print(f'Generated: {path}')
+          else:
+              print(f'Skipped (already exists): {path}')
           "
 
       - name: Generate recipe diagrams

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,6 +239,7 @@ src/autoskillit/
 │   ├── skill_command_guard.py #  PreToolUse hook — blocks run_skill with non-slash skill_command
 │   ├── open_kitchen_guard.py #  PreToolUse hook — blocks open_kitchen from headless sessions
 │   ├── unsafe_install_guard.py #  PreToolUse hook — blocks run_cmd editable installs without --python .venv
+│   ├── generated_file_write_guard.py #  PreToolUse hook — denies Write/Edit targeting generated files (hooks.json, settings.json)
 │   ├── headless_orchestration_guard.py #  PreToolUse hook — blocks run_skill/run_cmd/run_python from headless sessions
 │   ├── pretty_output.py     #   PostToolUse hook — reformats MCP JSON responses as Markdown-KV
 │   ├── token_summary_appender.py #  PostToolUse hook — appends ## Token Usage Summary table to PR body after run_skill returns a GitHub PR URL

--- a/src/autoskillit/cli/__init__.py
+++ b/src/autoskillit/cli/__init__.py
@@ -10,6 +10,12 @@ import subprocess  # noqa: F401 — tests patch autoskillit.cli.subprocess.run
 from pathlib import Path  # noqa: F401 — tests patch autoskillit.cli.Path.home
 
 from autoskillit.cli._cook import cook
+from autoskillit.cli._doctor import (
+    DoctorResult,
+    HookDriftResult,
+    _check_hook_health,
+    _count_hook_registry_drift,
+)
 from autoskillit.cli._hooks import _claude_settings_path
 from autoskillit.cli._init_helpers import _prompt_recipe_choice
 from autoskillit.cli._prompts import (
@@ -48,7 +54,11 @@ __all__ = [
     "_OPEN_KITCHEN_CHOICE",
     "_build_open_kitchen_prompt",
     "_build_orchestrator_prompt",
+    "DoctorResult",
+    "HookDriftResult",
+    "_check_hook_health",
     "_claude_settings_path",
+    "_count_hook_registry_drift",
     "_generate_config_yaml",
     "_prompt_recipe_choice",
     "_prompt_test_command",

--- a/src/autoskillit/cli/__init__.py
+++ b/src/autoskillit/cli/__init__.py
@@ -12,7 +12,6 @@ from pathlib import Path  # noqa: F401 — tests patch autoskillit.cli.Path.home
 from autoskillit.cli._cook import cook
 from autoskillit.cli._doctor import (
     DoctorResult,
-    HookDriftResult,
     _check_hook_health,
     _count_hook_registry_drift,
 )
@@ -49,6 +48,7 @@ from autoskillit.cli.app import (
     workspace_clean,
     workspace_init,
 )
+from autoskillit.hook_registry import HookDriftResult
 
 __all__ = [
     "_OPEN_KITCHEN_CHOICE",

--- a/src/autoskillit/cli/_doctor.py
+++ b/src/autoskillit/cli/_doctor.py
@@ -7,31 +7,15 @@ import shutil
 import urllib.parse
 from dataclasses import dataclass
 from pathlib import Path
-from typing import NamedTuple
 
 from autoskillit.cli._hooks import _claude_settings_path, _load_settings_data
 from autoskillit.cli._init_helpers import _KNOWN_SCANNERS, _detect_secret_scanner
 from autoskillit.core import _ROOT_GITIGNORE_ENTRIES, Severity
-from autoskillit.hook_registry import HOOK_REGISTRY
-from autoskillit.hooks import generate_hooks_json
-
-
-class HookDriftResult(NamedTuple):
-    """Bidirectional hook drift counts."""
-
-    missing: int  # canonical − deployed (hooks not yet deployed)
-    orphaned: int  # deployed − canonical (ghost hooks, fatal ENOENT risk)
-
-
-def _extract_cmds(hooks_dict: dict) -> set[str]:
-    return {
-        hook.get("command", "")
-        for event_entries in hooks_dict.values()
-        if isinstance(event_entries, list)
-        for entry in event_entries
-        for hook in entry.get("hooks", [])
-        if hook.get("command", "")
-    }
+from autoskillit.hook_registry import (
+    HOOK_REGISTRY,
+    _count_hook_registry_drift,
+    find_broken_hook_scripts,
+)
 
 
 @dataclass
@@ -128,28 +112,12 @@ def _check_hook_registration(settings_path: Path) -> DoctorResult:
     )
 
 
-def _count_hook_registry_drift(settings_path: Path) -> HookDriftResult:
-    """Return bidirectional hook drift counts between canonical and deployed settings.json."""
-    canonical = generate_hooks_json()
-    deployed_data = _load_settings_data(settings_path)
-    canonical_cmds = _extract_cmds(canonical.get("hooks", {}))
-    deployed_cmds = _extract_cmds(deployed_data.get("hooks", {}))
-    return HookDriftResult(
-        missing=len(canonical_cmds - deployed_cmds),
-        orphaned=len(deployed_cmds - canonical_cmds),
-    )
-
-
 def _check_hook_registry_drift(settings_path: Path) -> DoctorResult:
     """Compare generate_hooks_json() with what is deployed in settings.json."""
     result = _count_hook_registry_drift(settings_path)
     if result.orphaned > 0:
-        canonical_cmds = _extract_cmds(generate_hooks_json().get("hooks", {}))
-        deployed_cmds = _extract_cmds(_load_settings_data(settings_path).get("hooks", {}))
         ghost_scripts = sorted(
-            Path(cmd.split()[-1]).name
-            for cmd in (deployed_cmds - canonical_cmds)
-            if len(cmd.split()) >= 2
+            Path(cmd.split()[-1]).name for cmd in result.orphaned_cmds if len(cmd.split()) >= 2
         )
         return DoctorResult(
             Severity.ERROR,
@@ -177,17 +145,7 @@ def _check_hook_registry_drift(settings_path: Path) -> DoctorResult:
 
 def _check_hook_health(settings_path: Path) -> DoctorResult:
     """Verify all deployed hook scripts exist on disk for all event types."""
-    data = _load_settings_data(settings_path)
-    broken_hooks: list[str] = []
-    for event_type in ("PreToolUse", "PostToolUse", "SessionStart"):
-        for entry in data.get("hooks", {}).get(event_type, []):
-            for hook in entry.get("hooks", []):
-                cmd = hook.get("command", "")
-                parts = cmd.split()
-                if len(parts) >= 2:
-                    script_path = Path(parts[-1])
-                    if not script_path.is_file():
-                        broken_hooks.append(cmd)
+    broken_hooks = find_broken_hook_scripts(settings_path)
     if broken_hooks:
         return DoctorResult(
             severity=Severity.ERROR,

--- a/src/autoskillit/cli/_doctor.py
+++ b/src/autoskillit/cli/_doctor.py
@@ -7,11 +7,31 @@ import shutil
 import urllib.parse
 from dataclasses import dataclass
 from pathlib import Path
+from typing import NamedTuple
 
 from autoskillit.cli._hooks import _claude_settings_path, _load_settings_data
 from autoskillit.cli._init_helpers import _KNOWN_SCANNERS, _detect_secret_scanner
 from autoskillit.core import _ROOT_GITIGNORE_ENTRIES, Severity
 from autoskillit.hook_registry import HOOK_REGISTRY
+from autoskillit.hooks import generate_hooks_json
+
+
+class HookDriftResult(NamedTuple):
+    """Bidirectional hook drift counts."""
+
+    missing: int  # canonical − deployed (hooks not yet deployed)
+    orphaned: int  # deployed − canonical (ghost hooks, fatal ENOENT risk)
+
+
+def _extract_cmds(hooks_dict: dict) -> set[str]:
+    return {
+        hook.get("command", "")
+        for event_entries in hooks_dict.values()
+        if isinstance(event_entries, list)
+        for entry in event_entries
+        for hook in entry.get("hooks", [])
+        if hook.get("command", "")
+    }
 
 
 @dataclass
@@ -108,38 +128,44 @@ def _check_hook_registration(settings_path: Path) -> DoctorResult:
     )
 
 
-def _count_hook_registry_drift(settings_path: Path) -> int:
-    """Return count of canonical hook commands not present in deployed settings.json."""
-    from autoskillit.hooks import generate_hooks_json
-
+def _count_hook_registry_drift(settings_path: Path) -> HookDriftResult:
+    """Return bidirectional hook drift counts between canonical and deployed settings.json."""
     canonical = generate_hooks_json()
     deployed_data = _load_settings_data(settings_path)
-
-    def _extract_cmds(hooks_dict: dict) -> set[str]:
-        return {
-            hook.get("command", "")
-            for event_entries in hooks_dict.values()
-            if isinstance(event_entries, list)
-            for entry in event_entries
-            for hook in entry.get("hooks", [])
-            if hook.get("command", "")
-        }
-
     canonical_cmds = _extract_cmds(canonical.get("hooks", {}))
     deployed_cmds = _extract_cmds(deployed_data.get("hooks", {}))
-    return len(canonical_cmds - deployed_cmds)
+    return HookDriftResult(
+        missing=len(canonical_cmds - deployed_cmds),
+        orphaned=len(deployed_cmds - canonical_cmds),
+    )
 
 
 def _check_hook_registry_drift(settings_path: Path) -> DoctorResult:
     """Compare generate_hooks_json() with what is deployed in settings.json."""
-    n = _count_hook_registry_drift(settings_path)
-    if n > 0:
+    result = _count_hook_registry_drift(settings_path)
+    if result.orphaned > 0:
+        canonical_cmds = _extract_cmds(generate_hooks_json().get("hooks", {}))
+        deployed_cmds = _extract_cmds(_load_settings_data(settings_path).get("hooks", {}))
+        ghost_scripts = sorted(
+            Path(cmd.split()[-1]).name
+            for cmd in (deployed_cmds - canonical_cmds)
+            if len(cmd.split()) >= 2
+        )
+        return DoctorResult(
+            Severity.ERROR,
+            "hook_registry_drift",
+            f"Orphaned hook entries detected: {', '.join(ghost_scripts)}. "
+            f"These scripts are missing from HOOK_REGISTRY but present in "
+            f"settings.json — every matching tool call will be denied with ENOENT. "
+            f"Run 'autoskillit install' to regenerate hooks.",
+        )
+    if result.missing > 0:
         return DoctorResult(
             severity=Severity.WARNING,
             check="hook_registry_drift",
             message=(
                 f"Hook registry has changed since last install. "
-                f"Run 'autoskillit install' to deploy {n} new/changed hook(s)."
+                f"Run 'autoskillit install' to deploy {result.missing} new/changed hook(s)."
             ),
         )
     return DoctorResult(

--- a/src/autoskillit/cli/_hooks.py
+++ b/src/autoskillit/cli/_hooks.py
@@ -6,18 +6,12 @@ import json
 from pathlib import Path
 
 from autoskillit.core import atomic_write, pkg_root
-from autoskillit.hook_registry import _build_hook_entry
+from autoskillit.hook_registry import (
+    _build_hook_entry,
+    _claude_settings_path,  # noqa: F401 — re-exported; cli/__init__ + _stale_check + _init_helpers import from here
+    _load_settings_data,
+)
 from autoskillit.hooks import HOOK_REGISTRY
-
-
-def _load_settings_data(settings_path: Path) -> dict:
-    """Read and parse settings.json; return empty dict on any error."""
-    if settings_path.exists():
-        try:
-            return json.loads(settings_path.read_text())
-        except (OSError, json.JSONDecodeError):
-            pass
-    return {}
 
 
 def _write_settings_data(settings_path: Path, data: dict) -> None:
@@ -75,10 +69,3 @@ def sync_hooks_to_settings(settings_path: Path) -> None:
         ]
         event_list.append(_build_hook_entry(hook_def, hooks_list))
     _write_settings_data(settings_path, data)
-
-
-def _claude_settings_path(scope: str) -> Path:
-    """Return the Claude Code settings.json path for the given scope."""
-    if scope == "user":
-        return Path.home() / ".claude" / "settings.json"
-    return Path.cwd() / ".claude" / "settings.json"

--- a/src/autoskillit/cli/_hooks.py
+++ b/src/autoskillit/cli/_hooks.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 
 from autoskillit.core import atomic_write, pkg_root
+from autoskillit.hook_registry import _build_hook_entry
 from autoskillit.hooks import HOOK_REGISTRY
 
 
@@ -72,7 +73,7 @@ def sync_hooks_to_settings(settings_path: Path) -> None:
             {"type": "command", "command": f"python3 {hooks_dir / script}"}
             for script in hook_def.scripts
         ]
-        event_list.append({"matcher": hook_def.matcher, "hooks": hooks_list})
+        event_list.append(_build_hook_entry(hook_def, hooks_list))
     _write_settings_data(settings_path, data)
 
 

--- a/src/autoskillit/cli/_stale_check.py
+++ b/src/autoskillit/cli/_stale_check.py
@@ -314,7 +314,7 @@ def run_stale_check(home: Path | None = None) -> None:
                 _write_dismiss_state(_home, state)
 
     # Hook drift check
-    from autoskillit.cli._doctor import _count_hook_registry_drift
+    from autoskillit.cli import _count_hook_registry_drift
 
     settings_path = _claude_settings_path("user")
     drift = _count_hook_registry_drift(settings_path)

--- a/src/autoskillit/cli/_stale_check.py
+++ b/src/autoskillit/cli/_stale_check.py
@@ -317,13 +317,20 @@ def run_stale_check(home: Path | None = None) -> None:
     from autoskillit.cli._doctor import _count_hook_registry_drift
 
     settings_path = _claude_settings_path("user")
-    n_drift = _count_hook_registry_drift(settings_path)
-    if n_drift > 0 and not _is_dismissed(state, "hooks", None):
-        print(
-            f"\n{n_drift} new/changed hook(s) detected since last install.",
-            flush=True,
-        )
-        answer = input("Run 'autoskillit install' to sync hooks? [Y/n] ").strip().lower()
+    drift = _count_hook_registry_drift(settings_path)
+    if (drift.missing > 0 or drift.orphaned > 0) and not _is_dismissed(state, "hooks", None):
+        if drift.orphaned > 0:
+            prompt_msg = (
+                f"\n\u26a0\ufe0f  {drift.orphaned} orphaned hook entry(ies) in settings.json "
+                f"will block tool calls with ENOENT. Run 'autoskillit install'? [Y/n] "
+            )
+        else:
+            prompt_msg = (
+                f"\n{drift.missing} new/changed hook(s) detected since last install.\n"
+                f"Run 'autoskillit install' to sync hooks? [Y/n] "
+            )
+        print(prompt_msg, end="", flush=True)
+        answer = input("").strip().lower()
         if answer in ("", "y", "yes"):
             with terminal_guard():
                 subprocess.run(["autoskillit", "install"], check=False, env=_skip_env)

--- a/src/autoskillit/hook_registry.py
+++ b/src/autoskillit/hook_registry.py
@@ -53,6 +53,10 @@ HOOK_REGISTRY: list[HookDef] = [
         scripts=["unsafe_install_guard.py"],
     ),
     HookDef(
+        matcher=r"Write|Edit",
+        scripts=["generated_file_write_guard.py"],
+    ),
+    HookDef(
         matcher=r"mcp__.*autoskillit.*__(run_skill|run_cmd|run_python).*",
         scripts=["headless_orchestration_guard.py"],
     ),

--- a/src/autoskillit/hook_registry.py
+++ b/src/autoskillit/hook_registry.py
@@ -6,8 +6,10 @@ derive from this registry.
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
-from typing import Literal
+from pathlib import Path
+from typing import Literal, NamedTuple
 
 from autoskillit.core import pkg_root
 
@@ -102,3 +104,75 @@ def generate_hooks_json() -> dict:
             _build_hook_entry(hook_def, hook_commands)
         )
     return {"hooks": by_event}
+
+
+# ---------------------------------------------------------------------------
+# Hook diagnostic utilities — shared between cli/ and server/ (both L3).
+# Placed here (package root, L0-accessible) to avoid L3-to-L3 peer imports.
+# ---------------------------------------------------------------------------
+
+
+def _claude_settings_path(scope: str) -> Path:
+    """Return the Claude Code settings.json path for the given scope."""
+    if scope == "user":
+        return Path.home() / ".claude" / "settings.json"
+    return Path.cwd() / ".claude" / "settings.json"
+
+
+def _load_settings_data(settings_path: Path) -> dict:
+    """Read and parse settings.json; return empty dict on any error."""
+    if settings_path.exists():
+        try:
+            return json.loads(settings_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            pass
+    return {}
+
+
+def _extract_cmds(hooks_dict: dict) -> set[str]:
+    """Extract the set of hook command strings from a hooks dict."""
+    return {
+        hook.get("command", "")
+        for event_entries in hooks_dict.values()
+        if isinstance(event_entries, list)
+        for entry in event_entries
+        for hook in entry.get("hooks", [])
+        if hook.get("command", "")
+    }
+
+
+class HookDriftResult(NamedTuple):
+    """Bidirectional hook drift counts."""
+
+    missing: int  # canonical − deployed (hooks not yet deployed)
+    orphaned: int  # deployed − canonical (ghost hooks, fatal ENOENT risk)
+    orphaned_cmds: frozenset[str] = frozenset()
+
+
+def _count_hook_registry_drift(settings_path: Path) -> HookDriftResult:
+    """Return bidirectional hook drift counts between canonical and deployed settings.json."""
+    canonical = generate_hooks_json()
+    deployed_data = _load_settings_data(settings_path)
+    canonical_cmds = _extract_cmds(canonical.get("hooks", {}))
+    deployed_cmds = _extract_cmds(deployed_data.get("hooks", {}))
+    orphaned = deployed_cmds - canonical_cmds
+    return HookDriftResult(
+        missing=len(canonical_cmds - deployed_cmds),
+        orphaned=len(orphaned),
+        orphaned_cmds=frozenset(orphaned),
+    )
+
+
+def find_broken_hook_scripts(settings_path: Path) -> list[str]:
+    """Return list of hook commands whose script files do not exist on disk."""
+    data = _load_settings_data(settings_path)
+    broken: list[str] = []
+    for event_type in ("PreToolUse", "PostToolUse", "SessionStart"):
+        for entry in data.get("hooks", {}).get(event_type, []):
+            for hook in entry.get("hooks", []):
+                cmd = hook.get("command", "")
+                parts = cmd.split()
+                if len(parts) >= 2:
+                    if not Path(parts[-1]).is_file():
+                        broken.append(cmd)
+    return broken

--- a/src/autoskillit/hook_registry.py
+++ b/src/autoskillit/hook_registry.py
@@ -73,6 +73,18 @@ HOOK_REGISTRY: list[HookDef] = [
 ]
 
 
+def _build_hook_entry(hook_def: HookDef, hook_commands: list[dict]) -> dict:
+    """Build the per-entry dict for a hook definition.
+
+    SessionStart entries omit the 'matcher' key; all others include it.
+    This is the single authoritative formatter for both hooks.json and
+    settings.json generation.
+    """
+    if hook_def.event_type == "SessionStart":
+        return {"hooks": hook_commands}
+    return {"matcher": hook_def.matcher, "hooks": hook_commands}
+
+
 def generate_hooks_json() -> dict:
     """Generate the hooks.json structure from HOOK_REGISTRY using absolute paths."""
     hooks_dir = pkg_root() / "hooks"
@@ -82,10 +94,7 @@ def generate_hooks_json() -> dict:
             {"type": "command", "command": f"python3 {hooks_dir / script}"}
             for script in hook_def.scripts
         ]
-        entry: dict[str, object]
-        if hook_def.event_type == "SessionStart":
-            entry = {"hooks": hook_commands}
-        else:
-            entry = {"matcher": hook_def.matcher, "hooks": hook_commands}
-        by_event.setdefault(hook_def.event_type, []).append(entry)
+        by_event.setdefault(hook_def.event_type, []).append(
+            _build_hook_entry(hook_def, hook_commands)
+        )
     return {"hooks": by_event}

--- a/src/autoskillit/hooks/__init__.py
+++ b/src/autoskillit/hooks/__init__.py
@@ -1,5 +1,10 @@
 """Hook scripts (PreToolUse and PostToolUse) for AutoSkillit."""
 
-from autoskillit.hook_registry import HOOK_REGISTRY, HookDef, generate_hooks_json
+from autoskillit.hook_registry import (
+    HOOK_REGISTRY,
+    HookDef,
+    _build_hook_entry,
+    generate_hooks_json,
+)
 
-__all__ = ["HOOK_REGISTRY", "HookDef", "generate_hooks_json"]
+__all__ = ["HOOK_REGISTRY", "HookDef", "_build_hook_entry", "generate_hooks_json"]

--- a/src/autoskillit/hooks/__init__.py
+++ b/src/autoskillit/hooks/__init__.py
@@ -3,8 +3,7 @@
 from autoskillit.hook_registry import (
     HOOK_REGISTRY,
     HookDef,
-    _build_hook_entry,
     generate_hooks_json,
 )
 
-__all__ = ["HOOK_REGISTRY", "HookDef", "_build_hook_entry", "generate_hooks_json"]
+__all__ = ["HOOK_REGISTRY", "HookDef", "generate_hooks_json"]

--- a/src/autoskillit/hooks/generated_file_write_guard.py
+++ b/src/autoskillit/hooks/generated_file_write_guard.py
@@ -10,7 +10,7 @@ import json
 import os
 import sys
 
-_GENERATED_FILE_SUFFIXES = ("hooks.json", ".claude/settings.json")
+_GENERATED_FILE_SUFFIXES = ("/hooks/hooks.json", ".claude/settings.json")
 
 
 def main() -> None:

--- a/src/autoskillit/hooks/generated_file_write_guard.py
+++ b/src/autoskillit/hooks/generated_file_write_guard.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""
+PreToolUse hook — denies Write and Edit calls targeting generated files
+(hooks.json and .claude/settings.json). These files are machine-local
+generated artifacts managed by 'autoskillit install'. Direct edits bypass
+hook_registry.py and create ghost entries that cause ENOENT fatal denials.
+"""
+
+import json
+import os
+import sys
+
+_GENERATED_FILE_SUFFIXES = ("hooks.json", ".claude/settings.json")
+
+
+def main() -> None:
+    try:
+        data = json.loads(sys.stdin.read())
+    except (json.JSONDecodeError, ValueError, OSError):
+        sys.exit(0)
+
+    tool_name = data.get("tool_name", "")
+    if tool_name not in ("Write", "Edit"):
+        sys.exit(0)
+
+    file_path = data.get("tool_input", {}).get("file_path", "")
+    if not isinstance(file_path, str) or not file_path:
+        sys.exit(0)
+
+    # Normalize to forward slashes for cross-platform suffix matching
+    normalized = file_path.replace(os.sep, "/")
+    if not any(normalized.endswith(suffix) for suffix in _GENERATED_FILE_SUFFIXES):
+        sys.exit(0)
+
+    payload = json.dumps(
+        {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": (
+                    f"'{file_path}' is a generated file with machine-local absolute paths. "
+                    f"Direct edits bypass hook_registry.py and create ghost hook entries "
+                    f"that block all tool calls with ENOENT. "
+                    f"Use 'autoskillit install' to regenerate, or "
+                    f"'autoskillit init' to sync settings.json."
+                ),
+            }
+        }
+    )
+    sys.stdout.write(payload + "\n")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/autoskillit/server/helpers.py
+++ b/src/autoskillit/server/helpers.py
@@ -518,23 +518,22 @@ def _build_hook_diagnostic_warning() -> str | None:
     Only reads; never writes or modifies state. Returns None when all hooks are healthy
     or when settings.json does not yet exist (nothing to validate).
     """
-    from autoskillit.cli import (
-        _check_hook_health,
+    from autoskillit.hook_registry import (
         _claude_settings_path,
         _count_hook_registry_drift,
+        find_broken_hook_scripts,
     )
-    from autoskillit.core import Severity
 
-    settings_path = _claude_settings_path("project")
+    settings_path = _claude_settings_path("user")
     if not settings_path.exists():
         return None
 
-    health = _check_hook_health(settings_path)
+    broken = find_broken_hook_scripts(settings_path)
     drift = _count_hook_registry_drift(settings_path)
 
-    issues = []
-    if health.severity == Severity.ERROR:
-        issues.append(f"Hook scripts not found: {health.message}")
+    issues: list[str] = []
+    if broken:
+        issues.append(f"Hook scripts not found: {', '.join(broken)}")
     if drift.orphaned > 0:
         issues.append(
             f"{drift.orphaned} orphaned hook entry(ies) in settings.json are not in "

--- a/src/autoskillit/server/helpers.py
+++ b/src/autoskillit/server/helpers.py
@@ -518,12 +518,12 @@ def _build_hook_diagnostic_warning() -> str | None:
     Only reads; never writes or modifies state. Returns None when all hooks are healthy
     or when settings.json does not yet exist (nothing to validate).
     """
-    from autoskillit.cli._doctor import (
+    from autoskillit.cli import (
         _check_hook_health,
+        _claude_settings_path,
         _count_hook_registry_drift,
     )
-    from autoskillit.cli._hooks import _claude_settings_path
-    from autoskillit.core.types import Severity
+    from autoskillit.core import Severity
 
     settings_path = _claude_settings_path("project")
     if not settings_path.exists():

--- a/src/autoskillit/server/helpers.py
+++ b/src/autoskillit/server/helpers.py
@@ -510,3 +510,45 @@ async def _quota_refresh_loop(config: QuotaGuardConfig) -> None:
             await _refresh_quota_cache(config)
         except Exception as exc:
             logger.warning("quota_refresh_loop_error", exc_info=True, error=str(exc))
+
+
+def _build_hook_diagnostic_warning() -> str | None:
+    """Run hook health and drift checks. Return a warning string if issues are found.
+
+    Only reads; never writes or modifies state. Returns None when all hooks are healthy
+    or when settings.json does not yet exist (nothing to validate).
+    """
+    from autoskillit.cli._doctor import (
+        _check_hook_health,
+        _count_hook_registry_drift,
+    )
+    from autoskillit.cli._hooks import _claude_settings_path
+    from autoskillit.core.types import Severity
+
+    settings_path = _claude_settings_path("project")
+    if not settings_path.exists():
+        return None
+
+    health = _check_hook_health(settings_path)
+    drift = _count_hook_registry_drift(settings_path)
+
+    issues = []
+    if health.severity == Severity.ERROR:
+        issues.append(f"Hook scripts not found: {health.message}")
+    if drift.orphaned > 0:
+        issues.append(
+            f"{drift.orphaned} orphaned hook entry(ies) in settings.json are not in "
+            f"HOOK_REGISTRY — every matching tool call will be denied with ENOENT."
+        )
+    if drift.missing > 0:
+        issues.append(
+            f"{drift.missing} hook(s) from HOOK_REGISTRY are not deployed in settings.json."
+        )
+    if not issues:
+        return None
+
+    lines = ["\n⚠️  Hook configuration issues detected:"]
+    for issue in issues:
+        lines.append(f"   • {issue}")
+    lines.append("   → Run 'autoskillit install' to regenerate hook configuration.\n")
+    return "\n".join(lines)

--- a/src/autoskillit/server/tools_kitchen.py
+++ b/src/autoskillit/server/tools_kitchen.py
@@ -22,6 +22,7 @@ from autoskillit.pipeline import create_background_task
 from autoskillit.server import mcp
 from autoskillit.server.helpers import (
     _apply_triage_gate,
+    _build_hook_diagnostic_warning,
     _find_recipe,
     _hook_config_path,
     _prime_quota_cache,
@@ -176,6 +177,9 @@ async def open_kitchen(
         result = await _apply_triage_gate(result, name, recipe_info=recipe_info)
         result["kitchen"] = "open"
         result["version"] = __version__
+        warning = _build_hook_diagnostic_warning()
+        if warning:
+            result["hook_warning"] = warning.strip()
         return json.dumps(result)
 
     text = (
@@ -203,6 +207,10 @@ async def open_kitchen(
             "`.autoskillit/scripts/` still exists. Run `autoskillit upgrade` in this directory\n"
             "to migrate automatically, or ask me to do it for you."
         )
+
+    warning = _build_hook_diagnostic_warning()
+    if warning:
+        text += warning
 
     return text
 

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -671,7 +671,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "execution": 24,
         "core": 15,
         "cli": 15,
-        "hooks": 13,
+        "hooks": 14,
     }
     violations: list[str] = []
     for sub_dir in sorted(SRC_ROOT.iterdir()):

--- a/tests/cli/test_cli_hooks.py
+++ b/tests/cli/test_cli_hooks.py
@@ -207,7 +207,10 @@ def test_settings_json_matches_hook_registry_after_install(tmp_path, monkeypatch
     data = json.loads(settings_path.read_text())
     for hook_def in HOOK_REGISTRY:
         event_entries = data.get("hooks", {}).get(hook_def.event_type, [])
-        matching = [e for e in event_entries if e.get("matcher") == hook_def.matcher]
+        if hook_def.event_type == "SessionStart":
+            matching = [e for e in event_entries if "matcher" not in e]
+        else:
+            matching = [e for e in event_entries if e.get("matcher") == hook_def.matcher]
         assert len(matching) == 1, (
             f"Expected exactly 1 {hook_def.event_type} entry for matcher "
             f"{hook_def.matcher!r}, got {len(matching)}"

--- a/tests/cli/test_cli_hooks.py
+++ b/tests/cli/test_cli_hooks.py
@@ -285,3 +285,22 @@ def test_sync_hooks_to_settings_is_idempotent(tmp_path):
     assert len(posttooluse) == posttooluse_count, (
         f"Duplicate entries after evict+sync twice: {len(posttooluse)} PostToolUse entries"
     )
+
+
+# T-CROSS-1
+def test_sync_hooks_to_settings_session_start_no_matcher(tmp_path):
+    """sync_hooks_to_settings() must not emit 'matcher' key for SessionStart entries."""
+    from autoskillit.cli._hooks import _evict_stale_autoskillit_hooks, sync_hooks_to_settings
+
+    settings = tmp_path / ".claude" / "settings.json"
+    settings.parent.mkdir()
+    settings.write_text('{"hooks": {}}')
+    _evict_stale_autoskillit_hooks(settings)
+    sync_hooks_to_settings(settings)
+    data = json.loads(settings.read_text())
+    session_start_entries = data.get("hooks", {}).get("SessionStart", [])
+    assert session_start_entries, "Expected at least one SessionStart entry"
+    for entry in session_start_entries:
+        assert "matcher" not in entry, (
+            f"SessionStart entry must not have 'matcher' key, got: {entry}"
+        )

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -1112,7 +1112,6 @@ def test_count_hook_registry_drift_detects_orphaned_hooks(tmp_path: Path) -> Non
     Orphaned hooks are the fatal failure mode (ENOENT on every tool call).
     """
     from autoskillit.cli._doctor import _count_hook_registry_drift
-    from autoskillit.core import Severity
 
     settings = tmp_path / ".claude" / "settings.json"
     settings.parent.mkdir()
@@ -1132,9 +1131,7 @@ def test_count_hook_registry_drift_detects_orphaned_hooks(tmp_path: Path) -> Non
     assert hasattr(result, "orphaned"), (
         "_count_hook_registry_drift must return a result with 'orphaned' field"
     )
-    assert result.orphaned >= 1, (
-        f"Expected orphaned >= 1 for ghost entry, got {result.orphaned}"
-    )
+    assert result.orphaned >= 1, f"Expected orphaned >= 1 for ghost entry, got {result.orphaned}"
 
 
 # T-DRIFT-2: _check_hook_registry_drift() returns ERROR for orphaned hooks

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -1104,3 +1104,62 @@ def test_doctor_hook_health_checks_all_event_types(tmp_path: Path) -> None:
         "hook_health must report non-OK when a PostToolUse hook script is missing"
     )
     assert "token_summary_appender" in result.message or "PostToolUse" in result.message
+
+
+# T-DRIFT-1: _count_hook_registry_drift() detects orphaned hooks
+def test_count_hook_registry_drift_detects_orphaned_hooks(tmp_path: Path) -> None:
+    """deployed − canonical must be counted and returned.
+    Orphaned hooks are the fatal failure mode (ENOENT on every tool call).
+    """
+    from autoskillit.cli._doctor import _count_hook_registry_drift
+    from autoskillit.core import Severity
+
+    settings = tmp_path / ".claude" / "settings.json"
+    settings.parent.mkdir()
+    ghost_cmd = "python3 /path/to/status_health_guard.py"
+    data = {
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "mcp__.*autoskillit.*__run_skill.*",
+                    "hooks": [{"type": "command", "command": ghost_cmd}],
+                }
+            ]
+        }
+    }
+    settings.write_text(json.dumps(data))
+    result = _count_hook_registry_drift(settings)
+    assert hasattr(result, "orphaned"), (
+        "_count_hook_registry_drift must return a result with 'orphaned' field"
+    )
+    assert result.orphaned >= 1, (
+        f"Expected orphaned >= 1 for ghost entry, got {result.orphaned}"
+    )
+
+
+# T-DRIFT-2: _check_hook_registry_drift() returns ERROR for orphaned hooks
+def test_check_hook_registry_drift_error_on_orphaned_hooks(tmp_path: Path) -> None:
+    from autoskillit.cli._doctor import _check_hook_registry_drift
+    from autoskillit.core import Severity
+
+    settings = tmp_path / ".claude" / "settings.json"
+    settings.parent.mkdir()
+    ghost_cmd = "python3 /path/to/status_health_guard.py"
+    data = {
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "mcp__.*autoskillit.*__run_skill.*",
+                    "hooks": [{"type": "command", "command": ghost_cmd}],
+                }
+            ]
+        }
+    }
+    settings.write_text(json.dumps(data))
+    result = _check_hook_registry_drift(settings)
+    assert result.severity == Severity.ERROR, (
+        f"Orphaned hooks must produce ERROR severity, got {result.severity}"
+    )
+    assert "status_health_guard.py" in result.message, (
+        "Error message must name the orphaned script(s)"
+    )

--- a/tests/cli/test_stale_check.py
+++ b/tests/cli/test_stale_check.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from autoskillit.cli._doctor import HookDriftResult
+from autoskillit.hook_registry import HookDriftResult
 
 
 # SC-1: dev mode via ~/.autoskillit/dev marker

--- a/tests/cli/test_stale_check.py
+++ b/tests/cli/test_stale_check.py
@@ -334,7 +334,7 @@ def test_run_stale_check_hooks_n_path_writes_dismiss(
     written: dict[str, object] = {}
     monkeypatch.setattr(_sc, "_write_dismiss_state", lambda home, state: written.update(state))
     monkeypatch.setattr(
-        "autoskillit.cli._doctor._count_hook_registry_drift",
+        "autoskillit.cli._count_hook_registry_drift",
         lambda settings_path: HookDriftResult(missing=2, orphaned=0),
     )
     monkeypatch.setattr("builtins.input", lambda _: "n")

--- a/tests/cli/test_stale_check.py
+++ b/tests/cli/test_stale_check.py
@@ -11,6 +11,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from autoskillit.cli._doctor import HookDriftResult
+
 
 # SC-1: dev mode via ~/.autoskillit/dev marker
 def test_is_dev_mode_home_marker(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -159,7 +161,9 @@ def test_run_stale_check_writes_dismiss_on_no(
     monkeypatch.setattr(_sc, "is_dev_mode", lambda home=None: False)
     import autoskillit.cli._doctor as _doctor
 
-    monkeypatch.setattr(_doctor, "_count_hook_registry_drift", lambda p: 0)
+    monkeypatch.setattr(
+        _doctor, "_count_hook_registry_drift", lambda p: HookDriftResult(missing=0, orphaned=0)
+    )
     from autoskillit.cli._stale_check import _read_dismiss_state
 
     _sc.run_stale_check(home=tmp_path)
@@ -190,7 +194,9 @@ def test_run_stale_check_binary_update_y_path_injects_guard_env(
     monkeypatch.setattr(_sc, "is_dev_mode", lambda home=None: False)
     import autoskillit.cli._doctor as _doctor
 
-    monkeypatch.setattr(_doctor, "_count_hook_registry_drift", lambda p: 0)
+    monkeypatch.setattr(
+        _doctor, "_count_hook_registry_drift", lambda p: HookDriftResult(missing=0, orphaned=0)
+    )
 
     mock_run = MagicMock(return_value=subprocess.CompletedProcess([], 0))
     monkeypatch.setattr(_sc.subprocess, "run", mock_run)
@@ -225,7 +231,9 @@ def test_run_stale_check_hook_drift_y_path_injects_guard_env(
     monkeypatch.setattr(_sc, "_fetch_latest_version", lambda dev_mode: None)
     import autoskillit.cli._doctor as _doctor
 
-    monkeypatch.setattr(_doctor, "_count_hook_registry_drift", lambda p: 3)
+    monkeypatch.setattr(
+        _doctor, "_count_hook_registry_drift", lambda p: HookDriftResult(missing=3, orphaned=0)
+    )
     monkeypatch.setattr(_sc, "_is_dismissed", lambda *a, **kw: False)
 
     mock_run = MagicMock(return_value=subprocess.CompletedProcess([], 0))
@@ -327,7 +335,7 @@ def test_run_stale_check_hooks_n_path_writes_dismiss(
     monkeypatch.setattr(_sc, "_write_dismiss_state", lambda home, state: written.update(state))
     monkeypatch.setattr(
         "autoskillit.cli._doctor._count_hook_registry_drift",
-        lambda settings_path: 2,
+        lambda settings_path: HookDriftResult(missing=2, orphaned=0),
     )
     monkeypatch.setattr("builtins.input", lambda _: "n")
 

--- a/tests/cli/test_stale_check.py
+++ b/tests/cli/test_stale_check.py
@@ -159,10 +159,10 @@ def test_run_stale_check_writes_dismiss_on_no(
     monkeypatch.setattr(autoskillit, "__version__", "0.5.0")
     monkeypatch.setattr(_sc, "_fetch_latest_version", lambda dev_mode: "0.9.0")
     monkeypatch.setattr(_sc, "is_dev_mode", lambda home=None: False)
-    import autoskillit.cli._doctor as _doctor
+    import autoskillit.cli as _cli
 
     monkeypatch.setattr(
-        _doctor, "_count_hook_registry_drift", lambda p: HookDriftResult(missing=0, orphaned=0)
+        _cli, "_count_hook_registry_drift", lambda p: HookDriftResult(missing=0, orphaned=0)
     )
     from autoskillit.cli._stale_check import _read_dismiss_state
 
@@ -192,10 +192,10 @@ def test_run_stale_check_binary_update_y_path_injects_guard_env(
     monkeypatch.setattr(autoskillit, "__version__", "0.1.0")
     monkeypatch.setattr(_sc, "_fetch_latest_version", lambda dev_mode: "9.9.9")
     monkeypatch.setattr(_sc, "is_dev_mode", lambda home=None: False)
-    import autoskillit.cli._doctor as _doctor
+    import autoskillit.cli as _cli
 
     monkeypatch.setattr(
-        _doctor, "_count_hook_registry_drift", lambda p: HookDriftResult(missing=0, orphaned=0)
+        _cli, "_count_hook_registry_drift", lambda p: HookDriftResult(missing=0, orphaned=0)
     )
 
     mock_run = MagicMock(return_value=subprocess.CompletedProcess([], 0))
@@ -229,10 +229,10 @@ def test_run_stale_check_hook_drift_y_path_injects_guard_env(
     monkeypatch.setattr(fake_stdout, "isatty", lambda: True)
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     monkeypatch.setattr(_sc, "_fetch_latest_version", lambda dev_mode: None)
-    import autoskillit.cli._doctor as _doctor
+    import autoskillit.cli as _cli
 
     monkeypatch.setattr(
-        _doctor, "_count_hook_registry_drift", lambda p: HookDriftResult(missing=3, orphaned=0)
+        _cli, "_count_hook_registry_drift", lambda p: HookDriftResult(missing=3, orphaned=0)
     )
     monkeypatch.setattr(_sc, "_is_dismissed", lambda *a, **kw: False)
 

--- a/tests/infra/test_generated_file_write_guard.py
+++ b/tests/infra/test_generated_file_write_guard.py
@@ -1,0 +1,62 @@
+"""Tests for generated_file_write_guard.py PreToolUse hook."""
+
+import json
+import subprocess
+import sys
+
+from autoskillit.core.paths import pkg_root
+
+
+def _run_guard(event: dict) -> dict | None:
+    script = pkg_root() / "hooks" / "generated_file_write_guard.py"
+    result = subprocess.run(
+        [sys.executable, str(script)],
+        input=json.dumps(event),
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert result.returncode == 0
+    if result.stdout.strip():
+        return json.loads(result.stdout.strip())
+    return None
+
+
+def test_write_guard_denies_hooks_json_write():
+    event = {"tool_name": "Write", "tool_input": {"file_path": "/any/path/hooks.json"}}
+    output = _run_guard(event)
+    assert output is not None
+    assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_write_guard_denies_settings_json_write():
+    event = {"tool_name": "Write", "tool_input": {"file_path": "/repo/.claude/settings.json"}}
+    output = _run_guard(event)
+    assert output is not None
+    assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_write_guard_denies_edit_targeting_hooks_json():
+    event = {"tool_name": "Edit", "tool_input": {"file_path": "/any/path/hooks.json"}}
+    output = _run_guard(event)
+    assert output is not None
+    assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_write_guard_allows_other_files():
+    event = {"tool_name": "Write", "tool_input": {"file_path": "/repo/src/foo.py"}}
+    output = _run_guard(event)
+    assert output is None, "Non-generated-file Write must pass through (no stdout)"
+
+
+def test_write_guard_fail_open_on_invalid_json():
+    script = pkg_root() / "hooks" / "generated_file_write_guard.py"
+    result = subprocess.run(
+        [sys.executable, str(script)],
+        input="not json",
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == "", "Fail-open: invalid stdin must produce no output"

--- a/tests/infra/test_generated_file_write_guard.py
+++ b/tests/infra/test_generated_file_write_guard.py
@@ -23,7 +23,7 @@ def _run_guard(event: dict) -> dict | None:
 
 
 def test_write_guard_denies_hooks_json_write():
-    event = {"tool_name": "Write", "tool_input": {"file_path": "/any/path/hooks.json"}}
+    event = {"tool_name": "Write", "tool_input": {"file_path": "/any/path/hooks/hooks.json"}}
     output = _run_guard(event)
     assert output is not None
     assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
@@ -37,10 +37,17 @@ def test_write_guard_denies_settings_json_write():
 
 
 def test_write_guard_denies_edit_targeting_hooks_json():
-    event = {"tool_name": "Edit", "tool_input": {"file_path": "/any/path/hooks.json"}}
+    event = {"tool_name": "Edit", "tool_input": {"file_path": "/any/path/hooks/hooks.json"}}
     output = _run_guard(event)
     assert output is not None
     assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_write_guard_allows_unrelated_hooks_json():
+    """Ensure files like 'my-hooks.json' are not false-positive denied."""
+    event = {"tool_name": "Write", "tool_input": {"file_path": "/repo/my-hooks.json"}}
+    output = _run_guard(event)
+    assert output is None, "Unrelated *hooks.json file must not be denied"
 
 
 def test_write_guard_allows_other_files():

--- a/tests/infra/test_hook_executability.py
+++ b/tests/infra/test_hook_executability.py
@@ -117,3 +117,39 @@ def test_generate_hooks_json_session_start_no_matcher() -> None:
     assert session_start_entries, "hooks.json must include SessionStart"
     for entry in session_start_entries:
         assert "matcher" not in entry, "SessionStart entries must not have a matcher key"
+
+
+# T-CROSS-2
+def test_generate_hooks_json_and_sync_produce_equivalent_entries(tmp_path) -> None:
+    """Both generation paths must produce structurally identical hook entries
+    for every event type. Verifies that _build_hook_entry() is shared,
+    preventing path A/B divergence.
+    """
+    from autoskillit.cli._hooks import _evict_stale_autoskillit_hooks, sync_hooks_to_settings
+
+    settings = tmp_path / ".claude" / "settings.json"
+    settings.parent.mkdir()
+    settings.write_text('{"hooks": {}}')
+    _evict_stale_autoskillit_hooks(settings)
+    sync_hooks_to_settings(settings)
+    deployed = json.loads(settings.read_text())
+
+    canonical = generate_hooks_json()
+
+    for event_type in ("PreToolUse", "PostToolUse", "SessionStart"):
+        canonical_entries = canonical.get("hooks", {}).get(event_type, [])
+        deployed_entries = deployed.get("hooks", {}).get(event_type, [])
+        assert len(canonical_entries) == len(deployed_entries), (
+            f"{event_type}: canonical has {len(canonical_entries)} entries, "
+            f"deployed has {len(deployed_entries)}"
+        )
+        for i, (c_entry, d_entry) in enumerate(zip(canonical_entries, deployed_entries)):
+            assert set(c_entry.keys()) == set(d_entry.keys()), (
+                f"{event_type}[{i}]: key mismatch. "
+                f"canonical keys={set(c_entry.keys())}, "
+                f"deployed keys={set(d_entry.keys())}"
+            )
+            if "matcher" in c_entry:
+                assert c_entry["matcher"] == d_entry["matcher"], (
+                    f"{event_type}[{i}]: matcher mismatch"
+                )

--- a/tests/infra/test_hook_registration_coverage.py
+++ b/tests/infra/test_hook_registration_coverage.py
@@ -55,3 +55,12 @@ def test_all_session_start_hook_scripts_are_registered() -> None:
     }
     for script in session_scripts:
         assert (HOOKS_DIR / script).exists(), f"SessionStart script not found: {script}"
+
+
+# T-GUARD-2
+def test_generated_file_write_guard_registered() -> None:
+    """generated_file_write_guard.py must be registered in HOOK_REGISTRY."""
+    all_scripts = {s for h in HOOK_REGISTRY for s in h.scripts}
+    assert "generated_file_write_guard.py" in all_scripts, (
+        "generated_file_write_guard.py must be registered in HOOK_REGISTRY"
+    )

--- a/tests/server/test_tools_kitchen.py
+++ b/tests/server/test_tools_kitchen.py
@@ -627,6 +627,6 @@ async def test_open_kitchen_warns_on_missing_hook_scripts(tmp_path, monkeypatch)
 
                     result = await open_kitchen(ctx=mock_ctx)
 
-    assert "hook" in result.lower() and (
-        "missing" in result.lower() or "not found" in result.lower() or "install" in result.lower()
-    ), "open_kitchen() must warn when hook scripts are absent from disk"
+    assert "Hook scripts not found" in result, (
+        "open_kitchen() must include the exact _build_hook_diagnostic_warning phrase"
+    )

--- a/tests/server/test_tools_kitchen.py
+++ b/tests/server/test_tools_kitchen.py
@@ -560,21 +560,23 @@ def test_tool_context_has_quota_refresh_task_field():
 async def test_open_kitchen_warns_on_orphaned_hooks(tmp_path, monkeypatch):
     """When settings.json contains a hook not in HOOK_REGISTRY, open_kitchen()
     must include a drift warning in its response."""
-    from autoskillit.cli._doctor import DoctorResult, HookDriftResult
-    from autoskillit.core.types import Severity
+    from autoskillit.hook_registry import HookDriftResult
 
     settings_dir = tmp_path / ".claude"
     settings_dir.mkdir()
     (settings_dir / "settings.json").write_text("{}")
-    monkeypatch.chdir(tmp_path)
 
     monkeypatch.setattr(
-        "autoskillit.cli._count_hook_registry_drift",
+        "autoskillit.hook_registry._claude_settings_path",
+        lambda scope: settings_dir / "settings.json",
+    )
+    monkeypatch.setattr(
+        "autoskillit.hook_registry._count_hook_registry_drift",
         lambda _: HookDriftResult(missing=0, orphaned=1),
     )
     monkeypatch.setattr(
-        "autoskillit.cli._check_hook_health",
-        lambda _: DoctorResult(Severity.OK, "hook_health", "ok"),
+        "autoskillit.hook_registry.find_broken_hook_scripts",
+        lambda _: [],
     )
 
     mock_ctx = _make_mock_ctx()
@@ -597,22 +599,22 @@ async def test_open_kitchen_warns_on_orphaned_hooks(tmp_path, monkeypatch):
 @pytest.mark.anyio
 async def test_open_kitchen_warns_on_missing_hook_scripts(tmp_path, monkeypatch):
     """When hook scripts are absent from disk, open_kitchen() must warn."""
-    from autoskillit.cli._doctor import DoctorResult, HookDriftResult
-    from autoskillit.core.types import Severity
+    from autoskillit.hook_registry import HookDriftResult
 
     settings_dir = tmp_path / ".claude"
     settings_dir.mkdir()
     (settings_dir / "settings.json").write_text("{}")
-    monkeypatch.chdir(tmp_path)
 
     monkeypatch.setattr(
-        "autoskillit.cli._check_hook_health",
-        lambda _: DoctorResult(
-            Severity.ERROR, "hook_health", "Hook scripts not found: status_health_guard.py"
-        ),
+        "autoskillit.hook_registry._claude_settings_path",
+        lambda scope: settings_dir / "settings.json",
     )
     monkeypatch.setattr(
-        "autoskillit.cli._count_hook_registry_drift",
+        "autoskillit.hook_registry.find_broken_hook_scripts",
+        lambda _: ["python3 /missing/status_health_guard.py"],
+    )
+    monkeypatch.setattr(
+        "autoskillit.hook_registry._count_hook_registry_drift",
         lambda _: HookDriftResult(missing=0, orphaned=0),
     )
 

--- a/tests/server/test_tools_kitchen.py
+++ b/tests/server/test_tools_kitchen.py
@@ -569,11 +569,11 @@ async def test_open_kitchen_warns_on_orphaned_hooks(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
     monkeypatch.setattr(
-        "autoskillit.cli._doctor._count_hook_registry_drift",
+        "autoskillit.cli._count_hook_registry_drift",
         lambda _: HookDriftResult(missing=0, orphaned=1),
     )
     monkeypatch.setattr(
-        "autoskillit.cli._doctor._check_hook_health",
+        "autoskillit.cli._check_hook_health",
         lambda _: DoctorResult(Severity.OK, "hook_health", "ok"),
     )
 
@@ -606,13 +606,13 @@ async def test_open_kitchen_warns_on_missing_hook_scripts(tmp_path, monkeypatch)
     monkeypatch.chdir(tmp_path)
 
     monkeypatch.setattr(
-        "autoskillit.cli._doctor._check_hook_health",
+        "autoskillit.cli._check_hook_health",
         lambda _: DoctorResult(
             Severity.ERROR, "hook_health", "Hook scripts not found: status_health_guard.py"
         ),
     )
     monkeypatch.setattr(
-        "autoskillit.cli._doctor._count_hook_registry_drift",
+        "autoskillit.cli._count_hook_registry_drift",
         lambda _: HookDriftResult(missing=0, orphaned=0),
     )
 

--- a/tests/server/test_tools_kitchen.py
+++ b/tests/server/test_tools_kitchen.py
@@ -553,3 +553,80 @@ def test_tool_context_has_quota_refresh_task_field():
     fields = {f.name: f for f in dataclasses.fields(ToolContext)}
     assert "quota_refresh_task" in fields
     assert fields["quota_refresh_task"].default is None
+
+
+# T-KITCHEN-1
+@pytest.mark.anyio
+async def test_open_kitchen_warns_on_orphaned_hooks(tmp_path, monkeypatch):
+    """When settings.json contains a hook not in HOOK_REGISTRY, open_kitchen()
+    must include a drift warning in its response."""
+    from autoskillit.cli._doctor import DoctorResult, HookDriftResult
+    from autoskillit.core.types import Severity
+
+    settings_dir = tmp_path / ".claude"
+    settings_dir.mkdir()
+    (settings_dir / "settings.json").write_text("{}")
+    monkeypatch.chdir(tmp_path)
+
+    monkeypatch.setattr(
+        "autoskillit.cli._doctor._count_hook_registry_drift",
+        lambda _: HookDriftResult(missing=0, orphaned=1),
+    )
+    monkeypatch.setattr(
+        "autoskillit.cli._doctor._check_hook_health",
+        lambda _: DoctorResult(Severity.OK, "hook_health", "ok"),
+    )
+
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.enable_components = AsyncMock()
+
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        with patch("autoskillit.server.logger"):
+            with patch("autoskillit.server.tools_kitchen._prime_quota_cache", new=AsyncMock()):
+                with patch("autoskillit.server.tools_kitchen._write_hook_config"):
+                    from autoskillit.server.tools_kitchen import open_kitchen
+
+                    result = await open_kitchen(ctx=mock_ctx)
+
+    assert (
+        "orphan" in result.lower() or "drift" in result.lower() or "install" in result.lower()
+    ), "open_kitchen() must include a hook drift warning when orphaned > 0"
+
+
+# T-KITCHEN-2
+@pytest.mark.anyio
+async def test_open_kitchen_warns_on_missing_hook_scripts(tmp_path, monkeypatch):
+    """When hook scripts are absent from disk, open_kitchen() must warn."""
+    from autoskillit.cli._doctor import DoctorResult, HookDriftResult
+    from autoskillit.core.types import Severity
+
+    settings_dir = tmp_path / ".claude"
+    settings_dir.mkdir()
+    (settings_dir / "settings.json").write_text("{}")
+    monkeypatch.chdir(tmp_path)
+
+    monkeypatch.setattr(
+        "autoskillit.cli._doctor._check_hook_health",
+        lambda _: DoctorResult(
+            Severity.ERROR, "hook_health", "Hook scripts not found: status_health_guard.py"
+        ),
+    )
+    monkeypatch.setattr(
+        "autoskillit.cli._doctor._count_hook_registry_drift",
+        lambda _: HookDriftResult(missing=0, orphaned=0),
+    )
+
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.enable_components = AsyncMock()
+
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        with patch("autoskillit.server.logger"):
+            with patch("autoskillit.server.tools_kitchen._prime_quota_cache", new=AsyncMock()):
+                with patch("autoskillit.server.tools_kitchen._write_hook_config"):
+                    from autoskillit.server.tools_kitchen import open_kitchen
+
+                    result = await open_kitchen(ctx=mock_ctx)
+
+    assert "hook" in result.lower() and (
+        "missing" in result.lower() or "not found" in result.lower() or "install" in result.lower()
+    ), "open_kitchen() must warn when hook scripts are absent from disk"


### PR DESCRIPTION
## Summary

The structural weakness is **two independent hook entry formatters with no shared primitive**. `generate_hooks_json()` (in `hook_registry.py`) and `sync_hooks_to_settings()` (in `cli/_hooks.py`) both iterate `HOOK_REGISTRY` and emit per-entry dicts — but each builds the dict inline with separate logic. They have already diverged once (SessionStart matcher). Any future event-type special-casing must be applied in both places, and nothing prevents a second divergence.

Compounding this: drift detection is unidirectional. `_count_hook_registry_drift()` in `_doctor.py` only computes `canonical − deployed` (missing hooks). It never computes `deployed − canonical` (orphaned/ghost hooks). Orphaned hooks are strictly more dangerous — they cause fatal `ENOENT` denials — yet they are completely invisible to all detection. Finally, CI pre-regenerates `hooks.json` before running tests, so the on-disk validation test always compares freshly-generated output against itself and cannot catch staleness.

Part A addresses the root generation architecture and detection system. Part B covers runtime guards (`open_kitchen` diagnostic and write-guard hook).

## Requirements

### GUARD — Bidirectional Hook Drift Detection

- **REQ-GUARD-001:** `_check_hook_registry_drift()` in `_doctor.py` must detect BOTH directions: `canonical - deployed` (missing hooks) AND `deployed - canonical` (orphaned/stale hooks). Orphan count must be reported separately with severity `error` (not `warning`).
- **REQ-GUARD-002:** Add a new doctor check that validates every hook command in deployed `settings.json` points to an existing script file on disk. Report missing files as `error` severity.
- **REQ-GUARD-003:** At `open_kitchen` time (or at session startup if hooks are pre-loaded), validate that all hook script paths in settings.json resolve to existing files. If any are missing, emit a clear diagnostic message identifying the stale entries and how to fix them (e.g., "Run `autoskillit install` to regenerate hooks, or manually remove stale entries").

### SYNC — Fix Generation Path Divergence

- **REQ-SYNC-001:** `sync_hooks_to_settings()` in `_hooks.py` must omit the `"matcher"` key for `SessionStart` entries, matching `generate_hooks_json()` behavior. Add a test asserting this.
- **REQ-SYNC-002:** Add a test that asserts `sync_hooks_to_settings()` output is structurally consistent with `generate_hooks_json()` output for all event types (matching keys, matching script lists, matching matchers).

### CI — Stop Masking Drift

- **REQ-CI-001:** The CI workflow must NOT regenerate `hooks.json` before running `test_hooks_json_on_disk_exists_and_matches`. The test should validate the committed on-disk file directly against `generate_hooks_json()` output. If hooks.json needs regeneration, CI should fail the build and print the regeneration command — not silently fix it.

### PROTECT — Write-Guard for Generated Files

- **REQ-PROTECT-001:** Add a PreToolUse hook or guard that blocks Write/Edit tool calls targeting `hooks.json` from headless sessions, similar to how `GENERATED_FILES` protects against git operations. This prevents headless sessions from injecting entries that bypass `hook_registry.py`.

### ARCH — Consider Tracking hooks.json in Git

- **REQ-ARCH-001:** Evaluate making `hooks.json` git-tracked (removing it from `.gitignore`). If tracked, `git checkout` would revert it alongside `hook_registry.py`, eliminating the desync that caused this incident. The tradeoff is that hooks.json contains absolute paths — this would need to use relative paths or a path-independent format.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% === FLOW A: HOOK DEFINITION & DEPLOYMENT === %%
    subgraph Canonical ["Hook Definition (Single Source of Truth)"]
        direction TB
        REG["● HOOK_REGISTRY<br/>━━━━━━━━━━<br/>hook_registry.py<br/>11 HookDef entries<br/>incl. Write/Edit guard"]
        GEN["● generate_hooks_json()<br/>━━━━━━━━━━<br/>Builds absolute-path<br/>hook commands from<br/>HOOK_REGISTRY"]
    end

    subgraph Deploy ["Hook Deployment (autoskillit install)"]
        direction TB
        EVICT["● _evict_stale_hooks()<br/>━━━━━━━━━━<br/>Removes all autoskillit<br/>entries from settings.json"]
        SYNC["● sync_hooks_to_settings()<br/>━━━━━━━━━━<br/>Writes canonical entries<br/>fresh to settings.json"]
        HKJSON["hooks.json<br/>━━━━━━━━━━<br/>Plugin manifest<br/>(machine-local paths)"]
    end

    REG --> GEN
    GEN -->|"builds"| HKJSON
    REG -->|"iterates"| EVICT
    EVICT -->|"then"| SYNC
    SYNC -->|"writes"| SETTINGS

    SETTINGS[("● settings.json<br/>━━━━━━━━━━<br/>~/.claude/settings.json<br/>Deployed hook commands")]

    %% === FLOW B: WRITE GUARD (PreToolUse) === %%
    subgraph WriteGuard ["★ Generated File Write Guard (PreToolUse)"]
        direction TB
        TOOL_CALL(["Claude Code<br/>tool invocation"])
        CHK_TOOL{"Is tool<br/>Write or Edit?"}
        CHK_PATH{"file_path ends with<br/>hooks.json or<br/>.claude/settings.json?"}
        DENY["★ DENY<br/>━━━━━━━━━━<br/>generated_file_write_guard.py<br/>Blocks edit with<br/>ENOENT prevention msg"]
        ALLOW(["ALLOW<br/>━━━━━━━━━━<br/>exit 0"])
    end

    TOOL_CALL --> CHK_TOOL
    CHK_TOOL -->|"No"| ALLOW
    CHK_TOOL -->|"Yes"| CHK_PATH
    CHK_PATH -->|"No"| ALLOW
    CHK_PATH -->|"Yes"| DENY

    %% === FLOW C: DRIFT DETECTION (3 entry points) === %%
    subgraph DriftDetect ["Hook Drift Detection"]
        direction TB
        DRIFT_FN["● _count_hook_registry_drift()<br/>━━━━━━━━━━<br/>cli/_doctor.py<br/>canonical_cmds − deployed_cmds<br/>→ HookDriftResult(missing, orphaned)"]
        CHK_DRIFT{"missing > 0<br/>or orphaned > 0?"}
    end

    %% Three entry points into drift detection
    STALE["● run_stale_check()<br/>━━━━━━━━━━<br/>cli/_stale_check.py<br/>Interactive CLI startup"]
    DOCTOR["● run_doctor()<br/>━━━━━━━━━━<br/>cli/_doctor.py<br/>12 health checks"]
    OPNK["● open_kitchen()<br/>━━━━━━━━━━<br/>server/tools_kitchen.py<br/>MCP tool handler"]

    STALE -->|"reads user settings"| DRIFT_FN
    DOCTOR -->|"reads user settings"| DRIFT_FN
    OPNK -->|"reads project settings<br/>via _build_hook_diagnostic_warning()"| DRIFT_FN

    GEN -->|"canonical cmds"| DRIFT_FN
    SETTINGS -->|"deployed cmds"| DRIFT_FN

    DRIFT_FN --> CHK_DRIFT

    %% === FLOW D: REMEDIATION === %%
    subgraph Remediation ["Drift Remediation"]
        direction TB
        CHK_DISMISS{"Dismissed<br/>or snoozed?"}
        PROMPT["Prompt user<br/>━━━━━━━━━━<br/>Orphaned → ERROR severity<br/>Missing → WARNING severity"]
        CHK_ACCEPT{"User accepts<br/>install?"}
        RUN_INSTALL["Run<br/>autoskillit install<br/>━━━━━━━━━━<br/>Evict + Sync cycle"]
        DISMISS_ST["Write dismiss state<br/>━━━━━━━━━━<br/>~/.autoskillit/<br/>update_check.json<br/>12h cooldown"]
        WARN_OUT["Append warning<br/>to open_kitchen<br/>response"]
    end

    CHK_DRIFT -->|"No drift"| HEALTHY(["Healthy<br/>━━━━━━━━━━<br/>No action needed"])
    CHK_DRIFT -->|"Drift found"| CHK_DISMISS
    CHK_DISMISS -->|"Yes (CLI)"| HEALTHY
    CHK_DISMISS -->|"No (CLI)"| PROMPT
    CHK_DISMISS -->|"open_kitchen path"| WARN_OUT
    PROMPT --> CHK_ACCEPT
    CHK_ACCEPT -->|"Yes"| RUN_INSTALL
    CHK_ACCEPT -->|"No"| DISMISS_ST
    RUN_INSTALL -->|"triggers"| EVICT

    %% === CLASS ASSIGNMENTS === %%
    class REG,SYNC,EVICT,STALE,DOCTOR handler;
    class OPNK handler;
    class GEN,DRIFT_FN phase;
    class DENY,CHK_TOOL,CHK_PATH,CHK_DRIFT,CHK_DISMISS,CHK_ACCEPT detector;
    class SETTINGS stateNode;
    class HKJSON output;
    class TOOL_CALL,ALLOW,HEALTHY terminal;
    class PROMPT,RUN_INSTALL,DISMISS_ST,WARN_OUT phase;
```

### Error/Resilience Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ENTRY POINTS %%
    TOOL_CALL([Tool Call: Write / Edit])
    MCP_CALL([MCP Tool Call])
    CLI_START([CLI Startup])

    %% ============================================================ %%
    subgraph WriteGuard ["PRETOOLUSE — GENERATED FILE WRITE GUARD (★ New)"]
        direction TB
        WG_PARSE["★ Parse stdin JSON<br/>━━━━━━━━━━<br/>json.loads stdin"]
        WG_PARSE_FAIL{"Parse<br/>fails?"}
        WG_TOOL_CHECK{"Tool =<br/>Write or Edit?"}
        WG_PATH_CHECK{"Path ends<br/>hooks.json or<br/>settings.json?"}
        WG_DENY["★ Emit deny JSON<br/>━━━━━━━━━━<br/>permissionDecision: deny<br/>Ghost-entry ENOENT warning"]
        WG_ALLOW["★ exit 0, no stdout<br/>━━━━━━━━━━<br/>Pass-through (allow)"]
    end

    TOOL_CALL --> WG_PARSE
    WG_PARSE --> WG_PARSE_FAIL
    WG_PARSE_FAIL -->|"JSONDecodeError<br/>ValueError, OSError"| WG_ALLOW
    WG_PARSE_FAIL -->|"OK"| WG_TOOL_CHECK
    WG_TOOL_CHECK -->|"No"| WG_ALLOW
    WG_TOOL_CHECK -->|"Yes"| WG_PATH_CHECK
    WG_PATH_CHECK -->|"No match"| WG_ALLOW
    WG_PATH_CHECK -->|"Match"| WG_DENY

    %% ============================================================ %%
    subgraph KitchenGates ["MCP VALIDATION GATES"]
        direction TB
        G_HEADLESS["● _require_not_headless<br/>━━━━━━━━━━<br/>AUTOSKILLIT_HEADLESS=1?"]
        G_ENABLED["_require_enabled<br/>━━━━━━━━━━<br/>gate.enabled?"]
        G_SKILL["_validate_skill_command<br/>━━━━━━━━━━<br/>starts with /?"]
        G_DRY["_check_dry_walkthrough<br/>━━━━━━━━━━<br/>plan file + marker?"]
        G_HEADLESS_ERR["headless_error_result<br/>━━━━━━━━━━<br/>subtype: headless_error"]
        G_GATE_ERR["gate_error_result<br/>━━━━━━━━━━<br/>subtype: gate_error"]
    end

    MCP_CALL --> G_HEADLESS
    G_HEADLESS -->|"blocked"| G_HEADLESS_ERR
    G_HEADLESS -->|"OK"| G_ENABLED
    G_ENABLED -->|"closed"| G_GATE_ERR
    G_ENABLED -->|"open"| G_SKILL
    G_SKILL -->|"invalid"| G_GATE_ERR
    G_SKILL -->|"OK"| G_DRY
    G_DRY -->|"missing plan"| G_GATE_ERR

    %% ============================================================ %%
    subgraph OpenKitchen ["OPEN_KITCHEN ERROR PATHS"]
        direction TB
        OK_HANDLER["● open_kitchen<br/>━━━━━━━━━━<br/>@track_response_size"]
        OK_GATE_ENABLE["gate.enable<br/>━━━━━━━━━━<br/>Set enabled=True"]
        OK_HOOK_CFG["● _write_hook_config<br/>━━━━━━━━━━<br/>Write hooks to disk"]
        OK_HOOK_FAIL["OSError<br/>━━━━━━━━━━<br/>log + continue"]
        OK_QUOTA["_prime_quota_cache<br/>━━━━━━━━━━<br/>Fail-open on error"]
        OK_QUOTA_LOOP["_quota_refresh_loop<br/>━━━━━━━━━━<br/>Background task"]
        OK_QUOTA_ERR["Exception in loop<br/>━━━━━━━━━━<br/>log + loop continues"]
        OK_RECIPES_NIL{"recipes<br/>is None?"}
        OK_INIT_ERR["Server not initialized<br/>━━━━━━━━━━<br/>error JSON returned"]
        OK_HOOK_WARN["● _build_hook_diagnostic<br/>━━━━━━━━━━<br/>Inject hook_warning"]
        OK_SUCCESS["Kitchen opened<br/>━━━━━━━━━━<br/>JSON response"]
    end

    G_DRY -->|"OK"| OK_HANDLER
    OK_HANDLER --> OK_GATE_ENABLE
    OK_GATE_ENABLE --> OK_HOOK_CFG
    OK_HOOK_CFG -->|"OSError"| OK_HOOK_FAIL
    OK_HOOK_CFG -->|"OK"| OK_QUOTA
    OK_HOOK_FAIL -.->|"continue"| OK_QUOTA
    OK_QUOTA --> OK_QUOTA_LOOP
    OK_QUOTA_LOOP -->|"Exception"| OK_QUOTA_ERR
    OK_QUOTA_ERR -.->|"retry loop"| OK_QUOTA_LOOP
    OK_QUOTA --> OK_RECIPES_NIL
    OK_RECIPES_NIL -->|"Yes"| OK_INIT_ERR
    OK_RECIPES_NIL -->|"No"| OK_HOOK_WARN
    OK_HOOK_WARN --> OK_SUCCESS

    %% ============================================================ %%
    subgraph LastResort ["LAST-RESORT EXCEPTION HANDLER"]
        direction TB
        TRS["● @track_response_size<br/>━━━━━━━━━━<br/>Wraps all MCP tools"]
        TRS_CATCH["Catch Exception<br/>━━━━━━━━━━<br/>subtype: tool_exception<br/>exit_code: -1"]
    end

    OK_HANDLER -.->|"uncaught Exception"| TRS
    TRS --> TRS_CATCH

    %% ============================================================ %%
    subgraph StaleCheck ["CLI STALE CHECK — INTERACTIVE RECOVERY"]
        direction TB
        SC_GUARD{"Headless?<br/>not TTY?<br/>skip env?"}
        SC_SKIP["return<br/>━━━━━━━━━━<br/>Silent skip"]
        SC_FETCH["● _fetch_latest_version<br/>━━━━━━━━━━<br/>Network call"]
        SC_FETCH_FAIL["Exception<br/>━━━━━━━━━━<br/>returns None → skip"]
        SC_DISMISS{"Dismissed?<br/>Snoozed?"}
        SC_PROMPT["Prompt user<br/>━━━━━━━━━━<br/>Update Y/N?"]
        SC_UPDATE["subprocess.run<br/>━━━━━━━━━━<br/>uv + autoskillit install"]
        SC_VERIFY["● _verify_update_result<br/>━━━━━━━━━━<br/>Re-read version"]
        SC_SNOOZE["Write snooze<br/>━━━━━━━━━━<br/>1h TTL"]
        SC_DISMISS_W["Write dismiss<br/>━━━━━━━━━━<br/>12h TTL"]
        SC_DRIFT["● _count_hook_registry_drift<br/>━━━━━━━━━━<br/>HookDriftResult"]
        SC_ORPHAN{"Orphaned<br/>hooks?"}
        SC_ORPHAN_WARN["ENOENT-urgent prompt<br/>━━━━━━━━━━<br/>Ghost hooks detected"]
        SC_MISSING{"Missing<br/>hooks?"}
        SC_MISSING_WARN["Sync prompt<br/>━━━━━━━━━━<br/>New hooks available"]
    end

    CLI_START --> SC_GUARD
    SC_GUARD -->|"Yes"| SC_SKIP
    SC_GUARD -->|"No"| SC_FETCH
    SC_FETCH -->|"Exception"| SC_FETCH_FAIL
    SC_FETCH -->|"OK"| SC_DISMISS
    SC_DISMISS -->|"Yes"| SC_DRIFT
    SC_DISMISS -->|"No"| SC_PROMPT
    SC_PROMPT -->|"Y"| SC_UPDATE
    SC_PROMPT -->|"N"| SC_DISMISS_W
    SC_UPDATE --> SC_VERIFY
    SC_VERIFY -->|"unchanged"| SC_SNOOZE
    SC_VERIFY -->|"updated"| SC_DRIFT
    SC_DISMISS_W --> SC_DRIFT
    SC_SNOOZE --> SC_DRIFT
    SC_DRIFT --> SC_ORPHAN
    SC_ORPHAN -->|"Yes"| SC_ORPHAN_WARN
    SC_ORPHAN -->|"No"| SC_MISSING
    SC_MISSING -->|"Yes"| SC_MISSING_WARN

    %% ============================================================ %%
    subgraph Doctor ["DOCTOR HEALTH CHECKS (Subset)"]
        direction TB
        DOC_RUN["● run_doctor<br/>━━━━━━━━━━<br/>12 independent checks"]
        DOC_HOOK_HEALTH["● _check_hook_health<br/>━━━━━━━━━━<br/>Script paths exist?"]
        DOC_HOOK_REG["● _check_hook_registration<br/>━━━━━━━━━━<br/>Scripts in settings.json?"]
        DOC_DRIFT["● _check_hook_registry_drift<br/>━━━━━━━━━━<br/>Canonical vs deployed sets"]
        DOC_ERR["DoctorResult<br/>━━━━━━━━━━<br/>severity: ERROR<br/>Orphaned = ENOENT risk"]
        DOC_WARN["DoctorResult<br/>━━━━━━━━━━<br/>severity: WARNING<br/>Missing = sync needed"]
        DOC_OK["DoctorResult<br/>━━━━━━━━━━<br/>severity: OK"]
    end

    DOC_RUN --> DOC_HOOK_HEALTH
    DOC_RUN --> DOC_HOOK_REG
    DOC_RUN --> DOC_DRIFT
    DOC_HOOK_HEALTH -->|"scripts missing"| DOC_ERR
    DOC_HOOK_HEALTH -->|"all exist"| DOC_OK
    DOC_DRIFT -->|"orphaned > 0"| DOC_ERR
    DOC_DRIFT -->|"missing > 0"| DOC_WARN
    DOC_DRIFT -->|"both 0"| DOC_OK
    DOC_HOOK_REG -->|"absent"| DOC_WARN
    DOC_HOOK_REG -->|"present"| DOC_OK

    %% ============================================================ %%
    subgraph Registry ["HOOK REGISTRY — SOURCE OF TRUTH"]
        direction TB
        HR_REG["● HOOK_REGISTRY<br/>━━━━━━━━━━<br/>11 HookDef entries<br/>Canonical definitions"]
        HR_VALIDATE["HookDef.__post_init__<br/>━━━━━━━━━━<br/>ValueError if<br/>non-SessionStart + empty matcher"]
        HR_GENERATE["● generate_hooks_json<br/>━━━━━━━━━━<br/>Derive hooks.json<br/>from registry + pkg_root"]
    end

    HR_REG --> HR_VALIDATE
    HR_REG --> HR_GENERATE
    HR_GENERATE -.->|"canonical set"| DOC_DRIFT
    HR_GENERATE -.->|"canonical set"| SC_DRIFT

    %% ============================================================ %%
    %% TERMINAL STATES %%
    T_DENIED([TOOL DENIED])
    T_GATE_BLOCKED([GATE BLOCKED])
    T_TOOL_EX([TOOL EXCEPTION])
    T_KITCHEN_OK([KITCHEN OPEN])
    T_CLI_DONE([CLI CONTINUES])

    WG_DENY --> T_DENIED
    G_HEADLESS_ERR --> T_GATE_BLOCKED
    G_GATE_ERR --> T_GATE_BLOCKED
    TRS_CATCH --> T_TOOL_EX
    OK_SUCCESS --> T_KITCHEN_OK
    OK_INIT_ERR --> T_GATE_BLOCKED
    SC_SKIP --> T_CLI_DONE
    SC_FETCH_FAIL --> T_CLI_DONE
    SC_ORPHAN_WARN --> T_CLI_DONE
    SC_MISSING_WARN --> T_CLI_DONE

    %% CLASS ASSIGNMENTS %%
    class TOOL_CALL,MCP_CALL,CLI_START cli;
    class WG_PARSE,WG_DENY,WG_ALLOW newComponent;
    class WG_PARSE_FAIL,WG_TOOL_CHECK,WG_PATH_CHECK newComponent;
    class G_HEADLESS,G_ENABLED,G_SKILL,G_DRY detector;
    class G_HEADLESS_ERR,G_GATE_ERR gap;
    class OK_HANDLER,OK_GATE_ENABLE,OK_HOOK_CFG,OK_QUOTA,OK_QUOTA_LOOP handler;
    class OK_HOOK_FAIL,OK_QUOTA_ERR,OK_INIT_ERR gap;
    class OK_RECIPES_NIL stateNode;
    class OK_HOOK_WARN,OK_SUCCESS output;
    class TRS,TRS_CATCH detector;
    class SC_GUARD,SC_ORPHAN,SC_MISSING,SC_DISMISS stateNode;
    class SC_SKIP,SC_FETCH_FAIL,SC_SNOOZE,SC_DISMISS_W phase;
    class SC_FETCH,SC_PROMPT,SC_UPDATE,SC_VERIFY,SC_DRIFT handler;
    class SC_ORPHAN_WARN,SC_MISSING_WARN gap;
    class DOC_RUN,DOC_HOOK_HEALTH,DOC_HOOK_REG,DOC_DRIFT handler;
    class DOC_ERR gap;
    class DOC_WARN phase;
    class DOC_OK output;
    class HR_REG,HR_VALIDATE,HR_GENERATE stateNode;
    class T_DENIED,T_GATE_BLOCKED,T_TOOL_EX,T_KITCHEN_OK,T_CLI_DONE terminal;
```

### Development Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;

    subgraph Build ["BUILD TOOLING"]
        direction TB
        PYPROJECT["● pyproject.toml<br/>━━━━━━━━━━<br/>hatchling backend<br/>uv package manager<br/>10 runtime + 8 dev deps"]
        TASKFILE["Taskfile.yml<br/>━━━━━━━━━━<br/>test-all, test-check<br/>install-worktree<br/>sync-plugin-version"]
        EP["autoskillit CLI<br/>━━━━━━━━━━<br/>autoskillit.cli:main"]
    end

    subgraph Quality ["PRE-COMMIT QUALITY GATES"]
        direction LR
        RUFF_FMT["ruff format<br/>━━━━━━━━━━<br/>Auto-fix formatting"]
        RUFF_CHK["ruff check --fix<br/>━━━━━━━━━━<br/>Lint + auto-fix"]
        MYPY["mypy src/<br/>━━━━━━━━━━<br/>Type checking<br/>ignore-missing-imports"]
        UVLOCK["uv lock --check<br/>━━━━━━━━━━<br/>Lockfile integrity"]
        GITLEAKS["gitleaks<br/>━━━━━━━━━━<br/>Secret scanning"]
        NOGEN["no-generated-configs<br/>━━━━━━━━━━<br/>Blocks hooks.json<br/>+ settings.json commits"]
    end

    subgraph Testing ["TEST FRAMEWORK"]
        direction TB
        PYTEST["pytest + xdist<br/>━━━━━━━━━━<br/>-n 4 --dist worksteal<br/>asyncio_mode=auto<br/>timeout=60s"]
        CONFTEST["conftest.py<br/>━━━━━━━━━━<br/>4 autouse fixtures<br/>tool_ctx, parse_stdout_json<br/>StatefulMockTester"]
        TESTDIRS["13 test subdirectories<br/>━━━━━━━━━━<br/>arch/ cli/ config/ contracts/<br/>core/ execution/ infra/<br/>migration/ pipeline/ recipe/<br/>server/ skills/ workspace/"]
    end

    subgraph CI ["CI PIPELINE — .github/workflows/tests.yml"]
        direction LR
        PREFLIGHT["● preflight<br/>━━━━━━━━━━<br/>OS matrix computation<br/>uv lock --check<br/>Tool version report"]
        TESTJOB["● test<br/>━━━━━━━━━━<br/>uv sync --locked<br/>Generate hooks.json<br/>task test-all"]
    end

    subgraph HookSystem ["HOOK REGISTRATION SYSTEM (PR Focus)"]
        direction TB
        REGISTRY["● hook_registry.py<br/>━━━━━━━━━━<br/>HookDef dataclass<br/>HOOK_REGISTRY: 11 entries<br/>generate_hooks_json()"]
        HOOKS_CLI["● cli/_hooks.py<br/>━━━━━━━━━━<br/>evict_stale → sync<br/>sync_hooks_to_settings()"]
        STALE["● cli/_stale_check.py<br/>━━━━━━━━━━<br/>Binary version check<br/>Hook drift detection<br/>Dismissal persistence"]
        DOCTOR["● cli/_doctor.py<br/>━━━━━━━━━━<br/>Check 6: hook health<br/>Check 7: registration<br/>Check 7b: drift count"]
        KITCHEN["● server/tools_kitchen.py<br/>━━━━━━━━━━<br/>open_kitchen drift<br/>diagnostic warning"]
        HELPERS["● server/helpers.py<br/>━━━━━━━━━━<br/>_build_hook_diagnostic<br/>_warning()"]
        GUARD_NEW["★ hooks/generated_file<br/>_write_guard.py<br/>━━━━━━━━━━<br/>PreToolUse: deny Write/Edit<br/>on hooks.json, settings.json"]
    end

    subgraph TestsPR ["PR TEST COVERAGE"]
        direction TB
        T_GUARD["★ test_generated_file<br/>_write_guard.py<br/>━━━━━━━━━━<br/>Guard deny/allow tests"]
        T_HOOKS["● test_cli_hooks.py<br/>━━━━━━━━━━<br/>Hook sync tests"]
        T_STALE["● test_stale_check.py<br/>━━━━━━━━━━<br/>Drift detection tests"]
        T_DOCTOR["● test_doctor.py<br/>━━━━━━━━━━<br/>Doctor check tests"]
        T_KITCHEN["● test_tools_kitchen.py<br/>━━━━━━━━━━<br/>open_kitchen tests"]
        T_REG["● test_hook_registration<br/>_coverage.py<br/>━━━━━━━━━━<br/>Registry completeness"]
        T_EXEC["● test_hook_executability.py<br/>━━━━━━━━━━<br/>Script existence checks"]
        T_ARCH["● test_subpackage<br/>_isolation.py<br/>━━━━━━━━━━<br/>Layer boundary tests"]
    end

    %% BUILD FLOW %%
    PYPROJECT --> TASKFILE
    TASKFILE --> EP

    %% QUALITY FLOW %%
    RUFF_FMT --> RUFF_CHK --> MYPY
    UVLOCK -.-> MYPY
    GITLEAKS -.-> MYPY
    NOGEN -.-> MYPY

    %% TESTING FLOW %%
    TASKFILE -->|"task test-all"| PYTEST
    PYTEST --> CONFTEST
    CONFTEST --> TESTDIRS

    %% CI FLOW %%
    PREFLIGHT -->|"matrix"| TESTJOB
    TESTJOB -->|"task test-all"| PYTEST

    %% HOOK SYSTEM FLOW %%
    REGISTRY -->|"canonical defs"| HOOKS_CLI
    REGISTRY -->|"drift baseline"| DOCTOR
    REGISTRY -->|"new entry"| GUARD_NEW
    HOOKS_CLI -->|"sync to settings"| STALE
    DOCTOR -->|"drift count"| STALE
    HELPERS -->|"diagnostic"| KITCHEN
    DOCTOR -->|"health + drift"| HELPERS

    %% TEST COVERAGE FLOW %%
    GUARD_NEW -.->|"tested by"| T_GUARD
    HOOKS_CLI -.->|"tested by"| T_HOOKS
    STALE -.->|"tested by"| T_STALE
    DOCTOR -.->|"tested by"| T_DOCTOR
    KITCHEN -.->|"tested by"| T_KITCHEN
    REGISTRY -.->|"tested by"| T_REG
    REGISTRY -.->|"tested by"| T_EXEC
    REGISTRY -.->|"tested by"| T_ARCH

    %% CLASS ASSIGNMENTS %%
    class PYPROJECT,TASKFILE,EP phase;
    class RUFF_FMT,RUFF_CHK,MYPY,UVLOCK,GITLEAKS,NOGEN detector;
    class PYTEST,CONFTEST,TESTDIRS handler;
    class PREFLIGHT,TESTJOB cli;
    class REGISTRY,HOOKS_CLI,STALE,DOCTOR,KITCHEN,HELPERS stateNode;
    class GUARD_NEW newComponent;
    class T_GUARD newComponent;
    class T_HOOKS,T_STALE,T_DOCTOR,T_KITCHEN,T_REG,T_EXEC,T_ARCH handler;
```

Closes #669

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260408-133614-548228/.autoskillit/temp/rectify/rectify_ghost-hook-registrations_2026-04-08_134500_part_a.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
