### PR TITLE
Add Severity.INFO to StrEnum and update doctor display filter

### DIFF
--- a/src/autoskillit/cli/_doctor.py
+++ b/src/autoskillit/cli/_doctor.py
@@ -24,6 +24,7 @@ from autoskillit.hook_registry import (
 )
 
 _log = get_logger(__name__)
+_NON_PROBLEM: frozenset[Severity] = frozenset({Severity.OK, Severity.INFO})
 
 
 @dataclass
@@ -870,10 +871,10 @@ def run_doctor(*, output_json: bool = False) -> None:
             )
         )
     else:
-        has_problems = any(r.severity != Severity.OK for r in results)
+        has_problems = any(r.severity not in _NON_PROBLEM for r in results)
         if has_problems:
             for r in results:
-                if r.severity != Severity.OK:
+                if r.severity not in _NON_PROBLEM:
                     print(f"{r.severity.upper()}: {r.message}")
         else:
             for r in results:

--- a/src/autoskillit/core/_type_enums.py
+++ b/src/autoskillit/core/_type_enums.py
@@ -170,6 +170,7 @@ class Severity(StrEnum):
     OK = "ok"
     ERROR = "error"
     WARNING = "warning"
+    INFO = "info"
 
 
 class TerminationReason(StrEnum):

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -171,7 +171,17 @@ class TestCLIDoctor:
         captured = capsys.readouterr()
         data = json.loads(captured.out)
         severities = {r["severity"] for r in data["results"]}
