### PR TITLE
Implementation Plan: Franchise Release Hygiene (Version Bump + Sync + Verification)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "autoskillit"
-version = "0.9.86"
+version = "0.9.87"
 description = "MCP server for orchestrating automated skill-driven workflows with Claude Code"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/autoskillit/.claude-plugin/plugin.json
+++ b/src/autoskillit/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "autoskillit",
-  "version": "0.9.86",
+  "version": "0.9.87",
   "description": "Orchestrated skill-driven workflows using Claude Code headless sessions"
 }

--- a/uv.lock
+++ b/uv.lock
@@ -73,7 +73,7 @@ wheels = [
 
 [[package]]
 name = "autoskillit"
-version = "0.9.86"
+version = "0.9.87"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

Bump the package version from `0.9.86` to `0.9.87`, sync the plugin.json, regenerate the lock file, verify no hardcoded version strings are stale, and run the full quality gate pipeline. This is mechanical release plumbing — no logic changes, no new features. The version propagation chain is: `pyproject.toml` → `scripts/sync_plugin_json.py` → `plugin.json`, then `uv lock` → `uv.lock`, with `tests/contracts/test_version_consistency.py` enforcing three-way consistency at test time.

## Architecture Impact

### Development Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;

    %% ── SOURCE OF TRUTH ── %%
    subgraph SourceOfTruth ["BUILD CONFIGURATION (source of truth)"]
        direction TB
        PYPROJECT["● pyproject.toml<br/>━━━━━━━━━━<br/>version = 0.9.87<br/>build-backend: hatchling<br/>deps + dev-deps<br/>ruff / mypy / pytest / importlinter config"]
    end

    %% ── VERSION SYNC ── %%
    subgraph VersionSync ["VERSION SYNC PIPELINE"]
        direction LR
        SYNCCMD["task sync-plugin-version<br/>━━━━━━━━━━<br/>scripts/sync_plugin_json.py<br/>reads version from pyproject.toml"]
        PLUGINJSON["● .claude-plugin/plugin.json<br/>━━━━━━━━━━<br/>version = 0.9.87<br/>name: autoskillit<br/>MCP plugin metadata"]
    end

    %% ── DEPENDENCY LOCK ── %%
    subgraph DepLock ["DEPENDENCY MANAGEMENT"]
        direction LR
        UV["uv<br/>━━━━━━━━━━<br/>package manager<br/>uv sync / uv lock"]
        UVLOCK["● uv.lock<br/>━━━━━━━━━━<br/>pinned transitive deps<br/>regenerated on dep change"]
    end

    %% ── BUILD TOOLING ── %%
    subgraph BuildTooling ["BUILD TOOLING"]
        direction TB
        HATCH["hatchling<br/>━━━━━━━━━━<br/>build backend<br/>wheel + sdist artifacts<br/>includes hooks/, migrations/,<br/>.claude-plugin/, assets/"]
        TASKFILE["Taskfile.yml<br/>━━━━━━━━━━<br/>task install-worktree<br/>task sync-plugin-version<br/>task sync-hooks-hash"]
    end

    %% ── QUALITY GATES ── %%
    subgraph QualityGates ["CODE QUALITY GATES (pre-commit)"]
        direction LR
        RUFF["ruff format + check<br/>━━━━━━━━━━<br/>auto-fix formatter + linter<br/>target: py311, len=99"]
        MYPY["mypy<br/>━━━━━━━━━━<br/>static type checking<br/>reads src/autoskillit/"]
        IMPORTLINT["import-linter<br/>━━━━━━━━━━<br/>9 layer contracts (IL-001–009)<br/>L0→L1→L2→L3 enforcement"]
        GITLEAKS["gitleaks<br/>━━━━━━━━━━<br/>secret scanning<br/>pre-commit gate"]
        UVCHECK["uv lock check<br/>━━━━━━━━━━<br/>verifies uv.lock is in sync<br/>with pyproject.toml"]
    end

    %% ── TEST FRAMEWORK ── %%
    subgraph TestFramework ["TEST FRAMEWORK"]
        direction TB
        TESTCMD["task test-all / task test-check<br/>━━━━━━━━━━<br/>pytest -n 4 (xdist parallel)<br/>-m 'not smoke and not canary'<br/>basetemp=/dev/shm (Linux)"]
        MARKERS["Test Markers<br/>━━━━━━━━━━<br/>small / medium / large<br/>smoke / integration / canary<br/>layer(name)"]
        PLUGINS["pytest plugins<br/>━━━━━━━━━━<br/>pytest-asyncio (auto mode)<br/>pytest-xdist (-n 4)<br/>pytest-httpx / pytest-cov<br/>pytest-timeout (60s signal)"]
    end

    %% ── ENTRY POINT ── %%
    subgraph EntryPoint ["ENTRY POINT"]
        EP["autoskillit<br/>━━━━━━━━━━<br/>autoskillit.cli:main<br/>serve / init / config / doctor<br/>cook / franchise / recipes"]
    end

    %% ── FLOWS ── %%
    PYPROJECT -->|"version field"| SYNCCMD
    SYNCCMD -->|"writes version"| PLUGINJSON

    PYPROJECT -->|"[project.dependencies]"| UV
    UV -->|"uv lock"| UVLOCK

    PYPROJECT -->|"[build-system]"| HATCH
    PYPROJECT -->|"tasks reference"| TASKFILE
    TASKFILE -->|"task sync-plugin-version"| SYNCCMD

    PYPROJECT -->|"[tool.ruff]"| RUFF
    PYPROJECT -->|"[tool.mypy] (implicit)"| MYPY
    PYPROJECT -->|"[tool.importlinter]"| IMPORTLINT
    UVLOCK -->|"uv lock --check"| UVCHECK

    PYPROJECT -->|"[tool.pytest.ini_options]"| TESTCMD
    TESTCMD --> PLUGINS
    TESTCMD --> MARKERS

    HATCH -->|"[project.scripts]"| EP

    %% CLASS ASSIGNMENTS %%
    class PYPROJECT stateNode;
    class SYNCCMD,TASKFILE handler;
    class PLUGINJSON,UVLOCK output;
    class UV,HATCH phase;
    class RUFF,MYPY,IMPORTLINT,GITLEAKS,UVCHECK detector;
    class TESTCMD,PLUGINS,MARKERS handler;
    class EP cli;
```

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% BUILD / CONFIG LAYER (modified files) %%
    subgraph BuildLayer ["BUILD / CONFIG — Modified by this PR"]
        direction LR
        PYPROJECT["● pyproject.toml<br/>━━━━━━━━━━<br/>version = '0.9.87'<br/>importlinter contracts<br/>runtime deps + dev extras"]
        PLUGINJSON["● .claude-plugin/plugin.json<br/>━━━━━━━━━━<br/>version = '0.9.87'<br/>Must match pyproject"]
        UVLOCK["● uv.lock<br/>━━━━━━━━━━<br/>Pinned resolution for<br/>all runtime + dev deps"]
    end

    %% L0 — FOUNDATION %%
    subgraph L0 ["L0 — FOUNDATION (zero upward imports — IL-001)"]
        direction LR
        VERSION["version.py<br/>━━━━━━━━━━<br/>version_info() lru_cache<br/>reads importlib.metadata<br/>+ plugin.json at runtime"]
        CORE["core/<br/>━━━━━━━━━━<br/>_type_constants.py reads<br/>importlib.metadata.version<br/>__init__.py (L0 re-exports)"]
    end

    %% L1 — SERVICES %%
    subgraph L1 ["L1 — SERVICES (IL-008: siblings independent)"]
        direction LR
        CONFIG["config/<br/>━━━━━━━━━━<br/>settings.py"]
        PIPELINE["pipeline/<br/>━━━━━━━━━━<br/>context.py (DI)"]
        EXECUTION["execution/<br/>━━━━━━━━━━<br/>headless, quota, session_log"]
        WORKSPACE["workspace/<br/>━━━━━━━━━━<br/>clone, worktree, skills"]
    end

    %% L2 — DOMAIN %%
    subgraph L2 ["L2 — DOMAIN"]
        direction LR
        RECIPE["recipe/<br/>━━━━━━━━━━<br/>rules_campaign reads<br/>importlib.metadata.version"]
        MIGRATION["migration/<br/>━━━━━━━━━━<br/>engine, loader, store"]
        FRANCHISE["franchise/<br/>━━━━━━━━━━<br/>summary, result_parser"]
    end

    %% L3 — APPLICATION %%
    subgraph L3 ["L3 — APPLICATION"]
        direction LR
        SERVER["server/<br/>━━━━━━━━━━<br/>_state.py → version_info()<br/>tools_status.py exposes version"]
        CLI["cli/<br/>━━━━━━━━━━<br/>_update_checks.py references<br/>version_info() cache contract"]
    end

    %% EXTERNAL %%
    IMPORTLIB["importlib.metadata<br/>━━━━━━━━━━<br/>stdlib: reads installed<br/>package metadata at runtime"]

    %% BUILD → RUNTIME VERSION CHAIN %%
    PYPROJECT -->|"hatchling build embeds<br/>version into dist-info"| IMPORTLIB
    PYPROJECT -->|"uv resolves & pins"| UVLOCK
    PLUGINJSON -->|"file-read at runtime<br/>by version_info()"| VERSION
    IMPORTLIB -->|"metadata.version('autoskillit')"| VERSION
    IMPORTLIB -->|"metadata.version('autoskillit')"| CORE

    %% L0 DOWNWARD %%
    VERSION -->|"imported by _state.py"| SERVER
    VERSION -.->|"referenced in docstring<br/>(no direct import)"| CLI

    %% LAYER IMPORTS (valid downward) %%
    CORE --> CONFIG
    CORE --> PIPELINE
    CORE --> EXECUTION
    CORE --> WORKSPACE
    CONFIG --> PIPELINE
    CORE --> RECIPE
    CORE --> MIGRATION
    CORE --> FRANCHISE
    WORKSPACE --> RECIPE
    CONFIG --> SERVER
    PIPELINE --> SERVER
    EXECUTION --> SERVER
    WORKSPACE --> SERVER
    RECIPE --> SERVER
    MIGRATION --> SERVER
    FRANCHISE --> SERVER
    CONFIG --> CLI
    PIPELINE --> CLI
    EXECUTION --> CLI
    WORKSPACE --> CLI

    %% IMPORT-LINTER CONTRACT GUARD %%
    ILGUARD["import-linter (IL-001…IL-009)<br/>━━━━━━━━━━<br/>9 contracts in pyproject.toml<br/>enforce layer boundaries<br/>at lint time"]

    PYPROJECT -->|"defines contracts"| ILGUARD
    ILGUARD -.->|"guards"| L0
    ILGUARD -.->|"guards"| L1
    ILGUARD -.->|"guards"| L2

    %% CLASS ASSIGNMENTS %%
    class PYPROJECT,PLUGINJSON,UVLOCK output;
    class IMPORTLIB integration;
    class VERSION,CORE stateNode;
    class CONFIG,PIPELINE,EXECUTION,WORKSPACE handler;
    class RECIPE,MIGRATION,FRANCHISE phase;
    class SERVER,CLI cli;
    class ILGUARD detector;
```

Closes #890

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260422-035133-808156/.autoskillit/temp/make-plan/franchise_release_hygiene_plan_2026-04-22_035500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 84 | 7.4k | 768.3k | 49.8k | 1 | 6m 54s |
| verify | 37 | 5.4k | 310.9k | 28.4k | 1 | 3m 54s |
| implement | 134 | 3.8k | 475.2k | 22.5k | 1 | 1m 33s |
| prepare_pr | 52 | 3.7k | 147.3k | 19.9k | 1 | 1m 17s |
| run_arch_lenses | 146 | 11.0k | 478.3k | 59.9k | 2 | 3m 7s |
| compose_pr | 67 | 5.9k | 221.9k | 25.2k | 1 | 1m 31s |
| **Total** | 520 | 37.2k | 2.4M | 205.6k | | 18m 19s |