### PR TITLE
Rectify: SIGTERM Bypasses atexit — ScenarioRecorder.finalize() Never Runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,7 @@ generic_automation_mcp/
 │   ├── __init__.py          #   FastMCP app, kitchen gating, headless tool reveal
 │   ├── git.py               #   Merge workflow for merge_worktree
 │   ├── _editable_guard.py   #   Pre-deletion editable install guard (stdlib-only)
+│   ├── _lifespan.py         #   FastMCP lifespan: recorder teardown on shutdown
 │   ├── helpers.py
 │   ├── tools_kitchen.py     #   open_kitchen, close_kitchen + recipe:// resource
 │   ├── tools_ci.py          #   CI/merge-queue tool handlers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ timeout = 60
 timeout_method = "signal"
 markers = [
     "smoke: end-to-end smoke tests requiring Claude API access (deselect with: -m 'not smoke')",
+    "integration: integration tests that spawn real subprocesses (deselect with: -m 'not integration')",
 ]
 
 [tool.ruff]

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -115,8 +115,16 @@ def serve(*, verbose: Annotated[bool, Parameter(name=["--verbose", "-v"])] = Fal
     plugin_dir = str(pkg_root())
     ctx = make_context(cfg, plugin_dir=plugin_dir)
     _initialize(ctx)
-    signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
-    mcp.run()
+
+    def _sigterm_handler(*_):
+        """Convert SIGTERM into KeyboardInterrupt so asyncio shuts down cleanly."""
+        raise KeyboardInterrupt
+
+    signal.signal(signal.SIGTERM, _sigterm_handler)
+    try:
+        mcp.run()
+    except KeyboardInterrupt:
+        pass
 
 
 @app.command

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -121,6 +121,7 @@ def serve(*, verbose: Annotated[bool, Parameter(name=["--verbose", "-v"])] = Fal
         raise KeyboardInterrupt
 
     signal.signal(signal.SIGTERM, _sigterm_handler)
+    get_logger(__name__).info("sigterm_handler_ready")
     try:
         mcp.run()
     except KeyboardInterrupt:

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -7,6 +7,7 @@ import json
 import os
 import random
 import shutil
+import signal
 import subprocess
 import sys
 from datetime import UTC
@@ -114,6 +115,7 @@ def serve(*, verbose: Annotated[bool, Parameter(name=["--verbose", "-v"])] = Fal
     plugin_dir = str(pkg_root())
     ctx = make_context(cfg, plugin_dir=plugin_dir)
     _initialize(ctx)
+    signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
     mcp.run()
 
 

--- a/src/autoskillit/execution/recording.py
+++ b/src/autoskillit/execution/recording.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import atexit
-import shutil
 import tempfile
 from collections import deque
 from collections.abc import Mapping
@@ -64,7 +62,6 @@ class RecordingSubprocessRunner(SubprocessRunner):
         inner: SubprocessRunner | None = None,
     ) -> None:
         self.recorder = recorder
-        atexit.register(recorder.finalize)
         if inner is None:
             from autoskillit.execution.process import DefaultSubprocessRunner
 
@@ -169,6 +166,8 @@ class ReplayingSubprocessRunner(SubprocessRunner):
     dispatches to the matching step queue.
     """
 
+    _tmp_replay_dir: tempfile.TemporaryDirectory[str] | None
+
     def __init__(
         self,
         session_map: dict[str, deque[tuple[Any, Any]]],
@@ -180,6 +179,7 @@ class ReplayingSubprocessRunner(SubprocessRunner):
         self._non_session = non_session_results
         self.player: ScenarioPlayer | None = player
         self.call_log: list[tuple[str, list[str]]] = []
+        self._tmp_replay_dir = None
 
     async def __call__(
         self,
@@ -236,8 +236,8 @@ class ReplayingSubprocessRunner(SubprocessRunner):
 def build_replay_runner(replay_dir: str) -> ReplayingSubprocessRunner:
     """Build a ReplayingSubprocessRunner from a scenario directory.
 
-    Creates a temporary output directory for the player, registers an atexit
-    handler to clean it up, then parses the scenario manifest and constructs
+    Creates a temporary output directory for the player, then parses the
+    scenario manifest and constructs
     the deque-based session map.  All domain logic for replay setup lives here
     (L1) rather than in the L3 composition root.
 
@@ -262,8 +262,8 @@ def build_replay_runner(replay_dir: str) -> ReplayingSubprocessRunner:
             "Install it to enable scenario replay."
         ) from exc
 
-    tmp_replay = tempfile.mkdtemp(prefix="autoskillit-replay-")
-    atexit.register(shutil.rmtree, tmp_replay, True)
+    _tmp_replay_dir = tempfile.TemporaryDirectory(prefix="autoskillit-replay-")
+    tmp_replay = _tmp_replay_dir.name
 
     player = make_scenario_player(
         scenario_dir=replay_dir,
@@ -284,4 +284,6 @@ def build_replay_runner(replay_dir: str) -> ReplayingSubprocessRunner:
         raise
 
     session_map = {k: deque(v) for k, v in raw_map.items()}
-    return ReplayingSubprocessRunner(session_map, non_session, player=player)
+    runner = ReplayingSubprocessRunner(session_map, non_session, player=player)
+    runner._tmp_replay_dir = _tmp_replay_dir
+    return runner

--- a/src/autoskillit/server/__init__.py
+++ b/src/autoskillit/server/__init__.py
@@ -14,9 +14,12 @@ Transport: stdio (default for FastMCP).
 
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
+
 from fastmcp import FastMCP
 
 from autoskillit.core import get_logger
+from autoskillit.execution.recording import RecordingSubprocessRunner
 from autoskillit.pipeline import (  # noqa: F401
     GATED_TOOLS,
     UNGATED_TOOLS,
@@ -28,12 +31,23 @@ from autoskillit.server._state import (  # noqa: E402, F401
     _ctx,
     _get_config,
     _get_ctx,
+    _get_ctx_or_none,
     _get_plugin_dir,
     _initialize,
     version_info,
 )
 
-mcp: FastMCP = FastMCP("autoskillit")
+
+@asynccontextmanager
+async def _autoskillit_lifespan(server):
+    """Server lifecycle: teardown recording on shutdown."""
+    yield
+    ctx = _get_ctx_or_none()
+    if ctx is not None and isinstance(ctx.runner, RecordingSubprocessRunner):
+        ctx.runner.recorder.finalize()
+
+
+mcp: FastMCP = FastMCP("autoskillit", lifespan=_autoskillit_lifespan)
 
 logger = get_logger(__name__)
 

--- a/src/autoskillit/server/__init__.py
+++ b/src/autoskillit/server/__init__.py
@@ -24,12 +24,11 @@ from autoskillit.pipeline import (  # noqa: F401
     ToolContext,
     gate_error_result,
 )
-from autoskillit.server._lifespan import _autoskillit_lifespan  # noqa: F401
+from autoskillit.server._lifespan import _autoskillit_lifespan
 from autoskillit.server._state import (  # noqa: E402, F401
     _ctx,
     _get_config,
     _get_ctx,
-    _get_ctx_or_none,
     _get_plugin_dir,
     _initialize,
     version_info,

--- a/src/autoskillit/server/__init__.py
+++ b/src/autoskillit/server/__init__.py
@@ -14,12 +14,9 @@ Transport: stdio (default for FastMCP).
 
 from __future__ import annotations
 
-from contextlib import asynccontextmanager
-
 from fastmcp import FastMCP
 
 from autoskillit.core import get_logger
-from autoskillit.execution.recording import RecordingSubprocessRunner
 from autoskillit.pipeline import (  # noqa: F401
     GATED_TOOLS,
     UNGATED_TOOLS,
@@ -27,6 +24,7 @@ from autoskillit.pipeline import (  # noqa: F401
     ToolContext,
     gate_error_result,
 )
+from autoskillit.server._lifespan import _autoskillit_lifespan  # noqa: F401
 from autoskillit.server._state import (  # noqa: E402, F401
     _ctx,
     _get_config,
@@ -36,16 +34,6 @@ from autoskillit.server._state import (  # noqa: E402, F401
     _initialize,
     version_info,
 )
-
-
-@asynccontextmanager
-async def _autoskillit_lifespan(server):
-    """Server lifecycle: teardown recording on shutdown."""
-    yield
-    ctx = _get_ctx_or_none()
-    if ctx is not None and isinstance(ctx.runner, RecordingSubprocessRunner):
-        ctx.runner.recorder.finalize()
-
 
 mcp: FastMCP = FastMCP("autoskillit", lifespan=_autoskillit_lifespan)
 

--- a/src/autoskillit/server/_lifespan.py
+++ b/src/autoskillit/server/_lifespan.py
@@ -20,6 +20,7 @@ logger = get_logger(__name__)
 @asynccontextmanager
 async def _autoskillit_lifespan(server: Any) -> Any:
     """Server lifecycle: teardown recording on shutdown."""
+    logger.info("lifespan_started")
     yield
     ctx = _get_ctx_or_none()
     if ctx is not None and isinstance(ctx.runner, RecordingSubprocessRunner):

--- a/src/autoskillit/server/_lifespan.py
+++ b/src/autoskillit/server/_lifespan.py
@@ -1,0 +1,22 @@
+"""FastMCP lifespan for server resource teardown.
+
+Provides the async context manager wired into FastMCP via ``lifespan=``.
+The ``__aexit__`` side calls ``recorder.finalize()`` so scenario data survives
+SIGTERM (issue #745).
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+
+from autoskillit.execution import RecordingSubprocessRunner
+from autoskillit.server._state import _get_ctx_or_none
+
+
+@asynccontextmanager
+async def _autoskillit_lifespan(server):
+    """Server lifecycle: teardown recording on shutdown."""
+    yield
+    ctx = _get_ctx_or_none()
+    if ctx is not None and isinstance(ctx.runner, RecordingSubprocessRunner):
+        ctx.runner.recorder.finalize()

--- a/src/autoskillit/server/_lifespan.py
+++ b/src/autoskillit/server/_lifespan.py
@@ -8,15 +8,22 @@ SIGTERM (issue #745).
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
+from typing import Any
 
+from autoskillit.core import get_logger
 from autoskillit.execution import RecordingSubprocessRunner
 from autoskillit.server._state import _get_ctx_or_none
 
+logger = get_logger(__name__)
+
 
 @asynccontextmanager
-async def _autoskillit_lifespan(server):
+async def _autoskillit_lifespan(server: Any) -> Any:
     """Server lifecycle: teardown recording on shutdown."""
     yield
     ctx = _get_ctx_or_none()
     if ctx is not None and isinstance(ctx.runner, RecordingSubprocessRunner):
-        ctx.runner.recorder.finalize()
+        try:
+            ctx.runner.recorder.finalize()
+        except Exception:
+            logger.exception("recorder.finalize() failed during lifespan teardown")

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -527,15 +527,17 @@ def test_cli_is_package() -> None:
 
 
 def test_server_file_count_under_limit() -> None:
-    """server/ must not exceed 17 Python files (REQ-DSGN-002).
+    """server/ must not exceed 18 Python files (REQ-DSGN-002).
 
     Limit updated from 14 to 16 after tools_integrations was split into
     tools_github, tools_issue_lifecycle, and tools_pr_ops.
     Limit updated from 16 to 17 after _editable_guard.py was added as
     the pre-deletion editable install guard for perform_merge().
+    Limit updated from 17 to 18 after _lifespan.py was added for
+    FastMCP server lifespan teardown (#745).
     """
     py_files = list((SRC_ROOT / "server").glob("*.py"))
-    assert len(py_files) <= 17, f"server/ has {len(py_files)} files, max is 17"
+    assert len(py_files) <= 18, f"server/ has {len(py_files)} files, max is 18"
 
 
 def test_tools_integrations_replaced_by_split_modules() -> None:
@@ -678,7 +680,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         (14 hook scripts + 4 private helpers).
     """
     EXEMPTIONS: dict[str, int] = {
-        "server": 17,
+        "server": 18,
         "recipe": 30,
         "execution": 25,
         "core": 16,

--- a/tests/cli/test_serve_sigterm.py
+++ b/tests/cli/test_serve_sigterm.py
@@ -7,7 +7,7 @@ import pytest
 
 
 def test_serve_installs_sigterm_handler(monkeypatch, tmp_path):
-    """serve() installs signal.SIGTERM → sys.exit(0) before mcp.run()."""
+    """serve() installs signal.SIGTERM handler before mcp.run()."""
     installed_handlers = {}
 
     original_signal = signal_mod.signal
@@ -38,6 +38,5 @@ def test_serve_installs_sigterm_handler(monkeypatch, tmp_path):
     assert signal_mod.SIGTERM in installed_handlers, "SIGTERM handler not installed by serve()"
 
     handler = installed_handlers[signal_mod.SIGTERM]
-    with pytest.raises(SystemExit) as exc_info:
+    with pytest.raises(KeyboardInterrupt):
         handler(signal_mod.SIGTERM, None)
-    assert exc_info.value.code == 0

--- a/tests/cli/test_serve_sigterm.py
+++ b/tests/cli/test_serve_sigterm.py
@@ -1,0 +1,43 @@
+"""Test that serve() installs a SIGTERM handler. Regression guard for issue #745."""
+
+import signal as signal_mod
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def test_serve_installs_sigterm_handler(monkeypatch, tmp_path):
+    """serve() installs signal.SIGTERM → sys.exit(0) before mcp.run()."""
+    installed_handlers = {}
+
+    original_signal = signal_mod.signal
+
+    def capture(sig, handler):
+        installed_handlers[sig] = handler
+        return original_signal(sig, handler)
+
+    monkeypatch.chdir(tmp_path)
+
+    mock_cfg = MagicMock()
+    mock_cfg.logging.level = "INFO"
+    mock_cfg.logging.json_output = None
+    mock_cfg.safety.protected_branches = []
+
+    # Patch the source modules that serve() imports from at call time.
+    monkeypatch.setattr("autoskillit.config.load_config", lambda _: mock_cfg)
+    monkeypatch.setattr("autoskillit.core.configure_logging", lambda **kw: None)
+    monkeypatch.setattr("autoskillit.server.make_context", lambda *a, **kw: MagicMock())
+    monkeypatch.setattr("autoskillit.server._initialize", lambda ctx: None)
+    monkeypatch.setattr("autoskillit.server.mcp.run", lambda: None)
+    monkeypatch.setattr(signal_mod, "signal", capture)
+
+    from autoskillit.cli.app import serve
+
+    serve()
+
+    assert signal_mod.SIGTERM in installed_handlers, "SIGTERM handler not installed by serve()"
+
+    handler = installed_handlers[signal_mod.SIGTERM]
+    with pytest.raises(SystemExit) as exc_info:
+        handler(signal_mod.SIGTERM, None)
+    assert exc_info.value.code == 0

--- a/tests/execution/test_recording.py
+++ b/tests/execution/test_recording.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -46,6 +46,21 @@ class FakeMeta:
     exit_code: int
     model: str = "test"
     duration_ms: int = 1000
+
+
+# --- T0: RecordingSubprocessRunner must NOT call atexit.register ---
+
+
+def test_recording_runner_does_not_register_atexit():
+    """
+    RecordingSubprocessRunner must not register atexit hooks.
+    Teardown is owned by the FastMCP server lifespan, not the constructor.
+    Regression guard for issue #745.
+    """
+    mock_recorder = Mock()
+    with patch("atexit.register") as mock_atexit:
+        RecordingSubprocessRunner(recorder=mock_recorder, inner=Mock())
+    mock_atexit.assert_not_called()
 
 
 # --- T1: Protocol compliance ---
@@ -224,13 +239,15 @@ def test_make_context_wraps_runner_when_record_scenario(monkeypatch, tmp_path):
     monkeypatch.setattr(
         _api_sim_claude, "make_scenario_recorder", Mock(return_value=mock_recorder), raising=False
     )
-    monkeypatch.setattr("atexit.register", Mock())
+    mock_atexit = Mock()
+    monkeypatch.setattr("atexit.register", mock_atexit)
 
     from autoskillit.config import AutomationConfig
     from autoskillit.server._factory import make_context
 
     ctx = make_context(AutomationConfig(), plugin_dir=str(tmp_path))
     assert isinstance(ctx.runner, RecordingSubprocessRunner)
+    mock_atexit.assert_not_called()
 
 
 # --- T11: make_context default runner unchanged without env var ---
@@ -459,7 +476,8 @@ def test_replay_takes_precedence_over_record(monkeypatch, tmp_path):
     monkeypatch.setattr(
         _api_sim_claude, "make_scenario_recorder", mock_make_recorder, raising=False
     )
-    monkeypatch.setattr("atexit.register", Mock())
+    mock_atexit = Mock()
+    monkeypatch.setattr("atexit.register", mock_atexit)
 
     from autoskillit.config import AutomationConfig
     from autoskillit.server._factory import make_context
@@ -467,6 +485,7 @@ def test_replay_takes_precedence_over_record(monkeypatch, tmp_path):
     ctx = make_context(AutomationConfig(), plugin_dir=str(tmp_path))
     assert isinstance(ctx.runner, ReplayingSubprocessRunner)
     mock_make_recorder.assert_not_called()  # REPLAY takes precedence over RECORD
+    mock_atexit.assert_not_called()
 
 
 # --- T22: Cross-scenario session override (integration, requires api-simulator) ---
@@ -497,10 +516,12 @@ async def test_cross_scenario_override(tmp_path):
 
 def test_recording_runner_recorder_is_public(monkeypatch):
     """RecordingSubprocessRunner exposes recorder as a public attribute."""
-    monkeypatch.setattr("atexit.register", Mock())
+    mock_atexit = Mock()
+    monkeypatch.setattr("atexit.register", mock_atexit)
     mock_recorder = Mock()
     runner = RecordingSubprocessRunner(recorder=mock_recorder)
     assert runner.recorder is mock_recorder
+    mock_atexit.assert_not_called()
 
 
 # --- T-REPLAY-PLAYER: player attribute stored ---
@@ -540,7 +561,9 @@ def test_build_replay_runner_stores_player_on_runner(tmp_path, monkeypatch):
     monkeypatch.setattr(
         _api_sim_claude, "make_scenario_player", Mock(return_value=mock_player), raising=False
     )
-    monkeypatch.setattr("atexit.register", Mock())
+    mock_atexit = Mock()
+    monkeypatch.setattr("atexit.register", mock_atexit)
 
     result = build_replay_runner(str(tmp_path))
     assert result.player is mock_player
+    mock_atexit.assert_not_called()

--- a/tests/execution/test_recording_sigterm.py
+++ b/tests/execution/test_recording_sigterm.py
@@ -50,6 +50,7 @@ def test_sigterm_writes_scenario_json(tmp_path):
     # teardown which writes scenario.json. Close stdin so the stdio transport
     # detects EOF and the event loop can fully unwind.
     proc.stdin.close()
+    proc.stdin = None  # prevent communicate() from flushing the closed pipe
     proc.send_signal(signal.SIGTERM)
     try:
         stdout_bytes, stderr_bytes = proc.communicate(timeout=10)

--- a/tests/execution/test_recording_sigterm.py
+++ b/tests/execution/test_recording_sigterm.py
@@ -13,6 +13,8 @@ import time
 
 import pytest
 
+_READY_TOKEN = "lifespan_started"
+
 
 @pytest.mark.integration
 def test_sigterm_writes_scenario_json(tmp_path):
@@ -36,13 +38,25 @@ def test_sigterm_writes_scenario_json(tmp_path):
         env=env,
     )
 
-    # Poll stderr for any output (server startup log) to detect readiness,
-    # rather than using a fixed sleep. Falls back to a 5-second ceiling so
-    # the test is both responsive on fast hosts and resilient on slow CI.
+    # Poll stderr line-by-line for the "sigterm_handler_ready" token which
+    # serve() emits immediately after installing the SIGTERM handler. This
+    # guarantees the handler is active before we send SIGTERM, while still
+    # being responsive (no fixed sleep). Falls back after 5 s on slow CI.
+    stderr_lines: list[str] = []
     deadline = time.monotonic() + 5.0
     while time.monotonic() < deadline:
-        ready, _, _ = select.select([proc.stderr], [], [], 0.1)
-        if ready or proc.poll() is not None:
+        remaining = deadline - time.monotonic()
+        readable, _, _ = select.select([proc.stderr], [], [], min(remaining, 0.2))
+        if not readable:
+            if proc.poll() is not None:
+                break
+            continue
+        line = proc.stderr.readline()
+        if not line:
+            break  # EOF — process died
+        decoded = line.decode(errors="replace")
+        stderr_lines.append(decoded)
+        if _READY_TOKEN in decoded:
             break
 
     # SIGTERM is the exact signal Claude Code sends on /exit.
@@ -53,13 +67,13 @@ def test_sigterm_writes_scenario_json(tmp_path):
     proc.stdin = None  # prevent communicate() from flushing the closed pipe
     proc.send_signal(signal.SIGTERM)
     try:
-        stdout_bytes, stderr_bytes = proc.communicate(timeout=10)
+        stdout_bytes, remaining_stderr_bytes = proc.communicate(timeout=10)
     except subprocess.TimeoutExpired:
         proc.kill()
-        stdout_bytes, stderr_bytes = proc.communicate()
+        stdout_bytes, remaining_stderr_bytes = proc.communicate()
 
     stdout = stdout_bytes.decode(errors="replace")
-    stderr = stderr_bytes.decode(errors="replace")
+    stderr = "".join(stderr_lines) + remaining_stderr_bytes.decode(errors="replace")
 
     scenario_json = output_dir / "scenario.json"
     assert scenario_json.exists(), (

--- a/tests/execution/test_recording_sigterm.py
+++ b/tests/execution/test_recording_sigterm.py
@@ -7,8 +7,8 @@ import json
 import os
 import signal
 import subprocess
+import sys
 import time
-from pathlib import Path
 
 import pytest
 
@@ -25,8 +25,10 @@ def test_sigterm_writes_scenario_json(tmp_path):
         "RECORD_SCENARIO_DIR": str(output_dir),
         "RECORD_SCENARIO_RECIPE": "test-recipe",
     }
+    # Use sys.executable -m to ensure we run the worktree-installed version,
+    # not a system-wide `autoskillit` binary that may lack the lifespan fix.
     proc = subprocess.Popen(
-        ["autoskillit", "serve"],
+        [sys.executable, "-m", "autoskillit"],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -34,16 +36,23 @@ def test_sigterm_writes_scenario_json(tmp_path):
     )
 
     # Allow server to start and install its signal handler
-    time.sleep(0.5)
+    time.sleep(1.0)
 
-    # SIGTERM is the exact signal Claude Code sends on /exit
+    # SIGTERM is the exact signal Claude Code sends on /exit.
+    # The handler converts SIGTERM → KeyboardInterrupt, triggering lifespan
+    # teardown which writes scenario.json. Close stdin so the stdio transport
+    # detects EOF and the event loop can fully unwind.
+    proc.stdin.close()
     proc.send_signal(signal.SIGTERM)
-    proc.wait(timeout=10)
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
 
     scenario_json = output_dir / "scenario.json"
     assert scenario_json.exists(), (
-        "scenario.json not written after SIGTERM — "
-        "finalize() likely bypassed (issue #745)"
+        "scenario.json not written after SIGTERM — finalize() likely bypassed (issue #745)"
     )
     data = json.loads(scenario_json.read_text())
     assert data.get("recipe") == "test-recipe"

--- a/tests/execution/test_recording_sigterm.py
+++ b/tests/execution/test_recording_sigterm.py
@@ -1,0 +1,49 @@
+"""
+Integration test: real autoskillit serve subprocess receives SIGTERM
+and writes scenario.json to disk. Regression guard for issue #745.
+"""
+
+import json
+import os
+import signal
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.integration
+def test_sigterm_writes_scenario_json(tmp_path):
+    """Server writes scenario.json when terminated by SIGTERM."""
+    output_dir = tmp_path / "scenario"
+    output_dir.mkdir()
+
+    env = {
+        **os.environ,
+        "RECORD_SCENARIO": "1",
+        "RECORD_SCENARIO_DIR": str(output_dir),
+        "RECORD_SCENARIO_RECIPE": "test-recipe",
+    }
+    proc = subprocess.Popen(
+        ["autoskillit", "serve"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+    )
+
+    # Allow server to start and install its signal handler
+    time.sleep(0.5)
+
+    # SIGTERM is the exact signal Claude Code sends on /exit
+    proc.send_signal(signal.SIGTERM)
+    proc.wait(timeout=10)
+
+    scenario_json = output_dir / "scenario.json"
+    assert scenario_json.exists(), (
+        "scenario.json not written after SIGTERM — "
+        "finalize() likely bypassed (issue #745)"
+    )
+    data = json.loads(scenario_json.read_text())
+    assert data.get("recipe") == "test-recipe"

--- a/tests/execution/test_recording_sigterm.py
+++ b/tests/execution/test_recording_sigterm.py
@@ -5,6 +5,7 @@ and writes scenario.json to disk. Regression guard for issue #745.
 
 import json
 import os
+import select
 import signal
 import subprocess
 import sys
@@ -35,8 +36,14 @@ def test_sigterm_writes_scenario_json(tmp_path):
         env=env,
     )
 
-    # Allow server to start and install its signal handler
-    time.sleep(1.0)
+    # Poll stderr for any output (server startup log) to detect readiness,
+    # rather than using a fixed sleep. Falls back to a 5-second ceiling so
+    # the test is both responsive on fast hosts and resilient on slow CI.
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        ready, _, _ = select.select([proc.stderr], [], [], 0.1)
+        if ready or proc.poll() is not None:
+            break
 
     # SIGTERM is the exact signal Claude Code sends on /exit.
     # The handler converts SIGTERM → KeyboardInterrupt, triggering lifespan
@@ -45,14 +52,19 @@ def test_sigterm_writes_scenario_json(tmp_path):
     proc.stdin.close()
     proc.send_signal(signal.SIGTERM)
     try:
-        proc.wait(timeout=10)
+        stdout_bytes, stderr_bytes = proc.communicate(timeout=10)
     except subprocess.TimeoutExpired:
         proc.kill()
-        proc.wait()
+        stdout_bytes, stderr_bytes = proc.communicate()
+
+    stdout = stdout_bytes.decode(errors="replace")
+    stderr = stderr_bytes.decode(errors="replace")
 
     scenario_json = output_dir / "scenario.json"
     assert scenario_json.exists(), (
-        "scenario.json not written after SIGTERM — finalize() likely bypassed (issue #745)"
+        "scenario.json not written after SIGTERM — finalize() likely bypassed (issue #745)\n"
+        f"stdout: {stdout!r}\n"
+        f"stderr: {stderr!r}"
     )
     data = json.loads(scenario_json.read_text())
     assert data.get("recipe") == "test-recipe"

--- a/tests/server/test_lifespan.py
+++ b/tests/server/test_lifespan.py
@@ -1,0 +1,48 @@
+"""Tests that the FastMCP lifespan calls recorder.finalize() on server shutdown."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from autoskillit.execution.recording import RecordingSubprocessRunner
+
+
+@pytest.mark.asyncio
+async def test_lifespan_calls_finalize_on_recording_runner():
+    """lifespan __aexit__ calls recorder.finalize() when runner is RecordingSubprocessRunner."""
+    from autoskillit.server import _autoskillit_lifespan
+
+    mock_recorder = MagicMock()
+    mock_runner = MagicMock(spec=RecordingSubprocessRunner)
+    mock_runner.recorder = mock_recorder
+    mock_ctx = MagicMock()
+    mock_ctx.runner = mock_runner
+
+    with patch("autoskillit.server._get_ctx_or_none", return_value=mock_ctx):
+        async with _autoskillit_lifespan(MagicMock()):
+            pass  # server running phase
+
+    mock_recorder.finalize.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_lifespan_skips_finalize_when_not_recording():
+    """lifespan __aexit__ does not error when runner is not RecordingSubprocessRunner."""
+    from autoskillit.server import _autoskillit_lifespan
+
+    mock_ctx = MagicMock()
+    mock_ctx.runner = MagicMock()  # plain runner, not RecordingSubprocessRunner
+
+    with patch("autoskillit.server._get_ctx_or_none", return_value=mock_ctx):
+        async with _autoskillit_lifespan(MagicMock()):
+            pass  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_lifespan_skips_finalize_when_ctx_is_none():
+    """lifespan __aexit__ is safe when _get_ctx_or_none() returns None (non-recording mode)."""
+    from autoskillit.server import _autoskillit_lifespan
+
+    with patch("autoskillit.server._get_ctx_or_none", return_value=None):
+        async with _autoskillit_lifespan(MagicMock()):
+            pass  # must not raise

--- a/tests/server/test_lifespan.py
+++ b/tests/server/test_lifespan.py
@@ -18,7 +18,7 @@ async def test_lifespan_calls_finalize_on_recording_runner():
     mock_ctx = MagicMock()
     mock_ctx.runner = mock_runner
 
-    with patch("autoskillit.server._get_ctx_or_none", return_value=mock_ctx):
+    with patch("autoskillit.server._lifespan._get_ctx_or_none", return_value=mock_ctx):
         async with _autoskillit_lifespan(MagicMock()):
             pass  # server running phase
 
@@ -33,7 +33,7 @@ async def test_lifespan_skips_finalize_when_not_recording():
     mock_ctx = MagicMock()
     mock_ctx.runner = MagicMock()  # plain runner, not RecordingSubprocessRunner
 
-    with patch("autoskillit.server._get_ctx_or_none", return_value=mock_ctx):
+    with patch("autoskillit.server._lifespan._get_ctx_or_none", return_value=mock_ctx):
         async with _autoskillit_lifespan(MagicMock()):
             pass  # must not raise
 
@@ -43,6 +43,6 @@ async def test_lifespan_skips_finalize_when_ctx_is_none():
     """lifespan __aexit__ is safe when _get_ctx_or_none() returns None (non-recording mode)."""
     from autoskillit.server import _autoskillit_lifespan
 
-    with patch("autoskillit.server._get_ctx_or_none", return_value=None):
+    with patch("autoskillit.server._lifespan._get_ctx_or_none", return_value=None):
         async with _autoskillit_lifespan(MagicMock()):
             pass  # must not raise

--- a/tests/server/test_state.py
+++ b/tests/server/test_state.py
@@ -109,7 +109,8 @@ def test_initialize_registers_mcp_recording_middleware(tmp_path, monkeypatch):
     from autoskillit.execution.recording import RecordingSubprocessRunner
     from autoskillit.server._state import _initialize
 
-    monkeypatch.setattr("atexit.register", Mock())
+    mock_atexit = Mock()
+    monkeypatch.setattr("atexit.register", mock_atexit)
     mock_recorder = Mock()
     recording_runner = RecordingSubprocessRunner(recorder=mock_recorder)
 
@@ -131,6 +132,7 @@ def test_initialize_registers_mcp_recording_middleware(tmp_path, monkeypatch):
 
     mock_middleware_cls.assert_called_once_with(mock_recorder)
     mock_mcp.add_middleware.assert_called_once_with(mock_middleware_cls.return_value)
+    mock_atexit.assert_not_called()
 
 
 # --- T-INIT-2: No middleware registered for non-recording runner ---
@@ -162,7 +164,8 @@ def test_initialize_recording_middleware_import_error_does_not_raise(tmp_path, m
     from autoskillit.execution.recording import RecordingSubprocessRunner
     from autoskillit.server._state import _initialize
 
-    monkeypatch.setattr("atexit.register", Mock())
+    mock_atexit = Mock()
+    monkeypatch.setattr("atexit.register", mock_atexit)
     mock_recorder = Mock()
     recording_runner = RecordingSubprocessRunner(recorder=mock_recorder)
 
@@ -175,6 +178,8 @@ def test_initialize_recording_middleware_import_error_does_not_raise(tmp_path, m
 
     with patch("autoskillit.execution.recover_crashed_sessions", return_value=0):
         _initialize(mock_ctx)  # Must not raise
+
+    mock_atexit.assert_not_called()
 
 
 # --- T-INIT-4: McpReplayMiddleware registered for ReplayingSubprocessRunner ---


### PR DESCRIPTION
## Summary

The MCP server process (`autoskillit serve`) terminates under SIGTERM (delivered by Claude Code on `/exit`), which bypasses Python's `atexit` hooks entirely. `ScenarioRecorder.finalize()` — the sole writer of `scenario.json` and the only flush of the in-memory MCP call buffer — is registered only via `atexit.register()` at `recording.py:67`. It never runs. Every recording session loses all scenario data except PTY cassettes already written to disk incrementally by `run_skill`.

The architectural weakness is that **server resource teardown is scattered into the resource's constructor** (`recording.py:67`) rather than owned by the server's lifecycle system. Worse: the server has no lifecycle system at all — no FastMCP `lifespan`, no signal handler, no `try/finally` around `mcp.run()`. Any future resource that needs cleanup on server exit faces the identical failure mode.

The immunity comes from two structural changes:

1. **Introduce a FastMCP `lifespan` async context manager** — the single authoritative teardown point for all server resources. No other shutdown mechanism is valid; all resources register their teardown here.
2. **Install a SIGTERM → `sys.exit(0)` signal handler** — converts signal-based termination into a clean Python exit so the lifespan's `__aexit__` always fires.

Together, these make the class of "resource registered for cleanup but bypassed by signal" bugs impossible: teardown is now a framework contract enforced at the server boundary, not a voluntary constructor-level `atexit` registration.

## Architecture Impact

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 65, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ── STARTUP PHASE ── %%
    subgraph Startup ["SERVER STARTUP — make_context() + _initialize()"]
        direction LR

        CtxFields["ToolContext fields<br/>━━━━━━━━━━<br/>INIT_ONLY: config, gate, audit,<br/>executor, runner, recorder<br/>Set once by make_context()"]

        MWFlag["● _mcp_middleware_registered<br/>━━━━━━━━━━<br/>MUTABLE (write-once flag)<br/>Guard: prevents double middleware<br/>Set by _initialize()"]

        GateClosed["ctx.gate.enabled = False<br/>━━━━━━━━━━<br/>MUTABLE: starts CLOSED<br/>Toggled by open_kitchen /<br/>close_kitchen at runtime"]

        AuditLoad["ctx.audit entries<br/>━━━━━━━━━━<br/>APPEND_ONLY<br/>Disk load in _initialize()<br/>Tools append at runtime"]
    end

    %% ── FASTMCP WIRING ── %%
    subgraph MCPLayer ["● server/__init__.py — FastMCP App"]
        direction TB

        MCPApp["● mcp = FastMCP('autoskillit',...)<br/>━━━━━━━━━━<br/>INIT_ONLY at module import<br/>lifespan=_autoskillit_lifespan<br/>mcp.disable(tags={'kitchen'}) on import"]

        SigInstall["● signal.signal(SIGTERM, handler)<br/>━━━━━━━━━━<br/>INIT_ONLY: installed before mcp.run()<br/>Converts SIGTERM → KeyboardInterrupt<br/>Registered in serve()"]
    end

    %% ── SHUTDOWN TRIGGERS ── %%
    subgraph ShutdownTriggers ["SHUTDOWN TRIGGERS"]
        direction LR

        SIGTERM(["OS: SIGTERM<br/>━━━━━━━━━━<br/>e.g. Claude Code /exit"])

        SigHandler["● _sigterm_handler(*_)<br/>━━━━━━━━━━<br/>raise KeyboardInterrupt<br/>No state read/written<br/>Converts signal → exception"]

        NormalExit(["User EOF / Ctrl-C<br/>━━━━━━━━━━<br/>Direct KeyboardInterrupt"])
    end

    KBI(["KeyboardInterrupt<br/>━━━━━━━━━━<br/>Both paths converge here"])

    MCPRun["mcp.run() → shutdown<br/>━━━━━━━━━━<br/>Catches KeyboardInterrupt<br/>Triggers FastMCP lifespan __aexit__"]

    %% ── LIFESPAN TEARDOWN ── %%
    subgraph LifespanTeardown ["★ server/_lifespan.py — _autoskillit_lifespan.__aexit__"]
        direction TB

        LifespanCtx["★ _autoskillit_lifespan<br/>━━━━━━━━━━<br/>@asynccontextmanager<br/>Startup: no-op (yield only)<br/>Teardown: ALL work in __aexit__"]

        Gate1{"GATE 1<br/>ctx is not None<br/>━━━━━━━━━━<br/>_get_ctx_or_none()"}

        Gate2{"GATE 2<br/>isinstance(runner,<br/>RecordingSubprocessRunner)<br/>━━━━━━━━━━<br/>Type guard"}
    end

    %% ── RECORDING STATE ── %%
    subgraph RecordingState ["● execution/recording.py — RecordingSubprocessRunner"]
        direction TB

        RunnerFields["● RecordingSubprocessRunner<br/>━━━━━━━━━━<br/>recorder: INIT_ONLY (set in __init__)<br/>_inner: INIT_ONLY (delegation target)<br/>_mcp_middleware_registered: MUTABLE"]

        FinalizeCall["recorder.finalize()<br/>━━━━━━━━━━<br/>Called exactly once by lifespan<br/>No idempotency guard in this repo<br/>(api-simulator owns finalize logic)"]
    end

    ScenarioOut[/"scenario.json<br/>━━━━━━━━━━<br/>Written to RECORD_SCENARIO_DIR<br/>Contains recipe name + steps<br/>Issue #745: now guaranteed on SIGTERM"/]

    NoOp(["no-op<br/>━━━━━━━━━━<br/>Safe skip — not a recording run"])

    %% ── CONNECTIONS ── %%
    Startup --> MCPLayer
    CtxFields -->|"runner field"| RunnerFields
    MWFlag -->|"guards"| RunnerFields

    SIGTERM --> SigHandler
    SigHandler -->|"raises"| KBI
    NormalExit --> KBI
    KBI -->|"propagates into"| MCPRun
    SigInstall -->|"installed before"| MCPRun
    MCPApp -->|"lifespan= wired"| MCPRun
    MCPRun -->|"FastMCP __aexit__"| LifespanCtx
    LifespanCtx --> Gate1

    Gate1 -->|"ctx not None"| Gate2
    Gate1 -->|"ctx is None"| NoOp

    Gate2 -->|"isinstance pass"| FinalizeCall
    Gate2 -->|"type mismatch"| NoOp

    RunnerFields -->|"recorder field"| FinalizeCall
    FinalizeCall --> ScenarioOut

    %% ── CLASS ASSIGNMENTS ── %%
    class CtxFields,AuditLoad stateNode;
    class MWFlag,GateClosed gap;
    class MCPApp phase;
    class SigInstall,SigHandler cli;
    class SIGTERM,NormalExit,KBI,NoOp terminal;
    class MCPRun phase;
    class LifespanCtx newComponent;
    class Gate1,Gate2 detector;
    class RunnerFields handler;
    class FinalizeCall gap;
    class ScenarioOut output;
```

### Error/Resilience Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 52, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ENTRY POINTS %%
    SIGTERM(["SIGTERM<br/>External Signal"])
    KEYBOARD_INT(["KeyboardInterrupt<br/>Ctrl-C"])

    subgraph SignalGate ["● SIGNAL HANDLING — cli/app.py serve()"]
        direction TB
        SIGTERM_H["● _sigterm_handler<br/>━━━━━━━━━━<br/>raise KeyboardInterrupt<br/>(converts OS signal → Python exc)"]
        MCP_RUN["● mcp.run()<br/>━━━━━━━━━━<br/>try: mcp.run()<br/>except KeyboardInterrupt: pass"]
    end

    subgraph LifespanTeardown ["★ LIFESPAN TEARDOWN — server/_lifespan.py"]
        direction TB
        LIFESPAN["★ _autoskillit_lifespan<br/>━━━━━━━━━━<br/>@asynccontextmanager<br/>__aexit__ side fires on shutdown"]
        CTX_GUARD{"_get_ctx_or_none()<br/>returns None?"}
        TYPE_GUARD{"isinstance(runner,<br/>RecordingSubprocessRunner)?"}
        FINALIZE["★ recorder.finalize()<br/>━━━━━━━━━━<br/>Writes scenario.json<br/>NO try/except here"]
    end

    subgraph RecordingPath ["● RECORDING SESSION — execution/recording.py"]
        direction TB
        REC_CALL["● RecordingSubprocessRunner.__call__<br/>━━━━━━━━━━<br/>Routes: pty_mode + step_name → _record_session<br/>else → inner runner (optionally records summary)"]
        RECORD_SESSION["● _record_session()<br/>━━━━━━━━━━<br/>asyncio.to_thread(recorder.record_step)"]
        REC_TRY{"try:<br/>record_step()"}
        REC_EXCEPT["logger.exception(<br/>'record_step failed')<br/>then re-raise"]
    end

    subgraph ReplayValidation ["● REPLAY VALIDATION GATES — execution/recording.py"]
        direction TB
        REPLAY_STEP{"SCENARIO_STEP_NAME<br/>present in env?"}
        REPLAY_MAP{"step_name in<br/>sessions or non_session?"}
        REPLAY_RUN["Consume from deque /<br/>return non_session result"]
    end

    subgraph InitRecovery ["WARN-AND-CONTINUE RECOVERY — server/_state.py _initialize()"]
        direction TB
        SUBSET_GUARD["subset mcp.disable()<br/>━━━━━━━━━━<br/>ImportError → logger.error, continue"]
        MIDDLEWARE_GUARD["McpRecordingMiddleware add<br/>━━━━━━━━━━<br/>ImportError / Exception → logger.warning, continue"]
        CRASH_GUARD["recover_crashed_sessions()<br/>━━━━━━━━━━<br/>Any Exception → logger.debug, continue"]
        TELEMETRY_GUARD["telemetry recovery<br/>━━━━━━━━━━<br/>Any Exception → logger.warning, continue"]
        SKILL_GUARD["session_skill_manager.cleanup_stale()<br/>━━━━━━━━━━<br/>Any Exception → logger.warning, continue"]
    end

    %% TERMINAL STATES %%
    T_SHUTDOWN(["CLEAN_SHUTDOWN<br/>process exits 0"])
    T_SCENARIO_OK(["★ scenario.json WRITTEN<br/>Recording preserved"])
    T_SKIP_NONE(["SKIP: ctx=None<br/>Silent, safe"])
    T_SKIP_PLAIN(["SKIP: plain runner<br/>No recording to save"])
    T_RECORD_FAIL(["RECORD_STEP FAILED<br/>Exception propagates<br/>to tool handler"])
    T_VAL_MISSING(["ValueError:<br/>SCENARIO_STEP_NAME absent"])
    T_REPLAY_MISS(["ScenarioReplayError:<br/>step not found<br/>+ diagnostic names"])
    T_FINALIZE_UNCAUGHT(["UNHANDLED finalize()<br/>Exception bubbles<br/>through FastMCP"])
    T_CTX_UNINIT(["RuntimeError:<br/>serve() not called before<br/>_get_ctx() on gated tool"])
    T_INIT_OK(["_initialize() complete<br/>non-fatal errors logged,<br/>server continues"])

    %% SIGNAL FLOW %%
    SIGTERM --> SIGTERM_H
    KEYBOARD_INT --> MCP_RUN
    SIGTERM_H -->|"raises KeyboardInterrupt"| MCP_RUN
    MCP_RUN -->|"except KeyboardInterrupt: pass"| LIFESPAN
    MCP_RUN -->|"clean exit"| T_SHUTDOWN

    %% LIFESPAN TEARDOWN FLOW %%
    LIFESPAN --> CTX_GUARD
    CTX_GUARD -->|"None"| T_SKIP_NONE
    CTX_GUARD -->|"ctx present"| TYPE_GUARD
    TYPE_GUARD -->|"False"| T_SKIP_PLAIN
    TYPE_GUARD -->|"True"| FINALIZE
    FINALIZE -->|"success"| T_SCENARIO_OK
    FINALIZE -->|"raises"| T_FINALIZE_UNCAUGHT

    %% RECORDING PATH %%
    REC_CALL -->|"pty_mode=True + step_name"| RECORD_SESSION
    RECORD_SESSION --> REC_TRY
    REC_TRY -->|"success"| REC_CALL
    REC_TRY -->|"Exception"| REC_EXCEPT
    REC_EXCEPT --> T_RECORD_FAIL

    %% REPLAY VALIDATION GATES %%
    REPLAY_STEP -->|"absent"| T_VAL_MISSING
    REPLAY_STEP -->|"present"| REPLAY_MAP
    REPLAY_MAP -->|"found"| REPLAY_RUN
    REPLAY_MAP -->|"not found"| T_REPLAY_MISS

    %% INIT RECOVERY %%
    SUBSET_GUARD --> MIDDLEWARE_GUARD
    MIDDLEWARE_GUARD --> CRASH_GUARD
    CRASH_GUARD --> TELEMETRY_GUARD
    TELEMETRY_GUARD --> SKILL_GUARD
    SKILL_GUARD --> T_INIT_OK

    %% CLASS ASSIGNMENTS %%
    class SIGTERM,KEYBOARD_INT integration;
    class SIGTERM_H,MCP_RUN handler;
    class LIFESPAN,FINALIZE newComponent;
    class CTX_GUARD,TYPE_GUARD,REPLAY_STEP,REPLAY_MAP detector;
    class REC_CALL,RECORD_SESSION handler;
    class REC_TRY stateNode;
    class REC_EXCEPT gap;
    class REPLAY_RUN output;
    class SUBSET_GUARD,MIDDLEWARE_GUARD,CRASH_GUARD,TELEMETRY_GUARD,SKILL_GUARD output;
    class T_SHUTDOWN,T_SCENARIO_OK,T_SKIP_NONE,T_SKIP_PLAIN,T_RECORD_FAIL,T_VAL_MISSING,T_REPLAY_MISS,T_FINALIZE_UNCAUGHT,T_CTX_UNINIT,T_INIT_OK terminal;
```

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 42, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START — autoskillit serve])
    CLEAN_EXIT([CLEAN EXIT])
    FINALIZED([FINALIZED — scenario.json written])
    ERROR([ERROR — unexpected exception])

    subgraph Startup ["● Phase 1 — Server Startup (cli/app.py:serve)"]
        direction TB
        ConfigLog["● Configure Logging<br/>━━━━━━━━━━<br/>INFO or DEBUG to stderr<br/>before server import"]
        LoadConfig["● Load Config<br/>━━━━━━━━━━<br/>load_config(project_dir)<br/>resolve config path"]
        ImportServer["● Import autoskillit.server<br/>━━━━━━━━━━<br/>Triggers FastMCP construction<br/>tool module registration<br/>mcp.disable(tags={'kitchen'})"]
        HeadlessGate{"AUTOSKILLIT_HEADLESS<br/>== '1'?"}
        EnableHeadless["Enable headless tag<br/>━━━━━━━━━━<br/>mcp.enable(tags={'headless'})<br/>exposes test_check only"]
        SigtermHandler["● Install SIGTERM Handler<br/>━━━━━━━━━━<br/>signal.signal(SIGTERM,<br/>_sigterm_handler)<br/>converts SIGTERM → KeyboardInterrupt"]
        McpRun["● mcp.run()<br/>━━━━━━━━━━<br/>blocking event loop<br/>wrapped in try/except KeyboardInterrupt"]
    end

    subgraph Lifespan ["★ Phase 2 — FastMCP Lifespan (server/_lifespan.py)"]
        direction TB
        LifespanYield["★ _autoskillit_lifespan: yield<br/>━━━━━━━━━━<br/>startup: no-op<br/>server active, serving MCP requests"]
    end

    subgraph Recording ["● Phase 3 — Recording Dispatch (execution/recording.py)"]
        direction TB
        RecCall["● RecordingSubprocessRunner.__call__<br/>━━━━━━━━━━<br/>invoked per tool subprocess request<br/>no atexit registered (lifespan owns teardown)"]
        StepNameGate{"SCENARIO_STEP_NAME<br/>in env?"}
        PtyGate{"pty_mode<br/>== True?"}
        RecordSession["● _record_session()<br/>━━━━━━━━━━<br/>asyncio.to_thread(recorder.record_step)<br/>returns synthetic SubprocessResult<br/>termination=NATURAL_EXIT, pid=0"]
        PassThrough["Pass-through<br/>━━━━━━━━━━<br/>delegate to self._inner<br/>DefaultSubprocessRunner"]
        RecordNonSession["● record_non_session_step()<br/>━━━━━━━━━━<br/>captures exit_code + stdout[:500]<br/>after inner runner completes"]
    end

    subgraph Shutdown ["★ Phase 4 — SIGTERM Teardown (_lifespan.py __aexit__)"]
        direction TB
        SigtermReceived["● SIGTERM received<br/>━━━━━━━━━━<br/>_sigterm_handler raises KeyboardInterrupt<br/>asyncio/anyio unwinds event loop"]
        LifespanExit["★ _autoskillit_lifespan: __aexit__<br/>━━━━━━━━━━<br/>lifespan context manager exits<br/>FastMCP-driven teardown path"]
        GetCtx["★ _get_ctx_or_none()<br/>━━━━━━━━━━<br/>safe retrieval: returns None<br/>if no session context active"]
        CtxGate{"ctx is<br/>not None?"}
        RunnerGate{"isinstance(ctx.runner,<br/>RecordingSubprocessRunner)?"}
        Finalize["★ recorder.finalize()<br/>━━━━━━━━━━<br/>writes scenario.json to disk<br/>persists all captured steps"]
        NoOpExit["No-op teardown<br/>━━━━━━━━━━<br/>non-recording mode<br/>or no context initialized"]
    end

    %% STARTUP FLOW %%
    START --> ConfigLog
    ConfigLog --> LoadConfig
    LoadConfig --> ImportServer
    ImportServer --> HeadlessGate
    HeadlessGate -->|"yes"| EnableHeadless
    HeadlessGate -->|"no"| SigtermHandler
    EnableHeadless --> SigtermHandler
    SigtermHandler --> McpRun
    McpRun --> LifespanYield

    %% RECORDING DISPATCH (repeated per tool call) %%
    LifespanYield -->|"tool subprocess requested"| RecCall
    RecCall --> StepNameGate
    StepNameGate -->|"no step name"| PassThrough
    StepNameGate -->|"step name present"| PtyGate
    PtyGate -->|"pty_mode=True"| RecordSession
    PtyGate -->|"pty_mode=False"| PassThrough
    PassThrough -->|"non-pty + step name"| RecordNonSession
    RecordSession -->|"returns to lifespan"| LifespanYield
    RecordNonSession -->|"returns to lifespan"| LifespanYield
    PassThrough -->|"no step name: returns to lifespan"| LifespanYield

    %% SHUTDOWN FLOW %%
    McpRun -->|"KeyboardInterrupt caught"| SigtermReceived
    SigtermReceived --> LifespanExit
    LifespanExit --> GetCtx
    GetCtx --> CtxGate
    CtxGate -->|"None (no context)"| NoOpExit
    CtxGate -->|"ctx exists"| RunnerGate
    RunnerGate -->|"not RecordingSubprocessRunner"| NoOpExit
    RunnerGate -->|"is RecordingSubprocessRunner"| Finalize
    Finalize --> FINALIZED
    NoOpExit --> CLEAN_EXIT

    %% ERROR PATH %%
    RecordSession -->|"exception from record_step"| ERROR

    %% CLASS ASSIGNMENTS %%
    class START,CLEAN_EXIT,FINALIZED,ERROR terminal;
    class ConfigLog,LoadConfig,ImportServer,EnableHeadless phase;
    class SigtermHandler,McpRun,RecCall,PassThrough handler;
    class HeadlessGate,StepNameGate,PtyGate,CtxGate,RunnerGate stateNode;
    class SigtermReceived,Finalize detector;
    class LifespanYield,LifespanExit,GetCtx,RecordSession,RecordNonSession,NoOpExit newComponent;
```

Closes #745

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-745-20260411-213724-303410/.autoskillit/temp/rectify/rectify_sigterm_finalize_2026-04-11_120000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| investigate | 106 | 9.3k | 408.0k | 39.9k | 1 | 4m 53s |
| rectify | 121 | 25.0k | 579.5k | 57.2k | 1 | 9m 46s |
| review | 5.0k | 10.1k | 809.8k | 70.9k | 1 | 5m 18s |
| dry_walkthrough | 57 | 19.3k | 1.3M | 81.1k | 1 | 7m 25s |
| implement | 91 | 17.4k | 3.0M | 70.0k | 1 | 6m 24s |
| assess | 161 | 32.7k | 7.3M | 133.2k | 2 | 20m 22s |
| prepare_pr | 34 | 5.5k | 214.7k | 30.7k | 1 | 1m 55s |
| run_arch_lenses | 1.9k | 23.6k | 569.8k | 92.6k | 3 | 9m 59s |
| compose_pr | 75 | 10.5k | 260.3k | 34.6k | 1 | 2m 30s |
| **Total** | 7.6k | 153.2k | 14.5M | 610.2k | | 1h 8m |