### PR TITLE
refactor(hooks): consolidate quota guard threshold configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,8 +247,8 @@ generic_automation_mcp/
 │   ├── hooks.json           #   Plugin hook registration
 │   ├── branch_protection_guard.py
 │   ├── _hook_settings.py    #   Shared stdlib-only settings resolver for quota guard hooks
-│   ├── quota_check.py       #   Blocks run_skill when threshold exceeded
-│   ├── quota_post_check.py  #   Appends quota warning to run_skill output
+│   ├── quota_guard.py       #   Blocks run_skill when threshold exceeded
+│   ├── quota_post_hook.py   #   Appends quota warning to run_skill output
 │   ├── remove_clone_guard.py
 │   ├── skill_cmd_guard.py
 │   ├── skill_command_guard.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,8 +246,9 @@ generic_automation_mcp/
 │   ├── __init__.py
 │   ├── hooks.json           #   Plugin hook registration
 │   ├── branch_protection_guard.py
-│   ├── quota_guard.py       #   Blocks run_skill when threshold exceeded
-│   ├── quota_post_hook.py   #   Appends quota warning to run_skill output
+│   ├── _hook_settings.py    #   Shared stdlib-only settings resolver for quota guard hooks
+│   ├── quota_check.py       #   Blocks run_skill when threshold exceeded
+│   ├── quota_post_check.py  #   Appends quota warning to run_skill output
 │   ├── remove_clone_guard.py
 │   ├── skill_cmd_guard.py
 │   ├── skill_command_guard.py

--- a/src/autoskillit/hooks/_hook_settings.py
+++ b/src/autoskillit/hooks/_hook_settings.py
@@ -5,7 +5,8 @@ dynaconf-backed settings system without importing third-party packages:
 
     1. Function parameter (``cache_path_override`` — for tests/DI)
     2. Environment variable (``AUTOSKILLIT_QUOTA_GUARD__<KEY>``) — highest runtime priority
-    3. Hook config snapshot (``.autoskillit/temp/.hook_config.json``) — bridge from resolved settings
+    3. Hook config snapshot (``.autoskillit/temp/.hook_config.json``) — bridge from
+       resolved settings
     4. Module default (matches ``config/defaults.yaml``) — lowest
 
 This module is stdlib-only: no third-party imports, no ``autoskillit.*``

--- a/src/autoskillit/hooks/_hook_settings.py
+++ b/src/autoskillit/hooks/_hook_settings.py
@@ -5,7 +5,7 @@ dynaconf-backed settings system without importing third-party packages:
 
     1. Function parameter (``cache_path_override`` — for tests/DI)
     2. Environment variable (``AUTOSKILLIT_QUOTA_GUARD__<KEY>``) — highest runtime priority
-    3. Hook config snapshot (``.autoskillit/.hook_config.json``) — bridge from resolved settings
+    3. Hook config snapshot (``.autoskillit/temp/.hook_config.json``) — bridge from resolved settings
     4. Module default (matches ``config/defaults.yaml``) — lowest
 
 This module is stdlib-only: no third-party imports, no ``autoskillit.*``
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 HOOK_CONFIG_FILENAME = ".hook_config.json"
-HOOK_DIR_COMPONENTS = (".autoskillit",)
+HOOK_DIR_COMPONENTS = (".autoskillit", "temp")
 
 DEFAULT_CACHE_PATH = "~/.claude/autoskillit_quota_cache.json"
 DEFAULT_CACHE_MAX_AGE = 300
@@ -40,7 +40,7 @@ class QuotaHookSettings:
 
 
 def _read_hook_config() -> dict:
-    """Read the ``quota_guard`` section of ``<cwd>/.autoskillit/.hook_config.json``.
+    """Read the ``quota_guard`` section of ``<cwd>/.autoskillit/temp/.hook_config.json``.
 
     Returns ``{}`` if the file is absent or unreadable. This file is written by
     ``open_kitchen`` and removed by ``close_kitchen``.

--- a/src/autoskillit/hooks/_hook_settings.py
+++ b/src/autoskillit/hooks/_hook_settings.py
@@ -1,0 +1,106 @@
+"""Shared stdlib-only settings resolver for quota guard hooks.
+
+Resolves hook settings from a layered hierarchy that mirrors the
+dynaconf-backed settings system without importing third-party packages:
+
+    1. Function parameter (``cache_path_override`` — for tests/DI)
+    2. Environment variable (``AUTOSKILLIT_QUOTA_GUARD__<KEY>``) — highest runtime priority
+    3. Hook config snapshot (``.autoskillit/.hook_config.json``) — bridge from resolved settings
+    4. Module default (matches ``config/defaults.yaml``) — lowest
+
+This module is stdlib-only: no third-party imports, no ``autoskillit.*``
+imports. It runs unchanged under the bare Python interpreter used by
+Claude Code hook subprocesses.
+"""
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+HOOK_CONFIG_FILENAME = ".hook_config.json"
+HOOK_DIR_COMPONENTS = (".autoskillit",)
+
+DEFAULT_CACHE_PATH = "~/.claude/autoskillit_quota_cache.json"
+DEFAULT_CACHE_MAX_AGE = 300
+DEFAULT_BUFFER_SECONDS = 60
+
+ENV_CACHE_PATH = "AUTOSKILLIT_QUOTA_GUARD__CACHE_PATH"
+ENV_CACHE_MAX_AGE = "AUTOSKILLIT_QUOTA_GUARD__CACHE_MAX_AGE"
+ENV_BUFFER_SECONDS = "AUTOSKILLIT_QUOTA_GUARD__BUFFER_SECONDS"
+
+
+@dataclass(frozen=True, slots=True)
+class QuotaHookSettings:
+    """Resolved settings for quota guard hooks."""
+
+    cache_path: str
+    cache_max_age: int
+    buffer_seconds: int
+
+
+def _read_hook_config() -> dict:
+    """Read the ``quota_guard`` section of ``<cwd>/.autoskillit/.hook_config.json``.
+
+    Returns ``{}`` if the file is absent or unreadable. This file is written by
+    ``open_kitchen`` and removed by ``close_kitchen``.
+    """
+    try:
+        config_path = Path.cwd().joinpath(*HOOK_DIR_COMPONENTS, HOOK_CONFIG_FILENAME)
+        return json.loads(config_path.read_text()).get("quota_guard", {})
+    except (OSError, json.JSONDecodeError, AttributeError, TypeError):
+        return {}
+
+
+def _resolve_int(env_var: str, hook_value: object, default: int) -> int:
+    """Resolve an integer setting: env var > hook config > default.
+
+    Non-numeric env var values fall through to the next level.
+    """
+    env_raw = os.environ.get(env_var)
+    if env_raw is not None:
+        try:
+            return int(env_raw)
+        except (ValueError, TypeError):
+            pass
+    if isinstance(hook_value, int) and not isinstance(hook_value, bool):
+        return hook_value
+    if isinstance(hook_value, float):
+        return int(hook_value)
+    return default
+
+
+def resolve_quota_settings(
+    *, cache_path_override: str | None = None
+) -> QuotaHookSettings:
+    """Resolve quota hook settings from the layered hierarchy.
+
+    ``cache_path``: ``cache_path_override`` > env var > hook config > default.
+    ``cache_max_age`` / ``buffer_seconds``: env var > hook config > default.
+    """
+    hook_config = _read_hook_config()
+
+    cache_path = (
+        cache_path_override
+        or os.environ.get(ENV_CACHE_PATH)
+        or hook_config.get("cache_path")
+        or DEFAULT_CACHE_PATH
+    )
+
+    cache_max_age = _resolve_int(
+        ENV_CACHE_MAX_AGE,
+        hook_config.get("cache_max_age"),
+        DEFAULT_CACHE_MAX_AGE,
+    )
+
+    buffer_seconds = _resolve_int(
+        ENV_BUFFER_SECONDS,
+        hook_config.get("buffer_seconds"),
+        DEFAULT_BUFFER_SECONDS,
+    )
+
+    return QuotaHookSettings(
+        cache_path=cache_path,
+        cache_max_age=cache_max_age,
+        buffer_seconds=buffer_seconds,
+    )

--- a/src/autoskillit/hooks/_hook_settings.py
+++ b/src/autoskillit/hooks/_hook_settings.py
@@ -70,9 +70,7 @@ def _resolve_int(env_var: str, hook_value: object, default: int) -> int:
     return default
 
 
