### PR TITLE
Implementation Plan: Size Markers for workspace/ and cli/

### DIFF
--- a/tests/arch/test_size_markers.py
+++ b/tests/arch/test_size_markers.py
@@ -10,10 +10,12 @@ import pytest
 TESTS_ROOT = Path(__file__).resolve().parent.parent
 
 SIZE_DIRECTORIES: dict[str, str] = {
+    "cli": "cli",
     "config": "config",
     "core": "core",
     "migration": "migration",
     "pipeline": "pipeline",
+    "workspace": "workspace",
 }
 
 _VALID_SIZE_MARKERS = {"small", "medium", "large"}

--- a/tests/cli/test_ansi.py
+++ b/tests/cli/test_ansi.py
@@ -8,7 +8,7 @@ import pytest
 
 from autoskillit.cli._ansi import ingredients_to_terminal, supports_color
 
-pytestmark = [pytest.mark.layer("cli")]
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
 
 
 def test_supports_color_respects_no_color(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/cli/test_cli_hooks.py
+++ b/tests/cli/test_cli_hooks.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = [pytest.mark.layer("cli")]
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
 
 
 # HK9

--- a/tests/cli/test_cli_marketplace.py
+++ b/tests/cli/test_cli_marketplace.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-pytestmark = [pytest.mark.layer("cli")]
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
 
 
 # MK1

--- a/tests/cli/test_cli_prompts.py
+++ b/tests/cli/test_cli_prompts.py
@@ -6,7 +6,7 @@ import pytest
 
 from autoskillit.cli._mcp_names import DIRECT_PREFIX, MARKETPLACE_PREFIX
 
-pytestmark = [pytest.mark.layer("cli")]
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
 
 
 # PR1

--- a/tests/cli/test_cli_serve_logging.py
+++ b/tests/cli/test_cli_serve_logging.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 import pytest
 import structlog.testing
 
-pytestmark = [pytest.mark.layer("cli")]
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
 
 
 class TestServeLoggingPhases:

--- a/tests/cli/test_cook.py
+++ b/tests/cli/test_cook.py
@@ -16,7 +16,7 @@ from autoskillit.cli._prompts import _OPEN_KITCHEN_CHOICE, _resolve_recipe_input
 from autoskillit.cli._workspace import _format_age
 from autoskillit.core import ClaudeFlags
 
-pytestmark = [pytest.mark.layer("cli")]
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.medium]
 
 _SCRIPT_YAML = """\
 name: test-script

--- a/tests/cli/test_cook_env_scrub.py
+++ b/tests/cli/test_cook_env_scrub.py
@@ -15,7 +15,7 @@ import pytest
 
 from autoskillit.execution import _MAX_MCP_OUTPUT_TOKENS_VALUE
 
-pytestmark = [pytest.mark.layer("cli")]
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
 
 
 def test_launch_cook_session_env_excludes_ide_vars(

--- a/tests/cli/test_cook_ide_isolation.py
+++ b/tests/cli/test_cook_ide_isolation.py
@@ -19,7 +19,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-pytestmark = [pytest.mark.layer("cli")]
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
 
 
 def test_cook_session_ignores_ide_lock_file(

--- a/tests/cli/test_cook_interactive.py
+++ b/tests/cli/test_cook_interactive.py
@@ -11,7 +11,7 @@ import pytest
 from autoskillit import cli
 from autoskillit.workspace.session_skills import DefaultSessionSkillManager
 
-pytestmark = [pytest.mark.layer("cli")]
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.medium]
 
 
 class TestCookInteractive:

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -11,7 +11,7 @@ import pytest
 
 from autoskillit import cli
 
-pytestmark = [pytest.mark.layer("cli")]
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
 
 _MINIMAL_SCRIPT_YAML = """\
 name: my-script

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -12,7 +12,7 @@ import yaml
 from autoskillit import cli
 from autoskillit.cli import _generate_config_yaml
 
-pytestmark = [pytest.mark.layer("cli")]
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
 
 
 class TestCLIInit:

--- a/tests/cli/test_input_tty_contracts.py
+++ b/tests/cli/test_input_tty_contracts.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = [pytest.mark.layer("cli")]
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
 
 # Files that are *allowed* to contain raw input() calls.
 # _timed_input.py is the sole module that wraps input() with timeout/TTY/ANSI.

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -13,7 +13,7 @@ import pytest
 
 from autoskillit import cli
 
