### PR TITLE
Implementation Plan: franchise/state.py module (DispatchRecord + state file + resume algorithm)

### DIFF
--- a/src/autoskillit/franchise/__init__.py
+++ b/src/autoskillit/franchise/__init__.py
@@ -1,0 +1,31 @@
+"""Franchise sub-package: campaign dispatch orchestration.
+
+Gateway exports per REQ-IMP-001 — consumers import from
+``autoskillit.franchise``, not from sub-modules.
+"""
+
+from .state import (
+    CampaignState,
+    DispatchRecord,
+    DispatchStatus,
+    ResumeDecision,
+    append_dispatch_record,
+    mark_dispatch_interrupted,
+    mark_dispatch_running,
+    read_state,
+    resume_campaign_from_state,
+    write_initial_state,
+)
+
+__all__ = [
+    "CampaignState",
+    "DispatchRecord",
+    "DispatchStatus",
+    "ResumeDecision",
+    "append_dispatch_record",
+    "mark_dispatch_interrupted",
+    "mark_dispatch_running",
+    "read_state",
+    "resume_campaign_from_state",
+    "write_initial_state",
+]

--- a/src/autoskillit/franchise/state.py
+++ b/src/autoskillit/franchise/state.py
@@ -1,0 +1,286 @@
+"""Campaign state file management — DispatchRecord, atomic writes, resume algorithm.
+
+Provides the single-file state format for franchise campaign execution.
+All writes use core.io.atomic_write for crash-safety (tmp + os.replace).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import asdict, dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+from autoskillit.core import atomic_write, get_logger, write_versioned_json
+
+_log = get_logger(__name__)
+
+_SCHEMA_VERSION = 1
+
+
+class DispatchStatus(StrEnum):
+    """Status of a single dispatch within a campaign."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    SUCCESS = "success"
+    FAILURE = "failure"
+    INTERRUPTED = "interrupted"
+    SKIPPED = "skipped"
+    REFUSED = "refused"
+    RELEASED = "released"
+
+
+@dataclass
+class DispatchRecord:
+    """Runtime state of a single dispatch within a campaign.
+
+    Mutable: status and metadata fields are updated as the dispatch progresses.
+    """
+
+    name: str
+    status: str = DispatchStatus.PENDING
+    dispatch_id: str = ""
+    l2_session_id: str = ""
+    l2_session_log_dir: str = ""
+    l2_pid: int = 0
+    reason: str = ""
+    token_usage: dict[str, Any] = field(default_factory=dict)
+    started_at: float = 0.0
+    ended_at: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class CampaignState:
+    """Top-level campaign state file content."""
+
+    schema_version: int
+    campaign_id: str
+    campaign_name: str
+    manifest_path: str
+    started_at: float
+    dispatches: list[DispatchRecord] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class ResumeDecision:
+    """Result of the resume algorithm."""
+
+    next_dispatch_name: str
+    completed_dispatches_block: str
+
+
+_ALLOWED_TRANSITIONS: dict[str, frozenset[str]] = {
+    DispatchStatus.PENDING: frozenset(
+        {DispatchStatus.RUNNING, DispatchStatus.SKIPPED, DispatchStatus.REFUSED, DispatchStatus.RELEASED}
+    ),
+    DispatchStatus.RUNNING: frozenset(
+        {DispatchStatus.SUCCESS, DispatchStatus.FAILURE, DispatchStatus.INTERRUPTED}
+    ),
+}
+
+
+def _validate_transition(current: str, new: str, dispatch_name: str) -> None:
+    """Raise ValueError if the status transition is not allowed."""
+    allowed = _ALLOWED_TRANSITIONS.get(current)
+    if allowed is not None and new not in allowed:
+        msg = f"Invalid transition for dispatch '{dispatch_name}': {current!r} -> {new!r}"
+        raise ValueError(msg)
+
+
+def write_initial_state(
+    state_path: Path,
+    campaign_id: str,
+    campaign_name: str,
+    manifest_path: str,
+    dispatches: list[DispatchRecord],
+) -> None:
+    """Create the campaign state file with all dispatches in pending status.
+
+    Uses write_versioned_json for schema_version convention compliance.
+    """
+    payload = {
+        "campaign_id": campaign_id,
+        "campaign_name": campaign_name,
+        "manifest_path": manifest_path,
+        "started_at": time.time(),
+        "dispatches": [d.to_dict() for d in dispatches],
+    }
+    write_versioned_json(state_path, payload, schema_version=_SCHEMA_VERSION)
+
+
+def read_state(state_path: Path) -> CampaignState | None:
+    """Load campaign state from disk.
+
+    Returns None on missing file, malformed JSON, or schema mismatch.
+    Never raises.
+    """
+    try:
+        data = json.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    try:
+        dispatches = [
+            DispatchRecord(
+                name=d["name"],
+                status=d.get("status", DispatchStatus.PENDING),
+                dispatch_id=d.get("dispatch_id", ""),
+                l2_session_id=d.get("l2_session_id", ""),
+                l2_session_log_dir=d.get("l2_session_log_dir", ""),
+                l2_pid=d.get("l2_pid", 0),
+                reason=d.get("reason", ""),
+                token_usage=d.get("token_usage", {}),
+                started_at=d.get("started_at", 0.0),
+                ended_at=d.get("ended_at", 0.0),
+            )
+            for d in data["dispatches"]
+        ]
+        return CampaignState(
+            schema_version=data["schema_version"],
+            campaign_id=data["campaign_id"],
+            campaign_name=data["campaign_name"],
+            manifest_path=data["manifest_path"],
+            started_at=data["started_at"],
+            dispatches=dispatches,
+        )
+    except (KeyError, ValueError, TypeError):
+        return None
+
+
+def _write_state(state_path: Path, state: CampaignState) -> None:
+    """Internal: atomic write of full state to disk."""
+    payload = {
+        "campaign_id": state.campaign_id,
+        "campaign_name": state.campaign_name,
+        "manifest_path": state.manifest_path,
+        "started_at": state.started_at,
+        "dispatches": [d.to_dict() for d in state.dispatches],
+        "schema_version": state.schema_version,
+    }
+    atomic_write(state_path, json.dumps(payload))
+
+
+def mark_dispatch_running(
+    state_path: Path,
+    dispatch_name: str,
+    *,
+    dispatch_id: str,
+    l2_pid: int,
+) -> None:
+    """Atomically mark a dispatch as running with its dispatch_id and l2_pid."""
+    state = read_state(state_path)
+    if state is None:
+        raise FileNotFoundError(f"State file not found or corrupted: {state_path}")
+    for d in state.dispatches:
+        if d.name == dispatch_name:
+            _validate_transition(d.status, DispatchStatus.RUNNING, d.name)
+            d.status = DispatchStatus.RUNNING
+            d.dispatch_id = dispatch_id
+            d.l2_pid = l2_pid
+            d.started_at = time.time()
+            break
+    _write_state(state_path, state)
+
+
+def mark_dispatch_interrupted(
+    state_path: Path,
+    dispatch_name: str,
+    *,
+    reason: str,
+) -> None:
+    """Atomically mark a dispatch as interrupted with a reason."""
+    state = read_state(state_path)
+    if state is None:
+        raise FileNotFoundError(f"State file not found or corrupted: {state_path}")
+    for d in state.dispatches:
+        if d.name == dispatch_name:
+            _validate_transition(d.status, DispatchStatus.INTERRUPTED, d.name)
+            d.status = DispatchStatus.INTERRUPTED
+            d.reason = reason
+            d.ended_at = time.time()
+            break
+    _write_state(state_path, state)
+
+
+def append_dispatch_record(
+    state_path: Path,
+    record: DispatchRecord,
+) -> None:
+    """Atomically append or replace a dispatch record by name.
+
+    If a dispatch with the same name exists, it is replaced in-place.
+    Otherwise the record is appended to the end.
+    """
+    state = read_state(state_path)
+    if state is None:
+        raise FileNotFoundError(f"State file not found or corrupted: {state_path}")
+    for i, d in enumerate(state.dispatches):
+        if d.name == record.name:
+            _validate_transition(d.status, record.status, d.name)
+            state.dispatches[i] = record
+            _write_state(state_path, state)
+            return
+    state.dispatches.append(record)
+    _write_state(state_path, state)
+
+
+_COMPLETED_STATUSES = frozenset({DispatchStatus.SUCCESS, DispatchStatus.SKIPPED})
+
+
+def resume_campaign_from_state(
+    state_path: Path,
+    continue_on_failure: bool,
+) -> ResumeDecision | None:
+    """Determine the next dispatch for a resumed campaign.
+
+    Algorithm:
+      1. Read state.json; return None if absent or corrupted.
+      2. Find first dispatch not in {success, skipped}.
+      3. If running exists, mark it interrupted and continue from next.
+      4. If failure exists and continue_on_failure=False, return None
+         with reason franchise_halted_on_failure (encoded via a sentinel).
+      5. Return ResumeDecision with next_dispatch_name and completed block.
+
+    Returns None if the state file is missing/corrupted. Returns a
+    ResumeDecision with next_dispatch_name="" if all dispatches are
+    complete or the campaign is halted.
+    """
+    state = read_state(state_path)
+    if state is None:
+        return None
+
+    # Phase 1: handle any stale "running" dispatch (crash recovery)
+    for d in state.dispatches:
+        if d.status == DispatchStatus.RUNNING:
+            mark_dispatch_interrupted(state_path, d.name, reason="stale_running_on_resume")
+            d.status = DispatchStatus.INTERRUPTED
+            d.reason = "stale_running_on_resume"
+
+    # Phase 2: check for failure halt
+    for d in state.dispatches:
+        if d.status == DispatchStatus.FAILURE and not continue_on_failure:
+            return ResumeDecision(
+                next_dispatch_name="",
+                completed_dispatches_block="franchise_halted_on_failure",
+            )
+
+    # Phase 3: build completed dispatches block and find next
+    completed_lines: list[str] = []
+    next_name = ""
+    for d in state.dispatches:
+        if d.status in _COMPLETED_STATUSES:
+            completed_lines.append(f"- {d.name}: {d.status}")
+        elif not next_name:
+            next_name = d.name
+
+    completed_block = "\n".join(completed_lines) if completed_lines else ""
+
+    return ResumeDecision(
+        next_dispatch_name=next_name,
+        completed_dispatches_block=completed_block,
+    )

