### PR TITLE
Add Manifest Completeness and Orphan Detection Test

### DIFF
--- a/.autoskillit/test-filter-manifest.yaml
+++ b/.autoskillit/test-filter-manifest.yaml
@@ -87,8 +87,49 @@ README.md:
 src/autoskillit/assets/**/*:
   - assets/
 
-scripts/compare-coverage-ast.py:
+tests/recipe/fixtures/*:
+  - recipe/
+
+# Local .autoskillit/ config and state files
+.autoskillit/config.yaml:
   - infra/
 
-tests/recipe/fixtures/*:
+.autoskillit/test-filter-manifest.yaml:
+  - infra/
+
+.autoskillit/recipes/*.yaml:
+  - recipe/
+
+.autoskillit/recipes/contracts/*.yaml:
+  - recipe/
+  - contracts/
+
+.autoskillit/recipes/diagrams/*.md:
+  - recipe/
+
+# External skills installed under .claude/skills/
+.claude/skills/*/SKILL.md:
+  - skills/
+  - contracts/
+
+# Root config / tooling files
+.gitignore:
+  - infra/
+
+.python-version:
+  - infra/
+
+install.sh:
+  - infra/
+  - cli/
+
+scripts/verify-test-filter.sh:
+  - infra/
+
+# Source non-Python files
+src/autoskillit/.mcp.json:
+  - server/
+  - cli/
+
+src/autoskillit/recipes/sub-recipes/diagrams/*.md:
   - recipe/

--- a/tests/infra/test_manifest_completeness.py
+++ b/tests/infra/test_manifest_completeness.py
@@ -97,16 +97,20 @@ def _files_to_check() -> list[str]:
     return [f for f in _tracked_non_python_files() if _should_be_covered(f)]
 
 
-def _manifest_patterns() -> list[str]:
-    """All pattern keys from the manifest."""
-    return list(load_manifest(_MANIFEST_PATH).keys())
+# Manifest patterns loaded once at module level; shared by _MANIFEST_SPEC and
+# _PER_PATTERN_SPECS to avoid redundant YAML loads across the two parametrize sites.
+_MANIFEST_PATTERNS: list[str] = list(load_manifest(_MANIFEST_PATH).keys())
 
-
-# Module-level spec built from the manifest; precomputed once to avoid re-reading the
-# YAML file on every parametrized test-case invocation of test_file_covered_by_manifest.
+# Combined spec precomputed once; used by test_file_covered_by_manifest.
 _MANIFEST_SPEC: pathspec.PathSpec = pathspec.PathSpec.from_lines(
-    "gitwildmatch", _manifest_patterns()
+    "gitwildmatch", _MANIFEST_PATTERNS
 )
+
+# Per-pattern specs precomputed once; used by test_manifest_pattern_matches_real_file
+# to avoid O(N) PathSpec constructions across parametrized invocations.
+_PER_PATTERN_SPECS: dict[str, pathspec.PathSpec] = {
+    p: pathspec.PathSpec.from_lines("gitwildmatch", [p]) for p in _MANIFEST_PATTERNS
+}
 
 
 @pytest.mark.parametrize("file_path", _files_to_check())
@@ -125,7 +129,7 @@ def test_file_covered_by_manifest(file_path: str) -> None:
     )
 
 
-@pytest.mark.parametrize("pattern", _manifest_patterns())
+@pytest.mark.parametrize("pattern", _MANIFEST_PATTERNS)
 def test_manifest_pattern_matches_real_file(pattern: str) -> None:
     """Every manifest pattern must match at least one currently tracked non-Python file.
 
@@ -135,8 +139,7 @@ def test_manifest_pattern_matches_real_file(pattern: str) -> None:
     correct its path.
     """
     all_tracked = _tracked_non_python_files()
-    spec = pathspec.PathSpec.from_lines("gitwildmatch", [pattern])
-    matched_files = [f for f in all_tracked if spec.match_file(f)]
+    matched_files = [f for f in all_tracked if _PER_PATTERN_SPECS[pattern].match_file(f)]
     assert matched_files, (
         f"Manifest pattern {pattern!r} matches no tracked files — it may be stale "
         "or misspelled. Remove it from .autoskillit/test-filter-manifest.yaml."

--- a/tests/infra/test_manifest_completeness.py
+++ b/tests/infra/test_manifest_completeness.py
@@ -98,6 +98,13 @@ def _manifest_patterns() -> list[str]:
     return list(load_manifest(_MANIFEST_PATH).keys())
 
 
+# Module-level spec built from the manifest; precomputed once to avoid re-reading the
+# YAML file on every parametrized test-case invocation of test_file_covered_by_manifest.
+_MANIFEST_SPEC: pathspec.PathSpec = pathspec.PathSpec.from_lines(
+    "gitwildmatch", _manifest_patterns()
+)
+
+
 @pytest.mark.parametrize("file_path", _files_to_check())
 def test_file_covered_by_manifest(file_path: str) -> None:
     """Every non-Python tracked file (outside Bucket A + ignore list) must match
@@ -107,9 +114,7 @@ def test_file_covered_by_manifest(file_path: str) -> None:
     Fix: add a glob pattern to .autoskillit/test-filter-manifest.yaml, or add
     the file to _IGNORE_FILES / _IGNORE_PATTERNS if no test mapping is needed.
     """
-    manifest = load_manifest(_MANIFEST_PATH)
-    spec = pathspec.PathSpec.from_lines("gitwildmatch", list(manifest.keys()))
-    assert spec.match_file(file_path), (
+    assert _MANIFEST_SPEC.match_file(file_path), (
         f"File {file_path!r} is not covered by any manifest pattern. "
         "Add an entry to .autoskillit/test-filter-manifest.yaml "
         "or add to _IGNORE_FILES / _IGNORE_PATTERNS in this test file."

--- a/tests/infra/test_manifest_completeness.py
+++ b/tests/infra/test_manifest_completeness.py
@@ -1,0 +1,124 @@
+"""Manifest completeness and orphan detection tests for the test-filter manifest.
+
+Completeness test: every non-Python tracked file (outside Bucket A and the ignore
+list) must match at least one pattern in .autoskillit/test-filter-manifest.yaml.
+
+Orphan detection test: every manifest pattern must match at least one currently
+tracked non-Python file (no dead/stale patterns).
+"""
+from __future__ import annotations
+
+import functools
+import subprocess
+from pathlib import Path
+
+import pathspec
+import pytest
+
+from autoskillit._test_filter import load_manifest
+
+pytestmark = [pytest.mark.layer("infra")]
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_MANIFEST_PATH = _REPO_ROOT / ".autoskillit" / "test-filter-manifest.yaml"
+
+# Files that trigger a full test run (Bucket A) — excluded from manifest coverage check.
+# These are already handled before the manifest is consulted.
+_BUCKET_A_FILES: frozenset[str] = frozenset(
+    {
+        "pyproject.toml",
+        "uv.lock",
+        ".pre-commit-config.yaml",
+    }
+)
+
+# Files legitimately absent from the manifest (no test directory mapping needed).
+# Extend this set when new unmapped file types are added to the repo.
+_IGNORE_FILES: frozenset[str] = frozenset(
+    {
+        "LICENSE",
+        "tests/CLAUDE.md",
+    }
+)
+
+# Glob patterns for file types legitimately absent from the manifest.
+_IGNORE_PATTERNS: tuple[str, ...] = (
+    "*.gif",
+    "**/.gitkeep",
+)
+
+
+@functools.lru_cache(maxsize=None)
+def _tracked_non_python_files() -> tuple[str, ...]:
+    """Return all non-Python files currently tracked by git.
+
+    Cached to avoid repeated subprocess calls within a single worker process:
+    both _files_to_check() (collection time) and test_manifest_pattern_matches_real_file
+    (test execution) call this function.
+    """
+    result = subprocess.run(
+        ["git", "ls-files", "--cached"],
+        capture_output=True,
+        text=True,
+        cwd=_REPO_ROOT,
+        check=True,
+    )
+    return tuple(f for f in result.stdout.splitlines() if not f.endswith(".py"))
+
+
+def _should_be_covered(file_path: str) -> bool:
+    """Return True if file_path must be covered by a manifest pattern."""
+    if file_path in _BUCKET_A_FILES:
+        return False
+    if file_path in _IGNORE_FILES:
+        return False
+    for pattern in _IGNORE_PATTERNS:
+        if pathspec.PathSpec.from_lines("gitwildmatch", [pattern]).match_file(file_path):
+            return False
+    return True
+
+
+def _files_to_check() -> list[str]:
+    """Filtered list of non-Python tracked files that must appear in the manifest."""
+    return [f for f in _tracked_non_python_files() if _should_be_covered(f)]
+
+
+def _manifest_patterns() -> list[str]:
+    """All pattern keys from the manifest."""
+    return list(load_manifest(_MANIFEST_PATH).keys())
+
+
+@pytest.mark.parametrize("file_path", _files_to_check())
+def test_file_covered_by_manifest(file_path: str) -> None:
+    """Every non-Python tracked file (outside Bucket A + ignore list) must match
+    at least one manifest pattern.
+
+    Failure means a new non-Python file was added without a manifest entry.
+    Fix: add a glob pattern to .autoskillit/test-filter-manifest.yaml, or add
+    the file to _IGNORE_FILES / _IGNORE_PATTERNS if no test mapping is needed.
+    """
+    manifest = load_manifest(_MANIFEST_PATH)
+    spec = pathspec.PathSpec.from_lines("gitwildmatch", list(manifest.keys()))
+    assert spec.match_file(file_path), (
+        f"File {file_path!r} is not covered by any manifest pattern. "
+        "Add an entry to .autoskillit/test-filter-manifest.yaml "
+        "or add to _IGNORE_FILES / _IGNORE_PATTERNS in this test file."
+    )
+
+
+@pytest.mark.parametrize("pattern", _manifest_patterns())
+def test_manifest_pattern_matches_real_file(pattern: str) -> None:
+    """Every manifest pattern must match at least one currently tracked non-Python file.
+
+    Failure means the pattern is orphaned — either the files it matched were deleted,
+    renamed, or the pattern was misspelled from the start.
+    Fix: remove the stale pattern from .autoskillit/test-filter-manifest.yaml or
+    correct its path.
+    """
+    all_tracked = _tracked_non_python_files()
+    spec = pathspec.PathSpec.from_lines("gitwildmatch", [pattern])
+    matched_files = [f for f in all_tracked if spec.match_file(f)]
+    assert matched_files, (
+        f"Manifest pattern {pattern!r} matches no tracked files — it may be stale "
+        "or misspelled. Remove it from .autoskillit/test-filter-manifest.yaml."
+    )

