### PR TITLE
Add SequencingSubprocessRunner for Scenario Replay with Step-Name Dispatch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,7 @@ src/autoskillit/
 │   ├── linux_tracing.py     #   Linux-only /proc + psutil process tracing (accumulate snapshots)
 │   ├── anomaly_detection.py #   Post-hoc anomaly detection over ProcSnapshot series
 │   ├── session_log.py       #   File-based session diagnostics log writer (XDG-aware)
-│   ├── recording.py         #   RecordingSubprocessRunner — decorator that records headless sessions as scenario cassettes via api-simulator ScenarioRecorder
+│   ├── recording.py         #   RecordingSubprocessRunner, ReplayingSubprocessRunner, build_replay_runner — scenario I/O for headless sessions (record + replay via api-simulator)
 │   ├── process.py           #   Subprocess management facade (re-exports from _process_*.py)
 │   ├── _process_io.py       #   create_temp_io, read_temp_output
 │   ├── _process_jsonl.py    #   _jsonl_contains_marker, _jsonl_has_record_type, _marker_is_standalone

--- a/src/autoskillit/execution/__init__.py
+++ b/src/autoskillit/execution/__init__.py
@@ -68,8 +68,12 @@ from autoskillit.execution.recording import (
     RECORD_SCENARIO_DIR_ENV,
     RECORD_SCENARIO_ENV,
     RECORD_SCENARIO_RECIPE_ENV,
+    REPLAY_SCENARIO_DIR_ENV,
+    REPLAY_SCENARIO_ENV,
     SCENARIO_STEP_NAME_ENV,
     RecordingSubprocessRunner,
+    ScenarioReplayError,
+    SequencingSubprocessRunner,
 )
 from autoskillit.execution.remote_resolver import REMOTE_PRECEDENCE, resolve_remote_repo
 from autoskillit.execution.session import (
@@ -103,9 +107,13 @@ __all__ = [
     "run_managed_sync",
     # recording
     "RecordingSubprocessRunner",
+    "SequencingSubprocessRunner",
+    "ScenarioReplayError",
     "RECORD_SCENARIO_ENV",
     "RECORD_SCENARIO_DIR_ENV",
     "RECORD_SCENARIO_RECIPE_ENV",
+    "REPLAY_SCENARIO_ENV",
+    "REPLAY_SCENARIO_DIR_ENV",
     "SCENARIO_STEP_NAME_ENV",
     # quota
     "QuotaStatus",

--- a/src/autoskillit/execution/__init__.py
+++ b/src/autoskillit/execution/__init__.py
@@ -72,8 +72,9 @@ from autoskillit.execution.recording import (
     REPLAY_SCENARIO_ENV,
     SCENARIO_STEP_NAME_ENV,
     RecordingSubprocessRunner,
+    ReplayingSubprocessRunner,
     ScenarioReplayError,
-    SequencingSubprocessRunner,
+    build_replay_runner,
 )
 from autoskillit.execution.remote_resolver import REMOTE_PRECEDENCE, resolve_remote_repo
 from autoskillit.execution.session import (
@@ -107,8 +108,9 @@ __all__ = [
     "run_managed_sync",
     # recording
     "RecordingSubprocessRunner",
-    "SequencingSubprocessRunner",
+    "ReplayingSubprocessRunner",
     "ScenarioReplayError",
+    "build_replay_runner",
     "RECORD_SCENARIO_ENV",
     "RECORD_SCENARIO_DIR_ENV",
     "RECORD_SCENARIO_RECIPE_ENV",

--- a/src/autoskillit/execution/recording.py
+++ b/src/autoskillit/execution/recording.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import atexit
+from collections import deque
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -19,6 +20,14 @@ RECORD_SCENARIO_ENV = "RECORD_SCENARIO"
 RECORD_SCENARIO_DIR_ENV = "RECORD_SCENARIO_DIR"
 RECORD_SCENARIO_RECIPE_ENV = "RECORD_SCENARIO_RECIPE"
 SCENARIO_STEP_NAME_ENV = "SCENARIO_STEP_NAME"
+
+#: Environment variable names for scenario replay activation.
+REPLAY_SCENARIO_ENV = "REPLAY_SCENARIO"
+REPLAY_SCENARIO_DIR_ENV = "REPLAY_SCENARIO_DIR"
+
+
+class ScenarioReplayError(Exception):
+    """Raised when scenario replay cannot find a session or result for a step."""
 
 
 def _extract_env_and_args(cmd: list[str]) -> tuple[dict[str, str], list[str]]:
@@ -160,4 +169,74 @@ class RecordingSubprocessRunner(SubprocessRunner):
             termination=TerminationReason.NATURAL_EXIT,
             pid=0,
             elapsed_seconds=(step_result.cassette_duration_ms or 0) / 1000.0,
+        )
+
+
+class SequencingSubprocessRunner(SubprocessRunner):
+    """Replays pre-recorded sessions by step name.
+
+    Consumes the session map from ``ScenarioPlayer.build_session_map()``
+    and non-session step results from the scenario manifest. On each call,
+    extracts ``SCENARIO_STEP_NAME`` from the command env prefix and
+    dispatches to the matching step queue.
+    """
+
+    def __init__(
+        self,
+        session_map: dict[str, deque[tuple[Any, Any]]],
+        non_session_results: dict[str, dict[str, Any]],
+    ) -> None:
+        self._sessions = session_map
+        self._non_session = non_session_results
+        self.call_log: list[tuple[str, list[str]]] = []
+
+    async def __call__(
+        self,
+        cmd: list[str],
+        *,
+        cwd: Path,
+        timeout: float,
+        env: dict[str, str] | None = None,
+        stale_threshold: float = 1200,
+        completion_marker: str = "",
+        session_log_dir: Path | None = None,
+        pty_mode: bool = False,
+        input_data: str | None = None,
+        completion_drain_timeout: float = 5.0,
+        linux_tracing_config: Any | None = None,
+    ) -> SubprocessResult:
+        env_dict, clean_args = _extract_env_and_args(cmd)
+        step_name = env_dict.get(SCENARIO_STEP_NAME_ENV, "")
+        self.call_log.append((step_name, cmd))
+
+        if not step_name:
+            raise ValueError(f"SCENARIO_STEP_NAME not found in cmd env prefix: {cmd!r}")
+
+        if step_name in self._sessions and self._sessions[step_name]:
+            cli, meta = self._sessions[step_name].popleft()
+            result = cli.run()
+            return SubprocessResult(
+                returncode=meta.exit_code,
+                stdout=result.stdout,
+                stderr="",
+                termination=TerminationReason.NATURAL_EXIT,
+                pid=0,
+                elapsed_seconds=meta.duration_ms / 1000.0,
+            )
+
+        if step_name in self._non_session:
+            summary = self._non_session[step_name]
+            return SubprocessResult(
+                returncode=summary.get("exit_code", 0),
+                stdout=summary.get("stdout_head", ""),
+                stderr=summary.get("stderr", ""),
+                termination=TerminationReason.NATURAL_EXIT,
+                pid=0,
+            )
+
+        raise ScenarioReplayError(
+            f"No session or result for step {step_name!r}. "
+            f"Available sessions: {sorted(self._sessions.keys())}. "
+            f"Available non-session: {sorted(self._non_session.keys())}. "
+            f"Register a fallback via player.add_fallback({step_name!r}, cli)."
         )

--- a/src/autoskillit/execution/recording.py
+++ b/src/autoskillit/execution/recording.py
@@ -1,9 +1,11 @@
-"""RecordingSubprocessRunner — decorator that records headless sessions as scenario cassettes."""
+"""RecordingSubprocessRunner and ReplayingSubprocessRunner — scenario I/O for headless sessions."""
 
 from __future__ import annotations
 
 import asyncio
 import atexit
+import shutil
+import tempfile
 from collections import deque
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -15,13 +17,13 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
-#: Environment variable names for scenario recording activation.
+# Environment variable names for scenario recording activation.
 RECORD_SCENARIO_ENV = "RECORD_SCENARIO"
 RECORD_SCENARIO_DIR_ENV = "RECORD_SCENARIO_DIR"
 RECORD_SCENARIO_RECIPE_ENV = "RECORD_SCENARIO_RECIPE"
 SCENARIO_STEP_NAME_ENV = "SCENARIO_STEP_NAME"
 
-#: Environment variable names for scenario replay activation.
+# Environment variable names for scenario replay activation.
 REPLAY_SCENARIO_ENV = "REPLAY_SCENARIO"
 REPLAY_SCENARIO_DIR_ENV = "REPLAY_SCENARIO_DIR"
 
@@ -172,7 +174,7 @@ class RecordingSubprocessRunner(SubprocessRunner):
         )
 
 
-class SequencingSubprocessRunner(SubprocessRunner):
+class ReplayingSubprocessRunner(SubprocessRunner):
     """Replays pre-recorded sessions by step name.
 
     Consumes the session map from ``ScenarioPlayer.build_session_map()``
@@ -205,12 +207,13 @@ class SequencingSubprocessRunner(SubprocessRunner):
         completion_drain_timeout: float = 5.0,
         linux_tracing_config: Any | None = None,
     ) -> SubprocessResult:
-        env_dict, clean_args = _extract_env_and_args(cmd)
+        env_dict, _ = _extract_env_and_args(cmd)
         step_name = env_dict.get(SCENARIO_STEP_NAME_ENV, "")
-        self.call_log.append((step_name, cmd))
 
         if not step_name:
             raise ValueError(f"SCENARIO_STEP_NAME not found in cmd env prefix: {cmd!r}")
+
+        self.call_log.append((step_name, cmd))
 
         if step_name in self._sessions and self._sessions[step_name]:
             cli, meta = self._sessions[step_name].popleft()
@@ -238,5 +241,59 @@ class SequencingSubprocessRunner(SubprocessRunner):
             f"No session or result for step {step_name!r}. "
             f"Available sessions: {sorted(self._sessions.keys())}. "
             f"Available non-session: {sorted(self._non_session.keys())}. "
-            f"Register a fallback via player.add_fallback({step_name!r}, cli)."
+            f"Ensure the scenario was recorded with step {step_name!r} before replaying."
         )
+
+
+def build_replay_runner(replay_dir: str) -> ReplayingSubprocessRunner:
+    """Build a ReplayingSubprocessRunner from a scenario directory.
+
+    Creates a temporary output directory for the player, registers an atexit
+    handler to clean it up, then parses the scenario manifest and constructs
+    the deque-based session map.  All domain logic for replay setup lives here
+    (L1) rather than in the L3 composition root.
+
+    Args:
+        replay_dir: Path to a scenario directory produced by a recording run.
+
+    Returns:
+        A fully-initialised ReplayingSubprocessRunner ready to replace the
+        DefaultSubprocessRunner in a ToolContext.
+
+    Raises:
+        RuntimeError: If ``api_simulator`` is not installed.
+        Exception: Any exception raised by ``player.scenario()`` or
+            ``player.build_session_map()`` is re-raised after logging the
+            scenario path for context.
+    """
+    try:
+        from api_simulator.claude import make_scenario_player
+    except ImportError as exc:
+        raise RuntimeError(
+            "REPLAY_SCENARIO is set but 'api_simulator' is not installed. "
+            "Install it to enable scenario replay."
+        ) from exc
+
+    tmp_replay = tempfile.mkdtemp(prefix="autoskillit-replay-")
+    atexit.register(shutil.rmtree, tmp_replay, True)
+
+    player = make_scenario_player(
+        scenario_dir=replay_dir,
+        output_dir=tmp_replay,
+        binary_path=str(Path(tmp_replay) / "claude"),
+    )
+
+    try:
+        scenario = player.scenario()
+        non_session: dict[str, dict] = {
+            record.step_name: record.result_summary or {}
+            for record in scenario.step_sequence
+            if record.session_dir is None
+        }
+        raw_map = player.build_session_map()
+    except Exception:
+        logger.exception("Failed to parse scenario manifest in %r", replay_dir)
+        raise
+
+    session_map = {k: deque(v) for k, v in raw_map.items()}
+    return ReplayingSubprocessRunner(session_map, non_session)

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -19,6 +19,8 @@ from autoskillit.execution import (
     RECORD_SCENARIO_DIR_ENV,
     RECORD_SCENARIO_ENV,
     RECORD_SCENARIO_RECIPE_ENV,
+    REPLAY_SCENARIO_DIR_ENV,
+    REPLAY_SCENARIO_ENV,
     DefaultCIWatcher,
     DefaultDatabaseReader,
     DefaultGitHubFetcher,
@@ -116,7 +118,47 @@ def make_context(
 
         runner = DefaultSubprocessRunner()
 
-    if runner is not None and os.environ.get(RECORD_SCENARIO_ENV):
+    if runner is not None and os.environ.get(REPLAY_SCENARIO_ENV):
+        replay_dir = os.environ.get(REPLAY_SCENARIO_DIR_ENV, "")
+        if replay_dir:
+            if not os.path.isdir(replay_dir):
+                logger.warning(
+                    "REPLAY_SCENARIO_DIR=%r is not an existing directory — skipping replay",
+                    replay_dir,
+                )
+            else:
+                try:
+                    from api_simulator.claude import make_scenario_player
+                except ImportError as exc:
+                    raise RuntimeError(
+                        "REPLAY_SCENARIO is set but 'api_simulator' is not installed. "
+                        "Install it to enable scenario replay."
+                    ) from exc
+
+                import tempfile
+                from collections import deque
+
+                from autoskillit.execution import SequencingSubprocessRunner
+
+                tmp_replay = tempfile.mkdtemp(prefix="autoskillit-replay-")
+                player = make_scenario_player(
+                    scenario_dir=replay_dir,
+                    output_dir=tmp_replay,
+                    binary_path=os.path.join(tmp_replay, "claude"),
+                )
+
+                scenario = player.scenario()
+                non_session: dict[str, dict] = {}
+                for record in scenario.step_sequence:
+                    if record.session_dir is None:
+                        non_session[record.step_name] = record.result_summary or {}
+
+                raw_map = player.build_session_map()
+                session_map = {k: deque(v) for k, v in raw_map.items()}
+
+                runner = SequencingSubprocessRunner(session_map, non_session)
+
+    elif runner is not None and os.environ.get(RECORD_SCENARIO_ENV):
         scenario_dir = os.environ.get(RECORD_SCENARIO_DIR_ENV, "")
         recipe_name = os.environ.get(RECORD_SCENARIO_RECIPE_ENV, "unknown")
         if scenario_dir:

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -27,6 +27,7 @@ from autoskillit.execution import (
     DefaultHeadlessExecutor,
     DefaultMergeQueueWatcher,
     DefaultTestRunner,
+    build_replay_runner,
 )
 from autoskillit.migration import DefaultMigrationService, default_migration_engine
 from autoskillit.pipeline import (
@@ -120,43 +121,17 @@ def make_context(
 
     if runner is not None and os.environ.get(REPLAY_SCENARIO_ENV):
         replay_dir = os.environ.get(REPLAY_SCENARIO_DIR_ENV, "")
-        if replay_dir:
-            if not os.path.isdir(replay_dir):
-                logger.warning(
-                    "REPLAY_SCENARIO_DIR=%r is not an existing directory — skipping replay",
-                    replay_dir,
-                )
-            else:
-                try:
-                    from api_simulator.claude import make_scenario_player
-                except ImportError as exc:
-                    raise RuntimeError(
-                        "REPLAY_SCENARIO is set but 'api_simulator' is not installed. "
-                        "Install it to enable scenario replay."
-                    ) from exc
-
-                import tempfile
-                from collections import deque
-
-                from autoskillit.execution import SequencingSubprocessRunner
-
-                tmp_replay = tempfile.mkdtemp(prefix="autoskillit-replay-")
-                player = make_scenario_player(
-                    scenario_dir=replay_dir,
-                    output_dir=tmp_replay,
-                    binary_path=os.path.join(tmp_replay, "claude"),
-                )
-
-                scenario = player.scenario()
-                non_session: dict[str, dict] = {}
-                for record in scenario.step_sequence:
-                    if record.session_dir is None:
-                        non_session[record.step_name] = record.result_summary or {}
-
-                raw_map = player.build_session_map()
-                session_map = {k: deque(v) for k, v in raw_map.items()}
-
-                runner = SequencingSubprocessRunner(session_map, non_session)
+        if not replay_dir:
+            logger.warning(
+                "REPLAY_SCENARIO is set but REPLAY_SCENARIO_DIR is empty — skipping replay"
+            )
+        elif not os.path.isdir(replay_dir):
+            logger.warning(
+                "REPLAY_SCENARIO_DIR=%r is not an existing directory — skipping replay",
+                replay_dir,
+            )
+        else:
+            runner = build_replay_runner(replay_dir)
 
     elif runner is not None and os.environ.get(RECORD_SCENARIO_ENV):
         scenario_dir = os.environ.get(RECORD_SCENARIO_DIR_ENV, "")

--- a/tests/execution/test_recording.py
+++ b/tests/execution/test_recording.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import Mock
@@ -12,6 +13,8 @@ from autoskillit.core.types import SubprocessRunner, TerminationReason
 from autoskillit.execution.commands import build_full_headless_cmd
 from autoskillit.execution.recording import (
     RecordingSubprocessRunner,
+    ScenarioReplayError,
+    SequencingSubprocessRunner,
     _extract_env_and_args,
     _extract_model,
 )
@@ -23,6 +26,27 @@ class FakeStepResult:
     cassette_exit_code: int
     cassette_path: str
     cassette_duration_ms: int
+
+
+@dataclass
+class FakeSessionResult:
+    returncode: int
+    stdout: str
+
+
+class FakeCLI:
+    def __init__(self, stdout: str = "", returncode: int = 0) -> None:
+        self._result = FakeSessionResult(returncode, stdout)
+
+    def run(self, args: object = None, env: object = None) -> FakeSessionResult:
+        return self._result
+
+
+@dataclass
+class FakeMeta:
+    exit_code: int
+    model: str = "test"
+    duration_ms: int = 1000
 
 
 # --- T1: Protocol compliance ---
@@ -230,6 +254,7 @@ def test_make_context_wraps_runner_when_record_scenario(monkeypatch, tmp_path):
 
 def test_make_context_default_runner_without_record_scenario(monkeypatch, tmp_path):
     monkeypatch.delenv("RECORD_SCENARIO", raising=False)
+    monkeypatch.delenv("REPLAY_SCENARIO", raising=False)
 
     from autoskillit.config import AutomationConfig
     from autoskillit.execution.process import DefaultSubprocessRunner
@@ -237,3 +262,254 @@ def test_make_context_default_runner_without_record_scenario(monkeypatch, tmp_pa
 
     ctx = make_context(AutomationConfig(), plugin_dir=str(tmp_path))
     assert isinstance(ctx.runner, DefaultSubprocessRunner)
+
+
+# --- T12: Protocol conformance ---
+
+
+def test_sequencing_runner_satisfies_protocol():
+    """SequencingSubprocessRunner is a valid SubprocessRunner."""
+    runner = SequencingSubprocessRunner({}, {})
+    assert isinstance(runner, SubprocessRunner)
+
+
+# --- T13: Session step dispatch via FakeClaudeCLI replay ---
+
+
+@pytest.mark.anyio
+async def test_sequencing_session_step_dispatch(tmp_path):
+    """Step in session_map → popleft, cli.run(), return SubprocessResult from meta."""
+    cli = FakeCLI(stdout="session output", returncode=0)
+    meta = FakeMeta(exit_code=0, duration_ms=2000)
+    session_map: dict[str, deque] = {"implement": deque([(cli, meta)])}
+    runner = SequencingSubprocessRunner(session_map, {})
+
+    cmd = ["env", "SCENARIO_STEP_NAME=implement", "claude", "--print", "do stuff"]
+    result = await runner(cmd, cwd=tmp_path, timeout=60)
+
+    assert result.returncode == meta.exit_code
+    assert result.stdout == "session output"
+    assert result.termination == TerminationReason.NATURAL_EXIT
+    assert result.elapsed_seconds == meta.duration_ms / 1000.0
+
+
+# --- T14: Non-session step dispatch via result stub ---
+
+
+@pytest.mark.anyio
+async def test_sequencing_non_session_step_dispatch(tmp_path):
+    """Step in non_session_results → return SubprocessResult from summary."""
+    non_session = {
+        "test-check": {
+            "exit_code": 1,
+            "stdout_head": "FAILED",
+            "stderr": "error output",
+        }
+    }
+    runner = SequencingSubprocessRunner({}, non_session)
+
+    cmd = ["env", "SCENARIO_STEP_NAME=test-check", "task", "test-check"]
+    result = await runner(cmd, cwd=tmp_path, timeout=60)
+
+    assert result.returncode == 1
+    assert result.stdout == "FAILED"
+    assert result.stderr == "error output"
+    assert result.termination == TerminationReason.NATURAL_EXIT
+
+
+# --- T15: Missing step name raises ValueError ---
+
+
+@pytest.mark.anyio
+async def test_sequencing_missing_step_name_raises(tmp_path):
+    """No SCENARIO_STEP_NAME in cmd → ValueError."""
+    runner = SequencingSubprocessRunner({}, {})
+    cmd = ["claude", "--print", "test"]
+    with pytest.raises(ValueError, match="SCENARIO_STEP_NAME"):
+        await runner(cmd, cwd=tmp_path, timeout=60)
+
+
+# --- T16: Unknown step raises ScenarioReplayError ---
+
+
+@pytest.mark.anyio
+async def test_sequencing_unknown_step_raises(tmp_path):
+    """Step not in session_map or non_session → ScenarioReplayError with guidance."""
+    runner = SequencingSubprocessRunner({"known": deque()}, {"other": {}})
+    cmd = ["env", "SCENARIO_STEP_NAME=unknown-step", "claude", "--print", "test"]
+    with pytest.raises(ScenarioReplayError) as exc_info:
+        await runner(cmd, cwd=tmp_path, timeout=60)
+    msg = str(exc_info.value)
+    assert "unknown-step" in msg
+    assert "add_fallback" in msg
+    assert "known" in msg
+    assert "other" in msg
+
+
+# --- T17: call_log records all dispatches ---
+
+
+@pytest.mark.anyio
+async def test_sequencing_call_log(tmp_path):
+    """Each __call__ appends (step_name, cmd) to call_log."""
+    cli = FakeCLI(stdout="session", returncode=0)
+    meta = FakeMeta(exit_code=0, duration_ms=500)
+    non_session = {"check": {"exit_code": 0, "stdout_head": "ok", "stderr": ""}}
+    session_map: dict[str, deque] = {"run": deque([(cli, meta)])}
+    runner = SequencingSubprocessRunner(session_map, non_session)
+
+    cmd1 = ["env", "SCENARIO_STEP_NAME=run", "claude", "--print", "go"]
+    cmd2 = ["env", "SCENARIO_STEP_NAME=check", "task", "test"]
+
+    await runner(cmd1, cwd=tmp_path, timeout=60)
+    await runner(cmd2, cwd=tmp_path, timeout=60)
+
+    assert len(runner.call_log) == 2
+    assert runner.call_log[0] == ("run", cmd1)
+    assert runner.call_log[1] == ("check", cmd2)
+
+
+# --- T18: Multiple calls to same step advance the deque ---
+
+
+@pytest.mark.anyio
+async def test_sequencing_multiple_calls_advance_queue(tmp_path):
+    """Successive calls to same step popleft through the deque."""
+    cli1 = FakeCLI(stdout="first", returncode=0)
+    cli2 = FakeCLI(stdout="second", returncode=0)
+    meta1 = FakeMeta(exit_code=0, duration_ms=100)
+    meta2 = FakeMeta(exit_code=0, duration_ms=200)
+    session_map: dict[str, deque] = {"implement": deque([(cli1, meta1), (cli2, meta2)])}
+    runner = SequencingSubprocessRunner(session_map, {})
+
+    cmd = ["env", "SCENARIO_STEP_NAME=implement", "claude", "--print", "go"]
+    result1 = await runner(cmd, cwd=tmp_path, timeout=60)
+    result2 = await runner(cmd, cwd=tmp_path, timeout=60)
+
+    assert result1.stdout == "first"
+    assert result2.stdout == "second"
+
+
+# --- T19: Exhausted session deque falls through to non-session ---
+
+
+@pytest.mark.anyio
+async def test_sequencing_exhausted_session_falls_to_non_session(tmp_path):
+    """When session deque is empty but non_session has entry, use non_session."""
+    non_session = {"test": {"exit_code": 2, "stdout_head": "non-session result", "stderr": ""}}
+    session_map: dict[str, deque] = {"test": deque()}
+    runner = SequencingSubprocessRunner(session_map, non_session)
+
+    cmd = ["env", "SCENARIO_STEP_NAME=test", "task", "test"]
+    result = await runner(cmd, cwd=tmp_path, timeout=60)
+
+    assert result.returncode == 2
+    assert result.stdout == "non-session result"
+
+
+# --- T20: make_context wires SequencingSubprocessRunner when REPLAY_SCENARIO set ---
+
+
+def test_make_context_wires_sequencing_runner_when_replay_scenario(monkeypatch, tmp_path):
+    """REPLAY_SCENARIO=1 + valid dir → ctx.runner is SequencingSubprocessRunner."""
+    replay_dir = tmp_path / "replay"
+    replay_dir.mkdir()
+    monkeypatch.setenv("REPLAY_SCENARIO", "1")
+    monkeypatch.setenv("REPLAY_SCENARIO_DIR", str(replay_dir))
+    monkeypatch.delenv("RECORD_SCENARIO", raising=False)
+
+    mock_scenario = Mock()
+    mock_scenario.step_sequence = []
+    mock_player = Mock()
+    mock_player.scenario.return_value = mock_scenario
+    mock_player.build_session_map.return_value = {}
+
+    import api_simulator.claude as _api_sim_claude
+
+    monkeypatch.setattr(
+        _api_sim_claude, "make_scenario_player", Mock(return_value=mock_player), raising=False
+    )
+
+    from autoskillit.config import AutomationConfig
+    from autoskillit.server._factory import make_context
+
+    ctx = make_context(AutomationConfig(), plugin_dir=str(tmp_path))
+    assert isinstance(ctx.runner, SequencingSubprocessRunner)
+
+
+# --- T21: REPLAY_SCENARIO takes precedence over RECORD_SCENARIO ---
+
+
+def test_replay_takes_precedence_over_record(monkeypatch, tmp_path):
+    """When both REPLAY and RECORD env vars set, REPLAY wins."""
+    replay_dir = tmp_path / "replay"
+    replay_dir.mkdir()
+    monkeypatch.setenv("REPLAY_SCENARIO", "1")
+    monkeypatch.setenv("REPLAY_SCENARIO_DIR", str(replay_dir))
+    monkeypatch.setenv("RECORD_SCENARIO", "1")
+    monkeypatch.setenv("RECORD_SCENARIO_DIR", str(replay_dir))
+
+    mock_scenario = Mock()
+    mock_scenario.step_sequence = []
+    mock_player = Mock()
+    mock_player.scenario.return_value = mock_scenario
+    mock_player.build_session_map.return_value = {}
+    mock_recorder = Mock()
+
+    import api_simulator.claude as _api_sim_claude
+
+    monkeypatch.setattr(
+        _api_sim_claude, "make_scenario_player", Mock(return_value=mock_player), raising=False
+    )
+    monkeypatch.setattr(
+        _api_sim_claude, "make_scenario_recorder", Mock(return_value=mock_recorder), raising=False
+    )
+    monkeypatch.setattr("atexit.register", Mock())
+
+    from autoskillit.config import AutomationConfig
+    from autoskillit.server._factory import make_context
+
+    ctx = make_context(AutomationConfig(), plugin_dir=str(tmp_path))
+    assert isinstance(ctx.runner, SequencingSubprocessRunner)
+
+
+# --- T22: Cross-scenario session override (integration, requires api-simulator) ---
+
+
+@pytest.mark.anyio
+async def test_cross_scenario_override(tmp_path):
+    """ScenarioBuilder + cross-scenario override → SequencingSubprocessRunner replays override."""
+    api_sim = pytest.importorskip("api_simulator.claude")
+
+    b1 = api_sim.make_scenario_builder("recipe1")
+    b1.add_synthetic_step("implement", exit_code=0, stdout_lines=["from-scenario1"])
+
+    b2 = api_sim.make_scenario_builder("recipe2")
+    b2.add_synthetic_step("implement", exit_code=0, stdout_lines=["from-scenario2"])
+
+    scenario_dir1 = tmp_path / "s1"
+    scenario_dir1.mkdir()
+    scenario_dir2 = tmp_path / "s2"
+    scenario_dir2.mkdir()
+    binary = str(tmp_path / "claude")
+
+    player1 = b1.build(output_dir=str(scenario_dir1), binary_path=binary)
+    player2 = b2.build(output_dir=str(scenario_dir2), binary_path=binary)
+
+    raw_map1 = player1.build_session_map()
+    raw_map2 = player2.build_session_map()
+    assert "implement" in raw_map1
+    assert "implement" in raw_map2
+
+    # Override: replace player1's "implement" with a controlled FakeCLI (cross-scenario injection)
+    override_cli = FakeCLI(stdout="from-overridden-scenario2", returncode=0)
+    override_meta = FakeMeta(exit_code=0, duration_ms=500)
+    session_map: dict[str, deque] = {"implement": deque([(override_cli, override_meta)])}
+
+    runner = SequencingSubprocessRunner(session_map, {})
+    cmd = ["env", "SCENARIO_STEP_NAME=implement", "claude", "--print", "go"]
+    result = await runner(cmd, cwd=tmp_path, timeout=60)
+
+    assert result.stdout == "from-overridden-scenario2"
+    assert result.returncode == 0
+    assert result.elapsed_seconds == pytest.approx(0.5)

--- a/tests/execution/test_recording.py
+++ b/tests/execution/test_recording.py
@@ -13,8 +13,8 @@ from autoskillit.core.types import SubprocessRunner, TerminationReason
 from autoskillit.execution.commands import build_full_headless_cmd
 from autoskillit.execution.recording import (
     RecordingSubprocessRunner,
+    ReplayingSubprocessRunner,
     ScenarioReplayError,
-    SequencingSubprocessRunner,
     _extract_env_and_args,
     _extract_model,
 )
@@ -268,8 +268,8 @@ def test_make_context_default_runner_without_record_scenario(monkeypatch, tmp_pa
 
 
 def test_sequencing_runner_satisfies_protocol():
-    """SequencingSubprocessRunner is a valid SubprocessRunner."""
-    runner = SequencingSubprocessRunner({}, {})
+    """ReplayingSubprocessRunner is a valid SubprocessRunner."""
+    runner = ReplayingSubprocessRunner({}, {})
     assert isinstance(runner, SubprocessRunner)
 
 
@@ -282,7 +282,7 @@ async def test_sequencing_session_step_dispatch(tmp_path):
     cli = FakeCLI(stdout="session output", returncode=0)
     meta = FakeMeta(exit_code=0, duration_ms=2000)
     session_map: dict[str, deque] = {"implement": deque([(cli, meta)])}
-    runner = SequencingSubprocessRunner(session_map, {})
+    runner = ReplayingSubprocessRunner(session_map, {})
 
     cmd = ["env", "SCENARIO_STEP_NAME=implement", "claude", "--print", "do stuff"]
     result = await runner(cmd, cwd=tmp_path, timeout=60)
@@ -306,7 +306,7 @@ async def test_sequencing_non_session_step_dispatch(tmp_path):
             "stderr": "error output",
         }
     }
-    runner = SequencingSubprocessRunner({}, non_session)
+    runner = ReplayingSubprocessRunner({}, non_session)
 
     cmd = ["env", "SCENARIO_STEP_NAME=test-check", "task", "test-check"]
     result = await runner(cmd, cwd=tmp_path, timeout=60)
@@ -323,7 +323,7 @@ async def test_sequencing_non_session_step_dispatch(tmp_path):
 @pytest.mark.anyio
 async def test_sequencing_missing_step_name_raises(tmp_path):
     """No SCENARIO_STEP_NAME in cmd → ValueError."""
-    runner = SequencingSubprocessRunner({}, {})
+    runner = ReplayingSubprocessRunner({}, {})
     cmd = ["claude", "--print", "test"]
     with pytest.raises(ValueError, match="SCENARIO_STEP_NAME"):
         await runner(cmd, cwd=tmp_path, timeout=60)
@@ -335,13 +335,14 @@ async def test_sequencing_missing_step_name_raises(tmp_path):
 @pytest.mark.anyio
 async def test_sequencing_unknown_step_raises(tmp_path):
     """Step not in session_map or non_session → ScenarioReplayError with guidance."""
-    runner = SequencingSubprocessRunner({"known": deque()}, {"other": {}})
+    runner = ReplayingSubprocessRunner(
+        {"known": deque([(FakeCLI(), FakeMeta(exit_code=0))])}, {"other": {}}
+    )
     cmd = ["env", "SCENARIO_STEP_NAME=unknown-step", "claude", "--print", "test"]
     with pytest.raises(ScenarioReplayError) as exc_info:
         await runner(cmd, cwd=tmp_path, timeout=60)
     msg = str(exc_info.value)
     assert "unknown-step" in msg
-    assert "add_fallback" in msg
     assert "known" in msg
     assert "other" in msg
 
@@ -356,7 +357,7 @@ async def test_sequencing_call_log(tmp_path):
     meta = FakeMeta(exit_code=0, duration_ms=500)
     non_session = {"check": {"exit_code": 0, "stdout_head": "ok", "stderr": ""}}
     session_map: dict[str, deque] = {"run": deque([(cli, meta)])}
-    runner = SequencingSubprocessRunner(session_map, non_session)
+    runner = ReplayingSubprocessRunner(session_map, non_session)
 
     cmd1 = ["env", "SCENARIO_STEP_NAME=run", "claude", "--print", "go"]
     cmd2 = ["env", "SCENARIO_STEP_NAME=check", "task", "test"]
@@ -380,7 +381,7 @@ async def test_sequencing_multiple_calls_advance_queue(tmp_path):
     meta1 = FakeMeta(exit_code=0, duration_ms=100)
     meta2 = FakeMeta(exit_code=0, duration_ms=200)
     session_map: dict[str, deque] = {"implement": deque([(cli1, meta1), (cli2, meta2)])}
-    runner = SequencingSubprocessRunner(session_map, {})
+    runner = ReplayingSubprocessRunner(session_map, {})
 
     cmd = ["env", "SCENARIO_STEP_NAME=implement", "claude", "--print", "go"]
     result1 = await runner(cmd, cwd=tmp_path, timeout=60)
@@ -398,7 +399,7 @@ async def test_sequencing_exhausted_session_falls_to_non_session(tmp_path):
     """When session deque is empty but non_session has entry, use non_session."""
     non_session = {"test": {"exit_code": 2, "stdout_head": "non-session result", "stderr": ""}}
     session_map: dict[str, deque] = {"test": deque()}
-    runner = SequencingSubprocessRunner(session_map, non_session)
+    runner = ReplayingSubprocessRunner(session_map, non_session)
 
     cmd = ["env", "SCENARIO_STEP_NAME=test", "task", "test"]
     result = await runner(cmd, cwd=tmp_path, timeout=60)
@@ -407,11 +408,11 @@ async def test_sequencing_exhausted_session_falls_to_non_session(tmp_path):
     assert result.stdout == "non-session result"
 
 
-# --- T20: make_context wires SequencingSubprocessRunner when REPLAY_SCENARIO set ---
+# --- T20: make_context wires ReplayingSubprocessRunner when REPLAY_SCENARIO set ---
 
 
 def test_make_context_wires_sequencing_runner_when_replay_scenario(monkeypatch, tmp_path):
-    """REPLAY_SCENARIO=1 + valid dir → ctx.runner is SequencingSubprocessRunner."""
+    """REPLAY_SCENARIO=1 + valid dir → ctx.runner is ReplayingSubprocessRunner."""
     replay_dir = tmp_path / "replay"
     replay_dir.mkdir()
     monkeypatch.setenv("REPLAY_SCENARIO", "1")
@@ -423,18 +424,20 @@ def test_make_context_wires_sequencing_runner_when_replay_scenario(monkeypatch, 
     mock_player = Mock()
     mock_player.scenario.return_value = mock_scenario
     mock_player.build_session_map.return_value = {}
+    mock_make_player = Mock(return_value=mock_player)
 
     import api_simulator.claude as _api_sim_claude
 
-    monkeypatch.setattr(
-        _api_sim_claude, "make_scenario_player", Mock(return_value=mock_player), raising=False
-    )
+    monkeypatch.setattr(_api_sim_claude, "make_scenario_player", mock_make_player, raising=False)
 
     from autoskillit.config import AutomationConfig
     from autoskillit.server._factory import make_context
 
     ctx = make_context(AutomationConfig(), plugin_dir=str(tmp_path))
-    assert isinstance(ctx.runner, SequencingSubprocessRunner)
+    assert isinstance(ctx.runner, ReplayingSubprocessRunner)
+    mock_make_player.assert_called_once()
+    call_kwargs = mock_make_player.call_args.kwargs
+    assert call_kwargs.get("scenario_dir") == str(replay_dir)
 
 
 # --- T21: REPLAY_SCENARIO takes precedence over RECORD_SCENARIO ---
@@ -455,6 +458,7 @@ def test_replay_takes_precedence_over_record(monkeypatch, tmp_path):
     mock_player.scenario.return_value = mock_scenario
     mock_player.build_session_map.return_value = {}
     mock_recorder = Mock()
+    mock_make_recorder = Mock(return_value=mock_recorder)
 
     import api_simulator.claude as _api_sim_claude
 
@@ -462,7 +466,7 @@ def test_replay_takes_precedence_over_record(monkeypatch, tmp_path):
         _api_sim_claude, "make_scenario_player", Mock(return_value=mock_player), raising=False
     )
     monkeypatch.setattr(
-        _api_sim_claude, "make_scenario_recorder", Mock(return_value=mock_recorder), raising=False
+        _api_sim_claude, "make_scenario_recorder", mock_make_recorder, raising=False
     )
     monkeypatch.setattr("atexit.register", Mock())
 
@@ -470,7 +474,8 @@ def test_replay_takes_precedence_over_record(monkeypatch, tmp_path):
     from autoskillit.server._factory import make_context
 
     ctx = make_context(AutomationConfig(), plugin_dir=str(tmp_path))
-    assert isinstance(ctx.runner, SequencingSubprocessRunner)
+    assert isinstance(ctx.runner, ReplayingSubprocessRunner)
+    mock_make_recorder.assert_not_called()  # REPLAY takes precedence over RECORD
 
 
 # --- T22: Cross-scenario session override (integration, requires api-simulator) ---
@@ -478,35 +483,15 @@ def test_replay_takes_precedence_over_record(monkeypatch, tmp_path):
 
 @pytest.mark.anyio
 async def test_cross_scenario_override(tmp_path):
-    """ScenarioBuilder + cross-scenario override → SequencingSubprocessRunner replays override."""
-    api_sim = pytest.importorskip("api_simulator.claude")
-
-    b1 = api_sim.make_scenario_builder("recipe1")
-    b1.add_synthetic_step("implement", exit_code=0, stdout_lines=["from-scenario1"])
-
-    b2 = api_sim.make_scenario_builder("recipe2")
-    b2.add_synthetic_step("implement", exit_code=0, stdout_lines=["from-scenario2"])
-
-    scenario_dir1 = tmp_path / "s1"
-    scenario_dir1.mkdir()
-    scenario_dir2 = tmp_path / "s2"
-    scenario_dir2.mkdir()
-    binary = str(tmp_path / "claude")
-
-    player1 = b1.build(output_dir=str(scenario_dir1), binary_path=binary)
-    player2 = b2.build(output_dir=str(scenario_dir2), binary_path=binary)
-
-    raw_map1 = player1.build_session_map()
-    raw_map2 = player2.build_session_map()
-    assert "implement" in raw_map1
-    assert "implement" in raw_map2
-
-    # Override: replace player1's "implement" with a controlled FakeCLI (cross-scenario injection)
+    """Cross-scenario session injection → ReplayingSubprocessRunner replays override."""
+    # Simulate two scenarios providing the same step; override with a controlled FakeCLI
+    # to verify that ReplayingSubprocessRunner uses whatever session_map it is given,
+    # regardless of which scenario recorded a given step name.
     override_cli = FakeCLI(stdout="from-overridden-scenario2", returncode=0)
     override_meta = FakeMeta(exit_code=0, duration_ms=500)
     session_map: dict[str, deque] = {"implement": deque([(override_cli, override_meta)])}
 
-    runner = SequencingSubprocessRunner(session_map, {})
+    runner = ReplayingSubprocessRunner(session_map, {})
     cmd = ["env", "SCENARIO_STEP_NAME=implement", "claude", "--print", "go"]
     result = await runner(cmd, cwd=tmp_path, timeout=60)
 


### PR DESCRIPTION
## Summary

Add a `SequencingSubprocessRunner` to `src/autoskillit/execution/recording.py` that replays pre-recorded scenario fixtures dispatched by step name. This is the AutoSkillit-side adapter for `ScenarioPlayer.build_session_map()` from api-simulator. The runner consumes a step-name-keyed session map and non-session result stubs, and on each call extracts `SCENARIO_STEP_NAME` from the command prefix to dispatch to the correct replay source. Activation is via `REPLAY_SCENARIO=1` + `REPLAY_SCENARIO_DIR` environment variables in `make_context()`.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START])
    RESULT_OK([SubprocessResult returned])
    ERROR_REPLAY([ScenarioReplayError raised])
    ERROR_NOSTEP([ValueError: no SCENARIO_STEP_NAME])

    %% ─── PHASE 1: CONTEXT WIRING ─── %%
    subgraph Wiring ["● Phase 1 — Context Wiring  (server/_factory.py)"]
        direction TB
        MakeCtx["● make_context(config, runner)<br/>━━━━━━━━━━<br/>Composition root entry"]
        ChkReplay{"REPLAY_SCENARIO<br/>env set?"}
        ChkReplayDir{"REPLAY_SCENARIO_DIR<br/>is a valid directory?"}
        MakePlayer["make_scenario_player()<br/>━━━━━━━━━━<br/>api_simulator.claude<br/>Builds ScenarioPlayer"]
        BuildMap["player.build_session_map()<br/>+ extract non_session steps<br/>━━━━━━━━━━<br/>dict[step_name, deque[(cli,meta)]]<br/>dict[step_name, result_summary]"]
        SeqRunner["● SequencingSubprocessRunner<br/>━━━━━━━━━━<br/>session_map + non_session injected<br/>recording.py"]
        ChkRecord{"RECORD_SCENARIO<br/>env set?"}
        ChkRecordDir{"RECORD_SCENARIO_DIR<br/>is a valid directory?"}
        MakeRecorder["make_scenario_recorder()<br/>━━━━━━━━━━<br/>api_simulator.claude<br/>Builds ScenarioRecorder"]
        RecRunner["● RecordingSubprocessRunner<br/>━━━━━━━━━━<br/>recorder + inner runner injected<br/>recording.py"]
        DefaultRunner["DefaultSubprocessRunner<br/>━━━━━━━━━━<br/>Real subprocess execution"]
        CtxWired["● ToolContext.runner wired<br/>━━━━━━━━━━<br/>execution/__init__.py re-exports<br/>SequencingSubprocessRunner"]
    end

    %% ─── PHASE 2: SEQUENCING DISPATCH ─── %%
    subgraph SeqDispatch ["● Phase 2 — SequencingSubprocessRunner Dispatch  (recording.py)"]
        direction TB
        SeqCall["● __call__(cmd, ...)<br/>━━━━━━━━━━<br/>Replay path: no real subprocess"]
        ExtractSeq["_extract_env_and_args(cmd)<br/>━━━━━━━━━━<br/>Parse env K=V prefix<br/>Extract SCENARIO_STEP_NAME"]
        LogCall["call_log.append((step_name, cmd))<br/>━━━━━━━━━━<br/>Audit trail for test assertions"]
        ChkStepName{"step_name<br/>present?"}
        ChkSessionMap{"step_name in session_map<br/>AND deque non-empty?"}
        PopLeft["deque.popleft() → (cli, meta)<br/>━━━━━━━━━━<br/>Advances queue: next call<br/>gets next pre-recorded session"]
        RunCLI["cli.run()<br/>━━━━━━━━━━<br/>ScenarioPlayer CLI<br/>returns stdout + returncode"]
        BuildSeqResult["SubprocessResult(<br/>returncode=meta.exit_code,<br/>stdout=cli_result.stdout,<br/>elapsed=meta.duration_ms/1000<br/>)"]
        ChkNonSession{"step_name in<br/>non_session_results?"}
        BuildNonSessResult["SubprocessResult(<br/>returncode=summary[exit_code],<br/>stdout=summary[stdout_head],<br/>stderr=summary[stderr]<br/>)"]
    end

    %% ─── PHASE 3: RECORDING DISPATCH ─── %%
    subgraph RecDispatch ["● Phase 3 — RecordingSubprocessRunner Dispatch  (recording.py)"]
        direction TB
        RecCall["● __call__(cmd, ...)<br/>━━━━━━━━━━<br/>Record path: real subprocess + capture"]
        ExtractRec["_extract_env_and_args(cmd)<br/>━━━━━━━━━━<br/>Parse env K=V prefix<br/>Extract SCENARIO_STEP_NAME"]
        ChkPtyStep{"pty_mode=True<br/>AND step_name present?"}
        RecordStep["asyncio.to_thread(<br/>  recorder.record_step(<br/>    step_name, tool, args, model<br/>  )<br/>)<br/>━━━━━━━━━━<br/>Spawns real subprocess under PTY<br/>Writes cassette to disk"]
        ReadCassette["Read cassette/stdout.jsonl<br/>━━━━━━━━━━<br/>Load recorded session output"]
        BuildRecResult["SubprocessResult(<br/>returncode=cassette_exit_code,<br/>stdout=cassette_content,<br/>elapsed=duration_ms/1000<br/>)"]
        InnerCall["inner(cmd, ...)<br/>━━━━━━━━━━<br/>Delegate to DefaultSubprocessRunner<br/>Real subprocess execution"]
        ChkStepNameRec{"step_name<br/>present?"}
        RecordNonSession["recorder.record_non_session_step(<br/>  step_name, tool=run_cmd,<br/>  result_summary{exit_code, stdout_head}<br/>)<br/>━━━━━━━━━━<br/>Append to cassette manifest"]
    end

    %% ─── FLOW: WIRING ─── %%
    START --> MakeCtx
    MakeCtx --> ChkReplay
    ChkReplay -->|"yes"| ChkReplayDir
    ChkReplayDir -->|"yes"| MakePlayer
    MakePlayer --> BuildMap
    BuildMap --> SeqRunner
    SeqRunner --> CtxWired
    ChkReplayDir -->|"no / missing"| DefaultRunner
    ChkReplay -->|"no"| ChkRecord
    ChkRecord -->|"yes"| ChkRecordDir
    ChkRecordDir -->|"yes"| MakeRecorder
    MakeRecorder --> RecRunner
    RecRunner --> CtxWired
    ChkRecordDir -->|"no / missing"| DefaultRunner
    ChkRecord -->|"no"| DefaultRunner
    DefaultRunner --> CtxWired

    %% ─── FLOW: SEQUENCING DISPATCH ─── %%
    CtxWired -->|"runtime call → SequencingSubprocessRunner"| SeqCall
    SeqCall --> ExtractSeq
    ExtractSeq --> LogCall
    LogCall --> ChkStepName
    ChkStepName -->|"no"| ERROR_NOSTEP
    ChkStepName -->|"yes"| ChkSessionMap
    ChkSessionMap -->|"yes (deque has entries)"| PopLeft
    PopLeft --> RunCLI
    RunCLI --> BuildSeqResult
    BuildSeqResult --> RESULT_OK
    ChkSessionMap -->|"no (empty or absent)"| ChkNonSession
    ChkNonSession -->|"yes"| BuildNonSessResult
    BuildNonSessResult --> RESULT_OK
    ChkNonSession -->|"no"| ERROR_REPLAY

    %% ─── FLOW: RECORDING DISPATCH ─── %%
    CtxWired -->|"runtime call → RecordingSubprocessRunner"| RecCall
    RecCall --> ExtractRec
    ExtractRec --> ChkPtyStep
    ChkPtyStep -->|"yes"| RecordStep
    RecordStep --> ReadCassette
    ReadCassette --> BuildRecResult
    BuildRecResult --> RESULT_OK
    ChkPtyStep -->|"no"| InnerCall
    InnerCall --> ChkStepNameRec
    ChkStepNameRec -->|"yes"| RecordNonSession
    RecordNonSession --> RESULT_OK
    ChkStepNameRec -->|"no (pass-through)"| RESULT_OK

    %% ─── CLASS ASSIGNMENTS ─── %%
    class START,RESULT_OK,ERROR_REPLAY,ERROR_NOSTEP terminal;
    class MakeCtx,CtxWired phase;
    class ChkReplay,ChkReplayDir,ChkRecord,ChkRecordDir stateNode;
    class MakePlayer,BuildMap,MakeRecorder handler;
    class SeqRunner,RecRunner,DefaultRunner handler;
    class SeqCall,ExtractSeq,LogCall,PopLeft,RunCLI,BuildSeqResult,BuildNonSessResult handler;
    class RecCall,ExtractRec,RecordStep,ReadCassette,BuildRecResult,InnerCall,RecordNonSession handler;
    class ChkStepName,ChkSessionMap,ChkNonSession,ChkPtyStep,ChkStepNameRec stateNode;
    class ERROR_REPLAY,ERROR_NOSTEP detector;
```

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 55, 'rankSpacing': 75, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph L3 ["LAYER 3 — server/"]
        FACTORY["● server/_factory.py<br/>━━━━━━━━━━<br/>Composition Root<br/>make_context()"]
    end

    subgraph L1_EXEC ["LAYER 1 — execution/"]
        INIT["● execution/__init__.py<br/>━━━━━━━━━━<br/>Public re-export hub<br/>+SequencingSubprocessRunner<br/>+ScenarioReplayError"]
        RECORDING["● execution/recording.py<br/>━━━━━━━━━━<br/>RecordingSubprocessRunner<br/>SequencingSubprocessRunner (new)<br/>ScenarioReplayError (new)"]
        PROCESS["execution/process.py<br/>━━━━━━━━━━<br/>DefaultSubprocessRunner"]
    end

    subgraph L0 ["LAYER 0 — core/"]
        CORE["core/ (types + logging)<br/>━━━━━━━━━━<br/>SubprocessRunner Protocol<br/>SubprocessResult<br/>TerminationReason · get_logger"]
    end

    subgraph EXT ["EXTERNAL (optional install)"]
        API_SIM["api_simulator.claude<br/>━━━━━━━━━━<br/>ScenarioRecorder / make_scenario_recorder<br/>ScenarioPlayer / make_scenario_player"]
    end

    %% VALID DOWNWARD DEPENDENCIES %%
    FACTORY -->|"imports SequencingSubprocessRunner<br/>RecordingSubprocessRunner<br/>REPLAY/RECORD env-var constants"| INIT
    INIT -->|"re-exports from"| RECORDING
    RECORDING -->|"imports SubprocessRunner Protocol<br/>SubprocessResult · TerminationReason<br/>get_logger"| CORE
    RECORDING -->|"lazy import in __init__<br/>(RecordingSubprocessRunner default inner)"| PROCESS
    PROCESS -->|"implements"| CORE

    %% EXTERNAL / CONDITIONAL IMPORTS (dashed) %%
    FACTORY -.->|"conditional runtime import<br/>when REPLAY_SCENARIO_ENV set"| API_SIM
    RECORDING -.->|"TYPE_CHECKING only<br/>ScenarioRecorder annotation"| API_SIM

    %% CLASS ASSIGNMENTS %%
    class FACTORY phase;
    class INIT stateNode;
    class RECORDING handler;
    class PROCESS handler;
    class CORE stateNode;
    class API_SIM integration;
```

Closes #673

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260409-082853-554021/.autoskillit/temp/make-plan/sequencing_subprocess_runner_plan_2026-04-09_090000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 28 | 20.7k | 1.0M | 79.5k | 1 | 16m 21s |
| verify | 757 | 6.5k | 441.7k | 49.4k | 1 | 3m 56s |
| implement | 59 | 30.5k | 3.2M | 81.7k | 1 | 8m 43s |
| prepare_pr | 10 | 4.1k | 170.2k | 28.3k | 1 | 1m 22s |
| run_arch_lenses | 24 | 12.2k | 421.3k | 74.7k | 2 | 3m 32s |
| compose_pr | 10 | 6.4k | 193.4k | 27.1k | 1 | 1m 36s |
| **Total** | 888 | 80.5k | 5.5M | 340.5k | | 35m 32s |