### PR TITLE
Implementation Plan: Size Markers for server/ and recipe/

### DIFF
--- a/tests/arch/test_size_markers.py
+++ b/tests/arch/test_size_markers.py
@@ -15,6 +15,8 @@ SIZE_DIRECTORIES: dict[str, str] = {
     "core": "core",
     "migration": "migration",
     "pipeline": "pipeline",
+    "recipe": "recipe",
+    "server": "server",
     "workspace": "workspace",
 }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ _LAYER_DIRS: frozenset[str] = frozenset(
 )
 
 _SIZE_DIRS: frozenset[str] = frozenset(
-    {"cli", "config", "core", "migration", "pipeline", "workspace"}
+    {"cli", "config", "core", "migration", "pipeline", "recipe", "server", "workspace"}
 )
 
 _scope_key = pytest.StashKey[set[_Path] | None]()

--- a/tests/recipe/test__api.py
+++ b/tests/recipe/test__api.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 # ---------------------------------------------------------------------------
 # T5 — _drop_sub_recipe_step uses dataclasses.replace

--- a/tests/recipe/test_anti_pattern_guards.py
+++ b/tests/recipe/test_anti_pattern_guards.py
@@ -8,7 +8,7 @@ import yaml
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.recipe.rules_blocks import _block_budgets  # re-use the cached loader
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 
 def _budget_for(block_name: str) -> dict:  # type: ignore[type-arg]

--- a/tests/recipe/test_api.py
+++ b/tests/recipe/test_api.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 # Minimal recipe YAML with kitchen_rules
 _RECIPE_WITH_RULES = """\

--- a/tests/recipe/test_bundled_recipe_hidden_policy.py
+++ b/tests/recipe/test_bundled_recipe_hidden_policy.py
@@ -6,7 +6,7 @@ from autoskillit.core.paths import pkg_root
 from autoskillit.recipe.io import load_recipe
 from autoskillit.recipe.registry import run_semantic_rules
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 BUNDLED_RECIPE_NAMES = [
     "implementation",

--- a/tests/recipe/test_bundled_recipes.py
+++ b/tests/recipe/test_bundled_recipes.py
@@ -14,7 +14,7 @@ from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.recipe.rules_merge import _is_commit_guard
 from autoskillit.recipe.validator import analyze_dataflow, run_semantic_rules
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 SMOKE_RECIPE = PROJECT_ROOT / ".autoskillit" / "recipes" / "smoke-test.yaml"

--- a/tests/recipe/test_bundled_recipes_no_inversions.py
+++ b/tests/recipe/test_bundled_recipes_no_inversions.py
@@ -10,7 +10,7 @@ import yaml
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.recipe.registry import run_semantic_rules
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 _BUNDLED_RECIPE_PATHS: list[Path] = sorted(builtin_recipes_dir().glob("*.yaml"))
 

--- a/tests/recipe/test_check_repo_merge_state_routing.py
+++ b/tests/recipe/test_check_repo_merge_state_routing.py
@@ -10,7 +10,7 @@ import pytest
 
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 
 @pytest.mark.parametrize("recipe_name", ["implementation", "remediation", "implementation-groups"])

--- a/tests/recipe/test_contract_verdict_output_required.py
+++ b/tests/recipe/test_contract_verdict_output_required.py
@@ -15,7 +15,7 @@ import pytest
 
 from autoskillit.recipe.contracts import load_bundled_manifest
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 _AUTO_FIX_SKILLS = [
     "resolve-failures",

--- a/tests/recipe/test_contracts.py
+++ b/tests/recipe/test_contracts.py
@@ -18,7 +18,7 @@ from autoskillit.recipe.contracts import (
 )
 from autoskillit.workspace import bundled_skills_extended_dir
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 # ---------------------------------------------------------------------------
 # Bundled manifest tests

--- a/tests/recipe/test_contracts_block_fingerprint.py
+++ b/tests/recipe/test_contracts_block_fingerprint.py
@@ -11,7 +11,7 @@ from autoskillit.recipe.contracts import (
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.recipe.schema import Recipe, RecipeStep
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 
 def test_recipe_card_contains_block_fingerprint_for_every_declared_block():

--- a/tests/recipe/test_diagnose_ci_subtype_output.py
+++ b/tests/recipe/test_diagnose_ci_subtype_output.py
@@ -15,7 +15,7 @@ import pytest
 from autoskillit.core import pkg_root
 from autoskillit.recipe.contracts import load_bundled_manifest
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 _SKILL_MD = pkg_root() / "skills_extended" / "diagnose-ci" / "SKILL.md"
 

--- a/tests/recipe/test_diagrams.py
+++ b/tests/recipe/test_diagrams.py
@@ -14,7 +14,7 @@ from autoskillit.recipe.diagrams import (
 )
 from autoskillit.recipe.io import load_recipe
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.medium]
 
 
 def _extract_graph_section(content: str) -> str:

--- a/tests/recipe/test_experiment_type_registry.py
+++ b/tests/recipe/test_experiment_type_registry.py
@@ -12,7 +12,7 @@ from autoskillit.recipe.experiment_type_registry import (
     load_all_experiment_types,
 )
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 EXPECTED_TYPES = {
     "benchmark",

--- a/tests/recipe/test_full_audit_recipe.py
+++ b/tests/recipe/test_full_audit_recipe.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 RECIPE_PATH = Path(__file__).resolve().parents[2] / ".autoskillit" / "recipes" / "full-audit.yaml"
 

--- a/tests/recipe/test_hidden_ingredients.py
+++ b/tests/recipe/test_hidden_ingredients.py
@@ -7,7 +7,7 @@ import pytest
 from autoskillit.recipe._api import format_ingredients_table
 from autoskillit.recipe.schema import Recipe, RecipeIngredient, RecipeStep
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 
 def _make_recipe(**ingredients: RecipeIngredient) -> Recipe:

--- a/tests/recipe/test_implementation.py
+++ b/tests/recipe/test_implementation.py
@@ -6,7 +6,7 @@ import pytest
 
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 RECIPE_PATH = builtin_recipes_dir() / "implementation.yaml"
 

--- a/tests/recipe/test_implementation_groups_review_loop.py
+++ b/tests/recipe/test_implementation_groups_review_loop.py
@@ -7,7 +7,7 @@ import pytest
 
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 RECIPE_PATH = builtin_recipes_dir() / "implementation-groups.yaml"
 

--- a/tests/recipe/test_implementation_pr_decomposition.py
+++ b/tests/recipe/test_implementation_pr_decomposition.py
@@ -5,7 +5,7 @@ import pytest
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.recipe.validator import validate_recipe
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 RECIPE_PATH = builtin_recipes_dir() / "implementation.yaml"
 

--- a/tests/recipe/test_implementation_sprint_mode.py
+++ b/tests/recipe/test_implementation_sprint_mode.py
@@ -12,7 +12,7 @@ from autoskillit.recipe.registry import run_semantic_rules
 from autoskillit.recipe.validator import validate_recipe
 from tests.recipe.conftest import NO_AUTOSKILLIT_IMPORT as _NO_AUTOSKILLIT_IMPORT
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 
 @pytest.fixture(scope="module")

--- a/tests/recipe/test_io.py
+++ b/tests/recipe/test_io.py
@@ -22,7 +22,7 @@ from autoskillit.recipe.schema import (
 )
 from tests.recipe.conftest import VALID_RECIPE, _write_yaml
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.medium]
 
 
 def test_load_recipe_smoke() -> None:

--- a/tests/recipe/test_issue_url_pipeline.py
+++ b/tests/recipe/test_issue_url_pipeline.py
@@ -9,7 +9,7 @@ from autoskillit.recipe._api import validate_from_path
 from autoskillit.recipe.io import load_recipe
 from tests.recipe.conftest import NO_AUTOSKILLIT_IMPORT as _NO_AUTOSKILLIT_IMPORT
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 RECIPES_DIR = Path(__file__).parent.parent.parent / "src" / "autoskillit" / "recipes"
 

--- a/tests/recipe/test_loader.py
+++ b/tests/recipe/test_loader.py
@@ -11,7 +11,7 @@ from autoskillit.recipe.loader import (
     parse_recipe_metadata,
 )
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.medium]
 
 
 class TestParseRecipeMetadata:

--- a/tests/recipe/test_merge_prs.py
+++ b/tests/recipe/test_merge_prs.py
@@ -6,7 +6,7 @@ import pytest
 
 from autoskillit.recipe.io import builtin_recipes_dir, iter_steps_with_context, load_recipe
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 
 @pytest.fixture(scope="module")

--- a/tests/recipe/test_merge_prs_queue.py
+++ b/tests/recipe/test_merge_prs_queue.py
@@ -12,7 +12,7 @@ from autoskillit.core import PRState
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.recipe.validator import validate_recipe
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/tests/recipe/test_merge_sub_recipe_hidden.py
+++ b/tests/recipe/test_merge_sub_recipe_hidden.py
@@ -5,7 +5,7 @@ import pytest
 from autoskillit.recipe._api import _merge_sub_recipe
 from autoskillit.recipe.schema import Recipe, RecipeIngredient, RecipeStep
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 
 def _recipe(

--- a/tests/recipe/test_plan_visualization_step.py
+++ b/tests/recipe/test_plan_visualization_step.py
@@ -7,7 +7,7 @@ import pytest
 from autoskillit.core.paths import pkg_root
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 RESEARCH_RECIPE_PATH = builtin_recipes_dir() / "research.yaml"
 

--- a/tests/recipe/test_recipe_temp_substitution.py
+++ b/tests/recipe/test_recipe_temp_substitution.py
@@ -8,7 +8,7 @@ import pytest
 
 from autoskillit.recipe.io import load_recipe
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 _RECIPE_TEMPLATE = """\
 name: temp_subst_demo

