### PR TITLE
Wire McpRecordingMiddleware into MCP Server for Scenario Recording

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -231,4 +231,4 @@ forbidden_modules = [
 ]
 
 [tool.uv.sources]
-api-simulator = { git = "https://github.com/TalonT-Org/api-simulator", rev = "11aecd04a1bc86d7da0ca9043b26e30a49e6bc20", subdirectory = "crates/api-simulator-py" }
+api-simulator = { git = "https://github.com/TalonT-Org/api-simulator", rev = "8f711f958d4d93a8e53a3c3b51279fb420870f3a", subdirectory = "crates/api-simulator-py" }

--- a/src/autoskillit/execution/recording.py
+++ b/src/autoskillit/execution/recording.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any
 from autoskillit.core import SubprocessResult, SubprocessRunner, TerminationReason, get_logger
 
 if TYPE_CHECKING:
-    from api_simulator.claude import ScenarioRecorder
+    from api_simulator.claude import ScenarioPlayer, ScenarioRecorder
 
 logger = get_logger(__name__)
 
@@ -74,7 +74,7 @@ class RecordingSubprocessRunner(SubprocessRunner):
         recorder: ScenarioRecorder,
         inner: SubprocessRunner | None = None,
     ) -> None:
-        self._recorder = recorder
+        self.recorder = recorder
         atexit.register(recorder.finalize)
         if inner is None:
             from autoskillit.execution.process import DefaultSubprocessRunner
@@ -124,7 +124,7 @@ class RecordingSubprocessRunner(SubprocessRunner):
         )
 
         if step_name:
