### PR TITLE
feature-gate: Gate Franchise for Stable + Enable on Integration

### DIFF
--- a/.autoskillit/config.yaml
+++ b/.autoskillit/config.yaml
@@ -30,3 +30,6 @@ ci:
 
 github:
   default_repo: "TalonT-Org/AutoSkillit"
+
+features:
+  franchise: true  # Enable franchise on integration for active development

--- a/src/autoskillit/config/defaults.yaml
+++ b/src/autoskillit/config/defaults.yaml
@@ -256,4 +256,4 @@ franchise:
   l2_default_timeout_sec: 3600
 
 features:
-  franchise: true  # True during transition; flipped to false in ticket #8
+  franchise: false  # Disabled by default; enabled via project config on integration

--- a/src/autoskillit/core/_type_constants.py
+++ b/src/autoskillit/core/_type_constants.py
@@ -370,7 +370,7 @@ FEATURE_REGISTRY: dict[str, FeatureDef] = {
         skill_categories=frozenset({"franchise"}),
         import_package="autoskillit.franchise",
         tier=1,
-        default_enabled=True,
+        default_enabled=False,
         since_version="0.9.51",
     ),
 }

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -215,6 +215,9 @@ class TestCLIDoctor:
         """doctor JSON includes entries for all core check names."""
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         monkeypatch.chdir(tmp_path)
+        cfg_dir = tmp_path / ".autoskillit"
+        cfg_dir.mkdir(parents=True, exist_ok=True)
+        (cfg_dir / "config.yaml").write_text("features:\n  franchise: true\n")
         cli.doctor(output_json=True)
         captured = capsys.readouterr()
         data = json.loads(captured.out)
@@ -2173,6 +2176,9 @@ class TestGroupMFranchiseDoctorChecks:
         monkeypatch.chdir(tmp_path)
         monkeypatch.delenv("AUTOSKILLIT_SESSION_TYPE", raising=False)
         monkeypatch.delenv("AUTOSKILLIT_CAMPAIGN_ID", raising=False)
+        cfg_dir = tmp_path / ".autoskillit"
+        cfg_dir.mkdir(parents=True, exist_ok=True)
+        (cfg_dir / "config.yaml").write_text("features:\n  franchise: true\n")
         cli.doctor(output_json=True)
         data = json.loads(capsys.readouterr().out)
         check_names = {r["check"] for r in data["results"]}

