### PR TITLE
feat: preserve raw stdout on failure and extract per-turn API metadata

### DIFF
--- a/src/autoskillit/core/_type_results.py
+++ b/src/autoskillit/core/_type_results.py
@@ -155,6 +155,7 @@ class SkillResult:
     Surfaces from SubprocessResult so the formatter can annotate exit_code
     with the kill cause, resolving the "success=True + exit_code=-9" contradiction.
     """
+    last_stop_reason: str = ""
 
     def to_json(self) -> str:
         data: dict[str, Any] = {
@@ -172,6 +173,7 @@ class SkillResult:
             "token_usage": self.token_usage,
             "write_path_warnings": self.write_path_warnings,
             "write_call_count": self.write_call_count,
+            "last_stop_reason": self.last_stop_reason,
         }
         if self.worktree_path is not None:
             data["worktree_path"] = self.worktree_path

--- a/src/autoskillit/execution/headless.py
+++ b/src/autoskillit/execution/headless.py
@@ -27,6 +27,7 @@ from autoskillit.core import (
     ChannelConfirmation,
     CliSubtype,
     FailureRecord,
+    KillReason,
     RetryReason,
     SessionOutcome,
     SkillResult,
@@ -1210,7 +1211,12 @@ async def run_headless_core(
                     clone_contamination_reverted=_clone_reverted,
                     tracked_comm=result.tracked_comm,
                     orphaned_tool_result=result.orphaned_tool_result,
-                    raw_stdout=result.stdout if not skill_result.success else "",
+                    raw_stdout=result.stdout
+                    if (
+                        not skill_result.success
+                        or skill_result.kill_reason != KillReason.NATURAL_EXIT
+                    )
+                    else "",
                     last_stop_reason=skill_result.last_stop_reason,
                 )
             except Exception:

--- a/src/autoskillit/execution/headless.py
+++ b/src/autoskillit/execution/headless.py
@@ -599,6 +599,7 @@ def _build_skill_result(
                     retry_reason=RetryReason.NONE,
                     stderr=result.stderr if result.stderr else "",
                     token_usage=stale_session.token_usage,
+                    last_stop_reason=stale_session.last_stop_reason,
                 )
         # No valid result in stdout — fall through to original stale response
         _capture_failure(
@@ -868,6 +869,7 @@ def _build_skill_result(
             cli_subtype=session.subtype,
             write_path_warnings=write_path_warnings,
             write_call_count=write_call_count,
+            last_stop_reason=session.last_stop_reason,
         )
     else:
         sr = SkillResult(
@@ -886,6 +888,7 @@ def _build_skill_result(
             write_path_warnings=write_path_warnings,
             write_call_count=write_call_count,
             kill_reason=result.kill_reason,
+            last_stop_reason=session.last_stop_reason,
         )
     sr = _apply_budget_guard(sr, skill_command, audit, max_consecutive_retries)
 
@@ -1207,6 +1210,8 @@ async def run_headless_core(
                     clone_contamination_reverted=_clone_reverted,
                     tracked_comm=result.tracked_comm,
                     orphaned_tool_result=result.orphaned_tool_result,
+                    raw_stdout=result.stdout if not skill_result.success else "",
+                    last_stop_reason=skill_result.last_stop_reason,
                 )
             except Exception:
                 logger.debug("session_log_flush_failed", exc_info=True)

--- a/src/autoskillit/execution/session.py
+++ b/src/autoskillit/execution/session.py
@@ -80,6 +80,7 @@ class ClaudeSessionResult:
     assistant_messages: list[str] = field(default_factory=list)
     tool_uses: list[dict[str, Any]] = field(default_factory=list)
     jsonl_context_exhausted: bool = False
+    stop_reasons: list[str] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         if not isinstance(self.result, str):
@@ -182,6 +183,11 @@ class ClaudeSessionResult:
         Recovery operations and CHANNEL_B bypass may only run on complete sessions.
         """
         return not self.is_error and self.subtype not in FAILURE_SUBTYPES
+
+    @property
+    def last_stop_reason(self) -> str:
+        """The stop_reason from the final assistant turn, or empty string."""
+        return self.stop_reasons[-1] if self.stop_reasons else ""
 
 
 def extract_token_usage(stdout: str) -> dict[str, Any] | None:
@@ -318,6 +324,7 @@ class _ParseAccumulator:
     tool_uses: list[dict[str, Any]] = field(default_factory=list)
     assistant_messages: list[str] = field(default_factory=list)
     jsonl_context_exhausted: bool = False
+    stop_reasons: list[str] = field(default_factory=list)
 
 
 def parse_session_result(stdout: str) -> ClaudeSessionResult:
@@ -378,6 +385,9 @@ def parse_session_result(stdout: str) -> ClaudeSessionResult:
                         text = str(content).strip()
                     if text:
                         acc.assistant_messages.append(text)
+                    _stop = msg.get("stop_reason", "")
+                    if _stop:
+                        acc.stop_reasons.append(str(_stop))
                 elif "message" not in obj:
                     # Flat assistant record (no "message" wrapper) — detect
                     # context exhaustion inline instead of a separate scan pass.
