### PR TITLE
Inject MAX_MCP_OUTPUT_TOKENS into AutoSkillit Order Sessions

### DIFF
--- a/src/autoskillit/cli/_cook.py
+++ b/src/autoskillit/cli/_cook.py
@@ -134,8 +134,7 @@ def cook(*, resume: bool = False, session_id: str | None = None) -> None:
     from autoskillit.cli._onboarding import is_first_run, run_onboarding_menu
     from autoskillit.config import load_config
     from autoskillit.core import configure_logging, find_latest_session_id, pkg_root
-    from autoskillit.execution import build_interactive_cmd
-    from autoskillit.execution.commands import _MAX_MCP_OUTPUT_TOKENS_VALUE
+    from autoskillit.execution import _MAX_MCP_OUTPUT_TOKENS_VALUE, build_interactive_cmd
 
     configure_logging()
 

--- a/src/autoskillit/cli/_cook.py
+++ b/src/autoskillit/cli/_cook.py
@@ -135,6 +135,7 @@ def cook(*, resume: bool = False, session_id: str | None = None) -> None:
     from autoskillit.config import load_config
     from autoskillit.core import configure_logging, find_latest_session_id, pkg_root
     from autoskillit.execution import build_interactive_cmd
+    from autoskillit.execution.commands import _MAX_MCP_OUTPUT_TOKENS_VALUE
 
     configure_logging()
 
@@ -165,6 +166,7 @@ def cook(*, resume: bool = False, session_id: str | None = None) -> None:
         add_dirs=[skills_dir],
         initial_prompt=initial_prompt,
         resume_session_id=resume_session_id,
+        env_extras={"MAX_MCP_OUTPUT_TOKENS": _MAX_MCP_OUTPUT_TOKENS_VALUE},
     )
     _run_cook_session(
         cmd=spec.cmd,

--- a/src/autoskillit/core/_claude_env.py
+++ b/src/autoskillit/core/_claude_env.py
@@ -38,6 +38,9 @@ IDE_ENV_DENYLIST: frozenset[str] = frozenset(
         # into child sessions even when exit_after_stop_delay_ms=0 or no step name.
         "CLAUDE_CODE_EXIT_AFTER_STOP_DELAY",
         "SCENARIO_STEP_NAME",
+        # MCP response size gate: injected explicitly by AutoSkillit session launchers
+        # so the child always gets the correct value regardless of the parent env.
+        "MAX_MCP_OUTPUT_TOKENS",
     }
 )
 

