### PR TITLE
Implementation Plan: Size Markers for config/ and migration/

### DIFF
--- a/tests/arch/test_size_markers.py
+++ b/tests/arch/test_size_markers.py
@@ -10,7 +10,9 @@ import pytest
 TESTS_ROOT = Path(__file__).resolve().parent.parent
 
 SIZE_DIRECTORIES: dict[str, str] = {
+    "config": "config",
     "core": "core",
+    "migration": "migration",
     "pipeline": "pipeline",
 }
 

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -8,7 +8,7 @@ import yaml
 
 from autoskillit.config import AutomationConfig, ConfigSchemaError, RunSkillConfig, load_config
 
-pytestmark = [pytest.mark.layer("config")]
+pytestmark = [pytest.mark.layer("config"), pytest.mark.small]
 
 
 class TestDefaultConfig:

--- a/tests/config/test_defaults.py
+++ b/tests/config/test_defaults.py
@@ -11,7 +11,7 @@ import pytest
 from autoskillit.config import AutomationConfig
 from autoskillit.config.settings import RunSkillConfig
 
-pytestmark = [pytest.mark.layer("config")]
+pytestmark = [pytest.mark.layer("config"), pytest.mark.small]
 
 
 class TestGraceWindowCoherence:

--- a/tests/config/test_helpers.py
+++ b/tests/config/test_helpers.py
@@ -6,7 +6,7 @@ import subprocess
 
 import pytest
 
-pytestmark = [pytest.mark.layer("config")]
+pytestmark = [pytest.mark.layer("config"), pytest.mark.medium]
 
 
 def test_resolve_ingredient_defaults_uses_upstream_when_origin_is_file_url(tmp_path):

--- a/tests/config/test_settings_allowed_labels.py
+++ b/tests/config/test_settings_allowed_labels.py
@@ -5,7 +5,7 @@ import pytest
 from autoskillit.config import AutomationConfig
 from autoskillit.config.settings import GitHubConfig, _make_dynaconf
 
-pytestmark = [pytest.mark.layer("config")]
+pytestmark = [pytest.mark.layer("config"), pytest.mark.small]
 
 
 class TestGitHubConfigAllowedLabelsField:

--- a/tests/config/test_settings_staged_label.py
+++ b/tests/config/test_settings_staged_label.py
@@ -7,7 +7,7 @@ import pytest
 from autoskillit.config import AutomationConfig
 from autoskillit.config.settings import GitHubConfig, _make_dynaconf
 
-pytestmark = [pytest.mark.layer("config")]
+pytestmark = [pytest.mark.layer("config"), pytest.mark.small]
 
 
 class TestGitHubConfigStagedLabel:

--- a/tests/config/test_workspace_temp_dir_config.py
+++ b/tests/config/test_workspace_temp_dir_config.py
@@ -8,7 +8,7 @@ import pytest
 
 from autoskillit.config import WorkspaceConfig, load_config
 
-pytestmark = [pytest.mark.layer("config")]
+pytestmark = [pytest.mark.layer("config"), pytest.mark.small]
 
 
 def test_workspace_config_has_temp_dir_field() -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,7 @@ _LAYER_DIRS: frozenset[str] = frozenset(
     }
 )
 
-_SIZE_DIRS: frozenset[str] = frozenset({"core", "pipeline"})
+_SIZE_DIRS: frozenset[str] = frozenset({"config", "core", "migration", "pipeline"})
 
 _scope_key = pytest.StashKey[set[_Path] | None]()
 _filter_mode_key = pytest.StashKey[str | None]()

--- a/tests/migration/test_api.py
+++ b/tests/migration/test_api.py
@@ -10,7 +10,7 @@ import pytest
 from autoskillit.migration._api import check_and_migrate
 from autoskillit.migration.engine import MigrationResult
 
-pytestmark = [pytest.mark.layer("migration")]
+pytestmark = [pytest.mark.layer("migration"), pytest.mark.small]
 
 # ---------------------------------------------------------------------------
 # T6 — migration/_api.py recipe imports are deferred

--- a/tests/migration/test_engine.py
+++ b/tests/migration/test_engine.py
@@ -24,7 +24,7 @@ from autoskillit.migration.engine import (
 )
 from autoskillit.migration.loader import MigrationChange, MigrationNote
 
-pytestmark = [pytest.mark.layer("migration")]
+pytestmark = [pytest.mark.layer("migration"), pytest.mark.small]
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 

--- a/tests/migration/test_loader.py
+++ b/tests/migration/test_loader.py
@@ -13,7 +13,7 @@ from autoskillit.migration.loader import (
     list_migrations,
 )
 
