### PR TITLE
Fix finalize_bundle / re_push_research Step Ordering

### DIFF
--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -689,18 +689,18 @@ steps:
         route: re_run_experiment
       - when: "${{ context.claims_needs_rerun }} == true"
         route: re_run_experiment
-      - route: re_push_research
+      - route: finalize_bundle
     note: >
       Merged escalation consumer replacing check_escalations. Triggers a single
       re_run_experiment if either review resolution or claims resolution flagged
       a rerun. When only design_flaw escalations exist (or none), routes directly
-      to push — design_flaw escalations are already posted as inline PR comments
+      to finalize_bundle — design_flaw escalations are already posted as inline PR comments
       by the resolve skills. Both context.review_needs_rerun and
       context.claims_needs_rerun may be absent if their respective resolution
       steps were never reached (e.g., no changes_requested verdict on that gate);
       the recipe engine evaluates absent context variables as empty string, so
       absent == true is always false and routes safely fall through to
-      re_push_research.
+      finalize_bundle.
 
   re_run_experiment:
     tool: run_skill
@@ -784,7 +784,7 @@ steps:
       cmd: "cd '${{ context.worktree_path }}' && git push"
       cwd: "${{ context.worktree_path }}"
       step_name: re_push_research
-    on_success: finalize_bundle
+    on_success: finalize_bundle_render
     on_failure: begin_archival
 
   # --- ARCHIVAL PHASE ---
@@ -840,7 +840,7 @@ steps:
       step_name: finalize_bundle
     capture:
       report_path_after_finalize: "${{ result.report_path_after_finalize }}"
-    on_success: finalize_bundle_render
+    on_success: re_push_research
     on_failure: begin_archival
     note: >
       Single compression point. Runs exactly once per recipe run. In pr mode: renames

--- a/tests/recipe/test_bundled_recipes.py
+++ b/tests/recipe/test_bundled_recipes.py
@@ -1897,7 +1897,7 @@ class TestResearchRecipeStructure:
         for step_name in ("re_run_experiment", "re_generate_report", "re_test"):
             step = recipe.steps[step_name]
             assert step.on_failure in ("begin_archival", "re_push_research")
-        assert recipe.steps["re_push_research"].on_success == "finalize_bundle"
+        assert recipe.steps["re_push_research"].on_success == "finalize_bundle_render"
 
     def test_audit_claims_ingredient_default_false(self, recipe) -> None:
         assert "audit_claims" in recipe.ingredients
@@ -1955,7 +1955,7 @@ class TestResearchRecipeStructure:
         conditions = step.on_result.conditions
         # review_needs_rerun == true → re_run_experiment
         # claims_needs_rerun == true → re_run_experiment
-        # else → re_push_research
+        # else → finalize_bundle
         guarded = [c for c in conditions if c.when is not None]
         default = [c for c in conditions if c.when is None]
         assert len(guarded) == 2
@@ -1964,7 +1964,7 @@ class TestResearchRecipeStructure:
         assert any("review_needs_rerun" in c.when for c in guarded)
         assert any("claims_needs_rerun" in c.when for c in guarded)
         assert len(default) == 1
-        assert default[0].route == "re_push_research"
+        assert default[0].route == "finalize_bundle"
 
     def test_resolve_claims_review_step_exists(self, recipe) -> None:
         step = recipe.steps["resolve_claims_review"]
@@ -2085,16 +2085,16 @@ class TestResearchRecipeStructure:
                 f"{name}.on_failure must be research_complete for graceful degradation"
             )
 
-    def test_re_push_research_routes_to_finalize_bundle(self, recipe) -> None:
-        """re_push_research routes to finalize_bundle on success, begin_archival on failure."""
+    def test_re_push_research_routes_to_finalize_bundle_render(self, recipe) -> None:
+        """re_push_research routes to finalize_bundle_render on success."""
         step = recipe.steps["re_push_research"]
-        assert step.on_success == "finalize_bundle"
+        assert step.on_success == "finalize_bundle_render"
         assert step.on_failure == "begin_archival"
 
-    def test_finalize_bundle_routes_to_finalize_bundle_render(self, recipe) -> None:
-        """finalize_bundle on_success routes to finalize_bundle_render (not begin_archival)."""
+    def test_finalize_bundle_routes_to_re_push_research(self, recipe) -> None:
+        """finalize_bundle on_success routes to re_push_research (push includes the commit)."""
         step = recipe.steps["finalize_bundle"]
-        assert step.on_success == "finalize_bundle_render"
+        assert step.on_success == "re_push_research"
         assert step.on_failure == "begin_archival"
 
     def test_finalize_bundle_render_step_exists_and_routes(self, recipe) -> None:

