### PR TITLE
Implementation Plan: Google-Style Test Size Categories

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,9 @@ markers = [
     "integration: integration tests that spawn real subprocesses (deselect with: -m 'not integration')",
     "canary: development-time filter verification tests (deselect with: -m 'not canary')",
     "layer(name): source-layer marker for test file classification (core, config, pipeline, execution, workspace, recipe, migration, server, cli)",
+    "small: pure unit test — no persistent I/O, no network, no subprocess (RAM-backed tmpfs via tmp_path IS allowed)",
+    "medium: filesystem and subprocess allowed — no network, no external services",
+    "large: full integration — everything allowed (default for unannotated tests)",
 ]
 
 [tool.coverage.run]

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -52,6 +52,34 @@ time that marker values match directories (warnings on mismatch).
 
 **Usage:** `pytest -m 'layer("core")'` runs only L0 core tests.
 
+## Size Markers
+
+Test files in annotated directories carry a size marker indicating resource constraints:
+
+```python
+pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
+```
+
+**Size definitions (Google-style):**
+
+| Marker | Constraints | Examples |
+|--------|------------|---------|
+| `small` | No persistent I/O, no network, no subprocess. RAM-backed tmpfs via `tmp_path` IS allowed. | Pure logic, string parsing, in-memory dataclass tests |
+| `medium` | Filesystem and subprocess allowed. No network, no external services. | Tests spawning child processes, real file system operations |
+| `large` | Everything allowed. Full integration. Default for unannotated tests. | End-to-end tests, network calls, Claude API access |
+
+**In-scope directories:** core, pipeline (initial rollout). Other directories follow incrementally.
+
+**Aggressive filter behavior:** When `AUTOSKILLIT_TEST_FILTER=aggressive`, only `small` and `medium` tests run. Unannotated tests default to `large` and are deselected.
+
+**Rules:**
+- Each file has exactly one size marker — no conflicts (enforced by `tests/arch/test_size_markers.py`)
+- Place size marker after the `layer` marker in the `pytestmark` list
+- When in doubt, use `medium` — it's safer to over-classify than under-classify
+- `tests/arch/test_size_markers.py` enforces completeness via AST scan
+
+**Usage:** `pytest -m small` runs only small tests. `pytest -m 'small or medium'` excludes large tests.
+
 ## Placement Convention: tests/skills/ vs tests/contracts/
 
 - `tests/skills/` — tests that exercise the skill loader, skill discovery, or skill

