### PR TITLE
fix: config-resolved ingredient defaults override YAML literal defaults (#703)

### DIFF
--- a/.autoskillit/recipes/smoke-test.yaml
+++ b/.autoskillit/recipes/smoke-test.yaml
@@ -18,7 +18,7 @@ ingredients:
     required: true
   base_branch:
     description: Base branch for the PR target
-    default: main
+    default: ""
 
 kitchen_rules:
   - >-

--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -114,10 +114,10 @@ def build_ingredient_rows(
         sort_key = _ingredient_sort_key(name, required, default)
         if default is None and required:
             default_str, name_str = "(required)", f"{name} *"
+        elif res := resolved.get(name):
+            default_str, name_str = res, name
         elif default == "":
-            res = resolved.get(name)
-            default_str = res if res else "auto-detect"
-            name_str = name
+            default_str, name_str = "auto-detect", name
         elif default == "true":
             default_str, name_str = "on", name
         elif default == "false":

--- a/tests/cli/test_cli_prompts.py
+++ b/tests/cli/test_cli_prompts.py
@@ -209,7 +209,7 @@ def test_show_cook_preview_no_diagram(monkeypatch, tmp_path, capsys):
     assert "RECIPE" not in captured.out
 
 
-def test_show_cook_preview_uses_resolved_base_branch_for_smoke_test(monkeypatch, tmp_path, capsys):
+def test_show_cook_preview_uses_resolved_base_branch_for_smoke_test(monkeypatch, capsys):
     """T8: show_cook_preview renders the config-resolved base_branch for smoke-test."""
     import autoskillit.recipe._api as api_mod
     from autoskillit.cli._prompts import show_cook_preview

--- a/tests/cli/test_cli_prompts.py
+++ b/tests/cli/test_cli_prompts.py
@@ -223,8 +223,7 @@ def test_show_cook_preview_uses_resolved_base_branch_for_smoke_test(monkeypatch,
         lambda _: {"base_branch": "integration"},
     )
 
-    recipes_dir = project_dir / ".autoskillit" / "recipes"
-    recipe_info = find_recipe_by_name("smoke-test", recipes_dir)
+    recipe_info = find_recipe_by_name("smoke-test", project_dir)
     assert recipe_info is not None, "smoke-test recipe must exist in project-local recipes"
     recipe = load_recipe(recipe_info.path)
 

--- a/tests/cli/test_cli_prompts.py
+++ b/tests/cli/test_cli_prompts.py
@@ -209,6 +209,34 @@ def test_show_cook_preview_no_diagram(monkeypatch, tmp_path, capsys):
     assert "RECIPE" not in captured.out
 
 
+def test_show_cook_preview_uses_resolved_base_branch_for_smoke_test(monkeypatch, tmp_path, capsys):
+    """T8: show_cook_preview renders the config-resolved base_branch for smoke-test."""
+    import autoskillit.recipe._api as api_mod
+    from autoskillit.cli._prompts import show_cook_preview
+    from autoskillit.core import pkg_root
+    from autoskillit.recipe.io import find_recipe_by_name, load_recipe
+
+    project_dir = pkg_root().parent.parent
+    monkeypatch.setattr(api_mod, "_LOAD_CACHE", {})
+    monkeypatch.setattr(
+        "autoskillit.config.resolve_ingredient_defaults",
+        lambda _: {"base_branch": "integration"},
+    )
+
+    recipes_dir = project_dir / ".autoskillit" / "recipes"
+    recipe_info = find_recipe_by_name("smoke-test", recipes_dir)
+    assert recipe_info is not None, "smoke-test recipe must exist in project-local recipes"
+    recipe = load_recipe(recipe_info.path)
+
+    show_cook_preview("smoke-test", recipe, project_dir, project_dir)
+    captured = capsys.readouterr()
+    assert "integration" in captured.out
+    # base_branch row must NOT show the YAML literal "main"
+    base_branch_lines = [line for line in captured.out.splitlines() if "base_branch" in line]
+    assert base_branch_lines, "base_branch must appear in the rendered table"
+    assert all("main" not in line for line in base_branch_lines)
+
+
 def test_orchestrator_prompt_contains_multi_issue_guidance():
     """System prompt must document the sequential vs parallel decision for multiple issues."""
     from autoskillit.cli._prompts import _build_orchestrator_prompt

--- a/tests/recipe/test_api.py
+++ b/tests/recipe/test_api.py
@@ -47,6 +47,19 @@ def _setup_project_recipe(tmp_path: Path, name: str, content: str) -> Path:
     return recipe_path
 
 
+def _make_recipe_with_ingredient(name: str, ingredient: object) -> object:
+    """Build a minimal Recipe with a single named ingredient for unit testing."""
+    from autoskillit.recipe.schema import Recipe, RecipeStep
+
+    return Recipe(
+        name="test",
+        description="test recipe",
+        ingredients={name: ingredient},
+        steps={"done": RecipeStep(action="stop", message="done")},
+        kitchen_rules=[],
+    )
+
+
 # T4a
 def test_load_and_validate_includes_kitchen_rules(tmp_path):
     """Response has top-level 'kitchen_rules' key with rule strings."""
@@ -544,6 +557,84 @@ class TestFormatIngredientsTableGfmWidthCap:
                     f"run_mode description not capped in GFM output: "
                     f"{len(desc_cell)} > {_GFM_DESC_MAX_WIDTH}"
                 )
+
+
+def test_build_ingredient_rows_resolved_overrides_literal_default():
+    """T1: config-resolved value wins over a non-empty YAML literal default."""
+    from autoskillit.recipe._api import build_ingredient_rows
+    from autoskillit.recipe.schema import RecipeIngredient
+
+    recipe = _make_recipe_with_ingredient(
+        "base_branch",
+        RecipeIngredient(description="Base branch", default="main"),
+    )
+    rows = build_ingredient_rows(recipe, resolved_defaults={"base_branch": "integration"})
+    assert ("base_branch", "Base branch", "integration") in rows
+
+
+def test_build_ingredient_rows_literal_default_preserved_when_no_resolved():
+    """T2: YAML literal default is used when resolved_defaults has no entry."""
+    from autoskillit.recipe._api import build_ingredient_rows
+    from autoskillit.recipe.schema import RecipeIngredient
+
+    recipe = _make_recipe_with_ingredient(
+        "base_branch",
+        RecipeIngredient(description="Base branch", default="main"),
+    )
+    rows = build_ingredient_rows(recipe, resolved_defaults={})
+    assert ("base_branch", "Base branch", "main") in rows
+
+
+def test_build_ingredient_rows_resolved_overrides_empty_sentinel():
+    """T3: resolved value also wins over the empty-string sentinel (regression guard)."""
+    from autoskillit.recipe._api import build_ingredient_rows
+    from autoskillit.recipe.schema import RecipeIngredient
+
+    recipe = _make_recipe_with_ingredient(
+        "base_branch",
+        RecipeIngredient(description="Base branch", default=""),
+    )
+    rows = build_ingredient_rows(recipe, resolved_defaults={"base_branch": "integration"})
+    assert ("base_branch", "Base branch", "integration") in rows
+
+
+def test_build_ingredient_rows_empty_sentinel_falls_back_to_auto_detect():
+    """T4: empty-string sentinel displays 'auto-detect' when no resolved value exists."""
+    from autoskillit.recipe._api import build_ingredient_rows
+    from autoskillit.recipe.schema import RecipeIngredient
+
+    recipe = _make_recipe_with_ingredient(
+        "base_branch",
+        RecipeIngredient(description="Base branch", default=""),
+    )
+    rows = build_ingredient_rows(recipe, resolved_defaults={})
+    assert ("base_branch", "Base branch", "auto-detect") in rows
+
+
+def test_build_ingredient_rows_resolved_does_not_override_required_marker():
+    """T5: required-without-default always shows '(required)'; resolved override must not apply."""
+    from autoskillit.recipe._api import build_ingredient_rows
+    from autoskillit.recipe.schema import RecipeIngredient
+
+    recipe = _make_recipe_with_ingredient(
+        "x",
+        RecipeIngredient(description="Required thing", required=True),
+    )
+    rows = build_ingredient_rows(recipe, resolved_defaults={"x": "something"})
+    assert any(r[0] == "x *" and r[2] == "(required)" for r in rows)
+
+
+def test_build_ingredient_rows_resolved_overrides_boolean_literal():
+    """T6: resolved value wins over a boolean-literal default ('true'/'false' → 'on'/'off')."""
+    from autoskillit.recipe._api import build_ingredient_rows
+    from autoskillit.recipe.schema import RecipeIngredient
+
+    recipe = _make_recipe_with_ingredient(
+        "flag",
+        RecipeIngredient(description="A flag", default="true"),
+    )
+    rows = build_ingredient_rows(recipe, resolved_defaults={"flag": "off"})
+    assert ("flag", "A flag", "off") in rows
 
 
 def test_build_ingredient_rows_returns_tuples():

--- a/tests/recipe/test_bundled_recipes.py
+++ b/tests/recipe/test_bundled_recipes.py
@@ -1442,12 +1442,12 @@ class TestBaseBranchDefaults:
             f"{recipe_name}.yaml: base_branch must use auto-detect (default: '')"
         )
 
