### PR TITLE
Rectify: IDE Env Leak Across All Claude Subprocess Launch Sites

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,7 @@ generic_automation_mcp/
 │   ├── _type_results.py     #   LoadResult, SkillResult, FailureRecord, CleanupResult, etc.
 │   ├── _type_protocols.py   #   Protocols: GatePolicy, HeadlessExecutor, CIWatcher, etc.
 │   ├── _type_helpers.py
+│   ├── _claude_env.py       #   IDE-scrubbing canonical env builder for claude subprocesses
 │   ├── _terminal_table.py   #   L0 color-agnostic terminal table primitive
 │   ├── branch_guard.py
 │   ├── claude_conventions.py #  Skill discovery directory layout constants

--- a/src/autoskillit/_llm_triage.py
+++ b/src/autoskillit/_llm_triage.py
@@ -16,6 +16,7 @@ from autoskillit.core import (
     OutputFormat,
     SubprocessResult,
     TerminationReason,
+    build_claude_env,
     get_logger,
 )
 from autoskillit.execution import parse_session_result, run_managed_async
@@ -122,6 +123,7 @@ async def _triage_batch(
             cmd=triage_cmd,
             cwd=Path.cwd(),
             timeout=30.0,
+            env=build_claude_env(),
             pty_mode=True,
         )
         if result.termination == TerminationReason.TIMED_OUT:

--- a/src/autoskillit/cli/_cook.py
+++ b/src/autoskillit/cli/_cook.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-import os
 import shutil
 import subprocess
 import uuid
+from collections.abc import Mapping
 from pathlib import Path
 
 from autoskillit.cli._terminal import terminal_guard
