### PR TITLE
Rectify: Clone Registry Batch Delete — Missing Write-Back

### DIFF
--- a/src/autoskillit/workspace/clone_registry.py
+++ b/src/autoskillit/workspace/clone_registry.py
@@ -14,7 +14,7 @@ import fcntl
 import json
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Literal
+from typing import IO, Any, Literal
 
 from autoskillit.core import atomic_write, get_logger, resolve_temp_dir
 
@@ -35,6 +35,85 @@ def _entry_matches_owner(entry: dict[str, str], owner: str | None) -> bool:
     if owner is None:
         return True
     return entry.get("owner") == owner
+
+
+class CloneRegistry:
+    """Locked context manager for clone-cleanup-registry.json.
+
+    Acquires fcntl.LOCK_EX on __enter__, reads _entries from disk.
+    Writes _entries back atomically on __exit__ iff any mutation occurred.
+    Releases the lock unconditionally on __exit__ (even on exception).
+
+    All mutation methods set _dirty = True so __exit__ knows to persist.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._lock_path = path.with_suffix(".lock")
+        self._entries: list[dict[str, str]] = []
+        self._dirty: bool = False
+        self._lock_file: IO[str] | None = None
+
+    def __enter__(self) -> "CloneRegistry":
+        self._lock_path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock_file = open(self._lock_path, "w")
+        fcntl.flock(self._lock_file, fcntl.LOCK_EX)
+        if self._path.exists():
+            try:
+                self._entries = json.loads(self._path.read_text()).get("clones", [])
+            except (json.JSONDecodeError, OSError):
+                self._entries = []
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: object,
+    ) -> None:
+        try:
+            if self._dirty:
+                atomic_write(
+                    self._path,
+                    json.dumps({"clones": self._entries}, indent=2),
+                )
+        finally:
+            if self._lock_file is not None:
+                self._lock_file.close()  # releases fcntl advisory lock
+
+    def append(self, path: str, status: str, owner: str) -> None:
+        self._entries.append({"path": path, "status": status, "owner": owner})
+        self._dirty = True
+
+    def candidates(
+        self, owner: str | None
+    ) -> tuple[list[str], list[str]]:
+        """Return (to_delete, to_preserve) paths.
+
+        to_delete: status=success entries matching owner filter.
+        to_preserve: all other entries (status=error or different owner).
+        """
+        to_delete: list[str] = []
+        to_preserve: list[str] = []
+        for entry in self._entries:
+            if entry.get("status") == "success" and (
+                owner is None or entry.get("owner") == owner
+            ):
+                to_delete.append(entry["path"])
+            else:
+                to_preserve.append(entry["path"])
+        return to_delete, to_preserve
+
+    def prune_deleted(self, deleted_paths: set[str]) -> None:
+        """Remove successfully-deleted entries from the in-memory list.
+
+        Entries not in deleted_paths (failed deletes, other owners) are retained.
+        Sets _dirty = True so __exit__ persists the pruned list.
+        """
+        before = len(self._entries)
+        self._entries = [e for e in self._entries if e["path"] not in deleted_paths]
+        if len(self._entries) < before:
+            self._dirty = True
 
 
 def register_clone(

--- a/src/autoskillit/workspace/clone_registry.py
+++ b/src/autoskillit/workspace/clone_registry.py
@@ -128,18 +128,8 @@ def register_clone(
     if owner == "":
         raise ValueError("owner is required")
     path = _resolve_registry_path(registry_path, temp_dir)
-    lock_path = path.with_suffix(".lock")
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(lock_path, "w") as lock_file:
-        fcntl.flock(lock_file, fcntl.LOCK_EX)
-        existing: list[dict[str, str]] = []
-        if path.exists():
-            try:
-                existing = json.loads(path.read_text()).get("clones", [])
-            except (json.JSONDecodeError, OSError) as exc:
-                _log.warning("clone_registry: could not read %s: %s", path, exc)
-        existing.append({"path": clone_path, "status": status, "owner": owner})
-        atomic_write(path, json.dumps({"clones": existing}, indent=2))
+    with CloneRegistry(path) as reg:
+        reg.append(clone_path, status, owner)
     return {"registered": "true", "registry_path": str(path)}
 
 

--- a/src/autoskillit/workspace/clone_registry.py
+++ b/src/autoskillit/workspace/clone_registry.py
@@ -98,10 +98,13 @@ class CloneRegistry:
         for entry in self._entries:
             if owner is not None and entry.get("owner") != owner:
                 continue
+            path = entry.get("path")
+            if path is None:
+                continue
             if entry.get("status") == "success":
-                to_delete.append(entry["path"])
+                to_delete.append(path)
             else:
-                to_preserve.append(entry["path"])
+                to_preserve.append(path)
         return to_delete, to_preserve
 
     def prune_deleted(self, deleted_paths: set[str]) -> None:

--- a/src/autoskillit/workspace/clone_registry.py
+++ b/src/autoskillit/workspace/clone_registry.py
@@ -219,5 +219,6 @@ def batch_delete(
     if deleted:
         with CloneRegistry(path) as reg:
             reg.prune_deleted(set(deleted))
+            _, to_preserve = reg.candidates(owner)
 
     return {"deleted": deleted, "delete_failures": delete_failures, "preserved": to_preserve}

--- a/src/autoskillit/workspace/clone_registry.py
+++ b/src/autoskillit/workspace/clone_registry.py
@@ -88,17 +88,18 @@ class CloneRegistry:
     def candidates(
         self, owner: str | None
     ) -> tuple[list[str], list[str]]:
-        """Return (to_delete, to_preserve) paths.
+        """Return (to_delete, to_preserve) paths scoped to owner.
 
         to_delete: status=success entries matching owner filter.
-        to_preserve: all other entries (status=error or different owner).
+        to_preserve: status=error entries matching owner filter.
+        Entries belonging to other owners are not reported in either list.
         """
         to_delete: list[str] = []
         to_preserve: list[str] = []
         for entry in self._entries:
