### PR TITLE
feature-gate: CLI Entry Guards + autoskillit features list/status Subcommand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,6 +271,7 @@ generic_automation_mcp/
 │   ├── _update_checks.py    #   Unified startup update check: version/hook/source-drift signals, branch-aware dismissal
 │   ├── _serve_guard.py      #   Async signal-guarded MCP server bootstrap (extracted from app.py)
 │   ├── _franchise.py        #   franchise subcommand group: status --reap/--dry-run, run stub, signal guard; render_franchise_error()
+│   ├── _features.py         #   features subcommand group: list/status commands for feature gate inspection
 │   ├── _workspace.py        #   Workspace clean helpers
 │   └── app.py               #   CLI entry: serve, init, config, skills, recipes, doctor, update, etc.
 │

--- a/src/autoskillit/cli/_features.py
+++ b/src/autoskillit/cli/_features.py
@@ -1,0 +1,87 @@
+"""Features subapp: list and inspect feature gate state."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from cyclopts import App
+
+features_app = App(name="features", help="Feature gate inspection.")
+
+
+@features_app.command(name="list")
+def features_list() -> None:
+    """List all registered features with their effective state."""
+    from autoskillit.config import load_config
+    from autoskillit.core import (
+        FEATURE_REGISTRY,
+        TerminalColumn,
+        _render_terminal_table,
+        is_feature_enabled,
+    )
+
+    cfg = load_config(Path.cwd())
+
+    columns = [
+        TerminalColumn("FEATURE", 20, "<"),
+        TerminalColumn("TIER", 5, ">"),
+        TerminalColumn("LIFECYCLE", 14, "<"),
+        TerminalColumn("DEFAULT", 9, "<"),
+        TerminalColumn("EFFECTIVE", 10, "<"),
+        TerminalColumn("SOURCE", 10, "<"),
+    ]
+
+    rows = []
+    for name, defn in sorted(FEATURE_REGISTRY.items()):
+        effective = is_feature_enabled(name, cfg.features)
+        source = "config" if name in cfg.features else "default"
+        rows.append(
+            (
+                name,
+                str(defn.tier),
+                str(defn.lifecycle),
+                str(defn.default_enabled).lower(),
+                str(effective).lower(),
+                source,
+            )
+        )
+
+    print(_render_terminal_table(columns, rows))
+
+
+@features_app.command(name="status")
+def features_status(name: str) -> None:
+    """Show detailed state for a single feature."""
+    from autoskillit.config import load_config
+    from autoskillit.core import FEATURE_REGISTRY, is_feature_enabled
+
+    if name not in FEATURE_REGISTRY:
+        known = sorted(FEATURE_REGISTRY.keys())
+        print(
+            f"Unknown feature: {name!r}\nKnown features: {', '.join(known)}",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    defn = FEATURE_REGISTRY[name]
+    cfg = load_config(Path.cwd())
+    effective = is_feature_enabled(name, cfg.features)
+
+    source = "overridden by config" if name in cfg.features else "default"
+    enabled_str = f"{'true' if effective else 'false'} ({source})"
+
+    tool_tags = ", ".join(sorted(defn.tool_tags)) if defn.tool_tags else "(none)"
+    skill_cats = ", ".join(sorted(defn.skill_categories)) if defn.skill_categories else "(none)"
+    depends = ", ".join(sorted(defn.depends_on)) if defn.depends_on else "(none)"
+
+    print(f"Feature: {name}")
+    print(f"  Lifecycle:    {defn.lifecycle}")
+    print(f"  Tier:         {defn.tier}")
+    print(f"  Enabled:      {enabled_str}")
+    print(f"  Package:      {defn.import_package or '(none)'}")
+    print(f"  Tool tags:    {tool_tags}")
+    print(f"  Skill cats:   {skill_cats}")
+    print(f"  Since:        {f'v{defn.since_version}' if defn.since_version else '(none)'}")
+    print(f"  Depends on:   {depends}")
+    print(f"  Sunset date:  {defn.sunset_date or '(none)'}")

--- a/src/autoskillit/cli/_franchise.py
+++ b/src/autoskillit/cli/_franchise.py
@@ -22,7 +22,7 @@ import anyio.abc
 import psutil
 from cyclopts import App, Parameter
 
-from autoskillit.core import TerminalColumn, get_logger
+from autoskillit.core import TerminalColumn, get_logger, is_feature_enabled
 from autoskillit.franchise import (
     DispatchStatus,
     mark_dispatch_interrupted,
@@ -31,7 +31,21 @@ from autoskillit.franchise import (
 
 _log = get_logger(__name__)
 
+
+def _require_franchise(cfg: AutomationConfig) -> None:
+    """Exit with clear message if franchise feature is not enabled."""
+    if not is_feature_enabled("franchise", cfg.features):
+        print(
+            "The 'franchise' feature is not enabled.\n"
+            "Enable it with: features.franchise: true in your config\n"
+            "Or set: AUTOSKILLIT_FEATURES__FRANCHISE=true",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+
 if TYPE_CHECKING:
+    from autoskillit.config import AutomationConfig
     from autoskillit.franchise import CampaignState, DispatchRecord, ResumeDecision
     from autoskillit.recipe.schema import Recipe
 
@@ -599,6 +613,11 @@ def franchise_run(
         print("ERROR: 'claude' not found. Install: https://docs.anthropic.com/en/docs/claude-code")
         sys.exit(1)
 
+    from autoskillit.config import load_config
+
+    cfg = load_config(Path.cwd())
+    _require_franchise(cfg)
+
     from autoskillit.core import YAMLError
     from autoskillit.franchise import (
         DispatchRecord,
@@ -654,6 +673,11 @@ def franchise_run(
 @franchise_app.command(name="list")
 def franchise_list() -> None:
     """List available campaign recipes."""
+    from autoskillit.config import load_config
+
+    cfg = load_config(Path.cwd())
+    _require_franchise(cfg)
+
     from autoskillit.core import TerminalColumn, _render_terminal_table
     from autoskillit.recipe import list_campaign_recipes
 
@@ -682,6 +706,11 @@ def franchise_status(
     json_output: Annotated[bool, Parameter(name=["--json"])] = False,
 ) -> None:
     """Show franchise campaign status."""
+    from autoskillit.config import load_config
+
+    cfg = load_config(Path.cwd())
+    _require_franchise(cfg)
+
     franchise_dir = Path.cwd() / ".autoskillit" / "temp" / "franchise"
 
     if campaign_id is not None:

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Annotated
 
 import anyio
 
+from autoskillit.cli._features import features_app
 from autoskillit.cli._franchise import franchise_app
 from autoskillit.cli._serve_guard import serve_with_signal_guard
 
@@ -56,6 +57,7 @@ app.command(skills_app)
 app.command(recipes_app)
 app.command(workspace_app)
 app.command(franchise_app)
+app.command(features_app)
 
 
 class CliError(Exception):

--- a/tests/arch/_rules.py
+++ b/tests/arch/_rules.py
@@ -57,6 +57,7 @@ _LOGGER_METHODS = frozenset({"debug", "info", "warning", "error", "critical", "e
 _PRINT_EXEMPT = frozenset(
     {
         "_cook.py",
+        "_features.py",
         "_franchise.py",
         "_init_helpers.py",
         "_onboarding.py",

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -80,6 +80,7 @@ SINGLETON_ALLOWED_MODULES: frozenset[str] = frozenset(
         "_terminal",  # cli/_terminal.py: _BASE_RESET = "".join(...) derived from _RESET_SPEC
         "hook_registry",  # hook_registry.py: HOOK_REGISTRY_HASH = compute_registry_hash(...)
         "_franchise",  # cli/_franchise.py: franchise_app = App(name="franchise", ...)
+        "_features",  # cli/_features.py: features_app = App(name="features", ...)
     }
 )
 _SINGLETON_SAFE_CALL_NAMES: frozenset[str] = frozenset(
@@ -693,7 +694,8 @@ def test_no_subpackage_exceeds_10_files() -> None:
         _update_checks.py adds the unified update check orchestration.
         _update.py adds the first-class update subcommand implementation.
         _franchise.py adds franchise error envelope rendering for CLI consumers.
-        Exempt at 21 files.
+        _features.py adds feature gate inspection subcommand (list/status).
+        Exempt at 23 files.
       hooks/ — REQ-CNST-003-E6: hooks/ hosts one standalone script per hook event
         (PreToolUse, PostToolUse, SessionStart). Each script must remain a separate
         file so Claude Code can invoke it directly as a subprocess. pretty_output_hook.py
@@ -709,7 +711,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "recipe": 36,
         "execution": 26,
         "core": 24,
-        "cli": 22,
+        "cli": 23,
         "hooks": 22,
     }
     violations: list[str] = []

--- a/tests/cli/test_features_cli.py
+++ b/tests/cli/test_features_cli.py
@@ -49,8 +49,9 @@ def test_features_list_shows_effective_state(
     features_list()
     out = capsys.readouterr().out
     # franchise row should show effective=false and source=config
-    assert "false" in out
-    assert "config" in out
+    franchise_line = next(line for line in out.splitlines() if "franchise" in line)
+    assert "false" in franchise_line
+    assert "config" in franchise_line
 
 
 # ---------------------------------------------------------------------------
@@ -72,7 +73,8 @@ def test_features_status_detail(
     out = capsys.readouterr().out
     assert "franchise" in out
     assert "experimental" in out  # lifecycle
-    assert "1" in out  # tier
+    tier_line = next(line for line in out.splitlines() if "Tier" in line)
+    assert "1" in tier_line  # tier value on its own line
     assert "true" in out  # enabled (default_enabled=True for franchise)
 
 

--- a/tests/cli/test_features_cli.py
+++ b/tests/cli/test_features_cli.py
@@ -1,0 +1,96 @@
+"""Tests for the features CLI subcommand."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.medium]
+
+
+# ---------------------------------------------------------------------------
+# T_FEATURES_1: features list shows all registered features
+# ---------------------------------------------------------------------------
+
+
+def test_features_list_shows_registry(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """features list output includes all registered feature names and lifecycle values."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "autoskillit.config.load_config", lambda path: type("C", (), {"features": {}})()
+    )
+    from autoskillit.cli._features import features_list
+
+    features_list()
+    out = capsys.readouterr().out
+    assert "franchise" in out
+    assert "experimental" in out
+
+
+# ---------------------------------------------------------------------------
+# T_FEATURES_2: effective column reflects config override
+# ---------------------------------------------------------------------------
+
+
+def test_features_list_shows_effective_state(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """features list shows effective=false and source=config when feature is overridden."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "autoskillit.config.load_config",
+        lambda path: type("C", (), {"features": {"franchise": False}})(),
+    )
+    from autoskillit.cli._features import features_list
+
+    features_list()
+    out = capsys.readouterr().out
+    # franchise row should show effective=false and source=config
+    assert "false" in out
+    assert "config" in out
+
+
+# ---------------------------------------------------------------------------
+# T_FEATURES_3: features status <name> shows all FeatureDef fields
+# ---------------------------------------------------------------------------
+
+
+def test_features_status_detail(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """features status franchise shows all FeatureDef fields."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "autoskillit.config.load_config", lambda path: type("C", (), {"features": {}})()
+    )
+    from autoskillit.cli._features import features_status
+
+    features_status("franchise")
+    out = capsys.readouterr().out
+    assert "franchise" in out
+    assert "experimental" in out  # lifecycle
+    assert "1" in out  # tier
+    assert "true" in out  # enabled (default_enabled=True for franchise)
+
+
+# ---------------------------------------------------------------------------
+# T_FEATURES_4: features status unknown name exits 1
+# ---------------------------------------------------------------------------
+
+
+def test_features_status_unknown(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """features status exits 1 for an unknown feature name."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "autoskillit.config.load_config", lambda path: type("C", (), {"features": {}})()
+    )
+    from autoskillit.cli._features import features_status
+
+    with pytest.raises(SystemExit) as exc_info:
+        features_status("nonexistent-feature")
+    assert exc_info.value.code == 1

