### PR TITLE
feat: Channel B orphaned-tool-result detection and best-effort net/io proc snapshots

### DIFF
--- a/src/autoskillit/core/_type_subprocess.py
+++ b/src/autoskillit/core/_type_subprocess.py
@@ -117,6 +117,11 @@ class SubprocessResult:
     that downstream telemetry (sessions.jsonl, summary.json, GitHub issue bodies) can
     self-identify which process was actually observed. (Issue #806)
     """
+    orphaned_tool_result: bool = False
+    """True when Channel B fired STALE and the last JSONL record was type=user.
+    Diagnostic only — does not affect termination behavior.
+    Always False for non-STALE outcomes.
+    """
 
 
 @runtime_checkable

--- a/src/autoskillit/execution/_process_jsonl.py
+++ b/src/autoskillit/execution/_process_jsonl.py
@@ -104,3 +104,23 @@ def _jsonl_has_record_type(
                 continue  # marker configured but absent — do not confirm
         return True
     return False
+
+
+def _jsonl_last_record_type(content: str) -> str | None:
+    """Return the type field of the last parseable JSONL record in content, or None."""
+    import json as _json
+
+    last_type: str | None = None
+    for line in content.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = _json.loads(line)
+        except (ValueError, _json.JSONDecodeError):
+            continue
+        if isinstance(obj, dict):
+            t = obj.get("type")
+            if isinstance(t, str):
+                last_type = t
+    return last_type

--- a/src/autoskillit/execution/_process_monitor.py
+++ b/src/autoskillit/execution/_process_monitor.py
@@ -10,7 +10,11 @@ import anyio
 import psutil
 
 from autoskillit.core import ChannelBStatus, get_logger
-from autoskillit.execution._process_jsonl import _jsonl_contains_marker, _jsonl_has_record_type
+from autoskillit.execution._process_jsonl import (
+    _jsonl_contains_marker,
+    _jsonl_has_record_type,
+    _jsonl_last_record_type,
+)
 
 logger = get_logger(__name__)
 
@@ -20,6 +24,7 @@ class SessionMonitorResult(NamedTuple):
 
     status: ChannelBStatus
     session_id: str  # Claude Code session ID from JSONL filename stem, or ""
+    orphaned_tool_result: bool = False
 
 
 async def _heartbeat(
@@ -245,6 +250,7 @@ async def _session_log_monitor(
     os_error_count = 0
     suppression_start_api: float | None = None
     suppression_start_child: float | None = None
+    _last_record_type: str | None = None
 
     while True:
         await anyio.sleep(_phase2_poll)
@@ -278,6 +284,9 @@ async def _session_log_monitor(
                         scan_pos=scan_pos,
                     )
                     return SessionMonitorResult(ChannelBStatus.COMPLETION, _session_id)
+                last_type_in_chunk = _jsonl_last_record_type(new_content)
+                if last_type_in_chunk is not None:
+                    _last_record_type = last_type_in_chunk
             except OSError:
                 pass
         else:
@@ -325,4 +334,8 @@ async def _session_log_monitor(
                         pid,
                     )
                 else:
-                    return SessionMonitorResult(ChannelBStatus.STALE, _session_id)
+                    return SessionMonitorResult(
+                        ChannelBStatus.STALE,
+                        _session_id,
+                        orphaned_tool_result=(_last_record_type == "user"),
+                    )

--- a/src/autoskillit/execution/_process_race.py
+++ b/src/autoskillit/execution/_process_race.py
@@ -36,6 +36,7 @@ class RaceSignals:
     channel_b_session_id: str = ""  # Claude Code session ID from JSONL filename stem, or ""
     stdout_session_id: str | None = None  # Session ID extracted from stdout type=system record
     idle_stall: bool = False
+    channel_b_orphaned_tool_result: bool = False
     process_exited_event: anyio.Event = field(default_factory=anyio.Event)
 
 
@@ -60,6 +61,7 @@ class RaceAccumulator:
     channel_b_session_id: str = ""
     stdout_session_id: str | None = None
     idle_stall: bool = False
+    channel_b_orphaned_tool_result: bool = False
     process_exited_event: anyio.Event = field(default_factory=anyio.Event)
 
     def to_race_signals(self) -> RaceSignals:
@@ -71,6 +73,7 @@ class RaceAccumulator:
             channel_b_session_id=self.channel_b_session_id,
             stdout_session_id=self.stdout_session_id,
             idle_stall=self.idle_stall,
+            channel_b_orphaned_tool_result=self.channel_b_orphaned_tool_result,
             process_exited_event=self.process_exited_event,
         )
 
@@ -263,6 +266,7 @@ async def _watch_session_log(
     # there is no await between them and the function return.
     acc.channel_b_status = monitor_result.status
     acc.channel_b_session_id = monitor_result.session_id
+    acc.channel_b_orphaned_tool_result = monitor_result.orphaned_tool_result
     channel_b_ready.set()
     trigger.set()
 

--- a/src/autoskillit/execution/headless.py
+++ b/src/autoskillit/execution/headless.py
@@ -1206,6 +1206,7 @@ async def run_headless_core(
                     write_call_count=skill_result.write_call_count,
                     clone_contamination_reverted=_clone_reverted,
                     tracked_comm=result.tracked_comm,
+                    orphaned_tool_result=result.orphaned_tool_result,
                 )
             except Exception:
                 logger.debug("session_log_flush_failed", exc_info=True)

--- a/src/autoskillit/execution/linux_tracing.py
+++ b/src/autoskillit/execution/linux_tracing.py
@@ -306,7 +306,7 @@ class ProcSnapshot:
     # CPU utilisation (0.0 when process arg is not supplied to read_proc_snapshot)
     cpu_percent: float
     # Best-effort /proc/{pid}/net/tcp fields (Linux only; None when unavailable)
-    api_connections_established: int | None = None
+    api_connection_established: int | None = None
     api_connection_states: dict[str, int] | None = None
     # Best-effort /proc/{pid}/io fields (Linux only; None when unavailable)
     io_read_bytes: int | None = None
@@ -487,7 +487,7 @@ def read_proc_snapshot(pid: int, *, process: psutil.Process | None = None) -> Pr
         oom_score=oom,
         wchan=wchan,
         cpu_percent=cpu_pct,
-        api_connections_established=_api_conns_established,
+        api_connection_established=_api_conns_established,
         api_connection_states=_api_conn_states,
         io_read_bytes=_io_read,
         io_write_bytes=_io_write,

--- a/src/autoskillit/execution/linux_tracing.py
+++ b/src/autoskillit/execution/linux_tracing.py
@@ -305,6 +305,12 @@ class ProcSnapshot:
     wchan: str
     # CPU utilisation (0.0 when process arg is not supplied to read_proc_snapshot)
     cpu_percent: float
+    # Best-effort /proc/{pid}/net/tcp fields (Linux only; None when unavailable)
+    api_connections_established: int | None = None
+    api_connection_states: dict[str, int] | None = None
+    # Best-effort /proc/{pid}/io fields (Linux only; None when unavailable)
+    io_read_bytes: int | None = None
+    io_write_bytes: int | None = None
 
 
 def _parse_proc_status(content: str) -> dict[str, str]:
@@ -326,6 +332,68 @@ def _parse_proc_status(content: str) -> dict[str, str]:
         elif key == "SigCgt":
             fields["sig_cgt"] = value
     return fields
+
+
+_TCP_STATE_NAMES: dict[str, str] = {
+    "01": "ESTABLISHED",
+    "02": "SYN_SENT",
+    "03": "SYN_RECV",
+    "04": "FIN_WAIT1",
+    "05": "FIN_WAIT2",
+    "06": "TIME_WAIT",
+    "07": "CLOSE",
+    "08": "CLOSE_WAIT",
+    "09": "LAST_ACK",
+    "0A": "LISTEN",
+    "0B": "CLOSING",
+}
+_API_PORT_HEX: str = "01BB"  # port 443 in big-endian hex (Linux /proc/net/tcp format)
+
+
+def _parse_net_tcp(content: str) -> dict[str, int]:
+    """Parse /proc/{pid}/net/tcp content for connections to port 443.
+
+    Returns a dict mapping TCP state name to connection count.
+    Returns {} on empty or header-only content.
+    Lines with fewer than 4 fields are skipped silently.
+    """
+    counts: dict[str, int] = {}
+    for line in content.splitlines()[1:]:  # skip header
+        parts = line.split()
+        if len(parts) < 4:
+            continue
+        rem_addr = parts[2]
+        state_hex = parts[3].upper()
+        if ":" not in rem_addr:
+            continue
+        rem_port = rem_addr.split(":")[1].upper()
+        if rem_port != _API_PORT_HEX:
+            continue
+        state_name = _TCP_STATE_NAMES.get(state_hex, state_hex)
+        counts[state_name] = counts.get(state_name, 0) + 1
+    return counts
+
+
+def _parse_proc_io(content: str) -> tuple[int | None, int | None]:
+    """Parse /proc/{pid}/io content for read_bytes and write_bytes.
+
+    Returns (read_bytes, write_bytes). Either may be None if the field
+    is absent or unparseable.
+    """
+    read_b: int | None = None
+    write_b: int | None = None
+    for line in content.splitlines():
+        if line.startswith("read_bytes:"):
+            try:
+                read_b = int(line.split(":", 1)[1].strip())
+            except (ValueError, IndexError):
+                pass
+        elif line.startswith("write_bytes:"):
+            try:
+                write_b = int(line.split(":", 1)[1].strip())
+            except (ValueError, IndexError):
+                pass
+    return read_b, write_b
 
 
 def read_proc_snapshot(pid: int, *, process: psutil.Process | None = None) -> ProcSnapshot | None:
@@ -375,6 +443,34 @@ def read_proc_snapshot(pid: int, *, process: psutil.Process | None = None) -> Pr
     except (FileNotFoundError, PermissionError):
         wchan = ""
 
+    # Best-effort: /proc/{pid}/net/tcp and tcp6 (Linux network namespace for this PID)
+    _api_conn_states: dict[str, int] | None = None
+    try:
+        _tcp_content = Path(f"/proc/{pid}/net/tcp").read_text()
+        _states = _parse_net_tcp(_tcp_content)
+        try:
+            _tcp6_content = Path(f"/proc/{pid}/net/tcp6").read_text()
+            for k, v in _parse_net_tcp(_tcp6_content).items():
+                _states[k] = _states.get(k, 0) + v
+        except (FileNotFoundError, PermissionError, OSError):
+            pass
+        _api_conn_states = _states if _states else {}
+    except (FileNotFoundError, PermissionError, OSError, ValueError):
+        pass
+
+    _api_conns_established: int | None = None
+    if _api_conn_states is not None:
+        _api_conns_established = _api_conn_states.get("ESTABLISHED", 0)
+
+    # Best-effort: /proc/{pid}/io
+    _io_read: int | None = None
+    _io_write: int | None = None
+    try:
+        _io_content = Path(f"/proc/{pid}/io").read_text()
+        _io_read, _io_write = _parse_proc_io(_io_content)
+    except (FileNotFoundError, PermissionError, OSError):
+        pass
+
     return ProcSnapshot(
         captured_at=captured_at,
         comm=comm,
@@ -391,6 +487,10 @@ def read_proc_snapshot(pid: int, *, process: psutil.Process | None = None) -> Pr
         oom_score=oom,
         wchan=wchan,
         cpu_percent=cpu_pct,
+        api_connections_established=_api_conns_established,
+        api_connection_states=_api_conn_states,
+        io_read_bytes=_io_read,
+        io_write_bytes=_io_write,
     )
 
 

--- a/src/autoskillit/execution/process.py
+++ b/src/autoskillit/execution/process.py
@@ -32,6 +32,7 @@ from autoskillit.execution._process_io import create_temp_io, read_temp_output
 from autoskillit.execution._process_jsonl import (
     _jsonl_contains_marker,
     _jsonl_has_record_type,
+    _jsonl_last_record_type,
     _marker_is_standalone,
 )
 from autoskillit.execution._process_kill import (
@@ -80,6 +81,7 @@ __all__ = [
     "_heartbeat",
     "_jsonl_contains_marker",
     "_jsonl_has_record_type",
+    "_jsonl_last_record_type",
     "_marker_is_standalone",
     "_session_log_monitor",
     "_wait_process_dead",
@@ -419,6 +421,7 @@ async def run_managed_async(
                 ),
                 kill_reason=kill_reason,
                 tracked_comm=_tracked_comm,
+                orphaned_tool_result=signals.channel_b_orphaned_tool_result,
             )
             proc_log.debug(
                 "run_managed_async_result",

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -99,6 +99,7 @@ def flush_session_log(
     clone_contamination_reverted: bool = False,
     tracked_comm: str | None = None,
     exception_text: str = "",
+    orphaned_tool_result: bool = False,
 ) -> None:
     """Flush session diagnostics to disk.
 
@@ -239,6 +240,7 @@ def flush_session_log(
         "tracked_comm": _effective_tracked_comm,
         "tracked_comm_drift": _tracked_comm_drift,
         "tracer_target_resolution_version": 2,
+        "orphaned_tool_result": orphaned_tool_result,
     }
     summary_path = session_dir / "summary.json"
     atomic_write(summary_path, json.dumps(summary, sort_keys=True, indent=2) + "\n")

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -1172,6 +1172,7 @@ class TestGroupCMigration:
             "stdout_session_id",
             "idle_stall",
             "process_exited_event",
+            "channel_b_orphaned_tool_result",
         }  # REQ-SIG-008
 
     def test_race_signals_still_frozen(self):

