### PR TITLE
Extend TestCheckConfig and DefaultTestRunner for Filtering

### DIFF
--- a/src/autoskillit/config/defaults.yaml
+++ b/src/autoskillit/config/defaults.yaml
@@ -11,6 +11,8 @@ test_check:
     - task
     - test-check
   timeout: 600
+  filter_mode: null
+  base_ref: null
 
 classify_fix:
   path_prefixes: []

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -46,6 +46,8 @@ _METADATA_KEYS: frozenset[str] = frozenset({"version"})
 class TestCheckConfig:
     command: list[str] = field(default_factory=lambda: ["task", "test-check"])
     timeout: int = 600
+    filter_mode: str | None = None
+    base_ref: str | None = None
 
 
 @dataclass
@@ -383,6 +385,8 @@ class AutomationConfig:
             test_check=TestCheckConfig(
                 command=list(val(tc, "command", _tc["command"])),
                 timeout=int(val(tc, "timeout", _tc["timeout"])),
+                filter_mode=val(tc, "filter_mode", _tc["filter_mode"]) or None,
+                base_ref=val(tc, "base_ref", _tc["base_ref"]) or None,
             ),
             classify_fix=ClassifyFixConfig(
                 path_prefixes=list(val(cf, "path_prefixes", _cf["path_prefixes"])),

--- a/src/autoskillit/execution/testing.py
+++ b/src/autoskillit/execution/testing.py
@@ -90,8 +90,11 @@ async def _resolve_base_ref(config_base_ref: str | None, cwd: Path) -> str | Non
         try:
             await asyncio.wait_for(proc.wait(), timeout=15.0)
         except TimeoutError:
-            proc.kill()
-            await proc.wait()
+            try:
+                proc.kill()
+                await proc.wait()
+            except OSError:
+                pass
             return None
         if proc.returncode == 0:
             assert proc.stdout is not None

--- a/src/autoskillit/execution/testing.py
+++ b/src/autoskillit/execution/testing.py
@@ -7,6 +7,7 @@ _logging.
 
 from __future__ import annotations
 
+import asyncio
 import os
 import re
 from pathlib import Path
@@ -30,6 +31,78 @@ def build_sanitized_env() -> dict[str, str]:
     subprocess runner get full env inheritance minus the internal vars.
     """
     return {k: v for k, v in os.environ.items() if k not in AUTOSKILLIT_PRIVATE_ENV_VARS}
+
+
+def _read_sidecar_base_branch(cwd: Path) -> str | None:
+    """Read base-branch from worktree sidecar if cwd is a linked worktree.
+
+    Worktree sidecars are written by implement-worktree skills at
+    ``<project_root>/.autoskillit/temp/worktrees/<wt_name>/base-branch``.
+    Returns None if cwd is not a worktree or no sidecar exists.
+    """
+    git_path = cwd / ".git"
+    if not git_path.is_file():
+        return None
+    try:
+        content = git_path.read_text().strip()
+        if not content.startswith("gitdir:"):
+            return None
+        gitdir = Path(content.split(":", 1)[1].strip())
+        if not gitdir.is_absolute():
+            gitdir = (cwd / gitdir).resolve()
+        main_git = gitdir.parent.parent
+        project_root = main_git.parent
+        wt_name = cwd.name
+        sidecar = project_root / ".autoskillit" / "temp" / "worktrees" / wt_name / "base-branch"
+        if sidecar.is_file():
+            return sidecar.read_text().strip() or None
+    except (OSError, ValueError):
+        pass
+    return None
+
+
+async def _resolve_base_ref(config_base_ref: str | None, cwd: Path) -> str | None:
+    """Resolve the base ref for test filtering.
+
+    Resolution chain (first non-None wins):
+    1. Config override (explicit base_ref in TestCheckConfig)
+    2. Worktree sidecar (base-branch file written by implement-worktree skills)
+    3. Git upstream tracking ref (``@{upstream}`` of current branch)
+    4. None (no base ref available)
+    """
+    if config_base_ref:
+        return config_base_ref
+
+    sidecar_ref = _read_sidecar_base_branch(cwd)
+    if sidecar_ref:
+        return sidecar_ref
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "git",
+            "rev-parse",
+            "--abbrev-ref",
+            "@{upstream}",
+            cwd=cwd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=15.0)
+        except TimeoutError:
+            proc.kill()
+            await proc.wait()
+            return None
+        if proc.returncode == 0:
+            assert proc.stdout is not None
+            raw = await proc.stdout.read()
+            ref = raw.decode().strip()
+            if ref:
+                return ref
+    except OSError:
+        pass
+
+    return None
 
 
 _OUTCOME_PATTERN = re.compile(
@@ -116,6 +189,15 @@ class DefaultTestRunner:
         command = self._config.test_check.command
         timeout = float(self._config.test_check.timeout)
         env = build_sanitized_env()
+
+        filter_mode = self._config.test_check.filter_mode
+        if filter_mode:
+            env["AUTOSKILLIT_TEST_FILTER"] = filter_mode
+
+        base_ref = await _resolve_base_ref(self._config.test_check.base_ref, cwd)
+        if base_ref:
+            env["AUTOSKILLIT_TEST_BASE_REF"] = base_ref
+
         result = await self._runner(command, cwd=cwd, timeout=timeout, env=env)
         passed = check_test_passed(result.returncode, result.stdout, result.stderr)
         return TestResult(passed=passed, stdout=result.stdout, stderr=result.stderr)

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -75,3 +75,18 @@ def make_skills_config(**overrides):
     from autoskillit.config.settings import SkillsConfig
 
     return SkillsConfig(**overrides)
+
+
+def make_test_check_config(**overrides):
+    """Build TestCheckConfig for tests without direct config imports."""
+    from autoskillit.config.settings import TestCheckConfig
+
+    return TestCheckConfig(**overrides)
+
+
+def make_dynaconf_and_automation_config():
+    """Return (_make_dynaconf, AutomationConfig) for integration tests."""
+    from autoskillit.config import AutomationConfig
+    from autoskillit.config.settings import _make_dynaconf
+
+    return _make_dynaconf, AutomationConfig

--- a/tests/execution/test_testing.py
+++ b/tests/execution/test_testing.py
@@ -434,6 +434,16 @@ async def test_resolve_base_ref_git_upstream_fallback(tmp_path):
     repo.mkdir()
     subprocess.run(["git", "init", str(repo)], check=True, capture_output=True)
     subprocess.run(
+        ["git", "-C", str(repo), "config", "user.email", "test@test.com"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.name", "test"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
         ["git", "-C", str(repo), "commit", "--allow-empty", "-m", "init"],
         check=True,
         capture_output=True,

--- a/tests/execution/test_testing.py
+++ b/tests/execution/test_testing.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from autoskillit.config.settings import TestCheckConfig
 from autoskillit.core.types import (
     AUTOSKILLIT_PRIVATE_ENV_VARS,
     SubprocessResult,
@@ -13,6 +14,8 @@ from autoskillit.core.types import (
 )
 from autoskillit.execution.testing import (
     DefaultTestRunner,
+    _read_sidecar_base_branch,
+    _resolve_base_ref,
     build_sanitized_env,
 )
 from autoskillit.execution.testing import (
@@ -326,3 +329,169 @@ def test_test_result_dataclass_fields() -> None:
     assert r.passed is True
     assert r.stdout == "out"
     assert r.stderr == "err"
+
+
+# ---------- TestCheckConfig filter_mode / base_ref ----------
+
+
+def test_test_check_config_has_filter_mode_and_base_ref_fields():
+    cfg = TestCheckConfig()
+    assert cfg.filter_mode is None
+    assert cfg.base_ref is None
+
+
+def test_from_dynaconf_reads_filter_mode_and_base_ref(monkeypatch):
+    from autoskillit.config.settings import AutomationConfig, _make_dynaconf
+
+    monkeypatch.setenv("AUTOSKILLIT_TEST_CHECK__FILTER_MODE", "conservative")
+    monkeypatch.setenv("AUTOSKILLIT_TEST_CHECK__BASE_REF", "origin/main")
+    d = _make_dynaconf()
+    cfg = AutomationConfig.from_dynaconf(d)
+    assert cfg.test_check.filter_mode == "conservative"
+    assert cfg.test_check.base_ref == "origin/main"
+
+
+@pytest.mark.anyio
+async def test_default_test_runner_injects_filter_mode_env_var(monkeypatch, tmp_path):
+    captured_kwargs: dict = {}
+
+    async def capturing_runner(cmd, *, cwd, timeout, **kwargs):
+        captured_kwargs.update(kwargs)
+        return SubprocessResult(
+            returncode=0,
+            stdout="1 passed",
+            stderr="",
+            termination=TerminationReason.NATURAL_EXIT,
+            pid=12345,
+        )
+
+    config = make_test_config(test_check=TestCheckConfig(filter_mode="conservative"))
+    runner = DefaultTestRunner(config=config, runner=capturing_runner)
+    await runner.run(cwd=tmp_path)
+    assert captured_kwargs["env"]["AUTOSKILLIT_TEST_FILTER"] == "conservative"
+
+
+@pytest.mark.anyio
+async def test_default_test_runner_omits_filter_env_when_none(monkeypatch, tmp_path):
+    captured_kwargs: dict = {}
+
+    async def capturing_runner(cmd, *, cwd, timeout, **kwargs):
+        captured_kwargs.update(kwargs)
+        return SubprocessResult(
+            returncode=0,
+            stdout="1 passed",
+            stderr="",
+            termination=TerminationReason.NATURAL_EXIT,
+            pid=12345,
+        )
+
+    config = make_test_config(test_check=TestCheckConfig())
+    runner = DefaultTestRunner(config=config, runner=capturing_runner)
+    await runner.run(cwd=tmp_path)
+    assert "AUTOSKILLIT_TEST_FILTER" not in captured_kwargs["env"]
+
+
+@pytest.mark.anyio
+async def test_default_test_runner_injects_base_ref_from_config(monkeypatch, tmp_path):
+    captured_kwargs: dict = {}
+
+    async def capturing_runner(cmd, *, cwd, timeout, **kwargs):
+        captured_kwargs.update(kwargs)
+        return SubprocessResult(
+            returncode=0,
+            stdout="1 passed",
+            stderr="",
+            termination=TerminationReason.NATURAL_EXIT,
+            pid=12345,
+        )
+
+    config = make_test_config(test_check=TestCheckConfig(base_ref="origin/main"))
+    runner = DefaultTestRunner(config=config, runner=capturing_runner)
+    await runner.run(cwd=tmp_path)
+    assert captured_kwargs["env"]["AUTOSKILLIT_TEST_BASE_REF"] == "origin/main"
+
+
+# ---------- _resolve_base_ref ----------
+
+
+@pytest.mark.anyio
+async def test_resolve_base_ref_config_override_wins(tmp_path):
+    result = await _resolve_base_ref("origin/main", tmp_path)
+    assert result == "origin/main"
+
+
+@pytest.mark.anyio
+async def test_resolve_base_ref_returns_none_when_no_source(tmp_path):
+    result = await _resolve_base_ref(None, tmp_path)
+    assert result is None
+
+
+@pytest.mark.anyio
+async def test_resolve_base_ref_git_upstream_fallback(tmp_path):
+    import subprocess
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", str(repo)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "--allow-empty", "-m", "init"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "branch", "upstream-branch"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "branch", "--set-upstream-to=upstream-branch"],
+        check=True,
+        capture_output=True,
+    )
+    result = await _resolve_base_ref(None, repo)
+    assert result == "upstream-branch"
+
+
+# ---------- _read_sidecar_base_branch ----------
+
+
+def test_read_sidecar_base_branch_returns_branch(tmp_path):
+    wt_dir = tmp_path / "my-worktree"
+    wt_dir.mkdir()
+    main_git = tmp_path / "main-repo" / ".git"
+    main_git.mkdir(parents=True)
+    worktrees_gitdir = main_git / "worktrees" / "my-worktree"
+    worktrees_gitdir.mkdir(parents=True)
+    (wt_dir / ".git").write_text(f"gitdir: {worktrees_gitdir}\n")
+    sidecar = tmp_path / "main-repo" / ".autoskillit" / "temp" / "worktrees" / "my-worktree"
+    sidecar.mkdir(parents=True)
+    (sidecar / "base-branch").write_text("impl-934\n")
+    assert _read_sidecar_base_branch(wt_dir) == "impl-934"
+
+
+def test_read_sidecar_base_branch_returns_none_for_regular_dir(tmp_path):
+    assert _read_sidecar_base_branch(tmp_path) is None
+
+
+def test_read_sidecar_base_branch_returns_none_for_main_checkout(tmp_path):
+    (tmp_path / ".git").mkdir()
+    assert _read_sidecar_base_branch(tmp_path) is None
+
+
+# ---------- env var passthrough ----------
+
+
+def test_filter_env_vars_not_in_private_set():
+    assert "AUTOSKILLIT_TEST_FILTER" not in AUTOSKILLIT_PRIVATE_ENV_VARS
+    assert "AUTOSKILLIT_TEST_BASE_REF" not in AUTOSKILLIT_PRIVATE_ENV_VARS
+
+
+def test_defaults_yaml_has_filter_mode_and_base_ref():
+    from autoskillit.core import load_yaml, pkg_root
+
+    defaults = load_yaml(pkg_root() / "config" / "defaults.yaml")
+    tc = defaults["test_check"]
+    assert "filter_mode" in tc
+    assert "base_ref" in tc
+    assert tc["filter_mode"] is None
+    assert tc["base_ref"] is None

--- a/tests/execution/test_testing.py
+++ b/tests/execution/test_testing.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 import pytest
 
-from autoskillit.config.settings import TestCheckConfig
 from autoskillit.core.types import (
     AUTOSKILLIT_PRIVATE_ENV_VARS,
     SubprocessResult,
@@ -21,7 +20,7 @@ from autoskillit.execution.testing import (
 from autoskillit.execution.testing import (
     parse_pytest_summary as _parse_pytest_summary,
 )
-from tests._helpers import make_test_config
+from tests._helpers import make_test_check_config, make_test_config
 
 
 def test_build_sanitized_env_strips_private_env_vars(monkeypatch):
@@ -335,14 +334,15 @@ def test_test_result_dataclass_fields() -> None:
 
 
 def test_test_check_config_has_filter_mode_and_base_ref_fields():
-    cfg = TestCheckConfig()
+    cfg = make_test_check_config()
     assert cfg.filter_mode is None
     assert cfg.base_ref is None
 
 
 def test_from_dynaconf_reads_filter_mode_and_base_ref(monkeypatch):
-    from autoskillit.config.settings import AutomationConfig, _make_dynaconf
+    from tests._helpers import make_dynaconf_and_automation_config
 
+    _make_dynaconf, AutomationConfig = make_dynaconf_and_automation_config()
     monkeypatch.setenv("AUTOSKILLIT_TEST_CHECK__FILTER_MODE", "conservative")
     monkeypatch.setenv("AUTOSKILLIT_TEST_CHECK__BASE_REF", "origin/main")
     d = _make_dynaconf()
@@ -365,7 +365,7 @@ async def test_default_test_runner_injects_filter_mode_env_var(monkeypatch, tmp_
             pid=12345,
         )
 
-    config = make_test_config(test_check=TestCheckConfig(filter_mode="conservative"))
+    config = make_test_config(test_check=make_test_check_config(filter_mode="conservative"))
     runner = DefaultTestRunner(config=config, runner=capturing_runner)
     await runner.run(cwd=tmp_path)
     assert captured_kwargs["env"]["AUTOSKILLIT_TEST_FILTER"] == "conservative"
@@ -385,7 +385,7 @@ async def test_default_test_runner_omits_filter_env_when_none(monkeypatch, tmp_p
             pid=12345,
         )
 
-    config = make_test_config(test_check=TestCheckConfig())
+    config = make_test_config(test_check=make_test_check_config())
     runner = DefaultTestRunner(config=config, runner=capturing_runner)
     await runner.run(cwd=tmp_path)
     assert "AUTOSKILLIT_TEST_FILTER" not in captured_kwargs["env"]
@@ -405,7 +405,7 @@ async def test_default_test_runner_injects_base_ref_from_config(monkeypatch, tmp
             pid=12345,
         )
 
-    config = make_test_config(test_check=TestCheckConfig(base_ref="origin/main"))
+    config = make_test_config(test_check=make_test_check_config(base_ref="origin/main"))
     runner = DefaultTestRunner(config=config, runner=capturing_runner)
     await runner.run(cwd=tmp_path)
     assert captured_kwargs["env"]["AUTOSKILLIT_TEST_BASE_REF"] == "origin/main"

--- a/tests/test_python_no_hardcoded_temp.py
+++ b/tests/test_python_no_hardcoded_temp.py
@@ -43,6 +43,10 @@ _TEMP_PATH_WHITELIST: dict[str, str] = {
     # without any autoskillit imports. Falls back to .autoskillit/temp/kitchen_state relative to
     # CWD when AUTOSKILLIT_STATE_DIR is not set.
     "core/kitchen_state.py": "stdlib-only kitchen state module; cannot use resolve_temp_dir()",
+    # Justification: sidecar path for worktree base branch detection; reads from
+    # <project_root>/.autoskillit/temp/worktrees/<wt_name>/base-branch which is
+    # written by implement-worktree skills and must match the canonical layout.
+    "execution/testing.py": "sidecar path for worktree base branch detection",
 }
 
 _LITERAL = ".autoskillit/temp"


### PR DESCRIPTION
## Summary

Add `filter_mode` and `base_ref` fields to `TestCheckConfig`. Thread `AUTOSKILLIT_TEST_FILTER` and `AUTOSKILLIT_TEST_BASE_REF` env vars through `DefaultTestRunner.run()` into the subprocess environment. Implement a base ref resolution chain: config override -> worktree sidecar -> git upstream -> None. Verify that the filter env vars are NOT in `AUTOSKILLIT_PRIVATE_ENV_VARS` (they must pass through to subprocesses, not be stripped). Update `defaults.yaml` and `from_dynaconf()`.

## Requirements

- `TestCheckConfig` has `filter_mode` and `base_ref` fields
- `defaults.yaml` updated with defaults
- `DefaultTestRunner.run()` sets filter env vars when configured
- Filter vars not in `AUTOSKILLIT_PRIVATE_ENV_VARS`
- Base ref resolution: sidecar → upstream → None fallback chain
- Tests: `test_runner_sets_filter_env_when_configured`, `test_runner_omits_filter_env_when_none`, `test_build_sanitized_env_preserves_filter_vars`, `test_runner_resolves_base_ref_from_sidecar`

Closes #934

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-934-20260415-200306-865354/.autoskillit/temp/make-plan/extend_testcheckconfig_filtering_plan_2026-04-15_201300.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| make_plan | 88 | 17.4k | 893.1k | 74.9k | 1 | 8m 49s |
| review_approach | 2.6k | 4.1k | 304.2k | 52.2k | 1 | 3m 4s |
| dry_walkthrough | 45 | 10.1k | 1.0M | 63.4k | 1 | 5m 50s |
| implement | 64 | 10.0k | 1.2M | 47.5k | 1 | 3m 47s |
| resolve_failures | 53 | 8.4k | 925.0k | 38.7k | 1 | 5m 44s |
| prepare_pr | 26 | 4.5k | 217.8k | 25.1k | 1 | 1m 42s |
| run_arch_lenses | 59 | 10.0k | 438.8k | 43.0k | 1 | 3m 36s |
| compose_pr | 22 | 2.0k | 106.4k | 14.9k | 1 | 48s |
| **Total** | 3.0k | 66.7k | 5.1M | 359.7k | | 33m 22s |