-def resolve_quota_settings(
-    *, cache_path_override: str | None = None
-) -> QuotaHookSettings:
+def resolve_quota_settings(*, cache_path_override: str | None = None) -> QuotaHookSettings:
     """Resolve quota hook settings from the layered hierarchy.
 
     ``cache_path``: ``cache_path_override`` > env var > hook config > default.

--- a/src/autoskillit/hooks/quota_guard.py
+++ b/src/autoskillit/hooks/quota_guard.py
@@ -18,25 +18,16 @@ import sys
 from datetime import UTC, datetime
 from pathlib import Path
 
-# stdlib-only subprocess hook: import _fmt_primitives by bare name via sys.path
-# (test_hooks_are_stdlib_only). Venv tests use the autoskillit.hooks package path.
+# Sibling-import bootstrap: hooks run as ``python3 /path/to/quota_check.py``
+# subprocesses outside the autoskillit venv (test_hooks_are_stdlib_only).
+# Placing the script's directory first on sys.path lets the bare-name import
+# below resolve to the shared stdlib-only settings module in both subprocess
+# and package-mode invocations.
 _HOOKS_DIR = str(Path(__file__).resolve().parent)
 if _HOOKS_DIR not in sys.path:
     sys.path.insert(0, _HOOKS_DIR)
 
-from _fmt_primitives import (  # type: ignore[import-not-found]  # noqa: E402
-    _HOOK_CONFIG_PATH_COMPONENTS,
-    _read_hook_config,
-)
-
-_DEFAULT_CACHE_PATH = "~/.claude/autoskillit_quota_cache.json"
-_DEFAULT_CACHE_MAX_AGE = 300  # seconds
-
-# Public names preserved for test imports and the layer enforcement test.
-# Derived from _fmt_primitives._HOOK_CONFIG_PATH_COMPONENTS so the tuple has
-# exactly one source of truth across the hooks layer.
-HOOK_CONFIG_FILENAME: str = _HOOK_CONFIG_PATH_COMPONENTS[-1]
-HOOK_DIR_COMPONENTS: tuple[str, ...] = _HOOK_CONFIG_PATH_COMPONENTS[:-1]
+from _hook_settings import resolve_quota_settings  # type: ignore[import-not-found]  # noqa: E402
 
 _AUTOSKILLIT_LOG_DIR_ENV = "AUTOSKILLIT_LOG_DIR"
 
@@ -108,15 +99,9 @@ def main(*, cache_path_override: str | None = None) -> None:
         )
         sys.exit(0)  # log but approve — don't block run_skill on hook bugs
 
-    hook_config = _read_hook_config()
-    cache_max_age = hook_config.get("cache_max_age", _DEFAULT_CACHE_MAX_AGE)
-    # Function parameter > env var > hook config > module default
-    cache_path_str = (
-        cache_path_override
-        or os.environ.get("AUTOSKILLIT_QUOTA_CACHE")
-        or hook_config.get("cache_path")
-        or _DEFAULT_CACHE_PATH
-    )
+    settings = resolve_quota_settings(cache_path_override=cache_path_override)
+    cache_path_str = settings.cache_path
+    cache_max_age = settings.cache_max_age
     log_dir = _resolve_quota_log_dir()
     ts = datetime.now(UTC).isoformat()
 
@@ -156,13 +141,15 @@ def main(*, cache_path_override: str | None = None) -> None:
         if resets_at_str:
             try:
                 resets_at = datetime.fromisoformat(resets_at_str)
-                buffer_seconds = 60
                 now = datetime.now(UTC)
-                n = max(0, int((resets_at - now).total_seconds()) + buffer_seconds)
+                n = max(
+                    0,
+                    int((resets_at - now).total_seconds()) + settings.buffer_seconds,
+                )
             except (ValueError, TypeError):
-                n = 60
+                n = settings.buffer_seconds
         else:
-            n = 60
+            n = settings.buffer_seconds
 
         _write_quota_log_event(
             {

--- a/src/autoskillit/hooks/quota_post_hook.py
+++ b/src/autoskillit/hooks/quota_post_hook.py
@@ -15,25 +15,16 @@ import sys
 from datetime import UTC, datetime
 from pathlib import Path
 
-# stdlib-only subprocess hook: import _fmt_primitives by bare name via sys.path
-# (test_hooks_are_stdlib_only). Venv tests use the autoskillit.hooks package path.
+# Sibling-import bootstrap: hooks run as ``python3 /path/to/quota_post_check.py``
+# subprocesses outside the autoskillit venv (test_hooks_are_stdlib_only).
+# Placing the script's directory first on sys.path lets the bare-name import
+# below resolve to the shared stdlib-only settings module in both subprocess
+# and package-mode invocations.
 _HOOKS_DIR = str(Path(__file__).resolve().parent)
 if _HOOKS_DIR not in sys.path:
     sys.path.insert(0, _HOOKS_DIR)
 
-from _fmt_primitives import (  # type: ignore[import-not-found]  # noqa: E402
-    _HOOK_CONFIG_PATH_COMPONENTS,
-    _read_hook_config,
-)
-
-_DEFAULT_CACHE_PATH = "~/.claude/autoskillit_quota_cache.json"
-_DEFAULT_CACHE_MAX_AGE = 300  # seconds
-
-# Public names preserved for test imports. Derived from
-# _fmt_primitives._HOOK_CONFIG_PATH_COMPONENTS so the tuple has exactly one
-# source of truth across the hooks layer.
-HOOK_CONFIG_FILENAME: str = _HOOK_CONFIG_PATH_COMPONENTS[-1]
-HOOK_DIR_COMPONENTS: tuple[str, ...] = _HOOK_CONFIG_PATH_COMPONENTS[:-1]
+from _hook_settings import resolve_quota_settings  # type: ignore[import-not-found]  # noqa: E402
 
 _AUTOSKILLIT_LOG_DIR_ENV = "AUTOSKILLIT_LOG_DIR"
 
@@ -119,14 +110,9 @@ def main(*, cache_path_override: str | None = None) -> None:
     tool_name = event.get("tool_name", "")
     tool_response = event.get("tool_response") or ""
 
-    hook_config = _read_hook_config()
-    cache_max_age = hook_config.get("cache_max_age", _DEFAULT_CACHE_MAX_AGE)
-    cache_path_str = (
-        cache_path_override
-        or os.environ.get("AUTOSKILLIT_QUOTA_CACHE")
-        or hook_config.get("cache_path")
-        or _DEFAULT_CACHE_PATH
-    )
+    settings = resolve_quota_settings(cache_path_override=cache_path_override)
+    cache_path_str = settings.cache_path
+    cache_max_age = settings.cache_max_age
     log_dir = _resolve_quota_log_dir()
     ts = datetime.now(UTC).isoformat()
 
@@ -163,13 +149,15 @@ def main(*, cache_path_override: str | None = None) -> None:
     if resets_at_str:
         try:
             resets_at = datetime.fromisoformat(resets_at_str)
-            buffer_seconds = 60
             now = datetime.now(UTC)
-            n = max(0, int((resets_at - now).total_seconds()) + buffer_seconds)
+            n = max(
+                0,
+                int((resets_at - now).total_seconds()) + settings.buffer_seconds,
+            )
         except (ValueError, TypeError):
-            n = 60
+            n = settings.buffer_seconds
     else:
-        n = 60
+        n = settings.buffer_seconds
 
     result_summary = _extract_run_skill_result(tool_response)
 

--- a/src/autoskillit/server/tools_kitchen.py
+++ b/src/autoskillit/server/tools_kitchen.py
@@ -126,6 +126,7 @@ def _write_hook_config() -> None:
         "quota_guard": {
             "cache_max_age": cfg.cache_max_age,
             "cache_path": cfg.cache_path,
+            "buffer_seconds": cfg.buffer_seconds,
         },
         "kitchen_id": ctx.kitchen_id,
     }

--- a/tests/arch/test_layer_enforcement.py
+++ b/tests/arch/test_layer_enforcement.py
@@ -816,19 +816,22 @@ def test_native_tool_guard_absent_from_hook_registry():
 
 
 def test_hook_config_filename_and_dir_match_quota_check():
-    """server/helpers._hook_config_path must resolve to the same path as
-    _fmt_primitives._HOOK_CONFIG_PATH_COMPONENTS declares.
+    """Hook config path constants must agree across all readers and the server writer.
 
-    _fmt_primitives is the canonical hooks-layer source of truth for the hook
-    config path tuple. The server (tools_kitchen.py) writes the config via
-    server.helpers._hook_config_path; every hook reads the same tuple from
-    _fmt_primitives. They must resolve to an identical path, or the writer and
-    readers will silently disagree on the file location.
+    The server (tools_kitchen.py) writes the config; all hooks read it.
+    Two reader contracts must hold:
+    - _fmt_primitives._HOOK_CONFIG_PATH_COMPONENTS == server.helpers._hook_config_path
+    - _hook_settings.py constants == server.helpers constants
     """
