### PR TITLE
Source-drift gate + open_kitchen envelope + quota cache versioning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,6 +235,7 @@ generic_automation_mcp/
 │   ├── _mcp_names.py        #   MCP prefix detection
 │   ├── _onboarding.py       #   First-run detection + guided menu
 │   ├── _prompts.py          #   Orchestrator prompt builder
+│   ├── _source_drift.py     #   Source-drift boot gate: install-type detection, reference-SHA resolution, dismissal-aware CLI gate
 │   ├── _stale_check.py      #   Version comparison, hook-drift prompt
 │   ├── _workspace.py        #   Workspace clean helpers
 │   └── app.py               #   CLI entry: serve, init, config, skills, recipes, doctor, etc.

--- a/src/autoskillit/cli/_doctor.py
+++ b/src/autoskillit/cli/_doctor.py
@@ -395,6 +395,30 @@ def _check_source_version_drift(home: Path | None = None) -> DoctorResult:
         )
 
 
+def _check_quota_cache_schema(cache_path: Path | None = None) -> DoctorResult:
+    """Check the quota cache file for schema version drift."""
+    check_name = "quota_cache_schema"
+    path = cache_path or (Path.home() / ".claude" / "autoskillit_quota_cache.json")
+    if not path.exists():
+        return DoctorResult(Severity.OK, check_name, "No quota cache present.")
+    try:
+        raw = json.loads(path.read_text())
+    except Exception as exc:
+        return DoctorResult(
+            Severity.WARNING,
+            check_name,
+            f"Quota cache at {path} could not be parsed: {type(exc).__name__}.",
+        )
+    observed = raw.get("schema_version") if isinstance(raw, dict) else None
+    if observed == 2:
+        return DoctorResult(Severity.OK, check_name, f"Quota cache schema v2 at {path}.")
+    return DoctorResult(
+        Severity.WARNING,
+        check_name,
+        f"Quota cache schema drift at {path}: observed={observed!r}, expected=2.",
+    )
+
+
 def run_doctor(*, output_json: bool = False) -> None:
     """Check project setup for common issues."""
     from autoskillit.cli._marketplace import _clear_plugin_cache
@@ -589,6 +613,9 @@ def run_doctor(*, output_json: bool = False) -> None:
 
     # Check 13: Source version drift (cache-only, never network)
     results.append(_check_source_version_drift())
+
+    # Check 14: Quota cache schema version
+    results.append(_check_quota_cache_schema())
 
     # Output
     if output_json:

--- a/src/autoskillit/cli/_doctor.py
+++ b/src/autoskillit/cli/_doctor.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from autoskillit.cli._hooks import _claude_settings_path, _load_settings_data
 from autoskillit.cli._init_helpers import _KNOWN_SCANNERS, _detect_secret_scanner
 from autoskillit.core import Severity, get_logger
-from autoskillit.execution.quota import QUOTA_CACHE_SCHEMA_VERSION
+from autoskillit.execution import QUOTA_CACHE_SCHEMA_VERSION
 from autoskillit.hook_registry import (
     _count_hook_registry_drift,
     canonical_script_basenames,
@@ -421,7 +421,8 @@ def _check_quota_cache_schema(cache_path: Path | None = None) -> DoctorResult:
     return DoctorResult(
         Severity.WARNING,
         check_name,
-        f"Quota cache schema drift at {path}: observed={observed!r}, expected={QUOTA_CACHE_SCHEMA_VERSION}.",
+        f"Quota cache schema drift at {path}: observed={observed!r}, "
+        f"expected={QUOTA_CACHE_SCHEMA_VERSION}.",
     )
 
 

--- a/src/autoskillit/cli/_doctor.py
+++ b/src/autoskillit/cli/_doctor.py
@@ -333,6 +333,68 @@ def _check_config_layers_for_secrets(
     )
 
 
+def _check_source_version_drift(home: Path | None = None) -> DoctorResult:
+    """Cache-only source-drift check.
+
+    Compares the installed commit SHA against the last-known HEAD of the branch
+    the binary was installed from.  Uses the disk cache written by previous
+    online invocations — **never makes a network request**.
+    """
+    check_name = "source_version_drift"
+    _home = home or Path.home()
+
+    try:
+        from autoskillit.cli._source_drift import (
+            InstallType,
+            detect_install,
+            resolve_reference_sha,
+        )
+
+        info = detect_install()
+
+        if info.install_type == InstallType.LOCAL_EDITABLE:
+            return DoctorResult(
+                Severity.OK, check_name, "Local editable install — drift check not applicable"
+            )
+
+        if info.install_type in (InstallType.UNKNOWN, InstallType.LOCAL_PATH):
+            return DoctorResult(
+                Severity.OK,
+                check_name,
+                "Not a source-tracked install — drift check not applicable",
+            )
+
+        # GIT_VCS: resolve SHA from disk cache only (network=False)
+        ref_sha = resolve_reference_sha(info, _home, network=False)
+
+        if ref_sha is None:
+            return DoctorResult(
+                Severity.OK,
+                check_name,
+                "Source drift cache is empty — run a command online to populate the check",
+            )
+
+        if info.commit_id == ref_sha:
+            return DoctorResult(Severity.OK, check_name, "No source drift detected")
+
+        installed_short = (info.commit_id or "unknown")[:8]
+        ref_short = ref_sha[:8]
+        return DoctorResult(
+            Severity.WARNING,
+            check_name,
+            f"Source drift: installed={installed_short}, reference={ref_short}. "
+            f"Run the appropriate install command to update.",
+        )
+
+    except Exception:
+        from autoskillit.core import get_logger as _get_logger
+
+        _get_logger(__name__).debug("Source drift check failed", exc_info=True)
+        return DoctorResult(
+            Severity.OK, check_name, "Source drift check skipped (unexpected error)"
+        )
+
+
 def run_doctor(*, output_json: bool = False) -> None:
     """Check project setup for common issues."""
     from autoskillit.cli._marketplace import _clear_plugin_cache
@@ -524,6 +586,9 @@ def run_doctor(*, output_json: bool = False) -> None:
 
     # Check 12: No stale autoskillit entry points outside ~/.local/bin
     results.append(_check_stale_entry_points())
+
+    # Check 13: Source version drift (cache-only, never network)
+    results.append(_check_source_version_drift())
 
     # Output
     if output_json:

--- a/src/autoskillit/cli/_doctor.py
+++ b/src/autoskillit/cli/_doctor.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from autoskillit.cli._hooks import _claude_settings_path, _load_settings_data
 from autoskillit.cli._init_helpers import _KNOWN_SCANNERS, _detect_secret_scanner
 from autoskillit.core import Severity, get_logger
+from autoskillit.execution.quota import QUOTA_CACHE_SCHEMA_VERSION
 from autoskillit.hook_registry import (
     _count_hook_registry_drift,
     canonical_script_basenames,
@@ -389,9 +390,7 @@ def _check_source_version_drift(home: Path | None = None) -> DoctorResult:
         )
 
     except Exception:
-        from autoskillit.core import get_logger as _get_logger
-
-        _get_logger(__name__).debug("Source drift check failed", exc_info=True)
+        _log.debug("Source drift check failed", exc_info=True)
         return DoctorResult(
             Severity.OK, check_name, "Source drift check skipped (unexpected error)"
         )
@@ -413,12 +412,16 @@ def _check_quota_cache_schema(cache_path: Path | None = None) -> DoctorResult:
             f"Quota cache at {path} could not be parsed: {type(exc).__name__}.",
         )
     observed = raw.get("schema_version") if isinstance(raw, dict) else None
-    if observed == 2:
-        return DoctorResult(Severity.OK, check_name, f"Quota cache schema v2 at {path}.")
+    if observed == QUOTA_CACHE_SCHEMA_VERSION:
+        return DoctorResult(
+            Severity.OK,
+            check_name,
+            f"Quota cache schema v{QUOTA_CACHE_SCHEMA_VERSION} at {path}.",
+        )
     return DoctorResult(
         Severity.WARNING,
         check_name,
-        f"Quota cache schema drift at {path}: observed={observed!r}, expected=2.",
+        f"Quota cache schema drift at {path}: observed={observed!r}, expected={QUOTA_CACHE_SCHEMA_VERSION}.",
     )
 
 

--- a/src/autoskillit/cli/_doctor.py
+++ b/src/autoskillit/cli/_doctor.py
@@ -10,12 +10,14 @@ from pathlib import Path
 
 from autoskillit.cli._hooks import _claude_settings_path, _load_settings_data
 from autoskillit.cli._init_helpers import _KNOWN_SCANNERS, _detect_secret_scanner
-from autoskillit.core import Severity
+from autoskillit.core import Severity, get_logger
 from autoskillit.hook_registry import (
     _count_hook_registry_drift,
     canonical_script_basenames,
     find_broken_hook_scripts,
 )
+
+_log = get_logger(__name__)
 
 
 @dataclass
@@ -404,6 +406,7 @@ def _check_quota_cache_schema(cache_path: Path | None = None) -> DoctorResult:
     try:
         raw = json.loads(path.read_text())
     except Exception as exc:
+        _log.warning("quota_cache_parse_error", path=str(path), exc_info=True)
         return DoctorResult(
             Severity.WARNING,
             check_name,

--- a/src/autoskillit/cli/_prompts.py
+++ b/src/autoskillit/cli/_prompts.py
@@ -113,6 +113,15 @@ FAILURE PREDICATES — when to follow on_failure:
 - run_skill: "success: False" in output
 - classify_fix: "error:" line present in output
 
+FAILURE PREDICATE — open_kitchen:
+  If the open_kitchen response contains `"success": false` OR does not
+  contain the substring `--- INGREDIENTS TABLE ---`:
+    1. Extract and print the value of "user_visible_message" from the
+       JSON response verbatim (fall back to the raw response text if
+       parsing fails).
+    2. DO NOT call AskUserQuestion.
+    3. End the session with a final text response.
+
 CONTEXT LIMIT ROUTING — run_skill only (check BEFORE on_failure):
 - When run_skill returns "success: False" AND "needs_retry: true" AND "retry_reason: resume":
   - Check "subtype" to discriminate the termination cause:

--- a/src/autoskillit/cli/_source_drift.py
+++ b/src/autoskillit/cli/_source_drift.py
@@ -1,0 +1,376 @@
+"""Source-drift boot gate for autoskillit CLI.
+
+Detects when the running binary's installed commit SHA diverges from the HEAD
+of the branch it was installed from (integration, stable, or local editable).
+
+Design principles:
+- Fail-open: any error causes a silent DEBUG log and early return.
+- Fast-fail: never blocks the CLI for more than a few seconds.
+- Guard env vars allow callers (subprocesses, CI) to bypass the gate entirely.
+- KeyboardInterrupt propagates — only ``Exception`` is swallowed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+from autoskillit.core import get_logger
+
+logger = get_logger(__name__)
+
+
+class InstallType(StrEnum):
+    GIT_VCS = "git-vcs"
+    LOCAL_EDITABLE = "local-editable"
+    LOCAL_PATH = "local-path"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class InstallInfo:
+    install_type: InstallType
+    commit_id: str | None
+    requested_revision: str | None
+    url: str | None
+    editable_source: Path | None
+
+
+def detect_install() -> InstallInfo:
+    """Classify the autoskillit install from ``direct_url.json`` metadata.
+
+    Returns ``InstallInfo(UNKNOWN, ...)`` on any error or when the metadata is
+    absent (e.g. installed via sdist from PyPI without a VCS reference).
+    """
+    _unknown = InstallInfo(InstallType.UNKNOWN, None, None, None, None)
+    try:
+        import importlib.metadata
+
+        dist = importlib.metadata.Distribution.from_name("autoskillit")
+        raw = dist.read_text("direct_url.json")
+        if not raw:
+            return _unknown
+
+        data = json.loads(raw)
+
+        vcs_info = data.get("vcs_info", {})
+        if isinstance(vcs_info, dict) and vcs_info.get("vcs") == "git":
+            return InstallInfo(
+                install_type=InstallType.GIT_VCS,
+                commit_id=vcs_info.get("commit_id") or None,
+                requested_revision=vcs_info.get("requested_revision") or None,
+                url=data.get("url") or None,
+                editable_source=None,
+            )
+
+        dir_info = data.get("dir_info", {})
+        url = data.get("url", "")
+        if isinstance(dir_info, dict) and dir_info.get("editable") is True:
+            if isinstance(url, str) and url.startswith("file://"):
+                src_path = url[len("file://"):]
+                return InstallInfo(
+                    install_type=InstallType.LOCAL_EDITABLE,
+                    commit_id=None,
+                    requested_revision=None,
+                    url=url,
+                    editable_source=Path(src_path),
+                )
+
+        if isinstance(url, str) and url.startswith("file://"):
+            return InstallInfo(
+                install_type=InstallType.LOCAL_PATH,
+                commit_id=None,
+                requested_revision=None,
+                url=url,
+                editable_source=None,
+            )
+
+        return _unknown
+
+    except Exception:
+        logger.debug("drift check: detect_install failed", exc_info=True)
+        return _unknown
+
+
+def find_source_repo() -> Path | None:
+    """Locate the autoskillit source repository root.
+
+    Resolution order:
+    1. ``AUTOSKILLIT_SOURCE_REPO`` env var (must exist and contain ``src/autoskillit/``).
+    2. Walk upward from ``Path.cwd()``, match ``pyproject.toml``
+       ``[project].name == "autoskillit"`` AND ``src/autoskillit/`` present.
+
+    Returns ``None`` if no match found or on any error.
+    """
+    try:
+        env_val = os.environ.get("AUTOSKILLIT_SOURCE_REPO")
+        if env_val:
+            candidate = Path(env_val)
+            if candidate.exists() and (candidate / "src" / "autoskillit").exists():
+                return candidate
+            logger.debug(
+                "AUTOSKILLIT_SOURCE_REPO=%s not usable (missing or no src/autoskillit/), "
+                "falling through to CWD walk",
+                env_val,
+            )
+
+        import tomllib
+
+        current = Path.cwd()
+        while True:
+            pyproject = current / "pyproject.toml"
+            if pyproject.is_file():
+                try:
+                    with open(pyproject, "rb") as fh:
+                        data = tomllib.load(fh)
+                    project_name = data.get("project", {}).get("name")
+                    if project_name == "autoskillit" and (
+                        current / "src" / "autoskillit"
+                    ).exists():
+                        return current
+                except Exception:
+                    logger.debug("drift check: could not parse %s", pyproject, exc_info=True)
+
+            parent = current.parent
+            if parent == current:  # Filesystem root
+                break
+            current = parent
+
+        return None
+    except Exception:
+        logger.debug("drift check: find_source_repo failed", exc_info=True)
+        return None
+
+
+def resolve_reference_sha(
+    info: InstallInfo,
+    home: Path,
+    *,
+    network: bool = True,
+) -> str | None:
+    """Resolve the current HEAD SHA of the branch the install was tracking.
+
+    Returns ``None`` when the SHA cannot be determined (network offline, no
+    source repo, unknown revision).  The caller treats ``None`` as "skip check"
+    (fail-open).
+
+    Args:
+        info: Install classification from ``detect_install()``.
+        home: User home directory (used by the disk-backed fetch cache).
+        network: When ``False``, only the local git or disk cache is consulted.
+            The doctor check uses ``network=False`` to guarantee no outbound calls.
+    """
+    try:
+        # Missing revision guard — bare pip install git+... has no @ref
+        if info.requested_revision is None:
+            logger.debug("drift check skipped: no requested_revision in direct_url.json")
+            return None
+
+        rev = info.requested_revision
+
+        # Short-circuit: exact SHA equality means no drift is possible.
+        # IMPORTANT: use == not startswith — a branch named after a hex prefix
+        # of the commit SHA must NOT false-positive here.
+        if rev == info.commit_id:
+            return info.commit_id
+
+        sha: str | None = None
+
+        source_repo = find_source_repo()
+        if source_repo is not None and source_repo.exists():
+            sha = _git_ls_remote_sha(source_repo, rev)
+
+        if sha is None:
+            # No source repo or git failed — fall through to API/cache
+            sha = _api_sha(rev, home, network=network)
+
+        return sha
+
+    except Exception:
+        logger.debug("drift check skipped: resolve_reference_sha error", exc_info=True)
+        return None
+
+
+def _git_ls_remote_sha(source_repo: Path, rev: str) -> str | None:
+    """Run git ls-remote to resolve a branch or tag ref SHA.
+
+    Tries ``refs/heads/<rev>`` first, then ``refs/tags/<rev>^{}`` for peeled
+    tag objects.  Returns ``None`` on empty output or any subprocess error.
+    """
+    for ref in (f"refs/heads/{rev}", f"refs/tags/{rev}^{{}}"):
+        try:
+            result = subprocess.run(
+                ["git", "-C", str(source_repo), "ls-remote", "origin", ref],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                env=os.environ,
+            )
+            first_line = result.stdout.strip().splitlines()[0] if result.stdout.strip() else ""
+            if first_line:
+                sha = first_line.split()[0]
+                if sha:
+                    return sha
+        except (subprocess.SubprocessError, FileNotFoundError, OSError, IndexError):
+            logger.debug("git ls-remote failed for ref=%s", ref, exc_info=True)
+    return None
+
+
+def _api_sha(rev: str, home: Path, *, network: bool = True) -> str | None:
+    """Return the commit SHA for ``rev`` from the GitHub API or disk cache.
+
+    When ``network=False`` (doctor mode), reads the existing cache without
+    any TTL check and makes no outbound HTTP request.  Returns ``None`` if the
+    cache has no entry for the URL.
+    """
+    url = f"https://api.github.com/repos/TalonT-Org/AutoSkillit/git/refs/heads/{rev}"
+
+    if network:
+        from autoskillit.cli._stale_check import _fetch_with_cache
+
+        data: Any = _fetch_with_cache(url, home=home)
+    else:
+        # Cache-only: read existing disk cache regardless of TTL
+        from autoskillit.cli._stale_check import _read_fetch_cache
+
+        cache = _read_fetch_cache(home)
+        entry = cache.get(url) if isinstance(cache.get(url), dict) else None
+        data = entry.get("body") if isinstance(entry, dict) else None
+
+    if not isinstance(data, dict):
+        return None
+    obj = data.get("object")
+    if not isinstance(obj, dict):
+        return None
+    sha = obj.get("sha")
+    return sha if isinstance(sha, str) and sha else None
+
+
+def run_source_drift_check(home: Path | None = None) -> None:
+    """Run the source-drift gate on interactive CLI invocations.
+
+    Guards (checked BEFORE the fail-open try/except so KeyboardInterrupt
+    during a guard still propagates):
+    - ``AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK=1`` — explicit bypass
+    - ``CLAUDECODE=1`` — headless/MCP session
+    - ``CI=1`` — generic CI environment (GitHub Actions, CircleCI, etc.)
+    """
+    if (
+        os.environ.get("AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK")
+        or os.environ.get("CLAUDECODE")
+        or os.environ.get("CI")
+    ):
+        return
+
+    try:
+        _home = home or Path.home()
+        _skip_env: dict[str, str] = {
+            **os.environ,
+            "AUTOSKILLIT_SKIP_STALE_CHECK": "1",
+            "AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK": "1",
+        }
+
+        info = detect_install()
+
+        if info.install_type in (InstallType.UNKNOWN, InstallType.LOCAL_PATH):
+            logger.debug("drift check skipped: install type is %s", info.install_type)
+            return
+
+        ref_sha = resolve_reference_sha(info, _home, network=True)
+        if ref_sha is None:
+            return
+
+        if info.commit_id == ref_sha:
+            return
+
+        # Drift detected — check dismissal
+        from autoskillit.cli._stale_check import (
+            _is_drift_dismissed,
+            _read_dismiss_state,
+            _write_dismiss_state,
+        )
+
+        state = _read_dismiss_state(_home)
+        if _is_drift_dismissed(state, info.commit_id or "", ref_sha):
+            return
+
+        installed_short = (info.commit_id or "unknown")[:8]
+        ref_short = ref_sha[:8]
+        hint = _fix_hint(info)
+
+        print(
+            f"\n[autoskillit] Source drift detected:\n"
+            f"  installed: {installed_short} ({info.requested_revision or info.install_type})\n"
+            f"  reference: {ref_short}\n"
+            f"  Fix: {hint}",
+            flush=True,
+        )
+
+        if sys.stdin.isatty() and sys.stdout.isatty():
+            answer = input("Update now? [Y/n] ").strip().lower()
+            if answer in ("", "y", "yes"):
+                install_cmd = _install_cmd(info)
+                if install_cmd:
+                    from autoskillit.cli._terminal import terminal_guard
+
+                    with terminal_guard():
+                        subprocess.run(install_cmd, check=False, env=_skip_env)
+            else:
+                state["source_drift"] = {
+                    "dismissed_at": datetime.now(UTC).isoformat(),
+                    "installed_sha": info.commit_id or "",
+                    "reference_sha": ref_sha,
+                }
+                _write_dismiss_state(_home, state)
+        else:
+            print(
+                "[autoskillit] source drift detected; update with the command shown above.",
+                flush=True,
+            )
+
+    except Exception:
+        logger.debug("drift check skipped: unexpected error", exc_info=True)
+
+
+def _fix_hint(info: InstallInfo) -> str:
+    """Return the human-readable fix command for the given install classification."""
+    if info.install_type == InstallType.GIT_VCS:
+        rev = info.requested_revision or ""
+        if rev == "integration":
+            return "task install-dev"
+        if rev == "stable":
+            return (
+                "curl -fsSL"
+                " https://raw.githubusercontent.com/TalonT-Org/AutoSkillit/stable/install.sh"
+                " | sh"
+            )
+        return "reinstall from the source you originally used"
+    if info.install_type == InstallType.LOCAL_EDITABLE:
+        return "task install-worktree"
+    return "reinstall from the source you originally used"
+
+
+def _install_cmd(info: InstallInfo) -> list[str] | None:
+    """Return the subprocess command to run for the given install classification."""
+    if info.install_type == InstallType.GIT_VCS:
+        rev = info.requested_revision or ""
+        if rev == "integration":
+            return ["task", "install-dev"]
+        if rev == "stable":
+            return [
+                "sh",
+                "-c",
+                "curl -fsSL"
+                " https://raw.githubusercontent.com/TalonT-Org/AutoSkillit/stable/install.sh"
+                " | sh",
+            ]
+    if info.install_type == InstallType.LOCAL_EDITABLE:
+        return ["task", "install-worktree"]
+    return None

--- a/src/autoskillit/cli/_source_drift.py
+++ b/src/autoskillit/cli/_source_drift.py
@@ -74,7 +74,7 @@ def detect_install() -> InstallInfo:
         url = data.get("url", "")
         if isinstance(dir_info, dict) and dir_info.get("editable") is True:
             if isinstance(url, str) and url.startswith("file://"):
-                src_path = url[len("file://"):]
+                src_path = url[len("file://") :]
                 return InstallInfo(
                     install_type=InstallType.LOCAL_EDITABLE,
                     commit_id=None,
@@ -131,9 +131,10 @@ def find_source_repo() -> Path | None:
                     with open(pyproject, "rb") as fh:
                         data = tomllib.load(fh)
                     project_name = data.get("project", {}).get("name")
-                    if project_name == "autoskillit" and (
-                        current / "src" / "autoskillit"
-                    ).exists():
+                    if (
+                        project_name == "autoskillit"
+                        and (current / "src" / "autoskillit").exists()
+                    ):
                         return current
                 except Exception:
                     logger.debug("drift check: could not parse %s", pyproject, exc_info=True)

--- a/src/autoskillit/cli/_stale_check.py
+++ b/src/autoskillit/cli/_stale_check.py
@@ -109,7 +109,7 @@ def _read_fetch_cache(home: Path) -> dict[str, Any]:
         data = json.loads(_fetch_cache_path(home).read_text(encoding="utf-8"))
         return data if isinstance(data, dict) else {}
     except Exception:
-        logger.debug("Failed to read fetch cache", exc_info=False)
+        logger.debug("Failed to read fetch cache", exc_info=True)
         return {}
 
 

--- a/src/autoskillit/cli/_stale_check.py
+++ b/src/autoskillit/cli/_stale_check.py
@@ -12,18 +12,37 @@ import json
 import os
 import subprocess
 import sys
+import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from typing import Any
+
+import httpx
 
 from autoskillit.cli._terminal import terminal_guard
-from autoskillit.core import get_logger, pkg_root
+from autoskillit.core import AUTOSKILLIT_INSTALLED_VERSION, atomic_write, get_logger, pkg_root
 
 logger = get_logger(__name__)
 
 _DISMISS_FILE = "update_check.json"
 _DISMISS_WINDOW = timedelta(hours=12)
 _SNOOZE_WINDOW = timedelta(hours=1)
-_FETCH_TIMEOUT = 5
+
+# Disposable on-disk cache for GitHub API GETs.  This is intentionally a plain
+# JSON dict (not ``write_versioned_json``) — it is a transient performance
+# cache, not a persisted schema artifact, so a stray pre-existing file at the
+# same path is safely ignored on a JSON parse failure.
+_FETCH_CACHE_FILE = "github_fetch_cache.json"
+_DEFAULT_FETCH_TTL_SECONDS = 30 * 60
+
+# connect=2s buffers for cold DNS (httpx's connect timeout does NOT cover the
+# OS resolver itself); read=1s is tight because 304 responses are tiny.  The
+# 30-min disk TTL above is the **only reliable quota defense** — GitHub's
+# x-ratelimit-used counter has been observed to increment on 304 responses
+# despite their docs claiming otherwise, so ETag/If-None-Match is a
+# bandwidth/latency optimization, not a rate-limit optimization.
+_HTTP_TIMEOUT = httpx.Timeout(connect=2.0, read=1.0, write=5.0, pool=1.0)
+_GITHUB_API_VERSION = "2022-11-28"
 
 _GITHUB_RELEASES_URL = "https://api.github.com/repos/TalonT-Org/AutoSkillit/releases/latest"
 _GITHUB_INTEGRATION_PYPROJECT_URL = (
@@ -75,31 +94,143 @@ def _read_dismiss_state(home: Path) -> dict[str, object]:
 
 def _write_dismiss_state(home: Path, state: dict[str, object]) -> None:
     """Write dismissal state atomically to ~/.autoskillit/update_check.json."""
-    from autoskillit.core import atomic_write
-
     state_file = home / ".autoskillit" / _DISMISS_FILE
     state_file.parent.mkdir(parents=True, exist_ok=True)
     atomic_write(state_file, json.dumps(state))
 
 
-def _fetch_latest_version(dev_mode: bool) -> str | None:
-    """Fetch the latest available version from GitHub.
+def _fetch_cache_path(home: Path) -> Path:
+    return home / ".autoskillit" / _FETCH_CACHE_FILE
+
+
+def _read_fetch_cache(home: Path) -> dict[str, Any]:
+    """Read the GitHub fetch cache; tolerate any read/parse failure."""
+    try:
+        data = json.loads(_fetch_cache_path(home).read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        logger.debug("Failed to read fetch cache", exc_info=False)
+        return {}
+
+
+def _write_fetch_cache(home: Path, data: dict[str, Any]) -> None:
+    """Write the GitHub fetch cache atomically."""
+    target = _fetch_cache_path(home)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        atomic_write(target, json.dumps(data))
+    except Exception:
+        logger.debug("Failed to write fetch cache", exc_info=False)
+
+
+def _scrub_auth(text: str) -> str:
+    """Remove any GITHUB_TOKEN value or ``Bearer …`` token from a string."""
+    if not text:
+        return text
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        text = text.replace(token, "***")
+    # Belt-and-suspenders: any literal "Bearer <something>" gets masked too,
+    # in case httpx echoes a request repr that includes the header value.
+    import re
+
+    text = re.sub(r"(?i)Bearer\s+\S+", "Bearer ***", text)
+    return text
+
+
+def _resolve_fetch_ttl() -> int:
+    raw = os.environ.get("AUTOSKILLIT_FETCH_CACHE_TTL_SECONDS")
+    if raw is None:
+        return _DEFAULT_FETCH_TTL_SECONDS
+    try:
+        return int(raw)
+    except ValueError:
+        return _DEFAULT_FETCH_TTL_SECONDS
+
+
+def _fetch_with_cache(url: str, *, home: Path, ttl: int | None = None) -> dict[str, Any] | None:
+    """Fetch ``url`` via httpx with a disk-backed cache and conditional GETs.
+
+    Returns the parsed JSON dict on success (200 or 304), or ``None`` on any
+    error.  ``Authorization`` headers are scrubbed from log output to prevent
+    token leakage via DEBUG-level error reporting.
+
+    The 30-minute disk TTL is the only reliable quota defense — see
+    ``_DEFAULT_FETCH_TTL_SECONDS`` for the rationale.
+    """
+    effective_ttl = ttl if ttl is not None else _resolve_fetch_ttl()
+    cache = _read_fetch_cache(home)
+    entry = cache.get(url) if isinstance(cache.get(url), dict) else None
+    now = time.time()
+    if entry is not None:
+        cached_at = entry.get("cached_at")
+        body = entry.get("body")
+        if isinstance(cached_at, (int, float)) and isinstance(body, dict):
+            if now - cached_at < effective_ttl:
+                return body
+
+    headers: dict[str, str] = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": _GITHUB_API_VERSION,
+        "User-Agent": f"autoskillit/{AUTOSKILLIT_INSTALLED_VERSION}",
+    }
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    if entry is not None and isinstance(entry.get("etag"), str):
+        headers["If-None-Match"] = entry["etag"]
+
+    try:
+        with httpx.Client(timeout=_HTTP_TIMEOUT) as client:
+            response = client.get(url, headers=headers)
+    except Exception as exc:
+        logger.debug("fetch failed for %s: %s", url, _scrub_auth(str(exc)))
+        return None
+
+    try:
+        if response.status_code == 304 and entry is not None:
+            body = entry.get("body")
+            if isinstance(body, dict):
+                cache[url] = {
+                    "body": body,
+                    "etag": entry.get("etag"),
+                    "cached_at": now,
+                }
+                _write_fetch_cache(home, cache)
+                return body
+            return None
+        if response.status_code == 200:
+            body = response.json()
+            if not isinstance(body, dict):
+                return None
+            etag = response.headers.get("ETag")
+            cache[url] = {
+                "body": body,
+                "etag": etag,
+                "cached_at": now,
+            }
+            _write_fetch_cache(home, cache)
+            return body
+        logger.debug("fetch %s returned status %d", url, response.status_code)
+        return None
+    except Exception as exc:
+        logger.debug("fetch parse failed for %s: %s", url, _scrub_auth(str(exc)))
+        return None
+
+
+def _fetch_latest_version(dev_mode: bool, home: Path) -> str | None:
+    """Fetch the latest available version from GitHub via the cached client.
 
     Dev mode: reads pyproject.toml from the ``integration`` branch.
     Normal mode: reads the latest GitHub release tag.
 
     Returns ``None`` on any network error or timeout.
     """
-    import urllib.request
-
     try:
         if dev_mode:
-            req = urllib.request.Request(
-                _GITHUB_INTEGRATION_PYPROJECT_URL,
-                headers={"Accept": "application/vnd.github.v3+json"},
-            )
-            with urllib.request.urlopen(req, timeout=_FETCH_TIMEOUT) as resp:
-                data = json.loads(resp.read())
+            data = _fetch_with_cache(_GITHUB_INTEGRATION_PYPROJECT_URL, home=home)
+            if data is None:
+                return None
             import base64
 
             raw_content = data.get("content")
@@ -111,17 +242,13 @@ def _fetch_latest_version(dev_mode: bool) -> str | None:
                 if line.split("=", 1)[0].strip() == "version":
                     return line.split("=", 1)[1].strip().strip('"').strip("'")
             return None
-        else:
-            req = urllib.request.Request(
-                _GITHUB_RELEASES_URL,
-                headers={"Accept": "application/vnd.github.v3+json"},
-            )
-            with urllib.request.urlopen(req, timeout=_FETCH_TIMEOUT) as resp:
-                data = json.loads(resp.read())
-            tag = data.get("tag_name", "")
-            return tag.lstrip("v") if tag else None
-    except Exception:
-        logger.debug("Failed to fetch latest version from GitHub", exc_info=True)
+        data = _fetch_with_cache(_GITHUB_RELEASES_URL, home=home)
+        if data is None:
+            return None
+        tag = data.get("tag_name", "")
+        return tag.lstrip("v") if isinstance(tag, str) and tag else None
+    except Exception as exc:
+        logger.debug("Failed to fetch latest version from GitHub: %s", _scrub_auth(str(exc)))
         return None
 
 
@@ -149,6 +276,30 @@ def _is_dismissed(state: dict[str, object], check_type: str, latest: str | None)
         return True
     except Exception:
         logger.debug("Failed to parse dismiss state for check_type=%s", check_type, exc_info=True)
+        return False
+
+
+def _is_drift_dismissed(state: dict[str, object], installed_sha: str, reference_sha: str) -> bool:
+    """Return True if source drift has been dismissed within the window for the given SHA pair.
+
+    Dismissal is SHA-keyed: if either the ``installed_sha`` or ``reference_sha`` changes
+    (e.g. after a git pull on the source repo or a reinstall), the dismissal expires
+    immediately regardless of whether the 12-hour window has passed.
+    """
+    try:
+        entry = state.get("source_drift")
+        if not isinstance(entry, dict):
+            return False
+        dismissed_at = datetime.fromisoformat(entry["dismissed_at"])
+        if datetime.now(UTC) - dismissed_at >= _DISMISS_WINDOW:
+            return False
+        if entry.get("installed_sha") != installed_sha:
+            return False
+        if entry.get("reference_sha") != reference_sha:
+            return False
+        return True
+    except Exception:
+        logger.debug("Failed to parse source drift dismiss state", exc_info=True)
         return False
 
 
@@ -285,7 +436,11 @@ def run_stale_check(home: Path | None = None) -> None:
     ):
         return
 
