### PR TITLE
AST Import Walker Module

### DIFF
--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -6,6 +6,7 @@ import ast
 import enum
 import fnmatch
 import subprocess
+import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -228,8 +229,10 @@ class ASTImportWalker(ast.NodeVisitor):
             for child in node.body:
                 self.visit(child)
             self._context_stack.pop()
+            self._context_stack.append(ImportContext.CONDITIONAL)
             for child in node.orelse:
                 self.visit(child)
+            self._context_stack.pop()
         else:
             self._context_stack.append(ImportContext.CONDITIONAL)
             self.generic_visit(node)
@@ -292,7 +295,14 @@ def git_changed_files(
             timeout=10,
             check=True,
         )
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
+    except subprocess.CalledProcessError as exc:
+        warnings.warn(f"git diff failed (exit {exc.returncode}): {exc.stderr or ''}", stacklevel=2)
+        return None
+    except subprocess.TimeoutExpired:
+        warnings.warn("git diff timed out after 10s", stacklevel=2)
+        return None
+    except FileNotFoundError:
+        warnings.warn("git binary not found on PATH", stacklevel=2)
         return None
 
     lines = result.stdout.strip().splitlines()
@@ -317,8 +327,15 @@ def load_manifest(path: str | Path) -> dict[str, Any] | None:
     manifest_path = Path(path) / ".autoskillit" / "test-filter-manifest.yaml"
     if not manifest_path.exists():
         return None
