### PR TITLE
Food Truck Startup Pack Filter Using AUTOSKILLIT_L2_TOOL_TAGS

### DIFF
--- a/src/autoskillit/core/_type_protocols.py
+++ b/src/autoskillit/core/_type_protocols.py
@@ -210,6 +210,7 @@ class HeadlessExecutor(Protocol):
         stale_threshold: float | None = None,
         idle_output_timeout: float | None = None,
         env_extras: Mapping[str, str] | None = None,
+        requires_packs: Sequence[str] = (),
         on_spawn: Callable[[int], None] | None = None,
     ) -> SkillResult: ...
 

--- a/src/autoskillit/execution/headless.py
+++ b/src/autoskillit/execution/headless.py
@@ -1388,6 +1388,7 @@ class DefaultHeadlessExecutor:
         stale_threshold: float | None = None,
         idle_output_timeout: float | None = None,
         env_extras: Mapping[str, str] | None = None,
+        requires_packs: Sequence[str] = (),
         on_spawn: Callable[[int], None] | None = None,
     ) -> SkillResult:
         cfg = self._ctx.config
@@ -1400,13 +1401,17 @@ class DefaultHeadlessExecutor:
                 "dispatch_food_truck requires a configured plugin_dir; ctx.plugin_dir is None"
             )
 
+        merged_extras: dict[str, str] = dict(env_extras) if env_extras else {}
+        if requires_packs:
+            merged_extras["AUTOSKILLIT_L2_TOOL_TAGS"] = ",".join(sorted(requires_packs))
+
         spec = build_food_truck_cmd(
             orchestrator_prompt=orchestrator_prompt,
             plugin_dir=plugin_dir,
             cwd=cwd,
             completion_marker=completion_marker,
             model=resolved_model,
-            env_extras=env_extras,
+            env_extras=merged_extras or None,
             output_format_value=cfg.run_skill.output_format.value,
         )
 

--- a/src/autoskillit/execution/headless.py
+++ b/src/autoskillit/execution/headless.py
@@ -1403,6 +1403,11 @@ class DefaultHeadlessExecutor:
 
         merged_extras: dict[str, str] = dict(env_extras) if env_extras else {}
         if requires_packs:
+            if "AUTOSKILLIT_L2_TOOL_TAGS" in merged_extras:
+                raise ValueError(
+                    "dispatch_food_truck: requires_packs and env_extras both specify "
+                    "AUTOSKILLIT_L2_TOOL_TAGS — use requires_packs exclusively"
+                )
             merged_extras["AUTOSKILLIT_L2_TOOL_TAGS"] = ",".join(sorted(requires_packs))
 
         spec = build_food_truck_cmd(

--- a/src/autoskillit/server/_session_type.py
+++ b/src/autoskillit/server/_session_type.py
@@ -8,8 +8,10 @@ from __future__ import annotations
 
 import os
 
-from autoskillit.core import HEADLESS_ENV_VAR, SessionType
+from autoskillit.core import CATEGORY_TAGS, HEADLESS_ENV_VAR, SessionType, get_logger
 from autoskillit.core import session_type as _resolve_session_type
+
+_log = get_logger(__name__)
 
 
 def _apply_session_type_visibility() -> None:
@@ -27,8 +29,17 @@ def _apply_session_type_visibility() -> None:
             mcp.enable(tags={"kitchen-core"})
             for pack in tool_tags.split(","):
                 pack = pack.strip()
-                if pack:
-                    mcp.enable(tags={pack})
+                if not pack:
+                    continue
+                if pack not in CATEGORY_TAGS:
+                    _log.warning(
+                        "Unknown pack %r in AUTOSKILLIT_L2_TOOL_TAGS — skipping mcp.enable(); "
+                        "valid packs: %s",
+                        pack,
+                        ", ".join(sorted(CATEGORY_TAGS)),
+                    )
+                    continue
+                mcp.enable(tags={pack})
         else:
             mcp.enable(tags={"kitchen"})
     elif _session is SessionType.LEAF and _headless:

--- a/src/autoskillit/server/_session_type.py
+++ b/src/autoskillit/server/_session_type.py
@@ -22,7 +22,15 @@ def _apply_session_type_visibility() -> None:
     if _session is SessionType.FRANCHISE:
         mcp.enable(tags={"franchise"})
     elif _session is SessionType.ORCHESTRATOR and _headless:
-        mcp.enable(tags={"kitchen"})
+        tool_tags = os.environ.get("AUTOSKILLIT_L2_TOOL_TAGS", "")
+        if tool_tags:
+            mcp.enable(tags={"kitchen-core"})
+            for pack in tool_tags.split(","):
+                pack = pack.strip()
+                if pack:
+                    mcp.enable(tags={pack})
+        else:
+            mcp.enable(tags={"kitchen"})
     elif _session is SessionType.LEAF and _headless:
         mcp.enable(tags={"headless"})
     # ORCHESTRATOR+interactive and LEAF+interactive: no pre-reveal.

--- a/tests/execution/test_commands.py
+++ b/tests/execution/test_commands.py
@@ -539,6 +539,19 @@ class TestBuildFoodTruckCmd:
         assert "CLAUDE_CODE_SSE_PORT" not in spec.env
 
 
+class TestBuildFoodTruckCmdPackTags:
+    def test_env_extras_with_l2_tool_tags_passes_through(self):
+        """env_extras containing AUTOSKILLIT_L2_TOOL_TAGS reaches subprocess env."""
+        spec = build_food_truck_cmd(
+            orchestrator_prompt="...",
+            plugin_dir="/plugins",
+            cwd="/repo",
+            completion_marker="%%DONE%%",
+            env_extras={"AUTOSKILLIT_L2_TOOL_TAGS": "github,ci,clone,telemetry"},
+        )
+        assert spec.env["AUTOSKILLIT_L2_TOOL_TAGS"] == "github,ci,clone,telemetry"
+
+
 def test_headless_exclusive_vars_contains_max_mcp_output_tokens() -> None:
     """MAX_MCP_OUTPUT_TOKENS must be in _HEADLESS_EXCLUSIVE_VARS."""
     from autoskillit.execution.commands import _HEADLESS_EXCLUSIVE_VARS

--- a/tests/execution/test_headless.py
+++ b/tests/execution/test_headless.py
@@ -4332,6 +4332,91 @@ class TestDispatchFoodTruck:
         assert result.success is True
 
 
+class TestDispatchFoodTruckPackInjection:
+    """Tests that dispatch_food_truck correctly injects AUTOSKILLIT_L2_TOOL_TAGS."""
+
+    def _make_success_stdout(self, marker: str = "%%FT_DONE%%") -> str:
+        import json
+
+        return json.dumps(
+            {
+                "type": "result",
+                "subtype": "success",
+                "result": f"L2 done {marker}",
+                "session_id": "ft-session",
+                "is_error": False,
+            }
+        )
+
+    @pytest.mark.anyio
+    async def test_requires_packs_injected_as_l2_tool_tags(self, minimal_ctx, tmp_path: Path):
+        """dispatch_food_truck with requires_packs injects sorted comma-joined env var."""
+        from autoskillit.core.types import SubprocessResult, TerminationReason
+        from autoskillit.execution.headless import DefaultHeadlessExecutor
+        from tests.fakes import MockSubprocessRunner
+
+        runner = MockSubprocessRunner()
+        runner.set_default(
+            SubprocessResult(
+                returncode=0,
+                stdout=self._make_success_stdout(),
+                stderr="",
+                termination=TerminationReason.NATURAL_EXIT,
+                pid=12345,
+            )
+        )
+        minimal_ctx.runner = runner
+        minimal_ctx.plugin_dir = str(tmp_path)
+
+        executor = DefaultHeadlessExecutor(minimal_ctx)
+        await executor.dispatch_food_truck(
+            "You are an L2 orchestrator",
+            str(tmp_path),
+            completion_marker="%%FT_DONE%%",
+            requires_packs=["ci", "github", "clone"],
+        )
+
+        assert runner.call_args_list, "runner was never called"
+        _cmd, _cwd, _timeout, kwargs = runner.call_args_list[0]
+        env = kwargs.get("env")
+        assert env is not None
+        assert env["AUTOSKILLIT_L2_TOOL_TAGS"] == "ci,clone,github"
+
+    @pytest.mark.anyio
+    async def test_requires_packs_empty_omits_l2_tool_tags(self, minimal_ctx, tmp_path: Path):
+        """dispatch_food_truck with empty requires_packs does not inject L2_TOOL_TAGS."""
+        from autoskillit.core.types import SubprocessResult, TerminationReason
+        from autoskillit.execution.headless import DefaultHeadlessExecutor
+        from tests.fakes import MockSubprocessRunner
+
+        runner = MockSubprocessRunner()
+        runner.set_default(
+            SubprocessResult(
+                returncode=0,
+                stdout=self._make_success_stdout(),
+                stderr="",
+                termination=TerminationReason.NATURAL_EXIT,
+                pid=12345,
+            )
+        )
+        minimal_ctx.runner = runner
+        minimal_ctx.plugin_dir = str(tmp_path)
+
+        executor = DefaultHeadlessExecutor(minimal_ctx)
+        await executor.dispatch_food_truck(
+            "You are an L2 orchestrator",
+            str(tmp_path),
+            completion_marker="%%FT_DONE%%",
+            requires_packs=[],
+        )
+
+        assert runner.call_args_list, "runner was never called"
+        _cmd, _cwd, _timeout, kwargs = runner.call_args_list[0]
+        env = kwargs.get("env")
+        assert env is not None
+        assert "AUTOSKILLIT_L2_TOOL_TAGS" not in env
+
+
 def test_default_executor_satisfies_protocol_with_dispatch(minimal_ctx) -> None:
     """DefaultHeadlessExecutor satisfies HeadlessExecutor protocol with dispatch_food_truck."""
     from autoskillit.core import HeadlessExecutor

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -94,6 +94,7 @@ class DispatchFoodTruckCall:
     stale_threshold: float | None = None
     idle_output_timeout: float | None = None
     env_extras: Mapping[str, str] | None = None
+    requires_packs: Sequence[str] = ()
     on_spawn: Callable[[int], None] | None = None
 
 
@@ -190,6 +191,7 @@ class InMemoryHeadlessExecutor(HeadlessExecutor):
         stale_threshold: float | None = None,
         idle_output_timeout: float | None = None,
         env_extras: Mapping[str, str] | None = None,
+        requires_packs: Sequence[str] = (),
         on_spawn: Callable[[int], None] | None = None,
     ) -> SkillResult:
         self.dispatch_calls.append(
@@ -205,6 +207,7 @@ class InMemoryHeadlessExecutor(HeadlessExecutor):
                 stale_threshold=stale_threshold,
                 idle_output_timeout=idle_output_timeout,
                 env_extras=env_extras,
+                requires_packs=requires_packs,
                 on_spawn=on_spawn,
             )
         )

