### PR TITLE
Implementation Plan: Route Non-Blocking Review Findings Through resolve_review Before Proceeding

### DIFF
--- a/src/autoskillit/recipes/contracts/implementation-groups.yaml
+++ b/src/autoskillit/recipes/contracts/implementation-groups.yaml
@@ -162,9 +162,10 @@ skills:
     - name: verdict
       type: string
     expected_output_patterns:
-    - verdict\s*=\s*(approved|changes_requested|needs_human)
+    - verdict\s*=\s*(approved|approved_with_comments|changes_requested|needs_human)
     pattern_examples:
     - 'verdict = approved'
+    - 'verdict = approved_with_comments'
     - 'verdict = changes_requested'
     - 'verdict = needs_human'
   resolve-review:

--- a/src/autoskillit/recipes/contracts/implementation.yaml
+++ b/src/autoskillit/recipes/contracts/implementation.yaml
@@ -146,9 +146,10 @@ skills:
     - name: verdict
       type: string
     expected_output_patterns:
-    - verdict\s*=\s*(approved|changes_requested|needs_human)
+    - verdict\s*=\s*(approved|approved_with_comments|changes_requested|needs_human)
     pattern_examples:
     - 'verdict = approved'
+    - 'verdict = approved_with_comments'
     - 'verdict = changes_requested'
     - 'verdict = needs_human'
   resolve-review:

--- a/src/autoskillit/recipes/contracts/remediation.yaml
+++ b/src/autoskillit/recipes/contracts/remediation.yaml
@@ -173,9 +173,10 @@ skills:
     - name: verdict
       type: string
     expected_output_patterns:
-    - verdict\s*=\s*(approved|changes_requested|needs_human)
+    - verdict\s*=\s*(approved|approved_with_comments|changes_requested|needs_human)
     pattern_examples:
     - 'verdict = approved'
+    - 'verdict = approved_with_comments'
     - 'verdict = changes_requested'
     - 'verdict = needs_human'
   resolve-review:

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -566,9 +566,11 @@ steps:
       cwd: "${{ context.work_dir }}"
       step_name: "review_pr"
     capture:
-      verdict: "${{ result.verdict }}"
+      review_verdict: "${{ result.verdict }}"
     on_result:
       - when: "${{ result.verdict }} == changes_requested"
+        route: resolve_review
+      - when: "${{ result.verdict }} == approved_with_comments"
         route: resolve_review
       - when: "${{ result.verdict }} == needs_human"
         route: ci_watch
@@ -584,9 +586,10 @@ steps:
       Runs after compose_pr creates the PR. Invokes the review-pr skill as a
       headless session to leave inline review comments on the PR. The skill finds
       the open PR by feature branch name (context.merge_target). Captures verdict
-      and routes via on_result: changes_requested → resolve_review,
-      needs_human → ci_watch (explicit), approved → ci_watch. On tool-level failure (MCP error, gh
-      unavailable), routes to resolve_review. Skipped when open_pr=false.
+      as review_verdict and routes via on_result: changes_requested/approved_with_comments
+      → resolve_review, needs_human → ci_watch (explicit), approved → ci_watch. On
+      tool-level failure (MCP error, gh unavailable), routes to resolve_review.
+      Skipped when open_pr=false.
 
   resolve_review:
     tool: run_skill
@@ -639,20 +642,22 @@ steps:
       cwd: "${{ context.work_dir }}"
       current_iteration: "${{ context.review_loop_count }}"
       max_iterations: "${{ inputs.review_max_retries }}"
+      previous_verdict: "${{ context.review_verdict }}"
     capture:
       review_loop_count: "${{ result.next_iteration }}"
     on_result:
-      - when: "${{ result.max_exceeded }} == false"
+      - when: "${{ result.had_blocking }} == true and ${{ result.max_exceeded }} == false"
         route: review_pr
       - route: ci_watch
     on_failure: ci_watch
     skip_when_false: "inputs.open_pr"
     optional_context_refs:
       - review_loop_count
+      - review_verdict
     note: >
-      Pure iteration guard. Routes back to review_pr if the iteration budget
-      (inputs.review_max_retries) is not exhausted; otherwise proceeds to
-      ci_watch.
+      Compound iteration + blocking guard. Routes back to review_pr only when the
+      previous verdict was changes_requested (had_blocking=true) AND the iteration
+      budget is not exhausted (max_exceeded=false); otherwise proceeds to ci_watch.
 
   ci_watch:
     tool: wait_for_ci

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -564,9 +564,11 @@ steps:
       cwd: "${{ context.work_dir }}"
       step_name: "review_pr"
     capture:
-      verdict: "${{ result.verdict }}"
+      review_verdict: "${{ result.verdict }}"
     on_result:
       - when: "${{ result.verdict }} == changes_requested"
+        route: resolve_review
+      - when: "${{ result.verdict }} == approved_with_comments"
         route: resolve_review
       - when: "${{ result.verdict }} == needs_human"
         route: ci_watch
@@ -582,9 +584,10 @@ steps:
       Runs after compose_pr creates the PR. Invokes the review-pr skill as a
       headless session to leave inline review comments on the PR. The skill finds
       the open PR by feature branch name (context.merge_target). Captures verdict
-      and routes via on_result: changes_requested → resolve_review,
-      needs_human → ci_watch (explicit), approved → ci_watch. On tool-level failure (MCP error, gh
-      unavailable), routes to resolve_review. Skipped when open_pr=false.
+      as review_verdict and routes via on_result: changes_requested/approved_with_comments
+      → resolve_review, needs_human → ci_watch (explicit), approved → ci_watch. On
+      tool-level failure (MCP error, gh unavailable), routes to resolve_review.
+      Skipped when open_pr=false.
 
   resolve_review:
     tool: run_skill
@@ -637,20 +640,22 @@ steps:
       cwd: "${{ context.work_dir }}"
       current_iteration: "${{ context.review_loop_count }}"
       max_iterations: "${{ inputs.review_max_retries }}"
+      previous_verdict: "${{ context.review_verdict }}"
     capture:
       review_loop_count: "${{ result.next_iteration }}"
     on_result:
-      - when: "${{ result.max_exceeded }} == false"
+      - when: "${{ result.had_blocking }} == true and ${{ result.max_exceeded }} == false"
         route: review_pr
       - route: ci_watch
     on_failure: ci_watch
     skip_when_false: "inputs.open_pr"
     optional_context_refs:
       - review_loop_count
