### PR TITLE
Add idle_output_timeout as Per-Step Recipe Override

### DIFF
--- a/src/autoskillit/core/_type_protocols.py
+++ b/src/autoskillit/core/_type_protocols.py
@@ -182,6 +182,7 @@ class HeadlessExecutor(Protocol):
         add_dirs: Sequence[ValidatedAddDir] = (),
         timeout: float | None = None,
         stale_threshold: float | None = None,
+        idle_output_timeout: float | None = None,
         expected_output_patterns: Sequence[str] = (),
         write_behavior: WriteBehaviorSpec | None = None,
         completion_marker: str = "",

--- a/src/autoskillit/execution/headless.py
+++ b/src/autoskillit/execution/headless.py
@@ -989,7 +989,11 @@ async def run_headless_core(
 
         effective_timeout = timeout if timeout is not None else cfg.timeout
         effective_stale = stale_threshold if stale_threshold is not None else cfg.stale_threshold
-        _raw_idle = idle_output_timeout if idle_output_timeout is not None else float(cfg.idle_output_timeout)
+        _raw_idle = (
+            idle_output_timeout
+            if idle_output_timeout is not None
+            else float(cfg.idle_output_timeout)
+        )
         effective_idle: float | None = _raw_idle if _raw_idle > 0.0 else None
 
         logger.debug(
@@ -1192,7 +1196,11 @@ class DefaultHeadlessExecutor:
         cfg = self._ctx.config.run_skill
         effective_timeout = timeout if timeout is not None else cfg.timeout
         effective_stale = stale_threshold if stale_threshold is not None else cfg.stale_threshold
-        _raw_idle = idle_output_timeout if idle_output_timeout is not None else float(cfg.idle_output_timeout)
+        _raw_idle = (
+            idle_output_timeout
+            if idle_output_timeout is not None
+            else float(cfg.idle_output_timeout)
+        )
         effective_idle: float | None = _raw_idle if _raw_idle > 0.0 else None
         return await run_headless_core(
             skill_command,

--- a/src/autoskillit/execution/headless.py
+++ b/src/autoskillit/execution/headless.py
@@ -953,6 +953,7 @@ async def run_headless_core(
     add_dirs: Sequence[ValidatedAddDir] = (),
     timeout: float | None = None,
     stale_threshold: float | None = None,
+    idle_output_timeout: float | None = None,
     expected_output_patterns: Sequence[str] = (),
     write_behavior: WriteBehaviorSpec | None = None,
     completion_marker: str = "",
@@ -988,6 +989,8 @@ async def run_headless_core(
 
         effective_timeout = timeout if timeout is not None else cfg.timeout
         effective_stale = stale_threshold if stale_threshold is not None else cfg.stale_threshold
+        _raw_idle = idle_output_timeout if idle_output_timeout is not None else float(cfg.idle_output_timeout)
+        effective_idle: float | None = _raw_idle if _raw_idle > 0.0 else None
 
         logger.debug(
             "run_headless_core_entry",
@@ -1023,7 +1026,7 @@ async def run_headless_core(
                 stale_threshold=effective_stale,
                 completion_drain_timeout=cfg.completion_drain_timeout,
                 linux_tracing_config=linux_tracing_cfg,
-                idle_output_timeout=cfg.idle_output_timeout,
+                idle_output_timeout=effective_idle,
                 max_suppression_seconds=cfg.max_suppression_seconds,
             )
         finally:
@@ -1181,6 +1184,7 @@ class DefaultHeadlessExecutor:
         add_dirs: Sequence[ValidatedAddDir] = (),
         timeout: float | None = None,
         stale_threshold: float | None = None,
+        idle_output_timeout: float | None = None,
         expected_output_patterns: Sequence[str] = (),
         write_behavior: WriteBehaviorSpec | None = None,
         completion_marker: str = "",
@@ -1188,6 +1192,8 @@ class DefaultHeadlessExecutor:
         cfg = self._ctx.config.run_skill
         effective_timeout = timeout if timeout is not None else cfg.timeout
         effective_stale = stale_threshold if stale_threshold is not None else cfg.stale_threshold
+        _raw_idle = idle_output_timeout if idle_output_timeout is not None else float(cfg.idle_output_timeout)
+        effective_idle: float | None = _raw_idle if _raw_idle > 0.0 else None
         return await run_headless_core(
             skill_command,
             cwd,
@@ -1199,6 +1205,7 @@ class DefaultHeadlessExecutor:
             add_dirs=add_dirs,
             timeout=effective_timeout,
             stale_threshold=effective_stale,
+            idle_output_timeout=effective_idle,
             expected_output_patterns=expected_output_patterns,
             write_behavior=write_behavior,
             completion_marker=completion_marker,

--- a/src/autoskillit/execution/headless.py
+++ b/src/autoskillit/execution/headless.py
@@ -1196,12 +1196,6 @@ class DefaultHeadlessExecutor:
         cfg = self._ctx.config.run_skill
         effective_timeout = timeout if timeout is not None else cfg.timeout
         effective_stale = stale_threshold if stale_threshold is not None else cfg.stale_threshold
-        _raw_idle = (
-            idle_output_timeout
-            if idle_output_timeout is not None
-            else float(cfg.idle_output_timeout)
-        )
-        effective_idle: float | None = _raw_idle if _raw_idle > 0.0 else None
         return await run_headless_core(
             skill_command,
             cwd,
@@ -1213,7 +1207,7 @@ class DefaultHeadlessExecutor:
             add_dirs=add_dirs,
             timeout=effective_timeout,
             stale_threshold=effective_stale,
-            idle_output_timeout=effective_idle,
+            idle_output_timeout=idle_output_timeout,
             expected_output_patterns=expected_output_patterns,
             write_behavior=write_behavior,
             completion_marker=completion_marker,

--- a/src/autoskillit/recipe/io.py
+++ b/src/autoskillit/recipe/io.py
@@ -148,6 +148,7 @@ _PARSE_STEP_HANDLED_FIELDS: frozenset[str] = frozenset(
         "gate",
         "optional_context_refs",
         "stale_threshold",
+        "idle_output_timeout",
     }
 )
 if _PARSE_STEP_HANDLED_FIELDS != frozenset(RecipeStep.__dataclass_fields__):
@@ -254,6 +255,7 @@ def _parse_step(data: dict[str, Any]) -> RecipeStep:
         gate=data.get("gate"),
         optional_context_refs=data.get("optional_context_refs", []),
         stale_threshold=data.get("stale_threshold"),
+        idle_output_timeout=data.get("idle_output_timeout"),
     )
 
 

--- a/src/autoskillit/recipe/rules_tools.py
+++ b/src/autoskillit/recipe/rules_tools.py
@@ -13,8 +13,15 @@ _ALL_TOOLS: frozenset[str] = GATED_TOOLS | UNGATED_TOOLS | HEADLESS_TOOLS
 _TOOL_PARAMS: dict[str, frozenset[str]] = {
     # --- Execution tools ---
     "run_skill": frozenset(
-        {"skill_command", "cwd", "model", "step_name", "order_id", "stale_threshold",
-         "idle_output_timeout"}
+        {
+            "skill_command",
+            "cwd",
+            "model",
+            "step_name",
+            "order_id",
+            "stale_threshold",
+            "idle_output_timeout",
+        }
     ),
     "run_cmd": frozenset({"cmd", "cwd", "timeout", "step_name"}),
     "run_python": frozenset({"callable", "args", "timeout"}),

--- a/src/autoskillit/recipe/rules_tools.py
+++ b/src/autoskillit/recipe/rules_tools.py
@@ -13,7 +13,8 @@ _ALL_TOOLS: frozenset[str] = GATED_TOOLS | UNGATED_TOOLS | HEADLESS_TOOLS
 _TOOL_PARAMS: dict[str, frozenset[str]] = {
     # --- Execution tools ---
     "run_skill": frozenset(
-        {"skill_command", "cwd", "model", "step_name", "order_id", "stale_threshold"}
+        {"skill_command", "cwd", "model", "step_name", "order_id", "stale_threshold",
+         "idle_output_timeout"}
     ),
     "run_cmd": frozenset({"cmd", "cwd", "timeout", "step_name"}),
     "run_python": frozenset({"callable", "args", "timeout"}),

--- a/src/autoskillit/recipe/schema.py
+++ b/src/autoskillit/recipe/schema.py
@@ -89,6 +89,7 @@ class RecipeStep:
         default_factory=list
     )  # Context variable names that may be referenced before they are captured (cyclic routes)
     stale_threshold: int | None = None  # None means use global RunSkillConfig.stale_threshold
+    idle_output_timeout: int | None = None  # None = use global cfg; 0 = disabled for this step
 
 
 @dataclass

--- a/src/autoskillit/recipe/validator.py
+++ b/src/autoskillit/recipe/validator.py
@@ -161,6 +161,14 @@ def validate_recipe(recipe: Recipe) -> list[str]:
                 f"when set, got {step.stale_threshold!r}"
             )
 
+        if step.idle_output_timeout is not None and (
+            not isinstance(step.idle_output_timeout, int) or step.idle_output_timeout < 0
+        ):
+            errors.append(
+                f"Step {step_name!r}: 'idle_output_timeout' must be a non-negative integer "
+                f"when set (0 = disabled), got {step.idle_output_timeout!r}"
+            )
+
         if step.on_result is not None:
             if step.on_success is not None:
                 errors.append(

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -293,6 +293,7 @@ steps:
   implement_phase:
     tool: run_skill
     stale_threshold: 2400
+    idle_output_timeout: 0
     with:
       skill_command: "/autoskillit:implement-experiment ${{ context.phase_plan_path }}"
       cwd: "${{ context.worktree_path }}"
@@ -312,6 +313,7 @@ steps:
   troubleshoot_implement_failure:
     tool: run_skill
     stale_threshold: 2400
+    idle_output_timeout: 0
     with:
       skill_command: "/autoskillit:troubleshoot-experiment ${{ context.worktree_path }} implement_phase"
       cwd: "${{ inputs.source_dir }}"
@@ -343,6 +345,7 @@ steps:
   run_experiment:
     tool: run_skill
     stale_threshold: 2400
+    idle_output_timeout: 0
     with:
       skill_command: "/autoskillit:run-experiment ${{ context.worktree_path }}"
       cwd: "${{ context.worktree_path }}"
@@ -357,6 +360,7 @@ steps:
   adjust_experiment:
     tool: run_skill
     stale_threshold: 2400
+    idle_output_timeout: 0
     with:
       skill_command: "/autoskillit:run-experiment ${{ context.worktree_path }} --adjust"
       cwd: "${{ context.worktree_path }}"
@@ -661,6 +665,7 @@ steps:
   re_run_experiment:
     tool: run_skill
     stale_threshold: 2400
+    idle_output_timeout: 0
     with:
       skill_command: "/autoskillit:run-experiment ${{ context.worktree_path }} --adjust"
       cwd: "${{ context.worktree_path }}"

--- a/src/autoskillit/server/tools_execution.py
+++ b/src/autoskillit/server/tools_execution.py
@@ -300,7 +300,9 @@ async def run_skill(
             expected_output_patterns=expected_output_patterns,
             write_behavior=write_spec,
             stale_threshold=float(stale_threshold) if stale_threshold is not None else None,
-            idle_output_timeout=float(idle_output_timeout) if idle_output_timeout is not None else None,
+            idle_output_timeout=float(idle_output_timeout)
+            if idle_output_timeout is not None
+            else None,
             completion_marker=invocation_marker,
         )
         if skill_result.success:

--- a/src/autoskillit/server/tools_execution.py
+++ b/src/autoskillit/server/tools_execution.py
@@ -151,6 +151,7 @@ async def run_skill(
     step_name: str = "",
     order_id: str = "",
     stale_threshold: int | None = None,
+    idle_output_timeout: int | None = None,
     ctx: Context = CurrentContext(),
 ) -> str:
     """Run a Claude Code headless session with a skill command.
@@ -190,6 +191,9 @@ async def run_skill(
         stale_threshold: Override the staleness kill threshold in seconds. When set on
             a RecipeStep, the recipe orchestrator passes it here. None uses the global
             config default (RunSkillConfig.stale_threshold, default 1200s).
+        idle_output_timeout: Override the idle stdout kill threshold in seconds.
+            0 = disabled for this step. None = use global config
+            (RunSkillConfig.idle_output_timeout, default 600s).
     """
     if (headless := _require_not_headless("run_skill")) is not None:
         return headless
@@ -296,6 +300,7 @@ async def run_skill(
             expected_output_patterns=expected_output_patterns,
             write_behavior=write_spec,
             stale_threshold=float(stale_threshold) if stale_threshold is not None else None,
+            idle_output_timeout=float(idle_output_timeout) if idle_output_timeout is not None else None,
             completion_marker=invocation_marker,
         )
         if skill_result.success:

--- a/tests/execution/test_headless.py
+++ b/tests/execution/test_headless.py
@@ -3620,14 +3620,13 @@ class TestHeadlessExecutorIdleOutputTimeout:
         """idle_output_timeout=None falls back to float(cfg.idle_output_timeout)."""
         from autoskillit.execution.headless import run_headless_core
 
-        cfg_value = float(tool_ctx.config.run_skill.idle_output_timeout)
         marker = tool_ctx.config.run_skill.completion_marker
         tool_ctx.runner.push(self._success_payload(marker))
         await run_headless_core(
             "/investigate foo", cwd="/tmp", ctx=tool_ctx, idle_output_timeout=None
         )
         _, _cwd, _timeout, kwargs = tool_ctx.runner.call_args_list[0]
-        assert kwargs["idle_output_timeout"] == cfg_value
+        assert kwargs["idle_output_timeout"] == 600.0
 
 
 def _ndjson_with_write(result_text: str, file_paths: list[str], session_id: str = "test-session"):

--- a/tests/execution/test_headless.py
+++ b/tests/execution/test_headless.py
@@ -3601,9 +3601,7 @@ class TestHeadlessExecutorIdleOutputTimeout:
         assert kwargs["idle_output_timeout"] == 120.0
 
     @pytest.mark.anyio
-    async def test_default_headless_executor_converts_zero_to_none(
-        self, tool_ctx
-    ) -> None:
+    async def test_default_headless_executor_converts_zero_to_none(self, tool_ctx) -> None:
         """idle_output_timeout=0 is converted to None (disabled) before passing to runner."""
         from autoskillit.execution.headless import run_headless_core
 

--- a/tests/execution/test_headless.py
+++ b/tests/execution/test_headless.py
@@ -3560,6 +3560,78 @@ class TestHeadlessExecutorCompletionMarker:
         assert param.default == ""
 
 
+class TestHeadlessExecutorIdleOutputTimeout:
+    """Protocol conformance and resolution logic for idle_output_timeout."""
+
+    def test_headless_executor_accepts_idle_output_timeout(self) -> None:
+        import inspect
+
+        from autoskillit.execution.headless import DefaultHeadlessExecutor
+
+        sig = inspect.signature(DefaultHeadlessExecutor.run)
+        assert "idle_output_timeout" in sig.parameters
+        param = sig.parameters["idle_output_timeout"]
+        assert param.default is None
+
+    def _success_payload(self, marker: str) -> SubprocessResult:
+        payload = json.dumps(
+            {
+                "type": "result",
+                "subtype": "success",
+                "is_error": False,
+                "result": f"Done. {marker}",
+                "session_id": "sess-iot",
+            }
+        )
+        return SubprocessResult(0, payload, "", TerminationReason.NATURAL_EXIT, pid=1)
+
+    @pytest.mark.anyio
+    async def test_default_headless_executor_uses_per_step_idle_output_timeout(
+        self, tool_ctx
+    ) -> None:
+        """idle_output_timeout=120 is converted to float and passed to the runner."""
+        from autoskillit.execution.headless import run_headless_core
+
+        marker = tool_ctx.config.run_skill.completion_marker
+        tool_ctx.runner.push(self._success_payload(marker))
+        await run_headless_core(
+            "/investigate foo", cwd="/tmp", ctx=tool_ctx, idle_output_timeout=120.0
+        )
+        _, _cwd, _timeout, kwargs = tool_ctx.runner.call_args_list[0]
+        assert kwargs["idle_output_timeout"] == 120.0
+
+    @pytest.mark.anyio
+    async def test_default_headless_executor_converts_zero_to_none(
+        self, tool_ctx
+    ) -> None:
+        """idle_output_timeout=0 is converted to None (disabled) before passing to runner."""
+        from autoskillit.execution.headless import run_headless_core
+
+        marker = tool_ctx.config.run_skill.completion_marker
+        tool_ctx.runner.push(self._success_payload(marker))
+        await run_headless_core(
+            "/investigate foo", cwd="/tmp", ctx=tool_ctx, idle_output_timeout=0.0
+        )
+        _, _cwd, _timeout, kwargs = tool_ctx.runner.call_args_list[0]
+        assert kwargs["idle_output_timeout"] is None
+
+    @pytest.mark.anyio
+    async def test_default_headless_executor_falls_back_to_cfg_idle_output_timeout(
+        self, tool_ctx
+    ) -> None:
+        """idle_output_timeout=None falls back to float(cfg.idle_output_timeout)."""
+        from autoskillit.execution.headless import run_headless_core
+
+        cfg_value = float(tool_ctx.config.run_skill.idle_output_timeout)
+        marker = tool_ctx.config.run_skill.completion_marker
+        tool_ctx.runner.push(self._success_payload(marker))
+        await run_headless_core(
+            "/investigate foo", cwd="/tmp", ctx=tool_ctx, idle_output_timeout=None
+        )
+        _, _cwd, _timeout, kwargs = tool_ctx.runner.call_args_list[0]
+        assert kwargs["idle_output_timeout"] == cfg_value
+
+
 def _ndjson_with_write(result_text: str, file_paths: list[str], session_id: str = "test-session"):
     """Build NDJSON stdout with Write tool_use entries and a result record."""
     records = []

--- a/tests/pipeline/test_context.py
+++ b/tests/pipeline/test_context.py
@@ -166,7 +166,9 @@ def test_headless_executor_protocol_accepts_idle_output_timeout() -> None:
 
     sig = inspect.signature(HeadlessExecutor.run)
     params = sig.parameters
-    assert "idle_output_timeout" in params, "HeadlessExecutor.run missing idle_output_timeout param"
+    assert "idle_output_timeout" in params, (
+        "HeadlessExecutor.run missing idle_output_timeout param"
+    )
     assert params["idle_output_timeout"].default is None
 
 

--- a/tests/pipeline/test_context.py
+++ b/tests/pipeline/test_context.py
@@ -158,6 +158,18 @@ def test_headless_executor_protocol_accepts_timeout() -> None:
     assert params["stale_threshold"].default is None
 
 
+def test_headless_executor_protocol_accepts_idle_output_timeout() -> None:
+    """HeadlessExecutor.run() signature must include optional idle_output_timeout."""
+    import inspect
+
+    from autoskillit.core import HeadlessExecutor
+
+    sig = inspect.signature(HeadlessExecutor.run)
+    params = sig.parameters
+    assert "idle_output_timeout" in params, "HeadlessExecutor.run missing idle_output_timeout param"
+    assert params["idle_output_timeout"].default is None
+
+
 def test_recipe_repository_protocol_has_rich_methods() -> None:
     """RecipeRepository protocol must expose load_and_validate, validate_from_path, list_all."""
     from autoskillit.core import RecipeRepository

--- a/tests/recipe/test_io.py
+++ b/tests/recipe/test_io.py
@@ -443,6 +443,21 @@ class TestRecipeParser:
         step = _parse_step(data)
         assert step.stale_threshold is None
 
+    def test_parse_step_reads_idle_output_timeout(self) -> None:
+        data = {"tool": "run_skill", "idle_output_timeout": 120, "on_success": "done"}
+        step = _parse_step(data)
+        assert step.idle_output_timeout == 120
+
+    def test_parse_step_idle_output_timeout_defaults_to_none(self) -> None:
+        data = {"tool": "run_skill", "on_success": "done"}
+        step = _parse_step(data)
+        assert step.idle_output_timeout is None
+
+    def test_parse_step_idle_output_timeout_zero_means_disabled(self) -> None:
+        data = {"tool": "run_skill", "idle_output_timeout": 0, "on_success": "done"}
+        step = _parse_step(data)
+        assert step.idle_output_timeout == 0
+
     # MOD4
     def test_bundled_resolve_failures_steps_use_config_default(self) -> None:
         bd = builtin_recipes_dir()

--- a/tests/recipe/test_validator.py
+++ b/tests/recipe/test_validator.py
@@ -397,6 +397,37 @@ class TestValidateRecipe:
         errors = validate_recipe(recipe)
         assert not any("stale_threshold" in e for e in errors)
 
+    def test_validator_rejects_negative_idle_output_timeout(self) -> None:
+        recipe = Recipe(
+            name="test",
+            description="test",
+            steps={"s": RecipeStep(tool="run_skill", on_success="done", idle_output_timeout=-1)},
+            kitchen_rules=["test"],
+        )
+        errors = validate_recipe(recipe)
+        assert any("idle_output_timeout" in e for e in errors)
+
+    def test_validator_accepts_zero_idle_output_timeout(self) -> None:
+        # 0 = disabled, must NOT be rejected
+        recipe = Recipe(
+            name="test",
+            description="test",
+            steps={"s": RecipeStep(tool="run_skill", on_success="done", idle_output_timeout=0)},
+            kitchen_rules=["test"],
+        )
+        errors = validate_recipe(recipe)
+        assert not any("idle_output_timeout" in e for e in errors)
+
+    def test_validator_accepts_positive_idle_output_timeout(self) -> None:
+        recipe = Recipe(
+            name="test",
+            description="test",
+            steps={"s": RecipeStep(tool="run_skill", on_success="done", idle_output_timeout=120)},
+            kitchen_rules=["test"],
+        )
+        errors = validate_recipe(recipe)
+        assert not any("idle_output_timeout" in e for e in errors)
+
 
 # ---------------------------------------------------------------------------
 # TestDataFlowQuality — migrated from test_recipe_parser.py

--- a/tests/server/test_tools_execution.py
+++ b/tests/server/test_tools_execution.py
@@ -796,6 +796,7 @@ async def test_tools_execution_routes_through_executor(tool_ctx, monkeypatch) ->
             order_id: str = "",
             timeout: float | None = None,
             stale_threshold: float | None = None,
+            idle_output_timeout: float | None = None,
             expected_output_patterns: tuple[str, ...] | list[str] = (),
             write_behavior=None,
             completion_marker: str = "",
@@ -843,6 +844,7 @@ async def test_run_skill_passes_validated_add_dirs(tool_ctx, monkeypatch) -> Non
             order_id: str = "",
             timeout: float | None = None,
             stale_threshold: float | None = None,
+            idle_output_timeout: float | None = None,
             expected_output_patterns: tuple[str, ...] | list[str] = (),
             write_behavior=None,
             completion_marker: str = "",
@@ -1441,3 +1443,67 @@ async def test_run_skill_make_plan_closure_includes_arch_lens_pack(tool_ctx, mon
     assert "mermaid" in closure
     arch_members = {n for n in closure if n.startswith("arch-lens-")}
     assert len(arch_members) >= 1
+
+
+@pytest.mark.anyio
+async def test_run_skill_passes_idle_output_timeout(tool_ctx, monkeypatch) -> None:
+    """run_skill passes idle_output_timeout (as float) to executor.run()."""
+    from autoskillit.core import SkillResult
+
+    captured: dict = {}
+
+    class MockExecutor:
+        async def run(self, skill_command, cwd, *, idle_output_timeout=None, **kwargs) -> SkillResult:
+            captured["idle_output_timeout"] = idle_output_timeout
+            return SkillResult(
+                success=True,
+                result="ok",
+                session_id="",
+                subtype="success",
+                is_error=False,
+                exit_code=0,
+                needs_retry=False,
+                retry_reason="none",
+                stderr="",
+                token_usage=None,
+            )
+
+    tool_ctx.executor = MockExecutor()
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+
+    from autoskillit.server.tools_execution import run_skill
+
+    await run_skill("/test skill", "/tmp", idle_output_timeout=120)
+    assert captured["idle_output_timeout"] == 120.0  # int→float conversion
+
+
+@pytest.mark.anyio
+async def test_run_skill_idle_output_timeout_defaults_to_none(tool_ctx, monkeypatch) -> None:
+    """run_skill passes None to executor.run() when idle_output_timeout is not set."""
+    from autoskillit.core import SkillResult
+
+    captured: dict = {}
+
+    class MockExecutor:
+        async def run(self, skill_command, cwd, *, idle_output_timeout=None, **kwargs) -> SkillResult:
+            captured["idle_output_timeout"] = idle_output_timeout
+            return SkillResult(
+                success=True,
+                result="ok",
+                session_id="",
+                subtype="success",
+                is_error=False,
+                exit_code=0,
+                needs_retry=False,
+                retry_reason="none",
+                stderr="",
+                token_usage=None,
+            )
+
+    tool_ctx.executor = MockExecutor()
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+
+    from autoskillit.server.tools_execution import run_skill
+
+    await run_skill("/test skill", "/tmp")
+    assert captured["idle_output_timeout"] is None

--- a/tests/server/test_tools_execution.py
+++ b/tests/server/test_tools_execution.py
@@ -1445,9 +1445,8 @@ async def test_run_skill_make_plan_closure_includes_arch_lens_pack(tool_ctx, mon
     assert len(arch_members) >= 1
 
 
-@pytest.mark.anyio
-async def test_run_skill_passes_idle_output_timeout(tool_ctx, monkeypatch) -> None:
-    """run_skill passes idle_output_timeout (as float) to executor.run()."""
+def _make_capturing_executor():
+    """Return (executor, captured_dict) for testing idle_output_timeout propagation."""
     from autoskillit.core import SkillResult
 
     captured: dict = {}
@@ -1470,7 +1469,14 @@ async def test_run_skill_passes_idle_output_timeout(tool_ctx, monkeypatch) -> No
                 token_usage=None,
             )
 
-    tool_ctx.executor = MockExecutor()
+    return MockExecutor(), captured
+
+
+@pytest.mark.anyio
+async def test_run_skill_passes_idle_output_timeout(tool_ctx, monkeypatch) -> None:
+    """run_skill passes idle_output_timeout (as float) to executor.run()."""
+    executor, captured = _make_capturing_executor()
+    tool_ctx.executor = executor
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
 
     from autoskillit.server.tools_execution import run_skill
@@ -1482,29 +1488,8 @@ async def test_run_skill_passes_idle_output_timeout(tool_ctx, monkeypatch) -> No
 @pytest.mark.anyio
 async def test_run_skill_idle_output_timeout_defaults_to_none(tool_ctx, monkeypatch) -> None:
     """run_skill passes None to executor.run() when idle_output_timeout is not set."""
-    from autoskillit.core import SkillResult
-
-    captured: dict = {}
-
-    class MockExecutor:
-        async def run(
-            self, skill_command, cwd, *, idle_output_timeout=None, **kwargs
-        ) -> SkillResult:
-            captured["idle_output_timeout"] = idle_output_timeout
-            return SkillResult(
-                success=True,
-                result="ok",
-                session_id="",
-                subtype="success",
-                is_error=False,
-                exit_code=0,
-                needs_retry=False,
-                retry_reason="none",
-                stderr="",
-                token_usage=None,
-            )
-
-    tool_ctx.executor = MockExecutor()
+    executor, captured = _make_capturing_executor()
+    tool_ctx.executor = executor
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
 
     from autoskillit.server.tools_execution import run_skill

--- a/tests/server/test_tools_execution.py
+++ b/tests/server/test_tools_execution.py
@@ -1453,7 +1453,9 @@ async def test_run_skill_passes_idle_output_timeout(tool_ctx, monkeypatch) -> No
     captured: dict = {}
 
     class MockExecutor:
-        async def run(self, skill_command, cwd, *, idle_output_timeout=None, **kwargs) -> SkillResult:
+        async def run(
+            self, skill_command, cwd, *, idle_output_timeout=None, **kwargs
+        ) -> SkillResult:
             captured["idle_output_timeout"] = idle_output_timeout
             return SkillResult(
                 success=True,
@@ -1485,7 +1487,9 @@ async def test_run_skill_idle_output_timeout_defaults_to_none(tool_ctx, monkeypa
     captured: dict = {}
 
     class MockExecutor:
-        async def run(self, skill_command, cwd, *, idle_output_timeout=None, **kwargs) -> SkillResult:
+        async def run(
+            self, skill_command, cwd, *, idle_output_timeout=None, **kwargs
+        ) -> SkillResult:
             captured["idle_output_timeout"] = idle_output_timeout
             return SkillResult(
                 success=True,


### PR DESCRIPTION
## Summary

Thread `idle_output_timeout` through the same per-step override chain that `stale_threshold`
already uses. Add the field to `RecipeStep`, parse it from YAML, validate it (0 = disabled,
negative = error), whitelist it in `rules_tools.py`, add it to the `HeadlessExecutor` protocol,
thread it through `tools_execution.py` and both `DefaultHeadlessExecutor.run()` and
`run_headless_core()`, then set `idle_output_timeout: 0` (disabled) on the five compute-heavy
steps in `research.yaml`.

The key semantic difference from `stale_threshold`: `0` is a valid recipe value meaning
"no idle timeout for this step" (maps to `None` in `run_managed_async`'s API), whereas
`stale_threshold` rejects 0 as invalid. The 0→None conversion happens at the resolution
layer (both `DefaultHeadlessExecutor.run()` and `run_headless_core()`).

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 45, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START: Recipe YAML loaded])
    COMPLETE_WATCH([COMPLETE: idle watchdog active])
    COMPLETE_NO_WATCH([COMPLETE: no idle watchdog])
    IDLE_STALL([IDLE_STALL: process killed])

    subgraph RecipeLayer ["Recipe Layer — ● schema.py · ● io.py · ● validator.py · ● rules_tools.py"]
        direction TB
        ParseStep["● _parse_step()<br/>━━━━━━━━━━<br/>recipe/io.py<br/>data.get('idle_output_timeout')"]
        StepSchema["● RecipeStep<br/>━━━━━━━━━━<br/>idle_output_timeout: int | None<br/>None = use global cfg<br/>0 = disabled for this step"]
        Validate["● validate_recipe()<br/>━━━━━━━━━━<br/>recipe/validator.py<br/>must be int ≥ 0, or None"]
        RulesTools["● _TOOL_PARAMS[run_skill]<br/>━━━━━━━━━━<br/>recipe/rules_tools.py<br/>idle_output_timeout registered<br/>as first-class MCP param"]
    end

    subgraph MCPLayer ["MCP Layer — ● tools_execution.py"]
        direction TB
        RunSkill["● run_skill MCP tool<br/>━━━━━━━━━━<br/>server/tools_execution.py<br/>idle_output_timeout: int | None<br/>→ float(v) if v is not None else None"]
    end

    subgraph ExecutorLayer ["Executor Layer — ● _type_protocols.py · ● headless.py"]
        direction TB
        Protocol["● HeadlessExecutor.run()<br/>━━━━━━━━━━<br/>core/_type_protocols.py<br/>idle_output_timeout: float | None"]
        DefaultExec["● DefaultHeadlessExecutor.run()<br/>━━━━━━━━━━<br/>execution/headless.py<br/>_raw = val ?? float(cfg.idle_output_timeout=600)"]
        ZeroGate{"_raw_idle > 0.0?<br/>━━━━━━━━━━<br/>0 → None gate"}
    end

    subgraph CoreExec ["Core Execution — ● headless.py · process.py"]
        direction TB
        HeadlessCore["● run_headless_core()<br/>━━━━━━━━━━<br/>execution/headless.py<br/>passes effective_idle to runner<br/>(0→None guard is no-op here)"]
        ManagedAsync["run_managed_async()<br/>━━━━━━━━━━<br/>execution/process.py<br/>idle_output_timeout: float | None"]
        WatchDecision{"idle_output_timeout<br/>is not None?<br/>━━━━━━━━━━<br/>start watchdog?"}
        WatchStdout["_watch_stdout_idle()<br/>━━━━━━━━━━<br/>anyio task group coroutine<br/>polls stdout for idle time"]
    end

    %% FLOW %%
    START --> ParseStep
    ParseStep --> StepSchema
    StepSchema --> Validate
    Validate -->|"valid: int ≥ 0 or None"| RulesTools
    Validate -->|"invalid: raises error"| IDLE_STALL
    RulesTools --> RunSkill

    RunSkill --> Protocol
    Protocol --> DefaultExec
    DefaultExec --> ZeroGate
    ZeroGate -->|"yes → effective_idle: float"| HeadlessCore
    ZeroGate -->|"no (0.0) → effective_idle: None"| HeadlessCore
    HeadlessCore --> ManagedAsync
    ManagedAsync --> WatchDecision
    WatchDecision -->|"not None"| WatchStdout
    WatchDecision -->|"None (disabled)"| COMPLETE_NO_WATCH
    WatchStdout -->|"idle < threshold"| COMPLETE_WATCH
    WatchStdout -->|"idle ≥ threshold"| IDLE_STALL

    %% CLASS ASSIGNMENTS %%
    class START terminal;
    class COMPLETE_WATCH,COMPLETE_NO_WATCH output;
    class IDLE_STALL detector;
    class StepSchema stateNode;
    class ParseStep,RulesTools phase;
    class Validate detector;
    class RunSkill handler;
    class Protocol phase;
    class DefaultExec,HeadlessCore,ManagedAsync handler;
    class ZeroGate,WatchDecision stateNode;
    class WatchStdout phase;
```

### Data Lineage Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 65, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph Origins ["Data Origins"]
        direction TB
        DEFAULTS["defaults.yaml<br/>━━━━━━━━━━<br/>run_skill:<br/>  idle_output_timeout: 600"]
        RESEARCH["● research.yaml<br/>━━━━━━━━━━<br/>5 steps: idle_output_timeout: 0<br/>implement / troubleshoot / experiment"]
    end

    subgraph GlobalCfg ["Global Config (Fallback Source of Truth)"]
        SETTINGS["settings.py RunSkillConfig<br/>━━━━━━━━━━<br/>idle_output_timeout: int = 600<br/>loaded from defaults.yaml"]
    end

    subgraph SchemaValidation ["● Schema, Parse & Validation"]
        direction TB
        PARSE["● io.py _parse_step()<br/>━━━━━━━━━━<br/>data.get('idle_output_timeout')<br/>raw int | None from YAML"]
        RECIPE_STEP["● schema.py RecipeStep<br/>━━━━━━━━━━<br/>idle_output_timeout: int | None<br/>None = use global; 0 = disabled"]
        VALIDATOR["● validator.py<br/>━━━━━━━━━━<br/>non-negative int required when set<br/>0 allowed (explicit disable)"]
        RULES["● rules_tools.py<br/>━━━━━━━━━━<br/>idle_output_timeout whitelisted<br/>in per-step field set (lint-time)"]
    end

    subgraph ExecPipeline ["● Execution Pipeline"]
        direction TB
        PROTOCOL["● _type_protocols.py<br/>━━━━━━━━━━<br/>HeadlessExecutor.run() protocol<br/>idle_output_timeout: float | None"]
        RUN_SKILL["● tools_execution.run_skill()<br/>━━━━━━━━━━<br/>int | None param<br/>→ float | None cast before executor"]
        HEADLESS["● HeadlessExecutor.run()<br/>━━━━━━━━━━<br/>None → fallback to cfg.idle_output_timeout<br/>0.0 → None (disabled)"]
        CORE["● run_headless_core()<br/>━━━━━━━━━━<br/>effective_idle: float | None<br/>passes to subprocess runner"]
    end

    subgraph Watchdog ["Process Watchdog (Consumption)"]
        direction TB
        MANAGED["run_managed_async()<br/>━━━━━━━━━━<br/>spawns _watch_stdout_idle task<br/>only when value is positive float"]
        WATCH["_watch_stdout_idle()<br/>━━━━━━━━━━<br/>polls stdout file size every 5s<br/>fires if size stalls ≥ timeout"]
        KILL["async_kill_process_tree()<br/>━━━━━━━━━━<br/>IDLE_STALL → kill headless Claude<br/>acc.idle_stall = True"]
    end

    %% PRIMARY DATA FLOWS %%
    DEFAULTS -->|"dynaconf load"| SETTINGS
    RESEARCH -->|"YAML parse"| PARSE
    PARSE -->|"RecipeStep(idle_output_timeout=...)"| RECIPE_STEP
    RECIPE_STEP -->|"validate at load time"| VALIDATOR
    RECIPE_STEP -->|"step.idle_output_timeout"| RUN_SKILL
    SETTINGS -->|"fallback when None"| HEADLESS
    RUN_SKILL -->|"float | None"| HEADLESS
    HEADLESS -->|"effective_idle: float | None"| CORE
    CORE -->|"runner(..., idle_output_timeout=...)"| MANAGED
    MANAGED -->|"tg.start_soon()"| WATCH
    WATCH -->|"trigger.set() on expiry"| KILL

    %% SECONDARY / STRUCTURAL FLOWS %%
    RECIPE_STEP -.->|"lint-time field whitelist"| RULES
    PROTOCOL -.->|"declares interface"| HEADLESS

    %% CLASS ASSIGNMENTS %%
    class DEFAULTS,RESEARCH cli;
    class SETTINGS,RECIPE_STEP,PROTOCOL stateNode;
    class PARSE,RUN_SKILL,MANAGED handler;
    class HEADLESS,CORE phase;
    class VALIDATOR,RULES,WATCH detector;
    class KILL integration;
```

### Operational Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ── CONFIGURATION SOURCES ── %%
    subgraph Config ["CONFIGURATION (read-only inputs)"]
        direction TB

        GLOBAL_CFG["RunSkillConfig<br/>━━━━━━━━━━<br/>idle_output_timeout = 600<br/>(global default, seconds)<br/>config/settings.py"]

        RESEARCH_YAML["● research.yaml<br/>━━━━━━━━━━<br/>5 compute-heavy steps:<br/>implement_phase<br/>run_experiment<br/>re_run_experiment<br/>adjust_experiment<br/>troubleshoot_implement_failure<br/>→ idle_output_timeout: 0"]
    end

    %% ── RECIPE PIPELINE ── %%
    subgraph RecipePipeline ["● RECIPE PIPELINE (parse → validate → schema)"]
        direction TB

        PARSE["● recipe/io.py<br/>━━━━━━━━━━<br/>_parse_step()<br/>data.get('idle_output_timeout')<br/>→ int | None"]

        SCHEMA["● recipe/schema.py<br/>━━━━━━━━━━<br/>RecipeStep.idle_output_timeout<br/>type: int | None<br/>default: None<br/>None = use global cfg<br/>0 = disabled for this step"]

        VALIDATE["● recipe/validator.py<br/>━━━━━━━━━━<br/>must be non-negative int or None<br/>negative values rejected<br/>0 explicitly permitted"]

        RULES["● recipe/rules_tools.py<br/>━━━━━━━━━━<br/>registered as known run_skill param<br/>prevents dead-with-param false positive"]
    end

    %% ── MCP SERVER ── %%
    subgraph MCPServer ["● MCP SERVER — run_skill tool"]
        direction TB

        RUN_SKILL["● tools_execution.py<br/>━━━━━━━━━━<br/>run_skill(idle_output_timeout: int | None)<br/>None → pass None (executor falls back to global)<br/>int → float(value) passed to executor<br/>0 → float(0.0) → executor disables timeout"]
    end

    %% ── PROTOCOL BOUNDARY ── %%
    subgraph Protocol ["● PROTOCOL BOUNDARY"]
        direction TB

        PROTOCOL["● _type_protocols.py<br/>━━━━━━━━━━<br/>HeadlessExecutor.run(<br/>  idle_output_timeout: float | None<br/>)<br/>None = use global cfg"]
    end

    %% ── EXECUTION LAYER ── %%
    subgraph Execution ["● EXECUTION LAYER"]
        direction TB

        EXECUTOR["● execution/headless.py<br/>━━━━━━━━━━<br/>DefaultHeadlessExecutor.run()<br/>Resolution:<br/>  None → float(cfg.idle_output_timeout)<br/>  0.0 → effective_idle = None (disabled)<br/>  >0.0 → effective_idle = value"]

        CORE["● run_headless_core()<br/>━━━━━━━━━━<br/>Receives pre-resolved float | None<br/>Passes effective_idle to runner<br/>None = no idle kill signal"]
    end

    %% ── SUBPROCESS ── %%
    subgraph Subprocess ["SUBPROCESS RUNNER"]
        direction TB

        RUNNER["Process Runner<br/>━━━━━━━━━━<br/>idle_output_timeout=effective_idle<br/>None → timeout disabled<br/>600.0 → kill after 600s idle<br/>custom float → step override active"]
    end

    %% ── FLOWS ── %%
    RESEARCH_YAML -->|"idle_output_timeout: 0 (YAML field)"| PARSE
    PARSE --> SCHEMA
    SCHEMA --> VALIDATE
    SCHEMA --> RULES
    VALIDATE -->|"valid RecipeStep.idle_output_timeout"| RUN_SKILL

    GLOBAL_CFG -->|"fallback default (600s)"| EXECUTOR

    RUN_SKILL -->|"int|None → float|None"| PROTOCOL
    PROTOCOL --> EXECUTOR
    EXECUTOR -->|"resolved float|None"| CORE
    CORE --> RUNNER

    %% CLASS ASSIGNMENTS %%
    class GLOBAL_CFG phase;
    class RESEARCH_YAML cli;
    class PARSE,SCHEMA handler;
    class VALIDATE,RULES detector;
    class RUN_SKILL handler;
    class PROTOCOL phase;
    class EXECUTOR handler;
    class CORE handler;
    class RUNNER output;
```

Closes #785

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-785-20260412-214909-105758/.autoskillit/temp/make-plan/idle_output_timeout_per_step_plan_2026-04-12_215200.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 183 | 20.7k | 809.0k | 51.9k | 1 | 10m 58s |
| verify | 216 | 15.6k | 1.6M | 70.9k | 1 | 4m 23s |
| implement | 688 | 33.9k | 5.4M | 85.4k | 1 | 11m 9s |
| prepare_pr | 70 | 6.0k | 224.2k | 25.6k | 1 | 1m 44s |
| run_arch_lenses | 182 | 22.0k | 483.6k | 133.0k | 3 | 10m 24s |
| compose_pr | 67 | 7.6k | 232.0k | 28.9k | 1 | 2m 10s |
| **Total** | 1.4k | 105.8k | 8.7M | 395.8k | | 40m 52s |