### PR TITLE
Rectify: Verdict Routing Asymmetry — Flaky Tests Abort Instead of Retry

### DIFF
--- a/src/autoskillit/recipe/rules_verdict.py
+++ b/src/autoskillit/recipe/rules_verdict.py
@@ -1,8 +1,11 @@
-"""Semantic rules for skill verdict routing completeness.
+"""Semantic rules for skill verdict routing completeness and consistency.
 
 Ensures that recipe steps capturing a skill verdict with declared allowed_values
 have an explicit on_result condition for every allowed value. A catch-all
 `when: true` route does not count as explicit handling.
+
+Also ensures that steps invoking the same skill route the same verdict value
+to the same outcome category (continuation vs escalation).
 """
 
 from __future__ import annotations
@@ -132,5 +135,77 @@ def _check_unrouted_verdict_values(ctx: ValidationContext) -> list[RuleFinding]:
                         ),
                     )
                 )
+
+    return findings
+
+
+def _classify_route_target(target: str) -> str:
+    """Classify a route target as 'escalation' or 'continuation'."""
+    if "failure" in target or "escalat" in target or "stop" in target:
+        return "escalation"
+    return "continuation"
+
+
+@semantic_rule(
+    name="verdict-routing-asymmetry",
+    description=(
+        "Steps invoking the same skill must route the same verdict value to the "
+        "same outcome category (continuation vs escalation). Asymmetric routing "
+        "causes flaky tests to abort in one path while retrying in another."
+    ),
+    severity=Severity.ERROR,
+)
+def _check_verdict_routing_asymmetry(ctx: ValidationContext) -> list[RuleFinding]:
+    """Error when the same verdict routes to different outcome categories across steps."""
+    findings: list[RuleFinding] = []
+
+    # Build map: {(skill_name, verdict_value): [(step_name, classification), ...]}
+    routing_map: dict[tuple[str, str], list[tuple[str, str]]] = {}
+
+    for step_name, step in ctx.recipe.steps.items():
+        if step.tool != "run_skill":
+            continue
+        skill_command = (step.with_args or {}).get("skill_command", "")
+        skill_name = _extract_skill_name(skill_command)
+        if not skill_name:
+            continue
+
+        allowed_by_output = _get_allowed_values_for_skill(skill_name)
+        if not allowed_by_output:
+            continue
+
+        if not step.on_result:
+            continue
+
+        conditions = step.on_result.conditions or []
+        for _output_name, allowed_values in allowed_by_output.items():
+            for value in allowed_values:
+                for cond in conditions:
+                    if _is_explicit_condition(cond.when, value):
+                        classification = _classify_route_target(cond.route)
+                        key = (skill_name, value)
+                        routing_map.setdefault(key, []).append((step_name, classification))
+                        break
+
+    for (skill_name, value), entries in routing_map.items():
+        classifications = {cls for _, cls in entries}
+        if len(classifications) <= 1:
+            continue
+        escalation_steps = [name for name, cls in entries if cls == "escalation"]
+        continuation_steps = [name for name, cls in entries if cls == "continuation"]
+        if escalation_steps and continuation_steps:
+            findings.append(
+                RuleFinding(
+                    rule="verdict-routing-asymmetry",
+                    severity=Severity.ERROR,
+                    step_name=escalation_steps[0],
+                    message=(
+                        f"Verdict '{value}' from '{skill_name}' routes to escalation "
+                        f"in step '{escalation_steps[0]}' but continuation in step "
+                        f"'{continuation_steps[0]}'. All steps invoking the same skill "
+                        f"should treat the same verdict consistently."
+                    ),
+                )
+            )
 
     return findings

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -717,7 +717,7 @@ steps:
       - when: "${{ result.verdict }} == 'already_green'"
         route: pre_resolve_rebase
       - when: "${{ result.verdict }} == 'flake_suspected'"
-        route: release_issue_failure
+        route: re_push
       - when: "${{ result.verdict }} == 'ci_only_failure'"
         route: release_issue_failure
     on_failure: release_issue_failure
@@ -725,7 +725,8 @@ steps:
       Runs when ci_watch reports a CI failure. Receives ci_failed_jobs from wait_for_ci
       structured output to avoid redundant CI failure re-investigation. Routes via
       on_result: verdict dispatch — real_fix pushes, already_green rebases and re-diagnoses
-      (sibling fix may have landed), flake_suspected/ci_only_failure escalate to human.
+      (sibling fix may have landed), flake_suspected retries via re_push (bounded by
+      retries: 2 / on_exhausted: release_issue_failure), ci_only_failure escalates to human.
       Retries up to 2 times (3 total attempts) before exhausting to release_issue_failure.
 
   pre_resolve_rebase:

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -602,7 +602,7 @@ steps:
       - when: "${{ result.verdict }} == 'already_green'"
         route: re_push_review
       - when: "${{ result.verdict }} == 'flake_suspected'"
-        route: release_issue_failure
+        route: re_push_review
       - when: "${{ result.verdict }} == 'ci_only_failure'"
         route: release_issue_failure
     on_failure: release_issue_failure
@@ -611,9 +611,9 @@ steps:
       (context.work_dir) has the feature branch (context.merge_target) checked out.
       resolve-review fetches inline and summary review comments via the GitHub API,
       applies fixes for each actionable finding (critical + warning severity), and
-      commits each fix. Routes via on_result: verdict dispatch — real_fix/already_green
-      both route to re_push_review; flake_suspected/ci_only_failure escalate.
-      Retries up to 2 times (3 total attempts) before exhausting to release_issue_failure.
+      commits each fix. Routes via on_result: verdict dispatch — real_fix/already_green/
+      flake_suspected all route to re_push_review (retry bounded by retries: 2);
+      ci_only_failure escalates to release_issue_failure.
 
   re_push_review:
     tool: push_to_remote

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -600,7 +600,7 @@ steps:
       - when: "${{ result.verdict }} == 'already_green'"
         route: re_push_review
       - when: "${{ result.verdict }} == 'flake_suspected'"
-        route: release_issue_failure
+        route: re_push_review
       - when: "${{ result.verdict }} == 'ci_only_failure'"
         route: release_issue_failure
     on_failure: release_issue_failure
@@ -609,9 +609,9 @@ steps:
       (context.work_dir) has the feature branch (context.merge_target) checked out.
       resolve-review fetches inline and summary review comments via the GitHub API,
       applies fixes for each actionable finding (critical + warning severity), and
-      commits each fix. Routes via on_result: verdict dispatch — real_fix/already_green
-      both route to re_push_review; flake_suspected/ci_only_failure escalate.
-      Retries up to 2 times (3 total attempts) before exhausting to release_issue_failure.
+      commits each fix. Routes via on_result: verdict dispatch — real_fix/already_green/
+      flake_suspected all route to re_push_review (retry bounded by retries: 2);
+      ci_only_failure escalates to release_issue_failure.
 
   re_push_review:
     tool: push_to_remote

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -1148,7 +1148,7 @@ steps:
       - when: "${{ result.verdict }} == 'already_green'"
         route: pre_resolve_rebase
       - when: "${{ result.verdict }} == 'flake_suspected'"
-        route: release_issue_failure
+        route: re_push
       - when: "${{ result.verdict }} == 'ci_only_failure'"
         route: release_issue_failure
       - route: release_issue_failure
@@ -1157,7 +1157,8 @@ steps:
       Runs when ci_watch reports a CI failure. Receives ci_failed_jobs from wait_for_ci
       structured output to avoid redundant CI failure re-investigation. Routes via
       on_result: verdict dispatch — real_fix pushes, already_green rebases and re-diagnoses
-      (sibling fix may have landed), flake_suspected/ci_only_failure escalate to human.
+      (sibling fix may have landed), flake_suspected retries via re_push (bounded by
+      retries: 2 / on_exhausted: release_issue_failure), ci_only_failure escalates to human.
       Retries up to 2 times (3 total attempts) before exhausting to release_issue_failure.
 
   pre_resolve_rebase:

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -1128,7 +1128,7 @@ steps:
       - when: "${{ result.verdict }} == 'already_green'"
         route: pre_resolve_rebase
       - when: "${{ result.verdict }} == 'flake_suspected'"
-        route: release_issue_failure
+        route: re_push
       - when: "${{ result.verdict }} == 'ci_only_failure'"
         route: release_issue_failure
       - route: release_issue_failure
@@ -1137,7 +1137,8 @@ steps:
       Runs when ci_watch reports a CI failure. Receives ci_failed_jobs from wait_for_ci
       structured output to avoid redundant CI failure re-investigation. Routes via
       on_result: verdict dispatch — real_fix pushes, already_green rebases and re-diagnoses
-      (sibling fix may have landed), flake_suspected/ci_only_failure escalate to human.
+      (sibling fix may have landed), flake_suspected retries via re_push (bounded by
+      retries: 2 / on_exhausted: release_issue_failure), ci_only_failure escalates to human.
       Retries up to 2 times (3 total attempts) before exhausting to release_issue_failure.
 
   pre_resolve_rebase:

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -578,7 +578,7 @@ steps:
       - when: "${{ result.verdict }} == 'already_green'"
         route: re_push_review
       - when: "${{ result.verdict }} == 'flake_suspected'"
-        route: release_issue_failure
+        route: re_push_review
       - when: "${{ result.verdict }} == 'ci_only_failure'"
         route: release_issue_failure
     on_failure: release_issue_failure
@@ -587,9 +587,9 @@ steps:
       (context.work_dir) has the feature branch (context.merge_target) checked out.
       resolve-review fetches inline and summary review comments via the GitHub API,
       applies fixes for each actionable finding (critical + warning severity), and
-      commits each fix. Routes via on_result: verdict dispatch — real_fix/already_green
-      both route to re_push_review; flake_suspected/ci_only_failure escalate.
-      Retries up to 2 times (3 total attempts) before exhausting to release_issue_failure.
+      commits each fix. Routes via on_result: verdict dispatch — real_fix/already_green/
+      flake_suspected all route to re_push_review (retry bounded by retries: 2);
+      ci_only_failure escalates to release_issue_failure.
 
   re_push_review:
     tool: push_to_remote

--- a/src/autoskillit/skills_extended/diagnose-ci/SKILL.md
+++ b/src/autoskillit/skills_extended/diagnose-ci/SKILL.md
@@ -139,9 +139,9 @@ local test result):
 |---|---|
 | `flaky` or `timing_race` | `flake_suspected` |
 | `deterministic` | `ci_only_failure` (if local tests pass) or `real_fix` (if fixable locally) |
-| `fixture` or `import` | `ci_only_failure` (if local tests pass) |
-| `env` | `ci_only_failure` (conservative) |
-| `unknown` | `ci_only_failure` (conservative) |
+| `fixture` or `import` | `flake_suspected` (if local tests pass) |
+| `env` | `flake_suspected` |
+| `unknown` | `flake_suspected` |
 
 Determine `is_fixable`:
 - `true` for `test`, `lint`, `build`, `type_check`

--- a/src/autoskillit/skills_extended/resolve-failures/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-failures/SKILL.md
@@ -44,6 +44,12 @@ Fix test failures in a worktree implemented by `/autoskillit:implement-worktree-
 - Leave worktree intact on failure for manual inspection
 - Treat CI as the source of truth: "passes locally" is not a resolution
 
+**Flaky tests must always be resolved.** A test that failed previously and now passes
+is flaky by definition. Investigate timing dependencies, race conditions, insufficient
+timeouts, resource contention under parallel execution (pytest-xdist), and
+non-deterministic setup/teardown. Apply a stabilizing fix. Never classify a flaky test
+as unfixable. Never emit `ci_only_failure` for a test that is merely non-deterministic.
+
 ## Context Limit Behavior
 
 When context is exhausted mid-execution, edits may be on disk but not committed.
@@ -184,8 +190,8 @@ Using `{local_result}` from Step 2 and `{failure_subtype}` from Step 2a, determi
 | FAIL → (no fix possible after 3 iterations) | any | proceed to Step 5 |
 | PASS | `flaky` or `timing_race` | `flake_suspected` |
 | PASS | `deterministic` | `ci_only_failure` |
-| PASS | `fixture` or `import` | `ci_only_failure` |
-| PASS | `env` or `unknown` | `ci_only_failure` (conservative) |
+| PASS | `fixture` or `import` | `flake_suspected` |
+| PASS | `env` or `unknown` | `flake_suspected` |
 
 **Note on `already_green`:** This verdict is reserved for the `pre_resolve_rebase`
 re-entry path — when a sibling pipeline's fix has already landed on integration and
@@ -280,7 +286,7 @@ Where:
 Return control to the orchestrator. The recipe's `on_result:` routing dispatches
 on `verdict`:
 - `real_fix` → `re_push` (fix landed, push to remote)
-- `flake_suspected` → `release_issue_failure` (human escalation)
+- `flake_suspected` → `re_push` (retry via CI, bounded by retries: 2 / on_exhausted: release_issue_failure)
 - `ci_only_failure` → `release_issue_failure` (human escalation)
 
 ### Step 5: Report Failure

--- a/tests/recipe/test_resolve_ci_routing_invariant.py
+++ b/tests/recipe/test_resolve_ci_routing_invariant.py
@@ -12,6 +12,7 @@ import pytest
 
 from autoskillit.core import pkg_root
 from autoskillit.recipe.io import load_recipe
+from autoskillit.recipe.rules_verdict import _classify_route_target
 
 pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
@@ -208,8 +209,6 @@ def test_flake_suspected_routes_consistently_across_fix_and_resolve_ci(
     """flake_suspected must route to continuation in both fix/assess and resolve_ci steps."""
     recipe_path = _RECIPES_DIR / recipe_name
     recipe = load_recipe(recipe_path)
-    escalation_patterns = ("failure", "escalat", "stop")
-
     flake_routes: list[tuple[str, str, bool]] = []  # (step_name, route, is_escalation)
     for step_name, step in recipe.steps.items():
         if step.tool != "run_skill":
@@ -221,7 +220,7 @@ def test_flake_suspected_routes_consistently_across_fix_and_resolve_ci(
             continue
         for cond in step.on_result.conditions or []:
             if cond.when and "flake_suspected" in cond.when:
-                is_esc = any(p in cond.route for p in escalation_patterns)
+                is_esc = _classify_route_target(cond.route) == "escalation"
                 flake_routes.append((step_name, cond.route, is_esc))
 
     assert flake_routes, f"{recipe_name}: no flake_suspected routes found"

--- a/tests/recipe/test_resolve_ci_routing_invariant.py
+++ b/tests/recipe/test_resolve_ci_routing_invariant.py
@@ -158,14 +158,14 @@ def test_resolve_ci_on_result_routes_real_fix_to_re_push(recipe_name: str) -> No
 def test_resolve_ci_on_result_routes_escalation_verdicts_to_failure(
     recipe_name: str,
 ) -> None:
-    """flake_suspected and ci_only_failure must route to release_issue_failure."""
+    """ci_only_failure must route to release_issue_failure."""
     recipe_path = _RECIPES_DIR / recipe_name
     recipe = load_recipe(recipe_path)
     resolve_steps = _find_resolve_steps_reaching_push(recipe)
     for step_name, step in resolve_steps:
         if step.on_result is None:
             continue
-        for verdict in ("flake_suspected", "ci_only_failure"):
+        for verdict in ("ci_only_failure",):
             routes = [
                 cond.route
                 for cond in (step.on_result.conditions or [])

--- a/tests/recipe/test_resolve_ci_routing_invariant.py
+++ b/tests/recipe/test_resolve_ci_routing_invariant.py
@@ -180,6 +180,59 @@ def test_resolve_ci_on_result_routes_escalation_verdicts_to_failure(
 
 
 @pytest.mark.parametrize("recipe_name", _PIPELINE_RECIPES)
+def test_resolve_ci_routes_flake_suspected_to_re_push(recipe_name: str) -> None:
+    """flake_suspected in resolve_ci must route to re_push, not release_issue_failure."""
+    recipe_path = _RECIPES_DIR / recipe_name
+    recipe = load_recipe(recipe_path)
+    resolve_steps = _find_resolve_steps_reaching_push(recipe)
+    for step_name, step in resolve_steps:
+        if step.on_result is None:
+            continue
+        routes = [
+            cond.route
+            for cond in (step.on_result.conditions or [])
+            if cond.when and "flake_suspected" in cond.when
+        ]
+        if not routes:
+            continue
+        assert any("re_push" in r for r in routes), (
+            f"{recipe_name}/{step_name}: verdict=flake_suspected must route to "
+            f"a re_push step (retry), got routes: {routes}"
+        )
+
+
+@pytest.mark.parametrize("recipe_name", _PIPELINE_RECIPES)
+def test_flake_suspected_routes_consistently_across_fix_and_resolve_ci(
+    recipe_name: str,
+) -> None:
+    """flake_suspected must route to continuation in both fix/assess and resolve_ci steps."""
+    recipe_path = _RECIPES_DIR / recipe_name
+    recipe = load_recipe(recipe_path)
+    escalation_patterns = ("failure", "escalat", "stop")
+
+    flake_routes: list[tuple[str, str, bool]] = []  # (step_name, route, is_escalation)
+    for step_name, step in recipe.steps.items():
+        if step.tool != "run_skill":
+            continue
+        cmd = (step.with_args or {}).get("skill_command", "")
+        if "resolve-failures" not in cmd:
+            continue
+        if step.on_result is None:
+            continue
+        for cond in step.on_result.conditions or []:
+            if cond.when and "flake_suspected" in cond.when:
+                is_esc = any(p in cond.route for p in escalation_patterns)
+                flake_routes.append((step_name, cond.route, is_esc))
+
+    assert flake_routes, f"{recipe_name}: no flake_suspected routes found"
+    escalation_steps = [f"{name} → {route}" for name, route, is_esc in flake_routes if is_esc]
+    assert not escalation_steps, (
+        f"{recipe_name}: flake_suspected routes to escalation in: {escalation_steps}. "
+        "All steps invoking resolve-failures should route flake_suspected to continuation (retry)."
+    )
+
+
+@pytest.mark.parametrize("recipe_name", _PIPELINE_RECIPES)
 def test_pre_resolve_rebase_step_exists(recipe_name: str) -> None:
     """pre_resolve_rebase step must exist for already_green re-entry path."""
     recipe_path = _RECIPES_DIR / recipe_name

--- a/tests/recipe/test_rules_verdict.py
+++ b/tests/recipe/test_rules_verdict.py
@@ -171,7 +171,7 @@ def _asymmetric_resolve_steps() -> dict[str, RecipeStep]:
                         when="${{ result.verdict }} == 'flake_suspected'",
                     ),
                     StepResultCondition(
-                        route="fail_step",
+                        route="failure_step",
                         when="${{ result.verdict }} == 'ci_only_failure'",
                     ),
                     StepResultCondition(
@@ -184,7 +184,7 @@ def _asymmetric_resolve_steps() -> dict[str, RecipeStep]:
                     ),
                 ]
             ),
-            on_failure="fail_step",
+            on_failure="failure_step",
         ),
         "resolve_ci": RecipeStep(
             tool="run_skill",
@@ -215,7 +215,6 @@ def _asymmetric_resolve_steps() -> dict[str, RecipeStep]:
         "test_step": RecipeStep(tool="test_check"),
         "push_step": RecipeStep(tool="push_to_remote"),
         "rebase_step": RecipeStep(tool="run_cmd"),
-        "fail_step": RecipeStep(tool="run_cmd"),
         "failure_step": RecipeStep(tool="run_cmd"),
     }
 

--- a/tests/recipe/test_rules_verdict.py
+++ b/tests/recipe/test_rules_verdict.py
@@ -1,8 +1,11 @@
-"""Tests for the unrouted-verdict-value semantic rule.
+"""Tests for verdict semantic rules: unrouted-verdict-value and verdict-routing-asymmetry.
 
 Verifies that recipe steps using skills with declared allowed_values must
 explicitly handle every allowed value in their on_result block — no value
 may silently fall through a catch-all condition.
+
+Also verifies that steps invoking the same skill must route the same verdict
+value to the same outcome category (continuation vs escalation).
 """
 
 from __future__ import annotations