--- a/tests/infra/test_manifest_completeness.py
+++ b/tests/infra/test_manifest_completeness.py
@@ -6,6 +6,7 @@ list) must match at least one pattern in .autoskillit/test-filter-manifest.yaml.
 Orphan detection test: every manifest pattern must match at least one currently
 tracked non-Python file (no dead/stale patterns).
 """
+
 from __future__ import annotations
 
 import functools
@@ -38,6 +39,10 @@ _IGNORE_FILES: frozenset[str] = frozenset(
     {
         "LICENSE",
         "tests/CLAUDE.md",
+        # Generated/state files in .autoskillit/ that carry no test-routing signal.
+        ".autoskillit/.gitignore",
+        ".autoskillit/.onboarded",
+        ".autoskillit/sync_manifest.json",
     }
 )
 
@@ -48,7 +53,7 @@ _IGNORE_PATTERNS: tuple[str, ...] = (
 )
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def _tracked_non_python_files() -> tuple[str, ...]:
     """Return all non-Python files currently tracked by git.
 

--- a/tests/infra/test_manifest_completeness.py
+++ b/tests/infra/test_manifest_completeness.py
@@ -52,6 +52,12 @@ _IGNORE_PATTERNS: tuple[str, ...] = (
     "**/.gitkeep",
 )
 
