### PR TITLE
Protocol-Based Test Fakes

### DIFF
--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -80,7 +80,8 @@ tests/
 ├── CLAUDE.md                            # xdist compatibility guidelines
 ├── __init__.py
 ├── _helpers.py
-├── conftest.py                          # Shared fixtures: minimal_ctx, tool_ctx, MockSubprocessRunner, _make_result, _make_timeout_result
+├── conftest.py                          # Shared fixtures: minimal_ctx, tool_ctx, _make_result, _make_timeout_result
+├── fakes.py                             # Protocol-based test fakes: InMemory*, MockSubprocessRunner
 ├── test_conftest.py                     # Tests for conftest fixtures
 ├── test_phase2_skills.py
 ├── test_skill_preambles.py

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,81 +7,12 @@ import pytest
 from autoskillit.core.types import (
     ChannelConfirmation,
     SubprocessResult,
-    SubprocessRunner,
     TerminationReason,
-    TestResult,
 )
 from tests._helpers import _flush_structlog_proxy_caches
+from tests.fakes import MockSubprocessRunner
 
 _scope_key = pytest.StashKey[set[_Path] | None]()
-
-
-class StatefulMockTester:
-    """Test double for TestRunner returning pre-configured results on successive calls.
-
-    Enables the scenario: pre-rebase tests pass, post-rebase tests fail.
-    Falls back to TestResult(passed=True, stdout="", stderr="") for any call beyond the
-    configured list.
-    """
-
-    def __init__(self, results: list[TestResult]) -> None:
-        self._results = list(results)
-        self._index = 0
-
-    async def run(self, cwd: _Path) -> TestResult:
-        if self._index < len(self._results):
-            result = self._results[self._index]
-        else:
-            result = TestResult(passed=True, stdout="", stderr="")
-        self._index += 1
-        return result
-
-    @property
-    def call_count(self) -> int:
-        return self._index
-
-
-class MockSubprocessRunner(SubprocessRunner):
-    """Test double for SubprocessRunner. Queues predetermined results.
-
-    Inherits from SubprocessRunner (Protocol) so mypy verifies the __call__
-    signature matches the protocol at class definition, not just at call sites.
-
-    call_args_list stores (cmd, cwd, timeout, kwargs) tuples.
-    IMPORTANT: Assert [N][1] (cwd) when testing cwd propagation.
-    """
-
-    def __init__(self) -> None:
-        self._queue: list[SubprocessResult] = []
-        self._default = SubprocessResult(
-            returncode=0,
-            stdout="",
-            stderr="",
-            termination=TerminationReason.NATURAL_EXIT,
-            pid=99999,
-        )
-        self.call_args_list: list[tuple] = []
-
-    def push(self, result: SubprocessResult) -> None:
-        """Queue a result to be returned by the next __call__."""
-        self._queue.append(result)
-
-    def set_default(self, result: SubprocessResult) -> None:
-        """Set the result returned when the queue is empty."""
-        self._default = result
-
-    async def __call__(
-        self,
-        cmd: list[str],
-        *,
-        cwd: _Path,
-        timeout: float,
-        **kwargs: object,
-    ) -> SubprocessResult:
-        self.call_args_list.append((cmd, cwd, timeout, kwargs))
-        if self._queue:
-            return self._queue.pop(0)
-        return self._default
 
 
 @pytest.fixture(autouse=True)

--- a/tests/execution/test_clone_guard.py
+++ b/tests/execution/test_clone_guard.py
@@ -22,7 +22,7 @@ from autoskillit.execution.clone_guard import (
 )
 from autoskillit.execution.headless import _build_skill_result
 from autoskillit.pipeline.audit import DefaultAuditLog
-from tests.conftest import MockSubprocessRunner
+from tests.fakes import MockSubprocessRunner
 
 
 def _git_result(stdout: str = "", returncode: int = 0) -> SubprocessResult:

--- a/tests/execution/test_headless_env_injection.py
+++ b/tests/execution/test_headless_env_injection.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 
 from autoskillit.core.types import SubprocessResult, TerminationReason
-from tests.conftest import MockSubprocessRunner
+from tests.fakes import MockSubprocessRunner
 
 
 @pytest.mark.anyio

--- a/tests/execution/test_recording.py
+++ b/tests/execution/test_recording.py
@@ -17,7 +17,8 @@ from autoskillit.execution.recording import (
     ScenarioReplayError,
     _extract_model,
 )
-from tests.conftest import MockSubprocessRunner, _make_result
+from tests.conftest import _make_result
+from tests.fakes import MockSubprocessRunner
 
 
 @dataclass

--- a/tests/execution/test_testing.py
+++ b/tests/execution/test_testing.py
@@ -309,7 +309,8 @@ def test_check_test_passed_parses_pytest_summary_in_stderr() -> None:
 async def test_default_test_runner_returns_test_result_with_stderr(tmp_path: Path) -> None:
     from autoskillit.core import TestResult
     from autoskillit.execution.testing import DefaultTestRunner
-    from tests.conftest import MockSubprocessRunner, _make_result
+    from tests.conftest import _make_result
+    from tests.fakes import MockSubprocessRunner
 
     runner = MockSubprocessRunner()
     runner.push(_make_result(0, "", stderr="PASSED [0.5s] all tests"))

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -140,7 +140,7 @@ class InMemoryHeadlessExecutor(HeadlessExecutor):
             )
         )
         if self._queue:
-            return self._queue.popleft()
+            return dataclasses.replace(self._queue.popleft())
         # Return a defensive copy so callers mutating fields (e.g. run_skill
         # setting order_id) don't pollute the shared default across tests.
         return dataclasses.replace(self._default)

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -442,7 +442,7 @@ class MockSubprocessRunner(SubprocessRunner):
     """
 
     def __init__(self) -> None:
-        self._queue: list[SubprocessResult] = []
+        self._queue: deque[SubprocessResult] = deque()
         self._default = SubprocessResult(
             returncode=0,
             stdout="",
@@ -470,5 +470,5 @@ class MockSubprocessRunner(SubprocessRunner):
     ) -> SubprocessResult:
         self.call_args_list.append((cmd, cwd, timeout, kwargs))
         if self._queue:
-            return self._queue.pop(0)
+            return self._queue.popleft()
         return self._default

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -118,7 +118,9 @@ class InMemoryHeadlessExecutor(HeadlessExecutor):
         )
         if self._queue:
             return self._queue.popleft()
-        return self._default
+        # Return a defensive copy so callers mutating fields (e.g. run_skill
+        # setting order_id) don't pollute the shared default across tests.
+        return dataclasses.replace(self._default)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -1,0 +1,459 @@
+"""Protocol-based test fakes for autoskillit.
+
+Single authoritative module for in-memory test doubles that satisfy protocols
+defined in ``core/_type_protocols.py``. Imports only from L0 (``autoskillit.core``).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from collections import deque
+from collections.abc import Awaitable, Callable, Sequence
+from pathlib import Path
+from typing import Any
+
+from autoskillit.core.types import (
+    CIRunScope,
+    CIWatcher,
+    DatabaseReader,
+    HeadlessExecutor,
+    MergeQueueWatcher,
+    RecipeRepository,
+    SkillResult,
+    SubprocessResult,
+    SubprocessRunner,
+    TerminationReason,
+    TestResult,
+    TestRunner,
+    WriteBehaviorSpec,
+)
+
+# ---------------------------------------------------------------------------
+# HeadlessExecutor fake
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class ExecutorCall:
+    """Record of a single ``HeadlessExecutor.run()`` invocation."""
+
+    skill_command: str
+    cwd: str
+    model: str = ""
+    step_name: str = ""
+    kitchen_id: str = ""
+    order_id: str = ""
+    add_dirs: tuple[Any, ...] = ()
+    timeout: float | None = None
+    stale_threshold: float | None = None
+    idle_output_timeout: float | None = None
+    expected_output_patterns: tuple[str, ...] = ()
+    write_behavior: Any | None = None
+    completion_marker: str = ""
+
+
+_DEFAULT_SKILL_RESULT = SkillResult(
+    success=True,
+    result="ok",
+    session_id="",
+    subtype="success",
+    is_error=False,
+    exit_code=0,
+    needs_retry=False,
+    retry_reason="none",
+    stderr="",
+    token_usage=None,
+)
+
+
+class InMemoryHeadlessExecutor(HeadlessExecutor):
+    """In-memory test double for :class:`HeadlessExecutor`.
+
+    Supports a FIFO queue via :meth:`push` and records every call in
+    :attr:`calls`.
+    """
+
+    def __init__(self, default_result: SkillResult | None = None) -> None:
+        self._default = default_result or _DEFAULT_SKILL_RESULT
+        self._queue: deque[SkillResult] = deque()
+        self.calls: list[ExecutorCall] = []
+
+    def push(self, result: SkillResult) -> None:
+        """Enqueue a result to be returned by the next :meth:`run` call."""
+        self._queue.append(result)
+
+    async def run(
+        self,
+        skill_command: str,
+        cwd: str,
+        *,
+        model: str = "",
+        step_name: str = "",
+        kitchen_id: str = "",
+        order_id: str = "",
+        add_dirs: Sequence[Any] = (),
+        timeout: float | None = None,
+        stale_threshold: float | None = None,
+        idle_output_timeout: float | None = None,
+        expected_output_patterns: Sequence[str] = (),
+        write_behavior: WriteBehaviorSpec | None = None,
+        completion_marker: str = "",
+    ) -> SkillResult:
+        self.calls.append(
+            ExecutorCall(
+                skill_command=skill_command,
+                cwd=cwd,
+                model=model,
+                step_name=step_name,
+                kitchen_id=kitchen_id,
+                order_id=order_id,
+                add_dirs=tuple(add_dirs),
+                timeout=timeout,
+                stale_threshold=stale_threshold,
+                idle_output_timeout=idle_output_timeout,
+                expected_output_patterns=tuple(expected_output_patterns),
+                write_behavior=write_behavior,
+                completion_marker=completion_marker,
+            )
+        )
+        if self._queue:
+            return self._queue.popleft()
+        return self._default
+
+
+# ---------------------------------------------------------------------------
+# TestRunner fake
+# ---------------------------------------------------------------------------
+
+
+class InMemoryTestRunner(TestRunner):
+    """In-memory test double for :class:`TestRunner`.
+
+    Pops pre-configured results from a deque; falls back to a passing
+    ``TestResult`` when the deque is exhausted.
+    """
+
+    def __init__(self, results: list[TestResult] | None = None) -> None:
+        self._results: deque[TestResult] = deque(results or [])
+        self._call_count = 0
+        self.calls: list[Path] = []
+
+    async def run(self, cwd: Path) -> TestResult:
+        self._call_count += 1
+        self.calls.append(cwd)
+        if self._results:
+            return self._results.popleft()
+        return TestResult(passed=True, stdout="", stderr="")
+
+    @property
+    def call_count(self) -> int:
+        return self._call_count
+
+
+# ---------------------------------------------------------------------------
+# RecipeRepository fake
+# ---------------------------------------------------------------------------
+
+
+class InMemoryRecipeRepository(RecipeRepository):
+    """In-memory test double for :class:`RecipeRepository`."""
+
+    def __init__(self) -> None:
+        self._recipes: dict[str, Any] = {}
+        self._validated: dict[str, dict[str, Any]] = {}
+        self._path_validated: dict[str, dict[str, Any]] = {}
+        self._all_recipes: dict[str, Any] = {}
+
+    # -- test setup helpers --
+
+    def add_recipe(self, name: str, data: Any) -> None:
+        self._recipes[name] = data
+
+    def set_validated(self, name: str, result: dict[str, Any]) -> None:
+        self._validated[name] = result
+
+    def set_path_validated(self, path: str, result: dict[str, Any]) -> None:
+        self._path_validated[path] = result
+
+    def set_all(self, data: dict[str, Any]) -> None:
+        self._all_recipes = data
+
+    # -- protocol methods --
+
+    def find(self, name: str, project_dir: Path) -> Any:
+        return self._recipes.get(name)
+
+    def list(self, project_dir: Path) -> Any:
+        return list(self._recipes.keys())
+
+    def load_and_validate(
+        self,
+        name: str,
+        project_dir: Any,
+        *,
+        suppressed: Sequence[str] | None = None,
+        resolved_defaults: dict[str, str] | None = None,
+        ingredient_overrides: dict[str, str] | None = None,
+        temp_dir: Path | None = None,
+        temp_dir_relpath: str | None = None,
+    ) -> dict[str, Any]:
+        return self._validated.get(name, {"valid": False, "error": "not configured"})
+
+    def validate_from_path(
+        self, script_path: Any, temp_dir_relpath: str = ".autoskillit/temp"
+    ) -> dict[str, Any]:
+        key = str(script_path)
+        return self._path_validated.get(key, {"valid": False, "error": "not configured"})
+
+    def list_all(self, project_dir: Any | None = None) -> dict[str, Any]:
+        return self._all_recipes
+
+    async def apply_triage_gate(
+        self,
+        result: dict[str, Any],
+        recipe_name: str,
+        recipe_info: Any,
+        temp_dir: Path,
+        logger: Any,
+        triage_fn: Callable[..., Awaitable[Sequence[dict[str, Any]]]] | None = None,
+    ) -> dict[str, Any]:
+        return result
+
+
+# ---------------------------------------------------------------------------
+# CIWatcher fake
+# ---------------------------------------------------------------------------
+
+
+class InMemoryCIWatcher(CIWatcher):
+    """In-memory test double for :class:`CIWatcher`."""
+
+    def __init__(
+        self,
+        wait_result: dict[str, Any] | None = None,
+        status_result: dict[str, Any] | None = None,
+    ) -> None:
+        self._wait_result = wait_result or {
+            "run_id": 0,
+            "conclusion": "success",
+            "failed_jobs": [],
+        }
+        self._status_result = status_result or {"runs": []}
+        self.wait_calls: list[dict[str, Any]] = []
+        self.status_calls: list[dict[str, Any]] = []
+        self.wait_side_effect: Any | None = None
+        self.status_side_effect: Any | None = None
+
+    async def wait(
+        self,
+        branch: str,
+        *,
+        repo: str | None = None,
+        scope: CIRunScope = CIRunScope(),
+        timeout_seconds: int = 300,
+        lookback_seconds: int = 120,
+        cwd: str = "",
+    ) -> dict[str, Any]:
+        self.wait_calls.append(
+            {
+                "branch": branch,
+                "repo": repo,
+                "scope": scope,
+                "timeout_seconds": timeout_seconds,
+                "lookback_seconds": lookback_seconds,
+                "cwd": cwd,
+            }
+        )
+        if self.wait_side_effect is not None:
+            return self._resolve_side_effect(self.wait_side_effect)
+        return self._wait_result
+
+    async def status(
+        self,
+        branch: str,
+        *,
+        repo: str | None = None,
+        run_id: int | None = None,
+        scope: CIRunScope = CIRunScope(),
+        cwd: str = "",
+    ) -> dict[str, Any]:
+        self.status_calls.append(
+            {
+                "branch": branch,
+                "repo": repo,
+                "run_id": run_id,
+                "scope": scope,
+                "cwd": cwd,
+            }
+        )
+        if self.status_side_effect is not None:
+            return self._resolve_side_effect(self.status_side_effect)
+        return self._status_result
+
+    @staticmethod
+    def _resolve_side_effect(effect: Any) -> Any:
+        if isinstance(effect, BaseException):
+            raise effect
+        if isinstance(effect, type) and issubclass(effect, BaseException):
+            raise effect()
+        if callable(effect):
+            return effect()
+        return effect
+
+
+# ---------------------------------------------------------------------------
+# MergeQueueWatcher fake
+# ---------------------------------------------------------------------------
+
+
+class InMemoryMergeQueueWatcher(MergeQueueWatcher):
+    """In-memory test double for :class:`MergeQueueWatcher`."""
+
+    def __init__(
+        self,
+        wait_result: dict[str, Any] | None = None,
+        toggle_result: dict[str, Any] | None = None,
+    ) -> None:
+        self._wait_result = wait_result or {
+            "success": True,
+            "pr_state": "merged",
+            "reason": "PR merged",
+        }
+        self._toggle_result = toggle_result or {"success": True, "toggled": True}
+        self.wait_calls: list[dict[str, Any]] = []
+        self.toggle_calls: list[dict[str, Any]] = []
+        self.wait_side_effect: Any | None = None
+        self.toggle_side_effect: Any | None = None
+
+    async def wait(
+        self,
+        pr_number: int,
+        target_branch: str,
+        repo: str | None = None,
+        cwd: str = ".",
+        timeout_seconds: int = 600,
+        poll_interval: int = 15,
+        stall_grace_period: int = 60,
+        max_stall_retries: int = 3,
+        not_in_queue_confirmation_cycles: int = 2,
+        max_inconclusive_retries: int = 5,
+    ) -> dict[str, Any]:
+        self.wait_calls.append(
+            {
+                "pr_number": pr_number,
+                "target_branch": target_branch,
+                "repo": repo,
+                "cwd": cwd,
+                "timeout_seconds": timeout_seconds,
+                "poll_interval": poll_interval,
+            }
+        )
+        if self.wait_side_effect is not None:
+            return InMemoryCIWatcher._resolve_side_effect(self.wait_side_effect)
+        return self._wait_result
+
+    async def toggle(
+        self,
+        pr_number: int,
+        target_branch: str,
+        repo: str | None = None,
+        cwd: str = ".",
+    ) -> dict[str, Any]:
+        self.toggle_calls.append(
+            {
+                "pr_number": pr_number,
+                "target_branch": target_branch,
+                "repo": repo,
+                "cwd": cwd,
+            }
+        )
+        if self.toggle_side_effect is not None:
+            return InMemoryCIWatcher._resolve_side_effect(self.toggle_side_effect)
+        return self._toggle_result
+
+
+# ---------------------------------------------------------------------------
+# DatabaseReader fake
+# ---------------------------------------------------------------------------
+
+
+class InMemoryDatabaseReader(DatabaseReader):
+    """In-memory test double for :class:`DatabaseReader`."""
+
+    def __init__(self, query_result: dict[str, Any] | None = None) -> None:
+        self._query_result = query_result or {
+            "columns": [],
+            "rows": [],
+            "row_count": 0,
+        }
+        self.calls: list[dict[str, Any]] = []
+        self.side_effect: Any | None = None
+
+    def query(
+        self,
+        db_path: str,
+        sql: str,
+        params: list | dict,  # type: ignore[type-arg]
+        timeout_sec: int,
+        max_rows: int,
+    ) -> dict[str, Any]:
+        self.calls.append(
+            {
+                "db_path": db_path,
+                "sql": sql,
+                "params": params,
+                "timeout_sec": timeout_sec,
+                "max_rows": max_rows,
+            }
+        )
+        if self.side_effect is not None:
+            return InMemoryCIWatcher._resolve_side_effect(self.side_effect)
+        return self._query_result
+
+
+# ---------------------------------------------------------------------------
+# SubprocessRunner fake (moved from conftest.py)
+# ---------------------------------------------------------------------------
+
+
+class MockSubprocessRunner(SubprocessRunner):
+    """Test double for SubprocessRunner. Queues predetermined results.
+
+    Inherits from SubprocessRunner (Protocol) so mypy verifies the __call__
+    signature matches the protocol at class definition, not just at call sites.
+
+    call_args_list stores (cmd, cwd, timeout, kwargs) tuples.
+    IMPORTANT: Assert [N][1] (cwd) when testing cwd propagation.
+    """
+
+    def __init__(self) -> None:
+        self._queue: list[SubprocessResult] = []
+        self._default = SubprocessResult(
+            returncode=0,
+            stdout="",
+            stderr="",
+            termination=TerminationReason.NATURAL_EXIT,
+            pid=99999,
+        )
+        self.call_args_list: list[tuple] = []  # type: ignore[type-arg]
+
+    def push(self, result: SubprocessResult) -> None:
+        """Queue a result to be returned by the next __call__."""
+        self._queue.append(result)
+
+    def set_default(self, result: SubprocessResult) -> None:
+        """Set the result returned when the queue is empty."""
+        self._default = result
+
+    async def __call__(
+        self,
+        cmd: list[str],
+        *,
+        cwd: Path,
+        timeout: float,
+        **kwargs: object,
+    ) -> SubprocessResult:
+        self.call_args_list.append((cmd, cwd, timeout, kwargs))
+        if self._queue:
+            return self._queue.pop(0)
+        return self._default

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -6,6 +6,7 @@ defined in ``core/_type_protocols.py``. Imports only from L0 (``autoskillit.core
 
 from __future__ import annotations
 
+import asyncio
 import dataclasses
 from collections import deque
 from collections.abc import Awaitable, Callable, Sequence
@@ -27,6 +28,28 @@ from autoskillit.core.types import (
     TestRunner,
     WriteBehaviorSpec,
 )
+
+# ---------------------------------------------------------------------------
+# Shared side-effect resolution helper
+# ---------------------------------------------------------------------------
+
+
+def _resolve_side_effect(effect: Any) -> Any:
+    """Resolve a side-effect value: raise exceptions, call callables, or return as-is.
+
+    Handles async callables by running them on the current event loop.
+    """
+    if isinstance(effect, BaseException):
+        raise effect
+    if isinstance(effect, type) and issubclass(effect, BaseException):
+        raise effect()
+    if callable(effect):
+        result = effect()
+        if asyncio.iscoroutine(result):
+            return asyncio.get_event_loop().run_until_complete(result)
+        return result
+    return effect
+
 
 # ---------------------------------------------------------------------------
 # HeadlessExecutor fake
@@ -267,7 +290,7 @@ class InMemoryCIWatcher(CIWatcher):
             }
         )
         if self.wait_side_effect is not None:
