### PR TITLE
Cook session does not bypass feature gate — skills silently suppressed

### DIFF
--- a/src/autoskillit/workspace/session_skills.py
+++ b/src/autoskillit/workspace/session_skills.py
@@ -386,12 +386,14 @@ class DefaultSessionSkillManager:
             effective_custom_tags = dict(config.subsets.custom_tags)
 
         packs_enabled: list[str] = [] if config is None else list(config.packs.enabled)
-        session_features: dict[str, bool] = config.features if config is not None else {}
-
-        from autoskillit.core import FEATURE_REGISTRY, is_feature_enabled  # noqa: PLC0415
+        session_features: dict[str, bool] = (
+            {name: True for name in FEATURE_REGISTRY}
+            if cook_session
+            else (config.features if config is not None else {})
+        )
 
         disabled_feature_tags: frozenset[str] = frozenset()
-        if config is not None:
+        if config is not None and not cook_session:
             for feature_name, feature_def in FEATURE_REGISTRY.items():
                 if not is_feature_enabled(feature_name, config.features):
                     disabled_feature_tags |= feature_def.tool_tags

--- a/tests/workspace/test_session_skills.py
+++ b/tests/workspace/test_session_skills.py
@@ -556,6 +556,53 @@ def test_other_skills_unaffected_by_franchise_feature(tmp_path: Path) -> None:
     )
 
 
+# ── Tests: cook session + feature-gate interaction ─────────────────────────
+
+
+def test_cook_session_bypasses_feature_gate(tmp_path: Path) -> None:
+    """Cook sessions see all skills regardless of feature flags."""
+    from tests._helpers import make_test_config
+
+    config = make_test_config(features={"franchise": False})
+    provider = SkillsDirectoryProvider()
+    mgr = DefaultSessionSkillManager(provider, ephemeral_root=tmp_path)
+    session_path = mgr.init_session("cook-feat-gate", cook_session=True, config=config)
+    skill_names = {p.parent.name for p in session_path.glob(".claude/skills/*/SKILL.md")}
+    assert "make-campaign" in skill_names, (
+        "cook_session=True should bypass feature gates — "
+        "make-campaign must be available even when franchise is disabled"
+    )
+
+
+def test_cook_session_disabled_feature_tags_empty(tmp_path: Path) -> None:
+    """disabled_feature_tags is empty frozenset for cook sessions."""
+    from tests._helpers import make_test_config
+
+    config = make_test_config(features={"franchise": False})
+    provider = SkillsDirectoryProvider()
+    mgr = DefaultSessionSkillManager(provider, ephemeral_root=tmp_path)
+    session_path = mgr.init_session("cook-tags-empty", cook_session=True, config=config)
+    # Verify via the integration effect: franchise-tagged skills are present
+    skill_names = {p.parent.name for p in session_path.glob(".claude/skills/*/SKILL.md")}
+    # If disabled_feature_tags were non-empty, franchise skills would be suppressed
+    # via _resolve_effective_disabled even without the _is_skill_disabled feature loop
+    assert "make-campaign" in skill_names
+
+
+def test_non_cook_session_still_suppresses_feature_gated_skills(tmp_path: Path) -> None:
+    """Non-cook sessions with franchise=False still suppress make-campaign."""
+    from tests._helpers import make_test_config
+
+    config = make_test_config(features={"franchise": False})
+    provider = SkillsDirectoryProvider()
+    mgr = DefaultSessionSkillManager(provider, ephemeral_root=tmp_path)
+    session_path = mgr.init_session("non-cook-feat", cook_session=False, config=config)
+    skill_names = {p.parent.name for p in session_path.glob(".claude/skills/*/SKILL.md")}
+    assert "make-campaign" not in skill_names, (
+        "Non-cook session with franchise=False must suppress make-campaign"
+    )
+
+
 # ── Tests: _parse_activate_deps ─────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

