### PR TITLE
Resilient Plugin Cache Lifecycle — Grace Period, Install Locking, Kitchen-Open Guard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,7 @@ generic_automation_mcp/
 │   ├── claude_conventions.py #  Skill discovery directory layout constants
 │   ├── github_url.py        #   parse_github_repo
 │   ├── kitchen_state.py     #   Kitchen-open session marker (stdlib-only; readable from hooks)
+│   ├── _plugin_cache.py     #   Plugin cache lifecycle: retiring cache, install locking, kitchen registry
 │   └── readiness.py         #   Filesystem readiness sentinel primitives for MCP server startup (L0)
 │
 ├── config/                  # L1

--- a/src/autoskillit/cli/_marketplace.py
+++ b/src/autoskillit/cli/_marketplace.py
@@ -38,6 +38,10 @@ def _clear_plugin_cache() -> None:
         from autoskillit.core import _retire_old_versions
 
         _retire_old_versions(cache_dir, _new_version)
+    else:
+        from autoskillit.core import sweep_retiring_cache
+
+        sweep_retiring_cache()
 
     from autoskillit.cli._installed_plugins import InstalledPluginsFile
 

--- a/src/autoskillit/cli/_marketplace.py
+++ b/src/autoskillit/cli/_marketplace.py
@@ -35,7 +35,7 @@ def _clear_plugin_cache() -> None:
     cache_dir = Path.home() / ".claude" / "plugins" / "cache" / _MARKETPLACE_NAME / "autoskillit"
     if cache_dir.is_dir():
         from autoskillit import __version__ as _new_version
-        from autoskillit.cli._plugin_cache import _retire_old_versions
+        from autoskillit.core import _retire_old_versions
 
         _retire_old_versions(cache_dir, _new_version)
 
@@ -158,7 +158,7 @@ def install(*, scope: str = "user") -> bool:
 
     _ensure_workspace_ready()
 
-    from autoskillit.cli._plugin_cache import _InstallLock
+    from autoskillit.core import _InstallLock
 
     with _InstallLock():
         _clear_plugin_cache()

--- a/src/autoskillit/cli/_marketplace.py
+++ b/src/autoskillit/cli/_marketplace.py
@@ -34,7 +34,10 @@ def _clear_plugin_cache() -> None:
     """
     cache_dir = Path.home() / ".claude" / "plugins" / "cache" / _MARKETPLACE_NAME / "autoskillit"
     if cache_dir.is_dir():
-        shutil.rmtree(cache_dir)
+        from autoskillit import __version__ as _new_version
+        from autoskillit.cli._plugin_cache import _retire_old_versions
+
+        _retire_old_versions(cache_dir, _new_version)
 
     from autoskillit.cli._installed_plugins import InstalledPluginsFile
 
@@ -154,36 +157,40 @@ def install(*, scope: str = "user") -> bool:
         sys.exit(1)
 
     _ensure_workspace_ready()
-    _clear_plugin_cache()
 
-    # Regenerate hooks.json from the canonical registry with absolute paths
-    hooks_json_path = pkg_root() / "hooks" / "hooks.json"
-    atomic_write(hooks_json_path, json.dumps(generate_hooks_json(), indent=2) + "\n")
+    from autoskillit.cli._plugin_cache import _InstallLock
 
-    # Register the marketplace (idempotent)
-    result = subprocess.run(
-        ["claude", "plugin", "marketplace", "add", str(marketplace_dir)],
-        capture_output=True,
-        text=True,
-        stdin=subprocess.DEVNULL,
-        timeout=30,
-    )
-    if result.returncode != 0:
-        print(f"Failed to register marketplace: {result.stderr.strip()}")
-        sys.exit(1)
-    print("Marketplace registered.")
+    with _InstallLock():
+        _clear_plugin_cache()
 
-    # Install the plugin
-    result = subprocess.run(
-        ["claude", "plugin", "install", plugin_ref, "--scope", scope],
-        capture_output=True,
-        text=True,
-        stdin=subprocess.DEVNULL,
-        timeout=30,
-    )
-    if result.returncode != 0:
-        print(f"Failed to install plugin: {result.stderr.strip()}")
-        sys.exit(1)
+        # Regenerate hooks.json from the canonical registry with absolute paths
+        hooks_json_path = pkg_root() / "hooks" / "hooks.json"
+        atomic_write(hooks_json_path, json.dumps(generate_hooks_json(), indent=2) + "\n")
+
+        # Register the marketplace (idempotent)
+        result = subprocess.run(
+            ["claude", "plugin", "marketplace", "add", str(marketplace_dir)],
+            capture_output=True,
+            text=True,
+            stdin=subprocess.DEVNULL,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            print(f"Failed to register marketplace: {result.stderr.strip()}")
+            sys.exit(1)
+        print("Marketplace registered.")
+
+        # Install the plugin
+        result = subprocess.run(
+            ["claude", "plugin", "install", plugin_ref, "--scope", scope],
+            capture_output=True,
+            text=True,
+            stdin=subprocess.DEVNULL,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            print(f"Failed to install plugin: {result.stderr.strip()}")
+            sys.exit(1)
 
     print(f"Plugin installed: {plugin_ref} (scope: {scope})")
     if evict_direct_mcp_entry(_user_claude_json_path()):

--- a/src/autoskillit/cli/_plugin_cache.py
+++ b/src/autoskillit/cli/_plugin_cache.py
@@ -1,0 +1,251 @@
+"""Plugin cache lifecycle: retiring cache, install locking, kitchen registry."""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import shutil
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import IO
+
+import psutil
+
+from autoskillit.core import atomic_write, write_versioned_json
+from autoskillit.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+_SCHEMA_VERSION = 1
+
+
+def _autoskillit_home() -> Path:
+    return Path.home() / ".autoskillit"
+
+
+def _retiring_cache_path() -> Path:
+    return _autoskillit_home() / "retiring_cache.json"
+
+
+def _retiring_cache_lock() -> Path:
+    return _autoskillit_home() / "retiring_cache.lock"
+
+
+def _active_kitchens_path() -> Path:
+    return _autoskillit_home() / "active_kitchens.json"
+
+
+def _active_kitchens_lock() -> Path:
+    return _autoskillit_home() / "active_kitchens.lock"
+
+
+def _install_lock_path() -> Path:
+    return _autoskillit_home() / "install.lock"
+
+
+def _open_lock(lock_path: Path) -> IO[str]:
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fh = open(lock_path, "w")
+    try:
+        fcntl.flock(fh, fcntl.LOCK_EX)
+    except BaseException:
+        fh.close()
+        raise
+    return fh
+
+
+def append_retiring_entry(version: str, path: str) -> None:
+    lock = _retiring_cache_lock()
+    cache = _retiring_cache_path()
+    fh = _open_lock(lock)
+    try:
+        entries: list[dict[str, str]] = []
+        if cache.exists():
+            try:
+                entries = json.loads(cache.read_text()).get("retiring", [])
+            except (json.JSONDecodeError, AttributeError):
+                entries = []
+        entries.append({"version": version, "path": path, "retired_at": datetime.now(UTC).isoformat()})
+        write_versioned_json(cache, {"retiring": entries}, schema_version=_SCHEMA_VERSION)
+    finally:
+        fh.close()
+
+
+def sweep_retiring_cache(grace_hours: int = 2) -> int:
+    cache = _retiring_cache_path()
+    lock = _retiring_cache_lock()
+    if not cache.exists():
+        return 0
+    fh = _open_lock(lock)
+    try:
+        try:
+            data = json.loads(cache.read_text())
+            entries: list[dict[str, str]] = data.get("retiring", [])
+        except (json.JSONDecodeError, AttributeError, OSError):
+            return 0
+
+        survivors: list[dict[str, str]] = []
+        count = 0
+        cutoff = timedelta(hours=grace_hours)
+        for entry in entries:
+            retired_at_str = entry.get("retired_at")
+            if not retired_at_str:
+                continue
+            try:
+                retired_at = datetime.fromisoformat(retired_at_str)
+                age = datetime.now(UTC) - retired_at
+            except (ValueError, TypeError):
+                continue
+            if age >= cutoff:
+                path = entry.get("path", "")
+                if path and Path(path).is_dir():
+                    try:
+                        shutil.rmtree(path)
+                    except OSError:
+                        survivors.append(entry)
+                        continue
+                count += 1
+            else:
+                survivors.append(entry)
+
+        write_versioned_json(cache, {"retiring": survivors}, schema_version=_SCHEMA_VERSION)
+        return count
+    finally:
+        fh.close()
+
+
+def _retire_old_versions(cache_dir: Path, new_version: str) -> None:
+    for subdir in list(cache_dir.iterdir()):
+        if not subdir.is_dir():
+            continue
+        if subdir.name == new_version:
+            shutil.rmtree(subdir)
+        else:
+            append_retiring_entry(version=subdir.name, path=str(subdir))
+    sweep_retiring_cache()
+
+
+class _InstallLock:
+    """Exclusive fcntl lock for the autoskillit install critical section."""
+
+    def __init__(self) -> None:
+        self._lock_file: IO[str] | None = None
+
+    def __enter__(self) -> "_InstallLock":
+        self._lock_file = _open_lock(_install_lock_path())
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        if self._lock_file is not None:
+            self._lock_file.close()
+            self._lock_file = None
+
+
+def _pid_alive(pid: int, stored_create_time: float | None = None) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        if stored_create_time is not None:
+            try:
+                actual = psutil.Process(pid).create_time()
+                return abs(actual - stored_create_time) < 1.0
+            except psutil.NoSuchProcess:
+                return False
+        return True
+    if stored_create_time is not None:
+        try:
+            actual = psutil.Process(pid).create_time()
+            return abs(actual - stored_create_time) < 1.0
+        except psutil.NoSuchProcess:
+            return False
+    return True
+
+
+def register_active_kitchen(kitchen_id: str, pid: int, project_path: str) -> None:
+    lock = _active_kitchens_lock()
+    akp = _active_kitchens_path()
+    fh = _open_lock(lock)
+    try:
+        entries: list[dict[str, object]] = []
+        if akp.exists():
+            try:
+                entries = json.loads(akp.read_text()).get("kitchens", [])
+            except (json.JSONDecodeError, AttributeError):
+                entries = []
+        try:
+            create_time: float | None = psutil.Process(pid).create_time()
+        except psutil.NoSuchProcess:
+            create_time = None
+        entries.append({
+            "kitchen_id": kitchen_id,
+            "pid": pid,
+            "create_time": create_time,
+            "project_path": project_path,
+            "opened_at": datetime.now(UTC).isoformat(),
+        })
+        write_versioned_json(akp, {"kitchens": entries}, schema_version=_SCHEMA_VERSION)
+    finally:
+        fh.close()
+
+
+def unregister_active_kitchen(kitchen_id: str) -> None:
+    lock = _active_kitchens_lock()
+    akp = _active_kitchens_path()
+    fh = _open_lock(lock)
+    try:
+        entries: list[dict[str, object]] = []
+        if akp.exists():
+            try:
+                entries = json.loads(akp.read_text()).get("kitchens", [])
+            except (json.JSONDecodeError, AttributeError):
+                entries = []
+        survivors = [e for e in entries if e.get("kitchen_id") != kitchen_id]
+        write_versioned_json(akp, {"kitchens": survivors}, schema_version=_SCHEMA_VERSION)
+    finally:
+        fh.close()
+
+
+def clear_kitchens_for_pid(pid: int) -> None:
+    lock = _active_kitchens_lock()
+    akp = _active_kitchens_path()
+    fh = _open_lock(lock)
+    try:
+        entries: list[dict[str, object]] = []
+        if akp.exists():
+            try:
+                entries = json.loads(akp.read_text()).get("kitchens", [])
+            except (json.JSONDecodeError, AttributeError):
+                entries = []
+        survivors = [e for e in entries if e.get("pid") != pid]
+        write_versioned_json(akp, {"kitchens": survivors}, schema_version=_SCHEMA_VERSION)
+    finally:
+        fh.close()
+
+
+def any_kitchen_open() -> bool:
+    akp = _active_kitchens_path()
+    lock = _active_kitchens_lock()
+    if not akp.exists():
+        return False
+    fh = _open_lock(lock)
+    try:
+        try:
+            entries: list[dict[str, object]] = json.loads(akp.read_text()).get("kitchens", [])
+        except (json.JSONDecodeError, AttributeError, OSError):
+            return False
+        survivors = []
+        for entry in entries:
+            pid = entry.get("pid")
+            if not isinstance(pid, int):
+                continue
+            create_time = entry.get("create_time")
+            stored: float | None = float(create_time) if isinstance(create_time, (int, float)) else None
+            if _pid_alive(pid, stored_create_time=stored):
+                survivors.append(entry)
+        write_versioned_json(akp, {"kitchens": survivors}, schema_version=_SCHEMA_VERSION)
+        return len(survivors) > 0
+    finally:
+        fh.close()

--- a/src/autoskillit/cli/_update.py
+++ b/src/autoskillit/cli/_update.py
@@ -36,6 +36,12 @@ def run_update_command(home: Path | None = None) -> None:
         "AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK": "1",
     }
 
+    from autoskillit.cli._plugin_cache import any_kitchen_open
+
+    if any_kitchen_open():
+        print("A kitchen is currently open. Close it or wait for the pipeline to finish.")
+        raise SystemExit(1)
+
     info = detect_install()
     cmd = upgrade_command(info)
     if cmd is None:

--- a/src/autoskillit/cli/_update.py
+++ b/src/autoskillit/cli/_update.py
@@ -36,7 +36,7 @@ def run_update_command(home: Path | None = None) -> None:
         "AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK": "1",
     }
 
-    from autoskillit.cli._plugin_cache import any_kitchen_open
+    from autoskillit.core import any_kitchen_open
 
     if any_kitchen_open():
         print("A kitchen is currently open. Close it or wait for the pipeline to finish.")

--- a/src/autoskillit/cli/_update_checks.py
+++ b/src/autoskillit/cli/_update_checks.py
@@ -658,7 +658,7 @@ def run_update_checks(home: Path | None = None) -> None:
     ):
         return
 
-    from autoskillit.cli._plugin_cache import any_kitchen_open  # noqa: PLC0415
+    from autoskillit.core import any_kitchen_open  # noqa: PLC0415
 
     if any_kitchen_open():
         return

--- a/src/autoskillit/cli/_update_checks.py
+++ b/src/autoskillit/cli/_update_checks.py
@@ -658,6 +658,11 @@ def run_update_checks(home: Path | None = None) -> None:
     ):
         return
 
+    from autoskillit.cli._plugin_cache import any_kitchen_open  # noqa: PLC0415
+
+    if any_kitchen_open():
+        return
+
     _skip_env: dict[str, str] = {
         **os.environ,
         "AUTOSKILLIT_SKIP_STALE_CHECK": "1",

--- a/src/autoskillit/core/__init__.py
+++ b/src/autoskillit/core/__init__.py
@@ -6,6 +6,30 @@ explicit `from autoskillit.core.logging import get_logger`.
 """
 
 from ._claude_env import build_claude_env
