### PR TITLE
Rectify: check_review_loop Routing — Pure Iteration Guard + Callable Output Contracts

### DIFF
--- a/src/autoskillit/recipe/contracts.py
+++ b/src/autoskillit/recipe/contracts.py
@@ -185,7 +185,9 @@ def get_skill_contract(skill_name: str, manifest: dict[str, Any]) -> SkillContra
     )
 
 
-def get_callable_contract(dotted_path: str, manifest: dict[str, Any] | None = None) -> SkillContract | None:
+def get_callable_contract(
+    dotted_path: str, manifest: dict[str, Any] | None = None
+) -> SkillContract | None:
     """Look up a run_python callable in the manifest and return a SkillContract.
 
     Callable contracts live under the ``callable_contracts`` top-level key in
@@ -198,9 +200,7 @@ def get_callable_contract(dotted_path: str, manifest: dict[str, Any] | None = No
     entry = callables.get(dotted_path)
     if entry is None:
         return None
-    outputs = [
-        SkillOutput(name=out["name"], type=out["type"]) for out in entry.get("outputs", [])
-    ]
+    outputs = [SkillOutput(name=out["name"], type=out["type"]) for out in entry.get("outputs", [])]
     return SkillContract(inputs=[], outputs=outputs)
 
 

--- a/src/autoskillit/recipe/contracts.py
+++ b/src/autoskillit/recipe/contracts.py
@@ -185,6 +185,25 @@ def get_skill_contract(skill_name: str, manifest: dict[str, Any]) -> SkillContra
     )
 
 
+def get_callable_contract(dotted_path: str, manifest: dict[str, Any] | None = None) -> SkillContract | None:
+    """Look up a run_python callable in the manifest and return a SkillContract.
+
+    Callable contracts live under the ``callable_contracts`` top-level key in
+    skill_contracts.yaml, keyed by the fully-qualified dotted Python path
+    (e.g. ``autoskillit.smoke_utils.check_review_loop``).
+    """
+    if manifest is None:
+        manifest = load_bundled_manifest()
+    callables = manifest.get("callable_contracts", {})
+    entry = callables.get(dotted_path)
+    if entry is None:
+        return None
+    outputs = [
+        SkillOutput(name=out["name"], type=out["type"]) for out in entry.get("outputs", [])
+    ]
+    return SkillContract(inputs=[], outputs=outputs)
+
+
 def compute_skill_hash(skill_name: str, *, skills_dir: Path) -> str:
     """Compute SHA256 hash of a skill's SKILL.md file."""
     skill_md = skills_dir / skill_name / "SKILL.md"

--- a/src/autoskillit/recipe/rules_dataflow.py
+++ b/src/autoskillit/recipe/rules_dataflow.py
@@ -11,6 +11,7 @@ from autoskillit.core import (
 from autoskillit.recipe._analysis import ValidationContext
 from autoskillit.recipe.contracts import (
     RESULT_CAPTURE_RE,
+    get_callable_contract,
     get_skill_contract,
     load_bundled_manifest,
     resolve_skill_name,
@@ -120,6 +121,80 @@ def _check_capture_output_coverage(ctx: ValidationContext) -> list[RuleFinding]:
                             ),
                         )
                     )
+
+    return findings
+
+
+@semantic_rule(
+    name="undeclared-python-capture-key",
+    description="result.X references in run_python steps must match callable contract outputs",
+    severity=Severity.WARNING,
+)
+def _check_python_capture_output_coverage(ctx: ValidationContext) -> list[RuleFinding]:
+    """Validate that run_python steps only reference declared callable output fields.
+
+    Checks both capture: mappings and on_result condition when: expressions
+    for result.* field references, and verifies each against the callable's
+    contract in callable_contracts section of skill_contracts.yaml.
+    """
+    wf = ctx.recipe
+    findings: list[RuleFinding] = []
+    manifest = load_bundled_manifest()
+
+    for step_name, step in wf.steps.items():
+        if step.tool != "run_python":
+            continue
+
+        callable_path = step.with_args.get("callable", "")
+        if not callable_path:
+            continue
+
+        # Collect all result.* references from capture, capture_list, and on_result
+        result_refs: list[str] = []
+        for _capture_var, capture_expr in step.capture.items():
+            result_refs.extend(RESULT_CAPTURE_RE.findall(capture_expr))
+        for _capture_var, capture_expr in step.capture_list.items():
+            result_refs.extend(RESULT_CAPTURE_RE.findall(capture_expr))
+        if step.on_result is not None:
+            for cond in step.on_result.conditions:
+                if cond.when is not None:
+                    result_refs.extend(RESULT_CAPTURE_RE.findall(cond.when))
+
+        if not result_refs:
+            continue
+
+        contract = get_callable_contract(callable_path, manifest)
+        if contract is None:
+            findings.append(
+                RuleFinding(
+                    rule="undeclared-python-capture-key",
+                    severity=Severity.WARNING,
+                    step_name=step_name,
+                    message=(
+                        f"Step '{step_name}' references result.* fields from callable "
+                        f"'{callable_path}' which has no callable contract entry in "
+                        f"skill_contracts.yaml. Add a callable_contracts section to "
+                        f"verify capture correctness."
+                    ),
+                )
+            )
+            continue
+
+        declared_keys = {out.name for out in contract.outputs}
+        for ref_key in result_refs:
+            if ref_key not in declared_keys:
+                findings.append(
+                    RuleFinding(
+                        rule="undeclared-python-capture-key",
+                        severity=Severity.WARNING,
+                        step_name=step_name,
+                        message=(
+                            f"Step '{step_name}' references result.{ref_key} "
+                            f"but callable '{callable_path}' does not declare "
+                            f"'{ref_key}' in its outputs contract."
+                        ),
+                    )
+                )
 
     return findings
 

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -1744,3 +1744,28 @@ skills:
     pattern_examples:
     - "html_path = /tmp/research/report.html\n%%ORDER_UP%%"
     write_behavior: always
+callable_contracts:
+  autoskillit.smoke_utils.check_review_loop:
+    outputs:
+    - name: next_iteration
+      type: str
+    - name: max_exceeded
+      type: str
+  autoskillit.smoke_utils.check_bug_report_non_empty:
+    outputs:
+    - name: non_empty
+      type: str
+  autoskillit.smoke_utils.annotate_pr_diff:
+    outputs:
+    - name: annotated_diff_path
+      type: file_path
+    - name: hunk_ranges_path
+      type: file_path
+  autoskillit.smoke_utils.compute_domain_partitions:
+    outputs:
+    - name: domain_partitions_path
+      type: file_path
+  autoskillit.smoke_utils.fetch_merge_queue_data:
+    outputs:
+    - name: merge_queue_data_path
+      type: file_path

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -642,21 +642,16 @@ steps:
     capture:
       review_loop_count: "${{ result.next_iteration }}"
     on_result:
-      - when: "${{ result.has_blocking }} == true and ${{ result.max_exceeded }} == false"
+      - when: "${{ result.max_exceeded }} == false"
         route: review_pr
       - route: ci_watch
-    on_failure: ci_watch
-    optional: true
     skip_when_false: "inputs.open_pr"
     optional_context_refs:
       - review_loop_count
     note: >
-      After resolve_review fixes are pushed, checks GitHub API for unresolved
-      critical/warning review threads. Routes back to review_pr for another
-      review-resolve cycle if blocking comments persist and the iteration guard
-      (inputs.review_max_retries, default 3) has not been exceeded. Captures
-      review_loop_count to track iterations across loop passes. On GitHub API
-      failure, degrades to ci_watch to avoid blocking the pipeline.
+      Pure iteration guard. Routes back to review_pr if the iteration budget
+      (inputs.review_max_retries) is not exhausted; otherwise proceeds to
+      ci_watch.
 
   ci_watch:
     tool: wait_for_ci

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -645,6 +645,7 @@ steps:
       - when: "${{ result.max_exceeded }} == false"
         route: review_pr
       - route: ci_watch
+    on_failure: ci_watch
     skip_when_false: "inputs.open_pr"
     optional_context_refs:
       - review_loop_count

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -640,21 +640,16 @@ steps:
     capture:
       review_loop_count: "${{ result.next_iteration }}"
     on_result:
-      - when: "${{ result.has_blocking }} == true and ${{ result.max_exceeded }} == false"
+      - when: "${{ result.max_exceeded }} == false"
         route: review_pr
       - route: ci_watch
-    on_failure: ci_watch
-    optional: true
     skip_when_false: "inputs.open_pr"
     optional_context_refs:
       - review_loop_count
     note: >
-      After resolve_review fixes are pushed, checks GitHub API for unresolved
-      critical/warning review threads. Routes back to review_pr for another
-      review-resolve cycle if blocking comments persist and the iteration guard
-      (inputs.review_max_retries, default 3) has not been exceeded. Captures
-      review_loop_count to track iterations across loop passes. On GitHub API
-      failure, degrades to ci_watch to avoid blocking the pipeline.
+      Pure iteration guard. Routes back to review_pr if the iteration budget
+      (inputs.review_max_retries) is not exhausted; otherwise proceeds to
+      ci_watch.
 
   ci_watch:
     tool: wait_for_ci

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -643,6 +643,7 @@ steps:
       - when: "${{ result.max_exceeded }} == false"
         route: review_pr
       - route: ci_watch
