### PR TITLE
Add MCP tool to disable quota guard in order sessions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 AutoSkillit is a Claude Code plugin that runs YAML recipes through a
 two-tier orchestrator. The bundled recipes implement issue → plan → worktree
-→ tests → PR → merge pipelines using 43 MCP tools and 109 bundled skills.
+→ tests → PR → merge pipelines using 44 MCP tools and 109 bundled skills.
 
 ## Start here
 

--- a/docs/execution/architecture.md
+++ b/docs/execution/architecture.md
@@ -68,7 +68,7 @@ AutoSkillit supports four session modes with different tool and skill visibility
   `$ claude`); `/open-kitchen` reveals kitchen tools.
 
 - **`$ autoskillit order`**: Pipeline orchestrator session. Kitchen is pre-opened at startup —
-  all 43 MCP tools are available immediately. All skill tiers are accessible. The orchestrator
+  all 44 MCP tools are available immediately. All skill tiers are accessible. The orchestrator
   delegates work through `run_skill` (headless sessions) and `run_cmd` (shell commands).
 
 - **`run_skill` (headless)**: Worker sessions launched by the orchestrator. Sees 2 Free Range

--- a/docs/execution/tool-access.md
+++ b/docs/execution/tool-access.md
@@ -1,14 +1,14 @@
 # MCP Tool Access Control
 
