### PR TITLE
Implementation Plan: Deduplicate JSON Unwrap Logic and Test Helpers

### DIFF
--- a/src/autoskillit/hooks/token_summary_hook.py
+++ b/src/autoskillit/hooks/token_summary_hook.py
@@ -59,20 +59,25 @@ def _log_root() -> pathlib.Path:
     return base / "autoskillit/logs"
 
 
-def _extract_pr_url(tool_name: str, tool_response_raw: str) -> str | None:
-    """Extract a GitHub PR URL from a PostToolUse tool_response string.
+def _unwrap_mcp_response(tool_name: str, raw: str) -> dict | None:
+    """Parse and double-unwrap a PostToolUse tool_response string.
 
-    Replicates pretty_output._resolve_payload double-unwrap logic.
-    Returns the URL string or None if not found.
+    Returns the effective payload dict, or None if raw is not valid JSON or
+    not a dict.
+
+    For MCP tools (tool_name starts with 'mcp__'), if the outer dict has
+    exactly one key 'result' whose value is a JSON string, attempts to parse
+    that string as a nested dict and returns it. Falls back to returning the
+    outer dict when inner parsing fails or yields a non-dict. Non-MCP tools
+    return the outer dict directly.
     """
     try:
-        outer = json.loads(tool_response_raw)
+        outer = json.loads(raw)
     except (json.JSONDecodeError, ValueError):
         return None
     if not isinstance(outer, dict):
         return None
 
-    result_text: str | None = None
     if (
         tool_name.startswith("mcp__")
         and list(outer.keys()) == ["result"]
@@ -81,15 +86,24 @@ def _extract_pr_url(tool_name: str, tool_response_raw: str) -> str | None:
         try:
             inner = json.loads(outer["result"])
             if isinstance(inner, dict):
-                result_text = inner.get("result", "")
+                return inner
         except (json.JSONDecodeError, ValueError):
-            result_text = outer["result"]
-    else:
-        result_text = outer.get("result", "")
+            pass
 
+    return outer
+
+
+def _extract_pr_url(tool_name: str, tool_response_raw: str) -> str | None:
+    """Extract a GitHub PR URL from a PostToolUse tool_response string.
+
+    Returns the URL string or None if not found.
+    """
+    payload = _unwrap_mcp_response(tool_name, tool_response_raw)
+    if payload is None:
+        return None
+    result_text = payload.get("result", "")
     if not result_text or not isinstance(result_text, str):
         return None
-
     m = re.search(r"https://github\.com/[^/\s]+/[^/\s]+/pull/\d+", result_text)
     return m.group() if m else None
 
@@ -139,34 +153,12 @@ def _read_kitchen_id(base: pathlib.Path | None = None) -> str:
 def _extract_order_id(tool_name: str, tool_response_raw: str) -> str:
     """Extract order_id from a PostToolUse run_skill result JSON.
 
