### PR TITLE
Rectify: Trace Identity Contract

### DIFF
--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -193,6 +193,18 @@ class LinuxTracingConfig:
     log_dir: str = ""  # empty = platform default (~/.local/share/autoskillit/logs on Linux)
     tmpfs_path: str = "/dev/shm"  # RAM-backed tmpfs for crash-resilient streaming
 
+    def __post_init__(self) -> None:
+        import os
+
+        if self.tmpfs_path == "/dev/shm" and os.environ.get("PYTEST_CURRENT_TEST"):
+            raise RuntimeError(
+                "LinuxTracingConfig.tmpfs_path is '/dev/shm' but PYTEST_CURRENT_TEST "
+                "is set — this test would write to the real shared tmpfs and pollute "
+                "production state. Override tmpfs_path with a test-local path, e.g.: "
+                "LinuxTracingConfig(tmpfs_path=str(tmp_path)). "
+                "Use the isolated_tracing_config fixture for new tests."
+            )
+
 
 @dataclass
 class McpResponseConfig:

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -194,9 +194,18 @@ class LinuxTracingConfig:
     tmpfs_path: str = "/dev/shm"  # RAM-backed tmpfs for crash-resilient streaming
 
     def __post_init__(self) -> None:
+        import inspect
         import os
 
-        if self.tmpfs_path == "/dev/shm" and os.environ.get("PYTEST_CURRENT_TEST"):
+        if self.tmpfs_path != "/dev/shm" or not os.environ.get("PYTEST_CURRENT_TEST"):
+            return
+        # Only raise when called directly from test code — not from library machinery
+        # (e.g. AutomationConfig default_factory, from_dynaconf). We inspect the call
+        # frame two levels up: __post_init__ → __init__ (generated) → actual caller.
+        frame = inspect.currentframe()
+        init_frame = frame.f_back if frame is not None else None
+        caller = init_frame.f_back if init_frame is not None else None
+        if caller is not None and "/tests/" in (caller.f_code.co_filename or ""):
             raise RuntimeError(
                 "LinuxTracingConfig.tmpfs_path is '/dev/shm' but PYTEST_CURRENT_TEST "
                 "is set — this test would write to the real shared tmpfs and pollute "

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -11,7 +11,9 @@ Resolution order (low → high priority):
 from __future__ import annotations
 
 import dataclasses
+import inspect
 import logging
+import os
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -194,9 +196,6 @@ class LinuxTracingConfig:
     tmpfs_path: str = "/dev/shm"  # RAM-backed tmpfs for crash-resilient streaming
 
     def __post_init__(self) -> None:
-        import inspect
-        import os
-
         if self.tmpfs_path != "/dev/shm" or not os.environ.get("PYTEST_CURRENT_TEST"):
             return
         # Only raise when called directly from test code — not from library machinery
@@ -213,6 +212,7 @@ class LinuxTracingConfig:
                 "LinuxTracingConfig(tmpfs_path=str(tmp_path)). "
                 "Use the isolated_tracing_config fixture for new tests."
             )
+        del frame, init_frame, caller
 
 
 @dataclass

--- a/src/autoskillit/execution/linux_tracing.py
+++ b/src/autoskillit/execution/linux_tracing.py
@@ -31,8 +31,12 @@ import anyio
 import anyio.abc
 import psutil
 
+from autoskillit.core import get_logger
+
 if TYPE_CHECKING:
     from autoskillit.config import LinuxTracingConfig
+
+logger = get_logger(__name__)
 
 LINUX_TRACING_AVAILABLE = sys.platform == "linux"
 
@@ -269,6 +273,8 @@ class LinuxTracingHandle:
                 pass
             self._trace_file = None
         if self._trace_path is not None:
+            # Intentional: stop() cleans up its own trace file. Crash-recovery only reads
+            # files left behind by processes that never called stop() — so this is correct.
             self._trace_path.unlink(missing_ok=True)
             self._trace_path = None
         if self._enrollment_path is not None:
@@ -321,7 +327,8 @@ def start_linux_tracing(
             )
             _write_enrollment_atomic(enrollment_path, record)
             handle._enrollment_path = enrollment_path
-        except OSError:
+        except OSError as e:
+            logger.warning("Failed to write enrollment sidecar for pid %d: %s", pid, e)
             handle._enrollment_path = None
 
     async def _run_monitor() -> None:

--- a/src/autoskillit/execution/linux_tracing.py
+++ b/src/autoskillit/execution/linux_tracing.py
@@ -18,7 +18,9 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import os
 import sys
+import tempfile
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
@@ -56,6 +58,59 @@ def read_starttime_ticks(pid: int) -> int | None:
     except (OSError, ValueError, IndexError):
         pass
     return None
+
+
+@dataclass(frozen=True)
+class TraceEnrollmentRecord:
+    """Identity triple written atomically at trace-open time.
+
+    (boot_id, pid, starttime_ticks) together form a collision-resistant identity:
+    - boot_id rejects pre-reboot stale files
+    - starttime_ticks detects PID recycling
+    """
+
+    schema_version: int  # always 1
+    pid: int
+    boot_id: str | None  # read_boot_id(); None if /proc unavailable
+    starttime_ticks: int | None  # read_starttime_ticks(pid); None if unavailable
+    session_id: str  # caller-provided; "" if not yet resolved
+    enrolled_at: str  # ISO 8601 UTC
+    kitchen_id: str  # ""
+    order_id: str  # ""
+
+
+def _write_enrollment_atomic(path: Path, record: TraceEnrollmentRecord) -> None:
+    """Write enrollment sidecar atomically using tempfile + os.replace."""
+    content = json.dumps(dataclasses.asdict(record))
+    fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def _read_enrollment(path: Path) -> TraceEnrollmentRecord | None:
+    """Read and validate an enrollment sidecar. Returns None on any error."""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return TraceEnrollmentRecord(
+            schema_version=data["schema_version"],
+            pid=data["pid"],
+            boot_id=data.get("boot_id"),
+            starttime_ticks=data.get("starttime_ticks"),
+            session_id=data.get("session_id", ""),
+            enrolled_at=data.get("enrolled_at", ""),
+            kitchen_id=data.get("kitchen_id", ""),
+            order_id=data.get("order_id", ""),
+        )
+    except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError):
+        return None
 
 
 @dataclass(frozen=True)
@@ -200,6 +255,7 @@ class LinuxTracingHandle:
     _snapshots: list[ProcSnapshot] = field(default_factory=list)
     _trace_path: Path | None = field(default=None)
     _trace_file: IO[str] | None = field(default=None)
+    _enrollment_path: Path | None = field(default=None)
 
     def stop(self) -> list[ProcSnapshot]:
         """Stop tracing, flush and close the trace file, return accumulated snapshots."""
@@ -212,6 +268,12 @@ class LinuxTracingHandle:
             except OSError:
                 pass
             self._trace_file = None
+        if self._trace_path is not None:
+            self._trace_path.unlink(missing_ok=True)
+            self._trace_path = None
+        if self._enrollment_path is not None:
+            self._enrollment_path.unlink(missing_ok=True)
+            self._enrollment_path = None
         return list(self._snapshots)
 
 