@@ -437,6 +447,7 @@ def parse_session_result(stdout: str) -> ClaudeSessionResult:
         assistant_messages=acc.assistant_messages,
         tool_uses=acc.tool_uses,
         jsonl_context_exhausted=acc.jsonl_context_exhausted,
+        stop_reasons=acc.stop_reasons,
     )
 
 

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -100,6 +100,8 @@ def flush_session_log(
     tracked_comm: str | None = None,
     exception_text: str = "",
     orphaned_tool_result: bool = False,
+    raw_stdout: str = "",
+    last_stop_reason: str = "",
 ) -> None:
     """Flush session diagnostics to disk.
 
@@ -122,6 +124,31 @@ def flush_session_log(
 
     if cc_log and not cc_log.exists():
         logger.warning("claude_code_log_not_found", path=cc_log_str, session_id=session_id)
+
+    _cb_request_ids: list[str] = []
+    _cb_turn_timestamps: list[str] = []
+    if cc_log and cc_log.exists():
+        seen_request_ids: set[str] = set()
+        try:
+            for raw_line in cc_log.read_text(encoding="utf-8", errors="replace").splitlines():
+                raw_line = raw_line.strip()
+                if not raw_line:
+                    continue
+                try:
+                    rec = json.loads(raw_line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(rec, dict) or rec.get("type") != "assistant":
+                    continue
+                rid = rec.get("requestId", "")
+                if rid and rid not in seen_request_ids:
+                    seen_request_ids.add(rid)
+                    _cb_request_ids.append(str(rid))
+                ts = rec.get("timestamp", "")
+                if ts:
+                    _cb_turn_timestamps.append(str(ts))
+        except OSError:
+            pass
 
     session_dir = log_root / "sessions" / dir_name
     session_dir.mkdir(parents=True, exist_ok=True)
@@ -241,9 +268,15 @@ def flush_session_log(
         "tracked_comm_drift": _tracked_comm_drift,
         "tracer_target_resolution_version": 2,
         "orphaned_tool_result": orphaned_tool_result,
+        "last_stop_reason": last_stop_reason,
+        "request_ids": _cb_request_ids,
+        "turn_timestamps": _cb_turn_timestamps,
     }
     summary_path = session_dir / "summary.json"
     atomic_write(summary_path, json.dumps(summary, sort_keys=True, indent=2) + "\n")
+
+    if not success and raw_stdout:
+        atomic_write(session_dir / "raw_stdout.jsonl", raw_stdout)
 
     if exception_text:
         atomic_write(session_dir / "crash_exception.txt", exception_text)

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -141,14 +141,14 @@ def flush_session_log(
                 if not isinstance(rec, dict) or rec.get("type") != "assistant":
                     continue
                 rid = rec.get("requestId", "")
+                ts = rec.get("timestamp", "")
                 if rid and rid not in seen_request_ids:
                     seen_request_ids.add(rid)
                     _cb_request_ids.append(str(rid))
-                ts = rec.get("timestamp", "")
-                if ts:
-                    _cb_turn_timestamps.append(str(ts))
+                    if ts:
+                        _cb_turn_timestamps.append(str(ts))
         except OSError:
-            pass
+            logger.debug("channel_b_log_read_error", path=cc_log_str, exc_info=True)
 
     session_dir = log_root / "sessions" / dir_name
     session_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/execution/test_headless.py
+++ b/tests/execution/test_headless.py
@@ -841,6 +841,7 @@ class TestBuildSkillResultCrossValidation:
         "is_error",
         "exit_code",
         "kill_reason",
+        "last_stop_reason",
         "needs_retry",
         "retry_reason",
         "stderr",

--- a/tests/execution/test_headless.py
+++ b/tests/execution/test_headless.py
@@ -4154,3 +4154,33 @@ class TestContractNudge:
         )
         assert result.retry_reason == RetryReason.CONTRACT_RECOVERY
         assert result.needs_retry is True
+
+
+# ---------------------------------------------------------------------------
+# last_stop_reason threading test
+# ---------------------------------------------------------------------------
+
+
+def test_build_skill_result_surfaces_last_stop_reason():
+    ndjson = "\n".join(
+        [
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {"stop_reason": "end_turn", "content": [], "usage": {}},
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "result",
+                    "subtype": "success",
+                    "is_error": False,
+                    "result": "done",
+                    "session_id": "s1",
+                }
+            ),
+        ]
+    )
+    result = _make_result(returncode=0, stdout=ndjson)
+    sr = _build_skill_result(result)
+    assert sr.last_stop_reason == "end_turn"

--- a/tests/execution/test_session.py
+++ b/tests/execution/test_session.py
@@ -1031,6 +1031,7 @@ class TestSkillResult:
             "is_error",
             "exit_code",
             "kill_reason",
+            "last_stop_reason",
             "needs_retry",
             "retry_reason",
             "stderr",

--- a/tests/execution/test_session.py
+++ b/tests/execution/test_session.py
@@ -1269,3 +1269,108 @@ class TestFullChainZeroWriteGate:
         session = parse_session_result(ndjson)
         write_call_count = sum(1 for t in session.tool_uses if t.get("name") in {"Write", "Edit"})
         assert write_call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# stop_reasons extraction tests
+# ---------------------------------------------------------------------------
+
+
+def test_parse_session_result_extracts_stop_reasons():
+    ndjson = "\n".join(
+        [
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {"stop_reason": "tool_use", "content": [], "usage": {}},
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "message": {"stop_reason": "end_turn", "content": [], "usage": {}},
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "result",
+                    "subtype": "success",
+                    "is_error": False,
+                    "result": "Done.",
+                    "session_id": "abc",
+                }
+            ),
+        ]
+    )
+    parsed = parse_session_result(ndjson)
+    assert parsed.stop_reasons == ["tool_use", "end_turn"]
+    assert parsed.last_stop_reason == "end_turn"
+
+
+def test_parse_session_result_empty_stop_reasons_when_absent():
+    ndjson = json.dumps(
+        {
+            "type": "result",
+            "subtype": "success",
+            "is_error": False,
+            "result": "Done.",
+            "session_id": "abc",
+        }
+    )
+    parsed = parse_session_result(ndjson)
+    assert parsed.stop_reasons == []
+    assert parsed.last_stop_reason == ""
+
+
+def test_last_stop_reason_is_last_turn():
+    ndjson = "\n".join(
+        [
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "requestId": "r1",
+                    "timestamp": "t1",
+                    "message": {"stop_reason": "tool_use", "content": [], "usage": {}},
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "assistant",
+                    "requestId": "r2",
+                    "timestamp": "t2",
+                    "message": {"stop_reason": "max_tokens", "content": [], "usage": {}},
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "result",
+                    "subtype": "success",
+                    "is_error": False,
+                    "result": "x",
+                    "session_id": "s",
+                }
+            ),
+        ]
+    )
+    parsed = parse_session_result(ndjson)
+    assert parsed.last_stop_reason == "max_tokens"
+
+
+def test_parse_session_result_missing_stop_reason_skipped():
+    ndjson = "\n".join(
+        [
+            json.dumps({"type": "assistant", "message": {"content": [], "usage": {}}}),
+            json.dumps(
+                {
+                    "type": "result",
+                    "subtype": "success",
+                    "is_error": False,
+                    "result": "ok",
+                    "session_id": "s",
+                }
+            ),
+        ]
+    )
+    parsed = parse_session_result(ndjson)
+    assert parsed.stop_reasons == []
+    assert parsed.last_stop_reason == ""

--- a/tests/execution/test_session_log.py
+++ b/tests/execution/test_session_log.py
@@ -1054,3 +1054,81 @@ def test_flush_writes_crash_exception_file(tmp_path):
     crash_file = session_dir / "crash_exception.txt"
     assert crash_file.exists()
     assert "RuntimeError: boom" in crash_file.read_text()
+
+
+# ---------------------------------------------------------------------------
+# raw_stdout and per-turn field tests
+# ---------------------------------------------------------------------------
+
+
+def test_flush_session_log_writes_raw_stdout_on_failure(tmp_path):
+    raw = '{"type": "assistant"}\n{"type": "result"}\n'
+    flush_session_log(
+        log_dir=str(tmp_path),
+        cwd="/tmp",
+        session_id="test-session",
+        pid=1,
+        skill_command="test",
+        success=False,
+        subtype="empty_output",
+        exit_code=-1,
+        start_ts="2026-04-15T07:00:00Z",
+        proc_snapshots=None,
+        raw_stdout=raw,
+    )
+    raw_file = tmp_path / "sessions" / "test-session" / "raw_stdout.jsonl"
+    assert raw_file.exists()
+    assert raw_file.read_text() == raw
+
+
+def test_flush_session_log_no_raw_stdout_on_success(tmp_path):
+    flush_session_log(
+        log_dir=str(tmp_path),
+        cwd="/tmp",
+        session_id="ok-session",
+        pid=1,
+        skill_command="test",
+        success=True,
+        subtype="success",
+        exit_code=0,
+        start_ts="2026-04-15T07:00:00Z",
+        proc_snapshots=None,
+        raw_stdout='{"type": "result"}',
+    )
+    raw_file = tmp_path / "sessions" / "ok-session" / "raw_stdout.jsonl"
+    assert not raw_file.exists()
+
+
+def test_flush_session_log_summary_contains_per_turn_fields(tmp_path, monkeypatch):
+    cb_log = tmp_path / "s.jsonl"
+    cb_log.write_text(
+        json.dumps(
+            {"type": "assistant", "requestId": "req-001", "timestamp": "2026-04-15T07:00:00Z"}
+        )
+        + "\n"
+        + json.dumps(
+            {"type": "assistant", "requestId": "req-002", "timestamp": "2026-04-15T07:00:05Z"}
+        )
+        + "\n"
+    )
+    import autoskillit.execution.session_log as sl_mod
+
+    monkeypatch.setattr(sl_mod, "claude_code_log_path", lambda cwd, sid: cb_log)
+
+    flush_session_log(
+        log_dir=str(tmp_path),
+        cwd="/tmp",
+        session_id="s",
+        pid=1,
+        skill_command="test",
+        success=False,
+        subtype="empty_output",
+        exit_code=-1,
+        start_ts="2026-04-15T07:00:00Z",
+        proc_snapshots=None,
+        last_stop_reason="end_turn",
+    )
+    summary = json.loads((tmp_path / "sessions" / "s" / "summary.json").read_text())
+    assert summary["last_stop_reason"] == "end_turn"
+    assert summary["request_ids"] == ["req-001", "req-002"]
+    assert summary["turn_timestamps"] == ["2026-04-15T07:00:00Z", "2026-04-15T07:00:05Z"]

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -111,9 +111,9 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # core/io.py — write_versioned_json itself (the blessed helper) uses atomic_write+json.dumps
     ("src/autoskillit/core/io.py", 118),
     # session_log.py — summary dict, token_usage list, audit_log list
-    ("src/autoskillit/execution/session_log.py", 246),
-    ("src/autoskillit/execution/session_log.py", 262),
-    ("src/autoskillit/execution/session_log.py", 265),
+    ("src/autoskillit/execution/session_log.py", 276),
+    ("src/autoskillit/execution/session_log.py", 295),
+    ("src/autoskillit/execution/session_log.py", 298),
     # migration/store.py — failure store dicts
     ("src/autoskillit/migration/store.py", 54),
     ("src/autoskillit/migration/store.py", 64),
@@ -212,8 +212,8 @@ class TestSchemaVersionConvention:
         """List-payload sites are included since the AST scanner can't distinguish return types."""
         # These sites write list payloads through function calls but are caught by the scanner
         list_sites = [
-            ("src/autoskillit/execution/session_log.py", 262),
-            ("src/autoskillit/execution/session_log.py", 265),
+            ("src/autoskillit/execution/session_log.py", 295),
+            ("src/autoskillit/execution/session_log.py", 298),
             ("src/autoskillit/smoke_utils.py", 87),
             ("src/autoskillit/smoke_utils.py", 290),
         ]


