### PR TITLE
Implementation Plan: Clone Cleanup Registry — Session-Scoped Ownership Tagging

### DIFF
--- a/src/autoskillit/recipe/rules_tools.py
+++ b/src/autoskillit/recipe/rules_tools.py
@@ -61,6 +61,7 @@ _TOOL_PARAMS: dict[str, frozenset[str]] = {
     "batch_cleanup_clones": frozenset(
         {
             "registry_path",
+            "all_owners",
             "step_name",
         }
     ),

--- a/src/autoskillit/server/tools_clone.py
+++ b/src/autoskillit/server/tools_clone.py
@@ -298,7 +298,12 @@ async def register_clone_status(
     logger.info("register_clone_status", clone_path=clone_path, status=status)
 
     if status not in ("success", "error"):
-        return json.dumps({"error": f"Invalid status '{status}'. Must be 'success' or 'error'."})
+        return json.dumps(
+            {
+                "registered": "false",
+                "reason": f"Invalid status '{status}'. Must be 'success' or 'error'.",
+            }
+        )
 
     from autoskillit.server import _get_ctx
 

--- a/src/autoskillit/server/tools_clone.py
+++ b/src/autoskillit/server/tools_clone.py
@@ -303,6 +303,14 @@ async def register_clone_status(
     from autoskillit.server import _get_ctx
 
     tool_ctx = _get_ctx()
+    owner = tool_ctx.kitchen_id
+    if owner == "":
+        return json.dumps(
+            {
+                "registered": "false",
+                "reason": "no active kitchen (kitchen_id empty) — cannot register clone",
+            }
+        )
     _start = time.monotonic()
     typed_status: Literal["success", "error"] = "success" if status == "success" else "error"
     try:
@@ -310,6 +318,7 @@ async def register_clone_status(
             clone_registry.register_clone,
             clone_path,
             typed_status,
+            owner,
             registry_path,
             tool_ctx.temp_dir,
         )
@@ -326,6 +335,7 @@ async def register_clone_status(
 @track_response_size("batch_cleanup_clones")
 async def batch_cleanup_clones(
     registry_path: str = "",
+    all_owners: str = "false",
     step_name: str = "",
     ctx: Context = CurrentContext(),
 ) -> str:
@@ -334,11 +344,18 @@ async def batch_cleanup_clones(
     Called ONCE after all parallel pipelines have completed (after batch_confirm_cleanup
     action: confirm). Never raises — failures are reported in the result dict.
 
+    By default, deletion is scoped to the current kitchen's entries (owner = kitchen_id).
+    Pass all_owners="true" as an operator escape hatch to delete all success-status entries
+    regardless of owner, including legacy orphan entries from pre-owner-schema registries.
+
     Returns {"deleted": [...], "delete_failures": [...], "preserved": [...]}.
 
     Args:
         registry_path: Absolute path to the shared registry file. Defaults to
                        .autoskillit/temp/clone-cleanup-registry.json in cwd.
+        all_owners: "false" (default) scopes deletion to the current kitchen's entries;
+                    "true" is the operator escape hatch that ignores owner and deletes
+                    all success-status entries including legacy orphans.
         step_name: Optional YAML step key for wall-clock timing accumulation.
     """
     try:
@@ -346,7 +363,7 @@ async def batch_cleanup_clones(
             return gate
         structlog.contextvars.clear_contextvars()
         structlog.contextvars.bind_contextvars(tool="batch_cleanup_clones")
-        logger.info("batch_cleanup_clones", registry_path=registry_path)
+        logger.info("batch_cleanup_clones", registry_path=registry_path, all_owners=all_owners)
 
         from autoskillit.server import _get_ctx
 
@@ -361,6 +378,23 @@ async def batch_cleanup_clones(
                 }
             )
 
+        is_escape_hatch = all_owners.strip().lower() == "true"
+        owner_filter: str | None
+        if is_escape_hatch:
+            owner_filter = None
+        else:
+            owner_filter = tool_ctx.kitchen_id
+            if owner_filter == "":
+                return json.dumps(
+                    {
+                        "deleted": [],
+                        "delete_failures": [],
+                        "preserved": [],
+                        "error": "no active kitchen (kitchen_id empty) — "
+                        "pass all_owners='true' to force-cleanup legacy entries",
+                    }
+                )
+
         _start = time.monotonic()
         try:
             result = await asyncio.to_thread(
@@ -368,6 +402,7 @@ async def batch_cleanup_clones(
                 registry_path,
                 tool_ctx.clone_mgr.remove_clone,
                 tool_ctx.temp_dir,
+                owner_filter,
             )
             return json.dumps(result)
         finally:

--- a/src/autoskillit/skills_extended/process-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/process-issues/SKILL.md
@@ -278,8 +278,16 @@ batch_cleanup_clones()
 ```
 
 This reads the shared registry at `{{AUTOSKILLIT_TEMP}}/clone-cleanup-registry.json`,
-deletes all clones registered with `status=success` (their pipelines completed cleanly),
-and leaves all `status=error` clones on disk for investigation.
+deletes all clones registered with `status=success` by the **current kitchen** (their
+pipelines completed cleanly), and leaves all `status=error` clones on disk for investigation.
+
+The call is scoped to the current kitchen's entries by default — entries registered by other
+parallel orchestrator sessions are not touched.
+
+**Operator escape hatch (recovery only):** `batch_cleanup_clones(all_owners="true")` ignores
+owner scoping and deletes all success-status entries, including legacy orphan entries from
+registries created before the owner field was introduced. Do not use this on the normal happy
+path — it is intended for manual recovery of stale registry files only.
 
 ### Step 4: Write Summary Report
 

--- a/src/autoskillit/workspace/clone_registry.py
+++ b/src/autoskillit/workspace/clone_registry.py
@@ -5,7 +5,7 @@ After all pipelines complete, batch_cleanup_clones reads the registry and
 removes only success-status clones.
 
 Registry file format:
-    {"clones": [{"path": "/abs/path/to/clone", "status": "success|error"}]}
+    {"clones": [{"path": "/abs/path/to/clone", "status": "success|error", "owner": "kitchen-uuid"}]}
 """
 
 from __future__ import annotations
@@ -31,14 +31,23 @@ def _resolve_registry_path(registry_path: str, temp_dir: Path | None = None) -> 
     return base / _DEFAULT_REGISTRY_NAME
 
 
+def _entry_matches_owner(entry: dict[str, str], owner: str | None) -> bool:
+    if owner is None:
+        return True
+    return entry.get("owner") == owner
+
+
 def register_clone(
     clone_path: str,
     status: CloneStatus,
+    owner: str,
     registry_path: str = "",
     temp_dir: Path | None = None,
 ) -> dict[str, str]:
     """Append a clone entry to the registry. Safe for parallel callers — holds an
     exclusive advisory lock across the entire read-modify-write sequence."""
+    if owner == "":
+        raise ValueError("owner is required")
     path = _resolve_registry_path(registry_path, temp_dir)
     lock_path = path.with_suffix(".lock")
     lock_path.parent.mkdir(parents=True, exist_ok=True)
@@ -50,7 +59,7 @@ def register_clone(
                 existing = json.loads(path.read_text()).get("clones", [])
             except (json.JSONDecodeError, OSError) as exc:
                 _log.warning("clone_registry: could not read %s: %s", path, exc)
-        existing.append({"path": clone_path, "status": status})
+        existing.append({"path": clone_path, "status": status, "owner": owner})
         atomic_write(path, json.dumps({"clones": existing}, indent=2))
     return {"registered": "true", "registry_path": str(path)}
 
@@ -73,15 +82,28 @@ def read_registry(
 def cleanup_candidates(
     registry_path: str = "",
     temp_dir: Path | None = None,
+    owner: str | None = None,
 ) -> tuple[list[str], list[str]]:
     """Return (to_delete, to_preserve) path lists from the registry.
 
     to_delete  — clones with status='success' (safe to remove)
     to_preserve — clones with status='error'  (preserve for investigation)
+
+    When owner is provided, only entries belonging to that owner are considered.
+    Entries without an 'owner' field (legacy orphans) are only visible when
+    owner is None (all-owners mode).
     """
     entries = read_registry(registry_path, temp_dir)
-    to_delete = [e["path"] for e in entries if e.get("status") == "success" and "path" in e]
-    to_preserve = [e["path"] for e in entries if e.get("status") == "error" and "path" in e]
+    to_delete = [
+        e["path"]
+        for e in entries
+        if e.get("status") == "success" and "path" in e and _entry_matches_owner(e, owner)
+    ]
+    to_preserve = [
+        e["path"]
+        for e in entries
+        if e.get("status") == "error" and "path" in e and _entry_matches_owner(e, owner)
+    ]
     return to_delete, to_preserve
 
 
@@ -89,13 +111,17 @@ def batch_delete(
     registry_path: str,
     remove_fn: Callable[[str, str], dict[str, str]],
     temp_dir: Path | None = None,
+    owner: str | None = None,
 ) -> dict[str, Any]:
     """Read registry and delete success-status clones via remove_fn.
 
     Calls remove_fn(path, "false") for each success clone. Error clones are
     preserved. Returns {"deleted": [...], "delete_failures": [...], "preserved": [...]}.
+
+    When owner is provided, only entries belonging to that owner are considered.
+    Pass owner=None to operate on all entries (escape hatch mode).
     """
-    to_delete, to_preserve = cleanup_candidates(registry_path, temp_dir)
+    to_delete, to_preserve = cleanup_candidates(registry_path, temp_dir, owner=owner)
     deleted: list[str] = []
     delete_failures: list[dict[str, str]] = []
     for path in to_delete:

--- a/src/autoskillit/workspace/clone_registry.py
+++ b/src/autoskillit/workspace/clone_registry.py
@@ -5,7 +5,7 @@ After all pipelines complete, batch_cleanup_clones reads the registry and
 removes only success-status clones.
 
 Registry file format:
-    {"clones": [{"path": "/abs/path/to/clone", "status": "success|error", "owner": "kitchen-uuid"}]}
+    {"clones": [{"path": "/abs/path", "status": "success|error", "owner": "kitchen-uuid"}]}
 """
 
 from __future__ import annotations

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -118,7 +118,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/migration/store.py", 54),
     ("src/autoskillit/migration/store.py", 64),
     # clone_registry.py — clones dict
-    ("src/autoskillit/workspace/clone_registry.py", 54),
+    ("src/autoskillit/workspace/clone_registry.py", 63),
     # staleness_cache.py — cache dict
     ("src/autoskillit/recipe/staleness_cache.py", 67),
     # background.py — payload dict

--- a/tests/recipe/test_rules_tools.py
+++ b/tests/recipe/test_rules_tools.py
@@ -262,6 +262,21 @@ def test_wait_for_ci_rejects_poll_interval() -> None:
     assert dead, "phantom param 'poll_interval' must trigger dead-with-param on wait_for_ci"
 
 
+def test_rules_tools_batch_cleanup_clones_accepts_all_owners_param() -> None:
+    """T20 — batch_cleanup_clones with all_owners param must not trigger dead-with-param."""
+    from autoskillit.recipe.rules_tools import _TOOL_PARAMS
+
+    assert "all_owners" in _TOOL_PARAMS["batch_cleanup_clones"]
+
+    recipe = _make_recipe_with_args(
+        "batch_cleanup_clones",
+        {"all_owners": "true", "registry_path": "/tmp/reg.json"},
+    )
+    findings = run_semantic_rules(recipe)
+    dead = [f for f in findings if f.rule == "dead-with-param"]
+    assert not dead, f"all_owners must not trigger dead-with-param: {dead}"
+
+
 # ---------------------------------------------------------------------------
 # rebase-then-push-requires-force rule tests (T6, T7)
 # ---------------------------------------------------------------------------

--- a/tests/server/test_tools_clone.py
+++ b/tests/server/test_tools_clone.py
@@ -273,6 +273,7 @@ class TestRegisterCloneStatusTool:
     @pytest.mark.anyio
     async def test_register_clone_status_success(self, tool_ctx, tmp_path):
         """register_clone_status status='success' writes registry and returns registered=true."""
+        tool_ctx.kitchen_id = "kit-test"
         registry_path = str(tmp_path / "registry.json")
         result = json.loads(
             await register_clone_status(
@@ -287,6 +288,7 @@ class TestRegisterCloneStatusTool:
     @pytest.mark.anyio
     async def test_register_clone_status_error(self, tool_ctx, tmp_path):
         """register_clone_status status='error' writes registry and returns registered=true."""
+        tool_ctx.kitchen_id = "kit-test"
         registry_path = str(tmp_path / "registry.json")
         result = json.loads(
             await register_clone_status(
@@ -318,13 +320,14 @@ class TestBatchCleanupClonesTool:
     @pytest.mark.anyio
     async def test_batch_cleanup_clones_deletes_success_preserves_error(self, tool_ctx, tmp_path):
         """batch_cleanup_clones removes success clones, skips error clones."""
+        tool_ctx.kitchen_id = "kit-test"
         registry_path = str(tmp_path / "registry.json")
         success_path = str(tmp_path / "success_clone")
         error_path = str(tmp_path / "error_clone")
 
         # Pre-populate registry with one success and one error entry
-        clone_registry.register_clone(success_path, "success", registry_path)
-        clone_registry.register_clone(error_path, "error", registry_path)
+        clone_registry.register_clone(success_path, "success", "kit-test", registry_path)
+        clone_registry.register_clone(error_path, "error", "kit-test", registry_path)
 
         # Mock clone_mgr so remove_clone reports success for the success clone
         mock_mgr = MagicMock()
@@ -341,6 +344,7 @@ class TestBatchCleanupClonesTool:
     @pytest.mark.anyio
     async def test_batch_cleanup_clones_empty_registry(self, tool_ctx, tmp_path):
         """batch_cleanup_clones with missing registry returns deleted=[], preserved=[]."""
+        tool_ctx.kitchen_id = "kit-test"
         registry_path = str(tmp_path / "nonexistent.json")
         result = json.loads(await batch_cleanup_clones(registry_path=registry_path))
         assert result == {"deleted": [], "delete_failures": [], "preserved": []}
@@ -348,11 +352,12 @@ class TestBatchCleanupClonesTool:
     @pytest.mark.anyio
     async def test_batch_cleanup_clones_nonexistent_path_does_not_raise(self, tool_ctx, tmp_path):
         """batch_cleanup_clones reports failure gracefully when a success clone path is gone."""
+        tool_ctx.kitchen_id = "kit-test"
         registry_path = str(tmp_path / "registry.json")
         missing_path = str(tmp_path / "gone_clone")
 
         # Register a success clone whose directory does not exist on disk
-        clone_registry.register_clone(missing_path, "success", registry_path)
+        clone_registry.register_clone(missing_path, "success", "kit-test", registry_path)
 
         # Mock clone_mgr to report removal failure (path not found)
         mock_mgr = MagicMock()
@@ -365,3 +370,191 @@ class TestBatchCleanupClonesTool:
         assert result["deleted"] == []
         # Confirm no exception was raised (we received a well-formed result dict)
         assert "error" not in result
+
+
+# ---------------------------------------------------------------------------
+# New tests: T12–T19 (owner-scoping feature for server tools)
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterCloneStatusOwner:
+    """T12–T13: register_clone_status propagates kitchen_id as owner."""
+
+    @pytest.mark.anyio
+    async def test_register_clone_status_propagates_kitchen_id_as_owner(
+        self, tool_ctx, tmp_path
+    ):
+        """T12 — register_clone_status writes entry with owner == kitchen_id."""
+        tool_ctx.kitchen_id = "kit-xyz"
+        reg = str(tmp_path / "registry.json")
+        result = json.loads(
+            await register_clone_status(clone_path="/c", status="success", registry_path=reg)
+        )
+        assert result["registered"] == "true"
+
+        import json as _json
+        from pathlib import Path as _Path
+
+        data = _json.loads(_Path(reg).read_text())
+        assert len(data["clones"]) == 1
+        assert data["clones"][0]["owner"] == "kit-xyz"
+
+    @pytest.mark.anyio
+    async def test_register_clone_status_rejects_when_kitchen_id_empty(
+        self, tool_ctx, tmp_path
+    ):
+        """T13 — register_clone_status returns registered=false when kitchen_id is empty."""
+        tool_ctx.kitchen_id = ""
+        reg = str(tmp_path / "registry.json")
+        result = json.loads(
+            await register_clone_status(clone_path="/c", status="success", registry_path=reg)
+        )
+        assert result["registered"] == "false"
+        assert "kitchen_id" in result["reason"] or "kitchen" in result["reason"]
+        from pathlib import Path as _Path
+
+        assert not _Path(reg).exists()
+
+
+class TestBatchCleanupClonesOwner:
+    """T14–T19: batch_cleanup_clones owner-scoping and escape hatch."""
+
+    @pytest.mark.anyio
+    async def test_batch_cleanup_clones_default_scopes_to_current_kitchen_id(
+        self, tool_ctx, tmp_path
+    ):
+        """T14 — default call only removes current kitchen's clones."""
+        reg = str(tmp_path / "registry.json")
+        clone_registry.register_clone("/clone-A", "success", "kit-A", reg)
+        clone_registry.register_clone("/clone-B", "success", "kit-B", reg)
+
+        tool_ctx.kitchen_id = "kit-A"
+        mock_mgr = MagicMock()
+        mock_mgr.remove_clone.return_value = {"removed": "true"}
+        tool_ctx.clone_mgr = mock_mgr
+
+        result = json.loads(await batch_cleanup_clones(registry_path=reg))
+
+        assert "/clone-A" in result["deleted"]
+        assert "/clone-B" not in result["deleted"]
+        mock_mgr.remove_clone.assert_called_once_with("/clone-A", "false")
+
+    @pytest.mark.anyio
+    async def test_batch_cleanup_clones_all_owners_true_removes_every_success(
+        self, tool_ctx, tmp_path
+    ):
+        """T15 — all_owners='true' escape hatch removes all success entries."""
+        reg = str(tmp_path / "registry.json")
+        clone_registry.register_clone("/clone-A", "success", "kit-A", reg)
+        clone_registry.register_clone("/clone-B", "success", "kit-B", reg)
+
+        tool_ctx.kitchen_id = "kit-A"
+        mock_mgr = MagicMock()
+        mock_mgr.remove_clone.return_value = {"removed": "true"}
+        tool_ctx.clone_mgr = mock_mgr
+
+        result = json.loads(
+            await batch_cleanup_clones(registry_path=reg, all_owners="true")
+        )
+
+        deleted = result["deleted"]
+        assert "/clone-A" in deleted
+        assert "/clone-B" in deleted
+
+    @pytest.mark.anyio
+    async def test_batch_cleanup_clones_empty_kitchen_id_and_all_owners_false_returns_error(
+        self, tool_ctx, tmp_path
+    ):
+        """T16 — empty kitchen_id with default all_owners='false' returns error."""
+        tool_ctx.kitchen_id = ""
+        reg = str(tmp_path / "registry.json")
+        mock_mgr = MagicMock()
+        tool_ctx.clone_mgr = mock_mgr
+
+        result = json.loads(await batch_cleanup_clones(registry_path=reg))
+
+        assert "error" in result
+        assert "kitchen_id" in result["error"] or "kitchen" in result["error"]
+        mock_mgr.remove_clone.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_batch_cleanup_clones_empty_kitchen_id_with_all_owners_true_succeeds(
+        self, tool_ctx, tmp_path
+    ):
+        """T17 — escape hatch works even when kitchen_id is empty (legacy recovery)."""
+        from pathlib import Path as _Path
+
+        reg_path = tmp_path / "registry.json"
+        reg_path.write_text(
+            __import__("json").dumps(
+                {"clones": [{"path": "/legacy", "status": "success"}]}
+            )
+        )
+
+        tool_ctx.kitchen_id = ""
+        mock_mgr = MagicMock()
+        mock_mgr.remove_clone.return_value = {"removed": "true"}
+        tool_ctx.clone_mgr = mock_mgr
+
+        result = json.loads(
+            await batch_cleanup_clones(registry_path=str(reg_path), all_owners="true")
+        )
+
+        assert "/legacy" in result["deleted"]
+        mock_mgr.remove_clone.assert_called_once_with("/legacy", "false")
+
+    @pytest.mark.anyio
+    async def test_batch_cleanup_clones_invalid_all_owners_literal_treated_as_false(
+        self, tool_ctx, tmp_path
+    ):
+        """T18 — all_owners='yes' is not the escape hatch; scoped behaviour applies."""
+        reg = str(tmp_path / "registry.json")
+        clone_registry.register_clone("/clone-A", "success", "kit-A", reg)
+        clone_registry.register_clone("/clone-B", "success", "kit-B", reg)
+
+        tool_ctx.kitchen_id = "kit-A"
+        mock_mgr = MagicMock()
+        mock_mgr.remove_clone.return_value = {"removed": "true"}
+        tool_ctx.clone_mgr = mock_mgr
+
+        result = json.loads(
+            await batch_cleanup_clones(registry_path=reg, all_owners="yes")
+        )
+
+        assert "/clone-A" in result["deleted"]
+        assert "/clone-B" not in result["deleted"]
+
+    @pytest.mark.anyio
+    async def test_two_kitchens_register_and_cleanup_isolated(self, tool_ctx, tmp_path):
+        """T19 — kitchen A's cleanup does not touch kitchen B's registry entry."""
+        import json as _json
+        from pathlib import Path as _Path
+
+        reg = str(tmp_path / "registry.json")
+
+        # Session 1: kit-1 registers
+        tool_ctx.kitchen_id = "kit-1"
+        await register_clone_status(clone_path="/clone-1", status="success", registry_path=reg)
+
+        # Session 2: kit-2 registers
+        tool_ctx.kitchen_id = "kit-2"
+        await register_clone_status(clone_path="/clone-2", status="success", registry_path=reg)
+
+        # Session 1 cleans up
+        tool_ctx.kitchen_id = "kit-1"
+        mock_mgr = MagicMock()
+        mock_mgr.remove_clone.return_value = {"removed": "true"}
+        tool_ctx.clone_mgr = mock_mgr
+
+        result = json.loads(await batch_cleanup_clones(registry_path=reg))
+
+        # Only kit-1's clone is removed
+        assert "/clone-1" in result["deleted"]
+        assert "/clone-2" not in result["deleted"]
+        mock_mgr.remove_clone.assert_called_once_with("/clone-1", "false")
+
+        # kit-2's entry is still on disk
+        data = _json.loads(_Path(reg).read_text())
+        remaining = {e["path"]: e.get("owner") for e in data["clones"]}
+        assert "/clone-2" in remaining
+        assert remaining["/clone-2"] == "kit-2"

--- a/tests/server/test_tools_clone.py
+++ b/tests/server/test_tools_clone.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -390,10 +391,7 @@ class TestRegisterCloneStatusOwner:
         )
         assert result["registered"] == "true"
 
-        import json as _json
-        from pathlib import Path as _Path
-
-        data = _json.loads(_Path(reg).read_text())
+        data = json.loads(Path(reg).read_text())
         assert len(data["clones"]) == 1
         assert data["clones"][0]["owner"] == "kit-xyz"
 
@@ -407,9 +405,7 @@ class TestRegisterCloneStatusOwner:
         )
         assert result["registered"] == "false"
         assert "kitchen_id" in result["reason"] or "kitchen" in result["reason"]
-        from pathlib import Path as _Path
-
-        assert not _Path(reg).exists()
+        assert not Path(reg).exists()
 
 
 class TestBatchCleanupClonesOwner:
@@ -478,9 +474,7 @@ class TestBatchCleanupClonesOwner:
         """T17 — escape hatch works even when kitchen_id is empty (legacy recovery)."""
 
         reg_path = tmp_path / "registry.json"
-        reg_path.write_text(
-            __import__("json").dumps({"clones": [{"path": "/legacy", "status": "success"}]})
-        )
+        reg_path.write_text(json.dumps({"clones": [{"path": "/legacy", "status": "success"}]}))
 
         tool_ctx.kitchen_id = ""
         mock_mgr = MagicMock()
@@ -516,20 +510,14 @@ class TestBatchCleanupClonesOwner:
     @pytest.mark.anyio
     async def test_two_kitchens_register_and_cleanup_isolated(self, tool_ctx, tmp_path):
         """T19 — kitchen A's cleanup does not touch kitchen B's registry entry."""
-        import json as _json
-        from pathlib import Path as _Path
-
         reg = str(tmp_path / "registry.json")
 
-        # Session 1: kit-1 registers
-        tool_ctx.kitchen_id = "kit-1"
-        await register_clone_status(clone_path="/clone-1", status="success", registry_path=reg)
+        # Register directly via L1 to represent two independent sessions without
+        # mutating a shared ToolContext mid-test (a ToolContext represents one session).
+        clone_registry.register_clone("/clone-1", "success", "kit-1", reg)
+        clone_registry.register_clone("/clone-2", "success", "kit-2", reg)
 
-        # Session 2: kit-2 registers
-        tool_ctx.kitchen_id = "kit-2"
-        await register_clone_status(clone_path="/clone-2", status="success", registry_path=reg)
-
-        # Session 1 cleans up
+        # Session 1 cleans up via the MCP tool
         tool_ctx.kitchen_id = "kit-1"
         mock_mgr = MagicMock()
         mock_mgr.remove_clone.return_value = {"removed": "true"}
@@ -543,7 +531,7 @@ class TestBatchCleanupClonesOwner:
         mock_mgr.remove_clone.assert_called_once_with("/clone-1", "false")
 
         # kit-2's entry is still on disk
-        data = _json.loads(_Path(reg).read_text())
+        data = json.loads(Path(reg).read_text())
         remaining = {e["path"]: e.get("owner") for e in data["clones"]}
         assert "/clone-2" in remaining
         assert remaining["/clone-2"] == "kit-2"

--- a/tests/server/test_tools_clone.py
+++ b/tests/server/test_tools_clone.py
@@ -312,7 +312,8 @@ class TestRegisterCloneStatusTool:
                 registry_path=registry_path,
             )
         )
-        assert "error" in result
+        assert result["registered"] == "false"
+        assert "reason" in result
         # Registry file must not have been created
         assert not (tmp_path / "registry.json").exists()
 

--- a/tests/server/test_tools_clone.py
+++ b/tests/server/test_tools_clone.py
@@ -381,9 +381,7 @@ class TestRegisterCloneStatusOwner:
     """T12–T13: register_clone_status propagates kitchen_id as owner."""
 
     @pytest.mark.anyio
-    async def test_register_clone_status_propagates_kitchen_id_as_owner(
-        self, tool_ctx, tmp_path
-    ):
+    async def test_register_clone_status_propagates_kitchen_id_as_owner(self, tool_ctx, tmp_path):
         """T12 — register_clone_status writes entry with owner == kitchen_id."""
         tool_ctx.kitchen_id = "kit-xyz"
         reg = str(tmp_path / "registry.json")
@@ -400,9 +398,7 @@ class TestRegisterCloneStatusOwner:
         assert data["clones"][0]["owner"] == "kit-xyz"
 
     @pytest.mark.anyio
-    async def test_register_clone_status_rejects_when_kitchen_id_empty(
-        self, tool_ctx, tmp_path
-    ):
+    async def test_register_clone_status_rejects_when_kitchen_id_empty(self, tool_ctx, tmp_path):
         """T13 — register_clone_status returns registered=false when kitchen_id is empty."""
         tool_ctx.kitchen_id = ""
         reg = str(tmp_path / "registry.json")
@@ -453,9 +449,7 @@ class TestBatchCleanupClonesOwner:
         mock_mgr.remove_clone.return_value = {"removed": "true"}
         tool_ctx.clone_mgr = mock_mgr
 
-        result = json.loads(
-            await batch_cleanup_clones(registry_path=reg, all_owners="true")
-        )
+        result = json.loads(await batch_cleanup_clones(registry_path=reg, all_owners="true"))
 
         deleted = result["deleted"]
         assert "/clone-A" in deleted
@@ -482,13 +476,10 @@ class TestBatchCleanupClonesOwner:
         self, tool_ctx, tmp_path
     ):
         """T17 — escape hatch works even when kitchen_id is empty (legacy recovery)."""
-        from pathlib import Path as _Path
 
         reg_path = tmp_path / "registry.json"
         reg_path.write_text(
-            __import__("json").dumps(
-                {"clones": [{"path": "/legacy", "status": "success"}]}
-            )
+            __import__("json").dumps({"clones": [{"path": "/legacy", "status": "success"}]})
         )
 
         tool_ctx.kitchen_id = ""
@@ -517,9 +508,7 @@ class TestBatchCleanupClonesOwner:
         mock_mgr.remove_clone.return_value = {"removed": "true"}
         tool_ctx.clone_mgr = mock_mgr
 
-        result = json.loads(
-            await batch_cleanup_clones(registry_path=reg, all_owners="yes")
-        )
+        result = json.loads(await batch_cleanup_clones(registry_path=reg, all_owners="yes"))
 
         assert "/clone-A" in result["deleted"]
         assert "/clone-B" not in result["deleted"]

--- a/tests/workspace/test_clone_registry.py
+++ b/tests/workspace/test_clone_registry.py
@@ -152,9 +152,7 @@ class TestCleanupCandidatesOwnerFilter:
 
         assert sorted(to_delete) == ["/tmp/a", "/tmp/b", "/tmp/c"]
 
-    def test_cleanup_candidates_with_owner_filters_to_matching_only(
-        self, tmp_path: Path
-    ) -> None:
+    def test_cleanup_candidates_with_owner_filters_to_matching_only(self, tmp_path: Path) -> None:
         """T4 — cleanup_candidates(owner='kit-1') returns only kit-1's success entry."""
         reg = str(tmp_path / "registry.json")
         register_clone("/tmp/a", "success", "kit-1", registry_path=reg)
@@ -179,27 +177,19 @@ class TestCleanupCandidatesOwnerFilter:
         assert to_delete == ["/tmp/a"]
         assert to_preserve == []
 
-    def test_cleanup_candidates_owner_none_includes_legacy_entries(
-        self, tmp_path: Path
-    ) -> None:
+    def test_cleanup_candidates_owner_none_includes_legacy_entries(self, tmp_path: Path) -> None:
         """T6 — owner=None (all-owners mode) includes legacy entries without owner field."""
         reg_path = tmp_path / "registry.json"
-        reg_path.write_text(
-            json.dumps({"clones": [{"path": "/tmp/legacy", "status": "success"}]})
-        )
+        reg_path.write_text(json.dumps({"clones": [{"path": "/tmp/legacy", "status": "success"}]}))
 
         to_delete, _ = cleanup_candidates(registry_path=str(reg_path), owner=None)
 
         assert "/tmp/legacy" in to_delete
 
-    def test_cleanup_candidates_owner_scoped_hides_legacy_entries(
-        self, tmp_path: Path
-    ) -> None:
+    def test_cleanup_candidates_owner_scoped_hides_legacy_entries(self, tmp_path: Path) -> None:
         """T7 — owner-scoped call does not see legacy orphan entries (no owner field)."""
         reg_path = tmp_path / "registry.json"
-        reg_path.write_text(
-            json.dumps({"clones": [{"path": "/tmp/legacy", "status": "success"}]})
-        )
+        reg_path.write_text(json.dumps({"clones": [{"path": "/tmp/legacy", "status": "success"}]}))
 
         to_delete, _ = cleanup_candidates(registry_path=str(reg_path), owner="kit-1")
 
@@ -248,9 +238,7 @@ class TestBatchDeleteOwnerFilter:
         assert sorted(called_paths) == ["/tmp/a", "/tmp/b", "/tmp/legacy"]
         assert sorted(result["deleted"]) == ["/tmp/a", "/tmp/b", "/tmp/legacy"]
 
-    def test_batch_delete_preserves_other_owners_error_entries(
-        self, tmp_path: Path
-    ) -> None:
+    def test_batch_delete_preserves_other_owners_error_entries(self, tmp_path: Path) -> None:
         """T10 — kit-1's scoped batch_delete does not report kit-2's error as preserved."""
         reg = str(tmp_path / "registry.json")
         register_clone("/tmp/a", "success", "kit-1", registry_path=reg)
@@ -265,9 +253,7 @@ class TestBatchDeleteOwnerFilter:
 class TestRegisterCloneParallelWriters:
     """T11: parallel writers with distinct owners both persist correctly."""
 
-    def test_register_clone_parallel_writers_two_owners_interleaved(
-        self, tmp_path: Path
-    ) -> None:
+    def test_register_clone_parallel_writers_two_owners_interleaved(self, tmp_path: Path) -> None:
         """T11 — two sequential register_clone calls with distinct owners both persist."""
         reg = str(tmp_path / "registry.json")
         register_clone("/tmp/clone-A", "success", "owner-A", registry_path=reg)

--- a/tests/workspace/test_clone_registry.py
+++ b/tests/workspace/test_clone_registry.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
 
 from autoskillit.workspace.clone_registry import (
+    batch_delete,
     cleanup_candidates,
     read_registry,
     register_clone,
@@ -18,31 +22,41 @@ class TestRegisterClone:
     def test_register_clone_creates_registry(self, tmp_path: Path) -> None:
         """register_clone with new path creates registry file with one entry."""
         registry = str(tmp_path / "registry.json")
-        result = register_clone("/tmp/clone-a", "success", registry_path=registry)
+        result = register_clone("/tmp/clone-a", "success", "test-owner", registry_path=registry)
 
         assert result["registered"] == "true"
         assert result["registry_path"] == registry
         assert Path(registry).exists()
 
         data = json.loads(Path(registry).read_text())
-        assert data["clones"] == [{"path": "/tmp/clone-a", "status": "success"}]
+        assert data["clones"] == [
+            {"path": "/tmp/clone-a", "status": "success", "owner": "test-owner"}
+        ]
 
     def test_register_clone_appends_to_existing(self, tmp_path: Path) -> None:
         """Second register_clone appends without overwriting first entry."""
         registry = str(tmp_path / "registry.json")
-        register_clone("/tmp/clone-a", "success", registry_path=registry)
-        register_clone("/tmp/clone-b", "error", registry_path=registry)
+        register_clone("/tmp/clone-a", "success", "test-owner", registry_path=registry)
+        register_clone("/tmp/clone-b", "error", "test-owner", registry_path=registry)
 
         data = json.loads(Path(registry).read_text())
         assert len(data["clones"]) == 2
-        assert data["clones"][0] == {"path": "/tmp/clone-a", "status": "success"}
-        assert data["clones"][1] == {"path": "/tmp/clone-b", "status": "error"}
+        assert data["clones"][0] == {
+            "path": "/tmp/clone-a",
+            "status": "success",
+            "owner": "test-owner",
+        }
+        assert data["clones"][1] == {
+            "path": "/tmp/clone-b",
+            "status": "error",
+            "owner": "test-owner",
+        }
 
     def test_register_clone_success_and_error_statuses(self, tmp_path: Path) -> None:
         """Both 'success' and 'error' statuses are accepted and stored."""
         registry = str(tmp_path / "registry.json")
-        register_clone("/tmp/ok-clone", "success", registry_path=registry)
-        register_clone("/tmp/bad-clone", "error", registry_path=registry)
+        register_clone("/tmp/ok-clone", "success", "test-owner", registry_path=registry)
+        register_clone("/tmp/bad-clone", "error", "test-owner", registry_path=registry)
 
         entries = json.loads(Path(registry).read_text())["clones"]
         statuses = {e["path"]: e["status"] for e in entries}
@@ -54,7 +68,7 @@ class TestRegisterClone:
         custom = str(tmp_path / "custom-registry.json")
         default_candidate = tmp_path / ".autoskillit" / "temp" / "clone-cleanup-registry.json"
 
-        register_clone("/tmp/clone-x", "success", registry_path=custom)
+        register_clone("/tmp/clone-x", "success", "test-owner", registry_path=custom)
 
         assert Path(custom).exists()
         assert not default_candidate.exists()
@@ -76,9 +90,9 @@ class TestCleanupCandidates:
     def test_cleanup_candidates_partitions_by_status(self, tmp_path: Path) -> None:
         """cleanup_candidates returns (success_paths, error_paths) correctly separated."""
         registry = str(tmp_path / "registry.json")
-        register_clone("/tmp/success-1", "success", registry_path=registry)
-        register_clone("/tmp/error-1", "error", registry_path=registry)
-        register_clone("/tmp/success-2", "success", registry_path=registry)
+        register_clone("/tmp/success-1", "success", "test-owner", registry_path=registry)
+        register_clone("/tmp/error-1", "error", "test-owner", registry_path=registry)
+        register_clone("/tmp/success-2", "success", "test-owner", registry_path=registry)
 
         to_delete, to_preserve = cleanup_candidates(registry_path=registry)
 
@@ -91,3 +105,175 @@ class TestCleanupCandidates:
         to_delete, to_preserve = cleanup_candidates(registry_path=registry)
         assert to_delete == []
         assert to_preserve == []
+
+
+# ---------------------------------------------------------------------------
+# New tests: T1–T11 (owner-scoping feature)
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterClonePersistsOwner:
+    """T1: register_clone stores the owner field in the registry entry."""
+
+    def test_register_clone_persists_owner_field(self, tmp_path: Path) -> None:
+        """T1 — register_clone writes the owner field to the registry JSON."""
+        reg = str(tmp_path / "registry.json")
+        register_clone("/tmp/a", "success", owner="kit-abc", registry_path=reg)
+
+        data = json.loads(Path(reg).read_text())
+        assert len(data["clones"]) == 1
+        entry = data["clones"][0]
+        assert set(entry.keys()) == {"path", "status", "owner"}
+        assert entry["owner"] == "kit-abc"
+
+
+class TestRegisterCloneRejectsEmptyOwner:
+    """T2: register_clone raises ValueError when owner is empty string."""
+
+    def test_register_clone_rejects_empty_owner(self, tmp_path: Path) -> None:
+        """T2 — register_clone raises ValueError and does not write registry when owner=''."""
+        reg = str(tmp_path / "registry.json")
+        with pytest.raises(ValueError, match="owner is required"):
+            register_clone("/tmp/a", "success", owner="", registry_path=reg)
+        assert not Path(reg).exists()
+
+
+class TestCleanupCandidatesOwnerFilter:
+    """T3–T7: cleanup_candidates owner-scoping behaviour."""
+
+    def test_cleanup_candidates_without_owner_returns_all_entries(self, tmp_path: Path) -> None:
+        """T3 — cleanup_candidates(owner=None) returns all success entries regardless of owner."""
+        reg = str(tmp_path / "registry.json")
+        register_clone("/tmp/a", "success", "kit-1", registry_path=reg)
+        register_clone("/tmp/b", "success", "kit-2", registry_path=reg)
+        register_clone("/tmp/c", "success", "kit-3", registry_path=reg)
+
+        to_delete, _ = cleanup_candidates(registry_path=reg, owner=None)
+
+        assert sorted(to_delete) == ["/tmp/a", "/tmp/b", "/tmp/c"]
+
+    def test_cleanup_candidates_with_owner_filters_to_matching_only(
+        self, tmp_path: Path
+    ) -> None:
+        """T4 — cleanup_candidates(owner='kit-1') returns only kit-1's success entry."""
+        reg = str(tmp_path / "registry.json")
+        register_clone("/tmp/a", "success", "kit-1", registry_path=reg)
+        register_clone("/tmp/b", "success", "kit-2", registry_path=reg)
+
+        to_delete, to_preserve = cleanup_candidates(registry_path=reg, owner="kit-1")
+
+        assert to_delete == ["/tmp/a"]
+        assert "/tmp/b" not in to_delete
+        assert "/tmp/b" not in to_preserve
+
+    def test_cleanup_candidates_owner_filter_ignores_other_owners_error_entries(
+        self, tmp_path: Path
+    ) -> None:
+        """T5 — kit-1's scoped call does not see kit-2's error entry."""
+        reg = str(tmp_path / "registry.json")
+        register_clone("/tmp/a", "success", "kit-1", registry_path=reg)
+        register_clone("/tmp/b", "error", "kit-2", registry_path=reg)
+
+        to_delete, to_preserve = cleanup_candidates(registry_path=reg, owner="kit-1")
+
+        assert to_delete == ["/tmp/a"]
+        assert to_preserve == []
+
+    def test_cleanup_candidates_owner_none_includes_legacy_entries(
+        self, tmp_path: Path
+    ) -> None:
+        """T6 — owner=None (all-owners mode) includes legacy entries without owner field."""
+        reg_path = tmp_path / "registry.json"
+        reg_path.write_text(
+            json.dumps({"clones": [{"path": "/tmp/legacy", "status": "success"}]})
+        )
+
+        to_delete, _ = cleanup_candidates(registry_path=str(reg_path), owner=None)
+
+        assert "/tmp/legacy" in to_delete
+
+    def test_cleanup_candidates_owner_scoped_hides_legacy_entries(
+        self, tmp_path: Path
+    ) -> None:
+        """T7 — owner-scoped call does not see legacy orphan entries (no owner field)."""
+        reg_path = tmp_path / "registry.json"
+        reg_path.write_text(
+            json.dumps({"clones": [{"path": "/tmp/legacy", "status": "success"}]})
+        )
+
+        to_delete, _ = cleanup_candidates(registry_path=str(reg_path), owner="kit-1")
+
+        assert to_delete == []
+
+
+class TestBatchDeleteOwnerFilter:
+    """T8–T10: batch_delete owner-scoping behaviour."""
+
+    def test_batch_delete_with_owner_only_invokes_remove_fn_for_matching_entries(
+        self, tmp_path: Path
+    ) -> None:
+        """T8 — batch_delete(owner='kit-1') only removes kit-1's clone."""
+        reg = str(tmp_path / "registry.json")
+        register_clone("/tmp/a", "success", "kit-1", registry_path=reg)
+        register_clone("/tmp/b", "success", "kit-2", registry_path=reg)
+
+        mock_remove = MagicMock(return_value={"removed": "true"})
+        result = batch_delete(reg, mock_remove, owner="kit-1")
+
+        mock_remove.assert_called_once_with("/tmp/a", "false")
+        assert result["deleted"] == ["/tmp/a"]
+        assert "/tmp/b" not in result["deleted"]
+
+    def test_batch_delete_owner_none_invokes_remove_fn_for_all_success_entries(
+        self, tmp_path: Path
+    ) -> None:
+        """T9 — batch_delete(owner=None) removes all success entries including legacy."""
+        reg_path = tmp_path / "registry.json"
+        reg_path.write_text(
+            json.dumps(
+                {
+                    "clones": [
+                        {"path": "/tmp/a", "status": "success", "owner": "kit-1"},
+                        {"path": "/tmp/b", "status": "success", "owner": "kit-2"},
+                        {"path": "/tmp/legacy", "status": "success"},
+                    ]
+                }
+            )
+        )
+
+        mock_remove = MagicMock(return_value={"removed": "true"})
+        result = batch_delete(str(reg_path), mock_remove, owner=None)
+
+        called_paths = [call.args[0] for call in mock_remove.call_args_list]
+        assert sorted(called_paths) == ["/tmp/a", "/tmp/b", "/tmp/legacy"]
+        assert sorted(result["deleted"]) == ["/tmp/a", "/tmp/b", "/tmp/legacy"]
+
+    def test_batch_delete_preserves_other_owners_error_entries(
+        self, tmp_path: Path
+    ) -> None:
+        """T10 — kit-1's scoped batch_delete does not report kit-2's error as preserved."""
+        reg = str(tmp_path / "registry.json")
+        register_clone("/tmp/a", "success", "kit-1", registry_path=reg)
+        register_clone("/tmp/b", "error", "kit-2", registry_path=reg)
+
+        mock_remove = MagicMock(return_value={"removed": "true"})
+        result = batch_delete(reg, mock_remove, owner="kit-1")
+
+        assert result["preserved"] == []
+
+
+class TestRegisterCloneParallelWriters:
+    """T11: parallel writers with distinct owners both persist correctly."""
+
+    def test_register_clone_parallel_writers_two_owners_interleaved(
+        self, tmp_path: Path
+    ) -> None:
+        """T11 — two sequential register_clone calls with distinct owners both persist."""
+        reg = str(tmp_path / "registry.json")
+        register_clone("/tmp/clone-A", "success", "owner-A", registry_path=reg)
+        register_clone("/tmp/clone-B", "success", "owner-B", registry_path=reg)
+
+        data = json.loads(Path(reg).read_text())
+        entries = {e["path"]: e["owner"] for e in data["clones"]}
+        assert entries["/tmp/clone-A"] == "owner-A"
+        assert entries["/tmp/clone-B"] == "owner-B"

--- a/tests/workspace/test_clone_registry.py
+++ b/tests/workspace/test_clone_registry.py
@@ -161,8 +161,7 @@ class TestCleanupCandidatesOwnerFilter:
         to_delete, to_preserve = cleanup_candidates(registry_path=reg, owner="kit-1")
 
         assert to_delete == ["/tmp/a"]
-        assert "/tmp/b" not in to_delete
-        assert "/tmp/b" not in to_preserve
+        assert to_preserve == []
 
     def test_cleanup_candidates_owner_filter_ignores_other_owners_error_entries(
         self, tmp_path: Path


### PR DESCRIPTION
## Summary

The clone cleanup registry (`src/autoskillit/workspace/clone_registry.py`) is a single shared JSON file that every orchestrator session reads and writes. Today, entries carry only `{path, status}`. When any session calls `batch_cleanup_clones`, it deletes every `status="success"` entry — including clones owned by other running sessions. Two parallel orchestrator sessions on 2026-04-12 exposed the race window (sessions `927d5724…` and `2ae5a3dc…` both wrote into the same `clone-cleanup-registry.json`).

This plan extends the registry entry schema with an `owner` field (populated from `ToolContext.kitchen_id` at registration time), threads an owner filter through `register_clone`, `cleanup_candidates`, and `batch_delete`, updates the two server tool handlers (`register_clone_status`, `batch_cleanup_clones`) to source the owner from `tool_ctx.kitchen_id`, and adds an explicit `all_owners="true"` escape hatch on `batch_cleanup_clones` for operator recovery. Legacy entries without an `owner` field are classified as orphans — invisible to owner-scoped calls, deletable only via the escape hatch. Registry pruning after successful deletion is explicitly out of scope (tracked in #756).

## Requirements

**REQ-REG-001:** The registry entry schema must include an owner field identifying which orchestrator session registered the entry.

**REQ-REG-002:** The owner identifier must uniquely distinguish concurrent orchestrator sessions on the same host.

**REQ-REG-003:** `register_clone` must populate the owner field at registration time, sourced from the current session context.

**REQ-REG-004:** `cleanup_candidates` must accept an owner filter and return only entries matching that owner, defaulting to the current session's owner.

**REQ-REG-005:** `batch_cleanup_clones` must scope deletion to the caller's owner by default.

**REQ-REG-006:** The schema change must handle existing registry files whose entries lack an owner field without corrupting or losing data.

**REQ-REG-007:** An explicit "clean up orphaned entries from all owners" escape hatch must exist for operator recovery.

## Architecture Impact

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    REG_IN([● register_clone_status])
    CLEANUP_IN([● batch_cleanup_clones])

    subgraph ValidationGates ["VALIDATION GATES (Registration Path)"]
        direction TB
        GATE_KITCHEN["● kitchen_id gate<br/>━━━━━━━━━━<br/>kitchen_id == '' → error<br/>No active kitchen"]
        GATE_STATUS["status gate<br/>━━━━━━━━━━<br/>must be 'success'|'error'<br/>FAIL-FAST"]
        GATE_OWNER["● owner validation<br/>━━━━━━━━━━<br/>owner == '' → ValueError<br/>register_clone rejects empty"]
    end

    subgraph LockWrite ["CONCURRENT WRITE SAFETY"]
        direction TB
        FLOCK["fcntl.LOCK_EX<br/>━━━━━━━━━━<br/>Exclusive advisory lock<br/>Read-modify-write atomic"]
    end

    subgraph RegistryEntry ["REGISTRY ENTRY (INIT_ONLY fields)"]
        direction LR
        FIELD_PATH["path<br/>━━━━━━━━━━<br/>INIT_ONLY<br/>Clone dir — never changes"]
        FIELD_STATUS["status<br/>━━━━━━━━━━<br/>'success' | 'error'<br/>INIT_ONLY — terminal outcome"]
        FIELD_OWNER["● owner<br/>━━━━━━━━━━<br/>kitchen_id<br/>INIT_ONLY — session tag"]
    end

    subgraph LegacyPath ["LEGACY ENTRY (no owner field)"]
        LEGACY["orphan entry<br/>━━━━━━━━━━<br/>No 'owner' key<br/>Pre-owner schema"]
    end

    subgraph CleanupScope ["● OWNER SCOPE RESOLUTION"]
        direction TB
        SCOPE_CHECK{"all_owners<br/>== 'true'?"}
        SCOPE_KITCHEN["owner_filter = kitchen_id<br/>━━━━━━━━━━<br/>Default: scoped to session<br/>Other kitchen entries invisible"]
        SCOPE_ALL["owner_filter = None<br/>━━━━━━━━━━<br/>Escape hatch<br/>All entries including legacy"]
        GATE_EMPTY_K["● kitchen_id empty gate<br/>━━━━━━━━━━<br/>kitchen_id == '' and<br/>not escape hatch → error"]
    end

    subgraph CleanupFilter ["● _entry_matches_owner FILTER"]
        direction TB
        FILTER_FN["_entry_matches_owner(entry, owner)<br/>━━━━━━━━━━<br/>owner=None → True (pass all)<br/>owner=X → entry.get('owner')==X"]
        PARTITION["cleanup_candidates partition<br/>━━━━━━━━━━<br/>to_delete: status==success ∧ match<br/>to_preserve: status==error ∧ match"]
    end

    subgraph RecipeValidation ["● RECIPE VALIDATOR (rules_tools.py)"]
        RULE_PARAMS["dead-with-param rule<br/>━━━━━━━━━━<br/>batch_cleanup_clones params:<br/>{registry_path, all_owners, step_name}"]
    end

    RESULT_DELETE(["remove_clone() × N<br/>MUTABLE: deleted[]<br/>DERIVED: to_delete list"])
    RESULT_PRESERVE(["preserved on disk<br/>error-status clones<br/>manual investigation"])

    %% REGISTRATION FLOW %%
    REG_IN --> GATE_KITCHEN
    GATE_KITCHEN -->|kitchen_id valid| GATE_STATUS
    GATE_KITCHEN -->|kitchen_id empty| GATE_KITCHEN_ERR["registered=false<br/>no active kitchen"]
    GATE_STATUS -->|valid| GATE_OWNER
    GATE_OWNER -->|owner non-empty| FLOCK
    FLOCK --> FIELD_PATH
    FLOCK --> FIELD_STATUS
    FLOCK --> FIELD_OWNER

    %% CLEANUP FLOW %%
    CLEANUP_IN --> SCOPE_CHECK
    SCOPE_CHECK -->|"false (default)"| GATE_EMPTY_K
    SCOPE_CHECK -->|true| SCOPE_ALL
    GATE_EMPTY_K -->|kitchen_id present| SCOPE_KITCHEN
    GATE_EMPTY_K -->|kitchen_id empty| CLEANUP_ERR["deleted=[], error:<br/>pass all_owners='true'<br/>to force-cleanup"]
    SCOPE_KITCHEN --> FILTER_FN
    SCOPE_ALL --> FILTER_FN
    LEGACY -.->|visible only via owner=None| FILTER_FN
    FIELD_OWNER -.->|read back at cleanup| FILTER_FN
    FILTER_FN --> PARTITION
    PARTITION --> RESULT_DELETE
    PARTITION --> RESULT_PRESERVE

    %% RECIPE VALIDATOR READS PARAM TABLE %%
    CLEANUP_IN -.->|recipe YAML validation| RULE_PARAMS

    %% CLASS ASSIGNMENTS %%
    class REG_IN,CLEANUP_IN terminal;
    class GATE_KITCHEN,GATE_OWNER detector;
    class GATE_STATUS detector;
    class GATE_EMPTY_K detector;
    class FLOCK phase;
    class FIELD_PATH,FIELD_STATUS stateNode;
    class FIELD_OWNER handler;
    class LEGACY gap;
    class SCOPE_CHECK phase;
    class SCOPE_KITCHEN,SCOPE_ALL output;
    class FILTER_FN,PARTITION phase;
    class RULE_PARAMS stateNode;
    class RESULT_DELETE,RESULT_PRESERVE output;
    class GATE_KITCHEN_ERR,CLEANUP_ERR gap;
```

### Concurrency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 45, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;

    %% ── ENTRY ── %%
    START([FastMCP Event Loop<br/>receives tool call])

    %% ── ASYNC LAYER ── %%
    subgraph AsyncLayer ["ASYNC EVENT LOOP  (single-threaded, per kitchen process)"]
        direction TB
        CTX_RESET["● clear_contextvars()<br/>━━━━━━━━━━<br/>thread-local log reset<br/>per invocation"]
        KITCHEN_GUARD{"kitchen_id<br/>empty?"}
        ERROR_NO_KIT["return error<br/>━━━━━━━━━━<br/>no active kitchen"]
        OWNERS_CHECK{"all_owners<br/>== 'true'?"}
        DISPATCH_REG["await asyncio.to_thread(<br/>━━━━━━━━━━<br/>register_clone, owner=kitchen_id)"]
        DISPATCH_CLEAN["await asyncio.to_thread(<br/>━━━━━━━━━━<br/>batch_delete, owner_filter)"]
        BARRIER["await result<br/>━━━━━━━━━━<br/>event loop resumes here"]
    end

    %% ── THREAD POOL ── %%
    subgraph ThreadPool ["DEFAULT ThreadPoolExecutor  (asyncio.to_thread workers)"]
        direction LR
        REG_WORKER["● register_clone()<br/>━━━━━━━━━━<br/>owner=kitchen_id<br/>validates non-empty"]
        CLEAN_WORKER["● batch_delete()<br/>━━━━━━━━━━<br/>owner_filter scoped<br/>or None (all-owners)"]
    end

    %% ── FILE LOCK ── %%
    subgraph FileLock ["CROSS-PROCESS MUTEX  (fcntl.LOCK_EX on .lock sidecar)"]
        direction TB
        LOCK_ACQ["● fcntl.LOCK_EX<br/>━━━━━━━━━━<br/>.lock sidecar file<br/>blocks concurrent writers"]
        READ_REG["read registry JSON<br/>━━━━━━━━━━<br/>full snapshot while locked"]
        APPEND["append entry<br/>━━━━━━━━━━<br/>{path, status, owner}"]
        ATOMIC["● atomic_write<br/>━━━━━━━━━━<br/>tmp → rename<br/>crash-safe"]
        LOCK_REL["fcntl.LOCK_UN<br/>━━━━━━━━━━<br/>next writer unblocked"]
    end

    %% ── OWNER SCOPING ── %%
    subgraph OwnerScope ["OWNER SCOPING  (session isolation layer)"]
        direction TB
        FILTER["● _entry_matches_owner()<br/>━━━━━━━━━━<br/>entry.owner == kitchen_id<br/>legacy entries hidden"]
        ESCAPE["● all_owners='true'<br/>━━━━━━━━━━<br/>operator escape hatch<br/>bypasses owner filter"]
        SPLIT["partition to_delete<br/>━━━━━━━━━━<br/>status==success → delete<br/>status==error → preserve"]
    end

    %% ── PARALLEL KITCHENS (cross-process) ── %%
    subgraph Parallel ["PARALLEL KITCHEN PROCESSES  (each runs identical flow above)"]
        direction LR
        KIT_A["Kitchen A<br/>━━━━━━━━━━<br/>kitchen_id=kit-A<br/>own registry entries only"]
        KIT_B["Kitchen B<br/>━━━━━━━━━━<br/>kitchen_id=kit-B<br/>own registry entries only"]
    end

    %% ── REGISTRY ── %%
    REGISTRY[("● clone-cleanup-registry.json<br/>━━━━━━━━━━<br/>shared across all kitchens<br/>entries tagged by owner")]

    %% ── END ── %%
    END([return result to MCP caller])

    %% ── FLOWS ── %%
    START --> CTX_RESET
    CTX_RESET --> KITCHEN_GUARD
    KITCHEN_GUARD -->|"empty"| ERROR_NO_KIT
    KITCHEN_GUARD -->|"register path"| DISPATCH_REG
    KITCHEN_GUARD -->|"cleanup path"| OWNERS_CHECK
    OWNERS_CHECK -->|"no (default)"| DISPATCH_CLEAN
    OWNERS_CHECK -->|"yes"| ESCAPE

    DISPATCH_REG --> REG_WORKER
    DISPATCH_CLEAN --> CLEAN_WORKER
    ESCAPE --> CLEAN_WORKER

    REG_WORKER --> LOCK_ACQ
    LOCK_ACQ --> READ_REG --> APPEND --> ATOMIC --> LOCK_REL
    LOCK_REL --> BARRIER

    CLEAN_WORKER --> FILTER
    FILTER --> SPLIT
    SPLIT --> BARRIER

    BARRIER --> END

    %% cross-process parallel writers serialize on lock
    KIT_A -.->|"concurrent register"| LOCK_ACQ
    KIT_B -.->|"blocked until lock free"| LOCK_ACQ

    %% registry is shared state
    ATOMIC -->|"write"| REGISTRY
    FILTER -->|"read snapshot"| REGISTRY

    %% class assignments
    class START,END terminal;
    class CTX_RESET,KITCHEN_GUARD,OWNERS_CHECK stateNode;
    class ERROR_NO_KIT gap;
    class DISPATCH_REG,DISPATCH_CLEAN,BARRIER phase;
    class REG_WORKER,CLEAN_WORKER handler;
    class LOCK_ACQ,LOCK_REL detector;
    class READ_REG,APPEND phase;
    class ATOMIC output;
    class FILTER,ESCAPE,SPLIT newComponent;
    class REGISTRY stateNode;
    class KIT_A,KIT_B terminal;
```

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 55, 'rankSpacing': 80, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph L3 ["L3 — SERVER LAYER"]
        direction LR
        TOOLS_CLONE["● server/tools_clone.py<br/>━━━━━━━━━━<br/>MCP tools: clone_repo,<br/>remove_clone, register_clone_status,<br/>batch_cleanup_clones<br/>(plumbs kitchen_id as owner)"]
        HELPERS["server/helpers.py<br/>━━━━━━━━━━<br/>Facade + re-export bridge<br/>clone_registry re-exported<br/>for tools_clone.py"]
    end

    subgraph L2 ["L2 — RECIPE VALIDATION LAYER"]
        direction LR
        RULES_TOOLS["● recipe/rules_tools.py<br/>━━━━━━━━━━<br/>Semantic rules: unknown-tool,<br/>subset-disabled-tool,<br/>dead-with-param<br/>(registers all_owners param)"]
        RECIPE_REGISTRY["recipe/registry.py<br/>━━━━━━━━━━<br/>RuleFinding, semantic_rule<br/>_RULE_REGISTRY, run_semantic_rules"]
        RECIPE_ANALYSIS["recipe/_analysis.py<br/>━━━━━━━━━━<br/>ValidationContext<br/>make_validation_context"]
    end

    subgraph L1 ["L1 — WORKSPACE LAYER"]
        direction LR
        CLONE_REGISTRY["● workspace/clone_registry.py<br/>━━━━━━━━━━<br/>register_clone(owner=...)<br/>cleanup_candidates(owner=...)<br/>batch_delete(owner=...)<br/>File-locked JSON registry"]
    end

    subgraph L0 ["L0 — CORE FOUNDATION"]
        direction LR
        CORE_CONSTANTS["core/_type_constants.py<br/>━━━━━━━━━━<br/>GATED_TOOLS, HEADLESS_TOOLS<br/>UNGATED_TOOLS, TOOL_SUBSET_TAGS<br/>Severity"]
        CORE_IO["core/io.py + logging.py<br/>━━━━━━━━━━<br/>atomic_write, resolve_temp_dir<br/>get_logger"]
    end

    %% L3 → L3 (same-layer: tools_clone → helpers) %%
    TOOLS_CLONE -->|"imports: _notify, _require_enabled,<br/>clone_registry, track_response_size"| HELPERS

    %% L3 → L0 %%
    TOOLS_CLONE -->|"get_logger"| CORE_IO

    %% L3 → L1 (via helpers re-export bridge) %%
    HELPERS -->|"re-exports clone_registry<br/>(noqa: F401)"| CLONE_REGISTRY

    %% L3 helpers → L0 %%
    HELPERS -->|"atomic_write, get_logger<br/>resolve_temp_dir"| CORE_IO

    %% L2 → L2 (same-layer) %%
    RULES_TOOLS -->|"RuleFinding, semantic_rule"| RECIPE_REGISTRY
    RULES_TOOLS -->|"ValidationContext"| RECIPE_ANALYSIS
    RECIPE_REGISTRY -->|"ValidationContext<br/>make_validation_context"| RECIPE_ANALYSIS

    %% L2 → L0 %%
    RULES_TOOLS -->|"GATED_TOOLS, HEADLESS_TOOLS<br/>UNGATED_TOOLS, TOOL_SUBSET_TAGS<br/>Severity"| CORE_CONSTANTS
    RECIPE_REGISTRY -->|"Severity"| CORE_CONSTANTS

    %% L1 → L0 %%
    CLONE_REGISTRY -->|"atomic_write, get_logger<br/>resolve_temp_dir"| CORE_IO

    %% CLASS ASSIGNMENTS %%
    class TOOLS_CLONE cli;
    class HELPERS handler;
    class RULES_TOOLS,RECIPE_REGISTRY,RECIPE_ANALYSIS phase;
    class CLONE_REGISTRY stateNode;
    class CORE_CONSTANTS,CORE_IO integration;
```

Closes #757

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260412-092010-886732/.autoskillit/temp/make-plan/clone_registry_owner_scoping_plan_2026-04-12_092354.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 215 | 23.3k | 1.3M | 144.1k | 1 | 5m 40s |
| verify | 150 | 16.7k | 909.8k | 76.7k | 1 | 4m 31s |
| implement | 2.5k | 32.9k | 3.7M | 93.0k | 1 | 8m 45s |
| fix | 174 | 5.7k | 838.5k | 41.4k | 1 | 5m 46s |
| prepare_pr | 86 | 5.0k | 246.1k | 34.7k | 1 | 1m 32s |
| run_arch_lenses | 3.6k | 22.0k | 735.1k | 101.4k | 3 | 7m 48s |
| compose_pr | 59 | 7.7k | 198.4k | 29.7k | 1 | 1m 57s |
| **Total** | 6.8k | 113.2k | 7.9M | 521.0k | | 36m 2s |