### PR TITLE
Rectify: Merge Queue Watcher Inconclusive Budget Short-Circuits Outer Timeout

### DIFF
--- a/src/autoskillit/core/_type_protocols.py
+++ b/src/autoskillit/core/_type_protocols.py
@@ -415,6 +415,7 @@ class MergeQueueWatcher(Protocol):
         stall_grace_period: int = 60,
         max_stall_retries: int = 3,
         not_in_queue_confirmation_cycles: int = 2,
+        max_inconclusive_retries: int = 5,
     ) -> dict[str, Any]: ...
 
     async def toggle(

--- a/src/autoskillit/execution/merge_queue.py
+++ b/src/autoskillit/execution/merge_queue.py
@@ -171,6 +171,21 @@ class ClassifierInconclusive(Exception):
         self.reason = reason
 
 
+class CIStillRunning(ClassifierInconclusive):
+    """CI checks are legitimately in-progress (PENDING or EXPECTED).
+
+    Expected transient state — outer timeout_seconds bounds the wait.
+    Must NOT consume the inconclusive budget.
+    """
+
+
+class NoPositiveSignal(ClassifierInconclusive):
+    """No positive classifier gate matched — state is genuinely ambiguous.
+
+    Bounded by max_inconclusive_retries. Counts against the inconclusive budget.
+    """
+
+
 def _is_positive_stall(state: PRFetchState) -> bool:
     """True when auto-merge is enabled and merge_state_status indicates the PR is
     stuck in a state where it should be in queue but is not."""
@@ -230,9 +245,9 @@ def _classify_pr_state(state: PRFetchState) -> ClassificationResult:
         return ClassificationResult(PRState.DROPPED_HEALTHY, "PR healthy but auto_merge cleared")
 
     if state["checks_state"] in {"PENDING", "EXPECTED"}:
-        raise ClassifierInconclusive(state, "checks still running")
+        raise CIStillRunning(state, "checks still running")
 
-    raise ClassifierInconclusive(state, "no positive signal matched")
+    raise NoPositiveSignal(state, "no positive signal matched")
 
 
 class DefaultMergeQueueWatcher:
@@ -353,6 +368,7 @@ class DefaultMergeQueueWatcher:
             # In queue: reset window and continue
             if state["in_queue"]:
                 not_in_queue_cycles = 0
+                inconclusive_count = 0
                 if state["queue_state"] == "UNMERGEABLE":
                     return _make_result(False, PRState.EJECTED, "PR is UNMERGEABLE in merge queue")
                 await asyncio.sleep(poll_interval)
@@ -363,8 +379,10 @@ class DefaultMergeQueueWatcher:
             # Classify state using positive-signal gates
             try:
                 classification = _classify_pr_state(state)
-            except ClassifierInconclusive as exc:
-                # Apply confirmation window before consuming inconclusive budget
+            except CIStillRunning:
+                await asyncio.sleep(poll_interval)
+                continue
+            except NoPositiveSignal as exc:
                 if not_in_queue_cycles < not_in_queue_confirmation_cycles:
                     await asyncio.sleep(poll_interval)
                     continue

--- a/src/autoskillit/execution/merge_queue.py
+++ b/src/autoskillit/execution/merge_queue.py
@@ -301,6 +301,7 @@ class DefaultMergeQueueWatcher:
         stall_grace_period: int = 60,
         max_stall_retries: int = 3,
         not_in_queue_confirmation_cycles: int = 2,
+        max_inconclusive_retries: int = 5,
     ) -> dict[str, Any]:
         """Poll until PR is merged, ejected, stalled, dropped, or timeout expires.
 
@@ -319,6 +320,8 @@ class DefaultMergeQueueWatcher:
             not_in_queue_confirmation_cycles: Consecutive "not in queue" cycles required
                 before acting on absence. Guards against race between queue exit and
                 merged=true propagation (default 2).
+            max_inconclusive_retries: Maximum NoPositiveSignal cycles (beyond the
+                confirmation window) before returning pr_state="timeout" (default 5).
 
         Returns:
             {
@@ -387,12 +390,11 @@ class DefaultMergeQueueWatcher:
                     await asyncio.sleep(poll_interval)
                     continue
                 inconclusive_count += 1
-                if inconclusive_count >= self._max_inconclusive_retries:
+                if inconclusive_count >= max_inconclusive_retries:
                     return _make_result(
                         False,
                         PRState.TIMEOUT,
-                        f"Inconclusive after {self._max_inconclusive_retries} retries:"
-                        f" {exc.reason}",
+                        f"Inconclusive after {max_inconclusive_retries} retries: {exc.reason}",
                     )
                 await asyncio.sleep(poll_interval)
                 continue

--- a/src/autoskillit/recipe/rules_tools.py
+++ b/src/autoskillit/recipe/rules_tools.py
@@ -99,6 +99,7 @@ _TOOL_PARAMS: dict[str, frozenset[str]] = {
             "stall_grace_period",
             "max_stall_retries",
             "not_in_queue_confirmation_cycles",
+            "max_inconclusive_retries",
             "step_name",
         }
     ),

--- a/src/autoskillit/server/tools_ci.py
+++ b/src/autoskillit/server/tools_ci.py
@@ -387,6 +387,7 @@ async def wait_for_merge_queue(
     stall_grace_period: int = 60,
     max_stall_retries: int = 3,
     not_in_queue_confirmation_cycles: int = 2,
+    max_inconclusive_retries: int = 5,
     step_name: str = "",
     ctx: Context = CurrentContext(),
 ) -> str:
@@ -410,6 +411,8 @@ async def wait_for_merge_queue(
         not_in_queue_confirmation_cycles: Consecutive "not in queue" cycles required
                     before treating absence as definitive. Guards against race between
                     queue exit and merged=true propagation (default 2).
+        max_inconclusive_retries: Maximum NoPositiveSignal cycles (beyond the
+                    confirmation window) before returning pr_state="timeout" (default 5).
         step_name: Optional YAML step key for wall-clock timing accumulation.
 
     Returns:
@@ -474,6 +477,7 @@ async def wait_for_merge_queue(
                 stall_grace_period=stall_grace_period,
                 max_stall_retries=max_stall_retries,
                 not_in_queue_confirmation_cycles=not_in_queue_confirmation_cycles,
+                max_inconclusive_retries=max_inconclusive_retries,
             )
             return json.dumps(result)
         except Exception as exc:

--- a/tests/execution/test_merge_queue.py
+++ b/tests/execution/test_merge_queue.py
@@ -977,6 +977,76 @@ class TestInconclusiveBudget:
         assert result["pr_state"] == "merged"
         assert call_count == 8
 
+    @pytest.mark.anyio
+    async def test_wait_accepts_max_inconclusive_retries_per_call_param(self):
+        """max_inconclusive_retries must be a wait() parameter, not constructor-only.
+        Passing it must not raise TypeError. Passing a small value (1) must cause
+        budget exhaustion after 1 NoPositiveSignal cycle beyond the confirmation window.
+        """
+        watcher = _make_watcher()
+        # State: unknown — no positive classifier fires → NoPositiveSignal
+        watcher._fetch_pr_and_queue_state = AsyncMock(  # type: ignore[method-assign]
+            return_value=_queue_state(
+                merged=False,
+                in_queue=False,
+                checks_state="SUCCESS",
+                mergeable="UNKNOWN",
+                merge_state_status="UNKNOWN",
+                auto_merge_enabled_at=None,
+            )
+        )
+        with patch("autoskillit.execution.merge_queue.asyncio.sleep", new_callable=AsyncMock):
+            result = await watcher.wait(
+                pr_number=42,
+                target_branch="main",
+                repo="owner/repo",
+                poll_interval=1,
+                timeout_seconds=99999,
+                max_inconclusive_retries=1,  # ← per-call override
+            )
+
+        assert result["success"] is False
+        assert result["pr_state"] == "timeout"
+        assert "Inconclusive after 1 retries" in result["reason"]
+
+    @pytest.mark.anyio
+    async def test_per_call_max_inconclusive_retries_overrides_constructor_default(self):
+        """Per-call value must take precedence over the constructor default of 5.
+        budget=2 per call, constructor default would be 5. Budget exhaustion must
+        occur after 2 ambiguous cycles (+ confirmation window), not 5.
+        """
+        watcher = _make_watcher()  # constructor default = 5
+        call_count = 0
+
+        async def _fetch(*_a, **_kw):
+            nonlocal call_count
+            call_count += 1
+            return _queue_state(
+                merged=False,
+                in_queue=False,
+                checks_state="SUCCESS",
+                mergeable="UNKNOWN",
+                merge_state_status="UNKNOWN",
+                auto_merge_enabled_at=None,
+            )
+
+        watcher._fetch_pr_and_queue_state = _fetch  # type: ignore[method-assign]
+        with patch("autoskillit.execution.merge_queue.asyncio.sleep", new_callable=AsyncMock):
+            result = await watcher.wait(
+                pr_number=42,
+                target_branch="main",
+                repo="owner/repo",
+                poll_interval=1,
+                timeout_seconds=99999,
+                max_inconclusive_retries=2,  # ← per-call override
+            )
+
+        assert result["success"] is False
+        assert result["pr_state"] == "timeout"
+        # confirmation_cycles=2 (default): cycle 1 is window, cycles 2-3 consume budget
+        # budget=2: exhausted on call 3 → total calls = 3
+        assert call_count == 3
+
 
 class TestRelatedCoverage:
     """Coverage for related untested paths found during investigation."""

--- a/tests/execution/test_merge_queue.py
+++ b/tests/execution/test_merge_queue.py
@@ -792,6 +792,192 @@ class TestPendingCIGuard:
         assert isinstance(_make_watcher(), MergeQueueWatcher)
 
 
+class TestInconclusiveBudget:
+    """Tests for the split inconclusive budget: CIStillRunning vs NoPositiveSignal."""
+
+    @pytest.mark.anyio
+    async def test_pending_ci_does_not_exhaust_inconclusive_budget(self):
+        """CIStillRunning must not consume inconclusive_count.
+        Six PENDING cycles with budget=3 must NOT trigger budget ceiling.
+        timeout_seconds=99999 ensures outer deadline is not the cause.
+        """
+        watcher = DefaultMergeQueueWatcher(token=None, max_inconclusive_retries=3)
+        call_count = 0
+
+        async def _fetch(*_a, **_kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count > 6:
+                return _queue_state(merged=True)
+            return _queue_state(
+                merged=False,
+                in_queue=False,
+                checks_state="PENDING",
+                merge_state_status="BLOCKED",
+                auto_merge_enabled_at=None,
+            )
+
+        watcher._fetch_pr_and_queue_state = _fetch  # type: ignore[method-assign]
+        with patch("autoskillit.execution.merge_queue.asyncio.sleep", new_callable=AsyncMock):
+            result = await watcher.wait(
+                pr_number=42,
+                target_branch="main",
+                repo="owner/repo",
+                poll_interval=1,
+                timeout_seconds=99999,
+            )
+
+        assert result["success"] is True
+        assert result["pr_state"] == "merged"
+
+    @pytest.mark.anyio
+    async def test_expected_ci_does_not_exhaust_inconclusive_budget(self):
+        """CIStillRunning (EXPECTED) must not consume inconclusive_count.
+        Six EXPECTED cycles with budget=3 must NOT trigger budget ceiling.
+        """
+        watcher = DefaultMergeQueueWatcher(token=None, max_inconclusive_retries=3)
+        call_count = 0
+
+        async def _fetch(*_a, **_kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count > 6:
+                return _queue_state(merged=True)
+            return _queue_state(
+                merged=False,
+                in_queue=False,
+                checks_state="EXPECTED",
+                merge_state_status="BLOCKED",
+                auto_merge_enabled_at=None,
+            )
+
+        watcher._fetch_pr_and_queue_state = _fetch  # type: ignore[method-assign]
+        with patch("autoskillit.execution.merge_queue.asyncio.sleep", new_callable=AsyncMock):
+            result = await watcher.wait(
+                pr_number=42,
+                target_branch="main",
+                repo="owner/repo",
+                poll_interval=1,
+                timeout_seconds=99999,
+            )
+
+        assert result["success"] is True
+        assert result["pr_state"] == "merged"
+
+    @pytest.mark.anyio
+    async def test_no_positive_signal_exhausts_budget_returns_timeout(self):
+        """NoPositiveSignal must still exhaust the bounded budget.
+        Unknown state with no positive classifier match × (window + N) cycles
+        → pr_state='timeout'. Reason must contain 'Inconclusive after'.
+        """
+        watcher = DefaultMergeQueueWatcher(token=None, max_inconclusive_retries=3)
+        watcher._fetch_pr_and_queue_state = AsyncMock(  # type: ignore[method-assign]
+            return_value=_queue_state(
+                merged=False,
+                in_queue=False,
+                checks_state="SUCCESS",
+                mergeable="UNKNOWN",
+                merge_state_status="UNKNOWN",
+                auto_merge_enabled_at=None,
+            )
+        )
+        with patch("autoskillit.execution.merge_queue.asyncio.sleep", new_callable=AsyncMock):
+            result = await watcher.wait(
+                pr_number=42,
+                target_branch="main",
+                repo="owner/repo",
+                poll_interval=1,
+                timeout_seconds=99999,
+            )
+
+        assert result["success"] is False
+        assert result["pr_state"] == "timeout"
+        assert "Inconclusive after" in result["reason"]
+
+    @pytest.mark.anyio
+    async def test_inconclusive_count_resets_on_queue_reentry(self):
+        """inconclusive_count must reset when in_queue becomes True.
+        Scenario: out(PENDING×5) → in_queue → out(PENDING×5) → merged.
+        Budget=3. Without reset: second phase exhausts budget immediately.
+        With reset: both phases are tolerated independently.
+        """
+        watcher = DefaultMergeQueueWatcher(token=None, max_inconclusive_retries=3)
+        call_count = 0
+
+        async def _fetch(*_a, **_kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 5:
+                return _queue_state(
+                    merged=False,
+                    in_queue=False,
+                    checks_state="PENDING",
+                    merge_state_status="BLOCKED",
+                    auto_merge_enabled_at=None,
+                )
+            if call_count == 6:
+                return _queue_state(merged=False, in_queue=True)
+            if call_count <= 11:
+                return _queue_state(
+                    merged=False,
+                    in_queue=False,
+                    checks_state="PENDING",
+                    merge_state_status="BLOCKED",
+                    auto_merge_enabled_at=None,
+                )
+            return _queue_state(merged=True)
+
+        watcher._fetch_pr_and_queue_state = _fetch  # type: ignore[method-assign]
+        with patch("autoskillit.execution.merge_queue.asyncio.sleep", new_callable=AsyncMock):
+            result = await watcher.wait(
+                pr_number=42,
+                target_branch="main",
+                repo="owner/repo",
+                poll_interval=1,
+                timeout_seconds=99999,
+            )
+
+        assert result["success"] is True
+        assert result["pr_state"] == "merged"
+
+    @pytest.mark.anyio
+    async def test_confirmation_window_does_not_consume_inconclusive_budget(self):
+        """CIStillRunning (PENDING) must never consume the inconclusive budget at any cycle.
+        confirmation_cycles=4, budget=3: all 7 PENDING cycles complete without budget exhaustion
+        because PENDING raises CIStillRunning (exempt from budget). Merged on call 8.
+        """
+        watcher = DefaultMergeQueueWatcher(token=None, max_inconclusive_retries=3)
+        call_count = 0
+
+        async def _fetch(*_a, **_kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count > 7:
+                return _queue_state(merged=True)
+            return _queue_state(
+                merged=False,
+                in_queue=False,
+                checks_state="PENDING",
+                merge_state_status="BLOCKED",
+                auto_merge_enabled_at=None,
+            )
+
+        watcher._fetch_pr_and_queue_state = _fetch  # type: ignore[method-assign]
+        with patch("autoskillit.execution.merge_queue.asyncio.sleep", new_callable=AsyncMock):
+            result = await watcher.wait(
+                pr_number=42,
+                target_branch="main",
+                repo="owner/repo",
+                poll_interval=1,
+                timeout_seconds=99999,
+                not_in_queue_confirmation_cycles=4,
+            )
+
+        assert result["success"] is True
+        assert result["pr_state"] == "merged"
+        assert call_count == 8
+
+
 class TestRelatedCoverage:
     """Coverage for related untested paths found during investigation."""
 


### PR DESCRIPTION
## Summary

`DefaultMergeQueueWatcher.wait()` used a single exception class (`ClassifierInconclusive`) as a control-flow signal for two semantically incompatible situations: (1) CI checks are still running — an *expected transient* state that should poll until the outer `timeout_seconds` deadline — and (2) no positive classification signal matched at all — a *genuinely ambiguous* state that warrants a bounded retry ceiling before giving up. Both raised the same exception and incremented the same `inconclusive_count` counter, so CI that took longer than `max_inconclusive_retries × poll_interval` (default: 75 seconds) received a `timeout` result before the outer deadline was reached.

The fix is a **type-level distinction**: `ClassifierInconclusive` is split into `CIStillRunning` (transient — no budget consumed) and `NoPositiveSignal` (ambiguous — bounded budget), caught separately in `wait()`. Additionally, `inconclusive_count` resets on queue re-entry so budget from a prior exit episode does not bleed into subsequent ones.

Closes #911

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260414-074614-472907/.autoskillit/temp/rectify/rectify_merge_queue_inconclusive_budget_2026-04-14_083000_part_a.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| investigate | 120 | 8.4k | 389.7k | 40.7k | 1 | 5m 44s |
| rectify | 5.1k | 24.2k | 1.0M | 70.4k | 1 | 9m 13s |
| review | 98 | 8.2k | 346.5k | 39.7k | 1 | 2m 38s |
| dry_walkthrough | 308 | 28.1k | 1.7M | 105.3k | 2 | 8m 31s |
| implement | 492 | 21.1k | 2.6M | 94.0k | 2 | 6m 37s |
| assess | 226 | 8.5k | 1.2M | 42.8k | 1 | 10m 40s |
| prepare_pr | 52 | 5.6k | 145.0k | 25.7k | 1 | 1m 23s |
| run_arch_lenses | 261 | 24.6k | 1.1M | 163.1k | 3 | 7m 6s |
| compose_pr | 51 | 3.4k | 134.0k | 16.2k | 1 | 1m 5s |
| **Total** | 6.7k | 132.1k | 8.7M | 598.0k | | 53m 0s |