+      - review_verdict
     note: >
-      Pure iteration guard. Routes back to review_pr if the iteration budget
-      (inputs.review_max_retries) is not exhausted; otherwise proceeds to
-      ci_watch.
+      Compound iteration + blocking guard. Routes back to review_pr only when the
+      previous verdict was changes_requested (had_blocking=true) AND the iteration
+      budget is not exhausted (max_exceeded=false); otherwise proceeds to ci_watch.
 
   ci_watch:
     tool: wait_for_ci

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -542,9 +542,11 @@ steps:
       cwd: "${{ context.work_dir }}"
       step_name: "review_pr"
     capture:
-      verdict: "${{ result.verdict }}"
+      review_verdict: "${{ result.verdict }}"
     on_result:
       - when: "${{ result.verdict }} == changes_requested"
+        route: resolve_review
+      - when: "${{ result.verdict }} == approved_with_comments"
         route: resolve_review
       - when: "${{ result.verdict }} == needs_human"
         route: ci_watch
@@ -560,9 +562,10 @@ steps:
       Runs after compose_pr creates the PR. Invokes the review-pr skill as a
       headless session to leave inline review comments on the PR. The skill finds
       the open PR by feature branch name (context.merge_target). Captures verdict
-      and routes via on_result: changes_requested → resolve_review,
-      needs_human → ci_watch (explicit), approved → ci_watch. On tool-level failure (MCP error, gh
-      unavailable), routes to resolve_review. Skipped when open_pr=false.
+      as review_verdict and routes via on_result: changes_requested/approved_with_comments
+      → resolve_review, needs_human → ci_watch (explicit), approved → ci_watch. On
+      tool-level failure (MCP error, gh unavailable), routes to resolve_review.
+      Skipped when open_pr=false.
 
   resolve_review:
     tool: run_skill
@@ -615,20 +618,22 @@ steps:
       cwd: "${{ context.work_dir }}"
       current_iteration: "${{ context.review_loop_count }}"
       max_iterations: "${{ inputs.review_max_retries }}"
+      previous_verdict: "${{ context.review_verdict }}"
     capture:
       review_loop_count: "${{ result.next_iteration }}"
     on_result:
-      - when: "${{ result.max_exceeded }} == false"
+      - when: "${{ result.had_blocking }} == true and ${{ result.max_exceeded }} == false"
         route: review_pr
       - route: ci_watch
     on_failure: ci_watch
     skip_when_false: "inputs.open_pr"
     optional_context_refs:
       - review_loop_count
+      - review_verdict
     note: >
-      Pure iteration guard. Routes back to review_pr if the iteration budget
-      (inputs.review_max_retries) is not exhausted; otherwise proceeds to
-      ci_watch.
+      Compound iteration + blocking guard. Routes back to review_pr only when the
+      previous verdict was changes_requested (had_blocking=true) AND the iteration
+      budget is not exhausted (max_exceeded=false); otherwise proceeds to ci_watch.
 
   ci_watch:
     tool: wait_for_ci

--- a/src/autoskillit/skills_extended/review-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/review-pr/SKILL.md
@@ -381,20 +381,27 @@ This is not optional. Do not proceed to Step 5 without stating this.
 
 ### Step 5: Determine Verdict
 
-- Any `actionable_findings` present → `verdict = "changes_requested"` (clear fix exists, automated resolver handles it)
-- No actionable findings, but `decision_findings` present → `verdict = "needs_human"` (`needs_human` fires only when one or more findings have `requires_decision=true` — meaning the correct path forward requires a human decision that the automated reviewer cannot make)
-- No actionable or decision findings → `verdict = "approved"`
+- Any `blocking_findings` (critical severity, non-decision) present → `verdict = "changes_requested"` (clear fix exists, automated resolver handles it)
+- No blocking findings, but `warning_findings` (warning severity, non-decision) present → `verdict = "approved_with_comments"` (recipe routes to `resolve_review` but does not require a re-review cycle)
+- No blocking or warning findings, but `decision_findings` present → `verdict = "needs_human"` (`needs_human` fires only when one or more findings have `requires_decision=true` — meaning the correct path forward requires a human decision that the automated reviewer cannot make)
+- No findings of any kind → `verdict = "approved"`
 
 **Verdict logic:**
 ```python
 decision_findings = [f for f in all_findings if f.get("requires_decision")]
-actionable_findings = [
+blocking_findings = [
     f for f in all_findings
-    if not f.get("requires_decision") and f["severity"] in ("critical", "warning")
+    if not f.get("requires_decision") and f["severity"] == "critical"
+]
+warning_findings = [
+    f for f in all_findings
+    if not f.get("requires_decision") and f["severity"] == "warning"
 ]
 
-if actionable_findings:
+if blocking_findings:
     verdict = "changes_requested"
+elif warning_findings:
+    verdict = "approved_with_comments"
 elif decision_findings:
     verdict = "needs_human"
 else:
@@ -442,6 +449,7 @@ gh api /repos/{owner}/{repo}/pulls/{pr_number}/reviews \
 
 Event mapping:
 - `approved` → `APPROVE`
+- `approved_with_comments` → `COMMENT`
 - `needs_human` → `COMMENT`
 - `changes_requested` → `REQUEST_CHANGES`
 
@@ -516,6 +524,9 @@ Never reference local file paths (e.g., `{{AUTOSKILLIT_TEMP}}/...`, `summary_*.m
 # approved
 gh pr review {pr_number} --approve --body "AutoSkillit review passed. No blocking issues found."
 
+# approved_with_comments
+gh pr review {pr_number} --comment --body "AutoSkillit review: warning-only findings detected. See inline comments — no blocking changes required."
+
 # changes_requested
 gh pr review {pr_number} --request-changes --body "AutoSkillit review found {N} blocking issues. See inline comments."
 
@@ -537,7 +548,7 @@ Output the verdict as the final line:
 > exact token name — decorators cause match failure.
 
 ```
-verdict = {approved|changes_requested|needs_human}
+verdict = {approved|approved_with_comments|changes_requested|needs_human}
 ```
 
 Exit 0 in all normal cases (approved, needs_human, changes_requested).
@@ -546,6 +557,7 @@ Exit 1 only for unrecoverable tool-level errors.
 ## Output
 
 - `verdict=approved` — No blocking issues; CI can proceed
