### PR TITLE
Kitchen Resume Reminder Enhancement

### DIFF
--- a/src/autoskillit/hooks/session_start_hook.py
+++ b/src/autoskillit/hooks/session_start_hook.py
@@ -24,6 +24,8 @@ def main() -> None:
         sys.exit(0)  # fail-open on malformed input
 
     # Best-effort TTL sweep of stale kitchen markers. Fail-open — must not raise.
+    _best_recipe_name: str | None = None
+    _best_opened_at = None
     try:
         _state_override = os.environ.get("AUTOSKILLIT_STATE_DIR")
         if _state_override:
@@ -39,6 +41,14 @@ def main() -> None:
                     _age = datetime.now(UTC) - _opened_at
                     if _age.total_seconds() >= _ttl_hours * 3600:
                         _p.unlink()
+                    else:
+                        # Fresh — track most recent recipe name
+                        _this_recipe = _d.get("recipe_name")
+                        if _best_opened_at is None or _opened_at > _best_opened_at:
+                            _best_opened_at = _opened_at
+                            _best_recipe_name = (
+                                _this_recipe if isinstance(_this_recipe, str) else None
+                            )
                 except Exception:
                     try:
                         _p.unlink()
@@ -59,16 +69,22 @@ def main() -> None:
     if size == 0:
         sys.exit(0)  # fresh session — no reminder needed
 