-        assert severities <= {"ok", "warning", "error"}
+        assert severities <= {"ok", "warning", "error", "info"}
+
+    def test_doctor_info_severity_not_treated_as_problem(self) -> None:
+        """INFO findings must not appear in the problems section."""
+        from autoskillit.cli._doctor import _NON_PROBLEM
+        from autoskillit.core import Severity
+
+        assert Severity.INFO in _NON_PROBLEM, "INFO must be in _NON_PROBLEM"
+        assert Severity.OK in _NON_PROBLEM, "OK must be in _NON_PROBLEM"
+        assert Severity.ERROR not in _NON_PROBLEM, "ERROR must not be in _NON_PROBLEM"
+        assert Severity.WARNING not in _NON_PROBLEM, "WARNING must not be in _NON_PROBLEM"
 
     def test_doctor_passes_when_versions_match(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -216,7 +216,8 @@ def test_severity_has_ok_member():
     assert Severity.OK == "ok"
     assert Severity.ERROR == "error"
     assert Severity.WARNING == "warning"
-    assert set(Severity) == {Severity.OK, Severity.ERROR, Severity.WARNING}
+    assert Severity.INFO == "info"
+    assert set(Severity) == {Severity.OK, Severity.ERROR, Severity.WARNING, Severity.INFO}
 
 
 def test_github_fetcher_protocol_has_label_methods():


### PR DESCRIPTION
## Summary

Add `INFO = "info"` to the `Severity` StrEnum in `core/_type_enums.py` and update the doctor display logic in `cli/_doctor.py` so that INFO findings are surfaced in the "all clear" output section rather than being treated as problems. Update two test files that have hardcoded Severity member sets.

This is a foundational enum change that unblocks #884 (`_check_campaign_onboarding_hint` doctor check with INFO severity).

## Architecture Impact

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph L0 ["LAYER 0 — core (zero autoskillit imports)"]
        direction LR
        ENUMS["● _type_enums.py<br/>━━━━━━━━━━<br/>Severity(StrEnum)<br/>+ INFO = 'info' ★<br/>RetryReason, MergeState<br/>CliSubtype, PRState, …"]
        CORE_INIT["core/__init__.py<br/>━━━━━━━━━━<br/>Re-export hub<br/>Severity, get_logger<br/>RecipeSource, …"]
    end

    subgraph L1 ["LAYER 1 — config / execution"]
        direction LR
        CONFIG["config/<br/>━━━━━━━━━━<br/>ConfigSchemaError<br/>validate_layer_keys"]
        EXEC["execution/<br/>━━━━━━━━━━<br/>QUOTA_CACHE_SCHEMA_VERSION"]
    end

    subgraph L2 ["LAYER 2 — recipe / migration"]
        direction LR
        RECIPE_RULES["recipe/rules_*.py<br/>━━━━━━━━━━<br/>14 rule modules<br/>all import Severity<br/>(unchanged by PR)"]
        MIGRATION["migration/<br/>━━━━━━━━━━<br/>FailureStore<br/>default_store_path"]
    end

    subgraph L3 ["LAYER 3 — cli / hook_registry"]
        direction LR
        DOCTOR["● cli/_doctor.py<br/>━━━━━━━━━━<br/>_NON_PROBLEM =<br/>  {Severity.OK, Severity.INFO}<br/>run_doctor()"]
        CLI_PEERS["cli peers<br/>━━━━━━━━━━<br/>_hooks, _init_helpers<br/>_install_info<br/>_update_checks<br/>_installed_plugins"]
        HOOK_REG["hook_registry.py<br/>━━━━━━━━━━<br/>canonical_script_basenames<br/>iter_all_scope_paths<br/>_count_hook_registry_drift"]
    end

    %% L0 internal re-export
    ENUMS -->|"provides Severity"| CORE_INIT

    %% L0 → L1 (valid downward)
    CORE_INIT -->|"Severity"| CONFIG
    CORE_INIT -->|"Severity"| EXEC

    %% L0 → L2 (direct core import — 14 rule modules)
    CORE_INIT -->|"Severity ×14 rule modules"| RECIPE_RULES

    %% L1 → L2 (valid downward)
    EXEC -.->|"(indirect)"| RECIPE_RULES

    %% L2 → L3
    MIGRATION -->|"FailureStore"| DOCTOR
    RECIPE_RULES -.->|"(via recipe.list_recipes)"| DOCTOR

    %% L0 → L3 (direct; valid — L3 may import L0)
    CORE_INIT -->|"Severity, get_logger<br/>RecipeSource"| DOCTOR

    %% L1 → L3
    CONFIG -->|"ConfigSchemaError<br/>validate_layer_keys"| DOCTOR
    EXEC -->|"QUOTA_CACHE_SCHEMA_VERSION"| DOCTOR

    %% L3 peers → DOCTOR
    CLI_PEERS -->|"_load_settings_data<br/>_check_dual_mcp_files<br/>detect_install / dismiss"| DOCTOR
    HOOK_REG -->|"canonical_script_basenames<br/>iter_all_scope_paths"| DOCTOR

    %% CLASS ASSIGNMENTS %%
    class ENUMS,CORE_INIT stateNode;
    class CONFIG,EXEC handler;
    class RECIPE_RULES,MIGRATION phase;
    class DOCTOR cli;
    class CLI_PEERS,HOOK_REG integration;
```

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START: autoskillit doctor])
    COMPLETE([COMPLETE])

    subgraph Entry ["CLI Entry"]
        direction TB
        RunDoctor["run_doctor()<br/>━━━━━━━━━━<br/>Collect results list<br/>results: list[DoctorResult]"]
        FlagCheck{"output_json?"}
    end

    subgraph Checks ["Check Execution (17 checks, sequential)"]
        direction TB
        C1["stale_mcp_servers<br/>━━━━━━━━━━<br/>Parse ~/.claude.json<br/>dead cmd paths → ERROR"]
        C2["mcp_server_registered<br/>━━━━━━━━━━<br/>mcpServers entry OR<br/>claude plugin list → OK/WARNING"]
        C3["dual_mcp_registration<br/>━━━━━━━━━━<br/>both registrations? → WARNING"]
        C4["plugin_cache_exists / installed_plugins_entry<br/>━━━━━━━━━━<br/>plugin cache dir + JSON entry"]
        C5["autoskillit_on_path<br/>━━━━━━━━━━<br/>shutil.which() → OK/WARNING"]
        C6["project_config / config_secrets_placement<br/>━━━━━━━━━━<br/>config.yaml present + no secrets"]
        C7["version_consistency<br/>━━━━━━━━━━<br/>pkg_version == plugin.json version"]
        C8["hook_health / hook_registration / hook_registry_drift<br/>━━━━━━━━━━<br/>deployed scripts accessible<br/>all scopes checked"]
        C9["script_version_health<br/>━━━━━━━━━━<br/>failed migrations → ERROR<br/>outdated → WARNING"]
        C10["gitignore_completeness<br/>━━━━━━━━━━<br/>every .autoskillit/ item covered"]
        C11["secret_scanning_hook<br/>━━━━━━━━━━<br/>pre-commit-config has scanner → OK/ERROR"]
        C12["editable_install_source_exists<br/>━━━━━━━━━━<br/>direct_url.json src dir exists"]
        C13["stale_entry_points<br/>━━━━━━━━━━<br/>which -a autoskillit outside ~/.local"]
        C14["source_version_drift<br/>━━━━━━━━━━<br/>installed SHA vs reference SHA (network)"]
        C15["quota_cache_schema<br/>━━━━━━━━━━<br/>schema_version matches constant"]
        C16["claude_process_state<br/>━━━━━━━━━━<br/>ps -axo: D-state processes → WARNING"]
        C17["install_classification / update_dismissal_state<br/>━━━━━━━━━━<br/>direct_url.json + dismissal cache"]
    end

    subgraph SeverityClass ["● Severity Classification (_type_enums.py)"]
        direction LR
        SevOK["Severity.OK<br/>━━━━━━━━━━<br/>check passed"]
        SevINFO["● Severity.INFO<br/>━━━━━━━━━━<br/>informational only<br/>(new value)"]
        SevWARN["Severity.WARNING<br/>━━━━━━━━━━<br/>action recommended"]
        SevERR["Severity.ERROR<br/>━━━━━━━━━━<br/>action required"]
    end

    subgraph DisplayFilter ["● Display Filter (_doctor.py)"]
        direction TB
        NonProblem["● _NON_PROBLEM<br/>━━━━━━━━━━<br/>frozenset{OK, INFO}<br/>(INFO added here)"]
        HasProblems{"any result.severity<br/>not in _NON_PROBLEM?"}
        FilterProblems["Filter: show only<br/>━━━━━━━━━━<br/>severity ∉ {OK, INFO}<br/>i.e. ERROR + WARNING only"]
        ShowAll["Show all results<br/>━━━━━━━━━━<br/>OK + INFO + (no errors)"]
    end

    subgraph Output ["Output"]
        direction LR
        JsonOut["JSON output<br/>━━━━━━━━━━<br/>json.dumps all results<br/>with severity/check/message"]
        TerminalOut["Terminal output<br/>━━━━━━━━━━<br/>severity: message lines"]
    end

    %% MAIN FLOW %%
    START --> RunDoctor
    RunDoctor --> C1 --> C2 --> C3 --> C4 --> C5 --> C6 --> C7 --> C8 --> C9
    C9 --> C10 --> C11 --> C12 --> C13 --> C14 --> C15 --> C16 --> C17
    C1 & C2 & C3 & C4 & C5 & C6 & C7 & C8 & C9 & C10 & C11 & C12 & C13 & C14 & C15 & C16 & C17 -.->|"returns DoctorResult(severity=...)"| SeverityClass

    C17 --> FlagCheck
    FlagCheck -->|"output_json=True"| JsonOut
    FlagCheck -->|"output_json=False"| NonProblem

    SevOK & SevINFO --> NonProblem
    SevWARN & SevERR -.->|"not in _NON_PROBLEM"| HasProblems

    NonProblem --> HasProblems
    HasProblems -->|"yes: has ERROR or WARNING"| FilterProblems
    HasProblems -->|"no: all OK or INFO"| ShowAll
    FilterProblems --> TerminalOut
    ShowAll --> TerminalOut
    JsonOut --> COMPLETE
    TerminalOut --> COMPLETE

    %% CLASS ASSIGNMENTS %%
    class START,COMPLETE terminal;
    class RunDoctor,FlagCheck phase;
    class C1,C2,C3,C4,C5,C6,C7,C8,C9,C10,C11,C12,C13,C14,C15,C16,C17 handler;
    class SevOK,SevINFO,SevWARN,SevERR stateNode;
    class NonProblem,HasProblems detector;
    class FilterProblems,ShowAll phase;
    class JsonOut,TerminalOut output;
```

Closes #1048

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260418-190354-257428/.autoskillit/temp/make-plan/franchise_add_severity_info_plan_2026-04-18_190354.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 83 | 7.1k | 761.9k | 54.8k | 1 | 4m 54s |
| verify | 38 | 8.5k | 835.4k | 43.7k | 1 | 4m 21s |
| implement | 222 | 7.1k | 966.8k | 35.1k | 1 | 2m 12s |
| prepare_pr | 52 | 3.2k | 141.2k | 19.4k | 1 | 1m 10s |
| run_arch_lenses | 122 | 11.1k | 420.8k | 72.7k | 2 | 3m 23s |
| compose_pr | 67 | 9.4k | 211.6k | 34.6k | 1 | 2m 19s |
| **Total** | 584 | 46.4k | 3.3M | 260.3k | | 18m 22s |