### PR TITLE
feat: include uncommitted and untracked changes in test filter git diff

### DIFF
--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -111,7 +111,7 @@ changed files. Controlled by env var + CLI flags:
 **Filter algorithm** (`tests/_test_filter.py`):
 
 1. **Fail-open gate**: If env var is unset/falsy, all tests run. On any error, all tests run.
-2. **Changed files**: `git diff --name-only base_ref...HEAD`
+2. **Changed files**: `git merge-base HEAD base_ref` → SHA, then `git diff --name-only <sha>` (working tree vs merge-base: committed + staged + unstaged tracked) + `git ls-files --others --exclude-standard` (new untracked files). Union of all three — a strict superset of the old three-dot form. **Known limitation**: `git rm --cached` (stage-only deletions) are not captured — the file still exists on disk so the working-tree diff misses the deletion. This is acceptable given the fail-open design.
 3. **Bucket A**: If any "global impact" file changed (conftest.py, pyproject.toml, etc.) -> full run
 4. **Large changeset**: >30 files -> full run
 5. **Classification**: src Python -> layer cascade, test Python -> direct, non-Python -> manifest lookup

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -292,8 +292,18 @@ def git_changed_files(
         return None
 
     try:
-        result = subprocess.run(
-            ["git", "diff", "--name-only", f"{base_ref}...HEAD"],
+        merge_base_result = subprocess.run(
+            ["git", "merge-base", "HEAD", base_ref],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=True,
+        )
+        merge_base_sha = merge_base_result.stdout.strip()
+
+        diff_result = subprocess.run(
+            ["git", "diff", "--name-only", merge_base_sha],
             cwd=str(cwd),
             capture_output=True,
             text=True,
@@ -310,8 +320,25 @@ def git_changed_files(
         warnings.warn("git binary not found on PATH", stacklevel=2)
         return None
 
-    lines = result.stdout.strip().splitlines()
-    return {line.strip() for line in lines if line.strip()}
+    files: set[str] = set()
+    for line in diff_result.stdout.strip().splitlines():
+        if line.strip():
+            files.add(line.strip())
+
+    untracked = subprocess.run(
+        ["git", "ls-files", "--others", "--exclude-standard"],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    if untracked.returncode == 0:
+        for line in untracked.stdout.strip().splitlines():
+            if line.strip():
+                files.add(line.strip())
+
+    return files
 
 
 def check_bucket_a(changed_files: set[str]) -> bool:

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -301,6 +301,9 @@ def git_changed_files(
             check=True,
         )
         merge_base_sha = merge_base_result.stdout.strip()
+        if not merge_base_sha:
+            warnings.warn("git merge-base returned empty output", stacklevel=2)
+            return None
 
         diff_result = subprocess.run(
             ["git", "diff", "--name-only", merge_base_sha],

--- a/tests/test_test_filter.py
+++ b/tests/test_test_filter.py
@@ -408,12 +408,15 @@ class TestFilterModes:
 
 class TestGitChangedFiles:
     def test_git_changed_files_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        fake_result = subprocess.CompletedProcess(
+        merge_base_result = subprocess.CompletedProcess(args=[], returncode=0, stdout="abc123\n")
+        diff_result = subprocess.CompletedProcess(
             args=[],
             returncode=0,
             stdout="src/autoskillit/core/io.py\ntests/core/test_io.py\n",
         )
-        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: fake_result)
+        ls_files_result = subprocess.CompletedProcess(args=[], returncode=0, stdout="")
+        results = iter([merge_base_result, diff_result, ls_files_result])
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: next(results))
         result = git_changed_files("/fake", base_ref="main")
         assert result == {"src/autoskillit/core/io.py", "tests/core/test_io.py"}
 
@@ -447,15 +450,20 @@ class TestGitChangedFiles:
         monkeypatch.delenv("GITHUB_BASE_REF", raising=False)
 
         captured_args: list[list[str]] = []
+        call_count = 0
 
         def _capture(*a: object, **kw: object) -> subprocess.CompletedProcess[str]:
+            nonlocal call_count
             captured_args.append(list(a[0]))
-            return subprocess.CompletedProcess(args=[], returncode=0, stdout="")
+            call_count += 1
+            stdout = "abc123\n" if call_count == 1 else ""
+            return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout)
 
         monkeypatch.setattr(subprocess, "run", _capture)
         git_changed_files("/fake")
         assert captured_args
-        assert "feature-branch...HEAD" in captured_args[0]
+        assert captured_args[0][:3] == ["git", "merge-base", "HEAD"]
+        assert captured_args[0][3] == "feature-branch"
 
     def test_git_changed_files_github_base_ref(
         self,
@@ -465,15 +473,66 @@ class TestGitChangedFiles:
         monkeypatch.setenv("GITHUB_BASE_REF", "main")
 
         captured_args: list[list[str]] = []
+        call_count = 0
 
         def _capture(*a: object, **kw: object) -> subprocess.CompletedProcess[str]:
+            nonlocal call_count
             captured_args.append(list(a[0]))
-            return subprocess.CompletedProcess(args=[], returncode=0, stdout="")
+            call_count += 1
+            stdout = "abc123\n" if call_count == 1 else ""
+            return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout)
 
         monkeypatch.setattr(subprocess, "run", _capture)
         git_changed_files("/fake")
         assert captured_args
-        assert "main...HEAD" in captured_args[0]
+        assert captured_args[0][:3] == ["git", "merge-base", "HEAD"]
+        assert captured_args[0][3] == "main"
+
+    def test_git_changed_files_includes_unstaged_tracked(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        results = iter(
+            [
+                subprocess.CompletedProcess(args=[], returncode=0, stdout="abc123\n"),
+                subprocess.CompletedProcess(
+                    args=[], returncode=0, stdout="src/autoskillit/core/io.py\n"
+                ),
+                subprocess.CompletedProcess(args=[], returncode=0, stdout=""),
+            ]
+        )
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: next(results))
+        result = git_changed_files("/fake", base_ref="main")
+        assert result == {"src/autoskillit/core/io.py"}
+
+    def test_git_changed_files_includes_untracked_files(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        results = iter(
+            [
+                subprocess.CompletedProcess(args=[], returncode=0, stdout="abc123\n"),
+                subprocess.CompletedProcess(args=[], returncode=0, stdout=""),
+                subprocess.CompletedProcess(args=[], returncode=0, stdout="new_script.py\n"),
+            ]
+        )
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: next(results))
+        result = git_changed_files("/fake", base_ref="main")
+        assert result == {"new_script.py"}
+
+    def test_git_changed_files_ls_files_failure_is_nonfatal(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        results = iter(
+            [
+                subprocess.CompletedProcess(args=[], returncode=0, stdout="abc123\n"),
+                subprocess.CompletedProcess(
+                    args=[], returncode=0, stdout="src/autoskillit/core/io.py\n"
+                ),
+                subprocess.CompletedProcess(args=[], returncode=1, stdout=""),
+            ]
+        )
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: next(results))
+        result = git_changed_files("/fake", base_ref="main")
+        assert result == {"src/autoskillit/core/io.py"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_test_filter.py
+++ b/tests/test_test_filter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ast
 import subprocess
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 
@@ -408,17 +409,21 @@ class TestFilterModes:
 
 class TestGitChangedFiles:
     def test_git_changed_files_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        merge_base_result = subprocess.CompletedProcess(args=[], returncode=0, stdout="abc123\n")
-        diff_result = subprocess.CompletedProcess(
-            args=[],
-            returncode=0,
-            stdout="src/autoskillit/core/io.py\ntests/core/test_io.py\n",
+        mock_run = Mock(
+            side_effect=[
+                subprocess.CompletedProcess(args=[], returncode=0, stdout="abc123\n"),
+                subprocess.CompletedProcess(
+                    args=[],
+                    returncode=0,
+                    stdout="src/autoskillit/core/io.py\ntests/core/test_io.py\n",
+                ),
+                subprocess.CompletedProcess(args=[], returncode=0, stdout=""),
+            ]
         )
-        ls_files_result = subprocess.CompletedProcess(args=[], returncode=0, stdout="")
-        results = iter([merge_base_result, diff_result, ls_files_result])
-        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: next(results))
+        monkeypatch.setattr(subprocess, "run", mock_run)
         result = git_changed_files("/fake", base_ref="main")
         assert result == {"src/autoskillit/core/io.py", "tests/core/test_io.py"}
+        assert mock_run.call_count == 3
 
     def test_git_changed_files_failure_returns_none(
         self,
@@ -449,21 +454,19 @@ class TestGitChangedFiles:
         monkeypatch.setenv("AUTOSKILLIT_TEST_BASE_REF", "feature-branch")
         monkeypatch.delenv("GITHUB_BASE_REF", raising=False)
 
-        captured_args: list[list[str]] = []
-        call_count = 0
-
-        def _capture(*a: object, **kw: object) -> subprocess.CompletedProcess[str]:
-            nonlocal call_count
-            captured_args.append(list(a[0]))
-            call_count += 1
-            stdout = "abc123\n" if call_count == 1 else ""
-            return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout)
-
-        monkeypatch.setattr(subprocess, "run", _capture)
+        mock_run = Mock(
+            side_effect=[
+                subprocess.CompletedProcess(args=[], returncode=0, stdout="abc123\n"),
+                subprocess.CompletedProcess(args=[], returncode=0, stdout=""),
+                subprocess.CompletedProcess(args=[], returncode=0, stdout=""),
+            ]
+        )
+        monkeypatch.setattr(subprocess, "run", mock_run)
         git_changed_files("/fake")
-        assert captured_args
-        assert captured_args[0][:3] == ["git", "merge-base", "HEAD"]
-        assert captured_args[0][3] == "feature-branch"
+        assert mock_run.call_count == 3
+        first_call_args = list(mock_run.call_args_list[0][0][0])
+        assert first_call_args[:3] == ["git", "merge-base", "HEAD"]
+        assert first_call_args[3] == "feature-branch"
 
     def test_git_changed_files_github_base_ref(
         self,
@@ -472,27 +475,25 @@ class TestGitChangedFiles:
         monkeypatch.delenv("AUTOSKILLIT_TEST_BASE_REF", raising=False)
         monkeypatch.setenv("GITHUB_BASE_REF", "main")
 
-        captured_args: list[list[str]] = []
-        call_count = 0
-
-        def _capture(*a: object, **kw: object) -> subprocess.CompletedProcess[str]:
-            nonlocal call_count
-            captured_args.append(list(a[0]))
-            call_count += 1
-            stdout = "abc123\n" if call_count == 1 else ""
-            return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout)
-
-        monkeypatch.setattr(subprocess, "run", _capture)
+        mock_run = Mock(
+            side_effect=[
+                subprocess.CompletedProcess(args=[], returncode=0, stdout="abc123\n"),
+                subprocess.CompletedProcess(args=[], returncode=0, stdout=""),
+                subprocess.CompletedProcess(args=[], returncode=0, stdout=""),
+            ]
+        )
+        monkeypatch.setattr(subprocess, "run", mock_run)
         git_changed_files("/fake")
-        assert captured_args
-        assert captured_args[0][:3] == ["git", "merge-base", "HEAD"]
-        assert captured_args[0][3] == "main"
+        assert mock_run.call_count == 3
+        first_call_args = list(mock_run.call_args_list[0][0][0])
+        assert first_call_args[:3] == ["git", "merge-base", "HEAD"]
+        assert first_call_args[3] == "main"
 
     def test_git_changed_files_includes_unstaged_tracked(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        results = iter(
-            [
+        mock_run = Mock(
+            side_effect=[
                 subprocess.CompletedProcess(args=[], returncode=0, stdout="abc123\n"),
                 subprocess.CompletedProcess(
                     args=[], returncode=0, stdout="src/autoskillit/core/io.py\n"
@@ -500,29 +501,31 @@ class TestGitChangedFiles:
                 subprocess.CompletedProcess(args=[], returncode=0, stdout=""),
             ]
         )
-        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: next(results))
+        monkeypatch.setattr(subprocess, "run", mock_run)
         result = git_changed_files("/fake", base_ref="main")
         assert result == {"src/autoskillit/core/io.py"}
+        assert mock_run.call_count == 3
 
     def test_git_changed_files_includes_untracked_files(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        results = iter(
-            [
+        mock_run = Mock(
+            side_effect=[
                 subprocess.CompletedProcess(args=[], returncode=0, stdout="abc123\n"),
                 subprocess.CompletedProcess(args=[], returncode=0, stdout=""),
                 subprocess.CompletedProcess(args=[], returncode=0, stdout="new_script.py\n"),
             ]
         )
-        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: next(results))
+        monkeypatch.setattr(subprocess, "run", mock_run)
         result = git_changed_files("/fake", base_ref="main")
         assert result == {"new_script.py"}
+        assert mock_run.call_count == 3
 
     def test_git_changed_files_ls_files_failure_is_nonfatal(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        results = iter(
-            [
+        mock_run = Mock(
+            side_effect=[
                 subprocess.CompletedProcess(args=[], returncode=0, stdout="abc123\n"),
                 subprocess.CompletedProcess(
                     args=[], returncode=0, stdout="src/autoskillit/core/io.py\n"
@@ -530,9 +533,10 @@ class TestGitChangedFiles:
                 subprocess.CompletedProcess(args=[], returncode=1, stdout=""),
             ]
         )
-        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: next(results))
+        monkeypatch.setattr(subprocess, "run", mock_run)
         result = git_changed_files("/fake", base_ref="main")
         assert result == {"src/autoskillit/core/io.py"}
+        assert mock_run.call_count == 3
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`git_changed_files()` in `tests/_test_filter.py` currently uses `git diff --name-only base_ref...HEAD`, which only reports committed changes. On branches with no new commits yet (HEAD == merge-base), the filter returns an empty set and falls back to only `arch/` + `contracts/` — giving false confidence that the implementation is correct when source-layer tests were never run.

The fix replaces the single three-dot diff with three subprocess calls:
1. `git merge-base HEAD base_ref` → get the merge-base SHA
2. `git diff --name-only <sha>` (no trailing HEAD) → diff working tree against merge-base (includes staged + unstaged tracked changes)
3. `git ls-files --others --exclude-standard` → capture new untracked files

The result is a strict superset of the current output. Three existing tests are updated to handle the three-call sequence; three new tests validate the new coverage areas.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START<br/>git_changed_files])
    FULLRUN([FULL RUN<br/>return None])
    SCOPEDRUN([SCOPED RUN<br/>return set of Paths])
    ERROR([ERROR<br/>return None])

    subgraph BaseRef ["Phase 1 — Base Ref Resolution"]
        direction TB
        EnvCheck["● EnvCheck<br/>━━━━━━━━━━<br/>reads AUTOSKILLIT_TEST_BASE_REF<br/>falls back to GITHUB_BASE_REF"]
        NoRef{"base_ref<br/>is None?"}
    end

    subgraph GitDiff ["Phase 2 — Git Diff Collection (●Modified)"]
        direction TB
        MergeBase["● git merge-base HEAD base_ref<br/>━━━━━━━━━━<br/>resolve common ancestor SHA"]
        DiffCmd["● git diff --name-only sha<br/>━━━━━━━━━━<br/>committed + staged + unstaged tracked<br/>working tree vs merge-base"]
        LsFiles["● git ls-files --others --exclude-standard<br/>━━━━━━━━━━<br/>NEW: untracked files (non-fatal)"]
        LsFail{"ls-files<br/>returncode != 0?"}
        SubprocErr{"CalledProcessError /<br/>TimeoutExpired /<br/>FileNotFoundError?"}
        UnionSet["● Union: diff files + untracked<br/>━━━━━━━━━━<br/>complete working-tree change set"]
    end

    subgraph FailOpenGates ["Phase 3 — Fail-Open Gates (build_test_scope)"]
        direction TB
        ModeCheck{"FilterMode<br/>== NONE?"}
        NullCheck{"changed_files<br/>is None?"}
        SizeCheck{"len > 30<br/>files?"}
        BucketA{"Bucket A<br/>triggered?"}
    end

    subgraph Classify ["Phase 4 — File Classification"]
        direction TB
        FileLoop["For each changed file<br/>━━━━━━━━━━<br/>iterate changed_files set"]
        SrcPy{"starts with src/<br/>ends with .py?"}
        TestPy{"starts with tests/<br/>ends with .py?"}
        NonPy{"non-Python<br/>file?"}
        CascadeMap["Layer Cascade Map<br/>━━━━━━━━━━<br/>CONSERVATIVE: wide cascade<br/>AGGRESSIVE: narrow (self only)"]
        DirectFile["Add to direct_test_files<br/>━━━━━━━━━━<br/>exact path, no cascade"]
        ManifestLookup["apply_manifest()<br/>━━━━━━━━━━<br/>pathspec gitwildmatch<br/>pattern → test dirs"]
        UnknownFile{"pkg not in<br/>cascade map<br/>OR manifest None?"}
    end

    subgraph ReexportExpansion ["Phase 5 — Re-export Closure Expansion"]
        direction TB
        HasSrcPy{"any src/*.py<br/>changed?"}
        WalkParents["_expand_reexport_closure()<br/>━━━━━━━━━━<br/>walk parent dirs<br/>AST-parse __init__.py<br/>detect direct re-exports"]
        ExpandErr{"expansion<br/>raises?"}
        CascadeInit["cascade-classify<br/>expanded __init__.py files<br/>━━━━━━━━━━<br/>skip if pkg not in map"]
    end

    subgraph AlwaysRun ["Phase 6 — Always-Run Union"]
        direction TB
        AlwaysSet["Union always-run dirs<br/>━━━━━━━━━━<br/>CONSERVATIVE: arch, contracts,<br/>infra, docs<br/>AGGRESSIVE: arch, contracts"]
    end

    subgraph CoverageOracle ["Phase 7 — Coverage Oracle (Aggressive Only)"]
        direction TB
        AggrCheck{"mode == AGGRESSIVE<br/>AND cov map path set?"}
        LoadCov["load_coverage_map()<br/>━━━━━━━━━━<br/>JSON file, staleness guard<br/>(max 30 days)"]
        CovPresent{"cov_map<br/>not None?"}
        RefineLoop["For each cascade dir<br/>━━━━━━━━━━<br/>if ALL contributing src files<br/>have coverage data → replace<br/>dir with specific test files"]
    end

    subgraph Resolve ["Phase 8 — Path Resolution"]
        direction TB
        ResolveLoop["Resolve test_dirs → Paths<br/>━━━━━━━━━━<br/>tests_root / d if dir exists<br/>Add direct_test_files as Paths"]
    end

    %% FLOW %%
    START --> EnvCheck
    EnvCheck --> NoRef
    NoRef -->|"yes"| ERROR
    NoRef -->|"no"| MergeBase
    MergeBase --> SubprocErr
    SubprocErr -->|"yes"| ERROR
    SubprocErr -->|"no"| DiffCmd
    DiffCmd --> LsFiles
    LsFiles --> LsFail
    LsFail -->|"yes (skip, non-fatal)"| UnionSet
    LsFail -->|"no"| UnionSet
    UnionSet --> ModeCheck

    ModeCheck -->|"NONE"| FULLRUN
    ModeCheck -->|"other"| NullCheck
    NullCheck -->|"yes"| FULLRUN
    NullCheck -->|"no"| SizeCheck
    SizeCheck -->|"> 30"| FULLRUN
    SizeCheck -->|"<= 30"| BucketA
    BucketA -->|"yes"| FULLRUN
    BucketA -->|"no"| FileLoop

    FileLoop --> SrcPy
    SrcPy -->|"yes"| CascadeMap
    SrcPy -->|"no"| TestPy
    TestPy -->|"yes"| DirectFile
    TestPy -->|"no"| NonPy
    NonPy -->|"yes"| ManifestLookup
    NonPy -->|"no (other .py)"| FULLRUN
    ManifestLookup --> UnknownFile
    CascadeMap --> UnknownFile
    UnknownFile -->|"yes"| FULLRUN
    UnknownFile -->|"no"| HasSrcPy

    DirectFile --> HasSrcPy
    HasSrcPy -->|"yes"| WalkParents
    HasSrcPy -->|"no"| AlwaysSet
    WalkParents --> ExpandErr
    ExpandErr -->|"yes (logged, fail-open)"| AlwaysSet
    ExpandErr -->|"no"| CascadeInit
    CascadeInit --> AlwaysSet

    AlwaysSet --> AggrCheck
    AggrCheck -->|"no"| ResolveLoop
    AggrCheck -->|"yes"| LoadCov
    LoadCov --> CovPresent
    CovPresent -->|"no (stale/missing)"| ResolveLoop
    CovPresent -->|"yes"| RefineLoop
    RefineLoop --> ResolveLoop

    ResolveLoop --> SCOPEDRUN

    %% CLASS ASSIGNMENTS %%
    class START,FULLRUN,SCOPEDRUN,ERROR terminal;
    class EnvCheck,MergeBase,DiffCmd,LsFiles,UnionSet handler;
    class FileLoop,CascadeMap,DirectFile,ManifestLookup,WalkParents,CascadeInit,AlwaysSet,LoadCov,RefineLoop,ResolveLoop phase;
    class NoRef,SubprocErr,LsFail,ModeCheck,NullCheck,SizeCheck,BucketA,SrcPy,TestPy,NonPy,UnknownFile,HasSrcPy,ExpandErr,AggrCheck,CovPresent detector;
```

### Error/Resilience Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;

    %% TERMINALS %%
    FULL_RUN([FULL RUN<br/>━━━━━━━━━━<br/>None → run all tests])
    FILTERED([FILTERED RUN<br/>━━━━━━━━━━<br/>set of Path objects])

    subgraph GitDiff ["● GIT DIFF — git_changed_files()"]
        direction TB
        GD_ENV{"base_ref<br/>from env?"}
        GD_MERGE["git merge-base HEAD base_ref<br/>━━━━━━━━━━<br/>resolve common ancestor SHA"]
        GD_DIFF["git diff --name-only SHA<br/>━━━━━━━━━━<br/>committed + staged + unstaged tracked"]
        GD_UNTRACKED["git ls-files --others<br/>━━━━━━━━━━<br/>new untracked files"]
        GD_ERR_PROC["CalledProcessError<br/>━━━━━━━━━━<br/>exit ≠ 0 from merge-base or diff"]
        GD_ERR_TIMEOUT["TimeoutExpired<br/>━━━━━━━━━━<br/>10s timeout exceeded"]
        GD_ERR_NOTFOUND["FileNotFoundError<br/>━━━━━━━━━━<br/>git not on PATH"]
        GD_WARN["warnings.warn()<br/>━━━━━━━━━━<br/>soft failure — caller gets None"]
        GD_LSFAIL["ls-files returncode ≠ 0<br/>━━━━━━━━━━<br/>non-fatal: no untracked added"]
    end

    subgraph BuildScope ["● BUILD SCOPE — build_test_scope()"]
        direction TB
        GATE_MODE{"FilterMode<br/>== NONE?"}
        GATE_NONE{"changed_files<br/>is None?"}
        GATE_LARGE{"len > 30<br/>files?"}
        GATE_BUCKET{"Bucket A<br/>triggered?"}
        CLASSIFY["Classify each file<br/>━━━━━━━━━━<br/>src/*.py → cascade<br/>tests/*.py → direct<br/>non-.py → manifest"]
        GATE_UNKNOWN_PY["unknown .py outside<br/>src/ or tests/<br/>━━━━━━━━━━<br/>unclassifiable Python file"]
        GATE_UNKNOWN_PKG["src package not in<br/>cascade_map<br/>━━━━━━━━━━<br/>unknown autoskillit subpackage"]
    end

    subgraph Expansion ["REEXPORT CLOSURE — _expand_reexport_closure()"]
        direction TB
        EXP_WALK["Walk parent __init__.py files<br/>━━━━━━━━━━<br/>AST parse for re-export matches"]
        EXP_SYNTAX["SyntaxError on parse<br/>━━━━━━━━━━<br/>warnings.warn() + skip file"]
        EXP_EXCEPTION["Any Exception<br/>━━━━━━━━━━<br/>logging.debug(exc_info=True)"]
        EXP_UNCLASS["Expanded __init__.py<br/>not in cascade_map<br/>━━━━━━━━━━<br/>silently skipped — no full run"]
    end

    subgraph ManifestLoad ["MANIFEST — load_manifest()"]
        direction TB
        MAN_ABSENT["File absent<br/>━━━━━━━━━━<br/>returns None"]
        MAN_OSERR["OSError on read<br/>━━━━━━━━━━<br/>warnings.warn() → None"]
        MAN_YAML["yaml.YAMLError<br/>━━━━━━━━━━<br/>warnings.warn() → None"]
        MAN_OK["manifest dict<br/>━━━━━━━━━━<br/>pattern → test dirs map"]
    end

    subgraph ManifestApply ["MANIFEST APPLY — apply_manifest()"]
        direction TB
        MAPPLY_NONE["manifest is None<br/>━━━━━━━━━━<br/>fail-open → None"]
        MAPPLY_NOMATCH["file matches no pattern<br/>━━━━━━━━━━<br/>fail-open → None"]
        MAPPLY_OK["matched dirs<br/>━━━━━━━━━━<br/>set of test directories"]
    end

    subgraph CovMap ["COVERAGE MAP — load_coverage_map()"]
        direction TB
        COV_ABSENT["OSError on stat<br/>━━━━━━━━━━<br/>returns None"]
        COV_STALE["mtime > max_age_days<br/>━━━━━━━━━━<br/>returns None (default 30d)"]
        COV_READ_ERR["OSError / JSONDecodeError<br/>━━━━━━━━━━<br/>warnings.warn() → None"]
        COV_TYPE_ERR["not a dict OR<br/>value not a list<br/>━━━━━━━━━━<br/>warnings.warn() → None"]
        COV_OK["dict[str, set[str]]<br/>━━━━━━━━━━<br/>src file → test files map"]
    end

    %% GIT FLOW %%
    GD_ENV -->|"no base_ref"| FULL_RUN
    GD_ENV -->|"base_ref found"| GD_MERGE
    GD_MERGE -->|"CalledProcessError"| GD_ERR_PROC
    GD_MERGE -->|"TimeoutExpired"| GD_ERR_TIMEOUT
    GD_MERGE -->|"FileNotFoundError"| GD_ERR_NOTFOUND
    GD_MERGE -->|"ok"| GD_DIFF
    GD_DIFF -->|"ok"| GD_UNTRACKED
    GD_UNTRACKED -->|"returncode ≠ 0"| GD_LSFAIL
    GD_LSFAIL -->|"diff files only"| GATE_MODE
    GD_UNTRACKED -->|"ok — union both"| GATE_MODE
    GD_ERR_PROC --> GD_WARN
    GD_ERR_TIMEOUT --> GD_WARN
    GD_ERR_NOTFOUND --> GD_WARN
    GD_WARN --> FULL_RUN

    %% BUILD SCOPE GATES %%
    GATE_MODE -->|"NONE"| FULL_RUN
    GATE_MODE -->|"CONSERVATIVE / AGGRESSIVE"| GATE_NONE
    GATE_NONE -->|"None"| FULL_RUN
    GATE_NONE -->|"set[str]"| GATE_LARGE
    GATE_LARGE -->|"> 30"| FULL_RUN
    GATE_LARGE -->|"≤ 30"| GATE_BUCKET
    GATE_BUCKET -->|"yes"| FULL_RUN
    GATE_BUCKET -->|"no"| CLASSIFY
    CLASSIFY --> GATE_UNKNOWN_PY
    CLASSIFY --> GATE_UNKNOWN_PKG
    CLASSIFY --> EXP_WALK
    GATE_UNKNOWN_PY -->|"fail-open"| FULL_RUN
    GATE_UNKNOWN_PKG -->|"fail-open"| FULL_RUN

    %% EXPANSION %%
    EXP_WALK -->|"SyntaxError"| EXP_SYNTAX
    EXP_SYNTAX -->|"skip file, continue"| EXP_WALK
    EXP_WALK -->|"any Exception"| EXP_EXCEPTION
    EXP_EXCEPTION -->|"suppressed — scope from original classification"| MAPPLY_OK
    EXP_WALK -->|"init not in cascade"| EXP_UNCLASS
    EXP_UNCLASS -->|"skipped silently"| MAPPLY_OK

    %% MANIFEST %%
    CLASSIFY -->|"non-.py file"| MAN_ABSENT
    MAN_ABSENT --> MAPPLY_NONE
    MAN_OK --> MAPPLY_OK
    MAN_OSERR --> MAPPLY_NONE
    MAN_YAML --> MAPPLY_NONE
    MAPPLY_NONE --> FULL_RUN
    MAPPLY_NOMATCH --> FULL_RUN
    MAPPLY_OK --> COV_ABSENT

    %% COVERAGE MAP (aggressive mode only) %%
    COV_ABSENT -->|"None → dir-level fallback"| FILTERED
    COV_STALE -->|"None → dir-level fallback"| FILTERED
    COV_READ_ERR -->|"None → dir-level fallback"| FILTERED
    COV_TYPE_ERR -->|"None → dir-level fallback"| FILTERED
    COV_OK -->|"file-level refinement"| FILTERED

    %% CLASS ASSIGNMENTS %%
    class GATE_MODE,GATE_NONE,GATE_LARGE,GATE_BUCKET detector;
    class GD_ENV,MAPPLY_NONE,MAPPLY_NOMATCH,GATE_UNKNOWN_PY,GATE_UNKNOWN_PKG detector;
    class GD_ERR_PROC,GD_ERR_TIMEOUT,GD_ERR_NOTFOUND,MAN_ABSENT,MAN_OSERR,MAN_YAML gap;
    class COV_ABSENT,COV_STALE,COV_READ_ERR,COV_TYPE_ERR gap;
    class EXP_SYNTAX,EXP_EXCEPTION,GD_LSFAIL gap;
    class GD_MERGE,GD_DIFF,GD_UNTRACKED,EXP_WALK,CLASSIFY handler;
    class GD_WARN,EXP_UNCLASS phase;
    class MAN_OK,MAPPLY_OK,COV_OK,EXP_WALK output;
    class MAN_OK,COV_OK stateNode;
    class FULL_RUN,FILTERED terminal;
```

### Repository/Data Access Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph Callers ["CALLERS"]
        direction TB
        CONFTEST["conftest.py<br/>━━━━━━━━━━<br/>pytest plugin<br/>pytest_collection_modifyitems"]
        BUILD["build_test_scope()<br/>━━━━━━━━━━<br/>Orchestrator<br/>Computes test scope set"]
    end

    subgraph GitAccess ["● GIT DATA ACCESS"]
        direction TB
        GIT_FN["● git_changed_files()<br/>━━━━━━━━━━<br/>Reads working-tree diff<br/>+ untracked files"]
        MERGE_BASE["git merge-base HEAD base_ref<br/>━━━━━━━━━━<br/>Resolve merge-base SHA"]
        DIFF["git diff --name-only sha<br/>━━━━━━━━━━<br/>Committed + staged + unstaged"]
        LS_FILES["★ git ls-files --others<br/>--exclude-standard<br/>━━━━━━━━━━<br/>Untracked new files"]
    end

    subgraph FSAccess ["FILESYSTEM DATA ACCESS"]
        direction TB
        LOAD_MANIFEST["load_manifest()<br/>━━━━━━━━━━<br/>Reads YAML manifest<br/>fail-open on absence"]
        LOAD_COV["load_coverage_map()<br/>━━━━━━━━━━<br/>Reads JSON coverage map<br/>staleness-guarded (30d)"]
        AST_EXPAND["_expand_reexport_closure()<br/>+ ASTImportWalker<br/>━━━━━━━━━━<br/>AST-parses __init__.py files<br/>to find re-export hubs"]
    end

    subgraph PatternMatch ["IN-MEMORY LOOKUP"]
        direction TB
        CHECK_BUCKET["check_bucket_a()<br/>━━━━━━━━━━<br/>BUCKET_A_PATTERNS<br/>+ BUCKET_A_GLOBS constants"]
        APPLY_MAN["apply_manifest()<br/>━━━━━━━━━━<br/>pathspec gitwildmatch<br/>non-Python file routing"]
        CASCADE["LAYER_CASCADE_*<br/>━━━━━━━━━━<br/>conservative / aggressive<br/>package-to-test-dir maps"]
    end

    subgraph Storage ["STORAGE"]
        direction TB
        GIT_REPO[("Git Repository<br/>━━━━━━━━━━<br/>working tree + index")]
        MANIFEST_FILE[(".autoskillit/<br/>test-filter-manifest.yaml<br/>━━━━━━━━━━<br/>glob → test-dir mappings")]
        COV_FILE[(".autoskillit/<br/>test-source-map.json<br/>━━━━━━━━━━<br/>src-file → test-file map")]
        SRC_FILES[("src/autoskillit/**/__init__.py<br/>━━━━━━━━━━<br/>Python AST source")]
    end

    %% CALLER FLOW %%
    CONFTEST -->|calls| BUILD

    %% BUILD → DATA ACCESS %%
    BUILD -->|reads changed files| GIT_FN
    BUILD -->|check global trigger| CHECK_BUCKET
    BUILD -->|non-Python files| APPLY_MAN
    BUILD -->|src/*.py files| CASCADE
    BUILD -->|src/*.py expansion| AST_EXPAND
    BUILD -->|aggressive mode| LOAD_COV
    BUILD -->|load on startup| LOAD_MANIFEST

    %% GIT ACCESS INTERNALS %%
    GIT_FN --> MERGE_BASE
    GIT_FN --> DIFF
    GIT_FN --> LS_FILES

    %% STORAGE READS %%
    MERGE_BASE -->|reads| GIT_REPO
    DIFF -->|reads| GIT_REPO
    LS_FILES -->|reads| GIT_REPO
    LOAD_MANIFEST -->|reads| MANIFEST_FILE
    LOAD_COV -->|reads| COV_FILE
    AST_EXPAND -->|reads| SRC_FILES

    %% CLASS ASSIGNMENTS %%
    class CONFTEST cli;
    class BUILD phase;
    class GIT_FN handler;
    class MERGE_BASE,DIFF handler;
    class LS_FILES newComponent;
    class LOAD_MANIFEST,LOAD_COV,AST_EXPAND handler;
    class CHECK_BUCKET,APPLY_MAN,CASCADE detector;
    class GIT_REPO,MANIFEST_FILE,COV_FILE,SRC_FILES integration;
```

Closes #1028

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260417-130720-146746/.autoskillit/temp/make-plan/include_uncommitted_untracked_in_test_filter_plan_2026-04-17_130720.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 181 | 9.4k | 761.0k | 57.7k | 1 | 3m 24s |
| review | 380 | 140 | 1.6M | 96.8k | 1 | 3m 42s |
| verify | 92 | 9.2k | 362.5k | 33.9k | 1 | 2m 49s |
| implement | 264 | 11.9k | 1.4M | 46.3k | 1 | 3m 51s |
| prepare_pr | 60 | 5.3k | 181.9k | 24.3k | 1 | 1m 24s |
| run_arch_lenses | 214 | 17.7k | 803.3k | 143.9k | 3 | 5m 7s |
| compose_pr | 67 | 10.1k | 231.8k | 34.2k | 1 | 2m 18s |
| **Total** | 1.3k | 63.6k | 5.4M | 437.2k | | 22m 37s |