--- a/tests/recipe/test_remediation_pr_decomposition.py
+++ b/tests/recipe/test_remediation_pr_decomposition.py
@@ -5,7 +5,7 @@ import pytest
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.recipe.validator import validate_recipe
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 RECIPE_PATH = builtin_recipes_dir() / "remediation.yaml"
 

--- a/tests/recipe/test_remediation_recipe.py
+++ b/tests/recipe/test_remediation_recipe.py
@@ -7,7 +7,7 @@ import pytest
 from autoskillit.recipe.io import load_recipe
 from autoskillit.recipe.validator import validate_recipe
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 RECIPE_PATH = (
     Path(__file__).parent.parent.parent / "src" / "autoskillit" / "recipes" / "remediation.yaml"

--- a/tests/recipe/test_remediation_sprint_mode.py
+++ b/tests/recipe/test_remediation_sprint_mode.py
@@ -12,7 +12,7 @@ from autoskillit.recipe.registry import run_semantic_rules
 from autoskillit.recipe.validator import validate_recipe
 from tests.recipe.conftest import NO_AUTOSKILLIT_IMPORT as _NO_AUTOSKILLIT_IMPORT
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 
 @pytest.fixture(scope="module")

--- a/tests/recipe/test_repository.py
+++ b/tests/recipe/test_repository.py
@@ -12,7 +12,7 @@ from autoskillit.core._type_results import LoadResult
 from autoskillit.recipe.repository import DefaultRecipeRepository
 from autoskillit.recipe.schema import RecipeInfo
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 
 def _make_recipe_info(name: str, path: Path) -> RecipeInfo:

--- a/tests/recipe/test_research_bundle_lifecycle.py
+++ b/tests/recipe/test_research_bundle_lifecycle.py
@@ -2,7 +2,7 @@ import pytest
 
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 RESEARCH_RECIPE_PATH = builtin_recipes_dir() / "research.yaml"
 

--- a/tests/recipe/test_research_output_mode.py
+++ b/tests/recipe/test_research_output_mode.py
@@ -3,7 +3,7 @@ import pytest
 
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 RESEARCH_RECIPE_PATH = builtin_recipes_dir() / "research.yaml"
 

--- a/tests/recipe/test_research_recipe_diag.py
+++ b/tests/recipe/test_research_recipe_diag.py
@@ -3,7 +3,7 @@ import pytest
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.recipe.validator import validate_recipe
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 RESEARCH_RECIPE_PATH = builtin_recipes_dir() / "research.yaml"
 

--- a/tests/recipe/test_research_stage_data_step.py
+++ b/tests/recipe/test_research_stage_data_step.py
@@ -6,7 +6,7 @@ import pytest
 
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 RESEARCH_RECIPE_PATH = builtin_recipes_dir() / "research.yaml"
 

--- a/tests/recipe/test_resolve_ci_routing_invariant.py
+++ b/tests/recipe/test_resolve_ci_routing_invariant.py
@@ -13,7 +13,7 @@ import pytest
 from autoskillit.core import pkg_root
 from autoskillit.recipe.io import load_recipe
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 _RECIPES_DIR = pkg_root() / "recipes"
 _PIPELINE_RECIPES = [

--- a/tests/recipe/test_rule_decomposition.py
+++ b/tests/recipe/test_rule_decomposition.py
@@ -7,7 +7,7 @@ import pathlib
 
 import pytest
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 
 def test_no_deferred_validator_imports_in_rule_modules() -> None:

--- a/tests/recipe/test_rules_blocks.py
+++ b/tests/recipe/test_rules_blocks.py
@@ -7,7 +7,7 @@ import pytest
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.recipe.registry import run_semantic_rules
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 _QUEUE_CAPABLE = ("implementation.yaml", "remediation.yaml", "implementation-groups.yaml")
 

--- a/tests/recipe/test_rules_bypass.py
+++ b/tests/recipe/test_rules_bypass.py
@@ -12,7 +12,7 @@ from autoskillit.recipe.schema import (
 )
 from autoskillit.recipe.validator import run_semantic_rules
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 # ---------------------------------------------------------------------------
 # skip_when_false bypass routing tests

--- a/tests/recipe/test_rules_ci.py
+++ b/tests/recipe/test_rules_ci.py
@@ -9,7 +9,7 @@ from autoskillit.recipe.io import _parse_step, builtin_recipes_dir, load_recipe
 from autoskillit.recipe.registry import run_semantic_rules
 from autoskillit.recipe.schema import Recipe, RecipeStep, StepResultCondition, StepResultRoute
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 
 def _make_recipe(steps: dict[str, RecipeStep]) -> Recipe:

--- a/tests/recipe/test_rules_clone.py
+++ b/tests/recipe/test_rules_clone.py
@@ -11,7 +11,7 @@ from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.recipe.registry import run_semantic_rules
 from autoskillit.recipe.schema import Recipe, RecipeStep
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 _BUNDLED_RECIPE_YAMLS = list(builtin_recipes_dir().rglob("*.yaml"))
 assert _BUNDLED_RECIPE_YAMLS, (

--- a/tests/recipe/test_rules_cmd.py
+++ b/tests/recipe/test_rules_cmd.py
@@ -7,7 +7,7 @@ import pytest
 from autoskillit.recipe.validator import run_semantic_rules
 from tests.recipe.conftest import _make_workflow
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 
 def _make_recipe(steps: dict) -> object:

--- a/tests/recipe/test_rules_conditional_push.py
+++ b/tests/recipe/test_rules_conditional_push.py
@@ -19,7 +19,7 @@ from autoskillit.recipe.schema import (
 )
 from autoskillit.recipe.validator import run_semantic_rules
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 _RULE = "conditional-skill-ungated-push"
 

--- a/tests/recipe/test_rules_contracts.py
+++ b/tests/recipe/test_rules_contracts.py
@@ -14,7 +14,7 @@ from autoskillit.recipe.io import load_recipe
 from autoskillit.recipe.registry import run_semantic_rules
 from autoskillit.recipe.schema import Recipe, RecipeStep
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 
 def test_rule_flags_skills_with_empty_output_patterns() -> None:

--- a/tests/recipe/test_rules_dataflow.py
+++ b/tests/recipe/test_rules_dataflow.py
@@ -22,7 +22,7 @@ from autoskillit.recipe.validator import (
 )
 from tests.recipe.conftest import _make_workflow
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/tests/recipe/test_rules_graph.py
+++ b/tests/recipe/test_rules_graph.py
@@ -8,7 +8,7 @@ from autoskillit.core import Severity
 from autoskillit.recipe.registry import run_semantic_rules
 from autoskillit.recipe.schema import Recipe, RecipeStep, StepResultRoute
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 
 def _make_recipe(steps: dict[str, RecipeStep]) -> Recipe:

--- a/tests/recipe/test_rules_inputs.py
+++ b/tests/recipe/test_rules_inputs.py
@@ -11,7 +11,7 @@ from autoskillit.core import Severity
 from autoskillit.recipe.registry import run_semantic_rules
 from autoskillit.recipe.schema import Recipe, RecipeStep
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 
 def _make_recipe_with_skill_step(skill_command: str) -> Recipe:

--- a/tests/recipe/test_rules_isolation.py
+++ b/tests/recipe/test_rules_isolation.py
@@ -12,7 +12,7 @@ from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.recipe.registry import _RULE_REGISTRY, run_semantic_rules
 from tests.recipe.conftest import _make_workflow
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 # ---------------------------------------------------------------------------
 # Test 1a: Rule registration

--- a/tests/recipe/test_rules_merge.py
+++ b/tests/recipe/test_rules_merge.py
@@ -9,7 +9,7 @@ from autoskillit.recipe.registry import run_semantic_rules
 from autoskillit.recipe.rules_merge import _RECOVERABLE_FAILED_STEPS
 from autoskillit.recipe.schema import Recipe, RecipeStep, StepResultCondition, StepResultRoute
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 
 def _make_recipe(steps: dict[str, RecipeStep]) -> Recipe:

--- a/tests/recipe/test_rules_packs.py
+++ b/tests/recipe/test_rules_packs.py
@@ -6,7 +6,7 @@ from autoskillit.core import Severity
 from autoskillit.recipe.registry import run_semantic_rules
 from autoskillit.recipe.schema import Recipe, RecipeStep
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 
 def _make_recipe(requires_packs: list[str]) -> Recipe:

--- a/tests/recipe/test_rules_pipeline_internal.py
+++ b/tests/recipe/test_rules_pipeline_internal.py
@@ -6,7 +6,7 @@ from autoskillit.core import Severity
 from autoskillit.recipe.registry import _RULE_REGISTRY, run_semantic_rules
 from autoskillit.recipe.schema import Recipe, RecipeIngredient
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 
 def _make_recipe_with_ingredients(ingredients: dict) -> Recipe:

--- a/tests/recipe/test_rules_project_local_override.py
+++ b/tests/recipe/test_rules_project_local_override.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.medium]
 
 
 def test_project_local_override_rule_emits_warning(tmp_path):

--- a/tests/recipe/test_rules_reachability.py
+++ b/tests/recipe/test_rules_reachability.py
@@ -20,7 +20,7 @@ from autoskillit.recipe.schema import (
     StepResultRoute,
 )
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 _QUEUE_CAPABLE = ("implementation.yaml", "remediation.yaml", "implementation-groups.yaml")
 

--- a/tests/recipe/test_rules_recipe.py
+++ b/tests/recipe/test_rules_recipe.py
@@ -10,7 +10,7 @@ from autoskillit.recipe._analysis import make_validation_context
 from autoskillit.recipe.registry import _RULE_REGISTRY, run_semantic_rules
 from autoskillit.recipe.schema import Recipe, RecipeIngredient, RecipeStep
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 
 def _make_recipe_with_sub_recipe(sub_recipe_name: str) -> Recipe:

--- a/tests/recipe/test_rules_skill_content.py
+++ b/tests/recipe/test_rules_skill_content.py
@@ -13,7 +13,7 @@ import autoskillit.recipe.rules_skill_content as _rsc
 from autoskillit.recipe.io import load_recipe
 from autoskillit.recipe.registry import run_semantic_rules
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 # Minimal recipe YAML that calls a synthetic bad skill with an undefined placeholder.
 # The YAML key for skill arguments is `with:` (maps to `with_args` via _parse_recipe).

--- a/tests/recipe/test_rules_skills.py
+++ b/tests/recipe/test_rules_skills.py
@@ -9,7 +9,7 @@ from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.recipe.registry import run_semantic_rules
 from autoskillit.recipe.schema import Recipe, RecipeStep
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 
 def _make_recipe(skill_command: str) -> Recipe:

--- a/tests/recipe/test_rules_structure.py
+++ b/tests/recipe/test_rules_structure.py
@@ -23,7 +23,7 @@ from autoskillit.recipe.validator import (
 from tests.recipe.conftest import NO_AUTOSKILLIT_IMPORT as _NO_AUTOSKILLIT_IMPORT
 from tests.recipe.conftest import _make_workflow
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 # ---------------------------------------------------------------------------
 # Module-level semantic rule tests

--- a/tests/recipe/test_rules_subset_disabled.py
+++ b/tests/recipe/test_rules_subset_disabled.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.medium]
 
 
 def _make_skill_recipe(skill_command: str):

--- a/tests/recipe/test_rules_tools.py
+++ b/tests/recipe/test_rules_tools.py
@@ -9,7 +9,7 @@ from autoskillit.core import GATED_TOOLS, UNGATED_TOOLS, Severity
 from autoskillit.recipe.registry import run_semantic_rules
 from autoskillit.recipe.schema import Recipe, RecipeStep
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 
 def _make_recipe(tool: str | None = None, action: str | None = None) -> Recipe:

--- a/tests/recipe/test_rules_verdict.py
+++ b/tests/recipe/test_rules_verdict.py
@@ -19,7 +19,7 @@ from autoskillit.recipe.schema import (
 )
 from autoskillit.recipe.validator import run_semantic_rules
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 
 def _make_recipe(steps: dict[str, RecipeStep]) -> Recipe:

--- a/tests/recipe/test_rules_worktree.py
+++ b/tests/recipe/test_rules_worktree.py
@@ -19,7 +19,7 @@ from autoskillit.recipe.validator import (
 )
 from tests.recipe.conftest import _make_workflow
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 # ---------------------------------------------------------------------------
 # retry-worktree-cwd tests

--- a/tests/recipe/test_schema.py
+++ b/tests/recipe/test_schema.py
@@ -8,7 +8,7 @@ import pathlib
 
 import pytest
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 
 def test_all_dataclasses_importable() -> None:

--- a/tests/recipe/test_skill_emit_consistency.py
+++ b/tests/recipe/test_skill_emit_consistency.py
@@ -9,7 +9,7 @@ import pytest
 from autoskillit.core.paths import pkg_root
 from autoskillit.recipe.contracts import load_bundled_manifest
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 # Key pattern: if a contract output pattern requires an absolute path (contains
 # \s*=\s*/.+), verify that the SKILL.md does not assign the variable to a

--- a/tests/recipe/test_sprint_sub_recipe.py
+++ b/tests/recipe/test_sprint_sub_recipe.py
@@ -9,7 +9,7 @@ from autoskillit.recipe.io import builtin_sub_recipes_dir, load_recipe
 from autoskillit.recipe.registry import run_semantic_rules
 from autoskillit.recipe.validator import validate_recipe
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 
 @pytest.fixture(scope="module")

--- a/tests/recipe/test_staleness_cache.py
+++ b/tests/recipe/test_staleness_cache.py
@@ -11,7 +11,7 @@ from autoskillit.recipe.staleness_cache import (
     write_staleness_cache,
 )
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.medium]
 
 
 def _make_entry(**kwargs) -> StalenessEntry:

--- a/tests/recipe/test_sub_recipe_loading.py
+++ b/tests/recipe/test_sub_recipe_loading.py
@@ -10,7 +10,7 @@ import pytest
 from autoskillit.recipe._api import _build_active_recipe
 from autoskillit.recipe.schema import Recipe, RecipeIngredient, RecipeStep
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 
 def _make_parent_recipe(

--- a/tests/recipe/test_sub_recipe_schema.py
+++ b/tests/recipe/test_sub_recipe_schema.py
@@ -8,7 +8,7 @@ from autoskillit.recipe.io import _parse_step
 from autoskillit.recipe.schema import Recipe, RecipeIngredient, RecipeStep
 from autoskillit.recipe.validator import validate_recipe
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 
 def _make_minimal_recipe(steps: dict, ingredients: dict | None = None) -> Recipe:

--- a/tests/recipe/test_sub_recipe_validation.py
+++ b/tests/recipe/test_sub_recipe_validation.py
@@ -10,7 +10,7 @@ import pytest
 from autoskillit.recipe._analysis import make_validation_context
 from autoskillit.recipe.schema import Recipe, RecipeIngredient, RecipeStep
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 
 def _make_parent_recipe(

--- a/tests/recipe/test_validator.py
+++ b/tests/recipe/test_validator.py
@@ -26,7 +26,7 @@ from autoskillit.recipe.validator import (
 )
 from tests.recipe.conftest import VALID_RECIPE, _make_workflow, _write_yaml
 
-pytestmark = [pytest.mark.layer("recipe")]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.medium]
 
 # ---------------------------------------------------------------------------
 # TestValidateRecipe — migrated from test_recipe_parser.py

--- a/tests/server/test_editable_guard.py
+++ b/tests/server/test_editable_guard.py
@@ -7,7 +7,7 @@ import pytest
 
 from autoskillit.server._editable_guard import scan_editable_installs_for_worktree
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 def _make_dist_info(site_packages: Path, pkg: str, version: str, direct_url: dict) -> None:

--- a/tests/server/test_factory.py
+++ b/tests/server/test_factory.py
@@ -25,7 +25,7 @@ from autoskillit.workspace import DefaultCloneManager, SkillResolver
 from autoskillit.workspace.cleanup import DefaultWorkspaceManager
 from tests.fakes import MockSubprocessRunner
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 def _runner() -> MockSubprocessRunner:

--- a/tests/server/test_factory_recording.py
+++ b/tests/server/test_factory_recording.py
@@ -11,7 +11,7 @@ from autoskillit.execution.recording import RecordingSubprocessRunner, Replaying
 from tests.conftest import _make_result
 from tests.fakes import MockSubprocessRunner
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 @dataclass

--- a/tests/server/test_git.py
+++ b/tests/server/test_git.py
@@ -16,7 +16,7 @@ from autoskillit.core.types import (
 )
 from tests.fakes import InMemoryTestRunner, MockSubprocessRunner
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 def _make_result(

--- a/tests/server/test_headless_session.py
+++ b/tests/server/test_headless_session.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.medium]
 
 
 @pytest.mark.anyio

--- a/tests/server/test_helpers.py
+++ b/tests/server/test_helpers.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.medium]
 
 
 @pytest.mark.anyio

--- a/tests/server/test_helpers_gate.py
+++ b/tests/server/test_helpers_gate.py
@@ -6,7 +6,7 @@ import json
 
 import pytest
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 class TestGateDisabledSchema:

--- a/tests/server/test_lifespan.py
+++ b/tests/server/test_lifespan.py
@@ -8,7 +8,7 @@ import pytest
 
 from autoskillit.execution.recording import RecordingSubprocessRunner
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_lifespan_readiness_structural.py
+++ b/tests/server/test_lifespan_readiness_structural.py
@@ -19,7 +19,7 @@ import pytest
 
 from autoskillit.core._type_constants import RETIRED_READINESS_TOKENS
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 _LIFESPAN_PATH = (
     Path(__file__).parent.parent.parent / "src" / "autoskillit" / "server" / "_lifespan.py"

--- a/tests/server/test_mcp_overrides.py
+++ b/tests/server/test_mcp_overrides.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 def _make_mock_recipes(load_result: dict) -> MagicMock:

--- a/tests/server/test_no_raw_signal_handler.py
+++ b/tests/server/test_no_raw_signal_handler.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 _APP_PATH = Path(__file__).parent.parent.parent / "src" / "autoskillit" / "cli" / "app.py"
 _SRC_ROOT = Path(__file__).parent.parent.parent / "src" / "autoskillit"

--- a/tests/server/test_perform_merge_editable_guard.py
+++ b/tests/server/test_perform_merge_editable_guard.py
@@ -14,7 +14,7 @@ from autoskillit.core.types import (
 )
 from tests.fakes import InMemoryTestRunner, MockSubprocessRunner
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 def _make_result(returncode: int = 0, stdout: str = "", stderr: str = "") -> SubprocessResult:

--- a/tests/server/test_quota_refresh_loop.py
+++ b/tests/server/test_quota_refresh_loop.py
@@ -9,7 +9,7 @@ import pytest
 
 from autoskillit.config.settings import QuotaGuardConfig
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 @pytest.mark.anyio

--- a/tests/server/test_run_skill_add_dirs.py
+++ b/tests/server/test_run_skill_add_dirs.py
@@ -6,7 +6,7 @@ import pytest
 
 from autoskillit.core import ValidatedAddDir
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 @pytest.mark.anyio

--- a/tests/server/test_server_init.py
+++ b/tests/server/test_server_init.py
@@ -13,7 +13,7 @@ from autoskillit.pipeline.gate import DefaultGateState
 from autoskillit.server.helpers import _require_enabled
 from autoskillit.server.tools_kitchen import _close_kitchen_handler, _open_kitchen_handler
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.medium]
 
 
 class TestKitchenVisibility:

--- a/tests/server/test_server_tool_registration.py
+++ b/tests/server/test_server_tool_registration.py
@@ -17,7 +17,7 @@ from autoskillit.server.tools_status import (
     get_token_summary,
 )
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 class TestNoSkillsDirectoryProvider:

--- a/tests/server/test_server_version_telemetry.py
+++ b/tests/server/test_server_version_telemetry.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 import pytest
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 class TestPluginMetadataExists:

--- a/tests/server/test_service_wrappers.py
+++ b/tests/server/test_service_wrappers.py
@@ -14,7 +14,7 @@ import yaml
 
 import autoskillit
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 class TestDefaultRecipeRepository:

--- a/tests/server/test_set_commit_status.py
+++ b/tests/server/test_set_commit_status.py
@@ -10,7 +10,7 @@ from autoskillit.pipeline.gate import GATED_TOOLS, DefaultGateState
 from autoskillit.server.tools_ci import set_commit_status
 from tests.conftest import _make_result
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 async def _async_return(value: object) -> object:

--- a/tests/server/test_smoke_pipeline.py
+++ b/tests/server/test_smoke_pipeline.py
@@ -26,7 +26,7 @@ import pytest
 from autoskillit.recipe.io import builtin_recipes_dir
 from autoskillit.server.tools_recipe import list_recipes, validate_recipe
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.medium]
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 SMOKE_SCRIPT = PROJECT_ROOT / ".autoskillit" / "recipes" / "smoke-test.yaml"

