### PR TITLE
Franchise Per-Recipe Tool-Surface Test Suite (16 Tests)

### DIFF
--- a/tests/arch/test_layer_enforcement.py
+++ b/tests/arch/test_layer_enforcement.py
@@ -1103,7 +1103,9 @@ _TEST_LAYER_ALLOWED: dict[str, frozenset[str]] = {
     "tests/workspace": frozenset({"autoskillit.core", "autoskillit.workspace"}),
     "tests/recipe": frozenset({"autoskillit.core", "autoskillit.recipe"}),
     "tests/migration": frozenset({"autoskillit.core", "autoskillit.migration"}),
-    "tests/franchise": frozenset({"autoskillit.core", "autoskillit.franchise"}),
+    "tests/franchise": frozenset(
+        {"autoskillit.core", "autoskillit.franchise", "autoskillit.recipe", "autoskillit.server"}
+    ),
     "tests/server": frozenset({"autoskillit"}),  # wildcard: any autoskillit.* import allowed
     "tests/cli": frozenset({"autoskillit"}),  # wildcard: any autoskillit.* import allowed
 }

--- a/tests/franchise/_helpers.py
+++ b/tests/franchise/_helpers.py
@@ -1,0 +1,31 @@
+"""Shared helpers for tests/franchise/ test modules."""
+
+from __future__ import annotations
+
+from autoskillit.core._type_constants import PACK_REGISTRY, TOOL_SUBSET_TAGS
+
+# ---------------------------------------------------------------------------
+# Module-level constants — derived from the authoritative TOOL_SUBSET_TAGS map
+# ---------------------------------------------------------------------------
+
+_tools_by_pack: dict[str, set[str]] = {}
+for _tool, _tags in TOOL_SUBSET_TAGS.items():
+    for _tag in _tags:
+        if _tag in PACK_REGISTRY:
+            _tools_by_pack.setdefault(_tag, set()).add(_tool)
+
+TOOLS_BY_PACK: dict[str, frozenset[str]] = {k: frozenset(v) for k, v in _tools_by_pack.items()}
+
+KITCHEN_CORE_TOOLS = TOOLS_BY_PACK["kitchen-core"]
+
+
+def compute_food_truck_tool_surface(recipe_name: str) -> frozenset[str]:
+    """Compute the expected tool surface for a food truck running the given recipe."""
+    from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
+
+    path = builtin_recipes_dir() / f"{recipe_name}.yaml"
+    recipe = load_recipe(path)
+    expected: set[str] = set(KITCHEN_CORE_TOOLS)
+    for pack in recipe.requires_packs or []:
+        expected |= TOOLS_BY_PACK.get(pack, frozenset())
+    return frozenset(expected)

--- a/tests/franchise/conftest.py
+++ b/tests/franchise/conftest.py
@@ -30,4 +30,4 @@ def _reset_server_state(monkeypatch):
     """
     from autoskillit.server import _state
 
-    monkeypatch.setattr(_state, "_ctx", _state._ctx)
+    monkeypatch.setattr(_state, "_ctx", None)

--- a/tests/franchise/conftest.py
+++ b/tests/franchise/conftest.py
@@ -1,0 +1,33 @@
+"""Shared fixtures for tests/franchise/."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_mcp_tags():
+    """Reset MCP tag visibility to default (kitchen + headless disabled) before each test.
+
+    The mcp singleton is process-global. Tests that call mcp.enable(tags={"kitchen"})
+    or mcp.enable(tags={"headless"}) mutate shared state. This fixture ensures every
+    franchise test starts with all tags disabled — the same state as a fresh server import.
+    """
+    from autoskillit.server import mcp
+
+    mcp.disable(tags={"kitchen"})
+    mcp.disable(tags={"headless"})
+    mcp.disable(tags={"franchise"})
+
+
+@pytest.fixture(autouse=True)
+def _reset_server_state(monkeypatch):
+    """Reset module-level _ctx in server._state after each test.
+
+    Tests that call _initialize() directly set _state._ctx to a mock without
+    cleanup. monkeypatch records the current value before yield and restores it after,
+    giving each test a clean slate regardless of what _initialize() sets.
+    """
+    from autoskillit.server import _state
+
+    monkeypatch.setattr(_state, "_ctx", _state._ctx)

--- a/tests/franchise/test_pack_enforcement.py
+++ b/tests/franchise/test_pack_enforcement.py
@@ -9,44 +9,22 @@ from __future__ import annotations
 
 import pytest
 
-from autoskillit.core._type_constants import PACK_REGISTRY, TOOL_SUBSET_TAGS
+from tests.franchise._helpers import (
+    KITCHEN_CORE_TOOLS,
+    TOOLS_BY_PACK,
+    compute_food_truck_tool_surface,
+)
 
 pytestmark = [pytest.mark.layer("franchise"), pytest.mark.small]
 
 # ---------------------------------------------------------------------------
-# Module-level constants — derived from the authoritative TOOL_SUBSET_TAGS map
+# Module-level constants — additional packs used only in this test module
 # ---------------------------------------------------------------------------
 
-_tools_by_pack: dict[str, set[str]] = {}
-for _tool, _tags in TOOL_SUBSET_TAGS.items():
-    for _tag in _tags:
-        if _tag in PACK_REGISTRY:
-            _tools_by_pack.setdefault(_tag, set()).add(_tool)
-
-TOOLS_BY_PACK: dict[str, frozenset[str]] = {k: frozenset(v) for k, v in _tools_by_pack.items()}
-
-KITCHEN_CORE_TOOLS = TOOLS_BY_PACK["kitchen-core"]
 GITHUB_PACK_TOOLS = TOOLS_BY_PACK["github"]
 CI_PACK_TOOLS = TOOLS_BY_PACK["ci"]
 CLONE_PACK_TOOLS = TOOLS_BY_PACK["clone"]
 TELEMETRY_PACK_TOOLS = TOOLS_BY_PACK["telemetry"]
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def compute_food_truck_tool_surface(recipe_name: str) -> frozenset[str]:
-    """Compute the expected tool surface for a food truck running the given recipe."""
-    from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
-
-    path = builtin_recipes_dir() / f"{recipe_name}.yaml"
-    recipe = load_recipe(path)
-    expected: set[str] = set(KITCHEN_CORE_TOOLS)
-    for pack in recipe.requires_packs or []:
-        expected |= TOOLS_BY_PACK.get(pack, frozenset())
-    return frozenset(expected)
 
 
 def _simulate_food_truck(monkeypatch: pytest.MonkeyPatch, packs: str) -> None:
@@ -211,7 +189,9 @@ class TestPerRecipeToolSurface:
 
 class TestSyntheticPackScenarios:
     @pytest.mark.anyio
-    async def test_food_truck_with_empty_requires_packs_sees_only_kitchen_core(self, monkeypatch):
+    async def test_food_truck_with_empty_requires_packs_sees_full_kitchen_fallback(
+        self, monkeypatch
+    ):
         from fastmcp.client import Client
 
         from autoskillit.core import GATED_TOOLS
@@ -264,6 +244,9 @@ class TestSyntheticPackScenarios:
             _apply_session_type_visibility()
 
         enable_calls = mock_mcp.enable.call_args_list
+        assert len(enable_calls) == 4, (
+            f"Expected 4 enable calls, got {len(enable_calls)}: {enable_calls}"
+        )
         assert enable_calls[0] == call(tags={"kitchen-core"}), "kitchen-core must be first"
         assert enable_calls[1] == call(tags={"github"})
         assert enable_calls[2] == call(tags={"ci"})

--- a/tests/franchise/test_pack_enforcement.py
+++ b/tests/franchise/test_pack_enforcement.py
@@ -1,0 +1,320 @@
+"""Franchise per-recipe tool-surface enforcement tests.
+
+Validates that food trucks launched for each bundled recipe see exactly the
+expected tool surface under the pack enforcement model: kitchen-core tools
+plus only the tools from packs declared in the recipe's requires_packs field.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.core._type_constants import PACK_REGISTRY, TOOL_SUBSET_TAGS
+
+pytestmark = [pytest.mark.layer("franchise"), pytest.mark.small]
+
+# ---------------------------------------------------------------------------
+# Module-level constants — derived from the authoritative TOOL_SUBSET_TAGS map
+# ---------------------------------------------------------------------------
+
+_tools_by_pack: dict[str, set[str]] = {}
+for _tool, _tags in TOOL_SUBSET_TAGS.items():
+    for _tag in _tags:
+        if _tag in PACK_REGISTRY:
+            _tools_by_pack.setdefault(_tag, set()).add(_tool)
+
+TOOLS_BY_PACK: dict[str, frozenset[str]] = {k: frozenset(v) for k, v in _tools_by_pack.items()}
+
+KITCHEN_CORE_TOOLS = TOOLS_BY_PACK["kitchen-core"]
+GITHUB_PACK_TOOLS = TOOLS_BY_PACK["github"]
+CI_PACK_TOOLS = TOOLS_BY_PACK["ci"]
+CLONE_PACK_TOOLS = TOOLS_BY_PACK["clone"]
+TELEMETRY_PACK_TOOLS = TOOLS_BY_PACK["telemetry"]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def compute_food_truck_tool_surface(recipe_name: str) -> frozenset[str]:
+    """Compute the expected tool surface for a food truck running the given recipe."""
+    from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
+
+    path = builtin_recipes_dir() / f"{recipe_name}.yaml"
+    recipe = load_recipe(path)
+    expected: set[str] = set(KITCHEN_CORE_TOOLS)
+    for pack in recipe.requires_packs or []:
+        expected |= TOOLS_BY_PACK.get(pack, frozenset())
+    return frozenset(expected)
+
+
+def _simulate_food_truck(monkeypatch: pytest.MonkeyPatch, packs: str) -> None:
+    """Set env vars to simulate a food truck session, then apply visibility."""
+    monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "orchestrator")
+    monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+    monkeypatch.setenv("AUTOSKILLIT_L2_TOOL_TAGS", packs)
+    from autoskillit.server import _apply_session_type_visibility
+
+    _apply_session_type_visibility()
+
+
+# ---------------------------------------------------------------------------
+# Group A: 8 per-recipe tests
+# ---------------------------------------------------------------------------
+
+_STANDARD_PACKS = ",".join(sorted(["github", "ci", "clone", "telemetry"]))
+
+
+class TestPerRecipeToolSurface:
+    @pytest.mark.anyio
+    async def test_implementation_food_truck_sees_expected_tools(self, monkeypatch):
+        from fastmcp.client import Client
+
+        from autoskillit.server import mcp
+
+        expected = compute_food_truck_tool_surface("implementation")
+        _simulate_food_truck(monkeypatch, _STANDARD_PACKS)
+
+        async with Client(mcp) as client:
+            tools = await client.list_tools()
+        visible = {t.name for t in tools}
+
+        for name in expected:
+            assert name in visible, f"{name} should be visible for implementation food truck"
+
+    @pytest.mark.anyio
+    async def test_implementation_food_truck_hides_research_tools(self, monkeypatch):
+        from fastmcp.client import Client
+
+        from autoskillit.core import UNGATED_TOOLS
+        from autoskillit.server import mcp
+
+        expected = compute_food_truck_tool_surface("implementation")
+        _simulate_food_truck(monkeypatch, _STANDARD_PACKS)
+
+        async with Client(mcp) as client:
+            tools = await client.list_tools()
+        visible = {t.name for t in tools}
+
+        extras = visible - expected - UNGATED_TOOLS
+        assert not extras, f"Unexpected tools visible for implementation food truck: {extras}"
+
+    @pytest.mark.anyio
+    async def test_merge_prs_food_truck_sees_expected_tools(self, monkeypatch):
+        from fastmcp.client import Client
+
+        from autoskillit.server import mcp
+
+        expected = compute_food_truck_tool_surface("merge-prs")
+        _simulate_food_truck(monkeypatch, _STANDARD_PACKS)
+
+        async with Client(mcp) as client:
+            tools = await client.list_tools()
+        visible = {t.name for t in tools}
+
+        for name in expected:
+            assert name in visible, f"{name} should be visible for merge-prs food truck"
+
+    @pytest.mark.anyio
+    async def test_merge_prs_food_truck_hides_research_tools(self, monkeypatch):
+        from fastmcp.client import Client
+
+        from autoskillit.core import UNGATED_TOOLS
+        from autoskillit.server import mcp
+
+        expected = compute_food_truck_tool_surface("merge-prs")
+        _simulate_food_truck(monkeypatch, _STANDARD_PACKS)
+
+        async with Client(mcp) as client:
+            tools = await client.list_tools()
+        visible = {t.name for t in tools}
+
+        extras = visible - expected - UNGATED_TOOLS
+        assert not extras, f"Unexpected tools visible for merge-prs food truck: {extras}"
+
+    @pytest.mark.anyio
+    async def test_remediation_food_truck_sees_expected_tools(self, monkeypatch):
+        from fastmcp.client import Client
+
+        from autoskillit.server import mcp
+
+        expected = compute_food_truck_tool_surface("remediation")
+        _simulate_food_truck(monkeypatch, _STANDARD_PACKS)
+
+        async with Client(mcp) as client:
+            tools = await client.list_tools()
+        visible = {t.name for t in tools}
+
+        for name in expected:
+            assert name in visible, f"{name} should be visible for remediation food truck"
+
+    @pytest.mark.anyio
+    async def test_remediation_food_truck_hides_research_tools(self, monkeypatch):
+        from fastmcp.client import Client
+
+        from autoskillit.core import UNGATED_TOOLS
+        from autoskillit.server import mcp
+
+        expected = compute_food_truck_tool_surface("remediation")
+        _simulate_food_truck(monkeypatch, _STANDARD_PACKS)
+
+        async with Client(mcp) as client:
+            tools = await client.list_tools()
+        visible = {t.name for t in tools}
+
+        extras = visible - expected - UNGATED_TOOLS
+        assert not extras, f"Unexpected tools visible for remediation food truck: {extras}"
+
+    @pytest.mark.anyio
+    async def test_implementation_groups_food_truck_sees_expected_tools(self, monkeypatch):
+        from fastmcp.client import Client
+
+        from autoskillit.server import mcp
+
+        expected = compute_food_truck_tool_surface("implementation-groups")
+        _simulate_food_truck(monkeypatch, _STANDARD_PACKS)
+
+        async with Client(mcp) as client:
+            tools = await client.list_tools()
+        visible = {t.name for t in tools}
+
+        for name in expected:
+            assert name in visible, (
+                f"{name} should be visible for implementation-groups food truck"
+            )
+
+    @pytest.mark.anyio
+    async def test_implementation_groups_food_truck_hides_research_tools(self, monkeypatch):
+        from fastmcp.client import Client
+
+        from autoskillit.core import UNGATED_TOOLS
+        from autoskillit.server import mcp
+
+        expected = compute_food_truck_tool_surface("implementation-groups")
+        _simulate_food_truck(monkeypatch, _STANDARD_PACKS)
+
+        async with Client(mcp) as client:
+            tools = await client.list_tools()
+        visible = {t.name for t in tools}
+
+        extras = visible - expected - UNGATED_TOOLS
+        assert not extras, (
+            f"Unexpected tools visible for implementation-groups food truck: {extras}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Group B: 3 synthetic tests
+# ---------------------------------------------------------------------------
+
+
+class TestSyntheticPackScenarios:
+    @pytest.mark.anyio
+    async def test_food_truck_with_empty_requires_packs_sees_only_kitchen_core(self, monkeypatch):
+        from fastmcp.client import Client
+
+        from autoskillit.core import GATED_TOOLS
+        from autoskillit.server import _apply_session_type_visibility, mcp
+
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "orchestrator")
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        monkeypatch.setenv("AUTOSKILLIT_L2_TOOL_TAGS", "")
+        _apply_session_type_visibility()
+
+        async with Client(mcp) as client:
+            tools = await client.list_tools()
+        visible = {t.name for t in tools}
+
+        for name in GATED_TOOLS:
+            assert name in visible, (
+                f"{name} should be visible under full kitchen fallback (empty L2_TOOL_TAGS)"
+            )
+
+    @pytest.mark.anyio
+    async def test_food_truck_with_single_pack_sees_kitchen_core_plus_pack(self, monkeypatch):
+        from fastmcp.client import Client
+
+        from autoskillit.server import mcp
+
+        _simulate_food_truck(monkeypatch, "github")
+
+        async with Client(mcp) as client:
+            tools = await client.list_tools()
+        visible = {t.name for t in tools}
+
+        for name in KITCHEN_CORE_TOOLS:
+            assert name in visible, f"{name} (kitchen-core) should be visible"
+        for name in GITHUB_PACK_TOOLS:
+            assert name in visible, f"{name} (github pack) should be visible"
+        for name in CI_PACK_TOOLS:
+            assert name not in visible, f"{name} (ci pack) should be hidden"
+
+    def test_food_truck_startup_enables_tags_in_order(self, monkeypatch):
+        from unittest.mock import MagicMock, call, patch
+
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "orchestrator")
+        monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
+        monkeypatch.setenv("AUTOSKILLIT_L2_TOOL_TAGS", "github,ci,telemetry")
+
+        mock_mcp = MagicMock()
+        with patch("autoskillit.server.mcp", mock_mcp):
+            from autoskillit.server._session_type import _apply_session_type_visibility
+
+            _apply_session_type_visibility()
+
+        enable_calls = mock_mcp.enable.call_args_list
+        assert enable_calls[0] == call(tags={"kitchen-core"}), "kitchen-core must be first"
+        assert enable_calls[1] == call(tags={"github"})
+        assert enable_calls[2] == call(tags={"ci"})
+        assert enable_calls[3] == call(tags={"telemetry"})
+
+
+# ---------------------------------------------------------------------------
+# Group C: 3 regression guards (module-level functions)
+# ---------------------------------------------------------------------------
+
+
+def test_every_bundled_recipe_declares_requires_packs() -> None:
+    from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
+
+    MCP_TOOL_PACKS = {"github", "ci", "clone", "telemetry", "kitchen-core"}
+    RESEARCH_PACKS = {"research", "exp-lens", "vis-lens"}
+
+    for path in sorted(builtin_recipes_dir().glob("*.yaml")):
+        recipe = load_recipe(path)
+        assert recipe.requires_packs, f"{path.name} does not declare requires_packs"
+        pack_set = set(recipe.requires_packs)
+        if pack_set & RESEARCH_PACKS:
+            continue
+        assert pack_set & MCP_TOOL_PACKS, (
+            f"{path.name} declares packs {pack_set} but none are MCP tool packs"
+        )
+
+
+@pytest.mark.anyio
+async def test_no_tool_has_bare_kitchen_tag_only() -> None:
+    from autoskillit.core._type_constants import CATEGORY_TAGS
+    from autoskillit.server import mcp
+
+    all_tools = {t.name: t for t in await mcp.list_tools()}
+    for name, tool in all_tools.items():
+        if "kitchen" in tool.tags and "autoskillit" in tool.tags:
+            pack_tags = tool.tags & CATEGORY_TAGS
+            assert pack_tags, (
+                f"{name} has 'kitchen' tag but no pack tag from CATEGORY_TAGS. Tags: {tool.tags}"
+            )
+
+
+def test_kitchen_core_and_packs_partition_kitchen_gated_tools() -> None:
+    from autoskillit.core._type_constants import TOOL_SUBSET_TAGS
+
+    all_tools_in_subsets = set(TOOL_SUBSET_TAGS.keys())
+    union_of_packs: set[str] = set()
+    for tools in TOOLS_BY_PACK.values():
+        union_of_packs |= tools
+
+    orphaned = all_tools_in_subsets - union_of_packs
+    assert not orphaned, f"Tools not in any pack: {orphaned}"
+    extra = union_of_packs - all_tools_in_subsets
+    assert not extra, f"Tools in packs but not in TOOL_SUBSET_TAGS: {extra}"

--- a/tests/franchise/test_pack_enforcement_e2e.py
+++ b/tests/franchise/test_pack_enforcement_e2e.py
@@ -1,0 +1,111 @@
+"""Franchise per-recipe tool-surface e2e tests.
+
+Validates the tool surface using a real MCP server subprocess — no monkeypatching.
+Marked integration + medium to allow subprocess spawning.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+from autoskillit.core._type_constants import PACK_REGISTRY, TOOL_SUBSET_TAGS
+
+pytestmark = [pytest.mark.layer("franchise"), pytest.mark.medium]
+
+# ---------------------------------------------------------------------------
+# Module-level constants (mirrors test_pack_enforcement.py)
+# ---------------------------------------------------------------------------
+
+_tools_by_pack: dict[str, set[str]] = {}
+for _tool, _tags in TOOL_SUBSET_TAGS.items():
+    for _tag in _tags:
+        if _tag in PACK_REGISTRY:
+            _tools_by_pack.setdefault(_tag, set()).add(_tool)
+
+TOOLS_BY_PACK: dict[str, frozenset[str]] = {k: frozenset(v) for k, v in _tools_by_pack.items()}
+
+KITCHEN_CORE_TOOLS = TOOLS_BY_PACK["kitchen-core"]
+
+
+def compute_food_truck_tool_surface(recipe_name: str) -> frozenset[str]:
+    """Compute the expected tool surface for a food truck running the given recipe."""
+    from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
+
+    path = builtin_recipes_dir() / f"{recipe_name}.yaml"
+    recipe = load_recipe(path)
+    expected: set[str] = set(KITCHEN_CORE_TOOLS)
+    for pack in recipe.requires_packs or []:
+        expected |= TOOLS_BY_PACK.get(pack, frozenset())
+    return frozenset(expected)
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def franchise_runtime():
+    async def _get_surface(recipe_name: str) -> set[str]:
+        from fastmcp.client import Client
+        from fastmcp.client.transports import StdioTransport
+
+        from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
+
+        path = builtin_recipes_dir() / f"{recipe_name}.yaml"
+        recipe = load_recipe(path)
+        packs = ",".join(sorted(recipe.requires_packs))
+
+        env = {
+            **os.environ,
+            "AUTOSKILLIT_SESSION_TYPE": "orchestrator",
+            "AUTOSKILLIT_HEADLESS": "1",
+            "AUTOSKILLIT_L2_TOOL_TAGS": packs,
+        }
+
+        transport = StdioTransport(
+            command=sys.executable,
+            args=["-m", "autoskillit"],
+            env=env,
+        )
+        async with Client(transport) as client:
+            tools = await client.list_tools()
+        return {t.name for t in tools}
+
+    return _get_surface
+
+
+# ---------------------------------------------------------------------------
+# E2E tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.anyio
+async def test_implementation_food_truck_real_subprocess_tool_surface(franchise_runtime):
+    from autoskillit.core import UNGATED_TOOLS
+
+    visible = await franchise_runtime("implementation")
+    expected = compute_food_truck_tool_surface("implementation")
+
+    extras = visible - expected - UNGATED_TOOLS
+    assert not extras, f"Unexpected tools visible for implementation food truck: {extras}"
+    for name in expected:
+        assert name in visible, f"{name} should be visible for implementation food truck"
+
+
+@pytest.mark.integration
+@pytest.mark.anyio
+async def test_merge_prs_food_truck_real_subprocess_tool_surface(franchise_runtime):
+    from autoskillit.core import UNGATED_TOOLS
+
+    visible = await franchise_runtime("merge-prs")
+    expected = compute_food_truck_tool_surface("merge-prs")
+
+    extras = visible - expected - UNGATED_TOOLS
+    assert not extras, f"Unexpected tools visible for merge-prs food truck: {extras}"
+    for name in expected:
+        assert name in visible, f"{name} should be visible for merge-prs food truck"

