### PR TITLE
skill_cmd_guard Suggests Relocating Extra Context

### DIFF
--- a/src/autoskillit/hooks/skill_cmd_guard.py
+++ b/src/autoskillit/hooks/skill_cmd_guard.py
@@ -113,14 +113,25 @@ def main() -> None:
         sys.exit(0)
 
     # Anti-pattern: path exists but is not the first token.
-    correct_cmd = f"/autoskillit:{skill_name} {path_token}"
+    # Reconstruct corrected command: all path tokens first, then non-path tokens.
+    # When args_str is multiline, separate prose from paths with a blank line.
+    has_newlines = "\n" in args_str
+    path_tokens = [t for t in tokens if _looks_like_path(t)]
+    non_path_tokens = [t for t in tokens if not _looks_like_path(t)]
+    path_part = " ".join(path_tokens)
+    if has_newlines and non_path_tokens:
+        prose_block = " ".join(non_path_tokens)
+        correct_cmd = f"/autoskillit:{skill_name} {path_part}\n\n{prose_block}"
+    else:
+        tail = (" " + " ".join(non_path_tokens)) if non_path_tokens else ""
+        correct_cmd = f"/autoskillit:{skill_name} {path_part}{tail}"
     _deny(
         f"skill_command format error for '{skill_name}': "
         f"found extra descriptive text '{first}...' before the path argument "
         f"'{path_token}'. Path-argument skills require the path as the first "
-        f"argument after the skill name. "
-        f'Fix: set skill_command to "{correct_cmd}" '
-        f"(append any remaining positional args after the path if needed)."
+        f"argument after the skill name. Relocate any additional context or "
+        f"instructions to after all path arguments. "
+        f'Fix: set skill_command to "{correct_cmd}".'
     )
     sys.exit(0)
 

--- a/tests/infra/test_skill_cmd_check.py
+++ b/tests/infra/test_skill_cmd_check.py
@@ -197,3 +197,59 @@ class TestSkillCmdCheckDeny:
         assert hso["hookEventName"] == "PreToolUse"
         assert hso["permissionDecision"] == "deny"
         assert "permissionDecisionReason" in hso
+
+    def test_deny_suggests_all_tokens_single_line(self):
+        """Corrected command includes path tokens first, then non-path tokens."""
+        cmd = "/autoskillit:retry-worktree use this plan .autoskillit/temp/plan.md /path/worktree"
+        result = _run_hook({"skill_command": cmd})
+        assert _decision(result) == "deny"
+        reason = result["hookSpecificOutput"]["permissionDecisionReason"]
+        # Both path tokens appear in corrected suggestion
+        assert ".autoskillit/temp/plan.md" in reason
+        assert "/path/worktree" in reason
+        # Non-path tokens also preserved in the suggestion
+        assert "use this plan" in reason
+
+    def test_deny_suggests_paths_before_non_path_tokens(self):
+        """In corrected command, path tokens appear before non-path tokens."""
+        cmd = (
+            "/autoskillit:implement-worktree-no-merge the verified plan"
+            " .autoskillit/temp/rectify/plan.md"
+        )
+        result = _run_hook({"skill_command": cmd})
+        reason = result["hookSpecificOutput"]["permissionDecisionReason"]
+        path_pos = reason.find(".autoskillit/temp/rectify/plan.md")
+        nonpath_pos = reason.find("the verified plan")
+        # Path must appear before non-path text in the corrected suggestion
+        assert path_pos < nonpath_pos
+
+    def test_deny_multiline_prose_before_path_preserves_prose_after_path(self):
+        """Multiline prose context is preserved and placed after path args in suggestion."""
+        cmd = (
+            "/autoskillit:implement-worktree-no-merge "
+            "implement the feature described below\n\n"
+            ".autoskillit/temp/plan.md"
+        )
+        result = _run_hook({"skill_command": cmd})
+        assert _decision(result) == "deny"
+        reason = result["hookSpecificOutput"]["permissionDecisionReason"]
+        # Path must appear in the corrected suggestion
+        assert ".autoskillit/temp/plan.md" in reason
+        # Prose content must also be present (not dropped)
+        assert "implement the feature described below" in reason
+        # Path precedes prose in the corrected suggestion
+        path_pos = reason.find(".autoskillit/temp/plan.md")
+        prose_pos = reason.find("implement the feature described below")
+        assert path_pos < prose_pos
+
+    def test_deny_message_no_old_parenthetical(self):
+        """Old '(append any remaining positional args...)' phrasing must not appear."""
+        result = _run_hook({"skill_command": _CANONICAL_BUG})
+        reason = result["hookSpecificOutput"]["permissionDecisionReason"]
+        assert "append any remaining positional args" not in reason
+
+    def test_deny_message_uses_relocate_wording(self):
+        """Deny message must explicitly say 'relocate' or 'Relocate'."""
+        result = _run_hook({"skill_command": _CANONICAL_BUG})
+        reason = result["hookSpecificOutput"]["permissionDecisionReason"]
+        assert "relocate" in reason.lower()