+    import importlib
     from pathlib import Path
 
     from autoskillit.hooks._fmt_primitives import _HOOK_CONFIG_PATH_COMPONENTS
-    from autoskillit.server.helpers import _hook_config_path
+    from autoskillit.server.helpers import (
+        _HOOK_CONFIG_FILENAME,
+        _HOOK_DIR_COMPONENTS,
+        _hook_config_path,
+    )
 
     root = Path("/tmp/project-root")
     expected = root.joinpath(*_HOOK_CONFIG_PATH_COMPONENTS)
@@ -838,6 +841,17 @@ def test_hook_config_filename_and_dir_match_quota_check():
         f"server.helpers._hook_config_path({root!r})={actual!r} "
         f"does not match path derived from "
         f"_fmt_primitives._HOOK_CONFIG_PATH_COMPONENTS={expected!r}"
+    )
+
+    settings_mod = importlib.import_module("autoskillit.hooks._hook_settings")
+
+    assert settings_mod.HOOK_CONFIG_FILENAME == _HOOK_CONFIG_FILENAME, (
+        f"_hook_settings.HOOK_CONFIG_FILENAME={settings_mod.HOOK_CONFIG_FILENAME!r} "
+        f"does not match tools_kitchen._HOOK_CONFIG_FILENAME={_HOOK_CONFIG_FILENAME!r}"
+    )
+    assert settings_mod.HOOK_DIR_COMPONENTS == _HOOK_DIR_COMPONENTS, (
+        f"_hook_settings.HOOK_DIR_COMPONENTS={settings_mod.HOOK_DIR_COMPONENTS!r} "
+        f"does not match tools_kitchen._HOOK_DIR_COMPONENTS={_HOOK_DIR_COMPONENTS!r}"
     )
 
 

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -685,7 +685,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "execution": 25,
         "core": 16,
         "cli": 16,
-        "hooks": 18,
+        "hooks": 19,
     }
     violations: list[str] = []
     for sub_dir in sorted(SRC_ROOT.iterdir()):

--- a/tests/infra/test_hook_settings.py
+++ b/tests/infra/test_hook_settings.py
@@ -5,7 +5,7 @@ cache max age, and buffer seconds from a layered hierarchy:
 
     1. ``cache_path_override`` parameter (tests / DI)
     2. ``AUTOSKILLIT_QUOTA_GUARD__<KEY>`` env var
-    3. ``.autoskillit/.hook_config.json`` snapshot
+    3. ``.autoskillit/temp/.hook_config.json`` snapshot
     4. Module defaults (matching ``config/defaults.yaml``)
 
 These tests use ``tmp_path`` and ``monkeypatch`` for isolation — no global state.
@@ -28,7 +28,7 @@ def _clear_env(monkeypatch):
 
 
 def _write_hook_config(tmp_path, quota_guard: dict) -> None:
-    hook_cfg = tmp_path / ".autoskillit" / ".hook_config.json"
+    hook_cfg = tmp_path / ".autoskillit" / "temp" / ".hook_config.json"
     hook_cfg.parent.mkdir(parents=True, exist_ok=True)
     hook_cfg.write_text(json.dumps({"quota_guard": quota_guard}))
 

--- a/tests/infra/test_hook_settings.py
+++ b/tests/infra/test_hook_settings.py
@@ -1,0 +1,202 @@
+"""Tests for the shared stdlib-only quota hook settings resolver.
+
+``autoskillit.hooks._hook_settings.resolve_quota_settings()`` resolves cache path,
+cache max age, and buffer seconds from a layered hierarchy:
+
+    1. ``cache_path_override`` parameter (tests / DI)
+    2. ``AUTOSKILLIT_QUOTA_GUARD__<KEY>`` env var
+    3. ``.autoskillit/.hook_config.json`` snapshot
+    4. Module defaults (matching ``config/defaults.yaml``)
+
+These tests use ``tmp_path`` and ``monkeypatch`` for isolation — no global state.
+"""
+
+from __future__ import annotations
+
+import json
+
+_ENV_VARS = (
+    "AUTOSKILLIT_QUOTA_GUARD__CACHE_PATH",
+    "AUTOSKILLIT_QUOTA_GUARD__CACHE_MAX_AGE",
+    "AUTOSKILLIT_QUOTA_GUARD__BUFFER_SECONDS",
+)
+
+
+def _clear_env(monkeypatch):
+    for name in _ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
+def _write_hook_config(tmp_path, quota_guard: dict) -> None:
+    hook_cfg = tmp_path / ".autoskillit" / ".hook_config.json"
+    hook_cfg.parent.mkdir(parents=True, exist_ok=True)
+    hook_cfg.write_text(json.dumps({"quota_guard": quota_guard}))
+
+
+# T-HS-1
+def test_resolve_defaults_without_env_or_hook_config(tmp_path, monkeypatch):
+    """With no env var and no hook config, resolver returns module defaults."""
+    from autoskillit.hooks._hook_settings import (
+        DEFAULT_BUFFER_SECONDS,
+        DEFAULT_CACHE_MAX_AGE,
+        DEFAULT_CACHE_PATH,
+        resolve_quota_settings,
+    )
+
+    monkeypatch.chdir(tmp_path)
+    _clear_env(monkeypatch)
+
+    settings = resolve_quota_settings()
+
+    assert settings.cache_path == DEFAULT_CACHE_PATH
+    assert settings.cache_max_age == DEFAULT_CACHE_MAX_AGE
+    assert settings.buffer_seconds == DEFAULT_BUFFER_SECONDS
+
+
+# T-HS-2
+def test_env_var_overrides_cache_max_age(tmp_path, monkeypatch):
+    """AUTOSKILLIT_QUOTA_GUARD__CACHE_MAX_AGE env var sets cache_max_age."""
+    from autoskillit.hooks._hook_settings import resolve_quota_settings
+
+    monkeypatch.chdir(tmp_path)
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("AUTOSKILLIT_QUOTA_GUARD__CACHE_MAX_AGE", "600")
+
+    settings = resolve_quota_settings()
+
+    assert settings.cache_max_age == 600
+
+
+# T-HS-3
+def test_env_var_overrides_cache_path(tmp_path, monkeypatch):
+    """AUTOSKILLIT_QUOTA_GUARD__CACHE_PATH env var sets cache_path."""
+    from autoskillit.hooks._hook_settings import resolve_quota_settings
+
+    monkeypatch.chdir(tmp_path)
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("AUTOSKILLIT_QUOTA_GUARD__CACHE_PATH", "/custom/path.json")
+
+    settings = resolve_quota_settings()
+
+    assert settings.cache_path == "/custom/path.json"
+
+
+# T-HS-4
+def test_env_var_overrides_buffer_seconds(tmp_path, monkeypatch):
+    """AUTOSKILLIT_QUOTA_GUARD__BUFFER_SECONDS env var sets buffer_seconds."""
+    from autoskillit.hooks._hook_settings import resolve_quota_settings
+
+    monkeypatch.chdir(tmp_path)
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("AUTOSKILLIT_QUOTA_GUARD__BUFFER_SECONDS", "120")
+
+    settings = resolve_quota_settings()
+
+    assert settings.buffer_seconds == 120
+
+
+# T-HS-5
+def test_hook_config_overrides_defaults(tmp_path, monkeypatch):
+    """Hook config snapshot overrides module defaults when env vars are unset."""
+    from autoskillit.hooks._hook_settings import resolve_quota_settings
+
+    monkeypatch.chdir(tmp_path)
+    _clear_env(monkeypatch)
+    _write_hook_config(
+        tmp_path,
+        {
+            "cache_max_age": 600,
+            "cache_path": "/bridge/cache.json",
+            "buffer_seconds": 90,
+        },
+    )
+
+    settings = resolve_quota_settings()
+
+    assert settings.cache_max_age == 600
+    assert settings.cache_path == "/bridge/cache.json"
+    assert settings.buffer_seconds == 90
+
+
+# T-HS-6
+def test_env_var_beats_hook_config(tmp_path, monkeypatch):
+    """Env var takes precedence over hook config snapshot."""
+    from autoskillit.hooks._hook_settings import resolve_quota_settings
+
+    monkeypatch.chdir(tmp_path)
+    _clear_env(monkeypatch)
+    _write_hook_config(
+        tmp_path,
+        {
+            "cache_max_age": 600,
+            "cache_path": "/bridge/cache.json",
+            "buffer_seconds": 90,
+        },
+    )
+    monkeypatch.setenv("AUTOSKILLIT_QUOTA_GUARD__CACHE_MAX_AGE", "900")
+    monkeypatch.setenv("AUTOSKILLIT_QUOTA_GUARD__CACHE_PATH", "/env/cache.json")
+    monkeypatch.setenv("AUTOSKILLIT_QUOTA_GUARD__BUFFER_SECONDS", "300")
+
+    settings = resolve_quota_settings()
+
+    assert settings.cache_max_age == 900
+    assert settings.cache_path == "/env/cache.json"
+    assert settings.buffer_seconds == 300
+
+
+# T-HS-7
+def test_cache_path_override_parameter_beats_all(tmp_path, monkeypatch):
+    """``cache_path_override`` parameter wins over env var and hook config."""
+    from autoskillit.hooks._hook_settings import resolve_quota_settings
+
+    monkeypatch.chdir(tmp_path)
+    _clear_env(monkeypatch)
+    _write_hook_config(tmp_path, {"cache_path": "/bridge/cache.json"})
+    monkeypatch.setenv("AUTOSKILLIT_QUOTA_GUARD__CACHE_PATH", "/env/cache.json")
+
+    settings = resolve_quota_settings(cache_path_override="/test.json")
+
+    assert settings.cache_path == "/test.json"
+
+
+# T-HS-8
+def test_invalid_env_var_falls_through(tmp_path, monkeypatch):
+    """Non-numeric env var values fall through to hook config / default."""
+    from autoskillit.hooks._hook_settings import (
+        DEFAULT_BUFFER_SECONDS,
+        resolve_quota_settings,
+    )
+
+    monkeypatch.chdir(tmp_path)
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("AUTOSKILLIT_QUOTA_GUARD__CACHE_MAX_AGE", "not-a-number")
+    _write_hook_config(tmp_path, {"cache_max_age": 450})
+
+    settings = resolve_quota_settings()
+
+    # Invalid env var → falls through to hook config (450)
+    assert settings.cache_max_age == 450
+    # buffer_seconds has neither env var nor hook config → default
+    assert settings.buffer_seconds == DEFAULT_BUFFER_SECONDS
+
+
+# T-HS-9
+def test_defaults_match_defaults_yaml():
+    """Module default constants must match ``config/defaults.yaml`` exactly.
+
+    Structural guard against drift between the stdlib-only hook module and the
+    canonical dynaconf-loaded settings layer.
+    """
+    from autoskillit.core import load_yaml, pkg_root
+    from autoskillit.hooks._hook_settings import (
+        DEFAULT_BUFFER_SECONDS,
+        DEFAULT_CACHE_MAX_AGE,
+        DEFAULT_CACHE_PATH,
+    )
+
+    defaults = load_yaml(pkg_root() / "config" / "defaults.yaml")
+    assert isinstance(defaults, dict)
+    quota_guard = defaults["quota_guard"]
+    assert DEFAULT_CACHE_PATH == quota_guard["cache_path"]
+    assert DEFAULT_CACHE_MAX_AGE == quota_guard["cache_max_age"]
+    assert DEFAULT_BUFFER_SECONDS == quota_guard["buffer_seconds"]

