### PR TITLE
Rectify: RecipeInfo / Recipe Discovery–Execution Boundary Collapse

### DIFF
--- a/src/autoskillit/core/_type_protocols.py
+++ b/src/autoskillit/core/_type_protocols.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
-    from autoskillit.recipe.schema import RecipeInfo
+    from autoskillit.recipe.schema import Recipe, RecipeInfo
 
 from ._type_results import (
     CIRunScope,
@@ -241,6 +241,8 @@ class RecipeRepository(Protocol):
     """Protocol for recipe discovery and loading."""
 
     def find(self, name: str, project_dir: Path) -> RecipeInfo | None: ...
+
+    def load(self, path: Path) -> Recipe: ...
 
     def list(self, project_dir: Path) -> Any: ...
 

--- a/src/autoskillit/core/_type_protocols.py
+++ b/src/autoskillit/core/_type_protocols.py
@@ -18,6 +18,7 @@ from ._type_results import (
     CleanupResult,
     CloneResult,
     FailureRecord,
+    LoadResult,
     SkillResult,
     TestResult,
     ValidatedAddDir,
@@ -244,7 +245,7 @@ class RecipeRepository(Protocol):
 
     def load(self, path: Path) -> Recipe: ...
 
-    def list(self, project_dir: Path) -> Any: ...
+    def list(self, project_dir: Path) -> LoadResult[RecipeInfo]: ...
 
     def load_and_validate(
         self,

--- a/src/autoskillit/core/_type_protocols.py
+++ b/src/autoskillit/core/_type_protocols.py
@@ -8,7 +8,10 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from pathlib import Path
-from typing import Any, Literal, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from autoskillit.recipe.schema import RecipeInfo
 
 from ._type_results import (
     CIRunScope,
@@ -237,7 +240,7 @@ class SupportsLogger(SupportsDebug, Protocol):
 class RecipeRepository(Protocol):
     """Protocol for recipe discovery and loading."""
 
-    def find(self, name: str, project_dir: Path) -> Any: ...
+    def find(self, name: str, project_dir: Path) -> RecipeInfo | None: ...
 
     def list(self, project_dir: Path) -> Any: ...
 

--- a/src/autoskillit/franchise/_api.py
+++ b/src/autoskillit/franchise/_api.py
@@ -173,10 +173,8 @@ async def _run_dispatch(
             f"Recipe '{recipe}' not found.",
         )
 
-    from autoskillit.recipe.io import load_recipe  # noqa: PLC0415
-
     try:
-        full_recipe = load_recipe(recipe_obj.path)
+        full_recipe = tool_ctx.recipes.load(recipe_obj.path)
     except Exception as exc:
         return franchise_error(
             FranchiseErrorCode.FRANCHISE_RECIPE_NOT_FOUND,

--- a/src/autoskillit/franchise/_api.py
+++ b/src/autoskillit/franchise/_api.py
@@ -172,21 +172,32 @@ async def _run_dispatch(
             FranchiseErrorCode.FRANCHISE_RECIPE_NOT_FOUND,
             f"Recipe '{recipe}' not found.",
         )
-    if recipe_obj.kind != "standard":
+
+    from autoskillit.recipe.io import load_recipe  # noqa: PLC0415
+
+    try:
+        full_recipe = load_recipe(recipe_obj.path)
+    except Exception as exc:
+        return franchise_error(
+            FranchiseErrorCode.FRANCHISE_RECIPE_NOT_FOUND,
+            f"Recipe '{recipe}' could not be loaded: {exc}",
+        )
+
+    if full_recipe.kind != "standard":
         return franchise_error(
             FranchiseErrorCode.FRANCHISE_INVALID_RECIPE_KIND,
-            f"Recipe '{recipe}' has kind '{recipe_obj.kind}'. "
+            f"Recipe '{recipe}' has kind '{full_recipe.kind}'. "
             "Only standard recipes can be dispatched as food trucks.",
         )
 
     effective_ingredients = ingredients or {}
     if effective_ingredients:
-        unknown = set(effective_ingredients.keys()) - set(recipe_obj.ingredients.keys())
+        unknown = set(effective_ingredients.keys()) - set(full_recipe.ingredients.keys())
         if unknown:
             return franchise_error(
                 FranchiseErrorCode.FRANCHISE_UNKNOWN_INGREDIENT,
                 f"Unknown ingredient keys: {sorted(unknown)}. "
-                f"Valid keys: {sorted(recipe_obj.ingredients.keys())}",
+                f"Valid keys: {sorted(full_recipe.ingredients.keys())}",
             )
 
     quota_result = await quota_checker(tool_ctx.config.quota_guard)

--- a/src/autoskillit/franchise/_api.py
+++ b/src/autoskillit/franchise/_api.py
@@ -176,6 +176,7 @@ async def _run_dispatch(
     try:
         full_recipe = tool_ctx.recipes.load(recipe_obj.path)
     except Exception as exc:
+        logger.warning("load_recipe failed for '%s'", recipe, exc_info=True)
         return franchise_error(
             FranchiseErrorCode.FRANCHISE_RECIPE_NOT_FOUND,
             f"Recipe '{recipe}' could not be loaded: {exc}",

--- a/src/autoskillit/recipe/repository.py
+++ b/src/autoskillit/recipe/repository.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
+    from autoskillit.core import LoadResult
     from autoskillit.recipe.schema import Recipe, RecipeInfo
 
 import autoskillit.recipe._api as _api
@@ -34,12 +35,12 @@ class DefaultRecipeRepository:
     """Concrete RecipeRepository backed by list_recipes with in-memory mtime cache."""
 
     def __init__(self) -> None:
-        self._cached_list: Any | None = None
+        self._cached_list: LoadResult[RecipeInfo] | None = None
         self._cached_project_dir: Path | None = None
         self._cached_project_mtime: float = 0.0
         self._cached_builtin_mtime: float = 0.0
 
-    def _get_list(self, project_dir: Path) -> Any:
+    def _get_list(self, project_dir: Path) -> LoadResult[RecipeInfo]:
         pm = _dir_mtime(project_dir / ".autoskillit" / "recipes")
         bm = _dir_mtime(builtin_recipes_dir())
         if (
@@ -63,7 +64,7 @@ class DefaultRecipeRepository:
     def load(self, path: Path) -> Recipe:
         return load_recipe(path)
 
-    def list(self, project_dir: Path) -> Any:
+    def list(self, project_dir: Path) -> LoadResult[RecipeInfo]:
         return self._get_list(project_dir)
 
     def load_and_validate(

--- a/src/autoskillit/recipe/repository.py
+++ b/src/autoskillit/recipe/repository.py
@@ -6,7 +6,10 @@ import time
 from collections.abc import Sequence
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from autoskillit.recipe.schema import RecipeInfo
 
 import autoskillit.recipe._api as _api
 from autoskillit.recipe.contracts import StaleItem, load_bundled_manifest
@@ -53,7 +56,7 @@ class DefaultRecipeRepository:
         self._cached_builtin_mtime = bm
         return result
 
-    def find(self, name: str, project_dir: Path) -> Any:
+    def find(self, name: str, project_dir: Path) -> RecipeInfo | None:
         result = self._get_list(project_dir)
         return next((r for r in result.items if r.name == name), None)
 

--- a/src/autoskillit/recipe/repository.py
+++ b/src/autoskillit/recipe/repository.py
@@ -9,11 +9,11 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
-    from autoskillit.recipe.schema import RecipeInfo
+    from autoskillit.recipe.schema import Recipe, RecipeInfo
 
 import autoskillit.recipe._api as _api
 from autoskillit.recipe.contracts import StaleItem, load_bundled_manifest
-from autoskillit.recipe.io import builtin_recipes_dir, list_recipes
+from autoskillit.recipe.io import builtin_recipes_dir, list_recipes, load_recipe
 from autoskillit.recipe.staleness_cache import (
     StalenessEntry,
     compute_recipe_hash,
@@ -59,6 +59,9 @@ class DefaultRecipeRepository:
     def find(self, name: str, project_dir: Path) -> RecipeInfo | None:
         result = self._get_list(project_dir)
         return next((r for r in result.items if r.name == name), None)
+
+    def load(self, path: Path) -> Recipe:
+        return load_recipe(path)
 
     def list(self, project_dir: Path) -> Any:
         return self._get_list(project_dir)

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -830,9 +830,10 @@ def test_core_has_no_autoskillit_imports() -> None:
                 and isinstance(node.test, ast.Name)
                 and node.test.id == "TYPE_CHECKING"
             ):
-                for child in ast.walk(node):
-                    if isinstance(child, ast.Import | ast.ImportFrom):
-                        tc_lines.add(child.lineno)
+                for stmt in node.body:
+                    for child in ast.walk(stmt):
+                        if isinstance(child, ast.Import | ast.ImportFrom):
+                            tc_lines.add(child.lineno)
         for node in ast.walk(tree):
             if isinstance(node, ast.ImportFrom) and node.module:
                 if node.lineno in tc_lines:

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -813,18 +813,36 @@ def test_no_src_module_exceeds_line_limit() -> None:
 
 
 def test_core_has_no_autoskillit_imports() -> None:
-    """REQ-CNST-004: core/ modules must not import from any autoskillit sub-package."""
+    """REQ-CNST-004: core/ modules must not import from any autoskillit sub-package.
+
+    TYPE_CHECKING-guarded imports are permitted — they are zero-runtime-cost annotations
+    that do not create actual import dependencies (same exemption as test_layer_enforcement.py).
+    """
     core_dir = SRC_ROOT / "core"
     assert core_dir.exists(), "core/ package must exist"
     violations: list[str] = []
     for py_file in core_dir.glob("*.py"):
         tree = ast.parse(py_file.read_text())
+        tc_lines: set[int] = set()
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.If)
+                and isinstance(node.test, ast.Name)
+                and node.test.id == "TYPE_CHECKING"
+            ):
+                for child in ast.walk(node):
+                    if isinstance(child, ast.Import | ast.ImportFrom):
+                        tc_lines.add(child.lineno)
         for node in ast.walk(tree):
             if isinstance(node, ast.ImportFrom) and node.module:
+                if node.lineno in tc_lines:
+                    continue
                 parts = node.module.split(".")
                 if parts[0] == "autoskillit" and len(parts) > 1:
                     violations.append(f"core/{py_file.name}:{node.lineno}: imports {node.module}")
             elif isinstance(node, ast.Import):
+                if node.lineno in tc_lines:
+                    continue
                 for alias in node.names:
                     parts = alias.name.split(".")
                     if parts[0] == "autoskillit" and len(parts) > 1:

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -264,12 +264,16 @@ class InMemoryRecipeRepository(RecipeRepository):
 
     def __init__(self) -> None:
         self._recipes: dict[str, Any] = {}
+        self._full_recipes: dict[Any, Any] = {}
         self._validated: dict[str, dict[str, Any]] = {}
         self._path_validated: dict[str, dict[str, Any]] = {}
         self._all_recipes: dict[str, Any] = {}
         self.calls: list[dict[str, Any]] = []
 
     # -- test setup helpers --
+
+    def add_full_recipe(self, path: Any, recipe: Any) -> None:
+        self._full_recipes[path] = recipe
 
     def add_recipe(self, name: str, data: Any) -> None:
         from autoskillit.recipe.schema import RecipeInfo  # noqa: PLC0415
@@ -296,6 +300,15 @@ class InMemoryRecipeRepository(RecipeRepository):
     def find(self, name: str, project_dir: Path) -> Any:
         self.calls.append({"method": "find", "name": name, "project_dir": project_dir})
         return self._recipes.get(name)
+
+    def load(self, path: Path) -> Any:
+        self.calls.append({"method": "load", "path": path})
+        if path in self._full_recipes:
+            return self._full_recipes[path]
+        raise FileNotFoundError(
+            f"No mocked full Recipe for path {path!r}. "
+            "Call add_full_recipe(path, recipe) in the test to configure it."
+        )
 
     def list(self, project_dir: Path) -> Any:
         self.calls.append({"method": "list", "project_dir": project_dir})

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -272,6 +272,14 @@ class InMemoryRecipeRepository(RecipeRepository):
     # -- test setup helpers --
 
     def add_recipe(self, name: str, data: Any) -> None:
+        from autoskillit.recipe.schema import RecipeInfo  # noqa: PLC0415
+
+        if not isinstance(data, RecipeInfo):
+            raise TypeError(
+                f"InMemoryRecipeRepository.add_recipe expects RecipeInfo, "
+                f"got {type(data).__name__}. "
+                "Production DefaultRecipeRepository.find() returns RecipeInfo, not Recipe."
+            )
         self._recipes[name] = data
 
     def set_validated(self, name: str, result: dict[str, Any]) -> None:

--- a/tests/franchise/test_dispatch_failure_semantics.py
+++ b/tests/franchise/test_dispatch_failure_semantics.py
@@ -12,10 +12,17 @@ from tests.fakes import InMemoryHeadlessExecutor, InMemoryRecipeRepository
 pytestmark = [pytest.mark.layer("franchise"), pytest.mark.small, pytest.mark.feature("franchise")]
 
 
-def _make_standard_recipe(name: str = "test-recipe"):
-    from autoskillit.recipe.schema import Recipe, RecipeKind
+def _make_recipe_info(name: str = "test-recipe"):
+    from pathlib import Path
 
-    return Recipe(name=name, description="test", ingredients={}, kind=RecipeKind.STANDARD)
+    from autoskillit.recipe.schema import RecipeInfo, RecipeSource
+
+    return RecipeInfo(
+        name=name,
+        description="test",
+        source=RecipeSource.PROJECT,
+        path=Path(f"/fake/{name}.yaml"),
+    )
 
 
 def _simple_prompt_builder(**kwargs) -> str:
@@ -36,13 +43,21 @@ async def _noop_quota_refresher(config, **kwargs) -> None:
     pass
 
 
-def _setup_dispatch(tool_ctx, recipe_name: str = "test-recipe"):
+def _setup_dispatch(tool_ctx, monkeypatch, recipe_name: str = "test-recipe"):
     """Wire tool_ctx for dispatch tests."""
+    from autoskillit.recipe.schema import Recipe, RecipeKind
+
     tool_ctx.franchise_lock = asyncio.Lock()
     repo = InMemoryRecipeRepository()
-    repo.add_recipe(recipe_name, _make_standard_recipe(recipe_name))
+    repo.add_recipe(recipe_name, _make_recipe_info(recipe_name))
     tool_ctx.recipes = repo
     tool_ctx.executor = InMemoryHeadlessExecutor()
+    monkeypatch.setattr(
+        "autoskillit.franchise._api.load_recipe",
+        lambda _path: Recipe(
+            name=recipe_name, description="test", kind=RecipeKind.STANDARD, ingredients={}
+        ),
+    )
 
 
 async def _run(tool_ctx, recipe: str = "test-recipe") -> dict:
@@ -117,7 +132,7 @@ class TestTimeoutPath:
 
         from tests.fakes import _DEFAULT_SKILL_RESULT
 
-        _setup_dispatch(tool_ctx)
+        _setup_dispatch(tool_ctx, monkeypatch)
         tool_ctx.executor = InMemoryHeadlessExecutor(
             default_result=dataclasses.replace(_DEFAULT_SKILL_RESULT, subtype="timeout")
         )
@@ -133,7 +148,7 @@ class TestTimeoutPath:
 
         from tests.fakes import _DEFAULT_SKILL_RESULT
 
-        _setup_dispatch(tool_ctx)
+        _setup_dispatch(tool_ctx, monkeypatch)
         tool_ctx.executor = InMemoryHeadlessExecutor(
             default_result=dataclasses.replace(_DEFAULT_SKILL_RESULT, subtype="timeout")
         )
@@ -151,7 +166,7 @@ class TestTimeoutPath:
 
         from tests.fakes import _DEFAULT_SKILL_RESULT
 
-        _setup_dispatch(tool_ctx)
+        _setup_dispatch(tool_ctx, monkeypatch)
         tool_ctx.executor = InMemoryHeadlessExecutor(
             default_result=dataclasses.replace(_DEFAULT_SKILL_RESULT, subtype="timeout")
         )
@@ -175,7 +190,7 @@ class TestTimeoutPath:
 
         from tests.fakes import _DEFAULT_SKILL_RESULT
 
-        _setup_dispatch(tool_ctx)
+        _setup_dispatch(tool_ctx, monkeypatch)
         tool_ctx.executor = InMemoryHeadlessExecutor(
             default_result=dataclasses.replace(
                 _DEFAULT_SKILL_RESULT,
@@ -198,7 +213,7 @@ class TestTimeoutPath:
 
         from tests.fakes import _DEFAULT_SKILL_RESULT
 
-        _setup_dispatch(tool_ctx)
+        _setup_dispatch(tool_ctx, monkeypatch)
         tool_ctx.executor = InMemoryHeadlessExecutor(
             default_result=dataclasses.replace(
                 _DEFAULT_SKILL_RESULT,
@@ -225,7 +240,7 @@ class TestNoSentinelPath:
         self, tool_ctx, monkeypatch
     ):
         """no_sentinel outcome → DispatchRecord.reason = 'l2_no_result_block'."""
-        _setup_dispatch(tool_ctx)
+        _setup_dispatch(tool_ctx, monkeypatch)
         monkeypatch.setattr(
             "autoskillit.franchise._api.parse_l2_result_block",
             lambda **_: _make_no_sentinel(),
@@ -243,7 +258,7 @@ class TestNoSentinelPath:
 
         from tests.fakes import _DEFAULT_SKILL_RESULT
 
-        _setup_dispatch(tool_ctx)
+        _setup_dispatch(tool_ctx, monkeypatch)
         tool_ctx.executor = InMemoryHeadlessExecutor(
             default_result=dataclasses.replace(
                 _DEFAULT_SKILL_RESULT,
@@ -266,7 +281,7 @@ class TestCompletedDirtyPath:
         self, tool_ctx, monkeypatch
     ):
         """completed_dirty outcome → DispatchRecord.reason = 'l2_parse_failed'."""
-        _setup_dispatch(tool_ctx)
+        _setup_dispatch(tool_ctx, monkeypatch)
         monkeypatch.setattr(
             "autoskillit.franchise._api.parse_l2_result_block",
             lambda **_: _make_completed_dirty(),
@@ -282,7 +297,7 @@ class TestCompletedCleanPath:
     @pytest.mark.anyio
     async def test_completed_clean_success_writes_empty_reason(self, tool_ctx, monkeypatch):
         """completed_clean with success=True → DispatchRecord.reason = ''."""
-        _setup_dispatch(tool_ctx)
+        _setup_dispatch(tool_ctx, monkeypatch)
         monkeypatch.setattr(
             "autoskillit.franchise._api.parse_l2_result_block",
             lambda **_: _make_completed_clean(success=True),
@@ -296,7 +311,7 @@ class TestCompletedCleanPath:
     @pytest.mark.anyio
     async def test_completed_clean_failure_writes_reason_from_payload(self, tool_ctx, monkeypatch):
         """completed_clean success=False: payload.reason → DispatchRecord.reason."""
-        _setup_dispatch(tool_ctx)
+        _setup_dispatch(tool_ctx, monkeypatch)
         monkeypatch.setattr(
             "autoskillit.franchise._api.parse_l2_result_block",
             lambda **_: _make_completed_clean(success=False, reason="my-failure-reason"),

--- a/tests/franchise/test_dispatch_failure_semantics.py
+++ b/tests/franchise/test_dispatch_failure_semantics.py
@@ -49,15 +49,14 @@ def _setup_dispatch(tool_ctx, monkeypatch, recipe_name: str = "test-recipe"):
 
     tool_ctx.franchise_lock = asyncio.Lock()
     repo = InMemoryRecipeRepository()
-    repo.add_recipe(recipe_name, _make_recipe_info(recipe_name))
+    recipe_info = _make_recipe_info(recipe_name)
+    repo.add_recipe(recipe_name, recipe_info)
+    repo.add_full_recipe(
+        recipe_info.path,
+        Recipe(name=recipe_name, description="test", kind=RecipeKind.STANDARD, ingredients={}),
+    )
     tool_ctx.recipes = repo
     tool_ctx.executor = InMemoryHeadlessExecutor()
-    monkeypatch.setattr(
-        "autoskillit.franchise._api.load_recipe",
-        lambda _path: Recipe(
-            name=recipe_name, description="test", kind=RecipeKind.STANDARD, ingredients={}
-        ),
-    )
 
 
 async def _run(tool_ctx, recipe: str = "test-recipe") -> dict:

--- a/tests/franchise/test_dispatch_lifespan.py
+++ b/tests/franchise/test_dispatch_lifespan.py
@@ -48,15 +48,14 @@ def _setup_dispatch(tool_ctx, monkeypatch, recipe_name: str = "test-recipe"):
 
     tool_ctx.franchise_lock = asyncio.Lock()
     repo = InMemoryRecipeRepository()
-    repo.add_recipe(recipe_name, _make_recipe_info(recipe_name))
+    recipe_info = _make_recipe_info(recipe_name)
+    repo.add_recipe(recipe_name, recipe_info)
+    repo.add_full_recipe(
+        recipe_info.path,
+        Recipe(name=recipe_name, description="test", kind=RecipeKind.STANDARD, ingredients={}),
+    )
     tool_ctx.recipes = repo
     tool_ctx.executor = InMemoryHeadlessExecutor()
-    monkeypatch.setattr(
-        "autoskillit.franchise._api.load_recipe",
-        lambda _path: Recipe(
-            name=recipe_name, description="test", kind=RecipeKind.STANDARD, ingredients={}
-        ),
-    )
 
 
 async def _run(tool_ctx, recipe: str = "test-recipe") -> dict:

--- a/tests/franchise/test_dispatch_lifespan.py
+++ b/tests/franchise/test_dispatch_lifespan.py
@@ -12,10 +12,17 @@ from tests.fakes import InMemoryHeadlessExecutor, InMemoryRecipeRepository
 pytestmark = [pytest.mark.layer("franchise"), pytest.mark.small, pytest.mark.feature("franchise")]
 
 
-def _make_standard_recipe(name: str = "test-recipe"):
-    from autoskillit.recipe.schema import Recipe, RecipeKind
+def _make_recipe_info(name: str = "test-recipe"):
+    from pathlib import Path
 
-    return Recipe(name=name, description="test", ingredients={}, kind=RecipeKind.STANDARD)
+    from autoskillit.recipe.schema import RecipeInfo, RecipeSource
+
+    return RecipeInfo(
+        name=name,
+        description="test",
+        source=RecipeSource.PROJECT,
+        path=Path(f"/fake/{name}.yaml"),
+    )
 
 
 def _simple_prompt_builder(**kwargs) -> str:
@@ -36,12 +43,20 @@ async def _noop_quota_refresher(config, **kwargs) -> None:
     pass
 
 
-def _setup_dispatch(tool_ctx, recipe_name: str = "test-recipe"):
+def _setup_dispatch(tool_ctx, monkeypatch, recipe_name: str = "test-recipe"):
+    from autoskillit.recipe.schema import Recipe, RecipeKind
+
     tool_ctx.franchise_lock = asyncio.Lock()
     repo = InMemoryRecipeRepository()
-    repo.add_recipe(recipe_name, _make_standard_recipe(recipe_name))
+    repo.add_recipe(recipe_name, _make_recipe_info(recipe_name))
     tool_ctx.recipes = repo
     tool_ctx.executor = InMemoryHeadlessExecutor()
+    monkeypatch.setattr(
+        "autoskillit.franchise._api.load_recipe",
+        lambda _path: Recipe(
+            name=recipe_name, description="test", kind=RecipeKind.STANDARD, ingredients={}
+        ),
+    )
 
 
 async def _run(tool_ctx, recipe: str = "test-recipe") -> dict:
@@ -126,7 +141,7 @@ class TestLifespanStartedInEnvelopes:
 
         from tests.fakes import _DEFAULT_SKILL_RESULT
 
-        _setup_dispatch(tool_ctx)
+        _setup_dispatch(tool_ctx, monkeypatch)
         tool_ctx.executor = InMemoryHeadlessExecutor(
             default_result=dataclasses.replace(
                 _DEFAULT_SKILL_RESULT,
@@ -148,7 +163,7 @@ class TestLifespanStartedInEnvelopes:
         self, tool_ctx, monkeypatch
     ):
         """no_sentinel envelope includes 'lifespan_started' field."""
-        _setup_dispatch(tool_ctx)
+        _setup_dispatch(tool_ctx, monkeypatch)
         monkeypatch.setattr(
             "autoskillit.franchise._api.parse_l2_result_block",
             lambda **_: _make_no_sentinel(),
@@ -164,7 +179,7 @@ class TestLifespanStartedInEnvelopes:
         self, tool_ctx, monkeypatch
     ):
         """completed_dirty envelope includes 'lifespan_started' field."""
-        _setup_dispatch(tool_ctx)
+        _setup_dispatch(tool_ctx, monkeypatch)
         monkeypatch.setattr(
             "autoskillit.franchise._api.parse_l2_result_block",
             lambda **_: _make_completed_dirty(),

--- a/tests/franchise/test_franchise_e2e.py
+++ b/tests/franchise/test_franchise_e2e.py
@@ -221,10 +221,16 @@ class FranchiseRuntime:
 
     def add_recipe(self, name: str) -> None:
         """Register a minimal standard recipe."""
-        from autoskillit.recipe.schema import Recipe, RecipeKind
+        from autoskillit.recipe.schema import RecipeInfo, RecipeSource
 
         self.recipes.add_recipe(
-            name, Recipe(name=name, description="test", ingredients={}, kind=RecipeKind.STANDARD)
+            name,
+            RecipeInfo(
+                name=name,
+                description="test",
+                source=RecipeSource.PROJECT,
+                path=Path(f"/fake/{name}.yaml"),
+            ),
         )
 
     async def dispatch(
@@ -339,6 +345,14 @@ def franchise_runtime(
         recipes=recipes,
         monkeypatch=monkeypatch,
     )
+
+    def _load_recipe_stub(path: Path) -> Any:
+        from autoskillit.recipe.schema import Recipe, RecipeKind
+
+        name = Path(path).stem
+        return Recipe(name=name, description="test", kind=RecipeKind.STANDARD, ingredients={})
+
+    monkeypatch.setattr("autoskillit.franchise._api.load_recipe", _load_recipe_stub)
 
     yield rt
 

--- a/tests/franchise/test_franchise_e2e.py
+++ b/tests/franchise/test_franchise_e2e.py
@@ -221,16 +221,18 @@ class FranchiseRuntime:
 
     def add_recipe(self, name: str) -> None:
         """Register a minimal standard recipe."""
-        from autoskillit.recipe.schema import RecipeInfo, RecipeSource
+        from autoskillit.recipe.schema import Recipe, RecipeInfo, RecipeKind, RecipeSource
 
-        self.recipes.add_recipe(
-            name,
-            RecipeInfo(
-                name=name,
-                description="test",
-                source=RecipeSource.PROJECT,
-                path=Path(f"/fake/{name}.yaml"),
-            ),
+        info = RecipeInfo(
+            name=name,
+            description="test",
+            source=RecipeSource.PROJECT,
+            path=Path(f"/fake/{name}.yaml"),
+        )
+        self.recipes.add_recipe(name, info)
+        self.recipes.add_full_recipe(
+            info.path,
+            Recipe(name=name, description="test", kind=RecipeKind.STANDARD, ingredients={}),
         )
 
     async def dispatch(
@@ -345,14 +347,6 @@ def franchise_runtime(
         recipes=recipes,
         monkeypatch=monkeypatch,
     )
-
-    def _load_recipe_stub(path: Path) -> Any:
-        from autoskillit.recipe.schema import Recipe, RecipeKind
-
-        name = Path(path).stem
-        return Recipe(name=name, description="test", kind=RecipeKind.STANDARD, ingredients={})
-
-    monkeypatch.setattr("autoskillit.franchise._api.load_recipe", _load_recipe_stub)
 
     yield rt
 
@@ -803,11 +797,20 @@ async def test_resume_after_l3_crash(franchise_runtime: FranchiseRuntime, tmp_pa
 @pytest.mark.anyio
 async def test_manifest_corrupted_yaml(franchise_runtime: FranchiseRuntime) -> None:
     """Recipe with wrong kind returns franchise_invalid_recipe_kind without spawning."""
-    from types import SimpleNamespace
+    from autoskillit.recipe.schema import Recipe, RecipeInfo, RecipeKind, RecipeSource
 
     rt = franchise_runtime
-    bad_recipe = SimpleNamespace(kind="campaign", ingredients={})
-    rt.recipes.add_recipe("bad-recipe", bad_recipe)
+    recipe_info = RecipeInfo(
+        name="bad-recipe",
+        description="bad",
+        source=RecipeSource.PROJECT,
+        path=Path("/fake/bad-recipe.yaml"),
+    )
+    rt.recipes.add_recipe("bad-recipe", recipe_info)
+    rt.recipes.add_full_recipe(
+        recipe_info.path,
+        Recipe(name="bad-recipe", description="bad", kind=RecipeKind.CAMPAIGN, ingredients={}),
+    )
 
     result = await rt.dispatch("bad-recipe")
     assert result["success"] is False

--- a/tests/recipe/test_repository.py
+++ b/tests/recipe/test_repository.py
@@ -184,3 +184,42 @@ def test_list_all_delegates_to_api() -> None:
 
     assert result == expected
     mock_api.assert_called_once_with(project_dir=None)
+
+
+# ---------------------------------------------------------------------------
+# Protocol boundary enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_recipe_repository_protocol_find_return_type_is_recipe_info() -> None:
+    """RecipeRepository.find() must declare RecipeInfo | None.
+
+    If it returns Any, mypy cannot catch callers accessing Recipe-only attributes
+    on the result — exactly the bug class this guard is designed to prevent.
+    """
+    import inspect
+    import typing
+
+    from autoskillit.core._type_protocols import RecipeRepository
+
+    sig = inspect.signature(RecipeRepository.find)
+    ann = sig.return_annotation
+    type_args = typing.get_args(ann)
+    assert RecipeInfo in type_args, (
+        f"RecipeRepository.find() must return RecipeInfo | None. "
+        f"Got: {ann!r}. "
+        "Returning Any silences mypy on all callers and hides type boundary violations."
+    )
+
+
+def test_in_memory_recipe_repo_rejects_recipe_objects() -> None:
+    """InMemoryRecipeRepository.add_recipe must only accept RecipeInfo objects.
+
+    Accepting Recipe objects masks the production type mismatch in all dispatch tests.
+    """
+    from autoskillit.recipe.schema import Recipe
+    from tests.fakes import InMemoryRecipeRepository
+
+    repo = InMemoryRecipeRepository()
+    with pytest.raises(TypeError, match="RecipeInfo"):
+        repo.add_recipe("x", Recipe(name="x", description="x"))

--- a/tests/recipe/test_repository.py
+++ b/tests/recipe/test_repository.py
@@ -196,16 +196,17 @@ def test_recipe_repository_protocol_find_return_type_is_recipe_info() -> None:
 
     If it returns Any, mypy cannot catch callers accessing Recipe-only attributes
     on the result — exactly the bug class this guard is designed to prevent.
+
+    Uses string inspection because from __future__ import annotations stores
+    annotations as strings at runtime.
     """
     import inspect
-    import typing
 
     from autoskillit.core._type_protocols import RecipeRepository
 
     sig = inspect.signature(RecipeRepository.find)
     ann = sig.return_annotation
-    type_args = typing.get_args(ann)
-    assert RecipeInfo in type_args, (
+    assert "RecipeInfo" in str(ann), (
         f"RecipeRepository.find() must return RecipeInfo | None. "
         f"Got: {ann!r}. "
         "Returning Any silences mypy on all callers and hides type boundary violations."

--- a/tests/server/test_tools_dispatch.py
+++ b/tests/server/test_tools_dispatch.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import json
-from unittest.mock import AsyncMock
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -240,6 +241,113 @@ class TestDispatchFoodTruckValidation:
         )
         assert result["success"] is False
         assert result["error"] == "franchise_manifest_missing"
+
+    @pytest.mark.anyio
+    async def test_dispatch_recipe_info_kind_attribute_error_is_fixed(self, tool_ctx):
+        """find() returns RecipeInfo in production; dispatch must not crash on .kind.
+
+        Previously all dispatch tests stored Recipe objects in the fake, masking the
+        AttributeError. This test uses RecipeInfo (the actual production return type).
+        Before fix: recipe_obj.kind raises AttributeError → L2_STARTUP_OR_CRASH.
+        After fix: load_recipe upgrades RecipeInfo → Recipe before kind check.
+        """
+        from autoskillit.franchise._api import execute_dispatch
+        from autoskillit.recipe.schema import Recipe, RecipeInfo, RecipeKind, RecipeSource
+
+        tool_ctx.franchise_lock = asyncio.Lock()
+        tool_ctx.executor = None
+        repo = InMemoryRecipeRepository()
+        recipe_info = RecipeInfo(
+            name="test-recipe",
+            description="test",
+            source=RecipeSource.PROJECT,
+            path=Path("/fake/recipes/test-recipe.yaml"),
+        )
+        repo.add_recipe("test-recipe", recipe_info)
+        tool_ctx.recipes = repo
+
+        with patch(
+            "autoskillit.franchise._api.load_recipe",
+            return_value=Recipe(name="test-recipe", description="test", kind=RecipeKind.STANDARD),
+        ):
+            result = json.loads(
+                await execute_dispatch(
+                    tool_ctx=tool_ctx,
+                    recipe="test-recipe",
+                    task="run task",
+                    ingredients=None,
+                    dispatch_name=None,
+                    timeout_sec=None,
+                    prompt_builder=_simple_prompt_builder,
+                    quota_checker=_no_sleep_quota_checker,
+                    quota_refresher=_noop_quota_refresher,
+                )
+            )
+
+        # Before fix: L2_STARTUP_OR_CRASH (AttributeError on RecipeInfo.kind)
+        # After fix: FRANCHISE_MANIFEST_MISSING (executor=None, kind check passed)
+        assert result.get("error") != "l2_startup_or_crash", (
+            "Expected structured validation error, not L2_STARTUP_OR_CRASH. "
+            "RecipeInfo.kind AttributeError is not fixed."
+        )
+
+    @pytest.mark.anyio
+    async def test_dispatch_recipe_info_ingredients_attribute_error_is_fixed(self, tool_ctx):
+        """find() returns RecipeInfo; ingredients validation must not crash on
+        recipe_obj.ingredients when non-empty ingredients are passed.
+
+        Before fix: recipe_obj.ingredients raises AttributeError → L2_STARTUP_OR_CRASH.
+        After fix: load_recipe upgrades RecipeInfo → Recipe; unknown ingredient detected.
+        """
+        from autoskillit.franchise._api import execute_dispatch
+        from autoskillit.recipe.schema import (
+            Recipe,
+            RecipeInfo,
+            RecipeIngredient,
+            RecipeKind,
+            RecipeSource,
+        )
+
+        tool_ctx.franchise_lock = asyncio.Lock()
+        tool_ctx.executor = None
+        repo = InMemoryRecipeRepository()
+        recipe_info = RecipeInfo(
+            name="test-recipe",
+            description="test",
+            source=RecipeSource.PROJECT,
+            path=Path("/fake/recipes/test-recipe.yaml"),
+        )
+        repo.add_recipe("test-recipe", recipe_info)
+        tool_ctx.recipes = repo
+
+        with patch(
+            "autoskillit.franchise._api.load_recipe",
+            return_value=Recipe(
+                name="test-recipe",
+                description="test",
+                kind=RecipeKind.STANDARD,
+                ingredients={"env": RecipeIngredient(description="env var")},
+            ),
+        ):
+            result = json.loads(
+                await execute_dispatch(
+                    tool_ctx=tool_ctx,
+                    recipe="test-recipe",
+                    task="run task",
+                    ingredients={"unknown_key": "val"},
+                    dispatch_name=None,
+                    timeout_sec=None,
+                    prompt_builder=_simple_prompt_builder,
+                    quota_checker=_no_sleep_quota_checker,
+                    quota_refresher=_noop_quota_refresher,
+                )
+            )
+
+        # Before fix: L2_STARTUP_OR_CRASH (AttributeError on RecipeInfo.ingredients)
+        # After fix: FRANCHISE_UNKNOWN_INGREDIENT (unknown_key not in recipe.ingredients)
+        assert result.get("error") == "franchise_unknown_ingredient", (
+            f"Expected franchise_unknown_ingredient error. Got: {result}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/server/test_tools_dispatch.py
+++ b/tests/server/test_tools_dispatch.py
@@ -18,8 +18,20 @@ pytestmark = [pytest.mark.layer("server"), pytest.mark.medium, pytest.mark.featu
 # ---------------------------------------------------------------------------
 
 
+def _make_recipe_info(name: str = "test-recipe"):
+    """Return a minimal RecipeInfo for InMemoryRecipeRepository."""
+    from autoskillit.recipe.schema import RecipeInfo, RecipeSource
+
+    return RecipeInfo(
+        name=name,
+        description="test",
+        source=RecipeSource.PROJECT,
+        path=Path(f"/fake/recipes/{name}.yaml"),
+    )
+
+
 def _make_standard_recipe(name: str = "test-recipe", ingredient_keys: list[str] | None = None):
-    """Return a minimal Recipe with kind=STANDARD."""
+    """Return a minimal Recipe with kind=STANDARD for use as load_recipe mock return value."""
     from autoskillit.recipe.schema import Recipe, RecipeIngredient, RecipeKind
 
     ingredients = {k: RecipeIngredient(description=k) for k in (ingredient_keys or [])}
@@ -115,11 +127,14 @@ class TestDispatchFoodTruckValidation:
 
         tool_ctx.franchise_lock = asyncio.Lock()
         repo = InMemoryRecipeRepository()
-        repo.add_recipe(
-            "campaign-recipe",
-            Recipe(name="campaign-recipe", description="test", kind=RecipeKind.CAMPAIGN),
-        )
+        repo.add_recipe("campaign-recipe", _make_recipe_info("campaign-recipe"))
         tool_ctx.recipes = repo
+        monkeypatch.setattr(
+            "autoskillit.franchise._api.load_recipe",
+            lambda _path: Recipe(
+                name="campaign-recipe", description="test", kind=RecipeKind.CAMPAIGN
+            ),
+        )
 
         result = json.loads(
             await execute_dispatch(
@@ -144,9 +159,13 @@ class TestDispatchFoodTruckValidation:
 
         tool_ctx.franchise_lock = asyncio.Lock()
         repo = InMemoryRecipeRepository()
-        repo.add_recipe("test-recipe", _make_standard_recipe("test-recipe", ["task"]))
+        repo.add_recipe("test-recipe", _make_recipe_info("test-recipe"))
         tool_ctx.recipes = repo
         tool_ctx.executor = InMemoryHeadlessExecutor()
+        monkeypatch.setattr(
+            "autoskillit.franchise._api.load_recipe",
+            lambda _path: _make_standard_recipe("test-recipe", ["task"]),
+        )
 
         result = json.loads(
             await execute_dispatch(
@@ -222,9 +241,13 @@ class TestDispatchFoodTruckValidation:
 
         tool_ctx.franchise_lock = asyncio.Lock()
         repo = InMemoryRecipeRepository()
-        repo.add_recipe("test-recipe", _make_standard_recipe("test-recipe"))
+        repo.add_recipe("test-recipe", _make_recipe_info("test-recipe"))
         tool_ctx.recipes = repo
         tool_ctx.executor = None
+        monkeypatch.setattr(
+            "autoskillit.franchise._api.load_recipe",
+            lambda _path: _make_standard_recipe("test-recipe"),
+        )
 
         result = json.loads(
             await execute_dispatch(
@@ -356,20 +379,24 @@ class TestDispatchFoodTruckValidation:
 
 
 class TestDispatchFoodTruckExecution:
-    def _setup_standard_dispatch(self, tool_ctx):
+    def _setup_standard_dispatch(self, tool_ctx, monkeypatch):
         """Wire tool_ctx for a successful standard dispatch."""
         tool_ctx.franchise_lock = asyncio.Lock()
         repo = InMemoryRecipeRepository()
-        repo.add_recipe("test-recipe", _make_standard_recipe("test-recipe", ["task"]))
+        repo.add_recipe("test-recipe", _make_recipe_info("test-recipe"))
         tool_ctx.recipes = repo
         tool_ctx.executor = InMemoryHeadlessExecutor()
+        monkeypatch.setattr(
+            "autoskillit.franchise._api.load_recipe",
+            lambda _path: _make_standard_recipe("test-recipe", ["task"]),
+        )
 
     @pytest.mark.anyio
     async def test_dispatch_food_truck_releases_lock_on_success(self, tool_ctx, monkeypatch):
         """Lock released after successful dispatch."""
         from autoskillit.franchise._api import execute_dispatch
 
-        self._setup_standard_dispatch(tool_ctx)
+        self._setup_standard_dispatch(tool_ctx, monkeypatch)
 
         await execute_dispatch(
             tool_ctx=tool_ctx,
@@ -389,7 +416,7 @@ class TestDispatchFoodTruckExecution:
         """Lock released when executor raises."""
         from autoskillit.franchise._api import execute_dispatch
 
-        self._setup_standard_dispatch(tool_ctx)
+        self._setup_standard_dispatch(tool_ctx, monkeypatch)
         tool_ctx.executor.dispatch_food_truck = AsyncMock(
             side_effect=RuntimeError("executor crashed")
         )
@@ -415,7 +442,7 @@ class TestDispatchFoodTruckExecution:
         """Lock released on asyncio.CancelledError."""
         from autoskillit.franchise._api import execute_dispatch
 
-        self._setup_standard_dispatch(tool_ctx)
+        self._setup_standard_dispatch(tool_ctx, monkeypatch)
         tool_ctx.executor.dispatch_food_truck = AsyncMock(side_effect=asyncio.CancelledError())
 
         with pytest.raises(asyncio.CancelledError):
@@ -441,7 +468,7 @@ class TestDispatchFoodTruckExecution:
         from autoskillit.franchise.result_parser import L2ParseResult
         from tests.fakes import _DEFAULT_SKILL_RESULT
 
-        self._setup_standard_dispatch(tool_ctx)
+        self._setup_standard_dispatch(tool_ctx, monkeypatch)
         tool_ctx.executor = InMemoryHeadlessExecutor(
             default_result=dataclasses.replace(
                 _DEFAULT_SKILL_RESULT,
@@ -514,7 +541,7 @@ class TestDispatchFoodTruckExecution:
         from autoskillit.franchise._api import execute_dispatch
         from autoskillit.franchise.state import read_state
 
-        self._setup_standard_dispatch(tool_ctx)
+        self._setup_standard_dispatch(tool_ctx, monkeypatch)
 
         # Wrap dispatch_food_truck to invoke on_spawn before returning,
         # simulating the real headless executor calling the callback on process start.
@@ -550,7 +577,7 @@ class TestDispatchFoodTruckExecution:
         """After dispatch completes, quota cache is refreshed via background supervisor."""
         from autoskillit.franchise._api import execute_dispatch
 
-        self._setup_standard_dispatch(tool_ctx)
+        self._setup_standard_dispatch(tool_ctx, monkeypatch)
 
         submitted_labels: list[str] = []
 
@@ -580,7 +607,7 @@ class TestDispatchFoodTruckExecution:
         """Completed L2 session skill dir is cleaned up."""
         from autoskillit.franchise._api import execute_dispatch
 
-        self._setup_standard_dispatch(tool_ctx)
+        self._setup_standard_dispatch(tool_ctx, monkeypatch)
         import dataclasses
 
         from tests.fakes import _DEFAULT_SKILL_RESULT
@@ -615,11 +642,11 @@ class TestDispatchFoodTruckExecution:
         assert "l2-session-xyz" in cleanup_calls
 
     @pytest.mark.anyio
-    async def test_dispatch_food_truck_invalidates_quota_cache_file(self, tool_ctx):
+    async def test_dispatch_food_truck_invalidates_quota_cache_file(self, tool_ctx, monkeypatch):
         """After dispatch, cache_invalidator is called with the configured cache path."""
         from autoskillit.franchise._api import execute_dispatch
 
-        self._setup_standard_dispatch(tool_ctx)
+        self._setup_standard_dispatch(tool_ctx, monkeypatch)
 
         invalidate_calls: list[str] = []
 
@@ -654,7 +681,7 @@ class TestDispatchFoodTruckExecution:
         from autoskillit.franchise.result_parser import L2ParseResult
         from tests.fakes import _DEFAULT_SKILL_RESULT
 
-        self._setup_standard_dispatch(tool_ctx)
+        self._setup_standard_dispatch(tool_ctx, monkeypatch)
         tool_ctx.executor = InMemoryHeadlessExecutor(
             default_result=dataclasses.replace(
                 _DEFAULT_SKILL_RESULT,

--- a/tests/server/test_tools_dispatch.py
+++ b/tests/server/test_tools_dispatch.py
@@ -302,8 +302,6 @@ class TestDispatchFoodTruckValidation:
             )
         )
 
-        # Before fix: L2_STARTUP_OR_CRASH (AttributeError on RecipeInfo.kind)
-        # After fix: FRANCHISE_MANIFEST_MISSING (executor=None, kind check passed)
         assert result.get("error") != "l2_startup_or_crash", (
             "Expected structured validation error, not L2_STARTUP_OR_CRASH. "
             "RecipeInfo.kind AttributeError is not fixed."
@@ -361,8 +359,6 @@ class TestDispatchFoodTruckValidation:
             )
         )
 
-        # Before fix: L2_STARTUP_OR_CRASH (AttributeError on RecipeInfo.ingredients)
-        # After fix: FRANCHISE_UNKNOWN_INGREDIENT (unknown_key not in recipe.ingredients)
         assert result.get("error") == "franchise_unknown_ingredient", (
             f"Expected franchise_unknown_ingredient error. Got: {result}"
         )

--- a/tests/server/test_tools_dispatch.py
+++ b/tests/server/test_tools_dispatch.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -127,14 +127,13 @@ class TestDispatchFoodTruckValidation:
 
         tool_ctx.franchise_lock = asyncio.Lock()
         repo = InMemoryRecipeRepository()
-        repo.add_recipe("campaign-recipe", _make_recipe_info("campaign-recipe"))
-        tool_ctx.recipes = repo
-        monkeypatch.setattr(
-            "autoskillit.franchise._api.load_recipe",
-            lambda _path: Recipe(
-                name="campaign-recipe", description="test", kind=RecipeKind.CAMPAIGN
-            ),
+        recipe_info = _make_recipe_info("campaign-recipe")
+        repo.add_recipe("campaign-recipe", recipe_info)
+        repo.add_full_recipe(
+            recipe_info.path,
+            Recipe(name="campaign-recipe", description="test", kind=RecipeKind.CAMPAIGN),
         )
+        tool_ctx.recipes = repo
 
         result = json.loads(
             await execute_dispatch(
@@ -159,13 +158,11 @@ class TestDispatchFoodTruckValidation:
 
         tool_ctx.franchise_lock = asyncio.Lock()
         repo = InMemoryRecipeRepository()
-        repo.add_recipe("test-recipe", _make_recipe_info("test-recipe"))
+        recipe_info = _make_recipe_info("test-recipe")
+        repo.add_recipe("test-recipe", recipe_info)
+        repo.add_full_recipe(recipe_info.path, _make_standard_recipe("test-recipe", ["task"]))
         tool_ctx.recipes = repo
         tool_ctx.executor = InMemoryHeadlessExecutor()
-        monkeypatch.setattr(
-            "autoskillit.franchise._api.load_recipe",
-            lambda _path: _make_standard_recipe("test-recipe", ["task"]),
-        )
 
         result = json.loads(
             await execute_dispatch(
@@ -241,13 +238,11 @@ class TestDispatchFoodTruckValidation:
 
         tool_ctx.franchise_lock = asyncio.Lock()
         repo = InMemoryRecipeRepository()
-        repo.add_recipe("test-recipe", _make_recipe_info("test-recipe"))
+        recipe_info = _make_recipe_info("test-recipe")
+        repo.add_recipe("test-recipe", recipe_info)
+        repo.add_full_recipe(recipe_info.path, _make_standard_recipe("test-recipe"))
         tool_ctx.recipes = repo
         tool_ctx.executor = None
-        monkeypatch.setattr(
-            "autoskillit.franchise._api.load_recipe",
-            lambda _path: _make_standard_recipe("test-recipe"),
-        )
 
         result = json.loads(
             await execute_dispatch(
@@ -287,25 +282,25 @@ class TestDispatchFoodTruckValidation:
             path=Path("/fake/recipes/test-recipe.yaml"),
         )
         repo.add_recipe("test-recipe", recipe_info)
+        repo.add_full_recipe(
+            recipe_info.path,
+            Recipe(name="test-recipe", description="test", kind=RecipeKind.STANDARD),
+        )
         tool_ctx.recipes = repo
 
-        with patch(
-            "autoskillit.franchise._api.load_recipe",
-            return_value=Recipe(name="test-recipe", description="test", kind=RecipeKind.STANDARD),
-        ):
-            result = json.loads(
-                await execute_dispatch(
-                    tool_ctx=tool_ctx,
-                    recipe="test-recipe",
-                    task="run task",
-                    ingredients=None,
-                    dispatch_name=None,
-                    timeout_sec=None,
-                    prompt_builder=_simple_prompt_builder,
-                    quota_checker=_no_sleep_quota_checker,
-                    quota_refresher=_noop_quota_refresher,
-                )
+        result = json.loads(
+            await execute_dispatch(
+                tool_ctx=tool_ctx,
+                recipe="test-recipe",
+                task="run task",
+                ingredients=None,
+                dispatch_name=None,
+                timeout_sec=None,
+                prompt_builder=_simple_prompt_builder,
+                quota_checker=_no_sleep_quota_checker,
+                quota_refresher=_noop_quota_refresher,
             )
+        )
 
         # Before fix: L2_STARTUP_OR_CRASH (AttributeError on RecipeInfo.kind)
         # After fix: FRANCHISE_MANIFEST_MISSING (executor=None, kind check passed)
@@ -341,30 +336,30 @@ class TestDispatchFoodTruckValidation:
             path=Path("/fake/recipes/test-recipe.yaml"),
         )
         repo.add_recipe("test-recipe", recipe_info)
-        tool_ctx.recipes = repo
-
-        with patch(
-            "autoskillit.franchise._api.load_recipe",
-            return_value=Recipe(
+        repo.add_full_recipe(
+            recipe_info.path,
+            Recipe(
                 name="test-recipe",
                 description="test",
                 kind=RecipeKind.STANDARD,
                 ingredients={"env": RecipeIngredient(description="env var")},
             ),
-        ):
-            result = json.loads(
-                await execute_dispatch(
-                    tool_ctx=tool_ctx,
-                    recipe="test-recipe",
-                    task="run task",
-                    ingredients={"unknown_key": "val"},
-                    dispatch_name=None,
-                    timeout_sec=None,
-                    prompt_builder=_simple_prompt_builder,
-                    quota_checker=_no_sleep_quota_checker,
-                    quota_refresher=_noop_quota_refresher,
-                )
+        )
+        tool_ctx.recipes = repo
+
+        result = json.loads(
+            await execute_dispatch(
+                tool_ctx=tool_ctx,
+                recipe="test-recipe",
+                task="run task",
+                ingredients={"unknown_key": "val"},
+                dispatch_name=None,
+                timeout_sec=None,
+                prompt_builder=_simple_prompt_builder,
+                quota_checker=_no_sleep_quota_checker,
+                quota_refresher=_noop_quota_refresher,
             )
+        )
 
         # Before fix: L2_STARTUP_OR_CRASH (AttributeError on RecipeInfo.ingredients)
         # After fix: FRANCHISE_UNKNOWN_INGREDIENT (unknown_key not in recipe.ingredients)
@@ -383,13 +378,11 @@ class TestDispatchFoodTruckExecution:
         """Wire tool_ctx for a successful standard dispatch."""
         tool_ctx.franchise_lock = asyncio.Lock()
         repo = InMemoryRecipeRepository()
-        repo.add_recipe("test-recipe", _make_recipe_info("test-recipe"))
+        recipe_info = _make_recipe_info("test-recipe")
+        repo.add_recipe("test-recipe", recipe_info)
+        repo.add_full_recipe(recipe_info.path, _make_standard_recipe("test-recipe", ["task"]))
         tool_ctx.recipes = repo
         tool_ctx.executor = InMemoryHeadlessExecutor()
-        monkeypatch.setattr(
-            "autoskillit.franchise._api.load_recipe",
-            lambda _path: _make_standard_recipe("test-recipe", ["task"]),
-        )
 
     @pytest.mark.anyio
     async def test_dispatch_food_truck_releases_lock_on_success(self, tool_ctx, monkeypatch):


### PR DESCRIPTION
## Summary

`franchise/_api.py` accesses `.kind` and `.ingredients` on objects returned by
`DefaultRecipeRepository.find()`, which yields `RecipeInfo` — a lightweight metadata
projection that intentionally omits execution-time fields. The code treats discovery
objects as execution objects, a boundary violation producing `AttributeError` at runtime.

The architectural weakness is the **absence of a type-enforced boundary** between the
discovery phase (`RecipeInfo`) and the execution phase (`Recipe`). Every franchise
dispatch test masks this by storing full `Recipe` objects in the test fake instead of
`RecipeInfo` objects.

The remedy is not "add fields to `RecipeInfo`." `RecipeInfo` is deliberately minimal.
The remedy is to enforce — at the protocol level, in the test fake, and at module
import — that callers of `find()` receive a `RecipeInfo` and must explicitly upgrade to a
`Recipe` before accessing execution fields. The upgrade pattern already exists in
`rules_campaign.py:_load_dispatch_target()` and must be applied uniformly.

Part B (separate task) covers adding a `_RECIPE_INFO_FIELDS` import-time guard in
`schema.py` to make future `RecipeInfo`/`Recipe` field-set drift crash at startup.

## Architecture Impact

### Data Lineage Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    subgraph Input ["Data Origins"]
        MCP_CALL["MCP Caller<br/>━━━━━━━━━━<br/>recipe: str<br/>task: str<br/>ingredients: dict"]
    end

    subgraph Protocol ["● RecipeRepository Protocol<br/>(core/_type_protocols.py)"]
        direction TB
        FIND["● find(name, project_dir)<br/>━━━━━━━━━━<br/>returns RecipeInfo | None<br/>path + metadata only"]
        LOAD["● load(path: Path)<br/>━━━━━━━━━━<br/>returns Recipe<br/>full dataclass"]
    end

    subgraph Concrete ["● DefaultRecipeRepository<br/>(recipe/repository.py)"]
        direction TB
        CACHE["_get_list(project_dir)<br/>━━━━━━━━━━<br/>mtime-cached list_recipes()<br/>RecipeListResult in memory"]
        LOAD_RECIPE["load_recipe(path)<br/>━━━━━━━━━━<br/>YAML parse → Recipe<br/>extract_blocks()"]
    end

    subgraph Types ["Type Boundary (schema.py)"]
        direction TB
        RECIPE_INFO["RecipeInfo<br/>━━━━━━━━━━<br/>name, description<br/>source, path, summary"]
        RECIPE["Recipe<br/>━━━━━━━━━━<br/>name, steps, ingredients<br/>kind, blocks, kitchen_rules"]
    end

    subgraph Dispatch ["● franchise/_api.py — execute_dispatch"]
        direction TB
        VALIDATE_KIND["Kind Guard<br/>━━━━━━━━━━<br/>recipe.kind == 'standard'<br/>else FRANCHISE_INVALID_RECIPE_KIND"]
        VALIDATE_ING["Ingredient Guard<br/>━━━━━━━━━━<br/>unknown keys diff<br/>else FRANCHISE_UNKNOWN_INGREDIENT"]
        PROMPT["prompt_builder()<br/>━━━━━━━━━━<br/>recipe + task + ingredients<br/>→ orchestrator_prompt: str"]
        EXECUTOR["executor.dispatch_food_truck()<br/>━━━━━━━━━━<br/>orchestrator_prompt + env_extras<br/>→ SkillResult"]
        PARSE["parse_l2_result_block()<br/>━━━━━━━━━━<br/>stdout + JSONL fallback<br/>→ ParsedL2Result"]
    end

    subgraph Storage ["Primary Storage (Source of Truth)"]
        direction TB
        STATE_FILE[("temp/dispatches/{id}.json<br/>━━━━━━━━━━<br/>write_initial_state()<br/>mark_dispatch_running()<br/>append_dispatch_record()")]
    end

    subgraph Artifacts ["Write-Only Artifacts"]
        direction TB
        SESSION_LOG["JSONL session log<br/>━━━━━━━━━━<br/>~/.local/share/autoskillit/<br/>logs/{session_id}/"]
        STALENESS_CACHE[("recipe_staleness_cache.json<br/>━━━━━━━━━━<br/>triage result per recipe<br/>keyed by recipe name")]
    end

    subgraph Response ["MCP Response"]
        ENV_JSON["JSON Envelope<br/>━━━━━━━━━━<br/>success, dispatch_id<br/>l2_session_id, l2_payload<br/>token_usage"]
    end

    %% PRIMARY DATA FLOW %%
    MCP_CALL -->|"recipe name: str"| FIND
    FIND -->|"delegates to"| CACHE
    CACHE -->|"RecipeInfo | None"| RECIPE_INFO
    RECIPE_INFO -->|"RecipeInfo.path"| LOAD
    LOAD -->|"delegates to"| LOAD_RECIPE
    LOAD_RECIPE -->|"Recipe"| RECIPE

    RECIPE_INFO -.->|"boundary: only path crosses"| LOAD

    RECIPE -->|"Recipe.kind"| VALIDATE_KIND
    RECIPE -->|"Recipe.ingredients"| VALIDATE_ING
    VALIDATE_KIND -->|"pass"| VALIDATE_ING
    VALIDATE_ING -->|"pass"| PROMPT
    MCP_CALL -->|"task + ingredients: str"| PROMPT
    PROMPT -->|"orchestrator_prompt: str"| EXECUTOR
    EXECUTOR -->|"SkillResult (stdout + tokens)"| PARSE
    EXECUTOR -.->|"stdout / JSONL"| SESSION_LOG

    EXECUTOR -->|"on_spawn(pid, ticks)"| STATE_FILE
    PARSE -->|"append_dispatch_record()"| STATE_FILE
    STATE_FILE -->|"read for status queries"| ENV_JSON
    PARSE -->|"parsed.payload"| ENV_JSON
    EXECUTOR -->|"token_usage"| ENV_JSON

    LOAD_RECIPE -.->|"apply_triage_gate()"| STALENESS_CACHE

    %% CLASS ASSIGNMENTS %%
    class MCP_CALL cli;
    class FIND,LOAD handler;
    class CACHE,LOAD_RECIPE phase;
    class RECIPE_INFO,RECIPE stateNode;
    class VALIDATE_KIND,VALIDATE_ING detector;
    class PROMPT,EXECUTOR,PARSE handler;
    class STATE_FILE stateNode;
    class SESSION_LOG,STALENESS_CACHE output;
    class ENV_JSON integration;
```

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START<br/>execute_dispatch])
    COMPLETE([COMPLETE<br/>JSON envelope returned])
    ERROR([ERROR<br/>franchise_error JSON])

    subgraph EntryGate ["Entry Gate"]
        direction TB
        CheckIngredients{"ingredient values<br/>all strings?"}
        CheckLock{"franchise_lock<br/>configured?"}
        CheckContention{"lock already<br/>acquired?"}
        AcquireLock["Acquire asyncio.Lock<br/>━━━━━━━━━━<br/>Blocks concurrent dispatches"]
    end

    subgraph RecipeResolution ["● Recipe Resolution — franchise/_api.py + RecipeRepository boundary"]
        direction TB
        CheckRecipes{"tool_ctx.recipes<br/>configured?"}
        FindRecipe["● recipes.find(name, project_dir)<br/>━━━━━━━━━━<br/>Returns RecipeInfo | None<br/>RecipeInfo has: name, path, source<br/>RecipeInfo does NOT have: kind"]
        CheckFound{"RecipeInfo<br/>returned?"}
        LoadRecipe["● recipes.load(recipe_info.path)<br/>━━━━━━━━━━<br/>Routes through RecipeRepository.load()<br/>Returns full Recipe object<br/>Recipe HAS: kind, ingredients, steps"]
        CheckKind{"full_recipe.kind<br/>== 'standard'?"}
    end

    subgraph ProtocolMediation ["● RecipeRepository Protocol + DefaultRecipeRepository"]
        direction LR
        Protocol["● RecipeRepository Protocol<br/>━━━━━━━━━━<br/>find(name, project_dir) → RecipeInfo | None<br/>load(path) → Recipe<br/>list / load_and_validate / validate_from_path"]
        Concrete["● DefaultRecipeRepository<br/>━━━━━━━━━━<br/>find(): mtime-cached list_recipes<br/>load(): wraps load_recipe(path)<br/>apply_triage_gate(): LLM staleness"]
    end

    subgraph IngredientAndQuota ["Ingredient Validation + Quota"]
        direction TB
        CheckIngredientKeys{"unknown ingredient<br/>keys present?"}
        QuotaCheck["quota_checker(config)<br/>━━━━━━━━━━<br/>Returns should_sleep + sleep_seconds"]
        QuotaSleep["asyncio.sleep(sleep_seconds)<br/>━━━━━━━━━━<br/>Waits for quota window to clear"]
    end

    subgraph DispatchExecution ["Dispatch Execution"]
        direction TB
        BuildPrompt["Build orchestrator prompt<br/>━━━━━━━━━━<br/>dispatch_id, campaign_id,<br/>recipe, task, ingredients"]
        WriteState["write_initial_state()<br/>━━━━━━━━━━<br/>Writes dispatches/{dispatch_id}.json<br/>Status: PENDING"]
        ExecuteHeadless["executor.dispatch_food_truck()<br/>━━━━━━━━━━<br/>Spawns L2 headless Claude session<br/>on_spawn → _write_pid() marks RUNNING"]
        CheckTimeout{"skill_result.subtype<br/>== 'timeout'?"}
    end

    subgraph ResultParsing ["Result Parsing + Outcome Classification"]
        direction TB
        ParseBlock["parse_l2_result_block()<br/>━━━━━━━━━━<br/>Scans stdout + JSONL Channel B<br/>Returns: outcome, payload, source"]
        ClassifyOutcome{"parsed.outcome?"}
        CleanSuccess{"payload.success<br/>== True?"}
        StatusSuccess["final_status = SUCCESS<br/>reason = ''"]
        StatusFailClean["final_status = FAILURE<br/>reason = from payload"]
        StatusFailDirty["final_status = FAILURE<br/>reason = l2_parse_failed"]
        StatusFailNoSentinel["final_status = FAILURE<br/>reason = l2_no_result_block"]
    end

    subgraph StateAndCleanup ["State Record + Post-Dispatch Cleanup"]
        direction TB
        AppendRecord["append_dispatch_record()<br/>━━━━━━━━━━<br/>Writes final DispatchRecord<br/>token_usage, l2_pid, timestamps"]
        PostCleanup["_post_dispatch_cleanup()<br/>━━━━━━━━━━<br/>Invalidate quota cache<br/>Submit quota refresh background task<br/>Cleanup session skill dir"]
        ReleaseLock["lock.release()<br/>━━━━━━━━━━<br/>always in finally block"]
    end

    %% ── FLOW ──────────────────────────────────────────────────────────── %%

    START --> CheckIngredients
    CheckIngredients -->|"non-string values found"| ERROR
    CheckIngredients -->|"all strings"| CheckLock
    CheckLock -->|"lock is None"| ERROR
    CheckLock -->|"lock exists"| CheckContention
    CheckContention -->|"lock.locked() == True"| ERROR
    CheckContention -->|"not locked"| AcquireLock

    AcquireLock --> CheckRecipes
    CheckRecipes -->|"recipes is None"| ERROR
    CheckRecipes -->|"configured"| FindRecipe

    FindRecipe -->|"reads"| Protocol
    Protocol -->|"delegates"| Concrete
    Concrete -->|"returns RecipeInfo"| CheckFound

    CheckFound -->|"None — not found"| ERROR
    CheckFound -->|"RecipeInfo returned"| LoadRecipe
    LoadRecipe -->|"calls load(path)"| Protocol
    Protocol -->|"delegates"| Concrete
    Concrete -->|"returns Recipe"| CheckKind

    CheckKind -->|"kind != standard"| ERROR
    CheckKind -->|"kind == standard"| CheckIngredientKeys

    CheckIngredientKeys -->|"unknown keys"| ERROR
    CheckIngredientKeys -->|"valid"| QuotaCheck
    QuotaCheck -->|"should_sleep == True"| QuotaSleep
    QuotaSleep -->|"done"| BuildPrompt
    QuotaCheck -->|"should_sleep == False"| BuildPrompt

    BuildPrompt --> WriteState
    WriteState --> ExecuteHeadless
    ExecuteHeadless --> CheckTimeout

    CheckTimeout -->|"timeout"| AppendRecord
    CheckTimeout -->|"completed"| ParseBlock
    ParseBlock --> ClassifyOutcome

    ClassifyOutcome -->|"completed_clean"| CleanSuccess
    ClassifyOutcome -->|"completed_dirty"| StatusFailDirty
    ClassifyOutcome -->|"no_sentinel"| StatusFailNoSentinel

    CleanSuccess -->|"success == True"| StatusSuccess
    CleanSuccess -->|"success != True"| StatusFailClean

    StatusSuccess --> AppendRecord
    StatusFailClean --> AppendRecord
    StatusFailDirty --> AppendRecord
    StatusFailNoSentinel --> AppendRecord

    AppendRecord --> PostCleanup
    PostCleanup --> ReleaseLock
    ReleaseLock --> COMPLETE

    %% ── CLASS ASSIGNMENTS ─────────────────────────────────────────────── %%
    class START,COMPLETE,ERROR terminal;
    class CheckIngredients,CheckLock,CheckContention,CheckFound,CheckKind,CheckIngredientKeys,CheckTimeout,ClassifyOutcome,CleanSuccess stateNode;
    class AcquireLock,BuildPrompt,WriteState,ExecuteHeadless,ParseBlock,AppendRecord,PostCleanup,ReleaseLock handler;
    class FindRecipe,LoadRecipe phase;
    class QuotaCheck,QuotaSleep phase;
    class Protocol detector;
    class Concrete output;
    class StatusSuccess,StatusFailClean,StatusFailDirty,StatusFailNoSentinel output;
```

### Repository Access Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph Callers ["CALLERS"]
        DISPATCH["● execute_dispatch / _run_dispatch<br/>━━━━━━━━━━<br/>franchise/_api.py<br/>Acquires lock, sequences recipe lookup<br/>+ executor dispatch"]
        TOOLCTX["ToolContext.recipes<br/>━━━━━━━━━━<br/>DI injection point<br/>Holds RecipeRepository instance"]
    end

    subgraph Protocol ["PROTOCOL CONTRACT"]
        PROTO["● RecipeRepository Protocol<br/>━━━━━━━━━━<br/>core/_type_protocols.py<br/>find(name, project_dir) → RecipeInfo | None<br/>load(path) → Recipe<br/>list(project_dir) → Any<br/>load_and_validate(...) → dict<br/>validate_from_path(...) → dict<br/>list_all(...) → dict<br/>apply_triage_gate(...) → dict"]
    end

    subgraph Repositories ["REPOSITORIES"]
        direction TB
        PROD["● DefaultRecipeRepository<br/>━━━━━━━━━━<br/>recipe/repository.py<br/>mtime-invalidated in-memory cache<br/>_get_list() caches list_recipes() result"]
        FAKE["● InMemoryRecipeRepository<br/>━━━━━━━━━━<br/>tests/fakes.py<br/>add_recipe() enforces RecipeInfo type<br/>TypeError on Recipe objects<br/>Logs all protocol-method calls"]
    end

    subgraph Delegates ["DELEGATES / CONVERSION"]
        direction TB
        IO["recipe.io<br/>━━━━━━━━━━<br/>list_recipes(project_dir) → LoadResult[RecipeInfo]<br/>load_recipe(path) → Recipe<br/>builtin_recipes_dir"]
        API["recipe._api<br/>━━━━━━━━━━<br/>load_and_validate()<br/>validate_from_path()<br/>list_all()"]
        CACHE["recipe.staleness_cache<br/>━━━━━━━━━━<br/>read_staleness_cache()<br/>write_staleness_cache()<br/>compute_recipe_hash()"]
    end

    subgraph Storage ["STORAGE"]
        direction TB
        RECIPES[("Recipe YAML files<br/>━━━━━━━━━━<br/>.autoskillit/recipes/<br/>builtin recipes dir<br/>Filesystem (read-only for repo)")]
        SCACHE[("Staleness cache<br/>━━━━━━━━━━<br/>temp_dir/recipe_staleness_cache.json<br/>read + write (apply_triage_gate only)")]
    end

    %% CALL FLOW %%
    DISPATCH -->|"uses via DI"| TOOLCTX
    TOOLCTX -->|"satisfies"| PROTO

    %% Protocol implemented by both impls %%
    PROTO -.->|"implemented by (prod)"| PROD
    PROTO -.->|"implemented by (test)"| FAKE

    %% Production repo delegates %%
    PROD -->|"find / list:<br/>LoadResult[RecipeInfo]"| IO
    PROD -->|"load:<br/>Recipe"| IO
    PROD -->|"load_and_validate<br/>validate_from_path<br/>list_all"| API
    PROD -->|"apply_triage_gate:<br/>reads cache"| CACHE

    %% Storage reads/writes %%
    IO -->|"reads"| RECIPES
    CACHE -->|"reads/writes"| SCACHE

    %% Type boundary annotation %%
    DISPATCH -->|"find() → RecipeInfo<br/>load() → Recipe<br/>(strict boundary enforced)"| TOOLCTX

    %% CLASS ASSIGNMENTS %%
    class DISPATCH,TOOLCTX cli;
    class PROTO phase;
    class PROD newComponent;
    class FAKE detector;
    class IO,API handler;
    class CACHE output;
    class RECIPES,SCACHE integration;
```

Closes #1168

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260423-213648-256021/.autoskillit/temp/rectify/rectify_recipeinfo-missing-kind_2026-04-23_214400.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| assess | 246 | 11.2k | 1.4M | 55.0k | 1 | 8m 17s |
| prepare_pr | 52 | 4.5k | 164.5k | 28.5k | 1 | 1m 18s |
| run_arch_lenses | 193 | 16.6k | 645.6k | 166.3k | 3 | 6m 36s |
| compose_pr | 59 | 8.4k | 205.0k | 32.3k | 1 | 2m 26s |
| **Total** | 550 | 40.7k | 2.4M | 282.1k | | 18m 39s |