@@ -147,3 +150,166 @@ def test_unrouted_verdict_passes_for_review_design_in_research_recipe() -> None:
         if f.rule == "unrouted-verdict-value" and f.step_name == "review_design"
     ]
     assert not unrouted, f"unrouted-verdict-value fired for review_design step: {unrouted}"
+
+
+# ---------------------------------------------------------------------------
+# verdict-routing-asymmetry rule tests
+# ---------------------------------------------------------------------------
+
+
+def _asymmetric_resolve_steps() -> dict[str, RecipeStep]:
+    """Two steps invoking the same skill, routing flake_suspected differently."""
+    return {
+        "fix": RecipeStep(
+            tool="run_skill",
+            with_args={"skill_command": "/autoskillit:resolve-failures wp pp bb"},
+            capture={"verdict": "${{ result.verdict }}"},
+            on_result=StepResultRoute(
+                conditions=[
+                    StepResultCondition(
+                        route="test_step",
+                        when="${{ result.verdict }} == 'flake_suspected'",
+                    ),
+                    StepResultCondition(
+                        route="fail_step",
+                        when="${{ result.verdict }} == 'ci_only_failure'",
+                    ),
+                    StepResultCondition(
+                        route="push_step",
+                        when="${{ result.verdict }} == 'real_fix'",
+                    ),
+                    StepResultCondition(
+                        route="rebase_step",
+                        when="${{ result.verdict }} == 'already_green'",
+                    ),
+                ]
+            ),
+            on_failure="fail_step",
+        ),
+        "resolve_ci": RecipeStep(
+            tool="run_skill",
+            with_args={"skill_command": "/autoskillit:resolve-failures wp pp bb"},
+            capture={"verdict": "${{ result.verdict }}"},
+            on_result=StepResultRoute(
+                conditions=[
+                    StepResultCondition(
+                        route="failure_step",
+                        when="${{ result.verdict }} == 'flake_suspected'",
+                    ),
+                    StepResultCondition(
+                        route="failure_step",
+                        when="${{ result.verdict }} == 'ci_only_failure'",
+                    ),
+                    StepResultCondition(
+                        route="push_step",
+                        when="${{ result.verdict }} == 'real_fix'",
+                    ),
+                    StepResultCondition(
+                        route="rebase_step",
+                        when="${{ result.verdict }} == 'already_green'",
+                    ),
+                ]
+            ),
+            on_failure="failure_step",
+        ),
+        "test_step": RecipeStep(tool="test_check"),
+        "push_step": RecipeStep(tool="push_to_remote"),
+        "rebase_step": RecipeStep(tool="run_cmd"),
+        "fail_step": RecipeStep(tool="run_cmd"),
+        "failure_step": RecipeStep(tool="run_cmd"),
+    }
+
+
+def _consistent_resolve_steps() -> dict[str, RecipeStep]:
+    """Two steps invoking the same skill, routing flake_suspected consistently."""
+    steps = _asymmetric_resolve_steps()
+    # Make resolve_ci route flake_suspected to test_step (continuation), matching fix
+    steps["resolve_ci"].on_result.conditions[0] = StepResultCondition(
+        route="test_step",
+        when="${{ result.verdict }} == 'flake_suspected'",
+    )
+    return steps
+
+
+def _different_skills_steps() -> dict[str, RecipeStep]:
+    """Two steps invoking different skills — asymmetry should be ignored."""
+    steps = _asymmetric_resolve_steps()
+    # Change resolve_ci to invoke resolve-review instead
+    steps["resolve_ci"] = RecipeStep(
+        tool="run_skill",
+        with_args={"skill_command": "/autoskillit:resolve-review fb bb"},
+        capture={"verdict": "${{ result.verdict }}"},
+        on_result=StepResultRoute(
+            conditions=[
+                StepResultCondition(
+                    route="failure_step",
+                    when="${{ result.verdict }} == 'flake_suspected'",
+                ),
+                StepResultCondition(
+                    route="failure_step",
+                    when="${{ result.verdict }} == 'ci_only_failure'",
+                ),
+                StepResultCondition(
+                    route="push_step",
+                    when="${{ result.verdict }} == 'real_fix'",
+                ),
+                StepResultCondition(
+                    route="rebase_step",
+                    when="${{ result.verdict }} == 'already_green'",
+                ),
+            ]
+        ),
+        on_failure="failure_step",
+    )
+    return steps
+
+
+def test_verdict_routing_asymmetry_fires_on_inconsistent_routes() -> None:
+    """Rule must error when same skill routes same verdict to different outcome categories."""
+    findings = run_semantic_rules(_make_recipe(_asymmetric_resolve_steps()))
+    rule_names = [f.rule for f in findings]
+    assert "verdict-routing-asymmetry" in rule_names, (
+        "run_semantic_rules must emit 'verdict-routing-asymmetry' finding when "
+        "'flake_suspected' routes to continuation in fix but escalation in resolve_ci."
+    )
+
+
+def test_verdict_routing_asymmetry_passes_when_consistent() -> None:
+    """Rule must not fire when all steps route same verdict to same outcome category."""
+    findings = run_semantic_rules(_make_recipe(_consistent_resolve_steps()))
+    rule_names = [f.rule for f in findings]
+    assert "verdict-routing-asymmetry" not in rule_names, (
+        "verdict-routing-asymmetry must not fire when both steps route "
+        "'flake_suspected' to continuation steps."
+    )
+
+
+def test_verdict_routing_asymmetry_ignores_different_skills() -> None:
+    """Rule must not fire when different skills route same verdict differently."""
+    findings = run_semantic_rules(_make_recipe(_different_skills_steps()))
+    rule_names = [f.rule for f in findings]
+    assert "verdict-routing-asymmetry" not in rule_names, (
+        "verdict-routing-asymmetry must not compare routing across different skills."
+    )
+
+
+def test_verdict_routing_asymmetry_reports_correct_step_names() -> None:
+    """Rule finding message must include both step names involved in the asymmetry."""
+    findings = run_semantic_rules(_make_recipe(_asymmetric_resolve_steps()))
+    verdict_findings = [f for f in findings if f.rule == "verdict-routing-asymmetry"]
+    assert len(verdict_findings) >= 1
+    message = verdict_findings[0].message
+    assert "fix" in message and "resolve_ci" in message, (
+        f"Finding message must reference both step names, got: {message}"
+    )
+
+
+def test_verdict_routing_asymmetry_severity_is_error() -> None:
+    """Rule must emit ERROR severity."""
+    findings = run_semantic_rules(_make_recipe(_asymmetric_resolve_steps()))
+    verdict_findings = [f for f in findings if f.rule == "verdict-routing-asymmetry"]
+    assert len(verdict_findings) >= 1
+    for finding in verdict_findings:
+        assert finding.severity == Severity.ERROR, (
+            f"verdict-routing-asymmetry must be ERROR severity, got {finding.severity}"
+        )

