### PR TITLE
Rectify: Doctor Destroys Plugin Cache + Startup Race Regression (#902)

### DIFF
--- a/src/autoskillit/cli/_doctor.py
+++ b/src/autoskillit/cli/_doctor.py
@@ -585,12 +585,62 @@ def _check_claude_process_state_breakdown() -> DoctorResult:
     )
 
 
+def _check_plugin_cache_exists(
+    cache_dir: Path | None = None,
+) -> DoctorResult:
+    """Check that the plugin cache directory exists."""
+    _cache_dir = cache_dir or (
+        Path.home() / ".claude" / "plugins" / "cache" / "autoskillit-local" / "autoskillit"
+    )
+    if _cache_dir.is_dir():
+        return DoctorResult(
+            Severity.OK,
+            "plugin_cache_exists",
+            "Plugin cache directory exists",
+        )
+    return DoctorResult(
+        Severity.WARNING,
+        "plugin_cache_exists",
+        f"Plugin cache directory missing: {_cache_dir}. Run `autoskillit install` to recreate it.",
+    )
+
+
+def _check_installed_plugins_entry(
+    plugins_json_path: Path | None = None,
+) -> DoctorResult:
+    """Check that installed_plugins.json contains the autoskillit entry."""
+    _plugins_json = plugins_json_path or (
+        Path.home() / ".claude" / "plugins" / "installed_plugins.json"
+    )
+    if not _plugins_json.exists():
+        return DoctorResult(
+            Severity.WARNING,
+            "installed_plugins_entry",
+            "installed_plugins.json not found. Run `autoskillit install`.",
+        )
+    try:
+        data = json.loads(_plugins_json.read_text())
+    except (json.JSONDecodeError, OSError):
+        return DoctorResult(
+            Severity.WARNING,
+            "installed_plugins_entry",
+            "installed_plugins.json could not be parsed.",
+        )
+    if "autoskillit@autoskillit-local" in data:
+        return DoctorResult(
+            Severity.OK,
+            "installed_plugins_entry",
+            "autoskillit entry present in installed_plugins.json",
+        )
+    return DoctorResult(
+        Severity.WARNING,
+        "installed_plugins_entry",
+        "autoskillit entry missing from installed_plugins.json. Run `autoskillit install` to fix.",
+    )
+
+
 def run_doctor(*, output_json: bool = False) -> None:
     """Check project setup for common issues."""
-    from autoskillit.cli._marketplace import _clear_plugin_cache
-
-    _clear_plugin_cache()
-
     results: list[DoctorResult] = []
 
     # Check 1: Stale MCP servers — dead binaries or nonexistent paths
@@ -640,6 +690,12 @@ def run_doctor(*, output_json: bool = False) -> None:
 
     # Check 2b: Dual MCP registration — direct entry and marketplace plugin both present
     results.append(_check_dual_mcp_registration())
+
+    # Check 2c: Plugin cache directory exists
+    results.append(_check_plugin_cache_exists())
+
+    # Check 2d: installed_plugins.json has autoskillit entry
+    results.append(_check_installed_plugins_entry())
 
     # Check 3: autoskillit command on PATH
     if shutil.which("autoskillit") is None:

--- a/src/autoskillit/cli/_prompts.py
+++ b/src/autoskillit/cli/_prompts.py
@@ -78,6 +78,12 @@ includes {mcp_prefix}open_kitchen:
   Do NOT call AskUserQuestion — the tool is not unavailable; it only needs its \
 schema loaded on demand via ToolSearch.
 
+SERVER-STARTUP RECOVERY — If Claude Code reports "No such tool available" for \
+an AutoSkillit tool, the MCP server was still starting when the tool was called. \
+Wait a few seconds and retry the same tool call. Deferred startup I/O (audit \
+recovery, drift checks) runs in the background after the transport opens; tools \
+become available once the server finishes initializing.
+
 FIRST ACTION — before prompting for any inputs:
 0. Call {mcp_prefix}open_kitchen(name='{recipe_name}') to open the kitchen and load the recipe.
    DO NOT call AskUserQuestion or any other tool before open_kitchen.

--- a/src/autoskillit/cli/_prompts.py
+++ b/src/autoskillit/cli/_prompts.py
@@ -78,11 +78,6 @@ includes {mcp_prefix}open_kitchen:
   Do NOT call AskUserQuestion — the tool is not unavailable; it only needs its \
 schema loaded on demand via ToolSearch.
 