@@ -219,6 +281,10 @@ def start_linux_tracing(
     pid: int,
     config: LinuxTracingConfig,
     tg: anyio.abc.TaskGroup | None,
+    *,
+    session_id: str = "",
+    kitchen_id: str = "",
+    order_id: str = "",
 ) -> LinuxTracingHandle | None:
     """Start Linux tracing if all gates pass. Returns handle or None."""
     if not LINUX_TRACING_AVAILABLE or not config.enabled:
@@ -239,6 +305,24 @@ def start_linux_tracing(
         except OSError:
             handle._trace_path = None
             handle._trace_file = None
+
+        # Write enrollment sidecar atomically for crash-recovery identity contract
+        enrollment_path = tmpfs / f"autoskillit_enrollment_{pid}.json"
+        try:
+            record = TraceEnrollmentRecord(
+                schema_version=1,
+                pid=pid,
+                boot_id=read_boot_id(),
+                starttime_ticks=read_starttime_ticks(pid),
+                session_id=session_id,
+                enrolled_at=datetime.now(UTC).isoformat(),
+                kitchen_id=kitchen_id,
+                order_id=order_id,
+            )
+            _write_enrollment_atomic(enrollment_path, record)
+            handle._enrollment_path = enrollment_path
+        except OSError:
+            handle._enrollment_path = None
 
     async def _run_monitor() -> None:
         with scope:

--- a/src/autoskillit/execution/linux_tracing.py
+++ b/src/autoskillit/execution/linux_tracing.py
@@ -95,7 +95,7 @@ def _write_enrollment_atomic(path: Path, record: TraceEnrollmentRecord) -> None:
         raise
 
 
-def _read_enrollment(path: Path) -> TraceEnrollmentRecord | None:
+def read_enrollment(path: Path) -> TraceEnrollmentRecord | None:
     """Read and validate an enrollment sidecar. Returns None on any error."""
     try:
         data = json.loads(path.read_text(encoding="utf-8"))

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -17,8 +17,15 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+import psutil
+
 from autoskillit.core import atomic_write, claude_code_log_path, get_logger
 from autoskillit.execution.anomaly_detection import detect_anomalies
+from autoskillit.execution.linux_tracing import (
+    _read_enrollment,
+    read_boot_id,
+    read_starttime_ticks,
+)
 
 logger = get_logger(__name__)
 
@@ -315,6 +322,7 @@ def recover_crashed_sessions(tmpfs_path: str = "/dev/shm", log_dir: str = "") ->
         return 0
 
     count = 0
+    current_boot_id = read_boot_id()
     for trace_file in sorted(tmpfs.glob("autoskillit_trace_*.jsonl")):
         # Skip files modified within the last 30 seconds — may be active
         try:
@@ -324,7 +332,35 @@ def recover_crashed_sessions(tmpfs_path: str = "/dev/shm", log_dir: str = "") ->
         if age_seconds < 30:
             continue
 
-        # Read snapshots
+        # Extract PID from filename: autoskillit_trace_{pid}.jsonl
+        try:
+            pid = int(trace_file.stem.split("_")[-1])
+        except (ValueError, IndexError):
+            pid = 0
+
+        # Gate 1: Enrollment sidecar must exist — no sidecar means alien/test file
+        enrollment_path = tmpfs / f"autoskillit_enrollment_{pid}.json"
+        enrollment = _read_enrollment(enrollment_path)
+        if enrollment is None:
+            logger.debug("Skipping %s: no enrollment sidecar", trace_file.name)
+            continue
+
+        # Gate 2: Boot ID must match current boot — mismatch means pre-reboot stale file
+        if current_boot_id and enrollment.boot_id and enrollment.boot_id != current_boot_id:
+            logger.debug("Skipping %s: boot_id mismatch", trace_file.name)
+            trace_file.unlink(missing_ok=True)
+            enrollment_path.unlink(missing_ok=True)
+            continue
+
+        # Gate 3: PID liveness + starttime_ticks identity
+        if psutil.pid_exists(pid):
+            current_ticks = read_starttime_ticks(pid)
+            if current_ticks is None or current_ticks == enrollment.starttime_ticks:
+                logger.debug("Skipping %s: PID %d still alive", trace_file.name, pid)
+                continue
+            # PID recycled — original process is gone, treat as crash
+
+        # All gates passed — read snapshots and emit crashed row
         snapshots: list[dict[str, object]] = []
         try:
             for line in trace_file.read_text().splitlines():
@@ -334,12 +370,6 @@ def recover_crashed_sessions(tmpfs_path: str = "/dev/shm", log_dir: str = "") ->
                     continue
         except OSError:
             continue
-
-        # Extract PID from filename: autoskillit_trace_{pid}.jsonl
-        try:
-            pid = int(trace_file.stem.split("_")[-1])
-        except (ValueError, IndexError):
-            pid = 0
 
         # Compute start_ts from file mtime
         try:
@@ -365,10 +395,8 @@ def recover_crashed_sessions(tmpfs_path: str = "/dev/shm", log_dir: str = "") ->
             logger.debug("recover_crashed_sessions: failed to finalize %s", trace_file)
             continue
 
-        try:
-            trace_file.unlink()
-        except OSError:
-            pass
+        trace_file.unlink(missing_ok=True)
+        enrollment_path.unlink(missing_ok=True)
 
         count += 1
 

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -336,7 +336,7 @@ def recover_crashed_sessions(tmpfs_path: str = "/dev/shm", log_dir: str = "") ->
         try:
             pid = int(trace_file.stem.split("_")[-1])
         except (ValueError, IndexError):
-            pid = 0
+            pid = -1
 
         # Gate 1: Enrollment sidecar must exist — no sidecar means alien/test file
         enrollment_path = tmpfs / f"autoskillit_enrollment_{pid}.json"
@@ -355,7 +355,7 @@ def recover_crashed_sessions(tmpfs_path: str = "/dev/shm", log_dir: str = "") ->
         # Gate 3: PID liveness + starttime_ticks identity
         if psutil.pid_exists(pid):
             current_ticks = read_starttime_ticks(pid)
-            if current_ticks is None or current_ticks == enrollment.starttime_ticks:
+            if current_ticks is not None and current_ticks == enrollment.starttime_ticks:
                 logger.debug("Skipping %s: PID %d still alive", trace_file.name, pid)
                 continue
             # PID recycled — original process is gone, treat as crash

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -22,8 +22,8 @@ import psutil
 from autoskillit.core import atomic_write, claude_code_log_path, get_logger
 from autoskillit.execution.anomaly_detection import detect_anomalies
 from autoskillit.execution.linux_tracing import (
-    _read_enrollment,
     read_boot_id,
+    read_enrollment,
     read_starttime_ticks,
 )
 
@@ -340,7 +340,7 @@ def recover_crashed_sessions(tmpfs_path: str = "/dev/shm", log_dir: str = "") ->
 
         # Gate 1: Enrollment sidecar must exist — no sidecar means alien/test file
         enrollment_path = tmpfs / f"autoskillit_enrollment_{pid}.json"
-        enrollment = _read_enrollment(enrollment_path)
+        enrollment = read_enrollment(enrollment_path)
         if enrollment is None:
             logger.debug("Skipping %s: no enrollment sidecar", trace_file.name)
             continue

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -255,6 +255,7 @@ def tool_ctx(monkeypatch, tmp_path):
     ctx = make_context(AutomationConfig(), runner=mock_runner, plugin_dir=str(tmp_path))
     ctx.gate = DefaultGateState(enabled=True)
     ctx.config.linux_tracing.log_dir = str(tmp_path / "session_logs")
+    ctx.config.linux_tracing.tmpfs_path = str(tmp_path / "shm")
     # Anchor temp_dir to tmp_path so server tools that read from ctx.temp_dir
     # (e.g. _apply_triage_gate's staleness cache) write under the per-test
     # tmp directory rather than the cwd captured at fixture-init time.

--- a/tests/execution/conftest.py
+++ b/tests/execution/conftest.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+import pathlib
 import textwrap
+
+import pytest
+
+from autoskillit.config.settings import LinuxTracingConfig
 
 # Simulates Claude CLI process that writes a result line then hangs.
 # Used by test_process_channel_b.py and test_process_monitor.py.
@@ -14,3 +19,13 @@ WRITE_RESULT_THEN_HANG_SCRIPT = textwrap.dedent("""\
     sys.stdout.flush()
     time.sleep(3600)
 """)
+
+
+@pytest.fixture
+def isolated_tracing_config(tmp_path: pathlib.Path) -> LinuxTracingConfig:
+    """Pre-isolated LinuxTracingConfig for tracing tests.
+    Always writes to a tmp_path subdir, never to the real /dev/shm.
+    Use this fixture for all new tests that need a LinuxTracingConfig."""
+    shm = tmp_path / "shm"
+    shm.mkdir(parents=True, exist_ok=True)
+    return LinuxTracingConfig(enabled=True, proc_interval=0.05, tmpfs_path=str(shm))

--- a/tests/execution/test_linux_tracing.py
+++ b/tests/execution/test_linux_tracing.py
@@ -373,8 +373,10 @@ async def test_start_linux_tracing_writes_enrollment_sidecar(tmp_path):
         data = json.loads(enrollment.read_text())
         assert data["schema_version"] == 1
         assert data["pid"] == proc.pid
-        handle.stop()
-        proc.kill()
+        try:
+            handle.stop()
+        finally:
+            proc.kill()
     assert not enrollment.exists(), "Enrollment must be deleted by stop()"
 
 
@@ -440,7 +442,9 @@ async def test_stop_unlinks_trace_and_enrollment(tmp_path):
         trace = tmp_path / f"autoskillit_trace_{proc.pid}.jsonl"
         enrollment = tmp_path / f"autoskillit_enrollment_{proc.pid}.json"
         assert trace.exists()
-        handle.stop()
-        proc.kill()
+        try:
+            handle.stop()
+        finally:
+            proc.kill()
     assert not trace.exists(), "Trace file must be deleted on clean stop()"
     assert not enrollment.exists(), "Enrollment sidecar must be deleted on clean stop()"

--- a/tests/execution/test_linux_tracing.py
+++ b/tests/execution/test_linux_tracing.py
@@ -78,7 +78,7 @@ def test_read_proc_snapshot_has_all_fields():
 
 
 @pytest.mark.anyio
-async def test_tracing_handle_accumulates_snapshots():
+async def test_tracing_handle_accumulates_snapshots(tmp_path):
     """LinuxTracingHandle accumulates snapshots during monitoring."""
     import subprocess
 
@@ -88,7 +88,7 @@ async def test_tracing_handle_accumulates_snapshots():
     from autoskillit.execution.linux_tracing import start_linux_tracing
 
     proc = subprocess.Popen(["sleep", "2"])
-    cfg = LinuxTracingConfig(enabled=True, proc_interval=0.1)
+    cfg = LinuxTracingConfig(enabled=True, proc_interval=0.1, tmpfs_path=str(tmp_path))
 
     async with anyio.create_task_group() as tg:
         handle = start_linux_tracing(pid=proc.pid, config=cfg, tg=tg)
@@ -104,7 +104,7 @@ async def test_tracing_handle_accumulates_snapshots():
 
 
 @pytest.mark.anyio
-async def test_tracing_handle_stop_returns_snapshots():
+async def test_tracing_handle_stop_returns_snapshots(tmp_path):
     """stop() returns the accumulated snapshot list."""
     import os
 
@@ -113,7 +113,7 @@ async def test_tracing_handle_stop_returns_snapshots():
     from autoskillit.config import LinuxTracingConfig
     from autoskillit.execution.linux_tracing import start_linux_tracing
 
-    cfg = LinuxTracingConfig(enabled=True, proc_interval=0.1)
+    cfg = LinuxTracingConfig(enabled=True, proc_interval=0.1, tmpfs_path=str(tmp_path))
 
     async with anyio.create_task_group() as tg:
         handle = start_linux_tracing(pid=os.getpid(), config=cfg, tg=tg)
@@ -140,13 +140,13 @@ def test_linux_tracing_unavailable_on_non_linux():
     assert LINUX_TRACING_AVAILABLE is False
 
 
-def test_noop_on_non_linux(monkeypatch):
+def test_noop_on_non_linux(monkeypatch, tmp_path):
     """start_linux_tracing is a no-op when LINUX_TRACING_AVAILABLE is False."""
     from autoskillit.config import LinuxTracingConfig
     from autoskillit.execution import linux_tracing
 
     monkeypatch.setattr(linux_tracing, "LINUX_TRACING_AVAILABLE", False)
-    cfg = LinuxTracingConfig(enabled=True, proc_interval=1.0)
+    cfg = LinuxTracingConfig(enabled=True, proc_interval=1.0, tmpfs_path=str(tmp_path))
     result = linux_tracing.start_linux_tracing(pid=1, config=cfg, tg=None)
     assert result is None
 
@@ -304,7 +304,7 @@ def test_proc_snapshot_has_captured_at_field():
 
 
 @pytest.mark.anyio
-async def test_proc_monitor_snapshots_have_distinct_timestamps():
+async def test_proc_monitor_snapshots_have_distinct_timestamps(tmp_path):
     """Consecutive snapshots from proc_monitor must have distinct captured_at values."""
     import os
 
@@ -313,7 +313,7 @@ async def test_proc_monitor_snapshots_have_distinct_timestamps():
     from autoskillit.config import LinuxTracingConfig
     from autoskillit.execution.linux_tracing import start_linux_tracing
 
-    config = LinuxTracingConfig(proc_interval=0.05)
+    config = LinuxTracingConfig(proc_interval=0.05, tmpfs_path=str(tmp_path))
     async with anyio.create_task_group() as tg:
         handle = start_linux_tracing(os.getpid(), config, tg)
         await anyio.sleep(0.2)

--- a/tests/execution/test_linux_tracing.py
+++ b/tests/execution/test_linux_tracing.py
@@ -219,9 +219,14 @@ async def test_streaming_writes_each_snapshot_as_jsonl(tmp_path):
         await anyio.sleep(0.2)
         tg.cancel_scope.cancel()
 
+    # Save trace path and flush before stop() deletes the file on clean exit
+    trace_path = handle._trace_path
+    assert trace_path is not None
+    if handle._trace_file is not None:
+        handle._trace_file.flush()
+    content = trace_path.read_text()
     snapshots = handle.stop()
-    assert handle._trace_path is not None
-    lines = handle._trace_path.read_text().strip().split("\n")
+    lines = content.strip().split("\n")
     assert len(lines) >= 1
     for line in lines:
         record = json.loads(line)

--- a/tests/execution/test_linux_tracing.py
+++ b/tests/execution/test_linux_tracing.py
@@ -348,3 +348,48 @@ async def test_proc_monitor_persists_psutil_process_for_cpu_percent():
     finally:
         proc.kill()
         proc.wait()
+
+
+@pytest.mark.anyio
+async def test_start_linux_tracing_writes_enrollment_sidecar(tmp_path):
+    """start_linux_tracing must write autoskillit_enrollment_{pid}.json immediately."""
+    import anyio
+
+    from autoskillit.config import LinuxTracingConfig
+    from autoskillit.execution.linux_tracing import start_linux_tracing
+
+    cfg = LinuxTracingConfig(enabled=True, proc_interval=0.1, tmpfs_path=str(tmp_path))
+    async with anyio.create_task_group() as tg:
+        proc = await anyio.open_process(["sleep", "2"])
+        handle = start_linux_tracing(proc.pid, cfg, tg)
+        assert handle is not None
+        enrollment = tmp_path / f"autoskillit_enrollment_{proc.pid}.json"
+        assert enrollment.exists()
+        data = json.loads(enrollment.read_text())
+        assert data["schema_version"] == 1
+        assert data["pid"] == proc.pid
+        handle.stop()
+        proc.kill()
+    assert not enrollment.exists(), "Enrollment must be deleted by stop()"
+
+
+@pytest.mark.anyio
+async def test_stop_unlinks_trace_and_enrollment(tmp_path):
+    """stop() must delete both trace JSONL and enrollment sidecar on clean exit."""
+    import anyio
+
+    from autoskillit.config import LinuxTracingConfig
+    from autoskillit.execution.linux_tracing import start_linux_tracing
+
+    cfg = LinuxTracingConfig(enabled=True, proc_interval=0.1, tmpfs_path=str(tmp_path))
+    async with anyio.create_task_group() as tg:
+        proc = await anyio.open_process(["sleep", "2"])
+        handle = start_linux_tracing(proc.pid, cfg, tg)
+        assert handle is not None
+        trace = tmp_path / f"autoskillit_trace_{proc.pid}.jsonl"
+        enrollment = tmp_path / f"autoskillit_enrollment_{proc.pid}.json"
+        assert trace.exists()
+        handle.stop()
+        proc.kill()
+    assert not trace.exists(), "Trace file must be deleted on clean stop()"
+    assert not enrollment.exists(), "Enrollment sidecar must be deleted on clean stop()"

--- a/tests/execution/test_linux_tracing.py
+++ b/tests/execution/test_linux_tracing.py
@@ -378,6 +378,52 @@ async def test_start_linux_tracing_writes_enrollment_sidecar(tmp_path):
     assert not enrollment.exists(), "Enrollment must be deleted by stop()"
 
 
+# --- LinuxTracingConfig guard tests ---
+
+
+def test_tracing_config_rejects_dev_shm_in_test_env(monkeypatch):
+    """LinuxTracingConfig.__post_init__ must raise when tmpfs_path is /dev/shm
+    and PYTEST_CURRENT_TEST env var is set."""
+    from autoskillit.config import LinuxTracingConfig
+
+    monkeypatch.setenv(
+        "PYTEST_CURRENT_TEST",
+        "tests/execution/test_linux_tracing.py::fake_test",
+    )
+    with pytest.raises(RuntimeError, match="tmpfs_path|PYTEST_CURRENT_TEST"):
+        LinuxTracingConfig(tmpfs_path="/dev/shm")
+
+
+def test_tracing_config_allows_custom_tmpfs_in_test_env(monkeypatch, tmp_path):
+    """LinuxTracingConfig must not raise when a non-/dev/shm path is provided."""
+    from autoskillit.config import LinuxTracingConfig
+
+    monkeypatch.setenv(
+        "PYTEST_CURRENT_TEST",
+        "tests/execution/test_linux_tracing.py::fake_test",
+    )
+    cfg = LinuxTracingConfig(tmpfs_path=str(tmp_path))  # must not raise
+    assert cfg.tmpfs_path == str(tmp_path)
+
+
+def test_tracing_config_allows_dev_shm_outside_test_env(monkeypatch):
+    """LinuxTracingConfig must not raise for /dev/shm when not running under pytest."""
+    from autoskillit.config import LinuxTracingConfig
+
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    cfg = LinuxTracingConfig(tmpfs_path="/dev/shm")  # production path — must not raise
+    assert cfg.tmpfs_path == "/dev/shm"
+
+
+def test_isolated_tracing_config_fixture_returns_non_dev_shm(isolated_tracing_config):
+    """The isolated_tracing_config fixture must return a config pointing to a
+    temp dir, not /dev/shm."""
+    from pathlib import Path
+
+    assert isolated_tracing_config.tmpfs_path != "/dev/shm"
+    assert Path(isolated_tracing_config.tmpfs_path).is_dir()
+
+
 @pytest.mark.anyio
 async def test_stop_unlinks_trace_and_enrollment(tmp_path):
     """stop() must delete both trace JSONL and enrollment sidecar on clean exit."""

--- a/tests/execution/test_session_log.py
+++ b/tests/execution/test_session_log.py
@@ -391,15 +391,36 @@ def test_recover_crashed_sessions_skips_recent_files(tmp_path):
 
 
 def _write_old_trace(tmpfs: Path, filename: str, content: str) -> Path:
-    """Write a trace file and backdate its mtime to 60 seconds ago."""
-    import time
+    """Write a trace file (backdated 60s) and its enrollment sidecar.
 
+    The enrollment sidecar uses the current boot_id so Gate 2 passes.
+    The PID embedded in the filename is expected to be dead (so Gate 3 passes).
+    """
     trace = tmpfs / filename
     trace.write_text(content)
     old_mtime = time.time() - 60
-    import os
-
     os.utime(trace, (old_mtime, old_mtime))
+
+    # Write companion enrollment sidecar so Gate 1 passes
+    try:
+        pid = int(Path(filename).stem.split("_")[-1])
+    except (ValueError, IndexError):
+        pid = 0
+    enrollment = tmpfs / f"autoskillit_enrollment_{pid}.json"
+    enrollment.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "pid": pid,
+                "boot_id": read_boot_id() or "",
+                "starttime_ticks": None,
+                "session_id": "",
+                "enrolled_at": "2026-01-01T00:00:00+00:00",
+                "kitchen_id": "",
+                "order_id": "",
+            }
+        )
+    )
     return trace
 
 

