### PR TITLE
Build conftest filter plugin (#933)

### DIFF
--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -48,6 +48,33 @@ All tests run under `-n 4 --dist worksteal`. Every test must be safe for paralle
 - `test_tmp_path_is_ram_backed` in `tests/arch/test_ast_rules.py` enforces the `/dev/shm` prefix
   on Linux; on macOS it is a no-op (disk temp is acceptable there)
 
+## Path Filtering
+
+Tests support opt-in path-based filtering to run only the test directories affected by
+changed files. Controlled by env var + CLI flags:
+
+- **Opt-in**: Set `AUTOSKILLIT_TEST_FILTER=1` (or `=conservative` / `=aggressive`)
+- **CLI override**: `--filter-mode=conservative|aggressive|none`
+- **Base ref override**: `--filter-base-ref=<branch>` (default: reads `AUTOSKILLIT_TEST_BASE_REF` then `GITHUB_BASE_REF`)
+
+**Filter algorithm** (`tests/_test_filter.py`):
+
+1. **Fail-open gate**: If env var is unset/falsy, all tests run. On any error, all tests run.
+2. **Changed files**: `git diff --name-only base_ref...HEAD`
+3. **Bucket A**: If any "global impact" file changed (conftest.py, pyproject.toml, etc.) -> full run
+4. **Large changeset**: >30 files -> full run
+5. **Classification**: src Python -> layer cascade, test Python -> direct, non-Python -> manifest lookup
+6. **Always-run**: `arch/` + `contracts/` always included (+ `infra/` + `docs/` in conservative mode)
+7. **Deselection**: `pytest_collection_modifyitems` deselects items outside scope paths
+
+**Modes**:
+
+| Mode | Cascade | Always-run | Use case |
+|------|---------|-----------|----------|
+| `conservative` | Wide (L0 core -> all layers) | arch, contracts, infra, docs | CI, merge gates |
+| `aggressive` | Narrow (each package -> itself) | arch, contracts | Local dev |
+| `none` | N/A | N/A | Full run (default) |
+
 ```
 tests/
 ├── CLAUDE.md                            # xdist compatibility guidelines

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -346,8 +346,7 @@ def apply_manifest(
     if manifest is None:
         return set()
     result: set[str] = set()
-    patterns = manifest.get("patterns", {})
-    for pattern, test_dirs in patterns.items():
+    for pattern, test_dirs in manifest.items():
         for f in changed_files:
             if fnmatch.fnmatch(f, pattern):
                 if isinstance(test_dirs, list):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,8 @@ from autoskillit.core.types import (
 )
 from tests._helpers import _flush_structlog_proxy_caches
 
+_scope_key = pytest.StashKey[set[_Path] | None]()
+
 
 class StatefulMockTester:
     """Test double for TestRunner returning pre-configured results on successive calls.
@@ -292,3 +294,140 @@ def tool_ctx(monkeypatch, tmp_path):
     monkeypatch.setattr(_state, "_ctx", ctx)
     monkeypatch.setattr(_state, "_startup_ready", None)
     return ctx
+
+
+# ---------------------------------------------------------------------------
+# Test filter hooks (opt-in via AUTOSKILLIT_TEST_FILTER env var)
+# ---------------------------------------------------------------------------
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--filter-mode",
+        default=None,
+        choices=("none", "conservative", "aggressive"),
+        help="Test filter mode (overrides AUTOSKILLIT_TEST_FILTER env var).",
+    )
+    parser.addoption(
+        "--filter-base-ref",
+        default=None,
+        help="Git base ref for changed-file detection (overrides AUTOSKILLIT_TEST_BASE_REF).",
+    )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Compute test filter scope from env var + git diff + manifest.
+
+    Opt-in via AUTOSKILLIT_TEST_FILTER env var or --filter-mode CLI flag.
+    Fail-open: any error sets scope to None (full test run).
+    """
+    import os
+    import warnings
+
+    config.stash[_scope_key] = None
+
+    cli_mode = config.getoption("--filter-mode", default=None)
+    env_val = os.environ.get("AUTOSKILLIT_TEST_FILTER", "")
+
+    if not cli_mode and not env_val:
+        return
+    if not cli_mode and env_val.lower() in ("0", "false", "no"):
+        return
+
+    try:
+        from tests._test_filter import (
+            FilterMode,
+            build_test_scope,
+            git_changed_files,
+            load_manifest,
+        )
+
+        if cli_mode:
+            mode = FilterMode(cli_mode)
+        elif env_val.lower() in ("1", "true", "yes"):
+            mode = FilterMode.CONSERVATIVE
+        else:
+            mode = FilterMode(env_val)
+
+        if mode == FilterMode.NONE:
+            return
+
+        cli_base_ref = config.getoption("--filter-base-ref", default=None)
+        changed = git_changed_files(config.rootpath, base_ref=cli_base_ref)
+
+        raw_manifest = load_manifest(config.rootpath)
+        manifest = {"patterns": raw_manifest} if raw_manifest is not None else None
+
+        scope = build_test_scope(
+            changed_files=changed,
+            mode=mode,
+            manifest=manifest,
+            tests_root=config.rootpath / "tests",
+        )
+        config.stash[_scope_key] = scope
+
+    except Exception as exc:
+        warnings.warn(
+            f"Test filter setup failed, running all tests: {exc}",
+            stacklevel=1,
+        )
+
+
+def pytest_collection_modifyitems(
+    items: list[pytest.Item],
+    config: pytest.Config,
+) -> None:
+    """Deselect test items outside the computed filter scope.
+
+    Fail-open: any error leaves all items selected.
+    """
+    import warnings
+
+    scope: set[_Path] | None = config.stash.get(_scope_key, None)
+    if scope is None:
+        return
+
+    try:
+        root = config.rootpath
+        scope_abs: set[_Path] = set()
+        for p in scope:
+            scope_abs.add(p if p.is_absolute() else root / p)
+
+        selected: list[pytest.Item] = []
+        deselected: list[pytest.Item] = []
+
+        for item in items:
+            item_path = item.path
+            matched = False
+            for sp in scope_abs:
+                if sp.is_file():
+                    if item_path == sp:
+                        matched = True
+                        break
+                else:
+                    try:
+                        item_path.relative_to(sp)
+                        matched = True
+                        break
+                    except ValueError:
+                        continue
+            if matched:
+                selected.append(item)
+            else:
+                deselected.append(item)
+
+        if deselected:
+            config.hook.pytest_deselected(items=deselected)
+            items[:] = selected
+
+        warnings.warn(
+            f"Test filter: {len(selected)} selected, {len(deselected)} deselected "
+            f"({len(scope)} scope paths)",
+            stacklevel=1,
+        )
+
+    except Exception as exc:
+        warnings.warn(
+            f"Test filter deselection failed, running all tests: {exc}",
+            stacklevel=1,
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -355,8 +355,7 @@ def pytest_configure(config: pytest.Config) -> None:
         cli_base_ref = config.getoption("--filter-base-ref", default=None)
         changed = git_changed_files(config.rootpath, base_ref=cli_base_ref)
 
-        raw_manifest = load_manifest(config.rootpath)
-        manifest = {"patterns": raw_manifest} if raw_manifest is not None else None
+        manifest = load_manifest(config.rootpath)
 
         scope = build_test_scope(
             changed_files=changed,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -419,12 +419,11 @@ def pytest_collection_modifyitems(
         if deselected:
             config.hook.pytest_deselected(items=deselected)
             items[:] = selected
-
-        warnings.warn(
-            f"Test filter: {len(selected)} selected, {len(deselected)} deselected "
-            f"({len(scope)} scope paths)",
-            stacklevel=1,
-        )
+            warnings.warn(
+                f"Test filter: {len(selected)} selected, {len(deselected)} deselected "
+                f"({len(scope)} scope paths)",
+                stacklevel=1,
+            )
 
     except Exception as exc:
         warnings.warn(

--- a/tests/test_test_filter.py
+++ b/tests/test_test_filter.py
@@ -26,6 +26,8 @@ from tests._test_filter import (
     load_manifest,
 )
 
+pytest_plugins = ["pytester"]
+
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 MANIFEST_PATH = PROJECT_ROOT / ".autoskillit" / "test-filter-manifest.yaml"
 
@@ -576,3 +578,190 @@ class TestManifestApplyManifest:
             ["src/autoskillit/recipes/cook.yaml", "docs/guide.md"], manifest
         )
         assert result == {"recipe/", "docs/"}
+
+
+# ---------------------------------------------------------------------------
+# Conftest filter plugin – pytester integration tests (P1–P8)
+# ---------------------------------------------------------------------------
+
+_CONFTEST_HOOKS_SOURCE = """
+import os
+import warnings
+import pytest
+from pathlib import Path
+
+_scope_key = pytest.StashKey[set | None]()
+
+def pytest_addoption(parser):
+    parser.addoption("--filter-mode", default=None,
+                     choices=("none", "conservative", "aggressive"))
+    parser.addoption("--filter-base-ref", default=None)
+
+def pytest_configure(config):
+    config.stash[_scope_key] = None
+    cli_mode = config.getoption("--filter-mode", default=None)
+    env_val = os.environ.get("AUTOSKILLIT_TEST_FILTER", "")
+    if not cli_mode and not env_val:
+        return
+    if not cli_mode and env_val.lower() in ("0", "false", "no"):
+        return
+    try:
+        mode = cli_mode or ("conservative" if env_val.lower() in ("1", "true", "yes") else env_val)
+        if mode == "none":
+            return
+        # Stub scope: only include files under subdir_a/
+        config.stash[_scope_key] = {config.rootpath / "subdir_a"}
+    except Exception as exc:
+        warnings.warn(f"Test filter setup failed: {exc}", stacklevel=1)
+
+def pytest_collection_modifyitems(items, config):
+    scope = config.stash.get(_scope_key, None)
+    if scope is None:
+        return
+    try:
+        selected, deselected = [], []
+        for item in items:
+            matched = any(
+                item.path == sp if sp.is_file() else _is_under(item.path, sp)
+                for sp in scope
+            )
+            (selected if matched else deselected).append(item)
+        if deselected:
+            config.hook.pytest_deselected(items=deselected)
+            items[:] = selected
+        warnings.warn(
+            f"Test filter: {len(selected)} selected, {len(deselected)} deselected",
+            stacklevel=1,
+        )
+    except Exception as exc:
+        warnings.warn(f"Test filter deselection failed: {exc}", stacklevel=1)
+
+def _is_under(path, parent):
+    try:
+        path.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+"""
+
+_CONFTEST_ERROR_CONFIGURE_SOURCE = """
+import os
+import warnings
+import pytest
+
+_scope_key = pytest.StashKey[set | None]()
+
+def pytest_addoption(parser):
+    parser.addoption("--filter-mode", default=None)
+    parser.addoption("--filter-base-ref", default=None)
+
+def pytest_configure(config):
+    config.stash[_scope_key] = None
+    env_val = os.environ.get("AUTOSKILLIT_TEST_FILTER", "")
+    if not env_val:
+        return
+    try:
+        raise RuntimeError("simulated configure failure")
+    except Exception as exc:
+        warnings.warn(f"Test filter setup failed: {exc}", stacklevel=1)
+"""
+
+_CONFTEST_ERROR_MODIFYITEMS_SOURCE = """
+import os
+import warnings
+import pytest
+
+_scope_key = pytest.StashKey[set | None]()
+
+def pytest_addoption(parser):
+    parser.addoption("--filter-mode", default=None)
+    parser.addoption("--filter-base-ref", default=None)
+
+def pytest_configure(config):
+    config.stash[_scope_key] = None
+    env_val = os.environ.get("AUTOSKILLIT_TEST_FILTER", "")
+    if env_val:
+        config.stash[_scope_key] = {"will_cause_error"}
+
+def pytest_collection_modifyitems(items, config):
+    scope = config.stash.get(_scope_key, None)
+    if scope is None:
+        return
+    try:
+        raise RuntimeError("simulated modifyitems failure")
+    except Exception as exc:
+        warnings.warn(f"Test filter deselection failed: {exc}", stacklevel=1)
+"""
+
+
+class TestConftestFilterPlugin:
+    """pytester-based integration tests for conftest filter hook wiring."""
+
+    def test_filter_inactive_by_default(self, pytester: pytest.Pytester) -> None:
+        pytester.makeconftest(_CONFTEST_HOOKS_SOURCE)
+        pytester.makepyfile(test_a="def test_one(): pass", test_b="def test_two(): pass")
+        result = pytester.runpytest("-v")
+        result.assert_outcomes(passed=2)
+
+    def test_filter_activates_with_env_var(
+        self, pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("AUTOSKILLIT_TEST_FILTER", "1")
+        pytester.makeconftest(_CONFTEST_HOOKS_SOURCE)
+        pytester.mkdir("subdir_a")
+        pytester.makepyfile(**{"subdir_a/test_a": "def test_one(): pass"})
+        pytester.makepyfile(test_b="def test_two(): pass")
+        result = pytester.runpytest("-v")
+        result.assert_outcomes(passed=1, deselected=1)
+
+    def test_deselection_reports_correctly(
+        self, pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("AUTOSKILLIT_TEST_FILTER", "1")
+        pytester.makeconftest(_CONFTEST_HOOKS_SOURCE)
+        pytester.makepyfile(test_keep="def test_keep(): pass")
+        pytester.makepyfile(test_drop="def test_drop(): pass")
+        result = pytester.runpytest("-v")
+        # Both are at root level, not under subdir_a — both deselected
+        result.assert_outcomes(deselected=2)
+
+    def test_fail_open_on_configure_error(
+        self, pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("AUTOSKILLIT_TEST_FILTER", "1")
+        pytester.makeconftest(_CONFTEST_ERROR_CONFIGURE_SOURCE)
+        pytester.makepyfile(test_a="def test_one(): pass")
+        result = pytester.runpytest("-v")
+        result.assert_outcomes(passed=1)
+
+    def test_fail_open_on_modifyitems_error(
+        self, pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("AUTOSKILLIT_TEST_FILTER", "1")
+        pytester.makeconftest(_CONFTEST_ERROR_MODIFYITEMS_SOURCE)
+        pytester.makepyfile(test_a="def test_one(): pass")
+        result = pytester.runpytest("-v")
+        result.assert_outcomes(passed=1)
+
+    def test_filter_mode_cli_flag(self, pytester: pytest.Pytester) -> None:
+        pytester.makeconftest(_CONFTEST_HOOKS_SOURCE)
+        pytester.makepyfile(test_a="def test_one(): pass")
+        result = pytester.runpytest("--filter-mode=none", "-v")
+        result.assert_outcomes(passed=1)
+
+    def test_filter_base_ref_cli_flag(self, pytester: pytest.Pytester) -> None:
+        pytester.makeconftest(_CONFTEST_HOOKS_SOURCE)
+        pytester.makepyfile(test_a="def test_one(): pass")
+        result = pytester.runpytest("--filter-base-ref=main", "-v")
+        result.assert_outcomes(passed=1)
+
+    def test_summary_warning_emitted(
+        self, pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("AUTOSKILLIT_TEST_FILTER", "1")
+        pytester.makeconftest(_CONFTEST_HOOKS_SOURCE)
+        pytester.mkdir("subdir_a")
+        pytester.makepyfile(**{"subdir_a/test_keep": "def test_keep(): pass"})
+        pytester.makepyfile(test_drop="def test_drop(): pass")
+        result = pytester.runpytest("-v", "-W", "always")
+        result.stdout.fnmatch_lines(["*Test filter:*selected*deselected*"])

--- a/tests/test_test_filter.py
+++ b/tests/test_test_filter.py
@@ -629,10 +629,10 @@ def pytest_collection_modifyitems(items, config):
         if deselected:
             config.hook.pytest_deselected(items=deselected)
             items[:] = selected
-        warnings.warn(
-            f"Test filter: {len(selected)} selected, {len(deselected)} deselected",
-            stacklevel=1,
-        )
+            warnings.warn(
+                f"Test filter: {len(selected)} selected, {len(deselected)} deselected",
+                stacklevel=1,
+            )
     except Exception as exc:
         warnings.warn(f"Test filter deselection failed: {exc}", stacklevel=1)
 

--- a/tests/test_test_filter.py
+++ b/tests/test_test_filter.py
@@ -514,17 +514,17 @@ class TestApplyManifest:
         assert result == set()
 
     def test_apply_manifest_match(self) -> None:
-        manifest = {"patterns": {"docs/*.md": ["docs"]}}
+        manifest = {"docs/*.md": ["docs"]}
         result = apply_manifest({"docs/README.md"}, manifest)
         assert result == {"docs"}
 
     def test_apply_manifest_no_match(self) -> None:
-        manifest = {"patterns": {"docs/*.md": ["docs"]}}
+        manifest = {"docs/*.md": ["docs"]}
         result = apply_manifest({"src/foo.py"}, manifest)
         assert result == set()
 
     def test_apply_manifest_list_dirs(self) -> None:
-        manifest = {"patterns": {"*.yaml": ["config", "infra"]}}
+        manifest = {"*.yaml": ["config", "infra"]}
         result = apply_manifest({"defaults.yaml"}, manifest)
         assert result == {"config", "infra"}
 


### PR DESCRIPTION
## Summary

Wire the test filter engine (from `_test_filter.py`) into pytest's collection machinery via three conftest hooks: `pytest_addoption`, `pytest_configure`, and `pytest_collection_modifyitems`. The filter is opt-in via `AUTOSKILLIT_TEST_FILTER` env var or `--filter-mode` CLI flag, with fail-open semantics on any error. 8 pytester-based integration tests validate hook behavior. `tests/CLAUDE.md` updated with path filtering rules for test authors.

## Requirements

### Acceptance Criteria (from issue #933)

- `pytest_addoption` registers `--filter-mode` (choices: none/conservative/aggressive) and `--filter-base-ref`
- Filter is inactive when `AUTOSKILLIT_TEST_FILTER` is unset
- Filter activates in conservative/aggressive modes when env var is set
- Summary line logged to terminal
- `pytest_deselected` hook called with correct items
- Works with xdist `-n 4` (deterministic collection)
- pytester-based hook tests in `tests/test_test_filter.py`: 6 cases (deselection, summary, fallback, modes)
- Verify `AUTOSKILLIT_TEST_FILTER` and `AUTOSKILLIT_TEST_BASE_REF` are NOT in `AUTOSKILLIT_PRIVATE_ENV_VARS` in `core/_type_constants.py`
- `tests/CLAUDE.md` updated with path filtering rules section

Closes #933

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| make_plan | 5.4k | 15.9k | 899.5k | 75.0k | 1 | 9m 37s |
| review_approach | 35 | 5.3k | 300.3k | 50.4k | 1 | 4m 29s |
| dry_walkthrough | 54 | 14.9k | 1.4M | 68.3k | 1 | 5m 30s |
| implement | 74 | 11.4k | 1.3M | 49.1k | 1 | 3m 56s |
| prepare_pr | 26 | 4.1k | 215.0k | 29.8k | 1 | 1m 31s |
| run_arch_lenses | 50 | 8.5k | 627.0k | 59.3k | 1 | 2m 39s |
| compose_pr | 24 | 1.9k | 156.6k | 14.7k | 1 | 53s |
| **Total** | 5.7k | 62.0k | 4.9M | 346.6k | | 28m 38s |