--- a/tests/server/test_server_init.py
+++ b/tests/server/test_server_init.py
@@ -697,6 +697,89 @@ class TestSessionTypeVisibility:
             assert name not in tool_names, f"{name} (kitchen) should be hidden for leaf+headless"
 
     @pytest.mark.anyio
+    async def test_food_truck_with_tool_tags_sees_kitchen_core_plus_declared(self, monkeypatch):
+        """ORCHESTRATOR+HEADLESS with L2_TOOL_TAGS sees kitchen-core + github only."""
+        from fastmcp.client import Client
+
+        from autoskillit.server import _apply_session_type_visibility, mcp
+
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "orchestrator")
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        monkeypatch.setenv("AUTOSKILLIT_L2_TOOL_TAGS", "github")
+        _apply_session_type_visibility()
+
+        async with Client(mcp) as client:
+            tools = await client.list_tools()
+        tool_names = {t.name for t in tools}
+
+        assert "run_cmd" in tool_names
+        assert "run_skill" in tool_names
+        assert "merge_worktree" in tool_names
+        assert "fetch_github_issue" in tool_names
+        assert "wait_for_ci" not in tool_names
+        assert "clone_repo" not in tool_names
+
+    @pytest.mark.anyio
+    async def test_food_truck_with_multiple_packs(self, monkeypatch):
+        """ORCHESTRATOR+HEADLESS with L2_TOOL_TAGS=github,ci sees both packs."""
+        from fastmcp.client import Client
+
+        from autoskillit.server import _apply_session_type_visibility, mcp
+
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "orchestrator")
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        monkeypatch.setenv("AUTOSKILLIT_L2_TOOL_TAGS", "github,ci")
+        _apply_session_type_visibility()
+
+        async with Client(mcp) as client:
+            tools = await client.list_tools()
+        tool_names = {t.name for t in tools}
+
+        assert "fetch_github_issue" in tool_names
+        assert "wait_for_ci" in tool_names
+        assert "clone_repo" not in tool_names
+
+    @pytest.mark.anyio
+    async def test_food_truck_without_tool_tags_sees_full_kitchen(self, monkeypatch):
+        """ORCHESTRATOR+HEADLESS without L2_TOOL_TAGS falls back to full kitchen."""
+        from fastmcp.client import Client
+
+        from autoskillit.core import GATED_TOOLS
+        from autoskillit.server import _apply_session_type_visibility, mcp
+
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "orchestrator")
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        monkeypatch.delenv("AUTOSKILLIT_L2_TOOL_TAGS", raising=False)
+        _apply_session_type_visibility()
+
+        async with Client(mcp) as client:
+            tools = await client.list_tools()
+        tool_names = {t.name for t in tools}
+
+        for name in GATED_TOOLS:
+            assert name in tool_names
+
+    @pytest.mark.anyio
+    async def test_cook_interactive_unaffected_by_tool_tags(self, monkeypatch):
+        """Interactive ORCHESTRATOR (cook) ignores L2_TOOL_TAGS."""
+        from fastmcp.client import Client
+
+        from autoskillit.core import GATED_TOOLS
+        from autoskillit.server import _apply_session_type_visibility, mcp
+
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "orchestrator")
+        monkeypatch.delenv("AUTOSKILLIT_HEADLESS", raising=False)
+        monkeypatch.setenv("AUTOSKILLIT_L2_TOOL_TAGS", "github")
+        _apply_session_type_visibility()
+
+        async with Client(mcp) as client:
+            tools = await client.list_tools()
+        tool_names = {t.name for t in tools}
+
+        for name in GATED_TOOLS:
+            assert name not in tool_names
+
+    @pytest.mark.anyio
     async def test_leaf_interactive_no_pre_reveal(self, monkeypatch):
         from fastmcp.client import Client
 


### PR DESCRIPTION
## Summary

