### PR TITLE
Implementation Plan: Build Coverage DB Oracle for Test-to-Source Mapping

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -133,6 +133,13 @@ tasks:
           --coverage-db .coverage \
           --output "temp/coverage-audit-$(date +%Y%m%d-%H%M%S).json"
 
+        echo ""
+        echo "--- Building test-source map ---"
+        $PYTHON scripts/compare-coverage-ast.py \
+          --mode build-test-source-map \
+          --coverage-db .coverage \
+          --output ".autoskillit/test-source-map.json"
+
   test-smoke:
     desc: Run smoke tests (requires ANTHROPIC_API_KEY)
     deps: [_tmpdir-setup]

--- a/scripts/compare-coverage-ast.py
+++ b/scripts/compare-coverage-ast.py
@@ -182,7 +182,7 @@ def query_contexts_map(db_path: Path) -> dict[str, set[str]]:
     try:
         data = coverage.CoverageData(basename=str(db_path))
         data.read()
-    except Exception as exc:
+    except (OSError, coverage.CoverageException) as exc:
         print(f"ERROR: Failed to read coverage database {db_path}: {exc}", file=sys.stderr)
         return {}
 

--- a/scripts/compare-coverage-ast.py
+++ b/scripts/compare-coverage-ast.py
@@ -167,6 +167,69 @@ def query_coverage_db(
     return covered_result, executable_result
 
 
+def query_contexts_map(db_path: Path) -> dict[str, set[str]]:
+    """Query .coverage DB and return {source_file: {test_file_paths}}.
+
+    Uses CoverageData.contexts_by_lineno() to build the inversion.
+    Only includes source files under src/ and test contexts from tests/.
+    Context names from --cov-context=test are test node IDs like
+    'tests/recipe/test_rules_dataflow.py::TestClass::test_method|run'.
+    Only |run phase contexts are included to exclude fixture-inflation from
+    |setup and |teardown phases.
+    """
+    import coverage
+
+    try:
+        data = coverage.CoverageData(basename=str(db_path))
+        data.read()
+    except Exception as exc:
+        print(f"ERROR: Failed to read coverage database {db_path}: {exc}", file=sys.stderr)
+        return {}
+
+    result: dict[str, set[str]] = {}
+    for measured_file in data.measured_files():
+        try:
+            rel = str(Path(measured_file).relative_to(PROJECT_ROOT))
+        except ValueError:
+            continue
+        if not rel.startswith("src/"):
+            continue
+        contexts_by_line = data.contexts_by_lineno(measured_file)
+        test_files: set[str] = set()
+        for contexts in contexts_by_line.values():
+            for ctx in contexts:
+                if "::" in ctx and ctx.endswith("|run"):
+                    test_file = ctx.split("::")[0]
+                    if test_file.startswith("tests/") and test_file.endswith(".py"):
+                        test_files.add(test_file)
+        if test_files:
+            result[rel] = test_files
+    return result
+
+
+def build_test_source_map(
+    db_path: Path,
+    output_path: Path,
+) -> None:
+    """Build and write {source_file: [test_files]} map from coverage DB.
+
+    Args:
+        db_path: Path to .coverage SQLite database.
+        output_path: Path where test-source-map.json will be written.
+    """
+    if not db_path.exists():
+        print(f"WARNING: Coverage database not found: {db_path}", file=sys.stderr)
+        print("Run 'task coverage-audit' first to generate coverage data.", file=sys.stderr)
+        return
+
+    mapping = query_contexts_map(db_path)
+    # Convert sets to sorted lists for stable, human-readable JSON
+    serializable = {src: sorted(tests) for src, tests in sorted(mapping.items())}
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(serializable, indent=2) + "\n", encoding="utf-8")
+    print(f"Test-source map written to: {output_path} ({len(serializable)} source files)")
+
+
 def compare(
     ast_map: dict[str, list[FuncInfo]],
     coverage_map: dict[str, set[int]],
@@ -265,6 +328,12 @@ def main() -> int:
         description="Compare AST function map against coverage database"
     )
     parser.add_argument(
+        "--mode",
+        choices=["audit", "build-test-source-map"],
+        default="audit",
+        help="Operation mode (default: audit)",
+    )
+    parser.add_argument(
         "--coverage-db",
         type=Path,
         default=PROJECT_ROOT / ".coverage",
@@ -280,10 +349,16 @@ def main() -> int:
         "--output",
         type=Path,
         default=None,
-        help="Path for JSON report output",
+        help="Path for JSON report output (audit mode) or map output (build-test-source-map mode)",
     )
     args = parser.parse_args()
 
