### PR TITLE
Implementation Plan: Gate api-simulator Dev Dependency to Linux Only

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dev = [
     "ruff>=0.15.0",
     "import-linter>=2.1",
     "packaging>=25.0",
-    "api-simulator",
+    "api-simulator; sys_platform == 'linux'",
 ]
 
 [project.urls]

--- a/tests/execution/test_quota_http.py
+++ b/tests/execution/test_quota_http.py
@@ -7,17 +7,21 @@ They complement the unit tests in test_quota.py which mock at the function level
 from __future__ import annotations
 
 import json
+import sys
 import time
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
 import pytest
-from api_simulator.http import MockResponseSpec as PyResponseSpec
 
-from autoskillit.execution.quota import check_and_sleep_if_needed
+_api_sim_http = pytest.importorskip("api_simulator.http")
+PyResponseSpec = _api_sim_http.MockResponseSpec
+
+from autoskillit.execution.quota import check_and_sleep_if_needed  # noqa: E402
 
 pytestmark = [
     pytest.mark.layer("execution"),
+    pytest.mark.skipif(sys.platform != "linux", reason="api-simulator is Linux-only"),
     pytest.mark.anyio,
 ]
 

--- a/tests/infra/test_pyproject_metadata.py
+++ b/tests/infra/test_pyproject_metadata.py
@@ -44,3 +44,13 @@ def test_markdown_it_py_in_dependencies() -> None:
     assert any("markdown-it-py" in d for d in deps), (
         "markdown-it-py not found in [project].dependencies in pyproject.toml"
     )