--- a/src/autoskillit/franchise/state.py
+++ b/src/autoskillit/franchise/state.py
@@ -13,7 +13,7 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
-from autoskillit.core import atomic_write, get_logger, write_versioned_json
+from autoskillit.core import get_logger, write_versioned_json
 
 _log = get_logger(__name__)
 
@@ -77,7 +77,14 @@ class ResumeDecision:
 
 _ALLOWED_TRANSITIONS: dict[str, frozenset[str]] = {
     DispatchStatus.PENDING: frozenset(
-        {DispatchStatus.RUNNING, DispatchStatus.SKIPPED, DispatchStatus.REFUSED, DispatchStatus.RELEASED}
+        {
+            DispatchStatus.RUNNING,
+            DispatchStatus.SUCCESS,
+            DispatchStatus.FAILURE,
+            DispatchStatus.SKIPPED,
+            DispatchStatus.REFUSED,
+            DispatchStatus.RELEASED,
+        }
     ),
     DispatchStatus.RUNNING: frozenset(
         {DispatchStatus.SUCCESS, DispatchStatus.FAILURE, DispatchStatus.INTERRUPTED}
@@ -160,9 +167,8 @@ def _write_state(state_path: Path, state: CampaignState) -> None:
         "manifest_path": state.manifest_path,
         "started_at": state.started_at,
         "dispatches": [d.to_dict() for d in state.dispatches],
-        "schema_version": state.schema_version,
     }
-    atomic_write(state_path, json.dumps(payload))
+    write_versioned_json(state_path, payload, schema_version=state.schema_version)
 
 
 def mark_dispatch_running(

--- a/src/autoskillit/franchise/state.py
+++ b/src/autoskillit/franchise/state.py
@@ -41,7 +41,7 @@ class DispatchRecord:
     """
 
     name: str
-    status: str = DispatchStatus.PENDING
+    status: DispatchStatus = DispatchStatus.PENDING
     dispatch_id: str = ""
     l2_session_id: str = ""
     l2_session_log_dir: str = ""
@@ -89,6 +89,13 @@ _ALLOWED_TRANSITIONS: dict[str, frozenset[str]] = {
     DispatchStatus.RUNNING: frozenset(
         {DispatchStatus.SUCCESS, DispatchStatus.FAILURE, DispatchStatus.INTERRUPTED}
     ),
+    # Terminal states: no further transitions permitted
+    DispatchStatus.SUCCESS: frozenset(),
+    DispatchStatus.FAILURE: frozenset(),
+    DispatchStatus.INTERRUPTED: frozenset(),
+    DispatchStatus.SKIPPED: frozenset(),
+    DispatchStatus.REFUSED: frozenset(),
+    DispatchStatus.RELEASED: frozenset(),
 }
 
 
@@ -135,7 +142,7 @@ def read_state(state_path: Path) -> CampaignState | None:
         dispatches = [
             DispatchRecord(
                 name=d["name"],
-                status=d.get("status", DispatchStatus.PENDING),
+                status=DispatchStatus(d.get("status", DispatchStatus.PENDING)),
                 dispatch_id=d.get("dispatch_id", ""),
                 l2_session_id=d.get("l2_session_id", ""),
                 l2_session_log_dir=d.get("l2_session_log_dir", ""),
@@ -155,7 +162,8 @@ def read_state(state_path: Path) -> CampaignState | None:
             started_at=data["started_at"],
             dispatches=dispatches,
         )
-    except (KeyError, ValueError, TypeError):
+    except (KeyError, ValueError, TypeError) as exc:
+        _log.warning("read_state: schema mismatch or corrupt payload in %s: %s", state_path, exc)
         return None
 
 
@@ -190,6 +198,8 @@ def mark_dispatch_running(
             d.l2_pid = l2_pid
             d.started_at = time.time()
             break
+    else:
+        raise ValueError(f"Dispatch '{dispatch_name}' not found in state")
     _write_state(state_path, state)
 
 
@@ -210,6 +220,8 @@ def mark_dispatch_interrupted(
             d.reason = reason
             d.ended_at = time.time()
             break
+    else:
+        raise ValueError(f"Dispatch '{dispatch_name}' not found in state")
     _write_state(state_path, state)
 
 

--- a/tests/arch/test_import_paths.py
+++ b/tests/arch/test_import_paths.py
@@ -26,6 +26,7 @@ PACKAGES = frozenset(
         "workspace",
         "recipe",
         "migration",
+        "franchise",
         "config",
         "server",
         "cli",

--- a/tests/execution/test_process_channel_b.py
+++ b/tests/execution/test_process_channel_b.py
@@ -165,6 +165,9 @@ class TestChannelBDrainWait:
         for stdout_session_id_ready before Phase 1 starts;
         under CI load both the preamble and Phase 1 polls can overrun, so the outer
         timeout must exceed _session_id_timeout + _phase1_timeout (30s default) + drain (0.5s) = 31.5s.
+        _phase1_timeout=120: must exceed outer timeout (60s) so that Phase 1 never fires
+        first with STALE when subprocess startup is slow under WSL2 + xdist load; the
+        outer 60s guard cancels all tasks before Phase 1 can timeout independently.
         """
         session_dir = tmp_path / "session"
         session_dir.mkdir()
@@ -181,6 +184,7 @@ class TestChannelBDrainWait:
             _phase1_poll=0.01,
             _phase2_poll=0.05,
             _session_id_timeout=0.01,
+            _phase1_timeout=120,
         )
 
         assert result.termination == TerminationReason.COMPLETED
@@ -216,6 +220,8 @@ class TestChannelBDrainWait:
 
         Verifies that SubprocessResult.data_confirmed is False when the bounded
         drain wait times out — i.e. Channel A never confirmed stdout data.
+        _phase1_timeout=120: must exceed outer timeout (60s) to prevent Phase 1 from
+        firing STALE before the outer guard when subprocess startup is slow under load.
         """
         session_dir = tmp_path / "session"
         session_dir.mkdir()
@@ -232,6 +238,7 @@ class TestChannelBDrainWait:
             _phase1_poll=0.01,
             _phase2_poll=0.05,
             _session_id_timeout=0.01,
+            _phase1_timeout=120,
         )
 
         assert result.termination == TerminationReason.COMPLETED

--- a/tests/franchise/test_franchise.py
+++ b/tests/franchise/test_franchise.py
@@ -13,6 +13,9 @@ def test_franchise_package_importable() -> None:
     """franchise package can be imported without error."""
     import autoskillit.franchise  # noqa: F401
 
+    # Verify gateway exports are accessible
+    from autoskillit.franchise import CampaignState, DispatchRecord, read_state  # noqa: F401
+
 
 def test_asyncio_lock_satisfies_franchise_lock() -> None:
     """asyncio.Lock() is a structural match for FranchiseLock at runtime.

--- a/tests/franchise/test_state.py
+++ b/tests/franchise/test_state.py
@@ -31,7 +31,6 @@ def _state_path(tmp_path: Path) -> Path:
     return tmp_path / "campaign" / "state.json"
 
 
-# --- T1 ---
 class TestInitialState:
     def test_initial_state_file_has_all_dispatches_pending(self, tmp_path: Path) -> None:
         sp = _state_path(tmp_path)
@@ -49,7 +48,6 @@ class TestInitialState:
             assert d.status == DispatchStatus.PENDING
 
 
-# --- T2 ---
 class TestAppendDispatchRecord:
     def test_append_dispatch_record_updates_status(self, tmp_path: Path) -> None:
         sp = _state_path(tmp_path)
@@ -65,7 +63,6 @@ class TestAppendDispatchRecord:
         assert state.dispatches[0].status == DispatchStatus.SUCCESS
 
 
-# --- T3 ---
 class TestAtomicWriteSurvivesPartialTmp:
     def test_atomic_write_survives_partial_tmp_file(self, tmp_path: Path) -> None:
         sp = _state_path(tmp_path)
@@ -96,7 +93,6 @@ class TestAtomicWriteSurvivesPartialTmp:
         assert state.dispatches[0].status == DispatchStatus.RUNNING
 
 
-# --- T4 ---
 class TestResumeSkipsSuccessful:
     def test_resume_skips_successful_dispatches(self, tmp_path: Path) -> None:
         sp = _state_path(tmp_path)
@@ -109,7 +105,6 @@ class TestResumeSkipsSuccessful:
         assert "A" in decision.completed_dispatches_block
 
 
-# --- T5 ---
 class TestResumeMarksRunningInterrupted:
     def test_resume_marks_running_as_interrupted(self, tmp_path: Path) -> None:
         sp = _state_path(tmp_path)
@@ -130,7 +125,6 @@ class TestResumeMarksRunningInterrupted:
         assert decision.next_dispatch_name == "B"
 
 
-# --- T6 ---
 class TestResumeRejectsHaltedOnFailure:
     def test_resume_rejects_if_halted_on_failure_with_no_continue_on_failure(
         self, tmp_path: Path
@@ -146,7 +140,6 @@ class TestResumeRejectsHaltedOnFailure:
         assert "franchise_halted_on_failure" in decision.completed_dispatches_block
 
 
-# --- T7 ---
 class TestAtomicUnderConcurrentRead:
     def test_state_json_atomic_under_concurrent_read(self, tmp_path: Path) -> None:
         sp = _state_path(tmp_path)
@@ -177,7 +170,6 @@ class TestAtomicUnderConcurrentRead:
         assert not errors, f"Concurrent read errors: {errors}"
 
 
-# --- T8 ---
 class TestWriteDiskFull:
     def test_state_write_disk_full(self, tmp_path: Path) -> None:
         sp = _state_path(tmp_path)
@@ -195,7 +187,6 @@ class TestWriteDiskFull:
         assert sp.read_text(encoding="utf-8") == original
 
 
-# --- T9 ---
 class TestReadStateRejectsCorrupted:
     def test_read_state_rejects_corrupted_json(self, tmp_path: Path) -> None:
         sp = _state_path(tmp_path)

--- a/tests/franchise/test_state.py
+++ b/tests/franchise/test_state.py
@@ -1,0 +1,210 @@
+"""Tests for franchise state module (Group J)."""
+
+from __future__ import annotations
+
+import errno
+import json
+import os
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from autoskillit.franchise import (
+    CampaignState,
+    DispatchRecord,
+    DispatchStatus,
+    ResumeDecision,
+    append_dispatch_record,
+    mark_dispatch_interrupted,
+    mark_dispatch_running,
+    read_state,
+    resume_campaign_from_state,
+    write_initial_state,
+)
+
+pytestmark = [pytest.mark.layer("franchise"), pytest.mark.small]
+
+
+def _make_dispatches(*names: str) -> list[DispatchRecord]:
+    return [DispatchRecord(name=n) for n in names]
+
+
+def _state_path(tmp_path: Path) -> Path:
+    return tmp_path / "campaign" / "state.json"
+
+
+# --- T1 ---
+class TestInitialState:
+    def test_initial_state_file_has_all_dispatches_pending(self, tmp_path: Path) -> None:
+        sp = _state_path(tmp_path)
+        dispatches = _make_dispatches("a", "b", "c")
+        write_initial_state(sp, "cid-1", "my-campaign", "/m.yaml", dispatches)
+
+        state = read_state(sp)
+        assert state is not None
+        assert state.schema_version == 1
+        assert state.campaign_id == "cid-1"
+        assert state.campaign_name == "my-campaign"
+        assert state.manifest_path == "/m.yaml"
+        assert len(state.dispatches) == 3
+        for d in state.dispatches:
+            assert d.status == DispatchStatus.PENDING
+
+
+# --- T2 ---
+class TestAppendDispatchRecord:
+    def test_append_dispatch_record_updates_status(self, tmp_path: Path) -> None:
+        sp = _state_path(tmp_path)
+        write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("x", "y"))
+
+        updated = DispatchRecord(name="x", status=DispatchStatus.SUCCESS)
+        append_dispatch_record(sp, updated)
+
+        state = read_state(sp)
+        assert state is not None
+        assert len(state.dispatches) == 2
+        assert state.dispatches[0].name == "x"
+        assert state.dispatches[0].status == DispatchStatus.SUCCESS
+
+
+# --- T3 ---
+class TestAtomicWriteSurvivesPartialTmp:
+    def test_atomic_write_survives_partial_tmp_file(self, tmp_path: Path) -> None:
+        sp = _state_path(tmp_path)
+        write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("a"))
+
+        original = sp.read_text(encoding="utf-8")
+        real_replace = os.replace
+
+        call_count = 0
+
+        def failing_replace(src, dst):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise OSError("simulated crash")
+            return real_replace(src, dst)
+
+        with patch("autoskillit.core.io.os.replace", side_effect=failing_replace):
+            with pytest.raises(OSError, match="simulated crash"):
+                mark_dispatch_running(sp, "a", dispatch_id="d1", l2_pid=42)
+
+        assert sp.read_text(encoding="utf-8") == original
+
+        # Retry succeeds
+        mark_dispatch_running(sp, "a", dispatch_id="d1", l2_pid=42)
+        state = read_state(sp)
+        assert state is not None
+        assert state.dispatches[0].status == DispatchStatus.RUNNING
+
+
+# --- T4 ---
+class TestResumeSkipsSuccessful:
+    def test_resume_skips_successful_dispatches(self, tmp_path: Path) -> None:
+        sp = _state_path(tmp_path)
+        write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("A", "B", "C"))
+        append_dispatch_record(sp, DispatchRecord(name="A", status=DispatchStatus.SUCCESS))
+
+        decision = resume_campaign_from_state(sp, continue_on_failure=True)
+        assert decision is not None
+        assert decision.next_dispatch_name == "B"
+        assert "A" in decision.completed_dispatches_block
+
+
+# --- T5 ---
+class TestResumeMarksRunningInterrupted:
+    def test_resume_marks_running_as_interrupted(self, tmp_path: Path) -> None:
+        sp = _state_path(tmp_path)
+        write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("A", "B", "C"))
+        append_dispatch_record(sp, DispatchRecord(name="A", status=DispatchStatus.SUCCESS))
+        mark_dispatch_running(sp, "B", dispatch_id="d-b", l2_pid=99)
+
+        decision = resume_campaign_from_state(sp, continue_on_failure=True)
+        assert decision is not None
+
+        # B should now be interrupted on disk
+        state = read_state(sp)
+        assert state is not None
+        b = next(d for d in state.dispatches if d.name == "B")
+        assert b.status == DispatchStatus.INTERRUPTED
+
+        # Per algorithm: interrupted is not in {success, skipped}, so B is the next dispatch
+        assert decision.next_dispatch_name == "B"
+
+
+# --- T6 ---
+class TestResumeRejectsHaltedOnFailure:
+    def test_resume_rejects_if_halted_on_failure_with_no_continue_on_failure(
+        self, tmp_path: Path
+    ) -> None:
+        sp = _state_path(tmp_path)
+        write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("A", "B", "C"))
+        append_dispatch_record(sp, DispatchRecord(name="A", status=DispatchStatus.SUCCESS))
+        append_dispatch_record(sp, DispatchRecord(name="B", status=DispatchStatus.FAILURE))
+
+        decision = resume_campaign_from_state(sp, continue_on_failure=False)
+        assert decision is not None
+        assert decision.next_dispatch_name == ""
+        assert "franchise_halted_on_failure" in decision.completed_dispatches_block
+
+
+# --- T7 ---
+class TestAtomicUnderConcurrentRead:
+    def test_state_json_atomic_under_concurrent_read(self, tmp_path: Path) -> None:
+        sp = _state_path(tmp_path)
+        write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("a"))
+
+        barrier = threading.Barrier(2, timeout=5)
+        errors: list[str] = []
+
+        def writer():
+            barrier.wait()
+            mark_dispatch_running(sp, "a", dispatch_id="d1", l2_pid=42)
+
+        def reader():
+            barrier.wait()
+            for _ in range(50):
+                state = read_state(sp)
+                if state is None:
+                    errors.append("read_state returned None (corrupted)")
+                    break
+
+        t_write = threading.Thread(target=writer)
+        t_read = threading.Thread(target=reader)
+        t_write.start()
+        t_read.start()
+        t_write.join(timeout=5)
+        t_read.join(timeout=5)
+
+        assert not errors, f"Concurrent read errors: {errors}"
+
+
+# --- T8 ---
+class TestWriteDiskFull:
+    def test_state_write_disk_full(self, tmp_path: Path) -> None:
+        sp = _state_path(tmp_path)
+        write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("a"))
+
+        original = sp.read_text(encoding="utf-8")
+
+        def enospc_replace(src, dst):
+            raise OSError(errno.ENOSPC, "No space left on device")
+
+        with patch("autoskillit.core.io.os.replace", side_effect=enospc_replace):
+            with pytest.raises(OSError):
+                mark_dispatch_running(sp, "a", dispatch_id="d1", l2_pid=42)
+
+        assert sp.read_text(encoding="utf-8") == original
+
+
+# --- T9 ---
+class TestReadStateRejectsCorrupted:
+    def test_read_state_rejects_corrupted_json(self, tmp_path: Path) -> None:
+        sp = _state_path(tmp_path)
+        sp.parent.mkdir(parents=True, exist_ok=True)
+        sp.write_bytes(b"not valid json {{{")
+
+        result = read_state(sp)
+        assert result is None