-            return self._resolve_side_effect(self.wait_side_effect)
+            return _resolve_side_effect(self.wait_side_effect)
         return self._wait_result
 
     async def status(
@@ -289,18 +312,8 @@ class InMemoryCIWatcher(CIWatcher):
             }
         )
         if self.status_side_effect is not None:
-            return self._resolve_side_effect(self.status_side_effect)
+            return _resolve_side_effect(self.status_side_effect)
         return self._status_result
-
-    @staticmethod
-    def _resolve_side_effect(effect: Any) -> Any:
-        if isinstance(effect, BaseException):
-            raise effect
-        if isinstance(effect, type) and issubclass(effect, BaseException):
-            raise effect()
-        if callable(effect):
-            return effect()
-        return effect
 
 
 # ---------------------------------------------------------------------------
@@ -351,7 +364,7 @@ class InMemoryMergeQueueWatcher(MergeQueueWatcher):
             }
         )
         if self.wait_side_effect is not None:
-            return InMemoryCIWatcher._resolve_side_effect(self.wait_side_effect)
+            return _resolve_side_effect(self.wait_side_effect)
         return self._wait_result
 
     async def toggle(
@@ -370,7 +383,7 @@ class InMemoryMergeQueueWatcher(MergeQueueWatcher):
             }
         )
         if self.toggle_side_effect is not None:
-            return InMemoryCIWatcher._resolve_side_effect(self.toggle_side_effect)
+            return _resolve_side_effect(self.toggle_side_effect)
         return self._toggle_result
 
 
@@ -409,7 +422,7 @@ class InMemoryDatabaseReader(DatabaseReader):
             }
         )
         if self.side_effect is not None:
-            return InMemoryCIWatcher._resolve_side_effect(self.side_effect)
+            return _resolve_side_effect(self.side_effect)
         return self._query_result
 
 

--- a/tests/server/test_factory.py
+++ b/tests/server/test_factory.py
@@ -23,7 +23,7 @@ from autoskillit.recipe.repository import DefaultRecipeRepository
 from autoskillit.server._factory import TokenFactory, _gh_cli_token, make_context
 from autoskillit.workspace import DefaultCloneManager, SkillResolver
 from autoskillit.workspace.cleanup import DefaultWorkspaceManager
-from tests.conftest import MockSubprocessRunner
+from tests.fakes import MockSubprocessRunner
 
 
 def _runner() -> MockSubprocessRunner:

--- a/tests/server/test_factory_recording.py
+++ b/tests/server/test_factory_recording.py
@@ -8,7 +8,8 @@ from unittest.mock import Mock
 import pytest
 
 from autoskillit.execution.recording import RecordingSubprocessRunner, ReplayingSubprocessRunner
-from tests.conftest import MockSubprocessRunner, _make_result
+from tests.conftest import _make_result
+from tests.fakes import MockSubprocessRunner
 
 
 @dataclass

--- a/tests/server/test_git.py
+++ b/tests/server/test_git.py
@@ -14,7 +14,7 @@ from autoskillit.core.types import (
     TerminationReason,
     TestResult,
 )