+    if args.mode == "build-test-source-map":
+        output_path = args.output or (PROJECT_ROOT / ".autoskillit" / "test-source-map.json")
+        build_test_source_map(args.coverage_db, output_path)
+        return 0
+
+    # --- audit mode (existing logic) ---
     if not args.src_root.is_dir():
         print(f"ERROR: Source root not found: {args.src_root}", file=sys.stderr)
         return 0

--- a/scripts/compare-coverage-ast.py
+++ b/scripts/compare-coverage-ast.py
@@ -210,17 +210,20 @@ def query_contexts_map(db_path: Path) -> dict[str, set[str]]:
 def build_test_source_map(
     db_path: Path,
     output_path: Path,
-) -> None:
+) -> bool:
     """Build and write {source_file: [test_files]} map from coverage DB.
 
     Args:
         db_path: Path to .coverage SQLite database.
         output_path: Path where test-source-map.json will be written.
+
+    Returns:
+        True on success, False when the coverage DB is not found.
     """
     if not db_path.exists():
         print(f"WARNING: Coverage database not found: {db_path}", file=sys.stderr)
         print("Run 'task coverage-audit' first to generate coverage data.", file=sys.stderr)
-        return
+        return False
 
     mapping = query_contexts_map(db_path)
     # Convert sets to sorted lists for stable, human-readable JSON
@@ -228,6 +231,7 @@ def build_test_source_map(
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json.dumps(serializable, indent=2) + "\n", encoding="utf-8")
     print(f"Test-source map written to: {output_path} ({len(serializable)} source files)")