-    Replicates the same double-unwrap logic as _extract_pr_url.
     Returns '' if not found.
     """
-    try:
-        outer = json.loads(tool_response_raw)
-    except (json.JSONDecodeError, ValueError):
+    payload = _unwrap_mcp_response(tool_name, tool_response_raw)
+    if payload is None:
         return ""
-    if not isinstance(outer, dict):
-        return ""
-
-    inner_dict: dict | None = None
-    if (
-        tool_name.startswith("mcp__")
-        and list(outer.keys()) == ["result"]
-        and isinstance(outer["result"], str)
-    ):
-        try:
-            parsed = json.loads(outer["result"])
-            if isinstance(parsed, dict):
-                inner_dict = parsed
-        except (json.JSONDecodeError, ValueError):
-            pass
-    else:
-        inner_dict = outer
-
-    if inner_dict is None:
-        return ""
-    return str(inner_dict.get("order_id", ""))
+    return str(payload.get("order_id", ""))
 
 
 def _load_sessions(

--- a/tests/infra/test_token_summary_appender.py
+++ b/tests/infra/test_token_summary_appender.py
@@ -889,6 +889,65 @@ def test_e4_kitchen_id_renamed_in_hook_config(tmp_path: Path) -> None:
     assert result == "legacy-pipeline-uuid"
 
 
+# ---------------------------------------------------------------------------
+# _unwrap_mcp_response unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestUnwrapMcpResponse:
+    """Unit tests for the shared double-unwrap helper."""
+
+    def _call(self, tool_name: str, raw: str):
+        from autoskillit.hooks.token_summary_hook import _unwrap_mcp_response
+
+        return _unwrap_mcp_response(tool_name, raw)
+
+    def test_invalid_json_returns_none(self):
+        assert self._call("mcp__x__y", "not json") is None
+
+    def test_json_array_returns_none(self):
+        import json
+
+        assert self._call("mcp__x__y", json.dumps([1, 2, 3])) is None
+
+    def test_non_mcp_tool_returns_outer_dict(self):
+        import json
+
+        payload = {"result": "some text", "success": True}
+        result = self._call("run_python", json.dumps(payload))
+        assert result == payload
+
+    def test_mcp_tool_double_wrapped_returns_inner(self):
+        import json
+
+        inner = {"result": "https://github.com/o/r/pull/1", "order_id": "abc"}
+        outer = {"result": json.dumps(inner)}
+        result = self._call("mcp__autoskillit__run_skill", json.dumps(outer))
+        assert result == inner
+
+    def test_mcp_tool_inner_parse_fails_returns_outer(self):
+        import json
+
+        outer = {"result": "not-json-inner"}
+        result = self._call("mcp__autoskillit__run_skill", json.dumps(outer))
+        assert result == outer
+
+    def test_mcp_tool_inner_not_dict_returns_outer(self):
+        import json
+
+        outer = {"result": json.dumps([1, 2, 3])}
+        result = self._call("mcp__autoskillit__run_skill", json.dumps(outer))
+        assert result == outer
+
+    def test_mcp_tool_extra_keys_skips_double_unwrap(self):
+        """Outer dict with more than just 'result' key → not a double-wrapped response."""
+        import json
+
+        outer = {"result": json.dumps({"foo": "bar"}), "extra": "key"}
+        result = self._call("mcp__autoskillit__run_skill", json.dumps(outer))
+        assert result == outer
+
+
 def test_hook_subprocess_calls_have_timeout() -> None:
     """All subprocess.run() calls in token_summary_hook.py must have timeout=."""
     import ast

--- a/tests/pipeline/test_audit.py
+++ b/tests/pipeline/test_audit.py
@@ -16,6 +16,23 @@ from autoskillit.pipeline.audit import (
 pytestmark = [pytest.mark.layer("pipeline"), pytest.mark.small]
 
 
+def _valid_failure_record_dict(**overrides: object) -> dict:
+    """Module-level factory for valid failure record dicts.
+
+    Used by TestValidateFailureRecordDict and TestLoadFromLogDirTypeValidation.
+    """
+    base: dict = {
+        "timestamp": "2026-03-28T00:00:00Z",
+        "skill_command": "/autoskillit:implement-worktree",
+        "exit_code": 1,
+        "subtype": "error",
+        "needs_retry": False,
+        "retry_reason": "none",
+        "stderr": "oops",
+    }
+    return {**base, **overrides}
+
+
 def _make_record(**overrides: object) -> FailureRecord:
     defaults = dict(
         timestamp="2026-02-24T16:00:00Z",
@@ -418,62 +435,42 @@ def test_iter_session_log_entries_kitchen_id_backward_compat(tmp_path):
 
 
 class TestValidateFailureRecordDict:
-    def _valid_dict(self, **overrides) -> dict:
-        base = {
-            "timestamp": "2026-03-28T00:00:00Z",
-            "skill_command": "/autoskillit:implement-worktree",
-            "exit_code": 1,
-            "subtype": "error",
-            "needs_retry": False,
-            "retry_reason": "none",
-            "stderr": "oops",
-        }
-        return {**base, **overrides}
-
     def test_valid_dict_returns_true(self):
-        assert _validate_failure_record_dict(self._valid_dict()) is True
+        assert _validate_failure_record_dict(_valid_failure_record_dict()) is True
 
     def test_missing_key_returns_false(self):
-        d = self._valid_dict()
+        d = _valid_failure_record_dict()
         del d["stderr"]
         assert _validate_failure_record_dict(d) is False
 
     def test_wrong_type_exit_code_returns_false(self):
-        assert _validate_failure_record_dict(self._valid_dict(exit_code="bad")) is False
+        assert _validate_failure_record_dict(_valid_failure_record_dict(exit_code="bad")) is False
 
     def test_wrong_type_needs_retry_returns_false(self):
         # "true" is a str, not bool
-        assert _validate_failure_record_dict(self._valid_dict(needs_retry="true")) is False
+        assert (
+            _validate_failure_record_dict(_valid_failure_record_dict(needs_retry="true")) is False
+        )
 
     def test_wrong_type_timestamp_returns_false(self):
-        assert _validate_failure_record_dict(self._valid_dict(timestamp=12345)) is False
+        assert _validate_failure_record_dict(_valid_failure_record_dict(timestamp=12345)) is False
 
     def test_int_for_bool_field_returns_false(self):
         # 0 and 1 are int, not bool — must be rejected for needs_retry: bool
-        assert _validate_failure_record_dict(self._valid_dict(needs_retry=1)) is False
+        assert _validate_failure_record_dict(_valid_failure_record_dict(needs_retry=1)) is False
 
     def test_extra_keys_are_ignored(self):
-        d = self._valid_dict()
+        d = _valid_failure_record_dict()
         d["extra_unexpected_key"] = "ignored"
         assert _validate_failure_record_dict(d) is True
 
 
 class TestLoadFromLogDirTypeValidation:
-    def _valid_record(self, **overrides) -> dict:
-        base = {
-            "timestamp": "2026-03-28T00:00:00Z",
-            "skill_command": "/autoskillit:implement-worktree",
-            "exit_code": 1,
-            "subtype": "error",
-            "needs_retry": False,
-            "retry_reason": "none",
-            "stderr": "oops",
-        }
-        return {**base, **overrides}
-
     def test_wrong_type_exit_code_is_skipped(self, tmp_path):
         """record_dict with exit_code as str is skipped, not silently accepted."""
-        _write_audit_session(tmp_path, "s001", [self._valid_record(exit_code="not-an-int")])
+        _write_audit_session(
+            tmp_path, "s001", [_valid_failure_record_dict(exit_code="not-an-int")]
+        )
         log = DefaultAuditLog()
         n = log.load_from_log_dir(tmp_path)
         assert n == 0
@@ -481,14 +478,14 @@ class TestLoadFromLogDirTypeValidation:
 
     def test_wrong_type_needs_retry_is_skipped(self, tmp_path):
         """record_dict with needs_retry as str is skipped."""
-        _write_audit_session(tmp_path, "s001", [self._valid_record(needs_retry="true")])
+        _write_audit_session(tmp_path, "s001", [_valid_failure_record_dict(needs_retry="true")])
         log = DefaultAuditLog()
         n = log.load_from_log_dir(tmp_path)
         assert n == 0
 
     def test_missing_field_is_skipped(self, tmp_path):
         """record_dict missing a required field is skipped."""
-        bad = self._valid_record()
+        bad = _valid_failure_record_dict()
         del bad["retry_reason"]
         _write_audit_session(tmp_path, "s001", [bad])
         log = DefaultAuditLog()
@@ -498,8 +495,8 @@ class TestLoadFromLogDirTypeValidation:
     def test_valid_record_alongside_invalid_is_preserved(self, tmp_path):
         """A valid record in the same session file is loaded despite invalid siblings."""
         records = [
-            self._valid_record(exit_code="bad"),  # skipped
-            self._valid_record(skill_command="/ok", exit_code=2),  # kept
+            _valid_failure_record_dict(exit_code="bad"),  # skipped
+            _valid_failure_record_dict(skill_command="/ok", exit_code=2),  # kept
         ]
         _write_audit_session(tmp_path, "s001", records)
         log = DefaultAuditLog()


### PR DESCRIPTION
## Summary

Two deduplication opportunities confirmed by audit (issue #1012):

1. **R-19** — `token_summary_hook.py` has two functions (`_extract_pr_url` and `_extract_order_id`) that independently implement identical MCP double-unwrap JSON parsing logic. Extract a shared `_unwrap_mcp_response(tool_name, raw) -> dict | None` helper that both call.

2. **R-24** — `tests/pipeline/test_audit.py` has two test-class-level methods (`_valid_dict` and `_valid_record`) that return identical 7-key base dicts. Extract a module-level `_valid_failure_record_dict(**overrides)` factory that both classes delegate to.

## Architecture Impact

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 55, 'rankSpacing': 75, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ─── LAYER 0: FOUNDATION (context) ─── %%
    subgraph L0 ["LAYER 0 — FOUNDATION (context only)"]
        CORE["core/<br/>━━━━━━━━━━<br/>Types, logging, paths<br/>kitchen_state, io"]
    end

    %% ─── LAYER 1: HOOKS (primary change area) ─── %%
    subgraph L1_HOOKS ["LAYER 1 — hooks/  (primary change area)"]
        direction TB
        TOKEN_HOOK["● token_summary_hook.py<br/>━━━━━━━━━━<br/>PostToolUse: appends token<br/>summary to PR body<br/><br/>Callers: _extract_pr_url()<br/>          _extract_order_id()"]
        UNWRAP["★ _unwrap_mcp_response()<br/>━━━━━━━━━━<br/>Extracted shared helper<br/>MCP double-unwrap logic<br/>(was duplicated ×2)"]
        OTHER_HOOKS["other hooks<br/>━━━━━━━━━━<br/>quota_guard, pretty_output<br/>branch_protection, etc.<br/>(unchanged)"]
    end

    %% ─── LAYER 2: RECIPE (deferred context) ─── %%
    subgraph L2 ["LAYER 2 — DOMAIN (context only)"]
        RECIPE["recipe/<br/>━━━━━━━━━━<br/>LoadRecipeResult<br/>ListRecipesResult<br/>(TYPE_CHECKING only)"]
        PIPELINE_PKG["pipeline/<br/>━━━━━━━━━━<br/>FailureRecord, AuditLog<br/>(pipeline.audit)"]
    end

    %% ─── TESTS ─── %%
    subgraph TESTS ["TESTS (test coverage)"]
        direction TB
        TEST_HOOK["● tests/infra/<br/>test_token_summary_appender.py<br/>━━━━━━━━━━<br/>TestUnwrapMcpResponse (+7)<br/>Tests _unwrap_mcp_response<br/>directly"]
        TEST_AUDIT["● tests/pipeline/<br/>test_audit.py<br/>━━━━━━━━━━<br/>_valid_failure_record_dict()<br/>module-level factory<br/>(replaced 2 per-class copies)"]
    end

    %% ─── CONNECTIONS ─── %%

    %% Internal structure of token_summary_hook.py %%
    TOKEN_HOOK -->|"calls (refactored)"| UNWRAP

    %% token_summary_hook.py imports %%
    TOKEN_HOOK -->|"imports"| CORE
    TOKEN_HOOK -.->|"TYPE_CHECKING only<br/>(pre-existing)"| RECIPE

    %% other hooks %%
    OTHER_HOOKS -->|"imports"| CORE

    %% test imports %%
    TEST_HOOK -->|"imports & tests"| TOKEN_HOOK
    TEST_HOOK -->|"covers new helper"| UNWRAP
    TEST_AUDIT -->|"tests FailureRecord"| PIPELINE_PKG

    %% CLASS ASSIGNMENTS %%
    class CORE stateNode;
    class TOKEN_HOOK handler;
    class UNWRAP newComponent;
    class OTHER_HOOKS handler;
    class RECIPE,PIPELINE_PKG phase;
    class TEST_HOOK,TEST_AUDIT output;
```

Closes #1012

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260417-113154-356712/.autoskillit/temp/make-plan/deduplicate_json_unwrap_logic_and_test_helpers_plan_2026-04-17_000001.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 193 | 12.9k | 956.2k | 65.3k | 1 | 3m 57s |
| review | 52 | 4.0k | 143.2k | 22.3k | 1 | 2m 1s |
| verify | 68 | 9.7k | 353.0k | 60.7k | 1 | 2m 42s |
| implement | 166 | 10.2k | 1.0M | 61.2k | 1 | 2m 54s |
| fix | 168 | 7.7k | 521.7k | 63.0k | 2 | 9m 39s |
| prepare_pr | 52 | 3.0k | 140.0k | 20.5k | 1 | 1m 2s |
| run_arch_lenses | 2.4k | 9.2k | 220.3k | 69.6k | 1 | 3m 55s |
| compose_pr | 59 | 5.0k | 174.1k | 20.6k | 1 | 1m 21s |
| **Total** | 3.2k | 61.8k | 3.5M | 383.2k | | 27m 35s |