### PR TITLE
Implementation Plan: Add per-window enable/disable toggles for `quota_guard` (5-hour and weekly)

### DIFF
--- a/src/autoskillit/config/defaults.yaml
+++ b/src/autoskillit/config/defaults.yaml
@@ -62,6 +62,8 @@ token_usage:
 
 quota_guard:
   enabled: true
+  short_window_enabled: true   # Gates the 5-hour rolling window class.
+  long_window_enabled: true    # Gates the weekly / sonnet / opus class.
   short_window_threshold: 85.0
   long_window_threshold: 98.0
   long_window_patterns:

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -124,6 +124,8 @@ class TokenUsageConfig:
 @dataclass
 class QuotaGuardConfig:
     enabled: bool = True
+    short_window_enabled: bool = True
+    long_window_enabled: bool = True
     short_window_threshold: float = 85.0
     long_window_threshold: float = 98.0
     long_window_patterns: list[str] = field(default_factory=lambda: ["weekly", "sonnet", "opus"])
@@ -398,6 +400,12 @@ class AutomationConfig:
             ),
             quota_guard=QuotaGuardConfig(
                 enabled=bool(val(qg, "enabled", _qg["enabled"])),
+                short_window_enabled=bool(
+                    val(qg, "short_window_enabled", _qg["short_window_enabled"])
+                ),
+                long_window_enabled=bool(
+                    val(qg, "long_window_enabled", _qg["long_window_enabled"])
+                ),
                 short_window_threshold=float(
                     val(qg, "short_window_threshold", _qg["short_window_threshold"])
                 ),

--- a/src/autoskillit/execution/quota.py
+++ b/src/autoskillit/execution/quota.py
@@ -72,6 +72,12 @@ def _parse_resets_at(resets_at_str: str | None) -> datetime | None:
     return datetime.fromisoformat(resets_at_str.replace("Z", "+00:00"))
 
 
+def _is_long_window(name: str, long_patterns: list[str]) -> bool:
+    """Return True if the window name matches any long-window pattern."""
+    lowered = name.lower()
+    return any(pat.lower() in lowered for pat in long_patterns)
+
+
 def _threshold_for_window(
     name: str,
     *,
@@ -84,10 +90,8 @@ def _threshold_for_window(
     Long-window classification is substring match (case-insensitive) against
     long_patterns. Unknown windows fall through to short_threshold.
     """
-    lowered = name.lower()
-    for pat in long_patterns:
-        if pat.lower() in lowered:
-            return long_threshold
+    if _is_long_window(name, long_patterns):
+        return long_threshold
     return short_threshold
 
 
@@ -97,16 +101,27 @@ def _compute_binding(
     short_threshold: float,
     long_threshold: float,
     long_patterns: list[str],
+    short_enabled: bool = True,
+    long_enabled: bool = True,
 ) -> QuotaStatus:
     """Select the worst-case (binding) window using per-window thresholds.
 
     Each window is classified by name into short or long via long_patterns.
+    Windows whose class is disabled are dropped before threshold evaluation.
     Among windows at or above their own threshold, returns the one with the
     latest resets_at. If none are exhausted, returns the window with highest
     utilization (for diagnostic display; should_block will be False).
-    Returns QuotaStatus(0.0, None, ...) when windows is empty.
+    Returns QuotaStatus(0.0, None, ...) when windows is empty or all dropped.
     """
     if not windows:
+        return QuotaStatus(0.0, None, effective_threshold=100.0)
+
+    filtered = {
+        name: w
+        for name, w in windows.items()
+        if (long_enabled if _is_long_window(name, long_patterns) else short_enabled)
+    }
+    if not filtered:
         return QuotaStatus(0.0, None, effective_threshold=100.0)
 
     def threshold_of(name: str) -> float:
@@ -117,14 +132,14 @@ def _compute_binding(
             long_patterns=long_patterns,
         )
 
-    exhausted = [(name, w) for name, w in windows.items() if w.utilization >= threshold_of(name)]
+    exhausted = [(name, w) for name, w in filtered.items() if w.utilization >= threshold_of(name)]
     if exhausted:
         name, w = max(
             exhausted,
             key=lambda nw: nw[1].resets_at or datetime.min.replace(tzinfo=UTC),
         )
     else:
-        name, w = max(windows.items(), key=lambda nw: nw[1].utilization)
+        name, w = max(filtered.items(), key=lambda nw: nw[1].utilization)
 
     effective = threshold_of(name)
     return QuotaStatus(
@@ -218,6 +233,8 @@ async def _fetch_quota(
     short_threshold: float,
     long_threshold: float,
     long_patterns: list[str],
+    short_enabled: bool = True,
+    long_enabled: bool = True,
     base_url: str = _DEFAULT_BASE_URL,
     _httpx_timeout: float = 10,
 ) -> QuotaFetchResult:
@@ -252,6 +269,8 @@ async def _fetch_quota(
         short_threshold=short_threshold,
         long_threshold=long_threshold,
         long_patterns=long_patterns,
+        short_enabled=short_enabled,
+        long_enabled=long_enabled,
     )
     return QuotaFetchResult(windows=windows, binding=binding)
 
@@ -276,6 +295,8 @@ async def _refresh_quota_cache(
         short_threshold=config.short_window_threshold,
         long_threshold=config.long_window_threshold,
         long_patterns=list(config.long_window_patterns),
+        short_enabled=config.short_window_enabled,
+        long_enabled=config.long_window_enabled,
         base_url=base_url,
         _httpx_timeout=_httpx_timeout,
     )
@@ -319,6 +340,8 @@ async def check_and_sleep_if_needed(
         "short_threshold": config.short_window_threshold,
         "long_threshold": config.long_window_threshold,
         "long_patterns": list(config.long_window_patterns),
+        "short_enabled": config.short_window_enabled,
+        "long_enabled": config.long_window_enabled,
         "base_url": base_url,
         "_httpx_timeout": _httpx_timeout,
     }

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -434,6 +434,39 @@ class TestQuotaGuardConfig:
             "otherwise the loop arrives after the cache has already expired"
         )
 
+    def test_quota_guard_per_window_enabled_defaults_true(self):
+        """Test 14: QuotaGuardConfig() defaults both per-window flags to True."""
+        from autoskillit.config.settings import QuotaGuardConfig
+
+        config = QuotaGuardConfig()
+        assert config.short_window_enabled is True
+        assert config.long_window_enabled is True
+
+    def test_quota_guard_per_window_enabled_yaml_round_trip(self, tmp_path):
+        """Test 15: per-window enabled flags survive a YAML round-trip."""
+        config_dir = tmp_path / ".autoskillit"
+        config_dir.mkdir()
+        (config_dir / "config.yaml").write_text(
+            yaml.dump({"quota_guard": {"short_window_enabled": False}})
+        )
+        config = load_config(tmp_path)
+        assert config.quota_guard.short_window_enabled is False
+        assert config.quota_guard.long_window_enabled is True
+
+    def test_defaults_yaml_has_per_window_enabled_keys(self):
+        """Test 16: defaults.yaml has both per-window enabled keys set to True."""
+        from autoskillit.core.paths import pkg_root
+
+        defaults = yaml.safe_load((pkg_root() / "config" / "defaults.yaml").read_text())
+        assert defaults["quota_guard"]["short_window_enabled"] is True
+        assert defaults["quota_guard"]["long_window_enabled"] is True
+
+    def test_quota_guard_env_var_override_short_window_enabled(self, monkeypatch, tmp_path):
+        """Test 17: AUTOSKILLIT_QUOTA_GUARD__SHORT_WINDOW_ENABLED=false is cast to bool False."""
+        monkeypatch.setenv("AUTOSKILLIT_QUOTA_GUARD__SHORT_WINDOW_ENABLED", "false")
+        config = load_config(tmp_path)
+        assert config.quota_guard.short_window_enabled is False
+
 
 class TestLoggingConfig:
     """LoggingConfig dataclass and YAML loading."""

--- a/tests/execution/test_quota.py
+++ b/tests/execution/test_quota.py
@@ -1391,3 +1391,329 @@ class TestCacheSchemaVersion:
         await check_and_sleep_if_needed(config)
         new_data = json.loads(cache_path.read_text())
         assert new_data["schema_version"] == 3
+
+
+class TestPerWindowToggles:
+    """Per-window enable/disable toggles for _compute_binding."""
+
+    _LONG_PATTERNS = ["weekly", "sonnet", "opus"]
+
+    def _windows(self, five_hour_util: float, weekly_util: float) -> dict:
+        from autoskillit.execution.quota import QuotaWindowEntry
+
+        now = datetime.now(UTC)
+        return {
+            "five_hour": QuotaWindowEntry(
+                utilization=five_hour_util, resets_at=now + timedelta(hours=3)
+            ),
+            "weekly": QuotaWindowEntry(utilization=weekly_util, resets_at=now + timedelta(days=4)),
+        }
+
+    def test_compute_binding_defaults_both_enabled_preserves_behavior(self):
+        """Test 1: default call (no toggle kwargs) pins backward-compat."""
+        from autoskillit.execution.quota import _compute_binding
+
+        binding = _compute_binding(
+            self._windows(90.0, 80.0),
+            short_threshold=85.0,
+            long_threshold=98.0,
+            long_patterns=self._LONG_PATTERNS,
+        )
+        assert binding.window_name == "five_hour"
+        assert binding.should_block is True
+        assert binding.effective_threshold == pytest.approx(85.0)
+
+    def test_compute_binding_short_disabled_drops_five_hour(self):
+        """Test 2: short_enabled=False — five_hour is dropped, weekly survives."""
+        from autoskillit.execution.quota import _compute_binding
+
+        binding = _compute_binding(
+            self._windows(90.0, 80.0),
+            short_threshold=85.0,
+            long_threshold=98.0,
+            long_patterns=self._LONG_PATTERNS,
+            short_enabled=False,
+            long_enabled=True,
+        )
+        assert binding.window_name == "weekly"
+        assert binding.should_block is False
+        assert binding.effective_threshold == pytest.approx(98.0)
+
+    def test_compute_binding_short_disabled_and_only_short_windows_present(self):
+        """Test 3: all windows are short class → all dropped → empty sentinel."""
+        from autoskillit.execution.quota import QuotaWindowEntry, _compute_binding
+
+        now = datetime.now(UTC)
+        windows = {
+            "one_hour": QuotaWindowEntry(utilization=95.0, resets_at=now + timedelta(minutes=45)),
+            "five_hour": QuotaWindowEntry(utilization=90.0, resets_at=now + timedelta(hours=3)),
+        }
+        binding = _compute_binding(
+            windows,
+            short_threshold=85.0,
+            long_threshold=98.0,
+            long_patterns=self._LONG_PATTERNS,
+            short_enabled=False,
+        )
+        assert binding.utilization == pytest.approx(0.0)
+        assert binding.resets_at is None
+        assert binding.should_block is False
+        assert binding.effective_threshold == pytest.approx(100.0)
+        assert binding.window_name == "unknown"
+
+    def test_compute_binding_long_disabled_drops_weekly(self):
+        """Test 4: long_enabled=False — weekly dropped, five_hour survives."""
+        from autoskillit.execution.quota import _compute_binding
+
+        binding = _compute_binding(
+            self._windows(80.0, 99.0),
+            short_threshold=85.0,
+            long_threshold=98.0,
+            long_patterns=self._LONG_PATTERNS,
+            long_enabled=False,
+        )
+        assert binding.window_name == "five_hour"
+        assert binding.should_block is False
+        assert binding.effective_threshold == pytest.approx(85.0)
+
+    def test_compute_binding_long_disabled_suppresses_weekly_block(self):
+        """Test 5: long_enabled=False — weekly at 99% is ignored, five_hour at 2% passes."""
+        from autoskillit.execution.quota import _compute_binding
+
+        binding = _compute_binding(
+            self._windows(2.0, 99.0),
+            short_threshold=85.0,
+            long_threshold=98.0,
+            long_patterns=self._LONG_PATTERNS,
+            long_enabled=False,
+        )
+        assert binding.window_name == "five_hour"
+        assert binding.should_block is False
+
+    def test_compute_binding_both_disabled_returns_sentinel(self):
+        """Test 6: both disabled → empty sentinel with should_block=False."""
+        from autoskillit.execution.quota import _compute_binding
+
+        binding = _compute_binding(
+            self._windows(90.0, 99.0),
+            short_threshold=85.0,
+            long_threshold=98.0,
+            long_patterns=self._LONG_PATTERNS,
+            short_enabled=False,
+            long_enabled=False,
+        )
+        assert binding.utilization == pytest.approx(0.0)
+        assert binding.resets_at is None
+        assert binding.should_block is False
+        assert binding.effective_threshold == pytest.approx(100.0)
+
+    def test_compute_binding_substring_classification_respects_long_patterns(self):
+        """Test 7: weekly_sonnet is classified as long via substring match and dropped."""
+        from autoskillit.execution.quota import QuotaWindowEntry, _compute_binding
+
+        now = datetime.now(UTC)
+        windows = {
+            "weekly_sonnet": QuotaWindowEntry(utilization=99.0, resets_at=now + timedelta(days=6)),
+            "five_hour": QuotaWindowEntry(utilization=90.0, resets_at=now + timedelta(hours=3)),
+        }
+        binding = _compute_binding(
+            windows,
+            short_threshold=85.0,
+            long_threshold=98.0,
+            long_patterns=self._LONG_PATTERNS,
+            long_enabled=False,
+        )
+        assert binding.window_name == "five_hour"
+
+    def test_compute_binding_both_enabled_matches_legacy_keyword_signature(self):
+        """Test 8: explicit True values produce identical output to implicit defaults."""
+        from autoskillit.execution.quota import _compute_binding
+
+        windows = self._windows(90.0, 80.0)
+        implicit = _compute_binding(
+            windows,
+            short_threshold=85.0,
+            long_threshold=98.0,
+            long_patterns=self._LONG_PATTERNS,
+        )
+        explicit = _compute_binding(
+            windows,
+            short_threshold=85.0,
+            long_threshold=98.0,
+            long_patterns=self._LONG_PATTERNS,
+            short_enabled=True,
+            long_enabled=True,
+        )
+        assert explicit.window_name == implicit.window_name
+        assert explicit.should_block == implicit.should_block
+        assert explicit.effective_threshold == pytest.approx(implicit.effective_threshold)
+        assert explicit.utilization == pytest.approx(implicit.utilization)
+
+    @pytest.mark.anyio
+    async def test_check_and_sleep_respects_short_window_disabled(self, monkeypatch, tmp_path):
+        """Test 9: short_window_enabled=False — five_hour at 90% is ignored."""
+        from autoskillit.execution.quota import (
+            QuotaFetchResult,
+            QuotaStatus,
+            QuotaWindowEntry,
+            check_and_sleep_if_needed,
+        )
+
+        resets_at = datetime.now(UTC) + timedelta(hours=3)
+        config = QuotaGuardConfig(
+            short_window_enabled=False,
+            credentials_path=str(tmp_path / ".credentials.json"),
+            cache_path=str(tmp_path / "cache.json"),
+        )
+
+        async def fake_fetch(credentials_path, **kwargs):
+            return QuotaFetchResult(
+                windows={
+                    "five_hour": QuotaWindowEntry(utilization=90.0, resets_at=resets_at),
+                    "weekly": QuotaWindowEntry(
+                        utilization=80.0, resets_at=datetime.now(UTC) + timedelta(days=4)
+                    ),
+                },
+                binding=QuotaStatus(
+                    utilization=80.0,
+                    resets_at=datetime.now(UTC) + timedelta(days=4),
+                    window_name="weekly",
+                    should_block=False,
+                    effective_threshold=98.0,
+                ),
+            )
+
+        monkeypatch.setattr("autoskillit.execution.quota._fetch_quota", fake_fetch)
+        result = await check_and_sleep_if_needed(config)
+        assert result["should_sleep"] is False
+        assert result["window_name"] == "weekly"
+
+    @pytest.mark.anyio
+    async def test_check_and_sleep_respects_long_window_disabled(self, monkeypatch, tmp_path):
+        """Test 10: long_window_enabled=False — weekly at 99% is ignored."""
+        from autoskillit.execution.quota import (
+            QuotaFetchResult,
+            QuotaStatus,
+            QuotaWindowEntry,
+            check_and_sleep_if_needed,
+        )
+
+        config = QuotaGuardConfig(
+            long_window_enabled=False,
+            credentials_path=str(tmp_path / ".credentials.json"),
+            cache_path=str(tmp_path / "cache.json"),
+        )
+
+        async def fake_fetch(credentials_path, **kwargs):
+            return QuotaFetchResult(
+                windows={
+                    "weekly": QuotaWindowEntry(
+                        utilization=99.0, resets_at=datetime.now(UTC) + timedelta(days=6)
+                    ),
+                    "five_hour": QuotaWindowEntry(
+                        utilization=2.0, resets_at=datetime.now(UTC) + timedelta(hours=3)
+                    ),
+                },
+                binding=QuotaStatus(
+                    utilization=2.0,
+                    resets_at=datetime.now(UTC) + timedelta(hours=3),
+                    window_name="five_hour",
+                    should_block=False,
+                    effective_threshold=85.0,
+                ),
+            )
+
+        monkeypatch.setattr("autoskillit.execution.quota._fetch_quota", fake_fetch)
+        result = await check_and_sleep_if_needed(config)
+        assert result["should_sleep"] is False
+        assert result["window_name"] == "five_hour"
+
+    @pytest.mark.anyio
+    async def test_check_and_sleep_both_disabled_returns_sentinel_no_sleep(
+        self, monkeypatch, tmp_path
+    ):
+        """Test 11: both flags False → sentinel, no sleep, no error."""
+        from autoskillit.execution.quota import (
+            QuotaFetchResult,
+            QuotaStatus,
+            QuotaWindowEntry,
+            check_and_sleep_if_needed,
+        )
+
+        config = QuotaGuardConfig(
+            short_window_enabled=False,
+            long_window_enabled=False,
+            credentials_path=str(tmp_path / ".credentials.json"),
+            cache_path=str(tmp_path / "cache.json"),
+        )
+
+        async def fake_fetch(credentials_path, **kwargs):
+            return QuotaFetchResult(
+                windows={
+                    "weekly": QuotaWindowEntry(
+                        utilization=99.0, resets_at=datetime.now(UTC) + timedelta(days=6)
+                    ),
+                    "five_hour": QuotaWindowEntry(
+                        utilization=99.0, resets_at=datetime.now(UTC) + timedelta(hours=3)
+                    ),
+                },
+                binding=QuotaStatus(utilization=0.0, resets_at=None, effective_threshold=100.0),
+            )
+
+        monkeypatch.setattr("autoskillit.execution.quota._fetch_quota", fake_fetch)
+        result = await check_and_sleep_if_needed(config)
+        assert result["should_sleep"] is False
+        assert result["utilization"] == pytest.approx(0.0)
+        assert result["resets_at"] is None
+        assert "error" not in result
+
+    @pytest.mark.anyio
+    async def test_check_and_sleep_global_enabled_false_still_short_circuits(
+        self, monkeypatch, tmp_path
+    ):
+        """Test 12: global enabled=False short-circuits before _fetch_quota is called."""
+        fetch_called = []
+
+        async def sentinel_fetch(*a, **kw):
+            fetch_called.append(1)
+            raise AssertionError("_fetch_quota must not be called when enabled=False")
+
+        monkeypatch.setattr("autoskillit.execution.quota._fetch_quota", sentinel_fetch)
+        from autoskillit.execution.quota import check_and_sleep_if_needed
+
+        config = QuotaGuardConfig(
+            enabled=False,
+            short_window_enabled=True,
+            long_window_enabled=True,
+        )
+        result = await check_and_sleep_if_needed(config)
+        assert result["should_sleep"] is False
+        assert fetch_called == []
+
+    @pytest.mark.anyio
+    async def test_refresh_quota_cache_forwards_per_window_toggles(self, monkeypatch, tmp_path):
+        """Test 13: _refresh_quota_cache passes short_enabled/long_enabled to _fetch_quota."""
+        from autoskillit.execution.quota import (
+            QuotaFetchResult,
+            QuotaStatus,
+            QuotaWindowEntry,
+            _refresh_quota_cache,
+        )
+
+        captured_kwargs: dict = {}
+
+        async def fake_fetch(credentials_path, **kwargs):
+            captured_kwargs.update(kwargs)
+            return QuotaFetchResult(
+                windows={"five_hour": QuotaWindowEntry(utilization=0.1, resets_at=None)},
+                binding=QuotaStatus(utilization=0.1, resets_at=None, window_name="five_hour"),
+            )
+
+        monkeypatch.setattr("autoskillit.execution.quota._fetch_quota", fake_fetch)
+        config = QuotaGuardConfig(
+            short_window_enabled=False,
+            cache_path=str(tmp_path / "cache.json"),
+        )
+        await _refresh_quota_cache(config)
+        assert captured_kwargs["short_enabled"] is False
+        assert captured_kwargs["long_enabled"] is True

--- a/tests/execution/test_quota.py
+++ b/tests/execution/test_quota.py
@@ -1410,7 +1410,7 @@ class TestPerWindowToggles:
         }
 
     def test_compute_binding_defaults_both_enabled_preserves_behavior(self):
-        """Test 1: default call (no toggle kwargs) pins backward-compat."""
+        """Test 1: default call (no toggle kwargs) — five_hour at 90% is binding and blocks."""
         from autoskillit.execution.quota import _compute_binding
 
         binding = _compute_binding(
@@ -1566,7 +1566,10 @@ class TestPerWindowToggles:
             cache_path=str(tmp_path / "cache.json"),
         )
 
+        captured_kwargs: dict = {}
+
         async def fake_fetch(credentials_path, **kwargs):
+            captured_kwargs.update(kwargs)
             return QuotaFetchResult(
                 windows={
                     "five_hour": QuotaWindowEntry(utilization=90.0, resets_at=resets_at),
@@ -1587,6 +1590,7 @@ class TestPerWindowToggles:
         result = await check_and_sleep_if_needed(config)
         assert result["should_sleep"] is False
         assert result["window_name"] == "weekly"
+        assert captured_kwargs.get("short_enabled") is False
 
     @pytest.mark.anyio
     async def test_check_and_sleep_respects_long_window_disabled(self, monkeypatch, tmp_path):
@@ -1604,7 +1608,10 @@ class TestPerWindowToggles:
             cache_path=str(tmp_path / "cache.json"),
         )
 
+        captured_kwargs: dict = {}
+
         async def fake_fetch(credentials_path, **kwargs):
+            captured_kwargs.update(kwargs)
             return QuotaFetchResult(
                 windows={
                     "weekly": QuotaWindowEntry(
@@ -1627,6 +1634,7 @@ class TestPerWindowToggles:
         result = await check_and_sleep_if_needed(config)
         assert result["should_sleep"] is False
         assert result["window_name"] == "five_hour"
+        assert captured_kwargs.get("long_enabled") is False
 
     @pytest.mark.anyio
     async def test_check_and_sleep_both_disabled_returns_sentinel_no_sleep(

--- a/tests/execution/test_quota_http.py
+++ b/tests/execution/test_quota_http.py
@@ -43,6 +43,8 @@ def quota_config(credentials, tmp_path):
     """Minimal config namespace for check_and_sleep_if_needed."""
     return SimpleNamespace(
         enabled=True,
+        short_window_enabled=True,
+        long_window_enabled=True,
         credentials_path=credentials,
         cache_path=str(tmp_path / "quota_cache.json"),
         cache_max_age=120,

--- a/tests/infra/test_quota_check.py
+++ b/tests/infra/test_quota_check.py
@@ -549,6 +549,27 @@ def test_approve_when_binding_below_threshold(tmp_path):
     assert out.strip() == ""
 
 
+# Test 18: hook reads should_block=False from a cache produced with long_enabled=False
+def test_hook_respects_should_block_false_when_class_disabled(tmp_path):
+    """Hook approves when cache binding has should_block=False, even if utilization is high.
+
+    Simulates the outcome of _compute_binding called with long_enabled=False:
+    the binding is five_hour at 30%, should_block=False, effective_threshold=85.0.
+    The hook must exit 0 with no permissionDecision deny line — zero hook code changes required.
+    """
+    cache = tmp_path / "quota_cache.json"
+    _write_cache(
+        cache,
+        utilization=30.0,
+        window_name="five_hour",
+        should_block=False,
+        effective_threshold=85.0,
+    )
+    out, exit_code = _run_hook(event={"tool_name": "run_skill"}, cache_path=cache)
+    assert exit_code == 0
+    assert out.strip() == ""
+
+
 def test_resolve_quota_log_dir_and_resolve_log_dir_in_sync(monkeypatch):
     """_resolve_quota_log_dir() must produce the same path as resolve_log_dir('') for
     identical env inputs. Guards against independent evolution of the two implementations.


### PR DESCRIPTION
## Summary

Add two first-class boolean fields to `quota_guard` config — `short_window_enabled`
and `long_window_enabled` — that allow a user to disable one window class (5-hour
short window) while keeping the other (weekly / sonnet / opus long window) active,
or vice versa. Defaults are `True` for both so existing deployments are unchanged.

The toggle is applied inside `_compute_binding` (`src/autoskillit/execution/quota.py`)
as a pre-filter that drops windows belonging to a disabled class before the
exhausted-threshold filter runs. When all surviving windows have been dropped,
`_compute_binding` returns the same `QuotaStatus(0.0, None, effective_threshold=100.0)`
sentinel it already produces for the empty-windows case — so `should_block` is
`False` and the quota-guard hook approves, while a diagnostic cache entry is still
written through the normal `_write_cache` path.

Because the cache write side produces the final `should_block` verdict, the
stdlib-only hook subprocesses (`hooks/quota_guard.py` and `hooks/quota_post_hook.py`)
need **no** changes. They continue to read `should_block` directly from the cache
binding. This also resolves the open design question from the issue (suppress
disabled-window lines from the PostToolUse summary): when the class is disabled,
`should_block` is False and `quota_post_hook.py` exits without emitting a warning
at all — no special-case suppression logic required.

Env-var overrides (`AUTOSKILLIT_QUOTA_GUARD__SHORT_WINDOW_ENABLED=false`) work
automatically through the existing dynaconf envvar_prefix path, because dynaconf
type-casts env-var values against the bool type already present in the merged
YAML layer.

## Architecture Impact

### Operational Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% CONFIG SOURCES %%
    subgraph ConfigHierarchy ["● CONFIGURATION HIERARCHY (config/defaults.yaml + config/settings.py)"]
        direction TB
        ENV_VARS["ENV VARS (highest priority)<br/>━━━━━━━━━━<br/>AUTOSKILLIT_QUOTA_GUARD__SHORT_WINDOW_ENABLED<br/>AUTOSKILLIT_QUOTA_GUARD__LONG_WINDOW_ENABLED"]
        SECRETS["Secrets Layer<br/>━━━━━━━━━━<br/>.autoskillit/.secrets.yaml<br/>(credentials only)"]
        PROJECT_CFG["Project Config<br/>━━━━━━━━━━<br/>.autoskillit/config.yaml<br/>quota_guard.short_window_enabled<br/>quota_guard.long_window_enabled"]
        USER_CFG["User Config<br/>━━━━━━━━━━<br/>~/.autoskillit/config.yaml"]
        DEFAULTS["● Package Defaults<br/>━━━━━━━━━━<br/>config/defaults.yaml<br/>short_window_enabled: true<br/>long_window_enabled: true"]
        QUOTA_CFG["● QuotaGuardConfig<br/>━━━━━━━━━━<br/>short_window_enabled: bool<br/>long_window_enabled: bool<br/>short_window_threshold: 85.0<br/>long_window_threshold: 98.0<br/>long_window_patterns: [weekly, sonnet, opus]"]
    end

    ENV_VARS -->|"highest priority"| QUOTA_CFG
    SECRETS --> QUOTA_CFG
    PROJECT_CFG --> QUOTA_CFG
    USER_CFG --> QUOTA_CFG
    DEFAULTS -->|"lowest priority"| QUOTA_CFG

    %% QUOTA ENGINE %%
    subgraph QuotaEngine ["● QUOTA ENGINE (execution/quota.py)"]
        direction TB
        CHECK_FN["● check_and_sleep_if_needed<br/>━━━━━━━━━━<br/>Passes short_enabled / long_enabled<br/>to fetch and binding logic<br/>Returns: {should_sleep, sleep_seconds, ...}"]
        REFRESH_FN["● _refresh_quota_cache<br/>━━━━━━━━━━<br/>Background proactive refresh<br/>Passes short/long enabled flags<br/>Always does live API call"]
        FETCH_FN["● _fetch_quota<br/>━━━━━━━━━━<br/>Calls Anthropic /api/oauth/usage<br/>short_enabled / long_enabled params<br/>Passes flags to _compute_binding"]
        COMPUTE_FN["● _compute_binding<br/>━━━━━━━━━━<br/>Filters windows by class:<br/>  short_enabled=False → drop 5h windows<br/>  long_enabled=False → drop weekly/sonnet/opus<br/>Returns worst-case binding QuotaStatus"]
    end

    QUOTA_CFG --> CHECK_FN
    QUOTA_CFG --> REFRESH_FN
    CHECK_FN --> FETCH_FN
    REFRESH_FN --> FETCH_FN
    FETCH_FN --> COMPUTE_FN

    %% EXTERNAL API %%
    API["Anthropic API<br/>━━━━━━━━━━<br/>/api/oauth/usage<br/>All rate-limit windows"]

    FETCH_FN -->|"Bearer token from<br/>~/.claude/.credentials.json"| API
    API -->|"window dict<br/>{name: {utilization, resets_at}}"| FETCH_FN

    %% CACHE (state) %%
    subgraph CacheLayer ["STATE: QUOTA CACHE (read/write)"]
        CACHE["~/.claude/autoskillit_quota_cache.json<br/>━━━━━━━━━━<br/>fetched_at, windows snapshot<br/>binding: {should_block, effective_threshold,<br/>window_name, utilization, resets_at}<br/>schema_version: 3"]
    end

    COMPUTE_FN -->|"_write_cache"| CACHE
    CACHE -->|"_read_cache (max_age check)"| CHECK_FN

    %% HOOK (read-only from cache) %%
    subgraph HookLayer ["HOOK: QUOTA GUARD (quota_guard.py — read-only from cache)"]
        HOOK["quota_guard.py<br/>━━━━━━━━━━<br/>PreToolUse: run_skill<br/>Reads binding.should_block from cache<br/>No threshold logic (pre-computed)<br/>Fail-open on cache miss"]
        HOOK_CFG[".autoskillit/temp/.hook_config.json<br/>━━━━━━━━━━<br/>quota_guard: {cache_path,<br/>cache_max_age, buffer_seconds}"]
    end

    CACHE -->|"reads binding.should_block"| HOOK
    HOOK_CFG -->|"runtime settings"| HOOK

    %% DECISION + OBSERVABILITY %%
    subgraph Decision ["GATE DECISION"]
        APPROVE(["run_skill: APPROVED<br/>━━━━━━━━━━<br/>Logs: approved event"])
        DENY(["run_skill: DENIED<br/>━━━━━━━━━━<br/>Instructs: run_cmd sleep(N)<br/>then retry"])
    end

    HOOK -->|"should_block=false"| APPROVE
    HOOK -->|"should_block=true"| DENY

    subgraph Observability ["OBSERVABILITY (write-only artifacts)"]
        QUOTA_LOG["~/.local/share/autoskillit/logs/<br/>quota_events.jsonl<br/>━━━━━━━━━━<br/>Events: approved / blocked / cache_miss / parse_error<br/>{ts, event, utilization, window_name,<br/>effective_threshold, sleep_seconds}"]
    end

    HOOK --> QUOTA_LOG

    %% CLASS ASSIGNMENTS %%
    class ENV_VARS,PROJECT_CFG,USER_CFG cli;
    class DEFAULTS,SECRETS phase;
    class QUOTA_CFG phase;
    class CHECK_FN,REFRESH_FN handler;
    class FETCH_FN,COMPUTE_FN handler;
    class API integration;
    class CACHE stateNode;
    class HOOK detector;
    class HOOK_CFG phase;
    class APPROVE,DENY terminal;
    class QUOTA_LOG output;
```

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    TRIGGER([PreToolUse: run_skill])

    subgraph Config ["● CONFIG STATE — QuotaGuardConfig (settings.py / defaults.yaml)"]
        direction TB
        MASTER["enabled: bool<br/>━━━━━━━━━━<br/>MUTABLE — master on/off toggle<br/>Loaded from config layer at hook start"]
        SHORT_TOG["● short_window_enabled: bool<br/>━━━━━━━━━━<br/>MUTABLE — gates 5h rolling window class<br/>Default: true | bool()-coerced on load"]
        LONG_TOG["● long_window_enabled: bool<br/>━━━━━━━━━━<br/>MUTABLE — gates weekly/sonnet/opus class<br/>Default: true | bool()-coerced on load"]
        THRESHOLDS["short/long_window_threshold: float<br/>━━━━━━━━━━<br/>MUTABLE — 85.0 / 98.0 defaults<br/>No range validation (0–100 not enforced)"]
        CACHE_CFG["cache_path / cache_max_age<br/>━━━━━━━━━━<br/>INIT_PRESERVE — set at config load<br/>Stable for entire hook invocation"]
    end

    subgraph Resolution ["● SETTINGS RESOLUTION CHAIN (_hook_settings.py)"]
        direction LR
        ENV["Env Var Layer<br/>━━━━━━━━━━<br/>AUTOSKILLIT_QUOTA_GUARD__*<br/>Highest priority"]
        HOOK_CFG["Hook Config Layer<br/>━━━━━━━━━━<br/>.autoskillit/temp/.hook_config.json<br/>Written by open_kitchen"]
        DEFAULT["Module Default Layer<br/>━━━━━━━━━━<br/>Hardcoded fallbacks<br/>Lowest priority"]
        BOOL_COERCE["⚠ bool() coercion gate<br/>━━━━━━━━━━<br/>bool('false') → True footgun<br/>No str→bool guard for toggle fields"]
    end

    subgraph CacheCP ["CACHE CHECKPOINT (quota_cache.json)"]
        direction TB
        SCHEMA_GATE["● Schema Version Gate<br/>━━━━━━━━━━<br/>schema_version != 3 → discard<br/>Once-per-process log dedup (_SCHEMA_DRIFT_LOGGED)"]
        STALE_GATE["● Staleness Gate<br/>━━━━━━━━━━<br/>age > cache_max_age → discard<br/>Fail-open on ANY error (5 exception types)"]
        CACHE_STATE["Cache Payload — CHECKPOINT<br/>━━━━━━━━━━<br/>READ: before every hook invocation<br/>WRITE: after live API fetch (atomic)"]
    end

    subgraph Compute ["● _compute_binding (quota.py)"]
        direction TB
        WIN_FILTER["● Window Filter Gate<br/>━━━━━━━━━━<br/>short_enabled=False → exclude 5h windows<br/>long_enabled=False → exclude weekly/sonnet/opus<br/>All disabled → utilization = 0, no block"]
        THRESH_GATE["Threshold Gate<br/>━━━━━━━━━━<br/>utilization >= threshold<br/>→ should_block = True"]
        BINDING["QuotaStatus — INIT_ONLY<br/>━━━━━━━━━━<br/>utilization, resets_at<br/>window_name, should_block<br/>effective_threshold<br/>Never mutated after construction"]
    end

    subgraph Decision ["● HOOK DECISION (quota_guard.py)"]
        direction TB
        PARSE_GATE["Binding Parse Gate<br/>━━━━━━━━━━<br/>Missing binding / bad types<br/>→ fail-open: sys.exit(0) approve"]
        BLOCK_GATE["● should_block Decision Gate<br/>━━━━━━━━━━<br/>True → deny + sleep instruction<br/>False → approve tool use"]
    end

    EVENTS["quota_events.jsonl<br/>━━━━━━━━━━<br/>APPEND_ONLY<br/>approved + denied events<br/>Never read back for logic"]

    APPROVE([APPROVE — tool use proceeds])
    DENY([DENY — run_skill blocked + sleep N s])

    %% FLOW %%
    TRIGGER --> MASTER
    MASTER -->|"enabled=False → skip all gates"| APPROVE
    MASTER -->|"enabled=True → resolve settings"| ENV

    ENV -->|"first truthy wins"| BOOL_COERCE
    HOOK_CFG -->|"fallback"| BOOL_COERCE
    DEFAULT -->|"last resort"| BOOL_COERCE

    BOOL_COERCE --> SHORT_TOG
    BOOL_COERCE --> LONG_TOG
    BOOL_COERCE --> THRESHOLDS
    BOOL_COERCE --> CACHE_CFG

    CACHE_CFG -->|"cache_path + max_age"| SCHEMA_GATE
    SCHEMA_GATE -->|"version mismatch → live fetch"| CACHE_STATE
    SCHEMA_GATE -->|"valid schema"| STALE_GATE
    STALE_GATE -->|"stale / error → live fetch"| CACHE_STATE
    STALE_GATE -->|"fresh hit"| CACHE_STATE

    CACHE_STATE -->|"windows dict"| WIN_FILTER
    SHORT_TOG -->|"filter control"| WIN_FILTER
    LONG_TOG -->|"filter control"| WIN_FILTER
    THRESHOLDS -->|"thresholds"| THRESH_GATE

    WIN_FILTER -->|"included windows"| THRESH_GATE
    THRESH_GATE -->|"computes should_block"| BINDING

    BINDING -->|"binding dict written to cache"| CACHE_STATE
    BINDING -->|"read by hook"| PARSE_GATE
    PARSE_GATE -->|"invalid → fail-open"| APPROVE
    PARSE_GATE -->|"valid binding"| BLOCK_GATE
    BLOCK_GATE -->|"False"| APPROVE
    BLOCK_GATE -->|"True"| DENY

    APPROVE --> EVENTS
    DENY --> EVENTS

    %% CLASS ASSIGNMENTS %%
    class TRIGGER,APPROVE,DENY terminal;
    class MASTER,SHORT_TOG,LONG_TOG,THRESHOLDS,CACHE_CFG stateNode;
    class ENV,HOOK_CFG,DEFAULT cli;
    class BOOL_COERCE gap;
    class SCHEMA_GATE,STALE_GATE,WIN_FILTER,THRESH_GATE,PARSE_GATE,BLOCK_GATE detector;
    class CACHE_STATE,BINDING phase;
    class EVENTS output;
```

### Data Lineage Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph ConfigLayer ["Config Inputs"]
        DEFAULTS["● defaults.yaml<br/>━━━━━━━━━━<br/>+ short_window_enabled: true<br/>+ long_window_enabled: true<br/>thresholds, patterns"]
        USER_CFG["~/.autoskillit/config.yaml<br/>━━━━━━━━━━<br/>user-level overrides"]
        PROJ_CFG[".autoskillit/config.yaml<br/>━━━━━━━━━━<br/>project-level overrides"]
        ENV_VARS["AUTOSKILLIT_QUOTA_GUARD__*<br/>━━━━━━━━━━<br/>highest-priority overrides"]
    end

    subgraph ConfigResolution ["Config Resolution (settings.py)"]
        direction TB
        DYNACONF["_make_dynaconf()<br/>━━━━━━━━━━<br/>deep-merge: defaults<br/>→ user → project → env"]
        QG_CFG["● QuotaGuardConfig<br/>━━━━━━━━━━<br/>short_window_enabled<br/>long_window_enabled<br/>thresholds / patterns<br/>cache_path, buffer_seconds"]
    end

    subgraph External ["External (read-only)"]
        direction TB
        CREDS["~/.claude/.credentials.json<br/>━━━━━━━━━━<br/>OAuth Bearer token<br/>expiry check"]
        API["Anthropic /api/oauth/usage<br/>━━━━━━━━━━<br/>window_name → utilization<br/>+ resets_at per window"]
    end

    subgraph QuotaProcessing ["Quota Processing (quota.py)"]
        direction TB
        FETCH["● _fetch_quota()<br/>━━━━━━━━━━<br/>GET quota API<br/>parse raw windows dict"]
        BINDING["● _compute_binding()<br/>━━━━━━━━━━<br/>1. filter: drop disabled class<br/>   short_enabled / long_enabled<br/>2. classify via long_patterns<br/>3. pick worst-case threshold breach"]
        CHECK["● check_and_sleep_if_needed()<br/>━━━━━━━━━━<br/>cache-hit → skip fetch<br/>cache-miss → fetch + write<br/>returns sleep metadata dict"]
        REFRESH["● _refresh_quota_cache()<br/>━━━━━━━━━━<br/>background: always fetch<br/>unconditionally writes cache"]
    end

    subgraph Storage ["Primary Storage — Source of Truth"]
        CACHE[("● quota_cache.json<br/>━━━━━━━━━━<br/>schema_version: 3<br/>fetched_at, windows{}<br/>binding{utilization, should_block<br/>window_name, effective_threshold}")]
    end

    subgraph HookChain ["PreToolUse Hook Chain"]
        direction TB
        HOOK_CFG["_hook_settings.py<br/>━━━━━━━━━━<br/>stdlib-only resolver<br/>env > hook_config > default<br/>→ QuotaHookSettings"]
        HOOK["quota_guard.py<br/>━━━━━━━━━━<br/>read cache binding<br/>approve or deny run_skill"]
    end

    subgraph Artifacts ["Write-Only Artifacts"]
        QUOTA_LOG["quota_events.jsonl<br/>━━━━━━━━━━<br/>approved / blocked / cache_miss<br/>~/.local/share/autoskillit/logs/"]
    end

    %% CONFIG RESOLUTION FLOW %%
    DEFAULTS -->|"layer 1 (package)"| DYNACONF
    USER_CFG -->|"layer 2 (user)"| DYNACONF
    PROJ_CFG -->|"layer 3 (project)"| DYNACONF
    ENV_VARS -->|"env overlay"| DYNACONF
    DYNACONF -->|"from_dynaconf()\nqg section → typed fields"| QG_CFG

    %% QUOTA PROCESSING FLOW %%
    QG_CFG -->|"short/long_window_enabled\nthresholds, patterns\ncache_path"| CHECK
    QG_CFG -->|"short/long_window_enabled\nthresholds, patterns"| REFRESH
    CREDS -->|"read Bearer token"| FETCH
    API -->|"raw windows JSON"| FETCH
    FETCH -->|"dict[str, QuotaWindowEntry]"| BINDING
    QG_CFG -->|"short_enabled\nlong_enabled\nlong_patterns"| BINDING
    BINDING -->|"QuotaFetchResult\n(filtered binding)"| CHECK
    BINDING -->|"QuotaFetchResult\n(filtered binding)"| REFRESH

    %% CACHE I/O %%
    CHECK -->|"_write_cache() on miss"| CACHE
    REFRESH -->|"_write_cache() always"| CACHE
    CHECK -->|"_read_cache() first"| CACHE

    %% HOOK FLOW %%
    HOOK_CFG -->|"cache_path\ncache_max_age\nbuffer_seconds"| HOOK
    CACHE -->|"read binding{}\nshould_block flag"| HOOK
    HOOK -.->|"append event (write-only)"| QUOTA_LOG

    %% CLASS ASSIGNMENTS %%
    class DEFAULTS,USER_CFG,PROJ_CFG,ENV_VARS cli;
    class DYNACONF,QG_CFG phase;
    class FETCH,CHECK,REFRESH handler;
    class BINDING detector;
    class CACHE stateNode;
    class API,CREDS integration;
    class HOOK_CFG,HOOK handler;
    class QUOTA_LOG output;
```

Closes #763

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260412-120702-927128/.autoskillit/temp/make-plan/quota_guard_per_window_toggles_plan_2026-04-12_121031.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 225 | 20.6k | 1.6M | 151.3k | 1 | 5m 12s |
| verify | 150 | 16.9k | 797.9k | 54.8k | 1 | 5m 22s |
| implement | 394 | 21.5k | 2.8M | 77.3k | 1 | 7m 46s |
| fix | 332 | 10.7k | 1.4M | 74.3k | 2 | 9m 38s |
| prepare_pr | 60 | 5.7k | 184.9k | 25.8k | 1 | 1m 45s |
| run_arch_lenses | 3.1k | 23.3k | 684.7k | 192.8k | 3 | 7m 34s |
| compose_pr | 59 | 9.1k | 199.5k | 32.6k | 1 | 2m 34s |
| **Total** | 4.3k | 107.7k | 7.7M | 608.9k | | 39m 54s |