-            if entry.get("status") == "success" and (
-                owner is None or entry.get("owner") == owner
-            ):
+            if owner is not None and entry.get("owner") != owner:
+                continue
+            if entry.get("status") == "success":
                 to_delete.append(entry["path"])
             else:
                 to_preserve.append(entry["path"])
@@ -182,7 +183,12 @@ def batch_delete(
     temp_dir: Path | None = None,
     owner: str | None = None,
 ) -> dict[str, Any]:
-    """Read registry and delete success-status clones via remove_fn.
+    """Read registry and delete success-status clones via remove_fn, then prune registry.
+
+    Three-phase sequence:
+    1. Read candidates under lock (short hold — no I/O inside).
+    2. Delete outside lock (slow filesystem I/O).
+    3. Prune succeeded entries under lock (re-reads fresh, capturing concurrent appends).
 
     Calls remove_fn(path, "false") for each success clone. Error clones are
     preserved. Returns {"deleted": [...], "delete_failures": [...], "preserved": [...]}.
@@ -190,13 +196,28 @@ def batch_delete(
     When owner is provided, only entries belonging to that owner are considered.
     Pass owner=None to operate on all entries (escape hatch mode).
     """
-    to_delete, to_preserve = cleanup_candidates(registry_path, temp_dir, owner=owner)
+    path = _resolve_registry_path(registry_path, temp_dir)
+
+    # Phase 1: read candidates under lock (short hold — no I/O inside)
+    with CloneRegistry(path) as reg:
+        to_delete, to_preserve = reg.candidates(owner)
+
+    # Phase 2: delete outside lock (slow filesystem I/O)
     deleted: list[str] = []
     delete_failures: list[dict[str, str]] = []
-    for path in to_delete:
-        result = remove_fn(path, "false")
+    for clone_path in to_delete:
+        result = remove_fn(clone_path, "false")
         if result.get("removed") == "true":
-            deleted.append(path)
+            deleted.append(clone_path)
         else:
-            delete_failures.append({"path": path, "reason": result.get("reason", "unknown")})
+            delete_failures.append(
+                {"path": clone_path, "reason": result.get("reason", "unknown")}
+            )
+
+    # Phase 3: prune successfully-deleted entries (re-reads fresh under lock,
+    # capturing any register_clone writes that arrived during Phase 2)
+    if deleted:
+        with CloneRegistry(path) as reg:
+            reg.prune_deleted(set(deleted))
+
     return {"deleted": deleted, "delete_failures": delete_failures, "preserved": to_preserve}

--- a/src/autoskillit/workspace/clone_registry.py
+++ b/src/autoskillit/workspace/clone_registry.py
@@ -54,7 +54,7 @@ class CloneRegistry:
         self._dirty: bool = False
         self._lock_file: IO[str] | None = None
 
-    def __enter__(self) -> "CloneRegistry":
+    def __enter__(self) -> CloneRegistry:
         self._lock_path.parent.mkdir(parents=True, exist_ok=True)
         self._lock_file = open(self._lock_path, "w")
         fcntl.flock(self._lock_file, fcntl.LOCK_EX)
@@ -85,9 +85,7 @@ class CloneRegistry:
         self._entries.append({"path": path, "status": status, "owner": owner})
         self._dirty = True
 
-    def candidates(
-        self, owner: str | None
-    ) -> tuple[list[str], list[str]]:
+    def candidates(self, owner: str | None) -> tuple[list[str], list[str]]:
         """Return (to_delete, to_preserve) paths scoped to owner.
 
         to_delete: status=success entries matching owner filter.
@@ -210,9 +208,7 @@ def batch_delete(
         if result.get("removed") == "true":
             deleted.append(clone_path)
         else:
-            delete_failures.append(
-                {"path": clone_path, "reason": result.get("reason", "unknown")}
-            )
+            delete_failures.append({"path": clone_path, "reason": result.get("reason", "unknown")})
 
     # Phase 3: prune successfully-deleted entries (re-reads fresh under lock,
     # capturing any register_clone writes that arrived during Phase 2)

--- a/src/autoskillit/workspace/clone_registry.py
+++ b/src/autoskillit/workspace/clone_registry.py
@@ -61,7 +61,8 @@ class CloneRegistry:
         if self._path.exists():
             try:
                 self._entries = json.loads(self._path.read_text()).get("clones", [])
-            except (json.JSONDecodeError, OSError):
+            except (json.JSONDecodeError, OSError) as exc:
+                _log.warning("clone_registry: could not read %s: %s", self._path, exc)
                 self._entries = []
         return self
 

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -118,7 +118,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/migration/store.py", 54),
     ("src/autoskillit/migration/store.py", 64),
     # clone_registry.py — clones dict (CloneRegistry.__exit__ atomic write-back)
-    ("src/autoskillit/workspace/clone_registry.py", 76),
+    ("src/autoskillit/workspace/clone_registry.py", 77),
     # staleness_cache.py — cache dict
     ("src/autoskillit/recipe/staleness_cache.py", 67),
     # background.py — payload dict

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -117,8 +117,8 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # migration/store.py — failure store dicts
     ("src/autoskillit/migration/store.py", 54),
     ("src/autoskillit/migration/store.py", 64),
-    # clone_registry.py — clones dict
-    ("src/autoskillit/workspace/clone_registry.py", 63),
+    # clone_registry.py — clones dict (CloneRegistry.__exit__ atomic write-back)
+    ("src/autoskillit/workspace/clone_registry.py", 76),
     # staleness_cache.py — cache dict
     ("src/autoskillit/recipe/staleness_cache.py", 67),
     # background.py — payload dict

--- a/tests/workspace/test_clone_registry.py
+++ b/tests/workspace/test_clone_registry.py
@@ -325,6 +325,7 @@ class TestBatchDeleteRegistryWriteback:
 
         mock_remove = MagicMock(return_value={"removed": "true"})
         batch_delete(reg, mock_remove, owner="kit-1")
+        mock_remove.assert_called_once_with("/tmp/a", "false")
 
         mock_remove2 = MagicMock(return_value={"removed": "true"})
         result2 = batch_delete(reg, mock_remove2, owner="kit-1")

--- a/tests/workspace/test_clone_registry.py
+++ b/tests/workspace/test_clone_registry.py
@@ -271,9 +271,7 @@ class TestBatchDeleteRegistryWriteback:
     can distinguish a correct write-back from a missing one.
     """
 
-    def test_batch_delete_removes_deleted_entry_from_registry_file(
-        self, tmp_path: Path
-    ) -> None:
+    def test_batch_delete_removes_deleted_entry_from_registry_file(self, tmp_path: Path) -> None:
         """After batch_delete, successfully-deleted entries must be absent from disk."""
         reg = str(tmp_path / "registry.json")
         register_clone("/tmp/a", "success", "kit-1", registry_path=reg)
@@ -317,9 +315,7 @@ class TestBatchDeleteRegistryWriteback:
         assert "/tmp/a" not in remaining  # succeeded: pruned
         assert "/tmp/b" in remaining  # failed: retained
 
-    def test_batch_delete_second_call_finds_no_candidates(
-        self, tmp_path: Path
-    ) -> None:
+    def test_batch_delete_second_call_finds_no_candidates(self, tmp_path: Path) -> None:
         """After batch_delete prunes the registry, a second call finds nothing to delete.
 
         Verifies idempotency — the core regression contract for issue #756.
@@ -349,9 +345,7 @@ class TestBatchDeleteRegistryWriteback:
         data = json.loads(Path(reg).read_text())
         assert data["clones"] == []
 
-    def test_batch_delete_other_owner_entries_untouched_on_disk(
-        self, tmp_path: Path
-    ) -> None:
+    def test_batch_delete_other_owner_entries_untouched_on_disk(self, tmp_path: Path) -> None:
         """Owner-scoped batch_delete must not touch entries owned by other kitchens."""
         reg = str(tmp_path / "registry.json")
         register_clone("/tmp/mine", "success", "kit-1", registry_path=reg)

--- a/tests/workspace/test_clone_registry.py
+++ b/tests/workspace/test_clone_registry.py
@@ -298,7 +298,7 @@ class TestBatchDeleteRegistryWriteback:
         register_clone("/tmp/a", "success", "kit-1", registry_path=reg)
         register_clone("/tmp/b", "success", "kit-1", registry_path=reg)
 
-        def remove_side_effect(path: str, _: str) -> dict:  # type: ignore[type-arg]
+        def remove_side_effect(path: str, _: str) -> dict[str, str]:
             return (
                 {"removed": "true"}
                 if path == "/tmp/a"

--- a/tests/workspace/test_clone_registry.py
+++ b/tests/workspace/test_clone_registry.py
@@ -262,3 +262,105 @@ class TestRegisterCloneParallelWriters:
         entries = {e["path"]: e["owner"] for e in data["clones"]}
         assert entries["/tmp/clone-A"] == "owner-A"
         assert entries["/tmp/clone-B"] == "owner-B"
+
+
+class TestBatchDeleteRegistryWriteback:
+    """batch_delete must persist the pruned registry to disk after successful deletions.
+
+    These tests verify ON-DISK STATE, not just return values — only disk verification
+    can distinguish a correct write-back from a missing one.
+    """
+
+    def test_batch_delete_removes_deleted_entry_from_registry_file(
+        self, tmp_path: Path
+    ) -> None:
+        """After batch_delete, successfully-deleted entries must be absent from disk."""
+        reg = str(tmp_path / "registry.json")
+        register_clone("/tmp/a", "success", "kit-1", registry_path=reg)
+        register_clone("/tmp/b", "error", "kit-1", registry_path=reg)
+
+        mock_remove = MagicMock(return_value={"removed": "true"})
+        result = batch_delete(reg, mock_remove, owner="kit-1")
+
+        assert result["deleted"] == ["/tmp/a"]
+        assert result["preserved"] == ["/tmp/b"]
+
+        data = json.loads(Path(reg).read_text())
+        remaining = [e["path"] for e in data["clones"]]
+        assert "/tmp/a" not in remaining, (
+            "batch_delete must remove successfully-deleted entries from registry"
+        )
+        assert "/tmp/b" in remaining  # error entries preserved on disk
+
+    def test_batch_delete_partial_failure_keeps_only_failed_entry_on_disk(
+        self, tmp_path: Path
+    ) -> None:
+        """Succeeded deletions are pruned; failed deletions are retained on disk."""
+        reg = str(tmp_path / "registry.json")
+        register_clone("/tmp/a", "success", "kit-1", registry_path=reg)
+        register_clone("/tmp/b", "success", "kit-1", registry_path=reg)
+
+        def remove_side_effect(path: str, _: str) -> dict:  # type: ignore[type-arg]
+            return (
+                {"removed": "true"}
+                if path == "/tmp/a"
+                else {"removed": "false", "reason": "not_found"}
+            )
+
+        result = batch_delete(reg, remove_side_effect, owner="kit-1")
+
+        assert "/tmp/a" in result["deleted"]
+        assert any(f["path"] == "/tmp/b" for f in result["delete_failures"])
+
+        data = json.loads(Path(reg).read_text())
+        remaining = [e["path"] for e in data["clones"]]
+        assert "/tmp/a" not in remaining  # succeeded: pruned
+        assert "/tmp/b" in remaining  # failed: retained
+
+    def test_batch_delete_second_call_finds_no_candidates(
+        self, tmp_path: Path
+    ) -> None:
+        """After batch_delete prunes the registry, a second call finds nothing to delete.
+
+        Verifies idempotency — the core regression contract for issue #756.
+        """
+        reg = str(tmp_path / "registry.json")
+        register_clone("/tmp/a", "success", "kit-1", registry_path=reg)
+
+        mock_remove = MagicMock(return_value={"removed": "true"})
+        batch_delete(reg, mock_remove, owner="kit-1")
+
+        mock_remove2 = MagicMock(return_value={"removed": "true"})
+        result2 = batch_delete(reg, mock_remove2, owner="kit-1")
+
+        mock_remove2.assert_not_called()
+        assert result2["deleted"] == []
+
+    def test_batch_delete_all_entries_deleted_leaves_empty_clones_list(
+        self, tmp_path: Path
+    ) -> None:
+        """If all entries are deleted, the registry file retains an empty clones list."""
+        reg = str(tmp_path / "registry.json")
+        register_clone("/tmp/a", "success", "kit-1", registry_path=reg)
+
+        mock_remove = MagicMock(return_value={"removed": "true"})
+        batch_delete(reg, mock_remove, owner="kit-1")
+
+        data = json.loads(Path(reg).read_text())
+        assert data["clones"] == []
+
+    def test_batch_delete_other_owner_entries_untouched_on_disk(
+        self, tmp_path: Path
+    ) -> None:
+        """Owner-scoped batch_delete must not touch entries owned by other kitchens."""
+        reg = str(tmp_path / "registry.json")
+        register_clone("/tmp/mine", "success", "kit-1", registry_path=reg)
+        register_clone("/tmp/theirs", "success", "kit-2", registry_path=reg)
+
+        mock_remove = MagicMock(return_value={"removed": "true"})
+        batch_delete(reg, mock_remove, owner="kit-1")
+
+        data = json.loads(Path(reg).read_text())
+        remaining = [e["path"] for e in data["clones"]]
+        assert "/tmp/mine" not in remaining  # kit-1 entry pruned
+        assert "/tmp/theirs" in remaining  # kit-2 entry untouched


### PR DESCRIPTION
## Summary

`clone_registry.py` is a collection of standalone stateless functions. `register_clone` correctly performs a locked read-modify-write on the registry JSON. `batch_delete` reads the registry, deletes clone directories via `remove_fn`, but **never writes the pruned entry list back to disk** — the registry accumulates stale entries indefinitely.

The architectural weakness is not just the missing write-back call: it is that the standalone-function design provides no structural guarantee that mutations to logical state (entries deleted from the filesystem) are reflected in persistent state (the registry file). Any future function can read from the registry, act on what it reads, and silently omit the write-back — and existing tests will not catch it because they assert return values, not on-disk state.

The architectural immunity: introduce a `CloneRegistry` context manager class (modeled on `FailureStore`) that holds the exclusive lock for its lifetime, reads registry state on `__enter__`, and writes back atomically on `__exit__` when mutations occurred. This makes it structurally impossible to mutate the logical registry without persisting the result.

## Architecture Impact

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START([CALLER])

    subgraph EntryGates ["ENTRY VALIDATION GATES"]
        direction TB
        OwnerGuard["● owner != '' guard<br/>━━━━━━━━━━<br/>register_clone pre-flight<br/>ValueError → no registry write"]
        LockGate["fcntl.LOCK_EX<br/>━━━━━━━━━━<br/>Exclusive advisory lock<br/>serialises concurrent writers"]
        DiskRead["Disk read + parse<br/>━━━━━━━━━━<br/>JSONDecodeError / OSError<br/>→ graceful empty-list fallback"]
    end

    subgraph FieldLifecycles ["FIELD LIFECYCLE CATEGORIES"]
        direction TB
        INIT_ONLY["INIT_ONLY<br/>━━━━━━━━━━<br/>_path, _lock_path<br/>entry.path, entry.status<br/>entry.owner<br/>Set once — never reassigned"]
        MUTABLE_ENTRIES["MUTABLE — _entries<br/>━━━━━━━━━━<br/>[] on __init__<br/>disk-loaded on __enter__<br/>grown by append()<br/>shrunk by ● prune_deleted()"]
        MUTABLE_DIRTY["MUTABLE — _dirty<br/>━━━━━━━━━━<br/>False on __init__<br/>True after any mutation<br/>Gates the atomic write-back"]
        MUTABLE_LOCK["MUTABLE — _lock_file<br/>━━━━━━━━━━<br/>None on __init__<br/>open handle on __enter__<br/>closed in finally on __exit__"]
    end

    subgraph MutationOps ["MUTATION OPERATIONS"]
        direction TB
        AppendOp["● append()<br/>━━━━━━━━━━<br/>Pushes {path, status, owner}<br/>Sets _dirty = True"]
        PruneOp["● prune_deleted()<br/>━━━━━━━━━━<br/>Filters out deleted paths<br/>Sets _dirty = True iff shrank"]
        CandidatesOp["● candidates(owner)<br/>━━━━━━━━━━<br/>Reads _entries — no mutation<br/>Owner filter: None = all<br/>Returns (to_delete, to_preserve)"]
    end

    subgraph WriteBack ["EXIT / WRITE-BACK GATE"]
        direction TB
        DirtyCheck{"_dirty?"}
        AtomicWrite["atomic_write()<br/>━━━━━━━━━━<br/>json.dumps clones list<br/>Temp-rename guarantees<br/>no partial writes"]
        LockRelease["lock_file.close()<br/>━━━━━━━━━━<br/>Releases advisory lock<br/>finally — unconditional"]
    end

    subgraph BatchPhases ["● batch_delete — THREE-PHASE PROTOCOL"]
        direction TB
        Phase1["Phase 1 — Read candidates<br/>━━━━━━━━━━<br/>Short lock hold<br/>No I/O inside lock"]
        Phase2["Phase 2 — Delete outside lock<br/>━━━━━━━━━━<br/>Slow filesystem I/O<br/>remove_fn per success clone"]
        Phase3["Phase 3 — Prune registry<br/>━━━━━━━━━━<br/>Re-acquires lock<br/>Re-reads disk (captures<br/>concurrent appends)<br/>prune_deleted(deleted_set)"]
        IfDeleted{"deleted list<br/>non-empty?"}
    end

    subgraph DiskState ["DISK STATE (registry JSON)"]
        direction TB
        DiskFile[("clone-cleanup-registry.json<br/>━━━━━━━━━━<br/>{'clones': [...]}<br/>Read: Phase 1 + Phase 3<br/>Written: __exit__ iff _dirty")]
    end

    %% ENTRY FLOW %%
    START --> OwnerGuard
    OwnerGuard -->|"owner valid"| LockGate
    LockGate -->|"lock acquired"| DiskRead
    DiskRead -->|"_entries loaded"| INIT_ONLY

    %% FIELD CONNECTIONS %%
    INIT_ONLY --> MUTABLE_ENTRIES
    MUTABLE_ENTRIES --> AppendOp
    MUTABLE_ENTRIES --> CandidatesOp
    AppendOp --> MUTABLE_DIRTY
    PruneOp --> MUTABLE_DIRTY
    MUTABLE_DIRTY --> DirtyCheck
    MUTABLE_LOCK --> LockRelease

    %% BATCH DELETE FLOW %%
    CandidatesOp --> Phase1
    Phase1 --> Phase2
    Phase2 --> IfDeleted
    IfDeleted -->|"yes"| Phase3
    Phase3 --> PruneOp
    IfDeleted -->|"no — skip write-back"| LockRelease

    %% WRITE-BACK FLOW %%
    DirtyCheck -->|"yes"| AtomicWrite
    DirtyCheck -->|"no"| LockRelease
    AtomicWrite --> DiskFile
    AtomicWrite --> LockRelease
    DiskRead -.->|reads| DiskFile

    %% CLASS ASSIGNMENTS %%
    class OwnerGuard,DiskRead detector;
    class LockGate stateNode;
    class INIT_ONLY detector;
    class MUTABLE_ENTRIES,MUTABLE_DIRTY,MUTABLE_LOCK stateNode;
    class AppendOp,PruneOp handler;
    class CandidatesOp phase;
    class Phase1,Phase2,Phase3 phase;
    class IfDeleted,DirtyCheck gap;
    class AtomicWrite,LockRelease output;
    class DiskFile output;
    class START terminal;
```

### Concurrency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 42, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;

    START_REG([PIPELINE PROCESS — register_clone])
    START_DEL([CALLER — batch_delete])
    END_REG([ENTRY RECORDED])
    END_DEL([REGISTRY PRUNED])

    %% ─── PARALLEL WRITERS ─────────────────────────────────────── %%
    subgraph ParallelPipelines ["N PARALLEL PIPELINE PROCESSES (cross-process coordination)"]
        direction LR
        PP1["Pipeline Process 1<br/>━━━━━━━━━━<br/>register_clone(clone_path_1)"]
        PP2["Pipeline Process 2<br/>━━━━━━━━━━<br/>register_clone(clone_path_2)"]
        PPN["Pipeline Process N<br/>━━━━━━━━━━<br/>register_clone(clone_path_N)"]
    end

    LOCK_GATE["fcntl.LOCK_EX<br/>━━━━━━━━━━<br/>SERIALIZATION POINT<br/>Exclusive advisory lock on<br/>clone-cleanup-registry.lock<br/>OS queues concurrent callers"]

    subgraph RegisterCM ["● CloneRegistry.__enter__ / __exit__ (register path)"]
        direction TB
        CM_READ["Read registry from disk<br/>━━━━━━━━━━<br/>JSON parse → self._entries<br/>Under lock"]
        CM_APPEND["Append new entry<br/>━━━━━━━━━━<br/>_entries.append({path, status, owner})<br/>_dirty = True"]
        CM_WRITE["● atomic_write()<br/>━━━━━━━━━━<br/>mkstemp → write JSON → os.replace<br/>Written before lock release"]
        CM_UNLOCK["Release lock<br/>━━━━━━━━━━<br/>Close lock file (always, even on exc)<br/>Next queued process unblocks"]
    end

    %% ─── BATCH DELETE THREE-PHASE PROTOCOL ──────────────────── %%
    subgraph BatchDelete ["● batch_delete — Three-Phase Lock Protocol"]
        direction TB

        subgraph Phase1 ["Phase 1 — SHORT LOCK: Read Candidates"]
            P1_LOCK["Acquire fcntl.LOCK_EX<br/>━━━━━━━━━━<br/>Open .lock file, flock LOCK_EX"]
            P1_READ["Read all entries from disk<br/>━━━━━━━━━━<br/>Filter: status=completed<br/>Build to_delete list"]
            P1_UNLOCK["Release lock immediately<br/>━━━━━━━━━━<br/>Close .lock file<br/>NO filesystem I/O inside"]
        end

        subgraph Phase2 ["Phase 2 — OUTSIDE LOCK: Slow Filesystem I/O"]
            P2_LOOP["Sequential deletion loop<br/>━━━━━━━━━━<br/>for clone_path in to_delete:<br/>    remove_fn(clone_path)<br/>Concurrent register_clone allowed here"]
            P2_COLLECT["Collect deleted paths<br/>━━━━━━━━━━<br/>Track: deleted_paths set<br/>Ignore remove errors (not_found / OSError)"]
        end

        subgraph Phase3 ["● Phase 3 — LOCK AGAIN: Prune Registry (THIS PR FIX)"]
            P3_LOCK["Re-acquire fcntl.LOCK_EX<br/>━━━━━━━━━━<br/>Re-enter CloneRegistry context"]
            P3_REREAD["Re-read fresh from disk<br/>━━━━━━━━━━<br/>Captures register_clone writes<br/>that arrived during Phase 2"]
            P3_PRUNE["Prune deleted entries<br/>━━━━━━━━━━<br/>Remove entries whose path<br/>is in deleted_paths set"]
            P3_WRITE["● atomic_write()<br/>━━━━━━━━━━<br/>Shrunk registry written<br/>mkstemp → os.replace"]
            P3_UNLOCK["Release lock<br/>━━━━━━━━━━<br/>Close .lock file"]
        end
    end

    %% ─── CONCURRENT APPEND WINDOW ────────────────────────────── %%
    CONCURRENT_APPEND["Concurrent register_clone<br/>appends during Phase 2<br/>━━━━━━━━━━<br/>Each acquires its own LOCK_EX<br/>Serialized independently<br/>Phase 3 re-read captures them"]

    %% ─── SHARED FILE STATE ───────────────────────────────────── %%
    REGISTRY_FILE[("● clone-cleanup-registry.json<br/>━━━━━━━━━━<br/>Shared on-disk state<br/>Protected by fcntl + atomic_write<br/>Never partially visible")]

    %% ─── CONNECTIONS: REGISTER PATH ─────────────────────────── %%
    START_REG --> PP1
    START_REG --> PP2
    START_REG --> PPN

    PP1 --> LOCK_GATE
    PP2 --> LOCK_GATE
    PPN --> LOCK_GATE

    LOCK_GATE -->|"one at a time"| CM_READ
    CM_READ --> CM_APPEND
    CM_APPEND --> CM_WRITE
    CM_WRITE --> CM_UNLOCK
    CM_UNLOCK --> END_REG
    CM_WRITE --> REGISTRY_FILE

    %% ─── CONNECTIONS: BATCH DELETE PATH ─────────────────────── %%
    START_DEL --> P1_LOCK
    P1_LOCK --> P1_READ
    P1_READ --> P1_UNLOCK
    P1_UNLOCK --> P2_LOOP
    P2_LOOP --> P2_COLLECT
    P2_COLLECT --> P3_LOCK
    P3_LOCK --> P3_REREAD
    P3_REREAD --> P3_PRUNE
    P3_PRUNE --> P3_WRITE
    P3_WRITE --> P3_UNLOCK
    P3_UNLOCK --> END_DEL
    P3_WRITE --> REGISTRY_FILE

    %% ─── CONCURRENT APPEND ANNOTATION ────────────────────────── %%
    CONCURRENT_APPEND -.->|"appends during Phase 2 window"| REGISTRY_FILE
    P3_REREAD -.->|"re-reads to capture"| REGISTRY_FILE

    %% ─── CLASS ASSIGNMENTS ───────────────────────────────────── %%
    class START_REG,START_DEL,END_REG,END_DEL terminal;
    class PP1,PP2,PPN newComponent;
    class LOCK_GATE detector;
    class CM_READ,P1_READ,P3_REREAD phase;
    class CM_APPEND,P2_LOOP,P2_COLLECT,P3_PRUNE handler;
    class CM_WRITE,P3_WRITE,CM_UNLOCK,P1_UNLOCK,P3_UNLOCK,P1_LOCK,P3_LOCK output;
    class REGISTRY_FILE stateNode;
    class CONCURRENT_APPEND detector;
```

### Error/Resilience Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;

    %% ── ENTRY / VALIDATION GATE ──────────────────────────────────────────── %%
    CALLER(["Caller"])

    subgraph Gates ["VALIDATION GATES (Fail-Fast)"]
        direction TB
        OWNER_GATE["● owner != '' guard<br/>━━━━━━━━━━<br/>register_clone:127<br/>Checked before any I/O"]
        OWNER_ERR["ValueError<br/>━━━━━━━━━━<br/>'owner is required'<br/>No registry written"]
    end

    %% ── LOCK ACQUISITION ─────────────────────────────────────────────────── %%
    subgraph LockAcquire ["LOCK ACQUISITION"]
        direction TB
        MK_LOCK["● CloneRegistry.__enter__<br/>━━━━━━━━━━<br/>mkdir parents exist_ok<br/>open .lock → fcntl LOCK_EX"]
        READ_JSON{"registry.json<br/>exists?"}
        PARSE_OK["Parse JSON<br/>━━━━━━━━━━<br/>_entries = clones list"]
        PARSE_FAIL["JSONDecodeError<br/>or OSError<br/>━━━━━━━━━━<br/>_entries = []<br/>(soft-fail, dirty=False)"]
    end

    %% ── BATCH DELETE PHASES ──────────────────────────────────────────────── %%
    subgraph BatchPhases ["● BATCH DELETE — 3-PHASE SEQUENCE"]
        direction TB

        subgraph P1 ["Phase 1 — Read Under Lock (short hold)"]
            CAND["● candidates(owner)<br/>━━━━━━━━━━<br/>to_delete: status=success<br/>to_preserve: status=error<br/>Other owners skipped"]
        end

        subgraph P2 ["Phase 2 — Delete Outside Lock (slow I/O)"]
            DEL_LOOP["● remove_fn(path, 'false')<br/>━━━━━━━━━━<br/>For each success clone"]
            DEL_OK["removed == 'true'<br/>━━━━━━━━━━<br/>→ deleted list"]
            DEL_FAIL["removed != 'true'<br/>━━━━━━━━━━<br/>→ delete_failures list<br/>Entry RETAINED in registry"]
        end

        subgraph P3 ["Phase 3 — Prune Under Lock (if any deleted)"]
            PRUNE_GUARD{"any<br/>deleted?"}
            PRUNE["● prune_deleted(deleted_paths)<br/>━━━━━━━━━━<br/>Re-reads fresh registry<br/>Removes only succeeded<br/>_dirty = True"]
            SKIP_PRUNE["Skip write-back<br/>━━━━━━━━━━<br/>No I/O performed"]
        end
    end

    %% ── WRITE-BACK / ATOMIC WRITE ────────────────────────────────────────── %%
    subgraph WriteBack ["WRITE-BACK — CloneRegistry.__exit__"]
        direction TB
        DIRTY_CHECK{"_dirty?"}
        ATOMIC["atomic_write<br/>━━━━━━━━━━<br/>mkstemp → write → os.replace<br/>Crash-safe, no partial state"]
        ATOMIC_FAIL["write fails<br/>━━━━━━━━━━<br/>unlink(tmp)<br/>re-raise after lock release"]
        LOCK_REL["finally: lock_file.close()<br/>━━━━━━━━━━<br/>fcntl advisory lock released<br/>Even on exception"]
    end

    %% ── SCHEMA RATCHET ───────────────────────────────────────────────────── %%
    subgraph Ratchet ["● JSON WRITE-SITE RATCHET (infra gate)"]
        SCAN["AST scan: atomic_write + json.dumps<br/>━━━━━━━━━━<br/>test_schema_version_convention.py"]
        ALLOWLIST["_LEGACY_JSON_WRITES allowlist<br/>━━━━━━━━━━<br/>clone_registry.py:76 grandfathered<br/>New sites must use write_versioned_json"]
    end

    %% ── TERMINAL STATES ──────────────────────────────────────────────────── %%
    T_SUCCESS(["COMPLETE<br/>deleted + preserved<br/>+ delete_failures returned"])
    T_ERR_OWNER(["ERROR — owner<br/>validation failed"])
    T_ERR_WRITE(["ERROR — write<br/>propagated to caller"])
    T_IDEM(["IDEMPOTENT<br/>second call finds<br/>no candidates"])

    %% ── EDGES ────────────────────────────────────────────────────────────── %%

    CALLER --> OWNER_GATE
    OWNER_GATE -->|"owner == ''"| OWNER_ERR
    OWNER_ERR --> T_ERR_OWNER

    OWNER_GATE -->|"owner valid"| MK_LOCK
    MK_LOCK --> READ_JSON
    READ_JSON -->|"yes"| PARSE_OK
    READ_JSON -->|"no"| PARSE_FAIL
    PARSE_OK --> CAND
    PARSE_FAIL -->|"empty state"| CAND

    CAND --> DEL_LOOP
    DEL_LOOP --> DEL_OK
    DEL_LOOP --> DEL_FAIL

    DEL_OK --> PRUNE_GUARD
    DEL_FAIL --> PRUNE_GUARD
    PRUNE_GUARD -->|"yes"| PRUNE
    PRUNE_GUARD -->|"no"| SKIP_PRUNE

    PRUNE --> DIRTY_CHECK
    SKIP_PRUNE --> DIRTY_CHECK

    DIRTY_CHECK -->|"true"| ATOMIC
    DIRTY_CHECK -->|"false"| LOCK_REL
    ATOMIC --> LOCK_REL
    ATOMIC -->|"OSError"| ATOMIC_FAIL
    ATOMIC_FAIL --> LOCK_REL
    ATOMIC_FAIL --> T_ERR_WRITE

    LOCK_REL --> T_SUCCESS
    T_SUCCESS -->|"entries pruned → second call"| T_IDEM

    SCAN --> ALLOWLIST

    %% ── CLASS ASSIGNMENTS ────────────────────────────────────────────────── %%
    class CALLER terminal;
    class OWNER_GATE,SCAN detector;
    class OWNER_ERR,PARSE_FAIL,DEL_FAIL,ATOMIC_FAIL gap;
    class MK_LOCK,PARSE_OK handler;
    class READ_JSON,DIRTY_CHECK,PRUNE_GUARD stateNode;
    class CAND,DEL_LOOP,DEL_OK phase;
    class PRUNE,ATOMIC,ALLOWLIST output;
    class SKIP_PRUNE,LOCK_REL handler;
    class T_SUCCESS,T_ERR_OWNER,T_ERR_WRITE,T_IDEM terminal;
```

Closes #756

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260412-121355-324609/.autoskillit/temp/rectify/rectify_clone_registry_batch_delete_no_prune_2026-04-12_121355.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| group | 2.7k | 68.8k | 3.1M | 200.8k | 1 | 22m 49s |
| plan | 133 | 17.3k | 579.1k | 55.8k | 1 | 4m 58s |
| verify | 134 | 14.4k | 700.4k | 56.8k | 1 | 4m 13s |
| implement | 302 | 16.3k | 1.9M | 55.8k | 1 | 4m 25s |
| **Total** | 3.3k | 116.8k | 6.3M | 369.3k | | 36m 27s |