### PR TITLE
Implementation Plan: Detect sustained D-state and high-CPU anomalies in headless sessions

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -67,7 +67,7 @@ projects need.
 
     autoskillit doctor
 
-Doctor runs 14 checks (12 numbered + 2 lettered sub-checks `4b` and `7b`),
+Doctor runs 15 checks (13 numbered + 2 lettered sub-checks `4b` and `7b`),
 enumerated by `run_doctor` in `src/autoskillit/cli/_doctor.py`:
 
 | # | Check | What it verifies |
@@ -86,6 +86,9 @@ enumerated by `run_doctor` in `src/autoskillit/cli/_doctor.py`:
 | 10 | Secret scanning hook | `gitleaks` (or equivalent) is installed as a pre-commit hook |
 | 11 | Editable install source exists | An editable install still points at a real source directory |
 | 12 | No stale entry points | No leftover `autoskillit` scripts outside `~/.local/bin` |
+| 13 | Source version drift | Installed commit SHA matches the last-known HEAD of the installed branch |
+| 14 | Quota cache schema | `autoskillit_quota_cache.json` schema version is current |
+| 15 | Claude process state | Reports D-state and CPU breakdown of running `claude` processes via `ps` |
 
 See **[Hooks](safety/hooks.md)** for what each PreToolUse / PostToolUse /
 SessionStart hook actually enforces.

--- a/src/autoskillit/cli/_doctor.py
+++ b/src/autoskillit/cli/_doctor.py
@@ -462,7 +462,7 @@ def _check_claude_process_state_breakdown() -> DoctorResult:
         if len(parts) < 4:
             continue
         comm = parts[3]
-        if comm != "claude" and not comm.endswith("/claude"):
+        if comm != "claude":
             continue
         try:
             claude_rows.append((int(parts[0]), parts[1], float(parts[2])))

--- a/src/autoskillit/cli/_doctor.py
+++ b/src/autoskillit/cli/_doctor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import shutil
+import subprocess
 import urllib.parse
 from dataclasses import dataclass
 from pathlib import Path
@@ -32,8 +33,6 @@ class DoctorResult:
 
 def _check_mcp_server_registered(claude_json_path: Path | None = None) -> DoctorResult:
     """Check that autoskillit MCP server is registered (via mcpServers or plugin)."""
-    import subprocess
-
     if claude_json_path is None:
         claude_json_path = Path.home() / ".claude.json"
 
@@ -268,8 +267,6 @@ def _check_editable_install_source_exists() -> DoctorResult:
 
 def _check_stale_entry_points() -> DoctorResult:
     """Detect autoskillit binaries on PATH outside ~/.local/bin (stale/poisoned installs)."""
-    import subprocess
-
     check_name = "stale_entry_points"
     primary = shutil.which("autoskillit")
     if not primary:
@@ -432,6 +429,67 @@ def _check_quota_cache_schema(cache_path: Path | None = None) -> DoctorResult:
         check_name,
         f"Quota cache schema drift at {path}: observed={observed!r}, "
         f"expected={QUOTA_CACHE_SCHEMA_VERSION}.",