--- a/tests/execution/test_session_log.py
+++ b/tests/execution/test_session_log.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import json
+import os
+import sys
+import time
 from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
 
+from autoskillit.execution.linux_tracing import read_boot_id, read_starttime_ticks
 from autoskillit.execution.session_log import (
     flush_session_log,
     read_telemetry_clear_marker,
@@ -811,3 +815,83 @@ def test_flush_session_log_order_id_defaults_to_empty(tmp_path):
     entry = json.loads((tmp_path / "sessions.jsonl").read_text().strip())
     assert "order_id" in entry
     assert entry["order_id"] == ""
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux-only: uses /proc and boot_id")
+def test_recover_crashed_sessions_skips_live_pid(tmp_path):
+    """A trace file whose enrolled PID is still alive must not be recovered."""
+    tmpfs = tmp_path / "shm"
+    tmpfs.mkdir()
+    pid = os.getpid()
+    trace = tmpfs / f"autoskillit_trace_{pid}.jsonl"
+    enrollment = tmpfs / f"autoskillit_enrollment_{pid}.json"
+    trace.write_text("")
+    enrollment.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "pid": pid,
+                "boot_id": read_boot_id() or "",
+                "starttime_ticks": read_starttime_ticks(pid),
+                "session_id": "",
+                "enrolled_at": datetime.now(UTC).isoformat(),
+                "kitchen_id": "",
+                "order_id": "",
+            }
+        )
+    )
+    os.utime(trace, (time.time() - 60,) * 2)
+
+    count = recover_crashed_sessions(tmpfs_path=str(tmpfs), log_dir=str(tmp_path))
+
+    assert count == 0
+    assert trace.exists(), "Trace file for alive PID must not be deleted"
+    assert enrollment.exists(), "Enrollment sidecar for alive PID must not be deleted"
+
+
+def test_recover_crashed_sessions_skips_file_without_enrollment(tmp_path):
+    """A trace file with no enrollment sidecar must be skipped — it is not
+    an autoskillit-owned trace (e.g. a test artifact or alien file)."""
+    tmpfs = tmp_path / "shm"
+    tmpfs.mkdir()
+    trace = tmpfs / "autoskillit_trace_99997.jsonl"
+    trace.write_text("")
+    os.utime(trace, (time.time() - 60,) * 2)
+
+    count = recover_crashed_sessions(tmpfs_path=str(tmpfs), log_dir=str(tmp_path))
+
+    assert count == 0
+    assert trace.exists(), "Alien trace file must not be deleted"
+
+
+def test_recover_crashed_sessions_skips_wrong_boot_id(tmp_path, monkeypatch):
+    """An enrollment sidecar with a different boot_id must be rejected."""
+    monkeypatch.setattr(
+        "autoskillit.execution.session_log.read_boot_id",
+        lambda: "current-boot-id",
+    )
+    tmpfs = tmp_path / "shm"
+    tmpfs.mkdir()
+    pid = 99996
+    trace = tmpfs / f"autoskillit_trace_{pid}.jsonl"
+    enrollment = tmpfs / f"autoskillit_enrollment_{pid}.json"
+    trace.write_text("")
+    enrollment.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "pid": pid,
+                "boot_id": "stale-boot-id",
+                "starttime_ticks": 1234,
+                "session_id": "",
+                "enrolled_at": "2026-01-01T00:00:00+00:00",
+                "kitchen_id": "",
+                "order_id": "",
+            }
+        )
+    )
+    os.utime(trace, (time.time() - 60,) * 2)
+
+    count = recover_crashed_sessions(tmpfs_path=str(tmpfs), log_dir=str(tmp_path))
+
+    assert count == 0

