### PR TITLE
Rectify: Merge Queue Enrollment Strategy Unification

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 AutoSkillit is a Claude Code plugin that runs YAML recipes through a
 two-tier orchestrator. The bundled recipes implement issue → plan → worktree
-→ tests → PR → merge pipelines using 45 MCP tools and 111 bundled skills.
+→ tests → PR → merge pipelines using 46 MCP tools and 111 bundled skills.
 
 ## Start here
 

--- a/docs/execution/architecture.md
+++ b/docs/execution/architecture.md
@@ -68,7 +68,7 @@ AutoSkillit supports four session modes with different tool and skill visibility
   `$ claude`); `/open-kitchen` reveals kitchen tools.
 
 - **`$ autoskillit order`**: Pipeline orchestrator session. Kitchen is pre-opened at startup —
-  all 45 MCP tools are available immediately. All skill tiers are accessible. The orchestrator
+  all 46 MCP tools are available immediately. All skill tiers are accessible. The orchestrator
   delegates work through `run_skill` (headless sessions) and `run_cmd` (shell commands).
 
 - **`run_skill` (headless)**: Worker sessions launched by the orchestrator. Sees 3 Free Range

--- a/docs/execution/tool-access.md
+++ b/docs/execution/tool-access.md
@@ -1,6 +1,6 @@
 # MCP Tool Access Control
 
-AutoSkillit provides 45 MCP tools organized into three access levels that control which
+AutoSkillit provides 46 MCP tools organized into three access levels that control which
 session types can see each tool.
 
 ## Three Access Levels
@@ -64,7 +64,7 @@ Server startup sequence:
    → reveals test_check only (the sole headless-tagged tool)
 
 4. When open_kitchen is called:
-   ctx.enable_components(tags={"kitchen"})   → reveals all 42 kitchen tools
+   ctx.enable_components(tags={"kitchen"})   → reveals all 43 kitchen tools
    ctx.disable_components(tags={subset})     → re-hides each disabled subset
    (session-level enable overwrites server-level disable, so re-disabling is required)
 ```
@@ -85,7 +85,7 @@ missing kitchen visibility.
 
 ## Complete MCP Tool Access Control Map
 
-All 45 tools with their access level, tags, source file, and functional category.
+All 46 tools with their access level, tags, source file, and functional category.
 
 **Tag abbreviations**: AS = `autoskillit`, K = `kitchen`, HL = `headless`,
 GH = `github`, CI = `ci`, CL = `clone`, TL = `telemetry`

--- a/docs/skills/visibility.md
+++ b/docs/skills/visibility.md
@@ -84,7 +84,7 @@ and `/autoskillit:close-kitchen`. Skills in `skills_extended/` are never seen.
 
 Order is similar to cook: AutoSkillit launches Claude Code with access to all tiers.
 The key difference is the orchestrator (`sous-chef` skill) is injected and the kitchen
-is pre-opened so all 45 MCP tools are available from the start.
+is pre-opened so all 46 MCP tools are available from the start.
 
 ### Headless session (launched by `run_skill`)
 

--- a/src/autoskillit/cli/_cook.py
+++ b/src/autoskillit/cli/_cook.py
@@ -50,6 +50,7 @@ _DISPLAY_CATEGORIES: tuple[tuple[str, tuple[str, ...]], ...] = (
             "wait_for_merge_queue",
             "check_repo_merge_state",
             "toggle_auto_merge",
+            "enqueue_pr",
             "get_ci_status",
         ),
     ),

--- a/src/autoskillit/core/_type_constants.py
+++ b/src/autoskillit/core/_type_constants.py
@@ -168,6 +168,7 @@ GATED_TOOLS: frozenset[str] = frozenset(
         "wait_for_merge_queue",
         "check_repo_merge_state",
         "toggle_auto_merge",
+        "enqueue_pr",
         "create_unique_branch",
         "write_telemetry_files",
         "get_pr_reviews",
@@ -225,6 +226,7 @@ UNGATED_TOOLS: frozenset[str] = FREE_RANGE_TOOLS
 MUTATING_TOOLS: frozenset[str] = frozenset(
     {
         "toggle_auto_merge",
+        "enqueue_pr",
         "wait_for_merge_queue",
         "register_clone_status",
         "batch_cleanup_clones",

--- a/src/autoskillit/core/_type_constants.py
+++ b/src/autoskillit/core/_type_constants.py
@@ -304,6 +304,7 @@ TOOL_SUBSET_TAGS: dict[str, frozenset[str]] = {
     "wait_for_merge_queue": frozenset({"ci"}),
     "check_repo_merge_state": frozenset({"ci"}),
     "toggle_auto_merge": frozenset({"ci"}),
+    "enqueue_pr": frozenset({"ci"}),
     "get_ci_status": frozenset({"ci"}),
     # clone
     "clone_repo": frozenset({"clone"}),

--- a/src/autoskillit/core/_type_enums.py
+++ b/src/autoskillit/core/_type_enums.py
@@ -330,6 +330,7 @@ class PRState(StrEnum):
     EJECTED_CI_FAILURE = "ejected_ci_failure"
     STALLED = "stalled"
     DROPPED_HEALTHY = "dropped_healthy"
+    NOT_ENROLLED = "not_enrolled"
     TIMEOUT = "timeout"
     ERROR = "error"
 

--- a/src/autoskillit/core/_type_protocols.py
+++ b/src/autoskillit/core/_type_protocols.py
@@ -483,6 +483,7 @@ class MergeQueueWatcher(Protocol):
         max_stall_retries: int = 3,
         not_in_queue_confirmation_cycles: int = 2,
         max_inconclusive_retries: int = 5,
+        auto_merge_available: bool = True,
     ) -> dict[str, Any]: ...
 
     async def toggle(
@@ -491,6 +492,15 @@ class MergeQueueWatcher(Protocol):
         target_branch: str,
         repo: str | None = None,
         cwd: str = ".",
+    ) -> dict[str, Any]: ...
+
+    async def enqueue(
+        self,
+        pr_number: int,
+        target_branch: str,
+        repo: str | None = None,
+        cwd: str = ".",
+        auto_merge_available: bool = True,
     ) -> dict[str, Any]: ...
 
 

--- a/src/autoskillit/execution/merge_queue.py
+++ b/src/autoskillit/execution/merge_queue.py
@@ -633,6 +633,22 @@ class DefaultMergeQueueWatcher:
         if "errors" in body:
             raise RuntimeError(f"GraphQL mutation error: {body['errors']}")
 
+    async def _enable_auto_merge_direct(self, pr_node_id: str) -> None:
+        """Enable auto-merge for a PR via the enablePullRequestAutoMerge mutation."""
+        if not pr_node_id:
+            raise ValueError("pr_node_id must be a non-empty string")
+        resp = await self._ensure_client().post(
+            _GRAPHQL_ENDPOINT,
+            json={
+                "query": _MUTATION_ENABLE_AUTO_MERGE,
+                "variables": {"prId": pr_node_id, "mergeMethod": "SQUASH"},
+            },
+        )
+        resp.raise_for_status()
+        body = resp.json()
+        if "errors" in body:
+            raise RuntimeError(f"GraphQL mutation error: {body['errors']}")
+
     async def enqueue(
         self,
         pr_number: int,
@@ -664,18 +680,7 @@ class DefaultMergeQueueWatcher:
             )
             pr_node_id = state["pr_node_id"]
             if auto_merge_available:
-                client = self._ensure_client()
-                resp = await client.post(
-                    _GRAPHQL_ENDPOINT,
-                    json={
-                        "query": _MUTATION_ENABLE_AUTO_MERGE,
-                        "variables": {"prId": pr_node_id, "mergeMethod": "SQUASH"},
-                    },
-                )
-                resp.raise_for_status()
-                body = resp.json()
-                if "errors" in body:
-                    raise RuntimeError(f"GraphQL mutation error: {body['errors']}")
+                await self._enable_auto_merge_direct(pr_node_id)
                 enrollment_method = "auto_merge"
             else:
                 await self._enqueue_direct(pr_node_id)
@@ -702,20 +707,20 @@ class DefaultMergeQueueWatcher:
         if not auto_merge_available:
             await self._enqueue_direct(pr_node_id)
             return
-        mutations = [
-            (_MUTATION_DISABLE_AUTO_MERGE, {"prId": pr_node_id}),
-            (_MUTATION_ENABLE_AUTO_MERGE, {"prId": pr_node_id, "mergeMethod": "SQUASH"}),
-        ]
-        for i, (mutation, variables) in enumerate(mutations):
-            resp = await self._ensure_client().post(
-                _GRAPHQL_ENDPOINT, json={"query": mutation, "variables": variables}
-            )
-            resp.raise_for_status()
-            body = resp.json()
-            if "errors" in body:
-                raise RuntimeError(f"GraphQL mutation error: {body['errors']}")
-            if i < len(mutations) - 1:
-                await asyncio.sleep(2)
+        # Disable then re-enable auto-merge.
+        resp = await self._ensure_client().post(
+            _GRAPHQL_ENDPOINT,
+            json={
+                "query": _MUTATION_DISABLE_AUTO_MERGE,
+                "variables": {"prId": pr_node_id},
+            },
+        )
+        resp.raise_for_status()
+        body = resp.json()
+        if "errors" in body:
+            raise RuntimeError(f"GraphQL mutation error: {body['errors']}")
+        await asyncio.sleep(2)
+        await self._enable_auto_merge_direct(pr_node_id)
 
 
 # ---------------------------------------------------------------------------

--- a/src/autoskillit/execution/merge_queue.py
+++ b/src/autoskillit/execution/merge_queue.py
@@ -653,6 +653,11 @@ class DefaultMergeQueueWatcher:
                 "error": f"Invalid repo format: {repo!r}. Expected 'owner/name'.",
             }
         owner, repo_name = repo.split("/", 1)
+        if not owner or not repo_name:
+            return {
+                "success": False,
+                "error": f"Invalid repo format: {repo!r}. Expected 'owner/name'.",
+            }
         try:
             state = await self._fetch_pr_and_queue_state(
                 pr_number, owner, repo_name, target_branch

--- a/src/autoskillit/execution/merge_queue.py
+++ b/src/autoskillit/execution/merge_queue.py
@@ -518,9 +518,7 @@ class DefaultMergeQueueWatcher:
                 return _make_result(False, PRState.DROPPED_HEALTHY, classification.reason)
 
             elif classification.terminal == PRState.NOT_ENROLLED:
-                return _make_result(
-                    False, PRState.NOT_ENROLLED, "PR was never enrolled in the merge queue"
-                )
+                return _make_result(False, PRState.NOT_ENROLLED, classification.reason)
 
             else:
                 # Unreachable: _classify_pr_state never returns TIMEOUT or ERROR.

--- a/src/autoskillit/execution/merge_queue.py
+++ b/src/autoskillit/execution/merge_queue.py
@@ -132,6 +132,14 @@ mutation EnableAutoMerge($prId: ID!, $mergeMethod: PullRequestMergeMethod!) {
 }
 """
 
+_MUTATION_ENQUEUE_PR = """
+mutation EnqueuePullRequest($prId: ID!) {
+  enqueuePullRequest(input: {pullRequestId: $prId}) {
+    mergeQueueEntry { id }
+  }
+}
+"""
+
 # Repo-level state query: consolidates three former run_cmd steps into one HTTP round-trip.
 # Distinct from _QUERY (PR-level + queue-entries); do not merge these constants.
 # Returns: mergeQueue presence, autoMergeAllowed flag, and workflow file texts for
@@ -210,8 +218,10 @@ def _is_positive_stall(state: PRFetchState) -> bool:
     }
 
 
-def _is_positive_dropped_healthy(state: PRFetchState) -> bool:
+def _is_positive_dropped_healthy(state: PRFetchState, *, ever_enrolled: bool) -> bool:
     """True when the PR is fully healthy but auto_merge was cleared externally."""
+    if not ever_enrolled:
+        return False
     return (
         state["state"] == "OPEN"
         and state["mergeable"] == "MERGEABLE"
@@ -222,7 +232,21 @@ def _is_positive_dropped_healthy(state: PRFetchState) -> bool:
     )
 
 
-def _classify_pr_state(state: PRFetchState) -> ClassificationResult:
+def _is_not_enrolled(state: PRFetchState, *, ever_enrolled: bool) -> bool:
+    """True when the PR is healthy but was never enrolled in the merge queue."""
+    if ever_enrolled:
+        return False
+    return (
+        state["state"] == "OPEN"
+        and state["mergeable"] == "MERGEABLE"
+        and state["merge_state_status"] == "CLEAN"
+        and state["checks_state"] in (None, "SUCCESS")
+        and state["auto_merge_present"] is False
+        and state["in_queue"] is False
+    )
+
+
+def _classify_pr_state(state: PRFetchState, *, ever_enrolled: bool) -> ClassificationResult:
     """Classify PR state using positive signals only — no fall-through to EJECTED.
 
     Every return originates from a direct positive signal. When no positive gate
@@ -231,6 +255,7 @@ def _classify_pr_state(state: PRFetchState) -> ClassificationResult:
 
     Args:
         state: Current PR fetch state snapshot.
+        ever_enrolled: Whether the PR was ever observed in the queue or with auto-merge.
 
     Returns:
         ClassificationResult with the matched terminal PRState.
@@ -256,8 +281,13 @@ def _classify_pr_state(state: PRFetchState) -> ClassificationResult:
     if state["mergeable"] == "CONFLICTING":
         return ClassificationResult(PRState.EJECTED, "conflicting changes prevent merge")
 
-    if _is_positive_dropped_healthy(state):
+    if _is_positive_dropped_healthy(state, ever_enrolled=ever_enrolled):
         return ClassificationResult(PRState.DROPPED_HEALTHY, "PR healthy but auto_merge cleared")
+
+    if _is_not_enrolled(state, ever_enrolled=ever_enrolled):
+        return ClassificationResult(
+            PRState.NOT_ENROLLED, "PR was never enrolled in the merge queue"
+        )
 
     if state["checks_state"] in {"PENDING", "EXPECTED"}:
         raise CIStillRunning(state, "checks still running")
@@ -317,6 +347,7 @@ class DefaultMergeQueueWatcher:
         max_stall_retries: int = 3,
         not_in_queue_confirmation_cycles: int = 2,
         max_inconclusive_retries: int = 5,
+        auto_merge_available: bool = True,
     ) -> dict[str, Any]:
         """Poll until PR is merged, ejected, stalled, dropped, or timeout expires.
 
@@ -337,6 +368,8 @@ class DefaultMergeQueueWatcher:
                 merged=true propagation (default 2).
             max_inconclusive_retries: Maximum NoPositiveSignal cycles (beyond the
                 confirmation window) before returning pr_state="timeout" (default 5).
+            auto_merge_available: Whether the repository allows auto-merge. When False,
+                stall recovery uses enqueuePullRequest instead of toggle.
 
         Returns:
             {
@@ -359,6 +392,7 @@ class DefaultMergeQueueWatcher:
         stall_retries_attempted: int = 0
         not_in_queue_cycles: int = 0
         inconclusive_count: int = 0
+        ever_enrolled: bool = False
 
         def _make_result(
             success: bool, pr_state: PRState, reason: str, ejection_cause: str = ""
@@ -383,6 +417,9 @@ class DefaultMergeQueueWatcher:
                 await asyncio.sleep(poll_interval)
                 continue
 
+            if state["in_queue"] or state["auto_merge_present"]:
+                ever_enrolled = True
+
             # In queue: reset window and continue
             if state["in_queue"]:
                 not_in_queue_cycles = 0
@@ -396,7 +433,7 @@ class DefaultMergeQueueWatcher:
 
             # Classify state using positive-signal gates
             try:
-                classification = _classify_pr_state(state)
+                classification = _classify_pr_state(state, ever_enrolled=ever_enrolled)
             except CIStillRunning:
                 await asyncio.sleep(poll_interval)
                 continue
@@ -450,7 +487,10 @@ class DefaultMergeQueueWatcher:
                         backoff=backoff,
                     )
                     try:
-                        await self._toggle_auto_merge(state["pr_node_id"])
+                        await self._toggle_auto_merge(
+                            state["pr_node_id"],
+                            auto_merge_available=auto_merge_available,
+                        )
                     except Exception:
                         _log.warning("toggle_auto_merge failed", exc_info=True)
                     stall_retries_attempted += 1
@@ -476,6 +516,11 @@ class DefaultMergeQueueWatcher:
 
             elif classification.terminal == PRState.DROPPED_HEALTHY:
                 return _make_result(False, PRState.DROPPED_HEALTHY, classification.reason)
+
+            elif classification.terminal == PRState.NOT_ENROLLED:
+                return _make_result(
+                    False, PRState.NOT_ENROLLED, "PR was never enrolled in the merge queue"
+                )
 
             else:
                 # Unreachable: _classify_pr_state never returns TIMEOUT or ERROR.
@@ -577,10 +622,83 @@ class DefaultMergeQueueWatcher:
             _log.warning("toggle_auto_merge failed", exc_info=True)
             return {"success": False, "error": f"toggle failed: {exc}"}
 
-    async def _toggle_auto_merge(self, pr_node_id: str) -> None:
-        """Disable then re-enable auto-merge via GraphQL mutations."""
+    async def _enqueue_direct(self, pr_node_id: str) -> None:
+        """Enqueue a PR directly via the enqueuePullRequest GraphQL mutation."""
         if not pr_node_id:
             raise ValueError("pr_node_id must be a non-empty string")
+        resp = await self._ensure_client().post(
+            _GRAPHQL_ENDPOINT,
+            json={"query": _MUTATION_ENQUEUE_PR, "variables": {"prId": pr_node_id}},
+        )
+        resp.raise_for_status()
+        body = resp.json()
+        if "errors" in body:
+            raise RuntimeError(f"GraphQL mutation error: {body['errors']}")
+
+    async def enqueue(
+        self,
+        pr_number: int,
+        target_branch: str,
+        repo: str | None = None,
+        cwd: str = ".",
+        auto_merge_available: bool = True,
+    ) -> dict[str, Any]:
+        """Enqueue a PR using the correct enrollment strategy.
+
+        When auto_merge_available is True, uses enablePullRequestAutoMerge.
+        When False, uses the enqueuePullRequest GraphQL mutation directly.
+        Never raises; returns a structured result dict.
+        """
+        if not repo or "/" not in repo:
+            return {
+                "success": False,
+                "error": f"Invalid repo format: {repo!r}. Expected 'owner/name'.",
+            }
+        owner, repo_name = repo.split("/", 1)
+        try:
+            state = await self._fetch_pr_and_queue_state(
+                pr_number, owner, repo_name, target_branch
+            )
+            pr_node_id = state["pr_node_id"]
+            if auto_merge_available:
+                client = self._ensure_client()
+                resp = await client.post(
+                    _GRAPHQL_ENDPOINT,
+                    json={
+                        "query": _MUTATION_ENABLE_AUTO_MERGE,
+                        "variables": {"prId": pr_node_id, "mergeMethod": "SQUASH"},
+                    },
+                )
+                resp.raise_for_status()
+                body = resp.json()
+                if "errors" in body:
+                    raise RuntimeError(f"GraphQL mutation error: {body['errors']}")
+                enrollment_method = "auto_merge"
+            else:
+                await self._enqueue_direct(pr_node_id)
+                enrollment_method = "direct_enqueue"
+            return {
+                "success": True,
+                "pr_number": pr_number,
+                "enrollment_method": enrollment_method,
+            }
+        except Exception as exc:
+            _log.warning("enqueue failed", exc_info=True)
+            return {"success": False, "error": f"enqueue failed: {exc}"}
+
+    async def _toggle_auto_merge(
+        self, pr_node_id: str, *, auto_merge_available: bool = True
+    ) -> None:
+        """Re-enroll a PR in the merge queue.
+
+        When auto_merge_available is True, uses the disable/re-enable toggle.
+        When False, uses enqueuePullRequest directly (skip toggle entirely).
+        """
+        if not pr_node_id:
+            raise ValueError("pr_node_id must be a non-empty string")
+        if not auto_merge_available:
+            await self._enqueue_direct(pr_node_id)
+            return
         mutations = [
             (_MUTATION_DISABLE_AUTO_MERGE, {"prId": pr_node_id}),
             (_MUTATION_ENABLE_AUTO_MERGE, {"prId": pr_node_id, "mergeMethod": "SQUASH"}),

--- a/src/autoskillit/hooks/pretty_output_hook.py
+++ b/src/autoskillit/hooks/pretty_output_hook.py
@@ -176,6 +176,7 @@ _UNFORMATTED_TOOLS: frozenset[str] = frozenset(
         "wait_for_merge_queue",  # merge queue result dict, generic renders correctly
         "check_repo_merge_state",  # simple JSON boolean bundle, generic renders correctly
         "toggle_auto_merge",  # simple success/error result dict, generic renders correctly
+        "enqueue_pr",  # simple success/error result dict, generic renders correctly
         "create_unique_branch",  # simple result
         "write_telemetry_files",  # simple path results
         "get_pr_reviews",  # list of reviews

--- a/src/autoskillit/recipe/rules_ci.py
+++ b/src/autoskillit/recipe/rules_ci.py
@@ -207,7 +207,9 @@ def _check_ci_hardcoded_workflow(ctx: ValidationContext) -> list[RuleFinding]:
 # wait_for_merge_queue routing rules (I7 + I8)
 # ---------------------------------------------------------------------------
 
-_REQUIRED_MQ_PR_STATES: frozenset[str] = frozenset(s.value for s in PRState if s != PRState.ERROR)
+_REQUIRED_MQ_PR_STATES: frozenset[str] = frozenset(
+    s.value for s in PRState if s not in {PRState.ERROR, PRState.NOT_ENROLLED}
+)
 _PR_STATE_WHEN_RE = re.compile(r"\$\{\{\s*result\.pr_state\s*\}\}\s*==\s*(\w+)")
 _MQ_EXPECTED_FALLBACK = "register_clone_unconfirmed"
 

--- a/src/autoskillit/recipe/rules_merge.py
+++ b/src/autoskillit/recipe/rules_merge.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 
 from autoskillit.core import MergeFailedStep, Severity, get_logger
-from autoskillit.recipe._analysis import ValidationContext
+from autoskillit.recipe._analysis import ValidationContext, _bfs_reachable
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
 
 logger = get_logger(__name__)
@@ -256,4 +256,65 @@ def _check_release_issue_on_unconfirmed_merge(ctx: ValidationContext) -> list[Ru
                     ),
                 )
             )
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# merge-enrollment-auto-consistency rule
+# ---------------------------------------------------------------------------
+
+_AUTO_MERGE_FALSE_PATTERN = re.compile(
+    r"auto_merge_available\s*==\s*['\"]?false['\"]?", re.IGNORECASE
+)
+
+
+def _is_auto_flagged_step(step_name: str, ctx: ValidationContext) -> bool:
+    """Return True if step uses --auto in a gh pr merge command or calls toggle_auto_merge."""
+    step = ctx.recipe.steps.get(step_name)
+    if step is None:
+        return False
+    if step.tool == "run_cmd":
+        cmd = step.with_args.get("cmd", "")
+        if isinstance(cmd, str) and "gh pr merge" in cmd and "--auto" in cmd:
+            return True
+    if step.tool == "toggle_auto_merge":
+        return True
+    return False
+
+
+@semantic_rule(
+    name="merge-enrollment-auto-consistency",
+    description=(
+        "gh pr merge steps with --auto must not be reachable from auto_merge_available=false "
+        "routing arms. When auto_merge_available is false, --auto and toggle_auto_merge will "
+        "fail because the repository does not support enablePullRequestAutoMerge."
+    ),
+    severity=Severity.ERROR,
+)
+def _check_merge_enrollment_auto_consistency(ctx: ValidationContext) -> list[RuleFinding]:
+    findings: list[RuleFinding] = []
+
+    no_auto_targets: set[str] = set()
+    for step_name, step in ctx.recipe.steps.items():
+        if step.on_result and step.on_result.conditions:
+            for cond in step.on_result.conditions:
+                if cond.when and _AUTO_MERGE_FALSE_PATTERN.search(cond.when):
+                    no_auto_targets.add(cond.route)
+
+    for target in no_auto_targets:
+        reachable = _bfs_reachable(ctx.step_graph, target) | {target}
+        for reached in reachable:
+            if _is_auto_flagged_step(reached, ctx):
+                findings.append(
+                    RuleFinding(
+                        rule="merge-enrollment-auto-consistency",
+                        severity=Severity.ERROR,
+                        step_name=reached,
+                        message=(
+                            f"Step '{reached}' uses --auto or toggle_auto_merge but is "
+                            f"reachable from an auto_merge_available=false routing arm "
+                            f"(via '{target}'). Use enqueue_pr instead."
+                        ),
+                    )
+                )
     return findings

--- a/src/autoskillit/recipe/rules_tools.py
+++ b/src/autoskillit/recipe/rules_tools.py
@@ -101,6 +101,18 @@ _TOOL_PARAMS: dict[str, frozenset[str]] = {
             "max_stall_retries",
             "not_in_queue_confirmation_cycles",
             "max_inconclusive_retries",
+            "auto_merge_available",
+            "step_name",
+        }
+    ),
+    "enqueue_pr": frozenset(
+        {
+            "pr_number",
+            "target_branch",
+            "cwd",
+            "auto_merge_available",
+            "repo",
+            "remote_url",
             "step_name",
         }
     ),

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -528,7 +528,7 @@ steps:
     skip_when_false: "inputs.open_pr"
     note: >
       Extracts the integer PR number from the feature branch opened by compose_pr.
-      pr_number is required by the queue finale steps (enable_auto_merge, wait_for_queue).
+      pr_number is required by the queue finale steps (enqueue_to_queue, wait_for_queue).
 
   annotate_pr_diff:
     tool: run_python
@@ -779,45 +779,29 @@ steps:
     on_result:
       - when: "${{ inputs.auto_merge }} != 'true'"
         route: register_clone_success
-      - when: "${{ context.queue_available }} == true and ${{ context.merge_group_trigger }} == true and ${{ context.auto_merge_available }} == true"
-        route: enable_auto_merge
-      - when: "${{ context.queue_available }} == true and ${{ context.merge_group_trigger }} == true and ${{ context.auto_merge_available }} == false"
-        route: queue_enqueue_no_auto
+      - when: "${{ context.queue_available }} == true and ${{ context.merge_group_trigger }} == true"
+        route: enqueue_to_queue
       - when: "${{ context.auto_merge_available }} == true"
         route: direct_merge
       - route: immediate_merge
     skip_when_false: "inputs.open_pr"
 
-  enable_auto_merge:
-    tool: run_cmd
+  enqueue_to_queue:
+    tool: enqueue_pr
     with:
-      cmd: "gh pr merge '${{ context.pr_number }}' --squash --auto"
+      pr_number: "${{ context.pr_number }}"
+      target_branch: "${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
-      step_name: "enable_auto_merge"
+      auto_merge_available: "${{ context.auto_merge_available }}"
     on_success: wait_for_queue
     on_failure: verify_queue_enrollment
     skip_when_false: "inputs.open_pr"
     note: >
-      Submits the PR to the merge queue. On failure, probes the queue via
+      Submits the PR to the merge queue via the unified enqueue_pr tool.
+      The tool resolves the enrollment strategy internally based on
+      auto_merge_available. On failure, probes the queue via
       verify_queue_enrollment to distinguish a transient enqueue error from a
       PR that is already merged or still in queue.
-
-  queue_enqueue_no_auto:
-    tool: run_cmd
-    with:
-      cmd: "gh pr merge '${{ context.pr_number }}' --squash"
-      cwd: "${{ context.work_dir }}"
-      step_name: "queue_enqueue_no_auto"
-    on_success: wait_for_queue
-    on_failure: verify_queue_enrollment
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Submits the PR to the merge queue when the target branch has a configured
-      merge queue but the repository disallows auto-merge (autoMergeAllowed=false).
-      Uses plain `gh pr merge --squash` (no --auto, which would be rejected by
-      GitHub's API auto-merge gate). GitHub intercepts the call and enqueues
-      the PR because the branch has a queue. On failure, probes the queue via
-      verify_queue_enrollment before escalating.
 
   verify_queue_enrollment:
     description: "Probe merge queue after enqueue command failure to determine actual state"
@@ -834,6 +818,8 @@ steps:
         route: release_issue_success
       - when: "${{ result.pr_state }} == ejected_ci_failure"
         route: diagnose_ci
+      - when: "${{ result.pr_state }} == not_enrolled"
+        route: release_issue_failure
       - when: "${{ result.pr_state }} == dropped_healthy"
         route: wait_for_queue
       - when: "${{ result.pr_state }} == ejected"
@@ -845,14 +831,14 @@ steps:
       - route: register_clone_unconfirmed
     on_failure: register_clone_unconfirmed
     note: >
-      Short probe (60s) after enable_auto_merge or queue_enqueue_no_auto failure.
-      If the PR is already merged, route to release_issue_success. If the queue
-      already confirms CI failure (ejected_ci_failure), route directly to
-      diagnose_ci — the PR is already ejected and the 900s wait_for_queue watch
-      would only confirm the same state before escalating. For other active queue
-      states (dropped_healthy, ejected, stalled), route to wait_for_queue for
-      full 900s authoritative watch. If the probe timed out or returned an
-      unexpected state, escalate via register_clone_unconfirmed.
+      Short probe (60s) after enqueue_to_queue failure. If the PR is already
+      merged, route to release_issue_success. If the queue already confirms CI
+      failure (ejected_ci_failure), route directly to diagnose_ci. If enrollment
+      was attempted but the PR never appeared in the queue (not_enrolled), route
+      to release_issue_failure — this is a repo configuration error. For other
+      active queue states (dropped_healthy, ejected, stalled), route to
+      wait_for_queue for full 900s authoritative watch. If the probe timed out
+      or returned an unexpected state, escalate via register_clone_unconfirmed.
 
   wait_for_queue:
     tool: wait_for_merge_queue
@@ -869,6 +855,8 @@ steps:
         route: release_issue_success
       - when: "${{ result.pr_state }} == ejected_ci_failure"
         route: diagnose_ci
+      - when: "${{ result.pr_state }} == not_enrolled"
+        route: release_issue_failure
       - when: "${{ result.pr_state }} == dropped_healthy"
         route: reenter_merge_queue_cheap
       - when: "${{ result.pr_state }} == ejected"
@@ -884,16 +872,18 @@ steps:
       Waits up to 15 minutes for the PR to merge through the queue.
       merged → release_issue_success to transition issue state then register_clone_success.
       ejected_ci_failure → diagnose_ci (CI failure; conflict resolution cannot fix this).
+      not_enrolled → release_issue_failure (enrollment failed; repo configuration error).
       ejected → conflict fix cycle then re-enter.
-      stalled → lightweight re-enrollment (disable then re-enable auto-merge).
+      stalled → lightweight re-enrollment via enqueue_pr.
       timeout → register_clone_unconfirmed (release claim without staged label; merge unconfirmed).
 
   reenroll_stalled_pr:
-    tool: toggle_auto_merge
+    tool: enqueue_pr
     with:
       pr_number: "${{ context.pr_number }}"
       target_branch: "${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
+      auto_merge_available: "${{ context.auto_merge_available }}"
     on_success: wait_for_queue
     on_failure: release_issue_failure
     skip_when_false: "inputs.open_pr"
@@ -973,11 +963,12 @@ steps:
       on CI failure. Prevents re-entering the merge queue with a broken manifest or code.
 
   reenter_merge_queue:
-    tool: run_cmd
+    tool: enqueue_pr
     with:
-      cmd: "gh pr merge '${{ context.pr_number }}' --squash --auto"
+      pr_number: "${{ context.pr_number }}"
+      target_branch: "${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
-      step_name: "reenter_merge_queue"
+      auto_merge_available: "${{ context.auto_merge_available }}"
     on_success: wait_for_queue
     on_failure: release_issue_failure
     skip_when_false: "inputs.open_pr"
@@ -986,11 +977,12 @@ steps:
       If re-entry fails, release_issue_failure preserves the clone for debugging.
 
   reenter_merge_queue_cheap:
-    tool: run_cmd
+    tool: enqueue_pr
     with:
-      cmd: "gh pr merge '${{ context.pr_number }}' --squash --auto"
+      pr_number: "${{ context.pr_number }}"
+      target_branch: "${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
-      step_name: "reenter_merge_queue_cheap"
+      auto_merge_available: "${{ context.auto_merge_available }}"
     on_success: wait_for_queue
     on_failure: release_issue_failure
     skip_when_false: "inputs.open_pr"

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -699,45 +699,29 @@ steps:
     on_result:
       - when: "${{ inputs.auto_merge }} != 'true'"
         route: register_clone_success
-      - when: "${{ context.queue_available }} == true and ${{ context.merge_group_trigger }} == true and ${{ context.auto_merge_available }} == true"
-        route: enable_auto_merge
-      - when: "${{ context.queue_available }} == true and ${{ context.merge_group_trigger }} == true and ${{ context.auto_merge_available }} == false"
-        route: queue_enqueue_no_auto
+      - when: "${{ context.queue_available }} == true and ${{ context.merge_group_trigger }} == true"
+        route: enqueue_to_queue
       - when: "${{ context.auto_merge_available }} == true"
         route: direct_merge
       - route: immediate_merge
     skip_when_false: "inputs.open_pr"
 
-  enable_auto_merge:
-    tool: run_cmd
+  enqueue_to_queue:
+    tool: enqueue_pr
     with:
-      cmd: "gh pr merge '${{ context.pr_number }}' --squash --auto"
+      pr_number: "${{ context.pr_number }}"
+      target_branch: "${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
-      step_name: "enable_auto_merge"
+      auto_merge_available: "${{ context.auto_merge_available }}"
     on_success: wait_for_queue
     on_failure: verify_queue_enrollment
     skip_when_false: "inputs.open_pr"
     note: >
-      Submits the PR to the merge queue. On failure, probes the queue via
+      Submits the PR to the merge queue via the unified enqueue_pr tool.
+      The tool resolves the enrollment strategy internally based on
+      auto_merge_available. On failure, probes the queue via
       verify_queue_enrollment to distinguish a transient enqueue error from a
       PR that is already merged or still in queue.
-
-  queue_enqueue_no_auto:
-    tool: run_cmd
-    with:
-      cmd: "gh pr merge '${{ context.pr_number }}' --squash"
-      cwd: "${{ context.work_dir }}"
-      step_name: "queue_enqueue_no_auto"
-    on_success: wait_for_queue
-    on_failure: verify_queue_enrollment
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Submits the PR to the merge queue when the target branch has a configured
-      merge queue but the repository disallows auto-merge (autoMergeAllowed=false).
-      Uses plain `gh pr merge --squash` (no --auto, which would be rejected by
-      GitHub's API auto-merge gate). GitHub intercepts the call and enqueues
-      the PR because the branch has a queue. On failure, probes the queue via
-      verify_queue_enrollment before escalating.
 
   verify_queue_enrollment:
     description: "Probe merge queue after enqueue command failure to determine actual state"
@@ -754,6 +738,8 @@ steps:
         route: release_issue_success
       - when: "${{ result.pr_state }} == ejected_ci_failure"
         route: diagnose_ci
+      - when: "${{ result.pr_state }} == not_enrolled"
+        route: release_issue_failure
       - when: "${{ result.pr_state }} == dropped_healthy"
         route: wait_for_queue
       - when: "${{ result.pr_state }} == ejected"
@@ -765,14 +751,14 @@ steps:
       - route: register_clone_unconfirmed
     on_failure: register_clone_unconfirmed
     note: >
-      Short probe (60s) after enable_auto_merge or queue_enqueue_no_auto failure.
-      If the PR is already merged, route to release_issue_success. If the queue
-      already confirms CI failure (ejected_ci_failure), route directly to
-      diagnose_ci — the PR is already ejected and the 900s wait_for_queue watch
-      would only confirm the same state before escalating. For other active queue
-      states (dropped_healthy, ejected, stalled), route to wait_for_queue for
-      full 900s authoritative watch. If the probe timed out or returned an
-      unexpected state, escalate via register_clone_unconfirmed.
+      Short probe (60s) after enqueue_to_queue failure. If the PR is already
+      merged, route to release_issue_success. If the queue already confirms CI
+      failure (ejected_ci_failure), route directly to diagnose_ci. If enrollment
+      was attempted but the PR never appeared in the queue (not_enrolled), route
+      to release_issue_failure — this is a repo configuration error. For other
+      active queue states (dropped_healthy, ejected, stalled), route to
+      wait_for_queue for full 900s authoritative watch. If the probe timed out
+      or returned an unexpected state, escalate via register_clone_unconfirmed.
 
   wait_for_queue:
     tool: wait_for_merge_queue
@@ -789,6 +775,8 @@ steps:
         route: release_issue_success
       - when: "${{ result.pr_state }} == ejected_ci_failure"
         route: diagnose_ci
+      - when: "${{ result.pr_state }} == not_enrolled"
+        route: release_issue_failure
       - when: "${{ result.pr_state }} == dropped_healthy"
         route: reenter_merge_queue_cheap
       - when: "${{ result.pr_state }} == ejected"
@@ -804,16 +792,18 @@ steps:
       Waits up to 15 minutes for the PR to merge through the queue.
       merged → release_issue_success to transition issue state then register_clone_success.
       ejected_ci_failure → diagnose_ci (CI failure; conflict resolution cannot fix this).
+      not_enrolled → release_issue_failure (enrollment failed; repo configuration error).
       ejected → conflict fix cycle then re-enter.
-      stalled → lightweight re-enrollment (disable then re-enable auto-merge).
+      stalled → lightweight re-enrollment via enqueue_pr.
       timeout → register_clone_unconfirmed (release claim without staged label; merge unconfirmed).
 
   reenroll_stalled_pr:
-    tool: toggle_auto_merge
+    tool: enqueue_pr
     with:
       pr_number: "${{ context.pr_number }}"
       target_branch: "${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
+      auto_merge_available: "${{ context.auto_merge_available }}"
     on_success: wait_for_queue
     on_failure: release_issue_failure
     skip_when_false: "inputs.open_pr"
@@ -893,11 +883,12 @@ steps:
       on CI failure. Prevents re-entering the merge queue with a broken manifest or code.
 
   reenter_merge_queue:
-    tool: run_cmd
+    tool: enqueue_pr
     with:
-      cmd: "gh pr merge '${{ context.pr_number }}' --squash --auto"
+      pr_number: "${{ context.pr_number }}"
+      target_branch: "${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
-      step_name: "reenter_merge_queue"
+      auto_merge_available: "${{ context.auto_merge_available }}"
     on_success: wait_for_queue
     on_failure: release_issue_failure
     skip_when_false: "inputs.open_pr"
@@ -906,11 +897,12 @@ steps:
       If re-entry fails, release_issue_failure preserves the clone for debugging.
 
   reenter_merge_queue_cheap:
-    tool: run_cmd
+    tool: enqueue_pr
     with:
-      cmd: "gh pr merge '${{ context.pr_number }}' --squash --auto"
+      pr_number: "${{ context.pr_number }}"
+      target_branch: "${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
-      step_name: "reenter_merge_queue_cheap"
+      auto_merge_available: "${{ context.auto_merge_available }}"
     on_success: wait_for_queue
     on_failure: release_issue_failure
     skip_when_false: "inputs.open_pr"

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -117,6 +117,7 @@ steps:
       step_name: "check_repo_ci_event"
     capture:
       ci_event: "${{ result.ci_event }}"
+      auto_merge_available: "${{ result.auto_merge_available }}"
     on_success: check_integration_exists
     on_failure: check_integration_exists
     note: >
@@ -230,17 +231,19 @@ steps:
       context.current_pr_number before the sequential enqueue loop.
 
   enqueue_current_pr:
-    tool: run_cmd
+    tool: enqueue_pr
     with:
-      cmd: "gh pr merge '${{ context.current_pr_number }}' --squash --auto"
+      pr_number: "${{ context.current_pr_number }}"
+      target_branch: "${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
-      step_name: "enqueue_current_pr"
+      auto_merge_available: "${{ context.auto_merge_available }}"
     on_success: wait_queue_pr
     on_failure: register_clone_failure
     note: >
-      Queue mode only. Submits a single PR to the merge queue. Called once per PR
-      in the sequential enqueue loop: get_first_pr_number → enqueue_current_pr →
-      wait_queue_pr → (merged) → advance_queue_pr → enqueue_current_pr → ...
+      Queue mode only. Submits a single PR to the merge queue via the unified
+      enqueue_pr tool. Called once per PR in the sequential enqueue loop:
+      get_first_pr_number → enqueue_current_pr → wait_queue_pr → (merged) →
+      advance_queue_pr → enqueue_current_pr → ...
 
   wait_queue_pr:
     tool: wait_for_merge_queue
@@ -257,6 +260,8 @@ steps:
         route: advance_queue_pr
       - when: "${{ result.pr_state }} == ejected_ci_failure"
         route: diagnose_queue_ci
+      - when: "${{ result.pr_state }} == not_enrolled"
+        route: register_clone_failure
       - when: "${{ result.pr_state }} == ejected"
         route: get_ejected_pr_branch
       - when: "${{ result.pr_state }} == stalled"
@@ -353,11 +358,12 @@ steps:
       Uses context.ci_event captured from check_repo_ci_event upstream.
 
   reenter_queue:
-    tool: run_cmd
+    tool: enqueue_pr
     with:
-      cmd: "gh pr merge '${{ context.current_pr_number }}' --squash --auto"
+      pr_number: "${{ context.current_pr_number }}"
+      target_branch: "${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
-      step_name: "reenter_queue"
+      auto_merge_available: "${{ context.auto_merge_available }}"
     on_success: wait_queue_pr
     on_failure: register_clone_failure
     note: >
@@ -408,16 +414,16 @@ steps:
       auto-recoverable without human intervention.
 
   reenroll_stalled_queue_pr:
-    tool: toggle_auto_merge
+    tool: enqueue_pr
     with:
       pr_number: "${{ context.current_pr_number }}"
       target_branch: "${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
+      auto_merge_available: "${{ context.auto_merge_available }}"
     on_success: wait_queue_pr
     on_failure: register_clone_failure
     note: >
-      Uses the dedicated toggle_auto_merge tool (matching the proven pattern in
-      implementation.yaml's reenroll_stalled_pr) to re-enroll a stalled PR in the
+      Uses the unified enqueue_pr tool to re-enroll a stalled PR in the
       merge queue. Routes back to wait_queue_pr to resume monitoring.
 
   create_integration_branch:

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -688,45 +688,29 @@ steps:
     on_result:
       - when: "${{ inputs.auto_merge }} != 'true'"
         route: register_clone_success
-      - when: "${{ context.queue_available }} == true and ${{ context.merge_group_trigger }} == true and ${{ context.auto_merge_available }} == true"
-        route: enable_auto_merge
-      - when: "${{ context.queue_available }} == true and ${{ context.merge_group_trigger }} == true and ${{ context.auto_merge_available }} == false"
-        route: queue_enqueue_no_auto
+      - when: "${{ context.queue_available }} == true and ${{ context.merge_group_trigger }} == true"
+        route: enqueue_to_queue
       - when: "${{ context.auto_merge_available }} == true"
         route: direct_merge
       - route: immediate_merge
     skip_when_false: "inputs.open_pr"
 
-  enable_auto_merge:
-    tool: run_cmd
+  enqueue_to_queue:
+    tool: enqueue_pr
     with:
-      cmd: "gh pr merge '${{ context.pr_number }}' --squash --auto"
+      pr_number: "${{ context.pr_number }}"
+      target_branch: "${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
-      step_name: "enable_auto_merge"
+      auto_merge_available: "${{ context.auto_merge_available }}"
     on_success: wait_for_queue
     on_failure: verify_queue_enrollment
     skip_when_false: "inputs.open_pr"
     note: >
-      Submits the PR to the merge queue. On failure, probes the queue via
+      Submits the PR to the merge queue via the unified enqueue_pr tool.
+      The tool resolves the enrollment strategy internally based on
+      auto_merge_available. On failure, probes the queue via
       verify_queue_enrollment to distinguish a transient enqueue error from a
       PR that is already merged or still in queue.
-
-  queue_enqueue_no_auto:
-    tool: run_cmd
-    with:
-      cmd: "gh pr merge '${{ context.pr_number }}' --squash"
-      cwd: "${{ context.work_dir }}"
-      step_name: "queue_enqueue_no_auto"
-    on_success: wait_for_queue
-    on_failure: verify_queue_enrollment
-    skip_when_false: "inputs.open_pr"
-    note: >
-      Submits the PR to the merge queue when the target branch has a configured
-      merge queue but the repository disallows auto-merge (autoMergeAllowed=false).
-      Uses plain `gh pr merge --squash` (no --auto, which would be rejected by
-      GitHub's API auto-merge gate). GitHub intercepts the call and enqueues
-      the PR because the branch has a queue. On failure, probes the queue via
-      verify_queue_enrollment before escalating.
 
   verify_queue_enrollment:
     description: "Probe merge queue after enqueue command failure to determine actual state"
@@ -743,6 +727,8 @@ steps:
         route: release_issue_success
       - when: "${{ result.pr_state }} == ejected_ci_failure"
         route: diagnose_ci
+      - when: "${{ result.pr_state }} == not_enrolled"
+        route: release_issue_failure
       - when: "${{ result.pr_state }} == dropped_healthy"
         route: wait_for_queue
       - when: "${{ result.pr_state }} == ejected"
@@ -754,14 +740,14 @@ steps:
       - route: register_clone_unconfirmed
     on_failure: register_clone_unconfirmed
     note: >
-      Short probe (60s) after enable_auto_merge or queue_enqueue_no_auto failure.
-      If the PR is already merged, route to release_issue_success. If the queue
-      already confirms CI failure (ejected_ci_failure), route directly to
-      diagnose_ci — the PR is already ejected and the 900s wait_for_queue watch
-      would only confirm the same state before escalating. For other active queue
-      states (dropped_healthy, ejected, stalled), route to wait_for_queue for
-      full 900s authoritative watch. If the probe timed out or returned an
-      unexpected state, escalate via register_clone_unconfirmed.
+      Short probe (60s) after enqueue_to_queue failure. If the PR is already
+      merged, route to release_issue_success. If the queue already confirms CI
+      failure (ejected_ci_failure), route directly to diagnose_ci. If enrollment
+      was attempted but the PR never appeared in the queue (not_enrolled), route
+      to release_issue_failure — this is a repo configuration error. For other
+      active queue states (dropped_healthy, ejected, stalled), route to
+      wait_for_queue for full 900s authoritative watch. If the probe timed out
+      or returned an unexpected state, escalate via register_clone_unconfirmed.
 
   wait_for_queue:
     tool: wait_for_merge_queue
@@ -778,6 +764,8 @@ steps:
         route: release_issue_success
       - when: "${{ result.pr_state }} == ejected_ci_failure"
         route: diagnose_ci
+      - when: "${{ result.pr_state }} == not_enrolled"
+        route: release_issue_failure
       - when: "${{ result.pr_state }} == dropped_healthy"
         route: reenter_merge_queue_cheap
       - when: "${{ result.pr_state }} == ejected"
@@ -795,16 +783,18 @@ steps:
       release_issue_success is optional with skip_when_false: inputs.issue_url — when
       issue_url is absent the step is silently skipped and pipeline continues to register_clone_success.
       ejected_ci_failure → diagnose_ci (CI failure; conflict resolution cannot fix this).
+      not_enrolled → release_issue_failure (enrollment failed; repo configuration error).
       ejected → conflict fix cycle then re-enter.
-      stalled → lightweight re-enrollment (disable then re-enable auto-merge).
+      stalled → lightweight re-enrollment via enqueue_pr.
       timeout → register_clone_unconfirmed (release claim without staged label; merge unconfirmed).
 
   reenroll_stalled_pr:
-    tool: toggle_auto_merge
+    tool: enqueue_pr
     with:
       pr_number: "${{ context.pr_number }}"
       target_branch: "${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
+      auto_merge_available: "${{ context.auto_merge_available }}"
     on_success: wait_for_queue
     on_failure: release_issue_failure
     skip_when_false: "inputs.open_pr"
@@ -884,11 +874,12 @@ steps:
       on CI failure. Prevents re-entering the merge queue with a broken manifest or code.
 
   reenter_merge_queue:
-    tool: run_cmd
+    tool: enqueue_pr
     with:
-      cmd: "gh pr merge '${{ context.pr_number }}' --squash --auto"
+      pr_number: "${{ context.pr_number }}"
+      target_branch: "${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
-      step_name: "reenter_merge_queue"
+      auto_merge_available: "${{ context.auto_merge_available }}"
     on_success: wait_for_queue
     on_failure: release_issue_failure
     skip_when_false: "inputs.open_pr"
@@ -897,11 +888,12 @@ steps:
       If re-entry fails, release_issue_failure preserves the clone for debugging.
 
   reenter_merge_queue_cheap:
-    tool: run_cmd
+    tool: enqueue_pr
     with:
-      cmd: "gh pr merge '${{ context.pr_number }}' --squash --auto"
+      pr_number: "${{ context.pr_number }}"
+      target_branch: "${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
-      step_name: "reenter_merge_queue_cheap"
+      auto_merge_available: "${{ context.auto_merge_available }}"
     on_success: wait_for_queue
     on_failure: release_issue_failure
     skip_when_false: "inputs.open_pr"

--- a/src/autoskillit/server/__init__.py
+++ b/src/autoskillit/server/__init__.py
@@ -1,6 +1,6 @@
 """MCP server for orchestrating automated skill-driven workflows.
 
-Kitchen tools (42 kitchen-tagged: 41 gated + 1 headless-tagged) are hidden at startup
+Kitchen tools (43 kitchen-tagged: 42 gated + 1 headless-tagged) are hidden at startup
 via FastMCP v3 mcp.disable(tags={'kitchen'}) applied once after all tool modules are
 imported. Each new session sees only the 3 free-range tools (open_kitchen, close_kitchen,
 and disable_quota_guard).

--- a/src/autoskillit/server/tools_ci.py
+++ b/src/autoskillit/server/tools_ci.py
@@ -377,6 +377,88 @@ async def toggle_auto_merge(
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "ci"}, annotations={"readOnlyHint": False})
+@track_response_size("enqueue_pr")
+async def enqueue_pr(
+    pr_number: int,
+    target_branch: str,
+    cwd: str,
+    auto_merge_available: bool,
+    repo: str = "",
+    remote_url: str = "",
+    step_name: str = "",
+    ctx: Context = CurrentContext(),
+) -> str:
+    """Enqueue a PR into the merge queue using the correct enrollment strategy.
+
+    Uses enablePullRequestAutoMerge when auto_merge_available=true,
+    enqueuePullRequest GraphQL mutation when auto_merge_available=false.
+
+    Args:
+        pr_number: PR number to enqueue.
+        target_branch: Branch the merge queue targets (e.g. "integration").
+        cwd: Working directory for git remote resolution when repo is not provided.
+        auto_merge_available: Whether the repository allows auto-merge.
+        repo: Optional "owner/name" string. Inferred from git remote if empty.
+        remote_url: Full GitHub remote URL. Parsed to owner/repo before inference.
+        step_name: Optional YAML step key for wall-clock timing accumulation.
+
+    Returns:
+        JSON: {"success": bool, "pr_number": int, "enrollment_method": str} on success,
+              {"success": false, "error": str} on failure.
+
+    Never raises.
+    """
+    if (gate := _require_enabled()) is not None:
+        return gate
+    try:
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(
+            tool="enqueue_pr", pr_number=pr_number, target_branch=target_branch
+        )
+        await _notify(
+            ctx,
+            "info",
+            f"Enrolling PR #{pr_number} in merge queue on {target_branch!r}",
+            "autoskillit.enqueue_pr",
+            extra={"pr_number": pr_number, "target_branch": target_branch},
+        )
+
+        from autoskillit.server import _get_ctx
+
+        tool_ctx = _get_ctx()
+
+        if tool_ctx.merge_queue_watcher is None:
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": "merge_queue_watcher not configured (missing GITHUB_TOKEN?)",
+                }
+            )
+
+        resolved_repo = await infer_repo_from_remote(cwd, hint=remote_url or repo or None)
+
+        _start = time.monotonic()
+        try:
+            result = await tool_ctx.merge_queue_watcher.enqueue(
+                pr_number=pr_number,
+                target_branch=target_branch,
+                repo=resolved_repo or None,
+                cwd=cwd,
+                auto_merge_available=auto_merge_available,
+            )
+            return json.dumps(result)
+        except Exception as exc:
+            logger.error("enqueue_pr watcher error", exc_info=True)
+            return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
+        finally:
+            if step_name:
+                tool_ctx.timing_log.record(step_name, time.monotonic() - _start)
+    except Exception as exc:
+        logger.error("enqueue_pr unhandled exception", exc_info=True)
+        return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
+
+
+@mcp.tool(tags={"autoskillit", "kitchen", "ci"}, annotations={"readOnlyHint": False})
 @track_response_size("wait_for_merge_queue")
 async def wait_for_merge_queue(
     pr_number: int,
@@ -390,6 +472,7 @@ async def wait_for_merge_queue(
     max_stall_retries: int = 3,
     not_in_queue_confirmation_cycles: int = 2,
     max_inconclusive_retries: int = 5,
+    auto_merge_available: bool = True,
     step_name: str = "",
     ctx: Context = CurrentContext(),
 ) -> str:
@@ -415,13 +498,15 @@ async def wait_for_merge_queue(
                     queue exit and merged=true propagation (default 2).
         max_inconclusive_retries: Maximum NoPositiveSignal cycles (beyond the
                     confirmation window) before returning pr_state="timeout" (default 5).
+        auto_merge_available: Whether the repository allows auto-merge. When False,
+                    stall recovery uses enqueuePullRequest instead of toggle (default True).
         step_name: Optional YAML step key for wall-clock timing accumulation.
 
     Returns:
         JSON: {
             "success": bool,
             "pr_state": "merged"|"ejected"|"ejected_ci_failure"|"stalled"|
-                        "dropped_healthy"|"timeout"|"error",
+                        "dropped_healthy"|"not_enrolled"|"timeout"|"error",
             "reason": str,
             "stall_retries_attempted": int,
         }
@@ -432,6 +517,7 @@ async def wait_for_merge_queue(
           ejected_ci_failure — PR removed from queue because CI checks failed.
           stalled          — PR stuck in queue; max stall retries exhausted.
           dropped_healthy  — auto-merge disabled on a PR with no CI/conflict issues.
+          not_enrolled     — PR was never enrolled in the merge queue.
           timeout          — polling budget exhausted before a terminal state was reached.
           error            — watcher raised an unexpected exception.
 
@@ -482,6 +568,7 @@ async def wait_for_merge_queue(
                 max_stall_retries=max_stall_retries,
                 not_in_queue_confirmation_cycles=not_in_queue_confirmation_cycles,
                 max_inconclusive_retries=max_inconclusive_retries,
+                auto_merge_available=auto_merge_available,
             )
             return json.dumps(result)
         except Exception as exc:

--- a/src/autoskillit/server/tools_kitchen.py
+++ b/src/autoskillit/server/tools_kitchen.py
@@ -105,6 +105,7 @@ _DISPLAY_CATEGORIES: tuple[tuple[str, tuple[str, ...]], ...] = (
             "wait_for_merge_queue",
             "check_repo_merge_state",
             "toggle_auto_merge",
+            "enqueue_pr",
             "get_ci_status",
         ),
     ),

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -374,6 +374,7 @@ def test_pr_state_enum_members_are_locked():
         PRState.EJECTED_CI_FAILURE,
         PRState.STALLED,
         PRState.DROPPED_HEALTHY,
+        PRState.NOT_ENROLLED,
         PRState.TIMEOUT,
         PRState.ERROR,
     }

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -199,9 +199,9 @@ def _count_semantic_rule_files() -> int:
 # ----- tests ------------------------------------------------------------------
 
 
-def test_kitchen_tagged_tool_count_is_42() -> None:
-    assert _count_kitchen_tools() == 42, (
-        f"Expected 42 kitchen-tagged tools; found {_count_kitchen_tools()}"
+def test_kitchen_tagged_tool_count_is_43() -> None:
+    assert _count_kitchen_tools() == 43, (
+        f"Expected 43 kitchen-tagged tools; found {_count_kitchen_tools()}"
     )
 
 

--- a/tests/execution/test_merge_queue.py
+++ b/tests/execution/test_merge_queue.py
@@ -697,17 +697,33 @@ class TestPendingCIGuard:
         This is the exact issue #802 failure mode: the old elimination classifier returned
         'ejected' for this state because no other gate matched. The new classifier returns
         DROPPED_HEALTHY via positive signal — auto_merge was cleared while the PR was healthy.
+        Requires prior enrollment evidence (auto_merge_present=True in cycle 1).
         """
         watcher = _make_watcher()
-        watcher._fetch_pr_and_queue_state = AsyncMock(  # type: ignore[method-assign]
-            return_value=_queue_state(
+        responses = [
+            _queue_state(
+                in_queue=False,
+                mergeable="MERGEABLE",
+                merge_state_status="CLEAN",
+                checks_state="SUCCESS",
+                auto_merge_present=True,
+            ),
+            _queue_state(
                 in_queue=False,
                 mergeable="MERGEABLE",
                 merge_state_status="CLEAN",
                 checks_state="SUCCESS",
                 auto_merge_present=False,
-            )
-        )
+            ),
+            _queue_state(
+                in_queue=False,
+                mergeable="MERGEABLE",
+                merge_state_status="CLEAN",
+                checks_state="SUCCESS",
+                auto_merge_present=False,
+            ),
+        ]
+        watcher._fetch_pr_and_queue_state = AsyncMock(side_effect=responses)  # type: ignore[method-assign]
         with patch("autoskillit.execution.merge_queue.asyncio.sleep", new_callable=AsyncMock):
             result = await watcher.wait(pr_number=1, target_branch="main", repo="owner/repo")
 
@@ -1256,7 +1272,7 @@ class TestClassifierImmunity:
             in_queue=False,
             auto_merge_present=False,
         )
-        result = _mq._classify_pr_state(state)
+        result = _mq._classify_pr_state(state, ever_enrolled=True)
         assert result.terminal == PRState.DROPPED_HEALTHY
 
     # --- T2: Positive-signal contract: EJECTED requires positive signal ---
@@ -1289,7 +1305,7 @@ class TestClassifierImmunity:
     def test_classifier_never_returns_ejected_without_positive_signal(self, state):
         """For ambiguous-but-healthy states, classifier must NOT return EJECTED."""
         try:
-            result = _mq._classify_pr_state(state)
+            result = _mq._classify_pr_state(state, ever_enrolled=True)
             assert result.terminal != PRState.EJECTED, (
                 f"Classifier returned EJECTED without a positive signal for state: {state}"
             )
@@ -1310,7 +1326,7 @@ class TestClassifierImmunity:
             in_queue=False,
         )
         with pytest.raises(ClassifierInconclusive) as exc_info:
-            _mq._classify_pr_state(state)
+            _mq._classify_pr_state(state, ever_enrolled=True)
         assert exc_info.value.state is state
         assert exc_info.value.reason
 
@@ -1371,7 +1387,7 @@ class TestClassifierImmunity:
         self, expected_terminal, state
     ):
         """Every classifier-reachable PRState terminal has at least one positive fixture."""
-        result = _mq._classify_pr_state(state)
+        result = _mq._classify_pr_state(state, ever_enrolled=True)
         assert result.terminal == expected_terminal
 
     # --- T5: Import-time schema round-trip guard ---
@@ -1532,3 +1548,202 @@ class TestMergeQueueVocabularyContract:
             f"Positive stall statuses not in KNOWN_MQ_MERGE_STATE_STATUSES: "
             f"{positive_stall_statuses - KNOWN_MQ_MERGE_STATE_STATUSES}"
         )
+
+
+# ---------------------------------------------------------------------------
+# PRState.NOT_ENROLLED enum value
+# ---------------------------------------------------------------------------
+
+
+class TestNotEnrolledState:
+    """Tests for the NOT_ENROLLED classifier state and enrollment tracking."""
+
+    def test_pr_state_has_not_enrolled(self):
+        """PRState must include NOT_ENROLLED value."""
+        assert hasattr(PRState, "NOT_ENROLLED")
+        assert PRState.NOT_ENROLLED == "not_enrolled"
+
+    def test_classifier_returns_not_enrolled_when_never_in_queue_and_healthy(self):
+        """A healthy PR with ever_enrolled=False must classify as NOT_ENROLLED."""
+        state = _queue_state(
+            merged=False,
+            state="OPEN",
+            mergeable="MERGEABLE",
+            merge_state_status="CLEAN",
+            checks_state="SUCCESS",
+            in_queue=False,
+            auto_merge_present=False,
+        )
+        result = _mq._classify_pr_state(state, ever_enrolled=False)
+        assert result.terminal == PRState.NOT_ENROLLED
+
+    def test_classifier_returns_dropped_healthy_only_when_ever_enrolled(self):
+        """DROPPED_HEALTHY requires ever_enrolled=True."""
+        state = _queue_state(
+            merged=False,
+            state="OPEN",
+            mergeable="MERGEABLE",
+            merge_state_status="CLEAN",
+            checks_state="SUCCESS",
+            in_queue=False,
+            auto_merge_present=False,
+        )
+        result = _mq._classify_pr_state(state, ever_enrolled=True)
+        assert result.terminal == PRState.DROPPED_HEALTHY
+
+    @pytest.mark.anyio
+    async def test_wait_tracks_ever_enrolled_from_in_queue(self):
+        """wait() sets ever_enrolled=True when in_queue=True is observed."""
+        watcher = _make_watcher()
+        responses = [
+            _queue_state(in_queue=True, queue_state="QUEUED"),
+            _queue_state(
+                in_queue=False,
+                auto_merge_present=False,
+                mergeable="MERGEABLE",
+                merge_state_status="CLEAN",
+                checks_state="SUCCESS",
+            ),
+            _queue_state(
+                in_queue=False,
+                auto_merge_present=False,
+                mergeable="MERGEABLE",
+                merge_state_status="CLEAN",
+                checks_state="SUCCESS",
+            ),
+        ]
+        watcher._fetch_pr_and_queue_state = AsyncMock(side_effect=responses)  # type: ignore[method-assign]
+        with patch("autoskillit.execution.merge_queue.asyncio.sleep", new_callable=AsyncMock):
+            result = await watcher.wait(
+                pr_number=42,
+                target_branch="main",
+                repo="owner/repo",
+                poll_interval=1,
+                not_in_queue_confirmation_cycles=2,
+            )
+        assert result["pr_state"] == "dropped_healthy"
+
+    @pytest.mark.anyio
+    async def test_wait_tracks_ever_enrolled_from_auto_merge_present(self):
+        """wait() sets ever_enrolled=True when auto_merge_present=True is observed."""
+        watcher = _make_watcher()
+        responses = [
+            _queue_state(in_queue=False, auto_merge_present=True),
+            _queue_state(
+                in_queue=False,
+                auto_merge_present=False,
+                mergeable="MERGEABLE",
+                merge_state_status="CLEAN",
+                checks_state="SUCCESS",
+            ),
+            _queue_state(
+                in_queue=False,
+                auto_merge_present=False,
+                mergeable="MERGEABLE",
+                merge_state_status="CLEAN",
+                checks_state="SUCCESS",
+            ),
+        ]
+        watcher._fetch_pr_and_queue_state = AsyncMock(side_effect=responses)  # type: ignore[method-assign]
+        with patch("autoskillit.execution.merge_queue.asyncio.sleep", new_callable=AsyncMock):
+            result = await watcher.wait(
+                pr_number=42,
+                target_branch="main",
+                repo="owner/repo",
+                poll_interval=1,
+                not_in_queue_confirmation_cycles=2,
+            )
+        assert result["pr_state"] == "dropped_healthy"
+
+    @pytest.mark.anyio
+    async def test_wait_returns_not_enrolled_when_enrollment_never_observed(self):
+        """wait() returns NOT_ENROLLED when healthy PR never shows enrollment evidence."""
+        watcher = _make_watcher()
+        healthy_state = _queue_state(
+            in_queue=False,
+            auto_merge_present=False,
+            mergeable="MERGEABLE",
+            merge_state_status="CLEAN",
+            checks_state="SUCCESS",
+        )
+        watcher._fetch_pr_and_queue_state = AsyncMock(  # type: ignore[method-assign]
+            return_value=healthy_state,
+        )
+        with patch("autoskillit.execution.merge_queue.asyncio.sleep", new_callable=AsyncMock):
+            result = await watcher.wait(
+                pr_number=42,
+                target_branch="main",
+                repo="owner/repo",
+                poll_interval=1,
+                not_in_queue_confirmation_cycles=2,
+            )
+        assert result["pr_state"] == "not_enrolled"
+        assert result["success"] is False
+
+
+# ---------------------------------------------------------------------------
+# enqueue() method tests
+# ---------------------------------------------------------------------------
+
+
+class TestEnqueueMethod:
+    """Tests for DefaultMergeQueueWatcher.enqueue() enrollment strategy."""
+
+    @pytest.mark.anyio
+    async def test_enqueue_uses_enqueue_pr_mutation_when_auto_merge_unavailable(self):
+        """When auto_merge_available=False, enqueue() must call enqueuePullRequest."""
+        watcher = _make_watcher()
+        watcher._fetch_pr_and_queue_state = AsyncMock(  # type: ignore[method-assign]
+            return_value=_queue_state(pr_node_id="PR_kwDO_test123"),
+        )
+        posted_bodies: list[str] = []
+
+        async def _mock_post(*args, **kwargs):
+            body = kwargs.get("json", {})
+            posted_bodies.append(body.get("query", ""))
+            return httpx.Response(
+                200,
+                json={"data": {"enqueuePullRequest": {"mergeQueueEntry": {"id": "MQE_1"}}}},
+                request=httpx.Request("POST", "http://x"),
+            )
+
+        watcher._client.post = _mock_post  # type: ignore[method-assign]
+        result = await watcher.enqueue(
+            pr_number=42,
+            target_branch="main",
+            repo="owner/repo",
+            auto_merge_available=False,
+        )
+        assert result["success"] is True
+        assert result["enrollment_method"] == "direct_enqueue"
+        assert any("enqueuePullRequest" in b for b in posted_bodies)
+        assert not any("enablePullRequestAutoMerge" in b for b in posted_bodies)
+
+    @pytest.mark.anyio
+    async def test_enqueue_uses_auto_merge_mutation_when_auto_merge_available(self):
+        """When auto_merge_available=True, enqueue() must call enablePullRequestAutoMerge."""
+        watcher = _make_watcher()
+        watcher._fetch_pr_and_queue_state = AsyncMock(  # type: ignore[method-assign]
+            return_value=_queue_state(pr_node_id="PR_kwDO_test123"),
+        )
+        posted_bodies: list[str] = []
+
+        async def _mock_post(*args, **kwargs):
+            body = kwargs.get("json", {})
+            posted_bodies.append(body.get("query", ""))
+            return httpx.Response(
+                200,
+                json={"data": {"enablePullRequestAutoMerge": {"pullRequest": {"number": 42}}}},
+                request=httpx.Request("POST", "http://x"),
+            )
+
+        watcher._client.post = _mock_post  # type: ignore[method-assign]
+        result = await watcher.enqueue(
+            pr_number=42,
+            target_branch="main",
+            repo="owner/repo",
+            auto_merge_available=True,
+        )
+        assert result["success"] is True
+        assert result["enrollment_method"] == "auto_merge"
+        assert any("enablePullRequestAutoMerge" in b for b in posted_bodies)

--- a/tests/execution/test_merge_queue.py
+++ b/tests/execution/test_merge_queue.py
@@ -1747,3 +1747,4 @@ class TestEnqueueMethod:
         assert result["success"] is True
         assert result["enrollment_method"] == "auto_merge"
         assert any("enablePullRequestAutoMerge" in b for b in posted_bodies)
+        assert not any("enqueuePullRequest" in b for b in posted_bodies)

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -451,6 +451,7 @@ class InMemoryMergeQueueWatcher(MergeQueueWatcher):
         self,
         wait_result: dict[str, Any] | None = None,
         toggle_result: dict[str, Any] | None = None,
+        enqueue_result: dict[str, Any] | None = None,
     ) -> None:
         self._wait_result = wait_result or {
             "success": True,
@@ -458,10 +459,17 @@ class InMemoryMergeQueueWatcher(MergeQueueWatcher):
             "reason": "PR merged",
         }
         self._toggle_result = toggle_result or {"success": True, "toggled": True}
+        self._enqueue_result = enqueue_result or {
+            "success": True,
+            "pr_number": 0,
+            "enrollment_method": "auto_merge",
+        }
         self.wait_calls: list[dict[str, Any]] = []
         self.toggle_calls: list[dict[str, Any]] = []
+        self.enqueue_calls: list[dict[str, Any]] = []
         self.wait_side_effect: Any | None = None
         self.toggle_side_effect: Any | None = None
+        self.enqueue_side_effect: Any | None = None
 
     async def wait(
         self,
@@ -475,6 +483,7 @@ class InMemoryMergeQueueWatcher(MergeQueueWatcher):
         max_stall_retries: int = 3,
         not_in_queue_confirmation_cycles: int = 2,
         max_inconclusive_retries: int = 5,
+        auto_merge_available: bool = True,
     ) -> dict[str, Any]:
         self.wait_calls.append(
             {
@@ -484,6 +493,7 @@ class InMemoryMergeQueueWatcher(MergeQueueWatcher):
                 "cwd": cwd,
                 "timeout_seconds": timeout_seconds,
                 "poll_interval": poll_interval,
+                "auto_merge_available": auto_merge_available,
             }
         )
         if self.wait_side_effect is not None:
@@ -508,6 +518,27 @@ class InMemoryMergeQueueWatcher(MergeQueueWatcher):
         if self.toggle_side_effect is not None:
             return _resolve_side_effect(self.toggle_side_effect)
         return self._toggle_result
+
+    async def enqueue(
+        self,
+        pr_number: int,
+        target_branch: str,
+        repo: str | None = None,
+        cwd: str = ".",
+        auto_merge_available: bool = True,
+    ) -> dict[str, Any]:
+        self.enqueue_calls.append(
+            {
+                "pr_number": pr_number,
+                "target_branch": target_branch,
+                "repo": repo,
+                "cwd": cwd,
+                "auto_merge_available": auto_merge_available,
+            }
+        )
+        if self.enqueue_side_effect is not None:
+            return _resolve_side_effect(self.enqueue_side_effect)
+        return self._enqueue_result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -127,8 +127,8 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _lifespan.py — hooks.json self-heal on startup drift (co-owned with Claude plugin system)
     ("src/autoskillit/server/_lifespan.py", 56),
     # tools_kitchen.py — hook config dict
-    ("src/autoskillit/server/tools_kitchen.py", 179),
-    ("src/autoskillit/server/tools_kitchen.py", 587),
+    ("src/autoskillit/server/tools_kitchen.py", 180),
+    ("src/autoskillit/server/tools_kitchen.py", 588),
     # tools_status.py — mcp_data dict
     ("src/autoskillit/server/tools_status.py", 400),
     # tools_github.py — bug report dict

--- a/tests/pipeline/test_gate.py
+++ b/tests/pipeline/test_gate.py
@@ -36,6 +36,7 @@ def test_gated_tools_contains_expected_names():
         "wait_for_merge_queue",
         "check_repo_merge_state",
         "toggle_auto_merge",
+        "enqueue_pr",
         # formerly ungated — now kitchen-gated:
         "fetch_github_issue",
         "get_issue_title",

--- a/tests/recipe/test_merge_prs_queue.py
+++ b/tests/recipe/test_merge_prs_queue.py
@@ -1319,7 +1319,9 @@ def test_wait_for_direct_merge_on_failure_routes_to_register_clone_unconfirmed(
 # T9: Full routing parity — every PRState covered (universal + family-specific)
 # ---------------------------------------------------------------------------
 
-_REQUIRED_PR_STATE_VALUES = frozenset(s.value for s in PRState if s is not PRState.ERROR)
+_REQUIRED_PR_STATE_VALUES = frozenset(
+    s.value for s in PRState if s not in {PRState.ERROR, PRState.NOT_ENROLLED}
+)
 _PR_STATE_WHEN_RE = re.compile(r"\$\{\{\s*result\.pr_state\s*\}\}\s*==\s*(\w+)")
 
 

--- a/tests/recipe/test_merge_prs_queue.py
+++ b/tests/recipe/test_merge_prs_queue.py
@@ -1345,7 +1345,9 @@ def test_wait_for_direct_merge_on_failure_routes_to_register_clone_unconfirmed(
 # T9: Full routing parity — every PRState covered (universal + family-specific)
 # ---------------------------------------------------------------------------
 
-_REQUIRED_PR_STATE_VALUES = frozenset(s.value for s in PRState if s != PRState.ERROR)
+_REQUIRED_PR_STATE_VALUES = frozenset(
+    s.value for s in PRState if s not in {PRState.ERROR, PRState.NOT_ENROLLED}
+)
 _PR_STATE_WHEN_RE = re.compile(r"\$\{\{\s*result\.pr_state\s*\}\}\s*==\s*(\w+)")
 
 

--- a/tests/recipe/test_merge_prs_queue.py
+++ b/tests/recipe/test_merge_prs_queue.py
@@ -1178,7 +1178,7 @@ def test_reenroll_stalled_pr_uses_enqueue_pr_tool(any_recipe) -> None:
 
 
 def test_no_gh_pr_merge_in_queue_enrollment_steps(any_recipe) -> None:
-    """No queue enrollment or re-entry step should contain 'gh pr merge' in its cmd."""
+    """Every enrollment step must use enqueue_pr (not run_cmd with gh pr merge)."""
     enrollment_steps = [
         "enqueue_to_queue",
         "reenter_merge_queue",
@@ -1187,7 +1187,12 @@ def test_no_gh_pr_merge_in_queue_enrollment_steps(any_recipe) -> None:
     ]
     for step_name in enrollment_steps:
         step = any_recipe.steps.get(step_name)
-        if step and step.tool == "run_cmd":
+        if step is None:
+            continue
+        assert step.tool == "enqueue_pr", (
+            f"{step_name} must use enqueue_pr tool, got {step.tool!r}"
+        )
+        if step.tool == "run_cmd":
             cmd = step.with_args.get("cmd", "")
             assert "gh pr merge" not in cmd, f"{step_name} must not use gh pr merge"
 

--- a/tests/recipe/test_merge_prs_queue.py
+++ b/tests/recipe/test_merge_prs_queue.py
@@ -69,10 +69,10 @@ def test_merge_prs_route_by_queue_mode_is_route_action(pmp_recipe) -> None:
 
 
 def test_merge_prs_enqueue_current_pr_exists(pmp_recipe) -> None:
-    """enqueue_current_pr step must exist with tool=run_cmd."""
+    """enqueue_current_pr step must exist with tool=enqueue_pr."""
     assert "enqueue_current_pr" in pmp_recipe.steps
     step = pmp_recipe.steps["enqueue_current_pr"]
-    assert step.tool == "run_cmd"
+    assert step.tool == "enqueue_pr"
 
 
 def test_merge_prs_wait_queue_pr_exists(pmp_recipe) -> None:
@@ -150,12 +150,10 @@ def test_merge_prs_enqueue_current_pr_routes_to_wait(pmp_recipe) -> None:
 
 
 def test_merge_prs_enqueue_current_pr_references_single_pr(pmp_recipe) -> None:
-    """enqueue_current_pr cmd must reference context.current_pr_number (no batch loop)."""
+    """enqueue_current_pr must reference context.current_pr_number (no batch loop)."""
     step = pmp_recipe.steps["enqueue_current_pr"]
-    cmd = step.with_args.get("cmd", "")
-    assert "context.current_pr_number" in cmd
-    assert "while read" not in cmd
-    assert "jq -r '.[].number'" not in cmd
+    pr_number = step.with_args.get("pr_number", "")
+    assert "context.current_pr_number" in pr_number
 
 
 def test_merge_prs_get_first_pr_number_captures_pr_number(pmp_recipe) -> None:
@@ -296,10 +294,10 @@ def test_merge_prs_diagnose_queue_ci_exists(pmp_recipe) -> None:
 
 
 def test_merge_prs_reenroll_stalled_queue_pr_exists(pmp_recipe) -> None:
-    """reenroll_stalled_queue_pr step must exist with tool=toggle_auto_merge."""
+    """reenroll_stalled_queue_pr step must exist with tool=enqueue_pr."""
     assert "reenroll_stalled_queue_pr" in pmp_recipe.steps
     step = pmp_recipe.steps["reenroll_stalled_queue_pr"]
-    assert step.tool == "toggle_auto_merge"
+    assert step.tool == "enqueue_pr"
 
 
 def test_merge_prs_reenroll_stalled_routes_to_wait(pmp_recipe) -> None:
@@ -362,11 +360,11 @@ def test_implementation_route_queue_mode_is_route_action(impl_recipe) -> None:
     assert step.action == "route"
 
 
-def test_implementation_enable_auto_merge_is_run_cmd(impl_recipe) -> None:
-    """enable_auto_merge must use tool=run_cmd."""
-    assert "enable_auto_merge" in impl_recipe.steps
-    step = impl_recipe.steps["enable_auto_merge"]
-    assert step.tool == "run_cmd"
+def test_implementation_enqueue_to_queue_is_enqueue_pr(impl_recipe) -> None:
+    """enqueue_to_queue must use tool=enqueue_pr."""
+    assert "enqueue_to_queue" in impl_recipe.steps
+    step = impl_recipe.steps["enqueue_to_queue"]
+    assert step.tool == "enqueue_pr"
 
 
 def test_implementation_wait_for_queue_is_wait_for_merge_queue(impl_recipe) -> None:
@@ -437,7 +435,7 @@ def test_implementation_queue_finale_steps_all_have_skip_when_false(impl_recipe)
     finale_steps = [
         "check_repo_merge_state",
         "route_queue_mode",
-        "enable_auto_merge",
+        "enqueue_to_queue",
         "wait_for_queue",
         "queue_ejected_fix",
         "resolve_queue_merge_conflicts",
@@ -475,20 +473,19 @@ def test_implementation_compose_pr_routes_to_extract_pr_number(impl_recipe) -> N
 
 
 def test_implementation_route_queue_mode_requires_merge_group_trigger(impl_recipe) -> None:
-    """route_queue_mode must NOT route to enable_auto_merge without checking merge_group_trigger.
+    """route_queue_mode must NOT route to enqueue_to_queue without checking merge_group_trigger.
 
     Specifically, the conditions list must not contain a bare 'queue_available == true'
-    → enable_auto_merge without also requiring merge_group_trigger == true.
+    → enqueue_to_queue without also requiring merge_group_trigger == true.
     """
     step = impl_recipe.steps["route_queue_mode"]
     assert step.action == "route"
     conditions = step.on_result.conditions if step.on_result else []
-    # Find any condition that routes to enable_auto_merge
-    queue_conditions = [c for c in conditions if c.route == "enable_auto_merge"]
-    assert len(queue_conditions) == 1, "Exactly one condition must route to enable_auto_merge"
+    queue_conditions = [c for c in conditions if c.route == "enqueue_to_queue"]
+    assert len(queue_conditions) == 1, "Exactly one condition must route to enqueue_to_queue"
     cond_when = queue_conditions[0].when or ""
     assert "merge_group_trigger" in cond_when, (
-        "The enable_auto_merge route condition must reference merge_group_trigger "
+        "The enqueue_to_queue route condition must reference merge_group_trigger "
         "to prevent queue enrollment when the CI workflow lacks the trigger"
     )
 
@@ -529,11 +526,11 @@ def test_remediation_route_queue_mode_is_route_action(remed_recipe) -> None:
     assert step.action == "route"
 
 
-def test_remediation_enable_auto_merge_is_run_cmd(remed_recipe) -> None:
-    """enable_auto_merge must use tool=run_cmd."""
-    assert "enable_auto_merge" in remed_recipe.steps
-    step = remed_recipe.steps["enable_auto_merge"]
-    assert step.tool == "run_cmd"
+def test_remediation_enqueue_to_queue_is_enqueue_pr(remed_recipe) -> None:
+    """enqueue_to_queue must use tool=enqueue_pr."""
+    assert "enqueue_to_queue" in remed_recipe.steps
+    step = remed_recipe.steps["enqueue_to_queue"]
+    assert step.tool == "enqueue_pr"
 
 
 def test_remediation_wait_for_queue_is_wait_for_merge_queue(remed_recipe) -> None:
@@ -553,7 +550,7 @@ def test_remediation_queue_finale_steps_all_have_skip_when_false(remed_recipe) -
     finale_steps = [
         "check_repo_merge_state",
         "route_queue_mode",
-        "enable_auto_merge",
+        "enqueue_to_queue",
         "wait_for_queue",
         "queue_ejected_fix",
         "resolve_queue_merge_conflicts",
@@ -591,14 +588,10 @@ def test_remediation_compose_pr_routes_to_extract_pr_number(remed_recipe) -> Non
 
 
 def test_remediation_route_queue_mode_requires_merge_group_trigger(remed_recipe) -> None:
-    """route_queue_mode must NOT route to enable_auto_merge without checking merge_group_trigger.
-
-    Specifically, the conditions list must not contain a bare 'queue_available == true'
-    → enable_auto_merge without also requiring merge_group_trigger == true.
-    """
+    """route_queue_mode must NOT route to enqueue_to_queue without checking merge_group_trigger."""
     step = remed_recipe.steps["route_queue_mode"]
     conditions = step.on_result.conditions if step.on_result else []
-    queue_conditions = [c for c in conditions if c.route == "enable_auto_merge"]
+    queue_conditions = [c for c in conditions if c.route == "enqueue_to_queue"]
     assert len(queue_conditions) == 1
     cond_when = queue_conditions[0].when or ""
     assert "merge_group_trigger" in cond_when
@@ -612,14 +605,10 @@ def test_impl_groups_has_check_repo_merge_state(impl_groups_recipe) -> None:
 
 
 def test_impl_groups_route_queue_mode_requires_merge_group_trigger(impl_groups_recipe) -> None:
-    """route_queue_mode must NOT route to enable_auto_merge without checking merge_group_trigger.
-
-    Specifically, the conditions list must not contain a bare 'queue_available == true'
-    → enable_auto_merge without also requiring merge_group_trigger == true.
-    """
+    """route_queue_mode must NOT route to enqueue_to_queue without checking merge_group_trigger."""
     step = impl_groups_recipe.steps["route_queue_mode"]
     conditions = step.on_result.conditions if step.on_result else []
-    queue_conditions = [c for c in conditions if c.route == "enable_auto_merge"]
+    queue_conditions = [c for c in conditions if c.route == "enqueue_to_queue"]
     assert len(queue_conditions) == 1
     cond_when = queue_conditions[0].when or ""
     assert "merge_group_trigger" in cond_when
@@ -1112,36 +1101,17 @@ def test_wait_for_queue_ejected_ci_failure_precedes_ejected(recipe_fixture, requ
 # ---------------------------------------------------------------------------
 
 
-def test_route_queue_mode_queue_with_auto_routes_to_enable_auto_merge(any_recipe) -> None:
-    """queue+auto cell must route to enable_auto_merge."""
+def test_route_queue_mode_queue_routes_to_enqueue_to_queue(any_recipe) -> None:
+    """queue+merge_group_trigger cell must route to enqueue_to_queue (unified)."""
     step = any_recipe.steps["route_queue_mode"]
     cond = next(
         c
         for c in step.on_result.conditions
-        if c.when
-        and "queue_available" in c.when
-        and "merge_group_trigger" in c.when
-        and "auto_merge_available" in c.when
-        and "== true" in c.when.split("auto_merge_available")[1]
+        if c.when and "queue_available" in c.when and "merge_group_trigger" in c.when
     )
-    assert cond.route == "enable_auto_merge"
-
-
-def test_route_queue_mode_queue_without_auto_routes_to_queue_enqueue_no_auto(
-    any_recipe,
-) -> None:
-    """queue+no-auto cell must route to queue_enqueue_no_auto."""
-    step = any_recipe.steps["route_queue_mode"]
-    cond = next(
-        c
-        for c in step.on_result.conditions
-        if c.when
-        and "queue_available" in c.when
-        and "merge_group_trigger" in c.when
-        and "auto_merge_available" in c.when
-        and "== false" in c.when.split("auto_merge_available")[1]
-    )
-    assert cond.route == "queue_enqueue_no_auto"
+    assert cond.route == "enqueue_to_queue"
+    # The unified route must NOT split on auto_merge_available
+    assert "auto_merge_available" not in (cond.when or "")
 
 
 def test_route_queue_mode_no_queue_with_auto_routes_to_direct_merge(any_recipe) -> None:
@@ -1164,68 +1134,72 @@ def test_route_queue_mode_no_queue_no_auto_falls_through_to_immediate_merge(
     assert cond.route == "immediate_merge"
 
 
-def test_route_queue_mode_never_routes_to_enable_auto_merge_when_auto_unavailable(
-    any_recipe,
-) -> None:
-    """Every condition routing to enable_auto_merge must require auto_merge_available == true."""
+def test_enqueue_to_queue_route_count(any_recipe) -> None:
+    """Exactly one condition must route to enqueue_to_queue."""
     step = any_recipe.steps["route_queue_mode"]
-    for cond in step.on_result.conditions:
-        if cond.route == "enable_auto_merge":
-            assert cond.when is not None
-            assert "auto_merge_available" in cond.when
-            assert "}} == true" in cond.when.split("auto_merge_available")[1], (
-                "enable_auto_merge route must require auto_merge_available == true; "
-                f"got: {cond.when}"
-            )
-
-
-def test_enable_auto_merge_route_count(any_recipe) -> None:
-    """Exactly one condition must route to enable_auto_merge."""
-    step = any_recipe.steps["route_queue_mode"]
-    count = sum(1 for c in step.on_result.conditions if c.route == "enable_auto_merge")
-    assert count == 1, f"Expected exactly 1 enable_auto_merge route, got {count}"
+    count = sum(1 for c in step.on_result.conditions if c.route == "enqueue_to_queue")
+    assert count == 1, f"Expected exactly 1 enqueue_to_queue route, got {count}"
 
 
 # ---------------------------------------------------------------------------
-# New step: queue_enqueue_no_auto
+# Unified enrollment step: enqueue_to_queue (replaces enable_auto_merge + queue_enqueue_no_auto)
 # ---------------------------------------------------------------------------
 
 
-def test_queue_enqueue_no_auto_step_exists(any_recipe) -> None:
-    assert "queue_enqueue_no_auto" in any_recipe.steps
+def test_enqueue_to_queue_uses_enqueue_pr_tool(any_recipe) -> None:
+    """The unified enrollment step must use the enqueue_pr tool, not run_cmd."""
+    step = any_recipe.steps["enqueue_to_queue"]
+    assert step.tool == "enqueue_pr"
 
 
-def test_queue_enqueue_no_auto_is_run_cmd(any_recipe) -> None:
-    step = any_recipe.steps["queue_enqueue_no_auto"]
-    assert step.tool == "run_cmd"
+def test_enqueue_to_queue_passes_auto_merge_available(any_recipe) -> None:
+    """enqueue_to_queue must pass context.auto_merge_available to the tool."""
+    step = any_recipe.steps["enqueue_to_queue"]
+    assert "auto_merge_available" in (step.with_args or {})
+    assert "context.auto_merge_available" in (step.with_args or {}).get("auto_merge_available", "")
 
 
-def test_queue_enqueue_no_auto_uses_plain_squash(any_recipe) -> None:
-    """queue_enqueue_no_auto must use --squash without --auto."""
-    step = any_recipe.steps["queue_enqueue_no_auto"]
-    cmd = step.with_args.get("cmd", "")
-    assert "--squash" in cmd
-    assert "--auto" not in cmd
+def test_reenter_merge_queue_uses_enqueue_pr_tool(any_recipe) -> None:
+    """Re-entry after ejection must use enqueue_pr tool."""
+    step = any_recipe.steps["reenter_merge_queue"]
+    assert step.tool == "enqueue_pr"
 
 
-def test_queue_enqueue_no_auto_routes_to_wait_for_queue(any_recipe) -> None:
-    step = any_recipe.steps["queue_enqueue_no_auto"]
-    assert step.on_success == "wait_for_queue"
+def test_reenter_merge_queue_cheap_uses_enqueue_pr_tool(any_recipe) -> None:
+    """Re-entry after drop must use enqueue_pr tool."""
+    step = any_recipe.steps["reenter_merge_queue_cheap"]
+    assert step.tool == "enqueue_pr"
 
 
-def test_queue_enqueue_no_auto_failure_routes_to_verify_queue_enrollment(any_recipe) -> None:
-    step = any_recipe.steps["queue_enqueue_no_auto"]
-    assert step.on_failure == "verify_queue_enrollment"
+def test_reenroll_stalled_pr_uses_enqueue_pr_tool(any_recipe) -> None:
+    """Stall recovery must use enqueue_pr tool, not toggle_auto_merge."""
+    step = any_recipe.steps["reenroll_stalled_pr"]
+    assert step.tool == "enqueue_pr"
 
 
-def test_queue_enqueue_no_auto_skip_when_false(any_recipe) -> None:
-    step = any_recipe.steps["queue_enqueue_no_auto"]
-    assert step.skip_when_false == "inputs.open_pr"
+def test_no_gh_pr_merge_in_queue_enrollment_steps(any_recipe) -> None:
+    """No queue enrollment or re-entry step should contain 'gh pr merge' in its cmd."""
+    enrollment_steps = [
+        "enqueue_to_queue",
+        "reenter_merge_queue",
+        "reenter_merge_queue_cheap",
+        "reenroll_stalled_pr",
+    ]
+    for step_name in enrollment_steps:
+        step = any_recipe.steps.get(step_name)
+        if step and step.tool == "run_cmd":
+            cmd = step.with_args.get("cmd", "")
+            assert "gh pr merge" not in cmd, f"{step_name} must not use gh pr merge"
 
 
-def test_queue_enqueue_no_auto_step_name(any_recipe) -> None:
-    step = any_recipe.steps["queue_enqueue_no_auto"]
-    assert step.with_args["step_name"] == "queue_enqueue_no_auto"
+def test_no_enable_auto_merge_step_exists(any_recipe) -> None:
+    """enable_auto_merge step must be removed (replaced by enqueue_to_queue)."""
+    assert "enable_auto_merge" not in any_recipe.steps
+
+
+def test_no_queue_enqueue_no_auto_step_exists(any_recipe) -> None:
+    """queue_enqueue_no_auto step must be removed (merged into enqueue_to_queue)."""
+    assert "queue_enqueue_no_auto" not in any_recipe.steps
 
 
 # ---------------------------------------------------------------------------
@@ -1273,9 +1247,9 @@ def test_remediation_wait_for_queue_has_timeout_arm_and_release_timeout_fallback
 # ---------------------------------------------------------------------------
 
 
-def test_enable_auto_merge_failure_routes_to_verify_queue_enrollment(any_recipe) -> None:
-    """enable_auto_merge on_failure must route to verify_queue_enrollment."""
-    step = any_recipe.steps["enable_auto_merge"]
+def test_enqueue_to_queue_failure_routes_to_verify_queue_enrollment(any_recipe) -> None:
+    """enqueue_to_queue on_failure must route to verify_queue_enrollment."""
+    step = any_recipe.steps["enqueue_to_queue"]
     assert step.on_failure == "verify_queue_enrollment"
 
 
@@ -1345,9 +1319,7 @@ def test_wait_for_direct_merge_on_failure_routes_to_register_clone_unconfirmed(
 # T9: Full routing parity — every PRState covered (universal + family-specific)
 # ---------------------------------------------------------------------------
 
-_REQUIRED_PR_STATE_VALUES = frozenset(
-    s.value for s in PRState if s not in {PRState.ERROR, PRState.NOT_ENROLLED}
-)
+_REQUIRED_PR_STATE_VALUES = frozenset(s.value for s in PRState if s is not PRState.ERROR)
 _PR_STATE_WHEN_RE = re.compile(r"\$\{\{\s*result\.pr_state\s*\}\}\s*==\s*(\w+)")
 
 
@@ -1482,3 +1454,59 @@ def test_auto_discovery_matches_known_queue_recipes() -> None:
         f"QUEUE_RECIPES mismatch — expected {sorted(expected)}, got {sorted(actual)}. "
         f"Missing: {sorted(expected - actual)}, Extra: {sorted(actual - expected)}"
     )
+
+
+# ---------------------------------------------------------------------------
+# merge-prs.yaml — Part B: expanded captures + unified enrollment
+# ---------------------------------------------------------------------------
+
+
+def test_merge_prs_check_repo_ci_event_captures_auto_merge_available(pmp_recipe) -> None:
+    """check_repo_ci_event must capture auto_merge_available (expanded captures)."""
+    step = pmp_recipe.steps["check_repo_ci_event"]
+    assert step.tool == "check_repo_merge_state"
+    assert "auto_merge_available" in (step.capture or {})
+
+
+def test_merge_prs_enqueue_current_pr_uses_enqueue_pr_tool(pmp_recipe) -> None:
+    """enqueue_current_pr must use enqueue_pr tool."""
+    step = pmp_recipe.steps["enqueue_current_pr"]
+    assert step.tool == "enqueue_pr"
+
+
+def test_merge_prs_reenter_queue_uses_enqueue_pr_tool(pmp_recipe) -> None:
+    """reenter_queue must use enqueue_pr tool."""
+    step = pmp_recipe.steps["reenter_queue"]
+    assert step.tool == "enqueue_pr"
+
+
+def test_merge_prs_reenroll_stalled_queue_pr_uses_enqueue_pr_tool(pmp_recipe) -> None:
+    """reenroll_stalled_queue_pr must use enqueue_pr tool."""
+    step = pmp_recipe.steps["reenroll_stalled_queue_pr"]
+    assert step.tool == "enqueue_pr"
+
+
+# ---------------------------------------------------------------------------
+# NOT_ENROLLED routing — all queue-capable recipes
+# ---------------------------------------------------------------------------
+
+
+def test_wait_for_queue_routes_not_enrolled(any_recipe) -> None:
+    """wait_for_queue must have an explicit routing arm for not_enrolled."""
+    step = any_recipe.steps["wait_for_queue"]
+    conditions = [c.when for c in step.on_result.conditions]
+    assert any("not_enrolled" in c for c in conditions if c)
+
+
+def test_verify_queue_enrollment_routes_not_enrolled(any_recipe) -> None:
+    """verify_queue_enrollment must route not_enrolled state."""
+    step = any_recipe.steps["verify_queue_enrollment"]
+    conditions = [c.when for c in step.on_result.conditions]
+    assert any("not_enrolled" in c for c in conditions if c)
+
+
+def test_merge_prs_wait_queue_pr_routes_not_enrolled(pmp_recipe) -> None:
+    """wait_queue_pr must have an explicit routing arm for not_enrolled."""
+    step = pmp_recipe.steps["wait_queue_pr"]
+    conditions = [c.when for c in step.on_result.conditions]
+    assert any("not_enrolled" in c for c in conditions if c)

--- a/tests/recipe/test_rules_merge.py
+++ b/tests/recipe/test_rules_merge.py
@@ -423,3 +423,102 @@ def test_rule_does_not_fire_when_register_clone_unconfirmed_used() -> None:
         f"Unexpected release-issue-on-unconfirmed-merge finding: "
         f"{[f for f in findings if f.rule == 'release-issue-on-unconfirmed-merge']}"
     )
+
+
+# ---------------------------------------------------------------------------
+# merge-enrollment-auto-consistency rule tests
+# ---------------------------------------------------------------------------
+
+
+def test_rule_flags_auto_step_reachable_from_no_auto_route() -> None:
+    """A gh pr merge --auto step reachable from an auto_merge_available=false
+    routing condition must emit a finding."""
+    recipe = _make_recipe(
+        {
+            "route_queue_mode": RecipeStep(
+                action="route",
+                on_result=StepResultRoute(
+                    conditions=[
+                        StepResultCondition(
+                            route="enroll_with_auto",
+                            when="context.auto_merge_available == 'true'",
+                        ),
+                        StepResultCondition(
+                            route="enroll_no_auto",
+                            when="context.auto_merge_available == 'false'",
+                        ),
+                    ],
+                ),
+            ),
+            "enroll_with_auto": RecipeStep(
+                tool="run_cmd",
+                with_args={"cmd": "gh pr merge '42' --squash --auto", "cwd": "/tmp"},
+                on_success="wait_queue",
+            ),
+            "enroll_no_auto": RecipeStep(
+                tool="run_cmd",
+                with_args={"cmd": "gh pr merge '42' --squash", "cwd": "/tmp"},
+                on_success="wait_queue",
+                on_failure="reenter",
+            ),
+            "wait_queue": RecipeStep(
+                tool="wait_for_merge_queue",
+                with_args={},
+                on_success="done",
+                on_failure="reenter",
+            ),
+            "reenter": RecipeStep(
+                tool="run_cmd",
+                with_args={"cmd": "gh pr merge '42' --squash --auto", "cwd": "/tmp"},
+                on_success="wait_queue",
+            ),
+            "done": RecipeStep(action="stop", message="done"),
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    flagged = [f for f in findings if f.rule == "merge-enrollment-auto-consistency"]
+    assert len(flagged) >= 1
+    flagged_steps = {f.step_name for f in flagged}
+    assert "reenter" in flagged_steps
+
+
+def test_rule_passes_when_auto_steps_only_reachable_from_auto_route() -> None:
+    """Steps using --auto that are only reachable from auto_merge_available=true
+    routing conditions should not emit findings."""
+    recipe = _make_recipe(
+        {
+            "route_queue_mode": RecipeStep(
+                action="route",
+                on_result=StepResultRoute(
+                    conditions=[
+                        StepResultCondition(
+                            route="enroll_with_auto",
+                            when="context.auto_merge_available == 'true'",
+                        ),
+                        StepResultCondition(
+                            route="enroll_no_auto",
+                            when="context.auto_merge_available == 'false'",
+                        ),
+                    ],
+                ),
+            ),
+            "enroll_with_auto": RecipeStep(
+                tool="run_cmd",
+                with_args={"cmd": "gh pr merge '42' --squash --auto", "cwd": "/tmp"},
+                on_success="done",
+            ),
+            "enroll_no_auto": RecipeStep(
+                tool="enqueue_pr",
+                with_args={
+                    "pr_number": "42",
+                    "target_branch": "main",
+                    "auto_merge_available": "false",
+                },
+                on_success="done",
+            ),
+            "done": RecipeStep(action="stop", message="done"),
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    flagged = [f for f in findings if f.rule == "merge-enrollment-auto-consistency"]
+    assert flagged == []

--- a/tests/recipe/test_rules_merge.py
+++ b/tests/recipe/test_rules_merge.py
@@ -482,6 +482,16 @@ def test_rule_flags_auto_step_reachable_from_no_auto_route() -> None:
     assert "reenter" in flagged_steps
 
 
+@pytest.mark.parametrize("recipe_name", ["implementation", "remediation", "implementation-groups"])
+def test_merge_enrollment_auto_consistency_passes_after_migration(recipe_name: str) -> None:
+    """After migration, no recipe should have --auto steps reachable from
+    auto_merge_available=false routing arms."""
+    recipe = load_recipe(builtin_recipes_dir() / f"{recipe_name}.yaml")
+    findings = run_semantic_rules(recipe)
+    auto_findings = [f for f in findings if f.rule == "merge-enrollment-auto-consistency"]
+    assert auto_findings == [], f"{recipe_name}: {auto_findings}"
+
+
 def test_rule_passes_when_auto_steps_only_reachable_from_auto_route() -> None:
     """Steps using --auto that are only reachable from auto_merge_available=true
     routing conditions should not emit findings."""

--- a/tests/server/test_server_tool_registration.py
+++ b/tests/server/test_server_tool_registration.py
@@ -32,7 +32,7 @@ class TestNoSkillsDirectoryProvider:
 
 
 class TestToolRegistration:
-    """All 44 tools are registered on the MCP server."""
+    """All 45 tools are registered on the MCP server."""
 
     @pytest.mark.anyio
     async def test_all_tools_exist(self, kitchen_enabled):
@@ -77,6 +77,7 @@ class TestToolRegistration:
             "wait_for_merge_queue",
             "check_repo_merge_state",
             "toggle_auto_merge",
+            "enqueue_pr",
             "get_ci_status",
             "open_kitchen",
             "close_kitchen",

--- a/tests/server/test_tools_ci_enqueue.py
+++ b/tests/server/test_tools_ci_enqueue.py
@@ -25,14 +25,10 @@ async def test_enqueue_pr_delegates_to_watcher_enqueue(tool_ctx):
     tool_ctx.merge_queue_watcher = watcher
 
     with patch(
-        "autoskillit.execution.remote_resolver.asyncio.create_subprocess_exec",
+        "autoskillit.server.tools_ci.infer_repo_from_remote",
         new_callable=AsyncMock,
-    ) as mock_exec:
-        proc_inst = AsyncMock()
-        proc_inst.communicate = AsyncMock(return_value=(b"owner/repo", b""))
-        proc_inst.returncode = 0
-        mock_exec.return_value = proc_inst
-
+        return_value="owner/repo",
+    ):
         from autoskillit.server.tools_ci import enqueue_pr
 
         raw = await enqueue_pr(

--- a/tests/server/test_tools_ci_enqueue.py
+++ b/tests/server/test_tools_ci_enqueue.py
@@ -1,0 +1,67 @@
+"""Tests for enqueue_pr MCP tool handler."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tests.fakes import InMemoryMergeQueueWatcher
+
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+
+@pytest.mark.anyio
+async def test_enqueue_pr_delegates_to_watcher_enqueue(tool_ctx):
+    """enqueue_pr tool passes auto_merge_available to watcher.enqueue()."""
+    watcher = InMemoryMergeQueueWatcher(
+        enqueue_result={
+            "success": True,
+            "pr_number": 42,
+            "enrollment_method": "direct_enqueue",
+        },
+    )
+    tool_ctx.merge_queue_watcher = watcher
+
+    with patch(
+        "autoskillit.execution.remote_resolver.asyncio.create_subprocess_exec",
+        new_callable=AsyncMock,
+    ) as mock_exec:
+        proc_inst = AsyncMock()
+        proc_inst.communicate = AsyncMock(return_value=(b"owner/repo", b""))
+        proc_inst.returncode = 0
+        mock_exec.return_value = proc_inst
+
+        from autoskillit.server.tools_ci import enqueue_pr
+
+        raw = await enqueue_pr(
+            pr_number=42,
+            target_branch="main",
+            cwd="/tmp/work",
+            auto_merge_available=False,
+        )
+    result = json.loads(raw)
+    assert result["success"] is True
+    assert result["enrollment_method"] == "direct_enqueue"
+    assert len(watcher.enqueue_calls) == 1
+    call = watcher.enqueue_calls[0]
+    assert call["auto_merge_available"] is False
+
+
+@pytest.mark.anyio
+async def test_enqueue_pr_returns_structured_error_when_watcher_none(tool_ctx):
+    """enqueue_pr returns {"success": false} when merge_queue_watcher is None."""
+    tool_ctx.merge_queue_watcher = None
+
+    from autoskillit.server.tools_ci import enqueue_pr
+
+    raw = await enqueue_pr(
+        pr_number=42,
+        target_branch="main",
+        cwd="/tmp/work",
+        auto_merge_available=True,
+    )
+    result = json.loads(raw)
+    assert result["success"] is False
+    assert "error" in result


### PR DESCRIPTION
## Summary

Every merge queue enrollment path fails on repositories where `autoMergeAllowed=false` but a merge queue is configured. The root cause is **enrollment strategy fragmentation** — the decision about *how* to enroll is scattered across recipe YAML steps as hardcoded CLI flags (`--auto` / no `--auto`), instead of being encapsulated in the enrollment infrastructure. This fragmentation causes three compounding failures:

1. `gh pr merge --squash` (even without `--auto`) internally forces auto-merge when `shouldAddToMergeQueue()` returns true in the GitHub CLI — so `queue_enqueue_no_auto` never worked
2. All re-entry steps (`reenter_merge_queue`, `reenter_merge_queue_cheap`) hardcode `--auto`
3. Stall recovery (`reenroll_stalled_pr`) calls `enablePullRequestAutoMerge` which requires `autoMergeAllowed=true`

Additionally, the `DROPPED_HEALTHY` classifier misidentifies never-enrolled PRs as "dropped" because the poll loop has no enrollment history.

**Part A** fixes the core infrastructure: adds the `enqueuePullRequest` GraphQL mutation, creates a strategy-aware enrollment method, adds `NOT_ENROLLED` state, fixes the classifier, and adds a semantic rule to prevent future recurrence. Part B (separate task) migrates all recipe YAML steps to use the new infrastructure.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START<br/>Recipe step invokes<br/>merge queue enrollment])
    MERGED([MERGED<br/>PR successfully merged])
    ERROR([ERROR<br/>Unrecoverable failure])
    TIMEOUT([TIMEOUT<br/>Deadline or retries<br/>exhausted])

    subgraph GateDiscovery ["Phase 1: Gate & Repository Discovery"]
        direction TB
        GATE{"● Kitchen Gate<br/>━━━━━━━━━━<br/>ctx.gate.enabled?"}
        GATE_ERR["Gate Error<br/>━━━━━━━━━━<br/>gate_error_result()"]
        CHECK_STATE["● check_repo_merge_state<br/>━━━━━━━━━━<br/>Single GraphQL round-trip<br/>reads: mergeQueue, autoMergeAllowed,<br/>.github/workflows"]
        STATE_RESULT["● Repo State Result<br/>━━━━━━━━━━<br/>queue_available: bool<br/>auto_merge_available: bool<br/>merge_group_trigger: bool<br/>ci_event: str|None"]
    end

    subgraph EnrollRouting ["Phase 2: Enrollment Routing (Recipe-Level)"]
        direction TB
        ROUTE{"● route_queue_mode<br/>━━━━━━━━━━<br/>4-arm decision tree"}
        SKIP_MERGE["register_clone_success<br/>━━━━━━━━━━<br/>auto_merge != true"]
        DIRECT_MERGE["direct_merge<br/>━━━━━━━━━━<br/>auto_merge_available=true<br/>no merge_group trigger"]
        IMMEDIATE["immediate_merge<br/>━━━━━━━━━━<br/>Fallback: no queue,<br/>no auto-merge"]
    end

    subgraph EnrollExec ["Phase 3: ● enqueue_pr Execution"]
        direction TB
        ENQUEUE_ENTRY["● enqueue_pr<br/>━━━━━━━━━━<br/>tools_ci.py handler<br/>reads: repo from git remote"]
        WATCHER_NULL{"Watcher<br/>configured?"}
        STRATEGY{"● auto_merge<br/>_available?<br/>━━━━━━━━━━<br/>Enrollment<br/>strategy"}
        AUTO_MERGE["● enablePullRequest<br/>AutoMerge<br/>━━━━━━━━━━<br/>GraphQL mutation<br/>mergeMethod: SQUASH<br/>writes: enrollment_method=<br/>auto_merge"]
        DIRECT_ENQUEUE["● enqueuePullRequest<br/>━━━━━━━━━━<br/>GraphQL mutation<br/>writes: enrollment_method=<br/>direct_enqueue"]
    end

    subgraph QueueMonitor ["Phase 4: ● wait_for_merge_queue Poll Loop"]
        direction TB
        POLL_START["● Poll Cycle Start<br/>━━━━━━━━━━<br/>_fetch_pr_and_queue_state()<br/>reads: PR state via GraphQL"]
        IN_QUEUE{"in_queue?"}
        CLASSIFY["● _classify_pr_state<br/>━━━━━━━━━━<br/>Pure function:<br/>10-branch decision tree"]

        CLASSIFY_MERGED["MERGED<br/>━━━━━━━━━━<br/>merged=true"]
        CLASSIFY_EJECTED_CI["EJECTED_CI_FAILURE<br/>━━━━━━━━━━<br/>checks FAILURE|ERROR"]
        CLASSIFY_EJECTED["EJECTED<br/>━━━━━━━━━━<br/>state=CLOSED or<br/>mergeable=CONFLICTING"]
        CLASSIFY_STALLED["STALLED<br/>━━━━━━━━━━<br/>auto_merge set +<br/>merge_state CLEAN"]
        CLASSIFY_DROPPED["DROPPED_HEALTHY<br/>━━━━━━━━━━<br/>ever_enrolled + healthy<br/>+ not in queue"]
        CLASSIFY_NOT["NOT_ENROLLED<br/>━━━━━━━━━━<br/>never enrolled + healthy"]
        CLASSIFY_PENDING["CI_STILL_RUNNING<br/>━━━━━━━━━━<br/>checks PENDING|EXPECTED"]
        CLASSIFY_UNKNOWN["NO_POSITIVE_SIGNAL<br/>━━━━━━━━━━<br/>Inconclusive"]
    end

    subgraph StallRecovery ["Phase 5: ● Stall Recovery"]
        direction TB
        GRACE{"Past stall<br/>grace period?<br/>━━━━━━━━━━<br/>60s default"}
        TOGGLE_DECIDE{"● auto_merge<br/>_available?"}
        TOGGLE_AM["● Toggle Auto-Merge<br/>━━━━━━━━━━<br/>Disable → 2s sleep →<br/>Re-enable<br/>writes: auto_merge state"]
        DIRECT_RE["● _enqueue_direct<br/>━━━━━━━━━━<br/>enqueuePullRequest<br/>mutation"]
        RETRIES_LEFT{"stall_retries<br/>< max (3)?"}
    end

    subgraph RecipeRecovery ["Phase 6: ● Recipe-Level Recovery"]
        direction TB
        VERIFY["● verify_queue_enrollment<br/>━━━━━━━━━━<br/>Short probe: 60s timeout<br/>10s poll interval"]
        REENTER["● reenter_merge_queue<br/>━━━━━━━━━━<br/>enqueue_pr after<br/>conflict resolution"]
        REENROLL["● reenroll_stalled_pr<br/>━━━━━━━━━━<br/>enqueue_pr for<br/>stalled recovery"]
        REENTER_CHEAP["● reenter_merge_queue_cheap<br/>━━━━━━━━━━<br/>enqueue_pr for<br/>DROPPED_HEALTHY"]
    end

    subgraph RuleValidation ["● Semantic Rule Validation (Build-Time)"]
        direction TB
        RULE_STATES["● wait-for-merge-queue-<br/>routing-covers-all-<br/>pr-states<br/>━━━━━━━━━━<br/>All 7 PRState arms<br/>must be explicit"]
        RULE_TARGETS["● wait-for-merge-queue-<br/>routing-conforms-to-<br/>expected-targets<br/>━━━━━━━━━━<br/>fallback/on_failure →<br/>release_issue_timeout"]
        RULE_AUTO["● merge-enrollment-<br/>auto-consistency<br/>━━━━━━━━━━<br/>auto_merge=false paths<br/>must not use --auto"]
        RULE_PARAMS["● dead-with-param<br/>━━━━━━━━━━<br/>enqueue_pr params:<br/>pr_number, target_branch,<br/>auto_merge_available, ..."]
    end

    %% === FLOW CONNECTIONS === %%

    %% Phase 1: Gate & Discovery
    START --> GATE
    GATE -->|"No"| GATE_ERR
    GATE_ERR --> ERROR
    GATE -->|"Yes"| CHECK_STATE
    CHECK_STATE -->|"writes: repo state"| STATE_RESULT

    %% Phase 2: Routing
    STATE_RESULT -->|"reads: all flags"| ROUTE
    ROUTE -->|"auto_merge input != true"| SKIP_MERGE
    ROUTE -->|"queue_available=true<br/>AND merge_group_trigger=true"| ENQUEUE_ENTRY
    ROUTE -->|"auto_merge_available=true<br/>only"| DIRECT_MERGE
    ROUTE -->|"fallback"| IMMEDIATE
    SKIP_MERGE --> MERGED
    DIRECT_MERGE --> MERGED
    IMMEDIATE --> MERGED

    %% Phase 3: Enrollment
    ENQUEUE_ENTRY --> WATCHER_NULL
    WATCHER_NULL -->|"None"| ERROR
    WATCHER_NULL -->|"configured"| STRATEGY
    STRATEGY -->|"True"| AUTO_MERGE
    STRATEGY -->|"False"| DIRECT_ENQUEUE
    AUTO_MERGE -->|"success"| POLL_START
    DIRECT_ENQUEUE -->|"success"| POLL_START
    AUTO_MERGE -->|"failure"| VERIFY
    DIRECT_ENQUEUE -->|"failure"| VERIFY

    %% Phase 4: Poll Loop
    POLL_START --> IN_QUEUE
    IN_QUEUE -->|"Yes: ever_enrolled=true<br/>reset counters"| CLASSIFY
    IN_QUEUE -->|"No: not_in_queue_cycles++"| CLASSIFY

    CLASSIFY -->|"merged=true"| CLASSIFY_MERGED
    CLASSIFY -->|"CLOSED + checks fail"| CLASSIFY_EJECTED_CI
    CLASSIFY -->|"CLOSED or CONFLICTING"| CLASSIFY_EJECTED
    CLASSIFY -->|"auto_merge + CLEAN"| CLASSIFY_STALLED
    CLASSIFY -->|"ever_enrolled + healthy"| CLASSIFY_DROPPED
    CLASSIFY -->|"never enrolled + healthy"| CLASSIFY_NOT
    CLASSIFY -->|"checks PENDING"| CLASSIFY_PENDING
    CLASSIFY -->|"no signal"| CLASSIFY_UNKNOWN

    %% Terminal states from classifier
    CLASSIFY_MERGED --> MERGED
    CLASSIFY_EJECTED_CI --> ERROR
    CLASSIFY_EJECTED -->|"recipe: attempt_cheap_rebase"| REENTER
    CLASSIFY_NOT --> ERROR
    CLASSIFY_PENDING -->|"sleep(poll_interval)"| POLL_START
    CLASSIFY_UNKNOWN -->|"inconclusive_count<br/>< max (5)"| POLL_START
    CLASSIFY_UNKNOWN -->|"exhausted"| TIMEOUT
    CLASSIFY_DROPPED --> REENTER_CHEAP
    CLASSIFY_STALLED --> GRACE

    %% Phase 5: Stall Recovery
    GRACE -->|"within grace"| POLL_START
    GRACE -->|"past grace"| RETRIES_LEFT
    RETRIES_LEFT -->|"Yes"| TOGGLE_DECIDE
    RETRIES_LEFT -->|"No: exhausted"| TIMEOUT
    TOGGLE_DECIDE -->|"True"| TOGGLE_AM
    TOGGLE_DECIDE -->|"False"| DIRECT_RE
    TOGGLE_AM -->|"backoff: 30*2^n (max 120s)"| POLL_START
    DIRECT_RE -->|"backoff: 30*2^n (max 120s)"| POLL_START

    %% Phase 6: Recipe Recovery
    VERIFY -->|"merged"| MERGED
    VERIFY -->|"dropped/ejected/stalled"| POLL_START
    VERIFY -->|"not_enrolled/timeout"| TIMEOUT
    REENTER -->|"re-enrolls via enqueue_pr"| POLL_START
    REENROLL -->|"re-enrolls via enqueue_pr"| POLL_START
    REENTER_CHEAP -->|"re-enrolls via enqueue_pr"| POLL_START

    %% Rule validation (dashed - build-time only)
    RULE_STATES -.->|"validates"| CLASSIFY
    RULE_TARGETS -.->|"validates"| VERIFY
    RULE_AUTO -.->|"validates"| STRATEGY
    RULE_PARAMS -.->|"validates"| ENQUEUE_ENTRY

    %% CLASS ASSIGNMENTS %%
    class START,MERGED,ERROR,TIMEOUT terminal;
    class GATE,ROUTE,IN_QUEUE,STRATEGY,WATCHER_NULL,GRACE,TOGGLE_DECIDE,RETRIES_LEFT stateNode;
    class CHECK_STATE,ENQUEUE_ENTRY,AUTO_MERGE,DIRECT_ENQUEUE,POLL_START,CLASSIFY,TOGGLE_AM,DIRECT_RE handler;
    class STATE_RESULT,CLASSIFY_MERGED,CLASSIFY_EJECTED_CI,CLASSIFY_EJECTED,CLASSIFY_STALLED,CLASSIFY_DROPPED,CLASSIFY_NOT,CLASSIFY_PENDING,CLASSIFY_UNKNOWN output;
    class GATE_ERR,SKIP_MERGE,DIRECT_MERGE,IMMEDIATE phase;
    class VERIFY,REENTER,REENROLL,REENTER_CHEAP newComponent;
    class RULE_STATES,RULE_TARGETS,RULE_AUTO,RULE_PARAMS detector;
```

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START(["● open_kitchen<br/>━━━━━━━━━━<br/>Kitchen session entry"])

    subgraph InitOnly ["INIT_ONLY — Set Once at Construction"]
        direction TB
        CTX_DEPS["ToolContext Dependencies<br/>━━━━━━━━━━<br/>config, audit, runner,<br/>temp_dir, project_dir"]
        MQW_INIT["● MergeQueueWatcher<br/>━━━━━━━━━━<br/>_token_factory: Callable<br/>INIT_ONLY — never reassigned"]
        CIW_INIT["CIWatcher<br/>━━━━━━━━━━<br/>Injected at make_context()<br/>INIT_ONLY reference"]
    end

    subgraph KitchenScoped ["KITCHEN_SCOPED — Bounded by open/close_kitchen"]
        direction TB
        GATE["● GateState.enabled<br/>━━━━━━━━━━<br/>False → True on open<br/>True → False on close"]
        KID["● kitchen_id<br/>━━━━━━━━━━<br/>'' → uuid4() on open<br/>uuid4() → '' on close"]
        RECIPE_STATE["● Recipe Fields<br/>━━━━━━━━━━<br/>recipe_name, content_hash,<br/>composite_hash, version<br/>Set on open, cleared on close"]
        PACKS["● active_recipe_packs<br/>━━━━━━━━━━<br/>None → frozenset() on open<br/>frozenset() → None on close"]
    end

    subgraph EnrollGates ["VALIDATION GATES — ● enqueue_pr Chain"]
        direction TB
        G1["● Gate 1: _require_enabled<br/>━━━━━━━━━━<br/>gate.enabled == True?<br/>FAIL → gate_error_result"]
        G2["● Gate 2: Watcher Check<br/>━━━━━━━━━━<br/>merge_queue_watcher != None?<br/>FAIL → missing GITHUB_TOKEN"]
        G3["● Gate 3: Repo Format<br/>━━━━━━━━━━<br/>infer_repo_from_remote()<br/>owner/repo must contain /"]
        G4["● Gate 4: GraphQL Fetch<br/>━━━━━━━━━━<br/>_fetch_pr_and_queue_state<br/>Obtains pr_node_id"]
    end

    subgraph Snapshot ["SNAPSHOT — PRFetchState (Immutable Per-Poll)"]
        direction TB
        PRFS["● PRFetchState TypedDict<br/>━━━━━━━━━━<br/>merged, state, mergeable,<br/>merge_state_status,<br/>auto_merge_present,<br/>in_queue, checks_state"]
        DRIFT["● Import-Time Drift Guards<br/>━━━━━━━━━━<br/>_QUERY_FIELD_MAP == PRFetchState keys<br/>GraphQL fields ⊇ map heads<br/>RuntimeError on mismatch"]
    end

    subgraph EnrollDispatch ["★ ENROLLMENT DISPATCH — enqueue_pr Strategy"]
        direction TB
        DISPATCH{"auto_merge_available?"}
        AUTO_MERGE["auto_merge = True<br/>━━━━━━━━━━<br/>enablePullRequestAutoMerge<br/>mergeMethod: SQUASH"]
        DIRECT_ENQ["auto_merge = False<br/>━━━━━━━━━━<br/>enqueuePullRequest<br/>Direct queue mutation"]
    end

    subgraph PollLocal ["POLL_LOCAL + MONOTONIC — wait() Enrollment Tracking"]
        direction TB
        EVER["ever_enrolled: bool<br/>━━━━━━━━━━<br/>MONOTONIC: False → True<br/>Set when in_queue OR<br/>auto_merge_present observed"]
        STALL_CTR["stall_retries_attempted: int<br/>━━━━━━━━━━<br/>POLL_LOCAL: 0 → N<br/>Incremented on stall toggle"]
        NIQC["not_in_queue_cycles: int<br/>━━━━━━━━━━<br/>POLL_LOCAL: resettable<br/>Reset to 0 on re-entry"]
        INCON["inconclusive_count: int<br/>━━━━━━━━━━<br/>POLL_LOCAL: bounded<br/>Capped by max_retries"]
    end

    subgraph Classifier ["● PRState CLASSIFIER — Positive-Signal Only"]
        direction TB
        C1["● 1. merged == True<br/>→ MERGED"]
        C2["● 2. state == CLOSED<br/>→ EJECTED / EJECTED_CI_FAILURE"]
        C3["● 3. checks FAILURE/ERROR<br/>→ EJECTED_CI_FAILURE"]
        C4["● 4. _is_positive_stall<br/>→ STALLED"]
        C5["● 5. mergeable == CONFLICTING<br/>→ EJECTED"]
        C6["● 6. ever_enrolled + healthy<br/>→ DROPPED_HEALTHY"]
        C7["● 7. !ever_enrolled + healthy<br/>→ NOT_ENROLLED"]
        C8["● 8. checks PENDING<br/>→ CIStillRunning exception"]
        C9["● 9. No positive signal<br/>→ NoPositiveSignal exception"]
        C1 --> C2 --> C3 --> C4 --> C5 --> C6 --> C7 --> C8 --> C9
    end

    subgraph RecipeRules ["● RECIPE VALIDATION RULES"]
        direction TB
        R_CI["● rules_ci.py<br/>━━━━━━━━━━<br/>PRState completeness check<br/>Every non-error PRState<br/>needs a when arm"]
        R_MERGE["● rules_merge.py<br/>━━━━━━━━━━<br/>merge-enrollment-auto-consistency<br/>--auto must not reach<br/>auto_merge_available=false arms"]
        R_TOOLS["● rules_tools.py<br/>━━━━━━━━━━<br/>enqueue_pr known params:<br/>pr_number, target_branch, cwd,<br/>auto_merge_available, repo,<br/>remote_url, step_name"]
    end

    subgraph Frozen ["FROZEN — Immutable Results"]
        direction TB
        CRESULT["ClassificationResult<br/>━━━━━━━━━━<br/>frozen=True dataclass<br/>terminal: PRState<br/>reason: str"]
    end

    CLOSE(["● close_kitchen<br/>━━━━━━━━━━<br/>gate.disable, clear fields,<br/>cancel quota_refresh_task"])

    %% FLOW %%
    START --> GATE
    START --> KID
    START --> RECIPE_STATE
    START --> PACKS

    CTX_DEPS -.->|injected at startup| GATE
    MQW_INIT -.->|ref held in ToolContext| G2
    CIW_INIT -.->|ref held in ToolContext| G2

    GATE -->|enabled == True| G1
    G1 -->|pass| G2
    G2 -->|pass| G3
    G3 -->|pass| G4
    G4 -->|fetches| PRFS
    PRFS -.->|validated by| DRIFT

    G4 -->|pr_node_id| DISPATCH
    DISPATCH -->|True| AUTO_MERGE
    DISPATCH -->|False| DIRECT_ENQ

    AUTO_MERGE --> EVER
    DIRECT_ENQ --> EVER

    EVER --> C1
    STALL_CTR -.->|gates stall recovery| C4
    NIQC -.->|confirmation window| C6
    NIQC -.->|confirmation window| C7
    INCON -.->|budget check| C9

    C6 -.->|DROPPED_HEALTHY| DISPATCH
    C4 -.->|STALLED: re-enroll| DISPATCH

    C1 --> CRESULT
    C2 --> CRESULT
    C3 --> CRESULT
    C4 --> CRESULT
    C5 --> CRESULT
    C6 --> CRESULT
    C7 --> CRESULT

    R_CI -.->|validates PRState coverage| C1
    R_MERGE -.->|validates auto-merge consistency| DISPATCH
    R_TOOLS -.->|validates enqueue_pr params| G4

    GATE -->|disabled| CLOSE
    KID -->|cleared| CLOSE
    RECIPE_STATE -->|cleared| CLOSE
    PACKS -->|set None| CLOSE

    %% CLASS ASSIGNMENTS %%
    class START,CLOSE terminal;
    class CTX_DEPS,MQW_INIT,CIW_INIT stateNode;
    class GATE,KID,RECIPE_STATE,PACKS phase;
    class G1 detector;
    class G2,G3 detector;
    class G4 detector;
    class PRFS,DRIFT stateNode;
    class DISPATCH gap;
    class AUTO_MERGE,DIRECT_ENQ newComponent;
    class EVER handler;
    class STALL_CTR,NIQC,INCON handler;
    class C1,C2,C3,C4,C5,C6,C7,C8,C9 phase;
    class R_CI,R_MERGE,R_TOOLS detector;
    class CRESULT output;