### PR DESCRIPTION
## Summary

Two independent but complementary diagnostic improvements:

1. **Per-turn metadata extraction**: Add `stop_reasons` to `ClaudeSessionResult` by collecting `message.stop_reason` values during the existing NDJSON scan in `parse_session_result()` — this field is present in stream-json stdout. Thread `last_stop_reason` through `SkillResult` into `flush_session_log()`. Extract `request_ids` and `turn_timestamps` from Channel B JSONL (`cc_log`, already resolved in `flush_session_log`) and include them in `summary.json` directly — **`requestId` and `timestamp` are not present in stream-json stdout, only in Channel B JSONL**.

2. **Raw stdout preservation on failure**: Pass raw `stdout` to `flush_session_log()` on non-success sessions. The function writes it atomically as `raw_stdout.jsonl` in the session directory — available for post-mortem re-inspection without needing to rerun the session.

No new modules. No new abstractions. Pure addition of fields and two write calls, all within the existing data flow.

## Architecture Impact

### Data Lineage Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph Origins ["Data Origins"]
        direction TB
        NDJSON["Claude subprocess stdout<br/>━━━━━━━━━━<br/>Raw NDJSON stream<br/>assistant + result records"]
        CC_LOG["Claude Code JSONL log<br/>━━━━━━━━━━<br/>~/.local/share/claude/<br/>session UUID/*.jsonl"]
    end

    subgraph Parse ["● parse_session_result()  ·  session.py"]
        direction TB
        ACC["● _ParseAccumulator<br/>━━━━━━━━━━<br/>● stop_reasons: list[str]<br/>tool_uses, assistant_messages<br/>jsonl_context_exhausted"]
        CSR["● ClaudeSessionResult<br/>━━━━━━━━━━<br/>● stop_reasons: list[str]<br/>● last_stop_reason (prop)<br/>token_usage, tool_uses"]
    end

    subgraph Build ["● _build_skill_result()  ·  headless.py"]
        SR["● SkillResult<br/>━━━━━━━━━━<br/>● last_stop_reason: str<br/>success, subtype, is_error<br/>token_usage, kill_reason"]
    end

    subgraph Flush ["● flush_session_log()  ·  session_log.py"]
        direction TB
        CB_PARSE["● cc_log parser<br/>━━━━━━━━━━<br/>seen_request_ids (dedup)<br/>request_ids list<br/>turn_timestamps list"]
        FAIL_GATE["● Failure gate<br/>━━━━━━━━━━<br/>raw_stdout forwarded<br/>only when not success"]
    end

    subgraph Storage ["Primary Storage  (source of truth)"]
        direction TB
        SUMMARY[("● summary.json<br/>━━━━━━━━━━<br/>● last_stop_reason<br/>● request_ids list<br/>● turn_timestamps list<br/>session_id, success, subtype")]
        INDEX[("sessions.jsonl<br/>━━━━━━━━━━<br/>append-only index<br/>per-session summary row")]
    end

    subgraph Artifacts ["Write-Only Artifacts  (failure debugging)"]
        RAW["● raw_stdout.jsonl<br/>━━━━━━━━━━<br/>raw NDJSON bytes<br/>written only on failure<br/>never read by production"]
    end

    subgraph Surface ["MCP Output Surface"]
        MCP_JSON["● SkillResult.to_json()<br/>━━━━━━━━━━<br/>● last_stop_reason<br/>returned to orchestrator"]
    end

    %% PRIMARY FLOWS %%
    NDJSON -->|"line scan<br/>stop_reason per turn"| ACC
    ACC -->|"accumulate into"| CSR
    CSR -->|"last_stop_reason"| SR
    SR -->|"to_json()"| MCP_JSON
    SR -->|"last_stop_reason<br/>+ !success gate"| Flush

    %% CC LOG → FLUSH
    CC_LOG -->|"read on flush<br/>(per-session)"| CB_PARSE
    CB_PARSE -->|"request_ids<br/>turn_timestamps"| SUMMARY

    %% RAW STDOUT GATE
    NDJSON -->|"raw bytes<br/>(SubprocessResult.stdout)"| FAIL_GATE
    FAIL_GATE -.->|"write-only<br/>on failure"| RAW

    %% PRIMARY STORAGE
    SR -->|"success, subtype<br/>last_stop_reason"| SUMMARY
    SUMMARY -->|"index entry"| INDEX

    %% CLASS ASSIGNMENTS %%
    class NDJSON,CC_LOG cli;
    class ACC,CSR stateNode;
    class SR handler;
    class CB_PARSE,FAIL_GATE phase;
    class SUMMARY,INDEX stateNode;
    class RAW output;
    class MCP_JSON integration;