--- a/tests/execution/test_session_log_integration.py
+++ b/tests/execution/test_session_log_integration.py
@@ -21,7 +21,7 @@ async def test_full_tracing_pipeline_writes_distinct_timestamps(tmp_path):
     from autoskillit.execution.linux_tracing import start_linux_tracing
     from autoskillit.execution.session_log import flush_session_log
 
-    config = LinuxTracingConfig(proc_interval=0.05)
+    config = LinuxTracingConfig(proc_interval=0.05, tmpfs_path=str(tmp_path))
     start_ts = datetime.now(UTC).isoformat()
     start_mono = time.monotonic()
     async with anyio.create_task_group() as tg:

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -209,8 +209,8 @@ class TestSchemaVersionConvention:
         """List-payload sites are included since the AST scanner can't distinguish return types."""
         # These sites write list payloads through function calls but are caught by the scanner
         list_sites = [
-            ("src/autoskillit/execution/session_log.py", 219),
-            ("src/autoskillit/execution/session_log.py", 222),
+            ("src/autoskillit/execution/session_log.py", 226),
+            ("src/autoskillit/execution/session_log.py", 229),
             ("src/autoskillit/smoke_utils.py", 83),
             ("src/autoskillit/smoke_utils.py", 138),
         ]

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -111,9 +111,9 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # core/io.py — write_versioned_json itself (the blessed helper) uses atomic_write+json.dumps
     ("src/autoskillit/core/io.py", 118),
     # session_log.py — summary dict, token_usage list, audit_log list
