### PR TITLE
Rectify: Doctor-Install Disconnect

### DIFF
--- a/.autoskillit/.gitignore
+++ b/.autoskillit/.gitignore
@@ -1,1 +1,4 @@
 temp/
+.secrets.yaml
+.onboarded
+sync_manifest.json

--- a/.autoskillit/config.yaml
+++ b/.autoskillit/config.yaml
@@ -30,4 +30,5 @@ github:
   default_repo: "TalonT-Org/AutoSkillit"
 
 quota_guard:
+  enabled: false
   short_window_threshold: 95.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,6 +241,7 @@ generic_automation_mcp/
 │   ├── _doctor.py           #   16 project setup checks
 │   ├── _hooks.py            #   PreToolUse hook registration helpers
 │   ├── _init_helpers.py
+│   ├── _installed_plugins.py #  InstalledPluginsFile — canonical accessor for installed_plugins.json
 │   ├── _install_info.py     #   InstallInfo, InstallType, detect_install(), comparison_branch(), dismissal_window(), upgrade_command()
 │   ├── _marketplace.py      #   Plugin install/upgrade
 │   ├── _mcp_names.py        #   MCP prefix detection

--- a/src/autoskillit/cli/_doctor.py
+++ b/src/autoskillit/cli/_doctor.py
@@ -609,24 +609,16 @@ def _check_installed_plugins_entry(
     plugins_json_path: Path | None = None,
 ) -> DoctorResult:
     """Check that installed_plugins.json contains the autoskillit entry."""
-    _plugins_json = plugins_json_path or (
-        Path.home() / ".claude" / "plugins" / "installed_plugins.json"
-    )
-    if not _plugins_json.exists():
+    from autoskillit.cli._installed_plugins import InstalledPluginsFile
+
+    store = InstalledPluginsFile(plugins_json_path)
+    if not store.path.exists():
         return DoctorResult(
             Severity.WARNING,
             "installed_plugins_entry",
             "installed_plugins.json not found. Run `autoskillit install`.",
         )