-SERVER-STARTUP RECOVERY — If open_kitchen returns "No such tool available", \
-the MCP server may still be starting. Wait 10 seconds and retry the call. \
-If the second attempt also fails, wait another 15 seconds and try once more. \
-Do NOT call AskUserQuestion or abort — transient startup delays are normal.
-
 FIRST ACTION — before prompting for any inputs:
 0. Call {mcp_prefix}open_kitchen(name='{recipe_name}') to open the kitchen and load the recipe.
    DO NOT call AskUserQuestion or any other tool before open_kitchen.

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -93,7 +93,7 @@ def serve(*, verbose: Annotated[bool, Parameter(name=["--verbose", "-v"])] = Fal
 
     # Import server AFTER logging is configured so module-level loggers
     # resolve to stderr+JSON, not stdout+ConsoleRenderer (structlog default).
-    from autoskillit.server import _initialize, make_context, mcp, run_startup_drift_check
+    from autoskillit.server import _initialize, make_context, mcp
 
     project_path = project_dir / ".autoskillit" / "config.yaml"
     user_path = Path.home() / ".autoskillit" / "config.yaml"
@@ -122,8 +122,6 @@ def serve(*, verbose: Annotated[bool, Parameter(name=["--verbose", "-v"])] = Fal
     plugin_dir: str | None = None if _is_plugin_installed() else str(pkg_root())
     ctx = make_context(cfg, plugin_dir=plugin_dir)
     _initialize(ctx)
-
-    run_startup_drift_check()
 
     try:
         anyio.run(serve_with_signal_guard, mcp)

--- a/src/autoskillit/server/__init__.py
+++ b/src/autoskillit/server/__init__.py
@@ -25,7 +25,6 @@ from autoskillit.pipeline import (  # noqa: F401
 )
 from autoskillit.server._lifespan import (  # noqa: F401
     _autoskillit_lifespan,
-    run_startup_drift_check,
 )
 from autoskillit.server._state import (  # noqa: E402, F401
     _ctx,
@@ -46,7 +45,6 @@ __all__ = [
     # Public utilities consumed by CLI and tests
     "version_info",
     "make_context",
-    "run_startup_drift_check",
 ]
 
 # Import all tool sub-modules to trigger @mcp.tool() registration.

--- a/src/autoskillit/server/_lifespan.py
+++ b/src/autoskillit/server/_lifespan.py
@@ -20,8 +20,6 @@ import asyncio as _asyncio
 from contextlib import asynccontextmanager
 from typing import Any
 
-import anyio
-
 from autoskillit.core import cleanup_readiness_sentinel, get_logger, write_readiness_sentinel
 from autoskillit.execution import RecordingSubprocessRunner
 from autoskillit.server._state import _get_ctx_or_none, deferred_initialize
@@ -75,17 +73,19 @@ def _finalize_recorder() -> None:
             logger.exception("recorder.finalize() failed during lifespan teardown")
 
 
-async def _run_deferred_init() -> None:
-    """Create the startup-ready event and run deferred_initialize."""
-    from autoskillit.server import _state  # noqa: PLC0415
+async def _run_drift_check_async() -> None:
+    """Run run_startup_drift_check in a thread executor."""
+    loop = _asyncio.get_running_loop()
+    await loop.run_in_executor(None, run_startup_drift_check)
 
-    event = _asyncio.Event()
-    _state._startup_ready = event
+
+async def _run_deferred_init(ready_event: _asyncio.Event) -> None:
+    """Run deferred_initialize, signalling *ready_event* when done."""
     ctx = _get_ctx_or_none()
     if ctx is not None:
-        await deferred_initialize(ctx, ready_event=event)
+        await deferred_initialize(ctx, ready_event=ready_event)
     else:
-        event.set()
+        ready_event.set()
 
 
 @asynccontextmanager
@@ -98,18 +98,35 @@ async def _autoskillit_lifespan(server: Any) -> Any:
     signal receiver via ``tg.start()``. A SIGTERM delivered after the sentinel
     appears is guaranteed to be caught by the armed receiver — no race window.
 
+    Background tasks (drift check, deferred init) are launched via
+    ``create_background_task`` (from ``pipeline.background``) so they run
+    concurrently without wrapping the ``yield`` in a task group.  A task-group
+    ``yield`` causes a cancel-scope mismatch when FastMCP resumes the generator
+    on a different task at exit.
+
     Teardown model: ``CancelledError`` from the anyio cancel scope unwinds past
-    the ``yield``, triggering ``finally:``. The sentinel is cleaned up first,
-    then ``_finalize_recorder()`` writes ``scenario.json``. Any teardown
-    exception is logged and suppressed so the process exits cleanly.
+    the ``yield``, triggering ``finally:``. Background tasks are cancelled,
+    the sentinel is cleaned up, then ``_finalize_recorder()`` writes
+    ``scenario.json``. Any teardown exception is logged and suppressed so the
+    process exits cleanly.
     """
     try:
+        from autoskillit.pipeline import create_background_task  # noqa: PLC0415
+        from autoskillit.server import _state  # noqa: PLC0415
+
+        bg_tasks: list[_asyncio.Task[None]] = []
+        event = _asyncio.Event()
+        _state._startup_ready = event
         write_readiness_sentinel()
-        async with anyio.create_task_group() as tg:
-            tg.start_soon(anyio.to_thread.run_sync, run_startup_drift_check)
-            tg.start_soon(_run_deferred_init)
-            yield
+        bg_tasks.append(create_background_task(_run_drift_check_async(), label="drift_check"))
+        bg_tasks.append(create_background_task(_run_deferred_init(event), label="deferred_init"))
+        yield
     finally:
+        for task in bg_tasks:
+            if not task.done():
+                task.cancel()
+        if bg_tasks:
+            await _asyncio.gather(*bg_tasks, return_exceptions=True)
         try:
             cleanup_readiness_sentinel()
         except Exception:

--- a/src/autoskillit/server/_lifespan.py
+++ b/src/autoskillit/server/_lifespan.py
@@ -7,10 +7,6 @@ transport opens, not on the critical startup path.
 The ``__aexit__`` side calls ``recorder.finalize()`` so scenario data survives
 SIGTERM (issue #745).
 
-The registry-hash drift check (``run_startup_drift_check``) is invoked from
-``serve()`` in ``cli/app.py`` before ``mcp.run()``, not inside this lifespan,
-so that SIGTERM received during the check cannot bypass teardown.
-
 Readiness synchronization: the lifespan writes a filesystem sentinel at
 ``core.readiness.write_readiness_sentinel()`` as the first statement inside the
 ``try:`` block. Integration tests poll the sentinel path rather than parsing log
@@ -20,12 +16,15 @@ cleaned up in ``finally:`` before ``_finalize_recorder()`` runs.
 
 from __future__ import annotations
 
+import asyncio as _asyncio
 from contextlib import asynccontextmanager
 from typing import Any
 
+import anyio
+
 from autoskillit.core import cleanup_readiness_sentinel, get_logger, write_readiness_sentinel
 from autoskillit.execution import RecordingSubprocessRunner
-from autoskillit.server._state import _get_ctx_or_none
+from autoskillit.server._state import _get_ctx_or_none, deferred_initialize
 
 logger = get_logger(__name__)
 
@@ -76,6 +75,19 @@ def _finalize_recorder() -> None:
             logger.exception("recorder.finalize() failed during lifespan teardown")
 
 
+async def _run_deferred_init() -> None:
+    """Create the startup-ready event and run deferred_initialize."""
+    from autoskillit.server import _state  # noqa: PLC0415
+
+    event = _asyncio.Event()
+    _state._startup_ready = event
+    ctx = _get_ctx_or_none()
+    if ctx is not None:
+        await deferred_initialize(ctx, ready_event=event)
+    else:
+        event.set()
+
+
 @asynccontextmanager
 async def _autoskillit_lifespan(server: Any) -> Any:
     """Server lifecycle: write readiness sentinel, yield, then finalize recording.
@@ -93,7 +105,10 @@ async def _autoskillit_lifespan(server: Any) -> Any:
     """
     try:
         write_readiness_sentinel()
-        yield
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(anyio.to_thread.run_sync, run_startup_drift_check)
+            tg.start_soon(_run_deferred_init)
+            yield
     finally:
         try:
             cleanup_readiness_sentinel()

--- a/tests/arch/test_doctor_readonly.py
+++ b/tests/arch/test_doctor_readonly.py
@@ -1,0 +1,62 @@
+"""AST guard: run_doctor() must not perform filesystem mutations (REQ-DOCTOR-READONLY).
+
+Doctor is a diagnostic command — it reads and reports but must never modify
+the filesystem. Any destructive call (shutil.rmtree, os.remove, _clear_plugin_cache, …)
+in run_doctor() or its direct callees within _doctor.py is a structural violation.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parents[2] / "src" / "autoskillit"
+
+FORBIDDEN_WRITE_CALLS = frozenset(
+    {
+        "shutil.rmtree",
+        "os.remove",
+        "os.unlink",
+        "Path.unlink",
+        "Path.rmdir",
+        "_clear_plugin_cache",
+    }
+)
+
+
+def _get_call_name(node: ast.Call) -> str:
+    """Extract dotted call name from an ast.Call node."""
+    if isinstance(node.func, ast.Attribute) and isinstance(node.func.value, ast.Name):
+        return f"{node.func.value.id}.{node.func.attr}"
+    if isinstance(node.func, ast.Name):
+        return node.func.id
+    return ""
+
+
+def _find_function(tree: ast.Module, name: str) -> ast.FunctionDef | None:
+    """Find a top-level FunctionDef by name."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    return None
+
+
+def test_doctor_performs_no_writes() -> None:
+    """REQ-DOCTOR-READONLY: run_doctor() must not perform filesystem mutations."""
+    source = (SRC / "cli" / "_doctor.py").read_text()
+    tree = ast.parse(source)
+
+    func = _find_function(tree, "run_doctor")
+    assert func is not None, "run_doctor() not found in _doctor.py"
+
+    violations: list[str] = []
+    for node in ast.walk(func):
+        if isinstance(node, ast.Call):
+            call_name = _get_call_name(node)
+            if call_name in FORBIDDEN_WRITE_CALLS:
+                violations.append(f"{call_name} at line {node.lineno}")
+
+    assert not violations, (
+        "run_doctor() must be read-only — found forbidden write call(s):\n"
+        + "\n".join(f"  {v}" for v in violations)
+    )

--- a/tests/arch/test_startup_budget.py
+++ b/tests/arch/test_startup_budget.py
@@ -26,6 +26,36 @@ def _get_call_name(node: ast.Call) -> str:
     return ""
 
 
+def test_lifespan_calls_deferred_initialize() -> None:
+    """Lifespan must wire deferred_initialize as a background task."""
+    source = (SRC / "server" / "_lifespan.py").read_text()
+    tree = ast.parse(source)
+
+    lifespan_func = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "_autoskillit_lifespan":
+            lifespan_func = node
+            break
+    assert lifespan_func is not None, "_autoskillit_lifespan not found in _lifespan.py"
+
+    # Walk the entire function body for any call to deferred_initialize
+    found = False
+    for node in ast.walk(lifespan_func):
+        if isinstance(node, ast.Call):
+            name = _get_call_name(node)
+            if "deferred_initialize" in name:
+                found = True
+                break
+            # Also check for Name nodes (direct call without module prefix)
+            if isinstance(node.func, ast.Name) and node.func.id == "_run_deferred_init":
+                found = True
+                break
+    assert found, (
+        "_autoskillit_lifespan must call deferred_initialize (or _run_deferred_init) "
+        "as a background task — deferred startup I/O is not wired into the lifespan"
+    )
+
+
 def test_no_subprocess_in_make_context() -> None:
     """REQ-STARTUP-001: make_context() must not eagerly call subprocess."""
     factory_src = (SRC / "server" / "_factory.py").read_text()
@@ -71,6 +101,51 @@ def _iter_eager_calls(func_node: ast.FunctionDef) -> list[ast.Call]:
         _EagerCallVisitor().visit(stmt)
 
     return eager_calls
+
+
+def test_no_calls_between_initialize_and_anyio_run() -> None:
+    """REQ-STARTUP-001: serve() must not call anything between _initialize() and anyio.run()."""
+    source = (SRC / "cli" / "app.py").read_text()
+    tree = ast.parse(source)
+
+    serve_func = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "serve":
+            serve_func = node
+            break
+    assert serve_func is not None, "serve() not found in app.py"
+
+    # Find the indices of _initialize(...) and anyio.run(...) in the body
+    init_idx = None
+    anyio_idx = None
+    for i, stmt in enumerate(serve_func.body):
+        if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call):
+            name = _get_call_name(stmt.value)
+            if name == "_initialize":
+                init_idx = i
+        # anyio.run is wrapped in try/except — look for ast.Try containing anyio.run
+        if isinstance(stmt, ast.Try):
+            for try_stmt in stmt.body:
+                if isinstance(try_stmt, ast.Expr) and isinstance(try_stmt.value, ast.Call):
+                    name = _get_call_name(try_stmt.value)
+                    if name == "anyio.run":
+                        anyio_idx = i
+
+    assert init_idx is not None, "_initialize() call not found in serve() body"
+    assert anyio_idx is not None, "anyio.run() call not found in serve() body"
+    assert init_idx < anyio_idx, "_initialize() must come before anyio.run()"
+
+    # Check for function calls in statements between _initialize and anyio.run
+    violations: list[str] = []
+    for stmt in serve_func.body[init_idx + 1 : anyio_idx]:
+        if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call):
+            name = _get_call_name(stmt.value)
+            violations.append(f"{name}() at line {stmt.lineno}")
+
+    assert not violations, (
+        "serve() must not call anything between _initialize() and anyio.run() — "
+        "found:\n" + "\n".join(f"  {v}" for v in violations)
+    )
 
 
 def test_no_gh_cli_token_in_make_context() -> None:

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -202,6 +202,8 @@ class TestCLIDoctor:
             "editable_install_source_exists",  # ★ new
             "stale_entry_points",  # ★ new
             "dual_mcp_registration",  # ★ new
+            "plugin_cache_exists",
+            "installed_plugins_entry",
         }
         assert expected <= check_names
 
@@ -619,16 +621,53 @@ def test_doctor_fix_parameter_does_not_exist():
     assert "fix" not in sig.parameters, "doctor --fix is a silent no-op and must be removed"
 
 
-def test_doctor_clears_plugin_cache(tmp_path, monkeypatch, capsys):
-    """Doctor must clear the plugin cache on every run."""
+def test_doctor_does_not_modify_plugin_state(tmp_path, monkeypatch, capsys):
+    """Doctor must not delete the plugin cache or modify installed_plugins.json."""
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     monkeypatch.chdir(tmp_path)
     cache_dir = tmp_path / ".claude" / "plugins" / "cache" / "autoskillit-local" / "autoskillit"
     cache_dir.mkdir(parents=True)
     (cache_dir / "0.3.0" / "hooks").mkdir(parents=True)
-    (cache_dir / "0.3.0" / "hooks" / "pretty_output_hook.py").write_text("# stale")
+    (cache_dir / "0.3.0" / "hooks" / "pretty_output_hook.py").write_text("# cached")
+
+    plugins_json = tmp_path / ".claude" / "plugins" / "installed_plugins.json"
+    plugins_json.write_text('{"autoskillit@autoskillit-local": {"version": "0.8.25"}}')
+
     cli.doctor()
-    assert not cache_dir.exists()
+
+    assert cache_dir.exists(), "Doctor must not delete the plugin cache directory"
+    data = json.loads(plugins_json.read_text())
+    assert "autoskillit@autoskillit-local" in data, (
+        "Doctor must not remove installed_plugins.json entries"
+    )
+
+
+def test_doctor_checks_plugin_cache_exists(tmp_path, monkeypatch, capsys):
+    """Doctor must report when the plugin cache directory is missing."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.chdir(tmp_path)
+    cli.doctor(output_json=True)
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    checks = [r for r in data["results"] if r["check"] == "plugin_cache_exists"]
+    assert len(checks) == 1, "Expected a plugin_cache_exists check"
+    assert checks[0]["severity"] in ("warning", "error")
+
+
+def test_doctor_checks_installed_plugins_entry(tmp_path, monkeypatch, capsys):
+    """Doctor must report when installed_plugins.json is missing the autoskillit entry."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.chdir(tmp_path)
+    # Create installed_plugins.json without the autoskillit entry
+    plugins_dir = tmp_path / ".claude" / "plugins"
+    plugins_dir.mkdir(parents=True)
+    (plugins_dir / "installed_plugins.json").write_text("{}")
+    cli.doctor(output_json=True)
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    checks = [r for r in data["results"] if r["check"] == "installed_plugins_entry"]
+    assert len(checks) == 1, "Expected an installed_plugins_entry check"
+    assert checks[0]["severity"] in ("warning", "error")
 
 
 def test_stale_gate_check_absent_from_doctor_output(tmp_path, monkeypatch, capsys):

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -88,6 +88,14 @@ class TestCLIDoctor:
         (tmp_path / ".pre-commit-config.yaml").write_text(
             "repos:\n  - repo: dummy\n    hooks:\n      - id: gitleaks\n"
         )
+        # Create plugin cache directory for Check 2c
+        (tmp_path / ".claude" / "plugins" / "cache" / "autoskillit-local" / "autoskillit").mkdir(
+            parents=True, exist_ok=True
+        )
+        # Create installed_plugins.json for Check 2d
+        (tmp_path / ".claude" / "plugins" / "installed_plugins.json").write_text(
+            json.dumps({"autoskillit@autoskillit-local": {}})
+        )
         # Register hooks so hook_registration check passes
         # Use explicit path (tmp_path already monkeypatched as Path.home())
         from autoskillit.cli._hooks import (

--- a/tests/cli/test_serve_sigterm.py
+++ b/tests/cli/test_serve_sigterm.py
@@ -31,7 +31,6 @@ def test_serve_uses_anyio_run_not_mcp_run(monkeypatch, tmp_path):
     monkeypatch.setattr("autoskillit.core.configure_logging", lambda **kw: None)
     monkeypatch.setattr("autoskillit.server.make_context", lambda *a, **kw: MagicMock())
     monkeypatch.setattr("autoskillit.server._initialize", lambda ctx: None)
-    monkeypatch.setattr("autoskillit.server.run_startup_drift_check", lambda: None)
 
     def capture_anyio_run(coro_fn, *args, **kwargs):
         anyio_calls.append(coro_fn)

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -214,17 +214,17 @@ def test_quota_thresholds_defaults() -> None:
     assert long_ == pytest.approx(98.0)
 
 
-def test_doctor_check_count_is_20() -> None:
+def test_doctor_check_count_is_22() -> None:
     # _count_doctor_checks() counts every "# Check N:" and "# Check Nb:" marker
-    # in run_doctor() — 17 numbered base markers + 3 lettered sub-check markers
-    # (2b, 4b, 7b) = 20 total.  test_installation_states_17_doctor_checks checks the
-    # *user-visible* count from docs/installation.md ("15 numbered + 2 lettered
-    # sub-checks 4b and 7b = 17").  The gap of 3 is intentional: Check 2, Check 4,
-    # and Check 7 each appear as separate implementation markers but the docs
-    # present them as single numbered entries that subsume their b variants.
+    # in run_doctor() — 17 numbered base markers + 5 lettered sub-check markers
+    # (2b, 2c, 2d, 4b, 7b) = 22 total.  test_installation_states_17_doctor_checks
+    # checks the *user-visible* count from docs/installation.md ("15 numbered + 2
+    # lettered sub-checks 4b and 7b = 17").  The gap of 5 is intentional: Check 2,
+    # Check 4, and Check 7 each appear as separate implementation markers but the
+    # docs present them as single numbered entries that subsume their sub-variants.
     # Update both tests whenever a new doctor check is added.
-    assert _count_doctor_checks() == 20, (
-        f"Expected 20 doctor checks; found {_count_doctor_checks()}"
+    assert _count_doctor_checks() == 22, (
+        f"Expected 22 doctor checks; found {_count_doctor_checks()}"
     )
 
 

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -124,7 +124,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # background.py — payload dict
     ("src/autoskillit/pipeline/background.py", 132),
     # _lifespan.py — hooks.json self-heal on startup drift (co-owned with Claude plugin system)
-    ("src/autoskillit/server/_lifespan.py", 58),
+    ("src/autoskillit/server/_lifespan.py", 55),
     # tools_kitchen.py — hook config dict
     ("src/autoskillit/server/tools_kitchen.py", 142),
     # tools_status.py — mcp_data dict

--- a/tests/server/test_lifespan.py
+++ b/tests/server/test_lifespan.py
@@ -94,10 +94,12 @@ async def test_lifespan_sets_startup_ready_event():
     try:
         with patch("autoskillit.server._lifespan._get_ctx_or_none", return_value=mock_ctx):
             async with _autoskillit_lifespan(MagicMock()):
-                # After lifespan yields, _startup_ready should be set
+                # _startup_ready is assigned synchronously before yield
                 assert _state._startup_ready is not None, (
                     "_startup_ready must be assigned an asyncio.Event during lifespan"
                 )
+                # Background task may not have completed yet — await the event
+                await asyncio.wait_for(_state._startup_ready.wait(), timeout=5.0)
                 assert _state._startup_ready.is_set(), (
                     "_startup_ready event must be signalled after deferred_initialize completes"
                 )

--- a/tests/server/test_lifespan.py
+++ b/tests/server/test_lifespan.py
@@ -74,6 +74,37 @@ async def test_lifespan_calls_finalize_on_cancellation():
     mock_recorder.finalize.assert_called_once()
 
 
+@pytest.mark.asyncio
+async def test_lifespan_sets_startup_ready_event():
+    """_startup_ready must be set to a real Event and signalled after lifespan yield."""
+    from autoskillit.server import _autoskillit_lifespan, _state
+
+    mock_ctx = MagicMock()
+    mock_ctx.runner = MagicMock()
+    mock_ctx.config.linux_tracing.tmpfs_path = "/tmp"
+    mock_ctx.config.linux_tracing.log_dir = None
+    mock_ctx.audit = MagicMock()
+    mock_ctx.audit.load_from_log_dir = MagicMock(return_value=0)
+    mock_ctx.session_skill_manager = None
+
+    # Reset _startup_ready to None before test
+    original = _state._startup_ready
+    _state._startup_ready = None
+
+    try:
+        with patch("autoskillit.server._lifespan._get_ctx_or_none", return_value=mock_ctx):
+            async with _autoskillit_lifespan(MagicMock()):
+                # After lifespan yields, _startup_ready should be set
+                assert _state._startup_ready is not None, (
+                    "_startup_ready must be assigned an asyncio.Event during lifespan"
+                )
+                assert _state._startup_ready.is_set(), (
+                    "_startup_ready event must be signalled after deferred_initialize completes"
+                )
+    finally:
+        _state._startup_ready = original
+
+
 def test_serve_startup_regenerates_on_hash_mismatch(tmp_path: Path, monkeypatch) -> None:
     """run_startup_drift_check() regenerates hooks.json when hash is mismatched."""
     import json as _json

--- a/tests/skills/test_skill_body_cleanliness.py
+++ b/tests/skills/test_skill_body_cleanliness.py
@@ -1,4 +1,5 @@
 """Assert that no SKILL.md body references %%ORDER_UP%%."""
+
 from pathlib import Path
 
 import pytest


### PR DESCRIPTION
## Summary

Two compounding failures erode the reliability of AutoSkillit's setup and startup pathways:

1. **`run_doctor()` destroys the plugin installation state before checking it**, producing a false OK, then never restoring it. Only `autoskillit install` can recover. The fix removes `_clear_plugin_cache()` from `run_doctor()` and adds read-only diagnostic checks.

2. **A regression in #821 moved `run_startup_drift_check()` back onto the synchronous critical path** before `mcp.run()`, undoing the core structural fix from #803. The fix moves `run_startup_drift_check()` and `deferred_initialize()` into lifespan background tasks, and removes stale startup workarounds and dead monkeypatches.

### Commits

- `09fcbec6` fix: remove _clear_plugin_cache() from run_doctor() and add read-only diagnostic checks
- `d571ecbd` fix: move run_startup_drift_check and deferred_initialize into lifespan background tasks
- `eb095e0b` fix: remove stale startup workarounds and dead monkeypatches
- `dddf537b` chore: bump version to 0.8.26
- `7ee9434b` fix: replace anyio task group with create_background_task in lifespan and fix test expectations
- `8dbba7a1` test: add failing AST guards and integration tests for phase boundary immunity

Closes #902

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 328 | 28.2k | 1.8M | 132.8k | 2 | 7m 22s |
| verify | 2.3k | 19.5k | 1.0M | 89.5k | 2 | 5m 41s |
| implement | 2.6k | 22.6k | 2.9M | 99.5k | 2 | 8m 0s |
| prepare_pr | 60 | 14.2k | 194.7k | 35.3k | 1 | 3m 1s |
| run_arch_lenses | 2.7k | 23.7k | 584.4k | 156.7k | 3 | 10m 52s |
| compose_pr | 59 | 8.7k | 217.8k | 33.1k | 1 | 2m 26s |
| review_pr | 284 | 23.1k | 1.2M | 80.6k | 1 | 11m 29s |
| resolve_review | 221 | 9.4k | 919.1k | 34.9k | 1 | 5m 41s |
| fix | 182 | 6.9k | 754.3k | 31.9k | 1 | 10m 4s |
| **Total** | 8.8k | 156.4k | 9.5M | 694.2k | | 1h 4m |