### PR TITLE
Implementation Plan: Inject Recipe Ingredients into Orchestrator System Prompt

### DIFF
--- a/src/autoskillit/cli/_prompts.py
+++ b/src/autoskillit/cli/_prompts.py
@@ -43,16 +43,25 @@ def _get_ingredients_table(
     """Pre-render the ingredients table for system prompt injection.
 
     Uses load_and_validate (not load_recipe) so sub-recipe composition is included.
+    Returns None on any error so the orchestrator prompt is built without the
+    ingredients table rather than crashing.
     """
     from autoskillit.config import resolve_ingredient_defaults
     from autoskillit.recipe import load_and_validate
 
-    return load_and_validate(
-        recipe_name,
-        project_dir=cwd,
-        recipe_info=recipe_info,
-        resolved_defaults=resolve_ingredient_defaults(cwd),
-    ).get("ingredients_table")
+    try:
+        return load_and_validate(
+            recipe_name,
+            project_dir=cwd,
+            recipe_info=recipe_info,
+            resolved_defaults=resolve_ingredient_defaults(cwd),
+        ).get("ingredients_table")
+    except Exception:
+        logger.warning(
+            "Failed to pre-render ingredients table for %r — proceeding without it",
+            recipe_name,
+        )
+        return None
 
 
 _COOK_GREETINGS: list[str] = [

--- a/src/autoskillit/cli/_prompts.py
+++ b/src/autoskillit/cli/_prompts.py
@@ -37,6 +37,24 @@ def _resolve_recipe_input(raw: str, available: list[RecipeInfo]) -> RecipeInfo |
     return next((r for r in available if r.name == raw), None)
 
 
+def _get_ingredients_table(
+    recipe_name: str, recipe_info: RecipeInfo | None, cwd: Path
+) -> str | None:
+    """Pre-render the ingredients table for system prompt injection.
+
+    Uses load_and_validate (not load_recipe) so sub-recipe composition is included.
+    """
+    from autoskillit.config import resolve_ingredient_defaults
+    from autoskillit.recipe import load_and_validate
+
+    return load_and_validate(
+        recipe_name,
+        project_dir=cwd,
+        recipe_info=recipe_info,
+        resolved_defaults=resolve_ingredient_defaults(cwd),
+    ).get("ingredients_table")
+
+
 _COOK_GREETINGS: list[str] = [
     (
         "Welcome to Good Burger, home of the Good Burger, "

--- a/src/autoskillit/cli/_prompts.py
+++ b/src/autoskillit/cli/_prompts.py
@@ -54,7 +54,11 @@ _OPEN_KITCHEN_GREETINGS: list[str] = [
 ]
 
 
-def _build_orchestrator_prompt(recipe_name: str, mcp_prefix: str) -> str:
+def _build_orchestrator_prompt(
+    recipe_name: str,
+    mcp_prefix: str,
+    ingredients_table: str | None = None,
+) -> str:
     """Build the --append-system-prompt content for a cook session.
 
     The prompt contains behavioral instructions (routing rules, failure
@@ -66,6 +70,17 @@ def _build_orchestrator_prompt(recipe_name: str, mcp_prefix: str) -> str:
     _sous_chef_path = pkg_root() / "skills" / "sous-chef" / "SKILL.md"
     if _sous_chef_path.exists():
         sous_chef_content = "\n\n" + _sous_chef_path.read_text()
+
+    _ing_section = ""
+    if ingredients_table:
+        _ing_section = (
+            "RECIPE INGREDIENTS — USE THESE EXACT NAMES:\n"
+            f"{ingredients_table}\n\n"
+            "The ingredient names above are authoritative. Use them verbatim when:\n"
+            "- Collecting values from the user\n"
+            "- Evaluating skip_when_false conditions\n"
+            "- Passing ingredients to pipeline steps via `with:` arguments\n\n"
+        )
 
     return f"""\
 You are a pipeline orchestrator. Execute the recipe '{recipe_name}' step-by-step.
@@ -84,8 +99,10 @@ Wait a few seconds and retry the same tool call. Deferred startup I/O (audit \
 recovery, drift checks) runs in the background after the transport opens; tools \
 become available once the server finishes initializing.
 
-FIRST ACTION — before prompting for any inputs:
-0. Call {mcp_prefix}open_kitchen(name='{recipe_name}') to open the kitchen and load the recipe.
+{_ing_section}FIRST ACTION — before prompting for any inputs:
+0. Call {mcp_prefix}open_kitchen(name='{recipe_name}') to activate pipeline tools and open
+   the kitchen gate. open_kitchen is REQUIRED to enable all gated AutoSkillit tools —
+   the ingredients table above (when present) is provided for reference only.
    DO NOT call AskUserQuestion or any other tool before open_kitchen.
    If the call returns "No such tool available", the MCP server is still
    initializing. Wait 3 seconds and retry — this is normal on session start.

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -32,6 +32,7 @@ from autoskillit.cli._init_helpers import (
     _prompt_test_command,
     _register_all,
 )
+from autoskillit.cli._prompts import _build_orchestrator_prompt, _get_ingredients_table
 from autoskillit.cli._terminal import terminal_guard
 from autoskillit.core import ClaudeFlags, RecipeSource, atomic_write, pkg_root
 from autoskillit.execution import build_interactive_cmd
@@ -561,7 +562,6 @@ def order(recipe: str | None = None, session_id: str | None = None, *, resume: b
         When True, attempt to restore a previous session.
     """
     from autoskillit.cli._mcp_names import detect_autoskillit_mcp_prefix
-    from autoskillit.cli._prompts import _build_orchestrator_prompt
     from autoskillit.recipe import (
         find_recipe_by_name,
         list_recipes,
@@ -715,21 +715,7 @@ def order(recipe: str | None = None, session_id: str | None = None, *, resume: b
 
     from autoskillit.cli._prompts import _COOK_GREETINGS, show_cook_preview
 
-    # Pre-render ingredients table for system prompt injection (ING: issue #972)
-    # Uses load_and_validate() — not load_recipe() — to capture sub-recipe
-    # composition (e.g., sprint_mode=true merges sprint-prefix sub-recipe ingredients).
-    from autoskillit.config import resolve_ingredient_defaults as _resolve_defaults
-    from autoskillit.recipe import load_and_validate as _load_and_validate
-
-    _resolved_defaults = _resolve_defaults(Path.cwd())
-    _lav_result = _load_and_validate(
-        recipe,
-        project_dir=Path.cwd(),
-        recipe_info=_match,
-        resolved_defaults=_resolved_defaults,
-    )
-    _ingredients_table: str | None = _lav_result.get("ingredients_table")
-
+    _itable = _get_ingredients_table(recipe, _match, Path.cwd())
     show_cook_preview(recipe, parsed, _recipes_dir_for(_match), Path.cwd())
 
     from autoskillit.cli._ansi import permissions_warning
@@ -743,11 +729,7 @@ def order(recipe: str | None = None, session_id: str | None = None, *, resume: b
 
     greeting = random.choice(_COOK_GREETINGS).format(recipe_name=recipe)
     _launch_cook_session(
-        _build_orchestrator_prompt(
-            recipe,
-            mcp_prefix=mcp_prefix,
-            ingredients_table=_ingredients_table,
-        ),
+        _build_orchestrator_prompt(recipe, mcp_prefix=mcp_prefix, ingredients_table=_itable),
         initial_message=greeting,
         extra_env=_extra_env if _extra_env else None,
         resume_session_id=resume_session_id,

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -715,6 +715,21 @@ def order(recipe: str | None = None, session_id: str | None = None, *, resume: b
 
     from autoskillit.cli._prompts import _COOK_GREETINGS, show_cook_preview
 
+    # Pre-render ingredients table for system prompt injection (ING: issue #972)
+    # Uses load_and_validate() — not load_recipe() — to capture sub-recipe
+    # composition (e.g., sprint_mode=true merges sprint-prefix sub-recipe ingredients).
+    from autoskillit.config import resolve_ingredient_defaults as _resolve_defaults
+    from autoskillit.recipe import load_and_validate as _load_and_validate
+
+    _resolved_defaults = _resolve_defaults(Path.cwd())
+    _lav_result = _load_and_validate(
+        recipe,
+        project_dir=Path.cwd(),
+        recipe_info=_match,
+        resolved_defaults=_resolved_defaults,
+    )
+    _ingredients_table: str | None = _lav_result.get("ingredients_table")
+
     show_cook_preview(recipe, parsed, _recipes_dir_for(_match), Path.cwd())
 
     from autoskillit.cli._ansi import permissions_warning
@@ -728,7 +743,11 @@ def order(recipe: str | None = None, session_id: str | None = None, *, resume: b
 
     greeting = random.choice(_COOK_GREETINGS).format(recipe_name=recipe)
     _launch_cook_session(
-        _build_orchestrator_prompt(recipe, mcp_prefix=mcp_prefix),
+        _build_orchestrator_prompt(
+            recipe,
+            mcp_prefix=mcp_prefix,
+            ingredients_table=_ingredients_table,
+        ),
         initial_message=greeting,
         extra_env=_extra_env if _extra_env else None,
         resume_session_id=resume_session_id,

--- a/tests/cli/test_cli_prompts.py
+++ b/tests/cli/test_cli_prompts.py
@@ -460,3 +460,54 @@ def test_orchestrator_prompt_closes_optional_semantics():
     idx = prompt.index("OPTIONAL STEP SEMANTICS")
     section = prompt[idx : idx + 500]
     assert "ONLY" in section
+
+
+# ING-1
+def test_build_orchestrator_prompt_injects_ingredients_table_when_provided():
+    """When ingredients_table is supplied, it appears verbatim in the prompt."""
+    from autoskillit.cli._prompts import _build_orchestrator_prompt
+
+    table = "| Name | Description | Default |\n|------|-------------|---------|"
+    prompt = _build_orchestrator_prompt(
+        "my-recipe", mcp_prefix=DIRECT_PREFIX, ingredients_table=table
+    )
+    assert table in prompt, "ingredients_table content must appear verbatim in the prompt"
+
+
+# ING-2
+def test_build_orchestrator_prompt_omits_ingredients_section_when_none():
+    """When ingredients_table is None (default), no RECIPE INGREDIENTS section is injected."""
+    from autoskillit.cli._prompts import _build_orchestrator_prompt
+
+    prompt = _build_orchestrator_prompt("my-recipe", mcp_prefix=DIRECT_PREFIX)
+    assert "RECIPE INGREDIENTS" not in prompt, (
+        "No RECIPE INGREDIENTS section when ingredients_table is None"
+    )
+
+
+# ING-3
+def test_build_orchestrator_prompt_first_action_mentions_tool_activation():
+    """FIRST ACTION section must clarify open_kitchen is required for tool activation."""
+    from autoskillit.cli._prompts import _build_orchestrator_prompt
+
+    prompt = _build_orchestrator_prompt("my-recipe", mcp_prefix=DIRECT_PREFIX)
+    first_action_start = prompt.index("FIRST ACTION")
+    first_action_end = prompt.index("During pipeline execution", first_action_start)
+    section = prompt[first_action_start:first_action_end]
+    assert "tool" in section.lower() and (
+        "activat" in section.lower() or "enable" in section.lower()
+    ), "FIRST ACTION must clarify open_kitchen is required for tool activation/enabling"
+
+
+# ING-4
+def test_build_orchestrator_prompt_ingredients_section_before_first_action():
+    """RECIPE INGREDIENTS section must appear before FIRST ACTION so LLM sees names first."""
+    from autoskillit.cli._prompts import _build_orchestrator_prompt
+
+    table = "| task * | What to do | (required) |"
+    prompt = _build_orchestrator_prompt("impl", mcp_prefix=DIRECT_PREFIX, ingredients_table=table)
+    ing_idx = prompt.index("RECIPE INGREDIENTS")
+    first_action_idx = prompt.index("FIRST ACTION")
+    assert ing_idx < first_action_idx, (
+        "RECIPE INGREDIENTS section must appear before FIRST ACTION in the prompt"
+    )

--- a/tests/cli/test_cook.py
+++ b/tests/cli/test_cook.py
@@ -1385,7 +1385,6 @@ class TestOrderMcpPrefixSelection:
         self, mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """cook() must pass the pre-rendered ingredients_table to _build_orchestrator_prompt."""
-        # Capture the kwargs passed to _build_orchestrator_prompt
         captured: list[dict] = []
 
         def _capturing_build(
@@ -1420,7 +1419,7 @@ class TestOrderMcpPrefixSelection:
         cli.order("test-script")
 
         assert captured, "_build_orchestrator_prompt was not called"
-        assert captured[0]["ingredients_table"] is not None, (
+        assert captured[0]["ingredients_table"] == "| col | val |", (
             "app.cook() must pass pre-rendered ingredients_table to _build_orchestrator_prompt"
         )
 

--- a/tests/cli/test_cook.py
+++ b/tests/cli/test_cook.py
@@ -1347,6 +1347,50 @@ class TestOrderMcpPrefixSelection:
         captured_prompt = cmd[prompt_idx + 1]
         assert f"{MARKETPLACE_PREFIX}open_kitchen" in captured_prompt
 
+    @patch("autoskillit.cli.subprocess.run")
+    def test_cook_passes_ingredients_table_to_orchestrator_prompt(
+        self, mock_run: MagicMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """cook() must pass the pre-rendered ingredients_table to _build_orchestrator_prompt."""
+        # Capture the kwargs passed to _build_orchestrator_prompt
+        captured: list[dict] = []
+
+        def _capturing_build(
+            recipe_name: str, mcp_prefix: str, ingredients_table: object = None
+        ) -> str:
+            captured.append({"ingredients_table": ingredients_table})
+            return "ROUTING RULES\nFIRST ACTION\nopenKitchen\nDuring pipeline execution"
+
+        monkeypatch.delenv("CLAUDECODE", raising=False)
+        monkeypatch.chdir(tmp_path)
+        scripts_dir = tmp_path / ".autoskillit" / "recipes"
+        scripts_dir.mkdir(parents=True)
+        (scripts_dir / "test-script.yaml").write_text(_SCRIPT_YAML)
+        monkeypatch.setattr(shutil, "which", lambda cmd: "/usr/bin/claude")
+        monkeypatch.setattr("builtins.input", lambda _prompt="": "")
+        plugins_file = tmp_path / "plugins.json"
+        plugins_file.write_text('{"version": 2, "plugins": {}}')
+        monkeypatch.setattr(
+            "autoskillit.cli._mcp_names._installed_plugins_path", lambda: plugins_file
+        )
+        import importlib
+        import sys as _sys
+
+        _app_mod = _sys.modules.get("autoskillit.cli.app") or importlib.import_module(
+            "autoskillit.cli.app"
+        )
+        monkeypatch.setattr(_app_mod, "_build_orchestrator_prompt", _capturing_build)
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="", stderr=""
+        )
+
+        cli.order("test-script")
+
+        assert captured, "_build_orchestrator_prompt was not called"
+        assert captured[0]["ingredients_table"] is not None, (
+            "app.cook() must pass pre-rendered ingredients_table to _build_orchestrator_prompt"
+        )
+
 
 # SC-B-4: mark_onboarded() must NOT be called when the cook subprocess exits non-zero
 def test_cook_mark_onboarded_not_called_on_failure(

--- a/tests/cli/test_cook.py
+++ b/tests/cli/test_cook.py
@@ -113,6 +113,17 @@ class TestCLIOrder:
         )
         monkeypatch.setattr(_app_mod, "_is_plugin_installed", lambda: False)
 
+    @pytest.fixture(autouse=True)
+    def _stub_ingredients_table(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Stub _get_ingredients_table in app.py to prevent subprocess.run git calls."""
+        import importlib
+        import sys as _sys
+
+        _app_mod = _sys.modules.get("autoskillit.cli.app") or importlib.import_module(
+            "autoskillit.cli.app"
+        )
+        monkeypatch.setattr(_app_mod, "_get_ingredients_table", lambda *a, **kw: "| col | val |")
+
     # --- workspace init ---
 
     def test_prep_station_init_creates_dir_with_marker(
@@ -1096,6 +1107,17 @@ class TestOrderSubsetGate:
         )
         monkeypatch.setattr(_app_mod, "_is_plugin_installed", lambda: False)
 
+    @pytest.fixture(autouse=True)
+    def _stub_ingredients_table(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Stub _get_ingredients_table in app.py to prevent subprocess.run git calls."""
+        import importlib
+        import sys as _sys
+
+        _app_mod = _sys.modules.get("autoskillit.cli.app") or importlib.import_module(
+            "autoskillit.cli.app"
+        )
+        monkeypatch.setattr(_app_mod, "_get_ingredients_table", lambda *a, **kw: "| col | val |")
+
     def _make_config_mock(self, disabled: list[str]) -> MagicMock:
         mock_cfg = MagicMock()
         mock_cfg.subsets.disabled = disabled
@@ -1284,6 +1306,17 @@ class TestOrderMcpPrefixSelection:
             "autoskillit.cli.app"
         )
         monkeypatch.setattr(_app_mod, "_is_plugin_installed", lambda: False)
+
+    @pytest.fixture(autouse=True)
+    def _stub_ingredients_table(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Stub _get_ingredients_table in app.py to prevent subprocess.run git calls."""
+        import importlib
+        import sys as _sys
+
+        _app_mod = _sys.modules.get("autoskillit.cli.app") or importlib.import_module(
+            "autoskillit.cli.app"
+        )
+        monkeypatch.setattr(_app_mod, "_get_ingredients_table", lambda *a, **kw: "| col | val |")
 
     @patch("autoskillit.cli.subprocess.run")
     def test_order_prompt_uses_direct_prefix_when_no_marketplace_install(

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -179,14 +179,14 @@ def _count_semantic_rule_files() -> int:
 
 
 def test_kitchen_tagged_tool_count_is_41() -> None:
-    assert _count_kitchen_tools() == 40, (
-        f"Expected 40 kitchen-tagged tools; found {_count_kitchen_tools()}"
+    assert _count_kitchen_tools() == 41, (
+        f"Expected 41 kitchen-tagged tools; found {_count_kitchen_tools()}"
     )
 
 
 def test_free_range_tool_count_is_3() -> None:
-    assert _count_free_range_tools() == 4, (
-        f"Expected 4 free-range tools; found {_count_free_range_tools()}"
+    assert _count_free_range_tools() == 3, (
+        f"Expected 3 free-range tools; found {_count_free_range_tools()}"
     )
 
 

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -179,14 +179,14 @@ def _count_semantic_rule_files() -> int:
 
 
 def test_kitchen_tagged_tool_count_is_41() -> None:
-    assert _count_kitchen_tools() == 41, (
-        f"Expected 41 kitchen-tagged tools; found {_count_kitchen_tools()}"
+    assert _count_kitchen_tools() == 40, (
+        f"Expected 40 kitchen-tagged tools; found {_count_kitchen_tools()}"
     )
 
 
 def test_free_range_tool_count_is_3() -> None:
-    assert _count_free_range_tools() == 3, (
-        f"Expected 3 free-range tools; found {_count_free_range_tools()}"
+    assert _count_free_range_tools() == 4, (
+        f"Expected 4 free-range tools; found {_count_free_range_tools()}"
     )
 
 

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -39,19 +39,41 @@ def _docs_containing(pattern: str) -> list[Path]:
 # ----- canonical source-of-truth getters --------------------------------------
 
 
+def _extract_tool_decorators(text: str) -> list[str]:
+    """Extract full @mcp.tool(...) decorator text, handling multi-line decorators."""
+    decorators: list[str] = []
+    lines = text.splitlines()
+    i = 0
+    while i < len(lines):
+        stripped = lines[i].strip()
+        if stripped.startswith("@mcp.tool"):
+            # Collect the full decorator (may span multiple lines)
+            parts = [stripped]
+            if ")" not in stripped:
+                i += 1
+                while i < len(lines):
+                    part = lines[i].strip()
+                    parts.append(part)
+                    if ")" in part:
+                        break
+                    i += 1
+            decorators.append(" ".join(parts))
+        i += 1
+    return decorators
+
+
 def _count_mcp_tools() -> int:
     total = 0
     for f in (SRC_DIR / "server").glob("tools_*.py"):
-        total += sum(1 for line in _read(f).splitlines() if line.strip().startswith("@mcp.tool"))
+        total += len(_extract_tool_decorators(_read(f)))
     return total
 
 
 def _count_kitchen_tools() -> int:
     total = 0
     for f in (SRC_DIR / "server").glob("tools_*.py"):
-        text = _read(f)
-        for line in text.splitlines():
-            if line.strip().startswith("@mcp.tool") and '"kitchen"' in line:
+        for dec in _extract_tool_decorators(_read(f)):
+            if '"kitchen"' in dec:
                 total += 1
     return total
 
@@ -59,9 +81,8 @@ def _count_kitchen_tools() -> int:
 def _count_free_range_tools() -> int:
     total = 0
     for f in (SRC_DIR / "server").glob("tools_*.py"):
-        for line in _read(f).splitlines():
-            stripped = line.strip()
-            if stripped.startswith("@mcp.tool") and '"kitchen"' not in stripped:
+        for dec in _extract_tool_decorators(_read(f)):
+            if '"kitchen"' not in dec:
                 total += 1
     return total
 
@@ -69,8 +90,8 @@ def _count_free_range_tools() -> int:
 def _count_headless_tools() -> int:
     total = 0
     for f in (SRC_DIR / "server").glob("tools_*.py"):
-        for line in _read(f).splitlines():
-            if line.strip().startswith("@mcp.tool") and '"headless"' in line:
+        for dec in _extract_tool_decorators(_read(f)):
+            if '"headless"' in dec:
                 total += 1
     return total
 

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -127,7 +127,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/server/_lifespan.py", 55),
     # tools_kitchen.py — hook config dict
     ("src/autoskillit/server/tools_kitchen.py", 141),
-    ("src/autoskillit/server/tools_kitchen.py", 473),
+    ("src/autoskillit/server/tools_kitchen.py", 477),
     # tools_status.py — mcp_data dict
     ("src/autoskillit/server/tools_status.py", 385),
     # tools_github.py — bug report dict


### PR DESCRIPTION
## Summary

The orchestrator LLM hallucinates ingredient names when the `open_kitchen` MCP response exceeds the 50K-char persistence threshold. The ingredients table sits at line 1227 of 1243 in the formatted response — outside the 2KB preview the LLM actually sees. The fix: pre-render the ingredients table in `app.py` at session launch time and inject it into the orchestrator system prompt via `_build_orchestrator_prompt()`. This ensures the LLM has authoritative ingredient names before `open_kitchen` is even called.

Key design decisions driven by the gap analysis (issue #972 comment):

1. **Use `load_and_validate()` not raw `load_recipe()`** — `load_and_validate()` runs sub-recipe composition (e.g., `sprint_mode=true` merges sprint-prefix sub-recipe ingredients). Raw `load_recipe()` returns parent-only ingredients, diverging from `open_kitchen`'s composed view.

2. **Pre-render in `app.py`, pass `str | None` to `_build_orchestrator_prompt()`** — no new imports in `_prompts.py`; clean separation of concerns.

3. **Reword FIRST ACTION** — clarify `open_kitchen` is required for *tool activation*, not just ingredient discovery. Belt-and-suspenders: even when the LLM already has ingredients, `open_kitchen` enables the 40+ gated kitchen tools and must always run.

## Architecture Impact

### Data Lineage Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph Origins ["Data Origins"]
        YAML["Recipe YAML<br/>━━━━━━━━━━<br/>ingredients: section<br/>name → {desc, required,<br/>default, hidden}"]
        GIT["Git Remote<br/>━━━━━━━━━━<br/>upstream / origin<br/>→ source_dir URL"]
        CFG["Project Config<br/>━━━━━━━━━━<br/>defaults.yaml +<br/>branching.default_base_branch"]
    end

    subgraph Extraction ["Extraction & Resolution"]
        RESOLVE["resolve_ingredient_defaults()<br/>━━━━━━━━━━<br/>config/ingredient_defaults.py<br/>→ dict[str, str]<br/>{source_dir, base_branch}"]
        PIPELINE["load_and_validate()<br/>━━━━━━━━━━<br/>recipe/_api.py<br/>_parse_recipe → _build_active_recipe<br/>→ format_ingredients_table"]
    end

    subgraph InMem ["Primary In-Memory Storage"]
        RESULT[("LoadRecipeResult<br/>━━━━━━━━━━<br/>ingredients_table: str GFM<br/>content: YAML str<br/>kitchen_rules, suggestions")]
    end

    subgraph Injection ["● Injection Layer"]
        GET_ING["● _get_ingredients_table()<br/>━━━━━━━━━━<br/>cli/_prompts.py<br/>calls load_and_validate<br/>returns str | None"]
        COOK["● cook() / order()<br/>━━━━━━━━━━<br/>cli/app.py<br/>orchestration entry point"]
        BUILD["● _build_orchestrator_prompt()<br/>━━━━━━━━━━<br/>cli/_prompts.py<br/>injects _ing_section<br/>before FIRST ACTION block"]
    end

    subgraph WriteOnly ["Write-Only Artifacts"]
        PROMPT["System Prompt String<br/>━━━━━━━━━━<br/>RECIPE INGREDIENTS —<br/>USE THESE EXACT NAMES:<br/>{GFM table}<br/>+ FIRST ACTION + routing rules"]
        MCP_RESP["open_kitchen MCP Response<br/>━━━━━━━━━━<br/>JSON: ingredients_table,<br/>content YAML, kitchen_rules<br/>→ orchestrator conversation"]
    end

    ORCH["Orchestrator Claude<br/>━━━━━━━━━━<br/>Uses ingredient names<br/>verbatim: collect, skip_when_false,<br/>with: args to steps"]

    %% Data origins → extraction
    YAML -->|"YAML text"| PIPELINE
    GIT -->|"remote URL"| RESOLVE
    CFG -->|"base_branch config"| RESOLVE
    RESOLVE -->|"resolved_defaults dict"| PIPELINE

    %% Pipeline → in-memory storage
    PIPELINE -->|"format_ingredients_table()"| RESULT

    %% NEW: Result → injection layer
    RESULT -->|"ingredients_table str"| GET_ING
    GET_ING -->|"str | None"| COOK
    COOK -->|"ingredients_table="| BUILD
    BUILD -->|"prompt string"| PROMPT

    %% EXISTING: Result → open_kitchen MCP path
    RESULT -.->|"open_kitchen response"| MCP_RESP

    %% Write-only → Orchestrator
    PROMPT -.->|"--append-system-prompt"| ORCH
    MCP_RESP -.->|"MCP tool result"| ORCH

    %% CLASS ASSIGNMENTS %%
    class YAML,GIT,CFG cli;
    class RESOLVE,PIPELINE handler;
    class RESULT stateNode;
    class GET_ING,BUILD handler;
    class COOK phase;
    class PROMPT,MCP_RESP output;
    class ORCH integration;
```

### Operational Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START(["autoskillit order [recipe]"])

    subgraph CLIInput ["CLI ENTRY — app.py ●"]
        direction TB
        OrderCmd["● order()<br/>━━━━━━━━━━<br/>Recipe arg or interactive picker<br/>--resume / session_id flags"]
        RecipePicker["_resolve_recipe_input()<br/>━━━━━━━━━━<br/>0 = open-kitchen<br/>1..N = recipe by index/name"]
    end

    subgraph Validation ["RECIPE VALIDATION"]
        direction TB
        FindRecipe["find_recipe_by_name()<br/>━━━━━━━━━━<br/>Locate recipe YAML<br/>project or bundled"]
        ValidateRecipe["validate_recipe()<br/>━━━━━━━━━━<br/>Semantic rule checks<br/>Subset / pack gates"]
        SubsetGate["_get_subsets_needed()<br/>━━━━━━━━━━<br/>Check disabled subsets<br/>Prompt enable/cancel"]
        PackGate["_get_packs_needed()<br/>━━━━━━━━━━<br/>Check disabled packs<br/>Prompt enable/cancel"]
    end

    subgraph IngredientPrep ["● INGREDIENT INJECTION — _prompts.py ●"]
        direction TB
        GetIngTable["● _get_ingredients_table()<br/>━━━━━━━━━━<br/>load_and_validate() + resolve_ingredient_defaults()<br/>Returns pre-rendered markdown table"]
        ShowPreview["show_cook_preview()<br/>━━━━━━━━━━<br/>Flow diagram + ingredients table<br/>Printed to terminal before launch"]
    end

    subgraph Config ["CONFIGURATION (read-only)"]
        direction TB
        ProjConfig[".autoskillit/config.yaml<br/>━━━━━━━━━━<br/>subsets.disabled<br/>packs.enabled<br/>quota_guard"]
        IngDefaults["ingredient_defaults<br/>━━━━━━━━━━<br/>resolve_ingredient_defaults(cwd)<br/>Project-level ingredient overrides"]
    end

    subgraph PromptBuild ["● PROMPT BUILDER — _prompts.py ●"]
        direction TB
        BuildPrompt["● _build_orchestrator_prompt()<br/>━━━━━━━━━━<br/>recipe_name + mcp_prefix<br/>+ ingredients_table (NEW injection)<br/>Routing rules, failure predicates,<br/>quota logic, sous-chef content"]
        OpenKitchenPrompt["_build_open_kitchen_prompt()<br/>━━━━━━━━━━<br/>mcp_prefix only<br/>Orchestrator discipline rules"]
    end

    subgraph Launch ["SESSION LAUNCH"]
        direction TB
        LaunchSession["_launch_cook_session()<br/>━━━━━━━━━━<br/>claude --append-system-prompt<br/>--allowedTools AskUserQuestion<br/>--plugin-dir (if not installed)"]
    end

    subgraph InjectedPrompt ["INJECTED SYSTEM PROMPT (write-only artifact)"]
        direction TB
        SysPrompt["--append-system-prompt content<br/>━━━━━━━━━━<br/>RECIPE INGREDIENTS section (NEW)<br/>Deferred-tool recovery rules<br/>First-action: open_kitchen<br/>Routing + failure predicates<br/>Sous-chef orchestration rules"]
    end

    START --> OrderCmd
    OrderCmd --> RecipePicker
    RecipePicker -->|"recipe selected"| FindRecipe
    RecipePicker -->|"option 0"| OpenKitchenPrompt
    FindRecipe --> ValidateRecipe
    ValidateRecipe --> SubsetGate
    SubsetGate --> PackGate
    PackGate --> GetIngTable
    ProjConfig --> SubsetGate
    ProjConfig --> PackGate
    IngDefaults --> GetIngTable
    GetIngTable --> ShowPreview
    ShowPreview --> BuildPrompt
    GetIngTable -->|"ingredients_table string"| BuildPrompt
    BuildPrompt --> LaunchSession
    OpenKitchenPrompt --> LaunchSession
    LaunchSession --> SysPrompt

    class START terminal;
    class OrderCmd,RecipePicker cli;
    class FindRecipe,ValidateRecipe phase;
    class SubsetGate,PackGate detector;
    class GetIngTable,ShowPreview handler;
    class ProjConfig,IngDefaults stateNode;
    class BuildPrompt,OpenKitchenPrompt handler;
    class LaunchSession phase;
    class SysPrompt output;
```

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START — autoskillit order])
    COMPLETE([COMPLETE — Claude session exits])
    ABORT([ABORT])

    subgraph Phase1 ["Phase 1 — Command Entry & Recipe Resolution"]
        direction TB
        OrderCmd["● order()<br/>━━━━━━━━━━<br/>app.py entry point<br/>checks CLAUDECODE env"]
        RecipeNone{"recipe=None?"}
        Picker["Interactive picker<br/>━━━━━━━━━━<br/>list_recipes()<br/>timed_prompt()"]
        ResolveInput["● _resolve_recipe_input()<br/>━━━━━━━━━━<br/>digit / name / open-kitchen<br/>returns RecipeInfo | sentinel"]
        OpenKitchenPath["_build_open_kitchen_prompt()<br/>━━━━━━━━━━<br/>no recipe — kitchen only"]
        FindRecipe["find_recipe_by_name()<br/>━━━━━━━━━━<br/>project + bundled lookup"]
        LoadValidate["load_recipe() + validate_recipe()<br/>━━━━━━━━━━<br/>YAML parse + schema validation"]
        RecipeValid{"errors?"}
    end

    subgraph Phase2 ["Phase 2 — Subset & Pack Gates"]
        direction TB
        SubsetCheck{"disabled subsets<br/>needed?"}
        SubsetChoice["timed_prompt: enable<br/>temporarily / permanently<br/>/ cancel"]
        PackCheck{"default-disabled packs<br/>needed?"}
        PackChoice["timed_prompt: enable<br/>temporarily / permanently<br/>/ cancel"]
    end

    subgraph Phase3 ["Phase 3 — Ingredient Pre-Render"]
        direction TB
        GetIngTable["● _get_ingredients_table()<br/>━━━━━━━━━━<br/>cli/_prompts.py<br/>uses load_and_validate (with sub-recipe<br/>composition, not load_recipe)"]
        LoadAndValidate["load_and_validate()<br/>━━━━━━━━━━<br/>recipe.io — full composition<br/>expands sub-recipes"]
        ResolveDefaults["resolve_ingredient_defaults(cwd)<br/>━━━━━━━━━━<br/>config/ingredient_defaults.py"]
        IngTableResult["ingredients_table: str | None<br/>━━━━━━━━━━<br/>pre-rendered ASCII table<br/>or None if no ingredients"]
    end

    subgraph Phase4 ["Phase 4 — Preview & Confirmation"]
        direction TB
        ShowPreview["show_cook_preview()<br/>━━━━━━━━━━<br/>flow diagram + ingredients table<br/>printed to terminal"]
        PermWarn["permissions_warning()<br/>━━━━━━━━━━<br/>displays tool restriction notice"]
        ConfirmPrompt{"User confirms?<br/>timed_prompt 120s"}
    end

    subgraph Phase5 ["Phase 5 — System Prompt Construction"]
        direction TB
        BuildPrompt["● _build_orchestrator_prompt()<br/>━━━━━━━━━━<br/>cli/_prompts.py<br/>recipe_name + mcp_prefix + ingredients_table"]
        IngCheck{"ingredients_table<br/>present?"}
        IngSection["Inject _ing_section<br/>━━━━━━━━━━<br/>'RECIPE INGREDIENTS — USE THESE EXACT NAMES'<br/>+ table + usage rules"]
        SousChef["Inject sous_chef_content<br/>━━━━━━━━━━<br/>pkg_root/skills/sous-chef/SKILL.md"]
        SystemPrompt["system_prompt: str<br/>━━━━━━━━━━<br/>full orchestrator prompt<br/>with or without ingredients"]
    end

    subgraph Phase6 ["Phase 6 — Session Launch"]
        direction TB
        LaunchSession["_launch_cook_session()<br/>━━━━━━━━━━<br/>initial_message = greeting<br/>--append-system-prompt injected"]
        BuildCmd["build_interactive_cmd()<br/>━━━━━━━━━━<br/>execution/commands.py<br/>env_extras passed for subset/pack overrides"]
        SubprocessRun["subprocess.run(claude)<br/>━━━━━━━━━━<br/>--allowedTools AskUserQuestion<br/>--append-system-prompt"]
    end

    %% FLOW %%
    START --> OrderCmd
    OrderCmd --> RecipeNone
    RecipeNone -->|"yes"| Picker
    Picker --> ResolveInput
    ResolveInput -->|"open-kitchen sentinel"| OpenKitchenPath
    OpenKitchenPath --> LaunchSession
    ResolveInput -->|"None — invalid input"| ABORT
    ResolveInput -->|"RecipeInfo"| FindRecipe
    RecipeNone -->|"no — recipe arg given"| FindRecipe
    FindRecipe -->|"not found"| ABORT
    FindRecipe --> LoadValidate
    LoadValidate --> RecipeValid
    RecipeValid -->|"yes"| ABORT
    RecipeValid -->|"no"| SubsetCheck

    SubsetCheck -->|"yes"| SubsetChoice
    SubsetChoice -->|"cancel"| ABORT
    SubsetChoice -->|"temporary / permanent"| PackCheck
    SubsetCheck -->|"no"| PackCheck
    PackCheck -->|"yes"| PackChoice
    PackChoice -->|"cancel"| ABORT
    PackChoice -->|"temporary / permanent"| GetIngTable
    PackCheck -->|"no"| GetIngTable

    GetIngTable --> LoadAndValidate
    GetIngTable --> ResolveDefaults
    LoadAndValidate --> IngTableResult
    ResolveDefaults --> IngTableResult

    IngTableResult --> ShowPreview
    ShowPreview --> PermWarn
    PermWarn --> ConfirmPrompt
    ConfirmPrompt -->|"n / no"| ABORT
    ConfirmPrompt -->|"Enter / affirmative"| BuildPrompt

    BuildPrompt --> IngCheck
    IngCheck -->|"yes"| IngSection
    IngCheck -->|"no"| SousChef
    IngSection --> SousChef
    SousChef --> SystemPrompt

    SystemPrompt --> LaunchSession
    LaunchSession --> BuildCmd
    BuildCmd --> SubprocessRun
    SubprocessRun --> COMPLETE

    %% CLASS ASSIGNMENTS %%
    class START,COMPLETE,ABORT terminal;
    class OrderCmd,ResolveInput handler;
    class OpenKitchenPath,LoadValidate,FindRecipe,Picker phase;
    class RecipeNone,RecipeValid,SubsetCheck,PackCheck,IngCheck,ConfirmPrompt stateNode;
    class SubsetChoice,PackChoice handler;
    class GetIngTable,BuildPrompt newComponent;
    class LoadAndValidate,ResolveDefaults,IngTableResult handler;
    class ShowPreview,PermWarn phase;
    class IngSection,SousChef,SystemPrompt output;
    class LaunchSession,BuildCmd,SubprocessRun handler;
```

Closes #972

## Implementation Plan

Plan file: `.autoskillit/temp/make-plan/inject_ingredients_into_orchestrator_prompt_plan_2026-04-15_180951.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 165 | 12.3k | 765.1k | 124.3k | 1 | 3m 58s |
| verify | 238 | 20.5k | 1.7M | 70.8k | 1 | 6m 18s |
| implement | 270 | 14.8k | 1.7M | 58.2k | 1 | 4m 7s |
| fix | 410 | 56.9k | 4.6M | 126.1k | 1 | 20m 22s |
| prepare_pr | 60 | 5.0k | 175.2k | 23.5k | 1 | 1m 27s |
| run_arch_lenses | 2.6k | 20.5k | 660.5k | 137.3k | 3 | 7m 12s |
| compose_pr | 59 | 7.6k | 191.2k | 30.0k | 1 | 1m 48s |
| **Total** | 3.8k | 137.7k | 9.8M | 570.1k | | 45m 15s |