-    try:
-        data = json.loads(_plugins_json.read_text())
-    except (json.JSONDecodeError, OSError):
-        return DoctorResult(
-            Severity.WARNING,
-            "installed_plugins_entry",
-            "installed_plugins.json could not be parsed.",
-        )
-    if "autoskillit@autoskillit-local" in data:
+    if store.contains("autoskillit@autoskillit-local"):
         return DoctorResult(
             Severity.OK,
             "installed_plugins_entry",

--- a/src/autoskillit/cli/_installed_plugins.py
+++ b/src/autoskillit/cli/_installed_plugins.py
@@ -1,0 +1,65 @@
+"""Canonical accessor for ~/.claude/plugins/installed_plugins.json.
+
+The real file structure produced by `claude plugin install` is:
+    {"version": 2, "plugins": {"autoskillit@autoskillit-local": {...}}}
+
+All access to this file must go through InstalledPluginsFile so that the
+nesting contract is defined in exactly one place.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from autoskillit.core.io import atomic_write
+
+
+def _default_path() -> Path:
+    return Path.home() / ".claude" / "plugins" / "installed_plugins.json"
+
+
+class InstalledPluginsFile:
+    """Repository over installed_plugins.json.
+
+    Exposes typed query and mutation methods; enforces the {'plugins': {}} nesting.
+    """
+
+    def __init__(self, path: Path | None = None) -> None:
+        self._path = path or _default_path()
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def _read(self) -> dict[str, Any]:
+        if not self._path.exists():
+            return {}
+        try:
+            return json.loads(self._path.read_text())
+        except (json.JSONDecodeError, OSError):
+            return {}
+
+    def get_plugins(self) -> dict[str, Any]:
+        """Return the nested plugins dict (never raises)."""
+        return self._read().get("plugins", {})
+
+    def contains(self, plugin_ref: str) -> bool:
+        """Return True iff plugin_ref is present in data['plugins']."""
+        return plugin_ref in self.get_plugins()
+
+    def remove(self, plugin_ref: str) -> None:
+        """Remove plugin_ref from data['plugins'] and atomically rewrite the file.
+
+        No-op if the file does not exist or the key is absent.
+        """
+        if not self._path.exists():
+            return
+        data = self._read()
+        plugins = data.get("plugins", {})
+        if plugin_ref not in plugins:
+            return
+        del plugins[plugin_ref]
+        data["plugins"] = plugins
+        atomic_write(self._path, json.dumps(data, indent=2))

--- a/src/autoskillit/cli/_installed_plugins.py
+++ b/src/autoskillit/cli/_installed_plugins.py
@@ -13,7 +13,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from autoskillit.core.io import atomic_write
+from autoskillit.core import atomic_write
 
 
 def _default_path() -> Path:

--- a/src/autoskillit/cli/_marketplace.py
+++ b/src/autoskillit/cli/_marketplace.py
@@ -93,6 +93,24 @@ def _ensure_marketplace() -> Path:
     return marketplace_dir
 
 
+def _ensure_workspace_ready() -> None:
+    """Repair project workspace state that install() is responsible for.
+
+    Called after the CLAUDECODE guard — only when the actual install proceeds.
+    Idempotent: safe to call on any project state.
+    """
+    from autoskillit.core import ensure_project_temp
+
+    project_dir = Path.cwd()
+    # Repair .autoskillit/.gitignore and ensure temp/ exists
+    if (project_dir / ".autoskillit").is_dir():
+        ensure_project_temp(project_dir)
+
+    # Migrate legacy .autoskillit/scripts/ to .autoskillit/recipes/ if present
+    if (project_dir / ".autoskillit" / "scripts").exists():
+        upgrade()
+
+
 def install(*, scope: str = "user") -> bool:
     """Install the plugin persistently for Claude Code.
 
@@ -131,6 +149,7 @@ def install(*, scope: str = "user") -> bool:
         print("\nThen run: autoskillit init (in your project directory)")
         sys.exit(1)
 
+    _ensure_workspace_ready()
     _clear_plugin_cache()
 
     # Regenerate hooks.json from the canonical registry with absolute paths

--- a/src/autoskillit/cli/_marketplace.py
+++ b/src/autoskillit/cli/_marketplace.py
@@ -17,6 +17,7 @@ from autoskillit.cli._hooks import (
 )
 from autoskillit.cli._init_helpers import _user_claude_json_path, evict_direct_mcp_entry
 from autoskillit.core import atomic_write, is_git_worktree, pkg_root
+from autoskillit.hooks import generate_hooks_json
 
 _VALID_SCOPES = {"user", "project", "local"}
 _MARKETPLACE_NAME = "autoskillit-local"
@@ -153,8 +154,6 @@ def install(*, scope: str = "user") -> bool:
     _clear_plugin_cache()
 
     # Regenerate hooks.json from the canonical registry with absolute paths
-    from autoskillit.hooks import generate_hooks_json
-
     hooks_json_path = pkg_root() / "hooks" / "hooks.json"
     atomic_write(hooks_json_path, json.dumps(generate_hooks_json(), indent=2) + "\n")
 

--- a/src/autoskillit/cli/_marketplace.py
+++ b/src/autoskillit/cli/_marketplace.py
@@ -35,16 +35,12 @@ def _clear_plugin_cache() -> None:
     if cache_dir.is_dir():
         shutil.rmtree(cache_dir)
 
-    installed_json = Path.home() / ".claude" / "plugins" / "installed_plugins.json"
-    if installed_json.exists():
-        try:
-            data = json.loads(installed_json.read_text())
-            plugin_ref = f"autoskillit@{_MARKETPLACE_NAME}"
-            if plugin_ref in data:
-                del data[plugin_ref]
-                atomic_write(installed_json, json.dumps(data, indent=2))
-        except (OSError, json.JSONDecodeError):
-            pass  # non-fatal — install will proceed regardless
+    from autoskillit.cli._installed_plugins import InstalledPluginsFile
+
+    try:
+        InstalledPluginsFile().remove(f"autoskillit@{_MARKETPLACE_NAME}")
+    except OSError:
+        pass  # non-fatal — install will proceed regardless
 
 
 def _ensure_marketplace() -> Path:
@@ -97,7 +93,7 @@ def _ensure_marketplace() -> Path:
     return marketplace_dir
 
 
-def install(*, scope: str = "user"):
+def install(*, scope: str = "user") -> bool:
     """Install the plugin persistently for Claude Code.
 
     Sets up a local marketplace and installs the plugin so it loads
@@ -125,7 +121,7 @@ def install(*, scope: str = "user"):
         print(f"  claude plugin marketplace add {marketplace_dir}")
         print(f"  claude plugin install {plugin_ref} --scope {scope}")
         print("\nThen run: autoskillit init (in your project directory)")
-        return
+        return False  # deferred: user must complete manually in a regular terminal
 
     if shutil.which("claude") is None:
         print("\nERROR: 'claude' command not found on PATH.")
@@ -176,6 +172,7 @@ def install(*, scope: str = "user"):
     sweep_all_scopes_for_orphans(Path.cwd())
     settings_path = _hooks_mod._claude_settings_path(scope)
     sync_hooks_to_settings(settings_path)
+    return True
 
 
 def upgrade():

--- a/src/autoskillit/cli/_marketplace.py
+++ b/src/autoskillit/cli/_marketplace.py
@@ -109,7 +109,10 @@ def _ensure_workspace_ready() -> None:
 
     # Migrate legacy .autoskillit/scripts/ to .autoskillit/recipes/ if present
     if (project_dir / ".autoskillit" / "scripts").exists():
-        upgrade()
+        try:
+            upgrade()
+        except OSError as exc:
+            print(f"Warning: migration upgrade() failed (non-fatal): {exc}")
 
 
 def install(*, scope: str = "user") -> bool:

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -194,8 +194,9 @@ def install(
     from autoskillit.cli._init_helpers import _print_next_steps
     from autoskillit.cli._marketplace import install as _install
 
-    _install(scope=scope)
-    _print_next_steps(context="install")
+    completed = _install(scope=scope)
+    if completed:
+        _print_next_steps(context="install")
 
 
 @app.command

--- a/src/autoskillit/hook_registry.py
+++ b/src/autoskillit/hook_registry.py
@@ -281,6 +281,8 @@ def find_broken_hook_scripts(settings_path: Path) -> list[str]:
         for entry in data.get("hooks", {}).get(event_type, []):
             for hook in entry.get("hooks", []):
                 cmd = hook.get("command", "")
+                if not _is_own_hook(cmd):  # skip non-autoskillit hooks
+                    continue
                 parts = cmd.split()
                 if len(parts) >= 2:
                     if not Path(parts[-1]).is_file():

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -695,7 +695,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "recipe": 34,
         "execution": 26,
         "core": 18,
-        "cli": 19,
+        "cli": 20,
         "hooks": 20,
     }
     violations: list[str] = []

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -1784,6 +1784,7 @@ def test_doctor_no_dual_when_only_direct(tmp_path: Path, monkeypatch: pytest.Mon
 def test_check_installed_plugins_entry_real_structure_is_ok(tmp_path: Path) -> None:
     """With the real nested format, the check must report OK."""
     from autoskillit.cli._doctor import _check_installed_plugins_entry
+    from autoskillit.core import Severity
 
     p = tmp_path / "installed_plugins.json"
     p.write_text(
@@ -1795,14 +1796,15 @@ def test_check_installed_plugins_entry_real_structure_is_ok(tmp_path: Path) -> N
         )
     )
     result = _check_installed_plugins_entry(plugins_json_path=p)
-    assert result.severity.name == "OK"
+    assert result.severity == Severity.OK
 
 
 def test_check_installed_plugins_entry_flat_structure_is_warning(tmp_path: Path) -> None:
     """A flat structure (wrong format) must not be silently treated as OK."""
     from autoskillit.cli._doctor import _check_installed_plugins_entry
+    from autoskillit.core import Severity
 
     p = tmp_path / "installed_plugins.json"
     p.write_text(json.dumps({"autoskillit@autoskillit-local": {}}))
     result = _check_installed_plugins_entry(plugins_json_path=p)
-    assert result.severity.name == "WARNING"
+    assert result.severity == Severity.WARNING

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -94,7 +94,7 @@ class TestCLIDoctor:
         )
         # Create installed_plugins.json for Check 2d
         (tmp_path / ".claude" / "plugins" / "installed_plugins.json").write_text(
-            json.dumps({"autoskillit@autoskillit-local": {}})
+            json.dumps({"version": 2, "plugins": {"autoskillit@autoskillit-local": {}}})
         )
         # Register hooks so hook_registration check passes
         # Use explicit path (tmp_path already monkeypatched as Path.home())
@@ -639,13 +639,17 @@ def test_doctor_does_not_modify_plugin_state(tmp_path, monkeypatch, capsys):
     (cache_dir / "0.3.0" / "hooks" / "pretty_output_hook.py").write_text("# cached")
 
     plugins_json = tmp_path / ".claude" / "plugins" / "installed_plugins.json"
-    plugins_json.write_text('{"autoskillit@autoskillit-local": {"version": "0.8.25"}}')
+    plugins_json.write_text(
+        json.dumps(
+            {"version": 2, "plugins": {"autoskillit@autoskillit-local": {"version": "0.8.25"}}}
+        )
+    )
 
     cli.doctor()
 
     assert cache_dir.exists(), "Doctor must not delete the plugin cache directory"
     data = json.loads(plugins_json.read_text())
-    assert "autoskillit@autoskillit-local" in data, (
+    assert "autoskillit@autoskillit-local" in data.get("plugins", {}), (
         "Doctor must not remove installed_plugins.json entries"
     )
 
@@ -1776,3 +1780,30 @@ def test_doctor_no_dual_when_only_direct(tmp_path: Path, monkeypatch: pytest.Mon
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     result = _check_dual_mcp_registration()
     assert result.severity == Severity.OK
+
+
+def test_check_installed_plugins_entry_real_structure_is_ok(tmp_path: Path) -> None:
+    """With the real nested format, the check must report OK."""
+    from autoskillit.cli._doctor import _check_installed_plugins_entry
+
+    p = tmp_path / "installed_plugins.json"
+    p.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "plugins": {"autoskillit@autoskillit-local": {"name": "autoskillit"}},
+            }
+        )
+    )
+    result = _check_installed_plugins_entry(plugins_json_path=p)
+    assert result.severity.name == "OK"
+
+
+def test_check_installed_plugins_entry_flat_structure_is_warning(tmp_path: Path) -> None:
+    """A flat structure (wrong format) must not be silently treated as OK."""
+    from autoskillit.cli._doctor import _check_installed_plugins_entry
+
+    p = tmp_path / "installed_plugins.json"
+    p.write_text(json.dumps({"autoskillit@autoskillit-local": {}}))
+    result = _check_installed_plugins_entry(plugins_json_path=p)
+    assert result.severity.name == "WARNING"

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -69,7 +69,6 @@ class TestCLIDoctor:
                 {
                     "mcpServers": {
                         "other-server": {"type": "stdio", "command": str(fake_bin)},
-                        "autoskillit": {"type": "stdio", "command": "autoskillit"},
                     }
                 }
             )

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -678,3 +678,74 @@ def test_install_sweeps_all_scopes_for_orphans(
                 assert "pretty_output.py" not in hook["command"], (
                     "Orphaned hook was not evicted from project scope"
                 )
+
+
+def test_install_creates_autoskillit_gitignore(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """After install(), .autoskillit/.gitignore must exist (ensure_project_temp was called)."""
+    import importlib as _importlib
+
+    from autoskillit.cli._marketplace import install as _install
+
+    _app_mod = _importlib.import_module("autoskillit.cli._marketplace")
+    monkeypatch.setattr(_app_mod, "is_git_worktree", lambda path: False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(Path, "cwd", lambda: tmp_path)
+    monkeypatch.delenv("CLAUDECODE", raising=False)
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/claude")
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *a, **kw: type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})(),
+    )
+    monkeypatch.setattr("autoskillit.cli._marketplace.evict_direct_mcp_entry", lambda _: False)
+    monkeypatch.setattr(
+        "autoskillit.cli._marketplace.sweep_all_scopes_for_orphans", lambda _: None
+    )
+    monkeypatch.setattr("autoskillit.cli._marketplace.sync_hooks_to_settings", lambda _: None)
+    monkeypatch.setattr("autoskillit.cli._marketplace.generate_hooks_json", lambda: {})
+    monkeypatch.setattr("autoskillit.cli._marketplace.atomic_write", lambda *a, **kw: None)
+
+    (tmp_path / ".autoskillit").mkdir()
+    _install(scope="user")
+
+    assert (tmp_path / ".autoskillit" / ".gitignore").exists(), (
+        ".autoskillit/.gitignore must be created by install(), not just by init()"
+    )
+
+
+def test_install_calls_upgrade_when_scripts_dir_exists(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """install() must migrate .autoskillit/scripts/ → .autoskillit/recipes/ if scripts/ exists."""
+    import importlib as _importlib
+
+    from autoskillit.cli._marketplace import install as _install
+
+    _app_mod = _importlib.import_module("autoskillit.cli._marketplace")
+    monkeypatch.setattr(_app_mod, "is_git_worktree", lambda path: False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(Path, "cwd", lambda: tmp_path)
+    monkeypatch.delenv("CLAUDECODE", raising=False)
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/claude")
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *a, **kw: type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})(),
+    )
+    monkeypatch.setattr("autoskillit.cli._marketplace.evict_direct_mcp_entry", lambda _: False)
+    monkeypatch.setattr(
+        "autoskillit.cli._marketplace.sweep_all_scopes_for_orphans", lambda _: None
+    )
+    monkeypatch.setattr("autoskillit.cli._marketplace.sync_hooks_to_settings", lambda _: None)
+    monkeypatch.setattr("autoskillit.cli._marketplace.generate_hooks_json", lambda: {})
+    monkeypatch.setattr("autoskillit.cli._marketplace.atomic_write", lambda *a, **kw: None)
+
+    scripts_dir = tmp_path / ".autoskillit" / "scripts"
+    scripts_dir.mkdir(parents=True)
+
+    _install(scope="user")
+
+    assert (tmp_path / ".autoskillit" / "recipes").exists(), (
+        "install() must migrate scripts/ to recipes/ when scripts/ exists"
+    )
+    assert not scripts_dir.exists(), "scripts/ must be renamed away"

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -555,6 +555,85 @@ class TestGroupFInstall:
         )
 
 
+def test_clear_plugin_cache_removes_nested_entry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """_clear_plugin_cache must remove the entry from data['plugins'], not top-level data."""
+    from autoskillit.cli._marketplace import _clear_plugin_cache
+
+    plugins_dir = tmp_path / ".claude" / "plugins"
+    plugins_dir.mkdir(parents=True)
+    installed_json = plugins_dir / "installed_plugins.json"
+    installed_json.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "plugins": {"autoskillit@autoskillit-local": {"name": "autoskillit"}},
+            }
+        )
+    )
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    _clear_plugin_cache()
+    data = json.loads(installed_json.read_text())
+    assert "autoskillit@autoskillit-local" not in data.get("plugins", {})
+    assert data["version"] == 2  # other keys preserved
+
+
+def test_clear_plugin_cache_noop_when_entry_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """_clear_plugin_cache must not raise when the entry is already absent."""
+    from autoskillit.cli._marketplace import _clear_plugin_cache
+
+    plugins_dir = tmp_path / ".claude" / "plugins"
+    plugins_dir.mkdir(parents=True)
+    installed_json = plugins_dir / "installed_plugins.json"
+    installed_json.write_text(json.dumps({"version": 2, "plugins": {}}))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    _clear_plugin_cache()  # must not raise
+    data = json.loads(installed_json.read_text())
+    assert data == {"version": 2, "plugins": {}}
+
+
+def test_install_claudecode_guard_returns_false(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """install() must return False when CLAUDECODE guard fires, not None-as-success."""
+    import importlib as _importlib
+
+    from autoskillit.cli._marketplace import install as _install
+
+    _app_mod = _importlib.import_module("autoskillit.cli._marketplace")
+    monkeypatch.setattr(_app_mod, "is_git_worktree", lambda path: False)
+    monkeypatch.setenv("CLAUDECODE", "1")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    result = _install(scope="user")
+    assert result is False, f"Expected False, got {result!r}"
+
+
+def test_install_claudecode_guard_does_not_print_next_steps(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """app.install() must not print Next Steps when CLAUDECODE guard fires."""
+
+    import autoskillit.cli._init_helpers as _init_helpers_mod
+    import autoskillit.cli._marketplace as _mkt_mod
+
+    next_steps_called: list[dict] = []
+    monkeypatch.setattr(
+        _init_helpers_mod, "_print_next_steps", lambda **kw: next_steps_called.append(kw)
+    )
+    monkeypatch.setattr(_mkt_mod, "install", lambda **kw: False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    from autoskillit.cli.app import install as app_install
+
+    app_install(scope="user")
+    assert not next_steps_called, (
+        "_print_next_steps must not be called when install() returns False"
+    )
+
+
 def test_install_sweeps_all_scopes_for_orphans(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/cli/test_installed_plugins_file.py
+++ b/tests/cli/test_installed_plugins_file.py
@@ -5,15 +5,11 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
 from autoskillit.cli._installed_plugins import InstalledPluginsFile
 
 REAL_STRUCTURE = {
     "version": 2,
-    "plugins": {
-        "autoskillit@autoskillit-local": {"name": "autoskillit", "version": "0.8.30"}
-    },
+    "plugins": {"autoskillit@autoskillit-local": {"name": "autoskillit", "version": "0.8.30"}},
 }
 
 

--- a/tests/cli/test_installed_plugins_file.py
+++ b/tests/cli/test_installed_plugins_file.py
@@ -1,0 +1,85 @@
+"""Unit tests for the InstalledPluginsFile repository."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from autoskillit.cli._installed_plugins import InstalledPluginsFile
+
+REAL_STRUCTURE = {
+    "version": 2,
+    "plugins": {
+        "autoskillit@autoskillit-local": {"name": "autoskillit", "version": "0.8.30"}
+    },
+}
+
+
+def _write(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data))
+
+
+def test_contains_finds_entry_in_nested_plugins(tmp_path: Path) -> None:
+    p = tmp_path / "installed_plugins.json"
+    _write(p, REAL_STRUCTURE)
+    assert InstalledPluginsFile(p).contains("autoskillit@autoskillit-local") is True
+
+
+def test_contains_does_not_false_positive_on_flat_structure(tmp_path: Path) -> None:
+    """A flat dict should NOT be treated as containing the plugin."""
+    p = tmp_path / "installed_plugins.json"
+    _write(p, {"autoskillit@autoskillit-local": {}})  # flat — wrong format
+    # With the real nested structure absent, contains() must return False
+    assert InstalledPluginsFile(p).contains("autoskillit@autoskillit-local") is False
+
+
+def test_contains_returns_false_when_missing(tmp_path: Path) -> None:
+    p = tmp_path / "installed_plugins.json"
+    _write(p, {"version": 2, "plugins": {}})
+    assert InstalledPluginsFile(p).contains("autoskillit@autoskillit-local") is False
+
+
+def test_contains_returns_false_when_file_absent(tmp_path: Path) -> None:
+    p = tmp_path / "no_file.json"
+    assert InstalledPluginsFile(p).contains("autoskillit@autoskillit-local") is False
+
+
+def test_remove_deletes_nested_entry(tmp_path: Path) -> None:
+    p = tmp_path / "installed_plugins.json"
+    _write(p, REAL_STRUCTURE)
+    InstalledPluginsFile(p).remove("autoskillit@autoskillit-local")
+    data = json.loads(p.read_text())
+    assert "autoskillit@autoskillit-local" not in data.get("plugins", {})
+
+
+def test_remove_preserves_other_keys(tmp_path: Path) -> None:
+    p = tmp_path / "installed_plugins.json"
+    payload = {
+        "version": 2,
+        "plugins": {
+            "autoskillit@autoskillit-local": {},
+            "other@other-local": {"name": "other"},
+        },
+    }
+    _write(p, payload)
+    InstalledPluginsFile(p).remove("autoskillit@autoskillit-local")
+    data = json.loads(p.read_text())
+    assert data["version"] == 2
+    assert "other@other-local" in data["plugins"]
+
+
+def test_remove_is_noop_when_key_absent(tmp_path: Path) -> None:
+    p = tmp_path / "installed_plugins.json"
+    _write(p, {"version": 2, "plugins": {}})
+    InstalledPluginsFile(p).remove("autoskillit@autoskillit-local")  # should not raise
+    data = json.loads(p.read_text())
+    assert data == {"version": 2, "plugins": {}}
+
+
+def test_remove_is_noop_when_file_absent(tmp_path: Path) -> None:
+    p = tmp_path / "no_file.json"
+    InstalledPluginsFile(p).remove("autoskillit@autoskillit-local")  # should not raise
+    assert not p.exists()

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -142,7 +142,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _marketplace.py — marketplace.json (co-owned)
     ("src/autoskillit/cli/_marketplace.py", 85),
     # _marketplace.py — hooks.json (co-owned)
