### PR TITLE
Rectify: Headless Core Crash Path Raises Instead of Returning Structured Error

### DIFF
--- a/src/autoskillit/core/_type_enums.py
+++ b/src/autoskillit/core/_type_enums.py
@@ -214,6 +214,7 @@ class KillReason(StrEnum):
     NATURAL_EXIT = "natural_exit"
     KILL_AFTER_COMPLETION = "kill_after_completion"  # drain window expired
     INFRA_KILL = "infra_kill"  # timeout / stall / stale
+    EXCEPTION = "exception"  # runner raised an unhandled exception
 
 
 class ChannelConfirmation(StrEnum):

--- a/src/autoskillit/core/_type_results.py
+++ b/src/autoskillit/core/_type_results.py
@@ -182,7 +182,7 @@ class SkillResult:
     @classmethod
     def crashed(
         cls,
-        exception: BaseException,
+        exception: Exception,
         skill_command: str = "",
         session_id: str = "",
         order_id: str = "",

--- a/src/autoskillit/core/_type_results.py
+++ b/src/autoskillit/core/_type_results.py
@@ -179,6 +179,33 @@ class SkillResult:
             data["order_id"] = self.order_id
         return json.dumps(data, default=lambda o: o.value if isinstance(o, Enum) else str(o))
 
+    @classmethod
+    def crashed(
+        cls,
+        exception: BaseException,
+        skill_command: str = "",
+        session_id: str = "",
+        order_id: str = "",
+    ) -> SkillResult:
+        """Construct a SkillResult for a runner crash (pre-launch or mid-flight exception).
+
+        Produces the same 13+ field envelope as _build_skill_result, ensuring
+        pipeline orchestrators can route crash responses without schema inspection.
+        """
+        return cls(
+            success=False,
+            result=f"{type(exception).__name__}: {exception}",
+            session_id=session_id,
+            subtype="crashed",
+            is_error=True,
+            exit_code=-1,
+            needs_retry=False,
+            retry_reason=RetryReason.NONE,
+            stderr="",
+            kill_reason=KillReason.NATURAL_EXIT,
+            order_id=order_id,
+        )
+
     @property
     def outcome(self) -> SessionOutcome:
         """Classify this result as SUCCEEDED, RETRIABLE, or FAILED.

--- a/src/autoskillit/core/_type_results.py
+++ b/src/autoskillit/core/_type_results.py
@@ -192,9 +192,12 @@ class SkillResult:
         Produces the same 13+ field envelope as _build_skill_result, ensuring
         pipeline orchestrators can route crash responses without schema inspection.
         """
+        _result = f"{type(exception).__name__}: {exception}"
+        if skill_command:
+            _result += f" | skill_command={skill_command!r}"
         return cls(
             success=False,
-            result=f"{type(exception).__name__}: {exception}",
+            result=_result,
             session_id=session_id,
             subtype="crashed",
             is_error=True,
@@ -202,7 +205,7 @@ class SkillResult:
             needs_retry=False,
             retry_reason=RetryReason.NONE,
             stderr="",
-            kill_reason=KillReason.NATURAL_EXIT,
+            kill_reason=KillReason.EXCEPTION,
             order_id=order_id,
         )
 

--- a/src/autoskillit/execution/headless.py
+++ b/src/autoskillit/execution/headless.py
@@ -1040,6 +1040,8 @@ async def run_headless_core(
             _exc_text = traceback.format_exc()
             _log_dir = ctx.config.linux_tracing.log_dir
             try:
+                # Deferred: autoskillit.execution.__init__ imports headless.py (L39-42);
+                # a top-level import of autoskillit.execution would be circular.
                 from autoskillit.execution import flush_session_log
 
                 flush_session_log(
@@ -1063,6 +1065,11 @@ async def run_headless_core(
             return SkillResult.crashed(
                 exception=exc,
                 skill_command=original_skill_command,
+                order_id=order_id,
+            )
+        if _result is None:
+            return SkillResult.crashed(
+                exception=RuntimeError("runner() did not return a result"),
                 order_id=order_id,
             )
         _elapsed = time.monotonic() - _start_mono

--- a/src/autoskillit/execution/headless.py
+++ b/src/autoskillit/execution/headless.py
@@ -14,6 +14,7 @@ import dataclasses
 import os
 import re
 import time
+import traceback
 from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -1034,32 +1035,36 @@ async def run_headless_core(
                 idle_output_timeout=effective_idle,
                 max_suppression_seconds=cfg.max_suppression_seconds,
             )
-        finally:
-            if _result is None:
-                # Runner raised — write a crash entry so sessions.jsonl stays consistent
-                _log_dir = ctx.config.linux_tracing.log_dir
-                try:
-                    from autoskillit.execution import flush_session_log
+        except Exception as exc:
+            logger.error("run_headless_core runner crashed", exc_info=True)
+            _exc_text = traceback.format_exc()
+            _log_dir = ctx.config.linux_tracing.log_dir
+            try:
+                from autoskillit.execution import flush_session_log
 
-                    flush_session_log(
-                        log_dir=_log_dir,
-                        cwd=str(cwd),
-                        kitchen_id=kitchen_id,
-                        order_id=order_id,
-                        session_id="",
-                        pid=0,
-                        skill_command=skill_command,
-                        success=False,
-                        subtype="crashed",
-                        exit_code=-1,
-                        start_ts=_start_ts,
-                        proc_snapshots=None,
-                        termination_reason="CRASHED",
-                    )
-                except Exception:
-                    logger.debug("flush_session_log during crash failed", exc_info=True)
-        if _result is None:
-            raise RuntimeError("runner() did not return a result — cannot build SkillResult")
+                flush_session_log(
+                    log_dir=_log_dir,
+                    cwd=str(cwd),
+                    kitchen_id=kitchen_id,
+                    order_id=order_id,
+                    session_id="",
+                    pid=0,
+                    skill_command=original_skill_command,
+                    success=False,
+                    subtype="crashed",
+                    exit_code=-1,
+                    start_ts=_start_ts,
+                    proc_snapshots=None,
+                    termination_reason="CRASHED",
+                    exception_text=_exc_text,
+                )
+            except Exception:
+                logger.debug("flush_session_log during crash failed", exc_info=True)
+            return SkillResult.crashed(
+                exception=exc,
+                skill_command=original_skill_command,
+                order_id=order_id,
+            )
         _elapsed = time.monotonic() - _start_mono
         _end_ts = (datetime.fromisoformat(_start_ts) + timedelta(seconds=_elapsed)).isoformat()
         result = dataclasses.replace(  # type: ignore[arg-type]

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -98,6 +98,7 @@ def flush_session_log(
     write_call_count: int = 0,
     clone_contamination_reverted: bool = False,
     tracked_comm: str | None = None,
+    exception_text: str = "",
 ) -> None:
     """Flush session diagnostics to disk.
 
@@ -241,6 +242,9 @@ def flush_session_log(
     }
     summary_path = session_dir / "summary.json"
     atomic_write(summary_path, json.dumps(summary, sort_keys=True, indent=2) + "\n")
+
+    if exception_text:
+        (session_dir / "crash_exception.txt").write_text(exception_text, encoding="utf-8")
 
     # Write per-session telemetry files when step_name is provided
     if step_name and token_usage is not None:

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -244,7 +244,7 @@ def flush_session_log(
     atomic_write(summary_path, json.dumps(summary, sort_keys=True, indent=2) + "\n")
 
     if exception_text:
-        (session_dir / "crash_exception.txt").write_text(exception_text, encoding="utf-8")
+        atomic_write(session_dir / "crash_exception.txt", exception_text)
 
     # Write per-session telemetry files when step_name is provided
     if step_name and token_usage is not None:

--- a/src/autoskillit/server/tools_ci.py
+++ b/src/autoskillit/server/tools_ci.py
@@ -67,89 +67,95 @@ async def wait_for_ci(
         "action_required", "timed_out", "no_runs", "error", "unknown"),
         and failed_jobs list. Billing limit errors surface as
         conclusion="action_required" with failed_jobs=[].
+
+    Never raises.
     """
     if (gate := _require_enabled()) is not None:
         return gate
-    structlog.contextvars.clear_contextvars()
-    structlog.contextvars.bind_contextvars(tool="wait_for_ci")
-    logger.info("wait_for_ci", branch=branch, repo=repo or "(infer)")
-
-    from autoskillit.server import _get_ctx
-
-    tool_ctx = _get_ctx()
-    if tool_ctx.ci_watcher is None:
-        return json.dumps(
-            {
-                "run_id": None,
-                "conclusion": "error",
-                "failed_jobs": [],
-                "error": "CI watcher not configured",
-            }
-        )
-
-    # Infer head_sha from cwd if not provided
-    if head_sha is None and cwd:
-        try:
-            rc, stdout, _ = await _run_subprocess(
-                ["git", "rev-parse", "HEAD"], cwd=cwd, timeout=5.0
-            )
-            if rc == 0:
-                head_sha = stdout.strip()
-        except Exception:
-            logger.warning("git rev-parse HEAD failed", exc_info=True)
-
-    scope = CIRunScope(
-        workflow=workflow or tool_ctx.default_ci_scope.workflow,
-        head_sha=head_sha,
-        event=event or tool_ctx.default_ci_scope.event,
-    )
-
-    resolved_repo = await infer_repo_from_remote(cwd, hint=remote_url or repo or None)
-
-    await _notify(
-        ctx,
-        "info",
-        f"Watching CI for branch {branch}",
-        "autoskillit.wait_for_ci",
-        extra={
-            "repo": resolved_repo or "(infer)",
-            "head_sha": scope.head_sha or "(any)",
-            "workflow": scope.workflow or "(any)",
-        },
-    )
-
-    _start = time.monotonic()
     try:
-        result = await tool_ctx.ci_watcher.wait(
-            branch,
-            repo=resolved_repo or None,
-            scope=scope,
-            timeout_seconds=timeout_seconds,
-            cwd=cwd,
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(tool="wait_for_ci")
+        logger.info("wait_for_ci", branch=branch, repo=repo or "(infer)")
+
+        from autoskillit.server import _get_ctx
+
+        tool_ctx = _get_ctx()
+        if tool_ctx.ci_watcher is None:
+            return json.dumps(
+                {
+                    "run_id": None,
+                    "conclusion": "error",
+                    "failed_jobs": [],
+                    "error": "CI watcher not configured",
+                }
+            )
+
+        # Infer head_sha from cwd if not provided
+        if head_sha is None and cwd:
+            try:
+                rc, stdout, _ = await _run_subprocess(
+                    ["git", "rev-parse", "HEAD"], cwd=cwd, timeout=5.0
+                )
+                if rc == 0:
+                    head_sha = stdout.strip()
+            except Exception:
+                logger.warning("git rev-parse HEAD failed", exc_info=True)
+
+        scope = CIRunScope(
+            workflow=workflow or tool_ctx.default_ci_scope.workflow,
+            head_sha=head_sha,
+            event=event or tool_ctx.default_ci_scope.event,
         )
 
-        # Include head_sha used for this CI check so orchestrators can verify
-        # CI results correspond to the current HEAD after a force-push.
-        if scope.head_sha:
-            result = {**result, "head_sha": scope.head_sha}
+        resolved_repo = await infer_repo_from_remote(cwd, hint=remote_url or repo or None)
 
-        conclusion = result.get("conclusion", "unknown")
-        level = "info" if conclusion == "success" else "error"
         await _notify(
             ctx,
-            level,
-            f"CI result: {conclusion}",
+            "info",
+            f"Watching CI for branch {branch}",
             "autoskillit.wait_for_ci",
-            extra={"run_id": result.get("run_id")},
+            extra={
+                "repo": resolved_repo or "(infer)",
+                "head_sha": scope.head_sha or "(any)",
+                "workflow": scope.workflow or "(any)",
+            },
         )
 
-        return json.dumps(result)
+        _start = time.monotonic()
+        try:
+            result = await tool_ctx.ci_watcher.wait(
+                branch,
+                repo=resolved_repo or None,
+                scope=scope,
+                timeout_seconds=timeout_seconds,
+                cwd=cwd,
+            )
+
+            # Include head_sha used for this CI check so orchestrators can verify
+            # CI results correspond to the current HEAD after a force-push.
+            if scope.head_sha:
+                result = {**result, "head_sha": scope.head_sha}
+
+            conclusion = result.get("conclusion", "unknown")
+            level = "info" if conclusion == "success" else "error"
+            await _notify(
+                ctx,
+                level,
+                f"CI result: {conclusion}",
+                "autoskillit.wait_for_ci",
+                extra={"run_id": result.get("run_id")},
+            )
+
+            return json.dumps(result)
+        except Exception as exc:
+            logger.error("autoskillit.wait_for_ci failed", exc_info=exc)
+            return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
+        finally:
+            if step_name:
+                tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
     except Exception as exc:
-        logger.error("autoskillit.wait_for_ci failed", exc_info=exc)
+        logger.error("wait_for_ci unhandled exception", exc_info=True)
         return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
-    finally:
-        if step_name:
-            tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "github"}, annotations={"readOnlyHint": True})
@@ -177,6 +183,8 @@ async def set_commit_status(
         target_url: Optional URL linking to review details.
         repo: owner/repo format. Inferred from `cwd` git remote if absent.
         cwd: Working directory for repo inference. Defaults to plugin_dir.
+
+    Never raises.
     """
     if (gate := _require_enabled()) is not None:
         return gate
@@ -193,41 +201,45 @@ async def set_commit_status(
             }
         )
 
-    from autoskillit.server import _get_ctx
+    try:
+        from autoskillit.server import _get_ctx
 
-    tool_ctx = _get_ctx()
-    effective_cwd = cwd or tool_ctx.plugin_dir or "."
+        tool_ctx = _get_ctx()
+        effective_cwd = cwd or tool_ctx.plugin_dir or "."
 
-    # Resolve owner/repo if not provided
-    owner_repo = repo
-    if not owner_repo:
-        owner_repo = await infer_repo_from_remote(effective_cwd)
+        # Resolve owner/repo if not provided
+        owner_repo = repo
         if not owner_repo:
-            return json.dumps(
-                {"success": False, "error": "Could not infer owner/repo from git remote"}
-            )
+            owner_repo = await infer_repo_from_remote(effective_cwd)
+            if not owner_repo:
+                return json.dumps(
+                    {"success": False, "error": "Could not infer owner/repo from git remote"}
+                )
 
-    cmd = [
-        "gh",
-        "api",
-        "--method",
-        "POST",
-        f"/repos/{owner_repo}/statuses/{sha}",
-        "-f",
-        f"state={state}",
-        "-f",
-        f"context={context}",
-        "-f",
-        f"description={description}",
-    ]
-    if target_url:
-        cmd += ["-f", f"target_url={target_url}"]
+        cmd = [
+            "gh",
+            "api",
+            "--method",
+            "POST",
+            f"/repos/{owner_repo}/statuses/{sha}",
+            "-f",
+            f"state={state}",
+            "-f",
+            f"context={context}",
+            "-f",
+            f"description={description}",
+        ]
+        if target_url:
+            cmd += ["-f", f"target_url={target_url}"]
 
-    rc, _stdout, stderr = await _run_subprocess(cmd, cwd=effective_cwd, timeout=30.0)
-    if rc != 0:
-        return json.dumps({"success": False, "error": stderr})
+        rc, _stdout, stderr = await _run_subprocess(cmd, cwd=effective_cwd, timeout=30.0)
+        if rc != 0:
+            return json.dumps({"success": False, "error": stderr})
 
-    return json.dumps({"success": True, "sha": sha, "state": state, "context": context})
+        return json.dumps({"success": True, "sha": sha, "state": state, "context": context})
+    except Exception as exc:
+        logger.error("set_commit_status unhandled exception", exc_info=True)
+        return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "ci"}, annotations={"readOnlyHint": True})
@@ -254,31 +266,37 @@ async def get_ci_status(
 
     Returns:
         JSON with runs list, each containing id, status, conclusion, failed_jobs.
+
+    Never raises.
     """
     if (gate := _require_enabled()) is not None:
         return gate
-    from autoskillit.server import _get_ctx
+    try:
+        from autoskillit.server import _get_ctx
 
-    tool_ctx = _get_ctx()
-    if tool_ctx.ci_watcher is None:
-        return json.dumps({"runs": [], "error": "CI watcher not configured"})
+        tool_ctx = _get_ctx()
+        if tool_ctx.ci_watcher is None:
+            return json.dumps({"runs": [], "error": "CI watcher not configured"})
 
-    if branch is None and run_id is None:
-        return json.dumps({"runs": [], "error": "Provide branch or run_id"})
+        if branch is None and run_id is None:
+            return json.dumps({"runs": [], "error": "Provide branch or run_id"})
 
-    scope = CIRunScope(
-        workflow=workflow or tool_ctx.default_ci_scope.workflow,
-        event=event or tool_ctx.default_ci_scope.event,
-    )
+        scope = CIRunScope(
+            workflow=workflow or tool_ctx.default_ci_scope.workflow,
+            event=event or tool_ctx.default_ci_scope.event,
+        )
 
-    result = await tool_ctx.ci_watcher.status(
-        branch or "",
-        repo=repo,
-        run_id=run_id,
-        scope=scope,
-        cwd=cwd,
-    )
-    return json.dumps(result)
+        result = await tool_ctx.ci_watcher.status(
+            branch or "",
+            repo=repo,
+            run_id=run_id,
+            scope=scope,
+            cwd=cwd,
+        )
+        return json.dumps(result)
+    except Exception as exc:
+        logger.error("get_ci_status unhandled exception", exc_info=True)
+        return json.dumps({"runs": [], "error": f"{type(exc).__name__}: {exc}"})
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "ci"}, annotations={"readOnlyHint": False})
@@ -307,43 +325,48 @@ async def toggle_auto_merge(
     Returns:
         JSON: {"success": bool, "pr_number": int} on success,
               {"success": false, "error": str} on failure.
+
+    Never raises.
     """
     if (gate := _require_enabled()) is not None:
         return gate
-
-    structlog.contextvars.clear_contextvars()
-    structlog.contextvars.bind_contextvars(
-        tool="toggle_auto_merge", pr_number=pr_number, target_branch=target_branch
-    )
-    await _notify(
-        ctx,
-        "info",
-        f"Toggling auto-merge for PR #{pr_number} on {target_branch!r}",
-        "autoskillit.toggle_auto_merge",
-        extra={"pr_number": pr_number, "target_branch": target_branch},
-    )
-
-    from autoskillit.server import _get_ctx
-
-    tool_ctx = _get_ctx()
-
-    if tool_ctx.merge_queue_watcher is None:
-        return json.dumps(
-            {
-                "success": False,
-                "error": "merge_queue_watcher not configured (missing GITHUB_TOKEN?)",
-            }
+    try:
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(
+            tool="toggle_auto_merge", pr_number=pr_number, target_branch=target_branch
+        )
+        await _notify(
+            ctx,
+            "info",
+            f"Toggling auto-merge for PR #{pr_number} on {target_branch!r}",
+            "autoskillit.toggle_auto_merge",
+            extra={"pr_number": pr_number, "target_branch": target_branch},
         )
 
-    resolved_repo = await infer_repo_from_remote(cwd, hint=remote_url or repo or None)
+        from autoskillit.server import _get_ctx
 
-    result = await tool_ctx.merge_queue_watcher.toggle(
-        pr_number=pr_number,
-        target_branch=target_branch,
-        repo=resolved_repo or None,
-        cwd=cwd,
-    )
-    return json.dumps(result)
+        tool_ctx = _get_ctx()
+
+        if tool_ctx.merge_queue_watcher is None:
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": "merge_queue_watcher not configured (missing GITHUB_TOKEN?)",
+                }
+            )
+
+        resolved_repo = await infer_repo_from_remote(cwd, hint=remote_url or repo or None)
+
+        result = await tool_ctx.merge_queue_watcher.toggle(
+            pr_number=pr_number,
+            target_branch=target_branch,
+            repo=resolved_repo or None,
+            cwd=cwd,
+        )
+        return json.dumps(result)
+    except Exception as exc:
+        logger.error("toggle_auto_merge unhandled exception", exc_info=True)
+        return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "ci"}, annotations={"readOnlyHint": False})
@@ -401,57 +424,62 @@ async def wait_for_merge_queue(
           dropped_healthy  — auto-merge disabled on a PR with no CI/conflict issues.
           timeout          — polling budget exhausted before a terminal state was reached.
           error            — watcher raised an unexpected exception.
+
+    Never raises.
     """
     if (gate := _require_enabled()) is not None:
         return gate
-
-    structlog.contextvars.clear_contextvars()
-    structlog.contextvars.bind_contextvars(
-        tool="wait_for_merge_queue", pr_number=pr_number, target_branch=target_branch
-    )
-    await _notify(
-        ctx,
-        "info",
-        f"Waiting for PR #{pr_number} in merge queue on {target_branch!r}",
-        "autoskillit.wait_for_merge_queue",
-        extra={"pr_number": pr_number, "target_branch": target_branch},
-    )
-
-    from autoskillit.server import _get_ctx
-
-    tool_ctx = _get_ctx()
-
-    if tool_ctx.merge_queue_watcher is None:
-        return json.dumps(
-            {
-                "success": False,
-                "pr_state": "error",
-                "reason": "merge_queue_watcher not configured (missing GITHUB_TOKEN?)",
-            }
-        )
-
-    resolved_repo = await infer_repo_from_remote(cwd, hint=remote_url or repo or None)
-
-    _start = time.monotonic()
     try:
-        result = await tool_ctx.merge_queue_watcher.wait(
-            pr_number=pr_number,
-            target_branch=target_branch,
-            repo=resolved_repo or None,
-            cwd=cwd,
-            timeout_seconds=timeout_seconds,
-            poll_interval=poll_interval,
-            stall_grace_period=stall_grace_period,
-            max_stall_retries=max_stall_retries,
-            not_in_queue_confirmation_cycles=not_in_queue_confirmation_cycles,
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(
+            tool="wait_for_merge_queue", pr_number=pr_number, target_branch=target_branch
         )
-        return json.dumps(result)
+        await _notify(
+            ctx,
+            "info",
+            f"Waiting for PR #{pr_number} in merge queue on {target_branch!r}",
+            "autoskillit.wait_for_merge_queue",
+            extra={"pr_number": pr_number, "target_branch": target_branch},
+        )
+
+        from autoskillit.server import _get_ctx
+
+        tool_ctx = _get_ctx()
+
+        if tool_ctx.merge_queue_watcher is None:
+            return json.dumps(
+                {
+                    "success": False,
+                    "pr_state": "error",
+                    "reason": "merge_queue_watcher not configured (missing GITHUB_TOKEN?)",
+                }
+            )
+
+        resolved_repo = await infer_repo_from_remote(cwd, hint=remote_url or repo or None)
+
+        _start = time.monotonic()
+        try:
+            result = await tool_ctx.merge_queue_watcher.wait(
+                pr_number=pr_number,
+                target_branch=target_branch,
+                repo=resolved_repo or None,
+                cwd=cwd,
+                timeout_seconds=timeout_seconds,
+                poll_interval=poll_interval,
+                stall_grace_period=stall_grace_period,
+                max_stall_retries=max_stall_retries,
+                not_in_queue_confirmation_cycles=not_in_queue_confirmation_cycles,
+            )
+            return json.dumps(result)
+        except Exception as exc:
+            logger.error("autoskillit.wait_for_merge_queue failed", exc_info=exc)
+            return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
+        finally:
+            if step_name:
+                tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
     except Exception as exc:
-        logger.error("autoskillit.wait_for_merge_queue failed", exc_info=exc)
+        logger.error("wait_for_merge_queue unhandled exception", exc_info=True)
         return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
-    finally:
-        if step_name:
-            tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "ci"}, annotations={"readOnlyHint": True})
@@ -483,35 +511,52 @@ async def check_repo_merge_state(
     - ``ci_event``: ``"push"`` | ``"merge_group"`` | ``null`` — recommended
       event to use when polling CI via wait_for_ci.
     On any error, returns an error field alongside the four boolean/null defaults.
+
+    Never raises.
     """
     if (gate := _require_enabled()) is not None:
         return gate
-    from autoskillit.server import _get_ctx
-
-    tool_ctx = _get_ctx()
-    _start = time.monotonic()
     try:
-        resolved_repo = await infer_repo_from_remote(cwd, hint=remote_url or None)
-        if not resolved_repo or "/" not in resolved_repo:
+        from autoskillit.server import _get_ctx
+
+        tool_ctx = _get_ctx()
+        _start = time.monotonic()
+        try:
+            resolved_repo = await infer_repo_from_remote(cwd, hint=remote_url or None)
+            if not resolved_repo or "/" not in resolved_repo:
+                return json.dumps(
+                    {
+                        "error": f"Could not resolve owner/repo from cwd={cwd!r}",
+                        "queue_available": False,
+                        "merge_group_trigger": False,
+                        "auto_merge_available": False,
+                        "ci_event": None,
+                    }
+                )
+            owner, repo = resolved_repo.split("/", 1)
+            state = await fetch_repo_merge_state(
+                owner=owner,
+                repo=repo,
+                branch=branch,
+                token=tool_ctx.config.github.token,
+            )
+            return json.dumps(state)
+        except Exception as exc:
+            logger.error("autoskillit.check_repo_merge_state failed", exc_info=exc)
             return json.dumps(
                 {
-                    "error": f"Could not resolve owner/repo from cwd={cwd!r}",
+                    "error": f"{type(exc).__name__}: {exc}",
                     "queue_available": False,
                     "merge_group_trigger": False,
                     "auto_merge_available": False,
                     "ci_event": None,
                 }
             )
-        owner, repo = resolved_repo.split("/", 1)
-        state = await fetch_repo_merge_state(
-            owner=owner,
-            repo=repo,
-            branch=branch,
-            token=tool_ctx.config.github.token,
-        )
-        return json.dumps(state)
+        finally:
+            if step_name:
+                tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
     except Exception as exc:
-        logger.error("autoskillit.check_repo_merge_state failed", exc_info=exc)
+        logger.error("check_repo_merge_state unhandled exception", exc_info=True)
         return json.dumps(
             {
                 "error": f"{type(exc).__name__}: {exc}",
@@ -521,6 +566,3 @@ async def check_repo_merge_state(
                 "ci_event": None,
             }
         )
-    finally:
-        if step_name:
-            tool_ctx.timing_log.record(step_name, time.monotonic() - _start)

--- a/src/autoskillit/server/tools_ci.py
+++ b/src/autoskillit/server/tools_ci.py
@@ -73,6 +73,8 @@ async def wait_for_ci(
     if (gate := _require_enabled()) is not None:
         return gate
     try:
+        _start = time.monotonic()
+        _timing_ctx = None
         structlog.contextvars.clear_contextvars()
         structlog.contextvars.bind_contextvars(tool="wait_for_ci")
         logger.info("wait_for_ci", branch=branch, repo=repo or "(infer)")
@@ -80,6 +82,7 @@ async def wait_for_ci(
         from autoskillit.server import _get_ctx
 
         tool_ctx = _get_ctx()
+        _timing_ctx = tool_ctx
         if tool_ctx.ci_watcher is None:
             return json.dumps(
                 {
@@ -121,7 +124,6 @@ async def wait_for_ci(
             },
         )
 
-        _start = time.monotonic()
         try:
             result = await tool_ctx.ci_watcher.wait(
                 branch,
@@ -155,6 +157,8 @@ async def wait_for_ci(
                 tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
     except Exception as exc:
         logger.error("wait_for_ci unhandled exception", exc_info=True)
+        if step_name and _timing_ctx is not None:
+            _timing_ctx.timing_log.record(step_name, time.monotonic() - _start)
         return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
 
 
@@ -472,7 +476,7 @@ async def wait_for_merge_queue(
             )
             return json.dumps(result)
         except Exception as exc:
-            logger.error("autoskillit.wait_for_merge_queue failed", exc_info=exc)
+            logger.error("wait_for_merge_queue ci_watcher error", exc_info=True)
             return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
         finally:
             if step_name:
@@ -542,7 +546,7 @@ async def check_repo_merge_state(
             )
             return json.dumps(state)
         except Exception as exc:
-            logger.error("autoskillit.check_repo_merge_state failed", exc_info=exc)
+            logger.error("check_repo_merge_state ci_watcher error", exc_info=True)
             return json.dumps(
                 {
                     "error": f"{type(exc).__name__}: {exc}",

--- a/src/autoskillit/server/tools_ci.py
+++ b/src/autoskillit/server/tools_ci.py
@@ -150,7 +150,7 @@ async def wait_for_ci(
 
             return json.dumps(result)
         except Exception as exc:
-            logger.error("autoskillit.wait_for_ci failed", exc_info=exc)
+            logger.error("wait_for_ci failed", exc_info=True)
             return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
         finally:
             if step_name:

--- a/src/autoskillit/server/tools_clone.py
+++ b/src/autoskillit/server/tools_clone.py
@@ -64,51 +64,57 @@ async def clone_repo(
     operations (including checkout, fetch, reset, pull), run_cmd, or any other
     command in source_dir. All pipeline work — skill invocations, git operations,
     file reads — runs exclusively in clone_path (captured as work_dir in recipes).
+
+    Never raises.
     """
     if (gate := _require_enabled()) is not None:
         return gate
-    structlog.contextvars.clear_contextvars()
-    structlog.contextvars.bind_contextvars(tool="clone_repo", source_dir=source_dir)
-    logger.info("clone_repo", source_dir=source_dir, run_name=run_name, branch=branch)
-    await _notify(
-        ctx,
-        "info",
-        f"clone_repo: {source_dir!r} run_name={run_name!r} branch={branch!r}",
-        "autoskillit.clone_repo",
-        extra={
-            "source_dir": source_dir,
-            "run_name": run_name,
-            "branch": branch,
-            "strategy": strategy,
-            "remote_url": remote_url,
-        },
-    )
-
-    from autoskillit.server import _get_ctx
-
-    tool_ctx = _get_ctx()
-    if tool_ctx.clone_mgr is None:
-        return json.dumps({"error": "Clone manager not configured"})
-
-    _start = time.monotonic()
     try:
-        result = await asyncio.to_thread(
-            tool_ctx.clone_mgr.clone_repo, source_dir, run_name, branch, strategy, remote_url
-        )
-    except (ValueError, RuntimeError) as exc:
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(tool="clone_repo", source_dir=source_dir)
+        logger.info("clone_repo", source_dir=source_dir, run_name=run_name, branch=branch)
         await _notify(
             ctx,
-            "error",
-            "clone_repo failed",
+            "info",
+            f"clone_repo: {source_dir!r} run_name={run_name!r} branch={branch!r}",
             "autoskillit.clone_repo",
-            extra={"reason": str(exc)},
+            extra={
+                "source_dir": source_dir,
+                "run_name": run_name,
+                "branch": branch,
+                "strategy": strategy,
+                "remote_url": remote_url,
+            },
         )
-        return json.dumps({"error": str(exc)})
-    finally:
-        if step_name:
-            tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
 
-    return json.dumps(result)
+        from autoskillit.server import _get_ctx
+
+        tool_ctx = _get_ctx()
+        if tool_ctx.clone_mgr is None:
+            return json.dumps({"error": "Clone manager not configured"})
+
+        _start = time.monotonic()
+        try:
+            result = await asyncio.to_thread(
+                tool_ctx.clone_mgr.clone_repo, source_dir, run_name, branch, strategy, remote_url
+            )
+        except (ValueError, RuntimeError) as exc:
+            await _notify(
+                ctx,
+                "error",
+                "clone_repo failed",
+                "autoskillit.clone_repo",
+                extra={"reason": str(exc)},
+            )
+            return json.dumps({"error": str(exc)})
+        finally:
+            if step_name:
+                tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
+
+        return json.dumps(result)
+    except Exception as exc:
+        logger.error("clone_repo unhandled exception", exc_info=True)
+        return json.dumps({"error": f"{type(exc).__name__}: {exc}"})
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "clone"}, annotations={"readOnlyHint": True})
@@ -196,75 +202,83 @@ async def push_to_remote(
         source_dir: Source repo path (read-only URL lookup when remote_url is empty).
         remote_url: Pre-resolved upstream remote URL. When provided, source_dir is skipped.
         step_name: Optional YAML step key for wall-clock timing accumulation.
+
+    Never raises.
     """
     if (gate := _require_enabled()) is not None:
         return gate
-    structlog.contextvars.clear_contextvars()
-    structlog.contextvars.bind_contextvars(tool="push_to_remote", clone_path=clone_path)
-    logger.info(
-        "push_to_remote",
-        clone_path=clone_path,
-        source_dir=source_dir,
-        remote_url=remote_url,
-        branch=branch,
-    )
-    await _notify(
-        ctx,
-        "info",
-        f"push_to_remote: {clone_path!r} → branch={branch!r}",
-        "autoskillit.push_to_remote",
-        extra={
-            "clone_path": clone_path,
-            "source_dir": source_dir,
-            "remote_url": remote_url,
-            "branch": branch,
-        },
-    )
-
-    from autoskillit.server import _get_ctx
-
-    tool_ctx = _get_ctx()
-    clone_mgr = tool_ctx.clone_mgr
-    if clone_mgr is None:
-        return json.dumps({"error": "Clone manager not configured", "stderr": ""})
-
-    _start = time.monotonic()
     try:
-        result = await asyncio.to_thread(
-            lambda: clone_mgr.push_to_remote(
-                clone_path,
-                source_dir,
-                branch,
-                remote_url=remote_url,
-                protected_branches=tool_ctx.config.safety.protected_branches,
-                force=force.strip().lower() == "true",
-            )
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(tool="push_to_remote", clone_path=clone_path)
+        logger.info(
+            "push_to_remote",
+            clone_path=clone_path,
+            source_dir=source_dir,
+            remote_url=remote_url,
+            branch=branch,
+        )
+        await _notify(
+            ctx,
+            "info",
+            f"push_to_remote: {clone_path!r} → branch={branch!r}",
+            "autoskillit.push_to_remote",
+            extra={
+                "clone_path": clone_path,
+                "source_dir": source_dir,
+                "remote_url": remote_url,
+                "branch": branch,
+            },
         )
 
-        if not result.get("success"):
-            await _notify(
-                ctx,
-                "error",
-                "push_to_remote failed",
-                "autoskillit.push_to_remote",
-                extra={
-                    "stderr": result.get("stderr", ""),
-                    "error_type": result.get("error_type", ""),
-                },
-            )
-            return json.dumps(
-                {
-                    "success": False,
-                    "error": "push failed",
-                    "stderr": result.get("stderr", ""),
-                    "error_type": result.get("error_type", ""),
-                }
+        from autoskillit.server import _get_ctx
+
+        tool_ctx = _get_ctx()
+        clone_mgr = tool_ctx.clone_mgr
+        if clone_mgr is None:
+            return json.dumps({"error": "Clone manager not configured", "stderr": ""})
+
+        _start = time.monotonic()
+        try:
+            result = await asyncio.to_thread(
+                lambda: clone_mgr.push_to_remote(
+                    clone_path,
+                    source_dir,
+                    branch,
+                    remote_url=remote_url,
+                    protected_branches=tool_ctx.config.safety.protected_branches,
+                    force=force.strip().lower() == "true",
+                )
             )
 
-        return json.dumps(result)
-    finally:
-        if step_name:
-            tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
+            if not result.get("success"):
+                await _notify(
+                    ctx,
+                    "error",
+                    "push_to_remote failed",
+                    "autoskillit.push_to_remote",
+                    extra={
+                        "stderr": result.get("stderr", ""),
+                        "error_type": result.get("error_type", ""),
+                    },
+                )
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": "push failed",
+                        "stderr": result.get("stderr", ""),
+                        "error_type": result.get("error_type", ""),
+                    }
+                )
+
+            return json.dumps(result)
+        finally:
+            if step_name:
+                tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
+    except Exception as exc:
+        logger.error("push_to_remote unhandled exception", exc_info=True)
+        return json.dumps(
+            {"success": False, "error": f"{type(exc).__name__}: {exc}", "stderr": ""}
+        )
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "clone"}, annotations={"readOnlyHint": False})
@@ -290,50 +304,56 @@ async def register_clone_status(
         registry_path: Absolute path to the shared registry file. Defaults to
                        .autoskillit/temp/clone-cleanup-registry.json in cwd.
         step_name: Optional YAML step key for wall-clock timing accumulation.
+
+    Never raises.
     """
     if (gate := _require_enabled()) is not None:
         return gate
-    structlog.contextvars.clear_contextvars()
-    structlog.contextvars.bind_contextvars(tool="register_clone_status", clone_path=clone_path)
-    logger.info("register_clone_status", clone_path=clone_path, status=status)
-
-    if status not in ("success", "error"):
-        return json.dumps(
-            {
-                "registered": "false",
-                "reason": f"Invalid status '{status}'. Must be 'success' or 'error'.",
-            }
-        )
-
-    from autoskillit.server import _get_ctx
-
-    tool_ctx = _get_ctx()
-    owner = tool_ctx.kitchen_id
-    if owner == "":
-        return json.dumps(
-            {
-                "registered": "false",
-                "reason": "no active kitchen (kitchen_id empty) — cannot register clone",
-            }
-        )
-    _start = time.monotonic()
-    typed_status: Literal["success", "error"] = "success" if status == "success" else "error"
     try:
-        result = await asyncio.to_thread(
-            clone_registry.register_clone,
-            clone_path,
-            typed_status,
-            owner,
-            registry_path,
-            tool_ctx.temp_dir,
-        )
-        return json.dumps(result)
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(tool="register_clone_status", clone_path=clone_path)
+        logger.info("register_clone_status", clone_path=clone_path, status=status)
+
+        if status not in ("success", "error"):
+            return json.dumps(
+                {
+                    "registered": "false",
+                    "reason": f"Invalid status '{status}'. Must be 'success' or 'error'.",
+                }
+            )
+
+        from autoskillit.server import _get_ctx
+
+        tool_ctx = _get_ctx()
+        owner = tool_ctx.kitchen_id
+        if owner == "":
+            return json.dumps(
+                {
+                    "registered": "false",
+                    "reason": "no active kitchen (kitchen_id empty) — cannot register clone",
+                }
+            )
+        _start = time.monotonic()
+        typed_status: Literal["success", "error"] = "success" if status == "success" else "error"
+        try:
+            result = await asyncio.to_thread(
+                clone_registry.register_clone,
+                clone_path,
+                typed_status,
+                owner,
+                registry_path,
+                tool_ctx.temp_dir,
+            )
+            return json.dumps(result)
+        except Exception as exc:
+            logger.warning("register_clone_status failed", exc_info=True)
+            return json.dumps({"registered": "false", "reason": str(exc)})
+        finally:
+            if step_name:
+                tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
     except Exception as exc:
-        logger.warning("register_clone_status failed", exc_info=True)
-        return json.dumps({"registered": "false", "reason": str(exc)})
-    finally:
-        if step_name:
-            tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
+        logger.error("register_clone_status unhandled exception", exc_info=True)
+        return json.dumps({"registered": "false", "reason": f"{type(exc).__name__}: {exc}"})
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "clone"}, annotations={"readOnlyHint": False})

--- a/src/autoskillit/server/tools_execution.py
+++ b/src/autoskillit/server/tools_execution.py
@@ -12,6 +12,7 @@ from fastmcp.dependencies import CurrentContext
 
 from autoskillit.core import (
     LayoutError,
+    SkillResult,
     ValidatedAddDir,
     get_logger,
     truncate_text,
@@ -325,6 +326,13 @@ async def run_skill(
                 label="quota_post_run_refresh",
             )
         return skill_result.to_json()
+    except Exception as exc:
+        logger.error("run_skill executor raised unexpectedly", exc_info=True)
+        return SkillResult.crashed(
+            exception=exc,
+            skill_command=resolved_command,
+            order_id=order_id,
+        ).to_json()
     finally:
         if step_name:
             tool_ctx.timing_log.record(step_name, time.monotonic() - _start, order_id=order_id)

--- a/src/autoskillit/server/tools_execution.py
+++ b/src/autoskillit/server/tools_execution.py
@@ -54,44 +54,59 @@ async def run_cmd(
         cwd: Working directory for the command.
         timeout: Max seconds before killing the process (default 600).
         step_name: Optional YAML step key for wall-clock timing accumulation.
+
+    Never raises.
     """
     if (headless := _require_not_headless("run_cmd")) is not None:
         return headless
     if (gate := _require_enabled()) is not None:
         return gate
-    structlog.contextvars.clear_contextvars()
-    structlog.contextvars.bind_contextvars(tool="run_cmd", cwd=cwd)
-    logger.info("run_cmd", cmd=cmd[:80], cwd=cwd)
-    await _notify(ctx, "info", f"run_cmd: {cmd[:80]}", "autoskillit.run_cmd", extra={"cwd": cwd})
-
-    from autoskillit.server import _get_ctx
-
-    tool_ctx = _get_ctx()
-    _start = time.monotonic()
     try:
-        returncode, stdout, stderr = await _run_subprocess(
-            ["bash", "-c", cmd],
-            cwd=cwd,
-            timeout=float(timeout),
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(tool="run_cmd", cwd=cwd)
+        logger.info("run_cmd", cmd=cmd[:80], cwd=cwd)
+        await _notify(
+            ctx, "info", f"run_cmd: {cmd[:80]}", "autoskillit.run_cmd", extra={"cwd": cwd}
         )
-        result = {
-            "success": returncode == 0,
-            "exit_code": returncode,
-            "stdout": truncate_text(stdout),
-            "stderr": truncate_text(stderr),
-        }
-        if not result["success"]:
-            await _notify(
-                ctx,
-                "error",
-                "run_cmd failed",
-                "autoskillit.run_cmd",
-                extra={"exit_code": returncode},
+
+        from autoskillit.server import _get_ctx
+
+        tool_ctx = _get_ctx()
+        _start = time.monotonic()
+        try:
+            returncode, stdout, stderr = await _run_subprocess(
+                ["bash", "-c", cmd],
+                cwd=cwd,
+                timeout=float(timeout),
             )
-        return json.dumps(result)
-    finally:
-        if step_name:
-            tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
+            result = {
+                "success": returncode == 0,
+                "exit_code": returncode,
+                "stdout": truncate_text(stdout),
+                "stderr": truncate_text(stderr),
+            }
+            if not result["success"]:
+                await _notify(
+                    ctx,
+                    "error",
+                    "run_cmd failed",
+                    "autoskillit.run_cmd",
+                    extra={"exit_code": returncode},
+                )
+            return json.dumps(result)
+        finally:
+            if step_name:
+                tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
+    except Exception as exc:
+        logger.error("run_cmd unhandled exception", exc_info=True)
+        return json.dumps(
+            {
+                "success": False,
+                "exit_code": -1,
+                "stdout": "",
+                "stderr": f"{type(exc).__name__}: {exc}",
+            }
+        )
 
 
 @mcp.tool(tags={"autoskillit", "kitchen"}, annotations={"readOnlyHint": True})
@@ -116,31 +131,37 @@ async def run_python(
         callable: Dotted path to the function (e.g. "mypackage.module.function").
         args: Keyword arguments to pass to the function.
         timeout: Max seconds before aborting the call (default 30).
+
+    Never raises.
     """
     if (headless := _require_not_headless("run_python")) is not None:
         return headless
     if (gate := _require_enabled()) is not None:
         return gate
-    structlog.contextvars.clear_contextvars()
-    structlog.contextvars.bind_contextvars(tool="run_python")
-    logger.info("run_python", callable=callable, timeout=timeout)
-    await _notify(
-        ctx,
-        "info",
-        f"run_python: {callable}",
-        "autoskillit.run_python",
-        extra={"callable": callable},
-    )
-    result = await _import_and_call(callable, args=args, timeout=float(timeout))
-    if not result.get("success"):
+    try:
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(tool="run_python")
+        logger.info("run_python", callable=callable, timeout=timeout)
         await _notify(
             ctx,
-            "error",
-            "run_python failed",
+            "info",
+            f"run_python: {callable}",
             "autoskillit.run_python",
             extra={"callable": callable},
         )
-    return json.dumps(result)
+        result = await _import_and_call(callable, args=args, timeout=float(timeout))
+        if not result.get("success"):
+            await _notify(
+                ctx,
+                "error",
+                "run_python failed",
+                "autoskillit.run_python",
+                extra={"callable": callable},
+            )
+        return json.dumps(result)
+    except Exception as exc:
+        logger.error("run_python unhandled exception", exc_info=True)
+        return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
 
 
 @mcp.tool(tags={"autoskillit", "kitchen"}, annotations={"readOnlyHint": True})
@@ -195,6 +216,8 @@ async def run_skill(
         idle_output_timeout: Override the idle stdout kill threshold in seconds.
             0 = disabled for this step. None = use global config
             (RunSkillConfig.idle_output_timeout, default 600s).
+
+    Never raises.
     """
     if (headless := _require_not_headless("run_skill")) is not None:
         return headless
@@ -213,126 +236,134 @@ async def run_skill(
                 ),
             }
         )
-    structlog.contextvars.clear_contextvars()
-    structlog.contextvars.bind_contextvars(tool="run_skill", cwd=cwd)
-    logger.info("run_skill", command=skill_command[:80], cwd=cwd)
-    await _notify(
-        ctx,
-        "info",
-        f"run_skill: {skill_command[:80]}",
-        "autoskillit.run_skill",
-        extra={"cwd": cwd, "model": model or "default"},
-    )
-
-    from autoskillit.server import _get_config, _get_ctx
-
-    if _get_config().safety.require_dry_walkthrough:
-        if (gate_error := _check_dry_walkthrough(skill_command, cwd)) is not None:
-            return gate_error
-
-    tool_ctx = _get_ctx()
-    if tool_ctx.executor is None:
-        return json.dumps({"success": False, "error": "Executor not configured"})
-
-    # Look up artifact validation patterns from skill contract
-    expected_output_patterns: list[str] = []
-    if tool_ctx.output_pattern_resolver:
-        expected_output_patterns = list(tool_ctx.output_pattern_resolver(skill_command))
-
-    # Look up write-expectation metadata from skill contract
-    from autoskillit.core import WriteBehaviorSpec
-
-    write_spec: WriteBehaviorSpec | None = None
-    if tool_ctx.write_expected_resolver:
-        write_spec = tool_ctx.write_expected_resolver(skill_command)
-
-    # Build validated add_dirs via DefaultSessionSkillManager
-    from pathlib import Path
-    from uuid import uuid4
-
-    from autoskillit.core import resolve_target_skill
-
-    # Resolve correct namespace and prepare for tier2 activation
-    resolved_command = skill_command
-    target_name: str | None = None
-    if tool_ctx.skill_resolver is not None:
-        resolved_command, target_name = resolve_target_skill(
-            skill_command, tool_ctx.skill_resolver
-        )
-
-    invocation_marker = f"%%ORDER_UP::{uuid4().hex[:8]}%%"
-
-    skill_add_dirs: list[ValidatedAddDir] = []
-    if tool_ctx.session_skill_manager is not None:
-        allow_only: frozenset[str] | None = None
-        if target_name:
-            closure = tool_ctx.session_skill_manager.compute_skill_closure(target_name)
-            allow_only = closure if closure else None
-
-        session_id = f"headless-{uuid4().hex[:12]}"
-        session_root = tool_ctx.session_skill_manager.init_session(
-            session_id,
-            cook_session=False,
-            config=tool_ctx.config,
-            project_dir=Path(cwd),
-            recipe_packs=tool_ctx.active_recipe_packs,
-            allow_only=allow_only,
-        )
-        skill_add_dirs.append(session_root)
-
-        # Activate the target skill and its declared dependencies
-        if target_name:
-            tool_ctx.session_skill_manager.activate_skill_deps(session_id, target_name)
     try:
-        skill_add_dirs.append(validate_add_dir(Path(cwd)))
-    except LayoutError:
-        pass  # cwd has no project-local skills — already accessible as working dir
-
-    _start = time.monotonic()
-    try:
-        skill_result = await tool_ctx.executor.run(
-            resolved_command,
-            cwd,
-            model=model,
-            add_dirs=skill_add_dirs,
-            step_name=step_name,
-            kitchen_id=tool_ctx.kitchen_id,
-            order_id=order_id,
-            expected_output_patterns=expected_output_patterns,
-            write_behavior=write_spec,
-            stale_threshold=float(stale_threshold) if stale_threshold is not None else None,
-            idle_output_timeout=float(idle_output_timeout)
-            if idle_output_timeout is not None
-            else None,
-            completion_marker=invocation_marker,
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(tool="run_skill", cwd=cwd)
+        logger.info("run_skill", command=skill_command[:80], cwd=cwd)
+        await _notify(
+            ctx,
+            "info",
+            f"run_skill: {skill_command[:80]}",
+            "autoskillit.run_skill",
+            extra={"cwd": cwd, "model": model or "default"},
         )
-        if skill_result.success:
-            tool_ctx.audit.record_success(skill_command)
-        else:
-            await _notify(
-                ctx,
-                "error",
-                "run_skill failed",
-                "autoskillit.run_skill",
-                extra={"exit_code": skill_result.exit_code, "subtype": skill_result.subtype},
-            )
-        if order_id:
-            skill_result.order_id = order_id
-        from autoskillit.server.helpers import _refresh_quota_cache  # noqa: PLC0415
 
-        if tool_ctx.background is not None:
-            tool_ctx.background.submit(
-                _refresh_quota_cache(tool_ctx.config.quota_guard),
-                label="quota_post_run_refresh",
+        from autoskillit.server import _get_config, _get_ctx
+
+        if _get_config().safety.require_dry_walkthrough:
+            if (gate_error := _check_dry_walkthrough(skill_command, cwd)) is not None:
+                return gate_error
+
+        tool_ctx = _get_ctx()
+        if tool_ctx.executor is None:
+            return json.dumps({"success": False, "error": "Executor not configured"})
+
+        # Look up artifact validation patterns from skill contract
+        expected_output_patterns: list[str] = []
+        if tool_ctx.output_pattern_resolver:
+            expected_output_patterns = list(tool_ctx.output_pattern_resolver(skill_command))
+
+        # Look up write-expectation metadata from skill contract
+        from autoskillit.core import WriteBehaviorSpec
+
+        write_spec: WriteBehaviorSpec | None = None
+        if tool_ctx.write_expected_resolver:
+            write_spec = tool_ctx.write_expected_resolver(skill_command)
+
+        # Build validated add_dirs via DefaultSessionSkillManager
+        from pathlib import Path
+        from uuid import uuid4
+
+        from autoskillit.core import resolve_target_skill
+
+        # Resolve correct namespace and prepare for tier2 activation
+        resolved_command = skill_command
+        target_name: str | None = None
+        if tool_ctx.skill_resolver is not None:
+            resolved_command, target_name = resolve_target_skill(
+                skill_command, tool_ctx.skill_resolver
             )
-        return skill_result.to_json()
+
+        invocation_marker = f"%%ORDER_UP::{uuid4().hex[:8]}%%"
+
+        skill_add_dirs: list[ValidatedAddDir] = []
+        if tool_ctx.session_skill_manager is not None:
+            allow_only: frozenset[str] | None = None
+            if target_name:
+                closure = tool_ctx.session_skill_manager.compute_skill_closure(target_name)
+                allow_only = closure if closure else None
+
+            session_id = f"headless-{uuid4().hex[:12]}"
+            session_root = tool_ctx.session_skill_manager.init_session(
+                session_id,
+                cook_session=False,
+                config=tool_ctx.config,
+                project_dir=Path(cwd),
+                recipe_packs=tool_ctx.active_recipe_packs,
+                allow_only=allow_only,
+            )
+            skill_add_dirs.append(session_root)
+
+            # Activate the target skill and its declared dependencies
+            if target_name:
+                tool_ctx.session_skill_manager.activate_skill_deps(session_id, target_name)
+        try:
+            skill_add_dirs.append(validate_add_dir(Path(cwd)))
+        except LayoutError:
+            pass  # cwd has no project-local skills — already accessible as working dir
+
+        _start = time.monotonic()
+        try:
+            skill_result = await tool_ctx.executor.run(
+                resolved_command,
+                cwd,
+                model=model,
+                add_dirs=skill_add_dirs,
+                step_name=step_name,
+                kitchen_id=tool_ctx.kitchen_id,
+                order_id=order_id,
+                expected_output_patterns=expected_output_patterns,
+                write_behavior=write_spec,
+                stale_threshold=float(stale_threshold) if stale_threshold is not None else None,
+                idle_output_timeout=float(idle_output_timeout)
+                if idle_output_timeout is not None
+                else None,
+                completion_marker=invocation_marker,
+            )
+            if skill_result.success:
+                tool_ctx.audit.record_success(skill_command)
+            else:
+                await _notify(
+                    ctx,
+                    "error",
+                    "run_skill failed",
+                    "autoskillit.run_skill",
+                    extra={"exit_code": skill_result.exit_code, "subtype": skill_result.subtype},
+                )
+            if order_id:
+                skill_result.order_id = order_id
+            from autoskillit.server.helpers import _refresh_quota_cache  # noqa: PLC0415
+
+            if tool_ctx.background is not None:
+                tool_ctx.background.submit(
+                    _refresh_quota_cache(tool_ctx.config.quota_guard),
+                    label="quota_post_run_refresh",
+                )
+            return skill_result.to_json()
+        except Exception as exc:
+            logger.error("run_skill executor raised unexpectedly", exc_info=True)
+            return SkillResult.crashed(
+                exception=exc,
+                skill_command=resolved_command,
+                order_id=order_id,
+            ).to_json()
+        finally:
+            if step_name:
+                tool_ctx.timing_log.record(step_name, time.monotonic() - _start, order_id=order_id)
     except Exception as exc:
-        logger.error("run_skill executor raised unexpectedly", exc_info=True)
+        logger.error("run_skill unhandled exception", exc_info=True)
         return SkillResult.crashed(
             exception=exc,
-            skill_command=resolved_command,
+            skill_command=skill_command,
             order_id=order_id,
         ).to_json()
-    finally:
-        if step_name:
-            tool_ctx.timing_log.record(step_name, time.monotonic() - _start, order_id=order_id)

--- a/src/autoskillit/server/tools_git.py
+++ b/src/autoskillit/server/tools_git.py
@@ -89,7 +89,7 @@ async def merge_worktree(
                 tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
     except Exception as exc:
         logger.error("merge_worktree unhandled exception", exc_info=True)
-        return json.dumps({"error": f"{type(exc).__name__}: {exc}"})
+        return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
 
 
 @mcp.tool(tags={"autoskillit", "kitchen"}, annotations={"readOnlyHint": True})

--- a/src/autoskillit/server/tools_git.py
+++ b/src/autoskillit/server/tools_git.py
@@ -41,49 +41,55 @@ async def merge_worktree(
         worktree_path: Absolute path to the git worktree.
         base_branch: Branch to merge into (e.g. "integration").
         step_name: Optional YAML step key for wall-clock timing accumulation.
+
+    Never raises.
     """
     if (gate := _require_enabled()) is not None:
         return gate
-    structlog.contextvars.clear_contextvars()
-    structlog.contextvars.bind_contextvars(tool="merge_worktree", cwd=worktree_path)
-    logger.info("merge_worktree", path=worktree_path, base=base_branch)
-    await _notify(
-        ctx,
-        "info",
-        f"merge_worktree: {worktree_path} -> {base_branch}",
-        "autoskillit.merge_worktree",
-        extra={"worktree": worktree_path, "base": base_branch},
-    )
-
-    from autoskillit.server import _get_config, _get_ctx
-    from autoskillit.server.git import perform_merge
-
-    tool_ctx = _get_ctx()
-    runner = tool_ctx.runner
-    assert runner is not None, "No subprocess runner configured"
-    _start = time.monotonic()
     try:
-        result = await perform_merge(
-            worktree_path,
-            base_branch,
-            config=_get_config(),
-            runner=runner,
-            tester=tool_ctx.tester,
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(tool="merge_worktree", cwd=worktree_path)
+        logger.info("merge_worktree", path=worktree_path, base=base_branch)
+        await _notify(
+            ctx,
+            "info",
+            f"merge_worktree: {worktree_path} -> {base_branch}",
+            "autoskillit.merge_worktree",
+            extra={"worktree": worktree_path, "base": base_branch},
         )
 
-        if "error" in result:
-            await _notify(
-                ctx,
-                "error",
-                "merge_worktree failed",
-                "autoskillit.merge_worktree",
-                extra={"reason": result["error"]},
+        from autoskillit.server import _get_config, _get_ctx
+        from autoskillit.server.git import perform_merge
+
+        tool_ctx = _get_ctx()
+        runner = tool_ctx.runner
+        assert runner is not None, "No subprocess runner configured"
+        _start = time.monotonic()
+        try:
+            result = await perform_merge(
+                worktree_path,
+                base_branch,
+                config=_get_config(),
+                runner=runner,
+                tester=tool_ctx.tester,
             )
 
-        return json.dumps(result)
-    finally:
-        if step_name:
-            tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
+            if "error" in result:
+                await _notify(
+                    ctx,
+                    "error",
+                    "merge_worktree failed",
+                    "autoskillit.merge_worktree",
+                    extra={"reason": result["error"]},
+                )
+
+            return json.dumps(result)
+        finally:
+            if step_name:
+                tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
+    except Exception as exc:
+        logger.error("merge_worktree unhandled exception", exc_info=True)
+        return json.dumps({"error": f"{type(exc).__name__}: {exc}"})
 
 
 @mcp.tool(tags={"autoskillit", "kitchen"}, annotations={"readOnlyHint": True})
@@ -111,109 +117,125 @@ async def classify_fix(
         worktree_path: Path to the git worktree with the implemented fix.
         base_branch: The branch the worktree was created from (for merge-base).
         step_name: Optional YAML step key for wall-clock timing accumulation.
+
+    Never raises.
     """
     if (gate := _require_enabled()) is not None:
         return gate
-    structlog.contextvars.clear_contextvars()
-    structlog.contextvars.bind_contextvars(tool="classify_fix", cwd=worktree_path)
-    logger.info("classify_fix", worktree=worktree_path, base=base_branch)
-    await _notify(
-        ctx,
-        "info",
-        f"classify_fix: {worktree_path}",
-        "autoskillit.classify_fix",
-        extra={"worktree": worktree_path, "base": base_branch},
-    )
+    try:
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(tool="classify_fix", cwd=worktree_path)
+        logger.info("classify_fix", worktree=worktree_path, base=base_branch)
+        await _notify(
+            ctx,
+            "info",
+            f"classify_fix: {worktree_path}",
+            "autoskillit.classify_fix",
+            extra={"worktree": worktree_path, "base": base_branch},
+        )
 
-    if not os.path.isdir(worktree_path):
+        if not os.path.isdir(worktree_path):
+            return json.dumps(
+                {
+                    "restart_scope": RestartScope.FULL_RESTART,
+                    "reason": (
+                        f"worktree_path does not exist or is not a directory: {worktree_path}"
+                    ),
+                    "critical_files": [],
+                    "all_changed_files": [],
+                }
+            )
+
+        from autoskillit.server import _get_config, _get_ctx
+        from autoskillit.server.git import _filter_changed_files
+
+        tool_ctx = _get_ctx()
+        _start = time.monotonic()
+        try:
+            fetch_rc, _, fetch_stderr = await _run_subprocess(
+                ["git", "fetch", "origin", base_branch],
+                cwd=worktree_path,
+                timeout=30,
+            )
+            if fetch_rc != 0:
+                return json.dumps(
+                    {
+                        "restart_scope": RestartScope.FULL_RESTART,
+                        "reason": (
+                            f"git fetch origin {base_branch} failed — "
+                            "remote-tracking ref may be stale. "
+                            f"git error: {(fetch_stderr or '').strip()[:200]}"
+                        ),
+                        "critical_files": [],
+                        "all_changed_files": [],
+                    }
+                )
+
+            returncode, stdout, stderr = await _run_subprocess(
+                ["git", "diff", "--name-only", f"origin/{base_branch}...HEAD"],
+                cwd=worktree_path,
+                timeout=30,
+            )
+
+            if returncode != 0:
+                await _notify(
+                    ctx,
+                    "error",
+                    "classify_fix: git diff failed (falling back to full_restart)",
+                    "autoskillit.classify_fix",
+                    extra={"worktree": worktree_path},
+                )
+                # A missing origin/<base_branch> ref (rc=128, "ambiguous argument" or
+                # "unknown revision") is treated as FULL_RESTART — conservative safe default.
+                # Any other git error also falls back to FULL_RESTART for the same reason:
+                # if we can't determine what changed, assume the worst.
+                return json.dumps(
+                    {
+                        "restart_scope": RestartScope.FULL_RESTART,
+                        "reason": (
+                            f"Cannot diff against origin/{base_branch}"
+                            f" — ref may not exist locally. "
+                            f"git error: {stderr.strip()[:200]}"
+                        ),
+                        "critical_files": [],
+                        "all_changed_files": [],
+                    }
+                )
+
+            prefixes = _get_config().classify_fix.path_prefixes
+            changed_files, critical_files = _filter_changed_files(stdout, prefixes)
+
+            if critical_files:
+                return json.dumps(
+                    {
+                        "restart_scope": RestartScope.FULL_RESTART,
+                        "reason": f"Fix touches critical paths: {', '.join(critical_files[:5])}",
+                        "critical_files": critical_files,
+                        "all_changed_files": changed_files,
+                    }
+                )
+
+            return json.dumps(
+                {
+                    "restart_scope": RestartScope.PARTIAL_RESTART,
+                    "reason": "Fix does not touch critical paths — partial restart is sufficient",
+                    "critical_files": [],
+                    "all_changed_files": changed_files,
+                }
+            )
+        finally:
+            if step_name:
+                tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
+    except Exception as exc:
+        logger.error("classify_fix unhandled exception", exc_info=True)
         return json.dumps(
             {
                 "restart_scope": RestartScope.FULL_RESTART,
-                "reason": f"worktree_path does not exist or is not a directory: {worktree_path}",
+                "reason": f"{type(exc).__name__}: {exc}",
                 "critical_files": [],
                 "all_changed_files": [],
             }
         )
-
-    from autoskillit.server import _get_config, _get_ctx
-    from autoskillit.server.git import _filter_changed_files
-
-    tool_ctx = _get_ctx()
-    _start = time.monotonic()
-    try:
-        fetch_rc, _, fetch_stderr = await _run_subprocess(
-            ["git", "fetch", "origin", base_branch],
-            cwd=worktree_path,
-            timeout=30,
-        )
-        if fetch_rc != 0:
-            return json.dumps(
-                {
-                    "restart_scope": RestartScope.FULL_RESTART,
-                    "reason": (
-                        f"git fetch origin {base_branch} failed — "
-                        "remote-tracking ref may be stale. "
-                        f"git error: {(fetch_stderr or '').strip()[:200]}"
-                    ),
-                    "critical_files": [],
-                    "all_changed_files": [],
-                }
-            )
-
-        returncode, stdout, stderr = await _run_subprocess(
-            ["git", "diff", "--name-only", f"origin/{base_branch}...HEAD"],
-            cwd=worktree_path,
-            timeout=30,
-        )
-
-        if returncode != 0:
-            await _notify(
-                ctx,
-                "error",
-                "classify_fix: git diff failed (falling back to full_restart)",
-                "autoskillit.classify_fix",
-                extra={"worktree": worktree_path},
-            )
-            # A missing origin/<base_branch> ref (rc=128, "ambiguous argument" or
-            # "unknown revision") is treated as FULL_RESTART — conservative safe default.
-            # Any other git error also falls back to FULL_RESTART for the same reason:
-            # if we can't determine what changed, assume the worst.
-            return json.dumps(
-                {
-                    "restart_scope": RestartScope.FULL_RESTART,
-                    "reason": (
-                        f"Cannot diff against origin/{base_branch} — ref may not exist locally. "
-                        f"git error: {stderr.strip()[:200]}"
-                    ),
-                    "critical_files": [],
-                    "all_changed_files": [],
-                }
-            )
-
-        prefixes = _get_config().classify_fix.path_prefixes
-        changed_files, critical_files = _filter_changed_files(stdout, prefixes)
-
-        if critical_files:
-            return json.dumps(
-                {
-                    "restart_scope": RestartScope.FULL_RESTART,
-                    "reason": f"Fix touches critical paths: {', '.join(critical_files[:5])}",
-                    "critical_files": critical_files,
-                    "all_changed_files": changed_files,
-                }
-            )
-
-        return json.dumps(
-            {
-                "restart_scope": RestartScope.PARTIAL_RESTART,
-                "reason": "Fix does not touch critical paths — partial restart is sufficient",
-                "critical_files": [],
-                "all_changed_files": changed_files,
-            }
-        )
-    finally:
-        if step_name:
-            tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "github"}, annotations={"readOnlyHint": True})
@@ -257,98 +279,106 @@ async def create_unique_branch(
         base_branch_name: When provided, use this directly as the base name
                           instead of composing from slug+issue_number.
         step_name: Optional YAML step key for wall-clock timing accumulation.
+
+    Never raises.
     """
     if (gate := _require_enabled()) is not None:
         return gate
-    structlog.contextvars.clear_contextvars()
-    structlog.contextvars.bind_contextvars(tool="create_unique_branch", cwd=cwd)
-    _display = base_branch_name if base_branch_name else slug
-    logger.info(
-        "create_unique_branch",
-        slug=slug,
-        issue_number=issue_number,
-        remote=remote,
-        base_branch_name=base_branch_name,
-    )
-    await _notify(
-        ctx,
-        "info",
-        f"create_unique_branch: {_display}",
-        "autoskillit.create_unique_branch",
-        extra={"remote": remote},
-    )
-
-    from autoskillit.server import _get_ctx
-
-    tool_ctx = _get_ctx()
-    _start = time.monotonic()
-
-    if base_branch_name:
-        base_name = base_branch_name
-    elif not slug:
-        return json.dumps(
-            {
-                "success": False,
-                "error": "create_unique_branch requires either base_branch_name or slug",
-            }
-        )
-    else:
-        base_name = f"{slug}-{issue_number}" if issue_number is not None else slug
-    branch_name = base_name
-    was_unique = True
-
     try:
-        rc, stdout, _ = await _run_subprocess(
-            ["git", "ls-remote", remote, f"refs/heads/{branch_name}"],
-            cwd=cwd,
-            timeout=30,
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(tool="create_unique_branch", cwd=cwd)
+        _display = base_branch_name if base_branch_name else slug
+        logger.info(
+            "create_unique_branch",
+            slug=slug,
+            issue_number=issue_number,
+            remote=remote,
+            base_branch_name=base_branch_name,
+        )
+        await _notify(
+            ctx,
+            "info",
+            f"create_unique_branch: {_display}",
+            "autoskillit.create_unique_branch",
+            extra={"remote": remote},
         )
 
-        if rc == 0 and stdout.strip():
-            was_unique = False
-            suffix = 2
-            _MAX_SUFFIX = 100
-            while suffix <= _MAX_SUFFIX:
-                candidate = f"{base_name}-{suffix}"
-                rc2, stdout2, _ = await _run_subprocess(
-                    ["git", "ls-remote", remote, f"refs/heads/{candidate}"],
-                    cwd=cwd,
-                    timeout=30,
-                )
-                if rc2 != 0:
-                    branch_name = candidate
-                    break
-                if not stdout2.strip():
-                    branch_name = candidate
-                    break
-                suffix += 1
+        from autoskillit.server import _get_ctx
 
-        rc_head, head_out, _ = await _run_subprocess(
-            ["git", "branch", "--show-current"],
-            cwd=cwd,
-            timeout=10,
-        )
-        base_ref = head_out.strip() if rc_head == 0 and head_out.strip() else "DETACHED_HEAD"
+        tool_ctx = _get_ctx()
+        _start = time.monotonic()
 
-        rc_checkout, _, _stderr_checkout = await _run_subprocess(
-            ["git", "checkout", "-b", branch_name],
-            cwd=cwd,
-            timeout=30,
-        )
-        if rc_checkout != 0:
+        if base_branch_name:
+            base_name = base_branch_name
+        elif not slug:
             return json.dumps(
                 {
                     "success": False,
-                    "error": f"git checkout -b {branch_name!r} failed: {_stderr_checkout.strip()}",
+                    "error": "create_unique_branch requires either base_branch_name or slug",
                 }
             )
+        else:
+            base_name = f"{slug}-{issue_number}" if issue_number is not None else slug
+        branch_name = base_name
+        was_unique = True
 
-        return json.dumps(
-            {"branch_name": branch_name, "was_unique": was_unique, "base_ref": base_ref}
-        )
-    finally:
-        if step_name:
-            tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
+        try:
+            rc, stdout, _ = await _run_subprocess(
+                ["git", "ls-remote", remote, f"refs/heads/{branch_name}"],
+                cwd=cwd,
+                timeout=30,
+            )
+
+            if rc == 0 and stdout.strip():
+                was_unique = False
+                suffix = 2
+                _MAX_SUFFIX = 100
+                while suffix <= _MAX_SUFFIX:
+                    candidate = f"{base_name}-{suffix}"
+                    rc2, stdout2, _ = await _run_subprocess(
+                        ["git", "ls-remote", remote, f"refs/heads/{candidate}"],
+                        cwd=cwd,
+                        timeout=30,
+                    )
+                    if rc2 != 0:
+                        branch_name = candidate
+                        break
+                    if not stdout2.strip():
+                        branch_name = candidate
+                        break
+                    suffix += 1
+
+            rc_head, head_out, _ = await _run_subprocess(
+                ["git", "branch", "--show-current"],
+                cwd=cwd,
+                timeout=10,
+            )
+            base_ref = head_out.strip() if rc_head == 0 and head_out.strip() else "DETACHED_HEAD"
+
+            rc_checkout, _, _stderr_checkout = await _run_subprocess(
+                ["git", "checkout", "-b", branch_name],
+                cwd=cwd,
+                timeout=30,
+            )
+            if rc_checkout != 0:
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": (
+                            f"git checkout -b {branch_name!r} failed: {_stderr_checkout.strip()}"
+                        ),
+                    }
+                )
+
+            return json.dumps(
+                {"branch_name": branch_name, "was_unique": was_unique, "base_ref": base_ref}
+            )
+        finally:
+            if step_name:
+                tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
+    except Exception as exc:
+        logger.error("create_unique_branch unhandled exception", exc_info=True)
+        return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "github"}, annotations={"readOnlyHint": True})
@@ -374,37 +404,43 @@ async def check_pr_mergeable(
         pr_number: GitHub pull request number.
         cwd: Working directory for gh commands.
         repo: Repository as owner/repo. Passed as -R flag when provided.
+
+    Never raises.
     """
     if (gate := _require_enabled()) is not None:
         return gate
-    structlog.contextvars.clear_contextvars()
-    structlog.contextvars.bind_contextvars(tool="check_pr_mergeable", cwd=cwd)
-    logger.info("check_pr_mergeable", pr_number=pr_number, repo=repo)
-    await _notify(
-        ctx,
-        "info",
-        f"check_pr_mergeable: #{pr_number}",
-        "autoskillit.check_pr_mergeable",
-        extra={"repo": repo},
-    )
-
-    cmd = ["gh", "pr", "view", str(pr_number), "--json", "mergeable,mergeStateStatus"]
-    if repo:
-        cmd.extend(["-R", repo])
-
-    rc, stdout, stderr = await _run_subprocess(cmd, cwd=cwd, timeout=30)
-    if rc != 0:
-        return json.dumps({"success": False, "error": stderr.strip() or "gh command failed"})
-
     try:
-        data = json.loads(stdout)
-    except json.JSONDecodeError:
-        return json.dumps({"success": False, "error": "Failed to parse gh output"})
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(tool="check_pr_mergeable", cwd=cwd)
+        logger.info("check_pr_mergeable", pr_number=pr_number, repo=repo)
+        await _notify(
+            ctx,
+            "info",
+            f"check_pr_mergeable: #{pr_number}",
+            "autoskillit.check_pr_mergeable",
+            extra={"repo": repo},
+        )
 
-    return json.dumps(
-        {
-            "mergeable": data.get("mergeable") == "MERGEABLE",
-            "merge_state_status": data.get("mergeStateStatus", ""),
-            "mergeable_status": data.get("mergeable", ""),
-        }
-    )
+        cmd = ["gh", "pr", "view", str(pr_number), "--json", "mergeable,mergeStateStatus"]
+        if repo:
+            cmd.extend(["-R", repo])
+
+        rc, stdout, stderr = await _run_subprocess(cmd, cwd=cwd, timeout=30)
+        if rc != 0:
+            return json.dumps({"success": False, "error": stderr.strip() or "gh command failed"})
+
+        try:
+            data = json.loads(stdout)
+        except json.JSONDecodeError:
+            return json.dumps({"success": False, "error": "Failed to parse gh output"})
+
+        return json.dumps(
+            {
+                "mergeable": data.get("mergeable") == "MERGEABLE",
+                "merge_state_status": data.get("mergeStateStatus", ""),
+                "mergeable_status": data.get("mergeable", ""),
+            }
+        )
+    except Exception as exc:
+        logger.error("check_pr_mergeable unhandled exception", exc_info=True)
+        return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})

--- a/src/autoskillit/server/tools_github.py
+++ b/src/autoskillit/server/tools_github.py
@@ -119,29 +119,35 @@ async def get_issue_title(issue_url: str) -> str:
     Args:
         issue_url: Full GitHub issue URL (https://github.com/owner/repo/issues/42)
                    or shorthand (owner/repo#42).
+
+    Never raises.
     """
     if (gate := _require_enabled()) is not None:
         return gate
-    from autoskillit.server import _get_config, _get_ctx
+    try:
+        from autoskillit.server import _get_config, _get_ctx
 
-    tool_ctx = _get_ctx()
-    if tool_ctx.github_client is None:
-        return json.dumps({"success": False, "error": "GitHub client not available."})
+        tool_ctx = _get_ctx()
+        if tool_ctx.github_client is None:
+            return json.dumps({"success": False, "error": "GitHub client not available."})
 
-    config = _get_config()
-    url = issue_url.strip()
-    if url.isdigit():
-        if not config.github.default_repo:
-            return json.dumps(
-                {
-                    "success": False,
-                    "error": "Bare issue number requires github.default_repo in config.",
-                }
-            )
-        url = f"{config.github.default_repo}#{url}"
+        config = _get_config()
+        url = issue_url.strip()
+        if url.isdigit():
+            if not config.github.default_repo:
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": "Bare issue number requires github.default_repo in config.",
+                    }
+                )
+            url = f"{config.github.default_repo}#{url}"
 
-    result = await tool_ctx.github_client.fetch_title(url)
-    return json.dumps(result)
+        result = await tool_ctx.github_client.fetch_title(url)
+        return json.dumps(result)
+    except Exception as exc:
+        logger.error("get_issue_title unhandled exception", exc_info=True)
+        return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "github"}, annotations={"readOnlyHint": True})
@@ -177,117 +183,126 @@ async def report_bug(
         severity: "non_blocking" (fire-and-forget) or "blocking" (await completion).
         model: Model override. Empty string = config default.
         step_name: Optional label for token tracking.
+
+    Never raises.
     """
     if (gate := _require_enabled()) is not None:
         return gate
-
-    with structlog.contextvars.bound_contextvars(tool="report_bug", cwd=cwd, severity=severity):
-        logger.info("report_bug", error_context=error_context[:80], severity=severity)
-        await _notify(
-            ctx,
-            "info",
-            f"report_bug: {error_context[:60]}",
-            "autoskillit.report_bug",
-            extra={"severity": severity, "cwd": cwd},
-        )
-
-        from autoskillit.server import _get_config, _get_ctx
-
-        tool_ctx = _get_ctx()
-        if tool_ctx.executor is None:
-            return json.dumps({"success": False, "error": "Executor not configured"})
-
-        config = _get_config()
-        cfg = config.report_bug
-
-        # Resolve and create the report directory up front so the path is stable
-        # before the (potentially background) session writes the file.
-        report_dir = Path(cfg.report_dir) if cfg.report_dir else tool_ctx.temp_dir / "bug-reports"
-        report_dir.mkdir(parents=True, exist_ok=True)
-        timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S")
-        report_path = report_dir / f"{timestamp}_report.md"
-
-        effective_model = model or cfg.model or ""
-        skill_command = (
-            f"/autoskillit:report-bug\n\n"
-            f"Error context:\n{error_context}\n\n"
-            f"Report output path: {report_path}"
-        )
-
-        log_dir = config.linux_tracing.log_dir if config.linux_tracing is not None else ""
-
-        expected_output_patterns: list[str] = []
-        if tool_ctx.output_pattern_resolver:
-            expected_output_patterns = list(tool_ctx.output_pattern_resolver(skill_command))
-
-        from autoskillit.core import WriteBehaviorSpec
-
-        write_spec: WriteBehaviorSpec | None = None
-        if tool_ctx.write_expected_resolver:
-            write_spec = tool_ctx.write_expected_resolver(skill_command)
-
-        if severity == "blocking":
-            result = await _run_report_session(
-                skill_command,
-                cwd,
-                report_path,
-                error_context,
-                tool_ctx.executor,
-                tool_ctx.github_client,
-                config,
-                effective_model,
-                step_name,
-                log_dir=log_dir,
-                expected_output_patterns=expected_output_patterns,
-                write_behavior=write_spec,
+    try:
+        with structlog.contextvars.bound_contextvars(
+            tool="report_bug", cwd=cwd, severity=severity
+        ):
+            logger.info("report_bug", error_context=error_context[:80], severity=severity)
+            await _notify(
+                ctx,
+                "info",
+                f"report_bug: {error_context[:60]}",
+                "autoskillit.report_bug",
+                extra={"severity": severity, "cwd": cwd},
             )
-            if not result["success"]:
-                await _notify(
-                    ctx,
-                    "error",
-                    "report_bug session failed",
-                    "autoskillit.report_bug",
-                    extra={"report_path": str(report_path)},
-                )
-            return json.dumps(result)
 
-        # Non-blocking: supervised background dispatch, return immediately.
-        status_path = report_path.with_suffix(".status.json")
-        atomic_write(
-            status_path,
-            json.dumps(
-                {"status": "pending", "dispatched_at": datetime.now(UTC).isoformat()},
-                indent=2,
-            ),
-        )
-        if tool_ctx.background is None:  # always set by ToolContext.__post_init__
-            raise RuntimeError("ToolContext.background not initialized")
-        tool_ctx.background.submit(
-            _run_report_session(
-                skill_command,
-                cwd,
-                report_path,
-                error_context,
-                tool_ctx.executor,
-                tool_ctx.github_client,
-                config,
-                effective_model,
-                step_name,
-                log_dir=log_dir,
-                expected_output_patterns=expected_output_patterns,
-                write_behavior=write_spec,
-                status_path=status_path,
-            ),
-            label=step_name or "report_bug",
-        )
-        return json.dumps(
-            {
-                "success": True,
-                "status": "dispatched",
-                "report_path": str(report_path),
-                "status_path": str(status_path),
-            }
-        )
+            from autoskillit.server import _get_config, _get_ctx
+
+            tool_ctx = _get_ctx()
+            if tool_ctx.executor is None:
+                return json.dumps({"success": False, "error": "Executor not configured"})
+
+            config = _get_config()
+            cfg = config.report_bug
+
+            # Resolve and create the report directory up front so the path is stable
+            # before the (potentially background) session writes the file.
+            report_dir = (
+                Path(cfg.report_dir) if cfg.report_dir else tool_ctx.temp_dir / "bug-reports"
+            )
+            report_dir.mkdir(parents=True, exist_ok=True)
+            timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S")
+            report_path = report_dir / f"{timestamp}_report.md"
+
+            effective_model = model or cfg.model or ""
+            skill_command = (
+                f"/autoskillit:report-bug\n\n"
+                f"Error context:\n{error_context}\n\n"
+                f"Report output path: {report_path}"
+            )
+
+            log_dir = config.linux_tracing.log_dir if config.linux_tracing is not None else ""
+
+            expected_output_patterns: list[str] = []
+            if tool_ctx.output_pattern_resolver:
+                expected_output_patterns = list(tool_ctx.output_pattern_resolver(skill_command))
+
+            from autoskillit.core import WriteBehaviorSpec
+
+            write_spec: WriteBehaviorSpec | None = None
+            if tool_ctx.write_expected_resolver:
+                write_spec = tool_ctx.write_expected_resolver(skill_command)
+
+            if severity == "blocking":
+                result = await _run_report_session(
+                    skill_command,
+                    cwd,
+                    report_path,
+                    error_context,
+                    tool_ctx.executor,
+                    tool_ctx.github_client,
+                    config,
+                    effective_model,
+                    step_name,
+                    log_dir=log_dir,
+                    expected_output_patterns=expected_output_patterns,
+                    write_behavior=write_spec,
+                )
+                if not result["success"]:
+                    await _notify(
+                        ctx,
+                        "error",
+                        "report_bug session failed",
+                        "autoskillit.report_bug",
+                        extra={"report_path": str(report_path)},
+                    )
+                return json.dumps(result)
+
+            # Non-blocking: supervised background dispatch, return immediately.
+            status_path = report_path.with_suffix(".status.json")
+            atomic_write(
+                status_path,
+                json.dumps(
+                    {"status": "pending", "dispatched_at": datetime.now(UTC).isoformat()},
+                    indent=2,
+                ),
+            )
+            if tool_ctx.background is None:  # always set by ToolContext.__post_init__
+                raise RuntimeError("ToolContext.background not initialized")
+            tool_ctx.background.submit(
+                _run_report_session(
+                    skill_command,
+                    cwd,
+                    report_path,
+                    error_context,
+                    tool_ctx.executor,
+                    tool_ctx.github_client,
+                    config,
+                    effective_model,
+                    step_name,
+                    log_dir=log_dir,
+                    expected_output_patterns=expected_output_patterns,
+                    write_behavior=write_spec,
+                    status_path=status_path,
+                ),
+                label=step_name or "report_bug",
+            )
+            return json.dumps(
+                {
+                    "success": True,
+                    "status": "dispatched",
+                    "report_path": str(report_path),
+                    "status_path": str(status_path),
+                }
+            )
+    except Exception as exc:
+        logger.error("report_bug unhandled exception", exc_info=True)
+        return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
 
 
 # ---------------------------------------------------------------------------

--- a/src/autoskillit/server/tools_issue_lifecycle.py
+++ b/src/autoskillit/server/tools_issue_lifecycle.py
@@ -190,77 +190,82 @@ async def prepare_issue(
         labels: Additional labels to apply beyond triage labels (optional).
         dry_run: When True, classifies and previews without creating or labeling.
         split: When True, splits mixed-concern issues into sub-issues automatically.
+
+    Never raises.
     """
     if (gate := _require_enabled()) is not None:
         return gate
-
-    structlog.contextvars.clear_contextvars()
-    structlog.contextvars.bind_contextvars(tool="prepare_issue", title=title[:60])
-    logger.info("prepare_issue", title=title[:60], dry_run=dry_run, split=split)
-    await _notify(
-        ctx,
-        "info",
-        f"prepare_issue: {title[:60]}",
-        "autoskillit.prepare_issue",
-        extra={"dry_run": dry_run, "split": split},
-    )
-
-    from autoskillit.server import _get_ctx
-
-    tool_ctx = _get_ctx()
-    if tool_ctx.executor is None:
-        return json.dumps({"success": False, "error": "Executor not configured"})
-
-    if labels:
-        if err := tool_ctx.config.github.check_labels_allowed(labels):
-            return json.dumps({"success": False, "error": err})
-
-    skill_command = _build_prepare_skill_command(title, body, repo, labels, dry_run, split)
-
-    expected_output_patterns: list[str] = []
-    if tool_ctx.output_pattern_resolver:
-        expected_output_patterns = list(tool_ctx.output_pattern_resolver(skill_command))
-
-    write_spec: WriteBehaviorSpec | None = None
-    if tool_ctx.write_expected_resolver:
-        write_spec = tool_ctx.write_expected_resolver(skill_command)
-
-    result = await tool_ctx.executor.run(
-        skill_command,
-        str(Path.cwd()),
-        expected_output_patterns=expected_output_patterns,
-        write_behavior=write_spec,
-    )
-
-    if not result.success:
-        return json.dumps(
-            _build_headless_error_response(result, error=_retry_reason_to_error(result))
+    try:
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(tool="prepare_issue", title=title[:60])
+        logger.info("prepare_issue", title=title[:60], dry_run=dry_run, split=split)
+        await _notify(
+            ctx,
+            "info",
+            f"prepare_issue: {title[:60]}",
+            "autoskillit.prepare_issue",
+            extra={"dry_run": dry_run, "split": split},
         )
 
-    if result.result is None or not result.result.strip():
-        return json.dumps(
-            _build_headless_error_response(
-                result,
-                error="session completed but output was empty (drain race)",
+        from autoskillit.server import _get_ctx
+
+        tool_ctx = _get_ctx()
+        if tool_ctx.executor is None:
+            return json.dumps({"success": False, "error": "Executor not configured"})
+
+        if labels:
+            if err := tool_ctx.config.github.check_labels_allowed(labels):
+                return json.dumps({"success": False, "error": err})
+
+        skill_command = _build_prepare_skill_command(title, body, repo, labels, dry_run, split)
+
+        expected_output_patterns: list[str] = []
+        if tool_ctx.output_pattern_resolver:
+            expected_output_patterns = list(tool_ctx.output_pattern_resolver(skill_command))
+
+        write_spec: WriteBehaviorSpec | None = None
+        if tool_ctx.write_expected_resolver:
+            write_spec = tool_ctx.write_expected_resolver(skill_command)
+
+        result = await tool_ctx.executor.run(
+            skill_command,
+            str(Path.cwd()),
+            expected_output_patterns=expected_output_patterns,
+            write_behavior=write_spec,
+        )
+
+        if not result.success:
+            return json.dumps(
+                _build_headless_error_response(result, error=_retry_reason_to_error(result))
             )
+
+        if result.result is None or not result.result.strip():
+            return json.dumps(
+                _build_headless_error_response(
+                    result,
+                    error="session completed but output was empty (drain race)",
+                )
+            )
+
+        parsed = _parse_prepare_result(result.result)
+        # Distinguish block-parse failures (block absent or malformed JSON) from skill-level data.
+        # The sentinel errors from _parse_prepare_result signal a block-extraction failure —
+        # these are not the same as skill-internal errors embedded in a valid block.
+        if parsed.get("error") in _BLOCK_PARSE_ERRORS:
+            return json.dumps(_build_headless_error_response(result, error=parsed["error"]))
+
+        # Block parsed successfully. result.success=True is the authoritative signal —
+        # the parsed block's "success" field (if any) must not overwrite it.
+        return json.dumps(
+            {
+                "success": True,
+                "status": "complete",
+                **_without_success_key(parsed),
+            }
         )
-
-    parsed = _parse_prepare_result(result.result)
-    # Distinguish block-parse failures (block absent or malformed JSON) from skill-level data.
-    # The sentinel errors from _parse_prepare_result signal a block-extraction failure —
-    # these are not the same as skill-internal errors embedded in a valid block.
-    if parsed.get("error") in _BLOCK_PARSE_ERRORS:
-        return json.dumps(_build_headless_error_response(result, error=parsed["error"]))
-
-    # Block parsed successfully. result.success=True is the authoritative signal —
-    # the parsed block's "success" field (if any) must not overwrite it.
-    return json.dumps(
-        {
-            "success": True,
-            "status": "complete",
-            **_without_success_key(parsed),
-        }
-    )
+    except Exception as exc:
+        logger.error("prepare_issue unhandled exception", exc_info=True)
+        return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "github"}, annotations={"readOnlyHint": True})
@@ -291,73 +296,78 @@ async def enrich_issues(
         batch: Filter candidates by batch:N label in addition to recipe:implementation.
         dry_run: When True, previews generated requirements without editing issues.
         repo: Target repository as owner/repo. Falls back to gh default repo if None.
+
+    Never raises.
     """
     if (gate := _require_enabled()) is not None:
         return gate
-
-    structlog.contextvars.clear_contextvars()
-    structlog.contextvars.bind_contextvars(
-        tool="enrich_issues",
-        issue_number=issue_number,
-        batch=batch,
-        dry_run=dry_run,
-    )
-    logger.info("enrich_issues", issue_number=issue_number, batch=batch, dry_run=dry_run)
-    await _notify(
-        ctx,
-        "info",
-        "enrich_issues: backfilling requirements on recipe:implementation issues",
-        "autoskillit.enrich_issues",
-        extra={"dry_run": dry_run},
-    )
-
-    from autoskillit.server import _get_ctx
-
-    tool_ctx = _get_ctx()
-    if tool_ctx.executor is None:
-        return json.dumps({"success": False, "error": "Executor not configured"})
-
-    skill_command = _build_enrich_skill_command(issue_number, batch, dry_run, repo)
-
-    expected_output_patterns: list[str] = []
-    if tool_ctx.output_pattern_resolver:
-        expected_output_patterns = list(tool_ctx.output_pattern_resolver(skill_command))
-
-    write_spec: WriteBehaviorSpec | None = None
-    if tool_ctx.write_expected_resolver:
-        write_spec = tool_ctx.write_expected_resolver(skill_command)
-
-    result = await tool_ctx.executor.run(
-        skill_command,
-        str(Path.cwd()),
-        expected_output_patterns=expected_output_patterns,
-        write_behavior=write_spec,
-    )
-
-    if not result.success:
-        return json.dumps(
-            _build_headless_error_response(result, error=_retry_reason_to_error(result))
+    try:
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(
+            tool="enrich_issues",
+            issue_number=issue_number,
+            batch=batch,
+            dry_run=dry_run,
+        )
+        logger.info("enrich_issues", issue_number=issue_number, batch=batch, dry_run=dry_run)
+        await _notify(
+            ctx,
+            "info",
+            "enrich_issues: backfilling requirements on recipe:implementation issues",
+            "autoskillit.enrich_issues",
+            extra={"dry_run": dry_run},
         )
 
-    if result.result is None or not result.result.strip():
-        return json.dumps(
-            _build_headless_error_response(
-                result,
-                error="session completed but output was empty (drain race)",
+        from autoskillit.server import _get_ctx
+
+        tool_ctx = _get_ctx()
+        if tool_ctx.executor is None:
+            return json.dumps({"success": False, "error": "Executor not configured"})
+
+        skill_command = _build_enrich_skill_command(issue_number, batch, dry_run, repo)
+
+        expected_output_patterns: list[str] = []
+        if tool_ctx.output_pattern_resolver:
+            expected_output_patterns = list(tool_ctx.output_pattern_resolver(skill_command))
+
+        write_spec: WriteBehaviorSpec | None = None
+        if tool_ctx.write_expected_resolver:
+            write_spec = tool_ctx.write_expected_resolver(skill_command)
+
+        result = await tool_ctx.executor.run(
+            skill_command,
+            str(Path.cwd()),
+            expected_output_patterns=expected_output_patterns,
+            write_behavior=write_spec,
+        )
+
+        if not result.success:
+            return json.dumps(
+                _build_headless_error_response(result, error=_retry_reason_to_error(result))
             )
+
+        if result.result is None or not result.result.strip():
+            return json.dumps(
+                _build_headless_error_response(
+                    result,
+                    error="session completed but output was empty (drain race)",
+                )
+            )
+
+        parsed = _parse_enrich_result(result.result)
+        if parsed.get("error") in _BLOCK_PARSE_ERRORS:
+            return json.dumps(_build_headless_error_response(result, error=parsed["error"]))
+
+        return json.dumps(
+            {
+                "success": True,
+                "status": "complete",
+                **_without_success_key(parsed),
+            }
         )
-
-    parsed = _parse_enrich_result(result.result)
-    if parsed.get("error") in _BLOCK_PARSE_ERRORS:
-        return json.dumps(_build_headless_error_response(result, error=parsed["error"]))
-
-    return json.dumps(
-        {
-            "success": True,
-            "status": "complete",
-            **_without_success_key(parsed),
-        }
-    )
+    except Exception as exc:
+        logger.error("enrich_issues unhandled exception", exc_info=True)
+        return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "github"}, annotations={"readOnlyHint": True})
@@ -384,83 +394,88 @@ async def claim_issue(
         allow_reentry: When True and the in-progress label is already present, returns
                        claimed=True with reentry=True instead of claimed=False. Used by
                        process-issues to re-enter recipes for upfront-claimed issues.
+
+    Never raises.
     """
     if (gate := _require_enabled()) is not None:
         return gate
-
-    structlog.contextvars.clear_contextvars()
-    structlog.contextvars.bind_contextvars(tool="claim_issue", issue_url=issue_url)
-    logger.info("claim_issue", issue_url=issue_url)
-
-    from autoskillit.server import _get_ctx
-
-    tool_ctx = _get_ctx()
-    if tool_ctx.github_client is None:
-        return json.dumps(
-            {"success": False, "error": "GitHub token required for label management"}
-        )
-
-    effective_label = label or tool_ctx.config.github.in_progress_label
-
     try:
-        owner, repo, issue_number = _parse_issue_ref(issue_url)
-    except ValueError as exc:
-        return json.dumps({"success": False, "error": str(exc)})
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(tool="claim_issue", issue_url=issue_url)
+        logger.info("claim_issue", issue_url=issue_url)
 
-    if err := tool_ctx.config.github.check_label_allowed(effective_label):
-        return json.dumps({"success": False, "error": err})
+        from autoskillit.server import _get_ctx
 
-    result = await tool_ctx.github_client.fetch_issue(issue_url, include_comments=False)
-    if not result.get("success"):
-        return json.dumps({"success": False, "error": result.get("error", "fetch failed")})
+        tool_ctx = _get_ctx()
+        if tool_ctx.github_client is None:
+            return json.dumps(
+                {"success": False, "error": "GitHub token required for label management"}
+            )
 
-    current_labels = _extract_label_names(result.get("labels", []))
-    if effective_label in current_labels:
-        if allow_reentry:
+        effective_label = label or tool_ctx.config.github.in_progress_label
+
+        try:
+            owner, repo, issue_number = _parse_issue_ref(issue_url)
+        except ValueError as exc:
+            return json.dumps({"success": False, "error": str(exc)})
+
+        if err := tool_ctx.config.github.check_label_allowed(effective_label):
+            return json.dumps({"success": False, "error": err})
+
+        result = await tool_ctx.github_client.fetch_issue(issue_url, include_comments=False)
+        if not result.get("success"):
+            return json.dumps({"success": False, "error": result.get("error", "fetch failed")})
+
+        current_labels = _extract_label_names(result.get("labels", []))
+        if effective_label in current_labels:
+            if allow_reentry:
+                return json.dumps(
+                    {
+                        "success": True,
+                        "claimed": True,
+                        "reentry": True,
+                        "issue_number": issue_number,
+                        "label": effective_label,
+                    }
+                )
             return json.dumps(
                 {
                     "success": True,
-                    "claimed": True,
-                    "reentry": True,
-                    "issue_number": issue_number,
-                    "label": effective_label,
+                    "claimed": False,
+                    "reason": (
+                        f"Issue #{issue_number} already has '{effective_label}' label"
+                        " — another session may be processing it"
+                    ),
                 }
             )
+
+        await tool_ctx.github_client.ensure_label(
+            owner,
+            repo,
+            effective_label,
+            color="fbca04",
+            description="Issue is actively being processed by a pipeline session",
+        )
+
+        add_result = await tool_ctx.github_client.add_labels(
+            owner, repo, issue_number, [effective_label]
+        )
+        if not add_result.get("success"):
+            return json.dumps(
+                {"success": False, "error": add_result.get("error", "add_labels failed")}
+            )
+
         return json.dumps(
             {
                 "success": True,
-                "claimed": False,
-                "reason": (
-                    f"Issue #{issue_number} already has '{effective_label}' label"
-                    " — another session may be processing it"
-                ),
+                "claimed": True,
+                "issue_number": issue_number,
+                "label": effective_label,
             }
         )
-
-    await tool_ctx.github_client.ensure_label(
-        owner,
-        repo,
-        effective_label,
-        color="fbca04",
-        description="Issue is actively being processed by a pipeline session",
-    )
-
-    add_result = await tool_ctx.github_client.add_labels(
-        owner, repo, issue_number, [effective_label]
-    )
-    if not add_result.get("success"):
-        return json.dumps(
-            {"success": False, "error": add_result.get("error", "add_labels failed")}
-        )
-
-    return json.dumps(
-        {
-            "success": True,
-            "claimed": True,
-            "issue_number": issue_number,
-            "label": effective_label,
-        }
-    )
+    except Exception as exc:
+        logger.error("claim_issue unhandled exception", exc_info=True)
+        return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "github"}, annotations={"readOnlyHint": True})
@@ -487,96 +502,107 @@ async def release_issue(
         label: Label name to remove. Defaults to github.in_progress_label from config.
         target_branch: Branch the PR was merged into. When non-default, applies staged label.
         staged_label: Label name for staged state. Defaults to github.staged_label from config.
+
+    Never raises.
     """
     if (gate := _require_enabled()) is not None:
         return gate
-
-    structlog.contextvars.clear_contextvars()
-    structlog.contextvars.bind_contextvars(tool="release_issue", issue_url=issue_url)
-    logger.info("release_issue", issue_url=issue_url)
-
-    from autoskillit.server import _get_ctx
-
-    tool_ctx = _get_ctx()
-    if tool_ctx.github_client is None:
-        return json.dumps(
-            {"success": False, "error": "GitHub token required for label management"}
-        )
-
-    effective_label = label or tool_ctx.config.github.in_progress_label
-
     try:
-        owner, repo, issue_number = _parse_issue_ref(issue_url)
-    except ValueError as exc:
-        return json.dumps({"success": False, "error": str(exc)})
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(tool="release_issue", issue_url=issue_url)
+        logger.info("release_issue", issue_url=issue_url)
 
-    result = await tool_ctx.github_client.remove_label(owner, repo, issue_number, effective_label)
-    if not result.get("success", False):
+        from autoskillit.server import _get_ctx
+
+        tool_ctx = _get_ctx()
+        if tool_ctx.github_client is None:
+            return json.dumps(
+                {"success": False, "error": "GitHub token required for label management"}
+            )
+
+        effective_label = label or tool_ctx.config.github.in_progress_label
+
+        try:
+            owner, repo, issue_number = _parse_issue_ref(issue_url)
+        except ValueError as exc:
+            return json.dumps({"success": False, "error": str(exc)})
+
+        result = await tool_ctx.github_client.remove_label(
+            owner, repo, issue_number, effective_label
+        )
+        if not result.get("success", False):
+            return json.dumps(
+                {
+                    "success": False,
+                    "issue_number": issue_number,
+                    "label": effective_label,
+                    "staged": False,
+                    "staged_label": None,
+                }
+            )
+
+        # Determine if staging is needed
+        promotion_target = tool_ctx.config.branching.promotion_target
+        should_stage = target_branch is not None and target_branch != promotion_target
+
+        staged = False
+        effective_staged_label = staged_label or tool_ctx.config.github.staged_label
+
+        if should_stage:
+            if err := tool_ctx.config.github.check_label_allowed(effective_staged_label):
+                return json.dumps(
+                    {
+                        "success": False,
+                        "issue_number": issue_number,
+                        "label": effective_staged_label,
+                        "error": err,
+                    }
+                )
+
+            ensure_result = await tool_ctx.github_client.ensure_label(
+                owner,
+                repo,
+                effective_staged_label,
+                color="0075ca",
+                description=(
+                    f"Implementation staged and waiting for promotion to {promotion_target}"
+                ),
+            )
+            if not ensure_result.get("success"):
+                return json.dumps(
+                    {
+                        "success": False,
+                        "issue_number": issue_number,
+                        "label": effective_label,
+                        "error": (
+                            f"Failed to ensure staged label: {ensure_result.get('error', '?')}"
+                        ),
+                    }
+                )
+
+            apply_result = await tool_ctx.github_client.add_labels(
+                owner, repo, issue_number, [effective_staged_label]
+            )
+            if not apply_result.get("success"):
+                return json.dumps(
+                    {
+                        "success": False,
+                        "issue_number": issue_number,
+                        "label": effective_label,
+                        "error": f"Failed to apply staged label: {apply_result.get('error', '?')}",
+                    }
+                )
+            staged = True
+
         return json.dumps(
             {
-                "success": False,
+                "success": True,
                 "issue_number": issue_number,
                 "label": effective_label,
-                "staged": False,
-                "staged_label": None,
+                "staged": staged,
+                "staged_label": effective_staged_label if staged else None,
             }
         )
-
-    # Determine if staging is needed
-    promotion_target = tool_ctx.config.branching.promotion_target
-    should_stage = target_branch is not None and target_branch != promotion_target
-
-    staged = False
-    effective_staged_label = staged_label or tool_ctx.config.github.staged_label
-
-    if should_stage:
-        if err := tool_ctx.config.github.check_label_allowed(effective_staged_label):
-            return json.dumps(
-                {
-                    "success": False,
-                    "issue_number": issue_number,
-                    "label": effective_staged_label,
-                    "error": err,
-                }
-            )
-
-        ensure_result = await tool_ctx.github_client.ensure_label(
-            owner,
-            repo,
-            effective_staged_label,
-            color="0075ca",
-            description=(f"Implementation staged and waiting for promotion to {promotion_target}"),
-        )
-        if not ensure_result.get("success"):
-            return json.dumps(
-                {
-                    "success": False,
-                    "issue_number": issue_number,
-                    "label": effective_label,
-                    "error": (f"Failed to ensure staged label: {ensure_result.get('error', '?')}"),
-                }
-            )
-
-        apply_result = await tool_ctx.github_client.add_labels(
-            owner, repo, issue_number, [effective_staged_label]
-        )
-        if not apply_result.get("success"):
-            return json.dumps(
-                {
-                    "success": False,
-                    "issue_number": issue_number,
-                    "label": effective_label,
-                    "error": f"Failed to apply staged label: {apply_result.get('error', '?')}",
-                }
-            )
-        staged = True
-
-    return json.dumps(
-        {
-            "success": True,
-            "issue_number": issue_number,
-            "label": effective_label,
-            "staged": staged,
-            "staged_label": effective_staged_label if staged else None,
-        }
-    )
+    except Exception as exc:
+        logger.error("release_issue unhandled exception", exc_info=True)
+        return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})

--- a/src/autoskillit/server/tools_kitchen.py
+++ b/src/autoskillit/server/tools_kitchen.py
@@ -425,4 +425,4 @@ async def close_kitchen(ctx: Context = CurrentContext()) -> str:
         return "Kitchen is closed."
     except Exception as exc:
         logger.error("close_kitchen unhandled exception", exc_info=True)
-        return json.dumps({"error": f"{type(exc).__name__}: {exc}"})
+        return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})

--- a/src/autoskillit/server/tools_kitchen.py
+++ b/src/autoskillit/server/tools_kitchen.py
@@ -245,103 +245,148 @@ async def open_kitchen(
         name: Optional recipe name to load immediately after opening.
         overrides: Optional dict of ingredient name → value to override recipe defaults.
             Use to activate hidden features (e.g., ``{"sprint_mode": "true"}``).
+
+    Never raises.
     """
-    # Headless guard — wrap denial in envelope shape
-    if (h := _require_not_headless("open_kitchen")) is not None:
-        parsed_h = json.loads(h)
-        return json.dumps(
-            {
-                "success": False,
-                "kitchen": "failed",
-                "user_visible_message": parsed_h.get(
-                    "result",
-                    "open_kitchen cannot be called from headless sessions.",
-                ),
-                "error": "HeadlessDenied",
-                "stage": "headless_guard",
-            }
+    try:
+        # Headless guard — wrap denial in envelope shape
+        if (h := _require_not_headless("open_kitchen")) is not None:
+            parsed_h = json.loads(h)
+            return json.dumps(
+                {
+                    "success": False,
+                    "kitchen": "failed",
+                    "user_visible_message": parsed_h.get(
+                        "result",
+                        "open_kitchen cannot be called from headless sessions.",
+                    ),
+                    "error": "HeadlessDenied",
+                    "stage": "headless_guard",
+                }
+            )
+
+        from autoskillit.server import _get_ctx  # noqa: PLC0415
+
+        disabled_subsets = _get_ctx().config.subsets.disabled
+
+        handler_err = await _open_kitchen_handler()
+        if handler_err is not None:
+            return handler_err
+
+        try:
+            await ctx.enable_components(tags={"kitchen"})
+        except Exception as exc:
+            logger.warning("open_kitchen_failure", stage="enable_components", exc_info=True)
+            return _kitchen_failure_envelope(exc, stage="enable_components")
+
+        try:
+            await _redisable_subsets(ctx, disabled_subsets)
+        except Exception as exc:
+            logger.warning("open_kitchen_failure", stage="redisable_subsets", exc_info=True)
+            return _kitchen_failure_envelope(exc, stage="redisable_subsets")
+
+        _forbidden_list = ", ".join(PIPELINE_FORBIDDEN_TOOLS)
+        _categories = _build_tool_category_listing()
+
+        if name is not None:
+            tool_ctx = _get_ctx()
+            if tool_ctx.recipes is None:
+                return _kitchen_failure_envelope(
+                    RuntimeError("Server not initialized"),
+                    stage="recipe_context",
+                    user_hint=(
+                        "open_kitchen cannot load a recipe because the server is not "
+                        "initialized. Run 'autoskillit doctor' to diagnose."
+                    ),
+                )
+            suppressed = tool_ctx.config.migration.suppressed
+            _defaults = resolve_ingredient_defaults(Path.cwd())
+            # Runtime enum check: output_mode must be validated before recipe loading
+            if name == "research":
+                _om_value = (overrides or {}).get("output_mode")
+                if _om_value is not None and _om_value not in {"pr", "local"}:
+                    return json.dumps(
+                        {
+                            "error": (
+                                f"output_mode must be 'pr' or 'local', got {_om_value!r}. "
+                                "Only two modes are supported for the research recipe."
+                            )
+                        }
+                    )
+            try:
+                result = tool_ctx.recipes.load_and_validate(
+                    name,
+                    Path.cwd(),
+                    suppressed=suppressed,
+                    resolved_defaults=_defaults,
+                    ingredient_overrides=overrides,
+                )
+            except Exception as exc:
+                logger.warning("open_kitchen_failure", stage="load_and_validate", exc_info=True)
+                return _kitchen_failure_envelope(exc, stage="load_and_validate")
+
+            tool_ctx.active_recipe_packs = frozenset(result.get("requires_packs", []))
+
+            try:
+                recipe_info = tool_ctx.recipes.find(name, Path.cwd())
+            except Exception as exc:
+                logger.warning("open_kitchen_failure", stage="recipe_find", exc_info=True)
+                return _kitchen_failure_envelope(exc, stage="recipe_find")
+
+            try:
+                result = await _apply_triage_gate(result, name, recipe_info=recipe_info)
+            except Exception as exc:
+                logger.warning("open_kitchen_failure", stage="apply_triage_gate", exc_info=True)
+                return _kitchen_failure_envelope(exc, stage="apply_triage_gate")
+
+            result["success"] = True
+            result["kitchen"] = "open"
+            result["version"] = __version__
+
+            if "ingredients_table" not in result or not result["ingredients_table"]:
+                result["ingredients_table"] = None
+
+            try:
+                warning = _build_hook_diagnostic_warning()
+            except Exception as exc:
+                logger.warning("open_kitchen_failure", stage="hook_diagnostic", exc_info=True)
+                return _kitchen_failure_envelope(exc, stage="hook_diagnostic")
+            if warning:
+                result["hook_warning"] = warning.strip()
+            return json.dumps(result)
+
+        text = (
+            f"Kitchen is open. AutoSkillit {__version__}. Tools are ready for service.\n\n"
+            f"Available Tools by Category:\n{_categories}\n\n"
+            "IMPORTANT — Orchestrator Discipline:\n"
+            f"NEVER use native Claude Code tools ({_forbidden_list}) "
+            "in this session. All code reading, searching, editing, and "
+            "investigation MUST be delegated through run_skill, which launches "
+            "headless sessions with full tool access. Do NOT use native tools to "
+            "investigate failures — route to on_failure "
+            "and let the downstream skill handle diagnosis."
         )
 
-    from autoskillit.server import _get_ctx  # noqa: PLC0415
+        # Inject sous-chef global orchestration rules (graceful degradation if absent)
+        _sous_chef_path = pkg_root() / "skills" / "sous-chef" / "SKILL.md"
+        try:
+            if _sous_chef_path.exists():
+                text += "\n\n" + _sous_chef_path.read_text()
+        except Exception as exc:
+            logger.warning("open_kitchen_failure", stage="read_sous_chef", exc_info=True)
+            return _kitchen_failure_envelope(exc, stage="read_sous_chef")
 
-    disabled_subsets = _get_ctx().config.subsets.disabled
-
-    handler_err = await _open_kitchen_handler()
-    if handler_err is not None:
-        return handler_err
-
-    try:
-        await ctx.enable_components(tags={"kitchen"})
-    except Exception as exc:
-        logger.warning("open_kitchen_failure", stage="enable_components", exc_info=True)
-        return _kitchen_failure_envelope(exc, stage="enable_components")
-
-    try:
-        await _redisable_subsets(ctx, disabled_subsets)
-    except Exception as exc:
-        logger.warning("open_kitchen_failure", stage="redisable_subsets", exc_info=True)
-        return _kitchen_failure_envelope(exc, stage="redisable_subsets")
-
-    _forbidden_list = ", ".join(PIPELINE_FORBIDDEN_TOOLS)
-    _categories = _build_tool_category_listing()
-
-    if name is not None:
-        tool_ctx = _get_ctx()
-        if tool_ctx.recipes is None:
-            return _kitchen_failure_envelope(
-                RuntimeError("Server not initialized"),
-                stage="recipe_context",
-                user_hint=(
-                    "open_kitchen cannot load a recipe because the server is not "
-                    "initialized. Run 'autoskillit doctor' to diagnose."
-                ),
+        # Check if the project needs an upgrade
+        scripts_dir = Path.cwd() / ".autoskillit" / "scripts"
+        recipes_dir = Path.cwd() / ".autoskillit" / "recipes"
+        if scripts_dir.exists() and not recipes_dir.exists():
+            text += (
+                "\n\n⚠️ UPGRADE NEEDED: This project has not been migrated"
+                " to the new recipe format.\n"
+                "`.autoskillit/scripts/` still exists."
+                " Run `autoskillit upgrade` in this directory\n"
+                "to migrate automatically, or ask me to do it for you."
             )
-        suppressed = tool_ctx.config.migration.suppressed
-        _defaults = resolve_ingredient_defaults(Path.cwd())
-        # Runtime enum check: output_mode must be validated before recipe loading
-        if name == "research":
-            _om_value = (overrides or {}).get("output_mode")
-            if _om_value is not None and _om_value not in {"pr", "local"}:
-                return json.dumps(
-                    {
-                        "error": (
-                            f"output_mode must be 'pr' or 'local', got {_om_value!r}. "
-                            "Only two modes are supported for the research recipe."
-                        )
-                    }
-                )
-        try:
-            result = tool_ctx.recipes.load_and_validate(
-                name,
-                Path.cwd(),
-                suppressed=suppressed,
-                resolved_defaults=_defaults,
-                ingredient_overrides=overrides,
-            )
-        except Exception as exc:
-            logger.warning("open_kitchen_failure", stage="load_and_validate", exc_info=True)
-            return _kitchen_failure_envelope(exc, stage="load_and_validate")
-
-        tool_ctx.active_recipe_packs = frozenset(result.get("requires_packs", []))
-
-        try:
-            recipe_info = tool_ctx.recipes.find(name, Path.cwd())
-        except Exception as exc:
-            logger.warning("open_kitchen_failure", stage="recipe_find", exc_info=True)
-            return _kitchen_failure_envelope(exc, stage="recipe_find")
-
-        try:
-            result = await _apply_triage_gate(result, name, recipe_info=recipe_info)
-        except Exception as exc:
-            logger.warning("open_kitchen_failure", stage="apply_triage_gate", exc_info=True)
-            return _kitchen_failure_envelope(exc, stage="apply_triage_gate")
-
-        result["success"] = True
-        result["kitchen"] = "open"
-        result["version"] = __version__
-
-        if "ingredients_table" not in result or not result["ingredients_table"]:
-            result["ingredients_table"] = None
 
         try:
             warning = _build_hook_diagnostic_warning()
@@ -349,64 +394,35 @@ async def open_kitchen(
             logger.warning("open_kitchen_failure", stage="hook_diagnostic", exc_info=True)
             return _kitchen_failure_envelope(exc, stage="hook_diagnostic")
         if warning:
-            result["hook_warning"] = warning.strip()
-        return json.dumps(result)
+            text += warning
 
-    text = (
-        f"Kitchen is open. AutoSkillit {__version__}. Tools are ready for service.\n\n"
-        f"Available Tools by Category:\n{_categories}\n\n"
-        "IMPORTANT — Orchestrator Discipline:\n"
-        f"NEVER use native Claude Code tools ({_forbidden_list}) "
-        "in this session. All code reading, searching, editing, and "
-        "investigation MUST be delegated through run_skill, which launches "
-        "headless sessions with full tool access. Do NOT use native tools to "
-        "investigate failures — route to on_failure and let the downstream skill handle diagnosis."
-    )
-
-    # Inject sous-chef global orchestration rules (graceful degradation if absent)
-    _sous_chef_path = pkg_root() / "skills" / "sous-chef" / "SKILL.md"
-    try:
-        if _sous_chef_path.exists():
-            text += "\n\n" + _sous_chef_path.read_text()
-    except Exception as exc:
-        logger.warning("open_kitchen_failure", stage="read_sous_chef", exc_info=True)
-        return _kitchen_failure_envelope(exc, stage="read_sous_chef")
-
-    # Check if the project needs an upgrade
-    scripts_dir = Path.cwd() / ".autoskillit" / "scripts"
-    recipes_dir = Path.cwd() / ".autoskillit" / "recipes"
-    if scripts_dir.exists() and not recipes_dir.exists():
-        text += (
-            "\n\n⚠️ UPGRADE NEEDED: This project has not been migrated to the new recipe format.\n"
-            "`.autoskillit/scripts/` still exists. Run `autoskillit upgrade` in this directory\n"
-            "to migrate automatically, or ask me to do it for you."
+        return json.dumps(
+            {
+                "success": True,
+                "kitchen": "open",
+                "content": text,
+                "ingredients_table": None,
+                "version": __version__,
+            }
         )
-
-    try:
-        warning = _build_hook_diagnostic_warning()
     except Exception as exc:
-        logger.warning("open_kitchen_failure", stage="hook_diagnostic", exc_info=True)
-        return _kitchen_failure_envelope(exc, stage="hook_diagnostic")
-    if warning:
-        text += warning
-
-    return json.dumps(
-        {
-            "success": True,
-            "kitchen": "open",
-            "content": text,
-            "ingredients_table": None,
-            "version": __version__,
-        }
-    )
+        logger.error("open_kitchen unhandled exception", exc_info=True)
+        return _kitchen_failure_envelope(exc, stage="unhandled")
 
 
 @mcp.tool(tags={"autoskillit"}, annotations={"readOnlyHint": True})
 @track_response_size("close_kitchen")
 async def close_kitchen(ctx: Context = CurrentContext()) -> str:
-    """Close the AutoSkillit kitchen."""
-    if (h := _require_not_headless("close_kitchen")) is not None:
-        return h
-    _close_kitchen_handler()
-    await ctx.reset_visibility()
-    return "Kitchen is closed."
+    """Close the AutoSkillit kitchen.
+
+    Never raises.
+    """
+    try:
+        if (h := _require_not_headless("close_kitchen")) is not None:
+            return h
+        _close_kitchen_handler()
+        await ctx.reset_visibility()
+        return "Kitchen is closed."
+    except Exception as exc:
+        logger.error("close_kitchen unhandled exception", exc_info=True)
+        return json.dumps({"error": f"{type(exc).__name__}: {exc}"})

--- a/src/autoskillit/server/tools_pr_ops.py
+++ b/src/autoskillit/server/tools_pr_ops.py
@@ -87,46 +87,51 @@ async def get_pr_reviews(
         cwd: Working directory for gh commands.
         repo: Repository as owner/repo. Uses gh api path when provided;
               uses gh pr view when omitted.
+
+    Never raises.
     """
     if (gate := _require_enabled()) is not None:
         return gate
+    try:
+        with structlog.contextvars.bound_contextvars(tool="get_pr_reviews", cwd=cwd):
+            logger.info("get_pr_reviews", pr_number=pr_number, repo=repo)
+            await _notify(
+                ctx,
+                "info",
+                f"get_pr_reviews: #{pr_number}",
+                "autoskillit.get_pr_reviews",
+                extra={"repo": repo},
+            )
 
-    with structlog.contextvars.bound_contextvars(tool="get_pr_reviews", cwd=cwd):
-        logger.info("get_pr_reviews", pr_number=pr_number, repo=repo)
-        await _notify(
-            ctx,
-            "info",
-            f"get_pr_reviews: #{pr_number}",
-            "autoskillit.get_pr_reviews",
-            extra={"repo": repo},
-        )
+            if repo:
+                cmd = ["gh", "api", f"repos/{repo}/pulls/{pr_number}/reviews"]
+                rc, stdout, stderr = await _run_subprocess(cmd, cwd=cwd, timeout=30)
+                if rc != 0:
+                    return json.dumps(
+                        {"success": False, "error": stderr.strip() or "gh command failed"}
+                    )
+                try:
+                    raw = json.loads(stdout)
+                except json.JSONDecodeError:
+                    return json.dumps({"success": False, "error": "Failed to parse gh output"})
+                reviews = _map_api_reviews(raw)
+            else:
+                cmd = ["gh", "pr", "view", str(pr_number), "--json", "reviews"]
+                rc, stdout, stderr = await _run_subprocess(cmd, cwd=cwd, timeout=30)
+                if rc != 0:
+                    return json.dumps(
+                        {"success": False, "error": stderr.strip() or "gh command failed"}
+                    )
+                try:
+                    data = json.loads(stdout)
+                except json.JSONDecodeError:
+                    return json.dumps({"success": False, "error": "Failed to parse gh output"})
+                reviews = _map_pr_view_reviews(data)
 
-        if repo:
-            cmd = ["gh", "api", f"repos/{repo}/pulls/{pr_number}/reviews"]
-            rc, stdout, stderr = await _run_subprocess(cmd, cwd=cwd, timeout=30)
-            if rc != 0:
-                return json.dumps(
-                    {"success": False, "error": stderr.strip() or "gh command failed"}
-                )
-            try:
-                raw = json.loads(stdout)
-            except json.JSONDecodeError:
-                return json.dumps({"success": False, "error": "Failed to parse gh output"})
-            reviews = _map_api_reviews(raw)
-        else:
-            cmd = ["gh", "pr", "view", str(pr_number), "--json", "reviews"]
-            rc, stdout, stderr = await _run_subprocess(cmd, cwd=cwd, timeout=30)
-            if rc != 0:
-                return json.dumps(
-                    {"success": False, "error": stderr.strip() or "gh command failed"}
-                )
-            try:
-                data = json.loads(stdout)
-            except json.JSONDecodeError:
-                return json.dumps({"success": False, "error": "Failed to parse gh output"})
-            reviews = _map_pr_view_reviews(data)
-
-        return json.dumps({"reviews": reviews})
+            return json.dumps({"reviews": reviews})
+    except Exception as exc:
+        logger.error("get_pr_reviews unhandled exception", exc_info=True)
+        return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "github"}, annotations={"readOnlyHint": True})
@@ -151,19 +156,24 @@ async def bulk_close_issues(
         issue_numbers: List of GitHub issue numbers to close.
         comment: Optional comment to post when closing. Omitted when empty.
         cwd: Working directory for gh commands.
+
+    Never raises.
     """
     if (gate := _require_enabled()) is not None:
         return gate
+    try:
+        with structlog.contextvars.bound_contextvars(tool="bulk_close_issues", cwd=cwd):
+            logger.info("bulk_close_issues", count=len(issue_numbers))
+            await _notify(
+                ctx,
+                "info",
+                f"bulk_close_issues: {len(issue_numbers)} issue(s)",
+                "autoskillit.bulk_close_issues",
+                extra={},
+            )
 
-    with structlog.contextvars.bound_contextvars(tool="bulk_close_issues", cwd=cwd):
-        logger.info("bulk_close_issues", count=len(issue_numbers))
-        await _notify(
-            ctx,
-            "info",
-            f"bulk_close_issues: {len(issue_numbers)} issue(s)",
-            "autoskillit.bulk_close_issues",
-            extra={},
-        )
-
-        closed, failed = await _close_issues_sequentially(issue_numbers, comment, cwd)
-        return json.dumps({"closed": closed, "failed": failed})
+            closed, failed = await _close_issues_sequentially(issue_numbers, comment, cwd)
+            return json.dumps({"closed": closed, "failed": failed})
+    except Exception as exc:
+        logger.error("bulk_close_issues unhandled exception", exc_info=True)
+        return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})

--- a/src/autoskillit/server/tools_recipe.py
+++ b/src/autoskillit/server/tools_recipe.py
@@ -54,9 +54,9 @@ async def list_recipes() -> str:
             return json.dumps([])
         result = tool_ctx.recipes.list_all(Path.cwd())
         return json.dumps(result)
-    except Exception as exc:
+    except Exception:
         logger.error("list_recipes unhandled exception", exc_info=True)
-        return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
+        return json.dumps([])
 
 
 @mcp.tool(tags={"autoskillit", "kitchen"}, annotations={"readOnlyHint": True})
@@ -199,7 +199,7 @@ async def load_recipe(name: str, overrides: dict[str, str] | None = None) -> str
         return json.dumps(await _apply_triage_gate(result, name, recipe_info=recipe_info))
     except Exception as exc:
         logger.error("load_recipe unhandled exception", exc_info=True)
-        return json.dumps({"error": f"{type(exc).__name__}: {exc}"})
+        return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
 
 
 @mcp.tool(tags={"autoskillit", "kitchen"}, annotations={"readOnlyHint": True})

--- a/src/autoskillit/server/tools_recipe.py
+++ b/src/autoskillit/server/tools_recipe.py
@@ -41,16 +41,22 @@ async def list_recipes() -> str:
     .autoskillit/skills/ or any other directory).
 
     This tool requires the kitchen to be open (gated by open_kitchen).
+
+    Never raises.
     """
     if (gate := _require_enabled()) is not None:
         return gate
-    structlog.contextvars.clear_contextvars()
-    structlog.contextvars.bind_contextvars(tool="list_recipes")
-    tool_ctx = _get_ctx_or_none()
-    if tool_ctx is None or tool_ctx.recipes is None:
-        return json.dumps([])
-    result = tool_ctx.recipes.list_all(Path.cwd())
-    return json.dumps(result)
+    try:
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(tool="list_recipes")
+        tool_ctx = _get_ctx_or_none()
+        if tool_ctx is None or tool_ctx.recipes is None:
+            return json.dumps([])
+        result = tool_ctx.recipes.list_all(Path.cwd())
+        return json.dumps(result)
+    except Exception as exc:
+        logger.error("list_recipes unhandled exception", exc_info=True)
+        return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
 
 
 @mcp.tool(tags={"autoskillit", "kitchen"}, annotations={"readOnlyHint": True})
@@ -167,27 +173,33 @@ async def load_recipe(name: str, overrides: dict[str, str] | None = None) -> str
     ``diagram`` (pre-generated Markdown string or null), and
     ``suggestions`` (list of semantic findings, possibly empty) keys.
     On error: JSON with ``error`` key.
+
+    Never raises.
     """
     if (gate := _require_enabled()) is not None:
         return gate
-    structlog.contextvars.clear_contextvars()
-    structlog.contextvars.bind_contextvars(tool="load_recipe")
-    tool_ctx = _get_ctx_or_none()
-    if tool_ctx is None or tool_ctx.recipes is None:
-        return json.dumps({"error": "Server not initialized"})
-    suppressed = tool_ctx.config.migration.suppressed
-    _defaults = resolve_ingredient_defaults(Path.cwd())
-    result = tool_ctx.recipes.load_and_validate(
-        name,
-        Path.cwd(),
-        suppressed=suppressed,
-        resolved_defaults=_defaults,
-        ingredient_overrides=overrides,
-        temp_dir=tool_ctx.temp_dir,
-        temp_dir_relpath=temp_dir_display_str(tool_ctx.config.workspace.temp_dir),
-    )
-    recipe_info = tool_ctx.recipes.find(name, Path.cwd())
-    return json.dumps(await _apply_triage_gate(result, name, recipe_info=recipe_info))
+    try:
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(tool="load_recipe")
+        tool_ctx = _get_ctx_or_none()
+        if tool_ctx is None or tool_ctx.recipes is None:
+            return json.dumps({"error": "Server not initialized"})
+        suppressed = tool_ctx.config.migration.suppressed
+        _defaults = resolve_ingredient_defaults(Path.cwd())
+        result = tool_ctx.recipes.load_and_validate(
+            name,
+            Path.cwd(),
+            suppressed=suppressed,
+            resolved_defaults=_defaults,
+            ingredient_overrides=overrides,
+            temp_dir=tool_ctx.temp_dir,
+            temp_dir_relpath=temp_dir_display_str(tool_ctx.config.workspace.temp_dir),
+        )
+        recipe_info = tool_ctx.recipes.find(name, Path.cwd())
+        return json.dumps(await _apply_triage_gate(result, name, recipe_info=recipe_info))
+    except Exception as exc:
+        logger.error("load_recipe unhandled exception", exc_info=True)
+        return json.dumps({"error": f"{type(exc).__name__}: {exc}"})
 
 
 @mcp.tool(tags={"autoskillit", "kitchen"}, annotations={"readOnlyHint": True})
@@ -213,19 +225,25 @@ async def validate_recipe(script_path: str) -> str:
 
     Args:
         script_path: Absolute path to the .yaml recipe file to validate.
+
+    Never raises.
     """
     if (gate := _require_enabled()) is not None:
         return gate
-    structlog.contextvars.clear_contextvars()
-    structlog.contextvars.bind_contextvars(tool="validate_recipe")
-    tool_ctx = _get_ctx_or_none()
-    if tool_ctx is None or tool_ctx.recipes is None:
-        return json.dumps({"valid": False, "errors": ["Server not initialized"]})
-    result = tool_ctx.recipes.validate_from_path(
-        Path(script_path),
-        temp_dir_relpath=temp_dir_display_str(tool_ctx.config.workspace.temp_dir),
-    )
-    return json.dumps(result)
+    try:
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(tool="validate_recipe")
+        tool_ctx = _get_ctx_or_none()
+        if tool_ctx is None or tool_ctx.recipes is None:
+            return json.dumps({"valid": False, "errors": ["Server not initialized"]})
+        result = tool_ctx.recipes.validate_from_path(
+            Path(script_path),
+            temp_dir_relpath=temp_dir_display_str(tool_ctx.config.workspace.temp_dir),
+        )
+        return json.dumps(result)
+    except Exception as exc:
+        logger.error("validate_recipe unhandled exception", exc_info=True)
+        return json.dumps({"valid": False, "errors": [f"{type(exc).__name__}: {exc}"]})
 
 
 @mcp.tool(tags={"autoskillit", "kitchen"}, annotations={"readOnlyHint": True})
@@ -251,35 +269,41 @@ async def migrate_recipe(name: str, ctx: Context = CurrentContext()) -> str:
 
     Args:
         name: The recipe name (without .yaml extension) to migrate.
+
+    Never raises.
     """
     if (gate := _require_enabled()) is not None:
         return gate
-    structlog.contextvars.clear_contextvars()
-    structlog.contextvars.bind_contextvars(tool="migrate_recipe", recipe_name=name)
-    logger.info("migrate_recipe", recipe_name=name)
-    await _notify(
-        ctx,
-        "info",
-        f"migrate_recipe: {name}",
-        "autoskillit.migrate_recipe",
-        extra={"recipe_name": name},
-    )
+    try:
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(tool="migrate_recipe", recipe_name=name)
+        logger.info("migrate_recipe", recipe_name=name)
+        await _notify(
+            ctx,
+            "info",
+            f"migrate_recipe: {name}",
+            "autoskillit.migrate_recipe",
+            extra={"recipe_name": name},
+        )
 
-    from autoskillit.server import _get_config, _get_ctx
+        from autoskillit.server import _get_config, _get_ctx
 
-    tool_ctx = _get_ctx()
+        tool_ctx = _get_ctx()
 
-    # Check suppression list before attempting migration
-    if name in _get_config().migration.suppressed:
-        return json.dumps({"status": "up_to_date", "name": name})
+        # Check suppression list before attempting migration
+        if name in _get_config().migration.suppressed:
+            return json.dumps({"status": "up_to_date", "name": name})
 
-    if tool_ctx.recipes is None:
-        return json.dumps({"error": "Recipe repository not configured"})
-    recipe = tool_ctx.recipes.find(name, Path.cwd())
-    if recipe is None:
-        return json.dumps({"error": f"No recipe named '{name}' found"})
+        if tool_ctx.recipes is None:
+            return json.dumps({"error": "Recipe repository not configured"})
+        recipe = tool_ctx.recipes.find(name, Path.cwd())
+        if recipe is None:
+            return json.dumps({"error": f"No recipe named '{name}' found"})
 
-    if tool_ctx.migrations is None:
-        return json.dumps({"error": "Migration service not configured", "name": name})
-    result = await tool_ctx.migrations.migrate(recipe.path)
-    return json.dumps(result)
+        if tool_ctx.migrations is None:
+            return json.dumps({"error": "Migration service not configured", "name": name})
+        result = await tool_ctx.migrations.migrate(recipe.path)
+        return json.dumps(result)
+    except Exception as exc:
+        logger.error("migrate_recipe unhandled exception", exc_info=True)
+        return json.dumps({"error": f"{type(exc).__name__}: {exc}", "name": name})

--- a/src/autoskillit/server/tools_status.py
+++ b/src/autoskillit/server/tools_status.py
@@ -42,35 +42,41 @@ async def kitchen_status() -> str:
     enabling tools or anytime you need to verify the server is healthy.
 
     This tool requires the kitchen to be open (gated by open_kitchen).
+
+    Never raises.
     """
     if (gate := _require_enabled()) is not None:
         return gate
-    structlog.contextvars.clear_contextvars()
-    with structlog.contextvars.bound_contextvars(tool="kitchen_status"):
-        from autoskillit.server import _get_config, _get_ctx, version_info
+    try:
+        structlog.contextvars.clear_contextvars()
+        with structlog.contextvars.bound_contextvars(tool="kitchen_status"):
+            from autoskillit.server import _get_config, _get_ctx, version_info
 
-        info = version_info()
-        status = {
-            "package_version": info["package_version"],
-            "plugin_json_version": info["plugin_json_version"],
-            "versions_match": info["match"],
-            "tools_enabled": _get_ctx().gate.enabled,
-        }
-        if not info["match"]:
-            status["warning"] = (
-                f"Version mismatch: package is {info['package_version']} but "
-                f"plugin.json reports {info['plugin_json_version']}. "
-                f"Run `autoskillit doctor` for details or "
-                f"`autoskillit install` to refresh the plugin cache."
+            info = version_info()
+            status = {
+                "package_version": info["package_version"],
+                "plugin_json_version": info["plugin_json_version"],
+                "versions_match": info["match"],
+                "tools_enabled": _get_ctx().gate.enabled,
+            }
+            if not info["match"]:
+                status["warning"] = (
+                    f"Version mismatch: package is {info['package_version']} but "
+                    f"plugin.json reports {info['plugin_json_version']}. "
+                    f"Run `autoskillit doctor` for details or "
+                    f"`autoskillit install` to refresh the plugin cache."
+                )
+            status["token_usage_verbosity"] = _get_config().token_usage.verbosity
+            status["quota_guard_enabled"] = _get_config().quota_guard.enabled
+            github_client = _get_ctx().github_client
+            status["github_token_configured"] = (
+                github_client.has_token if github_client is not None else False
             )
-        status["token_usage_verbosity"] = _get_config().token_usage.verbosity
-        status["quota_guard_enabled"] = _get_config().quota_guard.enabled
-        github_client = _get_ctx().github_client
-        status["github_token_configured"] = (
-            github_client.has_token if github_client is not None else False
-        )
-        status["github_default_repo"] = _get_config().github.default_repo
-        return json.dumps(status)
+            status["github_default_repo"] = _get_config().github.default_repo
+            return json.dumps(status)
+    except Exception as exc:
+        logger.error("kitchen_status unhandled exception", exc_info=True)
+        return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
 
 
 @mcp.tool(tags={"autoskillit", "kitchen"}, annotations={"readOnlyHint": True})
@@ -88,40 +94,48 @@ async def get_pipeline_report(clear: bool = False) -> str:
                             needs_retry, retry_reason, stderr}
 
     This tool requires the kitchen to be open (gated by open_kitchen).
+
+    Never raises.
     """
     if (gate := _require_enabled()) is not None:
         return gate
-    structlog.contextvars.clear_contextvars()
-    with structlog.contextvars.bound_contextvars(tool="get_pipeline_report"):
-        from autoskillit.server._state import _startup_ready
+    try:
+        structlog.contextvars.clear_contextvars()
+        with structlog.contextvars.bound_contextvars(tool="get_pipeline_report"):
+            from autoskillit.server._state import _startup_ready
 
-        if _startup_ready is not None and not _startup_ready.is_set():
-            try:
-                await asyncio.wait_for(_startup_ready.wait(), timeout=30.0)
-            except TimeoutError:
-                logger.warning("startup_ready_timeout", timeout=30.0)
-                return json.dumps(
-                    {
-                        "total_failures": 0,
-                        "failures": [],
-                        "warning": "Startup initialization did not complete within 30s",
-                    }
-                )
+            if _startup_ready is not None and not _startup_ready.is_set():
+                try:
+                    await asyncio.wait_for(_startup_ready.wait(), timeout=30.0)
+                except TimeoutError:
+                    logger.warning("startup_ready_timeout", timeout=30.0)
+                    return json.dumps(
+                        {
+                            "total_failures": 0,
+                            "failures": [],
+                            "warning": "Startup initialization did not complete within 30s",
+                        }
+                    )
 
-        from autoskillit.server import _get_ctx
+            from autoskillit.server import _get_ctx
 
-        failures = _get_ctx().audit.get_report_as_dicts()
-        if clear:
-            _get_ctx().audit.clear()
-            try:
-                write_telemetry_clear_marker(_get_log_root())
-            except Exception:
-                logger.debug("write_telemetry_clear_marker failed", exc_info=True)
+            failures = _get_ctx().audit.get_report_as_dicts()
+            if clear:
+                _get_ctx().audit.clear()
+                try:
+                    write_telemetry_clear_marker(_get_log_root())
+                except Exception:
+                    logger.debug("write_telemetry_clear_marker failed", exc_info=True)
+            return json.dumps(
+                {
+                    "total_failures": len(failures),
+                    "failures": failures,
+                }
+            )
+    except Exception as exc:
+        logger.error("get_pipeline_report unhandled exception", exc_info=True)
         return json.dumps(
-            {
-                "total_failures": len(failures),
-                "failures": failures,
-            }
+            {"total_failures": 0, "failures": [], "error": f"{type(exc).__name__}: {exc}"}
         )
 
 
@@ -154,40 +168,46 @@ async def get_token_summary(clear: bool = False, format: str = "json", order_id:
                 "table" returns a pre-formatted markdown table string.
         order_id: If non-empty, return only token entries for this specific order/issue.
                   Empty string (default) returns aggregated data for all orders.
+
+    Never raises.
     """
     if (gate := _require_enabled()) is not None:
         return gate
-    structlog.contextvars.clear_contextvars()
-    with structlog.contextvars.bound_contextvars(tool="get_token_summary"):
-        from autoskillit.server import _get_ctx
+    try:
+        structlog.contextvars.clear_contextvars()
+        with structlog.contextvars.bound_contextvars(tool="get_token_summary"):
+            from autoskillit.server import _get_ctx
 
-        ctx = _get_ctx()
-        steps = _merge_wall_clock_seconds(
-            ctx.token_log.get_report(order_id=order_id),
-            ctx.timing_log.get_report(order_id=order_id),
-        )
-        total = ctx.token_log.compute_total(order_id=order_id)
-        mcp_report = ctx.response_log.get_report()
-        mcp_total = ctx.response_log.compute_total()
-        if clear:
-            ctx.token_log.clear()
-            ctx.response_log.clear()
-            try:
-                write_telemetry_clear_marker(_get_log_root())
-            except Exception:
-                logger.debug("write_telemetry_clear_marker failed", exc_info=True)
-        if format == "table":
-            return TelemetryFormatter.format_token_table(steps, total)
-        return json.dumps(
-            {
-                "steps": steps,
-                "total": total,
-                "mcp_responses": {
-                    "steps": mcp_report,
-                    "total": mcp_total,
-                },
-            }
-        )
+            ctx = _get_ctx()
+            steps = _merge_wall_clock_seconds(
+                ctx.token_log.get_report(order_id=order_id),
+                ctx.timing_log.get_report(order_id=order_id),
+            )
+            total = ctx.token_log.compute_total(order_id=order_id)
+            mcp_report = ctx.response_log.get_report()
+            mcp_total = ctx.response_log.compute_total()
+            if clear:
+                ctx.token_log.clear()
+                ctx.response_log.clear()
+                try:
+                    write_telemetry_clear_marker(_get_log_root())
+                except Exception:
+                    logger.debug("write_telemetry_clear_marker failed", exc_info=True)
+            if format == "table":
+                return TelemetryFormatter.format_token_table(steps, total)
+            return json.dumps(
+                {
+                    "steps": steps,
+                    "total": total,
+                    "mcp_responses": {
+                        "steps": mcp_report,
+                        "total": mcp_total,
+                    },
+                }
+            )
+    except Exception as exc:
+        logger.error("get_token_summary unhandled exception", exc_info=True)
+        return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "telemetry"}, annotations={"readOnlyHint": True})
@@ -205,24 +225,30 @@ async def get_timing_summary(clear: bool = False, format: str = "json", order_id
                 "table" returns a pre-formatted markdown table string.
         order_id: If non-empty, return only timing entries for this specific order/issue.
                   Empty string (default) returns aggregated data for all orders.
+
+    Never raises.
     """
     if (gate := _require_enabled()) is not None:
         return gate
-    structlog.contextvars.clear_contextvars()
-    with structlog.contextvars.bound_contextvars(tool="get_timing_summary"):
-        from autoskillit.server import _get_ctx
+    try:
+        structlog.contextvars.clear_contextvars()
+        with structlog.contextvars.bound_contextvars(tool="get_timing_summary"):
+            from autoskillit.server import _get_ctx
 
-        steps = _get_ctx().timing_log.get_report(order_id=order_id)
-        total = _get_ctx().timing_log.compute_total(order_id=order_id)
-        if clear:
-            _get_ctx().timing_log.clear()
-            try:
-                write_telemetry_clear_marker(_get_log_root())
-            except Exception:
-                logger.debug("write_telemetry_clear_marker failed", exc_info=True)
-        if format == "table":
-            return TelemetryFormatter.format_timing_table(steps, total)
-        return json.dumps({"steps": steps, "total": total})
+            steps = _get_ctx().timing_log.get_report(order_id=order_id)
+            total = _get_ctx().timing_log.compute_total(order_id=order_id)
+            if clear:
+                _get_ctx().timing_log.clear()
+                try:
+                    write_telemetry_clear_marker(_get_log_root())
+                except Exception:
+                    logger.debug("write_telemetry_clear_marker failed", exc_info=True)
+            if format == "table":
+                return TelemetryFormatter.format_timing_table(steps, total)
+            return json.dumps({"steps": steps, "total": total})
+    except Exception as exc:
+        logger.error("get_timing_summary unhandled exception", exc_info=True)
+        return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
 
 
 def _read_quota_events(log_root: Path, n: int) -> tuple[list[dict], int]:
@@ -269,17 +295,23 @@ async def get_quota_events(n: int = 50) -> str:
 
     This tool requires the kitchen to be open (gated by open_kitchen).
     This tool sends no MCP progress notifications.
+
+    Never raises.
     """
     if (gate := _require_enabled()) is not None:
         return gate
-    structlog.contextvars.clear_contextvars()
-    with structlog.contextvars.bound_contextvars(tool="get_quota_events"):
-        from autoskillit.server import _get_ctx
+    try:
+        structlog.contextvars.clear_contextvars()
+        with structlog.contextvars.bound_contextvars(tool="get_quota_events"):
+            from autoskillit.server import _get_ctx
 
-        ctx = _get_ctx()
-        log_root = resolve_log_dir(ctx.config.linux_tracing.log_dir)
-        events, total = _read_quota_events(log_root, n)
-        return json.dumps({"events": events, "total_count": total})
+            ctx = _get_ctx()
+            log_root = resolve_log_dir(ctx.config.linux_tracing.log_dir)
+            events, total = _read_quota_events(log_root, n)
+            return json.dumps({"events": events, "total_count": total})
+    except Exception as exc:
+        logger.error("get_quota_events unhandled exception", exc_info=True)
+        return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "telemetry"}, annotations={"readOnlyHint": True})
@@ -301,59 +333,67 @@ async def write_telemetry_files(
 
     Args:
         output_dir: Directory to write the markdown files into.
+
+    Never raises.
     """
     if (gate := _require_enabled()) is not None:
         return gate
 
-    structlog.contextvars.clear_contextvars()
-    with structlog.contextvars.bound_contextvars(
-        tool="write_telemetry_files", output_dir=output_dir
-    ):
-        logger.info("write_telemetry_files", output_dir=output_dir)
-        await _notify(
-            ctx,
-            "info",
-            f"write_telemetry_files: {output_dir}",
-            "autoskillit.write_telemetry_files",
-            extra={"output_dir": output_dir},
-        )
+    try:
+        structlog.contextvars.clear_contextvars()
+        with structlog.contextvars.bound_contextvars(
+            tool="write_telemetry_files", output_dir=output_dir
+        ):
+            logger.info("write_telemetry_files", output_dir=output_dir)
+            await _notify(
+                ctx,
+                "info",
+                f"write_telemetry_files: {output_dir}",
+                "autoskillit.write_telemetry_files",
+                extra={"output_dir": output_dir},
+            )
 
-        from autoskillit.server import _get_ctx
+            from autoskillit.server import _get_ctx
 
-        tool_ctx = _get_ctx()
-        out = Path(output_dir)
-        out.mkdir(parents=True, exist_ok=True)
+            tool_ctx = _get_ctx()
+            out = Path(output_dir)
+            out.mkdir(parents=True, exist_ok=True)
 
-        token_steps = _merge_wall_clock_seconds(
-            tool_ctx.token_log.get_report(), tool_ctx.timing_log.get_report()
-        )
-        token_total = tool_ctx.token_log.compute_total()
+            token_steps = _merge_wall_clock_seconds(
+                tool_ctx.token_log.get_report(), tool_ctx.timing_log.get_report()
+            )
+            token_total = tool_ctx.token_log.compute_total()
 
-        token_path = out / "token_summary.md"
-        atomic_write(token_path, TelemetryFormatter.format_token_table(token_steps, token_total))
+            token_path = out / "token_summary.md"
+            atomic_write(
+                token_path, TelemetryFormatter.format_token_table(token_steps, token_total)
+            )
 
-        timing_path = out / "timing_summary.md"
-        atomic_write(
-            timing_path,
-            TelemetryFormatter.format_timing_table(
-                tool_ctx.timing_log.get_report(), tool_ctx.timing_log.compute_total()
-            ),
-        )
+            timing_path = out / "timing_summary.md"
+            atomic_write(
+                timing_path,
+                TelemetryFormatter.format_timing_table(
+                    tool_ctx.timing_log.get_report(), tool_ctx.timing_log.compute_total()
+                ),
+            )
 
-        mcp_path = out / "mcp_response_metrics.json"
-        mcp_data = {
-            "steps": tool_ctx.response_log.get_report(),
-            "total": tool_ctx.response_log.compute_total(),
-        }
-        atomic_write(mcp_path, json.dumps(mcp_data, indent=2))
-
-        return json.dumps(
-            {
-                "token_summary_path": str(token_path),
-                "timing_summary_path": str(timing_path),
-                "mcp_response_metrics_path": str(mcp_path),
+            mcp_path = out / "mcp_response_metrics.json"
+            mcp_data = {
+                "steps": tool_ctx.response_log.get_report(),
+                "total": tool_ctx.response_log.compute_total(),
             }
-        )
+            atomic_write(mcp_path, json.dumps(mcp_data, indent=2))
+
+            return json.dumps(
+                {
+                    "token_summary_path": str(token_path),
+                    "timing_summary_path": str(timing_path),
+                    "mcp_response_metrics_path": str(mcp_path),
+                }
+            )
+    except Exception as exc:
+        logger.error("write_telemetry_files unhandled exception", exc_info=True)
+        return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
 
 
 @mcp.tool(tags={"autoskillit", "kitchen"}, annotations={"readOnlyHint": True})
@@ -376,116 +416,128 @@ async def read_db(
         query: SQL SELECT query. Use ? for positional or :name for named placeholders.
         params: JSON-encoded array or object of query parameter values (default "[]").
         timeout: Query timeout in seconds. 0 uses the configured default.
+
+    Never raises.
     """
     if (gate := _require_enabled()) is not None:
         return gate
-    structlog.contextvars.clear_contextvars()
-    with structlog.contextvars.bound_contextvars(tool="read_db"):
-        logger.info("read_db", db_path=db_path, query=query[:80])
-        await _notify(
-            ctx,
-            "info",
-            f"read_db: {query[:80]}",
-            "autoskillit.read_db",
-            extra={"db_path": db_path},
-        )
-
-        # Parse params
-        try:
-            parsed_params = json.loads(params)
-        except json.JSONDecodeError as exc:
+    try:
+        structlog.contextvars.clear_contextvars()
+        with structlog.contextvars.bound_contextvars(tool="read_db"):
+            logger.info("read_db", db_path=db_path, query=query[:80])
             await _notify(
                 ctx,
-                "error",
-                "read_db: invalid params JSON",
-                "autoskillit.read_db",
-                extra={"error": str(exc)},
-            )
-            return json.dumps({"success": False, "error": f"Invalid params JSON: {exc}"})
-        if not isinstance(parsed_params, (list, dict)):
-            await _notify(
-                ctx,
-                "error",
-                "read_db: params must be JSON array or object",
-                "autoskillit.read_db",
-                extra={},
-            )
-            return json.dumps({"success": False, "error": "params must be a JSON array or object"})
-
-        # Validate db_path
-        db = Path(db_path).resolve()
-        if not db.exists():
-            await _notify(
-                ctx,
-                "error",
-                "read_db: database does not exist",
+                "info",
+                f"read_db: {query[:80]}",
                 "autoskillit.read_db",
                 extra={"db_path": db_path},
             )
-            return json.dumps({"success": False, "error": f"Database does not exist: {db}"})
-        if not db.is_file():
-            await _notify(
-                ctx,
-                "error",
-                "read_db: path is not a file",
-                "autoskillit.read_db",
-                extra={"db_path": db_path},
-            )
-            return json.dumps({"success": False, "error": f"Path is not a file: {db}"})
 
-        from autoskillit.server import _get_config, _get_ctx
+            # Parse params
+            try:
+                parsed_params = json.loads(params)
+            except json.JSONDecodeError as exc:
+                await _notify(
+                    ctx,
+                    "error",
+                    "read_db: invalid params JSON",
+                    "autoskillit.read_db",
+                    extra={"error": str(exc)},
+                )
+                return json.dumps({"success": False, "error": f"Invalid params JSON: {exc}"})
+            if not isinstance(parsed_params, (list, dict)):
+                await _notify(
+                    ctx,
+                    "error",
+                    "read_db: params must be JSON array or object",
+                    "autoskillit.read_db",
+                    extra={},
+                )
+                return json.dumps(
+                    {"success": False, "error": "params must be a JSON array or object"}
+                )
 
-        tool_ctx = _get_ctx()
-        if tool_ctx.db_reader is None:
-            return json.dumps({"success": False, "error": "Database reader not configured"})
+            # Validate db_path
+            db = Path(db_path).resolve()
+            if not db.exists():
+                await _notify(
+                    ctx,
+                    "error",
+                    "read_db: database does not exist",
+                    "autoskillit.read_db",
+                    extra={"db_path": db_path},
+                )
+                return json.dumps({"success": False, "error": f"Database does not exist: {db}"})
+            if not db.is_file():
+                await _notify(
+                    ctx,
+                    "error",
+                    "read_db: path is not a file",
+                    "autoskillit.read_db",
+                    extra={"db_path": db_path},
+                )
+                return json.dumps({"success": False, "error": f"Path is not a file: {db}"})
 
-        # Resolve timeout
-        effective_timeout = timeout if timeout > 0 else _get_config().read_db.timeout
-        max_rows = _get_config().read_db.max_rows
+            from autoskillit.server import _get_config, _get_ctx
 
-        # Execute in thread (sqlite3 is blocking)
-        loop = asyncio.get_running_loop()
-        try:
-            result = await loop.run_in_executor(
-                None,
-                tool_ctx.db_reader.query,
-                str(db),
-                query,
-                parsed_params,
-                effective_timeout,
-                max_rows,
-            )
-            return json.dumps(result)
-        except ValueError as exc:
-            # Non-SELECT SQL rejected by db_reader's defence-in-depth validation
-            await _notify(
-                ctx,
-                "error",
-                "read_db: non-SELECT query rejected",
-                "autoskillit.read_db",
-                extra={"error": str(exc)},
-            )
-            return json.dumps(
-                {"success": False, "error": str(exc), "hint": "Only SELECT queries are allowed"}
-            )
-        except TimeoutError:
-            await _notify(
-                ctx,
-                "error",
-                "read_db: query timed out",
-                "autoskillit.read_db",
-                extra={"timeout": effective_timeout},
-            )
-            return json.dumps(
-                {"success": False, "error": f"Query exceeded {effective_timeout}s timeout"}
-            )
-        except Exception as exc:
-            logger.warning("read_db query failed", error=type(exc).__name__)
-            await _notify(
-                ctx,
-                "error",
-                "read_db: query failed",
-                "autoskillit.read_db",
-                extra={"error": type(exc).__name__},
-            )
-            return json.dumps({"success": False, "error": f"Query failed: {exc}"})
+            tool_ctx = _get_ctx()
+            if tool_ctx.db_reader is None:
+                return json.dumps({"success": False, "error": "Database reader not configured"})
+
+            # Resolve timeout
+            effective_timeout = timeout if timeout > 0 else _get_config().read_db.timeout
+            max_rows = _get_config().read_db.max_rows
+
+            # Execute in thread (sqlite3 is blocking)
+            loop = asyncio.get_running_loop()
+            try:
+                result = await loop.run_in_executor(
+                    None,
+                    tool_ctx.db_reader.query,
+                    str(db),
+                    query,
+                    parsed_params,
+                    effective_timeout,
+                    max_rows,
+                )
+                return json.dumps(result)
+            except ValueError as exc:
+                # Non-SELECT SQL rejected by db_reader's defence-in-depth validation
+                await _notify(
+                    ctx,
+                    "error",
+                    "read_db: non-SELECT query rejected",
+                    "autoskillit.read_db",
+                    extra={"error": str(exc)},
+                )
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": str(exc),
+                        "hint": "Only SELECT queries are allowed",
+                    }
+                )
+            except TimeoutError:
+                await _notify(
+                    ctx,
+                    "error",
+                    "read_db: query timed out",
+                    "autoskillit.read_db",
+                    extra={"timeout": effective_timeout},
+                )
+                return json.dumps(
+                    {"success": False, "error": f"Query exceeded {effective_timeout}s timeout"}
+                )
+            except Exception as exc:
+                logger.warning("read_db query failed", error=type(exc).__name__)
+                await _notify(
+                    ctx,
+                    "error",
+                    "read_db: query failed",
+                    "autoskillit.read_db",
+                    extra={"error": type(exc).__name__},
+                )
+                return json.dumps({"success": False, "error": f"Query failed: {exc}"})
+    except Exception as exc:
+        logger.error("read_db unhandled exception", exc_info=True)
+        return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})

--- a/src/autoskillit/server/tools_workspace.py
+++ b/src/autoskillit/server/tools_workspace.py
@@ -43,48 +43,54 @@ async def test_check(
     Args:
         worktree_path: Path to the git worktree to run tests in.
         step_name: Optional YAML step key for wall-clock timing accumulation.
+
+    Never raises.
     """
-    structlog.contextvars.clear_contextvars()
-    structlog.contextvars.bind_contextvars(tool="test_check", cwd=worktree_path)
-    logger.info("test_check", worktree=worktree_path)
-    await _notify(
-        ctx,
-        "info",
-        f"test_check: {worktree_path}",
-        "autoskillit.test_check",
-        extra={"worktree": worktree_path},
-    )
-
-    from autoskillit.server import _get_ctx
-
-    tool_ctx = _get_ctx()
-    if tool_ctx.tester is None:
-        return json.dumps({"passed": False, "error": "Test runner not configured"})
-
-    _start = time.monotonic()
     try:
-        resolved = os.path.realpath(worktree_path)
-        test_result = await tool_ctx.tester.run(Path(resolved))
-
-        if not test_result.passed:
-            await _notify(
-                ctx,
-                "error",
-                "test_check: tests failed",
-                "autoskillit.test_check",
-                extra={"worktree": worktree_path},
-            )
-
-        return json.dumps(
-            {
-                "passed": test_result.passed,
-                "stdout": truncate_text(test_result.stdout),
-                "stderr": truncate_text(test_result.stderr),
-            }
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(tool="test_check", cwd=worktree_path)
+        logger.info("test_check", worktree=worktree_path)
+        await _notify(
+            ctx,
+            "info",
+            f"test_check: {worktree_path}",
+            "autoskillit.test_check",
+            extra={"worktree": worktree_path},
         )
-    finally:
-        if step_name:
-            tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
+
+        from autoskillit.server import _get_ctx
+
+        tool_ctx = _get_ctx()
+        if tool_ctx.tester is None:
+            return json.dumps({"passed": False, "error": "Test runner not configured"})
+
+        _start = time.monotonic()
+        try:
+            resolved = os.path.realpath(worktree_path)
+            test_result = await tool_ctx.tester.run(Path(resolved))
+
+            if not test_result.passed:
+                await _notify(
+                    ctx,
+                    "error",
+                    "test_check: tests failed",
+                    "autoskillit.test_check",
+                    extra={"worktree": worktree_path},
+                )
+
+            return json.dumps(
+                {
+                    "passed": test_result.passed,
+                    "stdout": truncate_text(test_result.stdout),
+                    "stderr": truncate_text(test_result.stderr),
+                }
+            )
+        finally:
+            if step_name:
+                tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
+    except Exception as exc:
+        logger.error("test_check unhandled exception", exc_info=True)
+        return json.dumps({"passed": False, "error": f"{type(exc).__name__}: {exc}"})
 
 
 @mcp.tool(tags={"autoskillit", "kitchen"}, annotations={"readOnlyHint": True})
@@ -105,62 +111,68 @@ async def reset_test_dir(
         force: Override the marker check. When True, all contents are deleted
                including the marker file itself.
         step_name: Optional YAML step key for wall-clock timing accumulation.
+
+    Never raises.
     """
     if (gate := _require_enabled()) is not None:
         return gate
-    resolved = os.path.realpath(test_dir)
-    structlog.contextvars.clear_contextvars()
-    structlog.contextvars.bind_contextvars(tool="reset_test_dir", cwd=resolved)
-    logger.info("reset_test_dir", resolved=str(resolved), force=force)
-    await _notify(
-        ctx,
-        "info",
-        f"reset_test_dir: {resolved}",
-        "autoskillit.reset_test_dir",
-        extra={"resolved": resolved, "force": force},
-    )
-
-    from autoskillit.server import _get_config, _get_ctx
-
-    tool_ctx = _get_ctx()
-    _start = time.monotonic()
     try:
-        if not os.path.isdir(resolved):
-            await _notify(
-                ctx,
-                "error",
-                "reset_test_dir failed",
-                "autoskillit.reset_test_dir",
-                extra={"reason": "directory does not exist"},
-            )
-            return json.dumps({"error": f"Directory does not exist: {resolved}"})
+        resolved = os.path.realpath(test_dir)
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(tool="reset_test_dir", cwd=resolved)
+        logger.info("reset_test_dir", resolved=str(resolved), force=force)
+        await _notify(
+            ctx,
+            "info",
+            f"reset_test_dir: {resolved}",
+            "autoskillit.reset_test_dir",
+            extra={"resolved": resolved, "force": force},
+        )
 
-        marker_name = _get_config().safety.reset_guard_marker
-        marker_path = Path(resolved) / marker_name
-        if not force and not marker_path.is_file():
-            await _notify(
-                ctx,
-                "error",
-                "reset_test_dir failed",
-                "autoskillit.reset_test_dir",
-                extra={"reason": "marker missing"},
-            )
-            return json.dumps(
-                {
-                    "error": f"Safety: directory missing reset guard marker ({marker_name})",
-                    "hint": f"Create the marker with: autoskillit workspace init {resolved}",
-                }
-            )
+        from autoskillit.server import _get_config, _get_ctx
 
-        if tool_ctx.workspace_mgr is None:
-            return json.dumps({"error": "Workspace manager not configured"})
+        tool_ctx = _get_ctx()
+        _start = time.monotonic()
+        try:
+            if not os.path.isdir(resolved):
+                await _notify(
+                    ctx,
+                    "error",
+                    "reset_test_dir failed",
+                    "autoskillit.reset_test_dir",
+                    extra={"reason": "directory does not exist"},
+                )
+                return json.dumps({"error": f"Directory does not exist: {resolved}"})
 
-        preserve = None if force else {marker_name}
-        cleanup = tool_ctx.workspace_mgr.delete_contents(Path(resolved), preserve=preserve)
-        return json.dumps({**cleanup.to_dict(), "forced": force})
-    finally:
-        if step_name:
-            tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
+            marker_name = _get_config().safety.reset_guard_marker
+            marker_path = Path(resolved) / marker_name
+            if not force and not marker_path.is_file():
+                await _notify(
+                    ctx,
+                    "error",
+                    "reset_test_dir failed",
+                    "autoskillit.reset_test_dir",
+                    extra={"reason": "marker missing"},
+                )
+                return json.dumps(
+                    {
+                        "error": f"Safety: directory missing reset guard marker ({marker_name})",
+                        "hint": f"Create the marker with: autoskillit workspace init {resolved}",
+                    }
+                )
+
+            if tool_ctx.workspace_mgr is None:
+                return json.dumps({"error": "Workspace manager not configured"})
+
+            preserve = None if force else {marker_name}
+            cleanup = tool_ctx.workspace_mgr.delete_contents(Path(resolved), preserve=preserve)
+            return json.dumps({**cleanup.to_dict(), "forced": force})
+        finally:
+            if step_name:
+                tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
+    except Exception as exc:
+        logger.error("reset_test_dir unhandled exception", exc_info=True)
+        return json.dumps({"error": f"{type(exc).__name__}: {exc}"})
 
 
 @mcp.tool(tags={"autoskillit", "kitchen"}, annotations={"readOnlyHint": True})
@@ -171,89 +183,95 @@ async def reset_workspace(test_dir: str, ctx: Context = CurrentContext()) -> str
 
     Args:
         test_dir: Path to the test project directory. Must contain the reset guard marker.
+
+    Never raises.
     """
     if (gate := _require_enabled()) is not None:
         return gate
-    resolved = os.path.realpath(test_dir)
-    structlog.contextvars.clear_contextvars()
-    structlog.contextvars.bind_contextvars(tool="reset_workspace", cwd=resolved)
-    logger.info("reset_workspace", resolved=str(resolved))
-    await _notify(
-        ctx,
-        "info",
-        f"reset_workspace: {resolved}",
-        "autoskillit.reset_workspace",
-        extra={"resolved": resolved},
-    )
-
-    if not os.path.isdir(resolved):
+    try:
+        resolved = os.path.realpath(test_dir)
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(tool="reset_workspace", cwd=resolved)
+        logger.info("reset_workspace", resolved=str(resolved))
         await _notify(
             ctx,
-            "error",
-            "reset_workspace failed",
+            "info",
+            f"reset_workspace: {resolved}",
             "autoskillit.reset_workspace",
-            extra={"reason": "directory does not exist"},
-        )
-        return json.dumps({"error": f"Directory does not exist: {resolved}"})
-
-    from autoskillit.server import _get_config
-
-    marker_name = _get_config().safety.reset_guard_marker
-    marker_path = Path(resolved) / marker_name
-    if not marker_path.is_file():
-        await _notify(
-            ctx,
-            "error",
-            "reset_workspace failed",
-            "autoskillit.reset_workspace",
-            extra={"reason": "marker missing"},
-        )
-        return json.dumps(
-            {
-                "error": f"Safety: directory missing reset guard marker ({marker_name})",
-                "hint": f"Create the marker with: autoskillit workspace init {resolved}",
-            }
+            extra={"resolved": resolved},
         )
 
-    reset_cmd = _get_config().reset_workspace.command
-    if reset_cmd is None:
-        await _notify(
-            ctx,
-            "error",
-            "reset_workspace failed",
-            "autoskillit.reset_workspace",
-            extra={"reason": "not configured"},
+        if not os.path.isdir(resolved):
+            await _notify(
+                ctx,
+                "error",
+                "reset_workspace failed",
+                "autoskillit.reset_workspace",
+                extra={"reason": "directory does not exist"},
+            )
+            return json.dumps({"error": f"Directory does not exist: {resolved}"})
+
+        from autoskillit.server import _get_config
+
+        marker_name = _get_config().safety.reset_guard_marker
+        marker_path = Path(resolved) / marker_name
+        if not marker_path.is_file():
+            await _notify(
+                ctx,
+                "error",
+                "reset_workspace failed",
+                "autoskillit.reset_workspace",
+                extra={"reason": "marker missing"},
+            )
+            return json.dumps(
+                {
+                    "error": f"Safety: directory missing reset guard marker ({marker_name})",
+                    "hint": f"Create the marker with: autoskillit workspace init {resolved}",
+                }
+            )
+
+        reset_cmd = _get_config().reset_workspace.command
+        if reset_cmd is None:
+            await _notify(
+                ctx,
+                "error",
+                "reset_workspace failed",
+                "autoskillit.reset_workspace",
+                extra={"reason": "not configured"},
+            )
+            return json.dumps({"error": "reset_workspace not configured for this project"})
+
+        returncode, stdout, stderr = await _run_subprocess(
+            reset_cmd,
+            cwd=resolved,
+            timeout=60,
         )
-        return json.dumps({"error": "reset_workspace not configured for this project"})
 
-    returncode, stdout, stderr = await _run_subprocess(
-        reset_cmd,
-        cwd=resolved,
-        timeout=60,
-    )
+        if returncode != 0:
+            await _notify(
+                ctx,
+                "error",
+                "reset_workspace failed",
+                "autoskillit.reset_workspace",
+                extra={"reason": "reset command failed", "exit_code": returncode},
+            )
+            return json.dumps(
+                {
+                    "error": "reset command failed",
+                    "exit_code": returncode,
+                    "stderr": truncate_text(stderr),
+                }
+            )
 
-    if returncode != 0:
-        await _notify(
-            ctx,
-            "error",
-            "reset_workspace failed",
-            "autoskillit.reset_workspace",
-            extra={"reason": "reset command failed", "exit_code": returncode},
-        )
-        return json.dumps(
-            {
-                "error": "reset command failed",
-                "exit_code": returncode,
-                "stderr": truncate_text(stderr),
-            }
-        )
+        from autoskillit.server import _get_ctx
 
-    from autoskillit.server import _get_ctx
+        tool_ctx = _get_ctx()
+        if tool_ctx.workspace_mgr is None:
+            return json.dumps({"error": "Workspace manager not configured"})
 
-    tool_ctx = _get_ctx()
-    if tool_ctx.workspace_mgr is None:
-        return json.dumps({"error": "Workspace manager not configured"})
-
-    preserve = set(_get_config().reset_workspace.preserve_dirs) | {marker_name}
-    cleanup = tool_ctx.workspace_mgr.delete_contents(Path(resolved), preserve=preserve)
-    return json.dumps(cleanup.to_dict())
+        preserve = set(_get_config().reset_workspace.preserve_dirs) | {marker_name}
+        cleanup = tool_ctx.workspace_mgr.delete_contents(Path(resolved), preserve=preserve)
+        return json.dumps(cleanup.to_dict())
+    except Exception as exc:
+        logger.error("reset_workspace unhandled exception", exc_info=True)
+        return json.dumps({"error": f"{type(exc).__name__}: {exc}"})

--- a/tests/arch/_helpers.py
+++ b/tests/arch/_helpers.py
@@ -228,6 +228,54 @@ def _is_mcp_tool_decorator(node: ast.expr) -> bool:
     return False
 
 
+def _has_toplevel_except_exception(func_node: ast.AsyncFunctionDef | ast.FunctionDef) -> bool:
+    """Return True if the function has a top-level try/except Exception.
+
+    A leading gate-check guard (if ... return/raise ...) before the try is permitted,
+    matching the canonical gated-tool pattern used across the server layer.
+    """
+    body = func_node.body
+    # Skip docstring
+    stmts = [
+        s for s in body if not isinstance(s, ast.Expr) or not isinstance(s.value, ast.Constant)
+    ]
+    if not stmts:
+        return False
+    # Skip leading guard `if ... return` statements (gate checks, early validation exits)
+    idx = 0
+    while idx < len(stmts):
+        s = stmts[idx]
+        if (
+            isinstance(s, ast.If)
+            and len(s.body) == 1
+            and isinstance(s.body[0], (ast.Return, ast.Raise))
+            and not s.orelse
+        ):
+            idx += 1
+        else:
+            break
+    if idx >= len(stmts):
+        return False
+    first = stmts[idx]
+    if not isinstance(first, ast.Try):
+        return False
+    # Check that at least one handler catches Exception or BaseException
+    for handler in first.handlers:
+        if handler.type is None:  # bare except:
+            return True
+        if isinstance(handler.type, ast.Name) and handler.type.id in (
+            "Exception",
+            "BaseException",
+        ):
+            return True
+        if isinstance(handler.type, ast.Attribute) and handler.type.attr in (
+            "Exception",
+            "BaseException",
+        ):
+            return True
+    return False
+
+
 def _runtime_import_froms(path: Path) -> list[ast.ImportFrom]:
     """Return ImportFrom nodes not inside a TYPE_CHECKING guard."""
     tree = ast.parse(path.read_text())

--- a/tests/arch/test_never_raises_contracts.py
+++ b/tests/arch/test_never_raises_contracts.py
@@ -15,6 +15,8 @@ import ast
 import re
 from pathlib import Path
 
+from tests.arch._helpers import SRC_ROOT, _has_toplevel_except_exception, _is_mcp_tool_decorator
+
 _NEVER_RAISES_RE = re.compile(r"never raises", re.IGNORECASE)
 
 
@@ -22,52 +24,61 @@ def _repo_root() -> Path:
     return Path(__file__).parent.parent.parent
 
 
-def _has_toplevel_except_exception(func_node: ast.AsyncFunctionDef | ast.FunctionDef) -> bool:
-    """Return True if the function has a top-level try/except Exception.
+def test_all_mcp_tool_handlers_have_except_exception() -> None:
+    """Every @mcp.tool() decorated function in server/ must have a
+    top-level try/except Exception block.
 
-    A leading gate-check guard (if ... return/raise ...) before the try is permitted,
-    matching the canonical gated-tool pattern used across the server layer.
+    This is stronger than test_never_raises_contracts (which is opt-in via
+    docstring). This rule is mandatory for all tool handlers — exceptions
+    that escape to @track_response_size produce generic envelopes that
+    lack domain-specific fields callers need for routing.
     """
-    body = func_node.body
-    # Skip docstring
-    stmts = [
-        s for s in body if not isinstance(s, ast.Expr) or not isinstance(s.value, ast.Constant)
-    ]
-    if not stmts:
-        return False
-    # Skip leading guard `if ... return` statements (gate checks, early validation exits)
-    idx = 0
-    while idx < len(stmts):
-        s = stmts[idx]
-        if (
-            isinstance(s, ast.If)
-            and len(s.body) == 1
-            and isinstance(s.body[0], (ast.Return, ast.Raise))
-            and not s.orelse
-        ):
-            idx += 1
-        else:
-            break
-    if idx >= len(stmts):
-        return False
-    first = stmts[idx]
-    if not isinstance(first, ast.Try):
-        return False
-    # Check that at least one handler catches Exception or BaseException
-    for handler in first.handlers:
-        if handler.type is None:  # bare except:
-            return True
-        if isinstance(handler.type, ast.Name) and handler.type.id in (
-            "Exception",
-            "BaseException",
-        ):
-            return True
-        if isinstance(handler.type, ast.Attribute) and handler.type.attr in (
-            "Exception",
-            "BaseException",
-        ):
-            return True
-    return False
+    server_dir = SRC_ROOT / "server"
+    violations: list[str] = []
+
+    for path in sorted(server_dir.rglob("*.py")):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
+                continue
+            if not any(_is_mcp_tool_decorator(d) for d in node.decorator_list):
+                continue
+            if not _has_toplevel_except_exception(node):
+                rel = path.relative_to(SRC_ROOT.parent.parent)
+                violations.append(f"{rel}:{node.lineno} — {node.name}()")
+
+    assert not violations, (
+        "@mcp.tool() handlers must have a top-level try/except Exception "
+        "to return domain-specific structured errors instead of relying on "
+        "the @track_response_size safety net.\n"
+        "Violations:\n" + "\n".join(f"  {v}" for v in violations)
+    )
+
+
+def test_all_mcp_tool_handlers_claim_never_raises() -> None:
+    """Every @mcp.tool() handler should declare 'Never raises' in its docstring.
+
+    This activates test_never_raises_contracts enforcement as a second layer.
+    """
+    server_dir = SRC_ROOT / "server"
+    missing: list[str] = []
+
+    for path in sorted(server_dir.rglob("*.py")):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
+                continue
+            if not any(_is_mcp_tool_decorator(d) for d in node.decorator_list):
+                continue
+            docstring = ast.get_docstring(node) or ""
+            if "never raises" not in docstring.lower():
+                rel = path.relative_to(SRC_ROOT.parent.parent)
+                missing.append(f"{rel}:{node.lineno} — {node.name}()")
+
+    assert not missing, (
+        "@mcp.tool() handlers should claim 'Never raises' in their docstring.\n"
+        "Missing:\n" + "\n".join(f"  {v}" for v in missing)
+    )
 
 
 def test_never_raises_contracts_are_structurally_enforced() -> None:

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -375,3 +375,31 @@ def test_pr_state_enum_members_are_locked():
         PRState.ERROR,
     }
     assert PRState.DROPPED_HEALTHY.value == "dropped_healthy"
+
+
+class TestSkillResultCrashedFactory:
+    def test_crashed_returns_skill_result_with_correct_fields(self):
+        result = SkillResult.crashed(
+            exception=RuntimeError("boom"),
+            skill_command="/investigate test",
+        )
+        assert result.success is False
+        assert result.subtype == "crashed"
+        assert result.is_error is True
+        assert result.exit_code == -1
+        assert result.needs_retry is False
+        assert result.retry_reason == RetryReason.NONE
+        assert "RuntimeError: boom" in result.result
+        assert result.session_id == ""
+        assert result.stderr == ""
+
+    def test_crashed_to_json_produces_valid_envelope(self):
+        result = SkillResult.crashed(
+            exception=RuntimeError("boom"),
+            skill_command="/investigate test",
+        )
+        data = json.loads(result.to_json())
+        assert "needs_retry" in data
+        assert "session_id" in data
+        assert "subtype" in data
+        assert data["subtype"] == "crashed"

--- a/tests/execution/test_headless.py
+++ b/tests/execution/test_headless.py
@@ -2,6 +2,7 @@
 
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -9,6 +10,7 @@ from autoskillit.core.types import (
     CONTEXT_EXHAUSTION_MARKER,
     ChannelConfirmation,
     RetryReason,
+    SkillResult,
     SubprocessResult,
     TerminationReason,
 )
@@ -2148,12 +2150,62 @@ class TestCrashSessionLog:
 
         tool_ctx.runner = raising_runner  # type: ignore[assignment]
 
-        with pytest.raises(RuntimeError, match="simulated crash"):
-            await run_headless_core("/investigate test", cwd=str(tmp_path), ctx=tool_ctx)
+        skill_result = await run_headless_core(
+            "/investigate test", cwd=str(tmp_path), ctx=tool_ctx
+        )
+        assert isinstance(skill_result, SkillResult)
+        assert skill_result.success is False
+        assert skill_result.subtype == "crashed"
+        assert skill_result.is_error is True
+        assert skill_result.exit_code == -1
+        assert skill_result.needs_retry is False
+        assert "simulated crash" in skill_result.result
 
         crash_calls = [f for f in flushed if f.get("termination_reason") == "CRASHED"]
         assert len(crash_calls) >= 1
         assert crash_calls[0]["success"] is False
+
+    @pytest.mark.anyio
+    async def test_crash_exception_text_passed_to_flush(self, monkeypatch, tool_ctx, tmp_path):
+        """flush_session_log receives exception_text with the traceback on crash."""
+        from autoskillit.execution.headless import run_headless_core
+
+        flushed: list[dict] = []
+
+        def fake_flush(**kwargs: object) -> None:
+            flushed.append(dict(kwargs))
+
+        monkeypatch.setattr("autoskillit.execution.flush_session_log", fake_flush)
+
+        async def raising_runner(*args: object, **kwargs: object) -> None:
+            raise OSError("disk full")
+
+        tool_ctx.runner = raising_runner  # type: ignore[assignment]
+
+        await run_headless_core("/investigate test", cwd=str(tmp_path), ctx=tool_ctx)
+
+        crash_calls = [f for f in flushed if f.get("termination_reason") == "CRASHED"]
+        assert len(crash_calls) >= 1
+        assert "exception_text" in crash_calls[0]
+        assert "OSError: disk full" in crash_calls[0]["exception_text"]
+
+    @pytest.mark.anyio
+    async def test_crash_logs_exception_with_logger_error(self, monkeypatch, tool_ctx, tmp_path):
+        """Runner crash is logged at ERROR level with exc_info."""
+        from autoskillit.execution.headless import run_headless_core
+
+        monkeypatch.setattr("autoskillit.execution.flush_session_log", lambda **kw: None)
+
+        async def raising_runner(*args: object, **kwargs: object) -> None:
+            raise ValueError("bad input")
+
+        tool_ctx.runner = raising_runner  # type: ignore[assignment]
+
+        with patch("autoskillit.execution.headless.logger") as mock_logger:
+            await run_headless_core("/investigate test", cwd=str(tmp_path), ctx=tool_ctx)
+            mock_logger.error.assert_called_once()
+            call_kwargs = mock_logger.error.call_args
+            assert call_kwargs[1].get("exc_info") is not None
 
 
 class TestRetryBudgetEnforcement:

--- a/tests/execution/test_headless.py
+++ b/tests/execution/test_headless.py
@@ -2205,7 +2205,7 @@ class TestCrashSessionLog:
             await run_headless_core("/investigate test", cwd=str(tmp_path), ctx=tool_ctx)
             mock_logger.error.assert_called_once()
             call_kwargs = mock_logger.error.call_args
-            assert call_kwargs[1].get("exc_info") is not None
+            assert call_kwargs[1].get("exc_info")
 
 
 class TestRetryBudgetEnforcement:

--- a/tests/execution/test_headless.py
+++ b/tests/execution/test_headless.py
@@ -2202,10 +2202,11 @@ class TestCrashSessionLog:
         tool_ctx.runner = raising_runner  # type: ignore[assignment]
 
         with patch("autoskillit.execution.headless.logger") as mock_logger:
-            await run_headless_core("/investigate test", cwd=str(tmp_path), ctx=tool_ctx)
+            result = await run_headless_core("/investigate test", cwd=str(tmp_path), ctx=tool_ctx)
             mock_logger.error.assert_called_once()
             call_kwargs = mock_logger.error.call_args
             assert call_kwargs[1].get("exc_info")
+            assert result.success is False
 
 
 class TestRetryBudgetEnforcement:

--- a/tests/execution/test_session_log.py
+++ b/tests/execution/test_session_log.py
@@ -1032,3 +1032,25 @@ def test_recover_crashed_sessions_skips_wrong_boot_id(tmp_path, monkeypatch):
     count = recover_crashed_sessions(tmpfs_path=str(tmpfs), log_dir=str(tmp_path))
 
     assert count == 0
+
+
+def test_flush_writes_crash_exception_file(tmp_path):
+    """When exception_text is provided, flush_session_log writes crash_exception.txt."""
+    flush_session_log(
+        log_dir=str(tmp_path),
+        cwd="/tmp",
+        session_id="test-session",
+        pid=1234,
+        skill_command="/test",
+        success=False,
+        subtype="crashed",
+        exit_code=-1,
+        start_ts=datetime.now(UTC).isoformat(),
+        proc_snapshots=None,
+        termination_reason="CRASHED",
+        exception_text="RuntimeError: boom\n  at headless.py:1023",
+    )
+    session_dir = tmp_path / "sessions" / "test-session"
+    crash_file = session_dir / "crash_exception.txt"
+    assert crash_file.exists()
+    assert "RuntimeError: boom" in crash_file.read_text()

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -128,9 +128,9 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # tools_kitchen.py — hook config dict
     ("src/autoskillit/server/tools_kitchen.py", 142),
     # tools_status.py — mcp_data dict
-    ("src/autoskillit/server/tools_status.py", 348),
+    ("src/autoskillit/server/tools_status.py", 385),
     # tools_github.py — bug report dict
-    ("src/autoskillit/server/tools_github.py", 256),
+    ("src/autoskillit/server/tools_github.py", 268),
     # _hooks.py — settings.json dict (co-owned with Claude CLI)
     ("src/autoskillit/cli/_hooks.py", 23),
     # _init_helpers.py — ~/.claude.json (co-owned)

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -111,9 +111,9 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # core/io.py — write_versioned_json itself (the blessed helper) uses atomic_write+json.dumps
     ("src/autoskillit/core/io.py", 118),
     # session_log.py — summary dict, token_usage list, audit_log list
-    ("src/autoskillit/execution/session_log.py", 243),
-    ("src/autoskillit/execution/session_log.py", 256),
-    ("src/autoskillit/execution/session_log.py", 259),
+    ("src/autoskillit/execution/session_log.py", 244),
+    ("src/autoskillit/execution/session_log.py", 260),
+    ("src/autoskillit/execution/session_log.py", 263),
     # migration/store.py — failure store dicts
     ("src/autoskillit/migration/store.py", 54),
     ("src/autoskillit/migration/store.py", 64),

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -209,8 +209,8 @@ class TestSchemaVersionConvention:
         """List-payload sites are included since the AST scanner can't distinguish return types."""
         # These sites write list payloads through function calls but are caught by the scanner
         list_sites = [
-            ("src/autoskillit/execution/session_log.py", 256),
-            ("src/autoskillit/execution/session_log.py", 259),
+            ("src/autoskillit/execution/session_log.py", 260),
+            ("src/autoskillit/execution/session_log.py", 263),
             ("src/autoskillit/smoke_utils.py", 83),
             ("src/autoskillit/smoke_utils.py", 138),
         ]

--- a/tests/server/test_tools_execution.py
+++ b/tests/server/test_tools_execution.py
@@ -1498,3 +1498,27 @@ async def test_run_skill_idle_output_timeout_defaults_to_none(tool_ctx, monkeypa
 
     await run_skill("/test skill", "/tmp")
     assert captured["idle_output_timeout"] is None
+
+
+@pytest.mark.anyio
+async def test_run_skill_returns_structured_error_when_executor_raises(
+    tool_ctx, monkeypatch
+) -> None:
+    """run_skill returns SkillResult-shaped JSON even if executor.run() raises unexpectedly."""
+    from autoskillit.core import SkillResult
+
+    class ExplodingExecutor:
+        async def run(self, *args, **kwargs) -> SkillResult:
+            raise RuntimeError("unexpected executor failure")
+
+    tool_ctx.executor = ExplodingExecutor()
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+
+    from autoskillit.server.tools_execution import run_skill
+
+    result_json = await run_skill("/test cmd", "/tmp")
+    data = json.loads(result_json)
+    assert data["success"] is False
+    assert data["subtype"] == "crashed"
+    assert data["needs_retry"] is False
+    assert "unexpected executor failure" in data["result"]

--- a/tests/server/test_tools_execution.py
+++ b/tests/server/test_tools_execution.py
@@ -1502,7 +1502,7 @@ async def test_run_skill_idle_output_timeout_defaults_to_none(tool_ctx, monkeypa
 
 @pytest.mark.anyio
 async def test_run_skill_returns_structured_error_when_executor_raises(
-    tool_ctx, monkeypatch
+    tool_ctx, monkeypatch, tmp_path
 ) -> None:
     """run_skill returns SkillResult-shaped JSON even if executor.run() raises unexpectedly."""
     from autoskillit.core import SkillResult
@@ -1516,7 +1516,7 @@ async def test_run_skill_returns_structured_error_when_executor_raises(
 
     from autoskillit.server.tools_execution import run_skill
 
-    result_json = await run_skill("/test cmd", "/tmp")
+    result_json = await run_skill("/test cmd", str(tmp_path))
     data = json.loads(result_json)
     assert data["success"] is False
     assert data["subtype"] == "crashed"

--- a/tests/server/test_tools_load_recipe.py
+++ b/tests/server/test_tools_load_recipe.py
@@ -319,6 +319,7 @@ class TestLoadRecipeExceptionHandling:
             side_effect=AttributeError("programming error"),
         ):
             result = json.loads(await load_recipe(name="test"))
+        assert result["success"] is False
         assert "error" in result
         assert "programming error" in result["error"]
 

--- a/tests/server/test_tools_load_recipe.py
+++ b/tests/server/test_tools_load_recipe.py
@@ -307,7 +307,7 @@ class TestLoadRecipeExceptionHandling:
     async def test_unexpected_exception_returns_structured_error(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Unexpected exceptions are caught by the exception boundary."""
+        """Unexpected exceptions are caught by the handler-level exception boundary."""
         monkeypatch.chdir(tmp_path)
         recipes_dir = tmp_path / ".autoskillit" / "recipes"
         recipes_dir.mkdir(parents=True)
@@ -319,8 +319,7 @@ class TestLoadRecipeExceptionHandling:
             side_effect=AttributeError("programming error"),
         ):
             result = json.loads(await load_recipe(name="test"))
-        assert result["success"] is False
-        assert result["subtype"] == "tool_exception"
+        assert "error" in result
         assert "programming error" in result["error"]
 
 


### PR DESCRIPTION
## Summary

`run_headless_core` raises `RuntimeError` on runner crash instead of returning a structured `SkillResult`. The exception propagates through `DefaultHeadlessExecutor.run()` and `run_skill` (neither has `except`), reaching `@track_response_size` which converts it to a generic 4-field `tool_exception` envelope — not the 13+ field `SkillResult` envelope that pipeline orchestrators parse for `needs_retry`, `session_id`, `subtype`, etc. Additionally, the original exception traceback is never persisted to session diagnostics, making post-mortem analysis impossible.

The existing crash test (`test_headless.py:2151`) explicitly asserts `pytest.raises(RuntimeError)`, validating the broken behavior as correct.

This PR converts the crash path to return a structured `SkillResult` via a new `SkillResult.crashed()` factory, adds exception traceback persistence to `flush_session_log`, and adds defense-in-depth at the `run_skill` boundary. All 14 `@mcp.tool()` handlers gain mandatory `try/except Exception` boundaries enforced by a new AST test in `tests/arch/test_never_raises_contracts.py`.

## Architecture Impact

### Error/Resilience Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;

    MCP_IN([MCP Tool Request])

    %% ── L4: BACKSTOP ─────────────────────────────────────────────── %%
    BACKSTOP["L4: @track_response_size backstop<br/>━━━━━━━━━━<br/>unreachable in normal operation<br/>→ subtype: tool_exception"]

    %% ── HOOK-LEVEL GUARDS (PreToolUse, outside Python server) ─────── %%
    subgraph HookGates ["HOOK-LEVEL GATES (PreToolUse — Claude Code layer)"]
        direction LR
        HQ["quota_guard<br/>━━━━━━━━━━<br/>should_block?"]
        HH["headless_orchestration_guard<br/>━━━━━━━━━━<br/>run_skill in headless?"]
        HB["branch_protection_guard<br/>━━━━━━━━━━<br/>protected branch?"]
        HSK["skill_command_guard<br/>━━━━━━━━━━<br/>slash prefix check"]
    end

    %% ── L3: @mcp.tool() OUTER EXCEPTION BOUNDARY ─────────────────── %%
    subgraph ToolBoundary ["● L3: @mcp.tool() OUTER EXCEPTION BOUNDARY (tools_*.py × 14)"]
        direction TB
        OUTER_CATCH["outer except Exception<br/>━━━━━━━━━━<br/>pre-executor setup errors<br/>→ SkillResult.crashed().to_json()"]
    end

    %% ── IN-HANDLER VALIDATION ─────────────────────────────────────── %%
    subgraph InHandlerGates ["IN-HANDLER VALIDATION (fail-fast, tools_*.py)"]
        direction LR
        IH1["_require_not_headless()<br/>━━━━━━━━━━<br/>AUTOSKILLIT_HEADLESS == 1?"]
        IH2["_require_enabled()<br/>━━━━━━━━━━<br/>kitchen open? (gate state)"]
        IH3["run_skill preconditions<br/>━━━━━━━━━━<br/>absolute cwd · executor set<br/>dry-walkthrough marker check"]
    end

    %% ── L2: EXECUTOR EXCEPTION BOUNDARY ──────────────────────────── %%
    subgraph ExecBoundary ["● L2: EXECUTOR EXCEPTION BOUNDARY (tools_execution.py)"]
        direction TB
        INNER_CATCH["inner except Exception<br/>━━━━━━━━━━<br/>executor.run() errors<br/>→ SkillResult.crashed().to_json()"]
    end

    %% ── L1: run_headless_core() EXCEPTION BOUNDARY ────────────────── %%
    subgraph HeadlessBoundary ["● L1: run_headless_core() EXCEPTION BOUNDARY (headless.py)"]
        direction TB
        SUBPROCESS["subprocess runner<br/>━━━━━━━━━━<br/>claude headless session<br/>JSONL streaming"]
        CRASH_CATCH["except Exception<br/>━━━━━━━━━━<br/>traceback.format_exc()<br/>logger.error()"]
        ATOMIC_WRITE["● atomic_write()<br/>━━━━━━━━━━<br/>session_dir/crash_exception.txt<br/>(write-only post-mortem artifact)"]
        CRASHED_SR["● SkillResult.crashed()<br/>━━━━━━━━━━<br/>subtype=crashed · needs_retry=False<br/>exit_code=-1 · success=False"]
    end

    %% ── SESSION ERROR DETECTION ───────────────────────────────────── %%
    subgraph SessionDetect ["SESSION ERROR DETECTION (headless.py + session.py)"]
        direction TB
        TERM_REASON["termination reason classifier<br/>━━━━━━━━━━<br/>STALE · IDLE_STALL · TIMED_OUT<br/>NATURAL_EXIT"]
        PARSE_RESULT["parse_session_result()<br/>━━━━━━━━━━<br/>empty output · unparseable NDJSON<br/>context exhaustion"]
        CONTENT_EVAL["_evaluate_content_state()<br/>━━━━━━━━━━<br/>COMPLETE · ABSENT · CONTRACT_VIOLATION"]
        COMPUTE_OUT["_compute_outcome()<br/>━━━━━━━━━━<br/>contradiction guard (success+retry → failure)<br/>dead-end guard (ABSENT → DRAIN_RACE retry)"]
    end

    %% ── RESULT OVERRIDE GATES ─────────────────────────────────────── %%
    subgraph ResultGates ["● RESULT OVERRIDE GATES (_type_results.py + headless.py)"]
        direction LR
        PATH_G["path_contamination gate<br/>━━━━━━━━━━<br/>write path outside cwd?<br/>→ RETRIABLE(PATH_CONTAMINATION)"]
        ZERO_G["zero_writes gate<br/>━━━━━━━━━━<br/>write-expected skill, 0 Edit/Write calls?<br/>→ RETRIABLE(ZERO_WRITES)"]
        CONTRACT_G["contract_recovery gate<br/>━━━━━━━━━━<br/>adjudicated_failure + write evidence?<br/>→ promotes to RETRIABLE"]
        BUDGET_G["_apply_budget_guard() — circuit breaker<br/>━━━━━━━━━━<br/>consecutive_failures > max_consecutive_retries<br/>→ BUDGET_EXHAUSTED (terminal)"]
    end

    %% ── RECOVERY MECHANISMS ───────────────────────────────────────── %%
    subgraph Recovery ["RECOVERY MECHANISMS"]
        direction LR
        STALE_REC["stale stdout recovery<br/>━━━━━━━━━━<br/>parse SUCCESS from stdout<br/>→ synthesize recovered_from_stale"]
        CLONE_REV["clone contamination revert<br/>━━━━━━━━━━<br/>git reset --hard + git clean<br/>→ RETRIABLE(CLONE_CONTAMINATION)"]
        QUOTA_SLEEP["quota sleep routing<br/>━━━━━━━━━━<br/>hook: run_cmd sleep N<br/>→ LLM retries run_skill"]
    end

    %% ── AST ENFORCEMENT ───────────────────────────────────────────── %%
    AST_ENFORCE["● tests/arch/test_never_raises_contracts.py<br/>━━━━━━━━━━<br/>AST: all @mcp.tool() handlers must have<br/>except Exception + 'Never raises.' docstring"]

    %% ── TERMINAL STATES ───────────────────────────────────────────── %%
    T_GATE_DENY([GATE_DENIED])
    T_SUCCEED([SUCCEEDED])
    T_RETRY([RETRIABLE])
    T_FAIL([FAILED])
    T_BUDGET([BUDGET_EXHAUSTED])

    %% ═══════════════ CONNECTIONS ═══════════════ %%

    %% Entry → hooks %%
    MCP_IN --> HookGates
    HQ -->|"quota exceeded"| QUOTA_SLEEP
    QUOTA_SLEEP -->|"after sleep"| MCP_IN
    HH -->|"deny"| T_GATE_DENY
    HB -->|"deny"| T_GATE_DENY
    HSK -->|"deny"| T_GATE_DENY

    %% Hooks → L4 backstop → L3 boundary %%
    HookGates -->|"permit"| BACKSTOP
    BACKSTOP --> ToolBoundary
    BACKSTOP -->|"escapes all layers"| T_FAIL

    %% L3 → validation → L2 %%
    ToolBoundary --> InHandlerGates
    ToolBoundary -->|"exception in outer body"| OUTER_CATCH
    OUTER_CATCH --> T_FAIL
    IH1 -->|"headless"| T_GATE_DENY
    IH2 -->|"kitchen closed"| T_GATE_DENY
    IH3 -->|"precondition fail"| T_FAIL
    InHandlerGates --> ExecBoundary

    %% L2 → L1 %%
    ExecBoundary --> HeadlessBoundary
    ExecBoundary -->|"exception in executor.run()"| INNER_CATCH
    INNER_CATCH --> T_FAIL

    %% L1 crash path %%
    SUBPROCESS -->|"exception during run"| CRASH_CATCH
    CRASH_CATCH --> ATOMIC_WRITE
    CRASH_CATCH --> CRASHED_SR
    CRASHED_SR --> T_FAIL

    %% L1 normal exit → session detection %%
    SUBPROCESS -->|"subprocess exits"| SessionDetect
    TERM_REASON -->|"STALE"| STALE_REC
    STALE_REC -->|"recoverable stdout"| T_SUCCEED
    STALE_REC -->|"not recoverable"| ResultGates
    TERM_REASON -->|"IDLE_STALL / TIMED_OUT"| ResultGates
    TERM_REASON -->|"NATURAL_EXIT"| PARSE_RESULT
    PARSE_RESULT --> CONTENT_EVAL
    CONTENT_EVAL --> COMPUTE_OUT
    COMPUTE_OUT -->|"SUCCEEDED"| T_SUCCEED
    COMPUTE_OUT -->|"RETRIABLE / FAILED"| ResultGates

    %% Override gates %%
    PATH_G -->|"contaminated"| CLONE_REV
    CLONE_REV --> T_RETRY
    PATH_G -->|"clean"| ZERO_G
    ZERO_G -->|"zero writes"| T_RETRY
    ZERO_G -->|"ok"| CONTRACT_G
    CONTRACT_G -->|"promotes"| T_RETRY
    CONTRACT_G -->|"no promotion"| BUDGET_G
    BUDGET_G -->|"budget exhausted"| T_BUDGET
    BUDGET_G -->|"budget ok"| T_RETRY

    %% Enforcement link %%
    ToolBoundary -.->|"structurally enforced by"| AST_ENFORCE

    %% CLASS ASSIGNMENTS %%
    class MCP_IN terminal;
    class HQ,HH,HB,HSK detector;
    class BACKSTOP gap;
    class OUTER_CATCH,INNER_CATCH handler;
    class IH1,IH2,IH3 detector;
    class SUBPROCESS handler;
    class CRASH_CATCH,ATOMIC_WRITE,CRASHED_SR phase;
    class TERM_REASON,PARSE_RESULT,CONTENT_EVAL,COMPUTE_OUT handler;
    class PATH_G,ZERO_G,CONTRACT_G,BUDGET_G detector;
    class STALE_REC,CLONE_REV,QUOTA_SLEEP output;
    class AST_ENFORCE newComponent;
    class T_GATE_DENY,T_SUCCEED,T_RETRY,T_FAIL,T_BUDGET terminal;
```

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% TERMINAL NODES %%
    ENTRY([MCP Tool Called])
    RESULT_OUT([SkillResult / JSON → MCP Caller])

    subgraph Lifecycles ["FIELD LIFECYCLE CATEGORIES — ● SkillResult (_type_results.py)"]
        direction LR
        IO["INIT_ONLY — crash factory<br/>━━━━━━━━━━<br/>success=False · is_error=True<br/>exit_code=-1 · subtype='crashed'<br/>needs_retry=False · session_id=''<br/>retry_reason=NONE · stderr=''<br/>result='{ExcType}: {message}'"]
        MU["MUTABLE — reassignable ref<br/>━━━━━━━━━━<br/>skill_result (reference)<br/>may be reassigned by:<br/>• contract nudge (CONTRACT_RECOVERY)<br/>• clone contamination revert<br/>— token_usage · worktree_path"]
        AO["APPEND_ONLY<br/>━━━━━━━━━━<br/>write_path_warnings<br/>grows during run,<br/>never cleared or replaced"]
        DE["DERIVED — not stored<br/>━━━━━━━━━━<br/>outcome property<br/>SUCCEEDED / RETRIABLE / FAILED<br/>excluded from to_json()"]
    end

    subgraph ExcGates ["EXCEPTION BOUNDARY GATES — ● tools_*.py (all server tools)"]
        direction TB
        G1["● Pre-execution Gate<br/>━━━━━━━━━━<br/>Gate policy · kitchen open · quota<br/>Returns error json before any mutation<br/>(FAIL-FAST)"]
        G2["● try: handler body<br/>━━━━━━━━━━<br/>ALL @mcp.tool() handlers<br/>Mandatory top-level try/except Exception<br/>Contract: 'Never raises' in docstring"]
        G3{"exception<br/>raised?"}
        G4["● on exception → error json<br/>━━━━━━━━━━<br/>most tools: json.dumps({'success':False,...})<br/>run_skill: SkillResult.crashed().to_json()<br/>NEVER propagates raw exception"]
        G5["on success → structured json<br/>━━━━━━━━━━<br/>domain-specific response dict<br/>OR SkillResult.to_json()"]
        G6["@track_response_size<br/>━━━━━━━━━━<br/>Tertiary safety net (helpers.py)<br/>subtype='tool_exception'<br/>last-resort catch for any escape"]
    end

    subgraph CrashState ["● CRASH STATE CONSTRUCTION — run_headless_core (headless.py)"]
        direction TB
        C1["● except Exception as exc<br/>━━━━━━━━━━<br/>Runner failure intercepted<br/>NEVER re-raises to caller"]
        C2["● traceback.format_exc()<br/>━━━━━━━━━━<br/>Full traceback captured<br/>into _exc_text string"]
        C3["● flush_session_log(<br/>    exception_text=_exc_text,<br/>    termination_reason='CRASHED',<br/>    exit_code=-1, pid=0<br/>)<br/>━━━━━━━━━━<br/>Best-effort; swallows own failures"]
        C4["● SkillResult.crashed(exc)<br/>━━━━━━━━━━<br/>Factory locks all INIT_ONLY fields<br/>order_id passed through<br/>Returns structured SkillResult"]
    end

    subgraph Artifacts ["● SESSION ARTIFACTS (session_log.py)"]
        direction LR
        AF1["● crash_exception.txt<br/>━━━━━━━━━━<br/>atomic_write()<br/>Full traceback text<br/>WRITE-ONLY audit artifact<br/>(never read back by system)"]
        AF2["SkillResult JSON envelope<br/>━━━━━━━━━━<br/>worktree_path omitted if None<br/>order_id omitted if empty<br/>outcome always excluded"]
    end

    subgraph AST ["● BUILD-TIME ENFORCEMENT — test_never_raises_contracts.py"]
        direction TB
        A1["● test_all_mcp_tool_handlers_have_except_exception<br/>━━━━━━━━━━<br/>AST walk: every @mcp.tool() in server/<br/>must have top-level try/except Exception"]
        A2["● test_all_mcp_tool_handlers_claim_never_raises<br/>━━━━━━━━━━<br/>Docstring must contain 'Never raises'<br/>(case-insensitive)"]
        A3["● test_never_raises_contracts_are_structurally_enforced<br/>━━━━━━━━━━<br/>'Never raises' docstring anywhere in server/<br/>→ must have try/except Exception or BaseException"]
    end

    %% PRIMARY FLOW %%
    ENTRY --> G1
    G1 -->|gate fail: return error| RESULT_OUT
    G1 -->|gate pass| G2
    G2 --> G3
    G3 -->|No| G5
    G3 -->|Yes| G4
    G5 --> RESULT_OUT
    G4 --> RESULT_OUT
    G2 -.->|escape path| G6
    G6 --> RESULT_OUT

    %% CRASH PATH (run_skill delegates into headless) %%
    G2 -.->|"run_skill delegates to<br/>run_headless_core"| C1
    C1 --> C2
    C2 --> C3
    C3 --> C4
    C3 --> AF1
    C4 --> IO
    C4 --> AF2
    AF2 --> G4

    %% FIELD RELATIONSHIPS %%
    IO -.->|"sealed by factory"| AF2
    MU -.->|"may be replaced post-runner"| AF2
    DE -.->|"computed; excluded"| AF2

    %% BUILD-TIME ENFORCEMENT %%
    A1 & A2 & A3 -.->|"enforce at test-time"| G2

    %% CLASS ASSIGNMENTS %%
    class ENTRY,RESULT_OUT terminal;
    class IO detector;
    class MU stateNode;
    class AO gap;
    class DE output;
    class G1 detector;
    class G2,G3 phase;
    class G4 handler;
    class G5 output;
    class G6 gap;
    class C1,C2,C3,C4 handler;
    class A1,A2,A3 cli;
    class AF1,AF2 output;
```

### Operational Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 65, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    MCP_CLIENT(["MCP Client / Pipeline Orchestrator"])

    subgraph TOOL_LAYER ["● MCP TOOL HANDLER LAYER  (server/tools_*.py — 12 files)"]
        direction TB
        RUN_SKILL["● run_skill<br/>━━━━━━━━━━<br/>skill_command, cwd, model<br/>→ SkillResult JSON<br/><i>Never raises</i>"]
        OTHER_TOOLS["● 11 other @mcp.tool() handlers<br/>━━━━━━━━━━<br/>run_cmd · run_python · open_kitchen<br/>close_kitchen · kitchen_status<br/>merge_worktree · clone_repo · …<br/><i>Never raises</i>"]
        OUTER_EXCEPT["● Top-level try/except Exception<br/>━━━━━━━━━━<br/>Safety net: catches anything<br/>not caught by inner handlers<br/>Returns domain-specific JSON envelope"]
    end

    subgraph EXEC_LAYER ["● HEADLESS EXECUTION  (execution/headless.py)"]
        direction TB
        RUN_CORE["● run_headless_core()<br/>━━━━━━━━━━<br/>Full subprocess lifecycle<br/>cmd prep → launch → scan → result"]
        SUBPROCESS["claude CLI subprocess<br/>━━━━━━━━━━<br/>JSONL stdout / Channel B JSONL"]
        BUILD_RESULT["_build_skill_result()<br/>━━━━━━━━━━<br/>Normal path: parse session result<br/>subtype · needs_retry · retry_reason"]
        CRASH_EXCEPT["● except Exception (crash path)<br/>━━━━━━━━━━<br/>Pre-launch or mid-flight exception<br/>flush_session_log → SkillResult.crashed()"]
    end

    subgraph RESULT_TYPES ["● RESULT CONTRACTS  (core/_type_results.py)"]
        direction LR
        SKILL_RESULT_OK["SkillResult<br/>━━━━━━━━━━<br/>success · subtype · exit_code<br/>needs_retry · retry_reason<br/>token_usage · kill_reason"]
        CRASHED_FACTORY["● SkillResult.crashed()<br/>━━━━━━━━━━<br/>subtype='crashed'<br/>exit_code=-1 · is_error=True<br/>needs_retry=False<br/>result = ExcType: message"]
    end

    subgraph SESSION_OBS ["● SESSION OBSERVABILITY  (execution/session_log.py)"]
        direction TB
        FLUSH_LOG["● flush_session_log() on crash<br/>━━━━━━━━━━<br/>Writes crash entry to session dir<br/>termination_reason='CRASHED'<br/>exception_text stored"]
        LOG_DIR["Session Logs (write-only)<br/>━━━━━━━━━━<br/>~/.local/share/autoskillit/logs/<br/>{session-id}/  ·  sessions.jsonl<br/>Query: jq 'select(.success==false)'"]
    end

    subgraph ENFORCEMENT ["● STRUCTURAL GUARDS  (tests/arch/test_never_raises_contracts.py)"]
        direction TB
        AST_TOOL_TEST["● test_all_mcp_tool_handlers_have_except_exception<br/>━━━━━━━━━━<br/>AST walk: every @mcp.tool() fn<br/>must have top-level try/except Exception<br/>(stronger than Never raises docstring check)"]
        AST_HELPERS["● _helpers.py · _has_toplevel_except_exception()<br/>━━━━━━━━━━<br/>Shared AST visitor: verifies<br/>first stmt is Try with ExceptException handler"]
    end

    %% MAIN FLOW %%
    MCP_CLIENT --> RUN_SKILL
    MCP_CLIENT --> OTHER_TOOLS

    RUN_SKILL --> OUTER_EXCEPT
    OTHER_TOOLS --> OUTER_EXCEPT

    RUN_SKILL --> RUN_CORE
    RUN_CORE --> SUBPROCESS
    SUBPROCESS --> BUILD_RESULT
    SUBPROCESS --> CRASH_EXCEPT

    BUILD_RESULT --> SKILL_RESULT_OK
    CRASH_EXCEPT --> FLUSH_LOG
    CRASH_EXCEPT --> CRASHED_FACTORY
    OUTER_EXCEPT --> CRASHED_FACTORY

    FLUSH_LOG --> LOG_DIR

    SKILL_RESULT_OK --> MCP_CLIENT
    CRASHED_FACTORY --> MCP_CLIENT

    AST_HELPERS --> AST_TOOL_TEST

    %% CLASS ASSIGNMENTS %%
    class MCP_CLIENT terminal;
    class RUN_SKILL,OTHER_TOOLS handler;
    class OUTER_EXCEPT detector;
    class RUN_CORE,SUBPROCESS phase;
    class BUILD_RESULT phase;
    class CRASH_EXCEPT detector;
    class SKILL_RESULT_OK stateNode;
    class CRASHED_FACTORY newComponent;
    class FLUSH_LOG handler;
    class LOG_DIR output;
    class AST_TOOL_TEST,AST_HELPERS detector;
```

Closes #811

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260413-193250-102132/.autoskillit/temp/rectify/rectify_headless_core_crash_path_2026-04-13_194500_part_a.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 215 | 19.5k | 1.3M | 77.0k | 1 | 5m 11s |
| verify | 108 | 14.4k | 637.5k | 59.2k | 1 | 4m 3s |
| **Total** | 323 | 33.8k | 1.9M | 136.2k | | 9m 15s |