--- a/tests/recipe/test_research_bundle_lifecycle.py
+++ b/tests/recipe/test_research_bundle_lifecycle.py
@@ -70,11 +70,12 @@ def test_finalize_bundle_pr_mode(recipe):
 
 
 def test_finalize_bundle_runs_exactly_once_after_rerun(recipe):
-    """finalize_bundle is only reachable via re_push_research.on_success."""
-    # only entry point is re_push_research.on_success
-    re_push = recipe.steps["re_push_research"]
-    assert re_push.on_success == "finalize_bundle", (
-        "re_push_research.on_success must be finalize_bundle"
+    """finalize_bundle entry point is merge_escalations (not re_push_research)."""
+    # merge_escalations is the step that routes to finalize_bundle
+    merge = recipe.steps["merge_escalations"]
+    fallthrough_routes = [cond.route for cond in merge.on_result.conditions if cond.when is None]
+    assert "finalize_bundle" in fallthrough_routes, (
+        "merge_escalations fallthrough must reach finalize_bundle exactly once"
     )
     # test and retest do NOT route to finalize_bundle (they route to push_branch)
     assert recipe.steps["test"].on_success != "finalize_bundle"
@@ -83,4 +84,33 @@ def test_finalize_bundle_runs_exactly_once_after_rerun(recipe):
     stage_cmd = recipe.steps["stage_bundle"].with_args.get("cmd", "")
     assert "tar czf" not in stage_cmd and "tar -czf" not in stage_cmd, (
         "stage_bundle must not compress — only finalize_bundle may produce artifacts.tar.gz"
+    )
+
+
+def test_compression_commit_precedes_push(recipe):
+    """merge_escalations must route to finalize_bundle, not re_push_research."""
+    merge = recipe.steps["merge_escalations"]
+    # The fallthrough route (last on_result entry without a when-condition) must
+    # be finalize_bundle, not re_push_research.
+    fallthrough_routes = [cond.route for cond in merge.on_result.conditions if cond.when is None]
+    assert fallthrough_routes == ["finalize_bundle"], (
+        "merge_escalations fallthrough must route to finalize_bundle "
+        "so the compression commit is created before the push"
+    )
+
+
+def test_finalize_bundle_on_success_routes_to_re_push_research(recipe):
+    """finalize_bundle must push after committing — on_success must be re_push_research."""
+    step = recipe.steps["finalize_bundle"]
+    assert step.on_success == "re_push_research", (
+        "finalize_bundle.on_success must be re_push_research so the compression "
+        "commit is included in the push"
+    )
+
+
+def test_re_push_research_on_success_routes_to_finalize_bundle_render(recipe):
+    """re_push_research must advance to HTML rendering, not loop back to finalize_bundle."""
+    step = recipe.steps["re_push_research"]
+    assert step.on_success == "finalize_bundle_render", (
+        "re_push_research.on_success must be finalize_bundle_render"
     )

--- a/tests/recipe/test_research_output_mode.py
+++ b/tests/recipe/test_research_output_mode.py
@@ -173,10 +173,14 @@ def test_finalize_bundle_preserves_html_in_local_mode(recipe):
 
 
 def test_finalize_bundle_render_always_runs(recipe):
-    """finalize_bundle.on_success must always be finalize_bundle_render (no skip)."""
+    """finalize_bundle_render is always reached via re_push_research."""
     fb = recipe.steps["finalize_bundle"]
-    assert fb.on_success == "finalize_bundle_render", (
-        "finalize_bundle.on_success must be finalize_bundle_render (always runs)"
+    assert fb.on_success == "re_push_research", (
+        "finalize_bundle.on_success must be re_push_research (push includes the commit)"
+    )
+    rpr = recipe.steps["re_push_research"]
+    assert rpr.on_success == "finalize_bundle_render", (
+        "re_push_research.on_success must be finalize_bundle_render (always runs)"
     )
     fbr = recipe.steps["finalize_bundle_render"]
     assert not getattr(fbr, "skip_when_false", None), (


### PR DESCRIPTION
## Summary

In `src/autoskillit/recipes/research.yaml`, the `re_push_research` step runs before `finalize_bundle`.
Because `finalize_bundle` creates the compression commit (`Add compressed research artifacts`) in
PR mode, the compression commit is never included in the push to origin. The fix is a three-field
change to swap the steps: route `merge_escalations` → `finalize_bundle` → `re_push_research` →
`finalize_bundle_render`. One existing test encodes the bug (asserts the wrong ordering) and must
be corrected; three new tests capture the correct invariant.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 42, 'rankSpacing': 52, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START])
    COMPLETE([research_complete])
    ERROR([escalate_stop])
    REJECTED([design_rejected])

    %% ─────────────────────────────────────────────────────── %%
    subgraph Design ["DESIGN PHASE"]
        direction TB
        scope["scope<br/>━━━━━━━━━━<br/>Scopes research question<br/>→ scope_report"]
        plan_experiment["plan_experiment<br/>━━━━━━━━━━<br/>Creates experiment plan<br/>→ experiment_plan"]
        review_design{"review_design<br/>━━━━━━━━━━<br/>verdict?<br/>skip_when_false: review_design<br/>retries: 2"}
        plan_visualization["plan_visualization<br/>━━━━━━━━━━<br/>Selects vis-lens skills<br/>→ visualization_plan_path"]
        resolve_design_review["resolve_design_review<br/>━━━━━━━━━━<br/>Triages STOP findings<br/>ADDRESSABLE→revise STRUCTURAL→halt"]
    end

    %% ─────────────────────────────────────────────────────── %%
    subgraph Execution ["EXECUTION PHASE"]
        direction TB
        create_worktree["create_worktree<br/>━━━━━━━━━━<br/>git worktree add + commits plan<br/>→ worktree_path, research_dir"]
        stage_data["stage_data<br/>━━━━━━━━━━<br/>Pre-flight resource gate<br/>verdict: PASS/WARN/FAIL"]
        decompose_phases["decompose_phases<br/>━━━━━━━━━━<br/>make-groups splits plan<br/>→ group_files list"]
        plan_phase["plan_phase<br/>━━━━━━━━━━<br/>Plans current phase file<br/>→ phase_plan_path"]
        implement_phase["implement_phase<br/>━━━━━━━━━━<br/>implement-experiment in worktree<br/>context_limit = normal exit"]
        next_phase_or_exp{"next_phase_or_experiment<br/>━━━━━━━━━━<br/>More phases?"}
    end

    %% ─────────────────────────────────────────────────────── %%
    subgraph ExperimentReport ["EXPERIMENT + REPORT PHASE"]
        direction TB
        run_experiment["run_experiment<br/>━━━━━━━━━━<br/>run-experiment skill<br/>retries: 2"]
        adjust_experiment["adjust_experiment<br/>━━━━━━━━━━<br/>run-experiment --adjust"]
        ensure_results["ensure_results<br/>━━━━━━━━━━<br/>Creates placeholder results<br/>when retries exhausted"]
        gen_report["generate_report<br/>━━━━━━━━━━<br/>Writes conclusive report<br/>→ report_path"]
        gen_report_inc["generate_report_inconclusive<br/>━━━━━━━━━━<br/>Writes inconclusive report<br/>→ report_path"]
        test{"test<br/>━━━━━━━━━━<br/>test_check<br/>PASS/FAIL?"}
        fix_tests["fix_tests<br/>━━━━━━━━━━<br/>resolve-failures<br/>→ verdict"]
        retest{"retest<br/>━━━━━━━━━━<br/>test_check<br/>PASS/FAIL?"}
    end

    %% ─────────────────────────────────────────────────────── %%
    subgraph PRReview ["PR + REVIEW PHASE"]
        direction TB
        push_branch["push_branch<br/>━━━━━━━━━━<br/>git push -u origin HEAD"]
        prepare_research_pr["prepare_research_pr<br/>━━━━━━━━━━<br/>Prepares PR metadata<br/>→ prep_path, selected_lenses"]
        run_lenses["run_experiment_lenses<br/>━━━━━━━━━━<br/>exp-lens-{slug} in parallel<br/>→ all_diagram_paths"]
        stage_bundle["stage_bundle<br/>━━━━━━━━━━<br/>cp artifacts to research/<br/>Idempotent — no compress, no commit"]
        route_pr_or_local{"route_pr_or_local<br/>━━━━━━━━━━<br/>output_mode?"}
        compose_pr["compose_research_pr<br/>━━━━━━━━━━<br/>Opens research PR<br/>→ pr_url"]
        guard_pr_url{"guard_pr_url<br/>━━━━━━━━━━<br/>pr_url present?"}
        review_research_pr["review_research_pr<br/>━━━━━━━━━━<br/>Optional review gate<br/>skip_when_false: review_pr"]
        audit_claims["audit_claims<br/>━━━━━━━━━━<br/>Optional citation audit<br/>skip_when_false: audit_claims"]
        route_review_resolve{"route_review_resolve<br/>━━━━━━━━━━<br/>review changes_requested?"}
        resolve_research_review["resolve_research_review<br/>━━━━━━━━━━<br/>Resolves review comments<br/>retries: 2 → needs_rerun"]
        route_claims_resolve{"route_claims_resolve<br/>━━━━━━━━━━<br/>audit changes_requested?"}
        resolve_claims_review["resolve_claims_review<br/>━━━━━━━━━━<br/>Resolves claims findings<br/>retries: 2 → needs_rerun"]
        merge_escalations{"● merge_escalations<br/>━━━━━━━━━━<br/>review_needs_rerun OR<br/>claims_needs_rerun == true?"}
        re_run_exp["re_run_experiment<br/>━━━━━━━━━━<br/>run-experiment --adjust<br/>Re-runs affected benchmarks"]
        re_gen_report["re_generate_report<br/>━━━━━━━━━━<br/>Regenerates report<br/>with updated results"]
        re_stage_bundle["re_stage_bundle<br/>━━━━━━━━━━<br/>Re-stages artifacts<br/>(same as stage_bundle)"]
        re_test["re_test<br/>━━━━━━━━━━<br/>Post-revalidation test<br/>PASS+FAIL both → push"]
    end

    %% ─────────────────────────────────────────────────────── %%
    subgraph Finalization ["● FINALIZATION PHASE — Step Ordering Fixed"]
        direction TB
        finalize_bundle["● finalize_bundle<br/>━━━━━━━━━━<br/>pr mode: rename report.md→README.md<br/>tar czf artifacts.tar.gz (dynamic TAR_ITEMS)<br/>Append Archive Manifest → README.md<br/>git commit 'Add compressed research artifacts'<br/>local mode: skip rename + commit; keep HTML"]
        re_push_research["● re_push_research<br/>━━━━━━━━━━<br/>git push<br/>Push includes compression commit"]
        finalize_bundle_render["● finalize_bundle_render<br/>━━━━━━━━━━<br/>bundle-local-report skill<br/>Renders HTML → html_path"]
        route_archive_or_export{"route_archive_or_export<br/>━━━━━━━━━━<br/>output_mode?"}
        export_local_bundle["export_local_bundle<br/>━━━━━━━━━━<br/>cp research_dir → research-bundles/<br/>→ local_bundle_path"]
    end

    %% ─────────────────────────────────────────────────────── %%
    subgraph Archival ["ARCHIVAL PHASE"]
        direction TB
        begin_archival{"begin_archival<br/>━━━━━━━━━━<br/>pr_url present?"}
        capture_branch["capture_experiment_branch<br/>━━━━━━━━━━<br/>git rev-parse --abbrev-ref HEAD"]
        create_artifact_branch["create_artifact_branch<br/>━━━━━━━━━━<br/>Worktree from base_branch<br/>checkout research/ only → push"]
        open_artifact_pr["open_artifact_pr<br/>━━━━━━━━━━<br/>gh pr create<br/>artifact-only PR → artifact_pr_url"]
        tag_exp_branch["tag_experiment_branch<br/>━━━━━━━━━━<br/>git tag archive/research/{branch}<br/>Preserves full experiment code"]
        close_exp_pr["close_experiment_pr<br/>━━━━━━━━━━<br/>gh pr close with comment<br/>Links artifact PR + archive tag"]
    end

    %% ════════════════════════════════════════════════════════ %%
    %% DESIGN PHASE TRANSITIONS
    START --> scope
    scope -->|"scope_report"| plan_experiment
    scope -->|"on_failure"| ERROR
    plan_experiment -->|"experiment_plan"| review_design
    plan_experiment -->|"on_failure"| ERROR
    review_design -->|"GO"| plan_visualization
    review_design -->|"REVISE"| plan_experiment
    review_design -->|"STOP"| resolve_design_review
    review_design -->|"skip / exhausted / failure"| create_worktree
    resolve_design_review -->|"revised"| plan_experiment
    resolve_design_review -->|"failed / all-STRUCTURAL"| REJECTED
    plan_visualization -->|"on_success"| create_worktree
    plan_visualization -->|"on_failure"| ERROR

    %% EXECUTION PHASE TRANSITIONS
    create_worktree -->|"worktree_path, research_dir"| stage_data
    create_worktree -->|"on_failure"| ERROR
    stage_data -->|"PASS / WARN"| decompose_phases
    stage_data -->|"FAIL"| ERROR
    decompose_phases -->|"group_files"| plan_phase
    decompose_phases -->|"on_failure"| ERROR
    plan_phase -->|"phase_plan_path"| implement_phase
    plan_phase -->|"on_failure"| ERROR
    implement_phase -->|"on_success / context_limit / exhausted"| next_phase_or_exp
    implement_phase -->|"on_failure"| fix_tests
    next_phase_or_exp -->|"more_phases"| plan_phase
    next_phase_or_exp -->|"done"| run_experiment

    %% EXPERIMENT + REPORT TRANSITIONS
    run_experiment -->|"on_success"| gen_report
    run_experiment -->|"on_failure"| adjust_experiment
    run_experiment -->|"on_exhausted"| ensure_results
    adjust_experiment -->|"on_success"| run_experiment
    adjust_experiment -->|"on_failure"| ensure_results
    ensure_results -->|"on_success"| gen_report_inc
    ensure_results -->|"on_failure"| ERROR
    gen_report -->|"on_success / context_limit"| test
    gen_report -->|"on_failure"| ERROR
    gen_report_inc -->|"on_success / context_limit"| test
    gen_report_inc -->|"on_failure"| ERROR
    test -->|"PASS"| push_branch
    test -->|"FAIL"| fix_tests
    fix_tests -->|"real_fix / already_green / flake_suspected"| retest
    fix_tests -->|"ci_only_failure / on_failure"| ERROR
    retest -->|"PASS"| push_branch
    retest -->|"FAIL"| ERROR

    %% PR + REVIEW TRANSITIONS
    push_branch -->|"on_success"| prepare_research_pr
    push_branch -->|"on_failure"| ERROR
    prepare_research_pr -->|"on_success"| run_lenses
    prepare_research_pr -->|"on_failure"| ERROR
    run_lenses -->|"on_success / on_failure"| stage_bundle
    stage_bundle -->|"on_success / on_failure"| route_pr_or_local
    route_pr_or_local -->|"local"| finalize_bundle
    route_pr_or_local -->|"pr (fall-through)"| compose_pr
    compose_pr -->|"pr_url"| guard_pr_url
    compose_pr -->|"on_failure"| ERROR
    guard_pr_url -->|"pr_url present"| review_research_pr
    guard_pr_url -->|"empty"| COMPLETE
    review_research_pr -->|"all paths"| audit_claims
    audit_claims -->|"all paths"| route_review_resolve
    route_review_resolve -->|"changes_requested"| resolve_research_review
    route_review_resolve -->|"approved / needs_human / skipped"| route_claims_resolve
    resolve_research_review -->|"all paths"| route_claims_resolve
    route_claims_resolve -->|"changes_requested"| resolve_claims_review
    route_claims_resolve -->|"approved / needs_human / skipped"| merge_escalations
    resolve_claims_review -->|"all paths"| merge_escalations
    merge_escalations -->|"rerun == true"| re_run_exp
    merge_escalations -->|"● fallthrough: no rerun"| finalize_bundle

    re_run_exp -->|"on_success"| re_gen_report
    re_run_exp -->|"on_failure / context_limit"| re_push_research
    re_gen_report -->|"on_success"| re_stage_bundle
    re_gen_report -->|"on_failure / context_limit"| re_push_research
    re_stage_bundle -->|"on_success"| re_test
    re_stage_bundle -->|"on_failure"| re_push_research
    re_test -->|"PASS or FAIL"| re_push_research

    %% FINALIZATION TRANSITIONS (KEY FIX)
    finalize_bundle -->|"● on_success: compress+commit FIRST"| re_push_research
    finalize_bundle -->|"on_failure"| begin_archival
    re_push_research -->|"● on_success: push includes commit"| finalize_bundle_render
    re_push_research -->|"on_failure"| begin_archival
    finalize_bundle_render -->|"on_success / on_failure"| route_archive_or_export
    route_archive_or_export -->|"local"| export_local_bundle
    route_archive_or_export -->|"pr (fall-through)"| begin_archival
    export_local_bundle -->|"on_success / on_failure"| COMPLETE

    %% ARCHIVAL TRANSITIONS
    begin_archival -->|"pr_url present"| capture_branch
    begin_archival -->|"no pr_url"| COMPLETE
    capture_branch -->|"on_success"| create_artifact_branch
    capture_branch -->|"on_failure"| COMPLETE
    create_artifact_branch -->|"on_success"| open_artifact_pr
    create_artifact_branch -->|"on_failure"| COMPLETE
    open_artifact_pr -->|"on_success"| tag_exp_branch
    open_artifact_pr -->|"on_failure"| COMPLETE
    tag_exp_branch -->|"on_success"| close_exp_pr
    tag_exp_branch -->|"on_failure"| COMPLETE
    close_exp_pr -->|"on_success / on_failure"| COMPLETE

    %% CLASS ASSIGNMENTS %%
    class START,COMPLETE,ERROR,REJECTED terminal;
    class scope,plan_experiment,plan_visualization,resolve_design_review handler;
    class create_worktree,stage_data,decompose_phases,plan_phase,implement_phase handler;
    class run_experiment,adjust_experiment,ensure_results,gen_report,gen_report_inc handler;
    class fix_tests,push_branch,prepare_research_pr,run_lenses,stage_bundle handler;
    class compose_pr,review_research_pr,audit_claims handler;
    class resolve_research_review,resolve_claims_review handler;
    class re_run_exp,re_gen_report,re_stage_bundle handler;
    class capture_branch,create_artifact_branch,open_artifact_pr,tag_exp_branch,close_exp_pr handler;
    class export_local_bundle output;
    class review_design,next_phase_or_exp,test,retest stateNode;
    class route_pr_or_local,guard_pr_url,route_review_resolve,route_claims_resolve,merge_escalations,route_archive_or_export,begin_archival phase;
    class re_test phase;
    class finalize_bundle,re_push_research,finalize_bundle_render detector;
```

### Scenarios Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph S1 ["SCENARIO 1: Local Mode Output (output_mode=local)"]
        direction LR
        S1_STAGE["stage_bundle<br/>━━━━━━━━━━<br/>copy artifacts<br/>to research_dir"]
        S1_ROUTE["● route_pr_or_local<br/>━━━━━━━━━━<br/>output_mode==local?"]
        S1_FINAL["● finalize_bundle<br/>━━━━━━━━━━<br/>compress artifacts<br/>skip git commit"]
        S1_PUSH["● re_push_research<br/>━━━━━━━━━━<br/>git push<br/>→ finalize_bundle_render"]
        S1_RENDER["finalize_bundle_render<br/>━━━━━━━━━━<br/>render report.html"]
        S1_ROUTE2["route_archive_or_export<br/>━━━━━━━━━━<br/>output_mode==local?"]
        S1_EXPORT["export_local_bundle<br/>━━━━━━━━━━<br/>copy to research-bundles/"]
        S1_END(["research_complete"])
    end

    subgraph S2 ["SCENARIO 2: PR Mode — Compression Commit Before Push (bug fix)"]
        direction LR
        S2_MERGE["● merge_escalations<br/>━━━━━━━━━━<br/>no rerun needed<br/>fallthrough (fixed)"]
        S2_FINAL["● finalize_bundle<br/>━━━━━━━━━━<br/>compress + git commit<br/>artifacts.tar.gz"]
        S2_PUSH["● re_push_research<br/>━━━━━━━━━━<br/>git push<br/>(commit included)"]
        S2_RENDER["finalize_bundle_render<br/>━━━━━━━━━━<br/>render report.html"]
        S2_ROUTE2["route_archive_or_export<br/>━━━━━━━━━━<br/>pr fallthrough"]
        S2_ARCH["begin_archival<br/>━━━━━━━━━━<br/>artifact PR + tag<br/>+ close orig PR"]
        S2_END(["research_complete"])
    end

    subgraph S3 ["SCENARIO 3: PR Mode — Experiment Re-run (bypasses finalize_bundle)"]
        direction LR
        S3_MERGE["● merge_escalations<br/>━━━━━━━━━━<br/>rerun_required=true"]
        S3_RERUN["re_run_experiment<br/>━━━━━━━━━━<br/>run-experiment --adjust"]
        S3_REGEN["re_generate_report<br/>━━━━━━━━━━<br/>updated results"]
        S3_RESTAGE["re_stage_bundle<br/>━━━━━━━━━━<br/>copy updated artifacts"]
        S3_RETEST["re_test<br/>━━━━━━━━━━<br/>test gate"]
        S3_PUSH["● re_push_research<br/>━━━━━━━━━━<br/>git push<br/>(no finalize_bundle)"]
        S3_RENDER["finalize_bundle_render<br/>━━━━━━━━━━<br/>render report.html"]
        S3_END(["research_complete"])
    end

    subgraph S4 ["SCENARIO 4: Recipe Validator Tests (invariant enforcement)"]
        direction LR
        S4_MERGE_TEST["● test_compression_commit_precedes_push<br/>━━━━━━━━━━<br/>asserts merge_escalations<br/>fallthrough == finalize_bundle"]
        S4_ROUTE_TEST["● test_finalize_bundle_on_success_routes_to_re_push_research<br/>━━━━━━━━━━<br/>asserts finalize_bundle.on_success<br/>== re_push_research"]
        S4_PUSH_TEST["● test_re_push_research_on_success_routes_to_finalize_bundle_render<br/>━━━━━━━━━━<br/>asserts re_push_research.on_success<br/>== finalize_bundle_render"]
        S4_ONCE_TEST["● test_finalize_bundle_runs_exactly_once_after_rerun<br/>━━━━━━━━━━<br/>asserts no double-finalize<br/>in rerun path"]
        S4_PASS(["PASS"])
    end

    %% SCENARIO 1 FLOW %%
    S1_STAGE -->|"on_success / on_failure"| S1_ROUTE
    S1_ROUTE -->|"output_mode==local"| S1_FINAL
    S1_FINAL -->|"on_success"| S1_PUSH
    S1_PUSH -->|"on_success"| S1_RENDER
    S1_RENDER -->|"on_success / on_failure"| S1_ROUTE2
    S1_ROUTE2 -->|"local branch"| S1_EXPORT
    S1_EXPORT --> S1_END

    %% SCENARIO 2 FLOW %%
    S2_MERGE -->|"fallthrough<br/>(was: re_push — fixed)"| S2_FINAL
    S2_FINAL -->|"on_success<br/>(compress commit first)"| S2_PUSH
    S2_PUSH -->|"on_success<br/>(push includes commit)"| S2_RENDER
    S2_RENDER -->|"on_success / on_failure"| S2_ROUTE2
    S2_ROUTE2 -->|"pr fallthrough"| S2_ARCH
    S2_ARCH --> S2_END

    %% SCENARIO 3 FLOW %%
    S3_MERGE -->|"rerun=true"| S3_RERUN
    S3_RERUN -->|"on_success"| S3_REGEN
    S3_REGEN -->|"on_success"| S3_RESTAGE
    S3_RESTAGE -->|"on_success"| S3_RETEST
    S3_RETEST -->|"on_success / on_failure"| S3_PUSH
    S3_PUSH -->|"on_success<br/>(skips finalize_bundle)"| S3_RENDER
    S3_RENDER --> S3_END

    %% SCENARIO 4 FLOW %%
    S4_MERGE_TEST --> S4_ROUTE_TEST
    S4_ROUTE_TEST --> S4_PUSH_TEST
    S4_PUSH_TEST --> S4_ONCE_TEST
    S4_ONCE_TEST --> S4_PASS

    %% CLASS ASSIGNMENTS %%
    class S1_STAGE,S1_RENDER,S2_RENDER,S3_RERUN,S3_REGEN,S3_RESTAGE,S3_RETEST,S3_RENDER handler;
    class S1_ROUTE,S1_ROUTE2,S2_ROUTE2,S2_MERGE,S3_MERGE phase;
    class S1_FINAL,S2_FINAL handler;
    class S1_PUSH,S2_PUSH,S3_PUSH handler;
    class S1_EXPORT,S2_ARCH output;
    class S4_MERGE_TEST,S4_ROUTE_TEST,S4_PUSH_TEST,S4_ONCE_TEST detector;
    class S1_END,S2_END,S3_END,S4_PASS terminal;
```

### Error/Resilience Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 45, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;

    %% ── ENTRY POINTS ──────────────────────────────────────────── %%
    ME{"● merge_escalations<br/>━━━━━━━━━━<br/>rerun needed?"}
    RPOL{"● route_pr_or_local<br/>━━━━━━━━━━<br/>output_mode == local?"}

    %% ── RERUN BRANCH (abbreviated context) ─────────────────────── %%
    RE["re_run_experiment<br/>━━━━━━━━━━<br/>--adjust re-run"]

    %% ── BUNDLE FINALIZATION ─────────────────────────────────────── %%
    subgraph BundleFinaliz ["● BUNDLE FINALIZATION (finalize_bundle)"]
        direction TB
        FB["● finalize_bundle<br/>━━━━━━━━━━<br/>mode-aware: rename report.md→README.md<br/>compress artifacts → artifacts.tar.gz<br/>append Archive Manifest<br/>commit (pr mode only)"]
        G1{"GATE: tar.gz<br/>created?"}
        G2{"GATE: no leftover<br/>entries?"}
        G3{"GATE: report file<br/>present?"}
    end

    %% ── PUSH ────────────────────────────────────────────────────── %%
    RPR["● re_push_research<br/>━━━━━━━━━━<br/>git push<br/>(includes compression commit)"]

    %% ── HTML RENDER (non-fatal) ─────────────────────────────────── %%
    FBR["finalize_bundle_render<br/>━━━━━━━━━━<br/>bundle-local-report<br/>HTML rendering"]

    %% ── OUTPUT MODE BRANCH ──────────────────────────────────────── %%
    RAOE{"route_archive_or_export<br/>━━━━━━━━━━<br/>output_mode == local?"}

    %% ── LOCAL MODE TERMINAL ─────────────────────────────────────── %%
    ELB["export_local_bundle<br/>━━━━━━━━━━<br/>copy to research-bundles/"]

    %% ── PR ARCHIVAL GATE ─────────────────────────────────────────── %%
    BA{"begin_archival<br/>━━━━━━━━━━<br/>pr_url present?"}

    %% ── ARCHIVAL STEPS (best-effort) ────────────────────────────── %%
    subgraph Archival ["ARCHIVAL PHASE (all best-effort → research_complete on failure)"]
        direction TB
        CEB["capture_experiment_branch"]
        CAB["create_artifact_branch<br/>━━━━━━━━━━<br/>clean research/-only branch"]
        OAP["open_artifact_pr"]
        TEB["tag_experiment_branch<br/>━━━━━━━━━━<br/>archive/research/ tag"]
        CEP["close_experiment_pr"]
    end

    %% ── TERMINALS ────────────────────────────────────────────────── %%
    RC([research_complete])
    FAIL_EXIT(["exit 1<br/>━━━━━━━━━━<br/>validation failed"])

    %% ═══════════════════════════════════════════════════════════════ %%
    %% FLOW: ENTRY
    ME -->|"review/claims rerun needed"| RE
    ME -->|"no rerun (fallthrough)<br/>★ BUG FIX: was re_push_research"| FB
    RPOL -->|"output_mode == local"| FB
    RE -->|"after revalidation"| RPR

    %% FLOW: finalize_bundle internal validation gates
    FB --> G1
    G1 -->|"missing"| FAIL_EXIT
    G1 -->|"present"| G2
    G2 -->|"leftovers exist"| FAIL_EXIT
    G2 -->|"clean"| G3
    G3 -->|"missing"| FAIL_EXIT
    G3 -->|"present"| RPR

    %% FLOW: on_failure bypass (gates fired exit 1 → step fails)
    FB -->|"on_failure"| BA

    %% FLOW: push → render (FIXED ordering)
    RPR -->|"on_success<br/>★ BUG FIX: was finalize_bundle_render direct"| FBR
    RPR -->|"on_failure"| BA

    %% FLOW: HTML rendering (non-fatal)
    FBR -->|"on_success / on_failure<br/>(non-fatal)"| RAOE

    %% FLOW: output mode branch
    RAOE -->|"local"| ELB
    RAOE -->|"pr (fallthrough)"| BA

    ELB -->|"on_success / on_failure"| RC

    %% FLOW: archival gate
    BA -->|"pr_url absent"| RC
    BA -->|"pr_url present"| CEB

    %% FLOW: archival chain (all degrade to research_complete on failure)
    CEB -->|"on_success"| CAB
    CEB -->|"on_failure"| RC
    CAB -->|"on_success"| OAP
    CAB -->|"on_failure"| RC
    OAP -->|"on_success"| TEB
    OAP -->|"on_failure"| RC
    TEB -->|"on_success"| CEP
    TEB -->|"on_failure"| RC
    CEP -->|"on_success / on_failure"| RC

    %% CLASS ASSIGNMENTS %%
    class ME,RPOL,BA,RAOE stateNode;
    class FB handler;
    class G1,G2,G3 detector;
    class RPR,RE handler;
    class FBR,ELB output;
    class CEB,CAB,OAP,TEB,CEP phase;
    class FAIL_EXIT gap;
    class RC terminal;
```

Closes #1166

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260423-212618-150164/.autoskillit/temp/make-plan/research_recipe_finalize_bundle_ordering_plan_2026-04-23_000000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 125 | 11.2k | 629.4k | 61.3k | 1 | 4m 28s |
| verify | 100 | 6.8k | 429.1k | 35.9k | 1 | 2m 7s |
| implement | 166 | 7.1k | 784.6k | 41.6k | 1 | 2m 22s |
| fix | 200 | 10.7k | 1.0M | 47.2k | 1 | 4m 6s |
| prepare_pr | 60 | 4.1k | 176.2k | 21.0k | 1 | 1m 27s |
| run_arch_lenses | 217 | 30.6k | 1.0M | 167.1k | 3 | 7m 59s |
| compose_pr | 67 | 11.5k | 274.3k | 40.4k | 1 | 2m 51s |
| **Total** | 935 | 82.2k | 4.3M | 414.5k | | 25m 24s |