-    with manifest_path.open() as f:
-        return yaml.safe_load(f)
+    try:
+        with manifest_path.open() as f:
+            return yaml.safe_load(f)
+    except OSError as exc:
+        warnings.warn(f"Cannot read manifest {manifest_path}: {exc}", stacklevel=2)
+        return None
+    except yaml.YAMLError as exc:
+        warnings.warn(f"Malformed YAML in {manifest_path}: {exc}", stacklevel=2)
+        return None
 
 
 def apply_manifest(
@@ -374,13 +391,16 @@ def _expand_reexport_closure(
                     walker = ASTImportWalker()
                     walker.visit(tree)
                     for mod, _ctx in walker.imports:
-                        bare = mod.lstrip(".")
-                        if bare == module_name or bare.endswith(f".{module_name}"):
+                        bare = mod.split(".")[-1] if "." in mod else mod.lstrip(".")
+                        if bare == module_name:
                             rel_init = str(init_path.relative_to(src_root))
                             expanded.add(rel_init)
                             break
-                except SyntaxError:
-                    pass
+                except SyntaxError as exc:
+                    warnings.warn(
+                        f"Failed to parse {init_path}: {exc}",
+                        stacklevel=2,
+                    )
             parent = parent.parent
 
     return expanded
@@ -417,7 +437,6 @@ def build_test_scope(
     mode: FilterMode,
     manifest: dict[str, Any] | None = None,
     tests_root: str | Path = "tests",
-    src_root: str | Path = "src/autoskillit",
 ) -> set[Path] | None:
     """Compute the set of test paths to run, or None for a full run.
 

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -1,0 +1,416 @@
+"""Standalone test-path filtering logic. No pytest dependencies."""
+from __future__ import annotations
+
+import ast
+import enum
+import fnmatch
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+class FilterMode(enum.StrEnum):
+    NONE = "none"
+    CONSERVATIVE = "conservative"
+    AGGRESSIVE = "aggressive"
+
+
+class ImportContext(enum.StrEnum):
+    TOP_LEVEL = "top_level"
+    CONDITIONAL = "conditional"
+    TYPE_CHECKING = "type_checking"
+    DEFERRED = "deferred"
+    IMPORTLIB = "importlib"
+
+
+BUCKET_A_PATTERNS: frozenset[str] = frozenset({
+    "tests/conftest.py",
+    "tests/_helpers.py",
+    "tests/arch/_helpers.py",
+    "tests/arch/_rules.py",
+    "pyproject.toml",
+    "uv.lock",
+    ".pre-commit-config.yaml",
+    "src/autoskillit/server/_factory.py",
+})
+
+BUCKET_A_GLOBS: tuple[str, ...] = ("tests/*/conftest.py",)
+
+ALWAYS_RUN_CONSERVATIVE: frozenset[str] = frozenset({
+    "arch", "contracts", "infra", "docs",
+})
+
+ALWAYS_RUN_AGGRESSIVE: frozenset[str] = frozenset({
+    "arch", "contracts",
+})
+
+_LARGE_CHANGESET_THRESHOLD: int = 30
+
+# ---------------------------------------------------------------------------
+# Layer cascade maps
+# ---------------------------------------------------------------------------
+
+LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
+    # L0 — imported by everything
+    "core": frozenset({
+        "core", "config", "execution", "pipeline", "workspace",
+        "recipe", "migration", "server", "cli",
+        "hooks", "skills",
+    }),
+    # L1
+    "config": frozenset({
+        "config", "pipeline", "workspace", "server", "cli",
+    }),
+    "execution": frozenset({
+        "execution", "core", "workspace", "migration",
+        "server", "cli", "infra", "skills",
+    }),
+    "pipeline": frozenset({
+        "pipeline", "execution", "server", "infra",
+    }),
+    "workspace": frozenset({
+        "workspace", "recipe", "server", "cli", "skills",
+    }),
+    # L2
+    "recipe": frozenset({
+        "recipe", "execution", "server", "cli", "infra", "skills",
+    }),
+    "migration": frozenset({
+        "migration", "server",
+    }),
+    # L3
+    "server": frozenset({
+        "server", "cli", "infra",
+    }),
+    "cli": frozenset({
+        "cli",
+    }),
+    # Infra (non-layered)
+    "hooks": frozenset({
+        "hooks", "infra", "cli",
+    }),
+    "hook_registry": frozenset({
+        "server", "infra", "cli", "docs",
+    }),
+}
+
+LAYER_CASCADE_AGGRESSIVE: dict[str, frozenset[str]] = {
+    "core": frozenset({"core"}),
+    "config": frozenset({"config"}),
+    "execution": frozenset({"execution"}),
+    "pipeline": frozenset({"pipeline"}),
+    "workspace": frozenset({"workspace"}),
+    "recipe": frozenset({"recipe"}),
+    "migration": frozenset({"migration"}),
+    "server": frozenset({"server"}),
+    "cli": frozenset({"cli"}),
+    "hooks": frozenset({"hooks"}),
+    "hook_registry": frozenset({"hooks"}),
+}
+
+# ---------------------------------------------------------------------------
+# ASTImportWalker
+# ---------------------------------------------------------------------------
+
+
+class ASTImportWalker(ast.NodeVisitor):
+    """Extract all import statements from a Python source file with context tracking."""
+
+    def __init__(self) -> None:
+        self.imports: list[tuple[str, ImportContext]] = []
+        self._context_stack: list[ImportContext] = []
+
+    @property
+    def _current_context(self) -> ImportContext:
+        return self._context_stack[-1] if self._context_stack else ImportContext.TOP_LEVEL
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            self.imports.append((alias.name, self._current_context))
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        if node.module:
+            module = ("." * (node.level or 0)) + node.module
+        else:
+            module = "." * (node.level or 0)
+        self.imports.append((module, self._current_context))
+        self.generic_visit(node)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._context_stack.append(ImportContext.DEFERRED)
+        self.generic_visit(node)
+        self._context_stack.pop()
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._context_stack.append(ImportContext.DEFERRED)
+        self.generic_visit(node)
+        self._context_stack.pop()
+
+    def visit_If(self, node: ast.If) -> None:
+        if self._is_type_checking_guard(node.test):
+            self._context_stack.append(ImportContext.TYPE_CHECKING)
+            for child in node.body:
+                self.visit(child)
+            self._context_stack.pop()
+            for child in node.orelse:
+                self.visit(child)
+        else:
+            self._context_stack.append(ImportContext.CONDITIONAL)
+            self.generic_visit(node)
+            self._context_stack.pop()
+
+    def visit_Try(self, node: ast.Try) -> None:
+        self._context_stack.append(ImportContext.CONDITIONAL)
+        self.generic_visit(node)
+        self._context_stack.pop()
+
+    def visit_Call(self, node: ast.Call) -> None:
+        if self._is_importlib_call(node) and node.args:
+            arg = node.args[0]
+            if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                self.imports.append((arg.value, ImportContext.IMPORTLIB))
+        self.generic_visit(node)
+
+    @staticmethod
+    def _is_type_checking_guard(test: ast.expr) -> bool:
+        if isinstance(test, ast.Name) and test.id == "TYPE_CHECKING":
+            return True
+        if isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING":
+            return True
+        return False
+
+    @staticmethod
+    def _is_importlib_call(node: ast.Call) -> bool:
+        func = node.func
+        if isinstance(func, ast.Attribute) and func.attr == "import_module":
+            return True
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Utility functions
+# ---------------------------------------------------------------------------
+
+
+def git_changed_files(
+    cwd: str | Path,
+    base_ref: str | None = None,
+) -> set[str] | None:
+    """Return set of changed files relative to base_ref, or None on failure."""
+    import os
+
+    if base_ref is None:
+        base_ref = os.environ.get(
+            "AUTOSKILLIT_TEST_BASE_REF",
+            os.environ.get("GITHUB_BASE_REF"),
+        )
+    if base_ref is None:
+        return None
+
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--name-only", f"{base_ref}...HEAD"],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+
+    lines = result.stdout.strip().splitlines()
+    return {line.strip() for line in lines if line.strip()}
+
+
+def check_bucket_a(changed_files: set[str]) -> bool:
+    """Return True if any changed file triggers a full test run."""
+    for f in changed_files:
+        if f in BUCKET_A_PATTERNS:
+            return True
+        for glob_pat in BUCKET_A_GLOBS:
+            if fnmatch.fnmatch(f, glob_pat):
+                return True
+    return False
+
+
+def load_manifest(path: str | Path) -> dict[str, Any] | None:
+    """Load .autoskillit/test-filter-manifest.yaml, or None if absent."""
+    import yaml
+
+    manifest_path = Path(path) / ".autoskillit" / "test-filter-manifest.yaml"
+    if not manifest_path.exists():
+        return None
+    with manifest_path.open() as f:
+        return yaml.safe_load(f)
+
+
+def apply_manifest(
+    changed_files: set[str],
+    manifest: dict[str, Any] | None,
+) -> set[str]:
+    """Return test directories matched by manifest patterns for the changed files."""
+    if manifest is None:
+        return set()
+    result: set[str] = set()
+    patterns = manifest.get("patterns", {})
+    for pattern, test_dirs in patterns.items():
+        for f in changed_files:
+            if fnmatch.fnmatch(f, pattern):
+                if isinstance(test_dirs, list):
+                    result.update(test_dirs)
+                elif isinstance(test_dirs, str):
+                    result.add(test_dirs)
+                break
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Re-export closure
+# ---------------------------------------------------------------------------
+
+
+def _expand_reexport_closure(
+    changed_src_files: set[str],
+    src_root: str | Path,
+) -> set[str]:
+    """Expand changed files to include __init__.py files that directly re-export from them.
+
+    Walks up parent directories checking each __init__.py via AST parsing.
+    Only handles direct re-exports (from .module import X); transitive
+    chains through intermediate hubs are covered by cascade maps.
+    """
+    src_root = Path(src_root)
+    expanded = set(changed_src_files)
+
+    for changed in list(changed_src_files):
+        changed_path = src_root / changed
+        if not changed_path.exists():
+            continue
+        module_name = changed_path.stem
+        parent = changed_path.parent
+        while parent >= src_root:
+            init_path = parent / "__init__.py"
+            if init_path.exists():
+                try:
+                    source = init_path.read_text(errors="replace")
+                    tree = ast.parse(source, filename=str(init_path))
+                    walker = ASTImportWalker()
+                    walker.visit(tree)
+                    for mod, _ctx in walker.imports:
+                        bare = mod.lstrip(".")
+                        if bare == module_name or bare.endswith(f".{module_name}"):
+                            rel_init = str(init_path.relative_to(src_root))
+                            expanded.add(rel_init)
+                            break
+                except SyntaxError:
+                    pass
+            parent = parent.parent
+
+    return expanded
+
+
+# ---------------------------------------------------------------------------
+# build_test_scope
+# ---------------------------------------------------------------------------
+
+
+def _file_to_package(filepath: str) -> str | None:
+    """Extract the autoskillit subpackage name from a source file path.
+
+    e.g. 'src/autoskillit/core/io.py' -> 'core'
+         'src/autoskillit/execution/headless.py' -> 'execution'
+         'src/autoskillit/server/_factory.py' -> 'server'
+         'src/autoskillit/hook_registry.py' -> 'hook_registry'
+    """
+    parts = Path(filepath).parts
+    try:
+        idx = parts.index("autoskillit")
+        if idx + 1 < len(parts):
+            candidate = parts[idx + 1]
+            if candidate.endswith(".py"):
+                return candidate.removesuffix(".py")
+            return candidate
+    except ValueError:
+        pass
+    return None
+
+
+def build_test_scope(
+    changed_files: set[str] | None,
+    mode: FilterMode,
+    manifest: dict[str, Any] | None = None,
+    tests_root: str | Path = "tests",
+    src_root: str | Path = "src/autoskillit",
+) -> set[Path] | None:
+    """Compute the set of test paths to run, or None for a full run.
+
+    Algorithm:
+    1. None changed_files -> None (fail-open)
+    2. >30 files -> None (large changeset)
+    3. Bucket A triggered -> None (full run)
+    4. Classify: src Python -> cascade, test Python -> direct, non-Python -> manifest
+    5. Compute always-run set for mode (includes arch/contracts for both modes)
+    6. Union all sets
+    7. For aggressive mode -> AST-based file-level refinement (future)
+    8. Resolve to concrete paths
+    """
+    if mode == FilterMode.NONE:
+        return None
+
+    if changed_files is None:
+        return None
+
+    if len(changed_files) > _LARGE_CHANGESET_THRESHOLD:
+        return None
+
+    if check_bucket_a(changed_files):
+        return None
+
+    tests_root = Path(tests_root)
+
+    cascade_map = (
+        LAYER_CASCADE_CONSERVATIVE
+        if mode == FilterMode.CONSERVATIVE
+        else LAYER_CASCADE_AGGRESSIVE
+    )
+    always_run = (
+        ALWAYS_RUN_CONSERVATIVE
+        if mode == FilterMode.CONSERVATIVE
+        else ALWAYS_RUN_AGGRESSIVE
+    )
+
+    test_dirs: set[str] = set()
+    direct_test_files: set[str] = set()
+    for f in changed_files:
+        if f.startswith("tests/") and f.endswith(".py"):
+            direct_test_files.add(f)
+        elif f.startswith("src/") and f.endswith(".py"):
+            pkg = _file_to_package(f)
+            if pkg and pkg in cascade_map:
+                test_dirs.update(cascade_map[pkg])
+            else:
+                return None
+        elif f.endswith(".py"):
+            return None
+        else:
+            manifest_dirs = apply_manifest({f}, manifest)
+            if manifest_dirs:
+                test_dirs.update(manifest_dirs)
+
+    test_dirs.update(always_run)
+
+    result: set[Path] = set()
+    for d in test_dirs:
+        dir_path = tests_root / d
+        if dir_path.is_dir():
+            result.add(dir_path)
+
+    for f in direct_test_files:
+        result.add(Path(f))
+
+    return result

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -1,4 +1,5 @@
 """Standalone test-path filtering logic. No pytest dependencies."""
+
 from __future__ import annotations
 
 import ast
@@ -26,26 +27,36 @@ class ImportContext(enum.StrEnum):
     IMPORTLIB = "importlib"
 
 
-BUCKET_A_PATTERNS: frozenset[str] = frozenset({
-    "tests/conftest.py",
-    "tests/_helpers.py",
-    "tests/arch/_helpers.py",
-    "tests/arch/_rules.py",
-    "pyproject.toml",
-    "uv.lock",
-    ".pre-commit-config.yaml",
-    "src/autoskillit/server/_factory.py",
-})
+BUCKET_A_PATTERNS: frozenset[str] = frozenset(
+    {
+        "tests/conftest.py",
+        "tests/_helpers.py",
+        "tests/arch/_helpers.py",
+        "tests/arch/_rules.py",
+        "pyproject.toml",
+        "uv.lock",
+        ".pre-commit-config.yaml",
+        "src/autoskillit/server/_factory.py",
+    }
+)
 
 BUCKET_A_GLOBS: tuple[str, ...] = ("tests/*/conftest.py",)
 
-ALWAYS_RUN_CONSERVATIVE: frozenset[str] = frozenset({
-    "arch", "contracts", "infra", "docs",
-})
+ALWAYS_RUN_CONSERVATIVE: frozenset[str] = frozenset(
+    {
+        "arch",
+        "contracts",
+        "infra",
+        "docs",
+    }
+)
 
-ALWAYS_RUN_AGGRESSIVE: frozenset[str] = frozenset({
-    "arch", "contracts",
-})
+ALWAYS_RUN_AGGRESSIVE: frozenset[str] = frozenset(
+    {
+        "arch",
+        "contracts",
+    }
+)
 
 _LARGE_CHANGESET_THRESHOLD: int = 30
 
@@ -55,46 +66,107 @@ _LARGE_CHANGESET_THRESHOLD: int = 30
 
 LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
     # L0 — imported by everything
-    "core": frozenset({
-        "core", "config", "execution", "pipeline", "workspace",
-        "recipe", "migration", "server", "cli",
-        "hooks", "skills",
-    }),
+    "core": frozenset(
+        {
+            "core",
+            "config",
+            "execution",
+            "pipeline",
+            "workspace",
+            "recipe",
+            "migration",
+            "server",
+            "cli",
+            "hooks",
+            "skills",
+        }
+    ),
     # L1
-    "config": frozenset({
-        "config", "pipeline", "workspace", "server", "cli",
-    }),
-    "execution": frozenset({
-        "execution", "core", "workspace", "migration",
-        "server", "cli", "infra", "skills",
-    }),
-    "pipeline": frozenset({
-        "pipeline", "execution", "server", "infra",
-    }),
-    "workspace": frozenset({
-        "workspace", "recipe", "server", "cli", "skills",
-    }),
+    "config": frozenset(
+        {
+            "config",
+            "pipeline",
+            "workspace",
+            "server",
+            "cli",
+        }
+    ),
+    "execution": frozenset(
+        {
+            "execution",
+            "core",
+            "workspace",
+            "migration",
+            "server",
+            "cli",
+            "infra",
+            "skills",
+        }
+    ),
+    "pipeline": frozenset(
+        {
+            "pipeline",
+            "execution",
+            "server",
+            "infra",
+        }
+    ),
+    "workspace": frozenset(
+        {
+            "workspace",
+            "recipe",
+            "server",
+            "cli",
+            "skills",
+        }
+    ),
     # L2
-    "recipe": frozenset({
-        "recipe", "execution", "server", "cli", "infra", "skills",
-    }),
-    "migration": frozenset({
-        "migration", "server",
-    }),
+    "recipe": frozenset(
+        {
+            "recipe",
+            "execution",
+            "server",
+            "cli",
+            "infra",
+            "skills",
+        }
+    ),
+    "migration": frozenset(
+        {
+            "migration",
+            "server",
+        }
+    ),
     # L3
-    "server": frozenset({
-        "server", "cli", "infra",
-    }),
-    "cli": frozenset({
-        "cli",
-    }),
+    "server": frozenset(
+        {
+            "server",
+            "cli",
+            "infra",
+        }
+    ),
+    "cli": frozenset(
+        {
+            "cli",
+        }
+    ),
     # Infra (non-layered)
-    "hooks": frozenset({
-        "hooks", "infra", "cli",
-    }),
-    "hook_registry": frozenset({
-        "server", "infra", "cli", "docs",
-    }),
+    "hooks": frozenset(
+        {
+            "hooks",
+            "infra",
+            "cli",
+        }
+    ),
+    "hook_registry": frozenset(
+        {
+            "hooks",
+            "server",
+            "infra",
+            "cli",
+            "docs",
+        }
+    ),
 }
 
 LAYER_CASCADE_AGGRESSIVE: dict[str, frozenset[str]] = {
@@ -374,14 +446,10 @@ def build_test_scope(
     tests_root = Path(tests_root)
 
     cascade_map = (
-        LAYER_CASCADE_CONSERVATIVE
-        if mode == FilterMode.CONSERVATIVE
-        else LAYER_CASCADE_AGGRESSIVE
+        LAYER_CASCADE_CONSERVATIVE if mode == FilterMode.CONSERVATIVE else LAYER_CASCADE_AGGRESSIVE
     )
     always_run = (
-        ALWAYS_RUN_CONSERVATIVE
-        if mode == FilterMode.CONSERVATIVE
-        else ALWAYS_RUN_AGGRESSIVE
+        ALWAYS_RUN_CONSERVATIVE if mode == FilterMode.CONSERVATIVE else ALWAYS_RUN_AGGRESSIVE
     )
 
     test_dirs: set[str] = set()

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -39,19 +39,41 @@ def _docs_containing(pattern: str) -> list[Path]:
 # ----- canonical source-of-truth getters --------------------------------------
 
 
+def _extract_tool_decorators(text: str) -> list[str]:
+    """Extract full @mcp.tool(...) decorator text, handling multi-line decorators."""
+    decorators: list[str] = []
+    lines = text.splitlines()
+    i = 0
+    while i < len(lines):
+        stripped = lines[i].strip()
+        if stripped.startswith("@mcp.tool"):
+            # Collect the full decorator (may span multiple lines)
+            parts = [stripped]
+            if ")" not in stripped:
+                i += 1
+                while i < len(lines):
+                    part = lines[i].strip()
+                    parts.append(part)
+                    if ")" in part:
+                        break
+                    i += 1
+            decorators.append(" ".join(parts))
+        i += 1
+    return decorators
+
+
 def _count_mcp_tools() -> int:
     total = 0
     for f in (SRC_DIR / "server").glob("tools_*.py"):
-        total += sum(1 for line in _read(f).splitlines() if line.strip().startswith("@mcp.tool"))
+        total += len(_extract_tool_decorators(_read(f)))
     return total
 
 
 def _count_kitchen_tools() -> int:
     total = 0
     for f in (SRC_DIR / "server").glob("tools_*.py"):
-        text = _read(f)
-        for line in text.splitlines():
-            if line.strip().startswith("@mcp.tool") and '"kitchen"' in line:
+        for dec in _extract_tool_decorators(_read(f)):
+            if '"kitchen"' in dec:
                 total += 1
     return total
 
@@ -59,9 +81,8 @@ def _count_kitchen_tools() -> int:
 def _count_free_range_tools() -> int:
     total = 0
     for f in (SRC_DIR / "server").glob("tools_*.py"):
-        for line in _read(f).splitlines():
-            stripped = line.strip()
-            if stripped.startswith("@mcp.tool") and '"kitchen"' not in stripped:
+        for dec in _extract_tool_decorators(_read(f)):
+            if '"kitchen"' not in dec:
                 total += 1
     return total
 
@@ -69,8 +90,8 @@ def _count_free_range_tools() -> int:
 def _count_headless_tools() -> int:
     total = 0
     for f in (SRC_DIR / "server").glob("tools_*.py"):
-        for line in _read(f).splitlines():
-            if line.strip().startswith("@mcp.tool") and '"headless"' in line:
+        for dec in _extract_tool_decorators(_read(f)):
+            if '"headless"' in dec:
                 total += 1
     return total
 

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -127,7 +127,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/server/_lifespan.py", 55),
     # tools_kitchen.py — hook config dict
     ("src/autoskillit/server/tools_kitchen.py", 141),
-    ("src/autoskillit/server/tools_kitchen.py", 473),
+    ("src/autoskillit/server/tools_kitchen.py", 477),
     # tools_status.py — mcp_data dict
     ("src/autoskillit/server/tools_status.py", 385),
     # tools_github.py — bug report dict

--- a/tests/test_test_filter.py
+++ b/tests/test_test_filter.py
@@ -1,0 +1,407 @@
+"""Tests for tests/_test_filter.py — standalone test-path filtering logic."""
+from __future__ import annotations
+
+import ast
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests._test_filter import (
+    ALWAYS_RUN_AGGRESSIVE,
+    ALWAYS_RUN_CONSERVATIVE,
+    ASTImportWalker,
+    FilterMode,
+    ImportContext,
+    LAYER_CASCADE_AGGRESSIVE,
+    LAYER_CASCADE_CONSERVATIVE,
+    _expand_reexport_closure,
+    apply_manifest,
+    build_test_scope,
+    check_bucket_a,
+    git_changed_files,
+)
+
+
+# ---------------------------------------------------------------------------
+# Walker Tests (W1–W8)
+# ---------------------------------------------------------------------------
+
+
+class TestASTImportWalker:
+    def test_walker_top_level_import(self) -> None:
+        tree = ast.parse("import os")
+        walker = ASTImportWalker()
+        walker.visit(tree)
+        assert ("os", ImportContext.TOP_LEVEL) in walker.imports
+
+    def test_walker_top_level_from_import(self) -> None:
+        tree = ast.parse("from pathlib import Path")
+        walker = ASTImportWalker()
+        walker.visit(tree)
+        assert ("pathlib", ImportContext.TOP_LEVEL) in walker.imports
+
+    def test_walker_relative_from_import(self) -> None:
+        tree = ast.parse("from .sub import X")
+        walker = ASTImportWalker()
+        walker.visit(tree)
+        assert (".sub", ImportContext.TOP_LEVEL) in walker.imports
+
+    def test_walker_conditional_import(self) -> None:
+        source = "import sys\nif sys.platform == 'linux':\n    import foo"
+        tree = ast.parse(source)
+        walker = ASTImportWalker()
+        walker.visit(tree)
+        assert ("foo", ImportContext.CONDITIONAL) in walker.imports
+
+    def test_walker_type_checking_guard(self) -> None:
+        source = "from typing import TYPE_CHECKING\nif TYPE_CHECKING:\n    from foo import Bar"
+        tree = ast.parse(source)
+        walker = ASTImportWalker()
+        walker.visit(tree)
+        assert ("foo", ImportContext.TYPE_CHECKING) in walker.imports
+
+    def test_walker_type_checking_attribute(self) -> None:
+        source = "import typing\nif typing.TYPE_CHECKING:\n    from bar import Baz"
+        tree = ast.parse(source)
+        walker = ASTImportWalker()
+        walker.visit(tree)
+        assert ("bar", ImportContext.TYPE_CHECKING) in walker.imports
+
+    def test_walker_deferred_import(self) -> None:
+        source = "def f():\n    import foo"
+        tree = ast.parse(source)
+        walker = ASTImportWalker()
+        walker.visit(tree)
+        assert ("foo", ImportContext.DEFERRED) in walker.imports
+
+    def test_walker_importlib_literal(self) -> None:
+        source = 'import importlib\nimportlib.import_module("foo")'
+        tree = ast.parse(source)
+        walker = ASTImportWalker()
+        walker.visit(tree)
+        assert ("foo", ImportContext.IMPORTLIB) in walker.imports
+
+
+# ---------------------------------------------------------------------------
+# Bucket A Tests (B1–B9)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckBucketA:
+    def test_bucket_a_conftest(self) -> None:
+        assert check_bucket_a({"tests/conftest.py"}) is True
+
+    def test_bucket_a_helpers(self) -> None:
+        assert check_bucket_a({"tests/_helpers.py"}) is True
+
+    def test_bucket_a_arch_helpers(self) -> None:
+        assert check_bucket_a({"tests/arch/_helpers.py"}) is True
+        assert check_bucket_a({"tests/arch/_rules.py"}) is True
+
+    def test_bucket_a_pyproject(self) -> None:
+        assert check_bucket_a({"pyproject.toml"}) is True
+
+    def test_bucket_a_uv_lock(self) -> None:
+        assert check_bucket_a({"uv.lock"}) is True
+
+    def test_bucket_a_precommit(self) -> None:
+        assert check_bucket_a({".pre-commit-config.yaml"}) is True
+
+    def test_bucket_a_factory(self) -> None:
+        assert check_bucket_a({"src/autoskillit/server/_factory.py"}) is True
+
+    def test_bucket_a_subdir_conftest(self) -> None:
+        assert check_bucket_a({"tests/execution/conftest.py"}) is True
+
+    def test_bucket_a_negative(self) -> None:
+        assert check_bucket_a({"src/autoskillit/core/io.py"}) is False
+
+
+# ---------------------------------------------------------------------------
+# build_test_scope Tests (S1–S10)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTestScope:
+    def test_scope_none_changed_returns_none(self, tmp_path: Path) -> None:
+        result = build_test_scope(
+            changed_files=None,
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tmp_path / "tests",
+        )
+        assert result is None
+
+    def test_scope_large_changeset_returns_none(self, tmp_path: Path) -> None:
+        files = {f"src/autoskillit/core/f{i}.py" for i in range(31)}
+        result = build_test_scope(
+            changed_files=files,
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tmp_path / "tests",
+        )
+        assert result is None
+
+    def test_scope_bucket_a_returns_none(self, tmp_path: Path) -> None:
+        result = build_test_scope(
+            changed_files={"pyproject.toml"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tmp_path / "tests",
+        )
+        assert result is None
+
+    def test_scope_l0_core_conservative(self, tmp_path: Path) -> None:
+        tests_root = tmp_path / "tests"
+        for d in [
+            "core", "config", "execution", "pipeline", "workspace",
+            "recipe", "migration", "server", "cli",
+            "hooks", "skills", "arch", "contracts", "infra", "docs",
+        ]:
+            (tests_root / d).mkdir(parents=True, exist_ok=True)
+
+        result = build_test_scope(
+            changed_files={"src/autoskillit/core/io.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        for expected in ["core", "config", "execution", "pipeline", "workspace",
+                         "recipe", "migration", "server", "cli", "hooks", "skills"]:
+            assert expected in dir_names, f"{expected} missing from cascade"
+        for always in ["arch", "contracts", "infra", "docs"]:
+            assert always in dir_names, f"always-run {always} missing"
+
+    def test_scope_l1_execution_conservative(self, tmp_path: Path) -> None:
+        tests_root = tmp_path / "tests"
+        for d in [
+            "execution", "core", "workspace", "migration",
+            "server", "cli", "infra", "skills",
+            "arch", "contracts", "docs",
+        ]:
+            (tests_root / d).mkdir(parents=True, exist_ok=True)
+
+        result = build_test_scope(
+            changed_files={"src/autoskillit/execution/headless.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        for expected in ["execution", "core", "workspace", "migration",
+                         "server", "cli", "infra", "skills"]:
+            assert expected in dir_names, f"{expected} missing from cascade"
+
+    def test_scope_l2_recipe_conservative(self, tmp_path: Path) -> None:
+        tests_root = tmp_path / "tests"
+        for d in [
+            "recipe", "execution", "server", "cli", "infra", "skills",
+            "arch", "contracts", "docs",
+        ]:
+            (tests_root / d).mkdir(parents=True, exist_ok=True)
+
+        result = build_test_scope(
+            changed_files={"src/autoskillit/recipe/schema.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        for expected in ["recipe", "execution", "server", "cli", "infra", "skills"]:
+            assert expected in dir_names, f"{expected} missing from cascade"
+
+    def test_scope_l3_server_conservative(self, tmp_path: Path) -> None:
+        tests_root = tmp_path / "tests"
+        for d in ["server", "cli", "infra", "arch", "contracts", "docs"]:
+            (tests_root / d).mkdir(parents=True, exist_ok=True)
+
+        result = build_test_scope(
+            changed_files={"src/autoskillit/server/helpers.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        assert "server" in dir_names
+        assert "cli" in dir_names
+        assert "infra" in dir_names
+
+    def test_scope_test_file_included_directly(self, tmp_path: Path) -> None:
+        tests_root = tmp_path / "tests"
+        for d in ["arch", "contracts", "infra", "docs"]:
+            (tests_root / d).mkdir(parents=True, exist_ok=True)
+
+        result = build_test_scope(
+            changed_files={"tests/core/test_io.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        assert Path("tests/core/test_io.py") in result
+
+    def test_scope_nonpython_no_manifest_only_alwaysrun(self, tmp_path: Path) -> None:
+        tests_root = tmp_path / "tests"
+        for d in ["arch", "contracts", "infra", "docs"]:
+            (tests_root / d).mkdir(parents=True, exist_ok=True)
+
+        result = build_test_scope(
+            changed_files={"README.md"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        assert dir_names == {"arch", "contracts", "infra", "docs"}
+
+    def test_scope_empty_changeset(self, tmp_path: Path) -> None:
+        tests_root = tmp_path / "tests"
+        for d in ["arch", "contracts", "infra", "docs"]:
+            (tests_root / d).mkdir(parents=True, exist_ok=True)
+
+        result = build_test_scope(
+            changed_files=set(),
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        assert dir_names == {"arch", "contracts", "infra", "docs"}
+
+
+# ---------------------------------------------------------------------------
+# Conservative vs Aggressive Tests (M1–M4)
+# ---------------------------------------------------------------------------
+
+
+class TestFilterModes:
+    def test_conservative_always_run_includes_infra(self) -> None:
+        assert "arch" in ALWAYS_RUN_CONSERVATIVE
+        assert "contracts" in ALWAYS_RUN_CONSERVATIVE
+        assert "infra" in ALWAYS_RUN_CONSERVATIVE
+        assert "docs" in ALWAYS_RUN_CONSERVATIVE
+
+    def test_aggressive_always_run_excludes_infra(self) -> None:
+        assert "arch" in ALWAYS_RUN_AGGRESSIVE
+        assert "contracts" in ALWAYS_RUN_AGGRESSIVE
+        assert "infra" not in ALWAYS_RUN_AGGRESSIVE
+        assert "docs" not in ALWAYS_RUN_AGGRESSIVE
+
+    def test_aggressive_ast_refinement(self, tmp_path: Path) -> None:
+        tests_root = tmp_path / "tests"
+        (tests_root / "core").mkdir(parents=True)
+        (tests_root / "arch").mkdir()
+        (tests_root / "contracts").mkdir()
+
+        result_aggressive = build_test_scope(
+            changed_files={"src/autoskillit/core/io.py"},
+            mode=FilterMode.AGGRESSIVE,
+            tests_root=tests_root,
+        )
+        assert result_aggressive is not None
+        dir_names = {p.name for p in result_aggressive}
+        assert "core" in dir_names
+        assert "arch" in dir_names
+        assert "contracts" in dir_names
+
+    def test_conservative_wider_cascade(self) -> None:
+        for pkg in LAYER_CASCADE_CONSERVATIVE:
+            if pkg in LAYER_CASCADE_AGGRESSIVE:
+                assert LAYER_CASCADE_AGGRESSIVE[pkg] <= LAYER_CASCADE_CONSERVATIVE[pkg], (
+                    f"Aggressive cascade for {pkg} is not a subset of conservative"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Git Diff Edge Cases (G1–G5)
+# ---------------------------------------------------------------------------
+
+
+class TestGitChangedFiles:
+    def test_git_changed_files_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake_result = subprocess.CompletedProcess(
+            args=[], returncode=0,
+            stdout="src/autoskillit/core/io.py\ntests/core/test_io.py\n",
+        )
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: fake_result)
+        result = git_changed_files("/fake", base_ref="main")
+        assert result == {"src/autoskillit/core/io.py", "tests/core/test_io.py"}
+
+    def test_git_changed_files_failure_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        def _raise(*a: object, **kw: object) -> None:
+            raise subprocess.CalledProcessError(1, "git")
+
+        monkeypatch.setattr(subprocess, "run", _raise)
+        result = git_changed_files("/fake", base_ref="main")
+        assert result is None
+
+    def test_git_changed_files_timeout_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        def _raise(*a: object, **kw: object) -> None:
+            raise subprocess.TimeoutExpired("git", 10)
+
+        monkeypatch.setattr(subprocess, "run", _raise)
+        result = git_changed_files("/fake", base_ref="main")
+        assert result is None
+
+    def test_git_changed_files_env_override(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("AUTOSKILLIT_TEST_BASE_REF", "feature-branch")
+        monkeypatch.delenv("GITHUB_BASE_REF", raising=False)
+
+        captured_args: list[list[str]] = []
+
+        def _capture(*a: object, **kw: object) -> subprocess.CompletedProcess[str]:
+            captured_args.append(list(a[0]))
+            return subprocess.CompletedProcess(args=[], returncode=0, stdout="")
+
+        monkeypatch.setattr(subprocess, "run", _capture)
+        git_changed_files("/fake")
+        assert captured_args
+        assert "feature-branch...HEAD" in captured_args[0]
+
+    def test_git_changed_files_github_base_ref(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("AUTOSKILLIT_TEST_BASE_REF", raising=False)
+        monkeypatch.setenv("GITHUB_BASE_REF", "main")
+
+        captured_args: list[list[str]] = []
+
+        def _capture(*a: object, **kw: object) -> subprocess.CompletedProcess[str]:
+            captured_args.append(list(a[0]))
+            return subprocess.CompletedProcess(args=[], returncode=0, stdout="")
+
+        monkeypatch.setattr(subprocess, "run", _capture)
+        git_changed_files("/fake")
+        assert captured_args
+        assert "main...HEAD" in captured_args[0]
+
+
+# ---------------------------------------------------------------------------
+# Re-export Closure Tests (R1–R2)
+# ---------------------------------------------------------------------------
+
+
+class TestReexportClosure:
+    def test_reexport_closure_direct_init(self, tmp_path: Path) -> None:
+        pkg = tmp_path / "pkg"
+        pkg.mkdir()
+        (pkg / "sub.py").write_text("x = 1\n")
+        (pkg / "__init__.py").write_text("from .sub import x\n")
+
+        result = _expand_reexport_closure({"pkg/sub.py"}, tmp_path)
+        assert "pkg/__init__.py" in result
+        assert "pkg/sub.py" in result
+
+    def test_reexport_closure_no_match(self, tmp_path: Path) -> None:
+        pkg = tmp_path / "pkg"
+        pkg.mkdir()
+        (pkg / "other.py").write_text("y = 2\n")
+        (pkg / "__init__.py").write_text("from .sub import x\n")
+
+        result = _expand_reexport_closure({"pkg/other.py"}, tmp_path)
+        assert "pkg/__init__.py" not in result
+        assert "pkg/other.py" in result

--- a/tests/test_test_filter.py
+++ b/tests/test_test_filter.py
@@ -17,9 +17,11 @@ from tests._test_filter import (
     FilterMode,
     ImportContext,
     _expand_reexport_closure,
+    apply_manifest,
     build_test_scope,
     check_bucket_a,
     git_changed_files,
+    load_manifest,
 )
 
 # ---------------------------------------------------------------------------
@@ -297,6 +299,14 @@ class TestBuildTestScope:
         dir_names = {p.name for p in result}
         assert dir_names == {"arch", "contracts", "infra", "docs"}
 
+    def test_scope_none_mode_returns_none(self, tmp_path: Path) -> None:
+        result = build_test_scope(
+            changed_files={"src/autoskillit/core/io.py"},
+            mode=FilterMode.NONE,
+            tests_root=tmp_path / "tests",
+        )
+        assert result is None
+
     def test_scope_empty_changeset(self, tmp_path: Path) -> None:
         tests_root = tmp_path / "tests"
         for d in ["arch", "contracts", "infra", "docs"]:
@@ -455,3 +465,58 @@ class TestReexportClosure:
         result = _expand_reexport_closure({"pkg/other.py"}, tmp_path)
         assert "pkg/__init__.py" not in result
         assert "pkg/other.py" in result
+
+
+# ---------------------------------------------------------------------------
+# Manifest Tests (MA1–MA4)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadManifest:
+    def test_load_manifest_absent(self, tmp_path: Path) -> None:
+        result = load_manifest(tmp_path)
+        assert result is None
+
+    def test_load_manifest_valid(self, tmp_path: Path) -> None:
+        manifest_dir = tmp_path / ".autoskillit"
+        manifest_dir.mkdir()
+        (manifest_dir / "test-filter-manifest.yaml").write_text(
+            "patterns:\n  'docs/*.md':\n    - docs\n"
+        )
+        result = load_manifest(tmp_path)
+        assert result is not None
+        assert "patterns" in result
+        assert "docs/*.md" in result["patterns"]
+
+    def test_load_manifest_malformed_yaml(self, tmp_path: Path) -> None:
+        manifest_dir = tmp_path / ".autoskillit"
+        manifest_dir.mkdir()
+        (manifest_dir / "test-filter-manifest.yaml").write_text(":\n  - :\n  bad: [")
+        import warnings
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = load_manifest(tmp_path)
+        assert result is None
+        assert any("Malformed YAML" in str(warning.message) for warning in w)
+
+
+class TestApplyManifest:
+    def test_apply_manifest_none(self) -> None:
+        result = apply_manifest({"README.md"}, None)
+        assert result == set()
+
+    def test_apply_manifest_match(self) -> None:
+        manifest = {"patterns": {"docs/*.md": ["docs"]}}
+        result = apply_manifest({"docs/README.md"}, manifest)
+        assert result == {"docs"}
+
+    def test_apply_manifest_no_match(self) -> None:
+        manifest = {"patterns": {"docs/*.md": ["docs"]}}
+        result = apply_manifest({"src/foo.py"}, manifest)
+        assert result == set()
+
+    def test_apply_manifest_list_dirs(self) -> None:
+        manifest = {"patterns": {"*.yaml": ["config", "infra"]}}
+        result = apply_manifest({"defaults.yaml"}, manifest)
+        assert result == {"config", "infra"}

--- a/tests/test_test_filter.py
+++ b/tests/test_test_filter.py
@@ -1,4 +1,5 @@
 """Tests for tests/_test_filter.py — standalone test-path filtering logic."""
+
 from __future__ import annotations
 
 import ast
@@ -10,18 +11,16 @@ import pytest
 from tests._test_filter import (
     ALWAYS_RUN_AGGRESSIVE,
     ALWAYS_RUN_CONSERVATIVE,
+    LAYER_CASCADE_AGGRESSIVE,
+    LAYER_CASCADE_CONSERVATIVE,
     ASTImportWalker,
     FilterMode,
     ImportContext,
-    LAYER_CASCADE_AGGRESSIVE,
-    LAYER_CASCADE_CONSERVATIVE,
     _expand_reexport_closure,
-    apply_manifest,
     build_test_scope,
     check_bucket_a,
     git_changed_files,
 )
-
 
 # ---------------------------------------------------------------------------
 # Walker Tests (W1–W8)
@@ -152,9 +151,21 @@ class TestBuildTestScope:
     def test_scope_l0_core_conservative(self, tmp_path: Path) -> None:
         tests_root = tmp_path / "tests"
         for d in [
-            "core", "config", "execution", "pipeline", "workspace",
-            "recipe", "migration", "server", "cli",
-            "hooks", "skills", "arch", "contracts", "infra", "docs",
+            "core",
+            "config",
+            "execution",
+            "pipeline",
+            "workspace",
+            "recipe",
+            "migration",
+            "server",
+            "cli",
+            "hooks",
+            "skills",
+            "arch",
+            "contracts",
+            "infra",
+            "docs",
         ]:
             (tests_root / d).mkdir(parents=True, exist_ok=True)
 
@@ -165,8 +176,19 @@ class TestBuildTestScope:
         )
         assert result is not None
         dir_names = {p.name for p in result}
-        for expected in ["core", "config", "execution", "pipeline", "workspace",
-                         "recipe", "migration", "server", "cli", "hooks", "skills"]:
+        for expected in [
+            "core",
+            "config",
+            "execution",
+            "pipeline",
+            "workspace",
+            "recipe",
+            "migration",
+            "server",
+            "cli",
+            "hooks",
+            "skills",
+        ]:
             assert expected in dir_names, f"{expected} missing from cascade"
         for always in ["arch", "contracts", "infra", "docs"]:
             assert always in dir_names, f"always-run {always} missing"
@@ -174,9 +196,17 @@ class TestBuildTestScope:
     def test_scope_l1_execution_conservative(self, tmp_path: Path) -> None:
         tests_root = tmp_path / "tests"
         for d in [
-            "execution", "core", "workspace", "migration",
-            "server", "cli", "infra", "skills",
-            "arch", "contracts", "docs",
+            "execution",
+            "core",
+            "workspace",
+            "migration",
+            "server",
+            "cli",
+            "infra",
+            "skills",
+            "arch",
+            "contracts",
+            "docs",
         ]:
             (tests_root / d).mkdir(parents=True, exist_ok=True)
 
@@ -187,15 +217,30 @@ class TestBuildTestScope:
         )
         assert result is not None
         dir_names = {p.name for p in result}
-        for expected in ["execution", "core", "workspace", "migration",
-                         "server", "cli", "infra", "skills"]:
+        for expected in [
+            "execution",
+            "core",
+            "workspace",
+            "migration",
+            "server",
+            "cli",
+            "infra",
+            "skills",
+        ]:
             assert expected in dir_names, f"{expected} missing from cascade"
 
     def test_scope_l2_recipe_conservative(self, tmp_path: Path) -> None:
         tests_root = tmp_path / "tests"
         for d in [
-            "recipe", "execution", "server", "cli", "infra", "skills",
-            "arch", "contracts", "docs",
+            "recipe",
+            "execution",
+            "server",
+            "cli",
+            "infra",
+            "skills",
+            "arch",
+            "contracts",
+            "docs",
         ]:
             (tests_root / d).mkdir(parents=True, exist_ok=True)
 
@@ -318,7 +363,8 @@ class TestFilterModes:
 class TestGitChangedFiles:
     def test_git_changed_files_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
         fake_result = subprocess.CompletedProcess(
-            args=[], returncode=0,
+            args=[],
+            returncode=0,
             stdout="src/autoskillit/core/io.py\ntests/core/test_io.py\n",
         )
         monkeypatch.setattr(subprocess, "run", lambda *a, **kw: fake_result)
@@ -326,7 +372,8 @@ class TestGitChangedFiles:
         assert result == {"src/autoskillit/core/io.py", "tests/core/test_io.py"}
 
     def test_git_changed_files_failure_returns_none(
-        self, monkeypatch: pytest.MonkeyPatch,
+        self,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         def _raise(*a: object, **kw: object) -> None:
             raise subprocess.CalledProcessError(1, "git")
@@ -336,7 +383,8 @@ class TestGitChangedFiles:
         assert result is None
 
     def test_git_changed_files_timeout_returns_none(
-        self, monkeypatch: pytest.MonkeyPatch,
+        self,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         def _raise(*a: object, **kw: object) -> None:
             raise subprocess.TimeoutExpired("git", 10)
@@ -346,7 +394,8 @@ class TestGitChangedFiles:
         assert result is None
 
     def test_git_changed_files_env_override(
-        self, monkeypatch: pytest.MonkeyPatch,
+        self,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.setenv("AUTOSKILLIT_TEST_BASE_REF", "feature-branch")
         monkeypatch.delenv("GITHUB_BASE_REF", raising=False)
@@ -363,7 +412,8 @@ class TestGitChangedFiles:
         assert "feature-branch...HEAD" in captured_args[0]
 
     def test_git_changed_files_github_base_ref(
-        self, monkeypatch: pytest.MonkeyPatch,
+        self,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.delenv("AUTOSKILLIT_TEST_BASE_REF", raising=False)
         monkeypatch.setenv("GITHUB_BASE_REF", "main")


### PR DESCRIPTION
## Summary

Create `tests/_test_filter.py` — a standalone, pytest-free Python module that determines which test files to run based on `git diff` output. The module contains: `FilterMode` and `ImportContext` enums, `ASTImportWalker` (an `ast.NodeVisitor` subclass), `load_manifest`/`apply_manifest` for YAML-based overrides, `git_changed_files` for subprocess-based diff extraction, `check_bucket_a` for full-run triggers, hardcoded layer cascade maps derived from the actual cross-layer test import graph, transitive re-export closure logic, and `build_test_scope` as the top-level entry point. A companion test suite in `tests/test_test_filter.py` validates all components with ~30 test cases.

## Requirements

- [ ] `tests/_test_filter.py` exists with all components listed above
- [ ] ASTImportWalker correctly extracts: top-level, from, deferred, conditional, TYPE_CHECKING, importlib literal
- [ ] `git_changed_files` handles all edge cases (failure, timeout, detached HEAD)
- [ ] `check_bucket_a` catches all trigger patterns
- [ ] `build_test_scope` returns correct scope for all layer combinations
- [ ] Module has no pytest dependencies (pure Python + ast + subprocess)
- [ ] Comprehensive test suite in `tests/test_test_filter.py` (~30 test cases)
- [ ] Large changeset (>30 files) triggers fail-open

Closes #931

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-931-20260415-160044-646864/.autoskillit/temp/make-plan/ast_import_walker_plan_2026-04-15_160600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| make_plan | 5.0k | 13.4k | 710.4k | 53.5k | 1 | 9m 54s |
| review_approach | 12 | 3.7k | 135.1k | 7.9k | 1 | 5m 55s |
| dry_walkthrough | 63 | 24.1k | 1.8M | 79.1k | 1 | 9m 54s |
| implement | 56 | 12.7k | 815.9k | 42.8k | 1 | 4m 34s |
| resolve_failures | 42 | 3.4k | 464.1k | 29.8k | 1 | 3m 46s |
| prepare_pr | 27 | 4.4k | 270.7k | 29.5k | 1 | 1m 40s |
| run_arch_lenses | 34 | 7.6k | 234.4k | 45.0k | 1 | 3m 53s |
| compose_pr | 23 | 1.9k | 130.8k | 14.7k | 1 | 51s |
| **Total** | 5.2k | 71.1k | 4.5M | 302.3k | | 40m 29s |