--- a/tests/franchise/test_state.py
+++ b/tests/franchise/test_state.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import errno
-import json
 import os
 import threading
 from pathlib import Path
@@ -12,12 +11,9 @@ from unittest.mock import patch
 import pytest
 
 from autoskillit.franchise import (
-    CampaignState,
     DispatchRecord,
     DispatchStatus,
-    ResumeDecision,
     append_dispatch_record,
-    mark_dispatch_interrupted,
     mark_dispatch_running,
     read_state,
     resume_campaign_from_state,


### PR DESCRIPTION
## Summary

New `src/autoskillit/franchise/state.py` module consolidating the campaign state file format, `DispatchRecord` dataclass, atomic write helpers, and resume algorithm. This is the schema-level foundation that downstream tickets (#869, #870, #874, #876, #883, #888) consume for CLI resume, L3 prompt injection, dispatch recording, signal handling, status reporting, and e2e tests.

The module introduces:
- `DispatchStatus` StrEnum with 8 statuses
- `DispatchRecord` mutable dataclass matching D10 amendment schema
- `CampaignState` dataclass as the top-level state wrapper
- `ResumeDecision` frozen dataclass for resume algorithm output
- 6 public functions: `write_initial_state`, `mark_dispatch_running`, `mark_dispatch_interrupted`, `append_dispatch_record`, `read_state`, `resume_campaign_from_state`
- All writes via `core.io.atomic_write` / `write_versioned_json` for crash-safety
- Gateway exports from `franchise/__init__.py` per REQ-IMP-001

## Architecture Impact

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph CampaignFields ["★ CampaignState — Field Contracts (state.py)"]
        direction TB
        CF_INIT["INIT_ONLY — Set once, never modified<br/>━━━━━━━━━━<br/>schema_version · campaign_id<br/>campaign_name · manifest_path · started_at"]
        CF_APPEND["APPEND_ONLY — Append or in-place replace<br/>━━━━━━━━━━<br/>dispatches: list[DispatchRecord]"]
    end

    subgraph DispatchFields ["★ DispatchRecord — Field Contracts (state.py)"]
        direction TB
        DR_INIT["INIT_ONLY — Identity key for lookup<br/>━━━━━━━━━━<br/>name: str"]
        DR_MUTABLE["MUTABLE — Updated on each validated transition<br/>━━━━━━━━━━<br/>status · dispatch_id · l2_session_id<br/>l2_session_log_dir · l2_pid<br/>reason · token_usage · started_at · ended_at"]
    end

    subgraph ValidationGate ["★ Transition Validation Gate (_validate_transition)"]
        direction TB
        ALLOWED["_ALLOWED_TRANSITIONS table<br/>━━━━━━━━━━<br/>PENDING → {RUNNING, SUCCESS,<br/>FAILURE, SKIPPED, REFUSED, RELEASED}<br/>RUNNING → {SUCCESS, FAILURE, INTERRUPTED}"]
        TERMINAL["Terminal States — no outgoing transitions<br/>━━━━━━━━━━<br/>SUCCESS · FAILURE · INTERRUPTED<br/>SKIPPED · REFUSED · RELEASED"]
        VIOLATION["ValueError raised<br/>━━━━━━━━━━<br/>Invalid transition blocked<br/>before any disk write occurs"]
    end

    subgraph WriteLayer ["★ Atomic Write Mechanism (state.py → core.io)"]
        direction TB
        WRITE_FN["write_versioned_json()<br/>━━━━━━━━━━<br/>tmp file + os.replace<br/>schema_version=1 embedded on every write"]
        READ_FN["read_state() — never raises<br/>━━━━━━━━━━<br/>Returns None on:<br/>OSError · JSONDecodeError<br/>KeyError · schema mismatch"]
    end

    subgraph PublicAPI ["● franchise/__init__.py — Exported Public Surface"]
        direction LR
        WRITE_INIT["write_initial_state()<br/>━━━━━━━━━━<br/>Creates state file<br/>all dispatches=PENDING"]
        MARK_RUN["mark_dispatch_running()<br/>━━━━━━━━━━<br/>Sets dispatch_id, l2_pid<br/>started_at"]
        MARK_INT["mark_dispatch_interrupted()<br/>━━━━━━━━━━<br/>Sets reason<br/>ended_at"]
        APPEND_REC["append_dispatch_record()<br/>━━━━━━━━━━<br/>Replace in-place or append<br/>validates transition"]
        RESUME_FN["resume_campaign_from_state()<br/>━━━━━━━━━━<br/>3-phase resume algorithm<br/>Returns ResumeDecision | None"]
    end

    subgraph ResumeAlgo ["★ resume_campaign_from_state() — 3-Phase Algorithm"]
        direction TB
        PH1["Phase 1: Crash Recovery<br/>━━━━━━━━━━<br/>Stale RUNNING → INTERRUPTED<br/>reason: stale_running_on_resume"]
        PH2["Phase 2: Failure Halt Check<br/>━━━━━━━━━━<br/>FAILURE + continue_on_failure=False<br/>→ sentinel: 'franchise_halted_on_failure'"]
        PH3["Phase 3: Next Dispatch Resolution<br/>━━━━━━━━━━<br/>Build completed block from<br/>{SUCCESS, SKIPPED} dispatches<br/>→ first non-completed dispatch name"]
    end

    subgraph ResumeOut ["★ ResumeDecision — Derived Output (frozen dataclass)"]
        direction TB
        RD["ResumeDecision (frozen=True)<br/>━━━━━━━━━━<br/>next_dispatch_name: str<br/>completed_dispatches_block: str<br/>DERIVED — never written to state file"]
    end

    %% CONNECTIONS %%
    CF_INIT -->|"written once by write_initial_state"| WRITE_FN
    CF_APPEND -->|"grown by append_dispatch_record"| APPEND_REC
    DR_INIT -->|"lookup key"| ALLOWED
    DR_MUTABLE -->|"mutated then validated"| ALLOWED
    ALLOWED -->|"transition valid"| WRITE_FN
    ALLOWED -->|"transition invalid"| VIOLATION
    TERMINAL -->|"no further writes permitted"| VIOLATION

    WRITE_INIT --> WRITE_FN
    MARK_RUN --> ALLOWED
    MARK_INT --> ALLOWED
    APPEND_REC --> ALLOWED
    RESUME_FN --> PH1

    READ_FN -->|"loads current state before every mutation"| PH1
    PH1 -->|"calls mark_dispatch_interrupted"| MARK_INT
    PH1 --> PH2
    PH2 --> PH3
    PH2 -->|"halt sentinel"| RD
    PH3 -->|"next_dispatch_name + completed_block"| RD

    %% CLASS ASSIGNMENTS %%
    class CF_INIT detector;
    class CF_APPEND handler;
    class DR_INIT detector;
    class DR_MUTABLE phase;
    class ALLOWED stateNode;
    class TERMINAL gap;
    class VIOLATION detector;
    class WRITE_FN output;
    class READ_FN stateNode;
    class WRITE_INIT,MARK_RUN,MARK_INT,APPEND_REC,RESUME_FN newComponent;
    class PH1,PH2,PH3 phase;
    class RD output;
```

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph Layer0 ["L0 — FOUNDATION (core/)"]
        direction LR
        CORE_IO["core.io<br/>━━━━━━━━━━<br/>write_versioned_json<br/>atomic_write"]
        CORE_LOG["core.logging<br/>━━━━━━━━━━<br/>get_logger"]
        CORE_INIT["core/__init__.py<br/>━━━━━━━━━━<br/>Re-export hub<br/>for all L0 symbols"]
    end

    subgraph Layer2 ["L2 — BUSINESS LOGIC (franchise/)"]
        direction TB
        FRAN_INIT["● franchise/__init__.py<br/>━━━━━━━━━━<br/>Gateway re-export<br/>REQ-IMP-001 compliant<br/>Exports all public API"]
        FRAN_STATE["★ franchise/state.py<br/>━━━━━━━━━━<br/>DispatchStatus, DispatchRecord<br/>CampaignState, ResumeDecision<br/>write_initial_state, read_state<br/>mark_dispatch_running<br/>mark_dispatch_interrupted<br/>append_dispatch_record<br/>resume_campaign_from_state"]
    end

    subgraph TestLayer ["TESTS"]
        direction TB
        TEST_STATE["★ tests/franchise/test_state.py<br/>━━━━━━━━━━<br/>mark=layer(franchise), small<br/>State lifecycle + resume algo"]
        TEST_FRAN["● tests/franchise/test_franchise.py<br/>━━━━━━━━━━<br/>Updated franchise integration<br/>imports CampaignState, DispatchRecord"]
        TEST_IMPORT["● tests/arch/test_import_paths.py<br/>━━━━━━━━━━<br/>PACKAGES frozenset now<br/>includes 'franchise'<br/>REQ-IMP-001 enforcement"]
        TEST_CHAN_B["● tests/execution/test_process_channel_b.py<br/>━━━━━━━━━━<br/>Phase 1 STALE race fix<br/>(xdist load stability)"]
    end

    %% INTERNAL CORE STRUCTURE %%
    CORE_IO --> CORE_INIT
    CORE_LOG --> CORE_INIT

    %% FRANCHISE STATE IMPORTS (downward — valid L2→L0) %%
    FRAN_STATE -->|"from autoskillit.core import<br/>get_logger, write_versioned_json"| CORE_INIT

    %% FRANCHISE GATEWAY RE-EXPORTS (internal, same package) %%
    FRAN_INIT -->|"from .state import ..."| FRAN_STATE

    %% TEST IMPORTS — via gateway only (REQ-IMP-001 compliant) %%
    TEST_STATE -->|"from autoskillit.franchise import ..."| FRAN_INIT
    TEST_FRAN -->|"from autoskillit.franchise import ..."| FRAN_INIT

    %% ARCH ENFORCEMENT %%
    TEST_IMPORT -.->|"AST-scans franchise/<br/>for sub-module imports"| Layer2

    %% CLASS ASSIGNMENTS %%
    class CORE_IO,CORE_LOG,CORE_INIT stateNode;
    class FRAN_INIT phase;
    class FRAN_STATE newComponent;
    class TEST_STATE newComponent;
    class TEST_FRAN,TEST_IMPORT,TEST_CHAN_B handler;
```

Closes #889

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260419-071200-416641/.autoskillit/temp/make-plan/franchise_state_module_plan_2026-04-19_071500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 99 | 18.4k | 1.2M | 79.8k | 1 | 7m 15s |
| review | 3.5k | 6.3k | 215.1k | 39.2k | 1 | 4m 49s |
| verify | 452 | 13.8k | 1.4M | 64.3k | 1 | 5m 30s |
| implement | 198 | 10.8k | 1.3M | 59.2k | 1 | 3m 14s |
| fix | 588 | 51.0k | 4.6M | 166.0k | 2 | 27m 45s |
| prepare_pr | 52 | 4.0k | 169.2k | 29.6k | 1 | 1m 12s |
| run_arch_lenses | 169 | 13.1k | 585.3k | 68.6k | 2 | 4m 10s |
| compose_pr | 51 | 6.3k | 154.2k | 25.1k | 1 | 1m 52s |
| **Total** | 5.1k | 123.6k | 9.7M | 531.7k | | 55m 51s |