-pytestmark = [pytest.mark.layer("cli")]
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.medium]
 
 
 class TestCLIInstall:

--- a/tests/cli/test_install_info.py
+++ b/tests/cli/test_install_info.py
@@ -19,7 +19,7 @@ from autoskillit.cli._install_info import (
     upgrade_command,
 )
 
-pytestmark = [pytest.mark.layer("cli")]
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/cli/test_installed_plugins_file.py
+++ b/tests/cli/test_installed_plugins_file.py
@@ -9,7 +9,7 @@ import pytest
 
 from autoskillit.cli._installed_plugins import InstalledPluginsFile
 
-pytestmark = [pytest.mark.layer("cli")]
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
 
 REAL_STRUCTURE = {
     "version": 2,

--- a/tests/cli/test_interactive_subprocess_contracts.py
+++ b/tests/cli/test_interactive_subprocess_contracts.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = [pytest.mark.layer("cli")]
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
 
 CLI_DIR = Path(__file__).parent.parent.parent / "src" / "autoskillit" / "cli"
 

--- a/tests/cli/test_mcp_names.py
+++ b/tests/cli/test_mcp_names.py
@@ -13,7 +13,7 @@ from autoskillit.cli._mcp_names import (
     detect_autoskillit_mcp_prefix,
 )
 
-pytestmark = [pytest.mark.layer("cli")]
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
 
 _PLUGIN_KEY = "autoskillit@autoskillit-local"
 

--- a/tests/cli/test_onboarding.py
+++ b/tests/cli/test_onboarding.py
@@ -15,7 +15,7 @@ from autoskillit.cli._onboarding import (
     run_onboarding_menu,
 )
 
-pytestmark = [pytest.mark.layer("cli")]
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
 
 
 def _make_initialized_project(base: Path) -> Path:

--- a/tests/cli/test_orchestrator_prompt_contract.py
+++ b/tests/cli/test_orchestrator_prompt_contract.py
@@ -6,7 +6,7 @@ import re
 
 import pytest
 
-pytestmark = [pytest.mark.layer("cli")]
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
 
 
 def _get_prompt() -> str:

--- a/tests/cli/test_serve_sigterm.py
+++ b/tests/cli/test_serve_sigterm.py
@@ -17,7 +17,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-pytestmark = [pytest.mark.layer("cli")]
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
 
 
 def test_serve_uses_anyio_run_not_mcp_run(monkeypatch, tmp_path):

--- a/tests/cli/test_startup_budget.py
+++ b/tests/cli/test_startup_budget.py
@@ -15,7 +15,7 @@ import structlog.testing
 
 from autoskillit.server import _state
 
-pytestmark = [pytest.mark.layer("cli")]
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
 
 
 def test_serve_calls_mcp_run_within_budget(monkeypatch, tmp_path):

--- a/tests/cli/test_subprocess_env_contracts.py
+++ b/tests/cli/test_subprocess_env_contracts.py
@@ -27,7 +27,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = [pytest.mark.layer("cli")]
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
 
 CLI_ROOT = Path(__file__).parents[2] / "src" / "autoskillit" / "cli"
 SRC_ROOT = Path(__file__).parents[2] / "src" / "autoskillit"

--- a/tests/cli/test_terminal.py
+++ b/tests/cli/test_terminal.py
@@ -14,7 +14,7 @@ import pytest
 
 from autoskillit.cli._terminal import _RESET_SPEC
 
-pytestmark = [pytest.mark.layer("cli")]
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
 
 
 class TestTerminalGuardTTYRestore:

--- a/tests/cli/test_update_checks.py
+++ b/tests/cli/test_update_checks.py
@@ -25,7 +25,7 @@ from autoskillit.cli._update_checks import (
     run_update_checks,
 )
 
-pytestmark = [pytest.mark.layer("cli")]
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/cli/test_update_command.py
+++ b/tests/cli/test_update_command.py
@@ -8,7 +8,7 @@ import pytest
 
 from autoskillit.cli._install_info import InstallInfo, InstallType
 
-pytestmark = [pytest.mark.layer("cli")]
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
 
 
 def _make_info(

--- a/tests/cli/test_workspace.py
+++ b/tests/cli/test_workspace.py
@@ -11,7 +11,7 @@ import pytest
 from autoskillit.cli._workspace import _format_age, run_workspace_clean
 from autoskillit.workspace import CleanupResult
 
-pytestmark = [pytest.mark.layer("cli")]
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
 
 
 class TestFormatAge:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,9 @@ _LAYER_DIRS: frozenset[str] = frozenset(
     }
 )
 
-_SIZE_DIRS: frozenset[str] = frozenset({"config", "core", "migration", "pipeline"})
+_SIZE_DIRS: frozenset[str] = frozenset(
+    {"cli", "config", "core", "migration", "pipeline", "workspace"}
+)
 
 _scope_key = pytest.StashKey[set[_Path] | None]()
 _filter_mode_key = pytest.StashKey[str | None]()

--- a/tests/workspace/test_cleanup.py
+++ b/tests/workspace/test_cleanup.py
@@ -9,7 +9,7 @@ import pytest
 
 from autoskillit.workspace import CleanupResult, _delete_directory_contents
 
-pytestmark = [pytest.mark.layer("workspace")]
+pytestmark = [pytest.mark.layer("workspace"), pytest.mark.small]
 
 
 class TestCleanupResult:

--- a/tests/workspace/test_clone.py
+++ b/tests/workspace/test_clone.py
@@ -23,7 +23,7 @@ from autoskillit.workspace.clone import (
     remove_clone,
 )
 
-pytestmark = [pytest.mark.layer("workspace")]
+pytestmark = [pytest.mark.layer("workspace"), pytest.mark.medium]
 
 
 @pytest.fixture

--- a/tests/workspace/test_clone_ci_contract.py
+++ b/tests/workspace/test_clone_ci_contract.py
@@ -17,7 +17,7 @@ import pytest
 from autoskillit.execution import resolve_remote_repo
 from autoskillit.workspace import clone_repo
 
-pytestmark = [pytest.mark.layer("workspace")]
+pytestmark = [pytest.mark.layer("workspace"), pytest.mark.medium]
 
 # ---------------------------------------------------------------------------
 # Primary cross-boundary integration test

--- a/tests/workspace/test_clone_registry.py
+++ b/tests/workspace/test_clone_registry.py
@@ -15,7 +15,7 @@ from autoskillit.workspace.clone_registry import (
     register_clone,
 )
 
-pytestmark = [pytest.mark.layer("workspace")]
+pytestmark = [pytest.mark.layer("workspace"), pytest.mark.small]
 
 
 class TestRegisterClone:

--- a/tests/workspace/test_clone_timeouts.py
+++ b/tests/workspace/test_clone_timeouts.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = [pytest.mark.layer("workspace")]
+pytestmark = [pytest.mark.layer("workspace"), pytest.mark.small]
 
 _GIT_NETWORK_SUBCOMMANDS = {"push", "clone", "fetch", "pull", "ls-remote"}
 

--- a/tests/workspace/test_constants.py
+++ b/tests/workspace/test_constants.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-pytestmark = [pytest.mark.layer("workspace")]
+pytestmark = [pytest.mark.layer("workspace"), pytest.mark.small]
 
 
 def test_runs_dir_constant_is_exported():

--- a/tests/workspace/test_project_local_overrides.py
+++ b/tests/workspace/test_project_local_overrides.py
@@ -6,7 +6,7 @@ import pytest
 
 from autoskillit.core.types import PACK_REGISTRY
 
-pytestmark = [pytest.mark.layer("workspace")]
+pytestmark = [pytest.mark.layer("workspace"), pytest.mark.small]
 
 # Tags for packs that are disabled by default (e.g. research, exp-lens).
 # Shared by T-OVR-014 and T-OVR-017 to avoid duplication.

--- a/tests/workspace/test_session_skills.py
+++ b/tests/workspace/test_session_skills.py
@@ -16,7 +16,7 @@ from autoskillit.workspace.session_skills import (
     resolve_ephemeral_root,
 )
 
-pytestmark = [pytest.mark.layer("workspace")]
+pytestmark = [pytest.mark.layer("workspace"), pytest.mark.small]
 
 
 def test_resolve_ephemeral_root_returns_writable_dir(

--- a/tests/workspace/test_skill_content_substitution.py
+++ b/tests/workspace/test_skill_content_substitution.py
@@ -11,7 +11,7 @@ from autoskillit.workspace.session_skills import (
     SkillsDirectoryProvider,
 )
 
-pytestmark = [pytest.mark.layer("workspace")]
+pytestmark = [pytest.mark.layer("workspace"), pytest.mark.small]
 
 
 class _StubInfo:

--- a/tests/workspace/test_skills.py
+++ b/tests/workspace/test_skills.py
@@ -15,7 +15,7 @@ from autoskillit.workspace.skills import (
     bundled_skills_extended_dir,
 )
 
-pytestmark = [pytest.mark.layer("workspace")]
+pytestmark = [pytest.mark.layer("workspace"), pytest.mark.small]
 
 BUNDLED_SKILLS = [
     "analyze-prs",

--- a/tests/workspace/test_worktree.py
+++ b/tests/workspace/test_worktree.py
@@ -11,7 +11,7 @@ from autoskillit.workspace.worktree import (
     remove_worktree_sidecar,
 )
 
-pytestmark = [pytest.mark.layer("workspace")]
+pytestmark = [pytest.mark.layer("workspace"), pytest.mark.small]
 
 
 class TestListGitWorktrees:


### PR DESCRIPTION
## Summary

Roll out Google-style test size markers (`pytest.mark.small` / `pytest.mark.medium`) to
all `test_*.py` files in `tests/workspace/` (11 files) and `tests/cli/` (26 files on
disk). Update the two enforcement registries — `SIZE_DIRECTORIES` in
`tests/arch/test_size_markers.py` and `_SIZE_DIRS` in `tests/conftest.py` — to include
`"workspace"` and `"cli"`, activating the existing AST-scan enforcement for these
directories.

## Architecture Impact

### Development Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph Config ["BUILD & TEST CONFIGURATION"]
        direction TB
        PYPROJECT["pyproject.toml<br/>━━━━━━━━━━<br/>markers: small · medium · large<br/>asyncio_mode=auto · timeout=60s<br/>xdist: -n 4 --dist worksteal"]
        TASKFILE["Taskfile.yml<br/>━━━━━━━━━━<br/>test-all · test-check<br/>test-filtered · coverage-audit<br/>sync-plugin-version · install-worktree"]
        PRECOMMIT[".pre-commit-config.yaml<br/>━━━━━━━━━━<br/>ruff-format (auto-fix)<br/>ruff check (auto-fix)<br/>mypy · uv-lock-check · gitleaks"]
    end

    subgraph MarkerSystem ["● SIZE MARKER SYSTEM (pytest markers)"]
        direction LR
        SMALL["@pytest.mark.small<br/>━━━━━━━━━━<br/>No I/O · no subprocess<br/>no network · RAM tmpfs OK"]
        MEDIUM["@pytest.mark.medium<br/>━━━━━━━━━━<br/>Filesystem + subprocess OK<br/>no network · no external svc"]
        LARGE["@pytest.mark.large<br/>━━━━━━━━━━<br/>Full integration<br/>default for unannotated tests"]
    end

    subgraph Conftest ["● tests/conftest.py — Root Configuration"]
        direction TB
        CONFTESTFIX["Auto-use Fixtures<br/>━━━━━━━━━━<br/>_structlog_to_null<br/>_isolated_home<br/>_clear_headless_env<br/>_clear_skip_stale_check_env"]
        CONFTESTSHARED["Shared Fixtures<br/>━━━━━━━━━━<br/>anyio_backend · parse_stdout_json<br/>minimal_ctx · tool_ctx"]
        CONFTEST_HOOKS["pytest Hooks<br/>━━━━━━━━━━<br/>pytest_addoption: --filter-mode<br/>pytest_configure: SIZE_DIRS scope<br/>pytest_collection_modifyitems: layer align + deselect"]
        SIZE_DIRS["_SIZE_DIRS<br/>━━━━━━━━━━<br/>cli · config · core<br/>migration · pipeline · workspace"]
    end

    subgraph Enforcer ["● tests/arch/test_size_markers.py — AST Enforcement"]
        direction TB
        AST_SCAN["AST Scanner<br/>━━━━━━━━━━<br/>Reads every test_*.py<br/>in SIZE_DIRS"]
        T1["test_all_test_files_have_size_marker<br/>━━━━━━━━━━<br/>Each file must have ≥1 size marker<br/>in module-level pytestmark"]
        T2["test_no_conflicting_size_markers<br/>━━━━━━━━━━<br/>Each file must have exactly 1<br/>size marker (no duplicates)"]
        T3["test_size_markers_registered_in_pyproject<br/>━━━━━━━━━━<br/>small · medium · large in<br/>pyproject.toml markers list"]
        T4["test_size_marker_directories_match_conftest<br/>━━━━━━━━━━<br/>SIZE_DIRECTORIES == _SIZE_DIRS<br/>(cross-file consistency)"]
    end

    subgraph CLITests ["● tests/cli/ — 26 Test Files (size markers added)"]
        direction LR
        CLI_SMALL["small-marked files<br/>━━━━━━━━━━<br/>test_ansi · test_mcp_names<br/>test_installed_plugins_file<br/>test_install_info · test_terminal<br/>+ others (pure unit)"]
        CLI_MEDIUM["medium-marked files<br/>━━━━━━━━━━<br/>test_cook · test_doctor<br/>test_init · test_install<br/>test_cli_hooks · test_startup_budget<br/>+ others (subprocess/fs)"]
    end

    subgraph WorkspaceTests ["● tests/workspace/ — 10 Test Files (size markers added)"]
        direction LR
        WS_SMALL["small-marked files<br/>━━━━━━━━━━<br/>test_constants · test_skills<br/>test_session_skills<br/>test_skill_content_substitution"]
        WS_MEDIUM["medium-marked files<br/>━━━━━━━━━━<br/>test_cleanup · test_clone<br/>test_clone_registry · test_worktree<br/>test_clone_ci_contract<br/>test_clone_timeouts · test_project_local_overrides"]
    end

    subgraph TestFilter ["TEST FILTER (AUTOSKILLIT_TEST_FILTER)"]
        direction TB
        CONSERVATIVE["conservative mode<br/>━━━━━━━━━━<br/>Wide layer cascade<br/>all sizes run"]
        AGGRESSIVE["aggressive mode<br/>━━━━━━━━━━<br/>Narrow cascade<br/>small + medium only<br/>(large deselected)"]
        FAILOPEN["fail-open<br/>━━━━━━━━━━<br/>>30 files changed OR<br/>conftest.py/pyproject.toml touched<br/>→ full run"]
    end

    subgraph Runner ["TEST RUNNER (task test-all / task test-check)"]
        direction TB
        PYTEST["pytest<br/>━━━━━━━━━━<br/>-n 4 --dist worksteal<br/>-m 'not smoke and not canary'<br/>timeout: 60s signal"]
        XDIST["pytest-xdist<br/>━━━━━━━━━━<br/>4 parallel workers<br/>tmp_path isolation per test<br/>session fixtures: once per worker"]
        ASYNCIO["pytest-asyncio<br/>━━━━━━━━━━<br/>asyncio_mode=auto<br/>function-scoped event loops"]
    end

    %% FLOW %%
    PYPROJECT --> MarkerSystem
    PYPROJECT --> Conftest
    PRECOMMIT --> Runner
    TASKFILE --> Runner

    MarkerSystem --> CLITests
    MarkerSystem --> WorkspaceTests
    MarkerSystem --> Enforcer

    SIZE_DIRS --> AST_SCAN
    AST_SCAN --> T1
    AST_SCAN --> T2
    AST_SCAN --> T3
    AST_SCAN --> T4

    Conftest --> TestFilter
    TestFilter --> Runner

    CLITests --> Runner
    WorkspaceTests --> Runner

    PYTEST --> XDIST
    PYTEST --> ASYNCIO

    %% CLASS ASSIGNMENTS %%
    class PYPROJECT,TASKFILE,PRECOMMIT phase;
    class SMALL,MEDIUM,LARGE detector;
    class CONFTESTFIX,CONFTESTSHARED stateNode;
    class CONFTEST_HOOKS,SIZE_DIRS handler;
    class AST_SCAN,T1,T2,T3,T4 detector;
    class CLI_SMALL,CLI_MEDIUM cli;
    class WS_SMALL,WS_MEDIUM cli;
    class CONSERVATIVE,AGGRESSIVE,FAILOPEN phase;
    class PYTEST,XDIST,ASYNCIO handler;
```

### Scenarios Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph S1 ["SCENARIO 1 · Developer annotates test file"]
        direction LR
        S1_FILE["● test file<br/>━━━━━━━━━━<br/>tests/cli/ or<br/>tests/workspace/"]
        S1_MARK["● pytestmark<br/>━━━━━━━━━━<br/>layer + small/medium<br/>module-level list"]
        S1_CONF["● conftest._SIZE_DIRS<br/>━━━━━━━━━━<br/>in-scope directory<br/>registry"]
        S1_COLL["pytest collection<br/>━━━━━━━━━━<br/>marker attached<br/>to all items"]
    end

    subgraph S2 ["SCENARIO 2 · Arch enforcement gate"]
        direction LR
        S2_ARCH["● test_size_markers.py<br/>━━━━━━━━━━<br/>parametrized over<br/>6 directories"]
        S2_AST["AST scanner<br/>━━━━━━━━━━<br/>parse pytestmark<br/>without import"]
        S2_PROJ["pyproject.toml<br/>━━━━━━━━━━<br/>markers declaration<br/>small/medium/large"]
        S2_PASS["CI gate PASS<br/>━━━━━━━━━━<br/>all files annotated<br/>no conflicts"]
        S2_FAIL["CI gate FAIL<br/>━━━━━━━━━━<br/>missing or duplicate<br/>size marker"]
    end

    subgraph S3 ["SCENARIO 3 · Filtered execution (aggressive mode)"]
        direction LR
        S3_ENV["AUTOSKILLIT_TEST_FILTER<br/>━━━━━━━━━━<br/>=aggressive<br/>env var"]
        S3_HOOK["● conftest<br/>pytest_collection_modifyitems<br/>━━━━━━━━━━<br/>deselects large/<br/>unannotated items"]
        S3_SMALL["small tests run<br/>━━━━━━━━━━<br/>no I/O, no subprocess<br/>fast feedback"]
        S3_MED["medium tests run<br/>━━━━━━━━━━<br/>filesystem + subprocess<br/>allowed"]
        S3_SKIP["large tests skipped<br/>━━━━━━━━━━<br/>deselected from<br/>collection"]
    end

    subgraph S4 ["SCENARIO 4 · Registry sync validation"]
        direction LR
        S4_ARCH["● test_size_markers.py<br/>━━━━━━━━━━<br/>SIZE_DIRECTORIES<br/>constant"]
        S4_CONF["● conftest._SIZE_DIRS<br/>━━━━━━━━━━<br/>in-scope dir list<br/>used for filtering"]
        S4_CHK["sync check test<br/>━━━━━━━━━━<br/>asserts sets equal<br/>prevents drift"]
        S4_OK["sync OK<br/>━━━━━━━━━━<br/>arch test + conftest<br/>agree on scope"]
    end

    %% SCENARIO 1 FLOW %%
    S1_FILE -->|"adds pytestmark"| S1_MARK
    S1_MARK -->|"in-scope dir?"| S1_CONF
    S1_CONF -->|"collected with marker"| S1_COLL

    %% SCENARIO 2 FLOW %%
    S2_ARCH -->|"reads files via"| S2_AST
    S2_AST -->|"checks registered in"| S2_PROJ
    S2_AST -->|"all present"| S2_PASS
    S2_AST -->|"missing/conflict"| S2_FAIL

    %% SCENARIO 3 FLOW %%
    S3_ENV -->|"activates"| S3_HOOK
    S3_HOOK -->|"keeps"| S3_SMALL
    S3_HOOK -->|"keeps"| S3_MED
    S3_HOOK -->|"deselects"| S3_SKIP

    %% SCENARIO 4 FLOW %%
    S4_ARCH -->|"compared to"| S4_CHK
    S4_CONF -->|"compared to"| S4_CHK
    S4_CHK -->|"sets equal"| S4_OK

    %% CLASS ASSIGNMENTS %%
    class S1_FILE,S1_MARK handler;
    class S1_CONF,S4_CONF stateNode;
    class S1_COLL,S3_SMALL,S3_MED,S2_PASS,S4_OK output;
    class S2_ARCH,S2_AST,S4_ARCH,S4_CHK phase;
    class S2_PROJ,S2_FAIL,S3_SKIP detector;
    class S3_ENV cli;
    class S3_HOOK handler;
```

Closes #1001

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260417-015503-065316/.autoskillit/temp/make-plan/size_markers_workspace_cli_plan_2026-04-17_120000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 103 | 10.2k | 393.4k | 51.1k | 1 | 3m 8s |
| review | 52 | 3.8k | 136.7k | 21.1k | 1 | 2m 45s |
| verify | 76 | 7.8k | 333.4k | 42.8k | 1 | 2m 16s |
| implement | 126 | 7.5k | 453.7k | 69.2k | 1 | 1m 57s |
| prepare_pr | 76 | 5.6k | 233.1k | 23.7k | 1 | 1m 43s |
| run_arch_lenses | 122 | 10.8k | 338.0k | 45.7k | 2 | 4m 20s |
| compose_pr | 67 | 6.0k | 217.0k | 26.1k | 1 | 1m 49s |
| **Total** | 622 | 51.8k | 2.1M | 279.7k | | 18m 1s |