--- a/tests/contracts/test_protocol_satisfaction.py
+++ b/tests/contracts/test_protocol_satisfaction.py
@@ -497,7 +497,7 @@ class TestGroupDApiContractPreservation:
     # ------------------------------------------------------------------
 
     def test_req_api_005_subprocess_result_field_names(self):
-        """SubprocessResult must have exactly the 14 canonical fields."""
+        """SubprocessResult must have exactly the 15 canonical fields."""
         from autoskillit.core.types import SubprocessResult
 
         fields = {f.name for f in dataclasses.fields(SubprocessResult)}
@@ -516,6 +516,7 @@ class TestGroupDApiContractPreservation:
             "elapsed_seconds",
             "kill_reason",
             "tracked_comm",
+            "orphaned_tool_result",
         }
         assert fields == expected, (
             f"SubprocessResult fields changed.\n"

--- a/tests/execution/test_linux_tracing.py
+++ b/tests/execution/test_linux_tracing.py
@@ -389,14 +389,14 @@ def test_parse_proc_io_extracts_bytes():
 
 
 def test_read_proc_snapshot_has_network_fields():
-    """read_proc_snapshot includes api_connections_established on Linux."""
+    """read_proc_snapshot includes api_connection_established on Linux."""
     from autoskillit.execution.linux_tracing import read_proc_snapshot
 
     snap = read_proc_snapshot(os.getpid())
     assert snap is not None
     # Field exists and is either None (no port-443 connections from test process) or int >= 0
-    assert snap.api_connections_established is None or isinstance(
-        snap.api_connections_established, int
+    assert snap.api_connection_established is None or isinstance(
+        snap.api_connection_established, int
     )
 
 
@@ -416,7 +416,7 @@ def test_read_proc_snapshot_network_graceful_on_missing_proc_net(monkeypatch):
     monkeypatch.setattr(Path, "read_text", patched_read_text)
     snap = read_proc_snapshot(os.getpid())
     assert snap is not None
-    assert snap.api_connections_established is None
+    assert snap.api_connection_established is None
     assert snap.api_connection_states is None
 
 

--- a/tests/execution/test_linux_tracing.py
+++ b/tests/execution/test_linux_tracing.py
@@ -359,6 +359,67 @@ async def test_proc_monitor_persists_psutil_process_for_cpu_percent():
         proc.wait()
 
 
+def test_parse_net_tcp_established_port_443():
+    """_parse_net_tcp counts ESTABLISHED connections to port 443."""
+    from autoskillit.execution.linux_tracing import _parse_net_tcp
+
+    fixture = (
+        "  sl  local_address rem_address   st tx_queue rx_queue tr...\n"
+        "   0: 0100007F:0035 0101A8C0:01BB 01 00000000:00000000 ...\n"  # ESTABLISHED to :443
+        "   1: 0100007F:0035 0101A8C0:0050 01 00000000:00000000 ...\n"  # :80 excluded
+    )
+    result = _parse_net_tcp(fixture)
+    assert result.get("ESTABLISHED") == 1
+
+
+def test_parse_net_tcp_empty_returns_empty_dict():
+    from autoskillit.execution.linux_tracing import _parse_net_tcp
+
+    assert _parse_net_tcp("") == {}
+    assert _parse_net_tcp("  sl  local_address rem_address   st\n") == {}
+
+
+def test_parse_proc_io_extracts_bytes():
+    from autoskillit.execution.linux_tracing import _parse_proc_io
+
+    fixture = "rchar: 1000\nwchar: 2000\nread_bytes: 4096\nwrite_bytes: 8192\n"
+    read_b, write_b = _parse_proc_io(fixture)
+    assert read_b == 4096
+    assert write_b == 8192
+
+
+def test_read_proc_snapshot_has_network_fields():
+    """read_proc_snapshot includes api_connections_established on Linux."""
+    from autoskillit.execution.linux_tracing import read_proc_snapshot
+
+    snap = read_proc_snapshot(os.getpid())
+    assert snap is not None
+    # Field exists and is either None (no port-443 connections from test process) or int >= 0
+    assert snap.api_connections_established is None or isinstance(
+        snap.api_connections_established, int
+    )
+
+
+def test_read_proc_snapshot_network_graceful_on_missing_proc_net(monkeypatch):
+    """Fields are None, no exception, when /proc/{pid}/net/tcp is unavailable."""
+    from pathlib import Path
+
+    from autoskillit.execution.linux_tracing import read_proc_snapshot
+
+    original_read_text = Path.read_text
+
+    def patched_read_text(self, *args, **kwargs):
+        if "net/tcp" in str(self):
+            raise FileNotFoundError("mocked")
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", patched_read_text)
+    snap = read_proc_snapshot(os.getpid())
+    assert snap is not None
+    assert snap.api_connections_established is None
+    assert snap.api_connection_states is None
+
+
 @pytest.mark.anyio
 async def test_start_linux_tracing_writes_enrollment_sidecar(tmp_path):
     """start_linux_tracing must write autoskillit_enrollment_{pid}.json immediately."""

--- a/tests/execution/test_process_jsonl.py
+++ b/tests/execution/test_process_jsonl.py
@@ -12,6 +12,7 @@ import json
 from autoskillit.execution.process import (
     _jsonl_contains_marker,
     _jsonl_has_record_type,
+    _jsonl_last_record_type,
     _marker_is_standalone,
 )
 
@@ -361,3 +362,22 @@ class TestMarkerDiscrimination:
             + "\n"
         )
         assert not _jsonl_contains_marker(content, "%%ORDER_UP::bbb%%", frozenset({"assistant"}))
+
+
+class TestJsonlLastRecordType:
+    """_jsonl_last_record_type returns the type of the last parseable JSONL record."""
+
+    def test_returns_last_type_in_content(self):
+        content = '{"type": "assistant", "message": {}}\n{"type": "user", "message": {}}\n'
+        assert _jsonl_last_record_type(content) == "user"
+
+    def test_returns_none_for_empty_content(self):
+        assert _jsonl_last_record_type("") is None
+
+    def test_skips_unparseable_lines(self):
+        content = '{"type": "assistant"}\nnot-json\n'
+        assert _jsonl_last_record_type(content) == "assistant"
+
+    def test_ignores_records_without_type_field(self):
+        content = '{"other": "field"}\n{"type": "result"}\n'
+        assert _jsonl_last_record_type(content) == "result"

--- a/tests/execution/test_process_monitor.py
+++ b/tests/execution/test_process_monitor.py
@@ -1270,3 +1270,99 @@ class TestSessionLogMonitorDirMissing:
         assert result.status == ChannelBStatus.DIR_MISSING
         assert elapsed < 0.1  # FileNotFoundError is immediate after the poll sleep
         assert result.session_id == ""
+
+
+class TestOrphanedToolResultDetection:
+    """Channel B detects orphaned tool results when last JSONL record is type=user."""
+
+    @pytest.mark.anyio
+    async def test_orphaned_tool_result_detected_when_last_record_is_user_type(self, tmp_path):
+        """STALE result has orphaned_tool_result=True when last JSONL record is type=user."""
+        import json
+
+        log_dir = tmp_path / "session_logs"
+        log_dir.mkdir()
+        spawn_time = time.time() - 1
+
+        session_file = log_dir / "sess_orphaned.jsonl"
+        session_file.write_text(
+            json.dumps({"type": "assistant", "message": {"content": "working..."}})
+            + "\n"
+            + json.dumps({"type": "user", "message": {"content": [{"type": "tool_result"}]}})
+            + "\n"
+        )
+
+        result = await _session_log_monitor(
+            log_dir,
+            "%%AUTOSKILLIT_COMPLETE%%",
+            stale_threshold=0.15,
+            spawn_time=spawn_time,
+            _phase1_poll=0.01,
+            _phase2_poll=0.04,
+        )
+
+        assert result.status == ChannelBStatus.STALE
+        assert result.orphaned_tool_result is True
+
+    @pytest.mark.anyio
+    async def test_no_false_positive_when_last_record_is_assistant(self, tmp_path):
+        """STALE result has orphaned_tool_result=False when last JSONL record is type=assistant."""
+        import json
+
+        log_dir = tmp_path / "session_logs"
+        log_dir.mkdir()
+        spawn_time = time.time() - 1
+
+        session_file = log_dir / "sess_assistant.jsonl"
+        session_file.write_text(
+            json.dumps({"type": "user", "message": {"content": "do something"}})
+            + "\n"
+            + json.dumps({"type": "assistant", "message": {"content": "thinking..."}})
+            + "\n"
+        )
+
+        result = await _session_log_monitor(
+            log_dir,
+            "%%AUTOSKILLIT_COMPLETE%%",
+            stale_threshold=0.15,
+            spawn_time=spawn_time,
+            _phase1_poll=0.01,
+            _phase2_poll=0.04,
+        )
+
+        assert result.status == ChannelBStatus.STALE
+        assert result.orphaned_tool_result is False
+
+    @pytest.mark.anyio
+    async def test_orphaned_false_on_completion(self, tmp_path):
+        """COMPLETION result always has orphaned_tool_result=False."""
+        import json
+
+        log_dir = tmp_path / "session_logs"
+        log_dir.mkdir()
+        spawn_time = time.time() - 1
+
+        session_file = log_dir / "sess_complete.jsonl"
+        session_file.write_text(
+            json.dumps({"type": "user", "message": {"content": "do something"}})
+            + "\n"
+            + json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {"content": "done\n%%AUTOSKILLIT_COMPLETE%%"},
+                }
+            )
+            + "\n"
+        )
+
+        result = await _session_log_monitor(
+            log_dir,
+            "%%AUTOSKILLIT_COMPLETE%%",
+            stale_threshold=5.0,
+            spawn_time=spawn_time,
+            _phase1_poll=0.01,
+            _phase2_poll=0.04,
+        )
+
+        assert result.status == ChannelBStatus.COMPLETION
+        assert result.orphaned_tool_result is False