+- `verdict=approved_with_comments` — Warning-only findings; recipe routes to `resolve_review` but does not require a re-review cycle
 - `verdict=changes_requested` — Blocking issues found; recipe routes to `resolve_review`
 - `verdict=needs_human` — Uncertain trade-offs; human review requested via the authenticated GitHub user mention (derived at runtime)
 

--- a/src/autoskillit/smoke_utils.py
+++ b/src/autoskillit/smoke_utils.py
@@ -102,6 +102,10 @@ def check_review_loop(
 
     Returns next_iteration, max_exceeded, and had_blocking to determine
     whether to re-review (blocking + iterations remain) or proceed to ci_watch.
+
+    ``had_blocking`` is true only when ``previous_verdict == "changes_requested"``.
+    ``approved_with_comments`` intentionally yields ``had_blocking=false`` — the
+    resolve_review pass is one-shot and does not trigger a re-review cycle.
     """
     iteration = int(current_iteration.strip()) if current_iteration.strip() else 0
     next_iteration = iteration + 1

--- a/src/autoskillit/smoke_utils.py
+++ b/src/autoskillit/smoke_utils.py
@@ -96,11 +96,12 @@ def check_review_loop(
     cwd: str,
     current_iteration: str = "",
     max_iterations: str = "3",
+    previous_verdict: str = "",
 ) -> dict[str, str]:
     """Pure iteration guard for the review-resolve loop.
 
-    Returns next_iteration and max_exceeded to determine whether
-    to re-review (iterate) or proceed to ci_watch (budget exhausted).
+    Returns next_iteration, max_exceeded, and had_blocking to determine
+    whether to re-review (blocking + iterations remain) or proceed to ci_watch.
     """
     iteration = int(current_iteration.strip()) if current_iteration.strip() else 0
     next_iteration = iteration + 1
@@ -109,6 +110,7 @@ def check_review_loop(
     return {
         "next_iteration": str(next_iteration),
         "max_exceeded": "true" if next_iteration >= max_iter else "false",
+        "had_blocking": "true" if previous_verdict.strip() == "changes_requested" else "false",
     }
 
 

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -152,7 +152,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # smoke_utils.py — domain partitions dict, hunk ranges list, merge queue list
     ("src/autoskillit/smoke_utils.py", 57),
     ("src/autoskillit/smoke_utils.py", 87),
-    ("src/autoskillit/smoke_utils.py", 165),
+    ("src/autoskillit/smoke_utils.py", 169),
 }
 
 
@@ -214,7 +214,7 @@ class TestSchemaVersionConvention:
         # These sites write list payloads through function calls but are caught by the scanner
         list_sites = [
             ("src/autoskillit/smoke_utils.py", 87),
-            ("src/autoskillit/smoke_utils.py", 165),
+            ("src/autoskillit/smoke_utils.py", 169),
         ]
         for site in list_sites:
             assert site in _LEGACY_JSON_WRITES, (

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -152,7 +152,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # smoke_utils.py — domain partitions dict, hunk ranges list, merge queue list
     ("src/autoskillit/smoke_utils.py", 57),
     ("src/autoskillit/smoke_utils.py", 87),
-    ("src/autoskillit/smoke_utils.py", 163),
+    ("src/autoskillit/smoke_utils.py", 165),
 }
 
 
@@ -214,7 +214,7 @@ class TestSchemaVersionConvention:
         # These sites write list payloads through function calls but are caught by the scanner
         list_sites = [
             ("src/autoskillit/smoke_utils.py", 87),
-            ("src/autoskillit/smoke_utils.py", 163),
+            ("src/autoskillit/smoke_utils.py", 165),
         ]
         for site in list_sites:
             assert site in _LEGACY_JSON_WRITES, (

--- a/tests/recipe/test_bundled_recipes.py
+++ b/tests/recipe/test_bundled_recipes.py
@@ -1245,10 +1245,10 @@ class TestReviewPrRecipeIntegration:
         assert any(c.route == "ci_watch" for c in default_conditions)
 
     def test_review_pr_captures_verdict(self, recipe: object) -> None:
-        """T_RP4b: review_pr captures the verdict output from the skill result."""
+        """T_RP4b: review_pr captures the verdict output as review_verdict to avoid clobber."""
         step = recipe.steps["review_pr"]  # type: ignore[attr-defined]
-        assert "verdict" in step.capture
-        assert step.capture["verdict"] == "${{ result.verdict }}"
+        assert "review_verdict" in step.capture
+        assert step.capture["review_verdict"] == "${{ result.verdict }}"
 
     def test_review_pr_changes_requested_routes_to_resolve_review(self, recipe: object) -> None:
         """T_RP4c: on_result routes changes_requested verdict to resolve_review."""

--- a/tests/recipe/test_implementation.py
+++ b/tests/recipe/test_implementation.py
@@ -38,16 +38,20 @@ def test_check_review_loop_has_skip_when_false_open_pr(recipe) -> None:
 
 
 # T_IP_LOOP4
-def test_check_review_loop_on_result_routes_to_review_pr_when_max_not_exceeded(recipe) -> None:
-    """check_review_loop on_result routes to review_pr when max_exceeded=false."""
+def test_check_review_loop_on_result_routes_to_review_pr_when_had_blocking_and_not_max_exceeded(
+    recipe,
+) -> None:
+    """check_review_loop on_result routes to review_pr only when
+    had_blocking=true AND max_exceeded=false."""
     step = recipe.steps["check_review_loop"]
     assert step.on_result is not None
     review_conditions = [
         c for c in step.on_result.conditions if c.when is not None and c.route == "review_pr"
     ]
     assert review_conditions, "No conditional route to review_pr found"
-    assert "max_exceeded" in review_conditions[0].when
-    assert "has_blocking" not in review_conditions[0].when
+    cond = review_conditions[0].when
+    assert "had_blocking" in cond
+    assert "max_exceeded" in cond
 
 
 # T_IP_LOOP5

--- a/tests/recipe/test_implementation.py
+++ b/tests/recipe/test_implementation.py
@@ -97,3 +97,34 @@ def test_check_review_loop_captures_review_loop_count(recipe) -> None:
     capture = step.capture or {}
     assert "review_loop_count" in capture
     assert "next_iteration" in capture["review_loop_count"]
+
+
+# T_IP_LOOP11
+def test_review_pr_routes_approved_with_comments_to_resolve_review(recipe) -> None:
+    """review_pr on_result must route approved_with_comments to resolve_review."""
+    step = recipe.steps["review_pr"]
+    assert step.on_result is not None
+    routes = {c.when: c.route for c in step.on_result.conditions if c.when}
+    matching = [
+        when
+        for when, route in routes.items()
+        if "approved_with_comments" in when and route == "resolve_review"
+    ]
+    assert matching, "No approved_with_comments → resolve_review route found"
+
+
+# T_IP_LOOP12
+def test_review_pr_captures_review_verdict(recipe) -> None:
+    """review_pr must capture verdict as review_verdict (not verdict) to avoid clobber."""
+    step = recipe.steps["review_pr"]
+    capture = step.capture or {}
+    assert "review_verdict" in capture
+    assert "result.verdict" in capture["review_verdict"]
+
+
+# T_IP_LOOP13
+def test_check_review_loop_with_args_has_previous_verdict(recipe) -> None:
+    """check_review_loop with: must pass previous_verdict from context.review_verdict."""
+    step = recipe.steps["check_review_loop"]
+    assert "previous_verdict" in step.with_args
+    assert "review_verdict" in step.with_args["previous_verdict"]

--- a/tests/recipe/test_implementation_groups_review_loop.py
+++ b/tests/recipe/test_implementation_groups_review_loop.py
@@ -51,3 +51,34 @@ def test_check_review_loop_has_on_failure(recipe) -> None:
     (on-result-missing-failure-route semantic rule requires it)."""
     step = recipe.steps["check_review_loop"]
     assert step.on_failure == "ci_watch"
+
+
+# T_IG_LOOP5
+def test_review_pr_routes_approved_with_comments_to_resolve_review(recipe) -> None:
+    """review_pr on_result must route approved_with_comments to resolve_review."""
+    step = recipe.steps["review_pr"]
+    assert step.on_result is not None
+    routes = {c.when: c.route for c in step.on_result.conditions if c.when}
+    matching = [
+        when
+        for when, route in routes.items()
+        if "approved_with_comments" in when and route == "resolve_review"
+    ]
+    assert matching, "No approved_with_comments → resolve_review route found"
+
+
+# T_IG_LOOP6
+def test_review_pr_captures_review_verdict(recipe) -> None:
+    """review_pr must capture verdict as review_verdict (not verdict) to avoid clobber."""
+    step = recipe.steps["review_pr"]
+    capture = step.capture or {}
+    assert "review_verdict" in capture
+    assert "result.verdict" in capture["review_verdict"]
+
+
+# T_IG_LOOP7
+def test_check_review_loop_with_args_has_previous_verdict(recipe) -> None:
+    """check_review_loop with: must pass previous_verdict from context.review_verdict."""
+    step = recipe.steps["check_review_loop"]
+    assert "previous_verdict" in step.with_args
+    assert "review_verdict" in step.with_args["previous_verdict"]

--- a/tests/recipe/test_implementation_groups_review_loop.py
+++ b/tests/recipe/test_implementation_groups_review_loop.py
@@ -32,17 +32,19 @@ def test_re_push_review_routes_to_check_review_loop(recipe) -> None:
 
 
 # T_IG_LOOP3
-def test_check_review_loop_routes_on_max_exceeded_only(recipe) -> None:
-    """check_review_loop on_result condition must route on max_exceeded alone,
-    NOT on has_blocking."""
+def test_check_review_loop_on_result_routes_to_review_pr_when_had_blocking_and_not_max_exceeded(
+    recipe,
+) -> None:
+    """check_review_loop on_result condition must gate on had_blocking AND max_exceeded."""
     step = recipe.steps["check_review_loop"]
     assert step.on_result is not None
     review_conditions = [
         c for c in step.on_result.conditions if c.when is not None and c.route == "review_pr"
     ]
     assert review_conditions, "No conditional route to review_pr found"
-    assert "max_exceeded" in review_conditions[0].when
-    assert "has_blocking" not in review_conditions[0].when
+    cond = review_conditions[0].when
+    assert "had_blocking" in cond
+    assert "max_exceeded" in cond
 
 
 # T_IG_LOOP4

--- a/tests/recipe/test_remediation_recipe.py
+++ b/tests/recipe/test_remediation_recipe.py
@@ -67,3 +67,34 @@ def test_check_review_loop_has_on_failure(recipe) -> None:
     (on-result-missing-failure-route semantic rule requires it)."""
     step = recipe.steps["check_review_loop"]
     assert step.on_failure == "ci_watch"
+
+
+# T_REM_LOOP5
+def test_review_pr_routes_approved_with_comments_to_resolve_review(recipe) -> None:
+    """review_pr on_result must route approved_with_comments to resolve_review."""
+    step = recipe.steps["review_pr"]
+    assert step.on_result is not None
+    routes = {c.when: c.route for c in step.on_result.conditions if c.when}
+    matching = [
+        when
+        for when, route in routes.items()
+        if "approved_with_comments" in when and route == "resolve_review"
+    ]
+    assert matching, "No approved_with_comments → resolve_review route found"
+
+
+# T_REM_LOOP6
+def test_review_pr_captures_review_verdict(recipe) -> None:
+    """review_pr must capture verdict as review_verdict (not verdict) to avoid clobber."""
+    step = recipe.steps["review_pr"]
+    capture = step.capture or {}
+    assert "review_verdict" in capture
+    assert "result.verdict" in capture["review_verdict"]
+
+
+# T_REM_LOOP7
+def test_check_review_loop_with_args_has_previous_verdict(recipe) -> None:
+    """check_review_loop with: must pass previous_verdict from context.review_verdict."""
+    step = recipe.steps["check_review_loop"]
+    assert "previous_verdict" in step.with_args
+    assert "review_verdict" in step.with_args["previous_verdict"]

--- a/tests/recipe/test_remediation_recipe.py
+++ b/tests/recipe/test_remediation_recipe.py
@@ -48,17 +48,19 @@ def test_re_push_review_routes_to_check_review_loop(recipe) -> None:
 
 
 # T_REM_LOOP3
-def test_check_review_loop_routes_on_max_exceeded_only(recipe) -> None:
-    """check_review_loop on_result condition must route on max_exceeded alone,
-    NOT on has_blocking."""
+def test_check_review_loop_on_result_routes_to_review_pr_when_had_blocking_and_not_max_exceeded(
+    recipe,
+) -> None:
+    """check_review_loop on_result condition must gate on had_blocking AND max_exceeded."""
     step = recipe.steps["check_review_loop"]
     assert step.on_result is not None
     review_conditions = [
         c for c in step.on_result.conditions if c.when is not None and c.route == "review_pr"
     ]
     assert review_conditions, "No conditional route to review_pr found"
-    assert "max_exceeded" in review_conditions[0].when
-    assert "has_blocking" not in review_conditions[0].when
+    cond = review_conditions[0].when
+    assert "had_blocking" in cond
+    assert "max_exceeded" in cond
 
 
 # T_REM_LOOP4

--- a/tests/recipe/test_review_loop_routing_integration.py
+++ b/tests/recipe/test_review_loop_routing_integration.py
@@ -74,13 +74,75 @@ def test_review_loop_routes_to_ci_watch_at_max_iterations(recipe_name: str) -> N
 
 
 @pytest.mark.parametrize("recipe_name", RECIPE_NAMES)
-def test_check_review_loop_routes_on_max_exceeded_only(recipe_name: str) -> None:
-    """The check_review_loop on_result condition must route on max_exceeded alone,
-    NOT on has_blocking."""
+def test_check_review_loop_review_pr_route_uses_had_blocking_and_max_exceeded(
+    recipe_name: str,
+) -> None:
+    """The check_review_loop on_result condition for review_pr must gate on
+    had_blocking AND max_exceeded."""
     recipe = load_recipe(builtin_recipes_dir() / recipe_name)
     step = recipe.steps["check_review_loop"]
     assert step.on_result is not None
+    review_condition = next(c for c in step.on_result.conditions if c.route == "review_pr")
+    assert "had_blocking" in review_condition.when
+    assert "max_exceeded" in review_condition.when
+
+
+def _eval_compound_condition(when_expr: str) -> bool:
+    """Evaluate a compound condition like 'true == true and false == false'.
+
+    Splits on ' and ', evaluates each 'lhs == rhs' pair, ANDs results.
+    """
+    parts = when_expr.split(" and ")
+    results = []
+    for part in parts:
+        lhs, rhs = [s.strip() for s in part.split("==", 1)]
+        results.append(lhs == rhs)
+    return all(results)
+
+
+@pytest.mark.parametrize("recipe_name", RECIPE_NAMES)
+def test_review_loop_routes_to_ci_watch_when_no_blocking(recipe_name: str) -> None:
+    """When had_blocking=false, routing proceeds to ci_watch regardless of iteration count."""
+    result = check_review_loop(
+        pr_number="42",
+        cwd="/tmp",
+        current_iteration="0",
+        max_iterations="3",
+        previous_verdict="approved_with_comments",
+    )
+    assert result["had_blocking"] == "false"
+    assert result["max_exceeded"] == "false"
+    recipe = load_recipe(builtin_recipes_dir() / recipe_name)
+    step = recipe.steps["check_review_loop"]
     conditions = step.on_result.conditions
     review_condition = next(c for c in conditions if c.route == "review_pr")
-    assert "max_exceeded" in review_condition.when
-    assert "has_blocking" not in review_condition.when
+    when_expr = review_condition.when
+    for key, value in result.items():
+        when_expr = when_expr.replace(f"${{{{ result.{key} }}}}", value)
+    # Compound condition "false == true and false == false" must evaluate to False
+    assert not _eval_compound_condition(when_expr)
+
+
+@pytest.mark.parametrize("recipe_name", RECIPE_NAMES)
+def test_review_loop_routes_to_review_pr_when_had_blocking_and_not_max_exceeded(
+    recipe_name: str,
+) -> None:
+    """When had_blocking=true and max_exceeded=false, routing goes back to review_pr."""
+    result = check_review_loop(
+        pr_number="42",
+        cwd="/tmp",
+        current_iteration="0",
+        max_iterations="3",
+        previous_verdict="changes_requested",
+    )
+    assert result["had_blocking"] == "true"
+    assert result["max_exceeded"] == "false"
+    recipe = load_recipe(builtin_recipes_dir() / recipe_name)
+    step = recipe.steps["check_review_loop"]
+    conditions = step.on_result.conditions
+    review_condition = next(c for c in conditions if c.route == "review_pr")
+    when_expr = review_condition.when
+    for key, value in result.items():
+        when_expr = when_expr.replace(f"${{{{ result.{key} }}}}", value)
+    # "true == true and false == false" must evaluate to True
+    assert _eval_compound_condition(when_expr)

--- a/tests/recipe/test_review_loop_routing_integration.py
+++ b/tests/recipe/test_review_loop_routing_integration.py
@@ -16,17 +16,18 @@ RECIPE_NAMES = ["implementation.yaml", "remediation.yaml", "implementation-group
 def test_review_loop_routes_to_review_pr_after_resolve_cycle(recipe_name: str) -> None:
     """End-to-end routing test: after resolve_review -> re_push_review,
     check_review_loop must route to review_pr (not ci_watch) when
-    iterations remain.
+    previous verdict was changes_requested and iterations remain.
 
     This test calls the actual check_review_loop callable with
-    current_iteration=0 and max_iterations=3, then evaluates the
-    recipe's on_result conditions against the callable's return value.
+    previous_verdict=changes_requested, current_iteration=0 and max_iterations=3,
+    then evaluates the recipe's on_result conditions against the callable's return value.
     """
     result = check_review_loop(
         pr_number="42",
         cwd="/tmp",
         current_iteration="0",
         max_iterations="3",
+        previous_verdict="changes_requested",
     )
 
     recipe = load_recipe(builtin_recipes_dir() / recipe_name)
@@ -40,9 +41,8 @@ def test_review_loop_routes_to_review_pr_after_resolve_cycle(recipe_name: str) -
         when_expr = when_expr.replace(f"${{{{ result.{key} }}}}", value)
 
     # The first condition (route to review_pr) must be satisfiable
-    # when_expr becomes e.g. "false == false" — evaluate as string equality
-    lhs, rhs = [s.strip() for s in when_expr.split("==", 1)]
-    assert lhs == rhs
+    # when_expr becomes "true == true and false == false" — evaluate compound
+    assert _eval_compound_condition(when_expr)
     assert conditions[0].route == "review_pr"
 
 
@@ -54,6 +54,7 @@ def test_review_loop_routes_to_ci_watch_at_max_iterations(recipe_name: str) -> N
         cwd="/tmp",
         current_iteration="2",
         max_iterations="3",
+        previous_verdict="changes_requested",
     )
 
     recipe = load_recipe(builtin_recipes_dir() / recipe_name)
@@ -67,9 +68,8 @@ def test_review_loop_routes_to_ci_watch_at_max_iterations(recipe_name: str) -> N
         when_expr = when_expr.replace(f"${{{{ result.{key} }}}}", value)
 
     # The first condition must NOT be satisfied — falls through to default ci_watch
-    # when_expr becomes e.g. "true == false" — evaluate as string equality
-    lhs, rhs = [s.strip() for s in when_expr.split("==", 1)]
-    assert lhs != rhs
+    # when_expr becomes "true == true and true == false" — second clause is False
+    assert not _eval_compound_condition(when_expr)
     assert conditions[1].route == "ci_watch"
 
 

--- a/tests/recipe/test_review_loop_routing_integration.py
+++ b/tests/recipe/test_review_loop_routing_integration.py
@@ -82,7 +82,9 @@ def test_check_review_loop_review_pr_route_uses_had_blocking_and_max_exceeded(
     recipe = load_recipe(builtin_recipes_dir() / recipe_name)
     step = recipe.steps["check_review_loop"]
     assert step.on_result is not None
-    review_condition = next(c for c in step.on_result.conditions if c.route == "review_pr")
+    review_conditions = [c for c in step.on_result.conditions if c.route == "review_pr"]
+    assert review_conditions, f"No conditional route to review_pr found in {recipe_name}"
+    review_condition = review_conditions[0]
     assert "had_blocking" in review_condition.when
     assert "max_exceeded" in review_condition.when
 

--- a/tests/skills/test_review_pr_verdict_guards.py
+++ b/tests/skills/test_review_pr_verdict_guards.py
@@ -91,3 +91,37 @@ def test_needs_human_prose_describes_genuine_ambiguity():
         "needs_human verdict prose must describe it as triggered by genuine ambiguity "
         "or decisions requiring human judgment — not by a count of findings."
     )
+
+
+def test_contract_yamls_include_approved_with_comments() -> None:
+    """All 3 contract YAML files must include approved_with_comments in
+    expected_output_patterns and pattern_examples for the review-pr contract."""
+    import yaml
+
+    contracts_dir = (
+        Path(__file__).parent.parent.parent
+        / "src"
+        / "autoskillit"
+        / "recipes"
+        / "contracts"
+    )
+    contract_files = [
+        contracts_dir / "implementation.yaml",
+        contracts_dir / "remediation.yaml",
+        contracts_dir / "implementation-groups.yaml",
+    ]
+    for contract_path in contract_files:
+        data = yaml.safe_load(contract_path.read_text())
+        review_pr = data.get("skills", {}).get("review-pr", {})
+        patterns = review_pr.get("expected_output_patterns", [])
+        examples = review_pr.get("pattern_examples", [])
+        pattern_str = " ".join(patterns)
+        assert "approved_with_comments" in pattern_str, (
+            f"{contract_path.name}: expected_output_patterns for review-pr must include "
+            "'approved_with_comments'"
+        )
+        examples_str = " ".join(examples)
+        assert "approved_with_comments" in examples_str, (
+            f"{contract_path.name}: pattern_examples for review-pr must include "
+            "'approved_with_comments'"
+        )

--- a/tests/skills/test_review_pr_verdict_guards.py
+++ b/tests/skills/test_review_pr_verdict_guards.py
@@ -99,11 +99,7 @@ def test_contract_yamls_include_approved_with_comments() -> None:
     import yaml
 
     contracts_dir = (
-        Path(__file__).parent.parent.parent
-        / "src"
-        / "autoskillit"
-        / "recipes"
-        / "contracts"
+        Path(__file__).parent.parent.parent / "src" / "autoskillit" / "recipes" / "contracts"
     )
     contract_files = [
         contracts_dir / "implementation.yaml",

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -101,12 +101,10 @@ def test_check_review_loop_stops_at_max_iterations() -> None:
     assert result["next_iteration"] == "3"
 
 
-def test_check_review_loop_returns_only_iteration_fields() -> None:
-    """Pure iteration guard must not return has_blocking or blocking_count."""
+def test_check_review_loop_returns_expected_fields() -> None:
+    """check_review_loop must return next_iteration, max_exceeded, and had_blocking."""
     result = check_review_loop(pr_number="42", cwd="/tmp")
-    assert "has_blocking" not in result
-    assert "blocking_count" not in result
-    assert set(result.keys()) == {"next_iteration", "max_exceeded"}
+    assert set(result.keys()) == {"next_iteration", "max_exceeded", "had_blocking"}
 
 
 # T_CRL11 — verify check_review_loop has no subprocess calls

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -130,6 +130,27 @@ def test_check_review_loop_has_no_subprocess_calls() -> None:
             break
 
 
+# T_CRL12
+def test_crl_had_blocking_true_when_changes_requested() -> None:
+    """had_blocking=true when previous_verdict is changes_requested."""
+    result = check_review_loop("42", "/tmp", previous_verdict="changes_requested")
+    assert result["had_blocking"] == "true"
+
+
+# T_CRL13
+def test_crl_had_blocking_false_when_approved_with_comments() -> None:
+    """had_blocking=false when previous_verdict is approved_with_comments."""
+    result = check_review_loop("42", "/tmp", previous_verdict="approved_with_comments")
+    assert result["had_blocking"] == "false"
+
+
+# T_CRL14
+def test_crl_had_blocking_false_when_empty_verdict() -> None:
+    """had_blocking=false when previous_verdict is absent (first-pass guard)."""
+    result = check_review_loop("42", "/tmp")
+    assert result["had_blocking"] == "false"
+
+
 def test_subprocess_calls_have_timeout() -> None:
     """All subprocess.run() calls in smoke_utils.py must have a timeout= argument."""
     import ast


### PR DESCRIPTION
## Summary

The review-resolve loop has a routing gap: `review-pr` emits `changes_requested` for **both** critical and warning-only findings, but only critical findings warrant a re-review cycle after resolution. Warning-only findings currently either (a) trigger `changes_requested` and loop back for a full re-review they don't need, or (b) are silently swallowed if the net verdict is `approved` without reaching `resolve_review` at all.

The fix requires three coordinated changes:

1. **`review-pr` SKILL.md** — Split the existing `changes_requested` verdict into two tiers: `changes_requested` (critical findings only) and a new `approved_with_comments` verdict (warning-only, no critical). Info-only and zero findings remain `approved`.
2. **`smoke_utils.check_review_loop`** — Add a `previous_verdict` parameter; return `had_blocking` (`"true"` iff `previous_verdict == "changes_requested"`).
3. **Recipe YAMLs (all 3)** — Rename `review_pr.capture.verdict` → `review_verdict` (avoids clobber by `resolve_review`); add `approved_with_comments` route in `review_pr`; thread `previous_verdict` into `check_review_loop`; gate re-review on `had_blocking AND NOT max_exceeded`.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 45, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([compose_pr opens PR])
    CI_WATCH([ci_watch<br/>━━━━━━━━━━<br/>Proceed to CI/merge])
    ESCALATE([release_issue_failure<br/>━━━━━━━━━━<br/>Human intervention])

    subgraph ReviewPhase ["PR Review Phase"]
        direction TB
        REVIEW_PR["● review_pr<br/>━━━━━━━━━━<br/>run_skill: review-pr<br/>Parallel audit subagents<br/>Posts inline GitHub comments"]
        VERDICT{"● Verdict?<br/>━━━━━━━━━━<br/>Classify findings by<br/>severity + requires_decision"}
    end

    subgraph ResolutionPhase ["Resolution Phase"]
        direction TB
        RESOLVE["resolve_review<br/>━━━━━━━━━━<br/>run_skill: resolve-review<br/>Fetches GitHub review threads<br/>Applies fixes for actionable<br/>findings (critical + warning)"]
        RESOLVE_VERDICT{"Resolver verdict?<br/>━━━━━━━━━━<br/>real_fix / already_green<br/>flake_suspected / ci_only_failure"}
        RE_PUSH["re_push_review<br/>━━━━━━━━━━<br/>push_to_remote<br/>Publishes fixes to<br/>feature branch"]
    end

    subgraph LoopGuardPhase ["● Loop Guard Phase"]
        direction TB
        CHECK_LOOP["● check_review_loop<br/>━━━━━━━━━━<br/>run_python: smoke_utils<br/>.check_review_loop()<br/>Pure iteration guard"]
        LOOP_STATE["● smoke_utils.check_review_loop<br/>━━━━━━━━━━<br/>Returns: next_iteration<br/>max_exceeded (≥ max_retries?)<br/>had_blocking (prev == changes_requested?)"]
        LOOP_GATE{"● Route decision?<br/>━━━━━━━━━━<br/>had_blocking == true<br/>AND max_exceeded == false?"}
    end

    %% FLOW %%
    START --> REVIEW_PR
    REVIEW_PR --> VERDICT

    %% Verdict routing — modified branch %%
    VERDICT -->|"changes_requested<br/>(blocking findings)"| RESOLVE
    VERDICT -->|"● approved_with_comments<br/>(warning-only, non-decision)"| RESOLVE
    VERDICT -->|"needs_human<br/>(requires_decision findings)"| CI_WATCH
    VERDICT -->|"approved<br/>(no findings)"| CI_WATCH
    VERDICT -->|"on_failure<br/>(MCP error / gh unavailable)"| RESOLVE

    %% Resolution routing %%
    RESOLVE --> RESOLVE_VERDICT
    RESOLVE_VERDICT -->|"real_fix / already_green<br/>/ flake_suspected"| RE_PUSH
    RESOLVE_VERDICT -->|"ci_only_failure<br/>(retries: 2 exhausted)"| ESCALATE

    %% Re-push to loop guard %%
    RE_PUSH -->|"on_success"| CHECK_LOOP
    RE_PUSH -->|"on_failure"| ESCALATE

    %% Loop guard internals %%
    CHECK_LOOP --> LOOP_STATE
    LOOP_STATE --> LOOP_GATE

    %% Loop gate routing %%
    LOOP_GATE -->|"YES: had_blocking=true<br/>AND max_exceeded=false<br/>(was changes_requested)"| REVIEW_PR
    LOOP_GATE -->|"NO: approved_with_comments path<br/>OR max iterations exhausted<br/>OR no blocking findings"| CI_WATCH
    LOOP_GATE -->|"on_failure"| CI_WATCH

    %% CLASS ASSIGNMENTS %%
    class START,CI_WATCH,ESCALATE terminal;
    class REVIEW_PR handler;
    class VERDICT,RESOLVE_VERDICT,LOOP_GATE stateNode;
    class RESOLVE handler;
    class RE_PUSH phase;
    class CHECK_LOOP,LOOP_STATE newComponent;
```

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;

    START([REVIEW LOOP ENTRY])

    subgraph Fields ["FIELD LIFECYCLE CATEGORIES"]
        direction LR
        F_INIT["INIT_ONLY<br/>━━━━━━━━━━<br/>pr_number<br/>annotated_diff_path<br/>hunk_ranges_path<br/><i>Set once; never modified by loop</i>"]
        F_MUT["● MUTABLE<br/>━━━━━━━━━━<br/>review_verdict<br/>verdict (shared key)<br/><i>Overwritten on each loop re-entry</i>"]
        F_APP["● APPEND_ONLY<br/>━━━━━━━━━━<br/>review_loop_count<br/><i>absent → 0 → 1 → … (monotonic)</i>"]
        F_DER["● DERIVED<br/>━━━━━━━━━━<br/>had_blocking<br/>max_exceeded<br/><i>Computed inline; never stored</i>"]
    end

    subgraph ReviewPr ["● REVIEW_PR STEP (review-pr skill)"]
        direction TB
        RP["● review_pr<br/>━━━━━━━━━━<br/>Emits: verdict<br/>Captured as: review_verdict<br/>optional_context_ref: review_loop_count"]
        RV_WRITE["WRITE: review_verdict<br/>━━━━━━━━━━<br/>capture: review_verdict = result.verdict"]
    end

    subgraph VerdictGates ["VERDICT VALIDATION GATES (test_review_pr_verdict_guards.py)"]
        direction TB
        VG1["● Gate: No Count Threshold<br/>━━━━━━━━━━<br/>ASSERT: len(warning_findings) absent<br/>Verdict must be semantic, not numeric"]
        VG2["● Gate: requires_decision Schema<br/>━━━━━━━━━━<br/>ASSERT: requires_decision in finding schema<br/>Guard against flag omission"]
        VG3["● Gate: approved_with_comments in Contracts<br/>━━━━━━━━━━<br/>ASSERT: all 3 recipe contracts include<br/>approved_with_comments verdict"]
        VERDICT_VALS["Valid Verdicts<br/>━━━━━━━━━━<br/>approved<br/>● approved_with_comments<br/>changes_requested<br/>needs_human"]
    end

    subgraph Routing ["● REVIEW_VERDICT ROUTING (on_result in recipes)"]
        direction TB
        R_BLOCKING["changes_requested<br/>━━━━━━━━━━<br/>→ resolve_review<br/>(blocking: re-review loop eligible)"]
        R_NONBLOCK["● approved_with_comments<br/>━━━━━━━━━━<br/>→ resolve_review<br/>(non-blocking: resolve once, no re-review)"]
        R_HUMAN["needs_human<br/>━━━━━━━━━━<br/>→ ci_watch<br/>(bypass resolve entirely)"]
        R_APPROVED["approved<br/>━━━━━━━━━━<br/>→ ci_watch<br/>(no action needed)"]
    end

    subgraph ResolveReview ["RESOLVE_REVIEW STEP (resolve-review skill)"]
        direction TB
        RR["resolve_review<br/>━━━━━━━━━━<br/>Fetches inline + summary comments<br/>Classifies: ACCEPT / REJECT / DISCUSS<br/>Applies ACCEPT fixes, commits<br/>Emits: verdict (real_fix | already_green)"]
        RR_WRITE["WRITE: verdict (shared key clobbered)<br/>━━━━━━━━━━<br/>capture: verdict = result.verdict<br/>Disjoint vocabulary from review_verdict"]
    end

    subgraph LoopCounter ["● CHECK_REVIEW_LOOP STEP (smoke_utils.check_review_loop)"]
        direction TB
        CRL["● check_review_loop<br/>━━━━━━━━━━<br/>Reads: context.review_verdict (as previous_verdict)<br/>Reads: context.review_loop_count (as current_iteration)<br/>Pure function — no subprocess"]
        CRL_DERIVE["DERIVE: had_blocking + max_exceeded<br/>━━━━━━━━━━<br/>had_blocking = (review_verdict == changes_requested)<br/>max_exceeded = (next_iteration >= max_iterations)<br/>NEVER stored in context"]
        CRL_WRITE["WRITE: review_loop_count<br/>━━━━━━━━━━<br/>capture: review_loop_count = result.next_iteration<br/>Monotonic increment — never reset"]
    end

    subgraph LoopGates ["LOOP INTEGRITY GATES (test_smoke_utils + test_review_loop_routing_integration)"]
        direction TB
        LG1["● Gate: Exact Field Set<br/>━━━━━━━━━━<br/>ASSERT: {next_iteration, max_exceeded, had_blocking}<br/>No undeclared fields"]
        LG2["● Gate: Pure Function<br/>━━━━━━━━━━<br/>ASSERT: no subprocess.run() in check_review_loop<br/>AST-walk guard"]
        LG3["● Gate: Routing Condition Contract<br/>━━━━━━━━━━<br/>ASSERT: review_pr route references<br/>both had_blocking AND max_exceeded"]
    end

    subgraph LoopDecision ["LOOP EXIT DECISION (on_result gate)"]
        direction TB
        LD_GATE{"had_blocking == true<br/>AND max_exceeded == false?"}
        LD_LOOP["Re-enter Review Loop<br/>━━━━━━━━━━<br/>Route → review_pr<br/>(only for changes_requested)"]
        LD_PROCEED["Proceed to CI<br/>━━━━━━━━━━<br/>Route → ci_watch<br/>(approved_with_comments falls here)"]
    end

    END_CI([CI_WATCH])

    %% FLOW %%
    START --> Fields
    Fields --> ReviewPr

    RP --> RV_WRITE
    RV_WRITE --> VerdictGates

    VG1 --> VERDICT_VALS
    VG2 --> VERDICT_VALS
    VG3 --> VERDICT_VALS

    VERDICT_VALS --> R_BLOCKING
    VERDICT_VALS --> R_NONBLOCK
    VERDICT_VALS --> R_HUMAN
    VERDICT_VALS --> R_APPROVED

    R_BLOCKING --> ResolveReview
    R_NONBLOCK --> ResolveReview
    R_HUMAN --> END_CI
    R_APPROVED --> END_CI

    RR --> RR_WRITE
    RR_WRITE --> LoopCounter

    CRL --> CRL_DERIVE
    CRL_DERIVE --> CRL_WRITE
    CRL_WRITE --> LoopGates

    LG1 --> LoopDecision
    LG2 --> LoopDecision
    LG3 --> LoopDecision

    LD_GATE --> |"TRUE (changes_requested only)"| LD_LOOP
    LD_GATE --> |"FALSE (approved_with_comments + budget exhausted)"| LD_PROCEED

    LD_LOOP --> |"back to top of loop"| RP
    LD_PROCEED --> END_CI

    %% CLASS ASSIGNMENTS %%
    class START,END_CI terminal;
    class F_INIT detector;
    class F_MUT phase;
    class F_APP handler;
    class F_DER gap;
    class RP,RR phase;
    class RV_WRITE,RR_WRITE,CRL_WRITE stateNode;
    class VG1,VG2,VG3 detector;
    class VERDICT_VALS stateNode;
    class R_BLOCKING,R_NONBLOCK,R_HUMAN,R_APPROVED handler;
    class CRL phase;
    class CRL_DERIVE gap;
    class LG1,LG2,LG3 detector;
    class LD_GATE,LD_LOOP,LD_PROCEED output;
```

Closes #1112

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260421-215001-921824/.autoskillit/temp/make-plan/route_non_blocking_review_findings_plan_2026-04-21_000000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 2.8k | 21.1k | 707.9k | 57.5k | 1 | 8m 1s |
| verify | 150 | 18.2k | 1.5M | 105.4k | 1 | 5m 54s |
| implement | 414 | 32.7k | 3.4M | 83.7k | 1 | 10m 8s |
| fix | 168 | 8.6k | 1.0M | 56.6k | 1 | 8m 48s |
| prepare_pr | 60 | 4.8k | 191.5k | 26.2k | 1 | 1m 28s |
| run_arch_lenses | 138 | 12.5k | 606.9k | 91.6k | 2 | 5m 33s |
| compose_pr | 67 | 6.6k | 228.2k | 27.2k | 1 | 1m 55s |
| **Total** | 3.8k | 104.4k | 7.6M | 448.0k | | 41m 50s |