### PR TITLE
Rectify: Resume Intent Collapsed by Eager Session ID Resolution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,7 @@ generic_automation_mcp/
 │   ├── _type_results.py     #   LoadResult, SkillResult, FailureRecord, CleanupResult, etc.
 │   ├── _type_protocols.py   #   Protocols: GatePolicy, HeadlessExecutor, CIWatcher, etc.
 │   ├── _type_helpers.py
+│   ├── _type_resume.py      #   ResumeSpec discriminated union: NoResume, BareResume, NamedResume
 │   ├── _claude_env.py       #   IDE-scrubbing canonical env builder for claude subprocesses
 │   ├── _terminal_table.py   #   L0 color-agnostic terminal table primitive
 │   ├── _version_snapshot.py #   Process-scoped version snapshot for session telemetry (lru_cache'd)

--- a/src/autoskillit/cli/_cook.py
+++ b/src/autoskillit/cli/_cook.py
@@ -135,16 +135,12 @@ def cook(*, resume: bool = False, session_id: str | None = None) -> None:
     from autoskillit.cli._init_helpers import _is_plugin_installed
     from autoskillit.cli._onboarding import is_first_run, run_onboarding_menu
     from autoskillit.config import load_config
-    from autoskillit.core import configure_logging, find_latest_session_id, pkg_root
+    from autoskillit.core import configure_logging, pkg_root, resume_spec_from_cli
     from autoskillit.execution import build_interactive_cmd
 
     configure_logging()
 
-    resume_session_id: str | None = None
-    if resume:
-        resume_session_id = session_id or find_latest_session_id()
-        if resume_session_id is None:
-            print("No previous session found. Starting a fresh session.")
+    resume_spec = resume_spec_from_cli(resume=resume, session_id=session_id)
 
     project_dir = Path.cwd()
     initial_prompt: str | None = None
@@ -166,7 +162,7 @@ def cook(*, resume: bool = False, session_id: str | None = None) -> None:
         plugin_dir=plugin_dir,
         add_dirs=[skills_dir],
         initial_prompt=initial_prompt,