-    ("src/autoskillit/cli/_marketplace.py", 158),
+    ("src/autoskillit/cli/_marketplace.py", 161),
     # _update_checks.py — dismissal state file
     ("src/autoskillit/cli/_update_checks.py", 102),
     # _update_checks.py — fetch cache

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -137,12 +137,12 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/cli/_init_helpers.py", 376),
     # _init_helpers.py — evict_direct_mcp_entry write-back to ~/.claude.json (co-owned)
     ("src/autoskillit/cli/_init_helpers.py", 395),
-    # _marketplace.py — installed_plugins.json (co-owned with Claude plugin system)
-    ("src/autoskillit/cli/_marketplace.py", 45),
+    # _installed_plugins.py — installed_plugins.json (co-owned with Claude plugin system)
+    ("src/autoskillit/cli/_installed_plugins.py", 65),
     # _marketplace.py — marketplace.json (co-owned)
-    ("src/autoskillit/cli/_marketplace.py", 88),
+    ("src/autoskillit/cli/_marketplace.py", 84),
     # _marketplace.py — hooks.json (co-owned)
-    ("src/autoskillit/cli/_marketplace.py", 144),
+    ("src/autoskillit/cli/_marketplace.py", 140),
     # _update_checks.py — dismissal state file
     ("src/autoskillit/cli/_update_checks.py", 102),
     # _update_checks.py — fetch cache

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -140,9 +140,9 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _installed_plugins.py — installed_plugins.json (co-owned with Claude plugin system)
     ("src/autoskillit/cli/_installed_plugins.py", 65),
     # _marketplace.py — marketplace.json (co-owned)