+# Combined PathSpec built once from _IGNORE_PATTERNS to avoid O(files×patterns)
+# construction inside _should_be_covered().
+_IGNORE_SPEC: pathspec.PathSpec = pathspec.PathSpec.from_lines(
+    "gitwildmatch", list(_IGNORE_PATTERNS)
+)
+
 
 @functools.cache
 def _tracked_non_python_files() -> tuple[str, ...]:
@@ -77,9 +83,8 @@ def _should_be_covered(file_path: str) -> bool:
         return False
     if file_path in _IGNORE_FILES:
         return False
-    for pattern in _IGNORE_PATTERNS:
-        if pathspec.PathSpec.from_lines("gitwildmatch", [pattern]).match_file(file_path):
-            return False
+    if _IGNORE_SPEC.match_file(file_path):
+        return False
     return True
 
 

--- a/tests/infra/test_manifest_completeness.py
+++ b/tests/infra/test_manifest_completeness.py
@@ -67,13 +67,17 @@ def _tracked_non_python_files() -> tuple[str, ...]:
     both _files_to_check() (collection time) and test_manifest_pattern_matches_real_file
     (test execution) call this function.
     """
-    result = subprocess.run(
-        ["git", "ls-files", "--cached"],
-        capture_output=True,
-        text=True,
-        cwd=_REPO_ROOT,
-        check=True,
-    )
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "--cached"],
+            capture_output=True,
+            text=True,
+            cwd=_REPO_ROOT,
+            check=True,
+        )
+    except subprocess.CalledProcessError as e:
+        msg = f"git ls-files failed in {_REPO_ROOT}: {e.stderr.strip()}"
+        raise RuntimeError(msg) from e
     return tuple(f for f in result.stdout.splitlines() if not f.endswith(".py"))
 
 


### PR DESCRIPTION
## Summary

Add `tests/infra/test_manifest_completeness.py` with two parametrized tests:

1. **Completeness** — for every non-Python file tracked by git (excluding Bucket A and a defined ignore list), asserts at least one manifest pattern in `.autoskillit/test-filter-manifest.yaml` matches it.
2. **Orphan detection** — for every pattern in the manifest, asserts at least one tracked non-Python file matches it (no dead/stale patterns).

Both tests use `pathspec.PathSpec.from_lines("gitwildmatch", ...)` for matching, consistent with the production `apply_manifest` implementation. Parametrization is per-file and per-pattern respectively, yielding one pytest item per subject for precise failure messages.

**Dependency note:** The completeness test will fail if manifest entries from issue #998 have not been merged. This is expected — the test is written first, entries land separately.

## Architecture Impact

### Operational Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph TaskCmds ["TASK COMMANDS"]
        direction TB
        TESTALL["task test-all<br/>━━━━━━━━━━<br/>Lint + full test suite<br/>(human-facing)"]
        TESTCHECK["task test-check<br/>━━━━━━━━━━<br/>PASS/FAIL adjudication<br/>(automation / MCP)"]
        TESTFILTERED["task test-filtered<br/>━━━━━━━━━━<br/>AUTOSKILLIT_TEST_FILTER=<br/>conservative | aggressive"]
    end

    subgraph Config ["CONFIGURATION (read-only)"]
        direction TB
        ENVVAR["AUTOSKILLIT_TEST_FILTER<br/>━━━━━━━━━━<br/>Env var gate<br/>unset → full run"]
        BASEREF["AUTOSKILLIT_TEST_BASE_REF<br/>━━━━━━━━━━<br/>Git diff base<br/>default: GITHUB_BASE_REF"]
        MANIFEST["● .autoskillit/test-filter-manifest.yaml<br/>━━━━━━━━━━<br/>glob → test-dir mapping<br/>~30 non-Python patterns<br/>(MODIFIED: new entries added)"]
    end

    subgraph FilterEngine ["TEST FILTER ENGINE (read/write)"]
        direction TB
        LOAD["load_manifest()<br/>━━━━━━━━━━<br/>autoskillit._test_filter<br/>Loads YAML → dict"]
        APPLY["apply_manifest()<br/>━━━━━━━━━━<br/>pathspec gitwildmatch<br/>file → test dirs"]
        GITDIFF["git diff --name-only<br/>━━━━━━━━━━<br/>Changed files since base_ref<br/>Bucket A / large-set gates"]
    end

    subgraph ManifestGuards ["★ MANIFEST INTEGRITY GUARDS (new)"]
        direction TB
        GITLS["git ls-files --cached<br/>━━━━━━━━━━<br/>All tracked non-Python files<br/>Cached per worker process"]
        COMPLETE["★ test_file_covered_by_manifest<br/>━━━━━━━━━━<br/>tests/infra/test_manifest_completeness.py<br/>Every tracked non-Python file<br/>must match ≥1 manifest pattern<br/>Param: file_path (per tracked file)"]
        ORPHAN["★ test_manifest_pattern_matches_real_file<br/>━━━━━━━━━━<br/>tests/infra/test_manifest_completeness.py<br/>Every manifest pattern must<br/>match ≥1 tracked file<br/>Param: pattern (per manifest key)"]
        BUCKETIGNORE["_BUCKET_A_FILES + _IGNORE_FILES<br/>━━━━━━━━━━<br/>Exclusions: pyproject.toml,<br/>uv.lock, LICENSE, etc."]
    end

    subgraph Outputs ["OBSERVABILITY (write-only)"]
        direction TB
        PYTEST_OUT["pytest output<br/>━━━━━━━━━━<br/>PASSED / FAILED<br/>per parametrized case"]
        FAILMSG["Failure message<br/>━━━━━━━━━━<br/>File not covered →<br/>add pattern to manifest<br/>Orphan pattern →<br/>remove from manifest"]
    end

    %% FLOWS %%
    TESTALL --> ENVVAR
    TESTCHECK --> ENVVAR
    TESTFILTERED --> ENVVAR
    TESTFILTERED --> BASEREF

    ENVVAR --> LOAD
    MANIFEST --> LOAD
    LOAD --> APPLY
    BASEREF --> GITDIFF
    GITDIFF --> APPLY

    MANIFEST --> COMPLETE
    MANIFEST --> ORPHAN
    GITLS --> COMPLETE
    GITLS --> ORPHAN
    BUCKETIGNORE --> COMPLETE

    COMPLETE --> PYTEST_OUT
    ORPHAN --> PYTEST_OUT
    PYTEST_OUT --> FAILMSG

    %% CLASS ASSIGNMENTS %%
    class TESTALL,TESTCHECK,TESTFILTERED cli;
    class ENVVAR,BASEREF phase;
    class MANIFEST stateNode;
    class LOAD,APPLY handler;
    class GITDIFF handler;
    class GITLS handler;
    class COMPLETE,ORPHAN newComponent;
    class BUCKETIGNORE phase;
    class PYTEST_OUT output;
    class FAILMSG detector;
```

### Scenarios Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph S1 ["SCENARIO 1: Completeness Enforcement"]
        direction LR
        S1_git["git ls-files --cached<br/>━━━━━━━━━━<br/>all tracked files"]
        S1_filter["_should_be_covered()<br/>━━━━━━━━━━<br/>exclude BucketA + ignore list"]
        S1_param["pytest.parametrize<br/>━━━━━━━━━━<br/>one case per tracked file"]
        S1_test["★ test_file_covered_by_manifest<br/>━━━━━━━━━━<br/>load_manifest() + pathspec match"]
        S1_manifest["● test-filter-manifest.yaml<br/>━━━━━━━━━━<br/>pattern → test dirs"]
        S1_result{match?}
        S1_pass([PASS])
        S1_fail([FAIL: add manifest entry])
        S1_git --> S1_filter --> S1_param --> S1_test
        S1_manifest -->|reads| S1_test
        S1_test --> S1_result
        S1_result -->|yes| S1_pass
        S1_result -->|no| S1_fail
    end

    subgraph S2 ["SCENARIO 2: Orphan Pattern Detection"]
        direction LR
        S2_manifest["● test-filter-manifest.yaml<br/>━━━━━━━━━━<br/>all glob patterns"]
        S2_param["pytest.parametrize<br/>━━━━━━━━━━<br/>one case per pattern"]
        S2_test["★ test_manifest_pattern_matches_real_file<br/>━━━━━━━━━━<br/>compile pathspec + scan tracked files"]
        S2_git["git ls-files --cached<br/>━━━━━━━━━━<br/>all tracked non-Python files"]
        S2_result{any match?}
        S2_pass([PASS])
        S2_fail([FAIL: remove stale pattern])
        S2_manifest --> S2_param --> S2_test
        S2_git -->|reads| S2_test
        S2_test --> S2_result
        S2_result -->|yes| S2_pass
        S2_result -->|no| S2_fail
    end

    subgraph S3 ["SCENARIO 3: Manifest Load Chain"]
        direction LR
        S3_loader["_test_filter.load_manifest()<br/>━━━━━━━━━━<br/>Path → dict[pattern, dirs]"]
        S3_yaml["core.load_yaml()<br/>━━━━━━━━━━<br/>YAML → Python mapping"]
        S3_validate["type guard<br/>━━━━━━━━━━<br/>must be dict, raises TypeError"]
        S3_apply["apply_manifest()<br/>━━━━━━━━━━<br/>pathspec gitwildmatch per pattern"]
        S3_dirs["test dir set<br/>━━━━━━━━━━<br/>e.g. {infra/, contracts/}"]
        S3_loader --> S3_yaml --> S3_validate --> S3_apply --> S3_dirs
    end

    subgraph S4 ["SCENARIO 4: CI Test Filter Routing"]
        direction LR
        S4_diff["git diff base..HEAD<br/>━━━━━━━━━━<br/>changed non-Python files"]
        S4_manifest["● test-filter-manifest.yaml<br/>━━━━━━━━━━<br/>pattern → test dirs"]
        S4_apply["apply_manifest()<br/>━━━━━━━━━━<br/>match each changed file"]
        S4_guard{unmatched<br/>files?}
        S4_full([full test run<br/>fail-open])
        S4_scoped["scoped dirs<br/>━━━━━━━━━━<br/>e.g. infra/ only"]
        S4_pytest["pytest --collect<br/>━━━━━━━━━━<br/>deselect out-of-scope items"]
        S4_diff --> S4_apply
        S4_manifest -->|reads| S4_apply
        S4_apply --> S4_guard
        S4_guard -->|yes| S4_full
        S4_guard -->|no| S4_scoped --> S4_pytest
    end

    %% CLASS ASSIGNMENTS %%
    class S1_git,S2_git,S4_diff cli;
    class S1_manifest,S2_manifest,S4_manifest stateNode;
    class S1_filter,S1_test,S2_test phase;
    class S1_param,S2_param handler;
    class S1_test,S2_test newComponent;
    class S3_loader,S3_apply,S4_apply handler;
    class S3_yaml,S3_validate phase;
    class S3_dirs,S4_scoped,S4_pytest output;
    class S1_result,S2_result,S4_guard detector;
    class S1_pass,S2_pass,S4_full,S1_fail,S2_fail terminal;
```

Closes #999

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260416-233731-299051/.autoskillit/temp/make-plan/add_manifest_completeness_orphan_detection_test_plan_2026-04-16_235500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 127 | 15.1k | 504.2k | 59.8k | 1 | 7m 21s |
| review | 1.8k | 5.5k | 179.0k | 26.3k | 1 | 2m 55s |
| verify | 164 | 15.2k | 928.5k | 52.2k | 1 | 4m 12s |
| implement | 110 | 4.2k | 371.0k | 27.9k | 1 | 2m 32s |
| fix | 210 | 16.2k | 1.2M | 55.3k | 1 | 10m 17s |
| prepare_pr | 60 | 4.1k | 176.7k | 21.8k | 1 | 1m 19s |
| run_arch_lenses | 130 | 11.2k | 406.9k | 71.6k | 2 | 3m 31s |
| compose_pr | 59 | 5.7k | 187.4k | 24.5k | 1 | 1m 41s |
| **Total** | 2.7k | 77.3k | 3.9M | 339.4k | | 33m 51s |