-        resume_session_id=resume_session_id,
+        resume_spec=resume_spec,
     )
     _run_cook_session(
         cmd=spec.cmd,

--- a/src/autoskillit/cli/_session_launch.py
+++ b/src/autoskillit/cli/_session_launch.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 import shutil
 import subprocess
 import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from autoskillit.core import ResumeSpec
 
 
 def _run_interactive_session(
@@ -12,7 +16,7 @@ def _run_interactive_session(
     *,
     initial_message: str | None = None,
     extra_env: dict[str, str] | None = None,
-    resume_session_id: str | None = None,
+    resume_spec: ResumeSpec | None = None,
 ) -> None:
     """Launch an interactive Claude Code session with the given system prompt."""
     if shutil.which("claude") is None:
@@ -20,12 +24,12 @@ def _run_interactive_session(
         sys.exit(1)
     from autoskillit.cli._init_helpers import _is_plugin_installed
     from autoskillit.cli._terminal import terminal_guard
-    from autoskillit.core import ClaudeFlags, pkg_root
+    from autoskillit.core import ClaudeFlags, NoResume, pkg_root
     from autoskillit.execution import build_interactive_cmd
 
     spec = build_interactive_cmd(
         initial_prompt=initial_message,
-        resume_session_id=resume_session_id,
+        resume_spec=resume_spec if resume_spec is not None else NoResume(),
         env_extras=extra_env,
     )
     plugin_flags = [] if _is_plugin_installed() else [ClaudeFlags.PLUGIN_DIR, str(pkg_root())]

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -32,7 +32,14 @@ from autoskillit.cli._init_helpers import (
     _register_all,
 )
 from autoskillit.cli._prompts import _build_orchestrator_prompt, _get_ingredients_table
-from autoskillit.core import RecipeSource, atomic_write, pkg_root
+from autoskillit.core import (
+    NoResume,
+    RecipeSource,
+    ResumeSpec,
+    atomic_write,
+    pkg_root,
+    resume_spec_from_cli,
+)
 
 app = App(
     name="autoskillit",
@@ -445,7 +452,7 @@ def _launch_cook_session(
     *,
     initial_message: str | None = None,
     extra_env: dict[str, str] | None = None,
-    resume_session_id: str | None = None,
+    resume_spec: ResumeSpec = NoResume(),
 ) -> None:
     """Launch an interactive Claude Code cook session with the given system prompt."""
     from autoskillit.cli._session_launch import _run_interactive_session
@@ -454,7 +461,7 @@ def _launch_cook_session(
         system_prompt,
         initial_message=initial_message,
         extra_env=extra_env,
-        resume_session_id=resume_session_id,
+        resume_spec=resume_spec,
     )
 
 
@@ -522,8 +529,8 @@ def _cook_cmd(session_id: str | None = None, *, resume: bool = False) -> None:
     """Launch an interactive Claude session with all skills and kitchen tools.
 
     Use --resume to restore a previous session. Optionally provide a session ID
-    directly after --resume to target a specific session; omit for automatic
-    discovery of the most recent session.
+    directly after --resume to target a specific session; omit to present
+    Claude Code's interactive session picker.
     """
     cook_interactive(resume=resume or (session_id is not None), session_id=session_id)
 
@@ -559,14 +566,10 @@ def order(recipe: str | None = None, session_id: str | None = None, *, resume: b
         print("Run this command in a regular terminal.")
         sys.exit(1)
 
-    # Resolve resume session ID — must come before the 'if recipe is None:' block
-    from autoskillit.core import find_latest_session_id
-
-    resume_session_id: str | None = None
-    if resume or session_id:
-        resume_session_id = session_id or find_latest_session_id()
-        if resume_session_id is None:
-            print("No previous session found. Starting a fresh session.")
+    # Build resume intent — must come before the 'if recipe is None:' block
+    resume_spec = resume_spec_from_cli(
+        resume=resume or (session_id is not None), session_id=session_id
+    )
 
     mcp_prefix = detect_autoskillit_mcp_prefix()
 
@@ -601,7 +604,7 @@ def order(recipe: str | None = None, session_id: str | None = None, *, resume: b
             _launch_cook_session(
                 _build_open_kitchen_prompt(mcp_prefix=mcp_prefix),
                 initial_message=greeting,
-                resume_session_id=resume_session_id,
+                resume_spec=resume_spec,
             )
             return
         elif resolved is None:
@@ -717,7 +720,7 @@ def order(recipe: str | None = None, session_id: str | None = None, *, resume: b
         _build_orchestrator_prompt(recipe, mcp_prefix=mcp_prefix, ingredients_table=_itable),
         initial_message=greeting,
         extra_env=_extra_env if _extra_env else None,
-        resume_session_id=resume_session_id,
+        resume_spec=resume_spec,
     )
 
 

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -528,9 +528,8 @@ def _enable_subsets_permanently(project_dir: Path, subsets: frozenset[str]) -> N
 def _cook_cmd(session_id: str | None = None, *, resume: bool = False) -> None:
     """Launch an interactive Claude session with all skills and kitchen tools.
 
-    Use --resume to restore a previous session. Optionally provide a session ID
-    directly after --resume to target a specific session; omit to present
-    Claude Code's interactive session picker.
+    Use --resume to restore a previous session. Pass a session ID to target a
+    specific one, or omit for Claude Code's interactive picker.
     """
     cook_interactive(resume=resume or (session_id is not None), session_id=session_id)
 
@@ -565,11 +564,8 @@ def order(recipe: str | None = None, session_id: str | None = None, *, resume: b
         print("ERROR: 'order' cannot run inside a Claude Code session.")
         print("Run this command in a regular terminal.")
         sys.exit(1)
-
-    # Build resume intent — must come before the 'if recipe is None:' block
-    resume_spec = resume_spec_from_cli(
-        resume=resume or (session_id is not None), session_id=session_id
-    )
+    _resume = resume or (session_id is not None)
+    resume_spec = resume_spec_from_cli(resume=_resume, session_id=session_id)
 
     mcp_prefix = detect_autoskillit_mcp_prefix()
 

--- a/src/autoskillit/core/__init__.py
+++ b/src/autoskillit/core/__init__.py
@@ -107,6 +107,7 @@ from .types import (
     UNGATED_TOOLS,
     AuditLog,
     BackgroundSupervisor,
+    BareResume,
     ChannelBStatus,
     ChannelConfirmation,
     CIRunScope,
@@ -133,6 +134,8 @@ from .types import (
     MergeQueueWatcher,
     MergeState,
     MigrationService,
+    NamedResume,
+    NoResume,
     OutputFormat,
     OutputPatternResolver,
     PackDef,
@@ -142,6 +145,7 @@ from .types import (
     RecipeRepository,
     RecipeSource,
     RestartScope,
+    ResumeSpec,
     RetryReason,
     SessionOutcome,
     SessionSkillManager,
@@ -168,6 +172,7 @@ from .types import (
     extract_path_arg,
     extract_skill_name,
     resolve_target_skill,
+    resume_spec_from_cli,
     session_type,
     truncate_text,
 )
@@ -309,6 +314,12 @@ __all__ = [
     "TokenLog",
     "WorkspaceManager",
     "truncate_text",
+    # _type_resume
+    "NoResume",
+    "BareResume",
+    "NamedResume",
+    "ResumeSpec",
+    "resume_spec_from_cli",
     # _version_snapshot
     "collect_version_snapshot",
     # _plugin_cache

--- a/src/autoskillit/core/_type_resume.py
+++ b/src/autoskillit/core/_type_resume.py
@@ -41,7 +41,7 @@ ResumeSpec = NoResume | BareResume | NamedResume
 
 def resume_spec_from_cli(*, resume: bool, session_id: str | None) -> ResumeSpec:
     """Construct a ResumeSpec from CLI input without any I/O."""
-    if session_id is not None:
+    if session_id:
         return NamedResume(session_id=session_id)
     if resume:
         return BareResume()

--- a/src/autoskillit/core/_type_resume.py
+++ b/src/autoskillit/core/_type_resume.py
@@ -1,0 +1,48 @@
+"""Resume intent discriminated union for interactive session launch.
+
+Three sealed variants make the three user intents structurally distinct:
+- NoResume: start a fresh session (no --resume flag)
+- BareResume: pass --resume without an ID (delegate to Claude Code's picker)
+- NamedResume: pass --resume <id> (resume a specific session)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = [
+    "NoResume",
+    "BareResume",
+    "NamedResume",
+    "ResumeSpec",
+    "resume_spec_from_cli",
+]
+
+
+@dataclass(frozen=True)
+class NoResume:
+    """No resume: start a fresh session."""
+
+
+@dataclass(frozen=True)
+class BareResume:
+    """Bare --resume: delegate session selection to Claude Code's picker."""
+
+
+@dataclass(frozen=True)
+class NamedResume:
+    """--resume <id>: resume a specific named session."""
+
+    session_id: str
+
+
+ResumeSpec = NoResume | BareResume | NamedResume
+
+
+def resume_spec_from_cli(*, resume: bool, session_id: str | None) -> ResumeSpec:
+    """Construct a ResumeSpec from CLI input without any I/O."""
+    if session_id is not None:
+        return NamedResume(session_id=session_id)
+    if resume:
+        return BareResume()
+    return NoResume()

--- a/src/autoskillit/core/types.py
+++ b/src/autoskillit/core/types.py
@@ -16,9 +16,17 @@ from ._type_protocols import *  # noqa: F401, F403
 from ._type_protocols import __all__ as _protocols_all
 from ._type_results import *  # noqa: F401, F403
 from ._type_results import __all__ as _results_all
+from ._type_resume import *  # noqa: F401, F403
+from ._type_resume import __all__ as _resume_all
 from ._type_subprocess import *  # noqa: F401, F403
 from ._type_subprocess import __all__ as _subprocess_all
 
 __all__ = (
-    _constants_all + _enums_all + _helpers_all + _protocols_all + _results_all + _subprocess_all
+    _constants_all
+    + _enums_all
+    + _helpers_all
+    + _protocols_all
+    + _results_all
+    + _resume_all
+    + _subprocess_all
 )

--- a/src/autoskillit/execution/commands.py
+++ b/src/autoskillit/execution/commands.py
@@ -13,7 +13,11 @@ from autoskillit.core import (
     KITCHEN_SESSION_ID_ENV_VAR,
     SESSION_TYPE_LEAF,
     SESSION_TYPE_ORCHESTRATOR,
+    BareResume,
     ClaudeFlags,
+    NamedResume,
+    NoResume,
+    ResumeSpec,
     ValidatedAddDir,
     build_claude_env,
     temp_dir_display_str,
@@ -53,7 +57,7 @@ def build_interactive_cmd(
     model: str | None = None,
     plugin_dir: Path | None = None,
     add_dirs: Sequence[Path | str | ValidatedAddDir] = (),
-    resume_session_id: str | None = None,
+    resume_spec: ResumeSpec = NoResume(),
     env_extras: Mapping[str, str] | None = None,
 ) -> ClaudeInteractiveCmd:
     """Build a Claude interactive session command.
@@ -70,14 +74,21 @@ def build_interactive_cmd(
         When provided, appended as ``--plugin-dir <path>``.
     add_dirs
         Each entry is appended as ``--add-dir <path>``.
-    resume_session_id
-        When provided, appended as ``--resume <id>`` before any positional prompt.
+    resume_spec
+        Resume intent discriminated union. ``NoResume`` (default) starts a fresh
+        session. ``BareResume`` passes ``--resume`` without an ID (Claude Code's
+        interactive picker). ``NamedResume`` passes ``--resume <id>``.
     env_extras
         Optional caller overrides merged into the resolved env after IDE scrubbing.
     """
     cmd = ["claude", ClaudeFlags.DANGEROUSLY_SKIP_PERMISSIONS]
-    if resume_session_id is not None:
-        cmd += [ClaudeFlags.RESUME, resume_session_id]
+    match resume_spec:
+        case NamedResume(session_id=sid):
+            cmd += [ClaudeFlags.RESUME, sid]
+        case BareResume():
+            cmd.append(ClaudeFlags.RESUME)
+        case NoResume():
+            pass
     if model:
         cmd += [ClaudeFlags.MODEL, model]
     if plugin_dir is not None:

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -704,7 +704,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "server": 20,
         "recipe": 36,
         "execution": 26,
-        "core": 21,
+        "core": 22,
         "cli": 22,
         "hooks": 21,
     }

--- a/tests/cli/test_cook.py
+++ b/tests/cli/test_cook.py
@@ -927,9 +927,13 @@ class TestCLIOrder:
         cmd = mock_run.call_args[0][0]
         assert "--resume" in cmd
         idx = cmd.index("--resume")
-        assert idx == len(cmd) - 1 or cmd[idx + 1].startswith("-"), (
-            "bare --resume must not be followed by a session ID"
-        )
+        # bare --resume: next token (if any) must not be a session ID;
+        # session IDs have no spaces, initial prompts and flags are distinguishable
+        if idx + 1 < len(cmd):
+            next_tok = str(cmd[idx + 1])
+            assert " " in next_tok or next_tok.startswith("-"), (
+                f"bare --resume must not be followed by a session ID, got: {next_tok!r}"
+            )
         assert not discovery_calls, "find_latest_session_id must not be called for bare --resume"
 
     @patch("autoskillit.cli.subprocess.run")
@@ -990,9 +994,13 @@ class TestCLIOrder:
         cmd = mock_run.call_args[0][0]
         assert "--resume" in cmd
         idx = cmd.index("--resume")
-        assert idx == len(cmd) - 1 or cmd[idx + 1].startswith("-"), (
-            "bare --resume must not be followed by a session ID"
-        )
+        # bare --resume: next token (if any) must not be a session ID;
+        # session IDs have no spaces, initial prompts and flags are distinguishable
+        if idx + 1 < len(cmd):
+            next_tok = str(cmd[idx + 1])
+            assert " " in next_tok or next_tok.startswith("-"), (
+                f"bare --resume must not be followed by a session ID, got: {next_tok!r}"
+            )
 
 
 class TestOrderDisplayOwnership:

--- a/tests/cli/test_cook.py
+++ b/tests/cli/test_cook.py
@@ -899,13 +899,13 @@ class TestCLIOrder:
         )
 
     @patch("autoskillit.cli.subprocess.run")
-    def test_order_resume_discovered_session_id_in_subprocess_cmd(
+    def test_order_resume_bare_flag_produces_bare_resume_skips_discovery(
         self,
         mock_run: MagicMock,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """order(resume=True) discovers session via find_latest_session_id and passes --resume."""
+        """order(resume=True) passes bare --resume; find_latest_session_id must not be called."""
         monkeypatch.delenv("CLAUDECODE", raising=False)
         monkeypatch.chdir(tmp_path)
         scripts_dir = tmp_path / ".autoskillit" / "recipes"
@@ -916,13 +916,21 @@ class TestCLIOrder:
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="", stderr=""
         )
+        discovery_calls: list = []
 
-        with patch("autoskillit.core.find_latest_session_id", return_value="sess_abc"):
+        with patch(
+            "autoskillit.core.find_latest_session_id",
+            side_effect=lambda *a, **kw: discovery_calls.append(1) or "sess_abc",
+        ):
             cli.order("test-script", resume=True)
 
         cmd = mock_run.call_args[0][0]
         assert "--resume" in cmd
-        assert cmd[cmd.index("--resume") + 1] == "sess_abc"
+        idx = cmd.index("--resume")
+        assert idx == len(cmd) - 1 or cmd[idx + 1].startswith("-"), (
+            "bare --resume must not be followed by a session ID"
+        )
+        assert not discovery_calls, "find_latest_session_id must not be called for bare --resume"
 
     @patch("autoskillit.cli.subprocess.run")
     def test_order_resume_explicit_session_id_skips_discovery(
@@ -959,13 +967,13 @@ class TestCLIOrder:
         )
 
     @patch("autoskillit.cli.subprocess.run")
-    def test_order_resume_no_prior_session_starts_fresh(
+    def test_order_resume_bare_flag_always_emits_resume(
         self,
         mock_run: MagicMock,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """order(resume=True) with no prior session omits --resume from subprocess command."""
+        """order(resume=True) always emits bare --resume; Claude Code handles empty history."""
         monkeypatch.delenv("CLAUDECODE", raising=False)
         monkeypatch.chdir(tmp_path)
         scripts_dir = tmp_path / ".autoskillit" / "recipes"
@@ -977,11 +985,14 @@ class TestCLIOrder:
             args=[], returncode=0, stdout="", stderr=""
         )
 
-        with patch("autoskillit.core.find_latest_session_id", return_value=None):
-            cli.order("test-script", resume=True)
+        cli.order("test-script", resume=True)
 
         cmd = mock_run.call_args[0][0]
-        assert "--resume" not in cmd
+        assert "--resume" in cmd
+        idx = cmd.index("--resume")
+        assert idx == len(cmd) - 1 or cmd[idx + 1].startswith("-"), (
+            "bare --resume must not be followed by a session ID"
+        )
 
 
 class TestOrderDisplayOwnership:
@@ -1450,16 +1461,17 @@ class TestOrderResumeParsing:
     def test_order_recipe_resume_with_session_id(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
-        """order my-recipe --resume <uuid> passes session_id to launch — REQ-CLI-003."""
+        """order my-recipe --resume <uuid> passes NamedResume to launch — REQ-CLI-003."""
         from autoskillit.cli.app import app
+        from autoskillit.core import NamedResume, NoResume
 
         monkeypatch.delenv("CLAUDECODE", raising=False)
         monkeypatch.chdir(tmp_path)
 
         captured: dict = {}
 
-        def fake_launch(prompt, *, initial_message=None, extra_env=None, resume_session_id=None):
-            captured["resume_session_id"] = resume_session_id
+        def fake_launch(prompt, *, initial_message=None, extra_env=None, resume_spec=NoResume()):
+            captured["resume_spec"] = resume_spec
 
         with (
             patch("autoskillit.cli.app._launch_cook_session", side_effect=fake_launch),
@@ -1469,11 +1481,12 @@ class TestOrderResumeParsing:
             ),
             patch("autoskillit.recipe.load_recipe", return_value=MagicMock()),
             patch("autoskillit.recipe.validate_recipe", return_value=[]),
-            patch("autoskillit.core.find_latest_session_id", return_value=None),
             patch("builtins.input", return_value=""),
         ):
             with pytest.raises(SystemExit) as exc_info:
                 app(["order", "my-recipe", "--resume", "fa910a41-d1ca-4cae-b878-01028a0c7c1c"])
             assert exc_info.value.code == 0
 
-        assert captured["resume_session_id"] == "fa910a41-d1ca-4cae-b878-01028a0c7c1c"
+        assert captured["resume_spec"] == NamedResume(
+            session_id="fa910a41-d1ca-4cae-b878-01028a0c7c1c"
+        )

--- a/tests/cli/test_cook_interactive.py
+++ b/tests/cli/test_cook_interactive.py
@@ -355,14 +355,17 @@ class TestCookInteractive:
         assert not rmtree_calls, "cook() must not rmtree skills_dir on exit"
 
     # REQ-CLI-001 + REQ-CLI-002
-    def test_cook_resume_passes_resume_flag(self, monkeypatch, tmp_path):
-        """cook(resume=True) passes --resume <session_id> to subprocess."""
+    def test_cook_resume_bare_flag_produces_bare_resume_and_skips_discovery(
+        self, monkeypatch, tmp_path
+    ):
+        """cook(resume=True) passes bare --resume; find_latest_session_id must not be called."""
         from unittest.mock import MagicMock, patch
 
         fake_skills_dir = tmp_path / "skills"
         fake_skills_dir.mkdir()
         mock_mgr = MagicMock()
         mock_mgr.init_session.return_value = fake_skills_dir
+        discovery_calls: list = []
 
         with (
             patch("shutil.which", return_value="/usr/bin/claude"),
@@ -371,7 +374,7 @@ class TestCookInteractive:
             patch("subprocess.run", return_value=MagicMock(returncode=0)) as mock_run,
             patch(
                 "autoskillit.core.find_latest_session_id",
-                return_value="session123",
+                side_effect=lambda *a, **kw: discovery_calls.append(1) or "latest",
             ),
         ):
             import autoskillit.cli._cook as module
@@ -381,7 +384,10 @@ class TestCookInteractive:
         args = mock_run.call_args[0][0]
         assert "--resume" in args
         idx = args.index("--resume")
-        assert args[idx + 1] == "session123"
+        assert idx == len(args) - 1 or args[idx + 1].startswith("-"), (
+            "bare --resume must not be followed by a session ID"
+        )
+        assert not discovery_calls, "find_latest_session_id must not be called for bare --resume"
 
     # REQ-CLI-002
     def test_cook_resume_explicit_session_id(self, monkeypatch, tmp_path):
@@ -414,9 +420,9 @@ class TestCookInteractive:
         assert args[args.index("--resume") + 1] == "explicit-abc"
         assert not discovery_calls, "discovery must not be called when session_id is explicit"
 
-    # REQ-CLI-002 — fallback when no session exists
-    def test_cook_resume_falls_back_to_fresh_when_no_session(self, monkeypatch, tmp_path):
-        """cook(resume=True) with no prior session starts a fresh session."""
+    # REQ-CLI-002 — bare --resume always emits --resume; Claude Code's picker handles empty history
+    def test_cook_resume_bare_flag_always_emits_resume(self, monkeypatch, tmp_path):
+        """cook(resume=True) always emits bare --resume; empty history is Claude Code's concern."""
         from unittest.mock import MagicMock, patch
 
         fake_skills_dir = tmp_path / "skills"
@@ -429,14 +435,17 @@ class TestCookInteractive:
             patch("builtins.input", return_value=""),
             patch("autoskillit.workspace.DefaultSessionSkillManager", return_value=mock_mgr),
             patch("subprocess.run", return_value=MagicMock(returncode=0)) as mock_run,
-            patch("autoskillit.core.find_latest_session_id", return_value=None),
         ):
             import autoskillit.cli._cook as module
 
             module.cook(resume=True)
 
         args = mock_run.call_args[0][0]
-        assert "--resume" not in args
+        assert "--resume" in args
+        idx = args.index("--resume")
+        assert idx == len(args) - 1 or args[idx + 1].startswith("-"), (
+            "bare --resume must not be followed by a session ID"
+        )
 
     # REQ-CLI-003
     def test_cook_cmd_resume_with_session_id_no_error(

--- a/tests/execution/test_commands.py
+++ b/tests/execution/test_commands.py
@@ -81,7 +81,7 @@ class TestBuildInteractiveCmd:
         result = build_interactive_cmd(resume_spec=BareResume())
         assert "--resume" in result.cmd
         idx = result.cmd.index("--resume")
-        assert idx == len(result.cmd) - 1 or result.cmd[idx + 1].startswith("-")
+        assert idx == len(result.cmd) - 1
 
     def test_no_resume_spec_emits_no_flag(self) -> None:
         result = build_interactive_cmd(resume_spec=NoResume())

--- a/tests/execution/test_commands.py
+++ b/tests/execution/test_commands.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from autoskillit.core import ClaudeFlags
+from autoskillit.core import BareResume, ClaudeFlags, NamedResume, NoResume
 from autoskillit.execution.commands import (
     _MAX_MCP_OUTPUT_TOKENS_VALUE,
     ClaudeHeadlessCmd,
@@ -71,18 +71,26 @@ class TestBuildInteractiveCmd:
         assert len(result.cmd) == 2
 
     # REQ-CMD-001
-    def test_resume_session_id_appended(self) -> None:
-        result = build_interactive_cmd(resume_session_id="abc123")
+    def test_named_resume_appends_session_id(self) -> None:
+        result = build_interactive_cmd(resume_spec=NamedResume(session_id="abc123"))
         assert "--resume" in result.cmd
         idx = result.cmd.index("--resume")
         assert result.cmd[idx + 1] == "abc123"
 
-    def test_no_resume_flag_when_none(self) -> None:
-        result = build_interactive_cmd()
+    def test_bare_resume_produces_bare_flag_no_id(self) -> None:
+        result = build_interactive_cmd(resume_spec=BareResume())
+        assert "--resume" in result.cmd
+        idx = result.cmd.index("--resume")
+        assert idx == len(result.cmd) - 1 or result.cmd[idx + 1].startswith("-")
+
+    def test_no_resume_spec_emits_no_flag(self) -> None:
+        result = build_interactive_cmd(resume_spec=NoResume())
         assert "--resume" not in result.cmd
 
     def test_resume_placed_before_initial_prompt(self) -> None:
-        result = build_interactive_cmd(resume_session_id="abc123", initial_prompt="hello")
+        result = build_interactive_cmd(
+            resume_spec=NamedResume(session_id="abc123"), initial_prompt="hello"
+        )
         resume_idx = result.cmd.index("--resume")
         prompt_idx = result.cmd.index("hello")
         assert resume_idx < prompt_idx


### PR DESCRIPTION
## Summary

The `build_interactive_cmd` builder encoded only two resume states: no-resume (`resume_session_id=None`) and named-resume (`resume_session_id=str`). There was no vocabulary for a third, equally valid state: bare-resume (pass `--resume` without an ID, triggering Claude Code's interactive picker). The CLI layer filled this missing state by eagerly calling `find_latest_session_id()` — collapsing three distinct user intents into two, and silently replacing "show me the picker" with "resume the most recent session."

The architectural root cause was a **missing discriminated union**: `ResumeSpec`. Without it, `None` meant two things simultaneously — "no resume" and "bare resume" — and callers were left to resolve the ambiguity through side-channel filesystem operations. Introducing `ResumeSpec` as a sealed three-variant type makes the states explicit, moves the contract enforcement into the type system, and makes the misuse that caused this bug structurally impossible.

## Architecture Impact

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 55, 'rankSpacing': 75, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    %% ─── LAYER 0: FOUNDATION ──────────────────────────────── %%
    subgraph L0 ["LAYER 0 — core/ (Foundation · Fan-in: 118)"]
        direction TB
        TYPE_RESUME["★ _type_resume.py<br/>━━━━━━━━━━<br/>ResumeSpec union<br/>NoResume | BareResume | NamedResume<br/>resume_spec_from_cli()"]
        TYPES["● types.py<br/>━━━━━━━━━━<br/>Re-export hub<br/>wildcard from ._type_resume import *"]
        CORE_INIT["● core/__init__.py<br/>━━━━━━━━━━<br/>Public surface<br/>NoResume, BareResume, NamedResume<br/>ResumeSpec, resume_spec_from_cli"]
    end

    %% ─── LAYER 1: INFRASTRUCTURE ──────────────────────────── %%
    subgraph L1_Exec ["LAYER 1 — execution/ (Infrastructure · Fan-in: 19)"]
        direction TB
        COMMANDS["● commands.py<br/>━━━━━━━━━━<br/>ClaudeHeadlessCmd<br/>ClaudeInteractiveCmd<br/>resume_spec → --resume flag<br/>match NoResume|BareResume|NamedResume"]
        HEADLESS["headless.py<br/>━━━━━━━━━━<br/>Headless session orchestrator<br/>consumes ClaudeHeadlessCmd"]
    end

    %% ─── LAYER 3: APPLICATION ─────────────────────────────── %%
    subgraph L3_CLI ["LAYER 3 — cli/ (Application · Fan-in: 14)"]
        direction LR
        APP["● app.py<br/>━━━━━━━━━━<br/>CLI entry: cook subcommand<br/>resume_spec_from_cli(resume, session_id)<br/>→ ResumeSpec"]
        COOK["● _cook.py<br/>━━━━━━━━━━<br/>Interactive session launcher<br/>receives resume_spec: ResumeSpec<br/>(structural param — no direct import)"]
    end

    %% ─── RE-EXPORT CHAIN (within core/) ──────────────────── %%
    TYPE_RESUME -->|"wildcard export"| TYPES
    TYPES -->|"wildcard re-export"| CORE_INIT

    %% ─── DOWNWARD DEPENDENCIES (L0 → L1 → L3) ───────────── %%
    CORE_INIT -->|"NoResume, BareResume<br/>NamedResume, ResumeSpec<br/>from autoskillit.core"| COMMANDS
    CORE_INIT -->|"ResumeSpec<br/>resume_spec_from_cli<br/>NoResume<br/>from autoskillit.core"| APP

    %% ─── INTRA-LAYER (L1 internal) ────────────────────────── %%
    COMMANDS -->|"ClaudeHeadlessCmd"| HEADLESS

    %% ─── INTRA-LAYER (L3 internal) ────────────────────────── %%
    APP -->|"resume_spec: ResumeSpec<br/>(function parameter)"| COOK

    %% CLASS ASSIGNMENTS %%
    class TYPE_RESUME newComponent;
    class TYPES,CORE_INIT stateNode;
    class COMMANDS,HEADLESS handler;
    class APP,COOK cli;
```

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 65, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START([CLI Input])

    subgraph Inputs ["● CLI ENTRY (INIT_PRESERVE)"]
        direction TB
        FlagResume["● --resume flag<br/>━━━━━━━━━━<br/>resume: bool<br/>app.py / _cook.py"]
        ArgSessionId["● session_id positional<br/>━━━━━━━━━━<br/>session_id: str | None<br/>app.py / _cook.py"]
    end

    subgraph Gate1 ["● CAPTURE GATE — resume_spec_from_cli()"]
        direction TB
        PrecedenceRule["● Precedence rule<br/>━━━━━━━━━━<br/>session_id ≠ None<br/>→ NamedResume wins<br/>resume=True → BareResume<br/>else → NoResume"]
    end

    subgraph Union ["★ RESUMESPEC DISCRIMINATED UNION (_type_resume.py)"]
        direction LR
        NoResume["★ NoResume<br/>━━━━━━━━━━<br/>@dataclass(frozen=True)<br/>No fields<br/>→ fresh session"]
        BareResume["★ BareResume<br/>━━━━━━━━━━<br/>@dataclass(frozen=True)<br/>No fields<br/>→ --resume (picker)"]
        NamedResume["★ NamedResume<br/>━━━━━━━━━━<br/>@dataclass(frozen=True)<br/>session_id: str<br/>→ --resume &lt;id&gt;"]
    end

    subgraph ImmutGate ["★ IMMUTABILITY GATE"]
        direction TB
        FrozenContract["★ frozen=True contract<br/>━━━━━━━━━━<br/>FrozenInstanceError on<br/>any post-construction write<br/>Variants cannot drift"]
    end

    subgraph MatchGate ["● PATTERN MATCH GATE — build_interactive_cmd()"]
        direction TB
        ExhaustiveMatch["● match resume_spec:<br/>━━━━━━━━━━<br/>case NamedResume(session_id=sid):<br/>  cmd += [--resume, sid]<br/>case BareResume():<br/>  cmd += [--resume]<br/>case NoResume():<br/>  pass (no flag)"]
    end

    subgraph SessionGate ["● SESSION GUARD (order command)"]
        direction TB
        ClaudeCodeGuard["● CLAUDECODE env check<br/>━━━━━━━━━━<br/>Blocks order inside<br/>Claude Code session<br/>sys.exit(1) on violation"]
    end

    subgraph Output ["● RESOLVED CMD (MUTABLE → frozen after build)"]
        direction TB
        InteractiveCmd["● ClaudeInteractiveCmd<br/>━━━━━━━━━━<br/>cmd: list[str]<br/>env: Mapping[str, str]<br/>@dataclass(frozen=True)"]
    end

    END([Claude subprocess])

    START --> FlagResume
    START --> ArgSessionId
    FlagResume --> PrecedenceRule
    ArgSessionId --> PrecedenceRule

    PrecedenceRule --> NoResume
    PrecedenceRule --> BareResume
    PrecedenceRule --> NamedResume

    NoResume --> FrozenContract
    BareResume --> FrozenContract
    NamedResume --> FrozenContract

    FrozenContract --> ExhaustiveMatch
    ExhaustiveMatch --> ClaudeCodeGuard
    ClaudeCodeGuard --> InteractiveCmd
    InteractiveCmd --> END

    %% CLASS ASSIGNMENTS %%
    class START,END terminal;
    class FlagResume,ArgSessionId cli;
    class PrecedenceRule detector;
    class NoResume,BareResume,NamedResume newComponent;
    class FrozenContract detector;
    class ExhaustiveMatch phase;
    class ClaudeCodeGuard gap;
    class InteractiveCmd output;
```

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 45, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START])
    SESSION_LIVE([Claude Interactive Session Running])
    ERROR([ERROR — non-zero exit])

    %% ── PHASE 1: CLI Entry ── %%
    subgraph CLI_Entry ["● CLI Entry  (app.py / _cook.py)"]
        direction TB
        COOK_CMD["● cook / order command<br/>━━━━━━━━━━<br/>cyclopts @app.command<br/>args: session_id, --resume"]
        CLI_PARSE{"● Parse args<br/>━━━━━━━━━━<br/>resume: bool<br/>session_id: str | None"}
    end

    %% ── PHASE 2: Resume Intent Construction ── %%
    subgraph Resume_Construction ["★ ResumeSpec Construction  (_type_resume.py)"]
        direction TB
        RESUME_FACTORY["★ resume_spec_from_cli()<br/>━━━━━━━━━━<br/>pure function — no I/O<br/>reads: resume, session_id"]
        DECISION_SID{"★ session_id<br/>is not None?"}
        DECISION_RESUME{"★ resume<br/>is True?"}
        NAMED["★ NamedResume(session_id)<br/>━━━━━━━━━━<br/>resume a specific session"]
        BARE["★ BareResume()<br/>━━━━━━━━━━<br/>Claude Code picker"]
        NORESUME["★ NoResume()<br/>━━━━━━━━━━<br/>fresh session"]
    end

    %% ── PHASE 3: Command Assembly ── %%
    subgraph Cmd_Assembly ["● Command Assembly  (commands.py)"]
        direction TB
        BUILD_INTERACTIVE["● build_interactive_cmd()<br/>━━━━━━━━━━<br/>accepts resume_spec: ResumeSpec<br/>default: NoResume()"]
        MATCH_SPEC{"● match resume_spec<br/>━━━━━━━━━━<br/>structural pattern match"}
        ADD_NAMED["● append --resume &lt;id&gt;<br/>━━━━━━━━━━<br/>NamedResume branch"]
        ADD_BARE["● append --resume<br/>━━━━━━━━━━<br/>BareResume branch"]
        ADD_NONE["● no resume flags<br/>━━━━━━━━━━<br/>NoResume branch"]
        BUILD_ENV["build_claude_env()<br/>━━━━━━━━━━<br/>IDE scrub + extras merge<br/>reads: env_extras, base env"]
        INTERACTIVE_CMD["● ClaudeInteractiveCmd<br/>━━━━━━━━━━<br/>cmd: list[str]<br/>env: Mapping[str, str]"]
    end

    %% ── PHASE 4: Session Launch ── %%
    subgraph Session_Launch ["Session Launch  (_cook.py / app.py)"]
        direction TB
        RUN_SESSION["_run_cook_session() / _launch_cook_session()<br/>━━━━━━━━━━<br/>terminal_guard() context<br/>subprocess.run(cmd, env=env)"]
        CHECK_RC{"returncode == 0?"}
        ONBOARD["mark_onboarded()<br/>━━━━━━━━━━<br/>first-run only"]
    end

    %% ── FLOW ── %%
    START --> COOK_CMD
    COOK_CMD --> CLI_PARSE

    CLI_PARSE -->|"reads: session_id, resume"| RESUME_FACTORY
    RESUME_FACTORY --> DECISION_SID

    DECISION_SID -->|"yes"| NAMED
    DECISION_SID -->|"no"| DECISION_RESUME
    DECISION_RESUME -->|"yes"| BARE
    DECISION_RESUME -->|"no"| NORESUME

    NAMED -->|"NamedResume"| BUILD_INTERACTIVE
    BARE -->|"BareResume"| BUILD_INTERACTIVE
    NORESUME -->|"NoResume"| BUILD_INTERACTIVE

    BUILD_INTERACTIVE --> MATCH_SPEC
    MATCH_SPEC -->|"NamedResume(session_id=sid)"| ADD_NAMED
    MATCH_SPEC -->|"BareResume()"| ADD_BARE
    MATCH_SPEC -->|"NoResume()"| ADD_NONE
    ADD_NAMED --> BUILD_ENV
    ADD_BARE --> BUILD_ENV
    ADD_NONE --> BUILD_ENV
    BUILD_ENV -->|"writes: cmd+env"| INTERACTIVE_CMD

    INTERACTIVE_CMD --> RUN_SESSION
    RUN_SESSION --> CHECK_RC
    CHECK_RC -->|"yes + first_run"| ONBOARD
    CHECK_RC -->|"no"| ERROR
    ONBOARD --> SESSION_LIVE
    CHECK_RC -->|"yes, not first_run"| SESSION_LIVE

    %% CLASS ASSIGNMENTS %%
    class START,SESSION_LIVE,ERROR terminal;
    class COOK_CMD,CLI_PARSE cli;
    class RESUME_FACTORY,DECISION_SID,DECISION_RESUME newComponent;
    class NAMED,BARE,NORESUME newComponent;
    class BUILD_INTERACTIVE,MATCH_SPEC,ADD_NAMED,ADD_BARE,ADD_NONE handler;
    class BUILD_ENV phase;
    class INTERACTIVE_CMD stateNode;
    class RUN_SESSION handler;
    class CHECK_RC detector;
    class ONBOARD phase;
```

Closes #1063

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260421-140819-940160/.autoskillit/temp/rectify/rectify_resume-spec-discriminated-union_2026-04-21_141200.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 2.9k | 20.3k | 1.3M | 95.1k | 1 | 9m 24s |
| review | 4.3k | 6.4k | 284.8k | 34.5k | 1 | 4m 10s |
| verify | 56 | 15.6k | 1.8M | 70.5k | 1 | 8m 0s |
| implement | 392 | 28.0k | 3.3M | 85.4k | 1 | 11m 53s |
| prepare_pr | 68 | 6.0k | 243.9k | 30.2k | 1 | 1m 28s |
| run_arch_lenses | 2.0k | 24.8k | 710.4k | 109.3k | 3 | 9m 4s |
| compose_pr | 67 | 9.1k | 250.7k | 33.8k | 1 | 2m 28s |
| **Total** | 9.8k | 110.2k | 7.8M | 458.9k | | 46m 31s |