+    on_failure: ci_watch
     skip_when_false: "inputs.open_pr"
     optional_context_refs:
       - review_loop_count

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -618,21 +618,16 @@ steps:
     capture:
       review_loop_count: "${{ result.next_iteration }}"
     on_result:
-      - when: "${{ result.has_blocking }} == true and ${{ result.max_exceeded }} == false"
+      - when: "${{ result.max_exceeded }} == false"
         route: review_pr
       - route: ci_watch
-    on_failure: ci_watch
-    optional: true
     skip_when_false: "inputs.open_pr"
     optional_context_refs:
       - review_loop_count
     note: >
-      After resolve_review fixes are pushed, checks GitHub API for unresolved
-      critical/warning review threads. Routes back to review_pr for another
-      review-resolve cycle if blocking comments persist and the iteration guard
-      (inputs.review_max_retries, default 3) has not been exceeded. Captures
-      review_loop_count to track iterations across loop passes. On GitHub API
-      failure, degrades to ci_watch to avoid blocking the pipeline.
+      Pure iteration guard. Routes back to review_pr if the iteration budget
+      (inputs.review_max_retries) is not exhausted; otherwise proceeds to
+      ci_watch.
 
   ci_watch:
     tool: wait_for_ci

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -621,6 +621,7 @@ steps:
       - when: "${{ result.max_exceeded }} == false"
         route: review_pr
       - route: ci_watch
+    on_failure: ci_watch
     skip_when_false: "inputs.open_pr"
     optional_context_refs:
       - review_loop_count

--- a/src/autoskillit/smoke_utils.py
+++ b/src/autoskillit/smoke_utils.py
@@ -97,145 +97,18 @@ def check_review_loop(
     current_iteration: str = "",
     max_iterations: str = "3",
 ) -> dict[str, str]:
-    """Check GitHub review threads and determine if the review-resolve loop should continue.
+    """Pure iteration guard for the review-resolve loop.
 