-pytestmark = [pytest.mark.layer("migration")]
+pytestmark = [pytest.mark.layer("migration"), pytest.mark.small]
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/migration/test_store.py
+++ b/tests/migration/test_store.py
@@ -15,7 +15,7 @@ from autoskillit.migration.store import (
     record_from_skill,
 )
 
-pytestmark = [pytest.mark.layer("migration")]
+pytestmark = [pytest.mark.layer("migration"), pytest.mark.small]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add Google-style test size markers (`pytest.mark.small` / `pytest.mark.medium`) to all 10 test files in `tests/config/` and `tests/migration/`, then register both directories in the two enforcement points: `SIZE_DIRECTORIES` in `tests/arch/test_size_markers.py` and `_SIZE_DIRS` in `tests/conftest.py`.

## Architecture Impact

### Development Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% TERMINAL %%
    START([Task Runner])

    subgraph BuildTooling ["BUILD TOOLING"]
        direction TB
        PYPROJECT["pyproject.toml<br/>━━━━━━━━━━<br/>hatchling backend<br/>pytest markers registered<br/>xdist: -n 4 workers"]
        TASKFILE["Taskfile.yml<br/>━━━━━━━━━━<br/>test-all / test-check<br/>test-filtered<br/>coverage-audit"]
        PRECOMMIT[".pre-commit-config.yaml<br/>━━━━━━━━━━<br/>ruff format (auto-fix)<br/>ruff check (auto-fix)<br/>mypy · uv-lock-check<br/>gitleaks"]
    end

    subgraph MarkerRegistry ["SIZE MARKER REGISTRY (pyproject.toml)"]
        direction LR
        SMALL["small<br/>━━━━━━━━━━<br/>No I/O, no network<br/>tmpfs via tmp_path OK"]
        MEDIUM["medium<br/>━━━━━━━━━━<br/>FS + subprocess OK<br/>No network/services"]
        LARGE["large<br/>━━━━━━━━━━<br/>Full integration<br/>Default if unannotated"]
    end

    subgraph TestInfra ["TEST INFRASTRUCTURE"]
        direction TB
        CONFTEST["● tests/conftest.py<br/>━━━━━━━━━━<br/>_SIZE_DIRS constant<br/>{config, core, migration, pipeline}<br/>Shared autouse fixtures<br/>pytest_configure: size-aware filter"]
        FAKES["tests/fakes.py<br/>━━━━━━━━━━<br/>MockSubprocessRunner<br/>Shared test stubs"]
    end

    subgraph ArchEnforcement ["ARCH ENFORCEMENT"]
        direction TB
        SIZE_GUARD["● tests/arch/test_size_markers.py<br/>━━━━━━━━━━<br/>AST-scans SIZE_DIRECTORIES<br/>Imports conftest._SIZE_DIRS<br/>Fails if marker missing/conflicting<br/>Validates pyproject registration"]
    end

    subgraph ConfigTests ["CONFIG TEST LAYER — layer(config)"]
        direction TB
        TCFG["● test_config.py<br/>━━━━━━━━━━<br/>small · AutomationConfig<br/>write_config_layer, load_config<br/>ConfigSchemaError · subsets"]
        TDFL["● test_defaults.py<br/>━━━━━━━━━━<br/>small · RunSkillConfig<br/>Default value assertions"]
        THLP["● test_helpers.py<br/>━━━━━━━━━━<br/>medium · resolve_ingredient_defaults<br/>Real git subprocess"]
        TLBL["● test_settings_allowed_labels.py<br/>━━━━━━━━━━<br/>small · GitHubConfig<br/>Label validation logic"]
        TSTG["● test_settings_staged_label.py<br/>━━━━━━━━━━<br/>small · GitHubConfig<br/>Staged label behavior"]
        TWRK["● test_workspace_temp_dir_config.py<br/>━━━━━━━━━━<br/>small · WorkspaceConfig<br/>Temp dir resolution"]
    end

    subgraph MigrationTests ["MIGRATION TEST LAYER — layer(migration)"]
        direction TB
        TAPI["● tests/migration/test_api.py<br/>━━━━━━━━━━<br/>small · anyio async<br/>check_and_migrate · MigrationResult<br/>Patches recipe + engine"]
        TENG["● tests/migration/test_engine.py<br/>━━━━━━━━━━<br/>small · anyio async<br/>All adapter types<br/>MIGRATE_RECIPES_MAX_RETRIES"]
        TLDR["● tests/migration/test_loader.py<br/>━━━━━━━━━━<br/>small · _parse_migration<br/>applicable_migrations · list_migrations"]
        TSTR["● tests/migration/test_store.py<br/>━━━━━━━━━━<br/>small · FailureStore<br/>atomic_write · record_from_skill"]
    end

    subgraph SourceModules ["SOURCE MODULES UNDER TEST"]
        direction LR
        SRCCFG["autoskillit.config<br/>━━━━━━━━━━<br/>settings · defaults<br/>ingredient_defaults"]
        SRCMIG["autoskillit.migration<br/>━━━━━━━━━━<br/>engine · loader<br/>store · _api"]
    end

    %% FLOW %%
    START --> TASKFILE
    TASKFILE -->|"reads"| PYPROJECT
    PYPROJECT -->|"registers"| SMALL
    PYPROJECT -->|"registers"| MEDIUM
    PYPROJECT -->|"registers"| LARGE

    PRECOMMIT -->|"ruff + mypy gate"| CONFTEST

    CONFTEST -->|"_SIZE_DIRS imported by"| SIZE_GUARD
    PYPROJECT -->|"markers validated by"| SIZE_GUARD
    SIZE_GUARD -->|"AST-scans"| TCFG
    SIZE_GUARD -->|"AST-scans"| TAPI

    CONFTEST -->|"autouse fixtures"| TCFG
    CONFTEST -->|"autouse fixtures"| TDFL
    CONFTEST -->|"autouse fixtures"| THLP
    CONFTEST -->|"autouse fixtures"| TLBL
    CONFTEST -->|"autouse fixtures"| TSTG
    CONFTEST -->|"autouse fixtures"| TWRK

    CONFTEST -->|"autouse fixtures"| TAPI
    CONFTEST -->|"autouse fixtures"| TENG
    CONFTEST -->|"autouse fixtures"| TLDR
    CONFTEST -->|"autouse fixtures"| TSTR

    TCFG -->|"tests"| SRCCFG
    TDFL -->|"tests"| SRCCFG
    THLP -->|"tests"| SRCCFG
    TLBL -->|"tests"| SRCCFG
    TSTG -->|"tests"| SRCCFG
    TWRK -->|"tests"| SRCCFG

    TAPI -->|"tests"| SRCMIG
    TENG -->|"tests"| SRCMIG
    TLDR -->|"tests"| SRCMIG
    TSTR -->|"tests"| SRCMIG

    FAKES -->|"stubs used by"| CONFTEST

    %% CLASS ASSIGNMENTS %%
    class PYPROJECT,TASKFILE,PRECOMMIT phase;
    class SMALL,MEDIUM,LARGE output;
    class CONFTEST,FAKES stateNode;
    class SIZE_GUARD detector;
    class TCFG,TDFL,THLP,TLBL,TSTG,TWRK handler;
    class TAPI,TENG,TLDR,TSTR handler;
    class SRCCFG,SRCMIG cli;
    class START terminal;