--- a/tests/cli/test_features_cli.py
+++ b/tests/cli/test_features_cli.py
@@ -75,7 +75,7 @@ def test_features_status_detail(
     assert "experimental" in out  # lifecycle
     tier_line = next(line for line in out.splitlines() if "Tier" in line)
     assert "1" in tier_line  # tier value on its own line
-    assert "true" in out  # enabled (default_enabled=True for franchise)
+    assert "false" in out  # disabled (default_enabled=False for franchise)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_franchise_cli.py
+++ b/tests/cli/test_franchise_cli.py
@@ -24,6 +24,16 @@ from autoskillit.cli._franchise import franchise_status as _franchise_status
 pytestmark = [pytest.mark.layer("cli"), pytest.mark.medium, pytest.mark.feature("franchise")]
 
 
+@pytest.fixture(autouse=True)
+def _franchise_config(tmp_path: Path) -> None:
+    """Ensure .autoskillit/config.yaml enables franchise so _require_franchise passes."""
+    cfg_dir = tmp_path / ".autoskillit"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    cfg_file = cfg_dir / "config.yaml"
+    if not cfg_file.exists():
+        cfg_file.write_text("features:\n  franchise: true\n")
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -1304,6 +1304,8 @@ def test_project_config_has_franchise_override() -> None:
     import yaml
 
     config_path = Path(__file__).resolve().parents[2] / ".autoskillit" / "config.yaml"
+    if not config_path.exists():
+        pytest.skip("project config not present (clean clone or CI)")
     with open(config_path) as f:
         data = yaml.safe_load(f)
     assert data.get("features", {}).get("franchise") is True
@@ -1316,5 +1318,8 @@ def test_config_resolution_franchise_enabled_via_project_config() -> None:
     from autoskillit.config.settings import load_config
     from autoskillit.core.feature_flags import is_feature_enabled
 
-    cfg = load_config(Path(__file__).resolve().parents[2])
+    project_root = Path(__file__).resolve().parents[2]
+    if not (project_root / ".autoskillit" / "config.yaml").exists():
+        pytest.skip("project config not present (clean clone or CI)")
+    cfg = load_config(project_root)
     assert is_feature_enabled("franchise", cfg.features) is True

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -1284,3 +1284,37 @@ class TestFranchiseConfig:
         (config_dir / "config.yaml").write_text(yaml.dump(config_data))
         with pytest.raises(ValueError, match="l2_default_timeout_sec must be positive"):
             load_config(tmp_path)
+
+
+def test_defaults_yaml_franchise_false() -> None:
+    """Package default has franchise disabled."""
+    import yaml
+
+    from autoskillit.core.paths import pkg_root
+
+    with open(pkg_root() / "config" / "defaults.yaml") as f:
+        data = yaml.safe_load(f)
+    assert data["features"]["franchise"] is False
+
+
+def test_project_config_has_franchise_override() -> None:
+    """Integration's project config enables franchise."""
+    from pathlib import Path
+
+    import yaml
+
+    config_path = Path(__file__).resolve().parents[2] / ".autoskillit" / "config.yaml"
+    with open(config_path) as f:
+        data = yaml.safe_load(f)
+    assert data.get("features", {}).get("franchise") is True
+
+
+def test_config_resolution_franchise_enabled_via_project_config() -> None:
+    """Full config resolution picks up project-level franchise override."""
+    from pathlib import Path
+
+    from autoskillit.config.settings import load_config
+    from autoskillit.core.feature_flags import is_feature_enabled
+
+    cfg = load_config(Path(__file__).resolve().parents[2])
+    assert is_feature_enabled("franchise", cfg.features) is True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Shared test fixtures for autoskillit."""
 
+import functools
 import os
 from pathlib import Path as _Path
 
@@ -357,15 +358,36 @@ def pytest_configure(config: pytest.Config) -> None:
         )
 
 
+@functools.lru_cache(maxsize=1)
+def _resolve_test_features() -> dict[str, bool]:
+    """Resolve feature flags for test collection via full config resolution.
+
+    Uses the same dynaconf chain as production: defaults.yaml → project config → env vars.
+    Returns empty dict on any failure (fail-open: individual features fall back to
+    FEATURE_REGISTRY[name].default_enabled).
+    """
+    try:
+        from pathlib import Path
+
+        from autoskillit.config.settings import load_config
+
+        cfg = load_config(Path.cwd())
+        return dict(cfg.features)
+    except Exception:
+        return {}
+
+
 def _is_test_feature_enabled(feature_name: str, *, env_val: str | None) -> bool:
     """Return True if feature_name is enabled for this test run.
 
     Resolution order:
     1. If AUTOSKILLIT_TEST_FEATURES is set (including empty string), parse it
-       as a comma-separated list of enabled feature names.  Only listed names
-       are enabled; all others are disabled.
-    2. If unset, fall back to FEATURE_REGISTRY[name].default_enabled.
-       Unknown feature names return True (fail-open: don't skip unrecognised names).
+       as a comma-separated whitelist.  Only listed names are enabled.
+    2. If unset, resolve via full config chain (defaults.yaml → project config
+       → env vars) using load_config().  This respects project-level overrides
+       like .autoskillit/config.yaml features.franchise: true.
+    3. If config resolution fails, fall back to FEATURE_REGISTRY[name].default_enabled.
+       Unknown feature names return True (fail-open).
 
     Args:
         feature_name: The feature name to check.
@@ -374,6 +396,11 @@ def _is_test_feature_enabled(feature_name: str, *, env_val: str | None) -> bool:
     if env_val is not None:
         enabled = {f.strip() for f in env_val.split(",") if f.strip()}
         return feature_name in enabled
+
+    resolved = _resolve_test_features()
+    if feature_name in resolved:
+        return resolved[feature_name]
+
     from autoskillit.core import FEATURE_REGISTRY
 
     defn = FEATURE_REGISTRY.get(feature_name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -380,7 +380,13 @@ def _resolve_test_features() -> dict[str, bool]:
         repo_root = Path(__file__).resolve().parent.parent
         cfg = load_config(repo_root)
         return dict(cfg.features)
-    except Exception:
+    except Exception as exc:
+        import warnings
+
+        warnings.warn(
+            f"Feature flag config resolution failed, falling back to defaults: {exc}",
+            stacklevel=1,
+        )
         return {}
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -233,7 +233,7 @@ def minimal_ctx(tmp_path):
     from autoskillit.pipeline.tokens import DefaultTokenLog
 
     ctx = ToolContext(
-        config=AutomationConfig(),
+        config=AutomationConfig(features={"franchise": True}),
         audit=DefaultAuditLog(),
         token_log=DefaultTokenLog(),
         timing_log=DefaultTimingLog(),
@@ -266,7 +266,11 @@ def tool_ctx(monkeypatch, tmp_path):
     from autoskillit.server._factory import make_context
 
     mock_runner = MockSubprocessRunner()
-    ctx = make_context(AutomationConfig(), runner=mock_runner, plugin_dir=str(tmp_path))
+    ctx = make_context(
+        AutomationConfig(features={"franchise": True}),
+        runner=mock_runner,
+        plugin_dir=str(tmp_path),
+    )
     ctx.gate = DefaultGateState(enabled=True)
     ctx.config.linux_tracing.log_dir = str(tmp_path / "session_logs")
     ctx.config.linux_tracing.tmpfs_path = str(tmp_path / "shm")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -375,7 +375,10 @@ def _resolve_test_features() -> dict[str, bool]:
 
         from autoskillit.config.settings import load_config
 
-        cfg = load_config(Path.cwd())
+        # Anchor to repo root via this file's known location (tests/conftest.py)
+        # rather than Path.cwd(), which varies across IDE runners and monkeypatch.chdir.
+        repo_root = Path(__file__).resolve().parent.parent
+        cfg = load_config(repo_root)
         return dict(cfg.features)
     except Exception:
         return {}

--- a/tests/core/test_type_constants.py
+++ b/tests/core/test_type_constants.py
@@ -153,3 +153,17 @@ def test_exclusive_feature_tools_exists() -> None:
     from autoskillit.core import EXCLUSIVE_FEATURE_TOOLS
 
     assert isinstance(EXCLUSIVE_FEATURE_TOOLS, dict)
+
+
+def test_franchise_default_enabled_is_false() -> None:
+    """Franchise is gated off by default — enabled only via project config."""
+    from autoskillit.core import FEATURE_REGISTRY
+
+    assert FEATURE_REGISTRY["franchise"].default_enabled is False
+
+
+def test_is_feature_enabled_franchise_defaults_false() -> None:
+    """Without explicit config, franchise resolves to disabled."""
+    from autoskillit.core.feature_flags import is_feature_enabled
+
+    assert is_feature_enabled("franchise", {}) is False

--- a/tests/server/test_server_init.py
+++ b/tests/server/test_server_init.py
@@ -62,7 +62,7 @@ class TestKitchenVisibility:
 
         mock_ctx = AsyncMock()
 
-        await _redisable_subsets(mock_ctx, ["kitchen-core"])
+        await _redisable_subsets(mock_ctx, ["kitchen-core"], features={"franchise": True})
 
         mock_ctx.disable_components.assert_called_once_with(tags={"kitchen-core"})
 

--- a/tests/server/test_tools_kitchen.py
+++ b/tests/server/test_tools_kitchen.py
@@ -534,7 +534,9 @@ async def test_open_kitchen_no_redisable_when_empty(tmp_path, monkeypatch):
     mock_ctx = _make_mock_ctx()
     mock_ctx.enable_components = AsyncMock()
     mock_ctx.disable_components = AsyncMock()
-    mock_ctx.config = AutomationConfig(subsets=SubsetsConfig(disabled=[]))
+    mock_ctx.config = AutomationConfig(
+        subsets=SubsetsConfig(disabled=[]), features={"franchise": True}
+    )
 
     with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
         with patch("autoskillit.server.logger"):

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -223,3 +223,24 @@ def test_minimal_ctx_provides_isolated_gate(minimal_ctx):
 
     assert isinstance(minimal_ctx.gate, DefaultGateState)
     assert minimal_ctx.gate.enabled is True
+
+
+def test_is_test_feature_enabled_reads_project_config(monkeypatch):
+    """When AUTOSKILLIT_TEST_FEATURES is unset, conftest resolves features via config."""
+    monkeypatch.delenv("AUTOSKILLIT_TEST_FEATURES", raising=False)
+    from tests.conftest import _is_test_feature_enabled, _resolve_test_features
+
+    _resolve_test_features.cache_clear()
+    result = _is_test_feature_enabled("franchise", env_val=None)
+    assert result is True
+
+
+def test_is_test_feature_enabled_dynaconf_env_overrides(monkeypatch):
+    """AUTOSKILLIT_FEATURES__FRANCHISE=false overrides project config in test resolution."""
+    monkeypatch.delenv("AUTOSKILLIT_TEST_FEATURES", raising=False)
+    monkeypatch.setenv("AUTOSKILLIT_FEATURES__FRANCHISE", "false")
+    from tests.conftest import _is_test_feature_enabled, _resolve_test_features
+
+    _resolve_test_features.cache_clear()
+    result = _is_test_feature_enabled("franchise", env_val=None)
+    assert result is False

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -231,8 +231,11 @@ def test_is_test_feature_enabled_reads_project_config(monkeypatch):
     from tests.conftest import _is_test_feature_enabled, _resolve_test_features
 
     _resolve_test_features.cache_clear()
-    result = _is_test_feature_enabled("franchise", env_val=None)
-    assert result is True
+    try:
+        result = _is_test_feature_enabled("franchise", env_val=None)
+        assert result is True
+    finally:
+        _resolve_test_features.cache_clear()
 
 
 def test_is_test_feature_enabled_dynaconf_env_overrides(monkeypatch):
@@ -242,5 +245,8 @@ def test_is_test_feature_enabled_dynaconf_env_overrides(monkeypatch):
     from tests.conftest import _is_test_feature_enabled, _resolve_test_features
 
     _resolve_test_features.cache_clear()
-    result = _is_test_feature_enabled("franchise", env_val=None)
-    assert result is False
+    try:
+        result = _is_test_feature_enabled("franchise", env_val=None)
+        assert result is False
+    finally:
+        _resolve_test_features.cache_clear()

--- a/tests/workspace/test_project_local_overrides.py
+++ b/tests/workspace/test_project_local_overrides.py
@@ -245,7 +245,8 @@ def test_init_session_cook_full_skill_set_invariant(tmp_path):
 
     # Config disables all known categories — cook should bypass this
     config = make_test_config(
-        subsets=make_subsetsconfig(disabled=["github", "audit", "arch-lens", "ci"])
+        subsets=make_subsetsconfig(disabled=["github", "audit", "arch-lens", "ci"]),
+        features={"franchise": True},
     )
     mgr = DefaultSessionSkillManager(SkillsDirectoryProvider(), tmp_path / "ephemeral")
     skills_dir = mgr.init_session(
@@ -309,6 +310,7 @@ def test_cook_session_retains_non_colliding_extended_skills(tmp_path):
         SkillsDirectoryProvider,
     )
     from autoskillit.workspace.skills import DefaultSkillResolver
+    from tests._helpers import make_test_config
 
     # Override exactly one extended skill
     project_dir = tmp_path / "project"
@@ -317,8 +319,11 @@ def test_cook_session_retains_non_colliding_extended_skills(tmp_path):
     override.mkdir(parents=True)
     (override / "SKILL.md").write_text("# custom")
 
+    config = make_test_config(features={"franchise": True})
     mgr = DefaultSessionSkillManager(SkillsDirectoryProvider(), tmp_path / "ephemeral")
-    skills_dir = mgr.init_session("sess-retain", cook_session=True, project_dir=project_dir)
+    skills_dir = mgr.init_session(
+        "sess-retain", cook_session=True, config=config, project_dir=project_dir
+    )
 
     resolver = DefaultSkillResolver()
     expected = {

--- a/tests/workspace/test_session_skills.py
+++ b/tests/workspace/test_session_skills.py
@@ -513,15 +513,15 @@ def test_skill_enabled_when_feature_on(tmp_path: Path) -> None:
     )
 
 
-def test_skill_not_suppressed_when_no_features_config(tmp_path: Path) -> None:
+def test_skill_suppressed_when_no_features_config(tmp_path: Path) -> None:
     """Feature-gated skills use default_enabled when config is None (no features dict)."""
     provider = SkillsDirectoryProvider()
     mgr = DefaultSessionSkillManager(provider, ephemeral_root=tmp_path)
     session_path = mgr.init_session("test-no-features-config", cook_session=False, config=None)
     skill_names = {p.parent.name for p in session_path.glob(".claude/skills/*/SKILL.md")}
-    assert "make-campaign" in skill_names, (
-        "make-campaign must be present when no features config is provided "
-        "(franchise.default_enabled=True)"
+    assert "make-campaign" not in skill_names, (
+        "make-campaign must be absent when no features config is provided "
+        "(franchise.default_enabled=False)"
     )
 
 


### PR DESCRIPTION
## Summary

Flip the franchise feature gate from enabled-by-default to disabled-by-default, so that main/stable branches hide franchise entirely. Simultaneously add a project-level config override (`.autoskillit/config.yaml`) that keeps franchise active on integration. Update the test infrastructure so that `_is_test_feature_enabled` resolves feature state via the full dynaconf config chain (defaults.yaml → project config → env vars) rather than only `FEATURE_REGISTRY[name].default_enabled`.

Three production files change (`_type_constants.py`, `defaults.yaml`, `.autoskillit/config.yaml`). One test-infrastructure file changes (`tests/conftest.py`) to bridge the gap between test-time feature resolution and runtime config layering.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START])
    TOOLS_VISIBLE([TOOLS VISIBLE])
    TOOLS_HIDDEN([TOOLS HIDDEN])
    CLI_EXIT([CLI EXIT 1])
    ERROR([CONFIG ERROR])

    subgraph ConfigResolution ["● Config Resolution — settings.py + defaults.yaml"]
        direction TB
        DEFAULTS["● defaults.yaml<br/>━━━━━━━━━━<br/>features.franchise: false<br/>L0 package default"]
        LAYERS["_make_dynaconf()<br/>━━━━━━━━━━<br/>Merge 4 YAML layers<br/>defaults → user → project → secrets"]
        ENVVARS["Dynaconf Env Override<br/>━━━━━━━━━━<br/>AUTOSKILLIT_FEATURES__FRANCHISE<br/>Highest priority"]
        BUILD_FEAT["● _build_features_dict()<br/>━━━━━━━━━━<br/>Validate names vs FEATURE_REGISTRY<br/>Reject non-bool, check depends_on"]
        FEAT_VALID{"features valid?"}
        FRAN_VALIDATE["FranchiseConfig.validate()<br/>━━━━━━━━━━<br/>Skip if feature disabled<br/>Check timeout > 0 if enabled"]
    end

    subgraph FeatureRegistry ["● Feature Registry — _type_constants.py"]
        direction TB
        REGISTRY["● FEATURE_REGISTRY<br/>━━━━━━━━━━<br/>franchise: FeatureDef<br/>default_enabled=False<br/>lifecycle=EXPERIMENTAL"]
        REVEAL_TAGS["● FEATURE_REVEAL_TAGS<br/>━━━━━━━━━━<br/>frozenset franchise"]
        TOOL_TAGS["● TOOL_SUBSET_TAGS<br/>━━━━━━━━━━<br/>6 tools carry franchise tag<br/>All also carry kitchen-core or clone"]
    end

    subgraph ServerStartup ["MCP Server Startup — server/__init__.py + _session_type.py"]
        direction TB
        DISABLE_KITCHEN["mcp.disable tags=kitchen<br/>━━━━━━━━━━<br/>All kitchen tools hidden<br/>at import time"]
        SESSION_DISPATCH{"Session Type?"}
        FRAN_SESSION["mcp.enable tags=franchise<br/>━━━━━━━━━━<br/>Pre-reveal franchise tools"]
        ORCH_SESSION["mcp.enable tags=kitchen-core<br/>━━━━━━━━━━<br/>Pre-reveal orchestrator tools"]
        FRAN_GATE{"_franchise_gate<br/>━━━━━━━━━━<br/>AUTOSKILLIT_FEATURES__<br/>FRANCHISE env var?"}
        SUPPRESS_STARTUP["mcp.disable tags=franchise<br/>━━━━━━━━━━<br/>Override: suppress franchise<br/>tag at startup"]
    end

    subgraph OpenKitchen ["open_kitchen Runtime — tools_kitchen.py"]
        direction TB
        ENABLE_KITCHEN["ctx.enable_components<br/>tags=kitchen<br/>━━━━━━━━━━<br/>Reveal all kitchen tools"]
        REDISABLE_P1["_redisable_subsets Pass 1<br/>━━━━━━━━━━<br/>Re-suppress config.subsets.disabled"]
        FEAT_CHECK{"is_feature_enabled<br/>franchise?"}
        REDISABLE_P2["_redisable_subsets Pass 2<br/>━━━━━━━━━━<br/>ctx.disable_components<br/>tags=franchise"]
    end

    subgraph CLIGuards ["CLI & Doctor Guards — _franchise.py + _doctor.py"]
        direction TB
        CLI_LOAD["● load_config()<br/>━━━━━━━━━━<br/>Resolve AutomationConfig"]
        CLI_GATE{"is_feature_enabled<br/>franchise?"}
        CLI_PROCEED["CLI subcommand executes<br/>━━━━━━━━━━<br/>franchise run / list / status"]
        DOC_ALWAYS["● Doctor Checks 22-23<br/>━━━━━━━━━━<br/>Feature dependencies<br/>Registry consistency"]
        DOC_CONDITIONAL["● Doctor Checks 24-28<br/>━━━━━━━━━━<br/>sous-chef, dispatch guard<br/>stale state, onboarding"]
    end

    subgraph SkillInjection ["Skill Injection — session_skills.py"]
        direction TB
        BUILD_DISABLED["● build disabled_feature_tags<br/>━━━━━━━━━━<br/>Collect tool_tags for each<br/>disabled feature"]
        RESOLVE_EFF["_resolve_effective_disabled()<br/>━━━━━━━━━━<br/>disabled ∪ default_disabled_packs<br/>∪ disabled_feature_tags − enabled"]
        SKILL_CHECK{"● _is_skill_disabled<br/>━━━━━━━━━━<br/>categories ∩<br/>feature.skill_categories?"}
        SKILL_INJECT["Write skill to session dir"]
        SKILL_SKIP["Omit skill from session"]
    end

    %% === MAIN FLOW === %%

    START --> DEFAULTS
    DEFAULTS -->|"reads"| LAYERS
    LAYERS -->|"reads env"| ENVVARS
    ENVVARS -->|"writes merged dict"| BUILD_FEAT

    REGISTRY -.->|"validates against"| BUILD_FEAT
    BUILD_FEAT --> FEAT_VALID

    FEAT_VALID -->|"invalid: unknown name<br/>non-bool, missing dep"| ERROR
    FEAT_VALID -->|"valid"| FRAN_VALIDATE
    FRAN_VALIDATE -->|"writes AutomationConfig.features"| CLI_LOAD

    %% Feature Registry feeds into multiple consumers
    REGISTRY -.->|"defines default_enabled"| FRAN_GATE
    REVEAL_TAGS -.->|"determines suppression tag"| REDISABLE_P2
    REVEAL_TAGS -.->|"determines suppression tag"| SUPPRESS_STARTUP
    TOOL_TAGS -.->|"maps tools → tags"| ENABLE_KITCHEN

    %% Server Startup Path
    START --> DISABLE_KITCHEN
    DISABLE_KITCHEN --> SESSION_DISPATCH

    SESSION_DISPATCH -->|"FRANCHISE"| FRAN_SESSION
    SESSION_DISPATCH -->|"ORCHESTRATOR + headless"| ORCH_SESSION
    SESSION_DISPATCH -->|"Interactive"| FRAN_GATE

    FRAN_SESSION --> FRAN_GATE
    ORCH_SESSION --> FRAN_GATE

    FRAN_GATE -->|"false / 0 / no"| SUPPRESS_STARTUP
    FRAN_GATE -->|"absent or truthy"| TOOLS_VISIBLE
    SUPPRESS_STARTUP --> TOOLS_HIDDEN

    %% open_kitchen Runtime Path
    ENABLE_KITCHEN --> REDISABLE_P1
    REDISABLE_P1 --> FEAT_CHECK

    FEAT_CHECK -->|"enabled"| TOOLS_VISIBLE
    FEAT_CHECK -->|"disabled"| REDISABLE_P2
    REDISABLE_P2 --> TOOLS_HIDDEN

    %% CLI Guard Path
    CLI_LOAD --> CLI_GATE
    CLI_GATE -->|"enabled"| CLI_PROCEED
    CLI_GATE -->|"disabled"| CLI_EXIT

    CLI_LOAD --> DOC_ALWAYS
    DOC_ALWAYS --> CLI_GATE
    CLI_GATE -->|"enabled"| DOC_CONDITIONAL

    %% Skill Injection Path
    CLI_LOAD -->|"reads config.features"| BUILD_DISABLED
    BUILD_DISABLED --> RESOLVE_EFF
    RESOLVE_EFF --> SKILL_CHECK
    SKILL_CHECK -->|"intersection empty"| SKILL_INJECT
    SKILL_CHECK -->|"categories match<br/>disabled feature"| SKILL_SKIP

    %% CLASS ASSIGNMENTS %%
    class START,TOOLS_VISIBLE,TOOLS_HIDDEN,CLI_EXIT,ERROR terminal;
    class DEFAULTS,LAYERS,ENVVARS stateNode;
    class BUILD_FEAT,FRAN_VALIDATE handler;
    class REGISTRY,REVEAL_TAGS,TOOL_TAGS stateNode;
    class FEAT_VALID,SESSION_DISPATCH,FRAN_GATE,FEAT_CHECK,CLI_GATE,SKILL_CHECK detector;
    class DISABLE_KITCHEN,FRAN_SESSION,ORCH_SESSION,SUPPRESS_STARTUP phase;
    class ENABLE_KITCHEN,REDISABLE_P1,REDISABLE_P2 phase;
    class CLI_LOAD,CLI_PROCEED,DOC_ALWAYS,DOC_CONDITIONAL handler;
    class BUILD_DISABLED,RESOLVE_EFF,SKILL_INJECT,SKILL_SKIP output;
```

### Operational Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ── CONFIGURATION HIERARCHY ── %%
    subgraph Config ["CONFIGURATION HIERARCHY (read-only inputs)"]
        direction TB
        ENV["ENV VARS  ⟨priority 5⟩<br/>━━━━━━━━━━<br/>AUTOSKILLIT_FEATURES__FRANCHISE=true/false<br/>AUTOSKILLIT_SESSION_TYPE"]:::phase
        PROJ["● .autoskillit/config.yaml  ⟨priority 3⟩<br/>━━━━━━━━━━<br/>features.franchise: true<br/>(project override)"]:::phase
        DEFAULTS["● defaults.yaml  ⟨priority 1⟩<br/>━━━━━━━━━━<br/>features.franchise: false<br/>(package default)"]:::phase
        ENV -->|overrides| PROJ
        PROJ -->|overrides| DEFAULTS
    end

    %% ── FEATURE REGISTRY ── %%
    subgraph Registry ["FEATURE REGISTRY (L0 state)"]
        direction TB
        FEATREG["● FEATURE_REGISTRY<br/>━━━━━━━━━━<br/>franchise: FeatureDef<br/>default_enabled=False<br/>lifecycle=EXPERIMENTAL"]:::stateNode
        RESOLVE["is_feature_enabled()<br/>━━━━━━━━━━<br/>config → registry fallback<br/>Returns bool"]:::stateNode
    end

    %% ── GATE ENFORCEMENT ── %%
    subgraph Gates ["GATE ENFORCEMENT"]
        direction TB
        CLIGUARD["_require_franchise()<br/>━━━━━━━━━━<br/>CLI hard gate<br/>SystemExit(1) if disabled"]:::detector
        SESSTYPE["_session_type.py<br/>━━━━━━━━━━<br/>Server startup<br/>mcp.disable(tags=franchise)"]:::detector
        REDISABLE["_redisable_subsets()<br/>━━━━━━━━━━<br/>Post-open_kitchen pass 2<br/>Re-suppress franchise tag"]:::detector
    end

    %% ── CLI COMMANDS ── %%
    subgraph CLI ["CLI ENTRY POINTS"]
        direction TB
        FEATLIST["autoskillit features list<br/>━━━━━━━━━━<br/>All features table<br/>DEFAULT · EFFECTIVE · SOURCE"]:::cli
        FEATSTAT["autoskillit features status<br/>━━━━━━━━━━<br/>Single feature detail"]:::cli
        FRCMD["autoskillit franchise *<br/>━━━━━━━━━━<br/>run · list · status<br/>(gated by _require_franchise)"]:::cli
        DOCTOR["autoskillit doctor<br/>━━━━━━━━━━<br/>28 checks total<br/>6 franchise-specific (#22-28)"]:::cli
        CONFIGSHOW["autoskillit config show<br/>━━━━━━━━━━<br/>Resolved config JSON"]:::cli
    end

    %% ── DOCTOR CHECKS ── %%
    subgraph DoctorChecks ["DOCTOR — FEATURE GATE CHECKS"]
        direction TB
        D22["#22 feature_dependencies<br/>━━━━━━━━━━<br/>depends_on satisfied?"]:::handler
        D23["#23 registry_consistency<br/>━━━━━━━━━━<br/>import_package importable?"]:::handler
        D24["#24 sous_chef_bundled<br/>━━━━━━━━━━<br/>skills/sous-chef/ exists?<br/>(franchise-only)"]:::handler
        D25["#25 dispatch_guard_registered<br/>━━━━━━━━━━<br/>Hook in HOOK_REGISTRY?<br/>(franchise-only)"]:::handler
        D26["#26 stale_franchise_state<br/>━━━━━━━━━━<br/>Campaign files > 7d old?<br/>(franchise-only)"]:::handler
    end

    %% ── TASK AUTOMATION ── %%
    subgraph Tasks ["TASK COMMANDS"]
        direction TB
        TESTALL["task test-all<br/>━━━━━━━━━━<br/>lint + pytest -n 4"]:::output
        TESTCHECK["task test-check<br/>━━━━━━━━━━<br/>PASS/FAIL for automation"]:::output
        TESTFILT["task test-filtered<br/>━━━━━━━━━━<br/>Path-filtered conservative"]:::output
    end

    %% ── FLOWS ── %%
    Config -->|"load_config()"| RESOLVE
    FEATREG -->|"default_enabled fallback"| RESOLVE

    RESOLVE -->|"enabled?"| CLIGUARD
    RESOLVE -->|"enabled?"| SESSTYPE
    RESOLVE -->|"enabled?"| REDISABLE

    CLIGUARD -->|"guards"| FRCMD
    SESSTYPE -->|"suppresses MCP tags"| FRCMD
    REDISABLE -->|"post-kitchen gate"| FRCMD

    RESOLVE --> FEATLIST
    RESOLVE --> FEATSTAT
    RESOLVE --> CONFIGSHOW

    RESOLVE -->|"checks #22-28"| DOCTOR
    DOCTOR --> D22
    DOCTOR --> D23
    D22 -.->|"franchise-enabled path"| D24
    D24 --> D25
    D25 --> D26

    TESTALL -.->|"validates"| FEATREG
    TESTCHECK -.->|"validates"| RESOLVE
    TESTFILT -.->|"validates"| Gates

    %% CLASS ASSIGNMENTS %%
    class ENV,PROJ,DEFAULTS phase;
    class FEATREG,RESOLVE stateNode;
    class CLIGUARD,SESSTYPE,REDISABLE detector;
    class FEATLIST,FEATSTAT,FRCMD,DOCTOR,CONFIGSHOW cli;
    class D22,D23,D24,D25,D26 handler;
    class TESTALL,TESTCHECK,TESTFILT output;
```

Closes #1108

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260422-201218-394905/.autoskillit/temp/make-plan/feature_gate_gate_franchise_for_stable_enable_on_integration_plan_2026-04-22_202600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 70 | 18.4k | 700.0k | 58.4k | 1 | 8m 31s |
| verify | 57 | 14.0k | 1.1M | 60.7k | 1 | 8m 42s |
| implement | 80 | 11.4k | 1.5M | 45.9k | 1 | 6m 37s |
| fix | 5.5k | 25.4k | 5.9M | 131.4k | 2 | 24m 46s |
| prepare_pr | 22 | 5.0k | 93.5k | 26.0k | 1 | 1m 48s |
| run_arch_lenses | 3.4k | 12.6k | 772.4k | 104.1k | 2 | 8m 52s |
| compose_pr | 23 | 7.4k | 176.3k | 29.1k | 1 | 2m 29s |
| **Total** | 9.1k | 94.3k | 10.2M | 455.6k | | 1h 1m |