### PR TITLE
Implementation Plan: Flaky Test Architectural Immunity — Centralized Timeouts, Configurable Preamble, AST Guards

### DIFF
--- a/.claude/skills/audit-tests/SKILL.md
+++ b/.claude/skills/audit-tests/SKILL.md
@@ -181,7 +181,7 @@ Test files or supporting files exceeding 750 lines. Flag files approaching the t
 
 ### Category 10: xdist Safety Violations (HIGH)
 
-Tests that are unsafe for parallel execution under pytest-xdist (`-n 4 --dist worksteal`). This project runs tests in parallel by default with explicit safety rules defined in `tests/CLAUDE.md`.
+Tests that are unsafe for parallel execution under pytest-xdist (`-n 4 --dist load`). This project runs tests in parallel by default with explicit safety rules defined in `tests/CLAUDE.md`.
 
 **What to look for:**
 - Tests that create temporary files or directories at fixed paths instead of using `tmp_path` (pytest provides unique per-test paths; on Linux these should land under `/dev/shm/pytest-tmp` per `tests/CLAUDE.md` guidance)

--- a/src/autoskillit/execution/_process_race.py
+++ b/src/autoskillit/execution/_process_race.py
@@ -234,6 +234,7 @@ async def _watch_session_log(
     _phase1_poll: float,
     _phase2_poll: float,
     _phase1_timeout: float,
+    _session_id_timeout: float = 1.0,
     stdout_session_id_ready: anyio.Event | None = None,
     max_suppression_seconds: float | None = None,
 ) -> None:
@@ -247,7 +248,7 @@ async def _watch_session_log(
     extraction before starting Phase 1 to enable identity-based JSONL selection.
     """
     if stdout_session_id_ready is not None:
-        with anyio.move_on_after(1.0):
+        with anyio.move_on_after(_session_id_timeout):
             await stdout_session_id_ready.wait()
 
     _monitor_kwargs: dict[str, object] = {

--- a/src/autoskillit/execution/process.py
+++ b/src/autoskillit/execution/process.py
@@ -199,6 +199,7 @@ async def run_managed_async(
     _phase2_poll: float = 2.0,
     _heartbeat_poll: float = 0.5,
     _phase1_timeout: float = 30.0,
+    _session_id_timeout: float = 1.0,
 ) -> SubprocessResult:
     """Async subprocess execution with temp file I/O and process tree cleanup.
 
@@ -320,6 +321,7 @@ async def run_managed_async(
                         _phase1_poll,
                         _phase2_poll,
                         _phase1_timeout,
+                        _session_id_timeout,
                         stdout_session_id_ready,
                         max_suppression_seconds,
                     )

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## xdist Compatibility
 
-All tests run under `-n 4 --dist worksteal`. Every test must be safe for parallel execution:
+All tests run under `-n 4` (xdist default: `--dist load`). Every test must be safe for parallel execution:
 - Use `tmp_path` for filesystem isolation — never write to shared locations
 - Session-scoped fixtures run once per worker process, not once globally
 - Module-level globals are per-worker (separate processes) — no cross-worker state sharing

--- a/tests/arch/test_channel_b_timeout_guard.py
+++ b/tests/arch/test_channel_b_timeout_guard.py
@@ -1,0 +1,129 @@
+"""AST guard: Channel B tests must use timeout >= TimeoutTier.CHANNEL_B.
+
+Prevents the timeout=15 class of flaky-test bug by scanning run_managed_async
+call sites and enforcing minimum timeout values for Channel B tests.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from tests.conftest import TimeoutTier
+
+TESTS_ROOT = Path(__file__).parent.parent
+CHANNEL_B_TEST_FILE = TESTS_ROOT / "execution" / "test_process_channel_b.py"
+
+# Tests that deliberately use short timeouts to provoke TIMED_OUT behavior.
+# Each entry: (function_name, timeout_value, rationale)
+EXEMPTIONS: dict[str, tuple[int | float, str]] = {
+    "test_drain_window_times_out_when_no_session_jsonl": (
+        10,
+        "Deliberately short timeout with completion_drain_timeout=0.2; "
+        "no session JSONL written, so Channel B never fires.",
+    ),
+}
+
+_CHANNEL_B_DRAIN_THRESHOLD = 0.3  # completion_drain_timeout below this is not Channel B
+
+
+def _extract_run_managed_async_calls(
+    tree: ast.Module,
+) -> list[tuple[str, int, dict[str, ast.expr]]]:
+    """Extract (enclosing_function_name, lineno, keyword_dict) for run_managed_async calls."""
+    results: list[tuple[str, int, dict[str, ast.expr]]] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        func_name = node.name
+        for child in ast.walk(node):
+            if not isinstance(child, ast.Call):
+                continue
+            # Match run_managed_async(... or await run_managed_async(...)
+            callee = child.func
+            name = None
+            if isinstance(callee, ast.Name):
+                name = callee.id
+            elif isinstance(callee, ast.Attribute):
+                name = callee.attr
+            if name != "run_managed_async":
+                continue
+            kw_dict = {kw.arg: kw.value for kw in child.keywords if kw.arg is not None}
+            results.append((func_name, child.lineno, kw_dict))
+
+    return results
+
+
+def _is_channel_b_call(kw_dict: dict[str, ast.expr]) -> bool:
+    """Compound heuristic: session_log_dir + completion_marker + drain >= threshold."""
+    has_session_log_dir = "session_log_dir" in kw_dict
+    has_completion_marker = "completion_marker" in kw_dict
+    drain_node = kw_dict.get("completion_drain_timeout")
+    if not (has_session_log_dir and has_completion_marker and drain_node is not None):
+        return False
+    if not isinstance(drain_node, ast.Constant):
+        return True  # Non-literal drain — conservatively treat as Channel B
+    return drain_node.value >= _CHANNEL_B_DRAIN_THRESHOLD
+
+
+class TestChannelBTimeoutGuard:
+    """AST guard: Channel B run_managed_async calls must have timeout >= CHANNEL_B tier."""
+
+    def test_all_channel_b_calls_meet_minimum_timeout(self) -> None:
+        source = CHANNEL_B_TEST_FILE.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(CHANNEL_B_TEST_FILE))
+        calls = _extract_run_managed_async_calls(tree)
+        violations: list[str] = []
+
+        for func_name, lineno, kw_dict in calls:
+            if not _is_channel_b_call(kw_dict):
+                continue
+
+            # Check exemption
+            if func_name in EXEMPTIONS:
+                continue
+
+            timeout_node = kw_dict.get("timeout")
+            if timeout_node is None:
+                violations.append(f"  {func_name} (line {lineno}): no timeout= keyword")
+                continue
+
+            # timeout must be a literal (ast.Constant) or an attribute (TimeoutTier.CHANNEL_B)
+            if isinstance(timeout_node, ast.Constant):
+                if timeout_node.value < TimeoutTier.CHANNEL_B:
+                    violations.append(
+                        f"  {func_name} (line {lineno}): timeout={timeout_node.value} "
+                        f"< TimeoutTier.CHANNEL_B ({TimeoutTier.CHANNEL_B})"
+                    )
+            elif isinstance(timeout_node, ast.Attribute):
+                # TimeoutTier.CHANNEL_B — accepted by name
+                pass
+            else:
+                violations.append(
+                    f"  {func_name} (line {lineno}): timeout is not a literal or "
+                    f"TimeoutTier attribute — cannot statically verify"
+                )
+
+        assert not violations, (
+            f"Channel B tests with timeout below {TimeoutTier.CHANNEL_B}s:\n"
+            + "\n".join(violations)
+        )
+
+    def test_timeout_tier_constants(self) -> None:
+        """TimeoutTier values encode the documented budget math."""
+        assert TimeoutTier.UNIT == 10
+        assert TimeoutTier.INTEGRATION == 30
+        assert TimeoutTier.CHANNEL_B == 60
+
+    def test_exemptions_are_still_present(self) -> None:
+        """Guard against stale exemptions — each exempted function must still exist."""
+        source = CHANNEL_B_TEST_FILE.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(CHANNEL_B_TEST_FILE))
+        func_names = {
+            node.name
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        }
+        stale = set(EXEMPTIONS.keys()) - func_names
+        assert not stale, f"Stale exemptions (functions no longer exist): {stale}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,17 @@ _selected_count_key = pytest.StashKey[int | None]()
 _deselected_count_key = pytest.StashKey[int | None]()
 
 
+class TimeoutTier:
+    """Centralized timeout tiers encoding xdist -n 4 budget math.
+
+    CHANNEL_B minimum: 1s preamble + _phase1_timeout (30s) + drain + jitter > 31.5s.
+    """
+
+    UNIT = 10  # Pure logic, no I/O
+    INTEGRATION = 30  # Filesystem/subprocess, no Channel B
+    CHANNEL_B = 60  # Full session_log_dir + Channel B path
+
+
 @pytest.fixture(autouse=True)
 def _structlog_to_null():
     """Prevent structlog from writing to stdout in any test.

--- a/tests/execution/test_process_channel_b.py
+++ b/tests/execution/test_process_channel_b.py
@@ -9,6 +9,7 @@ import pytest
 
 from autoskillit.core.types import ChannelConfirmation, SubprocessResult, TerminationReason
 from autoskillit.execution.process import run_managed_async
+from tests.conftest import TimeoutTier
 from tests.execution.conftest import WRITE_RESULT_THEN_HANG_SCRIPT
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.medium]
@@ -22,6 +23,8 @@ CHANNEL_B_THEN_A_CONFIRM_SCRIPT = textwrap.dedent("""\
     import sys, time, json, os
     session_dir = sys.argv[1]
     os.makedirs(session_dir, exist_ok=True)
+    sys.stdout.write(json.dumps({"type": "system", "session_id": "session"}) + "\\n")
+    sys.stdout.flush()
     # Small delay to ensure file ctime > spawn_time recorded in run_managed_async
     time.sleep(0.1)
     with open(os.path.join(session_dir, "session.jsonl"), "w") as f:
@@ -66,6 +69,8 @@ CHANNEL_B_THEN_A_EMPTY_RESULT_SCRIPT = textwrap.dedent("""\
     import sys, time, json, os
     session_dir = sys.argv[1]
     os.makedirs(session_dir, exist_ok=True)
+    sys.stdout.write(json.dumps({"type": "system", "session_id": "session"}) + "\\n")
+    sys.stdout.flush()
     # Small delay to ensure file ctime > spawn_time recorded in run_managed_async
     time.sleep(0.1)
     with open(os.path.join(session_dir, "session.jsonl"), "w") as f:
@@ -90,6 +95,8 @@ PROCESS_EXIT_THEN_CHANNEL_B_FIRES_SCRIPT = textwrap.dedent("""\
     import sys, json, os, time
     session_dir = sys.argv[1]
     os.makedirs(session_dir, exist_ok=True)
+    sys.stdout.write(json.dumps({"type": "system", "session_id": "session"}) + "\\n")
+    sys.stdout.flush()
     # Small delay ensures file ctime > spawn_time recorded in run_managed_async
     time.sleep(0.1)
     with open(os.path.join(session_dir, "session.jsonl"), "w") as f:
@@ -129,13 +136,14 @@ class TestChannelBDrainWait:
         result = await run_managed_async(
             [sys.executable, str(script), str(session_dir), "0.15"],
             cwd=tmp_path,
-            timeout=60,
+            timeout=TimeoutTier.CHANNEL_B,
             session_log_dir=session_dir,
             completion_marker="%%ORDER_UP%%",
             completion_drain_timeout=5.0,
             _phase1_poll=0.01,
             _phase2_poll=0.05,
             _heartbeat_poll=0.05,
+            _session_id_timeout=0.01,
         )
 
         assert result.termination == TerminationReason.COMPLETED
@@ -152,10 +160,11 @@ class TestChannelBDrainWait:
           t=0.66s  drain times out (script never wrote to stdout)
           t=0.66s  process killed with empty stdout
 
-        timeout=60s: guards against the outer wall-clock expiring under xdist -n 4 load.
-        _watch_session_log waits up to 1s for stdout_session_id_ready before Phase 1 starts;
+        timeout=TimeoutTier.CHANNEL_B (60s): guards against the outer wall-clock expiring under xdist -n 4 load.
+        _watch_session_log waits up to _session_id_timeout (default 1.0s, tests pass 0.01s)
+        for stdout_session_id_ready before Phase 1 starts;
         under CI load both the preamble and Phase 1 polls can overrun, so the outer
-        timeout must exceed 1s + _phase1_timeout (30s default) + drain (0.5s) = 31.5s.
+        timeout must exceed _session_id_timeout + _phase1_timeout (30s default) + drain (0.5s) = 31.5s.
         """
         session_dir = tmp_path / "session"
         session_dir.mkdir()
@@ -165,12 +174,13 @@ class TestChannelBDrainWait:
         result = await run_managed_async(
             [sys.executable, str(script), str(session_dir)],
             cwd=tmp_path,
-            timeout=60,
+            timeout=TimeoutTier.CHANNEL_B,
             session_log_dir=session_dir,
             completion_marker="%%ORDER_UP%%",
             completion_drain_timeout=0.5,
             _phase1_poll=0.01,
             _phase2_poll=0.05,
+            _session_id_timeout=0.01,
         )
 
         assert result.termination == TerminationReason.COMPLETED
@@ -215,12 +225,13 @@ class TestChannelBDrainWait:
         result = await run_managed_async(
             [sys.executable, str(script), str(session_dir)],
             cwd=tmp_path,
-            timeout=60,
+            timeout=TimeoutTier.CHANNEL_B,
             session_log_dir=session_dir,
             completion_marker="%%ORDER_UP%%",
             completion_drain_timeout=0.1,
             _phase1_poll=0.01,
             _phase2_poll=0.05,
+            _session_id_timeout=0.01,
         )
 
         assert result.termination == TerminationReason.COMPLETED
@@ -263,13 +274,14 @@ class TestChannelBDrainWait:
         result = await run_managed_async(
             [sys.executable, str(script), str(session_dir)],
             cwd=tmp_path,
-            timeout=60,
+            timeout=TimeoutTier.CHANNEL_B,
             session_log_dir=session_dir,
             completion_marker="%%ORDER_UP%%",
             completion_drain_timeout=2.0,
             _phase1_poll=0.01,
             _phase2_poll=0.05,
             _heartbeat_poll=0.05,
+            _session_id_timeout=0.01,
         )
         assert result.termination == TerminationReason.COMPLETED
         assert (
@@ -291,9 +303,9 @@ class TestChannelBFullPipelineAdjudication:
         - completion_drain_timeout=0.5s: the heartbeat has already seen the empty result
           and failed to confirm by the time Channel B fires (~1s after task group start),
           so 0.5s of additional drain time is more than sufficient semantically.
-        - timeout=60s: guards against the outer wall-clock expiring under xdist -n 4 load.
-          Under heavy load the stdout_session_id_ready wait (1.0s) and inner drain (0.5s)
-          can each overrun 10x, giving a worst-case total of ~15s well inside 60s.
+        - timeout=TimeoutTier.CHANNEL_B (60s): guards against the outer wall-clock expiring under xdist -n 4 load.
+          Under heavy load the stdout_session_id_ready wait (_session_id_timeout, default 1.0s, tests pass 0.01s)
+          and inner drain (0.5s) can each overrun 10x, giving a worst-case total of ~15s well inside 60s.
         """
         from autoskillit.execution.headless import _build_skill_result
 
@@ -305,13 +317,14 @@ class TestChannelBFullPipelineAdjudication:
         result = await run_managed_async(
             [sys.executable, str(script), str(session_dir)],
             cwd=tmp_path,
-            timeout=60,
+            timeout=TimeoutTier.CHANNEL_B,
             session_log_dir=session_dir,
             completion_marker="%%ORDER_UP%%",
             completion_drain_timeout=0.5,
             _phase1_poll=0.01,
             _phase2_poll=0.05,
             _heartbeat_poll=0.05,
+            _session_id_timeout=0.01,
         )
         skill_result = _build_skill_result(
             result,
@@ -348,12 +361,13 @@ class TestChannelBDrainRacePipelineAdjudication:
         result = await run_managed_async(
             [sys.executable, str(script), str(session_dir)],
             cwd=tmp_path,
-            timeout=60,
+            timeout=TimeoutTier.CHANNEL_B,
             session_log_dir=session_dir,
             completion_marker="%%ORDER_UP%%",
             completion_drain_timeout=0.5,
             _phase1_poll=0.01,
             _phase2_poll=0.05,
+            _session_id_timeout=0.01,
         )
 
         assert result.termination == TerminationReason.COMPLETED
@@ -415,7 +429,7 @@ class TestPostExitDrainWindow:
 
         Timing rationale for completion_drain_timeout=30.0:
         - Before channel_b_ready can be set, _watch_session_log must:
-            1. Wait up to 1.0s for stdout_session_id_ready (move_on_after(1.0))
+            1. Wait up to _session_id_timeout for stdout_session_id_ready (default 1.0s, tests pass 0.01s)
             2. Sleep _phase1_poll=1.0s before Phase 1's first check
             3. Sleep _phase2_poll=0.05s before Phase 2's first check
           Total minimum: ~2.05s under normal conditions.
@@ -433,13 +447,14 @@ class TestPostExitDrainWindow:
         result = await run_managed_async(
             [sys.executable, str(script), str(session_dir)],
             cwd=tmp_path,
-            timeout=60,
+            timeout=TimeoutTier.CHANNEL_B,
             session_log_dir=session_dir,
             completion_marker="%%ORDER_UP%%",
             completion_drain_timeout=30.0,
             _phase1_poll=1.0,
             _phase2_poll=0.05,
             _heartbeat_poll=0.05,
+            _session_id_timeout=0.01,
         )
 
         assert result.channel_confirmation == ChannelConfirmation.CHANNEL_B
@@ -476,6 +491,7 @@ class TestPostExitDrainWindow:
             _phase1_poll=0.05,
             _phase2_poll=0.05,
             _heartbeat_poll=0.05,
+            _session_id_timeout=0.01,
         )
 
         assert result.channel_confirmation == ChannelConfirmation.UNMONITORED
@@ -492,6 +508,8 @@ CHANNEL_B_SUB_SKILL_COLLISION_SCRIPT = textwrap.dedent("""\
     session_dir = sys.argv[1]
     unique_marker = sys.argv[2]
     os.makedirs(session_dir, exist_ok=True)
+    sys.stdout.write(json.dumps({"type": "system", "session_id": "session"}) + "\\n")
+    sys.stdout.flush()
     time.sleep(0.1)
     with open(os.path.join(session_dir, "session.jsonl"), "w") as f:
         # Sub-skill emits static marker — should NOT trigger completion
@@ -519,6 +537,15 @@ class TestChannelBSubSkillCollision:
 
     @pytest.mark.anyio
     async def test_channel_b_ignores_sub_skill_marker(self, tmp_path):
+        """Channel B must not trigger on a sub-skill's static %%ORDER_UP%% marker.
+
+        timeout=TimeoutTier.CHANNEL_B (60s): guards against the outer wall-clock
+        expiring under xdist -n 4 load.
+        _watch_session_log waits up to _session_id_timeout (default 1.0s, tests pass 0.01s)
+        for stdout_session_id_ready before Phase 1 starts; under CI load the preamble
+        and Phase 1 polls can overrun, so the outer timeout must exceed
+        _session_id_timeout + _phase1_timeout (30s default) + drain + jitter > 31s.
+        """
         session_dir = tmp_path / "session"
         session_dir.mkdir()
         unique_marker = "%%ORDER_UP::test1234%%"
@@ -528,13 +555,14 @@ class TestChannelBSubSkillCollision:
         result = await run_managed_async(
             [sys.executable, str(script), str(session_dir), unique_marker],
             cwd=tmp_path,
-            timeout=15,
+            timeout=TimeoutTier.CHANNEL_B,
             session_log_dir=session_dir,
             completion_marker=unique_marker,
             completion_drain_timeout=2.0,
             _phase1_poll=0.05,
             _phase2_poll=0.05,
             _heartbeat_poll=0.05,
+            _session_id_timeout=0.01,
         )
 
         assert result.termination == TerminationReason.COMPLETED


### PR DESCRIPTION
## Summary

Implement six coordinated defenses against timing-sensitive async subprocess test flakiness under pytest-xdist. The root cause: Channel B tests in `test_process_channel_b.py` have insufficient timeout headroom for the timing budget (`1s preamble + _phase1_timeout + drain + jitter`). This plan fixes the immediate flaky test, adds centralized timeout tier constants, makes the 1.0s preamble configurable, adds an AST guard to prevent future regressions, injects synthetic `type=system` records into eligible test scripts to eliminate the preamble cost, and corrects documentation about `--dist` mode.

## Requirements

### REQ-FLAKY-001: Fix the immediate flaky test

Change `timeout=15` to `timeout=60` in `test_channel_b_ignores_sub_skill_marker` (`tests/execution/test_process_channel_b.py:531`), matching all sibling tests in `TestChannelBSubSkillCollision` that go through the same Channel B path.

Add the standard xdist load comment explaining the budget math, consistent with the comments at lines 155-158, 291-296, and 416-428 in the same file.

**Also fix 4 latent under-budgeted Channel B tests** that use `timeout=30` when the budget math requires >= 31.5s:
- `test_channel_b_wins_then_channel_a_confirms_within_drain` (line 132)
- `test_data_confirmed_false_set_on_drain_timeout` (line 218)
- `test_channel_b_then_a_empty_result_data_confirmed_is_false` (line 266)
- `test_channel_b_drain_timeout_produces_success_skill_result` (line 351)

These are latent flake risks per the budget math at lines 155-158 (minimum = 31.5s) and should be migrated to `timeout=60`.

### REQ-FLAKY-002: Centralized timeout tier system

Add a timeout tier system to `tests/conftest.py` that encodes the budget math for different test classes:

| Tier | Value | Use Case |
|---|---|---|
| UNIT | 10s | Pure logic tests, no I/O |
| INTEGRATION | 30s | Tests with filesystem or subprocess, no Channel B |
| CHANNEL_B | 60s | Tests going through full `session_log_dir` + Channel B path |

The tier values encode the documented timing budgets from the existing inline comments. The system should be a simple class or module-level constants — not an over-engineered abstraction. Tests should reference the tier constant rather than hardcoding timeout values for Channel B tests where the budget math is non-obvious.

Implementation notes:
- Place in `tests/conftest.py` alongside existing xdist-aware fixtures
- Do NOT retroactively convert all existing timeout values — only require tier constants for the Channel B tier where the budget math is non-obvious
- UNIT and INTEGRATION tiers exist for documentation; hardcoded values in those ranges are acceptable
- The previously proposed RECORDING tier (300s) is removed — those values in `test_recording.py` are arguments forwarded to a mock runner, not test wall-clock budgets
- Tests that deliberately use short timeouts (0.5-3s) to provoke `TIMED_OUT` behavior are not covered by tiers; their values are intentional and correct

### REQ-FLAKY-003: Make `stdout_session_id_ready` preamble timeout configurable

The `_process_race.py:250` hardcoded `anyio.move_on_after(1.0)` is the primary jitter source in tests. Make this timeout configurable via a parameter to `run_managed_async`:

- Add `_session_id_timeout: float = 1.0` parameter (underscore prefix, consistent with existing `_phase1_timeout`, `_phase1_poll`, `_phase2_poll` parameters)
- Tests can pass `_session_id_timeout=0.01` to skip the wait cheaply when the test script doesn't emit `type=system` records
- Production default remains `1.0` — no behavioral change for non-test callers

**Critical implementation constraints:**
- `_session_id_timeout` MUST be keyword-only with a default value. `test_process_monitor.py:1177` calls `_watch_session_log` directly with 13 positional args — adding a new positional arg would break that call.
- The underscore prefix is load-bearing: `test_req_api_001_public_params_present` in `tests/contracts/test_protocol_satisfaction.py:321-347` filters out `k.startswith("_")` when checking the public API surface. A non-underscore name would require updating that contract test.
- `run_managed_sync` does NOT need this parameter — it uses bare `subprocess.Popen` with no Channel B infrastructure.
- Inline comments at lines 156, 295, 418 of `test_process_channel_b.py` cite the 1.0s preamble as part of their budget calculation. These should be updated to reference the default value.

### REQ-FLAKY-004: AST guard for Channel B timeout minimums

Add a structural test that scans `tests/execution/test_process_channel_b.py` (and any future Channel B test files) for `run_managed_async(` calls and asserts that the associated `timeout=` value meets the Channel B minimum (60s).

Implementation approach:
- Parse the test file's AST to find `run_managed_async` call sites
- Extract the `timeout` keyword argument value (`timeout` is always keyword-only due to `*` in `run_managed_async` signature, and always a numeric literal in the codebase)
- Use a compound heuristic to identify Channel B tests: require `session_log_dir` + `completion_marker` + `completion_drain_timeout >= 0.3` to all be present
- Assert `timeout >= TimeoutTier.CHANNEL_B` for matching calls
- Include an explicit exemption set for known-intentional low-timeout Channel B tests (e.g., `test_drain_window_times_out_when_no_session_jsonl` at `timeout=10` with `completion_drain_timeout=0.2`)
- Assert `timeout` is an `ast.Constant` (literal) — if it becomes a variable, emit a separate violation
- Place in `tests/arch/` alongside existing AST-based guards (`test_anyio_migration.py`, `test_subpackage_isolation.py`)

### REQ-FLAKY-005: Make test scripts emit synthetic `type=system` records

Update the test subprocess script literals in `tests/execution/test_process_channel_b.py` to emit a synthetic `type=system` JSONL record to stdout at startup.

**Scripts that CAN receive the synthetic record:**
- `CHANNEL_B_THEN_A_CONFIRM_SCRIPT`
- `CHANNEL_B_THEN_A_EMPTY_RESULT_SCRIPT`
- `PROCESS_EXIT_THEN_CHANNEL_B_FIRES_SCRIPT`
- `CHANNEL_B_SUB_SKILL_COLLISION_SCRIPT`

**Scripts that MUST NOT receive the record:**
- `CHANNEL_B_NO_STDOUT_SCRIPT` — test asserts `not result.stdout.strip()`
- `WRITE_RESULT_THEN_HANG_SCRIPT` — no `session_log_dir` passed
- Inline script in `test_drain_window_times_out_when_no_session_jsonl` — deliberately no session JSONL

### REQ-FLAKY-006: Document `--dist` mode discrepancy

Update `tests/CLAUDE.md` and `.claude/skills/audit-tests/SKILL.md` to document the actual `--dist` mode in use (`load`, the xdist default when `-n 4` is given without `--dist`).

## Architecture Impact

### Concurrency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;

    START([run_managed_async])

    subgraph Setup ["SETUP — Sequential"]
        direction TB
        TempIO["create_temp_io<br/>━━━━━━━━━━<br/>stdout/stderr/stdin<br/>temp files"]
        Spawn["anyio.open_process<br/>━━━━━━━━━━<br/>start_new_session=True<br/>PTY optional"]
        AccInit["● RaceAccumulator()<br/>━━━━━━━━━━<br/>trigger / channel_b_ready<br/>stdout_session_id_ready"]
    end

    subgraph Race ["ANYIO TASK GROUP — Concurrent Coroutines"]
        direction TB
        WP["_watch_process<br/>━━━━━━━━━━<br/>await proc.wait()<br/>→ acc.process_exited<br/>→ process_exited_event.set()"]
        WH["_watch_heartbeat<br/>━━━━━━━━━━<br/>poll stdout NDJSON<br/>(Channel A)<br/>→ acc.channel_a_confirmed"]
        ESI["_extract_stdout_session_id<br/>━━━━━━━━━━<br/>scan type=system record<br/>→ acc.stdout_session_id<br/>→ stdout_session_id_ready"]
        WSL["● _watch_session_log<br/>━━━━━━━━━━<br/>Channel B JSONL monitor<br/>_session_id_timeout wait<br/>→ acc.channel_b_status"]
        WSI["_watch_stdout_idle<br/>━━━━━━━━━━<br/>poll st_size growth<br/>idle_output_timeout<br/>→ acc.idle_stall"]
        TO["anyio.move_on_after(timeout)<br/>━━━━━━━━━━<br/>global wall-clock guard<br/>timeout_scope"]
    end

    subgraph Events ["EVENT COORDINATION"]
        direction LR
        TRG["trigger: anyio.Event<br/>━━━━━━━━━━<br/>First race winner sets<br/>(any of 4 sources)"]
        CBR["channel_b_ready: anyio.Event<br/>━━━━━━━━━━<br/>Channel B deposit<br/>symmetric drain gate"]
        SIR["stdout_session_id_ready<br/>━━━━━━━━━━<br/>Session ID extracted<br/>Channel B preamble"]
    end

    subgraph Guard ["★ TIMEOUT GUARD — AST Enforcement"]
        direction TB
        TT["★ TimeoutTier (conftest.py)<br/>━━━━━━━━━━<br/>UNIT=10s / INTEGRATION=30s<br/>CHANNEL_B=60s"]
        ATG["★ TestChannelBTimeoutGuard<br/>━━━━━━━━━━<br/>AST-scans test_process_channel_b.py<br/>enforces timeout ≥ CHANNEL_B (60s)<br/>exemptions table for short-timeout tests"]
    end

    subgraph Resolution ["RESOLUTION — Sequential after race"]
        direction TB
        SYM["Symmetric Drain<br/>━━━━━━━━━━<br/>process_exited + no Channel B<br/>→ wait channel_b_ready<br/>(completion_drain_timeout)"]
        CANCEL["tg.cancel_scope.cancel()<br/>━━━━━━━━━━<br/>Cancel all remaining<br/>race coroutines"]
        RT["resolve_termination(signals)<br/>━━━━━━━━━━<br/>Pure function<br/>Priority: exit > idle > stale > channel"]
        DTA["decide_termination_action<br/>━━━━━━━━━━<br/>timeout_fired? → IMMEDIATE_KILL<br/>process_exited? → NO_KILL<br/>else → DRAIN / KILL"]
        ETA["execute_termination_action<br/>━━━━━━━━━━<br/>ONLY authorized kill caller<br/>DRAIN_THEN_KILL_IF_ALIVE<br/>awaits process_exited_event"]
        RESULT["SubprocessResult<br/>━━━━━━━━━━<br/>returncode / termination<br/>channel_confirmation<br/>session_id / kill_reason"]
    end

    %% MAIN FLOW %%
    START --> TempIO --> Spawn --> AccInit
    AccInit --> Race

    %% RACE SPAWN %%
    AccInit -->|"fork"| WP
    AccInit -->|"fork"| WH
    AccInit -->|"fork"| ESI
    AccInit -->|"fork (session_log_dir set)"| WSL
    AccInit -->|"fork (idle_output_timeout set)"| WSI
    AccInit --> TO

    %% EVENT WIRING %%
    WP -->|"sets"| TRG
    WH -->|"sets"| TRG
    WSL -->|"sets"| TRG
    WSI -->|"sets"| TRG
    TO -->|"cancelled_caught → TIMED_OUT"| TRG
    WSL -->|"sets"| CBR
    ESI -->|"sets"| SIR
    SIR -.->|"_session_id_timeout wait"| WSL
    WP -->|"sets (before trigger)"| Events

    %% BARRIER %%
    TRG -->|"trigger.wait() returns"| SYM
    SYM --> CANCEL
    CANCEL --> RT
    RT --> DTA
    DTA --> ETA
    ETA --> RESULT

    %% GUARD WIRING %%
    TT -.->|"CHANNEL_B = 60s threshold"| ATG
    ATG -.->|"static AST enforcement"| WSL

    %% CLASS ASSIGNMENTS %%
    class START terminal;
    class TempIO,Spawn,AccInit phase;
    class WP,WH,WSL,WSI handler;
    class ESI handler;
    class TRG,CBR,SIR stateNode;
    class TO detector;
    class SYM,CANCEL,RT,DTA phase;
    class ETA detector;
    class RESULT output;
    class TT,ATG newComponent;
```

### Error/Resilience Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 42, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    START([run_managed_async])

    subgraph ArchGuard ["★ ARCH GUARD — tests/arch/test_channel_b_timeout_guard.py"]
        direction LR
        AST_SCAN["★ AST scan<br/>━━━━━━━━━━<br/>Parse test_process_channel_b.py<br/>Extract run_managed_async calls"]
        IS_CH_B{"★ _is_channel_b_call?<br/>session_log_dir +<br/>completion_marker +<br/>drain >= 0.3s"}
        EXEMPT{"★ In EXEMPTIONS<br/>list?"}
        TIMEOUT_CHECK{"★ timeout literal<br/>>= CHANNEL_B (60s)<br/>or TimeoutTier attr?"}
        STALE_EXEMPT_CHECK["★ Stale exemption guard<br/>━━━━━━━━━━<br/>All EXEMPTIONS keys<br/>still exist in source"]
        VIOLATION([★ AssertionError<br/>violation list])
        PASS_GUARD([★ PASS])
    end

    subgraph TimeoutTiers ["● CENTRALIZED TIMEOUT TIERS — tests/conftest.py::TimeoutTier"]
        UNIT["● UNIT = 10s<br/>━━━━━━━━━━<br/>Pure logic, no I/O"]
        INTEG["● INTEGRATION = 30s<br/>━━━━━━━━━━<br/>Subprocess, no Channel B"]
        CHB_TIER["● CHANNEL_B = 60s<br/>━━━━━━━━━━<br/>session_log_dir + full<br/>Channel B path"]
    end

    subgraph SessionIDRace ["● SESSION ID EXTRACTION — _process_race.py::_extract_stdout_session_id"]
        SID_TASK["● _extract_stdout_session_id<br/>━━━━━━━━━━<br/>Poll stdout for type=system<br/>JSON record (_timeout=10s)"]
        SID_FOUND{"session_id<br/>in record?"}
        SID_READY_SET["● acc.stdout_session_id =<br/>stdout_session_id_ready.set()"]
        SID_TIMEOUT["● extraction timeout<br/>━━━━━━━━━━<br/>ready.set() with empty ID<br/>(fallback: JSONL filename)"]
    end

    subgraph ChannelRace ["CHANNEL RACE — anyio task group"]
        TRIGGER["trigger Event<br/>━━━━━━━━━━<br/>First watcher to<br/>fire wins"]
        WATCH_PROC["_watch_process<br/>━━━━━━━━━━<br/>await proc.wait()<br/>exit_snapshot attempt"]
        WATCH_A["_watch_heartbeat<br/>━━━━━━━━━━<br/>Poll stdout NDJSON<br/>for completion_marker<br/>(Channel A)"]
        WATCH_B["● _watch_session_log<br/>━━━━━━━━━━<br/>Phase 1: wait for JSONL dir<br/>Phase 2: monitor records<br/>(Channel B)"]
        WATCH_IDLE["_watch_stdout_idle<br/>━━━━━━━━━━<br/>Monitor stdout byte growth<br/>(optional)"]
        OUTER_TIMEOUT["move_on_after(timeout)<br/>━━━━━━━━━━<br/>Wall-clock budget<br/>e.g. CHANNEL_B = 60s"]
    end

    subgraph DrainWindows ["DRAIN WINDOWS — bounded recovery waits"]
        DRAIN_B2A["Channel B→A drain<br/>━━━━━━━━━━<br/>B fires COMPLETION:<br/>move_on_after(drain_timeout)<br/>await trigger.wait()"]
        DRAIN_PROC2B["Symmetric drain<br/>━━━━━━━━━━<br/>Process exits first:<br/>move_on_after(drain_timeout)<br/>await channel_b_ready.wait()"]
        SID_WAIT["● Session ID wait<br/>━━━━━━━━━━<br/>move_on_after(_session_id_timeout)<br/>await stdout_session_id_ready"]
    end

    subgraph FailureDetection ["FAILURE DETECTION — resolve_termination()"]
        PROC_EXIT_CHK{"process_exited?<br/>(priority 1)"}
        IDLE_CHK{"idle_stall?<br/>(priority 2)"}
        CHB_STATUS_CHK{"channel_b_status?<br/>(priority 3)"}
        SNAPSHOT_FAIL["exit_snapshot = None<br/>━━━━━━━━━━<br/>/proc already reaped<br/>bare except → log + continue"]
        T_NATURAL([NATURAL_EXIT])
        T_IDLE([IDLE_STALL])
        T_STALE([STALE / DIR_MISSING])
        T_COMPLETED([COMPLETED])
        T_TIMED_OUT([TIMED_OUT])
    end

    subgraph KillDecision ["TERMINATION DECISION — decide_termination_action()"]
        TIMEOUT_FIRED{"timeout_scope<br/>.cancelled_caught?"}
        PROC_EXIT2{"process already<br/>exited?"}
        ACTION_CHK{"termination<br/>reason?"}
        NO_KILL([NO_KILL<br/>natural exit])
        DRAIN_KILL["DRAIN_THEN_KILL_IF_ALIVE<br/>━━━━━━━━━━<br/>grace window then<br/>kill if alive"]
        IMM_KILL["IMMEDIATE_KILL<br/>━━━━━━━━━━<br/>async_kill_process_tree()"]
    end

    subgraph ShieldedCleanup ["SHIELDED CLEANUP — BaseException handler"]
        SHIELD["CancelScope(shield=True)<br/>━━━━━━━━━━<br/>Suspend outer cancel<br/>during cleanup"]
        KILL_TREE["async_kill_process_tree(pid)<br/>━━━━━━━━━━<br/>SIGTERM → SIGKILL<br/>process tree"]
        RERAISE([re-raise])
    end

    RESULT([SubprocessResult<br/>returncode / termination<br/>channel_confirmation<br/>session_id / kill_reason])

    %% ARCH GUARD FLOW %%
    AST_SCAN --> IS_CH_B
    IS_CH_B -->|"not Channel B"| PASS_GUARD
    IS_CH_B -->|"is Channel B"| EXEMPT
    EXEMPT -->|"exempted"| PASS_GUARD
    EXEMPT -->|"not exempted"| TIMEOUT_CHECK
    TIMEOUT_CHECK -->|">= 60s or TimeoutTier attr"| PASS_GUARD
    TIMEOUT_CHECK -->|"< 60s or non-literal"| VIOLATION
    STALE_EXEMPT_CHECK -->|"function missing"| VIOLATION
    STALE_EXEMPT_CHECK -->|"all present"| PASS_GUARD

    %% TIMEOUT TIERS INFORM TESTS %%
    CHB_TIER -->|"timeout=TimeoutTier.CHANNEL_B"| OUTER_TIMEOUT

    %% SESSION ID RACE %%
    START -->|"session_log_dir present"| SID_TASK
    SID_TASK --> SID_FOUND
    SID_FOUND -->|"found within 10s"| SID_READY_SET
    SID_FOUND -->|"10s timeout"| SID_TIMEOUT
    SID_READY_SET --> SID_WAIT
    SID_TIMEOUT --> SID_WAIT

    %% CHANNEL RACE START %%
    START --> WATCH_PROC
    START --> WATCH_A
    START -->|"session_log_dir present"| WATCH_B
    START -->|"idle_output_timeout set"| WATCH_IDLE

    %% SESSION ID WAIT GATES CHANNEL B PHASE 1 %%
    SID_WAIT -->|"_session_id_timeout (●1.0s default)"| WATCH_B

    %% WATCH_PROC side effect %%
    WATCH_PROC -->|"exit detected"| SNAPSHOT_FAIL
    SNAPSHOT_FAIL --> TRIGGER

    %% DRAIN WINDOW BEFORE CHANNEL B SETS TRIGGER %%
    WATCH_B -->|"COMPLETION status"| DRAIN_B2A
    DRAIN_B2A -->|"drain_timeout expires or A already set"| TRIGGER

    WATCH_A -->|"marker found"| TRIGGER
    WATCH_IDLE -->|"stdout stalled"| TRIGGER

    %% OUTER TIMEOUT %%
    OUTER_TIMEOUT -->|"cancelled_caught"| T_TIMED_OUT

    %% SYMMETRIC DRAIN %%
    TRIGGER --> DRAIN_PROC2B
    DRAIN_PROC2B -->|"process_exited + channel_b_status=None"| DRAIN_PROC2B
    DRAIN_PROC2B --> PROC_EXIT_CHK

    %% FAILURE DETECTION %%
    PROC_EXIT_CHK -->|"yes"| T_NATURAL
    PROC_EXIT_CHK -->|"no"| IDLE_CHK
    IDLE_CHK -->|"yes"| T_IDLE
    IDLE_CHK -->|"no"| CHB_STATUS_CHK
    CHB_STATUS_CHK -->|"STALE / DIR_MISSING"| T_STALE
    CHB_STATUS_CHK -->|"COMPLETION"| T_COMPLETED
    CHB_STATUS_CHK -->|"None + channel_a"| T_COMPLETED

    %% KILL DECISION %%
    T_TIMED_OUT --> TIMEOUT_FIRED
    T_NATURAL --> PROC_EXIT2
    T_IDLE --> TIMEOUT_FIRED
    T_STALE --> TIMEOUT_FIRED
    T_COMPLETED --> TIMEOUT_FIRED
    TIMEOUT_FIRED -->|"yes"| IMM_KILL
    TIMEOUT_FIRED -->|"no"| PROC_EXIT2
    PROC_EXIT2 -->|"yes"| NO_KILL
    PROC_EXIT2 -->|"no"| ACTION_CHK
    ACTION_CHK -->|"COMPLETED"| DRAIN_KILL
    ACTION_CHK -->|"IDLE_STALL / STALE"| IMM_KILL
    ACTION_CHK -->|"NATURAL_EXIT"| NO_KILL

    %% SHIELDED CLEANUP %%
    START -->|"BaseException raised"| SHIELD
    SHIELD --> KILL_TREE
    KILL_TREE --> RERAISE

    %% OUTCOME %%
    NO_KILL --> RESULT
    DRAIN_KILL --> RESULT
    IMM_KILL --> RESULT

    %% CLASS ASSIGNMENTS %%
    class START,RESULT terminal;
    class VIOLATION,RERAISE integration;
    class AST_SCAN,IS_CH_B,EXEMPT,TIMEOUT_CHECK,STALE_EXEMPT_CHECK newComponent;
    class PASS_GUARD newComponent;
    class UNIT,INTEG,CHB_TIER stateNode;
    class SID_TASK,SID_READY_SET,SID_TIMEOUT handler;
    class SID_FOUND,SID_WAIT phase;
    class WATCH_PROC,WATCH_A,WATCH_B,WATCH_IDLE handler;
    class TRIGGER,OUTER_TIMEOUT phase;
    class DRAIN_B2A,DRAIN_PROC2B,SID_WAIT output;
    class PROC_EXIT_CHK,IDLE_CHK,CHB_STATUS_CHK,SNAPSHOT_FAIL detector;
    class T_NATURAL,T_IDLE,T_STALE,T_COMPLETED,T_TIMED_OUT gap;
    class TIMEOUT_FIRED,PROC_EXIT2,ACTION_CHK stateNode;
    class NO_KILL output;
    class DRAIN_KILL,IMM_KILL gap;
    class SHIELD,KILL_TREE detector;
```

### Development Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ── STRUCTURE ──────────────────────────────────────────────── %%
    subgraph Structure ["PROJECT STRUCTURE"]
        direction TB
        SRC["src/autoskillit/<br/>━━━━━━━━━━<br/>9 L0–L3 packages"]
        TESTS["tests/<br/>━━━━━━━━━━<br/>13 directories + arch/"]
    end

    %% ── BUILD ──────────────────────────────────────────────────── %%
    subgraph Build ["BUILD TOOLING"]
        direction TB
        PYPROJECT["pyproject.toml<br/>━━━━━━━━━━<br/>hatchling backend<br/>Python ≥ 3.11"]
        TASK["Taskfile.yml<br/>━━━━━━━━━━<br/>task test-all / test-check<br/>task sync-plugin-version"]
        UV["uv lock<br/>━━━━━━━━━━<br/>Dependency lock<br/>uv.lock"]
    end

    %% ── QUALITY ─────────────────────────────────────────────────── %%
    subgraph Quality ["CODE QUALITY GATES  (pre-commit)"]
        direction LR
        FMT["ruff format<br/>━━━━━━━━━━<br/>Auto-fix formatting<br/>WRITES source"]
        LINT["ruff check --fix<br/>━━━━━━━━━━<br/>Auto-fix lint<br/>WRITES source"]
        TYPES["mypy<br/>━━━━━━━━━━<br/>src/ + tests/_test_filter.py<br/>READ-only, reports"]
        LOCKCHK["uv lock --check<br/>━━━━━━━━━━<br/>Verify lock is current<br/>READ-only"]
        SECRETS["gitleaks<br/>━━━━━━━━━━<br/>Secret scanning<br/>READ-only"]
    end

    %% ── TEST FRAMEWORK ──────────────────────────────────────────── %%
    subgraph Testing ["TEST FRAMEWORK"]
        direction TB
        CONFTEST["● conftest.py<br/>━━━━━━━━━━<br/>Shared fixtures<br/>TimeoutTier added"]
        TIMETIER["● TimeoutTier<br/>━━━━━━━━━━<br/>UNIT=10s / INTEGRATION=30s<br/>CHANNEL_B=60s"]
        XDIST["pytest-xdist -n 4<br/>━━━━━━━━━━<br/>Parallel execution<br/>dist=worksteal"]
        ANYIO["pytest-asyncio<br/>━━━━━━━━━━<br/>anyio backend=asyncio<br/>per-function scope"]
        FILTERHOOK["pytest hooks<br/>━━━━━━━━━━<br/>pytest_configure<br/>pytest_collection_modifyitems<br/>path-filter + layer-marker check"]
    end

    %% ── EXECUTION UNDER TEST ────────────────────────────────────── %%
    subgraph ExecLayer ["EXECUTION LAYER  (under test)"]
        direction TB
        PROCRACE["● _process_race.py<br/>━━━━━━━━━━<br/>_watch_session_log<br/>+_session_id_timeout param"]
        PROCESS["● process.py<br/>━━━━━━━━━━<br/>run_managed_async facade<br/>+_session_id_timeout param"]
        RACEACC["RaceAccumulator / RaceSignals<br/>━━━━━━━━━━<br/>Signal-accumulation<br/>for anyio task group"]
    end

    %% ── ARCH GUARDS ─────────────────────────────────────────────── %%
    subgraph ArchGuards ["ARCH / AST GUARDS  (tests/arch/)"]
        direction TB
        CHANBGUARD["★ test_channel_b_timeout_guard.py<br/>━━━━━━━━━━<br/>AST scan: run_managed_async calls<br/>timeout ≥ TimeoutTier.CHANNEL_B"]
        LAYERCHK["test_layer_markers.py<br/>━━━━━━━━━━<br/>pytestmark layer= required<br/>in all source-mirror test files"]
        SIZECHK["test_size_markers.py<br/>━━━━━━━━━━<br/>small/medium/large<br/>marker completeness"]
        ASTCHK["test_ast_rules.py<br/>━━━━━━━━━━<br/>Structural rules:<br/>tmp_path RAM-backed, etc."]
    end

    %% ── CHANNEL B INTEGRATION TESTS ─────────────────────────────── %%
    subgraph ChannelBTests ["CHANNEL B INTEGRATION  (tests/execution/)"]
        direction TB
        CHANBTEST["● test_process_channel_b.py<br/>━━━━━━━━━━<br/>timeout=TimeoutTier.CHANNEL_B<br/>drain-race, adjudication"]
        EXEMPTIONS["EXEMPTIONS dict<br/>━━━━━━━━━━<br/>Allowlist short-timeout tests<br/>(e.g. test_drain_window_times_out…)"]
    end

    %% ── ENTRY POINTS ────────────────────────────────────────────── %%
    subgraph EntryPoints ["ENTRY POINTS"]
        direction LR
        CLI["autoskillit<br/>━━━━━━━━━━<br/>autoskillit.cli:main<br/>serve / init / cook / doctor…"]
    end

    %% ── PIPELINE FLOW ───────────────────────────────────────────── %%
    SRC --> PYPROJECT
    TESTS --> PYPROJECT
    PYPROJECT --> UV
    PYPROJECT --> TASK

    TASK --> FMT
    FMT --> LINT
    LINT --> TYPES
    TYPES --> LOCKCHK
    LOCKCHK --> SECRETS

    SECRETS --> XDIST
    CONFTEST --> TIMETIER
    TIMETIER --> CHANBTEST
    TIMETIER --> CHANBGUARD
    CONFTEST --> FILTERHOOK
    XDIST --> ANYIO

    CHANBGUARD -->|"AST scans"| CHANBTEST
    CHANBTEST --> EXEMPTIONS
    CHANBTEST -->|"tests"| PROCESS
    PROCESS --> PROCRACE
    PROCRACE --> RACEACC

    PYPROJECT --> CLI

    %% CLASS ASSIGNMENTS %%
    class SRC,TESTS cli;
    class PYPROJECT,UV,TASK phase;
    class FMT,LINT detector;
    class TYPES,LOCKCHK,SECRETS detector;
    class CONFTEST,TIMETIER stateNode;
    class XDIST,ANYIO,FILTERHOOK handler;
    class CHANBGUARD newComponent;
    class LAYERCHK,SIZECHK,ASTCHK detector;
    class CHANBTEST,EXEMPTIONS handler;
    class PROCRACE,PROCESS,RACEACC stateNode;
    class CLI output;
```

Closes #1032

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260418-104101-025054/.autoskillit/temp/make-plan/flaky_test_architectural_immunity_plan_2026-04-18_104600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 71 | 11.7k | 858.9k | 63.8k | 1 | 6m 50s |
| review | 3.6k | 7.2k | 193.9k | 51.3k | 1 | 8m 15s |
| verify | 3.2k | 10.5k | 1.2M | 58.8k | 1 | 9m 59s |
| implement | 696 | 37.0k | 7.1M | 105.3k | 1 | 9m 10s |
| prepare_pr | 60 | 8.8k | 193.7k | 32.5k | 1 | 2m 35s |
| run_arch_lenses | 191 | 19.2k | 793.2k | 145.6k | 3 | 6m 16s |
| compose_pr | 67 | 12.5k | 266.1k | 40.4k | 1 | 3m 23s |
| **Total** | 7.9k | 106.9k | 10.6M | 497.7k | | 46m 31s |