-    payload = json.dumps(
-        {
-            "additionalContext": (
-                "RESUME REMINDER: You are resuming a previous AutoSkillit session. "
-                "MCP tool access (kitchen) is not automatically restored on resume. "
-                "Call /autoskillit:open-kitchen first to regain access to all "
-                "AutoSkillit MCP tools before continuing your work."
-            )
-        }
+    _base_msg = (
+        "RESUME REMINDER: You are resuming a previous AutoSkillit session. "
+        "MCP tool access (kitchen) is not automatically restored on resume. "
     )
+    if _best_recipe_name:
+        _detail = (
+            f"You were running recipe '{_best_recipe_name}' — "
+            f"call open_kitchen(name='{_best_recipe_name}') to regain access to all "
+            "AutoSkillit MCP tools before continuing your work."
+        )
+    else:
+        _detail = (
+            "Call /autoskillit:open-kitchen first to regain access to all "
+            "AutoSkillit MCP tools before continuing your work."
+        )
+    payload = json.dumps({"additionalContext": _base_msg + _detail})
     sys.stdout.write(payload + "\n")
     sys.exit(0)
 

--- a/tests/infra/test_session_start_reminder.py
+++ b/tests/infra/test_session_start_reminder.py
@@ -3,22 +3,40 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
-from datetime import UTC
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 SCRIPT = Path(__file__).resolve().parents[2] / "src/autoskillit/hooks/session_start_hook.py"
 
 
-def _run(stdin_data: str) -> tuple[int, str]:
+def _run(stdin_data: str, env: dict | None = None) -> tuple[int, str]:
     result = subprocess.run(
         [sys.executable, str(SCRIPT)],
         input=stdin_data,
         capture_output=True,
         text=True,
+        env=env,
     )
     return result.returncode, result.stdout
+
+
+def _write_marker(
+    marker_dir: Path, session_id: str, recipe_name: object, *, fresh: bool = True
+) -> None:
+    opened_at = datetime.now(UTC) if fresh else datetime.now(UTC) - timedelta(hours=25)
+    (marker_dir / f"{session_id}.json").write_text(
+        json.dumps(
+            {
+                "session_id": session_id,
+                "opened_at": opened_at.isoformat(),
+                "recipe_name": recipe_name,
+                "marker_version": 1,
+            }
+        )
+    )
 
 
 # REQ-HOOK-002, REQ-HOOK-003
@@ -109,3 +127,128 @@ def test_session_start_sweeps_stale_markers(tmp_path: Path) -> None:
     assert result.returncode == 0
     assert not stale.exists(), "Stale marker should have been swept"
     assert fresh.exists(), "Fresh marker must survive"
+
+
+def test_resumed_session_includes_recipe_name_from_fresh_marker(tmp_path: Path) -> None:
+    """Fresh marker with recipe_name → name appears in additionalContext."""
+    marker_dir = tmp_path / "state" / "kitchen_state"
+    marker_dir.mkdir(parents=True)
+    _write_marker(marker_dir, "sess-1", "my-recipe", fresh=True)
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text('{"type":"say","text":"hello"}\n')
+    payload = json.dumps({"session_id": "sess-1", "transcript_path": str(transcript)})
+    env = {**os.environ, "AUTOSKILLIT_STATE_DIR": str(tmp_path / "state")}
+    rc, out = _run(payload, env=env)
+    assert rc == 0
+    data = json.loads(out.strip())
+    assert "my-recipe" in data["additionalContext"]
+
+
+def test_resumed_session_no_recipe_name_when_marker_has_none(tmp_path: Path) -> None:
+    """Fresh marker with recipe_name=None → generic reminder, no recipe name."""
+    marker_dir = tmp_path / "state" / "kitchen_state"
+    marker_dir.mkdir(parents=True)
+    _write_marker(marker_dir, "sess-2", None, fresh=True)
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text('{"type":"say","text":"hello"}\n')
+    payload = json.dumps({"session_id": "sess-2", "transcript_path": str(transcript)})
+    env = {**os.environ, "AUTOSKILLIT_STATE_DIR": str(tmp_path / "state")}
+    rc, out = _run(payload, env=env)
+    assert rc == 0
+    data = json.loads(out.strip())
+    assert "recipe" not in data["additionalContext"]
+
+
+def test_resumed_session_no_recipe_name_when_no_markers_exist(tmp_path: Path) -> None:
+    """No marker files → additionalContext present but no recipe name."""
+    (tmp_path / "state" / "kitchen_state").mkdir(parents=True)
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text('{"type":"say","text":"hello"}\n')
+    payload = json.dumps({"session_id": "sess-3", "transcript_path": str(transcript)})
+    env = {**os.environ, "AUTOSKILLIT_STATE_DIR": str(tmp_path / "state")}
+    rc, out = _run(payload, env=env)
+    assert rc == 0
+    data = json.loads(out.strip())
+    assert "additionalContext" in data
+    assert "recipe" not in data["additionalContext"]
+
+
+def test_resumed_session_picks_most_recent_fresh_marker(tmp_path: Path) -> None:
+    """Two fresh markers → most recent recipe_name wins."""
+    marker_dir = tmp_path / "state" / "kitchen_state"
+    marker_dir.mkdir(parents=True)
+    # Write older marker first
+    older_at = datetime.now(UTC) - timedelta(seconds=10)
+    (marker_dir / "old-sess.json").write_text(
+        json.dumps(
+            {
+                "session_id": "old-sess",
+                "opened_at": older_at.isoformat(),
+                "recipe_name": "old-recipe",
+                "marker_version": 1,
+            }
+        )
+    )
+    # Write newer marker
+    newer_at = datetime.now(UTC)
+    (marker_dir / "new-sess.json").write_text(
+        json.dumps(
+            {
+                "session_id": "new-sess",
+                "opened_at": newer_at.isoformat(),
+                "recipe_name": "new-recipe",
+                "marker_version": 1,
+            }
+        )
+    )
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text('{"type":"say","text":"hello"}\n')
+    payload = json.dumps({"session_id": "new-sess", "transcript_path": str(transcript)})
+    env = {**os.environ, "AUTOSKILLIT_STATE_DIR": str(tmp_path / "state")}
+    rc, out = _run(payload, env=env)
+    assert rc == 0
+    data = json.loads(out.strip())
+    assert "new-recipe" in data["additionalContext"]
+    assert "old-recipe" not in data["additionalContext"]
+
+
+def test_resumed_session_ignores_stale_marker_recipe_name(tmp_path: Path) -> None:
+    """Stale marker recipe_name must not appear in additionalContext."""
+    marker_dir = tmp_path / "state" / "kitchen_state"
+    marker_dir.mkdir(parents=True)
+    _write_marker(marker_dir, "stale-sess", "stale-recipe", fresh=False)
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text('{"type":"say","text":"hello"}\n')
+    payload = json.dumps({"session_id": "stale-sess", "transcript_path": str(transcript)})
+    env = {**os.environ, "AUTOSKILLIT_STATE_DIR": str(tmp_path / "state")}
+    rc, out = _run(payload, env=env)
+    assert rc == 0
+    data = json.loads(out.strip())
+    assert "stale-recipe" not in data["additionalContext"]
+
+
+def test_fresh_session_not_affected_by_markers(tmp_path: Path) -> None:
+    """Fresh session (empty transcript) stays silent even with a marker present."""
+    marker_dir = tmp_path / "state" / "kitchen_state"
+    marker_dir.mkdir(parents=True)
+    _write_marker(marker_dir, "sess-6", "some-recipe", fresh=True)
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text("")
+    payload = json.dumps({"session_id": "sess-6", "transcript_path": str(transcript)})
+    env = {**os.environ, "AUTOSKILLIT_STATE_DIR": str(tmp_path / "state")}
+    rc, out = _run(payload, env=env)
+    assert rc == 0
+    assert "additionalContext" not in out
+
+
+def test_resumed_session_marker_dir_missing_no_crash(tmp_path: Path) -> None:
+    """Missing AUTOSKILLIT_STATE_DIR path → exit 0, generic reminder, no crash."""
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text('{"type":"say","text":"hello"}\n')
+    payload = json.dumps({"session_id": "sess-7", "transcript_path": str(transcript)})
+    env = {**os.environ, "AUTOSKILLIT_STATE_DIR": str(tmp_path / "nonexistent")}
+    rc, out = _run(payload, env=env)
+    assert rc == 0
+    data = json.loads(out.strip())
+    assert "additionalContext" in data
+    assert "recipe" not in data["additionalContext"]


### PR DESCRIPTION
## Summary

Extend `session_start_hook.py` to track the most recent fresh kitchen marker's `recipe_name`
during the existing TTL sweep loop, then inject that name into the `additionalContext` resume
message. Add 7 tests to `tests/infra/test_session_start_reminder.py`.

No new abstractions, no new files, no imports beyond stdlib — one modification to the sweep
loop, one conditional in the message builder, seven tests.

Closes #964

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260415-170413-450071/.autoskillit/temp/make-plan/kitchen_resume_reminder_enhancement_plan_2026-04-15_000001.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| make_plan | 105 | 8.1k | 381.7k | 52.3k | 1 | 2m 43s |
| review_approach | 2.3k | 5.0k | 168.6k | 25.9k | 1 | 3m 57s |
| dry_walkthrough | 76 | 7.8k | 286.5k | 36.7k | 1 | 2m 33s |
| implement | 158 | 7.3k | 666.5k | 36.4k | 1 | 2m 3s |
| prepare_pr | 23 | 4.2k | 111.0k | 23.6k | 1 | 1m 36s |
| run_arch_lenses | 25 | 3.0k | 183.1k | 30.6k | 1 | 1m 53s |
| compose_pr | 23 | 2.3k | 129.6k | 16.9k | 1 | 56s |
| **Total** | 2.7k | 37.6k | 1.9M | 222.5k | | 15m 43s |