### PR TITLE
[FIX] Inject MAX_MCP_OUTPUT_TOKENS at builder level for all session types

### DIFF
--- a/src/autoskillit/cli/_cook.py
+++ b/src/autoskillit/cli/_cook.py
@@ -134,7 +134,7 @@ def cook(*, resume: bool = False, session_id: str | None = None) -> None:
     from autoskillit.cli._onboarding import is_first_run, run_onboarding_menu
     from autoskillit.config import load_config
     from autoskillit.core import configure_logging, find_latest_session_id, pkg_root
-    from autoskillit.execution import _MAX_MCP_OUTPUT_TOKENS_VALUE, build_interactive_cmd
+    from autoskillit.execution import build_interactive_cmd
 
     configure_logging()
 
@@ -165,7 +165,6 @@ def cook(*, resume: bool = False, session_id: str | None = None) -> None:
         add_dirs=[skills_dir],
         initial_prompt=initial_prompt,
         resume_session_id=resume_session_id,
-        env_extras={"MAX_MCP_OUTPUT_TOKENS": _MAX_MCP_OUTPUT_TOKENS_VALUE},
     )
     _run_cook_session(
         cmd=spec.cmd,

--- a/src/autoskillit/execution/commands.py
+++ b/src/autoskillit/execution/commands.py
@@ -6,6 +6,7 @@ import os
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
+from types import MappingProxyType
 
 from autoskillit.core import (
     ClaudeFlags,
@@ -81,7 +82,10 @@ def build_interactive_cmd(
         cmd += [ClaudeFlags.ADD_DIR, str(d)]
     if initial_prompt is not None:
         cmd.append(initial_prompt)
-    return ClaudeInteractiveCmd(cmd=cmd, env=build_claude_env(extras=env_extras))
+    merged: dict[str, str] = dict(_SESSION_BASELINE_ENV)
+    if env_extras:
+        merged.update(env_extras)
+    return ClaudeInteractiveCmd(cmd=cmd, env=build_claude_env(extras=merged))
 
 
 def build_headless_cmd(
@@ -103,6 +107,16 @@ def build_headless_cmd(
 # default 25,000 tokens to 50,000, preventing open_kitchen() responses
 # from being persisted to a file instead of returned inline.
 _MAX_MCP_OUTPUT_TOKENS_VALUE: str = "50000"
+
+# Baseline env vars injected into EVERY AutoSkillit-launched Claude session
+# (both interactive and headless). Callers can override via env_extras.
+# Analogous to IDE_ENV_ALWAYS_EXTRAS in _claude_env.py but scoped to
+# session-level concerns rather than IDE scrubbing.
+_SESSION_BASELINE_ENV: Mapping[str, str] = MappingProxyType(
+    {
+        "MAX_MCP_OUTPUT_TOKENS": _MAX_MCP_OUTPUT_TOKENS_VALUE,
+    }
+)
 
 # Variables that build_full_headless_cmd controls exclusively. They must not
 # leak from the host process environment — the caller opts in via explicit
@@ -142,7 +156,10 @@ def build_headless_resume_cmd(
     ]
     if plugin_dir is not None:
         cmd += [ClaudeFlags.PLUGIN_DIR, str(plugin_dir)]
-    return ClaudeHeadlessCmd(cmd=cmd, env=build_claude_env(extras=env_extras))
+    merged: dict[str, str] = dict(_SESSION_BASELINE_ENV)
+    if env_extras:
+        merged.update(env_extras)
+    return ClaudeHeadlessCmd(cmd=cmd, env=build_claude_env(extras=merged))
 
 
 def _ensure_skill_prefix(skill_command: str) -> str:

--- a/tests/cli/test_cook_env_scrub.py
+++ b/tests/cli/test_cook_env_scrub.py
@@ -70,6 +70,26 @@ def test_launch_cook_session_extra_env_still_applied(
     assert "CLAUDE_CODE_SSE_PORT" not in env
 
 
+def test_launch_cook_session_env_has_max_mcp_output_tokens(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_launch_cook_session (order path) must produce env with MAX_MCP_OUTPUT_TOKENS."""
+    from autoskillit.cli.app import _launch_cook_session
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/claude"),
+        patch(
+            "autoskillit.cli.app.subprocess.run",
+            return_value=MagicMock(returncode=0),
+        ) as mock_run,
+        patch("autoskillit.cli.app.terminal_guard"),
+    ):
+        _launch_cook_session("system prompt", initial_message="hello")
+
+    env = mock_run.call_args.kwargs["env"]
+    assert env["MAX_MCP_OUTPUT_TOKENS"] == _MAX_MCP_OUTPUT_TOKENS_VALUE
+
+
 def test_cook_command_env_excludes_ide_vars(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/execution/test_commands.py
+++ b/tests/execution/test_commands.py
@@ -84,6 +84,16 @@ class TestBuildInteractiveCmd:
         prompt_idx = result.cmd.index("hello")
         assert resume_idx < prompt_idx
 
+    def test_env_has_max_mcp_output_tokens(self) -> None:
+        """build_interactive_cmd must inject MAX_MCP_OUTPUT_TOKENS even with no env_extras."""
+        spec = build_interactive_cmd()
+        assert spec.env["MAX_MCP_OUTPUT_TOKENS"] == _MAX_MCP_OUTPUT_TOKENS_VALUE
+
+    def test_caller_extras_override_baseline(self) -> None:
+        """Caller-supplied env_extras must override the baseline default."""
+        spec = build_interactive_cmd(env_extras={"MAX_MCP_OUTPUT_TOKENS": "99999"})
+        assert spec.env["MAX_MCP_OUTPUT_TOKENS"] == "99999"
+
 
 class TestBuildInteractiveCmdExtended:
     def test_accepts_plugin_dir(self, tmp_path: Path) -> None:
@@ -186,6 +196,11 @@ class TestBuildHeadlessResumeCmd:
         assert isinstance(result.env, Mapping)
         assert len(result.env) > 0
         assert result.env.get("CLAUDE_CODE_AUTO_CONNECT_IDE") == "0"
+
+    def test_env_has_max_mcp_output_tokens(self) -> None:
+        """build_headless_resume_cmd must inject MAX_MCP_OUTPUT_TOKENS even with no env_extras."""
+        spec = build_headless_resume_cmd(resume_session_id="abc", prompt="Emit token")
+        assert spec.env["MAX_MCP_OUTPUT_TOKENS"] == _MAX_MCP_OUTPUT_TOKENS_VALUE
 
     def test_no_plugin_dir_by_default(self) -> None:
         result = build_headless_resume_cmd(resume_session_id="abc-123", prompt="Emit token")
@@ -365,3 +380,29 @@ def test_headless_exclusive_vars_contains_max_mcp_output_tokens() -> None:
     from autoskillit.execution.commands import _HEADLESS_EXCLUSIVE_VARS
 
     assert "MAX_MCP_OUTPUT_TOKENS" in _HEADLESS_EXCLUSIVE_VARS
+
+
+# MAINTENANCE: When adding a new session builder to commands.py,
+# add it to this parametrize list. test_no_raw_claude_env ensures
+# env routing; this test ensures env CONTENT.
+@pytest.mark.parametrize(
+    "builder_call",
+    [
+        lambda: build_interactive_cmd(),
+        lambda: build_full_headless_cmd(
+            "/investigate foo",
+            cwd="/tmp",
+            completion_marker="%%DONE%%",
+            model=None,
+            plugin_dir=None,
+            output_format_value="stream-json",
+        ),
+        lambda: build_headless_resume_cmd(resume_session_id="abc", prompt="Emit"),
+    ],
+    ids=["interactive", "full_headless", "headless_resume"],
+)
+def test_all_session_builders_inject_max_mcp_output_tokens(builder_call) -> None:
+    """Every session command builder must produce env with MAX_MCP_OUTPUT_TOKENS."""
+    spec = builder_call()
+    assert "MAX_MCP_OUTPUT_TOKENS" in spec.env
+    assert spec.env["MAX_MCP_OUTPUT_TOKENS"] == _MAX_MCP_OUTPUT_TOKENS_VALUE


### PR DESCRIPTION
## Summary

`build_interactive_cmd()` is a pure pass-through for environment variables — it forwards caller-supplied `env_extras` to `build_claude_env` without injecting any defaults. This is structurally asymmetric with `build_full_headless_cmd()`, which internally injects `MAX_MCP_OUTPUT_TOKENS=50000` and `AUTOSKILLIT_HEADLESS=1` before delegating. The asymmetry means interactive launch paths depend on caller discipline to inject required vars, and when `_launch_cook_session` (the `order` command's launch path) was never updated by PR #910, the gap went undetected.

The fix adds a `_SESSION_BASELINE_ENV` frozen mapping in `commands.py` that `build_interactive_cmd` and `build_headless_resume_cmd` merge as defaults. Removes redundant caller-side injection from `_cook.py`. Adds structural guard tests covering all three session builders.

Closes #916

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260414-084428-773530/.autoskillit/temp/rectify/rectify_max_mcp_output_tokens_interactive_gap_2026-04-14_090500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| investigate | 2.6k | 8.3k | 628.8k | 48.1k | 1 | 4m 55s |
| rectify | 4.1k | 26.1k | 1.8M | 161.5k | 3 | 12m 42s |
| dry_walkthrough | 3.2k | 10.1k | 1.2M | 78.6k | 1 | 4m 39s |
| implement | 77 | 10.5k | 1.6M | 54.7k | 1 | 4m 19s |
| prepare_pr | 30 | 4.5k | 374.0k | 34.2k | 1 | 1m 34s |
| run_arch_lenses | 49 | 8.2k | 538.5k | 47.7k | 1 | 2m 52s |
| compose_pr | 23 | 1.5k | 128.6k | 15.6k | 1 | 39s |
| **Total** | 10.1k | 69.2k | 6.3M | 440.6k | | 31m 42s |