-    ("src/autoskillit/execution/session_log.py", 206),
-    ("src/autoskillit/execution/session_log.py", 219),
-    ("src/autoskillit/execution/session_log.py", 222),
+    ("src/autoskillit/execution/session_log.py", 213),
+    ("src/autoskillit/execution/session_log.py", 226),
+    ("src/autoskillit/execution/session_log.py", 229),
     # migration/store.py — failure store dicts
     ("src/autoskillit/migration/store.py", 54),
     ("src/autoskillit/migration/store.py", 64),


### PR DESCRIPTION
## Summary

The trace file lifecycle had no **identity contract**. The filename encodes a PID, but PIDs
recycle, `/dev/shm` is writable by any process, and there is no boot-epoch anchor. The
30-second age heuristic was the sole gate before `recover_crashed_sessions` emitted a
`subtype=crashed` row — making it trivially fooled by test artifacts, stale pre-reboot
files, and alien processes whose PIDs happen to match.

**Part A establishes the enrollment sidecar contract:** a per-session JSON file written
atomically at `start_linux_tracing` time containing the identity triple `(boot_id, pid,
starttime_ticks)`. Recovery now validates this sidecar before classifying any trace file as
a crash. `LinuxTracingHandle.stop()` deletes both files on clean exit so recovery only ever
sees genuine crashes.

Part B covers test isolation enforcement (`__post_init__` guard, fixing four non-isolated
test call sites, and the shared `isolated_tracing_config` conftest fixture).