-    Called by run_python from the check_review_loop step in recipe pipelines.
-    Fetches all review threads via GraphQL, counts unresolved threads with [critical]
-    or [warning] severity markers, and returns routing data for the recipe loop gate.
-
-    On any subprocess failure or GraphQL error, degrades gracefully: returns
-    has_blocking=false so the pipeline is never blocked by an API failure.
+    Returns next_iteration and max_exceeded to determine whether
+    to re-review (iterate) or proceed to ci_watch (budget exhausted).
     """
-    import subprocess  # noqa: PLC0415
-
     iteration = int(current_iteration.strip()) if current_iteration.strip() else 0
     next_iteration = iteration + 1
     max_iter = int(max_iterations.strip()) if max_iterations.strip() else 3
 
-    # Compute next_iteration string for degraded path before any subprocess calls
-    degraded: dict[str, str] = {
-        "has_blocking": "false",
-        "next_iteration": str(next_iteration),
-        "max_exceeded": "false",
-        "blocking_count": "0",
-    }
-
-    # Derive owner/repo
-    try:
-        repo_result = subprocess.run(
-            ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
-            capture_output=True,
-            text=True,
-            check=True,
-            cwd=cwd,
-            timeout=60,
-        )
-    except Exception:
-        logger.warning("check_review_loop: failed to get repo info", exc_info=True)
-        return degraded
-
-    name_with_owner = repo_result.stdout.strip()
-    if "/" not in name_with_owner:
-        logger.warning("check_review_loop: unexpected nameWithOwner format: %r", name_with_owner)
-        return degraded
-    owner, repo = name_with_owner.split("/", 1)
-
-    # GraphQL query with pagination
-    graphql_query = """
-query($owner:String!, $repo:String!, $number:Int!, $after:String) {
-  repository(owner:$owner, name:$repo) {
-    pullRequest(number:$number) {
-      reviewThreads(first:100, after:$after) {
-        pageInfo { hasNextPage endCursor }
-        nodes {
-          isResolved
-          line
-          originalLine
-          comments(first:1) {
-            nodes { body }
-          }
-        }
-      }
-    }
-  }
-}
-""".strip()
-
-    all_threads: list[dict] = []
-    cursor: str | None = None
-
-    while True:
-        try:
-            gql_result = subprocess.run(
-                [
-                    "gh",
-                    "api",
-                    "graphql",
-                    "-f",
-                    f"query={graphql_query}",
-                    "-F",
-                    f"owner={owner}",
-                    "-F",
-                    f"repo={repo}",
-                    "-F",
-                    f"number={int(pr_number)}",
-                    *((["-F", f"after={cursor}"]) if cursor is not None else []),
-                ],
-                capture_output=True,
-                text=True,
-                cwd=cwd,
-                timeout=60,
-            )
-        except Exception:
-            logger.warning("check_review_loop: GraphQL subprocess error", exc_info=True)
-            return degraded
-
-        if gql_result.returncode != 0:
-            logger.warning("check_review_loop: gh api graphql failed: %s", gql_result.stderr)
-            return degraded
-
-        try:
-            data = json.loads(gql_result.stdout)
-        except (json.JSONDecodeError, ValueError):
-            logger.warning("check_review_loop: JSON parse error", exc_info=True)
-            return degraded
-
-        if "errors" in data:
-            logger.warning("GraphQL errors: %s", data["errors"])
-            return degraded
-
-        try:
-            pr_data = data["data"]["repository"]["pullRequest"]
-            threads_page = pr_data["reviewThreads"]
-            nodes = threads_page["nodes"]
-            page_info = threads_page["pageInfo"]
-        except (KeyError, TypeError):
-            logger.warning("check_review_loop: unexpected GraphQL response shape", exc_info=True)
-            return degraded
-
-        all_threads.extend(nodes)
-
-        if page_info.get("hasNextPage"):
-            cursor = page_info.get("endCursor")
-        else:
-            break
-
-    # Classify threads
-    blocking_count = 0
-    for thread in all_threads:
-        if thread.get("isResolved"):
-            continue
-        comments_nodes = thread.get("comments", {}).get("nodes", [])
-        body = comments_nodes[0].get("body", "") if comments_nodes else ""
-        body_lower = body.lower()
-        if "[critical]" in body_lower or "[warning]" in body_lower:
-            blocking_count += 1
-
     return {
-        "has_blocking": "true" if blocking_count > 0 else "false",
         "next_iteration": str(next_iteration),
         "max_exceeded": "true" if next_iteration >= max_iter else "false",
-        "blocking_count": str(blocking_count),
     }
 
 

--- a/tests/arch/test_layer_enforcement.py
+++ b/tests/arch/test_layer_enforcement.py
@@ -1135,6 +1135,8 @@ _TEST_LAYER_ALLOWLIST: dict[str, frozenset[str]] = {
     # recipe tests — recipe layer is L2 and may use workspace (L1 sibling)
     "tests/recipe/test_contracts.py": frozenset({"autoskillit.workspace"}),
     "tests/recipe/test_rules_skill_content.py": frozenset({"autoskillit.workspace"}),
+    # review loop routing integration imports root-level smoke_utils
+    "tests/recipe/test_review_loop_routing_integration.py": frozenset({"autoskillit.smoke_utils"}),
     # migration tests — migration engine integrates with execution.session
     "tests/migration/test_engine.py": frozenset({"autoskillit.execution"}),
 }

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -152,7 +152,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # smoke_utils.py — domain partitions dict, hunk ranges list, merge queue list
     ("src/autoskillit/smoke_utils.py", 57),
     ("src/autoskillit/smoke_utils.py", 87),
-    ("src/autoskillit/smoke_utils.py", 290),
+    ("src/autoskillit/smoke_utils.py", 163),
 }
 
 
@@ -214,7 +214,7 @@ class TestSchemaVersionConvention:
         # These sites write list payloads through function calls but are caught by the scanner
         list_sites = [
             ("src/autoskillit/smoke_utils.py", 87),
-            ("src/autoskillit/smoke_utils.py", 290),
+            ("src/autoskillit/smoke_utils.py", 163),
         ]
         for site in list_sites:
             assert site in _LEGACY_JSON_WRITES, (

--- a/tests/recipe/test_implementation.py
+++ b/tests/recipe/test_implementation.py
@@ -38,18 +38,16 @@ def test_check_review_loop_has_skip_when_false_open_pr(recipe) -> None:
 
 
 # T_IP_LOOP4
-def test_check_review_loop_on_result_routes_to_review_pr_when_blocking(recipe) -> None:
-    """check_review_loop on_result routes to review_pr when has_blocking=true AND
-    max_exceeded=false."""
+def test_check_review_loop_on_result_routes_to_review_pr_when_max_not_exceeded(recipe) -> None:
+    """check_review_loop on_result routes to review_pr when max_exceeded=false."""
     step = recipe.steps["check_review_loop"]
     assert step.on_result is not None
-    blocking_conditions = [
-        c
-        for c in step.on_result.conditions
-        if c.when is not None and "has_blocking" in c.when and "max_exceeded" in c.when
+    review_conditions = [
+        c for c in step.on_result.conditions if c.when is not None and c.route == "review_pr"
     ]
-    assert blocking_conditions, "No condition for has_blocking + max_exceeded found"
-    assert blocking_conditions[0].route == "review_pr"
+    assert review_conditions, "No conditional route to review_pr found"
+    assert "max_exceeded" in review_conditions[0].when
+    assert "has_blocking" not in review_conditions[0].when
 
 
 # T_IP_LOOP5
@@ -63,10 +61,11 @@ def test_check_review_loop_on_result_default_routes_to_ci_watch(recipe) -> None:
 
 
 # T_IP_LOOP6
-def test_check_review_loop_on_failure_routes_to_ci_watch(recipe) -> None:
-    """check_review_loop on_failure routes to ci_watch (API failure must not block pipeline)."""
+def test_check_review_loop_has_no_on_failure(recipe) -> None:
+    """check_review_loop is a pure iteration guard with no subprocess calls,
+    so on_failure is not needed."""
     step = recipe.steps["check_review_loop"]
-    assert step.on_failure == "ci_watch"
+    assert step.on_failure is None
 
 
 # T_IP_LOOP7

--- a/tests/recipe/test_implementation.py
+++ b/tests/recipe/test_implementation.py
@@ -61,11 +61,11 @@ def test_check_review_loop_on_result_default_routes_to_ci_watch(recipe) -> None:
 
 
 # T_IP_LOOP6
-def test_check_review_loop_has_no_on_failure(recipe) -> None:
-    """check_review_loop is a pure iteration guard with no subprocess calls,
-    so on_failure is not needed."""
+def test_check_review_loop_has_on_failure(recipe) -> None:
+    """check_review_loop must declare on_failure because it uses on_result
+    (on-result-missing-failure-route semantic rule requires it)."""
     step = recipe.steps["check_review_loop"]
-    assert step.on_failure is None
+    assert step.on_failure == "ci_watch"
 
 
 # T_IP_LOOP7

--- a/tests/recipe/test_implementation_groups_review_loop.py
+++ b/tests/recipe/test_implementation_groups_review_loop.py
@@ -43,3 +43,11 @@ def test_check_review_loop_routes_on_max_exceeded_only(recipe) -> None:
     assert review_conditions, "No conditional route to review_pr found"
     assert "max_exceeded" in review_conditions[0].when
     assert "has_blocking" not in review_conditions[0].when
+
+
+# T_IG_LOOP4
+def test_check_review_loop_has_on_failure(recipe) -> None:
+    """check_review_loop must declare on_failure because it uses on_result
+    (on-result-missing-failure-route semantic rule requires it)."""
+    step = recipe.steps["check_review_loop"]
+    assert step.on_failure == "ci_watch"

--- a/tests/recipe/test_implementation_groups_review_loop.py
+++ b/tests/recipe/test_implementation_groups_review_loop.py
@@ -32,7 +32,14 @@ def test_re_push_review_routes_to_check_review_loop(recipe) -> None:
 
 
 # T_IG_LOOP3
-def test_check_review_loop_on_failure_routes_to_ci_watch(recipe) -> None:
-    """check_review_loop on_failure must route to ci_watch in implementation-groups recipe."""
+def test_check_review_loop_routes_on_max_exceeded_only(recipe) -> None:
+    """check_review_loop on_result condition must route on max_exceeded alone,
+    NOT on has_blocking."""
     step = recipe.steps["check_review_loop"]
-    assert step.on_failure == "ci_watch"
+    assert step.on_result is not None
+    review_conditions = [
+        c for c in step.on_result.conditions if c.when is not None and c.route == "review_pr"
+    ]
+    assert review_conditions, "No conditional route to review_pr found"
+    assert "max_exceeded" in review_conditions[0].when
+    assert "has_blocking" not in review_conditions[0].when

--- a/tests/recipe/test_remediation_recipe.py
+++ b/tests/recipe/test_remediation_recipe.py
@@ -59,3 +59,11 @@ def test_check_review_loop_routes_on_max_exceeded_only(recipe) -> None:
     assert review_conditions, "No conditional route to review_pr found"
     assert "max_exceeded" in review_conditions[0].when
     assert "has_blocking" not in review_conditions[0].when
+
+
+# T_REM_LOOP4
+def test_check_review_loop_has_on_failure(recipe) -> None:
+    """check_review_loop must declare on_failure because it uses on_result
+    (on-result-missing-failure-route semantic rule requires it)."""
+    step = recipe.steps["check_review_loop"]
+    assert step.on_failure == "ci_watch"

--- a/tests/recipe/test_remediation_recipe.py
+++ b/tests/recipe/test_remediation_recipe.py
@@ -48,7 +48,14 @@ def test_re_push_review_routes_to_check_review_loop(recipe) -> None:
 
 
 # T_REM_LOOP3
-def test_check_review_loop_on_failure_routes_to_ci_watch(recipe) -> None:
-    """check_review_loop on_failure must route to ci_watch in remediation recipe."""
+def test_check_review_loop_routes_on_max_exceeded_only(recipe) -> None:
+    """check_review_loop on_result condition must route on max_exceeded alone,
+    NOT on has_blocking."""
     step = recipe.steps["check_review_loop"]
-    assert step.on_failure == "ci_watch"
+    assert step.on_result is not None
+    review_conditions = [
+        c for c in step.on_result.conditions if c.when is not None and c.route == "review_pr"
+    ]
+    assert review_conditions, "No conditional route to review_pr found"
+    assert "max_exceeded" in review_conditions[0].when
+    assert "has_blocking" not in review_conditions[0].when

--- a/tests/recipe/test_review_loop_routing_integration.py
+++ b/tests/recipe/test_review_loop_routing_integration.py
@@ -1,0 +1,78 @@
+"""Compound routing integration tests for the review-resolve retry loop."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
+from autoskillit.smoke_utils import check_review_loop
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+RECIPE_NAMES = ["implementation.yaml", "remediation.yaml", "implementation-groups.yaml"]
+
+
+@pytest.mark.parametrize("recipe_name", RECIPE_NAMES)
+def test_review_loop_routes_to_review_pr_after_resolve_cycle(recipe_name: str) -> None:
+    """End-to-end routing test: after resolve_review -> re_push_review,
+    check_review_loop must route to review_pr (not ci_watch) when
+    iterations remain.
+
+    This test calls the actual check_review_loop callable with
+    current_iteration=0 and max_iterations=3, then evaluates the
+    recipe's on_result conditions against the callable's return value.
+    """
+    result = check_review_loop(
+        pr_number="42",
+        cwd="/tmp",
+        current_iteration="0",
+        max_iterations="3",
+    )
+
+    recipe = load_recipe(builtin_recipes_dir() / recipe_name)
+    step = recipe.steps["check_review_loop"]
+    conditions = step.on_result.conditions
+
+    # Simulate template interpolation
+    when_expr = conditions[0].when
+    for key, value in result.items():
+        when_expr = when_expr.replace(f"${{{{ result.{key} }}}}", value)
+
+    # The first condition (route to review_pr) must be satisfiable
+    assert eval(when_expr) is True  # noqa: S307
+    assert conditions[0].route == "review_pr"
+
+
+@pytest.mark.parametrize("recipe_name", RECIPE_NAMES)
+def test_review_loop_routes_to_ci_watch_at_max_iterations(recipe_name: str) -> None:
+    """When max_iterations is exhausted, routing must fall through to ci_watch."""
+    result = check_review_loop(
+        pr_number="42",
+        cwd="/tmp",
+        current_iteration="2",
+        max_iterations="3",
+    )
+
+    recipe = load_recipe(builtin_recipes_dir() / recipe_name)
+    step = recipe.steps["check_review_loop"]
+    conditions = step.on_result.conditions
+
+    # Simulate template interpolation on the first (review_pr) condition
+    when_expr = conditions[0].when
+    for key, value in result.items():
+        when_expr = when_expr.replace(f"${{{{ result.{key} }}}}", value)
+
+    # The first condition must NOT be satisfied — falls through to default ci_watch
+    assert eval(when_expr) is False  # noqa: S307
+
+
+@pytest.mark.parametrize("recipe_name", RECIPE_NAMES)
+def test_check_review_loop_routes_on_max_exceeded_only(recipe_name: str) -> None:
+    """The check_review_loop on_result condition must route on max_exceeded alone,
+    NOT on has_blocking."""
+    recipe = load_recipe(builtin_recipes_dir() / recipe_name)
+    step = recipe.steps["check_review_loop"]
+    conditions = step.on_result.conditions
+    review_condition = next(c for c in conditions if c.route == "review_pr")
+    assert "max_exceeded" in review_condition.when
+    assert "has_blocking" not in review_condition.when

--- a/tests/recipe/test_review_loop_routing_integration.py
+++ b/tests/recipe/test_review_loop_routing_integration.py
@@ -70,6 +70,7 @@ def test_review_loop_routes_to_ci_watch_at_max_iterations(recipe_name: str) -> N
     # when_expr becomes e.g. "true == false" — evaluate as string equality
     lhs, rhs = [s.strip() for s in when_expr.split("==", 1)]
     assert lhs != rhs