-    ("src/autoskillit/cli/_marketplace.py", 84),
+    ("src/autoskillit/cli/_marketplace.py", 85),
     # _marketplace.py — hooks.json (co-owned)
-    ("src/autoskillit/cli/_marketplace.py", 140),
+    ("src/autoskillit/cli/_marketplace.py", 158),
     # _update_checks.py — dismissal state file
     ("src/autoskillit/cli/_update_checks.py", 102),
     # _update_checks.py — fetch cache

--- a/tests/test_hook_registry.py
+++ b/tests/test_hook_registry.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from autoskillit.hook_registry import (
     HOOK_REGISTRY,
+    HOOKS_DIR,
     _extract_script_basenames,
     _is_own_hook,
     canonical_script_basenames,
+    find_broken_hook_scripts,
     generate_hooks_json,
 )
 
@@ -130,3 +133,55 @@ def test_hook_registry_uses_new_filenames() -> None:
     }
     for old in old_names:
         assert old not in all_scripts, f"HOOK_REGISTRY still references old name: {old}"
+
+
+def test_find_broken_hook_scripts_ignores_user_inline_hooks(tmp_path: Path) -> None:
+    """User inline hooks like 'wsl-notify-send.exe Done' must not be flagged as broken."""
+    settings = tmp_path / "settings.json"
+    settings.write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "PostToolUse": [{"hooks": [{"command": 'wsl-notify-send.exe "Build done"'}]}]
+                }
+            }
+        )
+    )
+    broken = find_broken_hook_scripts(settings)
+    assert broken == []
+
+
+def test_find_broken_hook_scripts_flags_missing_autoskillit_script(tmp_path: Path) -> None:
+    """A python3 /abs/path/autoskillit/hooks/script.py that doesn't exist must be flagged."""
+    missing = str(HOOKS_DIR / "nonexistent_guard.py")
+    settings = tmp_path / "settings.json"
+    settings.write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "PreToolUse": [{"matcher": ".*", "hooks": [{"command": f"python3 {missing}"}]}]
+                }
+            }
+        )
+    )
+    broken = find_broken_hook_scripts(settings)
+    assert any("nonexistent_guard.py" in b for b in broken)
+
+
+def test_find_broken_hook_scripts_does_not_flag_user_python_scripts(tmp_path: Path) -> None:
+    """A user's python3 script outside the autoskillit hooks dir must not be flagged."""
+    user_script = "/home/user/my_custom_guard.py"
+    settings = tmp_path / "settings.json"
+    settings.write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {"matcher": ".*", "hooks": [{"command": f"python3 {user_script}"}]}
+                    ]
+                }
+            }
+        )
+    )
+    broken = find_broken_hook_scripts(settings)
+    assert broken == []