-    def test_smoke_test_base_branch_remains_main(self) -> None:
-        """smoke-test.yaml must keep base_branch default 'main' — isolated scratch repo context."""
+    def test_smoke_test_base_branch_uses_auto_detect(self) -> None:
+        """smoke-test.yaml must use auto-detect for base_branch so config-resolved value wins."""
         recipe = load_recipe(SMOKE_RECIPE)
-        assert recipe.ingredients["base_branch"].default == "main", (
-            "smoke-test.yaml creates a fresh git repo initialized with 'main' — "
-            "its base_branch default must stay 'main'"
+        assert recipe.ingredients["base_branch"].default == "", (
+            "smoke-test.yaml base_branch must use auto-detect (default: '') so that "
+            "branching.default_base_branch from config is honoured at runtime (#703)"
         )
 
 

--- a/tests/server/test_tools_kitchen.py
+++ b/tests/server/test_tools_kitchen.py
@@ -729,6 +729,46 @@ async def test_open_kitchen_recipe_found_returns_envelope_with_content_and_ingre
 
 
 @pytest.mark.anyio
+async def test_open_kitchen_smoke_test_renders_resolved_base_branch(monkeypatch):
+    """T7: open_kitchen smoke-test renders the config-resolved base_branch value."""
+    import autoskillit.recipe._api as api_mod
+    from autoskillit.core import pkg_root
+    from autoskillit.recipe.repository import DefaultRecipeRepository
+
+    project_dir = pkg_root().parent.parent
+    monkeypatch.chdir(project_dir)
+    monkeypatch.setattr(api_mod, "_LOAD_CACHE", {})
+    monkeypatch.setattr(
+        "autoskillit.server.tools_kitchen.resolve_ingredient_defaults",
+        lambda _: {"base_branch": "integration"},
+    )
+
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.enable_components = AsyncMock()
+    mock_ctx.quota_refresh_task = None
+    mock_ctx.recipes = DefaultRecipeRepository()
+    mock_ctx.config.migration.suppressed = []
+
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        with patch("autoskillit.server.logger"):
+            with patch("autoskillit.server.tools_kitchen._prime_quota_cache", new=AsyncMock()):
+                with patch("autoskillit.server.tools_kitchen._write_hook_config"):
+                    from autoskillit.server.tools_kitchen import open_kitchen
+
+                    result_str = await open_kitchen(name="smoke-test", ctx=mock_ctx)
+
+    parsed = json.loads(result_str)
+    assert parsed["success"] is True
+    ing_table = parsed.get("ingredients_table") or ""
+    assert ing_table, "ingredients_table must be present and non-empty"
+    assert "integration" in ing_table
+    # base_branch row must NOT show the YAML literal "main"
+    base_branch_rows = [line for line in ing_table.splitlines() if "base_branch" in line]
+    assert base_branch_rows, "base_branch row must appear in ingredients_table"
+    assert all("main" not in row for row in base_branch_rows)
+
+
+@pytest.mark.anyio
 async def test_open_kitchen_recipe_not_found_returns_failure_envelope(tmp_path, monkeypatch):
     """Invalid recipe name returns failure envelope (via load_and_validate raising)."""
     monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
## Summary

`build_ingredient_rows` in `src/autoskillit/recipe/_api.py` only consulted the
`resolved_defaults` dict when an ingredient's YAML `default:` was the empty string `""`.
Any ingredient with a non-empty literal default (e.g. `default: main`) silently
bypassed config resolution, so `branching.default_base_branch` was ignored for the
project-local smoke-test recipe and any future recipe author who didn't know about
the empty-string sentinel convention.

The fix reorders the resolution logic so that a config-resolved value (when present
in `resolved_defaults`) **always wins** over a YAML literal default. The empty-string
sentinel is no longer load-bearing — `default: ""` and `default: "main"` both yield
the resolved value when one exists. The `.autoskillit/recipes/smoke-test.yaml`
project-local recipe is also updated from `default: main` to `default: ""` to
align with the bundled-recipe convention (auto-detect ingredients sort higher and
display "auto-detect" when no resolved value exists, which is the desired UX).

## Architecture Impact

### Data Lineage: Ingredient Default Resolution

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph ConfigSources ["Config Sources (5-layer dynaconf)"]
        direction TB
        DEFAULTS_YAML["config/defaults.yaml<br/>━━━━━━━━━━<br/>default_base_branch: main<br/>Layer 1 (lowest priority)"]
        USER_CFG["~/.autoskillit/config.yaml<br/>━━━━━━━━━━<br/>User-level overrides<br/>Layer 2"]
        PROJ_CFG[".autoskillit/config.yaml<br/>━━━━━━━━━━<br/>Project-level overrides<br/>Layer 3"]
        SECRETS[".autoskillit/.secrets.yaml<br/>━━━━━━━━━━<br/>Secrets layer<br/>Layer 4"]
        ENV_VARS["AUTOSKILLIT_SECTION__KEY<br/>━━━━━━━━━━<br/>Environment variables<br/>Layer 5 (highest priority)"]
    end

    subgraph GitProbe ["Git Environment Probe"]
        GIT_REMOTE["git remote get-url<br/>━━━━━━━━━━<br/>upstream → origin fallback<br/>→ source_dir URL string"]
    end

    subgraph RecipeInput ["Recipe YAML Input"]
        SMOKE_YAML["● smoke-test.yaml<br/>━━━━━━━━━━<br/>base_branch: default: ''<br/>source_dir: required: true"]
    end

    subgraph ConfigResolution ["Config Layer Resolution"]
        DYNACONF["_make_dynaconf()<br/>━━━━━━━━━━<br/>_apply_layer() deep-merge<br/>settings.py:632"]
        AUTO_CFG[("AutomationConfig<br/>━━━━━━━━━━<br/>branching.default_base_branch<br/>Typed dataclass")]
        RESOLVE_DEFS["resolve_ingredient_defaults()<br/>━━━━━━━━━━<br/>ingredient_defaults.py:16<br/>→ dict[str, str]"]
        RESOLVED_DICT[("resolved_defaults<br/>━━━━━━━━━━<br/>{'base_branch': 'main',<br/>'source_dir': 'git-url'}")]
    end

    subgraph RecipeParsing ["Recipe Parsing"]
        LOAD_RECIPE["load_recipe()<br/>━━━━━━━━━━<br/>YAML text load<br/>placeholder substitution"]
        PARSE_RECIPE["_parse_recipe()<br/>━━━━━━━━━━<br/>YAML dict → Recipe dataclass<br/>RecipeIngredient per key"]
        RECIPE_OBJ[("Recipe dataclass<br/>━━━━━━━━━━<br/>ingredients: dict[str, RecipeIngredient]<br/>.default / .required / .hidden")]
    end

    subgraph MergeResolution ["● Merge / Display Resolution (build_ingredient_rows)"]
        BUILD_ROWS["● build_ingredient_rows()<br/>━━━━━━━━━━<br/>_api.py:93<br/>Priority: required > config-resolved > YAML"]
        PRIORITY_NOTE{"Override Priority<br/>━━━━━━━━━━<br/>1. required=True → '(required)'<br/>2. resolved.get(name) WINS<br/>3. default=='' → auto-detect<br/>4. YAML bool/null/literal"}
    end

    subgraph OutputLayer ["Output"]
        INGR_TABLE["● ingredients_table<br/>━━━━━━━━━━<br/>GFM markdown table<br/>Shown to LLM / terminal"]
        LOAD_RESULT[("LoadRecipeResult<br/>━━━━━━━━━━<br/>TypedDict: content, diagram,<br/>ingredients_table, valid")]
        OPEN_KITCHEN["open_kitchen() response<br/>━━━━━━━━━━<br/>tools_kitchen.py:296<br/>JSON → MCP caller"]
    end

    %% CONFIG RESOLUTION FLOW %%
    DEFAULTS_YAML -->|"Layer 1"| DYNACONF
    USER_CFG -->|"Layer 2"| DYNACONF
    PROJ_CFG -->|"Layer 3"| DYNACONF
    SECRETS -->|"Layer 4"| DYNACONF
    ENV_VARS -->|"Layer 5 wins"| DYNACONF
    DYNACONF -->|"resolved config"| AUTO_CFG
    AUTO_CFG -->|"cfg.branching.default_base_branch"| RESOLVE_DEFS
    GIT_REMOTE -->|"source_dir URL"| RESOLVE_DEFS
    RESOLVE_DEFS -->|"dict[str, str]"| RESOLVED_DICT

    %% RECIPE PARSING FLOW %%
    SMOKE_YAML -->|"YAML text"| LOAD_RECIPE
    LOAD_RECIPE -->|"parsed dict"| PARSE_RECIPE
    PARSE_RECIPE -->|"Recipe obj"| RECIPE_OBJ

    %% MERGE FLOW %%
    RESOLVED_DICT -->|"resolved_defaults"| BUILD_ROWS
    RECIPE_OBJ -->|"ingredients dict"| BUILD_ROWS
    BUILD_ROWS --> PRIORITY_NOTE
    PRIORITY_NOTE -->|"resolved wins"| INGR_TABLE

    %% OUTPUT FLOW %%
    INGR_TABLE --> LOAD_RESULT
    RECIPE_OBJ -.->|"content (raw YAML)"| LOAD_RESULT
    LOAD_RESULT --> OPEN_KITCHEN

    %% CLASS ASSIGNMENTS %%
    class DEFAULTS_YAML,USER_CFG,PROJ_CFG,SECRETS,ENV_VARS cli;
    class GIT_REMOTE integration;
    class SMOKE_YAML cli;
    class DYNACONF,RESOLVE_DEFS,LOAD_RECIPE,PARSE_RECIPE handler;
    class AUTO_CFG,RESOLVED_DICT,RECIPE_OBJ stateNode;
    class BUILD_ROWS,PRIORITY_NOTE phase;
    class INGR_TABLE,OPEN_KITCHEN output;
    class LOAD_RESULT stateNode;
```

### Process Flow: Ingredient Default Resolution Pipeline

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START(["open_kitchen(name, overrides)"])
    COMPLETE(["LoadRecipeResult → agent"])
    ERROR(["failure envelope → agent"])

    subgraph Gate ["Kitchen Gate"]
        direction TB
        HeadlessGuard{"headless<br/>session?"}
        EnableKitchen["enable_components(kitchen)<br/>━━━━━━━━━━<br/>FastMCP tag visibility"]
    end

    subgraph ConfigRes ["● Config & Ingredient Default Resolution"]
        direction TB
        ResolveDefaults["● resolve_ingredient_defaults<br/>━━━━━━━━━━<br/>ingredient_defaults.py"]
        GitRemote{"try upstream<br/>remote URL"}
        GitOrigin["git remote get-url origin<br/>━━━━━━━━━━<br/>fallback remote"]
        LoadCfg["load_config(project_dir)<br/>━━━━━━━━━━<br/>settings.py · dynaconf"]
        LayerMerge["Layer Merge (low→high)<br/>━━━━━━━━━━<br/>defaults.yaml → user config →<br/>project config → secrets → env vars"]
        BaseBranch["cfg.branching.default_base_branch<br/>━━━━━━━━━━<br/>resolved['base_branch']"]
        ResolvedMap(["resolved: dict[str,str]<br/>━━━━━━━━━━<br/>source_dir, base_branch"])
    end

    subgraph RecipeLoad ["● Recipe Load & Validate Pipeline  (_api.py)"]
        direction TB
        CacheCheck{"cache hit?<br/>path+mtime+version"}
        FindRecipe["find_recipe_by_name<br/>━━━━━━━━━━<br/>project → builtin search"]
        YAMLParse["load_yaml + substitute_temp_placeholder<br/>━━━━━━━━━━<br/>{{AUTOSKILLIT_TEMP}} expansion"]
        BuildActive["_build_active_recipe<br/>━━━━━━━━━━<br/>sub-recipe gate eval + merge/drop"]
        GateDecision{"sub_recipe gate<br/>ingredient value?"}
        MergeSubRecipe["_merge_sub_recipe<br/>━━━━━━━━━━<br/>prefix steps, fix routes,<br/>merge ingredients + rules"]
        DropStep["_drop_sub_recipe_step<br/>━━━━━━━━━━<br/>placeholder removed"]
        StructValidate["validate_recipe (active + combined)<br/>━━━━━━━━━━<br/>structural rule checks"]
        SemanticRules["run_semantic_rules<br/>━━━━━━━━━━<br/>dataflow, skill refs, version"]
        ContractCard["validate_recipe_cards<br/>━━━━━━━━━━<br/>contract card comparison"]
        StalenessCheck["check_contract_staleness<br/>━━━━━━━━━━<br/>Haiku LLM triage + cache"]
        DiagramCheck["check_diagram_staleness<br/>━━━━━━━━━━<br/>mtime comparison"]
        WriteCache["write _LoadCacheEntry<br/>━━━━━━━━━━<br/>thread-safe dict update"]
    end

    subgraph IngPriority ["● Ingredient Default Priority  (build_ingredient_rows)"]
        direction TB
        IngLoop["iterate recipe.ingredients<br/>━━━━━━━━━━<br/>skip hidden ingredients"]
        PriorityGate{"priority check<br/>(per ingredient)"}
        UseRequired["mark as '(required) *'<br/>━━━━━━━━━━<br/>required=True, no default"]
        UseConfigResolved["● use config-resolved value<br/>━━━━━━━━━━<br/>resolved[name] overrides<br/>all YAML literal defaults"]
        UseAutoDetect["label 'auto-detect'<br/>━━━━━━━━━━<br/>default == ''"]
        UseYAML["use YAML literal default<br/>━━━━━━━━━━<br/>bool flags / constants"]
        SortRows["sort: required > auto-detect ><br/>flags > optional > constants"]
        IngTable(["ingredients_table<br/>━━━━━━━━━━<br/>pre-formatted GFM table"])
    end

    %% ── MAIN FLOW ── %%
    START --> HeadlessGuard
    HeadlessGuard -->|"headless"| ERROR
    HeadlessGuard -->|"interactive"| EnableKitchen
    EnableKitchen --> ResolveDefaults

    ResolveDefaults --> GitRemote
    GitRemote -->|"upstream found"| LoadCfg
    GitRemote -->|"upstream missing"| GitOrigin
    GitOrigin --> LoadCfg
    LoadCfg --> LayerMerge
    LayerMerge --> BaseBranch
    BaseBranch --> ResolvedMap

    ResolvedMap --> CacheCheck
    CacheCheck -->|"hit: all mtimes match"| COMPLETE
    CacheCheck -->|"miss"| FindRecipe
    FindRecipe -->|"not found"| ERROR
    FindRecipe --> YAMLParse
    YAMLParse -->|"YAML error"| ERROR
    YAMLParse --> BuildActive
    BuildActive --> GateDecision
    GateDecision -->|"gate == true"| MergeSubRecipe
    GateDecision -->|"gate == false"| DropStep
    MergeSubRecipe --> StructValidate
    DropStep --> StructValidate
    StructValidate --> SemanticRules
    SemanticRules --> ContractCard
    ContractCard --> StalenessCheck
    StalenessCheck --> DiagramCheck
    DiagramCheck --> IngLoop

    IngLoop --> PriorityGate
    PriorityGate -->|"required, no default"| UseRequired
    PriorityGate -->|"resolved[name] exists"| UseConfigResolved
    PriorityGate -->|"default == ''"| UseAutoDetect
    PriorityGate -->|"bool / constant"| UseYAML
    UseRequired --> SortRows
    UseConfigResolved --> SortRows
    UseAutoDetect --> SortRows
    UseYAML --> SortRows
    SortRows --> IngTable
    IngTable --> WriteCache
    WriteCache --> COMPLETE

    %% ── ● smoke-test.yaml flows through this path ── %%
    %% base_branch: default="" → resolved via cfg.branching.default_base_branch %%

    %% CLASS ASSIGNMENTS %%
    class START,COMPLETE,ERROR terminal;
    class EnableKitchen,FindRecipe,YAMLParse,StructValidate,SemanticRules,ContractCard,StalenessCheck,DiagramCheck,WriteCache handler;
    class ResolveDefaults,BuildActive,LayerMerge,IngLoop,SortRows phase;
    class HeadlessGuard,CacheCheck,GateDecision,PriorityGate detector;
    class GitRemote,GitOrigin,LoadCfg,BaseBranch stateNode;
    class MergeSubRecipe,DropStep,UseRequired,UseAutoDetect,UseYAML handler;
    class UseConfigResolved,ResolvedMap,IngTable output;
```

Closes #703

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260411-114315-286419/.autoskillit/temp/make-plan/config_resolved_ingredient_defaults_override_yaml_plan_2026-04-11_115443.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 194 | 13.8k | 885.0k | 95.5k | 1 | 3m 46s |
| verify | 140 | 8.5k | 632.6k | 48.1k | 1 | 2m 16s |
| implement | 470 | 30.9k | 3.8M | 78.4k | 1 | 17m 2s |
| prepare_pr | 60 | 4.8k | 176.3k | 22.6k | 1 | 1m 15s |
| run_arch_lenses | 199 | 24.0k | 689.3k | 106.8k | 3 | 9m 32s |
| compose_pr | 67 | 7.3k | 221.3k | 26.3k | 1 | 1m 56s |
| **Total** | 1.1k | 89.3k | 6.4M | 377.9k | | 35m 50s |