`init_session` in `session_skills.py` correctly bypasses subset restrictions (`explicit_disabled`, `effective_custom_tags`) when `cook_session=True`, but fails to bypass the feature gate. Both `session_features` (line 389) and `disabled_feature_tags` (lines 393-397) are computed from `config.features` unconditionally, creating a dual suppression path that silently removes feature-gated skills (e.g., `make-campaign` when `franchise=False`) from cook sessions despite cook's documented intent: "Kitchen open. All tools active."

The fix guards both variables with the `cook_session` flag, consistent with the existing pattern for `explicit_disabled` and `effective_custom_tags`.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START])
    COMPLETE([COMPLETE])
    ERROR([ERROR])

    subgraph EntryPoints ["Entry Points"]
        direction TB
        COOK["cook CLI command<br/>━━━━━━━━━━<br/>cli/_cook.py:156<br/>cook_session=True"]
        HEADLESS["run_skill MCP tool<br/>━━━━━━━━━━<br/>tools_execution.py:303<br/>cook_session=False"]
    end

    subgraph ConfigResolution ["● Config Resolution (session_skills.py)"]
        direction TB
        COOK_BRANCH{"cook_session?<br/>━━━━━━━━━━<br/>Lines 378-399"}
        COOK_PATH["Cook Path<br/>━━━━━━━━━━<br/>explicit_disabled = []<br/>custom_tags = {}<br/>session_features = ALL TRUE<br/>disabled_feature_tags = empty"]
        HEADLESS_PATH["Headless Path<br/>━━━━━━━━━━<br/>Read config.subsets.disabled<br/>Read config.subsets.custom_tags<br/>Read config.features"]
        FEAT_GATE["● Feature Gate Loop<br/>━━━━━━━━━━<br/>Lines 396-399<br/>For each FEATURE_REGISTRY entry:<br/>if not is_feature_enabled() →<br/>collect feat_def.tool_tags<br/>into disabled_feature_tags"]
    end

    subgraph EffectiveDisabled ["● Effective Disabled Merge"]
        direction TB
        MERGE["● _resolve_effective_disabled<br/>━━━━━━━━━━<br/>Lines 181-207<br/>effective = explicit ∪<br/>default_disabled_packs ∪<br/>disabled_feature_tags<br/>− packs_enabled<br/>− recipe_packs"]
        OVERRIDES["detect_project_local_overrides<br/>━━━━━━━━━━<br/>Channel dedup prep<br/>Lines 409-412"]
    end

    subgraph SkillLoop ["● Per-Skill Injection Loop (Lines 418-441)"]
        direction TB
        NEXT_SKILL["Next Skill<br/>━━━━━━━━━━<br/>Iterate provider.list_skills()"]
        ALLOW_CHECK{"allow_only<br/>filter?<br/>━━━━━━━━━━<br/>Line 419"}
        INJECT_CHECK{"● _should_inject_skill<br/>━━━━━━━━━━<br/>Lines 210-233"}
        CHANNEL_DEDUP{"Channel Dedup<br/>━━━━━━━━━━<br/>BUNDLED source? skip<br/>In overrides? skip"}
        DISABLED_CHECK{"● _is_skill_disabled<br/>━━━━━━━━━━<br/>Lines 150-178<br/>1. Check disabled tags<br/>2. Check FEATURE_REGISTRY:<br/>disabled feat ∩ skill cats"}
        WRITE_SKILL["Write SKILL.md<br/>━━━━━━━━━━<br/>atomic_write to<br/>ephemeral dir<br/>gated = tier2 & !cook"]
    end

    subgraph PostInit ["Post-Init Activation (headless only)"]
        direction TB
        ACTIVATE_CHECK{"target_name<br/>resolved?<br/>━━━━━━━━━━<br/>tools_execution.py:315"}
        ACTIVATE["activate_skill_deps<br/>━━━━━━━━━━<br/>Remove disable-model-invocation<br/>Parse activate_deps<br/>BFS transitive resolution"]
        CLEANUP["cleanup_session<br/>━━━━━━━━━━<br/>shutil.rmtree after<br/>session completes"]
    end

    %% FLOW %%
    START --> COOK
    START --> HEADLESS
    COOK --> COOK_BRANCH
    HEADLESS --> COOK_BRANCH
    COOK_BRANCH -->|"True (cook)"| COOK_PATH
    COOK_BRANCH -->|"False (headless)"| HEADLESS_PATH
    HEADLESS_PATH --> FEAT_GATE
    COOK_PATH --> MERGE
    FEAT_GATE --> MERGE
    MERGE --> OVERRIDES
    OVERRIDES --> NEXT_SKILL
    NEXT_SKILL --> ALLOW_CHECK
    ALLOW_CHECK -->|"not in allow_only"| NEXT_SKILL
    ALLOW_CHECK -->|"pass"| INJECT_CHECK
    INJECT_CHECK --> CHANNEL_DEDUP
    CHANNEL_DEDUP -->|"deduplicated"| NEXT_SKILL
    CHANNEL_DEDUP -->|"pass"| DISABLED_CHECK
    DISABLED_CHECK -->|"disabled"| NEXT_SKILL
    DISABLED_CHECK -->|"enabled"| WRITE_SKILL
    WRITE_SKILL --> NEXT_SKILL
    NEXT_SKILL -->|"all skills processed"| ACTIVATE_CHECK
    ACTIVATE_CHECK -->|"no target / cook session"| COMPLETE
    ACTIVATE_CHECK -->|"target resolved"| ACTIVATE
    ACTIVATE --> CLEANUP
    CLEANUP --> COMPLETE

    COOK_BRANCH -->|"invalid session_id"| ERROR

    %% CLASS ASSIGNMENTS %%
    class START,COMPLETE,ERROR terminal;
    class COOK,HEADLESS cli;
    class COOK_BRANCH,ALLOW_CHECK,ACTIVATE_CHECK stateNode;
    class INJECT_CHECK,CHANNEL_DEDUP,DISABLED_CHECK detector;
    class COOK_PATH,HEADLESS_PATH,FEAT_GATE phase;
    class MERGE,OVERRIDES phase;
    class NEXT_SKILL,WRITE_SKILL handler;
    class ACTIVATE,CLEANUP handler;