+from ._plugin_cache import (
+    _InstallLock as _InstallLock,
+)
+from ._plugin_cache import (
+    _retire_old_versions as _retire_old_versions,
+)
+from ._plugin_cache import (
+    any_kitchen_open as any_kitchen_open,
+)
+from ._plugin_cache import (
+    append_retiring_entry as append_retiring_entry,
+)
+from ._plugin_cache import (
+    clear_kitchens_for_pid as clear_kitchens_for_pid,
+)
+from ._plugin_cache import (
+    register_active_kitchen as register_active_kitchen,
+)
+from ._plugin_cache import (
+    sweep_retiring_cache as sweep_retiring_cache,
+)
+from ._plugin_cache import (
+    unregister_active_kitchen as unregister_active_kitchen,
+)
 from ._terminal_table import TerminalColumn as TerminalColumn
 from ._terminal_table import _render_gfm_table as _render_gfm_table
 from ._terminal_table import _render_terminal_table as _render_terminal_table
@@ -273,4 +297,11 @@ __all__ = [
     "truncate_text",
     # _version_snapshot
     "collect_version_snapshot",
+    # _plugin_cache
+    "any_kitchen_open",
+    "append_retiring_entry",
+    "clear_kitchens_for_pid",
+    "register_active_kitchen",
+    "sweep_retiring_cache",
+    "unregister_active_kitchen",
 ]

--- a/src/autoskillit/core/_plugin_cache.py
+++ b/src/autoskillit/core/_plugin_cache.py
@@ -12,8 +12,8 @@ from typing import IO
 
 import psutil
 
-from autoskillit.core import atomic_write, write_versioned_json
-from autoskillit.core.logging import get_logger
+from .io import atomic_write, write_versioned_json
+from .logging import get_logger
 
 logger = get_logger(__name__)
 

--- a/src/autoskillit/core/_plugin_cache.py
+++ b/src/autoskillit/core/_plugin_cache.py
@@ -12,7 +12,7 @@ from typing import IO
 
 import psutil
 
-from .io import atomic_write, write_versioned_json
+from .io import write_versioned_json
 from .logging import get_logger
 
 logger = get_logger(__name__)
@@ -49,7 +49,7 @@ def _open_lock(lock_path: Path) -> IO[str]:
     fh = open(lock_path, "w")
     try:
         fcntl.flock(fh, fcntl.LOCK_EX)
-    except BaseException:
+    except Exception:
         fh.close()
         raise
     return fh
@@ -66,7 +66,9 @@ def append_retiring_entry(version: str, path: str) -> None:
                 entries = json.loads(cache.read_text()).get("retiring", [])
             except (json.JSONDecodeError, AttributeError):
                 entries = []
-        entries.append({"version": version, "path": path, "retired_at": datetime.now(UTC).isoformat()})
+        entries.append(
+            {"version": version, "path": path, "retired_at": datetime.now(UTC).isoformat()}
+        )
         write_versioned_json(cache, {"retiring": entries}, schema_version=_SCHEMA_VERSION)
     finally:
         fh.close()
@@ -91,18 +93,21 @@ def sweep_retiring_cache(grace_hours: int = 2) -> int:
         for entry in entries:
             retired_at_str = entry.get("retired_at")
             if not retired_at_str:
+                survivors.append(entry)
                 continue
             try:
                 retired_at = datetime.fromisoformat(retired_at_str)
                 age = datetime.now(UTC) - retired_at
             except (ValueError, TypeError):
+                survivors.append(entry)
                 continue
             if age >= cutoff:
                 path = entry.get("path", "")
                 if path and Path(path).is_dir():
                     try:
                         shutil.rmtree(path)
-                    except OSError:
+                    except OSError as exc:
+                        logger.warning("sweep_retiring_cache: failed to remove %s: %s", path, exc)
                         survivors.append(entry)
                         continue
                 count += 1
@@ -120,7 +125,12 @@ def _retire_old_versions(cache_dir: Path, new_version: str) -> None:
         if not subdir.is_dir():
             continue
         if subdir.name == new_version:
-            shutil.rmtree(subdir)
+            try:
+                shutil.rmtree(subdir)
+            except OSError as exc:
+                logger.warning(
+                    "_retire_old_versions: failed to remove same-version dir %s: %s", subdir, exc
+                )
         else:
             append_retiring_entry(version=subdir.name, path=str(subdir))
     sweep_retiring_cache()
@@ -132,7 +142,7 @@ class _InstallLock:
     def __init__(self) -> None:
         self._lock_file: IO[str] | None = None
 
-    def __enter__(self) -> "_InstallLock":
+    def __enter__(self) -> _InstallLock:
         self._lock_file = _open_lock(_install_lock_path())
         return self
 
@@ -179,13 +189,15 @@ def register_active_kitchen(kitchen_id: str, pid: int, project_path: str) -> Non
             create_time: float | None = psutil.Process(pid).create_time()
         except psutil.NoSuchProcess:
             create_time = None
-        entries.append({
-            "kitchen_id": kitchen_id,
-            "pid": pid,
-            "create_time": create_time,
-            "project_path": project_path,
-            "opened_at": datetime.now(UTC).isoformat(),
-        })
+        entries.append(
+            {
+                "kitchen_id": kitchen_id,
+                "pid": pid,
+                "create_time": create_time,
+                "project_path": project_path,
+                "opened_at": datetime.now(UTC).isoformat(),
+            }
+        )
         write_versioned_json(akp, {"kitchens": entries}, schema_version=_SCHEMA_VERSION)
     finally:
         fh.close()
@@ -242,10 +254,16 @@ def any_kitchen_open() -> bool:
             if not isinstance(pid, int):
                 continue
             create_time = entry.get("create_time")
-            stored: float | None = float(create_time) if isinstance(create_time, (int, float)) else None
+            stored: float | None = (
+                float(create_time) if isinstance(create_time, (int, float)) else None
+            )
             if _pid_alive(pid, stored_create_time=stored):
                 survivors.append(entry)
-        write_versioned_json(akp, {"kitchens": survivors}, schema_version=_SCHEMA_VERSION)
+        if len(survivors) < len(entries):
+            try:
+                write_versioned_json(akp, {"kitchens": survivors}, schema_version=_SCHEMA_VERSION)
+            except OSError as exc:
+                logger.warning("any_kitchen_open: failed to persist pruned kitchens: %s", exc)
         return len(survivors) > 0
     finally:
         fh.close()

--- a/src/autoskillit/server/_lifespan.py
+++ b/src/autoskillit/server/_lifespan.py
@@ -17,6 +17,7 @@ cleaned up in ``finally:`` before ``_finalize_recorder()`` runs.
 from __future__ import annotations
 
 import asyncio as _asyncio