--- a/tests/skills/test_resolve_failures_ci_aware.py
+++ b/tests/skills/test_resolve_failures_ci_aware.py
@@ -133,3 +133,62 @@ def test_skill_verdict_covers_all_required_values(skill_text: str) -> None:
     required = {"real_fix", "already_green", "flake_suspected", "ci_only_failure"}
     missing = {v for v in required if v not in skill_text}
     assert not missing, f"resolve-failures SKILL.md is missing these verdict values: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# Verdict decision table row-level mapping tests
+# ---------------------------------------------------------------------------
+
+
+def _find_table_row_verdict(skill_text: str, subtype: str) -> str | None:
+    """Find the verdict assigned to a given failure_subtype in the decision table.
+
+    Scans the markdown table in the Verdict Decision Tree section for a row
+    containing the subtype, and extracts the verdict value from that row.
+    """
+    in_table = False
+    for line in skill_text.splitlines():
+        if "Local result" in line and "failure_subtype" in line and "Verdict" in line:
+            in_table = True
+            continue
+        if in_table and line.strip().startswith("|---"):
+            continue
+        if in_table and "|" in line:
+            cells = [c.strip() for c in line.split("|")]
+            # cells[0] is empty (before first |), cells[-1] is empty (after last |)
+            if len(cells) < 4:
+                continue
+            subtype_cell = cells[2]  # failure_subtype column
+            verdict_cell = cells[3]  # Verdict column
+            if subtype in subtype_cell:
+                # Extract verdict token (backtick-wrapped)
+                match = re.search(r"`(\w+)`", verdict_cell)
+                if match:
+                    return match.group(1)
+        elif in_table and line.strip() == "":
+            break
+    return None
+
+
+def test_unknown_subtype_maps_to_flake_suspected_not_ci_only(skill_text: str) -> None:
+    """The 'unknown' failure_subtype must map to flake_suspected, not ci_only_failure."""
+    verdict = _find_table_row_verdict(skill_text, "unknown")
+    assert verdict is not None, (
+        "resolve-failures SKILL.md verdict decision table must contain a row for 'unknown'"
+    )
+    assert verdict == "flake_suspected", (
+        f"'unknown' subtype must map to 'flake_suspected', got '{verdict}'. "
+        "Ambiguous subtypes should not be routed to abort."
+    )
+
+
+def test_env_subtype_maps_to_flake_suspected_not_ci_only(skill_text: str) -> None:
+    """The 'env' failure_subtype must map to flake_suspected, not ci_only_failure."""
+    verdict = _find_table_row_verdict(skill_text, "env")
+    assert verdict is not None, (
+        "resolve-failures SKILL.md verdict decision table must contain a row for 'env'"
+    )
+    assert verdict == "flake_suspected", (
+        f"'env' subtype must map to 'flake_suspected', got '{verdict}'. "
+        "Ambiguous subtypes should not be routed to abort."
+    )


