### PR TITLE
Record test-check Duration and Filter Stats in Telemetry

### DIFF
--- a/src/autoskillit/core/_type_results.py
+++ b/src/autoskillit/core/_type_results.py
@@ -40,6 +40,10 @@ class TestResult:
     passed: bool
     stdout: str
     stderr: str
+    duration_seconds: float | None = None
+    tests_selected: int | None = None
+    tests_deselected: int | None = None
+    filter_mode: str | None = None
 
 
 @dataclass

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -393,6 +393,7 @@ def flush_session_log(
         "recipe_content_hash": recipe_content_hash,
         "recipe_composite_hash": recipe_composite_hash,
         "recipe_version": recipe_version,
+        "duration_seconds": duration_seconds,
     }
     index_path = log_root / "sessions.jsonl"
     with index_path.open("a") as f:

--- a/src/autoskillit/execution/testing.py
+++ b/src/autoskillit/execution/testing.py
@@ -8,8 +8,11 @@ _logging.
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import re
+import tempfile
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -201,6 +204,30 @@ class DefaultTestRunner:
         if base_ref:
             env["AUTOSKILLIT_TEST_BASE_REF"] = base_ref
 
+        # Create sidecar for conftest to write filter stats into
+        fd, sidecar_path = tempfile.mkstemp(suffix=".json", prefix="filter-stats-")
+        os.close(fd)
+        env["AUTOSKILLIT_FILTER_STATS_FILE"] = sidecar_path
+
+        start = time.monotonic()
         result = await self._runner(command, cwd=cwd, timeout=timeout, env=env)
+        elapsed = time.monotonic() - start
+
+        # Read filter stats sidecar (written by conftest pytest_sessionfinish)
+        filter_stats: dict = {}
+        sidecar = Path(sidecar_path)
+        if sidecar.is_file() and sidecar.stat().st_size > 0:
+            try:
+                filter_stats = json.loads(sidecar.read_text())
+            except (json.JSONDecodeError, OSError):
+                pass
+        sidecar.unlink(missing_ok=True)
+
         passed = check_test_passed(result.returncode, result.stdout, result.stderr)
-        return TestResult(passed=passed, stdout=result.stdout, stderr=result.stderr)
+        return TestResult(
+            passed=passed,
+            stdout=result.stdout,
+            stderr=result.stderr,
+            duration_seconds=elapsed,
+            **filter_stats,
+        )

--- a/src/autoskillit/execution/testing.py
+++ b/src/autoskillit/execution/testing.py
@@ -209,19 +209,31 @@ class DefaultTestRunner:
         os.close(fd)
         env["AUTOSKILLIT_FILTER_STATS_FILE"] = sidecar_path
 
+        elapsed: float = 0.0
+        stat_filter_mode: str | None = None
+        stat_tests_selected: int | None = None
+        stat_tests_deselected: int | None = None
         start = time.monotonic()
-        result = await self._runner(command, cwd=cwd, timeout=timeout, env=env)
-        elapsed = time.monotonic() - start
+        try:
+            result = await self._runner(command, cwd=cwd, timeout=timeout, env=env)
+            elapsed = time.monotonic() - start
 
-        # Read filter stats sidecar (written by conftest pytest_sessionfinish)
-        filter_stats: dict = {}
-        sidecar = Path(sidecar_path)
-        if sidecar.is_file() and sidecar.stat().st_size > 0:
-            try:
-                filter_stats = json.loads(sidecar.read_text())
-            except (json.JSONDecodeError, OSError):
-                pass
-        sidecar.unlink(missing_ok=True)
+            # Read filter stats sidecar (written by conftest pytest_sessionfinish)
+            sidecar = Path(sidecar_path)
+            if sidecar.is_file() and sidecar.stat().st_size > 0:
+                try:
+                    raw = json.loads(sidecar.read_text())
+                    if isinstance(raw, dict):
+                        fm = raw.get("filter_mode")
+                        ts = raw.get("tests_selected")
+                        td = raw.get("tests_deselected")
+                        stat_filter_mode = fm if isinstance(fm, str) else None
+                        stat_tests_selected = ts if isinstance(ts, int) else None
+                        stat_tests_deselected = td if isinstance(td, int) else None
+                except (json.JSONDecodeError, OSError) as exc:
+                    logger.debug("filter stats sidecar read error: %s", exc)
+        finally:
+            Path(sidecar_path).unlink(missing_ok=True)
 
         passed = check_test_passed(result.returncode, result.stdout, result.stderr)
         return TestResult(
@@ -229,5 +241,7 @@ class DefaultTestRunner:
             stdout=result.stdout,
             stderr=result.stderr,
             duration_seconds=elapsed,
-            **filter_stats,
+            filter_mode=stat_filter_mode,
+            tests_selected=stat_tests_selected,
+            tests_deselected=stat_tests_deselected,
         )

--- a/src/autoskillit/hooks/_fmt_execution.py
+++ b/src/autoskillit/hooks/_fmt_execution.py
@@ -164,6 +164,17 @@ def _fmt_test_check(data: dict, _pipeline: bool) -> str:
     mark = _CHECK_MARK if passed else _CROSS_MARK
     status = "PASS" if passed else "FAIL"
     lines = [f"## test_check {mark} {status}", "", f"passed: {passed}"]
+
+    duration = data.get("duration_seconds")
+    if duration is not None:
+        lines.append(f"duration: {duration:.1f}s")
+
+    filter_mode = data.get("filter_mode")
+    if filter_mode:
+        selected = data.get("tests_selected", "?")
+        deselected = data.get("tests_deselected", "?")
+        lines.append(f"filter: {filter_mode} ({selected} selected, {deselected} deselected)")
+
     stdout = data.get("stdout", "")
     if stdout:
         filtered = _filter_pytest_output(stdout)

--- a/src/autoskillit/server/tools_workspace.py
+++ b/src/autoskillit/server/tools_workspace.py
@@ -78,13 +78,20 @@ async def test_check(
                     extra={"worktree": worktree_path},
                 )
 