### PR DESCRIPTION
## Summary

Four discrete bugs share a single architectural root: there is no canonical owner for `installed_plugins.json`. Every caller that touches the file re-implements its own structural interpretation of the JSON format, and two of those implementations got the nesting wrong (`{"plugins": {...}}` vs flat `{}`). The test fixtures matched the wrong implementations, so the regression passed CI.

The architectural fix is a **typed repository class** — `InstalledPluginsFile` — that becomes the single authorized interface for all reads and writes of `installed_plugins.json`. Once all call sites are routed through this class, the correct nesting is in exactly one place. A wrong structure cannot be silently introduced by a new call site: the class's API enforces the contract.

Two companion fixes complete the immunity:
- `install()` must return a typed value distinguishing "complete" from "deferred (CLAUDECODE)" so callers cannot proceed with misleading success output.
- `find_broken_hook_scripts` must apply the same `_is_own_hook` ownership filter that `_extract_script_basenames` already uses, eliminating false positives on user-defined inline hooks.

Part B (separate task) will cover `ensure_project_temp` call site completeness across CLI entry points.

## Architecture Impact

### Repository/Data Access Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 65, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph Callers ["CALLERS"]
        direction TB
        APP["● app.py<br/>━━━━━━━━━━<br/>CLI entry: install,<br/>init, doctor, upgrade"]
        MARKET["● _marketplace.py<br/>━━━━━━━━━━<br/>install() / upgrade()<br/>_clear_plugin_cache()"]
        DOCTOR["● _doctor.py<br/>━━━━━━━━━━<br/>_check_installed_plugins_entry()<br/>_check_hook_registry_drift()<br/>_check_hook_health()"]
    end

    subgraph PluginRepo ["★ PLUGIN REGISTRY (new)"]
        direction TB
        IPF["★ InstalledPluginsFile<br/>━━━━━━━━━━<br/>get_plugins() → read<br/>contains(ref) → read<br/>remove(ref) → read+write<br/>cli/_installed_plugins.py"]
    end

    subgraph HookRepo ["● HOOK REGISTRY (modified)"]
        direction TB
        HREG["● HOOK_REGISTRY<br/>━━━━━━━━━━<br/>List[HookDef] — canonical<br/>source of truth<br/>hook_registry.py"]
        GEN["● generate_hooks_json()<br/>━━━━━━━━━━<br/>HookDef → JSON structure<br/>hook_registry.py"]
        DRIFT["● _count_hook_registry_drift()<br/>━━━━━━━━━━<br/>canonical vs deployed<br/>hook_registry.py"]
        FIND["find_broken_hook_scripts()<br/>━━━━━━━━━━<br/>deployed scripts<br/>existence check"]
        EXTRACT["_extract_script_basenames()<br/>━━━━━━━━━━<br/>settings.json hooks<br/>→ basename set"]
    end

    subgraph IOLayer ["I/O PRIMITIVE"]
        AW["atomic_write()<br/>━━━━━━━━━━<br/>fsync + os.replace<br/>core/io.py"]
    end

    subgraph Storage ["STORAGE"]
        direction TB
        INSTJSON[("installed_plugins.json<br/>━━━━━━━━━━<br/>~/.claude/plugins/<br/>installed_plugins.json")]
        HOOKSJSON[("hooks.json<br/>━━━━━━━━━━<br/>hooks/hooks.json<br/>plugin manifest")]
        SETTINGS[("settings.json<br/>━━━━━━━━━━<br/>~/.claude/settings.json<br/>per-scope hook registration")]
        CLAUDEJSON[("~/.claude.json<br/>━━━━━━━━━━<br/>Legacy mcpServers<br/>config")]
        CACHE[("Plugin Cache Dir<br/>━━━━━━━━━━<br/>~/.claude/plugins/<br/>cache/autoskillit-local/")]
    end

    %% Caller → Repository relationships %%
    APP -->|"invokes"| MARKET
    APP -->|"invokes"| DOCTOR

    MARKET -->|"reads/writes"| IPF
    MARKET -->|"reads"| HREG
    MARKET -->|"writes hooks.json"| AW

    DOCTOR -->|"reads"| IPF
    DOCTOR -->|"reads"| DRIFT
    DOCTOR -->|"reads"| FIND
    DOCTOR -->|"reads"| SETTINGS

    %% Hook Registry internal %%
    HREG -->|"drives"| GEN
    HREG -->|"drives"| DRIFT
    GEN -->|"writes via"| AW
    DRIFT -->|"reads"| EXTRACT
    EXTRACT -->|"parses"| SETTINGS
    FIND -->|"parses"| SETTINGS

    %% Repository → Storage %%
    IPF -->|"reads"| INSTJSON
    IPF -->|"writes via atomic_write"| AW
    AW -->|"writes"| INSTJSON
    AW -->|"writes"| HOOKSJSON

    %% Cache eviction (marketplace) %%
    MARKET -->|"deletes"| CACHE

    %% Doctor reads legacy config %%
    DOCTOR -->|"reads"| CLAUDEJSON

    %% CLASS ASSIGNMENTS %%
    class APP,MARKET cli;
    class DOCTOR detector;
    class IPF newComponent;
    class HREG,GEN stateNode;
    class DRIFT,FIND,EXTRACT phase;
    class AW handler;
    class INSTJSON,HOOKSJSON,SETTINGS,CLAUDEJSON,CACHE integration;