+    )
+
+
+def _check_claude_process_state_breakdown() -> DoctorResult:
+    """Check current D-state and CPU usage of claude processes via ps."""
+    check_name = "claude_process_state"
+    try:
+        result = subprocess.run(
+            ["ps", "-axo", "pid,state,pcpu,comm"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        return DoctorResult(
+            Severity.OK,
+            check_name,
+            f"ps unavailable ({type(exc).__name__}); skipping claude process check",
+        )
+
+    if result.returncode != 0:
+        return DoctorResult(
+            Severity.OK,
+            check_name,
+            f"ps exited {result.returncode}; skipping claude process check",
+        )
+
+    claude_rows: list[tuple[int, str, float]] = []
+    for line in result.stdout.splitlines()[1:]:
+        parts = line.split(maxsplit=3)
+        if len(parts) < 4:
+            continue
+        comm = parts[3]
+        if comm != "claude" and not comm.endswith("/claude"):
+            continue
+        try:
+            claude_rows.append((int(parts[0]), parts[1], float(parts[2])))
+        except ValueError:
+            continue
+
+    if not claude_rows:
+        return DoctorResult(Severity.OK, check_name, "No claude processes running")
+
+    breakdown: dict[str, int] = {}
+    for _, state, _ in claude_rows:
+        breakdown[state] = breakdown.get(state, 0) + 1
+
+    summary = ", ".join(f"{s}={c}" for s, c in sorted(breakdown.items()))
+
+    d_rows = [f"pid={pid} pcpu={pcpu}" for pid, state, pcpu in claude_rows if state == "D"]
+    if d_rows:
+        return DoctorResult(
+            Severity.WARNING,
+            check_name,
+            f"claude processes in D state: {', '.join(d_rows)} (breakdown: {summary})",
+        )
+
+    return DoctorResult(
+        Severity.OK,
+        check_name,
+        f"claude process state breakdown: {summary}",
     )
 
 
@@ -635,6 +693,9 @@ def run_doctor(*, output_json: bool = False) -> None:
 
     # Check 14: Quota cache schema version
     results.append(_check_quota_cache_schema())
+
+    # Check 15: claude process state breakdown
+    results.append(_check_claude_process_state_breakdown())
 
     # Output
     if output_json:

--- a/src/autoskillit/execution/anomaly_detection.py
+++ b/src/autoskillit/execution/anomaly_detection.py
@@ -18,12 +18,29 @@ class AnomalyKind(StrEnum):
     SIGNALS_PENDING = "signals_pending"
     RSS_GROWTH = "rss_growth"
     FD_HIGH = "fd_high"
+    D_STATE_SUSTAINED = "d_state_sustained"
+    HIGH_CPU_SUSTAINED = "high_cpu_sustained"
 
 
 class AnomalySeverity(StrEnum):
     INFO = "info"
     WARNING = "warning"
     CRITICAL = "critical"
+
+
+# Kernel wait-channel values that are normal for a healthy process in
+# uninterruptible sleep.  D-state snapshots whose wchan matches any of these
+# are NOT counted toward the D_STATE_SUSTAINED threshold.
+# "" and "0" guard against missing-data snapshots (unreadable /proc/wchan).
+BENIGN_WCHANS: frozenset[str] = frozenset(
+    {
+        "do_nanosleep",
+        "do_epoll_wait",
+        "schedule_hrtimeout_range",
+        "",  # /proc returns empty when unreadable — treat as benign
+        "0",  # kernel reports literal "0" when thread is runnable
+    }
+)
 
 
 def _anomaly(
@@ -60,6 +77,8 @@ def detect_anomalies(
         return anomalies
 
     consecutive_zombie = 0
+    consecutive_d_state = 0
+    consecutive_high_cpu = 0
     prev_sig_pnd: str | None = None
     initial_rss: int | None = None
 
@@ -128,6 +147,49 @@ def detect_anomalies(
                 )
         else:
             consecutive_zombie = 0
+
+        # D-state sustained: process stuck in uninterruptible sleep
+        wchan = snap.get("wchan", "")
+        if state == "disk-sleep" and isinstance(wchan, str) and wchan not in BENIGN_WCHANS:
+            consecutive_d_state += 1
+            if consecutive_d_state >= 2:
+                anomalies.append(
+                    _anomaly(
+                        AnomalyKind.D_STATE_SUSTAINED,
+                        AnomalySeverity.WARNING,
+                        {
+                            "state": state,
+                            "wchan": wchan,
+                            "consecutive_count": consecutive_d_state,
+                        },
+                        snap,
+                        seq,
+                        pid,
+                    )
+                )
+        else:
+            consecutive_d_state = 0
+
+        # High-CPU sustained: process burning CPU >= 90% (suspected infinite loop)
+        cpu_percent = snap.get("cpu_percent", 0.0)
+        if isinstance(cpu_percent, (int, float)) and cpu_percent >= 90.0:
+            consecutive_high_cpu += 1
+            if consecutive_high_cpu >= 2:
+                anomalies.append(
+                    _anomaly(
+                        AnomalyKind.HIGH_CPU_SUSTAINED,
+                        AnomalySeverity.WARNING,
+                        {
+                            "cpu_percent": float(cpu_percent),
+                            "consecutive_count": consecutive_high_cpu,
+                        },
+                        snap,
+                        seq,
+                        pid,
+                    )
+                )
+        else:
+            consecutive_high_cpu = 0
 
         # Signals pending: transition from all-zeros to non-zero
         _all_zeros = "0000000000000000"

--- a/src/autoskillit/execution/linux_tracing.py
+++ b/src/autoskillit/execution/linux_tracing.py
@@ -78,6 +78,8 @@ class ProcSnapshot:
     sig_cgt: str
     oom_score: int
     wchan: str
+    # CPU utilisation (0.0 when process arg is not supplied to read_proc_snapshot)
+    cpu_percent: float
 
 
 def _parse_proc_status(content: str) -> dict[str, str]:
@@ -101,13 +103,19 @@ def _parse_proc_status(content: str) -> dict[str, str]:
     return fields
 
 
-def read_proc_snapshot(pid: int) -> ProcSnapshot | None:
-    """Read a complete snapshot for pid. Returns None if process gone."""
+def read_proc_snapshot(pid: int, *, process: psutil.Process | None = None) -> ProcSnapshot | None:
+    """Read a complete snapshot for pid. Returns None if process gone.
+
+    When *process* is provided, it is reused instead of constructing a fresh
+    psutil.Process(pid); cpu_percent(interval=0) then returns a meaningful
+    delta against the baseline primed by the caller.  When *process* is None,
+    cpu_percent defaults to 0.0.
+    """
     if not LINUX_TRACING_AVAILABLE:
         return None
     captured_at = datetime.now(UTC).isoformat()
     try:
-        p = psutil.Process(pid)
+        p = process if process is not None else psutil.Process(pid)
         with p.oneshot():
             state = p.status()
             mem = p.memory_info()
@@ -115,6 +123,7 @@ def read_proc_snapshot(pid: int) -> ProcSnapshot | None:
             num_fds = p.num_fds()
             fd_soft_limit = p.rlimit(psutil.RLIMIT_NOFILE)[0]
             ctx = p.num_ctx_switches()
+            cpu_pct = p.cpu_percent(interval=0) if process is not None else 0.0
     except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
         return None
 
@@ -149,6 +158,7 @@ def read_proc_snapshot(pid: int) -> ProcSnapshot | None:
         sig_cgt=sig_fields.get("sig_cgt", ""),
         oom_score=oom,
         wchan=wchan,
+        cpu_percent=cpu_pct,
     )
 
 
@@ -161,8 +171,13 @@ async def proc_monitor(pid: int, interval: float = 5.0) -> AsyncIterator[ProcSna
     maintain the monotonic ordering invariant at the production site.
     """
     _last_captured_at: str = ""
+    try:
+        _proc = psutil.Process(pid)
+        _proc.cpu_percent(interval=0)  # prime the psutil-internal baseline
+    except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+        return
     while True:
-        snap = read_proc_snapshot(pid)
+        snap = read_proc_snapshot(pid, process=_proc)
         if snap is None:
             return
         captured_at = snap.captured_at

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -1466,3 +1466,83 @@ def test_doctor_reports_drift_in_project_scope(
     assert result.severity == Severity.ERROR
     assert "[project]" in result.message
     assert "pretty_output.py" in result.message
+
+
+# ---------------------------------------------------------------------------
+# REQ-DOCTOR-001 — _check_claude_process_state_breakdown
+# ---------------------------------------------------------------------------
+
+
+class TestCheckClaudeProcessStateBreakdown:
+    """Tests for the claude_process_state doctor check (Check 15)."""
+
+    def _ps_result(self, stdout: str, returncode: int = 0):
+        return type(
+            "CompletedProcess",
+            (),
+            {"returncode": returncode, "stdout": stdout},
+        )()
+
+    def test_ok_when_only_sleeping(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Single sleeping claude process → Severity.OK with state breakdown."""
+        import subprocess
+
+        from autoskillit.cli._doctor import Severity, _check_claude_process_state_breakdown
+
+        header = "PID STAT %CPU COMMAND\n"
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *a, **kw: self._ps_result(header + "1234 S 0.5 claude"),
+        )
+        result = _check_claude_process_state_breakdown()
+        assert result.severity == Severity.OK
+        assert "S=1" in result.message
+
+    def test_warns_on_d_state(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """claude process in D state → Severity.WARNING with pid and pcpu in message."""
+        import subprocess
+
+        from autoskillit.cli._doctor import Severity, _check_claude_process_state_breakdown
+
+        header = "PID STAT %CPU COMMAND\n"
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *a, **kw: self._ps_result(header + "1234 D 99.0 claude"),
+        )
+        result = _check_claude_process_state_breakdown()
+        assert result.severity == Severity.WARNING
+        assert "D=1" in result.message
+        assert "99.0" in result.message
+
+    def test_ok_when_no_claude_processes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Empty ps output (no claude rows) → Severity.OK, 'No claude processes running'."""
+        import subprocess
+
+        from autoskillit.cli._doctor import Severity, _check_claude_process_state_breakdown
+
+        header = "PID STAT %CPU COMMAND\n"
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *a, **kw: self._ps_result(header + "5678 S 0.1 python"),
+        )
+        result = _check_claude_process_state_breakdown()
+        assert result.severity == Severity.OK
+        assert result.message == "No claude processes running"
+
+    def test_ok_when_ps_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """FileNotFoundError from ps → Severity.OK explaining ps unavailability."""
+        import subprocess
+
+        from autoskillit.cli._doctor import Severity, _check_claude_process_state_breakdown
+
+        def _raise(*a, **kw):
+            raise FileNotFoundError("ps")
+
+        monkeypatch.setattr(subprocess, "run", _raise)
+        result = _check_claude_process_state_breakdown()
+        assert result.severity == Severity.OK
+        assert "ps unavailable" in result.message
+        assert "FileNotFoundError" in result.message

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -203,6 +203,14 @@ def test_quota_thresholds_defaults() -> None:
 
 
 def test_doctor_check_count_is_17() -> None:
+    # _count_doctor_checks() counts every "# Check N:" and "# Check Nb:" marker
+    # in run_doctor() — 15 numbered base markers + 2 lettered sub-check markers
+    # (4b, 7b) = 17 total.  test_installation_states_15_doctor_checks checks the
+    # *user-visible* count from docs/installation.md ("13 numbered + 2 lettered
+    # sub-checks 4b and 7b = 15").  The gap of 2 is intentional: Check 4 and
+    # Check 7 each appear as separate implementation markers but the docs
+    # present them as single numbered entries that subsume their b variants.
+    # Update both tests whenever a new doctor check is added.
     assert _count_doctor_checks() == 17, (
         f"Expected 17 doctor checks; found {_count_doctor_checks()}"
     )

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -202,9 +202,9 @@ def test_quota_thresholds_defaults() -> None:
     assert long_ == pytest.approx(98.0)
 
 
-def test_doctor_check_count_is_16() -> None:
-    assert _count_doctor_checks() == 16, (
-        f"Expected 16 doctor checks; found {_count_doctor_checks()}"
+def test_doctor_check_count_is_17() -> None:
+    assert _count_doctor_checks() == 17, (
+        f"Expected 17 doctor checks; found {_count_doctor_checks()}"
     )
 
 
@@ -277,8 +277,8 @@ def test_configuration_states_quota_thresholds() -> None:
     )
 
 
-def test_installation_states_14_doctor_checks() -> None:
-    _assert_doc_states_number(DOCS_DIR / "installation.md", "doctor checks", 14)
+def test_installation_states_15_doctor_checks() -> None:
+    _assert_doc_states_number(DOCS_DIR / "installation.md", "doctor checks", 15)
 
 
 def test_recipes_overview_states_5_recipes() -> None:

--- a/tests/execution/test_anomaly_detection.py
+++ b/tests/execution/test_anomaly_detection.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from autoskillit.execution.anomaly_detection import (
+    BENIGN_WCHANS,
     AnomalyKind,
     AnomalySeverity,
     detect_anomalies,
@@ -23,6 +24,7 @@ def _snap(
     wchan: str = "",
     ctx_switches_voluntary: int = 500,
     ctx_switches_involuntary: int = 20,
+    cpu_percent: float = 0.0,
 ) -> dict[str, object]:
     return {
         "state": state,
@@ -37,6 +39,7 @@ def _snap(
         "wchan": wchan,
         "ctx_switches_voluntary": ctx_switches_voluntary,
         "ctx_switches_involuntary": ctx_switches_involuntary,
+        "cpu_percent": cpu_percent,
     }
 
 
@@ -137,3 +140,217 @@ def test_anomaly_record_structure():
     assert "detail" in anomaly
     assert "snapshot" in anomaly
     assert anomaly["pid"] == 1234
+
+
+# ---------------------------------------------------------------------------
+# REQ-ENUM-001, REQ-ENUM-002
+# ---------------------------------------------------------------------------
+
+
+def test_anomaly_kind_has_d_state_sustained():
+    """AnomalyKind.D_STATE_SUSTAINED is defined with the correct string value."""
+    assert AnomalyKind.D_STATE_SUSTAINED == "d_state_sustained"
+
+
+def test_anomaly_kind_has_high_cpu_sustained():
+    """AnomalyKind.HIGH_CPU_SUSTAINED is defined with the correct string value."""
+    assert AnomalyKind.HIGH_CPU_SUSTAINED == "high_cpu_sustained"
+
+
+# ---------------------------------------------------------------------------
+# REQ-WCHAN-003
+# ---------------------------------------------------------------------------
+
+
+def test_benign_wchans_is_central_frozenset():
+    """BENIGN_WCHANS is a frozenset containing the three issue-cited values."""
+    assert isinstance(BENIGN_WCHANS, frozenset)
+    assert "do_nanosleep" in BENIGN_WCHANS
+    assert "do_epoll_wait" in BENIGN_WCHANS
+    assert "schedule_hrtimeout_range" in BENIGN_WCHANS
+
+
+# ---------------------------------------------------------------------------
+# REQ-DETECT-001, REQ-TEST-001 — D_STATE_SUSTAINED fires
+# ---------------------------------------------------------------------------
+
+
+def test_d_state_sustained_fires_on_two_consecutive():
+    """Two consecutive disk-sleep snapshots with a non-benign wchan fire exactly one anomaly."""
+    snaps = [
+        _snap(state="disk-sleep", wchan="ext4_file_write_iter"),
+        _snap(state="disk-sleep", wchan="ext4_file_write_iter"),
+    ]
+    anomalies = detect_anomalies(snaps, pid=999)
+    d_state = [a for a in anomalies if a["kind"] == AnomalyKind.D_STATE_SUSTAINED]
+    assert len(d_state) == 1
+    assert d_state[0]["seq"] == 1
+
+
+# ---------------------------------------------------------------------------
+# REQ-DETECT-004, REQ-TEST-003 — single snapshot does not fire
+# ---------------------------------------------------------------------------
+
+
+def test_d_state_sustained_no_fire_on_single_snapshot():
+    """A single disk-sleep snapshot yields zero D_STATE_SUSTAINED anomalies."""
+    snaps = [_snap(state="disk-sleep", wchan="ext4_file_write_iter")]
+    anomalies = detect_anomalies(snaps, pid=999)
+    d_state = [a for a in anomalies if a["kind"] == AnomalyKind.D_STATE_SUSTAINED]
+    assert len(d_state) == 0
+
+
+# ---------------------------------------------------------------------------
+# REQ-DETECT-003, REQ-TEST-004 — counter resets on intervening non-D state
+# ---------------------------------------------------------------------------
+
+
+def test_d_state_sustained_counter_resets_on_intervening_sleep():
+    """Sequence [disk-sleep, sleeping, disk-sleep] yields zero D_STATE_SUSTAINED anomalies."""
+    snaps = [
+        _snap(state="disk-sleep", wchan="ext4_file_write_iter"),
+        _snap(state="sleeping"),
+        _snap(state="disk-sleep", wchan="ext4_file_write_iter"),
+    ]
+    anomalies = detect_anomalies(snaps, pid=999)
+    d_state = [a for a in anomalies if a["kind"] == AnomalyKind.D_STATE_SUSTAINED]
+    assert len(d_state) == 0
+
+
+# ---------------------------------------------------------------------------
+# REQ-WCHAN-002, REQ-TEST-005 — benign wchans are skipped
+# ---------------------------------------------------------------------------
+
+
+def test_d_state_sustained_benign_wchan_do_nanosleep_skipped():
+    """Two disk-sleep snapshots with wchan=do_nanosleep yield no D_STATE_SUSTAINED anomaly."""
+    snaps = [
+        _snap(state="disk-sleep", wchan="do_nanosleep"),
+        _snap(state="disk-sleep", wchan="do_nanosleep"),
+    ]
+    anomalies = detect_anomalies(snaps, pid=999)
+    d_state = [a for a in anomalies if a["kind"] == AnomalyKind.D_STATE_SUSTAINED]
+    assert len(d_state) == 0
+
+
+def test_d_state_sustained_benign_wchan_epoll_skipped():
+    """Two disk-sleep snapshots with wchan=do_epoll_wait yield no D_STATE_SUSTAINED anomaly."""
+    snaps = [
+        _snap(state="disk-sleep", wchan="do_epoll_wait"),
+        _snap(state="disk-sleep", wchan="do_epoll_wait"),
+    ]
+    anomalies = detect_anomalies(snaps, pid=999)
+    d_state = [a for a in anomalies if a["kind"] == AnomalyKind.D_STATE_SUSTAINED]
+    assert len(d_state) == 0
+
+
+def test_d_state_sustained_benign_wchan_hrtimeout_skipped():
+    """Two disk-sleep snapshots with wchan=schedule_hrtimeout_range yield no D_STATE_SUSTAINED."""
+    snaps = [
+        _snap(state="disk-sleep", wchan="schedule_hrtimeout_range"),
+        _snap(state="disk-sleep", wchan="schedule_hrtimeout_range"),
+    ]
+    anomalies = detect_anomalies(snaps, pid=999)
+    d_state = [a for a in anomalies if a["kind"] == AnomalyKind.D_STATE_SUSTAINED]
+    assert len(d_state) == 0
+
+
+# ---------------------------------------------------------------------------
+# REQ-WCHAN-001, REQ-TEST-006 — detail includes wchan
+# ---------------------------------------------------------------------------
+
+
+def test_d_state_sustained_detail_includes_wchan():
+    """The emitted D_STATE_SUSTAINED anomaly detail contains the triggering wchan value."""
+    wchan_val = "ext4_file_write_iter"
+    snaps = [
+        _snap(state="disk-sleep", wchan=wchan_val),
+        _snap(state="disk-sleep", wchan=wchan_val),
+    ]
+    anomalies = detect_anomalies(snaps, pid=999)
+    d_state = [a for a in anomalies if a["kind"] == AnomalyKind.D_STATE_SUSTAINED]
+    assert len(d_state) == 1
+    assert d_state[0]["detail"]["wchan"] == wchan_val
+
+
+# ---------------------------------------------------------------------------
+# REQ-DETECT-002, REQ-TEST-002 — HIGH_CPU_SUSTAINED fires
+# ---------------------------------------------------------------------------
+
+
+def test_high_cpu_sustained_fires_on_two_consecutive():
+    """Two consecutive snapshots with cpu_percent=95.0 produce exactly one HIGH_CPU_SUSTAINED."""
+    snaps = [_snap(cpu_percent=95.0), _snap(cpu_percent=95.0)]
+    anomalies = detect_anomalies(snaps, pid=999)
+    high_cpu = [a for a in anomalies if a["kind"] == AnomalyKind.HIGH_CPU_SUSTAINED]
+    assert len(high_cpu) == 1
+
+
+# ---------------------------------------------------------------------------
+# REQ-DETECT-004, REQ-TEST-003 — single high-CPU snapshot does not fire
+# ---------------------------------------------------------------------------
+
+
+def test_high_cpu_sustained_no_fire_on_single_snapshot():
+    """A single high-CPU snapshot yields zero HIGH_CPU_SUSTAINED anomalies."""
+    snaps = [_snap(cpu_percent=95.0)]
+    anomalies = detect_anomalies(snaps, pid=999)
+    high_cpu = [a for a in anomalies if a["kind"] == AnomalyKind.HIGH_CPU_SUSTAINED]
+    assert len(high_cpu) == 0
+
+
+# ---------------------------------------------------------------------------
+# REQ-DETECT-002 — exact threshold
+# ---------------------------------------------------------------------------
+
+
+def test_high_cpu_sustained_fires_at_exact_threshold():
+    """cpu_percent=90.0 fires; cpu_percent=89.9 does not."""
+    snaps_at = [_snap(cpu_percent=90.0), _snap(cpu_percent=90.0)]
+    anomalies_at = detect_anomalies(snaps_at, pid=999)
+    high_cpu_at = [a for a in anomalies_at if a["kind"] == AnomalyKind.HIGH_CPU_SUSTAINED]
+    assert len(high_cpu_at) == 1
+
+    snaps_below = [_snap(cpu_percent=89.9), _snap(cpu_percent=89.9)]
+    anomalies_below = detect_anomalies(snaps_below, pid=999)
+    high_cpu_below = [a for a in anomalies_below if a["kind"] == AnomalyKind.HIGH_CPU_SUSTAINED]
+    assert len(high_cpu_below) == 0
+
+
+# ---------------------------------------------------------------------------
+# REQ-DETECT-003, REQ-TEST-004 — counter resets on intervening idle
+# ---------------------------------------------------------------------------
+
+
+def test_high_cpu_sustained_counter_resets_on_intervening_idle():
+    """Sequence [95%, 10%, 95%] yields zero HIGH_CPU_SUSTAINED anomalies."""
+    snaps = [_snap(cpu_percent=95.0), _snap(cpu_percent=10.0), _snap(cpu_percent=95.0)]
+    anomalies = detect_anomalies(snaps, pid=999)
+    high_cpu = [a for a in anomalies if a["kind"] == AnomalyKind.HIGH_CPU_SUSTAINED]
+    assert len(high_cpu) == 0
+
+
+# ---------------------------------------------------------------------------
+# design — detail includes cpu_percent
+# ---------------------------------------------------------------------------
+
+
+def test_high_cpu_sustained_detail_includes_cpu_percent():
+    """The emitted HIGH_CPU_SUSTAINED anomaly detail contains the cpu_percent value."""
+    snaps = [_snap(cpu_percent=95.5), _snap(cpu_percent=95.5)]
+    anomalies = detect_anomalies(snaps, pid=999)
+    high_cpu = [a for a in anomalies if a["kind"] == AnomalyKind.HIGH_CPU_SUSTAINED]
+    assert len(high_cpu) == 1
+    assert high_cpu[0]["detail"]["cpu_percent"] == 95.5
+
+
+# ---------------------------------------------------------------------------
+# regression — existing normal session test still holds
+# ---------------------------------------------------------------------------
+
+
+def test_no_anomalies_for_normal_session_still_holds():
+    """Normal session with cpu_percent=0.0 default still produces no anomalies."""
+    snaps = [_snap(vm_rss_kb=100000 + i * 100, oom_score=50) for i in range(10)]
+    anomalies = detect_anomalies(snaps, pid=1234)
+    assert len(anomalies) == 0

--- a/tests/execution/test_anomaly_detection.py
+++ b/tests/execution/test_anomaly_detection.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from autoskillit.execution.anomaly_detection import (
     BENIGN_WCHANS,
     AnomalyKind,
@@ -157,22 +159,12 @@ def test_anomaly_kind_has_high_cpu_sustained():
     assert AnomalyKind.HIGH_CPU_SUSTAINED == "high_cpu_sustained"
 
 
-# ---------------------------------------------------------------------------
-# REQ-WCHAN-003
-# ---------------------------------------------------------------------------
-
-
 def test_benign_wchans_is_central_frozenset():
     """BENIGN_WCHANS is a frozenset containing the three issue-cited values."""
     assert isinstance(BENIGN_WCHANS, frozenset)
     assert "do_nanosleep" in BENIGN_WCHANS
     assert "do_epoll_wait" in BENIGN_WCHANS
     assert "schedule_hrtimeout_range" in BENIGN_WCHANS
-
-
-# ---------------------------------------------------------------------------
-# REQ-DETECT-001, REQ-TEST-001 — D_STATE_SUSTAINED fires
-# ---------------------------------------------------------------------------
 
 
 def test_d_state_sustained_fires_on_two_consecutive():
@@ -187,22 +179,12 @@ def test_d_state_sustained_fires_on_two_consecutive():
     assert d_state[0]["seq"] == 1
 
 
-# ---------------------------------------------------------------------------
-# REQ-DETECT-004, REQ-TEST-003 — single snapshot does not fire
-# ---------------------------------------------------------------------------
-
-
 def test_d_state_sustained_no_fire_on_single_snapshot():
     """A single disk-sleep snapshot yields zero D_STATE_SUSTAINED anomalies."""
     snaps = [_snap(state="disk-sleep", wchan="ext4_file_write_iter")]
     anomalies = detect_anomalies(snaps, pid=999)
     d_state = [a for a in anomalies if a["kind"] == AnomalyKind.D_STATE_SUSTAINED]
     assert len(d_state) == 0
-
-
-# ---------------------------------------------------------------------------
-# REQ-DETECT-003, REQ-TEST-004 — counter resets on intervening non-D state
-# ---------------------------------------------------------------------------
 
 
 def test_d_state_sustained_counter_resets_on_intervening_sleep():
@@ -222,42 +204,16 @@ def test_d_state_sustained_counter_resets_on_intervening_sleep():
 # ---------------------------------------------------------------------------
 
 
-def test_d_state_sustained_benign_wchan_do_nanosleep_skipped():
-    """Two disk-sleep snapshots with wchan=do_nanosleep yield no D_STATE_SUSTAINED anomaly."""
+@pytest.mark.parametrize("wchan", ["do_nanosleep", "do_epoll_wait", "schedule_hrtimeout_range"])
+def test_d_state_sustained_benign_wchan_skipped(wchan: str) -> None:
+    """Two disk-sleep snapshots with a benign wchan yield no D_STATE_SUSTAINED anomaly."""
     snaps = [
-        _snap(state="disk-sleep", wchan="do_nanosleep"),
-        _snap(state="disk-sleep", wchan="do_nanosleep"),
+        _snap(state="disk-sleep", wchan=wchan),
+        _snap(state="disk-sleep", wchan=wchan),
     ]
     anomalies = detect_anomalies(snaps, pid=999)
     d_state = [a for a in anomalies if a["kind"] == AnomalyKind.D_STATE_SUSTAINED]
     assert len(d_state) == 0
-
-
-def test_d_state_sustained_benign_wchan_epoll_skipped():
-    """Two disk-sleep snapshots with wchan=do_epoll_wait yield no D_STATE_SUSTAINED anomaly."""
-    snaps = [
-        _snap(state="disk-sleep", wchan="do_epoll_wait"),
-        _snap(state="disk-sleep", wchan="do_epoll_wait"),
-    ]
-    anomalies = detect_anomalies(snaps, pid=999)
-    d_state = [a for a in anomalies if a["kind"] == AnomalyKind.D_STATE_SUSTAINED]
-    assert len(d_state) == 0
-
-
-def test_d_state_sustained_benign_wchan_hrtimeout_skipped():
-    """Two disk-sleep snapshots with wchan=schedule_hrtimeout_range yield no D_STATE_SUSTAINED."""
-    snaps = [
-        _snap(state="disk-sleep", wchan="schedule_hrtimeout_range"),
-        _snap(state="disk-sleep", wchan="schedule_hrtimeout_range"),
-    ]
-    anomalies = detect_anomalies(snaps, pid=999)
-    d_state = [a for a in anomalies if a["kind"] == AnomalyKind.D_STATE_SUSTAINED]
-    assert len(d_state) == 0
-
-
-# ---------------------------------------------------------------------------
-# REQ-WCHAN-001, REQ-TEST-006 — detail includes wchan
-# ---------------------------------------------------------------------------
 
 
 def test_d_state_sustained_detail_includes_wchan():
@@ -273,11 +229,6 @@ def test_d_state_sustained_detail_includes_wchan():
     assert d_state[0]["detail"]["wchan"] == wchan_val
 
 
-# ---------------------------------------------------------------------------
-# REQ-DETECT-002, REQ-TEST-002 — HIGH_CPU_SUSTAINED fires
-# ---------------------------------------------------------------------------
-
-
 def test_high_cpu_sustained_fires_on_two_consecutive():
     """Two consecutive snapshots with cpu_percent=95.0 produce exactly one HIGH_CPU_SUSTAINED."""
     snaps = [_snap(cpu_percent=95.0), _snap(cpu_percent=95.0)]
@@ -286,22 +237,12 @@ def test_high_cpu_sustained_fires_on_two_consecutive():
     assert len(high_cpu) == 1
 
 
-# ---------------------------------------------------------------------------
-# REQ-DETECT-004, REQ-TEST-003 — single high-CPU snapshot does not fire
-# ---------------------------------------------------------------------------
-
-
 def test_high_cpu_sustained_no_fire_on_single_snapshot():
     """A single high-CPU snapshot yields zero HIGH_CPU_SUSTAINED anomalies."""
     snaps = [_snap(cpu_percent=95.0)]
     anomalies = detect_anomalies(snaps, pid=999)
     high_cpu = [a for a in anomalies if a["kind"] == AnomalyKind.HIGH_CPU_SUSTAINED]
     assert len(high_cpu) == 0
-
-
-# ---------------------------------------------------------------------------
-# REQ-DETECT-002 — exact threshold
-# ---------------------------------------------------------------------------
 
 
 def test_high_cpu_sustained_fires_at_exact_threshold():
@@ -317,22 +258,12 @@ def test_high_cpu_sustained_fires_at_exact_threshold():
     assert len(high_cpu_below) == 0
 
 
-# ---------------------------------------------------------------------------
-# REQ-DETECT-003, REQ-TEST-004 — counter resets on intervening idle
-# ---------------------------------------------------------------------------
-
-
 def test_high_cpu_sustained_counter_resets_on_intervening_idle():
     """Sequence [95%, 10%, 95%] yields zero HIGH_CPU_SUSTAINED anomalies."""
     snaps = [_snap(cpu_percent=95.0), _snap(cpu_percent=10.0), _snap(cpu_percent=95.0)]
     anomalies = detect_anomalies(snaps, pid=999)
     high_cpu = [a for a in anomalies if a["kind"] == AnomalyKind.HIGH_CPU_SUSTAINED]
     assert len(high_cpu) == 0
-
-
-# ---------------------------------------------------------------------------
-# design — detail includes cpu_percent
-# ---------------------------------------------------------------------------
 
 
 def test_high_cpu_sustained_detail_includes_cpu_percent():
@@ -342,11 +273,6 @@ def test_high_cpu_sustained_detail_includes_cpu_percent():
     high_cpu = [a for a in anomalies if a["kind"] == AnomalyKind.HIGH_CPU_SUSTAINED]
     assert len(high_cpu) == 1
     assert high_cpu[0]["detail"]["cpu_percent"] == 95.5
-
-
-# ---------------------------------------------------------------------------
-# regression — existing normal session test still holds
-# ---------------------------------------------------------------------------
 
 
 def test_no_anomalies_for_normal_session_still_holds():

--- a/tests/execution/test_linux_tracing.py
+++ b/tests/execution/test_linux_tracing.py
@@ -72,6 +72,9 @@ def test_read_proc_snapshot_has_all_fields():
     # context switches (psutil-sourced)
     assert snap.ctx_switches_voluntary >= 0
     assert snap.ctx_switches_involuntary >= 0
+    # cpu_percent field
+    assert isinstance(snap.cpu_percent, float)
+    assert snap.cpu_percent >= 0.0
 
 
 @pytest.mark.anyio
@@ -314,3 +317,48 @@ async def test_proc_monitor_snapshots_have_distinct_timestamps():
     assert len(result) >= 2
     timestamps = [s.captured_at for s in result]
     assert len(set(timestamps)) == len(timestamps), "All captured_at must be unique"
+
+
+# ---------------------------------------------------------------------------
+# design prerequisite — cpu_percent field
+# ---------------------------------------------------------------------------
+
+
+def test_read_proc_snapshot_returns_cpu_percent_field():
+    """read_proc_snapshot() returns a ProcSnapshot with cpu_percent as a float >= 0.0."""
+    from autoskillit.execution.linux_tracing import read_proc_snapshot
+
+    snap = read_proc_snapshot(os.getpid())
+    assert snap is not None
+    assert isinstance(snap.cpu_percent, float)
+    assert snap.cpu_percent >= 0.0
+
+
+@pytest.mark.anyio
+async def test_proc_monitor_persists_psutil_process_for_cpu_percent():
+    """proc_monitor reports cpu_percent > 0 for a CPU-bound subprocess.
+
+    This is only possible when a single psutil.Process is reused across iterations
+    and its baseline is primed before the loop. A fresh Process per iteration always
+    returns 0.0 on the first cpu_percent(interval=0) call.
+    """
+    import subprocess
+
+    from autoskillit.execution.linux_tracing import proc_monitor
+
+    proc = subprocess.Popen(
+        [sys.executable, "-c", "while True: pass"],
+    )
+    try:
+        snaps = []
+        async for snap in proc_monitor(proc.pid, interval=0.1):
+            snaps.append(snap)
+            if len(snaps) >= 5:
+                break
+        assert len(snaps) >= 3, "Need at least 3 snapshots"
+        assert any(s.cpu_percent > 0.0 for s in snaps), (
+            "At least one snapshot must show cpu_percent > 0.0 for a CPU-bound process"
+        )
+    finally:
+        proc.kill()
+        proc.wait()

--- a/tests/execution/test_linux_tracing.py
+++ b/tests/execution/test_linux_tracing.py
@@ -319,21 +319,6 @@ async def test_proc_monitor_snapshots_have_distinct_timestamps():
     assert len(set(timestamps)) == len(timestamps), "All captured_at must be unique"
 
 
-# ---------------------------------------------------------------------------
-# design prerequisite — cpu_percent field
-# ---------------------------------------------------------------------------
-
-
-def test_read_proc_snapshot_returns_cpu_percent_field():
-    """read_proc_snapshot() returns a ProcSnapshot with cpu_percent as a float >= 0.0."""
-    from autoskillit.execution.linux_tracing import read_proc_snapshot
-
-    snap = read_proc_snapshot(os.getpid())
-    assert snap is not None
-    assert isinstance(snap.cpu_percent, float)
-    assert snap.cpu_percent >= 0.0
-
-
 @pytest.mark.anyio
 async def test_proc_monitor_persists_psutil_process_for_cpu_percent():
     """proc_monitor reports cpu_percent > 0 for a CPU-bound subprocess.
@@ -351,10 +336,11 @@ async def test_proc_monitor_persists_psutil_process_for_cpu_percent():
     )
     try:
         snaps = []
-        async for snap in proc_monitor(proc.pid, interval=0.1):
-            snaps.append(snap)
-            if len(snaps) >= 5:
-                break
+        with anyio.fail_after(10):
+            async for snap in proc_monitor(proc.pid, interval=0.1):
+                snaps.append(snap)
+                if len(snaps) >= 5:
+                    break
         assert len(snaps) >= 3, "Need at least 3 snapshots"
         assert any(s.cpu_percent > 0.0 for s in snaps), (
             "At least one snapshot must show cpu_percent > 0.0 for a CPU-bound process"

--- a/tests/execution/test_session_log_integration.py
+++ b/tests/execution/test_session_log_integration.py
@@ -70,3 +70,68 @@ async def test_full_tracing_pipeline_writes_distinct_timestamps(tmp_path):
         "duration_seconds in summary.json must reflect monotonic elapsed, "
         "not wall-clock subtraction"
     )
+
+
+# ---------------------------------------------------------------------------
+# REQ-DIAG-001 — new anomaly kinds surface in anomalies.jsonl
+# ---------------------------------------------------------------------------
+
+_BASE_SNAP: dict[str, object] = {
+    "captured_at": "2026-01-01T00:00:00+00:00",
+    "vm_rss_kb": 100000,
+    "threads": 4,
+    "fd_count": 10,
+    "fd_soft_limit": 1024,
+    "ctx_switches_voluntary": 500,
+    "ctx_switches_involuntary": 20,
+    "sig_pnd": "0000000000000000",
+    "sig_blk": "0000000000000000",
+    "sig_cgt": "0000000000000000",
+    "oom_score": 50,
+    "cpu_percent": 0.0,
+}
+
+
+def _flush_with_snaps(tmp_path, session_id: str, snaps: list[dict]) -> None:
+    from autoskillit.execution.session_log import flush_session_log
+
+    flush_session_log(
+        log_dir=str(tmp_path),
+        cwd="/tmp",
+        session_id=session_id,
+        pid=12345,
+        skill_command="/test",
+        success=True,
+        subtype="completed",
+        exit_code=0,
+        start_ts="2026-01-01T00:00:00+00:00",
+        proc_snapshots=snaps,
+    )
+
+
+def test_flush_session_log_surfaces_d_state_sustained(tmp_path):
+    """flush_session_log writes d_state_sustained to anomalies.jsonl (REQ-DIAG-001)."""
+    snaps = [
+        {**_BASE_SNAP, "state": "disk-sleep", "wchan": "ext4_file_write_iter"},
+        {**_BASE_SNAP, "state": "disk-sleep", "wchan": "ext4_file_write_iter"},
+    ]
+    _flush_with_snaps(tmp_path, "diag-d-state-001", snaps)
+
+    anomalies_path = tmp_path / "sessions" / "diag-d-state-001" / "anomalies.jsonl"
+    assert anomalies_path.exists(), "anomalies.jsonl must be created when anomalies are detected"
+    kinds = [json.loads(line)["kind"] for line in anomalies_path.read_text().splitlines()]
+    assert "d_state_sustained" in kinds
+
+
+def test_flush_session_log_surfaces_high_cpu_sustained(tmp_path):
+    """flush_session_log writes high_cpu_sustained to anomalies.jsonl (REQ-DIAG-001)."""
+    snaps = [
+        {**_BASE_SNAP, "state": "sleeping", "wchan": "", "cpu_percent": 95.0},
+        {**_BASE_SNAP, "state": "sleeping", "wchan": "", "cpu_percent": 95.0},
+    ]
+    _flush_with_snaps(tmp_path, "diag-high-cpu-001", snaps)
+
+    anomalies_path = tmp_path / "sessions" / "diag-high-cpu-001" / "anomalies.jsonl"
+    assert anomalies_path.exists(), "anomalies.jsonl must be created when anomalies are detected"
+    kinds = [json.loads(line)["kind"] for line in anomalies_path.read_text().splitlines()]
+    assert "high_cpu_sustained" in kinds


### PR DESCRIPTION
## Summary

Extend `execution/anomaly_detection.py` with two new `AnomalyKind` members —
`D_STATE_SUSTAINED` and `HIGH_CPU_SUSTAINED` — that fire when ≥2 consecutive
`ProcSnapshot`s show the process stuck in uninterruptible sleep (I/O hang) or
burning CPU ≥ 90% (suspected infinite loop). Wire the detection into
`detect_anomalies()` following the existing `consecutive_zombie` counter
pattern, filter out benign `wchan` values via a centrally-defined
`BENIGN_WCHANS` frozenset, and include `wchan` in the D-state anomaly detail
so operators can see which kernel function the process is stuck in.

A prerequisite correction is required: the issue asserts CPU% is already
captured in `ProcSnapshot`, but the current `ProcSnapshot` dataclass has no
`cpu_percent` field. The plan therefore adds `cpu_percent` to `ProcSnapshot`
and teaches `proc_monitor` to persist a single `psutil.Process` instance so
that `cpu_percent(interval=0)` returns meaningful values across snapshots.
Without this, `HIGH_CPU_SUSTAINED` has no input signal.

Session diagnostics surfacing (REQ-DIAG-001) is automatic once detection
fires: `flush_session_log()` already serialises every anomaly record to
`anomalies.jsonl` via `json.dumps(a, sort_keys=True)` without enumerating
kinds. An integration test locks that behaviour in.

The optional doctor check (REQ-DOCTOR-001) is included: a new numbered
Check 15 runs `ps -axo pid,state,pcpu,comm`, filters to `claude`
processes, groups by state, and prints the breakdown, warning when any
claude process is currently in D state.

## Requirements

### ENUM — Anomaly Enum Extensions

- **REQ-ENUM-001:** `AnomalyKind` must include a `D_STATE_SUSTAINED` member.
- **REQ-ENUM-002:** `AnomalyKind` must include a `HIGH_CPU_SUSTAINED` member.

### DETECT — Detection Logic

- **REQ-DETECT-001:** `detect_anomalies()` must fire `D_STATE_SUSTAINED` when two or more consecutive snapshots show `state == "D"`.
- **REQ-DETECT-002:** `detect_anomalies()` must fire `HIGH_CPU_SUSTAINED` when two or more consecutive snapshots show CPU percent ≥ 90.
- **REQ-DETECT-003:** The consecutive-match counter for each new anomaly kind must reset when a non-matching snapshot intervenes.
- **REQ-DETECT-004:** Neither new anomaly kind must fire on a single matching snapshot.

### WCHAN — wchan Handling

- **REQ-WCHAN-001:** The `D_STATE_SUSTAINED` anomaly detail must include the `wchan` value from the matching snapshot.
- **REQ-WCHAN-002:** `D_STATE_SUSTAINED` must not fire when `wchan` indicates a legitimate sleep (e.g., `do_nanosleep`, `do_epoll_wait`, `schedule_hrtimeout_range`).
- **REQ-WCHAN-003:** The benign-`wchan` ignore list must be centrally defined so it can be extended without touching the detection loop.

### TEST — Test Coverage

- **REQ-TEST-001:** Tests must verify `D_STATE_SUSTAINED` fires on two consecutive D-state snapshots.
- **REQ-TEST-002:** Tests must verify `HIGH_CPU_SUSTAINED` fires on two consecutive snapshots where CPU percent is ≥ 90.
- **REQ-TEST-003:** Tests must verify neither new anomaly fires on a single matching snapshot.
- **REQ-TEST-004:** Tests must verify the consecutive-match counter resets when a non-matching snapshot intervenes for each new kind.
- **REQ-TEST-005:** Tests must verify D-state snapshots with benign `wchan` values do not fire `D_STATE_SUSTAINED`.
- **REQ-TEST-006:** Tests must verify the `D_STATE_SUSTAINED` anomaly detail includes the `wchan` field.

### DIAG — Session Diagnostics Surface

- **REQ-DIAG-001:** Session diagnostics JSONL entries written by `execution/session_log.py` must surface `D_STATE_SUSTAINED` and `HIGH_CPU_SUSTAINED` anomaly kinds alongside the existing kinds.

### DOCTOR — Diagnostic CLI (Optional)

- **REQ-DOCTOR-001:** If the `cli/_doctor.py` check is implemented, it must run `ps -axo pid,state,pcpu,comm`, filter to `claude` processes, and print the state breakdown for interactive hang debugging.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;

    %% ── TERMINALS ── %%
    START([START: run_headless_core])
    START2([START: autoskillit doctor])
    SESSION_DONE([SESSION COMPLETE])
    DOCTOR_OK([DOCTOR OK])
    DOCTOR_WARN([DOCTOR WARNING])

    %% ─────────────────────────────────── %%
    %% FLOW A: SESSION MONITORING          %%
    %% ─────────────────────────────────── %%

    subgraph Monitor ["● Phase 1 — Process Monitor Loop  (linux_tracing.py)"]
        direction TB
        PersistProc["● Persist psutil.Process once<br/>━━━━━━━━━━<br/>proc_monitor() constructs Process(pid)<br/>calls cpu_percent(interval=0) to prime baseline<br/>reuses same object every iteration"]
        SnapTick{"next interval tick<br/>━━━━━━━━━━<br/>await anyio.sleep(proc_interval)"}
        ReadSnap["● read_proc_snapshot(pid, process=_proc)<br/>━━━━━━━━━━<br/>psutil.oneshot(): state, vm_rss_kb, threads,<br/>  fd_count, fd_soft_limit, ctx_switches<br/>● cpu_percent(interval=0) — delta since last call<br/>/proc reads: oom_score, wchan, SigPnd/Blk/Cgt"]
        ProcDied{"snap is None?<br/>━━━━━━━━━━<br/>NoSuchProcess /<br/>AccessDenied"}
        AccSnap["accumulate + stream snapshot<br/>━━━━━━━━━━<br/>handle._snapshots.append(snap)<br/>writes JSON line → /dev/shm/autoskillit_trace_{pid}.jsonl"]
    end

    subgraph SessionEnd ["Phase 2 — Session Termination"]
        direction TB
        TrigFire["race trigger fires<br/>━━━━━━━━━━<br/>Channel A (stdout JSONL result)<br/>Channel B (Claude session JSONL)<br/>process exit / idle timeout"]
        StopTrace["tracing_handle.stop()<br/>━━━━━━━━━━<br/>cancel CancelScope → stops monitor task<br/>flush+close tmpfs file<br/>returns list[ProcSnapshot]"]
        FinalSnap["read final snapshot<br/>━━━━━━━━━━<br/>read_proc_snapshot(pid) — no process=<br/>cpu_percent = 0.0 (post-death baseline)"]
    end

    subgraph AnomalyDetect ["● Phase 3 — Post-Hoc Anomaly Detection  (anomaly_detection.py)"]
        direction TB
        DetectEntry["detect_anomalies(snapshots, pid)<br/>━━━━━━━━━━<br/>called once from flush_session_log()<br/>initialises counters: consecutive_zombie,<br/>consecutive_d_state, consecutive_high_cpu"]
        SnapIter{"for seq, snap in enumerate(snapshots)<br/>━━━━━━━━━━<br/>linear pass — no early exit"}
        DStateGate{"● state == disk-sleep?<br/>━━━━━━━━━━<br/>AND wchan not in BENIGN_WCHANS<br/>(do_nanosleep, do_epoll_wait,<br/>schedule_hrtimeout_range, '', '0')"}
        DStateCount{"● consecutive_d_state >= 2?"}
        EmitDState["● emit D_STATE_SUSTAINED<br/>━━━━━━━━━━<br/>severity: WARNING<br/>detail: {state, wchan, consecutive_count}"]
        CPUGate{"● cpu_percent >= 90.0?"}
        CPUCount{"● consecutive_high_cpu >= 2?"}
        EmitHighCPU["● emit HIGH_CPU_SUSTAINED<br/>━━━━━━━━━━<br/>severity: WARNING<br/>detail: {cpu_percent, consecutive_count}"]
        OtherDet["other detectors (unchanged)<br/>━━━━━━━━━━<br/>OOM_SPIKE (delta > 200) · OOM_CRITICAL (≥ 800)<br/>ZOMBIE_DETECTED · ZOMBIE_PERSISTENT (≥ 3)<br/>SIGNALS_PENDING (sig_pnd rising edge)<br/>FD_HIGH (fd ratio > 0.80)"]
        PostLoop["post-loop: RSS_GROWTH<br/>━━━━━━━━━━<br/>final_rss > 2x initial_rss<br/>AND len(snapshots) >= 5"]
    end

    subgraph LogFlush ["Phase 4 — Session Log Flush  (session_log.py)"]
        direction TB
        WriteTrace["write proc_trace.jsonl<br/>━━━━━━━━━━<br/>one line per snapshot<br/>tracks peak_rss_kb, peak_oom_score, peak_fd_ratio"]
        HasAnom{"anomalies list non-empty?"}
        WriteAnom["write anomalies.jsonl<br/>━━━━━━━━━━<br/>{ts, seq, event, kind, severity,<br/>pid, detail, snapshot} per line"]
        WriteSummary["write summary.json (atomic)<br/>━━━━━━━━━━<br/>anomaly_count · peak fields<br/>session metadata · termination_reason"]
        AppendIdx["append sessions.jsonl<br/>━━━━━━━━━━<br/>global index with anomaly_count,<br/>peak_rss_kb, peak_oom_score"]
        Retention["_enforce_retention()<br/>━━━━━━━━━━<br/>trim to 500 sessions, rewrite index"]
    end

    %% ─────────────────────────────────── %%
    %% FLOW B: DOCTOR CHECK 15             %%
    %% ─────────────────────────────────── %%

    subgraph DoctorFlow ["● Phase 5 — Doctor Check 15  (cli/_doctor.py)"]
        direction TB
        RunPS["● _check_claude_process_state_breakdown()<br/>━━━━━━━━━━<br/>run: ps -axo pid,state,pcpu,comm<br/>timeout=5s · returns OK on any ps failure"]
        FilterClaude{"comm == 'claude'<br/>or ends with '/claude'?"}
        AnyProcs{"claude processes<br/>found?"}
        BuildBreakdown["build state breakdown<br/>━━━━━━━━━━<br/>count by ps state letter<br/>format: 'D=1, S=3'"]
        CheckDStatePS{"any row<br/>state == 'D'?"}
        DoctorOKMsg["OK: 'claude process state breakdown: S=2'<br/>━━━━━━━━━━<br/>no D-state processes"]
        DoctorWarnMsg["WARNING: lists stuck PIDs<br/>━━━━━━━━━━<br/>'pid=X pcpu=Y' for each D-state claude proc<br/>includes full breakdown"]
    end

    %% ─────────────────────────────────── %%
    %% CONNECTIONS — FLOW A                %%
    %% ─────────────────────────────────── %%
    START --> PersistProc
    PersistProc --> SnapTick
    SnapTick --> ReadSnap
    ReadSnap --> ProcDied
    ProcDied -->|"yes — generator returns"| TrigFire
    ProcDied -->|"no"| AccSnap
    AccSnap -->|"sleep interval"| SnapTick

    TrigFire --> StopTrace
    StopTrace --> FinalSnap
    FinalSnap --> DetectEntry

    DetectEntry --> SnapIter
    SnapIter -->|"each snapshot"| DStateGate
    DStateGate -->|"yes — non-benign D-state"| DStateCount
    DStateGate -->|"no — reset counter"| CPUGate
    DStateCount -->|">= 2"| EmitDState
    DStateCount -->|"< 2"| CPUGate
    EmitDState --> CPUGate
    CPUGate -->|"yes"| CPUCount
    CPUGate -->|"no — reset counter"| OtherDet
    CPUCount -->|">= 2"| EmitHighCPU
    CPUCount -->|"< 2"| OtherDet
    EmitHighCPU --> OtherDet
    OtherDet -->|"next snapshot"| SnapIter
    SnapIter -->|"loop done"| PostLoop

    PostLoop --> WriteTrace
    WriteTrace --> HasAnom
    HasAnom -->|"yes"| WriteAnom
    HasAnom -->|"no"| WriteSummary
    WriteAnom --> WriteSummary
    WriteSummary --> AppendIdx
    AppendIdx --> Retention
    Retention --> SESSION_DONE

    %% ─────────────────────────────────── %%
    %% CONNECTIONS — FLOW B                %%
    %% ─────────────────────────────────── %%
    START2 --> RunPS
    RunPS --> FilterClaude
    FilterClaude -->|"match"| AnyProcs
    FilterClaude -->|"skip row"| FilterClaude
    AnyProcs -->|"none found"| DoctorOKMsg
    AnyProcs -->|"found"| BuildBreakdown
    BuildBreakdown --> CheckDStatePS
    CheckDStatePS -->|"no D-state"| DoctorOKMsg
    CheckDStatePS -->|"D-state found"| DoctorWarnMsg
    DoctorOKMsg --> DOCTOR_OK
    DoctorWarnMsg --> DOCTOR_WARN

    %% ─────────────────────────────────── %%
    %% CLASS ASSIGNMENTS                   %%
    %% ─────────────────────────────────── %%
    class START,START2,SESSION_DONE,DOCTOR_OK,DOCTOR_WARN terminal;
    class PersistProc,ReadSnap,AccSnap,FinalSnap,TrigFire,StopTrace handler;
    class DStateGate,DStateCount,CPUGate,CPUCount,SnapTick,ProcDied stateNode;
    class DetectEntry,SnapIter phase;
    class EmitDState,EmitHighCPU,OtherDet,PostLoop detector;
    class WriteTrace,WriteAnom,WriteSummary,AppendIdx,Retention output;
    class RunPS,FilterClaude,AnyProcs,BuildBreakdown,CheckDStatePS,DoctorOKMsg,DoctorWarnMsg handler;
```

### Operational Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ── COLUMN A: autoskillit doctor ── %%
    subgraph Doctor ["AUTOSKILLIT DOCTOR  (autoskillit doctor)"]
        direction TB
        DOCTOR_CMD["● autoskillit doctor<br/>━━━━━━━━━━<br/>15 project-health checks<br/>--json flag available<br/>cli/_doctor.py"]

        subgraph DoctorChecks ["Checks 1–14 (unchanged)"]
            direction TB
            CHECKS_PREV["stale_mcp_servers · mcp_server_registered<br/>autoskillit_on_path · project_config<br/>hook_health · hook_registration<br/>version_consistency · script_version_health<br/>gitignore · secret_scanning · quota_cache_schema<br/>source_version_drift · editable_install · stale_entry_points"]
        end

        CHECK15["● Check 15: claude_process_state<br/>━━━━━━━━━━<br/>ps -axo pid,state,pcpu,comm<br/>Detects D-state + high-CPU<br/>Reports per-process breakdown<br/>_check_claude_process_state_breakdown()"]
    end

    %% ── COLUMN B: runtime process monitoring ── %%
    subgraph Runtime ["HEADLESS SESSION RUNTIME  (execution/linux_tracing.py)"]
        direction TB
        PROC_MON["● proc_monitor(pid)<br/>━━━━━━━━━━<br/>Async generator, 5 s interval<br/>Persists psutil.Process handle<br/>Primes cpu_percent baseline<br/>Monotonic captured_at guarantee"]

        PROC_SNAP["● ProcSnapshot (dataclass)<br/>━━━━━━━━━━<br/>state · vm_rss_kb · threads<br/>fd_count · fd_soft_limit<br/>sig_pnd · sig_blk · sig_cgt<br/>oom_score · wchan<br/>★ cpu_percent (new field)"]

        TMPFS["/dev/shm/autoskillit_trace_{pid}.jsonl<br/>━━━━━━━━━━<br/>Crash-resilient tmpfs stream<br/>Line-buffered JSONL<br/>Recovered on next startup"]
    end

    %% ── COLUMN C: anomaly detection ── %%
    subgraph AnomalyDetect ["ANOMALY DETECTION  (execution/anomaly_detection.py)"]
        direction TB
        DETECT["● detect_anomalies(snapshots, pid)<br/>━━━━━━━━━━<br/>Post-hoc, runs at flush time<br/>Multi-snapshot pattern matching"]

        subgraph ExistingAnomalies ["Existing Anomaly Kinds"]
            direction TB
            EXISTING["OOM_SPIKE · OOM_CRITICAL<br/>ZOMBIE_DETECTED · ZOMBIE_PERSISTENT<br/>SIGNALS_PENDING · RSS_GROWTH · FD_HIGH"]
        end

        D_STATE["● D_STATE_SUSTAINED<br/>━━━━━━━━━━<br/>state == disk-sleep<br/>wchan ∉ BENIGN_WCHANS<br/>≥ 2 consecutive snapshots<br/>severity: WARNING"]

        HIGH_CPU["● HIGH_CPU_SUSTAINED<br/>━━━━━━━━━━<br/>cpu_percent ≥ 90 %<br/>≥ 2 consecutive snapshots<br/>severity: WARNING"]

        BENIGN["● BENIGN_WCHANS filter<br/>━━━━━━━━━━<br/>do_nanosleep · do_epoll_wait<br/>schedule_hrtimeout_range<br/>empty · 0  (benign D-states)"]
    end

    %% ── COLUMN D: session diagnostics logs ── %%
    subgraph SessionLogs ["SESSION DIAGNOSTICS LOGS  (execution/session_log.py)"]
        direction TB
        FLUSH["flush_session_log()<br/>━━━━━━━━━━<br/>Called post-session<br/>Runs detect_anomalies()<br/>Writes structured files"]

        ANOMALIES_OUT["anomalies.jsonl<br/>━━━━━━━━━━<br/>Written only if anomalies exist<br/>Includes D_STATE_SUSTAINED<br/>and HIGH_CPU_SUSTAINED records<br/>~/.local/share/autoskillit/logs/"]

        SUMMARY["summary.json<br/>━━━━━━━━━━<br/>anomaly_count field<br/>peak_rss_kb · peak_oom_score<br/>peak_fd_ratio"]

        INDEX["sessions.jsonl (append-only index)<br/>━━━━━━━━━━<br/>anomaly_count per entry<br/>jq-queryable for failed sessions<br/>500-session retention"]
    end

    %% ── FLOWS ── %%
    DOCTOR_CMD --> CHECKS_PREV
    DOCTOR_CMD --> CHECK15

    PROC_MON -->|"yields every 5 s"| PROC_SNAP
    PROC_SNAP -->|"streamed (line-buffered)"| TMPFS
    PROC_SNAP -->|"accumulated in memory"| FLUSH

    FLUSH --> DETECT
    DETECT --> EXISTING
    DETECT --> D_STATE
    DETECT --> HIGH_CPU
    D_STATE -.->|"wchan filtered by"| BENIGN
    HIGH_CPU -.->|"threshold: cpu_percent"| PROC_SNAP

    DETECT -->|"anomalies list"| ANOMALIES_OUT
    FLUSH --> SUMMARY
    FLUSH --> INDEX

    %% ── CLASS ASSIGNMENTS ── %%
    class DOCTOR_CMD cli;
    class CHECKS_PREV,CHECK15 phase;
    class PROC_MON handler;
    class PROC_SNAP stateNode;
    class TMPFS,ANOMALIES_OUT,SUMMARY,INDEX output;
    class DETECT handler;
    class EXISTING,D_STATE,HIGH_CPU,BENIGN detector;
    class FLUSH handler;
```

Closes #760

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260412-120704-347557/.autoskillit/temp/make-plan/detect_sustained_d_state_and_high_cpu_plan_2026-04-12_121132.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 244 | 32.4k | 1.5M | 137.0k | 1 | 8m 5s |
| verify | 2.0k | 11.0k | 439.5k | 42.8k | 1 | 6m 23s |
| implement | 554 | 34.9k | 5.2M | 104.3k | 1 | 9m 40s |
| prepare_pr | 52 | 6.8k | 167.0k | 29.8k | 1 | 1m 50s |
| run_arch_lenses | 202 | 29.0k | 636.0k | 164.6k | 3 | 10m 50s |
| compose_pr | 59 | 8.6k | 208.3k | 29.9k | 1 | 2m 34s |
| **Total** | 3.1k | 122.7k | 8.2M | 508.4k | | 39m 25s |