-            return json.dumps(
-                {
-                    "passed": test_result.passed,
-                    "stdout": truncate_text(test_result.stdout),
-                    "stderr": truncate_text(test_result.stderr),
-                }
-            )
+            response = {
+                "passed": test_result.passed,
+                "stdout": truncate_text(test_result.stdout),
+                "stderr": truncate_text(test_result.stderr),
+            }
+            if test_result.duration_seconds is not None:
+                response["duration_seconds"] = round(test_result.duration_seconds, 2)
+            if test_result.filter_mode is not None:
+                response["filter_mode"] = test_result.filter_mode
+            if test_result.tests_selected is not None:
+                response["tests_selected"] = test_result.tests_selected
+            if test_result.tests_deselected is not None:
+                response["tests_deselected"] = test_result.tests_deselected
+            return json.dumps(response)
         finally:
             if step_name:
                 tool_ctx.timing_log.record(step_name, time.monotonic() - _start)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Shared test fixtures for autoskillit."""
 
+import os
 from pathlib import Path as _Path
 
 import pytest
@@ -42,6 +43,8 @@ _SIZE_DIRS: frozenset[str] = frozenset(
 
 _scope_key = pytest.StashKey[set[_Path] | None]()
 _filter_mode_key = pytest.StashKey[str | None]()
+_selected_count_key = pytest.StashKey[int | None]()
+_deselected_count_key = pytest.StashKey[int | None]()
 
 
 @pytest.fixture(autouse=True)
@@ -281,7 +284,6 @@ def pytest_configure(config: pytest.Config) -> None:
     Opt-in via AUTOSKILLIT_TEST_FILTER env var or --filter-mode CLI flag.
     Fail-open: any error sets scope to None (full test run).
     """
-    import os
     import warnings
 
     config.stash[_scope_key] = None
@@ -408,6 +410,8 @@ def pytest_collection_modifyitems(
                 f"({len(scope)} scope paths)",
                 stacklevel=1,
             )
