### PR TITLE
fix: run_cmd env stripping regression — merge os.environ into child env

### DIFF
--- a/src/autoskillit/server/tools_execution.py
+++ b/src/autoskillit/server/tools_execution.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import time
 from pathlib import Path
 
@@ -76,7 +77,7 @@ async def run_cmd(
         _start = time.monotonic()
         try:
             _env: dict[str, str] | None = (
-                {SCENARIO_STEP_NAME_ENV: step_name} if step_name else None
+                {**os.environ, SCENARIO_STEP_NAME_ENV: step_name} if step_name else None
             )
             returncode, stdout, stderr = await _run_subprocess(
                 ["bash", "-c", cmd],

--- a/tests/cli/test_subprocess_env_contracts.py
+++ b/tests/cli/test_subprocess_env_contracts.py
@@ -206,6 +206,107 @@ def test_update_command_all_subprocess_calls_have_env_kwarg() -> None:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Sibling rule: _run_subprocess(env=...) calls in server/ must start from
+# os.environ — enforced via per-function AST walk with single-assignment
+# tracking.
+# ─────────────────────────────────────────────────────────────────────────────
+
+SERVER_ROOT = Path(__file__).parents[2] / "src" / "autoskillit" / "server"
+
+
+def _dict_has_os_environ_unpack(dict_node: ast.Dict) -> bool:
+    """True if the dict literal contains **os.environ."""
+    for key, val in zip(dict_node.keys, dict_node.values):
+        if key is None and isinstance(val, ast.Attribute):
+            if isinstance(val.value, ast.Name) and val.value.id == "os" and val.attr == "environ":
+                return True
+    return False
+
+
+def _check_env_value(
+    env_val: ast.expr,
+    bindings: dict[str, ast.expr],
+    lineno: int,
+    path: Path,
+) -> str | None:
+    """Return a violation string if env_val is unsafe, None if safe.
+
+    Safe patterns:
+    - env=None literal
+    - env=<Dict> containing **os.environ
+    - env=<Call> (builder function)
+    - env=<Name> bound to a safe value (resolved one level via bindings)
+    - env=<Name> unresolvable (parameter/outer scope — trusted)
+    """
+    if isinstance(env_val, ast.Constant) and env_val.value is None:
+        return None
+    if isinstance(env_val, ast.Dict):
+        if _dict_has_os_environ_unpack(env_val):
+            return None
+        rel = path.relative_to(SERVER_ROOT.parents[2])
+        return f"{rel}:{lineno}: _run_subprocess(env=<dict>) without **os.environ"
+    if isinstance(env_val, ast.Call):
+        return None
+    if isinstance(env_val, ast.Name):
+        bound = bindings.get(env_val.id)
+        if bound is None:
+            return None
+        return _check_env_value(bound, {}, lineno, path)
+    return None
+
+
+def _find_run_subprocess_env_violations(source: str, path: Path) -> list[str]:
+    """Find _run_subprocess() calls with unsafe env= kwargs, per-function."""
+    tree = ast.parse(source)
+    violations: list[str] = []
+    for func_node in ast.walk(tree):
+        if not isinstance(func_node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        bindings: dict[str, ast.expr] = {}
+        for stmt in ast.walk(func_node):
+            if isinstance(stmt, ast.Assign) and len(stmt.targets) == 1:
+                target = stmt.targets[0]
+                if isinstance(target, ast.Name):
+                    bindings[target.id] = stmt.value
+            elif isinstance(stmt, ast.AnnAssign) and stmt.value is not None:
+                if isinstance(stmt.target, ast.Name):
+                    bindings[stmt.target.id] = stmt.value
+        for node in ast.walk(func_node):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if not (isinstance(func, ast.Name) and func.id == "_run_subprocess"):
+                continue
+            env_kw = None
+            for kw in node.keywords:
+                if kw.arg == "env":
+                    env_kw = kw.value
+                    break
+            if env_kw is None:
+                continue
+            violation = _check_env_value(env_kw, bindings, node.lineno, path)
+            if violation:
+                violations.append(violation)
+    return violations
+
+
+def test_run_subprocess_callers_use_safe_env_pattern() -> None:
+    """Every _run_subprocess(env=...) call in server/ must start from os.environ."""
+    if not SERVER_ROOT.is_dir():
+        pytest.skip("Source tree unavailable")
+    violations: list[str] = []
+    for py_file in sorted(SERVER_ROOT.rglob("*.py")):
+        source = py_file.read_text(encoding="utf-8")
+        if "_run_subprocess" not in source:
+            continue
+        violations.extend(_find_run_subprocess_env_violations(source, py_file))
+    assert not violations, (
+        "Found _run_subprocess() calls with unsafe env= patterns:\n"
+        + "\n".join(f"  {v}" for v in violations)
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Sibling rule: claude-launching subprocess calls must route env through
 # build_claude_env() — enforced via intra-function AST walk.
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/server/test_tools_run_cmd_unit.py
+++ b/tests/server/test_tools_run_cmd_unit.py
@@ -74,6 +74,22 @@ class TestRunCmdRecording:
         assert call_kwargs.get("env", {}).get(SCENARIO_STEP_NAME_ENV) == "setup"
 
     @pytest.mark.anyio
+    async def test_run_cmd_with_step_name_preserves_parent_env(self, tool_ctx, monkeypatch):
+        """run_cmd with step_name must not strip PATH/HOME from the child env."""
+        from autoskillit.execution.recording import SCENARIO_STEP_NAME_ENV
+
+        monkeypatch.setenv("PATH", "/usr/bin:/usr/local/bin")
+        monkeypatch.setenv("HOME", "/home/testuser")
+        tool_ctx.runner.push(_make_result(0, "ok", ""))
+        await run_cmd(cmd="echo hi", cwd="/tmp", step_name="setup")
+        call_kwargs = tool_ctx.runner.call_args_list[-1][3]
+        env = call_kwargs["env"]
+        assert env is not None
+        assert "PATH" in env, "run_cmd stripped PATH from child environment"
+        assert "HOME" in env, "run_cmd stripped HOME from child environment"
+        assert env[SCENARIO_STEP_NAME_ENV] == "setup"
+
+    @pytest.mark.anyio
     async def test_run_cmd_without_step_name_passes_no_env(self, tool_ctx):
         """run_cmd without step_name passes env=None (no SCENARIO_STEP_NAME in env)."""
         from autoskillit.execution.recording import SCENARIO_STEP_NAME_ENV


### PR DESCRIPTION
## Summary

Single-commit fix for a v0.8.31 regression where `run_cmd` stripped the entire parent process environment when `step_name` was set. The `_env` dict passed to `_run_subprocess` contained only `SCENARIO_STEP_NAME`, replacing all inherited environment variables (`HOME`, `PATH`, etc.). This broke `gh` CLI authentication and any tool depending on standard environment variables.

The fix merges `SCENARIO_STEP_NAME` into `os.environ` instead of replacing it. Two test additions guard against regression: a unit test verifying `PATH`/`HOME` preservation in the child env, and an AST structural guard ensuring all `_run_subprocess(env=...)` calls in `server/` start from `os.environ`.

Closes #915

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| investigate | 48 | 6.6k | 511.0k | 53.7k | 1 | 4m 2s |
| rectify | 5.2k | 9.8k | 591.0k | 59.7k | 1 | 5m 14s |
| dry_walkthrough | 398 | 10.9k | 1.3M | 70.5k | 1 | 4m 41s |
| implement | 66 | 7.3k | 896.0k | 61.3k | 1 | 3m 31s |
| prepare_pr | 25 | 3.7k | 166.6k | 19.8k | 1 | 1m 25s |
| run_arch_lenses | 42 | 4.8k | 472.2k | 35.6k | 1 | 3m 38s |
| compose_pr | 23 | 1.6k | 129.5k | 14.0k | 1 | 41s |
| **Total** | 5.8k | 44.6k | 4.0M | 314.6k | | 23m 14s |