--- a/tests/infra/test_hook_sync.py
+++ b/tests/infra/test_hook_sync.py
@@ -27,24 +27,16 @@ def test_hook_config_path_components_in_sync():
 
 
 def test_hook_config_path_single_source_of_truth():
-    """quota_guard and quota_post_hook must derive their path constants from
-    _fmt_primitives, not define independent copies.
+    """_hook_settings must define path constants that match _fmt_primitives.
 
-    After deduplication, HOOK_DIR_COMPONENTS + HOOK_CONFIG_FILENAME from each
-    hook module must reconstruct the tuple from _fmt_primitives exactly.
+    After consolidation, quota_guard and quota_post_hook both delegate to
+    _hook_settings for config path resolution. This test verifies that
+    _hook_settings.HOOK_DIR_COMPONENTS + HOOK_CONFIG_FILENAME reconstructs
+    _fmt_primitives._HOOK_CONFIG_PATH_COMPONENTS exactly.
     """
     from autoskillit.hooks._fmt_primitives import _HOOK_CONFIG_PATH_COMPONENTS
-    from autoskillit.hooks.quota_guard import HOOK_CONFIG_FILENAME, HOOK_DIR_COMPONENTS
-    from autoskillit.hooks.quota_post_hook import (
-        HOOK_CONFIG_FILENAME as QPC_FILENAME,
-    )
-    from autoskillit.hooks.quota_post_hook import (
-        HOOK_DIR_COMPONENTS as QPC_DIR,
-    )
+    from autoskillit.hooks._hook_settings import HOOK_CONFIG_FILENAME, HOOK_DIR_COMPONENTS
 
     assert (*HOOK_DIR_COMPONENTS, HOOK_CONFIG_FILENAME) == _HOOK_CONFIG_PATH_COMPONENTS, (
-        "quota_guard path constants must match _fmt_primitives._HOOK_CONFIG_PATH_COMPONENTS"
-    )
-    assert (*QPC_DIR, QPC_FILENAME) == _HOOK_CONFIG_PATH_COMPONENTS, (
-        "quota_post_hook path constants must match _fmt_primitives._HOOK_CONFIG_PATH_COMPONENTS"
+        "_hook_settings path constants must match _fmt_primitives._HOOK_CONFIG_PATH_COMPONENTS"
     )

--- a/tests/infra/test_quota_check.py
+++ b/tests/infra/test_quota_check.py
@@ -270,7 +270,7 @@ def test_quota_check_buffer_seconds_from_hook_config(tmp_path, monkeypatch):
     cache = tmp_path / "quota_cache.json"
     _write_cache(cache, utilization=95.0, resets_at=None)
     _write_hook_config(
-        tmp_path / ".autoskillit" / ".hook_config.json",
+        tmp_path.joinpath(*_HOOK_CONFIG_PATH_COMPONENTS),
         cache_max_age=300,
         cache_path=str(cache),
         extra={"buffer_seconds": 120},

--- a/tests/infra/test_quota_check.py
+++ b/tests/infra/test_quota_check.py
@@ -8,7 +8,7 @@ missing/stale/corrupt.
 import io
 import json
 from contextlib import redirect_stdout
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import patch
 
@@ -205,9 +205,9 @@ def test_hook_does_not_consult_threshold_field_in_hook_config(tmp_path, monkeypa
 
 # T-CFG-2
 def test_quota_check_reads_cache_path_from_hook_config(tmp_path, monkeypatch):
-    """Hook must read cache from hook config cache_path when AUTOSKILLIT_QUOTA_CACHE is unset."""
+    """Hook must read cache from hook config cache_path when the env var is unset."""
     monkeypatch.chdir(tmp_path)
-    monkeypatch.delenv("AUTOSKILLIT_QUOTA_CACHE", raising=False)
+    monkeypatch.delenv("AUTOSKILLIT_QUOTA_GUARD__CACHE_PATH", raising=False)
     custom_cache = tmp_path / "my_custom_cache.json"
     _write_cache(custom_cache, utilization=95.0)
     _write_hook_config(
@@ -222,7 +222,7 @@ def test_quota_check_reads_cache_path_from_hook_config(tmp_path, monkeypatch):
 
 # T-CFG-3
 def test_quota_check_env_var_overrides_hook_config_cache_path(tmp_path, monkeypatch):
-    """AUTOSKILLIT_QUOTA_CACHE env var must take precedence over hook config cache_path.
+    """``AUTOSKILLIT_QUOTA_GUARD__CACHE_PATH`` must beat hook config ``cache_path``.
 
     Regression test: env var path must win even when a hook config is present at the
     canonical path (.autoskillit/.hook_config.json). Writing different
@@ -240,7 +240,7 @@ def test_quota_check_env_var_overrides_hook_config_cache_path(tmp_path, monkeypa
         cache_max_age=300,
         cache_path=str(wrong_cache),
     )
-    monkeypatch.setenv("AUTOSKILLIT_QUOTA_CACHE", str(correct_cache))
+    monkeypatch.setenv("AUTOSKILLIT_QUOTA_GUARD__CACHE_PATH", str(correct_cache))
     out, _ = _run_hook(event={"tool_name": "run_skill"})
     data = json.loads(out)
     # env var must win: deny because correct_cache has utilization=95.0
@@ -256,6 +256,78 @@ def test_quota_check_falls_back_to_defaults_without_hook_config(tmp_path, monkey
     out, _ = _run_hook(event={"tool_name": "run_skill"}, cache_path=cache)
     data = json.loads(out)
     assert data["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+# T-CFG-6
+def test_quota_check_buffer_seconds_from_hook_config(tmp_path, monkeypatch):
+    """Hook uses buffer_seconds from hook config when env var is unset.
+
+    Writes a cache with ``resets_at=None`` so the hook takes the plain-buffer branch
+    (``n = settings.buffer_seconds``), making the assertion deterministic.
+    """
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AUTOSKILLIT_QUOTA_GUARD__BUFFER_SECONDS", raising=False)
+    cache = tmp_path / "quota_cache.json"
+    _write_cache(cache, utilization=95.0, resets_at=None)
+    _write_hook_config(
+        tmp_path / ".autoskillit" / ".hook_config.json",
+        cache_max_age=300,
+        cache_path=str(cache),
+        extra={"buffer_seconds": 120},
+    )
+    out, _ = _run_hook(event={"tool_name": "run_skill"})
+    data = json.loads(out)
+    reason = data["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "time.sleep(120)" in reason
+    assert "Sleeping 120s" in reason
+
+
+# T-CFG-7
+def test_quota_check_buffer_seconds_env_var_override(tmp_path, monkeypatch):
+    """``AUTOSKILLIT_QUOTA_GUARD__BUFFER_SECONDS`` overrides the deny-message sleep duration."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AUTOSKILLIT_QUOTA_GUARD__BUFFER_SECONDS", "180")
+    cache = tmp_path / "quota_cache.json"
+    _write_cache(cache, utilization=95.0, resets_at=None)
+    out, _ = _run_hook(event={"tool_name": "run_skill"}, cache_path=cache)
+    data = json.loads(out)
+    reason = data["hookSpecificOutput"]["permissionDecisionReason"]
+    assert "time.sleep(180)" in reason
+    assert "Sleeping 180s" in reason
+
+
+# T-CFG-8
+def test_quota_check_cache_max_age_env_var_override(tmp_path, monkeypatch):
+    """AUTOSKILLIT_QUOTA_GUARD__CACHE_MAX_AGE env var overrides the cache freshness window.
+
+    With ``cache_max_age=60`` and a 61-second-old cache, the hook must treat the
+    cache as stale and emit a cache_miss event (fail-open approve).
+    """
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AUTOSKILLIT_QUOTA_GUARD__CACHE_MAX_AGE", "60")
+    cache = tmp_path / "quota_cache.json"
+    stale_fetched_at = (datetime.now(UTC) - timedelta(seconds=61)).isoformat()
+    payload = {
+        "fetched_at": stale_fetched_at,
+        "windows": {"five_hour": {"utilization": 95.0, "resets_at": None}},
+        "binding": {
+            "window_name": "five_hour",
+            "utilization": 95.0,
+            "resets_at": None,
+            "should_block": True,
+            "effective_threshold": 85.0,
+        },
+    }
+    cache.write_text(json.dumps(payload))
+    log_dir = tmp_path / "logs"
+    monkeypatch.setenv("AUTOSKILLIT_LOG_DIR", str(log_dir))
+    out, exit_code = _run_hook(event={"tool_name": "run_skill"}, cache_path=cache)
+    assert out.strip() == ""
+    assert exit_code == 0
+    events = [
+        json.loads(line) for line in (log_dir / "quota_events.jsonl").read_text().splitlines()
+    ]
+    assert events[0]["event"] == "cache_miss"
 
 
 # T1

