### PR TITLE
feat: restructure tool_ctx fixture — add minimal_ctx (#927)

### DIFF
--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -13,14 +13,21 @@ All tests run under `-n 4 --dist worksteal`. Every test must be safe for paralle
 
 ## Fixture Discipline
 
-- The `tool_ctx` fixture (conftest.py) provides a fully isolated `ToolContext` with gate open
-  by default (`DefaultGateState(enabled=True)`). It monkeypatches `server._ctx` so all server
-  tool handler calls use the test context without global state leakage.
-- To test with the kitchen closed, set `tool_ctx.gate = DefaultGateState(enabled=False)` at
+- The `tool_ctx` fixture (conftest.py) provides a fully isolated `ToolContext` via
+  `make_context()` — a full-stack L3 fixture that imports all production layers. Use for
+  server integration tests that need executor, tester, recipes, or other service fields.
+  It monkeypatches `server._ctx` so all server tool handler calls use the test context
+  without global state leakage.
+- The `minimal_ctx` fixture (conftest.py) provides a lightweight `ToolContext` using only
+  L0+L1 imports (core, pipeline, config). Use for tests that only need gate, audit,
+  token_log, timing_log, or config — no server factory, no L2/L3 service wiring. Does NOT
+  monkeypatch `server._state._ctx`. Guard tests in `test_conftest.py` enforce the import
+  boundary via AST analysis.
+- To test with the kitchen closed, set `ctx.gate = DefaultGateState(enabled=False)` at
   the start of the test or in a class-level autouse fixture (see `_close_kitchen` in
   `test_instruction_surface.py` for an example).
 - Never use bare assignment or `try/finally` to restore server state — use `monkeypatch` or
-  rely on `tool_ctx`'s fixture teardown.
+  rely on the fixture's teardown.
 
 ## Placement Convention: tests/skills/ vs tests/contracts/
 
@@ -46,7 +53,7 @@ tests/
 ├── CLAUDE.md                            # xdist compatibility guidelines
 ├── __init__.py
 ├── _helpers.py
-├── conftest.py                          # Shared fixtures: MockSubprocessRunner, _make_result, _make_timeout_result
+├── conftest.py                          # Shared fixtures: minimal_ctx, tool_ctx, MockSubprocessRunner, _make_result, _make_timeout_result
 ├── test_conftest.py                     # Tests for conftest fixtures
 ├── test_phase2_skills.py
 ├── test_skill_preambles.py

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -236,8 +236,44 @@ def anyio_backend():
 
 
 @pytest.fixture
+def minimal_ctx(tmp_path):
+    """Lightweight ToolContext using only L0+L1 imports (core, pipeline, config).
+
+    Use for tests that only need gate, audit, token_log, timing_log, or config —
+    no server factory, no L2/L3 service wiring. Importing this fixture does NOT
+    pull in autoskillit.server, autoskillit.execution, autoskillit.recipe,
+    autoskillit.migration, or autoskillit.workspace.
+
+    Tests that need full service wiring (executor, tester, recipes, etc.) should
+    use tool_ctx instead.
+    """
+    from autoskillit.config import AutomationConfig
+    from autoskillit.pipeline.audit import DefaultAuditLog
+    from autoskillit.pipeline.context import ToolContext
+    from autoskillit.pipeline.gate import DefaultGateState
+    from autoskillit.pipeline.timings import DefaultTimingLog
+    from autoskillit.pipeline.tokens import DefaultTokenLog
+
+    ctx = ToolContext(
+        config=AutomationConfig(),
+        audit=DefaultAuditLog(),
+        token_log=DefaultTokenLog(),
+        timing_log=DefaultTimingLog(),
+        gate=DefaultGateState(enabled=True),
+        plugin_dir=None,
+        runner=None,
+        temp_dir=tmp_path / ".autoskillit" / "temp",
+    )
+    return ctx
+
+
+@pytest.fixture
 def tool_ctx(monkeypatch, tmp_path):
-    """Provide a fully isolated ToolContext for server tests.
+    """Provide a fully isolated ToolContext for server integration tests.
+
+    Full-stack fixture: calls make_context() from server/_factory.py, which
+    imports ALL production layers (L0–L3). Use minimal_ctx instead when the
+    test only needs gate, audit, token_log, timing_log, or config fields.
 
     Monkeypatches server._ctx so all server tool calls use this context.
     Gate is enabled (open kitchen) by default — tests that need a closed

--- a/tests/contracts/test_instruction_surface.py
+++ b/tests/contracts/test_instruction_surface.py
@@ -63,10 +63,10 @@ class TestServerToolSurfaceContract:
     """Server tool docstrings and prompts must name all forbidden tools."""
 
     @pytest.fixture(autouse=True)
-    def _close_kitchen(self, tool_ctx, monkeypatch):
+    def _close_kitchen(self, minimal_ctx, monkeypatch):
         from autoskillit.pipeline.gate import DefaultGateState
 
-        monkeypatch.setattr(tool_ctx, "gate", DefaultGateState(enabled=False))
+        monkeypatch.setattr(minimal_ctx, "gate", DefaultGateState(enabled=False))
 
     @pytest.mark.anyio
     async def test_open_kitchen_prompt_names_all_forbidden_tools(self):

--- a/tests/contracts/test_instruction_surface.py
+++ b/tests/contracts/test_instruction_surface.py
@@ -65,8 +65,10 @@ class TestServerToolSurfaceContract:
     @pytest.fixture(autouse=True)
     def _close_kitchen(self, minimal_ctx, monkeypatch):
         from autoskillit.pipeline.gate import DefaultGateState
+        from autoskillit.server import _state
 
         monkeypatch.setattr(minimal_ctx, "gate", DefaultGateState(enabled=False))
+        monkeypatch.setattr(_state, "_ctx", minimal_ctx)
 
     @pytest.mark.anyio
     async def test_open_kitchen_prompt_names_all_forbidden_tools(self):

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -133,3 +133,70 @@ def test_tool_ctx_log_dir_is_isolated_from_production(tool_ctx):
     xdg = os.environ.get("XDG_DATA_HOME") or os.path.expanduser("~/.local/share")
     production_path = os.path.join(xdg, "autoskillit", "logs")
     assert not os.path.abspath(log_dir).startswith(production_path)
+
+
+def test_minimal_ctx_imports_only_core_pipeline_and_config():
+    """minimal_ctx fixture must only import from autoskillit.core, .pipeline, and .config."""
+    import ast
+    from pathlib import Path
+
+    conftest_path = Path(__file__).parent / "conftest.py"
+    tree = ast.parse(conftest_path.read_text(), filename=str(conftest_path))
+
+    func = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "minimal_ctx":
+            func = node
+            break
+    assert func is not None, "minimal_ctx fixture not found in conftest.py"
+
+    ALLOWED_PREFIXES = ("autoskillit.core", "autoskillit.pipeline", "autoskillit.config")
+
+    violations = []
+    for node in ast.walk(func):
+        if (
+            isinstance(node, ast.ImportFrom)
+            and node.module
+            and node.module.startswith("autoskillit.")
+        ):
+            if not any(node.module.startswith(p) for p in ALLOWED_PREFIXES):
+                violations.append(node.module)
+
+    assert not violations, (
+        f"minimal_ctx imports from forbidden modules: {violations}. "
+        f"Only autoskillit.core, autoskillit.pipeline, and autoskillit.config are allowed."
+    )
+
+
+def test_minimal_ctx_has_no_server_factory_dependency():
+    """minimal_ctx must not import from autoskillit.server or reference make_context."""
+    import ast
+    from pathlib import Path
+
+    conftest_path = Path(__file__).parent / "conftest.py"
+    tree = ast.parse(conftest_path.read_text(), filename=str(conftest_path))
+
+    func = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "minimal_ctx":
+            func = node
+            break
+    assert func is not None, "minimal_ctx fixture not found in conftest.py"
+
+    for node in ast.walk(func):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert not node.module.startswith("autoskillit.server"), (
+                f"minimal_ctx imports from server module: {node.module}"
+            )
+            names = [alias.name for alias in node.names]
+            assert "make_context" not in names, (
+                "minimal_ctx imports make_context — use direct ToolContext construction"
+            )
+
+
+def test_minimal_ctx_provides_isolated_gate(minimal_ctx):
+    """minimal_ctx fixture provides a ToolContext with gate enabled."""
+    from autoskillit.pipeline.gate import DefaultGateState
+
+    assert isinstance(minimal_ctx.gate, DefaultGateState)
+    assert minimal_ctx.gate.enabled is True


### PR DESCRIPTION
## Summary

Adds a lightweight `minimal_ctx` fixture to root `tests/conftest.py` that creates a `ToolContext` using only L0+L1 imports (no server factory dependency). Migrates `test_instruction_surface.py` from `tool_ctx` to `minimal_ctx`.

### Changes
- Added `minimal_ctx` fixture in `tests/conftest.py`
- Migrated `test_instruction_surface.py` from `tool_ctx` to `minimal_ctx`
- Updated `tests/CLAUDE.md` with fixture documentation
- Added guard tests: AST import boundary, server factory dependency, functional gate verification

Closes #927