### PR TITLE
Anti-Drift Verification System for Test Path Filter

### DIFF
--- a/.github/workflows/test-filter-audit.yml
+++ b/.github/workflows/test-filter-audit.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
     paths:
       - "tests/**"
-      - "conftest.py"
+      - "tests/conftest.py"
       - "tests/_test_filter.py"
       - "src/autoskillit/_test_filter.py"
       - ".autoskillit/test-filter-manifest.yaml"

--- a/.github/workflows/test-filter-audit.yml
+++ b/.github/workflows/test-filter-audit.yml
@@ -1,0 +1,56 @@
+name: Test Filter Audit
+
+on:
+  schedule:
+    - cron: "17 3 * * 1"  # Weekly Monday 3:17am UTC (offset avoids peak contention)
+  push:
+    branches: [main]
+    paths:
+      - "tests/**"
+      - "conftest.py"
+      - "tests/_test_filter.py"
+      - "src/autoskillit/_test_filter.py"
+      - ".autoskillit/test-filter-manifest.yaml"
+      - "Taskfile.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: Shadow-mode filter verification
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      TMPDIR: /dev/shm/pytest-audit
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 10  # Need history for HEAD~5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          uv-version: "0.9.21"
+
+      - name: Install go-task
+        uses: arduino/setup-task@v2
+        with:
+          version: "3.43.3"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git auth for private deps
+        run: git config --global url."https://${{ secrets.GH_USER }}:${{ secrets.GH_PAT }}@github.com/TalonT-Org/".insteadOf "https://github.com/TalonT-Org/"
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up environment
+        run: |
+          mkdir -p "$TMPDIR"
+          task install-worktree
+
+      - name: Run test filter audit
+        run: scripts/verify-test-filter.sh HEAD~5

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -38,7 +38,7 @@ tasks:
 
         set -o pipefail
         set +e
-        $PYTEST_CMD tests/ -q --tb=short -n 4 -m "not smoke" --disable-warnings -o "addopts=" --basetemp={{.PYTEST_TMPDIR}} -o "cache_dir={{.PYTEST_CACHEDIR}}" 2>&1 | tee "$TEST_OUTPUT"
+        $PYTEST_CMD tests/ -q --tb=short -n 4 -m "not smoke and not canary" --disable-warnings -o "addopts=" --basetemp={{.PYTEST_TMPDIR}} -o "cache_dir={{.PYTEST_CACHEDIR}}" 2>&1 | tee "$TEST_OUTPUT"
         PYTEST_EXIT=$?
         set +o pipefail
         set -e
@@ -67,7 +67,7 @@ tasks:
 
         set -o pipefail
         set +e
-        $PYTEST_CMD tests/ -q --tb=short -n 4 -m "not smoke" --disable-warnings -o "addopts=" --basetemp={{.PYTEST_TMPDIR}} -o "cache_dir={{.PYTEST_CACHEDIR}}" 2>&1 | tee "$TEST_OUTPUT"
+        $PYTEST_CMD tests/ -q --tb=short -n 4 -m "not smoke and not canary" --disable-warnings -o "addopts=" --basetemp={{.PYTEST_TMPDIR}} -o "cache_dir={{.PYTEST_CACHEDIR}}" 2>&1 | tee "$TEST_OUTPUT"
         PYTEST_EXIT=$?
         set +o pipefail
         set -e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ timeout_method = "signal"
 markers = [
     "smoke: end-to-end smoke tests requiring Claude API access (deselect with: -m 'not smoke')",
     "integration: integration tests that spawn real subprocesses (deselect with: -m 'not integration')",
+    "canary: development-time filter verification tests (deselect with: -m 'not canary')",
 ]
 
 [tool.ruff]

--- a/scripts/verify-test-filter.sh
+++ b/scripts/verify-test-filter.sh
@@ -80,11 +80,11 @@ echo "Missed tests (in full but not in filtered): $MISSED"
 echo ""
 echo "--- Report ---"
 if [[ "$TOTAL" -gt 0 ]]; then
