### PR TITLE
run_cmd bypasses RecordingSubprocessRunner during scenario recording

### DIFF
--- a/src/autoskillit/server/helpers.py
+++ b/src/autoskillit/server/helpers.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any
 
 from autoskillit.core import RESERVED_LOG_RECORD_KEYS, TerminationReason, get_logger
 from autoskillit.execution import (
+    SCENARIO_STEP_NAME_ENV,  # noqa: F401 — re-exported for tools_execution.py
     _refresh_quota_cache,  # noqa: F401 — re-exported for tools_execution.py; patched by tests
     fetch_repo_merge_state,  # noqa: F401 — re-exported for tools_ci.py
     resolve_log_dir,  # noqa: F401 — used by tools_github.py, tools_status.py

--- a/src/autoskillit/server/helpers.py
+++ b/src/autoskillit/server/helpers.py
@@ -7,7 +7,7 @@ import functools
 import json
 import os
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -352,6 +352,7 @@ async def _run_subprocess(
     *,
     cwd: str,
     timeout: float,
+    env: Mapping[str, str] | None = None,
 ) -> tuple[int, str, str]:
     """Run a subprocess asynchronously with timeout. Returns (returncode, stdout, stderr).
 
@@ -360,7 +361,7 @@ async def _run_subprocess(
     """
     runner = _get_ctx().runner
     assert runner is not None, "No subprocess runner configured"
-    result = await runner(cmd, cwd=Path(cwd), timeout=timeout)
+    result = await runner(cmd, cwd=Path(cwd), timeout=timeout, env=env)
     return _process_runner_result(result, timeout)
 
 

--- a/src/autoskillit/server/tools_execution.py
+++ b/src/autoskillit/server/tools_execution.py
@@ -74,10 +74,16 @@ async def run_cmd(
         tool_ctx = _get_ctx()
         _start = time.monotonic()
         try:
+            from autoskillit.execution.recording import SCENARIO_STEP_NAME_ENV
+
+            _env: dict[str, str] | None = (
+                {SCENARIO_STEP_NAME_ENV: step_name} if step_name else None
+            )
             returncode, stdout, stderr = await _run_subprocess(
                 ["bash", "-c", cmd],
                 cwd=cwd,
                 timeout=float(timeout),
+                env=_env,
             )
             result = {
                 "success": returncode == 0,

--- a/src/autoskillit/server/tools_execution.py
+++ b/src/autoskillit/server/tools_execution.py
@@ -20,6 +20,7 @@ from autoskillit.core import (
 )
 from autoskillit.server import mcp
 from autoskillit.server.helpers import (
+    SCENARIO_STEP_NAME_ENV,
     _check_dry_walkthrough,
     _import_and_call,
     _notify,
@@ -74,8 +75,6 @@ async def run_cmd(
         tool_ctx = _get_ctx()
         _start = time.monotonic()
         try:
-            from autoskillit.execution.recording import SCENARIO_STEP_NAME_ENV
-
             _env: dict[str, str] | None = (
                 {SCENARIO_STEP_NAME_ENV: step_name} if step_name else None
             )

--- a/tests/server/test_tools_run_cmd_unit.py
+++ b/tests/server/test_tools_run_cmd_unit.py
@@ -60,6 +60,73 @@ class TestRunCmdTiming:
         assert tool_ctx.timing_log.get_report() == []
 
 
+class TestRunCmdRecording:
+    """run_cmd threads SCENARIO_STEP_NAME into env kwarg for RecordingSubprocessRunner."""
+
+    @pytest.mark.anyio
+    async def test_run_cmd_with_step_name_passes_scenario_step_name_to_runner(self, tool_ctx):
+        """run_cmd with step_name passes SCENARIO_STEP_NAME in env kwarg to ctx.runner."""
+        from autoskillit.execution.recording import SCENARIO_STEP_NAME_ENV
+
+        tool_ctx.runner.push(_make_result(0, "ok", ""))
+        await run_cmd(cmd="echo hi", cwd="/tmp", step_name="setup")
+        call_kwargs = tool_ctx.runner.call_args_list[-1][3]
+        assert call_kwargs.get("env", {}).get(SCENARIO_STEP_NAME_ENV) == "setup"
+
+    @pytest.mark.anyio
+    async def test_run_cmd_without_step_name_passes_no_env(self, tool_ctx):
+        """run_cmd without step_name passes env=None (no SCENARIO_STEP_NAME in env)."""
+        from autoskillit.execution.recording import SCENARIO_STEP_NAME_ENV
+
+        tool_ctx.runner.push(_make_result(0, "", ""))
+        await run_cmd(cmd="echo hi", cwd="/tmp")
+        call_kwargs = tool_ctx.runner.call_args_list[-1][3]
+        env = call_kwargs.get("env")
+        assert env is None or SCENARIO_STEP_NAME_ENV not in env
+
+    @pytest.mark.anyio
+    async def test_run_cmd_with_step_name_records_non_session_step(self, tool_ctx, monkeypatch):
+        """End-to-end: run_cmd step_name → RecordingSubprocessRunner.record_non_session_step()."""
+        from unittest.mock import Mock
+
+        from autoskillit.execution.recording import RecordingSubprocessRunner
+        from tests.conftest import MockSubprocessRunner
+        from tests.conftest import _make_result as _mr
+
+        mock_recorder = Mock()
+        inner = MockSubprocessRunner()
+        inner.push(_mr(0, "task output", ""))
+        recording_runner = RecordingSubprocessRunner(recorder=mock_recorder, inner=inner)
+        tool_ctx.runner = recording_runner
+
+        await run_cmd(cmd="task install-worktree", cwd="/tmp", step_name="setup")
+
+        mock_recorder.record_non_session_step.assert_called_once_with(
+            step_name="setup",
+            tool="run_cmd",
+            result_summary={"exit_code": 0, "stdout_head": "task output"},
+        )
+
+    @pytest.mark.anyio
+    async def test_run_cmd_without_step_name_skips_recording(self, tool_ctx, monkeypatch):
+        """run_cmd without step_name does not call record_non_session_step."""
+        from unittest.mock import Mock
+
+        from autoskillit.execution.recording import RecordingSubprocessRunner
+        from tests.conftest import MockSubprocessRunner
+        from tests.conftest import _make_result as _mr
+
+        mock_recorder = Mock()
+        inner = MockSubprocessRunner()
+        inner.push(_mr(0, "", ""))
+        recording_runner = RecordingSubprocessRunner(recorder=mock_recorder, inner=inner)
+        tool_ctx.runner = recording_runner
+
+        await run_cmd(cmd="echo hi", cwd="/tmp")
+
+        mock_recorder.record_non_session_step.assert_not_called()
+
+
 class TestRunCmdHeadlessGate:
     """run_cmd returns headless_error when AUTOSKILLIT_HEADLESS=1."""
 


### PR DESCRIPTION
## Summary

`run_cmd` calls `_run_subprocess()`, which already routes through `ctx.runner` (i.e., the
`RecordingSubprocessRunner` when recording is active). The bug is that `_run_subprocess` does
not accept or forward an `env` parameter. `RecordingSubprocessRunner.__call__` reads
`SCENARIO_STEP_NAME` from the `env` kwarg to decide whether to record a non-session step;
since `env` is never passed, `step_name` is always `""` and recording is silently skipped.

The fix extends `_run_subprocess` to accept and forward `env: Mapping[str, str] | None = None`,
and wires `run_cmd` to build `{SCENARIO_STEP_NAME_ENV: step_name}` when `step_name` is non-empty —
matching the pattern already used by the headless executor for session calls.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START([run_cmd called])

    subgraph RunCmd ["● run_cmd — tools_execution.py"]
        direction TB
        StepCheck{"step_name<br/>provided?"}
        BuildEnv["★ Build env dict<br/>━━━━━━━━━━<br/>{SCENARIO_STEP_NAME_ENV: step_name}"]
        NoEnv["env = None"]
    end

    subgraph Helper ["● _run_subprocess — helpers.py"]
        direction TB
        Accept["★ Accept env param<br/>━━━━━━━━━━<br/>Mapping[str,str] | None"]
        CallRunner["runner(cmd, cwd, timeout,<br/>━━━━━━━━━━<br/>★ env=env)"]
    end

    subgraph Runner ["RecordingSubprocessRunner — recording.py"]
        direction TB
        ReadEnv["Read SCENARIO_STEP_NAME<br/>━━━━━━━━━━<br/>from env kwarg"]
        HasName{"step_name<br/>non-empty?"}
        ExecInner["Execute via inner runner<br/>━━━━━━━━━━<br/>DefaultSubprocessRunner"]
        Record["record_non_session_step()<br/>━━━━━━━━━━<br/>step_name, tool, result_summary"]
        PassThrough["Pass through unrecorded<br/>━━━━━━━━━━<br/>step_name is empty"]
    end

    RECORDED([Scenario step recorded])
    UNRECORDED([Unrecorded pass-through])

    START --> StepCheck
    StepCheck -->|"yes"| BuildEnv
    StepCheck -->|"no"| NoEnv
    BuildEnv --> Accept
    NoEnv --> Accept
    Accept --> CallRunner
    CallRunner --> ReadEnv
    ReadEnv --> HasName
    HasName -->|"yes"| ExecInner
    ExecInner --> Record
    Record --> RECORDED
    HasName -->|"no (env=None)"| PassThrough
    PassThrough --> UNRECORDED

    class START terminal;
    class RECORDED,UNRECORDED output;
    class StepCheck,HasName stateNode;
    class BuildEnv,NoEnv newComponent;
    class Accept,CallRunner newComponent;
    class ReadEnv,ExecInner handler;
    class Record phase;
    class PassThrough detector;
```

Closes #778

## Implementation Plan

Plan file: `.autoskillit/temp/make-plan/run_cmd_recording_fix_plan_2026-04-14_053310.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| make_plan | 145 | 13.6k | 882.3k | 67.5k | 1 | 4m 54s |
| dry_walkthrough | 118 | 9.3k | 674.6k | 56.2k | 1 | 2m 58s |
| implement | 148 | 5.8k | 681.7k | 43.0k | 1 | 1m 46s |
| resolve_failures | 184 | 8.6k | 981.3k | 47.3k | 1 | 11m 17s |
| compose_pr | 67 | 5.1k | 203.7k | 23.4k | 1 | 1m 37s |
| **Total** | 662 | 42.5k | 3.4M | 237.4k | | 22m 35s |