### PR TITLE
Rectify: xdist Sidecar Stats — Filter Telemetry Always Shows '?' for Selected/Deselected Counts

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,11 @@ _filter_mode_key = pytest.StashKey[str | None]()
 _selected_count_key = pytest.StashKey[int | None]()
 _deselected_count_key = pytest.StashKey[int | None]()
 
+# Module-level accumulator for xdist worker-to-controller IPC.
+# Populated by pytest_testnodedown (controller); cleared by pytest_configure
+# at session start so in-process pytester reruns don't leak stale data.
+_worker_filter_counts: dict[str, int | None] = {}
+
 
 class TimeoutTier:
     """Centralized timeout tiers encoding xdist -n 4 budget math.
@@ -310,6 +315,9 @@ def pytest_configure(config: pytest.Config) -> None:
     """
     import warnings
 
+    # Reset xdist IPC accumulator so in-process pytester reruns don't leak counts.
+    _worker_filter_counts.clear()
+
     config.stash[_scope_key] = None
     config.stash[_filter_mode_key] = None
 
@@ -567,13 +575,28 @@ def pytest_collection_modifyitems(
 def pytest_sessionfinish(session, exitstatus):
     """Write filter stats sidecar for DefaultTestRunner consumption."""
     if hasattr(session.config, "workerinput"):
-        return  # xdist worker — only the controller writes the sidecar
+        # xdist worker: propagate counts to controller via workeroutput IPC channel.
+        # config.stash is process-local; the controller never sees stash writes from
+        # workers, so we must transfer the counts explicitly here.
+        session.config.workeroutput["filter_selected"] = session.config.stash.get(
+            _selected_count_key, None
+        )
+        session.config.workeroutput["filter_deselected"] = session.config.stash.get(
+            _deselected_count_key, None
+        )
+        return
     out_path = os.environ.get("AUTOSKILLIT_FILTER_STATS_FILE")
     if not out_path:
         return
     filter_mode = session.config.stash.get(_filter_mode_key, None)
     selected = session.config.stash.get(_selected_count_key, None)
     deselected = session.config.stash.get(_deselected_count_key, None)
+    # Under xdist the controller never runs pytest_collection_modifyitems, so the
+    # stash keys are None there. Fall back to counts aggregated by pytest_testnodedown.
+    if selected is None and _worker_filter_counts:
+        selected = _worker_filter_counts.get("selected")
+    if deselected is None and _worker_filter_counts:
+        deselected = _worker_filter_counts.get("deselected")
     if filter_mode is None:
         return
     import json
@@ -587,3 +610,22 @@ def pytest_sessionfinish(session, exitstatus):
             }
         )
     )
+
+
+@pytest.hookimpl(optionalhook=True)
+def pytest_testnodedown(node, error):
+    """Aggregate filter counts from the first xdist worker that reports.
+
+    Called on the controller process by xdist after each worker finishes.
+    We capture the first non-None report; all workers see the same test set
+    (collection and filtering happen per-worker before distribution), so any
+    single worker's counts are representative of the full session.
+    """
+    if _worker_filter_counts:
+        return  # already captured from the first reporting worker
+    wo = getattr(node, "workeroutput", {})
+    selected = wo.get("filter_selected")
+    deselected = wo.get("filter_deselected")
+    if selected is not None or deselected is not None:
+        _worker_filter_counts["selected"] = selected
+        _worker_filter_counts["deselected"] = deselected

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -617,15 +617,18 @@ def pytest_testnodedown(node, error):
     """Aggregate filter counts from the first xdist worker that reports.
 
     Called on the controller process by xdist after each worker finishes.
-    We capture the first non-None report; all workers see the same test set
-    (collection and filtering happen per-worker before distribution), so any
-    single worker's counts are representative of the full session.
+    We capture the first worker that reports both counts as non-None; all workers
+    see the same test set under ``--dist load`` (collection and filtering happen
+    per-worker before distribution), so any single worker's counts are
+    representative of the full session.  Note: this assumption only holds under
+    ``--dist load``; under ``--dist loadscope`` or ``--dist loadfile`` different
+    workers process different subsets and counts may diverge.
     """
     if _worker_filter_counts:
         return  # already captured from the first reporting worker
     wo = getattr(node, "workeroutput", {})
     selected = wo.get("filter_selected")
     deselected = wo.get("filter_deselected")
-    if selected is not None or deselected is not None:
+    if selected is not None and deselected is not None:
         _worker_filter_counts["selected"] = selected
         _worker_filter_counts["deselected"] = deselected