```

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START([init_session called])

    subgraph InitOnly ["INIT_ONLY — Constructor Fields"]
        direction LR
        PROVIDER["_provider<br/>━━━━━━━━━━<br/>SkillsDirectoryProvider<br/>Set once, never modified"]
        ROOT["_root<br/>━━━━━━━━━━<br/>Path — ephemeral root<br/>Set once, never modified"]
    end

    subgraph Gate1 ["GATE 1 — Input Validation"]
        direction TB
        SESSID_CHECK["● session_id format<br/>━━━━━━━━━━<br/>Rejects empty, null, /, \\, ..<br/>FAIL-FAST: ValueError"]
    end

    subgraph Gate2 ["GATE 2 — Config Validation"]
        direction TB
        TIER_CHECK["Config tier check<br/>━━━━━━━━━━<br/>Unknown skills → warning<br/>Non-blocking"]
    end

    subgraph CookFork ["GATE 3 — ● cook_session Branch Fork"]
        direction TB
        COOK_DECISION{"cook_session?"}
        COOK_TRUE["● COOK = True<br/>━━━━━━━━━━<br/>explicit_disabled = ∅<br/>custom_tags = ∅<br/>session_features = ALL TRUE<br/>disabled_feature_tags = ∅"]
        COOK_FALSE["● NON-COOK<br/>━━━━━━━━━━<br/>explicit_disabled = config<br/>custom_tags = config<br/>session_features = config.features<br/>disabled_feature_tags = accumulated"]
    end

    subgraph FeatureGate ["GATE 4 — ● Feature-Gate Accumulation"]
        direction TB
        FEAT_LOOP["● disabled_feature_tags<br/>━━━━━━━━━━<br/>For each FEATURE_REGISTRY entry:<br/>if not is_feature_enabled →<br/>collect feature.tool_tags<br/>SKIPPED for cook sessions"]
    end

    subgraph EffectiveDisabled ["GATE 5 — ● Effective Disabled Set"]
        direction TB
        RESOLVE["● _resolve_effective_disabled<br/>━━━━━━━━━━<br/>explicit ∪ default_disabled ∪ feat_tags<br/>minus packs_enabled ∪ recipe_packs<br/>feat_tags are STICKY — never subtracted"]
    end

    subgraph PerSkillGates ["GATE 6 — Per-Skill Injection Decision"]
        direction TB
        ALLOW_ONLY["allow_only filter<br/>━━━━━━━━━━<br/>Allowlist pre-filter<br/>Skips before gate eval"]
        SHOULD_INJECT["● _should_inject_skill<br/>━━━━━━━━━━<br/>1. Channel dedup: BUNDLED → skip<br/>2. Override dedup: project-local → skip<br/>3. _is_skill_disabled gate"]
        IS_DISABLED["● _is_skill_disabled<br/>━━━━━━━━━━<br/>1. Tag/custom_tag check<br/>2. ● Feature-gate loop:<br/>   categories ∩ feat.skill_categories<br/>   Uses session_features dict"]
    end

    subgraph Mutation ["STATE MUTATION — Disk Write"]
        direction TB
        GATED_CALC["gated = !cook ∧ tier2<br/>━━━━━━━━━━<br/>Controls frontmatter injection"]
        CONTENT["get_skill_content<br/>━━━━━━━━━━<br/>Injects/omits<br/>disable-model-invocation"]
        WRITE["atomic_write SKILL.md<br/>━━━━━━━━━━<br/>Append-only: creates,<br/>never partial-deletes"]
    end

    RESULT([ValidatedAddDir — frozen])

    %% FLOW %%
    START --> Gate1
    InitOnly -.->|read-only ref| Gate2
    Gate1 --> Gate2
    Gate2 --> CookFork
    COOK_DECISION -->|true| COOK_TRUE
    COOK_DECISION -->|false| COOK_FALSE
    COOK_TRUE --> EffectiveDisabled
    COOK_FALSE --> FeatureGate
    FEAT_LOOP --> EffectiveDisabled
    EffectiveDisabled --> PerSkillGates
    ALLOW_ONLY --> SHOULD_INJECT
    SHOULD_INJECT --> IS_DISABLED
    IS_DISABLED -->|not disabled| Mutation
    GATED_CALC --> CONTENT
    CONTENT --> WRITE
    WRITE --> RESULT

    %% CLASS ASSIGNMENTS %%
    class PROVIDER,ROOT stateNode;
    class SESSID_CHECK detector;
    class TIER_CHECK handler;
    class COOK_DECISION phase;
    class COOK_TRUE,COOK_FALSE phase;
    class FEAT_LOOP detector;
    class RESOLVE detector;
    class ALLOW_ONLY handler;
    class SHOULD_INJECT,IS_DISABLED detector;
    class GATED_CALC phase;
    class CONTENT handler;
    class WRITE output;
    class START,RESULT terminal;
```

Closes #1148

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260423-071014-488603/.autoskillit/temp/make-plan/cook_session_feature_gate_bypass_plan_2026-04-23_071600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 147 | 18.7k | 1.6M | 119.8k | 2 | 9m 59s |
| verify | 2.3k | 16.0k | 1.6M | 83.0k | 2 | 9m 38s |
| implement | 800 | 18.7k | 2.0M | 119.9k | 2 | 8m 55s |
| prepare_pr | 47 | 5.7k | 280.5k | 44.4k | 2 | 2m 48s |
| run_arch_lenses | 104 | 17.0k | 1.0M | 144.6k | 3 | 12m 30s |
| compose_pr | 23 | 5.9k | 164.9k | 26.2k | 1 | 1m 41s |
| **Total** | 3.4k | 82.0k | 6.7M | 537.9k | | 45m 35s |