+import os
 from contextlib import asynccontextmanager
 from typing import Any
 
@@ -79,6 +80,14 @@ async def _run_drift_check_async() -> None:
     await loop.run_in_executor(None, run_startup_drift_check)
 
 
+async def _run_retiring_sweep_async() -> None:
+    """Offload blocking retiring cache sweep to a thread."""
+    from autoskillit.cli._plugin_cache import sweep_retiring_cache  # noqa: PLC0415
+
+    loop = _asyncio.get_running_loop()
+    await loop.run_in_executor(None, sweep_retiring_cache)
+
+
 async def _run_deferred_init(ready_event: _asyncio.Event) -> None:
     """Run deferred_initialize, signalling *ready_event* when done."""
     ctx = _get_ctx_or_none()
@@ -119,6 +128,7 @@ async def _autoskillit_lifespan(server: Any) -> Any:
         _state._startup_ready = event
         write_readiness_sentinel()
         bg_tasks.append(create_background_task(_run_drift_check_async(), label="drift_check"))
+        bg_tasks.append(create_background_task(_run_retiring_sweep_async(), label="cache_sweep"))
         bg_tasks.append(create_background_task(_run_deferred_init(event), label="deferred_init"))
         yield
     finally:
@@ -131,6 +141,12 @@ async def _autoskillit_lifespan(server: Any) -> Any:
             cleanup_readiness_sentinel()
         except Exception:
             logger.exception("lifespan sentinel cleanup error")
+        try:
+            from autoskillit.cli._plugin_cache import clear_kitchens_for_pid  # noqa: PLC0415
+
+            clear_kitchens_for_pid(os.getpid())
+        except Exception:
+            logger.exception("lifespan kitchen registry cleanup error")
         try:
             _finalize_recorder()
         except Exception:

--- a/src/autoskillit/server/_lifespan.py
+++ b/src/autoskillit/server/_lifespan.py
@@ -82,7 +82,7 @@ async def _run_drift_check_async() -> None:
 
 async def _run_retiring_sweep_async() -> None:
     """Offload blocking retiring cache sweep to a thread."""
-    from autoskillit.cli._plugin_cache import sweep_retiring_cache  # noqa: PLC0415
+    from autoskillit.core import sweep_retiring_cache  # noqa: PLC0415
 
     loop = _asyncio.get_running_loop()
     await loop.run_in_executor(None, sweep_retiring_cache)
@@ -142,7 +142,7 @@ async def _autoskillit_lifespan(server: Any) -> Any:
         except Exception:
             logger.exception("lifespan sentinel cleanup error")
         try:
-            from autoskillit.cli._plugin_cache import clear_kitchens_for_pid  # noqa: PLC0415
+            from autoskillit.core import clear_kitchens_for_pid  # noqa: PLC0415
 
             clear_kitchens_for_pid(os.getpid())
         except Exception:

--- a/src/autoskillit/server/tools_kitchen.py
+++ b/src/autoskillit/server/tools_kitchen.py
@@ -208,7 +208,7 @@ async def _open_kitchen_handler() -> str | None:
         return _kitchen_failure_envelope(exc, stage="start_quota_refresh")
 
     try:
-        from autoskillit.cli._plugin_cache import register_active_kitchen  # noqa: PLC0415
+        from autoskillit.core import register_active_kitchen  # noqa: PLC0415
 
         register_active_kitchen(ctx.kitchen_id, os.getpid(), str(Path.cwd()))
     except Exception:
@@ -238,7 +238,7 @@ def _close_kitchen_handler() -> None:
         ctx.quota_refresh_task = None
     ctx.gate.disable()
     try:
-        from autoskillit.cli._plugin_cache import unregister_active_kitchen  # noqa: PLC0415
+        from autoskillit.core import unregister_active_kitchen  # noqa: PLC0415
 
         unregister_active_kitchen(ctx.kitchen_id)
     except Exception:

--- a/src/autoskillit/server/tools_kitchen.py
+++ b/src/autoskillit/server/tools_kitchen.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict
 from uuid import uuid4
@@ -206,6 +207,13 @@ async def _open_kitchen_handler() -> str | None:
         logger.warning("open_kitchen_failure", stage="start_quota_refresh", exc_info=True)
         return _kitchen_failure_envelope(exc, stage="start_quota_refresh")
 
+    try:
+        from autoskillit.cli._plugin_cache import register_active_kitchen  # noqa: PLC0415
+
+        register_active_kitchen(ctx.kitchen_id, os.getpid(), str(Path.cwd()))
+    except Exception:
+        logger.warning("open_kitchen_registry_failed", exc_info=True)
+
     return None
 
 
@@ -229,6 +237,12 @@ def _close_kitchen_handler() -> None:
         ctx.quota_refresh_task.cancel()
         ctx.quota_refresh_task = None
     ctx.gate.disable()
+    try:
+        from autoskillit.cli._plugin_cache import unregister_active_kitchen  # noqa: PLC0415
+
+        unregister_active_kitchen(ctx.kitchen_id)
+    except Exception:
+        logger.warning("close_kitchen_registry_failed", exc_info=True)
     ctx.active_recipe_packs = None
     ctx.recipe_name = ""
     ctx.recipe_content_hash = ""

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -677,7 +677,10 @@ def test_no_subpackage_exceeds_10_files() -> None:
         kitchen-open session marker reader for hook subprocesses.
         _version_snapshot.py adds the process-scoped version snapshot for session
         telemetry (collect_version_snapshot, lru_cache'd).
-        Exempt at 19 files.
+        _plugin_cache.py adds the plugin cache lifecycle: retiring cache sweep,
+        install locking, and kitchen registry (accessible from server/ without
+        cli/ import).
+        Exempt at 20 files.
       cli/ — REQ-CNST-003-E5: cli/ retains _terminal_table.py as a re-export shim
         for backward-compatible cli/ imports; canonical implementation lives in
         core/_terminal_table.py. Also contains _terminal.py — the terminal state
@@ -700,7 +703,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "server": 20,
         "recipe": 35,
         "execution": 26,
-        "core": 19,
+        "core": 20,
         "cli": 20,
         "hooks": 20,
     }

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -678,12 +678,31 @@ def test_doctor_does_not_modify_plugin_state(tmp_path, monkeypatch, capsys):
         )
     )
 
+    retiring_json = tmp_path / ".autoskillit" / "retiring_cache.json"
+    retiring_json.parent.mkdir(parents=True, exist_ok=True)
+    retiring_content = json.dumps(
+        {
+            "retiring": [
+                {
+                    "version": "0.3.0",
+                    "path": str(cache_dir / "0.3.0"),
+                    "retired_at": "2026-01-01T00:00:00+00:00",
+                }
+            ],
+            "schema_version": 1,
+        }
+    )
+    retiring_json.write_text(retiring_content)
+
     cli.doctor()
 
     assert cache_dir.exists(), "Doctor must not delete the plugin cache directory"
     data = json.loads(plugins_json.read_text())
     assert "autoskillit@autoskillit-local" in data.get("plugins", {}), (
         "Doctor must not remove installed_plugins.json entries"
+    )
+    assert retiring_json.read_text() == retiring_content, (
+        "Doctor must not modify retiring_cache.json"
     )
 
 

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -560,7 +560,11 @@ class TestGroupFInstall:
 def test_clear_plugin_cache_removes_nested_entry(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """_clear_plugin_cache must remove the entry from data['plugins'], not top-level data."""
+    """_clear_plugin_cache must remove the entry from data['plugins'], not top-level data.
+
+    With the retiring-cache feature, old version directories survive under a grace
+    period instead of being immediately deleted.
+    """
     from autoskillit.cli._marketplace import _clear_plugin_cache
 
     plugins_dir = tmp_path / ".claude" / "plugins"
@@ -574,11 +578,28 @@ def test_clear_plugin_cache_removes_nested_entry(
             }
         )
     )
+    # Simulate an old version directory in the plugin cache
+    cache_dir = tmp_path / ".claude" / "plugins" / "cache" / "autoskillit-local" / "autoskillit"
+    old_version_dir = cache_dir / "0.9.0"
+    old_version_dir.mkdir(parents=True)
+    # Ensure the running __version__ differs from "0.9.0" so retirement applies
+    import autoskillit as _pkg
+
+    monkeypatch.setattr(_pkg, "__version__", "0.9.99-test")
+
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     _clear_plugin_cache()
+
     data = json.loads(installed_json.read_text())
     assert "autoskillit@autoskillit-local" not in data.get("plugins", {})
     assert data["version"] == 2  # other keys preserved