-    REDUCTION=$(( (TOTAL - FILTERED) * 100 / TOTAL ))
+    REDUCTION=$(awk "BEGIN {printf \"%.1f\", ($TOTAL - $FILTERED) * 100 / $TOTAL}")
     echo "Reduction: ${REDUCTION}% ($TOTAL → $FILTERED)"
 else
-    REDUCTION=0
-    echo "Reduction: 0% (no tests collected)"
+    REDUCTION="0.0"
+    echo "Reduction: 0.0% (no tests collected)"
 fi
 
 echo "Total tests:    $TOTAL"

--- a/scripts/verify-test-filter.sh
+++ b/scripts/verify-test-filter.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Anti-drift verification for test path filtering.
+#
+# Shadow-mode comparison: collects tests with and without the filter,
+# identifies missed tests, runs them to detect false negatives, and
+# reports reduction percentage.
+#
+# Usage: scripts/verify-test-filter.sh <base_ref>
+#   base_ref: git ref for AUTOSKILLIT_TEST_BASE_REF (e.g. HEAD~5)
+#
+# NOTE: This script uses .venv/bin/python -m pytest directly (not task
+# test-check) because it needs raw --collect-only output without the
+# Taskfile harness. This is an intentional exception to the "no bare
+# pytest" convention.
+
+set -euo pipefail
+
+# Deterministic byte-order for sort and comm — prevents locale-dependent
+# collation surprises with parametrized test IDs (brackets, hyphens, etc.)
+export LC_ALL=C
+
+BASE_REF="${1:?Usage: $0 <base_ref>}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+PYTEST=".venv/bin/python -m pytest"
+if [[ ! -x ".venv/bin/python" ]]; then
+    echo "ERROR: .venv/bin/python not found. Run 'task install-worktree' first." >&2
+    exit 1
+fi
+
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/test-filter-audit.XXXXXX")"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+FULL_FILE="$WORK_DIR/full_selected.txt"
+FILTER_FILE="$WORK_DIR/filter_selected.txt"
+MISSED_FILE="$WORK_DIR/missed_tests.txt"
+
+echo "=== Test Filter Anti-Drift Verification ==="
+echo "Base ref: $BASE_REF"
+echo ""
+
+# --- Step 1: Full collection (no filter) ---
+echo "--- Step 1: Collecting all tests (no filter) ---"
+$PYTEST tests/ --collect-only -q --no-header --disable-warnings -o "addopts=" -m "not smoke and not canary" 2>/dev/null \
+    | grep '::' \
+    | sort > "$FULL_FILE"
+
+TOTAL=$(wc -l < "$FULL_FILE")
+echo "Total tests collected: $TOTAL"
+
+if [[ "$TOTAL" -eq 0 ]]; then
+    echo "ERROR: No tests collected in full run. Something is wrong." >&2
+    exit 1
+fi
+
+# --- Step 2: Filtered collection (conservative) ---
+echo ""
+echo "--- Step 2: Collecting tests with conservative filter (base_ref=$BASE_REF) ---"
+AUTOSKILLIT_TEST_BASE_REF="$BASE_REF" \
+AUTOSKILLIT_TEST_FILTER=conservative \
+$PYTEST tests/ --collect-only -q --no-header --disable-warnings -o "addopts=" -m "not smoke and not canary" 2>/dev/null \
+    | grep '::' \
+    | sort > "$FILTER_FILE"
+
+FILTERED=$(wc -l < "$FILTER_FILE")
+echo "Filtered tests collected: $FILTERED"
+
+# --- Step 3: Find missed tests ---
+echo ""
+echo "--- Step 3: Computing shadow diff ---"
+comm -23 "$FULL_FILE" "$FILTER_FILE" > "$MISSED_FILE"
+
+MISSED=$(wc -l < "$MISSED_FILE")
+echo "Missed tests (in full but not in filtered): $MISSED"
+
+# --- Step 4: Report reduction ---
+echo ""
+echo "--- Report ---"
+if [[ "$TOTAL" -gt 0 ]]; then
+    REDUCTION=$(( (TOTAL - FILTERED) * 100 / TOTAL ))
+    echo "Reduction: ${REDUCTION}% ($TOTAL → $FILTERED)"
+else
+    REDUCTION=0
+    echo "Reduction: 0% (no tests collected)"
+fi
+
+echo "Total tests:    $TOTAL"
+echo "Filtered tests: $FILTERED"
+echo "Missed tests:   $MISSED"
+echo "Reduction:      ${REDUCTION}%"
+
+# --- Step 5: Run missed tests if any ---
+if [[ "$MISSED" -gt 0 ]]; then
+    echo ""
+    echo "--- Step 5: Running $MISSED missed tests to detect false negatives ---"
+
+    set +e
+    $PYTEST $(cat "$MISSED_FILE" | tr '\n' ' ') \
+        --tb=short -q --no-header -o "addopts=" \
+        -m "not smoke and not canary" 2>&1
+    MISSED_EXIT=$?
+    set -e
+
+    if [[ "$MISSED_EXIT" -ne 0 ]]; then
+        echo ""
+        echo "FALSE NEGATIVE DETECTED: $MISSED missed tests and some FAILED."
+        echo "The test filter is dropping tests that would have caught regressions."
+        exit 1
+    else
+        echo ""
+        echo "Missed tests all passed — no false negatives detected."
+        echo "These tests were excluded by the filter but would not have caught regressions."
+        exit 0
+    fi
+else
+    echo ""
+    echo "No missed tests — filter is not dropping any tests for this diff range."
+    exit 0
+fi