--- a/tests/infra/test_quota_post_check.py
+++ b/tests/infra/test_quota_post_check.py
@@ -230,7 +230,7 @@ def test_qpc11_reads_cache_path_from_hook_config(tmp_path, monkeypatch):
     locates the cache file via the hook config cache_path setting.
     """
     monkeypatch.chdir(tmp_path)
-    monkeypatch.delenv("AUTOSKILLIT_QUOTA_CACHE", raising=False)
+    monkeypatch.delenv("AUTOSKILLIT_QUOTA_GUARD__CACHE_PATH", raising=False)
     cache = tmp_path / "custom_cache.json"
     _write_cache(cache, utilization=95.0)
     hook_cfg_path = tmp_path.joinpath(*_HOOK_CONFIG_PATH_COMPONENTS)
@@ -339,3 +339,50 @@ def test_warns_when_binding_window_exhausted(tmp_path):
     out, _ = _run_hook(event=event, cache_path=cache)
     data = json.loads(out)
     assert "QUOTA WARNING" in data["hookSpecificOutput"]["updatedMCPToolOutput"]
+
+
+# T-PCHK-15
+def test_qpc_buffer_seconds_from_hook_config(tmp_path, monkeypatch):
+    """Post-check warning sleep uses ``buffer_seconds`` from hook config.
+
+    Writes a cache with ``resets_at=None`` so the hook takes the plain-buffer branch
+    (``n = settings.buffer_seconds``), making the assertion deterministic.
+    """
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AUTOSKILLIT_QUOTA_GUARD__BUFFER_SECONDS", raising=False)
+    cache = tmp_path / "quota_cache.json"
+    _write_cache(cache, utilization=95.0, resets_at=None)
+    hook_cfg_path = tmp_path / ".autoskillit" / ".hook_config.json"
+    hook_cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    hook_cfg_path.write_text(
+        json.dumps(
+            {
+                "quota_guard": {
+                    "cache_max_age": 300,
+                    "cache_path": str(cache),
+                    "buffer_seconds": 120,
+                }
+            }
+        )
+    )
+    event = _build_event()
+    out, _ = _run_hook(event=event)
+    data = json.loads(out)
+    output = data["hookSpecificOutput"]["updatedMCPToolOutput"]
+    assert "time.sleep(120)" in output
+    assert "Sleeping 120s" in output
+
+
+# T-PCHK-16
+def test_qpc_buffer_seconds_env_var_override(tmp_path, monkeypatch):
+    """AUTOSKILLIT_QUOTA_GUARD__BUFFER_SECONDS env var overrides the warning sleep duration."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AUTOSKILLIT_QUOTA_GUARD__BUFFER_SECONDS", "180")
+    cache = tmp_path / "quota_cache.json"
+    _write_cache(cache, utilization=95.0, resets_at=None)
+    event = _build_event()
+    out, _ = _run_hook(event=event, cache_path=cache)
+    data = json.loads(out)
+    output = data["hookSpecificOutput"]["updatedMCPToolOutput"]
+    assert "time.sleep(180)" in output
+    assert "Sleeping 180s" in output

--- a/tests/infra/test_quota_post_check.py
+++ b/tests/infra/test_quota_post_check.py
@@ -352,7 +352,7 @@ def test_qpc_buffer_seconds_from_hook_config(tmp_path, monkeypatch):
     monkeypatch.delenv("AUTOSKILLIT_QUOTA_GUARD__BUFFER_SECONDS", raising=False)
     cache = tmp_path / "quota_cache.json"
     _write_cache(cache, utilization=95.0, resets_at=None)