--- a/tests/execution/test_testing.py
+++ b/tests/execution/test_testing.py
@@ -582,6 +582,41 @@ async def test_default_test_runner_populates_filter_stats_from_sidecar(tmp_path:
 
 
 @pytest.mark.anyio
+async def test_default_test_runner_null_sidecar_values_become_none(tmp_path: Path) -> None:
+    """run() maps JSON null for selected/deselected counts to None in TestResult.
+
+    Regression guard for the isinstance(ts, int) guard at testing.py:244-245.
+    When the sidecar contains null (as happens under xdist before the workeroutput
+    fix), DefaultTestRunner must return None — not crash or coerce to 0.
+    """
+    import json
+
+    sidecar_data = {
+        "filter_mode": "conservative",
+        "tests_selected": None,
+        "tests_deselected": None,
+    }
+
+    async def fake_runner(command, *, cwd, timeout, env, **kwargs):
+        sidecar_path = env.get("AUTOSKILLIT_FILTER_STATS_FILE")
+        assert sidecar_path, "AUTOSKILLIT_FILTER_STATS_FILE must be set in env"
+        Path(sidecar_path).write_text(json.dumps(sidecar_data))
+        return SubprocessResult(
+            returncode=0,
+            stdout="= 1 passed =\n",
+            stderr="",
+            termination=TerminationReason.NATURAL_EXIT,
+            pid=12345,
+        )
+
+    tester = DefaultTestRunner(config=make_test_config(), runner=fake_runner)
+    result = await tester.run(tmp_path)
+    assert result.filter_mode == "conservative"
+    assert result.tests_selected is None
+    assert result.tests_deselected is None
+
+
+@pytest.mark.anyio
 async def test_default_test_runner_no_sidecar_means_no_filter_stats(tmp_path: Path) -> None:
     """run() leaves filter fields as None when no sidecar is written."""
     from tests.conftest import _make_result

--- a/tests/test_test_filter_plugin.py
+++ b/tests/test_test_filter_plugin.py
@@ -25,12 +25,15 @@ _filter_mode_key = pytest.StashKey[str | None]()
 _selected_count_key = pytest.StashKey[int | None]()
 _deselected_count_key = pytest.StashKey[int | None]()
 
+_worker_filter_counts = {}
+
 def pytest_addoption(parser):
     parser.addoption("--filter-mode", default=None,
                      choices=("none", "conservative", "aggressive"))
     parser.addoption("--filter-base-ref", default=None)
 
 def pytest_configure(config):
+    _worker_filter_counts.clear()
     config.stash[_scope_key] = None
     config.stash[_filter_mode_key] = None
     cli_mode = config.getoption("--filter-mode", default=None)
@@ -76,6 +79,12 @@ def pytest_collection_modifyitems(items, config):
 
 def pytest_sessionfinish(session, exitstatus):
     if hasattr(session.config, "workerinput"):
+        session.config.workeroutput["filter_selected"] = session.config.stash.get(
+            _selected_count_key, None
+        )
+        session.config.workeroutput["filter_deselected"] = session.config.stash.get(
+            _deselected_count_key, None
+        )
         return
     out_path = os.environ.get("AUTOSKILLIT_FILTER_STATS_FILE")
     if not out_path:
@@ -83,6 +92,10 @@ def pytest_sessionfinish(session, exitstatus):
     filter_mode = session.config.stash.get(_filter_mode_key, None)
     selected = session.config.stash.get(_selected_count_key, None)
     deselected = session.config.stash.get(_deselected_count_key, None)
+    if selected is None and _worker_filter_counts:
+        selected = _worker_filter_counts.get("selected")
+    if deselected is None and _worker_filter_counts:
+        deselected = _worker_filter_counts.get("deselected")
     if filter_mode is None:
         return
     Path(out_path).write_text(json.dumps({
@@ -90,6 +103,17 @@ def pytest_sessionfinish(session, exitstatus):
         "tests_selected": selected,
         "tests_deselected": deselected,
     }))
+
+@pytest.hookimpl(optionalhook=True)
+def pytest_testnodedown(node, error):
+    if _worker_filter_counts:
+        return
+    wo = getattr(node, "workeroutput", {})
+    selected = wo.get("filter_selected")
+    deselected = wo.get("filter_deselected")
+    if selected is not None or deselected is not None:
+        _worker_filter_counts["selected"] = selected
+        _worker_filter_counts["deselected"] = deselected
 
 def _is_under(path, parent):
     try:

--- a/tests/test_test_filter_plugin.py
+++ b/tests/test_test_filter_plugin.py
@@ -25,7 +25,10 @@ _filter_mode_key = pytest.StashKey[str | None]()
 _selected_count_key = pytest.StashKey[int | None]()
 _deselected_count_key = pytest.StashKey[int | None]()
 
-_worker_filter_counts = {}
+# Module-level accumulator for xdist worker-to-controller IPC.
+# Populated by pytest_testnodedown (controller); cleared by pytest_configure
+# at session start so in-process pytester reruns don't leak stale data.
+_worker_filter_counts: dict[str, int | None] = {}
 
 def pytest_addoption(parser):
     parser.addoption("--filter-mode", default=None,
@@ -106,12 +109,14 @@ def pytest_sessionfinish(session, exitstatus):
 
 @pytest.hookimpl(optionalhook=True)
 def pytest_testnodedown(node, error):
+    # Aggregate filter counts from the first xdist worker that reports both
+    # selected and deselected counts as non-None (mirrors production conftest.py).
     if _worker_filter_counts:
         return
     wo = getattr(node, "workeroutput", {})
     selected = wo.get("filter_selected")
     deselected = wo.get("filter_deselected")
-    if selected is not None or deselected is not None:
+    if selected is not None and deselected is not None:
         _worker_filter_counts["selected"] = selected
         _worker_filter_counts["deselected"] = deselected
 
@@ -317,6 +322,10 @@ class TestConftestFilterPlugin:
         pytester.mkdir("subdir_a")
         (pytester.path / "subdir_a" / "test_in_scope.py").write_text("def test_ok(): pass\n")
         pytester.makepyfile(test_out_scope="def test_skip(): pass")
+        # Use out-of-process subprocess mode (not runpytest_inprocess): xdist spawns
+        # real worker subprocesses that communicate via workeroutput IPC, which cannot
+        # be exercised in-process.  Resource contention risk is low because pytester
+        # runs its own isolated pytest session in a temp directory.
         pytester.runpytest("-n", "2", "--filter-mode=conservative")
         assert sidecar.is_file(), "Sidecar file must be written by pytest_sessionfinish"
         data = json.loads(sidecar.read_text())

--- a/tests/test_test_filter_plugin.py
+++ b/tests/test_test_filter_plugin.py
@@ -275,6 +275,35 @@ class TestConftestFilterPlugin:
         assert data["tests_selected"] == 2
         assert data["tests_deselected"] == 0
 
+    def test_conftest_writes_filter_sidecar_under_xdist(
+        self,
+        pytester: pytest.Pytester,
+        tmp_path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """pytest_sessionfinish writes integer counts under xdist (-n 2).
+
+        Regression test for the controller/worker stash split: under xdist
+        pytest_collection_modifyitems runs on workers while pytest_sessionfinish
+        runs on the controller, so the workeroutput IPC channel is required.
+        """
+        sidecar = tmp_path / "filter-stats.json"
+        monkeypatch.setenv("AUTOSKILLIT_FILTER_STATS_FILE", str(sidecar))
+        pytester.makeconftest(_CONFTEST_HOOKS_SOURCE)
+        pytester.mkdir("subdir_a")
+        (pytester.path / "subdir_a" / "test_in_scope.py").write_text("def test_ok(): pass\n")
+        pytester.makepyfile(test_out_scope="def test_skip(): pass")
+        pytester.runpytest("-n", "2", "--filter-mode=conservative")
+        assert sidecar.is_file(), "Sidecar file must be written by pytest_sessionfinish"
+        data = json.loads(sidecar.read_text())
+        assert data["filter_mode"] == "conservative"
+        assert isinstance(data["tests_selected"], int), (
+            f"tests_selected must be int under xdist, got {data['tests_selected']!r}"
+        )
+        assert isinstance(data["tests_deselected"], int), (
+            f"tests_deselected must be int under xdist, got {data['tests_deselected']!r}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Shadow-diff verification tests (SD1)
@@ -320,3 +349,31 @@ class TestShadowDiff:
         """When filter selects nothing, all full IDs are missed."""
         full_ids = sorted(["tests/core/test_core.py::test_a", "tests/core/test_core.py::test_b"])
         assert self._missed(full_ids, []) == full_ids
+
+    def test_shadow_conftest_has_workeroutput_propagation(self) -> None:
+        """Shadow conftest must define pytest_testnodedown and workeroutput propagation.
+
+        Structural guard: ensures _CONFTEST_HOOKS_SOURCE stays in sync with the
+        production conftest's xdist IPC pathway. Without this guard the shadow could
+        silently lose the workeroutput mechanism, causing pytester-based xdist tests
+        to pass against stale shadow code that doesn't match production behavior.
+        """
+        import ast
+
+        tree = ast.parse(_CONFTEST_HOOKS_SOURCE)
+        func_names = {node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)}
+        assert "pytest_testnodedown" in func_names, (
+            "Shadow conftest is missing pytest_testnodedown hook — "
+            "xdist worker-to-controller propagation not present"
+        )
+        # Verify pytest_sessionfinish contains a workeroutput assignment
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "pytest_sessionfinish":
+                func_src = ast.unparse(node)
+                assert "workeroutput" in func_src, (
+                    "pytest_sessionfinish in shadow conftest must assign workeroutput — "
+                    "xdist IPC channel missing"
+                )
+                break
+        else:
+            raise AssertionError("pytest_sessionfinish not found in shadow conftest")

--- a/tests/test_test_filter_plugin.py
+++ b/tests/test_test_filter_plugin.py
@@ -109,8 +109,11 @@ def pytest_sessionfinish(session, exitstatus):
 
 @pytest.hookimpl(optionalhook=True)
 def pytest_testnodedown(node, error):
-    # Aggregate filter counts from the first xdist worker that reports both
-    # selected and deselected counts as non-None (mirrors production conftest.py).
+    '''Aggregate filter counts from the first xdist worker that reports.
+
+    Mirrors production conftest.py: captures the first worker that reports both
+    selected and deselected counts as non-None.
+    '''
     if _worker_filter_counts:
         return
     wo = getattr(node, "workeroutput", {})


### PR DESCRIPTION
## Summary

The filter stats sidecar mechanism in `tests/conftest.py` treats `config.stash` as shared cross-process state, but under xdist it is process-local. `pytest_collection_modifyitems` (which writes the count keys) never runs on the controller, while `pytest_sessionfinish` (which reads the count keys and writes the sidecar) runs only on the controller. The result: the sidecar always contains `null` for `tests_selected`/`tests_deselected` under xdist, producing `"?"` in telemetry output.

The architectural weakness is that the conftest plugin has **no explicit xdist data propagation strategy**. It relies on implicit same-process stash locality that breaks the moment xdist splits hook execution across controller and worker processes. The fix adopts the standard `workeroutput`/`pytest_testnodedown` pattern (used by pytest-cov and other xdist-aware plugins), providing a structured IPC channel for worker-to-controller data transfer.

## Architecture Impact

### Development Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ENTRY %%
    DEV([Developer])

    subgraph BuildTools ["BUILD TOOLING"]
        direction TB
        PYPROJECT["pyproject.toml<br/>━━━━━━━━━━<br/>hatchling build backend<br/>uv package manager<br/>pytest config (asyncio_mode=auto)"]
        TASKFILE["Taskfile.yml<br/>━━━━━━━━━━<br/>task test-all / test-check<br/>pytest -n 4 -m not smoke<br/>TMPDIR=/dev/shm (RAM tmpfs)"]
        UV["uv / uv.lock<br/>━━━━━━━━━━<br/>Dependency pinning<br/>Checked by pre-commit hook"]
    end

    subgraph QualityGates ["CODE QUALITY GATES (pre-commit)"]
        direction LR
        RUFF_FMT["ruff-format<br/>━━━━━━━━━━<br/>Auto-formats src/"]
        RUFF_LINT["ruff check<br/>━━━━━━━━━━<br/>Lints with --fix"]
        MYPY["mypy<br/>━━━━━━━━━━<br/>Type-checks src/<br/>+ tests/_test_filter.py"]
        GITLEAKS["gitleaks v8.30<br/>━━━━━━━━━━<br/>Secret scanning"]
        UVLOCK["uv-lock-check<br/>━━━━━━━━━━<br/>Validates uv.lock<br/>matches pyproject.toml"]
    end

    subgraph TestFramework ["TEST FRAMEWORK"]
        direction TB

        subgraph ConftestPlugin ["● tests/conftest.py — Filter Plugin & xdist IPC"]
            direction TB
            CONFIGURE["pytest_configure<br/>━━━━━━━━━━<br/>Reads AUTOSKILLIT_TEST_FILTER<br/>Builds scope set via _test_filter<br/>Stores in config.stash"]
            MODIFYITEMS["pytest_collection_modifyitems<br/>━━━━━━━━━━<br/>Deselects out-of-scope tests<br/>Validates layer markers<br/>Skips disabled feature flags"]
            SESSION_FINISH["pytest_sessionfinish<br/>━━━━━━━━━━<br/>Writes JSON sidecar to<br/>AUTOSKILLIT_FILTER_STATS_FILE<br/>Worker: pushes counts to workeroutput"]
            NODE_DOWN["pytest_testnodedown (optionalhook)<br/>━━━━━━━━━━<br/>Controller-side xdist hook<br/>Reads workeroutput filter counts<br/>Accumulates into _worker_filter_counts"]
        end

        subgraph XdistIPC ["XDIST WORKER → CONTROLLER IPC"]
            direction LR
            WORKER["xdist Worker (×4)<br/>━━━━━━━━━━<br/>Runs test subset<br/>workeroutput[filter_selected]<br/>workeroutput[filter_deselected]"]
            CONTROLLER["xdist Controller<br/>━━━━━━━━━━<br/>Aggregates worker counts<br/>_worker_filter_counts dict<br/>Writes final sidecar JSON"]
        end

        subgraph Fixtures ["SHARED FIXTURES (conftest.py)"]
            direction LR
            AUTOUSE["Autouse fixtures<br/>━━━━━━━━━━<br/>_structlog_to_null<br/>_isolated_home<br/>_clear_*_env (3×)"]
            NAMED["Named fixtures<br/>━━━━━━━━━━<br/>minimal_ctx / tool_ctx<br/>parse_stdout_json<br/>anyio_backend"]
        end
    end

    subgraph TestFiles ["MODIFIED TEST FILES"]
        direction TB
        TEST_TESTING["● tests/execution/test_testing.py<br/>━━━━━━━━━━<br/>Layer: execution | medium<br/>Tests: DefaultTestRunner.run()<br/>parse_pytest_summary, check_test_passed<br/>build_sanitized_env, _read_sidecar_*<br/>Regression guard: null→None for xdist sidecar"]
        TEST_FILTER["● tests/test_test_filter_plugin.py<br/>━━━━━━━━━━<br/>Uses pytester (in-process pytest)<br/>TestConftestFilterPlugin (11 tests)<br/>Tests xdist sidecar with -n 2<br/>TestShadowDiff: AST guard for<br/>workeroutput + pytest_testnodedown"]
    end

    subgraph SidecarArtifact ["SIDECAR ARTIFACT"]
        SIDECAR["AUTOSKILLIT_FILTER_STATS_FILE<br/>━━━━━━━━━━<br/>JSON: filter_selected, filter_deselected<br/>Read by DefaultTestRunner.run()<br/>Maps null → None (xdist regression)"]
    end

    subgraph EntryPoints ["ENTRY POINTS"]
        CLI["autoskillit CLI<br/>━━━━━━━━━━<br/>autoskillit.cli:main<br/>serve / init / cook / doctor"]
        TESTCHECK["task test-check<br/>━━━━━━━━━━<br/>TEST_RESULT=PASS/FAIL banner<br/>Used by MCP test_check tool"]
        TESTALL["task test-all<br/>━━━━━━━━━━<br/>lint-imports + pytest -n 4<br/>Human-facing"]
    end

    %% FLOW %%
    DEV --> PYPROJECT
    PYPROJECT --> TASKFILE
    PYPROJECT --> UV

    DEV -->|"pre-commit run"| RUFF_FMT
    RUFF_FMT --> RUFF_LINT
    RUFF_LINT --> MYPY
    MYPY --> GITLEAKS
    GITLEAKS --> UVLOCK

    TASKFILE --> TESTALL
    TASKFILE --> TESTCHECK

    TESTALL -->|"pytest -n 4"| CONFIGURE
    TESTCHECK -->|"pytest -n 4"| CONFIGURE
    CONFIGURE --> MODIFYITEMS
    MODIFYITEMS --> WORKER
    WORKER -->|"workeroutput IPC"| NODE_DOWN
    WORKER --> SESSION_FINISH
    SESSION_FINISH -->|"controller path"| CONTROLLER
    NODE_DOWN --> CONTROLLER
    CONTROLLER --> SIDECAR

    SIDECAR -->|"read by"| TEST_TESTING
    SESSION_FINISH -->|"pytester validates"| TEST_FILTER
    NODE_DOWN -->|"AST-guarded by"| TEST_FILTER

    AUTOUSE -.->|"applied to all tests"| TEST_TESTING
    AUTOUSE -.->|"applied to all tests"| TEST_FILTER
    NAMED -.->|"injected on demand"| TEST_TESTING

    PYPROJECT --> CLI

    %% CLASS ASSIGNMENTS %%
    class DEV terminal;
    class PYPROJECT,UV phase;
    class TASKFILE phase;
    class RUFF_FMT,RUFF_LINT,MYPY,GITLEAKS,UVLOCK detector;
    class CONFIGURE,MODIFYITEMS,SESSION_FINISH,NODE_DOWN handler;
    class WORKER,CONTROLLER stateNode;
    class AUTOUSE,NAMED stateNode;
    class TEST_TESTING,TEST_FILTER handler;
    class SIDECAR output;
    class CLI,TESTCHECK,TESTALL cli;
```

### Concurrency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;

    %% ENTRY POINT %%
    START([DefaultTestRunner.run])

    subgraph ControllerSetup ["CONTROLLER: Session Setup (Sequential)"]
        direction TB
        SUBPROCESS["Launch pytest subprocess<br/>━━━━━━━━━━<br/>env: AUTOSKILLIT_FILTER_STATS_FILE<br/>env: AUTOSKILLIT_TEST_FILTER"]
        CTRL_CONFIGURE["● pytest_configure (controller)<br/>━━━━━━━━━━<br/>_worker_filter_counts.clear()<br/>stash[scope] = None"]
        SPAWN_WORKERS["xdist: Spawn N workers<br/>━━━━━━━━━━<br/>Each worker = isolated OS process<br/>No shared memory with controller"]
    end

    subgraph WorkerPool ["WORKER PROCESSES (N=4, Parallel)"]
        direction TB
        W_CONFIGURE["● pytest_configure (each worker)<br/>━━━━━━━━━━<br/>compute filter scope<br/>stash[scope] = {subdir_a, ...}"]
        W_MODIFYITEMS["● pytest_collection_modifyitems<br/>━━━━━━━━━━<br/>deselect items outside scope<br/>stash[selected_count] = N<br/>stash[deselected_count] = M"]
        W_TESTS["Test execution<br/>━━━━━━━━━━<br/>distributed by xdist load scheduler<br/>fully isolated per worker"]
        W_SESSION_FINISH["● pytest_sessionfinish (worker)<br/>━━━━━━━━━━<br/>workeroutput['filter_selected'] = stash[selected]<br/>workeroutput['filter_deselected'] = stash[deselected]"]
    end

    subgraph ControllerAgg ["CONTROLLER: Aggregation Barrier (Sequential)"]
        direction TB
        NODE_DOWN["● pytest_testnodedown (controller)<br/>━━━━━━━━━━<br/>first-write-wins guard:<br/>if _worker_filter_counts: return<br/>reads node.workeroutput → accumulate"]
        CTRL_COUNTS["_worker_filter_counts<br/>━━━━━━━━━━<br/>{'selected': int, 'deselected': int}<br/>module-level dict (controller process only)"]
        CTRL_SESSION_FINISH["● pytest_sessionfinish (controller)<br/>━━━━━━━━━━<br/>fallback: stash → _worker_filter_counts<br/>writes sidecar JSON to AUTOSKILLIT_FILTER_STATS_FILE"]
    end

    subgraph SidecarIO ["SIDECAR FILE (Atomic Write)"]
        direction TB
        SIDECAR["filter-stats.json<br/>━━━━━━━━━━<br/>{filter_mode, tests_selected,<br/> tests_deselected}"]
    end

    subgraph RunnerConsume ["DefaultTestRunner: Result Assembly (Sequential)"]
        direction TB
        READ_SIDECAR["Read sidecar JSON<br/>━━━━━━━━━━<br/>isinstance(ts, int) guard<br/>null → None (not 0)"]
        TEST_RESULT["TestResult<br/>━━━━━━━━━━<br/>passed, stdout, stderr<br/>filter_mode, tests_selected<br/>tests_deselected, duration_seconds"]
    end

    COMPLETE([Return TestResult])

    subgraph Isolation ["THREAD SAFETY GUARANTEES"]
        direction LR
        ISO1["Worker stash is process-local<br/>━━━━━━━━━━<br/>controller stash never populated<br/>by workers (separate process)"]
        ISO2["workeroutput is xdist IPC<br/>━━━━━━━━━━<br/>safe transfer: finished worker<br/>→ controller via xdist protocol"]
        ISO3["_worker_filter_counts first-write-wins<br/>━━━━━━━━━━<br/>all workers see same test set<br/>first reporter is representative"]
    end

    %% MAIN FLOW %%
    START --> SUBPROCESS
    SUBPROCESS --> CTRL_CONFIGURE
    CTRL_CONFIGURE --> SPAWN_WORKERS

    %% FORK: controller spawns N workers %%
    SPAWN_WORKERS -->|"fork × N"| W_CONFIGURE
    W_CONFIGURE --> W_MODIFYITEMS
    W_MODIFYITEMS --> W_TESTS
    W_TESTS --> W_SESSION_FINISH

    %% BARRIER: workers converge at controller %%
    W_SESSION_FINISH -->|"workeroutput IPC<br/>(xdist protocol)"| NODE_DOWN
    NODE_DOWN --> CTRL_COUNTS
    CTRL_COUNTS --> CTRL_SESSION_FINISH
    CTRL_SESSION_FINISH --> SIDECAR

    %% Runner reads sidecar after subprocess exits %%
    SIDECAR --> READ_SIDECAR
    READ_SIDECAR --> TEST_RESULT
    TEST_RESULT --> COMPLETE

    %% Isolation annotations %%
    W_SESSION_FINISH -.->|"write"| ISO2
    NODE_DOWN -.->|"read"| ISO2
    W_MODIFYITEMS -.->|"isolated"| ISO1
    NODE_DOWN -.->|"first-wins"| ISO3

    %% CLASS ASSIGNMENTS %%
    class START,COMPLETE terminal;
    class SUBPROCESS,SPAWN_WORKERS detector;
    class CTRL_CONFIGURE,CTRL_SESSION_FINISH,NODE_DOWN phase;
    class W_CONFIGURE,W_MODIFYITEMS,W_SESSION_FINISH handler;
    class W_TESTS newComponent;
    class CTRL_COUNTS stateNode;
    class SIDECAR,TEST_RESULT output;
    class READ_SIDECAR phase;
    class ISO1,ISO2,ISO3 stateNode;
```

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 42, 'rankSpacing': 54, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START: task test-check])
    COMPLETE([COMPLETE: TestResult returned])

    %% PHASE 1: TEST INVOCATION %%
    subgraph Phase1 ["Phase 1 — Test Invocation (execution/testing.py)"]
        direction TB
        DTR["DefaultTestRunner.run()<br/>━━━━━━━━━━<br/>Creates temp sidecar path<br/>reads: config.test_check.filter_mode"]
        EnvInject["build_sanitized_env()<br/>━━━━━━━━━━<br/>writes: AUTOSKILLIT_FILTER_STATS_FILE<br/>writes: AUTOSKILLIT_TEST_FILTER<br/>writes: AUTOSKILLIT_TEST_BASE_REF<br/>strips: AUTOSKILLIT_PRIVATE_ENV_VARS"]
    end

    %% PHASE 2: PYTEST CONFIGURE %%
    subgraph Phase2 ["Phase 2 — pytest Configure (● conftest.py: pytest_configure)"]
        direction TB
        ClearIPC["_worker_filter_counts.clear()<br/>━━━━━━━━━━<br/>writes: module-level dict reset<br/>prevents pytester rerun leaks"]
        FilterGate{"AUTOSKILLIT_TEST_FILTER<br/>set and truthy?"}
        BuildScope["build_test_scope()<br/>━━━━━━━━━━<br/>reads: git_changed_files()<br/>reads: load_manifest()<br/>reads: coverage_map_path<br/>writes: config.stash[_scope_key]<br/>writes: config.stash[_filter_mode_key]"]
        FailOpenConfigure["warn + set scope=None<br/>━━━━━━━━━━<br/>fail-open: full test run"]
    end

    %% PHASE 3: COLLECTION & DESELECTION %%
    subgraph Phase3 ["Phase 3 — Collection & Deselection (● conftest.py: pytest_collection_modifyitems)"]
        direction TB
        FeatureGate["Feature gate pass<br/>━━━━━━━━━━<br/>reads: AUTOSKILLIT_TEST_FEATURES<br/>reads: FEATURE_REGISTRY<br/>adds skip markers if disabled"]
        ScopeMatch{"scope is None?"}
        Deselect["Deselect out-of-scope items<br/>━━━━━━━━━━<br/>reads: config.stash[_scope_key]<br/>writes: config.stash[_selected_count_key]<br/>writes: config.stash[_deselected_count_key]"]
        AggressiveSize["Aggressive size filter<br/>━━━━━━━━━━<br/>reads: filter_mode == 'aggressive'<br/>deselects large/unannotated<br/>writes: updated count stash keys"]
    end

    %% PHASE 4A: XDIST WORKER PATH %%
    subgraph Phase4A ["Phase 4A — xdist Worker: pytest_sessionfinish (● conftest.py)"]
        direction TB
        WorkerCheck{"hasattr(config,<br/>'workerinput')?"}
        WorkerIPCWrite["workeroutput IPC write<br/>━━━━━━━━━━<br/>reads: config.stash[_selected_count_key]<br/>reads: config.stash[_deselected_count_key]<br/>writes: workeroutput['filter_selected']<br/>writes: workeroutput['filter_deselected']"]
        WorkerReturn["return early<br/>━━━━━━━━━━<br/>no sidecar write from worker"]
    end

    %% PHASE 4B: XDIST IPC AGGREGATION %%
    subgraph Phase4B ["Phase 4B — Controller: pytest_testnodedown (● conftest.py)"]
        direction TB
        NodeDown["pytest_testnodedown(node, error)<br/>━━━━━━━━━━<br/>reads: node.workeroutput<br/>called per worker completion"]
        AlreadyCaptured{"_worker_filter_counts<br/>already populated?"}
        IPCCapture["First-worker capture<br/>━━━━━━━━━━<br/>reads: workeroutput['filter_selected']<br/>reads: workeroutput['filter_deselected']<br/>writes: _worker_filter_counts['selected']<br/>writes: _worker_filter_counts['deselected']"]
    end

    %% PHASE 5: CONTROLLER SESSION FINISH %%
    subgraph Phase5 ["Phase 5 — Controller: pytest_sessionfinish (● conftest.py)"]
        direction TB
        EnvCheck{"AUTOSKILLIT_FILTER_STATS_FILE<br/>set in env?"}
        StashNull{"stash selected/deselected<br/>are None?"}
        IPCFallback["Fallback to IPC counts<br/>━━━━━━━━━━<br/>reads: _worker_filter_counts['selected']<br/>reads: _worker_filter_counts['deselected']"]
        ModeNull{"filter_mode stash<br/>is None?"}
        SidecarWrite["Write sidecar JSON<br/>━━━━━━━━━━<br/>reads: filter_mode, selected, deselected<br/>writes: AUTOSKILLIT_FILTER_STATS_FILE path<br/>format: {filter_mode, tests_selected, tests_deselected}"]
    end

    %% PHASE 6: SIDECAR CONSUMPTION %%
    subgraph Phase6 ["Phase 6 — Sidecar Consumption (execution/testing.py)"]
        direction TB
        SidecarRead{"sidecar file<br/>exists?"}
        NullGuard["isinstance(ts, int) guard<br/>━━━━━━━━━━<br/>reads: sidecar JSON null values<br/>maps null → None (not 0)"]
        TestResultBuild["TestResult construction<br/>━━━━━━━━━━<br/>writes: result.filter_mode<br/>writes: result.tests_selected (int or None)<br/>writes: result.tests_deselected (int or None)<br/>writes: result.duration_seconds"]
        NoStats["filter fields = None<br/>━━━━━━━━━━<br/>no sidecar → no telemetry"]
    end

    %% SIDECAR FILE (artifact) %%
    SidecarFile[("AUTOSKILLIT_FILTER_STATS_FILE<br/>━━━━━━━━━━<br/>filter-stats.json<br/>{filter_mode, tests_selected,<br/>tests_deselected}")]

    %% FLOW %%
    START --> DTR
    DTR --> EnvInject

    EnvInject -->|"subprocess spawn with env"| ClearIPC
    ClearIPC --> FilterGate
    FilterGate -->|"active"| BuildScope
    FilterGate -->|"inactive / error"| FailOpenConfigure
    BuildScope -->|"on error"| FailOpenConfigure
    BuildScope --> FeatureGate
    FailOpenConfigure --> FeatureGate
    FeatureGate --> ScopeMatch
    ScopeMatch -->|"yes (no filter)"| WorkerCheck
    ScopeMatch -->|"no (filter active)"| Deselect
    Deselect --> AggressiveSize
    AggressiveSize --> WorkerCheck

    WorkerCheck -->|"yes (xdist worker)"| WorkerIPCWrite
    WorkerIPCWrite --> WorkerReturn
    WorkerCheck -->|"no (controller or single)"| EnvCheck

    WorkerReturn -->|"controller: pytest_testnodedown"| NodeDown
    NodeDown --> AlreadyCaptured
    AlreadyCaptured -->|"yes"| EnvCheck
    AlreadyCaptured -->|"no"| IPCCapture
    IPCCapture --> EnvCheck

    EnvCheck -->|"not set"| NoStats
    EnvCheck -->|"set"| StashNull
    StashNull -->|"yes (xdist controller)"| IPCFallback
    StashNull -->|"no (single process)"| ModeNull
    IPCFallback --> ModeNull
    ModeNull -->|"None → no write"| NoStats
    ModeNull -->|"has value"| SidecarWrite
    SidecarWrite -->|"writes"| SidecarFile

    SidecarFile -->|"DefaultTestRunner reads"| SidecarRead
    SidecarRead -->|"present"| NullGuard
    SidecarRead -->|"absent"| NoStats
    NullGuard --> TestResultBuild
    NoStats --> TestResultBuild
    TestResultBuild --> COMPLETE

    %% CLASS ASSIGNMENTS %%
    class START,COMPLETE terminal;
    class DTR,EnvInject handler;
    class ClearIPC,BuildScope phase;
    class FilterGate,WorkerCheck,ScopeMatch,AlreadyCaptured,StashNull,ModeNull,EnvCheck,SidecarRead detector;
    class WorkerIPCWrite,IPCCapture,IPCFallback newComponent;
    class NodeDown,WorkerReturn phase;
    class FeatureGate,Deselect,AggressiveSize handler;
    class FailOpenConfigure detector;
    class SidecarWrite,SidecarFile output;
    class NullGuard,TestResultBuild stateNode;
    class NoStats stateNode;
```

Closes #1177

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260424-071654-860226/.autoskillit/temp/rectify/rectify_xdist-sidecar-stats-filter-telemetry_2026-04-24_072500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| investigate | 55 | 11.5k | 923.0k | 60.9k | 1 | 8m 34s |
| rectify | 73 | 13.2k | 1.1M | 67.5k | 1 | 9m 33s |
| review | 2.3k | 6.6k | 192.8k | 29.6k | 1 | 8m 52s |
| dry_walkthrough | 44 | 9.2k | 843.2k | 54.0k | 1 | 6m 23s |
| implement | 214 | 14.6k | 1.2M | 51.0k | 1 | 5m 6s |
| prepare_pr | 60 | 5.0k | 201.7k | 27.3k | 1 | 1m 31s |
| run_arch_lenses | 1.1k | 17.2k | 699.4k | 127.5k | 3 | 6m 31s |
| compose_pr | 67 | 10.0k | 255.6k | 35.1k | 1 | 2m 31s |
| **Total** | 3.9k | 87.2k | 5.4M | 453.0k | | 49m 5s |