+    return True
 
 
 def compare(
@@ -355,10 +359,9 @@ def main() -> int:
 
     if args.mode == "build-test-source-map":
         output_path = args.output or (PROJECT_ROOT / ".autoskillit" / "test-source-map.json")
-        build_test_source_map(args.coverage_db, output_path)
-        return 0
+        ok = build_test_source_map(args.coverage_db, output_path)
+        return 0 if ok else 1
 
-    # --- audit mode (existing logic) ---
     if not args.src_root.is_dir():
         print(f"ERROR: Source root not found: {args.src_root}", file=sys.stderr)
         return 0

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import ast
+import datetime
 import enum
 import fnmatch
+import json
 import logging
 import subprocess
 import warnings
@@ -358,9 +360,6 @@ def load_coverage_map(
         - The file is older than max_age_days
         - The file cannot be read or parsed
     """
-    import datetime
-    import json
-
     map_path = Path(map_path)
     try:
         stat = map_path.stat()

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -341,6 +341,49 @@ def load_manifest(path: str | Path) -> dict[str, Any] | None:
         return None
 
 
+def load_coverage_map(
+    map_path: str | Path,
+    max_age_days: int = 30,
+) -> dict[str, set[str]] | None:
+    """Load .autoskillit/test-source-map.json with staleness guard.
+
+    Args:
+        map_path: Path to the test-source-map.json file.
+        max_age_days: Maximum age in days before the map is considered stale.
+                      Defaults to 30 days.
+
+    Returns:
+        dict mapping source file paths to sets of test file paths, or None when:
+        - The file does not exist
+        - The file is older than max_age_days
+        - The file cannot be read or parsed
+    """
+    import datetime
+    import json
+
+    map_path = Path(map_path)
+    try:
+        stat = map_path.stat()
+    except OSError:
+        return None
+
+    age = datetime.datetime.now().timestamp() - stat.st_mtime
+    if age > max_age_days * 24 * 3600:
+        return None
+
+    try:
+        raw = json.loads(map_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        warnings.warn(f"Cannot read coverage map {map_path}: {exc}", stacklevel=2)
+        return None
+
+    if not isinstance(raw, dict):
+        warnings.warn(f"Coverage map {map_path} is not a JSON object", stacklevel=2)
+        return None
+
+    return {src: set(tests) for src, tests in raw.items()}
+
+
 def apply_manifest(
     changed_files: set[str],
     manifest: dict[str, Any] | None,

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -380,7 +380,16 @@ def load_coverage_map(
         warnings.warn(f"Coverage map {map_path} is not a JSON object", stacklevel=2)
         return None
 
-    return {src: set(tests) for src, tests in raw.items()}
+    result: dict[str, set[str]] = {}
+    for src, tests in raw.items():
+        if not isinstance(tests, list):
+            warnings.warn(
+                f"Coverage map {map_path}: value for {src!r} is not a list",
+                stacklevel=2,
+            )
+            return None
+        result[src] = set(tests)
+    return result
 
 
 def apply_manifest(

--- a/tests/infra/test_coverage_audit.py
+++ b/tests/infra/test_coverage_audit.py
@@ -223,6 +223,9 @@ class TestBuildTestSourceMap:
         assert output_path.exists()
         parsed = json.loads(output_path.read_text())
         assert isinstance(parsed, dict)
+        expected_key = "src/autoskillit/core/io.py"
+        assert expected_key in parsed
+        assert "tests/core/test_io.py" in parsed[expected_key]
 
     def test_main_routes_build_test_source_map_mode(self, cov_ast, tmp_path, monkeypatch):
         """main() with --mode build-test-source-map calls build_test_source_map()."""

--- a/tests/infra/test_coverage_audit.py
+++ b/tests/infra/test_coverage_audit.py
@@ -235,6 +235,7 @@ class TestBuildTestSourceMap:
         def fake_build(db_path, output_path):
             called_with["db_path"] = db_path
             called_with["output_path"] = output_path
+            return True
 
         monkeypatch.setattr(cov_ast, "build_test_source_map", fake_build)
         monkeypatch.setattr(

--- a/tests/infra/test_coverage_audit.py
+++ b/tests/infra/test_coverage_audit.py
@@ -244,6 +244,7 @@ class TestBuildTestSourceMap:
         result = cov_ast.main()
         assert result == 0
         assert "output_path" in called_with
+        assert called_with["db_path"] == cov_ast.PROJECT_ROOT / ".coverage"
 
     def test_map_json_values_are_lists(self, cov_ast, tmp_path, monkeypatch):
         """The written JSON has list values (not sets), loadable as JSON."""

--- a/tests/infra/test_coverage_audit.py
+++ b/tests/infra/test_coverage_audit.py
@@ -145,3 +145,130 @@ def test_compare_detects_partial_coverage(cov_ast):
     assert report.partial == 1
     assert report.covered == 0
     assert report.uncovered == 0
+
+
+# ── TestBuildTestSourceMap ──
+
+
+class TestBuildTestSourceMap:
+    def test_query_contexts_map_inverts_correctly(self, cov_ast, tmp_path, monkeypatch):
+        """query_contexts_map inverts {line: {ctx}} to {src_file: {test_file}}.
+
+        Uses MagicMock to simulate CoverageData.
+        Context names use |run suffix.
+        """
+        from unittest.mock import MagicMock
+
+        import coverage as coverage_mod
+
+        src_file = str(cov_ast.PROJECT_ROOT / "src" / "autoskillit" / "core" / "io.py")
+
+        mock_data = MagicMock()
+        mock_data.measured_files.return_value = [src_file]
+        mock_data.contexts_by_lineno.return_value = {
+            1: ["tests/core/test_io.py::TestIO::test_write|run"],
+            2: ["tests/core/test_io.py::TestIO::test_write|run"],
+        }
+        monkeypatch.setattr(coverage_mod, "CoverageData", MagicMock(return_value=mock_data))
+
+        result = cov_ast.query_contexts_map(tmp_path / ".coverage")
+        assert "src/autoskillit/core/io.py" in result
+        assert "tests/core/test_io.py" in result["src/autoskillit/core/io.py"]
+
+    def test_setup_and_teardown_contexts_excluded(self, cov_ast, tmp_path, monkeypatch):
+        """query_contexts_map excludes |setup and |teardown contexts.
+
+        Only |run phase entries map source files to tests. A source file touched
+        only during |setup or |teardown must NOT appear in the result.
+        """
+        from unittest.mock import MagicMock
+
+        import coverage as coverage_mod
+
+        src_file = str(cov_ast.PROJECT_ROOT / "src" / "autoskillit" / "core" / "io.py")
+
+        mock_data = MagicMock()
+        mock_data.measured_files.return_value = [src_file]
+        mock_data.contexts_by_lineno.return_value = {
+            1: [
+                "tests/core/test_io.py::TestIO::test_write|setup",
+                "tests/core/test_io.py::TestIO::test_write|teardown",
+            ],
+        }
+        monkeypatch.setattr(coverage_mod, "CoverageData", MagicMock(return_value=mock_data))
+
+        result = cov_ast.query_contexts_map(tmp_path / ".coverage")
+        assert "src/autoskillit/core/io.py" not in result
+
+    def test_build_test_source_map_writes_json(self, cov_ast, tmp_path, monkeypatch):
+        """build_test_source_map() writes a valid JSON file to the output path."""
+        import json
+        from unittest.mock import MagicMock
+
+        import coverage as coverage_mod
+
+        src_file = str(cov_ast.PROJECT_ROOT / "src" / "autoskillit" / "core" / "io.py")
+        mock_data = MagicMock()
+        mock_data.measured_files.return_value = [src_file]
+        mock_data.contexts_by_lineno.return_value = {
+            1: ["tests/core/test_io.py::TestIO::test_write|run"],
+        }
+        monkeypatch.setattr(coverage_mod, "CoverageData", MagicMock(return_value=mock_data))
+
+        db_path = tmp_path / ".coverage"
+        db_path.touch()
+        output_path = tmp_path / "test-source-map.json"
+        cov_ast.build_test_source_map(db_path, output_path)
+
+        assert output_path.exists()
+        parsed = json.loads(output_path.read_text())
+        assert isinstance(parsed, dict)
+
+    def test_main_routes_build_test_source_map_mode(self, cov_ast, tmp_path, monkeypatch):
+        """main() with --mode build-test-source-map calls build_test_source_map()."""
+
+        called_with: dict = {}
+
+        def fake_build(db_path, output_path):
+            called_with["db_path"] = db_path
+            called_with["output_path"] = output_path
+
+        monkeypatch.setattr(cov_ast, "build_test_source_map", fake_build)
+        monkeypatch.setattr(
+            "sys.argv",
+            ["compare-coverage-ast.py", "--mode", "build-test-source-map"],
+        )
+        result = cov_ast.main()
+        assert result == 0
+        assert "output_path" in called_with
+
+    def test_map_json_values_are_lists(self, cov_ast, tmp_path, monkeypatch):
+        """The written JSON has list values (not sets), loadable as JSON."""
+        import json
+        from unittest.mock import MagicMock
+
+        import coverage as coverage_mod
+
+        src_file = str(cov_ast.PROJECT_ROOT / "src" / "autoskillit" / "core" / "io.py")
+        mock_data = MagicMock()
+        mock_data.measured_files.return_value = [src_file]
+        mock_data.contexts_by_lineno.return_value = {
+            1: ["tests/core/test_io.py::TestIO::test_a|run"],
+            2: ["tests/core/test_io.py::TestIO::test_b|run"],
+        }
+        monkeypatch.setattr(coverage_mod, "CoverageData", MagicMock(return_value=mock_data))
+
+        db_path = tmp_path / ".coverage"
+        db_path.touch()
+        output_path = tmp_path / "test-source-map.json"
+        cov_ast.build_test_source_map(db_path, output_path)
+
+        parsed = json.loads(output_path.read_text())
+        for v in parsed.values():
+            assert isinstance(v, list)
+
+    def test_taskfile_coverage_audit_invokes_map_mode(self):
+        """Taskfile.yml coverage-audit task includes --mode build-test-source-map."""
+        taskfile = Path(__file__).parent.parent.parent / "Taskfile.yml"
+        content = taskfile.read_text()
+        assert "build-test-source-map" in content

--- a/tests/test_test_filter.py
+++ b/tests/test_test_filter.py
@@ -24,6 +24,7 @@ from tests._test_filter import (
     build_test_scope,
     check_bucket_a,
     git_changed_files,
+    load_coverage_map,
     load_manifest,
 )
 
@@ -801,3 +802,73 @@ class TestManifestApplyManifest:
             ["src/autoskillit/recipes/cook.yaml", "docs/guide.md"], manifest
         )
         assert result == {"recipe/", "docs/"}
+
+
+# ---------------------------------------------------------------------------
+# TestLoadCoverageMap
+# ---------------------------------------------------------------------------
+
+
+class TestLoadCoverageMap:
+    def test_returns_dict_from_valid_json(self, tmp_path: Path) -> None:
+        """Parses a valid JSON map and returns dict[str, set[str]]."""
+        map_file = tmp_path / "test-source-map.json"
+        map_file.write_text(
+            '{"src/autoskillit/recipe/rules_dataflow.py": '
+            '["tests/recipe/test_rules_dataflow.py", "tests/recipe/test_rules_structure.py"]}',
+            encoding="utf-8",
+        )
+        result = load_coverage_map(map_file)
+        assert result is not None
+        assert "src/autoskillit/recipe/rules_dataflow.py" in result
+        assert isinstance(result["src/autoskillit/recipe/rules_dataflow.py"], set)
+        assert (
+            "tests/recipe/test_rules_dataflow.py"
+            in result["src/autoskillit/recipe/rules_dataflow.py"]
+        )
+
+    def test_missing_file_returns_none(self, tmp_path: Path) -> None:
+        """Returns None when the map file does not exist."""
+        result = load_coverage_map(tmp_path / "nonexistent.json")
+        assert result is None
+
+    def test_stale_file_returns_none(self, tmp_path: Path) -> None:
+        """Returns None when the file mtime is older than max_age_days."""
+        import os
+        import time
+
+        map_file = tmp_path / "test-source-map.json"
+        map_file.write_text('{"src/foo.py": ["tests/test_foo.py"]}', encoding="utf-8")
+        # Backdate mtime by 31 days
+        old_mtime = time.time() - (31 * 24 * 3600)
+        os.utime(map_file, (old_mtime, old_mtime))
+        result = load_coverage_map(map_file, max_age_days=30)
+        assert result is None
+
+    def test_fresh_file_returns_data(self, tmp_path: Path) -> None:
+        """Returns data when the file mtime is within max_age_days."""
+        map_file = tmp_path / "test-source-map.json"
+        map_file.write_text('{"src/foo.py": ["tests/test_foo.py"]}', encoding="utf-8")
+        result = load_coverage_map(map_file, max_age_days=30)
+        assert result is not None
+        assert result["src/foo.py"] == {"tests/test_foo.py"}
+
+    def test_custom_max_age_days_respected(self, tmp_path: Path) -> None:
+        """Custom max_age_days threshold is respected."""
+        import os
+        import time
+
+        map_file = tmp_path / "test-source-map.json"
+        map_file.write_text('{"src/foo.py": ["tests/test_foo.py"]}', encoding="utf-8")
+        # Backdate by 2 days — stale with max_age_days=1, fresh with max_age_days=3
+        old_mtime = time.time() - (2 * 24 * 3600)
+        os.utime(map_file, (old_mtime, old_mtime))
+        assert load_coverage_map(map_file, max_age_days=1) is None
+        assert load_coverage_map(map_file, max_age_days=3) is not None
+
+    def test_malformed_json_returns_none(self, tmp_path: Path) -> None:
+        """Returns None on JSON parse failure."""
+        map_file = tmp_path / "test-source-map.json"
+        map_file.write_text("{bad json}", encoding="utf-8")
+        result = load_coverage_map(map_file)
+        assert result is None


### PR DESCRIPTION
## Summary

Add a coverage-based oracle that maps source files to the test files that actually executed them. This solves the side-effect registration blind spot in AST-based filtering (e.g., `recipe/rules_*.py` loaded via bulk imports, so 15/20 `test_rules_*.py` files don't directly import `rules_X.py`).

Three deliverables:
1. **`query_contexts_map` + `build_test_source_map`** in `scripts/compare-coverage-ast.py` — a new `--mode build-test-source-map` CLI submode that queries `.coverage` via `coverage.CoverageData`, inverts the test-context-per-line mapping to `{source_file → {test_files}}`, and writes `.autoskillit/test-source-map.json`.
2. **`load_coverage_map(map_path, max_age_days=30)`** in `tests/_test_filter.py` — stdlib-only loader with 30-day staleness guard; returns `dict[str, set[str]] | None`.
3. **Taskfile extension** — `coverage-audit` task gains a second script invocation that produces the map as a side output.

## Architecture Impact

### Development Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ENTRY POINTS %%
    DEVCLI["● task coverage-audit<br/>━━━━━━━━━━<br/>Full coverage pipeline<br/>(Taskfile.yml)"]
    FILTERCLI["task test-filtered<br/>━━━━━━━━━━<br/>Path-filtered test run<br/>(env: AUTOSKILLIT_TEST_FILTER)"]

    subgraph Coverage ["COVERAGE COLLECTION"]
        direction TB
        PYTEST["pytest --cov<br/>━━━━━━━━━━<br/>--cov=src/autoskillit<br/>--cov-context=test<br/>--cov-branch<br/>(-n 4 xdist)"]
        COVDB[("● .coverage<br/>━━━━━━━━━━<br/>SQLite coverage DB<br/>(coverage.py)")]
    end

    subgraph AuditScript ["● scripts/compare-coverage-ast.py"]
        direction TB
        ASTMODE["audit mode<br/>━━━━━━━━━━<br/>AST walk src/<br/>+ line coverage query<br/>→ covered/partial/uncovered"]
        MAPMODE["build-test-source-map mode<br/>━━━━━━━━━━<br/>contexts_by_lineno()<br/>invert: src → tests<br/>(|run phase only)"]
    end

    subgraph Artifacts ["OUTPUT ARTIFACTS"]
        direction TB
        AUDITJSON["temp/coverage-audit-*.json<br/>━━━━━━━━━━<br/>Per-function coverage<br/>report (human + JSON)"]
        SOURCEMAP[".autoskillit/test-source-map.json<br/>━━━━━━━━━━<br/>{ src_file: [test_file, ...] }<br/>oracle for test filtering"]
    end

    subgraph TestFilter ["● tests/_test_filter.py (& autoskillit._test_filter)"]
        direction TB
        LOADMAP["load_coverage_map()<br/>━━━━━━━━━━<br/>reads test-source-map.json<br/>staleness guard (30d)"]
        BUILDSCOPE["build_test_scope()<br/>━━━━━━━━━━<br/>ASTImportWalker<br/>+ LAYER_CASCADE<br/>+ reexport closure"]
        CONFTEST["conftest.py<br/>━━━━━━━━━━<br/>pytest_collection_modifyitems<br/>deselects out-of-scope tests"]
    end

    subgraph QualityGates ["QUALITY GATES (pre-commit)"]
        direction LR
        FORMAT["ruff format<br/>━━━━━━━━━━<br/>auto-fix"]
        LINT["ruff check<br/>━━━━━━━━━━<br/>auto-fix"]
        MYPY["mypy<br/>━━━━━━━━━━<br/>src/ + tests/_test_filter.py<br/>(typed standalone module)"]
        UVLOCK["uv lock --check<br/>━━━━━━━━━━<br/>lockfile sync"]
        GITLEAKS["gitleaks<br/>━━━━━━━━━━<br/>secret scanning"]
    end

    subgraph TestSuite ["TEST SUITE (PR-modified)"]
        direction LR
        TCOVAUDIT["● tests/infra/test_coverage_audit.py<br/>━━━━━━━━━━<br/>12 tests for compare-coverage-ast.py<br/>(audit + map modes, CLI routing)"]
        TTESTFILTER["● tests/test_test_filter.py<br/>━━━━━━━━━━<br/>~50 tests for _test_filter.py<br/>(AST walker, cascades, coverage map)"]
    end

    subgraph ImportLinter ["IMPORT LINTER (7 contracts)"]
        direction TB
        ILAYER["IL-001..IL-007<br/>━━━━━━━━━━<br/>L0 core / L1 / L2 / L3<br/>upward-import prohibition"]
    end

    %% FLOW: coverage pipeline %%
    DEVCLI --> PYTEST
    PYTEST --> COVDB
    COVDB --> ASTMODE
    COVDB --> MAPMODE
    ASTMODE --> AUDITJSON
    MAPMODE --> SOURCEMAP

    %% FLOW: test-filter pipeline %%
    SOURCEMAP --> LOADMAP
    LOADMAP --> BUILDSCOPE
    BUILDSCOPE --> CONFTEST
    FILTERCLI --> CONFTEST

    %% FLOW: quality gates %%
    FORMAT --> LINT --> MYPY --> UVLOCK --> GITLEAKS

    %% TEST VALIDATES IMPLEMENTATION %%
    TCOVAUDIT -. "validates" .-> AuditScript
    TTESTFILTER -. "validates" .-> TestFilter

    %% MYPY covers _test_filter %%
    MYPY -. "type-checks" .-> TestFilter

    %% CLASS ASSIGNMENTS %%
    class DEVCLI,FILTERCLI cli;
    class PYTEST,BUILDSCOPE handler;
    class ASTMODE,MAPMODE,LOADMAP phase;
    class COVDB stateNode;
    class AUDITJSON,SOURCEMAP output;
    class FORMAT,LINT,MYPY,UVLOCK,GITLEAKS detector;
    class TCOVAUDIT,TTESTFILTER newComponent;
    class CONFTEST,ILAYER phase;
```

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START])
    FULL_RUN([FULL RUN — return None])
    SCOPED_RUN([SCOPED RUN — return set of Path dirs])
    ERROR([ERROR — exit non-zero])

    %% ─────────────────────────────────────────────── %%
    subgraph CoverageAuditPipeline ["● Coverage Audit Pipeline  (Taskfile.yml: coverage-audit)"]
        direction TB
        T_PYTEST["● pytest run<br/>━━━━━━━━━━<br/>--cov=src/autoskillit<br/>--cov-context=test<br/>--cov-branch"]
        T_COVERAGEDB[("● .coverage<br/>━━━━━━━━━━<br/>SQLite DB<br/>written by pytest-cov")]
        T_AUDIT["● compare-coverage-ast.py<br/>━━━━━━━━━━<br/>--mode audit<br/>reads .coverage + AST"]
        T_MAP["● compare-coverage-ast.py<br/>━━━━━━━━━━<br/>--mode build-test-source-map<br/>inverts context index"]
        T_TASKTEST["● test_taskfile_coverage_audit_invokes_map_mode<br/>━━━━━━━━━━<br/>static assert: Taskfile.yml<br/>contains 'build-test-source-map'"]
    end

    %% ─────────────────────────────────────────────── %%
    subgraph AuditMode ["● Audit Mode  (compare-coverage-ast.py --mode audit)"]
        direction TB
        A_ARGS{"● argparse<br/>━━━━━━━━━━<br/>--mode audit<br/>--src-root --coverage-db --output"}
        A_SRCCHECK{"src_root is dir?"}
        A_DBCHECK{"● .coverage DB exists?"}
        A_ASTMAP["● build_ast_map<br/>━━━━━━━━━━<br/>rglob src/**/*.py<br/>→ AST parse each file<br/>(SyntaxError → warn, skip)"]
        A_QUERYCOV["● query_coverage_db<br/>━━━━━━━━━━<br/>CoverageData.measured_files()<br/>→ analysis2() per file<br/>(exception → skip file)"]
        A_COMPARE["● compare()<br/>━━━━━━━━━━<br/>per FuncInfo: covered/partial/uncovered<br/>based on covered_lines count"]
        A_REPORT["● _print_report()<br/>━━━━━━━━━━<br/>stdout: human-readable summary<br/>optional --output JSON file"]
        A_AUDITJSON[("temp/coverage-audit-&lt;ts&gt;.json<br/>━━━━━━━━━━<br/>structured FuncCoverage report")]
    end

    %% ─────────────────────────────────────────────── %%
    subgraph MapMode ["● Build-Test-Source-Map Mode  (compare-coverage-ast.py --mode build-test-source-map)"]
        direction TB
        M_DBCHECK{"● db_path exists?"}
        M_CTXMAP["● query_contexts_map()<br/>━━━━━━━━━━<br/>measured_files() → contexts_by_lineno()<br/>filter: src/ prefix, '::' + '|run' suffix<br/>skip '|setup', '|teardown'"]
        M_INVERT["● context inversion<br/>━━━━━━━━━━<br/>line→ctx dict → src_file→{test_files}<br/>only tests/ prefix .py files kept"]
        M_WRITE["● write JSON<br/>━━━━━━━━━━<br/>mkdir parents, atomic write<br/>.autoskillit/test-source-map.json"]
        M_MAPJSON[(".autoskillit/test-source-map.json<br/>━━━━━━━━━━<br/>{ source_file: [test_file, ...] }")]
    end

    %% ─────────────────────────────────────────────── %%
    subgraph TestFilter ["● Test-Filter Pipeline  (tests/_test_filter.py: build_test_scope)"]
        direction TB
        TF_TRIGGER["pytest collection<br/>━━━━━━━━━━<br/>conftest.py calls build_test_scope()<br/>at collection time"]
        TF_MODE{"● mode == FilterMode.NONE?"}
        TF_GITENV{"● env: AUTOSKILLIT_TEST_BASE_REF<br/>or GITHUB_BASE_REF set?"}
        TF_GIT["● git_changed_files()<br/>━━━━━━━━━━<br/>git diff --name-only base...HEAD<br/>(CalledProcessError/Timeout → None)"]
        TF_NULLCHECK{"● changed_files is None?"}
        TF_SIZECHECK{"● len(changed_files) > 30?"}
        TF_BUCKETCHECK{"● check_bucket_a()<br/>━━━━━━━━━━<br/>BUCKET_A_PATTERNS exact match<br/>or BUCKET_A_GLOBS fnmatch"}
        TF_CLASSIFY{"● classify each changed file<br/>━━━━━━━━━━<br/>tests/*.py → direct include<br/>src/*.py → cascade_map lookup<br/>non-py → apply_manifest()<br/>else → fail-open"}
        TF_REEXPORT["● _expand_reexport_closure()<br/>━━━━━━━━━━<br/>for each src/*.py: walk parent dirs<br/>parse __init__.py AST<br/>if re-exports changed module → add __init__"]
        TF_COVMAP["● load_coverage_map()<br/>━━━━━━━━━━<br/>reads .autoskillit/test-source-map.json<br/>staleness check: mtime > max_age_days"]
        TF_MANIFEST["● load_manifest()<br/>━━━━━━━━━━<br/>reads .autoskillit/test-filter-manifest.yaml<br/>(missing/parse error → None)"]
        TF_RESOLVEPATHS["● resolve dirs to Path<br/>━━━━━━━━━━<br/>add always_run dirs (mode-dependent)<br/>filter to dirs that exist on disk"]
        TF_UNRESOLVABLE{"● pkg not in cascade_map<br/>or manifest returns None?"}
    end

    %% ─────────────────────────────────────────────── %%
    subgraph TestInfra ["Test Infrastructure (validates pipeline)"]
        direction LR
        TI_COVTEST["● tests/infra/test_coverage_audit.py<br/>━━━━━━━━━━<br/>importlib loads script dynamically<br/>mocks CoverageData<br/>validates both modes"]
        TI_FILTERTEST["● tests/test_test_filter.py<br/>━━━━━━━━━━<br/>cross-validates conftest vs production _test_filter<br/>exercises all decision branches<br/>TestApplyManifestEquivalence"]
    end

    %% ════════════════ FLOW ════════════════ %%

    START --> T_PYTEST
    T_PYTEST -->|"writes"| T_COVERAGEDB
    T_COVERAGEDB -->|"reads"| T_AUDIT
    T_AUDIT --> A_ARGS
    T_COVERAGEDB -->|"reads"| T_MAP
    T_MAP --> M_DBCHECK

    A_ARGS --> A_SRCCHECK
    A_SRCCHECK -->|"not a dir"| ERROR
    A_SRCCHECK -->|"is dir"| A_DBCHECK
    A_DBCHECK -->|"missing — warn + show count"| A_ASTMAP
    A_DBCHECK -->|"exists"| A_ASTMAP
    A_ASTMAP -->|"reads src/**/*.py AST"| A_QUERYCOV
    A_QUERYCOV -->|"reads .coverage"| A_COMPARE
    A_COMPARE --> A_REPORT
    A_REPORT -->|"--output set"| A_AUDITJSON

    M_DBCHECK -->|"missing — warn, return early"| FULL_RUN
    M_DBCHECK -->|"exists"| M_CTXMAP
    M_CTXMAP -->|"reads .coverage contexts"| M_INVERT
    M_INVERT --> M_WRITE
    M_WRITE -->|"writes"| M_MAPJSON

    M_MAPJSON -->|"consumed by"| TF_COVMAP

    TF_TRIGGER --> TF_MODE
    TF_MODE -->|"NONE"| FULL_RUN
    TF_MODE -->|"conservative / aggressive"| TF_GITENV
    TF_GITENV -->|"neither env set"| FULL_RUN
    TF_GITENV -->|"env set"| TF_GIT
    TF_GIT -->|"git error / timeout"| FULL_RUN
    TF_GIT -->|"success"| TF_NULLCHECK
    TF_NULLCHECK -->|"None"| FULL_RUN
    TF_NULLCHECK -->|"not None"| TF_SIZECHECK
    TF_SIZECHECK -->|"> 30 files"| FULL_RUN
    TF_SIZECHECK -->|"<= 30"| TF_BUCKETCHECK
    TF_BUCKETCHECK -->|"bucket A file found"| FULL_RUN
    TF_BUCKETCHECK -->|"no bucket A"| TF_MANIFEST
    TF_MANIFEST -->|"loaded"| TF_CLASSIFY
    TF_COVMAP -->|"oracle data (optional)"| TF_CLASSIFY
    TF_CLASSIFY -->|"src/*.py present"| TF_REEXPORT
    TF_CLASSIFY --> TF_UNRESOLVABLE
    TF_REEXPORT -->|"__init__.py additions"| TF_UNRESOLVABLE
    TF_UNRESOLVABLE -->|"yes — fail-open"| FULL_RUN
    TF_UNRESOLVABLE -->|"no"| TF_RESOLVEPATHS
    TF_RESOLVEPATHS --> SCOPED_RUN

    T_TASKTEST -.->|"static assert"| T_MAP
    TI_COVTEST -.->|"validates"| T_AUDIT
    TI_COVTEST -.->|"validates"| T_MAP
    TI_FILTERTEST -.->|"validates"| TF_CLASSIFY
    TI_FILTERTEST -.->|"validates"| TF_REEXPORT

    %% ════════ CLASS ASSIGNMENTS ════════ %%
    class START,FULL_RUN,SCOPED_RUN,ERROR terminal;
    class T_COVERAGEDB,M_MAPJSON stateNode;
    class A_AUDITJSON output;
    class T_PYTEST,T_AUDIT,T_MAP phase;
    class T_TASKTEST,TI_COVTEST,TI_FILTERTEST integration;
    class A_ARGS,A_ASTMAP,A_QUERYCOV,A_COMPARE,A_REPORT handler;
    class M_CTXMAP,M_INVERT,M_WRITE handler;
    class TF_TRIGGER,TF_GIT,TF_REEXPORT,TF_COVMAP,TF_MANIFEST,TF_RESOLVEPATHS handler;
    class A_SRCCHECK,A_DBCHECK,M_DBCHECK,TF_MODE,TF_GITENV,TF_NULLCHECK,TF_SIZECHECK,TF_BUCKETCHECK,TF_CLASSIFY,TF_UNRESOLVABLE detector;
```

Closes #1005

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260417-051903-589005/.autoskillit/temp/make-plan/build_coverage_db_oracle_for_test_to_source_mapping_plan_2026-04-17_000001.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 151 | 13.1k | 766.6k | 65.3k | 1 | 3m 56s |
| review | 82 | 7.5k | 361.2k | 9.9k | 1 | 4m 30s |
| verify | 124 | 9.2k | 676.3k | 47.7k | 1 | 2m 39s |
| implement | 242 | 16.8k | 1.4M | 58.7k | 1 | 4m 48s |
| prepare_pr | 60 | 4.8k | 187.1k | 25.1k | 1 | 1m 27s |
| run_arch_lenses | 229 | 19.3k | 718.0k | 175.8k | 3 | 9m 37s |
| compose_pr | 51 | 7.9k | 161.8k | 28.8k | 1 | 2m 19s |
| **Total** | 939 | 78.6k | 4.3M | 411.3k | | 29m 20s |