### PR DESCRIPTION
## Summary

The `resolve-failures` skill's verdict decision tree and the recipe routing tables contain an interlocking defect pattern that has caused three documented pipeline aborts for flaky tests. The verdict tree maps ambiguous failure subtypes (`unknown`, `env`, `fixture`, `import`) to `ci_only_failure` (abort) instead of `flake_suspected` (retry). Simultaneously, all three pipeline recipes route `flake_suspected` to `release_issue_failure` (abort) in `resolve_ci` steps while correctly routing it to `test` (retry) in `fix`/`assess` steps — an asymmetry no existing test or semantic rule detects.

The architectural weakness is the **absence of cross-step verdict routing consistency enforcement**. The recipe validation system (`rules_verdict.py`) checks that each step handles all verdict values explicitly (`unrouted-verdict-value` rule), but never checks that the *same* verdict value gets *consistent treatment* across different steps invoking the same skill within a single recipe. This gap allowed the `fix → retry` / `resolve_ci → abort` asymmetry to exist undetected through multiple releases.

The fix is a new semantic rule — `verdict-routing-asymmetry` — that structurally prevents this class of bug by detecting when steps invoking the same skill route the same verdict to categorically different outcomes (continuation vs. escalation). Combined with correcting the verdict tree and recipe routing, this makes the bug class impossible to reintroduce without an explicit, conscious override.