--- a/tests/test_test_filter.py
+++ b/tests/test_test_filter.py
@@ -765,3 +765,109 @@ class TestConftestFilterPlugin:
         pytester.makepyfile(test_drop="def test_drop(): pass")
         result = pytester.runpytest("-v", "-W", "always")
         result.stdout.fnmatch_lines(["*Test filter:*selected*deselected*"])
+
+
+# ---------------------------------------------------------------------------
+# Canary Test Pattern (development-time technique)
+# ---------------------------------------------------------------------------
+#
+# Canary tests verify the filter itself by being intentionally placed to
+# trigger specific filter behavior. They are gated behind a pytest marker:
+#
+#     @pytest.mark.canary
+#     def test_canary_core_change(self):
+#         """Touch a core/ file and verify conservative cascade includes all layers."""
+#         ...
+#
+# Canary tests are excluded from default runs via ``-m 'not canary'`` in the
+# Taskfile. They only run when explicitly invoked during filter development:
+#
+#     .venv/bin/pytest tests/test_test_filter.py -m canary
+#
+# This is a development-time technique, not a permanent test pattern.
+# Canary tests should be removed once filter validation is complete.
+# The ``canary`` marker must be registered in pyproject.toml [tool.pytest.ini_options].
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Shadow-diff verification tests (SD1)
+# ---------------------------------------------------------------------------
+
+
+class TestShadowDiff:
+    """Shadow-diff verification tests (SD1)."""
+
+    def test_shadow_diff_detects_missed_tests(self, tmp_path: Path) -> None:
+        """Validate comm -23 logic: IDs in full but not in filtered are 'missed'."""
+        full_ids = [
+            "tests/core/test_core.py::test_a",
+            "tests/core/test_core.py::test_b",
+            "tests/execution/test_headless.py::test_c",
+            "tests/pipeline/test_gate.py::test_d",
+            "tests/server/test_init.py::test_e",
+        ]
+        filtered_ids = [
+            "tests/core/test_core.py::test_a",
+            "tests/core/test_core.py::test_b",
+            "tests/server/test_init.py::test_e",
+        ]
+
+        full_file = tmp_path / "full_selected.txt"
+        filtered_file = tmp_path / "filter_selected.txt"
+        missed_file = tmp_path / "missed_tests.txt"
+
+        full_file.write_text("\n".join(full_ids) + "\n")
+        filtered_file.write_text("\n".join(filtered_ids) + "\n")
+
+        result = subprocess.run(
+            ["comm", "-23", str(full_file), str(filtered_file)],
+            capture_output=True,
+            text=True,
+        )
+        missed_file.write_text(result.stdout)
+
+        missed = [line for line in result.stdout.strip().splitlines() if line]
+        assert missed == [
+            "tests/execution/test_headless.py::test_c",
+            "tests/pipeline/test_gate.py::test_d",
+        ]
+
+    def test_shadow_diff_no_missed_tests(self, tmp_path: Path) -> None:
+        """When filtered is a superset of full, no missed tests."""
+        ids = [
+            "tests/core/test_core.py::test_a",
+            "tests/core/test_core.py::test_b",
+        ]
+
+        full_file = tmp_path / "full_selected.txt"
+        filtered_file = tmp_path / "filter_selected.txt"
+
+        full_file.write_text("\n".join(ids) + "\n")
+        filtered_file.write_text("\n".join(ids) + "\n")
+
+        result = subprocess.run(
+            ["comm", "-23", str(full_file), str(filtered_file)],
+            capture_output=True,
+            text=True,
+        )
+        missed = [line for line in result.stdout.strip().splitlines() if line]
+        assert missed == []
+
+    def test_shadow_diff_empty_filtered(self, tmp_path: Path) -> None:
+        """When filter selects nothing, all full IDs are missed."""
+        full_ids = ["tests/core/test_core.py::test_a", "tests/core/test_core.py::test_b"]
+
+        full_file = tmp_path / "full_selected.txt"
+        filtered_file = tmp_path / "filter_selected.txt"
+
+        full_file.write_text("\n".join(full_ids) + "\n")
+        filtered_file.write_text("\n")
+
+        result = subprocess.run(
+            ["comm", "-23", str(full_file), str(filtered_file)],
+            capture_output=True,
+            text=True,
+        )
+        missed = [line for line in result.stdout.strip().splitlines() if line]
+        assert missed == full_ids