## Architecture Impact

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 65, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;

    %% ── CONSTRUCTION PATH ── %%
    subgraph Construction ["● LinuxTracingConfig Construction (settings.py)"]
        direction TB

        CFG_FIELDS["● INIT_ONLY Fields<br/>━━━━━━━━━━<br/>enabled: bool = True<br/>proc_interval: float = 5.0<br/>log_dir: str = ''<br/>tmpfs_path: str = '/dev/shm'"]

        GUARD["● __post_init__ TEST GUARD<br/>━━━━━━━━━━<br/>PYTEST_CURRENT_TEST set?<br/>AND tmpfs_path == '/dev/shm'?<br/>AND caller frame in /tests/?<br/>→ raise RuntimeError"]

        PROD_OK["Production Path OK<br/>━━━━━━━━━━<br/>No PYTEST_CURRENT_TEST<br/>→ /dev/shm allowed"]

        LIBRARY_OK["Library Factory Path OK<br/>━━━━━━━━━━<br/>default_factory / from_dynaconf<br/>caller not in /tests/<br/>→ guard bypassed"]
    end

    %% ── TEST ISOLATION LAYER ── %%
    subgraph TestIsolation ["● Test Isolation Contracts (conftest.py)"]
        direction LR

        ISOLATED_FIX["● isolated_tracing_config<br/>━━━━━━━━━━<br/>tmpfs_path = tmp_path/shm<br/>proc_interval = 0.05s<br/>mkdir on setup"]

        TOOL_CTX_FIX["tool_ctx fixture<br/>━━━━━━━━━━<br/>log_dir → tmp_path/session_logs<br/>tmpfs_path → tmp_path/shm<br/>both redirected"]

        ISO_HOME["_isolated_home (autouse)<br/>━━━━━━━━━━<br/>Path.home() → tmp_path<br/>blocks real config.yaml load"]
    end

    %% ── TRACING RUNTIME ── %%
    subgraph TracingRuntime ["● linux_tracing.py — Runtime State"]
        direction TB

        ENABLED_GATE["enabled gate<br/>━━━━━━━━━━<br/>if not enabled → return None<br/>FAIL-FAST"]

        TMPFS_CHECK["tmpfs_path.is_dir()<br/>━━━━━━━━━━<br/>dir present → open JSONL<br/>absent → silent skip"]

        HANDLE_MUTABLE["LinuxTracingHandle MUTABLE<br/>━━━━━━━━━━<br/>_trace_file (open → None)<br/>_trace_path (path → None)<br/>_enrollment_path (path → None)<br/>_monitor_cancel_scope (live → None)"]

        SNAPSHOTS_APPEND["_snapshots APPEND_ONLY<br/>━━━━━━━━━━<br/>grows during proc_monitor loop<br/>never shrunk mid-session<br/>read by stop() for flush"]
    end

    %% ── SESSION LOG WRITE PATH ── %%
    subgraph SessionLog ["● session_log.py — Write Path"]
        direction TB

        FLUSH["flush_session_log()<br/>━━━━━━━━━━<br/>sole write entry point<br/>called: normal end + crash recovery"]

        SESSION_ARTIFACTS["WRITE_ONCE Artifacts<br/>━━━━━━━━━━<br/>summary.json<br/>proc_trace.jsonl<br/>anomalies.jsonl"]

        RECOVERY_ARTIFACTS["WRITE_ONCE Recovery Files<br/>━━━━━━━━━━<br/>token_usage.json (next boot)<br/>step_timing.json (next boot)<br/>audit_log.json (next boot)"]

        SESSIONS_IDX["sessions.jsonl APPEND_ONLY<br/>━━━━━━━━━━<br/>global audit index<br/>append mode — never read<br/>by live logic (only retention)"]

        TELEMETRY_FENCE["FENCE: .telemetry_cleared_at<br/>━━━━━━━━━━<br/>write_telemetry_clear_marker()<br/>read only on next server boot<br/>excludes pre-clear sessions"]
    end

    %% ── CRASH RECOVERY GATE CHAIN ── %%
    subgraph Recovery ["● session_log.py — Crash Recovery Gate Chain"]
        direction TB

        TIMING_GATE["Gate 0: 30s Freshness<br/>━━━━━━━━━━<br/>mtime < now - 30s?<br/>skip if too fresh (active session)"]

        ENROLL_GATE["Gate 1: Enrollment Sidecar<br/>━━━━━━━━━━<br/>autoskillit_enrollment_{pid}.json<br/>absent → skip (alien file)"]

        BOOT_GATE["Gate 2: boot_id Match<br/>━━━━━━━━━━<br/>enrollment.boot_id == current_boot_id?<br/>mismatch → DELETE both files (stale)"]

        PID_GATE["Gate 3: PID Liveness + Reuse<br/>━━━━━━━━━━<br/>psutil.pid_exists(pid)?<br/>starttime_ticks == enrolled_ticks?<br/>same ticks → alive, skip<br/>different ticks → recycled, RECOVER"]

        RECOVER_FLUSH["recover: flush_session_log()<br/>━━━━━━━━━━<br/>subtype='crashed', exit_code=-1<br/>termination_reason='CRASHED'<br/>then unlink trace + enrollment"]
    end

    %% ── CONNECTIONS ── %%

    %% Construction flow
    CFG_FIELDS --> GUARD
    GUARD -->|"PYTEST_CURRENT_TEST set<br/>+ caller in /tests/<br/>+ tmpfs == /dev/shm"| ERR_RAISE(["RuntimeError raised"])
    GUARD -->|"no PYTEST env"| PROD_OK
    GUARD -->|"caller not in /tests/"| LIBRARY_OK

    %% Test isolation feeds construction safely
    ISOLATED_FIX -->|"tmpfs_path = tmp_path/shm"| CFG_FIELDS
    TOOL_CTX_FIX -->|"both paths redirected"| CFG_FIELDS
    ISO_HOME -->|"blocks real config"| LIBRARY_OK

    %% Config fields flow into runtime
    PROD_OK --> ENABLED_GATE
    LIBRARY_OK --> ENABLED_GATE
    ENABLED_GATE -->|"enabled=True"| TMPFS_CHECK
    ENABLED_GATE -->|"enabled=False"| SKIP(["return None"])
    TMPFS_CHECK -->|"dir exists"| HANDLE_MUTABLE
    TMPFS_CHECK -->|"dir absent"| HANDLE_MUTABLE
    HANDLE_MUTABLE --> SNAPSHOTS_APPEND

    %% Runtime feeds session log
    SNAPSHOTS_APPEND -->|"stop() called"| FLUSH
    FLUSH --> SESSION_ARTIFACTS
    FLUSH --> RECOVERY_ARTIFACTS
    FLUSH --> SESSIONS_IDX
    FLUSH --> TELEMETRY_FENCE

    %% Recovery gate chain
    TIMING_GATE -->|"stale enough"| ENROLL_GATE
    ENROLL_GATE -->|"sidecar present"| BOOT_GATE
    BOOT_GATE -->|"boot_id matches"| PID_GATE
    PID_GATE -->|"PID recycled"| RECOVER_FLUSH
    RECOVER_FLUSH -->|"calls"| FLUSH

    %% CLASS ASSIGNMENTS %%
    class CFG_FIELDS stateNode;
    class GUARD,ENROLL_GATE,BOOT_GATE,PID_GATE,TIMING_GATE detector;
    class PROD_OK,LIBRARY_OK phase;
    class ISOLATED_FIX,TOOL_CTX_FIX,ISO_HOME newComponent;
    class ENABLED_GATE,TMPFS_CHECK handler;
    class HANDLE_MUTABLE,SNAPSHOTS_APPEND stateNode;
    class FLUSH handler;
    class SESSION_ARTIFACTS,RECOVERY_ARTIFACTS,SESSIONS_IDX,TELEMETRY_FENCE output;
    class RECOVER_FLUSH phase;
    class ERR_RAISE,SKIP terminal;
