### PR TITLE
Rectify: Fail-Silent Manifest Handling and fnmatch/pathspec Mismatch in Test Filter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
 
       - id: mypy
         name: mypy
-        entry: mypy src/ --ignore-missing-imports
+        entry: mypy src/ tests/_test_filter.py --ignore-missing-imports
         language: system
         pass_filenames: false
 

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -10,6 +10,8 @@ import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import pathspec
+
 if TYPE_CHECKING:
     from typing import Any
 
@@ -341,20 +343,29 @@ def load_manifest(path: str | Path) -> dict[str, Any] | None:
 def apply_manifest(
     changed_files: set[str],
     manifest: dict[str, Any] | None,
-) -> set[str]:
-    """Return test directories matched by manifest patterns for the changed files."""
+) -> set[str] | None:
+    """Return test directories matched by manifest patterns for the changed files.
+
+    Returns None when manifest is None (fail-open) or when any changed file matches
+    no manifest pattern (fail-open: caller should run the full suite).
+    """
     if manifest is None:
-        return set()
-    result: set[str] = set()
-    for pattern, test_dirs in manifest.items():
-        for f in changed_files:
-            if fnmatch.fnmatch(f, pattern):
+        return None
+    compiled = {pat: pathspec.PathSpec.from_lines("gitwildmatch", [pat]) for pat in manifest}
+    matched_dirs: set[str] = set()
+    for f in changed_files:
+        file_matched = False
+        for pattern, spec in compiled.items():
+            if spec.match_file(f):
+                test_dirs = manifest[pattern]
                 if isinstance(test_dirs, list):
-                    result.update(test_dirs)
+                    matched_dirs.update(test_dirs)
                 elif isinstance(test_dirs, str):
-                    result.add(test_dirs)
-                break
-    return result
+                    matched_dirs.add(test_dirs)
+                file_matched = True
+        if not file_matched:
+            return None
+    return matched_dirs
 
 
 # ---------------------------------------------------------------------------