--- a/tests/test_test_filter.py
+++ b/tests/test_test_filter.py
@@ -798,20 +798,26 @@ class TestConftestFilterPlugin:
 class TestShadowDiff:
     """Shadow-diff verification tests (SD1)."""
 
+    _COMM_ENV = {"LC_ALL": "C"}
+
     def test_shadow_diff_detects_missed_tests(self, tmp_path: Path) -> None:
         """Validate comm -23 logic: IDs in full but not in filtered are 'missed'."""
-        full_ids = [
-            "tests/core/test_core.py::test_a",
-            "tests/core/test_core.py::test_b",
-            "tests/execution/test_headless.py::test_c",
-            "tests/pipeline/test_gate.py::test_d",
-            "tests/server/test_init.py::test_e",
-        ]
-        filtered_ids = [
-            "tests/core/test_core.py::test_a",
-            "tests/core/test_core.py::test_b",
-            "tests/server/test_init.py::test_e",
-        ]
+        full_ids = sorted(
+            [
+                "tests/core/test_core.py::test_a",
+                "tests/core/test_core.py::test_b",
+                "tests/execution/test_headless.py::test_c",
+                "tests/pipeline/test_gate.py::test_d",
+                "tests/server/test_init.py::test_e",
+            ]
+        )
+        filtered_ids = sorted(
+            [
+                "tests/core/test_core.py::test_a",
+                "tests/core/test_core.py::test_b",
+                "tests/server/test_init.py::test_e",
+            ]
+        )
 
         full_file = tmp_path / "full_selected.txt"
         filtered_file = tmp_path / "filter_selected.txt"