```

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 44, 'rankSpacing': 54, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START: run_headless_core])
    COMPLETE([COMPLETE: SkillResult returned])

    subgraph Runner ["Subprocess Execution"]
        direction TB
        Launch["Launch claude CLI<br/>━━━━━━━━━━<br/>PTY + session_log_dir<br/>timeout / stale_threshold"]
        RawStdout["raw stdout NDJSON<br/>━━━━━━━━━━<br/>Streamed from claude CLI<br/>Channel A + Channel B"]
    end

    subgraph Parsing ["● NDJSON Parsing — session.py"]
        direction TB
        Accumulate["● _ParseAccumulator<br/>━━━━━━━━━━<br/>result_obj, tool_uses<br/>assistant_messages<br/>stop_reasons ← NEW"]
        ExtractStop["● Extract stop_reason<br/>━━━━━━━━━━<br/>msg.get('stop_reason','')<br/>per assistant turn → acc.stop_reasons"]
        FlatCtx["Flat ctx-exhaustion detect<br/>━━━━━━━━━━<br/>output_tokens==0 → jsonl_context_exhausted"]
        BuildCSR["● Build ClaudeSessionResult<br/>━━━━━━━━━━<br/>subtype / is_error / result<br/>stop_reasons=acc.stop_reasons ← NEW"]
    end

    subgraph CSRProps ["● ClaudeSessionResult Properties — session.py"]
        direction TB
        LastStop["● last_stop_reason property<br/>━━━━━━━━━━<br/>stop_reasons[-1] if stop_reasons else ''<br/>Exposes final turn's stop signal"]
        NeedsRetry["needs_retry / retry_reason<br/>━━━━━━━━━━<br/>context_exhausted or max_turns?"]
        ContentState["_evaluate_content_state<br/>━━━━━━━━━━<br/>COMPLETE / ABSENT / CONTRACT_VIOLATION<br/>/ SESSION_ERROR"]
    end

    subgraph Outcome ["Outcome Computation — session.py"]
        direction TB
        ComputeOutcome["_compute_outcome<br/>━━━━━━━━━━<br/>_compute_success + _compute_retry<br/>→ SessionOutcome, RetryReason"]
        DeadEndGuard["Dead-end guard<br/>━━━━━━━━━━<br/>ABSENT + channel confirm → RETRIABLE"]
        ContradictionGuard["Contradiction guard<br/>━━━━━━━━━━<br/>success + needs_retry → demote success"]
    end

    subgraph ResultBuild ["● Skill Result Construction — headless.py"]
        direction TB
        TerminationBranch{"Termination<br/>branch?"}
        StaleRecovery["Stale recovery path<br/>━━━━━━━━━━<br/>parse stdout, attempt _compute_success<br/>● last_stop_reason=stale_session.last_stop_reason"]
        IdleStall["IDLE_STALL path<br/>━━━━━━━━━━<br/>SkillResult success=False<br/>needs_retry=True"]
        ChanBRecovery["Channel B drain-race recovery<br/>━━━━━━━━━━<br/>_recover_from_separate_marker<br/>if UNPARSEABLE/EMPTY_OUTPUT + marker"]
        NormalBuild["● Build SkillResult (normal)<br/>━━━━━━━━━━<br/>success / subtype / exit_code<br/>● last_stop_reason=session.last_stop_reason"]
        PathContam["Path contamination branch<br/>━━━━━━━━━━<br/>● last_stop_reason=session.last_stop_reason<br/>needs_retry=True"]
        BudgetGuard["Budget guard (_apply_budget_guard)<br/>━━━━━━━━━━<br/>cap consecutive retries<br/>→ BUDGET_EXHAUSTED if over limit"]
        ContractGate["CONTRACT_RECOVERY gate<br/>━━━━━━━━━━<br/>adjudicated_failure + write_call_count≥1<br/>→ promote to RETRIABLE"]
        ZeroWriteGate["Zero-write gate<br/>━━━━━━━━━━<br/>success + 0 writes + write_expected<br/>→ zero_writes / needs_retry=True"]
    end

    subgraph TypeResults ["● SkillResult Schema — _type_results.py"]
        direction TB
        SkillResultNode["● SkillResult dataclass<br/>━━━━━━━━━━<br/>success, result, session_id<br/>kill_reason, needs_retry<br/>● last_stop_reason: str = '' ← NEW<br/>to_json() includes last_stop_reason"]
    end

    subgraph Diagnostics ["● Session Diagnostics — session_log.py"]
        direction TB
        FlushDecision{"flush needed?<br/>━━━━━━━━━━<br/>proc_snapshots OR<br/>not success OR step_name"}
        FlushLog["● flush_session_log<br/>━━━━━━━━━━<br/>summary.json ← last_stop_reason NEW<br/>proc_trace.jsonl / anomalies.jsonl<br/>sessions.jsonl index"]
        WriteRaw["● Write raw_stdout.jsonl<br/>━━━━━━━━━━<br/>ONLY when: not success AND raw_stdout<br/>← NEW: preserves CLI stdout on failure"]
        WriteSummary["summary.json<br/>━━━━━━━━━━<br/>success, subtype, exit_code<br/>● last_stop_reason field ← NEW<br/>request_ids, turn_timestamps"]
    end

    %% TOP-LEVEL FLOW %%
    START --> Launch
    Launch --> RawStdout

    %% Parsing phase %%
    RawStdout --> Accumulate
    Accumulate -->|"per assistant record"| ExtractStop
    Accumulate -->|"flat record, output_tokens==0"| FlatCtx
    ExtractStop --> BuildCSR
    FlatCtx --> BuildCSR

    %% CSR properties %%
    BuildCSR --> LastStop
    BuildCSR --> NeedsRetry
    BuildCSR --> ContentState

    %% Outcome computation %%
    ContentState --> ComputeOutcome
    NeedsRetry --> ComputeOutcome
    ComputeOutcome --> DeadEndGuard
    ComputeOutcome --> ContradictionGuard

    %% Result construction %%
    ComputeOutcome --> TerminationBranch
    LastStop -->|"propagated"| StaleRecovery
    LastStop -->|"propagated"| NormalBuild
    LastStop -->|"propagated"| PathContam

    TerminationBranch -->|"STALE"| StaleRecovery
    TerminationBranch -->|"IDLE_STALL"| IdleStall
    TerminationBranch -->|"COMPLETED/NATURAL_EXIT"| ChanBRecovery
    ChanBRecovery -->|"recovered or pass-through"| NormalBuild

    NormalBuild -->|"path_contamination?"| PathContam
    NormalBuild --> BudgetGuard
    PathContam --> BudgetGuard
    StaleRecovery --> BudgetGuard
    IdleStall --> BudgetGuard
    BudgetGuard --> ContractGate
    ContractGate --> ZeroWriteGate
    ZeroWriteGate --> SkillResultNode

    %% Diagnostics %%
    SkillResultNode --> FlushDecision
    FlushDecision -->|"yes"| FlushLog
    FlushLog --> WriteSummary
    FlushLog -->|"not success AND raw_stdout non-empty"| WriteRaw

    SkillResultNode --> COMPLETE

    %% CLASS ASSIGNMENTS %%
    class START,COMPLETE terminal;
    class Launch,RawStdout phase;
    class Accumulate,ExtractStop,FlatCtx,BuildCSR handler;
    class LastStop,NeedsRetry,ContentState stateNode;
    class ComputeOutcome,DeadEndGuard,ContradictionGuard phase;
    class TerminationBranch detector;
    class StaleRecovery,ChanBRecovery,NormalBuild,PathContam,IdleStall handler;
    class BudgetGuard,ContractGate,ZeroWriteGate detector;
    class SkillResultNode stateNode;
    class FlushDecision detector;
    class FlushLog,WriteSummary,WriteRaw output;
```

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 65, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START([Headless Claude Session])

    %% ─── SUBPROCESS RESULT ─────────────────────────────────────────────────── %%
    subgraph SubprocResult ["● SubprocessResult — INIT_ONLY Bundle"]
        direction LR
        SR_STDOUT["stdout<br/>━━━━━━━━━━<br/>raw NDJSON<br/>INIT_ONLY"]
        SR_CHAN["channel_confirmation<br/>━━━━━━━━━━<br/>CHANNEL_A/B/UNMONITORED<br/>INIT_ONLY"]
        SR_TERM["termination<br/>━━━━━━━━━━<br/>COMPLETED/STALE/IDLE<br/>INIT_ONLY"]
        SR_META["timing / proc_snapshots<br/>━━━━━━━━━━<br/>replace() post-run<br/>INIT_ONLY"]
    end

    START --> SR_STDOUT
    START --> SR_CHAN
    START --> SR_TERM
    START --> SR_META

    %% ─── PARSE ACCUMULATOR ──────────────────────────────────────────────────── %%
    subgraph ParseAccum ["● _ParseAccumulator — MUTABLE scan state (session.py)"]
        direction TB
        PA_RESULT["result_obj<br/>━━━━━━━━━━<br/>Set ONCE on type=result<br/>MUTABLE (write-once)"]
        PA_CTX["jsonl_context_exhausted<br/>━━━━━━━━━━<br/>Latched True on detection<br/>MUTABLE (latch)"]
        PA_LISTS["tool_uses / assistant_messages<br/>stop_reasons<br/>━━━━━━━━━━<br/>APPEND_ONLY (never shrink)"]
    end

    SR_STDOUT -->|"NDJSON scan<br/>no early returns"| PA_RESULT
    SR_STDOUT --> PA_CTX
    SR_STDOUT --> PA_LISTS

    %% ─── GATE 1: SESSION COMPLETENESS ──────────────────────────────────────── %%
    G_COMPLETE{"● Gate: session_complete<br/>━━━━━━━━━━<br/>DERIVED from subtype<br/>Blocks synthesis if false"}

    PA_RESULT --> G_COMPLETE

    %% ─── CLAUDE SESSION RESULT ──────────────────────────────────────────────── %%
    subgraph SessionResult ["● ClaudeSessionResult — INIT_ONLY (session.py)"]
        direction LR
        CSR_CORE["subtype / is_error / result<br/>session_id / errors<br/>━━━━━━━━━━<br/>Normalized in __post_init__<br/>INIT_ONLY"]
        CSR_ACCUM["token_usage / assistant_messages<br/>tool_uses / stop_reasons<br/>━━━━━━━━━━<br/>Frozen after construction<br/>INIT_ONLY"]
        CSR_DERIVED["needs_retry / retry_reason<br/>session_complete / last_stop_reason<br/>agent_result<br/>━━━━━━━━━━<br/>DERIVED — computed at read time"]
    end

    G_COMPLETE -->|"complete=True"| CSR_CORE
    G_COMPLETE -->|"complete=True"| CSR_ACCUM
    CSR_CORE --> CSR_DERIVED
    CSR_ACCUM --> CSR_DERIVED

    %% ─── VALIDATION GATES (headless.py) ────────────────────────────────────── %%
    subgraph ValidationGates ["● Validation Gates — headless.py"]
        direction TB
        G_STALE{"Gate: Stale Recovery<br/>━━━━━━━━━━<br/>subtype==SUCCESS and<br/>result.strip() and not is_error"}
        G_CHAN{"Gate: Channel Awareness<br/>━━━━━━━━━━<br/>Synthesis only for UNMONITORED<br/>Channel A/B: absent = genuine"}
        G_CONTRACT{"Gate: CONTRACT_RECOVERY<br/>━━━━━━━━━━<br/>not success, not needs_retry<br/>subtype==adjudicated_failure<br/>write_call_count >= 1"}
        G_ZERO{"Gate: Zero-Write<br/>━━━━━━━━━━<br/>success and write_call_count==0<br/>write_behavior is not None"}
        G_BUDGET{"Gate: Budget Guard<br/>━━━━━━━━━━<br/>consecutive_failures vs<br/>max_consecutive_retries"}
    end

    CSR_DERIVED --> G_STALE
    SR_CHAN --> G_CHAN
    G_STALE --> G_CHAN
    G_CHAN --> G_CONTRACT
    G_CONTRACT --> G_ZERO
    G_ZERO --> G_BUDGET

    %% ─── SKILL RESULT ───────────────────────────────────────────────────────── %%
    subgraph SkillResultNode ["● SkillResult — INIT_ONLY (execution/_type_results.py)"]
        direction LR
        SK_CORE["success / result / session_id<br/>subtype / is_error / exit_code<br/>━━━━━━━━━━<br/>INIT_ONLY"]
        SK_RETRY["needs_retry / retry_reason<br/>kill_reason / last_stop_reason<br/>━━━━━━━━━━<br/>INIT_ONLY — stored (not derived)"]
        SK_WRITE["write_path_warnings<br/>━━━━━━━━━━<br/>APPEND_ONLY (list)<br/>write_call_count: MUTABLE (int)"]
        SK_OUT["outcome<br/>━━━━━━━━━━<br/>DERIVED from (success, needs_retry)<br/>Contradiction guard applied"]
    end

    G_BUDGET --> SK_CORE
    G_BUDGET --> SK_RETRY
    SK_RETRY --> SK_WRITE
    SK_CORE --> SK_OUT
    SK_RETRY --> SK_OUT

    %% ─── FROZEN / IMMUTABLE TYPES (type_results.py) ─────────────────────────── %%
    subgraph FrozenTypes ["● Frozen Dataclasses — zero mutation risk (_type_results.py)"]
        direction LR
        FT_VAD["ValidatedAddDir<br/>━━━━━━━━━━<br/>frozen=True<br/>path: str (INIT_ONLY)"]
        FT_WBS["WriteBehaviorSpec<br/>━━━━━━━━━━<br/>frozen=True, tuple fields<br/>mode / expected_when"]
        FT_CI["CIRunScope<br/>━━━━━━━━━━<br/>frozen=True<br/>workflow/head_sha/event"]
    end

    SK_CORE -.->|"gate input"| FT_WBS
    G_ZERO -.->|"reads mode/expected_when"| FT_WBS

    %% ─── FAILURE RECORD ─────────────────────────────────────────────────────── %%
    FR["● FailureRecord<br/>━━━━━━━━━━<br/>Write-once audit record<br/>timestamp / skill_command / exit_code<br/>subtype / stderr — INIT_ONLY"]

    SK_OUT -->|"failure path"| FR

    %% ─── SESSION LOG FLUSH ──────────────────────────────────────────────────── %%
    subgraph SessionLog ["● flush_session_log — session_log.py"]
        direction TB
        SL_COND{"success == False<br/>AND raw_stdout non-empty?"}
        SL_RAW["● raw_stdout.jsonl<br/>━━━━━━━━━━<br/>Preserved on failure ONLY<br/>atomic_write (write-once)"]
        SL_META["● summary.json<br/>━━━━━━━━━━<br/>request_ids (deduped)<br/>turn_timestamps<br/>WRITE-ONLY audit"]
        SL_TOKEN["token_usage.json<br/>━━━━━━━━━━<br/>From parse_session_result<br/>WRITE-ONLY audit"]
        SL_INDEX["sessions.jsonl index<br/>━━━━━━━━━━<br/>APPEND-ONLY index entry"]
    end

    SK_OUT --> SL_COND
    SL_COND -->|"Yes"| SL_RAW
    SL_COND -->|"No (success)"| SL_META
    SL_RAW --> SL_META
    SL_META --> SL_TOKEN
    SL_TOKEN --> SL_INDEX

    %% ─── CHANNEL B SOURCE ───────────────────────────────────────────────────── %%
    CHANB["Channel B JSONL log<br/>━━━━━━━━━━<br/>type=assistant records<br/>requestId + timestamp"]
    CHANB -->|"per-turn metadata extraction"| SL_META

    %% ─── CRASH RECOVERY GATES ───────────────────────────────────────────────── %%
    subgraph CrashGates ["● Crash Recovery Gates — session_log.py"]
        direction TB
        CG1{"Gate 1: Enrollment sidecar<br/>━━━━━━━━━━<br/>/dev/shm/autoskillit_enrollment_{pid}.json<br/>must exist"}
        CG2{"Gate 2: Boot ID match<br/>━━━━━━━━━━<br/>enrollment.boot_id == current_boot_id<br/>pre-reboot files deleted"}
        CG3{"Gate 3: PID liveness<br/>━━━━━━━━━━<br/>starttime_ticks identity check<br/>recycled PID → treat as crash"}
        CG4{"Gate 4: Comm match<br/>━━━━━━━━━━<br/>snapshots[0].comm == enrollment.comm<br/>alien binary → delete + skip"}
    end

    SL_INDEX --> CG1
    CG1 -->|"sidecar found"| CG2
    CG2 -->|"boot_id matches"| CG3
    CG3 -->|"PID recycled or dead"| CG4
    CG4 -->|"comm matches"| RECOVERED(["Crashed session recovered"])

    %% ─── CLASS ASSIGNMENTS ──────────────────────────────────────────────────── %%
    class SR_STDOUT,SR_CHAN,SR_TERM,SR_META stateNode;
    class PA_RESULT,PA_CTX phase;
    class PA_LISTS handler;
    class G_COMPLETE,G_STALE,G_CHAN,G_CONTRACT,G_ZERO,G_BUDGET detector;
    class CG1,CG2,CG3,CG4 detector;
    class CSR_CORE,CSR_ACCUM stateNode;
    class CSR_DERIVED gap;
    class SK_CORE,SK_RETRY stateNode;
    class SK_WRITE handler;
    class SK_OUT gap;
    class FR output;
    class FT_VAD,FT_WBS,FT_CI cli;
    class SL_COND detector;
    class SL_RAW,SL_META,SL_TOKEN,SL_INDEX output;
    class CHANB phase;
    class START,RECOVERED terminal;
```

Closes #947

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260416-070402-248506/.autoskillit/temp/make-plan/preserve_raw_stdout_on_failure_plan_2026-04-16_070402.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 577 | 51.2k | 3.8M | 287.9k | 3 | 15m 32s |
| review | 318 | 26.3k | 1.7M | 138.6k | 4 | 25m 30s |
| verify | 702 | 67.9k | 5.6M | 242.9k | 3 | 18m 37s |
| implement | 1.4k | 76.9k | 13.4M | 286.6k | 3 | 32m 50s |
| fix | 776 | 39.0k | 5.0M | 170.7k | 3 | 29m 22s |
| prepare_pr | 180 | 18.4k | 549.9k | 91.7k | 3 | 5m 1s |
| run_arch_lenses | 7.7k | 88.9k | 2.2M | 419.9k | 9 | 35m 19s |
| compose_pr | 201 | 31.3k | 756.3k | 110.1k | 3 | 8m 25s |
| review_pr | 441 | 50.9k | 1.3M | 127.5k | 2 | 12m 17s |
| resolve_review | 588 | 26.3k | 2.9M | 102.8k | 2 | 17m 21s |
| **Total** | 12.9k | 477.0k | 37.1M | 2.0M | | 3h 20m |