### PR TITLE
Rectify: Stale-Hooks Check Infinite Prompt Loop

### DIFF
--- a/src/autoskillit/cli/_doctor.py
+++ b/src/autoskillit/cli/_doctor.py
@@ -12,8 +12,8 @@ from autoskillit.cli._hooks import _claude_settings_path, _load_settings_data
 from autoskillit.cli._init_helpers import _KNOWN_SCANNERS, _detect_secret_scanner
 from autoskillit.core import _ROOT_GITIGNORE_ENTRIES, Severity
 from autoskillit.hook_registry import (
-    HOOK_REGISTRY,
     _count_hook_registry_drift,
+    canonical_script_basenames,
     find_broken_hook_scripts,
 )
 
@@ -96,9 +96,7 @@ def _check_hook_registration(settings_path: Path) -> DoctorResult:
         for entry in event_entries
         for hook in entry.get("hooks", [])
     )
-    missing = [
-        script for hdef in HOOK_REGISTRY for script in hdef.scripts if script not in registered
-    ]
+    missing = [script for script in canonical_script_basenames() if script not in registered]
     if missing:
         return DoctorResult(
             severity=Severity.WARNING,
@@ -116,9 +114,7 @@ def _check_hook_registry_drift(settings_path: Path) -> DoctorResult:
     """Compare generate_hooks_json() with what is deployed in settings.json."""
     result = _count_hook_registry_drift(settings_path)
     if result.orphaned > 0:
-        ghost_scripts = sorted(
-            Path(cmd.split()[-1]).name for cmd in result.orphaned_cmds if len(cmd.split()) >= 2
-        )
+        ghost_scripts = sorted(result.orphaned_cmds)
         return DoctorResult(
             Severity.ERROR,
             "hook_registry_drift",

--- a/src/autoskillit/cli/_hooks.py
+++ b/src/autoskillit/cli/_hooks.py
@@ -9,8 +9,10 @@ from autoskillit.core import atomic_write, pkg_root
 from autoskillit.hook_registry import (
     _build_hook_entry,
     _claude_settings_path,  # noqa: F401 — re-exported; cli/__init__ + _stale_check + _init_helpers import from here
-    _is_own_hook as _is_autoskillit_hook_command,
     _load_settings_data,
+)
+from autoskillit.hook_registry import (
+    _is_own_hook as _is_autoskillit_hook_command,
 )
 from autoskillit.hooks import HOOK_REGISTRY
 

--- a/src/autoskillit/cli/_hooks.py
+++ b/src/autoskillit/cli/_hooks.py
@@ -9,6 +9,7 @@ from autoskillit.core import atomic_write, pkg_root
 from autoskillit.hook_registry import (
     _build_hook_entry,
     _claude_settings_path,  # noqa: F401 — re-exported; cli/__init__ + _stale_check + _init_helpers import from here
+    _is_own_hook as _is_autoskillit_hook_command,
     _load_settings_data,
 )
 from autoskillit.hooks import HOOK_REGISTRY
@@ -18,14 +19,6 @@ def _write_settings_data(settings_path: Path, data: dict) -> None:
     """Write settings data back atomically, creating parent dirs if needed."""
     settings_path.parent.mkdir(parents=True, exist_ok=True)
     atomic_write(settings_path, json.dumps(data, indent=2))
-
-
-def _is_autoskillit_hook_command(command: str) -> bool:
-    """Check if a hook command belongs to autoskillit (any format)."""
-    if "autoskillit" in command:
-        return True
-    known_scripts = {s for h in HOOK_REGISTRY for s in h.scripts}
-    return any(command.endswith(script) or f"/{script}" in command for script in known_scripts)
 
 
 def _evict_stale_autoskillit_hooks(settings_path: Path) -> None:

--- a/src/autoskillit/cli/_stale_check.py
+++ b/src/autoskillit/cli/_stale_check.py
@@ -214,6 +214,31 @@ def _verify_update_result(
     return False
 
 
+def _verify_hooks_result(
+    home: Path,
+    state: dict[str, object],
+    settings_path: Path,
+    current: str,
+) -> bool:
+    """Verify that hooks install resolved all drift.
+
+    Returns True if drift is now zero.
+    Returns False if drift persists, writing a hooks_snoozed record.
+    """
+    from autoskillit.hook_registry import _count_hook_registry_drift
+
+    drift = _count_hook_registry_drift(settings_path)
+    if drift.missing == 0 and drift.orphaned == 0:
+        return True
+
+    state["hooks_snoozed"] = {
+        "snoozed_at": datetime.now(UTC).isoformat(),
+        "attempted_version": current,
+    }
+    _write_dismiss_state(home, state)
+    return False
+
+
 def _detect_install_type() -> tuple[str, str | None]:
     """Detect whether autoskillit is installed as an editable or tool install.
 
@@ -318,7 +343,11 @@ def run_stale_check(home: Path | None = None) -> None:
 
     settings_path = _claude_settings_path("user")
     drift = _count_hook_registry_drift(settings_path)
-    if (drift.missing > 0 or drift.orphaned > 0) and not _is_dismissed(state, "hooks", None):
+    if (
+        (drift.missing > 0 or drift.orphaned > 0)
+        and not _is_dismissed(state, "hooks", None)
+        and not _is_snoozed(state, "hooks")
+    ):
         if drift.orphaned > 0:
             prompt_msg = (
                 f"\n\u26a0\ufe0f  {drift.orphaned} orphaned hook entry(ies) in settings.json "
@@ -334,6 +363,8 @@ def run_stale_check(home: Path | None = None) -> None:
         if answer in ("", "y", "yes"):
             with terminal_guard():
                 subprocess.run(["autoskillit", "install"], check=False, env=_skip_env)
+            _verify_hooks_result(_home, state, settings_path, current)
+            return
         else:
             state["hooks"] = {
                 "dismissed_at": datetime.now(UTC).isoformat(),

--- a/src/autoskillit/cli/_stale_check.py
+++ b/src/autoskillit/cli/_stale_check.py
@@ -225,7 +225,11 @@ def _verify_hooks_result(
     Returns True if drift is now zero.
     Returns False if drift persists, writing a hooks_snoozed record.
     """
-    from autoskillit.hook_registry import _count_hook_registry_drift
+    try:
+        from autoskillit.hook_registry import _count_hook_registry_drift
+    except ImportError:
+        logger.debug("hook_registry unavailable — cannot verify hooks result")
+        return False
 
     drift = _count_hook_registry_drift(settings_path)
     if drift.missing == 0 and drift.orphaned == 0:

--- a/src/autoskillit/hook_registry.py
+++ b/src/autoskillit/hook_registry.py
@@ -129,15 +129,32 @@ def _load_settings_data(settings_path: Path) -> dict:
     return {}
 
 
-def _extract_cmds(hooks_dict: dict) -> set[str]:
-    """Extract the set of hook command strings from a hooks dict."""
+def canonical_script_basenames() -> frozenset[str]:
+    """Return the set of all known autoskillit hook script basenames."""
+    return frozenset(s for h in HOOK_REGISTRY for s in h.scripts)
+
+
+def _is_own_hook(command: str) -> bool:
+    """Check if a hook command belongs to autoskillit (any format)."""
+    if "autoskillit" in command:
+        return True
+    known_scripts = canonical_script_basenames()
+    return any(command.endswith(script) or f"/{script}" in command for script in known_scripts)
+
+
+def _extract_script_basenames(hooks_dict: dict) -> set[str]:
+    """Extract autoskillit hook script basenames from a hooks dict.
+
+    Filters to autoskillit-owned commands only, then normalizes
+    to bare script filenames for installation-path-agnostic comparison.
+    """
     return {
-        hook.get("command", "")
+        Path(cmd.split()[-1]).name
         for event_entries in hooks_dict.values()
         if isinstance(event_entries, list)
         for entry in event_entries
         for hook in entry.get("hooks", [])
-        if hook.get("command", "")
+        if (cmd := hook.get("command", "")) and _is_own_hook(cmd)
     }
 
 
@@ -151,13 +168,12 @@ class HookDriftResult(NamedTuple):
 
 def _count_hook_registry_drift(settings_path: Path) -> HookDriftResult:
     """Return bidirectional hook drift counts between canonical and deployed settings.json."""
-    canonical = generate_hooks_json()
     deployed_data = _load_settings_data(settings_path)
-    canonical_cmds = _extract_cmds(canonical.get("hooks", {}))
-    deployed_cmds = _extract_cmds(deployed_data.get("hooks", {}))
-    orphaned = deployed_cmds - canonical_cmds
+    canonical_basenames = canonical_script_basenames()
+    deployed_basenames = _extract_script_basenames(deployed_data.get("hooks", {}))
+    orphaned = deployed_basenames - canonical_basenames
     return HookDriftResult(
-        missing=len(canonical_cmds - deployed_cmds),
+        missing=len(canonical_basenames - deployed_basenames),
         orphaned=len(orphaned),
         orphaned_cmds=frozenset(orphaned),
     )

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -1206,7 +1206,10 @@ def test_count_hook_registry_drift_cross_env_path_mismatch(tmp_path: Path) -> No
     from autoskillit.hook_registry import HOOK_REGISTRY, _count_hook_registry_drift
 
     # Build settings.json with a DIFFERENT path prefix than current pkg_root()
-    foreign_hooks_dir = "/home/user/.local/share/uv/tools/autoskillit/lib/python3.13/site-packages/autoskillit/hooks"
+    foreign_hooks_dir = (
+        "/home/user/.local/share/uv/tools/autoskillit/lib/python3.13"
+        "/site-packages/autoskillit/hooks"
+    )
     by_event: dict[str, list[dict]] = {}
     for hdef in HOOK_REGISTRY:
         hook_commands = [

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -1160,3 +1160,73 @@ def test_check_hook_registry_drift_error_on_orphaned_hooks(tmp_path: Path) -> No
     assert "status_health_guard.py" in result.message, (
         "Error message must name the orphaned script(s)"
     )
+
+
+# T-DRIFT-3: User hooks must not appear as orphans
+def test_count_hook_registry_drift_ignores_user_hooks(tmp_path: Path) -> None:
+    """Non-autoskillit user hooks in settings.json must not be counted as orphaned.
+
+    Regression: _extract_cmds() includes ALL commands without filtering,
+    making user hooks appear as orphans in the deployed - canonical set diff.
+    """
+    from autoskillit.hook_registry import _count_hook_registry_drift, generate_hooks_json
+
+    # Start with all canonical hooks so missing=0
+    canonical_data = generate_hooks_json()
+    # Add non-autoskillit user hooks alongside canonical ones
+    user_hooks = [
+        {"type": "command", "command": "python3 /home/user/my_guard.py"},
+        {"type": "command", "command": 'wsl-notify-send.exe "Done!"'},
+    ]
+    canonical_data["hooks"].setdefault("PreToolUse", []).append(
+        {"matcher": ".*", "hooks": user_hooks}
+    )
+    settings = tmp_path / ".claude" / "settings.json"
+    settings.parent.mkdir()
+    settings.write_text(json.dumps(canonical_data))
+
+    result = _count_hook_registry_drift(settings)
+    assert result.orphaned == 0, (
+        f"User hooks must not be counted as orphaned, got orphaned={result.orphaned}, "
+        f"orphaned_cmds={result.orphaned_cmds}"
+    )
+    assert result.missing == 0, (
+        f"All canonical hooks are deployed, expected missing=0, got {result.missing}"
+    )
+
+
+# T-DRIFT-4: Cross-environment path mismatch must not cause false drift
+def test_count_hook_registry_drift_cross_env_path_mismatch(tmp_path: Path) -> None:
+    """settings.json written by a different install (different pkg_root prefix)
+    must not show drift when all script basenames match.
+
+    Regression: full-path string comparison treats path-prefix differences
+    as drift, even though the same scripts are deployed.
+    """
+    from autoskillit.hook_registry import HOOK_REGISTRY, _count_hook_registry_drift
+
+    # Build settings.json with a DIFFERENT path prefix than current pkg_root()
+    foreign_hooks_dir = "/home/user/.local/share/uv/tools/autoskillit/lib/python3.13/site-packages/autoskillit/hooks"
+    by_event: dict[str, list[dict]] = {}
+    for hdef in HOOK_REGISTRY:
+        hook_commands = [
+            {"type": "command", "command": f"python3 {foreign_hooks_dir}/{script}"}
+            for script in hdef.scripts
+        ]
+        entry: dict = {"hooks": hook_commands}
+        if hdef.event_type != "SessionStart":
+            entry["matcher"] = hdef.matcher
+        by_event.setdefault(hdef.event_type, []).append(entry)
+    data = {"hooks": by_event}
+
+    settings = tmp_path / ".claude" / "settings.json"
+    settings.parent.mkdir()
+    settings.write_text(json.dumps(data))
+
+    result = _count_hook_registry_drift(settings)
+    assert result.orphaned == 0, (
+        f"Path prefix difference must not cause orphaned hooks, got orphaned={result.orphaned}"
+    )
+    assert result.missing == 0, (
+        f"Path prefix difference must not cause missing hooks, got missing={result.missing}"
+    )

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -1166,7 +1166,7 @@ def test_check_hook_registry_drift_error_on_orphaned_hooks(tmp_path: Path) -> No
 def test_count_hook_registry_drift_ignores_user_hooks(tmp_path: Path) -> None:
     """Non-autoskillit user hooks in settings.json must not be counted as orphaned.
 
-    Regression: _extract_cmds() includes ALL commands without filtering,
+    Regression: _extract_script_basenames() includes ALL commands without filtering,
     making user hooks appear as orphans in the deployed - canonical set diff.
     """
     from autoskillit.hook_registry import _count_hook_registry_drift, generate_hooks_json

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -1115,7 +1115,7 @@ def test_count_hook_registry_drift_detects_orphaned_hooks(tmp_path: Path) -> Non
 
     settings = tmp_path / ".claude" / "settings.json"
     settings.parent.mkdir()
-    ghost_cmd = "python3 /path/to/status_health_guard.py"
+    ghost_cmd = "python3 /path/to/autoskillit/hooks/status_health_guard.py"
     data = {
         "hooks": {
             "PreToolUse": [
@@ -1141,7 +1141,7 @@ def test_check_hook_registry_drift_error_on_orphaned_hooks(tmp_path: Path) -> No
 
     settings = tmp_path / ".claude" / "settings.json"
     settings.parent.mkdir()
-    ghost_cmd = "python3 /path/to/status_health_guard.py"
+    ghost_cmd = "python3 /path/to/autoskillit/hooks/status_health_guard.py"
     data = {
         "hooks": {
             "PreToolUse": [

--- a/tests/cli/test_stale_check.py
+++ b/tests/cli/test_stale_check.py
@@ -551,3 +551,57 @@ def test_run_stale_check_dev_mode_editable_install_y_path(
     assert "/home/user/autoskillit" in uv_calls[0]
     # Must NOT use uv tool install --force for editable installs
     assert not any("tool" in str(c) and "install" in str(c) for c in uv_calls)
+
+
+# SC-23: hooks YES-path must write state and not re-prompt on second call
+def test_run_stale_check_hooks_y_path_writes_state_and_returns(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """After answering Y to the hook-drift prompt:
+    1. _write_dismiss_state must be called (dismiss or snooze)
+    2. A second call to run_stale_check() must NOT prompt again
+
+    Regression: the hooks YES-path ran the install subprocess but wrote no state
+    and did not return, causing an infinite prompt loop.
+    """
+    import autoskillit.cli._stale_check as _sc
+
+    monkeypatch.setattr(_sc, "is_dev_mode", lambda home=None: False)
+    monkeypatch.setattr(_sc, "_fetch_latest_version", lambda dev_mode: None)
+    monkeypatch.setattr(_sc.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(_sc.sys.stdout, "isatty", lambda: True)
+    monkeypatch.delenv("CLAUDECODE", raising=False)
+    monkeypatch.delenv("AUTOSKILLIT_SKIP_STALE_CHECK", raising=False)
+
+    written_states: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        _sc, "_write_dismiss_state", lambda home, state: written_states.append(dict(state))
+    )
+    monkeypatch.setattr(
+        "autoskillit.cli._count_hook_registry_drift",
+        lambda settings_path: HookDriftResult(missing=3, orphaned=0),
+    )
+
+    def fake_run(cmd: list[str], **kwargs: object) -> object:
+        return type("R", (), {"returncode": 0})()
+
+    monkeypatch.setattr(_sc.subprocess, "run", fake_run)
+
+    input_calls = []
+
+    def fake_input(prompt: str = "") -> str:
+        input_calls.append(prompt)
+        return "y"
+
+    monkeypatch.setattr("builtins.input", fake_input)
+
+    # First call: should prompt and write state
+    _sc.run_stale_check(home=tmp_path)
+
+    assert len(input_calls) == 1, (
+        f"Expected exactly 1 input prompt on first call, got {len(input_calls)}"
+    )
+    assert len(written_states) >= 1, (
+        "hooks YES-path must write dismiss/snooze state after install, "
+        f"but _write_dismiss_state was called {len(written_states)} times"
+    )

--- a/tests/cli/test_stale_check.py
+++ b/tests/cli/test_stale_check.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+import json
 import subprocess
 import sys
 from datetime import UTC, datetime, timedelta
@@ -574,9 +575,15 @@ def test_run_stale_check_hooks_y_path_writes_state_and_returns(
     monkeypatch.delenv("AUTOSKILLIT_SKIP_STALE_CHECK", raising=False)
 
     written_states: list[dict[str, object]] = []
-    monkeypatch.setattr(
-        _sc, "_write_dismiss_state", lambda home, state: written_states.append(dict(state))
-    )
+
+    def _tracking_write(home: Path, state: dict[str, object]) -> None:
+        written_states.append(dict(state))
+        # Actually persist so _read_dismiss_state picks up state on second call
+        state_file = home / ".autoskillit" / "update_check.json"
+        state_file.parent.mkdir(parents=True, exist_ok=True)
+        state_file.write_text(json.dumps(state))
+
+    monkeypatch.setattr(_sc, "_write_dismiss_state", _tracking_write)
     monkeypatch.setattr(
         "autoskillit.cli._count_hook_registry_drift",
         lambda settings_path: HookDriftResult(missing=3, orphaned=0),
@@ -604,4 +611,12 @@ def test_run_stale_check_hooks_y_path_writes_state_and_returns(
     assert len(written_states) >= 1, (
         "hooks YES-path must write dismiss/snooze state after install, "
         f"but _write_dismiss_state was called {len(written_states)} times"
+    )
+
+    # Second call: must NOT prompt again (snooze state persisted to disk)
+    prompt_count_before = len(input_calls)
+    _sc.run_stale_check(home=tmp_path)
+    assert len(input_calls) == prompt_count_before, (
+        "A second call to run_stale_check() must NOT prompt again, "
+        f"but {len(input_calls) - prompt_count_before} new prompt(s) appeared"
     )

--- a/tests/test_hook_registry.py
+++ b/tests/test_hook_registry.py
@@ -1,0 +1,81 @@
+"""Tests for hook_registry.py — L0 hook identity model."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from autoskillit.hook_registry import (
+    HOOK_REGISTRY,
+    _extract_script_basenames,
+    _is_own_hook,
+    canonical_script_basenames,
+    generate_hooks_json,
+)
+
+
+# HR-FILTER-1: command with "autoskillit" substring -> True
+def test_is_own_hook_autoskillit_substring() -> None:
+    assert _is_own_hook("python3 /path/to/autoskillit/hooks/quota_check.py") is True
+
+
+# HR-FILTER-2: command ending with known script basename -> True
+def test_is_own_hook_known_basename() -> None:
+    assert _is_own_hook("python3 /some/other/path/quota_check.py") is True
+
+
+# HR-FILTER-3: unrelated command -> False
+def test_is_own_hook_unrelated_command() -> None:
+    assert _is_own_hook('wsl-notify-send.exe "Done!"') is False
+    assert _is_own_hook("python3 /home/user/my_guard.py") is False
+
+
+# HR-FILTER-4: known basename with different path prefix -> True
+def test_is_own_hook_different_prefix() -> None:
+    assert _is_own_hook(
+        "python3 /home/user/.local/share/uv/tools/lib/hooks/skill_cmd_check.py"
+    ) is True
+
+
+# HR-BASENAME-1: canonical hooks dict -> returns set of bare filenames
+def test_extract_script_basenames_canonical() -> None:
+    canonical = generate_hooks_json()
+    result = _extract_script_basenames(canonical.get("hooks", {}))
+    expected = canonical_script_basenames()
+    assert result == expected
+
+
+# HR-BASENAME-2: different path prefixes -> returns same basenames
+def test_extract_script_basenames_different_prefix() -> None:
+    foreign_dir = "/home/user/.local/share/uv/tools/autoskillit/lib/python3.13/site-packages/autoskillit/hooks"
+    by_event: dict[str, list[dict]] = {}
+    for hdef in HOOK_REGISTRY:
+        hook_commands = [
+            {"type": "command", "command": f"python3 {foreign_dir}/{script}"}
+            for script in hdef.scripts
+        ]
+        entry: dict = {"hooks": hook_commands}
+        if hdef.event_type != "SessionStart":
+            entry["matcher"] = hdef.matcher
+        by_event.setdefault(hdef.event_type, []).append(entry)
+
+    result = _extract_script_basenames(by_event)
+    assert result == canonical_script_basenames()
+
+
+# HR-BASENAME-3: mixed autoskillit + user hooks -> returns only autoskillit basenames
+def test_extract_script_basenames_filters_user_hooks() -> None:
+    canonical = generate_hooks_json()
+    hooks = canonical["hooks"]
+    hooks.setdefault("PreToolUse", []).append(
+        {
+            "matcher": ".*",
+            "hooks": [
+                {"type": "command", "command": "python3 /home/user/my_guard.py"},
+                {"type": "command", "command": 'wsl-notify-send.exe "Done!"'},
+            ],
+        }
+    )
+    result = _extract_script_basenames(hooks)
+    assert result == canonical_script_basenames()
+    assert "my_guard.py" not in result

--- a/tests/test_hook_registry.py
+++ b/tests/test_hook_registry.py
@@ -45,7 +45,10 @@ def test_extract_script_basenames_canonical() -> None:
 
 # HR-BASENAME-2: different path prefixes -> returns same basenames
 def test_extract_script_basenames_different_prefix() -> None:
-    foreign_dir = "/home/user/.local/share/uv/tools/autoskillit/lib/python3.13/site-packages/autoskillit/hooks"
+    foreign_dir = (
+        "/home/user/.local/share/uv/tools/autoskillit/lib/python3.13"
+        "/site-packages/autoskillit/hooks"
+    )
     by_event: dict[str, list[dict]] = {}
     for hdef in HOOK_REGISTRY:
         hook_commands = [

--- a/tests/test_hook_registry.py
+++ b/tests/test_hook_registry.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-import json
-from pathlib import Path
-
 from autoskillit.hook_registry import (
     HOOK_REGISTRY,
     _extract_script_basenames,
@@ -32,9 +29,10 @@ def test_is_own_hook_unrelated_command() -> None:
 
 # HR-FILTER-4: known basename with different path prefix -> True
 def test_is_own_hook_different_prefix() -> None:
-    assert _is_own_hook(
-        "python3 /home/user/.local/share/uv/tools/lib/hooks/skill_cmd_check.py"
-    ) is True
+    assert (
+        _is_own_hook("python3 /home/user/.local/share/uv/tools/lib/hooks/skill_cmd_check.py")
+        is True
+    )
 
 
 # HR-BASENAME-1: canonical hooks dict -> returns set of bare filenames


### PR DESCRIPTION
## Summary

Three compounding defects in the hook drift detection and stale-check prompt system create an inescapable infinite prompt loop after `autoskillit install`. The architectural weakness is twofold: (1) hook identity comparison uses full absolute paths rather than stable basename identifiers, creating environment-dependent fragility; (2) the interactive prompt flow lacks the verify-persist-return pattern that the binary-version path implements correctly. The fix introduces a **basename-normalized hook identity model** in L0 and a **verified prompt action pattern** in the stale-check flow, making the entire class of bugs structurally impossible.

## Architecture Impact

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;

    subgraph Tests ["TESTS"]
        direction LR
        T_HR["★ test_hook_registry<br/>━━━━━━━━━━<br/>NEW — unit tests for<br/>hook identity model"]
        T_SC["● test_stale_check<br/>━━━━━━━━━━<br/>Stale-check + drift<br/>YES-path tests"]
        T_DR["● test_doctor<br/>━━━━━━━━━━<br/>Doctor hook-health<br/>check tests"]
    end

    subgraph L3_CLI ["L3 — CLI"]
        direction LR
        APP["cli/app.py<br/>━━━━━━━━━━<br/>CLI entry point<br/>dispatches commands"]
        HOOKS["● cli/_hooks.py<br/>━━━━━━━━━━<br/>Hook sync to<br/>settings.json"]
        STALE["● cli/_stale_check.py<br/>━━━━━━━━━━<br/>Version + drift<br/>check at startup"]
        DOCTOR["● cli/_doctor.py<br/>━━━━━━━━━━<br/>12 health checks<br/>including hook drift"]
        CLI_INIT["cli/__init__.py<br/>━━━━━━━━━━<br/>Re-exports:<br/>HookDriftResult"]
    end

    subgraph L3_SRV ["L3 — SERVER"]
        direction LR
        SRV_HELP["server/helpers.py<br/>━━━━━━━━━━<br/>Deferred hook<br/>diagnostic warning"]
    end

    subgraph L0 ["L0 — FOUNDATION"]
        direction LR
        HR["● hook_registry.py<br/>━━━━━━━━━━<br/>HookDef, HOOK_REGISTRY<br/>generate_hooks_json<br/>Fan-in: 6"]
        HOOKS_PKG["hooks/__init__.py<br/>━━━━━━━━━━<br/>Re-exports HOOK_REGISTRY<br/>HookDef, generate_hooks_json"]
        CORE["core/<br/>━━━━━━━━━━<br/>pkg_root, get_logger<br/>atomic_write, Severity<br/>Fan-in: high"]
    end

    %% === TEST → PRODUCTION DEPENDENCIES === %%
    T_HR -->|"imports 5 symbols"| HR
    T_SC -->|"imports HookDriftResult"| HR
    T_SC -->|"imports _stale_check module"| STALE
    T_SC -->|"imports cli namespace"| CLI_INIT
    T_DR -->|"imports cli namespace"| CLI_INIT

    %% === L3 CLI INTERNAL WIRING === %%
    APP -->|"deferred: run_stale_check()"| STALE
    APP -->|"deferred: run_doctor()"| DOCTOR
    CLI_INIT -->|"re-exports HookDriftResult"| HR
    CLI_INIT -->|"re-exports _check_hook_health"| DOCTOR

    %% === L3 CLI → L0 DEPENDENCIES === %%
    HOOKS -->|"_build_hook_entry,<br/>_claude_settings_path,<br/>_load_settings_data,<br/>_is_own_hook"| HR
    HOOKS -->|"HOOK_REGISTRY"| HOOKS_PKG
    HOOKS -->|"atomic_write, pkg_root"| CORE

    STALE -->|"deferred: _count_hook_registry_drift"| HR
    STALE -->|"deferred: _claude_settings_path"| HOOKS
    STALE -->|"get_logger, pkg_root"| CORE

    DOCTOR -->|"_count_hook_registry_drift,<br/>canonical_script_basenames,<br/>find_broken_hook_scripts"| HR
    DOCTOR -->|"_claude_settings_path,<br/>_load_settings_data"| HOOKS
    DOCTOR -->|"Severity, _ROOT_GITIGNORE_ENTRIES"| CORE

    %% === L3 SERVER → L0 === %%
    SRV_HELP -.->|"deferred: _claude_settings_path,<br/>_count_hook_registry_drift,<br/>find_broken_hook_scripts"| HR

    %% === L0 INTERNAL === %%
    HR -->|"pkg_root"| CORE
    HOOKS_PKG -->|"re-exports"| HR

    %% CLASS ASSIGNMENTS %%
    class APP,HOOKS,STALE,DOCTOR,CLI_INIT cli;
    class SRV_HELP phase;
    class HR stateNode;
    class HOOKS_PKG,CORE handler;
    class T_HR newComponent;
    class T_SC,T_DR output;
```

Closes #680

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260408-183501-840011/.autoskillit/temp/rectify/rectify_stale-hooks-infinite-prompt_2026-04-08_190500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| investigate | 24 | 7.9k | 507.9k | 46.0k | 1 | 6m 5s |
| rectify | 11.3k | 21.1k | 948.9k | 77.4k | 1 | 9m 51s |
| dry_walkthrough | 24 | 16.1k | 1.5M | 92.5k | 1 | 5m 37s |
| implement | 73 | 25.6k | 5.5M | 103.7k | 1 | 10m 4s |
| prepare_pr | 9 | 5.8k | 137.1k | 31.3k | 1 | 1m 40s |
| run_arch_lenses | 44 | 17.4k | 1.1M | 128.8k | 3 | 7m 16s |
| compose_pr | 9 | 4.0k | 153.6k | 22.1k | 1 | 1m 5s |
| **Total** | 11.5k | 97.9k | 9.8M | 501.7k | | 41m 41s |