-AutoSkillit provides 43 MCP tools organized into three access levels that control which
+AutoSkillit provides 44 MCP tools organized into three access levels that control which
 session types can see each tool.
 
 ## Three Access Levels
 
 ```
 ┌─────────────────────────────────────────────────────────┐
-│  FREE RANGE  (2 tools, always visible)                  │
-│  open_kitchen, close_kitchen                            │
+│  FREE RANGE  (3 tools, always visible)                  │
+│  open_kitchen, close_kitchen, disable_quota_guard       │
 │  Always visible — no gating, no headless restriction    │
 ├─────────────────────────────────────────────────────────┤
 │  HEADLESS-TAGGED  (1 tool)                              │
@@ -85,7 +85,7 @@ missing kitchen visibility.
 
 ## Complete MCP Tool Access Control Map
 
-All 43 tools with their access level, tags, source file, and functional category.
+All 44 tools with their access level, tags, source file, and functional category.
 
 **Tag abbreviations**: AS = `autoskillit`, K = `kitchen`, HL = `headless`,
 GH = `github`, CI = `ci`, CL = `clone`, TL = `telemetry`
@@ -98,6 +98,7 @@ GH = `github`, CI = `ci`, CL = `clone`, TL = `telemetry`
 |------|------|-------------|
 | `open_kitchen` | AS | `server/tools_kitchen.py` |
 | `close_kitchen` | AS | `server/tools_kitchen.py` |
+| `disable_quota_guard` | AS | `server/tools_kitchen.py` |
 
 ---
 

--- a/docs/skills/visibility.md
+++ b/docs/skills/visibility.md
@@ -84,7 +84,7 @@ and `/autoskillit:close-kitchen`. Skills in `skills_extended/` are never seen.
 
 Order is similar to cook: AutoSkillit launches Claude Code with access to all tiers.
 The key difference is the orchestrator (`sous-chef` skill) is injected and the kitchen
-is pre-opened so all 43 MCP tools are available from the start.
+is pre-opened so all 44 MCP tools are available from the start.
 
 ### Headless session (launched by `run_skill`)
 

--- a/src/autoskillit/cli/_cook.py
+++ b/src/autoskillit/cli/_cook.py
@@ -64,7 +64,7 @@ _DISPLAY_CATEGORIES: tuple[tuple[str, tuple[str, ...]], ...] = (
             "get_quota_events",
         ),
     ),
-    ("Kitchen", ("open_kitchen", "close_kitchen")),
+    ("Kitchen", ("open_kitchen", "close_kitchen", "disable_quota_guard")),
 )
 
 

--- a/src/autoskillit/core/_type_constants.py
+++ b/src/autoskillit/core/_type_constants.py
@@ -151,7 +151,9 @@ GATED_TOOLS: frozenset[str] = frozenset(
 
 HEADLESS_TOOLS: frozenset[str] = frozenset({"test_check"})
 
-FREE_RANGE_TOOLS: frozenset[str] = frozenset({"open_kitchen", "close_kitchen", "disable_quota_guard"})
+FREE_RANGE_TOOLS: frozenset[str] = frozenset(
+    {"open_kitchen", "close_kitchen", "disable_quota_guard"}
+)
 
 UNGATED_TOOLS: frozenset[str] = FREE_RANGE_TOOLS
 

--- a/src/autoskillit/core/_type_constants.py
+++ b/src/autoskillit/core/_type_constants.py
@@ -151,7 +151,7 @@ GATED_TOOLS: frozenset[str] = frozenset(
 
 HEADLESS_TOOLS: frozenset[str] = frozenset({"test_check"})
 
-FREE_RANGE_TOOLS: frozenset[str] = frozenset({"open_kitchen", "close_kitchen"})
+FREE_RANGE_TOOLS: frozenset[str] = frozenset({"open_kitchen", "close_kitchen", "disable_quota_guard"})
 
 UNGATED_TOOLS: frozenset[str] = FREE_RANGE_TOOLS
 

--- a/src/autoskillit/hooks/_hook_settings.py
+++ b/src/autoskillit/hooks/_hook_settings.py
@@ -38,6 +38,7 @@ class QuotaHookSettings:
     cache_path: str
     cache_max_age: int
     buffer_seconds: int
+    disabled: bool = False
 
 
 def _read_hook_config() -> dict:
@@ -98,8 +99,11 @@ def resolve_quota_settings(*, cache_path_override: str | None = None) -> QuotaHo
         DEFAULT_BUFFER_SECONDS,
     )
 
+    disabled = bool(hook_config.get("disabled", False))
+
     return QuotaHookSettings(
         cache_path=cache_path,
         cache_max_age=cache_max_age,
         buffer_seconds=buffer_seconds,
+        disabled=disabled,
     )

--- a/src/autoskillit/hooks/pretty_output_hook.py
+++ b/src/autoskillit/hooks/pretty_output_hook.py
@@ -189,6 +189,7 @@ _UNFORMATTED_TOOLS: frozenset[str] = frozenset(
         "get_ci_status",  # ci status dict
         "get_quota_events",  # list of quota events, generic renders correctly
         "close_kitchen",  # simple ack
+        "disable_quota_guard",  # simple success/error result
         "register_clone_status",  # simple registered/error result
         "batch_cleanup_clones",  # bulk delete summary dict
     }

--- a/src/autoskillit/hooks/quota_guard.py
+++ b/src/autoskillit/hooks/quota_guard.py
@@ -100,6 +100,8 @@ def main(*, cache_path_override: str | None = None) -> None:
         sys.exit(0)  # log but approve — don't block run_skill on hook bugs
 
     settings = resolve_quota_settings(cache_path_override=cache_path_override)
+    if settings.disabled:
+        sys.exit(0)  # quota guard disabled for this session
     cache_path_str = settings.cache_path
     cache_max_age = settings.cache_max_age
     log_dir = _resolve_quota_log_dir()

--- a/src/autoskillit/hooks/quota_post_hook.py
+++ b/src/autoskillit/hooks/quota_post_hook.py
@@ -111,6 +111,8 @@ def main(*, cache_path_override: str | None = None) -> None:
     tool_response = event.get("tool_response") or ""
 
     settings = resolve_quota_settings(cache_path_override=cache_path_override)
+    if settings.disabled:
+        sys.exit(0)  # quota guard disabled for this session
     cache_path_str = settings.cache_path
     cache_max_age = settings.cache_max_age
     log_dir = _resolve_quota_log_dir()

--- a/src/autoskillit/server/__init__.py
+++ b/src/autoskillit/server/__init__.py
@@ -2,7 +2,8 @@
 
 Kitchen tools (40 gated + 1 headless-tagged) are hidden at startup via FastMCP v3
 mcp.disable(tags={'kitchen'}) applied once after all tool modules are imported.
-Each new session sees only the 2 free-range tools (open_kitchen and close_kitchen).
+Each new session sees only the 3 free-range tools (open_kitchen, close_kitchen,
+and disable_quota_guard).
 Headless sessions (AUTOSKILLIT_HEADLESS=1) pre-reveal only headless-tagged tools
 (test_check) via mcp.enable(tags={'headless'}) — not all kitchen tools.
 Calling the open_kitchen tool reveals all 41 kitchen-tagged tools for that session

--- a/src/autoskillit/server/tools_kitchen.py
+++ b/src/autoskillit/server/tools_kitchen.py
@@ -114,7 +114,7 @@ _DISPLAY_CATEGORIES: tuple[tuple[str, tuple[str, ...]], ...] = (
             "get_quota_events",
         ),
     ),
-    ("Kitchen", ("open_kitchen", "close_kitchen")),
+    ("Kitchen", ("open_kitchen", "close_kitchen", "disable_quota_guard")),
 )
 
 
@@ -425,4 +425,50 @@ async def close_kitchen(ctx: Context = CurrentContext()) -> str:
         return "Kitchen is closed."
     except Exception as exc:
         logger.error("close_kitchen unhandled exception", exc_info=True)
+        return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
+
+
+@mcp.tool(tags={"autoskillit"})
+@track_response_size("disable_quota_guard")
+def disable_quota_guard() -> str:
+    """Disable the quota guard for the remainder of this kitchen session.
+
+    The quota guard blocks run_skill calls when API utilization exceeds a
+    threshold. Invoke this tool when you decide the work is worth the quota
+    spend and want to override the guard for the current session.
+
+    Session-scoped only: the guard re-activates when the kitchen is closed
+    and reopened. Does not modify persistent configuration.
+
+    Never raises.
+    """
+    try:
+        if (h := _require_not_headless("disable_quota_guard")) is not None:
+            return h
+        hook_cfg_path = _hook_config_path(Path.cwd())
+        if not hook_cfg_path.exists():
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": "Kitchen is not open — hook config file absent. Open the kitchen first.",
+                }
+            )
+        try:
+            payload = json.loads(hook_cfg_path.read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            return json.dumps(
+                {"success": False, "error": f"Failed to read hook config: {type(exc).__name__}: {exc}"}
+            )
+        quota_section = payload.get("quota_guard", {})
+        quota_section["disabled"] = True
+        payload["quota_guard"] = quota_section
+        atomic_write(hook_cfg_path, json.dumps(payload))
+        return json.dumps(
+            {
+                "success": True,
+                "content": "Quota guard disabled for this session. run_skill calls will no longer be blocked by quota checks.",
+            }
+        )
+    except Exception as exc:
+        logger.error("disable_quota_guard unhandled exception", exc_info=True)
         return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})

--- a/src/autoskillit/server/tools_kitchen.py
+++ b/src/autoskillit/server/tools_kitchen.py
@@ -430,7 +430,7 @@ async def close_kitchen(ctx: Context = CurrentContext()) -> str:
 
 @mcp.tool(tags={"autoskillit"})
 @track_response_size("disable_quota_guard")
-def disable_quota_guard() -> str:
+async def disable_quota_guard() -> str:
     """Disable the quota guard for the remainder of this kitchen session.
 
     The quota guard blocks run_skill calls when API utilization exceeds a
@@ -450,14 +450,17 @@ def disable_quota_guard() -> str:
             return json.dumps(
                 {
                     "success": False,
-                    "error": "Kitchen is not open — hook config file absent. Open the kitchen first.",
+                    "error": "Kitchen is not open — hook config file absent.",
                 }
             )
         try:
             payload = json.loads(hook_cfg_path.read_text())
         except (OSError, json.JSONDecodeError) as exc:
             return json.dumps(
-                {"success": False, "error": f"Failed to read hook config: {type(exc).__name__}: {exc}"}
+                {
+                    "success": False,
+                    "error": f"Failed to read hook config: {type(exc).__name__}: {exc}",
+                }
             )
         quota_section = payload.get("quota_guard", {})
         quota_section["disabled"] = True
@@ -466,7 +469,10 @@ def disable_quota_guard() -> str:
         return json.dumps(
             {
                 "success": True,
-                "content": "Quota guard disabled for this session. run_skill calls will no longer be blocked by quota checks.",
+                "content": (
+                    "Quota guard disabled for this session. "
+                    "run_skill calls will no longer be blocked by quota checks."
+                ),
             }
         )
     except Exception as exc:

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -184,9 +184,9 @@ def test_kitchen_tagged_tool_count_is_41() -> None:
     )
 
 
-def test_free_range_tool_count_is_2() -> None:
-    assert _count_free_range_tools() == 2, (
-        f"Expected 2 free-range tools; found {_count_free_range_tools()}"
+def test_free_range_tool_count_is_3() -> None:
+    assert _count_free_range_tools() == 3, (
+        f"Expected 3 free-range tools; found {_count_free_range_tools()}"
     )
 
 

--- a/tests/infra/test_quota_check.py
+++ b/tests/infra/test_quota_check.py
@@ -605,3 +605,37 @@ def test_resolve_quota_log_dir_and_resolve_log_dir_in_sync(monkeypatch):
         f"  quota_check: {quota_path_xdg}\n"
         f"  session_log: {session_path_xdg}"
     )
+
+
+def test_hook_approves_when_disabled_flag_set_in_hook_config(tmp_path, monkeypatch):
+    """Hook bypasses all checks and approves when disabled=True in hook config.
+
+    Even with a high-utilization blocking cache, the hook must exit 0 with
+    no output when the quota_guard.disabled flag is set.
+    """
+    monkeypatch.chdir(tmp_path)
+    cache = tmp_path / "blocking_cache.json"
+    _write_cache(cache, utilization=99.0, should_block=True)
+    _write_hook_config(
+        tmp_path.joinpath(*_HOOK_CONFIG_PATH_COMPONENTS),
+        cache_max_age=300,
+        cache_path=str(cache),
+        extra={"disabled": True},
+    )
+    out, _ = _run_hook(event={"tool_name": "run_skill"})
+    assert out.strip() == ""
+
+
+def test_hook_still_blocks_without_disabled_flag(tmp_path, monkeypatch):
+    """Regression guard: hook still blocks when disabled key is absent from hook config."""
+    monkeypatch.chdir(tmp_path)
+    cache = tmp_path / "blocking_cache.json"
+    _write_cache(cache, utilization=99.0, should_block=True)
+    _write_hook_config(
+        tmp_path.joinpath(*_HOOK_CONFIG_PATH_COMPONENTS),
+        cache_max_age=300,
+        cache_path=str(cache),
+    )
+    out, _ = _run_hook(event={"tool_name": "run_skill"})
+    data = json.loads(out)
+    assert data["hookSpecificOutput"]["permissionDecision"] == "deny"

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -127,6 +127,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/server/_lifespan.py", 55),
     # tools_kitchen.py — hook config dict
     ("src/autoskillit/server/tools_kitchen.py", 142),
+    ("src/autoskillit/server/tools_kitchen.py", 468),
     # tools_status.py — mcp_data dict
     ("src/autoskillit/server/tools_status.py", 385),
     # tools_github.py — bug report dict

--- a/tests/pipeline/test_gate.py
+++ b/tests/pipeline/test_gate.py
@@ -62,7 +62,7 @@ def test_check_quota_not_in_ungated_tools():
 def test_ungated_tools_contains_expected_names():
     from autoskillit.pipeline.gate import UNGATED_TOOLS
 
-    expected = {"open_kitchen", "close_kitchen"}
+    expected = {"open_kitchen", "close_kitchen", "disable_quota_guard"}
     assert UNGATED_TOOLS == expected
 
 
@@ -178,7 +178,7 @@ def test_headless_tools_contains_expected_names():
 def test_free_range_tools_contains_expected_names():
     from autoskillit.core.types import FREE_RANGE_TOOLS
 
-    assert FREE_RANGE_TOOLS == {"open_kitchen", "close_kitchen"}
+    assert FREE_RANGE_TOOLS == {"open_kitchen", "close_kitchen", "disable_quota_guard"}
 
 
 def test_ungated_tools_equals_free_range_tools():

--- a/tests/server/test_server_tool_registration.py
+++ b/tests/server/test_server_tool_registration.py
@@ -78,6 +78,7 @@ class TestToolRegistration:
             "get_ci_status",
             "open_kitchen",
             "close_kitchen",
+            "disable_quota_guard",
             "create_unique_branch",
             "check_pr_mergeable",
             "write_telemetry_files",

--- a/tests/server/test_tools_kitchen.py
+++ b/tests/server/test_tools_kitchen.py
@@ -1109,3 +1109,45 @@ def test_every_return_path_parses_as_json_and_has_boolean_success(stage):
 
     envelope = json.loads(_kitchen_failure_envelope(RuntimeError("test"), stage=stage))
     assert isinstance(envelope["success"], bool)
+
+
+def test_disable_quota_guard_writes_disabled_flag(tmp_path, monkeypatch):
+    """disable_quota_guard() sets quota_guard.disabled=True in the hook config file."""
+    monkeypatch.chdir(tmp_path)
+    hook_cfg_path = tmp_path.joinpath(*_HOOK_CONFIG_PATH_COMPONENTS)
+    hook_cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    hook_cfg_path.write_text(
+        json.dumps({"quota_guard": {"cache_path": "/some/path.json", "cache_max_age": 300}})
+    )
+
+    from autoskillit.server.tools_kitchen import disable_quota_guard
+
+    result_str = disable_quota_guard()
+    parsed = json.loads(result_str)
+    assert parsed["success"] is True
+
+    payload = json.loads(hook_cfg_path.read_text())
+    assert payload["quota_guard"]["disabled"] is True
+
+
+def test_disable_quota_guard_denies_headless(tmp_path, monkeypatch):
+    """disable_quota_guard() returns an error when called from a headless session."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+
+    from autoskillit.server.tools_kitchen import disable_quota_guard
+
+    result_str = disable_quota_guard()
+    parsed = json.loads(result_str)
+    assert parsed["success"] is False
+
+
+def test_disable_quota_guard_returns_error_when_kitchen_not_open(tmp_path, monkeypatch):
+    """disable_quota_guard() returns an error when the kitchen is not open."""
+    monkeypatch.chdir(tmp_path)
+
+    from autoskillit.server.tools_kitchen import disable_quota_guard
+
+    result_str = disable_quota_guard()
+    parsed = json.loads(result_str)
+    assert parsed["success"] is False

--- a/tests/server/test_tools_kitchen.py
+++ b/tests/server/test_tools_kitchen.py
@@ -1111,7 +1111,8 @@ def test_every_return_path_parses_as_json_and_has_boolean_success(stage):
     assert isinstance(envelope["success"], bool)
 
 
-def test_disable_quota_guard_writes_disabled_flag(tmp_path, monkeypatch):
+@pytest.mark.anyio
+async def test_disable_quota_guard_writes_disabled_flag(tmp_path, monkeypatch):
     """disable_quota_guard() sets quota_guard.disabled=True in the hook config file."""
     monkeypatch.chdir(tmp_path)
     hook_cfg_path = tmp_path.joinpath(*_HOOK_CONFIG_PATH_COMPONENTS)
@@ -1122,7 +1123,7 @@ def test_disable_quota_guard_writes_disabled_flag(tmp_path, monkeypatch):
 
     from autoskillit.server.tools_kitchen import disable_quota_guard
 
-    result_str = disable_quota_guard()
+    result_str = await disable_quota_guard()
     parsed = json.loads(result_str)
     assert parsed["success"] is True
 
@@ -1130,24 +1131,26 @@ def test_disable_quota_guard_writes_disabled_flag(tmp_path, monkeypatch):
     assert payload["quota_guard"]["disabled"] is True
 
 
-def test_disable_quota_guard_denies_headless(tmp_path, monkeypatch):
+@pytest.mark.anyio
+async def test_disable_quota_guard_denies_headless(tmp_path, monkeypatch):
     """disable_quota_guard() returns an error when called from a headless session."""
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
 
     from autoskillit.server.tools_kitchen import disable_quota_guard
 
-    result_str = disable_quota_guard()
+    result_str = await disable_quota_guard()
     parsed = json.loads(result_str)
     assert parsed["success"] is False
 
 
-def test_disable_quota_guard_returns_error_when_kitchen_not_open(tmp_path, monkeypatch):
+@pytest.mark.anyio
+async def test_disable_quota_guard_returns_error_when_kitchen_not_open(tmp_path, monkeypatch):
     """disable_quota_guard() returns an error when the kitchen is not open."""
     monkeypatch.chdir(tmp_path)
 
     from autoskillit.server.tools_kitchen import disable_quota_guard
 
-    result_str = disable_quota_guard()
+    result_str = await disable_quota_guard()
     parsed = json.loads(result_str)
     assert parsed["success"] is False


### PR DESCRIPTION
## Summary

Adds a new `disable_quota_guard` MCP tool that allows order sessions to bypass quota guard enforcement when needed. The quota guard hook (`quota_guard.py`) is updated to respect the new disabled state, and `_hook_settings.py` is extended to expose the disable flag. Kitchen tooling, CLI cook path, and type constants are updated to register and expose the new tool.

Closes #919

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| review_approach | 158 | 12.4k | 1.1M | 98.1k | 1 | 4m 53s |
| make_plan | 195 | 14.2k | 1.4M | 83.3k | 1 | 4m 22s |
| dry_walkthrough | 2.3k | 13.0k | 935.8k | 77.9k | 1 | 3m 52s |
| implement | 570 | 25.7k | 4.6M | 81.3k | 1 | 8m 37s |
| resolve_failures | 226 | 10.6k | 1.4M | 52.7k | 1 | 11m 17s |
| prepare_pr | 101 | 5.3k | 174.6k | 28.2k | 1 | 1m 27s |
| run_arch_lenses | 157 | 13.7k | 597.9k | 43.2k | 1 | 9m 22s |
| compose_pr | 67 | 1.8k | 178.2k | 14.4k | 1 | 43s |
| **Total** | 3.8k | 96.7k | 10.3M | 479.1k | | 44m 35s |