### PR TITLE
feat: per-window quota guard thresholds

### DIFF
--- a/.autoskillit/config.yaml
+++ b/.autoskillit/config.yaml
@@ -30,4 +30,4 @@ github:
   default_repo: "TalonT-Org/AutoSkillit"
 
 quota_guard:
-  threshold: 95.0
+  short_window_threshold: 95.0

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -139,9 +139,14 @@ Default: `command: null` (disabled), `preserve_dirs: []`.
 ```yaml
 quota_guard:
   enabled: true
-  threshold: 85.0          # block run_skill when 5-hour utilization exceeds this %
-  buffer_seconds: 60       # extra buffer after quota reset before resuming
-  cache_max_age: 60        # seconds before a live quota fetch is triggered
+  short_window_threshold: 85.0   # block at this % for short windows (e.g. five_hour)
+  long_window_threshold: 98.0    # block at this % for long windows (weekly, sonnet, opus)
+  long_window_patterns:          # substrings (case-insensitive) that classify a
+    - weekly                     # window name as long-window
+    - sonnet
+    - opus
+  buffer_seconds: 60             # extra buffer after quota reset before resuming
+  cache_max_age: 60              # seconds before a live quota fetch is triggered
 ```
 
 Check current quota: `autoskillit quota-status`.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -67,7 +67,9 @@ tree. See [safety/workspace.md](safety/workspace.md).
 
 ### How do I tune the API quota guard?
 
-Set `quota_guard.threshold` (default 85.0) and `quota_guard.buffer_seconds`
+Set `quota_guard.short_window_threshold` (default 85.0) for short windows
+(e.g. `five_hour`), `quota_guard.long_window_threshold` (default 98.0) for
+long windows (weekly, sonnet, opus), and `quota_guard.buffer_seconds`
 (default 60) in `.autoskillit/config.yaml`. See
 [operations/sprint-guide.md](operations/sprint-guide.md).
 

--- a/docs/operations/sprint-guide.md
+++ b/docs/operations/sprint-guide.md
@@ -51,15 +51,24 @@ bug surfaced during the run.
 
 ## Quota tuning + buffer
 
-The quota guard blocks new headless sessions when 5-hour rolling utilization
-exceeds `quota_guard.threshold` (default 85.0%). Two settings tune the
-behaviour:
+The quota guard blocks new headless sessions when the binding rate-limit
+window crosses its own per-window threshold. Short windows (e.g. `five_hour`)
+use `quota_guard.short_window_threshold` (default 85.0%); long windows
+matched by `quota_guard.long_window_patterns` (default `weekly`, `sonnet`,
+`opus`) use `quota_guard.long_window_threshold` (default 98.0%) — short-window
+exhaustion means imminent throttling, while 15% headroom on a multi-day
+weekly window is comfortable.
 
 ```yaml
 quota_guard:
   enabled: true
-  threshold: 85.0           # block at 85% of the 5-hour budget
-  buffer_seconds: 60        # extra delay above the strict reset time
+  short_window_threshold: 85.0   # block at 85% for short windows
+  long_window_threshold: 98.0    # block at 98% for long windows (weekly, sonnet, opus)
+  long_window_patterns:
+    - weekly
+    - sonnet
+    - opus
+  buffer_seconds: 60             # extra delay above the strict reset time
   cache_path: "~/.claude/autoskillit_quota_cache.json"
 ```
 

--- a/docs/safety/hooks.md
+++ b/docs/safety/hooks.md
@@ -17,9 +17,12 @@ Denies merges and pushes targeting branches in `safety.protected_branches`
 
 ### `quota_check.py`
 **Guarded tool:** `run_skill`
-Blocks launching new headless sessions when API quota utilization exceeds
-`quota_guard.threshold` (default 85.0% of the 5-hour window). Reports the
-exact sleep duration the orchestrator must wait.
+Blocks launching new headless sessions when the cached binding window marks
+`should_block=True`. The threshold is per-window: short windows (e.g.
+`five_hour`) use `quota_guard.short_window_threshold` (default 85.0%); long
+windows matched by `quota_guard.long_window_patterns` (default `weekly`,
+`sonnet`, `opus`) use `quota_guard.long_window_threshold` (default 98.0%).
+Reports the exact sleep duration the orchestrator must wait.
 
 ### `skill_command_guard.py`
 **Guarded tool:** `run_skill`
@@ -74,8 +77,9 @@ table to the PR body so reviewers can see per-step token cost.
 ### `quota_post_check.py`
 **Guarded tool:** `run_skill`
 After `run_skill` returns, appends a quota warning to the tool output when
-utilization has crossed `quota_guard.threshold`. Gives the orchestrator a
-chance to back off voluntarily before the PreToolUse hook starts denying.
+the cached binding window marks `should_block=True` (per-window threshold —
+see `quota_check.py` above). Gives the orchestrator a chance to back off
+voluntarily before the PreToolUse hook starts denying.
 
 ## SessionStart hook (1)
 
@@ -113,7 +117,9 @@ safety:
 
 quota_guard:
   enabled: true
