### PR TITLE
Franchise Status CLI with --cleanup / --reap / --watch / --json

### DIFF
--- a/src/autoskillit/cli/_franchise.py
+++ b/src/autoskillit/cli/_franchise.py
@@ -9,6 +9,7 @@ import os
 import shutil
 import signal
 import sys
+import time
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
@@ -21,7 +22,7 @@ import anyio.abc
 import psutil
 from cyclopts import App, Parameter
 
-from autoskillit.core import get_logger
+from autoskillit.core import TerminalColumn, get_logger
 from autoskillit.franchise import (
     DispatchStatus,
     mark_dispatch_interrupted,
@@ -31,8 +32,248 @@ from autoskillit.franchise import (
 _log = get_logger(__name__)
 
 if TYPE_CHECKING:
-    from autoskillit.franchise import ResumeDecision
+    from autoskillit.franchise import CampaignState, DispatchRecord, ResumeDecision
     from autoskillit.recipe.schema import Recipe
+
+_FAILURE_STATUSES = frozenset(
+    {
+        DispatchStatus.FAILURE,
+        DispatchStatus.INTERRUPTED,
+        DispatchStatus.REFUSED,
+        DispatchStatus.RELEASED,
+    }
+)
+
+_IN_PROGRESS_STATUSES = frozenset(
+    {
+        DispatchStatus.RUNNING,
+        DispatchStatus.PENDING,
+    }
+)
+
+_STATUS_COLUMNS = (
+    TerminalColumn("NAME", 30, "<"),
+    TerminalColumn("STATUS", 12, "<"),
+    TerminalColumn("ELAPSED", 10, ">"),
+    TerminalColumn("INPUT", 10, ">"),
+    TerminalColumn("OUTPUT", 10, ">"),
+    TerminalColumn("CACHE_RD", 10, ">"),
+    TerminalColumn("CACHE_WR", 10, ">"),
+    TerminalColumn("SESSION_LOG", None, "<"),
+)
+
+
+def _compute_exit_code(state: CampaignState) -> int:
+    """Compute CLI exit code from dispatch statuses.
+
+    0 = all success/skipped, 1 = any failure, 2 = any in-progress.
+    """
+    has_failure = any(d.status in _FAILURE_STATUSES for d in state.dispatches)
+    has_in_progress = any(d.status in _IN_PROGRESS_STATUSES for d in state.dispatches)
+    if has_failure:
+        return 1
+    if has_in_progress:
+        return 2
+    return 0
+
+
+def _fmt_elapsed(dispatch: DispatchRecord) -> str:
+    """Format dispatch elapsed time as human-readable string."""
+    if dispatch.started_at <= 0:
+        return "-"
+    if dispatch.status == DispatchStatus.RUNNING:
+        seconds = time.time() - dispatch.started_at
+    elif dispatch.ended_at > 0:
+        seconds = dispatch.ended_at - dispatch.started_at
+    else:
+        return "-"
+    seconds = max(0, seconds)
+    if seconds < 60:
+        return f"{seconds:.0f}s"
+    minutes = int(seconds // 60)
+    secs = int(seconds % 60)
+    if minutes < 60:
+        return f"{minutes}m {secs}s"
+    hours = minutes // 60
+    mins = minutes % 60
+    return f"{hours}h {mins}m"
+
+
+def _humanize(n: int | float | None) -> str:
+    """Humanize token counts: 1234 -> '1.2k', 1234567 -> '1.2M'."""
+    if n is None or n == 0:
+        return "0"
+    if not isinstance(n, (int, float)):
+        return "0"
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    if n >= 1_000:
+        return f"{n / 1_000:.1f}k"
+    return str(int(n))
+
+
+def _build_status_rows(state: CampaignState) -> list[tuple[str, ...]]:
+    """Build table rows from campaign state dispatches."""
+    rows: list[tuple[str, ...]] = []
+    for d in state.dispatches:
+        tu = d.token_usage
+        rows.append(
+            (
+                d.name,
+                str(d.status),
+                _fmt_elapsed(d),
+                _humanize(tu.get("input_tokens", 0)),
+                _humanize(tu.get("output_tokens", 0)),
+                _humanize(tu.get("cache_read_input_tokens", 0)),
+                _humanize(tu.get("cache_creation_input_tokens", 0)),
+                d.l2_session_log_dir or "-",
+            )
+        )
+    return rows
+
+
+def _aggregate_totals(state: CampaignState) -> dict[str, int]:
+    """Sum token_usage across all dispatches."""
+    totals: dict[str, int] = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read": 0,
+        "cache_creation": 0,
+    }
+    for d in state.dispatches:
+        tu = d.token_usage
+        totals["input_tokens"] += tu.get("input_tokens", 0)
+        totals["output_tokens"] += tu.get("output_tokens", 0)
+        totals["cache_read"] += tu.get("cache_read_input_tokens", 0)
+        totals["cache_creation"] += tu.get("cache_creation_input_tokens", 0)
+    return totals
+
+
+def _cross_check_tokens(state: CampaignState, state_totals: dict[str, int]) -> None:
+    """Warn on >5% token divergence between state.json and sessions.jsonl."""
+    from autoskillit.execution.session_log import resolve_log_dir
+    from autoskillit.pipeline.tokens import DefaultTokenLog
+
+    log_root = resolve_log_dir("")
+    sessions_index = log_root / "sessions.jsonl"
+    if not sessions_index.exists():
+        return
+
+    token_log = DefaultTokenLog()
+    loaded = token_log.load_from_log_dir(log_root, campaign_id_filter=state.campaign_id)
+    if loaded == 0:
+        return
+
+    log_totals = token_log.compute_total()
+
+    for label, state_key, log_key in [
+        ("input_tokens", "input_tokens", "input_tokens"),
+        ("output_tokens", "output_tokens", "output_tokens"),
+        ("cache_read", "cache_read", "cache_read_input_tokens"),
+        ("cache_creation", "cache_creation", "cache_creation_input_tokens"),
+    ]:
+        sv = state_totals.get(state_key, 0)
+        lv = log_totals.get(log_key, 0)
+        if sv > 0 and abs(sv - lv) / sv > 0.05:
+            sys.stderr.write(
+                f"WARNING: {label} diverge {abs(sv - lv) / sv:.1%} (>5%)"
+                f" (state={sv}, sessionlog={lv}); state.json wins\n"
+            )
+
+
+def _render_status_display(state: CampaignState) -> int:
+    """Print campaign header and 8-column dispatch table to stdout.
+
+    Returns the number of lines printed (for cursor-based screen refresh).
+    """
+    from autoskillit.cli._ansi import _render_terminal_table
+
+    started = datetime.fromtimestamp(state.started_at, tz=UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
+    header = f"Campaign: {state.campaign_name}  ID: {state.campaign_id}  Started: {started}"
+    print(header)
+
+    rows = _build_status_rows(state)
+    totals = _aggregate_totals(state)
+    rows.append(("─" * 6, "", "", "", "", "", "", ""))
+    rows.append(
+        (
+            "TOTAL",
+            "",
+            "",
+            _humanize(totals["input_tokens"]),
+            _humanize(totals["output_tokens"]),
+            _humanize(totals["cache_read"]),
+            _humanize(totals["cache_creation"]),
+            "",
+        )
+    )
+    table_str = _render_terminal_table(_STATUS_COLUMNS, rows)
+    print(table_str)
+    return 1 + table_str.count("\n") + 1
+
+
+def _watch_loop(state_path: Path) -> int:
+    """1 Hz polling loop for franchise status. Returns exit code."""
+    import select
+    import termios
+    import tty
+
+    state = read_state(state_path)
+    if state is None:
+        sys.stderr.write("ERROR: state file disappeared or corrupted\n")
+        return 3
+
+    # If campaign already terminal, render once and exit without needing a TTY
+    if all(d.status not in _IN_PROGRESS_STATUSES for d in state.dispatches):
+        _render_status_display(state)
+        print("\nAll dispatches complete.")
+        return _compute_exit_code(state)
+
+    if not sys.stdin.isatty() or not sys.stdout.isatty():
+        sys.stderr.write(
+            "ERROR: --watch requires an interactive terminal"
+            " (both stdin and stdout must be TTYs).\n"
+        )
+        return 1
+
+    fd = sys.stdin.fileno()
+    old_settings = termios.tcgetattr(fd)
+    prev_lines = 0
+    try:
+        tty.setcbreak(fd)
+        while True:
+            state = read_state(state_path)
+            if state is None:
+                sys.stderr.write("ERROR: state file disappeared or corrupted\n")
+                return 3
+
+            if prev_lines > 0:
+                sys.stdout.write(f"\033[{prev_lines}A")
+                for _ in range(prev_lines):
+                    sys.stdout.write("\033[2K\033[1B")
+                sys.stdout.write(f"\033[{prev_lines}A")
+            sys.stdout.flush()
+
+            prev_lines = _render_status_display(state)
+
+            if all(d.status not in _IN_PROGRESS_STATUSES for d in state.dispatches):
+                print("\nAll dispatches complete.")
+                return _compute_exit_code(state)
+
+            rlist, _, _ = select.select([sys.stdin], [], [], 1.0)
+            if rlist:
+                ch = sys.stdin.read(1)
+                if ch.lower() == "q":
+                    return _compute_exit_code(state)
+    except KeyboardInterrupt:
+        state = read_state(state_path)
+        return _compute_exit_code(state) if state else 3
+    finally:
+        try:
+            termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+        except (termios.error, OSError):
+            pass
+
 
 franchise_app = App(name="franchise", help="Campaign franchise management.")
 
@@ -429,8 +670,6 @@ def franchise_status(
     json_output: Annotated[bool, Parameter(name=["--json"])] = False,
 ) -> None:
     """Show franchise campaign status."""
-    from autoskillit.core import TerminalColumn, _render_terminal_table
-
     franchise_dir = Path.cwd() / ".autoskillit" / "temp" / "franchise"
 
     if campaign_id is not None:
@@ -438,30 +677,25 @@ def franchise_status(
         state = read_state(state_path)
         if state is None:
             print(f"ERROR: Campaign '{campaign_id}' not found or state corrupted.")
-            sys.exit(1)
+            sys.exit(3)
 
         if json_output:
+            totals = _aggregate_totals(state)
             data = {
                 "campaign_id": state.campaign_id,
                 "campaign_name": state.campaign_name,
                 "started_at": state.started_at,
                 "dispatches": [d.to_dict() for d in state.dispatches],
+                "totals": totals,
             }
             print(json.dumps(data))
-            return
+            _cross_check_tokens(state, totals)
+            sys.exit(_compute_exit_code(state))
 
-        started = datetime.fromtimestamp(state.started_at, tz=UTC).strftime(
-            "%Y-%m-%d %H:%M:%S UTC"
-        )
-        print(f"Campaign: {state.campaign_name}  ID: {state.campaign_id}  Started: {started}")
-        columns = [
-            TerminalColumn("NAME", 30, "<"),
-            TerminalColumn("STATUS", 12, "<"),
-            TerminalColumn("DISPATCH_ID", 36, "<"),
-            TerminalColumn("REASON", 40, "<"),
-        ]
-        rows = [(d.name, str(d.status), d.dispatch_id, d.reason) for d in state.dispatches]
-        print(_render_terminal_table(columns, rows))
+        if watch:
+            sys.exit(_watch_loop(state_path))
+
+        _render_status_display(state)
 
         if cleanup:
             from autoskillit.core import sweep_stale_markers
@@ -478,21 +712,32 @@ def franchise_status(
                     provider=SkillsDirectoryProvider(),
                     ephemeral_root=resolve_ephemeral_root(),
                 )
+                for d in state.dispatches:
+                    if d.l2_session_id:
+                        skill_mgr.cleanup_session(d.l2_session_id)
                 skill_mgr.cleanup_session(campaign_id)
             except Exception:
                 _log.warning(
                     "Session skill cleanup failed for campaign %s", campaign_id, exc_info=True
                 )
             sweep_stale_markers()
+            kitchen_state_dir = (
+                Path.cwd() / ".autoskillit" / "temp" / "kitchen_state" / campaign_id
+            )
+            if kitchen_state_dir.is_dir():
+                shutil.rmtree(kitchen_state_dir, ignore_errors=True)
             print(f"Cleanup complete for campaign '{campaign_id}'.")
 
         if reap or dry_run:
             _reap_stale_dispatches(state_path, dry_run=dry_run)
 
-        if watch:
-            raise NotImplementedError("--watch is not yet implemented.")
+        totals = _aggregate_totals(state)
+        _cross_check_tokens(state, totals)
+        sys.exit(_compute_exit_code(state))
 
     else:
+        from autoskillit.core import _render_terminal_table
+
         if not franchise_dir.exists():
             print("No campaigns found.")
             return
@@ -529,19 +774,19 @@ def franchise_status(
             TerminalColumn("DISPATCHES", 10, "<"),
             TerminalColumn("STARTED", 24, "<"),
         ]
-        rows = []
+        rows_list = []
         for subdir in sorted(subdirs):
             s = read_state(subdir / "state.json")
             if s is None:
                 continue
             started = datetime.fromtimestamp(s.started_at, tz=UTC).strftime("%Y-%m-%d %H:%M UTC")
-            rows.append((s.campaign_name, s.campaign_id, str(len(s.dispatches)), started))
+            rows_list.append((s.campaign_name, s.campaign_id, str(len(s.dispatches)), started))
 
-        if not rows:
+        if not rows_list:
             print("No campaigns found.")
             return
 
-        print(_render_terminal_table(columns, rows))
+        print(_render_terminal_table(columns, rows_list))
 
 
 def render_franchise_error(envelope_json: str) -> int:

--- a/src/autoskillit/cli/_franchise.py
+++ b/src/autoskillit/cli/_franchise.py
@@ -151,8 +151,8 @@ def _aggregate_totals(state: CampaignState) -> dict[str, int]:
 
 def _cross_check_tokens(state: CampaignState, state_totals: dict[str, int]) -> None:
     """Warn on >5% token divergence between state.json and sessions.jsonl."""
-    from autoskillit.execution.session_log import resolve_log_dir
-    from autoskillit.pipeline.tokens import DefaultTokenLog
+    from autoskillit.execution import resolve_log_dir
+    from autoskillit.pipeline import DefaultTokenLog
 
     log_root = resolve_log_dir("")
     sessions_index = log_root / "sessions.jsonl"

--- a/src/autoskillit/cli/_franchise.py
+++ b/src/autoskillit/cli/_franchise.py
@@ -277,6 +277,7 @@ def _watch_loop(state_path: Path) -> int:
         state = read_state(state_path)
         return _compute_exit_code(state) if state else 3
     except Exception as exc:
+        _log.error("unexpected error in --watch loop: %s", exc, exc_info=True)
         sys.stderr.write(f"ERROR: unexpected error in --watch loop: {exc}\n")
         return 3
     finally:

--- a/src/autoskillit/cli/_franchise.py
+++ b/src/autoskillit/cli/_franchise.py
@@ -113,7 +113,7 @@ def _humanize(n: int | float | None) -> str:
 
 
 def _build_status_rows(state: CampaignState) -> list[tuple[str, ...]]:
-    """Build table rows from campaign state dispatches."""
+    """Build table rows from campaign state dispatches, including separator and TOTAL rows."""
     rows: list[tuple[str, ...]] = []
     for d in state.dispatches:
         tu = d.token_usage
@@ -129,6 +129,20 @@ def _build_status_rows(state: CampaignState) -> list[tuple[str, ...]]:
                 d.l2_session_log_dir or "-",
             )
         )
+    totals = _aggregate_totals(state)
+    rows.append(("─" * 6, "", "", "", "", "", "", ""))
+    rows.append(
+        (
+            "TOTAL",
+            "",
+            "",
+            _humanize(totals["input_tokens"]),
+            _humanize(totals["output_tokens"]),
+            _humanize(totals["cache_read"]),
+            _humanize(totals["cache_creation"]),
+            "",
+        )
+    )
     return rows
 
 
@@ -149,22 +163,29 @@ def _aggregate_totals(state: CampaignState) -> dict[str, int]:
     return totals
 
 
-def _cross_check_tokens(state: CampaignState, state_totals: dict[str, int]) -> None:
-    """Warn on >5% token divergence between state.json and sessions.jsonl."""
+def _load_log_totals(state: CampaignState) -> dict[str, int] | None:
+    """Load token totals from sessions.jsonl for the campaign. Returns None if unavailable."""
     from autoskillit.execution import resolve_log_dir
     from autoskillit.pipeline import DefaultTokenLog
 
     log_root = resolve_log_dir("")
     sessions_index = log_root / "sessions.jsonl"
     if not sessions_index.exists():
-        return
+        return None
 
     token_log = DefaultTokenLog()
     loaded = token_log.load_from_log_dir(log_root, campaign_id_filter=state.campaign_id)
     if loaded == 0:
-        return
+        return None
 
-    log_totals = token_log.compute_total()
+    return token_log.compute_total()
+
+
+def _cross_check_tokens(state: CampaignState, state_totals: dict[str, int]) -> None:
+    """Warn on >5% token divergence between state.json and sessions.jsonl."""
+    log_totals = _load_log_totals(state)
+    if log_totals is None:
+        return
 
     for label, state_key, log_key in [
         ("input_tokens", "input_tokens", "input_tokens"),
@@ -193,23 +214,9 @@ def _render_status_display(state: CampaignState) -> int:
     print(header)
 
     rows = _build_status_rows(state)
-    totals = _aggregate_totals(state)
-    rows.append(("─" * 6, "", "", "", "", "", "", ""))
-    rows.append(
-        (
-            "TOTAL",
-            "",
-            "",
-            _humanize(totals["input_tokens"]),
-            _humanize(totals["output_tokens"]),
-            _humanize(totals["cache_read"]),
-            _humanize(totals["cache_creation"]),
-            "",
-        )
-    )
     table_str = _render_terminal_table(_STATUS_COLUMNS, rows)
     print(table_str)
-    return 1 + table_str.count("\n") + 1
+    return 1 + table_str.rstrip("\n").count("\n") + 1
 
 
 def _watch_loop(state_path: Path) -> int:
@@ -244,6 +251,7 @@ def _watch_loop(state_path: Path) -> int:
         while True:
             state = read_state(state_path)
             if state is None:
+                sys.stdout.flush()
                 sys.stderr.write("ERROR: state file disappeared or corrupted\n")
                 return 3
 
@@ -268,6 +276,9 @@ def _watch_loop(state_path: Path) -> int:
     except KeyboardInterrupt:
         state = read_state(state_path)
         return _compute_exit_code(state) if state else 3
+    except Exception as exc:
+        sys.stderr.write(f"ERROR: unexpected error in --watch loop: {exc}\n")
+        return 3
     finally:
         try:
             termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
@@ -691,6 +702,10 @@ def franchise_status(
             print(json.dumps(data))
             _cross_check_tokens(state, totals)
             sys.exit(_compute_exit_code(state))
+
+        if watch and cleanup:
+            print("ERROR: --watch and --cleanup are mutually exclusive.")
+            sys.exit(3)
 
         if watch:
             sys.exit(_watch_loop(state_path))

--- a/tests/arch/test_layer_enforcement.py
+++ b/tests/arch/test_layer_enforcement.py
@@ -1042,6 +1042,7 @@ def test_default_classes_only_instantiated_inside_factory_or_allowlist() -> None
         Path("cli/_franchise.py"): {
             "DefaultSessionSkillManager",  # interactive cleanup
             "DefaultWorkspaceManager",  # signal guard cleanup
+            "DefaultTokenLog",  # cross-check token diagnostic
         },
         Path("cli/app.py"): {"DefaultSkillResolver"},  # skill listing command
         Path("execution/recording.py"): {"DefaultSubprocessRunner"},  # lazy fallback

--- a/tests/cli/test_franchise_cli.py
+++ b/tests/cli/test_franchise_cli.py
@@ -8,10 +8,14 @@ import shutil
 import subprocess
 import time
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import pytest
 from cyclopts import App
+
+if TYPE_CHECKING:
+    from autoskillit.franchise import CampaignState
 
 from autoskillit.cli._franchise import franchise_list as _franchise_list
 from autoskillit.cli._franchise import franchise_run as _franchise_run
@@ -145,7 +149,7 @@ def _setup_campaign_with_sessions(
     )
 
 
-def _make_state(*, statuses: list[str]):  # type: ignore[no-untyped-def]
+def _make_state(*, statuses: list[str]) -> CampaignState:
     """Build an in-memory CampaignState for unit-testing _compute_exit_code."""
     from autoskillit.franchise import CampaignState, DispatchRecord, DispatchStatus
 
@@ -162,7 +166,7 @@ def _make_state(*, statuses: list[str]):  # type: ignore[no-untyped-def]
     )
 
 
-def _make_state_with_tokens(*, input_total: int):  # type: ignore[no-untyped-def]
+def _make_state_with_tokens(*, input_total: int) -> CampaignState:
     """Build an in-memory CampaignState with known token totals."""
     from autoskillit.franchise import CampaignState, DispatchRecord, DispatchStatus
 
@@ -702,6 +706,9 @@ def test_status_table_shows_totals_row(
         _franchise_status("cid01")
     out = capsys.readouterr().out
     assert "TOTAL" in out.upper()
+    # Verify the humanized token values actually appear in the TOTAL row
+    assert "100" in out  # input_tokens=100 → "100"
+    assert "50" in out  # output_tokens=50 → "50"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_franchise_cli.py
+++ b/tests/cli/test_franchise_cli.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import io
 import json
 import shutil
 import subprocess
+import time
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -75,6 +77,109 @@ def _setup_existing_campaign_state(tmp_path: Path, campaign_id: str, campaign_na
     dispatches = [DispatchRecord(name="dispatch-1")]
     write_initial_state(
         state_dir / "state.json", campaign_id, campaign_name, "manifest.yaml", dispatches
+    )
+
+
+def _setup_campaign_with_tokens(
+    tmp_path: Path,
+    campaign_id: str,
+    campaign_name: str,
+    *,
+    token_usage: dict | None = None,
+) -> None:
+    """Create a state.json with a succeeded dispatch and token usage."""
+    from autoskillit.franchise import DispatchRecord, DispatchStatus, write_initial_state
+
+    state_dir = tmp_path / ".autoskillit" / "temp" / "franchise" / campaign_id
+    state_dir.mkdir(parents=True)
+    if token_usage is None:
+        token_usage = {}
+    now = time.time()
+    dispatches = [
+        DispatchRecord(
+            name="dispatch-1",
+            status=DispatchStatus.SUCCESS,
+            token_usage=token_usage,
+            l2_session_log_dir="/tmp/test-session-log",
+            started_at=now - 60.0,
+            ended_at=now,
+        )
+    ]
+    write_initial_state(
+        state_dir / "state.json", campaign_id, campaign_name, "manifest.yaml", dispatches
+    )
+
+
+def _setup_campaign_with_status(
+    tmp_path: Path, campaign_id: str, campaign_name: str, *, status: str
+) -> None:
+    """Create a state.json with a single dispatch at a given status."""
+    from autoskillit.franchise import DispatchRecord, DispatchStatus, write_initial_state
+
+    state_dir = tmp_path / ".autoskillit" / "temp" / "franchise" / campaign_id
+    state_dir.mkdir(parents=True)
+    dispatches = [DispatchRecord(name="dispatch-1", status=DispatchStatus(status))]
+    write_initial_state(
+        state_dir / "state.json", campaign_id, campaign_name, "manifest.yaml", dispatches
+    )
+
+
+def _setup_campaign_with_sessions(
+    tmp_path: Path,
+    campaign_id: str,
+    campaign_name: str,
+    *,
+    dispatches: list[tuple[str, str, str]],
+) -> None:
+    """Create a state.json with dispatches that have l2_session_id set."""
+    from autoskillit.franchise import DispatchRecord, DispatchStatus, write_initial_state
+
+    state_dir = tmp_path / ".autoskillit" / "temp" / "franchise" / campaign_id
+    state_dir.mkdir(parents=True)
+    records = [
+        DispatchRecord(name=name, status=DispatchStatus(status), l2_session_id=session_id)
+        for name, status, session_id in dispatches
+    ]
+    write_initial_state(
+        state_dir / "state.json", campaign_id, campaign_name, "manifest.yaml", records
+    )
+
+
+def _make_state(*, statuses: list[str]):  # type: ignore[no-untyped-def]
+    """Build an in-memory CampaignState for unit-testing _compute_exit_code."""
+    from autoskillit.franchise import CampaignState, DispatchRecord, DispatchStatus
+
+    dispatches = [
+        DispatchRecord(name=f"d{i}", status=DispatchStatus(s)) for i, s in enumerate(statuses)
+    ]
+    return CampaignState(
+        schema_version=2,
+        campaign_id="test-id",
+        campaign_name="test",
+        manifest_path="manifest.yaml",
+        started_at=0.0,
+        dispatches=dispatches,
+    )
+
+
+def _make_state_with_tokens(*, input_total: int):  # type: ignore[no-untyped-def]
+    """Build an in-memory CampaignState with known token totals."""
+    from autoskillit.franchise import CampaignState, DispatchRecord, DispatchStatus
+
+    dispatches = [
+        DispatchRecord(
+            name="dispatch-1",
+            status=DispatchStatus.SUCCESS,
+            token_usage={"input_tokens": input_total},
+        )
+    ]
+    return CampaignState(
+        schema_version=2,
+        campaign_id="test-id",
+        campaign_name="test",
+        manifest_path="manifest.yaml",
+        started_at=0.0,
+        dispatches=dispatches,
     )
 
 
@@ -241,7 +346,7 @@ def test_franchise_list_shows_campaigns(
 
 
 # ---------------------------------------------------------------------------
-# T10. franchise status — reads state.json
+# T10 (existing). franchise status — reads state.json (updated for exit code)
 # ---------------------------------------------------------------------------
 
 
@@ -251,30 +356,32 @@ def test_franchise_status_shows_dispatches(
     """franchise status shows dispatch table from state.json."""
     _setup_existing_campaign_state(tmp_path, "abc123", "test-campaign")
     monkeypatch.chdir(tmp_path)
-    _franchise_status("abc123")
+    with pytest.raises(SystemExit):
+        _franchise_status("abc123")
     output = capsys.readouterr().out
     assert "test-campaign" in output
 
 
 # ---------------------------------------------------------------------------
-# T11. franchise status — JSON output
+# T11 (existing). franchise status — JSON output (updated for exit code)
 # ---------------------------------------------------------------------------
 
 
 def test_franchise_status_json_flag(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
 ) -> None:
-    """--json produces valid JSON output."""
+    """--json produces valid JSON output with campaign_id."""
     _setup_existing_campaign_state(tmp_path, "abc123", "test-campaign")
     monkeypatch.chdir(tmp_path)
-    _franchise_status("abc123", json_output=True)
+    with pytest.raises(SystemExit):
+        _franchise_status("abc123", json_output=True)
     output = capsys.readouterr().out
     data = json.loads(output)
     assert data["campaign_id"] == "abc123"
 
 
 # ---------------------------------------------------------------------------
-# T12. franchise status — cleanup
+# T12 (existing). franchise status — cleanup (updated for exit code)
 # ---------------------------------------------------------------------------
 
 
@@ -285,7 +392,8 @@ def test_franchise_status_cleanup_calls_batch_delete(
     _setup_existing_campaign_state(tmp_path, "abc123", "test-campaign")
     monkeypatch.chdir(tmp_path)
     mock_delete = _mock_batch_delete(monkeypatch)
-    _franchise_status("abc123", cleanup=True)
+    with pytest.raises(SystemExit):
+        _franchise_status("abc123", cleanup=True)
     assert mock_delete.called
     assert mock_delete.call_args.args[0] == ""
     assert mock_delete.call_args.kwargs.get("owner") == "abc123"
@@ -315,17 +423,285 @@ def test_franchise_run_exit_code_passthrough(
 
 
 # ---------------------------------------------------------------------------
-# T17. franchise status — no state file
+# T17 (existing). franchise status — no state file (exit code updated to 3)
 # ---------------------------------------------------------------------------
 
 
 def test_franchise_status_missing_campaign(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
 ) -> None:
-    """franchise status prints error for unknown campaign_id."""
+    """franchise status exits 3 for unknown campaign_id."""
     monkeypatch.chdir(tmp_path)
-    with pytest.raises(SystemExit, match="1"):
+    with pytest.raises(SystemExit, match="3"):
         _franchise_status("nonexistent")
+
+
+# ---------------------------------------------------------------------------
+# New T1. Table columns match 8-column specification
+# ---------------------------------------------------------------------------
+
+
+def test_franchise_status_table_columns(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """franchise status output contains all 8 header labels in order."""
+    _setup_campaign_with_tokens(tmp_path, "cid01", "my-campaign")
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(SystemExit):
+        _franchise_status("cid01")
+    out = capsys.readouterr().out
+    assert out.index("NAME") < out.index("STATUS") < out.index("ELAPSED")
+    assert out.index("INPUT") < out.index("OUTPUT") < out.index("CACHE_RD")
+    assert "SESSION_LOG" in out
+    assert "CACHE_WR" in out
+
+
+# ---------------------------------------------------------------------------
+# New T2. Numeric columns right-aligned
+# ---------------------------------------------------------------------------
+
+
+def test_status_numeric_columns_right_aligned() -> None:
+    """Numeric column definitions use align='>'."""
+    from autoskillit.cli._franchise import _STATUS_COLUMNS
+
+    numeric_labels = {"ELAPSED", "INPUT", "OUTPUT", "CACHE_RD", "CACHE_WR"}
+    for col in _STATUS_COLUMNS:
+        if col.label in numeric_labels:
+            assert col.align == ">", f"{col.label} should be right-aligned"
+
+
+# ---------------------------------------------------------------------------
+# New T3. --json includes totals dict
+# ---------------------------------------------------------------------------
+
+
+def test_franchise_status_json_includes_totals(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """--json output has totals key with summed token counts."""
+    _setup_campaign_with_tokens(
+        tmp_path,
+        "cid01",
+        "test",
+        token_usage={
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_creation_input_tokens": 10,
+            "cache_read_input_tokens": 20,
+        },
+    )
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(SystemExit):
+        _franchise_status("cid01", json_output=True)
+    data = json.loads(capsys.readouterr().out)
+    assert data["totals"]["input_tokens"] == 100
+    assert data["totals"]["output_tokens"] == 50
+    assert data["totals"]["cache_read"] == 20
+    assert data["totals"]["cache_creation"] == 10
+
+
+# ---------------------------------------------------------------------------
+# New T4. --json output has no ANSI escapes
+# ---------------------------------------------------------------------------
+
+
+def test_franchise_status_json_no_ansi(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """--json output must not contain ANSI escape sequences."""
+    _setup_existing_campaign_state(tmp_path, "cid01", "test")
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(SystemExit):
+        _franchise_status("cid01", json_output=True)
+    out = capsys.readouterr().out
+    assert "\x1b[" not in out
+
+
+# ---------------------------------------------------------------------------
+# New T5. Exit code 0: all dispatches succeeded
+# ---------------------------------------------------------------------------
+
+
+def test_exit_code_all_success() -> None:
+    """_compute_exit_code returns 0 when all dispatches succeed or skip."""
+    from autoskillit.cli._franchise import _compute_exit_code
+
+    state = _make_state(statuses=["success", "skipped", "success"])
+    assert _compute_exit_code(state) == 0
+
+
+# ---------------------------------------------------------------------------
+# New T6. Exit code 1: any dispatch failed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad_status", ["failure", "interrupted", "refused", "released"])
+def test_exit_code_any_failure(bad_status: str) -> None:
+    """_compute_exit_code returns 1 when any dispatch is in a failure-class status."""
+    from autoskillit.cli._franchise import _compute_exit_code
+
+    state = _make_state(statuses=["success", bad_status])
+    assert _compute_exit_code(state) == 1
+
+
+# ---------------------------------------------------------------------------
+# New T7. Exit code 2: any dispatch in-progress (no failures)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("progress_status", ["running", "pending"])
+def test_exit_code_in_progress(progress_status: str) -> None:
+    """_compute_exit_code returns 2 when any dispatch is in-progress and none failed."""
+    from autoskillit.cli._franchise import _compute_exit_code
+
+    state = _make_state(statuses=["success", progress_status])
+    assert _compute_exit_code(state) == 2
+
+
+# ---------------------------------------------------------------------------
+# New T8. Exit code 3: state file missing/corrupt
+# ---------------------------------------------------------------------------
+
+
+def test_exit_code_3_on_missing_state(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """franchise status exits 3 when state file is absent."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".autoskillit" / "temp" / "franchise" / "cid01").mkdir(parents=True)
+    with pytest.raises(SystemExit) as exc_info:
+        _franchise_status("cid01")
+    assert exc_info.value.code == 3
+
+
+# ---------------------------------------------------------------------------
+# New T9. Token cross-check warns on >5% divergence
+# ---------------------------------------------------------------------------
+
+
+def test_cross_check_warns_on_divergence(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """_cross_check_tokens emits a stderr warning when divergence exceeds 5%."""
+    from autoskillit.cli._franchise import _aggregate_totals, _cross_check_tokens
+
+    (tmp_path / "sessions.jsonl").write_text("")
+    state = _make_state_with_tokens(input_total=10000)
+    state_totals = _aggregate_totals(state)
+
+    monkeypatch.setattr(
+        "autoskillit.execution.session_log.resolve_log_dir",
+        lambda *a: tmp_path,
+    )
+    monkeypatch.setattr(
+        "autoskillit.pipeline.tokens.DefaultTokenLog.load_from_log_dir",
+        lambda self, *a, **kw: 1,
+    )
+    monkeypatch.setattr(
+        "autoskillit.pipeline.tokens.DefaultTokenLog.compute_total",
+        lambda self, **kw: {
+            "input_tokens": 8000,
+            "output_tokens": 0,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+            "total_elapsed_seconds": 0.0,
+        },
+    )
+    _cross_check_tokens(state, state_totals)
+    assert "diverge" in capsys.readouterr().err.lower()
+
+
+# ---------------------------------------------------------------------------
+# New T10. --watch exits on terminal campaign
+# ---------------------------------------------------------------------------
+
+
+def test_watch_exits_on_terminal_campaign(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """--watch detects all-terminal campaign and exits with code 0."""
+    _setup_campaign_with_status(tmp_path, "cid01", "test", status="success")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("sys.stdin", io.StringIO(""))
+    with pytest.raises(SystemExit) as exc_info:
+        _franchise_status("cid01", watch=True)
+    assert exc_info.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# New T11. --cleanup calls cleanup_session per terminal dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_cleanup_per_dispatch_session(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """--cleanup calls cleanup_session for each dispatch l2_session_id."""
+    _setup_campaign_with_sessions(
+        tmp_path,
+        "cid01",
+        "test",
+        dispatches=[("d1", "success", "sid-1"), ("d2", "failure", "sid-2")],
+    )
+    monkeypatch.chdir(tmp_path)
+    _mock_batch_delete(monkeypatch)
+    cleanup_calls: list[str] = []
+    monkeypatch.setattr(
+        "autoskillit.workspace.DefaultSessionSkillManager.cleanup_session",
+        lambda self, sid: cleanup_calls.append(sid) or True,
+    )
+    with pytest.raises(SystemExit):
+        _franchise_status("cid01", cleanup=True)
+    assert "sid-1" in cleanup_calls
+    assert "sid-2" in cleanup_calls
+
+
+# ---------------------------------------------------------------------------
+# New T12. Color-aware table respects NO_COLOR
+# ---------------------------------------------------------------------------
+
+
+def test_status_table_no_ansi_when_no_color(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """franchise status table contains no ANSI codes when NO_COLOR is set."""
+    _setup_existing_campaign_state(tmp_path, "cid01", "test")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("NO_COLOR", "1")
+    with pytest.raises(SystemExit):
+        _franchise_status("cid01")
+    out = capsys.readouterr().out
+    assert "\x1b[" not in out
+
+
+# ---------------------------------------------------------------------------
+# New T13. Exit code priority: failure overrides in-progress
+# ---------------------------------------------------------------------------
+
+
+def test_exit_code_failure_over_in_progress() -> None:
+    """_compute_exit_code returns 1 (failure) when mixed with in-progress."""
+    from autoskillit.cli._franchise import _compute_exit_code
+
+    state = _make_state(statuses=["failure", "running"])
+    assert _compute_exit_code(state) == 1
+
+
+# ---------------------------------------------------------------------------
+# New T14. Totals row appears in table output
+# ---------------------------------------------------------------------------
+
+
+def test_status_table_shows_totals_row(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """franchise status table includes a TOTAL row."""
+    _setup_campaign_with_tokens(
+        tmp_path,
+        "cid01",
+        "test",
+        token_usage={"input_tokens": 100, "output_tokens": 50},
+    )
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(SystemExit):
+        _franchise_status("cid01")
+    out = capsys.readouterr().out
+    assert "TOTAL" in out.upper()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_franchise_cli.py
+++ b/tests/cli/test_franchise_cli.py
@@ -589,7 +589,7 @@ def test_cross_check_warns_on_divergence(
     state_totals = _aggregate_totals(state)
 
     monkeypatch.setattr(
-        "autoskillit.execution.session_log.resolve_log_dir",
+        "autoskillit.execution.resolve_log_dir",
         lambda *a: tmp_path,
     )
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

Complete the `franchise status` CLI command in `src/autoskillit/cli/_franchise.py` by closing five gaps in the existing partial implementation: (1) replace the current 4-column dispatch table with the 8-column layout specified in CA-11 (name, status, elapsed, input_tokens, output_tokens, cache_read, cache_creation, l2_session_log_dir) with right-aligned numeric columns, (2) implement `--watch` as a 1 Hz polling loop with `q`/Ctrl-C exit, (3) enrich `--json` output with a `totals` dict and guarantee ANSI-free output, (4) add token cross-checking between state.json and sessions.jsonl with a >5% divergence diagnostic warning, (5) implement the exit code matrix (0=all-success, 1=any-failure, 2=any-in-progress, 3=envelope-error), and (6) enhance `--cleanup` to call `cleanup_session` per terminal dispatch's session ID. The `--reap` flag is already fully implemented via `_reap_stale_dispatches`; this plan leaves it untouched.

## Requirements

Complete the `franchise status` CLI with all flags. This is the operator-facing read/cleanup/reap command; the `run` subcommand lands separately (T7).

**Scope:**
- `cli/_franchise.py::status` subcommand implementation per CA-11:
  - Reads `.autoskillit/temp/franchise/<campaign_id>/state.json` (or picks latest if no id given)
  - Default table output (via `core/_terminal_table.py` — NO_COLOR aware) with columns: `name | status | elapsed | input_tokens | output_tokens | cache_read | cache_creation | l2_session_log_dir`
  - Numeric columns right-aligned
  - `--cleanup` flag: campaign-scoped sweep — `batch_cleanup_clones(owner_filter=campaign_id)` + `session_skills.cleanup_session(session_id)` per terminal dispatch + kitchen state marker dir cleanup
  - `--reap` flag: PID-safety-checked reap of orphaned `running` dispatches (see T14)
  - `--watch` flag: 1 Hz polling; re-render table; exit on `q` or Ctrl-C
  - `--json` flag: emit `{"campaign_id": ..., "dispatches": [...], "totals": {...}}`; suppress ANSI regardless of TTY; default table emits ANSI when tty is color-capable
  - Totals aggregated from state.json + cross-checked against `sessions.jsonl` filtered by `campaign_id`; warn on > 1% divergence (diagnostic only; state.json wins)
- Exit codes: `0` = all success, `1` = any failure, `2` = any in-progress, `3` = envelope error
- Atomic writes for state.json so watch readers never see torn JSON

**Acceptance criteria:**
- All 4 flags work (`--cleanup`, `--reap`, `--watch`, `--json`)
- JSON output shape stable; no ANSI
- Table respects NO_COLOR and TERM=dumb
- Atomic state.json read doesn't JSONDecodeError under concurrent write
- Exit codes match matrix (parametrized test)
- Token aggregation matches within 1% vs sessions.jsonl cross-check
- Group L tests pass (CLI)

## Architecture Impact

### Operational Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ENTRY POINTS %%
    subgraph CLI ["● CLI ENTRY — franchise sub-app"]
        direction LR
        RUN["franchise run &lt;name&gt;<br/>━━━━━━━━━━<br/>--resume &lt;campaign_id&gt;<br/>Launches L3 Claude session"]
        LIST["franchise list<br/>━━━━━━━━━━<br/>Tabular recipe listing"]
        STATUS["● franchise status [id]<br/>━━━━━━━━━━<br/>--watch --json<br/>--cleanup --reap --dry-run<br/>Exit: 0=ok 1=fail 2=in-progress 3=err"]
    end

    %% STATE %%
    subgraph State ["STATE (read/write)"]
        direction TB
        STATE_JSON[".autoskillit/temp/franchise/&lt;id&gt;/state.json<br/>━━━━━━━━━━<br/>CampaignState: dispatches, token_usage<br/>l2_pid, l2_starttime_ticks, l2_boot_id"]
        SESSIONS_JSONL["~/.local/share/autoskillit/logs/sessions.jsonl<br/>━━━━━━━━━━<br/>Token cross-check source<br/>(campaign_id_filter)"]
    end

    %% STATUS RENDERING %%
    subgraph Render ["● STATUS RENDERING"]
        direction TB
        TABLE["8-Column Dispatch Table<br/>━━━━━━━━━━<br/>NAME STATUS ELAPSED<br/>INPUT OUTPUT CACHE_RD CACHE_WR<br/>SESSION_LOG"]
        JSON_OUT["● --json totals output<br/>━━━━━━━━━━<br/>campaign_id, dispatches[],<br/>totals{input/output/cache}"]
        WATCH["● --watch (1 Hz loop)<br/>━━━━━━━━━━<br/>TTY required<br/>Cursor-refresh in-place<br/>q to quit"]
        XCHECK["● Token Cross-Check<br/>━━━━━━━━━━<br/>Warns >5% divergence<br/>state.json vs sessions.jsonl"]
    end

    %% REAP %%
    subgraph Reap ["● REAP — Stale Dispatch Cleanup"]
        direction TB
        REAP_CMD["● --reap / --dry-run<br/>━━━━━━━━━━<br/>fcntl.flock exclusive lock<br/>Scans RUNNING dispatches"]
        BOOT_CHECK["Boot-ID Check<br/>━━━━━━━━━━<br/>Rebooted? → reaped_pid_recycled"]
        PID_CHECK["PID Identity Check<br/>━━━━━━━━━━<br/>/proc starttime_ticks match<br/>Alive+match → kill+reaped_orphan<br/>Alive+mismatch → reaped_pid_recycled<br/>Dead → reaped_dead_pid"]
        REAP_OUT["Reap Log (stderr / _log)<br/>━━━━━━━━━━<br/>[MARKED] [KILLED] [SKIPPED]<br/>[WOULD MARK] [WOULD KILL]"]
    end

    %% CLEANUP %%
    subgraph Cleanup ["--cleanup (per-dispatch workspace)"]
        direction TB
        CLONE_DEL["batch_delete clones<br/>━━━━━━━━━━<br/>Removes workspace clone dirs<br/>owner=campaign_id"]
        SKILL_DEL["SessionSkillManager.cleanup<br/>━━━━━━━━━━<br/>Ephemeral skill dirs per l2_session_id<br/>+ campaign-level dir"]
        KITCHEN_DEL["kitchen_state dir removal<br/>━━━━━━━━━━<br/>.autoskillit/temp/kitchen_state/&lt;id&gt;"]
        MARKERS["sweep_stale_markers()<br/>━━━━━━━━━━<br/>Stale kitchen open/close markers"]
    end

    %% SIGNAL GUARD (franchise run) %%
    subgraph SignalGuard ["SIGNAL GUARD (franchise run context)"]
        direction TB
        SIG["SIGINT / SIGTERM<br/>━━━━━━━━━━<br/>anyio signal receiver<br/>Cancels enclosing task group"]
        SIG_KILL["PID identity-verified kill<br/>━━━━━━━━━━<br/>starttime_ticks check<br/>async_kill_process_tree(timeout=5s)"]
        SIG_MARK["mark_dispatch_interrupted()<br/>━━━━━━━━━━<br/>reason=signal_SIGINT|SIGTERM"]
        SIG_RESUME["Resume hint → stderr<br/>━━━━━━━━━━<br/>franchise run --resume &lt;id&gt;"]
    end

    %% FLOWS %%
    STATUS --> STATE_JSON
    STATUS --> TABLE
    STATUS --> JSON_OUT
    STATUS --> WATCH
    STATUS --> REAP_CMD
    STATUS --> CLONE_DEL

    WATCH -->|"reads every 1s"| STATE_JSON
    JSON_OUT --> XCHECK
    TABLE --> XCHECK
    XCHECK --> SESSIONS_JSONL

    REAP_CMD --> BOOT_CHECK
    BOOT_CHECK --> PID_CHECK
    PID_CHECK --> REAP_OUT
    REAP_OUT -->|"updates"| STATE_JSON

    CLONE_DEL --> SKILL_DEL
    SKILL_DEL --> KITCHEN_DEL
    KITCHEN_DEL --> MARKERS

    RUN --> STATE_JSON
    RUN --> SIG
    SIG --> SIG_KILL
    SIG_KILL --> SIG_MARK
    SIG_MARK -->|"updates"| STATE_JSON
    SIG_MARK --> SIG_RESUME

    %% CLASS ASSIGNMENTS %%
    class RUN,LIST,STATUS cli;
    class STATE_JSON,SESSIONS_JSONL stateNode;
    class TABLE,JSON_OUT,WATCH output;
    class XCHECK,BOOT_CHECK,PID_CHECK detector;
    class REAP_CMD phase;
    class REAP_OUT,SIG_RESUME output;
    class CLONE_DEL,SKILL_DEL,KITCHEN_DEL,MARKERS handler;
    class SIG,SIG_KILL,SIG_MARK phase;
```

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START([franchise run / franchise status])

    subgraph PreFlight ["● CLI PRE-FLIGHT GATES (cli/_franchise.py)"]
        direction TB
        G_CLAUDECODE["Guard: CLAUDECODE env<br/>━━━━━━━━━━<br/>Reject nested sessions"]
        G_LEAFSESS["Guard: SESSION_TYPE==leaf<br/>━━━━━━━━━━<br/>Reject leaf-session launch"]
        G_BINARY["Guard: claude binary<br/>━━━━━━━━━━<br/>shutil.which('claude')"]
        G_YAML["Guard: YAML parse<br/>━━━━━━━━━━<br/>load_recipe → YAMLError"]
        G_RECIPE["Guard: validate_recipe<br/>━━━━━━━━━━<br/>Semantic rule violations"]
    end

    subgraph InitFields ["CAMPAIGN STATE — INIT_ONLY (write_initial_state)"]
        direction LR
        F_CID["campaign_id<br/>━━━━━━━━━━<br/>uuid4().hex[:16]<br/>NEVER mutated"]
        F_CNAME["campaign_name<br/>━━━━━━━━━━<br/>from recipe<br/>NEVER mutated"]
        F_MPATH["manifest_path<br/>━━━━━━━━━━<br/>abs path to YAML<br/>NEVER mutated"]
        F_SAT["started_at<br/>━━━━━━━━━━<br/>time.time() at init<br/>NEVER mutated"]
    end

    subgraph DispatchStatus ["DISPATCH STATUS MACHINE (_validate_transition)"]
        direction LR
        S_PENDING["PENDING<br/>━━━━━━━━━━<br/>Initial state"]
        S_RUNNING["RUNNING<br/>━━━━━━━━━━<br/>L2 session active"]
        S_SUCCESS["SUCCESS<br/>━━━━━━━━━━<br/>Terminal"]
        S_FAILURE["FAILURE<br/>━━━━━━━━━━<br/>Terminal"]
        S_INTERRUPTED["INTERRUPTED<br/>━━━━━━━━━━<br/>Terminal"]
        S_SKIPPED["SKIPPED<br/>━━━━━━━━━━<br/>Terminal"]
        S_REFUSED["REFUSED<br/>━━━━━━━━━━<br/>Terminal"]
        S_RELEASED["RELEASED<br/>━━━━━━━━━━<br/>Terminal"]
    end

    subgraph RunningFields ["RUNNING-PHASE FIELDS (mark_dispatch_running)"]
        direction LR
        F_PID["l2_pid<br/>━━━━━━━━━━<br/>L2 subprocess PID<br/>identity guard"]
        F_TICKS["l2_starttime_ticks<br/>━━━━━━━━━━<br/>/proc/[pid]/stat[22]<br/>anti-recycling"]
        F_BOOT["l2_boot_id<br/>━━━━━━━━━━<br/>/proc/sys/kernel/.../boot_id<br/>reboot detection"]
        F_DID["dispatch_id<br/>━━━━━━━━━━<br/>unique exec attempt ID"]
    end

    subgraph CompletionFields ["COMPLETION FIELDS (append_dispatch_record)"]
        direction LR
        F_SESSID["l2_session_id<br/>━━━━━━━━━━<br/>Claude Code session UUID<br/>JSONL log key"]
        F_SESSLOG["l2_session_log_dir<br/>━━━━━━━━━━<br/>path to session log dir"]
        F_TU["token_usage<br/>━━━━━━━━━━<br/>input/output/cache_read/<br/>cache_creation"]
        F_ENDAT["ended_at<br/>━━━━━━━━━━<br/>terminal timestamp"]
    end

    subgraph InterruptPath ["● INTERRUPT PATH (mark_dispatch_interrupted)"]
        direction LR
        MUT_SIGNAL["Signal Guard<br/>━━━━━━━━━━<br/>SIGINT/SIGTERM<br/>→ INTERRUPTED"]
        MUT_REAP["● _reap_stale_dispatches<br/>━━━━━━━━━━<br/>fcntl.flock(LOCK_EX)<br/>boot_id / ticks / pid checks"]
        F_REASON["reason (write-only)<br/>━━━━━━━━━━<br/>signal_SIGINT, reaped_dead_pid,<br/>reaped_orphan, reaped_pid_recycled"]
    end

    subgraph ResumeDetection ["RESUME DETECTION (resume_campaign_from_state)"]
        direction TB
        R1["Phase 1: Crash Recovery<br/>━━━━━━━━━━<br/>RUNNING → INTERRUPTED<br/>reason=stale_running_on_resume"]
        R2["Phase 2: Halt Check<br/>━━━━━━━━━━<br/>FAILURE + continue_on_failure=False<br/>→ halt block injected"]
        R3["Phase 3: Next Dispatch<br/>━━━━━━━━━━<br/>Walk in order; first non-{SUCCESS,SKIPPED}<br/>→ next_dispatch_name"]
    end

    subgraph AtomicWrite ["ATOMIC WRITE CONTRACT"]
        direction TB
        W_ATOMIC["_write_state → write_versioned_json<br/>━━━━━━━━━━<br/>tmp file + os.replace()<br/>LOCK_EX on reap path"]
    end

    %% FLOW %%
    START --> G_CLAUDECODE
    G_CLAUDECODE --> G_LEAFSESS
    G_LEAFSESS --> G_BINARY
    G_BINARY --> G_YAML
    G_YAML --> G_RECIPE

    G_RECIPE -->|"new campaign"| F_CID
    G_RECIPE -->|"new campaign"| F_CNAME
    G_RECIPE -->|"new campaign"| F_MPATH
    G_RECIPE -->|"new campaign"| F_SAT

    G_RECIPE -->|"--resume"| R1
    R1 --> R2
    R2 --> R3

    F_CID --> S_PENDING
    F_CNAME --> S_PENDING

    S_PENDING -->|"mark_dispatch_running"| S_RUNNING
    S_RUNNING -->|"append_dispatch_record"| S_SUCCESS
    S_RUNNING -->|"append_dispatch_record"| S_FAILURE
    S_RUNNING -->|"mark_dispatch_interrupted"| S_INTERRUPTED
    S_PENDING -->|"skip gate"| S_SKIPPED
    S_PENDING -->|"refused"| S_REFUSED
    S_PENDING -->|"released"| S_RELEASED

    S_RUNNING --> F_PID
    S_RUNNING --> F_TICKS
    S_RUNNING --> F_BOOT
    S_RUNNING --> F_DID

    S_SUCCESS --> F_SESSID
    S_FAILURE --> F_SESSID
    F_SESSID --> F_SESSLOG
    F_SESSLOG --> F_TU
    F_TU --> F_ENDAT

    MUT_SIGNAL --> S_INTERRUPTED
    MUT_REAP --> S_INTERRUPTED
    S_INTERRUPTED --> F_REASON

    F_PID --> MUT_REAP
    F_TICKS --> MUT_REAP
    F_BOOT --> MUT_REAP

    S_RUNNING --> AtomicWrite
    S_SUCCESS --> AtomicWrite
    S_INTERRUPTED --> AtomicWrite

    R3 -->|"injects env + prompt"| S_PENDING

    %% CLASS ASSIGNMENTS %%
    class START terminal;
    class G_CLAUDECODE,G_LEAFSESS,G_BINARY,G_YAML,G_RECIPE detector;
    class F_CID,F_CNAME,F_MPATH,F_SAT gap;
    class S_PENDING,S_RUNNING phase;
    class S_SUCCESS,S_FAILURE,S_INTERRUPTED,S_SKIPPED,S_REFUSED,S_RELEASED stateNode;
    class F_PID,F_TICKS,F_BOOT,F_DID handler;
    class F_SESSID,F_SESSLOG,F_TU,F_ENDAT output;
    class MUT_SIGNAL,MUT_REAP,F_REASON cli;
    class R1,R2,R3 phase;
    class W_ATOMIC stateNode;
```

### Scenarios Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ─── SCENARIO 1: Table Status View ─────────────────────────────────────── %%
    subgraph S1 ["SCENARIO 1 — franchise status &lt;id&gt; (table view)"]
        direction LR
        S1_CLI["● franchise_status<br/>━━━━━━━━━━<br/>reads campaign_id arg"]
        S1_STATE["read_state<br/>━━━━━━━━━━<br/>loads state.json"]
        S1_RENDER["● _render_status_display<br/>━━━━━━━━━━<br/>8-col table + TOTAL row"]
        S1_XCHK["● _cross_check_tokens<br/>━━━━━━━━━━<br/>warn if &gt;5% diverge"]
        S1_EXIT["● _compute_exit_code<br/>━━━━━━━━━━<br/>0=ok 1=fail 2=running"]
    end

    %% ─── SCENARIO 2: JSON Output ────────────────────────────────────────────── %%
    subgraph S2 ["SCENARIO 2 — franchise status &lt;id&gt; --json"]
        direction LR
        S2_CLI["● franchise_status --json<br/>━━━━━━━━━━<br/>machine-readable output"]
        S2_AGG["● _aggregate_totals<br/>━━━━━━━━━━<br/>sum tokens across dispatches"]
        S2_JSON["JSON dump<br/>━━━━━━━━━━<br/>campaign_id + dispatches<br/>+ totals dict"]
        S2_TOK["● _cross_check_tokens<br/>━━━━━━━━━━<br/>loads DefaultTokenLog<br/>from sessions.jsonl"]
        S2_EXIT2["● _compute_exit_code<br/>━━━━━━━━━━<br/>sys.exit on --json path"]
    end

    %% ─── SCENARIO 3: Watch Loop ─────────────────────────────────────────────── %%
    subgraph S3 ["SCENARIO 3 — franchise status &lt;id&gt; --watch"]
        direction LR
        S3_CLI["● franchise_status --watch<br/>━━━━━━━━━━<br/>delegates to _watch_loop"]
        S3_TTY["TTY guard<br/>━━━━━━━━━━<br/>stdin + stdout must be TTY<br/>(or already-terminal fast-path)"]
        S3_LOOP["● _watch_loop 1Hz<br/>━━━━━━━━━━<br/>ANSI cursor up/erase<br/>redraw each second"]
        S3_DONE["terminal check<br/>━━━━━━━━━━<br/>all dispatches non-running?"]
        S3_EXIT3["exit / 'q' key<br/>━━━━━━━━━━<br/>_compute_exit_code result"]
    end

    %% ─── SCENARIO 4: Per-Dispatch Cleanup ──────────────────────────────────── %%
    subgraph S4 ["SCENARIO 4 — franchise status &lt;id&gt; --cleanup"]
        direction LR
        S4_CLI["● franchise_status --cleanup<br/>━━━━━━━━━━<br/>post-table cleanup path"]
        S4_BATCH["batch_delete<br/>━━━━━━━━━━<br/>removes clone dirs<br/>owner=campaign_id"]
        S4_SKILL["DefaultSessionSkillManager<br/>━━━━━━━━━━<br/>cleanup_session per<br/>dispatch l2_session_id"]
        S4_SWEEP["sweep_stale_markers<br/>━━━━━━━━━━<br/>removes stale kitchen<br/>open/close markers"]
        S4_KSTATE["kitchen_state dir<br/>━━━━━━━━━━<br/>shutil.rmtree campaign dir"]
    end

    %% ─── SCENARIO 5: Stale Dispatch Reap ───────────────────────────────────── %%
    subgraph S5 ["SCENARIO 5 — franchise status &lt;id&gt; --reap (or --dry-run)"]
        direction LR
        S5_CLI["● franchise_status --reap<br/>━━━━━━━━━━<br/>delegates to<br/>_reap_stale_dispatches"]
        S5_LOCK["fcntl.flock<br/>━━━━━━━━━━<br/>exclusive lock on<br/>state.json fd"]
        S5_BOOT["read_boot_id<br/>━━━━━━━━━━<br/>detect machine reboot<br/>(boot-id mismatch)"]
        S5_PID["read_starttime_ticks<br/>━━━━━━━━━━<br/>verify PID identity<br/>before kill"]
        S5_KILL["kill_process_tree<br/>━━━━━━━━━━<br/>SIGKILL orphan process<br/>ticks match only"]
        S5_MARK["mark_dispatch_interrupted<br/>━━━━━━━━━━<br/>reason: reaped_orphan<br/>reaped_pid_recycled<br/>reaped_dead_pid"]
    end

    %% ─── CROSS-SCENARIO SHARED STATE ───────────────────────────────────────── %%
    STATE_JSON[("state.json<br/>━━━━━━━━━━<br/>.autoskillit/temp/<br/>franchise/&lt;id&gt;/")]
    SESSION_LOG[("sessions.jsonl<br/>━━━━━━━━━━<br/>~/.local/share/<br/>autoskillit/logs/")]

    %% SCENARIO 1 FLOW %%
    S1_CLI -->|"reads"| S1_STATE
    S1_STATE -->|"loads dispatches"| S1_RENDER
    S1_RENDER -->|"triggers"| S1_XCHK
    S1_XCHK -->|"determines"| S1_EXIT

    %% SCENARIO 2 FLOW %%
    S2_CLI -->|"aggregates"| S2_AGG
    S2_AGG -->|"serializes"| S2_JSON
    S2_JSON -->|"cross-checks"| S2_TOK
    S2_TOK -->|"exits"| S2_EXIT2

    %% SCENARIO 3 FLOW %%
    S3_CLI -->|"checks"| S3_TTY
    S3_TTY -->|"enters loop"| S3_LOOP
    S3_LOOP -->|"polls"| S3_DONE
    S3_DONE -->|"complete or q"| S3_EXIT3

    %% SCENARIO 4 FLOW %%
    S4_CLI -->|"deletes clones"| S4_BATCH
    S4_BATCH -->|"cleans sessions"| S4_SKILL
    S4_SKILL -->|"sweeps markers"| S4_SWEEP
    S4_SWEEP -->|"removes dir"| S4_KSTATE

    %% SCENARIO 5 FLOW %%
    S5_CLI -->|"acquires lock"| S5_LOCK
    S5_LOCK -->|"boot check"| S5_BOOT
    S5_BOOT -->|"PID check"| S5_PID
    S5_PID -->|"alive + match"| S5_KILL
    S5_KILL -->|"marks"| S5_MARK
    S5_PID -->|"dead or recycled"| S5_MARK

    %% SHARED STATE READS %%
    STATE_JSON -->|"read_state"| S1_STATE
    STATE_JSON -->|"read_state"| S2_CLI
    STATE_JSON -->|"read_state"| S3_LOOP
    STATE_JSON -->|"locked read"| S5_LOCK
    SESSION_LOG -->|"load sessions"| S2_TOK

    %% CLASS ASSIGNMENTS %%
    class S1_CLI,S2_CLI,S3_CLI,S4_CLI,S5_CLI cli;
    class S1_STATE,S3_TTY,S5_LOCK phase;
    class S1_RENDER,S2_AGG,S3_LOOP,S4_BATCH,S5_BOOT handler;
    class S1_XCHK,S2_TOK,S3_DONE,S4_SKILL,S5_PID detector;
    class S1_EXIT,S2_JSON,S3_EXIT3,S4_SWEEP,S5_KILL handler;
    class S2_EXIT2,S4_KSTATE,S5_MARK output;
    class STATE_JSON,SESSION_LOG stateNode;
```

Closes #883

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260422-001423-386682/.autoskillit/temp/make-plan/franchise_status_cli_plan_2026-04-22_014500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 2.9k | 20.8k | 1.4M | 115.4k | 1 | 9m 0s |
| review | 34 | 7.1k | 261.2k | 54.8k | 1 | 6m 37s |
| verify | 55 | 21.2k | 1.8M | 91.1k | 1 | 9m 52s |
| implement | 2.2k | 52.9k | 2.5M | 121.3k | 1 | 12m 35s |
| fix | 152 | 10.5k | 929.6k | 59.3k | 1 | 3m 48s |
| prepare_pr | 52 | 5.1k | 159.9k | 29.8k | 1 | 1m 39s |
| run_arch_lenses | 192 | 18.1k | 728.3k | 123.7k | 3 | 6m 18s |
| compose_pr | 67 | 10.5k | 263.8k | 37.9k | 1 | 2m 50s |
| **Total** | 5.7k | 146.2k | 8.1M | 633.4k | | 52m 43s |