### PR TITLE
Rectify: Terminal Guard Reset Specification

### DIFF
--- a/src/autoskillit/cli/_terminal.py
+++ b/src/autoskillit/cli/_terminal.py
@@ -11,10 +11,12 @@ create_temp_io() context manager.
 from __future__ import annotations
 
 import contextlib
+import enum
 import os
 import sys
 import termios
 from collections.abc import Generator
+from typing import NamedTuple
 
 from autoskillit.core import get_logger
 
@@ -22,22 +24,57 @@ _log = get_logger(__name__)
 
 _KBP_TERMINALS = frozenset({"kitty", "WezTerm", "ghostty", "iTerm.app"})
 
-# Base VT100 reset — universally safe no-ops on all terminal emulators.
-_BASE_RESET = (
-    "\033[?1049l"  # exit alternate screen buffer (defensive)
-    "\033[?2004l"  # disable bracketed paste mode
-    "\033[?1000l"  # disable normal mouse tracking
-    "\033[?1002l"  # disable button-event mouse tracking
-    "\033[?1003l"  # disable any-event mouse tracking
-    "\033[?1006l"  # disable SGR extended mouse protocol
-    "\033[?1004l"  # disable focus in/out events
-    "\033[?2026l"  # disable synchronized output
-    "\033[?1l"  # disable application cursor keys (DECCKM)
-    "\033>"  # numeric keypad mode (DECKPNM)
-    "\033[!p"  # DECSTR soft reset (18 DEC attributes, no screen clear)
-    "\033[0m"  # reset SGR attributes
-    "\033[?25h"  # show cursor (DECTCEM)
+
+class ResetLayer(enum.StrEnum):
+    """Terminal state layers that must be fully reset on exit.
+
+    Each layer represents a category of terminal state that Claude Code's
+    Ink TUI may modify during its session. The terminal_guard() context
+    manager must emit at least one reset sequence per layer.
+
+    Reference: ECMA-48 (5th ed.), xterm ctlseqs (Thomas Dickey), VT510 spec.
+    """
+
+    SCREEN_BUFFER = "screen_buffer"
+    PRIVATE_MODE = "private_mode"
+    TERMINAL_STATE = "terminal_state"
+    CONTENT = "content"
+
+
+class ResetEntry(NamedTuple):
+    """A single VT100 reset sequence with its layer classification."""
+
+    sequence: str
+    name: str
+    layer: ResetLayer
+
+
+_RESET_SPEC: tuple[ResetEntry, ...] = (
+    # --- SCREEN_BUFFER layer ---
+    ResetEntry("\033[?1049l", "rmcup", ResetLayer.SCREEN_BUFFER),
+    ResetEntry("\033[?2026l", "sync_output_off", ResetLayer.SCREEN_BUFFER),
+    # --- PRIVATE_MODE layer ---
+    ResetEntry("\033[?2004l", "bracketed_paste_off", ResetLayer.PRIVATE_MODE),
+    ResetEntry("\033[?1000l", "mouse_normal_off", ResetLayer.PRIVATE_MODE),
+    ResetEntry("\033[?1002l", "mouse_button_off", ResetLayer.PRIVATE_MODE),
+    ResetEntry("\033[?1003l", "mouse_any_off", ResetLayer.PRIVATE_MODE),
+    ResetEntry("\033[?1006l", "mouse_sgr_off", ResetLayer.PRIVATE_MODE),
+    ResetEntry("\033[?1004l", "focus_events_off", ResetLayer.PRIVATE_MODE),
+    ResetEntry("\033[?1l", "decckm_off", ResetLayer.PRIVATE_MODE),
+    # --- TERMINAL_STATE layer ---
+    ResetEntry("\033>", "deckpnm", ResetLayer.TERMINAL_STATE),
+    ResetEntry("\033[r", "decstbm_reset", ResetLayer.TERMINAL_STATE),
+    ResetEntry("\033[!p", "decstr", ResetLayer.TERMINAL_STATE),
+    ResetEntry("\033(B", "g0_charset_ascii", ResetLayer.TERMINAL_STATE),
+    ResetEntry("\033[0m", "sgr_reset", ResetLayer.TERMINAL_STATE),
+    ResetEntry("\033[?25h", "dectcem_show_cursor", ResetLayer.TERMINAL_STATE),
+    # --- CONTENT layer (must be last) ---
+    ResetEntry("\033[H", "cursor_home", ResetLayer.CONTENT),
+    ResetEntry("\033[J", "erase_to_end", ResetLayer.CONTENT),
 )
+
+# Derived constant — computed from the spec, not hand-maintained.
+_BASE_RESET = "".join(entry.sequence for entry in _RESET_SPEC)
 
 # Kitty keyboard protocol teardown — NOT universally safe. JediTerm
 # (JetBrains IDEs) echoes literal chars from these sequences

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -75,6 +75,7 @@ SINGLETON_ALLOWED_MODULES: frozenset[str] = frozenset(
         "settings",  # config/settings.py: _CONFIG_SCHEMA = _build_config_schema()
         "headless",  # execution/headless.py: _OUTPUT_PATH_TOKENS = _build_path_token_set()
         "_stale_check",  # cli/_stale_check.py: _DISMISS_WINDOW = timedelta(hours=12)
+        "_terminal",  # cli/_terminal.py: _BASE_RESET = "".join(...) derived from _RESET_SPEC
     }
 )
 _SINGLETON_SAFE_CALL_NAMES: frozenset[str] = frozenset(

--- a/tests/cli/test_terminal.py
+++ b/tests/cli/test_terminal.py
@@ -12,6 +12,8 @@ from unittest.mock import patch
 
 import pytest
 
+from autoskillit.cli._terminal import _RESET_SPEC
+
 
 class TestTerminalGuardTTYRestore:
     """terminal_guard() saves and restores termios attrs in all exit paths."""
@@ -81,8 +83,9 @@ class TestTerminalGuardTTYRestore:
 
             mock_termios.tcsetattr.assert_called_once_with(0, termios.TCSAFLUSH, fake_attrs)
 
-    def test_emits_vt100_reset_sequences_on_normal_exit(self):
-        """Escape sequences are written to stdout after normal subprocess exit."""
+    @pytest.mark.parametrize("entry", _RESET_SPEC, ids=lambda e: e.name)
+    def test_emits_all_spec_sequences_on_normal_exit(self, entry):
+        """Every sequence in _RESET_SPEC is emitted by terminal_guard() on normal exit."""
         from autoskillit.cli._terminal import terminal_guard
 
         with (
@@ -97,20 +100,13 @@ class TestTerminalGuardTTYRestore:
                 pass
 
             written = "".join(c.args[0] for c in mock_stdout.write.call_args_list if c.args)
-            assert "\033[?1049l" in written, "Must exit alternate screen buffer"
-            assert "\033[?1l" in written, "Must reset application cursor keys"
-            assert "\033>" in written, "Must reset application keypad mode"
-            assert "\033[?2004l" in written, "Must disable bracketed paste mode"
-            assert "\033[?1000l" in written, "Must disable normal mouse tracking"
-            assert "\033[?1002l" in written, "Must disable button-event mouse tracking"
-            assert "\033[?1003l" in written, "Must disable any-event mouse tracking"
-            assert "\033[?1006l" in written, "Must disable SGR extended mouse protocol"
-            assert "\033[?1004l" in written, "Must disable focus in/out events"
-            assert "\033[?2026l" in written, "Must disable synchronized output"
-            assert "\033[!p" in written, "Must emit DECSTR soft reset"
+            assert entry.sequence in written, (
+                f"Must emit {entry.name} ({entry.sequence!r}) — layer: {entry.layer.value}"
+            )
 
-    def test_emits_vt100_reset_sequences_on_exception(self):
-        """Escape sequences are written even when subprocess raises."""
+    @pytest.mark.parametrize("entry", _RESET_SPEC, ids=lambda e: e.name)
+    def test_emits_all_spec_sequences_on_exception(self, entry):
+        """Every sequence in _RESET_SPEC is emitted by terminal_guard() on exception."""
         from autoskillit.cli._terminal import terminal_guard
 
         with (
@@ -126,12 +122,9 @@ class TestTerminalGuardTTYRestore:
                     raise KeyboardInterrupt
 
             written = "".join(c.args[0] for c in mock_stdout.write.call_args_list if c.args)
-            assert "\033[?1049l" in written, "Must exit alternate screen buffer"
-            assert "\033[?1l" in written
-            assert "\033[?2004l" in written, "Must disable bracketed paste mode"
-            assert "\033[?1003l" in written, "Must disable any-event mouse tracking"
-            assert "\033[?2026l" in written, "Must disable synchronized output"
-            assert "\033[!p" in written, "Must emit DECSTR soft reset"
+            assert entry.sequence in written, (
+                f"Must emit {entry.name} ({entry.sequence!r}) — layer: {entry.layer.value}"
+            )
 
     def test_noop_in_non_tty_environment(self):
         """When stdin is not a TTY, tcgetattr and tcsetattr are never called."""
@@ -358,6 +351,66 @@ class TestTerminalGuardTTYRestore:
             kitty_drain_pos = written.index("\033[<99u")
             assert decstr_pos < kitty_hard_pos, "Kitty hard-disable must follow DECSTR"
             assert decstr_pos < kitty_drain_pos, "Kitty stack drain must follow DECSTR"
+
+
+class TestResetSpecificationCompleteness:
+    """Bidirectional completeness tests for the terminal reset specification.
+
+    Follows the GATED_TOOLS pattern: a structured specification is tested
+    via set operations to detect missing, extra, or duplicate entries.
+    """
+
+    def test_reset_spec_covers_all_layers(self):
+        """Every ResetLayer enum member must have >= 1 entry in _RESET_SPEC."""
+        from autoskillit.cli._terminal import _RESET_SPEC, ResetLayer
+
+        covered_layers = {entry.layer for entry in _RESET_SPEC}
+        missing = set(ResetLayer) - covered_layers
+        assert not missing, (
+            f"ResetLayer members {missing} have no entry in _RESET_SPEC. "
+            "Every layer must have at least one reset sequence."
+        )
+
+    def test_base_reset_matches_spec_bidirectional(self):
+        """_BASE_RESET must contain exactly the sequences in _RESET_SPEC."""
+        import re
+
+        from autoskillit.cli._terminal import _BASE_RESET, _RESET_SPEC
+
+        spec_sequences = {entry.sequence for entry in _RESET_SPEC}
+        for seq in spec_sequences:
+            assert seq in _BASE_RESET, f"Spec sequence {seq!r} missing from _BASE_RESET"
+
+        # Reverse: parse _BASE_RESET and verify every sequence is in the spec.
+        found = set(re.findall(r"\033(?:[\[\(!][^a-zA-Z]*[a-zA-Z]|[>-~])", _BASE_RESET))
+        unregistered = found - spec_sequences
+        assert not unregistered, (
+            f"Sequences in _BASE_RESET not registered in _RESET_SPEC: {unregistered}"
+        )
+
+    def test_content_layer_sequences_are_last(self):
+        """CONTENT layer sequences must follow all other layers in _BASE_RESET."""
+        from autoskillit.cli._terminal import _BASE_RESET, _RESET_SPEC, ResetLayer
+
+        content_seqs = [e.sequence for e in _RESET_SPEC if e.layer == ResetLayer.CONTENT]
+        other_seqs = [e.sequence for e in _RESET_SPEC if e.layer != ResetLayer.CONTENT]
+
+        for content_seq in content_seqs:
+            content_pos = _BASE_RESET.index(content_seq)
+            for other_seq in other_seqs:
+                other_pos = _BASE_RESET.index(other_seq)
+                assert other_pos < content_pos, (
+                    f"CONTENT sequence {content_seq!r} must follow "
+                    f"non-CONTENT sequence {other_seq!r}"
+                )
+
+    def test_reset_spec_has_no_duplicate_sequences(self):
+        """Each escape sequence must appear exactly once in _RESET_SPEC."""
+        from autoskillit.cli._terminal import _RESET_SPEC
+
+        sequences = [e.sequence for e in _RESET_SPEC]
+        duplicates = [s for s in sequences if sequences.count(s) > 1]
+        assert not duplicates, f"Duplicate sequences in _RESET_SPEC: {set(duplicates)}"
 
 
 class TestCookTerminalGuard:


### PR DESCRIPTION
## Summary

`_BASE_RESET` in `src/autoskillit/cli/_terminal.py` is a raw concatenated string of 13 VT100 escape sequences with no formal specification or layer taxonomy. Tests verify only what the string currently contains (implementation-driven), not what a complete terminal reset should contain (specification-driven). This allowed three sequences to be missing (`\033[r`, `\033(B`, `\033[H\033[J`) and two existing sequences (`\033[0m`, `\033[?25h`) to have zero test assertions — all undetectable by the current test structure.

The architectural fix replaces the raw string with a **structured specification** — a typed tuple of `ResetEntry` named tuples categorized by layer — and adds **bidirectional completeness tests** that detect both missing sequences and uncovered layers. This follows the proven `GATED_TOOLS` + `test_all_mcp_tools_are_registered` pattern already used for MCP tool completeness in this codebase.

## Architecture Impact

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START(["cook() / app._launch_cook_session()"])

    subgraph Spec ["● INIT_PRESERVE: Structured Reset Specification"]
        direction TB
        LAYER["● ResetLayer StrEnum<br/>━━━━━━━━━━<br/>SCREEN_BUFFER<br/>PRIVATE_MODE<br/>TERMINAL_STATE<br/>CONTENT"]
        ENTRY["● ResetEntry NamedTuple<br/>━━━━━━━━━━<br/>sequence: str<br/>name: str<br/>layer: ResetLayer"]
        RSPEC["● _RESET_SPEC<br/>━━━━━━━━━━<br/>17 entries across 4 layers<br/>Ordered: buffer → private → state → content"]
    end

    subgraph Derived ["● DERIVED: Computed Constants"]
        direction TB
        BRESET["● _BASE_RESET<br/>━━━━━━━━━━<br/>= join entry.sequence for entry in _RESET_SPEC<br/>Never hand-maintained"]
        KRESET["_KITTY_RESET<br/>━━━━━━━━━━<br/>KBP teardown — conditional on<br/>KITTY_WINDOW_ID or TERM_PROGRAM"]
    end

    subgraph Guard ["● terminal_guard() Context Manager"]
        direction TB
        TTY_CHECK{"sys.stdin.isatty()?"}
        CAPTURE["INIT_ONLY: Capture State<br/>━━━━━━━━━━<br/>fd = stdin.fileno()<br/>old_settings = tcgetattr(fd)"]
        NOOP["No-Op Path<br/>━━━━━━━━━━<br/>fd = None<br/>Non-TTY / CI / pipes"]
        YIELD["yield — subprocess runs<br/>━━━━━━━━━━<br/>No entry-side sequences emitted<br/>Subprocess owns alt-screen entry"]
        RESTORE["Restore: tcsetattr<br/>━━━━━━━━━━<br/>TCSAFLUSH, old_settings<br/>Kernel TTY discipline reset"]
        FALLBACK["Fallback: stty sane<br/>━━━━━━━━━━<br/>On tcsetattr termios.error"]
        EMIT["Emit _BASE_RESET to stdout<br/>━━━━━━━━━━<br/>All 17 sequences in spec order<br/>+ conditional _KITTY_RESET"]
    end

    subgraph Layers ["● MUTABLE: Terminal Emulator State Layers"]
        direction TB
        L_SCREEN["SCREEN_BUFFER<br/>━━━━━━━━━━<br/>rmcup, sync_output_off"]
        L_PRIV["PRIVATE_MODE<br/>━━━━━━━━━━<br/>bracketed_paste, mouse×4<br/>focus_events, decckm"]
        L_STATE["TERMINAL_STATE<br/>━━━━━━━━━━<br/>deckpnm, decstbm_reset<br/>decstr, g0_charset_ascii<br/>sgr_reset, dectcem_show_cursor"]
        L_CONTENT["CONTENT (must be last)<br/>━━━━━━━━━━<br/>cursor_home, erase_to_end"]
    end

    subgraph Tests ["● Validation Gates (Bidirectional Completeness)"]
        direction TB
        G_COVER["● test_reset_spec_covers_all_layers<br/>━━━━━━━━━━<br/>set(ResetLayer) - covered = empty"]
        G_BIDIR["● test_base_reset_matches_spec_bidirectional<br/>━━━━━━━━━━<br/>Forward: every spec seq in _BASE_RESET<br/>Reverse: every parsed seq in spec"]
        G_ORDER["● test_content_layer_sequences_are_last<br/>━━━━━━━━━━<br/>CONTENT pos > all other pos"]
        G_DEDUP["● test_reset_spec_has_no_duplicate_sequences<br/>━━━━━━━━━━<br/>len(seqs) == len(set(seqs))"]
        G_PARAM["● test_emits_all_spec_sequences (parametrize)<br/>━━━━━━━━━━<br/>Normal exit + exception paths"]
        G_SINGLE["● SINGLETON_ALLOWED_MODULES<br/>━━━━━━━━━━<br/>_terminal added for derived _BASE_RESET"]
    end

    START --> TTY_CHECK
    TTY_CHECK -- "Yes" --> CAPTURE
    TTY_CHECK -- "No" --> NOOP
    CAPTURE --> YIELD
    NOOP --> YIELD

    LAYER --> ENTRY
    ENTRY --> RSPEC
    RSPEC --> BRESET

    YIELD -- "finally (any exit path)" --> RESTORE
    RESTORE -- "termios.error" --> FALLBACK
    RESTORE --> EMIT
    FALLBACK --> EMIT
    BRESET --> EMIT

    EMIT --> L_SCREEN
    L_SCREEN --> L_PRIV
    L_PRIV --> L_STATE
    L_STATE --> L_CONTENT

    RSPEC --> G_COVER
    RSPEC --> G_BIDIR
    RSPEC --> G_ORDER
    RSPEC --> G_DEDUP
    BRESET --> G_BIDIR
    RSPEC --> G_PARAM
    BRESET --> G_SINGLE

    END([Terminal Clean])
    L_CONTENT --> END

    %% CLASS ASSIGNMENTS %%
    class LAYER,ENTRY,RSPEC stateNode;
    class BRESET,KRESET output;
    class TTY_CHECK phase;
    class CAPTURE detector;
    class NOOP gap;
    class YIELD phase;
    class RESTORE,FALLBACK handler;
    class EMIT handler;
    class L_SCREEN,L_PRIV,L_STATE,L_CONTENT phase;
    class G_COVER,G_BIDIR,G_ORDER,G_DEDUP,G_PARAM,G_SINGLE detector;
    class START,END terminal;
```

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START: CLI caller invokes<br/>terminal_guard])
    COMPLETE([COMPLETE: Terminal<br/>state restored])
    ERROR([ERROR: OSError<br/>silently caught])

    subgraph Callers ["CLI Callers (unchanged context)"]
        direction LR
        COOK["_cook.py:_run_cook_session<br/>━━━━━━━━━━<br/>with terminal_guard:<br/>  subprocess.run"]
        APP["app.py:_launch_cook_session<br/>━━━━━━━━━━<br/>with terminal_guard:<br/>  subprocess.run"]
        STALE["_stale_check.py:run_stale_check<br/>━━━━━━━━━━<br/>with terminal_guard:<br/>  uv tool install/upgrade"]
    end

    subgraph EntryPhase ["Phase 1: Entry — TTY Detection"]
        direction TB
        ISATTY{"stdin.isatty?"}
        GETATTR["termios.tcgetattr(fd)<br/>━━━━━━━━━━<br/>saves kernel TTY attrs"]
        GETATTR_ERR{"tcgetattr<br/>raises?"}
    end

    subgraph YieldPhase ["Phase 2: Yield — Subprocess Owns Terminal"]
        direction TB
        YIELD["yield<br/>━━━━━━━━━━<br/>Subprocess runs<br/>No entry-side sequences<br/>emitted by guard"]
    end

    subgraph RestorePhase ["Phase 3: finally — Termios Restore"]
        direction TB
        HAS_SAVED{"fd + old_settings<br/>saved?"}
        TCSETATTR["termios.tcsetattr<br/>━━━━━━━━━━<br/>TCSAFLUSH restores<br/>saved kernel attrs"]
        TCSET_ERR{"tcsetattr<br/>raises?"}
        STTY["os.system<br/>━━━━━━━━━━<br/>stty sane 2>/dev/null<br/>last-resort fallback"]
    end

    subgraph EmitPhase ["Phase 4: finally — VT100 Reset Emission"]
        direction TB
        HAS_FD{"fd acquired?"}
        EMIT_BASE["● stdout.write _BASE_RESET<br/>━━━━━━━━━━<br/>Derived from _RESET_SPEC:<br/>17 sequences across 4 layers"]
        KBP_CHECK{"KITTY_WINDOW_ID or<br/>TERM_PROGRAM in<br/>KBP terminals?"}
        EMIT_KITTY["stdout.write _KITTY_RESET<br/>━━━━━━━━━━<br/>hard-disable + drain stack"]
        FLUSH["stdout.flush<br/>━━━━━━━━━━<br/>Ensure all sequences<br/>reach terminal"]
    end

    subgraph SpecStructure ["● Specification Structure (modified)"]
        direction TB
        LAYERS["● ResetLayer StrEnum<br/>━━━━━━━━━━<br/>SCREEN_BUFFER<br/>PRIVATE_MODE<br/>TERMINAL_STATE<br/>CONTENT"]
        ENTRIES["● ResetEntry NamedTuple<br/>━━━━━━━━━━<br/>sequence + name + layer"]
        SPEC["● _RESET_SPEC tuple<br/>━━━━━━━━━━<br/>17 entries, ordered:<br/>buffer → mode → state → content"]
        DERIVED["● _BASE_RESET<br/>━━━━━━━━━━<br/>= join(e.sequence<br/>  for e in _RESET_SPEC)"]
    end

    %% FLOW: Callers → Entry %%
    COOK --> START
    APP --> START
    STALE --> START

    %% FLOW: Entry Phase %%
    START --> ISATTY
    ISATTY -->|"True"| GETATTR
    ISATTY -->|"False (CI/pipes)"| YIELD
    GETATTR --> GETATTR_ERR
    GETATTR_ERR -->|"No"| YIELD
    GETATTR_ERR -->|"Yes: termios.error<br/>OSError, TypeError"| YIELD

    %% FLOW: Yield → finally %%
    YIELD -->|"normal exit /<br/>exception /<br/>KeyboardInterrupt /<br/>SystemExit"| HAS_SAVED

    %% FLOW: Termios Restore %%
    HAS_SAVED -->|"Yes"| TCSETATTR
    HAS_SAVED -->|"No (non-TTY or<br/>tcgetattr failed)"| HAS_FD
    TCSETATTR --> TCSET_ERR
    TCSET_ERR -->|"No"| HAS_FD
    TCSET_ERR -->|"Yes: termios.error"| STTY
    STTY --> HAS_FD

    %% FLOW: VT100 Emission %%
    HAS_FD -->|"Yes"| EMIT_BASE
    HAS_FD -->|"No"| COMPLETE
    EMIT_BASE --> KBP_CHECK
    KBP_CHECK -->|"Yes"| EMIT_KITTY
    KBP_CHECK -->|"No"| FLUSH
    EMIT_KITTY --> FLUSH
    FLUSH --> COMPLETE
    FLUSH -.->|"OSError"| ERROR
    ERROR --> COMPLETE

    %% FLOW: Spec reads %%
    LAYERS -->|"classifies"| ENTRIES
    ENTRIES -->|"populates"| SPEC
    SPEC -->|"derives"| DERIVED
    DERIVED -.->|"read by"| EMIT_BASE

    %% CLASS ASSIGNMENTS %%
    class START,COMPLETE,ERROR terminal;
    class COOK,APP,STALE cli;
    class ISATTY,GETATTR_ERR,HAS_SAVED,TCSET_ERR,HAS_FD,KBP_CHECK stateNode;
    class GETATTR,TCSETATTR,STTY handler;
    class YIELD phase;
    class EMIT_BASE,EMIT_KITTY,FLUSH handler;
    class LAYERS,ENTRIES,SPEC,DERIVED newComponent;
```

Closes #681

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260408-184158-269767/.autoskillit/temp/rectify/rectify_terminal_guard_reset_specification_2026-04-08_190500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| investigate | 3.9k | 7.9k | 426.3k | 39.6k | 1 | 6m 7s |
| rectify | 32 | 14.5k | 1.1M | 83.2k | 1 | 8m 38s |
| dry_walkthrough | 28 | 15.0k | 1.2M | 70.7k | 1 | 5m 37s |
| implement | 24 | 8.3k | 755.0k | 45.8k | 1 | 4m 30s |
| assess | 21 | 4.6k | 612.7k | 52.9k | 1 | 4m 16s |
| prepare_pr | 9 | 6.2k | 136.5k | 31.1k | 1 | 5m 50s |
| run_arch_lenses | 31 | 11.5k | 787.6k | 90.5k | 2 | 4m 7s |
| compose_pr | 8 | 6.5k | 134.1k | 28.8k | 1 | 1m 43s |
| **Total** | 4.1k | 74.6k | 5.1M | 442.5k | | 40m 52s |