### PR TITLE
Async resolve_trace_target + Shielded Kill in BaseException Handler

### DIFF
--- a/src/autoskillit/execution/linux_tracing.py
+++ b/src/autoskillit/execution/linux_tracing.py
@@ -117,7 +117,7 @@ class TraceTarget:
     resolved_at: datetime
 
 
-def resolve_trace_target(
+async def resolve_trace_target(
     root_pid: int,
     expected_basename: str,
     timeout: float = 2.0,
@@ -174,7 +174,7 @@ def resolve_trace_target(
             except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess, OSError):
                 continue
 
-        time.sleep(0.05)
+        await anyio.sleep(0.05)
 
     raise TraceTargetResolutionError(root_pid=root_pid, expected_basename=expected_basename)
 

--- a/src/autoskillit/execution/process.py
+++ b/src/autoskillit/execution/process.py
@@ -253,7 +253,7 @@ async def run_managed_async(
 
                 if pty_mode and LINUX_TRACING_AVAILABLE:
                     # PTY mode: proc.pid is the script(1) wrapper — resolve to workload
-                    _target = resolve_trace_target(
+                    _target = await resolve_trace_target(
                         root_pid=proc.pid,
                         expected_basename=_workload_basename,
                         timeout=2.0,
@@ -430,11 +430,16 @@ async def run_managed_async(
             )
             return sub_result
         except BaseException:
-            # Ensure cleanup on unexpected errors (including CancelledError)
-            if "tracing_handle" in locals() and tracing_handle is not None:
-                tracing_handle.stop()  # idempotent: flushes and closes trace file
-            if "proc" in locals() and proc.returncode is None:
-                kill_process_tree(proc.pid)
+            # Shielded cleanup: when a task is cancelled, the BaseException handler
+            # runs with cancellation active. Without shielding, the await in
+            # async_kill_process_tree would be immediately cancelled, leaking the
+            # subprocess tree. CancelScope(shield=True) suspends the outer cancel
+            # so cleanup completes before re-raising.
+            with anyio.CancelScope(shield=True):
+                if "tracing_handle" in locals() and tracing_handle is not None:
+                    tracing_handle.stop()
+                if "proc" in locals() and proc.returncode is None:
+                    await async_kill_process_tree(proc.pid)
             raise
         finally:
             if stdin_handle is not None:

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -178,15 +178,15 @@ def _count_semantic_rule_files() -> int:
 # ----- tests ------------------------------------------------------------------
 
 
-def test_kitchen_tagged_tool_count_is_41() -> None:
-    assert _count_kitchen_tools() == 41, (
-        f"Expected 41 kitchen-tagged tools; found {_count_kitchen_tools()}"
+def test_kitchen_tagged_tool_count_is_40() -> None:
+    assert _count_kitchen_tools() == 40, (
+        f"Expected 40 kitchen-tagged tools; found {_count_kitchen_tools()}"
     )
 
 
-def test_free_range_tool_count_is_3() -> None:
-    assert _count_free_range_tools() == 3, (
-        f"Expected 3 free-range tools; found {_count_free_range_tools()}"
+def test_free_range_tool_count_is_4() -> None:
+    assert _count_free_range_tools() == 4, (
+        f"Expected 4 free-range tools; found {_count_free_range_tools()}"
     )
 
 

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -178,15 +178,15 @@ def _count_semantic_rule_files() -> int:
 # ----- tests ------------------------------------------------------------------
 
 
-def test_kitchen_tagged_tool_count_is_40() -> None:
-    assert _count_kitchen_tools() == 40, (
-        f"Expected 40 kitchen-tagged tools; found {_count_kitchen_tools()}"
+def test_kitchen_tagged_tool_count_is_41() -> None:
+    assert _count_kitchen_tools() == 41, (
+        f"Expected 41 kitchen-tagged tools; found {_count_kitchen_tools()}"
     )
 
 
-def test_free_range_tool_count_is_4() -> None:
-    assert _count_free_range_tools() == 4, (
-        f"Expected 4 free-range tools; found {_count_free_range_tools()}"
+def test_free_range_tool_count_is_3() -> None:
+    assert _count_free_range_tools() == 3, (
+        f"Expected 3 free-range tools; found {_count_free_range_tools()}"
     )
 
 

--- a/tests/execution/test_trace_target_resolver.py
+++ b/tests/execution/test_trace_target_resolver.py
@@ -20,7 +20,8 @@ pytestmark = pytest.mark.skipif(
 
 
 @pytest.mark.skipif(shutil.which("script") is None, reason="script(1) not available")
-def test_resolve_trace_target_walks_from_wrapper_to_workload():
+@pytest.mark.anyio
+async def test_resolve_trace_target_walks_from_wrapper_to_workload():
     """resolve_trace_target resolves from script(1) wrapper to the workload process.
 
     Test 1.3: lock in the descendant-walk + basename-match contract.
@@ -33,7 +34,9 @@ def test_resolve_trace_target_walks_from_wrapper_to_workload():
         stderr=subprocess.DEVNULL,
     )
     try:
-        target = resolve_trace_target(root_pid=proc.pid, expected_basename="python3", timeout=2.0)
+        target = await resolve_trace_target(
+            root_pid=proc.pid, expected_basename="python3", timeout=2.0
+        )
         assert target.pid != proc.pid, (
             "Resolved PID must not be the wrapper (script) PID — "
             "resolver must walk children to find the workload"
@@ -48,7 +51,8 @@ def test_resolve_trace_target_walks_from_wrapper_to_workload():
         proc.wait()
 
 
-def test_resolve_trace_target_raises_on_miss():
+@pytest.mark.anyio
+async def test_resolve_trace_target_raises_on_miss():
     """resolve_trace_target raises TraceTargetResolutionError when workload never appears.
 
     Test 1.4: failure must be loud, not a silent fall-back to wrapper PID.
@@ -61,7 +65,7 @@ def test_resolve_trace_target_raises_on_miss():
     proc = subprocess.Popen(["sleep", "5"])
     try:
         with pytest.raises(TraceTargetResolutionError) as exc_info:
-            resolve_trace_target(
+            await resolve_trace_target(
                 root_pid=proc.pid,
                 expected_basename="definitely_not_there",
                 timeout=0.5,

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -127,7 +127,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/server/_lifespan.py", 55),
     # tools_kitchen.py — hook config dict
     ("src/autoskillit/server/tools_kitchen.py", 141),
-    ("src/autoskillit/server/tools_kitchen.py", 473),
+    ("src/autoskillit/server/tools_kitchen.py", 477),
     # tools_status.py — mcp_data dict
     ("src/autoskillit/server/tools_status.py", 385),
     # tools_github.py — bug report dict


### PR DESCRIPTION
## Summary

PR B eliminates event loop blocking during subprocess management via two sub-changes:

1. **B1**: Convert `resolve_trace_target()` from sync to async — replaces `time.sleep(0.05)` with `await anyio.sleep(0.05)`, yielding control back to the event loop during the polling loop that fires on every `run_skill` invocation.
2. **B2**: Replace synchronous `kill_process_tree()` with shielded `async_kill_process_tree()` in the `except BaseException` handler — wrapping cleanup in `anyio.CancelScope(shield=True)` so the async kill completes even when cancellation is active.

Both changes are in the execution layer (L1). No public API changes — `resolve_trace_target` is not exported from `execution/__init__.py`.

Relates to #964 (PR B of 3)

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260415-174255-336642/.autoskillit/temp/make-plan/pr_b_async_resolve_trace_target_shielded_kill_plan_2026-04-15_174500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| make_plan | 75 | 7.8k | 538.5k | 55.9k | 1 | 3m 9s |
| review_approach | 2.9k | 6.7k | 378.0k | 40.8k | 1 | 6m 54s |
| dry_walkthrough | 285 | 8.7k | 641.5k | 48.5k | 1 | 4m 37s |
| implement | 51 | 5.9k | 482.4k | 31.6k | 1 | 2m 14s |
| prepare_pr | 33 | 4.5k | 145.0k | 24.5k | 1 | 1m 30s |
| run_arch_lenses | 14 | 3.0k | 87.4k | 28.8k | 1 | 3m 33s |
| compose_pr | 22 | 2.4k | 107.0k | 15.0k | 1 | 50s |
| **Total** | 3.4k | 38.9k | 2.4M | 245.1k | | 22m 49s |