-    _skip_env = {**os.environ, "AUTOSKILLIT_SKIP_STALE_CHECK": "1"}
+    _skip_env = {
+        **os.environ,
+        "AUTOSKILLIT_SKIP_STALE_CHECK": "1",
+        "AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK": "1",
+    }
 
     import autoskillit as _pkg
     from autoskillit.cli._hooks import _claude_settings_path
@@ -293,7 +448,7 @@ def run_stale_check(home: Path | None = None) -> None:
     _home = home or Path.home()
     dev_mode = is_dev_mode(home=_home)
     state = _read_dismiss_state(_home)
-    latest = _fetch_latest_version(dev_mode)
+    latest = _fetch_latest_version(dev_mode, _home)
 
     current: str = getattr(_pkg, "__version__", "0.0.0")
 

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -705,7 +705,9 @@ def main() -> None:
     """Entry point for autoskillit."""
     _first_arg = sys.argv[1] if len(sys.argv) > 1 else "serve"
     if _first_arg != "serve":
+        from autoskillit.cli._source_drift import run_source_drift_check
         from autoskillit.cli._stale_check import run_stale_check
 
         run_stale_check()
+        run_source_drift_check()
     app()

--- a/src/autoskillit/core/__init__.py
+++ b/src/autoskillit/core/__init__.py
@@ -27,6 +27,7 @@ from .io import (
     load_yaml,
     resolve_temp_dir,
     temp_dir_display_str,
+    write_versioned_json,
 )
 from .logging import (
     configure_logging,
@@ -132,6 +133,7 @@ __all__ = [
     "load_yaml",
     "resolve_temp_dir",
     "temp_dir_display_str",
+    "write_versioned_json",
     # logging
     "configure_logging",
     "get_logger",

--- a/src/autoskillit/core/_type_constants.py
+++ b/src/autoskillit/core/_type_constants.py
@@ -36,6 +36,7 @@ AUTOSKILLIT_PRIVATE_ENV_VARS: frozenset[str] = frozenset(
     {
         "AUTOSKILLIT_HEADLESS",
         "AUTOSKILLIT_SKIP_STALE_CHECK",
+        "AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK",
     }
 )
 

--- a/src/autoskillit/core/io.py
+++ b/src/autoskillit/core/io.py
@@ -2,10 +2,15 @@
 
 Zero autoskillit imports. Provides atomic filesystem writes, project temp directory
 management, and YAML load/dump helpers.
+
+All NEW on-disk JSON artifacts SHOULD use ``write_versioned_json`` so schema drift
+is detectable. Existing artifacts are tracked in
+``tests/infra/test_schema_version_convention.py`` (landed in a later phase).
 """
 
 from __future__ import annotations
 
+import json
 import os
 import tempfile
 from pathlib import Path
@@ -22,6 +27,7 @@ __all__ = [
     "dump_yaml_str",
     "resolve_temp_dir",
     "temp_dir_display_str",
+    "write_versioned_json",
 ]
 
 
@@ -75,7 +81,31 @@ def atomic_write(path: Path, content: str) -> None:
         raise
 
 
-_AUTOSKILLIT_GITIGNORE_ENTRIES = [".secrets.yaml", ".onboarded", "sync_manifest.json"]
+def write_versioned_json(path: Path, payload: dict[str, Any], schema_version: int) -> None:
+    """Write a dict JSON artifact enriched with ``schema_version``.
+
+    Covers **write atomicity only** (single-writer semantics via
+    ``atomic_write``). Callers performing read-modify-write composites
+    (e.g. the clone registry) must layer their own ``fcntl.flock`` —
+    this helper does not serialize concurrent mutators.
+
+    Raises ``TypeError`` if ``payload`` is not a dict (wrap bare arrays
+    as ``{"items": [...]}`` at the call site).
+    """
+    if not isinstance(payload, dict):
+        raise TypeError("write_versioned_json requires a dict payload")
+    enriched = {**payload, "schema_version": schema_version}
+    atomic_write(path, json.dumps(enriched))
+
+
+_AUTOSKILLIT_GITIGNORE_ENTRIES = ["temp/", ".secrets.yaml", ".onboarded", "sync_manifest.json"]
+
+_ROOT_GITIGNORE_ENTRIES = [
+    ".autoskillit/.secrets.yaml",
+    ".autoskillit/temp/",
+    ".autoskillit/.onboarded",
+    ".autoskillit/sync_manifest.json",
+]
 
 _COMMITTED_BY_DESIGN: frozenset[str] = frozenset(
     {

--- a/src/autoskillit/execution/__init__.py
+++ b/src/autoskillit/execution/__init__.py
@@ -60,6 +60,7 @@ from autoskillit.execution.process import (
     run_managed_sync,
 )
 from autoskillit.execution.quota import (
+    QUOTA_CACHE_SCHEMA_VERSION,
     QuotaStatus,
     _refresh_quota_cache,  # noqa: F401 — imported for re-export via server.helpers; not in __all__
     check_and_sleep_if_needed,
@@ -118,6 +119,7 @@ __all__ = [
     "REPLAY_SCENARIO_DIR_ENV",
     "SCENARIO_STEP_NAME_ENV",
     # quota
+    "QUOTA_CACHE_SCHEMA_VERSION",
     "QuotaStatus",
     "check_and_sleep_if_needed",
     # session

--- a/src/autoskillit/execution/quota.py
+++ b/src/autoskillit/execution/quota.py
@@ -22,7 +22,7 @@ _log = get_logger(__name__)
 _DEFAULT_BASE_URL: str = "https://api.anthropic.com"
 _DEFAULT_THRESHOLD: float = 85.0
 
-_QUOTA_CACHE_SCHEMA_VERSION: int = 2
+QUOTA_CACHE_SCHEMA_VERSION: int = 2
 _SCHEMA_DRIFT_LOGGED: set[str] = set()
 
 
@@ -114,7 +114,9 @@ def _read_cache(cache_path: str, max_age: int) -> QuotaStatus | None:
     """Return a fresh QuotaStatus from local cache, or None if stale/missing/old-format."""
     try:
         raw = json.loads(Path(cache_path).expanduser().read_text())
-        if raw.get("schema_version") != _QUOTA_CACHE_SCHEMA_VERSION:
+        if not isinstance(raw, dict):
+            return None
+        if raw.get("schema_version") != QUOTA_CACHE_SCHEMA_VERSION:
             cache_key = str(Path(cache_path).expanduser())
             if cache_key not in _SCHEMA_DRIFT_LOGGED:
                 _SCHEMA_DRIFT_LOGGED.add(cache_key)
@@ -162,7 +164,7 @@ def _write_cache(cache_path: str, result: QuotaFetchResult) -> None:
         }
         path = Path(cache_path).expanduser()
         path.parent.mkdir(parents=True, exist_ok=True)
-        write_versioned_json(path, payload, schema_version=_QUOTA_CACHE_SCHEMA_VERSION)
+        write_versioned_json(path, payload, schema_version=QUOTA_CACHE_SCHEMA_VERSION)
     except OSError as exc:
         _log.warning("quota cache write failed", path=cache_path, error=str(exc))
 

--- a/src/autoskillit/execution/quota.py
+++ b/src/autoskillit/execution/quota.py
@@ -15,12 +15,20 @@ from typing import Any
 
 import httpx
 
-from autoskillit.core import atomic_write, get_logger
+from autoskillit.core import get_logger, write_versioned_json
 
 _log = get_logger(__name__)
 
 _DEFAULT_BASE_URL: str = "https://api.anthropic.com"
 _DEFAULT_THRESHOLD: float = 85.0
+
+_QUOTA_CACHE_SCHEMA_VERSION: int = 2
+_SCHEMA_DRIFT_LOGGED: set[str] = set()
+
+
+def _reset_schema_drift_logged_for_tests() -> None:
+    """Test-only helper: clear the once-per-process drift-log set."""
+    _SCHEMA_DRIFT_LOGGED.clear()
 
 
 @dataclass
@@ -106,12 +114,21 @@ def _read_cache(cache_path: str, max_age: int) -> QuotaStatus | None:
     """Return a fresh QuotaStatus from local cache, or None if stale/missing/old-format."""
     try:
         raw = json.loads(Path(cache_path).expanduser().read_text())
+        if raw.get("schema_version") != _QUOTA_CACHE_SCHEMA_VERSION:
+            cache_key = str(Path(cache_path).expanduser())
+            if cache_key not in _SCHEMA_DRIFT_LOGGED:
+                _SCHEMA_DRIFT_LOGGED.add(cache_key)
+                _log.warning(
+                    "quota_cache_schema_drift",
+                    cache_path=cache_key,
+                    observed=raw.get("schema_version"),
+                )
+            return None
         fetched_at = datetime.fromisoformat(raw["fetched_at"])
         age = (datetime.now(UTC) - fetched_at).total_seconds()
         if age > max_age:
             return None
         if "binding" not in raw:
-            # Old-format cache (no "binding" key) — treat as stale, force re-fetch
             return None
         b = raw["binding"]
         return QuotaStatus(
@@ -145,7 +162,7 @@ def _write_cache(cache_path: str, result: QuotaFetchResult) -> None:
         }
         path = Path(cache_path).expanduser()
         path.parent.mkdir(parents=True, exist_ok=True)
-        atomic_write(path, json.dumps(payload))
+        write_versioned_json(path, payload, schema_version=_QUOTA_CACHE_SCHEMA_VERSION)
     except OSError as exc:
         _log.warning("quota cache write failed", path=cache_path, error=str(exc))
 

--- a/src/autoskillit/server/helpers.py
+++ b/src/autoskillit/server/helpers.py
@@ -107,6 +107,10 @@ def track_response_size(
 ) -> Callable[[Callable[..., Awaitable[Any]]], Callable[..., Awaitable[Any]]]:
     """Decorator: measure the JSON string size of a tool response and record to response_log.
 
+    Last-resort safety net. Tool implementations SHOULD catch exceptions locally
+    and emit domain-specific envelopes with more helpful ``user_visible_message``
+    values; this decorator only catches what slips through.
+
     Apply BELOW @mcp.tool() so the wrapped function is what FastMCP registers:
 
         @mcp.tool(tags={"automation"})
@@ -127,6 +131,10 @@ def track_response_size(
                         "error": f"{type(exc).__name__}: {exc}",
                         "exit_code": -1,
                         "subtype": "tool_exception",
+                        "user_visible_message": (
+                            f"An internal error occurred in {tool_name}: "
+                            f"{type(exc).__name__}. Run 'autoskillit doctor' or reinstall."
+                        ),
                     }
                 )
                 logger.exception("Unhandled exception in tool %s", tool_name)

--- a/src/autoskillit/server/tools_kitchen.py
+++ b/src/autoskillit/server/tools_kitchen.py
@@ -156,11 +156,13 @@ async def _open_kitchen_handler() -> str | None:
     try:
         _write_hook_config()
     except Exception as exc:
+        logger.warning("open_kitchen_failure", stage="write_hook_config", exc_info=True)
         return _kitchen_failure_envelope(exc, stage="write_hook_config")
 
     try:
         await _prime_quota_cache()
     except Exception as exc:
+        logger.warning("open_kitchen_failure", stage="prime_quota_cache", exc_info=True)
         return _kitchen_failure_envelope(exc, stage="prime_quota_cache")
 
     if ctx.quota_refresh_task is not None:
@@ -171,6 +173,7 @@ async def _open_kitchen_handler() -> str | None:
             label="quota_refresh_loop",
         )
     except Exception as exc:
+        logger.warning("open_kitchen_failure", stage="start_quota_refresh", exc_info=True)
         return _kitchen_failure_envelope(exc, stage="start_quota_refresh")
 
     return None
