### PR TITLE
Update Check UX — Passive Notification for Dismissed Signals

### DIFF
--- a/src/autoskillit/cli/_update_checks.py
+++ b/src/autoskillit/cli/_update_checks.py
@@ -710,14 +710,11 @@ def run_update_checks(home: Path | None = None) -> None:
         if _is_dismissed(state, window=window, current_version=current, condition=s.kind)
     ]
 
-    # We have output to show: print status line now
-    from autoskillit.cli._timed_input import status_line
-
-    status_line("Checking for updates...")
-
     if undismissed:
         # Consolidated interactive prompt — behavior unchanged (REQ-FLOW-002)
-        from autoskillit.cli._timed_input import timed_prompt
+        from autoskillit.cli._timed_input import status_line, timed_prompt
+
+        status_line("Checking for updates...")
 
         _TIMEOUT_SENTINEL = "__timeout__"
         bullet_lines = "\n".join(f"  - {s.message}" for s in undismissed)

--- a/src/autoskillit/cli/_update_checks.py
+++ b/src/autoskillit/cli/_update_checks.py
@@ -684,12 +684,7 @@ def run_update_checks(home: Path | None = None) -> None:
     window = dismissal_window(info)
     state = _read_dismiss_state(_home)
 
-    # Pre-flight feedback: ensure the terminal is never silent during network I/O
-    from autoskillit.cli._timed_input import status_line
-
-    status_line("Checking for updates...")
-
-    # Gather signals
+    # Gather signals (network I/O happens here; status_line deferred until we know output exists)
     raw_signals: list[Signal | None] = [
         _binary_signal(info, _home, current),
         _hooks_signal(_claude_settings_path("user")),
@@ -697,49 +692,77 @@ def run_update_checks(home: Path | None = None) -> None:
         _dual_mcp_signal(_home),
     ]
 
