### PR TITLE
Implementation Plan: Recipe Feature Gate Validation Rule (rules_features.py)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,7 @@ generic_automation_mcp/
 │   ├── rules_cmd.py
 │   ├── rules_contracts.py
 │   ├── rules_dataflow.py
+│   ├── rules_features.py
 │   ├── rules_fixing.py
 │   ├── rules_graph.py
 │   ├── rules_inputs.py

--- a/src/autoskillit/recipe/__init__.py
+++ b/src/autoskillit/recipe/__init__.py
@@ -15,6 +15,7 @@ from autoskillit.recipe import rules_clone as _rules_clone  # noqa: E402 F401
 from autoskillit.recipe import rules_cmd as _rules_cmd  # noqa: E402 F401
 from autoskillit.recipe import rules_contracts as _rules_contracts  # noqa: E402 F401
 from autoskillit.recipe import rules_dataflow as _rules_dataflow  # noqa: E402 F401
+from autoskillit.recipe import rules_features as _rules_features  # noqa: E402 F401
 from autoskillit.recipe import rules_fixing as _rules_fixing  # noqa: E402 F401
 from autoskillit.recipe import rules_graph as _rules_graph  # noqa: E402 F401
 from autoskillit.recipe import rules_inputs as _rules_inputs  # noqa: E402 F401

--- a/src/autoskillit/recipe/_analysis.py
+++ b/src/autoskillit/recipe/_analysis.py
@@ -219,6 +219,7 @@ class ValidationContext:
     available_sub_recipes: frozenset[str] = field(default_factory=frozenset)
     project_dir: Path | None = None
     disabled_subsets: frozenset[str] = field(default_factory=frozenset)
+    disabled_features: frozenset[str] = field(default_factory=frozenset)
     skill_category_map: dict[str, frozenset[str]] | None = None
     overridden_skills: frozenset[str] | None = None
     blocks: tuple[RecipeBlock, ...] = field(default_factory=tuple)
@@ -807,6 +808,7 @@ def make_validation_context(
     available_sub_recipes: frozenset[str] = frozenset(),
     project_dir: Path | None = None,
     disabled_subsets: frozenset[str] = frozenset(),
+    disabled_features: frozenset[str] = frozenset(),
 ) -> ValidationContext:
     """Build a ``ValidationContext`` from a recipe.
 
@@ -830,6 +832,7 @@ def make_validation_context(
         available_sub_recipes=available_sub_recipes,
         project_dir=project_dir,
         disabled_subsets=disabled_subsets,
+        disabled_features=disabled_features,
         blocks=extract_blocks(recipe, step_graph, predecessors=predecessors),
         predecessors=predecessors,
     )

--- a/src/autoskillit/recipe/rules_features.py
+++ b/src/autoskillit/recipe/rules_features.py
@@ -17,7 +17,6 @@ from autoskillit.recipe._analysis import ValidationContext
 from autoskillit.recipe.contracts import resolve_skill_name
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -25,18 +24,12 @@ from autoskillit.recipe.registry import RuleFinding, semantic_rule
 
 def _tools_for_feature(fdef: FeatureDef) -> frozenset[str]:
     """Return all MCP tool names that carry at least one of this feature's tool_tags."""
-    return frozenset(
-        tool for tool, tags in TOOL_SUBSET_TAGS.items() if fdef.tool_tags & tags
-    )
+    return frozenset(tool for tool, tags in TOOL_SUBSET_TAGS.items() if fdef.tool_tags & tags)
 
 
 def _get_disabled_feature_defs(ctx: ValidationContext) -> list[FeatureDef]:
     """Return FeatureDef objects for all features named in ctx.disabled_features."""
-    return [
-        fdef
-        for name, fdef in FEATURE_REGISTRY.items()
-        if name in ctx.disabled_features
-    ]
+    return [fdef for name, fdef in FEATURE_REGISTRY.items() if name in ctx.disabled_features]
 
 
 def _get_skill_category_map() -> dict[str, frozenset[str]]:

--- a/src/autoskillit/recipe/rules_features.py
+++ b/src/autoskillit/recipe/rules_features.py
@@ -61,10 +61,16 @@ def check_feature_gated_tools(ctx: ValidationContext) -> list[RuleFinding]:
 
     findings: list[RuleFinding] = []
 
+    # Hoist per-feature tool sets and category_map outside the step loop
+    feature_tools = {fdef: _tools_for_feature(fdef) for fdef in disabled_fdefs}
+    category_map = (
+        ctx.skill_category_map if ctx.skill_category_map is not None else _get_skill_category_map()
+    )
+
     for step_name, step in ctx.recipe.steps.items():
         for fdef in disabled_fdefs:
             # --- Tool check ---