--- a/tests/franchise/test_pack_enforcement_e2e.py
+++ b/tests/franchise/test_pack_enforcement_e2e.py
@@ -11,36 +11,9 @@ import sys
 
 import pytest
 
-from autoskillit.core._type_constants import PACK_REGISTRY, TOOL_SUBSET_TAGS
+from tests.franchise._helpers import compute_food_truck_tool_surface
 
 pytestmark = [pytest.mark.layer("franchise"), pytest.mark.medium]
-
-# ---------------------------------------------------------------------------
-# Module-level constants (mirrors test_pack_enforcement.py)
-# ---------------------------------------------------------------------------
-
-_tools_by_pack: dict[str, set[str]] = {}
-for _tool, _tags in TOOL_SUBSET_TAGS.items():
-    for _tag in _tags:
-        if _tag in PACK_REGISTRY:
-            _tools_by_pack.setdefault(_tag, set()).add(_tool)
-
-TOOLS_BY_PACK: dict[str, frozenset[str]] = {k: frozenset(v) for k, v in _tools_by_pack.items()}
-
-KITCHEN_CORE_TOOLS = TOOLS_BY_PACK["kitchen-core"]
-
-
-def compute_food_truck_tool_surface(recipe_name: str) -> frozenset[str]:
-    """Compute the expected tool surface for a food truck running the given recipe."""
-    from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
-
-    path = builtin_recipes_dir() / f"{recipe_name}.yaml"
-    recipe = load_recipe(path)
-    expected: set[str] = set(KITCHEN_CORE_TOOLS)
-    for pack in recipe.requires_packs or []:
-        expected |= TOOLS_BY_PACK.get(pack, frozenset())
-    return frozenset(expected)
-
 
 # ---------------------------------------------------------------------------
 # Fixture