+    # Old version dir survives under grace period
+    assert old_version_dir.exists(), "Old version dir must survive under grace period"
+    # Retiring registry must record the old version
+    retiring_json = tmp_path / ".autoskillit" / "retiring_cache.json"
+    assert retiring_json.exists(), "retiring_cache.json must be created"
+    retiring_data = json.loads(retiring_json.read_text())
+    assert any(e["version"] == "0.9.0" for e in retiring_data["retiring"])
 
 
 def test_clear_plugin_cache_noop_when_entry_absent(

--- a/tests/cli/test_plugin_cache.py
+++ b/tests/cli/test_plugin_cache.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
+import fcntl
 import json
 import os
 import threading
-import fcntl
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -23,7 +23,7 @@ def test_retire_old_versions_registers_different_version(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    from autoskillit.cli._plugin_cache import _retire_old_versions
+    from autoskillit.core._plugin_cache import _retire_old_versions
 
     cache_dir = tmp_path / "cache"
     old_dir = cache_dir / "0.8.0"
@@ -44,7 +44,7 @@ def test_retire_old_versions_multiple_old_dirs(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    from autoskillit.cli._plugin_cache import _retire_old_versions
+    from autoskillit.core._plugin_cache import _retire_old_versions
 
     cache_dir = tmp_path / "cache"
     (cache_dir / "0.7.0").mkdir(parents=True)
@@ -69,7 +69,7 @@ def test_retire_old_versions_deletes_same_version(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    from autoskillit.cli._plugin_cache import _retire_old_versions
+    from autoskillit.core._plugin_cache import _retire_old_versions
 
     cache_dir = tmp_path / "cache"
     same_dir = cache_dir / "0.9.0"
@@ -88,7 +88,7 @@ def test_retire_old_versions_noop_empty_cache_dir(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    from autoskillit.cli._plugin_cache import _retire_old_versions
+    from autoskillit.core._plugin_cache import _retire_old_versions
 
     cache_dir = tmp_path / "cache"
     cache_dir.mkdir(parents=True)
@@ -106,11 +106,9 @@ def test_retire_old_versions_noop_empty_cache_dir(
 # ---------------------------------------------------------------------------
 
 
-def test_sweep_deletes_expired_entries(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_sweep_deletes_expired_entries(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    from autoskillit.cli._plugin_cache import sweep_retiring_cache
+    from autoskillit.core._plugin_cache import sweep_retiring_cache
 
     old_dir = tmp_path / "cache" / "0.8.0"
     old_dir.mkdir(parents=True)
@@ -118,7 +116,12 @@ def test_sweep_deletes_expired_entries(
     retiring_json = tmp_path / ".autoskillit" / "retiring_cache.json"
     retiring_json.parent.mkdir(parents=True, exist_ok=True)
     retiring_json.write_text(
-        json.dumps({"retiring": [{"version": "0.8.0", "path": str(old_dir), "retired_at": retired_at}], "schema_version": 1})
+        json.dumps(
+            {
+                "retiring": [{"version": "0.8.0", "path": str(old_dir), "retired_at": retired_at}],
+                "schema_version": 1,
+            }
+        )
     )
 
     count = sweep_retiring_cache(grace_hours=24)
@@ -129,11 +132,9 @@ def test_sweep_deletes_expired_entries(
     assert data["retiring"] == []
 
 
-def test_sweep_deletes_multiple_expired(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_sweep_deletes_multiple_expired(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    from autoskillit.cli._plugin_cache import sweep_retiring_cache
+    from autoskillit.core._plugin_cache import sweep_retiring_cache
 
     dir1 = tmp_path / "cache" / "0.7.0"
     dir2 = tmp_path / "cache" / "0.8.0"
@@ -143,13 +144,15 @@ def test_sweep_deletes_multiple_expired(
     retiring_json = tmp_path / ".autoskillit" / "retiring_cache.json"
     retiring_json.parent.mkdir(parents=True, exist_ok=True)
     retiring_json.write_text(
-        json.dumps({
-            "retiring": [
-                {"version": "0.7.0", "path": str(dir1), "retired_at": old_ts},
-                {"version": "0.8.0", "path": str(dir2), "retired_at": old_ts},
-            ],
-            "schema_version": 1,
-        })
+        json.dumps(
+            {
+                "retiring": [
+                    {"version": "0.7.0", "path": str(dir1), "retired_at": old_ts},
+                    {"version": "0.8.0", "path": str(dir2), "retired_at": old_ts},
+                ],
+                "schema_version": 1,
+            }
+        )
     )
 
     count = sweep_retiring_cache(grace_hours=24)
@@ -164,11 +167,9 @@ def test_sweep_deletes_multiple_expired(
 # ---------------------------------------------------------------------------
 
 
-def test_sweep_preserves_fresh_entries(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_sweep_preserves_fresh_entries(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    from autoskillit.cli._plugin_cache import sweep_retiring_cache
+    from autoskillit.core._plugin_cache import sweep_retiring_cache
 
     fresh_dir = tmp_path / "cache" / "0.8.0"
     fresh_dir.mkdir(parents=True)
@@ -176,7 +177,14 @@ def test_sweep_preserves_fresh_entries(
     retiring_json = tmp_path / ".autoskillit" / "retiring_cache.json"
     retiring_json.parent.mkdir(parents=True, exist_ok=True)
     retiring_json.write_text(
-        json.dumps({"retiring": [{"version": "0.8.0", "path": str(fresh_dir), "retired_at": retired_at}], "schema_version": 1})
+        json.dumps(
+            {
+                "retiring": [
+                    {"version": "0.8.0", "path": str(fresh_dir), "retired_at": retired_at}
+                ],
+                "schema_version": 1,
+            }
+        )
     )
 
     count = sweep_retiring_cache(grace_hours=24)
@@ -187,11 +195,9 @@ def test_sweep_preserves_fresh_entries(
     assert len(data["retiring"]) == 1
 
 
-def test_sweep_mixed_fresh_and_expired(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_sweep_mixed_fresh_and_expired(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    from autoskillit.cli._plugin_cache import sweep_retiring_cache
+    from autoskillit.core._plugin_cache import sweep_retiring_cache
 
     expired_dir = tmp_path / "cache" / "0.7.0"
     fresh_dir = tmp_path / "cache" / "0.8.0"
@@ -202,13 +208,15 @@ def test_sweep_mixed_fresh_and_expired(
     retiring_json = tmp_path / ".autoskillit" / "retiring_cache.json"
     retiring_json.parent.mkdir(parents=True, exist_ok=True)
     retiring_json.write_text(
-        json.dumps({
-            "retiring": [
-                {"version": "0.7.0", "path": str(expired_dir), "retired_at": expired_ts},
-                {"version": "0.8.0", "path": str(fresh_dir), "retired_at": fresh_ts},
-            ],
-            "schema_version": 1,
-        })
+        json.dumps(
+            {
+                "retiring": [
+                    {"version": "0.7.0", "path": str(expired_dir), "retired_at": expired_ts},
+                    {"version": "0.8.0", "path": str(fresh_dir), "retired_at": fresh_ts},
+                ],
+                "schema_version": 1,
+            }
+        )
     )
 
     count = sweep_retiring_cache(grace_hours=24)
@@ -230,7 +238,7 @@ def test_sweep_handles_already_deleted_dir(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    from autoskillit.cli._plugin_cache import sweep_retiring_cache
+    from autoskillit.core._plugin_cache import sweep_retiring_cache
 
     missing_dir = tmp_path / "cache" / "0.8.0"
     # Deliberately do NOT create the directory
@@ -238,7 +246,12 @@ def test_sweep_handles_already_deleted_dir(
     retiring_json = tmp_path / ".autoskillit" / "retiring_cache.json"
     retiring_json.parent.mkdir(parents=True, exist_ok=True)
     retiring_json.write_text(
-        json.dumps({"retiring": [{"version": "0.8.0", "path": str(missing_dir), "retired_at": old_ts}], "schema_version": 1})
+        json.dumps(
+            {
+                "retiring": [{"version": "0.8.0", "path": str(missing_dir), "retired_at": old_ts}],
+                "schema_version": 1,
+            }
+        )
     )
 
     count = sweep_retiring_cache(grace_hours=24)  # must not raise
@@ -248,21 +261,17 @@ def test_sweep_handles_already_deleted_dir(
     assert data["retiring"] == []
 
 
-def test_sweep_noop_when_file_missing(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_sweep_noop_when_file_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    from autoskillit.cli._plugin_cache import sweep_retiring_cache
+    from autoskillit.core._plugin_cache import sweep_retiring_cache
 
     count = sweep_retiring_cache()
     assert count == 0
 
 
-def test_sweep_handles_malformed_json(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_sweep_handles_malformed_json(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    from autoskillit.cli._plugin_cache import sweep_retiring_cache
+    from autoskillit.core._plugin_cache import sweep_retiring_cache
 
     retiring_json = tmp_path / ".autoskillit" / "retiring_cache.json"
     retiring_json.parent.mkdir(parents=True, exist_ok=True)
@@ -273,11 +282,9 @@ def test_sweep_handles_malformed_json(
     assert count == 0
 
 
-def test_sweep_handles_missing_retired_at(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_sweep_handles_missing_retired_at(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    from autoskillit.cli._plugin_cache import sweep_retiring_cache
+    from autoskillit.core._plugin_cache import sweep_retiring_cache
 
     old_dir = tmp_path / "cache" / "0.8.0"
     old_dir.mkdir(parents=True)
@@ -298,11 +305,9 @@ def test_sweep_handles_missing_retired_at(
 # ---------------------------------------------------------------------------
 
 
-def test_install_lock_creates_lock_file(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_install_lock_creates_lock_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    from autoskillit.cli._plugin_cache import _InstallLock
+    from autoskillit.core._plugin_cache import _InstallLock
 
     lock_path = tmp_path / ".autoskillit" / "install.lock"
     with _InstallLock():
@@ -315,7 +320,7 @@ def test_install_lock_blocks_concurrent_access(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    from autoskillit.cli._plugin_cache import _install_lock_path
+    from autoskillit.core._plugin_cache import _install_lock_path
 
     lock_file_path = _install_lock_path()
     lock_file_path.parent.mkdir(parents=True, exist_ok=True)
@@ -357,7 +362,7 @@ def test_append_preserves_existing_entries(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    from autoskillit.cli._plugin_cache import append_retiring_entry
+    from autoskillit.core._plugin_cache import append_retiring_entry
 
     append_retiring_entry("0.7.0", "/some/path/0.7.0")
     append_retiring_entry("0.8.0", "/some/path/0.8.0")
@@ -369,11 +374,9 @@ def test_append_preserves_existing_entries(
     assert "0.8.0" in versions
 
 
-def test_registry_path_is_absolute(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_registry_path_is_absolute(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    from autoskillit.cli._plugin_cache import append_retiring_entry
+    from autoskillit.core._plugin_cache import append_retiring_entry
 
     abs_path = str(tmp_path / "cache" / "0.8.0")
     append_retiring_entry("0.8.0", abs_path)
@@ -389,11 +392,9 @@ def test_registry_path_is_absolute(
 # ---------------------------------------------------------------------------
 
 
-def test_register_creates_entry(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_register_creates_entry(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    from autoskillit.cli._plugin_cache import register_active_kitchen
+    from autoskillit.core._plugin_cache import register_active_kitchen
 
     kitchen_id = "test-kitchen-001"
     pid = os.getpid()
@@ -411,11 +412,9 @@ def test_register_creates_entry(
     assert kitchens[0]["create_time"] is not None
 
 
-def test_unregister_removes_entry(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_unregister_removes_entry(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    from autoskillit.cli._plugin_cache import register_active_kitchen, unregister_active_kitchen
+    from autoskillit.core._plugin_cache import register_active_kitchen, unregister_active_kitchen
 
     kitchen_id = "test-kitchen-002"
     register_active_kitchen(kitchen_id, os.getpid(), str(tmp_path))
@@ -430,7 +429,7 @@ def test_any_kitchen_open_false_when_pid_dead(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    from autoskillit.cli._plugin_cache import any_kitchen_open, register_active_kitchen
+    from autoskillit.core._plugin_cache import any_kitchen_open, register_active_kitchen
 
     dead_pid = 99999999
     register_active_kitchen("test-kitchen-003", dead_pid, str(tmp_path))
@@ -439,11 +438,9 @@ def test_any_kitchen_open_false_when_pid_dead(
     assert result is False
 
 
-def test_any_kitchen_open_sweeps_stale(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_any_kitchen_open_sweeps_stale(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    from autoskillit.cli._plugin_cache import any_kitchen_open, register_active_kitchen
+    from autoskillit.core._plugin_cache import any_kitchen_open, register_active_kitchen
 
     dead_pid = 99999999
     register_active_kitchen("test-kitchen-004", dead_pid, str(tmp_path))
@@ -455,11 +452,9 @@ def test_any_kitchen_open_sweeps_stale(
     assert data["kitchens"] == []
 
 
-def test_clear_kitchens_for_pid(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_clear_kitchens_for_pid(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    from autoskillit.cli._plugin_cache import clear_kitchens_for_pid, register_active_kitchen
+    from autoskillit.core._plugin_cache import clear_kitchens_for_pid, register_active_kitchen
 
     pid = os.getpid()
     register_active_kitchen("test-kitchen-005a", pid, str(tmp_path))
@@ -476,7 +471,7 @@ def test_any_kitchen_open_true_for_live_pid(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    from autoskillit.cli._plugin_cache import any_kitchen_open, register_active_kitchen
+    from autoskillit.core._plugin_cache import any_kitchen_open, register_active_kitchen
 
     register_active_kitchen("test-kitchen-006", os.getpid(), str(tmp_path))
 

--- a/tests/cli/test_plugin_cache.py
+++ b/tests/cli/test_plugin_cache.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import fcntl
 import json
 import os
+import subprocess
 import threading
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -79,9 +80,9 @@ def test_retire_old_versions_deletes_same_version(
 
     assert not same_dir.exists(), "Same-version dir must be deleted immediately"
     retiring_json = tmp_path / ".autoskillit" / "retiring_cache.json"
-    if retiring_json.exists():
-        data = json.loads(retiring_json.read_text())
-        assert data.get("retiring", []) == []
+    assert not retiring_json.exists(), (
+        "No retiring entries should be created for a same-version reinstall"
+    )
 
 
 def test_retire_old_versions_noop_empty_cache_dir(
@@ -96,9 +97,9 @@ def test_retire_old_versions_noop_empty_cache_dir(
     _retire_old_versions(cache_dir, "0.9.0")  # must not raise
 
     retiring_json = tmp_path / ".autoskillit" / "retiring_cache.json"
-    if retiring_json.exists():
-        data = json.loads(retiring_json.read_text())
-        assert data.get("retiring", []) == []
+    assert not retiring_json.exists(), (
+        "No retiring entries should be created for an empty cache dir"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -297,7 +298,10 @@ def test_sweep_handles_missing_retired_at(tmp_path: Path, monkeypatch: pytest.Mo
     sweep_retiring_cache()  # must not raise
 
     data = json.loads(retiring_json.read_text())
-    assert data["retiring"] == []
+    assert len(data["retiring"]) == 1, (
+        "Entry with missing retired_at must be preserved in survivors"
+    )
+    assert data["retiring"][0]["version"] == "0.8.0"
 
 
 # ---------------------------------------------------------------------------
@@ -336,7 +340,7 @@ def test_install_lock_blocks_concurrent_access(
 
     t = threading.Thread(target=hold_lock, daemon=True)
     t.start()
-    acquired.wait(timeout=2)
+    assert acquired.wait(timeout=2), "background lock thread did not acquire within 2s"
 
     # Try non-blocking acquire — must fail while first holder has it
     with open(lock_file_path, "w") as fh2:
@@ -349,6 +353,7 @@ def test_install_lock_blocks_concurrent_access(
 
     release.set()
     t.join(timeout=2)
+    assert not t.is_alive(), "lock-holding thread did not exit within 2s after release"
 
     assert blocked, "Second acquire must be blocked while first holder has the lock"
 
@@ -431,7 +436,9 @@ def test_any_kitchen_open_false_when_pid_dead(
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     from autoskillit.core._plugin_cache import any_kitchen_open, register_active_kitchen
 
-    dead_pid = 99999999
+    proc = subprocess.Popen(["true"])
+    proc.wait()
+    dead_pid = proc.pid
     register_active_kitchen("test-kitchen-003", dead_pid, str(tmp_path))
 
     result = any_kitchen_open()
@@ -442,7 +449,9 @@ def test_any_kitchen_open_sweeps_stale(tmp_path: Path, monkeypatch: pytest.Monke
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     from autoskillit.core._plugin_cache import any_kitchen_open, register_active_kitchen
 
-    dead_pid = 99999999
+    proc = subprocess.Popen(["true"])
+    proc.wait()
+    dead_pid = proc.pid
     register_active_kitchen("test-kitchen-004", dead_pid, str(tmp_path))
 
     any_kitchen_open()

--- a/tests/cli/test_plugin_cache.py
+++ b/tests/cli/test_plugin_cache.py
@@ -1,0 +1,484 @@
+"""Tests for _plugin_cache: retiring cache, install locking, kitchen registry."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import fcntl
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.medium]
+
+
+# ---------------------------------------------------------------------------
+# Category A — Grace period on version change
+# ---------------------------------------------------------------------------
+
+
+def test_retire_old_versions_registers_different_version(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from autoskillit.cli._plugin_cache import _retire_old_versions
+
+    cache_dir = tmp_path / "cache"
+    old_dir = cache_dir / "0.8.0"
+    old_dir.mkdir(parents=True)
+
+    _retire_old_versions(cache_dir, "0.9.0")
+
+    assert old_dir.exists(), "0.8.0/ must survive (grace period)"
+    retiring_json = tmp_path / ".autoskillit" / "retiring_cache.json"
+    data = json.loads(retiring_json.read_text())
+    entries = data["retiring"]
+    assert len(entries) == 1
+    assert entries[0]["version"] == "0.8.0"
+    assert datetime.fromisoformat(entries[0]["retired_at"]) is not None
+
+
+def test_retire_old_versions_multiple_old_dirs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from autoskillit.cli._plugin_cache import _retire_old_versions
+
+    cache_dir = tmp_path / "cache"
+    (cache_dir / "0.7.0").mkdir(parents=True)
+    (cache_dir / "0.8.0").mkdir(parents=True)
+
+    _retire_old_versions(cache_dir, "0.9.0")
+
+    assert (cache_dir / "0.7.0").exists()
+    assert (cache_dir / "0.8.0").exists()
+    retiring_json = tmp_path / ".autoskillit" / "retiring_cache.json"
+    data = json.loads(retiring_json.read_text())
+    versions = {e["version"] for e in data["retiring"]}
+    assert versions == {"0.7.0", "0.8.0"}
+
+
+# ---------------------------------------------------------------------------
+# Category B — Same-version reinstall
+# ---------------------------------------------------------------------------
+
+
+def test_retire_old_versions_deletes_same_version(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from autoskillit.cli._plugin_cache import _retire_old_versions
+
+    cache_dir = tmp_path / "cache"
+    same_dir = cache_dir / "0.9.0"
+    same_dir.mkdir(parents=True)
+
+    _retire_old_versions(cache_dir, "0.9.0")
+
+    assert not same_dir.exists(), "Same-version dir must be deleted immediately"
+    retiring_json = tmp_path / ".autoskillit" / "retiring_cache.json"
+    if retiring_json.exists():
+        data = json.loads(retiring_json.read_text())
+        assert data.get("retiring", []) == []
+
+
+def test_retire_old_versions_noop_empty_cache_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from autoskillit.cli._plugin_cache import _retire_old_versions
+
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir(parents=True)
+
+    _retire_old_versions(cache_dir, "0.9.0")  # must not raise
+
+    retiring_json = tmp_path / ".autoskillit" / "retiring_cache.json"
+    if retiring_json.exists():
+        data = json.loads(retiring_json.read_text())
+        assert data.get("retiring", []) == []
+
+
+# ---------------------------------------------------------------------------
+# Category C — Sweep deletes expired
+# ---------------------------------------------------------------------------
+
+
+def test_sweep_deletes_expired_entries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from autoskillit.cli._plugin_cache import sweep_retiring_cache
+
+    old_dir = tmp_path / "cache" / "0.8.0"
+    old_dir.mkdir(parents=True)
+    retired_at = (datetime.now(UTC) - timedelta(hours=25)).isoformat()
+    retiring_json = tmp_path / ".autoskillit" / "retiring_cache.json"
+    retiring_json.parent.mkdir(parents=True, exist_ok=True)
+    retiring_json.write_text(
+        json.dumps({"retiring": [{"version": "0.8.0", "path": str(old_dir), "retired_at": retired_at}], "schema_version": 1})
+    )
+
+    count = sweep_retiring_cache(grace_hours=24)
+
+    assert count == 1
+    assert not old_dir.exists()
+    data = json.loads(retiring_json.read_text())
+    assert data["retiring"] == []
+
+
+def test_sweep_deletes_multiple_expired(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from autoskillit.cli._plugin_cache import sweep_retiring_cache
+
+    dir1 = tmp_path / "cache" / "0.7.0"
+    dir2 = tmp_path / "cache" / "0.8.0"
+    dir1.mkdir(parents=True)
+    dir2.mkdir(parents=True)
+    old_ts = (datetime.now(UTC) - timedelta(hours=30)).isoformat()
+    retiring_json = tmp_path / ".autoskillit" / "retiring_cache.json"
+    retiring_json.parent.mkdir(parents=True, exist_ok=True)
+    retiring_json.write_text(
+        json.dumps({
+            "retiring": [
+                {"version": "0.7.0", "path": str(dir1), "retired_at": old_ts},
+                {"version": "0.8.0", "path": str(dir2), "retired_at": old_ts},
+            ],
+            "schema_version": 1,
+        })
+    )
+
+    count = sweep_retiring_cache(grace_hours=24)
+
+    assert count == 2
+    assert not dir1.exists()
+    assert not dir2.exists()
+
+
+# ---------------------------------------------------------------------------
+# Category D — Sweep preserves fresh
+# ---------------------------------------------------------------------------
+
+
+def test_sweep_preserves_fresh_entries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from autoskillit.cli._plugin_cache import sweep_retiring_cache
+
+    fresh_dir = tmp_path / "cache" / "0.8.0"
+    fresh_dir.mkdir(parents=True)
+    retired_at = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+    retiring_json = tmp_path / ".autoskillit" / "retiring_cache.json"
+    retiring_json.parent.mkdir(parents=True, exist_ok=True)
+    retiring_json.write_text(
+        json.dumps({"retiring": [{"version": "0.8.0", "path": str(fresh_dir), "retired_at": retired_at}], "schema_version": 1})
+    )
+
+    count = sweep_retiring_cache(grace_hours=24)
+
+    assert count == 0
+    assert fresh_dir.exists()
+    data = json.loads(retiring_json.read_text())
+    assert len(data["retiring"]) == 1
+
+
+def test_sweep_mixed_fresh_and_expired(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from autoskillit.cli._plugin_cache import sweep_retiring_cache
+
+    expired_dir = tmp_path / "cache" / "0.7.0"
+    fresh_dir = tmp_path / "cache" / "0.8.0"
+    expired_dir.mkdir(parents=True)
+    fresh_dir.mkdir(parents=True)
+    expired_ts = (datetime.now(UTC) - timedelta(hours=30)).isoformat()
+    fresh_ts = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+    retiring_json = tmp_path / ".autoskillit" / "retiring_cache.json"
+    retiring_json.parent.mkdir(parents=True, exist_ok=True)
+    retiring_json.write_text(
+        json.dumps({
+            "retiring": [
+                {"version": "0.7.0", "path": str(expired_dir), "retired_at": expired_ts},
+                {"version": "0.8.0", "path": str(fresh_dir), "retired_at": fresh_ts},
+            ],
+            "schema_version": 1,
+        })
+    )
+
+    count = sweep_retiring_cache(grace_hours=24)
+
+    assert count == 1
+    assert not expired_dir.exists()
+    assert fresh_dir.exists()
+    data = json.loads(retiring_json.read_text())
+    assert len(data["retiring"]) == 1
+    assert data["retiring"][0]["version"] == "0.8.0"
+
+
+# ---------------------------------------------------------------------------
+# Category E — Sweep error handling
+# ---------------------------------------------------------------------------
+
+
+def test_sweep_handles_already_deleted_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from autoskillit.cli._plugin_cache import sweep_retiring_cache
+
+    missing_dir = tmp_path / "cache" / "0.8.0"
+    # Deliberately do NOT create the directory
+    old_ts = (datetime.now(UTC) - timedelta(hours=30)).isoformat()
+    retiring_json = tmp_path / ".autoskillit" / "retiring_cache.json"
+    retiring_json.parent.mkdir(parents=True, exist_ok=True)
+    retiring_json.write_text(
+        json.dumps({"retiring": [{"version": "0.8.0", "path": str(missing_dir), "retired_at": old_ts}], "schema_version": 1})
+    )
+
+    count = sweep_retiring_cache(grace_hours=24)  # must not raise
+
+    assert count == 1
+    data = json.loads(retiring_json.read_text())
+    assert data["retiring"] == []
+
+
+def test_sweep_noop_when_file_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from autoskillit.cli._plugin_cache import sweep_retiring_cache
+
+    count = sweep_retiring_cache()
+    assert count == 0
+
+
+def test_sweep_handles_malformed_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from autoskillit.cli._plugin_cache import sweep_retiring_cache
+
+    retiring_json = tmp_path / ".autoskillit" / "retiring_cache.json"
+    retiring_json.parent.mkdir(parents=True, exist_ok=True)
+    retiring_json.write_text("not valid json {{{")
+
+    count = sweep_retiring_cache()  # must not raise
+
+    assert count == 0
+
+
+def test_sweep_handles_missing_retired_at(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from autoskillit.cli._plugin_cache import sweep_retiring_cache
+
+    old_dir = tmp_path / "cache" / "0.8.0"
+    old_dir.mkdir(parents=True)
+    retiring_json = tmp_path / ".autoskillit" / "retiring_cache.json"
+    retiring_json.parent.mkdir(parents=True, exist_ok=True)
+    retiring_json.write_text(
+        json.dumps({"retiring": [{"version": "0.8.0", "path": str(old_dir)}], "schema_version": 1})
+    )
+
+    sweep_retiring_cache()  # must not raise
+
+    data = json.loads(retiring_json.read_text())
+    assert data["retiring"] == []
+
+
+# ---------------------------------------------------------------------------
+# Category F — Install locking
+# ---------------------------------------------------------------------------
+
+
+def test_install_lock_creates_lock_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from autoskillit.cli._plugin_cache import _InstallLock
+
+    lock_path = tmp_path / ".autoskillit" / "install.lock"
+    with _InstallLock():
+        assert lock_path.exists()
+    # File still exists after release (fcntl lock is released, not deleted)
+    assert lock_path.exists()
+
+
+def test_install_lock_blocks_concurrent_access(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from autoskillit.cli._plugin_cache import _install_lock_path
+
+    lock_file_path = _install_lock_path()
+    lock_file_path.parent.mkdir(parents=True, exist_ok=True)
+
+    acquired = threading.Event()
+    release = threading.Event()
+
+    def hold_lock() -> None:
+        with open(lock_file_path, "w") as fh:
+            fcntl.flock(fh, fcntl.LOCK_EX)
+            acquired.set()
+            release.wait(timeout=5)
+
+    t = threading.Thread(target=hold_lock, daemon=True)
+    t.start()
+    acquired.wait(timeout=2)
+
+    # Try non-blocking acquire — must fail while first holder has it
+    with open(lock_file_path, "w") as fh2:
+        try:
+            fcntl.flock(fh2, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            blocked = False
+            fcntl.flock(fh2, fcntl.LOCK_UN)
+        except OSError:
+            blocked = True
+
+    release.set()
+    t.join(timeout=2)
+
+    assert blocked, "Second acquire must be blocked while first holder has the lock"
+
+
+# ---------------------------------------------------------------------------
+# Category G — Retiring registry integrity
+# ---------------------------------------------------------------------------
+
+
+def test_append_preserves_existing_entries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from autoskillit.cli._plugin_cache import append_retiring_entry
+
+    append_retiring_entry("0.7.0", "/some/path/0.7.0")
+    append_retiring_entry("0.8.0", "/some/path/0.8.0")
+
+    retiring_json = tmp_path / ".autoskillit" / "retiring_cache.json"
+    data = json.loads(retiring_json.read_text())
+    versions = [e["version"] for e in data["retiring"]]
+    assert "0.7.0" in versions
+    assert "0.8.0" in versions
+
+
+def test_registry_path_is_absolute(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from autoskillit.cli._plugin_cache import append_retiring_entry
+
+    abs_path = str(tmp_path / "cache" / "0.8.0")
+    append_retiring_entry("0.8.0", abs_path)
+
+    retiring_json = tmp_path / ".autoskillit" / "retiring_cache.json"
+    data = json.loads(retiring_json.read_text())
+    assert len(data["retiring"]) == 1
+    assert Path(data["retiring"][0]["path"]).is_absolute()
+
+
+# ---------------------------------------------------------------------------
+# Category K — Kitchen registry
+# ---------------------------------------------------------------------------
+
+
+def test_register_creates_entry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from autoskillit.cli._plugin_cache import register_active_kitchen
+
+    kitchen_id = "test-kitchen-001"
+    pid = os.getpid()
+    project_path = str(tmp_path)
+
+    register_active_kitchen(kitchen_id, pid, project_path)
+
+    akp = tmp_path / ".autoskillit" / "active_kitchens.json"
+    data = json.loads(akp.read_text())
+    kitchens = data["kitchens"]
+    assert len(kitchens) == 1
+    assert kitchens[0]["kitchen_id"] == kitchen_id
+    assert kitchens[0]["pid"] == pid
+    assert kitchens[0]["project_path"] == project_path
+    assert kitchens[0]["create_time"] is not None
+
+
+def test_unregister_removes_entry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from autoskillit.cli._plugin_cache import register_active_kitchen, unregister_active_kitchen
+
+    kitchen_id = "test-kitchen-002"
+    register_active_kitchen(kitchen_id, os.getpid(), str(tmp_path))
+    unregister_active_kitchen(kitchen_id)
+
+    akp = tmp_path / ".autoskillit" / "active_kitchens.json"
+    data = json.loads(akp.read_text())
+    assert data["kitchens"] == []
+
+
+def test_any_kitchen_open_false_when_pid_dead(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from autoskillit.cli._plugin_cache import any_kitchen_open, register_active_kitchen
+
+    dead_pid = 99999999
+    register_active_kitchen("test-kitchen-003", dead_pid, str(tmp_path))
+
+    result = any_kitchen_open()
+    assert result is False
+
+
+def test_any_kitchen_open_sweeps_stale(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from autoskillit.cli._plugin_cache import any_kitchen_open, register_active_kitchen
+
+    dead_pid = 99999999
+    register_active_kitchen("test-kitchen-004", dead_pid, str(tmp_path))
+
+    any_kitchen_open()
+
+    akp = tmp_path / ".autoskillit" / "active_kitchens.json"
+    data = json.loads(akp.read_text())
+    assert data["kitchens"] == []
+
+
+def test_clear_kitchens_for_pid(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from autoskillit.cli._plugin_cache import clear_kitchens_for_pid, register_active_kitchen
+
+    pid = os.getpid()
+    register_active_kitchen("test-kitchen-005a", pid, str(tmp_path))
+    register_active_kitchen("test-kitchen-005b", pid, str(tmp_path))
+
+    clear_kitchens_for_pid(pid)
+
+    akp = tmp_path / ".autoskillit" / "active_kitchens.json"
+    data = json.loads(akp.read_text())
+    assert data["kitchens"] == []
+
+
+def test_any_kitchen_open_true_for_live_pid(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from autoskillit.cli._plugin_cache import any_kitchen_open, register_active_kitchen
+
+    register_active_kitchen("test-kitchen-006", os.getpid(), str(tmp_path))
+
+    result = any_kitchen_open()
+    assert result is True

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -141,9 +141,9 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _installed_plugins.py — installed_plugins.json (co-owned with Claude plugin system)
     ("src/autoskillit/cli/_installed_plugins.py", 65),
     # _marketplace.py — marketplace.json (co-owned)
-    ("src/autoskillit/cli/_marketplace.py", 88),
+    ("src/autoskillit/cli/_marketplace.py", 92),
     # _marketplace.py — hooks.json (co-owned)
-    ("src/autoskillit/cli/_marketplace.py", 168),
+    ("src/autoskillit/cli/_marketplace.py", 172),
     # _update_checks.py — dismissal state file
     ("src/autoskillit/cli/_update_checks.py", 102),
     # _update_checks.py — fetch cache

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -124,10 +124,10 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # background.py — payload dict
     ("src/autoskillit/pipeline/background.py", 132),
     # _lifespan.py — hooks.json self-heal on startup drift (co-owned with Claude plugin system)
-    ("src/autoskillit/server/_lifespan.py", 55),
+    ("src/autoskillit/server/_lifespan.py", 56),
     # tools_kitchen.py — hook config dict
-    ("src/autoskillit/server/tools_kitchen.py", 165),
-    ("src/autoskillit/server/tools_kitchen.py", 516),
+    ("src/autoskillit/server/tools_kitchen.py", 166),
+    ("src/autoskillit/server/tools_kitchen.py", 530),
     # tools_status.py — mcp_data dict
     ("src/autoskillit/server/tools_status.py", 397),
     # tools_github.py — bug report dict
@@ -141,9 +141,9 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _installed_plugins.py — installed_plugins.json (co-owned with Claude plugin system)
     ("src/autoskillit/cli/_installed_plugins.py", 65),
     # _marketplace.py — marketplace.json (co-owned)
-    ("src/autoskillit/cli/_marketplace.py", 85),
+    ("src/autoskillit/cli/_marketplace.py", 88),
     # _marketplace.py — hooks.json (co-owned)
-    ("src/autoskillit/cli/_marketplace.py", 161),
+    ("src/autoskillit/cli/_marketplace.py", 168),
     # _update_checks.py — dismissal state file
     ("src/autoskillit/cli/_update_checks.py", 102),
     # _update_checks.py — fetch cache


### PR DESCRIPTION
## Summary

When autoskillit auto-updates during an active pipeline, `_clear_plugin_cache()` unconditionally deletes the entire plugin cache directory via `shutil.rmtree`. Running Claude Code sessions hold in-memory references to the old version's `installPath` and check this path on every hook dispatch. When the directory disappears, all hooks fail open — safety guards (branch protection, quota enforcement, orchestration depth) are silently bypassed.

This PR introduces four components:
1. **Cache rotation with grace period** — retire old version directories instead of deleting them immediately
2. **Retiring cache sweep** — TTL-based cleanup of retired directories after a 2-hour grace period
3. **Install-path locking** — fcntl advisory lock serializing the install critical section
4. **Kitchen-open update guard** — global registry preventing updates while any kitchen is active

All new logic is consolidated in a new module `src/autoskillit/core/_plugin_cache.py`.

## Requirements

REQ-CACHE-001: Old plugin cache version directories MUST survive for a configurable grace period (default 2 hours) after a new version is installed.

REQ-CACHE-002: Same-version reinstalls MUST delete the existing version directory immediately (no grace period, no registry entry).

REQ-CACHE-003: The `InstalledPluginsFile().remove()` call MUST remain before `claude plugin install` — this ordering is the correctness invariant.

REQ-CACHE-004: A retiring cache sweep MUST run at install time and server startup, deleting directories whose grace period has expired.

REQ-CACHE-005: The sweep MUST be fail-open — malformed entries, missing directories, and rmtree failures must not abort the install or server startup.

REQ-LOCK-001: The critical section from `_clear_plugin_cache()` through `claude plugin install` MUST be serialized via fcntl advisory lock.

REQ-GUARD-001: `autoskillit update` and the auto-update check MUST be blocked while any kitchen is open, using a global (home-scoped) registry with PID liveness verification.

REQ-GUARD-002: A crashed server's kitchen entry MUST be automatically cleared via PID liveness check — never permanently blocking updates.

REQ-TEST-001: All new tests MUST be xdist-safe (`-n 4`) using `tmp_path` filesystem isolation.

## Architecture Impact

### Error/Resilience Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ─── VALIDATION GATES (top row) ─── %%
    subgraph Gates ["VALIDATION GATES (Fail-Fast)"]
        direction LR
        WorktreeGate["WorktreeGuard<br/>━━━━━━━━━━<br/>is_git_worktree() → SystemExit<br/>Symlink target must outlive process"]
        KitchenOpenGate["● any_kitchen_open() guard<br/>━━━━━━━━━━<br/>Kitchen open → SystemExit/return<br/>Blocks install & update commands"]
        HeadlessGate["● headless_guard<br/>━━━━━━━━━━<br/>CLAUDECODE session check<br/>open_kitchen stage=headless_guard"]
    end

    %% ─── INSTALL LOCK (new) ─── %%
    subgraph InstallLock ["★ INSTALL LOCK (_plugin_cache.py: _InstallLock)"]
        direction TB
        Lock["★ _InstallLock context manager<br/>━━━━━━━━━━<br/>fcntl LOCK_EX on install.lock<br/>BaseException → fh.close() in __exit__"]
        OpenLockFn["★ _open_lock()<br/>━━━━━━━━━━<br/>Creates ~/.autoskillit/ if absent<br/>BaseException → fh.close() + reraise"]
    end

    %% ─── RETIRING CACHE (new) ─── %%
    subgraph RetiringCache ["★ RETIRING CACHE (_plugin_cache.py)"]
        direction TB
        RetireOld["★ _retire_old_versions()<br/>━━━━━━━━━━<br/>Current version dir → rmtree immediately<br/>Older dirs → append_retiring_entry()"]
        AppendRetiring["★ append_retiring_entry()<br/>━━━━━━━━━━<br/>JSON corrupt → entries=[] (reset)<br/>Writes retiring_cache.json atomically"]
        SweepCache["★ sweep_retiring_cache()<br/>━━━━━━━━━━<br/>Grace: ≥2h since retired_at<br/>OSError on rmtree → survivors list<br/>JSON corrupt → return 0"]
    end

    %% ─── KITCHEN REGISTRY (new) ─── %%
    subgraph KitchenRegistry ["★ KITCHEN REGISTRY (_plugin_cache.py)"]
        direction TB
        RegisterKitchen["★ register_active_kitchen()<br/>━━━━━━━━━━<br/>Appends PID + create_time<br/>JSON corrupt → entries=[]"]
        UnregisterKitchen["★ unregister_active_kitchen()<br/>━━━━━━━━━━<br/>Filters by kitchen_id<br/>JSON corrupt → entries=[]"]
        AnyOpen["★ any_kitchen_open()<br/>━━━━━━━━━━<br/>Prunes dead PIDs in-place<br/>JSON corrupt → return False<br/>Rewrites survivors atomically"]
        PidAlive["★ _pid_alive()<br/>━━━━━━━━━━<br/>ProcessLookupError → False<br/>PermissionError → psutil fallback<br/>create_time delta guard"]
    end

    %% ─── OPEN KITCHEN (modified) ─── %%
    subgraph OpenKitchenFlow ["● OPEN_KITCHEN STAGE PIPELINE (tools_kitchen.py)"]
        direction TB
        OKStage1["● Critical Stages<br/>━━━━━━━━━━<br/>write_hook_config<br/>prime_quota_cache<br/>start_quota_refresh"]
        OKRollback["● gate.disable() rollback<br/>━━━━━━━━━━<br/>Re-closes gate on critical fail<br/>Prevents partial-open state"]
        OKRegistry["● register_active_kitchen call<br/>━━━━━━━━━━<br/>Exception → WARNING only<br/>No rollback — non-fatal"]
        OKRecipe["● Recipe Stages<br/>━━━━━━━━━━<br/>load_and_validate<br/>recipe_find<br/>apply_triage_gate<br/>hook_diagnostic"]
        OKEnvelope["● _kitchen_failure_envelope()<br/>━━━━━━━━━━<br/>JSON {success:false, stage, error}<br/>Catch-all at tool boundary"]
    end

    %% ─── CLOSE KITCHEN + LIFESPAN (modified) ─── %%
    subgraph CloseFlow ["● CLOSE KITCHEN + LIFESPAN TEARDOWN (_lifespan.py, tools_kitchen.py)"]
        direction TB
        CloseKitchen["● close_kitchen()<br/>━━━━━━━━━━<br/>unregister → WARNING only<br/>Never raises"]
        LifespanTeardown["● _autoskillit_lifespan() finally:<br/>━━━━━━━━━━<br/>3 independent try/except blocks<br/>Each isolated — one fail ≠ skip rest"]
        ClearPidBlock["● clear_kitchens_for_pid()<br/>━━━━━━━━━━<br/>Removes all kitchens for this PID<br/>Called on SIGTERM / process exit"]
        RetireSweepAsync["● _run_retiring_sweep_async()<br/>━━━━━━━━━━<br/>Thread-pool offload at startup<br/>sweep_retiring_cache() non-blocking"]
        DriftCheck["run_startup_drift_check()<br/>━━━━━━━━━━<br/>Exception → swallowed + logged<br/>Never prevents server startup"]
    end

    %% ─── TERMINAL STATES ─── %%
    TERROR(["ERROR ENVELOPE\n{success:false}"])
    TEXIT(["SystemExit"])
    TCOMPLETE(["COMPLETE / OPEN"])

    %% ─── CONNECTIONS ─── %%

    %% Gates → fail paths %%
    WorktreeGate -->|"worktree detected"| TEXIT
    KitchenOpenGate -->|"kitchen open"| TEXIT
    HeadlessGate -->|"headless session"| OKEnvelope

    %% Install flow %%
    KitchenOpenGate -->|"no kitchen open"| Lock
    Lock --> OpenLockFn
    OpenLockFn -->|"locked"| RetireOld
    RetireOld --> AppendRetiring
    RetireOld --> SweepCache
    AppendRetiring -->|"JSON corrupt"| AppendRetiring
    SweepCache -->|"OSError → stay in survivors"| SweepCache
    SweepCache -->|"≥ grace period"| TCOMPLETE

    %% Kitchen registry %%
    RegisterKitchen --> AnyOpen
    AnyOpen --> PidAlive
    PidAlive -->|"dead PID pruned"| AnyOpen
    PidAlive -->|"alive"| AnyOpen
    AnyOpen -->|"JSON corrupt → false"| KitchenOpenGate

    %% open_kitchen pipeline %%
    HeadlessGate -->|"interactive"| OKStage1
    OKStage1 -->|"any stage throws"| OKRollback
    OKRollback --> OKEnvelope
    OKStage1 -->|"all stages pass"| OKRegistry
    OKRegistry -->|"exception → WARNING"| OKRegistry
    OKRegistry --> OKRecipe
    OKRecipe -->|"any stage throws"| OKEnvelope
    OKRecipe -->|"all pass"| TCOMPLETE
    OKEnvelope --> TERROR

    %% Close / Lifespan %%
    CloseKitchen --> UnregisterKitchen
    UnregisterKitchen -->|"exception → WARNING"| TCOMPLETE
    LifespanTeardown --> ClearPidBlock
    LifespanTeardown --> RetireSweepAsync
    LifespanTeardown --> DriftCheck
    ClearPidBlock -->|"exception → logged"| TCOMPLETE
    RetireSweepAsync --> SweepCache
    DriftCheck -->|"exception swallowed"| TCOMPLETE

    %% CLASS ASSIGNMENTS %%
    class WorktreeGate,HeadlessGate,KitchenOpenGate detector;
    class Lock,OpenLockFn newComponent;
    class RetireOld,AppendRetiring,SweepCache newComponent;
    class RegisterKitchen,UnregisterKitchen,AnyOpen,PidAlive newComponent;
    class OKStage1,OKRecipe handler;
    class OKRollback gap;
    class OKRegistry output;
    class OKEnvelope gap;
    class CloseKitchen,LifespanTeardown phase;
    class ClearPidBlock,RetireSweepAsync,DriftCheck phase;
    class TERROR,TEXIT,TCOMPLETE terminal;
```

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 65, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ── ENTRY POINTS ─────────────────────────────────────────────────── %%
    INSTALL(["● autoskillit install"])
    UPDATE(["● autoskillit update"])
    OPEN(["● open_kitchen MCP tool"])
    CLOSE(["● close_kitchen MCP tool"])
    LIFESPAN(["● _autoskillit_lifespan"])

    %% ── GATE 1: Install Lock ──────────────────────────────────────────── %%
    subgraph InstallLock ["★ GATE 1 — Install Critical Section (_InstallLock)"]
        direction TB
        ILOCK["★ _InstallLock<br/>━━━━━━━━━━<br/>fcntl.LOCK_EX<br/>install.lock"]
        KITCHEN_GUARD["★ any_kitchen_open()<br/>━━━━━━━━━━<br/>Refuse install if<br/>kitchen live"]
    end

    %% ── GATE 2: Cache Mutation Lock ──────────────────────────────────── %%
    subgraph CacheMutex ["★ GATE 2 — Per-File Mutex (_open_lock / fcntl.LOCK_EX)"]
        direction LR
        RLOCK["★ retiring_cache.lock<br/>━━━━━━━━━━<br/>Exclusive per write"]
        AKLOCK["★ active_kitchens.lock<br/>━━━━━━━━━━<br/>Exclusive per write"]
    end

    %% ── APPEND-ONLY STATE: Retiring Cache ────────────────────────────── %%
    subgraph RetiringState ["★ APPEND-ONLY — retiring_cache.json (schema_version=1)"]
        direction TB
        RETIRE_APPEND["★ append_retiring_entry()<br/>━━━━━━━━━━<br/>APPEND_ONLY<br/>{version, path, retired_at}"]
        GRACE["★ sweep_retiring_cache()<br/>━━━━━━━━━━<br/>grace_hours=2<br/>survivors-list pattern"]
        RETIRE_FS["★ shutil.rmtree(path)<br/>━━━━━━━━━━<br/>Physical deletion<br/>after grace"]
    end

    %% ── MUTABLE STATE: Active Kitchens Registry ──────────────────────── %%
    subgraph KitchenRegistry ["★ MUTABLE — active_kitchens.json (schema_version=1)"]
        direction TB
        REG["★ register_active_kitchen()<br/>━━━━━━━━━━<br/>MUTABLE: append entry<br/>{kitchen_id, pid, create_time,<br/>project_path, opened_at}"]
        UNREG["★ unregister_active_kitchen()<br/>━━━━━━━━━━<br/>MUTABLE: filter by kitchen_id"]
        PID_CLEAR["★ clear_kitchens_for_pid()<br/>━━━━━━━━━━<br/>MUTABLE: filter by pid<br/>lifespan teardown"]
    end

    %% ── GATE 3: PID Liveness (Ghost Eviction) ────────────────────────── %%
    subgraph LivenessGate ["★ GATE 3 — Ghost Eviction (_pid_alive + create_time)"]
        direction TB
        PID_CHECK["★ _pid_alive(pid, stored_create_time)<br/>━━━━━━━━━━<br/>os.kill(pid, 0) + psutil.create_time()<br/>±1.0 s tolerance"]
        DERIVED_READ["★ any_kitchen_open()<br/>━━━━━━━━━━<br/>DERIVED: reads kitchens[],<br/>evicts ghosts, rewrites survivors"]
    end

    %% ── MUTABLE: Kitchen Session Context ─────────────────────────────── %%
    subgraph KitchenCtx ["● MUTABLE — ToolContext kitchen session fields"]
        direction LR
        CTX_OPEN["● ctx.gate.enable()<br/>ctx.kitchen_id = uuid4()<br/>ctx.active_recipe_packs = frozenset()"]
        CTX_RECIPE["● ctx.recipe_name<br/>ctx.recipe_content_hash<br/>ctx.recipe_composite_hash<br/>ctx.recipe_version"]
        CTX_CLOSE["● ctx.gate.disable()<br/>ctx.quota_refresh_task = None<br/>ctx.active_recipe_packs = None<br/>ctx.recipe_* = ''"]
    end

    %% ── INIT_ONLY: Lifespan Startup ──────────────────────────────────── %%
    subgraph LifespanInit ["● INIT_ONLY — _lifespan startup (write-once per process)"]
        direction LR
        SENTINEL["● write_readiness_sentinel()<br/>━━━━━━━━━━<br/>INIT_ONLY<br/>written once; cleaned in finally"]
        STARTUP_EVENT["● _state._startup_ready = Event()<br/>━━━━━━━━━━<br/>INIT_ONLY per startup<br/>signalled by deferred_init"]
        BG_TASKS["● Background tasks (INIT_ONLY)<br/>━━━━━━━━━━<br/>drift_check<br/>cache_sweep → sweep_retiring_cache<br/>deferred_init"]
    end

    %% ── FLOWS ─────────────────────────────────────────────────────────── %%

    INSTALL --> KITCHEN_GUARD
    UPDATE --> KITCHEN_GUARD
    KITCHEN_GUARD -->|"kitchen OPEN → reject"| ILOCK
    KITCHEN_GUARD -->|"no live kitchen → proceed"| ILOCK
    ILOCK --> RLOCK
    RLOCK --> RETIRE_APPEND
    RETIRE_APPEND --> GRACE
    GRACE -->|"age ≥ grace_hours"| RETIRE_FS
    GRACE -->|"age < grace_hours → survivor"| RETIRE_APPEND

    OPEN --> CTX_OPEN
    CTX_OPEN --> AKLOCK
    AKLOCK --> REG
    OPEN --> CTX_RECIPE

    CLOSE --> CTX_CLOSE
    CTX_CLOSE --> AKLOCK
    AKLOCK --> UNREG

    LIFESPAN --> SENTINEL
    LIFESPAN --> STARTUP_EVENT
    LIFESPAN --> BG_TASKS
    BG_TASKS -->|"startup sweep"| RLOCK
    RLOCK -->|"background sweep"| GRACE

    LIFESPAN -->|"finally: teardown"| PID_CLEAR
    PID_CLEAR --> AKLOCK

    DERIVED_READ --> PID_CHECK
    PID_CHECK -->|"ghost detected"| AKLOCK
    PID_CHECK -->|"live entry"| DERIVED_READ
    KITCHEN_GUARD -->|"read"| DERIVED_READ

    %% ── CLASS ASSIGNMENTS ─────────────────────────────────────────────── %%
    class INSTALL,UPDATE,OPEN,CLOSE,LIFESPAN cli;
    class ILOCK,RLOCK,AKLOCK detector;
    class KITCHEN_GUARD,PID_CHECK,DERIVED_READ phase;
    class RETIRE_APPEND,GRACE handler;
    class RETIRE_FS gap;
    class REG,UNREG,PID_CLEAR newComponent;
    class CTX_OPEN,CTX_RECIPE,CTX_CLOSE stateNode;
    class SENTINEL,STARTUP_EVENT,BG_TASKS output;
```

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;

    START([autoskillit install])

    subgraph PreGuards ["Pre-Install Guards"]
        direction TB
        CLAUDECODE{"CLAUDECODE env set?"}
        NO_CLAUDE{"claude on PATH?"}
        WORKTREE{"is_git_worktree?"}
    end

    subgraph CriticalSection ["★ Install Critical Section (_InstallLock)"]
        direction TB
        ACQUIRE["★ _InstallLock.__enter__<br/>━━━━━━━━━━<br/>fcntl.LOCK_EX on install.lock<br/>~/.autoskillit/install.lock"]
        CLEAR_CACHE["● _clear_plugin_cache()<br/>━━━━━━━━━━<br/>locate cache_dir<br/>~/.claude/plugins/cache/autoskillit-local/autoskillit"]
        RETIRE["★ _retire_old_versions(cache_dir, new_ver)<br/>━━━━━━━━━━<br/>iterdir() → classify subdirs"]
        REGEN_HOOKS["● regen hooks.json<br/>━━━━━━━━━━<br/>generate_hooks_json() → atomic_write"]
        MARKETPLACE_CMD["claude plugin marketplace add<br/>━━━━━━━━━━<br/>subprocess.run(timeout=30)"]
        INSTALL_CMD["claude plugin install autoskillit@autoskillit-local<br/>━━━━━━━━━━<br/>subprocess.run(timeout=30)"]
        RELEASE["★ _InstallLock.__exit__<br/>━━━━━━━━━━<br/>fh.close() → fcntl released"]
    end

    subgraph PostInstall ["Post-Install Housekeeping"]
        direction TB
        EVICT["evict_direct_mcp_entry()<br/>━━━━━━━━━━<br/>remove stale MCP from ~/.claude.json"]
        SWEEP_HOOKS["sweep_all_scopes_for_orphans()<br/>━━━━━━━━━━<br/>cross-scope hook cleanup"]
        SYNC_HOOKS["sync_hooks_to_settings()<br/>━━━━━━━━━━<br/>write canonical hooks to scope"]
    end

    DONE([DONE — plugin installed])
    DEFERRED([DEFERRED — manual steps printed])
    ERR_WORKTREE([ERROR — worktree detected])
    ERR_MARKETPLACE([ERROR — marketplace add failed])
    ERR_INSTALL([ERROR — plugin install failed])

    START --> WORKTREE
    WORKTREE -->|"yes"| ERR_WORKTREE
    WORKTREE -->|"no"| CLAUDECODE
    CLAUDECODE -->|"yes"| DEFERRED
    CLAUDECODE -->|"no"| NO_CLAUDE
    NO_CLAUDE -->|"not found"| ERR_WORKTREE
    NO_CLAUDE -->|"found"| ACQUIRE
    ACQUIRE --> CLEAR_CACHE
    CLEAR_CACHE --> RETIRE
    RETIRE --> REGEN_HOOKS
    REGEN_HOOKS --> MARKETPLACE_CMD
    MARKETPLACE_CMD -->|"returncode != 0"| ERR_MARKETPLACE
    MARKETPLACE_CMD -->|"ok"| INSTALL_CMD
    INSTALL_CMD -->|"returncode != 0"| ERR_INSTALL
    INSTALL_CMD -->|"ok"| RELEASE
    RELEASE --> EVICT
    EVICT --> SWEEP_HOOKS
    SWEEP_HOOKS --> SYNC_HOOKS
    SYNC_HOOKS --> DONE

    class START,DONE,DEFERRED terminal;
    class ERR_WORKTREE,ERR_MARKETPLACE,ERR_INSTALL detector;
    class CLAUDECODE,NO_CLAUDE,WORKTREE stateNode;
    class ACQUIRE,RELEASE newComponent;
    class CLEAR_CACHE,RETIRE,REGEN_HOOKS handler;
    class MARKETPLACE_CMD,INSTALL_CMD phase;
    class EVICT,SWEEP_HOOKS,SYNC_HOOKS output;
```

Closes #1065

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260419-133348-895289/.autoskillit/temp/make-plan/resilient_plugin_cache_lifecycle_plan_2026-04-19_134500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 3.2k | 15.5k | 598.2k | 69.6k | 1 | 6m 43s |
| review | 18 | 5.5k | 103.5k | 9.8k | 1 | 6m 37s |
| verify | 994 | 12.6k | 1.2M | 62.8k | 1 | 6m 20s |
| implement | 390 | 30.4k | 3.4M | 103.1k | 1 | 6m 39s |
| fix | 392 | 43.8k | 3.7M | 106.3k | 1 | 16m 33s |
| prepare_pr | 60 | 6.9k | 225.8k | 36.7k | 1 | 1m 57s |
| run_arch_lenses | 199 | 27.5k | 743.5k | 132.2k | 3 | 7m 42s |
| compose_pr | 67 | 9.3k | 269.6k | 40.5k | 1 | 2m 15s |
| **Total** | 5.3k | 151.4k | 10.2M | 560.9k | | 54m 48s |