--- a/tests/server/test_state.py
+++ b/tests/server/test_state.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 def _make_mock_ctx(tmp_path: Path) -> MagicMock:

--- a/tests/server/test_tool_exception_boundary.py
+++ b/tests/server/test_tool_exception_boundary.py
@@ -14,7 +14,7 @@ import pytest
 
 from autoskillit.pipeline.mcp_response import DefaultMcpResponseLog
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 class TestToolExceptionBoundary:

--- a/tests/server/test_tools_ci.py
+++ b/tests/server/test_tools_ci.py
@@ -18,7 +18,7 @@ from autoskillit.server.tools_ci import (
 )
 from tests.fakes import InMemoryCIWatcher, InMemoryMergeQueueWatcher
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 # ---------------------------------------------------------------------------
 # Gate membership

--- a/tests/server/test_tools_clone.py
+++ b/tests/server/test_tools_clone.py
@@ -17,7 +17,7 @@ from autoskillit.server.tools_clone import (
 )
 from autoskillit.workspace import clone_registry
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 class TestCloneRepoTool:

--- a/tests/server/test_tools_execution.py
+++ b/tests/server/test_tools_execution.py
@@ -26,7 +26,7 @@ from autoskillit.server.helpers import (
 from autoskillit.server.tools_execution import run_skill
 from tests.conftest import _make_result
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 _SUCCESS_JSON = (
     '{"type": "result", "subtype": "success", "is_error": false,'

--- a/tests/server/test_tools_execution_response.py
+++ b/tests/server/test_tools_execution_response.py
@@ -14,7 +14,7 @@ from autoskillit.core.types import (
 )
 from autoskillit.server.tools_execution import run_skill
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 def _make_session_result(

--- a/tests/server/test_tools_git.py
+++ b/tests/server/test_tools_git.py
@@ -20,7 +20,7 @@ from autoskillit.server.tools_git import (
 )
 from tests.conftest import _make_result
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 class TestClassifyFix:

--- a/tests/server/test_tools_github.py
+++ b/tests/server/test_tools_github.py
@@ -32,7 +32,7 @@ from autoskillit.server.tools_issue_lifecycle import (
 )
 from tests.server._helpers import _skill_fail, _skill_ok
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 # ---------------------------------------------------------------------------
 # _parse_fingerprint unit tests

--- a/tests/server/test_tools_integrations.py
+++ b/tests/server/test_tools_integrations.py
@@ -20,7 +20,7 @@ from autoskillit.server.tools_issue_lifecycle import (
 from autoskillit.server.tools_pr_ops import bulk_close_issues, get_pr_reviews
 from tests.conftest import _make_result
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 # ---------------------------------------------------------------------------
 # claim_issue / release_issue / prepare_issue / enrich_issues — gated tools

--- a/tests/server/test_tools_integrations_release.py
+++ b/tests/server/test_tools_integrations_release.py
@@ -9,7 +9,7 @@ import pytest
 
 from autoskillit.server.tools_issue_lifecycle import release_issue
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 class TestReleaseIssueStagedLifecycle:

--- a/tests/server/test_tools_issue_lifecycle.py
+++ b/tests/server/test_tools_issue_lifecycle.py
@@ -24,7 +24,7 @@ from autoskillit.server.tools_issue_lifecycle import (
     release_issue,
 )
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 def _make_skill_result(

--- a/tests/server/test_tools_kitchen.py
+++ b/tests/server/test_tools_kitchen.py
@@ -12,7 +12,7 @@ import pytest
 from autoskillit.config.settings import QuotaGuardConfig
 from autoskillit.hooks._fmt_primitives import _HOOK_CONFIG_PATH_COMPONENTS
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 def _make_mock_ctx():

--- a/tests/server/test_tools_label_validation.py
+++ b/tests/server/test_tools_label_validation.py
@@ -9,7 +9,7 @@ import pytest
 
 from autoskillit.server.tools_issue_lifecycle import claim_issue, prepare_issue, release_issue
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 class TestClaimIssueWhitelist:

--- a/tests/server/test_tools_list_recipes.py
+++ b/tests/server/test_tools_list_recipes.py
@@ -11,7 +11,7 @@ import pytest
 from autoskillit.pipeline.gate import DefaultGateState
 from autoskillit.server.tools_recipe import list_recipes
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 class TestListRecipeTools:

--- a/tests/server/test_tools_load_recipe.py
+++ b/tests/server/test_tools_load_recipe.py
@@ -17,7 +17,7 @@ from autoskillit.server.tools_recipe import (
     migrate_recipe,
 )
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 # ---------------------------------------------------------------------------
 # Minimal valid script YAML used across migration suggestion tests

--- a/tests/server/test_tools_pr_ops.py
+++ b/tests/server/test_tools_pr_ops.py
@@ -16,7 +16,7 @@ from autoskillit.server.tools_pr_ops import (
     get_pr_reviews,
 )
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 # ---------------------------------------------------------------------------
 # Pure helper functions

--- a/tests/server/test_tools_recipe.py
+++ b/tests/server/test_tools_recipe.py
@@ -9,7 +9,7 @@ import pytest
 
 from autoskillit.server.tools_recipe import validate_recipe
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 def _extract_docstring_sections(desc: str) -> dict[str, str]:

--- a/tests/server/test_tools_run_cmd.py
+++ b/tests/server/test_tools_run_cmd.py
@@ -12,7 +12,7 @@ from autoskillit.server.helpers import _run_subprocess
 from autoskillit.server.tools_execution import run_cmd, run_python
 from tests.conftest import _make_result, _make_timeout_result
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 class TestRunCmd:

--- a/tests/server/test_tools_run_cmd_unit.py
+++ b/tests/server/test_tools_run_cmd_unit.py
@@ -12,7 +12,7 @@ import structlog.testing
 from autoskillit.server.tools_execution import run_cmd
 from tests.conftest import _make_result
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 class TestRunCmdObservability:

--- a/tests/server/test_tools_run_python.py
+++ b/tests/server/test_tools_run_python.py
@@ -11,7 +11,7 @@ import structlog.testing
 
 from autoskillit.server.tools_execution import run_python
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 class TestRunPythonObservability:

--- a/tests/server/test_tools_run_skill_retry.py
+++ b/tests/server/test_tools_run_skill_retry.py
@@ -11,7 +11,7 @@ from autoskillit.core.types import RetryReason, TerminationReason
 from autoskillit.server.tools_execution import run_skill
 from tests.conftest import _make_result
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 # Deterministic UUID for tests that need to predict the per-invocation marker.
 _DETERMINISTIC_HEX = "a1b2c3d4e5f6a7b890123456"

--- a/tests/server/test_tools_session_diagnostics.py
+++ b/tests/server/test_tools_session_diagnostics.py
@@ -16,7 +16,7 @@ from autoskillit.server.tools_github import (
     report_bug,
 )
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 # ---------------------------------------------------------------------------
 # _read_session_diagnostics unit tests

--- a/tests/server/test_tools_status.py
+++ b/tests/server/test_tools_status.py
@@ -28,7 +28,7 @@ from autoskillit.server.tools_status import (
 )
 from tests.conftest import _make_result
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 def _make_failure_record(**overrides: object) -> FailureRecord:

--- a/tests/server/test_tools_status_mcp_response.py
+++ b/tests/server/test_tools_status_mcp_response.py
@@ -9,7 +9,7 @@ import pytest
 
 from autoskillit.server.tools_status import get_token_summary, write_telemetry_files
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 class TestGetTokenSummaryMcpResponses:

--- a/tests/server/test_tools_workspace.py
+++ b/tests/server/test_tools_workspace.py
@@ -17,7 +17,7 @@ from autoskillit.server.tools_workspace import reset_test_dir, reset_workspace, 
 from autoskillit.workspace import CleanupResult
 from tests.conftest import _make_result
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 test_check.__test__ = False  # type: ignore[attr-defined]
 

--- a/tests/server/test_track_response_size.py
+++ b/tests/server/test_track_response_size.py
@@ -9,7 +9,7 @@ import pytest
 
 from autoskillit.pipeline.mcp_response import DefaultMcpResponseLog
 
-pytestmark = [pytest.mark.layer("server")]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 
 class TestTrackResponseSize:


### PR DESCRIPTION
## Summary

Roll out Google-style test size markers (`pytest.mark.small` / `pytest.mark.medium`) to
`tests/server/` (46 files) and `tests/recipe/` (69 files). Each file gets exactly one
size marker appended to its existing `pytestmark` list. Two registry entries require
updating: `SIZE_DIRECTORIES` in `tests/arch/test_size_markers.py` and `_SIZE_DIRS` in
`tests/conftest.py`. The existing `test_size_markers.py` parametrized tests become the
primary verification gate — once the registry additions are in place, they will fail
until all 115 files carry valid size markers.

## Architecture Impact

### Development Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;

    subgraph Build ["BUILD TOOLING"]
        direction TB
        PYPROJECT["pyproject.toml<br/>━━━━━━━━━━<br/>hatchling backend<br/>markers: small/medium/large<br/>timeout: 60s · asyncio_mode: auto"]
        TASKFILE["Taskfile.yml<br/>━━━━━━━━━━<br/>test-all / test-check / test-filtered<br/>install-worktree / sync-plugin-version"]
        UV["uv<br/>━━━━━━━━━━<br/>Package manager + lock file<br/>worktree-aware venv"]
    end

    subgraph Quality ["CODE QUALITY GATES (pre-commit)"]
        direction LR
        RUFF_FMT["ruff format<br/>━━━━━━━━━━<br/>Auto-formats source<br/>(READ + WRITE)"]
        RUFF_LINT["ruff check --fix<br/>━━━━━━━━━━<br/>Lints + auto-fixes<br/>(READ + WRITE)"]
        MYPY["mypy<br/>━━━━━━━━━━<br/>Type checking<br/>(READ only)"]
        GITLEAKS["gitleaks v8.30<br/>━━━━━━━━━━<br/>Secret scanning<br/>(READ only)"]
        UV_CHECK["uv lock --check<br/>━━━━━━━━━━<br/>Lock file sync guard<br/>(READ only)"]
    end

    subgraph SizeMarkerSystem ["SIZE MARKER SYSTEM"]
        direction TB
        CONFTEST["● tests/conftest.py<br/>━━━━━━━━━━<br/>_SIZE_DIRS registry (8 dirs)<br/>pytest_collection_modifyitems<br/>aggressive filter deselects unannotated"]
        ARCH_TEST["● tests/arch/test_size_markers.py<br/>━━━━━━━━━━<br/>SIZE_DIRECTORIES registry<br/>AST-scans pytestmark assignments<br/>cross-validates _SIZE_DIRS ↔ SIZE_DIRECTORIES"]
        MARKERS["small / medium / large<br/>━━━━━━━━━━<br/>Google test size taxonomy<br/>small=unit · medium=fs/proc · large=network"]
    end

    subgraph EnrolledDirs ["TEST DIRECTORIES (size-marker enrolled)"]
        direction LR
        CLI_D["tests/cli/"]
        CFG_D["tests/config/"]
        CORE_D["tests/core/"]
        MIG_D["tests/migration/"]
        PIPE_D["tests/pipeline/"]
        WS_D["tests/workspace/"]
        RECIPE_D["● tests/recipe/<br/>━━━━━━━━━━<br/>68 test files<br/>recipe I/O · validation · rules"]
        SERVER_D["● tests/server/<br/>━━━━━━━━━━<br/>46 test files<br/>MCP tool handlers · kitchen gating"]
    end

    subgraph TestFramework ["TEST FRAMEWORK"]
        direction TB
        PYTEST["pytest-xdist<br/>━━━━━━━━━━<br/>-n 4 --dist worksteal<br/>parallel execution"]
        TMPFS["RAM-backed tmpdir<br/>━━━━━━━━━━<br/>/dev/shm/pytest-tmp<br/>Linux tmpfs isolation"]
        CONFTEST_FIXTURES["tests/conftest.py fixtures<br/>━━━━━━━━━━<br/>tool_ctx · minimal_ctx<br/>_isolated_home · _structlog_to_null"]
        SERVER_CF["● tests/server/conftest.py<br/>━━━━━━━━━━<br/>_reset_server_state (autouse)<br/>_reset_mcp_tags (autouse)<br/>kitchen_enabled · headless_enabled"]
        RECIPE_CF["tests/recipe/conftest.py<br/>━━━━━━━━━━<br/>_make_workflow · VALID_RECIPE<br/>_write_yaml · fixture YAML files"]
    end

    subgraph EntryPoints ["ENTRY POINTS"]
        direction LR
        CLI_EP["autoskillit<br/>━━━━━━━━━━<br/>autoskillit.cli:main<br/>serve · init · doctor · cook"]
        TEST_EP["task test-check<br/>━━━━━━━━━━<br/>TEST_RESULT=PASS/FAIL<br/>automation-safe output"]
        FILTER_EP["task test-filtered<br/>━━━━━━━━━━<br/>conservative/aggressive/none<br/>git-diff-scoped runs"]
    end

    %% FLOW %%
    PYPROJECT --> TASKFILE
    UV --> PYPROJECT

    PYPROJECT --> RUFF_FMT
    RUFF_FMT --> RUFF_LINT
    RUFF_LINT --> MYPY
    MYPY --> GITLEAKS
    GITLEAKS --> UV_CHECK

    PYPROJECT --> MARKERS
    MARKERS --> CONFTEST
    MARKERS --> ARCH_TEST
    CONFTEST <-->|cross-validates| ARCH_TEST

    CONFTEST --> CLI_D
    CONFTEST --> CFG_D
    CONFTEST --> CORE_D
    CONFTEST --> MIG_D
    CONFTEST --> PIPE_D
    CONFTEST --> WS_D
    CONFTEST --> RECIPE_D
    CONFTEST --> SERVER_D

    ARCH_TEST -->|AST scans| RECIPE_D
    ARCH_TEST -->|AST scans| SERVER_D

    CONFTEST_FIXTURES --> PYTEST
    SERVER_CF --> PYTEST
    RECIPE_CF --> PYTEST
    TMPFS --> PYTEST

    RECIPE_D --> PYTEST
    SERVER_D --> PYTEST

    UV_CHECK --> PYTEST
    TASKFILE --> TEST_EP
    TASKFILE --> FILTER_EP
    CLI_EP --> EntryPoints

    %% CLASS ASSIGNMENTS %%
    class PYPROJECT,UV phase;
    class TASKFILE phase;
    class RUFF_FMT,RUFF_LINT detector;
    class MYPY,GITLEAKS,UV_CHECK detector;
    class CONFTEST,ARCH_TEST stateNode;
    class MARKERS stateNode;
    class CLI_D,CFG_D,CORE_D,MIG_D,PIPE_D,WS_D cli;
    class RECIPE_D,SERVER_D handler;
    class PYTEST,TMPFS handler;
    class CONFTEST_FIXTURES,SERVER_CF,RECIPE_CF stateNode;
    class CLI_EP,TEST_EP,FILTER_EP output;
```

### Scenarios Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ══════════════════════════════════════════════════════════ %%
    %% SCENARIO 1: Developer aggressive filter run               %%
    %% ══════════════════════════════════════════════════════════ %%
    subgraph S1 ["● SCENARIO 1: Aggressive Filter — Small/Medium Only"]
        direction LR
        S1_ENV["AUTOSKILLIT_TEST_FILTER<br/>━━━━━━━━━━<br/>=aggressive env var<br/>or --filter-mode flag"]
        S1_COLLECT["pytest_collection_modifyitems<br/>━━━━━━━━━━<br/>● tests/conftest.py<br/>reads iter_markers()"]
        S1_FILTER["Size Deselection Pass<br/>━━━━━━━━━━<br/>● _SIZE_DIRS frozenset<br/>small+medium → kept<br/>large/unannotated → dropped"]
        S1_SERVER["● tests/server/<br/>━━━━━━━━━━<br/>42 small + 4 medium<br/>= 46 kept, 0 dropped"]
        S1_RECIPE["● tests/recipe/<br/>━━━━━━━━━━<br/>62 small + 7 medium<br/>= 69 kept, 0 dropped"]
        S1_OUT["Fast Local Run<br/>━━━━━━━━━━<br/>No large tests<br/>Full server+recipe coverage"]
    end

    S1_ENV --> S1_COLLECT --> S1_FILTER
    S1_FILTER --> S1_SERVER --> S1_OUT
    S1_FILTER --> S1_RECIPE --> S1_OUT

    %% ══════════════════════════════════════════════════════════ %%
    %% SCENARIO 2: CI arch enforcement                          %%
    %% ══════════════════════════════════════════════════════════ %%
    subgraph S2 ["● SCENARIO 2: CI Arch Enforcement — Every File Must Have a Marker"]
        direction LR
        S2_ENTRY["task test-all<br/>━━━━━━━━━━<br/>CI / local full run"]
        S2_ARCH["● test_size_markers.py<br/>━━━━━━━━━━<br/>SIZE_DIRECTORIES dict<br/>includes server + recipe"]
        S2_AST["AST Scanner<br/>━━━━━━━━━━<br/>parses pytestmark<br/>per test_*.py file"]
        S2_MARKER_CHECK["Presence + Uniqueness<br/>━━━━━━━━━━<br/>exactly one of<br/>small / medium / large<br/>per file"]
        S2_PYPROJECT["pyproject.toml markers<br/>━━━━━━━━━━<br/>small, medium, large<br/>registered → no warnings"]
        S2_PASS["PASS<br/>━━━━━━━━━━<br/>All 115+ files<br/>fully annotated"]
    end

    S2_ENTRY --> S2_ARCH --> S2_AST --> S2_MARKER_CHECK --> S2_PASS
    S2_ARCH --> S2_PYPROJECT --> S2_PASS

    %% ══════════════════════════════════════════════════════════ %%
    %% SCENARIO 3: Server tool test (small, fully mocked)       %%
    %% ══════════════════════════════════════════════════════════ %%
    subgraph S3 ["● SCENARIO 3: Server Tool Test — Small, Mocked Context"]
        direction LR
        S3_FILE["● test_tools_kitchen.py<br/>━━━━━━━━━━<br/>pytestmark = [layer(server),<br/>pytest.mark.small]"]
        S3_CONFROOT["● tests/conftest.py<br/>━━━━━━━━━━<br/>_structlog_to_null (autouse)<br/>_isolated_home (autouse)<br/>tool_ctx fixture"]
        S3_CONFSVR["● tests/server/conftest.py<br/>━━━━━━━━━━<br/>_reset_server_state (autouse)<br/>_reset_mcp_tags (autouse)<br/>kitchen_enabled / headless_enabled"]
        S3_CTX["tool_ctx → make_context()<br/>━━━━━━━━━━<br/>monkeypatches<br/>server._state._ctx<br/>full L3 mock stack"]
        S3_RUN["Test executes<br/>━━━━━━━━━━<br/>no real I/O<br/>no subprocess<br/>no network"]
        S3_TEARDOWN["xdist-safe teardown<br/>━━━━━━━━━━<br/>_reset_server_state restores ctx<br/>_reset_mcp_tags clears tags"]
    end

    S3_FILE --> S3_CONFROOT --> S3_CTX
    S3_FILE --> S3_CONFSVR --> S3_CTX
    S3_CTX --> S3_RUN --> S3_TEARDOWN

    %% ══════════════════════════════════════════════════════════ %%
    %% SCENARIO 4: Recipe file test (medium, real filesystem)   %%
    %% ══════════════════════════════════════════════════════════ %%
    subgraph S4 ["● SCENARIO 4: Recipe File Test — Medium, Real Filesystem"]
        direction LR
        S4_FILE["● test_io.py / test_loader.py<br/>━━━━━━━━━━<br/>pytestmark = [layer(recipe),<br/>pytest.mark.medium]"]
        S4_CONFROOT2["● tests/conftest.py<br/>━━━━━━━━━━<br/>_isolated_home → tmp_path<br/>replaces Path.home()<br/>anyio_backend = asyncio"]
        S4_HELPERS["tests/recipe/conftest.py<br/>━━━━━━━━━━<br/>_write_yaml(path, data)<br/>VALID_RECIPE constant<br/>_make_workflow(steps)"]
        S4_FS["Real Filesystem via tmp_path<br/>━━━━━━━━━━<br/>writes YAML to disk<br/>reads back via load_recipe<br/>no home dir contamination"]
        S4_RESULT["Validation Result<br/>━━━━━━━━━━<br/>recipe loaded + validated<br/>real I/O confirmed correct"]
    end

    S4_FILE --> S4_CONFROOT2 --> S4_FS
    S4_FILE --> S4_HELPERS --> S4_FS
    S4_FS --> S4_RESULT

    %% ══════════════════════════════════════════════════════════ %%
    %% SCENARIO 5: Directory registry divergence detection      %%
    %% ══════════════════════════════════════════════════════════ %%
    subgraph S5 ["● SCENARIO 5: Directory Registry Sync — Divergence Guard"]
        direction LR
        S5_ARCH2["● test_size_markers.py<br/>━━━━━━━━━━<br/>SIZE_DIRECTORIES dict<br/>includes server + recipe"]
        S5_IMPORT["imports _SIZE_DIRS<br/>━━━━━━━━━━<br/>from tests.conftest<br/>frozenset of 8 dirs"]
        S5_CMP["test_size_marker_directories_<br/>match_conftest<br/>━━━━━━━━━━<br/>set(SIZE_DIRECTORIES.keys())<br/>== _SIZE_DIRS assertion"]
        S5_GUARD["Divergence Blocked<br/>━━━━━━━━━━<br/>add dir to arch but not conftest<br/>(or vice versa) → FAIL<br/>cannot slip through CI"]
    end

    S5_ARCH2 --> S5_IMPORT --> S5_CMP --> S5_GUARD

    %% ══════════════════════════════════════════════════════════ %%
    %% CLASS ASSIGNMENTS %%
    class S1_ENV cli;
    class S1_COLLECT,S1_FILTER phase;
    class S1_SERVER,S1_RECIPE stateNode;
    class S1_OUT output;
    class S2_ENTRY cli;
    class S2_ARCH,S2_AST detector;
    class S2_MARKER_CHECK phase;
    class S2_PYPROJECT stateNode;
    class S2_PASS output;
    class S3_FILE cli;
    class S3_CONFROOT,S3_CONFSVR phase;
    class S3_CTX stateNode;
    class S3_RUN handler;
    class S3_TEARDOWN detector;
    class S4_FILE cli;
    class S4_CONFROOT2,S4_HELPERS phase;
    class S4_FS stateNode;
    class S4_RESULT output;
    class S5_ARCH2 cli;
    class S5_IMPORT phase;
    class S5_CMP detector;
    class S5_GUARD handler;
```

Closes #1002

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260417-023432-887906/.autoskillit/temp/make-plan/size_markers_server_recipe_plan_2026-04-17_030000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 173 | 14.4k | 938.5k | 63.5k | 1 | 3m 43s |
| review | 10 | 64 | 54.3k | 3.4k | 1 | 6m 51s |
| verify | 68 | 10.8k | 309.3k | 49.0k | 1 | 2m 33s |
| implement | 158 | 8.2k | 741.8k | 44.3k | 1 | 2m 33s |
| prepare_pr | 60 | 11.2k | 186.5k | 31.9k | 1 | 2m 8s |
| run_arch_lenses | 2.2k | 22.7k | 588.7k | 142.1k | 3 | 13m 0s |
| compose_pr | 67 | 7.2k | 220.3k | 30.8k | 1 | 1m 43s |
| **Total** | 2.7k | 74.6k | 3.0M | 365.0k | | 32m 34s |