### PR TITLE
Feature Registry Foundation (FeatureDef, FEATURE_REGISTRY, config, self-tests)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,7 @@ generic_automation_mcp/
 │   ├── kitchen_state.py     #   Kitchen-open session marker (stdlib-only; readable from hooks)
 │   ├── _plugin_cache.py     #   Plugin cache lifecycle: retiring cache, install locking, kitchen registry
 │   ├── _plugin_ids.py       #   DIRECT_PREFIX, MARKETPLACE_PREFIX, detect_autoskillit_mcp_prefix (stdlib-only)
+│   ├── feature_flags.py     #   is_feature_enabled() — L0 feature gate resolution primitive
 │   └── readiness.py         #   Filesystem readiness sentinel primitives for MCP server startup (L0)
 │
 ├── config/                  # L1

--- a/src/autoskillit/config/defaults.yaml
+++ b/src/autoskillit/config/defaults.yaml
@@ -254,3 +254,6 @@ workspace:
 
 franchise:
   l2_default_timeout_sec: 3600
+
+features:
+  franchise: true  # True during transition; flipped to false in ticket #8

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -348,12 +348,21 @@ class AutomationConfig:
         """
         result: dict[str, bool] = {}
         for name, value in raw.items():
+            if not isinstance(name, str):
+                raise ConfigSchemaError(
+                    f"Feature key must be a string, got {type(name).__name__!r}: {name!r}"
+                )
             if name not in FEATURE_REGISTRY:
                 known = sorted(FEATURE_REGISTRY.keys())
                 raise ConfigSchemaError(
                     f"Unknown feature {name!r} in features config. Known features: {known}"
                 )
-            result[name] = bool(value)
+            if not isinstance(value, bool):
+                raise ConfigSchemaError(
+                    f"Feature {name!r} value must be a bool, "
+                    f"got {type(value).__name__!r}: {value!r}"
+                )
+            result[name] = value
 
         # Dependency validation
         for name, enabled in result.items():
@@ -361,7 +370,14 @@ class AutomationConfig:
                 continue
             defn = FEATURE_REGISTRY[name]
             for dep in defn.depends_on:
-                dep_enabled = result.get(dep, FEATURE_REGISTRY[dep].default_enabled)
+                try:
+                    dep_default = FEATURE_REGISTRY[dep].default_enabled
+                except KeyError:
+                    raise ConfigSchemaError(
+                        f"Feature {name!r} depends_on {dep!r}, which is not in FEATURE_REGISTRY. "
+                        f"This is a bug in the FeatureDef definition."
+                    )
+                dep_enabled = result.get(dep, dep_default)
                 if not dep_enabled:
                     raise ConfigSchemaError(
                         f"Feature {name!r} is enabled but its dependency {dep!r} is disabled. "

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -598,7 +598,9 @@ class AutomationConfig:
                     val(fr, "l2_default_timeout_sec", _fr["l2_default_timeout_sec"])
                 ),
             ),
-            features=AutomationConfig._build_features_dict(dict(feat)),
+            features=AutomationConfig._build_features_dict(
+                dict(feat) if isinstance(feat, dict) else {}
+            ),
         )
 
 

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 from autoskillit.core import (
     CATEGORY_TAGS,
+    FEATURE_REGISTRY,
     OutputFormat,
     atomic_write,
     dump_yaml_str,
@@ -333,6 +334,41 @@ class AutomationConfig:
     packs: PacksConfig = field(default_factory=PacksConfig)
     workspace: WorkspaceConfig = field(default_factory=WorkspaceConfig)
     franchise: FranchiseConfig = field(default_factory=FranchiseConfig)
+    features: dict[str, bool] = field(default_factory=dict)
+
+    @staticmethod
+    def _build_features_dict(raw: dict[str, Any]) -> dict[str, bool]:
+        """Validate and coerce the features section from a raw config dict.
+
+        Raises ConfigSchemaError for:
+        - Unknown feature names (not in FEATURE_REGISTRY)
+        - Dependency violations: enabling feature B without its required feature A
+
+        Coerces all values to bool.
+        """
+        result: dict[str, bool] = {}
+        for name, value in raw.items():
+            if name not in FEATURE_REGISTRY:
+                known = sorted(FEATURE_REGISTRY.keys())
+                raise ConfigSchemaError(
+                    f"Unknown feature {name!r} in features config. Known features: {known}"
+                )
+            result[name] = bool(value)
+
+        # Dependency validation
+        for name, enabled in result.items():
+            if not enabled:
+                continue
+            defn = FEATURE_REGISTRY[name]
+            for dep in defn.depends_on:
+                dep_enabled = result.get(dep, FEATURE_REGISTRY[dep].default_enabled)
+                if not dep_enabled:
+                    raise ConfigSchemaError(
+                        f"Feature {name!r} is enabled but its dependency {dep!r} is disabled. "
+                        f"Enable {dep!r} first."
+                    )
+
+        return result
 
     @classmethod
     def from_dynaconf(cls, d: Dynaconf) -> AutomationConfig:
@@ -373,6 +409,7 @@ class AutomationConfig:
         pk = sec("packs")
         ws_raw = sec("workspace")
         fr = sec("franchise")
+        feat = sec("features")
 
         _tc = _field_defaults(TestCheckConfig)
         _cf = _field_defaults(ClassifyFixConfig)
@@ -545,6 +582,7 @@ class AutomationConfig:
                     val(fr, "l2_default_timeout_sec", _fr["l2_default_timeout_sec"])
                 ),
             ),
+            features=AutomationConfig._build_features_dict(dict(feat)),
         )
 
 
@@ -552,6 +590,10 @@ def _build_config_schema() -> dict[str, frozenset[str]]:
     """Derive a two-level schema map {section: {valid_field_names}} from AutomationConfig."""
     schema: dict[str, frozenset[str]] = {}
     for f in dataclasses.fields(AutomationConfig):
+        # Special case: features is a dict[str, bool]; valid sub-keys come from FEATURE_REGISTRY
+        if f.name == "features":
+            schema["features"] = frozenset(FEATURE_REGISTRY.keys())
+            continue
         sub_type: type | None = None
         if f.default_factory is not dataclasses.MISSING:  # type: ignore[misc]
             factory = f.default_factory  # type: ignore[assignment]

--- a/src/autoskillit/core/__init__.py
+++ b/src/autoskillit/core/__init__.py
@@ -41,6 +41,7 @@ from ._terminal_table import _render_terminal_table as _render_terminal_table
 from ._version_snapshot import collect_version_snapshot as collect_version_snapshot
 from .branch_guard import is_protected_branch
 from .claude_conventions import ClaudeDirectoryConventions, LayoutError, validate_add_dir
+from .feature_flags import is_feature_enabled as is_feature_enabled
 from .github_url import _parse_issue_ref as _parse_issue_ref
 from .github_url import normalize_owner_repo as normalize_owner_repo
 from .github_url import parse_github_repo as parse_github_repo
@@ -87,6 +88,7 @@ from .types import (
     CATEGORY_TAGS,
     CONTEXT_EXHAUSTION_MARKER,
     DISPATCH_ID_ENV_VAR,
+    FEATURE_REGISTRY,
     FRANCHISE_ERROR_CODES,
     FRANCHISE_TOOLS,
     FREE_RANGE_TOOLS,
@@ -99,6 +101,7 @@ from .types import (
     RECIPE_PACK_REGISTRY,
     RECIPE_PACK_TAGS,
     RESERVED_LOG_RECORD_KEYS,
+    RETIRED_FEATURES,
     RETIRED_READINESS_TOKENS,
     SESSION_TYPE_ENV_VAR,
     SESSION_TYPE_FRANCHISE,
@@ -125,6 +128,8 @@ from .types import (
     CloneSuccessResult,
     DatabaseReader,
     FailureRecord,
+    FeatureDef,
+    FeatureLifecycle,
     FranchiseErrorCode,
     FranchiseLock,
     GateState,
@@ -249,9 +254,11 @@ __all__ = [
     "TOOL_SUBSET_TAGS",
     "CONTEXT_EXHAUSTION_MARKER",
     "RETIRED_READINESS_TOKENS",
+    "FEATURE_REGISTRY",
     "FRANCHISE_ERROR_CODES",
     "FRANCHISE_TOOLS",
     "FREE_RANGE_TOOLS",
+    "RETIRED_FEATURES",
     "GATED_TOOLS",
     "HEADLESS_TOOLS",
     "PIPELINE_FORBIDDEN_TOOLS",
@@ -276,6 +283,8 @@ __all__ = [
     "CloneSuccessResult",
     "DatabaseReader",
     "FailureRecord",
+    "FeatureDef",
+    "FeatureLifecycle",
     "FranchiseErrorCode",
     "FranchiseLock",
     "GateState",
@@ -344,4 +353,6 @@ __all__ = [
     "DIRECT_PREFIX",
     "MARKETPLACE_PREFIX",
     "detect_autoskillit_mcp_prefix",
+    # feature_flags
+    "is_feature_enabled",
 ]

--- a/src/autoskillit/core/_type_constants.py
+++ b/src/autoskillit/core/_type_constants.py
@@ -333,15 +333,14 @@ FEATURE_REGISTRY: dict[str, FeatureDef] = {
         skill_categories=frozenset(),
         import_package="autoskillit.franchise",
         tier=1,
-        default_enabled=True,  # True during transition; flipped to False in ticket #8
+        default_enabled=True,
         since_version="0.9.51",
     ),
 }
 
 RETIRED_FEATURES: frozenset[str] = frozenset()
 
-# Module-level assertion: all tool_tags entries must exist in TOOL_SUBSET_TAGS tag values.
-# This catches stale tags at import time, before any test or server startup.
+# Guard: FeatureDef.tool_tags must be in TOOL_SUBSET_TAGS — checked at import time.
 _ALL_REGISTERED_TOOL_TAGS: frozenset[str] = frozenset(
     tag for tags in TOOL_SUBSET_TAGS.values() for tag in tags
 )

--- a/src/autoskillit/core/_type_constants.py
+++ b/src/autoskillit/core/_type_constants.py
@@ -5,10 +5,12 @@ Zero autoskillit imports. Provides the shared constant vocabulary for all higher
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
+from datetime import date
 from importlib.metadata import version
 from typing import NamedTuple
 
-from ._type_enums import FranchiseErrorCode
+from ._type_enums import FeatureLifecycle, FranchiseErrorCode
 
 __all__ = [
     "AUTOSKILLIT_INSTALLED_VERSION",
@@ -41,6 +43,9 @@ __all__ = [
     "DISPATCH_ID_ENV_VAR",
     "KITCHEN_SESSION_ID_ENV_VAR",
     "FRANCHISE_ERROR_CODES",
+    "FeatureDef",
+    "FEATURE_REGISTRY",
+    "RETIRED_FEATURES",
 ]
 
 AUTOSKILLIT_INSTALLED_VERSION: str = version("autoskillit")
@@ -300,6 +305,70 @@ TOOL_SUBSET_TAGS: dict[str, frozenset[str]] = {
     # kitchen-core — git
     "merge_worktree": frozenset({"kitchen-core"}),
 }
+
+
+@dataclass(frozen=True)
+class FeatureDef:
+    """Definition of a named feature gate.
+
+    Fields
+    ------
+    name:             Canonical feature name (must match FEATURE_REGISTRY key).
+    lifecycle:        Current lifecycle stage (EXPERIMENTAL / STABLE / DEPRECATED).
+    description:      Human-readable description of the feature.
+    tool_tags:        MCP tool subset tags controlled by this gate.
+    skill_categories: Skill category names controlled by this gate.
+    import_package:   Top-level package to probe for importability (optional).
+    tier:             Isolation tier — 1=package-isolated, 2=tag-isolated, 3=config-only.
+    default_enabled:  Whether the feature is on by default when no config override exists.
+    depends_on:       Other features that must be enabled when this one is enabled.
+    since_version:    Package version when this feature was first introduced (optional).
+    sunset_date:      Date after which the feature should be removed (optional time-bomb).
+    """
+
+    name: str
+    lifecycle: FeatureLifecycle
+    description: str
+    tool_tags: frozenset[str]
+    skill_categories: frozenset[str]
+    import_package: str | None
+    tier: int = 1
+    default_enabled: bool = False
+    depends_on: frozenset[str] = field(default_factory=frozenset)
+    since_version: str | None = None
+    sunset_date: date | None = None
+
+
+FEATURE_REGISTRY: dict[str, FeatureDef] = {
+    "franchise": FeatureDef(
+        name="franchise",
+        lifecycle=FeatureLifecycle.EXPERIMENTAL,
+        description="L3 Franchise Orchestrator — multi-session campaign dispatch",
+        tool_tags=frozenset({"franchise"}),
+        skill_categories=frozenset(),
+        import_package="autoskillit.franchise",
+        tier=1,
+        default_enabled=True,  # True during transition; flipped to False in ticket #8
+        since_version="0.9.51",
+    ),
+}
+
+RETIRED_FEATURES: frozenset[str] = frozenset()
+
+# Module-level assertion: all tool_tags entries must exist in TOOL_SUBSET_TAGS tag values.
+# This catches stale tags at import time, before any test or server startup.
+_ALL_REGISTERED_TOOL_TAGS: frozenset[str] = frozenset(
+    tag for tags in TOOL_SUBSET_TAGS.values() for tag in tags
+)
+assert all(
+    tag in _ALL_REGISTERED_TOOL_TAGS
+    for defn in FEATURE_REGISTRY.values()
+    for tag in defn.tool_tags
+), (
+    "FeatureDef.tool_tags contains a tag not present in TOOL_SUBSET_TAGS values. "
+    "Add the tag to the appropriate tool entry in TOOL_SUBSET_TAGS first."
+)
+
 
 # Canonical prefix required for all skill_command values passed to run_skill.
 # Enforced at the Claude Code hook boundary by skill_command_guard.py.

--- a/src/autoskillit/core/_type_constants.py
+++ b/src/autoskillit/core/_type_constants.py
@@ -309,22 +309,7 @@ TOOL_SUBSET_TAGS: dict[str, frozenset[str]] = {
 
 @dataclass(frozen=True)
 class FeatureDef:
-    """Definition of a named feature gate.
-
-    Fields
-    ------
-    name:             Canonical feature name (must match FEATURE_REGISTRY key).
-    lifecycle:        Current lifecycle stage (EXPERIMENTAL / STABLE / DEPRECATED).
-    description:      Human-readable description of the feature.
-    tool_tags:        MCP tool subset tags controlled by this gate.
-    skill_categories: Skill category names controlled by this gate.
-    import_package:   Top-level package to probe for importability (optional).
-    tier:             Isolation tier — 1=package-isolated, 2=tag-isolated, 3=config-only.
-    default_enabled:  Whether the feature is on by default when no config override exists.
-    depends_on:       Other features that must be enabled when this one is enabled.
-    since_version:    Package version when this feature was first introduced (optional).
-    sunset_date:      Date after which the feature should be removed (optional time-bomb).
-    """
+    """Definition of a named feature gate."""
 
     name: str
     lifecycle: FeatureLifecycle
@@ -360,14 +345,15 @@ RETIRED_FEATURES: frozenset[str] = frozenset()
 _ALL_REGISTERED_TOOL_TAGS: frozenset[str] = frozenset(
     tag for tags in TOOL_SUBSET_TAGS.values() for tag in tags
 )
-assert all(
+if not all(
     tag in _ALL_REGISTERED_TOOL_TAGS
     for defn in FEATURE_REGISTRY.values()
     for tag in defn.tool_tags
-), (
-    "FeatureDef.tool_tags contains a tag not present in TOOL_SUBSET_TAGS values. "
-    "Add the tag to the appropriate tool entry in TOOL_SUBSET_TAGS first."
-)
+):
+    raise AssertionError(
+        "FeatureDef.tool_tags contains a tag not present in TOOL_SUBSET_TAGS values. "
+        "Add the tag to the appropriate tool entry in TOOL_SUBSET_TAGS first."
+    )
 
 
 # Canonical prefix required for all skill_command values passed to run_skill.

--- a/src/autoskillit/core/_type_enums.py
+++ b/src/autoskillit/core/_type_enums.py
@@ -30,6 +30,7 @@ __all__ = [
     "SessionType",
     "session_type",
     "FranchiseErrorCode",
+    "FeatureLifecycle",
 ]
 
 
@@ -401,3 +402,16 @@ class FranchiseErrorCode(StrEnum):
     DISPATCH_BUDGET_EXCEEDED = "dispatch_budget_exceeded"
     QUOTA_EXHAUSTED = "quota_exhausted"
     CLEANUP_FAILED = "cleanup_failed"
+
+
+class FeatureLifecycle(StrEnum):
+    """Lifecycle stage of a registered feature gate.
+
+    EXPERIMENTAL — Off by default; explicit opt-in required via config or env var.
+    STABLE       — On by default; opt-out possible via config.
+    DEPRECATED   — Scheduled for removal; may be disabled without warning.
+    """
+
+    EXPERIMENTAL = "experimental"
+    STABLE = "stable"
+    DEPRECATED = "deprecated"

--- a/src/autoskillit/core/feature_flags.py
+++ b/src/autoskillit/core/feature_flags.py
@@ -1,0 +1,37 @@
+"""Feature flag resolution — L0 (zero autoskillit imports outside core/).
+
+is_feature_enabled() is the single gating primitive for all feature-gated
+code paths. Callers pass config.features (a dict[str, bool]) rather than the
+full AutomationConfig to keep core/ free of config/ imports.
+"""
+
+from __future__ import annotations
+
+from ._type_constants import FEATURE_REGISTRY
+
+
+def is_feature_enabled(name: str, features: dict[str, bool]) -> bool:
+    """Check whether a named feature is enabled.
+
+    Parameters
+    ----------
+    name:
+        Feature name — must exist in FEATURE_REGISTRY. Raises KeyError otherwise.
+    features:
+        Resolved features dict from ``AutomationConfig.features``. Typically
+        passed as ``config.features`` at call sites; never pass the full config.
+
+    Returns
+    -------
+    bool
+        ``features[name]`` if the key is present; otherwise ``FeatureDef.default_enabled``.
+
+    Raises
+    ------
+    KeyError
+        If ``name`` is not a registered feature in FEATURE_REGISTRY.
+    """
+    defn = FEATURE_REGISTRY.get(name)
+    if defn is None:
+        raise KeyError(f"Unknown feature: {name!r}")
+    return features.get(name, defn.default_enabled)

--- a/tests/arch/test_feature_registry.py
+++ b/tests/arch/test_feature_registry.py
@@ -111,37 +111,20 @@ def test_feature_skill_categories_match_real_skills():
     from autoskillit.core.paths import pkg_root
 
     skills_dirs = [pkg_root() / "skills", pkg_root() / "skills_extended"]
-    # Build a set of all category tags found in any SKILL.md
+    # Build a set of skill directory names as proxy for categories
     all_category_tags: set[str] = set()
     for skills_dir in skills_dirs:
         if not skills_dir.exists():
             continue
         for skill_md in skills_dir.rglob("SKILL.md"):
-            content = skill_md.read_text(encoding="utf-8")
-            for line in content.splitlines():
-                if line.strip().startswith("categories:") or "category:" in line:
-                    # naive tag extraction — collect any word after "- "
-                    pass
-            # Collect skill directory names as proxy for categories
             all_category_tags.add(skill_md.parent.name)
 
-    # Collect all category tags from all SKILL.md `category:` frontmatter lines
-    # (fallback: accept skill directory name match)
-    violations = []
-    for defn in FEATURE_REGISTRY.values():
-        for cat in defn.skill_categories:
-            # A skill_category must match at least one real skill directory name
-            # or appear as a category tag somewhere under skills/ or skills_extended/
-            found = any(
-                cat == skill_md.parent.name
-                for sd in skills_dirs
-                if sd.exists()
-                for skill_md in sd.rglob("SKILL.md")
-            )
-            if not found:
-                violations.append(
-                    f"{defn.name}.skill_categories contains {cat!r}: no matching SKILL.md found"
-                )
+    violations = [
+        f"{defn.name}.skill_categories contains {cat!r}: no matching SKILL.md found"
+        for defn in FEATURE_REGISTRY.values()
+        for cat in defn.skill_categories
+        if cat not in all_category_tags
+    ]
     assert not violations, "\n".join(violations)
 
 
@@ -192,7 +175,7 @@ def test_config_rejects_unknown_feature():
         AutomationConfig._build_features_dict({unknown: True})
 
 
-def test_config_dependency_validation():
+def test_config_dependency_validation(monkeypatch):
     """_build_features_dict raises ConfigSchemaError when B is enabled but dep A is disabled."""
 
     from autoskillit.config.settings import AutomationConfig, ConfigSchemaError
@@ -219,18 +202,13 @@ def test_config_dependency_validation():
     )
     import autoskillit.core._type_constants as tc
 
-    original = dict(tc.FEATURE_REGISTRY)
-    tc.FEATURE_REGISTRY["test_dep_a"] = dep_parent
-    tc.FEATURE_REGISTRY["test_dep_b"] = dep_feature
-    try:
-        # B enabled without A → ConfigSchemaError
-        with pytest.raises(ConfigSchemaError):
-            AutomationConfig._build_features_dict({"test_dep_b": True, "test_dep_a": False})
-        # B enabled with A → no error
-        AutomationConfig._build_features_dict({"test_dep_b": True, "test_dep_a": True})
-    finally:
-        tc.FEATURE_REGISTRY.clear()
-        tc.FEATURE_REGISTRY.update(original)
+    monkeypatch.setitem(tc.FEATURE_REGISTRY, "test_dep_a", dep_parent)
+    monkeypatch.setitem(tc.FEATURE_REGISTRY, "test_dep_b", dep_feature)
+    # B enabled without A → ConfigSchemaError
+    with pytest.raises(ConfigSchemaError):
+        AutomationConfig._build_features_dict({"test_dep_b": True, "test_dep_a": False})
+    # B enabled with A → no error
+    AutomationConfig._build_features_dict({"test_dep_b": True, "test_dep_a": True})
 
 
 def test_no_unregistered_feature_tag_on_tools():

--- a/tests/arch/test_feature_registry.py
+++ b/tests/arch/test_feature_registry.py
@@ -147,6 +147,7 @@ def test_is_feature_enabled_override():
     from autoskillit.core._type_constants import FEATURE_REGISTRY
     from autoskillit.core.feature_flags import is_feature_enabled
 
+    assert len(FEATURE_REGISTRY) > 0, "FEATURE_REGISTRY must not be empty"
     for name in FEATURE_REGISTRY:
         assert is_feature_enabled(name, {name: True}) is True
         assert is_feature_enabled(name, {name: False}) is False

--- a/tests/arch/test_feature_registry.py
+++ b/tests/arch/test_feature_registry.py
@@ -4,10 +4,8 @@ from __future__ import annotations
 
 import importlib
 from datetime import date
-from pathlib import Path
 
 import pytest
-
 
 # ── Structural registry tests ─────────────────────────────────────────────────
 
@@ -195,12 +193,10 @@ def test_config_rejects_unknown_feature():
 
 
 def test_config_dependency_validation():
-    """_build_features_dict raises ConfigSchemaError when B is enabled but its dep A is disabled."""
-    import dataclasses
-    from datetime import date as _date
+    """_build_features_dict raises ConfigSchemaError when B is enabled but dep A is disabled."""
 
     from autoskillit.config.settings import AutomationConfig, ConfigSchemaError
-    from autoskillit.core._type_constants import FEATURE_REGISTRY, FeatureDef
+    from autoskillit.core._type_constants import FeatureDef
     from autoskillit.core._type_enums import FeatureLifecycle
 
     # Temporarily patch FEATURE_REGISTRY with a dep-requiring entry for this test

--- a/tests/arch/test_feature_registry.py
+++ b/tests/arch/test_feature_registry.py
@@ -1,0 +1,262 @@
+"""Feature registry structural and behavioral self-tests."""
+
+from __future__ import annotations
+
+import importlib
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+
+# ── Structural registry tests ─────────────────────────────────────────────────
+
+
+def test_feature_lifecycle_enum_exists():
+    """FeatureLifecycle StrEnum exists with 3 members."""
+    from autoskillit.core._type_enums import FeatureLifecycle
+
+    assert set(FeatureLifecycle) == {
+        FeatureLifecycle.EXPERIMENTAL,
+        FeatureLifecycle.STABLE,
+        FeatureLifecycle.DEPRECATED,
+    }
+
+
+def test_feature_registry_keys_are_sorted():
+    """FEATURE_REGISTRY keys must be alphabetically sorted (prevents merge conflicts)."""
+    from autoskillit.core._type_constants import FEATURE_REGISTRY
+
+    keys = list(FEATURE_REGISTRY.keys())
+    assert keys == sorted(keys), f"FEATURE_REGISTRY keys not sorted: {keys}"
+
+
+def test_feature_tool_tags_exist_in_subset_tags():
+    """Every FeatureDef.tool_tags entry exists in TOOL_SUBSET_TAGS tag values."""
+    from autoskillit.core._type_constants import FEATURE_REGISTRY, TOOL_SUBSET_TAGS
+
+    all_tags = frozenset(tag for tags in TOOL_SUBSET_TAGS.values() for tag in tags)
+    violations = [
+        f"{defn.name}.tool_tags contains {tag!r} not in TOOL_SUBSET_TAGS"
+        for defn in FEATURE_REGISTRY.values()
+        for tag in defn.tool_tags
+        if tag not in all_tags
+    ]
+    assert not violations, "\n".join(violations)
+
+
+def test_feature_import_package_exists():
+    """Every FeatureDef.import_package resolves to a real importable package."""
+    from autoskillit.core._type_constants import FEATURE_REGISTRY
+
+    failures = []
+    for defn in FEATURE_REGISTRY.values():
+        if defn.import_package is None:
+            continue
+        try:
+            importlib.import_module(defn.import_package)
+        except ImportError as e:
+            failures.append(f"{defn.name}.import_package={defn.import_package!r}: {e}")
+    assert not failures, "\n".join(failures)
+
+
+def test_no_retired_feature_has_live_registry_entry():
+    """RETIRED_FEATURES and FEATURE_REGISTRY must be disjoint."""
+    from autoskillit.core._type_constants import FEATURE_REGISTRY, RETIRED_FEATURES
+
+    overlap = RETIRED_FEATURES & frozenset(FEATURE_REGISTRY.keys())
+    assert not overlap, f"Names appear in both RETIRED_FEATURES and FEATURE_REGISTRY: {overlap}"
+
+
+def test_stable_features_are_default_enabled():
+    """lifecycle=STABLE implies default_enabled=True."""
+    from autoskillit.core._type_constants import FEATURE_REGISTRY
+    from autoskillit.core._type_enums import FeatureLifecycle
+
+    violations = [
+        defn.name
+        for defn in FEATURE_REGISTRY.values()
+        if defn.lifecycle == FeatureLifecycle.STABLE and not defn.default_enabled
+    ]
+    assert not violations, f"STABLE features must be default_enabled=True: {violations}"
+
+
+def test_sunset_dates_not_expired():
+    """Time-bomb: no FeatureDef may have a sunset_date in the past."""
+    from autoskillit.core._type_constants import FEATURE_REGISTRY
+
+    today = date.today()
+    expired = [
+        f"{defn.name} (sunset={defn.sunset_date})"
+        for defn in FEATURE_REGISTRY.values()
+        if defn.sunset_date is not None and defn.sunset_date < today
+    ]
+    assert not expired, f"Features with expired sunset_date: {expired}"
+
+
+def test_feature_depends_on_references_valid_features():
+    """All depends_on entries must reference names that exist in FEATURE_REGISTRY."""
+    from autoskillit.core._type_constants import FEATURE_REGISTRY
+
+    violations = [
+        f"{defn.name}.depends_on contains unknown {dep!r}"
+        for defn in FEATURE_REGISTRY.values()
+        for dep in defn.depends_on
+        if dep not in FEATURE_REGISTRY
+    ]
+    assert not violations, "\n".join(violations)
+
+
+def test_feature_skill_categories_match_real_skills():
+    """Every FeatureDef.skill_categories entry maps to at least one SKILL.md."""
+    from autoskillit.core._type_constants import FEATURE_REGISTRY
+    from autoskillit.core.paths import pkg_root
+
+    skills_dirs = [pkg_root() / "skills", pkg_root() / "skills_extended"]
+    # Build a set of all category tags found in any SKILL.md
+    all_category_tags: set[str] = set()
+    for skills_dir in skills_dirs:
+        if not skills_dir.exists():
+            continue
+        for skill_md in skills_dir.rglob("SKILL.md"):
+            content = skill_md.read_text(encoding="utf-8")
+            for line in content.splitlines():
+                if line.strip().startswith("categories:") or "category:" in line:
+                    # naive tag extraction — collect any word after "- "
+                    pass
+            # Collect skill directory names as proxy for categories
+            all_category_tags.add(skill_md.parent.name)
+
+    # Collect all category tags from all SKILL.md `category:` frontmatter lines
+    # (fallback: accept skill directory name match)
+    violations = []
+    for defn in FEATURE_REGISTRY.values():
+        for cat in defn.skill_categories:
+            # A skill_category must match at least one real skill directory name
+            # or appear as a category tag somewhere under skills/ or skills_extended/
+            found = any(
+                cat == skill_md.parent.name
+                for sd in skills_dirs
+                if sd.exists()
+                for skill_md in sd.rglob("SKILL.md")
+            )
+            if not found:
+                violations.append(
+                    f"{defn.name}.skill_categories contains {cat!r}: no matching SKILL.md found"
+                )
+    assert not violations, "\n".join(violations)
+
+
+# ── is_feature_enabled() behavioral tests ────────────────────────────────────
+
+
+def test_is_feature_enabled_defaults():
+    """is_feature_enabled uses FeatureDef.default_enabled when key absent from dict."""
+    from autoskillit.core._type_constants import FEATURE_REGISTRY
+    from autoskillit.core.feature_flags import is_feature_enabled
+
+    for name, defn in FEATURE_REGISTRY.items():
+        assert is_feature_enabled(name, {}) == defn.default_enabled, (
+            f"{name}: is_feature_enabled({name!r}, {{}}) should be {defn.default_enabled}"
+        )
+
+
+def test_is_feature_enabled_override():
+    """is_feature_enabled respects explicit overrides in the features dict."""
+    from autoskillit.core._type_constants import FEATURE_REGISTRY
+    from autoskillit.core.feature_flags import is_feature_enabled
+
+    for name in FEATURE_REGISTRY:
+        assert is_feature_enabled(name, {name: True}) is True
+        assert is_feature_enabled(name, {name: False}) is False
+
+
+def test_is_feature_enabled_unknown():
+    """is_feature_enabled raises KeyError for an unknown feature name."""
+    from autoskillit.core.feature_flags import is_feature_enabled
+
+    with pytest.raises(KeyError, match="unknown_feature_xyz"):
+        is_feature_enabled("unknown_feature_xyz", {})
+
+
+# ── Config integration tests ──────────────────────────────────────────────────
+
+
+def test_config_rejects_unknown_feature():
+    """_build_features_dict raises ConfigSchemaError for keys not in FEATURE_REGISTRY."""
+    from autoskillit.config.settings import AutomationConfig, ConfigSchemaError
+    from autoskillit.core._type_constants import FEATURE_REGISTRY
+
+    unknown = "this_feature_does_not_exist_xyz"
+    assert unknown not in FEATURE_REGISTRY, "Test setup error: pick a truly unknown name"
+
+    with pytest.raises(ConfigSchemaError, match=unknown):
+        AutomationConfig._build_features_dict({unknown: True})
+
+
+def test_config_dependency_validation():
+    """_build_features_dict raises ConfigSchemaError when B is enabled but its dep A is disabled."""
+    import dataclasses
+    from datetime import date as _date
+
+    from autoskillit.config.settings import AutomationConfig, ConfigSchemaError
+    from autoskillit.core._type_constants import FEATURE_REGISTRY, FeatureDef
+    from autoskillit.core._type_enums import FeatureLifecycle
+
+    # Temporarily patch FEATURE_REGISTRY with a dep-requiring entry for this test
+    dep_feature = FeatureDef(
+        name="test_dep_b",
+        lifecycle=FeatureLifecycle.EXPERIMENTAL,
+        description="test dep B",
+        tool_tags=frozenset(),
+        skill_categories=frozenset(),
+        import_package=None,
+        depends_on=frozenset({"test_dep_a"}),
+    )
+    dep_parent = FeatureDef(
+        name="test_dep_a",
+        lifecycle=FeatureLifecycle.EXPERIMENTAL,
+        description="test dep A",
+        tool_tags=frozenset(),
+        skill_categories=frozenset(),
+        import_package=None,
+    )
+    import autoskillit.core._type_constants as tc
+
+    original = dict(tc.FEATURE_REGISTRY)
+    tc.FEATURE_REGISTRY["test_dep_a"] = dep_parent
+    tc.FEATURE_REGISTRY["test_dep_b"] = dep_feature
+    try:
+        # B enabled without A → ConfigSchemaError
+        with pytest.raises(ConfigSchemaError):
+            AutomationConfig._build_features_dict({"test_dep_b": True, "test_dep_a": False})
+        # B enabled with A → no error
+        AutomationConfig._build_features_dict({"test_dep_b": True, "test_dep_a": True})
+    finally:
+        tc.FEATURE_REGISTRY.clear()
+        tc.FEATURE_REGISTRY.update(original)
+
+
+def test_no_unregistered_feature_tag_on_tools():
+    """No tool in TOOL_SUBSET_TAGS may carry a tag absent from all known registries.
+
+    Known registries: FEATURE_REGISTRY names, PACK_REGISTRY names, and known
+    non-feature structural tags (e.g. 'kitchen-core').
+    """
+    from autoskillit.core._type_constants import (
+        FEATURE_REGISTRY,
+        PACK_REGISTRY,
+        TOOL_SUBSET_TAGS,
+    )
+
+    # Known structural (non-feature, non-pack) tags that are always valid
+    STRUCTURAL_TAGS: frozenset[str] = frozenset({"kitchen-core"})
+
+    known = frozenset(FEATURE_REGISTRY.keys()) | frozenset(PACK_REGISTRY.keys()) | STRUCTURAL_TAGS
+    violations = [
+        f"Tool {tool!r} has tag {tag!r} not in FEATURE_REGISTRY, PACK_REGISTRY, or STRUCTURAL_TAGS"
+        for tool, tags in TOOL_SUBSET_TAGS.items()
+        for tag in tags
+        if tag not in known
+    ]
+    assert not violations, "\n".join(violations)

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -682,7 +682,9 @@ def test_no_subpackage_exceeds_10_files() -> None:
         _plugin_cache.py adds the plugin cache lifecycle: retiring cache sweep,
         install locking, and kitchen registry (accessible from server/ without
         cli/ import).
-        Exempt at 20 files.
+        feature_flags.py adds the L0 is_feature_enabled() primitive — must live
+        in core/ to be importable by all layers without cross-layer violations.
+        Exempt at 24 files.
       cli/ — REQ-CNST-003-E5: cli/ retains _terminal_table.py as a re-export shim
         for backward-compatible cli/ imports; canonical implementation lives in
         core/_terminal_table.py. Also contains _terminal.py — the terminal state
@@ -706,7 +708,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "server": 20,
         "recipe": 36,
         "execution": 26,
-        "core": 23,
+        "core": 24,
         "cli": 22,
         "hooks": 22,
     }


### PR DESCRIPTION
## Summary

Establish the core feature gate data model, configuration integration, and a 15-test self-test
suite. All changes are purely additive — no existing behavior changes. `franchise` is registered
with `default_enabled=True` so all current behavior is preserved during the transition period.

The implementation spans 8 files:
- `src/autoskillit/core/_type_enums.py` — add `FeatureLifecycle`
- `src/autoskillit/core/_type_constants.py` — add `FeatureDef`, `FEATURE_REGISTRY`, `RETIRED_FEATURES`
- `src/autoskillit/core/feature_flags.py` — **new**: `is_feature_enabled()`
- `src/autoskillit/core/__init__.py` — re-export new symbols
- `src/autoskillit/config/settings.py` — add `features` field + validator + schema fix
- `src/autoskillit/config/defaults.yaml` — add `features: { franchise: true }`
- `tests/arch/test_feature_registry.py` — **new**: 15 self-tests
- `tests/arch/test_subpackage_isolation.py` — bump `core/` file count exemption 23 → 24

## Architecture Impact

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph L1 ["L1 — CONFIG"]
        direction LR
        SETTINGS["● config/settings.py<br/>━━━━━━━━━━<br/>AutomationConfig<br/>_build_features_dict()<br/>imports FEATURE_REGISTRY"]
        DEFAULTS["● config/defaults.yaml<br/>━━━━━━━━━━<br/>features: {franchise: true}<br/>Runtime gate defaults"]
    end

    subgraph L0_SURFACE ["L0 — CORE PUBLIC SURFACE"]
        CORE_INIT["● core/__init__.py<br/>━━━━━━━━━━<br/>Re-exports: is_feature_enabled<br/>FeatureDef, FEATURE_REGISTRY<br/>FeatureLifecycle, RETIRED_FEATURES"]
    end

    subgraph L0_INTERNALS ["L0 — CORE INTERNALS (stdlib-only)"]
        direction LR
        ENUMS["● core/_type_enums.py<br/>━━━━━━━━━━<br/>FeatureLifecycle (new)<br/>FranchiseErrorCode<br/>+ 20 other StrEnums"]
        CONSTANTS["● core/_type_constants.py<br/>━━━━━━━━━━<br/>FeatureDef (new dataclass)<br/>FEATURE_REGISTRY (new)<br/>RETIRED_FEATURES (new)<br/>tool/pack/subset constants"]
        FEATURE_FLAGS["★ core/feature_flags.py<br/>━━━━━━━━━━<br/>is_feature_enabled()<br/>name → FEATURE_REGISTRY<br/>→ FeatureDef.default_enabled"]
    end

    subgraph TESTS ["TESTS — arch/"]
        TEST_REGISTRY["★ tests/arch/test_feature_registry.py<br/>━━━━━━━━━━<br/>Structural registry invariants<br/>is_feature_enabled() behavior<br/>Config integration tests"]
        TEST_ISOLATION["● tests/arch/test_subpackage_isolation.py<br/>━━━━━━━━━━<br/>Subpackage isolation rules<br/>REQ-ARCH-002 (DS-008)"]
    end

    %% VALID DOWNWARD DEPENDENCIES %%
    SETTINGS -->|"imports FEATURE_REGISTRY<br/>OutputFormat, CATEGORY_TAGS<br/>via autoskillit.core"| CORE_INIT
    DEFAULTS -.->|"loaded by dynaconf<br/>into settings"| SETTINGS

    CORE_INIT -->|"re-exports from"| FEATURE_FLAGS
    CORE_INIT -->|"re-exports from<br/>(via .types)"| CONSTANTS

    FEATURE_FLAGS -->|"imports FEATURE_REGISTRY"| CONSTANTS
    CONSTANTS -->|"imports FeatureLifecycle<br/>FranchiseErrorCode"| ENUMS

    %% TEST DEPENDENCIES %%
    TEST_REGISTRY -->|"from autoskillit.core._type_constants<br/>FEATURE_REGISTRY, FeatureDef, etc."| CONSTANTS
    TEST_REGISTRY -->|"from autoskillit.core._type_enums<br/>FeatureLifecycle"| ENUMS
    TEST_REGISTRY -->|"from autoskillit.core.feature_flags<br/>is_feature_enabled"| FEATURE_FLAGS
    TEST_REGISTRY -->|"from autoskillit.config.settings<br/>AutomationConfig"| SETTINGS
    TEST_ISOLATION -->|"tests isolation rules<br/>for L0 modules"| CORE_INIT

    %% CLASS ASSIGNMENTS %%
    class SETTINGS handler;
    class DEFAULTS output;
    class CORE_INIT stateNode;
    class ENUMS phase;
    class CONSTANTS phase;
    class FEATURE_FLAGS newComponent;
    class TEST_REGISTRY newComponent;
    class TEST_ISOLATION detector;
```

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 65, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START([MODULE IMPORT])

    subgraph L0_Registry ["★ L0: FEATURE_REGISTRY — Static, Immutable"]
        direction TB
        FeatureLifecycleEnum["● FeatureLifecycle<br/>━━━━━━━━━━<br/>EXPERIMENTAL / STABLE / DEPRECATED<br/>_type_enums.py — StrEnum"]
        FeatureDef["● FeatureDef<br/>━━━━━━━━━━<br/>frozen dataclass — INIT_ONLY<br/>name, lifecycle, description<br/>tool_tags, skill_categories<br/>import_package, tier<br/>default_enabled, depends_on<br/>since_version, sunset_date<br/>_type_constants.py"]
        FeatureRegistry["● FEATURE_REGISTRY: dict[str,FeatureDef]<br/>━━━━━━━━━━<br/>Static at import — INIT_ONLY<br/>Currently: { 'franchise': ... }<br/>_type_constants.py"]
        RetiredFeatures["● RETIRED_FEATURES: frozenset[str]<br/>━━━━━━━━━━<br/>Disjoint from FEATURE_REGISTRY — INIT_ONLY<br/>_type_constants.py"]
        ModuleAssert["● Module-level assert<br/>━━━━━━━━━━<br/>tool_tags ⊆ TOOL_SUBSET_TAGS values<br/>Fails at import — fail-fast gate"]
    end

    subgraph L0_Primitive ["★ L0: is_feature_enabled() — Derived Resolver"]
        direction TB
        IsFeatEnabled["★ is_feature_enabled(name, features)<br/>━━━━━━━━━━<br/>DERIVED — never stored<br/>1. name not in REGISTRY → KeyError<br/>2. return features.get(name, defn.default_enabled)<br/>feature_flags.py — L0 primitive"]
    end

    subgraph L1_Config ["● L1: AutomationConfig — Mutable per Load"]
        direction TB
        FeaturesDict["● AutomationConfig.features: dict[str,bool]<br/>━━━━━━━━━━<br/>MUTABLE — replaced on each config load<br/>Empty dict = all defaults apply<br/>settings.py"]
        BuildFeatDict["● _build_features_dict(raw)<br/>━━━━━━━━━━<br/>Validation gate — raises ConfigSchemaError<br/>1. Unknown feature name → KeyError guard<br/>2. Dependency violation: B enabled, A disabled<br/>Coerces values to bool<br/>settings.py"]
        ConfigSchema["● _build_config_schema()<br/>━━━━━━━━━━<br/>features section → frozenset(FEATURE_REGISTRY.keys())<br/>Drives validate_layer_keys()<br/>settings.py"]
    end

    subgraph Config_Layers ["● Config Layer Resolution (Dynaconf)"]
        direction LR
        DefaultsYaml["● defaults.yaml<br/>━━━━━━━━━━<br/>Package defaults (lowest priority)<br/>config/defaults.yaml"]
        UserYaml["User config<br/>━━━━━━━━━━<br/>~/.autoskillit/config.yaml<br/>(optional)"]
        ProjectYaml["Project config<br/>━━━━━━━━━━<br/>.autoskillit/config.yaml<br/>(optional)"]
        EnvVars["Env vars<br/>━━━━━━━━━━<br/>AUTOSKILLIT_FEATURES__&lt;name&gt;=true/false<br/>(highest priority)"]
    end

    subgraph Validation_Gates ["Validation Gates — State Corruption Prevention"]
        direction TB
        Gate1["GATE 1 — Import-time<br/>━━━━━━━━━━<br/>ModuleAssert: tool_tags ⊆ TOOL_SUBSET_TAGS<br/>Raises AssertionError at import<br/>No runtime bypass possible"]
        Gate2["GATE 2 — Config load<br/>━━━━━━━━━━<br/>validate_layer_keys() per YAML layer<br/>ConfigSchemaError: unknown feature names<br/>Before Dynaconf merges layers"]
        Gate3["GATE 3 — Features dict build<br/>━━━━━━━━━━<br/>_build_features_dict() on from_dynaconf()<br/>ConfigSchemaError: unknown names + dep violations<br/>Prevents malformed config from reaching callers"]
        Gate4["GATE 4 — Call-site query<br/>━━━━━━━━━━<br/>is_feature_enabled(name, features)<br/>KeyError: name not in FEATURE_REGISTRY<br/>Prevents typos from silently defaulting"]
    end

    subgraph Contract_Tests ["★ Contract Tests — Structural Self-Enforcement"]
        direction TB
        TestRegistry["★ test_feature_registry.py<br/>━━━━━━━━━━<br/>STRUCTURAL (read-only audit):<br/>• Keys alphabetically sorted<br/>• tool_tags ⊆ TOOL_SUBSET_TAGS<br/>• import_package importable<br/>• RETIRED ∩ REGISTRY = ∅<br/>• STABLE → default_enabled=True<br/>• sunset_date not expired (time-bomb)<br/>• depends_on refs valid<br/>• skill_categories match SKILL.md"]
        TestBehavior["★ test_feature_registry.py (behavioral)<br/>━━━━━━━━━━<br/>• default fallback to FeatureDef.default_enabled<br/>• explicit override True/False respected<br/>• KeyError on unknown name<br/>• ConfigSchemaError on unknown feature in config<br/>• ConfigSchemaError on dep violation"]
        TestIsolation["● test_subpackage_isolation.py<br/>━━━━━━━━━━<br/>feature_flags.py: zero imports outside core/<br/>_type_constants.py: zero autoskillit imports"]
    end

    subgraph Contract_Lifecycle ["FeatureLifecycle Contract Rules"]
        direction TB
        ExpContract["EXPERIMENTAL<br/>━━━━━━━━━━<br/>default_enabled may be False or True<br/>Explicit opt-in via config/env<br/>No removal guarantee"]
        StableContract["STABLE<br/>━━━━━━━━━━<br/>default_enabled MUST be True<br/>Opt-out via config<br/>CONTRACT: test_stable_features_are_default_enabled"]
        DeprecatedContract["DEPRECATED<br/>━━━━━━━━━━<br/>May be disabled without warning<br/>sunset_date triggers time-bomb test<br/>CONTRACT: test_sunset_dates_not_expired"]
    end

    %% FLOW %%
    START --> FeatureLifecycleEnum
    START --> FeatureDef
    FeatureLifecycleEnum --> FeatureDef
    FeatureDef --> FeatureRegistry
    FeatureDef --> RetiredFeatures
    FeatureRegistry --> ModuleAssert
    ModuleAssert --> Gate1

    Gate1 --> IsFeatEnabled
    Gate1 --> ConfigSchema

    DefaultsYaml --> Gate2
    UserYaml --> Gate2
    ProjectYaml --> Gate2
    EnvVars --> FeaturesDict

    Gate2 --> BuildFeatDict
    ConfigSchema --> Gate2
    BuildFeatDict --> Gate3
    Gate3 --> FeaturesDict
    FeaturesDict --> Gate4
    FeatureRegistry --> Gate4
    Gate4 --> IsFeatEnabled

    FeatureLifecycleEnum --> ExpContract
    FeatureLifecycleEnum --> StableContract
    FeatureLifecycleEnum --> DeprecatedContract

    FeatureRegistry --> TestRegistry
    IsFeatEnabled --> TestBehavior
    BuildFeatDict --> TestBehavior
    FeatureRegistry --> TestIsolation
    IsFeatEnabled --> TestIsolation

    %% CLASS ASSIGNMENTS %%
    class FeatureLifecycleEnum gap;
    class FeatureDef detector;
    class FeatureRegistry,RetiredFeatures stateNode;
    class ModuleAssert,Gate1,Gate2,Gate3,Gate4 detector;
    class IsFeatEnabled newComponent;
    class FeaturesDict phase;
    class BuildFeatDict,ConfigSchema handler;
    class DefaultsYaml,UserYaml,ProjectYaml,EnvVars cli;
    class TestRegistry,TestBehavior newComponent;
    class TestIsolation output;
    class ExpContract,DeprecatedContract gap;
    class StableContract stateNode;
    class START terminal;
```

Closes #1101

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260422-114106-981001/.autoskillit/temp/make-plan/feature_gate_registry_foundation_plan_2026-04-22_000000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 171 | 20.5k | 1.3M | 122.7k | 1 | 6m 34s |
| verify | 124 | 13.7k | 1.1M | 93.5k | 1 | 3m 48s |
| implement | 594 | 32.5k | 5.6M | 96.3k | 1 | 9m 57s |
| fix | 194 | 7.5k | 1.1M | 51.2k | 1 | 6m 25s |
| prepare_pr | 52 | 4.6k | 166.8k | 31.7k | 1 | 1m 15s |
| run_arch_lenses | 130 | 11.1k | 485.2k | 78.2k | 2 | 3m 35s |
| compose_pr | 59 | 6.0k | 197.7k | 31.4k | 1 | 1m 35s |
| **Total** | 1.3k | 95.9k | 9.9M | 505.0k | | 33m 11s |