### PR TITLE
feat: decouple server/helpers.py from recipe/ (#926)

### DIFF
--- a/src/autoskillit/core/_type_protocols.py
+++ b/src/autoskillit/core/_type_protocols.py
@@ -217,6 +217,15 @@ class RecipeRepository(Protocol):
 
     def list_all(self, project_dir: Any | None = None) -> dict[str, Any]: ...
 
+    async def apply_triage_gate(
+        self,
+        result: dict[str, Any],
+        recipe_name: str,
+        recipe_info: Any,
+        temp_dir: Path,
+        logger: Any,
+    ) -> dict[str, Any]: ...
+
 
 @runtime_checkable
 class MigrationService(Protocol):

--- a/src/autoskillit/core/_type_protocols.py
+++ b/src/autoskillit/core/_type_protocols.py
@@ -224,6 +224,7 @@ class RecipeRepository(Protocol):
         recipe_info: Any,
         temp_dir: Path,
         logger: Any,
+        triage_fn: Any = None,
     ) -> dict[str, Any]: ...
 
 

--- a/src/autoskillit/recipe/repository.py
+++ b/src/autoskillit/recipe/repository.py
@@ -101,6 +101,7 @@ class DefaultRecipeRepository:
         recipe_info: Any,
         temp_dir: Path,
         logger: Any,
+        triage_fn: Any = None,
     ) -> dict[str, Any]:
         """Apply LLM triage to stale-contract suggestions, suppressing cosmetic ones."""
         stale_suggs = [
@@ -140,11 +141,9 @@ class DefaultRecipeRepository:
                 for s in stale_suggs
                 if s.get("reason") == "hash_mismatch"
             ]
-            if hash_items:
-                from autoskillit._llm_triage import triage_staleness
-
+            if hash_items and triage_fn is not None:
                 t_llm = time.perf_counter()