@@ -485,8 +496,9 @@ def build_test_scope(
             return None
         else:
             manifest_dirs = apply_manifest({f}, manifest)
-            if manifest_dirs:
-                test_dirs.update(manifest_dirs)
+            if manifest_dirs is None:
+                return None
+            test_dirs.update(manifest_dirs)
 
     test_dirs.update(always_run)
 

--- a/tests/arch/test_filter_contracts.py
+++ b/tests/arch/test_filter_contracts.py
@@ -1,0 +1,48 @@
+"""AST-based contract test enforcing signature compatibility between the two apply_manifest
+implementations: tests/_test_filter.py and src/autoskillit/_test_filter.py.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+
+import autoskillit._test_filter as src_filter
+import tests._test_filter as conftest_filter
+
+
+def _get_return_annotation(module: object, func_name: str) -> str:
+    """Return the string representation of func_name's return annotation in module."""
+    source = Path(inspect.getfile(module)).read_text()  # type: ignore[arg-type]
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == func_name:
+            if node.returns is not None:
+                return ast.unparse(node.returns)
+    return ""
+
+
+class TestApplyManifestSignatureContract:
+    """Enforces structural compatibility between the two apply_manifest implementations.
+
+    When the production module's apply_manifest signature changes, this test fails
+    immediately, forcing the conftest-side implementation to be updated in sync.
+    """
+
+    def test_both_return_optional_set(self) -> None:
+        """Both apply_manifest implementations must return set[str] | None."""
+        src_ann = _get_return_annotation(src_filter, "apply_manifest")
+        conftest_ann = _get_return_annotation(conftest_filter, "apply_manifest")
+        assert "None" in src_ann, f"src apply_manifest missing None return: {src_ann!r}"
+        assert "None" in conftest_ann, (
+            f"conftest apply_manifest missing None return: {conftest_ann!r}\n"
+            "The conftest module must return None (not empty set) to signal fail-open."
+        )
+
+    def test_both_accept_manifest_parameter(self) -> None:
+        """Both apply_manifest implementations must accept a manifest parameter."""
+        src_sig = inspect.signature(src_filter.apply_manifest)
+        conftest_sig = inspect.signature(conftest_filter.apply_manifest)
+        assert "manifest" in src_sig.parameters
+        assert "manifest" in conftest_sig.parameters

--- a/tests/arch/test_filter_contracts.py
+++ b/tests/arch/test_filter_contracts.py
@@ -34,9 +34,11 @@ class TestApplyManifestSignatureContract:
         """Both apply_manifest implementations must return set[str] | None."""
         src_ann = _get_return_annotation(src_filter, "apply_manifest")
         conftest_ann = _get_return_annotation(conftest_filter, "apply_manifest")
-        assert "None" in src_ann, f"src apply_manifest missing None return: {src_ann!r}"
-        assert "None" in conftest_ann, (
-            f"conftest apply_manifest missing None return: {conftest_ann!r}\n"
+        assert src_ann in ("set[str] | None", "Optional[set[str]]"), (
+            f"src apply_manifest unexpected return annotation: {src_ann!r}"
+        )
+        assert conftest_ann in ("set[str] | None", "Optional[set[str]]"), (
+            f"conftest apply_manifest unexpected return annotation: {conftest_ann!r}\n"
             "The conftest module must return None (not empty set) to signal fail-open."
         )
 

--- a/tests/test_test_filter.py
+++ b/tests/test_test_filter.py
@@ -293,6 +293,7 @@ class TestBuildTestScope:
         assert Path("tests/core/test_io.py") in result
 
     def test_scope_nonpython_no_manifest_only_alwaysrun(self, tmp_path: Path) -> None:
+        """Non-Python file with manifest=None → fail-open → result is None."""
         tests_root = tmp_path / "tests"
         for d in ["arch", "contracts", "infra", "docs"]:
             (tests_root / d).mkdir(parents=True, exist_ok=True)
@@ -302,9 +303,37 @@ class TestBuildTestScope:
             mode=FilterMode.CONSERVATIVE,
             tests_root=tests_root,
         )
+        assert result is None
+
+    def test_scope_nonpython_unmatched_manifest_returns_none(self, tmp_path: Path) -> None:
+        """A non-Python changed file with no manifest match must return None (full run)."""
+        tests_root = tmp_path / "tests"
+        for d in ["arch", "contracts", "infra", "docs"]:
+            (tests_root / d).mkdir(parents=True, exist_ok=True)
+        manifest = {"docs/**/*.md": ["docs"]}
+        result = build_test_scope(
+            changed_files={"some/unknown/file.txt"},
+            mode=FilterMode.CONSERVATIVE,
+            manifest=manifest,
+            tests_root=tests_root,
+        )
+        assert result is None
+
+    def test_scope_nonpython_matched_manifest_adds_dirs(self, tmp_path: Path) -> None:
+        """A non-Python file that DOES match a manifest pattern contributes its test dirs."""
+        tests_root = tmp_path / "tests"
+        for d in ["arch", "contracts", "infra", "docs"]:
+            (tests_root / d).mkdir(parents=True, exist_ok=True)
+        manifest = {"docs/**/*.md": ["docs"]}
+        result = build_test_scope(
+            changed_files={"docs/README.md"},
+            mode=FilterMode.CONSERVATIVE,
+            manifest=manifest,
+            tests_root=tests_root,
+        )
         assert result is not None
         dir_names = {p.name for p in result}
-        assert dir_names == {"arch", "contracts", "infra", "docs"}
+        assert "docs" in dir_names
 
     def test_scope_none_mode_returns_none(self, tmp_path: Path) -> None:
         result = build_test_scope(
@@ -511,7 +540,7 @@ class TestLoadManifest:
 class TestApplyManifest:
     def test_apply_manifest_none(self) -> None:
         result = apply_manifest({"README.md"}, None)
-        assert result == set()
+        assert result is None
 
     def test_apply_manifest_match(self) -> None:
         manifest = {"docs/*.md": ["docs"]}
@@ -519,14 +548,88 @@ class TestApplyManifest:
         assert result == {"docs"}
 
     def test_apply_manifest_no_match(self) -> None:
-        manifest = {"docs/*.md": ["docs"]}
+        manifest = {"tests/*.py": ["unit"]}
         result = apply_manifest({"src/foo.py"}, manifest)
-        assert result == set()
+        assert result is None
 
     def test_apply_manifest_list_dirs(self) -> None:
         manifest = {"*.yaml": ["config", "infra"]}
         result = apply_manifest({"defaults.yaml"}, manifest)
         assert result == {"config", "infra"}
+
+    def test_apply_manifest_doublestar_zero_segments(self) -> None:
+        """docs/**/*.md must match docs/README.md (zero intermediate path segments).
+
+        This pattern is in the production manifest. fnmatch fails this; pathspec passes it.
+        """
+        manifest = {"docs/**/*.md": ["docs"]}
+        result = apply_manifest({"docs/README.md"}, manifest)
+        assert result == {"docs"}
+
+    def test_apply_manifest_doublestar_nested(self) -> None:
+        """docs/**/*.md must match docs/developer/SETUP.md (non-zero intermediate segments)."""
+        manifest = {"docs/**/*.md": ["docs"]}
+        result = apply_manifest({"docs/developer/SETUP.md"}, manifest)
+        assert result == {"docs"}
+
+
+# ---------------------------------------------------------------------------
+# Behavioral equivalence cross-validation (EQ1–EQ2)
+# ---------------------------------------------------------------------------
+
+
+class TestApplyManifestEquivalence:
+    """Cross-validates conftest apply_manifest against production manifest_apply_manifest.
+
+    Both modules must agree on matched outputs. When a file matches patterns in one,
+    it must match the same patterns in the other. The two implementations are allowed
+    to differ only in how they handle the unmatched case (both must return None there too).
+    """
+
+    MANIFEST = {
+        "src/autoskillit/recipes/*.yaml": ["recipe", "contracts"],
+        "docs/**/*.md": ["docs"],
+        "Taskfile.yml": ["infra"],
+        "tests/recipe/fixtures/*": ["recipe"],
+        ".pre-commit-config.yaml": ["infra"],
+    }
+
+    @pytest.mark.parametrize(
+        "file_path,expected_dirs",
+        [
+            ("src/autoskillit/recipes/my.yaml", {"recipe", "contracts"}),
+            ("docs/README.md", {"docs"}),
+            ("docs/sub/dir/deep.md", {"docs"}),
+            ("Taskfile.yml", {"infra"}),
+            ("tests/recipe/fixtures/test.yaml", {"recipe"}),
+            (".pre-commit-config.yaml", {"infra"}),
+        ],
+    )
+    def test_matching_cases_agree(self, file_path: str, expected_dirs: set[str]) -> None:
+        """For files that match manifest patterns, both implementations return the same dirs."""
+        conftest_result = apply_manifest({file_path}, self.MANIFEST)
+        production_result = manifest_apply_manifest([file_path], self.MANIFEST)
+        assert conftest_result == production_result == expected_dirs, (
+            f"Implementations disagree for {file_path!r}: "
+            f"conftest={conftest_result!r}, production={production_result!r}"
+        )
+
+    @pytest.mark.parametrize(
+        "file_path",
+        [
+            "some/unknown/file.txt",
+            "README.md",
+            "pyproject.toml",
+        ],
+    )
+    def test_unmatched_cases_both_return_none(self, file_path: str) -> None:
+        """For files matching no manifest pattern, both implementations return None."""
+        conftest_result = apply_manifest({file_path}, self.MANIFEST)
+        production_result = manifest_apply_manifest([file_path], self.MANIFEST)
+        assert conftest_result is None, f"conftest returned {conftest_result!r} for {file_path!r}"
+        assert production_result is None, (
+            f"production returned {production_result!r} for {file_path!r}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_test_filter.py
+++ b/tests/test_test_filter.py
@@ -333,7 +333,7 @@ class TestBuildTestScope:
         )
         assert result is not None
         dir_names = {p.name for p in result}
-        assert "docs" in dir_names
+        assert dir_names == {"arch", "contracts", "infra", "docs"}
 
     def test_scope_none_mode_returns_none(self, tmp_path: Path) -> None:
         result = build_test_scope(


### PR DESCRIPTION
## Summary

The conftest-side test filter module (`tests/_test_filter.py`) independently re-implemented `apply_manifest` with two semantic divergences from the production module (`src/autoskillit/_test_filter.py`): it uses `fnmatch` instead of `pathspec` gitwildmatch (silently failing to match `**` patterns like `docs/**/*.md`), and it returns `set()` instead of `None` for the fail-open sentinel (silently narrowing the test scope when a non-Python file matches no manifest entry, instead of triggering a full run).

The architectural weakness is not the individual bugs but the structural absence of any contract between the two parallel implementations. There is no shared interface, no behavioral equivalence gate, and no type-checking coverage of the conftest module — so the divergence was invisible until runtime symptoms appeared.

The immunity plan replaces the shared semantic contract with an enforced one: `pathspec` (already a production dependency and importable in the conftest module) replaces `fnmatch` in the conftest module, eliminating the pattern-matching divergence at the source. Behavioral equivalence tests cross-validate both implementations on the same inputs. An AST-based contract test in `tests/arch/` enforces signature compatibility. Mypy coverage is extended to `tests/_test_filter.py`.

## Architecture Impact

### Error/Resilience Diagram — Test Filter Pipeline

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;

    FULL_RUN([FULL SUITE RUN])
    FILTERED_RUN([FILTERED RUN])

    subgraph GitLayer ["GIT DIFF — Error Boundary"]
        GIT_CALL["● git_changed_files()<br/>━━━━━━━━━━<br/>git diff --name-only<br/>base_ref...HEAD"]
        GIT_ERR{"subprocess error?<br/>timeout? no git?"}
        GIT_WARN["warnings.warn()<br/>━━━━━━━━━━<br/>non-fatal, logged"]
    end

    subgraph ValidationGates ["VALIDATION GATES — Fail-Fast"]
        GATE_NONE{"FilterMode<br/>== NONE?"}
        GATE_NULL{"changed_files<br/>is None?"}
        GATE_SIZE{"len > 30<br/>files?"}
        GATE_BUCKET{"● check_bucket_a()<br/>━━━━━━━━━━<br/>conftest / pyproject /<br/>.pre-commit-config.yaml<br/>/ uv.lock / _factory.py"}
    end

    subgraph Classification ["FILE CLASSIFICATION"]
        CLASS_SRC["src/*.py<br/>━━━━━━━━━━<br/>Layer cascade map<br/>→ test directories"]
        CLASS_TEST["tests/*.py<br/>━━━━━━━━━━<br/>Direct inclusion"]
        CLASS_OTHER["non-.py files<br/>━━━━━━━━━━<br/>→ manifest lookup"]
        CLASS_UNKNOWN["unknown .py<br/>outside src/ tests/<br/>━━━━━━━━━━<br/>→ fail-open"]
    end

    subgraph ManifestLayer ["MANIFEST LAYER — Pathspec Guard"]
        LOAD_MAN["● load_manifest()<br/>━━━━━━━━━━<br/>reads .autoskillit/<br/>test-filter-manifest.yaml"]
        MAN_ERR{"absent /<br/>OSError /<br/>YAMLError?"}
        MAN_WARN["warnings.warn()<br/>━━━━━━━━━━<br/>returns None"]
        APPLY_MAN["● apply_manifest()<br/>━━━━━━━━━━<br/>pathspec gitwildmatch<br/>(fixed from fnmatch)"]
        MATCH_CHECK{"any file<br/>unmatched?"}
    end

    subgraph ContractLayer ["★ CONTRACT ENFORCEMENT (NEW)"]
        CONTRACT["★ TestApplyManifestSignatureContract<br/>━━━━━━━━━━<br/>tests/arch/test_filter_contracts.py<br/>AST inspection of both impls"]
        C_ANN["test_both_return_optional_set<br/>━━━━━━━━━━<br/>enforces None in return annotation<br/>(fail-open guarantee)"]
        C_PARAM["test_both_accept_manifest_parameter<br/>━━━━━━━━━━<br/>enforces manifest param present"]
    end

    subgraph ConftestPlugin ["CONFTEST PLUGIN — Fail-Open Guards"]
        P_CFG{"pytest_configure<br/>raises?"}
        P_CFG_WARN["warnings.warn()<br/>━━━━━━━━━━<br/>scope = None"]
        P_MOD{"pytest_collection_<br/>modifyitems raises?"}
        P_MOD_WARN["warnings.warn()<br/>━━━━━━━━━━<br/>deselection skipped"]
    end

    %% ── Git error path ──
    GIT_CALL --> GIT_ERR
    GIT_ERR -->|"CalledProcessError<br/>TimeoutExpired<br/>FileNotFoundError"| GIT_WARN
    GIT_WARN -->|"None propagates"| GATE_NULL
    GIT_ERR -->|"success"| GATE_NONE

    %% ── Validation gates ──
    GATE_NONE -->|"NONE"| FULL_RUN
    GATE_NONE -->|"conservative / aggressive"| GATE_NULL
    GATE_NULL -->|"None"| FULL_RUN
    GATE_NULL -->|"set[str]"| GATE_SIZE
    GATE_SIZE -->|"> 30"| FULL_RUN
    GATE_SIZE -->|"≤ 30"| GATE_BUCKET
    GATE_BUCKET -->|"Bucket A hit"| FULL_RUN
    GATE_BUCKET -->|"no match"| Classification

    %% ── Classification ──
    Classification --> CLASS_SRC
    Classification --> CLASS_TEST
    Classification --> CLASS_OTHER
    Classification --> CLASS_UNKNOWN
    CLASS_UNKNOWN -->|"fail-open"| FULL_RUN
    CLASS_SRC -->|"cascade"| FILTERED_RUN
    CLASS_TEST -->|"direct"| FILTERED_RUN
    CLASS_OTHER --> APPLY_MAN

    %% ── Manifest layer ──
    LOAD_MAN --> MAN_ERR
    MAN_ERR -->|"absent / OSError / YAMLError"| MAN_WARN
    MAN_WARN -->|"None"| APPLY_MAN
    MAN_ERR -->|"ok"| APPLY_MAN
    APPLY_MAN --> MATCH_CHECK
    MATCH_CHECK -->|"unmatched file"| FULL_RUN
    MATCH_CHECK -->|"all matched"| FILTERED_RUN

    %% ── Contract enforcement (build-time guard) ──
    CONTRACT --> C_ANN
    CONTRACT --> C_PARAM
    C_ANN -->|"assert None in annotation<br/>fails → CI breaks"| APPLY_MAN
    C_PARAM -->|"assert manifest param exists<br/>fails → CI breaks"| APPLY_MAN

    %% ── Conftest plugin fail-open ──
    P_CFG -->|"exception"| P_CFG_WARN
    P_CFG_WARN -->|"scope=None → all tests run"| FULL_RUN
    P_CFG -->|"ok"| P_MOD
    P_MOD -->|"exception"| P_MOD_WARN
    P_MOD_WARN -->|"deselection skipped → all tests run"| FULL_RUN
    P_MOD -->|"ok"| FILTERED_RUN

    %% CLASS ASSIGNMENTS %%
    class FULL_RUN,FILTERED_RUN terminal;
    class GIT_CALL,APPLY_MAN,LOAD_MAN handler;
    class GIT_ERR,MAN_ERR,MATCH_CHECK,GATE_NONE,GATE_NULL,GATE_SIZE,GATE_BUCKET,P_CFG,P_MOD stateNode;
    class GIT_WARN,MAN_WARN,P_CFG_WARN,P_MOD_WARN gap;
    class GATE_BUCKET detector;
    class CLASS_SRC,CLASS_TEST,CLASS_OTHER,CLASS_UNKNOWN phase;
    class CONTRACT,C_ANN,C_PARAM newComponent;
    class Classification output;
```

### Module Dependency Diagram — autoskillit PR #997 Scope

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph SrcLayer ["LAYER 0 — Foundation (unchanged)"]
        CoreIO["autoskillit.core<br/>━━━━━━━━━━<br/>load_yaml · get_logger<br/>Fan-in: 10 (highest)"]
    end

    subgraph AuxLayer ["AUX — Root Utility Module"]
        TestFilter["● autoskillit._test_filter<br/>━━━━━━━━━━<br/>Glob → test-dir YAML manifest<br/>Imports: core.load_yaml only<br/>Fan-in: 0 (leaf consumer)"]
    end

    subgraph TestInfra ["TEST INFRASTRUCTURE"]
        TestHelper["● tests/_test_filter.py<br/>━━━━━━━━━━<br/>apply_manifest(manifest, paths)<br/>Fixed: pathspec gitwildmatch<br/>replaces fnmatch"]
        TestSuite["● tests/test_test_filter.py<br/>━━━━━━━━━━<br/>Sentinel handling tests<br/>fnmatch/pathspec divergence<br/>coverage added"]
    end

    subgraph ArchContracts ["ARCH CONTRACTS (new)"]
        ContractTest["★ tests/arch/test_filter_contracts.py<br/>━━━━━━━━━━<br/>AST-based contract test<br/>Enforces apply_manifest<br/>signature compatibility"]
    end

    subgraph QualityGates ["QUALITY GATES"]
        PreCommit["● .pre-commit-config.yaml<br/>━━━━━━━━━━<br/>mypy hook: extended to cover<br/>tests/_test_filter.py<br/>Type safety enforcement"]
    end

    subgraph ExtLayer ["EXTERNAL DEPENDENCIES"]
        Pathspec["pathspec (gitwildmatch)<br/>━━━━━━━━━━<br/>Replaces stdlib fnmatch<br/>Git-compatible pattern matching"]
        ASTLib["ast (stdlib)<br/>━━━━━━━━━━<br/>Source introspection<br/>Signature contract checking"]
    end

    %% SOURCE → CORE %%
    TestFilter -->|"imports load_yaml"| CoreIO

    %% TEST HELPER → SOURCE + EXTERNAL %%
    TestHelper -->|"applies manifest data from"| TestFilter
    TestHelper -->|"uses for glob matching"| Pathspec

    %% TEST SUITE → HELPERS %%
    TestSuite -->|"tests apply_manifest"| TestHelper
    TestSuite -->|"tests YAML loading via"| TestFilter

    %% CONTRACT TEST %%
    ContractTest -->|"★ AST-inspects signature of"| TestHelper
    ContractTest -->|"parses source with"| ASTLib

    %% QUALITY GATE %%
    PreCommit -->|"mypy type-checks"| TestHelper

    %% CLASS ASSIGNMENTS %%
    class CoreIO handler;
    class TestFilter stateNode;
    class TestHelper phase;
    class TestSuite output;
    class ContractTest newComponent;
    class PreCommit detector;
    class Pathspec,ASTLib integration;
```

Closes #997

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260416-163632-205313/.autoskillit/temp/rectify/rectify_fail-silent-manifest-fnmatch-pathspec_2026-04-16_164500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| investigate | 140 | 10.3k | 615.0k | 58.2k | 1 | 3m 15s |
| rectify | 97 | 13.8k | 410.7k | 48.0k | 1 | 6m 41s |
| review | 3.0k | 6.4k | 155.3k | 29.1k | 1 | 2m 47s |
| dry_walkthrough | 100 | 13.5k | 516.5k | 53.3k | 1 | 4m 11s |
| implement | 456 | 20.0k | 3.7M | 83.2k | 1 | 6m 14s |
| prepare_pr | 60 | 5.5k | 195.1k | 27.2k | 1 | 1m 30s |
| run_arch_lenses | 3.7k | 18.9k | 462.7k | 130.8k | 2 | 6m 19s |
| compose_pr | 75 | 6.8k | 242.4k | 26.3k | 1 | 2m 0s |
| **Total** | 7.6k | 95.2k | 6.3M | 456.1k | | 33m 1s |