--- a/src/autoskillit/execution/__init__.py
+++ b/src/autoskillit/execution/__init__.py
@@ -13,6 +13,7 @@ from autoskillit.execution.anomaly_detection import (
 )
 from autoskillit.execution.ci import DefaultCIWatcher
 from autoskillit.execution.commands import (
+    _MAX_MCP_OUTPUT_TOKENS_VALUE,  # noqa: F401 — re-exported so cli/_cook.py avoids submodule import
     ClaudeHeadlessCmd,
     ClaudeInteractiveCmd,
     build_headless_cmd,

--- a/src/autoskillit/execution/__init__.py
+++ b/src/autoskillit/execution/__init__.py
@@ -13,7 +13,7 @@ from autoskillit.execution.anomaly_detection import (
 )
 from autoskillit.execution.ci import DefaultCIWatcher
 from autoskillit.execution.commands import (
-    _MAX_MCP_OUTPUT_TOKENS_VALUE,  # noqa: F401 — re-exported so cli/_cook.py avoids submodule import
+    _MAX_MCP_OUTPUT_TOKENS_VALUE,  # noqa: F401
     ClaudeHeadlessCmd,
     ClaudeInteractiveCmd,
     build_headless_cmd,

--- a/src/autoskillit/execution/commands.py
+++ b/src/autoskillit/execution/commands.py
@@ -98,6 +98,12 @@ def build_headless_cmd(
     return ClaudeHeadlessCmd(cmd=cmd, env=build_claude_env(base=base, extras=env_extras))
 
 
+# Injected into every AutoSkillit-launched headless and cook session.
+# Raises the Claude Code client-side MCP tool result size gate from the
+# default 25,000 tokens to 50,000, preventing open_kitchen() responses
+# from being persisted to a file instead of returned inline.
+_MAX_MCP_OUTPUT_TOKENS_VALUE: str = "50000"
+
 # Variables that build_full_headless_cmd controls exclusively. They must not
 # leak from the host process environment — the caller opts in via explicit
 # parameters (exit_after_stop_delay_ms, scenario_step_name).
@@ -105,6 +111,7 @@ _HEADLESS_EXCLUSIVE_VARS: frozenset[str] = frozenset(
     {
         "CLAUDE_CODE_EXIT_AFTER_STOP_DELAY",
         "SCENARIO_STEP_NAME",
+        "MAX_MCP_OUTPUT_TOKENS",
     }
 )
 
@@ -247,7 +254,10 @@ def build_full_headless_cmd(
             temp_dir_relpath=temp_dir_relpath,
         )
     )
-    extras: dict[str, str] = {"AUTOSKILLIT_HEADLESS": "1"}
+    extras: dict[str, str] = {
+        "AUTOSKILLIT_HEADLESS": "1",
+        "MAX_MCP_OUTPUT_TOKENS": _MAX_MCP_OUTPUT_TOKENS_VALUE,
+    }
     if exit_after_stop_delay_ms > 0:
         extras["CLAUDE_CODE_EXIT_AFTER_STOP_DELAY"] = str(exit_after_stop_delay_ms)
     if scenario_step_name:

--- a/tests/cli/test_cook_env_scrub.py
+++ b/tests/cli/test_cook_env_scrub.py
@@ -13,6 +13,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from autoskillit.execution import _MAX_MCP_OUTPUT_TOKENS_VALUE
+
 
 def test_launch_cook_session_env_excludes_ide_vars(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
@@ -129,4 +131,4 @@ def test_cook_command_env_has_max_mcp_output_tokens(
         cook()
 
     env = mock_run.call_args.kwargs["env"]
-    assert env["MAX_MCP_OUTPUT_TOKENS"] == "50000"
+    assert env["MAX_MCP_OUTPUT_TOKENS"] == _MAX_MCP_OUTPUT_TOKENS_VALUE

--- a/tests/cli/test_cook_env_scrub.py
+++ b/tests/cli/test_cook_env_scrub.py
@@ -100,3 +100,33 @@ def test_cook_command_env_excludes_ide_vars(
     assert "CLAUDE_CODE_SSE_PORT" not in env
     assert "ENABLE_IDE_INTEGRATION" not in env
     assert env["CLAUDE_CODE_AUTO_CONNECT_IDE"] == "0"
+
+
+def test_cook_command_env_has_max_mcp_output_tokens(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """cook() must inject MAX_MCP_OUTPUT_TOKENS=50000 into the subprocess env."""
+    monkeypatch.chdir(tmp_path)
+
+    fake_skills_dir = tmp_path / "skills"
+    fake_skills_dir.mkdir()
+    mock_mgr = MagicMock()
+    mock_mgr.init_session.return_value = fake_skills_dir
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/claude"),
+        patch("builtins.input", return_value=""),
+        patch("sys.stdin.isatty", return_value=True),
+        patch("autoskillit.workspace.DefaultSessionSkillManager", return_value=mock_mgr),
+        patch(
+            "autoskillit.cli._cook.subprocess.run",
+            return_value=MagicMock(returncode=0),
+        ) as mock_run,
+        patch("autoskillit.cli._cook.terminal_guard"),
+    ):
+        from autoskillit.cli._cook import cook
+
+        cook()
+
+    env = mock_run.call_args.kwargs["env"]
+    assert env["MAX_MCP_OUTPUT_TOKENS"] == "50000"

--- a/tests/core/test_claude_env.py
+++ b/tests/core/test_claude_env.py
@@ -118,3 +118,15 @@ def test_ide_env_prefix_denylist_covers_ide_and_sse() -> None:
 
 def test_ide_env_always_extras_includes_auto_connect_off() -> None:
     assert IDE_ENV_ALWAYS_EXTRAS["CLAUDE_CODE_AUTO_CONNECT_IDE"] == "0"
+
+
+def test_ide_env_denylist_contains_max_mcp_output_tokens() -> None:
+    """MAX_MCP_OUTPUT_TOKENS must be in IDE_ENV_DENYLIST."""
+    assert "MAX_MCP_OUTPUT_TOKENS" in IDE_ENV_DENYLIST
+
+
+def test_build_claude_env_strips_max_mcp_output_tokens() -> None:
+    """MAX_MCP_OUTPUT_TOKENS must be stripped from base env by build_claude_env."""
+    result = build_claude_env(base={"MAX_MCP_OUTPUT_TOKENS": "99999", "HOME": "/tmp"})
+    assert "MAX_MCP_OUTPUT_TOKENS" not in result
+    assert result["HOME"] == "/tmp"

--- a/tests/execution/test_commands.py
+++ b/tests/execution/test_commands.py
@@ -339,3 +339,28 @@ class TestBuildFullHeadlessCmd:
         cmd = spec.cmd
         prompt_idx = cmd.index("-p") + 1 if "-p" in cmd else cmd.index("--print") + 1
         assert "EFFICIENCY DIRECTIVE" in cmd[prompt_idx]
+
+    def test_env_has_max_mcp_output_tokens(self):
+        """MAX_MCP_OUTPUT_TOKENS=50000 must be present in headless session env."""
+        spec = build_full_headless_cmd("/investigate foo", **self.BASE)
+        assert spec.env["MAX_MCP_OUTPUT_TOKENS"] == "50000"
+
+    def test_max_mcp_output_tokens_not_in_argv(self):
+        """MAX_MCP_OUTPUT_TOKENS must live in spec.env, not in argv."""
+        spec = build_full_headless_cmd("/investigate foo", **self.BASE)
+        assert not any(tok.startswith("MAX_MCP_OUTPUT_TOKENS=") for tok in spec.cmd)
+
+    def test_headless_exclusive_vars_strips_host_max_mcp_output_tokens(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Host-env MAX_MCP_OUTPUT_TOKENS must be stripped and replaced by the hardcoded value."""
+        monkeypatch.setenv("MAX_MCP_OUTPUT_TOKENS", "99999")
+        spec = build_full_headless_cmd("/investigate foo", **self.BASE)
+        assert spec.env["MAX_MCP_OUTPUT_TOKENS"] == "50000"
+
+
+def test_headless_exclusive_vars_contains_max_mcp_output_tokens() -> None:
+    """MAX_MCP_OUTPUT_TOKENS must be in _HEADLESS_EXCLUSIVE_VARS."""
+    from autoskillit.execution.commands import _HEADLESS_EXCLUSIVE_VARS
+
+    assert "MAX_MCP_OUTPUT_TOKENS" in _HEADLESS_EXCLUSIVE_VARS

--- a/tests/execution/test_commands.py
+++ b/tests/execution/test_commands.py
@@ -8,6 +8,7 @@ import pytest
 
 from autoskillit.core import ClaudeFlags
 from autoskillit.execution.commands import (
+    _MAX_MCP_OUTPUT_TOKENS_VALUE,
     ClaudeHeadlessCmd,
     ClaudeInteractiveCmd,
     build_full_headless_cmd,
@@ -343,7 +344,7 @@ class TestBuildFullHeadlessCmd:
     def test_env_has_max_mcp_output_tokens(self):
         """MAX_MCP_OUTPUT_TOKENS=50000 must be present in headless session env."""
         spec = build_full_headless_cmd("/investigate foo", **self.BASE)
-        assert spec.env["MAX_MCP_OUTPUT_TOKENS"] == "50000"
+        assert spec.env["MAX_MCP_OUTPUT_TOKENS"] == _MAX_MCP_OUTPUT_TOKENS_VALUE
 
     def test_max_mcp_output_tokens_not_in_argv(self):
         """MAX_MCP_OUTPUT_TOKENS must live in spec.env, not in argv."""
@@ -356,7 +357,7 @@ class TestBuildFullHeadlessCmd:
         """Host-env MAX_MCP_OUTPUT_TOKENS must be stripped and replaced by the hardcoded value."""
         monkeypatch.setenv("MAX_MCP_OUTPUT_TOKENS", "99999")
         spec = build_full_headless_cmd("/investigate foo", **self.BASE)
-        assert spec.env["MAX_MCP_OUTPUT_TOKENS"] == "50000"
+        assert spec.env["MAX_MCP_OUTPUT_TOKENS"] == _MAX_MCP_OUTPUT_TOKENS_VALUE
 
 
 def test_headless_exclusive_vars_contains_max_mcp_output_tokens() -> None:

--- a/tests/skills/test_skill_body_cleanliness.py
+++ b/tests/skills/test_skill_body_cleanliness.py
@@ -1,4 +1,5 @@
 """Assert that no SKILL.md body references %%ORDER_UP%%."""
+
 from pathlib import Path
 
 import pytest


### PR DESCRIPTION
## Summary

Claude Code v2.1.92 added a client-side MCP tool result size gate (default 25,000 tokens). The `open_kitchen(name="implementation")` response now exceeds this threshold (~80K chars / ~25-27K tokens), causing Claude Code to persist the result to a file and return an error instead — breaking orchestration flow.

The fix injects `MAX_MCP_OUTPUT_TOKENS=50000` into every subprocess environment that AutoSkillit launches (headless sessions and cook sessions). Simultaneously, the variable is added to the denylist in `_claude_env.py` and to `_HEADLESS_EXCLUSIVE_VARS` in `commands.py` so it cannot leak from a parent session into children (children always get it set explicitly). A named constant `_MAX_MCP_OUTPUT_TOKENS_VALUE = "50000"` in `commands.py` avoids magic-number duplication and is re-exported via `execution/__init__.py` for use in `_cook.py`.

## Architecture Impact

### Security Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 45, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ENTRY %%
    HOSTENV(["Host os.environ<br/>━━━━━━━━━━<br/>Untrusted / IDE-polluted"])

    subgraph DenylistLayer ["● TRUST BOUNDARY 1 — IDE Env Scrub (core/_claude_env.py)"]
        direction TB
        EXACTDENY["● IDE_ENV_DENYLIST<br/>━━━━━━━━━━<br/>Exact-match strip:<br/>CLAUDE_CODE_SSE_PORT<br/>ENABLE_IDE_INTEGRATION<br/>CLAUDE_CODE_WEBSOCKET_AUTH_FD<br/>VSCODE_GIT_ASKPASS_MAIN<br/>CURSOR_TRACE_ID · ZED_TERM<br/>EXIT_AFTER_STOP_DELAY ●<br/>SCENARIO_STEP_NAME ●<br/>MAX_MCP_OUTPUT_TOKENS ●"]
        PREFIXDENY["● IDE_ENV_PREFIX_DENYLIST<br/>━━━━━━━━━━<br/>Prefix-match strip:<br/>CLAUDE_CODE_IDE_*<br/>CLAUDE_CODE_SSE*"]
        AUTOCONN["● IDE_ENV_ALWAYS_EXTRAS<br/>━━━━━━━━━━<br/>Always injected:<br/>CLAUDE_CODE_AUTO_CONNECT_IDE=0<br/>(closes lock-file scan fallback)"]
    end

    subgraph ExclusiveFilter ["● TRUST BOUNDARY 2 — Headless Exclusive Var Filter (execution/commands.py)"]
        direction TB
        EXCL["● _HEADLESS_EXCLUSIVE_VARS filter<br/>━━━━━━━━━━<br/>Strips from os.environ before<br/>build_headless_cmd() base arg:<br/>EXIT_AFTER_STOP_DELAY<br/>SCENARIO_STEP_NAME<br/>MAX_MCP_OUTPUT_TOKENS"]
    end

    subgraph ExplicitInject ["● TRUST BOUNDARY 3 — Controlled Explicit Injection (execution/commands.py)"]
        direction TB
        MCPTOK["● MAX_MCP_OUTPUT_TOKENS=50000<br/>━━━━━━━━━━<br/>_MAX_MCP_OUTPUT_TOKENS_VALUE<br/>Always injected into headless extras<br/>Raises MCP gate: 25k → 50k tokens"]
        HEADLESSFLAGS["AUTOSKILLIT_HEADLESS=1<br/>━━━━━━━━━━<br/>Headless-mode signal<br/>Injected unconditionally"]
        OPTIONALS["Optional caller-controlled:<br/>━━━━━━━━━━<br/>EXIT_AFTER_STOP_DELAY (ms > 0)<br/>SCENARIO_STEP_NAME (non-empty)"]
    end

    subgraph SealedEnv ["SEALED ENV — MappingProxyType (core/_claude_env.py → build_claude_env)"]
        SEALED["MappingProxyType<br/>━━━━━━━━━━<br/>Read-only view<br/>Post-build mutation blocked"]
    end

    subgraph HeadlessPath ["● Headless Session Path (execution/commands.py → build_full_headless_cmd)"]
        HEADLESSCMD["● ClaudeHeadlessCmd<br/>━━━━━━━━━━<br/>cmd + sealed env<br/>Ready for subprocess runner"]
    end

    subgraph CookPath ["● Cook (Interactive) Session Path (cli/_cook.py)"]
        COOKEXTRAS["● env_extras injection<br/>━━━━━━━━━━<br/>MAX_MCP_OUTPUT_TOKENS=50000<br/>via _MAX_MCP_OUTPUT_TOKENS_VALUE<br/>(imported from execution/__init__.py ●)"]
        COOKCMD["ClaudeInteractiveCmd<br/>━━━━━━━━━━<br/>cmd + sealed env<br/>subprocess.run(env=spec.env)"]
    end

    BLOCKED(["BLOCKED<br/>━━━━━━━━━━<br/>IDE env vars<br/>Leaked session vars"])

    %% FLOW %%
    HOSTENV --> EXACTDENY
    HOSTENV --> PREFIXDENY
    EXACTDENY -->|"stripped"| BLOCKED
    PREFIXDENY -->|"stripped"| BLOCKED
    EXACTDENY -->|"surviving vars"| AUTOCONN
    PREFIXDENY -->|"surviving vars"| AUTOCONN

    AUTOCONN -->|"base env"| EXCL
    EXCL -->|"headless path"| MCPTOK
    EXCL -->|"headless path"| HEADLESSFLAGS
    EXCL -->|"headless path"| OPTIONALS

    MCPTOK --> SEALED
    HEADLESSFLAGS --> SEALED
    OPTIONALS --> SEALED
    AUTOCONN -->|"cook path"| COOKEXTRAS

    SEALED --> HEADLESSCMD
    COOKEXTRAS --> COOKCMD

    %% CLASS ASSIGNMENTS %%
    class HOSTENV cli;
    class EXACTDENY,PREFIXDENY detector;
    class AUTOCONN,EXCL detector;
    class MCPTOK,HEADLESSFLAGS phase;
    class OPTIONALS stateNode;
    class SEALED output;
    class HEADLESSCMD,COOKCMD output;
    class COOKEXTRAS phase;
    class BLOCKED gap;
```

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 45, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START])
    DONE([DONE — ClaudeHeadlessCmd / ClaudeInteractiveCmd])

    %% ── ENTRY SPLIT ─────────────────────────────────────────── %%
    ENTRY{"Session<br/>type?"}

    START --> ENTRY

    %% ══════════════════════════════════════════════════════════ %%
    %%  HEADLESS PATH                                            %%
    %% ══════════════════════════════════════════════════════════ %%
    subgraph HeadlessPath ["Headless Session Path  (execution/commands.py ●)"]
        direction TB

        BFH["● build_full_headless_cmd()<br/>━━━━━━━━━━<br/>Entry: skill_command, cwd,<br/>completion_marker, model, plugin_dir,<br/>exit_after_stop_delay_ms, scenario_step_name"]

        FILTER["● Filter os.environ<br/>━━━━━━━━━━<br/>Remove _HEADLESS_EXCLUSIVE_VARS:<br/>CLAUDE_CODE_EXIT_AFTER_STOP_DELAY<br/>SCENARIO_STEP_NAME<br/>MAX_MCP_OUTPUT_TOKENS<br/>→ filtered_base"]

        EXTRAS_H["● Assemble headless extras<br/>━━━━━━━━━━<br/>AUTOSKILLIT_HEADLESS = 1<br/>MAX_MCP_OUTPUT_TOKENS = 50000  ← new<br/>+ conditional vars below"]

        OPT_DELAY{"exit_after_stop<br/>_delay_ms > 0?"}
        OPT_STEP{"scenario_step<br/>_name set?"}

        INJECT_DELAY["Add CLAUDE_CODE_EXIT_AFTER_STOP_DELAY"]
        INJECT_STEP["Add SCENARIO_STEP_NAME"]

        PROMPT["Build prompt string<br/>━━━━━━━━━━<br/>_ensure_skill_prefix()<br/>→ _inject_completion_directive()<br/>→ _inject_cwd_anchor()<br/>→ _inject_narration_suppression()"]

        BHC["build_headless_cmd()<br/>━━━━━━━━━━<br/>cmd: [claude, --print, prompt,<br/>--dangerously-skip-permissions, ...]<br/>env: build_claude_env(base=filtered_base,<br/>                      extras=extras)"]
    end

    %% ══════════════════════════════════════════════════════════ %%
    %%  COOK (INTERACTIVE) PATH                                  %%
    %% ══════════════════════════════════════════════════════════ %%
    subgraph CookPath ["Cook (Interactive) Session Path  (cli/_cook.py ●)"]
        direction TB

        COOK["● cook()<br/>━━━━━━━━━━<br/>User-facing session launcher<br/>Imports _MAX_MCP_OUTPUT_TOKENS_VALUE<br/>from autoskillit.execution ●"]

        EXTRAS_C["● Assemble cook extras<br/>━━━━━━━━━━<br/>MAX_MCP_OUTPUT_TOKENS = 50000  ← new<br/>passed as env_extras=..."]

        BIC["build_interactive_cmd()<br/>━━━━━━━━━━<br/>cmd: [claude, --dangerously-skip-permissions,<br/>      --plugin-dir, --add-dir, ...]<br/>env: build_claude_env(extras=env_extras)"]
    end

    %% ══════════════════════════════════════════════════════════ %%
    %%  SHARED ENV BUILD LAYER  (_claude_env.py ●)              %%
    %% ══════════════════════════════════════════════════════════ %%
    subgraph EnvBuild ["● build_claude_env()  (core/_claude_env.py ●)"]
        direction TB

        SRC{"base provided?"}
        USE_BASE["Use provided base<br/>(filtered_base for headless)"]
        USE_OSENV["Use os.environ<br/>(cook path)"]

        SCRUB["● Denylist scrub loop<br/>━━━━━━━━━━<br/>For each key in src:<br/>  reject if key ∈ IDE_ENV_DENYLIST  ← extended<br/>  reject if key starts with prefix in<br/>  IDE_ENV_PREFIX_DENYLIST"]

        DENYLIST_NOTE["IDE_ENV_DENYLIST now includes:<br/>━━━━━━━━━━<br/>MAX_MCP_OUTPUT_TOKENS  ← new<br/>CLAUDE_CODE_EXIT_AFTER_STOP_DELAY  ← new<br/>SCENARIO_STEP_NAME  ← new<br/>+ original IDE vars"]

        ALWAYS["Inject IDE_ENV_ALWAYS_EXTRAS<br/>━━━━━━━━━━<br/>CLAUDE_CODE_AUTO_CONNECT_IDE = 0"]

        MERGE_EXTRAS["Merge caller extras<br/>━━━━━━━━━━<br/>Including MAX_MCP_OUTPUT_TOKENS = 50000<br/>(always wins — injected after scrub)"]

        SEAL["Return MappingProxyType<br/>━━━━━━━━━━<br/>Read-only sealed env<br/>prevents post-build mutation"]
    end

    %% ══════════════════════════════════════════════════════════ %%
    %%  RE-EXPORT BRIDGE  (execution/__init__.py ●)             %%
    %% ══════════════════════════════════════════════════════════ %%
    REEXPORT["● execution/__init__.py<br/>━━━━━━━━━━<br/>Re-exports _MAX_MCP_OUTPUT_TOKENS_VALUE<br/>from commands.py<br/>(avoids submodule import in _cook.py)"]

    %% ── FLOW ─────────────────────────────────────────────────── %%

    ENTRY -->|"headless"| BFH
    ENTRY -->|"cook / interactive"| COOK

    BFH --> FILTER
    FILTER --> PROMPT
    FILTER --> EXTRAS_H
    EXTRAS_H --> OPT_DELAY
    OPT_DELAY -->|"yes"| INJECT_DELAY
    OPT_DELAY -->|"no"| OPT_STEP
    INJECT_DELAY --> OPT_STEP
    OPT_STEP -->|"yes"| INJECT_STEP
    OPT_STEP -->|"no"| BHC
    INJECT_STEP --> BHC
    PROMPT --> BHC

    COOK --> REEXPORT
    REEXPORT -->|"_MAX_MCP_OUTPUT_TOKENS_VALUE"| EXTRAS_C
    COOK --> EXTRAS_C
    EXTRAS_C --> BIC

    BHC --> SRC
    BIC --> SRC

    SRC -->|"yes (headless)"| USE_BASE
    SRC -->|"no (cook)"| USE_OSENV
    USE_BASE --> SCRUB
    USE_OSENV --> SCRUB
    DENYLIST_NOTE -.->|"defines"| SCRUB
    SCRUB --> ALWAYS
    ALWAYS --> MERGE_EXTRAS
    MERGE_EXTRAS --> SEAL

    SEAL --> DONE

    %% ── CLASS ASSIGNMENTS ────────────────────────────────────── %%
    class START,DONE terminal;
    class ENTRY,OPT_DELAY,OPT_STEP,SRC stateNode;
    class BFH,BHC,BIC,COOK,PROMPT handler;
    class FILTER,EXTRAS_H,EXTRAS_C,REEXPORT phase;
    class SCRUB,DENYLIST_NOTE detector;
    class INJECT_DELAY,INJECT_STEP,ALWAYS,MERGE_EXTRAS,USE_BASE,USE_OSENV,SEAL output;
```

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;

    subgraph LayerCLI ["L3 — CLI LAYER"]
        direction LR
        COOK["● cli/_cook.py<br/>━━━━━━━━━━<br/>cook(): interactive skill launcher<br/>Imports _MAX_MCP_OUTPUT_TOKENS_VALUE<br/>Passes as env_extras to build_interactive_cmd"]
    end

    subgraph LayerExec ["L1 — EXECUTION LAYER"]
        direction LR
        EXEC_INIT["● execution/__init__.py<br/>━━━━━━━━━━<br/>Re-exports _MAX_MCP_OUTPUT_TOKENS_VALUE<br/>so cli/ avoids submodule import"]
        COMMANDS["● execution/commands.py<br/>━━━━━━━━━━<br/>_MAX_MCP_OUTPUT_TOKENS_VALUE = '50000'<br/>_HEADLESS_EXCLUSIVE_VARS (frozenset)<br/>build_full_headless_cmd(): injects token limit<br/>build_interactive_cmd(): caller-supplied extras<br/>build_headless_cmd(): delegates to build_claude_env"]
    end

    subgraph LayerCore ["L0 — CORE LAYER"]
        direction LR
        CLAUDE_ENV["● core/_claude_env.py<br/>━━━━━━━━━━<br/>IDE_ENV_DENYLIST: strips MAX_MCP_OUTPUT_TOKENS<br/>IDE_ENV_PREFIX_DENYLIST<br/>IDE_ENV_ALWAYS_EXTRAS<br/>build_claude_env(): scrub + seal env"]
        CORE_INIT["core/__init__.py<br/>━━━━━━━━━━<br/>Re-exports build_claude_env<br/>for execution layer consumers"]
    end

    subgraph LayerExt ["EXTERNAL"]
        direction LR
        OS_ENVIRON["os.environ<br/>━━━━━━━━━━<br/>Host process environment<br/>(MAX_MCP_OUTPUT_TOKENS stripped<br/>by denylist before child launch)"]
        CLAUDE_PROC["claude subprocess<br/>━━━━━━━━━━<br/>Receives sealed env<br/>MAX_MCP_OUTPUT_TOKENS=50000<br/>CLAUDE_CODE_AUTO_CONNECT_IDE=0"]
    end

    %% VALID DEPENDENCIES (downward) %%
    COOK -->|"from autoskillit.execution import<br/>_MAX_MCP_OUTPUT_TOKENS_VALUE,<br/>build_interactive_cmd"| EXEC_INIT
    EXEC_INIT -->|"re-exports from"| COMMANDS
    COMMANDS -->|"from autoskillit.core import<br/>build_claude_env, ClaudeFlags,<br/>ValidatedAddDir, temp_dir_display_str"| CORE_INIT
    CORE_INIT -->|"re-exports from"| CLAUDE_ENV

    %% DATA FLOW %%
    OS_ENVIRON -->|"base env (filtered:<br/>_HEADLESS_EXCLUSIVE_VARS removed)"| COMMANDS
    CLAUDE_ENV -->|"MappingProxyType<br/>scrubbed + sealed"| COMMANDS
    COMMANDS -->|"ClaudeHeadlessCmd / ClaudeInteractiveCmd<br/>(cmd=[], env=sealed)"| COOK
    COOK -->|"subprocess.run(cmd, env=spec.env)"| CLAUDE_PROC

    %% DESIGN INVARIANTS %%
    NOTE1["Design Invariant<br/>━━━━━━━━━━<br/>MAX_MCP_OUTPUT_TOKENS in denylist →<br/>cannot leak from host env into child.<br/>Injected only via explicit extras."]

    %% CLASS ASSIGNMENTS %%
    class COOK cli;
    class EXEC_INIT,COMMANDS handler;
    class CLAUDE_ENV,CORE_INIT stateNode;
    class OS_ENVIRON integration;
    class CLAUDE_PROC output;
    class NOTE1 phase;
```

Closes #907

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260414-065641-276152/.autoskillit/temp/make-plan/inject_max_mcp_output_tokens_plan_2026-04-14_070000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 157 | 11.3k | 787.5k | 62.7k | 1 | 3m 0s |
| verify | 2.2k | 9.5k | 397.5k | 52.3k | 1 | 2m 38s |
| implement | 2.3k | 9.3k | 1.4M | 55.3k | 1 | 2m 53s |
| fix | 182 | 6.9k | 754.3k | 31.9k | 1 | 10m 4s |
| prepare_pr | 60 | 5.7k | 181.0k | 24.0k | 1 | 1m 47s |
| run_arch_lenses | 210 | 16.3k | 654.8k | 88.8k | 3 | 5m 3s |
| compose_pr | 59 | 7.9k | 198.8k | 30.6k | 1 | 1m 59s |
| **Total** | 5.2k | 66.9k | 4.4M | 345.6k | | 27m 27s |