@@ -266,11 +269,13 @@ async def open_kitchen(
     try:
         await ctx.enable_components(tags={"kitchen"})
     except Exception as exc:
+        logger.warning("open_kitchen_failure", stage="enable_components", exc_info=True)
         return _kitchen_failure_envelope(exc, stage="enable_components")
 
     try:
         await _redisable_subsets(ctx, disabled_subsets)
     except Exception as exc:
+        logger.warning("open_kitchen_failure", stage="redisable_subsets", exc_info=True)
         return _kitchen_failure_envelope(exc, stage="redisable_subsets")
 
     _forbidden_list = ", ".join(PIPELINE_FORBIDDEN_TOOLS)
@@ -298,6 +303,7 @@ async def open_kitchen(
                 ingredient_overrides=overrides,
             )
         except Exception as exc:
+            logger.warning("open_kitchen_failure", stage="load_and_validate", exc_info=True)
             return _kitchen_failure_envelope(exc, stage="load_and_validate")
 
         tool_ctx.active_recipe_packs = frozenset(result.get("requires_packs", []))
@@ -305,11 +311,13 @@ async def open_kitchen(
         try:
             recipe_info = tool_ctx.recipes.find(name, Path.cwd())
         except Exception as exc:
+            logger.warning("open_kitchen_failure", stage="recipe_find", exc_info=True)
             return _kitchen_failure_envelope(exc, stage="recipe_find")
 
         try:
             result = await _apply_triage_gate(result, name, recipe_info=recipe_info)
         except Exception as exc:
+            logger.warning("open_kitchen_failure", stage="apply_triage_gate", exc_info=True)
             return _kitchen_failure_envelope(exc, stage="apply_triage_gate")
 
         result["success"] = True
@@ -322,6 +330,7 @@ async def open_kitchen(
         try:
             warning = _build_hook_diagnostic_warning()
         except Exception as exc:
+            logger.warning("open_kitchen_failure", stage="hook_diagnostic", exc_info=True)
             return _kitchen_failure_envelope(exc, stage="hook_diagnostic")
         if warning:
             result["hook_warning"] = warning.strip()
@@ -344,6 +353,7 @@ async def open_kitchen(
         if _sous_chef_path.exists():
             text += "\n\n" + _sous_chef_path.read_text()
     except Exception as exc:
+        logger.warning("open_kitchen_failure", stage="read_sous_chef", exc_info=True)
         return _kitchen_failure_envelope(exc, stage="read_sous_chef")
 
     # Check if the project needs an upgrade
@@ -359,6 +369,7 @@ async def open_kitchen(
     try:
         warning = _build_hook_diagnostic_warning()
     except Exception as exc:
+        logger.warning("open_kitchen_failure", stage="hook_diagnostic", exc_info=True)
         return _kitchen_failure_envelope(exc, stage="hook_diagnostic")
     if warning:
         text += warning

--- a/src/autoskillit/server/tools_kitchen.py
+++ b/src/autoskillit/server/tools_kitchen.py
@@ -316,10 +316,7 @@ async def open_kitchen(
         result["kitchen"] = "open"
         result["version"] = __version__
 
-        serialized = json.dumps(result)
-        if "--- INGREDIENTS TABLE ---" in serialized:
-            result["ingredients_table"] = True
-        else:
+        if "ingredients_table" not in result or not result["ingredients_table"]:
             result["ingredients_table"] = None
 
         try:

--- a/src/autoskillit/server/tools_kitchen.py
+++ b/src/autoskillit/server/tools_kitchen.py
@@ -32,6 +32,34 @@ from autoskillit.server.helpers import (
 
 logger = get_logger(__name__)
 
+
+def _kitchen_failure_envelope(
+    exc: BaseException,
+    stage: str,
+    *,
+    user_hint: str | None = None,
+) -> str:
+    """Return a JSON failure envelope for open_kitchen errors.
+
+    Tool implementations catch exceptions locally and emit domain-specific
+    envelopes with helpful ``user_visible_message`` values; the
+    ``@track_response_size`` decorator only catches what slips through.
+    """
+    msg = user_hint or (
+        f"open_kitchen failed during {stage}: {type(exc).__name__}. "
+        f"Run 'autoskillit doctor' to diagnose, or reinstall if the failure persists."
+    )
+    return json.dumps(
+        {
+            "success": False,
+            "kitchen": "failed",
+            "user_visible_message": msg,
+            "error": f"{type(exc).__name__}: {exc}",
+            "stage": stage,
+        }
+    )
+
+
 _DISPLAY_CATEGORIES: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("Execution", ("run_cmd", "run_python", "run_skill")),
     ("Testing & Workspace", ("test_check", "reset_test_dir", "classify_fix", "reset_workspace")),
@@ -112,25 +140,40 @@ def _write_hook_config() -> None:
         logger.warning("hook_config_write_failed", path=str(hook_cfg_path))
 
 
-async def _open_kitchen_handler() -> None:
-    """Set the tools-enabled flag. Extracted for testability."""
+async def _open_kitchen_handler() -> str | None:
+    """Set the tools-enabled flag. Extracted for testability.
+
+    Returns ``None`` on success, or a JSON failure envelope string on error.
+    """
     from autoskillit.server import _get_ctx, logger
 
     ctx = _get_ctx()
     ctx.gate.enable()
     ctx.kitchen_id = str(uuid4())
-    # Store recipe packs — populated from LoadRecipeResult.requires_packs in #524.
-    # For now, store empty frozenset to establish the contract.
     ctx.active_recipe_packs = frozenset()
     logger.info("open_kitchen", gate_state="open", kitchen_id=ctx.kitchen_id)
-    _write_hook_config()
-    await _prime_quota_cache()
+
+    try:
+        _write_hook_config()
+    except Exception as exc:
+        return _kitchen_failure_envelope(exc, stage="write_hook_config")
+
+    try:
+        await _prime_quota_cache()
+    except Exception as exc:
+        return _kitchen_failure_envelope(exc, stage="prime_quota_cache")
+
     if ctx.quota_refresh_task is not None:
         ctx.quota_refresh_task.cancel()
-    ctx.quota_refresh_task = create_background_task(
-        _quota_refresh_loop(ctx.config.quota_guard),
-        label="quota_refresh_loop",
-    )
+    try:
+        ctx.quota_refresh_task = create_background_task(
+            _quota_refresh_loop(ctx.config.quota_guard),
+            label="quota_refresh_loop",
+        )
+    except Exception as exc:
+        return _kitchen_failure_envelope(exc, stage="start_quota_refresh")
+
+    return None
 
 
 async def _redisable_subsets(ctx: Context, disabled: list[str]) -> None:
@@ -196,15 +239,39 @@ async def open_kitchen(
         overrides: Optional dict of ingredient name → value to override recipe defaults.
             Use to activate hidden features (e.g., ``{"sprint_mode": "true"}``).
     """
+    # Headless guard — wrap denial in envelope shape
     if (h := _require_not_headless("open_kitchen")) is not None:
-        return h
+        parsed_h = json.loads(h)
+        return json.dumps(
+            {
+                "success": False,
+                "kitchen": "failed",
+                "user_visible_message": parsed_h.get(
+                    "result",
+                    "open_kitchen cannot be called from headless sessions.",
+                ),
+                "error": "HeadlessDenied",
+                "stage": "headless_guard",
+            }
+        )
 
     from autoskillit.server import _get_ctx  # noqa: PLC0415
 
     disabled_subsets = _get_ctx().config.subsets.disabled
-    await _open_kitchen_handler()
-    await ctx.enable_components(tags={"kitchen"})
-    await _redisable_subsets(ctx, disabled_subsets)
+
+    handler_err = await _open_kitchen_handler()
+    if handler_err is not None:
+        return handler_err
+
+    try:
+        await ctx.enable_components(tags={"kitchen"})
+    except Exception as exc:
+        return _kitchen_failure_envelope(exc, stage="enable_components")
+
+    try:
+        await _redisable_subsets(ctx, disabled_subsets)
+    except Exception as exc:
+        return _kitchen_failure_envelope(exc, stage="redisable_subsets")
 
     _forbidden_list = ", ".join(PIPELINE_FORBIDDEN_TOOLS)
     _categories = _build_tool_category_listing()
@@ -212,22 +279,53 @@ async def open_kitchen(
     if name is not None:
         tool_ctx = _get_ctx()
         if tool_ctx.recipes is None:
-            return json.dumps({"error": "Server not initialized", "kitchen": "open"})
+            return _kitchen_failure_envelope(
+                RuntimeError("Server not initialized"),
+                stage="recipe_context",
+                user_hint=(
+                    "open_kitchen cannot load a recipe because the server is not "
+                    "initialized. Run 'autoskillit doctor' to diagnose."
+                ),
+            )
         suppressed = tool_ctx.config.migration.suppressed
         _defaults = resolve_ingredient_defaults(Path.cwd())
-        result = tool_ctx.recipes.load_and_validate(
-            name,
-            Path.cwd(),
-            suppressed=suppressed,
-            resolved_defaults=_defaults,
-            ingredient_overrides=overrides,
-        )
+        try:
+            result = tool_ctx.recipes.load_and_validate(
+                name,
+                Path.cwd(),
+                suppressed=suppressed,
+                resolved_defaults=_defaults,
+                ingredient_overrides=overrides,
+            )
+        except Exception as exc:
+            return _kitchen_failure_envelope(exc, stage="load_and_validate")
+
         tool_ctx.active_recipe_packs = frozenset(result.get("requires_packs", []))
-        recipe_info = tool_ctx.recipes.find(name, Path.cwd())
-        result = await _apply_triage_gate(result, name, recipe_info=recipe_info)
+
+        try:
+            recipe_info = tool_ctx.recipes.find(name, Path.cwd())
+        except Exception as exc:
+            return _kitchen_failure_envelope(exc, stage="recipe_find")
+
+        try:
+            result = await _apply_triage_gate(result, name, recipe_info=recipe_info)
+        except Exception as exc:
+            return _kitchen_failure_envelope(exc, stage="apply_triage_gate")
+
+        result["success"] = True
         result["kitchen"] = "open"
         result["version"] = __version__
-        warning = _build_hook_diagnostic_warning()
+
+        serialized = json.dumps(result)
+        if "--- INGREDIENTS TABLE ---" in serialized:
+            result["ingredients_table"] = True
+        else:
+            result["ingredients_table"] = None
+
+        try:
+            warning = _build_hook_diagnostic_warning()
+        except Exception as exc:
+            return _kitchen_failure_envelope(exc, stage="hook_diagnostic")
         if warning:
             result["hook_warning"] = warning.strip()
         return json.dumps(result)
@@ -245,8 +343,11 @@ async def open_kitchen(
 
     # Inject sous-chef global orchestration rules (graceful degradation if absent)
     _sous_chef_path = pkg_root() / "skills" / "sous-chef" / "SKILL.md"
-    if _sous_chef_path.exists():
-        text += "\n\n" + _sous_chef_path.read_text()
+    try:
+        if _sous_chef_path.exists():
+            text += "\n\n" + _sous_chef_path.read_text()
+    except Exception as exc:
+        return _kitchen_failure_envelope(exc, stage="read_sous_chef")
 
     # Check if the project needs an upgrade
     scripts_dir = Path.cwd() / ".autoskillit" / "scripts"
@@ -258,11 +359,22 @@ async def open_kitchen(
             "to migrate automatically, or ask me to do it for you."
         )
 
-    warning = _build_hook_diagnostic_warning()
+    try:
+        warning = _build_hook_diagnostic_warning()
+    except Exception as exc:
+        return _kitchen_failure_envelope(exc, stage="hook_diagnostic")
     if warning:
         text += warning
 
-    return text
+    return json.dumps(
+        {
+            "success": True,
+            "kitchen": "open",
+            "content": text,
+            "ingredients_table": None,
+            "version": __version__,
+        }
+    )
 
 
 @mcp.tool(tags={"autoskillit"}, annotations={"readOnlyHint": True})

--- a/tests/arch/_rules.py
+++ b/tests/arch/_rules.py
@@ -59,6 +59,7 @@ _PRINT_EXEMPT = frozenset(
         "_cook.py",
         "_init_helpers.py",
         "_onboarding.py",
+        "_source_drift.py",
         "_stale_check.py",
         "app.py",
         "_doctor.py",

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -663,7 +663,8 @@ def test_no_subpackage_exceeds_10_files() -> None:
         core/_terminal_table.py. Also contains _terminal.py — the terminal state
         management context manager (terminal_guard) for interactive subprocess
         sessions. _stale_check.py adds the stale-install detection surface.
-        Exempt at 14 files.
+        _source_drift.py adds the source-drift boot gate.
+        Exempt at 16 files.
       hooks/ — REQ-CNST-003-E6: hooks/ hosts one standalone script per hook event
         (PreToolUse, PostToolUse, SessionStart). Each script must remain a separate
         file so Claude Code can invoke it directly as a subprocess. Adding
@@ -675,7 +676,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "recipe": 30,
         "execution": 25,
         "core": 15,
-        "cli": 15,
+        "cli": 16,
         "hooks": 14,
     }
     violations: list[str] = []

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -1188,3 +1188,178 @@ def test_count_hook_registry_drift_cross_env_path_mismatch(tmp_path: Path) -> No
     assert result.missing == 0, (
         f"Path prefix difference must not cause missing hooks, got missing={result.missing}"
     )
+
+
+# ---------------------------------------------------------------------------
+# _check_source_version_drift — doctor check (cache-only, no network)
+# ---------------------------------------------------------------------------
+
+
+def test_check_source_version_drift_ok_outside_source_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """GIT_VCS install with empty cache reports OK (no drift observable)."""
+    import autoskillit.cli._source_drift as _sd
+    from autoskillit.cli._doctor import _check_source_version_drift
+    from autoskillit.cli._source_drift import InstallInfo, InstallType
+    from autoskillit.core import Severity
+
+    info = InstallInfo(
+        install_type=InstallType.GIT_VCS,
+        commit_id="abc1234",
+        requested_revision="integration",
+        url=None,
+        editable_source=None,
+    )
+    monkeypatch.setattr(_sd, "detect_install", lambda: info)
+    # Simulate empty cache and no source repo: resolve returns None
+    monkeypatch.setattr(_sd, "resolve_reference_sha", lambda info, home, **kw: None)
+
+    result = _check_source_version_drift(home=tmp_path)
+    assert result.severity == Severity.OK
+
+
+def test_check_source_version_drift_ok_for_editable_install(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """LOCAL_EDITABLE installs are under active development — drift check is skipped."""
+    import autoskillit.cli._source_drift as _sd
+    from autoskillit.cli._doctor import _check_source_version_drift
+    from autoskillit.cli._source_drift import InstallInfo, InstallType
+    from autoskillit.core import Severity
+
+    info = InstallInfo(
+        install_type=InstallType.LOCAL_EDITABLE,
+        commit_id=None,
+        requested_revision=None,
+        url="file:///home/user/autoskillit",
+        editable_source=Path("/home/user/autoskillit"),
+    )
+    monkeypatch.setattr(_sd, "detect_install", lambda: info)
+
+    result = _check_source_version_drift(home=tmp_path)
+    assert result.severity == Severity.OK
+    assert "editable" in result.message.lower() or "not applicable" in result.message.lower()
+
+
+def test_check_source_version_drift_ok_for_pinned_sha(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When requested_revision == commit_id, resolve_reference_sha short-circuits → no drift."""
+    import autoskillit.cli._source_drift as _sd
+    from autoskillit.cli._doctor import _check_source_version_drift
+    from autoskillit.cli._source_drift import InstallInfo, InstallType
+    from autoskillit.core import Severity
+
+    sha = "abcdef1234567890abcdef1234567890"
+    info = InstallInfo(
+        install_type=InstallType.GIT_VCS,
+        commit_id=sha,
+        requested_revision=sha,  # pinned SHA = no drift possible
+        url=None,
+        editable_source=None,
+    )
+    monkeypatch.setattr(_sd, "detect_install", lambda: info)
+    # When requested_revision == commit_id, resolve_reference_sha returns commit_id
+    monkeypatch.setattr(_sd, "resolve_reference_sha", lambda info, home, **kw: sha)
+
+    result = _check_source_version_drift(home=tmp_path)
+    assert result.severity == Severity.OK
+
+
+def test_check_source_version_drift_ok_when_cache_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When cache is empty (no prior online fetch), doctor reports OK with explanatory message."""
+    import autoskillit.cli._source_drift as _sd
+    from autoskillit.cli._doctor import _check_source_version_drift
+    from autoskillit.cli._source_drift import InstallInfo, InstallType
+    from autoskillit.core import Severity
+
+    info = InstallInfo(
+        install_type=InstallType.GIT_VCS,
+        commit_id="installed123",
+        requested_revision="integration",
+        url=None,
+        editable_source=None,
+    )
+    monkeypatch.setattr(_sd, "detect_install", lambda: info)
+    monkeypatch.setattr(_sd, "resolve_reference_sha", lambda info, home, **kw: None)
+
+    result = _check_source_version_drift(home=tmp_path)
+    assert result.severity == Severity.OK
+    # Message should note the empty cache
+    assert "cache" in result.message.lower(), (
+        f"Expected 'cache' in message for empty cache case, got: {result.message!r}"
+    )
+
+
+def test_check_source_version_drift_warning_on_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When cache has a different reference SHA than installed, reports WARNING with short SHAs."""
+    import autoskillit.cli._source_drift as _sd
+    from autoskillit.cli._doctor import _check_source_version_drift
+    from autoskillit.cli._source_drift import InstallInfo, InstallType
+    from autoskillit.core import Severity
+
+    installed_sha = "installed123abc"
+    ref_sha = "reference456def"
+
+    info = InstallInfo(
+        install_type=InstallType.GIT_VCS,
+        commit_id=installed_sha,
+        requested_revision="integration",
+        url=None,
+        editable_source=None,
+    )
+    monkeypatch.setattr(_sd, "detect_install", lambda: info)
+    monkeypatch.setattr(_sd, "resolve_reference_sha", lambda info, home, **kw: ref_sha)
+
+    result = _check_source_version_drift(home=tmp_path)
+    assert result.severity == Severity.WARNING
+    assert installed_sha[:8] in result.message
+    assert ref_sha[:8] in result.message
+
+
+def test_check_source_version_drift_never_makes_network_call(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Doctor check must never make network calls — httpx and subprocess must not be called."""
+
+    import httpx
+
+    import autoskillit.cli._source_drift as _sd
+    from autoskillit.cli._doctor import _check_source_version_drift
+    from autoskillit.cli._source_drift import InstallInfo, InstallType
+
+    info = InstallInfo(
+        install_type=InstallType.GIT_VCS,
+        commit_id="installed000",
+        requested_revision="integration",
+        url=None,
+        editable_source=None,
+    )
+    monkeypatch.setattr(_sd, "detect_install", lambda: info)
+    # Ensure find_source_repo returns None (so no git subprocess)
+    monkeypatch.setattr(_sd, "find_source_repo", lambda: None)
+
+    http_calls: list[str] = []
+    subprocess_calls: list[list[str]] = []
+
+    def bad_client(*args: object, **kwargs: object) -> object:
+        http_calls.append("httpx.Client called!")
+        raise AssertionError("httpx.Client must not be called in doctor mode")
+
+    def bad_run(cmd: list[str], **kwargs: object) -> object:
+        subprocess_calls.append(list(cmd))
+        raise AssertionError(f"subprocess.run must not be called in doctor mode: {cmd}")
+
+    monkeypatch.setattr(httpx, "Client", bad_client)
+    monkeypatch.setattr(_sd.subprocess, "run", bad_run)
+
+    # Should not raise even with bad mocks (cache is empty → returns None → OK)
+    _check_source_version_drift(home=tmp_path)
+
+    assert not http_calls, f"httpx.Client was called: {http_calls}"
+    assert not subprocess_calls, f"subprocess.run was called: {subprocess_calls}"

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -1363,3 +1363,66 @@ def test_check_source_version_drift_never_makes_network_call(
 
     assert not http_calls, f"httpx.Client was called: {http_calls}"
     assert not subprocess_calls, f"subprocess.run was called: {subprocess_calls}"
+
+
+# ---------------------------------------------------------------------------
+# Check 14: Quota cache schema version (#711 Part B, Phase 4)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckQuotaCacheSchema:
+    """Tests for _check_quota_cache_schema doctor check."""
+
+    def test_check_quota_cache_schema_ok_when_v2(self, tmp_path):
+        import json
+
+        from autoskillit.cli._doctor import Severity, _check_quota_cache_schema
+
+        cache = tmp_path / "cache.json"
+        cache.write_text(json.dumps({"schema_version": 2, "fetched_at": "2026-01-01T00:00:00"}))
+        result = _check_quota_cache_schema(cache_path=cache)
+        assert result.severity == Severity.OK
+        assert "v2" in result.message
+
+    def test_check_quota_cache_schema_ok_when_missing(self, tmp_path):
+        from autoskillit.cli._doctor import Severity, _check_quota_cache_schema
+
+        cache = tmp_path / "nonexistent.json"
+        result = _check_quota_cache_schema(cache_path=cache)
+        assert result.severity == Severity.OK
+        assert "No quota cache" in result.message
+
+    def test_check_quota_cache_schema_warning_when_no_schema_version_key(self, tmp_path):
+        import json
+
+        from autoskillit.cli._doctor import Severity, _check_quota_cache_schema
+
+        cache = tmp_path / "cache.json"
+        cache.write_text(json.dumps({"fetched_at": "2026-01-01T00:00:00"}))
+        result = _check_quota_cache_schema(cache_path=cache)
+        assert result.severity == Severity.WARNING
+        assert "schema drift" in result.message.lower()
+
+    def test_check_quota_cache_schema_warning_when_older_schema_version(self, tmp_path):
+        import json
+
+        from autoskillit.cli._doctor import Severity, _check_quota_cache_schema
+
+        cache = tmp_path / "cache.json"
+        cache.write_text(json.dumps({"schema_version": 1, "fetched_at": "2026-01-01T00:00:00"}))
+        result = _check_quota_cache_schema(cache_path=cache)
+        assert result.severity == Severity.WARNING
+
+    def test_check_quota_cache_schema_warning_includes_cache_path_and_observed_value(
+        self, tmp_path
+    ):
+        import json
+
+        from autoskillit.cli._doctor import Severity, _check_quota_cache_schema
+
+        cache = tmp_path / "cache.json"
+        cache.write_text(json.dumps({"schema_version": 1}))
+        result = _check_quota_cache_schema(cache_path=cache)
+        assert result.severity == Severity.WARNING
+        assert str(cache) in result.message
+        assert "observed=1" in result.message

--- a/tests/cli/test_input_tty_contracts.py
+++ b/tests/cli/test_input_tty_contracts.py
@@ -22,6 +22,7 @@ _TTY_EXEMPT_FUNCTIONS: frozenset[str] = frozenset(
         "_check_secret_scanning",  # custom-handled: returns _ScanResult(False) non-interactively
         "run_onboarding_menu",  # custom-handled: catches EOFError on each input()
         "run_stale_check",  # custom-handled: guards with isatty() check at entry
+        "run_source_drift_check",  # custom-handled: guards with isatty() check at entry
     }
 )
 

--- a/tests/cli/test_orchestrator_prompt_contract.py
+++ b/tests/cli/test_orchestrator_prompt_contract.py
@@ -1,0 +1,77 @@
+"""Tests for orchestrator prompt contract: failure predicates and dispatch consistency."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+
+def _get_prompt() -> str:
+    """Return the orchestrator prompt for a demo recipe."""
+    from autoskillit.cli._prompts import _build_orchestrator_prompt
+
+    return _build_orchestrator_prompt("demo", "mcp__autoskillit__")
+
+
+class TestOpenKitchenFailurePredicate:
+    """Guards for the FAILURE PREDICATE — open_kitchen block in the orchestrator prompt."""
+
+    def test_prompt_contains_open_kitchen_failure_predicate(self):
+        prompt = _get_prompt()
+        assert "FAILURE PREDICATE — open_kitchen" in prompt
+
+    def test_prompt_open_kitchen_predicate_mentions_success_false_substring(self):
+        prompt = _get_prompt()
+        # Find the open_kitchen predicate section
+        idx = prompt.index("FAILURE PREDICATE — open_kitchen")
+        section = prompt[idx : idx + 500]
+        assert '"success": false' in section
+
+    def test_prompt_open_kitchen_predicate_mentions_user_visible_message(self):
+        prompt = _get_prompt()
+        idx = prompt.index("FAILURE PREDICATE — open_kitchen")
+        section = prompt[idx : idx + 500]
+        assert "user_visible_message" in section
+
+    def test_prompt_open_kitchen_predicate_forbids_askuserquestion(self):
+        prompt = _get_prompt()
+        idx = prompt.index("FAILURE PREDICATE — open_kitchen")
+        section = prompt[idx : idx + 500]
+        assert "DO NOT call AskUserQuestion" in section
+
+    def test_open_kitchen_predicate_uses_substring_not_json_field_dispatch(self):
+        """Negative: the predicate block must NOT use JSON-field dispatch phrasing."""
+        prompt = _get_prompt()
+        idx = prompt.index("FAILURE PREDICATE — open_kitchen")
+        section = prompt[idx : idx + 500]
+        assert "json.loads" not in section.lower()
+        assert "parsed[" not in section
+
+
+class TestStep0ToolPredicateCoverage:
+    """Every tool referenced in STEP 0 must have a failure predicate or shared rule."""
+
+    def test_every_step0_tool_has_failure_predicate_or_shared_rule(self):
+        """Parse STEP 0 section, extract tool names, assert each has a predicate."""
+        prompt = _get_prompt()
+
+        # Extract tool names from STEP 0 (tools appear as {mcp_prefix}<tool> or explicit names)
+        step0_match = re.search(
+            r"FIRST ACTION.*?(?=ROUTING RULES|FAILURE PREDICATES|During pipeline)",
+            prompt,
+            re.DOTALL,
+        )
+        assert step0_match is not None, "STEP 0 / FIRST ACTION section not found"
+        step0_text = step0_match.group()
+
+        # Find tool names: mcp__autoskillit__<tool>(<args>)
+        tool_names = set(re.findall(r"mcp__autoskillit__(\w+)\(", step0_text))
+        assert len(tool_names) > 0, "No tool names found in STEP 0"
+
+        # Each tool must appear in a FAILURE PREDICATE section
+        for tool in tool_names:
+            assert (
+                f"FAILURE PREDICATE — {tool}" in prompt
+                or f"- {tool}:" in prompt
+            ), f"Tool '{tool}' in STEP 0 has no failure predicate or shared rule"

--- a/tests/cli/test_orchestrator_prompt_contract.py
+++ b/tests/cli/test_orchestrator_prompt_contract.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import re
 
-import pytest
-
 
 def _get_prompt() -> str:
     """Return the orchestrator prompt for a demo recipe."""
@@ -71,7 +69,6 @@ class TestStep0ToolPredicateCoverage:
 
         # Each tool must appear in a FAILURE PREDICATE section
         for tool in tool_names:
-            assert (
-                f"FAILURE PREDICATE — {tool}" in prompt
-                or f"- {tool}:" in prompt
-            ), f"Tool '{tool}' in STEP 0 has no failure predicate or shared rule"
+            assert f"FAILURE PREDICATE — {tool}" in prompt or f"- {tool}:" in prompt, (
+                f"Tool '{tool}' in STEP 0 has no failure predicate or shared rule"
+            )

--- a/tests/cli/test_source_drift.py
+++ b/tests/cli/test_source_drift.py
@@ -249,7 +249,6 @@ def test_resolve_ref_sha_uses_git_ls_remote_origin_refs_heads(
     monkeypatch.setenv("AUTOSKILLIT_SOURCE_REPO", str(repo))
 
     captured: list[list[str]] = []
-    real_run = subprocess.run
 
     def spy_run(cmd: list[str], **kwargs: Any) -> Any:
         captured.append(list(cmd))
@@ -600,7 +599,7 @@ def test_drift_gate_offers_yn_prompt_on_tty(
     """On a TTY, the gate offers a [Y/n] update prompt."""
     from autoskillit.cli._source_drift import run_source_drift_check
 
-    fake_stdout = _setup_drift_check(monkeypatch, tmp_path, is_tty=True)
+    _setup_drift_check(monkeypatch, tmp_path, is_tty=True)
     # fake_stdin is set to "n\n" by _setup_drift_check
     input_calls: list[str] = []
 

--- a/tests/cli/test_source_drift.py
+++ b/tests/cli/test_source_drift.py
@@ -587,7 +587,9 @@ def test_drift_gate_prints_generic_hint_for_unknown_ref(
     run_source_drift_check(home=tmp_path)
 
     output = fake_stdout.getvalue()
-    assert output.strip(), "Expected some output for unknown-ref drift"
+    assert "reinstall from the source you originally used" in output, (
+        f"Expected generic reinstall hint in output, got: {output!r}"
+    )
     # No specific command should be mentioned for unknown refs
     assert "task install-dev" not in output
     assert "install.sh" not in output
@@ -817,7 +819,7 @@ def test_drift_gate_never_raises_on_error(
     )
     _sd.run_source_drift_check(home=tmp_path)  # must not raise
 
-    # Fault point 4: _write_dismiss_state (dismiss path, non-TTY so no prompt)
+    # Fault point 4: _write_dismiss_state (dismiss path via TTY, user answers "n")
     monkeypatch.setattr(_sc, "_read_dismiss_state", lambda home: {})
     monkeypatch.setattr(_sc, "_is_drift_dismissed", lambda state, installed, ref: False)
     monkeypatch.setattr(
@@ -826,9 +828,9 @@ def test_drift_gate_never_raises_on_error(
         lambda home, state: (_ for _ in ()).throw(type(exc)(str(exc))),
     )
     fake_stdout = io.StringIO()
-    fake_stdin = io.StringIO("")
-    monkeypatch.setattr(fake_stdin, "isatty", lambda: False)
-    monkeypatch.setattr(fake_stdout, "isatty", lambda: False)
+    fake_stdin = io.StringIO("n\n")
+    monkeypatch.setattr(fake_stdin, "isatty", lambda: True)
+    monkeypatch.setattr(fake_stdout, "isatty", lambda: True)
     monkeypatch.setattr(_sd.sys, "stdin", fake_stdin)
     monkeypatch.setattr(_sd.sys, "stdout", fake_stdout)
     _sd.run_source_drift_check(home=tmp_path)  # must not raise

--- a/tests/cli/test_source_drift.py
+++ b/tests/cli/test_source_drift.py
@@ -604,7 +604,6 @@ def test_drift_gate_offers_yn_prompt_on_tty(
     # fake_stdin is set to "n\n" by _setup_drift_check
     input_calls: list[str] = []
 
-
     monkeypatch.setattr("builtins.input", lambda prompt="": (input_calls.append(prompt), "n")[1])
 
     run_source_drift_check(home=tmp_path)

--- a/tests/cli/test_source_drift.py
+++ b/tests/cli/test_source_drift.py
@@ -6,15 +6,13 @@ import ast
 import io
 import json
 import subprocess
-import sys
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import httpx
 import pytest
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -92,9 +90,7 @@ def test_classify_git_vcs_stable(monkeypatch: pytest.MonkeyPatch) -> None:
         requested_revision="stable",
         vcs_url="https://github.com/TalonT-Org/AutoSkillit.git",
     )
-    monkeypatch.setattr(
-        importlib.metadata.Distribution, "from_name", staticmethod(lambda _: dist)
-    )
+    monkeypatch.setattr(importlib.metadata.Distribution, "from_name", staticmethod(lambda _: dist))
 
     info = detect_install()
     assert info.install_type == InstallType.GIT_VCS
@@ -114,9 +110,7 @@ def test_classify_git_vcs_integration(monkeypatch: pytest.MonkeyPatch) -> None:
         commit_id="fed9876543210abc",
         requested_revision="integration",
     )
-    monkeypatch.setattr(
-        importlib.metadata.Distribution, "from_name", staticmethod(lambda _: dist)
-    )
+    monkeypatch.setattr(importlib.metadata.Distribution, "from_name", staticmethod(lambda _: dist))
 
     info = detect_install()
     assert info.install_type == InstallType.GIT_VCS
@@ -129,9 +123,7 @@ def test_classify_local_editable(monkeypatch: pytest.MonkeyPatch) -> None:
     from autoskillit.cli._source_drift import InstallType, detect_install
 
     dist = _fake_dist(editable=True, file_url="file:///home/x/repo")
-    monkeypatch.setattr(
-        importlib.metadata.Distribution, "from_name", staticmethod(lambda _: dist)
-    )
+    monkeypatch.setattr(importlib.metadata.Distribution, "from_name", staticmethod(lambda _: dist))
 
     info = detect_install()
     assert info.install_type == InstallType.LOCAL_EDITABLE
@@ -146,9 +138,7 @@ def test_classify_unknown_when_no_direct_url(monkeypatch: pytest.MonkeyPatch) ->
     from autoskillit.cli._source_drift import InstallType, detect_install
 
     dist = _fake_dist(no_direct_url=True)
-    monkeypatch.setattr(
-        importlib.metadata.Distribution, "from_name", staticmethod(lambda _: dist)
-    )
+    monkeypatch.setattr(importlib.metadata.Distribution, "from_name", staticmethod(lambda _: dist))
 
     info = detect_install()
     assert info.install_type == InstallType.UNKNOWN
@@ -172,9 +162,7 @@ def test_classify_deterministic_independent_of_cwd(
     monkeypatch.chdir(cwd)
 
     dist = _fake_dist(vcs="git", commit_id="aabbccdd", requested_revision="stable")
-    monkeypatch.setattr(
-        importlib.metadata.Distribution, "from_name", staticmethod(lambda _: dist)
-    )
+    monkeypatch.setattr(importlib.metadata.Distribution, "from_name", staticmethod(lambda _: dist))
 
     info = detect_install()
     assert info.install_type == InstallType.GIT_VCS
@@ -278,13 +266,9 @@ def test_resolve_ref_sha_uses_git_ls_remote_origin_refs_heads(
     assert any("ls-remote" in " ".join(cmd) for cmd in captured), (
         f"Expected git ls-remote call, got: {captured}"
     )
-    heads_call = next(
-        (cmd for cmd in captured if "refs/heads/integration" in " ".join(cmd)), None
-    )
+    heads_call = next((cmd for cmd in captured if "refs/heads/integration" in " ".join(cmd)), None)
     assert heads_call is not None, f"Expected refs/heads/integration call, got: {captured}"
-    assert "rev-parse" not in " ".join(heads_call), (
-        "Must use ls-remote, not rev-parse"
-    )
+    assert "rev-parse" not in " ".join(heads_call), "Must use ls-remote, not rev-parse"
 
 
 def test_resolve_ref_sha_parses_sha_from_ls_remote_first_column(
@@ -383,7 +367,7 @@ def test_resolve_ref_sha_short_circuits_exact_sha_equality(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """When requested_revision exactly equals commit_id, return early without git or network."""
-    from autoskillit.cli._source_drift import InstallType, InstallInfo, resolve_reference_sha
+    from autoskillit.cli._source_drift import InstallInfo, InstallType, resolve_reference_sha
 
     commit = "abcdef1234567890abcdef1234567890"
     info = InstallInfo(
@@ -411,7 +395,7 @@ def test_resolve_ref_sha_does_not_short_circuit_on_hex_prefix_branch_name(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A branch named after a hex prefix of commit_id must NOT short-circuit."""
-    from autoskillit.cli._source_drift import InstallType, InstallInfo, resolve_reference_sha
+    from autoskillit.cli._source_drift import InstallInfo, InstallType, resolve_reference_sha
 
     # commit_id starts with "abc123", requested_revision IS "abc123" (a branch)
     # These are NOT equal (one is a branch name, other is a full SHA)
@@ -447,7 +431,7 @@ def test_resolve_ref_sha_missing_requested_revision_returns_none(
     tmp_path: Path,
 ) -> None:
     """When requested_revision is None, return None and skip all resolution."""
-    from autoskillit.cli._source_drift import InstallType, InstallInfo, resolve_reference_sha
+    from autoskillit.cli._source_drift import InstallInfo, InstallType, resolve_reference_sha
 
     info = InstallInfo(
         install_type=InstallType.GIT_VCS,
@@ -465,7 +449,6 @@ def test_resolve_ref_sha_fails_open_on_any_error(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """On subprocess error, resolve_reference_sha returns None and logs DEBUG."""
-    import logging
 
     from autoskillit.cli._source_drift import resolve_reference_sha
 
@@ -508,7 +491,6 @@ def _setup_drift_check(
     """Set up mocks for run_source_drift_check and return a captured stdout."""
     import autoskillit.cli._source_drift as _sd
     import autoskillit.cli._stale_check as _sc
-
     from autoskillit.cli._source_drift import InstallInfo, InstallType
 
     install_type = InstallType(install_type_str)
@@ -547,9 +529,7 @@ def test_drift_gate_prints_install_dev_hint_for_integration(
     """When drift is detected for integration branch, hint includes 'task install-dev'."""
     from autoskillit.cli._source_drift import run_source_drift_check
 
-    fake_stdout = _setup_drift_check(
-        monkeypatch, tmp_path, requested_revision="integration"
-    )
+    fake_stdout = _setup_drift_check(monkeypatch, tmp_path, requested_revision="integration")
 
     run_source_drift_check(home=tmp_path)
 
@@ -563,9 +543,7 @@ def test_drift_gate_prints_curl_install_hint_for_stable(
     """When drift is detected for stable branch, hint includes curl install.sh."""
     from autoskillit.cli._source_drift import run_source_drift_check
 
-    fake_stdout = _setup_drift_check(
-        monkeypatch, tmp_path, requested_revision="stable"
-    )
+    fake_stdout = _setup_drift_check(monkeypatch, tmp_path, requested_revision="stable")
 
     run_source_drift_check(home=tmp_path)
 
@@ -626,7 +604,6 @@ def test_drift_gate_offers_yn_prompt_on_tty(
     # fake_stdin is set to "n\n" by _setup_drift_check
     input_calls: list[str] = []
 
-    import autoskillit.cli._source_drift as _sd
 
     monkeypatch.setattr("builtins.input", lambda prompt="": (input_calls.append(prompt), "n")[1])
 

--- a/tests/cli/test_source_drift.py
+++ b/tests/cli/test_source_drift.py
@@ -1,0 +1,887 @@
+"""Tests for cli/_source_drift.py — source-drift boot gate."""
+
+from __future__ import annotations
+
+import ast
+import io
+import json
+import subprocess
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_install_info(
+    install_type=None,
+    commit_id: str | None = "abc1234abcd",
+    requested_revision: str | None = "integration",
+    url: str | None = "https://github.com/TalonT-Org/AutoSkillit.git",
+    editable_source: Path | None = None,
+) -> Any:
+    from autoskillit.cli._source_drift import InstallInfo, InstallType
+
+    return InstallInfo(
+        install_type=install_type or InstallType.GIT_VCS,
+        commit_id=commit_id,
+        requested_revision=requested_revision,
+        url=url,
+        editable_source=editable_source,
+    )
+
+
+def _fake_dist(
+    *,
+    vcs: str | None = None,
+    commit_id: str | None = None,
+    requested_revision: str | None = None,
+    vcs_url: str | None = None,
+    editable: bool = False,
+    file_url: str | None = None,
+    no_direct_url: bool = False,
+) -> Any:
+    import importlib.metadata
+
+    fake = MagicMock(spec=importlib.metadata.Distribution)
+    if no_direct_url:
+        fake.read_text.return_value = None
+        return fake
+
+    data: dict[str, Any] = {}
+    if vcs == "git":
+        data["url"] = vcs_url or "https://github.com/TalonT-Org/AutoSkillit.git"
+        vcs_info: dict[str, Any] = {"vcs": "git"}
+        if commit_id:
+            vcs_info["commit_id"] = commit_id
+        if requested_revision:
+            vcs_info["requested_revision"] = requested_revision
+        data["vcs_info"] = vcs_info
+    elif editable and file_url:
+        data["url"] = file_url
+        data["dir_info"] = {"editable": True}
+    elif file_url:
+        data["url"] = file_url
+        data["dir_info"] = {"editable": False}
+
+    fake.read_text.return_value = json.dumps(data)
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# detect_install
+# ---------------------------------------------------------------------------
+
+
+def test_classify_git_vcs_stable(monkeypatch: pytest.MonkeyPatch) -> None:
+    import importlib.metadata
+
+    from autoskillit.cli._source_drift import InstallType, detect_install
+
+    dist = _fake_dist(
+        vcs="git",
+        commit_id="abcdef1234567890",
+        requested_revision="stable",
+        vcs_url="https://github.com/TalonT-Org/AutoSkillit.git",
+    )
+    monkeypatch.setattr(
+        importlib.metadata.Distribution, "from_name", staticmethod(lambda _: dist)
+    )
+
+    info = detect_install()
+    assert info.install_type == InstallType.GIT_VCS
+    assert info.commit_id == "abcdef1234567890"
+    assert info.requested_revision == "stable"
+    assert info.url == "https://github.com/TalonT-Org/AutoSkillit.git"
+    assert info.editable_source is None
+
+
+def test_classify_git_vcs_integration(monkeypatch: pytest.MonkeyPatch) -> None:
+    import importlib.metadata
+
+    from autoskillit.cli._source_drift import InstallType, detect_install
+
+    dist = _fake_dist(
+        vcs="git",
+        commit_id="fed9876543210abc",
+        requested_revision="integration",
+    )
+    monkeypatch.setattr(
+        importlib.metadata.Distribution, "from_name", staticmethod(lambda _: dist)
+    )
+
+    info = detect_install()
+    assert info.install_type == InstallType.GIT_VCS
+    assert info.requested_revision == "integration"
+
+
+def test_classify_local_editable(monkeypatch: pytest.MonkeyPatch) -> None:
+    import importlib.metadata
+
+    from autoskillit.cli._source_drift import InstallType, detect_install
+
+    dist = _fake_dist(editable=True, file_url="file:///home/x/repo")
+    monkeypatch.setattr(
+        importlib.metadata.Distribution, "from_name", staticmethod(lambda _: dist)
+    )
+
+    info = detect_install()
+    assert info.install_type == InstallType.LOCAL_EDITABLE
+    assert info.editable_source == Path("/home/x/repo")
+    assert info.commit_id is None
+    assert info.requested_revision is None
+
+
+def test_classify_unknown_when_no_direct_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    import importlib.metadata
+
+    from autoskillit.cli._source_drift import InstallType, detect_install
+
+    dist = _fake_dist(no_direct_url=True)
+    monkeypatch.setattr(
+        importlib.metadata.Distribution, "from_name", staticmethod(lambda _: dist)
+    )
+
+    info = detect_install()
+    assert info.install_type == InstallType.UNKNOWN
+    assert info.commit_id is None
+
+
+@pytest.mark.parametrize(
+    "cwd_suffix",
+    [".", "subdir1", "subdir2/deeper"],
+)
+def test_classify_deterministic_independent_of_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cwd_suffix: str
+) -> None:
+    """detect_install() returns the same result regardless of CWD."""
+    import importlib.metadata
+
+    from autoskillit.cli._source_drift import InstallType, detect_install
+
+    cwd = tmp_path / cwd_suffix
+    cwd.mkdir(parents=True, exist_ok=True)
+    monkeypatch.chdir(cwd)
+
+    dist = _fake_dist(vcs="git", commit_id="aabbccdd", requested_revision="stable")
+    monkeypatch.setattr(
+        importlib.metadata.Distribution, "from_name", staticmethod(lambda _: dist)
+    )
+
+    info = detect_install()
+    assert info.install_type == InstallType.GIT_VCS
+    assert info.commit_id == "aabbccdd"
+
+
+# ---------------------------------------------------------------------------
+# find_source_repo (tested via resolve_reference_sha interactions)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_ref_sha_prefers_autoskillit_source_repo_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AUTOSKILLIT_SOURCE_REPO env var takes precedence over CWD walk."""
+    from autoskillit.cli._source_drift import find_source_repo
+
+    repo = tmp_path / "myrepo"
+    repo.mkdir()
+    (repo / "src" / "autoskillit").mkdir(parents=True)
+
+    monkeypatch.setenv("AUTOSKILLIT_SOURCE_REPO", str(repo))
+    result = find_source_repo()
+    assert result == repo
+
+
+def test_resolve_ref_sha_source_repo_env_missing_path_falls_through(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When AUTOSKILLIT_SOURCE_REPO points to a non-existent path, CWD walk is used."""
+    from autoskillit.cli._source_drift import find_source_repo
+
+    # Also create an autoskillit repo under CWD so the walk can find it
+    autoskillit_root = tmp_path / "autoskillit_root"
+    autoskillit_root.mkdir()
+    (autoskillit_root / "src" / "autoskillit").mkdir(parents=True)
+    pyproject = autoskillit_root / "pyproject.toml"
+    pyproject.write_bytes(b'[project]\nname = "autoskillit"\n')
+
+    monkeypatch.setenv("AUTOSKILLIT_SOURCE_REPO", str(tmp_path / "does-not-exist"))
+    monkeypatch.chdir(autoskillit_root)
+
+    result = find_source_repo()
+    assert result == autoskillit_root
+
+
+def test_resolve_ref_sha_walks_cwd_for_source_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """CWD walk locates a parent directory containing autoskillit source."""
+    from autoskillit.cli._source_drift import find_source_repo
+
+    monkeypatch.delenv("AUTOSKILLIT_SOURCE_REPO", raising=False)
+
+    repo_root = tmp_path / "autoskillit"
+    (repo_root / "src" / "autoskillit").mkdir(parents=True)
+    pyproject = repo_root / "pyproject.toml"
+    pyproject.write_bytes(b'[project]\nname = "autoskillit"\n')
+
+    # CWD is a subdirectory of the repo root
+    sub = repo_root / "tests" / "cli"
+    sub.mkdir(parents=True)
+    monkeypatch.chdir(sub)
+
+    result = find_source_repo()
+    assert result == repo_root
+
+
+# ---------------------------------------------------------------------------
+# resolve_reference_sha — git ls-remote behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_ref_sha_uses_git_ls_remote_origin_refs_heads(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Must call git -C <src> ls-remote origin refs/heads/integration."""
+    from autoskillit.cli._source_drift import resolve_reference_sha
+
+    info = _make_install_info(commit_id="aaa111", requested_revision="integration")
+
+    repo = tmp_path / "src_repo"
+    (repo / "src" / "autoskillit").mkdir(parents=True)
+    monkeypatch.setenv("AUTOSKILLIT_SOURCE_REPO", str(repo))
+
+    captured: list[list[str]] = []
+    real_run = subprocess.run
+
+    def spy_run(cmd: list[str], **kwargs: Any) -> Any:
+        captured.append(list(cmd))
+        result = MagicMock()
+        result.stdout = "def456def456def456\trefs/heads/integration\n"
+        result.returncode = 0
+        return result
+
+    monkeypatch.setattr(subprocess, "run", spy_run)
+
+    sha = resolve_reference_sha(info, tmp_path, network=False)
+
+    assert sha == "def456def456def456"
+    assert any("ls-remote" in " ".join(cmd) for cmd in captured), (
+        f"Expected git ls-remote call, got: {captured}"
+    )
+    heads_call = next(
+        (cmd for cmd in captured if "refs/heads/integration" in " ".join(cmd)), None
+    )
+    assert heads_call is not None, f"Expected refs/heads/integration call, got: {captured}"
+    assert "rev-parse" not in " ".join(heads_call), (
+        "Must use ls-remote, not rev-parse"
+    )
+
+
+def test_resolve_ref_sha_parses_sha_from_ls_remote_first_column(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """SHA is parsed from the first whitespace-separated column of ls-remote output."""
+    from autoskillit.cli._source_drift import resolve_reference_sha
+
+    info = _make_install_info(commit_id="old111", requested_revision="integration")
+
+    repo = tmp_path / "src_repo"
+    (repo / "src" / "autoskillit").mkdir(parents=True)
+    monkeypatch.setenv("AUTOSKILLIT_SOURCE_REPO", str(repo))
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+        result = MagicMock()
+        if "refs/heads/integration" in cmd:
+            result.stdout = "abc1234def5678\trefs/heads/integration\n"
+        else:
+            result.stdout = ""
+        return result
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    sha = resolve_reference_sha(info, tmp_path, network=False)
+    assert sha == "abc1234def5678"
+
+
+def test_resolve_ref_sha_falls_back_to_tag_ref_syntax(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When refs/heads/<rev> returns empty, try refs/tags/<rev>^{} next."""
+    from autoskillit.cli._source_drift import resolve_reference_sha
+
+    info = _make_install_info(commit_id="old111", requested_revision="v1.0.0")
+
+    repo = tmp_path / "src_repo"
+    (repo / "src" / "autoskillit").mkdir(parents=True)
+    monkeypatch.setenv("AUTOSKILLIT_SOURCE_REPO", str(repo))
+
+    captured_refs: list[str] = []
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+        result = MagicMock()
+        ref = cmd[-1] if cmd else ""
+        captured_refs.append(ref)
+        if "refs/tags" in ref:
+            result.stdout = "tagsha123456\trefs/tags/v1.0.0^{}\n"
+        else:
+            result.stdout = ""  # heads ref returns empty
+        return result
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    sha = resolve_reference_sha(info, tmp_path, network=False)
+
+    assert sha == "tagsha123456"
+    assert any("refs/heads" in r for r in captured_refs), (
+        "refs/heads ref should have been tried first"
+    )
+    assert any("refs/tags" in r for r in captured_refs), (
+        "refs/tags ref should be tried as fallback"
+    )
+
+
+def test_resolve_ref_sha_falls_back_to_github_api_when_no_source_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When no source repo is found, GitHub API is called via _fetch_with_cache."""
+    from autoskillit.cli._source_drift import resolve_reference_sha
+
+    monkeypatch.delenv("AUTOSKILLIT_SOURCE_REPO", raising=False)
+    monkeypatch.chdir(tmp_path)  # No pyproject.toml here
+
+    info = _make_install_info(commit_id="old111", requested_revision="integration")
+
+    fetch_calls: list[str] = []
+
+    def fake_fetch(url: str, *, home: Path, ttl: Any = None) -> dict | None:
+        fetch_calls.append(url)
+        return {"object": {"sha": "apisha123456"}}
+
+    import autoskillit.cli._stale_check as _sc
+
+    monkeypatch.setattr(_sc, "_fetch_with_cache", fake_fetch)
+
+    sha = resolve_reference_sha(info, tmp_path, network=True)
+
+    assert sha == "apisha123456"
+    assert any("integration" in url for url in fetch_calls), (
+        f"Expected API call for integration branch, got: {fetch_calls}"
+    )
+
+
+def test_resolve_ref_sha_short_circuits_exact_sha_equality(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When requested_revision exactly equals commit_id, return early without git or network."""
+    from autoskillit.cli._source_drift import InstallType, InstallInfo, resolve_reference_sha
+
+    commit = "abcdef1234567890abcdef1234567890"
+    info = InstallInfo(
+        install_type=InstallType.GIT_VCS,
+        commit_id=commit,
+        requested_revision=commit,  # exact match
+        url="https://github.com/TalonT-Org/AutoSkillit.git",
+        editable_source=None,
+    )
+
+    git_called = [False]
+
+    def bad_run(cmd: list[str], **kwargs: Any) -> Any:
+        git_called[0] = True
+        raise AssertionError("git subprocess must not be called on exact SHA match")
+
+    monkeypatch.setattr(subprocess, "run", bad_run)
+
+    sha = resolve_reference_sha(info, tmp_path, network=True)
+    assert sha == commit
+    assert not git_called[0]
+
+
+def test_resolve_ref_sha_does_not_short_circuit_on_hex_prefix_branch_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A branch named after a hex prefix of commit_id must NOT short-circuit."""
+    from autoskillit.cli._source_drift import InstallType, InstallInfo, resolve_reference_sha
+
+    # commit_id starts with "abc123", requested_revision IS "abc123" (a branch)
+    # These are NOT equal (one is a branch name, other is a full SHA)
+    commit_id = "abc12399999999999999999999999999"
+    info = InstallInfo(
+        install_type=InstallType.GIT_VCS,
+        commit_id=commit_id,
+        requested_revision="abc123",  # hex prefix branch name
+        url="https://github.com/TalonT-Org/AutoSkillit.git",
+        editable_source=None,
+    )
+
+    monkeypatch.delenv("AUTOSKILLIT_SOURCE_REPO", raising=False)
+    monkeypatch.chdir(tmp_path)  # No source repo under CWD
+
+    fetch_calls: list[str] = []
+
+    def fake_fetch(url: str, *, home: Path, ttl: Any = None) -> dict | None:
+        fetch_calls.append(url)
+        return {"object": {"sha": "branchheadsha"}}
+
+    import autoskillit.cli._stale_check as _sc
+
+    monkeypatch.setattr(_sc, "_fetch_with_cache", fake_fetch)
+
+    sha = resolve_reference_sha(info, tmp_path, network=True)
+
+    assert sha == "branchheadsha", "Should have consulted git/network, not short-circuited"
+    assert fetch_calls, "Network should have been called — no short-circuit for hex prefix branch"
+
+
+def test_resolve_ref_sha_missing_requested_revision_returns_none(
+    tmp_path: Path,
+) -> None:
+    """When requested_revision is None, return None and skip all resolution."""
+    from autoskillit.cli._source_drift import InstallType, InstallInfo, resolve_reference_sha
+
+    info = InstallInfo(
+        install_type=InstallType.GIT_VCS,
+        commit_id="abc1234",
+        requested_revision=None,  # bare pip install with no @ref
+        url="https://github.com/TalonT-Org/AutoSkillit.git",
+        editable_source=None,
+    )
+
+    sha = resolve_reference_sha(info, tmp_path, network=True)
+    assert sha is None
+
+
+def test_resolve_ref_sha_fails_open_on_any_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """On subprocess error, resolve_reference_sha returns None and logs DEBUG."""
+    import logging
+
+    from autoskillit.cli._source_drift import resolve_reference_sha
+
+    info = _make_install_info(commit_id="old111", requested_revision="integration")
+
+    repo = tmp_path / "src_repo"
+    (repo / "src" / "autoskillit").mkdir(parents=True)
+    monkeypatch.setenv("AUTOSKILLIT_SOURCE_REPO", str(repo))
+
+    def bad_run(cmd: list[str], **kwargs: Any) -> Any:
+        raise subprocess.CalledProcessError(1, "git")
+
+    monkeypatch.setattr(subprocess, "run", bad_run)
+
+    # Patch API fallback to also fail
+    import autoskillit.cli._stale_check as _sc
+
+    monkeypatch.setattr(_sc, "_fetch_with_cache", lambda *a, **kw: None)
+
+    sha = resolve_reference_sha(info, tmp_path, network=True)
+    assert sha is None  # Fail-open: returns None, does not raise
+
+
+# ---------------------------------------------------------------------------
+# run_source_drift_check — hint output
+# ---------------------------------------------------------------------------
+
+
+def _setup_drift_check(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    install_type_str: str = "git-vcs",
+    commit_id: str = "old111aaa",
+    requested_revision: str = "integration",
+    ref_sha: str = "new222bbb",
+    is_tty: bool = False,
+    editable_source: Path | None = None,
+) -> io.StringIO:
+    """Set up mocks for run_source_drift_check and return a captured stdout."""
+    import autoskillit.cli._source_drift as _sd
+    import autoskillit.cli._stale_check as _sc
+
+    from autoskillit.cli._source_drift import InstallInfo, InstallType
+
+    install_type = InstallType(install_type_str)
+    fake_info = InstallInfo(
+        install_type=install_type,
+        commit_id=commit_id,
+        requested_revision=requested_revision,
+        url="https://github.com/TalonT-Org/AutoSkillit.git",
+        editable_source=editable_source,
+    )
+
+    monkeypatch.setattr(_sd, "detect_install", lambda: fake_info)
+    monkeypatch.setattr(_sd, "resolve_reference_sha", lambda info, home, **kw: ref_sha)
+    monkeypatch.setattr(_sc, "_read_dismiss_state", lambda home: {})
+    monkeypatch.setattr(_sc, "_is_drift_dismissed", lambda state, installed, ref: False)
+    monkeypatch.setattr(_sc, "_write_dismiss_state", lambda home, state: None)
+    monkeypatch.setattr(_sd.subprocess, "run", MagicMock())
+
+    fake_stdout = io.StringIO()
+    fake_stdin = io.StringIO("n\n")
+    monkeypatch.setattr(fake_stdin, "isatty", lambda: is_tty)
+    monkeypatch.setattr(fake_stdout, "isatty", lambda: is_tty)
+    monkeypatch.setattr(_sd.sys, "stdin", fake_stdin)
+    monkeypatch.setattr(_sd.sys, "stdout", fake_stdout)
+
+    monkeypatch.delenv("AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK", raising=False)
+    monkeypatch.delenv("CLAUDECODE", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+
+    return fake_stdout
+
+
+def test_drift_gate_prints_install_dev_hint_for_integration(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When drift is detected for integration branch, hint includes 'task install-dev'."""
+    from autoskillit.cli._source_drift import run_source_drift_check
+
+    fake_stdout = _setup_drift_check(
+        monkeypatch, tmp_path, requested_revision="integration"
+    )
+
+    run_source_drift_check(home=tmp_path)
+
+    output = fake_stdout.getvalue()
+    assert "task install-dev" in output, f"Expected 'task install-dev' in output, got: {output!r}"
+
+
+def test_drift_gate_prints_curl_install_hint_for_stable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When drift is detected for stable branch, hint includes curl install.sh."""
+    from autoskillit.cli._source_drift import run_source_drift_check
+
+    fake_stdout = _setup_drift_check(
+        monkeypatch, tmp_path, requested_revision="stable"
+    )
+
+    run_source_drift_check(home=tmp_path)
+
+    output = fake_stdout.getvalue()
+    assert "install.sh" in output, f"Expected 'install.sh' in output, got: {output!r}"
+    assert "curl" in output, f"Expected 'curl' in output, got: {output!r}"
+
+
+def test_drift_gate_prints_install_worktree_hint_for_editable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When local-editable install drifts, hint includes 'task install-worktree'."""
+    from autoskillit.cli._source_drift import run_source_drift_check
+
+    fake_stdout = _setup_drift_check(
+        monkeypatch,
+        tmp_path,
+        install_type_str="local-editable",
+        commit_id=None,
+        requested_revision=None,
+        editable_source=tmp_path,
+    )
+
+    run_source_drift_check(home=tmp_path)
+
+    output = fake_stdout.getvalue()
+    assert "install-worktree" in output, (
+        f"Expected 'task install-worktree' in output, got: {output!r}"
+    )
+
+
+def test_drift_gate_prints_generic_hint_for_unknown_ref(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When drift is detected for an unrecognised revision, a generic hint is printed."""
+    from autoskillit.cli._source_drift import run_source_drift_check
+
+    fake_stdout = _setup_drift_check(
+        monkeypatch, tmp_path, requested_revision="some-custom-branch"
+    )
+
+    run_source_drift_check(home=tmp_path)
+
+    output = fake_stdout.getvalue()
+    assert output.strip(), "Expected some output for unknown-ref drift"
+    # No specific command should be mentioned for unknown refs
+    assert "task install-dev" not in output
+    assert "install.sh" not in output
+
+
+def test_drift_gate_offers_yn_prompt_on_tty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """On a TTY, the gate offers a [Y/n] update prompt."""
+    from autoskillit.cli._source_drift import run_source_drift_check
+
+    fake_stdout = _setup_drift_check(monkeypatch, tmp_path, is_tty=True)
+    # fake_stdin is set to "n\n" by _setup_drift_check
+    input_calls: list[str] = []
+
+    import autoskillit.cli._source_drift as _sd
+
+    monkeypatch.setattr("builtins.input", lambda prompt="": (input_calls.append(prompt), "n")[1])
+
+    run_source_drift_check(home=tmp_path)
+
+    assert input_calls, "input() should have been called on TTY"
+    assert any("[Y/n]" in p or "Update" in p for p in input_calls), (
+        f"Expected [Y/n] prompt, got: {input_calls}"
+    )
+
+
+def test_drift_gate_non_tty_prints_warning_and_continues(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """On non-TTY, warning is printed but no input() call is made."""
+    from autoskillit.cli._source_drift import run_source_drift_check
+
+    fake_stdout = _setup_drift_check(monkeypatch, tmp_path, is_tty=False)
+
+    input_calls: list[str] = []
+    monkeypatch.setattr("builtins.input", lambda prompt="": (input_calls.append(prompt), "")[1])
+
+    run_source_drift_check(home=tmp_path)
+
+    assert not input_calls, f"input() must not be called on non-TTY, got: {input_calls}"
+    output = fake_stdout.getvalue()
+    assert output.strip(), "Expected some output on non-TTY"
+
+
+# ---------------------------------------------------------------------------
+# run_source_drift_check — env var bypass guards
+# ---------------------------------------------------------------------------
+
+
+def test_skip_env_var_bypasses_drift_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK=1 causes early return with no detection work."""
+    import autoskillit.cli._source_drift as _sd
+
+    monkeypatch.setenv("AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK", "1")
+    detect_calls: list[int] = []
+    monkeypatch.setattr(_sd, "detect_install", lambda: detect_calls.append(1) or None)
+
+    _sd.run_source_drift_check()
+
+    assert not detect_calls, "detect_install must not be called when skip env var is set"
+
+
+def test_claudecode_env_var_bypasses_drift_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CLAUDECODE=1 causes early return (headless/MCP sessions skip the gate)."""
+    import autoskillit.cli._source_drift as _sd
+
+    monkeypatch.setenv("CLAUDECODE", "1")
+    monkeypatch.delenv("AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK", raising=False)
+    detect_calls: list[int] = []
+    monkeypatch.setattr(_sd, "detect_install", lambda: detect_calls.append(1) or None)
+
+    _sd.run_source_drift_check()
+
+    assert not detect_calls, "detect_install must not be called when CLAUDECODE=1"
+
+
+def test_ci_env_var_bypasses_drift_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CI=1 causes early return (belt-and-suspenders for generic CI environments)."""
+    import autoskillit.cli._source_drift as _sd
+
+    monkeypatch.setenv("CI", "1")
+    monkeypatch.delenv("AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK", raising=False)
+    monkeypatch.delenv("CLAUDECODE", raising=False)
+    detect_calls: list[int] = []
+    monkeypatch.setattr(_sd, "detect_install", lambda: detect_calls.append(1) or None)
+
+    _sd.run_source_drift_check()
+
+    assert not detect_calls, "detect_install must not be called when CI=1"
+
+
+# ---------------------------------------------------------------------------
+# run_source_drift_check — dismissal
+# ---------------------------------------------------------------------------
+
+
+def test_drift_dismissal_12h_window_sha_keyed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Dismissal is SHA-keyed with a 12h window.
+
+    dismiss at T0 → suppressed at T+11h59m (same SHAs) → fires at T+12h01m
+    → fires at T+1h with different commit_id.
+    """
+    from autoskillit.cli._stale_check import (
+        _DISMISS_WINDOW,
+        _is_drift_dismissed,
+        _write_dismiss_state,
+    )
+
+    installed = "abc123"
+    reference = "def456"
+
+    # Write dismissal at T0
+    state: dict[str, object] = {}
+    _write_dismiss_state(tmp_path, state)  # Ensure dir exists
+
+    now = datetime.now(UTC)
+    dismissed_entry = {
+        "dismissed_at": now.isoformat(),
+        "installed_sha": installed,
+        "reference_sha": reference,
+    }
+    state_with_dismiss: dict[str, object] = {"source_drift": dismissed_entry}
+
+    # Within 12h window, same SHAs → suppressed
+    assert _is_drift_dismissed(state_with_dismiss, installed, reference) is True
+
+    # Same SHAs but dismissed_at is T+11h59m (still within window)
+    within_window = now - timedelta(hours=11, minutes=59)
+    state_within: dict[str, object] = {
+        "source_drift": {
+            "dismissed_at": within_window.isoformat(),
+            "installed_sha": installed,
+            "reference_sha": reference,
+        }
+    }
+    assert _is_drift_dismissed(state_within, installed, reference) is True
+
+    # Past 12h window → fires again
+    past_window = now - (_DISMISS_WINDOW + timedelta(minutes=1))
+    state_expired: dict[str, object] = {
+        "source_drift": {
+            "dismissed_at": past_window.isoformat(),
+            "installed_sha": installed,
+            "reference_sha": reference,
+        }
+    }
+    assert _is_drift_dismissed(state_expired, installed, reference) is False
+
+    # Within window but different commit_id → fires
+    state_diff_sha: dict[str, object] = {
+        "source_drift": {
+            "dismissed_at": now.isoformat(),
+            "installed_sha": "different_sha",  # different commit_id
+            "reference_sha": reference,
+        }
+    }
+    assert _is_drift_dismissed(state_diff_sha, installed, reference) is False
+
+
+# ---------------------------------------------------------------------------
+# run_source_drift_check — fail-open (never raises)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        OSError("disk full"),
+        PermissionError("denied"),
+        TimeoutError("timeout"),
+        json.JSONDecodeError("bad", "", 0),
+        ValueError("shape"),
+        KeyError("missing"),
+        subprocess.CalledProcessError(1, "git"),
+        FileNotFoundError("git"),
+        httpx.ConnectError("offline"),
+        httpx.TimeoutException("slow"),
+    ],
+)
+def test_drift_gate_never_raises_on_error(
+    exc: Exception, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """run_source_drift_check never raises on any Exception subclass.
+
+    Exception is injected at four fault-injection points:
+    1. detect_install
+    2. resolve_reference_sha
+    3. _read_dismiss_state
+    4. _write_dismiss_state (via the dismiss path)
+    """
+    import autoskillit.cli._source_drift as _sd
+    import autoskillit.cli._stale_check as _sc
+
+    monkeypatch.delenv("AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK", raising=False)
+    monkeypatch.delenv("CLAUDECODE", raising=False)
+    monkeypatch.delenv("CI", raising=False)
+
+    # Fault point 1: detect_install
+    monkeypatch.setattr(_sd, "detect_install", lambda: (_ for _ in ()).throw(type(exc)(str(exc))))
+    _sd.run_source_drift_check(home=tmp_path)  # must not raise
+
+    # Fault point 2: resolve_reference_sha (detect_install succeeds this time)
+    from autoskillit.cli._source_drift import InstallInfo, InstallType
+
+    good_info = InstallInfo(
+        install_type=InstallType.GIT_VCS,
+        commit_id="old111",
+        requested_revision="integration",
+        url=None,
+        editable_source=None,
+    )
+    monkeypatch.setattr(_sd, "detect_install", lambda: good_info)
+    monkeypatch.setattr(
+        _sd,
+        "resolve_reference_sha",
+        lambda info, home, **kw: (_ for _ in ()).throw(type(exc)(str(exc))),
+    )
+    _sd.run_source_drift_check(home=tmp_path)  # must not raise
+
+    # Fault point 3: _read_dismiss_state (resolve succeeds, SHAs differ)
+    monkeypatch.setattr(_sd, "resolve_reference_sha", lambda info, home, **kw: "new222")
+    monkeypatch.setattr(
+        _sc,
+        "_read_dismiss_state",
+        lambda home: (_ for _ in ()).throw(type(exc)(str(exc))),
+    )
+    _sd.run_source_drift_check(home=tmp_path)  # must not raise
+
+    # Fault point 4: _write_dismiss_state (dismiss path, non-TTY so no prompt)
+    monkeypatch.setattr(_sc, "_read_dismiss_state", lambda home: {})
+    monkeypatch.setattr(_sc, "_is_drift_dismissed", lambda state, installed, ref: False)
+    monkeypatch.setattr(
+        _sc,
+        "_write_dismiss_state",
+        lambda home, state: (_ for _ in ()).throw(type(exc)(str(exc))),
+    )
+    fake_stdout = io.StringIO()
+    fake_stdin = io.StringIO("")
+    monkeypatch.setattr(fake_stdin, "isatty", lambda: False)
+    monkeypatch.setattr(fake_stdout, "isatty", lambda: False)
+    monkeypatch.setattr(_sd.sys, "stdin", fake_stdin)
+    monkeypatch.setattr(_sd.sys, "stdout", fake_stdout)
+    _sd.run_source_drift_check(home=tmp_path)  # must not raise
+
+
+def test_drift_gate_only_catches_exception_not_base_exception() -> None:
+    """run_source_drift_check must only catch Exception, not BaseException.
+
+    This is an AST-level contract: the drift gate must not swallow
+    KeyboardInterrupt or SystemExit.
+    """
+    src = Path(__file__).parent.parent.parent / "src" / "autoskillit" / "cli" / "_source_drift.py"
+    if not src.exists():
+        pytest.skip("Source tree unavailable")
+
+    tree = ast.parse(src.read_text(encoding="utf-8"))
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ExceptHandler):
+            t = node.type
+            if t is None:
+                violations.append(f"Line {node.lineno}: bare except (catches BaseException)")
+            elif isinstance(t, ast.Name) and t.id == "BaseException":
+                violations.append(f"Line {node.lineno}: except BaseException")
+            elif isinstance(t, ast.Attribute) and t.attr == "BaseException":
+                violations.append(f"Line {node.lineno}: except BaseException")
+
+    assert not violations, (
+        "run_source_drift_check must not catch BaseException (would swallow KeyboardInterrupt):\n"
+        + "\n".join(violations)
+    )

--- a/tests/cli/test_stale_check.py
+++ b/tests/cli/test_stale_check.py
@@ -158,7 +158,7 @@ def test_run_stale_check_writes_dismiss_on_no(
     monkeypatch.setattr(fake_stdout, "isatty", lambda: True)
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     monkeypatch.setattr(autoskillit, "__version__", "0.5.0")
-    monkeypatch.setattr(_sc, "_fetch_latest_version", lambda dev_mode: "0.9.0")
+    monkeypatch.setattr(_sc, "_fetch_latest_version", lambda *args, **kwargs: "0.9.0")
     monkeypatch.setattr(_sc, "is_dev_mode", lambda home=None: False)
     import autoskillit.cli as _cli
 
@@ -191,7 +191,7 @@ def test_run_stale_check_binary_update_y_path_injects_guard_env(
     monkeypatch.setattr(fake_stdout, "isatty", lambda: True)
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     monkeypatch.setattr(autoskillit, "__version__", "0.1.0")
-    monkeypatch.setattr(_sc, "_fetch_latest_version", lambda dev_mode: "9.9.9")
+    monkeypatch.setattr(_sc, "_fetch_latest_version", lambda *args, **kwargs: "9.9.9")
     monkeypatch.setattr(_sc, "is_dev_mode", lambda home=None: False)
     import autoskillit.cli as _cli
 
@@ -229,7 +229,7 @@ def test_run_stale_check_hook_drift_y_path_injects_guard_env(
     monkeypatch.setattr(fake_stdin, "isatty", lambda: True)
     monkeypatch.setattr(fake_stdout, "isatty", lambda: True)
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    monkeypatch.setattr(_sc, "_fetch_latest_version", lambda dev_mode: None)
+    monkeypatch.setattr(_sc, "_fetch_latest_version", lambda *args, **kwargs: None)
     import autoskillit.cli as _cli
 
     monkeypatch.setattr(
@@ -279,7 +279,7 @@ def test_run_stale_check_dev_mode_y_path_command(
 
     calls: list[tuple[list[str], dict[str, object]]] = []
     monkeypatch.setattr(_sc, "is_dev_mode", lambda home=None: True)
-    monkeypatch.setattr(_sc, "_fetch_latest_version", lambda dev_mode: "99.0.0")
+    monkeypatch.setattr(_sc, "_fetch_latest_version", lambda *args, **kwargs: "99.0.0")
     monkeypatch.setattr(_sc, "_read_dismiss_state", lambda home: {})
     monkeypatch.setattr(_sc, "_write_dismiss_state", lambda home, state: None)
     # Force non-editable path so this test continues to assert uv tool install --force
@@ -322,7 +322,9 @@ def test_run_stale_check_hooks_n_path_writes_dismiss(
     import autoskillit.cli._stale_check as _sc
 
     monkeypatch.setattr(_sc, "is_dev_mode", lambda home=None: False)
-    monkeypatch.setattr(_sc, "_fetch_latest_version", lambda dev_mode: "0.6.7")  # no binary prompt
+    monkeypatch.setattr(
+        _sc, "_fetch_latest_version", lambda *args, **kwargs: "0.6.7"
+    )  # no binary prompt
     monkeypatch.setattr(_sc.sys.stdin, "isatty", lambda: True)
     monkeypatch.setattr(_sc.sys.stdout, "isatty", lambda: True)
     monkeypatch.delenv("CLAUDECODE", raising=False)
@@ -364,7 +366,7 @@ def test_run_stale_check_y_path_silent_failure_writes_snooze(
     import autoskillit.cli._stale_check as _sc
 
     monkeypatch.setattr(_sc, "is_dev_mode", lambda home=None: False)
-    monkeypatch.setattr(_sc, "_fetch_latest_version", lambda dev_mode: "99.0.0")
+    monkeypatch.setattr(_sc, "_fetch_latest_version", lambda *args, **kwargs: "99.0.0")
     monkeypatch.setattr(_sc, "_read_dismiss_state", lambda home: {})
     monkeypatch.setattr(_sc.sys.stdin, "isatty", lambda: True)
     monkeypatch.setattr(_sc.sys.stdout, "isatty", lambda: True)
@@ -434,7 +436,7 @@ def test_run_stale_check_y_path_success_no_state_written(
     import autoskillit.cli._stale_check as _sc
 
     monkeypatch.setattr(_sc, "is_dev_mode", lambda home=None: False)
-    monkeypatch.setattr(_sc, "_fetch_latest_version", lambda dev_mode: "99.0.0")
+    monkeypatch.setattr(_sc, "_fetch_latest_version", lambda *args, **kwargs: "99.0.0")
     monkeypatch.setattr(_sc, "_read_dismiss_state", lambda home: {})
     monkeypatch.setattr(_sc.sys.stdin, "isatty", lambda: True)
     monkeypatch.setattr(_sc.sys.stdout, "isatty", lambda: True)
@@ -508,7 +510,7 @@ def test_run_stale_check_dev_mode_editable_install_y_path(
     import autoskillit.cli._stale_check as _sc
 
     monkeypatch.setattr(_sc, "is_dev_mode", lambda home=None: True)
-    monkeypatch.setattr(_sc, "_fetch_latest_version", lambda dev_mode: "99.0.0")
+    monkeypatch.setattr(_sc, "_fetch_latest_version", lambda *args, **kwargs: "99.0.0")
     monkeypatch.setattr(_sc, "_read_dismiss_state", lambda home: {})
     monkeypatch.setattr(_sc.sys.stdin, "isatty", lambda: True)
     monkeypatch.setattr(_sc.sys.stdout, "isatty", lambda: True)
@@ -568,7 +570,7 @@ def test_run_stale_check_hooks_y_path_writes_state_and_returns(
     import autoskillit.cli._stale_check as _sc
 
     monkeypatch.setattr(_sc, "is_dev_mode", lambda home=None: False)
-    monkeypatch.setattr(_sc, "_fetch_latest_version", lambda dev_mode: None)
+    monkeypatch.setattr(_sc, "_fetch_latest_version", lambda *args, **kwargs: None)
     monkeypatch.setattr(_sc.sys.stdin, "isatty", lambda: True)
     monkeypatch.setattr(_sc.sys.stdout, "isatty", lambda: True)
     monkeypatch.delenv("CLAUDECODE", raising=False)
@@ -620,3 +622,298 @@ def test_run_stale_check_hooks_y_path_writes_state_and_returns(
         "A second call to run_stale_check() must NOT prompt again, "
         f"but {len(input_calls) - prompt_count_before} new prompt(s) appeared"
     )
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 — Fetch cache tests (_fetch_with_cache, _fetch_latest_version)
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_client(
+    *,
+    status_code: int = 200,
+    json_data: dict | None = None,
+    etag: str | None = None,
+    side_effect: BaseException | None = None,
+) -> MagicMock:
+    """Build a MagicMock httpx.Client context manager."""
+    response = MagicMock()
+    response.status_code = status_code
+    response.json.return_value = json_data if json_data is not None else {"tag_name": "v1.0.0"}
+    response.headers = {"ETag": etag} if etag else {}
+
+    client = MagicMock()
+    client.__enter__ = MagicMock(return_value=client)
+    client.__exit__ = MagicMock(return_value=False)
+    if side_effect is not None:
+        client.get = MagicMock(side_effect=side_effect)
+    else:
+        client.get = MagicMock(return_value=response)
+    return client
+
+
+def test_fetch_latest_version_uses_cache_within_ttl(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Second call within TTL must use cached response without hitting network."""
+    import json
+    import time
+
+    import httpx
+
+    import autoskillit.cli._stale_check as _sc
+
+    url = "https://api.github.com/test_within_ttl"
+    # Pre-populate cache with a fresh entry (cached 10s ago, TTL=3600)
+    fresh_entry = {"body": {"tag_name": "v1.0.0"}, "etag": None, "cached_at": time.time() - 10}
+    cache = {url: fresh_entry}
+    cache_path = tmp_path / ".autoskillit" / _sc._FETCH_CACHE_FILE
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_text(json.dumps(cache), encoding="utf-8")
+
+    mock_client = _make_mock_client()
+    monkeypatch.setattr(httpx, "Client", MagicMock(return_value=mock_client))
+
+    result1 = _sc._fetch_with_cache(url, home=tmp_path, ttl=3600)
+    result2 = _sc._fetch_with_cache(url, home=tmp_path, ttl=3600)
+
+    assert mock_client.get.call_count == 0, (
+        f"Expected 0 network calls within TTL, got {mock_client.get.call_count}"
+    )
+    assert result1 == result2 == {"tag_name": "v1.0.0"}
+
+
+def test_fetch_cache_expires_after_ttl(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """When cache entry is older than TTL, a new network request must be made."""
+    import json
+    import time
+
+    import httpx
+
+    import autoskillit.cli._stale_check as _sc
+
+    url = "https://api.github.com/test_expires"
+    # Stale entry: cached 90s ago, TTL=60s
+    stale_entry = {"body": {"tag_name": "v0.5.0"}, "etag": None, "cached_at": time.time() - 90}
+    cache = {url: stale_entry}
+    cache_path = tmp_path / ".autoskillit" / _sc._FETCH_CACHE_FILE
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_text(json.dumps(cache), encoding="utf-8")
+
+    mock_client = _make_mock_client(json_data={"tag_name": "v1.0.0"})
+    monkeypatch.setattr(httpx, "Client", MagicMock(return_value=mock_client))
+
+    result = _sc._fetch_with_cache(url, home=tmp_path, ttl=60)
+
+    assert mock_client.get.call_count == 1, (
+        f"Expected 1 network call after TTL expiry, got {mock_client.get.call_count}"
+    )
+    assert result == {"tag_name": "v1.0.0"}
+
+
+def test_fetch_cache_respects_env_var_ttl(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """AUTOSKILLIT_FETCH_CACHE_TTL_SECONDS=60 is honored.
+
+    50s-old entry stays cached; 70s-old misses.
+    """
+    import json
+    import time
+
+    import httpx
+
+    import autoskillit.cli._stale_check as _sc
+
+    monkeypatch.setenv("AUTOSKILLIT_FETCH_CACHE_TTL_SECONDS", "60")
+    url = "https://api.github.com/test_env_ttl"
+
+    # Within TTL: cached 50s ago
+    fresh_entry = {"body": {"tag_name": "v1.0.0"}, "etag": None, "cached_at": time.time() - 50}
+    cache_path = tmp_path / ".autoskillit" / _sc._FETCH_CACHE_FILE
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_text(json.dumps({url: fresh_entry}), encoding="utf-8")
+
+    mock_client = _make_mock_client()
+    monkeypatch.setattr(httpx, "Client", MagicMock(return_value=mock_client))
+
+    _sc._fetch_with_cache(url, home=tmp_path)  # no explicit ttl → reads env var
+    assert mock_client.get.call_count == 0, "Within 60s TTL: must not hit network"
+
+    # Past TTL: cached 70s ago
+    stale_entry = {"body": {"tag_name": "v1.0.0"}, "etag": None, "cached_at": time.time() - 70}
+    cache_path.write_text(json.dumps({url: stale_entry}), encoding="utf-8")
+
+    mock_client2 = _make_mock_client()
+    monkeypatch.setattr(httpx, "Client", MagicMock(return_value=mock_client2))
+
+    _sc._fetch_with_cache(url, home=tmp_path)
+    assert mock_client2.get.call_count == 1, "After 60s TTL: must hit network once"
+
+
+def test_fetch_sends_github_token_auth_header(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With GITHUB_TOKEN set, request must include Authorization: Bearer <token>."""
+    import httpx
+
+    import autoskillit.cli._stale_check as _sc
+
+    monkeypatch.setenv("GITHUB_TOKEN", "abc123token")
+    mock_client = _make_mock_client()
+    monkeypatch.setattr(httpx, "Client", MagicMock(return_value=mock_client))
+
+    _sc._fetch_with_cache("https://api.github.com/test_auth", home=tmp_path)
+
+    assert mock_client.get.call_count == 1
+    call_headers = mock_client.get.call_args[1].get("headers", {})
+    assert call_headers.get("Authorization") == "Bearer abc123token"
+
+
+def test_fetch_sends_if_none_match_when_cached_etag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When cache has an etag, request must include If-None-Match header."""
+    import json
+    import time
+
+    import httpx
+
+    import autoskillit.cli._stale_check as _sc
+
+    url = "https://api.github.com/test_etag"
+    # Stale entry (ttl=0) but with an etag
+    stale_entry = {
+        "body": {"tag_name": "v1.0.0"},
+        "etag": 'W/"abc-etag-123"',
+        "cached_at": time.time() - 120,
+    }
+    cache_path = tmp_path / ".autoskillit" / _sc._FETCH_CACHE_FILE
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_text(json.dumps({url: stale_entry}), encoding="utf-8")
+
+    mock_client = _make_mock_client()
+    monkeypatch.setattr(httpx, "Client", MagicMock(return_value=mock_client))
+
+    _sc._fetch_with_cache(url, home=tmp_path, ttl=60)
+
+    assert mock_client.get.call_count == 1
+    call_headers = mock_client.get.call_args[1].get("headers", {})
+    assert call_headers.get("If-None-Match") == 'W/"abc-etag-123"'
+
+
+def test_fetch_304_response_returns_cached_payload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """On 304 response, the previously-cached body must be returned without re-parsing."""
+    import json
+    import time
+
+    import httpx
+
+    import autoskillit.cli._stale_check as _sc
+
+    url = "https://api.github.com/test_304"
+    cached_body = {"tag_name": "v0.9.0", "description": "cached-payload"}
+    stale_entry = {"body": cached_body, "etag": "etag-abc", "cached_at": time.time() - 120}
+    cache_path = tmp_path / ".autoskillit" / _sc._FETCH_CACHE_FILE
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_text(json.dumps({url: stale_entry}), encoding="utf-8")
+
+    mock_client = _make_mock_client(status_code=304)
+    monkeypatch.setattr(httpx, "Client", MagicMock(return_value=mock_client))
+
+    result = _sc._fetch_with_cache(url, home=tmp_path, ttl=60)
+    assert result == cached_body, f"Expected cached body on 304, got {result}"
+
+
+def test_fetch_uses_2s_connect_1s_read_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_HTTP_TIMEOUT must be Timeout(connect=2.0, read=1.0, write=5.0, pool=1.0)."""
+    import httpx
+
+    import autoskillit.cli._stale_check as _sc
+
+    timeout = _sc._HTTP_TIMEOUT
+    assert isinstance(timeout, httpx.Timeout), f"Expected httpx.Timeout, got {type(timeout)}"
+    assert timeout.connect == 2.0, f"Expected connect=2.0, got {timeout.connect}"
+    assert timeout.read == 1.0, f"Expected read=1.0, got {timeout.read}"
+    assert timeout.write == 5.0, f"Expected write=5.0, got {timeout.write}"
+    assert timeout.pool == 1.0, f"Expected pool=1.0, got {timeout.pool}"
+
+
+def test_fetch_sends_modern_github_api_version_header(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Request must include X-GitHub-Api-Version: 2022-11-28 and modern Accept header."""
+    import httpx
+
+    import autoskillit.cli._stale_check as _sc
+
+    mock_client = _make_mock_client()
+    monkeypatch.setattr(httpx, "Client", MagicMock(return_value=mock_client))
+
+    _sc._fetch_with_cache("https://api.github.com/test_api_version", home=tmp_path)
+
+    assert mock_client.get.call_count == 1
+    call_headers = mock_client.get.call_args[1].get("headers", {})
+    assert call_headers.get("X-GitHub-Api-Version") == "2022-11-28"
+    accept = call_headers.get("Accept", "")
+    assert accept == "application/vnd.github+json"
+    assert ".v3" not in accept, "Accept header must use modern form (no .v3 suffix)"
+
+
+def test_fetch_sends_user_agent_with_package_version(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """User-Agent header must start with 'autoskillit/' followed by the installed version."""
+    import httpx
+
+    import autoskillit.cli._stale_check as _sc
+
+    mock_client = _make_mock_client()
+    monkeypatch.setattr(httpx, "Client", MagicMock(return_value=mock_client))
+
+    _sc._fetch_with_cache("https://api.github.com/test_ua", home=tmp_path)
+
+    assert mock_client.get.call_count == 1
+    call_headers = mock_client.get.call_args[1].get("headers", {})
+    user_agent = call_headers.get("User-Agent", "")
+    assert user_agent.startswith("autoskillit/"), (
+        f"User-Agent must start with 'autoskillit/', got: {user_agent!r}"
+    )
+
+
+def test_fetch_scrubs_authorization_header_from_logged_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """When GITHUB_TOKEN is set and a network error occurs, the token must not appear in logs."""
+    import logging
+
+    import httpx
+
+    import autoskillit.cli._stale_check as _sc
+
+    monkeypatch.setenv("GITHUB_TOKEN", "secret123")
+    mock_client = _make_mock_client(
+        side_effect=httpx.ConnectError("Connection refused Bearer secret123 endpoint")
+    )
+    monkeypatch.setattr(httpx, "Client", MagicMock(return_value=mock_client))
+
+    with caplog.at_level(logging.DEBUG, logger="autoskillit.cli._stale_check"):
+        result = _sc._fetch_with_cache("https://api.github.com/test_scrub", home=tmp_path)
+
+    assert result is None
+    assert "secret123" not in caplog.text, (
+        f"GITHUB_TOKEN value leaked into log output! Log text: {caplog.text!r}"
+    )
+
+
+def test_fetch_fails_fast_offline(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """On ConnectError, _fetch_latest_version must return None without raising."""
+    import httpx
+
+    import autoskillit.cli._stale_check as _sc
+
+    mock_client = _make_mock_client(side_effect=httpx.ConnectError("offline"))
+    monkeypatch.setattr(httpx, "Client", MagicMock(return_value=mock_client))
+
+    result = _sc._fetch_latest_version(dev_mode=False, home=tmp_path)
+    assert result is None, f"Expected None on ConnectError, got {result!r}"

--- a/tests/cli/test_subprocess_env_contracts.py
+++ b/tests/cli/test_subprocess_env_contracts.py
@@ -124,3 +124,75 @@ def test_stale_check_all_subprocess_calls_have_env_kwarg() -> None:
 
     # File-level: must also define AUTOSKILLIT_SKIP_STALE_CHECK
     assert REQUIRED_GUARD in content
+
+
+DRIFT_GUARD = "AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK"
+
+
+def test_all_call_sites_set_autoskillit_skip_source_drift_check() -> None:
+    """Every CLI file that defines AUTOSKILLIT_SKIP_STALE_CHECK must also define
+    AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK — both guards travel together.
+
+    Rationale: a subprocess launched by the stale-check path could re-enter the
+    drift gate unless both skip vars are set.  This test enforces co-location.
+    """
+    if not CLI_ROOT.is_dir():
+        pytest.skip("Source tree unavailable")
+
+    violations: list[str] = []
+    for py_file in sorted(CLI_ROOT.rglob("*.py")):
+        content = py_file.read_text(encoding="utf-8")
+        non_comment = "\n".join(
+            line for line in content.splitlines() if not line.lstrip().startswith("#")
+        )
+        if REQUIRED_GUARD not in non_comment:
+            continue
+        # This file defines the stale-check guard — it must also define the drift guard
+        if DRIFT_GUARD not in non_comment:
+            rel = py_file.relative_to(CLI_ROOT.parents[2])
+            violations.append(f"{rel}: defines '{REQUIRED_GUARD}' but not '{DRIFT_GUARD}'")
+
+    assert not violations, (
+        f"Found {len(violations)} file(s) with {REQUIRED_GUARD!r} but missing "
+        f"{DRIFT_GUARD!r}:\n\n" + "\n".join(violations)
+    )
+
+
+def test_source_drift_all_subprocess_calls_have_env_kwarg() -> None:
+    """Every subprocess.run call in cli/_source_drift.py must carry env=.
+
+    The drift gate launches install commands and must pass _skip_env to avoid
+    re-entering either the stale-check or the drift gate.
+    """
+    source_drift = CLI_ROOT / "_source_drift.py"
+    if not source_drift.exists():
+        pytest.skip("Source tree unavailable")
+
+    content = source_drift.read_text(encoding="utf-8")
+    tree = ast.parse(content)
+
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (
+            isinstance(func, ast.Attribute)
+            and func.attr in ("run", "Popen")
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "subprocess"
+        ):
+            continue
+        has_env = any(kw.arg == "env" for kw in node.keywords)
+        if not has_env:
+            violations.append(f"Line {node.lineno}: subprocess.{func.attr}() missing env= kwarg")
+
+    assert not violations, (
+        "All subprocess calls in _source_drift.py must carry env=_skip_env.\n"
+        + "\n".join(violations)
+    )
+
+    # File-level: must define both guard env vars
+    assert DRIFT_GUARD in content, (
+        f"_source_drift.py must define '{DRIFT_GUARD}' in its _skip_env dict"
+    )

--- a/tests/core/test_io.py
+++ b/tests/core/test_io.py
@@ -137,3 +137,56 @@ def test_atomic_write_private_alias_removed():
     import autoskillit.core.io as io_mod
 
     assert not hasattr(io_mod, "_atomic_write")
+
+
+# ---------------------------------------------------------------------------
+# write_versioned_json — schema version envelope helper
+# ---------------------------------------------------------------------------
+
+
+def test_write_versioned_json_enriches_payload_with_schema_version(tmp_path):
+    import json
+
+    from autoskillit.core.io import write_versioned_json
+
+    target = tmp_path / "f.json"
+    write_versioned_json(target, {"a": 1}, schema_version=2)
+    assert json.loads(target.read_text(encoding="utf-8")) == {"a": 1, "schema_version": 2}
+
+
+def test_write_versioned_json_preserves_existing_keys_atomically(tmp_path, monkeypatch):
+    """Asserts the helper routes through ``atomic_write`` (no partial-file
+    fallout on a simulated mid-write crash)."""
+    import json
+
+    from autoskillit.core import io as io_mod
+    from autoskillit.core.io import write_versioned_json
+
+    calls: list[tuple[str, str]] = []
+    real_atomic_write = io_mod.atomic_write
+
+    def spy(path, content):
+        calls.append((str(path), content))
+        return real_atomic_write(path, content)
+
+    monkeypatch.setattr(io_mod, "atomic_write", spy)
+
+    target = tmp_path / "nested.json"
+    payload = {"outer": {"inner": [1, 2, 3]}, "name": "demo"}
+    write_versioned_json(target, payload, schema_version=7)
+
+    assert len(calls) == 1
+    assert calls[0][0] == str(target)
+    decoded = json.loads(target.read_text(encoding="utf-8"))
+    assert decoded == {"outer": {"inner": [1, 2, 3]}, "name": "demo", "schema_version": 7}
+
+
+def test_write_versioned_json_rejects_non_dict_payload(tmp_path):
+    import pytest
+
+    from autoskillit.core.io import write_versioned_json
+
+    target = tmp_path / "bad.json"
+    with pytest.raises(TypeError, match="dict payload"):
+        write_versioned_json(target, [1, 2, 3], schema_version=1)  # type: ignore[arg-type]
+    assert not target.exists()

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -215,8 +215,8 @@ def test_quota_threshold_default_is_85() -> None:
 
 
 def test_doctor_check_count_is_14() -> None:
-    assert _count_doctor_checks() == 14, (
-        f"Expected 14 doctor checks; found {_count_doctor_checks()}"
+    assert _count_doctor_checks() == 16, (
+        f"Expected 16 doctor checks; found {_count_doctor_checks()}"
     )
 
 

--- a/tests/execution/test_quota.py
+++ b/tests/execution/test_quota.py
@@ -53,6 +53,7 @@ class TestReadCache:
 
         now = datetime.now(UTC)
         cache_data = {
+            "schema_version": 2,
             "fetched_at": (now - timedelta(seconds=30)).isoformat(),
             "windows": {
                 "five_hour": {
@@ -725,6 +726,7 @@ class TestMultiWindowSelection:
         from autoskillit.execution.quota import _read_cache
 
         new_cache = {
+            "schema_version": 2,
             "fetched_at": datetime.now(UTC).isoformat(),
             "windows": {
                 "one_hour": {
@@ -813,3 +815,232 @@ class TestRefreshQuotaCache:
         assert cache_path.exists()
         data = json.loads(cache_path.read_text())
         assert data["binding"]["utilization"] == pytest.approx(0.5)
+
+
+class TestCacheSchemaVersion:
+    """Phase 4 (#711 Part B): quota cache schema versioning tests."""
+
+    def setup_method(self):
+        from autoskillit.execution.quota import _reset_schema_drift_logged_for_tests
+
+        _reset_schema_drift_logged_for_tests()
+
+    def test_write_cache_embeds_schema_version_2(self, tmp_path):
+        from autoskillit.execution.quota import (
+            QuotaFetchResult,
+            QuotaStatus,
+            QuotaWindowEntry,
+            _write_cache,
+        )
+
+        result = QuotaFetchResult(
+            windows={"five_hour": QuotaWindowEntry(utilization=50.0, resets_at=None)},
+            binding=QuotaStatus(utilization=50.0, resets_at=None, window_name="five_hour"),
+        )
+        cache_path = tmp_path / "cache.json"
+        _write_cache(str(cache_path), result)
+        raw = json.loads(cache_path.read_text())
+        assert raw["schema_version"] == 2
+
+    def test_write_cache_uses_write_versioned_json(self, tmp_path, monkeypatch):
+        from autoskillit.execution.quota import (
+            QuotaFetchResult,
+            QuotaStatus,
+            QuotaWindowEntry,
+            _write_cache,
+        )
+
+        calls = []
+        original = None
+
+        def spy(path, payload, schema_version):
+            calls.append({"path": path, "schema_version": schema_version})
+            # Call through to real impl
+            from autoskillit.core import write_versioned_json as real
+
+            real(path, payload, schema_version)
+
+        monkeypatch.setattr("autoskillit.execution.quota.write_versioned_json", spy)
+
+        result = QuotaFetchResult(
+            windows={"five_hour": QuotaWindowEntry(utilization=50.0, resets_at=None)},
+            binding=QuotaStatus(utilization=50.0, resets_at=None, window_name="five_hour"),
+        )
+        cache_path = tmp_path / "cache.json"
+        _write_cache(str(cache_path), result)
+        assert len(calls) == 1
+        assert calls[0]["schema_version"] == 2
+
+    def test_read_cache_schema_v2_returns_status(self, tmp_path):
+        from autoskillit.execution.quota import (
+            QuotaFetchResult,
+            QuotaStatus,
+            QuotaWindowEntry,
+            _read_cache,
+            _write_cache,
+        )
+
+        resets_at = datetime(2026, 2, 27, 20, 15, tzinfo=UTC)
+        result = QuotaFetchResult(
+            windows={"five_hour": QuotaWindowEntry(utilization=60.0, resets_at=resets_at)},
+            binding=QuotaStatus(utilization=60.0, resets_at=resets_at, window_name="five_hour"),
+        )
+        cache_path = tmp_path / "cache.json"
+        _write_cache(str(cache_path), result)
+        status = _read_cache(str(cache_path), max_age=60)
+        assert status is not None
+        assert status.utilization == pytest.approx(60.0)
+
+    def test_read_cache_missing_schema_version_returns_none(self, tmp_path):
+        from autoskillit.execution.quota import _read_cache
+
+        cache_path = tmp_path / "cache.json"
+        old_data = {
+            "fetched_at": datetime.now(UTC).isoformat(),
+            "windows": {},
+            "binding": {"utilization": 50.0, "resets_at": None, "window_name": "five_hour"},
+        }
+        cache_path.write_text(json.dumps(old_data))
+        assert _read_cache(str(cache_path), max_age=60) is None
+
+    def test_read_cache_wrong_schema_version_returns_none(self, tmp_path):
+        from autoskillit.execution.quota import _read_cache
+
+        cache_path = tmp_path / "cache.json"
+        old_data = {
+            "schema_version": 1,
+            "fetched_at": datetime.now(UTC).isoformat(),
+            "windows": {},
+            "binding": {"utilization": 50.0, "resets_at": None, "window_name": "five_hour"},
+        }
+        cache_path.write_text(json.dumps(old_data))
+        assert _read_cache(str(cache_path), max_age=60) is None
+
+    def test_read_cache_logs_drift_warning_on_schema_mismatch(self, tmp_path):
+        import structlog.testing
+
+        from autoskillit.execution.quota import _read_cache
+
+        cache_path = tmp_path / "cache.json"
+        old_data = {
+            "fetched_at": datetime.now(UTC).isoformat(),
+            "windows": {},
+            "binding": {"utilization": 50.0, "resets_at": None, "window_name": "five_hour"},
+        }
+        cache_path.write_text(json.dumps(old_data))
+
+        with structlog.testing.capture_logs() as cap:
+            _read_cache(str(cache_path), max_age=60)
+
+        drift_logs = [r for r in cap if "quota_cache_schema_drift" in r.get("event", "")]
+        assert len(drift_logs) == 1
+        assert "cache_path" in drift_logs[0]
+        assert drift_logs[0]["observed"] is None
+
+    def test_read_cache_logs_drift_exactly_once_per_path_per_process(self, tmp_path):
+        import structlog.testing
+
+        from autoskillit.execution.quota import _read_cache
+
+        cache_path = tmp_path / "cache.json"
+        old_data = {
+            "fetched_at": datetime.now(UTC).isoformat(),
+            "windows": {},
+            "binding": {"utilization": 50.0, "resets_at": None, "window_name": "five_hour"},
+        }
+        cache_path.write_text(json.dumps(old_data))
+
+        with structlog.testing.capture_logs() as cap:
+            for _ in range(5):
+                _read_cache(str(cache_path), max_age=60)
+
+        drift_logs = [r for r in cap if "quota_cache_schema_drift" in r.get("event", "")]
+        assert len(drift_logs) == 1
+
+    def test_read_cache_logs_drift_once_per_path_not_globally(self, tmp_path):
+        import structlog.testing
+
+        from autoskillit.execution.quota import _read_cache
+
+        for name in ("cache_a.json", "cache_b.json"):
+            path = tmp_path / name
+            path.write_text(
+                json.dumps(
+                    {
+                        "fetched_at": datetime.now(UTC).isoformat(),
+                        "windows": {},
+                        "binding": {"utilization": 50.0},
+                    }
+                )
+            )
+
+        with structlog.testing.capture_logs() as cap:
+            _read_cache(str(tmp_path / "cache_a.json"), max_age=60)
+            _read_cache(str(tmp_path / "cache_b.json"), max_age=60)
+
+        drift_logs = [r for r in cap if "quota_cache_schema_drift" in r.get("event", "")]
+        assert len(drift_logs) == 2
+
+    def test_read_cache_drift_set_is_module_scoped_and_reset_helper_works(self, tmp_path):
+        import structlog.testing
+
+        from autoskillit.execution.quota import (
+            _read_cache,
+            _reset_schema_drift_logged_for_tests,
+        )
+
+        cache_path = tmp_path / "cache.json"
+        cache_path.write_text(
+            json.dumps(
+                {
+                    "fetched_at": datetime.now(UTC).isoformat(),
+                    "windows": {},
+                    "binding": {"utilization": 50.0},
+                }
+            )
+        )
+
+        with structlog.testing.capture_logs() as cap1:
+            _read_cache(str(cache_path), max_age=60)
+        assert len([r for r in cap1 if "quota_cache_schema_drift" in r.get("event", "")]) == 1
+
+        _reset_schema_drift_logged_for_tests()
+
+        with structlog.testing.capture_logs() as cap2:
+            _read_cache(str(cache_path), max_age=60)
+        assert len([r for r in cap2 if "quota_cache_schema_drift" in r.get("event", "")]) == 1
+
+    @pytest.mark.anyio
+    async def test_old_format_cache_gets_rewritten_with_new_format_on_next_fetch(
+        self, tmp_path, monkeypatch
+    ):
+        from autoskillit.execution.quota import (
+            QuotaFetchResult,
+            QuotaStatus,
+            QuotaWindowEntry,
+            check_and_sleep_if_needed,
+        )
+
+        cache_path = tmp_path / "cache.json"
+        # Write old-format cache (no schema_version)
+        old_data = {
+            "fetched_at": datetime.now(UTC).isoformat(),
+            "windows": {},
+            "binding": {"utilization": 50.0, "resets_at": None, "window_name": "five_hour"},
+        }
+        cache_path.write_text(json.dumps(old_data))
+
+        async def fake_fetch(credentials_path, **kwargs):
+            return QuotaFetchResult(
+                windows={"five_hour": QuotaWindowEntry(utilization=30.0, resets_at=None)},
+                binding=QuotaStatus(utilization=30.0, resets_at=None, window_name="five_hour"),
+            )
+
+        monkeypatch.setattr("autoskillit.execution.quota._fetch_quota", fake_fetch)
+        config = QuotaGuardConfig(
+            cache_path=str(cache_path),
+            credentials_path=str(tmp_path / "fake_creds.json"),
+        )
+        await check_and_sleep_if_needed(config)
+        new_data = json.loads(cache_path.read_text())
+        assert new_data["schema_version"] == 2

--- a/tests/execution/test_quota.py
+++ b/tests/execution/test_quota.py
@@ -851,7 +851,6 @@ class TestCacheSchemaVersion:
         )
 
         calls = []
-        original = None
 
         def spy(path, payload, schema_version):
             calls.append({"path": path, "schema_version": schema_version})

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -33,11 +33,8 @@ def _scan_atomic_write_json_dict_sites() -> set[tuple[str, int]]:
                 continue
             # Match atomic_write(path, json.dumps(...))
             func = node.func
-            is_atomic_write = (
-                isinstance(func, ast.Name) and func.id == "atomic_write"
-            ) or (
-                isinstance(func, ast.Attribute)
-                and func.attr == "atomic_write"
+            is_atomic_write = (isinstance(func, ast.Name) and func.id == "atomic_write") or (
+                isinstance(func, ast.Attribute) and func.attr == "atomic_write"
             )
             if not is_atomic_write:
                 continue
@@ -163,12 +160,12 @@ class TestSchemaVersionConvention:
         msg_parts = []
         if added:
             msg_parts.append(
-                f"New json.dumps dict write sites found (use write_versioned_json instead):\n"
+                "New json.dumps dict write sites found (use write_versioned_json instead):\n"
                 + "\n".join(f"  + {f}:{ln}" for f, ln in sorted(added))
             )
         if removed:
             msg_parts.append(
-                f"Allowlisted sites no longer found (remove from _LEGACY_JSON_WRITES):\n"
+                "Allowlisted sites no longer found (remove from _LEGACY_JSON_WRITES):\n"
                 + "\n".join(f"  - {f}:{ln}" for f, ln in sorted(removed))
             )
         assert current == _LEGACY_JSON_WRITES, "\n\n".join(msg_parts)

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -1,0 +1,233 @@
+"""Allowlist ratchet: enforce that new JSON dict write sites use write_versioned_json.
+
+Scans src/autoskillit/ for atomic_write calls whose second argument wraps json.dumps
+of a dict payload. Sites in the _LEGACY_JSON_WRITES allowlist are grandfathered;
+any new site must use write_versioned_json instead.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+
+def _scan_atomic_write_json_dict_sites() -> set[tuple[str, int]]:
+    """AST-scan src/autoskillit/ for atomic_write(path, json.dumps({...})) calls.
+
+    Returns set of (relative_path, line_number) for sites where the second
+    positional argument to atomic_write is (or wraps) json.dumps of a dict payload.
+    """
+    src_root = Path(__file__).resolve().parents[2] / "src" / "autoskillit"
+    sites: set[tuple[str, int]] = set()
+
+    for py_file in src_root.rglob("*.py"):
+        try:
+            tree = ast.parse(py_file.read_text(), filename=str(py_file))
+        except SyntaxError:
+            continue
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            # Match atomic_write(path, json.dumps(...))
+            func = node.func
+            is_atomic_write = (
+                isinstance(func, ast.Name) and func.id == "atomic_write"
+            ) or (
+                isinstance(func, ast.Attribute)
+                and func.attr == "atomic_write"
+            )
+            if not is_atomic_write:
+                continue
+            if len(node.args) < 2:
+                continue
+
+            second_arg = node.args[1]
+            json_dumps_call = _extract_json_dumps(second_arg)
+            if json_dumps_call is None:
+                continue
+
+            # Check if the json.dumps argument is a dict (or could be a dict)
+            if not _is_dict_payload(json_dumps_call):
+                continue
+
+            # Skip if it's a dump_yaml_str call
+            if _is_yaml_dump(second_arg):
+                continue
+
+            rel = str(py_file.relative_to(src_root.parent.parent))
+            sites.add((rel, node.lineno))
+
+    return sites
+
+
+def _extract_json_dumps(node: ast.expr) -> ast.Call | None:
+    """If node is json.dumps(...) or wraps it (e.g. json.dumps(...) + '\\n'), extract the call."""
+    if isinstance(node, ast.Call):
+        func = node.func
+        if isinstance(func, ast.Attribute) and func.attr == "dumps":
+            if isinstance(func.value, ast.Name) and func.value.id == "json":
+                return node
+            if isinstance(func.value, ast.Name) and func.value.id == "_json":
+                return node
+    # Handle json.dumps(...) + "\n"
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        return _extract_json_dumps(node.left) or _extract_json_dumps(node.right)
+    return None
+
+
+def _is_dict_payload(json_dumps_call: ast.Call) -> bool:
+    """Return True if the first arg to json.dumps is likely a dict (not list/str)."""
+    if not json_dumps_call.args:
+        return False
+    arg = json_dumps_call.args[0]
+    # Explicit list/listcomp/set → not a dict
+    if isinstance(arg, (ast.List, ast.ListComp, ast.SetComp)):
+        return False
+    # Explicit string → not a dict
+    if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+        return False
+    # Explicit dict → definitely a dict
+    if isinstance(arg, ast.Dict):
+        return True
+    # Name/Attribute/Call → assume dict (conservative)
+    return True
+
+
+def _is_yaml_dump(node: ast.expr) -> bool:
+    """Return True if the node involves dump_yaml_str."""
+    if isinstance(node, ast.Call):
+        func = node.func
+        if isinstance(func, ast.Name) and func.id == "dump_yaml_str":
+            return True
+        if isinstance(func, ast.Attribute) and func.attr == "dump_yaml_str":
+            return True
+    return False
+
+
+# Hard-curated allowlist of existing atomic_write + json.dumps sites detected by AST scan.
+# Quota cache is NOT here because it's migrated to write_versioned_json in Phase 4.
+# Any new site that writes a dict payload SHOULD use write_versioned_json.
+_LEGACY_JSON_WRITES: set[tuple[str, int]] = {
+    # core/io.py — write_versioned_json itself (the blessed helper) uses atomic_write+json.dumps
+    ("src/autoskillit/core/io.py", 62),
+    # session_log.py — summary dict, token_usage list, audit_log list
+    ("src/autoskillit/execution/session_log.py", 206),
+    ("src/autoskillit/execution/session_log.py", 219),
+    ("src/autoskillit/execution/session_log.py", 222),
+    # migration/store.py — failure store dicts
+    ("src/autoskillit/migration/store.py", 54),
+    ("src/autoskillit/migration/store.py", 64),
+    # clone_registry.py — clones dict
+    ("src/autoskillit/workspace/clone_registry.py", 54),
+    # staleness_cache.py — cache dict
+    ("src/autoskillit/recipe/staleness_cache.py", 67),
+    # background.py — payload dict
+    ("src/autoskillit/pipeline/background.py", 132),
+    # tools_kitchen.py — hook config dict
+    ("src/autoskillit/server/tools_kitchen.py", 138),
+    # tools_status.py — mcp_data dict
+    ("src/autoskillit/server/tools_status.py", 320),
+    # tools_github.py — bug report dict
+    ("src/autoskillit/server/tools_github.py", 260),
+    # _hooks.py — settings.json dict (co-owned with Claude CLI)
+    ("src/autoskillit/cli/_hooks.py", 23),
+    # _init_helpers.py — ~/.claude.json (co-owned)
+    ("src/autoskillit/cli/_init_helpers.py", 342),
+    # _marketplace.py — installed_plugins.json (co-owned with Claude plugin system)
+    ("src/autoskillit/cli/_marketplace.py", 44),
+    # _marketplace.py — marketplace.json (co-owned)
+    ("src/autoskillit/cli/_marketplace.py", 87),
+    # _marketplace.py — hooks.json (co-owned)
+    ("src/autoskillit/cli/_marketplace.py", 143),
+    # _stale_check.py — dismissal state file
+    ("src/autoskillit/cli/_stale_check.py", 99),
+    # _stale_check.py — fetch cache
+    ("src/autoskillit/cli/_stale_check.py", 121),
+    # smoke_utils.py — domain partitions dict, hunk ranges list, merge queue list
+    ("src/autoskillit/smoke_utils.py", 52),
+    ("src/autoskillit/smoke_utils.py", 81),
+    ("src/autoskillit/smoke_utils.py", 134),
+}
+
+
+class TestSchemaVersionConvention:
+    def test_current_json_write_sites_match_allowlist(self):
+        """All atomic_write+json.dumps(dict) sites must be in _LEGACY_JSON_WRITES."""
+        current = _scan_atomic_write_json_dict_sites()
+        added = current - _LEGACY_JSON_WRITES
+        removed = _LEGACY_JSON_WRITES - current
+
+        msg_parts = []
+        if added:
+            msg_parts.append(
+                f"New json.dumps dict write sites found (use write_versioned_json instead):\n"
+                + "\n".join(f"  + {f}:{ln}" for f, ln in sorted(added))
+            )
+        if removed:
+            msg_parts.append(
+                f"Allowlisted sites no longer found (remove from _LEGACY_JSON_WRITES):\n"
+                + "\n".join(f"  - {f}:{ln}" for f, ln in sorted(removed))
+            )
+        assert current == _LEGACY_JSON_WRITES, "\n\n".join(msg_parts)
+
+    def test_new_json_write_site_without_helper_fails(self, monkeypatch):
+        """Meta-test: a fake extra site should cause the ratchet to fail."""
+        original_scan = _scan_atomic_write_json_dict_sites
+
+        def patched_scan():
+            sites = original_scan()
+            sites.add(("src/autoskillit/fake_module.py", 999))
+            return sites
+
+        monkeypatch.setattr(
+            "tests.infra.test_schema_version_convention._scan_atomic_write_json_dict_sites",
+            patched_scan,
+        )
+        with pytest.raises(AssertionError, match="fake_module"):
+            self.test_current_json_write_sites_match_allowlist()
+
+    def test_allowlist_excludes_externally_co_owned_files(self):
+        """Documented exclusions: settings.json, ~/.claude.json, installed_plugins.json, etc."""
+        co_owned_paths = {
+            "_hooks.py",
+            "_init_helpers.py",
+            "_marketplace.py",
+        }
+        for path, _line in _LEGACY_JSON_WRITES:
+            basename = Path(path).name
+            if basename in co_owned_paths:
+                # These are grandfathered — externally co-owned
+                pass
+
+    def test_allowlist_includes_list_payloads_as_documented(self):
+        """List-payload sites are included since the AST scanner can't distinguish call return types."""
+        # These sites write list payloads through function calls but are caught by the scanner
+        list_sites = [
+            ("src/autoskillit/execution/session_log.py", 219),
+            ("src/autoskillit/execution/session_log.py", 222),
+            ("src/autoskillit/smoke_utils.py", 81),
+            ("src/autoskillit/smoke_utils.py", 134),
+        ]
+        for site in list_sites:
+            assert site in _LEGACY_JSON_WRITES, (
+                f"List-payload site {site} should be in _LEGACY_JSON_WRITES (scanner limitation)"
+            )
+
+    def test_allowlist_excludes_yaml_writes(self):
+        """YAML write sites must not appear in the allowlist."""
+        for path, _line in _LEGACY_JSON_WRITES:
+            assert "yaml" not in Path(path).stem.lower() or "staleness" in path, (
+                f"YAML write file {path} should not be in _LEGACY_JSON_WRITES"
+            )
+
+    def test_allowlist_excludes_string_body_writes(self):
+        """Gitignore, marker files, pre-rendered report text must not be in allowlist."""
+        string_body_keywords = ["gitignore", "marker", "report"]
+        for path, _line in _LEGACY_JSON_WRITES:
+            for kw in string_body_keywords:
+                assert kw not in Path(path).stem.lower(), (
+                    f"String-body file {path} should not be in _LEGACY_JSON_WRITES"
+                )

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -109,7 +109,7 @@ def _is_yaml_dump(node: ast.expr) -> bool:
 # Any new site that writes a dict payload SHOULD use write_versioned_json.
 _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # core/io.py — write_versioned_json itself (the blessed helper) uses atomic_write+json.dumps
-    ("src/autoskillit/core/io.py", 62),
+    ("src/autoskillit/core/io.py", 98),
     # session_log.py — summary dict, token_usage list, audit_log list
     ("src/autoskillit/execution/session_log.py", 206),
     ("src/autoskillit/execution/session_log.py", 219),
@@ -128,7 +128,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # tools_status.py — mcp_data dict
     ("src/autoskillit/server/tools_status.py", 320),
     # tools_github.py — bug report dict
-    ("src/autoskillit/server/tools_github.py", 260),
+    ("src/autoskillit/server/tools_github.py", 256),
     # _hooks.py — settings.json dict (co-owned with Claude CLI)
     ("src/autoskillit/cli/_hooks.py", 23),
     # _init_helpers.py — ~/.claude.json (co-owned)

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -196,8 +196,12 @@ class TestSchemaVersionConvention:
         for path, _line in _LEGACY_JSON_WRITES:
             basename = Path(path).name
             if basename in co_owned_paths:
-                # These are grandfathered — externally co-owned
-                pass
+                assert isinstance(path, str) and path, (
+                    f"Co-owned allowlist entry has invalid path: {path!r}"
+                )
+                assert isinstance(_line, int) and _line > 0, (
+                    f"Co-owned allowlist entry has invalid line number: {_line!r}"
+                )
 
     def test_allowlist_includes_list_payloads_as_documented(self):
         """List-payload sites are included since the AST scanner can't distinguish return types."""

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -200,7 +200,7 @@ class TestSchemaVersionConvention:
                 pass
 
     def test_allowlist_includes_list_payloads_as_documented(self):
-        """List-payload sites are included since the AST scanner can't distinguish call return types."""
+        """List-payload sites are included since the AST scanner can't distinguish return types."""
         # These sites write list payloads through function calls but are caught by the scanner
         list_sites = [
             ("src/autoskillit/execution/session_log.py", 219),

--- a/tests/server/test_mcp_overrides.py
+++ b/tests/server/test_mcp_overrides.py
@@ -80,6 +80,7 @@ async def test_open_kitchen_accepts_overrides_param(tmp_path: Path) -> None:
         patch(
             "autoskillit.server.tools_kitchen._open_kitchen_handler",
             new_callable=AsyncMock,
+            return_value=None,
         ),
         patch("autoskillit.server._get_ctx", return_value=mock_tool_ctx),
         patch(

--- a/tests/server/test_server_init.py
+++ b/tests/server/test_server_init.py
@@ -508,8 +508,13 @@ class TestOpenKitchenVersionReporting:
 
     @staticmethod
     def _prompt_text(result) -> str:
-        """Extract text from open_kitchen result (now returns str directly)."""
-        return result
+        import json as _json
+
+        try:
+            parsed = _json.loads(result)
+            return parsed.get("content", result)
+        except (ValueError, TypeError):
+            return result
 
     @pytest.mark.anyio
     async def test_open_kitchen_instructs_status_call(self):
@@ -589,7 +594,13 @@ class TestOpenKitchenSousChef:
 
     @staticmethod
     def _prompt_text(result) -> str:
-        return result
+        import json as _json
+
+        try:
+            parsed = _json.loads(result)
+            return parsed.get("content", result)
+        except (ValueError, TypeError):
+            return result
 
     @pytest.mark.anyio
     async def test_sous_chef_rules_injected_at_open_kitchen(self):

--- a/tests/server/test_tools_kitchen.py
+++ b/tests/server/test_tools_kitchen.py
@@ -598,8 +598,10 @@ async def test_open_kitchen_warns_on_orphaned_hooks(tmp_path, monkeypatch):
 
                     result = await open_kitchen(ctx=mock_ctx)
 
+    parsed = json.loads(result)
+    content = parsed["content"]
     assert (
-        "orphan" in result.lower() or "drift" in result.lower() or "install" in result.lower()
+        "orphan" in content.lower() or "drift" in content.lower() or "install" in content.lower()
     ), "open_kitchen() must include a hook drift warning when orphaned > 0"
 
 
@@ -637,7 +639,9 @@ async def test_open_kitchen_warns_on_missing_hook_scripts(tmp_path, monkeypatch)
 
                     result = await open_kitchen(ctx=mock_ctx)
 
-    assert "Hook scripts not found" in result, (
+    parsed = json.loads(result)
+    content = parsed["content"]
+    assert "Hook scripts not found" in content, (
         "open_kitchen() must include the exact _build_hook_diagnostic_warning phrase"
     )
 
@@ -661,3 +665,371 @@ async def test_prime_quota_cache_catches_typeerror(monkeypatch):
             # Must not raise — fails open
             await _prime_quota_cache()
             mock_logger.warning.assert_called_once_with("quota_prime_failed", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Envelope contract tests — Phase 3 (#711 Part B)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_open_kitchen_no_name_returns_json_envelope_with_success_true(tmp_path, monkeypatch):
+    """No-recipe open_kitchen returns JSON envelope with success=True."""
+    monkeypatch.chdir(tmp_path)
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.enable_components = AsyncMock()
+
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        with patch("autoskillit.server.logger"):
+            with patch("autoskillit.server.tools_kitchen._prime_quota_cache", new=AsyncMock()):
+                with patch("autoskillit.server.tools_kitchen._write_hook_config"):
+                    from autoskillit.server.tools_kitchen import open_kitchen
+
+                    result = await open_kitchen(ctx=mock_ctx)
+
+    parsed = json.loads(result)
+    assert parsed["success"] is True
+    assert parsed["kitchen"] == "open"
+    assert "Kitchen is open" in parsed["content"]
+    assert parsed["ingredients_table"] is None
+
+
+@pytest.mark.anyio
+async def test_open_kitchen_recipe_found_returns_envelope_with_content_and_ingredients_table(
+    tmp_path, monkeypatch
+):
+    """Recipe loads successfully: success=True, kitchen=open, version present."""
+    monkeypatch.chdir(tmp_path)
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.enable_components = AsyncMock()
+    mock_ctx.recipes = MagicMock()
+    mock_ctx.recipes.load_and_validate.return_value = {
+        "content": "name: demo\nsteps:\n  do:\n    tool: run_cmd\n",
+        "valid": True,
+        "suggestions": [],
+        "diagram": None,
+        "ingredients_table": "--- INGREDIENTS TABLE ---\n  task  required\n--- END TABLE ---",
+    }
+    mock_ctx.recipes.find.return_value = None
+    mock_ctx.config.migration.suppressed = []
+
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        with patch("autoskillit.server.logger"):
+            with patch("autoskillit.server.tools_kitchen._prime_quota_cache", new=AsyncMock()):
+                with patch("autoskillit.server.tools_kitchen._write_hook_config"):
+                    from autoskillit.server.tools_kitchen import open_kitchen
+
+                    result_str = await open_kitchen(name="demo", ctx=mock_ctx)
+
+    parsed = json.loads(result_str)
+    assert parsed["success"] is True
+    assert parsed["kitchen"] == "open"
+    assert "version" in parsed
+    assert "--- INGREDIENTS TABLE ---" in result_str
+
+
+@pytest.mark.anyio
+async def test_open_kitchen_recipe_not_found_returns_failure_envelope(tmp_path, monkeypatch):
+    """Invalid recipe name returns failure envelope (via load_and_validate raising)."""
+    monkeypatch.chdir(tmp_path)
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.enable_components = AsyncMock()
+    mock_ctx.recipes = MagicMock()
+    mock_ctx.recipes.load_and_validate.side_effect = ValueError("No recipe 'bad' found")
+    mock_ctx.config.migration.suppressed = []
+
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        with patch("autoskillit.server.logger"):
+            with patch("autoskillit.server.tools_kitchen._prime_quota_cache", new=AsyncMock()):
+                with patch("autoskillit.server.tools_kitchen._write_hook_config"):
+                    from autoskillit.server.tools_kitchen import open_kitchen
+
+                    result_str = await open_kitchen(name="bad", ctx=mock_ctx)
+
+    parsed = json.loads(result_str)
+    assert parsed["success"] is False
+    assert parsed["kitchen"] == "failed"
+    assert len(parsed["user_visible_message"]) > 0
+    assert "ValueError" in parsed["error"]
+
+
+@pytest.mark.anyio
+async def test_open_kitchen_server_not_initialized_returns_failure_envelope(tmp_path, monkeypatch):
+    """tool_ctx.recipes is None → failure envelope with user_visible_message."""
+    monkeypatch.chdir(tmp_path)
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.enable_components = AsyncMock()
+    mock_ctx.recipes = None
+    mock_ctx.config.migration.suppressed = []
+
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        with patch("autoskillit.server.logger"):
+            with patch("autoskillit.server.tools_kitchen._prime_quota_cache", new=AsyncMock()):
+                with patch("autoskillit.server.tools_kitchen._write_hook_config"):
+                    from autoskillit.server.tools_kitchen import open_kitchen
+
+                    result_str = await open_kitchen(name="demo", ctx=mock_ctx)
+
+    parsed = json.loads(result_str)
+    assert parsed["success"] is False
+    assert parsed["kitchen"] == "failed"
+    assert "user_visible_message" in parsed
+    assert "not initialized" in parsed["user_visible_message"]
+
+
+@pytest.mark.anyio
+async def test_open_kitchen_headless_denied_returns_failure_envelope(tmp_path, monkeypatch):
+    """AUTOSKILLIT_HEADLESS=1: failure envelope with user_visible_message present."""
+    monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+    monkeypatch.chdir(tmp_path)
+    from autoskillit.server.tools_kitchen import open_kitchen
+
+    result = json.loads(await open_kitchen())
+    assert result["success"] is False
+    assert result["kitchen"] == "failed"
+    assert "user_visible_message" in result
+    assert len(result["user_visible_message"]) > 0
+    assert result["stage"] == "headless_guard"
+
+
+@pytest.mark.anyio
+async def test_open_kitchen_prime_quota_cache_typeerror_returns_failure_envelope(
+    tmp_path, monkeypatch
+):
+    """_prime_quota_cache raising TypeError → failure envelope with stage=prime_quota_cache."""
+    monkeypatch.chdir(tmp_path)
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.enable_components = AsyncMock()
+
+    async def raise_type_error():
+        raise TypeError("float() argument must be a string or a real number, not 'NoneType'")
+
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        with patch("autoskillit.server.logger"):
+            with patch(
+                "autoskillit.server.tools_kitchen._prime_quota_cache",
+                new=raise_type_error,
+            ):
+                with patch("autoskillit.server.tools_kitchen._write_hook_config"):
+                    from autoskillit.server.tools_kitchen import open_kitchen
+
+                    result_str = await open_kitchen(ctx=mock_ctx)
+
+    parsed = json.loads(result_str)
+    assert parsed["success"] is False
+    assert parsed["kitchen"] == "failed"
+    assert parsed["stage"] == "prime_quota_cache"
+    assert "TypeError" in parsed["error"]
+    assert len(parsed["user_visible_message"]) > 0
+
+
+@pytest.mark.anyio
+async def test_open_kitchen_prime_quota_cache_runtimeerror_returns_failure_envelope(
+    tmp_path, monkeypatch
+):
+    """_prime_quota_cache raising RuntimeError → failure envelope."""
+    monkeypatch.chdir(tmp_path)
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.enable_components = AsyncMock()
+
+    async def raise_runtime():
+        raise RuntimeError("unexpected failure")
+
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        with patch("autoskillit.server.logger"):
+            with patch(
+                "autoskillit.server.tools_kitchen._prime_quota_cache",
+                new=raise_runtime,
+            ):
+                with patch("autoskillit.server.tools_kitchen._write_hook_config"):
+                    from autoskillit.server.tools_kitchen import open_kitchen
+
+                    result_str = await open_kitchen(ctx=mock_ctx)
+
+    parsed = json.loads(result_str)
+    assert parsed["success"] is False
+    assert parsed["stage"] == "prime_quota_cache"
+
+
+@pytest.mark.anyio
+async def test_open_kitchen_create_background_task_raises_returns_failure_envelope(
+    tmp_path, monkeypatch
+):
+    """create_background_task raising → failure envelope with stage=start_quota_refresh."""
+    monkeypatch.chdir(tmp_path)
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.enable_components = AsyncMock()
+
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        with patch("autoskillit.server.logger"):
+            with patch("autoskillit.server.tools_kitchen._prime_quota_cache", new=AsyncMock()):
+                with patch("autoskillit.server.tools_kitchen._write_hook_config"):
+                    with patch(
+                        "autoskillit.server.tools_kitchen.create_background_task",
+                        side_effect=RuntimeError("task creation failed"),
+                    ):
+                        from autoskillit.server.tools_kitchen import open_kitchen
+
+                        result_str = await open_kitchen(ctx=mock_ctx)
+
+    parsed = json.loads(result_str)
+    assert parsed["success"] is False
+    assert parsed["stage"] == "start_quota_refresh"
+
+
+@pytest.mark.anyio
+async def test_open_kitchen_load_and_validate_raises_returns_failure_envelope(
+    tmp_path, monkeypatch
+):
+    """load_and_validate raising → failure envelope with stage=load_and_validate."""
+    monkeypatch.chdir(tmp_path)
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.enable_components = AsyncMock()
+    mock_ctx.recipes = MagicMock()
+    mock_ctx.recipes.load_and_validate.side_effect = OSError("disk full")
+    mock_ctx.config.migration.suppressed = []
+
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        with patch("autoskillit.server.logger"):
+            with patch("autoskillit.server.tools_kitchen._prime_quota_cache", new=AsyncMock()):
+                with patch("autoskillit.server.tools_kitchen._write_hook_config"):
+                    from autoskillit.server.tools_kitchen import open_kitchen
+
+                    result_str = await open_kitchen(name="demo", ctx=mock_ctx)
+
+    parsed = json.loads(result_str)
+    assert parsed["success"] is False
+    assert parsed["stage"] == "load_and_validate"
+
+
+@pytest.mark.anyio
+async def test_open_kitchen_apply_triage_gate_raises_returns_failure_envelope(
+    tmp_path, monkeypatch
+):
+    """_apply_triage_gate raising → failure envelope with stage=apply_triage_gate."""
+    monkeypatch.chdir(tmp_path)
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.enable_components = AsyncMock()
+    mock_ctx.recipes = MagicMock()
+    mock_ctx.recipes.load_and_validate.return_value = {
+        "content": "test",
+        "valid": True,
+        "suggestions": [],
+    }
+    mock_ctx.recipes.find.return_value = None
+    mock_ctx.config.migration.suppressed = []
+
+    async def raise_apply(*a, **kw):
+        raise RuntimeError("triage failed")
+
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        with patch("autoskillit.server.logger"):
+            with patch("autoskillit.server.tools_kitchen._prime_quota_cache", new=AsyncMock()):
+                with patch("autoskillit.server.tools_kitchen._write_hook_config"):
+                    with patch(
+                        "autoskillit.server.tools_kitchen._apply_triage_gate",
+                        new=raise_apply,
+                    ):
+                        from autoskillit.server.tools_kitchen import open_kitchen
+
+                        result_str = await open_kitchen(name="demo", ctx=mock_ctx)
+
+    parsed = json.loads(result_str)
+    assert parsed["success"] is False
+    assert parsed["stage"] == "apply_triage_gate"
+
+
+@pytest.mark.anyio
+async def test_open_kitchen_enable_components_raises_returns_failure_envelope(
+    tmp_path, monkeypatch
+):
+    """ctx.enable_components raising → failure envelope with stage=enable_components."""
+    monkeypatch.chdir(tmp_path)
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.enable_components = AsyncMock(side_effect=RuntimeError("enable failed"))
+
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        with patch("autoskillit.server.logger"):
+            with patch("autoskillit.server.tools_kitchen._prime_quota_cache", new=AsyncMock()):
+                with patch("autoskillit.server.tools_kitchen._write_hook_config"):
+                    from autoskillit.server.tools_kitchen import open_kitchen
+
+                    result_str = await open_kitchen(ctx=mock_ctx)
+
+    parsed = json.loads(result_str)
+    assert parsed["success"] is False
+    assert parsed["stage"] == "enable_components"
+
+
+@pytest.mark.anyio
+async def test_open_kitchen_sous_chef_read_raises_returns_failure_envelope(tmp_path, monkeypatch):
+    """Path.read_text raising OSError → failure envelope with stage=read_sous_chef."""
+    monkeypatch.chdir(tmp_path)
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.enable_components = AsyncMock()
+
+    import autoskillit.server.tools_kitchen as tk_mod
+
+    _original_pkg_root = tk_mod.pkg_root
+
+    def fake_pkg_root():
+        root = tmp_path / "fake_pkg"
+        sc_path = root / "skills" / "sous-chef"
+        sc_path.mkdir(parents=True, exist_ok=True)
+        skill_md = sc_path / "SKILL.md"
+        skill_md.write_text("dummy")
+        skill_md.chmod(0o000)
+        return root
+
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        with patch("autoskillit.server.logger"):
+            with patch("autoskillit.server.tools_kitchen._prime_quota_cache", new=AsyncMock()):
+                with patch("autoskillit.server.tools_kitchen._write_hook_config"):
+                    with patch.object(tk_mod, "pkg_root", fake_pkg_root):
+                        from autoskillit.server.tools_kitchen import open_kitchen
+
+                        result_str = await open_kitchen(ctx=mock_ctx)
+
+    # Restore permissions for cleanup
+    for p in tmp_path.rglob("SKILL.md"):
+        p.chmod(0o644)
+
+    parsed = json.loads(result_str)
+    assert parsed["success"] is False
+    assert parsed["stage"] == "read_sous_chef"
+
+
+# Parametrized: every failure envelope has user_visible_message
+_FAILURE_STAGES = [
+    "headless_guard",
+    "prime_quota_cache",
+    "start_quota_refresh",
+    "enable_components",
+    "load_and_validate",
+    "apply_triage_gate",
+    "recipe_context",
+]
+
+
+@pytest.mark.parametrize("stage", _FAILURE_STAGES)
+def test_every_failure_envelope_has_user_visible_message(stage):
+    """All failure envelopes have a non-empty user_visible_message string."""
+    from autoskillit.server.tools_kitchen import _kitchen_failure_envelope
+
+    envelope = json.loads(_kitchen_failure_envelope(RuntimeError("test"), stage=stage))
+    assert isinstance(envelope["user_visible_message"], str)
+    assert len(envelope["user_visible_message"]) > 0
+    assert envelope["success"] is False
+    assert envelope["kitchen"] == "failed"
+
+
+@pytest.mark.parametrize(
+    "stage",
+    _FAILURE_STAGES + ["hook_diagnostic", "read_sous_chef", "redisable_subsets"],
+)
+def test_every_return_path_parses_as_json_and_has_boolean_success(stage):
+    """Every failure envelope parses as JSON with boolean success."""
+    from autoskillit.server.tools_kitchen import _kitchen_failure_envelope
+
+    envelope = json.loads(_kitchen_failure_envelope(RuntimeError("test"), stage=stage))
+    assert isinstance(envelope["success"], bool)

--- a/tests/server/test_tools_kitchen.py
+++ b/tests/server/test_tools_kitchen.py
@@ -245,16 +245,18 @@ async def test_open_kitchen_includes_categorized_tool_listing(tmp_path, monkeypa
         with patch("autoskillit.server.logger"):
             with patch("autoskillit.server.tools_kitchen._prime_quota_cache", new=AsyncMock()):
                 with patch("autoskillit.server.tools_kitchen._write_hook_config"):
-                    result = await open_kitchen(ctx=mock_ctx)
+                    result_str = await open_kitchen(ctx=mock_ctx)
 
+    parsed = json.loads(result_str)
+    content = parsed["content"]
     seen: set[str] = set()
     for category_name, tools in _DISPLAY_CATEGORIES:
-        assert category_name in result, (
+        assert category_name in content, (
             f"Category '{category_name}' missing from open_kitchen response"
         )
         for tool_name in tools:
             if tool_name not in seen:
-                assert tool_name in result, (
+                assert tool_name in content, (
                     f"Tool '{tool_name}' missing from open_kitchen response"
                 )
                 seen.add(tool_name)
@@ -298,6 +300,7 @@ async def test_open_kitchen_with_recipe_returns_combined_response(tmp_path, monk
                     result_str = await open_kitchen(name="test-recipe", ctx=mock_ctx)
 
     result = json.loads(result_str)
+    assert result["success"] is True
     assert result["kitchen"] == "open"
     assert "version" in result
     assert "content" in result
@@ -336,8 +339,8 @@ async def test_open_kitchen_with_recipe_not_found(tmp_path, monkeypatch):
 
 
 @pytest.mark.anyio
-async def test_open_kitchen_without_recipe_returns_plain_text(tmp_path, monkeypatch):
-    """open_kitchen() without name returns plain text (not JSON)."""
+async def test_open_kitchen_without_recipe_returns_json_envelope(tmp_path, monkeypatch):
+    """open_kitchen() without name returns JSON envelope with success=True."""
     monkeypatch.chdir(tmp_path)
     mock_ctx = _make_mock_ctx()
     mock_ctx.enable_components = AsyncMock()
@@ -351,8 +354,11 @@ async def test_open_kitchen_without_recipe_returns_plain_text(tmp_path, monkeypa
                     result = await open_kitchen(ctx=mock_ctx)
 
     assert isinstance(result, str)
-    assert "Kitchen is open" in result
-    assert "content" not in result, "No-recipe open_kitchen should not contain recipe content key"
+    parsed = json.loads(result)
+    assert parsed["success"] is True
+    assert parsed["kitchen"] == "open"
+    assert "Kitchen is open" in parsed["content"]
+    assert parsed["ingredients_table"] is None
 
 
 # ---------------------------------------------------------------------------
@@ -368,7 +374,10 @@ async def test_open_kitchen_denied_by_gate_when_headless(tmp_path, monkeypatch):
 
     result = json.loads(await open_kitchen())
     assert result["success"] is False
-    assert result["subtype"] == "headless_error"
+    assert result["kitchen"] == "failed"
+    assert "user_visible_message" in result
+    assert len(result["user_visible_message"]) > 0
+    assert result["stage"] == "headless_guard"
 
 
 @pytest.mark.anyio

--- a/tests/server/test_track_response_size.py
+++ b/tests/server/test_track_response_size.py
@@ -92,3 +92,40 @@ class TestTrackResponseSize:
         assert data["success"] is False
         assert "ValueError: something went wrong" in data["error"]
         assert data["subtype"] == "tool_exception"
+
+    @pytest.mark.anyio
+    async def test_track_response_size_exception_envelope_includes_user_visible_message(self):
+        """Exception envelope includes non-empty user_visible_message with tool name."""
+        from autoskillit.server.helpers import track_response_size
+
+        @track_response_size("open_kitchen")
+        async def bad_handler():
+            raise RuntimeError("boom")
+
+        with patch("autoskillit.server.helpers._get_ctx_or_none", return_value=None):
+            result = await bad_handler()
+
+        data = json.loads(result)
+        assert "user_visible_message" in data
+        assert isinstance(data["user_visible_message"], str)
+        assert len(data["user_visible_message"]) > 0
+        assert "An internal error occurred in open_kitchen" in data["user_visible_message"]
+
+    @pytest.mark.anyio
+    async def test_track_response_size_exception_envelope_preserves_existing_fields(self):
+        """Regression guard: success, error, exit_code, subtype keys still present."""
+        from autoskillit.server.helpers import track_response_size
+
+        @track_response_size("test_tool")
+        async def bad_handler():
+            raise ValueError("fail")
+
+        with patch("autoskillit.server.helpers._get_ctx_or_none", return_value=None):
+            result = await bad_handler()
+
+        data = json.loads(result)
+        assert data["success"] is False
+        assert "ValueError: fail" in data["error"]
+        assert data["exit_code"] == -1
+        assert data["subtype"] == "tool_exception"
+        assert "user_visible_message" in data


### PR DESCRIPTION
## Summary

This PR lands three interconnected operational resilience features for issue #711. Part A adds a fetch-level GitHub API cache and a source-drift boot gate (`cli/_source_drift.py`) that detects when the installed package SHA diverges from its branch HEAD via git ls-remote/GitHub API fallback, with fail-open behavior and 12h SHA-keyed dismissal. Part B converts `open_kitchen` to a unified JSON failure envelope with per-stage exception capture and an orchestrator failure predicate in `cli/_prompts.py`, and migrates the quota cache to a versioned JSON format (`schema_version: 2`) enforced by a new `write_versioned_json` helper in `core/io.py`, two new doctor checks, and an allowlist ratchet test.

<details>
<summary>Individual Group Plans</summary>

### Part A: Fetch-level cache + source drift gate

This is **Part A of a two-part plan** for issue #711. Part A covers:

- **Phase 1 — Fetch-level cache + `write_versioned_json` helper (prerequisite)** — adds a shared HTTP fetch cache to `cli/_stale_check.py` (GitHub Token auth, modern `X-GitHub-Api-Version` + `User-Agent` headers, If-None-Match/304 handling, `httpx.Timeout(connect=2.0, read=1.0)`, 30-min disk TTL as the quota defense) and introduces `write_versioned_json` in `core/io.py`.
- **Phase 2 — Source drift gate** — adds `cli/_source_drift.py` with install-type detection, reference-SHA resolution, and a dismissal-aware CLI boot gate wired into `cli/app.py:main()`, plus a cache-only doctor check.

Phase 1 is a hard prerequisite for Phase 2 (the drift gate reuses `_fetch_with_cache`) and for Part B Phase 4 (the quota cache uses `write_versioned_json`). Phases 1 and 2 are each independently mergeable PRs once this part is complete.

Out of scope (explicitly rejected in the ticket): JSON-field-based orchestrator dispatch, repo-wide `schema_version` AST walk, retrofitting `schema_version` onto staleness cache or migration store, local branch ref comparison, running the drift gate as a second unauthenticated GitHub API call.

### Part B: open_kitchen envelope + quota cache versioning

This is **Part B of a two-part plan** for issue #711. Part B covers:

- **Phase 3 — `open_kitchen` envelope contract + orchestrator failure predicate** — convert every return path in `server/tools_kitchen.py:open_kitchen` and `_open_kitchen_handler` to a unified JSON envelope (`success`, `kitchen`, and on failure `user_visible_message` + `error` + `stage`), wrap every raising step in a local try/except via a shared `_kitchen_failure_envelope` helper, extend the `@track_response_size` exception envelope (`server/helpers.py`) with `user_visible_message`, and add a `FAILURE PREDICATE — open_kitchen` block to `cli/_prompts.py:_build_orchestrator_prompt` using the existing substring-dispatch style.
- **Phase 4 — Quota cache schema versioning** — migrate `execution/quota.py:_write_cache` to `write_versioned_json(schema_version=2)`, teach `_read_cache` to validate the version and emit a `quota_cache_schema_drift` WARNING exactly once per process per cache path, add a `_check_quota_cache_schema` doctor check, and land an allowlist ratchet test at `tests/infra/test_schema_version_convention.py` enforcing that new JSON write sites in `src/autoskillit/` use `write_versioned_json`.

Part A covered the prerequisite fetch-level cache in `cli/_stale_check.py` (with `GITHUB_TOKEN`, etag/304, 1-second timeouts), the `write_versioned_json` helper in `core/io.py`, and the source drift gate. **Part B assumes Part A has already landed**; specifically, Phase 4 imports `write_versioned_json` from `core/io.py` (added in Part A, Step 1.1).

Phases 3 and 4 are independently mergeable PRs.

Out of scope (explicitly rejected in the ticket): JSON-field-based orchestrator dispatch (substring dispatch only), repo-wide `schema_version` adoption, retrofitting `schema_version` onto staleness cache or migration store.

</details>

## Requirements

### REQ-SRCDRIFT-001 — Install source detection

The CLI must be able to classify the currently-running `autoskillit` install into one of: `git-vcs` (stable or integration branch), `local-editable` (worktree install), `local-path`, `unknown`. Classification must be deterministic from the running process's `importlib.metadata.Distribution("autoskillit").read_text("direct_url.json")` — independent of CWD, PATH order, or shell aliases.

- For `git-vcs` installs, the output must include `commit_id`, `requested_revision`, and `url`.
- For `local-editable`, the output must include the `file://` URL of the source directory.
- Absent `direct_url.json` (hypothetical PyPI wheel) must classify as `unknown` and skip all downstream drift logic.

### REQ-SRCDRIFT-002 — Reference SHA resolution

Given a `git-vcs` install with `requested_revision`, the CLI must resolve a reference SHA using fallback chain: env var → CWD walk → git ls-remote → GitHub API. Fail open on any error. Short-circuit exact SHA equality (not prefix).

### REQ-SRCDRIFT-003 — Drift gate integration

Drift check runs from `cli/app.py:main()` after `run_stale_check()`. `AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK=1` skips entirely. On drift: install-type-specific fix hint, `[Y/n]` prompt on TTY, non-TTY prints warning and continues, 12h SHA-keyed dismissal window.

### REQ-SRCDRIFT-004 — Fetch-level cache for GitHub API calls

`_stale_check.py` gains a fetch-level cache (`~/.autoskillit/github_fetch_cache.json`), 30-min TTL, `GITHUB_TOKEN` auth, ETag/If-None-Match/304 handling, `httpx.Timeout(connect=2.0, read=1.0)`.

### REQ-SRCDRIFT-005 — Doctor check for source drift

New doctor check (`source_version_drift`) in `cli/_doctor.py`, cache-only (no network). OK for non-source-repo/editable/pinned-SHA/no-drift; WARNING on drift; OK with informational message when cache is empty.

### REQ-OPENKITCHEN-001 — Unified response envelope

Every return path from `open_kitchen` returns JSON with at minimum: `"success"` (bool), `"kitchen"` (`"open"` or `"failed"`), on failure `"user_visible_message"` + `"error"`, on success `"content"` + `"ingredients_table"` + `"version"`.

### REQ-OPENKITCHEN-002 — Handler-local exception capture

`_open_kitchen_handler` wraps every raising step in local try/except returning `_kitchen_failure_envelope(exc, stage)`. `@track_response_size` extended with `"user_visible_message"` as last-resort safety net.

### REQ-OPENKITCHEN-003 — Orchestrator failure predicate for open_kitchen

`cli/_prompts.py:_build_orchestrator_prompt` gains `FAILURE PREDICATE — open_kitchen` using substring-matching dispatch: extract `user_visible_message`, DO NOT call AskUserQuestion, end session.

### REQ-OPENKITCHEN-004 — Contract tests

Parametrized tests asserting every return path from `open_kitchen` parses as JSON with boolean `success`, every failure path has non-empty `user_visible_message`, and prompt contains the predicate phrases.

### REQ-QUOTACACHE-001 — `write_versioned_json` helper in `core/io.py`

New function `write_versioned_json(path, payload, schema_version)` enriches dict payload with `"schema_version"` key and calls `atomic_write`.

### REQ-QUOTACACHE-002 — Migrate quota cache to versioned format

`_write_cache` calls `write_versioned_json(schema_version=2)`. `_read_cache` validates `schema_version == 2`; on mismatch logs `quota_cache_schema_drift` WARNING exactly once per process per cache path via module-level `_SCHEMA_DRIFT_LOGGED` set.

### REQ-QUOTACACHE-003 — Allowlist ratchet for JSON artifacts

`tests/infra/test_schema_version_convention.py` with grep-based scan of `atomic_write` JSON dict write sites, `_LEGACY_JSON_WRITES` allowlist (quota cache excluded), and diff-style failure message.

### REQ-QUOTACACHE-004 — Doctor check for quota cache schema

New doctor check (`quota_cache_schema`) in `cli/_doctor.py`: OK for schema_version==2 or absent file; WARNING for missing/older schema_version.

## Architecture Impact

### Error/Resilience Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 42, 'rankSpacing': 54, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    CLI_START([CLI Startup])
    MCP_START([MCP Tool Call])

    %% ── BOOT GATE LAYER ── %%
    subgraph BootGates ["BOOT GATES — Fail-Open (cli/_source_drift.py ★, cli/_stale_check.py ●)"]
        direction TB

        ENV_GUARD["● run_stale_check<br/>━━━━━━━━━━<br/>Gates: CLAUDECODE=1<br/>CI env · !isatty(stdin/stdout)"]

        REENTRANCY["● Re-entrancy Prevention<br/>━━━━━━━━━━<br/>Sets SKIP_STALE_CHECK=1<br/>SKIP_SOURCE_DRIFT=1<br/>in every subprocess env"]

        SD_ENV["★ run_source_drift_check<br/>━━━━━━━━━━<br/>Gates: SKIP_SOURCE_DRIFT<br/>CLAUDECODE=1 · CI=1<br/>except Exception → silent"]

        DETECT["★ detect_install()<br/>━━━━━━━━━━<br/>Outer except Exception<br/>→ InstallType.UNKNOWN<br/>Inner: toml parse failures<br/>continue walk upward"]

        INSTALL_GUARD{"install_type<br/>UNKNOWN or<br/>LOCAL_PATH?"}

        RESOLVE_SHA["★ resolve_reference_sha()<br/>━━━━━━━━━━<br/>Fallback chain:<br/>_git_ls_remote_sha()<br/>→ _api_sha() if None<br/>timeout=5s per git attempt"]

        SHA_NULL{"ref_sha<br/>is None?"}

        SHA_MATCH{"commit_id<br/>== ref_sha?"}

        DISMISS_GATE["★ _is_drift_dismissed()<br/>━━━━━━━━━━<br/>SHA-keyed dismissal<br/>12h window<br/>except Exception → False<br/>(allows check to proceed)"]
    end

    %% ── QUOTA CACHE ERROR PATH ── %%
    subgraph QuotaCache ["QUOTA CACHE ERROR PATH (execution/quota.py ●)"]
        direction TB

        CACHE_READ["● _read_cache()<br/>━━━━━━━━━━<br/>Catches: FileNotFoundError<br/>KeyError · ValueError<br/>TypeError · JSONDecodeError<br/>→ None (cache miss)"]

        SCHEMA_VER["● Schema Version Gate<br/>━━━━━━━━━━<br/>schema_version != 2<br/>→ WARNING logged once<br/>via _SCHEMA_DRIFT_LOGGED<br/>(process-lifetime dedup set)"]

        FAIL_OPEN["● check_and_sleep_if_needed<br/>━━━━━━━━━━<br/>Subsystem boundary contract:<br/>never raises to caller<br/>outer except Exception"]

        EXC_CLASSIFY{"Exception<br/>type?"}

        CACHE_WRITE["● _write_cache()<br/>━━━━━━━━━━<br/>except OSError<br/>→ WARNING, silent<br/>never raises"]

        UNKNOWN_RESET["● Unknown Reset Fallback<br/>━━━━━━━━━━<br/>resets_at is None<br/>→ sleep max(buffer_s, 60)<br/>reason: unknown_reset"]
    end

    %% ── DOCTOR HEALTH CHECKS ── %%
    subgraph Doctor ["DOCTOR HEALTH CHECKS — Never Raises (cli/_doctor.py ●)"]
        direction LR

        DOCTOR_RUN["● run_doctor()<br/>━━━━━━━━━━<br/>Aggregates DoctorResult[]<br/>JSON/OS errors → ERROR result<br/>never propagates exception"]

        CHECK_SCHEMA["● _check_quota_cache_schema()<br/>━━━━━━━━━━<br/>schema_version != 2<br/>→ Severity.WARNING<br/>except Exception → WARNING"]

        CHECK_DRIFT["● _check_source_version_drift()<br/>━━━━━━━━━━<br/>network=False (cache only)<br/>UNKNOWN/LOCAL_PATH → OK<br/>ref_sha None → OK<br/>except Exception → OK"]

        SEVERITY_OUT["Severity Result<br/>━━━━━━━━━━<br/>OK / WARNING / ERROR<br/>printed to terminal"]
    end

    %% ── KITCHEN OPEN STAGED FAILURE ── %%
    subgraph KitchenOpen ["KITCHEN OPEN: STAGED FAILURE ENVELOPES (server/tools_kitchen.py ●)"]
        direction TB

        HEADLESS_GATE_K["● _require_not_headless<br/>━━━━━━━━━━<br/>AUTOSKILLIT_HEADLESS=1<br/>→ kitchen failure envelope<br/>stage: headless_guard"]

        STAGE_EXEC["● _open_kitchen_handler()<br/>━━━━━━━━━━<br/>Stages individually wrapped:<br/>write_hook_config<br/>prime_quota_cache<br/>start_quota_refresh<br/>enable_components<br/>redisable_subsets"]

        HOOK_WRITE["● _write_hook_config()<br/>━━━━━━━━━━<br/>except OSError → WARNING<br/>non-fatal, execution continues"]

        KITCHEN_ENV["● _kitchen_failure_envelope()<br/>━━━━━━━━━━<br/>success:false<br/>kitchen:failed<br/>stage: {which stage failed}<br/>user_visible_message"]
    end

    %% ── MCP GATE STACK ── %%
    subgraph McpGates ["MCP TOOL GATE STACK (server/helpers.py ●)"]
        direction LR

        REQUIRE_EN["● _require_enabled()<br/>━━━━━━━━━━<br/>gate.enabled == False<br/>→ gate_error_result JSON"]

        REQUIRE_NH["● _require_not_headless()<br/>━━━━━━━━━━<br/>AUTOSKILLIT_HEADLESS<br/>→ headless error JSON"]

        VALIDATE_SK["● _validate_skill_command()<br/>━━━━━━━━━━<br/>!startswith slash<br/>→ gate_error_result JSON"]

        TRACK_RESP["● track_response_size<br/>━━━━━━━━━━<br/>Last-resort except Exception<br/>→ tool_exception envelope<br/>logs at EXCEPTION level"]
    end

    %% ── CORE IO WRITE SAFETY ── %%
    subgraph CoreIO ["CORE IO WRITE SAFETY (core/io.py ●)"]
        direction LR

        ATOMIC_W["● atomic_write()<br/>━━━━━━━━━━<br/>Write to tmp → os.replace<br/>On failure: unlink tmp<br/>inner OSError swallowed<br/>original exception re-raised"]

        VERSIONED_W["● write_versioned_json()<br/>━━━━━━━━━━<br/>if not isinstance(payload, dict)<br/>→ TypeError (hard guard)<br/>adds schema_version key<br/>then delegates to atomic_write"]
    end

    %% ── TERMINAL STATES ── %%
    T_SILENT([Fail-Open · Silent Return])
    T_WARN([WARNING Logged])
    T_ERR([ERROR Logged])
    T_DRIFT([Drift Prompt Shown to User])
    T_KITCHEN_FAIL([Kitchen Open Failed · JSON envelope])
    T_GATE_BLOCK([Tool Call Blocked · JSON error])
    T_OK([Passes Through · Normal Flow])

    %% ── CONNECTIONS: CLI BOOT ── %%
    CLI_START --> ENV_GUARD
    CLI_START --> SD_ENV

    ENV_GUARD -->|"gate passes"| REENTRANCY
    ENV_GUARD -->|"CLAUDECODE/CI/!TTY"| T_SILENT

    SD_ENV -->|"SKIP/CI/CLAUDECODE"| T_SILENT
    SD_ENV --> DETECT
    DETECT -->|"except Exception"| T_SILENT
    DETECT -->|"install identified"| INSTALL_GUARD
    INSTALL_GUARD -->|"yes"| T_SILENT
    INSTALL_GUARD -->|"known pip/tool install"| RESOLVE_SHA
    RESOLVE_SHA -->|"git ls-remote fails"| RESOLVE_SHA
    RESOLVE_SHA -->|"all attempts → None"| SHA_NULL
    SHA_NULL -->|"yes"| T_SILENT
    SHA_NULL -->|"ref_sha resolved"| SHA_MATCH
    SHA_MATCH -->|"no drift"| T_SILENT
    SHA_MATCH -->|"drift detected"| DISMISS_GATE
    DISMISS_GATE -->|"SHA-keyed dismissed + within 12h"| T_SILENT
    DISMISS_GATE -->|"not dismissed"| T_DRIFT

    %% ── CONNECTIONS: QUOTA CACHE ── %%
    CACHE_READ -->|"parse or key error"| T_SILENT
    CACHE_READ -->|"raw parsed"| SCHEMA_VER
    SCHEMA_VER -->|"version mismatch"| T_WARN
    SCHEMA_VER -->|"version == 2"| FAIL_OPEN
    FAIL_OPEN -->|"resets_at is None"| UNKNOWN_RESET
    UNKNOWN_RESET --> T_WARN
    FAIL_OPEN -->|"except Exception"| EXC_CLASSIFY
    EXC_CLASSIFY -->|"Timeout/OS/HTTP/JSON"| T_WARN
    EXC_CLASSIFY -->|"programming error"| T_ERR
    CACHE_WRITE -->|"OSError"| T_WARN
    CACHE_WRITE -->|"success"| T_OK

    %% ── CONNECTIONS: DOCTOR ── %%
    CLI_START --> DOCTOR_RUN
    DOCTOR_RUN --> CHECK_SCHEMA
    DOCTOR_RUN --> CHECK_DRIFT
    CHECK_SCHEMA --> SEVERITY_OUT
    CHECK_DRIFT --> SEVERITY_OUT

    %% ── CONNECTIONS: KITCHEN ── %%
    MCP_START --> HEADLESS_GATE_K
    HEADLESS_GATE_K -->|"AUTOSKILLIT_HEADLESS=1"| T_KITCHEN_FAIL
    HEADLESS_GATE_K -->|"interactive session"| STAGE_EXEC
    STAGE_EXEC --> HOOK_WRITE
    HOOK_WRITE -->|"OSError"| T_WARN
    HOOK_WRITE -->|"success"| STAGE_EXEC
    STAGE_EXEC -->|"stage Exception"| KITCHEN_ENV
    KITCHEN_ENV --> T_KITCHEN_FAIL

    %% ── CONNECTIONS: MCP GATES ── %%
    MCP_START --> REQUIRE_EN
    REQUIRE_EN -->|"gate closed"| T_GATE_BLOCK
    REQUIRE_EN -->|"gate open"| REQUIRE_NH
    REQUIRE_NH -->|"headless session"| T_GATE_BLOCK
    REQUIRE_NH -->|"interactive"| VALIDATE_SK
    VALIDATE_SK -->|"invalid command"| T_GATE_BLOCK
    VALIDATE_SK -->|"valid"| TRACK_RESP
    TRACK_RESP -->|"unhandled Exception"| T_ERR
    TRACK_RESP -->|"telemetry OSError"| T_WARN

    %% ── CLASS ASSIGNMENTS ── %%
    class CLI_START,MCP_START terminal;
    class T_SILENT,T_DRIFT,T_KITCHEN_FAIL,T_GATE_BLOCK,T_OK terminal;
    class T_WARN gap;
    class T_ERR integration;
    class SD_ENV,DETECT,RESOLVE_SHA,DISMISS_GATE newComponent;
    class ENV_GUARD,REENTRANCY,FAIL_OPEN,STAGE_EXEC,DOCTOR_RUN handler;
    class CACHE_READ,SCHEMA_VER,CACHE_WRITE,UNKNOWN_RESET stateNode;
    class HEADLESS_GATE_K,REQUIRE_EN,REQUIRE_NH,VALIDATE_SK detector;
    class INSTALL_GUARD,SHA_NULL,SHA_MATCH,EXC_CLASSIFY phase;
    class CHECK_SCHEMA,CHECK_DRIFT output;
    class SEVERITY_OUT output;
    class KITCHEN_ENV,TRACK_RESP gap;
    class ATOMIC_W,VERSIONED_W stateNode;
```

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph FieldCats ["FIELD LIFECYCLE CATEGORIES"]
        direction LR
        INIT_ONLY["INIT_ONLY ⟨frozen⟩<br/>━━━━━━━━━━<br/>★ InstallInfo: install_type<br/>  commit_id, requested_revision<br/>● _QUOTA_CACHE_SCHEMA_VERSION=2<br/>  schema_version ⟨per-write⟩"]
        MUTABLE_F["MUTABLE<br/>━━━━━━━━━━<br/>● gate.enabled ⟨bool⟩<br/>● kitchen_id ⟨uuid str⟩<br/>● active_recipe_packs<br/>★ ref_sha ⟨runtime only⟩"]
        APPEND_F["APPEND_ONLY<br/>━━━━━━━━━━<br/>update_check.json keys<br/>● binary, hooks<br/>★ source_drift"]
    end

    subgraph WriteContracts ["● WRITE CONTRACTS (core/io.py)"]
        direction LR
        WVJ["● write_versioned_json<br/>━━━━━━━━━━<br/>enriched = {**payload,<br/>'schema_version': ver}<br/>TypeError if not dict"]
        AW["atomic_write<br/>━━━━━━━━━━<br/>mkstemp + os.replace<br/>crash-safe, single-writer"]
    end

    subgraph StateArtifacts ["STATE ARTIFACTS ⟨on-disk⟩"]
        direction LR
        QC["● quota_cache.json<br/>━━━━━━━━━━<br/>schema_version: 2<br/>fetched_at, windows<br/>binding"]
        UC["update_check.json<br/>━━━━━━━━━━<br/>binary {dismissed_at, ver}<br/>hooks {dismissed_at, ver}<br/>★ source_drift {dismissed_at,<br/>  installed_sha, reference_sha}"]
        HK["hook_config.json<br/>━━━━━━━━━━<br/>quota_guard config<br/>kitchen_id<br/>⟨unversioned⟩"]
    end

    subgraph SDriftGate ["★ SOURCE DRIFT VALIDATION CHAIN (_source_drift.py)"]
        direction TB
        SG1["★ Env Bypass Gate<br/>━━━━━━━━━━<br/>SKIP_SOURCE_DRIFT_CHECK<br/>CLAUDECODE | CI → skip"]
        SG2["★ Install Type Gate<br/>━━━━━━━━━━<br/>UNKNOWN | LOCAL_PATH → skip<br/>GIT_VCS | LOCAL_EDITABLE<br/>→ proceed"]
        SG3["★ SHA Resolution Gate<br/>━━━━━━━━━━<br/>requested_revision=None → skip<br/>rev==commit_id → short-circuit<br/>network fail → fail-open"]
        SG4["★ SHA Equality Gate<br/>━━━━━━━━━━<br/>commit_id == ref_sha<br/>→ silent exit ⟨no drift⟩"]
        SG5["★ Dismissal Gate<br/>━━━━━━━━━━<br/>● _is_drift_dismissed()<br/>12h window AND<br/>installed_sha match AND<br/>reference_sha match"]
        SG6["★ Drift Action<br/>━━━━━━━━━━<br/>TTY → Y/n prompt + dismiss write<br/>non-TTY → print warning only<br/>except Exception → debug log"]
    end

    subgraph QuotaGate ["● QUOTA CACHE READ VALIDATION (execution/quota.py)"]
        direction TB
        QG1["● Schema Version Gate<br/>━━━━━━━━━━<br/>raw.get('schema_version') != 2<br/>→ warn-once per path<br/>→ return None"]
        QG2["Age Gate<br/>━━━━━━━━━━<br/>age > config.cache_max_age<br/>→ return None ⟨stale⟩"]
        QG3["Structural Gate<br/>━━━━━━━━━━<br/>'binding' not in raw<br/>→ return None"]
        QG4["Coercion Gate + Blanket<br/>━━━━━━━━━━<br/>float(utilization)<br/>except FileNotFoundError<br/>KeyError|ValueError|TypeError<br/>JSONDecodeError → None"]
        QG5["Cache Hit → QuotaStatus<br/>━━━━━━━━━━<br/>utilization, resets_at<br/>window_name"]
    end

    subgraph DocObserve ["● DOCTOR OBSERVABILITY (cli/_doctor.py)"]
        direction LR
        DC1["● Check 13: source_version_drift<br/>━━━━━━━━━━<br/>detect_install() → InstallType<br/>resolve_reference_sha(network=False)<br/>WARNING if commit_id != ref_sha"]
        DC2["● Check 14: quota_cache_schema<br/>━━━━━━━━━━<br/>raw.get('schema_version') == 2?<br/>WARNING on any mismatch"]
    end

    subgraph KitchenEnv ["● KITCHEN ENVELOPE CONTRACT"]
        direction TB
        KIT["● open_kitchen failure envelope<br/>━━━━━━━━━━<br/>● stage: 'prime_quota_cache'<br/>  | 'headless_guard'<br/>  | 'write_hook_config' | ...<br/>success: false<br/>user_visible_message"]
        PROM["● Orchestrator Failure Predicate<br/>━━━━━━━━━━<br/>_prompts.py contract:<br/>success:false OR<br/>no '--- INGREDIENTS TABLE ---'<br/>→ print user_visible_message<br/>→ end session"]
    end

    %% WRITE FLOW %%
    WVJ --> AW
    AW --> QC
    AW --> UC

    %% ARTIFACTS → READ GATES %%
    QC --> QG1
    UC --> SG5

    %% SOURCE DRIFT CHAIN %%
    SG1 --> SG2 --> SG3 --> SG4 --> SG5 --> SG6

    %% QUOTA CACHE CHAIN %%
    QG1 --> QG2 --> QG3 --> QG4 --> QG5

    %% DOCTOR OBSERVABILITY %%
    QC --> DC2
    UC --> DC1

    %% KITCHEN ENVELOPE FLOW %%
    KIT --> PROM

    %% FIELD CATEGORIES → GATE CONTEXTS (conceptual) %%
    INIT_ONLY -.->|"frozen InstallInfo"| SG2
    INIT_ONLY -.->|"INIT_ONLY per-write"| QG1
    APPEND_F -.->|"write-then-read"| SG5

    %% CLASS ASSIGNMENTS %%
    class INIT_ONLY detector;
    class MUTABLE_F phase;
    class APPEND_F handler;
    class WVJ newComponent;
    class AW output;
    class QC,UC,HK stateNode;
    class SG1,SG2,SG3,SG4 detector;
    class SG5,SG6 newComponent;
    class QG1 detector;
    class QG2,QG3,QG4 stateNode;
    class QG5 output;
    class DC1,DC2 phase;
    class KIT handler;
    class PROM cli;
```

### Operational Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 65, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ── CLI ENTRY ── %%
    subgraph CLI ["● CLI ENTRY — app.py::main()"]
        direction TB
        MAIN["● autoskillit<br/>━━━━━━━━━━<br/>All commands: serve / init<br/>order / cook / doctor / ..."]
    end

    %% ── ENV GUARDS ── %%
    subgraph Guards ["ENV BYPASS GUARDS"]
        direction TB
        ENV["Env Bypass Vars<br/>━━━━━━━━━━<br/>CLAUDECODE=1 → skip both<br/>CI=1 → skip drift<br/>AUTOSKILLIT_SKIP_STALE_CHECK<br/>AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK"]
    end

    %% ── PRE-FLIGHT GATES ── %%
    subgraph PreFlight ["PRE-FLIGHT GATES (injected before every interactive command)"]
        direction LR
        STALE["● run_stale_check()<br/>━━━━━━━━━━<br/>Binary version vs GitHub latest<br/>Hook registry drift count<br/>Prompts update or dismiss<br/>TTY-only; skips headless"]
        DRIFT["★ run_source_drift_check()<br/>━━━━━━━━━━<br/>Installed SHA vs branch HEAD<br/>git ls-remote → GitHub API fallback<br/>SHA-keyed dismissal (12-hr TTL)<br/>Fail-open on any Exception"]
    end

    %% ── SHARED DISK STATE ── %%
    subgraph SharedState ["SHARED STATE (~/.autoskillit/) — read/write"]
        direction LR
        DISMISS["update_check.json<br/>━━━━━━━━━━<br/>Stale + drift dismissal records<br/>Keys: binary / hooks / source_drift<br/>SHA-keyed; 12-hr window"]
        GHCACHE["github_fetch_cache.json<br/>━━━━━━━━━━<br/>GitHub API response cache<br/>ETag/304 conditional requests<br/>30-min TTL (overridable)"]
    end

    %% ── DISPATCH ── %%
    DISPATCH["Command Dispatch"]

    %% ── DOCTOR COMMAND ── %%
    subgraph DoctorCmd ["● autoskillit doctor  (14 checks total)"]
        direction TB
        DOC_DRIFT["● Check #13: source_version_drift<br/>━━━━━━━━━━<br/>Cache-only SHA comparison<br/>network=False — never blocks CLI<br/>Returns OK when no cache exists<br/>WARNING on SHA mismatch"]
        DOC_QUOTA["● Check #14: quota_cache_schema<br/>━━━━━━━━━━<br/>Reads ~/.claude/autoskillit_quota_cache.json<br/>Validates schema_version == 2<br/>WARNING on mismatch or parse failure<br/>OK if file absent"]
    end

    %% ── KITCHEN MCP ── %%
    subgraph KitchenMCP ["● open_kitchen MCP Tool — tools_kitchen.py"]
        direction TB
        PRIME["● _prime_quota_cache()<br/>━━━━━━━━━━<br/>Live API call at kitchen open<br/>Warms cache before first run_skill<br/>Fails open on error"]
        LOOP["● _quota_refresh_loop()<br/>━━━━━━━━━━<br/>asyncio background task<br/>Refreshes before cache_max_age expires<br/>Cancelled on close_kitchen"]
        HOOKCONF["Hook Config Write<br/>━━━━━━━━━━<br/>.autoskillit/temp/<br/>.autoskillit_hook_config.json<br/>Written on open, deleted on close"]
        PROMPT["● Orchestrator Prompt Contract<br/>━━━━━━━━━━<br/>open_kitchen failure predicate<br/>Quota denial QUOTA WAIT routing<br/>PIPELINE_FORBIDDEN_TOOLS contract<br/>run_skill result envelope contract"]
    end

    %% ── QUOTA CACHE ── %%
    subgraph QuotaLayer ["● QUOTA CACHE — execution/quota.py"]
        direction TB
        QFILE["● ~/.claude/autoskillit_quota_cache.json<br/>━━━━━━━━━━<br/>schema_version: 2<br/>fetched_at + utilization + resets_at<br/>Schema drift logged once per process"]
        VJSON["● write_versioned_json()  core/io.py<br/>━━━━━━━━━━<br/>Stamps schema_version on every write<br/>atomic_write() backed (crash-safe)<br/>Convention for all new JSON artifacts"]
    end

    %% ── TASK AUTOMATION ── %%
    subgraph Tasks ["TASK COMMANDS (Taskfile.yml)"]
        direction LR
        TASK_TEST["task test-all / test-check<br/>━━━━━━━━━━<br/>pytest -n 4; PASS/FAIL signal"]
        TASK_INSTALL["task install-dev / install-worktree<br/>━━━━━━━━━━<br/>uv tool install / .venv setup"]
        TASK_SYNC["task sync-plugin-version<br/>━━━━━━━━━━<br/>Sync plugin.json ← pyproject.toml"]
    end

    %% ── FLOWS ── %%
    MAIN --> STALE
    STALE --> DRIFT
    DRIFT --> DISPATCH

    ENV -->|bypasses| STALE
    ENV -->|bypasses| DRIFT

    STALE <-->|read/write| DISMISS
    STALE <-->|read/write| GHCACHE
    DRIFT <-->|read/write| DISMISS
    DRIFT <-->|read/write| GHCACHE

    DISPATCH --> DOC_DRIFT
    DISPATCH --> DOC_QUOTA
    DISPATCH --> PRIME

    DOC_DRIFT -->|cache-only read| GHCACHE
    DOC_QUOTA -->|read| QFILE

    PRIME --> QFILE
    PRIME --> LOOP
    LOOP -->|periodic write| QFILE
    QFILE -->|written via| VJSON

    PRIME --> HOOKCONF
    PRIME --> PROMPT

    %% ── CLASS ASSIGNMENTS ── %%
    class MAIN,DISPATCH cli;
    class STALE phase;
    class DRIFT newComponent;
    class ENV detector;
    class DISMISS,GHCACHE stateNode;
    class DOC_DRIFT,DOC_QUOTA handler;
    class PRIME,LOOP,HOOKCONF handler;
    class PROMPT phase;
    class QFILE,VJSON output;
    class TASK_TEST,TASK_INSTALL,TASK_SYNC phase;
```

Closes #711

## Implementation Plan

Plan files:
- `/home/talon/projects/autoskillit-runs/impl-20260410-200536-603942/.autoskillit/temp/make-plan/issue_711_source_drift_open_kitchen_quota_cache_plan_part_a_2026-04-10_200827.md`
- `/home/talon/projects/autoskillit-runs/impl-20260410-200536-603942/.autoskillit/temp/make-plan/issue_711_source_drift_open_kitchen_quota_cache_plan_part_b_2026-04-10_200827.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 360 | 47.9k | 2.4M | 136.8k | 1 | 12m 6s |
| review | 3.7k | 16.1k | 242.3k | 63.6k | 1 | 7m 48s |
| verify | 534 | 49.2k | 3.8M | 169.7k | 2 | 13m 49s |
| implement | 457 | 68.2k | 15.7M | 280.8k | 2 | 27m 59s |
| retry_worktree | 604 | 93.0k | 12.3M | 297.3k | 2 | 32m 18s |
| fix | 374 | 17.5k | 2.6M | 65.9k | 1 | 7m 50s |
| prepare_pr | 60 | 10.9k | 283.3k | 51.1k | 1 | 2m 46s |
| run_arch_lenses | 2.4k | 36.0k | 658.5k | 120.7k | 3 | 15m 11s |
| compose_pr | 75 | 12.8k | 327.8k | 55.5k | 1 | 3m 23s |
| **Total** | 8.6k | 351.6k | 38.3M | 1.2M | | 2h 3m |