-    # Filter by dismissal
-    firing_signals: list[Signal] = [
+    all_fired: list[Signal] = [s for s in raw_signals if s is not None]
+
+    # Zero signals: return silently — no "Checking for updates..." printed (REQ-UX-006)
+    if not all_fired:
+        return
+
+    # Partition into dismissed vs. non-dismissed (REQ-FLOW-001)
+    undismissed: list[Signal] = [
         s
-        for s in raw_signals
-        if s is not None
-        and not _is_dismissed(
-            state,
-            window=window,
-            current_version=current,
-            condition=s.kind,
-        )
+        for s in all_fired
+        if not _is_dismissed(state, window=window, current_version=current, condition=s.kind)
+    ]
+    dismissed: list[Signal] = [
+        s
+        for s in all_fired
+        if _is_dismissed(state, window=window, current_version=current, condition=s.kind)
     ]
 
-    if not firing_signals:
-        return
+    # We have output to show: print status line now
+    from autoskillit.cli._timed_input import status_line
 
-    # Consolidated prompt
-    from autoskillit.cli._timed_input import timed_prompt
+    status_line("Checking for updates...")
 
-    _TIMEOUT_SENTINEL = "__timeout__"
-    bullet_lines = "\n".join(f"  - {s.message}" for s in firing_signals)
-    prompt_text = f"\nAutoSkillit has updates available:\n{bullet_lines}\nUpdate now? [Y/n]"
-    answer = timed_prompt(prompt_text, default=_TIMEOUT_SENTINEL, timeout=30, label="update check")
+    if undismissed:
+        # Consolidated interactive prompt — behavior unchanged (REQ-FLOW-002)
+        from autoskillit.cli._timed_input import timed_prompt
 
-    # On timeout: proceed to app() without writing a dismissal record so the
-    # prompt reappears on the next invocation.
-    if answer == _TIMEOUT_SENTINEL:
-        return
+        _TIMEOUT_SENTINEL = "__timeout__"
+        bullet_lines = "\n".join(f"  - {s.message}" for s in undismissed)
+        prompt_text = f"\nAutoSkillit has updates available:\n{bullet_lines}\nUpdate now? [Y/n]"
+        answer = timed_prompt(
+            prompt_text, default=_TIMEOUT_SENTINEL, timeout=30, label="update check"
+        )
 
-    if answer.lower() in ("", "y", "yes"):
-        _run_update_sequence(info, current, _home, state, _skip_env)
-        return
+        # On timeout: proceed to app() without writing a dismissal record so the
+        # prompt reappears on the next invocation.
+        if answer == _TIMEOUT_SENTINEL:
+            return
 
-    # N path — write unified dismissal record
-    state["update_prompt"] = {
-        "dismissed_at": datetime.now(UTC).isoformat(),
-        "dismissed_version": current,
-        "conditions": [s.kind for s in firing_signals],
-    }
-    _write_dismiss_state(_home, state)
-    expiry = (datetime.now(UTC) + window).strftime("%Y-%m-%d")
-    print(
-        f"Dismissed until {expiry}. Run 'autoskillit update' to update sooner, "
-        f"or set AUTOSKILLIT_SKIP_STALE_CHECK=1 to silence.",
-        flush=True,
-    )
+        if answer.lower() in ("", "y", "yes"):
+            _run_update_sequence(info, current, _home, state, _skip_env)
+            return
+
+        # N path — write unified dismissal record
+        state["update_prompt"] = {
+            "dismissed_at": datetime.now(UTC).isoformat(),
+            "dismissed_version": current,
+            "conditions": [s.kind for s in undismissed],
+        }
+        _write_dismiss_state(_home, state)
+        expiry = (datetime.now(UTC) + window).strftime("%Y-%m-%d")
+        print(
+            f"Dismissed until {expiry}. Run 'autoskillit update' to update sooner, "
+            f"or set AUTOSKILLIT_SKIP_STALE_CHECK=1 to silence.",
+            flush=True,
+        )
+    else:
+        # All signals are dismissed — passive one-liner (REQ-UX-002 through REQ-UX-005)
+        entry = state.get("update_prompt")
+        try:
+            if isinstance(entry, dict):
+                dismissed_at_raw = entry.get("dismissed_at", "")
+                dismissed_at = datetime.fromisoformat(str(dismissed_at_raw))
+            else:
+                raise ValueError("no entry")
+            expiry = (dismissed_at + window).strftime("%Y-%m-%d")
+        except Exception:
+            expiry = (datetime.now(UTC) + window).strftime("%Y-%m-%d")
+        messages = "; ".join(s.message for s in dismissed)
+        print(
+            f"{messages}. Auto-prompt silenced until {expiry}. "
+            f"Run 'autoskillit update' to upgrade.",
+            flush=True,
+        )

--- a/src/autoskillit/cli/_update_checks.py
+++ b/src/autoskillit/cli/_update_checks.py
@@ -759,6 +759,7 @@ def run_update_checks(home: Path | None = None) -> None:
                 raise ValueError("no entry")
             expiry = (dismissed_at + window).strftime("%Y-%m-%d")
         except Exception:
+            logger.warning("Failed to parse dismissed_at for expiry calculation", exc_info=True)
             expiry = (datetime.now(UTC) + window).strftime("%Y-%m-%d")
         messages = "; ".join(s.message for s in dismissed)
         print(

--- a/tests/cli/test_update_checks.py
+++ b/tests/cli/test_update_checks.py
@@ -1508,7 +1508,10 @@ def test_dismissed_signal_prints_passive_notification(
     )
     run_update_checks(home=tmp_path)
     assert not input_calls, "Dismissed signal must not trigger interactive prompt"
-    assert any(printed), "Dismissed signal must produce passive notification output"
+    combined = " ".join(printed)
+    assert "autoskillit update" in combined, (
+        "Dismissed signal must produce passive notification containing 'autoskillit update'"
+    )
 
 
 def test_passive_notification_contains_version_info(
@@ -1529,11 +1532,13 @@ def test_passive_notification_contains_expiry_date(
 ) -> None:
     dismissed_ago = timedelta(hours=1)
     state = _dismissed_state(ago=dismissed_ago, conditions=["binary"])
+    # Derive expiry from state to avoid date-boundary races between setup and assertion
+    dismissed_at = datetime.fromisoformat(state["update_prompt"]["dismissed_at"])
     printed, _ = _setup_run_checks(monkeypatch, tmp_path, binary_signal=True, state=state)
     run_update_checks(home=tmp_path)
     combined = " ".join(printed)
-    # Stable install: 7-day window. Expiry ≈ now + ~7 days.
-    expected_expiry = (datetime.now(UTC) + timedelta(days=7) - dismissed_ago).strftime("%Y-%m-%d")
+    # Stable install: 7-day window.
+    expected_expiry = (dismissed_at + timedelta(days=7)).strftime("%Y-%m-%d")
     assert expected_expiry in combined, (
         f"Passive notification must include expiry date {expected_expiry!r}; got: {combined!r}"
     )
@@ -1580,4 +1585,7 @@ def test_all_dismissed_signals_produce_no_interactive_prompt(
     )
     run_update_checks(home=tmp_path)
     assert not input_calls, "All-dismissed signals must not trigger interactive prompt"
-    assert any(printed), "All-dismissed signals must still produce passive notification"
+    combined = " ".join(printed)
+    assert "autoskillit update" in combined, (
+        "All-dismissed signals must produce passive notification containing 'autoskillit update'"
+    )

--- a/tests/cli/test_update_checks.py
+++ b/tests/cli/test_update_checks.py
@@ -564,6 +564,7 @@ def test_no_prompt_when_no_conditions_fire(
     printed, input_calls = _setup_run_checks(monkeypatch, tmp_path)
     run_update_checks(home=tmp_path)
     assert not input_calls
+    assert not printed, f"No output expected when zero signals fire; got: {printed!r}"
 
 
 def test_single_prompt_when_only_binary_fires(
@@ -1265,92 +1266,6 @@ def test_timed_prompt_respects_no_color(monkeypatch: pytest.MonkeyPatch) -> None
 
 
 # ---------------------------------------------------------------------------
-# Pre-flight feedback ordering test
-# ---------------------------------------------------------------------------
-
-
-def test_run_update_checks_emits_status_before_network(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    """The first print() call in run_update_checks occurs before any signal
-    gatherer is invoked (the 'time to first output' structural test)."""
-    import select as _select_mod
-
-    from autoskillit.cli._update_checks import Signal
-
-    monkeypatch.delenv("CLAUDECODE", raising=False)
-    monkeypatch.delenv("CI", raising=False)
-    monkeypatch.delenv("AUTOSKILLIT_SKIP_STALE_CHECK", raising=False)
-    monkeypatch.delenv("AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK", raising=False)
-    monkeypatch.delenv("AUTOSKILLIT_FORCE_UPDATE_CHECK", raising=False)
-
-    fake_stdin = MagicMock()
-    fake_stdin.isatty.return_value = True
-    fake_stdout = MagicMock()
-    fake_stdout.isatty.return_value = True
-    monkeypatch.setattr(sys, "stdin", fake_stdin)
-    monkeypatch.setattr(sys, "stdout", fake_stdout)
-
-    monkeypatch.setattr(
-        _select_mod,
-        "select",
-        lambda rlist, wlist, xlist, timeout=None: (rlist, [], []),
-    )
-
-    info = _make_stable_info()
-    monkeypatch.setattr("autoskillit.cli._update_checks.detect_install", lambda: info)
-    monkeypatch.setattr(
-        "autoskillit.cli._update_checks._claude_settings_path",
-        lambda scope: tmp_path / "settings.json",
-    )
-
-    import autoskillit as _pkg
-
-    monkeypatch.setattr(_pkg, "__version__", "0.7.77")
-
-    # Track call order: print vs signal gatherers
-    call_log: list[str] = []
-
-    def tracking_print(*args: Any, **kw: Any) -> None:
-        call_log.append("print")
-
-    monkeypatch.setattr("builtins.print", tracking_print)
-
-    monkeypatch.setattr(
-        "autoskillit.cli._update_checks._binary_signal",
-        lambda info, home, current: (
-            call_log.append("binary_signal")
-            or Signal("binary", "New release: 0.9.0 (you have 0.7.77)")
-        ),
-    )
-    monkeypatch.setattr(
-        "autoskillit.cli._update_checks._hooks_signal",
-        lambda settings_path: call_log.append("hooks_signal"),
-    )
-    monkeypatch.setattr(
-        "autoskillit.cli._update_checks._source_drift_signal",
-        lambda info, home: call_log.append("source_drift_signal"),
-    )
-
-    monkeypatch.setattr("builtins.input", lambda _="": "n")
-
-    run_update_checks(home=tmp_path)
-
-    # The first print (status_line) must come before any signal gatherer
-    assert call_log[0] == "print", (
-        f"Expected first call to be print() (status_line), got: {call_log}"
-    )
-    signal_calls = [c for c in call_log if c.endswith("_signal")]
-    assert signal_calls, f"No signal gatherers were called — call_log: {call_log}"
-    first_signal_idx = call_log.index(signal_calls[0])
-    first_print_idx = call_log.index("print")
-    assert first_print_idx < first_signal_idx, (
-        f"print() must occur before signal gatherers. Order: {call_log}"
-    )
-
-
-# ---------------------------------------------------------------------------
 # AUTOSKILLIT_FORCE_UPDATE_CHECK override
 # ---------------------------------------------------------------------------
 
@@ -1577,3 +1492,92 @@ def test_fetch_fails_fast_offline(tmp_path: Path) -> None:
         result = _fetch_latest_version("releases/latest", tmp_path)
 
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# UC-10 Passive notification for dismissed signals (REQ-UX-002–006, REQ-FLOW-001–004)
+# ---------------------------------------------------------------------------
+
+
+def test_dismissed_signal_prints_passive_notification(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    state = _dismissed_state(ago=timedelta(hours=1), conditions=["binary"])
+    printed, input_calls = _setup_run_checks(
+        monkeypatch, tmp_path, binary_signal=True, state=state
+    )
+    run_update_checks(home=tmp_path)
+    assert not input_calls, "Dismissed signal must not trigger interactive prompt"
+    assert any(printed), "Dismissed signal must produce passive notification output"
+
+
+def test_passive_notification_contains_version_info(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    state = _dismissed_state(ago=timedelta(hours=1), conditions=["binary"])
+    printed, _ = _setup_run_checks(monkeypatch, tmp_path, binary_signal=True, state=state)
+    run_update_checks(home=tmp_path)
+    combined = " ".join(printed)
+    # The binary signal message is "New release: 0.9.0 (you have 0.7.77)"
+    assert "0.9.0" in combined or "0.7.77" in combined, (
+        "Passive notification must include version info"
+    )
+
+
+def test_passive_notification_contains_expiry_date(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    dismissed_ago = timedelta(hours=1)
+    state = _dismissed_state(ago=dismissed_ago, conditions=["binary"])
+    printed, _ = _setup_run_checks(monkeypatch, tmp_path, binary_signal=True, state=state)
+    run_update_checks(home=tmp_path)
+    combined = " ".join(printed)
+    # Stable install: 7-day window. Expiry ≈ now + ~7 days.
+    expected_expiry = (datetime.now(UTC) + timedelta(days=7) - dismissed_ago).strftime("%Y-%m-%d")
+    assert expected_expiry in combined, (
+        f"Passive notification must include expiry date {expected_expiry!r}; got: {combined!r}"
+    )
+
+
+def test_passive_notification_contains_update_command(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    state = _dismissed_state(ago=timedelta(hours=1), conditions=["binary"])
+    printed, _ = _setup_run_checks(monkeypatch, tmp_path, binary_signal=True, state=state)
+    run_update_checks(home=tmp_path)
+    combined = " ".join(printed)
+    assert "autoskillit update" in combined, (
+        "Passive notification must contain 'autoskillit update'"
+    )
+
+
+def test_undismissed_signal_still_gets_interactive_prompt_when_dismissed_also_present(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # binary is dismissed; hooks is NOT dismissed (not in conditions list)
+    state = _dismissed_state(ago=timedelta(hours=1), conditions=["binary"])
+    printed, input_calls = _setup_run_checks(
+        monkeypatch,
+        tmp_path,
+        binary_signal=True,
+        hooks_signal=True,
+        state=state,
+    )
+    run_update_checks(home=tmp_path)
+    assert len(input_calls) == 1, "Undismissed hooks signal must trigger interactive prompt"
+
+
+def test_all_dismissed_signals_produce_no_interactive_prompt(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    state = _dismissed_state(ago=timedelta(hours=1), conditions=["binary", "hooks"])
+    printed, input_calls = _setup_run_checks(
+        monkeypatch,
+        tmp_path,
+        binary_signal=True,
+        hooks_signal=True,
+        state=state,
+    )
+    run_update_checks(home=tmp_path)
+    assert not input_calls, "All-dismissed signals must not trigger interactive prompt"
+    assert any(printed), "All-dismissed signals must still produce passive notification"


### PR DESCRIPTION
## Summary

`run_update_checks()` currently prints `"Checking for updates..."` unconditionally before
gathering signals, then silently returns when all signals are dismissed — leaving the user
with a misleading status line and no follow-up. The fix introduces a two-phase partitioning
approach: gather signals first, then decide what to show. Three output paths emerge:

1. **No signals fired** → silent return (no status line printed)
2. **Only dismissed signals** → status line + passive one-liner (available version, expiry
   date, `autoskillit update` hint)
3. **Undismissed signals present** → status line + existing interactive `[Y/n]` prompt
   (behavior unchanged)

The only file changed is `src/autoskillit/cli/_update_checks.py`. The only test file
changed is `tests/cli/test_update_checks.py`.

## Requirements

### UX — Update notification during dismissal window

**REQ-UX-001:** The system must still perform network I/O to check for updates even when the interactive prompt is within its dismissal window.

**REQ-UX-002:** When update signals fire but are within the dismissal window, the system must display a non-interactive, informational one-liner instead of silently returning.

**REQ-UX-003:** The informational one-liner must include the available version and the currently installed version.

**REQ-UX-004:** The informational one-liner must state that the interactive update prompt has been silenced and show the dismissal expiry date.

**REQ-UX-005:** The informational one-liner must tell the user how to update manually (`autoskillit update`).

**REQ-UX-006:** The system must not print "Checking for updates..." when there are zero signals (no update available and no other conditions detected).

### FLOW — Signal partitioning

**REQ-FLOW-001:** After gathering all signals, the system must partition them into dismissed and non-dismissed sets.

**REQ-FLOW-002:** Non-dismissed signals must continue to trigger the existing interactive `Update now? [Y/n]` prompt with no behavior change.

**REQ-FLOW-003:** Dismissed signals must trigger the passive informational notification described in REQ-UX-002 through REQ-UX-005.

**REQ-FLOW-004:** If the network check fails (no connectivity, timeout, etc.), the system must print nothing — same silent-failure behavior as today.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START(["START<br/>run_update_checks()"])
    SILENT_RETURN(["RETURN SILENTLY<br/>no output"])
    COMPLETE(["RETURN<br/>caller proceeds to app()"])
    ERROR(["ERROR / ABORT"])

    subgraph Guards ["Phase 1 — Guard Checks (fail-open, short-circuit)"]
        direction TB
        G1{"env guard?<br/>━━━━━━━━━━<br/>CLAUDECODE / CI /<br/>SKIP_STALE_CHECK /<br/>SKIP_SOURCE_DRIFT"}
        G2{"stdin/stdout TTY?<br/>━━━━━━━━━━<br/>sys.stdin.isatty()<br/>sys.stdout.isatty()"}
        G3{"kitchen open?<br/>━━━━━━━━━━<br/>any_kitchen_open()"}
        G4{"install type?<br/>━━━━━━━━━━<br/>LOCAL_EDITABLE /<br/>LOCAL_PATH / UNKNOWN"}
    end

    subgraph Signals ["Phase 2 — Signal Gathering (network I/O; status_line deferred)"]
        direction LR
        SB["_binary_signal()<br/>━━━━━━━━━━<br/>fetch latest release<br/>compare versions"]
        SH["_hooks_signal()<br/>━━━━━━━━━━<br/>hook registry drift<br/>orphaned / missing"]
        SD["● _source_drift_signal()<br/>━━━━━━━━━━<br/>resolve ref SHA<br/>compare to commit_id"]
        SM["_dual_mcp_signal()<br/>━━━━━━━━━━<br/>both direct + plugin<br/>registrations active?"]
    end

    subgraph FetchPipeline ["Fetch Sub-flow (inside each signal)"]
        direction TB
        FC{"disk cache<br/>fresh?<br/>━━━━━━━━━━<br/>cached_at + TTL"}
        FH["httpx GET<br/>━━━━━━━━━━<br/>GitHub API<br/>ETag / If-None-Match"]
        FW["write cache<br/>━━━━━━━━━━<br/>github_fetch_cache.json<br/>(atomic_write)"]
        FC -->|"hit → return body"| FW
        FC -->|"miss / stale"| FH
        FH -->|"200 or 304"| FW
        FH -->|"error / timeout"| FERR["return None<br/>(fail-open)"]
    end

    subgraph Partition ["Phase 3 — Partition Signals + Deferred status_line"]
        direction TB
        PA{"any signals<br/>fired?<br/>━━━━━━━━━━<br/>all_fired is empty?"}
        PB["● print status_line<br/>━━━━━━━━━━<br/>'Checking for updates...'<br/>(deferred — only if output follows)"]
        PC{"undismissed<br/>signals?<br/>━━━━━━━━━━<br/>_is_dismissed() per signal<br/>time-window + version delta"}
    end

    subgraph InteractivePath ["Phase 4A — Interactive Prompt (undismissed signals present)"]
        direction TB
        IP["timed_prompt()<br/>━━━━━━━━━━<br/>consolidated bullet list<br/>timeout=30s"]
        IA{"answer?<br/>━━━━━━━━━━<br/>timeout / Y / N"}
        IY["_run_update_sequence()<br/>━━━━━━━━━━<br/>upgrade_command() → subprocess<br/>autoskillit install → verify"]
        IN["write dismissal record<br/>━━━━━━━━━━<br/>update_check.json<br/>dismissed_at + conditions"]
        IO["print expiry + escape hint<br/>━━━━━━━━━━<br/>'Dismissed until {date}'<br/>'autoskillit update'"]
    end

    subgraph PassivePath ["● Phase 4B — Passive Notification (all signals dismissed — NEW)"]
        direction TB
        PN["print passive one-liner<br/>━━━━━━━━━━<br/>signal messages + expiry date<br/>'autoskillit update' hint"]
    end

    %% TOP-LEVEL FLOW %%
    START --> G1
    G1 -->|"env set"| SILENT_RETURN
    G1 -->|"env clear"| G2
    G2 -->|"not TTY"| SILENT_RETURN
    G2 -->|"is TTY"| G3
    G3 -->|"kitchen open"| SILENT_RETURN
    G3 -->|"kitchen closed"| G4
    G4 -->|"local / unknown<br/>no FORCE flag"| SILENT_RETURN
    G4 -->|"GIT_VCS / FORCE flag"| Signals

    %% SIGNAL GATHER %%
    SB & SH & SD & SM -->|"Signal or None"| PA

    %% FETCH PIPELINE linkage %%
    SB -.->|"calls"| FC
    SD -.->|"calls"| FC

    %% PARTITION %%
    PA -->|"empty → REQ-UX-006<br/>no output at all"| SILENT_RETURN
    PA -->|"signals exist"| PB
    PB --> PC

    %% BRANCH %%
    PC -->|"undismissed ≥ 1"| IP
    PC -->|"all dismissed"| PN

    %% INTERACTIVE PATH %%
    IP --> IA
    IA -->|"timeout"| COMPLETE
    IA -->|"Y / yes"| IY
    IA -->|"N / no"| IN
    IY --> COMPLETE
    IN --> IO
    IO --> COMPLETE

    %% PASSIVE PATH %%
    PN --> COMPLETE

    %% ERROR EDGES %%
    FH -->|"exception"| FERR
    FERR --> PA

    %% CLASS ASSIGNMENTS %%
    class START,SILENT_RETURN,COMPLETE,ERROR terminal;
    class G1,G2,G3,G4 detector;
    class PA,PC,IA stateNode;
    class SB,SH,SD,SM handler;
    class FC,FH,FW,FERR phase;
    class PB,IP,IY,IN,IO,PN output;
```

### Operational Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    %% ENTRY %%
    ENTRY(["autoskillit &lt;cmd&gt;<br/>━━━━━━━━━━<br/>any non-serve invocation"])

    subgraph Guards ["GUARDS — skip if any true"]
        direction LR
        G1["CLAUDECODE=1<br/>(headless/MCP)"]
        G2["CI=1"]
        G3["AUTOSKILLIT_SKIP_STALE_CHECK=1<br/>or SKIP_SOURCE_DRIFT=1"]
        G4["non-TTY stdin/stdout"]
        G5["any_kitchen_open()"]
    end

    subgraph InstallClass ["INSTALL CLASSIFICATION"]
        direction TB
        DETECT["detect_install()<br/>━━━━━━━━━━<br/>reads direct_url.json<br/>→ InstallInfo"]
        ITYPE{"install_type?"}
        UNKNOWN_SKIP["LOCAL_EDITABLE / LOCAL_PATH<br/>/ UNKNOWN → silent return<br/>(unless FORCE_UPDATE_CHECK)"]
    end

    subgraph SignalGather ["● SIGNAL GATHERING (parallel)"]
        direction LR
        BS["_binary_signal()<br/>━━━━━━━━━━<br/>GitHub releases API<br/>version compare"]
        HS["_hooks_signal()<br/>━━━━━━━━━━<br/>hook registry drift<br/>orphaned/missing"]
        SS["_source_drift_signal()<br/>━━━━━━━━━━<br/>git ls-remote / GitHub<br/>SHA compare"]
        DS["_dual_mcp_signal()<br/>━━━━━━━━━━<br/>dual MCP registration<br/>check"]
    end

    subgraph DismissCheck ["● DISMISSAL PARTITION"]
        direction TB
        READSTATE["_read_dismiss_state()<br/>━━━━━━━━━━<br/>~/.autoskillit/update_check.json"]
        PARTITION{"partition signals<br/>undismissed vs dismissed"}
    end

    ZERO_OUT(["silent return<br/>━━━━━━━━━━<br/>REQ-UX-006: no output<br/>if zero signals"])

    subgraph UXBranch ["● UX BRANCH (new in this PR)"]
        direction TB
        STATUSLINE["● status_line()<br/>━━━━━━━━━━<br/>deferred: printed only<br/>when output exists<br/>'Checking for updates...'"]

        UNDISMISSED_PATH["undismissed signals exist<br/>━━━━━━━━━━<br/>consolidated prompt"]
        TIMEDPROMPT["timed_prompt()<br/>━━━━━━━━━━<br/>timeout=30s<br/>'Update now? [Y/n]'"]

        PASSIVE_PATH["● passive notification<br/>━━━━━━━━━━<br/>REQ-UX-002..005<br/>all signals dismissed<br/>→ one-liner + expiry date"]
    end

    subgraph UpdateSeq ["UPDATE SEQUENCE"]
        direction TB
        UPGRADERUN["upgrade_command()<br/>━━━━━━━━━━<br/>uv tool upgrade / pip -e"]
        INSTALLRUN["autoskillit install<br/>━━━━━━━━━━<br/>re-register hooks"]
        VERIFY["_verify_update_result()<br/>━━━━━━━━━━<br/>importlib.metadata check"]
    end

    subgraph DismissWrite ["DISMISS STATE WRITE"]
        direction TB
        WRITESTATE["_write_dismiss_state()<br/>━━━━━━━━━━<br/>atomic write<br/>dismissed_at + conditions"]
        SNOOZE["binary_snoozed record<br/>━━━━━━━━━━<br/>if update silently failed"]
    end

    subgraph ExternalAPIs ["EXTERNAL / CACHES"]
        direction TB
        GH_RELEASES["GitHub Releases API<br/>━━━━━━━━━━<br/>/releases/latest"]
        GH_PYPROJECT["GitHub Contents API<br/>━━━━━━━━━━<br/>integration/pyproject.toml"]
        GH_REFS["GitHub Git Refs API<br/>━━━━━━━━━━<br/>refs/heads/{rev}"]
        FETCHCACHE["~/.autoskillit/<br/>github_fetch_cache.json<br/>━━━━━━━━━━<br/>30-min TTL, ETag support"]
    end

    subgraph EnvConfig ["CONFIGURATION (read-only)"]
        direction TB
        ENV_SKIP["AUTOSKILLIT_SKIP_STALE_CHECK<br/>AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK<br/>AUTOSKILLIT_FORCE_UPDATE_CHECK"]
        ENV_GITHUB["GITHUB_TOKEN<br/>AUTOSKILLIT_FETCH_CACHE_TTL_SECONDS<br/>AUTOSKILLIT_SOURCE_REPO"]
    end

    %% FLOWS %%
    ENTRY --> Guards
    Guards -->|"all false"| InstallClass
    Guards -->|"any true"| ZERO_OUT

    DETECT --> ITYPE
    ITYPE -->|"tool/git install"| SignalGather
    ITYPE -->|"local/unknown"| UNKNOWN_SKIP

    BS & HS & SS & DS --> READSTATE
    READSTATE --> PARTITION

    PARTITION -->|"zero signals fired"| ZERO_OUT
    PARTITION -->|"signals exist"| STATUSLINE

    STATUSLINE --> UNDISMISSED_PATH
    STATUSLINE --> PASSIVE_PATH

    UNDISMISSED_PATH --> TIMEDPROMPT
    TIMEDPROMPT -->|"Y / timeout→Y"| UpdateSeq
    TIMEDPROMPT -->|"N"| WRITESTATE
    TIMEDPROMPT -->|"timeout"| ZERO_OUT

    UpdateSeq --> VERIFY
    VERIFY -->|"version unchanged"| SNOOZE

    PASSIVE_PATH -->|"prints one-liner"| ZERO_OUT

    BS --> GH_RELEASES
    BS --> GH_PYPROJECT
    SS --> GH_REFS
    GH_RELEASES & GH_PYPROJECT & GH_REFS --> FETCHCACHE

    ENV_SKIP --> Guards
    ENV_GITHUB --> SignalGather

    %% CLASS ASSIGNMENTS %%
    class ENTRY terminal;
    class G1,G2,G3,G4,G5 detector;
    class DETECT,ITYPE phase;
    class UNKNOWN_SKIP output;
    class BS,HS,SS,DS handler;
    class READSTATE,FETCHCACHE stateNode;
    class PARTITION phase;
    class STATUSLINE,TIMEDPROMPT,UNDISMISSED_PATH,PASSIVE_PATH cli;
    class UPGRADERUN,INSTALLRUN,VERIFY handler;
    class WRITESTATE,SNOOZE stateNode;
    class GH_RELEASES,GH_PYPROJECT,GH_REFS integration;
    class ENV_SKIP,ENV_GITHUB phase;
    class ZERO_OUT output;
```

Closes #1098

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260421-190838-689286/.autoskillit/temp/make-plan/update_check_ux_passive_notification_plan_2026-04-21_190838.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 115 | 15.9k | 663.3k | 80.9k | 1 | 5m 4s |
| verify | 198 | 14.8k | 1.3M | 132.5k | 1 | 4m 32s |
| implement | 262 | 12.0k | 1.6M | 51.2k | 1 | 3m 14s |
| fix | 134 | 3.8k | 550.2k | 32.5k | 1 | 2m 46s |
| prepare_pr | 52 | 4.1k | 153.5k | 25.3k | 1 | 1m 19s |
| run_arch_lenses | 114 | 9.8k | 425.4k | 90.4k | 2 | 3m 25s |
| compose_pr | 67 | 6.6k | 227.9k | 27.0k | 1 | 2m 4s |
| **Total** | 942 | 67.0k | 4.9M | 439.7k | | 22m 26s |