### PR TITLE
Extend InMemoryRecipeRepository with Call Recording

### DIFF
--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -211,6 +211,7 @@ class InMemoryRecipeRepository(RecipeRepository):
         return self._recipes.get(name)
 
     def list(self, project_dir: Path) -> Any:
+        self.calls.append({"method": "list", "project_dir": project_dir})
         return list(self._recipes.keys())
 
     def load_and_validate(
@@ -241,6 +242,13 @@ class InMemoryRecipeRepository(RecipeRepository):
     def validate_from_path(
         self, script_path: Any, temp_dir_relpath: str = ".autoskillit/temp"
     ) -> dict[str, Any]:
+        self.calls.append(
+            {
+                "method": "validate_from_path",
+                "script_path": script_path,
+                "temp_dir_relpath": temp_dir_relpath,
+            }
+        )
         key = str(script_path)
         return self._path_validated.get(key, {"valid": False, "error": "not configured"})
 

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -188,6 +188,7 @@ class InMemoryRecipeRepository(RecipeRepository):
         self._validated: dict[str, dict[str, Any]] = {}
         self._path_validated: dict[str, dict[str, Any]] = {}
         self._all_recipes: dict[str, Any] = {}
+        self.calls: list[dict[str, Any]] = []
 
     # -- test setup helpers --
 
@@ -206,6 +207,7 @@ class InMemoryRecipeRepository(RecipeRepository):
     # -- protocol methods --
 
     def find(self, name: str, project_dir: Path) -> Any:
+        self.calls.append({"method": "find", "name": name, "project_dir": project_dir})
         return self._recipes.get(name)
 
     def list(self, project_dir: Path) -> Any:
@@ -222,6 +224,18 @@ class InMemoryRecipeRepository(RecipeRepository):
         temp_dir: Path | None = None,
         temp_dir_relpath: str | None = None,
     ) -> dict[str, Any]:
+        self.calls.append(
+            {
+                "method": "load_and_validate",
+                "name": name,
+                "project_dir": project_dir,
+                "suppressed": suppressed,
+                "resolved_defaults": resolved_defaults,
+                "ingredient_overrides": ingredient_overrides,
+                "temp_dir": temp_dir,
+                "temp_dir_relpath": temp_dir_relpath,
+            }
+        )
         return self._validated.get(name, {"valid": False, "error": "not configured"})
 
     def validate_from_path(
@@ -231,6 +245,7 @@ class InMemoryRecipeRepository(RecipeRepository):
         return self._path_validated.get(key, {"valid": False, "error": "not configured"})
 
     def list_all(self, project_dir: Any | None = None) -> dict[str, Any]:
+        self.calls.append({"method": "list_all", "project_dir": project_dir})
         return self._all_recipes
 
     async def apply_triage_gate(

--- a/tests/test_fakes_conformance.py
+++ b/tests/test_fakes_conformance.py
@@ -213,3 +213,73 @@ async def test_database_reader_returns_configured_result():
     result = reader.query("test.db", "SELECT 1", [], 30, 100)
     assert result["row_count"] == 1
     assert len(reader.calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# T5: InMemoryRecipeRepository call recording
+# ---------------------------------------------------------------------------
+
+
+def test_recipe_repository_find_records_call():
+    repo = InMemoryRecipeRepository()
+    repo.find("my-recipe", Path("/proj"))
+    assert len(repo.calls) == 1
+    call = repo.calls[0]
+    assert call["method"] == "find"
+    assert call["name"] == "my-recipe"
+    assert call["project_dir"] == Path("/proj")
+
+
+def test_recipe_repository_load_and_validate_records_call():
+    repo = InMemoryRecipeRepository()
+    repo.load_and_validate(
+        "my-recipe",
+        Path("/proj"),
+        suppressed=["rule-a"],
+        resolved_defaults={"k": "v"},
+        ingredient_overrides={"x": "y"},
+        temp_dir=Path("/tmp"),
+        temp_dir_relpath=".autoskillit/temp",
+    )
+    assert len(repo.calls) == 1
+    call = repo.calls[0]
+    assert call["method"] == "load_and_validate"
+    assert call["name"] == "my-recipe"
+    assert call["project_dir"] == Path("/proj")
+    assert call["suppressed"] == ["rule-a"]
+    assert call["resolved_defaults"] == {"k": "v"}
+    assert call["ingredient_overrides"] == {"x": "y"}
+    assert call["temp_dir"] == Path("/tmp")
+    assert call["temp_dir_relpath"] == ".autoskillit/temp"
+
+
+def test_recipe_repository_list_all_records_call():
+    repo = InMemoryRecipeRepository()
+    repo.list_all(project_dir=Path("/proj"))
+    assert len(repo.calls) == 1
+    call = repo.calls[0]
+    assert call["method"] == "list_all"
+    assert call["project_dir"] == Path("/proj")
+
+
+def test_recipe_repository_list_all_records_call_with_none_project_dir():
+    repo = InMemoryRecipeRepository()
+    repo.list_all()
+    assert len(repo.calls) == 1
+    assert repo.calls[0]["project_dir"] is None
+
+
+def test_recipe_repository_calls_accumulate():
+    repo = InMemoryRecipeRepository()
+    repo.find("r1", Path("/a"))
+    repo.list_all()
+    repo.load_and_validate("r1", Path("/a"))
+    assert len(repo.calls) == 3
+    assert repo.calls[0]["method"] == "find"
+    assert repo.calls[1]["method"] == "list_all"
+    assert repo.calls[2]["method"] == "load_and_validate"
+
+
+def test_recipe_repository_calls_starts_empty():
+    repo = InMemoryRecipeRepository()
+    assert repo.calls == []

--- a/tests/test_fakes_conformance.py
+++ b/tests/test_fakes_conformance.py
@@ -283,3 +283,14 @@ def test_recipe_repository_calls_accumulate():
 def test_recipe_repository_calls_starts_empty():
     repo = InMemoryRecipeRepository()
     assert repo.calls == []
+
+
+def test_recipe_repository_validate_from_path_records_call():
+    repo = InMemoryRecipeRepository()
+    script_path = Path("/proj/recipe.yaml")
+    repo.validate_from_path(script_path, ".autoskillit/temp")
+    assert len(repo.calls) == 1
+    call = repo.calls[0]
+    assert call["method"] == "validate_from_path"
+    assert call["script_path"] == script_path
+    assert call["temp_dir_relpath"] == ".autoskillit/temp"

--- a/tests/test_fakes_conformance.py
+++ b/tests/test_fakes_conformance.py
@@ -230,6 +230,15 @@ def test_recipe_repository_find_records_call():
     assert call["project_dir"] == Path("/proj")
 
 
+def test_recipe_repository_list_records_call():
+    repo = InMemoryRecipeRepository()
+    repo.list(Path("/proj"))
+    assert len(repo.calls) == 1
+    call = repo.calls[0]
+    assert call["method"] == "list"
+    assert call["project_dir"] == Path("/proj")
+
+
 def test_recipe_repository_load_and_validate_records_call():
     repo = InMemoryRecipeRepository()
     repo.load_and_validate(
@@ -289,6 +298,17 @@ def test_recipe_repository_validate_from_path_records_call():
     repo = InMemoryRecipeRepository()
     script_path = Path("/proj/recipe.yaml")
     repo.validate_from_path(script_path, ".autoskillit/temp")
+    assert len(repo.calls) == 1
+    call = repo.calls[0]
+    assert call["method"] == "validate_from_path"
+    assert call["script_path"] == script_path
+    assert call["temp_dir_relpath"] == ".autoskillit/temp"
+
+
+def test_recipe_repository_validate_from_path_records_call_default_relpath():
+    repo = InMemoryRecipeRepository()
+    script_path = Path("/proj/recipe.yaml")
+    repo.validate_from_path(script_path)
     assert len(repo.calls) == 1
     call = repo.calls[0]
     assert call["method"] == "validate_from_path"


### PR DESCRIPTION
## Summary

Add a unified `calls: list[dict[str, Any]]` attribute to `InMemoryRecipeRepository` in
`tests/fakes.py`. The three observable methods — `find()`, `load_and_validate()`, and
`list_all()` — each append a dict keyed with `"method"` plus every argument (by name) to
`self.calls` before returning their existing result. Conformance tests are added to
`tests/test_fakes_conformance.py` under a new `T5` section. No production code or test
adoption is touched.

## Architecture Impact

### Repository/Data Access Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 65, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    subgraph Protocols ["PROTOCOLS — core/types.py"]
        direction TB
        RECIPE_PROTO["RecipeRepository<br/>━━━━━━━━━━<br/>find()<br/>list()<br/>load_and_validate()<br/>validate_from_path()<br/>list_all()<br/>apply_triage_gate()"]
        EXEC_PROTO["HeadlessExecutor<br/>━━━━━━━━━━<br/>run()"]
        TEST_PROTO["TestRunner<br/>━━━━━━━━━━<br/>run()"]
        CI_PROTO["CIWatcher<br/>━━━━━━━━━━<br/>wait() / status()"]
        MQ_PROTO["MergeQueueWatcher<br/>━━━━━━━━━━<br/>wait() / toggle()"]
        DB_PROTO["DatabaseReader<br/>━━━━━━━━━━<br/>query()"]
        SUB_PROTO["SubprocessRunner<br/>━━━━━━━━━━<br/>__call__()"]
    end

    subgraph Fakes ["FAKES — ● tests/fakes.py"]
        direction TB
        IMR["● InMemoryRecipeRepository<br/>━━━━━━━━━━<br/>_recipes: dict<br/>_validated: dict<br/>_path_validated: dict<br/>_all_recipes: dict<br/>calls: list[dict] ← NEW"]
        IMHE["InMemoryHeadlessExecutor<br/>━━━━━━━━━━<br/>_queue: deque[SkillResult]<br/>calls: list[ExecutorCall]"]
        IMTR["InMemoryTestRunner<br/>━━━━━━━━━━<br/>_results: deque[TestResult]<br/>calls: list[Path]"]
        IMCI["InMemoryCIWatcher<br/>━━━━━━━━━━<br/>_wait_result: dict<br/>wait_calls / status_calls"]
        IMMQ["InMemoryMergeQueueWatcher<br/>━━━━━━━━━━<br/>_wait_result: dict<br/>wait_calls / toggle_calls"]
        IMDB["InMemoryDatabaseReader<br/>━━━━━━━━━━<br/>_query_result: dict<br/>calls: list[dict]"]
        MSUB["MockSubprocessRunner<br/>━━━━━━━━━━<br/>_queue: deque[SubprocessResult]<br/>call_args_list"]
    end

    subgraph CallRecording ["CALL RECORDING — ● InMemoryRecipeRepository.calls"]
        direction TB
        FIND_REC["find() → calls<br/>━━━━━━━━━━<br/>{method, name, project_dir}"]
        LAV_REC["load_and_validate() → calls<br/>━━━━━━━━━━<br/>{method, name, project_dir,<br/>suppressed, resolved_defaults,<br/>ingredient_overrides, temp_dir,<br/>temp_dir_relpath}"]
        LA_REC["list_all() → calls<br/>━━━━━━━━━━<br/>{method, project_dir}"]
    end

    subgraph InMemStorage ["IN-MEMORY STORAGE — dict / deque"]
        direction TB
        RECIPE_STORE[("_recipes<br/>━━━━━━━━━━<br/>name → recipe data")]
        VALID_STORE[("_validated<br/>━━━━━━━━━━<br/>name → validation result")]
        PVALID_STORE[("_path_validated<br/>━━━━━━━━━━<br/>path_str → validation result")]
        ALL_STORE[("_all_recipes<br/>━━━━━━━━━━<br/>name → recipe metadata")]
        CALLS_STORE[("calls<br/>━━━━━━━━━━<br/>list[dict] — append-only<br/>ordered call history")]
    end

    subgraph Conformance ["CONFORMANCE TESTS — ● tests/test_fakes_conformance.py"]
        direction TB
        T1["T1: isinstance protocol checks<br/>━━━━━━━━━━<br/>all 7 fakes verified"]
        T5["● T5: RecipeRepository call recording<br/>━━━━━━━━━━<br/>find / load_and_validate / list_all<br/>calls accumulate + start empty"]
    end

    %% Protocol → Fake satisfaction
    RECIPE_PROTO -->|"satisfies"| IMR
    EXEC_PROTO -->|"satisfies"| IMHE
    TEST_PROTO -->|"satisfies"| IMTR
    CI_PROTO -->|"satisfies"| IMCI
    MQ_PROTO -->|"satisfies"| IMMQ
    DB_PROTO -->|"satisfies"| IMDB
    SUB_PROTO -->|"satisfies"| MSUB

    %% RecipeRepository methods → call recording
    IMR -->|"writes"| FIND_REC
    IMR -->|"writes"| LAV_REC
    IMR -->|"writes"| LA_REC

    %% Call recording → calls store
    FIND_REC -->|"appends"| CALLS_STORE
    LAV_REC -->|"appends"| CALLS_STORE
    LA_REC -->|"appends"| CALLS_STORE

    %% RecipeRepository reads from in-memory stores
    IMR -->|"reads"| RECIPE_STORE
    IMR -->|"reads"| VALID_STORE
    IMR -->|"reads"| PVALID_STORE
    IMR -->|"reads"| ALL_STORE

    %% Conformance tests use fakes
    T1 -->|"validates"| IMR
    T5 -->|"asserts"| CALLS_STORE

    %% CLASS ASSIGNMENTS %%
    class RECIPE_PROTO,EXEC_PROTO,TEST_PROTO,CI_PROTO,MQ_PROTO,DB_PROTO,SUB_PROTO phase;
    class IMR handler;
    class IMHE,IMTR,IMCI,IMMQ,IMDB,MSUB stateNode;
    class FIND_REC,LAV_REC,LA_REC newComponent;
    class RECIPE_STORE,VALID_STORE,PVALID_STORE,ALL_STORE,CALLS_STORE integration;
    class T1,T5 cli;
```

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ENTRY %%
    INIT([Protocol Test Start])

    subgraph InitOnly ["INIT_ONLY — Preset Result Fields"]
        direction LR
        ExecDefault["_default: SkillResult<br/>━━━━━━━━━━<br/>InMemoryHeadlessExecutor<br/>Never mutated by run()"]
        RecipeData["_recipes / _validated<br/>_path_validated / _all_recipes<br/>━━━━━━━━━━<br/>● InMemoryRecipeRepository<br/>Set by add_recipe / set_* helpers"]
        CIResults["_wait_result / _status_result<br/>_toggle_result / _query_result<br/>━━━━━━━━━━<br/>InMemory{CI,MergeQueue,Database}<br/>Set at construction"]
    end

    subgraph Mutable ["MUTABLE — Test-Controlled State"]
        direction LR
        Queue["_queue: deque<br/>━━━━━━━━━━<br/>InMemoryHeadlessExecutor<br/>MockSubprocessRunner<br/>push() / popleft()"]
        SideEffect["side_effect / wait_side_effect<br/>status_side_effect / toggle_side_effect<br/>━━━━━━━━━━<br/>InMemory{CI,MergeQueue,Database}<br/>None → exception/callable/value"]
        CallCount["_call_count: int<br/>━━━━━━━━━━<br/>InMemoryTestRunner<br/>Incremented on every run()"]
    end

    subgraph ResolutionGate ["RESPONSE RESOLUTION GATE"]
        direction TB
        SECheck{"side_effect<br/>is not None?"}
        SEResolver["_resolve_side_effect()<br/>━━━━━━━━━━<br/>Raise if exception<br/>Call if callable<br/>Return as-is"]
        QueueCheck{"_queue<br/>non-empty?"}
        QueuePop["popleft()<br/>━━━━━━━━━━<br/>Defensive copy via<br/>dataclasses.replace()"]
        DefaultReturn["Return default<br/>━━━━━━━━━━<br/>dataclasses.replace(_default)<br/>Isolated copy per call"]
    end

    subgraph AppendOnly ["APPEND_ONLY — Call Recording"]
        direction TB
        RecipeCalls["● calls: list[dict]<br/>━━━━━━━━━━<br/>InMemoryRecipeRepository<br/>find / load_and_validate / list_all<br/>Records method + all args"]
        ExecCalls["calls: list[ExecutorCall]<br/>━━━━━━━━━━<br/>InMemoryHeadlessExecutor<br/>One ExecutorCall per run()"]
        RunnerCalls["calls: list[Path]<br/>━━━━━━━━━━<br/>InMemoryTestRunner<br/>call_args_list: list[tuple]<br/>MockSubprocessRunner"]
        WatcherCalls["wait_calls / status_calls<br/>toggle_calls: list[dict]<br/>━━━━━━━━━━<br/>InMemory{CI,MergeQueue,Database}<br/>Full kwargs snapshot per call"]
    end

    subgraph ConformanceGate ["PROTOCOL CONFORMANCE GATE (T1 Tests)"]
        direction LR
        IsInstance["isinstance(fake, Protocol)<br/>━━━━━━━━━━<br/>Structural subtyping check<br/>runtime_checkable"]
        T1Pass["PASS: fake satisfies<br/>━━━━━━━━━━<br/>All 7 protocol types<br/>HeadlessExecutor, TestRunner<br/>RecipeRepository, CIWatcher<br/>MergeQueueWatcher, DatabaseReader<br/>SubprocessRunner"]
    end

    %% FLOW %%
    INIT --> InitOnly
    INIT --> Mutable

    InitOnly --> ResolutionGate
    Mutable --> ResolutionGate

    SECheck -->|yes| SEResolver
    SECheck -->|no| QueueCheck
    QueueCheck -->|yes| QueuePop
    QueueCheck -->|no| DefaultReturn

    ResolutionGate --> AppendOnly

    SEResolver --> RecipeCalls
    QueuePop --> ExecCalls
    DefaultReturn --> RunnerCalls
    DefaultReturn --> WatcherCalls

    AppendOnly --> ConformanceGate
    IsInstance --> T1Pass

    %% CLASS ASSIGNMENTS %%
    class ExecDefault,RecipeData,CIResults detector;
    class Queue,SideEffect,CallCount phase;
    class SECheck,QueueCheck gap;
    class SEResolver,QueuePop,DefaultReturn handler;
    class RecipeCalls,ExecCalls,RunnerCalls,WatcherCalls stateNode;
    class IsInstance,T1Pass output;
    class INIT terminal;
```

Closes #1009

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260417-103818-181851/.autoskillit/temp/make-plan/extend_inmemoryreciperepository_call_recording_plan_2026-04-17_103818.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 117 | 6.5k | 458.9k | 43.6k | 1 | 2m 12s |
| review | 2.5k | 5.1k | 207.1k | 39.1k | 1 | 4m 7s |
| verify | 100 | 6.3k | 408.8k | 35.2k | 1 | 2m 10s |
| implement | 150 | 5.6k | 674.8k | 37.9k | 1 | 1m 49s |
| prepare_pr | 60 | 3.5k | 168.9k | 19.5k | 1 | 1m 7s |
| run_arch_lenses | 122 | 10.5k | 403.3k | 81.2k | 2 | 3m 11s |
| compose_pr | 67 | 6.2k | 215.8k | 25.4k | 1 | 1m 50s |
| **Total** | 3.1k | 43.8k | 2.5M | 281.8k | | 16m 30s |