### PR TITLE
pytestmark Layer Markers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ markers = [
     "smoke: end-to-end smoke tests requiring Claude API access (deselect with: -m 'not smoke')",
     "integration: integration tests that spawn real subprocesses (deselect with: -m 'not integration')",
     "canary: development-time filter verification tests (deselect with: -m 'not canary')",
+    "layer(name): source-layer marker for test file classification (core, config, pipeline, execution, workspace, recipe, migration, server, cli)",
 ]
 
 [tool.coverage.run]

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -29,6 +29,29 @@ All tests run under `-n 4 --dist worksteal`. Every test must be safe for paralle
 - Never use bare assignment or `try/finally` to restore server state — use `monkeypatch` or
   rely on the fixture's teardown.
 
+## Layer Markers
+
+Every `test_*.py` file in a source-layer-mirroring directory carries a module-level
+`pytestmark` with a `layer` marker matching the directory name:
+
+```python
+pytestmark = [pytest.mark.layer("execution")]
+```
+
+**In-scope directories:** core, config, pipeline, execution, workspace, recipe,
+migration, server, cli.
+
+**Out of scope:** arch/, contracts/, infra/, docs/, skills/, hooks/, skills_extended/.
+
+When a file already defines `pytestmark` for other markers (e.g., `skipif`, `anyio`),
+use list form and place the `layer` marker first.
+
+The `layer` marker is registered in `pyproject.toml`. Conftest validates at collection
+time that marker values match directories (warnings on mismatch).
+`tests/arch/test_layer_markers.py` enforces completeness and correctness via AST scan.
+
+**Usage:** `pytest -m 'layer("core")'` runs only L0 core tests.
+
 ## Placement Convention: tests/skills/ vs tests/contracts/
 
 - `tests/skills/` — tests that exercise the skill loader, skill discovery, or skill

--- a/tests/arch/test_layer_markers.py
+++ b/tests/arch/test_layer_markers.py
@@ -90,6 +90,16 @@ def test_all_test_files_have_correct_layer_marker(directory: str) -> None:
     assert not errors, "\n".join(errors)
 
 
+def test_layer_directories_matches_conftest() -> None:
+    """LAYER_DIRECTORIES keys must match _LAYER_DIRS in conftest.py."""
+    from tests.conftest import _LAYER_DIRS
+
+    assert set(LAYER_DIRECTORIES.keys()) == _LAYER_DIRS, (
+        f"LAYER_DIRECTORIES keys {set(LAYER_DIRECTORIES.keys())} != "
+        f"conftest _LAYER_DIRS {_LAYER_DIRS}"
+    )
+
+
 def test_layer_marker_registered_in_pyproject() -> None:
     """The 'layer' marker is registered in pyproject.toml to avoid warnings."""
     import tomllib