+    assert conditions[1].route == "ci_watch"
 
 
 @pytest.mark.parametrize("recipe_name", RECIPE_NAMES)

--- a/tests/recipe/test_review_loop_routing_integration.py
+++ b/tests/recipe/test_review_loop_routing_integration.py
@@ -39,7 +39,9 @@ def test_review_loop_routes_to_review_pr_after_resolve_cycle(recipe_name: str) -
         when_expr = when_expr.replace(f"${{{{ result.{key} }}}}", value)
 
     # The first condition (route to review_pr) must be satisfiable
-    assert eval(when_expr) is True  # noqa: S307
+    # when_expr becomes e.g. "false == false" — evaluate as string equality
+    lhs, rhs = [s.strip() for s in when_expr.split("==")]
+    assert lhs == rhs
     assert conditions[0].route == "review_pr"
 
 
@@ -63,7 +65,9 @@ def test_review_loop_routes_to_ci_watch_at_max_iterations(recipe_name: str) -> N
         when_expr = when_expr.replace(f"${{{{ result.{key} }}}}", value)
 
     # The first condition must NOT be satisfied — falls through to default ci_watch
-    assert eval(when_expr) is False  # noqa: S307
+    # when_expr becomes e.g. "true == false" — evaluate as string equality
+    lhs, rhs = [s.strip() for s in when_expr.split("==")]
+    assert lhs != rhs
 
 
 @pytest.mark.parametrize("recipe_name", RECIPE_NAMES)

--- a/tests/recipe/test_review_loop_routing_integration.py
+++ b/tests/recipe/test_review_loop_routing_integration.py
@@ -31,6 +31,7 @@ def test_review_loop_routes_to_review_pr_after_resolve_cycle(recipe_name: str) -
 
     recipe = load_recipe(builtin_recipes_dir() / recipe_name)
     step = recipe.steps["check_review_loop"]
+    assert step.on_result is not None
     conditions = step.on_result.conditions
 
     # Simulate template interpolation
@@ -40,7 +41,7 @@ def test_review_loop_routes_to_review_pr_after_resolve_cycle(recipe_name: str) -
 
     # The first condition (route to review_pr) must be satisfiable
     # when_expr becomes e.g. "false == false" — evaluate as string equality
-    lhs, rhs = [s.strip() for s in when_expr.split("==")]
+    lhs, rhs = [s.strip() for s in when_expr.split("==", 1)]
     assert lhs == rhs
     assert conditions[0].route == "review_pr"
 
@@ -57,6 +58,7 @@ def test_review_loop_routes_to_ci_watch_at_max_iterations(recipe_name: str) -> N
 
     recipe = load_recipe(builtin_recipes_dir() / recipe_name)
     step = recipe.steps["check_review_loop"]
+    assert step.on_result is not None
     conditions = step.on_result.conditions
 
     # Simulate template interpolation on the first (review_pr) condition
@@ -66,7 +68,7 @@ def test_review_loop_routes_to_ci_watch_at_max_iterations(recipe_name: str) -> N
 
     # The first condition must NOT be satisfied — falls through to default ci_watch
     # when_expr becomes e.g. "true == false" — evaluate as string equality
-    lhs, rhs = [s.strip() for s in when_expr.split("==")]
+    lhs, rhs = [s.strip() for s in when_expr.split("==", 1)]
     assert lhs != rhs
 
 