## Requirements

### Problem

The `resolve-failures` skill classifies flaky tests as `ci_only_failure` and routes to `release_issue_failure` (pipeline abort) instead of attempting to fix them. This is the **third documented occurrence** of this pattern (prior: 2026-04-13, 2026-04-16). No structural fix has been applied.

#### Affected pipelines (current batch)

| Issue | Title | Outcome |
|---|---|---|
| #1012 | Deduplicate JSON unwrap logic and test helpers | Pipeline aborted — flaky `test_process_channel_b.py` timing test |
| #944 | Recipe identity hashing (Part A) | Pipeline aborted — same flaky test |

Both implementations were fully green (9519 and 9543 tests passed). The pipeline aborted because resolve-failures classified the flaky test as unfixable.

#### Prior occurrences

1. **2026-04-13** — Three concurrent pipelines (784, 786, 788) ejected from merge queue for `test_sigterm_writes_scenario_json` flake. resolve-failures no-op looped with `fixes_applied=0`.
2. **2026-04-16** — `test_channel_b_ignores_sub_skill_marker` timing flake caused remediation pipeline abort via `PASS + unknown → ci_only_failure`.

### Root Cause

Two interlocking problems in `resolve-failures/SKILL.md`:

#### 1. The verdict decision tree defaults `unknown` to `ci_only_failure`

**File:** `src/autoskillit/skills_extended/resolve-failures/SKILL.md`, lines 177-198

