### PR TITLE
Rectify: Stale MCP Direct Entry — Symmetric Registration Lifecycle

### DIFF
--- a/src/autoskillit/cli/__init__.py
+++ b/src/autoskillit/cli/__init__.py
@@ -16,7 +16,7 @@ from autoskillit.cli._doctor import (
     _count_hook_registry_drift,
 )
 from autoskillit.cli._hooks import _claude_settings_path
-from autoskillit.cli._init_helpers import _is_plugin_installed, _prompt_recipe_choice
+from autoskillit.cli._init_helpers import _prompt_recipe_choice
 from autoskillit.cli._prompts import (
     _OPEN_KITCHEN_CHOICE,
     _build_open_kitchen_prompt,
@@ -50,6 +50,18 @@ from autoskillit.cli.app import (
     workspace_init,
 )
 from autoskillit.hook_registry import HookDriftResult
+
+
+def _is_plugin_installed() -> bool:
+    """Return True if autoskillit is installed as a Claude marketplace plugin.
+
+    Package-level wrapper over autoskillit.cli._init_helpers._is_plugin_installed,
+    exposed for consumers outside cli/ (e.g. server._factory).
+    """
+    from autoskillit.cli._init_helpers import _is_plugin_installed as _check
+
+    return _check()
+
 
 __all__ = [
     "_OPEN_KITCHEN_CHOICE",

--- a/src/autoskillit/cli/__init__.py
+++ b/src/autoskillit/cli/__init__.py
@@ -16,14 +16,13 @@ from autoskillit.cli._doctor import (
     _count_hook_registry_drift,
 )
 from autoskillit.cli._hooks import _claude_settings_path
-from autoskillit.cli._init_helpers import _prompt_recipe_choice
+from autoskillit.cli._init_helpers import _is_plugin_installed, _prompt_recipe_choice
 from autoskillit.cli._prompts import (
     _OPEN_KITCHEN_CHOICE,
     _build_open_kitchen_prompt,
     _build_orchestrator_prompt,
     _resolve_recipe_input,
 )
-from autoskillit.cli._update_checks import _is_plugin_installed
 from autoskillit.cli.app import (
     _generate_config_yaml,
     _prompt_test_command,

--- a/src/autoskillit/cli/__init__.py
+++ b/src/autoskillit/cli/__init__.py
@@ -23,6 +23,7 @@ from autoskillit.cli._prompts import (
     _build_orchestrator_prompt,
     _resolve_recipe_input,
 )
+from autoskillit.cli._update_checks import _is_plugin_installed
 from autoskillit.cli.app import (
     _generate_config_yaml,
     _prompt_test_command,
@@ -50,18 +51,6 @@ from autoskillit.cli.app import (
     workspace_init,
 )
 from autoskillit.hook_registry import HookDriftResult
-
-
-def _is_plugin_installed() -> bool:
-    """Return True if autoskillit is installed as a Claude marketplace plugin.
-
-    Package-level wrapper over autoskillit.cli._init_helpers._is_plugin_installed,
-    exposed for consumers outside cli/ (e.g. server._factory).
-    """
-    from autoskillit.cli._init_helpers import _is_plugin_installed as _check
-
-    return _check()
-
 
 __all__ = [
     "_OPEN_KITCHEN_CHOICE",

--- a/src/autoskillit/cli/__init__.py
+++ b/src/autoskillit/cli/__init__.py
@@ -16,7 +16,7 @@ from autoskillit.cli._doctor import (
     _count_hook_registry_drift,
 )
 from autoskillit.cli._hooks import _claude_settings_path
-from autoskillit.cli._init_helpers import _prompt_recipe_choice
+from autoskillit.cli._init_helpers import _is_plugin_installed, _prompt_recipe_choice
 from autoskillit.cli._prompts import (
     _OPEN_KITCHEN_CHOICE,
     _build_open_kitchen_prompt,
@@ -53,6 +53,7 @@ from autoskillit.hook_registry import HookDriftResult
 
 __all__ = [
     "_OPEN_KITCHEN_CHOICE",
+    "_is_plugin_installed",
     "_build_open_kitchen_prompt",
     "_build_orchestrator_prompt",
     "DoctorResult",

--- a/src/autoskillit/cli/__init__.py
+++ b/src/autoskillit/cli/__init__.py
@@ -16,7 +16,7 @@ from autoskillit.cli._doctor import (
     _count_hook_registry_drift,
 )
 from autoskillit.cli._hooks import _claude_settings_path
-from autoskillit.cli._init_helpers import _is_plugin_installed, _prompt_recipe_choice
+from autoskillit.cli._init_helpers import _prompt_recipe_choice
 from autoskillit.cli._prompts import (
     _OPEN_KITCHEN_CHOICE,
     _build_open_kitchen_prompt,
@@ -53,7 +53,6 @@ from autoskillit.hook_registry import HookDriftResult
 
 __all__ = [
     "_OPEN_KITCHEN_CHOICE",
-    "_is_plugin_installed",
     "_build_open_kitchen_prompt",
     "_build_orchestrator_prompt",
     "DoctorResult",

--- a/src/autoskillit/cli/__init__.py
+++ b/src/autoskillit/cli/__init__.py
@@ -25,6 +25,7 @@ from autoskillit.cli._prompts import (
 )
 from autoskillit.cli.app import (
     _generate_config_yaml,
+    _is_plugin_installed,
     _prompt_test_command,
     app,
     config_app,
@@ -53,6 +54,7 @@ from autoskillit.hook_registry import HookDriftResult
 
 __all__ = [
     "_OPEN_KITCHEN_CHOICE",
+    "_is_plugin_installed",
     "_build_open_kitchen_prompt",
     "_build_orchestrator_prompt",
     "DoctorResult",

--- a/src/autoskillit/cli/_cook.py
+++ b/src/autoskillit/cli/_cook.py
@@ -130,6 +130,7 @@ def cook(*, resume: bool = False, session_id: str | None = None) -> None:
     if confirm.lower() in ("n", "no"):
         return
 
+    from autoskillit.cli._init_helpers import _is_plugin_installed
     from autoskillit.cli._onboarding import is_first_run, run_onboarding_menu
     from autoskillit.config import load_config
     from autoskillit.core import configure_logging, find_latest_session_id, pkg_root
@@ -158,8 +159,9 @@ def cook(*, resume: bool = False, session_id: str | None = None) -> None:
         session_id_local, cook_session=True, config=config, project_dir=project_dir
     )
 
+    plugin_dir = None if _is_plugin_installed() else pkg_root()
     spec = build_interactive_cmd(
-        plugin_dir=pkg_root(),
+        plugin_dir=plugin_dir,
         add_dirs=[skills_dir],
         initial_prompt=initial_prompt,
         resume_session_id=resume_session_id,

--- a/src/autoskillit/cli/_doctor.py
+++ b/src/autoskillit/cli/_doctor.py
@@ -10,7 +10,11 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from autoskillit.cli._hooks import _claude_settings_path, _load_settings_data
-from autoskillit.cli._init_helpers import _KNOWN_SCANNERS, _detect_secret_scanner
+from autoskillit.cli._init_helpers import (
+    _KNOWN_SCANNERS,
+    _check_dual_mcp_files,
+    _detect_secret_scanner,
+)
 from autoskillit.core import Severity, get_logger
 from autoskillit.execution import QUOTA_CACHE_SCHEMA_VERSION
 from autoskillit.hook_registry import (
@@ -102,26 +106,17 @@ def _check_dual_mcp_registration(
     _plugins_json = plugins_json_path or (
         Path.home() / ".claude" / "plugins" / "installed_plugins.json"
     )
-    try:
-        has_direct = _claude_json.exists() and "autoskillit" in json.loads(
-            _claude_json.read_text()
-        ).get("mcpServers", {})
-        has_marketplace = _plugins_json.exists() and "autoskillit@autoskillit-local" in json.loads(
-            _plugins_json.read_text()
-        ).get("plugins", {})
-        if has_direct and has_marketplace:
-            return DoctorResult(
-                severity=Severity.WARNING,
-                check="dual_mcp_registration",
-                message=(
-                    "autoskillit is registered both as a direct mcpServers entry "
-                    "(~/.claude.json) and as a marketplace plugin. This spawns two "
-                    "independent server processes per session with split gate state. "
-                    "Run `autoskillit install` to remove the stale direct entry."
-                ),
-            )
-    except (OSError, json.JSONDecodeError):
-        pass  # fail-open: unreadable files → cannot confirm dual, treat as OK
+    if _check_dual_mcp_files(_claude_json, _plugins_json):
+        return DoctorResult(
+            severity=Severity.WARNING,
+            check="dual_mcp_registration",
+            message=(
+                "autoskillit is registered both as a direct mcpServers entry "
+                "(~/.claude.json) and as a marketplace plugin. This spawns two "
+                "independent server processes per session with split gate state. "
+                "Run `autoskillit install` to remove the stale direct entry."
+            ),
+        )
     return DoctorResult(
         severity=Severity.OK,
         check="dual_mcp_registration",

--- a/src/autoskillit/cli/_doctor.py
+++ b/src/autoskillit/cli/_doctor.py
@@ -89,6 +89,46 @@ def _check_mcp_server_registered(claude_json_path: Path | None = None) -> Doctor
     )
 
 
+def _check_dual_mcp_registration(
+    claude_json_path: Path | None = None,
+    plugins_json_path: Path | None = None,
+) -> DoctorResult:
+    """Check that autoskillit is not registered both as a direct entry and as a marketplace plugin.
+
+    Returns WARNING if both registrations are simultaneously present (split-brain condition).
+    Fail-open: unreadable files → cannot confirm dual registration, return OK.
+    """
+    _claude_json = claude_json_path or (Path.home() / ".claude.json")
+    _plugins_json = plugins_json_path or (
+        Path.home() / ".claude" / "plugins" / "installed_plugins.json"
+    )
+    try:
+        has_direct = _claude_json.exists() and "autoskillit" in json.loads(
+            _claude_json.read_text()
+        ).get("mcpServers", {})
+        has_marketplace = _plugins_json.exists() and "autoskillit@autoskillit-local" in json.loads(
+            _plugins_json.read_text()
+        ).get("plugins", {})
+        if has_direct and has_marketplace:
+            return DoctorResult(
+                severity=Severity.WARNING,
+                check="dual_mcp_registration",
+                message=(
+                    "autoskillit is registered both as a direct mcpServers entry "
+                    "(~/.claude.json) and as a marketplace plugin. This spawns two "
+                    "independent server processes per session with split gate state. "
+                    "Run `autoskillit install` to remove the stale direct entry."
+                ),
+            )
+    except (OSError, json.JSONDecodeError):
+        pass  # fail-open: unreadable files → cannot confirm dual, treat as OK
+    return DoctorResult(
+        severity=Severity.OK,
+        check="dual_mcp_registration",
+        message="",
+    )
+
+
 def _check_hook_registration(settings_path: Path) -> DoctorResult:
     data = _load_settings_data(settings_path)
     registered = " ".join(
@@ -602,6 +642,9 @@ def run_doctor(*, output_json: bool = False) -> None:
 
     # Check 2: MCP server registered in ~/.claude.json or via plugin
     results.append(_check_mcp_server_registered(claude_json_path=Path.home() / ".claude.json"))
+
+    # Check 2b: Dual MCP registration — direct entry and marketplace plugin both present
+    results.append(_check_dual_mcp_registration())
 
     # Check 3: autoskillit command on PATH
     if shutil.which("autoskillit") is None:

--- a/src/autoskillit/cli/_init_helpers.py
+++ b/src/autoskillit/cli/_init_helpers.py
@@ -329,6 +329,26 @@ safety:
 """
 
 
+def _check_dual_mcp_files(claude_json: Path, plugins_json: Path) -> bool:
+    """Return True if both direct mcpServers entry and marketplace plugin are active.
+
+    Checks ~/.claude.json for an 'autoskillit' mcpServers key and
+    installed_plugins.json for an 'autoskillit@autoskillit-local' plugin entry.
+
+    Fail-open: any I/O or parse error returns False without raising.
+    """
+    try:
+        has_direct = claude_json.exists() and "autoskillit" in json.loads(
+            claude_json.read_text()
+        ).get("mcpServers", {})
+        has_marketplace = plugins_json.exists() and "autoskillit@autoskillit-local" in json.loads(
+            plugins_json.read_text()
+        ).get("plugins", {})
+        return has_direct and has_marketplace
+    except (OSError, json.JSONDecodeError):
+        return False
+
+
 def _user_claude_json_path() -> Path:
     """Return path to ~/.claude.json (user-scoped MCP server config)."""
     return Path.home() / ".claude.json"

--- a/src/autoskillit/cli/_init_helpers.py
+++ b/src/autoskillit/cli/_init_helpers.py
@@ -289,10 +289,8 @@ def _is_plugin_installed() -> bool:
             timeout=10,
         )
         return result.returncode == 0 and "autoskillit" in result.stdout
-    except FileNotFoundError:
-        return False  # claude CLI not on PATH
-    except (subprocess.TimeoutExpired, OSError):
-        return False  # CLI unavailable or timed out
+    except Exception:
+        return False  # CLI unavailable, timed out, or returned unexpected mock type
 
 
 def _generate_config_yaml(test_command: list[str]) -> str:

--- a/src/autoskillit/cli/_init_helpers.py
+++ b/src/autoskillit/cli/_init_helpers.py
@@ -10,8 +10,10 @@ from pathlib import Path
 from typing import NamedTuple
 
 from autoskillit.config import write_config_layer
-from autoskillit.core import YAMLError, atomic_write, dump_yaml_str, load_yaml
+from autoskillit.core import YAMLError, atomic_write, dump_yaml_str, get_logger, load_yaml
 from autoskillit.recipe import list_recipes
+
+logger = get_logger(__name__)
 
 
 class _ScanResult(NamedTuple):
@@ -290,7 +292,8 @@ def _is_plugin_installed() -> bool:
         )
         return result.returncode == 0 and "autoskillit" in result.stdout
     except Exception:
-        return False  # CLI unavailable, timed out, or returned unexpected mock type
+        logger.debug("plugin install check failed", exc_info=True)
+        return False
 
 
 def _generate_config_yaml(test_command: list[str]) -> str:

--- a/src/autoskillit/cli/_init_helpers.py
+++ b/src/autoskillit/cli/_init_helpers.py
@@ -355,6 +355,28 @@ def _register_mcp_server(claude_json_path: Path) -> None:
     atomic_write(claude_json_path, json.dumps(data, indent=2))
 
 
+def evict_direct_mcp_entry(claude_json_path: Path) -> bool:
+    """Remove mcpServers['autoskillit'] from ~/.claude.json if present.
+
+    Returns True if the entry was removed, False if nothing changed.
+    Fail-open: any I/O or parse error returns False without raising.
+    """
+    if not claude_json_path.exists():
+        return False
+    try:
+        data: dict = json.loads(claude_json_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return False
+    if "autoskillit" not in data.get("mcpServers", {}):
+        return False
+    del data["mcpServers"]["autoskillit"]
+    try:
+        atomic_write(claude_json_path, json.dumps(data, indent=2))
+    except OSError:
+        return False
+    return True
+
+
 def _print_next_steps(*, context: str = "install") -> None:
     _B, _C, _D, _G, _Y, _R = _colors()
     if context == "install":
@@ -433,6 +455,8 @@ def _register_all(scope: str, project_dir: Path) -> None:
     plugin_ok = _is_plugin_installed()
     if not plugin_ok:
         _register_mcp_server(_user_claude_json_path())
+    else:
+        evict_direct_mcp_entry(_user_claude_json_path())  # remove stale direct entry
 
     # --- Summary block ---
     print()

--- a/src/autoskillit/cli/_marketplace.py
+++ b/src/autoskillit/cli/_marketplace.py
@@ -15,6 +15,7 @@ from autoskillit.cli._hooks import (
     sweep_all_scopes_for_orphans,
     sync_hooks_to_settings,
 )
+from autoskillit.cli._init_helpers import _user_claude_json_path, evict_direct_mcp_entry
 from autoskillit.core import atomic_write, is_git_worktree, pkg_root
 
 _VALID_SCOPES = {"user", "project", "local"}
@@ -168,6 +169,8 @@ def install(*, scope: str = "user"):
         sys.exit(1)
 
     print(f"Plugin installed: {plugin_ref} (scope: {scope})")
+    if evict_direct_mcp_entry(_user_claude_json_path()):
+        print("Removed stale direct MCP entry from ~/.claude.json")
     # Cross-scope sweep: evict orphaned autoskillit hooks from ALL scopes before
     # writing canonical entries to the target scope.
     sweep_all_scopes_for_orphans(Path.cwd())

--- a/src/autoskillit/cli/_update_checks.py
+++ b/src/autoskillit/cli/_update_checks.py
@@ -72,7 +72,7 @@ _GITHUB_INTEGRATION_PYPROJECT_URL = (
 class Signal:
     """A single firing update condition."""
 
-    kind: Literal["binary", "hooks", "source_drift"]
+    kind: Literal["binary", "hooks", "source_drift", "dual_mcp"]
     message: str
 
 
@@ -521,6 +521,37 @@ def _source_drift_signal(info: InstallInfo, home: Path) -> Signal | None:
     return None
 
 
+def _is_dual_mcp_registered(home: Path) -> bool:
+    """Return True if both direct mcpServers entry and marketplace plugin are active."""
+    claude_json = home / ".claude.json"
+    plugins_json = home / ".claude" / "plugins" / "installed_plugins.json"
+    try:
+        has_direct = claude_json.exists() and "autoskillit" in json.loads(
+            claude_json.read_text()
+        ).get("mcpServers", {})
+        has_marketplace = plugins_json.exists() and "autoskillit@autoskillit-local" in json.loads(
+            plugins_json.read_text()
+        ).get("plugins", {})
+        return has_direct and has_marketplace
+    except (OSError, json.JSONDecodeError):
+        return False
+
+
+def _dual_mcp_signal(home: Path | None = None) -> Signal | None:
+    """Return a Signal if both direct mcpServers entry and marketplace plugin are registered."""
+    try:
+        if _is_dual_mcp_registered(home or Path.home()):
+            return Signal(
+                "dual_mcp",
+                "autoskillit is registered as both a direct MCP server (~/.claude.json) "
+                "and a marketplace plugin — two server processes will spawn per session. "
+                "Run `autoskillit install` to remove the stale direct entry.",
+            )
+    except Exception:
+        logger.debug("dual_mcp signal check failed", exc_info=True)
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Unified dismissal
 # ---------------------------------------------------------------------------
@@ -658,6 +689,7 @@ def run_update_checks(home: Path | None = None) -> None:
         _binary_signal(info, _home, current),
         _hooks_signal(_claude_settings_path("user")),
         _source_drift_signal(info, _home),
+        _dual_mcp_signal(_home),
     ]
 
     # Filter by dismissal

--- a/src/autoskillit/cli/_update_checks.py
+++ b/src/autoskillit/cli/_update_checks.py
@@ -28,9 +28,6 @@ from typing import Any, Literal
 import httpx
 
 from autoskillit.cli._hooks import _claude_settings_path
-from autoskillit.cli._init_helpers import (
-    _is_plugin_installed,  # noqa: F401 — relay for autoskillit.cli re-export
-)
 from autoskillit.cli._install_info import (
     InstallInfo,
     InstallType,

--- a/src/autoskillit/cli/_update_checks.py
+++ b/src/autoskillit/cli/_update_checks.py
@@ -532,17 +532,18 @@ def _is_dual_mcp_registered(home: Path) -> bool:
 
 
 def _dual_mcp_signal(home: Path | None = None) -> Signal | None:
-    """Return a Signal if both direct mcpServers entry and marketplace plugin are registered."""
-    try:
-        if _is_dual_mcp_registered(home or Path.home()):
-            return Signal(
-                "dual_mcp",
-                "autoskillit is registered as both a direct MCP server (~/.claude.json) "
-                "and a marketplace plugin — two server processes will spawn per session. "
-                "Run `autoskillit install` to remove the stale direct entry.",
-            )
-    except Exception:
-        logger.debug("dual_mcp signal check failed", exc_info=True)
+    """Return a Signal if both direct mcpServers entry and marketplace plugin are registered.
+
+    _is_dual_mcp_registered() delegates to _check_dual_mcp_files() which is
+    fail-open (catches OSError and json.JSONDecodeError internally, never raises).
+    """
+    if _is_dual_mcp_registered(home or Path.home()):
+        return Signal(
+            "dual_mcp",
+            "autoskillit is registered as both a direct MCP server (~/.claude.json) "
+            "and a marketplace plugin — two server processes will spawn per session. "
+            "Run `autoskillit install` to remove the stale direct entry.",
+        )
     return None
 
 

--- a/src/autoskillit/cli/_update_checks.py
+++ b/src/autoskillit/cli/_update_checks.py
@@ -526,18 +526,12 @@ def _source_drift_signal(info: InstallInfo, home: Path) -> Signal | None:
 
 def _is_dual_mcp_registered(home: Path) -> bool:
     """Return True if both direct mcpServers entry and marketplace plugin are active."""
-    claude_json = home / ".claude.json"
-    plugins_json = home / ".claude" / "plugins" / "installed_plugins.json"
-    try:
-        has_direct = claude_json.exists() and "autoskillit" in json.loads(
-            claude_json.read_text()
-        ).get("mcpServers", {})
-        has_marketplace = plugins_json.exists() and "autoskillit@autoskillit-local" in json.loads(
-            plugins_json.read_text()
-        ).get("plugins", {})
-        return has_direct and has_marketplace
-    except (OSError, json.JSONDecodeError):
-        return False
+    from autoskillit.cli._init_helpers import _check_dual_mcp_files
+
+    return _check_dual_mcp_files(
+        home / ".claude.json",
+        home / ".claude" / "plugins" / "installed_plugins.json",
+    )
 
 
 def _dual_mcp_signal(home: Path | None = None) -> Signal | None:

--- a/src/autoskillit/cli/_update_checks.py
+++ b/src/autoskillit/cli/_update_checks.py
@@ -28,6 +28,9 @@ from typing import Any, Literal
 import httpx
 
 from autoskillit.cli._hooks import _claude_settings_path
+from autoskillit.cli._init_helpers import (
+    _is_plugin_installed,  # noqa: F401 — relay for autoskillit.cli re-export
+)
 from autoskillit.cli._install_info import (
     InstallInfo,
     InstallType,

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -27,6 +27,7 @@ from autoskillit.cli._init_helpers import (
     _MARKER_CONTENT,
     _check_secret_scanning,
     _generate_config_yaml,
+    _is_plugin_installed,
     _log_secret_scan_bypass,
     _prompt_test_command,
     _register_all,
@@ -118,7 +119,7 @@ def serve(*, verbose: Annotated[bool, Parameter(name=["--verbose", "-v"])] = Fal
             ",".join(cfg.safety.protected_branches),
         )
 
-    plugin_dir = str(pkg_root())
+    plugin_dir: str | None = None if _is_plugin_installed() else str(pkg_root())
     ctx = make_context(cfg, plugin_dir=plugin_dir)
     _initialize(ctx)
 
@@ -457,14 +458,19 @@ def _launch_cook_session(
         resume_session_id=resume_session_id,
         env_extras=extra_env,
     )
-    cmd = spec.cmd + [
-        ClaudeFlags.PLUGIN_DIR,
-        str(pkg_root()),
-        ClaudeFlags.TOOLS,
-        "AskUserQuestion",
-        ClaudeFlags.APPEND_SYSTEM_PROMPT,
-        system_prompt,
-    ]
+    plugin_dir_flags: list[str] = (
+        [] if _is_plugin_installed() else [ClaudeFlags.PLUGIN_DIR, str(pkg_root())]
+    )
+    cmd = (
+        spec.cmd
+        + plugin_dir_flags
+        + [
+            ClaudeFlags.TOOLS,
+            "AskUserQuestion",
+            ClaudeFlags.APPEND_SYSTEM_PROMPT,
+            system_prompt,
+        ]
+    )
     with terminal_guard():
         result = subprocess.run(cmd, env=spec.env)
     if result.returncode != 0:

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -738,6 +738,9 @@ def main() -> None:
     """Entry point for autoskillit."""
     _first_arg = sys.argv[1] if len(sys.argv) > 1 else "serve"
     if _first_arg != "serve":
+        from autoskillit.cli._init_helpers import _user_claude_json_path, evict_direct_mcp_entry
+
+        evict_direct_mcp_entry(_user_claude_json_path())  # silent heal for stale installs
         from autoskillit.cli._update_checks import run_update_checks
 
         run_update_checks()

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -738,11 +738,15 @@ def order(recipe: str | None = None, session_id: str | None = None, *, resume: b
 
 def main() -> None:
     """Entry point for autoskillit."""
+    from autoskillit.cli._init_helpers import _user_claude_json_path, evict_direct_mcp_entry
+
+    if evict_direct_mcp_entry(_user_claude_json_path()):
+        from autoskillit.core import get_logger
+
+        get_logger(__name__).debug("evicted stale direct MCP entry from ~/.claude.json")
+
     _first_arg = sys.argv[1] if len(sys.argv) > 1 else "serve"
     if _first_arg != "serve":
-        from autoskillit.cli._init_helpers import _user_claude_json_path, evict_direct_mcp_entry
-
-        evict_direct_mcp_entry(_user_claude_json_path())  # silent heal for stale installs
         from autoskillit.cli._update_checks import run_update_checks
 
         run_update_checks()

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -740,11 +740,7 @@ def main() -> None:
     """Entry point for autoskillit."""
     from autoskillit.cli._init_helpers import _user_claude_json_path, evict_direct_mcp_entry
 
-    if evict_direct_mcp_entry(_user_claude_json_path()):
-        from autoskillit.core import get_logger
-
-        get_logger(__name__).debug("evicted stale direct MCP entry from ~/.claude.json")
-
+    evict_direct_mcp_entry(_user_claude_json_path())
     _first_arg = sys.argv[1] if len(sys.argv) > 1 else "serve"
     if _first_arg != "serve":
         from autoskillit.cli._update_checks import run_update_checks

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -458,19 +458,15 @@ def _launch_cook_session(
         resume_session_id=resume_session_id,
         env_extras=extra_env,
     )
-    plugin_dir_flags: list[str] = (
-        [] if _is_plugin_installed() else [ClaudeFlags.PLUGIN_DIR, str(pkg_root())]
-    )
-    cmd = (
-        spec.cmd
-        + plugin_dir_flags
-        + [
-            ClaudeFlags.TOOLS,
-            "AskUserQuestion",
-            ClaudeFlags.APPEND_SYSTEM_PROMPT,
-            system_prompt,
-        ]
-    )
+    plugin_flags = [] if _is_plugin_installed() else [ClaudeFlags.PLUGIN_DIR, str(pkg_root())]
+    cmd = [
+        *spec.cmd,
+        *plugin_flags,
+        ClaudeFlags.TOOLS,
+        "AskUserQuestion",
+        ClaudeFlags.APPEND_SYSTEM_PROMPT,
+        system_prompt,
+    ]
     with terminal_guard():
         result = subprocess.run(cmd, env=spec.env)
     if result.returncode != 0:

--- a/src/autoskillit/execution/commands.py
+++ b/src/autoskillit/execution/commands.py
@@ -183,7 +183,7 @@ def build_full_headless_cmd(
     cwd: str,
     completion_marker: str,
     model: str | None,
-    plugin_dir: str | Path,
+    plugin_dir: str | Path | None,
     output_format_value: str,
     output_format_required_flags: Sequence[str] = (),
     add_dirs: Sequence[ValidatedAddDir] = (),
@@ -234,12 +234,10 @@ def build_full_headless_cmd(
 
     filtered_base = {k: v for k, v in os.environ.items() if k not in _HEADLESS_EXCLUSIVE_VARS}
     spec = build_headless_cmd(prompt, model=model, env_extras=extras, base=filtered_base)
-    cmd: list[str] = spec.cmd + [
-        ClaudeFlags.PLUGIN_DIR,
-        str(plugin_dir),
-        ClaudeFlags.OUTPUT_FORMAT,
-        output_format_value,
-    ]
+    cmd: list[str] = list(spec.cmd)
+    if plugin_dir is not None:
+        cmd += [ClaudeFlags.PLUGIN_DIR, str(plugin_dir)]
+    cmd += [ClaudeFlags.OUTPUT_FORMAT, output_format_value]
     for flag in output_format_required_flags:
         if flag not in cmd:
             cmd.append(flag)

--- a/src/autoskillit/execution/commands.py
+++ b/src/autoskillit/execution/commands.py
@@ -234,7 +234,7 @@ def build_full_headless_cmd(
 
     filtered_base = {k: v for k, v in os.environ.items() if k not in _HEADLESS_EXCLUSIVE_VARS}
     spec = build_headless_cmd(prompt, model=model, env_extras=extras, base=filtered_base)
-    cmd: list[str] = list(spec.cmd)
+    cmd: list[str] = [*spec.cmd]
     if plugin_dir is not None:
         cmd += [ClaudeFlags.PLUGIN_DIR, str(plugin_dir)]
     cmd += [ClaudeFlags.OUTPUT_FORMAT, output_format_value]

--- a/src/autoskillit/pipeline/context.py
+++ b/src/autoskillit/pipeline/context.py
@@ -56,7 +56,8 @@ class ToolContext:
     timing_log:           TimingLog — per-step wall-clock duration tracking
     response_log:         McpResponseLog — per-tool MCP response size tracking
     gate:                 GateState — enables/disables gated tools
-    plugin_dir:           Absolute path string to the autoskillit package directory
+    plugin_dir:           Absolute path string to the autoskillit package directory, or None if
+                          the marketplace plugin is installed and `--plugin-dir` should be omitted.
     runner:               SubprocessRunner implementation (DefaultSubprocessRunner in production,
                           MockSubprocessRunner in tests)
     executor:             HeadlessExecutor — runs headless Claude Code sessions
@@ -86,7 +87,7 @@ class ToolContext:
     token_log: TokenLog
     timing_log: TimingLog
     gate: GateState
-    plugin_dir: str
+    plugin_dir: str | None
     runner: SubprocessRunner | None
     # Always supply temp_dir explicitly when constructing ToolContext directly.
     # The default captures Path.cwd() at field-instantiation time, which is

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -15,7 +15,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
-from autoskillit.cli._init_helpers import _is_plugin_installed
+from autoskillit.cli import _is_plugin_installed
 from autoskillit.config import AutomationConfig
 from autoskillit.core import (
     SubprocessRunner,

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -15,7 +15,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
-from autoskillit.cli import _is_plugin_installed
+from autoskillit.cli._init_helpers import _is_plugin_installed
 from autoskillit.config import AutomationConfig
 from autoskillit.core import (
     SubprocessRunner,

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -15,6 +15,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+from autoskillit.cli._init_helpers import _is_plugin_installed
 from autoskillit.config import AutomationConfig
 from autoskillit.core import (
     SubprocessRunner,
@@ -200,7 +201,11 @@ def make_context(
         lambda: config.github.token or os.environ.get("GITHUB_TOKEN") or _gh_cli_token()
     )
 
-    resolved_dir = plugin_dir if plugin_dir is not None else _default_plugin_dir()
+    resolved_dir = (
+        plugin_dir
+        if plugin_dir is not None
+        else (_default_plugin_dir() if not _is_plugin_installed() else None)
+    )
     gate = DefaultGateState(enabled=False)
 
     project_dir = Path.cwd()

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -125,7 +125,7 @@ def make_context(
     config: AutomationConfig,
     *,
     runner: SubprocessRunner | None = _UNSET,
-    plugin_dir: str | None = None,
+    plugin_dir: str | None = _UNSET,
 ) -> ToolContext:
     """Create a fully-wired ToolContext with all 22 service fields populated.
 
@@ -141,8 +141,10 @@ def make_context(
         runner: Subprocess runner implementation. Defaults to DefaultSubprocessRunner()
                 for production use. Pass runner=None explicitly to disable the
                 tester (useful in tests that don't need real subprocess execution).
-        plugin_dir: Absolute path to the autoskillit plugin directory. Defaults
-                    to the autoskillit package directory (parent of server/).
+        plugin_dir: Absolute path to the autoskillit plugin directory.
+                    Pass None explicitly to indicate the plugin is installed
+                    (marketplace install; no --plugin-dir needed). When omitted
+                    (sentinel), auto-detects via _is_plugin_installed().
 
     Returns:
         ToolContext with gate starting closed (enabled=False) in all contexts.
@@ -203,7 +205,7 @@ def make_context(
 
     resolved_dir = (
         plugin_dir
-        if plugin_dir is not None
+        if plugin_dir is not _UNSET
         else (_default_plugin_dir() if not _is_plugin_installed() else None)
     )
     gate = DefaultGateState(enabled=False)

--- a/tests/cli/test_cook.py
+++ b/tests/cli/test_cook.py
@@ -102,6 +102,17 @@ class TestCLIOrder:
         """Most order() paths require an interactive TTY — default to True for this class."""
         monkeypatch.setattr("sys.stdin.isatty", lambda: True)
 
+    @pytest.fixture(autouse=True)
+    def _stub_is_plugin_installed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Stub _is_plugin_installed in app.py to False to prevent subprocess.run collision."""
+        import importlib
+        import sys as _sys
+
+        _app_mod = _sys.modules.get("autoskillit.cli.app") or importlib.import_module(
+            "autoskillit.cli.app"
+        )
+        monkeypatch.setattr(_app_mod, "_is_plugin_installed", lambda: False)
+
     # --- workspace init ---
 
     def test_prep_station_init_creates_dir_with_marker(
@@ -447,6 +458,9 @@ class TestCLIOrder:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """order omits --plugin-dir when marketplace plugin is installed."""
+        import importlib
+        import sys as _sys
+
         monkeypatch.delenv("CLAUDECODE", raising=False)
         monkeypatch.chdir(tmp_path)
         scripts_dir = tmp_path / ".autoskillit" / "recipes"
@@ -454,7 +468,10 @@ class TestCLIOrder:
         (scripts_dir / "my-script.yaml").write_text(_SCRIPT_YAML)
         monkeypatch.setattr(shutil, "which", lambda cmd: "/usr/bin/claude")
         monkeypatch.setattr("builtins.input", lambda _prompt="": "")
-        monkeypatch.setattr("autoskillit.cli.app._is_plugin_installed", lambda: True)
+        _app_mod = _sys.modules.get("autoskillit.cli.app") or importlib.import_module(
+            "autoskillit.cli.app"
+        )
+        monkeypatch.setattr(_app_mod, "_is_plugin_installed", lambda: True)
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="", stderr=""
         )
@@ -473,6 +490,9 @@ class TestCLIOrder:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """order includes --plugin-dir when marketplace plugin is not installed."""
+        import importlib
+        import sys as _sys
+
         monkeypatch.delenv("CLAUDECODE", raising=False)
         monkeypatch.chdir(tmp_path)
         scripts_dir = tmp_path / ".autoskillit" / "recipes"
@@ -480,7 +500,10 @@ class TestCLIOrder:
         (scripts_dir / "my-script.yaml").write_text(_SCRIPT_YAML)
         monkeypatch.setattr(shutil, "which", lambda cmd: "/usr/bin/claude")
         monkeypatch.setattr("builtins.input", lambda _prompt="": "")
-        monkeypatch.setattr("autoskillit.cli.app._is_plugin_installed", lambda: False)
+        _app_mod = _sys.modules.get("autoskillit.cli.app") or importlib.import_module(
+            "autoskillit.cli.app"
+        )
+        monkeypatch.setattr(_app_mod, "_is_plugin_installed", lambda: False)
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="", stderr=""
         )
@@ -1062,6 +1085,17 @@ class TestOrderSubsetGate:
             lambda *a, **kw: None,
         )
 
+    @pytest.fixture(autouse=True)
+    def _stub_is_plugin_installed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Stub _is_plugin_installed in app.py to False to prevent subprocess.run collision."""
+        import importlib
+        import sys as _sys
+
+        _app_mod = _sys.modules.get("autoskillit.cli.app") or importlib.import_module(
+            "autoskillit.cli.app"
+        )
+        monkeypatch.setattr(_app_mod, "_is_plugin_installed", lambda: False)
+
     def _make_config_mock(self, disabled: list[str]) -> MagicMock:
         mock_cfg = MagicMock()
         mock_cfg.subsets.disabled = disabled
@@ -1239,6 +1273,17 @@ class TestOrderMcpPrefixSelection:
     @pytest.fixture(autouse=True)
     def _interactive_stdin(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+
+    @pytest.fixture(autouse=True)
+    def _stub_is_plugin_installed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Stub _is_plugin_installed in app.py to False to prevent subprocess.run collision."""
+        import importlib
+        import sys as _sys
+
+        _app_mod = _sys.modules.get("autoskillit.cli.app") or importlib.import_module(
+            "autoskillit.cli.app"
+        )
+        monkeypatch.setattr(_app_mod, "_is_plugin_installed", lambda: False)
 
     @patch("autoskillit.cli.subprocess.run")
     def test_order_prompt_uses_direct_prefix_when_no_marketplace_install(

--- a/tests/cli/test_cook.py
+++ b/tests/cli/test_cook.py
@@ -440,6 +440,58 @@ class TestCLIOrder:
         assert "stdin" not in kwargs
 
     @patch("autoskillit.cli.subprocess.run")
+    def test_order_suppresses_plugin_dir_when_plugin_installed(
+        self,
+        mock_run: MagicMock,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """order omits --plugin-dir when marketplace plugin is installed."""
+        monkeypatch.delenv("CLAUDECODE", raising=False)
+        monkeypatch.chdir(tmp_path)
+        scripts_dir = tmp_path / ".autoskillit" / "recipes"
+        scripts_dir.mkdir(parents=True)
+        (scripts_dir / "my-script.yaml").write_text(_SCRIPT_YAML)
+        monkeypatch.setattr(shutil, "which", lambda cmd: "/usr/bin/claude")
+        monkeypatch.setattr("builtins.input", lambda _prompt="": "")
+        monkeypatch.setattr("autoskillit.cli.app._is_plugin_installed", lambda: True)
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="", stderr=""
+        )
+
+        cli.order("test-script")
+
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert ClaudeFlags.PLUGIN_DIR not in cmd
+
+    @patch("autoskillit.cli.subprocess.run")
+    def test_order_includes_plugin_dir_when_no_plugin_installed(
+        self,
+        mock_run: MagicMock,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """order includes --plugin-dir when marketplace plugin is not installed."""
+        monkeypatch.delenv("CLAUDECODE", raising=False)
+        monkeypatch.chdir(tmp_path)
+        scripts_dir = tmp_path / ".autoskillit" / "recipes"
+        scripts_dir.mkdir(parents=True)
+        (scripts_dir / "my-script.yaml").write_text(_SCRIPT_YAML)
+        monkeypatch.setattr(shutil, "which", lambda cmd: "/usr/bin/claude")
+        monkeypatch.setattr("builtins.input", lambda _prompt="": "")
+        monkeypatch.setattr("autoskillit.cli.app._is_plugin_installed", lambda: False)
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="", stderr=""
+        )
+
+        cli.order("test-script")
+
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert ClaudeFlags.PLUGIN_DIR in cmd
+
+    @patch("autoskillit.cli.subprocess.run")
     def test_order_system_prompt_contains_behavioral_instructions(
         self,
         mock_run: MagicMock,

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -201,6 +201,7 @@ class TestCLIDoctor:
             "secret_scanning_hook",
             "editable_install_source_exists",  # ★ new
             "stale_entry_points",  # ★ new
+            "dual_mcp_registration",  # ★ new
         }
         assert expected <= check_names
 
@@ -1696,3 +1697,35 @@ class TestDoctorSourceVersionDriftUsesNetwork:
             f"got {result.severity}: {result.message}"
         )
         assert "unavailable" in result.message.lower() or "network" in result.message.lower()
+
+
+def test_doctor_dual_mcp_registration_warns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """_check_dual_mcp_registration() warns when both direct and marketplace entries exist."""
+    from autoskillit.cli._doctor import _check_dual_mcp_registration
+    from autoskillit.core import Severity
+
+    claude_json = tmp_path / ".claude.json"
+    claude_json.write_text(json.dumps({"mcpServers": {"autoskillit": {"type": "stdio"}}}))
+    plugins_dir = tmp_path / ".claude" / "plugins"
+    plugins_dir.mkdir(parents=True)
+    (plugins_dir / "installed_plugins.json").write_text(
+        json.dumps({"plugins": {"autoskillit@autoskillit-local": {"name": "autoskillit"}}})
+    )
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    result = _check_dual_mcp_registration()
+    assert result.severity == Severity.WARNING
+    assert "autoskillit install" in result.message
+
+
+def test_doctor_no_dual_when_only_direct(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """_check_dual_mcp_registration() returns OK when only the direct entry exists."""
+    from autoskillit.cli._doctor import _check_dual_mcp_registration
+    from autoskillit.core import Severity
+
+    claude_json = tmp_path / ".claude.json"
+    claude_json.write_text(json.dumps({"mcpServers": {"autoskillit": {"type": "stdio"}}}))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    result = _check_dual_mcp_registration()
+    assert result.severity == Severity.OK

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -801,3 +801,73 @@ def test_init_from_pkg_root_like_cwd_refuses(
 
     with pytest.raises(Exception, match="inside the autoskillit source tree"):
         _register_all(scope="user", project_dir=fake_pkg_root)
+
+
+# --- evict_direct_mcp_entry unit tests ---
+
+
+def test_evict_direct_mcp_entry_removes_key(tmp_path: Path) -> None:
+    """evict_direct_mcp_entry() removes the autoskillit key and preserves all other keys."""
+    from autoskillit.cli._init_helpers import evict_direct_mcp_entry
+
+    claude_json = tmp_path / ".claude.json"
+    claude_json.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "autoskillit": {"type": "stdio", "command": "autoskillit", "args": []}
+                },
+                "other": "preserved",
+            }
+        )
+    )
+    result = evict_direct_mcp_entry(claude_json)
+    assert result is True
+    data = json.loads(claude_json.read_text())
+    assert "autoskillit" not in data.get("mcpServers", {})
+    assert data["other"] == "preserved"
+
+
+def test_evict_direct_mcp_entry_idempotent_when_absent(tmp_path: Path) -> None:
+    """evict_direct_mcp_entry() returns False and leaves the file unchanged when key is absent."""
+    from autoskillit.cli._init_helpers import evict_direct_mcp_entry
+
+    claude_json = tmp_path / ".claude.json"
+    original = {"mcpServers": {}}
+    claude_json.write_text(json.dumps(original))
+    result = evict_direct_mcp_entry(claude_json)
+    assert result is False
+    assert json.loads(claude_json.read_text()) == original
+
+
+def test_evict_direct_mcp_entry_returns_false_when_file_absent(tmp_path: Path) -> None:
+    """evict_direct_mcp_entry() returns False without raising when the file does not exist."""
+    from autoskillit.cli._init_helpers import evict_direct_mcp_entry
+
+    result = evict_direct_mcp_entry(tmp_path / "nonexistent.json")
+    assert result is False
+
+
+def test_register_all_evicts_direct_entry_when_plugin_installed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """_register_all() evicts the direct MCP entry when the plugin is already installed."""
+    (tmp_path / ".pre-commit-config.yaml").write_text(
+        "repos:\n  - repo: dummy\n    hooks:\n      - id: gitleaks\n"
+    )
+    claude_json = tmp_path / ".claude.json"
+    claude_json.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "autoskillit": {"type": "stdio", "command": "autoskillit", "args": []}
+                }
+            }
+        )
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setattr("autoskillit.cli._init_helpers._is_plugin_installed", lambda: True)
+    cli.init(scope="user", test_command="task test-all")
+    data = json.loads(claude_json.read_text())
+    assert "autoskillit" not in data.get("mcpServers", {})

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -171,6 +171,40 @@ class TestCLIInstall:
 
         assert (tmp_path / ".autoskillit" / "marketplace" / "plugins" / "autoskillit").is_symlink()
 
+    @patch("autoskillit.cli._marketplace.subprocess.run")
+    def test_install_evicts_stale_direct_mcp_entry(
+        self, mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """install() must remove a stale mcpServers.autoskillit entry left by a prior init."""
+        import importlib as _importlib
+
+        _app_mod = _importlib.import_module("autoskillit.cli._marketplace")
+
+        # Seed stale direct entry as left by a prior `autoskillit init`
+        claude_json = tmp_path / ".claude.json"
+        claude_json.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "autoskillit": {"type": "stdio", "command": "autoskillit", "args": []}
+                    }
+                }
+            )
+        )
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(shutil, "which", lambda cmd: "/usr/bin/claude")
+        monkeypatch.delenv("CLAUDECODE", raising=False)
+        monkeypatch.setattr(_app_mod, "is_git_worktree", lambda path: False)
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="", stderr=""
+        )
+        from autoskillit.cli._marketplace import install
+
+        install(scope="user")
+
+        data = json.loads(claude_json.read_text())
+        assert "autoskillit" not in data.get("mcpServers", {})
+
 
 class TestMigrateCommand:
     """Tests for the ``autoskillit migrate`` CLI command."""

--- a/tests/cli/test_terminal.py
+++ b/tests/cli/test_terminal.py
@@ -438,6 +438,7 @@ class TestCookTerminalGuard:
             lambda *a, **kw: (_ for _ in ()).throw(KeyboardInterrupt()),
         )
         monkeypatch.setattr("shutil.which", lambda cmd: "/usr/bin/claude")
+        monkeypatch.setattr("autoskillit.cli._cook._is_plugin_installed", lambda: False)
         # is_first_run is imported inside cook() body — patch the source module
         monkeypatch.setattr("autoskillit.cli._onboarding.is_first_run", lambda _: False)
         # cook() calls input() for launch confirmation before subprocess.run
@@ -483,6 +484,7 @@ class TestCookTerminalGuard:
             lambda *a, **kw: (_ for _ in ()).throw(KeyboardInterrupt()),
         )
         monkeypatch.setattr("shutil.which", lambda cmd: "/usr/bin/claude")
+        monkeypatch.setattr("autoskillit.cli.app._is_plugin_installed", lambda: False)
 
         with pytest.raises(KeyboardInterrupt):
             app_mod._launch_cook_session("system prompt")

--- a/tests/cli/test_terminal.py
+++ b/tests/cli/test_terminal.py
@@ -438,7 +438,7 @@ class TestCookTerminalGuard:
             lambda *a, **kw: (_ for _ in ()).throw(KeyboardInterrupt()),
         )
         monkeypatch.setattr("shutil.which", lambda cmd: "/usr/bin/claude")
-        monkeypatch.setattr("autoskillit.cli._cook._is_plugin_installed", lambda: False)
+        monkeypatch.setattr("autoskillit.cli._init_helpers._is_plugin_installed", lambda: False)
         # is_first_run is imported inside cook() body — patch the source module
         monkeypatch.setattr("autoskillit.cli._onboarding.is_first_run", lambda _: False)
         # cook() calls input() for launch confirmation before subprocess.run
@@ -484,7 +484,7 @@ class TestCookTerminalGuard:
             lambda *a, **kw: (_ for _ in ()).throw(KeyboardInterrupt()),
         )
         monkeypatch.setattr("shutil.which", lambda cmd: "/usr/bin/claude")
-        monkeypatch.setattr("autoskillit.cli.app._is_plugin_installed", lambda: False)
+        monkeypatch.setattr(app_mod, "_is_plugin_installed", lambda: False)
 
         with pytest.raises(KeyboardInterrupt):
             app_mod._launch_cook_session("system prompt")

--- a/tests/cli/test_update_checks.py
+++ b/tests/cli/test_update_checks.py
@@ -392,16 +392,14 @@ def test_dual_mcp_signal_silent_when_only_one_registered(
     assert sig is None
 
 
-def test_dual_mcp_signal_silent_on_exception(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+def test_dual_mcp_signal_silent_on_corrupted_files(
+    tmp_path: Path,
 ) -> None:
+    # _check_dual_mcp_files is fail-open: corrupted JSON → False → no signal
     from autoskillit.cli._update_checks import _dual_mcp_signal
 
-    monkeypatch.setattr(
-        "autoskillit.cli._update_checks._is_dual_mcp_registered",
-        lambda home: (_ for _ in ()).throw(OSError("disk error")),
-    )
-    # Exceptions must be silently swallowed — signal functions never raise
+    claude_json = tmp_path / ".claude.json"
+    claude_json.write_text("{invalid json")
     sig = _dual_mcp_signal(tmp_path)
     assert sig is None
 

--- a/tests/cli/test_update_checks.py
+++ b/tests/cli/test_update_checks.py
@@ -364,6 +364,48 @@ def test_source_drift_signal_silent_when_ref_sha_none(
     assert _source_drift_signal(info, tmp_path) is None
 
 
+def test_dual_mcp_signal_fires_when_both_registered(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from autoskillit.cli._update_checks import _dual_mcp_signal
+
+    monkeypatch.setattr(
+        "autoskillit.cli._update_checks._is_dual_mcp_registered",
+        lambda home: True,
+    )
+    sig = _dual_mcp_signal(tmp_path)
+    assert sig is not None
+    assert sig.kind == "dual_mcp"
+    assert "autoskillit install" in sig.message
+
+
+def test_dual_mcp_signal_silent_when_only_one_registered(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from autoskillit.cli._update_checks import _dual_mcp_signal
+
+    monkeypatch.setattr(
+        "autoskillit.cli._update_checks._is_dual_mcp_registered",
+        lambda home: False,
+    )
+    sig = _dual_mcp_signal(tmp_path)
+    assert sig is None
+
+
+def test_dual_mcp_signal_silent_on_exception(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from autoskillit.cli._update_checks import _dual_mcp_signal
+
+    monkeypatch.setattr(
+        "autoskillit.cli._update_checks._is_dual_mcp_registered",
+        lambda home: (_ for _ in ()).throw(OSError("disk error")),
+    )
+    # Exceptions must be silently swallowed — signal functions never raise
+    sig = _dual_mcp_signal(tmp_path)
+    assert sig is None
+
+
 # ---------------------------------------------------------------------------
 # find_source_repo behavioral tests
 # ---------------------------------------------------------------------------

--- a/tests/contracts/test_package_gateways.py
+++ b/tests/contracts/test_package_gateways.py
@@ -211,6 +211,7 @@ def test_factory_make_context_returns_toolcontext(monkeypatch):
     from autoskillit.pipeline.context import ToolContext
     from autoskillit.server._factory import make_context
 
+    monkeypatch.setattr("autoskillit.server._factory._is_plugin_installed", lambda: False)
     ctx = make_context(AutomationConfig())
     assert isinstance(ctx, ToolContext)
     assert ctx.gate.enabled is False  # starts closed

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -214,17 +214,17 @@ def test_quota_thresholds_defaults() -> None:
     assert long_ == pytest.approx(98.0)
 
 
-def test_doctor_check_count_is_19() -> None:
+def test_doctor_check_count_is_20() -> None:
     # _count_doctor_checks() counts every "# Check N:" and "# Check Nb:" marker
-    # in run_doctor() — 17 numbered base markers + 2 lettered sub-check markers
-    # (4b, 7b) = 19 total.  test_installation_states_17_doctor_checks checks the
+    # in run_doctor() — 17 numbered base markers + 3 lettered sub-check markers
+    # (2b, 4b, 7b) = 20 total.  test_installation_states_17_doctor_checks checks the
     # *user-visible* count from docs/installation.md ("15 numbered + 2 lettered
-    # sub-checks 4b and 7b = 17").  The gap of 2 is intentional: Check 4 and
-    # Check 7 each appear as separate implementation markers but the docs
+    # sub-checks 4b and 7b = 17").  The gap of 3 is intentional: Check 2, Check 4,
+    # and Check 7 each appear as separate implementation markers but the docs
     # present them as single numbered entries that subsume their b variants.
     # Update both tests whenever a new doctor check is added.
-    assert _count_doctor_checks() == 19, (
-        f"Expected 19 doctor checks; found {_count_doctor_checks()}"
+    assert _count_doctor_checks() == 20, (
+        f"Expected 20 doctor checks; found {_count_doctor_checks()}"
     )
 
 

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -144,9 +144,9 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _marketplace.py — hooks.json (co-owned)
     ("src/autoskillit/cli/_marketplace.py", 144),
     # _update_checks.py — dismissal state file
-    ("src/autoskillit/cli/_update_checks.py", 102),
+    ("src/autoskillit/cli/_update_checks.py", 105),
     # _update_checks.py — fetch cache
-    ("src/autoskillit/cli/_update_checks.py", 129),
+    ("src/autoskillit/cli/_update_checks.py", 132),
     # smoke_utils.py — domain partitions dict, hunk ranges list, merge queue list
     ("src/autoskillit/smoke_utils.py", 53),
     ("src/autoskillit/smoke_utils.py", 83),

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -134,9 +134,9 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _hooks.py — settings.json dict (co-owned with Claude CLI)
     ("src/autoskillit/cli/_hooks.py", 23),
     # _init_helpers.py — ~/.claude.json (co-owned)
-    ("src/autoskillit/cli/_init_helpers.py", 356),
+    ("src/autoskillit/cli/_init_helpers.py", 376),
     # _init_helpers.py — evict_direct_mcp_entry write-back to ~/.claude.json (co-owned)
-    ("src/autoskillit/cli/_init_helpers.py", 375),
+    ("src/autoskillit/cli/_init_helpers.py", 395),
     # _marketplace.py — installed_plugins.json (co-owned with Claude plugin system)
     ("src/autoskillit/cli/_marketplace.py", 45),
     # _marketplace.py — marketplace.json (co-owned)
@@ -144,9 +144,9 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _marketplace.py — hooks.json (co-owned)
     ("src/autoskillit/cli/_marketplace.py", 144),
     # _update_checks.py — dismissal state file
-    ("src/autoskillit/cli/_update_checks.py", 105),
+    ("src/autoskillit/cli/_update_checks.py", 102),
     # _update_checks.py — fetch cache
-    ("src/autoskillit/cli/_update_checks.py", 132),
+    ("src/autoskillit/cli/_update_checks.py", 129),
     # smoke_utils.py — domain partitions dict, hunk ranges list, merge queue list
     ("src/autoskillit/smoke_utils.py", 53),
     ("src/autoskillit/smoke_utils.py", 83),

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -135,12 +135,14 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/cli/_hooks.py", 23),
     # _init_helpers.py — ~/.claude.json (co-owned)
     ("src/autoskillit/cli/_init_helpers.py", 355),
+    # _init_helpers.py — evict_direct_mcp_entry write-back to ~/.claude.json (co-owned)
+    ("src/autoskillit/cli/_init_helpers.py", 374),
     # _marketplace.py — installed_plugins.json (co-owned with Claude plugin system)
-    ("src/autoskillit/cli/_marketplace.py", 44),
+    ("src/autoskillit/cli/_marketplace.py", 45),
     # _marketplace.py — marketplace.json (co-owned)
-    ("src/autoskillit/cli/_marketplace.py", 87),
+    ("src/autoskillit/cli/_marketplace.py", 88),
     # _marketplace.py — hooks.json (co-owned)
-    ("src/autoskillit/cli/_marketplace.py", 143),
+    ("src/autoskillit/cli/_marketplace.py", 144),
     # _update_checks.py — dismissal state file
     ("src/autoskillit/cli/_update_checks.py", 102),
     # _update_checks.py — fetch cache

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -134,9 +134,9 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _hooks.py — settings.json dict (co-owned with Claude CLI)
     ("src/autoskillit/cli/_hooks.py", 23),
     # _init_helpers.py — ~/.claude.json (co-owned)
-    ("src/autoskillit/cli/_init_helpers.py", 355),
+    ("src/autoskillit/cli/_init_helpers.py", 356),
     # _init_helpers.py — evict_direct_mcp_entry write-back to ~/.claude.json (co-owned)
-    ("src/autoskillit/cli/_init_helpers.py", 374),
+    ("src/autoskillit/cli/_init_helpers.py", 375),
     # _marketplace.py — installed_plugins.json (co-owned with Claude plugin system)
     ("src/autoskillit/cli/_marketplace.py", 45),
     # _marketplace.py — marketplace.json (co-owned)

--- a/tests/server/test_factory.py
+++ b/tests/server/test_factory.py
@@ -432,3 +432,22 @@ def test_gh_cli_token_not_called_during_make_context(monkeypatch):
 
     gh_calls = [c for c in calls if "gh" in str(c)]
     assert gh_calls == [], f"_gh_cli_token() called during make_context: {gh_calls}"
+
+
+def test_make_context_sets_plugin_dir_none_when_plugin_installed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """make_context() sets plugin_dir=None when marketplace plugin is installed."""
+    monkeypatch.setattr("autoskillit.server._factory._is_plugin_installed", lambda: True)
+    ctx = make_context(AutomationConfig(), runner=None)
+    assert ctx.plugin_dir is None
+
+
+def test_make_context_sets_plugin_dir_when_plugin_not_installed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """make_context() sets plugin_dir to package root when plugin is not installed."""
+    monkeypatch.setattr("autoskillit.server._factory._is_plugin_installed", lambda: False)
+    ctx = make_context(AutomationConfig(), runner=None)
+    assert ctx.plugin_dir is not None
+    assert ctx.plugin_dir != ""


### PR DESCRIPTION
## Summary

The MCP server registration in `~/.claude.json` is a write-only operation with no complementary eviction path. When a user runs `autoskillit init` (which writes `mcpServers.autoskillit`) and later runs `autoskillit install` (which installs the marketplace plugin), the direct entry is never removed — causing two independent autoskillit server processes to spawn per Claude Code session with isolated in-process gate state and shared disk-based kitchen-state, producing split-brain behavior.

The hooks system has already solved the analogous problem: `_evict_stale_autoskillit_hooks()` is always called before `sync_hooks_to_settings()`, in both `install()` and `_register_all()`. MCP registration has no such symmetric lifecycle. The architectural solution is to mirror the hooks eviction pattern exactly: introduce `evict_direct_mcp_entry()` alongside `_register_mcp_server()`, and call it from both `install()` and `_register_all()` — making the registration lifecycle bidirectional by design. A new independent doctor check exposes the dual-registration condition when it slips through.

Part B (separate task) covers the `_dual_mcp_signal` in `_update_checks.py` and conditional `--plugin-dir` suppression in cook/order/headless sessions.

## Architecture Impact

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% TERMINAL NODES %%
    START([startup / init / install])
    END([session launched])

    %% ── MCP CONFIG STATE ── %%
    subgraph MCPConfig ["● MCP REGISTRATION (External Config State)"]
        direction LR
        DirectMCP["DirectMCP<br/>━━━━━━━━━━<br/>~/.claude.json<br/>mcpServers[autoskillit]<br/>MUTABLE: write OR evict"]
        PluginMCP["PluginMCP<br/>━━━━━━━━━━<br/>installed_plugins.json<br/>autoskillit@local<br/>MUTABLE: install / uninstall"]
        DualBug["DUAL STATE<br/>━━━━━━━━━━<br/>DirectMCP AND PluginMCP<br/>both present simultaneously<br/>→ 2 server procs + split gate state"]
    end

    %% ── DETECTION GATES ── %%
    subgraph DetectionGates ["● DETECTION GATES (read-only, DERIVED)"]
        direction LR
        DualCheck["● _check_dual_mcp_registration<br/>━━━━━━━━━━<br/>reads both config files<br/>has_direct AND has_marketplace<br/>→ DoctorResult WARNING"]
        DualSignal["● _dual_mcp_signal<br/>━━━━━━━━━━<br/>wraps _is_dual_mcp_registered<br/>→ Signal fed to update checks<br/>alongside binary/hooks/drift"]
    end

    %% ── EVICTION GATES ── %%
    subgraph EvictionGates ["● EVICTION GATES (DirectMCP mutation control)"]
        direction TB
        RegisterEvict["● _register_all<br/>━━━━━━━━━━<br/>GATE: plugin_ok = True?<br/>→ evict_direct_mcp_entry<br/>FAIL-OPEN on IO/JSON error"]
        InstallEvict["● install<br/>━━━━━━━━━━<br/>POST-INSTALL GATE<br/>unconditional evict after<br/>claude plugin install succeeds"]
        StartupEvict["● main startup<br/>━━━━━━━━━━<br/>HEAL GATE<br/>evict_direct_mcp_entry<br/>every non-serve invocation"]
    end

    %% ── PLUGIN-DIR RESOLUTION ── %%
    subgraph PluginDirRes ["● PLUGIN-DIR RESOLUTION (DERIVED → INIT_ONLY)"]
        direction TB
        IsInstalled{"● _is_plugin_installed<br/>━━━━━━━━━━<br/>DERIVED gate<br/>reads installed_plugins.json<br/>at resolution time"}
        PDResolved["● resolved_dir<br/>━━━━━━━━━━<br/>INIT_ONLY after resolution<br/>None → omit --plugin-dir flag<br/>pkg_root() → inject --plugin-dir"]
    end

    %% ── TOOL CONTEXT PHASE 1 ── %%
    subgraph CtxP1 ["● TOOL CONTEXT Phase 1 — Construction"]
        direction LR
        PluginDirField["● ctx.plugin_dir<br/>━━━━━━━━━━<br/>MUTABLE<br/>str or None<br/>resolved in make_context"]
        KitchenId["ctx.kitchen_id<br/>━━━━━━━━━━<br/>MUTABLE<br/>empty string = closed<br/>UUID = open"]
        ActivePacks["ctx.active_recipe_packs<br/>━━━━━━━━━━<br/>MUTABLE<br/>None = kitchen closed<br/>frozenset = open"]
    end

    %% ── TOOL CONTEXT PHASE 2 ── %%
    subgraph CtxP2 ["● TOOL CONTEXT Phase 2 — Post-Construction Wiring"]
        direction LR
        ExecutorWire["ctx.executor<br/>━━━━━━━━━━<br/>MUTABLE two-phase<br/>None → DefaultHeadlessExecutor<br/>wired once in make_context"]
        MigrationsWire["ctx.migrations<br/>━━━━━━━━━━<br/>MUTABLE two-phase<br/>None → DefaultMigrationService<br/>wired once in make_context"]
        ResolverWire["● ctx output/write resolvers<br/>━━━━━━━━━━<br/>MUTABLE two-phase<br/>None → closures<br/>wired once in make_context"]
    end

    %% ── APPEND-ONLY STATE ── %%
    subgraph AppendOnly ["APPEND-ONLY STATE"]
        direction LR
        AuditLog["ctx.audit / token_log / timing_log<br/>━━━━━━━━━━<br/>APPEND_ONLY<br/>never cleared during session"]
        DoctorAccum["list DoctorResult<br/>━━━━━━━━━━<br/>APPEND_ONLY<br/>17 checks always accumulated"]
    end

    %% ── FROZEN COMMANDS ── %%
    subgraph FrozenCmds ["FROZEN COMMAND STATE (INIT_ONLY)"]
        direction LR
        ICmd["● ClaudeInteractiveCmd<br/>━━━━━━━━━━<br/>frozen dataclass<br/>cmd: list, env: Mapping<br/>immutable after build"]
        HCmd["ClaudeHeadlessCmd<br/>━━━━━━━━━━<br/>frozen dataclass<br/>cmd: list, env: Mapping<br/>immutable after build"]
    end

    %% ── DISMISS STATE ── %%
    subgraph DismissState ["● DISMISS STATE (~/.autoskillit/update_check.json)"]
        direction TB
        DismissFields["● update_prompt entry<br/>━━━━━━━━━━<br/>MUTABLE persisted JSON<br/>dismissed_at, dismissed_version<br/>conditions: list of str"]
        DismissGate["● _is_dismissed<br/>━━━━━━━━━━<br/>3-AXIS GATE:<br/>time window AND version AND<br/>condition membership — ALL must hold"]
    end

    %% ── CONNECTIONS ── %%

    %% startup flows into detection and resolution
    START --> DirectMCP
    START --> PluginMCP
    START --> IsInstalled
    START --> StartupEvict

    %% detection reads config
    DirectMCP --> DualCheck
    PluginMCP --> DualCheck
    DirectMCP --> DualSignal
    PluginMCP --> DualSignal
    DualCheck --> DualBug
    DualSignal --> DismissGate
    DismissFields --> DismissGate

    %% eviction gates mutate DirectMCP
    RegisterEvict -->|plugin_ok=True: evict| DirectMCP
    RegisterEvict -->|plugin_ok=False: write| DirectMCP
    InstallEvict -->|post-install: evict| DirectMCP
    StartupEvict -->|heal: evict| DirectMCP
    PluginMCP --> RegisterEvict
    PluginMCP --> InstallEvict

    %% plugin-dir resolution flows
    IsInstalled -->|not installed: pkg_root| PDResolved
    IsInstalled -->|installed: None| PDResolved
    PluginMCP --> IsInstalled
    PDResolved --> PluginDirField
    PDResolved --> ICmd
    PDResolved --> HCmd

    %% context construction flows
    PluginDirField --> ExecutorWire
    PluginDirField --> MigrationsWire
    PluginDirField --> ResolverWire
    KitchenId --> ExecutorWire
    ActivePacks --> ExecutorWire

    %% context → append-only → end
    ExecutorWire --> AuditLog
    MigrationsWire --> AuditLog
    ResolverWire --> AuditLog
    DoctorAccum --> AuditLog
    AuditLog --> END
    ICmd --> END
    HCmd --> END

    %% CLASS ASSIGNMENTS %%
    class DirectMCP,PluginMCP stateNode;
    class DualBug gap;
    class DualCheck,DualSignal,IsInstalled detector;
    class RegisterEvict,InstallEvict,StartupEvict handler;
    class PDResolved phase;
    class PluginDirField,KitchenId,ActivePacks stateNode;
    class ExecutorWire,MigrationsWire,ResolverWire stateNode;
    class AuditLog,DoctorAccum handler;
    class ICmd,HCmd output;
    class DismissFields stateNode;
    class DismissGate detector;
    class START,END terminal;
```

### Deployment Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 65, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph InitPhase ["INIT PHASE — autoskillit init (_init_helpers.py)"]
        direction TB
        REGISTER_ALL["● _register_all()<br/>━━━━━━━━━━<br/>Registration orchestrator<br/>_init_helpers.py"]
        IS_PLUGIN_INIT["● _is_plugin_installed()<br/>━━━━━━━━━━<br/>claude plugin list subprocess<br/>_init_helpers.py:281"]
        EVICT["● evict_direct_mcp_entry()<br/>━━━━━━━━━━<br/>Removes stale ~/.claude.json entry<br/>_init_helpers.py:359"]
        REGISTER_DIRECT["_register_mcp_server()<br/>━━━━━━━━━━<br/>Writes mcpServers.autoskillit<br/>_init_helpers.py:337"]
    end

    subgraph RegistrationStorage ["MCP REGISTRATION — LOCAL FILESYSTEM"]
        direction LR
        CLAUDE_JSON[("● ~/.claude.json<br/>━━━━━━━━━━<br/>Direct MCP entry<br/>mcpServers.autoskillit")]
        PLUGIN_REG[("Claude Plugin Registry<br/>━━━━━━━━━━<br/>~/.claude/plugins/<br/>Marketplace install")]
    end

    subgraph ClaudeCodeHost ["CLAUDE CODE HOST PROCESS"]
        direction TB
        CLAUDE_CODE["Claude Code<br/>━━━━━━━━━━<br/>Parent host process<br/>Reads both registrations"]
        DUAL_RISK["⚠ Dual-Server Risk (pre-fix)<br/>━━━━━━━━━━<br/>Both entries present →<br/>two MCP server instances spawned"]
    end

    subgraph MCPServer ["MCP SERVER — autoskillit serve (stdio)"]
        direction TB
        FACTORY["● make_context()<br/>━━━━━━━━━━<br/>Composition root<br/>server/_factory.py:124"]
        IS_PLUGIN_FACTORY["● _is_plugin_installed()<br/>━━━━━━━━━━<br/>Detects install mode<br/>server/_factory.py:207"]
        PLUGIN_DIR_RESOLVE["● plugin_dir resolution<br/>━━━━━━━━━━<br/>None if plugin mode<br/>pkg_root() if direct mode"]
        GATE["DefaultGateState<br/>━━━━━━━━━━<br/>Kitchen closed at startup<br/>Tag-based tool visibility"]
        BG_SUPER["DefaultBackgroundSupervisor<br/>━━━━━━━━━━<br/>Async task queue<br/>pipeline/background.py"]
    end

    subgraph ExecutionPhase ["SKILL EXECUTION — run_skill (MCP tool)"]
        direction TB
        BUILD_CMD["● build_full_headless_cmd()<br/>━━━━━━━━━━<br/>Builds claude --print argv<br/>execution/commands.py:180"]
        PLUGIN_DIR_FLAG["● Conditional --plugin-dir<br/>━━━━━━━━━━<br/>Only injected if plugin_dir≠None<br/>commands.py:238"]
        SESSION_SKILLS["DefaultSessionSkillManager<br/>━━━━━━━━━━<br/>Stages skill dirs<br/>--add-dir injection"]
    end

    subgraph HeadlessProcess ["HEADLESS SUBPROCESS — claude --print"]
        direction TB
        PTY_WRAP["script(1) PTY wrapper<br/>━━━━━━━━━━<br/>Linux: script -qefc<br/>New process group"]
        HEADLESS_CLAUDE["claude --print (headless)<br/>━━━━━━━━━━<br/>Skill execution session<br/>--output-format stream-json"]
    end

    subgraph LocalStorage ["LOCAL STORAGE"]
        direction TB
        TEMP_DIR[(".autoskillit/temp/<br/>━━━━━━━━━━<br/>Kitchen state, sentinel<br/>JSON / filesystem")]
        SESSION_LOGS[("~/.local/share/autoskillit/logs/<br/>━━━━━━━━━━<br/>Session diagnostics<br/>JSONL append")]
        CLAUDE_LOGS[("~/.claude/projects/.../SESSION.jsonl<br/>━━━━━━━━━━<br/>Conversation logs<br/>Polled for completion")]
        EPHEMERAL_SKILLS[("/dev/shm/autoskillit-sessions/<br/>━━━━━━━━━━<br/>Ephemeral skill dirs<br/>tmpfs / add-dir targets")]
        CREDENTIALS[("~/.claude/.credentials.json<br/>━━━━━━━━━━<br/>OAuth token<br/>Quota API auth")]
    end

    subgraph ExternalServices ["EXTERNAL SERVICES (HTTPS:443)"]
        direction TB
        GITHUB["GitHub REST + GraphQL API<br/>━━━━━━━━━━<br/>api.github.com<br/>Issues · PRs · CI · Merge queue"]
        ANTHROPIC["Anthropic Quota API<br/>━━━━━━━━━━<br/>api.anthropic.com/api/oauth/usage<br/>Rate-limit guard"]
    end

    %% INIT PHASE FLOW %%
    REGISTER_ALL --> IS_PLUGIN_INIT
    IS_PLUGIN_INIT -->|"plugin installed → fix"| EVICT
    IS_PLUGIN_INIT -->|"not installed"| REGISTER_DIRECT
    EVICT -->|"atomic delete"| CLAUDE_JSON
    REGISTER_DIRECT -->|"atomic write"| CLAUDE_JSON

    %% REGISTRATION → HOST %%
    CLAUDE_JSON -.->|"direct entry (stale if plugin)"| DUAL_RISK
    PLUGIN_REG -->|"plugin entry"| DUAL_RISK
    DUAL_RISK -->|"eviction fixes: one path only"| CLAUDE_CODE

    %% HOST → MCP SERVER %%
    CLAUDE_CODE -->|"spawns via stdio"| FACTORY

    %% MCP SERVER INTERNALS %%
    FACTORY --> IS_PLUGIN_FACTORY
    IS_PLUGIN_FACTORY -->|"plugin mode: None"| PLUGIN_DIR_RESOLVE
    IS_PLUGIN_FACTORY -->|"direct mode: pkg_root()"| PLUGIN_DIR_RESOLVE
    FACTORY --> GATE
    FACTORY --> BG_SUPER

    %% FACTORY → STORAGE %%
    FACTORY -->|"reads/writes"| TEMP_DIR
    FACTORY -->|"writes session data"| SESSION_LOGS
    FACTORY -->|"reads OAuth token"| CREDENTIALS
    BG_SUPER -->|"quota check"| ANTHROPIC
    FACTORY -->|"GitHub tools"| GITHUB

    %% EXECUTION PHASE %%
    PLUGIN_DIR_RESOLVE -->|"plugin_dir value"| BUILD_CMD
    SESSION_SKILLS -->|"stages skill dirs"| EPHEMERAL_SKILLS
    BUILD_CMD --> PLUGIN_DIR_FLAG
    PLUGIN_DIR_FLAG -->|"--plugin-dir only if direct mode"| PTY_WRAP
    SESSION_SKILLS -->|"--add-dir paths"| PTY_WRAP

    %% HEADLESS %%
    PTY_WRAP -->|"wraps"| HEADLESS_CLAUDE
    HEADLESS_CLAUDE -->|"writes"| CLAUDE_LOGS
    FACTORY -->|"polls Channel B"| CLAUDE_LOGS
    HEADLESS_CLAUDE -->|"reads skill dirs"| EPHEMERAL_SKILLS

    %% CLASS ASSIGNMENTS %%
    class REGISTER_ALL,IS_PLUGIN_INIT,EVICT,REGISTER_DIRECT handler;
    class CLAUDE_JSON,PLUGIN_REG stateNode;
    class CLAUDE_CODE,DUAL_RISK cli;
    class FACTORY,IS_PLUGIN_FACTORY,PLUGIN_DIR_RESOLVE,GATE,BG_SUPER phase;
    class BUILD_CMD,PLUGIN_DIR_FLAG,SESSION_SKILLS handler;
    class PTY_WRAP,HEADLESS_CLAUDE cli;
    class TEMP_DIR,SESSION_LOGS,CLAUDE_LOGS,EPHEMERAL_SKILLS,CREDENTIALS stateNode;
    class GITHUB,ANTHROPIC integration;
```

### Error/Resilience Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 42, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    %% ── ENTRY ── %%
    ENTRY(["● app.main()"])

    subgraph DISPATCH ["● CLI ENTRY DISPATCH (app.py)"]
        SERVE_CHK{"● command<br/>== 'serve'?"}
        PRE_EVICT["● evict_direct_mcp_entry()<br/>━━━━━━━━━━<br/>Proactive self-heal on<br/>every non-serve invocation<br/>(runs BEFORE app())"]
    end

    subgraph DUAL_MCP ["● DUAL-MCP CIRCUIT BREAKERS (_update_checks.py / _doctor.py)"]
        direction TB
        DETECT{"● _is_dual_mcp_registered()<br/>━━━━━━━━━━<br/>~/.claude.json mcpServers AND<br/>plugins/installed_plugins.json<br/>both present?"}
        DET_FAIL["OSError / JSONDecodeError<br/>━━━━━━━━━━<br/>→ return False<br/>(fail-open: cannot confirm)"]
        DUAL_SIG["● _dual_mcp_signal()<br/>━━━━━━━━━━<br/>Signal(dual_mcp, severity=WARNING)<br/>→ prompt: autoskillit install"]
        SIG_FAIL["except Exception<br/>━━━━━━━━━━<br/>→ return None<br/>(silently skip signal)"]
        DOCTOR["● _check_dual_mcp_registration()<br/>━━━━━━━━━━<br/>DoctorResult(WARNING)<br/>Advisory only — never aborts<br/>(OSError/JSONDecodeError → OK)"]
    end

    subgraph EVICTION ["● EVICTION CHAIN (_init_helpers.py / _marketplace.py)"]
        direction TB
        REG_ROUTE{"● _register_all()<br/>_is_plugin_installed()?<br/>━━━━━━━━━━<br/>Plugin already manages MCP?"}
        EVICT_REG["● evict_direct_mcp_entry()<br/>━━━━━━━━━━<br/>Remove stale mcpServers entry<br/>at init time if plugin present<br/>(OSError/JSONDecodeError → False)"]
        WRITE_MCP["_register_mcp_server()<br/>━━━━━━━━━━<br/>Write direct entry to<br/>~/.claude.json<br/>(no plugin path)"]
        MCP_FAIL["ValueError / OSError<br/>━━━━━━━━━━<br/>→ re-raised as CliError<br/>→ caught in init()<br/>→ SystemExit(1)"]
        POST_EVICT["● _marketplace.install()<br/>post-install eviction<br/>━━━━━━━━━━<br/>evict_direct_mcp_entry()<br/>after plugin successfully installed"]
    end

    subgraph INIT_GATES ["● INIT / INSTALL VALIDATION GATES (Fail-Fast)"]
        direction LR
        STDIN_G{"_require_interactive_stdin()<br/>━━━━━━━━━━<br/>stdin.isatty()?"}
        SECRET_G{"● _check_secret_scanning()<br/>━━━━━━━━━━<br/>Scanner present OR<br/>exact bypass phrase accepted?"}
        SRCTREE_G{"source tree guard<br/>━━━━━━━━━━<br/>project_dir inside<br/>autoskillit source?"}
        WORKTREE_G{"● _ensure_marketplace()<br/>━━━━━━━━━━<br/>is_git_worktree(pkg_dir)?"}
        BINARY_G{"claude binary check<br/>━━━━━━━━━━<br/>shutil.which('claude')?"}
        SCOPE_G{"scope validation<br/>━━━━━━━━━━<br/>scope in<br/>('user','project')?"}
    end

    subgraph CMD_GATE ["● COMMAND-BUILDER GATE (_cook.py / app.py / commands.py)"]
        direction LR
        PLUGIN_CHK{"● _is_plugin_installed()?<br/>━━━━━━━━━━<br/>plugin_dir = None if True"}
        WITH_DIR["--plugin-dir injected<br/>━━━━━━━━━━<br/>No plugin: server launched<br/>via --plugin-dir flag"]
        NO_DIR["● --plugin-dir OMITTED<br/>━━━━━━━━━━<br/>Plugin present:<br/>prevents 2nd server spawn<br/>(core dual-MCP fix)"]
    end

    subgraph FACTORY ["● FACTORY / CONTEXT GUARDS (_factory.py / context.py)"]
        direction TB
        TOKEN_G["● _gh_cli_token()<br/>━━━━━━━━━━<br/>except Exception → None<br/>Server starts without token"]
        REC_CHK{"RECORD_SCENARIO set?<br/>━━━━━━━━━━<br/>ImportError on api_simulator?"}
        REC_FAIL["ImportError<br/>━━━━━━━━━━<br/>→ re-raised as RuntimeError<br/>(explicit message, hard abort)"]
        REPLAY_G{"REPLAY_SCENARIO_DIR<br/>━━━━━━━━━━<br/>path exists?"}
        BG_G["● context.__post_init__<br/>━━━━━━━━━━<br/>background=None →<br/>auto-construct DefaultBackgroundSupervisor"]
    end

    subgraph SIGNALS ["● UPDATE-CHECK SIGNAL GATHERING (All Fail-Open)"]
        direction LR
        NET_S["_fetch_with_cache()<br/>━━━━━━━━━━<br/>network + JSON parse<br/>except Exception → None"]
        DRIFT_S["_source_drift_signal()<br/>━━━━━━━━━━<br/>except Exception → None"]
        HOOK_S["_hooks_signal()<br/>━━━━━━━━━━<br/>except Exception → None"]
        BIN_S["_binary_signal()<br/>━━━━━━━━━━<br/>except Exception → None"]
    end

    %% ── TERMINALS ── %%
    T_SERVE(["● Server starts<br/>(single-process, MCP safe)"])
    T_CMD(["● Claude cmd built<br/>(dual-MCP safe)"])
    T_WARN(["● Advisory WARNING<br/>surfaced to user"])
    T_SKIP(["Signal/check = None<br/>(silently skipped)"])
    T_ABORT(["SystemExit(1)<br/>ABORT"])

    %% ── CONNECTIONS ── %%

    %% Entry dispatch
    ENTRY --> SERVE_CHK
    SERVE_CHK -->|"serve"| TOKEN_G
    SERVE_CHK -->|"non-serve"| PRE_EVICT
    PRE_EVICT -->|"OSError/JSONDecodeError<br/>→ False"| T_SKIP
    PRE_EVICT -->|"entry removed"| T_WARN
    PRE_EVICT --> DETECT
    PRE_EVICT --> NET_S

    %% Dual-MCP detection
    DETECT -->|"both present"| DUAL_SIG
    DETECT -->|"file error"| DET_FAIL
    DET_FAIL --> T_SKIP
    DUAL_SIG -->|"signal emitted"| T_WARN
    DUAL_SIG -->|"except Exception"| SIG_FAIL
    SIG_FAIL --> T_SKIP
    DOCTOR -->|"both found"| T_WARN
    DOCTOR -->|"file error"| T_SKIP

    %% Eviction chain
    REG_ROUTE -->|"no plugin"| WRITE_MCP
    REG_ROUTE -->|"plugin installed"| EVICT_REG
    WRITE_MCP -->|"ValueError/OSError"| MCP_FAIL
    MCP_FAIL --> T_ABORT
    EVICT_REG -->|"fail-open result"| T_WARN
    POST_EVICT --> T_WARN

    %% Init/install fail-fast gates
    STDIN_G -->|"not tty"| T_ABORT
    SECRET_G -->|"bypass failed"| T_ABORT
    SRCTREE_G -->|"inside source"| T_ABORT
    WORKTREE_G -->|"is worktree"| T_ABORT
    BINARY_G -->|"missing"| T_ABORT
    SCOPE_G -->|"invalid scope"| T_ABORT
    STDIN_G -->|"ok"| REG_ROUTE
    SECRET_G -->|"ok"| SRCTREE_G
    WORKTREE_G -->|"ok"| WRITE_MCP
    BINARY_G -->|"found"| PLUGIN_CHK

    %% Command-builder gate
    PLUGIN_CHK -->|"no plugin"| WITH_DIR
    PLUGIN_CHK -->|"plugin installed"| NO_DIR
    WITH_DIR --> T_CMD
    NO_DIR --> T_CMD

    %% Factory guards
    TOKEN_G --> T_SERVE
    REC_CHK -->|"set + pkg missing"| REC_FAIL
    REC_FAIL --> T_ABORT
    REC_CHK -->|"not set / pkg ok"| T_SERVE
    REPLAY_G -->|"path missing"| T_SKIP
    REPLAY_G -->|"valid"| T_SERVE
    BG_G --> T_SERVE

    %% Fail-open signals
    NET_S --> T_SKIP
    DRIFT_S --> T_SKIP
    HOOK_S --> T_SKIP
    BIN_S --> T_SKIP

    %% ── CLASS ASSIGNMENTS ── %%
    class ENTRY cli;
    class SERVE_CHK,DETECT,REG_ROUTE,STDIN_G,SECRET_G,SRCTREE_G,WORKTREE_G,BINARY_G,SCOPE_G,PLUGIN_CHK,REC_CHK,REPLAY_G detector;
    class PRE_EVICT,EVICT_REG,POST_EVICT,DUAL_SIG handler;
    class WRITE_MCP,TOKEN_G,BG_G phase;
    class DET_FAIL,SIG_FAIL,MCP_FAIL,REC_FAIL gap;
    class NET_S,DRIFT_S,HOOK_S,BIN_S gap;
    class DOCTOR stateNode;
    class WITH_DIR,NO_DIR output;
    class T_SERVE,T_CMD,T_WARN,T_SKIP,T_ABORT terminal;
```

Closes #859

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260413-190109-264954/.autoskillit/temp/rectify/rectify_stale_mcp_dual_server_spawning_2026-04-13_191500_part_a.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
