### PR TITLE
feat: add RecordingSubprocessRunner for multi-session scenario recording

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,7 @@ src/autoskillit/
 │   ├── linux_tracing.py     #   Linux-only /proc + psutil process tracing (accumulate snapshots)
 │   ├── anomaly_detection.py #   Post-hoc anomaly detection over ProcSnapshot series
 │   ├── session_log.py       #   File-based session diagnostics log writer (XDG-aware)
+│   ├── recording.py         #   RecordingSubprocessRunner — decorator that records headless sessions as scenario cassettes via api-simulator ScenarioRecorder
 │   ├── process.py           #   Subprocess management facade (re-exports from _process_*.py)
 │   ├── _process_io.py       #   create_temp_io, read_temp_output
 │   ├── _process_jsonl.py    #   _jsonl_contains_marker, _jsonl_has_record_type, _marker_is_standalone

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -118,6 +118,41 @@ tasks:
         echo "Smoke test output saved to: $TEST_OUTPUT"
         exit $PYTEST_EXIT
 
+  test-smoke-record:
+    desc: Record smoke test as a scenario fixture
+    deps: [_tmpdir-setup]
+    env:
+      PYTHONDONTWRITEBYTECODE: "1"
+      OMP_NUM_THREADS: "1"
+      SMOKE_TEST: "1"
+      RECORD_SCENARIO: "1"
+      RECORD_SCENARIO_DIR: "tests/fixtures/scenarios/smoke-happy"
+      RECORD_SCENARIO_RECIPE: "smoke-test"
+      TMPDIR: "{{.PYTEST_TMPDIR}}"
+    cmds:
+      - |
+        mkdir -p temp
+        TEST_OUTPUT="temp/smoke-record-$(date +%Y-%m-%d_%H%M%S).txt"
+        echo "Recording smoke tests as scenario fixtures"
+        echo "Output: $TEST_OUTPUT"
+
+        if [[ -d ".venv" ]]; then
+          PYTEST_CMD=".venv/bin/python -m pytest"
+        else
+          PYTEST_CMD="pytest"
+        fi
+
+        set -o pipefail
+        set +e
+        $PYTEST_CMD tests/test_smoke_pipeline.py -m smoke -v --tb=short -o "addopts=" --basetemp={{.PYTEST_TMPDIR}} -o "cache_dir={{.PYTEST_CACHEDIR}}" 2>&1 | tee "$TEST_OUTPUT"
+        PYTEST_EXIT=$?
+        set +o pipefail
+        set -e
+
+        echo ""
+        echo "Smoke record output saved to: $TEST_OUTPUT"
+        exit $PYTEST_EXIT
+
   check-docs:
     desc: Verify documentation counts match source code
     cmds:

--- a/src/autoskillit/execution/__init__.py
+++ b/src/autoskillit/execution/__init__.py
@@ -64,7 +64,13 @@ from autoskillit.execution.quota import (
     _refresh_quota_cache,  # noqa: F401 — imported for re-export via server.helpers; not in __all__
     check_and_sleep_if_needed,
 )