Modify the food truck (L2 orchestrator+headless) startup path to selectively enable only `kitchen-core` plus the packs declared in `AUTOSKILLIT_L2_TOOL_TAGS` instead of revealing the entire kitchen surface. The dispatch side injects this env var from `recipe.requires_packs`. Cook/order (interactive) and L3 franchise sessions remain unchanged.

## Architecture Impact

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START([SESSION START])

    subgraph Dispatch ["● SESSION TYPE DISPATCH — _session_type.py"]
        FRANCHISE["FRANCHISE<br/>━━━━━━━━━━<br/>tags: franchise"]
        ORCH_L2["ORCHESTRATOR + HEADLESS + L2_TOOL_TAGS<br/>━━━━━━━━━━<br/>tags: kitchen-core + pack tags"]
        ORCH_H["ORCHESTRATOR + HEADLESS<br/>━━━━━━━━━━<br/>tags: kitchen"]
        LEAF_H["LEAF + HEADLESS<br/>━━━━━━━━━━<br/>tags: headless — test_check only"]
        INTERACTIVE["INTERACTIVE SESSION<br/>━━━━━━━━━━<br/>no pre-reveal — tools hidden"]
    end

    subgraph Fields ["FIELD LIFECYCLE CATEGORIES — ● _type_protocols.py"]
        INIT_F["INIT_ONLY — frozen dataclass<br/>━━━━━━━━━━<br/>ValidatedAddDir.path<br/>WriteBehaviorSpec.mode / expected_when<br/>CIRunScope.*"]
        SET_F["SET-ONCE — via make_context<br/>━━━━━━━━━━<br/>config, audit, gate, runner<br/>executor, recipes, token_log<br/>timing_log, session_skill_manager"]
        MUT_F["LIFECYCLE-MUTABLE<br/>━━━━━━━━━━<br/>kitchen_id — set at open_kitchen<br/>active_recipe_packs — None when closed<br/>quota_refresh_task, franchise_lock<br/>DefaultGateState.enabled"]
        APPEND_F["APPEND-ONLY — protocol write<br/>━━━━━━━━━━<br/>AuditLog — record_failure / record_success<br/>TokenLog / TimingLog — record<br/>assistant_messages, tool_uses<br/>McpResponseLog — record"]
        REPLACE_F["REPLACE-ONLY — dataclasses.replace<br/>━━━━━━━━━━<br/>SkillResult — all gate mutations<br/>ClaudeSessionResult — all updates<br/>No direct field assignment post-construction"]
        COMPUTED_F["COMPUTED — not stored<br/>━━━━━━━━━━<br/>SkillResult.outcome<br/>ClaudeSessionResult.needs_retry<br/>.agent_result, .session_complete<br/>.last_stop_reason, .lifespan_started"]
    end

    subgraph GateTransitions ["GATE STATE TRANSITIONS — GateState Protocol"]
        G_CLOSED["enabled = False<br/>━━━━━━━━━━<br/>Initial state<br/>All GATED_TOOLS blocked"]
        G_OPEN["enabled = True<br/>━━━━━━━━━━<br/>After open_kitchen<br/>GATED_TOOLS allowed"]
        G_CHECK["_require_enabled<br/>━━━━━━━━━━<br/>gate_error_result if closed<br/>subtype=gate_error, needs_retry=False"]
    end

    subgraph ValPipeline ["● VALIDATION GATE PIPELINE — headless.py _build_skill_result"]
        V1["1 Termination Routing<br/>━━━━━━━━━━<br/>STALE — recovery attempt on stdout<br/>IDLE_STALL — synthetic session<br/>TIMED_OUT — synthetic session"]
        V2["2 Channel B Recovery<br/>━━━━━━━━━━<br/>CHANNEL_B + UNPARSEABLE/EMPTY<br/>Drain-race repair via assistant_messages"]
        V3["3 Marker Recovery<br/>━━━━━━━━━━<br/>_recover_from_separate_marker<br/>DIR_MISSING late-bind path"]
        V4["4 Pattern Recovery<br/>━━━━━━━━━━<br/>_recover_block_from_assistant_messages<br/>expected_output_patterns scan"]
        V5["5 Artifact Synthesis<br/>━━━━━━━━━━<br/>UNMONITORED only — not CHANNEL_A/B<br/>Write/Edit file_path token injection"]
        V6["6 _compute_outcome<br/>━━━━━━━━━━<br/>Sets success / needs_retry<br/>retry_reason per CliSubtype"]
        V7["7 _capture_failure<br/>━━━━━━━━━━<br/>audit.record_failure — APPEND-ONLY<br/>Write-only side effect on audit log"]
        V8["8 Path Contamination<br/>━━━━━━━━━━<br/>_validate_output_paths<br/>CWD boundary enforcement<br/>subtype=path_contamination"]
        V9["9 Budget Guard 1st pass<br/>━━━━━━━━━━<br/>audit.consecutive_failures check<br/>BUDGET_EXHAUSTED override"]
        V10["10 CONTRACT_RECOVERY Gate<br/>━━━━━━━━━━<br/>adjudicated_failure + write_call_count >= 1<br/>_attempt_contract_nudge — 60s timeout<br/>--resume session_id nudge"]
        V11["11 Budget Guard 2nd pass<br/>━━━━━━━━━━<br/>Caps CONTRACT_RECOVERY retries<br/>Same budget check after recovery gate"]
        V12["12 Zero-Write Gate<br/>━━━━━━━━━━<br/>write_behavior.mode=always or conditional<br/>pattern match on result<br/>subtype=zero_writes demotion"]
    end

    subgraph ResumeStrategy ["RESUME DETECTION — ClaudeSessionResult._is_context_exhausted"]
        R1["Path 1 — JSONL Flat-Record<br/>━━━━━━━━━━<br/>jsonl_context_exhausted = True<br/>_detect_flat_context_exhaustion<br/>Bypasses is_error guard"]
        R2["Path 2 — Structured Errors List<br/>━━━━━━━━━━<br/>is_error=True + CONTEXT_EXHAUSTION_MARKER<br/>in errors list"]
        R3["Path 3 — Result Text Fallback<br/>━━━━━━━━━━<br/>is_error=True + subtype in SUCCESS/MAX_TURNS<br/>marker in result.lower"]
        RESUME_CMD["build_headless_resume_cmd<br/>━━━━━━━━━━<br/>--resume session_id<br/>retry_reason=RESUME — safe to resume"]
        SCRATCH["Retry From Scratch<br/>━━━━━━━━━━<br/>STALE, ZERO_WRITES<br/>PATH_CONTAMINATION<br/>CONTRACT_RECOVERY"]
    end

    FINAL["SkillResult — REPLACE-ONLY<br/>━━━━━━━━━━<br/>All mutations via dataclasses.replace<br/>success, needs_retry, retry_reason<br/>subtype, write_call_count, kill_reason"]

    START --> Dispatch
    FRANCHISE --> G_CLOSED
    ORCH_L2 --> G_CLOSED
    ORCH_H --> G_CLOSED
    LEAF_H --> G_CLOSED
    INTERACTIVE --> G_CLOSED

    SET_F --> G_CLOSED
    MUT_F -.->|"enable on open_kitchen"| G_OPEN
    INIT_F -.->|"immutable inputs"| V1
    REPLACE_F -.->|"replace pattern enforced"| V1

    G_CLOSED -->|"enable() on open_kitchen"| G_OPEN
    G_OPEN --> G_CHECK
    G_CHECK -->|"gate open"| V1
    G_CHECK -->|"gate closed"| FINAL

    V1 --> V2 --> V3 --> V4 --> V5 --> V6 --> V7 --> V8 --> V9 --> V10 --> V11 --> V12 --> FINAL

    APPEND_F -.->|"record_failure append"| V7

    FINAL --> R1
    FINAL --> R2
    FINAL --> R3
    R1 --> RESUME_CMD
    R2 --> RESUME_CMD
    R3 --> RESUME_CMD
    FINAL -->|"retry_reason != RESUME"| SCRATCH
    COMPUTED_F -.->|"derived from FINAL"| FINAL

    class FRANCHISE,ORCH_L2,ORCH_H,LEAF_H,INTERACTIVE cli;
    class INIT_F,SET_F stateNode;
    class MUT_F,APPEND_F phase;
    class REPLACE_F,COMPUTED_F output;
    class G_CLOSED,G_OPEN handler;
    class G_CHECK detector;
    class V1,V2,V3,V4,V5 phase;
    class V6 handler;
    class V7 output;
    class V8,V9,V10,V11,V12 detector;
    class FINAL stateNode;
    class R1,R2,R3 cli;
    class RESUME_CMD output;
    class SCRATCH gap;
    class START terminal;