--- a/tests/arch/test_size_markers.py
+++ b/tests/arch/test_size_markers.py
@@ -1,0 +1,112 @@
+"""Enforce pytestmark size markers on in-scope test files."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+TESTS_ROOT = Path(__file__).resolve().parent.parent
+
+SIZE_DIRECTORIES: dict[str, str] = {
+    "core": "core",
+    "pipeline": "pipeline",
+}
+
+_VALID_SIZE_MARKERS = {"small", "medium", "large"}
+
+
+def _extract_size_markers(path: Path) -> list[str]:
+    """Parse a test file's AST and return all size marker names found."""
+    tree = ast.parse(path.read_text())
+    found: list[str] = []
+    for node in ast.iter_child_nodes(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == "pytestmark":
+                if isinstance(node.value, ast.List):
+                    for elt in node.value.elts:
+                        name = _marker_name(elt)
+                        if name in _VALID_SIZE_MARKERS:
+                            found.append(name)
+                else:
+                    name = _marker_name(node.value)
+                    if name and name in _VALID_SIZE_MARKERS:
+                        found.append(name)
+    return found
+
+
+def _marker_name(node: ast.expr) -> str | None:
+    """If node is pytest.mark.<name>, return <name>."""
+    if (
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Attribute)
+        and node.value.attr == "mark"
+    ):
+        return node.attr
+    if isinstance(node, ast.Call):
+        return _marker_name(node.func)
+    return None
+
+
+@pytest.mark.parametrize(
+    "directory",
+    sorted(SIZE_DIRECTORIES),
+    ids=sorted(SIZE_DIRECTORIES),
+)
+def test_all_test_files_have_size_marker(directory: str) -> None:
+    """Every test_*.py in an in-scope directory has a size marker."""
+    dir_path = TESTS_ROOT / directory
+    test_files = sorted(dir_path.glob("test_*.py"))
+    assert test_files, f"No test files found in {dir_path}"
+
+    missing: list[str] = []
+    for tf in test_files:
+        markers = _extract_size_markers(tf)
+        if not markers:
+            missing.append(tf.name)
+
+    assert not missing, f"Missing size marker (small/medium/large): {missing}"
+
+
+@pytest.mark.parametrize(
+    "directory",
+    sorted(SIZE_DIRECTORIES),
+    ids=sorted(SIZE_DIRECTORIES),
+)
+def test_no_conflicting_size_markers(directory: str) -> None:
+    """No test file may have more than one size marker."""
+    dir_path = TESTS_ROOT / directory
+    test_files = sorted(dir_path.glob("test_*.py"))
+
+    conflicts: list[tuple[str, list[str]]] = []
+    for tf in test_files:
+        markers = _extract_size_markers(tf)
+        if len(markers) > 1:
+            conflicts.append((tf.name, markers))
+
+    assert not conflicts, f"Conflicting size markers: {conflicts}"
+
+
+def test_size_markers_registered_in_pyproject() -> None:
+    """All three size markers are registered in pyproject.toml."""
+    import tomllib
+
+    pyproject = TESTS_ROOT.parent / "pyproject.toml"
+    data = tomllib.loads(pyproject.read_text())
+    markers = data["tool"]["pytest"]["ini_options"]["markers"]
+    marker_names = {m.split(":")[0].strip().split("(")[0] for m in markers}
+    for size in ("small", "medium", "large"):
+        assert size in marker_names, f"'{size}' marker not registered in pyproject.toml"
+
+
+def test_size_marker_directories_match_conftest() -> None:
+    """SIZE_DIRECTORIES keys must match _SIZE_DIRS in conftest.py."""
+    from tests.conftest import _SIZE_DIRS
+
+    assert set(SIZE_DIRECTORIES.keys()) == _SIZE_DIRS, (
+        f"SIZE_DIRECTORIES keys {set(SIZE_DIRECTORIES.keys())} != "
+        f"conftest _SIZE_DIRS {_SIZE_DIRS}"
+    )

--- a/tests/arch/test_size_markers.py
+++ b/tests/arch/test_size_markers.py
@@ -19,7 +19,10 @@ _VALID_SIZE_MARKERS = {"small", "medium", "large"}
 
 def _extract_size_markers(path: Path) -> list[str]:
     """Parse a test file's AST and return all size marker names found."""
-    tree = ast.parse(path.read_text())
+    try:
+        tree = ast.parse(path.read_text())
+    except (SyntaxError, OSError) as exc:
+        raise type(exc)(f"{path}: {exc}") from exc
     found: list[str] = []
     for node in ast.iter_child_nodes(tree):
         if not isinstance(node, ast.Assign):
@@ -44,6 +47,8 @@ def _marker_name(node: ast.expr) -> str | None:
         isinstance(node, ast.Attribute)
         and isinstance(node.value, ast.Attribute)
         and node.value.attr == "mark"
+        and isinstance(node.value.value, ast.Name)
+        and node.value.value.id == "pytest"
     ):
         return node.attr
     if isinstance(node, ast.Call):
@@ -107,6 +112,5 @@ def test_size_marker_directories_match_conftest() -> None:
     from tests.conftest import _SIZE_DIRS
 
     assert set(SIZE_DIRECTORIES.keys()) == _SIZE_DIRS, (
-        f"SIZE_DIRECTORIES keys {set(SIZE_DIRECTORIES.keys())} != "
-        f"conftest _SIZE_DIRS {_SIZE_DIRS}"
+        f"SIZE_DIRECTORIES keys {set(SIZE_DIRECTORIES.keys())} != conftest _SIZE_DIRS {_SIZE_DIRS}"
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,10 @@ _LAYER_DIRS: frozenset[str] = frozenset(
     }
 )
 
