### PR TITLE
CancelledError Shielded Cleanup in run_headless_core

### DIFF
--- a/src/autoskillit/execution/headless.py
+++ b/src/autoskillit/execution/headless.py
@@ -20,6 +20,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, assert_never
 
+import anyio
 import structlog
 
 from autoskillit.core import (
@@ -1087,6 +1088,33 @@ async def run_headless_core(
                 skill_command=original_skill_command,
                 order_id=order_id,
             )
+        except BaseException:
+            logger.warning("run_headless_core cancelled", exc_info=True)
+            _exc_text = traceback.format_exc()
+            _log_dir = ctx.config.linux_tracing.log_dir
+            try:
+                from autoskillit.execution import flush_session_log
+
+                with anyio.CancelScope(shield=True):
+                    flush_session_log(
+                        log_dir=_log_dir,
+                        cwd=str(cwd),
+                        kitchen_id=kitchen_id,
+                        order_id=order_id,
+                        session_id="",
+                        pid=0,
+                        skill_command=original_skill_command,
+                        success=False,
+                        subtype="cancelled",
+                        exit_code=-1,
+                        start_ts=_start_ts,
+                        proc_snapshots=None,
+                        termination_reason="CANCELLED",
+                        exception_text=_exc_text,
+                    )
+            except Exception:
+                logger.debug("flush_session_log during cancel failed", exc_info=True)
+            raise
         if _result is None:
             return SkillResult.crashed(
                 exception=RuntimeError("runner() did not return a result"),

--- a/src/autoskillit/server/tools_execution.py
+++ b/src/autoskillit/server/tools_execution.py
@@ -373,3 +373,6 @@ async def run_skill(
             skill_command=skill_command,
             order_id=order_id,
         ).to_json()
+    except BaseException:
+        logger.warning("run_skill cancelled", exc_info=True)
+        raise

--- a/tests/execution/test_headless.py
+++ b/tests/execution/test_headless.py
@@ -2200,6 +2200,83 @@ class TestCrashSessionLog:
             assert result.success is False
 
 
+class TestCancelledSessionLog:
+    """flush_session_log is called with success=False when runner raises CancelledError."""
+
+    @pytest.mark.anyio
+    async def test_run_headless_core_cancellation_still_flushes_session_log(
+        self, monkeypatch, tool_ctx, tmp_path
+    ):
+        """flush_session_log is called with CANCELLED termination_reason on cancellation."""
+        import anyio
+
+        from autoskillit.execution.headless import run_headless_core
+
+        flushed: list[dict] = []
+
+        def fake_flush(**kwargs: object) -> None:
+            flushed.append(dict(kwargs))
+
+        monkeypatch.setattr("autoskillit.execution.flush_session_log", fake_flush)
+
+        async def cancelled_runner(*args: object, **kwargs: object) -> None:
+            raise anyio.get_cancelled_exc_class()()
+
+        tool_ctx.runner = cancelled_runner  # type: ignore[assignment]
+
+        with pytest.raises(anyio.get_cancelled_exc_class()):
+            await run_headless_core("/investigate test", cwd=str(tmp_path), ctx=tool_ctx)
+
+        cancel_calls = [f for f in flushed if f.get("termination_reason") == "CANCELLED"]
+        assert len(cancel_calls) == 1
+        assert cancel_calls[0]["success"] is False
+        assert cancel_calls[0]["subtype"] == "cancelled"
+        assert cancel_calls[0]["exit_code"] == -1
+        assert cancel_calls[0]["session_id"] == ""
+        assert cancel_calls[0]["pid"] == 0
+
+    @pytest.mark.anyio
+    async def test_run_headless_core_cancelled_error_propagates_after_flush(
+        self, monkeypatch, tool_ctx, tmp_path
+    ):
+        """CancelledError re-raises after flush — never swallowed."""
+        import anyio
+
+        from autoskillit.execution.headless import run_headless_core
+
+        monkeypatch.setattr("autoskillit.execution.flush_session_log", lambda **kw: None)
+
+        async def cancelled_runner(*args: object, **kwargs: object) -> None:
+            raise anyio.get_cancelled_exc_class()()
+
+        tool_ctx.runner = cancelled_runner  # type: ignore[assignment]
+
+        with pytest.raises(anyio.get_cancelled_exc_class()):
+            await run_headless_core("/investigate test", cwd=str(tmp_path), ctx=tool_ctx)
+
+    @pytest.mark.anyio
+    async def test_run_headless_core_flush_failure_does_not_suppress_cancellation(
+        self, monkeypatch, tool_ctx, tmp_path
+    ):
+        """Even if flush_session_log raises, cancellation still propagates."""
+        import anyio
+
+        from autoskillit.execution.headless import run_headless_core
+
+        def exploding_flush(**kwargs: object) -> None:
+            raise OSError("log disk full")
+
+        monkeypatch.setattr("autoskillit.execution.flush_session_log", exploding_flush)
+
+        async def cancelled_runner(*args: object, **kwargs: object) -> None:
+            raise anyio.get_cancelled_exc_class()()
+
+        tool_ctx.runner = cancelled_runner  # type: ignore[assignment]
+
+        with pytest.raises(anyio.get_cancelled_exc_class()):
+            await run_headless_core("/investigate test", cwd=str(tmp_path), ctx=tool_ctx)
+
+
 class TestRetryBudgetEnforcement:
     """_build_skill_result enforces max_consecutive_retries budget."""
 


### PR DESCRIPTION
## Summary

Add a `BaseException` handler to `run_headless_core` (in `headless.py`) so that when a `CancelledError` arrives, `flush_session_log` still executes under an `anyio.CancelScope(shield=True)` before re-raising. This mirrors the pattern already established by PR B in `process.py`. An optional observability `except BaseException` is also added to `run_skill` in `tools_execution.py`.

Closes #964

## Implementation Plan

Plan file: `.autoskillit/temp/make-plan/prc_cancelled_error_shielded_cleanup_plan_2026-04-15_192855.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| make_plan | 77 | 10.5k | 1.1M | 51.0k | 1 | 7m 56s |
| review_approach | 30 | 5.0k | 362.7k | 29.8k | 1 | 3m 30s |
| dry_walkthrough | 48 | 8.8k | 870.3k | 47.2k | 1 | 4m 7s |
| implement | 66 | 10.5k | 1.1M | 38.2k | 1 | 3m 53s |
| prepare_pr | 33 | 3.9k | 144.1k | 23.7k | 1 | 1m 17s |
| run_arch_lenses | 47 | 8.7k | 903.1k | 63.3k | 1 | 4m 3s |
| compose_pr | 23 | 2.6k | 133.0k | 15.3k | 1 | 51s |
| **Total** | 324 | 50.2k | 4.6M | 268.4k | | 25m 38s |