### PR TITLE
Franchise L2 Timeout Semantics + No-Result-Block Failure Semantics

### DIFF
--- a/src/autoskillit/core/_type_results.py
+++ b/src/autoskillit/core/_type_results.py
@@ -160,6 +160,8 @@ class SkillResult:
     with the kill cause, resolving the "success=True + exit_code=-9" contradiction.
     """
     last_stop_reason: str = ""
+    lifespan_started: bool = False
+    """True when the L2 session invoked at least one MCP tool (heuristic for server lifespan)."""
 
     def to_json(self) -> str:
         data: dict[str, Any] = {
@@ -178,6 +180,7 @@ class SkillResult:
             "write_path_warnings": self.write_path_warnings,
             "write_call_count": self.write_call_count,
             "last_stop_reason": self.last_stop_reason,
+            "lifespan_started": self.lifespan_started,
         }
         if self.worktree_path is not None:
             data["worktree_path"] = self.worktree_path

--- a/src/autoskillit/execution/headless.py
+++ b/src/autoskillit/execution/headless.py
@@ -879,6 +879,7 @@ def _build_skill_result(
             write_path_warnings=write_path_warnings,
             write_call_count=write_call_count,
             last_stop_reason=session.last_stop_reason,
+            lifespan_started=session.lifespan_started,
         )
     else:
         sr = SkillResult(
@@ -898,6 +899,7 @@ def _build_skill_result(
             write_call_count=write_call_count,
             kill_reason=result.kill_reason,
             last_stop_reason=session.last_stop_reason,
+            lifespan_started=session.lifespan_started,
         )
     sr = _apply_budget_guard(sr, skill_command, audit, max_consecutive_retries)
 
@@ -1009,9 +1011,17 @@ async def _execute_claude_headless(
     dispatch_id = dispatch_id or os.environ.get(DISPATCH_ID_ENV_VAR, "")
 
     cfg = ctx.config.run_skill
-    _raw_idle = (
-        idle_output_timeout if idle_output_timeout is not None else float(cfg.idle_output_timeout)
-    )
+    if idle_output_timeout is not None:
+        _raw_idle = idle_output_timeout
+    else:
+        env_idle = os.environ.get("AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT")
+        if env_idle is not None:
+            try:
+                _raw_idle = float(env_idle)
+            except ValueError:
+                _raw_idle = float(cfg.idle_output_timeout)
+        else:
+            _raw_idle = float(cfg.idle_output_timeout)
     effective_idle: float | None = _raw_idle if _raw_idle > 0.0 else None
 
     runner = ctx.runner
@@ -1433,6 +1443,10 @@ class DefaultHeadlessExecutor:
                     "AUTOSKILLIT_L2_TOOL_TAGS — use requires_packs exclusively"
                 )
             merged_extras["AUTOSKILLIT_L2_TOOL_TAGS"] = ",".join(sorted(requires_packs))
+
+        idle_cfg_val = cfg.run_skill.idle_output_timeout
+        if idle_cfg_val > 0:
+            merged_extras.setdefault("AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT", str(int(idle_cfg_val)))
 
         spec = build_food_truck_cmd(
             orchestrator_prompt=orchestrator_prompt,

--- a/src/autoskillit/execution/headless.py
+++ b/src/autoskillit/execution/headless.py
@@ -1019,6 +1019,11 @@ async def _execute_claude_headless(
             try:
                 _raw_idle = float(env_idle)
             except ValueError:
+                logger.warning(
+                    "AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT: invalid float — falling back to config",
+                    env_value=env_idle,
+                    fallback=cfg.idle_output_timeout,
+                )
                 _raw_idle = float(cfg.idle_output_timeout)
         else:
             _raw_idle = float(cfg.idle_output_timeout)
@@ -1446,7 +1451,7 @@ class DefaultHeadlessExecutor:
 
         idle_cfg_val = cfg.run_skill.idle_output_timeout
         if idle_cfg_val > 0:
-            merged_extras.setdefault("AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT", str(int(idle_cfg_val)))
+            merged_extras.setdefault("AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT", str(idle_cfg_val))
 
         spec = build_food_truck_cmd(
             orchestrator_prompt=orchestrator_prompt,

--- a/src/autoskillit/franchise/_api.py
+++ b/src/autoskillit/franchise/_api.py
@@ -323,6 +323,7 @@ async def _run_dispatch(
                 "dispatch_id": dispatch_id,
                 "l2_session_id": skill_result.session_id,
                 "l2_payload": parsed.payload,
+                "reason": reason,
                 "token_usage": skill_result.token_usage,
                 "l2_parse_source": parsed.source,
                 "lifespan_started": skill_result.lifespan_started,

--- a/src/autoskillit/franchise/_api.py
+++ b/src/autoskillit/franchise/_api.py
@@ -10,7 +10,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
-from autoskillit.core import FranchiseErrorCode, claude_code_log_path, franchise_error, get_logger
+from autoskillit.core import (
+    FranchiseErrorCode,
+    SkillResult,
+    claude_code_log_path,
+    franchise_error,
+    get_logger,
+)
 from autoskillit.franchise.result_parser import parse_l2_result_block
 
 if TYPE_CHECKING:
@@ -41,6 +47,34 @@ def _write_pid(
         )
     except Exception:
         logger.warning("_write_pid: failed to mark dispatch running", exc_info=True)
+
+
+def _post_dispatch_cleanup(
+    tool_ctx: ToolContext,
+    skill_result: SkillResult,
+    cache_invalidator: Callable[[str], None] | None,
+    quota_refresher: Callable[..., Any],
+) -> None:
+    """Run quota cache invalidation, background quota refresh, and session skill cleanup."""
+    if cache_invalidator is not None:
+        cache_invalidator(tool_ctx.config.quota_guard.cache_path)
+
+    if tool_ctx.background is not None:
+        tool_ctx.background.submit(
+            quota_refresher(tool_ctx.config.quota_guard),
+            label="quota_post_dispatch_refresh",
+        )
+
+    if tool_ctx.session_skill_manager is not None and skill_result.session_id:
+        try:
+            tool_ctx.session_skill_manager.cleanup_session(skill_result.session_id)
+        except Exception as exc:
+            logger.warning(
+                "session skills cleanup failed — dispatch not affected",
+                session_id=skill_result.session_id,
+                exc_class=type(exc).__name__,
+                exc_info=True,
+            )
 
 
 async def execute_dispatch(
@@ -215,6 +249,34 @@ async def _run_dispatch(
     )
     ended_at = time.time()
 
+    # --- Timeout pre-check: short-circuit before result-block parsing ---
+    if skill_result.subtype == "timeout":
+        append_dispatch_record(
+            state_path,
+            DispatchRecord(
+                name=effective_name,
+                status=DispatchStatus.FAILURE,
+                dispatch_id=dispatch_id,
+                l2_session_id=skill_result.session_id,
+                l2_pid=_l2_pid[0] if _l2_pid else 0,
+                reason="l2_timeout",
+                token_usage=skill_result.token_usage or {},
+                started_at=started_at,
+                ended_at=ended_at,
+            ),
+        )
+        _post_dispatch_cleanup(tool_ctx, skill_result, cache_invalidator, quota_refresher)
+        return franchise_error(
+            FranchiseErrorCode.L2_TIMEOUT,
+            f"L2 dispatch '{effective_name}' timed out",
+            details={
+                "dispatch_id": dispatch_id,
+                "l2_session_id": skill_result.session_id,
+                "lifespan_started": skill_result.lifespan_started,
+                "token_usage": skill_result.token_usage,
+            },
+        )
+
     jsonl_path = claude_code_log_path(str(tool_ctx.project_dir), skill_result.session_id or "")
     parsed = parse_l2_result_block(
         stdout=skill_result.result or "",
@@ -222,10 +284,19 @@ async def _run_dispatch(
         assistant_messages_path=jsonl_path,
     )
 
+    # Classify outcome → (final_status, reason)
     if parsed.outcome == "completed_clean" and parsed.payload and parsed.payload.get("success"):
         final_status = DispatchStatus.SUCCESS
-    else:
+        reason = ""
+    elif parsed.outcome == "completed_clean":
         final_status = DispatchStatus.FAILURE
+        reason = parsed.payload.get("reason", "") if parsed.payload else ""
+    elif parsed.outcome == "completed_dirty":
+        final_status = DispatchStatus.FAILURE
+        reason = "l2_parse_failed"
+    else:  # no_sentinel
+        final_status = DispatchStatus.FAILURE
+        reason = "l2_no_result_block"
 
     append_dispatch_record(
         state_path,
@@ -235,31 +306,14 @@ async def _run_dispatch(
             dispatch_id=dispatch_id,
             l2_session_id=skill_result.session_id,
             l2_pid=_l2_pid[0] if _l2_pid else 0,
+            reason=reason,
             token_usage=skill_result.token_usage or {},
             started_at=started_at,
             ended_at=ended_at,
         ),
     )
 
-    if cache_invalidator is not None:
-        cache_invalidator(tool_ctx.config.quota_guard.cache_path)
-
-    if tool_ctx.background is not None:
-        tool_ctx.background.submit(
-            quota_refresher(tool_ctx.config.quota_guard),
-            label="quota_post_dispatch_refresh",
-        )
-
-    if tool_ctx.session_skill_manager is not None and skill_result.session_id:
-        try:
-            tool_ctx.session_skill_manager.cleanup_session(skill_result.session_id)
-        except Exception as exc:
-            logger.warning(
-                "session skills cleanup failed — dispatch not affected",
-                session_id=skill_result.session_id,
-                exc_class=type(exc).__name__,
-                exc_info=True,
-            )
+    _post_dispatch_cleanup(tool_ctx, skill_result, cache_invalidator, quota_refresher)
 
     if parsed.outcome == "completed_clean":
         envelope_success = bool(parsed.payload and parsed.payload.get("success", False))
@@ -271,6 +325,7 @@ async def _run_dispatch(
                 "l2_payload": parsed.payload,
                 "token_usage": skill_result.token_usage,
                 "l2_parse_source": parsed.source,
+                "lifespan_started": skill_result.lifespan_started,
             }
         )
     elif parsed.outcome == "completed_dirty":
@@ -285,6 +340,7 @@ async def _run_dispatch(
                 "l2_parse_error": parsed.parse_error,
                 "token_usage": skill_result.token_usage,
                 "l2_parse_source": parsed.source,
+                "lifespan_started": skill_result.lifespan_started,
             }
         )
     else:
@@ -297,5 +353,6 @@ async def _run_dispatch(
                 "reason": "l2_no_result_block",
                 "l2_parse_source": parsed.source,
                 "token_usage": skill_result.token_usage,
+                "lifespan_started": skill_result.lifespan_started,
             }
         )

--- a/tests/execution/test_headless.py
+++ b/tests/execution/test_headless.py
@@ -844,6 +844,7 @@ class TestBuildSkillResultCrossValidation:
         "exit_code",
         "kill_reason",
         "last_stop_reason",
+        "lifespan_started",
         "needs_retry",
         "retry_reason",
         "stderr",
@@ -968,6 +969,53 @@ class TestBuildSkillResultCrossValidation:
         )
         response = json.loads(_build_skill_result(result_obj).to_json())
         assert set(response.keys()) == self.EXPECTED_SKILL_KEYS
+
+
+def _make_subprocess_result_with_tool_uses(
+    tool_use_names: list[str] | None = None,
+) -> SubprocessResult:
+    """Build a SubprocessResult whose stdout includes optional tool_use NDJSON blocks."""
+    records = []
+    if tool_use_names:
+        content = [
+            {"type": "tool_use", "name": name, "id": f"tu-{i}"}
+            for i, name in enumerate(tool_use_names)
+        ]
+        records.append(json.dumps({"type": "assistant", "message": {"content": content}}))
+    records.append(
+        json.dumps(
+            {
+                "type": "result",
+                "subtype": "success",
+                "is_error": False,
+                "result": "done",
+                "session_id": "test-session",
+            }
+        )
+    )
+    return SubprocessResult(
+        returncode=0,
+        stdout="\n".join(records),
+        stderr="",
+        termination=TerminationReason.NATURAL_EXIT,
+        pid=12345,
+    )
+
+
+class TestBuildSkillResultLifespanStarted:
+    """_build_skill_result sets lifespan_started based on tool_uses in stdout."""
+
+    def test_build_skill_result_sets_lifespan_started_true(self):
+        """Non-empty tool_uses in stdout → _build_skill_result produces lifespan_started=True."""
+        result = _make_subprocess_result_with_tool_uses(tool_use_names=["Write", "Edit"])
+        sr = _build_skill_result(result)
+        assert sr.lifespan_started is True
+
+    def test_build_skill_result_sets_lifespan_started_false_no_tool_uses(self):
+        """Empty tool_uses in stdout → _build_skill_result produces lifespan_started=False."""
+        result = _make_subprocess_result_with_tool_uses(tool_use_names=None)
+        sr = _build_skill_result(result)
+        assert sr.lifespan_started is False
 
 
 class TestBuildSkillResultStderr:

--- a/tests/execution/test_idle_output_env.py
+++ b/tests/execution/test_idle_output_env.py
@@ -14,12 +14,7 @@ from tests.fakes import MockSubprocessRunner
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 
-# ---------------------------------------------------------------------------
-# Shared helpers
-# ---------------------------------------------------------------------------
-
-
-def _success_result(idle_value: float | None = None) -> SubprocessResult:
+def _success_result() -> SubprocessResult:
     """Build a minimal successful SubprocessResult for MockSubprocessRunner."""
     return SubprocessResult(
         returncode=0,
@@ -36,11 +31,6 @@ def _success_result(idle_value: float | None = None) -> SubprocessResult:
         termination=TerminationReason.NATURAL_EXIT,
         pid=12345,
     )
-
-
-# ---------------------------------------------------------------------------
-# Test _execute_claude_headless idle timeout env resolution
-# ---------------------------------------------------------------------------
 
 
 class TestExecuteClaudeHeadlessIdleEnv:
@@ -134,11 +124,6 @@ class TestExecuteClaudeHeadlessIdleEnv:
         _, _, _, kwargs = minimal_ctx.runner.call_args_list[0]
         actual = kwargs.get("idle_output_timeout")
         assert actual is None, f"Expected idle_output_timeout=None when env=0, got {actual!r}"
-
-
-# ---------------------------------------------------------------------------
-# Test dispatch_food_truck idle env injection
-# ---------------------------------------------------------------------------
 
 
 class TestDispatchFoodTruckIdleEnvInjection:

--- a/tests/execution/test_idle_output_env.py
+++ b/tests/execution/test_idle_output_env.py
@@ -68,7 +68,7 @@ class TestExecuteClaudeHeadlessIdleEnv:
     async def test_idle_output_timeout_priority_chain(
         self, minimal_ctx, tmp_path: Path, monkeypatch
     ) -> None:
-        """Priority chain: per-step arg > AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT env > cfg.idle_output_timeout.
+        """Priority chain: per-step arg > AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT env > cfg.
 
         Level 1: per-step arg beats env and cfg.
         Level 2: env beats cfg when per-step arg is None.
@@ -132,9 +132,8 @@ class TestExecuteClaudeHeadlessIdleEnv:
 
         assert minimal_ctx.runner.call_args_list, "runner was never called"
         _, _, _, kwargs = minimal_ctx.runner.call_args_list[0]
-        assert kwargs.get("idle_output_timeout") is None, (
-            f"Expected idle_output_timeout=None when env=0, got {kwargs.get('idle_output_timeout')!r}"
-        )
+        actual = kwargs.get("idle_output_timeout")
+        assert actual is None, f"Expected idle_output_timeout=None when env=0, got {actual!r}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/execution/test_idle_output_env.py
+++ b/tests/execution/test_idle_output_env.py
@@ -1,0 +1,204 @@
+"""Group G (execution part): AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT env variable injection tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from autoskillit.core.types import SubprocessResult, TerminationReason
+from tests.fakes import MockSubprocessRunner
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _success_result(idle_value: float | None = None) -> SubprocessResult:
+    """Build a minimal successful SubprocessResult for MockSubprocessRunner."""
+    return SubprocessResult(
+        returncode=0,
+        stdout=json.dumps(
+            {
+                "type": "result",
+                "subtype": "success",
+                "is_error": False,
+                "result": "done",
+                "session_id": "sess-idle-test",
+            }
+        ),
+        stderr="",
+        termination=TerminationReason.NATURAL_EXIT,
+        pid=12345,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test _execute_claude_headless idle timeout env resolution
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteClaudeHeadlessIdleEnv:
+    @pytest.mark.anyio
+    async def test_execute_claude_headless_reads_idle_output_env(
+        self, minimal_ctx, tmp_path: Path, monkeypatch
+    ) -> None:
+        """When idle_output_timeout=None and AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT is set in env,
+        run_headless_core uses the env value as the effective idle timeout."""
+        from autoskillit.execution.headless import run_headless_core
+
+        monkeypatch.setenv("AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT", "30")
+        minimal_ctx.runner = MockSubprocessRunner()
+        minimal_ctx.runner.set_default(_success_result())
+
+        await run_headless_core("/investigate foo", str(tmp_path), minimal_ctx)
+
+        assert minimal_ctx.runner.call_args_list, "runner was never called"
+        _cmd, _cwd, _timeout, kwargs = minimal_ctx.runner.call_args_list[0]
+        assert kwargs.get("idle_output_timeout") == 30.0, (
+            f"Expected idle_output_timeout=30.0, got {kwargs.get('idle_output_timeout')!r}"
+        )
+
+    @pytest.mark.anyio
+    async def test_idle_output_timeout_priority_chain(
+        self, minimal_ctx, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Priority chain: per-step arg > AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT env > cfg.idle_output_timeout.
+
+        Level 1: per-step arg beats env and cfg.
+        Level 2: env beats cfg when per-step arg is None.
+        Level 3: cfg is used when both arg and env are absent.
+        """
+        from autoskillit.execution.headless import run_headless_core
+
+        # Level 1: per-step arg takes priority over env and cfg
+        monkeypatch.setenv("AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT", "30")
+        minimal_ctx.config.run_skill.idle_output_timeout = 60
+        minimal_ctx.runner = MockSubprocessRunner()
+        minimal_ctx.runner.set_default(_success_result())
+
+        await run_headless_core(
+            "/investigate foo", str(tmp_path), minimal_ctx, idle_output_timeout=15.0
+        )
+        _, _, _, kwargs1 = minimal_ctx.runner.call_args_list[0]
+        assert kwargs1.get("idle_output_timeout") == 15.0, (
+            f"Level 1 (per-step arg): expected 15.0, got {kwargs1.get('idle_output_timeout')!r}"
+        )
+
+        # Level 2: env beats cfg when per-step arg is None
+        minimal_ctx.runner = MockSubprocessRunner()
+        minimal_ctx.runner.set_default(_success_result())
+
+        await run_headless_core(
+            "/investigate foo", str(tmp_path), minimal_ctx, idle_output_timeout=None
+        )
+        _, _, _, kwargs2 = minimal_ctx.runner.call_args_list[0]
+        assert kwargs2.get("idle_output_timeout") == 30.0, (
+            f"Level 2 (env): expected 30.0, got {kwargs2.get('idle_output_timeout')!r}"
+        )
+
+        # Level 3: cfg when env is absent and arg is None
+        monkeypatch.delenv("AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT")
+        minimal_ctx.config.run_skill.idle_output_timeout = 45
+        minimal_ctx.runner = MockSubprocessRunner()
+        minimal_ctx.runner.set_default(_success_result())
+
+        await run_headless_core(
+            "/investigate foo", str(tmp_path), minimal_ctx, idle_output_timeout=None
+        )
+        _, _, _, kwargs3 = minimal_ctx.runner.call_args_list[0]
+        assert kwargs3.get("idle_output_timeout") == 45.0, (
+            f"Level 3 (cfg): expected 45.0, got {kwargs3.get('idle_output_timeout')!r}"
+        )
+
+    @pytest.mark.anyio
+    async def test_idle_output_env_zero_means_disabled(
+        self, minimal_ctx, tmp_path: Path, monkeypatch
+    ) -> None:
+        """AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT=0 → effective idle is None (feature disabled)."""
+        from autoskillit.execution.headless import run_headless_core
+
+        monkeypatch.setenv("AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT", "0")
+        minimal_ctx.config.run_skill.idle_output_timeout = 0  # cfg also 0
+        minimal_ctx.runner = MockSubprocessRunner()
+        minimal_ctx.runner.set_default(_success_result())
+
+        await run_headless_core("/investigate foo", str(tmp_path), minimal_ctx)
+
+        assert minimal_ctx.runner.call_args_list, "runner was never called"
+        _, _, _, kwargs = minimal_ctx.runner.call_args_list[0]
+        assert kwargs.get("idle_output_timeout") is None, (
+            f"Expected idle_output_timeout=None when env=0, got {kwargs.get('idle_output_timeout')!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test dispatch_food_truck idle env injection
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchFoodTruckIdleEnvInjection:
+    @pytest.mark.anyio
+    async def test_dispatch_food_truck_injects_idle_output_timeout_env(
+        self, minimal_ctx, tmp_path: Path, monkeypatch
+    ) -> None:
+        """dispatch_food_truck adds AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT to env_extras
+        based on cfg.run_skill.idle_output_timeout when it is > 0."""
+        from autoskillit.core.types import SkillResult as _SkillResult
+        from autoskillit.execution.headless import DefaultHeadlessExecutor
+
+        minimal_ctx.config.run_skill.idle_output_timeout = 120
+
+        captured_env_extras: list[dict[str, str] | None] = []
+
+        def _capture_build(**kwargs: Any):
+            captured_env_extras.append(kwargs.get("env_extras"))
+            from autoskillit.execution.commands import ClaudeHeadlessCmd
+
+            return ClaudeHeadlessCmd(cmd=["echo", "done"], env={})
+
+        async def _fake_execute(*_args: Any, **_kwargs: Any) -> _SkillResult:
+            from autoskillit.core.types import KillReason, RetryReason
+
+            return _SkillResult(
+                success=True,
+                result="done",
+                session_id="",
+                subtype="success",
+                is_error=False,
+                exit_code=0,
+                needs_retry=False,
+                retry_reason=RetryReason.NONE,
+                stderr="",
+                kill_reason=KillReason.NATURAL_EXIT,
+            )
+
+        monkeypatch.setattr(
+            "autoskillit.execution.headless.build_food_truck_cmd",
+            _capture_build,
+        )
+        monkeypatch.setattr(
+            "autoskillit.execution.headless._execute_claude_headless",
+            _fake_execute,
+        )
+
+        minimal_ctx.plugin_dir = str(tmp_path / "plugin")
+        executor = DefaultHeadlessExecutor(minimal_ctx)
+        await executor.dispatch_food_truck(
+            orchestrator_prompt="test",
+            cwd=str(tmp_path),
+            completion_marker="%%DONE%%",
+            env_extras=None,
+        )
+
+        assert captured_env_extras, "build_food_truck_cmd was not called"
+        env = captured_env_extras[0] or {}
+        assert "AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT" in env, (
+            f"Expected AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT in env_extras, got {env!r}"
+        )
+        assert env["AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT"] == "120"

--- a/tests/execution/test_session.py
+++ b/tests/execution/test_session.py
@@ -1034,6 +1034,7 @@ class TestSkillResult:
             "exit_code",
             "kill_reason",
             "last_stop_reason",
+            "lifespan_started",
             "needs_retry",
             "retry_reason",
             "stderr",

--- a/tests/franchise/test_dispatch_failure_semantics.py
+++ b/tests/franchise/test_dispatch_failure_semantics.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-from unittest.mock import AsyncMock
 
 import pytest
 
@@ -249,7 +248,7 @@ class TestNoSentinelPath:
 
     @pytest.mark.anyio
     async def test_no_sentinel_clean_exit_is_not_success(self, tool_ctx, monkeypatch):
-        """success=True + exit_code=0 SkillResult but no_sentinel outcome → envelope.success=False."""
+        """no_sentinel outcome → envelope.success=False even when SkillResult.success=True."""
         import dataclasses
 
         from tests.fakes import _DEFAULT_SKILL_RESULT
@@ -305,10 +304,8 @@ class TestCompletedCleanPath:
         assert record["reason"] == ""
 
     @pytest.mark.anyio
-    async def test_completed_clean_failure_writes_reason_from_payload(
-        self, tool_ctx, monkeypatch
-    ):
-        """completed_clean with success=False and payload.reason → DispatchRecord.reason from payload."""
+    async def test_completed_clean_failure_writes_reason_from_payload(self, tool_ctx, monkeypatch):
+        """completed_clean success=False: payload.reason → DispatchRecord.reason."""
         _setup_dispatch(tool_ctx)
         monkeypatch.setattr(
             "autoskillit.franchise._api.parse_l2_result_block",

--- a/tests/franchise/test_dispatch_failure_semantics.py
+++ b/tests/franchise/test_dispatch_failure_semantics.py
@@ -12,11 +12,6 @@ from tests.fakes import InMemoryHeadlessExecutor, InMemoryRecipeRepository
 pytestmark = [pytest.mark.layer("franchise"), pytest.mark.small]
 
 
-# ---------------------------------------------------------------------------
-# Shared helpers
-# ---------------------------------------------------------------------------
-
-
 def _make_standard_recipe(name: str = "test-recipe"):
     from autoskillit.recipe.schema import Recipe, RecipeKind
 
@@ -112,11 +107,6 @@ def _make_completed_clean(success: bool, reason: str = ""):
         parse_error=None,
         source="stdout",
     )
-
-
-# ---------------------------------------------------------------------------
-# Group F tests
-# ---------------------------------------------------------------------------
 
 
 class TestTimeoutPath:

--- a/tests/franchise/test_dispatch_failure_semantics.py
+++ b/tests/franchise/test_dispatch_failure_semantics.py
@@ -1,0 +1,321 @@
+"""Group F: Timeout + No-Result-Block failure semantics for franchise dispatch."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tests.fakes import InMemoryHeadlessExecutor, InMemoryRecipeRepository
+
+pytestmark = [pytest.mark.layer("franchise"), pytest.mark.small]
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_standard_recipe(name: str = "test-recipe"):
+    from autoskillit.recipe.schema import Recipe, RecipeKind
+
+    return Recipe(name=name, description="test", ingredients={}, kind=RecipeKind.STANDARD)
+
+
+def _simple_prompt_builder(**kwargs) -> str:
+    return f"prompt-for-{kwargs.get('recipe', 'unknown')}"
+
+
+async def _no_sleep_quota_checker(config, **kwargs) -> dict:
+    return {
+        "should_sleep": False,
+        "sleep_seconds": 0,
+        "utilization": None,
+        "resets_at": None,
+        "window_name": None,
+    }
+
+
+async def _noop_quota_refresher(config, **kwargs) -> None:
+    pass
+
+
+def _setup_dispatch(tool_ctx, recipe_name: str = "test-recipe"):
+    """Wire tool_ctx for dispatch tests."""
+    tool_ctx.franchise_lock = asyncio.Lock()
+    repo = InMemoryRecipeRepository()
+    repo.add_recipe(recipe_name, _make_standard_recipe(recipe_name))
+    tool_ctx.recipes = repo
+    tool_ctx.executor = InMemoryHeadlessExecutor()
+
+
+async def _run(tool_ctx, recipe: str = "test-recipe") -> dict:
+    from autoskillit.franchise._api import execute_dispatch
+
+    raw = await execute_dispatch(
+        tool_ctx=tool_ctx,
+        recipe=recipe,
+        task="t",
+        ingredients=None,
+        dispatch_name=None,
+        timeout_sec=None,
+        prompt_builder=_simple_prompt_builder,
+        quota_checker=_no_sleep_quota_checker,
+        quota_refresher=_noop_quota_refresher,
+    )
+    return json.loads(raw)
+
+
+def _read_dispatch_record(tool_ctx) -> dict:
+    """Read the single dispatch record written to the state file."""
+    state_files = list((tool_ctx.temp_dir / "dispatches").glob("*.json"))
+    assert len(state_files) == 1, f"Expected 1 state file, found {len(state_files)}"
+    state = json.loads(state_files[0].read_text())
+    return state["dispatches"][0]
+
+
+def _make_no_sentinel():
+    from autoskillit.franchise.result_parser import L2ParseResult
+
+    return L2ParseResult(
+        outcome="no_sentinel",
+        payload=None,
+        raw_body=None,
+        parse_error=None,
+        source="stdout",
+    )
+
+
+def _make_completed_dirty():
+    from autoskillit.franchise.result_parser import L2ParseResult
+
+    return L2ParseResult(
+        outcome="completed_dirty",
+        payload=None,
+        raw_body="garbled",
+        parse_error="json decode error",
+        source="stdout",
+    )
+
+
+def _make_completed_clean(success: bool, reason: str = ""):
+    from autoskillit.franchise.result_parser import L2ParseResult
+
+    payload: dict = {"success": success}
+    if reason:
+        payload["reason"] = reason
+    return L2ParseResult(
+        outcome="completed_clean",
+        payload=payload,
+        raw_body=None,
+        parse_error=None,
+        source="stdout",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Group F tests
+# ---------------------------------------------------------------------------
+
+
+class TestTimeoutPath:
+    @pytest.mark.anyio
+    async def test_timeout_returns_franchise_error_envelope(self, tool_ctx, monkeypatch):
+        """skill_result.subtype == 'timeout' → franchise_error envelope with error='l2_timeout'."""
+        import dataclasses
+
+        from tests.fakes import _DEFAULT_SKILL_RESULT
+
+        _setup_dispatch(tool_ctx)
+        tool_ctx.executor = InMemoryHeadlessExecutor(
+            default_result=dataclasses.replace(_DEFAULT_SKILL_RESULT, subtype="timeout")
+        )
+
+        result = await _run(tool_ctx)
+        assert result["success"] is False
+        assert result["error"] == "l2_timeout"
+
+    @pytest.mark.anyio
+    async def test_timeout_writes_state_with_reason_l2_timeout(self, tool_ctx, monkeypatch):
+        """Timeout path writes DispatchRecord with status=failure and reason=l2_timeout."""
+        import dataclasses
+
+        from tests.fakes import _DEFAULT_SKILL_RESULT
+
+        _setup_dispatch(tool_ctx)
+        tool_ctx.executor = InMemoryHeadlessExecutor(
+            default_result=dataclasses.replace(_DEFAULT_SKILL_RESULT, subtype="timeout")
+        )
+
+        await _run(tool_ctx)
+
+        record = _read_dispatch_record(tool_ctx)
+        assert record["status"] == "failure"
+        assert record["reason"] == "l2_timeout"
+
+    @pytest.mark.anyio
+    async def test_timeout_skips_parse_l2_result_block(self, tool_ctx, monkeypatch):
+        """Timeout path must not call parse_l2_result_block."""
+        import dataclasses
+
+        from tests.fakes import _DEFAULT_SKILL_RESULT
+
+        _setup_dispatch(tool_ctx)
+        tool_ctx.executor = InMemoryHeadlessExecutor(
+            default_result=dataclasses.replace(_DEFAULT_SKILL_RESULT, subtype="timeout")
+        )
+
+        def _should_not_be_called(**_kwargs):
+            raise AssertionError("parse_l2_result_block called on timeout path")
+
+        monkeypatch.setattr(
+            "autoskillit.franchise._api.parse_l2_result_block",
+            _should_not_be_called,
+        )
+
+        # Should succeed (return l2_timeout error envelope) without raising
+        result = await _run(tool_ctx)
+        assert result["error"] == "l2_timeout"
+
+    @pytest.mark.anyio
+    async def test_timeout_envelope_includes_dispatch_metadata(self, tool_ctx, monkeypatch):
+        """Timeout envelope details includes dispatch_id, l2_session_id, and token_usage."""
+        import dataclasses
+
+        from tests.fakes import _DEFAULT_SKILL_RESULT
+
+        _setup_dispatch(tool_ctx)
+        tool_ctx.executor = InMemoryHeadlessExecutor(
+            default_result=dataclasses.replace(
+                _DEFAULT_SKILL_RESULT,
+                subtype="timeout",
+                session_id="sess-timeout-123",
+                token_usage={"input_tokens": 50},
+            )
+        )
+
+        result = await _run(tool_ctx)
+        details = result.get("details", {})
+        assert "dispatch_id" in details
+        assert details["l2_session_id"] == "sess-timeout-123"
+        assert details["token_usage"] == {"input_tokens": 50}
+
+    @pytest.mark.anyio
+    async def test_idle_stall_falls_through_to_parse(self, tool_ctx, monkeypatch):
+        """idle_stall subtype must NOT trigger the timeout pre-check; parse is called."""
+        import dataclasses
+
+        from tests.fakes import _DEFAULT_SKILL_RESULT
+
+        _setup_dispatch(tool_ctx)
+        tool_ctx.executor = InMemoryHeadlessExecutor(
+            default_result=dataclasses.replace(
+                _DEFAULT_SKILL_RESULT,
+                subtype="idle_stall",
+                success=False,
+            )
+        )
+
+        parse_called = []
+
+        def _recording_parse(**kwargs):
+            parse_called.append(True)
+            return _make_no_sentinel()
+
+        monkeypatch.setattr("autoskillit.franchise._api.parse_l2_result_block", _recording_parse)
+
+        await _run(tool_ctx)
+        assert parse_called, "parse_l2_result_block was not called for idle_stall"
+
+
+class TestNoSentinelPath:
+    @pytest.mark.anyio
+    async def test_no_sentinel_writes_state_with_reason_l2_no_result_block(
+        self, tool_ctx, monkeypatch
+    ):
+        """no_sentinel outcome → DispatchRecord.reason = 'l2_no_result_block'."""
+        _setup_dispatch(tool_ctx)
+        monkeypatch.setattr(
+            "autoskillit.franchise._api.parse_l2_result_block",
+            lambda **_: _make_no_sentinel(),
+        )
+
+        await _run(tool_ctx)
+
+        record = _read_dispatch_record(tool_ctx)
+        assert record["reason"] == "l2_no_result_block"
+
+    @pytest.mark.anyio
+    async def test_no_sentinel_clean_exit_is_not_success(self, tool_ctx, monkeypatch):
+        """success=True + exit_code=0 SkillResult but no_sentinel outcome → envelope.success=False."""
+        import dataclasses
+
+        from tests.fakes import _DEFAULT_SKILL_RESULT
+
+        _setup_dispatch(tool_ctx)
+        tool_ctx.executor = InMemoryHeadlessExecutor(
+            default_result=dataclasses.replace(
+                _DEFAULT_SKILL_RESULT,
+                success=True,
+                exit_code=0,
+            )
+        )
+        monkeypatch.setattr(
+            "autoskillit.franchise._api.parse_l2_result_block",
+            lambda **_: _make_no_sentinel(),
+        )
+
+        result = await _run(tool_ctx)
+        assert result["success"] is False
+
+
+class TestCompletedDirtyPath:
+    @pytest.mark.anyio
+    async def test_completed_dirty_writes_state_with_reason_l2_parse_failed(
+        self, tool_ctx, monkeypatch
+    ):
+        """completed_dirty outcome → DispatchRecord.reason = 'l2_parse_failed'."""
+        _setup_dispatch(tool_ctx)
+        monkeypatch.setattr(
+            "autoskillit.franchise._api.parse_l2_result_block",
+            lambda **_: _make_completed_dirty(),
+        )
+
+        await _run(tool_ctx)
+
+        record = _read_dispatch_record(tool_ctx)
+        assert record["reason"] == "l2_parse_failed"
+
+
+class TestCompletedCleanPath:
+    @pytest.mark.anyio
+    async def test_completed_clean_success_writes_empty_reason(self, tool_ctx, monkeypatch):
+        """completed_clean with success=True → DispatchRecord.reason = ''."""
+        _setup_dispatch(tool_ctx)
+        monkeypatch.setattr(
+            "autoskillit.franchise._api.parse_l2_result_block",
+            lambda **_: _make_completed_clean(success=True),
+        )
+
+        await _run(tool_ctx)
+
+        record = _read_dispatch_record(tool_ctx)
+        assert record["reason"] == ""
+
+    @pytest.mark.anyio
+    async def test_completed_clean_failure_writes_reason_from_payload(
+        self, tool_ctx, monkeypatch
+    ):
+        """completed_clean with success=False and payload.reason → DispatchRecord.reason from payload."""
+        _setup_dispatch(tool_ctx)
+        monkeypatch.setattr(
+            "autoskillit.franchise._api.parse_l2_result_block",
+            lambda **_: _make_completed_clean(success=False, reason="my-failure-reason"),
+        )
+
+        await _run(tool_ctx)
+
+        record = _read_dispatch_record(tool_ctx)
+        assert record["reason"] == "my-failure-reason"

--- a/tests/franchise/test_dispatch_lifespan.py
+++ b/tests/franchise/test_dispatch_lifespan.py
@@ -1,0 +1,237 @@
+"""Group G (franchise part): lifespan_started surface + envelope propagation."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from tests.fakes import InMemoryHeadlessExecutor, InMemoryRecipeRepository
+
+pytestmark = [pytest.mark.layer("franchise"), pytest.mark.small]
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers (mirror test_dispatch_failure_semantics.py pattern)
+# ---------------------------------------------------------------------------
+
+
+def _make_standard_recipe(name: str = "test-recipe"):
+    from autoskillit.recipe.schema import Recipe, RecipeKind
+
+    return Recipe(name=name, description="test", ingredients={}, kind=RecipeKind.STANDARD)
+
+
+def _simple_prompt_builder(**kwargs) -> str:
+    return f"prompt-for-{kwargs.get('recipe', 'unknown')}"
+
+
+async def _no_sleep_quota_checker(config, **kwargs) -> dict:
+    return {
+        "should_sleep": False,
+        "sleep_seconds": 0,
+        "utilization": None,
+        "resets_at": None,
+        "window_name": None,
+    }
+
+
+async def _noop_quota_refresher(config, **kwargs) -> None:
+    pass
+
+
+def _setup_dispatch(tool_ctx, recipe_name: str = "test-recipe"):
+    tool_ctx.franchise_lock = asyncio.Lock()
+    repo = InMemoryRecipeRepository()
+    repo.add_recipe(recipe_name, _make_standard_recipe(recipe_name))
+    tool_ctx.recipes = repo
+    tool_ctx.executor = InMemoryHeadlessExecutor()
+
+
+async def _run(tool_ctx, recipe: str = "test-recipe") -> dict:
+    from autoskillit.franchise._api import execute_dispatch
+
+    raw = await execute_dispatch(
+        tool_ctx=tool_ctx,
+        recipe=recipe,
+        task="t",
+        ingredients=None,
+        dispatch_name=None,
+        timeout_sec=None,
+        prompt_builder=_simple_prompt_builder,
+        quota_checker=_no_sleep_quota_checker,
+        quota_refresher=_noop_quota_refresher,
+    )
+    return json.loads(raw)
+
+
+def _make_subprocess_result(tool_use_names: list[str] | None = None):
+    """Build a SubprocessResult whose stdout includes optional tool_use NDJSON blocks."""
+    from autoskillit.core.types import SubprocessResult, TerminationReason
+
+    records = []
+    if tool_use_names:
+        content = [
+            {"type": "tool_use", "name": name, "id": f"tu-{i}"}
+            for i, name in enumerate(tool_use_names)
+        ]
+        records.append(json.dumps({"type": "assistant", "message": {"content": content}}))
+    records.append(
+        json.dumps(
+            {
+                "type": "result",
+                "subtype": "success",
+                "is_error": False,
+                "result": "done",
+                "session_id": "test-session",
+            }
+        )
+    )
+    return SubprocessResult(
+        returncode=0,
+        stdout="\n".join(records),
+        stderr="",
+        termination=TerminationReason.NATURAL_EXIT,
+        pid=12345,
+    )
+
+
+def _make_completed_clean(success: bool):
+    from autoskillit.franchise.result_parser import L2ParseResult
+
+    return L2ParseResult(
+        outcome="completed_clean",
+        payload={"success": success},
+        raw_body=None,
+        parse_error=None,
+        source="stdout",
+    )
+
+
+def _make_no_sentinel():
+    from autoskillit.franchise.result_parser import L2ParseResult
+
+    return L2ParseResult(
+        outcome="no_sentinel",
+        payload=None,
+        raw_body=None,
+        parse_error=None,
+        source="stdout",
+    )
+
+
+def _make_completed_dirty():
+    from autoskillit.franchise.result_parser import L2ParseResult
+
+    return L2ParseResult(
+        outcome="completed_dirty",
+        payload=None,
+        raw_body="bad",
+        parse_error="json error",
+        source="stdout",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Group G: SkillResult.lifespan_started field
+# ---------------------------------------------------------------------------
+
+
+class TestLifespanStartedField:
+    def test_skill_result_lifespan_started_field_exists(self):
+        """SkillResult has a lifespan_started: bool field defaulting to False."""
+        from autoskillit.core import SkillResult
+        from autoskillit.core.types import KillReason, RetryReason
+
+        sr = SkillResult(
+            success=True,
+            result="ok",
+            session_id="",
+            subtype="success",
+            is_error=False,
+            exit_code=0,
+            needs_retry=False,
+            retry_reason=RetryReason.NONE,
+            stderr="",
+        )
+        assert hasattr(sr, "lifespan_started")
+        assert sr.lifespan_started is False
+
+    def test_build_skill_result_sets_lifespan_started_true(self):
+        """Non-empty tool_uses in stdout → _build_skill_result produces lifespan_started=True."""
+        from autoskillit.execution.headless import _build_skill_result
+
+        result = _make_subprocess_result(tool_use_names=["Write", "Edit"])
+        sr = _build_skill_result(result)
+        assert sr.lifespan_started is True
+
+    def test_build_skill_result_sets_lifespan_started_false_no_tool_uses(self):
+        """Empty tool_uses in stdout → _build_skill_result produces lifespan_started=False."""
+        from autoskillit.execution.headless import _build_skill_result
+
+        result = _make_subprocess_result(tool_use_names=None)
+        sr = _build_skill_result(result)
+        assert sr.lifespan_started is False
+
+
+# ---------------------------------------------------------------------------
+# Group G: lifespan_started in dispatch envelopes
+# ---------------------------------------------------------------------------
+
+
+class TestLifespanStartedInEnvelopes:
+    @pytest.mark.anyio
+    async def test_success_envelope_includes_lifespan_started(self, tool_ctx, monkeypatch):
+        """completed_clean success envelope includes 'lifespan_started' key."""
+        import dataclasses
+
+        from tests.fakes import _DEFAULT_SKILL_RESULT
+
+        _setup_dispatch(tool_ctx)
+        tool_ctx.executor = InMemoryHeadlessExecutor(
+            default_result=dataclasses.replace(
+                _DEFAULT_SKILL_RESULT,
+                lifespan_started=True,
+            )
+        )
+        monkeypatch.setattr(
+            "autoskillit.franchise._api.parse_l2_result_block",
+            lambda **_: _make_completed_clean(success=True),
+        )
+
+        result = await _run(tool_ctx)
+        assert result["success"] is True
+        assert "lifespan_started" in result
+        assert result["lifespan_started"] is True
+
+    @pytest.mark.anyio
+    async def test_failure_envelope_includes_lifespan_started_no_sentinel(
+        self, tool_ctx, monkeypatch
+    ):
+        """no_sentinel envelope includes 'lifespan_started' field."""
+        _setup_dispatch(tool_ctx)
+        monkeypatch.setattr(
+            "autoskillit.franchise._api.parse_l2_result_block",
+            lambda **_: _make_no_sentinel(),
+        )
+
+        result = await _run(tool_ctx)
+        assert result["success"] is False
+        assert "lifespan_started" in result
+        assert result["lifespan_started"] is False
+
+    @pytest.mark.anyio
+    async def test_failure_envelope_includes_lifespan_started_completed_dirty(
+        self, tool_ctx, monkeypatch
+    ):
+        """completed_dirty envelope includes 'lifespan_started' field."""
+        _setup_dispatch(tool_ctx)
+        monkeypatch.setattr(
+            "autoskillit.franchise._api.parse_l2_result_block",
+            lambda **_: _make_completed_dirty(),
+        )
+
+        result = await _run(tool_ctx)
+        assert result["success"] is False
+        assert "lifespan_started" in result

--- a/tests/franchise/test_dispatch_lifespan.py
+++ b/tests/franchise/test_dispatch_lifespan.py
@@ -12,11 +12,6 @@ from tests.fakes import InMemoryHeadlessExecutor, InMemoryRecipeRepository
 pytestmark = [pytest.mark.layer("franchise"), pytest.mark.small]
 
 
-# ---------------------------------------------------------------------------
-# Shared helpers (mirror test_dispatch_failure_semantics.py pattern)
-# ---------------------------------------------------------------------------
-
-
 def _make_standard_recipe(name: str = "test-recipe"):
     from autoskillit.recipe.schema import Recipe, RecipeKind
 
@@ -102,11 +97,6 @@ def _make_completed_dirty():
     )
 
 
-# ---------------------------------------------------------------------------
-# Group G: SkillResult.lifespan_started field
-# ---------------------------------------------------------------------------
-
-
 class TestLifespanStartedField:
     def test_skill_result_lifespan_started_field_exists(self):
         """SkillResult has a lifespan_started: bool field defaulting to False."""
@@ -126,11 +116,6 @@ class TestLifespanStartedField:
         )
         assert hasattr(sr, "lifespan_started")
         assert sr.lifespan_started is False
-
-
-# ---------------------------------------------------------------------------
-# Group G: lifespan_started in dispatch envelopes
-# ---------------------------------------------------------------------------
 
 
 class TestLifespanStartedInEnvelopes:

--- a/tests/franchise/test_dispatch_lifespan.py
+++ b/tests/franchise/test_dispatch_lifespan.py
@@ -66,37 +66,6 @@ async def _run(tool_ctx, recipe: str = "test-recipe") -> dict:
     return json.loads(raw)
 
 
-def _make_subprocess_result(tool_use_names: list[str] | None = None):
-    """Build a SubprocessResult whose stdout includes optional tool_use NDJSON blocks."""
-    from autoskillit.core.types import SubprocessResult, TerminationReason
-
-    records = []
-    if tool_use_names:
-        content = [
-            {"type": "tool_use", "name": name, "id": f"tu-{i}"}
-            for i, name in enumerate(tool_use_names)
-        ]
-        records.append(json.dumps({"type": "assistant", "message": {"content": content}}))
-    records.append(
-        json.dumps(
-            {
-                "type": "result",
-                "subtype": "success",
-                "is_error": False,
-                "result": "done",
-                "session_id": "test-session",
-            }
-        )
-    )
-    return SubprocessResult(
-        returncode=0,
-        stdout="\n".join(records),
-        stderr="",
-        termination=TerminationReason.NATURAL_EXIT,
-        pid=12345,
-    )
-
-
 def _make_completed_clean(success: bool):
     from autoskillit.franchise.result_parser import L2ParseResult
 
@@ -142,7 +111,7 @@ class TestLifespanStartedField:
     def test_skill_result_lifespan_started_field_exists(self):
         """SkillResult has a lifespan_started: bool field defaulting to False."""
         from autoskillit.core import SkillResult
-        from autoskillit.core.types import KillReason, RetryReason
+        from autoskillit.core.types import RetryReason
 
         sr = SkillResult(
             success=True,
@@ -156,22 +125,6 @@ class TestLifespanStartedField:
             stderr="",
         )
         assert hasattr(sr, "lifespan_started")
-        assert sr.lifespan_started is False
-
-    def test_build_skill_result_sets_lifespan_started_true(self):
-        """Non-empty tool_uses in stdout → _build_skill_result produces lifespan_started=True."""
-        from autoskillit.execution.headless import _build_skill_result
-
-        result = _make_subprocess_result(tool_use_names=["Write", "Edit"])
-        sr = _build_skill_result(result)
-        assert sr.lifespan_started is True
-
-    def test_build_skill_result_sets_lifespan_started_false_no_tool_uses(self):
-        """Empty tool_uses in stdout → _build_skill_result produces lifespan_started=False."""
-        from autoskillit.execution.headless import _build_skill_result
-
-        result = _make_subprocess_result(tool_use_names=None)
-        sr = _build_skill_result(result)
         assert sr.lifespan_started is False
 
 


### PR DESCRIPTION
## Summary

Add concrete failure classification to the franchise dispatch pipeline: (1) detect L2 subprocess timeout before result-block parsing and emit `L2_TIMEOUT` error envelopes; (2) populate `DispatchRecord.reason` for every failure path; (3) surface `lifespan_started` on `SkillResult` for future #801 P3 integration; (4) propagate `AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT` env var into food truck subprocesses so L2 orchestrators inherit idle-output timeout configuration.

The infrastructure for timeout (runner + `TerminationReason.TIMED_OUT`), result parsing (`parse_l2_result_block` tri-state), and error codes (`FranchiseErrorCode.L2_TIMEOUT/L2_NO_RESULT_BLOCK/L2_PARSE_FAILED`) already exists. This ticket wires the classification logic into `_run_dispatch()` and propagates state metadata.

## Architecture Impact

### Error/Resilience Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 52, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;

    %% ── ENTRY ── %%
    ENTRY([execute_dispatch called])

    %% ── FRANCHISE VALIDATION GATES ── %%
    subgraph FranchiseGates ["FRANCHISE VALIDATION GATES (Fail-Fast)"]
        direction TB
        G_ING["Ingredient type gate<br/>━━━━━━━━━━<br/>values must be str"]
        G_LOCK["Parallel dispatch guard<br/>━━━━━━━━━━<br/>lock.locked() check"]
        G_RECIPE["Recipe lookup<br/>━━━━━━━━━━<br/>find + kind == standard"]
        G_QUOTA["Quota check<br/>━━━━━━━━━━<br/>sleep if should_sleep"]
        G_EXEC["Executor guard<br/>━━━━━━━━━━<br/>ctx.executor is None"]
    end

    %% ── L2 DISPATCH & IDLE TIMEOUT ENV ── %%
    subgraph L2Dispatch ["L2 DISPATCH (dispatch_food_truck)"]
        direction TB
        IDLE_ENV["● idle timeout resolution<br/>━━━━━━━━━━<br/>arg > env var > cfg<br/>injected as env_extras"]
        FOOD_TRUCK["dispatch_food_truck<br/>━━━━━━━━━━<br/>food truck subprocess<br/>on_spawn → _write_pid"]
        LIFESPAN["● SkillResult.lifespan_started<br/>━━━━━━━━━━<br/>bool: L2 invoked MCP tool<br/>propagated from session"]
    end

    %% ── BUILD SKILL RESULT FAILURE PATHS ── %%
    subgraph BuildSkillResult ["● _build_skill_result FAILURE PATHS"]
        direction TB
        BSR_STALE["STALE<br/>━━━━━━━━━━<br/>no activity threshold<br/>needs_retry=True"]
        BSR_IDLE["IDLE_STALL<br/>━━━━━━━━━━<br/>no stdout growth<br/>needs_retry=True"]
        BSR_TIMEOUT["TIMED_OUT<br/>━━━━━━━━━━<br/>subtype=timeout<br/>is_error=True"]
        BSR_CONTAM["PATH_CONTAMINATION<br/>━━━━━━━━━━<br/>output outside cwd<br/>needs_retry=True"]
        BSR_CONTRACT["CONTRACT_RECOVERY<br/>━━━━━━━━━━<br/>wrote artifact but<br/>omitted output token"]
        BSR_BUDGET["BUDGET_EXHAUSTED<br/>━━━━━━━━━━<br/>consecutive failures ><br/>max_consecutive_retries"]
        BSR_ZERO["ZERO_WRITES<br/>━━━━━━━━━━<br/>write-expected skill<br/>zero Edit/Write calls"]
        BSR_CRASHED["CRASHED<br/>━━━━━━━━━━<br/>runner exception<br/>SkillResult.crashed()"]
    end

    %% ── TIMEOUT PRE-CHECK ── %%
    subgraph TimeoutPreCheck ["● TIMEOUT PRE-CHECK (Short-Circuit Gate)"]
        direction TB
        T_CHECK{"skill_result.subtype<br/>== 'timeout'?"}
        T_STATE["Write state: FAILURE<br/>━━━━━━━━━━<br/>reason=l2_timeout<br/>append_dispatch_record"]
    end

    %% ── RESULT PARSING ── %%
    subgraph ResultParse ["RESULT PARSING (parse_l2_result_block)"]
        direction TB
        PARSE["parse_l2_result_block<br/>━━━━━━━━━━<br/>stdout + JSONL fallback<br/>Channel B drain-race"]
        OUT_CLEAN{"outcome ==<br/>completed_clean?"}
        OUT_DIRTY{"outcome ==<br/>completed_dirty?"}
        OUT_NOSENTINEL{"outcome ==<br/>no_sentinel?"}
    end

    %% ── TERMINAL STATES ── %%
    T_SUCCESS([SUCCESS<br/>envelope success=True<br/>+ lifespan_started])
    T_L2FAIL([FAILURE<br/>envelope success=False<br/>from payload reason])
    T_TIMEOUT([L2_TIMEOUT<br/>franchise_error<br/>+ lifespan_started in details])
    T_DIRTY([l2_parse_failed<br/>envelope + raw_body<br/>+ lifespan_started])
    T_NOBLOCK([● l2_no_result_block<br/>envelope success=False<br/>+ lifespan_started])
    T_GATE_ERR([FRANCHISE_ERROR<br/>gate rejection<br/>no dispatch attempted])
    T_CRASH([L2_STARTUP_OR_CRASH<br/>uncaught exception<br/>in _run_dispatch])

    %% ── CONNECTIONS ── %%
    ENTRY --> G_ING
    G_ING -->|"non-str values"| T_GATE_ERR
    G_ING -->|"valid"| G_LOCK
    G_LOCK -->|"locked"| T_GATE_ERR
    G_LOCK -->|"acquired"| G_RECIPE
    G_RECIPE -->|"not found / wrong kind"| T_GATE_ERR
    G_RECIPE -->|"valid standard"| G_QUOTA
    G_QUOTA -->|"sleep if needed"| G_EXEC
    G_EXEC -->|"None"| T_GATE_ERR
    G_EXEC -->|"configured"| IDLE_ENV

    IDLE_ENV --> FOOD_TRUCK
    FOOD_TRUCK --> LIFESPAN
    FOOD_TRUCK -->|"TerminationReason.STALE"| BSR_STALE
    FOOD_TRUCK -->|"TerminationReason.IDLE_STALL"| BSR_IDLE
    FOOD_TRUCK -->|"TerminationReason.TIMED_OUT"| BSR_TIMEOUT
    FOOD_TRUCK -->|"cwd violation"| BSR_CONTAM
    FOOD_TRUCK -->|"artifact without token"| BSR_CONTRACT
    FOOD_TRUCK -->|"runner exception"| BSR_CRASHED
    BSR_CONTRACT -->|"consecutive > max"| BSR_BUDGET
    FOOD_TRUCK -->|"write-expected + 0 writes"| BSR_ZERO

    BSR_STALE -->|"needs_retry=True"| T_CHECK
    BSR_IDLE -->|"needs_retry=True"| T_CHECK
    BSR_TIMEOUT -->|"subtype=timeout"| T_CHECK
    BSR_CONTAM -->|"needs_retry=True"| T_CHECK
    BSR_CONTRACT -->|"needs_retry=True"| T_CHECK
    BSR_BUDGET -->|"needs_retry=False"| T_CHECK
    BSR_ZERO -->|"needs_retry=True"| T_CHECK
    BSR_CRASHED -->|"success=False"| T_CHECK
    LIFESPAN -->|"propagated to SkillResult"| T_CHECK

    T_CHECK -->|"YES"| T_STATE
    T_STATE --> T_TIMEOUT
    T_CHECK -->|"NO"| PARSE

    PARSE --> OUT_CLEAN
    OUT_CLEAN -->|"YES + success=True"| T_SUCCESS
    OUT_CLEAN -->|"YES + success=False"| T_L2FAIL
    OUT_CLEAN -->|"NO"| OUT_DIRTY
    OUT_DIRTY -->|"YES"| T_DIRTY
    OUT_DIRTY -->|"NO"| OUT_NOSENTINEL
    OUT_NOSENTINEL -->|"YES"| T_NOBLOCK

    G_LOCK -.->|"uncaught exception"| T_CRASH

    %% ── CLASS ASSIGNMENTS ── %%
    class ENTRY terminal;
    class G_ING,G_LOCK,G_RECIPE,G_EXEC detector;
    class G_QUOTA phase;
    class IDLE_ENV,LIFESPAN newComponent;
    class FOOD_TRUCK handler;
    class BSR_STALE,BSR_IDLE,BSR_CONTAM,BSR_ZERO gap;
    class BSR_TIMEOUT,BSR_CONTRACT,BSR_BUDGET,BSR_CRASHED gap;
    class T_CHECK stateNode;
    class T_STATE handler;
    class PARSE phase;
    class OUT_CLEAN,OUT_DIRTY,OUT_NOSENTINEL stateNode;
    class T_SUCCESS output;
    class T_L2FAIL,T_TIMEOUT,T_DIRTY,T_NOBLOCK,T_GATE_ERR,T_CRASH terminal;
```

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START([L1: dispatch_food_truck])

    %% ── PHASE 1: INIT_ONLY FIELDS LOCKED AT CONSTRUCTION ──────────────── %%
    subgraph InitFields ["INIT_ONLY FIELDS (locked at construction)"]
        direction LR
        F_dispatch_id["dispatch_id<br/>━━━━━━━━━━<br/>uuid4() — never changes"]
        F_campaign_id["campaign_id<br/>━━━━━━━━━━<br/>kitchen_id at call time"]
        F_l2_pid["_l2_pid list<br/>━━━━━━━━━━<br/>APPEND_ONLY via on_spawn"]
        F_state_path["state_path<br/>━━━━━━━━━━<br/>dispatches/{id}.json"]
    end

    %% ── PHASE 2: SESSION EXECUTION → SkillResult CONSTRUCTION ──────────── %%
    subgraph SessionExec ["● headless.py: _execute_claude_headless → _build_skill_result"]
        direction TB
        BSR["● _build_skill_result<br/>━━━━━━━━━━<br/>SubprocessResult → SkillResult<br/>Constructs INIT_ONLY fields"]
        SR_lifespan["● lifespan_started<br/>━━━━━━━━━━<br/>INIT_ONLY: from session.lifespan_started<br/>True = L2 invoked ≥1 MCP tool"]
        SR_mutable["MUTABLE fields<br/>━━━━━━━━━━<br/>success / subtype / needs_retry<br/>retry_reason"]
    end

    %% ── PHASE 3: MUTATION GATES (in-place dataclasses.replace) ───────────── %%
    subgraph MutationGates ["MUTATION GATES (sequential, each may replace sr)"]
        direction TB
        BG1["BudgetGuard #1<br/>━━━━━━━━━━<br/>needs_retry → False<br/>if consecutive > budget"]
        CRG["CONTRACT_RECOVERY Gate<br/>━━━━━━━━━━<br/>adjudicated_failure + writes≥1<br/>→ needs_retry=True, CONTRACT_RECOVERY"]
        BG2["BudgetGuard #2<br/>━━━━━━━━━━<br/>re-applied after CRG<br/>caps CONTRACT_RECOVERY retries"]
        ZWG["Zero-Write Gate<br/>━━━━━━━━━━<br/>success + write_count=0 + write_expected<br/>→ demote to zero_writes"]
    end

    %% ── PHASE 4: FRANCHISE DISPATCH OUTCOME ROUTING ─────────────────────── %%
    subgraph DispatchRouting ["● franchise/_api.py: Dispatch Outcome Routing"]
        direction TB
        TGate["TIMEOUT PRE-CHECK GATE<br/>━━━━━━━━━━<br/>skill_result.subtype == 'timeout'<br/>→ short-circuit BEFORE parse<br/>idle_stall falls through"]
        ParseCall["parse_l2_result_block<br/>━━━━━━━━━━<br/>Channel A stdout + Channel B JSONL<br/>→ L2ParseResult"]
        OutcomeRouter["Outcome Classifier<br/>━━━━━━━━━━<br/>completed_clean+success → SUCCESS<br/>completed_clean+fail → FAILURE<br/>completed_dirty → l2_parse_failed<br/>no_sentinel → l2_no_result_block"]
    end

    %% ── PHASE 5: DISPATCH RECORD WRITES (append_dispatch_record) ─────────── %%
    subgraph DispatchState ["DispatchRecord State (written to dispatches/{id}.json)"]
        direction LR
        DR_timeout["TIMEOUT PATH<br/>━━━━━━━━━━<br/>status=FAILURE<br/>reason='l2_timeout'<br/>lifespan_started in envelope"]
        DR_normal["NORMAL PATH<br/>━━━━━━━━━━<br/>status=SUCCESS|FAILURE<br/>reason from outcome<br/>lifespan_started in envelope"]
    end

    %% ── PHASE 6: OUTPUT ENVELOPES ────────────────────────────────────────── %%
    subgraph Envelopes ["JSON Envelopes (returned to L3 caller)"]
        direction LR
        ENV_timeout["● L2_TIMEOUT Envelope<br/>━━━━━━━━━━<br/>error=l2_timeout<br/>details.lifespan_started ★<br/>details.dispatch_id<br/>details.token_usage"]
        ENV_clean["Completed-Clean Envelope<br/>━━━━━━━━━━<br/>success=bool<br/>lifespan_started ★<br/>l2_payload / l2_parse_source"]
        ENV_dirty["● Dirty/No-Sentinel Envelope<br/>━━━━━━━━━━<br/>success=False<br/>reason=l2_parse_failed|<br/>l2_no_result_block<br/>lifespan_started ★"]
    end

    %% ── NEW TESTS (★) ────────────────────────────────────────────────────── %%
    subgraph NewTests ["★ NEW TESTS"]
        direction LR
        T_timeout["★ test_dispatch_failure_semantics.py<br/>━━━━━━━━━━<br/>TestTimeoutPath: timeout short-circuit<br/>TestNoSentinelPath: no_sentinel→FAILURE<br/>TestCompletedDirtyPath / CleanPath"]
        T_lifespan["★ test_dispatch_lifespan.py<br/>━━━━━━━━━━<br/>lifespan_started propagation<br/>in timeout + non-timeout paths"]
        T_idle_env["★ test_idle_output_env.py<br/>━━━━━━━━━━<br/>AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT<br/>env var resolution in dispatch_food_truck"]
    end

    %% ── CONNECTIONS ──────────────────────────────────────────────────────── %%
    START --> InitFields
    START --> SessionExec

    BSR --> SR_lifespan
    BSR --> SR_mutable
    SR_mutable --> BG1
    BG1 --> CRG
    CRG --> BG2
    BG2 --> ZWG

    ZWG --> TGate
    TGate -->|"subtype=timeout"| DR_timeout
    TGate -->|"other subtypes"| ParseCall
    ParseCall --> OutcomeRouter
    OutcomeRouter --> DR_normal

    DR_timeout --> ENV_timeout
    DR_normal -->|"completed_clean"| ENV_clean
    DR_normal -->|"dirty/no_sentinel"| ENV_dirty

    SR_lifespan -.->|"propagated"| ENV_timeout
    SR_lifespan -.->|"propagated"| ENV_clean
    SR_lifespan -.->|"propagated"| ENV_dirty

    T_timeout -.->|"covers"| TGate
    T_timeout -.->|"covers"| OutcomeRouter
    T_lifespan -.->|"covers"| SR_lifespan
    T_idle_env -.->|"covers"| SessionExec

    %% ── CLASS ASSIGNMENTS ─────────────────────────────────────────────────── %%
    class START terminal;
    class F_dispatch_id,F_campaign_id,F_state_path detector;
    class F_l2_pid gap;
    class BSR,SR_mutable handler;
    class SR_lifespan gap;
    class BG1,BG2 detector;
    class CRG,ZWG phase;
    class TGate detector;
    class ParseCall,OutcomeRouter phase;
    class DR_timeout,DR_normal stateNode;
    class ENV_timeout,ENV_clean,ENV_dirty output;
    class T_timeout,T_lifespan,T_idle_env newComponent;
```

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 52, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START<br/>execute_dispatch called])
    END_OK([COMPLETE<br/>JSON envelope returned])
    END_ERR([ERROR<br/>franchise_error envelope])

    %% PHASE 1: Dispatch Entry %%
    subgraph Phase1 ["● Dispatch Entry — franchise/_api.py"]
        direction TB
        LockCheck{"lock.locked?<br/>━━━━━━━━━━<br/>Parallel guard"}
        AcquireLock["acquire lock<br/>━━━━━━━━━━<br/>asyncio.Lock"]
        RunDispatch["_run_dispatch<br/>━━━━━━━━━━<br/>inner dispatch body"]
    end

    %% PHASE 2: Validation & Quota %%
    subgraph Phase2 ["● Validation & Quota — franchise/_api.py"]
        direction TB
        RecipeFind{"recipe_obj found?<br/>━━━━━━━━━━<br/>kind == standard?"}
        QuotaCheck["quota_checker<br/>━━━━━━━━━━<br/>check utilization"]
        QuotaSleep{"should_sleep?<br/>━━━━━━━━━━<br/>asyncio.sleep if yes"}
        WriteInitState["write_initial_state<br/>━━━━━━━━━━<br/>dispatch_{id}.json"]
    end

    %% PHASE 3: Idle Timeout Resolution %%
    subgraph Phase3 ["● Idle Timeout Resolution — execution/headless.py"]
        direction TB
        IdlePriority{"idle_output_timeout arg?<br/>━━━━━━━━━━<br/>3-level priority chain"}
        IdleEnv["read AUTOSKILLIT_<br/>IDLE_OUTPUT_TIMEOUT env<br/>━━━━━━━━━━<br/>Level 2: env beats cfg"]
        IdleCfg["cfg.idle_output_timeout<br/>━━━━━━━━━━<br/>Level 3: config default"]
        InjectEnv["inject into env_extras<br/>━━━━━━━━━━<br/>AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT<br/>for L2 subprocess"]
    end

    %% PHASE 4: Subprocess Execution %%
    subgraph Phase4 ["● Subprocess Execution — execution/headless.py"]
        direction TB
        RunnerCall["runner subprocess<br/>━━━━━━━━━━<br/>pty_mode=True<br/>completion_marker set"]
        ExcHandler{"exception?<br/>━━━━━━━━━━<br/>OSError / BaseException"}
        BuildResult["● _build_skill_result<br/>━━━━━━━━━━<br/>SubprocessResult →<br/>SkillResult"]
        LifespanField["★ SkillResult.lifespan_started<br/>━━━━━━━━━━<br/>bool: MCP tool invoked?<br/>heuristic for server lifespan"]
    end

    %% PHASE 5: Timeout Pre-check %%
    subgraph Phase5 ["● Timeout Pre-check — franchise/_api.py (NEW)"]
        direction TB
        TimeoutCheck{"skill_result.subtype<br/>== 'timeout'?<br/>━━━━━━━━━━<br/>short-circuit gate"}
        TimeoutRecord["append_dispatch_record<br/>━━━━━━━━━━<br/>status=failure<br/>reason='l2_timeout'"]
    end

    %% PHASE 6: Result Parsing %%
    subgraph Phase6 ["Result Parsing — franchise/result_parser.py"]
        direction TB
        ParseBlock["parse_l2_result_block<br/>━━━━━━━━━━<br/>stdout + JSONL fallback<br/>Channel B drain-race"]
        OutcomeRoute{"parsed.outcome?<br/>━━━━━━━━━━<br/>3-way branch"}
    end

    %% PHASE 7: Envelope Construction %%
    subgraph Phase7 ["● Envelope Construction — franchise/_api.py"]
        direction TB
        EnvCleanOK["completed_clean + success<br/>━━━━━━━━━━<br/>success=True<br/>+ lifespan_started"]
        EnvCleanFail["completed_clean + failure<br/>━━━━━━━━━━<br/>success=False<br/>reason from payload<br/>+ lifespan_started"]
        EnvDirty["completed_dirty<br/>━━━━━━━━━━<br/>success=False<br/>reason='l2_parse_failed'<br/>+ lifespan_started"]
        EnvNoSentinel["● no_sentinel<br/>━━━━━━━━━━<br/>success=False<br/>reason='l2_no_result_block'<br/>+ lifespan_started"]
    end

    %% FLOW %%
    START --> LockCheck
    LockCheck -->|"locked"| END_ERR
    LockCheck -->|"free"| AcquireLock
    AcquireLock --> RunDispatch
    RunDispatch --> RecipeFind

    RecipeFind -->|"not found / wrong kind"| END_ERR
    RecipeFind -->|"valid standard recipe"| QuotaCheck
    QuotaCheck --> QuotaSleep
    QuotaSleep -->|"sleep if needed"| WriteInitState
    WriteInitState --> IdlePriority

    IdlePriority -->|"arg != None (Level 1)"| InjectEnv
    IdlePriority -->|"arg is None"| IdleEnv
    IdleEnv -->|"env var set"| InjectEnv
    IdleEnv -->|"env var absent"| IdleCfg
    IdleCfg --> InjectEnv
    InjectEnv --> RunnerCall

    RunnerCall --> ExcHandler
    ExcHandler -->|"OSError / crash"| END_ERR
    ExcHandler -->|"no exception"| BuildResult
    BuildResult --> LifespanField
    LifespanField --> TimeoutCheck

    TimeoutCheck -->|"subtype == 'timeout'"| TimeoutRecord
    TimeoutRecord --> END_ERR

    TimeoutCheck -->|"other subtypes fall through<br/>(idle_stall, error, etc.)"| ParseBlock
    ParseBlock --> OutcomeRoute

    OutcomeRoute -->|"completed_clean + success=True"| EnvCleanOK
    OutcomeRoute -->|"completed_clean + success=False"| EnvCleanFail
    OutcomeRoute -->|"completed_dirty"| EnvDirty
    OutcomeRoute -->|"no_sentinel"| EnvNoSentinel

    EnvCleanOK --> END_OK
    EnvCleanFail --> END_OK
    EnvDirty --> END_OK
    EnvNoSentinel --> END_OK

    %% CLASS ASSIGNMENTS %%
    class START,END_OK,END_ERR terminal;
    class LockCheck,RecipeFind,QuotaSleep,ExcHandler,IdlePriority,TimeoutCheck,OutcomeRoute detector;
    class AcquireLock,RunDispatch,QuotaCheck,WriteInitState handler;
    class IdleEnv,IdleCfg,InjectEnv phase;
    class RunnerCall,BuildResult handler;
    class LifespanField newComponent;
    class TimeoutRecord,ParseBlock handler;
    class EnvCleanOK,EnvCleanFail,EnvDirty,EnvNoSentinel output;
```

Closes #877

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260421-221949-550220/.autoskillit/temp/make-plan/franchise_l2_timeout_no_result_block_failure_semantics_plan_2026-04-21_222500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 3.6k | 16.6k | 1.1M | 94.3k | 1 | 10m 5s |
| review | 25 | 7.7k | 218.3k | 39.1k | 1 | 8m 42s |
| verify | 57 | 16.3k | 1.1M | 60.2k | 1 | 6m 15s |
| implement | 480 | 38.4k | 4.7M | 111.0k | 1 | 12m 13s |
| fix | 288 | 14.8k | 1.9M | 59.2k | 1 | 8m 52s |
| prepare_pr | 60 | 4.7k | 196.4k | 25.8k | 1 | 1m 29s |
| run_arch_lenses | 207 | 21.8k | 1.0M | 191.4k | 3 | 6m 40s |
| compose_pr | 67 | 9.9k | 260.8k | 36.5k | 1 | 2m 45s |
| **Total** | 4.8k | 130.3k | 10.5M | 617.5k | | 57m 4s |