-from tests.conftest import MockSubprocessRunner, StatefulMockTester
+from tests.fakes import InMemoryTestRunner, MockSubprocessRunner
 
 
 def _make_result(
@@ -39,7 +39,7 @@ def default_config():
 
 @pytest.fixture
 def conftest_mock_runner():
-    from tests.conftest import MockSubprocessRunner
+    from tests.fakes import MockSubprocessRunner
 
     return MockSubprocessRunner()
 
@@ -153,7 +153,7 @@ async def test_perform_merge_returns_success_on_green_tests(
     from autoskillit.server.git import perform_merge
 
     fake_wt = str(tmp_path)
-    tester = StatefulMockTester(
+    tester = InMemoryTestRunner(
         results=[TestResult(True, "= 50 passed =", ""), TestResult(True, "= 50 passed =", "")]
     )
     # Queue 9 steps: rev-parse, branch, dirty check, fetch, rebase,
@@ -202,7 +202,7 @@ async def test_perform_merge_blocks_on_post_rebase_test_failure(
     from autoskillit.server.git import perform_merge
 
     # Pre-rebase: pass; post-rebase: fail
-    tester = StatefulMockTester(
+    tester = InMemoryTestRunner(
         results=[TestResult(True, "= 10 passed =", ""), TestResult(False, "= 1 failed =", "")]
     )
     # Queue: rev-parse (valid worktree), branch, dirty check, fetch ok,
@@ -236,7 +236,7 @@ async def test_perform_merge_uses_no_edit_flag(default_config, conftest_mock_run
     from autoskillit.server.git import perform_merge
 
     fake_wt = str(tmp_path)
-    tester = StatefulMockTester(results=[TestResult(True, "ok", ""), TestResult(True, "ok", "")])
+    tester = InMemoryTestRunner(results=[TestResult(True, "ok", ""), TestResult(True, "ok", "")])
     # Queue all 10 steps for success path
     conftest_mock_runner.push(_make_result(0, f"{fake_wt}/.git/worktrees/wt", ""))
     conftest_mock_runner.push(_make_result(0, "feature-branch\n", ""))
@@ -284,7 +284,7 @@ async def test_perform_merge_blocks_on_missing_remote_tracking_ref(
 
     worktree_dir = tmp_path / "wt"
     worktree_dir.mkdir()
-    tester = StatefulMockTester(results=[TestResult(True, "= 10 passed =", "")])
+    tester = InMemoryTestRunner(results=[TestResult(True, "= 10 passed =", "")])
     # Step 2: worktree verified (needs /worktrees/ in git-dir path)
     conftest_mock_runner.push(_make_result(0, str(tmp_path / ".git/worktrees/wt"), ""))
     # Step 3: branch name found
@@ -321,7 +321,7 @@ async def test_perform_merge_strips_tracked_generated_files(
     from autoskillit.server.git import perform_merge
 
     fake_wt = str(tmp_path)
-    tester = StatefulMockTester(results=[TestResult(True, "ok", ""), TestResult(True, "ok", "")])
+    tester = InMemoryTestRunner(results=[TestResult(True, "ok", ""), TestResult(True, "ok", "")])
     conftest_mock_runner.push(_make_result(0, f"{fake_wt}/.git/worktrees/wt", ""))  # rev-parse
     conftest_mock_runner.push(_make_result(0, "feature-branch\n", ""))  # branch
     conftest_mock_runner.push(
@@ -375,7 +375,7 @@ async def test_perform_merge_noop_when_no_generated_files_tracked(
     from autoskillit.server.git import perform_merge
 
     fake_wt = str(tmp_path)
-    tester = StatefulMockTester(results=[TestResult(True, "ok", ""), TestResult(True, "ok", "")])
+    tester = InMemoryTestRunner(results=[TestResult(True, "ok", ""), TestResult(True, "ok", "")])
     conftest_mock_runner.push(_make_result(0, f"{fake_wt}/.git/worktrees/wt", ""))  # rev-parse
     conftest_mock_runner.push(_make_result(0, "feature-branch\n", ""))  # branch
     conftest_mock_runner.push(_make_result(0, "", ""))  # git ls-files (empty — no generated files)
@@ -413,7 +413,7 @@ async def test_perform_merge_fails_on_generated_file_cleanup_error(
     from autoskillit.server.git import perform_merge
 
     fake_wt = str(tmp_path)
-    tester = StatefulMockTester(results=[TestResult(True, "ok", "")])
+    tester = InMemoryTestRunner(results=[TestResult(True, "ok", "")])
     conftest_mock_runner.push(_make_result(0, f"{fake_wt}/.git/worktrees/wt", ""))  # rev-parse
     conftest_mock_runner.push(_make_result(0, "feature-branch\n", ""))  # branch
     conftest_mock_runner.push(
@@ -441,7 +441,7 @@ async def test_perform_merge_dirty_check_ignores_generated_files(
     from autoskillit.server.git import perform_merge
 
     fake_wt = str(tmp_path)
-    tester = StatefulMockTester(results=[TestResult(True, "ok", ""), TestResult(True, "ok", "")])
+    tester = InMemoryTestRunner(results=[TestResult(True, "ok", ""), TestResult(True, "ok", "")])
     conftest_mock_runner.push(_make_result(0, f"{fake_wt}/.git/worktrees/wt", ""))  # rev-parse
     conftest_mock_runner.push(_make_result(0, "feature-branch\n", ""))  # branch
     conftest_mock_runner.push(_make_result(0, "", ""))  # git ls-files (no tracked generated files)
@@ -477,7 +477,7 @@ async def test_perform_merge_strips_generated_files_before_dirty_check(
     from autoskillit.server.git import perform_merge
 
     fake_wt = str(tmp_path)
-    tester = StatefulMockTester(results=[TestResult(True, "ok", ""), TestResult(True, "ok", "")])
+    tester = InMemoryTestRunner(results=[TestResult(True, "ok", ""), TestResult(True, "ok", "")])
     conftest_mock_runner.push(_make_result(0, f"{fake_wt}/.git/worktrees/wt", ""))  # rev-parse
     conftest_mock_runner.push(_make_result(0, "feature-branch\n", ""))  # branch
     conftest_mock_runner.push(
@@ -508,9 +508,9 @@ async def test_perform_merge_strips_generated_files_before_dirty_check(
     assert ls_files_idx < status_idx < rebase_idx
 
 
-def _make_tester() -> StatefulMockTester:
-    """Return a StatefulMockTester with two passing test results (pre- and post-rebase)."""
-    return StatefulMockTester(
+def _make_tester() -> InMemoryTestRunner:
+    """Return a InMemoryTestRunner with two passing test results (pre- and post-rebase)."""
+    return InMemoryTestRunner(
         results=[
             TestResult(True, "PASS\n= 10 passed =", ""),
             TestResult(True, "PASS\n= 10 passed =", ""),
@@ -527,7 +527,7 @@ def _push_full_success_sequence(
     """Push the git subprocess sequence for a successful merge onto runner.
 
     Covers all git calls in perform_merge (steps 2-9, 11, 12). The test gate
-    (step 4) is handled by StatefulMockTester, not via the runner.
+    (step 4) is handled by InMemoryTestRunner, not via the runner.
     Cleanup steps (remove_git_worktree, branch -D) use the runner default (rc=0).
     """
     runner.push(_make_result(0, "/repo/.git/worktrees/impl-test\n"))  # rev-parse --git-dir

--- a/tests/server/test_perform_merge_editable_guard.py
+++ b/tests/server/test_perform_merge_editable_guard.py
@@ -12,7 +12,7 @@ from autoskillit.core.types import (
     TerminationReason,
     TestResult,
 )
-from tests.conftest import MockSubprocessRunner, StatefulMockTester
+from tests.fakes import InMemoryTestRunner, MockSubprocessRunner
 
 
 def _make_result(returncode: int = 0, stdout: str = "", stderr: str = "") -> SubprocessResult:
@@ -46,7 +46,7 @@ async def test_perform_merge_aborts_before_cleanup_on_poisoned_install(
     )
 
     runner = MockSubprocessRunner()
-    tester = StatefulMockTester(
+    tester = InMemoryTestRunner(
         results=[TestResult(True, "= 10 passed =", ""), TestResult(True, "= 10 passed =", "")]
     )
     # Queue git calls in step order through merge (step 8); cleanup is never reached.
@@ -104,7 +104,7 @@ async def test_perform_merge_proceeds_normally_when_guard_returns_empty(
     )
 
     runner = MockSubprocessRunner()
-    tester = StatefulMockTester(
+    tester = InMemoryTestRunner(
         results=[TestResult(True, "= 10 passed =", ""), TestResult(True, "= 10 passed =", "")]
     )
     runner.push(_make_result(0, f"{fake_wt}/.git/worktrees/wt"))  # rev-parse (step 2)

--- a/tests/server/test_run_skill_add_dirs.py
+++ b/tests/server/test_run_skill_add_dirs.py
@@ -10,40 +10,24 @@ from autoskillit.core import ValidatedAddDir
 @pytest.mark.anyio
 async def test_raw_skills_extended_excluded_from_run_skill_add_dirs(tool_ctx):
     """T-OVR-014: run_skill passes ephemeral session dir (not raw skills_extended/) as add_dirs."""
-    from autoskillit.core import SkillResult
     from autoskillit.server.tools_execution import run_skill
+    from tests.fakes import InMemoryHeadlessExecutor
 
-    captured: dict = {}
-
-    class MockExecutor:
-        async def run(self, skill_command, cwd, *, add_dirs=(), **kwargs):
-            captured["add_dirs"] = add_dirs
-            captured["cwd"] = cwd
-            return SkillResult(
-                success=True,
-                result="ok",
-                session_id="",
-                subtype="success",
-                is_error=False,
-                exit_code=0,
-                needs_retry=False,
-                retry_reason="none",
-                stderr="",
-                token_usage=None,
-            )
-
-    tool_ctx.executor = MockExecutor()
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx.executor = executor
 
     await run_skill("/autoskillit:investigate foo", "/some/cwd")
 
+    add_dirs = executor.calls[0].add_dirs
+
     # All add_dirs entries must be ValidatedAddDir instances
-    assert all(isinstance(d, ValidatedAddDir) for d in captured["add_dirs"])
+    assert all(isinstance(d, ValidatedAddDir) for d in add_dirs)
 
     # At least one add_dir must have .claude/skills/*/SKILL.md layout
     from pathlib import Path
 
     has_skills = False
-    for d in captured["add_dirs"]:
+    for d in add_dirs:
         p = Path(d.path)
         if list(p.glob(".claude/skills/*/SKILL.md")):
             has_skills = True
@@ -54,7 +38,7 @@ async def test_raw_skills_extended_excluded_from_run_skill_add_dirs(tool_ctx):
     from autoskillit.workspace.skills import bundled_skills_extended_dir
 
     skills_ext = str(bundled_skills_extended_dir())
-    add_dir_paths = [d.path for d in captured["add_dirs"]]
+    add_dir_paths = [d.path for d in add_dirs]
     assert skills_ext not in add_dir_paths, (
         "run_skill must not pass skills_extended/ directly — "
         "it should route through DefaultSessionSkillManager"

--- a/tests/server/test_tools_ci.py
+++ b/tests/server/test_tools_ci.py
@@ -16,6 +16,7 @@ from autoskillit.server.tools_ci import (
     wait_for_ci,
     wait_for_merge_queue,
 )
+from tests.fakes import InMemoryCIWatcher, InMemoryMergeQueueWatcher
 
 # ---------------------------------------------------------------------------
 # Gate membership
@@ -52,11 +53,10 @@ async def test_wait_for_ci_gate_check(tool_ctx):
 
 @pytest.mark.anyio
 async def test_wait_for_ci_success_response(tool_ctx):
-    mock_watcher = AsyncMock()
-    mock_watcher.wait = AsyncMock(
-        return_value={"run_id": 12345, "conclusion": "success", "failed_jobs": []}
+    watcher = InMemoryCIWatcher(
+        wait_result={"run_id": 12345, "conclusion": "success", "failed_jobs": []}
     )
-    tool_ctx.ci_watcher = mock_watcher
+    tool_ctx.ci_watcher = watcher
     tool_ctx.runner.push(
         SubprocessResult(
             returncode=0,
@@ -76,15 +76,14 @@ async def test_wait_for_ci_success_response(tool_ctx):
 
 @pytest.mark.anyio
 async def test_wait_for_ci_failure_response(tool_ctx):
-    mock_watcher = AsyncMock()
-    mock_watcher.wait = AsyncMock(
-        return_value={
+    watcher = InMemoryCIWatcher(
+        wait_result={
             "run_id": 12345,
             "conclusion": "failure",
             "failed_jobs": ["test", "lint"],
         }
     )
-    tool_ctx.ci_watcher = mock_watcher
+    tool_ctx.ci_watcher = watcher
     tool_ctx.runner.push(
         SubprocessResult(
             returncode=0,
@@ -109,11 +108,10 @@ async def test_wait_for_ci_failure_response(tool_ctx):
 @pytest.mark.anyio
 async def test_wait_for_ci_infers_head_sha(tool_ctx):
     """When head_sha is not provided, it's inferred via git rev-parse HEAD."""
-    mock_watcher = AsyncMock()
-    mock_watcher.wait = AsyncMock(
-        return_value={"run_id": 1, "conclusion": "success", "failed_jobs": []}
+    watcher = InMemoryCIWatcher(
+        wait_result={"run_id": 1, "conclusion": "success", "failed_jobs": []}
     )
-    tool_ctx.ci_watcher = mock_watcher
+    tool_ctx.ci_watcher = watcher
     tool_ctx.runner.push(
         SubprocessResult(
             returncode=0,
@@ -127,18 +125,16 @@ async def test_wait_for_ci_infers_head_sha(tool_ctx):
     await wait_for_ci("main", cwd="/some/repo")
 
     # Verify that wait was called with the inferred head_sha inside scope
-    call_kwargs = mock_watcher.wait.call_args
-    assert call_kwargs.kwargs["scope"].head_sha == "abc123"
+    assert watcher.wait_calls[-1]["scope"].head_sha == "abc123"
 
 
 @pytest.mark.anyio
 async def test_wait_for_ci_head_sha_uses_runner(tool_ctx):
     """git rev-parse HEAD must flow through MockSubprocessRunner, not raw asyncio."""
-    mock_watcher = AsyncMock()
-    mock_watcher.wait = AsyncMock(
-        return_value={"run_id": 1, "conclusion": "success", "failed_jobs": []}
+    watcher = InMemoryCIWatcher(
+        wait_result={"run_id": 1, "conclusion": "success", "failed_jobs": []}
     )
-    tool_ctx.ci_watcher = mock_watcher
+    tool_ctx.ci_watcher = watcher
 
     # Pre-configure runner to return a valid SHA when git rev-parse is called
     tool_ctx.runner.push(
@@ -159,8 +155,7 @@ async def test_wait_for_ci_head_sha_uses_runner(tool_ctx):
     assert cmd == ["git", "rev-parse", "HEAD"], f"Unexpected runner call: {cmd}"
 
     # SHA extracted from runner output must have been passed to the CI watcher
-    scope = mock_watcher.wait.call_args.kwargs["scope"]
-    assert scope.head_sha == "deadbeef"
+    assert watcher.wait_calls[-1]["scope"].head_sha == "deadbeef"
 
 
 # ---------------------------------------------------------------------------
@@ -191,8 +186,8 @@ async def test_get_ci_status_gate_check(tool_ctx):
 
 @pytest.mark.anyio
 async def test_get_ci_status_missing_branch_and_run_id(tool_ctx):
-    mock_watcher = AsyncMock()
-    tool_ctx.ci_watcher = mock_watcher
+    watcher = InMemoryCIWatcher()
+    tool_ctx.ci_watcher = watcher
 
     result = json.loads(await get_ci_status())
     assert result["runs"] == []
@@ -215,19 +210,13 @@ async def test_get_ci_status_no_watcher(tool_ctx):
 @pytest.mark.anyio
 async def test_wait_for_ci_passes_event_to_scope(tool_ctx):
     """wait_for_ci must propagate event param into CIRunScope."""
-    captured_scope = None
-
-    async def _side_effect(branch, *, repo, scope, **kw):
-        nonlocal captured_scope
-        captured_scope = scope
-        return {"run_id": 1, "conclusion": "success", "failed_jobs": []}
-
-    mock_watcher = AsyncMock()
-    mock_watcher.wait = AsyncMock(side_effect=_side_effect)
-    tool_ctx.ci_watcher = mock_watcher
+    watcher = InMemoryCIWatcher(
+        wait_result={"run_id": 1, "conclusion": "success", "failed_jobs": []}
+    )
+    tool_ctx.ci_watcher = watcher
     await wait_for_ci(branch="main", event="push", cwd="/tmp")
-    assert captured_scope is not None
-    assert captured_scope.event == "push"
+    assert len(watcher.wait_calls) == 1
+    assert watcher.wait_calls[-1]["scope"].event == "push"
 
 
 # ---------------------------------------------------------------------------
@@ -250,11 +239,10 @@ async def test_gate_closed_returns_gate_error(tool_ctx):
 
 @pytest.mark.anyio
 async def test_delegates_to_merge_queue_watcher(tool_ctx):
-    mock_watcher = AsyncMock()
-    mock_watcher.wait = AsyncMock(
-        return_value={"success": True, "pr_state": "merged", "reason": "PR merged"}
+    watcher = InMemoryMergeQueueWatcher(
+        wait_result={"success": True, "pr_state": "merged", "reason": "PR merged"}
     )
-    tool_ctx.merge_queue_watcher = mock_watcher
+    tool_ctx.merge_queue_watcher = watcher
 
     with patch(
         "autoskillit.execution.remote_resolver.asyncio.create_subprocess_exec",
@@ -272,19 +260,17 @@ async def test_delegates_to_merge_queue_watcher(tool_ctx):
         )
 
     assert result["pr_state"] == "merged"
-    mock_watcher.wait.assert_called_once()
-    call_kwargs = mock_watcher.wait.call_args
-    assert call_kwargs.kwargs["pr_number"] == 42
-    assert call_kwargs.kwargs["target_branch"] == "integration"
+    assert len(watcher.wait_calls) == 1
+    assert watcher.wait_calls[-1]["pr_number"] == 42
+    assert watcher.wait_calls[-1]["target_branch"] == "integration"
 
 
 @pytest.mark.anyio
 async def test_infers_repo_from_git_remote_when_repo_empty(tool_ctx):
-    mock_watcher = AsyncMock()
-    mock_watcher.wait = AsyncMock(
-        return_value={"success": True, "pr_state": "merged", "reason": "PR merged"}
+    watcher = InMemoryMergeQueueWatcher(
+        wait_result={"success": True, "pr_state": "merged", "reason": "PR merged"}
     )
-    tool_ctx.merge_queue_watcher = mock_watcher
+    tool_ctx.merge_queue_watcher = watcher
 
     with patch(
         "autoskillit.execution.remote_resolver.asyncio.create_subprocess_exec",
@@ -299,17 +285,15 @@ async def test_infers_repo_from_git_remote_when_repo_empty(tool_ctx):
 
         await wait_for_merge_queue(pr_number=42, target_branch="main", cwd=".", repo="")
 
-    call_kwargs = mock_watcher.wait.call_args
-    assert call_kwargs.kwargs["repo"] == "owner/repo"
+    assert watcher.wait_calls[-1]["repo"] == "owner/repo"
 
 
 @pytest.mark.anyio
 async def test_explicit_repo_skips_subprocess(tool_ctx):
-    mock_watcher = AsyncMock()
-    mock_watcher.wait = AsyncMock(
-        return_value={"success": True, "pr_state": "merged", "reason": "PR merged"}
+    watcher = InMemoryMergeQueueWatcher(
+        wait_result={"success": True, "pr_state": "merged", "reason": "PR merged"}
     )
-    tool_ctx.merge_queue_watcher = mock_watcher
+    tool_ctx.merge_queue_watcher = watcher
 
     with patch(
         "autoskillit.execution.remote_resolver.asyncio.create_subprocess_exec",
@@ -323,8 +307,7 @@ async def test_explicit_repo_skips_subprocess(tool_ctx):
         )
 
     mock_proc.assert_not_called()
-    call_kwargs = mock_watcher.wait.call_args
-    assert call_kwargs.kwargs["repo"] == "owner/explicit-repo"
+    assert watcher.wait_calls[-1]["repo"] == "owner/explicit-repo"
 
 
 @pytest.mark.anyio
@@ -345,14 +328,15 @@ async def test_watcher_none_returns_error(tool_ctx):
 async def test_wait_for_ci_parses_remote_url_to_resolve_repo(tool_ctx):
     """When remote_url is provided, wait_for_ci must parse it to owner/repo
     and pass that to the watcher without calling any subprocess."""
-    mock_watcher = AsyncMock()
-    mock_watcher.wait.return_value = {
-        "conclusion": "success",
-        "run_id": 1,
-        "failed_jobs": [],
-        "head_sha": "abc123",
-    }
-    tool_ctx.ci_watcher = mock_watcher
+    watcher = InMemoryCIWatcher(
+        wait_result={
+            "conclusion": "success",
+            "run_id": 1,
+            "failed_jobs": [],
+            "head_sha": "abc123",
+        }
+    )
+    tool_ctx.ci_watcher = watcher
 
     result = json.loads(
         await wait_for_ci(
@@ -362,28 +346,28 @@ async def test_wait_for_ci_parses_remote_url_to_resolve_repo(tool_ctx):
         )
     )
     assert result["conclusion"] == "success"
-    call_kwargs = mock_watcher.wait.call_args
-    assert call_kwargs.kwargs.get("repo") == "owner/repo"
+    assert watcher.wait_calls[-1].get("repo") == "owner/repo"
 
 
 @pytest.mark.anyio
 async def test_wait_for_ci_remote_url_wins_over_empty_repo(tool_ctx):
     """remote_url= supersedes repo='' — hint priority in resolve_remote_repo."""
-    mock_watcher = AsyncMock()
-    mock_watcher.wait.return_value = {
-        "conclusion": "success",
-        "run_id": 1,
-        "failed_jobs": [],
-        "head_sha": "abc",
-    }
-    tool_ctx.ci_watcher = mock_watcher
+    watcher = InMemoryCIWatcher(
+        wait_result={
+            "conclusion": "success",
+            "run_id": 1,
+            "failed_jobs": [],
+            "head_sha": "abc",
+        }
+    )
+    tool_ctx.ci_watcher = watcher
     await wait_for_ci(
         branch="main",
         remote_url="https://github.com/owner/repo.git",
         repo="",  # empty — remote_url must win
         cwd="/any/cwd",
     )
-    assert mock_watcher.wait.call_args.kwargs.get("repo") == "owner/repo"
+    assert watcher.wait_calls[-1].get("repo") == "owner/repo"
 
 
 # ---------------------------------------------------------------------------
@@ -395,9 +379,10 @@ async def test_wait_for_ci_remote_url_wins_over_empty_repo(tool_ctx):
 async def test_wait_for_merge_queue_parses_remote_url_to_resolve_repo(tool_ctx):
     """When remote_url is provided, wait_for_merge_queue parses it to owner/repo
     without calling any subprocess."""
-    mock_watcher = AsyncMock()
-    mock_watcher.wait.return_value = {"success": True, "pr_state": "merged", "pr_number": 42}
-    tool_ctx.merge_queue_watcher = mock_watcher
+    watcher = InMemoryMergeQueueWatcher(
+        wait_result={"success": True, "pr_state": "merged", "pr_number": 42}
+    )
+    tool_ctx.merge_queue_watcher = watcher
 
     result = json.loads(
         await wait_for_merge_queue(
@@ -408,8 +393,7 @@ async def test_wait_for_merge_queue_parses_remote_url_to_resolve_repo(tool_ctx):
         )
     )
     assert result["pr_state"] == "merged"
-    call_kwargs = mock_watcher.wait.call_args
-    assert call_kwargs.kwargs.get("repo") == "owner/repo"
+    assert watcher.wait_calls[-1].get("repo") == "owner/repo"
 
 
 class TestWaitForCiTiming:
@@ -417,21 +401,19 @@ class TestWaitForCiTiming:
 
     @pytest.mark.anyio
     async def test_wait_for_ci_step_name_records_timing(self, tool_ctx):
-        mock_watcher = AsyncMock()
-        mock_watcher.wait = AsyncMock(
-            return_value={"run_id": 1, "conclusion": "success", "failed_jobs": []}
+        watcher = InMemoryCIWatcher(
+            wait_result={"run_id": 1, "conclusion": "success", "failed_jobs": []}
         )
-        tool_ctx.ci_watcher = mock_watcher
+        tool_ctx.ci_watcher = watcher
         await wait_for_ci("main", step_name="ci_wait")
         assert any(e["step_name"] == "ci_wait" for e in tool_ctx.timing_log.get_report())
 
     @pytest.mark.anyio
     async def test_wait_for_ci_empty_step_name_skips_timing(self, tool_ctx):
-        mock_watcher = AsyncMock()
-        mock_watcher.wait = AsyncMock(
-            return_value={"run_id": 1, "conclusion": "success", "failed_jobs": []}
+        watcher = InMemoryCIWatcher(
+            wait_result={"run_id": 1, "conclusion": "success", "failed_jobs": []}
         )
-        tool_ctx.ci_watcher = mock_watcher
+        tool_ctx.ci_watcher = watcher
         await wait_for_ci("main")
         assert tool_ctx.timing_log.get_report() == []
 
@@ -441,11 +423,10 @@ class TestWaitForMergeQueueTiming:
 
     @pytest.mark.anyio
     async def test_wait_for_merge_queue_step_name_records_timing(self, tool_ctx):
-        mock_watcher = AsyncMock()
-        mock_watcher.wait = AsyncMock(
-            return_value={"success": True, "pr_state": "merged", "reason": "PR merged"}
+        watcher = InMemoryMergeQueueWatcher(
+            wait_result={"success": True, "pr_state": "merged", "reason": "PR merged"}
         )
-        tool_ctx.merge_queue_watcher = mock_watcher
+        tool_ctx.merge_queue_watcher = watcher
         with patch(
             "autoskillit.execution.remote_resolver.asyncio.create_subprocess_exec",
             new_callable=AsyncMock,
@@ -463,11 +444,10 @@ class TestWaitForMergeQueueTiming:
 
     @pytest.mark.anyio
     async def test_wait_for_merge_queue_empty_step_name_skips_timing(self, tool_ctx):
-        mock_watcher = AsyncMock()
-        mock_watcher.wait = AsyncMock(
-            return_value={"success": True, "pr_state": "merged", "reason": "PR merged"}
+        watcher = InMemoryMergeQueueWatcher(
+            wait_result={"success": True, "pr_state": "merged", "reason": "PR merged"}
         )
-        tool_ctx.merge_queue_watcher = mock_watcher
+        tool_ctx.merge_queue_watcher = watcher
         with patch(
             "autoskillit.execution.remote_resolver.asyncio.create_subprocess_exec",
             new_callable=AsyncMock,
@@ -490,13 +470,14 @@ async def test_wait_for_merge_queue_invalid_remote_url_falls_through_to_inferenc
     remote_url that parses to None (e.g. file://) does NOT short-circuit;
     inference continues via resolve_remote_repo(cwd).
     """
-    mock_watcher = AsyncMock()
-    mock_watcher.wait.return_value = {
-        "success": False,
-        "pr_state": "error",
-        "reason": "Invalid repo format: None",
-    }
-    tool_ctx.merge_queue_watcher = mock_watcher
+    watcher = InMemoryMergeQueueWatcher(
+        wait_result={
+            "success": False,
+            "pr_state": "error",
+            "reason": "Invalid repo format: None",
+        }
+    )
+    tool_ctx.merge_queue_watcher = watcher
 
     # provide a file:// remote_url — should fall through, eventually fail gracefully
     result = json.loads(
@@ -509,7 +490,7 @@ async def test_wait_for_merge_queue_invalid_remote_url_falls_through_to_inferenc
     )
     assert result["pr_state"] == "error"
     # The file:// URL must not resolve to a GitHub repo, so watcher receives repo=None
-    assert mock_watcher.wait.call_args.kwargs.get("repo") is None
+    assert watcher.wait_calls[-1].get("repo") is None
 
 
 # ---------------------------------------------------------------------------
@@ -520,31 +501,27 @@ async def test_wait_for_merge_queue_invalid_remote_url_falls_through_to_inferenc
 @pytest.mark.anyio
 async def test_wait_for_ci_handler_passes_workflow(tool_ctx):
     """wait_for_ci MCP handler must forward workflow to watcher via scope."""
-    mock_watcher = AsyncMock()
-    mock_watcher.wait = AsyncMock(
-        return_value={"conclusion": "success", "failed_jobs": [], "run_id": 1}
+    watcher = InMemoryCIWatcher(
+        wait_result={"conclusion": "success", "failed_jobs": [], "run_id": 1}
     )
-    tool_ctx.ci_watcher = mock_watcher
+    tool_ctx.ci_watcher = watcher
 
     # cwd="" → head_sha inference skipped (empty string is falsy)
     json.loads(await wait_for_ci(branch="main", workflow="tests.yml", cwd=""))
 
-    mock_watcher.wait.assert_called_once()
-    call_kwargs = mock_watcher.wait.call_args
-    assert call_kwargs.kwargs["scope"].workflow == "tests.yml"
+    assert len(watcher.wait_calls) == 1
+    assert watcher.wait_calls[-1]["scope"].workflow == "tests.yml"
 
 
 @pytest.mark.anyio
 async def test_get_ci_status_handler_passes_workflow(tool_ctx):
     """get_ci_status MCP handler must forward workflow to watcher via scope."""
-    mock_watcher = AsyncMock()
-    mock_watcher.status = AsyncMock(return_value={"runs": []})
-    tool_ctx.ci_watcher = mock_watcher
+    watcher = InMemoryCIWatcher(status_result={"runs": []})
+    tool_ctx.ci_watcher = watcher
 
     await get_ci_status(branch="main", workflow="tests.yml")
 
-    call_kwargs = mock_watcher.status.call_args
-    assert call_kwargs.kwargs["scope"].workflow == "tests.yml"
+    assert watcher.status_calls[-1]["scope"].workflow == "tests.yml"
 
 
 # ---------------------------------------------------------------------------
@@ -559,9 +536,9 @@ async def test_wait_for_ci_watcher_exception_returns_structured_json(tool_ctx):
     BEFORE fix: bare raise propagates to track_response_size which adds
     subtype='tool_exception'. AFTER fix: explicit return gives clean JSON.
     """
-    mock_watcher = AsyncMock()
-    mock_watcher.wait = AsyncMock(side_effect=RuntimeError("network timeout"))
-    tool_ctx.ci_watcher = mock_watcher
+    watcher = InMemoryCIWatcher()
+    watcher.wait_side_effect = RuntimeError("network timeout")
+    tool_ctx.ci_watcher = watcher
 
     with patch(
         "autoskillit.execution.remote_resolver.asyncio.create_subprocess_exec",
@@ -587,9 +564,9 @@ async def test_wait_for_merge_queue_watcher_exception_returns_structured_json(to
     BEFORE fix: bare raise propagates to track_response_size decorator.
     AFTER fix: explicit return gives clean JSON.
     """
-    mock_watcher = AsyncMock()
-    mock_watcher.wait = AsyncMock(side_effect=RuntimeError("connection refused"))
-    tool_ctx.merge_queue_watcher = mock_watcher
+    watcher = InMemoryMergeQueueWatcher()
+    watcher.wait_side_effect = RuntimeError("connection refused")
+    tool_ctx.merge_queue_watcher = watcher
 
     with patch(
         "autoskillit.execution.remote_resolver.asyncio.create_subprocess_exec",
@@ -617,11 +594,10 @@ async def test_wait_for_merge_queue_watcher_exception_returns_structured_json(to
 @pytest.mark.anyio
 async def test_wait_for_ci_includes_head_sha_in_result(tool_ctx):
     """wait_for_ci result includes head_sha when git rev-parse HEAD succeeds."""
-    mock_watcher = AsyncMock()
-    mock_watcher.wait = AsyncMock(
-        return_value={"run_id": 1, "conclusion": "success", "failed_jobs": []}
+    watcher = InMemoryCIWatcher(
+        wait_result={"run_id": 1, "conclusion": "success", "failed_jobs": []}
     )
-    tool_ctx.ci_watcher = mock_watcher
+    tool_ctx.ci_watcher = watcher
     tool_ctx.runner.push(
         SubprocessResult(
             returncode=0,
@@ -640,11 +616,10 @@ async def test_wait_for_ci_includes_head_sha_in_result(tool_ctx):
 @pytest.mark.anyio
 async def test_wait_for_ci_omits_head_sha_when_git_fails(tool_ctx):
     """wait_for_ci result omits head_sha when git rev-parse fails."""
-    mock_watcher = AsyncMock()
-    mock_watcher.wait = AsyncMock(
-        return_value={"run_id": 1, "conclusion": "success", "failed_jobs": []}
+    watcher = InMemoryCIWatcher(
+        wait_result={"run_id": 1, "conclusion": "success", "failed_jobs": []}
     )
-    tool_ctx.ci_watcher = mock_watcher
+    tool_ctx.ci_watcher = watcher
     tool_ctx.runner.push(
         SubprocessResult(
             returncode=128,
@@ -673,15 +648,14 @@ async def test_wait_for_merge_queue_serializes_every_pr_state(pr_state, tool_ctx
 
     Adding a new PRState member without a handler test fails this parametrized suite.
     """
-    mock_watcher = AsyncMock()
-    mock_watcher.wait = AsyncMock(
-        return_value={
+    watcher = InMemoryMergeQueueWatcher(
+        wait_result={
             "success": pr_state == PRState.MERGED,
             "pr_state": pr_state.value,
             "reason": f"test reason for {pr_state.value}",
         }
     )
-    tool_ctx.merge_queue_watcher = mock_watcher
+    tool_ctx.merge_queue_watcher = watcher
 
     with patch(
         "autoskillit.execution.remote_resolver.asyncio.create_subprocess_exec",

--- a/tests/server/test_tools_execution.py
+++ b/tests/server/test_tools_execution.py
@@ -808,105 +808,41 @@ class TestNotifyHelper:
 @pytest.mark.anyio
 async def test_tools_execution_routes_through_executor(tool_ctx, monkeypatch) -> None:
     """run_skill routes through ctx.executor.run(), not run_headless_core directly."""
-    from autoskillit.core import SkillResult
+    from tests.fakes import InMemoryHeadlessExecutor
 
-    calls = []
-
-    class MockExecutor:
-        async def run(
-            self,
-            skill_command: str,
-            cwd: str,
-            *,
-            model: str = "",
-            step_name: str = "",
-            add_dirs=(),
-            kitchen_id: str = "",
-            order_id: str = "",
-            timeout: float | None = None,
-            stale_threshold: float | None = None,
-            idle_output_timeout: float | None = None,
-            expected_output_patterns: tuple[str, ...] | list[str] = (),
-            write_behavior=None,
-            completion_marker: str = "",
-        ) -> SkillResult:
-            calls.append((skill_command, cwd))
-            return SkillResult(
-                success=True,
-                result="ok",
-                session_id="",
-                subtype="success",
-                is_error=False,
-                exit_code=0,
-                needs_retry=False,
-                retry_reason="none",
-                stderr="",
-                token_usage=None,
-            )
-
-    tool_ctx.executor = MockExecutor()
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx.executor = executor
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
 
     from autoskillit.server.tools_execution import run_skill
 
     await run_skill("/test skill", "/tmp")
-    assert calls == [("/test skill", "/tmp")]
+    assert len(executor.calls) == 1
+    assert executor.calls[0].skill_command == "/test skill"
+    assert executor.calls[0].cwd == "/tmp"
 
 
 @pytest.mark.anyio
 async def test_run_skill_passes_validated_add_dirs(tool_ctx, monkeypatch) -> None:
     """run_skill passes ValidatedAddDir instances (not raw strings) as add_dirs."""
-    from autoskillit.core import SkillResult, ValidatedAddDir
+    from autoskillit.core import ValidatedAddDir
+    from tests.fakes import InMemoryHeadlessExecutor
 
-    captured: dict = {}
-
-    class MockExecutor:
-        async def run(
-            self,
-            skill_command: str,
-            cwd: str,
-            *,
-            model: str = "",
-            step_name: str = "",
-            add_dirs=(),
-            kitchen_id: str = "",
-            order_id: str = "",
-            timeout: float | None = None,
-            stale_threshold: float | None = None,
-            idle_output_timeout: float | None = None,
-            expected_output_patterns: tuple[str, ...] | list[str] = (),
-            write_behavior=None,
-            completion_marker: str = "",
-        ) -> SkillResult:
-            captured["add_dirs"] = add_dirs
-            captured["cwd"] = cwd
-            return SkillResult(
-                success=True,
-                result="ok",
-                session_id="",
-                subtype="success",
-                is_error=False,
-                exit_code=0,
-                needs_retry=False,
-                retry_reason="none",
-                stderr="",
-                token_usage=None,
-            )
-
-    tool_ctx.executor = MockExecutor()
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx.executor = executor
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
 
     from autoskillit.server.tools_execution import run_skill
 
     await run_skill("/test skill", "/tmp")
     # All add_dirs must be ValidatedAddDir instances
-    assert len(captured["add_dirs"]) >= 1
-    assert all(isinstance(d, ValidatedAddDir) for d in captured["add_dirs"])
+    assert len(executor.calls[0].add_dirs) >= 1
+    assert all(isinstance(d, ValidatedAddDir) for d in executor.calls[0].add_dirs)
     # Must not include raw skills_extended/ path
     from autoskillit.workspace.skills import bundled_skills_extended_dir
 
     skills_ext = str(bundled_skills_extended_dir())
-    add_dir_paths = [d.path for d in captured["add_dirs"]]
+    add_dir_paths = [d.path for d in executor.calls[0].add_dirs]
     assert skills_ext not in add_dir_paths
 
 
@@ -915,7 +851,7 @@ async def test_run_skill_calls_session_skill_manager_init_session(tool_ctx, monk
     """run_skill routes through session_skill_manager.init_session() for add_dirs."""
     from unittest.mock import MagicMock
 
-    from autoskillit.core import SkillResult, ValidatedAddDir
+    from autoskillit.core import ValidatedAddDir
 
     # Create a spy on init_session
     fake_validated = ValidatedAddDir(path="/fake/session/dir")
@@ -923,25 +859,10 @@ async def test_run_skill_calls_session_skill_manager_init_session(tool_ctx, monk
     mock_ssm.init_session.return_value = fake_validated
     tool_ctx.session_skill_manager = mock_ssm
 
-    captured: dict = {}
+    from tests.fakes import InMemoryHeadlessExecutor
 
-    class MockExecutor:
-        async def run(self, skill_command, cwd, *, add_dirs=(), **kwargs) -> SkillResult:
-            captured["add_dirs"] = add_dirs
-            return SkillResult(
-                success=True,
-                result="ok",
-                session_id="",
-                subtype="success",
-                is_error=False,
-                exit_code=0,
-                needs_retry=False,
-                retry_reason="none",
-                stderr="",
-                token_usage=None,
-            )
-
-    tool_ctx.executor = MockExecutor()
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx.executor = executor
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
 
     from autoskillit.server.tools_execution import run_skill
@@ -954,7 +875,7 @@ async def test_run_skill_calls_session_skill_manager_init_session(tool_ctx, monk
     assert call_kwargs.kwargs.get("cook_session") is False
 
     # The returned ValidatedAddDir is in add_dirs
-    assert fake_validated in captured["add_dirs"]
+    assert fake_validated in executor.calls[0].add_dirs
 
 
 @pytest.mark.anyio
@@ -962,7 +883,7 @@ async def test_run_skill_activates_deps_for_tier3_target(tool_ctx, monkeypatch) 
     """run_skill calls activate_skill_deps even when target is tier3 (not in tier2 list)."""
     from unittest.mock import MagicMock
 
-    from autoskillit.core import SkillResult, ValidatedAddDir
+    from autoskillit.core import ValidatedAddDir
 
     fake_validated = ValidatedAddDir(path="/fake/session/dir")
     mock_ssm = MagicMock()
@@ -974,22 +895,9 @@ async def test_run_skill_activates_deps_for_tier3_target(tool_ctx, monkeypatch) 
     mock_resolver.resolve.return_value = MagicMock(source=MagicMock(value="bundled_extended"))
     tool_ctx.skill_resolver = mock_resolver
 
-    class MockExecutor:
-        async def run(self, skill_command, cwd, *, add_dirs=(), **kwargs) -> SkillResult:
-            return SkillResult(
-                success=True,
-                result="ok",
-                session_id="",
-                subtype="success",
-                is_error=False,
-                exit_code=0,
-                needs_retry=False,
-                retry_reason="none",
-                stderr="",
-                token_usage=None,
-            )
+    from tests.fakes import InMemoryHeadlessExecutor
 
-    tool_ctx.executor = MockExecutor()
+    tool_ctx.executor = InMemoryHeadlessExecutor()
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
 
     from autoskillit.server.tools_execution import run_skill
@@ -1006,24 +914,9 @@ async def test_run_skill_result_includes_order_id_when_passed(tool_ctx, monkeypa
     """run_skill injects order_id into the result JSON when order_id is non-empty."""
     import json as _json
 
-    from autoskillit.core import SkillResult
+    from tests.fakes import InMemoryHeadlessExecutor
 
-    class MockExecutor:
-        async def run(self, skill_command, cwd, *, add_dirs=(), **kwargs) -> SkillResult:
-            return SkillResult(
-                success=True,
-                result="done",
-                session_id="",
-                subtype="success",
-                is_error=False,
-                exit_code=0,
-                needs_retry=False,
-                retry_reason="none",
-                stderr="",
-                token_usage=None,
-            )
-
-    tool_ctx.executor = MockExecutor()
+    tool_ctx.executor = InMemoryHeadlessExecutor()
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
 
     from autoskillit.server.tools_execution import run_skill
@@ -1038,24 +931,9 @@ async def test_run_skill_result_no_order_id_field_when_empty(tool_ctx, monkeypat
     """run_skill does NOT inject order_id into result JSON when order_id is empty."""
     import json as _json
 
-    from autoskillit.core import SkillResult
+    from tests.fakes import InMemoryHeadlessExecutor
 
-    class MockExecutor:
-        async def run(self, skill_command, cwd, *, add_dirs=(), **kwargs) -> SkillResult:
-            return SkillResult(
-                success=True,
-                result="done",
-                session_id="",
-                subtype="success",
-                is_error=False,
-                exit_code=0,
-                needs_retry=False,
-                retry_reason="none",
-                stderr="",
-                token_usage=None,
-            )
-
-    tool_ctx.executor = MockExecutor()
+    tool_ctx.executor = InMemoryHeadlessExecutor()
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
 
     from autoskillit.server.tools_execution import run_skill
@@ -1324,7 +1202,8 @@ async def test_run_skill_passes_allow_only_to_init_session(tool_ctx, monkeypatch
     """run_skill computes the closure for the resolved target and forwards it as allow_only."""
     from unittest.mock import MagicMock
 
-    from autoskillit.core import SkillResult, ValidatedAddDir
+    from autoskillit.core import ValidatedAddDir
+    from tests.fakes import InMemoryHeadlessExecutor
 
     fake_validated = ValidatedAddDir(path="/fake/session/dir")
     expected_closure = frozenset({"investigate", "mermaid"})
@@ -1338,22 +1217,7 @@ async def test_run_skill_passes_allow_only_to_init_session(tool_ctx, monkeypatch
     mock_resolver.resolve.return_value = MagicMock(source=MagicMock(value="bundled_extended"))
     tool_ctx.skill_resolver = mock_resolver
 
-    class MockExecutor:
-        async def run(self, skill_command, cwd, *, add_dirs=(), **kwargs) -> SkillResult:
-            return SkillResult(
-                success=True,
-                result="ok",
-                session_id="",
-                subtype="success",
-                is_error=False,
-                exit_code=0,
-                needs_retry=False,
-                retry_reason="none",
-                stderr="",
-                token_usage=None,
-            )
-
-    tool_ctx.executor = MockExecutor()
+    tool_ctx.executor = InMemoryHeadlessExecutor()
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
 
     from autoskillit.server.tools_execution import run_skill
@@ -1370,7 +1234,8 @@ async def test_run_skill_no_target_skill_passes_none_allow_only(tool_ctx, monkey
     """When skill_resolver is unset, target_name is None and allow_only stays None."""
     from unittest.mock import MagicMock
 
-    from autoskillit.core import SkillResult, ValidatedAddDir
+    from autoskillit.core import ValidatedAddDir
+    from tests.fakes import InMemoryHeadlessExecutor
 
     fake_validated = ValidatedAddDir(path="/fake/session/dir")
     mock_ssm = MagicMock()
@@ -1378,22 +1243,7 @@ async def test_run_skill_no_target_skill_passes_none_allow_only(tool_ctx, monkey
     tool_ctx.session_skill_manager = mock_ssm
     tool_ctx.skill_resolver = None  # disables resolve_target_skill
 
-    class MockExecutor:
-        async def run(self, skill_command, cwd, *, add_dirs=(), **kwargs) -> SkillResult:
-            return SkillResult(
-                success=True,
-                result="ok",
-                session_id="",
-                subtype="success",
-                is_error=False,
-                exit_code=0,
-                needs_retry=False,
-                retry_reason="none",
-                stderr="",
-                token_usage=None,
-            )
-
-    tool_ctx.executor = MockExecutor()
+    tool_ctx.executor = InMemoryHeadlessExecutor()
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
 
     from autoskillit.server.tools_execution import run_skill
@@ -1410,11 +1260,12 @@ async def test_run_skill_make_plan_closure_includes_arch_lens_pack(tool_ctx, mon
     """End-to-end: /make-plan resolves a closure containing the entire arch-lens pack."""
     from unittest.mock import MagicMock
 
-    from autoskillit.core import SkillResult, ValidatedAddDir
+    from autoskillit.core import ValidatedAddDir
     from autoskillit.workspace.session_skills import (
         DefaultSessionSkillManager,
         SkillsDirectoryProvider,
     )
+    from tests.fakes import InMemoryHeadlessExecutor
 
     real_provider = SkillsDirectoryProvider()
     real_mgr = DefaultSessionSkillManager(provider=real_provider, ephemeral_root=tool_ctx.temp_dir)
@@ -1444,22 +1295,7 @@ async def test_run_skill_make_plan_closure_includes_arch_lens_pack(tool_ctx, mon
     mock_resolver.resolve.return_value = MagicMock(source=MagicMock(value="bundled_extended"))
     tool_ctx.skill_resolver = mock_resolver
 
-    class MockExecutor:
-        async def run(self, skill_command, cwd, *, add_dirs=(), **kwargs) -> SkillResult:
-            return SkillResult(
-                success=True,
-                result="ok",
-                session_id="",
-                subtype="success",
-                is_error=False,
-                exit_code=0,
-                needs_retry=False,
-                retry_reason="none",
-                stderr="",
-                token_usage=None,
-            )
-
-    tool_ctx.executor = MockExecutor()
+    tool_ctx.executor = InMemoryHeadlessExecutor()
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
 
     from autoskillit.server.tools_execution import run_skill
@@ -1474,57 +1310,34 @@ async def test_run_skill_make_plan_closure_includes_arch_lens_pack(tool_ctx, mon
     assert len(arch_members) >= 1
 
 
-def _make_capturing_executor():
-    """Return (executor, captured_dict) for testing idle_output_timeout propagation."""
-    from autoskillit.core import SkillResult
-
-    captured: dict = {}
-
-    class MockExecutor:
-        async def run(
-            self, skill_command, cwd, *, idle_output_timeout=None, **kwargs
-        ) -> SkillResult:
-            captured["idle_output_timeout"] = idle_output_timeout
-            return SkillResult(
-                success=True,
-                result="ok",
-                session_id="",
-                subtype="success",
-                is_error=False,
-                exit_code=0,
-                needs_retry=False,
-                retry_reason="none",
-                stderr="",
-                token_usage=None,
-            )
-
-    return MockExecutor(), captured
-
-
 @pytest.mark.anyio
 async def test_run_skill_passes_idle_output_timeout(tool_ctx, monkeypatch) -> None:
     """run_skill passes idle_output_timeout (as float) to executor.run()."""
-    executor, captured = _make_capturing_executor()
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    executor = InMemoryHeadlessExecutor()
     tool_ctx.executor = executor
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
 
     from autoskillit.server.tools_execution import run_skill
 
     await run_skill("/test skill", "/tmp", idle_output_timeout=120)
-    assert captured["idle_output_timeout"] == 120.0  # int→float conversion
+    assert executor.calls[0].idle_output_timeout == 120.0  # int→float conversion
 
 
 @pytest.mark.anyio
 async def test_run_skill_idle_output_timeout_defaults_to_none(tool_ctx, monkeypatch) -> None:
     """run_skill passes None to executor.run() when idle_output_timeout is not set."""
-    executor, captured = _make_capturing_executor()
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    executor = InMemoryHeadlessExecutor()
     tool_ctx.executor = executor
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
 
     from autoskillit.server.tools_execution import run_skill
 
     await run_skill("/test skill", "/tmp")
-    assert captured["idle_output_timeout"] is None
+    assert executor.calls[0].idle_output_timeout is None
 
 
 @pytest.mark.anyio

--- a/tests/server/test_tools_run_cmd_unit.py
+++ b/tests/server/test_tools_run_cmd_unit.py
@@ -106,8 +106,8 @@ class TestRunCmdRecording:
         from unittest.mock import Mock
 
         from autoskillit.execution.recording import RecordingSubprocessRunner
-        from tests.conftest import MockSubprocessRunner
         from tests.conftest import _make_result as _mr
+        from tests.fakes import MockSubprocessRunner
 
         mock_recorder = Mock()
         inner = MockSubprocessRunner()
@@ -129,8 +129,8 @@ class TestRunCmdRecording:
         from unittest.mock import Mock
 
         from autoskillit.execution.recording import RecordingSubprocessRunner
-        from tests.conftest import MockSubprocessRunner
         from tests.conftest import _make_result as _mr
+        from tests.fakes import MockSubprocessRunner
 
         mock_recorder = Mock()
         inner = MockSubprocessRunner()

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -25,7 +25,7 @@ def test_tool_ctx_provides_isolated_token_log(tool_ctx):
 
 async def test_mock_subprocess_runner_push_and_pop(tmp_path: Path):
     """MockSubprocessRunner.push() queues results, __call__ pops in order."""
-    from tests.conftest import MockSubprocessRunner
+    from tests.fakes import MockSubprocessRunner
 
     runner = MockSubprocessRunner()
     r1 = SubprocessResult(0, "out1", "", TerminationReason.NATURAL_EXIT, 100)
@@ -41,7 +41,7 @@ async def test_mock_subprocess_runner_push_and_pop(tmp_path: Path):
 
 async def test_mock_subprocess_runner_default_when_empty(tmp_path: Path):
     """MockSubprocessRunner returns a zero-exit default when queue is empty."""
-    from tests.conftest import MockSubprocessRunner
+    from tests.fakes import MockSubprocessRunner
 
     runner = MockSubprocessRunner()
     result = await runner(["cmd"], cwd=tmp_path, timeout=30.0)

--- a/tests/test_fakes_conformance.py
+++ b/tests/test_fakes_conformance.py
@@ -1,0 +1,208 @@
+"""Protocol conformance and behavioral tests for tests/fakes.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from autoskillit.core.types import (
+    CIWatcher,
+    DatabaseReader,
+    HeadlessExecutor,
+    MergeQueueWatcher,
+    RecipeRepository,
+    SkillResult,
+    SubprocessRunner,
+    TestResult,
+    TestRunner,
+)
+from tests.fakes import (
+    InMemoryCIWatcher,
+    InMemoryDatabaseReader,
+    InMemoryHeadlessExecutor,
+    InMemoryMergeQueueWatcher,
+    InMemoryRecipeRepository,
+    InMemoryTestRunner,
+    MockSubprocessRunner,
+)
+
+# ---------------------------------------------------------------------------
+# T1: isinstance protocol conformance
+# ---------------------------------------------------------------------------
+
+
+def test_in_memory_headless_executor_satisfies_protocol():
+    assert isinstance(InMemoryHeadlessExecutor(), HeadlessExecutor)
+
+
+def test_in_memory_test_runner_satisfies_protocol():
+    assert isinstance(InMemoryTestRunner(), TestRunner)
+
+
+def test_in_memory_recipe_repository_satisfies_protocol():
+    assert isinstance(InMemoryRecipeRepository(), RecipeRepository)
+
+
+def test_in_memory_ci_watcher_satisfies_protocol():
+    assert isinstance(InMemoryCIWatcher(), CIWatcher)
+
+
+def test_in_memory_merge_queue_watcher_satisfies_protocol():
+    assert isinstance(InMemoryMergeQueueWatcher(), MergeQueueWatcher)
+
+
+def test_in_memory_database_reader_satisfies_protocol():
+    assert isinstance(InMemoryDatabaseReader(), DatabaseReader)
+
+
+def test_mock_subprocess_runner_satisfies_protocol():
+    assert isinstance(MockSubprocessRunner(), SubprocessRunner)
+
+
+# ---------------------------------------------------------------------------
+# T2: InMemoryHeadlessExecutor behavioral tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_executor_returns_configured_result():
+    result = SkillResult(
+        success=True,
+        result="ok",
+        session_id="s1",
+        subtype="success",
+        is_error=False,
+        exit_code=0,
+        needs_retry=False,
+        retry_reason="none",
+        stderr="",
+    )
+    executor = InMemoryHeadlessExecutor(default_result=result)
+    got = await executor.run("/skill", "/cwd")
+    assert got is result
+
+
+@pytest.mark.anyio
+async def test_executor_records_calls():
+    executor = InMemoryHeadlessExecutor()
+    await executor.run("/skill", "/cwd", model="opus")
+    assert len(executor.calls) == 1
+    assert executor.calls[0].skill_command == "/skill"
+    assert executor.calls[0].cwd == "/cwd"
+    assert executor.calls[0].model == "opus"
+
+
+@pytest.mark.anyio
+async def test_executor_pops_from_queue():
+    r1 = SkillResult(
+        success=True,
+        result="first",
+        session_id="",
+        subtype="success",
+        is_error=False,
+        exit_code=0,
+        needs_retry=False,
+        retry_reason="none",
+        stderr="",
+    )
+    r2 = SkillResult(
+        success=False,
+        result="second",
+        session_id="",
+        subtype="error",
+        is_error=True,
+        exit_code=1,
+        needs_retry=False,
+        retry_reason="none",
+        stderr="",
+    )
+    executor = InMemoryHeadlessExecutor()
+    executor.push(r1)
+    executor.push(r2)
+    assert (await executor.run("/s", "/c")).result == "first"
+    assert (await executor.run("/s", "/c")).result == "second"
+
+
+# ---------------------------------------------------------------------------
+# T3: InMemoryTestRunner behavioral tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_runner_returns_configured_results_in_order():
+    runner = InMemoryTestRunner(
+        results=[
+            TestResult(passed=True, stdout="ok", stderr=""),
+            TestResult(passed=False, stdout="fail", stderr="err"),
+        ]
+    )
+    assert (await runner.run(Path("/a"))).passed is True
+    assert (await runner.run(Path("/b"))).passed is False
+
+
+@pytest.mark.anyio
+async def test_runner_fallback_after_exhaustion():
+    runner = InMemoryTestRunner(results=[])
+    r = await runner.run(Path("/a"))
+    assert r.passed is True
+
+
+def test_runner_tracks_call_count():
+    runner = InMemoryTestRunner(results=[])
+    assert runner.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# T4: InMemoryCIWatcher and InMemoryMergeQueueWatcher behavioral tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_ci_watcher_returns_configured_wait_result():
+    watcher = InMemoryCIWatcher(wait_result={"run_id": 42, "conclusion": "failure"})
+    result = await watcher.wait("main")
+    assert result["run_id"] == 42
+    assert result["conclusion"] == "failure"
+
+
+@pytest.mark.anyio
+async def test_ci_watcher_records_wait_calls():
+    watcher = InMemoryCIWatcher()
+    await watcher.wait("main", repo="owner/repo")
+    assert len(watcher.wait_calls) == 1
+    assert watcher.wait_calls[0]["branch"] == "main"
+    assert watcher.wait_calls[0]["repo"] == "owner/repo"
+
+
+@pytest.mark.anyio
+async def test_ci_watcher_side_effect_raises():
+    watcher = InMemoryCIWatcher()
+    watcher.wait_side_effect = RuntimeError("network timeout")
+    with pytest.raises(RuntimeError, match="network timeout"):
+        await watcher.wait("main")
+
+
+@pytest.mark.anyio
+async def test_merge_queue_watcher_records_calls():
+    watcher = InMemoryMergeQueueWatcher()
+    await watcher.wait(123, "main")
+    assert len(watcher.wait_calls) == 1
+    assert watcher.wait_calls[0]["pr_number"] == 123
+    assert watcher.wait_calls[0]["target_branch"] == "main"
+
+
+@pytest.mark.anyio
+async def test_merge_queue_watcher_toggle():
+    watcher = InMemoryMergeQueueWatcher()
+    result = await watcher.toggle(42, "main")
+    assert result["toggled"] is True
+    assert len(watcher.toggle_calls) == 1
+
+
+@pytest.mark.anyio
+async def test_database_reader_returns_configured_result():
+    reader = InMemoryDatabaseReader(query_result={"columns": ["id"], "rows": [[1]], "row_count": 1})
+    result = reader.query("test.db", "SELECT 1", [], 30, 100)
+    assert result["row_count"] == 1
+    assert len(reader.calls) == 1

--- a/tests/test_fakes_conformance.py
+++ b/tests/test_fakes_conformance.py
@@ -148,9 +148,14 @@ async def test_runner_fallback_after_exhaustion():
     assert r.passed is True
 
 
-def test_runner_tracks_call_count():
+@pytest.mark.anyio
+async def test_runner_tracks_call_count():
     runner = InMemoryTestRunner(results=[])
     assert runner.call_count == 0
+    await runner.run(Path("/a"))
+    assert runner.call_count == 1
+    await runner.run(Path("/b"))
+    assert runner.call_count == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_fakes_conformance.py
+++ b/tests/test_fakes_conformance.py
@@ -80,7 +80,7 @@ async def test_executor_returns_configured_result():
     )
     executor = InMemoryHeadlessExecutor(default_result=result)
     got = await executor.run("/skill", "/cwd")
-    assert got is result
+    assert got == result
 
 
 @pytest.mark.anyio
@@ -202,7 +202,9 @@ async def test_merge_queue_watcher_toggle():
 
 @pytest.mark.anyio
 async def test_database_reader_returns_configured_result():
-    reader = InMemoryDatabaseReader(query_result={"columns": ["id"], "rows": [[1]], "row_count": 1})
+    reader = InMemoryDatabaseReader(
+        query_result={"columns": ["id"], "rows": [[1]], "row_count": 1}
+    )
     result = reader.query("test.db", "SELECT 1", [], 30, 100)
     assert result["row_count"] == 1
     assert len(reader.calls) == 1


### PR DESCRIPTION
## Summary

Create `tests/fakes.py` as the single authoritative module for in-memory test doubles that satisfy protocols defined in `core/_type_protocols.py`. This consolidates 10+ inline `MockExecutor` classes scattered across server tests, replaces untyped `AsyncMock`/`MagicMock` usage for CI/merge-queue watchers, and migrates `MockSubprocessRunner` and `StatefulMockTester` out of `conftest.py`. Each fake carries `isinstance` conformance tests via a new `tests/test_fakes_conformance.py`. Six server/ test files are migrated to import from `tests.fakes`.

## Requirements

- [ ] `tests/fakes.py` exists with all protocol fakes
- [ ] Each fake satisfies its protocol (`isinstance` check)
- [ ] At least server/ tests migrated to use fakes for non-server dependencies
- [ ] At least 5 server/ test files no longer import from execution/ or recipe/ at module level after switching to fakes
- [ ] All existing tests pass

Closes #937

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-937-20260415-225324-347495/.autoskillit/temp/make-plan/protocol_test_fakes_plan_2026-04-15_225500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| make_plan | 1.1k | 16.9k | 1.0M | 70.4k | 1 | 8m 13s |
| review_approach | 24 | 3.2k | 149.4k | 23.8k | 1 | 4m 32s |
| dry_walkthrough | 63 | 12.3k | 822.7k | 47.1k | 1 | 6m 32s |
| implement | 107 | 34.8k | 6.2M | 132.5k | 1 | 16m 9s |
| resolve_failures | 57 | 7.3k | 1.2M | 40.4k | 1 | 8m 8s |
| prepare_pr | 26 | 4.1k | 234.7k | 31.0k | 1 | 1m 41s |
| compose_pr | 25 | 2.2k | 186.3k | 18.5k | 1 | 47s |
| **Total** | 1.4k | 80.8k | 9.8M | 363.8k | | 46m 6s |