-            if step.tool and step.tool in _tools_for_feature(fdef):
+            if step.tool and step.tool in feature_tools[fdef]:
                 findings.append(
                     RuleFinding(
                         rule="feature-gate-tool-reference",
@@ -82,15 +88,10 @@ def check_feature_gated_tools(ctx: ValidationContext) -> list[RuleFinding]:
             # --- Skill check (only when the feature gates skill categories) ---
             if step.tool not in SKILL_TOOLS or not fdef.skill_categories:
                 continue
-            skill_cmd = (step.with_args or {}).get("skill_command", "")
+            skill_cmd = (step.with_args or {}).get("skill_command") or ""
             skill_name = resolve_skill_name(skill_cmd)
             if skill_name is None:
                 continue
-            category_map = (
-                ctx.skill_category_map
-                if ctx.skill_category_map is not None
-                else _get_skill_category_map()
-            )
             categories = category_map.get(skill_name, frozenset())
             if categories & fdef.skill_categories:
                 findings.append(

--- a/src/autoskillit/recipe/rules_features.py
+++ b/src/autoskillit/recipe/rules_features.py
@@ -12,14 +12,11 @@ from autoskillit.core import (
     TOOL_SUBSET_TAGS,
     FeatureDef,
     Severity,
+    SkillLister,
 )
 from autoskillit.recipe._analysis import ValidationContext
 from autoskillit.recipe.contracts import resolve_skill_name
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
 
 
 def _tools_for_feature(fdef: FeatureDef) -> frozenset[str]:
@@ -32,17 +29,13 @@ def _get_disabled_feature_defs(ctx: ValidationContext) -> list[FeatureDef]:
     return [fdef for name, fdef in FEATURE_REGISTRY.items() if name in ctx.disabled_features]
 
 
-def _get_skill_category_map() -> dict[str, frozenset[str]]:
-    """Return {skill_name: categories} for all bundled skills (deferred import)."""
-    from autoskillit.workspace import DefaultSkillResolver  # noqa: PLC0415
+def _get_skill_category_map(lister: SkillLister | None = None) -> dict[str, frozenset[str]]:
+    """Return {skill_name: categories} for all bundled skills."""
+    if lister is None:
+        from autoskillit.workspace import DefaultSkillResolver  # noqa: PLC0415
 
-    lister = DefaultSkillResolver()
+        lister = DefaultSkillResolver()
     return {s.name: s.categories for s in lister.list_all()}
-
-
-# ---------------------------------------------------------------------------
-# Rule
-# ---------------------------------------------------------------------------
 
 
 @semantic_rule(

--- a/src/autoskillit/recipe/rules_features.py
+++ b/src/autoskillit/recipe/rules_features.py
@@ -1,0 +1,118 @@
+"""Semantic rules for feature-gated tool and skill references.
+
+Validates that recipe steps do not reference tools or skills belonging to
+features that are currently disabled in the project configuration.
+"""
+
+from __future__ import annotations
+
+from autoskillit.core import (
+    FEATURE_REGISTRY,
+    SKILL_TOOLS,
+    TOOL_SUBSET_TAGS,
+    FeatureDef,
+    Severity,
+)
+from autoskillit.recipe._analysis import ValidationContext
+from autoskillit.recipe.contracts import resolve_skill_name
+from autoskillit.recipe.registry import RuleFinding, semantic_rule
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _tools_for_feature(fdef: FeatureDef) -> frozenset[str]:
+    """Return all MCP tool names that carry at least one of this feature's tool_tags."""
+    return frozenset(
+        tool for tool, tags in TOOL_SUBSET_TAGS.items() if fdef.tool_tags & tags
+    )
+
+
+def _get_disabled_feature_defs(ctx: ValidationContext) -> list[FeatureDef]:
+    """Return FeatureDef objects for all features named in ctx.disabled_features."""
+    return [
+        fdef
+        for name, fdef in FEATURE_REGISTRY.items()
+        if name in ctx.disabled_features
+    ]
+
+
+def _get_skill_category_map() -> dict[str, frozenset[str]]:
+    """Return {skill_name: categories} for all bundled skills (deferred import)."""
+    from autoskillit.workspace import DefaultSkillResolver  # noqa: PLC0415
+
+    lister = DefaultSkillResolver()
+    return {s.name: s.categories for s in lister.list_all()}
+
+
+# ---------------------------------------------------------------------------
+# Rule
+# ---------------------------------------------------------------------------
+
+
+@semantic_rule(
+    name="feature-gate-tool-reference",
+    description="Steps must not reference tools or skills from disabled features",
+    severity=Severity.ERROR,
+)
+def check_feature_gated_tools(ctx: ValidationContext) -> list[RuleFinding]:
+    """Flag steps that reference tools or skills belonging to a disabled feature."""
+    if not ctx.disabled_features:
+        return []
+
+    disabled_fdefs = _get_disabled_feature_defs(ctx)
+    if not disabled_fdefs:
+        return []
+
+    findings: list[RuleFinding] = []
+
+    for step_name, step in ctx.recipe.steps.items():
+        for fdef in disabled_fdefs:
+            # --- Tool check ---
+            if step.tool and step.tool in _tools_for_feature(fdef):
+                findings.append(
+                    RuleFinding(
+                        rule="feature-gate-tool-reference",
+                        severity=Severity.ERROR,
+                        step_name=step_name,
+                        message=(
+                            f"step '{step_name}': tool '{step.tool}' belongs to "
+                            f"disabled feature '{fdef.name}'. "
+                            f"Enable '{fdef.name}' in .autoskillit/config.yaml "
+                            f"features to use this tool."
+                        ),
+                    )
+                )
+
+            # --- Skill check (only when the feature gates skill categories) ---
+            if step.tool not in SKILL_TOOLS or not fdef.skill_categories:
+                continue
+            skill_cmd = (step.with_args or {}).get("skill_command", "")
+            skill_name = resolve_skill_name(skill_cmd)
+            if skill_name is None:
+                continue
+            category_map = (
+                ctx.skill_category_map
+                if ctx.skill_category_map is not None
+                else _get_skill_category_map()
+            )
+            categories = category_map.get(skill_name, frozenset())
+            if categories & fdef.skill_categories:
+                findings.append(
+                    RuleFinding(
+                        rule="feature-gate-tool-reference",
+                        severity=Severity.ERROR,
+                        step_name=step_name,
+                        message=(
+                            f"step '{step_name}': skill_command '{skill_cmd}' references "
+                            f"skill '{skill_name}' which belongs to disabled feature "
+                            f"'{fdef.name}'. "
+                            f"Enable '{fdef.name}' in .autoskillit/config.yaml "
+                            f"features to use this skill."
+                        ),
+                    )
+                )
+
+    return findings

--- a/tests/arch/test_layer_enforcement.py
+++ b/tests/arch/test_layer_enforcement.py
@@ -1058,6 +1058,9 @@ def test_default_classes_only_instantiated_inside_factory_or_allowlist() -> None
         Path("recipe/rules_skills.py"): {
             "DefaultSkillResolver"
         },  # deferred default factory fallback
+        Path("recipe/rules_features.py"): {
+            "DefaultSkillResolver"
+        },  # deferred default factory fallback
         Path("workspace/session_skills.py"): {
             "DefaultSkillResolver"
         },  # ephemeral session resolver fallback

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -706,7 +706,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
     """
     EXEMPTIONS: dict[str, int] = {
         "server": 20,
-        "recipe": 36,
+        "recipe": 37,
         "execution": 26,
         "core": 24,
         "cli": 22,

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -262,7 +262,7 @@ def test_retry_reason_value_count_is_11() -> None:
 
 
 def test_semantic_rule_family_count_is_20() -> None:
-    assert _count_semantic_rule_files() == 21
+    assert _count_semantic_rule_files() == 22
 
 
 # ----- per-doc count assertions (run once docs exist) -------------------------

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -261,7 +261,7 @@ def test_retry_reason_value_count_is_11() -> None:
     assert len(values) == 11, f"RetryReason has {len(values)} values: {values}"
 
 
-def test_semantic_rule_family_count_is_20() -> None:
+def test_semantic_rule_family_count_is_22() -> None:
     assert _count_semantic_rule_files() == 22
 
 

--- a/tests/recipe/test_rules_features.py
+++ b/tests/recipe/test_rules_features.py
@@ -1,0 +1,135 @@
+"""Tests for feature-gate-tool-reference validation rule (T-FEAT-001..005)."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.medium]
+
+
+def test_feature_gate_rule_fires_on_disabled_feature_tool() -> None:
+    """Severity.ERROR when recipe uses dispatch_food_truck with franchise disabled."""
+    from autoskillit.core import Severity
+    from autoskillit.recipe._analysis import make_validation_context
+    from autoskillit.recipe.registry import run_semantic_rules
+    from autoskillit.recipe.schema import Recipe, RecipeStep
+
+    recipe = Recipe(
+        name="r", description="d", version="0.2.0", kitchen_rules="k",
+        steps={"s": RecipeStep(tool="dispatch_food_truck", with_args={})},
+    )
+    ctx = make_validation_context(recipe, disabled_features=frozenset({"franchise"}))
+    findings = [f for f in run_semantic_rules(ctx) if f.rule == "feature-gate-tool-reference"]
+    assert findings
+    assert all(f.severity == Severity.ERROR for f in findings)
+    assert any("franchise" in f.message for f in findings)
+    assert any("dispatch_food_truck" in f.message for f in findings)
+
+
+def test_feature_gate_rule_passes_when_feature_enabled() -> None:
+    """No feature-gate-tool-reference finding when disabled_features is empty."""
+    from autoskillit.recipe._analysis import make_validation_context
+    from autoskillit.recipe.registry import run_semantic_rules
+    from autoskillit.recipe.schema import Recipe, RecipeStep
+
+    recipe = Recipe(
+        name="r", description="d", version="0.2.0", kitchen_rules="k",
+        steps={"s": RecipeStep(tool="dispatch_food_truck", with_args={})},
+    )
+    ctx = make_validation_context(recipe, disabled_features=frozenset())
+    findings = [f for f in run_semantic_rules(ctx) if f.rule == "feature-gate-tool-reference"]
+    assert not findings
+
+
+def test_feature_gate_rule_ignores_non_feature_tools() -> None:
+    """run_cmd has no feature tags — no finding even when franchise is disabled."""
+    from autoskillit.recipe._analysis import make_validation_context
+    from autoskillit.recipe.registry import run_semantic_rules
+    from autoskillit.recipe.schema import Recipe, RecipeStep
+
+    recipe = Recipe(
+        name="r", description="d", version="0.2.0", kitchen_rules="k",
+        steps={"s": RecipeStep(tool="run_cmd", with_args={"cmd": "echo hi"})},
+    )
+    ctx = make_validation_context(recipe, disabled_features=frozenset({"franchise"}))
+    findings = [f for f in run_semantic_rules(ctx) if f.rule == "feature-gate-tool-reference"]
+    assert not findings
+
+
+def test_feature_gate_rule_fires_on_disabled_feature_skill(monkeypatch) -> None:
+    """ERROR when recipe uses a skill from a feature's skill_categories."""
+    import autoskillit.core._type_constants as _consts
+    from autoskillit.core import FeatureDef, FeatureLifecycle, Severity
+    from autoskillit.recipe._analysis import (
+        ValidationContext, _build_step_graph, analyze_dataflow,
+    )
+    from autoskillit.recipe.registry import run_semantic_rules
+    from autoskillit.recipe.schema import Recipe, RecipeStep
+
+    # Inject a test feature with skill_categories into the registry
+    test_fdef = FeatureDef(
+        name="test-skill-gate",
+        lifecycle=FeatureLifecycle.EXPERIMENTAL,
+        description="Test feature gating a skill category",
+        tool_tags=frozenset(),
+        skill_categories=frozenset({"arch-lens"}),
+        import_package=None,
+    )
+    monkeypatch.setitem(_consts.FEATURE_REGISTRY, "test-skill-gate", test_fdef)
+
+    recipe = Recipe(
+        name="r", description="d", version="0.2.0", kitchen_rules="k",
+        steps={"s": RecipeStep(
+            tool="run_skill",
+            with_args={"skill_command": "/autoskillit:arch-lens-c4-container"},
+        )},
+    )
+    step_graph = _build_step_graph(recipe)
+    ctx = ValidationContext(
+        recipe=recipe,
+        step_graph=step_graph,
+        dataflow=analyze_dataflow(recipe, step_graph=step_graph),
+        disabled_features=frozenset({"test-skill-gate"}),
+        skill_category_map={"arch-lens-c4-container": frozenset({"arch-lens"})},
+    )
+    findings = [f for f in run_semantic_rules(ctx) if f.rule == "feature-gate-tool-reference"]
+    assert findings
+    assert all(f.severity == Severity.ERROR for f in findings)
+    assert any("test-skill-gate" in f.message for f in findings)
+
+
+def test_feature_gate_rule_with_multiple_features(monkeypatch) -> None:
+    """Each disabled feature independently flags its own tools."""
+    import autoskillit.core._type_constants as _consts
+    from autoskillit.core import FeatureDef, FeatureLifecycle, TOOL_SUBSET_TAGS, Severity
+    from autoskillit.recipe._analysis import make_validation_context
+    from autoskillit.recipe.registry import run_semantic_rules
+    from autoskillit.recipe.schema import Recipe, RecipeStep
+
+    # A second test feature that controls 'ci' tools
+    test_ci_fdef = FeatureDef(
+        name="test-ci-gate",
+        lifecycle=FeatureLifecycle.EXPERIMENTAL,
+        description="Test feature gating ci tools",
+        tool_tags=frozenset({"ci"}),
+        skill_categories=frozenset(),
+        import_package=None,
+    )
+    monkeypatch.setitem(_consts.FEATURE_REGISTRY, "test-ci-gate", test_ci_fdef)
+
+    recipe = Recipe(
+        name="r", description="d", version="0.2.0", kitchen_rules="k",
+        steps={
+            "franchise_step": RecipeStep(tool="dispatch_food_truck", with_args={}),
+            "ci_step": RecipeStep(tool="wait_for_ci", with_args={}),
+        },
+    )
+    ctx = make_validation_context(
+        recipe, disabled_features=frozenset({"franchise", "test-ci-gate"})
+    )
+    findings = [f for f in run_semantic_rules(ctx) if f.rule == "feature-gate-tool-reference"]
+
+    step_names = {f.step_name for f in findings}
+    assert "franchise_step" in step_names, "franchise tool not flagged"
+    assert "ci_step" in step_names, "ci tool not flagged"
+    assert all(f.severity == Severity.ERROR for f in findings)

--- a/tests/recipe/test_rules_features.py
+++ b/tests/recipe/test_rules_features.py
@@ -23,7 +23,7 @@ def test_feature_gate_rule_fires_on_disabled_feature_tool() -> None:
     )
     ctx = make_validation_context(recipe, disabled_features=frozenset({"franchise"}))
     findings = [f for f in run_semantic_rules(ctx) if f.rule == "feature-gate-tool-reference"]
-    assert findings
+    assert findings, "expected feature-gate-tool-reference finding for disabled franchise tool"
     assert all(f.severity == Severity.ERROR for f in findings)
     assert any("franchise" in f.message for f in findings)
     assert any("dispatch_food_truck" in f.message for f in findings)
@@ -109,7 +109,7 @@ def test_feature_gate_rule_fires_on_disabled_feature_skill(monkeypatch) -> None:
         skill_category_map={"arch-lens-c4-container": frozenset({"arch-lens"})},
     )
     findings = [f for f in run_semantic_rules(ctx) if f.rule == "feature-gate-tool-reference"]
-    assert findings
+    assert findings, "expected feature-gate-tool-reference finding for disabled skill category"
     assert all(f.severity == Severity.ERROR for f in findings)
     assert any("test-skill-gate" in f.message for f in findings)
 
@@ -149,6 +149,7 @@ def test_feature_gate_rule_with_multiple_features(monkeypatch) -> None:
     findings = [f for f in run_semantic_rules(ctx) if f.rule == "feature-gate-tool-reference"]
 
     step_names = {f.step_name for f in findings}
+    assert len(step_names) == 2, f"expected exactly 2 flagged steps, got {step_names!r}"
     assert "franchise_step" in step_names, "franchise tool not flagged"
     assert "ci_step" in step_names, "ci tool not flagged"
     assert all(f.severity == Severity.ERROR for f in findings)

--- a/tests/recipe/test_rules_features.py
+++ b/tests/recipe/test_rules_features.py
@@ -15,7 +15,10 @@ def test_feature_gate_rule_fires_on_disabled_feature_tool() -> None:
     from autoskillit.recipe.schema import Recipe, RecipeStep
 
     recipe = Recipe(
-        name="r", description="d", version="0.2.0", kitchen_rules="k",
+        name="r",
+        description="d",
+        version="0.2.0",
+        kitchen_rules="k",
         steps={"s": RecipeStep(tool="dispatch_food_truck", with_args={})},
     )
     ctx = make_validation_context(recipe, disabled_features=frozenset({"franchise"}))
@@ -33,7 +36,10 @@ def test_feature_gate_rule_passes_when_feature_enabled() -> None:
     from autoskillit.recipe.schema import Recipe, RecipeStep
 
     recipe = Recipe(
-        name="r", description="d", version="0.2.0", kitchen_rules="k",
+        name="r",
+        description="d",
+        version="0.2.0",
+        kitchen_rules="k",
         steps={"s": RecipeStep(tool="dispatch_food_truck", with_args={})},
     )
     ctx = make_validation_context(recipe, disabled_features=frozenset())
@@ -48,7 +54,10 @@ def test_feature_gate_rule_ignores_non_feature_tools() -> None:
     from autoskillit.recipe.schema import Recipe, RecipeStep
 
     recipe = Recipe(
-        name="r", description="d", version="0.2.0", kitchen_rules="k",
+        name="r",
+        description="d",
+        version="0.2.0",
+        kitchen_rules="k",
         steps={"s": RecipeStep(tool="run_cmd", with_args={"cmd": "echo hi"})},
     )
     ctx = make_validation_context(recipe, disabled_features=frozenset({"franchise"}))
@@ -61,7 +70,9 @@ def test_feature_gate_rule_fires_on_disabled_feature_skill(monkeypatch) -> None:
     import autoskillit.core._type_constants as _consts
     from autoskillit.core import FeatureDef, FeatureLifecycle, Severity
     from autoskillit.recipe._analysis import (
-        ValidationContext, _build_step_graph, analyze_dataflow,
+        ValidationContext,
+        _build_step_graph,
+        analyze_dataflow,
     )
     from autoskillit.recipe.registry import run_semantic_rules
     from autoskillit.recipe.schema import Recipe, RecipeStep
@@ -78,11 +89,16 @@ def test_feature_gate_rule_fires_on_disabled_feature_skill(monkeypatch) -> None:
     monkeypatch.setitem(_consts.FEATURE_REGISTRY, "test-skill-gate", test_fdef)
 
     recipe = Recipe(
-        name="r", description="d", version="0.2.0", kitchen_rules="k",
-        steps={"s": RecipeStep(
-            tool="run_skill",
-            with_args={"skill_command": "/autoskillit:arch-lens-c4-container"},
-        )},
+        name="r",
+        description="d",
+        version="0.2.0",
+        kitchen_rules="k",
+        steps={
+            "s": RecipeStep(
+                tool="run_skill",
+                with_args={"skill_command": "/autoskillit:arch-lens-c4-container"},
+            )
+        },
     )
     step_graph = _build_step_graph(recipe)
     ctx = ValidationContext(
@@ -101,7 +117,7 @@ def test_feature_gate_rule_fires_on_disabled_feature_skill(monkeypatch) -> None:
 def test_feature_gate_rule_with_multiple_features(monkeypatch) -> None:
     """Each disabled feature independently flags its own tools."""
     import autoskillit.core._type_constants as _consts
-    from autoskillit.core import FeatureDef, FeatureLifecycle, TOOL_SUBSET_TAGS, Severity
+    from autoskillit.core import FeatureDef, FeatureLifecycle, Severity
     from autoskillit.recipe._analysis import make_validation_context
     from autoskillit.recipe.registry import run_semantic_rules
     from autoskillit.recipe.schema import Recipe, RecipeStep
@@ -118,7 +134,10 @@ def test_feature_gate_rule_with_multiple_features(monkeypatch) -> None:
     monkeypatch.setitem(_consts.FEATURE_REGISTRY, "test-ci-gate", test_ci_fdef)
 
     recipe = Recipe(
-        name="r", description="d", version="0.2.0", kitchen_rules="k",
+        name="r",
+        description="d",
+        version="0.2.0",
+        kitchen_rules="k",
         steps={
             "franchise_step": RecipeStep(tool="dispatch_food_truck", with_args={}),
             "ci_step": RecipeStep(tool="wait_for_ci", with_args={}),


### PR DESCRIPTION
## Summary

Add a `feature-gate-tool-reference` semantic validation rule that flags recipe steps referencing tools or skills belonging to disabled features. The rule fires at validate time (before execution), preventing misconfigured recipes from reaching the runner. Severity is `ERROR` (not WARNING) because a recipe that references a disabled feature's tool cannot execute successfully — this is a configuration error, not a style advisory.

Changes span four files:
1. **`recipe/_analysis.py`** — add `disabled_features: frozenset[str]` and `skill_category_map` to `ValidationContext` and `make_validation_context`, mirroring the existing `disabled_subsets` field.
2. **`recipe/rules_features.py`** (new) — `@semantic_rule` implementation using `FEATURE_REGISTRY` + `TOOL_SUBSET_TAGS` to map feature → tools, and `ctx.skill_category_map` + `FeatureDef.skill_categories` to map feature → skills.
3. **`recipe/__init__.py`** — side-effect import to trigger rule registration.
4. **`tests/recipe/test_rules_features.py`** (new) — five focused tests (T-FEAT-001..005).

## Architecture Impact

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph L0 ["L0 — CORE (autoskillit.core)"]
        direction LR
        CORE_CONSTS["core._type_constants<br/>━━━━━━━━━━<br/>FEATURE_REGISTRY<br/>TOOL_SUBSET_TAGS<br/>SKILL_TOOLS<br/>FeatureDef"]
        CORE_ENUMS["core._type_enums<br/>━━━━━━━━━━<br/>Severity"]
    end

    subgraph L1 ["L1 — WORKSPACE (deferred import)"]
        WORKSPACE["workspace<br/>━━━━━━━━━━<br/>DefaultSkillResolver<br/>(list_all → skill categories)"]
    end

    subgraph L2_RECIPE ["L2 — RECIPE"]
        direction TB

        SCHEMA["recipe.schema<br/>━━━━━━━━━━<br/>Recipe, RecipeStep<br/>DataFlowReport"]

        ANALYSIS["● recipe._analysis<br/>━━━━━━━━━━<br/>ValidationContext<br/>+ disabled_features<br/>+ skill_category_map<br/>make_validation_context()"]

        CONTRACTS["recipe.contracts<br/>━━━━━━━━━━<br/>resolve_skill_name()"]

        REGISTRY["recipe.registry<br/>━━━━━━━━━━<br/>RuleFinding<br/>semantic_rule (decorator)<br/>run_semantic_rules()"]

        RULES_FEATURES["★ recipe.rules_features<br/>━━━━━━━━━━<br/>check_feature_gated_tools()<br/>feature-gate-tool-reference<br/>(registered via @semantic_rule)"]

        INIT["● recipe.__init__<br/>━━━━━━━━━━<br/>+ import rules_features<br/>(triggers @semantic_rule reg.)"]
    end

    subgraph TESTS ["TESTS"]
        direction TB
        TEST_RULES_FEAT["★ tests/recipe/test_rules_features.py<br/>━━━━━━━━━━<br/>T-FEAT-001..005<br/>pytest.mark.layer(recipe) medium"]
        TEST_ARCH_LAYER["● tests/arch/test_layer_enforcement.py<br/>━━━━━━━━━━<br/>Layer boundary contracts"]
        TEST_ARCH_ISO["● tests/arch/test_subpackage_isolation.py<br/>━━━━━━━━━━<br/>Subpackage isolation checks"]
        TEST_DOC["● tests/docs/test_doc_counts.py<br/>━━━━━━━━━━<br/>Rule/module count regression guard"]
    end

    %% L0 → used by L2 recipe._analysis %%
    CORE_CONSTS -->|"SKILL_TOOLS"| ANALYSIS
    CORE_ENUMS -->|"Severity"| ANALYSIS

    %% L0 → used by recipe.schema %%
    CORE_ENUMS -->|"Severity"| SCHEMA

    %% L0 → used directly by rules_features %%
    CORE_CONSTS -->|"FEATURE_REGISTRY<br/>TOOL_SUBSET_TAGS<br/>SKILL_TOOLS<br/>FeatureDef"| RULES_FEATURES
    CORE_ENUMS -->|"Severity"| RULES_FEATURES

    %% L0 → registry %%
    CORE_ENUMS -->|"Severity"| REGISTRY

    %% L2 internal wiring %%
    SCHEMA -->|"Recipe, RecipeStep"| ANALYSIS
    ANALYSIS -->|"ValidationContext"| REGISTRY
    ANALYSIS -->|"ValidationContext"| RULES_FEATURES
    CONTRACTS -->|"resolve_skill_name()"| RULES_FEATURES
    REGISTRY -->|"RuleFinding, semantic_rule"| RULES_FEATURES

    %% __init__ triggers registration %%
    RULES_FEATURES -.->|"@semantic_rule registration<br/>(side-effect on import)"| REGISTRY
    INIT -->|"import rules_features"| RULES_FEATURES

    %% L1 deferred import from rules_features %%
    WORKSPACE -.->|"deferred import<br/>_get_skill_category_map()"| RULES_FEATURES

    %% Test → production wiring %%
    TEST_RULES_FEAT -->|"imports"| RULES_FEATURES
    TEST_RULES_FEAT -->|"imports"| ANALYSIS
    TEST_RULES_FEAT -->|"imports"| REGISTRY
    TEST_ARCH_LAYER -->|"contract checks"| INIT
    TEST_ARCH_ISO -->|"isolation checks"| RULES_FEATURES
    TEST_DOC -->|"count regression"| INIT

    %% CLASS ASSIGNMENTS %%
    class CORE_CONSTS,CORE_ENUMS stateNode;
    class WORKSPACE handler;
    class SCHEMA phase;
    class ANALYSIS phase;
    class CONTRACTS handler;
    class REGISTRY stateNode;
    class RULES_FEATURES newComponent;
    class INIT cli;
    class TEST_RULES_FEAT newComponent;
    class TEST_ARCH_LAYER,TEST_ARCH_ISO,TEST_DOC detector;
```

### Data Lineage Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ── INPUTS ──────────────────────────────────────── %%
    subgraph Origins ["Data Origins (L0 Constants + Config)"]
        direction TB
        FEAT_REG["FEATURE_REGISTRY<br/>━━━━━━━━━━<br/>core/_type_constants.py<br/>dict[str, FeatureDef]<br/>name, tool_tags, skill_categories"]
        TOOL_TAGS["TOOL_SUBSET_TAGS<br/>━━━━━━━━━━<br/>core/_type_constants.py<br/>dict[str, frozenset[str]]<br/>tool → category tags"]
        SKILL_TOOLS_C["SKILL_TOOLS<br/>━━━━━━━━━━<br/>core/_type_constants.py<br/>frozenset — run_skill"]
        DIS_FEAT["disabled_features<br/>━━━━━━━━━━<br/>config.yaml → AutomationConfig<br/>frozenset[str]<br/>caller-provided"]
        RECIPE_IN["Recipe (steps)<br/>━━━━━━━━━━<br/>YAML → schema.py<br/>dict[str, RecipeStep]<br/>tool, with_args"]
    end

    %% ── CONTEXT BUILD (modified) ──────────────────── %%
    subgraph CtxBuild ["● make_validation_context()<br/>recipe/_analysis.py"]
        direction TB
        CTX["● ValidationContext<br/>━━━━━━━━━━<br/>recipe, step_graph, dataflow<br/>disabled_features ← NEW<br/>skill_category_map ← NEW"]
    end

    %% ── REGISTRATION (new) ──────────────────────────── %%
    subgraph Registration ["★ Import-time Registration<br/>recipe/__init__.py + registry.py"]
        direction TB
        IMPORT["● recipe/__init__.py<br/>━━━━━━━━━━<br/>imports rules_features<br/>triggers @semantic_rule"]
        RULE_REG["_RULE_REGISTRY<br/>━━━━━━━━━━<br/>registry.py<br/>list[RuleSpec] — in-memory<br/>appended at import time"]
    end

    %% ── RESOLUTION HELPERS (new) ────────────────────── %%
    subgraph Resolution ["★ Feature Resolution Helpers<br/>rules_features.py"]
        direction TB
        GET_DEFS["★ _get_disabled_feature_defs(ctx)<br/>━━━━━━━━━━<br/>filters FEATURE_REGISTRY<br/>by ctx.disabled_features<br/>→ list[FeatureDef]"]
        TOOLS_FOR["★ _tools_for_feature(fdef)<br/>━━━━━━━━━━<br/>TOOL_SUBSET_TAGS ∩ fdef.tool_tags<br/>→ frozenset[str] (tool names)"]
        SKILL_CAT["★ _get_skill_category_map()<br/>━━━━━━━━━━<br/>DefaultSkillResolver (lazy)<br/>→ dict[str, frozenset[str]]<br/>skill name → categories"]
    end

    %% ── VALIDATION RULE (new) ────────────────────────── %%
    subgraph Validation ["★ check_feature_gated_tools(ctx)<br/>rules_features.py"]
        direction TB
        TOOL_CHK["Tool check<br/>━━━━━━━━━━<br/>step.tool ∈ disabled tool names<br/>→ RuleFinding (ERROR)"]
        SKILL_CHK["Skill check<br/>━━━━━━━━━━<br/>resolve_skill_name(skill_cmd)<br/>+ category_map lookup<br/>→ RuleFinding (ERROR)"]
    end

    %% ── DISPATCH ──────────────────────────────────────── %%
    DISPATCH["run_semantic_rules()<br/>━━━━━━━━━━<br/>registry.py<br/>iterates _RULE_REGISTRY<br/>calls each spec.check(ctx)"]

    %% ── OUTPUTS ──────────────────────────────────────── %%
    subgraph Outputs ["Validation Output"]
        FINDINGS["list[RuleFinding]<br/>━━━━━━━━━━<br/>rule, severity=ERROR<br/>step_name, message<br/>→ caller (validate_recipe)"]
    end

    %% ── FLOWS ──────────────────────────────────────────── %%
    DIS_FEAT -->|"disabled_features"| CTX
    RECIPE_IN -->|"recipe"| CTX

    IMPORT -->|"@semantic_rule triggers"| RULE_REG

    CTX -->|"ctx"| GET_DEFS
    FEAT_REG -->|"read"| GET_DEFS
    GET_DEFS -->|"list[FeatureDef]"| TOOLS_FOR
    TOOL_TAGS -->|"read"| TOOLS_FOR
    SKILL_TOOLS_C -->|"SKILL_TOOLS guard"| SKILL_CHK

    CTX -->|"ctx.recipe.steps"| TOOL_CHK
    CTX -->|"ctx.recipe.steps"| SKILL_CHK
    CTX -->|"ctx.skill_category_map"| SKILL_CHK
    TOOLS_FOR -->|"disabled tool names"| TOOL_CHK
    SKILL_CAT -.->|"fallback if ctx.skill_category_map is None"| SKILL_CHK

    RULE_REG -->|"dispatch"| DISPATCH
    CTX -->|"ctx"| DISPATCH
    DISPATCH -->|"spec.check(ctx)"| TOOL_CHK
    DISPATCH -->|"spec.check(ctx)"| SKILL_CHK

    TOOL_CHK -->|"findings"| FINDINGS
    SKILL_CHK -->|"findings"| FINDINGS

    %% ── CLASS ASSIGNMENTS ──────────────────────────────── %%
    class FEAT_REG,TOOL_TAGS,SKILL_TOOLS_C stateNode;
    class DIS_FEAT,RECIPE_IN cli;
    class CTX phase;
    class IMPORT,RULE_REG handler;
    class GET_DEFS,TOOLS_FOR,SKILL_CAT newComponent;
    class TOOL_CHK,SKILL_CHK detector;
    class DISPATCH handler;
    class FINDINGS output;
```

Closes #1104

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260422-131243-823821/.autoskillit/temp/make-plan/recipe_feature_gate_validation_rule_plan_2026-04-22_120001.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 221 | 22.7k | 1.6M | 91.7k | 1 | 6m 7s |
| verify | 84 | 7.9k | 403.1k | 45.0k | 1 | 2m 10s |
| implement | 2.2k | 13.7k | 2.0M | 55.7k | 1 | 5m 35s |
| fix | 202 | 9.9k | 1.1M | 54.6k | 1 | 6m 11s |
| prepare_pr | 60 | 5.3k | 181.9k | 37.4k | 1 | 1m 43s |
| run_arch_lenses | 164 | 11.7k | 613.4k | 124.1k | 2 | 3m 42s |
| compose_pr | 67 | 6.3k | 228.5k | 26.7k | 1 | 1m 54s |
| **Total** | 3.0k | 77.4k | 6.1M | 435.3k | | 27m 25s |