When `diagnosis_path` is absent (no CI context — common when invoked from `merge_worktree`'s local test gate or the `assess` step), `failure_subtype` defaults to `unknown` (line 155-156). The decision tree maps `PASS + unknown → ci_only_failure` (line 188). This is wrong — a test that failed previously and now passes is **flaky by definition**, not a "CI-only failure."

#### 2. Both `flake_suspected` and `ci_only_failure` route to abort in `resolve_ci`

**File:** `src/autoskillit/recipes/implementation.yaml`, lines 1134-1155

Even when correctly classified as `flake_suspected`, the `resolve_ci` step routes it to `release_issue_failure` (abort).

#### 3. Step 2.5 CI-truth gate has a coverage gap

The CI-truth gate correctly says "local pass is not a resolution" and redirects to the fix loop — but it only fires when `ci_conclusion == "failure"` AND `failure_type == "test"`. It doesn't cover invocations from local test gates (no CI context).

### Required Changes

1. Add Critical Constraint to `resolve-failures/SKILL.md`
2. Change the verdict decision tree default
3. Make `flake_suspected` route to the fix loop, not abort
4. Update recipe routing for `resolve_ci` step
5. Narrow `ci_only_failure` scope
6. Update contract tests

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START([START: CI or Test Failure Detected])
    DONE([DONE: Pipeline Continues])
    ESCALATE([ESCALATE: release_issue_failure])

    subgraph DiagPhase ["● diagnose-ci: Failure Classification"]
        direction TB
        FETCH_LOGS["Fetch CI Logs<br/>━━━━━━━━━━<br/>gh run view --log-failed"]
        CLASSIFY_TYPE{"● Classify failure_type<br/>━━━━━━━━━━<br/>test / lint / build /<br/>type_check / env / unknown"}
        CLASSIFY_SUB{"● Classify failure_subtype<br/>━━━━━━━━━━<br/>flaky / timing_race /<br/>deterministic / fixture /<br/>import / env / unknown"}
    end

    subgraph ResolvePhase ["● resolve-failures: Verdict Decision"]
        direction TB
        RUN_TESTS["Run test_check<br/>━━━━━━━━━━<br/>Local test execution"]
        VERDICT_GATE{"● Verdict Decision Tree<br/>━━━━━━━━━━<br/>local_result x failure_subtype"}
        FIX_LOOP["Fix Loop<br/>━━━━━━━━━━<br/>Analyze → Fix → Commit<br/>→ Re-test (max 3 iter)"]
        EMIT_VERDICT["Emit verdict token<br/>━━━━━━━━━━<br/>verdict = real_fix /<br/>flake_suspected /<br/>ci_only_failure"]
    end

    subgraph LocalRoute ["● Recipe: Local Fix Routing (fix / assess)"]
        direction TB
        LOCAL_VERDICT{"● Route on verdict<br/>━━━━━━━━━━<br/>fix step / assess step"}
        LOCAL_TEST["Re-run test<br/>━━━━━━━━━━<br/>test_check validation"]
    end

    subgraph CIRoute ["● Recipe: CI Fix Routing (resolve_ci)"]
        direction TB
        CI_VERDICT{"● Route on verdict<br/>━━━━━━━━━━<br/>resolve_ci step"}
        RE_PUSH["re_push<br/>━━━━━━━━━━<br/>Force-push branch"]
        CI_WATCH["ci_watch<br/>━━━━━━━━━━<br/>Wait for CI result"]
        REBASE["pre_resolve_rebase<br/>━━━━━━━━━━<br/>Fetch + rebase<br/>against origin/base"]
    end

    subgraph ReviewRoute ["● Recipe: Review Fix Routing (resolve_review)"]
        direction TB
        REV_VERDICT{"● Route on verdict<br/>━━━━━━━━━━<br/>resolve_review step"}
        RE_PUSH_REV["re_push_review<br/>━━━━━━━━━━<br/>Push + re-check review"]
    end

    subgraph Validation ["● Semantic Validation Rules"]
        direction TB
        RULE_ASYM["● verdict-routing-asymmetry<br/>━━━━━━━━━━<br/>Same skill + same verdict<br/>→ same outcome category<br/>across all steps"]
        RULE_UNROUTED["● unrouted-verdict-value<br/>━━━━━━━━━━<br/>Every allowed_value must<br/>have explicit on_result<br/>condition"]
    end

    %% MAIN FLOW %%
    START --> FETCH_LOGS
    FETCH_LOGS --> CLASSIFY_TYPE
    CLASSIFY_TYPE --> CLASSIFY_SUB

    CLASSIFY_SUB -->|"writes diagnosis_path"| RUN_TESTS
    RUN_TESTS --> VERDICT_GATE

    VERDICT_GATE -->|"FAIL: iteration < 3"| FIX_LOOP
    FIX_LOOP -->|"re-test"| VERDICT_GATE
    VERDICT_GATE -->|"FAIL: iteration >= 3"| ESCALATE

    VERDICT_GATE -->|"PASS + flaky/timing_race/<br/>fixture/import/env/unknown"| EMIT_VERDICT
    VERDICT_GATE -->|"PASS + deterministic"| EMIT_VERDICT
    VERDICT_GATE -->|"FAIL → fix → PASS"| EMIT_VERDICT

    %% LOCAL ROUTING %%
    EMIT_VERDICT -->|"local path"| LOCAL_VERDICT
    LOCAL_VERDICT -->|"real_fix"| LOCAL_TEST
    LOCAL_VERDICT -->|"already_green"| LOCAL_TEST
    LOCAL_VERDICT -->|"flake_suspected"| LOCAL_TEST
    LOCAL_VERDICT -->|"ci_only_failure"| ESCALATE
    LOCAL_TEST --> DONE

    %% CI ROUTING %%
    EMIT_VERDICT -->|"CI path"| CI_VERDICT
    CI_VERDICT -->|"real_fix"| RE_PUSH
    CI_VERDICT -->|"flake_suspected"| RE_PUSH
    CI_VERDICT -->|"already_green"| REBASE
    CI_VERDICT -->|"ci_only_failure"| ESCALATE
    RE_PUSH --> CI_WATCH
    CI_WATCH -->|"CI green"| DONE
    CI_WATCH -->|"CI red: retries left"| CLASSIFY_TYPE
    CI_WATCH -->|"CI red: exhausted (3x)"| ESCALATE
    REBASE -->|"re-diagnose"| CLASSIFY_TYPE

    %% REVIEW ROUTING %%
    EMIT_VERDICT -->|"review path"| REV_VERDICT
    REV_VERDICT -->|"real_fix"| RE_PUSH_REV
    REV_VERDICT -->|"already_green"| RE_PUSH_REV
    REV_VERDICT -->|"flake_suspected"| RE_PUSH_REV
    REV_VERDICT -->|"ci_only_failure"| ESCALATE
    RE_PUSH_REV -->|"review ok"| DONE
    RE_PUSH_REV -->|"review still failing:<br/>retries left"| REV_VERDICT
    RE_PUSH_REV -->|"exhausted (3x)"| ESCALATE

    %% VALIDATION (static analysis) %%
    RULE_ASYM -.->|"validates consistency"| LOCAL_VERDICT
    RULE_ASYM -.->|"validates consistency"| CI_VERDICT
    RULE_ASYM -.->|"validates consistency"| REV_VERDICT
    RULE_UNROUTED -.->|"validates coverage"| CI_VERDICT

    %% CLASS ASSIGNMENTS %%
    class START,DONE,ESCALATE terminal;
    class FETCH_LOGS handler;
    class CLASSIFY_TYPE,CLASSIFY_SUB stateNode;
    class RUN_TESTS,FIX_LOOP handler;
    class VERDICT_GATE stateNode;
    class EMIT_VERDICT output;
    class LOCAL_VERDICT,CI_VERDICT,REV_VERDICT stateNode;
    class LOCAL_TEST,RE_PUSH,CI_WATCH,REBASE handler;
    class RE_PUSH_REV handler;
    class RULE_ASYM,RULE_UNROUTED detector;
```

### Error/Resilience Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ENTRY %%
    CI_FAIL([CI / Review Failure Detected])

    subgraph DiagnoseGate ["CONFLICT GATE (Fail-Fast)"]
        direction TB
        DETECT_CONFLICT["detect_ci_conflict<br/>━━━━━━━━━━<br/>git merge-base --is-ancestor<br/>Stale base check"]
    end

    subgraph Diagnosis ["DIAGNOSIS"]
        direction TB
        DIAG["● diagnose-ci<br/>━━━━━━━━━━<br/>failure_type, failure_subtype<br/>is_fixable classification"]
        DIAG_FALLBACK["gh unavailable fallback<br/>━━━━━━━━━━<br/>failure_type=unknown<br/>is_fixable=false"]
    end

    subgraph Fixing ["FIXING SKILLS"]
        direction TB
        RESOLVE_FAIL["● resolve-failures<br/>━━━━━━━━━━<br/>Max 3 fix iterations<br/>Commits each attempt"]
        RESOLVE_CI["● resolve-ci / resolve-review<br/>━━━━━━━━━━<br/>retries: 2<br/>on_exhausted → escalation"]
    end

    subgraph VerdictRouting ["● VERDICT ROUTING (on_result)"]
        direction TB
        VERDICT{"Verdict<br/>value?"}
        V_REAL_FIX["real_fix<br/>━━━━━━━━━━<br/>Fix applied, tests pass"]
        V_ALREADY_GREEN["already_green<br/>━━━━━━━━━━<br/>Pre-resolve rebase path"]
        V_FLAKE["● flake_suspected<br/>━━━━━━━━━━<br/>Ambiguous / transient<br/>flaky, timing_race,<br/>fixture, import, env, unknown"]
        V_CI_ONLY["ci_only_failure<br/>━━━━━━━━━━<br/>deterministic subtype<br/>+ local tests green"]
    end

    subgraph Recovery ["RECOVERY MECHANISMS"]
        direction TB
        RE_PUSH["re_push / re_push_review<br/>━━━━━━━━━━<br/>Retry: push & re-enter CI"]
        RE_TEST["test step<br/>━━━━━━━━━━<br/>Re-validate locally"]
        REBASE_FIX["ci_conflict_fix<br/>━━━━━━━━━━<br/>Rebase before retry<br/>retries: 1"]
    end

    subgraph StaticGuards ["● STATIC ANALYSIS GUARDS (Build-Time)"]
        direction TB
        RULE_UNROUTED["● unrouted-verdict-value<br/>━━━━━━━━━━<br/>Fires when 2+ verdicts<br/>fall through catch-all<br/>Severity: ERROR"]
        RULE_ASYMMETRY["● verdict-routing-asymmetry<br/>━━━━━━━━━━<br/>Fires when same skill +<br/>same verdict routes to<br/>escalation in one step,<br/>continuation in another<br/>Severity: ERROR"]
        RULE_UNGATED["conditional-skill-ungated-push<br/>━━━━━━━━━━<br/>BFS reachability: push<br/>without on_result gate<br/>Severity: ERROR"]
        RULE_CONFLICT["ci-failure-missing-conflict-gate<br/>━━━━━━━━━━<br/>resolve-failures reachable<br/>before conflict gate<br/>Severity: ERROR"]
    end

    subgraph Validity ["RECIPE VALIDITY GATE"]
        direction TB
        COMPUTE["compute_recipe_validity<br/>━━━━━━━━━━<br/>schema errors ∪ semantic<br/>findings ∪ contract findings"]
    end

    %% TERMINALS %%
    T_DONE([DONE — Pipeline Success])
    T_ESCALATE([ESCALATE — Human Handoff<br/>release_issue_failure →<br/>register_clone_failure →<br/>escalate_stop])
    T_BLOCK([RECIPE BLOCKED<br/>Validity = False])

    %% === RUNTIME FLOW === %%
    CI_FAIL --> DETECT_CONFLICT
    DETECT_CONFLICT -->|"stale base"| REBASE_FIX
    DETECT_CONFLICT -->|"base current"| DIAG

    DIAG -->|"gh missing"| DIAG_FALLBACK
    DIAG_FALLBACK -->|"best-effort"| RESOLVE_CI
    DIAG -->|"is_fixable=true"| RESOLVE_FAIL
    DIAG -->|"is_fixable=false"| T_ESCALATE

    RESOLVE_FAIL --> VERDICT
    RESOLVE_CI --> VERDICT

    VERDICT -->|"real_fix"| V_REAL_FIX
    VERDICT -->|"already_green"| V_ALREADY_GREEN
    VERDICT -->|"flake_suspected"| V_FLAKE
    VERDICT -->|"ci_only_failure"| V_CI_ONLY

    V_REAL_FIX --> RE_PUSH
    V_ALREADY_GREEN --> RE_TEST
    V_FLAKE --> RE_PUSH
    V_CI_ONLY --> T_ESCALATE

    RE_PUSH -->|"CI passes"| T_DONE
    RE_PUSH -->|"CI fails again"| CI_FAIL
    RE_TEST -->|"passes"| RE_PUSH
    RE_TEST -->|"fails"| RESOLVE_FAIL

    REBASE_FIX -->|"rebased"| DIAG
    REBASE_FIX -->|"exhausted"| T_ESCALATE

    RESOLVE_CI -->|"on_exhausted"| T_ESCALATE
    RESOLVE_FAIL -->|"3 iterations exhausted"| T_ESCALATE

    %% === STATIC ANALYSIS FLOW === %%
    RULE_UNROUTED --> COMPUTE
    RULE_ASYMMETRY --> COMPUTE
    RULE_UNGATED --> COMPUTE
    RULE_CONFLICT --> COMPUTE
    COMPUTE -->|"any ERROR finding"| T_BLOCK
    COMPUTE -->|"all clear"| T_DONE

    %% CLASS ASSIGNMENTS %%
    class CI_FAIL,T_DONE,T_ESCALATE,T_BLOCK terminal;
    class DETECT_CONFLICT detector;
    class DIAG,DIAG_FALLBACK handler;
    class RESOLVE_FAIL,RESOLVE_CI handler;
    class VERDICT stateNode;
    class V_REAL_FIX,V_ALREADY_GREEN output;
    class V_FLAKE gap;
    class V_CI_ONLY gap;
    class RE_PUSH,RE_TEST,REBASE_FIX output;
    class RULE_UNROUTED,RULE_ASYMMETRY,RULE_UNGATED,RULE_CONFLICT detector;
    class COMPUTE phase;
```

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START([Recipe Load])

    subgraph InitOnly ["INIT_ONLY — Set Once at Load"]
        direction TB
        SKILL_AV["● allowed_values<br/>━━━━━━━━━━<br/>resolve-failures emits:<br/>real_fix, flake_suspected,<br/>ci_only_failure, already_green"]
        STEP_TOOL["RecipeStep.tool<br/>━━━━━━━━━━<br/>run_skill target<br/>IMMUTABLE"]
    end

    subgraph InitPreserve ["INIT_PRESERVE — Routing Config"]
        direction TB
        ON_RESULT_CI["● on_result conditions<br/>━━━━━━━━━━<br/>resolve_ci routing map<br/>flake_suspected → re_push"]
        ON_RESULT_REV["● on_result conditions<br/>━━━━━━━━━━<br/>resolve_review routing map<br/>flake_suspected → re_push_review"]
        ON_EXHAUST["on_exhausted<br/>━━━━━━━━━━<br/>release_issue_failure<br/>after retries exceeded"]
    end

    subgraph Mutable ["MUTABLE — Runtime Verdict State"]
        direction TB
        RESULT_V["result.verdict<br/>━━━━━━━━━━<br/>Written by skill exec<br/>Read by condition eval"]
        CTX_V["context.verdict<br/>━━━━━━━━━━<br/>Captured from result<br/>Forwarded to next step"]
    end

    subgraph AppendOnly ["APPEND_ONLY — Validation Findings"]
        direction TB
        FINDINGS["● RuleFinding list<br/>━━━━━━━━━━<br/>Grows per rule violation<br/>Never shrinks"]
    end

    subgraph Gates ["VALIDATION GATES — Execution Order"]
        direction TB
        G1["Gate 1: validate_recipe<br/>━━━━━━━━━━<br/>Structural checks<br/>on_result targets exist<br/>FAIL-FAST on schema error"]
        G2["● Gate 2: unrouted-verdict-value<br/>━━━━━━━━━━<br/>Every allowed_value needs<br/>explicit when condition<br/>Fires when ≥2 unrouted"]
        G3["● Gate 3: verdict-routing-asymmetry<br/>━━━━━━━━━━<br/>Same skill+verdict must<br/>route to same class<br/>across all steps"]
        G4["Gate 4: compute_recipe_validity<br/>━━━━━━━━━━<br/>Aggregates all findings<br/>Any ERROR → invalid"]
    end

    subgraph Classify ["DERIVED — Route Classification"]
        direction TB
        CLASSIFY["● _classify_route_target<br/>━━━━━━━━━━<br/>failure/escalat/stop → ESCALATION<br/>all others → CONTINUATION"]
        ASYM_MAP["{skill,verdict} →<br/>classification map<br/>━━━━━━━━━━<br/>Detects mixed sets"]
    end

    subgraph Resume ["RESUME SAFETY — Retry Routing"]
        direction TB
        TIER1["Tier 1: resolve_ci path<br/>━━━━━━━━━━<br/>● flake_suspected → re_push<br/>already_green → pre_resolve_rebase<br/>retries: 2 before escalation"]
        TIER2["Tier 2: resolve_review path<br/>━━━━━━━━━━<br/>● flake_suspected → re_push_review<br/>already_green → re_push_review<br/>symmetric continuation"]
        TIER3["Tier 3: fix/assess path<br/>━━━━━━━━━━<br/>flake_suspected → test<br/>already_green → test<br/>local re-validation loop"]
    end

    subgraph Tests ["CONTRACT ENFORCEMENT — Tests"]
        direction TB
        T1["● test_routing_invariant<br/>━━━━━━━━━━<br/>flake_suspected must<br/>route to re_push<br/>never to escalation"]
        T2["● test_rules_verdict<br/>━━━━━━━━━━<br/>asymmetry rule fires<br/>on mixed classification<br/>severity = ERROR"]
        T3["● test_ci_aware<br/>━━━━━━━━━━<br/>SKILL.md declares all<br/>4 verdict values +<br/>decision tree present"]
    end

    VALID_OUT([Recipe Valid])
    INVALID_OUT([Recipe Invalid — Blocked])

    %% FLOW %%
    START --> SKILL_AV
    START --> STEP_TOOL
    SKILL_AV --> ON_RESULT_CI
    SKILL_AV --> ON_RESULT_REV
    STEP_TOOL --> ON_RESULT_CI
    STEP_TOOL --> ON_RESULT_REV

    ON_RESULT_CI --> G1
    ON_RESULT_REV --> G1
    ON_EXHAUST --> G1

    G1 -->|pass| G2
    G1 -->|fail| INVALID_OUT

    G2 --> FINDINGS
    G2 -->|pass| G3

    G3 --> CLASSIFY
    CLASSIFY --> ASYM_MAP
    ASYM_MAP --> FINDINGS
    G3 -->|pass| G4

    G4 -->|no errors| VALID_OUT
    G4 -->|has errors| INVALID_OUT

    VALID_OUT --> RESULT_V
    RESULT_V -->|capture| CTX_V
    CTX_V --> TIER1
    CTX_V --> TIER2
    CTX_V --> TIER3

    T1 -.->|guards| ON_RESULT_CI
    T1 -.->|guards| ON_RESULT_REV
    T2 -.->|guards| CLASSIFY
    T3 -.->|guards| SKILL_AV

    %% CLASS ASSIGNMENTS %%
    class SKILL_AV,STEP_TOOL detector;
    class ON_RESULT_CI,ON_RESULT_REV,ON_EXHAUST gap;
    class RESULT_V,CTX_V phase;
    class FINDINGS handler;
    class G1,G2,G3,G4 stateNode;
    class CLASSIFY,ASYM_MAP output;
    class TIER1,TIER2,TIER3 cli;
    class T1,T2,T3 detector;
    class START,VALID_OUT,INVALID_OUT terminal;
```

Closes #1031

## Implementation Plan

Plan file: `.autoskillit/temp/rectify/rectify_resolve-failures-flaky-abort_2026-04-18_103000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 6.7k | 36.2k | 3.3M | 209.8k | 3 | 22m 23s |
| review | 26 | 6.0k | 165.4k | 9.7k | 1 | 7m 48s |
| **Total** | 6.7k | 42.2k | 3.5M | 219.5k | | 30m 11s |