### PR TITLE
Implementation Plan: Kitchen-Core Tag Split + Retag Decorators + Backfill requires_packs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ select = ["E", "F", "I", "UP", "TID251"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/execution/test_session_classification_e2e.py" = ["E402"]
+"tests/execution/test_process_channel_b.py" = ["E501"]
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "logging.getLogger" = {msg = "Use get_logger() from autoskillit._logging instead."}

--- a/src/autoskillit/core/_type_constants.py
+++ b/src/autoskillit/core/_type_constants.py
@@ -186,6 +186,7 @@ class PackDef(NamedTuple):
 
 
 PACK_REGISTRY: dict[str, PackDef] = {
+    "kitchen-core": PackDef(True, "Core kitchen orchestration tools"),
     "github": PackDef(True, "GitHub issue and PR tools"),
     "ci": PackDef(True, "CI polling and merge queue tools"),
     "clone": PackDef(True, "Clone-based run isolation tools"),
@@ -229,10 +230,30 @@ TOOL_SUBSET_TAGS: dict[str, frozenset[str]] = {
     "register_clone_status": frozenset({"clone"}),
     "batch_cleanup_clones": frozenset({"clone"}),
     # telemetry
-    "get_token_summary": frozenset({"telemetry"}),
-    "get_timing_summary": frozenset({"telemetry"}),
-    "write_telemetry_files": frozenset({"telemetry"}),
-    "get_quota_events": frozenset({"telemetry"}),
+    "get_token_summary": frozenset({"kitchen-core", "telemetry"}),
+    "get_timing_summary": frozenset({"kitchen-core", "telemetry"}),
+    "write_telemetry_files": frozenset({"kitchen-core", "telemetry"}),
+    "get_quota_events": frozenset({"kitchen-core", "telemetry"}),
+    # kitchen-core — execution
+    "run_cmd": frozenset({"kitchen-core"}),
+    "run_python": frozenset({"kitchen-core"}),
+    "run_skill": frozenset({"kitchen-core"}),
+    # kitchen-core — workspace
+    "test_check": frozenset({"kitchen-core"}),
+    "reset_test_dir": frozenset({"kitchen-core"}),
+    "reset_workspace": frozenset({"kitchen-core"}),
+    "classify_fix": frozenset({"kitchen-core"}),
+    # kitchen-core — recipe
+    "list_recipes": frozenset({"kitchen-core"}),
+    "load_recipe": frozenset({"kitchen-core"}),
+    "validate_recipe": frozenset({"kitchen-core"}),
+    "migrate_recipe": frozenset({"kitchen-core"}),
+    # kitchen-core — status
+    "kitchen_status": frozenset({"kitchen-core"}),
+    "read_db": frozenset({"kitchen-core"}),
+    "get_pipeline_report": frozenset({"kitchen-core"}),
+    # kitchen-core — git
+    "merge_worktree": frozenset({"kitchen-core"}),
 }
 
 # Canonical prefix required for all skill_command values passed to run_skill.

--- a/src/autoskillit/core/_type_constants.py
+++ b/src/autoskillit/core/_type_constants.py
@@ -229,7 +229,7 @@ TOOL_SUBSET_TAGS: dict[str, frozenset[str]] = {
     "remove_clone": frozenset({"clone"}),
     "register_clone_status": frozenset({"clone"}),
     "batch_cleanup_clones": frozenset({"clone"}),
-    # telemetry
+    # kitchen-core — telemetry
     "get_token_summary": frozenset({"kitchen-core", "telemetry"}),
     "get_timing_summary": frozenset({"kitchen-core", "telemetry"}),
     "write_telemetry_files": frozenset({"kitchen-core", "telemetry"}),

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -3,6 +3,7 @@ description: Decompose a source document into sequenced implementation groups, t
 summary: clone > capture_base_sha > set_merge_target > (create_branch?) > make-groups > make-plan > (review-approach?) > dry-walkthrough > implement > test > merge (per group, per plan part) > (audit-impl?) > (open_pr?) > push > (review_pr?) > (ci_watch?) > cleanup
 autoskillit_version: "0.3.0"
 recipe_version: "1.0.0"
+requires_packs: [github, ci, clone, telemetry]
 
 ingredients:
   source_doc:

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -3,6 +3,7 @@ description: Plan, verify, implement, test, and merge a task end-to-end. Use whe
 summary: "[sprint: triage > plan > confirm > dispatch > report] | clone > capture_base_sha > set_merge_target > (create_branch?) > make-plan > (review-approach?) > dry-walkthrough > implement > test > merge (per plan part) > (audit-impl?) > (open_pr?) > push > cleanup"
 autoskillit_version: "0.3.0"
 recipe_version: "1.0.0"
+requires_packs: [github, ci, clone, telemetry]
 
 ingredients:
   task:

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -3,6 +3,7 @@ description: Analyze open PRs, determine merge order, collapse them sequentially
 summary: "clone > setup_remote > analyze_prs > create_integration_branch > [loop per PR: merge_pr or (plan > verify > implement > test > push_worktree_branch > create_conflict_pr > wait_for_conflict_ci > merge_conflict_pr)] > push_integration_branch > collect_artifacts > check_impl_plans > (audit_impl?) > open_integration_pr > wait_for_review_pr_mergeability > check_mergeability > (resolve_integration_conflicts > force_push_after_rebase)? > review_pr_integration > (resolve_review_integration > re_push_review_integration)? > ci_watch_pr > cleanup"
 autoskillit_version: "0.3.0"
 recipe_version: "1.0.0"
+requires_packs: [github, ci, clone, telemetry]
 
 ingredients:
   source_dir:

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -3,6 +3,7 @@ description: Investigate deeply, plan architectural fix, implement and open a PR
 summary: "[sprint: triage > plan > confirm > dispatch > report] | clone > investigate > rectify > dry-walkthrough > implement > test > merge (per plan part) > (audit-impl?) > (open_pr?) > push > cleanup"
 autoskillit_version: "0.3.0"
 recipe_version: "1.0.0"
+requires_packs: [github, ci, clone, telemetry]
 
 kitchen_rules:
   - "NEVER use native Claude Code tools (Read, Grep, Glob, Edit, Write,

--- a/src/autoskillit/server/tools_execution.py
+++ b/src/autoskillit/server/tools_execution.py
@@ -40,7 +40,7 @@ def _is_absolute_path(path: str) -> bool:
     return Path(path).is_absolute()
 
 
-@mcp.tool(tags={"autoskillit", "kitchen"}, annotations={"readOnlyHint": True})
+@mcp.tool(tags={"autoskillit", "kitchen", "kitchen-core"}, annotations={"readOnlyHint": True})
 @track_response_size("run_cmd")
 async def run_cmd(
     cmd: str,
@@ -115,7 +115,7 @@ async def run_cmd(
         )
 
 
-@mcp.tool(tags={"autoskillit", "kitchen"}, annotations={"readOnlyHint": True})
+@mcp.tool(tags={"autoskillit", "kitchen", "kitchen-core"}, annotations={"readOnlyHint": True})
 @track_response_size("run_python")
 async def run_python(
     callable: str,
@@ -170,7 +170,7 @@ async def run_python(
         return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
 
 
-@mcp.tool(tags={"autoskillit", "kitchen"}, annotations={"readOnlyHint": True})
+@mcp.tool(tags={"autoskillit", "kitchen", "kitchen-core"}, annotations={"readOnlyHint": True})
 @track_response_size("run_skill")
 async def run_skill(
     skill_command: str,

--- a/src/autoskillit/server/tools_git.py
+++ b/src/autoskillit/server/tools_git.py
@@ -22,7 +22,7 @@ from autoskillit.server.helpers import (
 logger = get_logger(__name__)
 
 
-@mcp.tool(tags={"autoskillit", "kitchen"}, annotations={"readOnlyHint": True})
+@mcp.tool(tags={"autoskillit", "kitchen", "kitchen-core"}, annotations={"readOnlyHint": True})
 @track_response_size("merge_worktree")
 async def merge_worktree(
     worktree_path: str,
@@ -92,7 +92,7 @@ async def merge_worktree(
         return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
 
 
-@mcp.tool(tags={"autoskillit", "kitchen"}, annotations={"readOnlyHint": True})
+@mcp.tool(tags={"autoskillit", "kitchen", "kitchen-core"}, annotations={"readOnlyHint": True})
 @track_response_size("classify_fix")
 async def classify_fix(
     worktree_path: str,

--- a/src/autoskillit/server/tools_recipe.py
+++ b/src/autoskillit/server/tools_recipe.py
@@ -24,7 +24,7 @@ from autoskillit.server.helpers import (
 logger = get_logger(__name__)
 
 
-@mcp.tool(tags={"autoskillit", "kitchen"}, annotations={"readOnlyHint": True})
+@mcp.tool(tags={"autoskillit", "kitchen", "kitchen-core"}, annotations={"readOnlyHint": True})
 @track_response_size("list_recipes")
 async def list_recipes() -> str:
     """List available recipes from .autoskillit/recipes/.
@@ -60,7 +60,7 @@ async def list_recipes() -> str:
 
 
 @mcp.tool(
-    tags={"autoskillit", "kitchen"},
+    tags={"autoskillit", "kitchen", "kitchen-core"},
     annotations={"readOnlyHint": True},
     meta={"anthropic/maxResultSizeChars": 100_000},
 )
@@ -212,7 +212,7 @@ async def load_recipe(name: str, overrides: dict[str, str] | None = None) -> str
         return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
 
 
-@mcp.tool(tags={"autoskillit", "kitchen"}, annotations={"readOnlyHint": True})
+@mcp.tool(tags={"autoskillit", "kitchen", "kitchen-core"}, annotations={"readOnlyHint": True})
 @track_response_size("validate_recipe")
 async def validate_recipe(script_path: str) -> str:
     """Validate a recipe YAML file against the recipe schema.
@@ -256,7 +256,7 @@ async def validate_recipe(script_path: str) -> str:
         return json.dumps({"valid": False, "errors": [f"{type(exc).__name__}: {exc}"]})
 
 
-@mcp.tool(tags={"autoskillit", "kitchen"}, annotations={"readOnlyHint": True})
+@mcp.tool(tags={"autoskillit", "kitchen", "kitchen-core"}, annotations={"readOnlyHint": True})
 @track_response_size("migrate_recipe")
 async def migrate_recipe(name: str, ctx: Context = CurrentContext()) -> str:
     """Apply pending migration notes to a recipe file.

--- a/src/autoskillit/server/tools_status.py
+++ b/src/autoskillit/server/tools_status.py
@@ -32,7 +32,7 @@ def _get_log_root() -> Path:
     return resolve_log_dir(_get_ctx().config.linux_tracing.log_dir)
 
 
-@mcp.tool(tags={"autoskillit", "kitchen"}, annotations={"readOnlyHint": True})
+@mcp.tool(tags={"autoskillit", "kitchen", "kitchen-core"}, annotations={"readOnlyHint": True})
 @track_response_size("kitchen_status")
 async def kitchen_status() -> str:
     """Return version health and configuration status for the running server.
@@ -79,7 +79,7 @@ async def kitchen_status() -> str:
         return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
 
 
-@mcp.tool(tags={"autoskillit", "kitchen"}, annotations={"readOnlyHint": True})
+@mcp.tool(tags={"autoskillit", "kitchen", "kitchen-core"}, annotations={"readOnlyHint": True})
 @track_response_size("get_pipeline_report")
 async def get_pipeline_report(clear: bool = False) -> str:
     """Return accumulated run_skill failures since last clear.
@@ -148,7 +148,10 @@ def _merge_wall_clock_seconds(steps: list[dict], timing_report: list[dict]) -> l
     return steps
 
 
-@mcp.tool(tags={"autoskillit", "kitchen", "telemetry"}, annotations={"readOnlyHint": True})
+@mcp.tool(
+    tags={"autoskillit", "kitchen", "kitchen-core", "telemetry"},
+    annotations={"readOnlyHint": True},
+)
 @track_response_size("get_token_summary")
 async def get_token_summary(clear: bool = False, format: str = "json", order_id: str = "") -> str:
     """Return accumulated run_skill token usage grouped by step name.
@@ -210,7 +213,10 @@ async def get_token_summary(clear: bool = False, format: str = "json", order_id:
         return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
 
 
-@mcp.tool(tags={"autoskillit", "kitchen", "telemetry"}, annotations={"readOnlyHint": True})
+@mcp.tool(
+    tags={"autoskillit", "kitchen", "kitchen-core", "telemetry"},
+    annotations={"readOnlyHint": True},
+)
 @track_response_size("get_timing_summary")
 async def get_timing_summary(clear: bool = False, format: str = "json", order_id: str = "") -> str:
     """Return accumulated wall-clock timing grouped by step name.
@@ -275,7 +281,10 @@ def _read_quota_events(log_root: Path, n: int) -> tuple[list[dict], int]:
     return list(reversed(events))[:n], total  # most recent first
 
 
-@mcp.tool(tags={"autoskillit", "kitchen", "telemetry"}, annotations={"readOnlyHint": True})
+@mcp.tool(
+    tags={"autoskillit", "kitchen", "kitchen-core", "telemetry"},
+    annotations={"readOnlyHint": True},
+)
 @track_response_size("get_quota_events")
 async def get_quota_events(n: int = 50) -> str:
     """Return the most recent quota guard events from the diagnostic log.
@@ -314,7 +323,10 @@ async def get_quota_events(n: int = 50) -> str:
         return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
 
 
-@mcp.tool(tags={"autoskillit", "kitchen", "telemetry"}, annotations={"readOnlyHint": True})
+@mcp.tool(
+    tags={"autoskillit", "kitchen", "kitchen-core", "telemetry"},
+    annotations={"readOnlyHint": True},
+)
 @track_response_size("write_telemetry_files")
 async def write_telemetry_files(
     output_dir: str,
@@ -396,7 +408,7 @@ async def write_telemetry_files(
         return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
 
 
-@mcp.tool(tags={"autoskillit", "kitchen"}, annotations={"readOnlyHint": True})
+@mcp.tool(tags={"autoskillit", "kitchen", "kitchen-core"}, annotations={"readOnlyHint": True})
 @track_response_size("read_db")
 async def read_db(
     db_path: str,

--- a/src/autoskillit/server/tools_workspace.py
+++ b/src/autoskillit/server/tools_workspace.py
@@ -23,7 +23,9 @@ from autoskillit.server.helpers import (
 logger = get_logger(__name__)
 
 
-@mcp.tool(tags={"autoskillit", "kitchen", "headless"}, annotations={"readOnlyHint": True})
+@mcp.tool(
+    tags={"autoskillit", "kitchen", "kitchen-core", "headless"}, annotations={"readOnlyHint": True}
+)
 @track_response_size("test_check")
 async def test_check(
     worktree_path: str,
@@ -100,7 +102,7 @@ async def test_check(
         return json.dumps({"passed": False, "error": f"{type(exc).__name__}: {exc}"})
 
 
-@mcp.tool(tags={"autoskillit", "kitchen"}, annotations={"readOnlyHint": True})
+@mcp.tool(tags={"autoskillit", "kitchen", "kitchen-core"}, annotations={"readOnlyHint": True})
 @track_response_size("reset_test_dir")
 async def reset_test_dir(
     test_dir: str,
@@ -182,7 +184,7 @@ async def reset_test_dir(
         return json.dumps({"error": f"{type(exc).__name__}: {exc}"})
 
 
-@mcp.tool(tags={"autoskillit", "kitchen"}, annotations={"readOnlyHint": True})
+@mcp.tool(tags={"autoskillit", "kitchen", "kitchen-core"}, annotations={"readOnlyHint": True})
 @track_response_size("reset_workspace")
 async def reset_workspace(test_dir: str, ctx: Context = CurrentContext()) -> str:
     """Runs a configured reset command then deletes directory contents,

--- a/tests/core/test_type_constants.py
+++ b/tests/core/test_type_constants.py
@@ -53,6 +53,14 @@ def test_pack_registry_importable_from_core() -> None:
     assert all(isinstance(v, PackDef) for v in PACK_REGISTRY.values())
 
 
+def test_kitchen_core_in_pack_registry() -> None:
+    """kitchen-core is a registered pack with default_enabled=True."""
+    from autoskillit.core.types import PACK_REGISTRY
+
+    assert "kitchen-core" in PACK_REGISTRY
+    assert PACK_REGISTRY["kitchen-core"].default_enabled is True
+
+
 def test_private_env_vars_includes_franchise_tier_vars() -> None:
     from autoskillit.core import AUTOSKILLIT_PRIVATE_ENV_VARS
 

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -129,7 +129,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/server/tools_kitchen.py", 165),
     ("src/autoskillit/server/tools_kitchen.py", 516),
     # tools_status.py — mcp_data dict
-    ("src/autoskillit/server/tools_status.py", 385),
+    ("src/autoskillit/server/tools_status.py", 397),
     # tools_github.py — bug report dict
     ("src/autoskillit/server/tools_github.py", 268),
     # _hooks.py — settings.json dict (co-owned with Claude CLI)

--- a/tests/recipe/test_api.py
+++ b/tests/recipe/test_api.py
@@ -115,11 +115,12 @@ def test_load_and_validate_includes_requires_packs(tmp_path):
 
 
 # T4d
-def test_load_recipe_result_requires_packs_absent_for_standard_recipe():
-    """Standard recipes without requires_packs omit the key (matches kitchen_rules pattern)."""
+def test_load_recipe_result_requires_packs_absent_for_standard_recipe(tmp_path):
+    """Recipes without requires_packs omit the key (matches kitchen_rules pattern)."""
     from autoskillit.recipe._api import load_and_validate
 
-    result = load_and_validate(name="implementation", project_dir=None)
+    _setup_project_recipe(tmp_path, "test-recipe-no-rules", _RECIPE_NO_RULES)
+    result = load_and_validate(name="test-recipe-no-rules", project_dir=tmp_path)
     assert "requires_packs" not in result
 
 

--- a/tests/recipe/test_bundled_recipes.py
+++ b/tests/recipe/test_bundled_recipes.py
@@ -83,6 +83,15 @@ def _assert_ci_steps(recipe) -> None:
     assert re_push.on_failure == "release_issue_failure"
 
 
+def test_every_bundled_recipe_declares_requires_packs() -> None:
+    """All top-level bundled recipes must declare a non-empty requires_packs."""
+    from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
+
+    for path in sorted(builtin_recipes_dir().glob("*.yaml")):
+        recipe = load_recipe(path)
+        assert recipe.requires_packs, f"{path.name} does not declare requires_packs"
+
+
 # ---------------------------------------------------------------------------
 # TestImplementationPipelineStructure
 # ---------------------------------------------------------------------------

--- a/tests/server/test_server_init.py
+++ b/tests/server/test_server_init.py
@@ -53,6 +53,22 @@ class TestKitchenVisibility:
             # test_check must NOT be visible at startup (has kitchen tag)
             assert "test_check" not in tool_names, "test_check should not be visible at startup"
 
+    @pytest.mark.anyio
+    async def test_redisable_subsets_hides_kitchen_core(self) -> None:
+        """When kitchen-core is in disabled subsets, those tools stay hidden after open_kitchen."""
+        from unittest.mock import AsyncMock
+
+        from autoskillit.server import mcp
+        from autoskillit.server.tools_kitchen import _redisable_subsets
+
+        await mcp.enable_components(tags={"kitchen"})
+
+        mock_ctx = AsyncMock()
+
+        await _redisable_subsets(mock_ctx, ["kitchen-core"])
+
+        mock_ctx.disable_components.assert_called_once_with(tags={"kitchen-core"})
+
 
 class TestGatedToolAccess:
     """Prompt-gated tool access: tools disabled by default, user-only activation."""

--- a/tests/server/test_server_init.py
+++ b/tests/server/test_server_init.py
@@ -58,10 +58,7 @@ class TestKitchenVisibility:
         """When kitchen-core is in disabled subsets, those tools stay hidden after open_kitchen."""
         from unittest.mock import AsyncMock
 
-        from autoskillit.server import mcp
         from autoskillit.server.tools_kitchen import _redisable_subsets
-
-        await mcp.enable_components(tags={"kitchen"})
 
         mock_ctx = AsyncMock()
 

--- a/tests/server/test_server_tool_registration.py
+++ b/tests/server/test_server_tool_registration.py
@@ -181,6 +181,48 @@ class TestToolRegistration:
         for name in kitchen_only:
             assert name not in visible, f"{name} should not be revealed by headless-only enable"
 
+    @pytest.mark.anyio
+    async def test_no_tool_has_bare_kitchen_tag_only(self, kitchen_enabled) -> None:
+        """Every kitchen-tagged tool must also carry kitchen-core or a pack tag."""
+        from autoskillit.core.types import PACK_REGISTRY
+        from autoskillit.server import mcp
+
+        pack_tags = frozenset(PACK_REGISTRY.keys()) | {"headless"}
+        all_tools = {t.name: t for t in await mcp.list_tools()}
+        for tool in all_tools.values():
+            if "kitchen" not in tool.tags:
+                continue
+            has_subtag = bool(tool.tags & pack_tags)
+            assert has_subtag, (
+                f"{tool.name} has 'kitchen' tag but no pack/kitchen-core/headless subtag: "
+                f"{sorted(tool.tags)}"
+            )
+
+    @pytest.mark.anyio
+    async def test_kitchen_core_and_packs_partition_kitchen_gated_tools(
+        self, kitchen_enabled
+    ) -> None:
+        """Every gated/headless tool has kitchen-core and/or a pack tag — full coverage."""
+        from autoskillit.core.types import HEADLESS_TOOLS, PACK_REGISTRY
+        from autoskillit.pipeline.gate import GATED_TOOLS
+        from autoskillit.server import mcp
+
+        all_gated = GATED_TOOLS | HEADLESS_TOOLS
+        pack_tags = frozenset(PACK_REGISTRY.keys())
+
+        all_tools = {t.name: t for t in await mcp.list_tools()}
+        missing: list[str] = []
+        for name in sorted(all_gated):
+            tool = all_tools[name]
+            has_classification = bool(tool.tags & pack_tags)
+            if not has_classification:
+                missing.append(f"{name}: tags={sorted(tool.tags)}")
+
+        assert not missing, (
+            "Tools in GATED_TOOLS|HEADLESS_TOOLS without kitchen-core or pack tag:\n"
+            + "\n".join(f"  {m}" for m in missing)
+        )
+
 
 class TestConfigDrivenBehavior:
     """S1-S10: Verify tools use config instead of hardcoded values."""


### PR DESCRIPTION
## Summary

Split the monolithic `kitchen` tag tier into `kitchen` (umbrella gate, retained on all gated tools) + `kitchen-core` (new subtag for 19 always-needed orchestrator tools). The `kitchen` umbrella tag stays on every gated tool so `mcp.disable(tags={"kitchen"})` and `enable_components(tags={"kitchen"})` continue to work unchanged. `kitchen-core` is added as a new entry in `PACK_REGISTRY` (default_enabled=True) and as an additional decorator tag on 19 core tools. Pack-scoped tools (github/ci/clone) are unchanged. Additionally, backfill `requires_packs` on 4 bundled recipes that currently omit it.

**Key correction (per issue comment):** The original issue body said "drop bare `kitchen`" — the validation review amendment reverses this. ALL gated tools KEEP `kitchen`. `kitchen-core` is additive only.

## Architecture Impact

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 65, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START([PROCESS START])

    subgraph INIT_ONLY_Fields ["INIT_ONLY — Set Once at Registration; Never Mutated"]
        direction TB
        TagRegistry["● Tool Tag Registrations<br/>━━━━━━━━━━<br/>kitchen-core added to:<br/>run_cmd, run_python, run_skill<br/>merge_worktree, classify_fix<br/>list_recipes, load_recipe<br/>validate_recipe, migrate_recipe<br/>kitchen_status, get_*_summary<br/>read_db, get_pipeline_report"]
        TestCheckTag["● test_check Tags<br/>━━━━━━━━━━<br/>kitchen-core + headless<br/>(dual-tag: visible in both<br/>orchestrator & leaf tiers)"]
        PackRegistry["● PACK_REGISTRY<br/>━━━━━━━━━━<br/>kitchen-core: default_enabled=True<br/>github, ci, clone, telemetry<br/>arch-lens, audit, research<br/>exp-lens, vis-lens"]
        ToolSubsetTags["● TOOL_SUBSET_TAGS<br/>━━━━━━━━━━<br/>Canonical tool→category map<br/>kitchen-core: 20+ tools<br/>github: 13 tools, ci: 5 tools<br/>clone: 4 tools, telemetry: 4 tools"]
        HeadlessTools["● HEADLESS_TOOLS<br/>━━━━━━━━━━<br/>frozenset({test_check})<br/>NEVER modify — immutable sentinel"]
        FreeRangeTools["FREE_RANGE_TOOLS<br/>━━━━━━━━━━<br/>open_kitchen, close_kitchen<br/>disable_quota_guard<br/>Always visible — no gate check"]
    end

    subgraph INIT_PRESERVE_Fields ["INIT_PRESERVE — Resolved at Startup; Stable Across Kitchen Cycles"]
        direction TB
        SessionTypeConst["● SESSION_TYPE_* Constants<br/>━━━━━━━━━━<br/>SESSION_TYPE_ENV_VAR<br/>SESSION_TYPE_FRANCHISE<br/>SESSION_TYPE_ORCHESTRATOR<br/>SESSION_TYPE_LEAF<br/>HEADLESS_ENV_VAR<br/>String aliases — no StrEnum import needed"]
        SessionTypeResolved["SessionType (resolved)<br/>━━━━━━━━━━<br/>_resolve_session_type()<br/>reads AUTOSKILLIT_SESSION_TYPE<br/>→ FRANCHISE | ORCHESTRATOR | LEAF"]
        HeadlessFlag["HEADLESS env flag<br/>━━━━━━━━━━<br/>AUTOSKILLIT_HEADLESS == '1'<br/>read once; stable for process lifetime"]
    end

    subgraph SessionTypeDispatch ["GATE 1 — Session-Type Tag Visibility Dispatch (INIT, runs once)"]
        direction TB
        DispatchCheck["_apply_session_type_visibility()<br/>━━━━━━━━━━<br/>_session_type.py<br/>Reads SessionType + HEADLESS"]
        FranchiseBranch["FRANCHISE branch<br/>━━━━━━━━━━<br/>mcp.enable(tags={'franchise'})"]
        OrchestratorBranch["ORCHESTRATOR + HEADLESS<br/>━━━━━━━━━━<br/>mcp.enable(tags={'kitchen'})<br/>→ all kitchen-core tools visible"]
        LeafBranch["● LEAF + HEADLESS branch<br/>━━━━━━━━━━<br/>mcp.enable(tags={'headless'})<br/>→ test_check now visible here<br/>(kitchen-core + headless dual tag)"]
        InteractiveBranch["INTERACTIVE (no pre-reveal)<br/>━━━━━━━━━━<br/>No mcp.enable() at startup<br/>User must call open_kitchen"]
    end

    subgraph MUTABLE_Fields ["MUTABLE — Freely Toggled by Tools"]
        direction TB
        GateState["DefaultGateState.enabled<br/>━━━━━━━━━━<br/>Initial: False<br/>open_kitchen → True<br/>close_kitchen → False<br/>READ on every gated tool call"]
    end

    subgraph ToolCallGates ["GATE 2 — Per-Call Validation (every gated tool invocation)"]
        direction TB
        GateCheck["_require_enabled()<br/>━━━━━━━━━━<br/>gate.enabled == False → gate_error_result()<br/>FAIL-FAST; subtype='gate_error'"]
        HeadlessCheck["_require_not_headless()<br/>━━━━━━━━━━<br/>AUTOSKILLIT_HEADLESS == '1' → headless_error_result()<br/>Blocks orchestration tools in leaf sessions<br/>subtype='headless_error'"]
        SkillCmdCheck["_validate_skill_command()<br/>━━━━━━━━━━<br/>skill_command must start with '/'\<br/>Enforced at hook boundary too"]
    end

    subgraph APPEND_ONLY_Fields ["APPEND_ONLY — Only Grows; Never Truncated"]
        direction TB
        AuditLog["AuditLog entries<br/>━━━━━━━━━━<br/>audit.record_success(skill_command)<br/>appended on run_skill success"]
        TimingLog["TimingLog entries<br/>━━━━━━━━━━<br/>timing_log.record(step_name, elapsed)<br/>appended on each step completion"]
    end

    subgraph DERIVED_Fields ["DERIVED — Computed from Tag + Gate State; Never Stored"]
        direction TB
        EffectiveTools["Effective Visible Tool Set<br/>━━━━━━━━━━<br/>tag enablement ∩ gate state<br/>Computed per MCP request by FastMCP"]
        UngatedAlias["UNGATED_TOOLS alias<br/>━━━━━━━━━━<br/>= FREE_RANGE_TOOLS<br/>(re-export, never modify separately)"]
    end

    END_OK([TOOL CALL PROCEEDS])
    END_GATE([GATE ERROR RETURNED])

    %% FLOW %%
    START --> TagRegistry
    START --> TestCheckTag
    START --> PackRegistry
    START --> ToolSubsetTags
    START --> HeadlessTools
    START --> FreeRangeTools
    START --> SessionTypeConst
    START --> SessionTypeResolved
    START --> HeadlessFlag

    SessionTypeResolved --> DispatchCheck
    HeadlessFlag --> DispatchCheck
    DispatchCheck --> FranchiseBranch
    DispatchCheck --> OrchestratorBranch
    DispatchCheck --> LeafBranch
    DispatchCheck --> InteractiveBranch

    FranchiseBranch --> GateState
    OrchestratorBranch --> GateState
    LeafBranch --> GateState
    InteractiveBranch --> GateState

    GateState --> GateCheck
    HeadlessFlag --> HeadlessCheck
    GateCheck -->|enabled=True| HeadlessCheck
    GateCheck -->|enabled=False| END_GATE
    HeadlessCheck -->|not headless| SkillCmdCheck
    HeadlessCheck -->|is headless| END_GATE
    SkillCmdCheck -->|valid| END_OK
    SkillCmdCheck -->|invalid| END_GATE

    END_OK --> AuditLog
    END_OK --> TimingLog
    TagRegistry --> EffectiveTools
    TestCheckTag --> EffectiveTools
    GateState --> EffectiveTools
    FreeRangeTools --> UngatedAlias

    %% CLASS ASSIGNMENTS %%
    class TagRegistry,TestCheckTag,PackRegistry,ToolSubsetTags,HeadlessTools,FreeRangeTools detector;
    class SessionTypeConst,SessionTypeResolved,HeadlessFlag gap;
    class GateState phase;
    class AuditLog,TimingLog handler;
    class EffectiveTools,UngatedAlias output;
    class DispatchCheck,FranchiseBranch,OrchestratorBranch,LeafBranch,InteractiveBranch stateNode;
    class GateCheck,HeadlessCheck,SkillCmdCheck stateNode;
    class START,END_OK,END_GATE terminal;
```

### Development Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph Build ["BUILD TOOLING"]
        direction TB
        PYPROJECT["● pyproject.toml<br/>━━━━━━━━━━<br/>hatchling build backend<br/>v0.9.55 · 13 runtime deps"]
        UV["uv<br/>━━━━━━━━━━<br/>Package manager<br/>uv.lock integrity check"]
        TASKFILE["Taskfile.yml<br/>━━━━━━━━━━<br/>test-all · test-check<br/>test-filtered · sync-plugin-version<br/>install-worktree · coverage-audit"]
    end

    subgraph Quality ["CODE QUALITY GATES (pre-commit)"]
        direction LR
        RUFF_FMT["ruff format<br/>━━━━━━━━━━<br/>Auto-formats Python<br/>READ + WRITE"]
        RUFF_LINT["ruff check --fix<br/>━━━━━━━━━━<br/>Lint + autofix<br/>READ + WRITE"]
        MYPY["mypy<br/>━━━━━━━━━━<br/>src/ + _test_filter.py<br/>--ignore-missing-imports<br/>READ-ONLY"]
        GITLEAKS["gitleaks v8.30.0<br/>━━━━━━━━━━<br/>Secret scanning<br/>READ-ONLY"]
        UV_LOCK["uv lock --check<br/>━━━━━━━━━━<br/>Lock file consistency<br/>READ-ONLY"]
    end

    subgraph Core ["● CORE: Tag Constant Layer"]
        direction TB
        TYPE_CONST["● _type_constants.py<br/>━━━━━━━━━━<br/>PACK_REGISTRY (10 packs)<br/>TOOL_SUBSET_TAGS<br/>GATED_TOOLS · HEADLESS_TOOLS<br/>FREE_RANGE_TOOLS"]
        PACK_REG["PACK_REGISTRY<br/>━━━━━━━━━━<br/>kitchen-core (enabled)<br/>github · ci · clone · telemetry<br/>arch-lens · audit (enabled)<br/>research · exp-lens · vis-lens (disabled)"]
    end

    subgraph Server ["● SERVER: MCP Tool Registration"]
        direction TB
        TOOLS_EXEC["● tools_execution.py<br/>━━━━━━━━━━<br/>run_cmd · run_python · run_skill<br/>tags: {autoskillit, kitchen, kitchen-core}"]
        TOOLS_GIT["● tools_git.py<br/>━━━━━━━━━━<br/>merge_worktree · classify_fix<br/>tags: kitchen-core<br/>create_unique_branch · check_pr_mergeable<br/>tags: github"]
        TOOLS_RECIPE["● tools_recipe.py<br/>━━━━━━━━━━<br/>list_recipes · load_recipe<br/>validate_recipe · migrate_recipe<br/>tags: {autoskillit, kitchen, kitchen-core}"]
        TOOLS_STATUS["● tools_status.py<br/>━━━━━━━━━━<br/>kitchen_status · get_pipeline_report<br/>read_db · tags: kitchen-core<br/>get_token/timing/quota · write_telemetry<br/>tags: kitchen-core + telemetry"]
        TOOLS_WS["● tools_workspace.py<br/>━━━━━━━━━━<br/>test_check · tags: kitchen-core + headless<br/>reset_test_dir · reset_workspace<br/>tags: kitchen-core"]
    end

    subgraph Recipes ["● RECIPES (modified)"]
        direction LR
        RECIPE_IMPL["● implementation.yaml<br/>● implementation-groups.yaml"]
        RECIPE_MERGE["● merge-prs.yaml<br/>● remediation.yaml"]
    end

    subgraph Testing ["TEST FRAMEWORK (pytest + xdist)"]
        direction TB
        PYTEST_CFG["pytest configuration<br/>━━━━━━━━━━<br/>asyncio_mode=auto · timeout=60s<br/>-n 4 parallel workers<br/>markers: smoke·integration·canary·layer"]
        TEST_CORE["● tests/core/<br/>━━━━━━━━━━<br/>test_type_constants.py<br/>PACK_REGISTRY · CATEGORY_TAGS<br/>kitchen-core membership · exp-lens disabled"]
        TEST_SERVER["● tests/server/<br/>━━━━━━━━━━<br/>test_server_init.py<br/>test_server_tool_registration.py<br/>44 tools registered<br/>kitchen-core rule: no bare kitchen tag"]
        TEST_RECIPE["● tests/recipe/<br/>━━━━━━━━━━<br/>test_api.py<br/>test_bundled_recipes.py<br/>kitchen_rules forbidden-tool coverage"]
        TEST_INFRA["● tests/infra/<br/>━━━━━━━━━━<br/>test_schema_version_convention.py"]
    end

    subgraph EntryPoints ["ENTRY POINTS"]
        direction LR
        CLI["autoskillit CLI<br/>━━━━━━━━━━<br/>autoskillit.cli:main<br/>serve · init · config · doctor · update"]
    end

    %% BUILD FLOW %%
    PYPROJECT --> UV
    PYPROJECT --> TASKFILE

    %% CORE → SERVER DEPENDENCY %%
    TYPE_CONST --> PACK_REG
    TYPE_CONST --> TOOLS_EXEC
    TYPE_CONST --> TOOLS_GIT
    TYPE_CONST --> TOOLS_RECIPE
    TYPE_CONST --> TOOLS_STATUS
    TYPE_CONST --> TOOLS_WS

    %% RECIPES USE SERVER TOOLS %%
    TOOLS_RECIPE --> RECIPE_IMPL
    TOOLS_RECIPE --> RECIPE_MERGE

    %% QUALITY GATE PIPELINE %%
    PYPROJECT --> RUFF_FMT
    RUFF_FMT --> RUFF_LINT
    RUFF_LINT --> MYPY
    MYPY --> GITLEAKS
    GITLEAKS --> UV_LOCK

    %% TEST EXECUTION %%
    TASKFILE --> PYTEST_CFG
    PYTEST_CFG --> TEST_CORE
    PYTEST_CFG --> TEST_SERVER
    PYTEST_CFG --> TEST_RECIPE
    PYTEST_CFG --> TEST_INFRA

    %% TEST → SOURCE COVERAGE %%
    TYPE_CONST -.->|"validates"| TEST_CORE
    TOOLS_EXEC -.->|"validates"| TEST_SERVER
    TOOLS_GIT -.->|"validates"| TEST_SERVER
    TOOLS_RECIPE -.->|"validates"| TEST_RECIPE
    TOOLS_STATUS -.->|"validates"| TEST_SERVER
    TOOLS_WS -.->|"validates"| TEST_SERVER

    %% ENTRY POINT %%
    PYPROJECT --> CLI

    %% CLASS ASSIGNMENTS %%
    class PYPROJECT,UV,TASKFILE phase;
    class TYPE_CONST,PACK_REG stateNode;
    class TOOLS_EXEC,TOOLS_GIT,TOOLS_RECIPE,TOOLS_STATUS,TOOLS_WS handler;
    class RECIPE_IMPL,RECIPE_MERGE output;
    class RUFF_FMT,RUFF_LINT detector;
    class MYPY,GITLEAKS,UV_LOCK detector;
    class PYTEST_CFG phase;
    class TEST_CORE,TEST_SERVER,TEST_RECIPE,TEST_INFRA handler;
    class CLI cli;
```

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef terminal fill:#37474f,stroke:#90a4ae,stroke-width:2px,color:#fff;

    %% ===== L0: CORE FOUNDATION ===== %%
    subgraph L0 ["L0 — CORE FOUNDATION (zero autoskillit imports)"]
        direction LR
        TC["● core/_type_constants<br/>━━━━━━━━━━<br/>GATED_TOOLS, FREE_RANGE_TOOLS<br/>HEADLESS_TOOLS, SKILL_TOOLS<br/>PACK_REGISTRY, TOOL_SUBSET_TAGS<br/>PIPELINE_FORBIDDEN_TOOLS<br/>CATEGORY_TAGS"]
        CTYPES["core/types<br/>━━━━━━━━━━<br/>Re-export shim<br/>from ._type_constants import *"]
        CORE["core/__init__<br/>━━━━━━━━━━<br/>Public surface<br/>~20 consumers downstream"]
    end

    %% ===== L1: PIPELINE ===== %%
    subgraph L1 ["L1 — PIPELINE (imports core only)"]
        direction LR
        GATE["pipeline/gate<br/>━━━━━━━━━━<br/>GATED_TOOLS, UNGATED_TOOLS<br/>DefaultGateState<br/>gate_error_result"]
        PIPEINIT["pipeline/__init__<br/>━━━━━━━━━━<br/>Re-export hub<br/>GATED_TOOLS, UNGATED_TOOLS<br/>ToolContext, TelemetryFormatter"]
    end

    %% ===== L1: CONFIG ===== %%
    subgraph L1C ["L1 — CONFIG"]
        direction LR
        CFG["config/settings<br/>━━━━━━━━━━<br/>Layered resolution<br/>PACK_REGISTRY consumer"]
    end

    %% ===== L2: SERVER INFRASTRUCTURE ===== %%
    subgraph L2INFRA ["L2 — SERVER INFRASTRUCTURE"]
        direction LR
        SRVR["server/__init__<br/>━━━━━━━━━━<br/>FastMCP app bootstrap<br/>mcp.disable(tags={kitchen})<br/>session-type tag dispatch<br/>imports all tools_* modules"]
        HELPERS["server/helpers<br/>━━━━━━━━━━<br/>_require_enabled<br/>_notify, _run_subprocess<br/>track_response_size"]
        STATE["server/_state<br/>━━━━━━━━━━<br/>Lazy init<br/>_startup_ready<br/>_get_ctx_or_none"]
        SGIT["server/git<br/>━━━━━━━━━━<br/>perform_merge<br/>_filter_changed_files"]
    end

    %% ===== L2: SERVER TOOLS (all modified in PR) ===== %%
    subgraph L2TOOLS ["L2 — SERVER TOOLS (● all five modified in PR)"]
        direction TB
        EXEC["● server/tools_execution<br/>━━━━━━━━━━<br/>run_cmd, run_python, run_skill<br/>tags: kitchen + kitchen-core<br/>fan-in: 1 prod + 11 tests"]
        GIT["● server/tools_git<br/>━━━━━━━━━━<br/>merge_worktree, classify_fix<br/>tags: kitchen + kitchen-core<br/>fan-in: 1 prod + 2 tests"]
        RECIPE["● server/tools_recipe<br/>━━━━━━━━━━<br/>list_recipes, load_recipe<br/>validate_recipe, migrate_recipe<br/>tags: kitchen + kitchen-core<br/>GATED_TOOLS, UNGATED_TOOLS consumer<br/>fan-in: 1 prod + 8 tests"]
        STATUS["● server/tools_status<br/>━━━━━━━━━━<br/>kitchen_status, get_timing_summary<br/>get_token_summary, write_telemetry_files<br/>tags: kitchen + kitchen-core/telemetry<br/>fan-in: 1 prod + 4 tests"]
        WKSP["● server/tools_workspace<br/>━━━━━━━━━━<br/>test_check, reset_workspace<br/>reset_test_dir<br/>tags: kitchen + kitchen-core<br/>fan-in: 1 prod + 2 tests"]
    end

    %% ===== L2: RECIPES (data files) ===== %%
    subgraph L2REC ["L2 — RECIPES (data files, no imports)"]
        direction LR
        RYAML["● recipes/*.yaml<br/>━━━━━━━━━━<br/>implementation-groups.yaml<br/>implementation.yaml<br/>merge-prs.yaml<br/>remediation.yaml"]
    end

    %% ===== TESTS ===== %%
    subgraph TESTS ["TESTS (● modified test suites)"]
        direction LR
        TCONST["● tests/core/<br/>test_type_constants"]
        TREC["● tests/recipe/<br/>test_api<br/>test_bundled_recipes"]
        TSRV["● tests/server/<br/>test_server_init<br/>test_server_tool_registration"]
        TINFRA["● tests/infra/<br/>test_schema_version_convention"]
    end

    %% ===== EXTERNAL ===== %%
    EXT["External<br/>━━━━━━━━━━<br/>fastmcp, structlog<br/>stdlib: json, os, pathlib"]

    %% ===== VALID DOWNWARD DEPENDENCIES ===== %%
    TC --> CTYPES
    CTYPES --> CORE
    CORE --> GATE
    CORE --> PIPEINIT
    CORE --> CFG
    GATE --> PIPEINIT

    CORE --> SRVR
    PIPEINIT --> SRVR
    CORE --> HELPERS
    CORE --> STATE
    CORE --> SGIT
    CFG --> SRVR

    %% tools_* → server infrastructure
    CORE --> EXEC
    SRVR --> EXEC
    HELPERS --> EXEC

    CORE --> GIT
    SRVR --> GIT
    HELPERS --> GIT
    SGIT --> GIT

    CORE --> RECIPE
    PIPEINIT --> RECIPE
    CFG --> RECIPE
    SRVR --> RECIPE
    STATE --> RECIPE
    HELPERS --> RECIPE

    CORE --> STATUS
    PIPEINIT --> STATUS
    SRVR --> STATUS
    STATE --> STATUS
    HELPERS --> STATUS

    CORE --> WKSP
    SRVR --> WKSP
    HELPERS --> WKSP

    %% server/__init__ imports all tools_* (side-effect only, @mcp.tool registration)
    SRVR -.->|"side-effect import<br/>@mcp.tool() registration"| EXEC
    SRVR -.->|"side-effect import"| GIT
    SRVR -.->|"side-effect import"| RECIPE
    SRVR -.->|"side-effect import"| STATUS
    SRVR -.->|"side-effect import"| WKSP

    EXT --> EXEC
    EXT --> GIT
    EXT --> RECIPE
    EXT --> STATUS
    EXT --> WKSP

    %% Test dependencies
    TCONST --> TC
    TREC --> RECIPE
    TREC --> RYAML
    TSRV --> SRVR
    TSRV --> EXEC
    TSRV --> GIT
    TSRV --> RECIPE
    TSRV --> STATUS
    TSRV --> WKSP
    TINFRA --> RYAML

    %% CLASS ASSIGNMENTS %%
    class TC stateNode;
    class CTYPES,CORE stateNode;
    class GATE,PIPEINIT phase;
    class CFG phase;
    class SRVR cli;
    class HELPERS,STATE,SGIT handler;
    class EXEC,GIT,RECIPE,STATUS,WKSP handler;
    class RYAML output;
    class TCONST,TREC,TSRV,TINFRA detector;
    class EXT integration;
```

Closes #885

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260418-222142-495754/.autoskillit/temp/make-plan/kitchen_core_tag_split_plan_2026-04-18_223500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 85 | 20.2k | 1.0M | 79.1k | 1 | 10m 13s |
| review | 52 | 13.1k | 1.2M | 37.4k | 1 | 6m 33s |
| verify | 52 | 18.4k | 1.5M | 69.0k | 1 | 8m 56s |
| implement | 448 | 25.5k | 3.1M | 70.9k | 1 | 7m 35s |
| fix | 176 | 9.9k | 975.9k | 53.4k | 1 | 8m 33s |
| prepare_pr | 52 | 6.3k | 149.2k | 28.3k | 1 | 1m 40s |
| run_arch_lenses | 199 | 21.7k | 660.6k | 100.5k | 3 | 9m 15s |
| compose_pr | 59 | 10.9k | 211.2k | 36.2k | 1 | 2m 49s |
| **Total** | 1.1k | 126.0k | 8.9M | 474.9k | | 55m 36s |