### PR TITLE
fix: route_queue_mode — handle queue + autoMergeAllowed=false

### DIFF
--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -749,8 +749,10 @@ steps:
     on_result:
       - when: "${{ inputs.auto_merge }} != 'true'"
         route: register_clone_success
-      - when: "${{ context.queue_available }} == true and ${{ context.merge_group_trigger }} == true"
+      - when: "${{ context.queue_available }} == true and ${{ context.merge_group_trigger }} == true and ${{ context.auto_merge_available }} == true"
         route: enable_auto_merge
+      - when: "${{ context.queue_available }} == true and ${{ context.merge_group_trigger }} == true and ${{ context.auto_merge_available }} == false"
+        route: queue_enqueue_no_auto
       - when: "${{ context.auto_merge_available }} == true"
         route: direct_merge
       - route: immediate_merge
@@ -768,6 +770,24 @@ steps:
     note: >
       Submits the PR to the merge queue. On failure (PR not mergeable, already merged),
       degrades to register_clone_success.
+
+  queue_enqueue_no_auto:
+    tool: run_cmd
+    with:
+      cmd: "gh pr merge '${{ context.pr_number }}' --squash"
+      cwd: "${{ context.work_dir }}"
+      step_name: "queue_enqueue_no_auto"
+    on_success: wait_for_queue
+    on_failure: register_clone_success
+    skip_when_false: "inputs.open_pr"
+    note: >
+      Submits the PR to the merge queue when the target branch has a configured
+      merge queue but the repository disallows auto-merge (autoMergeAllowed=false).
+      Uses plain `gh pr merge --squash` (no --auto, which would be rejected by
+      GitHub's API auto-merge gate). GitHub intercepts the call and enqueues
+      the PR because the branch has a queue. Routes to wait_for_queue (the
+      shared queue waiter) — never to wait_for_immediate_merge, whose 5-minute
+      poll is too short for queue serialization.
 
   wait_for_queue:
     tool: wait_for_merge_queue

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -699,8 +699,10 @@ steps:
     on_result:
       - when: "${{ inputs.auto_merge }} != 'true'"
         route: register_clone_success
-      - when: "${{ context.queue_available }} == true and ${{ context.merge_group_trigger }} == true"
+      - when: "${{ context.queue_available }} == true and ${{ context.merge_group_trigger }} == true and ${{ context.auto_merge_available }} == true"
         route: enable_auto_merge
+      - when: "${{ context.queue_available }} == true and ${{ context.merge_group_trigger }} == true and ${{ context.auto_merge_available }} == false"
+        route: queue_enqueue_no_auto
       - when: "${{ context.auto_merge_available }} == true"
         route: direct_merge
       - route: immediate_merge
@@ -718,6 +720,24 @@ steps:
     note: >
       Submits the PR to the merge queue. On failure (PR not mergeable, already merged),
       degrades to register_clone_success.
+
+  queue_enqueue_no_auto:
+    tool: run_cmd
+    with:
+      cmd: "gh pr merge '${{ context.pr_number }}' --squash"
+      cwd: "${{ context.work_dir }}"
+      step_name: "queue_enqueue_no_auto"
+    on_success: wait_for_queue
+    on_failure: register_clone_success
+    skip_when_false: "inputs.open_pr"
+    note: >
+      Submits the PR to the merge queue when the target branch has a configured
+      merge queue but the repository disallows auto-merge (autoMergeAllowed=false).
+      Uses plain `gh pr merge --squash` (no --auto, which would be rejected by
+      GitHub's API auto-merge gate). GitHub intercepts the call and enqueues
+      the PR because the branch has a queue. Routes to wait_for_queue (the
+      shared queue waiter) — never to wait_for_immediate_merge, whose 5-minute
+      poll is too short for queue serialization.
 
   wait_for_queue:
     tool: wait_for_merge_queue

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -674,8 +674,10 @@ steps:
     on_result:
       - when: "${{ inputs.auto_merge }} != 'true'"
         route: register_clone_success
-      - when: "${{ context.queue_available }} == true and ${{ context.merge_group_trigger }} == true"
+      - when: "${{ context.queue_available }} == true and ${{ context.merge_group_trigger }} == true and ${{ context.auto_merge_available }} == true"
         route: enable_auto_merge
+      - when: "${{ context.queue_available }} == true and ${{ context.merge_group_trigger }} == true and ${{ context.auto_merge_available }} == false"
+        route: queue_enqueue_no_auto
       - when: "${{ context.auto_merge_available }} == true"
         route: direct_merge
       - route: immediate_merge
@@ -693,6 +695,24 @@ steps:
     note: >
       Submits the PR to the merge queue. On failure (PR not mergeable, already merged),
       degrades to register_clone_success.
+
+  queue_enqueue_no_auto:
+    tool: run_cmd
+    with:
+      cmd: "gh pr merge '${{ context.pr_number }}' --squash"
+      cwd: "${{ context.work_dir }}"
+      step_name: "queue_enqueue_no_auto"
+    on_success: wait_for_queue
+    on_failure: register_clone_success
+    skip_when_false: "inputs.open_pr"
+    note: >
+      Submits the PR to the merge queue when the target branch has a configured
+      merge queue but the repository disallows auto-merge (autoMergeAllowed=false).
+      Uses plain `gh pr merge --squash` (no --auto, which would be rejected by
+      GitHub's API auto-merge gate). GitHub intercepts the call and enqueues
+      the PR because the branch has a queue. Routes to wait_for_queue (the
+      shared queue waiter) — never to wait_for_immediate_merge, whose 5-minute
+      poll is too short for queue serialization.
 
   wait_for_queue:
     tool: wait_for_merge_queue

--- a/src/autoskillit/server/_lifespan.py
+++ b/src/autoskillit/server/_lifespan.py
@@ -21,10 +21,12 @@ logger = get_logger(__name__)
 async def _autoskillit_lifespan(server: Any) -> Any:
     """Server lifecycle: teardown recording on shutdown."""
     logger.info("lifespan_started")
-    yield
-    ctx = _get_ctx_or_none()
-    if ctx is not None and isinstance(ctx.runner, RecordingSubprocessRunner):
-        try:
-            ctx.runner.recorder.finalize()
-        except Exception:
-            logger.exception("recorder.finalize() failed during lifespan teardown")
+    try:
+        yield
+    finally:
+        ctx = _get_ctx_or_none()
+        if ctx is not None and isinstance(ctx.runner, RecordingSubprocessRunner):
+            try:
+                ctx.runner.recorder.finalize()
+            except Exception:
+                logger.exception("recorder.finalize() failed during lifespan teardown")

--- a/src/autoskillit/skills/sous-chef/SKILL.md
+++ b/src/autoskillit/skills/sous-chef/SKILL.md
@@ -241,28 +241,39 @@ Capture the result as `auto_merge_available`. If detection fails, default to `"f
 perform both detections automatically via `check_merge_queue` + `check_auto_merge` —
 **do not repeat them manually when following a recipe**.
 
-### 2. Route based on queue availability
+### 2. Route based on queue availability and auto-merge availability
 
-**When `queue_available == true`:**
-GitHub's merge queue serializes concurrent merges. Each pipeline's
-`enable_auto_merge → wait_for_queue` sequence is safe to proceed in parallel — the
-queue handles ordering. No additional sequencing is required from the orchestrator.
+The recipes route on the four-cell matrix `queue_available × auto_merge_available`:
 
-**When `queue_available == false` and `auto_merge_available == true`:**
-Use `gh pr merge --squash --auto` (direct_merge path). GitHub merges the PR once
-all required status checks pass. PRs must not be merged concurrently — never execute
-two `direct_merge` steps concurrently on a non-queue branch.
+| `queue_available` | `auto_merge_available` | Recipe path                                    |
+|-------------------|------------------------|------------------------------------------------|
+| `true`            | `true`                 | `enable_auto_merge` → `wait_for_queue`         |
+| `true`            | `false`                | `queue_enqueue_no_auto` → `wait_for_queue`     |
+| `false`           | `true`                 | `direct_merge` → `wait_for_direct_merge`       |
+| `false`           | `false`                | `immediate_merge` → `wait_for_immediate_merge` |
 
-**When `queue_available == false` and `auto_merge_available == false`:**
-Use `gh pr merge --squash` (immediate_merge path — no `--auto` flag). GitHub
-executes the merge synchronously without waiting for status checks (there are none
-to wait for when `autoMergeAllowed=false`). PRs MUST still be merged one at a time.
+**When `queue_available == true`:** GitHub's merge queue intercepts every merge
+request on the branch regardless of the `--auto` flag. Both queue cells route
+through `wait_for_queue` (the merge-queue-aware waiter). The
+`enable_auto_merge` cell uses `--auto` so the queue serializes via GitHub
+auto-merge; the `queue_enqueue_no_auto` cell (condition:
+`queue_available == true and auto_merge_available == false`) uses plain `--squash`
+because the repository's `autoMergeAllowed=false` setting causes `--auto` to be
+rejected by the API auto-merge gate **before** the queue interception.
 
-- If following a recipe: the recipe's `route_queue_mode` step routes to the correct
-  path automatically based on `context.auto_merge_available`.
-- **NEVER** use `gh pr merge --squash --auto` when `auto_merge_available == false` —
-  this command fails with "auto-merge is not allowed for this repository"; in recipe
-  context it silently routes to `confirm_cleanup`, leaving the PR unmerged.
+**When `queue_available == false`:** there is no queue, so behaviour matches
+the historical paths — `direct_merge` waits via auto-merge, `immediate_merge`
+executes synchronously.
+
+- If following a recipe: `route_queue_mode` selects the correct cell
+  automatically from `context.queue_available` and `context.auto_merge_available`.
+- **NEVER** use `gh pr merge --squash --auto` when `auto_merge_available == false`,
+  regardless of `queue_available`. The `--auto` flag is rejected by GitHub's API
+  auto-merge gate before the queue intercepts. Use plain `gh pr merge --squash`;
+  if a queue exists on the branch the queue still enqueues the call.
+- **NEVER** route a queue+no-auto enqueue call through `wait_for_immediate_merge`
+  — its 5-minute poll is too short for a busy queue and on timeout the recipe
+  reports `merge unconfirmed` even though the PR will eventually merge.
 
 For ad-hoc (off-recipe) merges:
 - If merging multiple PRs collected from parallel pipelines: route through the
@@ -272,7 +283,7 @@ For ad-hoc (off-recipe) merges:
 
 **NEVER use `run_cmd` with `gh pr merge` to merge a PR outside of a named recipe
 step.** All PR merges must flow through the recipe's `merge_pr`, `direct_merge`,
-`immediate_merge`, or `enable_auto_merge` steps. Bypassing these steps skips CI
+`immediate_merge`, `enable_auto_merge` or `queue_enqueue_no_auto` steps. Bypassing these steps skips CI
 enforcement, conflict detection, and conflict routing.
 
 ### 4. Merge conflict failure handling

--- a/src/autoskillit/skills/sous-chef/SKILL.md
+++ b/src/autoskillit/skills/sous-chef/SKILL.md
@@ -267,7 +267,7 @@ executes synchronously.
 
 - If following a recipe: `route_queue_mode` selects the correct cell
   automatically from `context.queue_available` and `context.auto_merge_available`.
-- **NEVER** use `gh pr merge --squash --auto` when `auto_merge_available == false`,
+- **NEVER use** `gh pr merge --squash --auto` when `auto_merge_available == false`,
   regardless of `queue_available`. The `--auto` flag is rejected by GitHub's API
   auto-merge gate before the queue intercepts. Use plain `gh pr merge --squash`;
   if a queue exists on the branch the queue still enqueues the call.

--- a/tests/contracts/test_sous_chef_routing.py
+++ b/tests/contracts/test_sous_chef_routing.py
@@ -72,3 +72,34 @@ class TestSousChefStaleRouting:
             "sous-chef/SKILL.md must contain 'subtype: stale' or 'subtype=stale' as a "
             "compound routing discriminant, not just the words 'stale' and 'subtype' separately"
         )
+
+
+def _extract_merge_phase_section(skill_md: str) -> str:
+    """Extract text from '## MERGE PHASE' up to the next top-level '## ' heading."""
+    lines = skill_md.splitlines()
+    in_section = False
+    extracted: list[str] = []
+    for line in lines:
+        if line.startswith("## MERGE PHASE"):
+            in_section = True
+            extracted.append(line)
+            continue
+        if in_section and line.startswith("## ") and "MERGE PHASE" not in line:
+            break
+        if in_section:
+            extracted.append(line)
+    return "\n".join(extracted)
+
+
+def test_sous_chef_merge_phase_documents_queue_no_auto_path() -> None:
+    """MERGE PHASE section must document the queue_enqueue_no_auto routing cell."""
+    skill_md = _sous_chef_text()
+    merge_phase = _extract_merge_phase_section(skill_md)
+    assert merge_phase, "MERGE PHASE section not found in sous-chef/SKILL.md"
+    assert "queue_enqueue_no_auto" in merge_phase, (
+        "MERGE PHASE section must document the queue_enqueue_no_auto step"
+    )
+    assert "queue_available == true and auto_merge_available == false" in merge_phase, (
+        "MERGE PHASE section must document the condition "
+        "'queue_available == true and auto_merge_available == false'"
+    )

--- a/tests/recipe/test_merge_prs_queue.py
+++ b/tests/recipe/test_merge_prs_queue.py
@@ -623,7 +623,11 @@ def test_route_queue_mode_has_auto_merge_available_condition(any_recipe) -> None
 def test_route_queue_mode_auto_merge_available_routes_to_direct_merge(any_recipe) -> None:
     step = any_recipe.steps["route_queue_mode"]
     cond = next(
-        c for c in step.on_result.conditions if c.when and "auto_merge_available" in c.when
+        c
+        for c in step.on_result.conditions
+        if c.when
+        and "auto_merge_available" in c.when
+        and "queue_available" not in c.when
     )
     assert cond.when == "${{ context.auto_merge_available }} == true"
     assert cond.route == "direct_merge"
@@ -870,3 +874,125 @@ def test_wait_for_queue_ejected_ci_failure_precedes_ejected(recipe_fixture, requ
         "ejected_ci_failure route must appear before generic ejected route "
         "to prevent CI failure ejections from being handled as conflict ejections"
     )
+
+
+# ---------------------------------------------------------------------------
+# Routing matrix exhaustiveness — queue_available × auto_merge_available
+# ---------------------------------------------------------------------------
+
+
+def test_route_queue_mode_queue_with_auto_routes_to_enable_auto_merge(any_recipe) -> None:
+    """queue+auto cell must route to enable_auto_merge."""
+    step = any_recipe.steps["route_queue_mode"]
+    cond = next(
+        c
+        for c in step.on_result.conditions
+        if c.when
+        and "queue_available" in c.when
+        and "merge_group_trigger" in c.when
+        and "auto_merge_available" in c.when
+        and "== true" in c.when.split("auto_merge_available")[1]
+    )
+    assert cond.route == "enable_auto_merge"
+
+
+def test_route_queue_mode_queue_without_auto_routes_to_queue_enqueue_no_auto(
+    any_recipe,
+) -> None:
+    """queue+no-auto cell must route to queue_enqueue_no_auto."""
+    step = any_recipe.steps["route_queue_mode"]
+    cond = next(
+        c
+        for c in step.on_result.conditions
+        if c.when
+        and "queue_available" in c.when
+        and "merge_group_trigger" in c.when
+        and "auto_merge_available" in c.when
+        and "== false" in c.when.split("auto_merge_available")[1]
+    )
+    assert cond.route == "queue_enqueue_no_auto"
+
+
+def test_route_queue_mode_no_queue_with_auto_routes_to_direct_merge(any_recipe) -> None:
+    """no-queue+auto cell must route to direct_merge."""
+    step = any_recipe.steps["route_queue_mode"]
+    cond = next(
+        c
+        for c in step.on_result.conditions
+        if c.when
+        and "auto_merge_available" in c.when
+        and "queue_available" not in c.when
+    )
+    assert cond.route == "direct_merge"
+
+
+def test_route_queue_mode_no_queue_no_auto_falls_through_to_immediate_merge(
+    any_recipe,
+) -> None:
+    """Default (when is None) condition must route to immediate_merge."""
+    step = any_recipe.steps["route_queue_mode"]
+    cond = next(c for c in step.on_result.conditions if c.when is None)
+    assert cond.route == "immediate_merge"
+
+
+def test_route_queue_mode_never_routes_to_enable_auto_merge_when_auto_unavailable(
+    any_recipe,
+) -> None:
+    """Every condition routing to enable_auto_merge must require auto_merge_available == true."""
+    step = any_recipe.steps["route_queue_mode"]
+    for cond in step.on_result.conditions:
+        if cond.route == "enable_auto_merge":
+            assert cond.when is not None
+            assert "auto_merge_available" in cond.when
+            assert "}} == true" in cond.when.split("auto_merge_available")[1], (
+                f"enable_auto_merge route must require auto_merge_available == true; got: {cond.when}"
+            )
+
+
+def test_enable_auto_merge_route_count(any_recipe) -> None:
+    """Exactly one condition must route to enable_auto_merge."""
+    step = any_recipe.steps["route_queue_mode"]
+    count = sum(1 for c in step.on_result.conditions if c.route == "enable_auto_merge")
+    assert count == 1, f"Expected exactly 1 enable_auto_merge route, got {count}"
+
+
+# ---------------------------------------------------------------------------
+# New step: queue_enqueue_no_auto
+# ---------------------------------------------------------------------------
+
+
+def test_queue_enqueue_no_auto_step_exists(any_recipe) -> None:
+    assert "queue_enqueue_no_auto" in any_recipe.steps
+
+
+def test_queue_enqueue_no_auto_is_run_cmd(any_recipe) -> None:
+    step = any_recipe.steps["queue_enqueue_no_auto"]
+    assert step.tool == "run_cmd"
+
+
+def test_queue_enqueue_no_auto_uses_plain_squash(any_recipe) -> None:
+    """queue_enqueue_no_auto must use --squash without --auto."""
+    step = any_recipe.steps["queue_enqueue_no_auto"]
+    cmd = step.with_args.get("cmd", "")
+    assert "--squash" in cmd
+    assert "--auto" not in cmd
+
+
+def test_queue_enqueue_no_auto_routes_to_wait_for_queue(any_recipe) -> None:
+    step = any_recipe.steps["queue_enqueue_no_auto"]
+    assert step.on_success == "wait_for_queue"
+
+
+def test_queue_enqueue_no_auto_failure_routes_to_register_clone_success(any_recipe) -> None:
+    step = any_recipe.steps["queue_enqueue_no_auto"]
+    assert step.on_failure == "register_clone_success"
+
+
+def test_queue_enqueue_no_auto_skip_when_false(any_recipe) -> None:
+    step = any_recipe.steps["queue_enqueue_no_auto"]
+    assert step.skip_when_false == "inputs.open_pr"
+
+
+def test_queue_enqueue_no_auto_step_name(any_recipe) -> None:
+    step = any_recipe.steps["queue_enqueue_no_auto"]
+    assert step.with_args["step_name"] == "queue_enqueue_no_auto"

--- a/tests/recipe/test_merge_prs_queue.py
+++ b/tests/recipe/test_merge_prs_queue.py
@@ -625,9 +625,7 @@ def test_route_queue_mode_auto_merge_available_routes_to_direct_merge(any_recipe
     cond = next(
         c
         for c in step.on_result.conditions
-        if c.when
-        and "auto_merge_available" in c.when
-        and "queue_available" not in c.when
+        if c.when and "auto_merge_available" in c.when and "queue_available" not in c.when
     )
     assert cond.when == "${{ context.auto_merge_available }} == true"
     assert cond.route == "direct_merge"
@@ -919,9 +917,7 @@ def test_route_queue_mode_no_queue_with_auto_routes_to_direct_merge(any_recipe) 
     cond = next(
         c
         for c in step.on_result.conditions
-        if c.when
-        and "auto_merge_available" in c.when
-        and "queue_available" not in c.when
+        if c.when and "auto_merge_available" in c.when and "queue_available" not in c.when
     )
     assert cond.route == "direct_merge"
 
@@ -945,7 +941,8 @@ def test_route_queue_mode_never_routes_to_enable_auto_merge_when_auto_unavailabl
             assert cond.when is not None
             assert "auto_merge_available" in cond.when
             assert "}} == true" in cond.when.split("auto_merge_available")[1], (
-                f"enable_auto_merge route must require auto_merge_available == true; got: {cond.when}"
+                "enable_auto_merge route must require auto_merge_available == true; "
+                f"got: {cond.when}"
             )
 
 

--- a/tests/server/test_lifespan.py
+++ b/tests/server/test_lifespan.py
@@ -1,5 +1,6 @@
 """Tests that the FastMCP lifespan calls recorder.finalize() on server shutdown."""
 
+import asyncio
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -46,3 +47,27 @@ async def test_lifespan_skips_finalize_when_ctx_is_none():
     with patch("autoskillit.server._lifespan._get_ctx_or_none", return_value=None):
         async with _autoskillit_lifespan(MagicMock()):
             pass  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_lifespan_calls_finalize_on_cancellation():
+    """finalize() is called even when the lifespan task is cancelled (SIGTERM path).
+
+    Regression guard for issue #745: the try/finally in _autoskillit_lifespan must
+    ensure finalize() runs when CancelledError is thrown at the yield point, which
+    is exactly what anyio does when KeyboardInterrupt cancels the running task group.
+    """
+    from autoskillit.server import _autoskillit_lifespan
+
+    mock_recorder = MagicMock()
+    mock_runner = MagicMock(spec=RecordingSubprocessRunner)
+    mock_runner.recorder = mock_recorder
+    mock_ctx = MagicMock()
+    mock_ctx.runner = mock_runner
+
+    with patch("autoskillit.server._lifespan._get_ctx_or_none", return_value=mock_ctx):
+        with pytest.raises(asyncio.CancelledError):
+            async with _autoskillit_lifespan(MagicMock()):
+                raise asyncio.CancelledError
+
+    mock_recorder.finalize.assert_called_once()


### PR DESCRIPTION
## Summary

Fix the `route_queue_mode` routing block in `implementation.yaml`,
`implementation-groups.yaml`, and `remediation.yaml` so that a target branch with
**both** a configured merge queue and `autoMergeAllowed=false` on the repository
no longer routes to `enable_auto_merge` (which calls `gh pr merge --squash --auto`
and is rejected by GitHub's API auto-merge gate).

The fix introduces an explicit four-cell routing matrix over `queue_available ×
auto_merge_available`, adds a new pipeline step `queue_enqueue_no_auto` that runs
plain `gh pr merge --squash` and waits via the existing `wait_for_queue` step,
and updates the `sous-chef` MERGE PHASE rules so the kitchen contract matches
the new recipe shape.

After the fix, all four (queue × auto) combinations have a single safe route:

| `queue_available` | `auto_merge_available` | Routes to                                  |
|-------------------|------------------------|--------------------------------------------|
| `true`            | `true`                 | `enable_auto_merge` → `wait_for_queue`     |
| `true`            | `false`                | `queue_enqueue_no_auto` → `wait_for_queue` |
| `false`           | `true`                 | `direct_merge` → `wait_for_direct_merge`   |
| `false`           | `false`                | `immediate_merge` → `wait_for_immediate_merge` |

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START<br/>ci_watch passes])
    DONE([DONE<br/>register_clone_success → done])
    SKIP([SKIP<br/>auto_merge input disabled<br/>PR left open for human])

    subgraph Detection ["Detection Pipeline (shared by all 3 recipes)"]
        direction TB
        CMQ["check_merge_queue<br/>━━━━━━━━━━<br/>GraphQL: active queue on base_branch?<br/>captures: queue_available<br/>skip_when_false: open_pr"]
        CMGT["check_merge_group_trigger<br/>━━━━━━━━━━<br/>grep workflows for merge_group trigger<br/>captures: merge_group_trigger<br/>on_success + on_failure → check_auto_merge"]
        CAM["check_auto_merge<br/>━━━━━━━━━━<br/>GraphQL: autoMergeAllowed?<br/>captures: auto_merge_available<br/>on_success + on_failure → route_queue_mode"]
    end

    subgraph Routing ["● route_queue_mode — 5-Branch Priority Matrix (action: route)"]
        direction TB
        RQM{"● route_queue_mode<br/>━━━━━━━━━━<br/>Priority dispatch — evaluated top-down<br/>auto_merge bypass checked FIRST"}
    end

    subgraph QueueAuto ["Queue Path — auto_merge_available = true"]
        direction TB
        EAM["enable_auto_merge<br/>━━━━━━━━━━<br/>gh pr merge --squash --auto<br/>GitHub enqueues PR into merge queue"]
    end

    subgraph QueueNoAuto ["● Queue Path — auto_merge_available = false"]
        direction TB
        QENA["● queue_enqueue_no_auto<br/>━━━━━━━━━━<br/>gh pr merge --squash  (no --auto flag)<br/>repo disallows autoMergeAllowed<br/>GitHub still enqueues via active queue<br/>on_failure → register_clone_success"]
    end

    subgraph WaitQueue ["Wait for Queue (timeout: 900s)"]
        direction TB
        WFQ["wait_for_queue<br/>━━━━━━━━━━<br/>tool: wait_for_merge_queue<br/>outcomes: merged | ejected_ci_failure | ejected | stalled | timeout"]
        RSP["reenroll_stalled_pr<br/>━━━━━━━━━━<br/>tool: toggle_auto_merge<br/>disable → re-enable to unstall PR"]
        EJCI["diagnose_ci → resolve_ci → re_push<br/>━━━━━━━━━━<br/>CI failure ejection path<br/>loops back via ci_watch"]
        EJCON["queue_ejected_fix<br/>━━━━━━━━━━<br/>run_skill: resolve-merge-conflicts (retries: 1)<br/>→ re_push_queue_fix → ci_watch_post_queue_fix<br/>→ reenter_merge_queue → wait_for_queue"]
    end

    subgraph DirectPath ["Direct Merge Path — auto_merge_available=true, no queue/trigger"]
        direction TB
        DM["direct_merge<br/>━━━━━━━━━━<br/>gh pr merge --squash --auto<br/>GitHub merges when checks pass (no queue)"]
        WDM["wait_for_direct_merge<br/>━━━━━━━━━━<br/>poll 90×10s = 15 min max<br/>outcomes: merged | closed | timeout"]
        DMCF["direct_merge_conflict_fix<br/>━━━━━━━━━━<br/>run_skill: resolve-merge-conflicts (retries: 1)<br/>→ re_push_direct_fix → redirect_merge<br/>→ loops back to wait_for_direct_merge"]
    end

    subgraph ImmPath ["Immediate Merge Path — no auto-merge, no queue"]
        direction TB
        IM["immediate_merge<br/>━━━━━━━━━━<br/>gh pr merge --squash  (no --auto)<br/>Synchronous squash merge"]
        WIM["wait_for_immediate_merge<br/>━━━━━━━━━━<br/>poll 30×10s = 5 min max<br/>outcomes: merged | closed | timeout"]
        IMCF["immediate_merge_conflict_fix<br/>━━━━━━━━━━<br/>run_skill: resolve-merge-conflicts (retries: 1)<br/>→ re_push_immediate_fix → remerge_immediate<br/>→ loops back to wait_for_immediate_merge"]
    end

    subgraph Cleanup ["Issue Release + Clone Cleanup"]
        direction LR
        RIS["release_issue_success<br/>━━━━━━━━━━<br/>remove in-progress label<br/>apply staged label (non-default base)"]
        RCS["register_clone_success<br/>━━━━━━━━━━<br/>mark clone for batch deletion"]
    end

    %% MAIN DETECTION FLOW %%
    START --> CMQ
    CMQ -->|"on_failure"| RCS
    CMQ --> CMGT
    CMGT -->|"on_success + on_failure (unconditional)"| CAM
    CAM -->|"on_success + on_failure (unconditional)"| RQM

    %% ROUTING BRANCHES (priority order) %%
    RQM -->|"① inputs.auto_merge != 'true'"| SKIP
    RQM -->|"② queue=✓ AND trigger=✓ AND auto_avail=✓"| EAM
    RQM -->|"③ queue=✓ AND trigger=✓ AND auto_avail=✗"| QENA
    RQM -->|"④ auto_avail=✓  (no queue or trigger missing)"| DM
    RQM -->|"⑤ default fallback"| IM

    %% QUEUE AUTO PATH %%
    EAM --> WFQ

    %% QUEUE NO-AUTO PATH %%
    QENA -->|"on_success"| WFQ
    QENA -->|"on_failure"| RCS

    %% WAIT FOR QUEUE OUTCOMES %%
    WFQ -->|"merged"| RIS
    WFQ -->|"stalled"| RSP
    RSP -->|"→ wait_for_queue"| WFQ
    WFQ -->|"ejected_ci_failure (checked FIRST)"| EJCI
    WFQ -->|"ejected conflict (checked SECOND)"| EJCON
    EJCI -->|"re_push → ci_watch loop → reenter"| WFQ
    EJCON -->|"re_push → reenter_merge_queue"| WFQ
    WFQ -->|"timeout"| RCS

    %% DIRECT PATH %%
    DM -->|"on_success"| WDM
    DM -->|"on_failure"| RCS
    WDM -->|"merged"| RIS
    WDM -->|"closed (conflict)"| DMCF
    WDM -->|"timeout"| RCS
    DMCF -->|"fix loop"| WDM

    %% IMMEDIATE PATH %%
    IM -->|"on_success"| WIM
    IM -->|"on_failure"| RCS
    WIM -->|"merged"| RIS
    WIM -->|"closed (conflict)"| IMCF
    WIM -->|"timeout"| RCS
    IMCF -->|"fix loop"| WIM

    %% CLEANUP %%
    RIS --> RCS
    RCS --> DONE

    %% CLASS ASSIGNMENTS %%
    class START,DONE,SKIP terminal;
    class CMQ,CMGT,CAM detector;
    class RQM stateNode;
    class EAM,QENA,DM,IM handler;
    class WFQ,WDM,WIM phase;
    class RSP,EJCI,EJCON detector;
    class DMCF,IMCF handler;
    class RIS,RCS phase;
```

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 65, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ── INPUT GUARDS ── %%
    subgraph Guards ["INIT_ONLY INPUT GUARDS"]
        direction LR
        OP["inputs.open_pr<br/>━━━━━━━━━━<br/>skip_when_false gate<br/>Bypasses entire detection chain"]
        AM["inputs.auto_merge<br/>━━━━━━━━━━<br/>INIT_ONLY user ingredient<br/>Priority-1 routing gate"]
    end

    %% ── DETECTION PHASE ── %%
    subgraph Detection ["● QUEUE STATE DETECTION (SET_ONCE → READ_ONCE)"]
        direction TB
        CMQ["● check_merge_queue<br/>━━━━━━━━━━<br/>GraphQL mergeQueue query<br/>on_failure → release_issue_success<br/>(safe degradation, leaves field unset)"]
        CMGT["● check_merge_group_trigger<br/>━━━━━━━━━━<br/>Scans .github/workflows/ for merge_group<br/>on_failure → check_auto_merge<br/>(graceful fallthrough)"]
        CMA["● check_auto_merge<br/>━━━━━━━━━━<br/>GraphQL autoMergeAllowed<br/>on_failure → route_queue_mode<br/>(jq fallback always emits 'false')"]

        QA["context.queue_available<br/>━━━━━━━━━━<br/>SET_ONCE / READ_ONCE<br/>'true' | 'false'<br/>Read exclusively by route_queue_mode"]
        MGT["context.merge_group_trigger<br/>━━━━━━━━━━<br/>SET_ONCE / READ_ONCE<br/>'true' | 'false'<br/>Read exclusively by route_queue_mode"]
        AMA["context.auto_merge_available<br/>━━━━━━━━━━<br/>SET_ONCE / READ_ONCE<br/>'true' | 'false'<br/>Always written (fallback = 'false')"]
    end

    %% ── ROUTING GATE ── %%
    subgraph Router ["● ROUTE_QUEUE_MODE (DERIVED — produced: [])"]
        RQM["● route_queue_mode<br/>━━━━━━━━━━<br/>action: route<br/>Reads 3 detection fields + inputs.auto_merge<br/>Writes NOTHING to context<br/>5-condition priority chain"]
    end

    %% ── MERGE PATHS ── %%
    subgraph Paths ["MERGE PATH SELECTION"]
        direction LR
        BYPASS["register_clone_success<br/>━━━━━━━━━━<br/>P1: auto_merge != 'true'<br/>Skip all merging"]
        EAM["enable_auto_merge<br/>━━━━━━━━━━<br/>P2: queue+trigger+auto<br/>gh pr merge --squash --auto"]
        QENA["● queue_enqueue_no_auto<br/>━━━━━━━━━━<br/>P3: queue+trigger, no auto<br/>gh pr merge --squash<br/>No --auto (autoMergeAllowed=false)<br/>GitHub still enqueues via queue intercept"]
        DM["direct_merge<br/>━━━━━━━━━━<br/>P4: no queue, auto avail<br/>gh pr merge --squash --auto"]
        IM["immediate_merge<br/>━━━━━━━━━━<br/>P5 (default)<br/>gh pr merge --squash"]
    end

    %% ── QUEUE WAIT STATE ── %%
    subgraph QueueWait ["QUEUE WAIT (MUTABLE STATE)"]
        WFQ["wait_for_queue<br/>━━━━━━━━━━<br/>timeout: 900s<br/>Shared by enable_auto_merge<br/>AND queue_enqueue_no_auto"]
        QPS["context.queue_pr_state<br/>━━━━━━━━━━<br/>MUTABLE — written by wait_for_queue<br/>merged | ejected | ejected_ci_failure<br/>stalled | timeout"]
    end

    %% ── RESUME DETECTION ── %%
    subgraph Resume ["RESUME DETECTION (● SKILL.md Context Limit Routing)"]
        direction LR
        T1["Tier 1: stale re-execute<br/>━━━━━━━━━━<br/>retry_reason=resume<br/>subtype=stale (compound discriminant)<br/>Re-execute with decrement<br/>NEVER routes to on_context_limit"]
        T2["Tier 2: partial resume<br/>━━━━━━━━━━<br/>retry_reason=resume (not stale)<br/>Step has on_context_limit<br/>→ follow on_context_limit"]
        T3["Tier 3: failure fallback<br/>━━━━━━━━━━<br/>All other retry_reason values<br/>(empty_output, path_contamination, etc.)<br/>→ on_failure"]
    end

    %% ── CONNECTIONS ── %%
    OP -->|"false → bypass chain"| BYPASS
    OP -->|"true → enter chain"| CMQ

    CMQ --> QA
    CMQ -->|"on_failure →"| BYPASS
    CMGT --> MGT
    CMA --> AMA

    QA -->|"feeds"| RQM
    MGT -->|"feeds"| RQM
    AMA -->|"feeds"| RQM
    AM -->|"Priority-1 gate"| RQM

    CMQ -->|"on_success"| CMGT
    CMGT -->|"on_success / on_failure"| CMA
    CMA -->|"on_success / on_failure"| RQM

    RQM -->|"P1: auto_merge≠true"| BYPASS
    RQM -->|"P2: queue+trigger+auto"| EAM
    RQM -->|"P3: queue+trigger, no auto"| QENA
    RQM -->|"P4: no queue, auto"| DM
    RQM -->|"P5: default"| IM

    EAM --> WFQ
    QENA --> WFQ
    WFQ --> QPS

    %% CLASS ASSIGNMENTS %%
    class OP,AM cli;
    class CMQ,CMGT,CMA detector;
    class QA,MGT,AMA stateNode;
    class RQM phase;
    class BYPASS,IM output;
    class EAM,DM handler;
    class QENA newComponent;
    class WFQ handler;
    class QPS stateNode;
    class T1 detector;
    class T2 gap;
    class T3 handler;
```

### Scenarios Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph S1 ["SCENARIO 1: Queue + Trigger + Auto Merge  (existing queue cell — now gated)"]
        direction LR
        S1_PR["PR opened<br/>━━━━━━━━━━<br/>push_to_remote / compose_pr"]
        S1_CMQ["check_merge_queue<br/>━━━━━━━━━━<br/>queue_available = true"]
        S1_CMGT["● check_merge_group_trigger<br/>━━━━━━━━━━<br/>merge_group_trigger = true"]
        S1_CAM["check_auto_merge<br/>━━━━━━━━━━<br/>auto_merge_available = true"]
        S1_RQM["● route_queue_mode<br/>━━━━━━━━━━<br/>queue=T · trigger=T · auto=T"]
        S1_EAM["enable_auto_merge<br/>━━━━━━━━━━<br/>gh pr merge --squash --auto"]
        S1_WFQ["wait_for_queue<br/>━━━━━━━━━━<br/>poll 15s / 900s deadline"]
        S1_OK(["merged ✓"])
    end

    subgraph S2 ["SCENARIO 2: Queue + Trigger + No Auto  (● new cell: queue_enqueue_no_auto)"]
        direction LR
        S2_PR["PR opened<br/>━━━━━━━━━━<br/>push_to_remote / compose_pr"]
        S2_CMQ["check_merge_queue<br/>━━━━━━━━━━<br/>queue_available = true"]
        S2_CMGT["● check_merge_group_trigger<br/>━━━━━━━━━━<br/>merge_group_trigger = true"]
        S2_CAM["check_auto_merge<br/>━━━━━━━━━━<br/>auto_merge_available = false"]
        S2_RQM["● route_queue_mode<br/>━━━━━━━━━━<br/>queue=T · trigger=T · auto=F"]
        S2_QNA["● queue_enqueue_no_auto<br/>━━━━━━━━━━<br/>gh pr merge --squash<br/>(no --auto flag)"]
        S2_WFQ["wait_for_queue<br/>━━━━━━━━━━<br/>same waiter as auto path"]
        S2_OK(["merged ✓"])
    end

    subgraph S3 ["SCENARIO 3: Queue + NO Trigger  (bug fix — was incorrectly routed to queue)"]
        direction LR
        S3_PR["PR opened<br/>━━━━━━━━━━<br/>queue exists on branch"]
        S3_CMQ["check_merge_queue<br/>━━━━━━━━━━<br/>queue_available = true"]
        S3_CMGT["● check_merge_group_trigger<br/>━━━━━━━━━━<br/>merge_group_trigger = false<br/>(no merge_group CI event)"]
        S3_CAM["check_auto_merge<br/>━━━━━━━━━━<br/>any value"]
        S3_RQM["● route_queue_mode<br/>━━━━━━━━━━<br/>queue=T · trigger=F<br/>→ falls through"]
        S3_IM["immediate_merge<br/>━━━━━━━━━━<br/>gh pr merge --squash"]
        S3_WIM["wait_for_immediate_merge<br/>━━━━━━━━━━<br/>5-min poll (correct waiter)"]
        S3_OK(["merged ✓"])
    end

    subgraph S4 ["SCENARIO 4: No Queue Baseline  (unchanged fallback)"]
        direction LR
        S4_PR["PR opened<br/>━━━━━━━━━━<br/>no merge queue on branch"]
        S4_CMQ["check_merge_queue<br/>━━━━━━━━━━<br/>queue_available = false"]
        S4_RQM["● route_queue_mode<br/>━━━━━━━━━━<br/>queue=F · auto=F<br/>→ immediate path"]
        S4_IM["immediate_merge<br/>━━━━━━━━━━<br/>gh pr merge --squash"]
        S4_WIM["wait_for_immediate_merge<br/>━━━━━━━━━━<br/>5-min poll"]
        S4_OK(["merged ✓"])
    end

    subgraph S5 ["SCENARIO 5: sous-chef Contract Alignment  (● SKILL.md + test coverage)"]
        direction LR
        S5_SC["● sous-chef/SKILL.md<br/>━━━━━━━━━━<br/>MERGE PHASE section<br/>documents routing matrix"]
        S5_CT["● test_sous_chef_routing.py<br/>━━━━━━━━━━<br/>assert queue_enqueue_no_auto<br/>+ condition in SKILL.md"]
        S5_MQ["● test_merge_prs_queue.py<br/>━━━━━━━━━━<br/>assert routing matrix<br/>+ queue_enqueue_no_auto step"]
        S5_REC["● 3 recipe YAMLs<br/>━━━━━━━━━━<br/>implementation / impl-groups<br/>/ remediation"]
        S5_OK(["contracts satisfied ✓"])
    end

    %% SCENARIO 1 FLOW %%
    S1_PR --> S1_CMQ --> S1_CMGT --> S1_CAM --> S1_RQM --> S1_EAM --> S1_WFQ --> S1_OK

    %% SCENARIO 2 FLOW %%
    S2_PR --> S2_CMQ --> S2_CMGT --> S2_CAM --> S2_RQM --> S2_QNA --> S2_WFQ --> S2_OK

    %% SCENARIO 3 FLOW %%
    S3_PR --> S3_CMQ --> S3_CMGT --> S3_CAM --> S3_RQM --> S3_IM --> S3_WIM --> S3_OK

    %% SCENARIO 4 FLOW %%
    S4_PR --> S4_CMQ --> S4_RQM --> S4_IM --> S4_WIM --> S4_OK

    %% SCENARIO 5 FLOW %%
    S5_SC -- "documents" --> S5_CT
    S5_CT -- "validates" --> S5_REC
    S5_REC -- "tested by" --> S5_MQ
    S5_MQ --> S5_OK

    %% CLASS ASSIGNMENTS %%
    class S1_PR,S2_PR,S3_PR,S4_PR cli;
    class S1_CMQ,S2_CMQ,S3_CMQ,S4_CMQ phase;
    class S1_CMGT,S2_CMGT,S3_CMGT handler;
    class S1_CAM,S2_CAM,S3_CAM phase;
    class S1_RQM,S2_RQM,S3_RQM,S4_RQM handler;
    class S1_EAM,S3_IM,S4_IM handler;
    class S2_QNA newComponent;
    class S1_WFQ,S2_WFQ,S3_WIM,S4_WIM stateNode;
    class S1_OK,S2_OK,S3_OK,S4_OK,S5_OK terminal;
    class S5_SC,S5_REC output;
    class S5_CT,S5_MQ detector;
```

Closes #755

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260412-092011-605768/.autoskillit/temp/make-plan/route_queue_mode_no_auto_merge_plan_2026-04-12_092640.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 289 | 32.7k | 1.8M | 160.3k | 1 | 8m 19s |
| verify | 150 | 23.8k | 960.9k | 63.9k | 1 | 5m 55s |
| implement | 286 | 17.3k | 1.7M | 61.4k | 1 | 6m 1s |
| fix | 214 | 8.4k | 917.7k | 33.6k | 1 | 8m 17s |
| prepare_pr | 60 | 6.3k | 192.3k | 26.2k | 1 | 1m 40s |
| run_arch_lenses | 221 | 32.7k | 684.0k | 208.0k | 3 | 15m 31s |
| compose_pr | 59 | 10.3k | 214.3k | 35.7k | 1 | 2m 37s |
| **Total** | 1.3k | 131.6k | 6.4M | 589.1k | | 48m 24s |