--- a/tests/execution/test_process_race.py
+++ b/tests/execution/test_process_race.py
@@ -244,8 +244,8 @@ class TestRaceSignalsFieldCount:
     """Sentinel test: breaks when RaceSignals fields change."""
 
     def test_race_signals_field_count(self) -> None:
-        assert len(dataclasses.fields(RaceSignals)) == 8, (
-            f"RaceSignals has {len(dataclasses.fields(RaceSignals))} fields (expected 8). "
+        assert len(dataclasses.fields(RaceSignals)) == 9, (
+            f"RaceSignals has {len(dataclasses.fields(RaceSignals))} fields (expected 9). "
             "Update tests to cover the new field."
         )
 

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -111,9 +111,9 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # core/io.py — write_versioned_json itself (the blessed helper) uses atomic_write+json.dumps
     ("src/autoskillit/core/io.py", 118),
     # session_log.py — summary dict, token_usage list, audit_log list
-    ("src/autoskillit/execution/session_log.py", 244),
-    ("src/autoskillit/execution/session_log.py", 260),
-    ("src/autoskillit/execution/session_log.py", 263),
+    ("src/autoskillit/execution/session_log.py", 246),
+    ("src/autoskillit/execution/session_log.py", 262),
+    ("src/autoskillit/execution/session_log.py", 265),
     # migration/store.py — failure store dicts
     ("src/autoskillit/migration/store.py", 54),
     ("src/autoskillit/migration/store.py", 64),
@@ -212,8 +212,8 @@ class TestSchemaVersionConvention:
         """List-payload sites are included since the AST scanner can't distinguish return types."""
         # These sites write list payloads through function calls but are caught by the scanner
         list_sites = [
-            ("src/autoskillit/execution/session_log.py", 260),
-            ("src/autoskillit/execution/session_log.py", 263),
+            ("src/autoskillit/execution/session_log.py", 262),
+            ("src/autoskillit/execution/session_log.py", 265),
             ("src/autoskillit/smoke_utils.py", 87),
             ("src/autoskillit/smoke_utils.py", 290),
         ]


### PR DESCRIPTION
## Summary

Two orthogonal diagnostic improvements:

1. **Channel B orphaned-tool-result detection**: When `_session_log_monitor` Phase 2 fires `STALE`, inspect the last JSONL record type seen in the session file. If `type=user` (the Claude Code envelope for tool results) was the last record with no subsequent `type=assistant`, set `orphaned_tool_result=True` on `SessionMonitorResult` and propagate through `RaceAccumulator` → `SubprocessResult` → `summary.json`. Diagnostic only — no change to termination behavior.

2. **Best-effort network visibility in proc snapshots**: Extend `read_proc_snapshot()` in `linux_tracing.py` to attempt reading `/proc/{pid}/net/tcp`, `/proc/{pid}/net/tcp6`, and `/proc/{pid}/io`. Parse port-443 ESTABLISHED connections into `api_connections_established` / `api_connection_states` fields, and byte counters into `io_read_bytes` / `io_write_bytes`. All reads wrapped in `try/except` — failures produce `None`, never raise.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 38, 'rankSpacing': 52, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START<br/>run_headless_core])
    COMPLETE([COMPLETE<br/>SkillResult returned])
    CRASHED([ERROR<br/>crashed / cancelled])

    %% ── PHASE 1: SESSION LAUNCH ── %%
    subgraph Launch ["● Session Launch  (headless.py · process.py · linux_tracing.py)"]
        direction TB
        BuildCmd["● build_full_headless_cmd<br/>━━━━━━━━━━<br/>resolve model · thresholds<br/>clone snapshot (optional)"]
        SpawnProc["● run_managed_async<br/>━━━━━━━━━━<br/>create_temp_io → open_process<br/>start_new_session=True"]
        TraceMode{"● PTY mode?"}
        ResolveTrace["● resolve_trace_target<br/>━━━━━━━━━━<br/>walk children for<br/>expected_basename<br/>raises on timeout"]
        DirectTrace["● trace_target_from_pid<br/>━━━━━━━━━━<br/>direct /proc read<br/>never raises"]
        StartTrace["● start_linux_tracing<br/>━━━━━━━━━━<br/>open tmpfs trace file<br/>write enrollment sidecar<br/>start proc_monitor loop"]
    end

    %% ── PHASE 2: TWO-CHANNEL RACE ── %%
    subgraph Race ["● Two-Channel Race  (anyio task group · move_on_after timeout)"]
        direction TB

        subgraph ChA ["Channel A — Stdout Heartbeat  (● _process_monitor.py)"]
            direction TB
            HBLoop["● _heartbeat<br/>━━━━━━━━━━<br/>poll stdout temp file every 0.5s<br/>reads from scan_pos offset"]
            JsonlHas["● _jsonl_has_record_type<br/>━━━━━━━━━━<br/>find type=result<br/>non-empty result field<br/>optional completion_marker check"]
            ChAFire["Channel A COMPLETION<br/>━━━━━━━━━━<br/>fire trigger event"]
        end

        subgraph ChB ["Channel B — Session JSONL Monitor  (● _process_monitor.py · ● _process_jsonl.py)"]
            direction TB
            Ph1{"● Phase 1<br/>━━━━━━━━━━<br/>scan log dir for<br/>.jsonl newer than<br/>spawn_time (1s poll)"}
            Ph1DirMiss["DIR_MISSING<br/>━━━━━━━━━━<br/>fire trigger immediately"]
            Ph1Timeout["Phase 1 STALE<br/>━━━━━━━━━━<br/>_phase1_timeout elapsed<br/>fire trigger"]
            Ph1Found["session file found<br/>━━━━━━━━━━<br/>init scan_pos · last_size<br/>last_change · suppression timers"]
            Ph2Loop["● Phase 2 monitor loop<br/>━━━━━━━━━━<br/>poll every 2s"]
            GrowCheck{"● file size<br/>grew?"}
            MarkerScan["● _jsonl_contains_marker<br/>━━━━━━━━━━<br/>scan new JSONL bytes<br/>for completion marker<br/>in assistant/result records"]
            LastRec["● _jsonl_last_record_type<br/>━━━━━━━━━━<br/>track last parseable<br/>record type (new)"]
            StaleElapsed{"● stale elapsed<br/>≥ threshold?"}
            ApiCheck["● _has_active_api_connection<br/>━━━━━━━━━━<br/>psutil TCP:443 walk<br/>suppress STALE; reset timer<br/>bounded by max_suppression_s"]
            ChildCheck["● _has_active_child_processes<br/>━━━━━━━━━━<br/>CPU delta via cached psutil<br/>suppress STALE; reset timer<br/>bounded by max_suppression_s"]
            OrphanCheck["● orphaned_tool_result detection<br/>━━━━━━━━━━<br/>last record == type:user?<br/>set orphaned_tool_result=True<br/>(new in this PR)"]
            ChBDrain["Channel B COMPLETION<br/>━━━━━━━━━━<br/>move_on_after drain window<br/>→ fire trigger"]
            ChBStale["Channel B STALE<br/>━━━━━━━━━━<br/>fire trigger"]
        end

        ProcWatcher["● _watch_process<br/>━━━━━━━━━━<br/>await proc exit<br/>set process_exited_event<br/>then fire trigger"]
        IdleWatcher["● _watch_stdout_idle<br/>━━━━━━━━━━<br/>no byte growth for<br/>idle_output_timeout → trigger"]
        SidExtract["_extract_stdout_session_id<br/>━━━━━━━━━━<br/>parse type=system record<br/>0.3s poll · 10s max"]
    end

    %% ── PHASE 3: RACE RESOLUTION ── %%
    subgraph Resolution ["● Race Resolution  (● _process_race.py · ● process.py)"]
        direction TB
        RaceAcc["● RaceAccumulator<br/>━━━━━━━━━━<br/>channel_a_confirmed<br/>channel_b_status<br/>● channel_b_orphaned_tool_result<br/>process_exited · idle_stall"]
        DrainWait["symmetric drain<br/>━━━━━━━━━━<br/>if proc exited but channel_b=None<br/>move_on_after(drain_timeout)<br/>await channel_b_ready"]
        ResolveTerm["● resolve_termination<br/>━━━━━━━━━━<br/>pure priority function<br/>→ TerminationReason + ChannelConfirmation"]
        DecideAction["● decide_termination_action<br/>━━━━━━━━━━<br/>NO_KILL · DRAIN_THEN_KILL · IMMEDIATE_KILL"]
        ExecAction["execute_termination_action<br/>━━━━━━━━━━<br/>async_kill_process_tree<br/>or await natural exit (grace window)"]
        StopTrace["● LinuxTracingHandle.stop<br/>━━━━━━━━━━<br/>cancel monitor scope<br/>flush+close trace file<br/>unlink tmpfs + enrollment sidecar<br/>return accumulated snapshots"]
        BuildSR["● SubprocessResult<br/>━━━━━━━━━━<br/>termination · channel · session_id<br/>kill_reason · proc_snapshots<br/>● orphaned_tool_result (new field)"]
    end

    %% ── PHASE 4: RESULT CLASSIFICATION ── %%
    subgraph Classify ["● Result Classification  (● headless.py _build_skill_result)"]
        direction TB
        EarlyExit{"● early exit?<br/>STALE / IDLE_STALL<br/>TIMED_OUT"}
        StaleRec["● stale recovery<br/>━━━━━━━━━━<br/>parse stdout despite stale<br/>compute_success check<br/>→ recovered_from_stale"]
        NormalParse["parse_session_result<br/>━━━━━━━━━━<br/>parse stdout JSONL<br/>count write_call_count"]
        RecoveryCascade["● recovery cascade<br/>━━━━━━━━━━<br/>1. Channel B drain-race recovery<br/>2. DIR_MISSING late-bind<br/>3. separate marker recovery<br/>4. pattern recovery<br/>5. artifact synthesis (UNMONITORED)"]
        ComputeOut["● _compute_outcome<br/>━━━━━━━━━━<br/>SessionOutcome + RetryReason<br/>_normalize_subtype"]
        BudgetGuard["_apply_budget_guard<br/>━━━━━━━━━━<br/>contract nudge gate<br/>zero-write demotion gate"]
    end

    %% ── PHASE 5: SESSION LOG ── %%
    subgraph LogFlush ["● Session Log Flush  (● session_log.py)"]
        direction TB
        WriteProc["● write proc_trace.jsonl<br/>━━━━━━━━━━<br/>● best-effort net/io fields<br/>peak_rss_kb · peak_oom_score<br/>tracked_comm · comm drift"]
        AnomalyD["detect_anomalies<br/>━━━━━━━━━━<br/>detect_identity_drift<br/>→ anomalies.jsonl"]
        WriteSumm["● write summary.json<br/>━━━━━━━━━━<br/>atomic_write · append sessions.jsonl<br/>● orphaned_tool_result in record"]
        Retention["_enforce_retention<br/>━━━━━━━━━━<br/>delete oldest dirs beyond 500<br/>rewrite sessions.jsonl index"]
    end

    %% ── CONNECTIONS ── %%
    START --> BuildCmd
    BuildCmd --> SpawnProc
    SpawnProc -->|"exception"| CRASHED
    SpawnProc --> TraceMode
    TraceMode -->|"PTY"| ResolveTrace
    TraceMode -->|"non-PTY"| DirectTrace
    ResolveTrace --> StartTrace
    DirectTrace --> StartTrace
    StartTrace --> Race

    HBLoop --> JsonlHas
    JsonlHas -->|"type=result found"| ChAFire
    JsonlHas -->|"not yet"| HBLoop

    Ph1 -->|"dir missing"| Ph1DirMiss
    Ph1 -->|"timeout"| Ph1Timeout
    Ph1 -->|"file found"| Ph1Found
    Ph1Found --> Ph2Loop
    Ph2Loop --> GrowCheck
    GrowCheck -->|"yes"| MarkerScan
    GrowCheck -->|"no"| StaleElapsed
    MarkerScan --> LastRec
    LastRec -->|"marker found"| ChBDrain
    LastRec -->|"not found"| Ph2Loop
    StaleElapsed -->|"not yet"| Ph2Loop
    StaleElapsed -->|"yes"| ApiCheck
    ApiCheck -->|"API active → suppress"| Ph2Loop
    ApiCheck -->|"API inactive"| ChildCheck
    ChildCheck -->|"child CPU active → suppress"| Ph2Loop
    ChildCheck -->|"no active children"| OrphanCheck
    OrphanCheck -->|"last=type:user → orphaned=True"| ChBStale
    OrphanCheck -->|"other type → orphaned=False"| ChBStale

    ChAFire --> RaceAcc
    ChBDrain --> RaceAcc
    ChBStale --> RaceAcc
    Ph1DirMiss --> RaceAcc
    Ph1Timeout --> RaceAcc
    ProcWatcher --> RaceAcc
    IdleWatcher --> RaceAcc
    SidExtract --> RaceAcc

    RaceAcc --> DrainWait
    DrainWait --> ResolveTerm
    ResolveTerm --> DecideAction
    DecideAction --> ExecAction
    ExecAction --> StopTrace
    StopTrace --> BuildSR

    BuildSR --> EarlyExit
    EarlyExit -->|"STALE"| StaleRec
    EarlyExit -->|"IDLE_STALL / TIMED_OUT"| ComputeOut
    EarlyExit -->|"NATURAL_EXIT / COMPLETED"| NormalParse
    StaleRec --> ComputeOut
    NormalParse --> RecoveryCascade
    RecoveryCascade --> ComputeOut
    ComputeOut --> BudgetGuard

    BudgetGuard --> WriteProc
    WriteProc --> AnomalyD
    AnomalyD --> WriteSumm
    WriteSumm --> Retention
    Retention --> COMPLETE

    %% CLASS ASSIGNMENTS %%
    class START,COMPLETE,CRASHED terminal;
    class BuildCmd,SpawnProc,ResolveTrace,DirectTrace,StartTrace handler;
    class TraceMode stateNode;
    class HBLoop,JsonlHas,ChAFire phase;
    class Ph1,GrowCheck,StaleElapsed detector;
    class Ph1DirMiss,Ph1Timeout,Ph1Found,Ph2Loop,MarkerScan,LastRec phase;
    class ApiCheck,ChildCheck,OrphanCheck detector;
    class ChBDrain,ChBStale phase;
    class ProcWatcher,IdleWatcher,SidExtract handler;
    class RaceAcc,DrainWait stateNode;
    class ResolveTerm,DecideAction phase;
    class ExecAction,StopTrace,BuildSR handler;
    class EarlyExit detector;
    class StaleRec,NormalParse,RecoveryCascade,ComputeOut,BudgetGuard handler;
    class WriteProc,AnomalyD,WriteSumm,Retention output;
