### PR TITLE
Implementation Plan: Adopt InMemoryDatabaseReader in test_tools_status.py

### DIFF
--- a/tests/server/test_tools_status.py
+++ b/tests/server/test_tools_status.py
@@ -6,7 +6,6 @@ import asyncio
 import json
 from datetime import UTC, datetime
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import anyio
 import pytest
@@ -1215,16 +1214,17 @@ async def test_tools_status_routes_through_db_reader(tool_ctx, tmp_path) -> None
     """read_db routes through ctx.db_reader.query()."""
     import sqlite3 as _sqlite3
 
-    tool_ctx.db_reader = MagicMock()
-    tool_ctx.db_reader.query.return_value = {"rows": [], "count": 0}
+    from tests.fakes import InMemoryDatabaseReader
+
+    reader = InMemoryDatabaseReader(query_result={"rows": [], "count": 0})
+    tool_ctx.db_reader = reader
 
     db_path = str(tmp_path / "test.db")
     # Create an empty sqlite db so path-exists check passes
     _sqlite3.connect(db_path).close()
     await read_db(db_path, "SELECT 1")
-    tool_ctx.db_reader.query.assert_called_once()
-    call_kwargs = tool_ctx.db_reader.query.call_args
-    assert "SELECT 1" in str(call_kwargs)
+    assert len(reader.calls) == 1
+    assert "SELECT 1" in reader.calls[0]["sql"]
 
 
 # T3 — read_db error paths include success: False


### PR DESCRIPTION
## Summary

Replace the `MagicMock`-based db_reader stub in `test_tools_status_routes_through_db_reader`
with `InMemoryDatabaseReader` from `tests/fakes.py`. This eliminates the fragile
`str(call_args)` substring match in favour of typed `reader.calls[0]["sql"]` field access.
The `MagicMock` import becomes unused and must be removed. No production code changes. No
behaviour change — the same pass/fail contract holds.

## Architecture Impact

### Repository/Data Access Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;

    subgraph Callers ["CALLERS"]
        TEST["● test_tools_status.py<br/>━━━━━━━━━━<br/>test_tools_status_routes_through_db_reader<br/>Injects InMemoryDatabaseReader<br/>into ctx.db_reader"]
        TOOL["read_db<br/>━━━━━━━━━━<br/>tools_status.py<br/>MCP tool handler"]
    end

    subgraph DI ["DEPENDENCY INJECTION"]
        CTX["ToolContext.db_reader<br/>━━━━━━━━━━<br/>pipeline/context.py<br/>DatabaseReader | None"]
    end

    subgraph Protocol ["PROTOCOL BOUNDARY"]
        PROTO["DatabaseReader<br/>━━━━━━━━━━<br/>core/_type_protocols.py<br/>.query(db_path, sql, params,<br/>timeout_sec, max_rows)"]
    end

    subgraph Impls ["IMPLEMENTATIONS"]
        direction TB
        PROD["DefaultDatabaseReader<br/>━━━━━━━━━━<br/>execution/db.py<br/>_execute_readonly_query()<br/>mode=ro + authorizer"]
        FAKE["InMemoryDatabaseReader<br/>━━━━━━━━━━<br/>tests/fakes.py<br/>Records calls; returns<br/>pre-configured result"]
    end

    subgraph Storage ["STORAGE"]
        direction TB
        SQLITE[("SQLite DB<br/>━━━━━━━━━━<br/>File on disk<br/>read-only mode")]
        MEM[("In-Memory<br/>━━━━━━━━━━<br/>query_result dict<br/>calls list")]
    end

    TEST -->|"sets ctx.db_reader = InMemoryDatabaseReader"| CTX
    TEST -->|"calls read_db()"| TOOL
    TOOL -->|"reads ctx.db_reader"| CTX
    CTX -->|"satisfies"| PROTO
    PROTO -->|"production"| PROD
    PROTO -->|"test injection"| FAKE
    PROD -->|"reads"| SQLITE
    FAKE -->|"reads"| MEM

    %% CLASS ASSIGNMENTS %%
    class TEST phase;
    class TOOL handler;
    class CTX stateNode;
    class PROTO cli;
    class PROD output;
    class FAKE newComponent;
    class SQLITE,MEM integration;