+
+
+def test_api_simulator_dev_dep_is_linux_only() -> None:
+    """api-simulator must carry sys_platform == 'linux' so it is not installed on macOS/Windows."""
+    deps: list[str] = _project()["project"]["optional-dependencies"]["dev"]
+    api_sim = next((d for d in deps if d.startswith("api-simulator")), None)
+    assert api_sim is not None, "api-simulator not found in dev dependencies"
+    assert "sys_platform" in api_sim and "linux" in api_sim, (
+        f"api-simulator dev dep missing sys_platform == 'linux' marker: {api_sim!r}"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -94,7 +94,7 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
-    { name = "api-simulator" },
+    { name = "api-simulator", marker = "sys_platform == 'linux'" },
     { name = "import-linter" },
     { name = "packaging" },
     { name = "pytest" },
@@ -109,7 +109,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anyio", specifier = ">=4.6.0" },
-    { name = "api-simulator", marker = "extra == 'dev'", git = "https://github.com/TalonT-Org/api-simulator?subdirectory=crates%2Fapi-simulator-py&rev=8f711f958d4d93a8e53a3c3b51279fb420870f3a" },
+    { name = "api-simulator", marker = "sys_platform == 'linux' and extra == 'dev'", git = "https://github.com/TalonT-Org/api-simulator?subdirectory=crates%2Fapi-simulator-py&rev=8f711f958d4d93a8e53a3c3b51279fb420870f3a" },
     { name = "cyclopts", specifier = ">=4.0" },
     { name = "dynaconf", specifier = ">=3.2.13,<4.0" },
     { name = "fastmcp", specifier = ">=3.2.0,<4.0" },


### PR DESCRIPTION
## Summary

Add a `sys_platform == 'linux'` PEP 508 environment marker to the `api-simulator` entry in `pyproject.toml`'s `[project.optional-dependencies] dev` list, then regenerate the lockfile. One test file (`test_quota_http.py`) has a **module-level** `from api_simulator.http import ...` that would cause an `ImportError` on non-Linux where the package is no longer installed — fix it by adding a `sys.platform` skip to its `pytestmark`. All other test imports of `api_simulator` are already lazy (inside function bodies) and need no change. Add a regression test in `test_pyproject_metadata.py` that asserts the platform marker is present.

## Architecture Impact

### Development Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph BuildConfig ["BUILD CONFIG"]
        direction LR
        PYPROJECT["● pyproject.toml<br/>━━━━━━━━━━<br/>hatchling backend<br/>uv package manager<br/>api-simulator: sys_platform==linux"]
        UVLOCK["● uv.lock<br/>━━━━━━━━━━<br/>Resolved deps<br/>marker: sys_platform==linux<br/>and extra==dev"]
    end

    subgraph DevDeps ["DEV DEPENDENCIES"]
        direction TB
        PYTEST_CORE["pytest ≥9.0 + plugins<br/>━━━━━━━━━━<br/>pytest-asyncio (auto mode)<br/>pytest-xdist (-n 4)<br/>pytest-httpx / pytest-timeout"]
        APISIM["api-simulator<br/>━━━━━━━━━━<br/>git source: TalonT-Org<br/>sys_platform == 'linux'<br/>provides mock_http_server fixture"]
        RUFF["ruff ≥0.15<br/>━━━━━━━━━━<br/>format + lint (--fix)<br/>target: py311 / line 99"]
    end

    subgraph QualityGates ["QUALITY GATES (pre-commit)"]
        direction TB
        FMT["ruff-format<br/>━━━━━━━━━━<br/>READ source<br/>WRITE formatted files"]
        LINT["ruff check --fix<br/>━━━━━━━━━━<br/>READ source<br/>WRITE auto-fixed source"]
        TYPES["mypy<br/>━━━━━━━━━━<br/>READ src/<br/>REPORT only<br/>--ignore-missing-imports"]
        LOCKCHK["uv-lock-check<br/>━━━━━━━━━━<br/>READ pyproject.toml + uv.lock<br/>REPORT drift"]
        SECRETS["gitleaks v8.30<br/>━━━━━━━━━━<br/>READ staged files<br/>REPORT secrets"]
    end

    subgraph TestFramework ["TEST FRAMEWORK"]
        direction TB
        CONFTEST["tests/conftest.py<br/>━━━━━━━━━━<br/>isolated_home (autouse)<br/>structlog → null<br/>anyio_backend=asyncio<br/>layer-marker enforcement"]
        EXEC_CONF["tests/execution/conftest.py<br/>━━━━━━━━━━<br/>isolated_tracing_config<br/>merge_group_only_repo_state"]
        QUOTAHTTP["● tests/execution/test_quota_http.py<br/>━━━━━━━━━━<br/>12 HTTP integration tests<br/>skipif(sys.platform != linux)<br/>importorskip(api_simulator.http)<br/>pytest.mark.layer(execution)"]
        METACHECK["● tests/infra/test_pyproject_metadata.py<br/>━━━━━━━━━━<br/>release metadata assertions<br/>+ test_api_simulator_dev_dep_is_linux_only<br/>verifies sys_platform+linux in marker"]
    end

    subgraph Taskfile ["TASK RUNNER (Taskfile.yml)"]
        direction TB
        TESTALL["task test-all<br/>━━━━━━━━━━<br/>lint-imports → pytest<br/>-n 4, excl. smoke/canary"]
        TESTCHECK["task test-check<br/>━━━━━━━━━━<br/>automation: TEST_RESULT=PASS/FAIL<br/>correct PIPESTATUS capture"]
        EP["autoskillit (entry point)<br/>━━━━━━━━━━<br/>autoskillit.cli:main<br/>console script"]
    end

    %% FLOWS %%
    PYPROJECT -->|"uv lock"| UVLOCK
    PYPROJECT -->|"declares linux-only"| APISIM
    PYPROJECT -->|"dev deps"| PYTEST_CORE
    PYPROJECT -->|"dev deps"| RUFF

    UVLOCK -->|"resolved marker"| APISIM

    APISIM -->|"mock_http_server fixture<br/>(Linux only)"| QUOTAHTTP
    PYTEST_CORE --> QUOTAHTTP
    PYTEST_CORE --> METACHECK
    CONFTEST --> QUOTAHTTP
    CONFTEST --> METACHECK
    EXEC_CONF --> QUOTAHTTP

    PYPROJECT -->|"reads for validation"| METACHECK

    RUFF --> FMT
    RUFF --> LINT
    FMT --> LINT
    LINT --> TYPES
    TYPES --> LOCKCHK
    LOCKCHK --> SECRETS

    PYTEST_CORE --> TESTALL
    TESTALL --> TESTCHECK
    PYPROJECT --> EP

    %% CLASS ASSIGNMENTS %%
    class PYPROJECT,UVLOCK phase;
    class PYTEST_CORE,RUFF handler;
    class APISIM integration;
    class FMT,LINT,TYPES,LOCKCHK,SECRETS detector;
    class CONFTEST,EXEC_CONF stateNode;
    class QUOTAHTTP,METACHECK cli;
    class TESTALL,TESTCHECK phase;
    class EP output;
```

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% BUILD / CONFIG LAYER %%
    subgraph BuildConfig ["BUILD / CONFIG (● Modified)"]
        direction LR
        PYPROJECT["● pyproject.toml<br/>━━━━━━━━━━<br/>api-simulator dev dep<br/>+ sys_platform=='linux'"]
        UVLOCK["● uv.lock<br/>━━━━━━━━━━<br/>Platform-aware<br/>lock entries"]
    end

    %% EXTERNAL DEPENDENCIES %%
    subgraph ExtPlatformGated ["EXTERNAL — Platform-Gated (Linux only)"]
        direction LR
        APISIM["api-simulator<br/>━━━━━━━━━━<br/>Rust mock HTTP server<br/>(git dep, Linux binary)"]
    end

    subgraph ExtCrossPlatform ["EXTERNAL — Cross-platform"]
        direction LR
        HTTPX["httpx<br/>━━━━━━━━━━<br/>Async HTTP client<br/>(runtime dep)"]
        PYTEST["pytest / pytest-asyncio<br/>━━━━━━━━━━<br/>Test framework"]
    end

    %% L0 CORE %%
    subgraph CoreLayer ["L0 — CORE (unchanged)"]
        direction LR
        CORE_LOG["core/logging.py<br/>━━━━━━━━━━<br/>get_logger"]
        CORE_IO["core/io.py<br/>━━━━━━━━━━<br/>write_versioned_json"]
    end

    %% L1 EXECUTION %%
    subgraph ExecutionLayer ["L1 — EXECUTION"]
        direction LR
        QUOTA["execution/quota.py<br/>━━━━━━━━━━<br/>check_and_sleep_if_needed<br/>_fetch_quota"]
        RECORDING["execution/recording.py<br/>━━━━━━━━━━<br/>RecordingSubprocessRunner<br/>ReplayingSubprocessRunner<br/>build_replay_runner"]
    end

    %% L3 TESTS %%
    subgraph TestLayer ["L3 — TESTS (● Modified)"]
        direction LR
        TEST_QUOTA["● tests/execution/<br/>test_quota_http.py<br/>━━━━━━━━━━<br/>pytest.importorskip<br/>+ skipif linux guard<br/>@layer('execution')"]
        TEST_META["● tests/infra/<br/>test_pyproject_metadata.py<br/>━━━━━━━━━━<br/>Regression guard:<br/>sys_platform marker check"]
    end

    %% DEPENDENCY EDGES %%

    %% pyproject controls what gets installed %%
    PYPROJECT -->|"declares dev dep<br/>(sys_platform=='linux')"| APISIM
    PYPROJECT -->|"declares dev dep<br/>(cross-platform)"| PYTEST
    PYPROJECT -->|"declares runtime dep"| HTTPX
    UVLOCK -->|"locks platform-aware<br/>resolution of"| APISIM

    %% execution/quota.py imports %%
    QUOTA -->|"imports"| HTTPX
    QUOTA -->|"imports"| CORE_LOG
    QUOTA -->|"imports"| CORE_IO

    %% execution/recording.py imports %%
    RECORDING -->|"TYPE_CHECKING only<br/>(no runtime cost)"| APISIM
    RECORDING -.->|"deferred import<br/>try/except ImportError<br/>(only if REPLAY_SCENARIO set)"| APISIM

    %% tests import %%
    TEST_QUOTA -->|"importorskip<br/>(skips on non-Linux)"| APISIM
    TEST_QUOTA -->|"imports under test"| QUOTA
    TEST_QUOTA -->|"test framework"| PYTEST
    TEST_META -->|"reads"| PYPROJECT
    TEST_META -->|"test framework"| PYTEST

    %% CLASS ASSIGNMENTS %%
    class PYPROJECT,UVLOCK output;
    class APISIM integration;
    class HTTPX,PYTEST stateNode;
    class CORE_LOG,CORE_IO handler;
    class QUOTA,RECORDING phase;
    class TEST_QUOTA,TEST_META detector;
```

Closes #954

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260416-094758-235321/.autoskillit/temp/make-plan/gate_api_simulator_linux_plan_2026-04-16_094900.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 129 | 8.8k | 567.8k | 51.1k | 1 | 2m 21s |
| review | 68 | 5.8k | 215.9k | 30.6k | 1 | 3m 26s |
| verify | 116 | 8.7k | 522.3k | 37.4k | 1 | 2m 53s |
| implement | 116 | 5.2k | 398.7k | 25.2k | 1 | 1m 49s |
| prepare_pr | 68 | 3.6k | 191.9k | 19.3k | 1 | 1m 12s |
| run_arch_lenses | 122 | 9.6k | 328.7k | 55.5k | 2 | 5m 1s |
| compose_pr | 67 | 5.5k | 211.4k | 24.2k | 1 | 1m 42s |
| **Total** | 686 | 47.3k | 2.4M | 243.2k | | 18m 27s |