### PR TITLE
Record Claude Code, AutoSkillit, and Plugin Versions in Session Telemetry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,7 @@ generic_automation_mcp/
 │   ├── _type_helpers.py
 │   ├── _claude_env.py       #   IDE-scrubbing canonical env builder for claude subprocesses
 │   ├── _terminal_table.py   #   L0 color-agnostic terminal table primitive
+│   ├── _version_snapshot.py #   Process-scoped version snapshot for session telemetry (lru_cache'd)
 │   ├── branch_guard.py
 │   ├── claude_conventions.py #  Skill discovery directory layout constants
 │   ├── github_url.py        #   parse_github_repo

--- a/src/autoskillit/core/__init__.py
+++ b/src/autoskillit/core/__init__.py
@@ -246,4 +246,6 @@ __all__ = [
     "TokenLog",
     "WorkspaceManager",
     "truncate_text",
+    # _version_snapshot
+    "collect_version_snapshot",
 ]

--- a/src/autoskillit/core/__init__.py
+++ b/src/autoskillit/core/__init__.py
@@ -9,6 +9,7 @@ from ._claude_env import build_claude_env
 from ._terminal_table import TerminalColumn as TerminalColumn
 from ._terminal_table import _render_gfm_table as _render_gfm_table
 from ._terminal_table import _render_terminal_table as _render_terminal_table
+from ._version_snapshot import collect_version_snapshot as collect_version_snapshot
 from .branch_guard import is_protected_branch
 from .claude_conventions import ClaudeDirectoryConventions, LayoutError, validate_add_dir
 from .github_url import _parse_issue_ref as _parse_issue_ref

--- a/src/autoskillit/core/_version_snapshot.py
+++ b/src/autoskillit/core/_version_snapshot.py
@@ -124,7 +124,8 @@ def _plugins() -> list[dict[str, Any]]:
         for ref, installs in plugins.items():
             if not isinstance(installs, list) or not installs:
                 continue
-            info = installs[0] if isinstance(installs[0], dict) else {}
+            first = installs[0]
+            info = first if isinstance(first, dict) else {}
             entry: dict[str, Any] = {"ref": ref}
             if "version" in info:
                 entry["version"] = info["version"]

--- a/src/autoskillit/core/_version_snapshot.py
+++ b/src/autoskillit/core/_version_snapshot.py
@@ -13,6 +13,7 @@ import functools
 import importlib.metadata
 import json
 import logging