```

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 42, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START])
    SUCCESS([SUCCESS SkillResult])
    FAILURE([FAILURE SkillResult])
    CRASHED([CRASHED SkillResult])

    subgraph Dispatch ["● Dispatch Entry — HeadlessExecutor Protocol"]
        direction TB
        RunCall["● DefaultHeadlessExecutor.run()<br/>━━━━━━━━━━<br/>skill_command, cwd, model,<br/>add_dirs, timeouts, patterns"]
        FoodTruckCall["● DefaultHeadlessExecutor.dispatch_food_truck()<br/>━━━━━━━━━━<br/>orchestrator_prompt, cwd,<br/>completion_marker, requires_packs"]
        BuildCmd{"Build Cmd<br/>━━━━━━━━━━<br/>run() → build_leaf_headless_cmd<br/>dispatch → build_food_truck_cmd"}
    end

    subgraph PackResolution ["● Pack Resolution — requires_packs → L2_TOOL_TAGS"]
        direction TB
        PackCheck{"requires_packs<br/>present?"}
        InjectPacks["● Inject env: AUTOSKILLIT_L2_TOOL_TAGS<br/>━━━━━━━━━━<br/>\",\".join(sorted(requires_packs))<br/>merged into env_extras"]
        NoPacksPath["No pack tag injection<br/>━━━━━━━━━━<br/>env_extras passed as-is"]
    end

    subgraph SessionTypeDispatch ["● Session-Type Tag Visibility — _session_type.py"]
        direction TB
        ResolveSession["● _apply_session_type_visibility()<br/>━━━━━━━━━━<br/>reads SessionType + HEADLESS_ENV_VAR"]
        SessionBranch{"Session type?"}
        FranchisePath["FRANCHISE<br/>━━━━━━━━━━<br/>mcp.enable(tags={'franchise'})"]
        OrchestratorBranch{"ORCHESTRATOR<br/>+ headless?"}
        L2TagsCheck{"● AUTOSKILLIT_L2_TOOL_TAGS<br/>set in env?"}
        EnablePackTags["● Enable kitchen-core<br/>+ per-pack tags<br/>━━━━━━━━━━<br/>mcp.enable({'kitchen-core'})<br/>for each pack: mcp.enable({pack})"]
        EnableKitchen["Enable full kitchen<br/>━━━━━━━━━━<br/>mcp.enable({'kitchen'})"]
        LeafHeadless["LEAF + headless<br/>━━━━━━━━━━<br/>mcp.enable({'headless'})"]
        NoReveal["Interactive sessions<br/>━━━━━━━━━━<br/>no pre-reveal<br/>open_kitchen unlocks later"]
    end

    subgraph Execution ["● Headless Execution — _execute_claude_headless"]
        direction TB
        CloneSnap["Clone snapshot<br/>━━━━━━━━━━<br/>if worktree_skill and not worktree"]
        SubprocRun["● runner(spec.cmd, cwd, timeout,<br/>env, pty_mode, session_log_dir,<br/>completion_marker, stale_threshold)<br/>━━━━━━━━━━<br/>SubprocessResult"]
        ExcBranch{"Exception?"}
        CrashLog["flush_session_log<br/>(crashed/cancelled)<br/>━━━━━━━━━━<br/>exit_code=-1"]
        TermBranch{"Termination<br/>reason?"}
    end

    subgraph ResultBuilding ["● _build_skill_result — Termination Routing"]
        direction TB
        StaleCheck{"STALE?<br/>━━━━━━━━━━<br/>try stdout recovery"}
        StaleRecover["Stale recovery<br/>━━━━━━━━━━<br/>parse_session_result<br/>→ SkillResult(recovered_from_stale)"]
        IdleStall["IDLE_STALL<br/>━━━━━━━━━━<br/>SkillResult(idle_stall)<br/>needs_retry=True"]
        TimeoutBranch["TIMED_OUT<br/>━━━━━━━━━━<br/>subtype=TIMEOUT<br/>is_error=True"]
        NormalParse["NORMAL<br/>━━━━━━━━━━<br/>parse_session_result(stdout)"]
    end

    subgraph Recovery ["Recovery Paths — Channel B + Pattern + Contract"]
        direction TB
        ChanBCheck{"ChannelConfirmation?<br/>━━━━━━━━━━<br/>CHANNEL_B or DIR_MISSING<br/>+ recoverable subtype?"}
        DrainRace["Channel B drain-race recovery<br/>━━━━━━━━━━<br/>_recover_from_separate_marker()<br/>→ promote to SUCCESS subtype"]
        PatternCheck{"expected_patterns<br/>missing from result?"}
        PatternRecover["_recover_block_from_assistant_messages()<br/>━━━━━━━━━━<br/>rebuild result from assistant_messages"]
        ArtifactSynth["_synthesize_from_write_artifacts()<br/>━━━━━━━━━━<br/>UNMONITORED only: inject<br/>token_name=file_path from Write/Edit"]
        ComputeOutcome["_compute_outcome()<br/>━━━━━━━━━━<br/>→ SUCCEEDED / RETRIABLE / FAILED"]
    end

    subgraph Guards ["Result Guards — Budget + Contract + Zero-Write"]
        direction TB
        BudgetGuard["_apply_budget_guard()<br/>━━━━━━━━━━<br/>consecutive_failures > max?<br/>→ retry_reason=BUDGET_EXHAUSTED"]
        ContractGate{"adjudicated_failure<br/>+ write_call_count ≥ 1?"}
        ContractNudge["_attempt_contract_nudge()<br/>━━━━━━━━━━<br/>resume session: emit missing token<br/>60s timeout, 1 attempt"]
        NudgeSuccess{"Nudge patterns<br/>found?"}
        ContractPromo["Promote: needs_retry=True<br/>retry_reason=CONTRACT_RECOVERY<br/>━━━━━━━━━━<br/>re-apply budget_guard"]
        ZeroWriteGate{"success + write_count=0<br/>+ write_behavior=always?"}
        ZeroWriteDemote["Demote: success=False<br/>subtype=zero_writes<br/>━━━━━━━━━━<br/>needs_retry=True<br/>retry_reason=ZERO_WRITES"]
    end

    subgraph PostProcess ["Post-Processing"]
        direction TB
        CloneGuard["check_and_revert_clone_contamination()<br/>━━━━━━━━━━<br/>if clone_snapshot present"]
        SessionLog["flush_session_log()<br/>━━━━━━━━━━<br/>proc_snapshots or failed<br/>or step_name set"]
        TokenLog["ctx.token_log.record()<br/>━━━━━━━━━━<br/>if step_name set"]
    end

    %% MAIN FLOW %%
    START --> RunCall
    START --> FoodTruckCall
    RunCall --> BuildCmd
    FoodTruckCall --> PackCheck
    PackCheck -->|"yes"| InjectPacks
    PackCheck -->|"no"| NoPacksPath
    InjectPacks --> BuildCmd
    NoPacksPath --> BuildCmd

    %% Session type dispatch (parallel startup path) %%
    START --> ResolveSession
    ResolveSession --> SessionBranch
    SessionBranch -->|"FRANCHISE"| FranchisePath
    SessionBranch -->|"ORCHESTRATOR"| OrchestratorBranch
    SessionBranch -->|"LEAF"| LeafHeadless
    OrchestratorBranch -->|"headless=true"| L2TagsCheck
    OrchestratorBranch -->|"interactive"| NoReveal
    L2TagsCheck -->|"set"| EnablePackTags
    L2TagsCheck -->|"not set"| EnableKitchen

    %% Execution flow %%
    BuildCmd --> CloneSnap
    CloneSnap --> SubprocRun
    SubprocRun --> ExcBranch
    ExcBranch -->|"Exception / BaseException"| CrashLog
    CrashLog --> CRASHED
    ExcBranch -->|"ok"| TermBranch

    TermBranch -->|"STALE"| StaleCheck
    TermBranch -->|"IDLE_STALL"| IdleStall
    TermBranch -->|"TIMED_OUT"| TimeoutBranch
    TermBranch -->|"COMPLETED"| NormalParse

    StaleCheck -->|"stdout valid"| StaleRecover
    StaleCheck -->|"no valid result"| IdleStall
    StaleRecover --> PostProcess
    IdleStall --> BudgetGuard

    TimeoutBranch --> ChanBCheck
    NormalParse --> ChanBCheck

    ChanBCheck -->|"CHANNEL_B/DIR_MISSING + recoverable"| DrainRace
    ChanBCheck -->|"other"| PatternCheck
    DrainRace --> PatternCheck
    PatternCheck -->|"patterns missing"| PatternRecover
    PatternCheck -->|"UNMONITORED + writes"| ArtifactSynth
    PatternCheck -->|"satisfied"| ComputeOutcome
    PatternRecover --> ComputeOutcome
    ArtifactSynth --> ComputeOutcome

    ComputeOutcome --> BudgetGuard
    BudgetGuard --> ContractGate
    ContractGate -->|"yes"| ContractNudge
    ContractGate -->|"no"| ZeroWriteGate
    ContractNudge --> NudgeSuccess
    NudgeSuccess -->|"yes → patched SkillResult"| PostProcess
    NudgeSuccess -->|"no"| ContractPromo
    ContractPromo --> ZeroWriteGate
    ZeroWriteGate -->|"yes"| ZeroWriteDemote
    ZeroWriteGate -->|"no"| CloneGuard
    ZeroWriteDemote --> CloneGuard

    CloneGuard --> SessionLog
    SessionLog --> TokenLog
    TokenLog --> SUCCESS
    TokenLog --> FAILURE

    %% CLASS ASSIGNMENTS %%
    class START,SUCCESS,FAILURE,CRASHED terminal;
    class RunCall,FoodTruckCall handler;
    class BuildCmd,ExcBranch,TermBranch,StaleCheck,PackCheck,OrchestratorBranch,ChanBCheck,PatternCheck,ContractGate,NudgeSuccess,ZeroWriteGate stateNode;
    class SessionBranch,L2TagsCheck stateNode;
    class InjectPacks,NoPacksPath,PackResolution newComponent;
    class EnablePackTags newComponent;
    class EnableKitchen,FranchisePath,LeafHeadless,NoReveal phase;
    class ResolveSession,ResolveSession phase;
    class CloneSnap,SubprocRun,StaleRecover,IdleStall,TimeoutBranch,NormalParse handler;
    class DrainRace,PatternRecover,ArtifactSynth,ContractNudge,ContractPromo handler;
    class BudgetGuard,ZeroWriteDemote detector;
    class CrashLog,CloneGuard detector;
    class SessionLog,TokenLog output;
    class ComputeOutcome phase;
```

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph L0 ["LAYER 0 — CORE (Foundation, stdlib-only)"]
        direction LR
        RESULTS["core/_type_results.py<br/>━━━━━━━━━━<br/>SkillResult, TestResult<br/>FailureRecord, CleanupResult<br/>CIRunScope, CloneResult"]
        PROTOCOLS["● core/_type_protocols.py<br/>━━━━━━━━━━<br/>HeadlessExecutor, SubprocessRunner<br/>GateState, TestRunner, CIWatcher<br/>25 Protocol definitions"]
        TYPES["core/types.py<br/>━━━━━━━━━━<br/>Re-export hub<br/>star-imports _type_protocols<br/>+ _type_results, _type_enums"]
    end

    subgraph L1E ["LAYER 1 — EXECUTION"]
        direction LR
        COMMANDS["execution/commands.py<br/>━━━━━━━━━━<br/>build_headless_cmd<br/>build_leaf_headless_cmd<br/>ClaudeHeadlessCmd"]
        HEADLESS["● execution/headless.py<br/>━━━━━━━━━━<br/>DefaultHeadlessExecutor<br/>run_headless_core<br/>Implements HeadlessExecutor protocol"]
    end

    subgraph L3S ["LAYER 3 — SERVER"]
        direction LR
        SESSION_TYPE["● server/_session_type.py<br/>━━━━━━━━━━<br/>_apply_session_type_visibility()<br/>FRANCHISE / ORCHESTRATOR / LEAF<br/>maps SessionType → mcp.enable()"]
        SERVER_INIT["server/__init__.py<br/>━━━━━━━━━━<br/>FastMCP app bootstrap<br/>imports + re-exports<br/>_apply_session_type_visibility"]
    end

    subgraph TESTS ["TEST LAYER"]
        direction TB
        FAKES["● tests/fakes.py<br/>━━━━━━━━━━<br/>InMemoryHeadlessExecutor<br/>MockSubprocessRunner<br/>InMemoryTestRunner, CIWatcher etc.<br/>L0-only imports"]
        TEST_HEADLESS["● tests/execution/test_headless.py<br/>━━━━━━━━━━<br/>Tests DefaultHeadlessExecutor<br/>dispatch_food_truck<br/>JSONL parsing helpers"]
        TEST_COMMANDS["● tests/execution/test_commands.py<br/>━━━━━━━━━━<br/>Tests command builder functions<br/>ClaudeHeadlessCmd, ClaudeInteractiveCmd"]
        TEST_SERVER["● tests/server/test_server_init.py<br/>━━━━━━━━━━<br/>Tests _apply_session_type_visibility<br/>Kitchen gate + tool tag visibility"]
    end

    %% L0 INTRA-CORE %%
    PROTOCOLS -->|"imports (sibling)"| RESULTS
    TYPES -->|"star re-export"| PROTOCOLS

    %% L1 → L0 %%
    HEADLESS -->|"imports HeadlessExecutor<br/>protocol + core types"| TYPES
    HEADLESS -->|"uses command builders"| COMMANDS
    COMMANDS -->|"imports ClaudeFlags<br/>pkg_root, ValidatedAddDir"| TYPES

    %% L3 → L0 %%
    SESSION_TYPE -->|"imports SessionType<br/>HEADLESS_ENV_VAR<br/>session_type resolver"| TYPES
    SESSION_TYPE -.->|"deferred import<br/>(avoids circular)"| SERVER_INIT
    SERVER_INIT -->|"imports + calls at init"| SESSION_TYPE

    %% TEST → L0 %%
    FAKES -->|"imports only L0<br/>HeadlessExecutor, SubprocessRunner<br/>CIWatcher etc."| TYPES

    %% TEST → L1 %%
    TEST_HEADLESS -->|"tests internals"| HEADLESS
    TEST_HEADLESS -->|"uses MockSubprocessRunner"| FAKES
    TEST_COMMANDS -->|"tests command builders"| COMMANDS
    TEST_COMMANDS -->|"imports ClaudeFlags, ValidatedAddDir"| TYPES

    %% TEST → L3 %%
    TEST_SERVER -->|"tests via re-export"| SERVER_INIT
    TEST_SERVER -->|"imports _apply_session_type_visibility"| SESSION_TYPE

    %% CLASS ASSIGNMENTS %%
    class PROTOCOLS,RESULTS,TYPES stateNode;
    class HEADLESS,COMMANDS handler;
    class SESSION_TYPE,SERVER_INIT phase;
    class FAKES output;
    class TEST_HEADLESS,TEST_COMMANDS,TEST_SERVER cli;
```

Closes #886

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260420-090133-275988/.autoskillit/temp/make-plan/franchise_food_truck_startup_pack_filter_plan_2026-04-20_091500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 3.2k | 16.9k | 2.0M | 84.5k | 1 | 8m 30s |
| verify | 1.0k | 18.8k | 2.4M | 75.0k | 1 | 9m 37s |
| implement | 350 | 15.6k | 2.3M | 63.3k | 1 | 5m 3s |
| prepare_pr | 60 | 4.8k | 190.2k | 24.2k | 1 | 1m 15s |
| run_arch_lenses | 193 | 27.3k | 661.3k | 174.7k | 3 | 10m 48s |
| compose_pr | 59 | 10.0k | 207.0k | 35.2k | 1 | 2m 30s |
| **Total** | 4.9k | 93.5k | 7.7M | 457.0k | | 37m 45s |