@@ -57,7 +30,7 @@ def franchise_runtime():
 
         path = builtin_recipes_dir() / f"{recipe_name}.yaml"
         recipe = load_recipe(path)
-        packs = ",".join(sorted(recipe.requires_packs))
+        packs = ",".join(sorted(recipe.requires_packs or []))
 
         env = {
             **os.environ,


### PR DESCRIPTION
## Summary

Add 16 tests across two new files (`tests/franchise/test_pack_enforcement.py` and
`tests/franchise/test_pack_enforcement_e2e.py`) plus a `tests/franchise/conftest.py`
with MCP tag-reset fixtures. The tests validate that food trucks launched for each
bundled recipe see exactly the expected tool surface under the pack enforcement model:
kitchen-core tools plus only the tools from packs declared in the recipe's
`requires_packs` field.

**Dependencies:** #885 (retag + backfill) and #886 (startup filter) must land first.
Tests are designed TDD-style — they will fail until those tickets land, then pass.

## Architecture Impact

### Security Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ── BOUNDARY 1: Env Input Validation ────────────────────────────────── %%
    subgraph EnvBoundary ["TRUST BOUNDARY 1 · Env Input Validation"]
        ENV_TYPE["AUTOSKILLIT_SESSION_TYPE<br/>━━━━━━━━━━<br/>orchestrator / franchise / leaf"]
        ENV_HEADLESS["AUTOSKILLIT_HEADLESS<br/>━━━━━━━━━━<br/>1 = headless mode"]
        ENV_TAGS["AUTOSKILLIT_L2_TOOL_TAGS<br/>━━━━━━━━━━<br/>comma-separated pack names"]
        SESSION_RESOLVER["_resolve_session_type()<br/>━━━━━━━━━━<br/>Enumerated SessionType"]
    end

    %% ── BOUNDARY 2: Pack Name Validation ────────────────────────────────── %%
    subgraph PackValidation ["TRUST BOUNDARY 2 · Pack Name Validation"]
        PACK_SPLIT["split(',') + strip()<br/>━━━━━━━━━━<br/>Tokenise tag string"]
        CATEGORY_CHECK["CATEGORY_TAGS lookup<br/>━━━━━━━━━━<br/>Unknown → warn + skip"]
        PACK_REGISTRY_NODE["PACK_REGISTRY / TOOL_SUBSET_TAGS<br/>━━━━━━━━━━<br/>L0 authoritative map"]
    end

    %% ── BOUNDARY 3: FastMCP Visibility Gate ─────────────────────────────── %%
    subgraph VisibilityGate ["TRUST BOUNDARY 3 · FastMCP Visibility Gate (_apply_session_type_visibility)"]
        ENABLE_CORE["mcp.enable(kitchen-core) — FIRST<br/>━━━━━━━━━━<br/>Ordering enforced"]
        ENABLE_PACKS["mcp.enable(pack) — per declared pack<br/>━━━━━━━━━━<br/>Additive surface expansion"]
        EMPTY_FALLBACK["empty tags → mcp.enable(kitchen)<br/>━━━━━━━━━━<br/>Full kitchen fallback"]
        FRANCHISE_PATH["mcp.enable(franchise)<br/>━━━━━━━━━━<br/>Franchise-tier surface"]
    end

    %% ── TOOL SURFACE ────────────────────────────────────────────────────── %%
    subgraph ToolSurface ["ENFORCED TOOL SURFACE"]
        VISIBLE["kitchen-core + declared packs<br/>━━━━━━━━━━<br/>Tools visible to food truck"]
        UNGATED_NODE["UNGATED_TOOLS<br/>━━━━━━━━━━<br/>Always visible (no gate)"]
        HIDDEN["Non-declared packs<br/>━━━━━━━━━━<br/>Hidden — not enabled"]
    end

    %% ── BOUNDARY 4: Per-Tool Gate Guard ─────────────────────────────────── %%
    subgraph ToolGuard ["TRUST BOUNDARY 4 · Per-Tool Gate Guard"]
        REQUIRE_ENABLED["_require_enabled()<br/>━━━━━━━━━━<br/>Must precede await/return"]
        GATED_SET["GATED_TOOLS set (L0)<br/>━━━━━━━━━━<br/>Bidirectional registry check"]
    end

    %% ── TEST LAYER BOUNDARY ─────────────────────────────────────────────── %%
    subgraph TestLayerBoundary ["ARCH SECURITY · Test Layer Import Boundary"]
        LAYER_MAP["● _TEST_LAYER_ALLOWED map<br/>━━━━━━━━━━<br/>tests/franchise → {core, franchise, recipe, server}"]
        AST_SCAN["test_test_files_respect_layer_boundaries<br/>━━━━━━━━━━<br/>AST scan — cross-layer import detection"]
        DEFERRED_SCAN["test_l2_no_deferred_upward_imports<br/>━━━━━━━━━━<br/>Covers function-body (deferred) imports"]
    end

    %% ── NEW TEST COMPONENTS ─────────────────────────────────────────────── %%
    subgraph FranchiseTests ["★ NEW: Franchise Test Suite (tests/franchise/)"]
        CONFTEST["★ conftest.py<br/>━━━━━━━━━━<br/>autouse: disable kitchen/headless/franchise<br/>tags before each test"]
        UNIT_TESTS["★ test_pack_enforcement.py<br/>━━━━━━━━━━<br/>16 tests: per-recipe surface, synthetic<br/>scenarios, regression guards"]
        E2E_TESTS["★ test_pack_enforcement_e2e.py<br/>━━━━━━━━━━<br/>Real subprocess MCP server —<br/>no monkeypatching"]
    end

    %% ── FLOW ────────────────────────────────────────────────────────────── %%
    ENV_TYPE --> SESSION_RESOLVER
    ENV_HEADLESS --> SESSION_RESOLVER
    ENV_TAGS --> PACK_SPLIT

    SESSION_RESOLVER -->|orchestrator + headless| PACK_SPLIT
    SESSION_RESOLVER -->|franchise| FRANCHISE_PATH
    PACK_SPLIT --> CATEGORY_CHECK
    CATEGORY_CHECK -->|valid pack| PACK_REGISTRY_NODE
    CATEGORY_CHECK -->|unknown pack| HIDDEN
    PACK_REGISTRY_NODE --> ENABLE_CORE
    ENABLE_CORE --> ENABLE_PACKS
    ENV_TAGS -->|empty string| EMPTY_FALLBACK

    ENABLE_PACKS --> VISIBLE
    EMPTY_FALLBACK --> VISIBLE
    FRANCHISE_PATH --> VISIBLE
    UNGATED_NODE --> VISIBLE

    VISIBLE --> REQUIRE_ENABLED
    REQUIRE_ENABLED --> GATED_SET

    LAYER_MAP --> AST_SCAN
    AST_SCAN --> DEFERRED_SCAN

    %% ── TEST COVERAGE ARROWS ────────────────────────────────────────────── %%
    CONFTEST -.->|resets tag state| VisibilityGate
    UNIT_TESTS -.->|validates| ToolSurface
    UNIT_TESTS -.->|validates ordering| ENABLE_CORE
    E2E_TESTS -.->|subprocess validates| ToolSurface
    LAYER_MAP -.->|covers franchise test files| FranchiseTests

    %% ── CLASS ASSIGNMENTS ───────────────────────────────────────────────── %%
    class ENV_TYPE,ENV_HEADLESS,ENV_TAGS cli;
    class SESSION_RESOLVER,CATEGORY_CHECK detector;
    class PACK_SPLIT,PACK_REGISTRY_NODE phase;
    class ENABLE_CORE,ENABLE_PACKS,EMPTY_FALLBACK,FRANCHISE_PATH handler;
    class VISIBLE,UNGATED_NODE stateNode;
    class HIDDEN gap;
    class REQUIRE_ENABLED,GATED_SET detector;
    class LAYER_MAP,AST_SCAN,DEFERRED_SCAN detector;
    class CONFTEST,UNIT_TESTS,E2E_TESTS newComponent;
```

### Scenarios Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    %% ── SCENARIO 1: Unit Pack Validation ────────────────────────────────────
    subgraph S1 ["SCENARIO 1 — Unit Pack Validation (Group A, 8 tests)"]
        direction LR
        S1_ENTRY["★ TestPerRecipeToolSurface<br/>━━━━━━━━━━<br/>test_pack_enforcement.py<br/>monkeypatch env vars"]
        S1_RECIPE["load_recipe(recipe.yaml)<br/>━━━━━━━━━━<br/>reads requires_packs<br/>builds expected surface"]
        S1_SIM["★ _simulate_food_truck()<br/>━━━━━━━━━━<br/>sets SESSION_TYPE=orchestrator<br/>HEADLESS=1, L2_TOOL_TAGS"]
        S1_VIS["_apply_session_type_visibility()<br/>━━━━━━━━━━<br/>mcp.enable(kitchen-core)<br/>+ mcp.enable(pack) per pack"]
        S1_CLIENT["FastMCP Client<br/>━━━━━━━━━━<br/>client.list_tools()<br/>→ visible tool set"]
        S1_ASSERT["Assert surface<br/>━━━━━━━━━━<br/>expected ⊆ visible<br/>extras = ∅"]
    end

    %% ── SCENARIO 2: Synthetic Pack Scenarios ────────────────────────────────
    subgraph S2 ["SCENARIO 2 — Synthetic Pack Scenarios (Group B, 3 tests)"]
        direction LR
        S2_ENTRY["★ TestSyntheticPackScenarios<br/>━━━━━━━━━━<br/>test_pack_enforcement.py<br/>edge-case pack configs"]
        S2_CASES["3 edge cases<br/>━━━━━━━━━━<br/>empty L2_TOOL_TAGS → full kitchen<br/>single-pack → core+pack only<br/>ordered enable sequence"]
        S2_VIS["_apply_session_type_visibility()<br/>━━━━━━━━━━<br/>branch: empty → mcp.enable(kitchen)<br/>branch: packs → sequential enable"]
        S2_MOCK["mock_mcp / FastMCP<br/>━━━━━━━━━━<br/>verify enable call order<br/>kitchen-core MUST be first"]
        S2_ASSERT["Assert ordering<br/>━━━━━━━━━━<br/>CI pack hidden when<br/>only github declared"]
    end

    %% ── SCENARIO 3: E2E Subprocess Validation ────────────────────────────────
    subgraph S3 ["SCENARIO 3 — E2E Subprocess Validation (2 tests)"]
        direction LR
        S3_ENTRY["★ franchise_runtime fixture<br/>━━━━━━━━━━<br/>test_pack_enforcement_e2e.py<br/>no monkeypatching"]
        S3_RECIPE["load_recipe(recipe.yaml)<br/>━━━━━━━━━━<br/>reads requires_packs<br/>builds packs env string"]
        S3_PROC["StdioTransport subprocess<br/>━━━━━━━━━━<br/>python -m autoskillit<br/>SESSION_TYPE + HEADLESS + L2_TOOL_TAGS"]
        S3_SERVER["Real MCP server<br/>━━━━━━━━━━<br/>_apply_session_type_visibility()<br/>inside subprocess"]
        S3_CLIENT["FastMCP Client (stdio)<br/>━━━━━━━━━━<br/>client.list_tools()<br/>→ real visible set"]
        S3_ASSERT["Assert surface<br/>━━━━━━━━━━<br/>expected ⊆ visible<br/>extras - UNGATED_TOOLS = ∅"]
    end

    %% ── SCENARIO 4: Architecture Layer Gate ────────────────────────────────
    subgraph S4 ["SCENARIO 4 — Architecture Layer Gate (modified)"]
        direction LR
        S4_ENTRY["● test_layer_enforcement.py<br/>━━━━━━━━━━<br/>SUBPACKAGE_LAYERS updated<br/>franchise → L2"]
        S4_LAYERS["● SUBPACKAGE_LAYERS<br/>━━━━━━━━━━<br/>franchise: 2<br/>(alongside recipe, migration)"]
        S4_IMPORT["test_import_layer_enforcement<br/>━━━━━━━━━━<br/>franchise/ may only import<br/>from L0 (core) + L1 layers"]
        S4_TBOUND["● _TEST_LAYER_ALLOWED<br/>━━━━━━━━━━<br/>tests/franchise → {core,<br/>franchise, recipe, server}"]
        S4_TFILES["test_test_files_respect<br/>_layer_boundaries<br/>━━━━━━━━━━<br/>scan test_pack_enforcement*.py<br/>for cross-layer violations"]
        S4_STOOLS["● ALLOWED in server/tools_*.py<br/>━━━━━━━━━━<br/>franchise added to allowed<br/>import set for tools handlers"]
    end

    %% ── SCENARIO 5: Structural Regression Guards ────────────────────────────
    subgraph S5 ["SCENARIO 5 — Structural Regression Guards (Group C, 3 tests)"]
        direction LR
        S5_ENTRY["★ Group C module functions<br/>━━━━━━━━━━<br/>test_pack_enforcement.py<br/>structural invariants"]
        S5_R1["test_every_bundled_recipe<br/>_declares_requires_packs<br/>━━━━━━━━━━<br/>glob recipes/*.yaml<br/>load + assert requires_packs"]
        S5_R2["test_no_tool_has_bare<br/>_kitchen_tag_only<br/>━━━━━━━━━━<br/>mcp.list_tools() all tools<br/>kitchen tag → needs CATEGORY_TAG"]
        S5_R3["test_kitchen_core_and_packs<br/>_partition_kitchen_gated_tools<br/>━━━━━━━━━━<br/>TOOL_SUBSET_TAGS coverage<br/>no orphaned tools"]
        S5_SRC["TOOL_SUBSET_TAGS +<br/>PACK_REGISTRY<br/>━━━━━━━━━━<br/>core._type_constants<br/>single source of truth"]
    end

    %% ── SHARED FIXTURE ───────────────────────────────────────────────────────
    subgraph FX ["★ Shared Fixture (conftest.py)"]
        FX_RESET["★ _reset_mcp_tags (autouse)<br/>━━━━━━━━━━<br/>mcp.disable(kitchen/headless<br/>/franchise) before each test"]
        FX_STATE["★ _reset_server_state (autouse)<br/>━━━━━━━━━━<br/>monkeypatch _state._ctx<br/>clean slate per test"]
    end

    %% ── FLOWS ────────────────────────────────────────────────────────────────

    %% Scenario 1 flow
    FX_RESET --> S1_ENTRY
    FX_STATE --> S1_ENTRY
    S1_ENTRY -->|reads| S1_RECIPE
    S1_ENTRY -->|calls| S1_SIM
    S1_SIM -->|triggers| S1_VIS
    S1_VIS -->|exposes tools| S1_CLIENT
    S1_RECIPE -->|computes expected| S1_ASSERT
    S1_CLIENT -->|visible set| S1_ASSERT

    %% Scenario 2 flow
    FX_RESET --> S2_ENTRY
    S2_ENTRY -->|configures| S2_CASES
    S2_CASES -->|invokes| S2_VIS
    S2_VIS -->|enable calls| S2_MOCK
    S2_MOCK -->|call args| S2_ASSERT

    %% Scenario 3 flow
    S3_ENTRY -->|reads packs from| S3_RECIPE
    S3_RECIPE -->|env vars| S3_PROC
    S3_PROC -->|spawns| S3_SERVER
    S3_SERVER -->|exposes tools| S3_CLIENT
    S3_RECIPE -->|computes expected| S3_ASSERT
    S3_CLIENT -->|visible set| S3_ASSERT

    %% Scenario 4 flow
    S4_ENTRY -->|defines| S4_LAYERS
    S4_LAYERS -->|parametrize| S4_IMPORT
    S4_ENTRY -->|defines| S4_TBOUND
    S4_TBOUND -->|parametrize| S4_TFILES
    S4_ENTRY -->|updates| S4_STOOLS

    %% Scenario 5 flow
    S5_ENTRY --> S5_R1
    S5_ENTRY --> S5_R2
    S5_ENTRY --> S5_R3
    S5_SRC -->|read by| S5_R2
    S5_SRC -->|read by| S5_R3

    %% CLASS ASSIGNMENTS %%
    class S1_ENTRY,S2_ENTRY,S3_ENTRY,S4_ENTRY,S5_ENTRY newComponent;
    class FX_RESET,FX_STATE newComponent;
    class S1_RECIPE,S3_RECIPE stateNode;
    class S1_SIM,S2_CASES newComponent;
    class S1_VIS,S2_VIS,S3_SERVER handler;
    class S1_CLIENT,S2_MOCK,S3_CLIENT,S3_PROC phase;
    class S1_ASSERT,S2_ASSERT,S3_ASSERT,S4_IMPORT,S4_TFILES detector;
    class S4_LAYERS,S4_TBOUND,S4_STOOLS output;
    class S5_R1,S5_R2,S5_R3 detector;
    class S5_SRC stateNode;
```

### Development Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    subgraph Build ["BUILD TOOLING"]
        direction LR
        PYPROJ["pyproject.toml<br/>━━━━━━━━━━<br/>hatchling backend<br/>autoskillit 0.9.75<br/>14 runtime deps"]
        TASKFILE["Taskfile.yml<br/>━━━━━━━━━━<br/>test-all / test-check<br/>test-filtered / coverage-audit"]
    end

    subgraph QualityGates ["CODE QUALITY GATES (pre-commit)"]
        direction LR
        RUFF_FMT["ruff-format<br/>━━━━━━━━━━<br/>READS+WRITES src/<br/>auto-fix: format"]
        RUFF_LINT["ruff check<br/>━━━━━━━━━━<br/>READS+WRITES src/<br/>auto-fix: lint"]
        MYPY["mypy<br/>━━━━━━━━━━<br/>READS src/<br/>report-only"]
        GITLEAKS["gitleaks v8.30.0<br/>━━━━━━━━━━<br/>READS repo<br/>secret scanning"]
    end

    subgraph TestRunner ["TEST RUNNER"]
        direction LR
        PYTEST["pytest + xdist -n 4<br/>━━━━━━━━━━<br/>asyncio_mode=auto<br/>timeout=60s signal"]
        MARKERS["Markers<br/>━━━━━━━━━━<br/>layer · small · medium<br/>large · integration · smoke"]
    end

    subgraph FranchiseTests ["★ tests/franchise/ — NEW MODULE"]
        direction TB
        CONFTEST["★ conftest.py<br/>━━━━━━━━━━<br/>_reset_mcp_tags (autouse)<br/>_reset_server_state (autouse)<br/>Isolates mcp process-global state"]
        UNIT["★ test_pack_enforcement.py<br/>━━━━━━━━━━<br/>layer=franchise · small<br/>Group A: 8 per-recipe surface tests<br/>Group B: 3 synthetic pack scenarios<br/>Group C: 3 regression guards<br/>Uses monkeypatch env vars"]
        E2E["★ test_pack_enforcement_e2e.py<br/>━━━━━━━━━━<br/>layer=franchise · medium · integration<br/>StdioTransport real subprocess<br/>2 full-server E2E tests<br/>No monkeypatching"]
    end

    subgraph ArchGates ["● tests/arch/ — MODIFIED"]
        direction TB
        LAYERENF["● test_layer_enforcement.py<br/>━━━━━━━━━━<br/>_TEST_LAYER_ALLOWED extended:<br/>tests/franchise →<br/>{autoskillit.core, .franchise,<br/>.recipe, .server}"]
    end

    subgraph EntryPoints ["ENTRY POINTS"]
        CLI["autoskillit<br/>━━━━━━━━━━<br/>autoskillit.cli:main<br/>serve / init / cook / franchise"]
    end

    PYPROJ --> TASKFILE
    TASKFILE --> PYTEST
    PYPROJ --> RUFF_FMT
    RUFF_FMT --> RUFF_LINT
    RUFF_LINT --> MYPY
    MYPY --> GITLEAKS
    PYTEST --> MARKERS
    PYTEST --> CONFTEST
    CONFTEST --> UNIT
    CONFTEST --> E2E
    LAYERENF -.->|enforces import bounds| UNIT
    LAYERENF -.->|enforces import bounds| E2E
    PYPROJ --> CLI

    %% CLASS ASSIGNMENTS %%
    class PYPROJ,TASKFILE phase;
    class RUFF_FMT,RUFF_LINT,MYPY,GITLEAKS detector;
    class PYTEST,MARKERS handler;
    class CONFTEST,UNIT,E2E newComponent;
    class LAYERENF stateNode;
    class CLI cli;
```

Closes #887

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260420-202243-460343/.autoskillit/temp/make-plan/franchise_per_recipe_tool_surface_test_suite_plan_2026-04-20_203600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 7.5k | 27.5k | 1.3M | 80.1k | 1 | 13m 15s |
| verify | 1.7k | 15.9k | 1.8M | 77.6k | 1 | 7m 33s |
| implement | 126 | 11.2k | 649.7k | 49.1k | 1 | 5m 53s |
| fix | 229 | 11.1k | 1.1M | 68.3k | 1 | 9m 29s |
| prepare_pr | 60 | 4.1k | 201.5k | 26.3k | 1 | 1m 7s |
| run_arch_lenses | 225 | 22.4k | 1.1M | 167.2k | 3 | 6m 55s |
| compose_pr | 91 | 9.4k | 342.6k | 34.2k | 1 | 2m 36s |
| **Total** | 9.9k | 101.6k | 6.5M | 502.8k | | 46m 51s |