```

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START])
    BLOCKED([BLOCKED — RuntimeError])
    NONE([returns None])
    HANDLE([returns LinuxTracingHandle])
    COMPLETE([COMPLETE])

    %% ─── PHASE 1: CONFIG GUARD ─── %%
    subgraph GuardPhase ["● LinuxTracingConfig — Test Isolation Guard  (settings.py)"]
        direction TB
        N_config["● LinuxTracingConfig()<br/>━━━━━━━━━━<br/>dataclass __init__ called"]
        N_guard{"tmpfs_path == '/dev/shm'<br/>━━━━━━━━━━<br/>default value?"}
        N_pytest{"PYTEST_CURRENT_TEST<br/>━━━━━━━━━━<br/>env var set?"}
        N_frame{"inspect caller frame<br/>━━━━━━━━━━<br/>f_back.f_back<br/>co_filename in /tests/?"}
        N_pass["guard passes<br/>━━━━━━━━━━<br/>normal construction"]
    end

    %% ─── PHASE 2: TRACING START ─── %%
    subgraph StartPhase ["● start_linux_tracing()  (linux_tracing.py)"]
        direction TB
        N_start["● start_linux_tracing(pid, config, tg)<br/>━━━━━━━━━━<br/>entry: open session tracing"]
        N_gate1{"LINUX_TRACING_AVAILABLE<br/>━━━━━━━━━━<br/>& config.enabled?"}
        N_gate2{"tg (task group)<br/>━━━━━━━━━━<br/>provided?"}
        N_open["open tmpfs trace file<br/>━━━━━━━━━━<br/>config.tmpfs_path /autoskillit_trace_{pid}.jsonl<br/>buffering=1 (line-buffered)"]
        N_enroll["write enrollment sidecar (atomic)<br/>━━━━━━━━━━<br/>config.tmpfs_path /autoskillit_enrollment_{pid}.json<br/>TraceEnrollmentRecord: pid+boot_id+starttime_ticks"]
        N_spawn["tg.start_soon(_run_monitor)<br/>━━━━━━━━━━<br/>async monitor task in cancel scope"]
    end

    %% ─── PHASE 3: MONITORING LOOP ─── %%
    subgraph MonitorPhase ["● proc_monitor() + _run_monitor()  (linux_tracing.py)"]
        direction TB
        N_snap["read_proc_snapshot(pid)<br/>━━━━━━━━━━<br/>psutil.Process.oneshot()<br/>+ /proc/{pid}/status|oom_score|wchan"]
        N_gone{"snapshot is None?<br/>━━━━━━━━━━<br/>process exited"}
        N_clock{"captured_at ≤<br/>last_captured_at?<br/>━━━━━━━━━━<br/>NTP / WSL2 clock jump"}
        N_advance["advance by 1 µs<br/>━━━━━━━━━━<br/>maintain monotonic<br/>captured_at invariant"]
        N_append["append to handle._snapshots<br/>━━━━━━━━━━<br/>in-memory list"]
        N_write["write JSON line to tmpfs file<br/>━━━━━━━━━━<br/>crash-resilient streaming"]
        N_file_err{"OSError on write?"}
        N_degrade["close trace file<br/>━━━━━━━━━━<br/>degrade to in-memory only"]
        N_sleep["anyio.sleep(config.proc_interval)<br/>━━━━━━━━━━<br/>default 5.0s → loop"]
    end

    %% ─── PHASE 4: SESSION END + LOG FLUSH ─── %%
    subgraph FlushPhase ["● handle.stop() + flush_session_log()  (linux_tracing.py / session_log.py)"]
        direction TB
        N_stop["handle.stop()<br/>━━━━━━━━━━<br/>cancel CancelScope<br/>flush+close trace file<br/>unlink tmpfs files"]
        N_flush["● flush_session_log()<br/>━━━━━━━━━━<br/>called by headless.py<br/>after session completes"]
        N_proc_trace["write proc_trace.jsonl<br/>━━━━━━━━━━<br/>session_dir/proc_trace.jsonl"]
        N_anomaly["detect_anomalies()<br/>━━━━━━━━━━<br/>post-hoc over snapshots"]
        N_summary["write summary.json<br/>━━━━━━━━━━<br/>+ anomalies.jsonl (if any)"]
        N_index["append to sessions.jsonl<br/>━━━━━━━━━━<br/>log_root/sessions.jsonl<br/>global append-only index"]
        N_retention["_enforce_retention()<br/>━━━━━━━━━━<br/>trim to max 500 session dirs<br/>rewrite sessions.jsonl"]
    end

    %% ─── PHASE 5: CRASH RECOVERY ─── %%
    subgraph RecoveryPhase ["● recover_crashed_sessions()  (session_log.py)"]
        direction TB
        R_entry["● recover_crashed_sessions(tmpfs_path)<br/>━━━━━━━━━━<br/>called at server startup<br/>glob autoskillit_trace_*.jsonl"]
        R_age{"file age < 30s?<br/>━━━━━━━━━━<br/>may be active session"}
        R_sidecar{"enrollment sidecar<br/>━━━━━━━━━━<br/>autoskillit_enrollment_{pid}.json<br/>exists & parses?"}
        R_bootid{"boot_id matches<br/>━━━━━━━━━━<br/>current boot?"}
        R_pid{"psutil.pid_exists(pid)?"}
        R_ticks{"starttime_ticks<br/>━━━━━━━━━━<br/>unchanged?<br/>(same process)"}
        R_read["read snapshot lines<br/>━━━━━━━━━━<br/>from trace file"]
        R_flush["flush_session_log()<br/>━━━━━━━━━━<br/>subtype='crashed', exit_code=-1<br/>termination_reason='CRASHED'"]
        R_cleanup["unlink trace file<br/>━━━━━━━━━━<br/>+ enrollment sidecar"]
    end

    %% ─── PHASE 6: TEST ISOLATION FIXTURE ─── %%
    subgraph FixturePhase ["● isolated_tracing_config fixture  (tests/execution/conftest.py)"]
        direction TB
        F_fixture["● isolated_tracing_config(tmp_path)<br/>━━━━━━━━━━<br/>pytest fixture"]
        F_return["LinuxTracingConfig(<br/>━━━━━━━━━━<br/>tmpfs_path=str(tmp_path/shm)<br/>proc_interval=0.05)"]
    end

    %% ─── FLOW: CONFIG GUARD ─── %%
    START --> N_config
    N_config --> N_guard
    N_guard -->|"yes (default path)"| N_pytest
    N_guard -->|"no (custom path)"| N_pass
    N_pytest -->|"yes — test context"| N_frame
    N_pytest -->|"no — production"| N_pass
    N_frame -->|"yes — direct test caller"| BLOCKED
    N_frame -->|"no — library machinery"| N_pass

    %% ─── FLOW: TRACING START ─── %%
    N_pass --> N_start
    N_start --> N_gate1
    N_gate1 -->|"no"| NONE
    N_gate1 -->|"yes"| N_gate2
    N_gate2 -->|"no"| NONE
    N_gate2 -->|"yes"| N_open
    N_open --> N_enroll
    N_enroll --> N_spawn
    N_spawn --> HANDLE

    %% ─── FLOW: MONITORING LOOP ─── %%
    HANDLE --> N_snap
    N_snap --> N_gone
    N_gone -->|"yes"| N_stop
    N_gone -->|"no"| N_clock
    N_clock -->|"yes (stepped back)"| N_advance
    N_clock -->|"no"| N_append
    N_advance --> N_append
    N_append --> N_write
    N_write --> N_file_err
    N_file_err -->|"yes"| N_degrade
    N_file_err -->|"no"| N_sleep
    N_degrade --> N_sleep
    N_sleep -->|"loop"| N_snap

    %% ─── FLOW: SESSION END + FLUSH ─── %%
    N_stop --> N_flush
    N_flush --> N_proc_trace
    N_proc_trace --> N_anomaly
    N_anomaly --> N_summary
    N_summary --> N_index
    N_index --> N_retention
    N_retention --> COMPLETE

    %% ─── FLOW: CRASH RECOVERY ─── %%
    R_entry --> R_age
    R_age -->|"yes — skip"| R_entry
    R_age -->|"no — old enough"| R_sidecar
    R_sidecar -->|"missing — alien file, skip"| R_entry
    R_sidecar -->|"found"| R_bootid
    R_bootid -->|"mismatch — stale pre-reboot<br/>unlink both files"| R_entry
    R_bootid -->|"match"| R_pid
    R_pid -->|"no — process gone"| R_read
    R_pid -->|"yes — alive"| R_ticks
    R_ticks -->|"unchanged — still running, skip"| R_entry
    R_ticks -->|"changed — PID recycled, treat as crash"| R_read
    R_read --> R_flush
    R_flush --> R_cleanup
    R_cleanup --> R_entry

    %% ─── FLOW: TEST ISOLATION ─── %%
    F_fixture --> F_return
    F_return -->|"passed to tests as LinuxTracingConfig"| N_start

    %% CLASS ASSIGNMENTS %%
    class START,BLOCKED,NONE,HANDLE,COMPLETE terminal;
    class N_config,N_pass,N_start,N_open,N_enroll,N_spawn handler;
    class N_guard,N_pytest,N_frame,N_gate1,N_gate2,N_gone,N_clock,N_file_err stateNode;
    class N_snap,N_advance,N_append,N_write,N_degrade,N_sleep phase;
    class N_stop,N_flush,N_proc_trace,N_anomaly,N_summary,N_index,N_retention handler;
    class R_entry,R_read,R_flush,R_cleanup handler;
    class R_age,R_sidecar,R_bootid,R_pid,R_ticks detector;
    class F_fixture,F_return newComponent;
```

