### PR TITLE
FeatureDef Key/Name Consistency & L0 Dynamic Import Prevention

### DIFF
--- a/src/autoskillit/core/_type_constants.py
+++ b/src/autoskillit/core/_type_constants.py
@@ -392,8 +392,8 @@ if not all(
     )
 
 # Guard: FEATURE_REGISTRY key must equal FeatureDef.name — checked at import time.
-if any(key != defn.name for key, defn in FEATURE_REGISTRY.items()):
-    _mismatches = {k: defn.name for k, defn in FEATURE_REGISTRY.items() if k != defn.name}
+_mismatches = {k: defn.name for k, defn in FEATURE_REGISTRY.items() if k != defn.name}
+if _mismatches:
     raise AssertionError(f"FEATURE_REGISTRY key/name mismatch: {_mismatches}")
 
 

--- a/src/autoskillit/core/_type_constants.py
+++ b/src/autoskillit/core/_type_constants.py
@@ -391,6 +391,11 @@ if not all(
         "Add the tag to the appropriate tool entry in TOOL_SUBSET_TAGS first."
     )
 
+# Guard: FEATURE_REGISTRY key must equal FeatureDef.name — checked at import time.
+if any(key != defn.name for key, defn in FEATURE_REGISTRY.items()):
+    _mismatches = {k: defn.name for k, defn in FEATURE_REGISTRY.items() if k != defn.name}
+    raise AssertionError(f"FEATURE_REGISTRY key/name mismatch: {_mismatches}")
+
 
 # Canonical prefix required for all skill_command values passed to run_skill.
 # Enforced at the Claude Code hook boundary by skill_command_guard.py.

--- a/tests/arch/test_feature_registry.py
+++ b/tests/arch/test_feature_registry.py
@@ -29,6 +29,14 @@ def test_feature_registry_keys_are_sorted():
     assert keys == sorted(keys), f"FEATURE_REGISTRY keys not sorted: {keys}"
 
 
+def test_feature_registry_key_name_consistency() -> None:
+    """FEATURE_REGISTRY key must equal FeatureDef.name for every entry."""
+    from autoskillit.core._type_constants import FEATURE_REGISTRY
+
+    mismatches = {k: defn.name for k, defn in FEATURE_REGISTRY.items() if k != defn.name}
+    assert not mismatches, f"FEATURE_REGISTRY key/name mismatch: {mismatches}"
+
+
 def test_feature_tool_tags_exist_in_subset_tags():
     """Every FeatureDef.tool_tags entry exists in TOOL_SUBSET_TAGS tag values."""
     from autoskillit.core._type_constants import FEATURE_REGISTRY, TOOL_SUBSET_TAGS

--- a/tests/arch/test_layer_enforcement.py
+++ b/tests/arch/test_layer_enforcement.py
@@ -444,7 +444,7 @@ def test_l0_no_dynamic_internal_imports() -> None:
     """L0 code must not dynamically import autoskillit subpackages."""
     violations = []
     for src_file in sorted(_CORE_SRC.glob("*.py")):
-        tree = ast.parse(src_file.read_text())
+        tree = ast.parse(src_file.read_text(), filename=str(src_file))
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call):
                 continue

--- a/tests/arch/test_layer_enforcement.py
+++ b/tests/arch/test_layer_enforcement.py
@@ -49,6 +49,8 @@ _LAYER_EXEMPT_STEMS: frozenset[str] = frozenset(
     {"version", "smoke_utils", "_llm_triage", "__init__", "__main__"}
 )
 