+_SIZE_DIRS: frozenset[str] = frozenset({"core", "pipeline"})
+
 _scope_key = pytest.StashKey[set[_Path] | None]()
+_filter_mode_key = pytest.StashKey[str | None]()
 
 
 @pytest.fixture(autouse=True)
@@ -270,6 +273,7 @@ def pytest_configure(config: pytest.Config) -> None:
     import warnings
 
     config.stash[_scope_key] = None
+    config.stash[_filter_mode_key] = None
 
     cli_mode = config.getoption("--filter-mode", default=None)
     env_val = os.environ.get("AUTOSKILLIT_TEST_FILTER", "")
@@ -309,6 +313,7 @@ def pytest_configure(config: pytest.Config) -> None:
             tests_root=config.rootpath / "tests",
         )
         config.stash[_scope_key] = scope
+        config.stash[_filter_mode_key] = mode.value
 
     except Exception as exc:
         warnings.warn(
@@ -395,3 +400,27 @@ def pytest_collection_modifyitems(
             f"Test filter deselection failed, running all tests: {exc}",
             stacklevel=1,
         )
+
+    # --- Size-based deselection (aggressive mode only) ---
+    filter_mode = config.stash.get(_filter_mode_key, None)
+    if filter_mode == "aggressive":
+        _SIZE_MARKERS = {"small", "medium", "large"}
+        size_selected: list[pytest.Item] = []
+        size_deselected: list[pytest.Item] = []
+
+        for item in items:
+            size_marks = [m.name for m in item.iter_markers() if m.name in _SIZE_MARKERS]
+            effective_size = size_marks[0] if size_marks else "large"
+            if effective_size in ("small", "medium"):
+                size_selected.append(item)
+            else:
+                size_deselected.append(item)
+
+        if size_deselected:
+            config.hook.pytest_deselected(items=size_deselected)
+            items[:] = size_selected
+            warnings.warn(
+                f"Size filter (aggressive): {len(size_selected)} selected, "
+                f"{len(size_deselected)} large/unannotated deselected",
+                stacklevel=1,
+            )

--- a/tests/core/test_add_dir_validation.py
+++ b/tests/core/test_add_dir_validation.py
@@ -10,7 +10,7 @@ import pytest
 from autoskillit.core import ValidatedAddDir
 from autoskillit.core.claude_conventions import LayoutError, validate_add_dir
 
-pytestmark = [pytest.mark.layer("core")]
+pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
 
 
 class TestValidatedAddDir:

--- a/tests/core/test_branch_guard.py
+++ b/tests/core/test_branch_guard.py
@@ -4,7 +4,7 @@ import pytest
 
 from autoskillit.core.branch_guard import is_protected_branch
 
-pytestmark = [pytest.mark.layer("core")]
+pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
 
 _DEFAULTS = ["main", "integration", "stable"]
 

--- a/tests/core/test_claude_env.py
+++ b/tests/core/test_claude_env.py
@@ -13,7 +13,7 @@ from autoskillit.core._claude_env import (
     IDE_ENV_PREFIX_DENYLIST,
 )
 
-pytestmark = [pytest.mark.layer("core")]
+pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
 
 
 def test_build_claude_env_strips_sse_port() -> None:

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-pytestmark = [pytest.mark.layer("core")]
+pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
 
 
 def test_atomic_write_docstring_contains_atomic_keyword():

--- a/tests/core/test_core_terminal_table.py
+++ b/tests/core/test_core_terminal_table.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-pytestmark = [pytest.mark.layer("core")]
+pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
 
 
 def test_compute_col_widths_is_module_level() -> None:

--- a/tests/core/test_ensure_project_temp_with_config.py
+++ b/tests/core/test_ensure_project_temp_with_config.py
@@ -8,7 +8,7 @@ import pytest
 
 from autoskillit.core.io import ensure_project_temp
 
-pytestmark = [pytest.mark.layer("core")]
+pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
 
 
 def test_ensure_project_temp_default_writes_self_gitignore(tmp_path: Path) -> None:

--- a/tests/core/test_github_url.py
+++ b/tests/core/test_github_url.py
@@ -6,7 +6,7 @@ import pytest
 
 from autoskillit.core import parse_github_repo
 
-pytestmark = [pytest.mark.layer("core")]
+pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
 
 
 @pytest.mark.parametrize(

--- a/tests/core/test_io.py
+++ b/tests/core/test_io.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-pytestmark = [pytest.mark.layer("core")]
+pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
 
 
 class TestLoadYamlExtended:

--- a/tests/core/test_logging.py
+++ b/tests/core/test_logging.py
@@ -11,7 +11,7 @@ import structlog
 
 from tests._helpers import _flush_structlog_proxy_caches as _flush_logger_proxy_caches
 
-pytestmark = [pytest.mark.layer("core")]
+pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
 
 
 class TestGetLogger:

--- a/tests/core/test_paths.py
+++ b/tests/core/test_paths.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = [pytest.mark.layer("core")]
+pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
 
 
 class TestWorktreeDetection:

--- a/tests/core/test_resolve_temp_dir.py
+++ b/tests/core/test_resolve_temp_dir.py
@@ -9,7 +9,7 @@ import pytest
 
 from autoskillit.core.io import resolve_temp_dir
 
-pytestmark = [pytest.mark.layer("core")]
+pytestmark = [pytest.mark.layer("core"), pytest.mark.medium]
 
 
 def test_resolve_temp_dir_default_returns_project_relative() -> None:

--- a/tests/core/test_skill_command_parsing.py
+++ b/tests/core/test_skill_command_parsing.py
@@ -6,7 +6,7 @@ import pytest
 
 from autoskillit.core._type_helpers import _PATH_PREFIXES, extract_path_arg
 
-pytestmark = [pytest.mark.layer("core")]
+pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
 
 
 class TestExtractPathArg:

--- a/tests/core/test_type_constants.py
+++ b/tests/core/test_type_constants.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-pytestmark = [pytest.mark.layer("core")]
+pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
 
 
 # REQ-PACK-001: PACK_REGISTRY defines all packs with default_enabled

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -16,7 +16,7 @@ from autoskillit.core.types import (
     SkillResult,
 )
 
-pytestmark = [pytest.mark.layer("core")]
+pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
 
 
 def test_retry_reason_values():

--- a/tests/core/test_types_structure.py
+++ b/tests/core/test_types_structure.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-pytestmark = [pytest.mark.layer("core")]
+pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
 
 
 def test_enums_importable_from_sub_module():

--- a/tests/pipeline/test_audit.py
+++ b/tests/pipeline/test_audit.py
@@ -13,7 +13,7 @@ from autoskillit.pipeline.audit import (
     _validate_failure_record_dict,
 )
 
-pytestmark = [pytest.mark.layer("pipeline")]
+pytestmark = [pytest.mark.layer("pipeline"), pytest.mark.small]
 
 
 def _make_record(**overrides: object) -> FailureRecord:

--- a/tests/pipeline/test_background_supervisor.py
+++ b/tests/pipeline/test_background_supervisor.py
@@ -6,7 +6,7 @@ import pytest
 
 from autoskillit.pipeline.background import DefaultBackgroundSupervisor
 
-pytestmark = [pytest.mark.layer("pipeline")]
+pytestmark = [pytest.mark.layer("pipeline"), pytest.mark.small]
 
 
 @pytest.mark.anyio

--- a/tests/pipeline/test_context.py
+++ b/tests/pipeline/test_context.py
@@ -15,7 +15,7 @@ from autoskillit.pipeline.gate import DefaultGateState
 from autoskillit.pipeline.timings import DefaultTimingLog
 from autoskillit.pipeline.tokens import DefaultTokenLog
 
-pytestmark = [pytest.mark.layer("pipeline")]
+pytestmark = [pytest.mark.layer("pipeline"), pytest.mark.small]
 
 
 def test_tool_context_fields_accessible(tmp_path):

--- a/tests/pipeline/test_gate.py
+++ b/tests/pipeline/test_gate.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-pytestmark = [pytest.mark.layer("pipeline")]
+pytestmark = [pytest.mark.layer("pipeline"), pytest.mark.small]
 
 
 def test_gated_tools_contains_expected_names():

--- a/tests/pipeline/test_mcp_response.py
+++ b/tests/pipeline/test_mcp_response.py
@@ -6,7 +6,7 @@ import pytest
 
 from autoskillit.pipeline.mcp_response import DefaultMcpResponseLog, McpResponseEntry
 
-pytestmark = [pytest.mark.layer("pipeline")]
+pytestmark = [pytest.mark.layer("pipeline"), pytest.mark.small]
 
 
 class TestMcpResponseEntry:

--- a/tests/pipeline/test_pr_gates.py
+++ b/tests/pipeline/test_pr_gates.py
@@ -17,7 +17,7 @@ from autoskillit.pipeline.pr_gates import (
     partition_prs,
 )
 
-pytestmark = [pytest.mark.layer("pipeline")]
+pytestmark = [pytest.mark.layer("pipeline"), pytest.mark.small]
 
 # ---------------------------------------------------------------------------
 # CI Gate

--- a/tests/pipeline/test_telemetry_formatter.py
+++ b/tests/pipeline/test_telemetry_formatter.py
@@ -6,7 +6,7 @@ import pytest
 
 from autoskillit.pipeline.telemetry_fmt import TelemetryFormatter
 
-pytestmark = [pytest.mark.layer("pipeline")]
+pytestmark = [pytest.mark.layer("pipeline"), pytest.mark.small]
 
 # ---------------------------------------------------------------------------
 # Shared test data

--- a/tests/pipeline/test_timings.py
+++ b/tests/pipeline/test_timings.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = [pytest.mark.layer("pipeline")]
+pytestmark = [pytest.mark.layer("pipeline"), pytest.mark.small]
 
 
 class TestTimingEntry:

--- a/tests/pipeline/test_tokens.py
+++ b/tests/pipeline/test_tokens.py
@@ -10,7 +10,7 @@ import pytest
 
 from autoskillit.pipeline.tokens import DefaultTokenLog, TokenEntry
 
-pytestmark = [pytest.mark.layer("pipeline")]
+pytestmark = [pytest.mark.layer("pipeline"), pytest.mark.small]
 
 
 def _make_usage(**overrides: int) -> dict[str, int]:


### PR DESCRIPTION
## Summary

Adopt Google's small/medium/large test size taxonomy as a second filtering axis alongside existing layer markers. Register three new pytest markers (`small`, `medium`, `large`) in `pyproject.toml`, annotate all 24 test files in `tests/core/` and `tests/pipeline/` with the appropriate size marker, add conftest-level size deselection in aggressive filter mode (restricting to small+medium only), create architectural enforcement via AST scan, and document the categorization criteria.

Closes #939

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-939-20260416-084122-192188/.autoskillit/temp/make-plan/google_style_test_size_categories_plan_2026-04-16_084500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| make_plan | 86 | 12.0k | 1.0M | 68.4k | 1 | 7m 56s |
| review_approach | 38 | 5.4k | 341.1k | 30.4k | 1 | 4m 22s |
| dry_walkthrough | 1.3k | 10.5k | 962.0k | 49.2k | 1 | 5m 55s |
| implement | 85 | 13.8k | 1.8M | 80.2k | 1 | 8m 19s |
| prepare_pr | 34 | 4.8k | 181.5k | 25.0k | 1 | 1m 23s |
| compose_pr | 24 | 2.1k | 158.9k | 15.4k | 1 | 56s |
| **Total** | 1.6k | 48.6k | 4.5M | 268.6k | | 28m 52s |