### PR DESCRIPTION
## Summary

`skill_cmd_guard.py` currently builds the corrected `skill_command` suggestion using only the first found path token, silently dropping all other tokens (non-path descriptive text and additional path arguments). The fix reconstructs the corrected command with **all path-like tokens leading** (preserving their original order) and **all non-path tokens trailing**, separated by a blank line when the original `args_str` contained newlines. The deny message wording is updated to say "relocate" rather than implying removal.

Scope is confined to two files: `src/autoskillit/hooks/skill_cmd_guard.py` and `tests/infra/test_skill_cmd_check.py`.

## Requirements

**REQ-DENY-001:** The deny message must include all path-like tokens from the original `args_str`, ordered by their appearance, as the leading positional arguments in the suggested corrected command.

**REQ-DENY-002:** The deny message must include all non-path tokens from the original `args_str` after the path-like tokens in the suggested corrected command, preserving their original content.

**REQ-DENY-003:** When `args_str` contains newline characters (indicating multiline prose context), the suggested corrected command must show the path arguments on the first line followed by the prose block on subsequent lines, separated by a blank line.

**REQ-DENY-004:** The deny message wording must explicitly instruct the agent to relocate (not remove) any additional context or instructions, using language that distinguishes prose context from positional arguments.

**REQ-MSG-001:** The `_deny()` reason string must not use the parenthetical `(append any remaining positional args after the path if needed)` phrasing, replacing it with explicit relocation guidance.

**REQ-TEST-001:** Test coverage must include a deny case where multiline prose context precedes the path argument, verifying the suggested corrected command preserves the prose after the path args.

**REQ-TEST-002:** Test coverage must include a deny case where single-line extra tokens precede the path argument, verifying all tokens appear in the suggested corrected command (paths first, then non-path tokens).

**REQ-COMPAT-001:** The hook must continue to deny (not allow) when extra text appears before path arguments — only the suggested fix in the deny message changes, not the deny/allow decision logic.

Closes #914

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260414-081544-986008/.autoskillit/temp/make-plan/skill_cmd_guard_relocate_context_plan_2026-04-14_000000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| make_plan | 121 | 12.2k | 519.0k | 43.5k | 1 | 3m 35s |
| dry_walkthrough | 60 | 6.1k | 206.2k | 32.7k | 1 | 1m 58s |
| implement | 158 | 6.7k | 704.3k | 38.7k | 1 | 2m 2s |
| prepare_pr | 84 | 7.2k | 265.6k | 24.2k | 1 | 1m 53s |
| compose_pr | 75 | 3.1k | 211.9k | 16.9k | 1 | 1m 9s |
| **Total** | 498 | 35.4k | 1.9M | 155.9k | | 10m 39s |