@@ -824,6 +830,7 @@ class TestShadowDiff:
             ["comm", "-23", str(full_file), str(filtered_file)],
             capture_output=True,
             text=True,
+            env=self._COMM_ENV,
         )
         missed_file.write_text(result.stdout)
 
@@ -835,10 +842,12 @@ class TestShadowDiff:
 
     def test_shadow_diff_no_missed_tests(self, tmp_path: Path) -> None:
         """When filtered is a superset of full, no missed tests."""
-        ids = [
-            "tests/core/test_core.py::test_a",
-            "tests/core/test_core.py::test_b",
-        ]
+        ids = sorted(
+            [
+                "tests/core/test_core.py::test_a",
+                "tests/core/test_core.py::test_b",
+            ]
+        )
 
         full_file = tmp_path / "full_selected.txt"
         filtered_file = tmp_path / "filter_selected.txt"
@@ -850,13 +859,14 @@ class TestShadowDiff:
             ["comm", "-23", str(full_file), str(filtered_file)],
             capture_output=True,
             text=True,
+            env=self._COMM_ENV,
         )
         missed = [line for line in result.stdout.strip().splitlines() if line]
         assert missed == []
 
     def test_shadow_diff_empty_filtered(self, tmp_path: Path) -> None:
         """When filter selects nothing, all full IDs are missed."""
-        full_ids = ["tests/core/test_core.py::test_a", "tests/core/test_core.py::test_b"]
+        full_ids = sorted(["tests/core/test_core.py::test_a", "tests/core/test_core.py::test_b"])
 
         full_file = tmp_path / "full_selected.txt"
         filtered_file = tmp_path / "filter_selected.txt"
@@ -868,6 +878,7 @@ class TestShadowDiff:
             ["comm", "-23", str(full_file), str(filtered_file)],
             capture_output=True,
             text=True,
+            env=self._COMM_ENV,
         )
         missed = [line for line in result.stdout.strip().splitlines() if line]
         assert missed == full_ids


### PR DESCRIPTION
## Summary

Create a shadow-mode verification system that detects false negatives in the test path filter by comparing full vs filtered pytest collection, running any missed tests, and reporting reduction metrics. Three deliverables: a shell script (`scripts/verify-test-filter.sh`), a GitHub Actions workflow (`.github/workflows/test-filter-audit.yml`), and unit tests with canary pattern documentation in `tests/test_test_filter.py`.

## Requirements

- `scripts/verify-test-filter.sh` exists and runs correctly
- `.github/workflows/test-filter-audit.yml` exists with weekly schedule
- Script reports: total tests, filtered tests, reduction %, missed tests
- Script runs missed tests and detects false negatives
- Canary pattern documented
- Unit test: `test_shadow_diff_detects_missed_tests` — given two lists of test IDs (full and filtered), verify the `comm` logic correctly identifies IDs present in full but absent from filtered

Closes #936

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-936-20260415-215002-555319/.autoskillit/temp/make-plan/anti_drift_verification_plan_2026-04-15_215500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| make_plan | 1.6k | 9.7k | 817.4k | 61.8k | 2 | 4m 49s |
| review_approach | 12 | 4.7k | 125.4k | 6.6k | 1 | 4m 9s |
| dry_walkthrough | 42 | 12.0k | 886.3k | 74.8k | 1 | 5m 47s |
| implement | 70 | 10.0k | 968.7k | 38.9k | 1 | 3m 28s |
| prepare_pr | 28 | 3.1k | 287.6k | 27.1k | 1 | 1m 37s |
| run_arch_lenses | 1.2k | 4.6k | 193.4k | 23.7k | 1 | 2m 58s |
| compose_pr | 22 | 1.7k | 105.9k | 14.4k | 1 | 36s |
| **Total** | 2.9k | 45.7k | 3.4M | 247.3k | | 23m 27s |