### PR TITLE
clone_repo: clone from remote URL, not local working copy

### DIFF
--- a/src/autoskillit/workspace/clone.py
+++ b/src/autoskillit/workspace/clone.py
@@ -33,6 +33,19 @@ RUNS_DIR = "autoskillit-runs"
 _NETWORK_URL_PREFIXES = ("https://", "http://", "git@", "git://", "ssh://", "file://")
 
 
+def _is_not_file_url(url: str) -> bool:
+    """Return True if url is a usable clone source (not a self-referential file:// URL).
+
+    file:// URLs are written by _ensure_origin_isolated to point at the clone directory
+    itself. Using them as a clone source would clone from the stale local working tree
+    instead of fetching fresh state from the real remote (the #817 bug).
+
+    Local bare paths (no scheme) and real network URLs (https://, git@, etc.) are both
+    valid clone sources and are accepted.
+    """
+    return bool(url) and not url.startswith("file://")
+
+
 def classify_remote_url(url: str) -> str:
     """Classify a git remote URL as 'network', 'bare_local', 'nonbare_local', 'none', or 'unknown'.
 
@@ -238,10 +251,13 @@ def _ensure_origin_isolated(clone_path: Path, known_url: str) -> None:
 
 @dataclass(frozen=True)
 class CloneSourceResolution:
-    """Result of probing a source directory for its origin URL.
+    """Result of probing a source directory for its clone-source remote URL.
+
+    Tries 'upstream' first (real remote when source_dir is a previous autoskillit
+    clone), then 'origin'. Returns the first non-file:// URL found.
 
     reason:
-        "ok"        — origin is configured and subprocess returned a URL
+        "ok"        — a usable remote URL was found and returned
         "no_origin" — no origin remote is configured in this repo
         "timeout"   — subprocess.run timed out (30 s)
         "error"     — subprocess returned non-zero exit code
@@ -254,17 +270,15 @@ class CloneSourceResolution:
     stderr: str
 
 
-def _probe_origin_url(source: Path) -> CloneSourceResolution:
-    """Probe source for its origin remote URL.
+def _probe_single_remote(source: Path, remote_name: str) -> CloneSourceResolution:
+    """Run ``git remote get-url <remote_name>`` in source and return a typed result.
 
-    Runs ``git remote get-url origin`` with a 30-second timeout and
-    classifies the result into one of four typed reasons so callers
-    cannot collapse the outcomes into a single empty string.
+    Shared by _probe_clone_source_url for each candidate remote name.
     """
