### PR TITLE
Implementation Plan: Size Markers for execution/

### DIFF
--- a/tests/arch/test_size_markers.py
+++ b/tests/arch/test_size_markers.py
@@ -13,6 +13,7 @@ SIZE_DIRECTORIES: dict[str, str] = {
     "cli": "cli",
     "config": "config",
     "core": "core",
+    "execution": "execution",
     "migration": "migration",
     "pipeline": "pipeline",
     "recipe": "recipe",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,17 @@ _LAYER_DIRS: frozenset[str] = frozenset(
 )
 
 _SIZE_DIRS: frozenset[str] = frozenset(
-    {"cli", "config", "core", "execution", "migration", "pipeline", "recipe", "server", "workspace"}
+    {
+        "cli",
+        "config",
+        "core",
+        "execution",
+        "migration",
+        "pipeline",
+        "recipe",
+        "server",
+        "workspace",
+    }
 )
 
 _scope_key = pytest.StashKey[set[_Path] | None]()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ _LAYER_DIRS: frozenset[str] = frozenset(
 )
 
 _SIZE_DIRS: frozenset[str] = frozenset(
-    {"cli", "config", "core", "migration", "pipeline", "recipe", "server", "workspace"}
+    {"cli", "config", "core", "execution", "migration", "pipeline", "recipe", "server", "workspace"}
 )
 
 _scope_key = pytest.StashKey[set[_Path] | None]()

--- a/tests/execution/test_anomaly_detection.py
+++ b/tests/execution/test_anomaly_detection.py
@@ -11,7 +11,7 @@ from autoskillit.execution.anomaly_detection import (
     detect_anomalies,
 )
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 
 def _snap(

--- a/tests/execution/test_check_repo_merge_state.py
+++ b/tests/execution/test_check_repo_merge_state.py
@@ -11,7 +11,7 @@ import pytest
 
 from autoskillit.execution.merge_queue import fetch_repo_merge_state
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 # Reminder: fetch_repo_merge_state now returns ci_event in addition to the
 # three boolean fields. Tests below check for the ci_event field explicitly.

--- a/tests/execution/test_ci.py
+++ b/tests/execution/test_ci.py
@@ -13,7 +13,7 @@ from autoskillit.execution.ci import (
     _jittered_sleep,
 )
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/execution/test_ci_params.py
+++ b/tests/execution/test_ci_params.py
@@ -15,7 +15,7 @@ import pytest
 from autoskillit.core import CIRunScope
 from autoskillit.execution.ci import DefaultCIWatcher, _validate_run_matches_scope
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 
 def _now() -> str:

--- a/tests/execution/test_clone_guard.py
+++ b/tests/execution/test_clone_guard.py
@@ -24,7 +24,7 @@ from autoskillit.execution.headless import _build_skill_result
 from autoskillit.pipeline.audit import DefaultAuditLog
 from tests.fakes import MockSubprocessRunner
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 
 def _git_result(stdout: str = "", returncode: int = 0) -> SubprocessResult:

--- a/tests/execution/test_commands.py
+++ b/tests/execution/test_commands.py
@@ -17,7 +17,7 @@ from autoskillit.execution.commands import (
     build_interactive_cmd,
 )
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 
 class TestBuildInteractiveCmd:

--- a/tests/execution/test_db.py
+++ b/tests/execution/test_db.py
@@ -15,7 +15,7 @@ from autoskillit.execution.db import (
     _validate_select_only,
 )
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 
 class TestValidateSelectOnly:

--- a/tests/execution/test_diff_annotator.py
+++ b/tests/execution/test_diff_annotator.py
@@ -10,7 +10,7 @@ from autoskillit.execution.diff_annotator import (
     parse_hunk_ranges,
 )
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 # --- parse_hunk_ranges ---
 

--- a/tests/execution/test_flag_contracts.py
+++ b/tests/execution/test_flag_contracts.py
@@ -15,7 +15,7 @@ from autoskillit.execution.commands import (
     build_interactive_cmd,
 )
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 # ---------------------------------------------------------------------------
 # Part 1: Constant value contracts — each assertion is the ground truth.

--- a/tests/execution/test_github.py
+++ b/tests/execution/test_github.py
@@ -12,7 +12,7 @@ from autoskillit.execution.github import (
     parse_merge_queue_response,
 )
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 # ---------------------------------------------------------------------------
 # _parse_issue_ref unit tests

--- a/tests/execution/test_github_headers.py
+++ b/tests/execution/test_github_headers.py
@@ -11,7 +11,7 @@ import pytest
 from autoskillit.execution.github import github_headers
 from autoskillit.execution.merge_queue import DefaultMergeQueueWatcher
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 # ---------------------------------------------------------------------------
 # github_headers — unit tests

--- a/tests/execution/test_headless.py
+++ b/tests/execution/test_headless.py
@@ -23,7 +23,7 @@ from autoskillit.execution.headless import (
 )
 from tests.conftest import _make_result, _make_timeout_result
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 
 def test_inject_completion_directive_appends_marker():

--- a/tests/execution/test_headless_add_dirs.py
+++ b/tests/execution/test_headless_add_dirs.py
@@ -6,7 +6,7 @@ import pytest
 
 from autoskillit.core import ValidatedAddDir
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 
 @pytest.mark.anyio

--- a/tests/execution/test_headless_debug_logging.py
+++ b/tests/execution/test_headless_debug_logging.py
@@ -9,7 +9,7 @@ import structlog.testing
 
 from autoskillit.core.types import SubprocessResult, TerminationReason
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 
 def _sr(returncode=0, stdout="", stderr="", termination=TerminationReason.NATURAL_EXIT):

--- a/tests/execution/test_headless_env_injection.py
+++ b/tests/execution/test_headless_env_injection.py
@@ -10,7 +10,7 @@ import pytest
 from autoskillit.core.types import SubprocessResult, TerminationReason
 from tests.fakes import MockSubprocessRunner
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 
 @pytest.mark.anyio

--- a/tests/execution/test_headless_env_scrub.py
+++ b/tests/execution/test_headless_env_scrub.py
@@ -13,7 +13,7 @@ import pytest
 
 from tests.conftest import _make_result
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 
 @pytest.mark.anyio

--- a/tests/execution/test_linux_tracing.py
+++ b/tests/execution/test_linux_tracing.py
@@ -12,6 +12,7 @@ import pytest
 
 pytestmark = [
     pytest.mark.layer("execution"),
+    pytest.mark.medium,
     pytest.mark.skipif(
         sys.platform != "linux",
         reason="Linux-only tracing tests",

--- a/tests/execution/test_linux_tracing_pty_integration.py
+++ b/tests/execution/test_linux_tracing_pty_integration.py
@@ -21,6 +21,7 @@ from tests.execution.conftest import _ALLOCATE_60MB_SCRIPT
 
 pytestmark = [
     pytest.mark.layer("execution"),
+    pytest.mark.medium,
     pytest.mark.skipif(
         sys.platform != "linux",
         reason="Linux only — tests PTY wrapping + /proc tracing",

--- a/tests/execution/test_merge_queue.py
+++ b/tests/execution/test_merge_queue.py
@@ -16,7 +16,7 @@ from autoskillit.execution.merge_queue import (
     PRFetchState,
 )
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 
 def _make_watcher() -> DefaultMergeQueueWatcher:

--- a/tests/execution/test_normalize_subtype.py
+++ b/tests/execution/test_normalize_subtype.py
@@ -9,7 +9,7 @@ from autoskillit.core.types import (
 )
 from autoskillit.execution.session import ClaudeSessionResult, _normalize_subtype
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 
 def _session(

--- a/tests/execution/test_output_format_contract.py
+++ b/tests/execution/test_output_format_contract.py
@@ -28,7 +28,7 @@ from autoskillit.execution.session import (
     parse_session_result,
 )
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 
 class TestOutputFormatDataContract:

--- a/tests/execution/test_pr_analysis.py
+++ b/tests/execution/test_pr_analysis.py
@@ -11,7 +11,7 @@ from autoskillit.execution.pr_analysis import (
     partition_files_by_domain,
 )
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 # ---------------------------------------------------------------------------
 # extract_linked_issues

--- a/tests/execution/test_process_channel_b.py
+++ b/tests/execution/test_process_channel_b.py
@@ -11,7 +11,7 @@ from autoskillit.core.types import ChannelConfirmation, SubprocessResult, Termin
 from autoskillit.execution.process import run_managed_async
 from tests.execution.conftest import WRITE_RESULT_THEN_HANG_SCRIPT
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.medium]
 
 # Script that:
 #   (1) writes %%ORDER_UP%% to a JSONL session file (Channel B fires)

--- a/tests/execution/test_process_debug_logging.py
+++ b/tests/execution/test_process_debug_logging.py
@@ -10,7 +10,7 @@ import structlog.testing
 from autoskillit.core.types import TerminationReason
 from autoskillit.execution.process import RaceAccumulator, RaceSignals
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.medium]
 
 
 @pytest.mark.anyio

--- a/tests/execution/test_process_idle_watchdog.py
+++ b/tests/execution/test_process_idle_watchdog.py
@@ -14,7 +14,7 @@ from autoskillit.execution._process_race import (
     _watch_stdout_idle,
 )
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.medium]
 
 WRITE_BURST_THEN_STALL_SCRIPT = textwrap.dedent("""\
     import sys, time, json

--- a/tests/execution/test_process_jsonl.py
+++ b/tests/execution/test_process_jsonl.py
@@ -18,7 +18,7 @@ from autoskillit.execution.process import (
     _marker_is_standalone,
 )
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 
 class TestJsonlContainsMarker:

--- a/tests/execution/test_process_kill.py
+++ b/tests/execution/test_process_kill.py
@@ -24,7 +24,7 @@ from autoskillit.execution.process import (
     run_managed_async,
 )
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.medium]
 
 # ---------------------------------------------------------------------------
 # Helper scripts — small Python programs that reproduce specific scenarios

--- a/tests/execution/test_process_monitor.py
+++ b/tests/execution/test_process_monitor.py
@@ -22,7 +22,7 @@ from autoskillit.execution.process import (
 )
 from tests.execution.conftest import WRITE_RESULT_THEN_HANG_SCRIPT
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.medium]
 
 # Script that writes non-matching output then hangs
 PARTIAL_OUTPUT_THEN_HANG_SCRIPT = (

--- a/tests/execution/test_process_pty.py
+++ b/tests/execution/test_process_pty.py
@@ -30,7 +30,7 @@ from autoskillit.execution.process import (
 )
 from autoskillit.execution.session import ClaudeSessionResult
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.medium]
 
 # ---------------------------------------------------------------------------
 # Helper scripts — small Python programs that reproduce specific scenarios

--- a/tests/execution/test_process_race.py
+++ b/tests/execution/test_process_race.py
@@ -17,7 +17,7 @@ from autoskillit.execution._process_race import (
     resolve_termination,
 )
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.medium]
 
 
 class TestChannelBStatusExhaustiveCoverage:

--- a/tests/execution/test_process_run.py
+++ b/tests/execution/test_process_run.py
@@ -26,7 +26,7 @@ from autoskillit.execution.process import (
     run_managed_sync,
 )
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.medium]
 
 # ---------------------------------------------------------------------------
 # Helper scripts — small Python programs that reproduce specific scenarios

--- a/tests/execution/test_process_submodules.py
+++ b/tests/execution/test_process_submodules.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import pytest
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 
 def test_process_kill_exports():

--- a/tests/execution/test_quota.py
+++ b/tests/execution/test_quota.py
@@ -11,7 +11,7 @@ import pytest
 
 from tests._helpers import make_quota_guard_config
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.medium]
 
 
 class TestReadCredentials:

--- a/tests/execution/test_quota_http.py
+++ b/tests/execution/test_quota_http.py
@@ -21,6 +21,7 @@ from autoskillit.execution.quota import check_and_sleep_if_needed  # noqa: E402
 
 pytestmark = [
     pytest.mark.layer("execution"),
+    pytest.mark.medium,
     pytest.mark.skipif(sys.platform != "linux", reason="api-simulator is Linux-only"),
     pytest.mark.anyio,
 ]

--- a/tests/execution/test_readiness_helper_contract.py
+++ b/tests/execution/test_readiness_helper_contract.py
@@ -23,7 +23,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 _TESTS_ROOT = Path(__file__).parent.parent
 

--- a/tests/execution/test_recording.py
+++ b/tests/execution/test_recording.py
@@ -20,7 +20,7 @@ from autoskillit.execution.recording import (
 from tests.conftest import _make_result
 from tests.fakes import MockSubprocessRunner
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 
 @dataclass

--- a/tests/execution/test_recording_sigterm.py
+++ b/tests/execution/test_recording_sigterm.py
@@ -18,7 +18,7 @@ import pytest
 from autoskillit.core.readiness import readiness_sentinel_path
 from tests._subprocess_ready import wait_for_subprocess_ready
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.medium]
 
 
 @pytest.mark.integration

--- a/tests/execution/test_recording_sigterm_early_term.py
+++ b/tests/execution/test_recording_sigterm_early_term.py
@@ -24,7 +24,7 @@ import sys
 
 import pytest
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.medium]
 
 
 @pytest.mark.integration

--- a/tests/execution/test_remote_resolver.py
+++ b/tests/execution/test_remote_resolver.py
@@ -9,7 +9,7 @@ import pytest
 
 from autoskillit.execution import resolve_remote_repo
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.medium]
 
 # ---------------------------------------------------------------------------
 # Hint-path tests (no subprocess calls)

--- a/tests/execution/test_session.py
+++ b/tests/execution/test_session.py
@@ -22,7 +22,7 @@ from autoskillit.execution.session import (
 )
 from tests._helpers import _flush_structlog_proxy_caches as _flush_logger_proxy_caches
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 
 def _make_session_result(

--- a/tests/execution/test_session_adjudication.py
+++ b/tests/execution/test_session_adjudication.py
@@ -25,7 +25,7 @@ from autoskillit.execution.session import (
     parse_session_result,
 )
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 
 def _make_success_session(result: str = "done") -> ClaudeSessionResult:

--- a/tests/execution/test_session_debug_logging.py
+++ b/tests/execution/test_session_debug_logging.py
@@ -14,7 +14,7 @@ from autoskillit.execution.session import (
     _compute_success,
 )
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 
 class TestCheckSessionContentLogging:

--- a/tests/execution/test_session_log.py
+++ b/tests/execution/test_session_log.py
@@ -20,7 +20,7 @@ from autoskillit.execution.session_log import (
     write_telemetry_clear_marker,
 )
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.medium]
 
 
 def _snap(

--- a/tests/execution/test_session_log_integration.py
+++ b/tests/execution/test_session_log_integration.py
@@ -15,6 +15,7 @@ from tests.execution.conftest import _ALLOCATE_60MB_SCRIPT
 
 pytestmark = [
     pytest.mark.layer("execution"),
+    pytest.mark.medium,
     pytest.mark.skipif(sys.platform != "linux", reason="Linux only"),
 ]
 

--- a/tests/execution/test_termination_action.py
+++ b/tests/execution/test_termination_action.py
@@ -12,7 +12,7 @@ import pytest
 from autoskillit.core.types import TerminationAction, TerminationReason
 from autoskillit.execution.process import decide_termination_action
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 
 @pytest.mark.parametrize(

--- a/tests/execution/test_termination_executor.py
+++ b/tests/execution/test_termination_executor.py
@@ -17,7 +17,7 @@ import pytest
 from autoskillit.core.types import KillReason, TerminationAction
 from autoskillit.execution.process import execute_termination_action
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.medium]
 
 # ---------------------------------------------------------------------------
 # Helper scripts

--- a/tests/execution/test_testing.py
+++ b/tests/execution/test_testing.py
@@ -22,7 +22,7 @@ from autoskillit.execution.testing import (
 )
 from tests._helpers import make_test_check_config, make_test_config
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.medium]
 
 
 def test_build_sanitized_env_strips_private_env_vars(monkeypatch):

--- a/tests/execution/test_trace_target_resolver.py
+++ b/tests/execution/test_trace_target_resolver.py
@@ -15,6 +15,7 @@ import pytest
 
 pytestmark = [
     pytest.mark.layer("execution"),
+    pytest.mark.medium,
     pytest.mark.skipif(
         sys.platform != "linux",
         reason="Linux only — tests /proc descendant walking",

--- a/tests/execution/test_zero_write_detection.py
+++ b/tests/execution/test_zero_write_detection.py
@@ -15,7 +15,7 @@ from autoskillit.core import RetryReason, WriteBehaviorSpec, extract_skill_name
 from autoskillit.execution.headless import _build_skill_result
 from tests.conftest import _make_result
 
-pytestmark = [pytest.mark.layer("execution")]
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 
 def _ndjson_with_tool_uses(tool_names: list[str]) -> str:


### PR DESCRIPTION
## Summary

Roll out Google-style test size markers (`pytest.mark.small` / `pytest.mark.medium`) to all
test files in `tests/execution/`. This is the final in-scope directory, completing the full
9-directory size-marker rollout. The work has two infrastructure changes (registry updates in
`test_size_markers.py` and `conftest.py`) plus pytestmark edits across every file in the
directory.

After this plan, `tests/arch/test_size_markers.py` enforces `execution/` in the same sweep
as the 8 already-annotated directories, and `AUTOSKILLIT_TEST_FILTER=aggressive` will
correctly deselect large/unannotated execution tests.

## Architecture Impact

### Development (Build & Test) Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph Structure ["TEST STRUCTURE"]
        direction TB
        EXECMOD["● tests/execution/<br/>━━━━━━━━━━<br/>49 files annotated<br/>29 × @small · 20 × @medium<br/>pytestmark = [layer(execution), &lt;size&gt;]"]
        ARCHMOD["● tests/arch/<br/>━━━━━━━━━━<br/>test_size_markers.py<br/>AST enforcement suite"]
        OTHERMOD["tests/{cli,core,recipe,...}<br/>━━━━━━━━━━<br/>8 more size-enforced dirs<br/>387 total test files"]
    end

    subgraph Registry ["SIZE MARKER REGISTRY"]
        direction TB
        SIZEDIRS["● SIZE_DIRECTORIES<br/>━━━━━━━━━━<br/>dict — 9 dirs incl. execution<br/>test_size_markers.py:12<br/>Parametrize source-of-truth"]
        CONFDIRS["● _SIZE_DIRS<br/>━━━━━━━━━━<br/>frozenset — 9 dirs<br/>conftest.py:29<br/>Aggressive filter scope"]
    end

    subgraph Validation ["SIZE MARKER VALIDATION (● test_size_markers.py)"]
        direction TB
        HASMARKER["test_all_test_files_have_size_marker<br/>━━━━━━━━━━<br/>AST-parses pytestmark assignment<br/>Param: each of 9 SIZE_DIRECTORIES"]
        NOCONFLICT["test_no_conflicting_size_markers<br/>━━━━━━━━━━<br/>Fails if file has &gt;1 size marker"]
        INPYPROJ["test_size_markers_registered_in_pyproject<br/>━━━━━━━━━━<br/>small/medium/large in pyproject.toml markers"]
        CROSSCHK["test_size_marker_directories_match_conftest<br/>━━━━━━━━━━<br/>Asserts SIZE_DIRECTORIES.keys() == _SIZE_DIRS"]
    end

    subgraph Conftest ["● CONFTEST.PY — Collection Pipeline"]
        direction TB
        AUTOUSE["Autouse Fixtures<br/>━━━━━━━━━━<br/>_structlog_to_null (structlog isolation)<br/>_isolated_home (Path.home() monkeypatch)<br/>_clear_headless_env · _clear_skip_stale_check_env"]
        LAYERCHECK["Layer Marker Validation<br/>━━━━━━━━━━<br/>pytest_collection_modifyitems<br/>Validates layer(name) matches test dir"]
        SCOPEFILTER["Scope Filter<br/>━━━━━━━━━━<br/>conservative: git-diff scoped<br/>aggressive: drops @large tests<br/>AUTOSKILLIT_TEST_FILTER env"]
    end

    subgraph QualityGates ["PRE-COMMIT QUALITY GATES"]
        direction LR
        RFMT["ruff format<br/>━━━━━━━━━━<br/>Auto-fix style"]
        RLINT["ruff check<br/>━━━━━━━━━━<br/>Lint + fix"]
        MYPY["mypy<br/>━━━━━━━━━━<br/>Type checking<br/>src/ + _test_filter"]
        UVLOCK["uv lock<br/>━━━━━━━━━━<br/>Lock integrity"]
        GITLEAKS["gitleaks<br/>━━━━━━━━━━<br/>Secret scan"]
    end

    subgraph TaskRunner ["TASK RUNNER (Taskfile.yml)"]
        direction LR
        TESTALL["task test-all<br/>━━━━━━━━━━<br/>lint-imports + pytest -n 4<br/>not smoke/canary"]
        TESTCHK["task test-check<br/>━━━━━━━━━━<br/>TEST_RESULT=PASS/FAIL<br/>Automation target"]
        TESTFILT["task test-filtered<br/>━━━━━━━━━━<br/>conservative scope filter<br/>→ delegates to test-check"]
    end

    EP["autoskillit<br/>━━━━━━━━━━<br/>autoskillit.cli:main<br/>Single CLI entry point"]

    %% REGISTRY CROSS-CHECK FLOW %%
    SIZEDIRS --> CROSSCHK
    CONFDIRS --> CROSSCHK

    %% VALIDATION PARAMETRIZE FLOW %%
    SIZEDIRS --> HASMARKER
    SIZEDIRS --> NOCONFLICT
    EXECMOD --> HASMARKER
    EXECMOD --> NOCONFLICT
    OTHERMOD --> HASMARKER
    ARCHMOD --> CROSSCHK

    %% CONFTEST COLLECTION FLOW %%
    AUTOUSE --> LAYERCHECK
    CONFDIRS --> SCOPEFILTER
    LAYERCHECK --> SCOPEFILTER

    %% PRE-COMMIT PIPELINE %%
    RFMT --> RLINT --> MYPY --> UVLOCK --> GITLEAKS

    %% TASK RUNNER %%
    TESTFILT --> TESTCHK
    TESTALL --> EP
    TESTCHK --> EP

    %% CLASS ASSIGNMENTS %%
    class EXECMOD handler;
    class ARCHMOD,OTHERMOD cli;
    class SIZEDIRS,CONFDIRS stateNode;
    class HASMARKER,NOCONFLICT,INPYPROJ,CROSSCHK detector;
    class AUTOUSE,LAYERCHECK,SCOPEFILTER phase;
    class RFMT,RLINT,MYPY,UVLOCK,GITLEAKS detector;
    class TESTALL,TESTCHK,TESTFILT output;
    class EP terminal;
```

### Process Flow (Physiological) Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START — pytest invoked])
    COMPLETE([COMPLETE — tests run])
    FAIL([FAIL — enforcement violation])

    %% ─── PHASE A: STATIC ENFORCEMENT (test_size_markers.py) ──────────────── %%
    subgraph PhaseA ["● Phase A: Static Size Marker Enforcement (test_size_markers.py)"]
        direction TB
        A1["● SIZE_DIRECTORIES registry<br/>━━━━━━━━━━<br/>cli, config, core, execution,<br/>migration, pipeline, recipe,<br/>server, workspace"]
        A2["● _extract_size_markers()<br/>━━━━━━━━━━<br/>ast.parse each test_*.py<br/>iterate child nodes for pytestmark"]
        A3{"marker found?<br/>━━━━━━━━━━<br/>name in _VALID_SIZE_MARKERS?"}
        A4{"conflict?<br/>━━━━━━━━━━<br/>len(markers) > 1?"}
        A5["● test_size_marker_directories_match_conftest()<br/>━━━━━━━━━━<br/>SIZE_DIRECTORIES.keys() == _SIZE_DIRS"]
        A6["test_size_markers_registered_in_pyproject()<br/>━━━━━━━━━━<br/>small / medium / large in markers list"]
    end

    %% ─── PHASE B: CONFTEST CONFIGURE ─────────────────────────────────────── %%
    subgraph PhaseB ["● Phase B: pytest_configure — Filter Setup (conftest.py)"]
        direction TB
        B1{"filter enabled?<br/>━━━━━━━━━━<br/>AUTOSKILLIT_TEST_FILTER set<br/>OR --filter-mode passed?"}
        B2["resolve FilterMode<br/>━━━━━━━━━━<br/>cli_mode > env_val<br/>conservative / aggressive / none"]
        B3["git_changed_files()<br/>━━━━━━━━━━<br/>git diff --name-only base_ref...HEAD"]
        B4["build_test_scope()<br/>━━━━━━━━━━<br/>classify files → scope paths<br/>global-impact? → full run<br/>>30 files? → full run"]
        B5["stash scope + mode<br/>━━━━━━━━━━<br/>_scope_key → set[Path] | None<br/>_filter_mode_key → str | None"]
    end

    %% ─── PHASE C: COLLECTION MODIFY ITEMS ────────────────────────────────── %%
    subgraph PhaseC ["● Phase C: pytest_collection_modifyitems — Item Gating (conftest.py)"]
        direction TB
        C1["layer marker validation<br/>━━━━━━━━━━<br/>controller-only (no workerinput)<br/>warn on layer/directory mismatch"]
        C2{"scope is None?<br/>━━━━━━━━━━<br/>filter disabled or error?"}
        C3["scope path matching<br/>━━━━━━━━━━<br/>for item in items:<br/>  is_file? exact match<br/>  is_dir? relative_to check"]
        C4["scope deselection<br/>━━━━━━━━━━<br/>items[:] = selected<br/>pytest_deselected(deselected)"]
        C5{"filter_mode == 'aggressive'?"}
        C6["● size marker extraction<br/>━━━━━━━━━━<br/>iter_markers for small/medium/large<br/>default effective_size = 'large'"]
        C7{"● effective_size in<br/>small or medium?"}
        C8["● size deselection<br/>━━━━━━━━━━<br/>items[:] = size_selected<br/>pytest_deselected(size_deselected)"]
    end

    %% ─── PHASE D: EXECUTION TEST SIZE ANNOTATIONS ──────────────────────── %%
    subgraph PhaseD ["● Phase D: tests/execution/ — Size-Annotated Test Files (49 files)"]
        direction LR
        D1["● pytestmark list<br/>━━━━━━━━━━<br/>pytest.mark.layer('execution')<br/>+ pytest.mark.small/medium/large"]
        D2["● ● small tests<br/>━━━━━━━━━━<br/>pure logic, no I/O<br/>no network, no subprocess"]
        D3["● medium tests<br/>━━━━━━━━━━<br/>filesystem + subprocess ok<br/>no network"]
        D4["● large tests<br/>━━━━━━━━━━<br/>full integration<br/>network allowed"]
    end

    %% ─── _SIZE_DIRS REGISTRY ────────────────────────────────────────────── %%
    SD["● _SIZE_DIRS frozenset<br/>━━━━━━━━━━<br/>conftest.py<br/>cli, config, core, execution,<br/>migration, pipeline, recipe,<br/>server, workspace"]

    %% ─── FLOW ──────────────────────────────────────────────────────────── %%
    START --> PhaseA
    START --> PhaseB

    A1 -->|"glob test_*.py per directory"| A2
    A2 --> A3
    A3 -->|"missing"| FAIL
    A3 -->|"found"| A4
    A4 -->|"conflict (>1 marker)"| FAIL
    A4 -->|"exactly one"| A5
    A5 -->|"mismatch"| FAIL
    A5 -->|"match"| A6
    A6 --> COMPLETE

    SD -->|"reads"| A5

    B1 -->|"no"| C1
    B1 -->|"yes"| B2
    B2 --> B3
    B3 --> B4
    B4 -->|"writes scope"| B5
    B5 --> C1

    C1 --> C2
    C2 -->|"yes (full run)"| COMPLETE
    C2 -->|"no (scope active)"| C3
    C3 --> C4
    C4 --> C5
    C5 -->|"no"| COMPLETE
    C5 -->|"yes"| C6
    C6 --> C7
    C7 -->|"large or unannotated"| C8
    C7 -->|"small or medium"| COMPLETE
    C8 --> COMPLETE

    PhaseD -->|"pytestmark consumed by"| C6
    PhaseD -->|"pytestmark scanned by"| A2

    %% CLASS ASSIGNMENTS %%
    class START,COMPLETE,FAIL terminal;
    class A1,SD stateNode;
    class A2,A6 handler;
    class A3,A4,B1,C2,C5,C7 detector;
    class B2,B3,B4,C1,C3,C6 phase;
    class B5,C4,C8 handler;
    class A5 detector;
    class D1,D2,D3,D4 output;
```

### Operational (Administration) Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    subgraph EnvVars ["ENVIRONMENT / CONFIGURATION"]
        direction TB
        FILTER_ENV["AUTOSKILLIT_TEST_FILTER<br/>━━━━━━━━━━<br/>none / conservative / aggressive<br/>(read-only: injected before pytest)"]
        BASE_REF_ENV["AUTOSKILLIT_TEST_BASE_REF<br/>━━━━━━━━━━<br/>git ref for diff base<br/>fallback: GITHUB_BASE_REF"]
        TEST_CMD_CFG["test_check.command config<br/>━━━━━━━━━━<br/>default: [task, test-check]<br/>timeout: 600s"]
    end

    subgraph Tasks ["TASK COMMANDS"]
        direction TB
        TEST_ALL["task test-all<br/>━━━━━━━━━━<br/>pytest -n 4 -m 'not smoke and not canary'<br/>runs lint-imports first"]
        TEST_CHECK["task test-check<br/>━━━━━━━━━━<br/>same as test-all<br/>emits TEST_RESULT=PASS/FAIL"]
        TEST_FILTERED["task test-filtered<br/>━━━━━━━━━━<br/>sets AUTOSKILLIT_TEST_FILTER=conservative<br/>delegates to test-check"]
    end

    subgraph FilterEngine ["TEST FILTER ENGINE (tests/_test_filter.py)"]
        direction TB
        GIT_DIFF["git diff --name-only<br/>━━━━━━━━━━<br/>base_ref...HEAD<br/>discovers changed files"]
        BUCKET_A["Bucket-A detection<br/>━━━━━━━━━━<br/>conftest.py / pyproject.toml<br/>uv.lock → full run"]
        CASCADE["Layer cascade map<br/>━━━━━━━━━━<br/>conservative: core → all 11 dirs<br/>aggressive: each pkg → itself"]
        SCOPE["build_test_scope()<br/>━━━━━━━━━━<br/>returns set of test paths<br/>or None (full run)"]
    end

    subgraph Conftest ["● tests/conftest.py — COLLECTION HOOKS"]
        direction TB
        SIZE_DIRS["● _SIZE_DIRS registry<br/>━━━━━━━━━━<br/>frozenset: cli, config, core,<br/>execution, migration, pipeline,<br/>recipe, server, workspace"]
        LAYER_GUARD["layer marker validator<br/>━━━━━━━━━━<br/>enforces layer(name) values<br/>match directory names"]
        PATH_DESELECT["path deselection<br/>━━━━━━━━━━<br/>removes items outside<br/>computed filter scope"]
        SIZE_DESELECT["size deselection (aggressive)<br/>━━━━━━━━━━<br/>drops large + unannotated tests<br/>small/medium always kept"]
    end

    subgraph SizeMarkers ["● tests/arch/test_size_markers.py — ENFORCEMENT"]
        direction TB
        SIZE_DIRS_ARCH["● SIZE_DIRECTORIES registry<br/>━━━━━━━━━━<br/>9 dirs: cli, config, core,<br/>execution, migration, pipeline,<br/>recipe, server, workspace"]
        CHECK_ALL["test_all_test_files_have_size_marker<br/>━━━━━━━━━━<br/>AST-parses every test_*.py<br/>fails if no size mark present"]
        CHECK_CONFLICT["test_no_conflicting_size_markers<br/>━━━━━━━━━━<br/>fails if >1 size marker per file"]
        CHECK_PYPROJECT["test_size_markers_registered_in_pyproject<br/>━━━━━━━━━━<br/>validates small/medium/large<br/>in pyproject.toml markers"]
        CHECK_SYNC["test_size_marker_directories_match_conftest<br/>━━━━━━━━━━<br/>asserts SIZE_DIRECTORIES.keys()<br/>== _SIZE_DIRS from conftest"]
    end

    subgraph TestSuite ["TEST SUITE"]
        direction TB
        EXEC_TESTS["● tests/execution/ (49 files)<br/>━━━━━━━━━━<br/>pytestmark = [layer('execution'), small/medium/large]<br/>all 49 files now annotated"]
        OTHER_DIRS["tests/cli/, core/, server/, ...<br/>━━━━━━━━━━<br/>8 other size-marked directories<br/>(unchanged in this PR)"]
        ARCH_TESTS["tests/arch/<br/>━━━━━━━━━━<br/>always-run in all filter modes<br/>size enforcement tests here"]
    end

    subgraph Observability ["OBSERVABILITY"]
        direction TB
        TASK_OUT["temp/test-TIMESTAMP.txt<br/>━━━━━━━━━━<br/>timestamped pytest output<br/>(write-only artifact)"]
        PASS_FAIL["stdout: TEST_RESULT=PASS/FAIL<br/>━━━━━━━━━━<br/>machine-readable exit signal<br/>for automation (test-check only)"]
        COV_JSON["temp/coverage-audit-TIMESTAMP.json<br/>━━━━━━━━━━<br/>coverage vs AST comparison<br/>(write-only artifact)"]
    end

    %% FLOWS %%
    FILTER_ENV --> FilterEngine
    BASE_REF_ENV --> GIT_DIFF
    TEST_CMD_CFG --> TEST_CHECK

    TEST_ALL --> Conftest
    TEST_CHECK --> Conftest
    TEST_FILTERED --> FILTER_ENV
    TEST_FILTERED --> TEST_CHECK

    GIT_DIFF --> BUCKET_A
    BUCKET_A --> CASCADE
    CASCADE --> SCOPE
    SCOPE --> PATH_DESELECT

    SIZE_DIRS --> SIZE_DESELECT
    LAYER_GUARD --> PATH_DESELECT
    PATH_DESELECT --> SIZE_DESELECT

    SIZE_DIRS_ARCH --> CHECK_ALL
    SIZE_DIRS_ARCH --> CHECK_CONFLICT
    SIZE_DIRS_ARCH --> CHECK_SYNC
    SIZE_DIRS --> CHECK_SYNC

    SIZE_DESELECT --> EXEC_TESTS
    SIZE_DESELECT --> OTHER_DIRS
    SIZE_DESELECT --> ARCH_TESTS

    EXEC_TESTS --> TASK_OUT
    OTHER_DIRS --> TASK_OUT
    ARCH_TESTS --> TASK_OUT
    ARCH_TESTS --> CHECK_ALL
    ARCH_TESTS --> CHECK_CONFLICT
    ARCH_TESTS --> CHECK_PYPROJECT
    ARCH_TESTS --> CHECK_SYNC

    TEST_CHECK --> PASS_FAIL
    TEST_ALL --> TASK_OUT

    %% CLASS ASSIGNMENTS %%
    class FILTER_ENV,BASE_REF_ENV,TEST_CMD_CFG phase;
    class TEST_ALL,TEST_CHECK,TEST_FILTERED cli;
    class GIT_DIFF,BUCKET_A,CASCADE,SCOPE handler;
    class SIZE_DIRS,LAYER_GUARD,PATH_DESELECT,SIZE_DESELECT stateNode;
    class SIZE_DIRS_ARCH,CHECK_ALL,CHECK_CONFLICT,CHECK_PYPROJECT,CHECK_SYNC detector;
    class EXEC_TESTS,OTHER_DIRS,ARCH_TESTS stateNode;
    class TASK_OUT,PASS_FAIL,COV_JSON output;
```

Closes #1003

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260417-032744-644073/.autoskillit/temp/make-plan/size_markers_execution_plan_2026-04-17_032900.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 111 | 10.4k | 442.4k | 47.6k | 1 | 3m 24s |
| review | 52 | 4.5k | 140.0k | 23.3k | 1 | 2m 37s |
| verify | 124 | 11.3k | 682.7k | 47.5k | 1 | 3m 28s |
| implement | 190 | 9.5k | 914.1k | 42.4k | 1 | 2m 56s |
| fix | 250 | 12.6k | 935.0k | 62.7k | 2 | 10m 6s |
| prepare_pr | 68 | 7.5k | 206.6k | 25.9k | 1 | 1m 58s |
| run_arch_lenses | 7.6k | 18.3k | 544.8k | 99.0k | 3 | 8m 12s |
| compose_pr | 67 | 9.2k | 239.6k | 33.1k | 1 | 2m 39s |
| **Total** | 8.5k | 83.2k | 4.1M | 381.4k | | 35m 24s |