```

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START([Process Spawned])

    subgraph ChB ["● CHANNEL B MONITORING — _process_monitor.py"]
        direction TB
        P1["Phase 1: JSONL Discovery<br/>━━━━━━━━━━<br/>Identity: f.stem == session_id<br/>Recency fallback: max st_ctime<br/>DIR_MISSING → abort immediately<br/>30s timeout → STALE"]
        P2["Phase 2: Content Monitoring<br/>━━━━━━━━━━<br/>scan_pos byte-offset cursor<br/>Poll st_size @ 2s intervals<br/>Reads only new chunks"]
        LastRec["● _last_record_type  MUTABLE<br/>━━━━━━━━━━<br/>Updated per growth event<br/>via _jsonl_last_record_type()<br/>Persists across poll iterations"]
        SnapAcc["proc_snapshots  APPEND_ONLY<br/>━━━━━━━━━━<br/>LinuxTracingHandle.stop()<br/>+ final read_proc_snapshot<br/>Best-effort net/IO Linux tracing"]
    end

    subgraph Gates ["● STALE SUPPRESSION GATES — _process_monitor.py"]
        direction TB
        SuppG1["Suppression Gate 1<br/>━━━━━━━━━━<br/>_has_active_api_connection(pid)<br/>ESTABLISHED TCP port-443<br/>→ reset last_change, loop"]
        SuppG2["Suppression Gate 2<br/>━━━━━━━━━━<br/>_has_active_child_processes(pid)<br/>child CPU above 10 percent<br/>→ reset last_change, loop"]
        StaleGate{"Elapsed >= stale_threshold<br/>AND max_suppression exceeded?"}
        OrphanDet["● Orphaned Tool Result Detection<br/>━━━━━━━━━━<br/>DERIVED at stale fire only<br/>orphaned = last_record_type == user<br/>type=user means tool result sent<br/>but no assistant reply arrived"]
    end

    subgraph Accum ["● MUTABLE ACCUMULATION — _process_race.py RaceAccumulator"]
        direction LR
        AccB["acc.channel_b_status<br/>━━━━━━━━━━<br/>STALE written here"]
        AccSID["acc.channel_b_session_id<br/>━━━━━━━━━━<br/>session UUID stem"]
        AccOTR["● acc.channel_b_orphaned_tool_result<br/>━━━━━━━━━━<br/>bool default False<br/>Atomic: no await between<br/>channel_b_status / session_id / here"]
    end

    subgraph Freeze ["FREEZE BOUNDARY — to_race_signals()"]
        direction TB
        RS["RaceSignals  frozen=True<br/>━━━━━━━━━━<br/>channel_b_status<br/>channel_b_session_id<br/>● channel_b_orphaned_tool_result<br/>stdout_session_id<br/>channel_a_confirmed<br/>Immutable after construction"]
    end

    subgraph Build ["● IMMUTABLE RESULT — _type_subprocess.py + process.py"]
        direction TB
        SIDResolve["_resolve_session_id()  DERIVED<br/>━━━━━━━━━━<br/>stdout_session_id wins<br/>channel_b_session_id fallback<br/>Empty string when both absent"]
        SR["● SubprocessResult  immutable dataclass<br/>━━━━━━━━━━<br/>session_id DERIVED INIT_ONLY<br/>channel_b_session_id INIT_ONLY<br/>channel_confirmation INIT_ONLY<br/>proc_snapshots INIT_ONLY list<br/>● orphaned_tool_result INIT_ONLY bool<br/>tracked_comm INIT_ONLY"]
    end

    subgraph Persist ["● PERSISTENCE — session_log.py + headless.py"]
        direction LR
        FSL["● flush_session_log()  WRITE_ONLY<br/>━━━━━━━━━━<br/>● accepts orphaned_tool_result<br/>Sink: never read back for logic"]
        SumJSON["summary.json<br/>━━━━━━━━━━<br/>● orphaned_tool_result persisted<br/>Per-session detail only"]
        JSONL["sessions.jsonl  APPEND_ONLY<br/>━━━━━━━━━━<br/>orphaned_tool_result excluded<br/>Index-level fields only"]
    end

    subgraph Contracts ["● CONTRACT ENFORCEMENT — tests/"]
        direction TB
        C1["● test_protocol_satisfaction<br/>━━━━━━━━━━<br/>SubprocessResult: exactly 15 fields<br/>RaceSignals: frozen + 9 fields<br/>orphaned_tool_result named explicitly"]
        C2["● test_schema_version_convention<br/>━━━━━━━━━━<br/>session_log.py lines 246 262 265<br/>in _LEGACY_JSON_WRITES allowlist<br/>atomic_write ratchet enforced"]
        C3["● test_subpackage_isolation<br/>━━━━━━━━━━<br/>execution/ file cap 26<br/>headless.py line cap 1300<br/>anyio migration guards active"]
    end

    START --> P1
    P1 --> P2
    P2 --> LastRec
    P2 --> SnapAcc
    LastRec --> SuppG1
    SuppG1 --> SuppG2
    SuppG2 --> StaleGate
    StaleGate -- "No: continue polling" --> P2
    StaleGate -- "Yes: STALE fires" --> OrphanDet
    OrphanDet --> AccOTR
    OrphanDet --> AccB
    OrphanDet --> AccSID
    AccB --> RS
    AccSID --> RS
    AccOTR --> RS
    RS --> SIDResolve
    RS --> SR
    SIDResolve --> SR
    SnapAcc --> SR
    SR --> FSL
    FSL --> SumJSON
    FSL --> JSONL
    SR -. "REQ-API-005 field contract" .-> C1
    RS -. "REQ-SIG-008 frozen contract" .-> C1
    FSL -. "legacy allowlist" .-> C2
    SR -. "line and file caps" .-> C3

    %% CLASS ASSIGNMENTS %%
    class START terminal;
    class P1,P2 phase;
    class LastRec,AccB,AccSID,AccOTR stateNode;
    class SnapAcc handler;
    class SuppG1,SuppG2 detector;
    class StaleGate detector;
    class OrphanDet detector;
    class RS gap;
    class SIDResolve phase;
    class SR stateNode;
    class FSL,SumJSON,JSONL output;
    class C1,C2,C3 cli;
```