### Error/Resilience Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;

    CONSTRUCT_START(["LinuxTracingConfig()"])

    subgraph PostInitGate ["● CONSTRUCTION GUARD — LinuxTracingConfig.__post_init__"]
        CHECK_SHM{"tmpfs_path<br/>== /dev/shm?"}
        CHECK_PYTEST{"PYTEST_CURRENT_TEST<br/>env set?"}
        CHECK_FRAME{"caller frame<br/>inside /tests/?"}
        GUARD_PASS["Config accepted<br/>━━━━━━━━━━<br/>proceeds to use"]
    end

    subgraph TestIsolation ["● TEST ISOLATION ESCAPE HATCH"]
        FIXTURE["● isolated_tracing_config<br/>━━━━━━━━━━<br/>pytest fixture<br/>tests/execution/conftest.py"]
        SAFE_CONFIG["LinuxTracingConfig<br/>━━━━━━━━━━<br/>tmpfs_path=str(tmp_path/shm)<br/>proc_interval=0.05"]
    end

    subgraph CrashRecovery ["● CRASH RECOVERY GATES — recover_crashed_sessions"]
        SCAN["Scan tmpfs<br/>━━━━━━━━━━<br/>autoskillit_trace_*.jsonl"]
        AGE_GATE{"mtime age<br/>< 30s?"}
        ENROLLMENT_GATE{"enrollment<br/>sidecar exists?"}
        BOOT_GATE{"boot_id<br/>matches current?"}
        PID_GATE{"PID alive +<br/>same starttime_ticks?"}
        READ_SNAPS["Read snapshots<br/>━━━━━━━━━━<br/>parse JSONL lines<br/>OSError → skip file"]
    end

    subgraph Finalization ["● CRASH FINALIZATION — flush_session_log"]
        FLUSH["flush_session_log<br/>━━━━━━━━━━<br/>subtype=crashed<br/>termination=CRASHED"]
        FLUSH_ERR{"Exception<br/>during flush?"}
        UNLINK["Unlink trace +<br/>enrollment files<br/>━━━━━━━━━━<br/>missing_ok=True"]
    end

    T_RUNTIME_ERR(["RuntimeError<br/>dev/shm rejected<br/>in test context"])
    T_PASS(["SAFE<br/>config constructed"])
    T_SKIP(["SKIPPED<br/>file left in place"])
    T_STALE_DEL(["STALE DELETED<br/>pre-reboot file removed"])
    T_RECOVERED(["RECOVERED<br/>session finalized<br/>count += 1"])
    T_FIXTURE_SAFE(["TEST SAFE<br/>isolated tmp_path/shm"])

    %% Construction gate flow
    CONSTRUCT_START --> CHECK_SHM
    CHECK_SHM -->|"no — safe path"| GUARD_PASS
    CHECK_SHM -->|"yes"| CHECK_PYTEST
    CHECK_PYTEST -->|"not set — production"| GUARD_PASS
    CHECK_PYTEST -->|"set"| CHECK_FRAME
    CHECK_FRAME -->|"library machinery<br/>(AutomationConfig etc.)"| GUARD_PASS
    CHECK_FRAME -->|"direct test code"| T_RUNTIME_ERR
    GUARD_PASS --> T_PASS

    %% Test isolation path (recommended escape hatch)
    FIXTURE --> SAFE_CONFIG --> T_FIXTURE_SAFE

    %% Crash recovery gates
    SCAN --> AGE_GATE
    AGE_GATE -->|"too recent<br/>(may be active)"| T_SKIP
    AGE_GATE -->|"old enough"| ENROLLMENT_GATE
    ENROLLMENT_GATE -->|"missing — alien/test file"| T_SKIP
    ENROLLMENT_GATE -->|"present"| BOOT_GATE
    BOOT_GATE -->|"mismatch<br/>→ unlink both"| T_STALE_DEL
    BOOT_GATE -->|"matches"| PID_GATE
    PID_GATE -->|"alive, same ticks<br/>(process running)"| T_SKIP
    PID_GATE -->|"gone or PID recycled"| READ_SNAPS
    READ_SNAPS --> FLUSH

    %% Finalization
    FLUSH --> FLUSH_ERR
    FLUSH_ERR -->|"yes — log debug,<br/>continue loop"| T_SKIP
    FLUSH_ERR -->|"no"| UNLINK
    UNLINK --> T_RECOVERED

    %% CLASS ASSIGNMENTS
    class CONSTRUCT_START terminal;
    class CHECK_SHM,CHECK_PYTEST,CHECK_FRAME,AGE_GATE,ENROLLMENT_GATE,BOOT_GATE,PID_GATE,FLUSH_ERR detector;
    class GUARD_PASS,READ_SNAPS handler;
    class SCAN phase;
    class FIXTURE,SAFE_CONFIG newComponent;
    class FLUSH,UNLINK output;
    class T_RUNTIME_ERR,T_PASS,T_SKIP,T_STALE_DEL,T_RECOVERED,T_FIXTURE_SAFE terminal;
```

Closes #771

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260412-142552-496727/.autoskillit/temp/rectify/rectify_trace_identity_contract_2026-04-12_180100_part_a.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| group | 2.7k | 68.8k | 3.1M | 200.8k | 1 | 22m 49s |
| plan | 3.2k | 139.0k | 4.9M | 383.9k | 6 | 48m 3s |
| verify | 3.2k | 81.1k | 4.5M | 293.1k | 6 | 24m 41s |
| implement | 4.9k | 156.8k | 20.6M | 442.5k | 7 | 56m 14s |
| fix | 818 | 43.5k | 4.2M | 208.9k | 4 | 27m 56s |
| **Total** | 14.9k | 489.2k | 37.3M | 1.5M | | 2h 59m |