```

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph L4_Tests ["L4 — TEST LAYER (all nodes modified ●)"]
        direction LR
        CONFTEST["● tests/conftest.py<br/>━━━━━━━━━━<br/>Shared autouse fixtures<br/>_SIZE_DIRS constant<br/>minimal_ctx / tool_ctx"]
        ARCH["● tests/arch/<br/>test_size_markers.py<br/>━━━━━━━━━━<br/>Validates size marker<br/>registration in pyproject.toml<br/>Reads _SIZE_DIRS from conftest"]
        CFG_TESTS["● tests/config/<br/>test_config · test_defaults<br/>test_helpers · test_settings_*<br/>test_workspace_temp_dir_config<br/>━━━━━━━━━━<br/>pytestmark: layer=config, small"]
        MIG_TESTS["● tests/migration/<br/>test_api · test_engine<br/>test_loader · test_store<br/>━━━━━━━━━━<br/>pytestmark: layer=migration, small"]
    end

    subgraph L3_Server ["L3 — SERVER (unchanged)"]
        SERVER["autoskillit.server<br/>━━━━━━━━━━<br/>_state · _factory"]
    end

    subgraph L2_Domain ["L2 — DOMAIN (unchanged)"]
        direction LR
        MIG_API["autoskillit.migration._api<br/>━━━━━━━━━━<br/>check_and_migrate"]
        MIG_ENGINE["autoskillit.migration.engine<br/>━━━━━━━━━━<br/>MigrationEngine + adapters<br/>MigrationResult"]
        MIG_LOADER["autoskillit.migration.loader<br/>━━━━━━━━━━<br/>MigrationNote<br/>applicable_migrations"]
        MIG_STORE["autoskillit.migration.store<br/>━━━━━━━━━━<br/>FailureStore"]
    end

    subgraph L1_Infra ["L1 — INFRASTRUCTURE (unchanged)"]
        direction LR
        CONFIG["autoskillit.config<br/>━━━━━━━━━━<br/>AutomationConfig · load_config<br/>WorkspaceConfig · PacksConfig<br/>SubsetsConfig"]
        CONFIG_SETTINGS["autoskillit.config.settings<br/>━━━━━━━━━━<br/>GitHubConfig · RunSkillConfig<br/>QuotaGuardConfig · SkillsConfig<br/>write_config_layer · _make_dynaconf"]
        PIPELINE["autoskillit.pipeline<br/>━━━━━━━━━━<br/>audit · context · gate<br/>timings · tokens"]
        EXEC_SESSION["autoskillit.execution.session<br/>━━━━━━━━━━<br/>SkillResult"]
    end

    subgraph L0_Core ["L0 — FOUNDATION (unchanged)"]
        direction LR
        CORE["autoskillit.core<br/>━━━━━━━━━━<br/>pkg_root · load_yaml"]
        CORE_TYPES["autoskillit.core.types<br/>━━━━━━━━━━<br/>ChannelConfirmation<br/>SubprocessResult<br/>TerminationReason · RetryReason"]
    end

    %% TEST → SOURCE IMPORTS %%
    ARCH -->|"reads _SIZE_DIRS"| CONFTEST
    CFG_TESTS -->|"imports config types"| CONFIG
    CFG_TESTS -->|"imports settings internals"| CONFIG_SETTINGS
    CFG_TESTS -->|"imports pkg_root, load_yaml"| CORE
    MIG_TESTS -->|"imports check_and_migrate"| MIG_API
    MIG_TESTS -->|"imports engine + adapters"| MIG_ENGINE
    MIG_TESTS -->|"imports loader helpers"| MIG_LOADER
    MIG_TESTS -->|"imports FailureStore"| MIG_STORE
    MIG_TESTS -->|"imports SkillResult"| EXEC_SESSION
    MIG_TESTS -->|"imports pkg_root, RetryReason"| CORE_TYPES
    CONFTEST -->|"imports AutomationConfig"| CONFIG
    CONFTEST -->|"imports pipeline primitives"| PIPELINE
    CONFTEST -->|"imports make_context"| SERVER
    CONFTEST -->|"imports core types"| CORE_TYPES

    %% VALID SOURCE LAYER DEPENDENCIES %%
    MIG_ENGINE -->|"imports from"| CONFIG
    MIG_ENGINE -->|"imports from"| EXEC_SESSION
    MIG_ENGINE -->|"imports from"| MIG_LOADER
    MIG_API -->|"imports from"| MIG_ENGINE
    CONFIG -->|"imports from"| CORE
    CONFIG_SETTINGS -->|"imports from"| CORE
    PIPELINE -->|"imports from"| CONFIG
    PIPELINE -->|"imports from"| CORE
    SERVER -->|"imports from"| PIPELINE
    SERVER -->|"imports from"| CONFIG
    EXEC_SESSION -->|"imports from"| CORE_TYPES

    %% CLASS ASSIGNMENTS %%
    class CONFTEST,CFG_TESTS,MIG_TESTS,ARCH detector;
    class SERVER integration;
    class MIG_API,MIG_ENGINE,MIG_LOADER,MIG_STORE phase;
    class CONFIG,CONFIG_SETTINGS,PIPELINE,EXEC_SESSION handler;
    class CORE,CORE_TYPES stateNode;
```

Closes #1000

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260417-011154-773535/.autoskillit/temp/make-plan/size_markers_config_migration_plan_2026-04-17_000000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 193 | 9.0k | 836.8k | 46.6k | 1 | 2m 24s |
| review | 52 | 3.6k | 144.3k | 23.3k | 1 | 7m 19s |
| verify | 68 | 7.1k | 281.4k | 42.3k | 1 | 2m 0s |
| implement | 150 | 8.0k | 610.2k | 72.6k | 1 | 2m 2s |
| prepare_pr | 60 | 4.5k | 171.9k | 21.1k | 1 | 1m 49s |
| run_arch_lenses | 1.7k | 11.4k | 336.1k | 59.5k | 2 | 5m 15s |
| compose_pr | 59 | 6.2k | 183.6k | 25.7k | 1 | 1m 48s |
| **Total** | 2.3k | 49.9k | 2.6M | 291.1k | | 22m 40s |