@@ -76,6 +78,7 @@ def test_check_review_loop_routes_on_max_exceeded_only(recipe_name: str) -> None
     NOT on has_blocking."""
     recipe = load_recipe(builtin_recipes_dir() / recipe_name)
     step = recipe.steps["check_review_loop"]
+    assert step.on_result is not None
     conditions = step.on_result.conditions
     review_condition = next(c for c in conditions if c.route == "review_pr")
     assert "max_exceeded" in review_condition.when

--- a/tests/recipe/test_rules_dataflow.py
+++ b/tests/recipe/test_rules_dataflow.py
@@ -928,3 +928,176 @@ class TestUncapturedHandoffConsumerRule:
         findings = run_semantic_rules(recipe)
         handoff = [f for f in findings if f.rule == "uncaptured-handoff-consumer"]
         assert handoff == []
+
+
+# ---------------------------------------------------------------------------
+# TestCallableContracts
+# ---------------------------------------------------------------------------
+
+
+class TestCallableContracts:
+    """Tests for callable output contracts (run_python steps)."""
+
+    def test_callable_contract_check_review_loop(self) -> None:
+        """The callable contract for check_review_loop must declare its output fields."""
+        from autoskillit.recipe.contracts import get_callable_contract
+
+        contract = get_callable_contract("autoskillit.smoke_utils.check_review_loop")
+        assert contract is not None
+        declared = {out.name for out in contract.outputs}
+        assert "next_iteration" in declared
+        assert "max_exceeded" in declared
+
+    def test_callable_contract_missing_returns_none(self) -> None:
+        """get_callable_contract returns None for unknown callable paths."""
+        from autoskillit.recipe.contracts import get_callable_contract
+
+        contract = get_callable_contract("nonexistent.module.function")
+        assert contract is None
+
+
+# ---------------------------------------------------------------------------
+# TestPythonCaptureOutputCoverageRule
+# ---------------------------------------------------------------------------
+
+
+class TestPythonCaptureOutputCoverageRule:
+    def test_python_capture_declared_key_no_warning(self) -> None:
+        """A run_python capture referencing a declared callable output key
+        must not produce an undeclared-python-capture-key warning."""
+        recipe_yaml = textwrap.dedent("""\
+            name: python-capture-valid
+            description: test
+            steps:
+              check:
+                tool: run_python
+                with:
+                  callable: "autoskillit.smoke_utils.check_review_loop"
+                  pr_number: "42"
+                  cwd: "/tmp"
+                capture:
+                  loop_count: "${{ result.next_iteration }}"
+                on_result:
+                  - when: "${{ result.max_exceeded }} == false"
+                    route: review
+                  - route: done
+              review:
+                tool: run_skill
+                with:
+                  skill_command: /autoskillit:review-pr
+                on_success: done
+                on_failure: done
+              done:
+                action: stop
+                message: Done
+        """)
+        recipe = _parse_recipe(yaml.safe_load(recipe_yaml))
+        findings = run_semantic_rules(recipe)
+        undeclared = [f for f in findings if f.rule == "undeclared-python-capture-key"]
+        assert undeclared == []
+
+    def test_python_capture_undeclared_key_fires_warning(self) -> None:
+        """A run_python step referencing result.nonexistent must fire a warning."""
+        recipe_yaml = textwrap.dedent("""\
+            name: python-capture-invalid
+            description: test
+            steps:
+              check:
+                tool: run_python
+                with:
+                  callable: "autoskillit.smoke_utils.check_review_loop"
+                  pr_number: "42"
+                  cwd: "/tmp"
+                capture:
+                  bad: "${{ result.nonexistent }}"
+                on_success: done
+                on_failure: done
+              done:
+                action: stop
+                message: Done
+        """)
+        recipe = _parse_recipe(yaml.safe_load(recipe_yaml))
+        findings = run_semantic_rules(recipe)
+        undeclared = [f for f in findings if f.rule == "undeclared-python-capture-key"]
+        assert len(undeclared) == 1
+        assert undeclared[0].severity == Severity.WARNING
+        assert "nonexistent" in undeclared[0].message
+
+    def test_python_capture_no_contract_fires_warning(self) -> None:
+        """A run_python step with an unknown callable must warn about missing contract."""
+        recipe_yaml = textwrap.dedent("""\
+            name: python-capture-no-contract
+            description: test
+            steps:
+              check:
+                tool: run_python
+                with:
+                  callable: "some.unknown.callable"
+                capture:
+                  val: "${{ result.output }}"
+                on_success: done
+                on_failure: done
+              done:
+                action: stop
+                message: Done
+        """)
+        recipe = _parse_recipe(yaml.safe_load(recipe_yaml))
+        findings = run_semantic_rules(recipe)
+        undeclared = [f for f in findings if f.rule == "undeclared-python-capture-key"]
+        assert len(undeclared) == 1
+        assert "no callable contract entry" in undeclared[0].message
+
+    def test_python_on_result_undeclared_ref_fires_warning(self) -> None:
+        """A run_python on_result condition referencing an undeclared field must fire."""
+        recipe_yaml = textwrap.dedent("""\
+            name: python-on-result-invalid
+            description: test
+            steps:
+              check:
+                tool: run_python
+                with:
+                  callable: "autoskillit.smoke_utils.check_review_loop"
+                  pr_number: "42"
+                  cwd: "/tmp"
+                on_result:
+                  - when: "${{ result.has_blocking }} == true"
+                    route: review
+                  - route: done
+              review:
+                tool: run_skill
+                with:
+                  skill_command: /autoskillit:review-pr
+                on_success: done
+                on_failure: done
+              done:
+                action: stop
+                message: Done
+        """)
+        recipe = _parse_recipe(yaml.safe_load(recipe_yaml))
+        findings = run_semantic_rules(recipe)
+        undeclared = [f for f in findings if f.rule == "undeclared-python-capture-key"]
+        assert len(undeclared) == 1
+        assert "has_blocking" in undeclared[0].message
+
+    def test_non_python_step_not_flagged(self) -> None:
+        """run_skill steps must not be flagged by the python capture rule."""
+        recipe_yaml = textwrap.dedent("""\
+            name: skill-step-ignored
+            description: test
+            steps:
+              run:
+                tool: run_skill
+                with:
+                  skill_command: /autoskillit:implement-worktree-no-merge ${{ inputs.plan }}
+                capture:
+                  wp: "${{ result.worktree_path }}"
+                on_success: done
+                on_failure: done
+              done:
+                action: stop
+                message: Done
+        """)
+        recipe = _parse_recipe(yaml.safe_load(recipe_yaml))
+        findings = run_semantic_rules(recipe)
+        undeclared = [f for f in findings if f.rule == "undeclared-python-capture-key"]
+        assert undeclared == []

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -2,56 +2,10 @@
 
 from __future__ import annotations
 
-import ast
 import json
-import subprocess
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 
 from autoskillit.smoke_utils import check_bug_report_non_empty, check_review_loop
-
-
-def _make_graphql_response(nodes: list[dict]) -> str:
-    """Build a minimal single-page GraphQL reviewThreads response."""
-    return json.dumps(
-        {
-            "data": {
-                "repository": {
-                    "pullRequest": {
-                        "reviewThreads": {
-                            "pageInfo": {"hasNextPage": False, "endCursor": None},
-                            "nodes": nodes,
-                        }
-                    }
-                }
-            }
-        }
-    )
-
-
-def _mock_run_factory(nodes: list[dict]):
-    """Return a subprocess.run mock that serves repo-view then graphql responses."""
-
-    def _mock_run(cmd, **kwargs):
-        result = MagicMock(spec=subprocess.CompletedProcess)
-        result.returncode = 0
-        if "nameWithOwner" in " ".join(cmd):
-            result.stdout = "owner/repo\n"
-        else:
-            result.stdout = _make_graphql_response(nodes)
-        result.stderr = ""
-        return result
-
-    return _mock_run
-
-
-def _thread(is_resolved: bool, body: str) -> dict:
-    return {
-        "isResolved": is_resolved,
-        "line": 10,
-        "originalLine": 10,
-        "comments": {"nodes": [{"body": body}]},
-    }
 
 
 # T_SU1
@@ -86,126 +40,100 @@ def test_returns_false_when_bug_report_malformed(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# T_CRL1–T_CRL11: check_review_loop tests
+# T_CRL6–T_CRL8: check_review_loop tests (pure iteration guard)
 # ---------------------------------------------------------------------------
 
 
-# T_CRL1
-def test_crl_no_unresolved_threads_returns_not_blocking(tmp_path: Path) -> None:
-    """Returns has_blocking=false and next_iteration=1 when no unresolved threads exist."""
-    with patch("subprocess.run", side_effect=_mock_run_factory([])):
-        result = check_review_loop("42", str(tmp_path))
-    assert result["has_blocking"] == "false"
-    assert result["next_iteration"] == "1"
-
-
-# T_CRL2
-def test_crl_unresolved_critical_is_blocking(tmp_path: Path) -> None:
-    """Returns has_blocking=true when at least one unresolved thread body contains [critical]."""
-    nodes = [_thread(False, "[critical] arch: missing abstraction")]
-    with patch("subprocess.run", side_effect=_mock_run_factory(nodes)):
-        result = check_review_loop("42", str(tmp_path))
-    assert result["has_blocking"] == "true"
-    assert result["blocking_count"] == "1"
-
-
-# T_CRL3
-def test_crl_unresolved_warning_is_blocking(tmp_path: Path) -> None:
-    """Returns has_blocking=true when at least one unresolved thread body contains [warning]."""
-    nodes = [_thread(False, "[warning] tests: weak assertion")]
-    with patch("subprocess.run", side_effect=_mock_run_factory(nodes)):
-        result = check_review_loop("42", str(tmp_path))
-    assert result["has_blocking"] == "true"
-
-
-# T_CRL4
-def test_crl_unresolved_info_not_blocking(tmp_path: Path) -> None:
-    """Returns has_blocking=false for unresolved threads with neither [critical] nor [warning]."""
-    nodes = [_thread(False, "[info] style: minor nit")]
-    with patch("subprocess.run", side_effect=_mock_run_factory(nodes)):
-        result = check_review_loop("42", str(tmp_path))
-    assert result["has_blocking"] == "false"
-
-
-# T_CRL5
-def test_crl_resolved_critical_not_blocking(tmp_path: Path) -> None:
-    """Returns has_blocking=false for resolved threads even if body contains [critical]."""
-    nodes = [_thread(True, "[critical] already fixed")]
-    with patch("subprocess.run", side_effect=_mock_run_factory(nodes)):
-        result = check_review_loop("42", str(tmp_path))
-    assert result["has_blocking"] == "false"
-
-
 # T_CRL6
-def test_crl_next_iteration_increments(tmp_path: Path) -> None:
+def test_crl_next_iteration_increments() -> None:
     """next_iteration increments from current_iteration: "" → "1", "1" → "2", "2" → "3"."""
-    nodes: list[dict] = []
-    with patch("subprocess.run", side_effect=_mock_run_factory(nodes)):
-        r1 = check_review_loop("1", str(tmp_path), current_iteration="")
+    r1 = check_review_loop("1", "/tmp", current_iteration="")
     assert r1["next_iteration"] == "1"
 
-    with patch("subprocess.run", side_effect=_mock_run_factory(nodes)):
-        r2 = check_review_loop("1", str(tmp_path), current_iteration="1")
+    r2 = check_review_loop("1", "/tmp", current_iteration="1")
     assert r2["next_iteration"] == "2"
 
-    with patch("subprocess.run", side_effect=_mock_run_factory(nodes)):
-        r3 = check_review_loop("1", str(tmp_path), current_iteration="2")
+    r3 = check_review_loop("1", "/tmp", current_iteration="2")
     assert r3["next_iteration"] == "3"
 
 
 # T_CRL7
-def test_crl_max_exceeded_when_next_iteration_ge_max(tmp_path: Path) -> None:
+def test_crl_max_exceeded_when_next_iteration_ge_max() -> None:
     """max_exceeded=true when next_iteration >= max_iterations."""
-    nodes = [_thread(False, "[critical] blocking")]
-    with patch("subprocess.run", side_effect=_mock_run_factory(nodes)):
-        result = check_review_loop("1", str(tmp_path), current_iteration="2", max_iterations="3")
-    # next_iteration = 3, max_iterations = 3 → 3 >= 3 → max_exceeded=true
+    result = check_review_loop("1", "/tmp", current_iteration="2", max_iterations="3")
     assert result["max_exceeded"] == "true"
     assert result["next_iteration"] == "3"
 
 
 # T_CRL8
-def test_crl_max_not_exceeded_when_below_max(tmp_path: Path) -> None:
+def test_crl_max_not_exceeded_when_below_max() -> None:
     """max_exceeded=false when next_iteration < max_iterations."""
-    nodes = [_thread(False, "[critical] blocking")]
-    with patch("subprocess.run", side_effect=_mock_run_factory(nodes)):
-        result = check_review_loop("1", str(tmp_path), current_iteration="1", max_iterations="3")
-    # next_iteration = 2, max_iterations = 3 → 2 < 3 → max_exceeded=false
+    result = check_review_loop("1", "/tmp", current_iteration="1", max_iterations="3")
     assert result["max_exceeded"] == "false"
 
 
-# T_CRL9
-def test_crl_graceful_degradation_on_subprocess_failure(tmp_path: Path) -> None:
-    """Returns has_blocking=false and max_exceeded=false on gh CLI failure."""
+def test_check_review_loop_always_continues_when_iterations_remain() -> None:
+    """After a resolve cycle, check_review_loop must indicate continuation
+    when max_iterations is not exceeded — regardless of GitHub thread state.
 