@@ -65,7 +65,7 @@ _DISPLAY_CATEGORIES: tuple[tuple[str, tuple[str, ...]], ...] = (
 def _run_cook_session(
     *,
     cmd: list[str],
-    env: dict[str, str],
+    env: Mapping[str, str],
     _first_run: bool,
     initial_prompt: str | None,
     project_dir: Path,
@@ -151,16 +151,15 @@ def cook(*, resume: bool = False, session_id: str | None = None) -> None:
         session_id_local, cook_session=True, config=config, project_dir=project_dir
     )
 
-    cmd = build_interactive_cmd(
+    spec = build_interactive_cmd(
         plugin_dir=pkg_root(),
         add_dirs=[skills_dir],
         initial_prompt=initial_prompt,
         resume_session_id=resume_session_id,
-    ).cmd
-    env = {**os.environ}
+    )
     _run_cook_session(
-        cmd=cmd,
-        env=env,
+        cmd=spec.cmd,
+        env=spec.env,
         _first_run=_first_run,
         initial_prompt=initial_prompt,
         project_dir=project_dir,

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -428,7 +428,9 @@ def _launch_cook_session(
         print("ERROR: 'claude' not found. Install: https://docs.anthropic.com/en/docs/claude-code")
         sys.exit(1)
     spec = build_interactive_cmd(
-        initial_prompt=initial_message, resume_session_id=resume_session_id
+        initial_prompt=initial_message,
+        resume_session_id=resume_session_id,
+        env_extras=extra_env,
     )
     cmd = spec.cmd + [
         ClaudeFlags.PLUGIN_DIR,
@@ -438,11 +440,8 @@ def _launch_cook_session(
         ClaudeFlags.APPEND_SYSTEM_PROMPT,
         system_prompt,
     ]
-    env = {**os.environ, **spec.env}
-    if extra_env:
-        env.update(extra_env)
     with terminal_guard():
-        result = subprocess.run(cmd, env=env)
+        result = subprocess.run(cmd, env=spec.env)
     if result.returncode != 0:
         sys.exit(result.returncode)
 

--- a/src/autoskillit/core/__init__.py
+++ b/src/autoskillit/core/__init__.py
@@ -5,6 +5,7 @@ so callers can do either `from autoskillit.core import get_logger` or the
 explicit `from autoskillit.core.logging import get_logger`.
 """
 
+from ._claude_env import build_claude_env
 from ._terminal_table import TerminalColumn as TerminalColumn
 from ._terminal_table import _render_gfm_table as _render_gfm_table
 from ._terminal_table import _render_terminal_table as _render_terminal_table
@@ -111,6 +112,8 @@ from .types import (
 )
 
 __all__ = [
+    # _claude_env
+    "build_claude_env",
     # _terminal_table
     "TerminalColumn",
     "_render_gfm_table",

--- a/src/autoskillit/core/_claude_env.py
+++ b/src/autoskillit/core/_claude_env.py
@@ -1,0 +1,89 @@
+"""Canonical env builder for claude-launching subprocesses.
+
+Every subprocess that invokes the ``claude`` CLI must route its environment
+through :func:`build_claude_env` so that host-process IDE state (VS Code,
+Cursor, Zed, JetBrains, Neovim bridges) cannot leak across the trust
+boundary and silently widen the child's tool surface.
+
+Two layers of immunity are applied:
+
+1. **Denylist scrub** — IDE discovery variables such as
+   ``CLAUDE_CODE_SSE_PORT`` and the ``CLAUDE_CODE_IDE_*`` family are
+   stripped from ``base``. Removing the port env closes the direct-signal
+   attach path.
+2. **Implicit auto-connect disable** — ``CLAUDE_CODE_AUTO_CONNECT_IDE=0``
+   is always injected. This suppresses the ``~/.claude/ide/*.lock`` scan
+   fallback that the Claude CLI follows at startup even when no IDE env
+   vars are set; without it, third-party IDE bridges (e.g.
+   ``claudecode.nvim``) can still attach via the lock-file mechanism.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from types import MappingProxyType
+
+# Exact-match IDE discovery variable names stripped from the child env.
+IDE_ENV_DENYLIST: frozenset[str] = frozenset(
+    {
+        "CLAUDE_CODE_SSE_PORT",
+        "ENABLE_IDE_INTEGRATION",
+        "CLAUDE_CODE_WEBSOCKET_AUTH_FILE_DESCRIPTOR",
+        "VSCODE_GIT_ASKPASS_MAIN",
+        "CURSOR_TRACE_ID",
+        "ZED_TERM",
+    }
+)
+
+# Prefix-match IDE variable patterns stripped from the child env.
+IDE_ENV_PREFIX_DENYLIST: tuple[str, ...] = (
+    "CLAUDE_CODE_IDE_",
+    "CLAUDE_CODE_SSE",
+)
+
+# Variables injected into every built env regardless of caller. These close
+# discovery paths that cannot be closed by scrubbing alone — notably
+# CLAUDE_CODE_AUTO_CONNECT_IDE=0, which suppresses the ~/.claude/ide/*.lock
+# scan path that fires even when SSE_PORT is absent.
+IDE_ENV_ALWAYS_EXTRAS: Mapping[str, str] = MappingProxyType(
+    {
+        "CLAUDE_CODE_AUTO_CONNECT_IDE": "0",
+    }
+)
+
+
+def build_claude_env(
+    base: Mapping[str, str] | None = None,
+    *,
+    extras: Mapping[str, str] | None = None,
+) -> Mapping[str, str]:
+    """Return a scrubbed, sealed env dict suitable for a claude subprocess.
+
+    Parameters
+    ----------
+    base
+        Starting environment. Defaults to ``os.environ``.
+    extras
+        Caller-supplied overrides merged last. Used to carry
+        ``AUTOSKILLIT_HEADLESS=1``, ``SCENARIO_STEP_NAME=...`` and similar
+        into the child.
+
+    Returns
+    -------
+    Mapping[str, str]
+        A ``MappingProxyType`` over the resolved env. Both
+        ``subprocess.run(env=...)`` and ``anyio.open_process(env=...)``
+        accept any ``Mapping``, so this is a drop-in for the underlying
+        runners. The read-only view prevents post-build mutation.
+    """
+    src = os.environ if base is None else base
+    out: dict[str, str] = {
+        k: v
+        for k, v in src.items()
+        if k not in IDE_ENV_DENYLIST and not any(k.startswith(p) for p in IDE_ENV_PREFIX_DENYLIST)
+    }
+    out.update(IDE_ENV_ALWAYS_EXTRAS)
+    if extras:
+        out.update(extras)
+    return MappingProxyType(out)

--- a/src/autoskillit/core/_type_subprocess.py
+++ b/src/autoskillit/core/_type_subprocess.py
@@ -6,7 +6,7 @@ SubprocessRunner, and the termination contract sentinel.
 
 from __future__ import annotations
 
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
@@ -115,7 +115,7 @@ class SubprocessRunner(Protocol):
         *,
         cwd: Path,
         timeout: float,
-        env: dict[str, str] | None = None,
+        env: Mapping[str, str] | None = None,
         stale_threshold: float = 1200,
         completion_marker: str = "",
         session_log_dir: Path | None = None,

--- a/src/autoskillit/execution/commands.py
+++ b/src/autoskillit/execution/commands.py
@@ -3,23 +3,43 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from autoskillit.core import ClaudeFlags, ValidatedAddDir, temp_dir_display_str
+from autoskillit.core import (
+    ClaudeFlags,
+    ValidatedAddDir,
+    build_claude_env,
+    temp_dir_display_str,
+)
 
 
 @dataclass(frozen=True)
 class ClaudeInteractiveCmd:
+    """Resolved argv + env for a claude interactive subprocess.
+
+    ``env`` is the fully resolved environment returned by
+    :func:`build_claude_env` — pass directly to ``subprocess.run(env=...)``.
+    Callers must NOT merge in ``os.environ`` again; the sanitization layer
+    has already applied the denylist and the auto-connect suppressor.
+    """
+
     cmd: list[str]
-    env: dict[str, str]
+    env: Mapping[str, str] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
 class ClaudeHeadlessCmd:
+    """Resolved argv + env for a claude headless subprocess.
+
+    ``env`` is the fully resolved environment returned by
+    :func:`build_claude_env`, including any headless-only extras such as
+    ``AUTOSKILLIT_HEADLESS=1``. Pass directly to the subprocess runner.
+    """
+
     cmd: list[str]
-    env: dict[str, str] = field(default_factory=dict)  # always {}
+    env: Mapping[str, str] = field(default_factory=dict)
 
 
 def build_interactive_cmd(
@@ -29,6 +49,7 @@ def build_interactive_cmd(
     plugin_dir: Path | None = None,
     add_dirs: Sequence[Path | str | ValidatedAddDir] = (),
     resume_session_id: str | None = None,
+    env_extras: Mapping[str, str] | None = None,
 ) -> ClaudeInteractiveCmd:
     """Build a Claude interactive session command.
 
@@ -46,6 +67,8 @@ def build_interactive_cmd(
         Each entry is appended as ``--add-dir <path>``.
     resume_session_id
         When provided, appended as ``--resume <id>`` before any positional prompt.
+    env_extras
+        Optional caller overrides merged into the resolved env after IDE scrubbing.
     """
     cmd = ["claude", ClaudeFlags.DANGEROUSLY_SKIP_PERMISSIONS]
     if resume_session_id is not None:
@@ -58,15 +81,20 @@ def build_interactive_cmd(
         cmd += [ClaudeFlags.ADD_DIR, str(d)]
     if initial_prompt is not None:
         cmd.append(initial_prompt)
-    return ClaudeInteractiveCmd(cmd=cmd, env={})
+    return ClaudeInteractiveCmd(cmd=cmd, env=build_claude_env(extras=env_extras))
 
 
-def build_headless_cmd(prompt: str, *, model: str | None = None) -> ClaudeHeadlessCmd:
+def build_headless_cmd(
+    prompt: str,
+    *,
+    model: str | None = None,
+    env_extras: Mapping[str, str] | None = None,
+) -> ClaudeHeadlessCmd:
     """Build a Claude headless session command for skill execution."""
     cmd = ["claude", ClaudeFlags.PRINT, prompt, ClaudeFlags.DANGEROUSLY_SKIP_PERMISSIONS]
     if model:
         cmd += [ClaudeFlags.MODEL, model]
-    return ClaudeHeadlessCmd(cmd=cmd, env={})
+    return ClaudeHeadlessCmd(cmd=cmd, env=build_claude_env(extras=env_extras))
 
 
 def _ensure_skill_prefix(skill_command: str) -> str:
@@ -121,12 +149,13 @@ def build_full_headless_cmd(
     exit_after_stop_delay_ms: int = 0,
     scenario_step_name: str = "",
     temp_dir_relpath: str | None = None,
-) -> list[str]:
-    """Build the complete headless command list ready for subprocess invocation.
+) -> ClaudeHeadlessCmd:
+    """Build the complete headless command spec ready for subprocess invocation.
 
     Applies prompt transformations (skill prefix, completion directive, cwd anchor),
     then constructs the full CLI command including plugin-dir, output-format,
-    add-dir entries, and the ``env AUTOSKILLIT_HEADLESS=1`` prefix.
+    and add-dir entries. The environment carries ``AUTOSKILLIT_HEADLESS=1`` and any
+    scenario / exit-delay extras on ``.env`` — it is NOT serialized as an argv prefix.
 
     Parameters
     ----------
@@ -147,16 +176,22 @@ def build_full_headless_cmd(
     add_dirs
         Each entry is appended as ``--add-dir <path>``.
     exit_after_stop_delay_ms
-        When > 0, ``CLAUDE_CODE_EXIT_AFTER_STOP_DELAY=<ms>`` is prepended.
+        When > 0, carried as ``CLAUDE_CODE_EXIT_AFTER_STOP_DELAY=<ms>`` in ``.env``.
     scenario_step_name
-        When non-empty, ``SCENARIO_STEP_NAME=<name>`` is prepended for recording.
+        When non-empty, carried as ``SCENARIO_STEP_NAME=<name>`` in ``.env`` for recording.
     """
     prompt = _inject_cwd_anchor(
         _inject_completion_directive(_ensure_skill_prefix(skill_command), completion_marker),
         cwd,
         temp_dir_relpath=temp_dir_relpath,
     )
-    spec = build_headless_cmd(prompt, model=model)
+    extras: dict[str, str] = {"AUTOSKILLIT_HEADLESS": "1"}
+    if exit_after_stop_delay_ms > 0:
+        extras["CLAUDE_CODE_EXIT_AFTER_STOP_DELAY"] = str(exit_after_stop_delay_ms)
+    if scenario_step_name:
+        extras["SCENARIO_STEP_NAME"] = scenario_step_name
+
+    spec = build_headless_cmd(prompt, model=model, env_extras=extras)
     cmd: list[str] = spec.cmd + [
         ClaudeFlags.PLUGIN_DIR,
         str(plugin_dir),
@@ -169,9 +204,4 @@ def build_full_headless_cmd(
     for validated_dir in add_dirs:
         cmd.extend([ClaudeFlags.ADD_DIR, validated_dir.path])
 
-    env_vars = ["AUTOSKILLIT_HEADLESS=1"]
-    if exit_after_stop_delay_ms > 0:
-        env_vars.append(f"CLAUDE_CODE_EXIT_AFTER_STOP_DELAY={exit_after_stop_delay_ms}")
-    if scenario_step_name:
-        env_vars.append(f"SCENARIO_STEP_NAME={scenario_step_name}")
-    return ["env"] + env_vars + cmd
+    return ClaudeHeadlessCmd(cmd=cmd, env=spec.env)

--- a/src/autoskillit/execution/headless.py
+++ b/src/autoskillit/execution/headless.py
@@ -835,7 +835,7 @@ async def run_headless_core(
     ):
         effective_plugin_dir = ctx.plugin_dir
         resolved_model = _resolve_model(model, ctx.config)
-        cmd = build_full_headless_cmd(
+        spec = build_full_headless_cmd(
             skill_command,
             cwd=cwd,
             completion_marker=effective_marker,
@@ -876,9 +876,10 @@ async def run_headless_core(
         _result: SubprocessResult | None = None
         try:
             _result = await runner(
-                cmd,
+                spec.cmd,
                 cwd=Path(cwd),
                 timeout=effective_timeout,
+                env=spec.env,
                 pty_mode=True,
                 session_log_dir=_session_log_dir(cwd),
                 completion_marker=effective_marker,

--- a/src/autoskillit/execution/process.py
+++ b/src/autoskillit/execution/process.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import subprocess
 import time
+from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -98,7 +99,7 @@ async def run_managed_async(
     cwd: Path,
     timeout: float,
     input_data: str | None = None,
-    env: dict[str, str] | None = None,
+    env: Mapping[str, str] | None = None,
     pty_mode: bool = False,
     heartbeat_record_types: frozenset[str] = frozenset({"result"}),
     session_log_dir: Path | None = None,
@@ -322,7 +323,7 @@ def run_managed_sync(
     cwd: Path | None,
     timeout: float,
     input_data: str | None = None,
-    env: dict[str, str] | None = None,
+    env: Mapping[str, str] | None = None,
 ) -> SubprocessResult:
     """Sync subprocess execution with temp file I/O and process tree cleanup.
 
@@ -398,7 +399,7 @@ class DefaultSubprocessRunner:
         *,
         cwd: Path,
         timeout: float,
-        env: dict[str, str] | None = None,
+        env: Mapping[str, str] | None = None,
         stale_threshold: float = 1200,
         completion_marker: str = "",
         session_log_dir: Path | None = None,

--- a/src/autoskillit/execution/recording.py
+++ b/src/autoskillit/execution/recording.py
@@ -7,6 +7,7 @@ import atexit
 import shutil
 import tempfile
 from collections import deque
+from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -30,23 +31,6 @@ REPLAY_SCENARIO_DIR_ENV = "REPLAY_SCENARIO_DIR"
 
 class ScenarioReplayError(Exception):
     """Raised when scenario replay cannot find a session or result for a step."""
-
-
-def _extract_env_and_args(cmd: list[str]) -> tuple[dict[str, str], list[str]]:
-    """Parse ``["env", "K=V", ..., "program", ...]`` into (env_dict, clean_args).
-
-    If *cmd* does not start with ``"env"``, returns ``({}, cmd)``.
-    """
-    if not cmd or cmd[0] != "env":
-        return {}, list(cmd)
-
-    env_dict: dict[str, str] = {}
-    i = 1
-    while i < len(cmd) and "=" in cmd[i]:
-        key, _, val = cmd[i].partition("=")
-        env_dict[key] = val
-        i += 1
-    return env_dict, cmd[i:]
 
 
 def _extract_model(args: list[str]) -> str:
@@ -93,7 +77,7 @@ class RecordingSubprocessRunner(SubprocessRunner):
         *,
         cwd: Path,
         timeout: float,
-        env: dict[str, str] | None = None,
+        env: Mapping[str, str] | None = None,
         stale_threshold: float = 1200,
         completion_marker: str = "",
         session_log_dir: Path | None = None,
@@ -102,15 +86,13 @@ class RecordingSubprocessRunner(SubprocessRunner):
         completion_drain_timeout: float = 5.0,
         linux_tracing_config: Any | None = None,
     ) -> SubprocessResult:
-        env_dict, clean_args = _extract_env_and_args(cmd)
-        step_name = env_dict.get(SCENARIO_STEP_NAME_ENV, "")
+        step_name = (env or {}).get(SCENARIO_STEP_NAME_ENV, "")
 
         if pty_mode and step_name:
             return await self._record_session(
                 cmd=cmd,
-                clean_args=clean_args,
                 step_name=step_name,
-                model=_extract_model(clean_args),
+                model=_extract_model(cmd),
                 session_log_dir=session_log_dir,
             )
 
@@ -144,7 +126,6 @@ class RecordingSubprocessRunner(SubprocessRunner):
         self,
         *,
         cmd: list[str],
-        clean_args: list[str],
         step_name: str,
         model: str,
         session_log_dir: Path | None,
@@ -155,7 +136,7 @@ class RecordingSubprocessRunner(SubprocessRunner):
                 self.recorder.record_step,
                 step_name=step_name,
                 tool="run_skill",
-                args=clean_args,
+                args=cmd,
                 model=model,
                 session_log_dir=str(session_log_dir) if session_log_dir else None,
             )
@@ -206,7 +187,7 @@ class ReplayingSubprocessRunner(SubprocessRunner):
         *,
         cwd: Path,
         timeout: float,
-        env: dict[str, str] | None = None,
+        env: Mapping[str, str] | None = None,
         stale_threshold: float = 1200,
         completion_marker: str = "",
         session_log_dir: Path | None = None,
@@ -215,11 +196,10 @@ class ReplayingSubprocessRunner(SubprocessRunner):
         completion_drain_timeout: float = 5.0,
         linux_tracing_config: Any | None = None,
     ) -> SubprocessResult:
-        env_dict, _ = _extract_env_and_args(cmd)
-        step_name = env_dict.get(SCENARIO_STEP_NAME_ENV, "")
+        step_name = (env or {}).get(SCENARIO_STEP_NAME_ENV, "")
 
         if not step_name:
-            raise ValueError(f"SCENARIO_STEP_NAME not found in cmd env prefix: {cmd!r}")
+            raise ValueError(f"SCENARIO_STEP_NAME not found in env kwarg for cmd: {cmd!r}")
 
         self.call_log.append((step_name, cmd))
 

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -99,6 +99,7 @@ _SINGLETON_SAFE_CALL_NAMES: frozenset[str] = frozenset(
         "version",
         "compile",
         "object",
+        "MappingProxyType",  # types.MappingProxyType — read-only view, no state
     }
 )
 
@@ -657,7 +658,9 @@ def test_no_subpackage_exceeds_10_files() -> None:
         prevent circular imports while keeping L0 types co-located. Also houses
         _terminal_table.py as the L0 shared terminal rendering primitive so that
         both cli/ (L3) and pipeline/ (L1) can import it without layer violations.
-        Exempt at 15 files.
+        _claude_env.py adds the canonical IDE-scrubbing env builder for all
+        claude subprocess launches.
+        Exempt at 16 files.
       cli/ — REQ-CNST-003-E5: cli/ retains _terminal_table.py as a re-export shim
         for backward-compatible cli/ imports; canonical implementation lives in
         core/_terminal_table.py. Also contains _terminal.py — the terminal state
@@ -675,7 +678,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "server": 17,
         "recipe": 30,
         "execution": 25,
-        "core": 15,
+        "core": 16,
         "cli": 16,
         "hooks": 14,
     }

--- a/tests/cli/test_cook_env_scrub.py
+++ b/tests/cli/test_cook_env_scrub.py
@@ -1,0 +1,102 @@
+"""Launch-site env-scrub contract tests for _launch_cook_session and cook().
+
+Each test monkeypatches ``CLAUDE_CODE_SSE_PORT`` and ``ENABLE_IDE_INTEGRATION``
+into the parent env, drives the launch site with ``subprocess.run`` patched,
+and asserts the captured ``env`` kwarg does not contain the IDE discovery
+variables and does contain the auto-connect suppressor.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def test_launch_cook_session_env_excludes_ide_vars(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("CLAUDE_CODE_SSE_PORT", "23270")
+    monkeypatch.setenv("ENABLE_IDE_INTEGRATION", "true")
+    monkeypatch.setenv("VSCODE_GIT_ASKPASS_MAIN", "/fake/vscode")
+    monkeypatch.setenv("CLAUDE_CODE_IDE_HOST_OVERRIDE", "host")
+
+    from autoskillit.cli.app import _launch_cook_session
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/claude"),
+        patch(
+            "autoskillit.cli.app.subprocess.run",
+            return_value=MagicMock(returncode=0),
+        ) as mock_run,
+        patch("autoskillit.cli.app.terminal_guard"),
+    ):
+        _launch_cook_session("system prompt", initial_message="hello")
+
+    assert mock_run.call_args is not None
+    env = mock_run.call_args.kwargs["env"]
+    assert "CLAUDE_CODE_SSE_PORT" not in env
+    assert "ENABLE_IDE_INTEGRATION" not in env
+    assert "VSCODE_GIT_ASKPASS_MAIN" not in env
+    assert "CLAUDE_CODE_IDE_HOST_OVERRIDE" not in env
+    assert env["CLAUDE_CODE_AUTO_CONNECT_IDE"] == "0"
+
+
+def test_launch_cook_session_extra_env_still_applied(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("CLAUDE_CODE_SSE_PORT", "23270")
+
+    from autoskillit.cli.app import _launch_cook_session
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/claude"),
+        patch(
+            "autoskillit.cli.app.subprocess.run",
+            return_value=MagicMock(returncode=0),
+        ) as mock_run,
+        patch("autoskillit.cli.app.terminal_guard"),
+    ):
+        _launch_cook_session(
+            "system prompt",
+            extra_env={"AUTOSKILLIT_SUBSETS__DISABLED": "@json []"},
+        )
+
+    env = mock_run.call_args.kwargs["env"]
+    assert env["AUTOSKILLIT_SUBSETS__DISABLED"] == "@json []"
+    assert "CLAUDE_CODE_SSE_PORT" not in env
+
+
+def test_cook_command_env_excludes_ide_vars(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("CLAUDE_CODE_SSE_PORT", "23270")
+    monkeypatch.setenv("ENABLE_IDE_INTEGRATION", "true")
+    monkeypatch.chdir(tmp_path)
+
+    fake_skills_dir = tmp_path / "skills"
+    fake_skills_dir.mkdir()
+    mock_mgr = MagicMock()
+    mock_mgr.init_session.return_value = fake_skills_dir
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/claude"),
+        patch("builtins.input", return_value=""),
+        patch("sys.stdin.isatty", return_value=True),
+        patch("autoskillit.workspace.DefaultSessionSkillManager", return_value=mock_mgr),
+        patch(
+            "autoskillit.cli._cook.subprocess.run",
+            return_value=MagicMock(returncode=0),
+        ) as mock_run,
+        patch("autoskillit.cli._cook.terminal_guard"),
+    ):
+        from autoskillit.cli._cook import cook
+
+        cook()
+
+    assert mock_run.call_args is not None
+    env = mock_run.call_args.kwargs["env"]
+    assert "CLAUDE_CODE_SSE_PORT" not in env
+    assert "ENABLE_IDE_INTEGRATION" not in env
+    assert env["CLAUDE_CODE_AUTO_CONNECT_IDE"] == "0"

--- a/tests/cli/test_cook_ide_isolation.py
+++ b/tests/cli/test_cook_ide_isolation.py
@@ -1,0 +1,90 @@
+"""End-to-end regression canary: _launch_cook_session under simulated IDE state.
+
+This test encodes the exact scenario the ide-env-leak investigation reproduced:
+VS Code (or any IDE) has ``CLAUDE_CODE_SSE_PORT`` set and an active
+``~/.claude/ide/$PORT.lock`` file. When autoskillit launches the cook session,
+the child must NOT attach to the IDE channel via either discovery path:
+
+1. **Env scrub** — ``CLAUDE_CODE_SSE_PORT`` and the expanded IDE denylist are
+   stripped from the child env.
+2. **Auto-connect disable** — ``CLAUDE_CODE_AUTO_CONNECT_IDE=0`` is injected,
+   which suppresses the ``~/.claude/ide/*.lock`` scan fallback that fires even
+   when no IDE env vars are set.
+3. **Lock file is not opened** by the parent process between the builder call
+   and the subprocess spawn. Env scrub alone cannot catch a lock-file-scan
+   regression; this is the additional assertion that locks the immunity claim.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def test_cook_session_ignores_ide_lock_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Launch cook under simulated IDE state; assert the three-layer immunity."""
+    fake_home = tmp_path / "home"
+    ide_dir = fake_home / ".claude" / "ide"
+    ide_dir.mkdir(parents=True)
+    lock_file = ide_dir / "65535.lock"
+    lock_file.write_text('{"pid": 1, "transport": "ws"}')
+
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("CLAUDE_CODE_SSE_PORT", "65535")
+    monkeypatch.setenv("ENABLE_IDE_INTEGRATION", "1")
+    monkeypatch.setenv("VSCODE_GIT_ASKPASS_MAIN", "/fake/vscode")
+    monkeypatch.setenv("CLAUDE_CODE_IDE_HOST_OVERRIDE", "localhost")
+
+    # Wrap Path.open so any parent-process touch of the IDE lock path is
+    # detectable. We count reads against the exact lock_file path object.
+    lock_touches = {"count": 0}
+    real_path_open = Path.open
+    resolved_lock = lock_file.resolve()
+
+    def tracking_open(self: Path, *args: object, **kwargs: object) -> object:
+        try:
+            if self.resolve() == resolved_lock:
+                lock_touches["count"] += 1
+        except OSError:
+            pass
+        return real_path_open(self, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "open", tracking_open)
+
+    from autoskillit.cli.app import _launch_cook_session
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/claude"),
+        patch(
+            "autoskillit.cli.app.subprocess.run",
+            return_value=MagicMock(returncode=0),
+        ) as mock_run,
+        patch("autoskillit.cli.app.terminal_guard"),
+    ):
+        _launch_cook_session("system prompt", initial_message="hello")
+
+    # (1) Env scrub
+    env = mock_run.call_args.kwargs["env"]
+    assert "CLAUDE_CODE_SSE_PORT" not in env
+    assert "ENABLE_IDE_INTEGRATION" not in env
+    assert "VSCODE_GIT_ASKPASS_MAIN" not in env
+    assert "CLAUDE_CODE_IDE_HOST_OVERRIDE" not in env
+
+    # (2) Auto-connect suppressor
+    assert env["CLAUDE_CODE_AUTO_CONNECT_IDE"] == "0"
+
+    # (3) Parent process must NOT open the IDE lock file during session build.
+    assert lock_touches["count"] == 0, (
+        f"IDE lock file was opened {lock_touches['count']} time(s) by the parent "
+        "process between build_claude_env() and subprocess.run. This indicates a "
+        "regression in the lock-file-scan discovery path that env scrub alone "
+        "cannot catch."
+    )
+
+    # Argv must no longer carry a leading ['env', ...] prefix.
+    cmd = mock_run.call_args.args[0]
+    assert cmd[0] == "claude"

--- a/tests/cli/test_cook_ide_isolation.py
+++ b/tests/cli/test_cook_ide_isolation.py
@@ -10,9 +10,6 @@ the child must NOT attach to the IDE channel via either discovery path:
 2. **Auto-connect disable** — ``CLAUDE_CODE_AUTO_CONNECT_IDE=0`` is injected,
    which suppresses the ``~/.claude/ide/*.lock`` scan fallback that fires even
    when no IDE env vars are set.
-3. **Lock file is not opened** by the parent process between the builder call
-   and the subprocess spawn. Env scrub alone cannot catch a lock-file-scan
-   regression; this is the additional assertion that locks the immunity claim.
 """
 
 from __future__ import annotations
@@ -26,7 +23,7 @@ import pytest
 def test_cook_session_ignores_ide_lock_file(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """Launch cook under simulated IDE state; assert the three-layer immunity."""
+    """Launch cook under simulated IDE state; assert env scrub + auto-connect disable."""
     fake_home = tmp_path / "home"
     ide_dir = fake_home / ".claude" / "ide"
     ide_dir.mkdir(parents=True)
@@ -38,22 +35,6 @@ def test_cook_session_ignores_ide_lock_file(
     monkeypatch.setenv("ENABLE_IDE_INTEGRATION", "1")
     monkeypatch.setenv("VSCODE_GIT_ASKPASS_MAIN", "/fake/vscode")
     monkeypatch.setenv("CLAUDE_CODE_IDE_HOST_OVERRIDE", "localhost")
-
-    # Wrap Path.open so any parent-process touch of the IDE lock path is
-    # detectable. We count reads against the exact lock_file path object.
-    lock_touches = {"count": 0}
-    real_path_open = Path.open
-    resolved_lock = lock_file.resolve()
-
-    def tracking_open(self: Path, *args: object, **kwargs: object) -> object:
-        try:
-            if self.resolve() == resolved_lock:
-                lock_touches["count"] += 1
-        except OSError:
-            pass
-        return real_path_open(self, *args, **kwargs)  # type: ignore[arg-type]
-
-    monkeypatch.setattr(Path, "open", tracking_open)
 
     from autoskillit.cli.app import _launch_cook_session
 
@@ -76,14 +57,6 @@ def test_cook_session_ignores_ide_lock_file(
 
     # (2) Auto-connect suppressor
     assert env["CLAUDE_CODE_AUTO_CONNECT_IDE"] == "0"
-
-    # (3) Parent process must NOT open the IDE lock file during session build.
-    assert lock_touches["count"] == 0, (
-        f"IDE lock file was opened {lock_touches['count']} time(s) by the parent "
-        "process between build_claude_env() and subprocess.run. This indicates a "
-        "regression in the lock-file-scan discovery path that env scrub alone "
-        "cannot catch."
-    )
 
     # Argv must no longer carry a leading ['env', ...] prefix.
     cmd = mock_run.call_args.args[0]

--- a/tests/cli/test_subprocess_env_contracts.py
+++ b/tests/cli/test_subprocess_env_contracts.py
@@ -11,6 +11,13 @@ Contract: each call site must satisfy BOTH conditions:
      same source file, confirming the env dict is built from the guard (the variable
      pattern ``_skip_env = {**os.environ, "AUTOSKILLIT_SKIP_STALE_CHECK": "1"}``
      satisfies this without requiring the literal to appear inside the call expression).
+
+Also contains ``test_no_raw_claude_env``: the sibling rule for claude-launching
+subprocess calls. Every claude-launching site must route its env through
+:func:`autoskillit.core.build_claude_env` (via ``spec.env`` from a
+``Claude*Cmd`` dataclass, or via a direct builder call). The rule bans
+``env={**os.environ, ...}``, ``env=os.environ``, ``env=None``, missing ``env=``,
+and ``env=<literal dict>`` at every claude-launching site.
 """
 
 from __future__ import annotations
@@ -21,7 +28,16 @@ from pathlib import Path
 import pytest
 
 CLI_ROOT = Path(__file__).parents[2] / "src" / "autoskillit" / "cli"
+SRC_ROOT = Path(__file__).parents[2] / "src" / "autoskillit"
 REQUIRED_GUARD = "AUTOSKILLIT_SKIP_STALE_CHECK"
+
+_CLAUDE_BUILDER_NAMES = frozenset(
+    {
+        "build_interactive_cmd",
+        "build_headless_cmd",
+        "build_full_headless_cmd",
+    }
+)
 
 
 def _collect_autoskillit_subprocess_calls(source: str) -> list[tuple[int, str, bool]]:
@@ -195,4 +211,222 @@ def test_source_drift_all_subprocess_calls_have_env_kwarg() -> None:
     # File-level: must define both guard env vars
     assert DRIFT_GUARD in content, (
         f"_source_drift.py must define '{DRIFT_GUARD}' in its _skip_env dict"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Sibling rule: claude-launching subprocess calls must route env through
+# build_claude_env() — enforced via intra-function AST walk.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _call_func_name(func: ast.AST) -> str:
+    """Return the simple/qualified name of a Call's .func expression (best-effort)."""
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return ""
+
+
+def _is_claude_builder_call(node: ast.AST) -> bool:
+    """True if *node* is a call to any claude command builder."""
+    if not isinstance(node, ast.Call):
+        return False
+    return _call_func_name(node.func) in _CLAUDE_BUILDER_NAMES
+
+
+def _is_literal_claude_list(node: ast.AST) -> bool:
+    """True if *node* is a literal list whose first element is the string 'claude'."""
+    if not isinstance(node, ast.List) or not node.elts:
+        return False
+    first = node.elts[0]
+    return isinstance(first, ast.Constant) and first.value == "claude"
+
+
+class _ClaudeLaunchWalker:
+    """Per-function walker: tracks single-assignment symbol table for a FunctionDef.
+
+    Detects claude-launching call patterns on the first positional or ``cmd=``
+    kwarg and verifies the ``env=`` kwarg shape is one of:
+
+    - ``Attribute(value=Name, attr="env")`` where Name was assigned from a
+      ``build_interactive_cmd``/``build_headless_cmd``/``build_full_headless_cmd``
+      call earlier in the same function body (spec.env pattern).
+    - ``Call(func=Name("build_claude_env") | Attribute(..., "build_claude_env"))``
+      (direct builder escape hatch).
+    """
+
+    def __init__(self, func_node: ast.AST, path: Path) -> None:
+        self.func_node = func_node
+        self.path = path
+        # Name -> most recent assigned value (single-assignment tracker).
+        self._bindings: dict[str, ast.expr] = {}
+        self.violations: list[str] = []
+
+    def walk(self) -> None:
+        for stmt in ast.walk(self.func_node):
+            # Track simple assignments first so calls later in the body can resolve.
+            if isinstance(stmt, ast.Assign) and len(stmt.targets) == 1:
+                target = stmt.targets[0]
+                if isinstance(target, ast.Name):
+                    self._bindings[target.id] = stmt.value
+            elif isinstance(stmt, ast.AnnAssign) and stmt.value is not None:
+                if isinstance(stmt.target, ast.Name):
+                    self._bindings[stmt.target.id] = stmt.value
+            elif isinstance(stmt, ast.Call):
+                self._check_call(stmt)
+
+    def _resolve_name(self, node: ast.AST) -> ast.expr | None:
+        """Follow a Name through one level of assignment; return the bound value or None."""
+        if isinstance(node, ast.Name) and node.id in self._bindings:
+            return self._bindings[node.id]
+        return None
+
+    def _cmd_is_claude_launching(self, cmd_arg: ast.AST) -> bool:
+        """True if *cmd_arg* refers to a claude-launching argv (via spec or literal)."""
+        # Direct literal: ["claude", ...]
+        if _is_literal_claude_list(cmd_arg):
+            return True
+
+        # spec.cmd attribute access where spec was assigned from a builder.
+        if isinstance(cmd_arg, ast.Attribute) and cmd_arg.attr == "cmd":
+            bound = self._resolve_name(cmd_arg.value)
+            if bound is not None and _is_claude_builder_call(bound):
+                return True
+
+        # Name: resolve one level.
+        if isinstance(cmd_arg, ast.Name):
+            bound = self._resolve_name(cmd_arg)
+            if bound is None:
+                return False
+            # cmd = ["claude", ...]
+            if _is_literal_claude_list(bound):
+                return True
+            # cmd = spec.cmd (+ [...])  or  cmd = spec.cmd
+            if isinstance(bound, ast.Attribute) and bound.attr == "cmd":
+                return self._cmd_is_claude_launching(bound)
+            if isinstance(bound, ast.BinOp) and isinstance(bound.op, ast.Add):
+                return self._cmd_is_claude_launching(bound.left) or self._cmd_is_claude_launching(
+                    bound.right
+                )
+            # cmd = spec_result_of_builder  → treat attribute .cmd the same way
+            if _is_claude_builder_call(bound):
+                return True
+
+        # cmd = spec.cmd + [...] passed inline as BinOp.
+        if isinstance(cmd_arg, ast.BinOp) and isinstance(cmd_arg.op, ast.Add):
+            return self._cmd_is_claude_launching(cmd_arg.left) or self._cmd_is_claude_launching(
+                cmd_arg.right
+            )
+
+        return False
+
+    @staticmethod
+    def _cmd_arg_of(call: ast.Call) -> ast.AST | None:
+        """Return the claude argv argument: first positional, or cmd= kwarg."""
+        if call.args:
+            return call.args[0]
+        for kw in call.keywords:
+            if kw.arg == "cmd":
+                return kw.value
+        return None
+
+    @staticmethod
+    def _env_kwarg(call: ast.Call) -> ast.expr | None:
+        for kw in call.keywords:
+            if kw.arg == "env":
+                return kw.value
+        return None
+
+    def _env_shape_ok(self, env_val: ast.expr | None) -> tuple[bool, str]:
+        if env_val is None:
+            return False, "missing env= kwarg"
+        if isinstance(env_val, ast.Constant) and env_val.value is None:
+            return False, "env=None is not allowed"
+        if isinstance(env_val, ast.Dict):
+            # env={**os.environ, ...} or env={"K": "V"} — both are banned.
+            return False, "env=<literal dict> is not allowed"
+        if isinstance(env_val, ast.Attribute):
+            # env=os.environ
+            if (
+                isinstance(env_val.value, ast.Name)
+                and env_val.value.id == "os"
+                and env_val.attr == "environ"
+            ):
+                return False, "env=os.environ is not allowed"
+            # env=spec.env / env=foo.env
+            if env_val.attr == "env":
+                return True, ""
+        if isinstance(env_val, ast.Call):
+            fn = _call_func_name(env_val.func)
+            if fn == "build_claude_env":
+                return True, ""
+        if isinstance(env_val, ast.Name):
+            # Parameter / local re-binding: rely on the function owning it to pass
+            # a scrubbed env. This escape hatch is narrow — direct os.environ bindings
+            # would already be visible as a Dict/Attribute at the call site.
+            return True, ""
+        return False, f"env= has unrecognised shape: {ast.dump(env_val)[:60]}"
+
+    def _check_call(self, call: ast.Call) -> None:
+        cmd_arg = self._cmd_arg_of(call)
+        if cmd_arg is None:
+            return
+        if not self._cmd_is_claude_launching(cmd_arg):
+            return
+        env_val = self._env_kwarg(call)
+        ok, reason = self._env_shape_ok(env_val)
+        if not ok:
+            rel = self.path.relative_to(SRC_ROOT.parents[1])
+            self.violations.append(
+                f"{rel}:{call.lineno}: claude-launching call at "
+                f"{_call_func_name(call.func) or '<anonymous>'}(...) — {reason}"
+            )
+
+
+# Allowlist: administrative ``claude plugin ...`` subprocess calls that are
+# plugin marketplace / registration operations, NOT skill sessions. They do
+# not present a tool surface to the model, so IDE-channel attach is not a
+# concern. Each entry is (filename, enclosing_function_name).
+#
+# Adding a new entry requires a comment justifying why the call cannot use
+# build_claude_env — matching the convention in
+# ``tests/arch/test_ast_rules.py::test_no_raw_claude_list_construction``.
+_CLAUDE_ENV_RULE_ALLOWED: frozenset[tuple[str, str]] = frozenset(
+    {
+        # doctor check: `claude plugin list` — read-only registration probe.
+        ("_doctor.py", "_check_mcp_server_registered"),
+        # onboarding probe: `claude plugin list` — read-only install check.
+        ("_init_helpers.py", "_is_plugin_installed"),
+        # marketplace registration + install: `claude plugin marketplace add` /
+        # `claude plugin install`. Administrative ops invoked once during setup.
+        ("_marketplace.py", "install"),
+    }
+)
+
+
+def test_no_raw_claude_env() -> None:
+    """Every claude-launching subprocess call must route env through build_claude_env()."""
+    if not SRC_ROOT.is_dir():
+        pytest.skip("Source tree unavailable")
+
+    violations: list[str] = []
+    for py_file in sorted(SRC_ROOT.rglob("*.py")):
+        try:
+            tree = ast.parse(py_file.read_text(encoding="utf-8"))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if (py_file.name, node.name) in _CLAUDE_ENV_RULE_ALLOWED:
+                continue
+            walker = _ClaudeLaunchWalker(node, py_file)
+            walker.walk()
+            violations.extend(walker.violations)
+
+    assert not violations, (
+        "Found claude-launching subprocess calls that bypass build_claude_env():\n"
+        + "\n".join(f"  {v}" for v in violations)
     )

--- a/tests/cli/test_subprocess_env_contracts.py
+++ b/tests/cli/test_subprocess_env_contracts.py
@@ -363,9 +363,12 @@ class _ClaudeLaunchWalker:
             if fn == "build_claude_env":
                 return True, ""
         if isinstance(env_val, ast.Name):
-            # Parameter / local re-binding: rely on the function owning it to pass
-            # a scrubbed env. This escape hatch is narrow — direct os.environ bindings
-            # would already be visible as a Dict/Attribute at the call site.
+            # Resolve one level of local binding to catch aliased os.environ.
+            bound = self._resolve_name(env_val)
+            if bound is not None:
+                return self._env_shape_ok(bound)
+            # Unresolvable name (parameter / outer scope): rely on the function
+            # owning it to pass a scrubbed env.
             return True, ""
         return False, f"env= has unrecognised shape: {ast.dump(env_val)[:60]}"
 

--- a/tests/core/test_claude_env.py
+++ b/tests/core/test_claude_env.py
@@ -1,0 +1,120 @@
+"""Unit tests for build_claude_env() — IDE env scrubbing at the subprocess launch boundary."""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+
+import pytest
+
+from autoskillit.core import build_claude_env
+from autoskillit.core._claude_env import (
+    IDE_ENV_ALWAYS_EXTRAS,
+    IDE_ENV_DENYLIST,
+    IDE_ENV_PREFIX_DENYLIST,
+)
+
+
+def test_build_claude_env_strips_sse_port() -> None:
+    base = {"CLAUDE_CODE_SSE_PORT": "23270", "HOME": "/tmp", "PATH": "/usr/bin"}
+    result = build_claude_env(base=base)
+    assert "CLAUDE_CODE_SSE_PORT" not in result
+    assert result["HOME"] == "/tmp"
+    assert result["PATH"] == "/usr/bin"
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "CLAUDE_CODE_IDE_HOST_OVERRIDE",
+        "CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL",
+        "CLAUDE_CODE_IDE_SKIP_VALID_CHECK",
+        "CLAUDE_CODE_SSE_TOKEN",
+        "CLAUDE_CODE_SSE_HOST",
+    ],
+)
+def test_build_claude_env_strips_ide_prefix(key: str) -> None:
+    result = build_claude_env(base={key: "value", "HOME": "/tmp"})
+    assert key not in result
+    assert "HOME" in result
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "CLAUDE_CODE_SSE_PORT",
+        "ENABLE_IDE_INTEGRATION",
+        "CLAUDE_CODE_WEBSOCKET_AUTH_FILE_DESCRIPTOR",
+        "VSCODE_GIT_ASKPASS_MAIN",
+        "CURSOR_TRACE_ID",
+        "ZED_TERM",
+    ],
+)
+def test_build_claude_env_strips_expanded_denylist(key: str) -> None:
+    result = build_claude_env(base={key: "value", "HOME": "/tmp"})
+    assert key not in result
+    assert "HOME" in result
+
+
+def test_build_claude_env_preserves_unrelated_claude_vars() -> None:
+    base = {
+        "CLAUDE_CONFIG_DIR": "/home/user/.claude",
+        "ANTHROPIC_API_KEY": "sk-...",
+        "ANTHROPIC_LOG": "debug",
+    }
+    result = build_claude_env(base=base)
+    assert result["CLAUDE_CONFIG_DIR"] == "/home/user/.claude"
+    assert result["ANTHROPIC_API_KEY"] == "sk-..."
+    assert result["ANTHROPIC_LOG"] == "debug"
+
+
+def test_build_claude_env_injects_auto_connect_off() -> None:
+    result = build_claude_env(base={})
+    assert result["CLAUDE_CODE_AUTO_CONNECT_IDE"] == "0"
+
+
+def test_build_claude_env_caller_extras_can_override_auto_connect() -> None:
+    result = build_claude_env(base={}, extras={"CLAUDE_CODE_AUTO_CONNECT_IDE": "1"})
+    assert result["CLAUDE_CODE_AUTO_CONNECT_IDE"] == "1"
+
+
+def test_build_claude_env_applies_extras() -> None:
+    result = build_claude_env(base={}, extras={"AUTOSKILLIT_HEADLESS": "1"})
+    assert result["AUTOSKILLIT_HEADLESS"] == "1"
+
+
+def test_build_claude_env_extras_override_base() -> None:
+    result = build_claude_env(base={"FOO": "original"}, extras={"FOO": "overridden"})
+    assert result["FOO"] == "overridden"
+
+
+def test_build_claude_env_defaults_to_os_environ(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AUTOSKILLIT_TEST_DEFAULT_ENV_MARKER", "present")
+    monkeypatch.setenv("CLAUDE_CODE_SSE_PORT", "23270")
+    result = build_claude_env()
+    assert result.get("AUTOSKILLIT_TEST_DEFAULT_ENV_MARKER") == "present"
+    assert "CLAUDE_CODE_SSE_PORT" not in result
+
+
+def test_build_claude_env_returns_mappingproxy() -> None:
+    result = build_claude_env(base={"HOME": "/tmp"})
+    assert isinstance(result, MappingProxyType)
+    with pytest.raises(TypeError):
+        result["X"] = "Y"  # type: ignore[index]
+
+
+def test_ide_env_denylist_contains_expected_names() -> None:
+    assert "CLAUDE_CODE_SSE_PORT" in IDE_ENV_DENYLIST
+    assert "ENABLE_IDE_INTEGRATION" in IDE_ENV_DENYLIST
+    assert "CLAUDE_CODE_WEBSOCKET_AUTH_FILE_DESCRIPTOR" in IDE_ENV_DENYLIST
+    assert "VSCODE_GIT_ASKPASS_MAIN" in IDE_ENV_DENYLIST
+    assert "CURSOR_TRACE_ID" in IDE_ENV_DENYLIST
+    assert "ZED_TERM" in IDE_ENV_DENYLIST
+
+
+def test_ide_env_prefix_denylist_covers_ide_and_sse() -> None:
+    assert "CLAUDE_CODE_IDE_" in IDE_ENV_PREFIX_DENYLIST
+    assert "CLAUDE_CODE_SSE" in IDE_ENV_PREFIX_DENYLIST
+
+
+def test_ide_env_always_extras_includes_auto_connect_off() -> None:
+    assert IDE_ENV_ALWAYS_EXTRAS["CLAUDE_CODE_AUTO_CONNECT_IDE"] == "0"

--- a/tests/execution/test_commands.py
+++ b/tests/execution/test_commands.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from autoskillit.core import ClaudeFlags
 from autoskillit.execution.commands import (
     ClaudeHeadlessCmd,
@@ -35,9 +37,18 @@ class TestBuildInteractiveCmd:
         result = build_interactive_cmd()
         assert result.cmd[0] == "claude"
 
-    def test_env_is_empty(self) -> None:
+    def test_env_is_populated_and_scrubbed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CLAUDE_CODE_SSE_PORT", "23270")
+        monkeypatch.setenv("HOME", "/tmp/home")
         result = build_interactive_cmd()
-        assert result.env == {}
+        assert "CLAUDE_CODE_SSE_PORT" not in result.env
+        assert result.env.get("HOME") == "/tmp/home"
+        assert result.env["CLAUDE_CODE_AUTO_CONNECT_IDE"] == "0"
+
+    def test_env_strips_sse_port(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CLAUDE_CODE_SSE_PORT", "23270")
+        result = build_interactive_cmd()
+        assert "CLAUDE_CODE_SSE_PORT" not in result.env
 
     def test_accepts_model(self) -> None:
         result = build_interactive_cmd(model="claude-opus-4-6")
@@ -143,9 +154,18 @@ class TestBuildHeadlessCmd:
         result = build_headless_cmd("some prompt")
         assert ClaudeFlags.ALLOW_DANGEROUSLY_SKIP_PERMISSIONS not in result.cmd
 
-    def test_env_is_empty(self) -> None:
+    def test_env_is_populated_and_scrubbed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CLAUDE_CODE_SSE_PORT", "23270")
+        monkeypatch.setenv("HOME", "/tmp/home")
         result = build_headless_cmd("some prompt")
-        assert result.env == {}
+        assert "CLAUDE_CODE_SSE_PORT" not in result.env
+        assert result.env.get("HOME") == "/tmp/home"
+        assert result.env["CLAUDE_CODE_AUTO_CONNECT_IDE"] == "0"
+
+    def test_env_strips_sse_port(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CLAUDE_CODE_SSE_PORT", "23270")
+        result = build_headless_cmd("some prompt")
+        assert "CLAUDE_CODE_SSE_PORT" not in result.env
 
     def test_accepts_model(self) -> None:
         result = build_headless_cmd("some prompt", model="claude-sonnet-4-6")
@@ -166,82 +186,106 @@ class TestBuildFullHeadlessCmd:
         exit_after_stop_delay_ms=120000,
     )
 
-    def test_env_prefix_present(self):
-        """cmd must start with ['env', 'AUTOSKILLIT_HEADLESS=1', ...]"""
-        cmd = build_full_headless_cmd("/investigate foo", **self.BASE)
-        assert cmd[0] == "env"
-        assert "AUTOSKILLIT_HEADLESS=1" in cmd
+    def test_returns_claude_headless_cmd(self):
+        spec = build_full_headless_cmd("/investigate foo", **self.BASE)
+        assert isinstance(spec, ClaudeHeadlessCmd)
 
-    def test_exit_delay_appended_when_positive(self):
-        cmd = build_full_headless_cmd("/investigate foo", **self.BASE)
-        assert "CLAUDE_CODE_EXIT_AFTER_STOP_DELAY=120000" in cmd
+    def test_cmd_starts_with_claude_not_env(self):
+        """Argv no longer carries a leading ['env', ...] prefix."""
+        spec = build_full_headless_cmd("/investigate foo", **self.BASE)
+        assert spec.cmd[0] == "claude"
+        assert "env" != spec.cmd[0]
+        assert not any(tok.startswith("AUTOSKILLIT_HEADLESS=") for tok in spec.cmd)
+        assert not any(tok.startswith("CLAUDE_CODE_EXIT_AFTER_STOP_DELAY=") for tok in spec.cmd)
+        assert not any(tok.startswith("SCENARIO_STEP_NAME=") for tok in spec.cmd)
 
-    def test_exit_delay_omitted_when_zero(self):
+    def test_env_has_autoskillit_headless(self):
+        """AUTOSKILLIT_HEADLESS=1 now lives on spec.env, not in argv."""
+        spec = build_full_headless_cmd("/investigate foo", **self.BASE)
+        assert spec.env["AUTOSKILLIT_HEADLESS"] == "1"
+
+    def test_env_has_exit_delay_when_positive(self):
+        spec = build_full_headless_cmd("/investigate foo", **self.BASE)
+        assert spec.env["CLAUDE_CODE_EXIT_AFTER_STOP_DELAY"] == "120000"
+
+    def test_env_omits_exit_delay_when_zero(self):
         params = {**self.BASE, "exit_after_stop_delay_ms": 0}
-        cmd = build_full_headless_cmd("/investigate foo", **params)
-        assert not any("CLAUDE_CODE_EXIT_AFTER_STOP_DELAY" in s for s in cmd)
+        spec = build_full_headless_cmd("/investigate foo", **params)
+        assert "CLAUDE_CODE_EXIT_AFTER_STOP_DELAY" not in spec.env
+
+    def test_env_strips_sse_port(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CLAUDE_CODE_SSE_PORT", "23270")
+        spec = build_full_headless_cmd("/investigate foo", **self.BASE)
+        assert "CLAUDE_CODE_SSE_PORT" not in spec.env
+
+    def test_env_has_auto_connect_off(self):
+        spec = build_full_headless_cmd("/investigate foo", **self.BASE)
+        assert spec.env["CLAUDE_CODE_AUTO_CONNECT_IDE"] == "0"
 
     def test_plugin_dir_present(self):
-        cmd = build_full_headless_cmd("/investigate foo", **self.BASE)
-        assert "--plugin-dir" in cmd
-        idx = cmd.index("--plugin-dir")
-        assert cmd[idx + 1] == "/plugins"
+        spec = build_full_headless_cmd("/investigate foo", **self.BASE)
+        assert "--plugin-dir" in spec.cmd
+        idx = spec.cmd.index("--plugin-dir")
+        assert spec.cmd[idx + 1] == "/plugins"
 
     def test_output_format_present(self):
-        cmd = build_full_headless_cmd("/investigate foo", **self.BASE)
-        assert "--output-format" in cmd
-        idx = cmd.index("--output-format")
-        assert cmd[idx + 1] == "stream-json"
+        spec = build_full_headless_cmd("/investigate foo", **self.BASE)
+        assert "--output-format" in spec.cmd
+        idx = spec.cmd.index("--output-format")
+        assert spec.cmd[idx + 1] == "stream-json"
 
     def test_output_format_required_flags_appended(self):
-        cmd = build_full_headless_cmd("/investigate foo", **self.BASE)
-        assert "--verbose" in cmd
+        spec = build_full_headless_cmd("/investigate foo", **self.BASE)
+        assert "--verbose" in spec.cmd
 
     def test_output_format_required_flags_not_duplicated(self):
         """If a required flag is already present it must not be added twice."""
         params = {**self.BASE, "output_format_required_flags": ["--output-format"]}
-        cmd = build_full_headless_cmd("/investigate foo", **params)
-        assert cmd.count("--output-format") == 1
+        spec = build_full_headless_cmd("/investigate foo", **params)
+        assert spec.cmd.count("--output-format") == 1
 
     def test_add_dirs_injected(self):
         from autoskillit.core import ValidatedAddDir
 
         d = ValidatedAddDir(path="/skills/custom")
         params = {**self.BASE, "add_dirs": [d]}
-        cmd = build_full_headless_cmd("/investigate foo", **params)
-        assert "--add-dir" in cmd
-        idx = cmd.index("--add-dir")
-        assert cmd[idx + 1] == "/skills/custom"
+        spec = build_full_headless_cmd("/investigate foo", **params)
+        assert "--add-dir" in spec.cmd
+        idx = spec.cmd.index("--add-dir")
+        assert spec.cmd[idx + 1] == "/skills/custom"
 
     def test_no_add_dirs_emits_no_flag(self):
-        cmd = build_full_headless_cmd("/investigate foo", **self.BASE)
-        assert "--add-dir" not in cmd
+        spec = build_full_headless_cmd("/investigate foo", **self.BASE)
+        assert "--add-dir" not in spec.cmd
 
     def test_skill_prefix_injected(self):
         """Slash commands must be prefixed with 'Use '."""
-        cmd = build_full_headless_cmd("/investigate foo", **self.BASE)
+        spec = build_full_headless_cmd("/investigate foo", **self.BASE)
+        cmd = spec.cmd
         prompt_idx = cmd.index("-p") + 1 if "-p" in cmd else cmd.index("--print") + 1
         assert cmd[prompt_idx].startswith("Use /investigate")
 
     def test_completion_marker_appended(self):
         """Completion directive must appear in the prompt."""
-        cmd = build_full_headless_cmd("/investigate foo", **self.BASE)
+        spec = build_full_headless_cmd("/investigate foo", **self.BASE)
+        cmd = spec.cmd
         prompt_idx = cmd.index("-p") + 1 if "-p" in cmd else cmd.index("--print") + 1
         assert "DONE" in cmd[prompt_idx]
 
     def test_cwd_anchor_appended(self):
         """Working-directory anchor must appear in the prompt."""
-        cmd = build_full_headless_cmd("/investigate foo", **self.BASE)
+        spec = build_full_headless_cmd("/investigate foo", **self.BASE)
+        cmd = spec.cmd
         prompt_idx = cmd.index("-p") + 1 if "-p" in cmd else cmd.index("--print") + 1
         assert "/repo" in cmd[prompt_idx]
 
     def test_model_injected_when_provided(self):
         params = {**self.BASE, "model": "claude-opus-4-6"}
-        cmd = build_full_headless_cmd("/investigate foo", **params)
-        assert "--model" in cmd
-        idx = cmd.index("--model")
-        assert cmd[idx + 1] == "claude-opus-4-6"
+        spec = build_full_headless_cmd("/investigate foo", **params)
+        assert "--model" in spec.cmd
+        idx = spec.cmd.index("--model")
+        assert spec.cmd[idx + 1] == "claude-opus-4-6"
 
     def test_model_omitted_when_none(self):
-        cmd = build_full_headless_cmd("/investigate foo", **self.BASE)
-        assert "--model" not in cmd
+        spec = build_full_headless_cmd("/investigate foo", **self.BASE)
+        assert "--model" not in spec.cmd

--- a/tests/execution/test_commands.py
+++ b/tests/execution/test_commands.py
@@ -45,11 +45,6 @@ class TestBuildInteractiveCmd:
         assert result.env.get("HOME") == "/tmp/home"
         assert result.env["CLAUDE_CODE_AUTO_CONNECT_IDE"] == "0"
 
-    def test_env_strips_sse_port(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("CLAUDE_CODE_SSE_PORT", "23270")
-        result = build_interactive_cmd()
-        assert "CLAUDE_CODE_SSE_PORT" not in result.env
-
     def test_accepts_model(self) -> None:
         result = build_interactive_cmd(model="claude-opus-4-6")
         assert ClaudeFlags.MODEL in result.cmd
@@ -161,11 +156,6 @@ class TestBuildHeadlessCmd:
         assert "CLAUDE_CODE_SSE_PORT" not in result.env
         assert result.env.get("HOME") == "/tmp/home"
         assert result.env["CLAUDE_CODE_AUTO_CONNECT_IDE"] == "0"
-
-    def test_env_strips_sse_port(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("CLAUDE_CODE_SSE_PORT", "23270")
-        result = build_headless_cmd("some prompt")
-        assert "CLAUDE_CODE_SSE_PORT" not in result.env
 
     def test_accepts_model(self) -> None:
         result = build_headless_cmd("some prompt", model="claude-sonnet-4-6")

--- a/tests/execution/test_headless_env_injection.py
+++ b/tests/execution/test_headless_env_injection.py
@@ -46,8 +46,11 @@ async def test_headless_command_includes_headless_env_var(tmp_path: Path) -> Non
     await run_headless_core("/investigate foo", str(tmp_path), ctx)
 
     assert mock_runner.call_args_list, "runner was never called"
-    cmd, *_ = mock_runner.call_args_list[0]
-    assert "AUTOSKILLIT_HEADLESS=1" in cmd, (
-        "run_headless_core must inject AUTOSKILLIT_HEADLESS=1 into the subprocess command "
+    cmd, _cwd, _timeout, kwargs = mock_runner.call_args_list[0]
+    env = kwargs.get("env")
+    assert env is not None
+    assert env["AUTOSKILLIT_HEADLESS"] == "1", (
+        "run_headless_core must inject AUTOSKILLIT_HEADLESS=1 via the env kwarg "
         "so PreToolUse hooks can identify headless sessions."
     )
+    assert cmd[0] != "env", "argv must no longer carry a leading ['env', ...] prefix"

--- a/tests/execution/test_headless_env_scrub.py
+++ b/tests/execution/test_headless_env_scrub.py
@@ -1,0 +1,45 @@
+"""Launch-site env-scrub contract test for run_headless_core.
+
+Asserts that ``CLAUDE_CODE_SSE_PORT`` and other IDE discovery vars are
+stripped from the env passed to the subprocess runner, and that the
+auto-connect suppressor is always present.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import MockSubprocessRunner, _make_result
+
+
+@pytest.mark.anyio
+async def test_run_headless_core_env_excludes_ide_vars(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("CLAUDE_CODE_SSE_PORT", "23270")
+    monkeypatch.setenv("ENABLE_IDE_INTEGRATION", "true")
+    monkeypatch.setenv("CLAUDE_CODE_IDE_HOST_OVERRIDE", "host")
+
+    from autoskillit.config import AutomationConfig
+    from autoskillit.execution.headless import run_headless_core
+    from autoskillit.pipeline import DefaultGateState
+    from autoskillit.server._factory import make_context
+
+    mock_runner = MockSubprocessRunner()
+    mock_runner.set_default(_make_result())
+    ctx = make_context(AutomationConfig(), runner=mock_runner, plugin_dir=str(tmp_path))
+    ctx.gate = DefaultGateState(enabled=True)
+
+    await run_headless_core("/investigate foo", str(tmp_path), ctx)
+
+    assert mock_runner.call_args_list, "runner was never called"
+    _cmd, _cwd, _timeout, kwargs = mock_runner.call_args_list[0]
+    env = kwargs.get("env")
+    assert env is not None
+    assert "CLAUDE_CODE_SSE_PORT" not in env
+    assert "ENABLE_IDE_INTEGRATION" not in env
+    assert "CLAUDE_CODE_IDE_HOST_OVERRIDE" not in env
+    assert env["CLAUDE_CODE_AUTO_CONNECT_IDE"] == "0"
+    assert env["AUTOSKILLIT_HEADLESS"] == "1"

--- a/tests/execution/test_recording.py
+++ b/tests/execution/test_recording.py
@@ -15,7 +15,6 @@ from autoskillit.execution.recording import (
     RecordingSubprocessRunner,
     ReplayingSubprocessRunner,
     ScenarioReplayError,
-    _extract_env_and_args,
     _extract_model,
 )
 from tests.conftest import MockSubprocessRunner, _make_result
@@ -64,7 +63,7 @@ def test_recording_runner_satisfies_protocol():
 
 @pytest.mark.anyio
 async def test_session_call_routes_to_record_step(tmp_path):
-    """pty_mode=True + SCENARIO_STEP_NAME → record_step(), not inner runner."""
+    """pty_mode=True + SCENARIO_STEP_NAME in env kwarg → record_step(), not inner runner."""
     mock_recorder = Mock()
     mock_recorder.record_step.return_value = FakeStepResult(
         cassette_exit_code=0,
@@ -74,18 +73,13 @@ async def test_session_call_routes_to_record_step(tmp_path):
     inner = MockSubprocessRunner()
     runner = RecordingSubprocessRunner(recorder=mock_recorder, inner=inner)
 
-    cmd = [
-        "env",
-        "AUTOSKILLIT_HEADLESS=1",
-        "SCENARIO_STEP_NAME=investigate",
-        "claude",
-        "--model",
-        "sonnet",
-        "--print",
-        "do stuff",
-    ]
+    cmd = ["claude", "--model", "sonnet", "--print", "do stuff"]
+    env = {
+        "AUTOSKILLIT_HEADLESS": "1",
+        "SCENARIO_STEP_NAME": "investigate",
+    }
 
-    result = await runner(cmd, cwd=Path("/tmp"), timeout=300, pty_mode=True)
+    result = await runner(cmd, cwd=Path("/tmp"), timeout=300, env=env, pty_mode=True)
 
     mock_recorder.record_step.assert_called_once_with(
         step_name="investigate",
@@ -110,9 +104,10 @@ async def test_non_session_call_delegates_and_records():
     inner.set_default(_make_result(returncode=0))
     runner = RecordingSubprocessRunner(recorder=mock_recorder, inner=inner)
 
-    cmd = ["env", "SCENARIO_STEP_NAME=test-check", "pytest", "tests/"]
+    cmd = ["pytest", "tests/"]
+    env = {"SCENARIO_STEP_NAME": "test-check"}
 
-    result = await runner(cmd, cwd=Path("/tmp"), timeout=60, pty_mode=False)
+    result = await runner(cmd, cwd=Path("/tmp"), timeout=60, env=env, pty_mode=False)
 
     assert len(inner.call_args_list) == 1  # inner WAS called
     mock_recorder.record_non_session_step.assert_called_once_with(
@@ -133,30 +128,14 @@ async def test_no_step_name_skips_recording():
     inner.set_default(_make_result(returncode=0))
     runner = RecordingSubprocessRunner(recorder=mock_recorder, inner=inner)
 
-    cmd = ["env", "AUTOSKILLIT_HEADLESS=1", "claude", "--print", "test"]
+    cmd = ["claude", "--print", "test"]
+    env = {"AUTOSKILLIT_HEADLESS": "1"}
 
-    await runner(cmd, cwd=Path("/tmp"), timeout=300, pty_mode=True)
+    await runner(cmd, cwd=Path("/tmp"), timeout=300, env=env, pty_mode=True)
 
     assert len(inner.call_args_list) == 1  # inner called (no recording intercept)
     mock_recorder.record_step.assert_not_called()
     mock_recorder.record_non_session_step.assert_not_called()
-
-
-# --- T5: _extract_env_and_args parsing ---
-
-
-def test_extract_env_and_args():
-    cmd = ["env", "A=1", "B=hello", "claude", "--print", "do stuff"]
-    env_dict, clean_args = _extract_env_and_args(cmd)
-    assert env_dict == {"A": "1", "B": "hello"}
-    assert clean_args == ["claude", "--print", "do stuff"]
-
-
-def test_extract_env_and_args_no_env_prefix():
-    cmd = ["claude", "--print", "do stuff"]
-    env_dict, clean_args = _extract_env_and_args(cmd)
-    assert env_dict == {}
-    assert clean_args == ["claude", "--print", "do stuff"]
 
 
 # --- T6: _extract_model from args ---
@@ -184,23 +163,25 @@ _BASE_CMD_ARGS = dict(
 
 
 def test_build_full_headless_cmd_injects_scenario_step_name():
-    cmd = build_full_headless_cmd(
+    spec = build_full_headless_cmd(
         "/investigate foo",
         scenario_step_name="investigate",
         **_BASE_CMD_ARGS,
     )
-    assert "SCENARIO_STEP_NAME=investigate" in cmd
+    assert spec.env["SCENARIO_STEP_NAME"] == "investigate"
+    assert not any("SCENARIO_STEP_NAME" in tok for tok in spec.cmd)
 
 
 # --- T8: build_full_headless_cmd without scenario_step_name ---
 
 
 def test_build_full_headless_cmd_no_scenario_step_name():
-    cmd = build_full_headless_cmd(
+    spec = build_full_headless_cmd(
         "/investigate foo",
         **_BASE_CMD_ARGS,
     )
-    assert not any("SCENARIO_STEP_NAME" in token for token in cmd)
+    assert "SCENARIO_STEP_NAME" not in spec.env
+    assert not any("SCENARIO_STEP_NAME" in tok for tok in spec.cmd)
 
 
 # --- T9: run_headless_core passes scenario_step_name through ---
@@ -208,7 +189,7 @@ def test_build_full_headless_cmd_no_scenario_step_name():
 
 @pytest.mark.anyio
 async def test_run_headless_core_injects_scenario_step_name(tmp_path):
-    """run_headless_core passes step_name as scenario_step_name to cmd builder."""
+    """run_headless_core passes step_name as scenario_step_name and routes it via env kwarg."""
     from autoskillit.config import AutomationConfig
     from autoskillit.execution.headless import run_headless_core
     from autoskillit.pipeline import DefaultGateState
@@ -221,8 +202,11 @@ async def test_run_headless_core_injects_scenario_step_name(tmp_path):
 
     await run_headless_core("/investigate foo", str(tmp_path), ctx, step_name="investigate")
 
-    cmd = mock_runner.call_args_list[0][0]
-    assert "SCENARIO_STEP_NAME=investigate" in cmd
+    cmd, _cwd, _timeout, kwargs = mock_runner.call_args_list[0]
+    assert cmd[0] != "env"
+    env = kwargs.get("env")
+    assert env is not None
+    assert env["SCENARIO_STEP_NAME"] == "investigate"
 
 
 # --- T10: make_context wraps runner when RECORD_SCENARIO set ---
@@ -284,8 +268,9 @@ async def test_sequencing_session_step_dispatch(tmp_path):
     session_map: dict[str, deque] = {"implement": deque([(cli, meta)])}
     runner = ReplayingSubprocessRunner(session_map, {})
 
-    cmd = ["env", "SCENARIO_STEP_NAME=implement", "claude", "--print", "do stuff"]
-    result = await runner(cmd, cwd=tmp_path, timeout=60)
+    cmd = ["claude", "--print", "do stuff"]
+    env = {"SCENARIO_STEP_NAME": "implement"}
+    result = await runner(cmd, cwd=tmp_path, timeout=60, env=env)
 
     assert result.returncode == meta.exit_code
     assert result.stdout == "session output"
@@ -308,8 +293,9 @@ async def test_sequencing_non_session_step_dispatch(tmp_path):
     }
     runner = ReplayingSubprocessRunner({}, non_session)
 
-    cmd = ["env", "SCENARIO_STEP_NAME=test-check", "task", "test-check"]
-    result = await runner(cmd, cwd=tmp_path, timeout=60)
+    cmd = ["task", "test-check"]
+    env = {"SCENARIO_STEP_NAME": "test-check"}
+    result = await runner(cmd, cwd=tmp_path, timeout=60, env=env)
 
     assert result.returncode == 1
     assert result.stdout == "FAILED"
@@ -322,7 +308,7 @@ async def test_sequencing_non_session_step_dispatch(tmp_path):
 
 @pytest.mark.anyio
 async def test_sequencing_missing_step_name_raises(tmp_path):
-    """No SCENARIO_STEP_NAME in cmd → ValueError."""
+    """No SCENARIO_STEP_NAME in env kwarg → ValueError."""
     runner = ReplayingSubprocessRunner({}, {})
     cmd = ["claude", "--print", "test"]
     with pytest.raises(ValueError, match="SCENARIO_STEP_NAME"):
@@ -338,9 +324,10 @@ async def test_sequencing_unknown_step_raises(tmp_path):
     runner = ReplayingSubprocessRunner(
         {"known": deque([(FakeCLI(), FakeMeta(exit_code=0))])}, {"other": {}}
     )
-    cmd = ["env", "SCENARIO_STEP_NAME=unknown-step", "claude", "--print", "test"]
+    cmd = ["claude", "--print", "test"]
+    env = {"SCENARIO_STEP_NAME": "unknown-step"}
     with pytest.raises(ScenarioReplayError) as exc_info:
-        await runner(cmd, cwd=tmp_path, timeout=60)
+        await runner(cmd, cwd=tmp_path, timeout=60, env=env)
     msg = str(exc_info.value)
     assert "unknown-step" in msg
     assert "known" in msg
@@ -359,11 +346,13 @@ async def test_sequencing_call_log(tmp_path):
     session_map: dict[str, deque] = {"run": deque([(cli, meta)])}
     runner = ReplayingSubprocessRunner(session_map, non_session)
 
-    cmd1 = ["env", "SCENARIO_STEP_NAME=run", "claude", "--print", "go"]
-    cmd2 = ["env", "SCENARIO_STEP_NAME=check", "task", "test"]
+    cmd1 = ["claude", "--print", "go"]
+    env1 = {"SCENARIO_STEP_NAME": "run"}
+    cmd2 = ["task", "test"]
+    env2 = {"SCENARIO_STEP_NAME": "check"}
 
-    await runner(cmd1, cwd=tmp_path, timeout=60)
-    await runner(cmd2, cwd=tmp_path, timeout=60)
+    await runner(cmd1, cwd=tmp_path, timeout=60, env=env1)
+    await runner(cmd2, cwd=tmp_path, timeout=60, env=env2)
 
     assert len(runner.call_log) == 2
     assert runner.call_log[0] == ("run", cmd1)
@@ -383,9 +372,10 @@ async def test_sequencing_multiple_calls_advance_queue(tmp_path):
     session_map: dict[str, deque] = {"implement": deque([(cli1, meta1), (cli2, meta2)])}
     runner = ReplayingSubprocessRunner(session_map, {})
 
-    cmd = ["env", "SCENARIO_STEP_NAME=implement", "claude", "--print", "go"]
-    result1 = await runner(cmd, cwd=tmp_path, timeout=60)
-    result2 = await runner(cmd, cwd=tmp_path, timeout=60)
+    cmd = ["claude", "--print", "go"]
+    env = {"SCENARIO_STEP_NAME": "implement"}
+    result1 = await runner(cmd, cwd=tmp_path, timeout=60, env=env)
+    result2 = await runner(cmd, cwd=tmp_path, timeout=60, env=env)
 
     assert result1.stdout == "first"
     assert result2.stdout == "second"
@@ -401,8 +391,9 @@ async def test_sequencing_exhausted_session_falls_to_non_session(tmp_path):
     session_map: dict[str, deque] = {"test": deque()}
     runner = ReplayingSubprocessRunner(session_map, non_session)
 
-    cmd = ["env", "SCENARIO_STEP_NAME=test", "task", "test"]
-    result = await runner(cmd, cwd=tmp_path, timeout=60)
+    cmd = ["task", "test"]
+    env = {"SCENARIO_STEP_NAME": "test"}
+    result = await runner(cmd, cwd=tmp_path, timeout=60, env=env)
 
     assert result.returncode == 2
     assert result.stdout == "non-session result"
@@ -492,8 +483,9 @@ async def test_cross_scenario_override(tmp_path):
     session_map: dict[str, deque] = {"implement": deque([(override_cli, override_meta)])}
 
     runner = ReplayingSubprocessRunner(session_map, {})
-    cmd = ["env", "SCENARIO_STEP_NAME=implement", "claude", "--print", "go"]
-    result = await runner(cmd, cwd=tmp_path, timeout=60)
+    cmd = ["claude", "--print", "go"]
+    env = {"SCENARIO_STEP_NAME": "implement"}
+    result = await runner(cmd, cwd=tmp_path, timeout=60, env=env)
 
     assert result.stdout == "from-overridden-scenario2"
     assert result.returncode == 0

--- a/tests/server/test_tools_execution.py
+++ b/tests/server/test_tools_execution.py
@@ -167,7 +167,8 @@ class TestRunSkillPrefix:
         )
         await run_skill("/investigate error", "/tmp")
         cmd = tool_ctx.runner.call_args_list[0][0]
-        assert cmd[5].startswith("Use /investigate error")
+        prompt_idx = cmd.index("--print") + 1 if "--print" in cmd else cmd.index("-p") + 1
+        assert cmd[prompt_idx].startswith("Use /investigate error")
         # cwd must propagate to the subprocess runner
         from pathlib import Path
 
@@ -222,7 +223,8 @@ class TestRunSkillPrefix:
         )
         await run_skill("/investigate error", "/tmp")
         cmd = tool_ctx.runner.call_args_list[0][0]
-        assert "%%ORDER_UP::" in cmd[5]
+        prompt_idx = cmd.index("--print") + 1 if "--print" in cmd else cmd.index("-p") + 1
+        assert "%%ORDER_UP::" in cmd[prompt_idx]
         # cwd must propagate to the subprocess runner
         from pathlib import Path
 
@@ -328,9 +330,8 @@ class TestRunSkillInjectsCompletionDirective:
         await run_skill("/investigate foo", "/tmp")
 
         cmd = tool_ctx.runner.call_args_list[-1][0]
-        # The prompt argument is at index 5
-        # (shifted by 3 env tokens: env + AUTOSKILLIT_HEADLESS=1 + delay)
-        skill_arg = cmd[5]
+        prompt_idx = cmd.index("--print") + 1 if "--print" in cmd else cmd.index("-p") + 1
+        skill_arg = cmd[prompt_idx]
         assert "%%ORDER_UP::" in skill_arg
         assert "ORCHESTRATION DIRECTIVE" in skill_arg
 
@@ -350,17 +351,17 @@ class TestRunSkillInjectsCompletionDirective:
 
 
 class TestRunSkillEnvPrefix:
-    """run_skill always injects AUTOSKILLIT_HEADLESS=1 and optionally CLAUDE_CODE_EXIT_AFTER_STOP_DELAY."""  # noqa: E501
+    """run_skill always injects AUTOSKILLIT_HEADLESS=1 and optionally CLAUDE_CODE_EXIT_AFTER_STOP_DELAY via the env kwarg."""  # noqa: E501
 
     @pytest.mark.anyio
-    async def test_default_delay_prepends_env_to_cmd(self, tool_ctx):
+    async def test_default_delay_populates_env(self, tool_ctx):
         tool_ctx.runner.push(_make_result(0, _SUCCESS_JSON, ""))
         await run_skill("/investigate something", "/tmp")
-        cmd = tool_ctx.runner.call_args_list[0][0]
-        assert cmd[0] == "env"
-        assert cmd[1] == "AUTOSKILLIT_HEADLESS=1"
-        assert cmd[2] == "CLAUDE_CODE_EXIT_AFTER_STOP_DELAY=120000"
-        assert "claude" in cmd
+        cmd, _cwd, _timeout, kwargs = tool_ctx.runner.call_args_list[0]
+        assert cmd[0] == "claude"
+        env = kwargs["env"]
+        assert env["AUTOSKILLIT_HEADLESS"] == "1"
+        assert env["CLAUDE_CODE_EXIT_AFTER_STOP_DELAY"] == "120000"
 
     @pytest.mark.anyio
     async def test_zero_delay_omits_delay_env_var(self, tool_ctx):
@@ -370,25 +371,25 @@ class TestRunSkillEnvPrefix:
         tool_ctx.config = cfg
         tool_ctx.runner.push(_make_result(0, _SUCCESS_JSON, ""))
         await run_skill("/investigate something", "/tmp")
-        cmd = tool_ctx.runner.call_args_list[0][0]
-        # AUTOSKILLIT_HEADLESS=1 is always injected; delay var is omitted when delay=0
-        assert cmd[0] == "env"
-        assert cmd[1] == "AUTOSKILLIT_HEADLESS=1"
-        assert cmd[2] == "claude"
-        assert not any("CLAUDE_CODE_EXIT_AFTER_STOP_DELAY" in arg for arg in cmd)
+        cmd, _cwd, _timeout, kwargs = tool_ctx.runner.call_args_list[0]
+        assert cmd[0] == "claude"
+        env = kwargs["env"]
+        assert env["AUTOSKILLIT_HEADLESS"] == "1"
+        assert "CLAUDE_CODE_EXIT_AFTER_STOP_DELAY" not in env
 
     @pytest.mark.anyio
-    async def test_custom_delay_value_in_cmd(self, tool_ctx):
+    async def test_custom_delay_value_in_env(self, tool_ctx):
         cfg = AutomationConfig()
         cfg.run_skill = RunSkillConfig(exit_after_stop_delay_ms=60000)
         cfg.safety.require_dry_walkthrough = False
         tool_ctx.config = cfg
         tool_ctx.runner.push(_make_result(0, _SUCCESS_JSON, ""))
         await run_skill("/investigate something", "/tmp")
-        cmd = tool_ctx.runner.call_args_list[0][0]
-        assert cmd[0] == "env"
-        assert cmd[1] == "AUTOSKILLIT_HEADLESS=1"
-        assert cmd[2] == "CLAUDE_CODE_EXIT_AFTER_STOP_DELAY=60000"
+        cmd, _cwd, _timeout, kwargs = tool_ctx.runner.call_args_list[0]
+        assert cmd[0] == "claude"
+        env = kwargs["env"]
+        assert env["AUTOSKILLIT_HEADLESS"] == "1"
+        assert env["CLAUDE_CODE_EXIT_AFTER_STOP_DELAY"] == "60000"
 
 
 class TestRunSkillPassesSessionLogDir:

--- a/tests/test_llm_triage.py
+++ b/tests/test_llm_triage.py
@@ -491,3 +491,57 @@ async def test_triage_command_includes_format_required_flags(
     fmt = OutputFormat.JSON
     for flag in fmt.required_cli_flags:
         assert flag in cmd, f"Missing required flag {flag!r} in triage command: {cmd}"
+
+
+@pytest.mark.anyio
+async def test_triage_env_excludes_ide_vars(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """triage_staleness must route env through build_claude_env() — no IDE leak."""
+    from unittest.mock import AsyncMock
+
+    from autoskillit._llm_triage import triage_staleness
+    from autoskillit.execution.process import SubprocessResult, TerminationReason
+
+    monkeypatch.setenv("CLAUDE_CODE_SSE_PORT", "23270")
+    monkeypatch.setenv("ENABLE_IDE_INTEGRATION", "true")
+
+    skill_dir = tmp_path / "test-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("# Test\nContent.")
+    monkeypatch.setattr("autoskillit._llm_triage.bundled_skills_dir", lambda: tmp_path)
+
+    ndjson = (
+        json.dumps(
+            {
+                "type": "result",
+                "subtype": "success",
+                "is_error": False,
+                "result": json.dumps(
+                    [
+                        {
+                            "index": 1,
+                            "skill": "test-skill",
+                            "meaningful_change": False,
+                            "summary": "",
+                        }
+                    ]
+                ),
+                "session_id": "s1",
+            }
+        )
+        + "\n"
+    )
+    mock_run = AsyncMock(
+        return_value=SubprocessResult(0, ndjson, "", TerminationReason.NATURAL_EXIT, pid=1)
+    )
+    monkeypatch.setattr("autoskillit._llm_triage.run_managed_async", mock_run)
+
+    item = StaleItem(
+        skill="test-skill", reason="hash_mismatch", stored_value="old", current_value="new"
+    )
+    await triage_staleness([item])
+
+    env = mock_run.call_args.kwargs["env"]
+    assert env is not None
+    assert "CLAUDE_CODE_SSE_PORT" not in env
+    assert "ENABLE_IDE_INTEGRATION" not in env
+    assert env["CLAUDE_CODE_AUTO_CONNECT_IDE"] == "0"


### PR DESCRIPTION
## Summary

The stray `LSP(workspaceSymbol)` call observed in `autoskillit order` is one symptom of a **systemic pattern weakness**: every claude-launching subprocess in autoskillit inherits the parent process's full environment without sanitization. When autoskillit runs under a shell that has `CLAUDE_CODE_SSE_PORT` set (VS Code integrated terminal, any descendant process), that var is propagated into the cook subprocess, which then attaches to `~/.claude/ide/$PORT.lock` over a websocket and merges IDE-provided LSP tools into the model's manifest.

This PR introduces a canonical L0 env builder (`build_claude_env()`) that applies a principled IDE-denylist and injects `CLAUDE_CODE_AUTO_CONNECT_IDE=0` to suppress the lock-file-scan fallback. All four claude-launching sites are wired through it, and an AST rule enforces compliance structurally.

### Changes

**New components (★):**
- `src/autoskillit/core/_claude_env.py` — IDE-scrubbing env builder with denylist, prefix denylist, and always-extras
- `tests/core/test_claude_env.py` — 14 unit tests for the builder
- `tests/cli/test_cook_env_scrub.py` — launch-site env-capture tests for cook/order
- `tests/cli/test_cook_ide_isolation.py` — end-to-end IDE-lock simulation smoke canary
- `tests/execution/test_headless_env_scrub.py` — headless runner env-capture test

**Modified components (●):**
- `execution/commands.py` — `ClaudeInteractiveCmd`/`ClaudeHeadlessCmd.env` now hold fully resolved scrubbed env; `build_full_headless_cmd` returns `ClaudeHeadlessCmd` (was `list[str]`); `["env", ...]` argv prefix eliminated
- `cli/app.py`, `cli/_cook.py` — drop inline `{**os.environ}`, use `spec.env` directly
- `execution/headless.py` — pass `env=spec.env` to runner
- `_llm_triage.py` — pass `env=build_claude_env()` to `run_managed_async`
- `execution/recording.py` — read `SCENARIO_STEP_NAME` from `env` kwarg (not argv prefix); delete obsolete `_extract_env_and_args`
- `execution/process.py`, `core/_type_subprocess.py` — widen `env` param type to `Mapping[str, str] | None`
- `tests/cli/test_subprocess_env_contracts.py` — new `test_no_raw_claude_env` AST rule with allowlist
- Test migrations: `test_commands.py`, `test_recording.py`, `test_headless_env_injection.py`, `test_tools_execution.py`, `test_llm_triage.py`

### Immunity claim

- The specific bug is impossible to reintroduce without (a) bypassing the builder (blocked by AST rule), (b) removing a var from the denylist, or (c) removing the `CLAUDE_CODE_AUTO_CONNECT_IDE=0` injection — all deliberate, reviewable single-file changes
- Two-layer immunity: env scrub closes the direct-signal path; auto-connect disable closes the lock-file-scan fallback
- Test discipline is now symmetric with argv discipline: both layers have a builder, a dataclass field, and an AST rule

## Implementation Plan

Plan file: `.autoskillit/temp/rectify/rectify_ide_env_leak_2026-04-11_120000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