+            config.stash[_selected_count_key] = len(selected)
+            config.stash[_deselected_count_key] = len(deselected)
 
     except Exception as exc:
         warnings.warn(
@@ -438,3 +442,31 @@ def pytest_collection_modifyitems(
                 f"{len(size_deselected)} large/unannotated deselected",
                 stacklevel=1,
             )
+            prev_deselected = config.stash.get(_deselected_count_key, None) or 0
+            config.stash[_selected_count_key] = len(size_selected)
+            config.stash[_deselected_count_key] = prev_deselected + len(size_deselected)
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Write filter stats sidecar for DefaultTestRunner consumption."""
+    if hasattr(session.config, "workerinput"):
+        return  # xdist worker — only the controller writes the sidecar
+    out_path = os.environ.get("AUTOSKILLIT_FILTER_STATS_FILE")
+    if not out_path:
+        return
+    filter_mode = session.config.stash.get(_filter_mode_key, None)
+    selected = session.config.stash.get(_selected_count_key, None)
+    deselected = session.config.stash.get(_deselected_count_key, None)
+    if filter_mode is None:
+        return
+    import json
+
+    _Path(out_path).write_text(
+        json.dumps(
+            {
+                "filter_mode": filter_mode,
+                "tests_selected": selected,
+                "tests_deselected": deselected,
+            }
+        )
+    )

--- a/tests/execution/test_session_log.py
+++ b/tests/execution/test_session_log.py
@@ -1355,8 +1355,6 @@ def test_summary_no_recipe_provenance_when_empty(tmp_path):
     assert "recipe_provenance" not in summary
 
 
-# T7
-
 
 def test_flush_index_includes_duration_seconds(tmp_path):
     """sessions.jsonl index entry includes duration_seconds."""

--- a/tests/execution/test_session_log.py
+++ b/tests/execution/test_session_log.py
@@ -1353,3 +1353,14 @@ def test_summary_no_recipe_provenance_when_empty(tmp_path):
     session_dir = tmp_path / "sessions" / "rp-005"
     summary = json.loads((session_dir / "summary.json").read_text())
     assert "recipe_provenance" not in summary
+
+
+# T7
+
+
+def test_flush_index_includes_duration_seconds(tmp_path):
+    """sessions.jsonl index entry includes duration_seconds."""
+    _flush(tmp_path, elapsed_seconds=42.5)
+    index = (tmp_path / "sessions.jsonl").read_text().strip()
+    entry = json.loads(index)
+    assert entry["duration_seconds"] == pytest.approx(42.5)

--- a/tests/execution/test_testing.py
+++ b/tests/execution/test_testing.py
@@ -510,11 +510,6 @@ def test_defaults_yaml_has_filter_mode_and_base_ref():
     assert tc["base_ref"] is None
 
 
-# ---------------------------------------------------------------------------
-# T1: TestResult optional fields
-# ---------------------------------------------------------------------------
-
-
 def test_test_result_has_duration_and_filter_fields():
     """TestResult accepts optional duration_seconds and filter stat fields."""
     from autoskillit.core import TestResult
@@ -545,11 +540,6 @@ def test_test_result_new_fields_default_to_none():
     assert tr.filter_mode is None
 
 
-# ---------------------------------------------------------------------------
-# T2: DefaultTestRunner.run() measures duration
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.anyio
 async def test_default_test_runner_measures_duration(tmp_path: Path) -> None:
     """run() populates duration_seconds on the returned TestResult."""
@@ -562,11 +552,6 @@ async def test_default_test_runner_measures_duration(tmp_path: Path) -> None:
     result = await tester.run(tmp_path)
     assert result.duration_seconds is not None
     assert result.duration_seconds >= 0.0
-
-
-# ---------------------------------------------------------------------------
-# T3: DefaultTestRunner.run() reads filter stats from sidecar file
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.anyio

--- a/tests/execution/test_testing.py
+++ b/tests/execution/test_testing.py
@@ -508,3 +508,103 @@ def test_defaults_yaml_has_filter_mode_and_base_ref():
     assert "base_ref" in tc
     assert tc["filter_mode"] is None
     assert tc["base_ref"] is None
+
+
+# ---------------------------------------------------------------------------
+# T1: TestResult optional fields
+# ---------------------------------------------------------------------------
+
+
+def test_test_result_has_duration_and_filter_fields():
+    """TestResult accepts optional duration_seconds and filter stat fields."""
+    from autoskillit.core import TestResult
+
+    tr = TestResult(
+        passed=True,
+        stdout="out",
+        stderr="err",
+        duration_seconds=3.14,
+        tests_selected=73,
+        tests_deselected=275,
+        filter_mode="aggressive",
+    )
+    assert tr.duration_seconds == 3.14
+    assert tr.tests_selected == 73
+    assert tr.tests_deselected == 275
+    assert tr.filter_mode == "aggressive"
+
+
+def test_test_result_new_fields_default_to_none():
+    """Existing callers with positional args still work."""
+    from autoskillit.core import TestResult
+
+    tr = TestResult(passed=True, stdout="", stderr="")
+    assert tr.duration_seconds is None
+    assert tr.tests_selected is None
+    assert tr.tests_deselected is None
+    assert tr.filter_mode is None
+
+
+# ---------------------------------------------------------------------------
+# T2: DefaultTestRunner.run() measures duration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_default_test_runner_measures_duration(tmp_path: Path) -> None:
+    """run() populates duration_seconds on the returned TestResult."""
+    from tests.conftest import _make_result
+    from tests.fakes import MockSubprocessRunner
+
+    runner = MockSubprocessRunner()
+    runner.push(_make_result(0, "= 10 passed =\n", ""))
+    tester = DefaultTestRunner(config=make_test_config(), runner=runner)
+    result = await tester.run(tmp_path)
+    assert result.duration_seconds is not None
+    assert result.duration_seconds >= 0.0
+
+
+# ---------------------------------------------------------------------------
+# T3: DefaultTestRunner.run() reads filter stats from sidecar file
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_default_test_runner_populates_filter_stats_from_sidecar(tmp_path: Path) -> None:
+    """run() populates filter fields when sidecar JSON file is written."""
+    import json
+
+    sidecar_data = {"filter_mode": "conservative", "tests_selected": 50, "tests_deselected": 100}
+
+    async def fake_runner(command, *, cwd, timeout, env, **kwargs):
+        sidecar_path = env.get("AUTOSKILLIT_FILTER_STATS_FILE")
+        assert sidecar_path, "AUTOSKILLIT_FILTER_STATS_FILE must be set in env"
+        Path(sidecar_path).write_text(json.dumps(sidecar_data))
+        return SubprocessResult(
+            returncode=0,
+            stdout="= 50 passed =\n",
+            stderr="",
+            termination=TerminationReason.NATURAL_EXIT,
+            pid=12345,
+        )
+
+    tester = DefaultTestRunner(config=make_test_config(), runner=fake_runner)
+    result = await tester.run(tmp_path)
+    assert result.filter_mode == "conservative"
+    assert result.tests_selected == 50
+    assert result.tests_deselected == 100
+
+
+@pytest.mark.anyio
+async def test_default_test_runner_no_sidecar_means_no_filter_stats(tmp_path: Path) -> None:
+    """run() leaves filter fields as None when no sidecar is written."""
+    from tests.conftest import _make_result
+    from tests.fakes import MockSubprocessRunner
+
+    runner = MockSubprocessRunner()
+    runner.push(_make_result(0, "= 10 passed =\n", ""))
+    tester = DefaultTestRunner(config=make_test_config(), runner=runner)
+    result = await tester.run(tmp_path)
+    assert result.filter_mode is None
+    assert result.tests_selected is None
+    assert result.tests_deselected is None

--- a/tests/infra/test_pretty_output.py
+++ b/tests/infra/test_pretty_output.py
@@ -1871,9 +1871,6 @@ def test_fmt_run_skill_legacy_payload_without_kill_reason_renders_bare() -> None
     assert "infra" not in text
 
 
-# T6
-
-
 def test_fmt_test_check_displays_duration():
     """Pretty output shows duration when present."""
     from autoskillit.hooks._fmt_execution import _fmt_test_check

--- a/tests/infra/test_pretty_output.py
+++ b/tests/infra/test_pretty_output.py
@@ -1869,3 +1869,32 @@ def test_fmt_run_skill_legacy_payload_without_kill_reason_renders_bare() -> None
     text = _fmt_run_skill(data, pipeline=False)
     assert "exit_code: 0" in text
     assert "infra" not in text
+
+
+# T6
+
+
+def test_fmt_test_check_displays_duration():
+    """Pretty output shows duration when present."""
+    from autoskillit.hooks._fmt_execution import _fmt_test_check
+
+    data = {"passed": True, "stdout": "= 10 passed =", "duration_seconds": 12.34}
+    out = _fmt_test_check(data, False)
+    assert "12.3s" in out or "12.34" in out
+
+
+def test_fmt_test_check_displays_filter_stats():
+    """Pretty output shows filter stats when present."""
+    from autoskillit.hooks._fmt_execution import _fmt_test_check
+
+    data = {
+        "passed": True,
+        "stdout": "",
+        "filter_mode": "conservative",
+        "tests_selected": 50,
+        "tests_deselected": 100,
+    }
+    out = _fmt_test_check(data, False)
+    assert "conservative" in out
+    assert "50" in out
+    assert "100" in out

--- a/tests/server/test_tools_workspace.py
+++ b/tests/server/test_tools_workspace.py
@@ -158,7 +158,10 @@ class TestTestCheck:
         result = json.loads(await test_check(worktree_path="/tmp/wt"))
         assert "summary" not in result
         assert "output_file" not in result
-        assert set(result.keys()) == {"passed", "stdout", "stderr", "duration_seconds"}
+        assert "passed" in result
+        assert "stdout" in result
+        assert "stderr" in result
+        assert "duration_seconds" in result
 
     @pytest.mark.anyio
     async def test_cross_validates_error_in_output(self, tool_ctx):
@@ -282,7 +285,6 @@ class TestTestCheck:
         result = json.loads(await test_check(worktree_path="/tmp/wt"))
         assert result["passed"] is False
 
-    # T4
     @pytest.mark.anyio
     async def test_test_check_response_includes_duration(self, tool_ctx):
         """test_check JSON includes duration_seconds."""
@@ -293,9 +295,8 @@ class TestTestCheck:
         assert isinstance(data["duration_seconds"], float)
         assert data["duration_seconds"] >= 0.0
 
-    # T5
     @pytest.mark.anyio
-    async def test_test_check_response_includes_filter_stats(self, tool_ctx):
+    async def test_test_check_response_includes_filter_stats(self, tool_ctx, monkeypatch):
         """test_check JSON includes filter fields when sidecar is written."""
         from pathlib import Path as _Path
 
@@ -309,8 +310,8 @@ class TestTestCheck:
 
         async def fake_runner(command, *, cwd, timeout, env, **kwargs):
             sidecar_path = env.get("AUTOSKILLIT_FILTER_STATS_FILE")
-            if sidecar_path:
-                _Path(sidecar_path).write_text(json.dumps(sidecar_data))
+            assert sidecar_path, "AUTOSKILLIT_FILTER_STATS_FILE must be injected into env"
+            _Path(sidecar_path).write_text(json.dumps(sidecar_data))
             return SubprocessResult(
                 returncode=0,
                 stdout="= 73 passed =\n",
@@ -319,7 +320,7 @@ class TestTestCheck:
                 pid=12345,
             )
 
-        tool_ctx.tester._runner = fake_runner
+        monkeypatch.setattr(tool_ctx.tester, "_runner", fake_runner)
         raw = await test_check("/tmp/wt")
         data = json.loads(raw)
         assert data["filter_mode"] == "aggressive"

--- a/tests/server/test_tools_workspace.py
+++ b/tests/server/test_tools_workspace.py
@@ -158,7 +158,7 @@ class TestTestCheck:
         result = json.loads(await test_check(worktree_path="/tmp/wt"))
         assert "summary" not in result
         assert "output_file" not in result
-        assert set(result.keys()) == {"passed", "stdout", "stderr"}
+        assert set(result.keys()) == {"passed", "stdout", "stderr", "duration_seconds"}
 
     @pytest.mark.anyio
     async def test_cross_validates_error_in_output(self, tool_ctx):
@@ -273,7 +273,7 @@ class TestTestCheck:
         """test_check response contains passed, stdout, and stderr keys."""
         tool_ctx.runner.push(_make_result(0, "= 10 passed =\n", ""))
         result = json.loads(await test_check(worktree_path="/tmp/wt"))
-        assert set(result.keys()) == {"passed", "stdout", "stderr"}
+        assert set(result.keys()) == {"passed", "stdout", "stderr", "duration_seconds"}
 
     @pytest.mark.anyio
     async def test_pytest_failure_still_detected(self, tool_ctx):
@@ -281,6 +281,59 @@ class TestTestCheck:
         tool_ctx.runner.push(_make_result(0, "= 3 failed, 97 passed =\n", ""))
         result = json.loads(await test_check(worktree_path="/tmp/wt"))
         assert result["passed"] is False
+
+    # T4
+    @pytest.mark.anyio
+    async def test_test_check_response_includes_duration(self, tool_ctx):
+        """test_check JSON includes duration_seconds."""
+        tool_ctx.runner.push(_make_result(0, "= 10 passed =\n", ""))
+        raw = await test_check("/tmp/wt")
+        data = json.loads(raw)
+        assert "duration_seconds" in data
+        assert isinstance(data["duration_seconds"], float)
+        assert data["duration_seconds"] >= 0.0
+
+    # T5
+    @pytest.mark.anyio
+    async def test_test_check_response_includes_filter_stats(self, tool_ctx):
+        """test_check JSON includes filter fields when sidecar is written."""
+        from pathlib import Path as _Path
+
+        from autoskillit.core.types import SubprocessResult, TerminationReason
+
+        sidecar_data = {
+            "filter_mode": "aggressive",
+            "tests_selected": 73,
+            "tests_deselected": 275,
+        }
+
+        async def fake_runner(command, *, cwd, timeout, env, **kwargs):
+            sidecar_path = env.get("AUTOSKILLIT_FILTER_STATS_FILE")
+            if sidecar_path:
+                _Path(sidecar_path).write_text(json.dumps(sidecar_data))
+            return SubprocessResult(
+                returncode=0,
+                stdout="= 73 passed =\n",
+                stderr="",
+                termination=TerminationReason.NATURAL_EXIT,
+                pid=12345,
+            )
+
+        tool_ctx.tester._runner = fake_runner
+        raw = await test_check("/tmp/wt")
+        data = json.loads(raw)
+        assert data["filter_mode"] == "aggressive"
+        assert data["tests_selected"] == 73
+        assert data["tests_deselected"] == 275
+
+    @pytest.mark.anyio
+    async def test_test_check_response_omits_filter_stats_when_absent(self, tool_ctx):
+        """Filter fields are absent (not null) from response when no filter active."""
+        tool_ctx.runner.push(_make_result(0, "= 10 passed =\n", ""))
+        raw = await test_check("/tmp/wt")
+        data = json.loads(raw)
+        assert "filter_mode" not in data
+        assert "tests_selected" not in data
 
 
 class TestResetGuard:

--- a/tests/test_test_filter_plugin.py
+++ b/tests/test_test_filter_plugin.py
@@ -245,7 +245,8 @@ class TestConftestFilterPlugin:
     def test_conftest_no_sidecar_when_env_unset(self, pytester: pytest.Pytester) -> None:
         """No sidecar written when AUTOSKILLIT_FILTER_STATS_FILE is not in env."""
         pytester.makeconftest(_CONFTEST_HOOKS_SOURCE)
-        pytester.makepyfile(test_simple="def test_a(): pass")
+        pytester.mkdir("subdir_a")
+        (pytester.path / "subdir_a" / "test_simple.py").write_text("def test_a(): pass\n")
         result = pytester.runpytest("--filter-mode=conservative")
         result.assert_outcomes(passed=1)
 

--- a/tests/test_test_filter_plugin.py
+++ b/tests/test_test_filter_plugin.py
@@ -220,8 +220,6 @@ class TestConftestFilterPlugin:
         result = pytester.runpytest("-v", "-W", "always")
         result.stdout.fnmatch_lines(["*Test filter:*selected*deselected*"])
 
-    # T8
-
     def test_conftest_writes_filter_sidecar(
         self,
         pytester: pytest.Pytester,

--- a/tests/test_test_filter_plugin.py
+++ b/tests/test_test_filter_plugin.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 pytest_plugins = ["pytester"]
@@ -12,12 +14,16 @@ pytest_plugins = ["pytester"]
 # ---------------------------------------------------------------------------
 
 _CONFTEST_HOOKS_SOURCE = """
+import json
 import os
 import warnings
 import pytest
 from pathlib import Path
 
 _scope_key = pytest.StashKey[set | None]()
+_filter_mode_key = pytest.StashKey[str | None]()
+_selected_count_key = pytest.StashKey[int | None]()
+_deselected_count_key = pytest.StashKey[int | None]()
 
 def pytest_addoption(parser):
     parser.addoption("--filter-mode", default=None,
@@ -26,6 +32,7 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     config.stash[_scope_key] = None
+    config.stash[_filter_mode_key] = None
     cli_mode = config.getoption("--filter-mode", default=None)
     env_val = os.environ.get("AUTOSKILLIT_TEST_FILTER", "")
     if not cli_mode and not env_val:
@@ -36,6 +43,7 @@ def pytest_configure(config):
         mode = cli_mode or ("conservative" if env_val.lower() in ("1", "true", "yes") else env_val)
         if mode == "none":
             return
+        config.stash[_filter_mode_key] = mode
         # Stub scope: only include files under subdir_a/
         config.stash[_scope_key] = {config.rootpath / "subdir_a"}
     except Exception as exc:
@@ -60,8 +68,27 @@ def pytest_collection_modifyitems(items, config):
                 f"Test filter: {len(selected)} selected, {len(deselected)} deselected",
                 stacklevel=1,
             )
+            config.stash[_selected_count_key] = len(selected)
+            config.stash[_deselected_count_key] = len(deselected)
     except Exception as exc:
         warnings.warn(f"Test filter deselection failed: {exc}", stacklevel=1)
+
+def pytest_sessionfinish(session, exitstatus):
+    if hasattr(session.config, "workerinput"):
+        return
+    out_path = os.environ.get("AUTOSKILLIT_FILTER_STATS_FILE")
+    if not out_path:
+        return
+    filter_mode = session.config.stash.get(_filter_mode_key, None)
+    selected = session.config.stash.get(_selected_count_key, None)
+    deselected = session.config.stash.get(_deselected_count_key, None)
+    if filter_mode is None:
+        return
+    Path(out_path).write_text(json.dumps({
+        "filter_mode": filter_mode,
+        "tests_selected": selected,
+        "tests_deselected": deselected,
+    }))
 
 def _is_under(path, parent):
     try:
@@ -192,6 +219,35 @@ class TestConftestFilterPlugin:
         pytester.makepyfile(test_drop="def test_drop(): pass")
         result = pytester.runpytest("-v", "-W", "always")
         result.stdout.fnmatch_lines(["*Test filter:*selected*deselected*"])
+
+    # T8
+
+    def test_conftest_writes_filter_sidecar(
+        self,
+        pytester: pytest.Pytester,
+        tmp_path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """pytest_sessionfinish writes filter stats JSON when sidecar env var is set."""
+        sidecar = tmp_path / "filter-stats.json"
+        monkeypatch.setenv("AUTOSKILLIT_FILTER_STATS_FILE", str(sidecar))
+        pytester.makeconftest(_CONFTEST_HOOKS_SOURCE)
+        pytester.mkdir("subdir_a")
+        (pytester.path / "subdir_a" / "test_in_scope.py").write_text("def test_ok(): pass\n")
+        pytester.makepyfile(test_out_scope="def test_skip(): pass")
+        pytester.runpytest("--filter-mode=conservative")
+        assert sidecar.is_file(), "Sidecar file must be written by pytest_sessionfinish"
+        data = json.loads(sidecar.read_text())
+        assert data["filter_mode"] == "conservative"
+        assert isinstance(data["tests_selected"], int)
+        assert isinstance(data["tests_deselected"], int)
+
+    def test_conftest_no_sidecar_when_env_unset(self, pytester: pytest.Pytester) -> None:
+        """No sidecar written when AUTOSKILLIT_FILTER_STATS_FILE is not in env."""
+        pytester.makeconftest(_CONFTEST_HOOKS_SOURCE)
+        pytester.makepyfile(test_simple="def test_a(): pass")
+        result = pytester.runpytest("--filter-mode=conservative")
+        result.assert_outcomes(passed=1)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add wall-clock duration and test-filter deselection statistics to the `test_check` telemetry pipeline. Currently, `test_check` measures elapsed time via `time.monotonic()` but only feeds it to the in-memory `timing_log` — it never appears in the JSON response, `TestResult` dataclass, session diagnostics index, or pretty output. Filter deselection counts are emitted as `warnings.warn` in conftest and lost. This plan threads duration and filter stats from their origins (pytest subprocess, conftest plugin) through `TestResult`, the MCP response, the pretty-output formatter, and the `sessions.jsonl` index.

## Architecture Impact

### Data Lineage Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ── INPUT ── %%
    subgraph Input ["Data Origins"]
        WTP["● MCP Caller<br/>━━━━━━━━━━<br/>worktree_path: str<br/>step_name: str"]
        CONFIG["AutomationConfig<br/>━━━━━━━━━━<br/>test_check.command<br/>test_check.filter_mode<br/>test_check.base_ref"]
    end

    %% ── ORCHESTRATION ── %%
    subgraph Orch ["● test_check Tool<br/>(server/tools_workspace.py)"]
        TC["● test_check()<br/>━━━━━━━━━━<br/>calls tester.run()<br/>records step timing"]
    end

    %% ── TEST RUNNER ── %%
    subgraph Runner ["● DefaultTestRunner<br/>(execution/testing.py)"]
        TR["● DefaultTestRunner.run()<br/>━━━━━━━━━━<br/>start = time.monotonic()<br/>mkstemp → sidecar path<br/>builds sanitized env"]
        ENV["Subprocess Env<br/>━━━━━━━━━━<br/>AUTOSKILLIT_TEST_FILTER<br/>AUTOSKILLIT_TEST_BASE_REF<br/>AUTOSKILLIT_FILTER_STATS_FILE"]
    end

    %% ── PYTEST SUBPROCESS ── %%
    subgraph Pytest ["● pytest Process<br/>(tests/conftest.py)"]
        PC["pytest_configure()<br/>━━━━━━━━━━<br/>builds scope<br/>stash[filter_mode_key]"]
        PM["pytest_collection_modifyitems()<br/>━━━━━━━━━━<br/>deselects items<br/>stash[selected_count]<br/>stash[deselected_count]"]
        PF["● pytest_sessionfinish()<br/>━━━━━━━━━━<br/>reads AUTOSKILLIT_FILTER_STATS_FILE<br/>writes JSON sidecar"]
    end

    %% ── SIDECAR (TEMP STORAGE) ── %%
    subgraph TempSidecar ["Temp Sidecar (write-once, read-once)"]
        SC[("/tmp/filter-stats-XXXX.json<br/>━━━━━━━━━━<br/>filter_mode: str<br/>tests_selected: int<br/>tests_deselected: int")]
    end

    %% ── RESULT ASSEMBLY ── %%
    subgraph Assembly ["● TestResult Assembly<br/>(execution/testing.py + core/_type_results.py)"]
        CHK["check_test_passed()<br/>━━━━━━━━━━<br/>returncode + stdout<br/>→ passed: bool"]
        RES["● TestResult<br/>━━━━━━━━━━<br/>passed: bool<br/>stdout / stderr<br/>● duration_seconds: float<br/>● filter_mode: str | None<br/>● tests_selected: int | None<br/>● tests_deselected: int | None"]
    end

    %% ── MCP RESPONSE ── %%
    subgraph MCPResp ["● MCP JSON Response<br/>(server/tools_workspace.py)"]
        JSON["● response dict<br/>━━━━━━━━━━<br/>passed, stdout, stderr<br/>● duration_seconds<br/>● filter_mode<br/>● tests_selected<br/>● tests_deselected"]
    end

    %% ── DISPLAY ── %%
    subgraph Display ["● Human Display<br/>(hooks/_fmt_execution.py)"]
        FMT["● _fmt_test_check()<br/>━━━━━━━━━━<br/>## test_check ✓ PASS<br/>● duration: Xs<br/>● filter: mode (N sel, N desel)"]
    end

    %% ── SESSION LOG STORAGE ── %%
    subgraph SessionLog ["● Session Log<br/>(execution/session_log.py)"]
        SUM[("● summary.json<br/>━━━━━━━━━━<br/>session_id, success<br/>duration_seconds<br/>...40+ fields")]
        IDX[("● sessions.jsonl<br/>━━━━━━━━━━<br/>append-only index<br/>duration_seconds")]
        TU[("token_usage.json<br/>━━━━━━━━━━<br/>step telemetry<br/>(if step_name)")]
    end

    %% ── FLOWS ── %%
    WTP -->|"worktree_path"| TC
    CONFIG -->|"command, filter_mode"| TR
    TC -->|"tester.run(Path)"| TR
    TR -->|"env dict"| ENV
    ENV -->|"AUTOSKILLIT_FILTER_STATS_FILE<br/>AUTOSKILLIT_TEST_FILTER"| PC
    PC -->|"stash[filter_mode, scope]"| PM
    PM -->|"stash[selected, deselected]"| PF
    PF -->|"json.dumps → write"| SC
    SC -->|"json.loads ← read<br/>(then unlinked)"| TR
    TR -->|"elapsed = monotonic() - start"| RES
    TR -->|"filter_stats dict"| RES
    ENV -->|"subprocess stdout/stderr<br/>returncode"| CHK
    CHK -->|"passed: bool"| RES
    RES -->|"TestResult"| TC
    TC -->|"if not None → include"| JSON
    JSON -->|"json.dumps"| FMT
    TC -->|"flush_session_log()"| SUM
    TC -->|"timing_log.record()"| TU
    SUM -.->|"write-only"| IDX

    %% CLASS ASSIGNMENTS %%
    class WTP cli;
    class CONFIG stateNode;
    class TC handler;
    class TR,CHK handler;
    class ENV phase;
    class PC,PM,PF phase;
    class SC output;
    class RES stateNode;
    class JSON handler;
    class FMT output;
    class SUM,IDX,TU stateNode;
```

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 42, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START(["START<br/>MCP client invokes test_check"])
    DONE(["DONE<br/>JSON response returned to client"])

    %% ── PHASE 1: MCP ENTRY ── %%
    subgraph Phase1 ["① MCP Entry — tools_workspace.py"]
        direction TB
        TC["● test_check<br/>━━━━━━━━━━<br/>worktree_path, step_name<br/>bind structlog ctx<br/>notify client"]
        GateCheck{"tester<br/>configured?"}
    end

    %% ── PHASE 2: ENV & SIDECAR SETUP ── %%
    subgraph Phase2 ["② Env & Sidecar Setup — execution/testing.py"]
        direction TB
        BuildEnv["● DefaultTestRunner.run()<br/>━━━━━━━━━━<br/>build_sanitized_env()<br/>strip AUTOSKILLIT_PRIVATE_ENV_VARS"]
        FilterEnv{"filter_mode<br/>in config?"}
        InjectFilter["inject<br/>AUTOSKILLIT_TEST_FILTER=&lt;mode&gt;"]
        BaseRef["● _resolve_base_ref()<br/>━━━━━━━━━━<br/>config → sidecar → git upstream<br/>injects AUTOSKILLIT_TEST_BASE_REF"]
        MkSidecar["create temp sidecar<br/>AUTOSKILLIT_FILTER_STATS_FILE=&lt;path&gt;<br/>injected into subprocess env"]
        StartTimer["start monotonic timer<br/>━━━━━━━━━━<br/>start = time.monotonic()"]
    end

    %% ── PHASE 3: PYTEST SUBPROCESS ── %%
    subgraph Phase3 ["③ Pytest Subprocess — tests/conftest.py"]
        direction TB
        PytestRun["subprocess: task test-check<br/>━━━━━━━━━━<br/>reads AUTOSKILLIT_TEST_FILTER<br/>reads AUTOSKILLIT_TEST_BASE_REF"]
        ModifyItems["● pytest_collection_modifyitems<br/>━━━━━━━━━━<br/>deselect out-of-scope items<br/>stash: filter_mode, selected, deselected"]
        SessionFinish["● pytest_sessionfinish<br/>━━━━━━━━━━<br/>reads AUTOSKILLIT_FILTER_STATS_FILE<br/>writes JSON sidecar:<br/>{filter_mode, tests_selected, tests_deselected}"]
    end

    %% ── PHASE 4: TELEMETRY ASSEMBLY ── %%
    subgraph Phase4 ["④ Telemetry Assembly — execution/testing.py + core/_type_results.py"]
        direction TB
        StopTimer["stop timer → elapsed<br/>━━━━━━━━━━<br/>duration_seconds = time.monotonic() - start"]
        ReadSidecar{"sidecar<br/>non-empty?"}
        ParseStats["● read & parse sidecar JSON<br/>━━━━━━━━━━<br/>filter_stats = {filter_mode,<br/>tests_selected, tests_deselected}"]
        DeleteSidecar["sidecar.unlink()"]
        Adjudicate["check_test_passed()<br/>━━━━━━━━━━<br/>exit_code + pytest summary cross-check"]
        BuildResult["● TestResult (dataclass)<br/>━━━━━━━━━━<br/>passed, stdout, stderr<br/>+ duration_seconds ●<br/>+ filter_mode ●<br/>+ tests_selected ●<br/>+ tests_deselected ●"]
    end

    %% ── PHASE 5: RESPONSE ASSEMBLY ── %%
    subgraph Phase5 ["⑤ Response Assembly — tools_workspace.py + hooks/_fmt_execution.py"]
        direction TB
        BuildJSON["● test_check assembles JSON response<br/>━━━━━━━━━━<br/>passed, stdout, stderr<br/>+ duration_seconds if not None ●<br/>+ filter_mode if not None ●<br/>+ tests_selected if not None ●<br/>+ tests_deselected if not None ●"]
        StepTiming{"step_name<br/>provided?"}
        RecordTiming["timing_log.record(step_name, elapsed)"]
        FmtHook["● _fmt_test_check (pretty_output hook)<br/>━━━━━━━━━━<br/>render: duration: N.Ns ●<br/>render: filter: mode (N sel, N desel) ●<br/>filter pytest boilerplate from stdout"]
    end

    %% ── PHASE 6: SESSION LOG ── %%
    subgraph Phase6 ["⑥ Session Log Index — execution/session_log.py"]
        direction TB
        SessionLog["● flush_session_log()<br/>━━━━━━━━━━<br/>appends to sessions.jsonl index<br/>+ duration_seconds ● in index entry"]
    end

    ERR(["ERROR<br/>{'passed': false, 'error': '...'}"])

    %% ── FLOW ── %%
    START --> TC
    TC --> GateCheck
    GateCheck -->|"tester is None"| ERR
    GateCheck -->|"tester configured"| BuildEnv
    BuildEnv --> FilterEnv
    FilterEnv -->|"yes"| InjectFilter
    FilterEnv -->|"no"| BaseRef
    InjectFilter --> BaseRef
    BaseRef --> MkSidecar
    MkSidecar --> StartTimer
    StartTimer -->|"run subprocess"| PytestRun
    PytestRun --> ModifyItems
    ModifyItems --> SessionFinish
    SessionFinish -->|"writes sidecar JSON"| StopTimer
    StopTimer --> ReadSidecar
    ReadSidecar -->|"yes — parse"| ParseStats
    ReadSidecar -->|"no / error — empty dict"| DeleteSidecar
    ParseStats --> DeleteSidecar
    DeleteSidecar --> Adjudicate
    Adjudicate --> BuildResult
    BuildResult --> BuildJSON
    BuildJSON --> StepTiming
    StepTiming -->|"yes"| RecordTiming
    StepTiming -->|"no"| FmtHook
    RecordTiming --> FmtHook
    FmtHook --> SessionLog
    SessionLog --> DONE

    %% ── CLASS ASSIGNMENTS ── %%
    class START,DONE,ERR terminal;
    class TC,BuildJSON handler;
    class GateCheck,FilterEnv,ReadSidecar,StepTiming stateNode;
    class BuildEnv,BaseRef,MkSidecar,StartTimer,StopTimer,ParseStats,DeleteSidecar,Adjudicate phase;
    class PytestRun,ModifyItems,SessionFinish handler;
    class BuildResult,FmtHook,RecordTiming,SessionLog output;
```

### Development Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;

    %% ENTRY POINT %%
    EP["autoskillit CLI<br/>━━━━━━━━━━<br/>autoskillit.cli:main"]

    subgraph Source ["SOURCE LAYOUT (src/autoskillit/)"]
        direction LR
        CORE["● core/<br/>━━━━━━━━━━<br/>_type_results.py<br/>TestResult + new fields"]
        EXEC["● execution/<br/>━━━━━━━━━━<br/>testing.py · session_log.py<br/>DefaultTestRunner"]
        SERVER["● server/<br/>━━━━━━━━━━<br/>tools_workspace.py<br/>test_check MCP tool"]
        HOOKS["● hooks/<br/>━━━━━━━━━━<br/>_fmt_execution.py<br/>_fmt_test_check formatter"]
    end

    subgraph Build ["BUILD TOOLING"]
        direction TB
        PYPROJECT["pyproject.toml<br/>━━━━━━━━━━<br/>hatch-vcs build backend<br/>uv package manager"]
        TASKFILE["Taskfile.yml<br/>━━━━━━━━━━<br/>test-all · test-check<br/>test-filtered · sync-plugin-version"]
    end

    subgraph Quality ["CODE QUALITY GATES (pre-commit)"]
        direction LR
        RUFF_FMT["ruff format<br/>━━━━━━━━━━<br/>Auto-fix: rewrites src"]
        RUFF_CHK["ruff check<br/>━━━━━━━━━━<br/>Auto-fix: lint errors"]
        MYPY["mypy<br/>━━━━━━━━━━<br/>Type checking<br/>Read-only"]
        GITLEAKS["gitleaks<br/>━━━━━━━━━━<br/>Secret scanning<br/>Read-only"]
        UV_LOCK["uv lock check<br/>━━━━━━━━━━<br/>Lockfile freshness<br/>Read-only"]
    end

    subgraph TestFramework ["TEST FRAMEWORK"]
        direction TB
        PYTEST["pytest + xdist<br/>━━━━━━━━━━<br/>-n 4 --dist worksteal<br/>163 test files"]
        CONFTEST["● tests/conftest.py<br/>━━━━━━━━━━<br/>pytest_sessionfinish<br/>writes filter stats sidecar"]
        FIXTURES["fixtures: tool_ctx · minimal_ctx<br/>━━━━━━━━━━<br/>_isolated_home · _clear_headless_env<br/>_structlog_to_null"]
    end

    subgraph TestDirs ["TEST DIRECTORIES (modified)"]
        direction LR
        T_EXEC["● tests/execution/<br/>━━━━━━━━━━<br/>test_testing.py<br/>test_session_log.py"]
        T_SERVER["● tests/server/<br/>━━━━━━━━━━<br/>test_tools_workspace.py"]
        T_INFRA["● tests/infra/<br/>━━━━━━━━━━<br/>test_pretty_output.py"]
        T_FILTER["● tests/test_test_filter_plugin.py<br/>━━━━━━━━━━<br/>filter stats sidecar contract"]
    end

    subgraph TelemetryFlow ["● TELEMETRY ENRICHMENT PIPELINE (PR #1029)"]
        direction TB
        ENV_SIDECAR["AUTOSKILLIT_FILTER_STATS_FILE<br/>━━━━━━━━━━<br/>env var → tempfile path<br/>set by DefaultTestRunner"]
        SIDECAR_JSON[("filter-stats-*.json<br/>━━━━━━━━━━<br/>tmpfs sidecar<br/>written by conftest")]
        TEST_RESULT["● TestResult<br/>━━━━━━━━━━<br/>duration_seconds<br/>filter_mode · tests_selected<br/>tests_deselected"]
        MCP_RESP["● test_check response<br/>━━━━━━━━━━<br/>JSON: duration_seconds<br/>filter_mode · tests_selected<br/>tests_deselected"]
        FMT_OUT["● _fmt_test_check<br/>━━━━━━━━━━<br/>duration: Xs<br/>filter: mode (N selected, M deselected)"]
    end

    %% CONNECTIONS %%
    EP --> Source
    Source --> Build
    Build --> TASKFILE

    PYPROJECT --> RUFF_FMT
    RUFF_FMT --> RUFF_CHK
    RUFF_CHK --> MYPY
    MYPY --> GITLEAKS
    GITLEAKS --> UV_LOCK
    UV_LOCK --> PYTEST

    PYTEST --> CONFTEST
    CONFTEST --> FIXTURES
    FIXTURES --> TestDirs

    %% Telemetry flow
    EXEC -->|"sets env var"| ENV_SIDECAR
    ENV_SIDECAR --> CONFTEST
    CONFTEST -->|"pytest_sessionfinish writes"| SIDECAR_JSON
    SIDECAR_JSON -->|"DefaultTestRunner reads"| TEST_RESULT
    TEST_RESULT -->|"tools_workspace.py"| MCP_RESP
    MCP_RESP -->|"pretty_output hook"| FMT_OUT

    CORE -.->|"defines"| TEST_RESULT

    %% CLASS ASSIGNMENTS %%
    class EP cli;
    class CORE,EXEC,SERVER,HOOKS stateNode;
    class PYTEST handler;
    class CONFTEST,FIXTURES handler;
    class T_EXEC,T_SERVER,T_INFRA,T_FILTER handler;
    class RUFF_FMT,RUFF_CHK detector;
    class MYPY,GITLEAKS,UV_LOCK detector;
    class PYPROJECT,TASKFILE phase;
    class ENV_SIDECAR,SIDECAR_JSON,TEST_RESULT phase;
    class MCP_RESP,FMT_OUT output;
```

Closes #1029

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260418-104056-990635/.autoskillit/temp/make-plan/record_test_check_duration_and_filter_stats_plan_2026-04-18_104500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 6.5k | 12.1k | 1.3M | 74.1k | 1 | 7m 38s |
| review | 26 | 6.0k | 165.4k | 9.7k | 1 | 7m 48s |
| verify | 41 | 24.7k | 1.5M | 82.8k | 1 | 12m 28s |
| implement | 690 | 39.5k | 5.9M | 100.5k | 1 | 12m 15s |
| fix | 104 | 5.8k | 464.8k | 46.3k | 1 | 7m 7s |
| prepare_pr | 60 | 4.9k | 186.5k | 37.5k | 1 | 2m 47s |
| run_arch_lenses | 231 | 19.6k | 1.1M | 158.4k | 3 | 6m 0s |
| compose_pr | 67 | 8.6k | 236.0k | 31.7k | 1 | 2m 23s |
| **Total** | 7.7k | 121.3k | 10.9M | 541.0k | | 58m 30s |