-    def _fail(*args, **kwargs):
-        raise OSError("gh not found")
-
-    with patch("subprocess.run", side_effect=_fail):
-        result = check_review_loop("1", str(tmp_path))
-    assert result["has_blocking"] == "false"
+    The function is a pure iteration guard: if next_iteration < max_iterations,
+    it must return max_exceeded=false so the recipe routes back to review_pr.
+    """
+    result = check_review_loop(
+        pr_number="42",
+        cwd="/tmp",
+        current_iteration="0",
+        max_iterations="3",
+    )
     assert result["max_exceeded"] == "false"
+    assert result["next_iteration"] == "1"
 
 
-# T_CRL10
-def test_crl_blocking_count_reflects_unresolved_severity_threads(tmp_path: Path) -> None:
-    """blocking_count reflects number of unresolved critical/warning threads."""
-    nodes = [
-        _thread(False, "[critical] arch issue"),
-        _thread(False, "[warning] test coverage"),
-        _thread(False, "[info] nit"),
-        _thread(True, "[critical] already resolved"),
-    ]
-    with patch("subprocess.run", side_effect=_mock_run_factory(nodes)):
-        result = check_review_loop("42", str(tmp_path))
-    assert result["blocking_count"] == "2"
+def test_check_review_loop_stops_at_max_iterations() -> None:
+    """When current_iteration reaches max_iterations, max_exceeded must be true."""
+    result = check_review_loop(
+        pr_number="42",
+        cwd="/tmp",
+        current_iteration="2",
+        max_iterations="3",
+    )
+    assert result["max_exceeded"] == "true"
+    assert result["next_iteration"] == "3"
 
 
-# T_CRL11 — enforced by the existing AST test_subprocess_calls_have_timeout below
+def test_check_review_loop_returns_only_iteration_fields() -> None:
+    """Pure iteration guard must not return has_blocking or blocking_count."""
+    result = check_review_loop(pr_number="42", cwd="/tmp")
+    assert "has_blocking" not in result
+    assert "blocking_count" not in result
+    assert set(result.keys()) == {"next_iteration", "max_exceeded"}
+
+
+# T_CRL11 — verify check_review_loop has no subprocess calls
+def test_check_review_loop_has_no_subprocess_calls() -> None:
+    """The simplified check_review_loop must not use subprocess at all."""
+    import ast
+
+    src = Path("src/autoskillit/smoke_utils.py").read_text()
+    tree = ast.parse(src)
+
+    # Find the check_review_loop function node
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "check_review_loop":
+            for child in ast.walk(node):
+                if isinstance(child, ast.Attribute) and child.attr == "run":
+                    if isinstance(child.value, ast.Name) and child.value.id == "subprocess":
+                        raise AssertionError(
+                            "check_review_loop should not use subprocess.run() — "
+                            "it is a pure iteration guard"
+                        )
+            break
 
 
 def test_subprocess_calls_have_timeout() -> None:
     """All subprocess.run() calls in smoke_utils.py must have a timeout= argument."""
+    import ast
+
     src = Path("src/autoskillit/smoke_utils.py").read_text()
     tree = ast.parse(src)
     for node in ast.walk(tree):


### PR DESCRIPTION
## Summary

The `check_review_loop` function queries GitHub GraphQL API for unresolved review threads to decide whether to re-review fix commits. But `resolve_review` (the preceding skill) resolves ALL threads before the gate runs, so `has_blocking` is always `false` and fix commits are never re-reviewed. The root cause is a semantic mismatch: the routing signal (GitHub thread state) is not the loop invariant (should we iterate again?). The architectural weakness is that `run_python` callable steps have no output contracts, so the recipe validation engine cannot detect that routing conditions reference semantically meaningless fields.

**Immunity approach:** (1) Replace the external-state query with a pure iteration guard — the function only needs to answer "have we exhausted our retry budget?" (2) Extend the callable contract system from `run_skill` steps to `run_python` steps, so routing condition field references are validated at recipe load time.

## Requirements

`check_review_loop` in the `implementation` recipe checks GitHub for **unresolved review threads** to decide whether to loop back to `review_pr`. This is wrong. When `resolve_review` resolves all threads before pushing, `check_review_loop` finds `has_blocking: false` and routes to `ci_watch` — skipping the mandatory re-review of fix commits.

### Root Cause

`check_review_loop` calls `autoskillit.smoke_utils.check_review_loop` which queries GitHub API for unresolved blocking threads. Since `resolve_review` resolves all threads as part of its workflow, the check always returns `has_blocking: false` after a resolve cycle, even though fix commits were just pushed that have never been reviewed.

### Desired Behavior

The re-review decision should be based on: **did the last `review_pr` pass have blocking findings?** — not on whether threads are currently resolved.

- If the last `review_pr` returned `changes_requested` (blocking findings existed) → after `resolve_review` + `re_push_review`, **always** route back to `review_pr` for a fresh review of the new commits
- Still resolve non-blocking comments, but they don't factor into the re-review routing
- Discuss comments don't factor into the re-review routing
- Proceed to `ci_watch` only when: (a) the latest `review_pr` pass had **no blocking findings**, OR (b) `review_max_retries` iterations exhausted
- Thread resolution status on GitHub is **irrelevant** to the routing decision

### Proposed Fix

Simplify `check_review_loop` to an iteration guard only. Since we only reach `check_review_loop` through the `changes_requested` → `resolve_review` → `re_push_review` path, blocking was already confirmed. The step should:

1. Increment the iteration counter
2. If `max_iterations` not exceeded → route to `review_pr`
3. If `max_iterations` exceeded → route to `ci_watch`

The GitHub API unresolved-thread check should be removed from the routing decision entirely.

### Affected Files

- `src/autoskillit/smoke_utils.py` — `check_review_loop` function logic
- `.autoskillit/recipes/implementation.yaml` — `check_review_loop` step routing
- `.autoskillit/recipes/remediation.yaml` — same pattern if present
- `.autoskillit/recipes/implementation-groups.yaml` — same pattern if present

### Observed Impact

In PR #1094 (issue #1091), `review_pr` found 13 findings (10 warnings). After `resolve_review` applied 6 fixes and resolved all threads, `check_review_loop` returned `has_blocking: false` and skipped re-review. The 6 fix commits were merged without any review pass.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START<br/>━━━━━━━━━━<br/>Recipe execution<br/>reaches PR stage])
    DONE([DONE<br/>━━━━━━━━━━<br/>CI watch /<br/>merge queue])
    FAIL([FAILURE<br/>━━━━━━━━━━<br/>release_issue_failure])

    subgraph ReviewLoop ["● Review Loop — PR Quality Gate"]
        direction TB

        REVIEW_PR["● review_pr<br/>━━━━━━━━━━<br/>run_skill: review-pr<br/>captures: verdict<br/>optional: review_loop_count"]

        VERDICT_ROUTE{"● Verdict<br/>Routing<br/>━━━━━━━━━━<br/>on_result /<br/>on_failure?"}

        RESOLVE["resolve_review<br/>━━━━━━━━━━<br/>run_skill: resolve-review<br/>retries: 2<br/>captures: verdict"]

        RESOLVE_ROUTE{"Resolve<br/>Verdict<br/>━━━━━━━━━━<br/>real_fix /<br/>already_green /<br/>flake?"}

        REPUSH["re_push_review<br/>━━━━━━━━━━<br/>Push fixed branch<br/>to origin"]

        CHECK_LOOP["● check_review_loop<br/>━━━━━━━━━━<br/>run_python:<br/>smoke_utils.check_review_loop<br/>captures: review_loop_count,<br/>max_exceeded"]

        MAX_ROUTE{"● max_exceeded?<br/>━━━━━━━━━━<br/>Gates on<br/>max_exceeded ONLY<br/>not has_blocking"}
    end

    subgraph ContractGen ["● Contract Generation Pipeline"]
        direction TB

        LOAD_MANIFEST["● load_bundled_manifest<br/>━━━━━━━━━━<br/>skill_contracts.yaml<br/>lru_cache'd"]

        GEN_CARD["● generate_recipe_card<br/>━━━━━━━━━━<br/>Walk steps, resolve skills,<br/>track available set"]

        RESOLVE_SKILL{"resolve_skill_name<br/>━━━━━━━━━━<br/>Dynamic name?<br/>Has placeholder?"}

        WRITE_CARD["atomic_write<br/>━━━━━━━━━━<br/>contracts/name.yaml"]
    end

    subgraph DataflowRules ["● Dataflow Rule Validation"]
        direction TB

        RULE_CTX["ValidationContext<br/>━━━━━━━━━━<br/>recipe + step_graph +<br/>dataflow analysis"]

        PYTHON_CAPTURE["● undeclared-python-<br/>capture-key<br/>━━━━━━━━━━<br/>Validates run_python<br/>result.X refs against<br/>callable_contracts"]

        SKILL_CAPTURE["undeclared-capture-key<br/>━━━━━━━━━━<br/>Validates run_skill<br/>result.X refs against<br/>skill_contracts"]

        FINDINGS["Rule Findings<br/>━━━━━━━━━━<br/>ERROR blocks,<br/>WARNING advises"]
    end

    subgraph IntegrationTests ["★ Integration Test Validation"]
        direction TB

        T_ROUTE_BACK["★ T_IP_LOOP4<br/>━━━━━━━━━━<br/>iter 0/3: routes<br/>back to review_pr"]

        T_ROUTE_EXIT["★ T_IP_LOOP5<br/>━━━━━━━━━━<br/>iter 2/3: falls<br/>through to ci_watch"]

        T_NO_BLOCKING["★ T_IP_LOOP6<br/>━━━━━━━━━━<br/>Asserts: when expr<br/>contains max_exceeded,<br/>NOT has_blocking,<br/>on_failure present"]
    end

    %% === REVIEW LOOP FLOW === %%
    START --> REVIEW_PR

    REVIEW_PR --> VERDICT_ROUTE
    VERDICT_ROUTE -->|"approved / default"| DONE
    VERDICT_ROUTE -->|"changes_requested"| RESOLVE
    VERDICT_ROUTE -->|"needs_human"| DONE
    VERDICT_ROUTE -->|"on_failure"| RESOLVE
    VERDICT_ROUTE -->|"on_context_limit"| DONE

    RESOLVE --> RESOLVE_ROUTE
    RESOLVE_ROUTE -->|"real_fix / already_green /<br/>flake_suspected"| REPUSH
    RESOLVE_ROUTE -->|"ci_only_failure"| FAIL
    RESOLVE -->|"on_failure /<br/>on_exhausted"| FAIL

    REPUSH -->|"on_success"| CHECK_LOOP
    REPUSH -->|"on_failure"| FAIL

    CHECK_LOOP --> MAX_ROUTE
    MAX_ROUTE -->|"max_exceeded == false"| REVIEW_PR
    MAX_ROUTE -->|"default: budget<br/>exhausted"| DONE
    CHECK_LOOP -->|"on_failure"| DONE

    %% === CONTRACT GENERATION FLOW === %%
    LOAD_MANIFEST --> GEN_CARD
    GEN_CARD --> RESOLVE_SKILL
    RESOLVE_SKILL -->|"resolvable"| WRITE_CARD
    RESOLVE_SKILL -->|"dynamic / placeholder"| GEN_CARD

    %% === DATAFLOW VALIDATION FLOW === %%
    RULE_CTX --> PYTHON_CAPTURE
    RULE_CTX --> SKILL_CAPTURE
    PYTHON_CAPTURE --> FINDINGS
    SKILL_CAPTURE --> FINDINGS

    %% === CROSS-DOMAIN CONNECTIONS === %%
    LOAD_MANIFEST -.->|"provides callable_contracts"| PYTHON_CAPTURE
    LOAD_MANIFEST -.->|"provides skill outputs"| SKILL_CAPTURE
    PYTHON_CAPTURE -.->|"validates result.max_exceeded<br/>on check_review_loop"| CHECK_LOOP
    T_NO_BLOCKING -.->|"asserts max_exceeded only,<br/>no has_blocking"| MAX_ROUTE
    T_ROUTE_BACK -.->|"validates loop-back<br/>condition"| MAX_ROUTE
    T_ROUTE_EXIT -.->|"validates exit<br/>condition"| MAX_ROUTE

    %% CLASS ASSIGNMENTS %%
    class START,DONE,FAIL terminal;
    class REVIEW_PR,CHECK_LOOP handler;
    class VERDICT_ROUTE,RESOLVE_ROUTE,MAX_ROUTE,RESOLVE_SKILL stateNode;
    class RESOLVE,REPUSH handler;
    class LOAD_MANIFEST,GEN_CARD phase;
    class WRITE_CARD output;
    class RULE_CTX phase;
    class PYTHON_CAPTURE,SKILL_CAPTURE detector;
    class FINDINGS output;
    class T_ROUTE_BACK,T_ROUTE_EXIT,T_NO_BLOCKING newComponent;
```

### Error/Resilience Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ENTRY %%
    LOAD([Recipe Load])

    subgraph LoadTimeGates ["LOAD-TIME VALIDATION GATES (Fail-Fast)"]
        direction TB
        VAL["● validator.py<br/>━━━━━━━━━━<br/>validate_recipe<br/>structural checks:<br/>routing targets, retries,<br/>capture expressions"]
        SEM["● rules_dataflow.py<br/>━━━━━━━━━━<br/>Semantic rules:<br/>dead-output ERROR<br/>implicit-handoff ERROR<br/>undeclared-capture-key WARN<br/>stale-ref-after-merge WARN<br/>uncaptured-handoff-consumer WARN"]
        CONTR["● contracts.py<br/>━━━━━━━━━━<br/>validate_recipe_cards<br/>contract-unsatisfied-input ERROR<br/>contract-unreferenced-required ERROR"]
        STALE["● contracts.py<br/>━━━━━━━━━━<br/>check_contract_staleness<br/>block_composition_drift<br/>version_mismatch<br/>hash_mismatch"]
        VALID{"compute_recipe<br/>_validity<br/>any ERROR?"}
    end

    subgraph ReviewLoop ["REVIEW LOOP (● recipes, ● smoke_utils)"]
        direction TB
        REV["review_pr<br/>━━━━━━━━━━<br/>run_skill: review-pr<br/>retries: 1"]
        CHKREV["● check_review_loop<br/>━━━━━━━━━━<br/>smoke_utils.py<br/>iteration budget guard<br/>max_iterations check"]
        REVDEC{"max_exceeded?"}
        RESOLVE_REV["resolve_review<br/>━━━━━━━━━━<br/>retries: 2<br/>on_exhausted:<br/>release_issue_failure"]
    end

    subgraph MergeRecovery ["MERGE FAILURE RECOVERY (● recipes)"]
        direction TB
        MERGE["● merge_worktree<br/>━━━━━━━━━━<br/>on_result verdict routing"]
        MERGEDEC{"failed_step?"}
        FIX["fix / assess<br/>━━━━━━━━━━<br/>resolve-failures skill"]
        FIXDEC{"verdict?"}
        TEST["test<br/>━━━━━━━━━━<br/>run_skill: test-check"]
    end

    subgraph CIRecovery ["CI FAILURE RECOVERY (● recipes)"]
        direction TB
        CIWATCH["ci_watch<br/>━━━━━━━━━━<br/>poll CI status"]
        DETECT["detect_ci_conflict<br/>━━━━━━━━━━<br/>stale-base check"]
        DETECTDEC{"conflict<br/>type?"}
        CIFIX["ci_conflict_fix<br/>━━━━━━━━━━<br/>rebase + resolve<br/>retries: 1"]
        DIAG["diagnose_ci<br/>━━━━━━━━━━<br/>on_failure: resolve_ci"]
        RESCI["resolve_ci<br/>━━━━━━━━━━<br/>retries: 2<br/>on_exhausted:<br/>release_issue_failure"]
        RESCIDEC{"verdict?"}
    end

    subgraph ConflictRecovery ["MERGE-QUEUE CONFLICT RECOVERY (● recipes)"]
        direction TB
        REBASE["pre_resolve_rebase<br/>━━━━━━━━━━<br/>retries: 1"]
        REBASEDEC{"clean?"}
        RESCONF["resolve_*_merge_conflicts<br/>━━━━━━━━━━<br/>retries: 1<br/>on_exhausted:<br/>release_issue_failure"]
        RESCONFDEC{"escalation<br/>required?"}
    end

    subgraph Terminals ["TERMINAL STATES"]
        T_DONE([done])
        T_ESCALATE([escalate_stop<br/>human intervention])
        T_RELEASE_F["release_issue_failure<br/>━━━━━━━━━━<br/>optional: true"]
        T_RELEASE_T["release_issue_timeout<br/>━━━━━━━━━━<br/>optional: true"]
        T_RELEASE_S["release_issue_success"]
        REG_FAIL["register_clone_failure"]
        REG_OK["register_clone_success"]
    end

    %% LOAD-TIME FLOW %%
    LOAD --> VAL
    VAL --> SEM
    SEM --> CONTR
    CONTR --> STALE
    STALE -->|"staleness warnings"| VALID
    VAL -->|"errors"| VALID
    SEM -->|"findings"| VALID
    CONTR -->|"findings"| VALID
    VALID -->|"ERROR found"| T_ESCALATE
    VALID -->|"clean / warnings only"| REV

    %% REVIEW LOOP FLOW %%
    REV -->|"on_success"| CHKREV
    REV -->|"on_failure"| T_RELEASE_F
    CHKREV --> REVDEC
    REVDEC -->|"false"| RESOLVE_REV
    RESOLVE_REV -->|"on_success"| REV
    RESOLVE_REV -->|"exhausted"| T_RELEASE_F
    REVDEC -->|"true: budget exceeded"| CIWATCH

    %% MERGE FAILURE FLOW %%
    MERGE --> MERGEDEC
    MERGEDEC -->|"dirty_tree / test_gate<br/>rebase"| FIX
    MERGEDEC -->|"result.error"| T_RELEASE_F
    MERGEDEC -->|"success"| T_RELEASE_S
    FIX --> FIXDEC
    FIXDEC -->|"real_fix / flake"| TEST
    FIXDEC -->|"ci_only_failure"| T_RELEASE_F
    TEST -->|"on_success"| MERGE
    TEST -->|"on_failure"| FIX

    %% CI RECOVERY FLOW %%
    CIWATCH -->|"failed"| DETECT
    CIWATCH -->|"passed"| T_RELEASE_S
    CIWATCH -->|"timeout"| T_RELEASE_T
    DETECT --> DETECTDEC
    DETECTDEC -->|"stale base"| CIFIX
    DETECTDEC -->|"code failure"| DIAG
    CIFIX -->|"on_success"| CIWATCH
    CIFIX -->|"exhausted"| T_RELEASE_F
    DIAG --> RESCI
    RESCI --> RESCIDEC
    RESCIDEC -->|"real_fix / flake"| CIWATCH
    RESCIDEC -->|"ci_only_failure"| T_RELEASE_F
    RESCI -->|"exhausted"| T_RELEASE_F

    %% CONFLICT RECOVERY FLOW %%
    REBASE --> REBASEDEC
    REBASEDEC -->|"clean"| CIWATCH
    REBASEDEC -->|"conflicts"| RESCONF
    RESCONF --> RESCONFDEC
    RESCONFDEC -->|"false"| CIWATCH
    RESCONFDEC -->|"true"| T_RELEASE_F
    RESCONF -->|"exhausted"| T_RELEASE_F

    %% TERMINAL CONVERGENCE %%
    T_RELEASE_F --> REG_FAIL
    T_RELEASE_T --> REG_FAIL
    T_RELEASE_S --> REG_OK
    REG_FAIL --> T_ESCALATE
    REG_OK --> T_DONE

    %% CLASS ASSIGNMENTS %%
    class LOAD,T_DONE,T_ESCALATE terminal;
    class VAL,SEM,CONTR,STALE,VALID detector;
    class REV,RESOLVE_REV,MERGE,FIX,TEST,CIWATCH,DETECT,DIAG,RESCI,CIFIX,REBASE,RESCONF handler;
    class CHKREV,REVDEC,MERGEDEC,FIXDEC,DETECTDEC,RESCIDEC,REBASEDEC,RESCONFDEC stateNode;
    class T_RELEASE_F,T_RELEASE_T,REG_FAIL gap;
    class T_RELEASE_S,REG_OK output;
```

### Scenarios Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph S1 ["SCENARIO 1: Review Loop — Iterations Remain"]
        direction LR
        S1_REVIEW["● review_pr<br/>━━━━━━━━━━<br/>changes_requested"]
        S1_RESOLVE["● resolve_review<br/>━━━━━━━━━━<br/>fix / assess"]
        S1_REPUSH["● re_push_review<br/>━━━━━━━━━━<br/>on_success"]
        S1_CHECK["● check_review_loop<br/>━━━━━━━━━━<br/>run_python callable"]
        S1_SMOKE["● smoke_utils<br/>━━━━━━━━━━<br/>check_review_loop()<br/>next_iteration, max_exceeded"]
        S1_ROUTE["● on_result routing<br/>━━━━━━━━━━<br/>max_exceeded == false<br/>→ back to review_pr"]
    end

    subgraph S2 ["SCENARIO 2: Review Loop — Max Exceeded"]
        direction LR
        S2_CHECK["● check_review_loop<br/>━━━━━━━━━━<br/>iteration == max"]
        S2_SMOKE["● smoke_utils<br/>━━━━━━━━━━<br/>max_exceeded = true"]
        S2_DEFAULT["● default route<br/>━━━━━━━━━━<br/>→ ci_watch"]
        S2_CI["ci_watch<br/>━━━━━━━━━━<br/>exit review loop"]
    end

    subgraph S3 ["SCENARIO 3: Blocking Finding — Early Termination"]
        direction LR
        S3_REVIEW["● review_pr<br/>━━━━━━━━━━<br/>changes_requested"]
        S3_RESOLVE["● resolve_review<br/>━━━━━━━━━━<br/>ci_only_failure verdict"]
        S3_RELEASE["release_issue_failure<br/>━━━━━━━━━━<br/>bypasses retry loop"]
        S3_END(["escalate_stop"])
    end

    subgraph S4 ["SCENARIO 4: Contract Card Generation"]
        direction LR
        S4_RECIPE["● recipe YAML<br/>━━━━━━━━━━<br/>reads step definitions"]
        S4_MANIFEST["● skill_contracts.yaml<br/>━━━━━━━━━━<br/>callable_contracts section<br/>check_review_loop outputs"]
        S4_CONTRACTS["● contracts.py<br/>━━━━━━━━━━<br/>generate_recipe_card()<br/>reads manifest + recipe"]
        S4_CARD["contract card<br/>━━━━━━━━━━<br/>dataflow: available,<br/>required, produced"]
    end

    subgraph S5 ["SCENARIO 5: Dataflow Rule — Undeclared Capture Key"]
        direction LR
        S5_RECIPE["● recipe YAML<br/>━━━━━━━━━━<br/>capture: result.X"]
        S5_MANIFEST["● skill_contracts.yaml<br/>━━━━━━━━━━<br/>callable_contracts<br/>declared outputs"]
        S5_RULE["● rules_dataflow.py<br/>━━━━━━━━━━<br/>undeclared-python-<br/>capture-key rule"]
        S5_FINDING["finding: WARNING<br/>━━━━━━━━━━<br/>has_blocking not<br/>in declared outputs"]
    end

    subgraph TESTS ["VALIDATION: Integration Tests"]
        direction LR
        T_NEW["★ test_review_loop_<br/>routing_integration.py<br/>━━━━━━━━━━<br/>3 parametrized tests<br/>x 3 recipes"]
        T_IMPL["● test_implementation.py<br/>━━━━━━━━━━<br/>T_IP_LOOP1–LOOP10"]
        T_GROUPS["● test_impl_groups_<br/>review_loop.py<br/>━━━━━━━━━━<br/>T_IG_LOOP1–LOOP3"]
        T_DATAFLOW["● test_rules_dataflow.py<br/>━━━━━━━━━━<br/>TestCallableContracts<br/>TestPythonCaptureOutput"]
    end

    %% SCENARIO 1 FLOW %%
    S1_REVIEW -->|"changes_requested"| S1_RESOLVE
    S1_RESOLVE -->|"fix/assess"| S1_REPUSH
    S1_REPUSH -->|"on_success"| S1_CHECK
    S1_CHECK -->|"invokes"| S1_SMOKE
    S1_SMOKE -->|"returns dict"| S1_ROUTE
    S1_ROUTE -.->|"loops back"| S1_REVIEW

    %% SCENARIO 2 FLOW %%
    S2_CHECK -->|"invokes"| S2_SMOKE
    S2_SMOKE -->|"max_exceeded=true"| S2_DEFAULT
    S2_DEFAULT -->|"falls through"| S2_CI

    %% SCENARIO 3 FLOW %%
    S3_REVIEW -->|"changes_requested"| S3_RESOLVE
    S3_RESOLVE -->|"ci_only_failure"| S3_RELEASE
    S3_RELEASE --> S3_END

    %% SCENARIO 4 FLOW %%
    S4_RECIPE -->|"parsed by"| S4_CONTRACTS
    S4_MANIFEST -->|"loaded by"| S4_CONTRACTS
    S4_CONTRACTS -->|"writes"| S4_CARD

    %% SCENARIO 5 FLOW %%
    S5_RECIPE -->|"capture refs"| S5_RULE
    S5_MANIFEST -->|"declared outputs"| S5_RULE
    S5_RULE -->|"emits"| S5_FINDING

    %% TEST VALIDATION LINKS %%
    T_NEW -.->|"validates S1,S2,S3"| S1_ROUTE
    T_IMPL -.->|"validates S1,S2"| S1_CHECK
    T_GROUPS -.->|"validates S1"| S1_ROUTE
    T_DATAFLOW -.->|"validates S5"| S5_RULE

    %% CLASS ASSIGNMENTS %%
    class S1_REVIEW,S1_RESOLVE,S1_REPUSH,S2_CI handler;
    class S1_CHECK,S2_CHECK phase;
    class S1_SMOKE,S2_SMOKE stateNode;
    class S1_ROUTE,S2_DEFAULT,S3_RESOLVE phase;
    class S3_REVIEW handler;
    class S3_RELEASE,S3_END detector;
    class S4_RECIPE,S5_RECIPE cli;
    class S4_MANIFEST,S5_MANIFEST stateNode;
    class S4_CONTRACTS,S5_RULE handler;
    class S4_CARD,S5_FINDING output;
    class T_NEW newComponent;
    class T_IMPL,T_GROUPS,T_DATAFLOW phase;
```

Closes #1096

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260421-172832-418686/.autoskillit/temp/rectify/rectify_check_review_loop_routing_2026-04-21_173600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| investigate | 2.4k | 9.6k | 877.2k | 64.5k | 1 | 6m 48s |
| rectify | 65 | 14.2k | 927.3k | 57.0k | 1 | 6m 22s |
| review | 4.2k | 5.8k | 163.8k | 30.9k | 1 | 3m 45s |
| dry_walkthrough | 58 | 14.0k | 1.6M | 61.1k | 1 | 6m 0s |
| implement | 112 | 29.7k | 5.8M | 104.1k | 1 | 11m 49s |
| assess | 81 | 12.6k | 2.6M | 68.3k | 1 | 14m 3s |
| prepare_pr | 24 | 5.2k | 167.0k | 28.6k | 1 | 1m 28s |
| run_arch_lenses | 6.1k | 17.4k | 562.4k | 88.0k | 3 | 9m 7s |
| compose_pr | 44 | 19.3k | 288.1k | 65.1k | 2 | 5m 36s |
| **Total** | 13.2k | 127.7k | 13.0M | 567.7k | | 1h 5m |