+_CORE_SRC = SRC_ROOT / "core"
+
 # ── REQ-ARCH layer enforcement rule descriptors ───────────────────────────────────
 LAYER_RULES: dict[str, RuleDescriptor] = {
     "REQ-ARCH-001": RuleDescriptor(
@@ -436,6 +438,31 @@ def test_layer_enforcement_detects_upward_import(tmp_path: Path) -> None:
                 if SUBPACKAGE_LAYERS.get(imported, 0) > 1:
                     violations.append(imported)
     assert violations  # must detect the upward import
+
+
+def test_l0_no_dynamic_internal_imports() -> None:
+    """L0 code must not dynamically import autoskillit subpackages."""
+    violations = []
+    for src_file in sorted(_CORE_SRC.glob("*.py")):
+        tree = ast.parse(src_file.read_text())
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            is_import_module = (
+                isinstance(func, ast.Attribute) and func.attr == "import_module"
+            ) or (isinstance(func, ast.Name) and func.id == "import_module")
+            if not is_import_module or not node.args:
+                continue
+            arg = node.args[0]
+            if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                if arg.value.startswith("autoskillit."):
+                    violations.append(
+                        f"{src_file.name}:{node.lineno}: importlib.import_module({arg.value!r})"
+                    )
+    assert not violations, (
+        "L0 (core/) must not dynamically import autoskillit subpackages:\n" + "\n".join(violations)
+    )
 
 
 # ── L1 Package Runtime Isolation Tests ────────────────────────────────────────


### PR DESCRIPTION
## Summary

Add two structural guards to prevent silent regressions in the feature registry:

1. **Import-time assertion** in `_type_constants.py` that validates every `FEATURE_REGISTRY` key matches its `FeatureDef.name` field — catches typos at module load.
2. **AST-based arch test** in `test_layer_enforcement.py` that scans `core/*.py` for `importlib.import_module(...)` calls with `autoskillit.*` string literal arguments — prevents future L0-to-L2 layer violations via dynamic imports.

No production behavior change. No API surface change.

## Architecture Impact

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;

    subgraph L0 ["LAYER 0 — CORE FOUNDATION"]
        direction LR
        ENUMS["_type_enums.py<br/>━━━━━━━━━━<br/>FeatureLifecycle<br/>FranchiseErrorCode"]
        CONST["● _type_constants.py<br/>━━━━━━━━━━<br/>FEATURE_REGISTRY<br/>FeatureDef, GATED_TOOLS<br/>TOOL_SUBSET_TAGS<br/>import-time assertions"]
        FF["feature_flags.py<br/>━━━━━━━━━━<br/>is_feature_enabled()"]
        TYPES["types.py<br/>━━━━━━━━━━<br/>Star re-export hub"]
        INIT_CORE["core/__init__.py<br/>━━━━━━━━━━<br/>Public surface<br/>named re-exports"]
    end

    subgraph L1 ["LAYER 1 — DOMAIN PRIMITIVES"]
        direction LR
        CONFIG["config/settings.py<br/>━━━━━━━━━━<br/>_build_features_dict<br/>schema validation"]
        GATE["pipeline/gate.py<br/>━━━━━━━━━━<br/>GATED_TOOLS re-export<br/>UNGATED_TOOLS re-export"]
        WS["workspace/session_skills.py<br/>━━━━━━━━━━<br/>FEATURE_REGISTRY<br/>PACK_REGISTRY"]
    end

    subgraph L2 ["LAYER 2 — DOMAIN SERVICES"]
        direction LR
        RF["recipe/rules_features.py<br/>━━━━━━━━━━<br/>FEATURE_REGISTRY<br/>TOOL_SUBSET_TAGS"]
        RT["recipe/rules_tools.py<br/>━━━━━━━━━━<br/>GATED_TOOLS<br/>TOOL_SUBSET_TAGS"]
    end

    subgraph L3 ["LAYER 3 — APPLICATION"]
        direction LR
        SRVK["server/tools_kitchen.py<br/>━━━━━━━━━━<br/>FEATURE_REGISTRY<br/>FEATURE_REVEAL_TAGS"]
        SRVI["server/__init__.py<br/>━━━━━━━━━━<br/>Imports from pipeline"]
        SRVS["server/_session_type.py<br/>━━━━━━━━━━<br/>FEATURE_REGISTRY<br/>CATEGORY_TAGS"]
        CLIF["cli/_features.py<br/>━━━━━━━━━━<br/>FEATURE_REGISTRY"]
    end

    subgraph TESTS ["ARCH GUARD TESTS"]
        direction LR
        TFR["● test_feature_registry.py<br/>━━━━━━━━━━<br/>key/name consistency<br/>tool_tags validation<br/>lifecycle invariants"]
        TLE["● test_layer_enforcement.py<br/>━━━━━━━━━━<br/>AST layer contracts<br/>L0 dynamic import guard<br/>cross-package rules"]
    end

    %% L0 INTERNAL IMPORTS %%
    ENUMS -->|"FeatureLifecycle"| CONST
    CONST -->|"FEATURE_REGISTRY"| FF
    CONST -->|"star re-export"| TYPES
    ENUMS -->|"star re-export"| TYPES
    TYPES -->|"named re-export"| INIT_CORE

    %% L1 IMPORTS FROM L0 %%
    INIT_CORE -->|"FEATURE_REGISTRY"| CONFIG
    INIT_CORE -->|"GATED_TOOLS, UNGATED_TOOLS"| GATE
    INIT_CORE -->|"FEATURE_REGISTRY, PACK_REGISTRY"| WS

    %% L2 IMPORTS FROM L0 %%
    INIT_CORE -->|"FEATURE_REGISTRY, TOOL_SUBSET_TAGS"| RF
    INIT_CORE -->|"GATED_TOOLS, TOOL_SUBSET_TAGS"| RT

    %% L3 IMPORTS FROM L0+L1 %%
    INIT_CORE -->|"FEATURE_REGISTRY, FEATURE_REVEAL_TAGS"| SRVK
    GATE -->|"GATED_TOOLS, UNGATED_TOOLS"| SRVI
    INIT_CORE -->|"FEATURE_REGISTRY, CATEGORY_TAGS"| SRVS
    INIT_CORE -->|"FEATURE_REGISTRY"| CLIF

    %% TEST IMPORTS — cross-cutting %%
    CONST -.->|"direct import"| TFR
    FF -.->|"is_feature_enabled"| TFR
    CONFIG -.->|"ConfigSchemaError"| TFR
    TLE -.->|"AST scans all layers"| L0
    TLE -.->|"AST scans all layers"| L1
    TLE -.->|"AST scans all layers"| L2
    TLE -.->|"AST scans all layers"| L3

    %% CLASS ASSIGNMENTS %%
    class ENUMS,FF,TYPES,INIT_CORE stateNode;
    class CONST handler;
    class CONFIG,GATE,WS phase;
    class RF,RT output;
    class SRVK,SRVI,SRVS,CLIF cli;
    class TFR,TLE detector;
```

Closes #1149

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260423-081631-215467/.autoskillit/temp/make-plan/featuredef_structural_guards_plan_2026-04-23_081900.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 291 | 34.3k | 3.0M | 201.9k | 4 | 18m 27s |
| verify | 3.3k | 29.1k | 2.8M | 162.9k | 4 | 22m 48s |
| implement | 1.6k | 34.3k | 3.7M | 188.2k | 4 | 15m 10s |
| prepare_pr | 94 | 11.8k | 555.9k | 86.8k | 4 | 6m 48s |
| run_arch_lenses | 171 | 27.3k | 1.6M | 235.2k | 5 | 19m 49s |
| compose_pr | 68 | 15.5k | 451.5k | 71.6k | 3 | 5m 12s |
| review_pr | 63 | 26.9k | 603.9k | 73.3k | 2 | 7m 15s |
| resolve_review | 34 | 8.7k | 688.9k | 98.0k | 1 | 7m 52s |
| diagnose_ci | 108 | 6.0k | 672.3k | 49.5k | 3 | 3m 11s |
| resolve_ci | 126 | 10.5k | 1.1M | 81.9k | 3 | 7m 28s |
| fix | 44 | 3.4k | 613.4k | 37.8k | 1 | 5m 25s |
| **Total** | 5.9k | 207.9k | 15.9M | 1.3M | | 1h 59m |