-  threshold: 85.0
+  short_window_threshold: 85.0
+  long_window_threshold: 98.0
+  long_window_patterns: ["weekly", "sonnet", "opus"]
   buffer_seconds: 60
 ```
 

--- a/src/autoskillit/config/defaults.yaml
+++ b/src/autoskillit/config/defaults.yaml
@@ -60,7 +60,12 @@ token_usage:
 
 quota_guard:
   enabled: true
-  threshold: 85.0
+  short_window_threshold: 85.0
+  long_window_threshold: 98.0
+  long_window_patterns:
+    - weekly
+    - sonnet
+    - opus
   buffer_seconds: 60
   cache_max_age: 300
   cache_refresh_interval: 240

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -122,7 +122,9 @@ class TokenUsageConfig:
 @dataclass
 class QuotaGuardConfig:
     enabled: bool = True
-    threshold: float = 85.0
+    short_window_threshold: float = 85.0
+    long_window_threshold: float = 98.0
+    long_window_patterns: list[str] = field(default_factory=lambda: ["weekly", "sonnet", "opus"])
     buffer_seconds: int = 60
     cache_max_age: int = 300
     cache_refresh_interval: int = 240
@@ -388,7 +390,15 @@ class AutomationConfig:
             ),
             quota_guard=QuotaGuardConfig(
                 enabled=bool(val(qg, "enabled", _qg["enabled"])),
-                threshold=float(val(qg, "threshold", _qg["threshold"])),
+                short_window_threshold=float(
+                    val(qg, "short_window_threshold", _qg["short_window_threshold"])
+                ),
+                long_window_threshold=float(
+                    val(qg, "long_window_threshold", _qg["long_window_threshold"])
+                ),
+                long_window_patterns=list(
+                    val(qg, "long_window_patterns", _qg["long_window_patterns"])
+                ),
                 buffer_seconds=int(val(qg, "buffer_seconds", _qg["buffer_seconds"])),
                 cache_max_age=int(val(qg, "cache_max_age", _qg["cache_max_age"])),
                 cache_refresh_interval=int(

--- a/src/autoskillit/execution/quota.py
+++ b/src/autoskillit/execution/quota.py
@@ -107,7 +107,7 @@ def _compute_binding(
     Returns QuotaStatus(0.0, None, ...) when windows is empty.
     """
     if not windows:
-        return QuotaStatus(0.0, None)
+        return QuotaStatus(0.0, None, effective_threshold=100.0)
 
     def threshold_of(name: str) -> float:
         return _threshold_for_window(
@@ -244,7 +244,9 @@ async def _fetch_quota(
                 resets_at=_parse_resets_at(w.get("resets_at")),
             )
     if not windows:
-        return QuotaFetchResult(windows={}, binding=QuotaStatus(0.0, None))
+        return QuotaFetchResult(
+            windows={}, binding=QuotaStatus(0.0, None, effective_threshold=100.0)
+        )
     binding = _compute_binding(
         windows,
         short_threshold=short_threshold,

--- a/src/autoskillit/execution/quota.py
+++ b/src/autoskillit/execution/quota.py
@@ -20,9 +20,8 @@ from autoskillit.core import get_logger, write_versioned_json
 _log = get_logger(__name__)
 
 _DEFAULT_BASE_URL: str = "https://api.anthropic.com"
-_DEFAULT_THRESHOLD: float = 85.0
 
-QUOTA_CACHE_SCHEMA_VERSION: int = 2
+QUOTA_CACHE_SCHEMA_VERSION: int = 3
 _SCHEMA_DRIFT_LOGGED: set[str] = set()
 
 
@@ -36,6 +35,8 @@ class QuotaStatus:
     utilization: float  # percentage 0–100
     resets_at: datetime | None  # UTC-aware; None when utilization is 0
     window_name: str = "unknown"  # which window this came from (diagnostic)
+    should_block: bool = False
+    effective_threshold: float = 0.0
 
     def __post_init__(self) -> None:
         if self.utilization is None:
@@ -71,30 +72,68 @@ def _parse_resets_at(resets_at_str: str | None) -> datetime | None:
     return datetime.fromisoformat(resets_at_str.replace("Z", "+00:00"))
 
 
+def _threshold_for_window(
+    name: str,
+    *,
+    short_threshold: float,
+    long_threshold: float,
+    long_patterns: list[str],
+) -> float:
+    """Return the threshold to apply to a window of the given name.
+
+    Long-window classification is substring match (case-insensitive) against
+    long_patterns. Unknown windows fall through to short_threshold.
+    """
+    lowered = name.lower()
+    for pat in long_patterns:
+        if pat.lower() in lowered:
+            return long_threshold
+    return short_threshold
+
+
 def _compute_binding(
     windows: dict[str, QuotaWindowEntry],
-    threshold: float,
+    *,
+    short_threshold: float,
+    long_threshold: float,
+    long_patterns: list[str],
 ) -> QuotaStatus:
-    """Select the worst-case (binding) window.
+    """Select the worst-case (binding) window using per-window thresholds.
 
-    Among windows at or above threshold, returns the one with the latest resets_at
-    (the last window to reset governs how long the caller must sleep).
-    If no window is above threshold, returns the window with highest utilization
-    (for diagnostic display; should_sleep will be False for the caller).
-    Returns QuotaStatus(0.0, None) when windows is empty.
+    Each window is classified by name into short or long via long_patterns.
+    Among windows at or above their own threshold, returns the one with the
+    latest resets_at. If none are exhausted, returns the window with highest
+    utilization (for diagnostic display; should_block will be False).
+    Returns QuotaStatus(0.0, None, ...) when windows is empty.
     """
     if not windows:
         return QuotaStatus(0.0, None)
-    exhausted = [(name, w) for name, w in windows.items() if w.utilization >= threshold]
+
+    def threshold_of(name: str) -> float:
+        return _threshold_for_window(
+            name,
+            short_threshold=short_threshold,
+            long_threshold=long_threshold,
+            long_patterns=long_patterns,
+        )
+
+    exhausted = [(name, w) for name, w in windows.items() if w.utilization >= threshold_of(name)]
     if exhausted:
         name, w = max(
             exhausted,
             key=lambda nw: nw[1].resets_at or datetime.min.replace(tzinfo=UTC),
         )
-        return QuotaStatus(utilization=w.utilization, resets_at=w.resets_at, window_name=name)
-    # No window exhausted — return highest utilization for display
-    name, w = max(windows.items(), key=lambda nw: nw[1].utilization)
-    return QuotaStatus(utilization=w.utilization, resets_at=w.resets_at, window_name=name)
+    else:
+        name, w = max(windows.items(), key=lambda nw: nw[1].utilization)
+
+    effective = threshold_of(name)
+    return QuotaStatus(
+        utilization=w.utilization,
+        resets_at=w.resets_at,
+        window_name=name,
+        should_block=w.utilization >= effective,
+        effective_threshold=effective,
+    )
 
 
 def _read_credentials(credentials_path: str) -> str:
@@ -137,6 +176,8 @@ def _read_cache(cache_path: str, max_age: int) -> QuotaStatus | None:
             utilization=float(b["utilization"]),
             resets_at=_parse_resets_at(b.get("resets_at")),
             window_name=str(b.get("window_name", "unknown")),
+            should_block=bool(b.get("should_block", False)),
+            effective_threshold=float(b.get("effective_threshold", 0.0)),
         )
     except (FileNotFoundError, KeyError, ValueError, TypeError, json.JSONDecodeError):
         return None
@@ -160,6 +201,8 @@ def _write_cache(cache_path: str, result: QuotaFetchResult) -> None:
                 "resets_at": (
                     result.binding.resets_at.isoformat() if result.binding.resets_at else None
                 ),
+                "should_block": result.binding.should_block,
+                "effective_threshold": result.binding.effective_threshold,
             },
         }
         path = Path(cache_path).expanduser()
@@ -172,6 +215,9 @@ def _write_cache(cache_path: str, result: QuotaFetchResult) -> None:
 async def _fetch_quota(
     credentials_path: str,
     *,
+    short_threshold: float,
+    long_threshold: float,
+    long_patterns: list[str],
     base_url: str = _DEFAULT_BASE_URL,
     _httpx_timeout: float = 10,
 ) -> QuotaFetchResult:
@@ -199,7 +245,12 @@ async def _fetch_quota(
             )
     if not windows:
         return QuotaFetchResult(windows={}, binding=QuotaStatus(0.0, None))
-    binding = _compute_binding(windows, threshold=_DEFAULT_THRESHOLD)
+    binding = _compute_binding(
+        windows,
+        short_threshold=short_threshold,
+        long_threshold=long_threshold,
+        long_patterns=long_patterns,
+    )
     return QuotaFetchResult(windows=windows, binding=binding)
 
 
@@ -219,7 +270,12 @@ async def _refresh_quota_cache(
     Exceptions from _fetch_quota propagate to the caller for supervision.
     """
     fetch_result = await _fetch_quota(
-        config.credentials_path, base_url=base_url, _httpx_timeout=_httpx_timeout
+        config.credentials_path,
+        short_threshold=config.short_window_threshold,
+        long_threshold=config.long_window_threshold,
+        long_patterns=list(config.long_window_patterns),
+        base_url=base_url,
+        _httpx_timeout=_httpx_timeout,
     )
     _write_cache(config.cache_path, fetch_result)
 
@@ -257,22 +313,29 @@ async def check_and_sleep_if_needed(
             "window_name": None,
         }
 
+    fetch_kwargs = {
+        "short_threshold": config.short_window_threshold,
+        "long_threshold": config.long_window_threshold,
+        "long_patterns": list(config.long_window_patterns),
+        "base_url": base_url,
+        "_httpx_timeout": _httpx_timeout,
+    }
+
     try:
         status = _read_cache(config.cache_path, config.cache_max_age)
         if status is None:
-            fetch_result = await _fetch_quota(
-                config.credentials_path, base_url=base_url, _httpx_timeout=_httpx_timeout
-            )
+            fetch_result = await _fetch_quota(config.credentials_path, **fetch_kwargs)
             _write_cache(config.cache_path, fetch_result)
             status = fetch_result.binding
 
-        if status.utilization < config.threshold:
+        if not status.should_block:
             return {
                 "should_sleep": False,
                 "sleep_seconds": 0,
                 "utilization": status.utilization,
                 "resets_at": status.resets_at.isoformat() if status.resets_at else None,
                 "window_name": status.window_name,
+                "effective_threshold": status.effective_threshold,
             }
 
         if status.resets_at is None:
@@ -288,13 +351,12 @@ async def check_and_sleep_if_needed(
                 "utilization": status.utilization,
                 "resets_at": None,
                 "window_name": status.window_name,
+                "effective_threshold": status.effective_threshold,
                 "reason": "unknown_reset",
             }
 
         # Re-fetch for accurate resets_at before returning sleep metadata
-        fetch_result = await _fetch_quota(
-            config.credentials_path, base_url=base_url, _httpx_timeout=_httpx_timeout
-        )
+        fetch_result = await _fetch_quota(config.credentials_path, **fetch_kwargs)
         _write_cache(config.cache_path, fetch_result)
         status = fetch_result.binding
 
@@ -312,6 +374,7 @@ async def check_and_sleep_if_needed(
                 "utilization": status.utilization,
                 "resets_at": None,
                 "window_name": status.window_name,
+                "effective_threshold": status.effective_threshold,
                 "reason": "unknown_reset",
             }
 
@@ -321,7 +384,8 @@ async def check_and_sleep_if_needed(
         _log.info(
             "quota threshold exceeded — caller should sleep",
             utilization=status.utilization,
-            threshold=config.threshold,
+            effective_threshold=status.effective_threshold,
+            window_name=status.window_name,
             sleep_seconds=sleep_secs,
             resets_at=status.resets_at.isoformat(),
         )
@@ -331,6 +395,7 @@ async def check_and_sleep_if_needed(
             "utilization": status.utilization,
             "resets_at": status.resets_at.isoformat(),
             "window_name": status.window_name,
+            "effective_threshold": status.effective_threshold,
         }
 
     except Exception as exc:

--- a/src/autoskillit/hooks/quota_check.py
+++ b/src/autoskillit/hooks/quota_check.py
@@ -2,8 +2,10 @@
 """PreToolUse hook: quota check before run_skill.
 
 Reads the local quota cache file (written by autoskillit's quota module) and
-denies run_skill when utilization exceeds the threshold. Fails open when the
-cache is missing, expired, or unreadable — the next run_skill call will discover
+denies run_skill when the cached binding marks ``should_block=True``. The
+threshold classification is computed once on the cache write side, so this
+hook contains no threshold logic of its own. Fails open when the cache is
+missing, expired, or unreadable — the next run_skill call will discover
 quota exhaustion on its own.
 
 This script is stdlib-only so it can run under any Python interpreter without
@@ -17,7 +19,6 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 _DEFAULT_CACHE_PATH = "~/.claude/autoskillit_quota_cache.json"
-_DEFAULT_THRESHOLD = 85.0
 _DEFAULT_CACHE_MAX_AGE = 300  # seconds
 
 HOOK_CONFIG_FILENAME = ".hook_config.json"
@@ -79,7 +80,8 @@ def _write_quota_log_event(event: dict, log_dir: Path | None) -> None:
     """Append a quota guard event to quota_events.jsonl at the log root.
 
     Silently no-ops on any error — hook observability must never block run_skill.
-    Event schema: {ts, event, threshold, utilization?, sleep_seconds?, resets_at?, cache_path?}
+    Event schema: {ts, event, effective_threshold?, window_name?, utilization?,
+    sleep_seconds?, resets_at?, cache_path?}
     """
     if log_dir is None:
         return
@@ -106,7 +108,6 @@ def main(*, cache_path_override: str | None = None) -> None:
         sys.exit(0)  # log but approve — don't block run_skill on hook bugs
 
     hook_config = _read_hook_config()
-    threshold = hook_config.get("threshold", _DEFAULT_THRESHOLD)
     cache_max_age = hook_config.get("cache_max_age", _DEFAULT_CACHE_MAX_AGE)
     # Function parameter > env var > hook config > module default
     cache_path_str = (
@@ -124,7 +125,6 @@ def main(*, cache_path_override: str | None = None) -> None:
             {
                 "ts": ts,
                 "event": "cache_miss",
-                "threshold": threshold,
                 "cache_path": cache_path_str,
             },
             log_dir,
@@ -136,19 +136,21 @@ def main(*, cache_path_override: str | None = None) -> None:
         if not binding or not isinstance(binding, dict):
             raise KeyError("binding")
         utilization = float(binding["utilization"])
+        should_block = bool(binding.get("should_block", False))
+        effective_threshold = float(binding.get("effective_threshold", 0.0))
+        window_name = str(binding.get("window_name", "unknown"))
     except (KeyError, ValueError, TypeError):
         _write_quota_log_event(
             {
                 "ts": ts,
                 "event": "parse_error",
-                "threshold": threshold,
                 "cache_path": cache_path_str,
             },
             log_dir,
         )
         sys.exit(0)  # malformed cache — fail open
 
-    if utilization >= threshold:
+    if should_block:
         resets_at_str = binding.get("resets_at")
         if resets_at_str:
             try:
@@ -165,7 +167,8 @@ def main(*, cache_path_override: str | None = None) -> None:
             {
                 "ts": ts,
                 "event": "blocked",
-                "threshold": threshold,
+                "effective_threshold": effective_threshold,
+                "window_name": window_name,
                 "utilization": utilization,
                 "sleep_seconds": n,
                 "resets_at": resets_at_str,
@@ -180,7 +183,8 @@ def main(*, cache_path_override: str | None = None) -> None:
                         "permissionDecision": "deny",
                         "permissionDecisionReason": (
                             f"QUOTA WAIT REQUIRED (temporary — NOT a permanent error). "
-                            f"Utilization: {utilization:.0f}% (threshold: {threshold:.0f}%). "
+                            f"Utilization: {utilization:.0f}% on window '{window_name}' "
+                            f"(threshold: {effective_threshold:.0f}%). "
                             f"MANDATORY ACTION: Call run_cmd with: "
                             f'python3 -c "import time; time.sleep({n})" timeout={n + 30} — '
                             f"then retry the SAME run_skill call with identical arguments. "
@@ -197,7 +201,8 @@ def main(*, cache_path_override: str | None = None) -> None:
             {
                 "ts": ts,
                 "event": "approved",
-                "threshold": threshold,
+                "effective_threshold": effective_threshold,
+                "window_name": window_name,
                 "utilization": utilization,
             },
             log_dir,

--- a/src/autoskillit/hooks/quota_post_check.py
+++ b/src/autoskillit/hooks/quota_post_check.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
 """PostToolUse hook: quota warning after run_skill execution.
 
-Fires after run_skill completes and checks whether post-execution quota
-utilization exceeds the threshold. When over threshold, replaces the tool
-output with a compact result summary + quota warning + sleep instruction
-via updatedMCPToolOutput.
+Fires after run_skill completes and checks whether the cached binding marks
+``should_block=True``. When set, replaces the tool output with a compact
+result summary + quota warning + sleep instruction via updatedMCPToolOutput.
 
 This script is stdlib-only so it can run under any Python interpreter without
 requiring the autoskillit package to be importable.
@@ -17,7 +16,6 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 _DEFAULT_CACHE_PATH = "~/.claude/autoskillit_quota_cache.json"
-_DEFAULT_THRESHOLD = 85.0
 _DEFAULT_CACHE_MAX_AGE = 300  # seconds
 
 HOOK_CONFIG_FILENAME = ".hook_config.json"
@@ -120,7 +118,6 @@ def main(*, cache_path_override: str | None = None) -> None:
     tool_response = event.get("tool_response") or ""
 
     hook_config = _read_hook_config()
-    threshold = hook_config.get("threshold", _DEFAULT_THRESHOLD)
     cache_max_age = hook_config.get("cache_max_age", _DEFAULT_CACHE_MAX_AGE)
     cache_path_str = (
         cache_path_override
@@ -140,15 +137,19 @@ def main(*, cache_path_override: str | None = None) -> None:
         if not binding or not isinstance(binding, dict):
             raise KeyError("binding")
         utilization = float(binding["utilization"])
+        should_block = bool(binding.get("should_block", False))
+        effective_threshold = float(binding.get("effective_threshold", 0.0))
+        window_name = str(binding.get("window_name", "unknown"))
     except (KeyError, ValueError, TypeError):
         sys.exit(0)
 
-    if utilization < threshold:
+    if not should_block:
         _write_quota_log_event(
             {
                 "ts": ts,
                 "event": "post_check_pass",
-                "threshold": threshold,
+                "effective_threshold": effective_threshold,
+                "window_name": window_name,
                 "utilization": utilization,
                 "tool_name": tool_name,
             },
@@ -173,7 +174,8 @@ def main(*, cache_path_override: str | None = None) -> None:
     warning_text = (
         f"{result_summary}\n\n"
         f"--- QUOTA WARNING ---\n"
-        f"Post-execution utilization: {utilization:.0f}% (threshold: {threshold:.0f}%)\n"
+        f"Post-execution utilization: {utilization:.0f}% on window '{window_name}' "
+        f"(threshold: {effective_threshold:.0f}%)\n"
         f"MANDATORY ACTION before next run_skill: Call run_cmd with: "
         f'python3 -c "import time; time.sleep({n})" timeout={n + 30}\n'
         f"Before executing, state aloud: "
@@ -184,7 +186,8 @@ def main(*, cache_path_override: str | None = None) -> None:
         {
             "ts": ts,
             "event": "post_check_warning",
-            "threshold": threshold,
+            "effective_threshold": effective_threshold,
+            "window_name": window_name,
             "utilization": utilization,
             "sleep_seconds": n,
             "resets_at": resets_at_str,

--- a/src/autoskillit/server/tools_kitchen.py
+++ b/src/autoskillit/server/tools_kitchen.py
@@ -124,11 +124,11 @@ def _write_hook_config() -> None:
     cfg = ctx.config.quota_guard
     payload = {
         "quota_guard": {
-            "threshold": cfg.threshold if cfg.threshold is not None else 85.0,
-            "cache_max_age": cfg.cache_max_age if cfg.cache_max_age is not None else 300,
-            "cache_path": cfg.cache_path
-            if cfg.cache_path is not None
-            else "~/.claude/autoskillit_quota_cache.json",
+            "short_window_threshold": cfg.short_window_threshold,
+            "long_window_threshold": cfg.long_window_threshold,
+            "long_window_patterns": list(cfg.long_window_patterns),
+            "cache_max_age": cfg.cache_max_age,
+            "cache_path": cfg.cache_path,
         },
         "kitchen_id": ctx.kitchen_id,
     }

--- a/src/autoskillit/server/tools_kitchen.py
+++ b/src/autoskillit/server/tools_kitchen.py
@@ -124,9 +124,6 @@ def _write_hook_config() -> None:
     cfg = ctx.config.quota_guard
     payload = {
         "quota_guard": {
-            "short_window_threshold": cfg.short_window_threshold,
-            "long_window_threshold": cfg.long_window_threshold,
-            "long_window_patterns": list(cfg.long_window_patterns),
             "cache_max_age": cfg.cache_max_age,
             "cache_path": cfg.cache_path,
         },

--- a/src/autoskillit/server/tools_status.py
+++ b/src/autoskillit/server/tools_status.py
@@ -236,8 +236,9 @@ async def get_quota_events(n: int = 50) -> str:
     during long pipeline runs.
 
     Returns JSON with:
-      - events: list of {ts, event, threshold, utilization?, sleep_seconds?,
-                         resets_at?, cache_path?}  (most recent first)
+      - events: list of {ts, event, effective_threshold?, window_name?,
+                         utilization?, sleep_seconds?, resets_at?, cache_path?}
+                         (most recent first)
       - total_count: int  (total events in the log, before limiting to n)
 
     Args:

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -1373,16 +1373,21 @@ def test_check_source_version_drift_never_makes_network_call(
 class TestCheckQuotaCacheSchema:
     """Tests for _check_quota_cache_schema doctor check."""
 
-    def test_check_quota_cache_schema_ok_when_v2(self, tmp_path):
+    def test_check_quota_cache_schema_ok_when_current(self, tmp_path):
         import json
 
         from autoskillit.cli._doctor import Severity, _check_quota_cache_schema
+        from autoskillit.execution import QUOTA_CACHE_SCHEMA_VERSION
 
         cache = tmp_path / "cache.json"
-        cache.write_text(json.dumps({"schema_version": 2, "fetched_at": "2026-01-01T00:00:00"}))
+        cache.write_text(
+            json.dumps(
+                {"schema_version": QUOTA_CACHE_SCHEMA_VERSION, "fetched_at": "2026-01-01T00:00:00"}
+            )
+        )
         result = _check_quota_cache_schema(cache_path=cache)
         assert result.severity == Severity.OK
-        assert "v2" in result.message
+        assert f"v{QUOTA_CACHE_SCHEMA_VERSION}" in result.message
 
     def test_check_quota_cache_schema_ok_when_missing(self, tmp_path):
         from autoskillit.cli._doctor import Severity, _check_quota_cache_schema

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -342,7 +342,8 @@ class TestQuotaGuardConfig:
 
         config = AutomationConfig()
         assert config.quota_guard.enabled is True
-        assert config.quota_guard.threshold == pytest.approx(85.0)
+        assert config.quota_guard.short_window_threshold == pytest.approx(85.0)
+        assert config.quota_guard.long_window_threshold == pytest.approx(98.0)
         assert config.quota_guard.buffer_seconds == 60
         assert config.quota_guard.cache_max_age == 300
 
@@ -352,13 +353,66 @@ class TestQuotaGuardConfig:
         config_dir = tmp_path / ".autoskillit"
         config_dir.mkdir()
         (config_dir / "config.yaml").write_text(
-            yaml.dump({"quota_guard": {"enabled": True, "threshold": 85.0}})
+            yaml.dump(
+                {
+                    "quota_guard": {
+                        "enabled": True,
+                        "short_window_threshold": 85.0,
+                        "long_window_threshold": 98.0,
+                    }
+                }
+            )
         )
         config = load_config(tmp_path)
         assert config.quota_guard.enabled is True
-        assert config.quota_guard.threshold == pytest.approx(85.0)
+        assert config.quota_guard.short_window_threshold == pytest.approx(85.0)
+        assert config.quota_guard.long_window_threshold == pytest.approx(98.0)
         # Unspecified fields keep defaults
         assert config.quota_guard.buffer_seconds == 60
+
+    def test_short_window_threshold_defaults_to_85(self):
+        from autoskillit.config.settings import QuotaGuardConfig
+
+        assert QuotaGuardConfig().short_window_threshold == 85.0
+
+    def test_long_window_threshold_defaults_to_98(self):
+        from autoskillit.config.settings import QuotaGuardConfig
+
+        assert QuotaGuardConfig().long_window_threshold == 98.0
+
+    def test_long_window_patterns_default(self):
+        from autoskillit.config.settings import QuotaGuardConfig
+
+        assert QuotaGuardConfig().long_window_patterns == ["weekly", "sonnet", "opus"]
+
+    def test_threshold_field_removed(self):
+        import dataclasses
+
+        from autoskillit.config.settings import QuotaGuardConfig
+
+        names = {f.name for f in dataclasses.fields(QuotaGuardConfig)}
+        assert "threshold" not in names
+
+    def test_quota_guard_yaml_round_trip_per_window(self, tmp_path):
+        import pytest
+
+        config_dir = tmp_path / ".autoskillit"
+        config_dir.mkdir()
+        (config_dir / "config.yaml").write_text(
+            yaml.dump(
+                {
+                    "quota_guard": {
+                        "short_window_threshold": 85.0,
+                        "long_window_threshold": 98.0,
+                        "long_window_patterns": ["weekly", "sonnet", "opus"],
+                    }
+                }
+            )
+        )
+        config = load_config(tmp_path)
+        assert config.quota_guard.short_window_threshold == pytest.approx(85.0)
+        assert config.quota_guard.long_window_threshold == pytest.approx(98.0)
+        assert config.quota_guard.long_window_patterns == ["weekly", "sonnet", "opus"]
 
     def test_quota_guard_config_has_cache_refresh_interval(self):
         """QG_C3: QuotaGuardConfig has cache_refresh_interval defaulting to 240."""

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -121,13 +121,19 @@ def _count_hooks_by_event() -> dict[str, int]:
     return {event: len(scripts) for event, scripts in by_event.items()}
 
 
-def _quota_threshold_default() -> float:
+def _quota_thresholds_default() -> tuple[float, float]:
     data = yaml.safe_load(_read(SRC_DIR / "config" / "defaults.yaml"))
     quota = data.get("quota_guard")
     assert quota is not None, "quota_guard key missing from config/defaults.yaml"
-    threshold = quota.get("threshold")
-    assert threshold is not None, "quota_guard.threshold key missing from config/defaults.yaml"
-    return float(threshold)
+    short = quota.get("short_window_threshold")
+    long_ = quota.get("long_window_threshold")
+    assert short is not None, (
+        "quota_guard.short_window_threshold key missing from config/defaults.yaml"
+    )
+    assert long_ is not None, (
+        "quota_guard.long_window_threshold key missing from config/defaults.yaml"
+    )
+    return float(short), float(long_)
 
 
 def _count_doctor_checks() -> int:
@@ -210,8 +216,10 @@ def test_hook_total_is_13() -> None:
     assert counts["SessionStart"] == 1, counts
 
 
-def test_quota_threshold_default_is_85() -> None:
-    assert _quota_threshold_default() == pytest.approx(85.0)
+def test_quota_thresholds_defaults() -> None:
+    short, long_ = _quota_thresholds_default()
+    assert short == pytest.approx(85.0)
+    assert long_ == pytest.approx(98.0)
 
 
 def test_doctor_check_count_is_14() -> None:
@@ -276,12 +284,17 @@ def test_safety_hooks_states_13_hooks() -> None:
     _assert_doc_states_number(DOCS_DIR / "safety" / "hooks.md", "hooks total", 13)
 
 
-def test_configuration_states_quota_threshold() -> None:
+def test_configuration_states_quota_thresholds() -> None:
     doc = DOCS_DIR / "configuration.md"
     if not doc.exists():
         pytest.skip("docs/configuration.md not present")
     text = _read(doc)
-    assert "85.0" in text, "docs/configuration.md does not state quota_guard.threshold = 85.0"
+    assert "85.0" in text, (
+        "docs/configuration.md does not state quota_guard.short_window_threshold = 85.0"
+    )
+    assert "98.0" in text, (
+        "docs/configuration.md does not state quota_guard.long_window_threshold = 98.0"
+    )
 
 
 def test_installation_states_14_doctor_checks() -> None:

--- a/tests/execution/test_quota.py
+++ b/tests/execution/test_quota.py
@@ -53,7 +53,7 @@ class TestReadCache:
 
         now = datetime.now(UTC)
         cache_data = {
-            "schema_version": 2,
+            "schema_version": 3,
             "fetched_at": (now - timedelta(seconds=30)).isoformat(),
             "windows": {
                 "five_hour": {
@@ -65,6 +65,8 @@ class TestReadCache:
                 "window_name": "five_hour",
                 "utilization": 87.3,
                 "resets_at": "2026-02-27T20:15:00+00:00",
+                "should_block": True,
+                "effective_threshold": 85.0,
             },
         }
         cache_path = tmp_path / "usage_cache.json"
@@ -226,7 +228,6 @@ class TestCheckAndSleepIfNeeded:
         resets_at = datetime.now(UTC) + timedelta(hours=2)
         config = QuotaGuardConfig(
             enabled=True,
-            threshold=80.0,
             credentials_path=str(tmp_path / ".credentials.json"),
             cache_path=str(tmp_path / "cache.json"),
         )
@@ -259,7 +260,6 @@ class TestCheckAndSleepIfNeeded:
         resets_at = datetime.now(UTC) + timedelta(hours=2)
         config = QuotaGuardConfig(
             enabled=True,
-            threshold=80.0,
             buffer_seconds=0,
             credentials_path=str(tmp_path / ".credentials.json"),
             cache_path=str(tmp_path / "cache.json"),
@@ -269,7 +269,11 @@ class TestCheckAndSleepIfNeeded:
             return QuotaFetchResult(
                 windows={"five_hour": QuotaWindowEntry(utilization=util, resets_at=resets_at)},
                 binding=QuotaStatus(
-                    utilization=util, resets_at=resets_at, window_name="five_hour"
+                    utilization=util,
+                    resets_at=resets_at,
+                    window_name="five_hour",
+                    should_block=util >= 85.0,
+                    effective_threshold=85.0,
                 ),
             )
 
@@ -304,7 +308,6 @@ class TestCheckAndSleepIfNeeded:
         )
         config = QuotaGuardConfig(
             enabled=True,
-            threshold=80.0,
             cache_max_age=120,
             credentials_path=str(tmp_path / ".credentials.json"),
             cache_path=str(cache_path),
@@ -378,7 +381,6 @@ class TestCheckAndSleepIfNeeded:
 
         config = QuotaGuardConfig(
             enabled=True,
-            threshold=80.0,
             credentials_path=str(tmp_path / ".credentials.json"),
             cache_path=str(tmp_path / "cache.json"),
         )
@@ -386,12 +388,24 @@ class TestCheckAndSleepIfNeeded:
         # First fetch: above threshold, has resets_at so Gate 1 passes
         first_result = QuotaFetchResult(
             windows={"five_hour": QuotaWindowEntry(utilization=90.0, resets_at=resets)},
-            binding=QuotaStatus(utilization=90.0, resets_at=resets, window_name="five_hour"),
+            binding=QuotaStatus(
+                utilization=90.0,
+                resets_at=resets,
+                window_name="five_hour",
+                should_block=True,
+                effective_threshold=85.0,
+            ),
         )
         # Second fetch (re-fetch): above threshold, resets_at is None → Gate 2 fires
         second_result = QuotaFetchResult(
             windows={"five_hour": QuotaWindowEntry(utilization=90.0, resets_at=None)},
-            binding=QuotaStatus(utilization=90.0, resets_at=None, window_name="five_hour"),
+            binding=QuotaStatus(
+                utilization=90.0,
+                resets_at=None,
+                window_name="five_hour",
+                should_block=True,
+                effective_threshold=85.0,
+            ),
         )
 
         mock_fetch = AsyncMock(side_effect=[first_result, second_result])
@@ -424,7 +438,6 @@ class TestCheckAndSleepResetAtNoneBlocks:
 
         config = QuotaGuardConfig(
             enabled=True,
-            threshold=80.0,
             buffer_seconds=60,
             credentials_path=str(tmp_path / ".credentials.json"),
             cache_path=str(tmp_path / "cache.json"),
@@ -433,7 +446,13 @@ class TestCheckAndSleepResetAtNoneBlocks:
         async def mock_fetch(path, **kwargs):
             return QuotaFetchResult(
                 windows={"five_hour": QuotaWindowEntry(utilization=90.0, resets_at=None)},
-                binding=QuotaStatus(utilization=90.0, resets_at=None, window_name="five_hour"),
+                binding=QuotaStatus(
+                    utilization=90.0,
+                    resets_at=None,
+                    window_name="five_hour",
+                    should_block=True,
+                    effective_threshold=85.0,
+                ),
             )
 
         monkeypatch.setattr("autoskillit.execution.quota._fetch_quota", mock_fetch)
@@ -456,7 +475,6 @@ class TestCheckAndSleepResetAtNoneBlocks:
         resets_at = datetime.now(UTC) + timedelta(hours=2)
         config = QuotaGuardConfig(
             enabled=True,
-            threshold=80.0,
             buffer_seconds=60,
             credentials_path=str(tmp_path / ".credentials.json"),
             cache_path=str(tmp_path / "cache.json"),
@@ -464,11 +482,23 @@ class TestCheckAndSleepResetAtNoneBlocks:
         # First fetch has resets_at (passes first None guard), second fetch has None
         first_result = QuotaFetchResult(
             windows={"five_hour": QuotaWindowEntry(utilization=90.0, resets_at=resets_at)},
-            binding=QuotaStatus(utilization=90.0, resets_at=resets_at, window_name="five_hour"),
+            binding=QuotaStatus(
+                utilization=90.0,
+                resets_at=resets_at,
+                window_name="five_hour",
+                should_block=True,
+                effective_threshold=85.0,
+            ),
         )
         second_result = QuotaFetchResult(
             windows={"five_hour": QuotaWindowEntry(utilization=90.0, resets_at=None)},
-            binding=QuotaStatus(utilization=90.0, resets_at=None, window_name="five_hour"),
+            binding=QuotaStatus(
+                utilization=90.0,
+                resets_at=None,
+                window_name="five_hour",
+                should_block=True,
+                effective_threshold=85.0,
+            ),
         )
         mock_fetch = AsyncMock(side_effect=[first_result, second_result])
         monkeypatch.setattr("autoskillit.execution.quota._fetch_quota", mock_fetch)
@@ -493,12 +523,17 @@ class TestCheckAndSleepResetAtNoneBlocks:
             str(cache_path),
             QuotaFetchResult(
                 windows={"five_hour": QuotaWindowEntry(utilization=90.0, resets_at=None)},
-                binding=QuotaStatus(utilization=90.0, resets_at=None, window_name="five_hour"),
+                binding=QuotaStatus(
+                    utilization=90.0,
+                    resets_at=None,
+                    window_name="five_hour",
+                    should_block=True,
+                    effective_threshold=85.0,
+                ),
             ),
         )
         config = QuotaGuardConfig(
             enabled=True,
-            threshold=80.0,
             buffer_seconds=60,
             cache_max_age=120,
             credentials_path=str(tmp_path / ".credentials.json"),
@@ -527,7 +562,6 @@ class TestCheckAndSleepResetAtNoneBlocks:
 
         config = QuotaGuardConfig(
             enabled=True,
-            threshold=80.0,
             buffer_seconds=120,
             credentials_path=str(tmp_path / ".credentials.json"),
             cache_path=str(tmp_path / "cache.json"),
@@ -536,7 +570,13 @@ class TestCheckAndSleepResetAtNoneBlocks:
         async def mock_fetch(path, **kwargs):
             return QuotaFetchResult(
                 windows={"five_hour": QuotaWindowEntry(utilization=90.0, resets_at=None)},
-                binding=QuotaStatus(utilization=90.0, resets_at=None, window_name="five_hour"),
+                binding=QuotaStatus(
+                    utilization=90.0,
+                    resets_at=None,
+                    window_name="five_hour",
+                    should_block=True,
+                    effective_threshold=85.0,
+                ),
             )
 
         monkeypatch.setattr("autoskillit.execution.quota._fetch_quota", mock_fetch)
@@ -560,7 +600,6 @@ class TestCheckAndSleepResetAtNoneBlocks:
         # Do NOT override buffer_seconds — exercises the real default (60)
         config = QuotaGuardConfig(
             enabled=True,
-            threshold=80.0,
             credentials_path=str(tmp_path / ".credentials.json"),
             cache_path=str(tmp_path / "cache.json"),
         )
@@ -569,7 +608,11 @@ class TestCheckAndSleepResetAtNoneBlocks:
             return QuotaFetchResult(
                 windows={"five_hour": QuotaWindowEntry(utilization=util, resets_at=resets_at)},
                 binding=QuotaStatus(
-                    utilization=util, resets_at=resets_at, window_name="five_hour"
+                    utilization=util,
+                    resets_at=resets_at,
+                    window_name="five_hour",
+                    should_block=util >= 85.0,
+                    effective_threshold=85.0,
                 ),
             )
 
@@ -605,7 +648,13 @@ class TestIntegration:
             str(cache_path),
             QuotaFetchResult(
                 windows={"five_hour": QuotaWindowEntry(utilization=95.0, resets_at=None)},
-                binding=QuotaStatus(utilization=95.0, resets_at=None, window_name="five_hour"),
+                binding=QuotaStatus(
+                    utilization=95.0,
+                    resets_at=None,
+                    window_name="five_hour",
+                    should_block=True,
+                    effective_threshold=85.0,
+                ),
             ),
         )
 
@@ -636,7 +685,12 @@ class TestMultiWindowSelection:
             "one_hour": QuotaWindowEntry(utilization=91.0, resets_at=resets_one_hour),
             "five_hour": QuotaWindowEntry(utilization=35.0, resets_at=now + timedelta(hours=4)),
         }
-        binding = _compute_binding(windows, threshold=85.0)
+        binding = _compute_binding(
+            windows,
+            short_threshold=85.0,
+            long_threshold=98.0,
+            long_patterns=["weekly", "sonnet", "opus"],
+        )
         assert binding.utilization == pytest.approx(91.0)
         assert binding.resets_at == resets_one_hour
         assert binding.window_name == "one_hour"
@@ -653,7 +707,12 @@ class TestMultiWindowSelection:
             "one_day": QuotaWindowEntry(utilization=97.0, resets_at=resets_one_day),
             "five_hour": QuotaWindowEntry(utilization=35.0, resets_at=now + timedelta(hours=4)),
         }
-        binding = _compute_binding(windows, threshold=85.0)
+        binding = _compute_binding(
+            windows,
+            short_threshold=85.0,
+            long_threshold=98.0,
+            long_patterns=["weekly", "sonnet", "opus"],
+        )
         assert binding.window_name == "one_day"
         assert binding.resets_at == resets_one_day
 
@@ -668,7 +727,12 @@ class TestMultiWindowSelection:
             "five_hour": QuotaWindowEntry(utilization=60.0, resets_at=five_hour_resets),
             "one_day": QuotaWindowEntry(utilization=30.0, resets_at=now + timedelta(days=1)),
         }
-        binding = _compute_binding(windows, threshold=85.0)
+        binding = _compute_binding(
+            windows,
+            short_threshold=85.0,
+            long_threshold=98.0,
+            long_patterns=["weekly", "sonnet", "opus"],
+        )
         assert binding.utilization == pytest.approx(60.0)
         assert binding.window_name == "five_hour"
         assert binding.resets_at == five_hour_resets
@@ -677,7 +741,12 @@ class TestMultiWindowSelection:
     def test_empty_windows_returns_zero_sentinel(self):
         from autoskillit.execution.quota import _compute_binding
 
-        binding = _compute_binding({}, threshold=85.0)
+        binding = _compute_binding(
+            {},
+            short_threshold=85.0,
+            long_threshold=98.0,
+            long_patterns=["weekly", "sonnet", "opus"],
+        )
         assert binding.utilization == pytest.approx(0.0)
         assert binding.resets_at is None
 
@@ -726,7 +795,7 @@ class TestMultiWindowSelection:
         from autoskillit.execution.quota import _read_cache
 
         new_cache = {
-            "schema_version": 2,
+            "schema_version": 3,
             "fetched_at": datetime.now(UTC).isoformat(),
             "windows": {
                 "one_hour": {
@@ -742,6 +811,8 @@ class TestMultiWindowSelection:
                 "window_name": "one_hour",
                 "utilization": 91.0,
                 "resets_at": "2026-04-10T09:45:00+00:00",
+                "should_block": True,
+                "effective_threshold": 85.0,
             },
         }
         cache_path = tmp_path / "new_cache.json"
@@ -750,6 +821,283 @@ class TestMultiWindowSelection:
         assert status is not None
         assert status.utilization == pytest.approx(91.0)
         assert status.window_name == "one_hour"
+
+
+class TestPerWindowThresholds:
+    """Per-window threshold classification: short windows block at 85%, long at 98%."""
+
+    _LONG_PATTERNS = ["weekly", "sonnet", "opus"]
+
+    def test_threshold_for_window_short_default(self):
+        from autoskillit.execution.quota import _threshold_for_window
+
+        assert (
+            _threshold_for_window(
+                "five_hour",
+                short_threshold=85.0,
+                long_threshold=98.0,
+                long_patterns=self._LONG_PATTERNS,
+            )
+            == 85.0
+        )
+
+    def test_threshold_for_window_long_weekly(self):
+        from autoskillit.execution.quota import _threshold_for_window
+
+        assert (
+            _threshold_for_window(
+                "weekly",
+                short_threshold=85.0,
+                long_threshold=98.0,
+                long_patterns=self._LONG_PATTERNS,
+            )
+            == 98.0
+        )
+
+    def test_threshold_for_window_long_sonnet_substring(self):
+        from autoskillit.execution.quota import _threshold_for_window
+
+        assert (
+            _threshold_for_window(
+                "weekly_sonnet",
+                short_threshold=85.0,
+                long_threshold=98.0,
+                long_patterns=self._LONG_PATTERNS,
+            )
+            == 98.0
+        )
+
+    def test_threshold_for_window_case_insensitive(self):
+        from autoskillit.execution.quota import _threshold_for_window
+
+        assert (
+            _threshold_for_window(
+                "Weekly",
+                short_threshold=85.0,
+                long_threshold=98.0,
+                long_patterns=self._LONG_PATTERNS,
+            )
+            == 98.0
+        )
+
+    def test_threshold_for_window_unknown_uses_short(self):
+        from autoskillit.execution.quota import _threshold_for_window
+
+        assert (
+            _threshold_for_window(
+                "context",
+                short_threshold=85.0,
+                long_threshold=98.0,
+                long_patterns=self._LONG_PATTERNS,
+            )
+            == 85.0
+        )
+
+    def test_compute_binding_picks_short_when_only_short_exhausted(self):
+        from autoskillit.execution.quota import QuotaWindowEntry, _compute_binding
+
+        now = datetime.now(UTC)
+        windows = {
+            "five_hour": QuotaWindowEntry(utilization=90.0, resets_at=now + timedelta(hours=1)),
+            "weekly": QuotaWindowEntry(utilization=80.0, resets_at=now + timedelta(days=4)),
+        }
+        binding = _compute_binding(
+            windows,
+            short_threshold=85.0,
+            long_threshold=98.0,
+            long_patterns=self._LONG_PATTERNS,
+        )
+        assert binding.window_name == "five_hour"
+        assert binding.should_block is True
+        assert binding.effective_threshold == pytest.approx(85.0)
+
+    def test_compute_binding_does_not_block_weekly_below_long_threshold(self):
+        """Regression test for issue #721: weekly at 86% must not block.
+
+        Long-window quotas (weekly, sonnet, opus) reset across multi-day windows,
+        so 14% remaining headroom is comfortable, not exhausted. The pre-fix
+        behaviour blocked the pipeline for ~4 days at 86% weekly.
+        """
+        from autoskillit.execution.quota import QuotaWindowEntry, _compute_binding
+
+        now = datetime.now(UTC)
+        windows = {
+            "weekly": QuotaWindowEntry(utilization=86.0, resets_at=now + timedelta(days=4)),
+            "five_hour": QuotaWindowEntry(utilization=50.0, resets_at=now + timedelta(hours=1)),
+        }
+        binding = _compute_binding(
+            windows,
+            short_threshold=85.0,
+            long_threshold=98.0,
+            long_patterns=self._LONG_PATTERNS,
+        )
+        assert binding.should_block is False
+        assert binding.effective_threshold == pytest.approx(98.0)
+
+    def test_compute_binding_blocks_weekly_at_99_percent(self):
+        from autoskillit.execution.quota import QuotaWindowEntry, _compute_binding
+
+        now = datetime.now(UTC)
+        windows = {
+            "weekly": QuotaWindowEntry(utilization=99.0, resets_at=now + timedelta(days=4)),
+        }
+        binding = _compute_binding(
+            windows,
+            short_threshold=85.0,
+            long_threshold=98.0,
+            long_patterns=self._LONG_PATTERNS,
+        )
+        assert binding.should_block is True
+        assert binding.effective_threshold == pytest.approx(98.0)
+
+    def test_compute_binding_picks_latest_resets_among_exhausted(self):
+        """Among exhausted windows, the one with the latest reset wins."""
+        from autoskillit.execution.quota import QuotaWindowEntry, _compute_binding
+
+        now = datetime.now(UTC)
+        weekly_resets = now + timedelta(days=4)
+        windows = {
+            "five_hour": QuotaWindowEntry(utilization=90.0, resets_at=now + timedelta(hours=1)),
+            "weekly": QuotaWindowEntry(utilization=99.0, resets_at=weekly_resets),
+        }
+        binding = _compute_binding(
+            windows,
+            short_threshold=85.0,
+            long_threshold=98.0,
+            long_patterns=self._LONG_PATTERNS,
+        )
+        assert binding.window_name == "weekly"
+        assert binding.resets_at == weekly_resets
+        assert binding.should_block is True
+
+    def test_write_cache_includes_should_block_and_effective_threshold(self, tmp_path):
+        from autoskillit.execution.quota import (
+            QuotaFetchResult,
+            QuotaStatus,
+            QuotaWindowEntry,
+            _write_cache,
+        )
+
+        now = datetime.now(UTC)
+        weekly_resets = now + timedelta(days=4)
+        windows = {
+            "weekly": QuotaWindowEntry(utilization=86.0, resets_at=weekly_resets),
+        }
+        binding = QuotaStatus(
+            utilization=86.0,
+            resets_at=weekly_resets,
+            window_name="weekly",
+            should_block=False,
+            effective_threshold=98.0,
+        )
+        result = QuotaFetchResult(windows=windows, binding=binding)
+        cache_path = tmp_path / "cache.json"
+        _write_cache(str(cache_path), result)
+        data = json.loads(cache_path.read_text())
+        assert data["binding"]["should_block"] is False
+        assert data["binding"]["effective_threshold"] == pytest.approx(98.0)
+
+    def test_read_cache_round_trip_should_block(self, tmp_path):
+        from autoskillit.execution.quota import (
+            QuotaFetchResult,
+            QuotaStatus,
+            QuotaWindowEntry,
+            _read_cache,
+            _write_cache,
+        )
+
+        now = datetime.now(UTC)
+        weekly_resets = now + timedelta(days=4)
+        windows = {
+            "weekly": QuotaWindowEntry(utilization=99.0, resets_at=weekly_resets),
+        }
+        binding = QuotaStatus(
+            utilization=99.0,
+            resets_at=weekly_resets,
+            window_name="weekly",
+            should_block=True,
+            effective_threshold=98.0,
+        )
+        cache_path = tmp_path / "cache.json"
+        _write_cache(str(cache_path), QuotaFetchResult(windows=windows, binding=binding))
+        status = _read_cache(str(cache_path), max_age=300)
+        assert status is not None
+        assert status.should_block is True
+        assert status.effective_threshold == pytest.approx(98.0)
+        assert status.window_name == "weekly"
+
+    @pytest.mark.anyio
+    async def test_check_and_sleep_returns_false_for_weekly_at_86_percent(
+        self, monkeypatch, tmp_path
+    ):
+        """End-to-end regression test for #721 — weekly at 86% must not sleep."""
+        from autoskillit.execution.quota import (
+            QuotaFetchResult,
+            QuotaWindowEntry,
+            _compute_binding,
+            check_and_sleep_if_needed,
+        )
+
+        now = datetime.now(UTC)
+        windows = {
+            "weekly": QuotaWindowEntry(utilization=86.0, resets_at=now + timedelta(days=4)),
+            "five_hour": QuotaWindowEntry(utilization=2.0, resets_at=now + timedelta(hours=1)),
+        }
+        binding = _compute_binding(
+            windows,
+            short_threshold=85.0,
+            long_threshold=98.0,
+            long_patterns=self._LONG_PATTERNS,
+        )
+
+        async def fake_fetch(credentials_path, **kwargs):
+            return QuotaFetchResult(windows=windows, binding=binding)
+
+        monkeypatch.setattr("autoskillit.execution.quota._fetch_quota", fake_fetch)
+        config = QuotaGuardConfig(
+            cache_path=str(tmp_path / "cache.json"),
+            credentials_path=str(tmp_path / "creds.json"),
+        )
+        result = await check_and_sleep_if_needed(config)
+        assert result["should_sleep"] is False
+        assert result["window_name"] == "weekly"
+
+    @pytest.mark.anyio
+    async def test_check_and_sleep_returns_true_for_weekly_at_99_percent(
+        self, monkeypatch, tmp_path
+    ):
+        from autoskillit.execution.quota import (
+            QuotaFetchResult,
+            QuotaWindowEntry,
+            _compute_binding,
+            check_and_sleep_if_needed,
+        )
+
+        now = datetime.now(UTC)
+        weekly_resets = now + timedelta(days=4)
+        windows = {
+            "weekly": QuotaWindowEntry(utilization=99.0, resets_at=weekly_resets),
+            "five_hour": QuotaWindowEntry(utilization=2.0, resets_at=now + timedelta(hours=1)),
+        }
+        binding = _compute_binding(
+            windows,
+            short_threshold=85.0,
+            long_threshold=98.0,
+            long_patterns=self._LONG_PATTERNS,
+        )
+
+        async def fake_fetch(credentials_path, **kwargs):
+            return QuotaFetchResult(windows=windows, binding=binding)
+
+        monkeypatch.setattr("autoskillit.execution.quota._fetch_quota", fake_fetch)
+        config = QuotaGuardConfig(
+            cache_path=str(tmp_path / "cache.json"),
+            credentials_path=str(tmp_path / "creds.json"),
+        )
+        result = await check_and_sleep_if_needed(config)
+        assert result["should_sleep"] is True
+        assert result["window_name"] == "weekly"
+        assert result["sleep_seconds"] > 0
 
 
 class TestRefreshQuotaCache:
@@ -825,7 +1173,7 @@ class TestCacheSchemaVersion:
 
         _reset_schema_drift_logged_for_tests()
 
-    def test_write_cache_embeds_schema_version_2(self, tmp_path):
+    def test_write_cache_embeds_schema_version(self, tmp_path):
         from autoskillit.execution.quota import (
             QuotaFetchResult,
             QuotaStatus,
@@ -840,7 +1188,7 @@ class TestCacheSchemaVersion:
         cache_path = tmp_path / "cache.json"
         _write_cache(str(cache_path), result)
         raw = json.loads(cache_path.read_text())
-        assert raw["schema_version"] == 2
+        assert raw["schema_version"] == 3
 
     def test_write_cache_uses_write_versioned_json(self, tmp_path, monkeypatch):
         from autoskillit.execution.quota import (
@@ -868,9 +1216,9 @@ class TestCacheSchemaVersion:
         cache_path = tmp_path / "cache.json"
         _write_cache(str(cache_path), result)
         assert len(calls) == 1
-        assert calls[0]["schema_version"] == 2
+        assert calls[0]["schema_version"] == 3
 
-    def test_read_cache_schema_v2_returns_status(self, tmp_path):
+    def test_read_cache_schema_round_trip_returns_status(self, tmp_path):
         from autoskillit.execution.quota import (
             QuotaFetchResult,
             QuotaStatus,
@@ -1042,4 +1390,4 @@ class TestCacheSchemaVersion:
         )
         await check_and_sleep_if_needed(config)
         new_data = json.loads(cache_path.read_text())
-        assert new_data["schema_version"] == 2
+        assert new_data["schema_version"] == 3

--- a/tests/execution/test_quota_http.py
+++ b/tests/execution/test_quota_http.py
@@ -46,7 +46,9 @@ def quota_config(credentials, tmp_path):
         credentials_path=credentials,
         cache_path=str(tmp_path / "quota_cache.json"),
         cache_max_age=120,
-        threshold=80,
+        short_window_threshold=80.0,
+        long_window_threshold=98.0,
+        long_window_patterns=["weekly", "sonnet", "opus"],
         buffer_seconds=60,
     )
 

--- a/tests/infra/test_quota_check.py
+++ b/tests/infra/test_quota_check.py
@@ -1,7 +1,8 @@
 """Tests for the quota_check PreToolUse hook.
 
-The hook reads a local quota cache file and denies run_skill when utilization
-exceeds the threshold. It fails open when the cache is missing/stale/corrupt.
+The hook reads a local quota cache file and denies run_skill when the cached
+binding marks ``should_block=True``. It fails open when the cache is
+missing/stale/corrupt.
 """
 
 import io
@@ -11,6 +12,13 @@ from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import patch
 
+_LONG_PATTERNS = ("weekly", "sonnet", "opus")
+
+
+def _classify_threshold(window_name: str) -> float:
+    lowered = window_name.lower()
+    return 98.0 if any(p in lowered for p in _LONG_PATTERNS) else 85.0
+
 
 def _write_cache(
     cache_path: Path,
@@ -18,8 +26,18 @@ def _write_cache(
     resets_at: str | None = None,
     window_name: str = "five_hour",
     extra_windows: dict | None = None,
+    should_block: bool | None = None,
+    effective_threshold: float | None = None,
 ) -> None:
-    """Write a fresh quota cache file in the full-snapshot format."""
+    """Write a fresh quota cache file in the full-snapshot format.
+
+    When ``should_block`` is None, classifies the window via the default
+    long-window patterns and computes ``should_block`` from utilization.
+    """
+    if effective_threshold is None:
+        effective_threshold = _classify_threshold(window_name)
+    if should_block is None:
+        should_block = utilization >= effective_threshold
     windows = {window_name: {"utilization": utilization, "resets_at": resets_at}}
     if extra_windows:
         windows.update(extra_windows)
@@ -30,6 +48,8 @@ def _write_cache(
             "window_name": window_name,
             "utilization": utilization,
             "resets_at": resets_at,
+            "should_block": should_block,
+            "effective_threshold": effective_threshold,
         },
     }
     cache_path.parent.mkdir(parents=True, exist_ok=True)
@@ -138,38 +158,47 @@ def test_approve_when_stale_cache(tmp_path):
 
 
 def _write_hook_config(
-    hook_cfg_path: Path, threshold: float, cache_max_age: int, cache_path: str
+    hook_cfg_path: Path,
+    cache_max_age: int,
+    cache_path: str,
+    extra: dict | None = None,
 ) -> None:
     """Write a hook config file to the given path."""
+    quota_guard: dict = {
+        "cache_max_age": cache_max_age,
+        "cache_path": cache_path,
+    }
+    if extra:
+        quota_guard.update(extra)
     hook_cfg_path.parent.mkdir(parents=True, exist_ok=True)
-    hook_cfg_path.write_text(
-        json.dumps(
-            {
-                "quota_guard": {
-                    "threshold": threshold,
-                    "cache_max_age": cache_max_age,
-                    "cache_path": cache_path,
-                }
-            }
-        )
-    )
+    hook_cfg_path.write_text(json.dumps({"quota_guard": quota_guard}))
 
 
-# T-CFG-1
-def test_quota_check_reads_threshold_from_hook_config(tmp_path, monkeypatch):
-    """Hook must deny when utilization exceeds user-configured threshold from hook config."""
+# T-CFG-1: hook trusts cache binding, never re-derives a verdict from hook config.
+def test_hook_does_not_consult_threshold_field_in_hook_config(tmp_path, monkeypatch):
+    """Hook trusts ``binding.should_block`` and ignores any threshold in hook config.
+
+    Single-source-of-truth assertion: even if a stale ``short_window_threshold``
+    in hook config would imply a deny, the hook must approve when the cache
+    binding says ``should_block=False``.
+    """
     monkeypatch.chdir(tmp_path)
     cache = tmp_path / "custom_cache.json"
-    _write_cache(cache, utilization=60.0)
+    _write_cache(
+        cache,
+        utilization=70.0,
+        window_name="five_hour",
+        should_block=False,
+        effective_threshold=85.0,
+    )
     _write_hook_config(
         tmp_path / ".autoskillit" / ".hook_config.json",
-        threshold=50.0,
         cache_max_age=300,
         cache_path=str(cache),
+        extra={"short_window_threshold": 50.0},
     )
     out, _ = _run_hook(event={"tool_name": "run_skill"})
-    data = json.loads(out)
-    assert data["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert out.strip() == ""
 
 
 # T-CFG-2
@@ -181,7 +210,6 @@ def test_quota_check_reads_cache_path_from_hook_config(tmp_path, monkeypatch):
     _write_cache(custom_cache, utilization=95.0)
     _write_hook_config(
         tmp_path / ".autoskillit" / ".hook_config.json",
-        threshold=85.0,
         cache_max_age=300,
         cache_path=str(custom_cache),
     )
@@ -207,7 +235,6 @@ def test_quota_check_env_var_overrides_hook_config_cache_path(tmp_path, monkeypa
     _write_cache(wrong_cache, utilization=50.0)
     _write_hook_config(
         tmp_path / ".autoskillit" / ".hook_config.json",
-        threshold=85.0,
         cache_max_age=300,
         cache_path=str(wrong_cache),
     )
@@ -220,10 +247,7 @@ def test_quota_check_env_var_overrides_hook_config_cache_path(tmp_path, monkeypa
 
 # T-CFG-4
 def test_quota_check_falls_back_to_defaults_without_hook_config(tmp_path, monkeypatch):
-    """Without hook config, hook falls back to hard-coded defaults (threshold=85.0).
-
-    Regression test: no regression when kitchen was never opened or hook config was removed.
-    """
+    """Without hook config, hook still resolves cache via override / env var."""
     monkeypatch.chdir(tmp_path)
     cache = tmp_path / "quota_cache.json"
     _write_cache(cache, utilization=95.0)
@@ -245,7 +269,7 @@ def test_quota_event_approved_written_to_log(tmp_path, monkeypatch):
     assert len(events) == 1
     assert events[0]["event"] == "approved"
     assert events[0]["utilization"] == 50.0
-    assert events[0]["threshold"] == 85.0
+    assert events[0]["effective_threshold"] == 85.0
     assert "ts" in events[0]
 
 
@@ -263,7 +287,7 @@ def test_quota_event_blocked_written_to_log(tmp_path, monkeypatch):
     ev = events[0]
     assert ev["event"] == "blocked"
     assert ev["utilization"] == 95.0
-    assert ev["threshold"] == 85.0
+    assert ev["effective_threshold"] == 85.0
     assert isinstance(ev["sleep_seconds"], int)
     assert ev["sleep_seconds"] > 0
     assert "ts" in ev
@@ -347,6 +371,78 @@ def test_defaults_yaml_cache_max_age_is_300():
     defaults = load_yaml(pkg_root() / "config" / "defaults.yaml")
     assert isinstance(defaults, dict)
     assert defaults["quota_guard"]["cache_max_age"] == 300
+
+
+# T-HOOK-PWT-1: regression test for #721 — weekly at 86% must approve.
+def test_hook_approves_weekly_at_86_percent_should_block_false(tmp_path):
+    """Weekly window at 86% utilisation must NOT be blocked.
+
+    Regression test for issue #721: long-window quotas (weekly/sonnet/opus)
+    use a higher threshold (98%), so 86% is comfortable headroom — not exhaustion.
+    """
+    cache = tmp_path / "quota_cache.json"
+    _write_cache(
+        cache,
+        utilization=86.0,
+        window_name="weekly",
+        should_block=False,
+        effective_threshold=98.0,
+    )
+    out, _ = _run_hook(event={"tool_name": "run_skill"}, cache_path=cache)
+    assert out.strip() == ""
+
+
+# T-HOOK-PWT-2: weekly above 98% must still deny.
+def test_hook_blocks_weekly_above_long_threshold(tmp_path):
+    cache = tmp_path / "quota_cache.json"
+    _write_cache(
+        cache,
+        utilization=99.0,
+        window_name="weekly",
+        should_block=True,
+        effective_threshold=98.0,
+    )
+    out, _ = _run_hook(event={"tool_name": "run_skill"}, cache_path=cache)
+    data = json.loads(out)
+    assert data["hookSpecificOutput"]["permissionDecision"] == "deny"
+    reason = data["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "weekly" in reason
+    assert "98" in reason
+
+
+# T-HOOK-PWT-3: short window above 85% must deny with short threshold in message.
+def test_hook_blocks_short_window_above_threshold_message(tmp_path):
+    cache = tmp_path / "quota_cache.json"
+    _write_cache(
+        cache,
+        utilization=90.0,
+        window_name="five_hour",
+        should_block=True,
+        effective_threshold=85.0,
+    )
+    out, _ = _run_hook(event={"tool_name": "run_skill"}, cache_path=cache)
+    data = json.loads(out)
+    reason = data["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "five_hour" in reason
+    assert "85" in reason
+
+
+# T-HOOK-PWT-4: missing should_block field → fail open (approve).
+def test_hook_falls_back_when_should_block_field_missing(tmp_path):
+    """Old-format cache without should_block defaults to approve (fail-open)."""
+    cache = tmp_path / "quota_cache.json"
+    payload = {
+        "fetched_at": datetime.now(UTC).isoformat(),
+        "windows": {"five_hour": {"utilization": 95.0, "resets_at": None}},
+        "binding": {
+            "window_name": "five_hour",
+            "utilization": 95.0,
+            "resets_at": None,
+        },
+    }
+    cache.write_text(json.dumps(payload))
+    out, _ = _run_hook(event={"tool_name": "run_skill"}, cache_path=cache)
+    assert out.strip() == ""
 
 
 # T-HOOK-MW-1: cache with one_hour binding above threshold → deny

--- a/tests/infra/test_quota_post_check.py
+++ b/tests/infra/test_quota_post_check.py
@@ -299,8 +299,9 @@ def test_post_hook_silent_when_weekly_below_long_threshold(tmp_path):
         effective_threshold=98.0,
     )
     event = _build_event()
-    out, _ = _run_hook(event=event, cache_path=cache)
+    out, exit_code = _run_hook(event=event, cache_path=cache)
     assert out.strip() == ""
+    assert exit_code == 0
 
 
 # T-PCHK-PWT-2: weekly above 98% must still warn.

--- a/tests/infra/test_quota_post_check.py
+++ b/tests/infra/test_quota_post_check.py
@@ -12,6 +12,13 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import patch
 
+_LONG_PATTERNS = ("weekly", "sonnet", "opus")
+
+
+def _classify_threshold(window_name: str) -> float:
+    lowered = window_name.lower()
+    return 98.0 if any(p in lowered for p in _LONG_PATTERNS) else 85.0
+
 
 def _write_cache(
     cache_path: Path,
@@ -19,8 +26,18 @@ def _write_cache(
     resets_at: str | None = None,
     window_name: str = "five_hour",
     extra_windows: dict | None = None,
+    should_block: bool | None = None,
+    effective_threshold: float | None = None,
 ) -> None:
-    """Write a fresh quota cache file in the full-snapshot format."""
+    """Write a fresh quota cache file in the full-snapshot format.
+
+    When ``should_block`` is None, classifies the window via the default
+    long-window patterns and computes ``should_block`` from utilization.
+    """
+    if effective_threshold is None:
+        effective_threshold = _classify_threshold(window_name)
+    if should_block is None:
+        should_block = utilization >= effective_threshold
     windows = {window_name: {"utilization": utilization, "resets_at": resets_at}}
     if extra_windows:
         windows.update(extra_windows)
@@ -31,6 +48,8 @@ def _write_cache(
             "window_name": window_name,
             "utilization": utilization,
             "resets_at": resets_at,
+            "should_block": should_block,
+            "effective_threshold": effective_threshold,
         },
     }
     cache_path.parent.mkdir(parents=True, exist_ok=True)
@@ -200,19 +219,24 @@ def test_qpc10_fires_on_failed_run_skill(tmp_path):
     assert "QUOTA WARNING" in data["hookSpecificOutput"]["updatedMCPToolOutput"]
 
 
-# T11: Hook reads threshold from hook config
-def test_qpc11_reads_threshold_from_hook_config(tmp_path, monkeypatch):
-    """PostToolUse hook reads threshold from .autoskillit/.hook_config.json."""
+# T11: Hook reads cache_path from hook config
+def test_qpc11_reads_cache_path_from_hook_config(tmp_path, monkeypatch):
+    """PostToolUse hook reads cache_path from .autoskillit/.hook_config.json.
+
+    The hook trusts the cache binding's ``should_block`` flag — it never re-derives
+    a verdict from a hook config threshold. This test only verifies that the hook
+    locates the cache file via the hook config cache_path setting.
+    """
     monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AUTOSKILLIT_QUOTA_CACHE", raising=False)
     cache = tmp_path / "custom_cache.json"
-    _write_cache(cache, utilization=60.0)
+    _write_cache(cache, utilization=95.0)
     hook_cfg_path = tmp_path / ".autoskillit" / ".hook_config.json"
     hook_cfg_path.parent.mkdir(parents=True, exist_ok=True)
     hook_cfg_path.write_text(
         json.dumps(
             {
                 "quota_guard": {
-                    "threshold": 50.0,
                     "cache_max_age": 300,
                     "cache_path": str(cache),
                 }
@@ -261,6 +285,41 @@ def test_qpc14_only_run_skill_matcher():
     assert re.match(entry.matcher, "mcp__plugin_autoskillit_autoskillit__run_skill")
     assert not re.match(entry.matcher, "mcp__plugin_autoskillit_autoskillit__run_cmd")
     assert not re.match(entry.matcher, "mcp__plugin_autoskillit_autoskillit__kitchen_status")
+
+
+# T-PCHK-PWT-1: regression test for #721 — post_check silent for weekly at 86%.
+def test_post_hook_silent_when_weekly_below_long_threshold(tmp_path):
+    """Weekly window at 86% must NOT emit a warning. Regression test for #721."""
+    cache = tmp_path / "quota_cache.json"
+    _write_cache(
+        cache,
+        utilization=86.0,
+        window_name="weekly",
+        should_block=False,
+        effective_threshold=98.0,
+    )
+    event = _build_event()
+    out, _ = _run_hook(event=event, cache_path=cache)
+    assert out.strip() == ""
+
+
+# T-PCHK-PWT-2: weekly above 98% must still warn.
+def test_post_hook_warns_when_weekly_above_long_threshold(tmp_path):
+    cache = tmp_path / "quota_cache.json"
+    _write_cache(
+        cache,
+        utilization=99.0,
+        window_name="weekly",
+        should_block=True,
+        effective_threshold=98.0,
+    )
+    event = _build_event()
+    out, _ = _run_hook(event=event, cache_path=cache)
+    data = json.loads(out)
+    output = data["hookSpecificOutput"]["updatedMCPToolOutput"]
+    assert "QUOTA WARNING" in output
+    assert "weekly" in output
+    assert "98" in output
 
 
 # T-PCHK-MW-1: post_check warns when binding window is exhausted (not five_hour)

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -124,7 +124,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # background.py — payload dict
     ("src/autoskillit/pipeline/background.py", 132),
     # tools_kitchen.py — hook config dict
-    ("src/autoskillit/server/tools_kitchen.py", 138),
+    ("src/autoskillit/server/tools_kitchen.py", 135),
     # tools_status.py — mcp_data dict
     ("src/autoskillit/server/tools_status.py", 321),
     # tools_github.py — bug report dict

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -126,7 +126,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # tools_kitchen.py — hook config dict
     ("src/autoskillit/server/tools_kitchen.py", 138),
     # tools_status.py — mcp_data dict
-    ("src/autoskillit/server/tools_status.py", 320),
+    ("src/autoskillit/server/tools_status.py", 321),
     # tools_github.py — bug report dict
     ("src/autoskillit/server/tools_github.py", 256),
     # _hooks.py — settings.json dict (co-owned with Claude CLI)

--- a/tests/server/test_tools_kitchen.py
+++ b/tests/server/test_tools_kitchen.py
@@ -118,12 +118,13 @@ async def test_open_kitchen_writes_hook_config_json(tmp_path, monkeypatch):
     hook_cfg = tmp_path / ".autoskillit" / ".hook_config.json"
     assert hook_cfg.exists(), "Hook config file must be written by open_kitchen"
     data = json.loads(hook_cfg.read_text())
-    assert data["quota_guard"]["short_window_threshold"] == 85.0
-    assert data["quota_guard"]["long_window_threshold"] == 98.0
-    assert data["quota_guard"]["long_window_patterns"] == ["weekly", "sonnet", "opus"]
-    assert "threshold" not in data["quota_guard"]
     assert data["quota_guard"]["cache_max_age"] == 300
     assert data["quota_guard"]["cache_path"] == "/custom/path.json"
+    # threshold fields are pre-computed into should_block in the cache — not written to hook_config
+    assert "threshold" not in data["quota_guard"]
+    assert "short_window_threshold" not in data["quota_guard"]
+    assert "long_window_threshold" not in data["quota_guard"]
+    assert "long_window_patterns" not in data["quota_guard"]
     # Confirm kitchen_id rename: hook config must contain 'kitchen_id' (not 'pipeline_id')
     assert "kitchen_id" in data, (
         "hook config must contain 'kitchen_id' after rename from 'pipeline_id'"

--- a/tests/server/test_tools_kitchen.py
+++ b/tests/server/test_tools_kitchen.py
@@ -94,7 +94,9 @@ async def test_open_kitchen_writes_hook_config_json(tmp_path, monkeypatch):
     """open_kitchen must write .autoskillit/.hook_config.json with user quota_guard values."""
     monkeypatch.chdir(tmp_path)
     mock_ctx = _make_mock_ctx()
-    mock_ctx.config.quota_guard.threshold = 85.0
+    mock_ctx.config.quota_guard.short_window_threshold = 85.0
+    mock_ctx.config.quota_guard.long_window_threshold = 98.0
+    mock_ctx.config.quota_guard.long_window_patterns = ["weekly", "sonnet", "opus"]
     mock_ctx.config.quota_guard.cache_max_age = 300
     mock_ctx.config.quota_guard.cache_path = "/custom/path.json"
 
@@ -116,7 +118,10 @@ async def test_open_kitchen_writes_hook_config_json(tmp_path, monkeypatch):
     hook_cfg = tmp_path / ".autoskillit" / ".hook_config.json"
     assert hook_cfg.exists(), "Hook config file must be written by open_kitchen"
     data = json.loads(hook_cfg.read_text())
-    assert data["quota_guard"]["threshold"] == 85.0
+    assert data["quota_guard"]["short_window_threshold"] == 85.0
+    assert data["quota_guard"]["long_window_threshold"] == 98.0
+    assert data["quota_guard"]["long_window_patterns"] == ["weekly", "sonnet", "opus"]
+    assert "threshold" not in data["quota_guard"]
     assert data["quota_guard"]["cache_max_age"] == 300
     assert data["quota_guard"]["cache_path"] == "/custom/path.json"
     # Confirm kitchen_id rename: hook config must contain 'kitchen_id' (not 'pipeline_id')
@@ -134,7 +139,9 @@ async def test_close_kitchen_removes_hook_config_json(tmp_path, monkeypatch):
     """close_kitchen must remove .autoskillit/.hook_config.json to prevent stale config."""
     monkeypatch.chdir(tmp_path)
     mock_ctx = _make_mock_ctx()
-    mock_ctx.config.quota_guard.threshold = 85.0
+    mock_ctx.config.quota_guard.short_window_threshold = 85.0
+    mock_ctx.config.quota_guard.long_window_threshold = 98.0
+    mock_ctx.config.quota_guard.long_window_patterns = ["weekly", "sonnet", "opus"]
     mock_ctx.config.quota_guard.cache_max_age = 300
     mock_ctx.config.quota_guard.cache_path = "~/.claude/quota_cache.json"
 
@@ -206,9 +213,11 @@ async def test_open_kitchen_does_not_write_gate_file(tmp_path, monkeypatch):
     """_open_kitchen_handler must never write a gate file."""
     monkeypatch.chdir(tmp_path)
     mock_ctx = _make_mock_ctx()
-    mock_ctx.config.quota_guard.threshold = None
-    mock_ctx.config.quota_guard.cache_max_age = None
-    mock_ctx.config.quota_guard.cache_path = None
+    mock_ctx.config.quota_guard.short_window_threshold = 85.0
+    mock_ctx.config.quota_guard.long_window_threshold = 98.0
+    mock_ctx.config.quota_guard.long_window_patterns = ["weekly", "sonnet", "opus"]
+    mock_ctx.config.quota_guard.cache_max_age = 300
+    mock_ctx.config.quota_guard.cache_path = "~/.claude/quota_cache.json"
     with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
         with patch("autoskillit.server.logger"):
             with patch("autoskillit.server.tools_kitchen._prime_quota_cache", new=AsyncMock()):


### PR DESCRIPTION
## Summary

The quota guard currently uses one global threshold (85%) for every rate-limit window
returned by the Anthropic usage API. This is correct for short-window quotas
(`five_hour`, `context`) where 85% means imminent exhaustion, but wrong for
long-window quotas (`weekly`, `sonnet`/model-weekly windows) where 15% remaining
budget across multi-day reset windows is comfortable headroom. The result is that
the pipeline halts for ~4 days at 86% weekly when it should keep running.

This PR introduces **per-window thresholds**, classified by window-name pattern,
and pushes the classification into the cache writer so the stdlib-only hooks
(`quota_check.py`, `quota_post_check.py`) need no classification logic of their own.

**Design summary:**

1. `QuotaGuardConfig` gains three fields: `short_window_threshold` (default 85.0),
   `long_window_threshold` (default 98.0), and `long_window_patterns`
   (default `["weekly", "sonnet", "opus"]` — substrings matched case-insensitively
   against window names).
2. `quota.py` adds `_threshold_for_window(name, short, long, patterns) -> float`
   and `_compute_binding` is rewritten to apply that per-window threshold.
3. The cache binding payload gains two new fields written by `_write_cache`:
   - `should_block: bool` — true iff the binding window exceeds *its own* threshold
   - `effective_threshold: float` — the threshold applied to the binding window
4. `_write_hook_config` writes the same three new config fields into
   `.autoskillit/.hook_config.json`.
5. `quota_check.py` and `quota_post_check.py` no longer compute "above threshold"
   themselves. They read `binding.should_block` and use `effective_threshold` only
   for human-readable display in the deny/warning message.
6. `check_and_sleep_if_needed` uses the new per-window comparison.

The single `threshold` field is removed entirely (no backward-compat shim — the
config is project-internal and the YAML default is updated in lockstep).

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 52, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START — kitchen open or run_skill trigger])
    APPROVE([APPROVE — run_skill proceeds])
    DENY([DENY — run_skill blocked])
    WARN([WARN — post-execution quota warning injected])
    PASS([PASS — post-execution no-op])

    %% CONFIG LAYER %%
    subgraph Config ["● Configuration Layer"]
        direction LR
        DefaultsYAML["● defaults.yaml<br/>━━━━━━━━━━<br/>short_window_threshold: 85%<br/>long_window_threshold: 98%<br/>long_window_patterns: weekly/sonnet/opus"]
        QGConfig["● QuotaGuardConfig<br/>━━━━━━━━━━<br/>short_window_threshold: float<br/>long_window_threshold: float<br/>long_window_patterns: list[str]<br/>cache_max_age / buffer_seconds"]
        DefaultsYAML -->|"dynaconf layered load"| QGConfig
    end

    %% KITCHEN OPEN SEQUENCE %%
    subgraph KitchenOpen ["Kitchen Open Sequence"]
        direction TB
        WriteHookCfg["_write_hook_config<br/>━━━━━━━━━━<br/>writes short/long thresholds<br/>+ long_patterns to<br/>.autoskillit/.hook_config.json"]
        PrimeCache["_prime_quota_cache<br/>━━━━━━━━━━<br/>calls check_and_sleep_if_needed<br/>populates cache before first hook"]
        RefreshLoop["_quota_refresh_loop<br/>━━━━━━━━━━<br/>background task<br/>sleeps cache_refresh_interval(240s)<br/>then calls _refresh_quota_cache<br/>loops until CancelledError"]
    end

    %% QUOTA RESOLUTION CORE %%
    subgraph QuotaCore ["● Quota Resolution Core (quota.py)"]
        direction TB
        CheckEnabled{"● quota_guard<br/>enabled?"}
        ReadCache["● _read_cache<br/>━━━━━━━━━━<br/>reads cache_path<br/>validates schema_version==3<br/>checks age ≤ cache_max_age"]
        CacheFresh{"cache fresh<br/>and valid?"}
        FetchQuota["_fetch_quota<br/>━━━━━━━━━━<br/>GET /api/oauth/usage<br/>Bearer token from credentials_path<br/>returns all windows"]
        WriteCache["_write_cache<br/>━━━━━━━━━━<br/>writes windows + binding<br/>to cache_path (versioned JSON)"]
        ComputeBinding["● _compute_binding<br/>━━━━━━━━━━<br/>iterates all windows<br/>calls _threshold_for_window per window<br/>collects exhausted windows"]
        ThresholdFor["● _threshold_for_window<br/>━━━━━━━━━━<br/>substring match name vs long_patterns<br/>match → long_window_threshold(98%)<br/>no match → short_window_threshold(85%)"]
        WindowExhausted{"any window<br/>≥ its threshold?"}
        BindingExhausted["select binding = latest resets_at<br/>among exhausted windows<br/>should_block = True"]
        BindingDiag["select binding = highest utilization<br/>among all windows (diagnostic)<br/>should_block = False"]
    end

    %% PRE-TOOL-USE GATE %%
    subgraph PreHook ["● PreToolUse Gate (quota_check.py)"]
        direction TB
        ReadHookCfg["● _read_hook_config<br/>━━━━━━━━━━<br/>reads .autoskillit/.hook_config.json<br/>gets cache_path, cache_max_age<br/>quota thresholds (reference only)"]
        ReadCacheHook["● _read_quota_cache<br/>━━━━━━━━━━<br/>reads binding.should_block<br/>binding.effective_threshold<br/>binding.window_name / utilization"]
        ShouldBlock{"binding<br/>should_block?"}
        CalcSleep["calc sleep_seconds<br/>━━━━━━━━━━<br/>resets_at − now + buffer(60s)<br/>fallback = 60s if resets_at None"]
        EmitDeny["emit deny decision<br/>━━━━━━━━━━<br/>JSON hookSpecificOutput<br/>permissionDecision: deny<br/>with sleep instruction + retry prompt"]
        LogEvent["● _write_quota_log_event<br/>━━━━━━━━━━<br/>appends to quota_events.jsonl<br/>event: blocked / approved / cache_miss"]
    end

    %% POST-TOOL-USE WARNING %%
    subgraph PostHook ["● PostToolUse Warning (quota_post_check.py)"]
        direction TB
        ReadCachePost["● _read_quota_cache (post)<br/>━━━━━━━━━━<br/>re-reads cache after run_skill<br/>binding.should_block"]
        PostShouldBlock{"binding<br/>should_block?"}
        ExtractResult["_extract_run_skill_result<br/>━━━━━━━━━━<br/>compact summary ≤ 500 chars<br/>from double-wrapped JSON"]
        EmitWarning["emit updatedMCPToolOutput<br/>━━━━━━━━━━<br/>result summary + QUOTA WARNING<br/>with sleep instruction"]
        LogPostEvent["● _write_quota_log_event (post)<br/>━━━━━━━━━━<br/>event: post_check_warning<br/>or post_check_pass"]
    end

    %% OBSERVABILITY %%
    subgraph Observability ["● Observability"]
        direction LR
        EventsJSONL[("quota_events.jsonl<br/>━━━━━━━━━━<br/>~/.local/share/autoskillit/logs/<br/>append-only JSONL")]
        GetQuotaEvents["● get_quota_events MCP tool<br/>━━━━━━━━━━<br/>reads last n events<br/>most-recent-first"]
        EventsJSONL -->|"reads"| GetQuotaEvents
    end

    %% TOP-LEVEL FLOW %%
    START --> QGConfig
    QGConfig -->|"passed to open_kitchen"| WriteHookCfg
    WriteHookCfg -->|"config written"| PrimeCache
    PrimeCache -->|"triggers"| CheckEnabled
    WriteHookCfg -.->|"starts background task"| RefreshLoop
    RefreshLoop -.->|"periodic: every 240s"| FetchQuota

    %% QUOTA RESOLUTION FLOW %%
    CheckEnabled -->|"disabled"| APPROVE
    CheckEnabled -->|"enabled"| ReadCache
    ReadCache --> CacheFresh
    CacheFresh -->|"yes — use cached binding"| WindowExhausted
    CacheFresh -->|"no — cache miss/stale/schema-drift"| FetchQuota
    FetchQuota -->|"all windows parsed"| ComputeBinding
    ComputeBinding -->|"per window"| ThresholdFor
    ThresholdFor -->|"effective threshold set"| WindowExhausted
    WindowExhausted -->|"yes"| BindingExhausted
    WindowExhausted -->|"no"| BindingDiag
    BindingExhausted --> WriteCache
    BindingDiag --> WriteCache

    %% PRE-HOOK FLOW %%
    WriteCache -->|"cache ready"| ReadHookCfg
    ReadHookCfg --> ReadCacheHook
    ReadCacheHook --> ShouldBlock
    ShouldBlock -->|"no"| LogEvent
    ShouldBlock -->|"yes"| CalcSleep
    CalcSleep --> EmitDeny
    EmitDeny --> LogEvent
    LogEvent -->|"approved"| APPROVE
    LogEvent -->|"blocked"| DENY

    %% POST-HOOK FLOW %%
    APPROVE -->|"run_skill executes"| ReadCachePost
    ReadCachePost --> PostShouldBlock
    PostShouldBlock -->|"no"| LogPostEvent
    PostShouldBlock -->|"yes"| ExtractResult
    ExtractResult --> EmitWarning
    EmitWarning --> LogPostEvent
    LogPostEvent -->|"pass"| PASS
    LogPostEvent -->|"warned"| WARN

    %% OBSERVABILITY CONNECTIONS %%
    LogEvent -.->|"appends"| EventsJSONL
    LogPostEvent -.->|"appends"| EventsJSONL

    %% CLASS ASSIGNMENTS %%
    class START,APPROVE,DENY,WARN,PASS terminal;
    class QGConfig,DefaultsYAML stateNode;
    class WriteHookCfg,PrimeCache,FetchQuota,WriteCache,CalcSleep,ExtractResult handler;
    class RefreshLoop,ComputeBinding,ThresholdFor phase;
    class ReadCache,ReadCacheHook,ReadCachePost,ReadHookCfg,LogEvent,LogPostEvent handler;
    class CheckEnabled,CacheFresh,WindowExhausted,ShouldBlock,PostShouldBlock detector;
    class BindingExhausted,BindingDiag phase;
    class EmitDeny,EmitWarning detector;
    class EventsJSONL,GetQuotaEvents output;
```

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph ConfigLayer ["● INIT_ONLY CONFIG — QuotaGuardConfig (settings.py / defaults.yaml)"]
        direction LR
        SHORT_T["● short_window_threshold<br/>━━━━━━━━━━<br/>default 85.0 — strict<br/>INIT_ONLY"]
        LONG_T["● long_window_threshold<br/>━━━━━━━━━━<br/>default 98.0 — permissive<br/>INIT_ONLY"]
        LONG_PAT["● long_window_patterns<br/>━━━━━━━━━━<br/>[weekly, sonnet, opus]<br/>INIT_ONLY"]
        CACHE_CFG["cache_max_age / cache_path<br/>━━━━━━━━━━<br/>300s / autoskillit_quota_cache.json<br/>INIT_ONLY"]
    end

    subgraph ThresholdDispatch ["● THRESHOLD DISPATCH — _threshold_for_window (quota.py)"]
        direction TB
        ROUTE{"window_name ∈<br/>● long_window_patterns?"}
        LONG_BRANCH["● long_window_threshold<br/>━━━━━━━━━━<br/>weekly / sonnet / opus<br/>permissive: 98.0"]
        SHORT_BRANCH["● short_window_threshold<br/>━━━━━━━━━━<br/>hourly / daily / other<br/>strict: 85.0"]
    end

    subgraph ComputeBinding ["● DERIVED — _compute_binding (quota.py)"]
        direction LR
        EFF_T["● effective_threshold<br/>━━━━━━━━━━<br/>per-window threshold applied<br/>DERIVED — display only"]
        SHOULD_BLK["● should_block<br/>━━━━━━━━━━<br/>utilization >= effective_threshold<br/>DERIVED — gate key"]
        WIN_UTIL["utilization / window_name / resets_at<br/>━━━━━━━━━━<br/>worst-case window selected<br/>DERIVED from API windows"]
    end

    subgraph CacheCheckpoint ["● CHECKPOINT — autoskillit_quota_cache.json (schema_v3)"]
        direction TB
        SCHEMA["schema_version = 3<br/>━━━━━━━━━━<br/>INIT_ONLY at write<br/>mismatch → discard cache"]
        FETCHED["fetched_at: datetime<br/>━━━━━━━━━━<br/>INIT_ONLY at write, TTL anchor<br/>age > 300s → discard cache"]
        BINDING_SNAP["binding: snapshot<br/>━━━━━━━━━━<br/>should_block · utilization<br/>effective_threshold · window_name<br/>resets_at — pre-resolved, INIT_ONLY"]
    end

    subgraph ResumeGates ["● RESUME DETECTION — _read_cache (quota.py)"]
        direction TB
        VER_CHECK{"schema_version<br/>== 3?"}
        AGE_CHECK{"age<br/>≤ cache_max_age?"}
        LIVE_FETCH["Live Fetch<br/>━━━━━━━━━━<br/>_fetch_quota() API call<br/>→ rewrite cache fresh"]
        CACHE_HIT["Cache Hit<br/>━━━━━━━━━━<br/>restore binding snapshot<br/>skip API call entirely"]
    end

    subgraph HookGates ["● VALIDATION GATES — quota hooks (fail-open design)"]
        direction TB
        PRE["● PreToolUse Gate<br/>━━━━━━━━━━<br/>quota_check.py<br/>deny run_skill if should_block=True"]
        POST["● PostToolUse Gate<br/>━━━━━━━━━━<br/>quota_post_check.py<br/>replace output if should_block=True"]
        FO["FAIL OPEN<br/>━━━━━━━━━━<br/>cache miss / stale / corrupt<br/>→ always pass through (sys.exit 0)"]
    end

    subgraph AppendOnly ["APPEND_ONLY AUDIT — quota_events.jsonl"]
        direction LR
        LOG["quota_events.jsonl<br/>━━━━━━━━━━<br/>approved / blocked / post_check_pass<br/>write-only to system logic"]
    end

    subgraph StatusSurface ["● STATUS SURFACE — tools_status.py / tools_kitchen.py"]
        direction LR
        KS["● kitchen_status<br/>━━━━━━━━━━<br/>quota_guard_enabled: bool<br/>read from config only"]
        GQE["● get_quota_events<br/>━━━━━━━━━━<br/>reads quota_events.jsonl<br/>human-facing, most-recent-first"]
        REFRESH["● _quota_refresh_loop<br/>━━━━━━━━━━<br/>open_kitchen starts / close_kitchen stops<br/>sleep-first, 240s interval"]
    end

    %% CONFIG → DISPATCH %%
    LONG_PAT --> ROUTE
    SHORT_T --> SHORT_BRANCH
    LONG_T --> LONG_BRANCH
    ROUTE -- "yes" --> LONG_BRANCH
    ROUTE -- "no" --> SHORT_BRANCH

    %% DISPATCH → DERIVED BINDING %%
    LONG_BRANCH --> EFF_T
    SHORT_BRANCH --> EFF_T
    EFF_T --> SHOULD_BLK

    %% BINDING → CHECKPOINT %%
    SHOULD_BLK --> BINDING_SNAP
    EFF_T --> BINDING_SNAP
    WIN_UTIL --> BINDING_SNAP

    %% RESUME DETECTION %%
    SCHEMA --> VER_CHECK
    FETCHED --> AGE_CHECK
    CACHE_CFG --> AGE_CHECK
    VER_CHECK -- "match" --> AGE_CHECK
    VER_CHECK -- "mismatch" --> LIVE_FETCH
    AGE_CHECK -- "fresh (≤ 300s)" --> CACHE_HIT
    AGE_CHECK -- "stale" --> LIVE_FETCH
    CACHE_HIT --> BINDING_SNAP
    LIVE_FETCH --> FETCHED

    %% BINDING → HOOK GATES %%
    BINDING_SNAP --> PRE
    BINDING_SNAP --> POST
    PRE -- "error / cache miss" --> FO
    POST -- "error / cache miss" --> FO

    %% AUDIT LOG %%
    PRE --> LOG
    POST --> LOG
    LOG --> GQE

    %% REFRESH LOOP FEEDS LIVE FETCH %%
    REFRESH --> LIVE_FETCH

    %% CLASS ASSIGNMENTS %%
    class SHORT_T,LONG_T,LONG_PAT,CACHE_CFG detector;
    class ROUTE phase;
    class LONG_BRANCH,SHORT_BRANCH handler;
    class EFF_T,WIN_UTIL gap;
    class SHOULD_BLK gap;
    class SCHEMA,FETCHED,BINDING_SNAP stateNode;
    class VER_CHECK,AGE_CHECK phase;
    class LIVE_FETCH handler;
    class CACHE_HIT output;
    class PRE,POST detector;
    class FO gap;
    class LOG output;
    class KS,GQE,REFRESH cli;
```

Closes #721

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260411-110719-627813/.autoskillit/temp/make-plan/quota_guard_per_window_threshold_plan_2026-04-11_110956.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| implement | 945 | 53.9k | 11.0M | 188.5k | 1 | 17m 16s |
| retry_worktree | 835 | 40.1k | 9.2M | 188.9k | 1 | 13m 32s |
| prepare_pr | 60 | 4.7k | 175.2k | 34.8k | 1 | 1m 20s |
| run_arch_lenses | 140 | 19.8k | 502.9k | 113.4k | 2 | 5m 41s |
| compose_pr | 59 | 9.0k | 206.9k | 29.8k | 1 | 2m 39s |
| **Total** | 2.0k | 127.5k | 21.1M | 555.4k | | 40m 30s |