-    _no_origin_markers = ("no such remote",)
+    _no_remote_markers = ("no such remote",)
     try:
         result = subprocess.run(
-            ["git", "remote", "get-url", "origin"],
+            ["git", "remote", "get-url", remote_name],
             cwd=str(source),
             capture_output=True,
             text=True,
@@ -277,17 +291,41 @@ def _probe_origin_url(source: Path) -> CloneSourceResolution:
 
     if result.returncode != 0:
         stderr = result.stderr.strip()
-        stderr_lower = stderr.lower()
-        if any(marker in stderr_lower for marker in _no_origin_markers):
+        if any(m in stderr.lower() for m in _no_remote_markers):
             return CloneSourceResolution(reason="no_origin", url="", stderr=stderr)
         return CloneSourceResolution(reason="error", url="", stderr=stderr)
 
     url = result.stdout.strip()
     if not url:
-        # git normally returns non-zero for missing origin, but guard defensively
         return CloneSourceResolution(reason="no_origin", url="", stderr="")
-
     return CloneSourceResolution(reason="ok", url=url, stderr="")
+
+
+def _probe_clone_source_url(source: Path) -> CloneSourceResolution:
+    """Probe source for the best remote URL to use as the git clone source.
+
+    Avoids cloning from stale file:// local state:
+    1. Try 'upstream' — when source_dir is a previous autoskillit clone,
+       _ensure_origin_isolated sets upstream to the real remote and
+       origin to a self-referential file:// URL. Using upstream avoids cloning
+       from the stale local filesystem (fix for #817).
+    2. Try 'origin' — if upstream is absent or is itself a file:// URL, falls
+       back to origin, which is the real remote in a fresh dev checkout.
+    3. If neither yields a non-file:// URL, returns origin's result so callers
+       get the appropriate error (no_origin / error / local path as-is).
+
+    file:// URLs are explicitly excluded because _ensure_origin_isolated writes
+    them to point at the clone directory itself — a stale local reference.
+    Local bare paths (no scheme) and real network URLs are both accepted.
+    """
+    for remote_name in ("upstream", "origin"):
+        result = _probe_single_remote(source, remote_name)
+        if result.reason == "ok" and _is_not_file_url(result.url):
+            return result
+
+    # No non-file:// URL found — return origin's result (may be no_origin, error,
+    # or a local path). The caller raises RuntimeError for non-ok reasons.
+    return _probe_single_remote(source, "origin")
 
 
 def clone_repo(
@@ -390,7 +428,7 @@ def clone_repo(
     clone_path = runs_parent / f"{run_name}-{timestamp}"
     runs_parent.mkdir(parents=True, exist_ok=True)
 
-    resolution = _probe_origin_url(source)
+    resolution = _probe_clone_source_url(source)
 
     if strategy == "clone_local":
         shutil.copytree(str(source), str(clone_path))

--- a/tests/workspace/test_clone.py
+++ b/tests/workspace/test_clone.py
@@ -1503,51 +1503,295 @@ class TestCloneRemoteUrlResolution:
         )
 
 
-class TestProbeOriginUrl:
-    """Unit tests for _probe_origin_url (replaces TestResolveCloneSource)."""
+class TestProbeSingleRemote:
+    """Unit tests for _probe_single_remote helper."""
 
-    def test_probe_origin_url_returns_ok_reason_when_remote_configured(
+    def test_probe_single_remote_returns_ok_reason_when_remote_configured(
         self, local_with_remote: Path, bare_remote: Path
     ) -> None:
-        from autoskillit.workspace.clone import _probe_origin_url
+        from autoskillit.workspace.clone import _probe_single_remote
 
-        resolution = _probe_origin_url(local_with_remote)
+        resolution = _probe_single_remote(local_with_remote, "origin")
         assert resolution.reason == "ok"
         assert resolution.url == str(bare_remote)
         assert resolution.stderr == ""
 
-    def test_probe_origin_url_returns_no_origin_reason_when_no_remote(
+    def test_probe_single_remote_returns_no_origin_reason_when_no_remote(
         self, git_repo: Path
     ) -> None:
-        from autoskillit.workspace.clone import _probe_origin_url
+        from autoskillit.workspace.clone import _probe_single_remote
 
-        resolution = _probe_origin_url(git_repo)
+        resolution = _probe_single_remote(git_repo, "origin")
         assert resolution.reason == "no_origin"
         assert resolution.url == ""
 
-    def test_probe_origin_url_returns_timeout_reason_on_timeout(self, tmp_path: Path) -> None:
-        from autoskillit.workspace.clone import _probe_origin_url
+    def test_probe_single_remote_returns_timeout_reason_on_timeout(self, tmp_path: Path) -> None:
+        from autoskillit.workspace.clone import _probe_single_remote
 
         with patch(
             "autoskillit.workspace.clone.subprocess.run",
             side_effect=subprocess.TimeoutExpired(cmd=["git"], timeout=30),
         ):
-            resolution = _probe_origin_url(tmp_path)
+            resolution = _probe_single_remote(tmp_path, "origin")
         assert resolution.reason == "timeout"
         assert resolution.url == ""
 
-    def test_probe_origin_url_returns_error_reason_on_non_zero_rc(self, tmp_path: Path) -> None:
-        from autoskillit.workspace.clone import _probe_origin_url
+    def test_probe_single_remote_returns_error_reason_on_non_zero_rc(self, tmp_path: Path) -> None:
+        from autoskillit.workspace.clone import _probe_single_remote
 
         mock_result = MagicMock()
         mock_result.returncode = 1
         mock_result.stdout = ""
         mock_result.stderr = "fatal: not a git repository"
         with patch("autoskillit.workspace.clone.subprocess.run", return_value=mock_result):
-            resolution = _probe_origin_url(tmp_path)
+            resolution = _probe_single_remote(tmp_path, "origin")
         assert resolution.reason == "error"
         assert resolution.url == ""
         assert resolution.stderr == "fatal: not a git repository"
+
+
+class TestProbeCloneSourceUrl:
+    """Unit tests for the updated _probe_clone_source_url URL resolution logic."""
+
+    def test_prefers_upstream_network_url_over_file_origin(self, tmp_path: Path) -> None:
+        """When origin=file:// and upstream=network URL, uses upstream (the key bug fix).
+
+        This is the exact scenario that caused stale clones in multi-batch pipelines:
+        source_dir is a previous autoskillit clone with origin rewritten to file://.
+        """
+        from autoskillit.workspace.clone import _probe_clone_source_url
+
+        bare = tmp_path / "bare.git"
+        subprocess.run(["git", "init", "--bare", str(bare)], check=True, capture_output=True)
+        source = tmp_path / "source"
+        subprocess.run(["git", "init", str(source)], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(source), "config", "user.email", "t@t.com"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(source), "config", "user.name", "T"], check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "-C", str(source), "commit", "--allow-empty", "-m", "init"],
+            check=True,
+            capture_output=True,
+        )
+        # Simulate a previous _ensure_origin_isolated call: origin=file://, upstream=real remote
+        subprocess.run(
+            ["git", "-C", str(source), "remote", "add", "origin", f"file://{source}"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(source), "remote", "add", "upstream", str(bare)],
+            check=True,
+            capture_output=True,
+        )
+
+        result = _probe_clone_source_url(source)
+
+        assert result.reason == "ok"
+        assert result.url == str(bare), (
+            f"Expected upstream URL {bare!r}, got {result.url!r}. "
+            "When origin=file://, upstream should be preferred."
+        )
+
+    def test_falls_back_to_origin_when_no_upstream(self, tmp_path: Path) -> None:
+        """Without upstream remote, falls back to origin URL (existing behavior preserved)."""
+        from autoskillit.workspace.clone import _probe_clone_source_url
+
+        bare = tmp_path / "bare.git"
+        subprocess.run(["git", "init", "--bare", str(bare)], check=True, capture_output=True)
+        source = tmp_path / "source"
+        subprocess.run(["git", "clone", str(bare), str(source)], capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(source), "config", "user.email", "t@t.com"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(source), "config", "user.name", "T"], check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "-C", str(source), "commit", "--allow-empty", "-m", "init"],
+            check=True,
+            capture_output=True,
+        )
+        # Only origin is configured, no upstream
+
+        result = _probe_clone_source_url(source)
+
+        assert result.reason == "ok"
+        assert result.url == str(bare)
+
+    def test_uses_origin_when_upstream_is_file_url_and_origin_is_network(
+        self, tmp_path: Path
+    ) -> None:
+        """When upstream=file:// and origin=non-file-local-path that is network-equivalent,
+        falls through to origin result (covers edge cases where upstream is also local)."""
+        from autoskillit.workspace.clone import _probe_clone_source_url
+
+        bare = tmp_path / "bare.git"
+        subprocess.run(["git", "init", "--bare", str(bare)], check=True, capture_output=True)
+        source = tmp_path / "source"
+        subprocess.run(["git", "init", str(source)], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(source), "config", "user.email", "t@t.com"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(source), "config", "user.name", "T"], check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "-C", str(source), "commit", "--allow-empty", "-m", "init"],
+            check=True,
+            capture_output=True,
+        )
+        # upstream is a file:// URL (not a real network URL), origin is the bare path
+        subprocess.run(
+            ["git", "-C", str(source), "remote", "add", "upstream", f"file://{source}"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(source), "remote", "add", "origin", str(bare)],
+            check=True,
+            capture_output=True,
+        )
+
+        result = _probe_clone_source_url(source)
+
+        # upstream is file:// → excluded by _is_not_file_url → falls through to origin
+        assert result.reason == "ok"
+        assert result.url == str(bare)
+
+    def test_returns_no_origin_for_repo_without_remotes(self, tmp_path: Path) -> None:
+        """Repo with no remotes returns reason='no_origin' (unchanged from current behavior)."""
+        from autoskillit.workspace.clone import _probe_clone_source_url
+
+        source = tmp_path / "source"
+        subprocess.run(["git", "init", str(source)], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(source), "config", "user.email", "t@t.com"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(source), "config", "user.name", "T"], check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "-C", str(source), "commit", "--allow-empty", "-m", "init"],
+            check=True,
+            capture_output=True,
+        )
+
+        result = _probe_clone_source_url(source)
+
+        assert result.reason == "no_origin"
+        assert result.url == ""
+
+
+class TestCloneFromPreviousAutoskillitClone:
+    """Regression: cloning from a previous autoskillit clone must use the network remote."""
+
+    def test_clone_from_previous_clone_uses_upstream_not_stale_local(self, tmp_path: Path) -> None:
+        """Batch N+1 clones from batch N's clone must get fresh HEAD from the network remote,
+        not the stale local state of the previous clone.
+
+        Setup:
+          bare_remote (has commit A + commit B)
+          source      (has commit A only — stale)
+          source has: origin=file://source (isolation), upstream=bare_remote
+
+        Expected: clone_from_source gets commit B (fetched from bare_remote via upstream).
+        Bug behavior (pre-fix): gets only commit A (cloned from file://source via origin).
+        """
+        bare_remote = tmp_path / "bare.git"
+        subprocess.run(
+            ["git", "init", "--bare", "--initial-branch=main", str(bare_remote)],
+            check=True,
+            capture_output=True,
+        )
+
+        # source: has commit A, stale (does not have commit B)
+        source = tmp_path / "source"
+        subprocess.run(["git", "init", str(source)], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(source), "config", "user.email", "t@t.com"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(source), "config", "user.name", "T"], check=True, capture_output=True
+        )
+        (source / "a.txt").write_text("commit A")
+        subprocess.run(["git", "-C", str(source), "add", "."], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(source), "commit", "-m", "commit A"], check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "-C", str(source), "branch", "-M", "main"], check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "-C", str(source), "push", str(bare_remote), "main"],
+            check=True,
+            capture_output=True,
+        )
+
+        # Simulate _ensure_origin_isolated: source.origin = file://, source.upstream = bare_remote
+        subprocess.run(
+            ["git", "-C", str(source), "remote", "add", "origin", f"file://{source}"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(source), "remote", "add", "upstream", str(bare_remote)],
+            check=True,
+            capture_output=True,
+        )
+
+        # Add commit B to bare_remote directly (simulates another batch merging)
+        tmp_push = tmp_path / "push_helper"
+        subprocess.run(
+            ["git", "clone", str(bare_remote), str(tmp_push)], check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "-C", str(tmp_push), "config", "user.email", "t@t.com"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(tmp_push), "config", "user.name", "T"],
+            check=True,
+            capture_output=True,
+        )
+        (tmp_push / "b.txt").write_text("commit B")
+        subprocess.run(["git", "-C", str(tmp_push), "add", "."], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(tmp_push), "commit", "-m", "commit B"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(tmp_push), "push", "origin", "main"], check=True, capture_output=True
+        )
+
+        # Now clone from source (which is stale — missing commit B)
+        result = clone_repo(str(source), "batch2", branch="main", strategy="proceed")
+        clone_path = Path(result["clone_path"])
+
+        try:
+            # The clone MUST have b.txt (from bare_remote commit B), not just a.txt
+            assert (clone_path / "b.txt").exists(), (
+                "Clone is missing b.txt — it cloned from the stale local source instead of "
+                "the network remote (bare_remote). This is the #817 regression."
+            )
+        finally:
+            shutil.rmtree(clone_path.parent, ignore_errors=True)
+            shutil.rmtree(tmp_push, ignore_errors=True)
 
 
 class TestCloneOriginProbeFailFast:


### PR DESCRIPTION
## Summary

Changed `clone_repo` to discover the remote URL from `source_dir` (trying `upstream` first, then `origin`) and clone from the remote directly, instead of cloning from the local filesystem via `file://`. This prevents stale clones when the local checkout is behind the remote during multi-batch pipeline runs.

Key changes:
- Added `_is_not_file_url()` to reject `file://` URLs set by `_ensure_origin_isolated`
- Added `_probe_single_remote()` extracted helper for probing any named remote
- Replaced `_probe_origin_url()` with `_probe_clone_source_url()` — tries upstream first, falls back to origin, excludes `file://` URLs
- `strategy=clone_local` escape hatch unchanged
- Full test coverage: unit tests for new helpers + integration regression test

Closes #817

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| make_plan | 171 | 23.0k | 999.4k | 88.1k | 1 | 6m 2s |
| dry_walkthrough | 158 | 17.6k | 1.1M | 65.5k | 1 | 4m 38s |
| implement | 198 | 12.5k | 1.1M | 53.6k | 1 | 3m 34s |
| prepare_pr | 68 | 5.1k | 226.3k | 29.0k | 1 | 1m 28s |
| compose_pr | 67 | 2.5k | 181.2k | 15.5k | 1 | 50s |
| **Total** | 662 | 60.7k | 3.6M | 251.8k | | 16m 34s |