```

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph L3_Server ["LAYER 3 — SERVER (FastMCP)"]
        direction LR
        SERVER_INIT["● server/__init__.py<br/>━━━━━━━━━━<br/>Tool registration<br/>Tag-based gating"]
        TOOLS_CI["● server/tools_ci.py<br/>━━━━━━━━━━<br/>enqueue_pr, wait_for_ci<br/>Fan-In: 0 · Fan-Out: 3"]
        TOOLS_KITCHEN["● server/tools_kitchen.py<br/>━━━━━━━━━━<br/>open/close kitchen<br/>Fan-In: 1 · Fan-Out: 6"]
        SERVER_HELPERS["server/helpers.py<br/>━━━━━━━━━━<br/>_notify, _run_subprocess<br/>fetch_repo_merge_state"]
    end

    subgraph L3_CLI ["LAYER 3 — CLI"]
        direction LR
        COOK["● cli/_cook.py<br/>━━━━━━━━━━<br/>Ephemeral skill sessions<br/>Fan-In: 2 · Fan-Out: 8"]
    end

    subgraph L2_Recipe ["LAYER 2 — RECIPE RULES"]
        direction LR
        RULES_CI["● recipe/rules_ci.py<br/>━━━━━━━━━━<br/>CI step validation"]
        RULES_MERGE["● recipe/rules_merge.py<br/>━━━━━━━━━━<br/>Merge step rules"]
        RULES_TOOLS["● recipe/rules_tools.py<br/>━━━━━━━━━━<br/>Tool-set validation"]
        RECIPE_INIT["recipe/__init__.py<br/>━━━━━━━━━━<br/>Side-effect registration"]
        RECIPE_ANALYSIS["recipe/_analysis.py<br/>━━━━━━━━━━<br/>ValidationContext"]
        RECIPE_REGISTRY["recipe/registry.py<br/>━━━━━━━━━━<br/>@semantic_rule"]
    end

    subgraph L2_Franchise ["LAYER 2 — FRANCHISE"]
        direction LR
        FRANCHISE["franchise/<br/>━━━━━━━━━━<br/>FRANCHISE_MENU_TOOLS"]
    end

    subgraph L1_Execution ["LAYER 1 — EXECUTION"]
        direction LR
        MERGE_QUEUE["● execution/merge_queue.py<br/>━━━━━━━━━━<br/>MergeQueueWatcher<br/>fetch_repo_merge_state<br/>Fan-In: 4 · Fan-Out: 2"]
        EXEC_GITHUB["execution/github.py<br/>━━━━━━━━━━<br/>github_headers"]
    end

    subgraph L1_Pipeline ["LAYER 1 — PIPELINE"]
        direction LR
        PIPELINE_GATE["pipeline/gate.py<br/>━━━━━━━━━━<br/>GATED/UNGATED_TOOLS<br/>DefaultGateState"]
    end

    subgraph L1_Config ["LAYER 1 — CONFIG"]
        direction LR
        CONFIG["config/<br/>━━━━━━━━━━<br/>Settings, defaults"]
    end

    subgraph L0_Core ["LAYER 0 — CORE (Foundation)"]
        direction LR
        TYPE_ENUMS["● core/_type_enums.py<br/>━━━━━━━━━━<br/>PRState, StrEnums<br/>Fan-In: 5 · Fan-Out: 0"]
        TYPE_CONSTANTS["● core/_type_constants.py<br/>━━━━━━━━━━<br/>GATED_TOOLS, HEADLESS_TOOLS<br/>Fan-In: 4 · Fan-Out: 1"]
        TYPE_PROTOCOLS["● core/_type_protocols.py<br/>━━━━━━━━━━<br/>Protocol ABCs<br/>Fan-In: 2 · Fan-Out: 1"]
        TYPES_HUB["core/types.py<br/>━━━━━━━━━━<br/>Re-export hub ★*"]
    end

    subgraph Hooks_Layer ["HOOKS (Isolated — stdlib-only)"]
        direction LR
        PRETTY_HOOK["● hooks/pretty_output_hook.py<br/>━━━━━━━━━━<br/>MCP JSON→Markdown<br/>reformatter"]
        FMT_EXEC["hooks/_fmt_execution.py<br/>━━━━━━━━━━<br/>run_skill, test_check fmt"]
        FMT_PRIMITIVES["hooks/_fmt_primitives.py<br/>━━━━━━━━━━<br/>Payload dataclasses"]
    end

    subgraph Tests_Layer ["TESTS"]
        direction LR
        TEST_ENQUEUE["★ tests/server/<br/>test_tools_ci_enqueue.py<br/>━━━━━━━━━━<br/>NEW: enqueue_pr tests"]
        TEST_MERGE_Q["● tests/execution/<br/>test_merge_queue.py"]
        TEST_TYPES["● tests/core/<br/>test_types.py"]
        TEST_GATE["● tests/pipeline/<br/>test_gate.py"]
        TEST_RULES["● tests/recipe/<br/>test_rules_merge.py<br/>test_merge_prs_queue.py"]
        TEST_REG["● tests/server/<br/>test_server_tool_registration.py"]
        TEST_FAKES["● tests/fakes.py"]
    end

    %% ═══ L3 SERVER INTERNAL ═══ %%
    SERVER_INIT -->|"registers"| TOOLS_CI
    SERVER_INIT -->|"registers"| TOOLS_KITCHEN
    TOOLS_CI -->|"imports"| SERVER_HELPERS
    TOOLS_KITCHEN -->|"imports"| SERVER_HELPERS

    %% ═══ L3 → L2 ═══ %%
    TOOLS_KITCHEN -->|"imports"| FRANCHISE
    COOK -->|"imports"| FRANCHISE

    %% ═══ L3 → L1 ═══ %%
    TOOLS_CI -->|"imports CIRunScope"| TYPES_HUB
    SERVER_INIT -->|"imports"| PIPELINE_GATE
    SERVER_INIT -->|"imports"| CONFIG
    COOK -->|"imports"| CONFIG

    %% ═══ L2 RECIPE INTERNAL ═══ %%
    RECIPE_INIT -->|"side-effect import"| RULES_CI
    RECIPE_INIT -->|"side-effect import"| RULES_MERGE
    RECIPE_INIT -->|"side-effect import"| RULES_TOOLS
    RULES_CI -->|"imports"| RECIPE_ANALYSIS
    RULES_CI -->|"imports"| RECIPE_REGISTRY
    RULES_MERGE -->|"imports"| RECIPE_ANALYSIS
    RULES_MERGE -->|"imports"| RECIPE_REGISTRY
    RULES_TOOLS -->|"imports"| RECIPE_ANALYSIS
    RULES_TOOLS -->|"imports"| RECIPE_REGISTRY

    %% ═══ L2 → L0 ═══ %%
    RULES_CI -->|"PRState, Severity"| TYPES_HUB
    RULES_MERGE -->|"MergeFailedStep, Severity"| TYPES_HUB
    RULES_TOOLS -->|"GATED_TOOLS, HEADLESS_TOOLS"| TYPES_HUB

    %% ═══ L1 EXECUTION INTERNAL ═══ %%
    MERGE_QUEUE -->|"imports"| EXEC_GITHUB

    %% ═══ L1 → L0 ═══ %%
    MERGE_QUEUE -->|"PRState"| TYPES_HUB
    PIPELINE_GATE -->|"imports"| TYPES_HUB

    %% ═══ L0 CORE INTERNAL ═══ %%
    TYPE_CONSTANTS -->|"imports"| TYPE_ENUMS
    TYPE_PROTOCOLS -->|"imports _type_results"| TYPE_ENUMS
    TYPES_HUB -->|"re-exports *"| TYPE_ENUMS
    TYPES_HUB -->|"re-exports *"| TYPE_CONSTANTS
    TYPES_HUB -->|"re-exports *"| TYPE_PROTOCOLS

    %% ═══ HOOKS INTERNAL (stdlib-only) ═══ %%
    PRETTY_HOOK -->|"sibling import"| FMT_EXEC
    PRETTY_HOOK -->|"sibling import"| FMT_PRIMITIVES

    %% ═══ TESTS → PRODUCTION ═══ %%
    TEST_ENQUEUE -->|"imports enqueue_pr"| TOOLS_CI
    TEST_MERGE_Q -->|"imports"| MERGE_QUEUE
    TEST_TYPES -->|"imports"| TYPES_HUB
    TEST_GATE -->|"imports"| PIPELINE_GATE
    TEST_RULES -->|"imports"| RULES_MERGE
    TEST_RULES -->|"imports"| RECIPE_REGISTRY
    TEST_REG -->|"imports"| PIPELINE_GATE
    TEST_FAKES -->|"imports"| TYPES_HUB

    %% ═══ CLASS ASSIGNMENTS ═══ %%
    class SERVER_INIT,TOOLS_CI,TOOLS_KITCHEN,SERVER_HELPERS cli;
    class COOK cli;
    class RULES_CI,RULES_MERGE,RULES_TOOLS,RECIPE_INIT,RECIPE_ANALYSIS,RECIPE_REGISTRY phase;
    class FRANCHISE phase;
    class MERGE_QUEUE,EXEC_GITHUB handler;
    class PIPELINE_GATE,CONFIG handler;
    class TYPE_ENUMS,TYPE_CONSTANTS,TYPE_PROTOCOLS,TYPES_HUB stateNode;
    class PRETTY_HOOK,FMT_EXEC,FMT_PRIMITIVES detector;
    class TEST_ENQUEUE newComponent;
    class TEST_MERGE_Q,TEST_TYPES,TEST_GATE,TEST_RULES,TEST_REG,TEST_FAKES output;
```