```

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 42, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    INSTALL_START([autoskillit install])
    INSTALL_DEFERRED([DEFERRED<br/>━━━━━━━━━━<br/>user must run manually])
    INSTALL_COMPLETE([INSTALL COMPLETE])
    DOCTOR_START([autoskillit doctor])
    DOCTOR_END([DOCTOR COMPLETE])

    %% ─────────────────────────────────────────────
    %%  INSTALL FLOW
    %% ─────────────────────────────────────────────

    subgraph InstallPreflight ["Install — Preflight"]
        direction TB
        ValidateScope{"● scope valid?<br/>━━━━━━━━━━<br/>user / project / local"}
        EnsureMarketplace["_ensure_marketplace()<br/>━━━━━━━━━━<br/>mkdir ~/.autoskillit/marketplace<br/>write marketplace.json<br/>symlink → pkg_root()"]
        GuardCLAUDECODE{"CLAUDECODE env set?<br/>━━━━━━━━━━<br/>running inside session?"}
        GuardClaude{"claude on PATH?<br/>━━━━━━━━━━<br/>shutil.which('claude')"}
        EnsureWorkspace["_ensure_workspace_ready()<br/>━━━━━━━━━━<br/>ensure_project_temp()<br/>upgrade() if scripts/ present"]
    end

    subgraph CacheClear ["Install — Cache Clearing (●)"]
        direction TB
        RmCacheDir["shutil.rmtree(cache_dir)<br/>━━━━━━━━━━<br/>~/.claude/plugins/cache/<br/>autoskillit-local/autoskillit"]
        InstalledPluginsRemove["★ InstalledPluginsFile.remove()<br/>━━━━━━━━━━<br/>reads installed_plugins.json<br/>deletes 'autoskillit@autoskillit-local'<br/>atomic_write() back"]
        HooksJsonRegen["● generate_hooks_json()<br/>━━━━━━━━━━<br/>iterates HOOK_REGISTRY<br/>writes hooks/hooks.json<br/>embeds HOOK_REGISTRY_HASH"]
    end

    subgraph PluginRegistration ["Install — Plugin Registration"]
        direction TB
        MarketplaceAdd["claude plugin marketplace add<br/>━━━━━━━━━━<br/>subprocess, timeout=30s"]
        PluginInstall["claude plugin install<br/>━━━━━━━━━━<br/>plugin_ref @ scope"]
        EvictDirect["evict_direct_mcp_entry()<br/>━━━━━━━━━━<br/>remove stale direct entry<br/>from ~/.claude.json"]
    end

    subgraph HookSync ["Install — Hook Sync (●)"]
        direction TB
        SweepAllScopes["sweep_all_scopes_for_orphans()<br/>━━━━━━━━━━<br/>iterate user + project + local<br/>remove orphaned hook entries"]
        SyncHooks["sync_hooks_to_settings()<br/>━━━━━━━━━━<br/>write canonical hooks<br/>to target scope settings.json"]
    end

    %% ─────────────────────────────────────────────
    %%  SHARED STATE
    %% ─────────────────────────────────────────────

    subgraph SharedState ["★ InstalledPluginsFile (_installed_plugins.py)"]
        direction LR
        IPF_Read["_read()<br/>━━━━━━━━━━<br/>json.loads(path)<br/>→ {} on missing/error"]
        IPF_Contains["contains(plugin_ref)<br/>━━━━━━━━━━<br/>plugin_ref in get_plugins()"]
        IPF_Remove["remove(plugin_ref)<br/>━━━━━━━━━━<br/>del plugins[ref]<br/>atomic_write() back"]
        InstalledPluginsJSON[("installed_plugins.json<br/>━━━━━━━━━━<br/>~/.claude/plugins/<br/>{version,plugins:{}}")]
    end

    %% ─────────────────────────────────────────────
    %%  DOCTOR FLOW
    %% ─────────────────────────────────────────────

    subgraph DoctorMCP ["Doctor — MCP Checks"]
        direction TB
        ChkStaleMCP["check: stale_mcp_servers<br/>━━━━━━━━━━<br/>dead binary paths in ~/.claude.json"]
        ChkMCPReg["check: mcp_server_registered<br/>━━━━━━━━━━<br/>mcpServers entry OR<br/>claude plugin list"]
        ChkDualReg["● check: dual_mcp_registration<br/>━━━━━━━━━━<br/>direct entry AND plugin both present?<br/>→ WARNING: split-brain"]
        ChkPluginCache["check: plugin_cache_exists<br/>━━━━━━━━━━<br/>~/.claude/plugins/cache/... dir?"]
        ChkInstalledPlugins["● check: installed_plugins_entry<br/>━━━━━━━━━━<br/>InstalledPluginsFile.contains()<br/>'autoskillit@autoskillit-local'?"]
    end

    subgraph DoctorHooks ["Doctor — Hook Checks (●)"]
        direction TB
        ChkHookHealth["check: hook_health<br/>━━━━━━━━━━<br/>find_broken_hook_scripts()<br/>script files exist on disk?"]
        ChkHookReg["check: hook_registration<br/>━━━━━━━━━━<br/>canonical_script_basenames()<br/>all scripts in settings.json?"]
        ChkHookDrift["● check: hook_registry_drift<br/>━━━━━━━━━━<br/>_count_hook_registry_drift()<br/>orphaned | missing hooks<br/>iterates all scopes"]
    end

    subgraph DoctorHealth ["Doctor — Health Checks"]
        direction TB
        ChkVersion["check: version_consistency<br/>━━━━━━━━━━<br/>pkg version == plugin.json version?"]
        ChkConfig["check: project_config<br/>━━━━━━━━━━<br/>.autoskillit/config.yaml exists?"]
        ChkGitignore["check: gitignore_completeness<br/>━━━━━━━━━━<br/>.autoskillit/ entries covered?"]
        ChkQuota["check: quota_cache_schema<br/>━━━━━━━━━━<br/>schema_version drift?"]
        ChkInstallClass["check: install_classification<br/>━━━━━━━━━━<br/>detect_install() → InstallType"]
        ChkSourceDrift["check: source_version_drift<br/>━━━━━━━━━━<br/>commit SHA vs reference SHA<br/>(network + disk-cache TTL)"]
        ChkEditableInst["check: editable_install_source_exists<br/>━━━━━━━━━━<br/>direct_url.json → source path exists?"]
        ChkDismissal["check: update_dismissal_state<br/>━━━━━━━━━━<br/>dismissed_at + window expiry"]
    end

    %% ─────────────────────────────────────────────
    %%  INSTALL EDGES
    %% ─────────────────────────────────────────────
    INSTALL_START --> ValidateScope
    ValidateScope -->|"invalid"| INSTALL_COMPLETE
    ValidateScope -->|"valid"| EnsureMarketplace
    EnsureMarketplace --> GuardCLAUDECODE
    GuardCLAUDECODE -->|"yes — inside session"| INSTALL_DEFERRED
    GuardCLAUDECODE -->|"no"| GuardClaude
    GuardClaude -->|"missing"| INSTALL_COMPLETE
    GuardClaude -->|"found"| EnsureWorkspace
    EnsureWorkspace --> RmCacheDir
    RmCacheDir --> InstalledPluginsRemove
    InstalledPluginsRemove -->|"reads/writes"| InstalledPluginsJSON
    InstalledPluginsRemove --> HooksJsonRegen
    HooksJsonRegen --> MarketplaceAdd
    MarketplaceAdd -->|"returncode != 0"| INSTALL_COMPLETE
    MarketplaceAdd -->|"ok"| PluginInstall
    PluginInstall -->|"returncode != 0"| INSTALL_COMPLETE
    PluginInstall -->|"ok"| EvictDirect
    EvictDirect --> SweepAllScopes
    SweepAllScopes --> SyncHooks
    SyncHooks --> INSTALL_COMPLETE

    %% ─────────────────────────────────────────────
    %%  DOCTOR EDGES
    %% ─────────────────────────────────────────────
    DOCTOR_START --> ChkStaleMCP
    ChkStaleMCP --> ChkMCPReg
    ChkMCPReg --> ChkDualReg
    ChkDualReg --> ChkPluginCache
    ChkPluginCache --> ChkInstalledPlugins
    ChkInstalledPlugins -->|"reads"| IPF_Contains
    IPF_Contains -->|"reads"| IPF_Read
    IPF_Read -->|"reads"| InstalledPluginsJSON
    ChkInstalledPlugins --> ChkHookHealth
    ChkHookHealth --> ChkHookReg
    ChkHookReg --> ChkHookDrift
    ChkHookDrift --> ChkVersion
    ChkVersion --> ChkConfig
    ChkConfig --> ChkGitignore
    ChkGitignore --> ChkQuota
    ChkQuota --> ChkInstallClass
    ChkInstallClass --> ChkSourceDrift
    ChkSourceDrift --> ChkEditableInst
    ChkEditableInst --> ChkDismissal
    ChkDismissal --> DOCTOR_END

    %% ─────────────────────────────────────────────
    %%  SHARED STATE INTERNAL EDGES
    %% ─────────────────────────────────────────────
    IPF_Remove -->|"atomic_write()"| InstalledPluginsJSON

    %% ─────────────────────────────────────────────
    %%  CLASS ASSIGNMENTS
    %% ─────────────────────────────────────────────
    class INSTALL_START,INSTALL_DEFERRED,INSTALL_COMPLETE,DOCTOR_START,DOCTOR_END terminal;
    class ValidateScope,GuardCLAUDECODE,GuardClaude stateNode;
    class EnsureMarketplace,EnsureWorkspace,HooksJsonRegen,MarketplaceAdd,PluginInstall,EvictDirect handler;
    class RmCacheDir,SweepAllScopes,SyncHooks phase;
    class InstalledPluginsRemove,IPF_Read,IPF_Contains,IPF_Remove newComponent;
    class InstalledPluginsJSON output;
    class ChkStaleMCP,ChkMCPReg,ChkDualReg,ChkPluginCache,ChkInstalledPlugins detector;
    class ChkHookHealth,ChkHookReg,ChkHookDrift detector;
    class ChkVersion,ChkConfig,ChkGitignore,ChkQuota,ChkInstallClass,ChkSourceDrift,ChkEditableInst,ChkDismissal phase;
```

Closes #912

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260414-075239-201688/.autoskillit/temp/rectify/rectify_doctor-install-disconnect_2026-04-14_120000_part_a.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| review_approach | 158 | 12.4k | 1.1M | 98.1k | 1 | 4m 53s |
| make_plan | 195 | 14.2k | 1.4M | 83.3k | 1 | 4m 22s |
| dry_walkthrough | 2.3k | 13.0k | 935.8k | 77.9k | 1 | 3m 52s |
| implement | 570 | 25.7k | 4.6M | 81.3k | 1 | 8m 37s |
| resolve_failures | 226 | 10.6k | 1.4M | 52.7k | 1 | 11m 17s |
| prepare_pr | 101 | 5.3k | 174.6k | 28.2k | 1 | 1m 27s |
| run_arch_lenses | 157 | 13.7k | 597.9k | 43.2k | 1 | 9m 22s |
| compose_pr | 67 | 1.8k | 178.2k | 14.4k | 1 | 43s |
| review_pr | 94 | 21.1k | 374.8k | 48.0k | 1 | 6m 6s |
| **Total** | 3.9k | 117.8k | 10.7M | 527.1k | | 50m 42s |