+import os
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -84,8 +85,6 @@ def _claude_code_version() -> str:
     launched the server is queried rather than whatever `claude` resolves to in
     the current PATH.
     """
-    import os
-
     exec_path = os.environ.get("CLAUDE_CODE_EXECPATH") or "claude"
     try:
         result = subprocess.run(

--- a/src/autoskillit/core/_version_snapshot.py
+++ b/src/autoskillit/core/_version_snapshot.py
@@ -1,0 +1,126 @@
+"""Process-scoped version snapshot for session telemetry (L0).
+
+collect_version_snapshot() is cached with lru_cache(maxsize=1) so that the
+subprocess call to `claude --version` and filesystem reads happen once per
+process lifetime. Callers must call .cache_clear() in tests that need isolation.
+
+Never raises — all helpers silently return empty fallbacks on any error.
+"""
+from __future__ import annotations
+
+import functools
+import importlib.metadata
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+@functools.lru_cache(maxsize=1)
+def collect_version_snapshot() -> dict[str, Any]:
+    """Return a static version snapshot for the current process.
+
+    Fields:
+        autoskillit_version: installed package version string.
+        install_type: "git-vcs" | "local-editable" | "local-path" | "unknown".
+        commit_id: git commit hash when install_type is "git-vcs", else None.
+        claude_code_version: output of `claude --version`, or "".
+        plugins: list of {"ref": ..., "version"?: ...} dicts
+            read from ~/.claude/plugins/installed_plugins.json.
+    """
+    install = _install_info()
+    return {
+        "autoskillit_version": _autoskillit_version(),
+        "install_type": install.get("install_type", "unknown"),
+        "commit_id": install.get("commit_id"),
+        "claude_code_version": _claude_code_version(),
+        "plugins": _plugins(),
+    }
+
+
+def _autoskillit_version() -> str:
+    try:
+        return importlib.metadata.version("autoskillit")
+    except Exception:
+        return ""
+
+
+def _install_info() -> dict[str, Any]:
+    """Parse direct_url.json to classify the autoskillit install."""
+    try:
+        dist = importlib.metadata.Distribution.from_name("autoskillit")
+        raw = dist.read_text("direct_url.json")
+        if not raw:
+            return {"install_type": "unknown", "commit_id": None}
+        data = json.loads(raw)
+        vcs = data.get("vcs_info", {})
+        if isinstance(vcs, dict) and vcs.get("vcs") == "git":
+            return {
+                "install_type": "git-vcs",
+                "commit_id": vcs.get("commit_id") or None,
+            }
+        dir_info = data.get("dir_info", {})
+        url = data.get("url", "")
+        if isinstance(dir_info, dict) and dir_info.get("editable") is True:
+            return {"install_type": "local-editable", "commit_id": None}
+        if isinstance(url, str) and url.startswith("file://"):
+            return {"install_type": "local-path", "commit_id": None}
+        return {"install_type": "unknown", "commit_id": None}
+    except Exception:
+        return {"install_type": "unknown", "commit_id": None}
+
+
+def _claude_code_version() -> str:
+    """Run `claude --version` and return the stripped output, or "" on error.
+
+    Prefers CLAUDE_CODE_EXECPATH (injected by Claude Code into the MCP server
+    environment) over bare `claude` on PATH so that the binary that actually
+    launched the server is queried rather than whatever `claude` resolves to in
+    the current PATH.
+    """
+    import os
+
+    exec_path = os.environ.get("CLAUDE_CODE_EXECPATH") or "claude"
+    try:
+        result = subprocess.run(
+            [exec_path, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return result.stdout.strip() or result.stderr.strip()
+    except subprocess.TimeoutExpired:
+        return ""
+    except Exception:
+        return ""
+
+
+def _plugins() -> list[dict[str, Any]]:
+    """Read installed_plugins.json and return a list of plugin descriptors.
+
+    The real schema produced by `claude plugin install` is:
+        {"version": 2, "plugins": {"<ref>": [{"version": "...", ...}, ...]}}
+
+    Each ref maps to a **list** of install-scope objects; each object carries a
+    "version" field. We use the first entry (index 0) per ref.
+    """
+    try:
+        path = Path.home() / ".claude" / "plugins" / "installed_plugins.json"
+        if not path.exists():
+            return []
+        data = json.loads(path.read_text(encoding="utf-8"))
+        plugins: dict[str, Any] = data.get("plugins", {})
+        if not isinstance(plugins, dict):
+            return []
+        entries = []
+        for ref, installs in plugins.items():
+            if not isinstance(installs, list) or not installs:
+                continue
+            info = installs[0] if isinstance(installs[0], dict) else {}
+            entry: dict[str, Any] = {"ref": ref}
+            if "version" in info:
+                entry["version"] = info["version"]
+            entries.append(entry)
+        return entries
+    except Exception:
+        return []

--- a/src/autoskillit/core/_version_snapshot.py
+++ b/src/autoskillit/core/_version_snapshot.py
@@ -93,6 +93,8 @@ def _claude_code_version() -> str:
             text=True,
             timeout=5,
         )
+        if result.returncode != 0:
+            _logger.warning("claude --version exited with code %d", result.returncode)
         return result.stdout.strip() or result.stderr.strip()
     except subprocess.TimeoutExpired:
         return ""

--- a/src/autoskillit/core/_version_snapshot.py
+++ b/src/autoskillit/core/_version_snapshot.py
@@ -6,14 +6,18 @@ process lifetime. Callers must call .cache_clear() in tests that need isolation.
 
 Never raises — all helpers silently return empty fallbacks on any error.
 """
+
 from __future__ import annotations
 
 import functools
 import importlib.metadata
 import json
+import logging
 import subprocess
 from pathlib import Path
 from typing import Any
+
+_logger = logging.getLogger(__name__)  # noqa: TID251 — L0 module, no autoskillit imports allowed
 
 
 @functools.lru_cache(maxsize=1)
@@ -42,6 +46,7 @@ def _autoskillit_version() -> str:
     try:
         return importlib.metadata.version("autoskillit")
     except Exception:
+        _logger.warning("Failed to read autoskillit version", exc_info=True)
         return ""
 
 
@@ -67,6 +72,7 @@ def _install_info() -> dict[str, Any]:
             return {"install_type": "local-path", "commit_id": None}
         return {"install_type": "unknown", "commit_id": None}
     except Exception:
+        _logger.warning("Failed to parse install info from direct_url.json", exc_info=True)
         return {"install_type": "unknown", "commit_id": None}
 
 
@@ -92,6 +98,7 @@ def _claude_code_version() -> str:
     except subprocess.TimeoutExpired:
         return ""
     except Exception:
+        _logger.warning("Failed to run claude --version", exc_info=True)
         return ""
 
 
@@ -123,4 +130,5 @@ def _plugins() -> list[dict[str, Any]]:
             entries.append(entry)
         return entries
     except Exception:
+        _logger.warning("Failed to read installed_plugins.json", exc_info=True)
         return []

--- a/src/autoskillit/execution/headless.py
+++ b/src/autoskillit/execution/headless.py
@@ -1189,8 +1189,8 @@ async def run_headless_core(
                 flush_session_log,
             )
 
-            _model_id = _primary_model_identifier(skill_result.token_usage)
             try:
+                _model_id = _primary_model_identifier(skill_result.token_usage)
                 flush_session_log(
                     log_dir=ctx.config.linux_tracing.log_dir,
                     cwd=cwd,

--- a/src/autoskillit/execution/headless.py
+++ b/src/autoskillit/execution/headless.py
@@ -1184,13 +1184,9 @@ async def run_headless_core(
         audit_record = new_audit_records[0] if new_audit_records else None
 
         if result.proc_snapshots is not None or not skill_result.success or bool(step_name):
-            from autoskillit.execution.session_log import (
-                _primary_model_identifier,
-                flush_session_log,
-            )
+            from autoskillit.execution.session_log import flush_session_log
 
             try:
-                _model_id = _primary_model_identifier(skill_result.token_usage)
                 flush_session_log(
                     log_dir=ctx.config.linux_tracing.log_dir,
                     cwd=cwd,
@@ -1227,7 +1223,6 @@ async def run_headless_core(
                     else "",
                     last_stop_reason=skill_result.last_stop_reason,
                     versions=_versions,
-                    model_identifier=_model_id,
                 )
             except Exception:
                 logger.debug("session_log_flush_failed", exc_info=True)

--- a/src/autoskillit/execution/headless.py
+++ b/src/autoskillit/execution/headless.py
@@ -35,6 +35,7 @@ from autoskillit.core import (
     ValidatedAddDir,
     WriteBehaviorSpec,
     claude_code_project_dir,
+    collect_version_snapshot,
     get_logger,
     is_git_worktree,
     load_yaml,
@@ -1039,6 +1040,7 @@ async def run_headless_core(
         linux_tracing_cfg = ctx.config.linux_tracing
         _start_ts = datetime.now(UTC).isoformat()
         _start_mono = time.monotonic()
+        _versions = collect_version_snapshot()
 
         _clone_snapshot = None
         if is_worktree_skill(original_skill_command) and not is_git_worktree(Path(cwd)):
@@ -1084,6 +1086,7 @@ async def run_headless_core(
                     proc_snapshots=None,
                     termination_reason="CRASHED",
                     exception_text=_exc_text,
+                    versions=_versions,
                 )
             except Exception:
                 logger.debug("flush_session_log during crash failed", exc_info=True)
@@ -1115,6 +1118,7 @@ async def run_headless_core(
                         proc_snapshots=None,
                         termination_reason="CANCELLED",
                         exception_text=_exc_text,
+                        versions=_versions,
                     )
             except Exception:
                 logger.debug("flush_session_log during cancel failed", exc_info=True)
@@ -1180,8 +1184,12 @@ async def run_headless_core(
         audit_record = new_audit_records[0] if new_audit_records else None
 
         if result.proc_snapshots is not None or not skill_result.success or bool(step_name):
-            from autoskillit.execution.session_log import flush_session_log
+            from autoskillit.execution.session_log import (
+                _primary_model_identifier,
+                flush_session_log,
+            )
 
+            _model_id = _primary_model_identifier(skill_result.token_usage)
             try:
                 flush_session_log(
                     log_dir=ctx.config.linux_tracing.log_dir,
@@ -1218,6 +1226,8 @@ async def run_headless_core(
                     )
                     else "",
                     last_stop_reason=skill_result.last_stop_reason,
+                    versions=_versions,
+                    model_identifier=_model_id,
                 )
             except Exception:
                 logger.debug("session_log_flush_failed", exc_info=True)

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -34,6 +34,21 @@ from autoskillit.execution.linux_tracing import (
 logger = get_logger(__name__)
 
 _MAX_SESSIONS = 500
+
+
+def _primary_model_identifier(token_usage: dict[str, Any] | None) -> str:
+    """Return the model name with the most total tokens from model_breakdown.
+
+    Returns "" when token_usage is absent or model_breakdown is empty.
+    """
+    if not token_usage:
+        return ""
+    mb = token_usage.get("model_breakdown", {})
+    if not isinstance(mb, dict) or not mb:
+        return ""
+    return max(mb, key=lambda m: sum(mb[m].values()) if isinstance(mb[m], dict) else 0)
+
+
 _CLEAR_MARKER_FILENAME = ".telemetry_cleared_at"
 
 
@@ -106,6 +121,8 @@ def flush_session_log(
     orphaned_tool_result: bool = False,
     raw_stdout: str = "",
     last_stop_reason: str = "",
+    versions: dict[str, Any] | None = None,
+    model_identifier: str = "",
 ) -> None:
     """Flush session diagnostics to disk.
 
@@ -291,6 +308,11 @@ def flush_session_log(
         "request_ids": _cb_request_ids,
         "turn_timestamps": _cb_turn_timestamps,
     }
+    if versions is not None:
+        summary["versions"] = {
+            **versions,
+            "model_identifier": model_identifier,
+        }
     summary_path = session_dir / "summary.json"
     atomic_write(summary_path, json.dumps(summary, sort_keys=True, indent=2) + "\n")
 
@@ -352,6 +374,8 @@ def flush_session_log(
         "write_call_count": write_call_count,
         "tracked_comm": _effective_tracked_comm,
         "tracked_comm_drift": _tracked_comm_drift,
+        "autoskillit_version": versions.get("autoskillit_version", "") if versions else "",
+        "claude_code_version": versions.get("claude_code_version", "") if versions else "",
     }
     index_path = log_root / "sessions.jsonl"
     with index_path.open("a") as f:

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -309,9 +309,10 @@ def flush_session_log(
         "turn_timestamps": _cb_turn_timestamps,
     }
     if versions is not None:
+        effective_model_id = model_identifier or _primary_model_identifier(token_usage)
         summary["versions"] = {
             **versions,
-            "model_identifier": model_identifier,
+            "model_identifier": effective_model_id,
         }
     summary_path = session_dir / "summary.json"
     atomic_write(summary_path, json.dumps(summary, sort_keys=True, indent=2) + "\n")

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -673,7 +673,9 @@ def test_no_subpackage_exceeds_10_files() -> None:
         _claude_env.py adds the canonical IDE-scrubbing env builder for all
         claude subprocess launches. kitchen_state.py adds the stdlib-only
         kitchen-open session marker reader for hook subprocesses.
-        Exempt at 17 files.
+        _version_snapshot.py adds the process-scoped version snapshot for session
+        telemetry (collect_version_snapshot, lru_cache'd).
+        Exempt at 19 files.
       cli/ — REQ-CNST-003-E5: cli/ retains _terminal_table.py as a re-export shim
         for backward-compatible cli/ imports; canonical implementation lives in
         core/_terminal_table.py. Also contains _terminal.py — the terminal state
@@ -696,7 +698,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "server": 19,
         "recipe": 34,
         "execution": 26,
-        "core": 18,
+        "core": 19,
         "cli": 20,
         "hooks": 20,
     }

--- a/tests/core/test_version_snapshot.py
+++ b/tests/core/test_version_snapshot.py
@@ -1,9 +1,9 @@
 """Tests for core/_version_snapshot.py."""
+
 from __future__ import annotations
 
 import json
 import subprocess
-from pathlib import Path
 
 import pytest
 
@@ -90,9 +90,7 @@ def test_plugins_reads_version(monkeypatch, tmp_path):
             "ref": [{"version": "1.0", "extra": "ignored"}],
         },
     }
-    (plugins_dir / "installed_plugins.json").write_text(
-        json.dumps(plugin_data), encoding="utf-8"
-    )
+    (plugins_dir / "installed_plugins.json").write_text(json.dumps(plugin_data), encoding="utf-8")
     monkeypatch.setattr(mod.Path, "home", classmethod(lambda cls: tmp_path))
     result = collect_version_snapshot()
     assert len(result["plugins"]) == 1

--- a/tests/core/test_version_snapshot.py
+++ b/tests/core/test_version_snapshot.py
@@ -1,0 +1,113 @@
+"""Tests for core/_version_snapshot.py."""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from autoskillit.core._version_snapshot import collect_version_snapshot
+
+pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
+
+
+@pytest.fixture(autouse=True)
+def _clear_snapshot_cache():
+    collect_version_snapshot.cache_clear()
+    yield
+    collect_version_snapshot.cache_clear()
+
+
+def test_collect_version_snapshot_returns_required_keys():
+    result = collect_version_snapshot()
+    assert set(result.keys()) == {
+        "autoskillit_version",
+        "install_type",
+        "commit_id",
+        "claude_code_version",
+        "plugins",
+    }
+
+
+def test_collect_version_snapshot_is_cached():
+    first = collect_version_snapshot()
+    second = collect_version_snapshot()
+    assert first is second
+
+
+def test_collect_version_snapshot_cache_clear_works():
+    first = collect_version_snapshot()
+    collect_version_snapshot.cache_clear()
+    second = collect_version_snapshot()
+    assert first is not second
+
+
+def test_autoskillit_version_is_nonempty_string():
+    result = collect_version_snapshot()
+    assert isinstance(result["autoskillit_version"], str)
+    assert result["autoskillit_version"] != ""
+
+
+def test_claude_code_version_graceful_on_subprocess_error(monkeypatch):
+    import autoskillit.core._version_snapshot as mod
+
+    def _raise(*args, **kwargs):
+        raise FileNotFoundError("claude not found")
+
+    monkeypatch.setattr(mod.subprocess, "run", _raise)
+    result = collect_version_snapshot()
+    assert result["claude_code_version"] == ""
+
+
+def test_claude_code_version_graceful_on_timeout(monkeypatch):
+    import autoskillit.core._version_snapshot as mod
+
+    def _raise(*args, **kwargs):
+        raise subprocess.TimeoutExpired("claude", 5)
+
+    monkeypatch.setattr(mod.subprocess, "run", _raise)
+    result = collect_version_snapshot()
+    assert result["claude_code_version"] == ""
+
+
+def test_plugins_graceful_when_file_absent(monkeypatch, tmp_path):
+    import autoskillit.core._version_snapshot as mod
+
+    monkeypatch.setattr(mod.Path, "home", classmethod(lambda cls: tmp_path))
+    result = collect_version_snapshot()
+    assert result["plugins"] == []
+
+
+def test_plugins_reads_version(monkeypatch, tmp_path):
+    import autoskillit.core._version_snapshot as mod
+
+    plugins_dir = tmp_path / ".claude" / "plugins"
+    plugins_dir.mkdir(parents=True)
+    plugin_data = {
+        "version": 2,
+        "plugins": {
+            "ref": [{"version": "1.0", "extra": "ignored"}],
+        },
+    }
+    (plugins_dir / "installed_plugins.json").write_text(
+        json.dumps(plugin_data), encoding="utf-8"
+    )
+    monkeypatch.setattr(mod.Path, "home", classmethod(lambda cls: tmp_path))
+    result = collect_version_snapshot()
+    assert len(result["plugins"]) == 1
+    entry = result["plugins"][0]
+    assert entry["ref"] == "ref"
+    assert entry["version"] == "1.0"
+    assert "name" not in entry
+
+
+def test_plugins_graceful_on_corrupt_json(monkeypatch, tmp_path):
+    import autoskillit.core._version_snapshot as mod
+
+    plugins_dir = tmp_path / ".claude" / "plugins"
+    plugins_dir.mkdir(parents=True)
+    (plugins_dir / "installed_plugins.json").write_text("not valid json", encoding="utf-8")
+    monkeypatch.setattr(mod.Path, "home", classmethod(lambda cls: tmp_path))
+    result = collect_version_snapshot()
+    assert result["plugins"] == []

--- a/tests/execution/test_session_log.py
+++ b/tests/execution/test_session_log.py
@@ -1222,3 +1222,67 @@ def test_proc_trace_preserves_exit_snapshot_event(tmp_path):
     assert rows[0]["event"] == "snapshot"
     assert rows[1]["event"] == "snapshot"
     assert rows[2]["event"] == "exit_snapshot"
+
+
+# --- Versions block tests ---
+
+_VERSIONS = {
+    "autoskillit_version": "1.2.3",
+    "install_type": "local-editable",
+    "commit_id": None,
+    "claude_code_version": "1.0.5",
+    "plugins": [],
+}
+
+
+def test_summary_json_includes_versions_block(tmp_path):
+    _flush(tmp_path, session_id="vs-001", versions=_VERSIONS)
+    summary = json.loads((tmp_path / "sessions" / "vs-001" / "summary.json").read_text())
+    assert "versions" in summary
+    assert summary["versions"]["autoskillit_version"] == "1.2.3"
+    assert summary["versions"]["claude_code_version"] == "1.0.5"
+
+
+def test_summary_json_versions_includes_model_identifier(tmp_path):
+    _flush(tmp_path, session_id="vs-002", versions=_VERSIONS, model_identifier="claude-opus-4")
+    summary = json.loads((tmp_path / "sessions" / "vs-002" / "summary.json").read_text())
+    assert summary["versions"]["model_identifier"] == "claude-opus-4"
+
+
+def test_summary_json_omits_versions_when_not_passed(tmp_path):
+    _flush(tmp_path, session_id="vs-003")
+    summary = json.loads((tmp_path / "sessions" / "vs-003" / "summary.json").read_text())
+    assert "versions" not in summary
+
+
+def test_sessions_jsonl_includes_autoskillit_version(tmp_path):
+    _flush(tmp_path, session_id="vs-004", versions=_VERSIONS)
+    entries = [
+        json.loads(line)
+        for line in (tmp_path / "sessions.jsonl").read_text().splitlines()
+        if line.strip()
+    ]
+    entry = next(e for e in entries if e["session_id"] == "vs-004")
+    assert entry["autoskillit_version"] == "1.2.3"
+
+
+def test_sessions_jsonl_includes_claude_code_version(tmp_path):
+    _flush(tmp_path, session_id="vs-005", versions=_VERSIONS)
+    entries = [
+        json.loads(line)
+        for line in (tmp_path / "sessions.jsonl").read_text().splitlines()
+        if line.strip()
+    ]
+    entry = next(e for e in entries if e["session_id"] == "vs-005")
+    assert entry["claude_code_version"] == "1.0.5"
+
+
+def test_sessions_jsonl_autoskillit_version_empty_when_no_versions(tmp_path):
+    _flush(tmp_path, session_id="vs-006")
+    entries = [
+        json.loads(line)
+        for line in (tmp_path / "sessions.jsonl").read_text().splitlines()
+        if line.strip()
+    ]
+    entry = next(e for e in entries if e["session_id"] == "vs-006")
+    assert entry["autoskillit_version"] == ""

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -111,9 +111,9 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # core/io.py — write_versioned_json itself (the blessed helper) uses atomic_write+json.dumps
     ("src/autoskillit/core/io.py", 118),
     # session_log.py — summary dict, token_usage dict, step_timing dict
-    ("src/autoskillit/execution/session_log.py", 295),
-    ("src/autoskillit/execution/session_log.py", 314),
     ("src/autoskillit/execution/session_log.py", 317),
+    ("src/autoskillit/execution/session_log.py", 336),
+    ("src/autoskillit/execution/session_log.py", 339),
     # migration/store.py — failure store dicts
     ("src/autoskillit/migration/store.py", 54),
     ("src/autoskillit/migration/store.py", 64),
@@ -212,8 +212,8 @@ class TestSchemaVersionConvention:
         """List-payload sites are included since the AST scanner can't distinguish return types."""
         # These sites write list payloads through function calls but are caught by the scanner
         list_sites = [
-            ("src/autoskillit/execution/session_log.py", 295),
             ("src/autoskillit/execution/session_log.py", 317),
+            ("src/autoskillit/execution/session_log.py", 336),
             ("src/autoskillit/smoke_utils.py", 87),
             ("src/autoskillit/smoke_utils.py", 290),
         ]

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -111,9 +111,9 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # core/io.py — write_versioned_json itself (the blessed helper) uses atomic_write+json.dumps
     ("src/autoskillit/core/io.py", 118),
     # session_log.py — summary dict, token_usage dict, step_timing dict
-    ("src/autoskillit/execution/session_log.py", 317),
-    ("src/autoskillit/execution/session_log.py", 336),
-    ("src/autoskillit/execution/session_log.py", 339),
+    ("src/autoskillit/execution/session_log.py", 318),
+    ("src/autoskillit/execution/session_log.py", 337),
+    ("src/autoskillit/execution/session_log.py", 340),
     # migration/store.py — failure store dicts
     ("src/autoskillit/migration/store.py", 54),
     ("src/autoskillit/migration/store.py", 64),
@@ -212,8 +212,8 @@ class TestSchemaVersionConvention:
         """List-payload sites are included since the AST scanner can't distinguish return types."""
         # These sites write list payloads through function calls but are caught by the scanner
         list_sites = [
-            ("src/autoskillit/execution/session_log.py", 317),
-            ("src/autoskillit/execution/session_log.py", 336),
+            ("src/autoskillit/execution/session_log.py", 318),
+            ("src/autoskillit/execution/session_log.py", 337),
             ("src/autoskillit/smoke_utils.py", 87),
             ("src/autoskillit/smoke_utils.py", 290),
         ]


### PR DESCRIPTION
## Summary

Every headless session already writes `summary.json` and appends to the `sessions.jsonl`
index. This plan adds a `versions` block to `summary.json` and two fields
(`autoskillit_version`, `claude_code_version`) to each `sessions.jsonl` index entry.

Version collection lives in a new `core/_version_snapshot.py` module (L0). It is
cached with `functools.lru_cache` so the subprocess call to `claude --version` and
file reads happen once per process, not once per session. `flush_session_log` accepts
the snapshot as a caller-supplied parameter; `headless.py` collects it and passes it
through on every `flush_session_log` call site.

## Architecture Impact

### Data Lineage Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph Origins ["Data Origins"]
        direction TB
        META["importlib.metadata<br/>━━━━━━━━━━<br/>autoskillit package<br/>direct_url.json"]
        CLAUDE_CLI["claude --version<br/>━━━━━━━━━━<br/>subprocess stdout<br/>timeout: 5s"]
        PLUGINS_FILE["~/.claude/plugins/<br/>installed_plugins.json<br/>━━━━━━━━━━<br/>plugin ref + version"]
        NDJSON["Claude Code<br/>NDJSON stdout<br/>━━━━━━━━━━<br/>result/assistant records"]
    end

    subgraph Snapshot ["Version Snapshot — NEW"]
        direction TB
        VS["★ collect_version_snapshot()<br/>core/_version_snapshot.py<br/>━━━━━━━━━━<br/>lru_cache per process<br/>autoskillit_version<br/>install_type · commit_id<br/>claude_code_version<br/>plugins list"]
    end

    subgraph Orchestration ["Session Orchestration — MODIFIED"]
        direction TB
        SESSION["ClaudeSessionResult<br/>execution/session.py<br/>━━━━━━━━━━<br/>subtype · is_error<br/>token_usage · session_id<br/>assistant_messages"]
        HEADLESS["● run_headless_core()<br/>execution/headless.py<br/>━━━━━━━━━━<br/>captures _versions before<br/>subprocess launch<br/>threads versions alongside result"]
    end

    subgraph Logger ["Session Logger — MODIFIED"]
        FLUSH["● flush_session_log()<br/>execution/session_log.py<br/>━━━━━━━━━━<br/>merges versions dict<br/>+ model_identifier<br/>into two storage targets"]
    end

    subgraph PrimaryStorage ["Primary Storage (Read-Write)"]
        direction TB
        SESS_JSONL[("sessions.jsonl<br/>━━━━━━━━━━<br/>~/.local/.../autoskillit/<br/>autoskillit_version ✓<br/>claude_code_version ✓<br/>append-only index")]
        TOKEN_JSON[("token_usage.json<br/>━━━━━━━━━━<br/>per session dir<br/>read back on server restart")]
        AUDIT_JSON[("audit_log.json<br/>━━━━━━━━━━<br/>per session dir<br/>read back on server restart")]
    end

    subgraph Artifacts ["Write-Only Artifacts"]
        direction TB
        SUMMARY["summary.json<br/>━━━━━━━━━━<br/>full versions dict<br/>+ model_identifier<br/>+ pid · cwd · exit_code<br/>+ peak RSS · timing<br/>install_type · commit_id · plugins"]
        PROC["proc_trace.jsonl<br/>anomalies.jsonl<br/>raw_stdout.jsonl<br/>crash_exception.txt<br/>━━━━━━━━━━<br/>diagnostic only"]
    end

    %% DATA FLOWS %%
    META -->|"version + direct_url.json"| VS
    CLAUDE_CLI -->|"stdout text"| VS
    PLUGINS_FILE -->|"JSON parse"| VS

    VS -->|"_versions dict"| HEADLESS
    NDJSON -->|"parse_session_result()"| SESSION
    SESSION -->|"SkillResult"| HEADLESS

    HEADLESS -->|"versions= kwarg (normal + crash paths)"| FLUSH

    FLUSH -->|"append entry<br/>2 fields only"| SESS_JSONL
    FLUSH -->|"atomic write"| TOKEN_JSON
    FLUSH -->|"atomic write"| AUDIT_JSON
    FLUSH -.->|"write-only<br/>full versions + model_id"| SUMMARY
    FLUSH -.->|"write-only"| PROC

    %% CLASS ASSIGNMENTS %%
    class META,CLAUDE_CLI,PLUGINS_FILE,NDJSON cli;
    class VS newComponent;
    class SESSION,HEADLESS handler;
    class FLUSH phase;
    class SESS_JSONL,TOKEN_JSON,AUDIT_JSON stateNode;
    class SUMMARY,PROC output;
```

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph L0 ["L0 — CORE (zero autoskillit imports)"]
        direction LR
        VS["★ _version_snapshot.py<br/>━━━━━━━━━━<br/>collect_version_snapshot()<br/>lru_cache(maxsize=1)<br/>Never raises"]
        CORE["● core/__init__.py<br/>━━━━━━━━━━<br/>Re-exports<br/>collect_version_snapshot"]
    end

    subgraph L1_Exec ["L1 — EXECUTION"]
        direction TB
        HL["● execution/headless.py<br/>━━━━━━━━━━<br/>run_headless_core()<br/>Captures snapshot at<br/>session start"]
        SL["● execution/session_log.py<br/>━━━━━━━━━━<br/>flush_session_log()<br/>versions= param<br/>Writes to summary.json<br/>& sessions.jsonl index"]
    end

    subgraph EXT ["EXTERNAL (stdlib + third-party)"]
        direction LR
        STDLIB["stdlib<br/>━━━━━━━━━━<br/>importlib.metadata<br/>subprocess · json<br/>pathlib · os"]
        PSUTIL["psutil<br/>━━━━━━━━━━<br/>Process tracing"]
        ANYIO["anyio / structlog<br/>━━━━━━━━━━<br/>Async I/O + logging"]
    end

    subgraph ARTIFACTS ["DISK ARTIFACTS"]
        direction LR
        SUMM["summary.json<br/>━━━━━━━━━━<br/>versions.autoskillit_version<br/>versions.claude_code_version<br/>versions.plugins<br/>model_identifier"]
        IDX["sessions.jsonl<br/>━━━━━━━━━━<br/>autoskillit_version<br/>claude_code_version<br/>(index fields)"]
    end

    %% VALID DEPENDENCIES (downward) %%
    VS -->|"stdlib only"| STDLIB
    CORE -->|"re-exports"| VS
    HL -->|"from autoskillit.core import<br/>collect_version_snapshot"| CORE
    HL -->|"calls flush_session_log<br/>versions=_versions"| SL
    SL -->|"from autoskillit.core import<br/>atomic_write, get_logger"| CORE
    SL -->|"psutil.pid_exists"| PSUTIL
    HL -->|"anyio / structlog"| ANYIO

    %% WRITE PATHS %%
    SL -->|"atomic_write"| SUMM
    SL -->|"append"| IDX

    %% CLASS ASSIGNMENTS %%
    class VS newComponent;
    class CORE stateNode;
    class HL handler;
    class SL handler;
    class STDLIB,PSUTIL,ANYIO integration;
    class SUMM,IDX output;
```

### Operational Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ENTRY %%
    SKILL_CMD["● run_headless_core()<br/>━━━━━━━━━━<br/>execution/headless.py<br/>Session start"]

    subgraph VersionSources ["VERSION DATA SOURCES (read-only)"]
        direction TB
        PKG_META["importlib.metadata<br/>━━━━━━━━━━<br/>autoskillit version string<br/>direct_url.json → install_type<br/>commit_id (git-vcs only)"]
        CLAUDE_BIN["claude --version<br/>━━━━━━━━━━<br/>CLAUDE_CODE_EXECPATH env<br/>fallback: bare 'claude' on PATH<br/>5-second timeout"]
        PLUGINS_JSON["~/.claude/plugins/<br/>installed_plugins.json<br/>━━━━━━━━━━<br/>Plugin refs + versions<br/>(schema_version=2)"]
    end

    subgraph VersionSnapshot ["★ VERSION SNAPSHOT (new — core/_version_snapshot.py)"]
        direction TB
        SNAPSHOT["★ collect_version_snapshot()<br/>━━━━━━━━━━<br/>lru_cache(maxsize=1)<br/>Process-scoped, collected once<br/>Never raises — silent fallbacks"]
        SNAP_FIELDS["Snapshot fields:<br/>━━━━━━━━━━<br/>autoskillit_version<br/>install_type<br/>commit_id<br/>claude_code_version<br/>plugins: list of ref+version"]
    end

    subgraph CoreExports ["● core/__init__.py (modified)"]
        EXPORT["● collect_version_snapshot<br/>━━━━━━━━━━<br/>Re-exported as public API<br/>from ._version_snapshot"]
    end

    subgraph SessionTelemetry ["● SESSION LOG (execution/session_log.py — modified)"]
        direction TB
        FLUSH["● flush_session_log()<br/>━━━━━━━━━━<br/>+versions: dict param<br/>+model_identifier: str param"]
        SUMMARY["● summary.json<br/>━━━━━━━━━━<br/>versions{} block added:<br/>autoskillit_version<br/>install_type, commit_id<br/>claude_code_version<br/>plugins[], model_identifier"]
        INDEX["● sessions.jsonl index<br/>━━━━━━━━━━<br/>+autoskillit_version field<br/>+claude_code_version field<br/>Append-only, queryable"]
    end

    subgraph DiagnosticQuery ["OPERATOR QUERIES (read-only)"]
        direction LR
        Q1["jq '.versions' summary.json<br/>━━━━━━━━━━<br/>Full version snapshot<br/>for one session"]
        Q2["jq '{autoskillit_version,claude_code_version}'<br/>sessions.jsonl<br/>━━━━━━━━━━<br/>Version history across sessions"]
    end

    %% FLOWS %%
    PKG_META --> SNAPSHOT
    CLAUDE_BIN --> SNAPSHOT
    PLUGINS_JSON --> SNAPSHOT
    SNAPSHOT --> SNAP_FIELDS
    SNAP_FIELDS --> EXPORT
    EXPORT --> SKILL_CMD
    SKILL_CMD --> FLUSH
    FLUSH --> SUMMARY
    FLUSH --> INDEX
    SUMMARY --> Q1
    INDEX --> Q2

    %% CLASS ASSIGNMENTS %%
    class SKILL_CMD handler;
    class PKG_META,CLAUDE_BIN,PLUGINS_JSON phase;
    class SNAPSHOT,SNAP_FIELDS newComponent;
    class EXPORT stateNode;
    class FLUSH handler;
    class SUMMARY,INDEX output;
    class Q1,Q2 cli;
```

Closes #943

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260416-095438-935084/.autoskillit/temp/make-plan/record_versions_in_session_telemetry_plan_2026-04-16_100203.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 213 | 18.7k | 1.5M | 87.5k | 1 | 5m 48s |
| review | 60 | 5.7k | 168.0k | 36.4k | 1 | 3m 49s |
| verify | 124 | 14.3k | 687.1k | 52.9k | 1 | 4m 18s |
| implement | 334 | 21.9k | 2.0M | 59.5k | 1 | 7m 27s |
| fix | 428 | 24.1k | 2.4M | 72.0k | 1 | 12m 56s |
| prepare_pr | 68 | 4.8k | 213.4k | 23.9k | 1 | 1m 14s |
| run_arch_lenses | 209 | 16.0k | 661.3k | 142.0k | 3 | 12m 19s |
| compose_pr | 59 | 6.7k | 187.7k | 28.0k | 1 | 1m 50s |
| **Total** | 1.5k | 112.2k | 7.9M | 502.2k | | 49m 45s |