--- a/tests/arch/test_layer_markers.py
+++ b/tests/arch/test_layer_markers.py
@@ -1,0 +1,102 @@
+"""Enforce pytestmark layer markers on all in-scope test files."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+TESTS_ROOT = Path(__file__).resolve().parent.parent
+
+LAYER_DIRECTORIES: dict[str, str] = {
+    "core": "core",
+    "config": "config",
+    "pipeline": "pipeline",
+    "execution": "execution",
+    "workspace": "workspace",
+    "recipe": "recipe",
+    "migration": "migration",
+    "server": "server",
+    "cli": "cli",
+}
+
+
+def _extract_layer_marker(path: Path) -> str | None:
+    """Parse a test file's AST and return the layer marker value, or None."""
+    tree = ast.parse(path.read_text())
+    for node in ast.iter_child_nodes(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == "pytestmark":
+                # pytestmark = [pytest.mark.layer("x"), ...]
+                if isinstance(node.value, ast.List):
+                    for elt in node.value.elts:
+                        val = _marker_layer_arg(elt)
+                        if val is not None:
+                            return val
+                # pytestmark = pytest.mark.layer("x")  (bare, no list)
+                val = _marker_layer_arg(node.value)
+                if val is not None:
+                    return val
+    return None
+
+
+def _marker_layer_arg(node: ast.expr) -> str | None:
+    """If node is pytest.mark.layer("x"), return "x"."""
+    if not isinstance(node, ast.Call):
+        return None
+    func = node.func
+    # pytest.mark.layer(...)
+    if (
+        isinstance(func, ast.Attribute)
+        and func.attr == "layer"
+        and isinstance(func.value, ast.Attribute)
+        and func.value.attr == "mark"
+    ):
+        if node.args and isinstance(node.args[0], ast.Constant):
+            return node.args[0].value
+    return None
+
+
+@pytest.mark.parametrize(
+    "directory",
+    sorted(LAYER_DIRECTORIES),
+    ids=sorted(LAYER_DIRECTORIES),
+)
+def test_all_test_files_have_correct_layer_marker(directory: str) -> None:
+    """Every test_*.py in an in-scope directory has pytestmark with correct layer."""
+    expected = LAYER_DIRECTORIES[directory]
+    dir_path = TESTS_ROOT / directory
+    test_files = sorted(dir_path.glob("test_*.py"))
+    assert test_files, f"No test files found in {dir_path}"
+
+    missing: list[str] = []
+    wrong: list[tuple[str, str]] = []
+
+    for tf in test_files:
+        layer = _extract_layer_marker(tf)
+        if layer is None:
+            missing.append(tf.name)
+        elif layer != expected:
+            wrong.append((tf.name, layer))
+
+    errors: list[str] = []
+    if missing:
+        errors.append(f"Missing layer marker: {missing}")
+    if wrong:
+        errors.append(f"Wrong layer marker: {wrong}")
+    assert not errors, "\n".join(errors)
+
+
+def test_layer_marker_registered_in_pyproject() -> None:
+    """The 'layer' marker is registered in pyproject.toml to avoid warnings."""
+    import tomllib
+
+    pyproject = TESTS_ROOT.parent / "pyproject.toml"
+    data = tomllib.loads(pyproject.read_text())
+    markers = data["tool"]["pytest"]["ini_options"]["markers"]
+    assert any(m.startswith("layer") for m in markers), (
+        "layer marker not registered in pyproject.toml [tool.pytest.ini_options].markers"
+    )

--- a/tests/cli/test_ansi.py
+++ b/tests/cli/test_ansi.py
@@ -8,6 +8,8 @@ import pytest
 
 from autoskillit.cli._ansi import ingredients_to_terminal, supports_color
 
+pytestmark = [pytest.mark.layer("cli")]
+
 
 def test_supports_color_respects_no_color(monkeypatch: pytest.MonkeyPatch) -> None:
     """NO_COLOR env var disables color."""

--- a/tests/cli/test_cli_hooks.py
+++ b/tests/cli/test_cli_hooks.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
+pytestmark = [pytest.mark.layer("cli")]
+
 
 # HK9
 def test_claude_settings_path_user_scope():

--- a/tests/cli/test_cli_marketplace.py
+++ b/tests/cli/test_cli_marketplace.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import pytest
+
+pytestmark = [pytest.mark.layer("cli")]
+
 
 # MK1
 def test_marketplace_module_exists():

--- a/tests/cli/test_cli_prompts.py
+++ b/tests/cli/test_cli_prompts.py
@@ -6,6 +6,8 @@ import pytest
 
 from autoskillit.cli._mcp_names import DIRECT_PREFIX, MARKETPLACE_PREFIX
 
+pytestmark = [pytest.mark.layer("cli")]
+
 
 # PR1
 def test_prompts_module_exists():

--- a/tests/cli/test_cli_serve_logging.py
+++ b/tests/cli/test_cli_serve_logging.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import logging as _stdlib_logging
 from unittest.mock import patch
 
+import pytest
 import structlog.testing
+
+pytestmark = [pytest.mark.layer("cli")]
 
 
 class TestServeLoggingPhases:

--- a/tests/cli/test_cook.py
+++ b/tests/cli/test_cook.py
@@ -16,6 +16,8 @@ from autoskillit.cli._prompts import _OPEN_KITCHEN_CHOICE, _resolve_recipe_input
 from autoskillit.cli._workspace import _format_age
 from autoskillit.core import ClaudeFlags
 
+pytestmark = [pytest.mark.layer("cli")]
+
 _SCRIPT_YAML = """\
 name: test-script
 description: A test script

--- a/tests/cli/test_cook_env_scrub.py
+++ b/tests/cli/test_cook_env_scrub.py
@@ -15,6 +15,8 @@ import pytest
 
 from autoskillit.execution import _MAX_MCP_OUTPUT_TOKENS_VALUE
 
+pytestmark = [pytest.mark.layer("cli")]
+
 
 def test_launch_cook_session_env_excludes_ide_vars(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path

--- a/tests/cli/test_cook_ide_isolation.py
+++ b/tests/cli/test_cook_ide_isolation.py
@@ -19,6 +19,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+pytestmark = [pytest.mark.layer("cli")]
+
 
 def test_cook_session_ignores_ide_lock_file(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path

--- a/tests/cli/test_cook_interactive.py
+++ b/tests/cli/test_cook_interactive.py
@@ -11,6 +11,8 @@ import pytest
 from autoskillit import cli
 from autoskillit.workspace.session_skills import DefaultSessionSkillManager
 
+pytestmark = [pytest.mark.layer("cli")]
+
 
 class TestCookInteractive:
     @pytest.fixture(autouse=True)

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -11,6 +11,8 @@ import pytest
 
 from autoskillit import cli
 
+pytestmark = [pytest.mark.layer("cli")]
+
 _MINIMAL_SCRIPT_YAML = """\
 name: my-script
 description: A test script

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -12,6 +12,8 @@ import yaml
 from autoskillit import cli
 from autoskillit.cli import _generate_config_yaml
 
+pytestmark = [pytest.mark.layer("cli")]
+
 
 class TestCLIInit:
     @pytest.fixture(autouse=True)

--- a/tests/cli/test_input_tty_contracts.py
+++ b/tests/cli/test_input_tty_contracts.py
@@ -11,6 +11,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = [pytest.mark.layer("cli")]
+
 # Files that are *allowed* to contain raw input() calls.
 # _timed_input.py is the sole module that wraps input() with timeout/TTY/ANSI.
 _RAW_INPUT_EXEMPT_FILES: frozenset[str] = frozenset(

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -13,6 +13,8 @@ import pytest
 
 from autoskillit import cli
 
+pytestmark = [pytest.mark.layer("cli")]
+
 
 class TestCLIInstall:
     def test_install_validates_scope(self, capsys: pytest.CaptureFixture) -> None:

--- a/tests/cli/test_install_info.py
+++ b/tests/cli/test_install_info.py
@@ -19,6 +19,8 @@ from autoskillit.cli._install_info import (
     upgrade_command,
 )
 
+pytestmark = [pytest.mark.layer("cli")]
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_installed_plugins_file.py
+++ b/tests/cli/test_installed_plugins_file.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from autoskillit.cli._installed_plugins import InstalledPluginsFile
+
+pytestmark = [pytest.mark.layer("cli")]
 
 REAL_STRUCTURE = {
     "version": 2,

--- a/tests/cli/test_interactive_subprocess_contracts.py
+++ b/tests/cli/test_interactive_subprocess_contracts.py
@@ -10,6 +10,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = [pytest.mark.layer("cli")]
+
 CLI_DIR = Path(__file__).parent.parent.parent / "src" / "autoskillit" / "cli"
 
 # Files that contain no subprocess.run calls — skip for clarity

--- a/tests/cli/test_mcp_names.py
+++ b/tests/cli/test_mcp_names.py
@@ -13,6 +13,8 @@ from autoskillit.cli._mcp_names import (
     detect_autoskillit_mcp_prefix,
 )
 
+pytestmark = [pytest.mark.layer("cli")]
+
 _PLUGIN_KEY = "autoskillit@autoskillit-local"
 
 

--- a/tests/cli/test_onboarding.py
+++ b/tests/cli/test_onboarding.py
@@ -15,6 +15,8 @@ from autoskillit.cli._onboarding import (
     run_onboarding_menu,
 )
 
+pytestmark = [pytest.mark.layer("cli")]
+
 
 def _make_initialized_project(base: Path) -> Path:
     """Create a minimal initialized project dir (config.yaml present)."""

--- a/tests/cli/test_orchestrator_prompt_contract.py
+++ b/tests/cli/test_orchestrator_prompt_contract.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 import re
 
+import pytest
+
+pytestmark = [pytest.mark.layer("cli")]
+
 
 def _get_prompt() -> str:
     """Return the orchestrator prompt for a demo recipe."""

--- a/tests/cli/test_serve_sigterm.py
+++ b/tests/cli/test_serve_sigterm.py
@@ -15,6 +15,10 @@ from __future__ import annotations
 import inspect
 from unittest.mock import MagicMock
 
+import pytest
+
+pytestmark = [pytest.mark.layer("cli")]
+
 
 def test_serve_uses_anyio_run_not_mcp_run(monkeypatch, tmp_path):
     """serve() routes through anyio.run(), not mcp.run() directly."""

--- a/tests/cli/test_startup_budget.py
+++ b/tests/cli/test_startup_budget.py
@@ -10,9 +10,12 @@ from __future__ import annotations
 import time
 from unittest.mock import patch
 
+import pytest
 import structlog.testing
 
 from autoskillit.server import _state
+
+pytestmark = [pytest.mark.layer("cli")]
 
 
 def test_serve_calls_mcp_run_within_budget(monkeypatch, tmp_path):

--- a/tests/cli/test_subprocess_env_contracts.py
+++ b/tests/cli/test_subprocess_env_contracts.py
@@ -27,6 +27,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = [pytest.mark.layer("cli")]
+
 CLI_ROOT = Path(__file__).parents[2] / "src" / "autoskillit" / "cli"
 SRC_ROOT = Path(__file__).parents[2] / "src" / "autoskillit"
 REQUIRED_GUARD = "AUTOSKILLIT_SKIP_STALE_CHECK"

--- a/tests/cli/test_terminal.py
+++ b/tests/cli/test_terminal.py
@@ -14,6 +14,8 @@ import pytest
 
 from autoskillit.cli._terminal import _RESET_SPEC
 
+pytestmark = [pytest.mark.layer("cli")]
+
 
 class TestTerminalGuardTTYRestore:
     """terminal_guard() saves and restores termios attrs in all exit paths."""

--- a/tests/cli/test_update_checks.py
+++ b/tests/cli/test_update_checks.py
@@ -25,6 +25,8 @@ from autoskillit.cli._update_checks import (
     run_update_checks,
 )
 
+pytestmark = [pytest.mark.layer("cli")]
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_update_command.py
+++ b/tests/cli/test_update_command.py
@@ -8,6 +8,8 @@ import pytest
 
 from autoskillit.cli._install_info import InstallInfo, InstallType
 
+pytestmark = [pytest.mark.layer("cli")]
+
 
 def _make_info(
     install_type: InstallType,

--- a/tests/cli/test_workspace.py
+++ b/tests/cli/test_workspace.py
@@ -11,6 +11,8 @@ import pytest
 from autoskillit.cli._workspace import _format_age, run_workspace_clean
 from autoskillit.workspace import CleanupResult
 
+pytestmark = [pytest.mark.layer("cli")]
+
 
 class TestFormatAge:
     def test_format_age_under_one_hour_returns_minutes(self) -> None:

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -8,6 +8,8 @@ import yaml
 
 from autoskillit.config import AutomationConfig, ConfigSchemaError, RunSkillConfig, load_config
 
+pytestmark = [pytest.mark.layer("config")]
+
 
 class TestDefaultConfig:
     def test_default_config_matches_current_constants(self):

--- a/tests/config/test_defaults.py
+++ b/tests/config/test_defaults.py
@@ -11,6 +11,8 @@ import pytest
 from autoskillit.config import AutomationConfig
 from autoskillit.config.settings import RunSkillConfig
 
+pytestmark = [pytest.mark.layer("config")]
+
 
 class TestGraceWindowCoherence:
     """natural_exit_grace_seconds must cover exit_after_stop_delay_ms + margin."""

--- a/tests/config/test_helpers.py
+++ b/tests/config/test_helpers.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 import subprocess
 
+import pytest
+
+pytestmark = [pytest.mark.layer("config")]
+
 
 def test_resolve_ingredient_defaults_uses_upstream_when_origin_is_file_url(tmp_path):
     """resolve_ingredient_defaults must return the upstream URL when origin is file://."""

--- a/tests/config/test_settings_allowed_labels.py
+++ b/tests/config/test_settings_allowed_labels.py
@@ -1,7 +1,11 @@
 """Tests for GitHubConfig.allowed_labels field and check_label_allowed validation."""
 
+import pytest
+
 from autoskillit.config import AutomationConfig
 from autoskillit.config.settings import GitHubConfig, _make_dynaconf
+
+pytestmark = [pytest.mark.layer("config")]
 
 
 class TestGitHubConfigAllowedLabelsField:

--- a/tests/config/test_settings_staged_label.py
+++ b/tests/config/test_settings_staged_label.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import pytest
+
 from autoskillit.config import AutomationConfig
 from autoskillit.config.settings import GitHubConfig, _make_dynaconf
+
+pytestmark = [pytest.mark.layer("config")]
 
 
 class TestGitHubConfigStagedLabel:

--- a/tests/config/test_workspace_temp_dir_config.py
+++ b/tests/config/test_workspace_temp_dir_config.py
@@ -8,6 +8,8 @@ import pytest
 
 from autoskillit.config import WorkspaceConfig, load_config
 
+pytestmark = [pytest.mark.layer("config")]
+
 
 def test_workspace_config_has_temp_dir_field() -> None:
     assert WorkspaceConfig().temp_dir is None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -327,6 +327,27 @@ def pytest_collection_modifyitems(
     """
     import warnings
 
+    # Layer marker mismatch validation (controller-only under xdist)
+    if not hasattr(config, "workerinput"):
+        tests_root = config.rootpath / "tests"
+        for item in items:
+            try:
+                rel = item.path.relative_to(tests_root)
+            except (ValueError, TypeError):
+                continue
+            parts = rel.parts
+            if not parts or parts[0] not in _LAYER_DIRS:
+                continue
+            expected_dir = parts[0]
+
+            for mark in item.iter_markers("layer"):
+                if mark.args and mark.args[0] != expected_dir:
+                    warnings.warn(
+                        f"Layer marker mismatch: {item.nodeid} has layer('{mark.args[0]}') "
+                        f"but lives in tests/{expected_dir}/",
+                        stacklevel=1,
+                    )
+
     scope: set[_Path] | None = config.stash.get(_scope_key, None)
     if scope is None:
         return
@@ -374,26 +395,3 @@ def pytest_collection_modifyitems(
             f"Test filter deselection failed, running all tests: {exc}",
             stacklevel=1,
         )
-
-    # Layer marker mismatch validation (controller-only under xdist)
-    if hasattr(config, "workerinput"):
-        return
-
-    tests_root = config.rootpath / "tests"
-    for item in items:
-        try:
-            rel = item.path.relative_to(tests_root)
-        except (ValueError, TypeError):
-            continue
-        parts = rel.parts
-        if not parts or parts[0] not in _LAYER_DIRS:
-            continue
-        expected_dir = parts[0]
-
-        for mark in item.iter_markers("layer"):
-            if mark.args and mark.args[0] != expected_dir:
-                warnings.warn(
-                    f"Layer marker mismatch: {item.nodeid} has layer('{mark.args[0]}') "
-                    f"but lives in tests/{expected_dir}/",
-                    stacklevel=1,
-                )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,20 @@ from autoskillit.core.types import (
 from tests._helpers import _flush_structlog_proxy_caches
 from tests.fakes import MockSubprocessRunner
 
+_LAYER_DIRS: frozenset[str] = frozenset(
+    {
+        "core",
+        "config",
+        "pipeline",
+        "execution",
+        "workspace",
+        "recipe",
+        "migration",
+        "server",
+        "cli",
+    }
+)
+
 _scope_key = pytest.StashKey[set[_Path] | None]()
 
 
@@ -360,3 +374,26 @@ def pytest_collection_modifyitems(
             f"Test filter deselection failed, running all tests: {exc}",
             stacklevel=1,
         )
+
+    # Layer marker mismatch validation (controller-only under xdist)
+    if hasattr(config, "workerinput"):
+        return
+
+    tests_root = config.rootpath / "tests"
+    for item in items:
+        try:
+            rel = item.path.relative_to(tests_root)
+        except (ValueError, TypeError):
+            continue
+        parts = rel.parts
+        if not parts or parts[0] not in _LAYER_DIRS:
+            continue
+        expected_dir = parts[0]
+
+        for mark in item.iter_markers("layer"):
+            if mark.args and mark.args[0] != expected_dir:
+                warnings.warn(
+                    f"Layer marker mismatch: {item.nodeid} has layer('{mark.args[0]}') "
+                    f"but lives in tests/{expected_dir}/",
+                    stacklevel=1,
+                )

--- a/tests/core/test_add_dir_validation.py
+++ b/tests/core/test_add_dir_validation.py
@@ -10,6 +10,8 @@ import pytest
 from autoskillit.core import ValidatedAddDir
 from autoskillit.core.claude_conventions import LayoutError, validate_add_dir
 
+pytestmark = [pytest.mark.layer("core")]
+
 
 class TestValidatedAddDir:
     """ValidatedAddDir is an opaque wrapper with str/fspath support."""

--- a/tests/core/test_branch_guard.py
+++ b/tests/core/test_branch_guard.py
@@ -4,6 +4,8 @@ import pytest
 
 from autoskillit.core.branch_guard import is_protected_branch
 
+pytestmark = [pytest.mark.layer("core")]
+
 _DEFAULTS = ["main", "integration", "stable"]
 
 # ---------- standard protected list ----------

--- a/tests/core/test_claude_env.py
+++ b/tests/core/test_claude_env.py
@@ -13,6 +13,8 @@ from autoskillit.core._claude_env import (
     IDE_ENV_PREFIX_DENYLIST,
 )
 
+pytestmark = [pytest.mark.layer("core")]
+
 
 def test_build_claude_env_strips_sse_port() -> None:
     base = {"CLAUDE_CODE_SSE_PORT": "23270", "HOME": "/tmp", "PATH": "/usr/bin"}

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import pytest
+
+pytestmark = [pytest.mark.layer("core")]
+
 
 def test_atomic_write_docstring_contains_atomic_keyword():
     import autoskillit.core.io as m

--- a/tests/core/test_core_terminal_table.py
+++ b/tests/core/test_core_terminal_table.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import pytest
+
+pytestmark = [pytest.mark.layer("core")]
+
 
 def test_compute_col_widths_is_module_level() -> None:
     """_compute_col_widths must be importable as a module-level function.

--- a/tests/core/test_ensure_project_temp_with_config.py
+++ b/tests/core/test_ensure_project_temp_with_config.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from autoskillit.core.io import ensure_project_temp
+
+pytestmark = [pytest.mark.layer("core")]
 
 
 def test_ensure_project_temp_default_writes_self_gitignore(tmp_path: Path) -> None:

--- a/tests/core/test_github_url.py
+++ b/tests/core/test_github_url.py
@@ -6,6 +6,8 @@ import pytest
 
 from autoskillit.core import parse_github_repo
 
+pytestmark = [pytest.mark.layer("core")]
+
 
 @pytest.mark.parametrize(
     "url,expected",

--- a/tests/core/test_io.py
+++ b/tests/core/test_io.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import pytest
 
+pytestmark = [pytest.mark.layer("core")]
+
 
 class TestLoadYamlExtended:
     def test_accepts_path(self, tmp_path):

--- a/tests/core/test_logging.py
+++ b/tests/core/test_logging.py
@@ -11,6 +11,8 @@ import structlog
 
 from tests._helpers import _flush_structlog_proxy_caches as _flush_logger_proxy_caches
 
+pytestmark = [pytest.mark.layer("core")]
+
 
 class TestGetLogger:
     def test_returns_bound_logger(self):

--- a/tests/core/test_paths.py
+++ b/tests/core/test_paths.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 import importlib.resources as ir
 from pathlib import Path
 
+import pytest
+
+pytestmark = [pytest.mark.layer("core")]
+
 
 class TestWorktreeDetection:
     def test_detects_main_checkout_as_not_worktree(self, tmp_path: Path) -> None:

--- a/tests/core/test_resolve_temp_dir.py
+++ b/tests/core/test_resolve_temp_dir.py
@@ -9,6 +9,8 @@ import pytest
 
 from autoskillit.core.io import resolve_temp_dir
 
+pytestmark = [pytest.mark.layer("core")]
+
 
 def test_resolve_temp_dir_default_returns_project_relative() -> None:
     assert resolve_temp_dir(Path("/proj"), None) == Path("/proj/.autoskillit/temp")

--- a/tests/core/test_skill_command_parsing.py
+++ b/tests/core/test_skill_command_parsing.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import pytest
+
 from autoskillit.core._type_helpers import _PATH_PREFIXES, extract_path_arg
+
+pytestmark = [pytest.mark.layer("core")]
 
 
 class TestExtractPathArg:

--- a/tests/core/test_type_constants.py
+++ b/tests/core/test_type_constants.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import pytest
+
+pytestmark = [pytest.mark.layer("core")]
+
 
 # REQ-PACK-001: PACK_REGISTRY defines all packs with default_enabled
 def test_pack_registry_contains_all_packs() -> None:

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -16,6 +16,8 @@ from autoskillit.core.types import (
     SkillResult,
 )
 
+pytestmark = [pytest.mark.layer("core")]
+
 
 def test_retry_reason_values():
     """RetryReason enum has exactly the expected members."""

--- a/tests/core/test_types_structure.py
+++ b/tests/core/test_types_structure.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import pytest
+
+pytestmark = [pytest.mark.layer("core")]
+
 
 def test_enums_importable_from_sub_module():
     from autoskillit.core._type_enums import (

--- a/tests/execution/test_anomaly_detection.py
+++ b/tests/execution/test_anomaly_detection.py
@@ -11,6 +11,8 @@ from autoskillit.execution.anomaly_detection import (
     detect_anomalies,
 )
 
+pytestmark = [pytest.mark.layer("execution")]
+
 
 def _snap(
     *,

--- a/tests/execution/test_check_repo_merge_state.py
+++ b/tests/execution/test_check_repo_merge_state.py
@@ -11,6 +11,8 @@ import pytest
 
 from autoskillit.execution.merge_queue import fetch_repo_merge_state
 
+pytestmark = [pytest.mark.layer("execution")]
+
 # Reminder: fetch_repo_merge_state now returns ci_event in addition to the
 # three boolean fields. Tests below check for the ci_event field explicitly.
 

--- a/tests/execution/test_ci.py
+++ b/tests/execution/test_ci.py
@@ -13,6 +13,8 @@ from autoskillit.execution.ci import (
     _jittered_sleep,
 )
 
+pytestmark = [pytest.mark.layer("execution")]
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/execution/test_ci_params.py
+++ b/tests/execution/test_ci_params.py
@@ -15,6 +15,8 @@ import pytest
 from autoskillit.core import CIRunScope
 from autoskillit.execution.ci import DefaultCIWatcher, _validate_run_matches_scope
 
+pytestmark = [pytest.mark.layer("execution")]
+
 
 def _now() -> str:
     return datetime.now(UTC).isoformat()

--- a/tests/execution/test_clone_guard.py
+++ b/tests/execution/test_clone_guard.py
@@ -24,6 +24,8 @@ from autoskillit.execution.headless import _build_skill_result
 from autoskillit.pipeline.audit import DefaultAuditLog
 from tests.fakes import MockSubprocessRunner
 
+pytestmark = [pytest.mark.layer("execution")]
+
 
 def _git_result(stdout: str = "", returncode: int = 0) -> SubprocessResult:
     """Build a minimal SubprocessResult simulating a git command."""

--- a/tests/execution/test_commands.py
+++ b/tests/execution/test_commands.py
@@ -17,6 +17,8 @@ from autoskillit.execution.commands import (
     build_interactive_cmd,
 )
 
+pytestmark = [pytest.mark.layer("execution")]
+
 
 class TestBuildInteractiveCmd:
     def test_returns_correct_type(self) -> None:

--- a/tests/execution/test_db.py
+++ b/tests/execution/test_db.py
@@ -15,6 +15,8 @@ from autoskillit.execution.db import (
     _validate_select_only,
 )
 
+pytestmark = [pytest.mark.layer("execution")]
+
 
 class TestValidateSelectOnly:
     """SQL validation: pure function _validate_select_only."""

--- a/tests/execution/test_diff_annotator.py
+++ b/tests/execution/test_diff_annotator.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import pytest
+
 from autoskillit.execution.diff_annotator import (
     annotate_diff,
     filter_findings,
     parse_hunk_ranges,
 )
+
+pytestmark = [pytest.mark.layer("execution")]
 
 # --- parse_hunk_ranges ---
 

--- a/tests/execution/test_flag_contracts.py
+++ b/tests/execution/test_flag_contracts.py
@@ -7,11 +7,15 @@ If the claude CLI renames a flag, update the constant value here — one change,
 one place, and all tests catch the ripple.
 """
 
+import pytest
+
 from autoskillit.core import ClaudeFlags
 from autoskillit.execution.commands import (
     build_headless_cmd,
     build_interactive_cmd,
 )
+
+pytestmark = [pytest.mark.layer("execution")]
 
 # ---------------------------------------------------------------------------
 # Part 1: Constant value contracts — each assertion is the ground truth.

--- a/tests/execution/test_github.py
+++ b/tests/execution/test_github.py
@@ -12,6 +12,8 @@ from autoskillit.execution.github import (
     parse_merge_queue_response,
 )
 
+pytestmark = [pytest.mark.layer("execution")]
+
 # ---------------------------------------------------------------------------
 # _parse_issue_ref unit tests
 # ---------------------------------------------------------------------------

--- a/tests/execution/test_github_headers.py
+++ b/tests/execution/test_github_headers.py
@@ -11,6 +11,8 @@ import pytest
 from autoskillit.execution.github import github_headers
 from autoskillit.execution.merge_queue import DefaultMergeQueueWatcher
 
+pytestmark = [pytest.mark.layer("execution")]
+
 # ---------------------------------------------------------------------------
 # github_headers — unit tests
 # ---------------------------------------------------------------------------

--- a/tests/execution/test_headless.py
+++ b/tests/execution/test_headless.py
@@ -23,6 +23,8 @@ from autoskillit.execution.headless import (
 )
 from tests.conftest import _make_result, _make_timeout_result
 
+pytestmark = [pytest.mark.layer("execution")]
+
 
 def test_inject_completion_directive_appends_marker():
     from autoskillit.execution.commands import _inject_completion_directive
@@ -3509,8 +3511,6 @@ class TestSynthesizeFromWriteArtifacts:
 # ---------------------------------------------------------------------------
 
 from autoskillit.pipeline.audit import DefaultAuditLog, FailureRecord  # noqa: E402
-
-pytestmark = [pytest.mark.layer("execution")]
 
 
 @pytest.fixture

--- a/tests/execution/test_headless.py
+++ b/tests/execution/test_headless.py
@@ -3510,6 +3510,8 @@ class TestSynthesizeFromWriteArtifacts:
 
 from autoskillit.pipeline.audit import DefaultAuditLog, FailureRecord  # noqa: E402
 
+pytestmark = [pytest.mark.layer("execution")]
+
 
 @pytest.fixture
 def make_build_skill_result_kwargs():

--- a/tests/execution/test_headless_add_dirs.py
+++ b/tests/execution/test_headless_add_dirs.py
@@ -6,6 +6,8 @@ import pytest
 
 from autoskillit.core import ValidatedAddDir
 
+pytestmark = [pytest.mark.layer("execution")]
+
 
 @pytest.mark.anyio
 async def test_run_headless_core_no_add_dir_when_empty(minimal_ctx, tmp_path):

--- a/tests/execution/test_headless_debug_logging.py
+++ b/tests/execution/test_headless_debug_logging.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import json
 
+import pytest
 import structlog.testing
 
 from autoskillit.core.types import SubprocessResult, TerminationReason
+
+pytestmark = [pytest.mark.layer("execution")]
 
 
 def _sr(returncode=0, stdout="", stderr="", termination=TerminationReason.NATURAL_EXIT):

--- a/tests/execution/test_headless_env_injection.py
+++ b/tests/execution/test_headless_env_injection.py
@@ -10,6 +10,8 @@ import pytest
 from autoskillit.core.types import SubprocessResult, TerminationReason
 from tests.fakes import MockSubprocessRunner
 
+pytestmark = [pytest.mark.layer("execution")]
+
 
 @pytest.mark.anyio
 async def test_headless_command_includes_headless_env_var(minimal_ctx, tmp_path: Path) -> None:

--- a/tests/execution/test_headless_env_scrub.py
+++ b/tests/execution/test_headless_env_scrub.py
@@ -13,6 +13,8 @@ import pytest
 
 from tests.conftest import _make_result
 
+pytestmark = [pytest.mark.layer("execution")]
+
 
 @pytest.mark.anyio
 async def test_run_headless_core_env_excludes_ide_vars(

--- a/tests/execution/test_linux_tracing.py
+++ b/tests/execution/test_linux_tracing.py
@@ -10,10 +10,13 @@ from datetime import datetime
 import anyio
 import pytest
 
-pytestmark = pytest.mark.skipif(
-    sys.platform != "linux",
-    reason="Linux-only tracing tests",
-)
+pytestmark = [
+    pytest.mark.layer("execution"),
+    pytest.mark.skipif(
+        sys.platform != "linux",
+        reason="Linux-only tracing tests",
+    ),
+]
 
 PROC_STATUS_FIXTURE = """\
 Name:\tclaude

--- a/tests/execution/test_linux_tracing_pty_integration.py
+++ b/tests/execution/test_linux_tracing_pty_integration.py
@@ -19,10 +19,13 @@ import pytest
 
 from tests.execution.conftest import _ALLOCATE_60MB_SCRIPT
 
-pytestmark = pytest.mark.skipif(
-    sys.platform != "linux",
-    reason="Linux only — tests PTY wrapping + /proc tracing",
-)
+pytestmark = [
+    pytest.mark.layer("execution"),
+    pytest.mark.skipif(
+        sys.platform != "linux",
+        reason="Linux only — tests PTY wrapping + /proc tracing",
+    ),
+]
 
 # Skip the entire module when script(1) is absent; no stub needed.
 pytestmark_script = pytest.mark.skipif(

--- a/tests/execution/test_merge_queue.py
+++ b/tests/execution/test_merge_queue.py
@@ -16,6 +16,8 @@ from autoskillit.execution.merge_queue import (
     PRFetchState,
 )
 
+pytestmark = [pytest.mark.layer("execution")]
+
 
 def _make_watcher() -> DefaultMergeQueueWatcher:
     return DefaultMergeQueueWatcher(token=None)

--- a/tests/execution/test_normalize_subtype.py
+++ b/tests/execution/test_normalize_subtype.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import pytest
+
 from autoskillit.core.types import (
     SessionOutcome,
 )
 from autoskillit.execution.session import ClaudeSessionResult, _normalize_subtype
+
+pytestmark = [pytest.mark.layer("execution")]
 
 
 def _session(

--- a/tests/execution/test_output_format_contract.py
+++ b/tests/execution/test_output_format_contract.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from autoskillit.core.types import (
     ChannelConfirmation,
     OutputFormat,
@@ -25,6 +27,8 @@ from autoskillit.execution.session import (
     _compute_success,
     parse_session_result,
 )
+
+pytestmark = [pytest.mark.layer("execution")]
 
 
 class TestOutputFormatDataContract:

--- a/tests/execution/test_pr_analysis.py
+++ b/tests/execution/test_pr_analysis.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import pytest
+
 from autoskillit.execution.pr_analysis import (
     DOMAIN_PATHS,
     extract_linked_issues,
     is_valid_fidelity_finding,
     partition_files_by_domain,
 )
+
+pytestmark = [pytest.mark.layer("execution")]
 
 # ---------------------------------------------------------------------------
 # extract_linked_issues

--- a/tests/execution/test_process_channel_b.py
+++ b/tests/execution/test_process_channel_b.py
@@ -11,6 +11,8 @@ from autoskillit.core.types import ChannelConfirmation, SubprocessResult, Termin
 from autoskillit.execution.process import run_managed_async
 from tests.execution.conftest import WRITE_RESULT_THEN_HANG_SCRIPT
 
+pytestmark = [pytest.mark.layer("execution")]
+
 # Script that:
 #   (1) writes %%ORDER_UP%% to a JSONL session file (Channel B fires)
 #   (2) writes type=result to stdout after a delay (Channel A confirms within drain window)

--- a/tests/execution/test_process_debug_logging.py
+++ b/tests/execution/test_process_debug_logging.py
@@ -10,6 +10,8 @@ import structlog.testing
 from autoskillit.core.types import TerminationReason
 from autoskillit.execution.process import RaceAccumulator, RaceSignals
 
+pytestmark = [pytest.mark.layer("execution")]
+
 
 @pytest.mark.anyio
 async def test_run_managed_async_logs_entry(tmp_path):

--- a/tests/execution/test_process_idle_watchdog.py
+++ b/tests/execution/test_process_idle_watchdog.py
@@ -14,6 +14,8 @@ from autoskillit.execution._process_race import (
     _watch_stdout_idle,
 )
 
+pytestmark = [pytest.mark.layer("execution")]
+
 WRITE_BURST_THEN_STALL_SCRIPT = textwrap.dedent("""\
     import sys, time, json
     for i in range(3):

--- a/tests/execution/test_process_jsonl.py
+++ b/tests/execution/test_process_jsonl.py
@@ -9,12 +9,16 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from autoskillit.execution.process import (
     _jsonl_contains_marker,
     _jsonl_has_record_type,
     _jsonl_last_record_type,
     _marker_is_standalone,
 )
+
+pytestmark = [pytest.mark.layer("execution")]
 
 
 class TestJsonlContainsMarker:

--- a/tests/execution/test_process_kill.py
+++ b/tests/execution/test_process_kill.py
@@ -24,6 +24,8 @@ from autoskillit.execution.process import (
     run_managed_async,
 )
 
+pytestmark = [pytest.mark.layer("execution")]
+
 # ---------------------------------------------------------------------------
 # Helper scripts — small Python programs that reproduce specific scenarios
 # ---------------------------------------------------------------------------

--- a/tests/execution/test_process_monitor.py
+++ b/tests/execution/test_process_monitor.py
@@ -22,6 +22,8 @@ from autoskillit.execution.process import (
 )
 from tests.execution.conftest import WRITE_RESULT_THEN_HANG_SCRIPT
 
+pytestmark = [pytest.mark.layer("execution")]
+
 # Script that writes non-matching output then hangs
 PARTIAL_OUTPUT_THEN_HANG_SCRIPT = (
     "import sys, time\n"

--- a/tests/execution/test_process_pty.py
+++ b/tests/execution/test_process_pty.py
@@ -30,6 +30,8 @@ from autoskillit.execution.process import (
 )
 from autoskillit.execution.session import ClaudeSessionResult
 
+pytestmark = [pytest.mark.layer("execution")]
+
 # ---------------------------------------------------------------------------
 # Helper scripts — small Python programs that reproduce specific scenarios
 # ---------------------------------------------------------------------------

--- a/tests/execution/test_process_race.py
+++ b/tests/execution/test_process_race.py
@@ -17,6 +17,8 @@ from autoskillit.execution._process_race import (
     resolve_termination,
 )
 
+pytestmark = [pytest.mark.layer("execution")]
+
 
 class TestChannelBStatusExhaustiveCoverage:
     """Every ChannelBStatus member maps to a defined termination pair."""

--- a/tests/execution/test_process_run.py
+++ b/tests/execution/test_process_run.py
@@ -26,6 +26,8 @@ from autoskillit.execution.process import (
     run_managed_sync,
 )
 
+pytestmark = [pytest.mark.layer("execution")]
+
 # ---------------------------------------------------------------------------
 # Helper scripts — small Python programs that reproduce specific scenarios
 # ---------------------------------------------------------------------------

--- a/tests/execution/test_process_submodules.py
+++ b/tests/execution/test_process_submodules.py
@@ -6,6 +6,10 @@ process.py remains a re-export facade for all public symbols.
 
 from __future__ import annotations
 
+import pytest
+
+pytestmark = [pytest.mark.layer("execution")]
+
 
 def test_process_kill_exports():
     """_process_kill.py exports kill/async_kill functions."""

--- a/tests/execution/test_quota.py
+++ b/tests/execution/test_quota.py
@@ -11,6 +11,8 @@ import pytest
 
 from tests._helpers import make_quota_guard_config
 
+pytestmark = [pytest.mark.layer("execution")]
+
 
 class TestReadCredentials:
     def test_reads_access_token(self, tmp_path):

--- a/tests/execution/test_quota_http.py
+++ b/tests/execution/test_quota_http.py
@@ -16,7 +16,10 @@ from api_simulator.http import MockResponseSpec as PyResponseSpec
 
 from autoskillit.execution.quota import check_and_sleep_if_needed
 
-pytestmark = pytest.mark.anyio
+pytestmark = [
+    pytest.mark.layer("execution"),
+    pytest.mark.anyio,
+]
 
 QUOTA_ENDPOINT = "/api/oauth/usage"
 

--- a/tests/execution/test_readiness_helper_contract.py
+++ b/tests/execution/test_readiness_helper_contract.py
@@ -21,6 +21,10 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
+import pytest
+
+pytestmark = [pytest.mark.layer("execution")]
+
 _TESTS_ROOT = Path(__file__).parent.parent
 
 

--- a/tests/execution/test_recording.py
+++ b/tests/execution/test_recording.py
@@ -20,6 +20,8 @@ from autoskillit.execution.recording import (
 from tests.conftest import _make_result
 from tests.fakes import MockSubprocessRunner
 
+pytestmark = [pytest.mark.layer("execution")]
+
 
 @dataclass
 class FakeStepResult:

--- a/tests/execution/test_recording_sigterm.py
+++ b/tests/execution/test_recording_sigterm.py
@@ -18,6 +18,8 @@ import pytest
 from autoskillit.core.readiness import readiness_sentinel_path
 from tests._subprocess_ready import wait_for_subprocess_ready
 
+pytestmark = [pytest.mark.layer("execution")]
+
 
 @pytest.mark.integration
 def test_sigterm_writes_scenario_json(tmp_path):

--- a/tests/execution/test_recording_sigterm_early_term.py
+++ b/tests/execution/test_recording_sigterm_early_term.py
@@ -24,6 +24,8 @@ import sys
 
 import pytest
 
+pytestmark = [pytest.mark.layer("execution")]
+
 
 @pytest.mark.integration
 def test_sigterm_during_startup_no_hang(tmp_path):

--- a/tests/execution/test_remote_resolver.py
+++ b/tests/execution/test_remote_resolver.py
@@ -9,6 +9,8 @@ import pytest
 
 from autoskillit.execution import resolve_remote_repo
 
+pytestmark = [pytest.mark.layer("execution")]
+
 # ---------------------------------------------------------------------------
 # Hint-path tests (no subprocess calls)
 # ---------------------------------------------------------------------------

--- a/tests/execution/test_session.py
+++ b/tests/execution/test_session.py
@@ -22,6 +22,8 @@ from autoskillit.execution.session import (
 )
 from tests._helpers import _flush_structlog_proxy_caches as _flush_logger_proxy_caches
 
+pytestmark = [pytest.mark.layer("execution")]
+
 
 def _make_session_result(
     returncode: int = 0,

--- a/tests/execution/test_session_adjudication.py
+++ b/tests/execution/test_session_adjudication.py
@@ -1672,6 +1672,8 @@ class TestDeadEndGuardContentState:
 
 import json  # noqa: E402 — imported here to keep T1 tests self-contained
 
+pytestmark = [pytest.mark.layer("execution")]
+
 
 @pytest.fixture
 def make_ndjson():

--- a/tests/execution/test_session_adjudication.py
+++ b/tests/execution/test_session_adjudication.py
@@ -25,6 +25,8 @@ from autoskillit.execution.session import (
     parse_session_result,
 )
 
+pytestmark = [pytest.mark.layer("execution")]
+
 
 def _make_success_session(result: str = "done") -> ClaudeSessionResult:
     return ClaudeSessionResult(
@@ -1671,8 +1673,6 @@ class TestDeadEndGuardContentState:
 # ---------------------------------------------------------------------------
 
 import json  # noqa: E402 — imported here to keep T1 tests self-contained
-
-pytestmark = [pytest.mark.layer("execution")]
 
 
 @pytest.fixture

--- a/tests/execution/test_session_debug_logging.py
+++ b/tests/execution/test_session_debug_logging.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pytest
 import structlog.testing
 
 from autoskillit.core.types import ChannelConfirmation, TerminationReason
@@ -12,6 +13,8 @@ from autoskillit.execution.session import (
     _compute_retry,
     _compute_success,
 )
+
+pytestmark = [pytest.mark.layer("execution")]
 
 
 class TestCheckSessionContentLogging:

--- a/tests/execution/test_session_log.py
+++ b/tests/execution/test_session_log.py
@@ -20,6 +20,8 @@ from autoskillit.execution.session_log import (
     write_telemetry_clear_marker,
 )
 
+pytestmark = [pytest.mark.layer("execution")]
+
 
 def _snap(
     *,

--- a/tests/execution/test_session_log_integration.py
+++ b/tests/execution/test_session_log_integration.py
@@ -13,7 +13,10 @@ import pytest
 
 from tests.execution.conftest import _ALLOCATE_60MB_SCRIPT
 
-pytestmark = pytest.mark.skipif(sys.platform != "linux", reason="Linux only")
+pytestmark = [
+    pytest.mark.layer("execution"),
+    pytest.mark.skipif(sys.platform != "linux", reason="Linux only"),
+]
 
 
 @pytest.mark.anyio

--- a/tests/execution/test_termination_action.py
+++ b/tests/execution/test_termination_action.py
@@ -12,6 +12,8 @@ import pytest
 from autoskillit.core.types import TerminationAction, TerminationReason
 from autoskillit.execution.process import decide_termination_action
 
+pytestmark = [pytest.mark.layer("execution")]
+
 
 @pytest.mark.parametrize(
     "termination,timeout_fired,process_exited,expected",

--- a/tests/execution/test_termination_executor.py
+++ b/tests/execution/test_termination_executor.py
@@ -17,6 +17,8 @@ import pytest
 from autoskillit.core.types import KillReason, TerminationAction
 from autoskillit.execution.process import execute_termination_action
 
+pytestmark = [pytest.mark.layer("execution")]
+
 # ---------------------------------------------------------------------------
 # Helper scripts
 # ---------------------------------------------------------------------------

--- a/tests/execution/test_testing.py
+++ b/tests/execution/test_testing.py
@@ -22,6 +22,8 @@ from autoskillit.execution.testing import (
 )
 from tests._helpers import make_test_check_config, make_test_config
 
+pytestmark = [pytest.mark.layer("execution")]
+
 
 def test_build_sanitized_env_strips_private_env_vars(monkeypatch):
     """build_sanitized_env() must strip every var in AUTOSKILLIT_PRIVATE_ENV_VARS."""

--- a/tests/execution/test_trace_target_resolver.py
+++ b/tests/execution/test_trace_target_resolver.py
@@ -13,10 +13,13 @@ import sys
 
 import pytest
 
-pytestmark = pytest.mark.skipif(
-    sys.platform != "linux",
-    reason="Linux only — tests /proc descendant walking",
-)
+pytestmark = [
+    pytest.mark.layer("execution"),
+    pytest.mark.skipif(
+        sys.platform != "linux",
+        reason="Linux only — tests /proc descendant walking",
+    ),
+]
 
 
 @pytest.mark.skipif(shutil.which("script") is None, reason="script(1) not available")

--- a/tests/execution/test_zero_write_detection.py
+++ b/tests/execution/test_zero_write_detection.py
@@ -9,9 +9,13 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from autoskillit.core import RetryReason, WriteBehaviorSpec, extract_skill_name
 from autoskillit.execution.headless import _build_skill_result
 from tests.conftest import _make_result
+
+pytestmark = [pytest.mark.layer("execution")]
 
 
 def _ndjson_with_tool_uses(tool_names: list[str]) -> str:

--- a/tests/migration/test_api.py
+++ b/tests/migration/test_api.py
@@ -10,6 +10,8 @@ import pytest
 from autoskillit.migration._api import check_and_migrate
 from autoskillit.migration.engine import MigrationResult
 
+pytestmark = [pytest.mark.layer("migration")]
+
 # ---------------------------------------------------------------------------
 # T6 — migration/_api.py recipe imports are deferred
 # ---------------------------------------------------------------------------

--- a/tests/migration/test_engine.py
+++ b/tests/migration/test_engine.py
@@ -24,6 +24,8 @@ from autoskillit.migration.engine import (
 )
 from autoskillit.migration.loader import MigrationChange, MigrationNote
 
+pytestmark = [pytest.mark.layer("migration")]
+
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 
 # ---------------------------------------------------------------------------

--- a/tests/migration/test_loader.py
+++ b/tests/migration/test_loader.py
@@ -13,6 +13,8 @@ from autoskillit.migration.loader import (
     list_migrations,
 )
 
+pytestmark = [pytest.mark.layer("migration")]
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/migration/test_store.py
+++ b/tests/migration/test_store.py
@@ -15,6 +15,8 @@ from autoskillit.migration.store import (
     record_from_skill,
 )
 
+pytestmark = [pytest.mark.layer("migration")]
+
 
 # ---------------------------------------------------------------------------
 # FS1: load() returns {} when failures.json absent

--- a/tests/pipeline/test_audit.py
+++ b/tests/pipeline/test_audit.py
@@ -5,11 +5,15 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from autoskillit.pipeline.audit import (
     DefaultAuditLog,
     FailureRecord,
     _validate_failure_record_dict,
 )
+
+pytestmark = [pytest.mark.layer("pipeline")]
 
 
 def _make_record(**overrides: object) -> FailureRecord:

--- a/tests/pipeline/test_background_supervisor.py
+++ b/tests/pipeline/test_background_supervisor.py
@@ -6,6 +6,8 @@ import pytest
 
 from autoskillit.pipeline.background import DefaultBackgroundSupervisor
 
+pytestmark = [pytest.mark.layer("pipeline")]
+
 
 @pytest.mark.anyio
 async def test_supervisor_captures_exception():

--- a/tests/pipeline/test_context.py
+++ b/tests/pipeline/test_context.py
@@ -15,6 +15,8 @@ from autoskillit.pipeline.gate import DefaultGateState
 from autoskillit.pipeline.timings import DefaultTimingLog
 from autoskillit.pipeline.tokens import DefaultTokenLog
 
+pytestmark = [pytest.mark.layer("pipeline")]
+
 
 def test_tool_context_fields_accessible(tmp_path):
     """ToolContext exposes all expected fields."""

--- a/tests/pipeline/test_gate.py
+++ b/tests/pipeline/test_gate.py
@@ -1,5 +1,9 @@
 # test_gate.py — unit tests for _gate.py constants and functions
 
+import pytest
+
+pytestmark = [pytest.mark.layer("pipeline")]
+
 
 def test_gated_tools_contains_expected_names():
     from autoskillit.pipeline.gate import GATED_TOOLS

--- a/tests/pipeline/test_mcp_response.py
+++ b/tests/pipeline/test_mcp_response.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import pytest
+
 from autoskillit.pipeline.mcp_response import DefaultMcpResponseLog, McpResponseEntry
+
+pytestmark = [pytest.mark.layer("pipeline")]
 
 
 class TestMcpResponseEntry:

--- a/tests/pipeline/test_pr_gates.py
+++ b/tests/pipeline/test_pr_gates.py
@@ -9,11 +9,15 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from autoskillit.pipeline.pr_gates import (
     is_ci_passing,
     is_review_passing,
     partition_prs,
 )
+
+pytestmark = [pytest.mark.layer("pipeline")]
 
 # ---------------------------------------------------------------------------
 # CI Gate

--- a/tests/pipeline/test_telemetry_formatter.py
+++ b/tests/pipeline/test_telemetry_formatter.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import pytest
+
 from autoskillit.pipeline.telemetry_fmt import TelemetryFormatter
+
+pytestmark = [pytest.mark.layer("pipeline")]
 
 # ---------------------------------------------------------------------------
 # Shared test data

--- a/tests/pipeline/test_timings.py
+++ b/tests/pipeline/test_timings.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = [pytest.mark.layer("pipeline")]
+
 
 class TestTimingEntry:
     def test_fields_exist(self):

--- a/tests/pipeline/test_tokens.py
+++ b/tests/pipeline/test_tokens.py
@@ -10,6 +10,8 @@ import pytest
 
 from autoskillit.pipeline.tokens import DefaultTokenLog, TokenEntry
 
+pytestmark = [pytest.mark.layer("pipeline")]
+
 
 def _make_usage(**overrides: int) -> dict[str, int]:
     defaults = {

--- a/tests/recipe/test__api.py
+++ b/tests/recipe/test__api.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import pytest
+
+pytestmark = [pytest.mark.layer("recipe")]
+
 # ---------------------------------------------------------------------------
 # T5 — _drop_sub_recipe_step uses dataclasses.replace
 # ---------------------------------------------------------------------------

--- a/tests/recipe/test_anti_pattern_guards.py
+++ b/tests/recipe/test_anti_pattern_guards.py
@@ -8,6 +8,8 @@ import yaml
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.recipe.rules_blocks import _block_budgets  # re-use the cached loader
 
+pytestmark = [pytest.mark.layer("recipe")]
+
 
 def _budget_for(block_name: str) -> dict:  # type: ignore[type-arg]
     """Return the budget dict for a named block, falling back to the DEFAULT entry."""

--- a/tests/recipe/test_api.py
+++ b/tests/recipe/test_api.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
+pytestmark = [pytest.mark.layer("recipe")]
+
 # Minimal recipe YAML with kitchen_rules
 _RECIPE_WITH_RULES = """\
 name: test-recipe-with-rules

--- a/tests/recipe/test_bundled_recipe_hidden_policy.py
+++ b/tests/recipe/test_bundled_recipe_hidden_policy.py
@@ -6,6 +6,8 @@ from autoskillit.core.paths import pkg_root
 from autoskillit.recipe.io import load_recipe
 from autoskillit.recipe.registry import run_semantic_rules
 
+pytestmark = [pytest.mark.layer("recipe")]
+
 BUNDLED_RECIPE_NAMES = [
     "implementation",
     "remediation",

--- a/tests/recipe/test_bundled_recipes.py
+++ b/tests/recipe/test_bundled_recipes.py
@@ -14,6 +14,8 @@ from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.recipe.rules_merge import _is_commit_guard
 from autoskillit.recipe.validator import analyze_dataflow, run_semantic_rules
 
+pytestmark = [pytest.mark.layer("recipe")]
+
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 SMOKE_RECIPE = PROJECT_ROOT / ".autoskillit" / "recipes" / "smoke-test.yaml"
 

--- a/tests/recipe/test_bundled_recipes_no_inversions.py
+++ b/tests/recipe/test_bundled_recipes_no_inversions.py
@@ -10,6 +10,8 @@ import yaml
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.recipe.registry import run_semantic_rules
 
+pytestmark = [pytest.mark.layer("recipe")]
+
 _BUNDLED_RECIPE_PATHS: list[Path] = sorted(builtin_recipes_dir().glob("*.yaml"))
 
 

--- a/tests/recipe/test_check_repo_merge_state_routing.py
+++ b/tests/recipe/test_check_repo_merge_state_routing.py
@@ -10,6 +10,8 @@ import pytest
 
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 
+pytestmark = [pytest.mark.layer("recipe")]
+
 
 @pytest.mark.parametrize("recipe_name", ["implementation", "remediation", "implementation-groups"])
 def test_check_repo_merge_state_on_failure_routes_to_immediate_merge_not_success(recipe_name):

--- a/tests/recipe/test_contract_verdict_output_required.py
+++ b/tests/recipe/test_contract_verdict_output_required.py
@@ -15,6 +15,8 @@ import pytest
 
 from autoskillit.recipe.contracts import load_bundled_manifest
 
+pytestmark = [pytest.mark.layer("recipe")]
+
 _AUTO_FIX_SKILLS = [
     "resolve-failures",
     "resolve-review",

--- a/tests/recipe/test_contracts.py
+++ b/tests/recipe/test_contracts.py
@@ -18,6 +18,8 @@ from autoskillit.recipe.contracts import (
 )
 from autoskillit.workspace import bundled_skills_extended_dir
 
+pytestmark = [pytest.mark.layer("recipe")]
+
 # ---------------------------------------------------------------------------
 # Bundled manifest tests
 # ---------------------------------------------------------------------------

--- a/tests/recipe/test_contracts_block_fingerprint.py
+++ b/tests/recipe/test_contracts_block_fingerprint.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import pytest
+
 from autoskillit.recipe.contracts import (
     check_contract_staleness,
     generate_recipe_card,
 )
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.recipe.schema import Recipe, RecipeStep
+
+pytestmark = [pytest.mark.layer("recipe")]
 
 
 def test_recipe_card_contains_block_fingerprint_for_every_declared_block():

--- a/tests/recipe/test_diagnose_ci_subtype_output.py
+++ b/tests/recipe/test_diagnose_ci_subtype_output.py
@@ -10,8 +10,12 @@ from __future__ import annotations
 
 import re
 
+import pytest
+
 from autoskillit.core import pkg_root
 from autoskillit.recipe.contracts import load_bundled_manifest
+
+pytestmark = [pytest.mark.layer("recipe")]
 
 _SKILL_MD = pkg_root() / "skills_extended" / "diagnose-ci" / "SKILL.md"
 

--- a/tests/recipe/test_diagrams.py
+++ b/tests/recipe/test_diagrams.py
@@ -14,6 +14,8 @@ from autoskillit.recipe.diagrams import (
 )
 from autoskillit.recipe.io import load_recipe
 
+pytestmark = [pytest.mark.layer("recipe")]
+
 
 def _extract_graph_section(content: str) -> str:
     """Extract the ### Graph section content."""

--- a/tests/recipe/test_experiment_type_registry.py
+++ b/tests/recipe/test_experiment_type_registry.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 import yaml
 
 from autoskillit.recipe.experiment_type_registry import (
     ExperimentTypeSpec,
     load_all_experiment_types,
 )
+
+pytestmark = [pytest.mark.layer("recipe")]
 
 EXPECTED_TYPES = {
     "benchmark",

--- a/tests/recipe/test_full_audit_recipe.py
+++ b/tests/recipe/test_full_audit_recipe.py
@@ -1,5 +1,9 @@
 from pathlib import Path
 
+import pytest
+
+pytestmark = [pytest.mark.layer("recipe")]
+
 RECIPE_PATH = Path(__file__).resolve().parents[2] / ".autoskillit" / "recipes" / "full-audit.yaml"
 
 

--- a/tests/recipe/test_hidden_ingredients.py
+++ b/tests/recipe/test_hidden_ingredients.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import pytest
+
 from autoskillit.recipe._api import format_ingredients_table
 from autoskillit.recipe.schema import Recipe, RecipeIngredient, RecipeStep
+
+pytestmark = [pytest.mark.layer("recipe")]
 
 
 def _make_recipe(**ingredients: RecipeIngredient) -> Recipe:

--- a/tests/recipe/test_implementation.py
+++ b/tests/recipe/test_implementation.py
@@ -6,6 +6,8 @@ import pytest
 
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 
+pytestmark = [pytest.mark.layer("recipe")]
+
 RECIPE_PATH = builtin_recipes_dir() / "implementation.yaml"
 
 

--- a/tests/recipe/test_implementation_groups_review_loop.py
+++ b/tests/recipe/test_implementation_groups_review_loop.py
@@ -7,6 +7,8 @@ import pytest
 
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 
+pytestmark = [pytest.mark.layer("recipe")]
+
 RECIPE_PATH = builtin_recipes_dir() / "implementation-groups.yaml"
 
 

--- a/tests/recipe/test_implementation_pr_decomposition.py
+++ b/tests/recipe/test_implementation_pr_decomposition.py
@@ -5,6 +5,8 @@ import pytest
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.recipe.validator import validate_recipe
 
+pytestmark = [pytest.mark.layer("recipe")]
+
 RECIPE_PATH = builtin_recipes_dir() / "implementation.yaml"
 
 

--- a/tests/recipe/test_implementation_sprint_mode.py
+++ b/tests/recipe/test_implementation_sprint_mode.py
@@ -12,6 +12,8 @@ from autoskillit.recipe.registry import run_semantic_rules
 from autoskillit.recipe.validator import validate_recipe
 from tests.recipe.conftest import NO_AUTOSKILLIT_IMPORT as _NO_AUTOSKILLIT_IMPORT
 
+pytestmark = [pytest.mark.layer("recipe")]
+
 
 @pytest.fixture(scope="module")
 def impl_recipe():

--- a/tests/recipe/test_io.py
+++ b/tests/recipe/test_io.py
@@ -22,6 +22,8 @@ from autoskillit.recipe.schema import (
 )
 from tests.recipe.conftest import VALID_RECIPE, _write_yaml
 
+pytestmark = [pytest.mark.layer("recipe")]
+
 
 def test_load_recipe_smoke() -> None:
     """load_recipe(path) returns a Recipe with correct name."""

--- a/tests/recipe/test_issue_url_pipeline.py
+++ b/tests/recipe/test_issue_url_pipeline.py
@@ -2,11 +2,14 @@
 
 from pathlib import Path
 
+import pytest
 import yaml
 
 from autoskillit.recipe._api import validate_from_path
 from autoskillit.recipe.io import load_recipe
 from tests.recipe.conftest import NO_AUTOSKILLIT_IMPORT as _NO_AUTOSKILLIT_IMPORT
+
+pytestmark = [pytest.mark.layer("recipe")]
 
 RECIPES_DIR = Path(__file__).parent.parent.parent / "src" / "autoskillit" / "recipes"
 

--- a/tests/recipe/test_loader.py
+++ b/tests/recipe/test_loader.py
@@ -11,6 +11,8 @@ from autoskillit.recipe.loader import (
     parse_recipe_metadata,
 )
 
+pytestmark = [pytest.mark.layer("recipe")]
+
 
 class TestParseRecipeMetadata:
     def test_single_document(self, tmp_path: Path) -> None:

--- a/tests/recipe/test_merge_prs.py
+++ b/tests/recipe/test_merge_prs.py
@@ -6,6 +6,8 @@ import pytest
 
 from autoskillit.recipe.io import builtin_recipes_dir, iter_steps_with_context, load_recipe
 
+pytestmark = [pytest.mark.layer("recipe")]
+
 
 @pytest.fixture(scope="module")
 def recipe():

--- a/tests/recipe/test_merge_prs_queue.py
+++ b/tests/recipe/test_merge_prs_queue.py
@@ -12,6 +12,8 @@ from autoskillit.core import PRState
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.recipe.validator import validate_recipe
 
+pytestmark = [pytest.mark.layer("recipe")]
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------

--- a/tests/recipe/test_merge_sub_recipe_hidden.py
+++ b/tests/recipe/test_merge_sub_recipe_hidden.py
@@ -1,7 +1,11 @@
 """Test that _merge_sub_recipe skips hidden sub-recipe ingredients."""
 
+import pytest
+
 from autoskillit.recipe._api import _merge_sub_recipe
 from autoskillit.recipe.schema import Recipe, RecipeIngredient, RecipeStep
+
+pytestmark = [pytest.mark.layer("recipe")]
 
 
 def _recipe(

--- a/tests/recipe/test_plan_visualization_step.py
+++ b/tests/recipe/test_plan_visualization_step.py
@@ -7,6 +7,8 @@ import pytest
 from autoskillit.core.paths import pkg_root
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 
+pytestmark = [pytest.mark.layer("recipe")]
+
 RESEARCH_RECIPE_PATH = builtin_recipes_dir() / "research.yaml"
 
 

--- a/tests/recipe/test_recipe_temp_substitution.py
+++ b/tests/recipe/test_recipe_temp_substitution.py
@@ -8,6 +8,8 @@ import pytest
 
 from autoskillit.recipe.io import load_recipe
 
+pytestmark = [pytest.mark.layer("recipe")]
+
 _RECIPE_TEMPLATE = """\
 name: temp_subst_demo
 description: demo recipe for temp dir substitution

--- a/tests/recipe/test_remediation_pr_decomposition.py
+++ b/tests/recipe/test_remediation_pr_decomposition.py
@@ -5,6 +5,8 @@ import pytest
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.recipe.validator import validate_recipe
 
+pytestmark = [pytest.mark.layer("recipe")]
+
 RECIPE_PATH = builtin_recipes_dir() / "remediation.yaml"
 
 

--- a/tests/recipe/test_remediation_recipe.py
+++ b/tests/recipe/test_remediation_recipe.py
@@ -7,6 +7,8 @@ import pytest
 from autoskillit.recipe.io import load_recipe
 from autoskillit.recipe.validator import validate_recipe
 
+pytestmark = [pytest.mark.layer("recipe")]
+
 RECIPE_PATH = (
     Path(__file__).parent.parent.parent / "src" / "autoskillit" / "recipes" / "remediation.yaml"
 )

--- a/tests/recipe/test_remediation_sprint_mode.py
+++ b/tests/recipe/test_remediation_sprint_mode.py
@@ -12,6 +12,8 @@ from autoskillit.recipe.registry import run_semantic_rules
 from autoskillit.recipe.validator import validate_recipe
 from tests.recipe.conftest import NO_AUTOSKILLIT_IMPORT as _NO_AUTOSKILLIT_IMPORT
 
+pytestmark = [pytest.mark.layer("recipe")]
+
 
 @pytest.fixture(scope="module")
 def rem_recipe():

--- a/tests/recipe/test_repository.py
+++ b/tests/recipe/test_repository.py
@@ -12,6 +12,8 @@ from autoskillit.core._type_results import LoadResult
 from autoskillit.recipe.repository import DefaultRecipeRepository
 from autoskillit.recipe.schema import RecipeInfo
 
+pytestmark = [pytest.mark.layer("recipe")]
+
 
 def _make_recipe_info(name: str, path: Path) -> RecipeInfo:
     return RecipeInfo(

--- a/tests/recipe/test_research_bundle_lifecycle.py
+++ b/tests/recipe/test_research_bundle_lifecycle.py
@@ -2,6 +2,8 @@ import pytest
 
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 
+pytestmark = [pytest.mark.layer("recipe")]
+
 RESEARCH_RECIPE_PATH = builtin_recipes_dir() / "research.yaml"
 
 

--- a/tests/recipe/test_research_output_mode.py
+++ b/tests/recipe/test_research_output_mode.py
@@ -3,6 +3,8 @@ import pytest
 
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 
+pytestmark = [pytest.mark.layer("recipe")]
+
 RESEARCH_RECIPE_PATH = builtin_recipes_dir() / "research.yaml"
 
 

--- a/tests/recipe/test_research_recipe_diag.py
+++ b/tests/recipe/test_research_recipe_diag.py
@@ -3,6 +3,8 @@ import pytest
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.recipe.validator import validate_recipe
 
+pytestmark = [pytest.mark.layer("recipe")]
+
 RESEARCH_RECIPE_PATH = builtin_recipes_dir() / "research.yaml"
 
 

--- a/tests/recipe/test_research_stage_data_step.py
+++ b/tests/recipe/test_research_stage_data_step.py
@@ -6,6 +6,8 @@ import pytest
 
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 
+pytestmark = [pytest.mark.layer("recipe")]
+
 RESEARCH_RECIPE_PATH = builtin_recipes_dir() / "research.yaml"
 
 

--- a/tests/recipe/test_resolve_ci_routing_invariant.py
+++ b/tests/recipe/test_resolve_ci_routing_invariant.py
@@ -13,6 +13,8 @@ import pytest
 from autoskillit.core import pkg_root
 from autoskillit.recipe.io import load_recipe
 
+pytestmark = [pytest.mark.layer("recipe")]
+
 _RECIPES_DIR = pkg_root() / "recipes"
 _PIPELINE_RECIPES = [
     "implementation.yaml",

--- a/tests/recipe/test_rule_decomposition.py
+++ b/tests/recipe/test_rule_decomposition.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 import ast
 import pathlib
 
+import pytest
+
+pytestmark = [pytest.mark.layer("recipe")]
+
 
 def test_no_deferred_validator_imports_in_rule_modules() -> None:
     """T1: No rule sub-module should defer-import from validator.py inside a function body."""

--- a/tests/recipe/test_rules_blocks.py
+++ b/tests/recipe/test_rules_blocks.py
@@ -7,6 +7,8 @@ import pytest
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.recipe.registry import run_semantic_rules
 
+pytestmark = [pytest.mark.layer("recipe")]
+
 _QUEUE_CAPABLE = ("implementation.yaml", "remediation.yaml", "implementation-groups.yaml")
 
 

--- a/tests/recipe/test_rules_bypass.py
+++ b/tests/recipe/test_rules_bypass.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from autoskillit.core.types import Severity
 from autoskillit.recipe.schema import (
     Recipe,
@@ -9,6 +11,8 @@ from autoskillit.recipe.schema import (
     RecipeStep,
 )
 from autoskillit.recipe.validator import run_semantic_rules
+
+pytestmark = [pytest.mark.layer("recipe")]
 
 # ---------------------------------------------------------------------------
 # skip_when_false bypass routing tests

--- a/tests/recipe/test_rules_ci.py
+++ b/tests/recipe/test_rules_ci.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import pytest
+
 from autoskillit.core import PRState, Severity
 from autoskillit.recipe.io import _parse_step, builtin_recipes_dir, load_recipe
 from autoskillit.recipe.registry import run_semantic_rules
 from autoskillit.recipe.schema import Recipe, RecipeStep, StepResultCondition, StepResultRoute
+
+pytestmark = [pytest.mark.layer("recipe")]
 
 
 def _make_recipe(steps: dict[str, RecipeStep]) -> Recipe:

--- a/tests/recipe/test_rules_clone.py
+++ b/tests/recipe/test_rules_clone.py
@@ -11,6 +11,8 @@ from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.recipe.registry import run_semantic_rules
 from autoskillit.recipe.schema import Recipe, RecipeStep
 
+pytestmark = [pytest.mark.layer("recipe")]
+
 _BUNDLED_RECIPE_YAMLS = list(builtin_recipes_dir().rglob("*.yaml"))
 assert _BUNDLED_RECIPE_YAMLS, (
     "builtin_recipes_dir() returned no YAMLs — parametrize would silently vacuous-pass"

--- a/tests/recipe/test_rules_cmd.py
+++ b/tests/recipe/test_rules_cmd.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import pytest
+
 from autoskillit.recipe.validator import run_semantic_rules
 from tests.recipe.conftest import _make_workflow
+
+pytestmark = [pytest.mark.layer("recipe")]
 
 
 def _make_recipe(steps: dict) -> object:

--- a/tests/recipe/test_rules_conditional_push.py
+++ b/tests/recipe/test_rules_conditional_push.py
@@ -7,6 +7,8 @@ dispatches on a declared verdict-like output.
 
 from __future__ import annotations
 
+import pytest
+
 import autoskillit.recipe.rules_fixing as _rf
 from autoskillit.core.types import Severity
 from autoskillit.recipe.schema import (
@@ -16,6 +18,8 @@ from autoskillit.recipe.schema import (
     StepResultRoute,
 )
 from autoskillit.recipe.validator import run_semantic_rules
+
+pytestmark = [pytest.mark.layer("recipe")]
 
 _RULE = "conditional-skill-ungated-push"
 

--- a/tests/recipe/test_rules_contracts.py
+++ b/tests/recipe/test_rules_contracts.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import pytest
+
 import autoskillit.recipe.rules_contracts as _rc
 from autoskillit.core.paths import pkg_root
 from autoskillit.core.types import Severity
@@ -11,6 +13,8 @@ from autoskillit.recipe.contracts import SkillContract
 from autoskillit.recipe.io import load_recipe
 from autoskillit.recipe.registry import run_semantic_rules
 from autoskillit.recipe.schema import Recipe, RecipeStep
+
+pytestmark = [pytest.mark.layer("recipe")]
 
 
 def test_rule_flags_skills_with_empty_output_patterns() -> None:

--- a/tests/recipe/test_rules_dataflow.py
+++ b/tests/recipe/test_rules_dataflow.py
@@ -22,6 +22,8 @@ from autoskillit.recipe.validator import (
 )
 from tests.recipe.conftest import _make_workflow
 
+pytestmark = [pytest.mark.layer("recipe")]
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------

--- a/tests/recipe/test_rules_graph.py
+++ b/tests/recipe/test_rules_graph.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import pytest
+
 from autoskillit.core import Severity
 from autoskillit.recipe.registry import run_semantic_rules
 from autoskillit.recipe.schema import Recipe, RecipeStep, StepResultRoute
+
+pytestmark = [pytest.mark.layer("recipe")]
 
 
 def _make_recipe(steps: dict[str, RecipeStep]) -> Recipe:

--- a/tests/recipe/test_rules_inputs.py
+++ b/tests/recipe/test_rules_inputs.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 import ast
 import pathlib
 
+import pytest
+
 from autoskillit.core import Severity
 from autoskillit.recipe.registry import run_semantic_rules
 from autoskillit.recipe.schema import Recipe, RecipeStep
+
+pytestmark = [pytest.mark.layer("recipe")]
 
 
 def _make_recipe_with_skill_step(skill_command: str) -> Recipe:

--- a/tests/recipe/test_rules_isolation.py
+++ b/tests/recipe/test_rules_isolation.py
@@ -5,10 +5,14 @@ Covers source-isolation-violation and git-mutation-on-source rules.
 
 from __future__ import annotations
 
+import pytest
+
 from autoskillit.core.types import Severity
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.recipe.registry import _RULE_REGISTRY, run_semantic_rules
 from tests.recipe.conftest import _make_workflow
+
+pytestmark = [pytest.mark.layer("recipe")]
 
 # ---------------------------------------------------------------------------
 # Test 1a: Rule registration

--- a/tests/recipe/test_rules_merge.py
+++ b/tests/recipe/test_rules_merge.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import pytest
+
 from autoskillit.core import Severity
 from autoskillit.recipe.registry import run_semantic_rules
 from autoskillit.recipe.rules_merge import _RECOVERABLE_FAILED_STEPS
 from autoskillit.recipe.schema import Recipe, RecipeStep, StepResultCondition, StepResultRoute
+
+pytestmark = [pytest.mark.layer("recipe")]
 
 
 def _make_recipe(steps: dict[str, RecipeStep]) -> Recipe:

--- a/tests/recipe/test_rules_packs.py
+++ b/tests/recipe/test_rules_packs.py
@@ -1,8 +1,12 @@
 """Tests for the unknown-required-pack semantic rule."""
 
+import pytest
+
 from autoskillit.core import Severity
 from autoskillit.recipe.registry import run_semantic_rules
 from autoskillit.recipe.schema import Recipe, RecipeStep
+
+pytestmark = [pytest.mark.layer("recipe")]
 
 
 def _make_recipe(requires_packs: list[str]) -> Recipe:

--- a/tests/recipe/test_rules_pipeline_internal.py
+++ b/tests/recipe/test_rules_pipeline_internal.py
@@ -1,8 +1,12 @@
 """Tests for the pipeline-internal-not-hidden semantic rule."""
 
+import pytest
+
 from autoskillit.core import Severity
 from autoskillit.recipe.registry import _RULE_REGISTRY, run_semantic_rules
 from autoskillit.recipe.schema import Recipe, RecipeIngredient
+
+pytestmark = [pytest.mark.layer("recipe")]
 
 
 def _make_recipe_with_ingredients(ingredients: dict) -> Recipe:

--- a/tests/recipe/test_rules_project_local_override.py
+++ b/tests/recipe/test_rules_project_local_override.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import pytest
+
+pytestmark = [pytest.mark.layer("recipe")]
+
 
 def test_project_local_override_rule_emits_warning(tmp_path):
     """T-OVR-015: /autoskillit:review-pr with project-local override → WARNING finding."""

--- a/tests/recipe/test_rules_reachability.py
+++ b/tests/recipe/test_rules_reachability.py
@@ -20,6 +20,8 @@ from autoskillit.recipe.schema import (
     StepResultRoute,
 )
 
+pytestmark = [pytest.mark.layer("recipe")]
+
 _QUEUE_CAPABLE = ("implementation.yaml", "remediation.yaml", "implementation-groups.yaml")
 
 

--- a/tests/recipe/test_rules_recipe.py
+++ b/tests/recipe/test_rules_recipe.py
@@ -10,6 +10,8 @@ from autoskillit.recipe._analysis import make_validation_context
 from autoskillit.recipe.registry import _RULE_REGISTRY, run_semantic_rules
 from autoskillit.recipe.schema import Recipe, RecipeIngredient, RecipeStep
 
+pytestmark = [pytest.mark.layer("recipe")]
+
 
 def _make_recipe_with_sub_recipe(sub_recipe_name: str) -> Recipe:
     return Recipe(

--- a/tests/recipe/test_rules_skill_content.py
+++ b/tests/recipe/test_rules_skill_content.py
@@ -13,6 +13,8 @@ import autoskillit.recipe.rules_skill_content as _rsc
 from autoskillit.recipe.io import load_recipe
 from autoskillit.recipe.registry import run_semantic_rules
 
+pytestmark = [pytest.mark.layer("recipe")]
+
 # Minimal recipe YAML that calls a synthetic bad skill with an undefined placeholder.
 # The YAML key for skill arguments is `with:` (maps to `with_args` via _parse_recipe).
 _SYNTHETIC_BAD_SKILL_MD = textwrap.dedent(

--- a/tests/recipe/test_rules_skills.py
+++ b/tests/recipe/test_rules_skills.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import pytest
+
 from autoskillit.core import Severity
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.recipe.registry import run_semantic_rules
 from autoskillit.recipe.schema import Recipe, RecipeStep
+
+pytestmark = [pytest.mark.layer("recipe")]
 
 
 def _make_recipe(skill_command: str) -> Recipe:

--- a/tests/recipe/test_rules_structure.py
+++ b/tests/recipe/test_rules_structure.py
@@ -23,6 +23,8 @@ from autoskillit.recipe.validator import (
 from tests.recipe.conftest import NO_AUTOSKILLIT_IMPORT as _NO_AUTOSKILLIT_IMPORT
 from tests.recipe.conftest import _make_workflow
 
+pytestmark = [pytest.mark.layer("recipe")]
+
 # ---------------------------------------------------------------------------
 # Module-level semantic rule tests
 # ---------------------------------------------------------------------------

--- a/tests/recipe/test_rules_subset_disabled.py
+++ b/tests/recipe/test_rules_subset_disabled.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import pytest
+
+pytestmark = [pytest.mark.layer("recipe")]
+
 
 def _make_skill_recipe(skill_command: str):
     from autoskillit.recipe.schema import Recipe, RecipeStep

--- a/tests/recipe/test_rules_tools.py
+++ b/tests/recipe/test_rules_tools.py
@@ -9,6 +9,8 @@ from autoskillit.core import GATED_TOOLS, UNGATED_TOOLS, Severity
 from autoskillit.recipe.registry import run_semantic_rules
 from autoskillit.recipe.schema import Recipe, RecipeStep
 
+pytestmark = [pytest.mark.layer("recipe")]
+
 
 def _make_recipe(tool: str | None = None, action: str | None = None) -> Recipe:
     """Minimal recipe factory for unknown-tool rule tests."""

--- a/tests/recipe/test_rules_verdict.py
+++ b/tests/recipe/test_rules_verdict.py
@@ -7,6 +7,8 @@ may silently fall through a catch-all condition.
 
 from __future__ import annotations
 
+import pytest
+
 from autoskillit.core.types import Severity
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.recipe.schema import (
@@ -16,6 +18,8 @@ from autoskillit.recipe.schema import (
     StepResultRoute,
 )
 from autoskillit.recipe.validator import run_semantic_rules
+
+pytestmark = [pytest.mark.layer("recipe")]
 
 
 def _make_recipe(steps: dict[str, RecipeStep]) -> Recipe:

--- a/tests/recipe/test_rules_worktree.py
+++ b/tests/recipe/test_rules_worktree.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from autoskillit.core.types import Severity
 from autoskillit.recipe.io import (
     _parse_recipe,
@@ -16,6 +18,8 @@ from autoskillit.recipe.validator import (
     run_semantic_rules,
 )
 from tests.recipe.conftest import _make_workflow
+
+pytestmark = [pytest.mark.layer("recipe")]
 
 # ---------------------------------------------------------------------------
 # retry-worktree-cwd tests

--- a/tests/recipe/test_schema.py
+++ b/tests/recipe/test_schema.py
@@ -8,6 +8,8 @@ import pathlib
 
 import pytest
 
+pytestmark = [pytest.mark.layer("recipe")]
+
 
 def test_all_dataclasses_importable() -> None:
     """All dataclasses are importable from recipe.schema."""

--- a/tests/recipe/test_skill_emit_consistency.py
+++ b/tests/recipe/test_skill_emit_consistency.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 import re
 
+import pytest
+
 from autoskillit.core.paths import pkg_root
 from autoskillit.recipe.contracts import load_bundled_manifest
+
+pytestmark = [pytest.mark.layer("recipe")]
 
 # Key pattern: if a contract output pattern requires an absolute path (contains
 # \s*=\s*/.+), verify that the SKILL.md does not assign the variable to a

--- a/tests/recipe/test_sprint_sub_recipe.py
+++ b/tests/recipe/test_sprint_sub_recipe.py
@@ -9,6 +9,8 @@ from autoskillit.recipe.io import builtin_sub_recipes_dir, load_recipe
 from autoskillit.recipe.registry import run_semantic_rules
 from autoskillit.recipe.validator import validate_recipe
 
+pytestmark = [pytest.mark.layer("recipe")]
+
 
 @pytest.fixture(scope="module")
 def sprint_prefix_recipe():

--- a/tests/recipe/test_staleness_cache.py
+++ b/tests/recipe/test_staleness_cache.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import pytest
+
 from autoskillit.recipe.staleness_cache import (
     StalenessEntry,
     compute_recipe_hash,
     read_staleness_cache,
     write_staleness_cache,
 )
+
+pytestmark = [pytest.mark.layer("recipe")]
 
 
 def _make_entry(**kwargs) -> StalenessEntry:

--- a/tests/recipe/test_sub_recipe_loading.py
+++ b/tests/recipe/test_sub_recipe_loading.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 import textwrap
 from pathlib import Path
 
+import pytest
+
 from autoskillit.recipe._api import _build_active_recipe
 from autoskillit.recipe.schema import Recipe, RecipeIngredient, RecipeStep
+
+pytestmark = [pytest.mark.layer("recipe")]
 
 
 def _make_parent_recipe(

--- a/tests/recipe/test_sub_recipe_schema.py
+++ b/tests/recipe/test_sub_recipe_schema.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import pytest
+
 from autoskillit.recipe.io import _parse_step
 from autoskillit.recipe.schema import Recipe, RecipeIngredient, RecipeStep
 from autoskillit.recipe.validator import validate_recipe
+
+pytestmark = [pytest.mark.layer("recipe")]
 
 
 def _make_minimal_recipe(steps: dict, ingredients: dict | None = None) -> Recipe:

--- a/tests/recipe/test_sub_recipe_validation.py
+++ b/tests/recipe/test_sub_recipe_validation.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 import textwrap
 from pathlib import Path
 
+import pytest
+
 from autoskillit.recipe._analysis import make_validation_context
 from autoskillit.recipe.schema import Recipe, RecipeIngredient, RecipeStep
+
+pytestmark = [pytest.mark.layer("recipe")]
 
 
 def _make_parent_recipe(

--- a/tests/recipe/test_validator.py
+++ b/tests/recipe/test_validator.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import dataclasses
 from pathlib import Path
 
+import pytest
 import yaml
 
 from autoskillit.recipe.io import (
@@ -24,6 +25,8 @@ from autoskillit.recipe.validator import (
     validate_recipe,
 )
 from tests.recipe.conftest import VALID_RECIPE, _make_workflow, _write_yaml
+
+pytestmark = [pytest.mark.layer("recipe")]
 
 # ---------------------------------------------------------------------------
 # TestValidateRecipe — migrated from test_recipe_parser.py

--- a/tests/server/test_editable_guard.py
+++ b/tests/server/test_editable_guard.py
@@ -3,7 +3,11 @@
 import json
 from pathlib import Path
 
+import pytest
+
 from autoskillit.server._editable_guard import scan_editable_installs_for_worktree
+
+pytestmark = [pytest.mark.layer("server")]
 
 
 def _make_dist_info(site_packages: Path, pkg: str, version: str, direct_url: dict) -> None:

--- a/tests/server/test_factory.py
+++ b/tests/server/test_factory.py
@@ -25,6 +25,8 @@ from autoskillit.workspace import DefaultCloneManager, SkillResolver
 from autoskillit.workspace.cleanup import DefaultWorkspaceManager
 from tests.fakes import MockSubprocessRunner
 
+pytestmark = [pytest.mark.layer("server")]
+
 
 def _runner() -> MockSubprocessRunner:
     r = MockSubprocessRunner()

--- a/tests/server/test_factory_recording.py
+++ b/tests/server/test_factory_recording.py
@@ -11,6 +11,8 @@ from autoskillit.execution.recording import RecordingSubprocessRunner, Replaying
 from tests.conftest import _make_result
 from tests.fakes import MockSubprocessRunner
 
+pytestmark = [pytest.mark.layer("server")]
+
 
 @dataclass
 class FakeStepResult:

--- a/tests/server/test_git.py
+++ b/tests/server/test_git.py
@@ -16,6 +16,8 @@ from autoskillit.core.types import (
 )
 from tests.fakes import InMemoryTestRunner, MockSubprocessRunner
 
+pytestmark = [pytest.mark.layer("server")]
+
 
 def _make_result(
     returncode: int = 0,

--- a/tests/server/test_headless_session.py
+++ b/tests/server/test_headless_session.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import pytest
 
+pytestmark = [pytest.mark.layer("server")]
+
 
 @pytest.mark.anyio
 async def test_mcp_enable_kitchen_reveals_gated_tools(kitchen_enabled) -> None:

--- a/tests/server/test_helpers.py
+++ b/tests/server/test_helpers.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = [pytest.mark.layer("server")]
+
 
 @pytest.mark.anyio
 async def test_infer_repo_from_remote_returns_empty_for_file_url(tmp_path: Path) -> None:

--- a/tests/server/test_helpers_gate.py
+++ b/tests/server/test_helpers_gate.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
+pytestmark = [pytest.mark.layer("server")]
+
 
 class TestGateDisabledSchema:
     """Gate-disabled response schema matches the expected skill result keys."""

--- a/tests/server/test_lifespan.py
+++ b/tests/server/test_lifespan.py
@@ -8,6 +8,8 @@ import pytest
 
 from autoskillit.execution.recording import RecordingSubprocessRunner
 
+pytestmark = [pytest.mark.layer("server")]
+
 
 @pytest.mark.asyncio
 async def test_lifespan_calls_finalize_on_recording_runner():

--- a/tests/server/test_lifespan_readiness_structural.py
+++ b/tests/server/test_lifespan_readiness_structural.py
@@ -19,6 +19,8 @@ import pytest
 
 from autoskillit.core._type_constants import RETIRED_READINESS_TOKENS
 
+pytestmark = [pytest.mark.layer("server")]
+
 _LIFESPAN_PATH = (
     Path(__file__).parent.parent.parent / "src" / "autoskillit" / "server" / "_lifespan.py"
 )

--- a/tests/server/test_mcp_overrides.py
+++ b/tests/server/test_mcp_overrides.py
@@ -6,6 +6,10 @@ import json
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
+pytestmark = [pytest.mark.layer("server")]
+
 
 def _make_mock_recipes(load_result: dict) -> MagicMock:
     """Create a mock recipe repository that returns the given load result."""

--- a/tests/server/test_no_raw_signal_handler.py
+++ b/tests/server/test_no_raw_signal_handler.py
@@ -15,6 +15,10 @@ import ast
 import re
 from pathlib import Path
 
+import pytest
+
+pytestmark = [pytest.mark.layer("server")]
+
 _APP_PATH = Path(__file__).parent.parent.parent / "src" / "autoskillit" / "cli" / "app.py"
 _SRC_ROOT = Path(__file__).parent.parent.parent / "src" / "autoskillit"
 

--- a/tests/server/test_perform_merge_editable_guard.py
+++ b/tests/server/test_perform_merge_editable_guard.py
@@ -14,6 +14,8 @@ from autoskillit.core.types import (
 )
 from tests.fakes import InMemoryTestRunner, MockSubprocessRunner
 
+pytestmark = [pytest.mark.layer("server")]
+
 
 def _make_result(returncode: int = 0, stdout: str = "", stderr: str = "") -> SubprocessResult:
     return SubprocessResult(

--- a/tests/server/test_quota_refresh_loop.py
+++ b/tests/server/test_quota_refresh_loop.py
@@ -9,6 +9,8 @@ import pytest
 
 from autoskillit.config.settings import QuotaGuardConfig
 
+pytestmark = [pytest.mark.layer("server")]
+
 
 @pytest.mark.anyio
 async def test_quota_refresh_loop_calls_refresh_at_each_interval(monkeypatch):

--- a/tests/server/test_run_skill_add_dirs.py
+++ b/tests/server/test_run_skill_add_dirs.py
@@ -6,6 +6,8 @@ import pytest
 
 from autoskillit.core import ValidatedAddDir
 
+pytestmark = [pytest.mark.layer("server")]
+
 
 @pytest.mark.anyio
 async def test_raw_skills_extended_excluded_from_run_skill_add_dirs(tool_ctx):

--- a/tests/server/test_server_init.py
+++ b/tests/server/test_server_init.py
@@ -13,6 +13,8 @@ from autoskillit.pipeline.gate import DefaultGateState
 from autoskillit.server.helpers import _require_enabled
 from autoskillit.server.tools_kitchen import _close_kitchen_handler, _open_kitchen_handler
 
+pytestmark = [pytest.mark.layer("server")]
+
 
 class TestKitchenVisibility:
     """FastMCP v3 tag-based visibility: kitchen tools hidden at startup."""

--- a/tests/server/test_server_tool_registration.py
+++ b/tests/server/test_server_tool_registration.py
@@ -17,6 +17,8 @@ from autoskillit.server.tools_status import (
     get_token_summary,
 )
 
+pytestmark = [pytest.mark.layer("server")]
+
 
 class TestNoSkillsDirectoryProvider:
     """T3: SkillsDirectoryProvider is not used in the new plugin architecture."""

--- a/tests/server/test_server_version_telemetry.py
+++ b/tests/server/test_server_version_telemetry.py
@@ -8,6 +8,8 @@ from unittest.mock import patch
 
 import pytest
 
+pytestmark = [pytest.mark.layer("server")]
+
 
 class TestPluginMetadataExists:
     """T1: Plugin metadata files are shipped in the package."""

--- a/tests/server/test_service_wrappers.py
+++ b/tests/server/test_service_wrappers.py
@@ -14,6 +14,8 @@ import yaml
 
 import autoskillit
 
+pytestmark = [pytest.mark.layer("server")]
+
 
 class TestDefaultRecipeRepository:
     def setup_method(self) -> None:

--- a/tests/server/test_set_commit_status.py
+++ b/tests/server/test_set_commit_status.py
@@ -10,6 +10,8 @@ from autoskillit.pipeline.gate import GATED_TOOLS, DefaultGateState
 from autoskillit.server.tools_ci import set_commit_status
 from tests.conftest import _make_result
 
+pytestmark = [pytest.mark.layer("server")]
+
 
 async def _async_return(value: object) -> object:
     """Minimal async helper returning a fixed value — for monkeypatching async callables."""

--- a/tests/server/test_smoke_pipeline.py
+++ b/tests/server/test_smoke_pipeline.py
@@ -26,6 +26,8 @@ import pytest
 from autoskillit.recipe.io import builtin_recipes_dir
 from autoskillit.server.tools_recipe import list_recipes, validate_recipe
 
+pytestmark = [pytest.mark.layer("server")]
+
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 SMOKE_SCRIPT = PROJECT_ROOT / ".autoskillit" / "recipes" / "smoke-test.yaml"
 

--- a/tests/server/test_state.py
+++ b/tests/server/test_state.py
@@ -11,6 +11,8 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
+pytestmark = [pytest.mark.layer("server")]
+
 
 def _make_mock_ctx(tmp_path: Path) -> MagicMock:
     """Return a minimal mock ToolContext for _initialize tests."""

--- a/tests/server/test_tool_exception_boundary.py
+++ b/tests/server/test_tool_exception_boundary.py
@@ -14,6 +14,8 @@ import pytest
 
 from autoskillit.pipeline.mcp_response import DefaultMcpResponseLog
 
+pytestmark = [pytest.mark.layer("server")]
+
 
 class TestToolExceptionBoundary:
     @pytest.mark.anyio

--- a/tests/server/test_tools_ci.py
+++ b/tests/server/test_tools_ci.py
@@ -18,6 +18,8 @@ from autoskillit.server.tools_ci import (
 )
 from tests.fakes import InMemoryCIWatcher, InMemoryMergeQueueWatcher
 
+pytestmark = [pytest.mark.layer("server")]
+
 # ---------------------------------------------------------------------------
 # Gate membership
 # ---------------------------------------------------------------------------

--- a/tests/server/test_tools_clone.py
+++ b/tests/server/test_tools_clone.py
@@ -17,6 +17,8 @@ from autoskillit.server.tools_clone import (
 )
 from autoskillit.workspace import clone_registry
 
+pytestmark = [pytest.mark.layer("server")]
+
 
 class TestCloneRepoTool:
     @pytest.mark.anyio

--- a/tests/server/test_tools_execution.py
+++ b/tests/server/test_tools_execution.py
@@ -26,6 +26,8 @@ from autoskillit.server.helpers import (
 from autoskillit.server.tools_execution import run_skill
 from tests.conftest import _make_result
 
+pytestmark = [pytest.mark.layer("server")]
+
 _SUCCESS_JSON = (
     '{"type": "result", "subtype": "success", "is_error": false,'
     ' "result": "done", "session_id": "s1"}'

--- a/tests/server/test_tools_execution_response.py
+++ b/tests/server/test_tools_execution_response.py
@@ -14,6 +14,8 @@ from autoskillit.core.types import (
 )
 from autoskillit.server.tools_execution import run_skill
 
+pytestmark = [pytest.mark.layer("server")]
+
 
 def _make_session_result(
     returncode: int = 0,

--- a/tests/server/test_tools_git.py
+++ b/tests/server/test_tools_git.py
@@ -20,6 +20,8 @@ from autoskillit.server.tools_git import (
 )
 from tests.conftest import _make_result
 
+pytestmark = [pytest.mark.layer("server")]
+
 
 class TestClassifyFix:
     """T4, T5: classify_fix returns correct restart scope based on changed files."""

--- a/tests/server/test_tools_github.py
+++ b/tests/server/test_tools_github.py
@@ -32,6 +32,8 @@ from autoskillit.server.tools_issue_lifecycle import (
 )
 from tests.server._helpers import _skill_fail, _skill_ok
 
+pytestmark = [pytest.mark.layer("server")]
+
 # ---------------------------------------------------------------------------
 # _parse_fingerprint unit tests
 # ---------------------------------------------------------------------------

--- a/tests/server/test_tools_integrations.py
+++ b/tests/server/test_tools_integrations.py
@@ -20,6 +20,8 @@ from autoskillit.server.tools_issue_lifecycle import (
 from autoskillit.server.tools_pr_ops import bulk_close_issues, get_pr_reviews
 from tests.conftest import _make_result
 
+pytestmark = [pytest.mark.layer("server")]
+
 # ---------------------------------------------------------------------------
 # claim_issue / release_issue / prepare_issue / enrich_issues — gated tools
 # ---------------------------------------------------------------------------

--- a/tests/server/test_tools_integrations_release.py
+++ b/tests/server/test_tools_integrations_release.py
@@ -9,6 +9,8 @@ import pytest
 
 from autoskillit.server.tools_issue_lifecycle import release_issue
 
+pytestmark = [pytest.mark.layer("server")]
+
 
 class TestReleaseIssueStagedLifecycle:
     @pytest.mark.anyio

--- a/tests/server/test_tools_issue_lifecycle.py
+++ b/tests/server/test_tools_issue_lifecycle.py
@@ -24,6 +24,8 @@ from autoskillit.server.tools_issue_lifecycle import (
     release_issue,
 )
 
+pytestmark = [pytest.mark.layer("server")]
+
 
 def _make_skill_result(
     success: bool = True,

--- a/tests/server/test_tools_kitchen.py
+++ b/tests/server/test_tools_kitchen.py
@@ -12,6 +12,8 @@ import pytest
 from autoskillit.config.settings import QuotaGuardConfig
 from autoskillit.hooks._fmt_primitives import _HOOK_CONFIG_PATH_COMPONENTS
 
+pytestmark = [pytest.mark.layer("server")]
+
 
 def _make_mock_ctx():
     """Return a minimal mock ToolContext with a gate."""

--- a/tests/server/test_tools_label_validation.py
+++ b/tests/server/test_tools_label_validation.py
@@ -9,6 +9,8 @@ import pytest
 
 from autoskillit.server.tools_issue_lifecycle import claim_issue, prepare_issue, release_issue
 
+pytestmark = [pytest.mark.layer("server")]
+
 
 class TestClaimIssueWhitelist:
     @pytest.mark.anyio

--- a/tests/server/test_tools_list_recipes.py
+++ b/tests/server/test_tools_list_recipes.py
@@ -11,6 +11,8 @@ import pytest
 from autoskillit.pipeline.gate import DefaultGateState
 from autoskillit.server.tools_recipe import list_recipes
 
+pytestmark = [pytest.mark.layer("server")]
+
 
 class TestListRecipeTools:
     """Tests for kitchen-gated list_recipes tool."""

--- a/tests/server/test_tools_load_recipe.py
+++ b/tests/server/test_tools_load_recipe.py
@@ -17,6 +17,8 @@ from autoskillit.server.tools_recipe import (
     migrate_recipe,
 )
 
+pytestmark = [pytest.mark.layer("server")]
+
 # ---------------------------------------------------------------------------
 # Minimal valid script YAML used across migration suggestion tests
 # ---------------------------------------------------------------------------

--- a/tests/server/test_tools_pr_ops.py
+++ b/tests/server/test_tools_pr_ops.py
@@ -16,6 +16,8 @@ from autoskillit.server.tools_pr_ops import (
     get_pr_reviews,
 )
 
+pytestmark = [pytest.mark.layer("server")]
+
 # ---------------------------------------------------------------------------
 # Pure helper functions
 # ---------------------------------------------------------------------------

--- a/tests/server/test_tools_recipe.py
+++ b/tests/server/test_tools_recipe.py
@@ -9,6 +9,8 @@ import pytest
 
 from autoskillit.server.tools_recipe import validate_recipe
 
+pytestmark = [pytest.mark.layer("server")]
+
 
 def _extract_docstring_sections(desc: str) -> dict[str, str]:
     """Split a tool description into named sections by detecting headers.

--- a/tests/server/test_tools_run_cmd.py
+++ b/tests/server/test_tools_run_cmd.py
@@ -12,6 +12,8 @@ from autoskillit.server.helpers import _run_subprocess
 from autoskillit.server.tools_execution import run_cmd, run_python
 from tests.conftest import _make_result, _make_timeout_result
 
+pytestmark = [pytest.mark.layer("server")]
+
 
 class TestRunCmd:
     """T1, T2: run_cmd executes commands and returns exit code semantics."""

--- a/tests/server/test_tools_run_cmd_unit.py
+++ b/tests/server/test_tools_run_cmd_unit.py
@@ -12,6 +12,8 @@ import structlog.testing
 from autoskillit.server.tools_execution import run_cmd
 from tests.conftest import _make_result
 
+pytestmark = [pytest.mark.layer("server")]
+
 
 class TestRunCmdObservability:
     """run_cmd binds structlog contextvars and calls ctx.info/ctx.error."""

--- a/tests/server/test_tools_run_python.py
+++ b/tests/server/test_tools_run_python.py
@@ -11,6 +11,8 @@ import structlog.testing
 
 from autoskillit.server.tools_execution import run_python
 
+pytestmark = [pytest.mark.layer("server")]
+
 
 class TestRunPythonObservability:
     """run_python binds structlog contextvars and calls ctx.info/ctx.error."""

--- a/tests/server/test_tools_run_skill_retry.py
+++ b/tests/server/test_tools_run_skill_retry.py
@@ -11,6 +11,8 @@ from autoskillit.core.types import RetryReason, TerminationReason
 from autoskillit.server.tools_execution import run_skill
 from tests.conftest import _make_result
 
+pytestmark = [pytest.mark.layer("server")]
+
 # Deterministic UUID for tests that need to predict the per-invocation marker.
 _DETERMINISTIC_HEX = "a1b2c3d4e5f6a7b890123456"
 _DETERMINISTIC_MARKER = f"%%ORDER_UP::{_DETERMINISTIC_HEX[:8]}%%"

--- a/tests/server/test_tools_session_diagnostics.py
+++ b/tests/server/test_tools_session_diagnostics.py
@@ -16,6 +16,8 @@ from autoskillit.server.tools_github import (
     report_bug,
 )
 
+pytestmark = [pytest.mark.layer("server")]
+
 # ---------------------------------------------------------------------------
 # _read_session_diagnostics unit tests
 # ---------------------------------------------------------------------------

--- a/tests/server/test_tools_status.py
+++ b/tests/server/test_tools_status.py
@@ -28,6 +28,8 @@ from autoskillit.server.tools_status import (
 )
 from tests.conftest import _make_result
 
+pytestmark = [pytest.mark.layer("server")]
+
 
 def _make_failure_record(**overrides: object) -> FailureRecord:
     defaults = dict(

--- a/tests/server/test_tools_status_mcp_response.py
+++ b/tests/server/test_tools_status_mcp_response.py
@@ -9,6 +9,8 @@ import pytest
 
 from autoskillit.server.tools_status import get_token_summary, write_telemetry_files
 
+pytestmark = [pytest.mark.layer("server")]
+
 
 class TestGetTokenSummaryMcpResponses:
     @pytest.mark.anyio

--- a/tests/server/test_tools_workspace.py
+++ b/tests/server/test_tools_workspace.py
@@ -17,6 +17,8 @@ from autoskillit.server.tools_workspace import reset_test_dir, reset_workspace, 
 from autoskillit.workspace import CleanupResult
 from tests.conftest import _make_result
 
+pytestmark = [pytest.mark.layer("server")]
+
 test_check.__test__ = False  # type: ignore[attr-defined]
 
 

--- a/tests/server/test_track_response_size.py
+++ b/tests/server/test_track_response_size.py
@@ -9,6 +9,8 @@ import pytest
 
 from autoskillit.pipeline.mcp_response import DefaultMcpResponseLog
 
+pytestmark = [pytest.mark.layer("server")]
+
 
 class TestTrackResponseSize:
     @pytest.mark.anyio

--- a/tests/workspace/test_cleanup.py
+++ b/tests/workspace/test_cleanup.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from autoskillit.workspace import CleanupResult, _delete_directory_contents
+
+pytestmark = [pytest.mark.layer("workspace")]
 
 
 class TestCleanupResult:

--- a/tests/workspace/test_clone.py
+++ b/tests/workspace/test_clone.py
@@ -23,6 +23,8 @@ from autoskillit.workspace.clone import (
     remove_clone,
 )
 
+pytestmark = [pytest.mark.layer("workspace")]
+
 
 @pytest.fixture
 def bare_remote(tmp_path: Path) -> Path:

--- a/tests/workspace/test_clone_ci_contract.py
+++ b/tests/workspace/test_clone_ci_contract.py
@@ -17,6 +17,8 @@ import pytest
 from autoskillit.execution import resolve_remote_repo
 from autoskillit.workspace import clone_repo
 
+pytestmark = [pytest.mark.layer("workspace")]
+
 # ---------------------------------------------------------------------------
 # Primary cross-boundary integration test
 # ---------------------------------------------------------------------------

--- a/tests/workspace/test_clone_registry.py
+++ b/tests/workspace/test_clone_registry.py
@@ -15,6 +15,8 @@ from autoskillit.workspace.clone_registry import (
     register_clone,
 )
 
+pytestmark = [pytest.mark.layer("workspace")]
+
 
 class TestRegisterClone:
     """register_clone contract tests."""

--- a/tests/workspace/test_clone_timeouts.py
+++ b/tests/workspace/test_clone_timeouts.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
+import pytest
+
+pytestmark = [pytest.mark.layer("workspace")]
+
 _GIT_NETWORK_SUBCOMMANDS = {"push", "clone", "fetch", "pull", "ls-remote"}
 
 

--- a/tests/workspace/test_constants.py
+++ b/tests/workspace/test_constants.py
@@ -1,6 +1,10 @@
 # tests/workspace/test_constants.py
 """Asserts that workspace directory name constants are exported from workspace/__init__."""
 
+import pytest
+
+pytestmark = [pytest.mark.layer("workspace")]
+
 
 def test_runs_dir_constant_is_exported():
     from autoskillit.workspace import RUNS_DIR

--- a/tests/workspace/test_project_local_overrides.py
+++ b/tests/workspace/test_project_local_overrides.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import pytest
+
 from autoskillit.core.types import PACK_REGISTRY
+
+pytestmark = [pytest.mark.layer("workspace")]
 
 # Tags for packs that are disabled by default (e.g. research, exp-lens).
 # Shared by T-OVR-014 and T-OVR-017 to avoid duplication.

--- a/tests/workspace/test_session_skills.py
+++ b/tests/workspace/test_session_skills.py
@@ -16,6 +16,8 @@ from autoskillit.workspace.session_skills import (
     resolve_ephemeral_root,
 )
 
+pytestmark = [pytest.mark.layer("workspace")]
+
 
 def test_resolve_ephemeral_root_returns_writable_dir(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/workspace/test_skill_content_substitution.py
+++ b/tests/workspace/test_skill_content_substitution.py
@@ -11,6 +11,8 @@ from autoskillit.workspace.session_skills import (
     SkillsDirectoryProvider,
 )
 
+pytestmark = [pytest.mark.layer("workspace")]
+
 
 class _StubInfo:
     def __init__(self, path: Path, name: str) -> None:

--- a/tests/workspace/test_skills.py
+++ b/tests/workspace/test_skills.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+import pytest
 import yaml
 
 from autoskillit.core.types import SkillSource
@@ -13,6 +14,8 @@ from autoskillit.workspace.skills import (
     bundled_skills_dir,
     bundled_skills_extended_dir,
 )
+
+pytestmark = [pytest.mark.layer("workspace")]
 
 BUNDLED_SKILLS = [
     "analyze-prs",

--- a/tests/workspace/test_worktree.py
+++ b/tests/workspace/test_worktree.py
@@ -11,6 +11,8 @@ from autoskillit.workspace.worktree import (
     remove_worktree_sidecar,
 )
 
+pytestmark = [pytest.mark.layer("workspace")]
+
 
 class TestListGitWorktrees:
     """list_git_worktrees(project_root) returns paths of linked worktrees under root."""


### PR DESCRIPTION
## Summary

Add `pytestmark = [pytest.mark.layer("<subpackage>")]` to every `test_*.py` file in the 9 in-scope test directories (core, config, pipeline, execution, workspace, recipe, migration, server, cli). Register the `layer` marker in `pyproject.toml`. Add conftest-level collection validation that warns when a marker value mismatches the directory. Add an architectural enforcement test. Update `tests/CLAUDE.md`.

Out of scope: `tests/arch/`, `tests/contracts/`, `tests/infra/`, `tests/docs/`, `tests/skills/`, `tests/hooks/`, `tests/skills_extended/`, `tests/assets/`.

Closes #938

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-938-20260416-073648-433860/.autoskillit/temp/make-plan/pytestmark_layer_markers_plan_2026-04-16_074300.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| make_plan | 1.9k | 10.6k | 656.1k | 48.4k | 1 | 7m 10s |
| review_approach | 24 | 3.4k | 146.5k | 22.9k | 1 | 4m 23s |
| dry_walkthrough | 51 | 8.8k | 577.6k | 42.7k | 1 | 4m 49s |
| implement | 82 | 14.4k | 1.6M | 46.9k | 1 | 5m 31s |
| prepare_pr | 39 | 12.0k | 428.0k | 49.6k | 1 | 3m 30s |
| compose_pr | 24 | 1.9k | 171.3k | 18.5k | 1 | 55s |
| **Total** | 2.1k | 51.1k | 3.6M | 229.0k | | 26m 20s |