-    hook_cfg_path = tmp_path / ".autoskillit" / ".hook_config.json"
+    hook_cfg_path = tmp_path.joinpath(*_HOOK_CONFIG_PATH_COMPONENTS)
     hook_cfg_path.parent.mkdir(parents=True, exist_ok=True)
     hook_cfg_path.write_text(
         json.dumps(

--- a/tests/infra/test_quota_post_check.py
+++ b/tests/infra/test_quota_post_check.py
@@ -386,3 +386,32 @@ def test_qpc_buffer_seconds_env_var_override(tmp_path, monkeypatch):
     output = data["hookSpecificOutput"]["updatedMCPToolOutput"]
     assert "time.sleep(180)" in output
     assert "Sleeping 180s" in output
+
+
+# T-PCHK-17
+def test_qpc_cache_max_age_env_var_override(tmp_path, monkeypatch):
+    """AUTOSKILLIT_QUOTA_GUARD__CACHE_MAX_AGE env var overrides the cache freshness window.
+
+    With ``cache_max_age=60`` and a 61-second-old cache, the hook treats the cache
+    as stale and exits silently (fail-open, no warning output).
+    """
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AUTOSKILLIT_QUOTA_GUARD__CACHE_MAX_AGE", "60")
+    cache = tmp_path / "quota_cache.json"
+    stale_fetched_at = (datetime.now(UTC) - timedelta(seconds=61)).isoformat()
+    payload = {
+        "fetched_at": stale_fetched_at,
+        "windows": {"five_hour": {"utilization": 95.0, "resets_at": None}},
+        "binding": {
+            "window_name": "five_hour",
+            "utilization": 95.0,
+            "resets_at": None,
+            "should_block": True,
+            "effective_threshold": 85.0,
+        },
+    }
+    cache.write_text(json.dumps(payload))
+    event = _build_event()
+    out, exit_code = _run_hook(event=event, cache_path=cache)
+    assert out.strip() == ""
+    assert exit_code == 0

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -124,7 +124,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # background.py — payload dict
     ("src/autoskillit/pipeline/background.py", 132),
     # tools_kitchen.py — hook config dict
-    ("src/autoskillit/server/tools_kitchen.py", 135),
+    ("src/autoskillit/server/tools_kitchen.py", 136),
     # tools_status.py — mcp_data dict
     ("src/autoskillit/server/tools_status.py", 333),
     # tools_github.py — bug report dict

--- a/tests/server/test_tools_kitchen.py
+++ b/tests/server/test_tools_kitchen.py
@@ -121,6 +121,7 @@ async def test_open_kitchen_writes_hook_config_json(tmp_path, monkeypatch):
     mock_ctx.config.quota_guard.long_window_patterns = ["weekly", "sonnet", "opus"]
     mock_ctx.config.quota_guard.cache_max_age = 300
     mock_ctx.config.quota_guard.cache_path = "/custom/path.json"
+    mock_ctx.config.quota_guard.buffer_seconds = 60
 
     # _write_hook_config uses 'from autoskillit.server import _get_ctx' at call time.
     # Patching autoskillit.server._get_ctx correctly intercepts that deferred import;
@@ -142,6 +143,7 @@ async def test_open_kitchen_writes_hook_config_json(tmp_path, monkeypatch):
     data = json.loads(hook_cfg.read_text())
     assert data["quota_guard"]["cache_max_age"] == 300
     assert data["quota_guard"]["cache_path"] == "/custom/path.json"
+    assert data["quota_guard"]["buffer_seconds"] == 60
     # threshold fields are pre-computed into should_block in the cache — not written to hook_config
     assert "threshold" not in data["quota_guard"]
     assert "short_window_threshold" not in data["quota_guard"]
@@ -167,6 +169,7 @@ async def test_close_kitchen_removes_hook_config_json(tmp_path, monkeypatch):
     mock_ctx.config.quota_guard.long_window_patterns = ["weekly", "sonnet", "opus"]
     mock_ctx.config.quota_guard.cache_max_age = 300
     mock_ctx.config.quota_guard.cache_path = "~/.claude/quota_cache.json"
+    mock_ctx.config.quota_guard.buffer_seconds = 60
 
     with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
         with patch("autoskillit.server.logger"):
@@ -241,6 +244,7 @@ async def test_open_kitchen_does_not_write_gate_file(tmp_path, monkeypatch):
     mock_ctx.config.quota_guard.long_window_patterns = ["weekly", "sonnet", "opus"]
     mock_ctx.config.quota_guard.cache_max_age = 300
     mock_ctx.config.quota_guard.cache_path = "~/.claude/quota_cache.json"
+    mock_ctx.config.quota_guard.buffer_seconds = 60
     with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
         with patch("autoskillit.server.logger"):
             with patch("autoskillit.server.tools_kitchen._prime_quota_cache", new=AsyncMock()):

--- a/tests/test_python_no_hardcoded_temp.py
+++ b/tests/test_python_no_hardcoded_temp.py
@@ -35,6 +35,10 @@ _TEMP_PATH_WHITELIST: dict[str, str] = {
     "workspace/worktree.py": "docstring example",
     # Justification: docstring referencing the canonical default path.
     "server/tools_clone.py": "docstring example",
+    # Justification: stdlib-only hook module that cannot import resolve_temp_dir().
+    # HOOK_DIR_COMPONENTS = (".autoskillit", "temp") mirrors the canonical bridge path
+    # defined by _fmt_primitives._HOOK_CONFIG_PATH_COMPONENTS.
+    "hooks/_hook_settings.py": "stdlib-only hook; cannot use resolve_temp_dir()",
 }
 
 _LITERAL = ".autoskillit/temp"


### PR DESCRIPTION
## Summary

Create a shared stdlib-only hook settings resolver (`_hook_settings.py`) that gives quota guard hooks the same layered configuration resolution as the rest of AutoSkillit: **env var > hook config snapshot > package default**. Forward `buffer_seconds` through the hook config bridge. Standardize env var names to match the dynaconf `AUTOSKILLIT_QUOTA_GUARD__*` convention. Remove hardcoded `buffer_seconds = 60` from both hooks.

**Key findings from analysis:**

1. **Thresholds are already in settings.** `QuotaGuardConfig` (9 fields) has been in the dynaconf hierarchy since the per-window threshold work. Hooks never evaluate thresholds — they trust the pre-computed `should_block` boolean in the quota cache. No threshold migration is needed.

2. **The actual gap is in hook-consumed settings.** The hooks (`quota_check.py`, `quota_post_check.py`) resolved `cache_max_age` and `cache_path` through `.hook_config.json` with hardcoded fallbacks. `buffer_seconds` was hardcoded to `60` in both hooks, ignoring the settings value entirely.

3. **`.hook_config.json` is a bridge, not a source.** It serializes resolved settings for stdlib-only hook consumers. The issue's request to "remove it as a threshold source" is already satisfied (it contains no thresholds). The bridge remains necessary for propagating project/user-level config to hooks that can't import dynaconf.

4. **Env var naming was inconsistent.** Hooks used `AUTOSKILLIT_QUOTA_CACHE` for cache path — this didn't match the dynaconf convention `AUTOSKILLIT_QUOTA_GUARD__CACHE_PATH`. `cache_max_age` had no env var override at all.

## Architecture Impact

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 55, 'rankSpacing': 75, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ── LAYER 3: SERVER ─────────────────────────────────────────────────── %%
    subgraph L3 ["L3 — SERVER (autoskillit package required)"]
        direction LR
        TK["● tools_kitchen.py<br/>━━━━━━━━━━<br/>open_kitchen / close_kitchen<br/>_write_hook_config()<br/>_close_kitchen_handler()"]
        HELPERS["server/helpers.py<br/>━━━━━━━━━━<br/>_hook_config_path()<br/>_HOOK_CONFIG_FILENAME<br/>_HOOK_DIR_COMPONENTS<br/>_prime_quota_cache()"]
    end

    %% ── LAYER 1: CONFIG ─────────────────────────────────────────────────── %%
    subgraph L1CFG ["L1 — CONFIG (dynaconf-backed)"]
        direction LR
        QGC["config/settings.py<br/>━━━━━━━━━━<br/>QuotaGuardConfig<br/>cache_path / cache_max_age<br/>buffer_seconds / enabled<br/>short/long_window_threshold"]
    end

    %% ── LAYER 1: EXECUTION ──────────────────────────────────────────────── %%
    subgraph L1EXE ["L1 — EXECUTION"]
        direction LR
        QUOTA["execution/quota.py<br/>━━━━━━━━━━<br/>QuotaStatus<br/>check_and_sleep_if_needed()<br/>quota cache writer"]
    end

    %% ── LAYER 0: HOOKS (stdlib-only) ────────────────────────────────────── %%
    subgraph L0 ["L0 — HOOKS (stdlib-only — no autoskillit.* imports)"]
        direction LR
        HS["★ _hook_settings.py<br/>━━━━━━━━━━<br/>QuotaHookSettings dataclass<br/>resolve_quota_settings()<br/>Resolution: override→env→file→default"]
        QC["● quota_check.py<br/>━━━━━━━━━━<br/>PreToolUse hook<br/>Blocks run_skill when<br/>should_block=True"]
        QPC["● quota_post_check.py<br/>━━━━━━━━━━<br/>PostToolUse hook<br/>Appends quota warning<br/>to run_skill output"]
    end

    %% ── RUNTIME BRIDGE ARTIFACT ─────────────────────────────────────────── %%
    subgraph BRIDGE ["Runtime Bridge Artifact"]
        CFG_FILE[(".autoskillit/<br/>.hook_config.json<br/>━━━━━━━━━━<br/>quota_guard section:<br/>cache_path, cache_max_age,<br/>buffer_seconds")]
    end

    %% ── EXTERNAL ────────────────────────────────────────────────────────── %%
    subgraph EXT ["External"]
        ENV["Environment Variables<br/>━━━━━━━━━━<br/>AUTOSKILLIT_QUOTA_GUARD__<br/>CACHE_PATH / CACHE_MAX_AGE<br/>BUFFER_SECONDS"]
        CACHE_FILE["~/.claude/<br/>autoskillit_quota_cache.json<br/>━━━━━━━━━━<br/>Live quota binding<br/>should_block / utilization"]
    end

    %% ── DEPENDENCIES ────────────────────────────────────────────────────── %%

    %% Server imports config
    TK -->|"reads quota_guard<br/>config fields"| QGC
    TK -->|"calls _hook_config_path()<br/>_HOOK_CONFIG_FILENAME match"| HELPERS
    HELPERS -->|"calls check_and_sleep_if_needed"| QUOTA

    %% Server writes runtime bridge
    TK -->|"open_kitchen:<br/>atomic_write()"| CFG_FILE
    TK -->|"close_kitchen:<br/>unlink()"| CFG_FILE

    %% Hook settings reads from bridge + env
    HS -->|"_read_hook_config()<br/>reads quota_guard section"| CFG_FILE
    HS -->|"os.environ.get()"| ENV

    %% Quota hooks import shared resolver (sibling import via sys.path)
    QC -->|"sibling import<br/>resolve_quota_settings()"| HS
    QPC -->|"sibling import<br/>resolve_quota_settings()"| HS

    %% Quota hooks read live cache
    QC -->|"_read_quota_cache()"| CACHE_FILE
    QPC -->|"_read_quota_cache()"| CACHE_FILE

    %% Execution layer writes live cache
    QUOTA -->|"writes quota cache"| CACHE_FILE

    %% CLASS ASSIGNMENTS %%
    class TK phase;
    class HELPERS phase;
    class QGC stateNode;
    class QUOTA stateNode;
    class HS newComponent;
    class QC,QPC handler;
    class CFG_FILE output;
    class ENV,CACHE_FILE integration;
```

### Data Lineage Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph Inputs ["Configuration Inputs"]
        DYNACONF["Dynaconf Config<br/>━━━━━━━━━━<br/>ctx.config.quota_guard<br/>cache_max_age / cache_path<br/>buffer_seconds"]
        ENVVARS["Env Vars<br/>━━━━━━━━━━<br/>AUTOSKILLIT_QUOTA_GUARD__<br/>CACHE_PATH<br/>CACHE_MAX_AGE / BUFFER_SECONDS"]
        STDIN["stdin — PostToolUse<br/>━━━━━━━━━━<br/>Claude Code hook event JSON<br/>tool_response field"]
    end

    subgraph KitchenLayer ["● tools_kitchen.py"]
        OPEN_K["● open_kitchen<br/>━━━━━━━━━━<br/>MCP tool<br/>reads ctx.config.quota_guard<br/>writes hook config bridge"]
        CLOSE_K["● close_kitchen<br/>━━━━━━━━━━<br/>MCP tool<br/>deletes hook config bridge"]
    end

    subgraph BridgeFile ["Config Bridge — .autoskillit/"]
        HOOK_CFG[".hook_config.json<br/>━━━━━━━━━━<br/>quota_guard settings<br/>cache_max_age / cache_path<br/>buffer_seconds / kitchen_id"]
    end

    subgraph Resolver ["★ _hook_settings.py — stdlib-only"]
        RESOLVE_FN["★ resolve_quota_settings<br/>━━━━━━━━━━<br/>4-level priority chain:<br/>1. cache_path_override arg<br/>2. Env vars<br/>3. .hook_config.json values<br/>4. Hardcoded defaults"]
        QHS["★ QuotaHookSettings<br/>━━━━━━━━━━<br/>frozen dataclass<br/>cache_path: str<br/>cache_max_age: int<br/>buffer_seconds: int"]
    end

    QUOTA_CACHE[("quota_cache.json<br/>━━━━━━━━━━<br/>~/.claude/<br/>autoskillit_quota_cache.json<br/>utilization / should_block<br/>effective_threshold / resets_at")]

    subgraph HookScripts ["Hook Scripts — Claude Code Subprocess"]
        PRE_HOOK["● quota_check.py<br/>━━━━━━━━━━<br/>PreToolUse: run_skill<br/>staleness check on cache<br/>sleep-until-reset logic<br/>fail-open on errors"]
        POST_HOOK["● quota_post_check.py<br/>━━━━━━━━━━<br/>PostToolUse: run_skill<br/>unwraps double-wrapped JSON<br/>truncates result to 500 chars<br/>injects quota warning"]
    end

    subgraph HookOutputs ["Hook Outputs"]
        DENY["stdout — deny JSON<br/>━━━━━━━━━━<br/>permissionDecision: deny<br/>permissionDecisionReason<br/>sleep + retry instruction"]
        INJECT["stdout — inject JSON<br/>━━━━━━━━━━<br/>updatedMCPToolOutput<br/>truncated result summary<br/>+ quota warning + sleep cmd"]
        EVENTS[("quota_events.jsonl<br/>━━━━━━━━━━<br/>logs/quota_events.jsonl<br/>cache_miss / parse_error<br/>blocked / approved<br/>post_check_pass / post_check_warning")]
    end

    %% Config ingestion
    DYNACONF -->|"ctx.config.quota_guard"| OPEN_K
    OPEN_K -->|"atomic_write"| HOOK_CFG
    CLOSE_K -.->|"deletes on close"| HOOK_CFG

    %% Settings resolution
    ENVVARS -->|"override values"| RESOLVE_FN
    HOOK_CFG -->|"_read_hook_config"| RESOLVE_FN
    RESOLVE_FN --> QHS

    %% Settings + cache feed hook scripts
    QHS -->|"cache_path + max_age"| PRE_HOOK
    QHS -->|"cache_path + max_age"| POST_HOOK
    QUOTA_CACHE -->|"_read_quota_cache"| PRE_HOOK
    QUOTA_CACHE -->|"_read_quota_cache"| POST_HOOK
    STDIN -->|"tool_response"| POST_HOOK

    %% Hook decisions and artifacts
    PRE_HOOK -->|"deny / approve"| DENY
    POST_HOOK -->|"inject / pass-through"| INJECT
    PRE_HOOK -.->|"append JSONL event"| EVENTS
    POST_HOOK -.->|"append JSONL event"| EVENTS

    %% CLASS ASSIGNMENTS %%
    class DYNACONF,ENVVARS,STDIN cli;
    class HOOK_CFG,QUOTA_CACHE stateNode;
    class OPEN_K,CLOSE_K handler;
    class RESOLVE_FN,QHS newComponent;
    class PRE_HOOK,POST_HOOK detector;
    class DENY,INJECT,EVENTS output;
```

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ENTRY POINTS %%
    OPEN_K(["● open_kitchen<br/>MCP tool"])
    CLOSE_K(["● close_kitchen<br/>MCP tool"])
    HOOK_PRE(["● quota_check.py<br/>PreToolUse subprocess"])
    HOOK_POST(["● quota_post_check.py<br/>PostToolUse subprocess"])

    %% SETTINGS SOURCE LAYER (dynaconf — full package) %%
    subgraph DynaconfStack ["FULL CONFIG STACK (dynaconf — package process)"]
        direction TB
        L1["L1: config/defaults.yaml<br/>━━━━━━━━━━<br/>cache_path, cache_max_age<br/>buffer_seconds (hardcoded defaults)"]
        L2["L2: ~/.autoskillit/config.yaml<br/>━━━━━━━━━━<br/>user-level overrides"]
        L3["L3: .autoskillit/config.yaml<br/>━━━━━━━━━━<br/>project-level overrides"]
        L4["L4: .autoskillit/.secrets.yaml<br/>━━━━━━━━━━<br/>secrets layer"]
        L5["L5: AUTOSKILLIT_SECTION__KEY<br/>━━━━━━━━━━<br/>env var overrides (highest)"]
        L1 --> L2 --> L3 --> L4 --> L5
    end

    %% RESOLVED PACKAGE CONFIG %%
    QG_CFG["QuotaGuardConfig<br/>━━━━━━━━━━<br/>cache_path · cache_max_age<br/>buffer_seconds · enabled<br/>thresholds · credentials_path<br/>(MUTABLE — AutomationConfig)"]

    %% HOOK CONFIG BRIDGE (kitchen-scoped file state) %%
    subgraph HookBridge ["● HOOK CONFIG BRIDGE (.autoskillit/.hook_config.json)"]
        direction TB
        HC_WRITE["atomic_write()<br/>━━━━━━━━━━<br/>Writes quota_guard section<br/>on open_kitchen"]
        HC_FILE[("● .hook_config.json<br/>━━━━━━━━━━<br/>quota_guard.cache_path<br/>quota_guard.cache_max_age<br/>quota_guard.buffer_seconds<br/>kitchen_id<br/>[MUTABLE — kitchen-scoped]")]
        HC_REMOVE["unlink(missing_ok=True)<br/>━━━━━━━━━━<br/>Removed on close_kitchen"]
        HC_WRITE --> HC_FILE
        HC_FILE --> HC_REMOVE
    end

    %% HOOK SETTINGS RESOLVER (★ new module — stdlib-only) %%
    subgraph HookResolver ["★ _hook_settings.py — LAYERED RESOLVER (stdlib-only subprocess)"]
        direction TB
        R1["Tier 1: cache_path_override param<br/>━━━━━━━━━━<br/>DI injection for tests<br/>(cache_path only)"]
        R2["Tier 2: AUTOSKILLIT_QUOTA_GUARD__*<br/>━━━━━━━━━━<br/>Env var overrides<br/>(highest runtime priority)"]
        R3["Tier 3: .hook_config.json quota_guard<br/>━━━━━━━━━━<br/>Bridge from resolved settings<br/>(fails silently if absent)"]
        R4["Tier 4: Module defaults<br/>━━━━━━━━━━<br/>cache_path · cache_max_age=300<br/>buffer_seconds=60"]
        R1 --> R2 --> R3 --> R4
    end

    %% RESOLVED HOOK SETTINGS (INIT_ONLY — frozen dataclass) %%
    QHS["★ QuotaHookSettings<br/>━━━━━━━━━━<br/>cache_path: str<br/>cache_max_age: int<br/>buffer_seconds: int<br/>[INIT_ONLY — frozen=True, slots=True]"]

    %% QUOTA CACHE STATE (written by refresh loop, read by hooks) %%
    subgraph QuotaCache ["QUOTA CACHE (~/.claude/autoskillit_quota_cache.json)"]
        direction TB
        QC_FILE[("quota_cache.json<br/>━━━━━━━━━━<br/>fetched_at · binding<br/>[MUTABLE — quota-refresh loop]")]
        QC_AGE{"Age check<br/>━━━━━━━━━━<br/>now - fetched_at<br/>> cache_max_age?"}
        QC_STALE["STALE → None<br/>━━━━━━━━━━<br/>Fail open"]
        QC_FRESH["FRESH → dict<br/>━━━━━━━━━━<br/>Parse binding"]
        QC_FILE --> QC_AGE
        QC_AGE -->|"yes"| QC_STALE
        QC_AGE -->|"no"| QC_FRESH
    end

    %% BINDING FIELDS (DERIVED — computed by quota module) %%
    subgraph Binding ["BINDING (DERIVED — from quota API, read-only in hooks)"]
        direction TB
        B_UTIL["utilization: float<br/>━━━━━━━━━━<br/>% of quota used<br/>[DERIVED — read only]"]
        B_BLOCK["should_block: bool<br/>━━━━━━━━━━<br/>Gate decision<br/>[DERIVED — read only]"]
        B_THRESH["effective_threshold: float<br/>━━━━━━━━━━<br/>Applied threshold<br/>[DERIVED — read only]"]
        B_WIN["window_name: str<br/>━━━━━━━━━━<br/>Rate limit window<br/>[DERIVED — read only]"]
        B_RESET["resets_at: str | None<br/>━━━━━━━━━━<br/>Quota reset ISO timestamp<br/>[DERIVED — read only]"]
    end

    %% GATE DECISIONS %%
    subgraph PreGates ["● PRETOOLUSE GATE (quota_check.py)"]
        direction TB
        PG1{"Stdin JSON<br/>valid?"}
        PG2{"Cache<br/>present +<br/>fresh?"}
        PG3{"Binding<br/>parseable?"}
        PG4{"should_block<br/>== True?"}
        PG_DENY["deny run_skill<br/>━━━━━━━━━━<br/>sleep instruction<br/>+ requeue"]
        PG_APPROVE["exit 0 (approve)<br/>━━━━━━━━━━<br/>run_skill proceeds"]
        PG1 -->|"no"| PG_APPROVE
        PG1 -->|"yes"| PG2
        PG2 -->|"no (fail open)"| PG_APPROVE
        PG2 -->|"yes"| PG3
        PG3 -->|"no (fail open)"| PG_APPROVE
        PG3 -->|"yes"| PG4
        PG4 -->|"yes"| PG_DENY
        PG4 -->|"no"| PG_APPROVE
    end

    subgraph PostGates ["● POSTTOOLUSE GATE (quota_post_check.py)"]
        direction TB
        POG1{"Cache<br/>present +<br/>fresh?"}
        POG2{"should_block<br/>== True?"}
        POG_WARN["updatedMCPToolOutput<br/>━━━━━━━━━━<br/>Append quota warning<br/>+ sleep instruction"]
        POG_PASS["exit 0 (pass)<br/>━━━━━━━━━━<br/>No output change"]
        POG1 -->|"no (fail open)"| POG_PASS
        POG1 -->|"yes"| POG2
        POG2 -->|"yes"| POG_WARN
        POG2 -->|"no"| POG_PASS
    end

    %% AUDIT LOG (APPEND_ONLY) %%
    AUDIT[("quota_events.jsonl<br/>━━━━━━━━━━<br/>cache_miss · approved<br/>blocked · parse_error<br/>post_check_pass<br/>post_check_warning<br/>[APPEND_ONLY — write only]")]

    %% CONNECTIONS %%
    OPEN_K --> DynaconfStack
    DynaconfStack --> QG_CFG
    QG_CFG --> HC_WRITE
    CLOSE_K --> HC_REMOVE

    HC_FILE -->|"_read_hook_config()"| R3
    R1 & R2 & R3 & R4 --> QHS

    QHS -->|"cache_path + cache_max_age"| QC_FILE
    QHS -->|"buffer_seconds → sleep n"| PG_DENY
    QHS -->|"buffer_seconds → sleep n"| POG_WARN

    HOOK_PRE --> R1
    HOOK_POST --> R1

    QC_FRESH --> B_UTIL & B_BLOCK & B_THRESH & B_WIN & B_RESET
    B_BLOCK --> PG4
    B_BLOCK --> POG2
    B_UTIL & B_THRESH & B_WIN & B_RESET --> PG_DENY
    B_UTIL & B_THRESH & B_WIN --> POG_WARN

    PG_DENY --> AUDIT
    PG_APPROVE --> AUDIT
    POG_WARN --> AUDIT
    POG_PASS --> AUDIT

    %% CLASS ASSIGNMENTS %%
    class OPEN_K,CLOSE_K handler;
    class HOOK_PRE,HOOK_POST phase;
    class L1,L2,L3,L4,L5 cli;
    class QG_CFG stateNode;
    class HC_WRITE,HC_REMOVE handler;
    class HC_FILE stateNode;
    class R1,R2,R3,R4 newComponent;
    class QHS detector;
    class QC_FILE stateNode;
    class QC_AGE,QC_STALE,QC_FRESH phase;
    class B_UTIL,B_BLOCK,B_THRESH,B_WIN,B_RESET output;
    class PG1,PG2,PG3,PG4 detector;
    class PG_DENY gap;
    class PG_APPROVE,POG_PASS terminal;
    class POG1,POG2 detector;
    class POG_WARN gap;
    class AUDIT output;
```

Closes #729

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260411-224332-895896/.autoskillit/temp/make-plan/consolidate_quota_guard_threshold_plan_2026-04-11_224700.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