-from autoskillit.execution.recording import RecordingSubprocessRunner
+from autoskillit.execution.recording import (
+    RECORD_SCENARIO_DIR_ENV,
+    RECORD_SCENARIO_ENV,
+    RECORD_SCENARIO_RECIPE_ENV,
+    SCENARIO_STEP_NAME_ENV,
+    RecordingSubprocessRunner,
+)
 from autoskillit.execution.remote_resolver import REMOTE_PRECEDENCE, resolve_remote_repo
 from autoskillit.execution.session import (
     ClaudeSessionResult,
@@ -97,6 +103,10 @@ __all__ = [
     "run_managed_sync",
     # recording
     "RecordingSubprocessRunner",
+    "RECORD_SCENARIO_ENV",
+    "RECORD_SCENARIO_DIR_ENV",
+    "RECORD_SCENARIO_RECIPE_ENV",
+    "SCENARIO_STEP_NAME_ENV",
     # quota
     "QuotaStatus",
     "check_and_sleep_if_needed",

--- a/src/autoskillit/execution/__init__.py
+++ b/src/autoskillit/execution/__init__.py
@@ -64,6 +64,7 @@ from autoskillit.execution.quota import (
     _refresh_quota_cache,  # noqa: F401 — imported for re-export via server.helpers; not in __all__
     check_and_sleep_if_needed,
 )
+from autoskillit.execution.recording import RecordingSubprocessRunner
 from autoskillit.execution.remote_resolver import REMOTE_PRECEDENCE, resolve_remote_repo
 from autoskillit.execution.session import (
     ClaudeSessionResult,
@@ -94,6 +95,8 @@ __all__ = [
     "DefaultSubprocessRunner",
     "run_managed_async",
     "run_managed_sync",
+    # recording
+    "RecordingSubprocessRunner",
     # quota
     "QuotaStatus",
     "check_and_sleep_if_needed",

--- a/src/autoskillit/execution/commands.py
+++ b/src/autoskillit/execution/commands.py
@@ -118,6 +118,7 @@ def build_full_headless_cmd(
     output_format_required_flags: Sequence[str] = (),
     add_dirs: Sequence[ValidatedAddDir] = (),
     exit_after_stop_delay_ms: int = 0,
+    scenario_step_name: str = "",
 ) -> list[str]:
     """Build the complete headless command list ready for subprocess invocation.
 
@@ -145,6 +146,8 @@ def build_full_headless_cmd(
         Each entry is appended as ``--add-dir <path>``.
     exit_after_stop_delay_ms
         When > 0, ``CLAUDE_CODE_EXIT_AFTER_STOP_DELAY=<ms>`` is prepended.
+    scenario_step_name
+        When non-empty, ``SCENARIO_STEP_NAME=<name>`` is prepended for recording.
     """
     prompt = _inject_cwd_anchor(
         _inject_completion_directive(_ensure_skill_prefix(skill_command), completion_marker),
@@ -166,4 +169,6 @@ def build_full_headless_cmd(
     env_vars = ["AUTOSKILLIT_HEADLESS=1"]
     if exit_after_stop_delay_ms > 0:
         env_vars.append(f"CLAUDE_CODE_EXIT_AFTER_STOP_DELAY={exit_after_stop_delay_ms}")
+    if scenario_step_name:
+        env_vars.append(f"SCENARIO_STEP_NAME={scenario_step_name}")
     return ["env"] + env_vars + cmd

--- a/src/autoskillit/execution/headless.py
+++ b/src/autoskillit/execution/headless.py
@@ -844,6 +844,7 @@ async def run_headless_core(
             output_format_required_flags=cfg.output_format.required_cli_flags,
             add_dirs=add_dirs,
             exit_after_stop_delay_ms=cfg.exit_after_stop_delay_ms,
+            scenario_step_name=step_name,
         )
 
         effective_timeout = timeout if timeout is not None else cfg.timeout

--- a/src/autoskillit/execution/recording.py
+++ b/src/autoskillit/execution/recording.py
@@ -6,8 +6,7 @@ import asyncio
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from autoskillit.core import get_logger
-from autoskillit.core.types import SubprocessResult, SubprocessRunner, TerminationReason
+from autoskillit.core import SubprocessResult, SubprocessRunner, TerminationReason, get_logger
 
 if TYPE_CHECKING:
     from api_simulator.claude import ScenarioRecorder

--- a/src/autoskillit/execution/recording.py
+++ b/src/autoskillit/execution/recording.py
@@ -1,0 +1,154 @@
+"""RecordingSubprocessRunner — decorator that records headless sessions as scenario cassettes."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from autoskillit.core import get_logger
+from autoskillit.core.types import SubprocessResult, SubprocessRunner, TerminationReason
+
+if TYPE_CHECKING:
+    from api_simulator.claude import ScenarioRecorder
+
+logger = get_logger(__name__)
+
+
+def _extract_env_and_args(cmd: list[str]) -> tuple[dict[str, str], list[str]]:
+    """Parse ``["env", "K=V", ..., "program", ...]`` into (env_dict, clean_args).
+
+    If *cmd* does not start with ``"env"``, returns ``({}, cmd)``.
+    """
+    if not cmd or cmd[0] != "env":
+        return {}, list(cmd)
+
+    env_dict: dict[str, str] = {}
+    i = 1
+    while i < len(cmd) and "=" in cmd[i]:
+        key, _, val = cmd[i].partition("=")
+        env_dict[key] = val
+        i += 1
+    return env_dict, cmd[i:]
+
+
+def _extract_model(args: list[str]) -> str:
+    """Find ``--model <model>`` in an argument list."""
+    try:
+        idx = args.index("--model")
+        return args[idx + 1]
+    except (ValueError, IndexError):
+        return ""
+
+
+class RecordingSubprocessRunner(SubprocessRunner):
+    """Wraps a SubprocessRunner, records each session via ScenarioRecorder.
+
+    - **Session calls** (``pty_mode=True`` + ``SCENARIO_STEP_NAME`` in cmd env prefix):
+      delegates to ``ScenarioRecorder.record_step()`` which spawns the real subprocess
+      under PTY capture, then constructs a ``SubprocessResult`` from the cassette.
+    - **Non-session calls**: delegates to the inner runner, then records a summary via
+      ``recorder.record_non_session_step()`` if ``SCENARIO_STEP_NAME`` is present.
+    - **Calls without SCENARIO_STEP_NAME**: passes through to inner runner unrecorded.
+    """
+
+    def __init__(
+        self,
+        recorder: ScenarioRecorder,
+        inner: SubprocessRunner | None = None,
+    ) -> None:
+        self._recorder = recorder
+        if inner is None:
+            from autoskillit.execution.process import DefaultSubprocessRunner
+
+            inner = DefaultSubprocessRunner()
+        self._inner = inner
+
+    async def __call__(
+        self,
+        cmd: list[str],
+        *,
+        cwd: Path,
+        timeout: float,
+        env: dict[str, str] | None = None,
+        stale_threshold: float = 1200,
+        completion_marker: str = "",
+        session_log_dir: Path | None = None,
+        pty_mode: bool = False,
+        input_data: str | None = None,
+        completion_drain_timeout: float = 5.0,
+        linux_tracing_config: Any | None = None,
+    ) -> SubprocessResult:
+        env_dict, clean_args = _extract_env_and_args(cmd)
+        step_name = env_dict.get("SCENARIO_STEP_NAME", "")
+
+        if pty_mode and step_name:
+            return await self._record_session(
+                cmd=cmd,
+                clean_args=clean_args,
+                step_name=step_name,
+                model=_extract_model(clean_args),
+                session_log_dir=session_log_dir,
+            )
+
+        # Non-session or no step_name — delegate to inner runner
+        result = await self._inner(
+            cmd,
+            cwd=cwd,
+            timeout=timeout,
+            env=env,
+            stale_threshold=stale_threshold,
+            completion_marker=completion_marker,
+            session_log_dir=session_log_dir,
+            pty_mode=pty_mode,
+            input_data=input_data,
+            completion_drain_timeout=completion_drain_timeout,
+            linux_tracing_config=linux_tracing_config,
+        )
+
+        if step_name:
+            tool = env_dict.get("SCENARIO_TOOL", "run_cmd")
+            self._recorder.record_non_session_step(
+                step_name=step_name,
+                tool=tool,
+                result_summary={
+                    "exit_code": result.returncode,
+                    "stdout_head": result.stdout[:500],
+                },
+            )
+
+        return result
+
+    async def _record_session(
+        self,
+        *,
+        cmd: list[str],
+        clean_args: list[str],
+        step_name: str,
+        model: str,
+        session_log_dir: Path | None,
+    ) -> SubprocessResult:
+        """Record a session call via ScenarioRecorder.record_step()."""
+        step_result = await asyncio.to_thread(
+            self._recorder.record_step,
+            step_name=step_name,
+            tool="run_skill",
+            args=clean_args,
+            model=model,
+            session_log_dir=str(session_log_dir) if session_log_dir else None,
+        )
+
+        # Read stdout from cassette for _build_skill_result compatibility
+        stdout = ""
+        cassette_stdout = Path(step_result.cassette_path) / "stdout.jsonl"
+        if cassette_stdout.exists():
+            stdout = cassette_stdout.read_text()
+
+        return SubprocessResult(
+            returncode=step_result.cassette_exit_code,
+            stdout=stdout,
+            stderr="",
+            termination=TerminationReason.NATURAL_EXIT,
+            pid=0,
+            elapsed_seconds=step_result.cassette_duration_ms / 1000.0,
+        )

--- a/src/autoskillit/execution/recording.py
+++ b/src/autoskillit/execution/recording.py
@@ -98,7 +98,6 @@ class RecordingSubprocessRunner(SubprocessRunner):
                 session_log_dir=session_log_dir,
             )
 
-        # Non-session or no step_name — delegate to inner runner
         result = await self._inner(
             cmd,
             cwd=cwd,

--- a/src/autoskillit/execution/recording.py
+++ b/src/autoskillit/execution/recording.py
@@ -14,6 +14,12 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+#: Environment variable names for scenario recording activation.
+RECORD_SCENARIO_ENV = "RECORD_SCENARIO"
+RECORD_SCENARIO_DIR_ENV = "RECORD_SCENARIO_DIR"
+RECORD_SCENARIO_RECIPE_ENV = "RECORD_SCENARIO_RECIPE"
+SCENARIO_STEP_NAME_ENV = "SCENARIO_STEP_NAME"
+
 
 def _extract_env_and_args(cmd: list[str]) -> tuple[dict[str, str], list[str]]:
     """Parse ``["env", "K=V", ..., "program", ...]`` into (env_dict, clean_args).
@@ -81,7 +87,7 @@ class RecordingSubprocessRunner(SubprocessRunner):
         linux_tracing_config: Any | None = None,
     ) -> SubprocessResult:
         env_dict, clean_args = _extract_env_and_args(cmd)
-        step_name = env_dict.get("SCENARIO_STEP_NAME", "")
+        step_name = env_dict.get(SCENARIO_STEP_NAME_ENV, "")
 
         if pty_mode and step_name:
             return await self._record_session(

--- a/src/autoskillit/execution/recording.py
+++ b/src/autoskillit/execution/recording.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import atexit
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -57,6 +58,7 @@ class RecordingSubprocessRunner(SubprocessRunner):
         inner: SubprocessRunner | None = None,
     ) -> None:
         self._recorder = recorder
+        atexit.register(recorder.finalize)
         if inner is None:
             from autoskillit.execution.process import DefaultSubprocessRunner
 

--- a/src/autoskillit/execution/recording.py
+++ b/src/autoskillit/execution/recording.py
@@ -114,13 +114,12 @@ class RecordingSubprocessRunner(SubprocessRunner):
         )
 
         if step_name:
-            tool = env_dict.get("SCENARIO_TOOL", "run_cmd")
             self._recorder.record_non_session_step(
                 step_name=step_name,
-                tool=tool,
+                tool="run_cmd",
                 result_summary={
                     "exit_code": result.returncode,
-                    "stdout_head": result.stdout[:500],
+                    "stdout_head": (result.stdout or "")[:500],
                 },
             )
 
@@ -136,20 +135,24 @@ class RecordingSubprocessRunner(SubprocessRunner):
         session_log_dir: Path | None,
     ) -> SubprocessResult:
         """Record a session call via ScenarioRecorder.record_step()."""
-        step_result = await asyncio.to_thread(
-            self._recorder.record_step,
-            step_name=step_name,
-            tool="run_skill",
-            args=clean_args,
-            model=model,
-            session_log_dir=str(session_log_dir) if session_log_dir else None,
-        )
+        try:
+            step_result = await asyncio.to_thread(
+                self._recorder.record_step,
+                step_name=step_name,
+                tool="run_skill",
+                args=clean_args,
+                model=model,
+                session_log_dir=str(session_log_dir) if session_log_dir else None,
+            )
+        except Exception:
+            logger.exception("record_step failed for step=%r", step_name)
+            raise
 
-        # Read stdout from cassette for _build_skill_result compatibility
         stdout = ""
-        cassette_stdout = Path(step_result.cassette_path) / "stdout.jsonl"
-        if cassette_stdout.exists():
-            stdout = cassette_stdout.read_text()
+        if step_result.cassette_path:
+            cassette_stdout = Path(step_result.cassette_path) / "stdout.jsonl"
+            if cassette_stdout.exists():
+                stdout = cassette_stdout.read_text(encoding="utf-8")
 
         return SubprocessResult(
             returncode=step_result.cassette_exit_code,
@@ -157,5 +160,5 @@ class RecordingSubprocessRunner(SubprocessRunner):
             stderr="",
             termination=TerminationReason.NATURAL_EXIT,
             pid=0,
-            elapsed_seconds=step_result.cassette_duration_ms / 1000.0,
+            elapsed_seconds=(step_result.cassette_duration_ms or 0) / 1000.0,
         )

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -16,6 +16,9 @@ from typing import Any
 from autoskillit.config import AutomationConfig
 from autoskillit.core import SubprocessRunner, WriteBehaviorSpec, get_logger, pkg_root
 from autoskillit.execution import (
+    RECORD_SCENARIO_DIR_ENV,
+    RECORD_SCENARIO_ENV,
+    RECORD_SCENARIO_RECIPE_ENV,
     DefaultCIWatcher,
     DefaultDatabaseReader,
     DefaultGitHubFetcher,
@@ -113,9 +116,9 @@ def make_context(
 
         runner = DefaultSubprocessRunner()
 
-    if runner is not None and os.environ.get("RECORD_SCENARIO"):
-        scenario_dir = os.environ.get("RECORD_SCENARIO_DIR", "")
-        recipe_name = os.environ.get("RECORD_SCENARIO_RECIPE", "unknown")
+    if runner is not None and os.environ.get(RECORD_SCENARIO_ENV):
+        scenario_dir = os.environ.get(RECORD_SCENARIO_DIR_ENV, "")
+        recipe_name = os.environ.get(RECORD_SCENARIO_RECIPE_ENV, "unknown")
         if scenario_dir:
             if not os.path.isdir(scenario_dir):
                 logger.warning(

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -113,6 +113,20 @@ def make_context(
 
         runner = DefaultSubprocessRunner()
 
+    if runner is not None and os.environ.get("RECORD_SCENARIO"):
+        scenario_dir = os.environ.get("RECORD_SCENARIO_DIR", "")
+        recipe_name = os.environ.get("RECORD_SCENARIO_RECIPE", "unknown")
+        if scenario_dir:
+            import atexit
+
+            from api_simulator.claude import make_scenario_recorder
+
+            from autoskillit.execution.recording import RecordingSubprocessRunner
+
+            recorder = make_scenario_recorder(output_dir=scenario_dir, recipe_name=recipe_name)
+            runner = RecordingSubprocessRunner(recorder=recorder, inner=runner)
+            atexit.register(recorder.finalize)
+
     # Resolve token: config → GITHUB_TOKEN env var → gh CLI → None (unauthenticated)
     github_token = config.github.token or os.environ.get("GITHUB_TOKEN") or _gh_cli_token()
 

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -121,7 +121,7 @@ def make_context(
 
             from api_simulator.claude import make_scenario_recorder
 
-            from autoskillit.execution.recording import RecordingSubprocessRunner
+            from autoskillit.execution import RecordingSubprocessRunner
 
             recorder = make_scenario_recorder(output_dir=scenario_dir, recipe_name=recipe_name)
             runner = RecordingSubprocessRunner(recorder=recorder, inner=runner)

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -119,7 +119,13 @@ def make_context(
         if scenario_dir:
             import atexit
 
-            from api_simulator.claude import make_scenario_recorder
+            try:
+                from api_simulator.claude import make_scenario_recorder
+            except ImportError as exc:
+                raise RuntimeError(
+                    "RECORD_SCENARIO is set but 'api_simulator' is not installed. "
+                    "Install it to enable scenario recording."
+                ) from exc
 
             from autoskillit.execution import RecordingSubprocessRunner
 

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -117,21 +117,24 @@ def make_context(
         scenario_dir = os.environ.get("RECORD_SCENARIO_DIR", "")
         recipe_name = os.environ.get("RECORD_SCENARIO_RECIPE", "unknown")
         if scenario_dir:
-            import atexit
+            if not os.path.isdir(scenario_dir):
+                logger.warning(
+                    "RECORD_SCENARIO_DIR=%r is not an existing directory — skipping recording",
+                    scenario_dir,
+                )
+            else:
+                try:
+                    from api_simulator.claude import make_scenario_recorder
+                except ImportError as exc:
+                    raise RuntimeError(
+                        "RECORD_SCENARIO is set but 'api_simulator' is not installed. "
+                        "Install it to enable scenario recording."
+                    ) from exc
 
-            try:
-                from api_simulator.claude import make_scenario_recorder
-            except ImportError as exc:
-                raise RuntimeError(
-                    "RECORD_SCENARIO is set but 'api_simulator' is not installed. "
-                    "Install it to enable scenario recording."
-                ) from exc
+                from autoskillit.execution import RecordingSubprocessRunner
 
-            from autoskillit.execution import RecordingSubprocessRunner
-
-            recorder = make_scenario_recorder(output_dir=scenario_dir, recipe_name=recipe_name)
-            runner = RecordingSubprocessRunner(recorder=recorder, inner=runner)
-            atexit.register(recorder.finalize)
+                recorder = make_scenario_recorder(output_dir=scenario_dir, recipe_name=recipe_name)
+                runner = RecordingSubprocessRunner(recorder=recorder, inner=runner)
 
     # Resolve token: config → GITHUB_TOKEN env var → gh CLI → None (unauthenticated)
     github_token = config.github.token or os.environ.get("GITHUB_TOKEN") or _gh_cli_token()

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -648,6 +648,9 @@ def test_no_subpackage_exceeds_10_files() -> None:
       execution/ — REQ-CNST-003-E3: execution/ decomposes process lifecycle into
         focused single-concern modules (_process_io, _process_kill, _process_race,
         etc.) that cannot be merged without re-introducing the coupling they isolate.
+        recording.py adds the RecordingSubprocessRunner decorator as a separate module
+        to keep scenario recording concerns isolated from the core process lifecycle.
+        Exempt at 25 files.
       core/ — REQ-CNST-003-E4: core/ types split into per-concern type modules
         (_type_enums, _type_protocols, _type_results, _type_subprocess, etc.) to
         prevent circular imports while keeping L0 types co-located. Also houses
@@ -669,7 +672,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
     EXEMPTIONS: dict[str, int] = {
         "server": 17,
         "recipe": 29,
-        "execution": 24,
+        "execution": 25,
         "core": 15,
         "cli": 15,
         "hooks": 14,

--- a/tests/execution/test_recording.py
+++ b/tests/execution/test_recording.py
@@ -211,9 +211,10 @@ def test_make_context_wraps_runner_when_record_scenario(monkeypatch, tmp_path):
     monkeypatch.setenv("RECORD_SCENARIO_DIR", str(scenario_dir))
     monkeypatch.setenv("RECORD_SCENARIO_RECIPE", "smoke-test")
     mock_recorder = Mock()
+    import api_simulator.claude as _api_sim_claude
+
     monkeypatch.setattr(
-        "api_simulator.claude.make_scenario_recorder",
-        Mock(return_value=mock_recorder),
+        _api_sim_claude, "make_scenario_recorder", Mock(return_value=mock_recorder), raising=False
     )
     monkeypatch.setattr("atexit.register", Mock())
 

--- a/tests/execution/test_recording.py
+++ b/tests/execution/test_recording.py
@@ -63,7 +63,13 @@ async def test_session_call_routes_to_record_step(tmp_path):
 
     result = await runner(cmd, cwd=Path("/tmp"), timeout=300, pty_mode=True)
 
-    mock_recorder.record_step.assert_called_once()
+    mock_recorder.record_step.assert_called_once_with(
+        step_name="investigate",
+        tool="run_skill",
+        args=["claude", "--model", "sonnet", "--print", "do stuff"],
+        model="sonnet",
+        session_log_dir=None,
+    )
     assert inner.call_args_list == []  # inner NOT called
     assert result.returncode == 0
     assert result.termination == TerminationReason.NATURAL_EXIT
@@ -199,8 +205,10 @@ async def test_run_headless_core_injects_scenario_step_name(tmp_path):
 
 
 def test_make_context_wraps_runner_when_record_scenario(monkeypatch, tmp_path):
+    scenario_dir = tmp_path / "scenario"
+    scenario_dir.mkdir()
     monkeypatch.setenv("RECORD_SCENARIO", "1")
-    monkeypatch.setenv("RECORD_SCENARIO_DIR", str(tmp_path / "scenario"))
+    monkeypatch.setenv("RECORD_SCENARIO_DIR", str(scenario_dir))
     monkeypatch.setenv("RECORD_SCENARIO_RECIPE", "smoke-test")
     mock_recorder = Mock()
     monkeypatch.setattr(

--- a/tests/execution/test_recording.py
+++ b/tests/execution/test_recording.py
@@ -1,0 +1,230 @@
+"""Tests for RecordingSubprocessRunner and related helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from autoskillit.core.types import SubprocessRunner, TerminationReason
+from autoskillit.execution.commands import build_full_headless_cmd
+from autoskillit.execution.recording import (
+    RecordingSubprocessRunner,
+    _extract_env_and_args,
+    _extract_model,
+)
+from tests.conftest import MockSubprocessRunner, _make_result
+
+
+@dataclass
+class FakeStepResult:
+    cassette_exit_code: int
+    cassette_path: str
+    cassette_duration_ms: int
+
+
+# --- T1: Protocol compliance ---
+
+
+def test_recording_runner_satisfies_protocol():
+    """RecordingSubprocessRunner is a valid SubprocessRunner."""
+    mock_recorder = Mock()
+    runner = RecordingSubprocessRunner(recorder=mock_recorder)
+    assert isinstance(runner, SubprocessRunner)
+
+
+# --- T2: Session call routes to record_step ---
+
+
+@pytest.mark.anyio
+async def test_session_call_routes_to_record_step(tmp_path):
+    """pty_mode=True + SCENARIO_STEP_NAME → record_step(), not inner runner."""
+    mock_recorder = Mock()
+    mock_recorder.record_step.return_value = FakeStepResult(
+        cassette_exit_code=0,
+        cassette_path=str(tmp_path / "cassette"),
+        cassette_duration_ms=5000,
+    )
+    inner = MockSubprocessRunner()
+    runner = RecordingSubprocessRunner(recorder=mock_recorder, inner=inner)
+
+    cmd = [
+        "env",
+        "AUTOSKILLIT_HEADLESS=1",
+        "SCENARIO_STEP_NAME=investigate",
+        "claude",
+        "--model",
+        "sonnet",
+        "--print",
+        "do stuff",
+    ]
+
+    result = await runner(cmd, cwd=Path("/tmp"), timeout=300, pty_mode=True)
+
+    mock_recorder.record_step.assert_called_once()
+    assert inner.call_args_list == []  # inner NOT called
+    assert result.returncode == 0
+    assert result.termination == TerminationReason.NATURAL_EXIT
+
+
+# --- T3: Non-session call delegates to inner runner + records summary ---
+
+
+@pytest.mark.anyio
+async def test_non_session_call_delegates_and_records():
+    """pty_mode=False → inner runner called, then record_non_session_step()."""
+    mock_recorder = Mock()
+    inner = MockSubprocessRunner()
+    inner.set_default(_make_result(returncode=0))
+    runner = RecordingSubprocessRunner(recorder=mock_recorder, inner=inner)
+
+    cmd = ["env", "SCENARIO_STEP_NAME=test-check", "pytest", "tests/"]
+
+    result = await runner(cmd, cwd=Path("/tmp"), timeout=60, pty_mode=False)
+
+    assert len(inner.call_args_list) == 1  # inner WAS called
+    mock_recorder.record_non_session_step.assert_called_once_with(
+        step_name="test-check",
+        tool="run_cmd",
+        result_summary={"exit_code": 0, "stdout_head": result.stdout[:500]},
+    )
+
+
+# --- T4: No step_name skips recording ---
+
+
+@pytest.mark.anyio
+async def test_no_step_name_skips_recording():
+    """Calls without SCENARIO_STEP_NAME go through inner runner unrecorded."""
+    mock_recorder = Mock()
+    inner = MockSubprocessRunner()
+    inner.set_default(_make_result(returncode=0))
+    runner = RecordingSubprocessRunner(recorder=mock_recorder, inner=inner)
+
+    cmd = ["env", "AUTOSKILLIT_HEADLESS=1", "claude", "--print", "test"]
+
+    await runner(cmd, cwd=Path("/tmp"), timeout=300, pty_mode=True)
+
+    assert len(inner.call_args_list) == 1  # inner called (no recording intercept)
+    mock_recorder.record_step.assert_not_called()
+    mock_recorder.record_non_session_step.assert_not_called()
+
+
+# --- T5: _extract_env_and_args parsing ---
+
+
+def test_extract_env_and_args():
+    cmd = ["env", "A=1", "B=hello", "claude", "--print", "do stuff"]
+    env_dict, clean_args = _extract_env_and_args(cmd)
+    assert env_dict == {"A": "1", "B": "hello"}
+    assert clean_args == ["claude", "--print", "do stuff"]
+
+
+def test_extract_env_and_args_no_env_prefix():
+    cmd = ["claude", "--print", "do stuff"]
+    env_dict, clean_args = _extract_env_and_args(cmd)
+    assert env_dict == {}
+    assert clean_args == ["claude", "--print", "do stuff"]
+
+
+# --- T6: _extract_model from args ---
+
+
+def test_extract_model():
+    args = ["claude", "--print", "hello", "--model", "sonnet"]
+    assert _extract_model(args) == "sonnet"
+
+
+def test_extract_model_missing():
+    args = ["claude", "--print", "hello"]
+    assert _extract_model(args) == ""
+
+
+# --- T7: SCENARIO_STEP_NAME in cmd from build_full_headless_cmd ---
+
+_BASE_CMD_ARGS = dict(
+    cwd="/tmp",
+    completion_marker="DONE",
+    model=None,
+    plugin_dir="/plugins",
+    output_format_value="stream-json",
+)
+
+
+def test_build_full_headless_cmd_injects_scenario_step_name():
+    cmd = build_full_headless_cmd(
+        "/investigate foo",
+        scenario_step_name="investigate",
+        **_BASE_CMD_ARGS,
+    )
+    assert "SCENARIO_STEP_NAME=investigate" in cmd
+
+
+# --- T8: build_full_headless_cmd without scenario_step_name ---
+
+
+def test_build_full_headless_cmd_no_scenario_step_name():
+    cmd = build_full_headless_cmd(
+        "/investigate foo",
+        **_BASE_CMD_ARGS,
+    )
+    assert not any("SCENARIO_STEP_NAME" in token for token in cmd)
+
+
+# --- T9: run_headless_core passes scenario_step_name through ---
+
+
+@pytest.mark.anyio
+async def test_run_headless_core_injects_scenario_step_name(tmp_path):
+    """run_headless_core passes step_name as scenario_step_name to cmd builder."""
+    from autoskillit.config import AutomationConfig
+    from autoskillit.execution.headless import run_headless_core
+    from autoskillit.pipeline import DefaultGateState
+    from autoskillit.server._factory import make_context
+
+    mock_runner = MockSubprocessRunner()
+    mock_runner.set_default(_make_result())
+    ctx = make_context(AutomationConfig(), runner=mock_runner, plugin_dir=str(tmp_path))
+    ctx.gate = DefaultGateState(enabled=True)
+
+    await run_headless_core("/investigate foo", str(tmp_path), ctx, step_name="investigate")
+
+    cmd = mock_runner.call_args_list[0][0]
+    assert "SCENARIO_STEP_NAME=investigate" in cmd
+
+
+# --- T10: make_context wraps runner when RECORD_SCENARIO set ---
+
+
+def test_make_context_wraps_runner_when_record_scenario(monkeypatch, tmp_path):
+    monkeypatch.setenv("RECORD_SCENARIO", "1")
+    monkeypatch.setenv("RECORD_SCENARIO_DIR", str(tmp_path / "scenario"))
+    monkeypatch.setenv("RECORD_SCENARIO_RECIPE", "smoke-test")
+    mock_recorder = Mock()
+    monkeypatch.setattr(
+        "api_simulator.claude.make_scenario_recorder",
+        Mock(return_value=mock_recorder),
+    )
+    monkeypatch.setattr("atexit.register", Mock())
+
+    from autoskillit.config import AutomationConfig
+    from autoskillit.server._factory import make_context
+
+    ctx = make_context(AutomationConfig(), plugin_dir=str(tmp_path))
+    assert isinstance(ctx.runner, RecordingSubprocessRunner)
+
+
+# --- T11: make_context default runner unchanged without env var ---
+
+
+def test_make_context_default_runner_without_record_scenario(monkeypatch, tmp_path):
+    monkeypatch.delenv("RECORD_SCENARIO", raising=False)
+
+    from autoskillit.config import AutomationConfig
+    from autoskillit.execution.process import DefaultSubprocessRunner
+    from autoskillit.server._factory import make_context
+
+    ctx = make_context(AutomationConfig(), plugin_dir=str(tmp_path))
+    assert isinstance(ctx.runner, DefaultSubprocessRunner)


### PR DESCRIPTION
## Summary

Add a `RecordingSubprocessRunner` that decorates `DefaultSubprocessRunner` and records each
headless session as a numbered cassette via `api-simulator`'s `ScenarioRecorder`. For session
calls (`pty_mode=True` with `SCENARIO_STEP_NAME`), it delegates to `ScenarioRecorder.record_step()`
which spawns the real subprocess under PTY capture. For non-session calls, it delegates to
the inner runner and records a summary via `record_non_session_step()`. The recording layer
activates only when `RECORD_SCENARIO=1` is set, leaving the default execution path untouched.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 42, 'rankSpacing': 54, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START<br/>━━━━━━━━━━<br/>MCP server init])
    END_PASS([COMPLETE<br/>━━━━━━━━━━<br/>SubprocessResult returned])
    END_PASS2([COMPLETE<br/>━━━━━━━━━━<br/>SubprocessResult returned])
    END_PASS3([COMPLETE<br/>━━━━━━━━━━<br/>SubprocessResult returned])

    %% PHASE 1: Context Wiring %%
    subgraph CtxWiring ["● Phase 1 — Context Wiring (server/_factory.py :: make_context)"]
        direction TB
        DefaultRunner["● DefaultSubprocessRunner<br/>━━━━━━━━━━<br/>Baseline runner instantiated<br/>when runner is _UNSET"]
        EnvCheck{"RECORD_SCENARIO<br/>env var set?"}
        DirCheck{"RECORD_SCENARIO_DIR<br/>non-empty?"}
        MakeRecorder["★ make_scenario_recorder()<br/>━━━━━━━━━━<br/>api_simulator.claude<br/>output_dir + recipe_name"]
        WrapRunner["★ RecordingSubprocessRunner<br/>━━━━━━━━━━<br/>recorder= + inner=DefaultRunner<br/>wraps baseline runner"]
        AtexitReg["atexit.register(recorder.finalize)<br/>━━━━━━━━━━<br/>Cassette flushed at process exit"]
    end

    %% PHASE 2: Command Build %%
    subgraph CmdBuild ["● Phase 2 — Command Building (execution/commands.py :: build_full_headless_cmd)"]
        direction TB
        PromptBuild["● build_full_headless_cmd()<br/>━━━━━━━━━━<br/>skill_command + cwd + marker<br/>+ scenario_step_name (new param)"]
        StepNameCheck{"scenario_step_name<br/>non-empty?"}
        InjectStep["● Inject SCENARIO_STEP_NAME=&lt;name&gt;<br/>━━━━━━━━━━<br/>Prepended to env prefix<br/>alongside AUTOSKILLIT_HEADLESS=1"]
        NoStepInject["No SCENARIO_STEP_NAME<br/>━━━━━━━━━━<br/>env prefix unchanged"]
        FinalCmd["● Final cmd list<br/>━━━━━━━━━━<br/>['env', 'AUTOSKILLIT_HEADLESS=1',<br/>'SCENARIO_STEP_NAME=step', 'claude', ...]"]
    end

    %% PHASE 3: Runner Dispatch %%
    subgraph Dispatch ["★ Phase 3 — Runner Dispatch (execution/recording.py :: RecordingSubprocessRunner.__call__)"]
        direction TB
        ParseCmd["★ _extract_env_and_args(cmd)<br/>━━━━━━━━━━<br/>Splits 'env K=V...' prefix<br/>into env_dict + clean_args"]
        GetStepName["★ env_dict.get('SCENARIO_STEP_NAME')<br/>━━━━━━━━━━<br/>step_name extracted"]
        DispatchDecision{"pty_mode=True<br/>AND step_name set?"}
    end

    %% PHASE 4: Session Recording %%
    subgraph SessionRec ["★ Phase 4 — Session Recording (execution/recording.py :: _record_session)"]
        direction TB
        RecordStep["★ recorder.record_step()<br/>━━━━━━━━━━<br/>asyncio.to_thread()<br/>step_name + tool + args + model"]
        ReadCassette{"cassette stdout.jsonl<br/>exists?"}
        ReadStdout["★ cassette_path/stdout.jsonl<br/>━━━━━━━━━━<br/>Read cassette output<br/>as stdout string"]
        EmptyStdout["stdout = ''<br/>━━━━━━━━━━<br/>No cassette output available"]
        BuildResult["★ SubprocessResult<br/>━━━━━━━━━━<br/>returncode=cassette_exit_code<br/>stdout=cassette_content<br/>termination=NATURAL_EXIT<br/>elapsed=duration_ms/1000"]
    end

    %% PHASE 5: Non-Session / Pass-Through %%
    subgraph NonSession ["★ Phase 5 — Non-Session & Pass-Through (execution/recording.py)"]
        direction TB
        DelegateInner["★ _inner(cmd, ...)<br/>━━━━━━━━━━<br/>Delegates to DefaultSubprocessRunner<br/>All kwargs forwarded unchanged"]
        StepNameAfter{"step_name set<br/>after delegation?"}
        RecordNonSession["★ recorder.record_non_session_step()<br/>━━━━━━━━━━<br/>step_name + tool (SCENARIO_TOOL)<br/>result_summary: exit_code + stdout_head"]
        PassThrough["Pass-through result<br/>━━━━━━━━━━<br/>No recording — step_name absent"]
    end

    %% FLOW: Startup Wiring %%
    START --> DefaultRunner
    DefaultRunner --> EnvCheck
    EnvCheck -->|"not set"| CtxComplete["runner = DefaultRunner<br/>━━━━━━━━━━<br/>No recording wrapper"]
    EnvCheck -->|"set"| DirCheck
    DirCheck -->|"empty"| CtxComplete
    DirCheck -->|"non-empty"| MakeRecorder
    MakeRecorder --> WrapRunner
    WrapRunner --> AtexitReg
    AtexitReg --> CtxComplete2["runner = RecordingSubprocessRunner<br/>━━━━━━━━━━<br/>Injected into ToolContext"]

    %% FLOW: Command Build %%
    CtxComplete --> PromptBuild
    CtxComplete2 --> PromptBuild
    PromptBuild --> StepNameCheck
    StepNameCheck -->|"non-empty"| InjectStep
    StepNameCheck -->|"empty"| NoStepInject
    InjectStep --> FinalCmd
    NoStepInject --> FinalCmd

    %% FLOW: Runner Dispatch %%
    FinalCmd --> ParseCmd
    ParseCmd --> GetStepName
    GetStepName --> DispatchDecision

    %% FLOW: Session path %%
    DispatchDecision -->|"YES — session call"| RecordStep
    RecordStep --> ReadCassette
    ReadCassette -->|"exists"| ReadStdout
    ReadCassette -->|"missing"| EmptyStdout
    ReadStdout --> BuildResult
    EmptyStdout --> BuildResult
    BuildResult --> END_PASS

    %% FLOW: Non-session / pass-through path %%
    DispatchDecision -->|"NO — non-session or no step_name"| DelegateInner
    DelegateInner --> StepNameAfter
    StepNameAfter -->|"set"| RecordNonSession
    StepNameAfter -->|"absent"| PassThrough
    RecordNonSession --> END_PASS2
    PassThrough --> END_PASS3

    %% CLASS ASSIGNMENTS %%
    class START terminal;
    class END_PASS,END_PASS2,END_PASS3 terminal;
    class DefaultRunner,PromptBuild,FinalCmd,InjectStep,NoStepInject handler;
    class CtxComplete,CtxComplete2 stateNode;
    class EnvCheck,DirCheck,StepNameCheck,DispatchDecision,ReadCassette,StepNameAfter detector;
    class MakeRecorder,WrapRunner,AtexitReg,ParseCmd,GetStepName,RecordStep,ReadStdout,EmptyStdout,BuildResult,DelegateInner,RecordNonSession,PassThrough newComponent;
```

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 80, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph L3 ["L3 — SERVER / COMPOSITION ROOT"]
        direction TB
        FACTORY["● server/_factory.py<br/>━━━━━━━━━━<br/>make_context()<br/>Wires ToolContext<br/>Wraps runner when RECORD_SCENARIO set"]
    end

    subgraph L2 ["L2 — PIPELINE"]
        direction TB
        TOOLCTX["pipeline/context.py<br/>━━━━━━━━━━<br/>ToolContext<br/>runner: SubprocessRunner | None"]
    end

    subgraph L1 ["L1 — EXECUTION"]
        direction LR
        RECORDING["★ execution/recording.py<br/>━━━━━━━━━━<br/>RecordingSubprocessRunner<br/>Decorator wrapping inner runner<br/>Records sessions as cassettes"]
        HEADLESS["● execution/headless.py<br/>━━━━━━━━━━<br/>run_headless_core()<br/>Calls ctx.runner(...) polymorphically"]
        PROCESS["execution/process.py<br/>━━━━━━━━━━<br/>DefaultSubprocessRunner<br/>Real subprocess launcher"]
        INIT["● execution/__init__.py<br/>━━━━━━━━━━<br/>Re-exports RecordingSubprocessRunner<br/>Public surface of L1"]
    end

    subgraph L0 ["L0 — CORE PROTOCOLS"]
        direction LR
        PROTOCOL["core/_type_subprocess.py<br/>━━━━━━━━━━<br/>SubprocessRunner Protocol<br/>SubprocessResult<br/>TerminationReason"]
        CORE_LOG["core/logging.py<br/>━━━━━━━━━━<br/>get_logger"]
    end

    subgraph EXT ["EXTERNAL"]
        direction LR
        APISIM["api_simulator.claude<br/>━━━━━━━━━━<br/>ScenarioRecorder (TYPE_CHECKING)<br/>make_scenario_recorder (conditional)"]
    end

    %% L3 → L2 (valid downward) %%
    FACTORY -->|"imports ToolContext"| TOOLCTX

    %% L3 → L1 (valid downward) %%
    FACTORY -->|"imports DefaultSubprocessRunner<br/>RecordingSubprocessRunner"| INIT
    FACTORY -->|"wraps: RecordingSubprocessRunner(inner=DefaultSubprocessRunner())"| RECORDING

    %% L3 → External (conditional runtime import) %%
    FACTORY -.->|"RECORD_SCENARIO env var<br/>conditional import"| APISIM

    %% L2 → L1 (valid: ToolContext holds runner reference) %%
    TOOLCTX -->|"runner field: SubprocessRunner"| PROTOCOL

    %% L1 internal: __init__ re-exports %%
    INIT -->|"re-exports"| RECORDING
    INIT -->|"re-exports"| PROCESS

    %% recording.py → core (valid L1→L0) %%
    RECORDING -->|"implements SubprocessRunner<br/>uses SubprocessResult<br/>TerminationReason"| PROTOCOL
    RECORDING -->|"get_logger"| CORE_LOG

    %% recording.py → external (TYPE_CHECKING only) %%
    RECORDING -.->|"TYPE_CHECKING only<br/>(no runtime dep)"| APISIM

    %% recording.py → process.py (same-layer lazy import) %%
    RECORDING -.->|"lazy import inside __init__<br/>(avoids circular)"| PROCESS

    %% headless.py calls ctx.runner polymorphically %%
    HEADLESS -->|"ctx.runner(...)<br/>polymorphic call via Protocol"| TOOLCTX

    %% DefaultSubprocessRunner implements same protocol %%
    PROCESS -->|"implements SubprocessRunner"| PROTOCOL

    %% CLASS ASSIGNMENTS %%
    class FACTORY cli;
    class TOOLCTX stateNode;
    class RECORDING newComponent;
    class HEADLESS,INIT handler;
    class PROCESS handler;
    class PROTOCOL,CORE_LOG phase;
    class APISIM integration;
```

### Development Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph Protocols ["CORE PROTOCOLS"]
        PROTO["SubprocessRunner Protocol<br/>━━━━━━━━━━<br/>core/types.py<br/>async __call__(cmd, *, cwd, ...)"]
    end

    subgraph Composition ["● COMPOSITION ROOT — server/_factory.py"]
        ENV["RECORD_SCENARIO env var<br/>━━━━━━━━━━<br/>+ RECORD_SCENARIO_DIR<br/>+ RECORD_SCENARIO_RECIPE"]
        MAKE_CTX["● make_context()<br/>━━━━━━━━━━<br/>Wires ToolContext<br/>Wraps runner when env flag set"]
        DEFAULT_RUNNER["DefaultSubprocessRunner<br/>━━━━━━━━━━<br/>Real PTY subprocess<br/>Inner runner (unchanged)"]
    end

    subgraph Recording ["★ RECORDING DECORATOR — execution/recording.py"]
        REC_RUNNER["★ RecordingSubprocessRunner<br/>━━━━━━━━━━<br/>Implements SubprocessRunner<br/>Decorator: wraps inner runner"]
        PARSE_ENV["_extract_env_and_args()<br/>━━━━━━━━━━<br/>Parses env K=V cmd prefix<br/>Extracts SCENARIO_STEP_NAME"]
        PARSE_MODEL["_extract_model()<br/>━━━━━━━━━━<br/>Finds --model value<br/>from clean_args"]
        SESSION_PATH["Session Path<br/>━━━━━━━━━━<br/>pty_mode=True<br/>+ SCENARIO_STEP_NAME set"]
        NON_SESSION_PATH["Non-Session Path<br/>━━━━━━━━━━<br/>pty_mode=False<br/>+ SCENARIO_STEP_NAME set"]
        PASSTHRU["Pass-Through Path<br/>━━━━━━━━━━<br/>No SCENARIO_STEP_NAME<br/>Unrecorded delegation"]
    end

    subgraph ExternalIntegration ["EXTERNAL — api_simulator.claude"]
        RECORDER["ScenarioRecorder<br/>━━━━━━━━━━<br/>record_step()<br/>record_non_session_step()"]
        CASSETTE["Cassette Output<br/>━━━━━━━━━━<br/>stdout.jsonl + scenario YAML<br/>(RECORD_SCENARIO_DIR)"]
    end

    subgraph CommandChain ["● COMMAND CHAIN — execution/"]
        HEADLESS["● run_headless_core()<br/>━━━━━━━━━━<br/>headless.py<br/>Accepts step_name= kwarg"]
        BUILD_CMD["● build_full_headless_cmd()<br/>━━━━━━━━━━<br/>commands.py<br/>Injects SCENARIO_STEP_NAME=name"]
    end

    subgraph TestSuite ["★ TEST SUITE — tests/execution/"]
        TESTS["★ test_recording.py<br/>━━━━━━━━━━<br/>11 tests T1–T11<br/>Protocol · routing · env parsing · factory"]
        ARCH_TEST["● test_subpackage_isolation.py<br/>━━━━━━━━━━<br/>Arch isolation rules<br/>Updated allowlist for recording.py"]
    end

    %% COMPOSITION WIRING %%
    ENV -->|"flag detected"| MAKE_CTX
    DEFAULT_RUNNER -->|"wrapped as inner"| MAKE_CTX
    MAKE_CTX -->|"wraps → runner"| REC_RUNNER
    PROTO -.->|"satisfied by"| DEFAULT_RUNNER
    PROTO -.->|"satisfied by"| REC_RUNNER

    %% COMMAND CHAIN FLOW %%
    HEADLESS -->|"step_name= arg"| BUILD_CMD
    BUILD_CMD -->|"env prefix: SCENARIO_STEP_NAME=name"| REC_RUNNER

    %% RECORDING DISPATCH %%
    REC_RUNNER --> PARSE_ENV
    PARSE_ENV --> PARSE_MODEL
    PARSE_ENV -->|"pty_mode=True + name"| SESSION_PATH
    PARSE_ENV -->|"pty_mode=False + name"| NON_SESSION_PATH
    PARSE_ENV -->|"no name"| PASSTHRU

    SESSION_PATH -->|"record_step()"| RECORDER
    NON_SESSION_PATH -->|"delegate then record_non_session_step()"| RECORDER
    NON_SESSION_PATH -->|"delegate first"| DEFAULT_RUNNER
    PASSTHRU -->|"delegate unrecorded"| DEFAULT_RUNNER
    RECORDER -->|"writes"| CASSETTE

    %% TEST COVERAGE %%
    TESTS -->|"covers"| REC_RUNNER
    TESTS -->|"covers"| BUILD_CMD
    TESTS -->|"covers T10-T11"| MAKE_CTX
    ARCH_TEST -->|"validates isolation"| REC_RUNNER

    %% CLASS ASSIGNMENTS %%
    class PROTO stateNode;
    class ENV cli;
    class MAKE_CTX phase;
    class DEFAULT_RUNNER handler;
    class REC_RUNNER newComponent;
    class PARSE_ENV,PARSE_MODEL detector;
    class SESSION_PATH,NON_SESSION_PATH,PASSTHRU phase;
    class RECORDER integration;
    class CASSETTE output;
    class HEADLESS,BUILD_CMD handler;
    class TESTS newComponent;
    class ARCH_TEST handler;
```

Closes #672

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260408-221825-200595/.autoskillit/temp/make-plan/add_recording_subprocess_runner_plan_2026-04-08_222500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 2.3k | 30.8k | 1.1M | 69.6k | 1 | 12m 48s |
| verify | 43 | 22.2k | 2.0M | 72.1k | 1 | 8m 10s |
| implement | 72 | 22.2k | 3.6M | 69.9k | 1 | 9m 40s |
| prepare_pr | 10 | 5.0k | 175.1k | 30.6k | 1 | 1m 19s |
| run_arch_lenses | 1.2k | 19.3k | 713.3k | 101.7k | 3 | 6m 33s |
| compose_pr | 11 | 9.5k | 261.3k | 34.2k | 1 | 2m 26s |
| **Total** | 3.7k | 109.0k | 7.9M | 378.0k | | 40m 58s |