### Error/Resilience Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 52, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;

    %% TERMINALS %%
    START([START: run_headless_core])
    T_SUCCESS([SUCCESS])
    T_CRASHED([CRASHED: SkillResult.crashed])
    T_VALIDATION_ERR([VALIDATION ERROR])
    T_BUDGET([CIRCUIT BROKEN: BUDGET_EXHAUSTED])

    %% ─── VALIDATION GATES ─── %%
    subgraph ValidationGates ["VALIDATION GATES — Fail-Fast"]
        ARCH008["● ARCH-008 Guard<br/>━━━━━━━━━━<br/>isinstance(target, TraceTarget)<br/>raises TypeError for raw int"]
        ASSERT_RUNNER["assert runner is not None<br/>━━━━━━━━━━<br/>Hard fail: no runner injected<br/>(headless.py)"]
        TRACE_RESOLVE["resolve_trace_target()<br/>━━━━━━━━━━<br/>TraceTargetResolutionError<br/>if no descendant in timeout"]
    end

    %% ─── CHANNEL B MONITOR ─── %%
    subgraph ChannelB ["● CHANNEL B MONITOR (_process_monitor.py + _process_jsonl.py)"]
        SESSION_LOG_MON["● _session_log_monitor()<br/>━━━━━━━━━━<br/>Polls JSONL file<br/>Tracks last parseable record type"]
        JSONL_LAST["● _jsonl_last_record_type()<br/>━━━━━━━━━━<br/>ValueError/JSONDecodeError<br/>per-line → silently skipped"]
        CONSEC_ERR["Soft Circuit Breaker<br/>━━━━━━━━━━<br/>10 consecutive OSError<br/>logs warning, continues"]
        SUPPRESS_CB{"Suppression<br/>Circuit Breaker<br/>max_suppression_seconds"}
        API_CHK["_has_active_api_connection()<br/>━━━━━━━━━━<br/>ESTABLISHED TCP:443<br/>suppresses premature STALE"]
        CPU_CHK["_has_active_child_processes()<br/>━━━━━━━━━━<br/>child CPU > 10%<br/>suppresses premature STALE"]
        DIR_MISS["DIR_MISSING<br/>━━━━━━━━━━<br/>FileNotFoundError on JSONL dir<br/>Structural error — won't self-heal"]
    end

    %% ─── ORPHANED DETECTION ─── %%
    subgraph OrphanedDetection ["● ORPHANED TOOL RESULT DETECTION (new in this PR)"]
        STALE["STALE verdict<br/>━━━━━━━━━━<br/>Timeout — no completion signal"]
        ORPHAN_CHK{"last_record_type<br/>== 'user'?"}
        ORPHAN_FLAG["● orphaned_tool_result = True<br/>━━━━━━━━━━<br/>Claude received tool result<br/>but never responded<br/>Diagnostic only — no behavior change"]
    end

    %% ─── RACE ACCUMULATOR ─── %%
    subgraph RaceLayer ["● RACE ACCUMULATOR (_process_race.py)"]
        IDLE_STALL["_watch_stdout_idle()<br/>━━━━━━━━━━<br/>IDLE_STALL: no byte growth<br/>Orthogonal to Channel B"]
        RACE_ACC["● RaceAccumulator<br/>━━━━━━━━━━<br/>Collects all race signals<br/>channel_b_orphaned_tool_result: bool"]
        RESOLVE["resolve_termination()<br/>━━━━━━━━━━<br/>assert_never: exhaustive<br/>ChannelBStatus enum handling"]
    end

    %% ─── BEST-EFFORT /PROC ─── %%
    subgraph BestEffort ["● BEST-EFFORT /PROC SNAPSHOTS (linux_tracing.py)"]
        SNAPSHOT["read_proc_snapshot()<br/>━━━━━━━━━━<br/>psutil.NoSuchProcess/AccessDenied/<br/>ZombieProcess → returns None"]
        NET_IO["● net/io reads<br/>━━━━━━━━━━<br/>FileNotFoundError/PermissionError/OSError<br/>→ api_connections/io_bytes = None"]
        ENROLLMENT["read_enrollment()<br/>━━━━━━━━━━<br/>OSError/KeyError/TypeError/<br/>ValueError/JSONDecodeError → None"]
    end

    %% ─── EXECUTION ERROR HANDLING ─── %%
    subgraph ExecHandling ["EXECUTION ERROR HANDLING (headless.py)"]
        BUDGET_GUARD["_apply_budget_guard()<br/>━━━━━━━━━━<br/>consecutive_failures circuit breaker<br/>→ needs_retry=False, BUDGET_EXHAUSTED"]
        EXCEPT_EXC["except Exception<br/>━━━━━━━━━━<br/>Runner crash:<br/>flush + SkillResult.crashed()"]
        EXCEPT_BASE["except BaseException<br/>━━━━━━━━━━<br/>Cancellation/KeyboardInterrupt:<br/>CancelScope(shield=True) flush, re-raise"]
    end

    %% ─── CRASH RECOVERY ─── %%
    subgraph CrashRecovery ["CRASH RECOVERY — Four-Gate Pipeline (session_log.py)"]
        G1["Gate 1: Enrollment sidecar<br/>━━━━━━━━━━<br/>Missing → skip (continue)"]
        G2["Gate 2: Boot ID match<br/>━━━━━━━━━━<br/>Reboot detected → skip"]
        G3["Gate 3: PID liveness<br/>━━━━━━━━━━<br/>starttime_ticks identity<br/>PID recycling → skip"]
        G4["Gate 4: comm alien reject<br/>━━━━━━━━━━<br/>issue #806 immunity → skip"]
    end

    %% ─── OUTPUT ─── %%
    subgraph OutputLayer ["● OUTPUT / TELEMETRY"]
        FLUSH_LOG["● flush_session_log()<br/>━━━━━━━━━━<br/>Writes orphaned_tool_result<br/>to summary.json<br/>secondary ops: except Exception, no-raise"]
        SUBPROCESS_RES["● SubprocessResult<br/>━━━━━━━━━━<br/>orphaned_tool_result: bool = False<br/>Diagnostic only — never drives behavior"]
        ANOMALY["detect_anomalies()<br/>━━━━━━━━━━<br/>Post-session over ProcSnapshot series<br/>writes anomalies.jsonl"]
    end

    %% ─── FLOW CONNECTIONS ─── %%

    START --> ARCH008
    START --> ASSERT_RUNNER
    ARCH008 -->|"raw int passed"| T_VALIDATION_ERR
    ARCH008 -->|"valid TraceTarget"| TRACE_RESOLVE
    TRACE_RESOLVE -->|"TraceTargetResolutionError"| T_VALIDATION_ERR
    ASSERT_RUNNER -->|"None runner"| T_VALIDATION_ERR

    SESSION_LOG_MON --> JSONL_LAST
    JSONL_LAST -->|"parse error per-line: skip"| SESSION_LOG_MON
    SESSION_LOG_MON -->|"FileNotFoundError"| DIR_MISS
    SESSION_LOG_MON -->|"OSError ×N"| CONSEC_ERR
    CONSEC_ERR -->|"continue"| SESSION_LOG_MON
    SESSION_LOG_MON --> API_CHK
    SESSION_LOG_MON --> CPU_CHK
    API_CHK --> SUPPRESS_CB
    CPU_CHK --> SUPPRESS_CB
    SUPPRESS_CB -->|"within limit: suppress"| SESSION_LOG_MON
    SUPPRESS_CB -->|"max_suppression_seconds exceeded"| STALE

    SESSION_LOG_MON -->|"timeout"| STALE
    STALE --> ORPHAN_CHK
    ORPHAN_CHK -->|"yes"| ORPHAN_FLAG
    ORPHAN_CHK -->|"no"| RACE_ACC
    ORPHAN_FLAG -->|"flag propagated"| RACE_ACC

    IDLE_STALL --> RACE_ACC
    RACE_ACC --> RESOLVE
    RESOLVE -->|"exhaustive ChannelBStatus match"| FLUSH_LOG

    SNAPSHOT -->|"psutil error"| NET_IO
    SNAPSHOT -->|"psutil.NoSuchProcess → None"| RACE_ACC
    NET_IO -->|"OSError family → nullable fields"| SUBPROCESS_RES
    ENROLLMENT -->|"all exceptions → None"| G1

    BUDGET_GUARD -->|"budget exhausted"| T_BUDGET
    EXCEPT_EXC --> FLUSH_LOG
    EXCEPT_BASE --> FLUSH_LOG

    G1 --> G2 --> G3 --> G4
    G4 -->|"all gates passed"| FLUSH_LOG
    G1 -->|"gate fail → skip"| T_SUCCESS
    G2 -->|"gate fail → skip"| T_SUCCESS
    G3 -->|"gate fail → skip"| T_SUCCESS
    G4 -->|"gate fail → skip"| T_SUCCESS

    FLUSH_LOG --> SUBPROCESS_RES
    SUBPROCESS_RES --> ANOMALY
    ANOMALY --> T_SUCCESS
    EXCEPT_EXC -->|"SkillResult.crashed()"| T_CRASHED

    %% ─── CLASS ASSIGNMENTS ─── %%
    class START,T_SUCCESS,T_CRASHED,T_VALIDATION_ERR,T_BUDGET terminal;
    class ARCH008,ASSERT_RUNNER,TRACE_RESOLVE,ORPHAN_CHK,SUPPRESS_CB detector;
    class SESSION_LOG_MON,JSONL_LAST,RACE_ACC,RESOLVE phase;
    class ORPHAN_FLAG,DIR_MISS,IDLE_STALL gap;
    class API_CHK,CPU_CHK,CONSEC_ERR stateNode;
    class SNAPSHOT,ENROLLMENT,BUDGET_GUARD,EXCEPT_EXC,EXCEPT_BASE handler;
    class NET_IO handler;
    class G1,G2,G3,G4 output;
    class FLUSH_LOG,SUBPROCESS_RES,ANOMALY output;
```

Closes #948

## Implementation Plan

Plan file: `.autoskillit/temp/make-plan/channel_b_orphaned_tool_result_detection_plan_2026-04-15_234600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 422 | 38.1k | 2.8M | 206.8k | 2 | 10m 55s |
| review | 266 | 20.7k | 1.5M | 107.9k | 3 | 18m 44s |
| verify | 368 | 37.3k | 3.3M | 166.4k | 2 | 10m 43s |
| implement | 990 | 54.5k | 9.7M | 196.0k | 2 | 26m 21s |
| fix | 584 | 30.2k | 4.0M | 122.6k | 2 | 21m 38s |
| prepare_pr | 120 | 13.2k | 361.5k | 66.0k | 2 | 3m 28s |
| run_arch_lenses | 7.4k | 65.1k | 1.1M | 212.3k | 6 | 27m 8s |
| compose_pr | 134 | 21.9k | 511.0k | 75.7k | 2 | 5m 57s |
| review_pr | 120 | 25.2k | 648.4k | 67.5k | 1 | 5m 37s |
| resolve_review | 309 | 15.6k | 1.6M | 58.5k | 1 | 11m 12s |
| **Total** | 10.8k | 321.8k | 25.5M | 1.3M | | 2h 21m |