-            self._recorder.record_non_session_step(
+            self.recorder.record_non_session_step(
                 step_name=step_name,
                 tool="run_cmd",
                 result_summary={
@@ -147,7 +147,7 @@ class RecordingSubprocessRunner(SubprocessRunner):
         """Record a session call via ScenarioRecorder.record_step()."""
         try:
             step_result = await asyncio.to_thread(
-                self._recorder.record_step,
+                self.recorder.record_step,
                 step_name=step_name,
                 tool="run_skill",
                 args=clean_args,
@@ -187,9 +187,12 @@ class ReplayingSubprocessRunner(SubprocessRunner):
         self,
         session_map: dict[str, deque[tuple[Any, Any]]],
         non_session_results: dict[str, dict[str, Any]],
+        *,
+        player: ScenarioPlayer | None = None,
     ) -> None:
         self._sessions = session_map
         self._non_session = non_session_results
+        self.player: ScenarioPlayer | None = player
         self.call_log: list[tuple[str, list[str]]] = []
 
     async def __call__(
@@ -296,4 +299,4 @@ def build_replay_runner(replay_dir: str) -> ReplayingSubprocessRunner:
         raise
 
     session_map = {k: deque(v) for k, v in raw_map.items()}
-    return ReplayingSubprocessRunner(session_map, non_session)
+    return ReplayingSubprocessRunner(session_map, non_session, player=player)

--- a/src/autoskillit/execution/recording.py
+++ b/src/autoskillit/execution/recording.py
@@ -67,6 +67,11 @@ class RecordingSubprocessRunner(SubprocessRunner):
     - **Non-session calls**: delegates to the inner runner, then records a summary via
       ``recorder.record_non_session_step()`` if ``SCENARIO_STEP_NAME`` is present.
     - **Calls without SCENARIO_STEP_NAME**: passes through to inner runner unrecorded.
+
+    Public attribute ``recorder`` holds the :class:`ScenarioRecorder` instance.
+    The symmetric counterpart :class:`ReplayingSubprocessRunner` exposes ``player``
+    (a ``ScenarioPlayer``).  The different names reflect the different domain objects
+    each class wraps — the asymmetry is intentional.
     """
 
     def __init__(

--- a/src/autoskillit/server/_state.py
+++ b/src/autoskillit/server/_state.py
@@ -24,12 +24,11 @@ from autoskillit.pipeline import ToolContext
 logger = get_logger(__name__)
 
 _ctx: ToolContext | None = None
-_wired_runner_id: int | None = None
 
 
 def _initialize(ctx: ToolContext) -> None:
     """Set the server's ToolContext. Called by cli/app.py serve() before mcp.run()."""
-    global _ctx, _wired_runner_id
+    global _ctx
     _ctx = ctx
 
     # Apply server-level subset visibility from config.
@@ -51,37 +50,42 @@ def _initialize(ctx: ToolContext) -> None:
     # Wire MCP recording/replay middleware for scenario capture.
     # Core imports are outside the try/except so a broken autoskillit installation
     # surfaces as an error rather than being silently swallowed as a middleware warning.
-    # The idempotency guard on _wired_runner_id prevents double-registration if
-    # _initialize() is called more than once with the same runner instance.
+    # The _mcp_middleware_registered flag on the runner prevents double-registration
+    # if _initialize() is called more than once with the same runner instance.
     from autoskillit.execution import (  # noqa: PLC0415
         RecordingSubprocessRunner,
         ReplayingSubprocessRunner,
     )
     from autoskillit.server import mcp  # noqa: PLC0415
 
-    if id(ctx.runner) != _wired_runner_id:
-        if isinstance(ctx.runner, RecordingSubprocessRunner):
-            try:
-                from api_simulator.mcp import McpRecordingMiddleware  # noqa: PLC0415
+    if isinstance(ctx.runner, RecordingSubprocessRunner) and not getattr(
+        ctx.runner, "_mcp_middleware_registered", False
+    ):
+        try:
+            from api_simulator.mcp import McpRecordingMiddleware  # noqa: PLC0415
 
-                mcp.add_middleware(McpRecordingMiddleware(ctx.runner.recorder))
-                _wired_runner_id = id(ctx.runner)
-                logger.info("mcp_recording_middleware_registered")
-            except ImportError:
-                logger.warning("mcp_scenario_middleware_unavailable", exc_info=True)
-            except Exception:
-                logger.warning("mcp_scenario_middleware_registration_failed", exc_info=True)
-        elif isinstance(ctx.runner, ReplayingSubprocessRunner) and ctx.runner.player is not None:
-            try:
-                from api_simulator.mcp import McpReplayMiddleware  # noqa: PLC0415
+            mcp.add_middleware(McpRecordingMiddleware(ctx.runner.recorder))
+            ctx.runner._mcp_middleware_registered = True  # type: ignore[attr-defined]
+            logger.info("mcp_recording_middleware_registered")
+        except ImportError:
+            logger.warning("mcp_scenario_middleware_unavailable", exc_info=True)
+        except Exception:
+            logger.warning("mcp_scenario_middleware_registration_failed", exc_info=True)
+    elif (
+        isinstance(ctx.runner, ReplayingSubprocessRunner)
+        and ctx.runner.player is not None
+        and not getattr(ctx.runner, "_mcp_middleware_registered", False)
+    ):
+        try:
+            from api_simulator.mcp import McpReplayMiddleware  # noqa: PLC0415
 
-                mcp.add_middleware(McpReplayMiddleware(ctx.runner.player))
-                _wired_runner_id = id(ctx.runner)
-                logger.info("mcp_replay_middleware_registered")
-            except ImportError:
-                logger.warning("mcp_scenario_middleware_unavailable", exc_info=True)
-            except Exception:
-                logger.warning("mcp_scenario_middleware_registration_failed", exc_info=True)
+            mcp.add_middleware(McpReplayMiddleware(ctx.runner.player))
+            ctx.runner._mcp_middleware_registered = True  # type: ignore[attr-defined]
+            logger.info("mcp_replay_middleware_registered")
+        except ImportError:
+            logger.warning("mcp_scenario_middleware_unavailable", exc_info=True)
+        except Exception:
+            logger.warning("mcp_scenario_middleware_registration_failed", exc_info=True)
 
     # Recovery sweep: finalize any orphaned tmpfs trace files from crashed sessions.
     try:

--- a/src/autoskillit/server/_state.py
+++ b/src/autoskillit/server/_state.py
@@ -49,7 +49,7 @@ def _initialize(ctx: ToolContext) -> None:
 
     # Wire MCP recording/replay middleware for scenario capture
     try:
-        from autoskillit.execution.recording import (  # noqa: PLC0415
+        from autoskillit.execution import (  # noqa: PLC0415
             RecordingSubprocessRunner,
             ReplayingSubprocessRunner,
         )

--- a/src/autoskillit/server/_state.py
+++ b/src/autoskillit/server/_state.py
@@ -47,6 +47,32 @@ def _initialize(ctx: ToolContext) -> None:
                 exc_info=True,
             )
 
+    # Wire MCP recording/replay middleware for scenario capture
+    try:
+        from autoskillit.execution.recording import (  # noqa: PLC0415
+            RecordingSubprocessRunner,
+            ReplayingSubprocessRunner,
+        )
+        from autoskillit.server import mcp  # noqa: PLC0415
+
+        if isinstance(ctx.runner, RecordingSubprocessRunner):
+            from api_simulator.mcp import McpRecordingMiddleware  # noqa: PLC0415
+
+            mcp.add_middleware(McpRecordingMiddleware(ctx.runner.recorder))
+            logger.info("mcp_recording_middleware_registered")
+        elif isinstance(ctx.runner, ReplayingSubprocessRunner) and ctx.runner.player is not None:
+            from api_simulator.mcp import McpReplayMiddleware  # noqa: PLC0415
+
+            mcp.add_middleware(McpReplayMiddleware(ctx.runner.player))
+            logger.info("mcp_replay_middleware_registered")
+    except ImportError:
+        logger.warning(
+            "mcp_scenario_middleware_unavailable",
+            exc_info=True,
+        )
+    except Exception:
+        logger.warning("mcp_scenario_middleware_registration_failed", exc_info=True)
+
     # Recovery sweep: finalize any orphaned tmpfs trace files from crashed sessions.
     try:
         from autoskillit.execution import recover_crashed_sessions

--- a/src/autoskillit/server/_state.py
+++ b/src/autoskillit/server/_state.py
@@ -24,11 +24,12 @@ from autoskillit.pipeline import ToolContext
 logger = get_logger(__name__)
 
 _ctx: ToolContext | None = None
+_wired_runner_id: int | None = None
 
 
 def _initialize(ctx: ToolContext) -> None:
     """Set the server's ToolContext. Called by cli/app.py serve() before mcp.run()."""
-    global _ctx
+    global _ctx, _wired_runner_id
     _ctx = ctx
 
     # Apply server-level subset visibility from config.
@@ -47,31 +48,40 @@ def _initialize(ctx: ToolContext) -> None:
                 exc_info=True,
             )
 
-    # Wire MCP recording/replay middleware for scenario capture
-    try:
-        from autoskillit.execution import (  # noqa: PLC0415
-            RecordingSubprocessRunner,
-            ReplayingSubprocessRunner,
-        )
-        from autoskillit.server import mcp  # noqa: PLC0415
+    # Wire MCP recording/replay middleware for scenario capture.
+    # Core imports are outside the try/except so a broken autoskillit installation
+    # surfaces as an error rather than being silently swallowed as a middleware warning.
+    # The idempotency guard on _wired_runner_id prevents double-registration if
+    # _initialize() is called more than once with the same runner instance.
+    from autoskillit.execution import (  # noqa: PLC0415
+        RecordingSubprocessRunner,
+        ReplayingSubprocessRunner,
+    )
+    from autoskillit.server import mcp  # noqa: PLC0415
 
+    if id(ctx.runner) != _wired_runner_id:
         if isinstance(ctx.runner, RecordingSubprocessRunner):
-            from api_simulator.mcp import McpRecordingMiddleware  # noqa: PLC0415
+            try:
+                from api_simulator.mcp import McpRecordingMiddleware  # noqa: PLC0415
 
-            mcp.add_middleware(McpRecordingMiddleware(ctx.runner.recorder))
-            logger.info("mcp_recording_middleware_registered")
+                mcp.add_middleware(McpRecordingMiddleware(ctx.runner.recorder))
+                _wired_runner_id = id(ctx.runner)
+                logger.info("mcp_recording_middleware_registered")
+            except ImportError:
+                logger.warning("mcp_scenario_middleware_unavailable", exc_info=True)
+            except Exception:
+                logger.warning("mcp_scenario_middleware_registration_failed", exc_info=True)
         elif isinstance(ctx.runner, ReplayingSubprocessRunner) and ctx.runner.player is not None:
-            from api_simulator.mcp import McpReplayMiddleware  # noqa: PLC0415
+            try:
+                from api_simulator.mcp import McpReplayMiddleware  # noqa: PLC0415
 
-            mcp.add_middleware(McpReplayMiddleware(ctx.runner.player))
-            logger.info("mcp_replay_middleware_registered")
-    except ImportError:
-        logger.warning(
-            "mcp_scenario_middleware_unavailable",
-            exc_info=True,
-        )
-    except Exception:
-        logger.warning("mcp_scenario_middleware_registration_failed", exc_info=True)
+                mcp.add_middleware(McpReplayMiddleware(ctx.runner.player))
+                _wired_runner_id = id(ctx.runner)
+                logger.info("mcp_replay_middleware_registered")
+            except ImportError:
+                logger.warning("mcp_scenario_middleware_unavailable", exc_info=True)
+            except Exception:
+                logger.warning("mcp_scenario_middleware_registration_failed", exc_info=True)
 
     # Recovery sweep: finalize any orphaned tmpfs trace files from crashed sessions.
     try:

--- a/tests/config/test_workspace_temp_dir_config.py
+++ b/tests/config/test_workspace_temp_dir_config.py
@@ -46,9 +46,7 @@ def test_temp_dir_layered_priority_user_wins_over_default(
     assert cfg.workspace.temp_dir == "/user/x"
 
 
-def test_temp_dir_env_override_wins(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_temp_dir_env_override_wins(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     project_dir = tmp_path / "project"
     project_cfg = project_dir / ".autoskillit"
     project_cfg.mkdir(parents=True)

--- a/tests/core/test_resolve_temp_dir.py
+++ b/tests/core/test_resolve_temp_dir.py
@@ -62,6 +62,4 @@ def test_resolve_temp_dir_no_autoskillit_imports() -> None:
         text=True,
         check=False,
     )
-    assert result.returncode == 0, (
-        f"core.io leaked imports outside core/: {result.stdout.strip()}"
-    )
+    assert result.returncode == 0, f"core.io leaked imports outside core/: {result.stdout.strip()}"

--- a/tests/execution/test_recording.py
+++ b/tests/execution/test_recording.py
@@ -498,3 +498,57 @@ async def test_cross_scenario_override(tmp_path):
     assert result.stdout == "from-overridden-scenario2"
     assert result.returncode == 0
     assert result.elapsed_seconds == pytest.approx(0.5)
+
+
+# --- T-REC-PUBLIC: recorder is a public attribute ---
+
+
+def test_recording_runner_recorder_is_public(monkeypatch):
+    """RecordingSubprocessRunner exposes recorder as a public attribute."""
+    monkeypatch.setattr("atexit.register", Mock())
+    mock_recorder = Mock()
+    runner = RecordingSubprocessRunner(recorder=mock_recorder)
+    assert runner.recorder is mock_recorder
+
+
+# --- T-REPLAY-PLAYER: player attribute stored ---
+
+
+def test_replaying_runner_stores_player_attribute():
+    """ReplayingSubprocessRunner stores player when provided."""
+    mock_player = Mock()
+    runner = ReplayingSubprocessRunner({}, {}, player=mock_player)
+    assert runner.player is mock_player
+
+
+# --- T-REPLAY-PLAYER-NONE: player defaults to None ---
+
+
+def test_replaying_runner_player_defaults_to_none():
+    """ReplayingSubprocessRunner.player is None when not provided."""
+    runner = ReplayingSubprocessRunner({}, {})
+    assert runner.player is None
+
+
+# --- T-BUILD-REPLAY-PLAYER: build_replay_runner stores player on runner ---
+
+
+def test_build_replay_runner_stores_player_on_runner(tmp_path, monkeypatch):
+    """build_replay_runner() passes the ScenarioPlayer to ReplayingSubprocessRunner.player."""
+    from autoskillit.execution.recording import build_replay_runner
+
+    mock_scenario = Mock()
+    mock_scenario.step_sequence = []
+    mock_player = Mock()
+    mock_player.scenario.return_value = mock_scenario
+    mock_player.build_session_map.return_value = {}
+
+    import api_simulator.claude as _api_sim_claude
+
+    monkeypatch.setattr(
+        _api_sim_claude, "make_scenario_player", Mock(return_value=mock_player), raising=False
+    )
+    monkeypatch.setattr("atexit.register", Mock())
+
+    result = build_replay_runner(str(tmp_path))
+    assert result.player is mock_player

--- a/tests/recipe/test_recipe_temp_substitution.py
+++ b/tests/recipe/test_recipe_temp_substitution.py
@@ -68,9 +68,7 @@ def test_load_recipe_rejects_yaml_unsafe_temp_dir_relpath(tmp_path: Path) -> Non
 
 def test_no_recipe_yaml_contains_literal_temp_path() -> None:
     """Bundled recipe YAMLs must use {{AUTOSKILLIT_TEMP}}, never the literal."""
-    recipes_root = (
-        Path(__file__).resolve().parents[2] / "src" / "autoskillit" / "recipes"
-    )
+    recipes_root = Path(__file__).resolve().parents[2] / "src" / "autoskillit" / "recipes"
     assert recipes_root.is_dir(), f"recipes root not found: {recipes_root}"
 
     offenders: list[str] = []

--- a/tests/server/test_server_init.py
+++ b/tests/server/test_server_init.py
@@ -1290,6 +1290,7 @@ def test_initialize_applies_subset_disables(monkeypatch):
     ctx = MagicMock(spec=ToolContext)
     ctx.config = AutomationConfig(subsets=SubsetsConfig(disabled=["github", "ci"]))
     ctx.session_skill_manager = None
+    ctx.runner = None
 
     with patch("autoskillit.server._ctx", None):
         with patch("autoskillit.server.mcp", mock_mcp):
@@ -1314,6 +1315,7 @@ def test_initialize_skips_subset_disable_when_empty(monkeypatch):
     ctx = MagicMock(spec=ToolContext)
     ctx.config = AutomationConfig(subsets=SubsetsConfig(disabled=[]))
     ctx.session_skill_manager = None
+    ctx.runner = None
 
     with patch("autoskillit.server.mcp", mock_mcp):
         from autoskillit.server._state import _initialize

--- a/tests/server/test_state.py
+++ b/tests/server/test_state.py
@@ -130,7 +130,7 @@ def test_initialize_registers_mcp_recording_middleware(tmp_path, monkeypatch):
         _initialize(mock_ctx)
 
     mock_middleware_cls.assert_called_once_with(mock_recorder)
-    mock_mcp.add_middleware.assert_called_once()
+    mock_mcp.add_middleware.assert_called_once_with(mock_middleware_cls.return_value)
 
 
 # --- T-INIT-2: No middleware registered for non-recording runner ---
@@ -205,4 +205,4 @@ def test_initialize_registers_mcp_replay_middleware(tmp_path, monkeypatch):
         _initialize(mock_ctx)
 
     mock_middleware_cls.assert_called_once_with(mock_player)
-    mock_mcp.add_middleware.assert_called_once()
+    mock_mcp.add_middleware.assert_called_once_with(mock_middleware_cls.return_value)

--- a/tests/server/test_state.py
+++ b/tests/server/test_state.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import sys
 import json
+import sys
 from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
@@ -105,7 +105,7 @@ def test_initialize_does_not_load_token_log(tmp_path):
 
 
 def test_initialize_registers_mcp_recording_middleware(tmp_path, monkeypatch):
-    """_initialize() calls mcp.add_middleware(McpRecordingMiddleware(recorder)) when runner is RecordingSubprocessRunner."""
+    """_initialize() registers McpRecordingMiddleware when runner is RecordingSubprocessRunner."""
     from autoskillit.execution.recording import RecordingSubprocessRunner
     from autoskillit.server._state import _initialize
 
@@ -137,7 +137,7 @@ def test_initialize_registers_mcp_recording_middleware(tmp_path, monkeypatch):
 
 
 def test_initialize_skips_middleware_for_non_recording_runner(tmp_path, monkeypatch):
-    """_initialize() does not call mcp.add_middleware() when runner is not RecordingSubprocessRunner."""
+    """_initialize() does not call mcp.add_middleware() for a non-recording runner."""
     from autoskillit.server._state import _initialize
 
     mock_ctx = _make_mock_ctx(tmp_path)
@@ -181,7 +181,7 @@ def test_initialize_recording_middleware_import_error_does_not_raise(tmp_path, m
 
 
 def test_initialize_registers_mcp_replay_middleware(tmp_path, monkeypatch):
-    """_initialize() calls mcp.add_middleware(McpReplayMiddleware(player)) when runner is ReplayingSubprocessRunner with player."""
+    """_initialize() registers McpReplayMiddleware when runner is ReplayingSubprocessRunner."""
     from autoskillit.execution.recording import ReplayingSubprocessRunner
     from autoskillit.server._state import _initialize
 

--- a/tests/server/test_state.py
+++ b/tests/server/test_state.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import sys
 import json
 from datetime import UTC, datetime
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 
 def _make_mock_ctx(tmp_path: Path) -> MagicMock:
@@ -98,3 +99,110 @@ def test_initialize_does_not_load_token_log(tmp_path):
         "_initialize() must not populate DefaultTimingLog from disk; "
         "timing telemetry is per-pipeline only"
     )
+
+
+# --- T-INIT-1: McpRecordingMiddleware registered for RecordingSubprocessRunner ---
+
+
+def test_initialize_registers_mcp_recording_middleware(tmp_path, monkeypatch):
+    """_initialize() calls mcp.add_middleware(McpRecordingMiddleware(recorder)) when runner is RecordingSubprocessRunner."""
+    from autoskillit.execution.recording import RecordingSubprocessRunner
+    from autoskillit.server._state import _initialize
+
+    monkeypatch.setattr("atexit.register", Mock())
+    mock_recorder = Mock()
+    recording_runner = RecordingSubprocessRunner(recorder=mock_recorder)
+
+    mock_ctx = _make_mock_ctx(tmp_path)
+    mock_ctx.runner = recording_runner
+    mock_ctx.config.subsets.disabled = []
+    mock_ctx.session_skill_manager = None
+
+    mock_mcp = MagicMock()
+    mock_middleware_cls = MagicMock()
+
+    import api_simulator.mcp as _api_sim_mcp
+
+    monkeypatch.setattr("autoskillit.server.mcp", mock_mcp)
+    monkeypatch.setattr(_api_sim_mcp, "McpRecordingMiddleware", mock_middleware_cls)
+
+    with patch("autoskillit.execution.recover_crashed_sessions", return_value=0):
+        _initialize(mock_ctx)
+
+    mock_middleware_cls.assert_called_once_with(mock_recorder)
+    mock_mcp.add_middleware.assert_called_once()
+
+
+# --- T-INIT-2: No middleware registered for non-recording runner ---
+
+
+def test_initialize_skips_middleware_for_non_recording_runner(tmp_path, monkeypatch):
+    """_initialize() does not call mcp.add_middleware() when runner is not RecordingSubprocessRunner."""
+    from autoskillit.server._state import _initialize
+
+    mock_ctx = _make_mock_ctx(tmp_path)
+    mock_ctx.runner = MagicMock()
+    mock_ctx.config.subsets.disabled = []
+    mock_ctx.session_skill_manager = None
+
+    mock_mcp = MagicMock()
+    monkeypatch.setattr("autoskillit.server.mcp", mock_mcp)
+
+    with patch("autoskillit.execution.recover_crashed_sessions", return_value=0):
+        _initialize(mock_ctx)
+
+    mock_mcp.add_middleware.assert_not_called()
+
+
+# --- T-INIT-3: ImportError from api_simulator.mcp does not raise ---
+
+
+def test_initialize_recording_middleware_import_error_does_not_raise(tmp_path, monkeypatch):
+    """_initialize() degrades gracefully when api_simulator.mcp is unavailable."""
+    from autoskillit.execution.recording import RecordingSubprocessRunner
+    from autoskillit.server._state import _initialize
+
+    monkeypatch.setattr("atexit.register", Mock())
+    mock_recorder = Mock()
+    recording_runner = RecordingSubprocessRunner(recorder=mock_recorder)
+
+    mock_ctx = _make_mock_ctx(tmp_path)
+    mock_ctx.runner = recording_runner
+    mock_ctx.config.subsets.disabled = []
+    mock_ctx.session_skill_manager = None
+
+    monkeypatch.setitem(sys.modules, "api_simulator.mcp", None)
+
+    with patch("autoskillit.execution.recover_crashed_sessions", return_value=0):
+        _initialize(mock_ctx)  # Must not raise
+
+
+# --- T-INIT-4: McpReplayMiddleware registered for ReplayingSubprocessRunner ---
+
+
+def test_initialize_registers_mcp_replay_middleware(tmp_path, monkeypatch):
+    """_initialize() calls mcp.add_middleware(McpReplayMiddleware(player)) when runner is ReplayingSubprocessRunner with player."""
+    from autoskillit.execution.recording import ReplayingSubprocessRunner
+    from autoskillit.server._state import _initialize
+
+    mock_player = Mock()
+    replaying_runner = ReplayingSubprocessRunner({}, {}, player=mock_player)
+
+    mock_ctx = _make_mock_ctx(tmp_path)
+    mock_ctx.runner = replaying_runner
+    mock_ctx.config.subsets.disabled = []
+    mock_ctx.session_skill_manager = None
+
+    mock_mcp = MagicMock()
+    mock_middleware_cls = MagicMock()
+
+    import api_simulator.mcp as _api_sim_mcp
+
+    monkeypatch.setattr("autoskillit.server.mcp", mock_mcp)
+    monkeypatch.setattr(_api_sim_mcp, "McpReplayMiddleware", mock_middleware_cls)
+
+    with patch("autoskillit.execution.recover_crashed_sessions", return_value=0):
+        _initialize(mock_ctx)
+
+    mock_middleware_cls.assert_called_once_with(mock_player)
+    mock_mcp.add_middleware.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -48,7 +48,7 @@ wheels = [
 [[package]]
 name = "api-simulator"
 version = "0.1.0"
-source = { git = "https://github.com/TalonT-Org/api-simulator?subdirectory=crates%2Fapi-simulator-py&rev=11aecd04a1bc86d7da0ca9043b26e30a49e6bc20#11aecd04a1bc86d7da0ca9043b26e30a49e6bc20" }
+source = { git = "https://github.com/TalonT-Org/api-simulator?subdirectory=crates%2Fapi-simulator-py&rev=8f711f958d4d93a8e53a3c3b51279fb420870f3a#8f711f958d4d93a8e53a3c3b51279fb420870f3a" }
 
 [[package]]
 name = "attrs"
@@ -106,7 +106,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anyio", specifier = ">=4.6.0" },
-    { name = "api-simulator", marker = "extra == 'dev'", git = "https://github.com/TalonT-Org/api-simulator?subdirectory=crates%2Fapi-simulator-py&rev=11aecd04a1bc86d7da0ca9043b26e30a49e6bc20" },
+    { name = "api-simulator", marker = "extra == 'dev'", git = "https://github.com/TalonT-Org/api-simulator?subdirectory=crates%2Fapi-simulator-py&rev=8f711f958d4d93a8e53a3c3b51279fb420870f3a" },
     { name = "cyclopts", specifier = ">=4.0" },
     { name = "dynaconf", specifier = ">=3.2.13,<4.0" },
     { name = "fastmcp", specifier = ">=3.2.0,<4.0" },


### PR DESCRIPTION
## Summary

Wire `McpRecordingMiddleware` (and `McpReplayMiddleware`) from the updated `api-simulator`
package into the FastMCP server so that every MCP tool call is captured in `scenario.json`
during `RECORD_SCENARIO=1` runs. The recording middleware must be registered on the `mcp`
instance after the `ScenarioRecorder` is created (inside `make_context()`) but before
`mcp.run()` is invoked. The registration point is `_initialize()` in `server/_state.py`,
which already holds both the `ToolContext` (via its `ctx` parameter) and can locally import
`mcp` following the established subset-visibility pattern. Two small structural changes in
`execution/recording.py` expose the recorder and player via public attributes to avoid
accessing private state in `_initialize()`.

## Architecture Impact

### Scenarios Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;

    %% ─────────────────────────────────────────────────────────
    %% SCENARIO 1: Scenario Recording
    %% ─────────────────────────────────────────────────────────
    subgraph S1 ["SCENARIO 1 — Scenario Recording (RECORD_SCENARIO set)"]
        direction LR
        S1_SERVE["serve()<br/>━━━━━━━━━━<br/>cli/app.py entry"]
        S1_FACTORY["make_context()<br/>━━━━━━━━━━<br/>reads RECORD_SCENARIO<br/>+ RECORD_SCENARIO_DIR"]
        S1_RECORDER["make_scenario_recorder()<br/>━━━━━━━━━━<br/>api_simulator.claude<br/>writes to scenario_dir"]
        S1_RUNNER["● RecordingSubprocessRunner<br/>━━━━━━━━━━<br/>recorder (public)<br/>wraps DefaultRunner"]
        S1_CTX["ToolContext<br/>━━━━━━━━━━<br/>runner = RecordingRunner"]
        S1_INIT["● _initialize(ctx)<br/>━━━━━━━━━━<br/>server/_state.py<br/>detects RecordingRunner"]
        S1_MW["McpRecordingMiddleware<br/>━━━━━━━━━━<br/>api_simulator.mcp<br/>mcp.add_middleware()"]
        S1_MCP["FastMCP server<br/>━━━━━━━━━━<br/>MCP calls + subprocess<br/>sessions both captured"]
    end

    S1_SERVE -->|"loads config"| S1_FACTORY
    S1_FACTORY -->|"instantiates"| S1_RECORDER
    S1_RECORDER -->|"injected into"| S1_RUNNER
    S1_RUNNER -->|"stored in"| S1_CTX
    S1_CTX -->|"passed to"| S1_INIT
    S1_INIT -->|"runner.recorder →"| S1_MW
    S1_MW -->|"registered on"| S1_MCP

    %% ─────────────────────────────────────────────────────────
    %% SCENARIO 2: Scenario Replay
    %% ─────────────────────────────────────────────────────────
    subgraph S2 ["SCENARIO 2 — Scenario Replay (REPLAY_SCENARIO set)"]
        direction LR
        S2_SERVE["serve()<br/>━━━━━━━━━━<br/>cli/app.py entry"]
        S2_FACTORY["make_context()<br/>━━━━━━━━━━<br/>reads REPLAY_SCENARIO<br/>+ REPLAY_SCENARIO_DIR"]
        S2_BUILD["build_replay_runner()<br/>━━━━━━━━━━<br/>execution/recording.py<br/>L1 factory function"]
        S2_PLAYER["make_scenario_player()<br/>━━━━━━━━━━<br/>api_simulator.claude<br/>loads cassette manifest"]
        S2_RUNNER["● ReplayingSubprocessRunner<br/>━━━━━━━━━━<br/>player (public)<br/>session_map from cassettes"]
        S2_CTX["ToolContext<br/>━━━━━━━━━━<br/>runner = ReplayingRunner"]
        S2_INIT["● _initialize(ctx)<br/>━━━━━━━━━━<br/>server/_state.py<br/>detects ReplayingRunner + player"]
        S2_MW["McpReplayMiddleware<br/>━━━━━━━━━━<br/>api_simulator.mcp<br/>mcp.add_middleware()"]
        S2_MCP["FastMCP server<br/>━━━━━━━━━━<br/>MCP calls + sessions<br/>served from cassettes"]
    end

    S2_SERVE -->|"loads config"| S2_FACTORY
    S2_FACTORY -->|"calls"| S2_BUILD
    S2_BUILD -->|"calls"| S2_PLAYER
    S2_PLAYER -->|"player injected into"| S2_RUNNER
    S2_RUNNER -->|"stored in"| S2_CTX
    S2_CTX -->|"passed to"| S2_INIT
    S2_INIT -->|"runner.player →"| S2_MW
    S2_MW -->|"registered on"| S2_MCP

    %% ─────────────────────────────────────────────────────────
    %% SCENARIO 3: Normal Server Startup
    %% ─────────────────────────────────────────────────────────
    subgraph S3 ["SCENARIO 3 — Normal Server Startup (no scenario env vars)"]
        direction LR
        S3_SERVE["serve()<br/>━━━━━━━━━━<br/>cli/app.py entry"]
        S3_FACTORY["make_context()<br/>━━━━━━━━━━<br/>no scenario env vars<br/>DefaultSubprocessRunner"]
        S3_RUNNER["DefaultSubprocessRunner<br/>━━━━━━━━━━<br/>live subprocess execution"]
        S3_CTX["ToolContext<br/>━━━━━━━━━━<br/>runner = DefaultRunner"]
        S3_INIT["● _initialize(ctx)<br/>━━━━━━━━━━<br/>neither Recording<br/>nor Replaying runner"]
        S3_MCP["FastMCP server<br/>━━━━━━━━━━<br/>no middleware added<br/>normal execution"]
    end

    S3_SERVE -->|"loads config"| S3_FACTORY
    S3_FACTORY -->|"instantiates"| S3_RUNNER
    S3_RUNNER -->|"stored in"| S3_CTX
    S3_CTX -->|"passed to"| S3_INIT
    S3_INIT -->|"no isinstance match →<br/>skip middleware"| S3_MCP

    %% ─────────────────────────────────────────────────────────
    %% SCENARIO 4: Graceful Degradation
    %% ─────────────────────────────────────────────────────────
    subgraph S4 ["SCENARIO 4 — Graceful Degradation (api_simulator absent)"]
        direction LR
        S4_RUNNER["● RecordingSubprocessRunner<br/>━━━━━━━━━━<br/>wired by make_context()"]
        S4_CTX["ToolContext<br/>━━━━━━━━━━<br/>runner = RecordingRunner"]
        S4_INIT["● _initialize(ctx)<br/>━━━━━━━━━━<br/>tries import<br/>api_simulator.mcp"]
        S4_ERR["ImportError<br/>━━━━━━━━━━<br/>api_simulator not installed"]
        S4_WARN["logger.warning()<br/>━━━━━━━━━━<br/>mcp_scenario_middleware_unavailable"]
        S4_MCP["FastMCP server<br/>━━━━━━━━━━<br/>no middleware added<br/>server starts normally"]
    end

    S4_RUNNER -->|"stored in"| S4_CTX
    S4_CTX -->|"passed to"| S4_INIT
    S4_INIT -->|"ImportError raised"| S4_ERR
    S4_ERR -->|"caught → logs"| S4_WARN
    S4_WARN -->|"continues →"| S4_MCP

    %% CLASS ASSIGNMENTS %%
    class S1_SERVE,S2_SERVE,S3_SERVE cli;
    class S1_FACTORY,S2_FACTORY,S3_FACTORY phase;
    class S1_RECORDER,S2_PLAYER,S2_BUILD handler;
    class S1_RUNNER,S2_RUNNER,S4_RUNNER handler;
    class S3_RUNNER handler;
    class S1_CTX,S2_CTX,S3_CTX,S4_CTX stateNode;
    class S1_INIT,S2_INIT,S3_INIT,S4_INIT phase;
    class S1_MW,S2_MW newComponent;
    class S1_MCP,S2_MCP,S3_MCP,S4_MCP output;
    class S4_ERR,S4_WARN detector;
```

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph L3 ["L3 — SERVER (FastMCP Application)"]
        direction LR
        SERVER_INIT["server/__init__.py<br/>━━━━━━━━━━<br/>FastMCP app + tool routing<br/>Calls _initialize() at startup"]
        STATE["● server/_state.py<br/>━━━━━━━━━━<br/>_initialize() wires<br/>McpRecordingMiddleware<br/>McpReplayMiddleware<br/>into MCP session"]
    end

    subgraph L1_EXEC ["L1 — EXECUTION"]
        direction LR
        EXEC_INIT["execution/__init__.py<br/>━━━━━━━━━━<br/>Re-export facade<br/>(full public surface)"]
        RECORDING["● execution/recording.py<br/>━━━━━━━━━━<br/>RecordingSubprocessRunner<br/>ReplayingSubprocessRunner<br/>build_replay_runner"]
        PROCESS["execution/process.py<br/>━━━━━━━━━━<br/>DefaultSubprocessRunner<br/>(concrete runner impl)"]
    end

    subgraph L1_SVC ["L1 — CONFIG + PIPELINE"]
        direction LR
        CONFIG["config/<br/>━━━━━━━━━━<br/>AutomationConfig"]
        PIPELINE["pipeline/<br/>━━━━━━━━━━<br/>ToolContext"]
    end

    subgraph L0 ["L0 — CORE (Foundation)"]
        direction LR
        CORE["core/<br/>━━━━━━━━━━<br/>SubprocessResult<br/>SubprocessRunner (Protocol)<br/>TerminationReason<br/>get_logger"]
    end

    subgraph EXT ["EXTERNAL — api_simulator"]
        direction LR
        API_CLAUDE["api_simulator.claude<br/>━━━━━━━━━━<br/>ScenarioPlayer<br/>ScenarioRecorder<br/>make_scenario_player"]
        API_MCP["api_simulator.mcp<br/>━━━━━━━━━━<br/>McpRecordingMiddleware<br/>McpReplayMiddleware"]
    end

    %% L3 internal
    SERVER_INIT -->|"imports _state.*"| STATE

    %% L3 → L1 (deferred inside _initialize)
    STATE -.->|"deferred: RecordingSubprocessRunner<br/>ReplayingSubprocessRunner"| EXEC_INIT
    STATE -->|"imports AutomationConfig"| CONFIG
    STATE -->|"imports ToolContext"| PIPELINE
    STATE -->|"imports get_logger"| CORE

    %% L3 → External (deferred inside _initialize)
    STATE -.->|"deferred: McpRecordingMiddleware<br/>McpReplayMiddleware"| API_MCP

    %% L1 Execution internal
    EXEC_INIT -->|"re-exports"| RECORDING
    RECORDING -.->|"deferred import"| PROCESS

    %% L1 → L0
    RECORDING -->|"imports SubprocessResult<br/>SubprocessRunner<br/>TerminationReason<br/>get_logger"| CORE

    %% L1 → External
    RECORDING -.->|"TYPE_CHECKING + deferred<br/>ScenarioPlayer / ScenarioRecorder<br/>make_scenario_player"| API_CLAUDE

    %% CLASS ASSIGNMENTS
    class SERVER_INIT cli;
    class STATE phase;
    class EXEC_INIT stateNode;
    class RECORDING,PROCESS handler;
    class CONFIG,PIPELINE phase;
    class CORE stateNode;
    class API_CLAUDE,API_MCP integration;
```

### Development Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    %% ===========================
    %%  COMPOSITION ROOT
    %% ===========================
    subgraph Factory ["COMPOSITION ROOT — server/_factory.py"]
        direction LR
        ENV_REC["RECORD_SCENARIO env<br/>━━━━━━━━━━<br/>Activates recording mode"]
        ENV_REP["REPLAY_SCENARIO env<br/>━━━━━━━━━━<br/>Activates replay mode"]
        MAKE_CTX["make_context()<br/>━━━━━━━━━━<br/>Wires runner into ToolContext<br/>REPLAY takes precedence"]
    end

    %% ===========================
    %%  EXECUTION LAYER
    %% ===========================
    subgraph Execution ["EXECUTION LAYER — execution/recording.py ●"]
        direction TB
        REC_RUNNER["● RecordingSubprocessRunner<br/>━━━━━━━━━━<br/>.recorder (public attr)<br/>Delegates to ScenarioRecorder<br/>for pty_mode session calls"]
        REP_RUNNER["● ReplayingSubprocessRunner<br/>━━━━━━━━━━<br/>.player (public attr, Optional)<br/>Replays sessions from deque<br/>via step_name dispatch"]
        BUILD_FN["● build_replay_runner(replay_dir)<br/>━━━━━━━━━━<br/>Factory: make_scenario_player()<br/>→ ReplayingSubprocessRunner(player=player)"]
    end

    %% ===========================
    %%  SERVER INIT
    %% ===========================
    subgraph ServerInit ["SERVER INITIALIZATION — server/_state.py ●"]
        direction TB
        INIT["● _initialize(ctx)<br/>━━━━━━━━━━<br/>Called by cli/app.py serve()<br/>before mcp.run()"]
        CHECK_REC["isinstance(ctx.runner,<br/>RecordingSubprocessRunner)<br/>━━━━━━━━━━<br/>Route to recording branch"]
        CHECK_REP["isinstance(ctx.runner,<br/>ReplayingSubprocessRunner)<br/>and player is not None<br/>━━━━━━━━━━<br/>Route to replay branch"]
        WIRE_REC["mcp.add_middleware(<br/>McpRecordingMiddleware<br/>(ctx.runner.recorder))"]
        WIRE_REP["mcp.add_middleware(<br/>McpReplayMiddleware<br/>(ctx.runner.player))"]
        IMPORT_ERR["ImportError → warn + degrade<br/>━━━━━━━━━━<br/>api_simulator unavailable<br/>= no middleware registered"]
    end

    %% ===========================
    %%  FASTMCP SERVER
    %% ===========================
    subgraph MCP ["FASTMCP SERVER — server/__init__.py"]
        direction LR
        MCP_INST["mcp (FastMCP instance)<br/>━━━━━━━━━━<br/>add_middleware() call<br/>registers middleware chain"]
    end

    %% ===========================
    %%  EXTERNAL: api_simulator
    %% ===========================
    subgraph ApiSim ["EXTERNAL — api_simulator (dev dependency ●)"]
        direction LR
        MCP_REC_MW["McpRecordingMiddleware<br/>━━━━━━━━━━<br/>api_simulator.mcp<br/>Records MCP tool calls"]
        MCP_REP_MW["McpReplayMiddleware<br/>━━━━━━━━━━<br/>api_simulator.mcp<br/>Replays MCP tool calls"]
        SCENARIO_REC["ScenarioRecorder<br/>━━━━━━━━━━<br/>api_simulator.claude<br/>Records session cassettes"]
        SCENARIO_PLAY["ScenarioPlayer<br/>━━━━━━━━━━<br/>api_simulator.claude<br/>Builds session_map deques"]
    end

    %% ===========================
    %%  TESTS
    %% ===========================
    subgraph Tests ["TEST COVERAGE — pytest + pytest-asyncio"]
        direction TB
        TEST_REC["● tests/execution/test_recording.py<br/>━━━━━━━━━━<br/>T-REC-PUBLIC: recorder is public<br/>T-REPLAY-PLAYER: player stored<br/>T-REPLAY-PLAYER-NONE: defaults None<br/>T-BUILD-REPLAY-PLAYER: builder wires player<br/>T1–T22: full recording/replay suite"]
        TEST_STATE["● tests/server/test_state.py<br/>━━━━━━━━━━<br/>T-INIT-1: McpRecordingMiddleware registered<br/>T-INIT-2: skipped for non-recording runner<br/>T-INIT-3: ImportError degrades gracefully<br/>T-INIT-4: McpReplayMiddleware registered"]
        TEST_OTHER["● tests/config/test_workspace_temp_dir_config.py<br/>● tests/core/test_resolve_temp_dir.py<br/>● tests/recipe/test_recipe_temp_substitution.py<br/>━━━━━━━━━━<br/>Collateral updates (minor)"]
    end

    %% ===========================
    %%  CONNECTIONS
    %% ===========================
    ENV_REC --> MAKE_CTX
    ENV_REP --> MAKE_CTX
    MAKE_CTX -->|"RECORD path"| REC_RUNNER
    MAKE_CTX -->|"REPLAY path"| BUILD_FN
    BUILD_FN -->|"player=player"| REP_RUNNER
    BUILD_FN -->|"calls"| SCENARIO_PLAY

    REC_RUNNER -->|".recorder"| SCENARIO_REC
    REP_RUNNER -->|".player"| SCENARIO_PLAY

    MAKE_CTX -->|"ToolContext.runner ="| INIT
    INIT --> CHECK_REC
    INIT --> CHECK_REP
    CHECK_REC -->|"runner.recorder"| WIRE_REC
    CHECK_REP -->|"runner.player"| WIRE_REP
    WIRE_REC -->|"instantiates"| MCP_REC_MW
    WIRE_REP -->|"instantiates"| MCP_REP_MW
    WIRE_REC -->|"add_middleware()"| MCP_INST
    WIRE_REP -->|"add_middleware()"| MCP_INST
    CHECK_REC -->|"ImportError"| IMPORT_ERR
    CHECK_REP -->|"ImportError"| IMPORT_ERR

    REC_RUNNER -.->|"tested by"| TEST_REC
    REP_RUNNER -.->|"tested by"| TEST_REC
    INIT -.->|"tested by"| TEST_STATE
    BUILD_FN -.->|"tested by"| TEST_REC

    %% CLASS ASSIGNMENTS %%
    class ENV_REC,ENV_REP cli;
    class MAKE_CTX phase;
    class REC_RUNNER,REP_RUNNER,BUILD_FN handler;
    class INIT,CHECK_REC,CHECK_REP phase;
    class WIRE_REC,WIRE_REP output;
    class IMPORT_ERR detector;
    class MCP_INST stateNode;
    class MCP_REC_MW,MCP_REP_MW,SCENARIO_REC,SCENARIO_PLAY integration;
    class TEST_REC,TEST_STATE,TEST_OTHER output;
```

Closes #716

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260411-073152-252651/.autoskillit/temp/make-plan/wire_mcprecordingmiddleware_plan_2026-04-11_155534.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 227 | 21.6k | 1.4M | 79.7k | 1 | 6m 46s |
| verify | 116 | 10.4k | 503.8k | 50.2k | 1 | 4m 53s |
| implement | 8.2k | 25.2k | 3.6M | 82.0k | 1 | 10m 14s |
| fix | 184 | 5.7k | 816.6k | 38.5k | 1 | 6m 2s |
| prepare_pr | 60 | 4.9k | 200.9k | 26.1k | 1 | 1m 18s |
| run_arch_lenses | 191 | 19.9k | 679.9k | 111.5k | 3 | 5m 47s |
| compose_pr | 91 | 8.5k | 364.5k | 34.2k | 1 | 1m 53s |
| **Total** | 9.1k | 96.1k | 7.6M | 422.2k | | 36m 56s |