-                triage = await triage_staleness(hash_items)
+                triage = await triage_fn(hash_items)
                 logger.debug(
                     "triage_gate_llm_triage",
                     recipe=recipe_name,

--- a/src/autoskillit/recipe/repository.py
+++ b/src/autoskillit/recipe/repository.py
@@ -2,12 +2,21 @@
 
 from __future__ import annotations
 
+import time
 from collections.abc import Sequence
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, cast
 
 import autoskillit.recipe._api as _api
+from autoskillit.recipe.contracts import StaleItem, load_bundled_manifest
 from autoskillit.recipe.io import builtin_recipes_dir, list_recipes
+from autoskillit.recipe.staleness_cache import (
+    StalenessEntry,
+    compute_recipe_hash,
+    read_staleness_cache,
+    write_staleness_cache,
+)
 
 
 def _dir_mtime(path: Path) -> float:
@@ -84,3 +93,83 @@ class DefaultRecipeRepository:
 
     def list_all(self, project_dir: Any | None = None) -> dict[str, Any]:
         return _api.list_all(project_dir=project_dir)
+
+    async def apply_triage_gate(
+        self,
+        result: dict[str, Any],
+        recipe_name: str,
+        recipe_info: Any,
+        temp_dir: Path,
+        logger: Any,
+    ) -> dict[str, Any]:
+        """Apply LLM triage to stale-contract suggestions, suppressing cosmetic ones."""
+        stale_suggs = [
+            s for s in result.get("suggestions", []) if s.get("rule") == "stale-contract"
+        ]
+        if not stale_suggs:
+            return result
+
+        if recipe_info is None:
+            recipe_info = self.find(recipe_name, Path.cwd())
+        if recipe_info is None:
+            return result
+
+        cache_path = temp_dir / "recipe_staleness_cache.json"
+        t0 = time.perf_counter()
+        cached = read_staleness_cache(cache_path, recipe_name)
+        logger.debug(
+            "triage_gate_cache_read",
+            recipe=recipe_name,
+            elapsed_ms=round((time.perf_counter() - t0) * 1000, 1),
+        )
+
+        if cached is not None and cached.triage_result == "cosmetic":
+            result["suggestions"] = [
+                s for s in result["suggestions"] if s.get("rule") != "stale-contract"
+            ]
+            return result
+
+        if cached is None or cached.triage_result is None:
+            hash_items = [
+                StaleItem(
+                    skill=s["skill"],
+                    reason=s["reason"],
+                    stored_value=s.get("stored_value", ""),
+                    current_value=s.get("current_value", ""),
+                )
+                for s in stale_suggs
+                if s.get("reason") == "hash_mismatch"
+            ]
+            if hash_items:
+                from autoskillit._llm_triage import triage_staleness
+
+                t_llm = time.perf_counter()
+                triage = await triage_staleness(hash_items)
+                logger.debug(
+                    "triage_gate_llm_triage",
+                    recipe=recipe_name,
+                    elapsed_ms=round((time.perf_counter() - t_llm) * 1000, 1),
+                )
+                all_cosmetic = all(not r.get("meaningful", True) for r in triage)
+                triage_str = "cosmetic" if all_cosmetic else "meaningful"
+                current_hash = compute_recipe_hash(recipe_info.path)
+                current_ver = load_bundled_manifest().get("version", "")
+                write_staleness_cache(
+                    cache_path,
+                    recipe_name,
+                    StalenessEntry(
+                        recipe_hash=current_hash,
+                        manifest_version=current_ver,
+                        is_stale=True,
+                        triage_result=triage_str,
+                        checked_at=datetime.now(UTC).isoformat(),
+                    ),
+                )
+                if all_cosmetic and not any(
+                    s.get("reason") == "version_mismatch" for s in stale_suggs
+                ):
+                    result["suggestions"] = [
+                        s for s in result["suggestions"] if s.get("rule") != "stale-contract"
+                    ]
+
+        return result

--- a/src/autoskillit/server/helpers.py
+++ b/src/autoskillit/server/helpers.py
@@ -6,7 +6,6 @@ import asyncio
 import functools
 import json
 import os
-import time
 from collections.abc import Awaitable, Callable, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -21,15 +20,6 @@ from autoskillit.execution import (
 )
 from autoskillit.hooks import _HOOK_CONFIG_PATH_COMPONENTS
 from autoskillit.pipeline import gate_error_result
-from autoskillit.recipe import (
-    StaleItem,
-    StalenessEntry,
-    compute_recipe_hash,
-    find_recipe_by_name,
-    load_bundled_manifest,
-    read_staleness_cache,
-    write_staleness_cache,
-)
 from autoskillit.workspace import clone_registry  # noqa: F401 — re-exported for tools_clone.py
 
 if TYPE_CHECKING:
@@ -248,90 +238,14 @@ async def _apply_triage_gate(
 ) -> dict[str, Any]:
     """Apply LLM triage to stale-contract suggestions, suppressing cosmetic ones.
 
-    Checks the staleness cache for a cached triage result. If not cached,
-    runs triage_staleness() (a 30s Haiku call) for hash_mismatch items only.
-    version_mismatch items are always treated as meaningful and never suppressed.
-
-    When ``recipe_info`` is provided by the caller, the internal find() call is
-    skipped, eliminating the duplicate YAML directory scan.
-
-    Modifies ``result`` in-place and returns it.
+    Delegates to the RecipeRepository implementation via the Composition Root.
     """
     from autoskillit.server._state import _ctx
 
     if _ctx is None or _ctx.recipes is None:
         return result
 
-    stale_suggs = [s for s in result.get("suggestions", []) if s.get("rule") == "stale-contract"]
-    if not stale_suggs:
-        return result
-
-    if recipe_info is None:
-        recipe_info = _ctx.recipes.find(name, Path.cwd())
-    if recipe_info is None:
-        return result
-
-    cache_path = _ctx.temp_dir / "recipe_staleness_cache.json"
-    t0 = time.perf_counter()
-    cached = read_staleness_cache(cache_path, name)
-    logger.debug(
-        "triage_gate_cache_read",
-        recipe=name,
-        elapsed_ms=round((time.perf_counter() - t0) * 1000, 1),
-    )
-
-    if cached is not None and cached.triage_result == "cosmetic":
-        result["suggestions"] = [
-            s for s in result["suggestions"] if s.get("rule") != "stale-contract"
-        ]
-        return result
-
-    if cached is None or cached.triage_result is None:
-        hash_items = [
-            StaleItem(
-                skill=s["skill"],
-                reason=s["reason"],
-                stored_value=s.get("stored_value", ""),
-                current_value=s.get("current_value", ""),
-            )
-            for s in stale_suggs
-            if s.get("reason") == "hash_mismatch"
-        ]
-        if hash_items:
-            from datetime import UTC, datetime
-
-            from autoskillit._llm_triage import triage_staleness
-
-            t_llm = time.perf_counter()
-            triage = await triage_staleness(hash_items)
-            logger.debug(
-                "triage_gate_llm_triage",
-                recipe=name,
-                elapsed_ms=round((time.perf_counter() - t_llm) * 1000, 1),
-            )
-            all_cosmetic = all(not r.get("meaningful", True) for r in triage)
-            triage_str = "cosmetic" if all_cosmetic else "meaningful"
-            current_hash = compute_recipe_hash(recipe_info.path)
-            current_ver = load_bundled_manifest().get("version", "")
-            write_staleness_cache(
-                cache_path,
-                name,
-                StalenessEntry(
-                    recipe_hash=current_hash,
-                    manifest_version=current_ver,
-                    is_stale=True,
-                    triage_result=triage_str,
-                    checked_at=datetime.now(UTC).isoformat(),
-                ),
-            )
-            if all_cosmetic and not any(
-                s.get("reason") == "version_mismatch" for s in stale_suggs
-            ):
-                result["suggestions"] = [
-                    s for s in result["suggestions"] if s.get("rule") != "stale-contract"
-                ]
-
-    return result
+    return await _ctx.recipes.apply_triage_gate(result, name, recipe_info, _ctx.temp_dir, logger)
 
 
 def _process_runner_result(
@@ -466,16 +380,6 @@ async def _import_and_call(
         return {"success": True, "result": result}
     except (TypeError, ValueError):
         return {"success": True, "result": str(result)}
-
-
-def _find_recipe(name: str, cwd: Path) -> Any:
-    """Look up a recipe by name. Delegates to recipe layer; exposed for tools_kitchen.py.
-
-    tools_kitchen.py (a tools_*.py file) is restricted by REQ-IMP-003 to importing
-    only from autoskillit.core, autoskillit.pipeline, and autoskillit.server.
-    This function provides the architecture-compliant bridge to autoskillit.recipe.
-    """
-    return find_recipe_by_name(name, cwd)
 
 
 async def infer_repo_from_remote(cwd: str, hint: str | None = None) -> str:

--- a/src/autoskillit/server/helpers.py
+++ b/src/autoskillit/server/helpers.py
@@ -245,7 +245,11 @@ async def _apply_triage_gate(
     if _ctx is None or _ctx.recipes is None:
         return result
 
-    return await _ctx.recipes.apply_triage_gate(result, name, recipe_info, _ctx.temp_dir, logger)
+    from autoskillit._llm_triage import triage_staleness
+
+    return await _ctx.recipes.apply_triage_gate(
+        result, name, recipe_info, _ctx.temp_dir, logger, triage_fn=triage_staleness
+    )
 
 
 def _process_runner_result(

--- a/src/autoskillit/server/tools_kitchen.py
+++ b/src/autoskillit/server/tools_kitchen.py
@@ -22,7 +22,6 @@ from autoskillit.server import mcp
 from autoskillit.server.helpers import (
     _apply_triage_gate,
     _build_hook_diagnostic_warning,
-    _find_recipe,
     _hook_config_path,
     _prime_quota_cache,
     _quota_refresh_loop,
@@ -218,7 +217,10 @@ def _close_kitchen_handler() -> None:
 @mcp.resource("recipe://{name}")
 def get_recipe(name: str) -> str:
     """Return recipe YAML for the orchestrating agent to follow."""
-    match = _find_recipe(name, Path.cwd())
+    from autoskillit.server._state import _get_ctx_or_none
+
+    ctx = _get_ctx_or_none()
+    match = ctx.recipes.find(name, Path.cwd()) if ctx and ctx.recipes else None
     if match is None:
         return json.dumps({"error": f"No recipe named '{name}'."})
     return match.path.read_text()

--- a/tests/arch/test_import_paths.py
+++ b/tests/arch/test_import_paths.py
@@ -14,6 +14,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.arch._helpers import _runtime_import_froms
+
 SRC = Path(__file__).parent.parent.parent / "src" / "autoskillit"
 PACKAGES = frozenset(
     [
@@ -338,3 +340,15 @@ def test_req_imp_007_server_cli_no_unauthorized_cross_submodule_imports() -> Non
                     if other_pkg in forbidden_pkgs and other_pkg != pkg:
                         violations.append(f"{rel} → {mod}")
     assert not violations, "REQ-IMP-007 violations:\n" + "\n".join(violations)
+
+
+def test_helpers_no_recipe_imports() -> None:
+    """server/helpers.py must have zero runtime imports from autoskillit.recipe."""
+    helpers_path = SRC / "server" / "helpers.py"
+    runtime_imports = _runtime_import_froms(helpers_path)
+    recipe_imports = [
+        node.module
+        for node in runtime_imports
+        if node.module and node.module.startswith("autoskillit.recipe")
+    ]
+    assert recipe_imports == [], f"Forbidden recipe imports in helpers.py: {recipe_imports}"

--- a/tests/contracts/test_protocol_satisfaction.py
+++ b/tests/contracts/test_protocol_satisfaction.py
@@ -175,6 +175,31 @@ def test_default_recipe_repository_satisfies_recipe_repository():
     assert isinstance(DefaultRecipeRepository(), RecipeRepository)
 
 
+def test_recipe_repository_has_apply_triage_gate():
+    """RecipeRepository protocol defines apply_triage_gate as an async method."""
+    import inspect
+
+    from autoskillit.core import RecipeRepository
+
+    method = getattr(RecipeRepository, "apply_triage_gate", None)
+    assert method is not None, "RecipeRepository must define apply_triage_gate"
+    assert inspect.iscoroutinefunction(method), "apply_triage_gate must be async"
+    sig = inspect.signature(method)
+    expected_params = ["self", "result", "recipe_name", "recipe_info", "temp_dir", "logger"]
+    assert list(sig.parameters.keys()) == expected_params
+
+
+def test_default_recipe_repository_has_apply_triage_gate():
+    """DefaultRecipeRepository implements apply_triage_gate from the protocol."""
+    import inspect
+
+    from autoskillit.recipe.repository import DefaultRecipeRepository
+
+    method = getattr(DefaultRecipeRepository, "apply_triage_gate", None)
+    assert method is not None
+    assert inspect.iscoroutinefunction(method)
+
+
 def test_default_migration_service_satisfies_migration_service():
     from autoskillit.core import MigrationService
     from autoskillit.migration.engine import DefaultMigrationService, MigrationEngine

--- a/tests/contracts/test_protocol_satisfaction.py
+++ b/tests/contracts/test_protocol_satisfaction.py
@@ -185,7 +185,15 @@ def test_recipe_repository_has_apply_triage_gate():
     assert method is not None, "RecipeRepository must define apply_triage_gate"
     assert inspect.iscoroutinefunction(method), "apply_triage_gate must be async"
     sig = inspect.signature(method)
-    expected_params = ["self", "result", "recipe_name", "recipe_info", "temp_dir", "logger"]
+    expected_params = [
+        "self",
+        "result",
+        "recipe_name",
+        "recipe_info",
+        "temp_dir",
+        "logger",
+        "triage_fn",
+    ]
     assert list(sig.parameters.keys()) == expected_params
 
 

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -126,8 +126,8 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _lifespan.py — hooks.json self-heal on startup drift (co-owned with Claude plugin system)
     ("src/autoskillit/server/_lifespan.py", 55),
     # tools_kitchen.py — hook config dict
-    ("src/autoskillit/server/tools_kitchen.py", 142),
-    ("src/autoskillit/server/tools_kitchen.py", 471),
+    ("src/autoskillit/server/tools_kitchen.py", 141),
+    ("src/autoskillit/server/tools_kitchen.py", 473),
     # tools_status.py — mcp_data dict
     ("src/autoskillit/server/tools_status.py", 385),
     # tools_github.py — bug report dict

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -5,6 +5,23 @@ from __future__ import annotations
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _reset_server_state(monkeypatch):
+    """Reset module-level _ctx in server._state after each test.
+
+    Tests that call _initialize() directly set _state._ctx to a mock without
+    cleanup. Subsequent tests in the same xdist worker then find a stale mock
+    _ctx, causing _apply_triage_gate to await a regular MagicMock and fail.
+
+    monkeypatch records the current value before yield and restores it after,
+    giving each test a clean slate regardless of what _initialize() sets.
+    """
+    if "autoskillit.server._state" in __import__("sys").modules:
+        from autoskillit.server import _state
+
+        monkeypatch.setattr(_state, "_ctx", _state._ctx)
+
+
 @pytest.fixture()
 def kitchen_enabled():
     """Enable the kitchen tag on the MCP server for the duration of the test."""


### PR DESCRIPTION
## Summary

Decouples `server/helpers.py` from the `recipe/` package by:

1. Extending `RecipeRepository` protocol with `apply_triage_gate()` method
2. Implementing in `DefaultRecipeRepository` with full triage logic
3. Reducing `_apply_triage_gate` in helpers.py to a delegation wrapper (zero recipe imports)
4. Removing `_find_recipe()` bridge function
5. Updating `tools_kitchen.py` to use `_ctx.recipes.find()` directly

### Tests Added
- `test_helpers_no_recipe_imports` — AST-verifiable zero recipe imports
- `test_recipe_repository_has_apply_triage_gate` — protocol contract
- `test_default_recipe_repository_satisfies_protocol` — implementation contract

### Additional Fixes
- Fixed xdist state contamination in server tests (autouse fixture for `_state._ctx` reset)
- Updated schema version convention test allowlist line numbers

Closes #926