--- a/tests/cli/test_features_cli.py
+++ b/tests/cli/test_features_cli.py
@@ -81,9 +81,7 @@ def test_features_status_detail(
 # ---------------------------------------------------------------------------
 
 
-def test_features_status_unknown(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_features_status_unknown(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """features status exits 1 for an unknown feature name."""
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(

--- a/tests/cli/test_franchise_cli.py
+++ b/tests/cli/test_franchise_cli.py
@@ -759,3 +759,92 @@ class TestFranchiseCLIRegistration:
         sig = inspect.signature(franchise_status)
         assert "dry_run" in sig.parameters
         assert "reap" in sig.parameters
+
+
+# ---------------------------------------------------------------------------
+# T_GUARD_1: franchise_run exits 1 when franchise feature disabled
+# ---------------------------------------------------------------------------
+
+
+def test_franchise_run_exits_when_disabled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """franchise_run exits 1 when franchise feature is disabled via feature gate."""
+    monkeypatch.chdir(tmp_path)
+    _stub_guards(monkeypatch)
+    monkeypatch.setattr(
+        "autoskillit.cli._franchise.is_feature_enabled", lambda name, features: False
+    )
+    monkeypatch.setattr(
+        "autoskillit.config.load_config", lambda path: type("C", (), {"features": {}})()
+    )
+    with pytest.raises(SystemExit) as exc_info:
+        _franchise_run("any-campaign")
+    assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# T_GUARD_2: franchise_list exits 1 when franchise feature disabled
+# ---------------------------------------------------------------------------
+
+
+def test_franchise_list_exits_when_disabled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """franchise_list exits 1 when franchise feature is disabled via feature gate."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "autoskillit.cli._franchise.is_feature_enabled", lambda name, features: False
+    )
+    monkeypatch.setattr(
+        "autoskillit.config.load_config", lambda path: type("C", (), {"features": {}})()
+    )
+    with pytest.raises(SystemExit) as exc_info:
+        _franchise_list()
+    assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# T_GUARD_3: franchise_status exits 1 when franchise feature disabled
+# ---------------------------------------------------------------------------
+
+
+def test_franchise_status_exits_when_disabled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """franchise_status exits 1 when franchise feature is disabled via feature gate."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "autoskillit.cli._franchise.is_feature_enabled", lambda name, features: False
+    )
+    monkeypatch.setattr(
+        "autoskillit.config.load_config", lambda path: type("C", (), {"features": {}})()
+    )
+    with pytest.raises(SystemExit) as exc_info:
+        _franchise_status(None)
+    assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# T_GUARD_4: franchise_run proceeds normally when franchise enabled
+# ---------------------------------------------------------------------------
+
+
+def test_franchise_run_proceeds_when_enabled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """franchise_run passes the feature guard and proceeds to campaign resolution."""
+    _stub_guards(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "autoskillit.cli._franchise.is_feature_enabled", lambda name, features: True
+    )
+    monkeypatch.setattr(
+        "autoskillit.config.load_config", lambda path: type("C", (), {"features": {}})()
+    )
+    # Campaign not found → exits 1 for campaign resolution, NOT the feature guard
+    # (guard passes, but campaign does not exist)
+    with pytest.raises(SystemExit) as exc_info:
+        _franchise_run("nonexistent-campaign")
+    # Would have exited at campaign resolution (not the feature guard)
+    assert exc_info.value.code == 1

--- a/tests/cli/test_franchise_cli.py
+++ b/tests/cli/test_franchise_cli.py
@@ -772,8 +772,10 @@ def test_franchise_run_exits_when_disabled(
     """franchise_run exits 1 when franchise feature is disabled via feature gate."""
     monkeypatch.chdir(tmp_path)
     _stub_guards(monkeypatch)
+    checked_features: list[str] = []
     monkeypatch.setattr(
-        "autoskillit.cli._franchise.is_feature_enabled", lambda name, features: False
+        "autoskillit.cli._franchise.is_feature_enabled",
+        lambda name, features: checked_features.append(name) or False,
     )
     monkeypatch.setattr(
         "autoskillit.config.load_config", lambda path: type("C", (), {"features": {}})()
@@ -781,6 +783,7 @@ def test_franchise_run_exits_when_disabled(
     with pytest.raises(SystemExit) as exc_info:
         _franchise_run("any-campaign")
     assert exc_info.value.code == 1
+    assert "franchise" in checked_features
 
 
 # ---------------------------------------------------------------------------
@@ -793,8 +796,10 @@ def test_franchise_list_exits_when_disabled(
 ) -> None:
     """franchise_list exits 1 when franchise feature is disabled via feature gate."""
     monkeypatch.chdir(tmp_path)
+    checked_features: list[str] = []
     monkeypatch.setattr(
-        "autoskillit.cli._franchise.is_feature_enabled", lambda name, features: False
+        "autoskillit.cli._franchise.is_feature_enabled",
+        lambda name, features: checked_features.append(name) or False,
     )
     monkeypatch.setattr(
         "autoskillit.config.load_config", lambda path: type("C", (), {"features": {}})()
@@ -802,6 +807,7 @@ def test_franchise_list_exits_when_disabled(
     with pytest.raises(SystemExit) as exc_info:
         _franchise_list()
     assert exc_info.value.code == 1
+    assert "franchise" in checked_features
 
 
 # ---------------------------------------------------------------------------
@@ -814,8 +820,10 @@ def test_franchise_status_exits_when_disabled(
 ) -> None:
     """franchise_status exits 1 when franchise feature is disabled via feature gate."""
     monkeypatch.chdir(tmp_path)
+    checked_features: list[str] = []
     monkeypatch.setattr(
-        "autoskillit.cli._franchise.is_feature_enabled", lambda name, features: False
+        "autoskillit.cli._franchise.is_feature_enabled",
+        lambda name, features: checked_features.append(name) or False,
     )
     monkeypatch.setattr(
         "autoskillit.config.load_config", lambda path: type("C", (), {"features": {}})()
@@ -823,6 +831,7 @@ def test_franchise_status_exits_when_disabled(
     with pytest.raises(SystemExit) as exc_info:
         _franchise_status(None)
     assert exc_info.value.code == 1
+    assert "franchise" in checked_features
 
 
 # ---------------------------------------------------------------------------
@@ -831,7 +840,7 @@ def test_franchise_status_exits_when_disabled(
 
 
 def test_franchise_run_proceeds_when_enabled(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
 ) -> None:
     """franchise_run passes the feature guard and proceeds to campaign resolution."""
     _stub_guards(monkeypatch)
@@ -842,9 +851,10 @@ def test_franchise_run_proceeds_when_enabled(
     monkeypatch.setattr(
         "autoskillit.config.load_config", lambda path: type("C", (), {"features": {}})()
     )
-    # Campaign not found → exits 1 for campaign resolution, NOT the feature guard
-    # (guard passes, but campaign does not exist)
     with pytest.raises(SystemExit) as exc_info:
         _franchise_run("nonexistent-campaign")
-    # Would have exited at campaign resolution (not the feature guard)
     assert exc_info.value.code == 1
+    # Guard passed — exit must come from campaign resolution, not the feature gate
+    captured = capsys.readouterr()
+    assert "not enabled" not in captured.err
+    assert "not found" in captured.out.lower()


### PR DESCRIPTION
## Summary

Add runtime feature-gate guards at the three franchise CLI command entry points and introduce a new `autoskillit features` subcommand for listing and inspecting registered feature gate state. The franchise handlers currently have no config access at all; each will get a deferred `load_config()` call followed by a `_require_franchise(cfg)` guard that exits cleanly with an actionable message when the feature is disabled. The new `features` subapp mirrors the pattern of existing subapps (`config_app`, `skills_app`, etc.) and exposes two commands: `list` (tabular overview of all FEATURE_REGISTRY entries with effective state) and `status <name>` (detailed single-feature view). A subordinate mechanical change bumps the `cli/` file-count exemption from 22 to 23 in the architecture isolation test and adds `_features` to the singleton-allowed-modules set.

## Architecture Impact

### Operational Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ENTRY %%
    ENTRY(["autoskillit <subcommand>"])

    %% CLI SUBCOMMANDS %%
    subgraph CLI ["● CLI ENTRY (app.py)"]
        direction TB
        FeaturesApp["★ features_app<br/>━━━━━━━━━━<br/>features list<br/>features status"]
        FranchiseApp["● franchise_app<br/>━━━━━━━━━━<br/>franchise run<br/>franchise list<br/>franchise status"]
    end

    %% FEATURES SUBCOMMANDS %%
    subgraph FeaturesGroup ["★ FEATURES SUBCOMMANDS (_features.py)"]
        direction TB
        FeatList["★ features list<br/>━━━━━━━━━━<br/>Reads FEATURE_REGISTRY<br/>Reads cfg.features<br/>Calls is_feature_enabled()"]
        FeatStatus["★ features status <name><br/>━━━━━━━━━━<br/>Single-feature detail view<br/>tier / lifecycle / depends_on<br/>tool_tags / skill_categories"]
    end

    %% FRANCHISE GUARD %%
    subgraph FranchiseGroup ["● FRANCHISE COMMANDS (_franchise.py)"]
        direction TB
        RequireFranchise["● _require_franchise(cfg)<br/>━━━━━━━━━━<br/>is_feature_enabled('franchise',<br/>  cfg.features)<br/>→ exit(1) if disabled"]
        FranchiseCmds["franchise run / list / status<br/>━━━━━━━━━━<br/>Campaign orchestration<br/>(unchanged logic)"]
    end

    %% FEATURE GATE LAYER %%
    subgraph FeatureGate ["FEATURE GATE (core/feature_flags.py + _type_constants.py)"]
        direction TB
        IsFeatureEnabled["is_feature_enabled(name, features)<br/>━━━━━━━━━━<br/>features[name] if present<br/>else FeatureDef.default_enabled"]
        FeatureRegistry["FEATURE_REGISTRY<br/>━━━━━━━━━━<br/>name → FeatureDef<br/>tier / lifecycle<br/>default_enabled<br/>tool_tags / skill_categories<br/>depends_on / since_version"]
    end

    %% CONFIGURATION %%
    subgraph Config ["CONFIGURATION (read-only at runtime)"]
        direction TB
        EnvVar["Env Override<br/>━━━━━━━━━━<br/>AUTOSKILLIT_FEATURES__FRANCHISE=true<br/>AUTOSKILLIT_FEATURES__*=true/false"]
        ConfigYaml["● .autoskillit/config.yaml<br/>━━━━━━━━━━<br/>features:<br/>  franchise: true/false<br/>  <name>: true/false"]
        Defaults["FeatureDef.default_enabled<br/>━━━━━━━━━━<br/>Per-feature default<br/>(in FEATURE_REGISTRY)"]
    end

    %% OUTPUTS %%
    subgraph Outputs ["OUTPUTS (write-only / human inspection)"]
        direction TB
        TableOutput["★ Terminal Table<br/>━━━━━━━━━━<br/>FEATURE / TIER / LIFECYCLE<br/>DEFAULT / EFFECTIVE / SOURCE<br/>(features list)"]
        DetailOutput["★ Detail View<br/>━━━━━━━━━━<br/>Feature: <name><br/>Lifecycle / Tier / Enabled / Source<br/>Package / Tool tags / Skill cats<br/>Since / Depends on / Sunset"]
        GateError["● Stderr + exit(1)<br/>━━━━━━━━━━<br/>'franchise feature not enabled'<br/>Enable hint: config or env var"]
    end

    %% FLOWS %%
    ENTRY --> FeaturesApp
    ENTRY --> FranchiseApp

    FeaturesApp --> FeatList
    FeaturesApp --> FeatStatus

    FranchiseApp --> RequireFranchise
    RequireFranchise --> FranchiseCmds
    RequireFranchise -->|"disabled"| GateError

    FeatList --> IsFeatureEnabled
    FeatStatus --> IsFeatureEnabled
    RequireFranchise --> IsFeatureEnabled

    IsFeatureEnabled --> FeatureRegistry

    EnvVar -->|"highest priority"| IsFeatureEnabled
    ConfigYaml -->|"project config"| IsFeatureEnabled
    Defaults -->|"fallback"| IsFeatureEnabled

    FeatList --> TableOutput
    FeatStatus --> DetailOutput

    %% CLASS ASSIGNMENTS %%
    class ENTRY terminal;
    class FeaturesApp newComponent;
    class FranchiseApp phase;
    class FeatList,FeatStatus newComponent;
    class RequireFranchise detector;
    class FranchiseCmds handler;
    class IsFeatureEnabled phase;
    class FeatureRegistry stateNode;
    class EnvVar,ConfigYaml,Defaults cli;
    class TableOutput,DetailOutput,GateError output;
```

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START: autoskillit CLI invoked])
    COMPLETE([COMPLETE: output rendered])
    ERROR([ERROR: SystemExit 1])

    %% PHASE: CLI Entry %%
    subgraph EntryPhase ["● CLI Entry — app.py: main()"]
        direction TB
        EvictMCP["● evict_direct_mcp_entry<br/>━━━━━━━━━━<br/>Evict stale direct MCP entry<br/>from ~/.claude.json"]
        UpdateChecks["● run_update_checks<br/>━━━━━━━━━━<br/>Version / hook / source-drift<br/>signals (skipped for 'serve')"]
        RouteCmd{"● Route subcommand<br/>━━━━━━━━━━<br/>features? / franchise? / other?"}
    end

    %% PHASE: Config Load %%
    subgraph ConfigPhase ["Config Resolution"]
        direction TB
        LoadCfg["load_config(Path.cwd())<br/>━━━━━━━━━━<br/>Dynaconf layered resolution<br/>.autoskillit/config.yaml<br/>→ AutomationConfig"]
    end

    %% PHASE: Features subcommand (NEW) %%
    subgraph FeaturesPhase ["★ features subcommand — _features.py"]
        direction TB
        FeaturesRoute{"★ Route features<br/>━━━━━━━━━━<br/>list / status?"}

        subgraph FeaturesListFlow ["★ features list"]
            direction TB
            IterRegistry["★ iter FEATURE_REGISTRY<br/>━━━━━━━━━━<br/>sorted(FEATURE_REGISTRY.items())"]
            CallIsEnabled["★ is_feature_enabled(name, cfg.features)<br/>━━━━━━━━━━<br/>cfg.features override → default_enabled<br/>determines effective state"]
            DetermineSource["★ determine source<br/>━━━━━━━━━━<br/>name in cfg.features?<br/>→ 'config' or 'default'"]
            RenderTable["★ _render_terminal_table()<br/>━━━━━━━━━━<br/>6 columns: FEATURE / TIER /<br/>LIFECYCLE / DEFAULT /<br/>EFFECTIVE / SOURCE"]
        end

        subgraph FeaturesStatusFlow ["★ features status <name>"]
            direction TB
            CheckRegistry{"★ name in FEATURE_REGISTRY?<br/>━━━━━━━━━━<br/>KeyError guard"}
            PrintDetail["★ print detailed status<br/>━━━━━━━━━━<br/>lifecycle / tier / enabled /<br/>tool_tags / skill_cats /<br/>since_version / depends_on"]
        end
    end

    %% PHASE: Franchise Guard (MODIFIED) %%
    subgraph FranchisePhase ["● franchise subcommand — _franchise.py"]
        direction TB
        FranchiseCmd["● franchise run/list/status<br/>━━━━━━━━━━<br/>Campaign management commands"]
        RequireFranchise["● _require_franchise(cfg)<br/>━━━━━━━━━━<br/>Feature gate entry guard<br/>(NEW in this PR)"]
        FeatureGate{"● is_feature_enabled<br/>('franchise', cfg.features)<br/>━━━━━━━━━━<br/>FEATURE_REGISTRY lookup<br/>+ config override"}
        FranchiseProceed["● franchise command proceeds<br/>━━━━━━━━━━<br/>run / list / status logic"]
        GateError["● print error to stderr<br/>━━━━━━━━━━<br/>'franchise feature not enabled'\nconfig override hint"]
    end

    %% FEATURE_REGISTRY (shared state) %%
    subgraph RegistryState ["FEATURE_REGISTRY — core/_type_constants.py"]
        direction LR
        Registry[("FEATURE_REGISTRY<br/>━━━━━━━━━━<br/>dict[str, FeatureDef]<br/>name / lifecycle / tier /<br/>default_enabled / tool_tags")]
    end

    %% IS_FEATURE_ENABLED (shared primitive) %%
    IsFeatEnabled["is_feature_enabled(name, features)<br/>━━━━━━━━━━<br/>L0 gate primitive<br/>features.get(name, defn.default_enabled)<br/>raises KeyError if unknown"]

    %% FLOW %%
    START --> EvictMCP
    EvictMCP --> UpdateChecks
    UpdateChecks --> RouteCmd

    RouteCmd -->|"autoskillit features ..."| LoadCfg
    RouteCmd -->|"autoskillit franchise ..."| LoadCfg
    RouteCmd -->|"other commands"| COMPLETE

    LoadCfg -->|"features path"| FeaturesRoute
    LoadCfg -->|"franchise path"| FranchiseCmd

    %% Features list path %%
    FeaturesRoute -->|"list"| IterRegistry
    IterRegistry --> CallIsEnabled
    CallIsEnabled -->|"reads"| Registry
    CallIsEnabled --> DetermineSource
    DetermineSource --> RenderTable
    RenderTable --> COMPLETE

    %% Features status path %%
    FeaturesRoute -->|"status <name>"| CheckRegistry
    CheckRegistry -->|"name unknown"| ERROR
    CheckRegistry -->|"name found"| IsFeatEnabled
    IsFeatEnabled -->|"reads"| Registry
    IsFeatEnabled --> PrintDetail
    PrintDetail --> COMPLETE

    %% Franchise guard path %%
    FranchiseCmd --> RequireFranchise
    RequireFranchise --> FeatureGate
    FeatureGate -->|"reads"| Registry
    FeatureGate -->|"enabled=true"| FranchiseProceed
    FeatureGate -->|"enabled=false"| GateError
    FranchiseProceed --> COMPLETE
    GateError --> ERROR

    %% CLASS ASSIGNMENTS %%
    class START,COMPLETE,ERROR terminal;
    class EvictMCP,UpdateChecks,RouteCmd phase;
    class LoadCfg handler;
    class FeaturesRoute stateNode;
    class IterRegistry,CallIsEnabled,DetermineSource,RenderTable newComponent;
    class CheckRegistry detector;
    class PrintDetail newComponent;
    class FranchiseCmd,RequireFranchise phase;
    class FeatureGate detector;
    class FranchiseProceed handler;
    class GateError detector;
    class Registry stateNode;
    class IsFeatEnabled handler;
```

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph L3_CLI ["L3 — CLI Application Layer"]
        direction LR
        APP["● cli/app.py<br/>━━━━━━━━━━<br/>CLI entry: serve, order, cook<br/>Registers: franchise_app, features_app"]
        FEATURES["★ cli/_features.py<br/>━━━━━━━━━━<br/>features list / features status<br/>features_app = App(name='features')"]
        FRANCHISE["● cli/_franchise.py<br/>━━━━━━━━━━<br/>franchise run / list / status<br/>+_require_franchise() guard"]
    end

    subgraph L2_Domain ["L2 — Domain Layer"]
        FRANCHISE_PKG["franchise/<br/>━━━━━━━━━━<br/>CampaignState, DispatchStatus<br/>read_state, mark_dispatch_interrupted"]
    end

    subgraph L1_Infra ["L1 — Infrastructure Layer"]
        CONFIG["config/<br/>━━━━━━━━━━<br/>load_config()<br/>AutomationConfig"]
        PIPELINE["pipeline/<br/>━━━━━━━━━━<br/>DefaultTokenLog"]
        EXECUTION["execution/<br/>━━━━━━━━━━<br/>resolve_log_dir<br/>async_kill_process_tree<br/>read_starttime_ticks"]
    end

    subgraph L0_Core ["L0 — Core Foundation (feature gate primitives)"]
        FEATURE_FLAGS["core/feature_flags.py<br/>━━━━━━━━━━<br/>is_feature_enabled()<br/>FEATURE_REGISTRY (FeatureDef)"]
        TERMINAL_TABLE["core/_terminal_table.py<br/>━━━━━━━━━━<br/>TerminalColumn<br/>_render_terminal_table()"]
        CORE_TYPES["core/_type_*.py<br/>━━━━━━━━━━<br/>StrEnums, Protocols<br/>GATED_TOOLS, constants"]
    end

    subgraph TESTS ["Tests (arch + cli)"]
        TEST_FEATURES["★ tests/cli/test_features_cli.py<br/>━━━━━━━━━━<br/>T_FEATURES_1..4<br/>list/status command coverage"]
        TEST_FRANCHISE["● tests/cli/test_franchise_cli.py<br/>━━━━━━━━━━<br/>franchise guard tests"]
        ARCH_RULES["● tests/arch/_rules.py<br/>━━━━━━━━━━<br/>+_features.py → _PRINT_EXEMPT<br/>ARCH-001 no-print exemption"]
        ARCH_ISOLATION["● tests/arch/test_subpackage_isolation.py<br/>━━━━━━━━━━<br/>+_features → SINGLETON_ALLOWED<br/>allows App() at module scope"]
    end

    subgraph EXT ["External"]
        CYCLOPTS["cyclopts<br/>━━━━━━━━━━<br/>App (CLI framework)"]
    end

    %% L3 app.py wires both subapps %%
    APP -->|"imports features_app"| FEATURES
    APP -->|"imports franchise_app"| FRANCHISE

    %% NEW: _features.py → L0 core (feature registry read path) %%
    FEATURES -->|"FEATURE_REGISTRY, is_feature_enabled"| FEATURE_FLAGS
    FEATURES -->|"TerminalColumn, _render_terminal_table"| TERMINAL_TABLE
    FEATURES -->|"load_config()"| CONFIG

    %% MODIFIED: _franchise.py now also gates on is_feature_enabled %%
    FRANCHISE -->|"is_feature_enabled() — NEW guard"| FEATURE_FLAGS
    FRANCHISE -->|"TerminalColumn, get_logger"| CORE_TYPES
    FRANCHISE -->|"load_config()"| CONFIG
    FRANCHISE -->|"read_state, DispatchStatus, ..."| FRANCHISE_PKG
    FRANCHISE -->|"resolve_log_dir, kill_process_tree"| EXECUTION
    FRANCHISE -->|"DefaultTokenLog"| PIPELINE

    %% L0 internal %%
    FEATURE_FLAGS -->|"reads FeatureDef entries"| CORE_TYPES
    TERMINAL_TABLE -->|"uses type primitives"| CORE_TYPES

    %% External %%
    FEATURES -->|"App() constructor"| CYCLOPTS
    FRANCHISE -->|"App() constructor"| CYCLOPTS
    APP -->|"App() constructor"| CYCLOPTS

    %% Tests → src %%
    TEST_FEATURES -.->|"exercises"| FEATURES
    TEST_FRANCHISE -.->|"exercises"| FRANCHISE
    ARCH_RULES -.->|"exempts"| FEATURES
    ARCH_ISOLATION -.->|"exempts"| FEATURES

    %% CLASS ASSIGNMENTS %%
    class APP,FEATURES,FRANCHISE cli;
    class FEATURE_FLAGS stateNode;
    class TERMINAL_TABLE,CORE_TYPES handler;
    class CONFIG,PIPELINE,EXECUTION phase;
    class FRANCHISE_PKG phase;
    class FEATURES newComponent;
    class TEST_FEATURES,TEST_FRANCHISE,ARCH_RULES,ARCH_ISOLATION output;
    class CYCLOPTS integration;
```

Closes #1107

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260422-131252-641042/.autoskillit/temp/make-plan/feature_gate_cli_entry_guards_and_features_subcommand_plan_2026-04-22_140100.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 219 | 21.7k | 1.9M | 113.7k | 1 | 5m 43s |
| verify | 100 | 14.4k | 866.1k | 97.7k | 1 | 4m 47s |
| implement | 376 | 17.6k | 4.1M | 102.7k | 1 | 5m 15s |
| fix | 232 | 8.7k | 1.4M | 61.0k | 1 | 6m 17s |
| prepare_pr | 52 | 5.6k | 171.1k | 28.7k | 1 | 1m 49s |
| run_arch_lenses | 199 | 15.4k | 891.7k | 174.9k | 3 | 4m 41s |
| compose_pr | 91 | 8.4k | 330.3k | 32.5k | 1 | 2m 39s |
| **Total** | 1.3k | 91.8k | 9.6M | 611.1k | | 31m 15s |