```

### Scenarios Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;

    subgraph S1 ["SCENARIO 1 ●: read_db Routes Through DatabaseReader Protocol (PR Change)"]
        direction LR
        S1_TEST["● test_tools_status_routes_<br/>through_db_reader<br/>━━━━━━━━━━<br/>reads: InMemoryDatabaseReader<br/>writes: tool_ctx.db_reader"]
        S1_FAKE["InMemoryDatabaseReader<br/>━━━━━━━━━━<br/>reads: query_result dict<br/>writes: self.calls list"]
        S1_CTX["tool_ctx<br/>━━━━━━━━━━<br/>reads: db_reader field<br/>passes through: DI container"]
        S1_HANDLER["read_db()<br/>tools_status.py<br/>━━━━━━━━━━<br/>reads: ctx.db_reader<br/>passes through: sql, params"]
        S1_ASSERT["assert len(reader.calls)==1<br/>assert SQL in calls[0]<br/>━━━━━━━━━━<br/>reads: reader.calls"]
    end

    subgraph S2 ["SCENARIO 2: Full-Stack SQLite Integration"]
        direction LR
        S2_FIXTURE["sample_db fixture<br/>━━━━━━━━━━<br/>writes: real .db file<br/>in tmp_path"]
        S2_CTX["tool_ctx<br/>━━━━━━━━━━<br/>reads: make_context()<br/>wires: DefaultDatabaseReader"]
        S2_HANDLER["read_db()<br/>tools_status.py<br/>━━━━━━━━━━<br/>reads: db_path, sql<br/>validates: SELECT-only"]
        S2_GUARD["Security Guards<br/>━━━━━━━━━━<br/>reads: sql pattern<br/>rejects: INSERT/DROP/ATTACH"]
        S2_REAL["DefaultDatabaseReader<br/>execution/db.py<br/>━━━━━━━━━━<br/>reads: db via mode=ro URI<br/>writes: query result dict"]
        S2_RESULT["JSON result<br/>━━━━━━━━━━<br/>rows, column_names<br/>truncated, row_count"]
    end

    subgraph S3 ["SCENARIO 3: Kitchen Gate Enforcement"]
        direction LR
        S3_TEST["test_gated_when_disabled<br/>━━━━━━━━━━<br/>writes: gate = DefaultGateState<br/>(enabled=False)"]
        S3_HANDLER["read_db()<br/>tools_status.py<br/>━━━━━━━━━━<br/>reads: _require_enabled()"]
        S3_GATE["DefaultGateState<br/>━━━━━━━━━━<br/>reads: enabled flag<br/>returns: gate_error"]
        S3_RESP["gate_error JSON<br/>━━━━━━━━━━<br/>success=False, is_error=True<br/>'not enabled'"]
    end

    subgraph S4 ["SCENARIO 4: Telemetry Status Tools (In-Memory State)"]
        direction LR
        S4_TEST["Test populates<br/>tool_ctx state<br/>━━━━━━━━━━<br/>writes: token_log.record()<br/>writes: timing_log.record()<br/>writes: audit.record_failure()"]
        S4_CTX["tool_ctx<br/>━━━━━━━━━━<br/>reads: token_log, timing_log<br/>reads: audit, gate"]
        S4_HANDLERS["Status Handlers<br/>get_token_summary()<br/>get_timing_summary()<br/>get_pipeline_report()<br/>━━━━━━━━━━<br/>reads: ctx logs<br/>writes: clear markers"]
        S4_RESULT["JSON / Markdown Table<br/>━━━━━━━━━━<br/>steps[], total{}<br/>failures[]"]
    end

    %% SCENARIO 1 FLOW %%
    S1_TEST -->|"injects"| S1_FAKE
    S1_FAKE -->|"assigned to db_reader"| S1_CTX
    S1_CTX -->|"provides ctx"| S1_HANDLER
    S1_HANDLER -->|"calls query()"| S1_FAKE
    S1_FAKE -->|"records call"| S1_ASSERT

    %% SCENARIO 2 FLOW %%
    S2_FIXTURE -->|"provides path"| S2_HANDLER
    S2_CTX -->|"provides ctx"| S2_HANDLER
    S2_HANDLER -->|"pre-validates"| S2_GUARD
    S2_GUARD -->|"delegates"| S2_REAL
    S2_REAL -->|"returns"| S2_RESULT

    %% SCENARIO 3 FLOW %%
    S3_TEST -->|"configures ctx"| S3_HANDLER
    S3_HANDLER -->|"checks gate"| S3_GATE
    S3_GATE -->|"blocks"| S3_RESP

    %% SCENARIO 4 FLOW %%
    S4_TEST -->|"populates"| S4_CTX
    S4_CTX -->|"provides ctx"| S4_HANDLERS
    S4_HANDLERS -->|"reads state"| S4_RESULT

    %% CLASS ASSIGNMENTS %%
    class S1_TEST,S2_FIXTURE,S3_TEST,S4_TEST cli;
    class S1_CTX,S2_CTX,S4_CTX stateNode;
    class S1_HANDLER,S2_HANDLER,S4_HANDLERS handler;
    class S1_FAKE newComponent;
    class S2_REAL phase;
    class S2_GUARD,S3_GATE detector;
    class S1_ASSERT,S2_RESULT,S3_RESP,S4_RESULT output;
    class S3_HANDLER handler;
```

Closes #1008

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260417-100316-584009/.autoskillit/temp/make-plan/adopt_inmemorydatabasereader_test_tools_status_plan_2026-04-17_100316.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 125 | 5.7k | 577.3k | 53.7k | 1 | 2m 30s |
| review | 68 | 3.7k | 185.3k | 18.6k | 1 | 1m 39s |
| verify | 84 | 6.6k | 329.7k | 34.7k | 1 | 1m 49s |
| implement | 108 | 3.2k | 343.0k | 20.4k | 1 | 1m 9s |
| prepare_pr | 60 | 3.5k | 163.3k | 18.7k | 1 | 1m 7s |
| run_arch_lenses | 132 | 10.0k | 565.8k | 109.1k | 2 | 4m 9s |
| compose_pr | 67 | 5.4k | 207.9k | 27.3k | 1 | 1m 24s |
| **Total** | 644 | 38.1k | 2.4M | 282.6k | | 13m 48s |