### PR TITLE
Eliminate open_kitchen First-Call MCP Startup Race

### DIFF
--- a/src/autoskillit/cli/_prompts.py
+++ b/src/autoskillit/cli/_prompts.py
@@ -271,7 +271,7 @@ def _build_open_kitchen_prompt(mcp_prefix: str) -> str:
 
     _forbidden_list = ", ".join(PIPELINE_FORBIDDEN_TOOLS)
     text = (
-        f"Call Bash(command=\"sleep 2\") first — this ensures MCP plugin tools are fully "
+        f'Call Bash(command="sleep 2") first — this ensures MCP plugin tools are fully '
         f"registered before proceeding. Bash is a built-in tool, always available.\n"
         f"Then call ToolSearch(query='select:{mcp_prefix}open_kitchen') to load the schema.\n"
         f"Then call {mcp_prefix}open_kitchen to open the AutoSkillit kitchen.\n\n"

--- a/src/autoskillit/cli/_prompts.py
+++ b/src/autoskillit/cli/_prompts.py
@@ -114,21 +114,23 @@ def _build_orchestrator_prompt(
 You are a pipeline orchestrator. Execute the recipe '{recipe_name}' step-by-step.
 
 {_ing_section}FIRST ACTION — before prompting for any inputs:
-0. Call ToolSearch(query='select:{mcp_prefix}open_kitchen') to ensure its schema is loaded.
+0. Call Bash(command="sleep 2") — this ensures MCP plugin tools are fully registered
+   before proceeding. Bash is a built-in tool, always available. DO NOT SKIP THIS STEP.
+1. Call ToolSearch(query='select:{mcp_prefix}open_kitchen') to ensure its schema is loaded.
    ToolSearch is a no-op if the schema is already loaded, but required if the tool appears
    in Claude Code's deferred-tool list. Always call it — no conditional check needed.
-1. Call {mcp_prefix}open_kitchen(name='{recipe_name}') to activate pipeline tools and open
+2. Call {mcp_prefix}open_kitchen(name='{recipe_name}') to activate pipeline tools and open
    the kitchen gate. open_kitchen is REQUIRED to enable all gated AutoSkillit tools —
    the ingredients table above (when present) is provided for reference only.
    DO NOT call AskUserQuestion or any other tool before open_kitchen.
-2. The response contains a pre-formatted ingredients table
+3. The response contains a pre-formatted ingredients table
    between --- INGREDIENTS TABLE --- and --- END TABLE --- markers.
    Display it verbatim in your response — do not reformat or re-render it.
    Then ask for the required fields (marked with *). If the recipe has both
    a task and an issue_url ingredient, mention that a GitHub issue URL can
    be provided as the task. Keep it to one or two short sentences.
-3. Collect ingredient values conversationally from the user's response.
-4. Execute the pipeline steps.
+4. Collect ingredient values conversationally from the user's response.
+5. Execute the pipeline steps.
 
 During pipeline execution, only use AutoSkillit MCP tools:
 - Read, Grep, Glob (code investigation) — not used here because investigation
@@ -269,10 +271,10 @@ def _build_open_kitchen_prompt(mcp_prefix: str) -> str:
 
     _forbidden_list = ", ".join(PIPELINE_FORBIDDEN_TOOLS)
     text = (
-        f"Call ToolSearch(query='select:{mcp_prefix}open_kitchen') first, then call "
-        f"{mcp_prefix}open_kitchen to open the AutoSkillit kitchen.\n"
-        "ToolSearch ensures the schema is loaded (no-op if already loaded, required if "
-        "deferred).\n\n"
+        f"Call Bash(command=\"sleep 2\") first — this ensures MCP plugin tools are fully "
+        f"registered before proceeding. Bash is a built-in tool, always available.\n"
+        f"Then call ToolSearch(query='select:{mcp_prefix}open_kitchen') to load the schema.\n"
+        f"Then call {mcp_prefix}open_kitchen to open the AutoSkillit kitchen.\n\n"
         "IMPORTANT — Orchestrator Discipline:\n"
         f"NEVER use native Claude Code tools ({_forbidden_list}) "
         "in this session. All code reading, searching, editing, and "

--- a/src/autoskillit/execution/commands.py
+++ b/src/autoskillit/execution/commands.py
@@ -115,6 +115,7 @@ _MAX_MCP_OUTPUT_TOKENS_VALUE: str = "50000"
 _SESSION_BASELINE_ENV: Mapping[str, str] = MappingProxyType(
     {
         "MAX_MCP_OUTPUT_TOKENS": _MAX_MCP_OUTPUT_TOKENS_VALUE,
+        "MCP_CONNECTION_NONBLOCKING": "0",
     }
 )
 
@@ -277,6 +278,7 @@ def build_full_headless_cmd(
     extras: dict[str, str] = {
         "AUTOSKILLIT_HEADLESS": "1",
         "MAX_MCP_OUTPUT_TOKENS": _MAX_MCP_OUTPUT_TOKENS_VALUE,
+        "MCP_CONNECTION_NONBLOCKING": "0",
     }
     if exit_after_stop_delay_ms > 0:
         extras["CLAUDE_CODE_EXIT_AFTER_STOP_DELAY"] = str(exit_after_stop_delay_ms)

--- a/tests/cli/test_cli_prompts.py
+++ b/tests/cli/test_cli_prompts.py
@@ -453,7 +453,7 @@ def test_orchestrator_prompt_has_no_deferred_tool_recovery_conditional():
 
 
 def test_first_action_step0_calls_toolsearch_unconditionally():
-    """Step 0 of FIRST ACTION must call ToolSearch unconditionally — no 'if' guard."""
+    """Step 0 is Bash sleep; ToolSearch is still present in FIRST ACTION (step 1)."""
     from autoskillit.cli._mcp_names import DIRECT_PREFIX
     from autoskillit.cli._prompts import _build_orchestrator_prompt
 
@@ -463,14 +463,14 @@ def test_first_action_step0_calls_toolsearch_unconditionally():
     end = prompt.index("During pipeline execution", start)
     first_action = prompt[start:end]
 
-    assert "ToolSearch" in first_action
-
+    # Step 0 is now Bash sleep, not ToolSearch
     step0_end = first_action.index("\n1.")
     step0_text = first_action[:step0_end]
-    lower = step0_text.lower()
-    assert "if the session" not in lower, "Step 0 ToolSearch must be unconditional"
-    assert "if deferred" not in lower, "Step 0 ToolSearch must be unconditional"
-    assert "when the" not in lower, "Step 0 ToolSearch must be unconditional"
+    assert "Bash" in step0_text, "Step 0 must be a Bash sleep gate"
+    assert "sleep" in step0_text.lower(), "Step 0 must contain a sleep command"
+
+    # ToolSearch is still present in the FIRST ACTION section
+    assert "ToolSearch" in first_action
 
 
 def test_first_action_toolsearch_index_precedes_open_kitchen():
@@ -489,12 +489,14 @@ def test_first_action_toolsearch_index_precedes_open_kitchen():
     assert ts_idx < ok_idx, "ToolSearch must appear before open_kitchen in FIRST ACTION"
 
 
-def test_open_kitchen_prompt_step0_unconditional_toolsearch():
-    """_build_open_kitchen_prompt must also call ToolSearch unconditionally."""
+def test_open_kitchen_prompt_has_bash_sleep_and_toolsearch():
+    """_build_open_kitchen_prompt must have Bash sleep and ToolSearch (no conditionals)."""
     from autoskillit.cli._mcp_names import DIRECT_PREFIX
     from autoskillit.cli._prompts import _build_open_kitchen_prompt
 
     prompt = _build_open_kitchen_prompt(mcp_prefix=DIRECT_PREFIX)
+    assert "Bash" in prompt, "Open kitchen prompt must include Bash sleep gate"
+    assert "sleep" in prompt.lower()
     assert "ToolSearch" in prompt
     lower = prompt.lower()
     assert "if the session's deferred-tool list" not in lower
@@ -587,3 +589,64 @@ def test_orchestrator_prompt_contains_skill_command_format_guidance():
         "Orchestrator prompt must contain a SKILL_COMMAND FORMATTING section. "
         "This prevents the LLM from adding markdown headers to skill_command values."
     )
+
+
+def test_first_action_step0_is_bash_sleep():
+    """Step 0 of FIRST ACTION must be a Bash sleep gate, not ToolSearch."""
+    from autoskillit.cli._mcp_names import DIRECT_PREFIX
+    from autoskillit.cli._prompts import _build_orchestrator_prompt
+
+    prompt = _build_orchestrator_prompt("my_recipe", mcp_prefix=DIRECT_PREFIX)
+    start = prompt.index("FIRST ACTION")
+    end = prompt.index("During pipeline execution", start)
+    first_action = prompt[start:end]
+
+    step0_end = first_action.index("\n1.")
+    step0_text = first_action[:step0_end]
+    assert "Bash" in step0_text, "Step 0 must be a Bash sleep gate"
+    assert "sleep" in step0_text.lower(), "Step 0 must contain a sleep command"
+
+
+def test_first_action_bash_sleep_precedes_toolsearch():
+    """Bash sleep gate must appear before ToolSearch in FIRST ACTION."""
+    from autoskillit.cli._mcp_names import DIRECT_PREFIX
+    from autoskillit.cli._prompts import _build_orchestrator_prompt
+
+    prompt = _build_orchestrator_prompt("my_recipe", mcp_prefix=DIRECT_PREFIX)
+    start = prompt.index("FIRST ACTION")
+    end = prompt.index("During pipeline execution", start)
+    first_action = prompt[start:end]
+
+    bash_idx = first_action.index("Bash")
+    ts_idx = first_action.index("ToolSearch")
+    assert bash_idx < ts_idx, "Bash sleep must appear before ToolSearch"
+
+
+def test_first_action_bash_sleep_is_unconditional():
+    """Step 0 Bash sleep must not be gated by any conditional."""
+    from autoskillit.cli._mcp_names import DIRECT_PREFIX
+    from autoskillit.cli._prompts import _build_orchestrator_prompt
+
+    prompt = _build_orchestrator_prompt("my_recipe", mcp_prefix=DIRECT_PREFIX)
+    start = prompt.index("FIRST ACTION")
+    end = prompt.index("During pipeline execution", start)
+    first_action = prompt[start:end]
+
+    step0_end = first_action.index("\n1.")
+    step0_text = first_action[:step0_end].lower()
+    assert "if " not in step0_text, "Step 0 Bash sleep must be unconditional"
+    assert "only if" not in step0_text
+    assert "when the" not in step0_text
+
+
+def test_open_kitchen_prompt_has_bash_sleep_before_toolsearch():
+    """_build_open_kitchen_prompt must have Bash sleep before ToolSearch."""
+    from autoskillit.cli._mcp_names import DIRECT_PREFIX
+    from autoskillit.cli._prompts import _build_open_kitchen_prompt
+
+    prompt = _build_open_kitchen_prompt(mcp_prefix=DIRECT_PREFIX)
+    assert "Bash" in prompt, "Open kitchen prompt must include Bash sleep gate"
+    assert "sleep" in prompt.lower()
+    bash_idx = prompt.index("Bash")
+    ts_idx = prompt.index("ToolSearch")
+    assert bash_idx < ts_idx, "Bash sleep must precede ToolSearch"

--- a/tests/cli/test_cook_env_scrub.py
+++ b/tests/cli/test_cook_env_scrub.py
@@ -92,6 +92,26 @@ def test_launch_cook_session_env_has_max_mcp_output_tokens(
     assert env["MAX_MCP_OUTPUT_TOKENS"] == _MAX_MCP_OUTPUT_TOKENS_VALUE
 
 
+def test_launch_cook_session_env_has_mcp_connection_nonblocking(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_launch_cook_session (order path) must produce env with MCP_CONNECTION_NONBLOCKING=0."""
+    from autoskillit.cli.app import _launch_cook_session
+
+    with (
+        patch("shutil.which", return_value="/usr/bin/claude"),
+        patch(
+            "autoskillit.cli.app.subprocess.run",
+            return_value=MagicMock(returncode=0),
+        ) as mock_run,
+        patch("autoskillit.cli.app.terminal_guard"),
+    ):
+        _launch_cook_session("system prompt", initial_message="hello")
+
+    env = mock_run.call_args.kwargs["env"]
+    assert env["MCP_CONNECTION_NONBLOCKING"] == "0"
+
+
 def test_cook_command_env_excludes_ide_vars(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/cli/test_orchestrator_prompt_contract.py
+++ b/tests/cli/test_orchestrator_prompt_contract.py
@@ -93,22 +93,26 @@ class TestFirstActionAskUserQuestionProhibition:
 
 
 class TestFirstActionTimingResilience:
-    """FIRST ACTION step 0 must call ToolSearch unconditionally before open_kitchen."""
+    """FIRST ACTION step 0 must be a Bash sleep gate before ToolSearch and open_kitchen."""
 
-    def test_first_action_step0_calls_toolsearch_not_open_kitchen_directly(self):
-        """Step 0 in FIRST ACTION must be ToolSearch — not a direct open_kitchen call.
-        ToolSearch is a no-op on loaded schemas; it ensures schema availability without
-        requiring any conditional phrase-matching."""
+    def test_first_action_step0_is_bash_sleep_gate(self):
+        """Step 0 in FIRST ACTION must be a Bash sleep gate — not a direct open_kitchen
+        or ToolSearch call. The sleep ensures MCP plugin tools are registered."""
         prompt = _get_prompt()
         first_action_start = prompt.index("FIRST ACTION")
         first_action_end = prompt.index("During pipeline execution", first_action_start)
         first_action_section = prompt[first_action_start:first_action_end]
 
-        # Step 0 must reference ToolSearch
-        assert "ToolSearch" in first_action_section
-
-        # Step 0 text must not be conditional on a deferred-tool check
+        # Step 0 must be Bash sleep
         step0_end = first_action_section.index("\n1.")
-        step0 = first_action_section[:step0_end].lower()
-        assert "if the session" not in step0
-        assert "if deferred" not in step0
+        step0 = first_action_section[:step0_end]
+        assert "Bash" in step0, "Step 0 must be a Bash sleep gate"
+        assert "sleep" in step0.lower(), "Step 0 must contain a sleep command"
+
+        # Step 0 must not be conditional
+        step0_lower = step0.lower()
+        assert "if the session" not in step0_lower
+        assert "if deferred" not in step0_lower
+
+        # ToolSearch must still appear in FIRST ACTION (as step 1)
+        assert "ToolSearch" in first_action_section

--- a/tests/execution/test_commands.py
+++ b/tests/execution/test_commands.py
@@ -408,3 +408,38 @@ def test_all_session_builders_inject_max_mcp_output_tokens(builder_call) -> None
     spec = builder_call()
     assert "MAX_MCP_OUTPUT_TOKENS" in spec.env
     assert spec.env["MAX_MCP_OUTPUT_TOKENS"] == _MAX_MCP_OUTPUT_TOKENS_VALUE
+
+
+def test_session_baseline_env_contains_mcp_connection_nonblocking() -> None:
+    from autoskillit.execution.commands import _SESSION_BASELINE_ENV
+
+    assert "MCP_CONNECTION_NONBLOCKING" in _SESSION_BASELINE_ENV
+    assert _SESSION_BASELINE_ENV["MCP_CONNECTION_NONBLOCKING"] == "0"
+
+
+def test_interactive_cmd_env_has_mcp_connection_nonblocking() -> None:
+    spec = build_interactive_cmd()
+    assert spec.env.get("MCP_CONNECTION_NONBLOCKING") == "0"
+
+
+@pytest.mark.parametrize(
+    "builder_call",
+    [
+        lambda: build_interactive_cmd(),
+        lambda: build_full_headless_cmd(
+            "/investigate foo",
+            cwd="/tmp",
+            completion_marker="%%DONE%%",
+            model=None,
+            plugin_dir=None,
+            output_format_value="stream-json",
+        ),
+        lambda: build_headless_resume_cmd(resume_session_id="abc", prompt="Emit"),
+    ],
+    ids=["interactive", "full_headless", "headless_resume"],
+)
+def test_all_session_builders_inject_mcp_connection_nonblocking(builder_call) -> None:
+    """Every session command builder must produce env with MCP_CONNECTION_NONBLOCKING=0."""
+    spec = builder_call()
+    assert "MCP_CONNECTION_NONBLOCKING" in spec.env
+    assert spec.env["MCP_CONNECTION_NONBLOCKING"] == "0"


### PR DESCRIPTION
## Summary

Fix the 31.8% session failure rate caused by Claude Code auto-submitting the initial greeting concurrently with MCP server initialization. The LLM generates its first tool call (~2.5s) before the MCP server completes `initialize` + `tools/list` (~3s), causing `open_kitchen` to fail with "No such tool available." The fix inserts a `Bash(command="sleep 2")` gate as the absolute first action in both orchestrator prompts, ensuring MCP tools are loaded before any MCP tool call. A belt-and-suspenders `MCP_CONNECTION_NONBLOCKING=0` env var is injected into all cook sessions.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START: User invokes cook])
    COMPLETE([SESSION LAUNCHED])
    ERROR([ERROR: Session aborted])

    subgraph RecipeSelection ["● Recipe Selection (_prompts.py)"]
        direction TB
        RAW_INPUT["● _resolve_recipe_input<br/>━━━━━━━━━━<br/>Parse user picker text"]
        RECIPE_DECISION{"Recipe or<br/>Open Kitchen?"}
        INVALID_INPUT["Invalid Input<br/>━━━━━━━━━━<br/>Returns None → re-prompt"]
    end

    subgraph PromptAssembly ["● Prompt Assembly (_prompts.py)"]
        direction TB
        ING_TABLE["● _get_ingredients_table<br/>━━━━━━━━━━<br/>load_and_validate → table<br/>Returns None on error"]
        SOUS_CHEF{"sous-chef/<br/>SKILL.md<br/>exists?"}
        BUILD_RECIPE["● _build_orchestrator_prompt<br/>━━━━━━━━━━<br/>Recipe prompt with routing<br/>rules + failure predicates"]
        BUILD_OPEN["● _build_open_kitchen_prompt<br/>━━━━━━━━━━<br/>Free-form prompt with<br/>orchestrator discipline"]
        PROMPT_READY["System Prompt Ready<br/>━━━━━━━━━━<br/>--append-system-prompt"]
    end

    subgraph CommandBuilding ["● Command Building (commands.py)"]
        direction TB
        CMD_DECISION{"Session<br/>Type?"}
        BUILD_INTERACTIVE["● build_interactive_cmd<br/>━━━━━━━━━━<br/>claude --dangerously-skip-permissions<br/>+ _SESSION_BASELINE_ENV"]
        BUILD_HEADLESS["● build_full_headless_cmd<br/>━━━━━━━━━━<br/>claude --print + prompt transforms<br/>+ AUTOSKILLIT_HEADLESS=1"]
        BUILD_RESUME["● build_headless_resume_cmd<br/>━━━━━━━━━━<br/>claude --print --resume id<br/>--output-format json"]
    end

    subgraph PromptTransforms ["● Prompt Transformation Chain (commands.py)"]
        direction LR
        TX1["● _ensure_skill_prefix<br/>━━━━━━━━━━<br/>Prepend 'Use ' to<br/>/slash-commands"]
        TX2["● _inject_completion_directive<br/>━━━━━━━━━━<br/>Append ORCHESTRATION<br/>DIRECTIVE + marker"]
        TX3["● _inject_cwd_anchor<br/>━━━━━━━━━━<br/>Append WORKING<br/>DIRECTORY ANCHOR"]
        TX4["● _inject_narration_suppression<br/>━━━━━━━━━━<br/>Append EFFICIENCY<br/>DIRECTIVE"]
    end

    subgraph EnvSanitization ["● Environment Sanitization (commands.py)"]
        direction TB
        BASELINE["● _SESSION_BASELINE_ENV<br/>━━━━━━━━━━<br/>MAX_MCP_OUTPUT_TOKENS=50000<br/>MCP_CONNECTION_NONBLOCKING=0"]
        SCRUB["build_claude_env<br/>━━━━━━━━━━<br/>IDE var denylist<br/>+ AUTO_CONNECT_IDE=0"]
        STRIP_EXCLUSIVE["● Strip _HEADLESS_EXCLUSIVE_VARS<br/>━━━━━━━━━━<br/>Remove CLAUDE_CODE_EXIT_AFTER_STOP_DELAY<br/>SCENARIO_STEP_NAME from host env"]
    end

    subgraph MCPStartup ["● MCP Startup Sequence (in prompt)"]
        direction TB
        STEP0["● Step 0: Bash sleep 2<br/>━━━━━━━━━━<br/>Wait for MCP plugin<br/>tool registration"]
        STEP1["Step 1: ToolSearch<br/>━━━━━━━━━━<br/>Load open_kitchen<br/>schema from deferred list"]
        STEP2["Step 2: open_kitchen<br/>━━━━━━━━━━<br/>Activate pipeline tools<br/>+ kitchen gate"]
        OK_CHECK{"open_kitchen<br/>success?"}
        STEP3["Step 3: Display table<br/>━━━━━━━━━━<br/>Render ingredients<br/>verbatim from markers"]
        STEP4["Step 4: Collect inputs<br/>━━━━━━━━━━<br/>Ask for required<br/>ingredient values"]
    end

    %% MAIN FLOW %%
    START --> RAW_INPUT
    RAW_INPUT --> RECIPE_DECISION
    RECIPE_DECISION -->|"raw == '0'"| BUILD_OPEN
    RECIPE_DECISION -->|"valid index/name"| ING_TABLE
    RECIPE_DECISION -->|"invalid"| INVALID_INPUT
    INVALID_INPUT -->|"re-prompt"| RAW_INPUT

    ING_TABLE -->|"table or None"| SOUS_CHEF
    SOUS_CHEF -->|"exists"| BUILD_RECIPE
    SOUS_CHEF -->|"absent"| BUILD_RECIPE
    BUILD_RECIPE --> PROMPT_READY
    BUILD_OPEN --> PROMPT_READY

    PROMPT_READY --> CMD_DECISION
    CMD_DECISION -->|"cook (interactive)"| BUILD_INTERACTIVE
    CMD_DECISION -->|"run_skill (headless)"| BUILD_HEADLESS
    CMD_DECISION -->|"contract recovery"| BUILD_RESUME

    BUILD_HEADLESS --> TX1
    TX1 --> TX2
    TX2 --> TX3
    TX3 --> TX4

    BUILD_INTERACTIVE --> BASELINE
    BUILD_HEADLESS --> BASELINE
    BUILD_RESUME --> BASELINE
    BASELINE --> SCRUB
    BUILD_HEADLESS --> STRIP_EXCLUSIVE
    STRIP_EXCLUSIVE --> SCRUB

    TX4 --> SCRUB
    SCRUB --> COMPLETE

    BUILD_INTERACTIVE -.->|"prompt instructs"| STEP0
    STEP0 --> STEP1
    STEP1 --> STEP2
    STEP2 --> OK_CHECK
    OK_CHECK -->|"success: true +<br/>TABLE markers"| STEP3
    OK_CHECK -->|"success: false or<br/>no TABLE markers"| ERROR
    STEP3 --> STEP4
    STEP4 --> COMPLETE

    %% CLASS ASSIGNMENTS %%
    class START,COMPLETE,ERROR terminal;
    class RAW_INPUT,ING_TABLE cli;
    class RECIPE_DECISION,SOUS_CHEF,CMD_DECISION,OK_CHECK stateNode;
    class BUILD_RECIPE,BUILD_OPEN,BUILD_INTERACTIVE,BUILD_HEADLESS,BUILD_RESUME handler;
    class TX1,TX2,TX3,TX4 phase;
    class BASELINE,SCRUB,STRIP_EXCLUSIVE stateNode;
    class STEP0,STEP1,STEP2,STEP3,STEP4 handler;
    class INVALID_INPUT detector;
    class PROMPT_READY output;
```

### Error/Resilience Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;

    START([SESSION START])

    subgraph PromptBuild ["● PROMPT CONSTRUCTION (cli/_prompts.py)"]
        direction TB
        SLEEP_GATE["● Bash sleep 2 Gate<br/>━━━━━━━━━━<br/>Step 0: ensures MCP tools<br/>registered before proceeding"]
        TOOLSEARCH["ToolSearch Gate<br/>━━━━━━━━━━<br/>Step 1: load open_kitchen<br/>schema from deferred tools"]
        ING_TABLE["● _get_ingredients_table<br/>━━━━━━━━━━<br/>Graceful degradation:<br/>bare Exception → None"]
    end

    subgraph EnvSanitize ["● ENV SANITIZATION (execution/commands.py)"]
        direction TB
        BASELINE["● _SESSION_BASELINE_ENV<br/>━━━━━━━━━━<br/>MCP_CONNECTION_NONBLOCKING=0<br/>MAX_MCP_OUTPUT_TOKENS=50000"]
        ENV_SCRUB["build_claude_env<br/>━━━━━━━━━━<br/>IDE denylist + prefix strip<br/>+ always-inject overrides"]
        EXCLUSIVE["● _HEADLESS_EXCLUSIVE_VARS<br/>━━━━━━━━━━<br/>Filter parent env leakage<br/>into child sessions"]
    end

    subgraph KitchenGate ["KITCHEN GATE (server/tools_kitchen.py)"]
        direction TB
        HEADLESS_CHK{"Headless<br/>guard?"}
        HOOK_CFG["_write_hook_config<br/>━━━━━━━━━━<br/>OSError → silent continue"]
        PRIME_QUOTA["_prime_quota_cache<br/>━━━━━━━━━━<br/>Exception → disable gate"]
        ENABLE["enable_components<br/>━━━━━━━━━━<br/>Exception → disable gate"]
        OK_FAIL{"open_kitchen<br/>success?"}
    end

    subgraph HookGuards ["PRETOOLUSE HOOK GUARDS (hooks/)"]
        direction TB
        QUOTA_G["quota_guard<br/>━━━━━━━━━━<br/>Fail-open design:<br/>all errors → approve"]
        SKILL_CMD_G["skill_command_guard<br/>━━━━━━━━━━<br/>Fail-CLOSED: errors → deny<br/>Validates / prefix"]
        BRANCH_G["branch_protection_guard<br/>━━━━━━━━━━<br/>Protected branch list check"]
        HEADLESS_G["headless_orchestration_guard<br/>━━━━━━━━━━<br/>Blocks run_skill in Tier 2"]
        ASK_G["ask_user_question_guard<br/>━━━━━━━━━━<br/>Kitchen marker freshness<br/>24h TTL check"]
    end

    subgraph PromptRouting ["● FAILURE ROUTING (cli/_prompts.py)"]
        direction TB
        PRED{"Failure<br/>predicate<br/>match?"}
        RETRY_RSN{"retry_reason?"}
        STALE_R["subtype=stale<br/>━━━━━━━━━━<br/>Retry step, decrement<br/>counter (max 3)"]
        CONTEXT_R["resume / drain_race<br/>━━━━━━━━━━<br/>→ on_context_limit<br/>or on_failure fallback"]
        EMPTY_R["empty_output /<br/>path_contamination<br/>━━━━━━━━━━<br/>→ on_failure always"]
        QUOTA_DENY["● QUOTA WAIT REQUIRED<br/>━━━━━━━━━━<br/>Execute sleep N seconds<br/>then retry same call"]
        QUOTA_WARN["● QUOTA_POST_WARNING<br/>━━━━━━━━━━<br/>Sleep before next<br/>run_skill call"]
    end

    subgraph HeadlessRecovery ["HEADLESS RECOVERY (execution/headless.py)"]
        direction TB
        BUDGET["_apply_budget_guard<br/>━━━━━━━━━━<br/>consecutive_failures > 3<br/>→ BUDGET_EXHAUSTED"]
        CONTRACT["CONTRACT_RECOVERY<br/>━━━━━━━━━━<br/>adjudicated_failure +<br/>writes ≥ 1 → retry"]
        NUDGE["_attempt_contract_nudge<br/>━━━━━━━━━━<br/>60s timeout, single attempt<br/>OSError/Exception → None"]
        ZERO_W["Zero-write gate<br/>━━━━━━━━━━<br/>success + 0 writes<br/>→ demote to failure"]
        PATH_V["_validate_output_paths<br/>━━━━━━━━━━<br/>CWD boundary check<br/>→ path_contamination"]
        CRASH["except Exception<br/>━━━━━━━━━━<br/>SkillResult.crashed()<br/>+ shielded session log"]
    end

    subgraph Terminals ["TERMINAL STATES"]
        T_SUCCESS([PIPELINE SUCCESS])
        T_ERROR([PIPELINE ERROR])
        T_CIRCUIT([BUDGET EXHAUSTED])
        T_GATE([GATE DENIED])
        T_SESSION_END([SESSION TERMINATED])
    end

    %% FLOW: Session start through prompt build %%
    START --> SLEEP_GATE
    SLEEP_GATE -->|"MCP ready"| TOOLSEARCH
    TOOLSEARCH --> ING_TABLE
    ING_TABLE -->|"table or None"| BASELINE

    %% ENV flow %%
    BASELINE --> ENV_SCRUB
    ENV_SCRUB --> EXCLUSIVE

    %% Kitchen gate %%
    EXCLUSIVE -->|"session launched"| HEADLESS_CHK
    HEADLESS_CHK -->|"headless=1"| T_GATE
    HEADLESS_CHK -->|"interactive"| HOOK_CFG
    HOOK_CFG --> PRIME_QUOTA
    PRIME_QUOTA -->|"Exception"| T_GATE
    PRIME_QUOTA -->|"ok"| ENABLE
    ENABLE -->|"Exception"| T_GATE
    ENABLE -->|"ok"| OK_FAIL
    OK_FAIL -->|"success:false / no table"| T_SESSION_END
    OK_FAIL -->|"success:true"| PRED

    %% Hook guards (parallel checks on each tool call) %%
    PRED -.->|"each tool call"| QUOTA_G
    PRED -.->|"each tool call"| SKILL_CMD_G
    PRED -.->|"each tool call"| BRANCH_G
    PRED -.->|"each tool call"| HEADLESS_G
    PRED -.->|"each tool call"| ASK_G
    QUOTA_G -->|"deny"| QUOTA_DENY
    SKILL_CMD_G -->|"deny"| T_ERROR
    BRANCH_G -->|"deny"| T_ERROR
    HEADLESS_G -->|"deny"| T_ERROR
    ASK_G -->|"deny"| T_ERROR

    %% Failure routing %%
    PRED -->|"success:false"| RETRY_RSN
    RETRY_RSN -->|"stale"| STALE_R
    RETRY_RSN -->|"resume/drain_race"| CONTEXT_R
    RETRY_RSN -->|"empty/contamination"| EMPTY_R
    STALE_R -->|"retries left"| PRED
    STALE_R -->|"exhausted"| T_CIRCUIT
    CONTEXT_R -->|"on_context_limit"| PRED
    CONTEXT_R -->|"fallback"| T_ERROR
    EMPTY_R --> T_ERROR
    QUOTA_DENY -->|"sleep done"| PRED
    QUOTA_WARN -->|"sleep done"| PRED
    PRED -->|"success:true"| T_SUCCESS

    %% Headless recovery (inside run_skill) %%
    RETRY_RSN -.->|"inside headless"| BUDGET
    BUDGET -->|"exceeded"| T_CIRCUIT
    BUDGET -->|"under limit"| CONTRACT
    CONTRACT -->|"eligible"| NUDGE
    NUDGE -->|"recovered"| T_SUCCESS
    NUDGE -->|"failed/timeout"| ZERO_W
    CONTRACT -->|"not eligible"| ZERO_W
    ZERO_W -->|"demoted"| T_ERROR
    ZERO_W -->|"ok"| PATH_V
    PATH_V -->|"contaminated"| T_ERROR
    PATH_V -->|"clean"| T_SUCCESS
    CRASH --> T_ERROR

    %% CLASS ASSIGNMENTS %%
    class START,T_SUCCESS,T_ERROR,T_CIRCUIT,T_GATE,T_SESSION_END terminal;
    class SLEEP_GATE,TOOLSEARCH,ING_TABLE handler;
    class BASELINE,ENV_SCRUB,EXCLUSIVE stateNode;
    class HEADLESS_CHK,OK_FAIL,PRED,RETRY_RSN phase;
    class HOOK_CFG,PRIME_QUOTA,ENABLE handler;
    class QUOTA_G,SKILL_CMD_G,BRANCH_G,HEADLESS_G,ASK_G detector;
    class STALE_R,CONTEXT_R,EMPTY_R,QUOTA_DENY,QUOTA_WARN output;
    class BUDGET,CONTRACT,NUDGE,ZERO_W,PATH_V,CRASH output;
```

### Concurrency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START([SESSION START])
    COMPLETE([SESSION LIVE])

    subgraph PromptLayer ["● PROMPT LAYER — _prompts.py"]
        direction TB
        ORCH_PROMPT["● _build_orchestrator_prompt<br/>━━━━━━━━━━<br/>Builds orchestrator system prompt<br/>with FIRST ACTION timing gates"]
        OK_PROMPT["● _build_open_kitchen_prompt<br/>━━━━━━━━━━<br/>Builds open-kitchen prompt<br/>with sleep gate at top"]
        SLEEP_GATE["● Step 0: Bash sleep 2<br/>━━━━━━━━━━<br/>UNCONDITIONAL timing gate<br/>Ensures MCP tools registered<br/>before any ToolSearch call"]
        TS_STEP["Step 1: ToolSearch<br/>━━━━━━━━━━<br/>Load deferred tool schemas<br/>only after sleep completes"]
    end

    subgraph EnvLayer ["● ENV LAYER — commands.py"]
        direction TB
        BASELINE_ENV["● _SESSION_BASELINE_ENV<br/>━━━━━━━━━━<br/>MCP_CONNECTION_NONBLOCKING=0<br/>MAX_MCP_OUTPUT_TOKENS=50000"]
        BUILD_INTER["● build_interactive_cmd<br/>━━━━━━━━━━<br/>Merges baseline env<br/>Calls build_claude_env"]
        BUILD_FULL["● build_full_headless_cmd<br/>━━━━━━━━━━<br/>Injects MCP_CONNECTION_NONBLOCKING=0<br/>+ AUTOSKILLIT_HEADLESS=1"]
        BUILD_RESUME["build_headless_resume_cmd<br/>━━━━━━━━━━<br/>Merges baseline env<br/>for contract nudge recovery"]
    end

    subgraph EnvScrub ["ENV SCRUBBING — _claude_env.py"]
        direction TB
        SCRUB["build_claude_env<br/>━━━━━━━━━━<br/>IDE denylist strip<br/>Prefix denylist strip<br/>Returns MappingProxyType"]
        AUTO_CONNECT["CLAUDE_CODE_AUTO_CONNECT_IDE=0<br/>━━━━━━━━━━<br/>Suppress IDE bridge scan"]
    end

    subgraph MCPServer ["MCP SERVER STARTUP"]
        direction TB
        LIFESPAN["_lifespan.py<br/>━━━━━━━━━━<br/>asynccontextmanager<br/>writes readiness sentinel"]
        SENTINEL["readiness.py<br/>━━━━━━━━━━<br/>PID-scoped sentinel file<br/>atomic_write via os.replace"]
        BG_TASKS["Background Tasks<br/>━━━━━━━━━━<br/>drift_check via run_in_executor<br/>deferred_init via create_task"]
        STARTUP_EVT["asyncio.Event<br/>━━━━━━━━━━<br/>_startup_ready<br/>set after deferred_init"]
    end

    subgraph ProcessRace ["PROCESS RACE — run_managed_async"]
        direction TB
        TASK_GROUP["anyio.create_task_group<br/>━━━━━━━━━━<br/>Fan-out 4-5 coroutines"]
        TRIGGER["anyio.Event trigger<br/>━━━━━━━━━━<br/>First-wins race signal"]
    end

    subgraph Watchers ["CONCURRENT WATCHERS"]
        direction LR
        W_PROC["_watch_process<br/>━━━━━━━━━━<br/>await proc.wait<br/>Channel A exit"]
        W_HEART["_watch_heartbeat<br/>━━━━━━━━━━<br/>Poll stdout NDJSON<br/>Channel A confirm"]
        W_SESS["_watch_session_log<br/>━━━━━━━━━━<br/>Poll JSONL file<br/>Channel B"]
        W_IDLE["_watch_stdout_idle<br/>━━━━━━━━━━<br/>Stall detection<br/>idle_output_timeout"]
    end

    subgraph Resolution ["TERMINATION RESOLUTION"]
        direction TB
        RACE_ACC["RaceAccumulator<br/>━━━━━━━━━━<br/>Mutable dataclass<br/>No lock needed<br/>cooperative scheduling"]
        RESOLVE["resolve_termination<br/>━━━━━━━━━━<br/>Pure function<br/>Signals → Reason + Channel"]
        DRAIN["Symmetric Drain Window<br/>━━━━━━━━━━<br/>move_on_after timeout<br/>Channel B grace period"]
        KILL["async_kill_process_tree<br/>━━━━━━━━━━<br/>anyio.to_thread.run_sync<br/>SIGTERM → SIGKILL<br/>CancelScope shield=True"]
    end

    subgraph QuotaGate ["QUOTA SLEEP GATES — prompt-instructed"]
        direction TB
        QUOTA_DENY["Quota Denial<br/>━━━━━━━━━━<br/>run_cmd sleep from deny msg<br/>then retry run_skill"]
        QUOTA_WARN["Quota Post-Warning<br/>━━━━━━━━━━<br/>run_cmd sleep before<br/>next run_skill"]
    end

    subgraph DrainRace ["● DRAIN RACE HANDLING — _prompts.py"]
        direction TB
        DRAIN_RACE["● drain_race routing<br/>━━━━━━━━━━<br/>needs_retry + drain_race<br/>stdout not flushed before kill"]
    end

    %% === PRIMARY FLOW === %%
    START --> ORCH_PROMPT
    START --> OK_PROMPT
    ORCH_PROMPT --> SLEEP_GATE
    OK_PROMPT --> SLEEP_GATE
    SLEEP_GATE -->|"2s elapsed"| TS_STEP

    START --> BASELINE_ENV
    BASELINE_ENV --> BUILD_INTER
    BASELINE_ENV --> BUILD_FULL
    BASELINE_ENV --> BUILD_RESUME
    BUILD_INTER --> SCRUB
    BUILD_FULL --> SCRUB
    BUILD_RESUME --> SCRUB
    SCRUB --> AUTO_CONNECT

    %% === MCP STARTUP RACE === %%
    SLEEP_GATE -.->|"defends against"| LIFESPAN
    BASELINE_ENV -.->|"MCP_CONNECTION_NONBLOCKING=0<br/>forces blocking handshake"| LIFESPAN
    LIFESPAN --> SENTINEL
    LIFESPAN --> BG_TASKS
    BG_TASKS --> STARTUP_EVT

    %% === SUBPROCESS PROCESS RACE === %%
    BUILD_FULL -->|"spawns subprocess"| TASK_GROUP
    TASK_GROUP --> W_PROC
    TASK_GROUP --> W_HEART
    TASK_GROUP --> W_SESS
    TASK_GROUP --> W_IDLE
    TASK_GROUP --> TRIGGER

    W_PROC --> RACE_ACC
    W_HEART --> RACE_ACC
    W_SESS --> RACE_ACC
    W_IDLE --> RACE_ACC

    RACE_ACC --> RESOLVE
    RESOLVE --> DRAIN
    DRAIN --> KILL

    TRIGGER -.->|"first-wins"| RESOLVE

    %% === PROMPT-LEVEL GATES === %%
    TS_STEP --> COMPLETE
    ORCH_PROMPT --> QUOTA_DENY
    ORCH_PROMPT --> QUOTA_WARN
    ORCH_PROMPT --> DRAIN_RACE

    %% CLASS ASSIGNMENTS %%
    class START,COMPLETE terminal;
    class ORCH_PROMPT,OK_PROMPT,SLEEP_GATE,DRAIN_RACE handler;
    class TS_STEP phase;
    class BASELINE_ENV,BUILD_INTER,BUILD_FULL,BUILD_RESUME handler;
    class SCRUB,AUTO_CONNECT stateNode;
    class LIFESPAN,SENTINEL,STARTUP_EVT phase;
    class BG_TASKS newComponent;
    class TASK_GROUP,TRIGGER detector;
    class W_PROC,W_HEART,W_SESS,W_IDLE newComponent;
    class RACE_ACC,RESOLVE stateNode;
    class DRAIN,KILL detector;
    class QUOTA_DENY,QUOTA_WARN phase;
```

Closes #1010

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260417-074151-080150/.autoskillit/temp/make-plan/eliminate_open_kitchen_mcp_startup_race_plan_2026-04-17_075200.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 99 | 20.8k | 2.0M | 100.4k | 1 | 16m 7s |
| review | 30 | 6.4k | 386.1k | 35.0k | 1 | 5m 48s |
| verify | 50 | 12.5k | 1.6M | 89.2k | 1 | 5m 37s |
| implement | 85 | 15.4k | 1.9M | 52.4k | 1 | 5m 37s |
| prepare_pr | 27 | 3.9k | 265.7k | 26.8k | 1 | 1m 25s |
| run_arch_lenses | 7.1k | 19.1k | 829.4k | 111.5k | 3 | 11m 5s |
| compose_pr | 24 | 10.2k | 205.9k | 36.1k | 1 | 3m 6s |
| **Total** | 7.4k | 88.3k | 7.1M | 451.3k | | 48m 48s |