### PR TITLE
fix: expand VT100 reset to prevent terminal corruption after cook/order exit (#676)

### DIFF
--- a/src/autoskillit/cli/_terminal.py
+++ b/src/autoskillit/cli/_terminal.py
@@ -20,7 +20,7 @@ from autoskillit.core import get_logger
 
 _log = get_logger(__name__)
 
-_KITTY_TERMINALS = frozenset({"kitty", "WezTerm", "ghostty", "iTerm.app"})
+_KBP_TERMINALS = frozenset({"kitty", "WezTerm", "ghostty", "iTerm.app"})
 
 # Base VT100 reset — universally safe no-ops on all terminal emulators.
 _BASE_RESET = (
@@ -92,7 +92,7 @@ def terminal_guard() -> Generator[None, None, None]:
                 sys.stdout.write(_BASE_RESET)
                 if (
                     os.environ.get("KITTY_WINDOW_ID")
-                    or os.environ.get("TERM_PROGRAM", "") in _KITTY_TERMINALS
+                    or os.environ.get("TERM_PROGRAM", "") in _KBP_TERMINALS
                 ):
                     sys.stdout.write(_KITTY_RESET)
                 sys.stdout.flush()

--- a/src/autoskillit/cli/_terminal.py
+++ b/src/autoskillit/cli/_terminal.py
@@ -20,6 +20,33 @@ from autoskillit.core import get_logger
 
 _log = get_logger(__name__)
 
+_KITTY_TERMINALS = frozenset({"kitty", "WezTerm", "ghostty", "iTerm.app"})
+
+# Base VT100 reset — universally safe no-ops on all terminal emulators.
+_BASE_RESET = (
+    "\033[?1049l"  # exit alternate screen buffer (defensive)
+    "\033[?2004l"  # disable bracketed paste mode
+    "\033[?1000l"  # disable normal mouse tracking
+    "\033[?1002l"  # disable button-event mouse tracking
+    "\033[?1003l"  # disable any-event mouse tracking
+    "\033[?1006l"  # disable SGR extended mouse protocol
+    "\033[?1004l"  # disable focus in/out events
+    "\033[?2026l"  # disable synchronized output
+    "\033[?1l"  # disable application cursor keys (DECCKM)
+    "\033>"  # numeric keypad mode (DECKPNM)
+    "\033[!p"  # DECSTR soft reset (18 DEC attributes, no screen clear)
+    "\033[0m"  # reset SGR attributes
+    "\033[?25h"  # show cursor (DECTCEM)
+)
+
+# Kitty keyboard protocol teardown — NOT universally safe. JediTerm
+# (JetBrains IDEs) echoes literal chars from these sequences
+# (claude-code#18135). Only emit when terminal is known to support KBP.
+_KITTY_RESET = (
+    "\033[=0u"  # hard-disable Kitty keyboard protocol
+    "\033[<99u"  # drain Kitty keyboard protocol push stack
+)
+
 
 @contextlib.contextmanager
 def terminal_guard() -> Generator[None, None, None]:
@@ -62,7 +89,12 @@ def terminal_guard() -> Generator[None, None, None]:
                 os.system("stty sane 2>/dev/null")
         if fd is not None:
             try:
-                sys.stdout.write("\033[?1049l\033[?1l\033>\033[0m\033[?25h")
+                sys.stdout.write(_BASE_RESET)
+                if (
+                    os.environ.get("KITTY_WINDOW_ID")
+                    or os.environ.get("TERM_PROGRAM", "") in _KITTY_TERMINALS
+                ):
+                    sys.stdout.write(_KITTY_RESET)
                 sys.stdout.flush()
             except OSError:
                 pass

--- a/tests/cli/test_terminal.py
+++ b/tests/cli/test_terminal.py
@@ -6,6 +6,7 @@ the investigation's test strategy recommendation.
 
 from __future__ import annotations
 
+import os
 import termios
 from unittest.mock import patch
 
@@ -99,6 +100,14 @@ class TestTerminalGuardTTYRestore:
             assert "\033[?1049l" in written, "Must exit alternate screen buffer"
             assert "\033[?1l" in written, "Must reset application cursor keys"
             assert "\033>" in written, "Must reset application keypad mode"
+            assert "\033[?2004l" in written, "Must disable bracketed paste mode"
+            assert "\033[?1000l" in written, "Must disable normal mouse tracking"
+            assert "\033[?1002l" in written, "Must disable button-event mouse tracking"
+            assert "\033[?1003l" in written, "Must disable any-event mouse tracking"
+            assert "\033[?1006l" in written, "Must disable SGR extended mouse protocol"
+            assert "\033[?1004l" in written, "Must disable focus in/out events"
+            assert "\033[?2026l" in written, "Must disable synchronized output"
+            assert "\033[!p" in written, "Must emit DECSTR soft reset"
 
     def test_emits_vt100_reset_sequences_on_exception(self):
         """Escape sequences are written even when subprocess raises."""
@@ -119,6 +128,10 @@ class TestTerminalGuardTTYRestore:
             written = "".join(c.args[0] for c in mock_stdout.write.call_args_list if c.args)
             assert "\033[?1049l" in written, "Must exit alternate screen buffer"
             assert "\033[?1l" in written
+            assert "\033[?2004l" in written, "Must disable bracketed paste mode"
+            assert "\033[?1003l" in written, "Must disable any-event mouse tracking"
+            assert "\033[?2026l" in written, "Must disable synchronized output"
+            assert "\033[!p" in written, "Must emit DECSTR soft reset"
 
     def test_noop_in_non_tty_environment(self):
         """When stdin is not a TTY, tcgetattr and tcsetattr are never called."""
@@ -249,6 +262,102 @@ class TestTerminalGuardTTYRestore:
                 pass
 
             mock_stdout.write.assert_not_called()
+
+    def test_kitty_sequences_emitted_on_supported_terminal(self):
+        """Kitty KBP sequences are emitted when TERM_PROGRAM indicates support."""
+        from autoskillit.cli._terminal import terminal_guard
+
+        with (
+            patch("autoskillit.cli._terminal.sys.stdin") as mock_stdin,
+            patch("autoskillit.cli._terminal.termios"),
+            patch("autoskillit.cli._terminal.sys.stdout") as mock_stdout,
+            patch.dict("os.environ", {"TERM_PROGRAM": "kitty"}, clear=False),
+        ):
+            mock_stdin.isatty.return_value = True
+            mock_stdin.fileno.return_value = 0
+
+            with terminal_guard():
+                pass
+
+            written = "".join(c.args[0] for c in mock_stdout.write.call_args_list if c.args)
+            assert "\033[=0u" in written, "Must hard-disable Kitty keyboard protocol"
+            assert "\033[<99u" in written, "Must drain Kitty keyboard protocol push stack"
+
+    def test_kitty_sequences_not_emitted_on_unsupported_terminal(self):
+        """Kitty KBP sequences must NOT be emitted on unsupported terminals.
+
+        JediTerm (JetBrains IDEs) echoes literal garbage from \\033[<99u.
+        """
+        from autoskillit.cli._terminal import terminal_guard
+
+        env = os.environ.copy()
+        env.pop("TERM_PROGRAM", None)
+        env.pop("KITTY_WINDOW_ID", None)
+
+        with (
+            patch("autoskillit.cli._terminal.sys.stdin") as mock_stdin,
+            patch("autoskillit.cli._terminal.termios"),
+            patch("autoskillit.cli._terminal.sys.stdout") as mock_stdout,
+            patch.dict("os.environ", env, clear=True),
+        ):
+            mock_stdin.isatty.return_value = True
+            mock_stdin.fileno.return_value = 0
+
+            with terminal_guard():
+                pass
+
+            written = "".join(c.args[0] for c in mock_stdout.write.call_args_list if c.args)
+            assert "\033[=0u" not in written, (
+                "Kitty hard-disable must not be emitted on unsupported terminals"
+            )
+            assert "\033[<99u" not in written, (
+                "Kitty stack drain must not be emitted on unsupported terminals"
+            )
+            # Base sequences must still be present
+            assert "\033[?2004l" in written, "Base reset must still be emitted"
+            assert "\033[!p" in written, "DECSTR must still be emitted"
+
+    def test_kitty_sequences_emitted_via_kitty_window_id(self):
+        """KITTY_WINDOW_ID triggers Kitty KBP sequences regardless of TERM_PROGRAM."""
+        from autoskillit.cli._terminal import terminal_guard
+
+        with (
+            patch("autoskillit.cli._terminal.sys.stdin") as mock_stdin,
+            patch("autoskillit.cli._terminal.termios"),
+            patch("autoskillit.cli._terminal.sys.stdout") as mock_stdout,
+            patch.dict("os.environ", {"KITTY_WINDOW_ID": "1"}, clear=False),
+        ):
+            mock_stdin.isatty.return_value = True
+            mock_stdin.fileno.return_value = 0
+
+            with terminal_guard():
+                pass
+
+            written = "".join(c.args[0] for c in mock_stdout.write.call_args_list if c.args)
+            assert "\033[=0u" in written, "Must hard-disable Kitty keyboard protocol"
+
+    def test_kitty_protocol_sequences_emitted_after_decstr(self):
+        """Kitty KBP sequences must follow DECSTR to avoid being reset."""
+        from autoskillit.cli._terminal import terminal_guard
+
+        with (
+            patch("autoskillit.cli._terminal.sys.stdin") as mock_stdin,
+            patch("autoskillit.cli._terminal.termios"),
+            patch("autoskillit.cli._terminal.sys.stdout") as mock_stdout,
+            patch.dict("os.environ", {"TERM_PROGRAM": "kitty"}, clear=False),
+        ):
+            mock_stdin.isatty.return_value = True
+            mock_stdin.fileno.return_value = 0
+
+            with terminal_guard():
+                pass
+
+            written = "".join(c.args[0] for c in mock_stdout.write.call_args_list if c.args)
+            decstr_pos = written.index("\033[!p")
+            kitty_hard_pos = written.index("\033[=0u")
+            kitty_drain_pos = written.index("\033[<99u")
+            assert decstr_pos < kitty_hard_pos, "Kitty hard-disable must follow DECSTR"
+            assert decstr_pos < kitty_drain_pos, "Kitty stack drain must follow DECSTR"
 
 
 class TestCookTerminalGuard:


### PR DESCRIPTION
## Summary

After exiting an `autoskillit cook` or `autoskillit order` session, the terminal exhibits input garbling: typed commands mix with remnant output, Ctrl-C prints `9;5u` instead of sending SIGINT, and bracketed paste markers appear in pasted text. The root cause is that `terminal_guard()` in `src/autoskillit/cli/_terminal.py` correctly restores kernel TTY discipline (termios) but emits an incomplete VT100 reset sequence — it is missing reset sequences for bracketed paste mode, mouse tracking modes, focus event reporting, Kitty keyboard protocol, and a DECSTR soft reset.

The fix expands the single-line escape sequence string on line 65 of `_terminal.py` into a comprehensive, well-documented multi-line string literal that covers all known terminal modes Claude Code may enable but fail to disable on exit. The base reset sequences (DEC private modes, DECSTR, SGR) are universally safe no-ops. Kitty keyboard protocol sequences (`\033[=0u`, `\033[<99u`) are gated behind a `TERM_PROGRAM` / `KITTY_WINDOW_ID` runtime check because they produce visible garbage on terminals that don't support the protocol (notably JediTerm in JetBrains IDEs — see claude-code#18135).

## Architecture Impact

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START(["cook() / order() / stale_check()"])

    subgraph InitOnly ["INIT_ONLY FIELDS — Set Once, Never Modified"]
        direction TB
        FD["fd = stdin.fileno()<br/>━━━━━━━━━━<br/>Raw FD integer<br/>None if non-TTY"]
        OLD["old_settings = tcgetattr(fd)<br/>━━━━━━━━━━<br/>Full kernel TTY snapshot<br/>7-element termios struct"]
    end

    subgraph Gates ["VALIDATION GATE CHAIN"]
        direction TB
        G1{"Gate 1: isatty()<br/>━━━━━━━━━━<br/>Non-TTY = full no-op"}
        G2{"Gate 2: tcgetattr<br/>━━━━━━━━━━<br/>error/OSError/TypeError<br/>= fd := None"}
        G3{"Gate 3: fd + old_settings<br/>━━━━━━━━━━<br/>Both non-None?<br/>= restore eligible"}
        G4{"Gate 4: tcsetattr<br/>━━━━━━━━━━<br/>error = stty sane<br/>fallback"}
        G5{"Gate 5: fd not None<br/>━━━━━━━━━━<br/>VT100 emission<br/>eligible"}
        G6{"Gate 6: Kitty detect<br/>━━━━━━━━━━<br/>KITTY_WINDOW_ID or<br/>TERM_PROGRAM check"}
        G7{"Gate 7: OSError<br/>━━━━━━━━━━<br/>stdout.write catch<br/>= silent swallow"}
    end

    subgraph Subprocess ["SUBPROCESS PHASE — Guard Yields"]
        direction TB
        YIELD["yield — subprocess owns terminal<br/>━━━━━━━━━━<br/>Claude Code Ink TUI<br/>No entry-side sequences emitted"]
    end

    subgraph Restore ["● EXIT-ONLY RESTORE — finally block"]
        direction TB
        TERMIOS["tcsetattr(TCSAFLUSH)<br/>━━━━━━━━━━<br/>Kernel TTY discipline<br/>restored from old_settings"]
        STTY["stty sane 2>/dev/null<br/>━━━━━━━━━━<br/>Emergency fallback<br/>if tcsetattr fails"]
    end

    subgraph BaseReset ["● _BASE_RESET — 13 VT100 Sequences"]
        direction TB
        ALT["?1049l exit alt-screen"]
        BRACKET["?2004l disable bracketed paste"]
        MOUSE["?1000l/?1002l/?1003l/?1006l<br/>disable all mouse tracking"]
        FOCUS["?1004l disable focus events"]
        SYNC["?2026l disable sync output"]
        CURSOR["?1l DECCKM + DECKPNM"]
        DECSTR["ESC[!p DECSTR soft reset"]
        SGR["ESC[0m reset SGR + ESC[?25h show cursor"]
    end

    subgraph KittyReset ["● _KITTY_RESET — Gated KBP Teardown"]
        direction TB
        KHARD["ESC[=0u hard-disable KBP"]
        KDRAIN["ESC[less-than 99u drain push stack"]
    end

    DONE(["Terminal Clean — Parent Shell Safe"])

    %% ENTRY FLOW %%
    START --> G1
    G1 -->|"True"| FD
    G1 -->|"False: pipe/CI"| DONE
    FD --> G2
    G2 -->|"Success"| OLD
    G2 -->|"Exception"| DONE
    OLD --> YIELD

    %% EXIT FLOW %%
    YIELD -->|"any exit path"| G3
    G3 -->|"Both set"| G4
    G3 -->|"Missing"| G5
    G4 -->|"Success"| TERMIOS
    G4 -->|"termios.error"| STTY
    TERMIOS --> G5
    STTY --> G5

    %% VT100 EMISSION %%
    G5 -->|"fd valid"| ALT
    ALT --> BRACKET
    BRACKET --> MOUSE
    MOUSE --> FOCUS
    FOCUS --> SYNC
    SYNC --> CURSOR
    CURSOR --> DECSTR
    DECSTR --> SGR
    SGR --> G6

    %% KITTY GATE %%
    G6 -->|"Kitty/WezTerm/ghostty/iTerm"| KHARD
    G6 -->|"Generic terminal"| G7
    KHARD --> KDRAIN
    KDRAIN --> G7

    G7 -->|"flush OK or OSError swallowed"| DONE

    %% CLASS ASSIGNMENTS %%
    class START,DONE terminal;
    class FD,OLD stateNode;
    class G1,G2,G3,G4,G5,G6,G7 detector;
    class YIELD phase;
    class TERMIOS,STTY handler;
    class ALT,BRACKET,MOUSE,FOCUS,SYNC,CURSOR,DECSTR,SGR output;
    class KHARD,KDRAIN gap;
```

### Error/Resilience Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START([CLI Entry<br/>cook / order / stale_check])

    subgraph Callers ["CALL SITES (4 locations)"]
        COOK["_cook._run_cook_session<br/>━━━━━━━━━━<br/>subprocess.run inside guard"]
        ORDER["app._launch_cook_session<br/>━━━━━━━━━━<br/>subprocess.run inside guard"]
        STALE_BIN["_stale_check binary update<br/>━━━━━━━━━━<br/>uv install + autoskillit install"]
        STALE_HOOK["_stale_check hook drift<br/>━━━━━━━━━━<br/>autoskillit install"]
    end

    subgraph TTY_Save ["ENTRY GATE: TTY Save"]
        direction TB
        ISATTY{"stdin.isatty()?"}
        SAVE["● terminal_guard ENTRY<br/>━━━━━━━━━━<br/>fd = stdin.fileno()<br/>old = tcgetattr(fd)"]
        SAVE_ERR["tcgetattr fails<br/>━━━━━━━━━━<br/>fd = None<br/>guard becomes no-op"]
    end

    subgraph Subprocess ["SUBPROCESS EXECUTION"]
        EXEC["subprocess.run(cmd)<br/>━━━━━━━━━━<br/>Interactive Claude session"]
        KBINT["KeyboardInterrupt<br/>━━━━━━━━━━<br/>Ctrl+C during session"]
        OSERR["OSError<br/>━━━━━━━━━━<br/>claude binary missing"]
    end

    subgraph Restore ["EXIT: TTY Restore (finally block)"]
        direction TB
        TCSET["● tcsetattr(TCSAFLUSH)<br/>━━━━━━━━━━<br/>Primary: restore saved attrs"]
        TCSET_FAIL["tcsetattr fails<br/>━━━━━━━━━━<br/>termios.error"]
        STTY["stty sane 2>/dev/null<br/>━━━━━━━━━━<br/>Fallback: OS-level reset"]
    end

    subgraph VT100 ["EXIT: VT100 Reset (finally block)"]
        direction TB
        BASE["● _BASE_RESET emission<br/>━━━━━━━━━━<br/>13 escape sequences:<br/>alt-screen, mouse, paste,<br/>sync-output, DECSTR, SGR,<br/>cursor-keys, keypad, cursor"]
        KITTY_CHK{"Kitty-compatible<br/>terminal?"}
        KITTY["_KITTY_RESET emission<br/>━━━━━━━━━━<br/>KBP hard-disable + stack drain"]
        FLUSH["stdout.flush()<br/>━━━━━━━━━━<br/>Force write to terminal"]
        VT_ERR["OSError<br/>━━━━━━━━━━<br/>Broken pipe / closed stdout<br/>Silently swallowed"]
    end

    subgraph Terminals ["TERMINAL STATES"]
        T_OK([SUCCESS<br/>returncode = 0])
        T_EXIT([SystemExit<br/>returncode != 0])
        T_PROPAGATE([Exception propagates<br/>terminal restored])
        T_NOOP([NO-OP<br/>non-TTY environment])
    end

    %% ENTRY FLOW %%
    START --> COOK
    START --> ORDER
    START --> STALE_BIN
    START --> STALE_HOOK

    COOK --> ISATTY
    ORDER --> ISATTY
    STALE_BIN --> ISATTY
    STALE_HOOK --> ISATTY

    %% TTY SAVE GATE %%
    ISATTY -->|"False (CI/pipe)"| T_NOOP
    ISATTY -->|"True"| SAVE
    SAVE --> EXEC
    SAVE -->|"termios.error / OSError / TypeError"| SAVE_ERR
    SAVE_ERR -->|"fd=None, skip restore"| EXEC

    %% SUBPROCESS OUTCOMES %%
    EXEC -->|"normal exit"| TCSET
    EXEC -->|"Ctrl+C"| KBINT
    EXEC -->|"binary gone"| OSERR
    KBINT -->|"finally"| TCSET
    OSERR -->|"finally"| TCSET

    %% RESTORE PATH %%
    TCSET -->|"success"| BASE
    TCSET -->|"termios.error"| TCSET_FAIL
    TCSET_FAIL --> STTY
    STTY --> BASE

    %% VT100 RESET PATH %%
    BASE --> KITTY_CHK
    KITTY_CHK -->|"KITTY_WINDOW_ID or<br/>TERM_PROGRAM in allowlist"| KITTY
    KITTY_CHK -->|"other terminal"| FLUSH
    KITTY --> FLUSH
    FLUSH --> T_OK
    FLUSH --> T_EXIT
    FLUSH --> T_PROPAGATE
    FLUSH -->|"OSError"| VT_ERR
    VT_ERR --> T_OK
    VT_ERR --> T_EXIT
    VT_ERR --> T_PROPAGATE

    %% CLASS ASSIGNMENTS %%
    class START terminal;
    class COOK,ORDER,STALE_BIN,STALE_HOOK handler;
    class ISATTY,KITTY_CHK stateNode;
    class SAVE,TCSET,BASE detector;
    class SAVE_ERR,TCSET_FAIL,VT_ERR gap;
    class EXEC,KBINT,OSERR handler;
    class STTY,KITTY,FLUSH output;
    class T_OK,T_EXIT,T_PROPAGATE,T_NOOP terminal;
```

Closes #676

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260408-164447-021290/.autoskillit/temp/make-plan/fix-terminal-state-corruption-after-cook-order-exit_plan_2026-04-08_175500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 739 | 18.1k | 1.7M | 102.2k | 2 | 9m 53s |
| review | 14 | 7.7k | 258.0k | 43.2k | 1 | 5m 15s |
| verify | 28 | 21.5k | 1.2M | 68.6k | 1 | 7m 29s |
| implement | 34 | 8.3k | 1.0M | 43.5k | 1 | 3m 23s |
| prepare_pr | 12 | 6.4k | 164.1k | 28.5k | 1 | 2m 0s |
| run_arch_lenses | 2.1k | 16.3k | 973.1k | 127.3k | 3 | 9m 58s |
| compose_pr | 9 | 7.1k | 170.0k | 29.5k | 1 | 2m 17s |
| **Total** | 2.9k | 85.4k | 5.5M | 442.9k | | 40m 17s |