### PR TITLE
fix: decouple _clear_headless_env from server module (#928)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 """Shared test fixtures for autoskillit."""
 
-import sys
 from pathlib import Path as _Path
 
 import pytest
@@ -213,15 +212,9 @@ def _clear_headless_env(monkeypatch):
     """Ensure AUTOSKILLIT_HEADLESS is unset at the start of every test.
 
     Tools check this env var to block calls from headless sessions.
-    Also resets mcp kitchen visibility transforms when the server module is
-    already imported.
+    MCP tag resets are handled by tests/server/conftest.py for server tests.
     """
-
     monkeypatch.delenv("AUTOSKILLIT_HEADLESS", raising=False)
-    if "autoskillit.server" in sys.modules:
-        from autoskillit.server import mcp
-
-        mcp.disable(tags={"kitchen"})
 
 
 @pytest.fixture(autouse=True)

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -22,6 +22,20 @@ def _reset_server_state(monkeypatch):
         monkeypatch.setattr(_state, "_ctx", _state._ctx)
 
 
+@pytest.fixture(autouse=True)
+def _reset_mcp_tags():
+    """Reset MCP tag visibility to default (kitchen + headless disabled) before each test.
+
+    The mcp singleton is process-global. Tests that call mcp.enable(tags={"kitchen"})
+    or mcp.enable(tags={"headless"}) mutate shared state. This fixture ensures every
+    server test starts with both tags disabled — the same state as a fresh server import.
+    """
+    from autoskillit.server import mcp
+
+    mcp.disable(tags={"kitchen"})
+    mcp.disable(tags={"headless"})
+
+
 @pytest.fixture()
 def kitchen_enabled():
     """Enable the kitchen tag on the MCP server for the duration of the test."""

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -194,6 +194,29 @@ def test_minimal_ctx_has_no_server_factory_dependency():
             )
 
 
+def test_clear_headless_env_no_server_import():
+    """_clear_headless_env must not import from autoskillit.server."""
+    import ast
+    from pathlib import Path
+
+    conftest_path = Path(__file__).parent / "conftest.py"
+    tree = ast.parse(conftest_path.read_text(), filename=str(conftest_path))
+
+    func = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "_clear_headless_env":
+            func = node
+            break
+    assert func is not None, "_clear_headless_env fixture not found in conftest.py"
+
+    for node in ast.walk(func):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert not node.module.startswith("autoskillit.server"), (
+                f"_clear_headless_env imports from server module: {node.module}. "
+                f"MCP tag resets belong in tests/server/conftest.py."
+            )
+
+
 def test_minimal_ctx_provides_isolated_gate(minimal_ctx):
     """minimal_ctx fixture provides a ToolContext with gate enabled."""
     from autoskillit.pipeline.gate import DefaultGateState


### PR DESCRIPTION
## Summary

Fixes autouse fixture pollution where `_clear_headless_env` conditionally imported `autoskillit.server`, contaminating all xdist worker processes.

### Changes
- Simplified root `_clear_headless_env` to only clear env var (no server import)
- Added `_reset_mcp_tags` autouse fixture in `tests/server/conftest.py` for MCP tag reset
- Added AST guard test `test_clear_headless_env_no_server_import`

Closes #928