Closes #1178

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260424-070448-248773/.autoskillit/temp/rectify/rectify_merge_queue_enrollment_2026-04-24_071500_part_a.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| investigate | 55 | 11.5k | 923.0k | 60.9k | 1 | 8m 34s |
| rectify | 73 | 13.2k | 1.1M | 67.5k | 1 | 9m 33s |
| review | 2.3k | 6.6k | 192.8k | 29.6k | 1 | 8m 52s |
| dry_walkthrough | 44 | 9.2k | 843.2k | 54.0k | 1 | 6m 23s |
| implement | 214 | 14.6k | 1.2M | 51.0k | 1 | 5m 6s |
| prepare_pr | 60 | 5.0k | 201.7k | 27.3k | 1 | 1m 31s |
| run_arch_lenses | 1.1k | 17.2k | 699.4k | 127.5k | 3 | 6m 31s |
| compose_pr | 67 | 10.0k | 255.6k | 35.1k | 1 | 2m 31s |
| review_pr | 798 | 39.3k | 1.1M | 76.0k | 1 | 10m 1s |
| resolve_review | 458 | 48.6k | 3.1M | 156.9k | 2 | 17m 13s |
| diagnose_ci | 132 | 4.4k | 354.2k | 31.7k | 2 | 3m 18s |
| resolve_ci | 88 | 3.6k | 309.2k | 28.7k | 1 | 4m 44s |
| **Total** | 5.4k | 183.1k | 10.2M | 746.3k | | 1h 24m |