### PR TITLE
Remove code-index MCP Server Integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,9 @@ A Claude Code plugin that orchestrates automated skill-driven workflows using he
   * **Version Bumps**: When bumping the package version, update `pyproject.toml` and run `task sync-plugin-version && uv lock`; then search tests for hardcoded version strings (e.g. `AUTOSKILLIT_INSTALLED_VERSION` monkeypatches) and update them.
   * **Run pre-commit before committing**: Always run `pre-commit run --all-files` before committing. Do not skip this step even when code appears clean — hooks auto-fix formatting and abort the commit, requiring re-stage and retry.
   * **Hook Renames**: Renaming a hook script under `src/autoskillit/hooks/` must update `HOOK_REGISTRY` in `hook_registry.py` AND add the old basename to `RETIRED_SCRIPT_BASENAMES` in the same commit. `test_no_retired_name_has_a_live_file` will fail otherwise.
+  * **Grep tool uses ripgrep (ERE) syntax**: Use `|` for OR-alternation in Grep tool `pattern`
+    arguments. `\|` is Bash grep BRE syntax — ripgrep treats it as a literal backslash-pipe
+    and returns 0 results. Example: `Grep(pattern="foo|bar")` not `Grep(pattern="foo\|bar")`.
 
 ### **3.2. File System**
 
@@ -38,23 +41,12 @@ A Claude Code plugin that orchestrates automated skill-driven workflows using he
   * **Do Not Add Root Files**: Never create new root files unless explicitly required.
   * **Never commit unless told to do so**
 
-### **3.3. Code Index MCP Usage**
-
-  * **Initialize before use**: Always call `set_project_path` with the project root as the first action in any session that will use code-index tools. Without this call, all code-index tools fail with "Project path not set" and cascade-cancel sibling parallel calls.
-  * **Index is locked to the main project root**: The `code-index` MCP server is indexed against the source repo and must never be redirected to a worktree or branch. Its value is for exploration before code changes — at that point any worktree is identical to main, so the index is accurate regardless of where you are working.
-  * **Prefer code-index tools over native search** when exploring the codebase: `find_files`, `search_code_advanced`, `get_file_summary`, `get_symbol_body` (includes `called_by` call graph).
-  * **Do not rely on code-index for code added or modified during a branch** — use Read/Grep directly for that.
-  * **Fall back to native Grep/Glob** for multiline patterns or paths outside the project root.
-  * **Grep tool uses ripgrep (ERE) syntax**: Use `|` for OR-alternation in Grep tool `pattern`
-    arguments. `\|` is Bash grep BRE syntax — ripgrep treats it as a literal backslash-pipe
-    and returns 0 results. Example: `Grep(pattern="foo|bar")` not `Grep(pattern="foo\|bar")`.
-
-### **3.4. CLAUDE.md Modifications**
+### **3.3. CLAUDE.md Modifications**
 
   * **Correcting existing content is permitted**: If you discover that CLAUDE.md contains inaccurate information (wrong file paths, stale names, incorrect tool attributions), you may correct it without being asked.
   * **Adding new content requires explicit instruction**: Never add new sections, bullet points, entries, or any new information to CLAUDE.md unless the user has explicitly asked you to update or extend it. Corrections to existing facts ≠ permission to expand scope.
 
-### **3.5. GitHub API Call Discipline**
+### **3.4. GitHub API Call Discipline**
 
   * **Batch inline review comments** via `POST /pulls/{N}/reviews` with `comments[]` array — never post comments individually unless the batch call fails.
   * **Batch GraphQL mutations** via aliases (N mutations in 1 request = 5 pts total, not N × 5 pts). Use for thread resolution, bulk PR queries, and any operation touching multiple entities.

--- a/src/autoskillit/execution/commands.py
+++ b/src/autoskillit/execution/commands.py
@@ -218,9 +218,7 @@ def _inject_cwd_anchor(skill_command: str, cwd: str, temp_dir_relpath: str | Non
         f"\n\nWORKING DIRECTORY ANCHOR: Your working directory is {cwd}. "
         f"All relative paths ({relpath}/, .autoskillit/, etc.) "
         f"MUST resolve against {cwd}. "
-        f"Do NOT use any other directory as a base for relative paths, regardless of "
-        f"what paths appear in code-index tool responses or set_project_path results. "
-        f"The code-index project path is for READ-ONLY exploration only."
+        f"Do NOT use any other directory as a base for relative paths."
     )
     return skill_command + directive
 

--- a/src/autoskillit/skills_extended/audit-claims/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-claims/SKILL.md
@@ -75,25 +75,6 @@ fi
 If `pr_url` is missing or positional args are insufficient, abort with:
 `"Usage: /autoskillit:audit-claims <worktree_path> <base_branch> <pr_url>"`
 
-### Step 0.5 — Code-Index Initialization (required before any code-index tool call)
-
-Call `set_project_path` with the repo root where this skill was invoked (not a worktree path):
-
-```
-mcp__code-index__set_project_path(path="{PROJECT_ROOT}")
-```
-
-Code-index tools require **project-relative paths**. Always use paths like:
-
-    src/mypackage/core/module.py
-
-NOT absolute paths like:
-
-    /path/to/project/src/mypackage/core/module.py
-
-Agents launched via `run_skill` inherit no code-index state from the parent session — this
-call is mandatory at the start of every headless session that uses code-index tools.
-
 ### Step 1: Use the Explicit PR URL
 
 Parse `pr_number` from `pr_url` (last path segment).

--- a/src/autoskillit/skills_extended/audit-cohesion/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-cohesion/SKILL.md
@@ -369,12 +369,6 @@ Flag duplicates (same name in different agents).
 
 ## Audit Workflow
 
-### Step 0: Initialize Code Index
-
-```
-mcp__code-index__set_project_path(path="{PROJECT_ROOT}")
-```
-
 ### Step 1: Launch Parallel Subagents
 
 Spawn subagents for each cohesion dimension. Each subagent MUST be instructed:

--- a/src/autoskillit/skills_extended/audit-impl/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-impl/SKILL.md
@@ -116,30 +116,6 @@ exist (e.g., plan file arguments, `{{AUTOSKILLIT_TEMP}}/investigate/` reports, e
 `Glob` or `ls` to confirm the path exists first. This prevents ENOENT errors that cascade into
 sibling parallel-call cancellations.
 
-### Step 0.5 — Code-Index Initialization (required before any code-index tool call)
-
-Call `set_project_path` with the repo root where this skill was invoked (not a worktree path):
-
-```
-mcp__code-index__set_project_path(path="{PROJECT_ROOT}")
-```
-
-Code-index tools require **project-relative paths**. Always use paths like:
-
-    src/<your_package>/some_module.py
-
-NOT absolute paths like:
-
-    /absolute/path/to/src/<your_package>/some_module.py
-
-> **Note:** Code-index tools (`find_files`, `search_code_advanced`, `get_file_summary`,
-> `get_symbol_body`) are only available when the `code-index` MCP server is configured.
-> If `set_project_path` returns an error, fall back to native `Glob` and `Grep` tools
-> for the same searches — they provide equivalent results without the code-index server.
-
-Agents launched via `run_skill` inherit no code-index state from the parent session — this
-call is mandatory at the start of every headless session that uses code-index tools.
-
 ### Step 1 — Load Plans via Parallel Subagents
 
 Launch one Explore subagent per plan file in parallel. Each returns:

--- a/src/autoskillit/skills_extended/build-execution-map/SKILL.md
+++ b/src/autoskillit/skills_extended/build-execution-map/SKILL.md
@@ -61,11 +61,6 @@ if present (default: `main`). Validate the issue count:
 - **One issue**: emit a warning and write a trivial single-group map (single issue always gets `parallel: false`).
 - **Two or more issues**: proceed to Step 0.5.
 
-### Step 0.5 — Code-Index Initialization
-
-Call `mcp__code-index__set_project_path` with the project root (current working directory).
-Fall back to native Glob/Grep if the code-index MCP is unavailable.
-
 ### Step 1 — Fetch Issue Data (parallel subagents)
 
 Launch up to 8 parallel `sonnet` subagents, one per issue. Each subagent:

--- a/src/autoskillit/skills_extended/diagnose-ci/SKILL.md
+++ b/src/autoskillit/skills_extended/diagnose-ci/SKILL.md
@@ -38,7 +38,6 @@ before routing to `resolve-failures`.
 - Block on missing `gh` CLI — write a minimal `failure_type=unknown` diagnosis instead
 
 **ALWAYS:**
-- Initialize code-index: call `set_project_path` to current cwd before any search
 - Write the diagnosis file before emitting output tokens
 - Emit the four output tokens (`diagnosis_path`, `failure_type`, `failure_subtype`, `is_fixable`) at the end of the response on their own lines
 
@@ -55,13 +54,7 @@ best-effort with whatever diagnosis was written (or none).
 
 ## Workflow
 
-### Step 1: Initialize Code Index
-
-```
-mcp__code-index__set_project_path(path=<cwd>)
-```
-
-### Step 2: Discover Run ID (if not provided)
+### Step 1: Discover Run ID (if not provided)
 
 If `run_id` is not provided as an argument (or is `-`), construct the `gh run list` command
 with any provided filters:

--- a/src/autoskillit/skills_extended/implement-worktree-no-merge/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-worktree-no-merge/SKILL.md
@@ -132,16 +132,6 @@ execution layer scans `assistant_messages` for `worktree_path=` and surfaces
 it as a top-level field in the `run_skill` JSON response. The orchestrator
 reads this field directly without filesystem discovery heuristics.
 
-### Step 1.5: Initialize Code Index for Original Project
-
-Set the MCP code-index project path to the **original project directory** so Explore subagents can use code search tools:
-
-```
-mcp__code-index__set_project_path(path="{ORIGINAL_PROJECT_PATH}")
-```
-
-This must happen before Step 2 or any code-index search tools will fail with "Project path not set."
-
 ### Step 2: Deep System Understanding (Subagents)
 
 Before implementing ANY code, launch parallel Explore subagents to understand affected systems:
@@ -163,16 +153,6 @@ task install-worktree   # or equivalent for the project type
 **Why isolated env matters:** Installing packages without isolation overwrites the global state. When the worktree is deleted, CLI commands break with import errors.
 
 **All commands in Steps 4–5 must run from `${WORKTREE_PATH}`.** Use absolute paths to avoid CWD drift across Bash tool calls.
-
-### Step 3.5: Re-point Code Index to Worktree (REQUIRED)
-
-**CRITICAL:** After setting up the worktree environment, you **MUST** update the MCP code-index project path to the worktree:
-
-```
-mcp__code-index__set_project_path(path="${WORKTREE_PATH}")
-```
-
-**Failure to do this means code-index searches will return results from the original project, not your worktree.**
 
 ### Step 4: Implement Phase by Phase
 
@@ -237,14 +217,6 @@ branch_name = ${WORKTREE_NAME}
 created from the post-merge state of the base branch, not from Part N's base
 commit. This is a global sequencing rule — it applies even when operating
 off-recipe.
-
-### Step 6.5: Reset Code Index to Original Project (REQUIRED)
-
-**CRITICAL:** After completion, you **MUST** reset the MCP code-index project path back to the original project directory:
-
-```
-mcp__code-index__set_project_path(path="{ORIGINAL_PROJECT_PATH}")
-```
 
 ## Error Handling
 

--- a/src/autoskillit/skills_extended/implement-worktree/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-worktree/SKILL.md
@@ -90,16 +90,6 @@ mkdir -p "{{AUTOSKILLIT_TEMP}}/worktrees/${WORKTREE_NAME}"
 echo "${CURRENT_BRANCH}" > "{{AUTOSKILLIT_TEMP}}/worktrees/${WORKTREE_NAME}/base-branch"
 ```
 
-### Step 1.5: Initialize Code Index for Original Project
-
-Set the MCP code-index project path to the **original project directory** so Explore subagents can use code search tools:
-
-```
-mcp__code-index__set_project_path(path="{ORIGINAL_PROJECT_PATH}")
-```
-
-This must happen before Step 2 or any code-index search tools will fail with "Project path not set."
-
 ### Step 2: Deep System Understanding (Subagents)
 
 Before implementing ANY code, launch parallel Explore subagents to understand affected systems:
@@ -121,16 +111,6 @@ task install-worktree   # or equivalent for the project type
 **Why isolated env matters:** Installing packages without isolation overwrites the global state. When the worktree is deleted, CLI commands break with import errors.
 
 **All commands in Steps 4–6 must run from `${WORKTREE_PATH}`.** Use absolute paths to avoid CWD drift across Bash tool calls.
-
-### Step 3.5: Re-point Code Index to Worktree (REQUIRED)
-
-**CRITICAL:** After setting up the worktree environment, you **MUST** update the MCP code-index project path to the worktree. This ensures all subsequent code searches operate on the worktree's files (which will diverge from the original as implementation proceeds):
-
-```
-mcp__code-index__set_project_path(path="${WORKTREE_PATH}")
-```
-
-**Failure to do this means code-index searches will return results from the original project, not your worktree — leading to confusion and incorrect file reads.**
 
 ### Step 4: Implement Phase by Phase
 
@@ -214,16 +194,6 @@ worktree_path = ${WORKTREE_PATH}
 branch_name = ${WORKTREE_NAME}
 base_branch = ${CURRENT_BRANCH}
 ```
-
-### Step 7.5: Reset Code Index to Original Project (REQUIRED)
-
-**CRITICAL:** After worktree cleanup, you **MUST** reset the MCP code-index project path back to the original project directory:
-
-```
-mcp__code-index__set_project_path(path="{ORIGINAL_PROJECT_PATH}")
-```
-
-**Failure to do this leaves code-index pointing at a deleted worktree path, breaking all subsequent code searches in any session.**
 
 ## Error Handling
 

--- a/src/autoskillit/skills_extended/investigate/SKILL.md
+++ b/src/autoskillit/skills_extended/investigate/SKILL.md
@@ -75,30 +75,6 @@ exist (e.g., plan file arguments, `{{AUTOSKILLIT_TEMP}}/investigate/` reports, e
 `Glob` or `ls` to confirm the path exists first. This prevents ENOENT errors that cascade into
 sibling parallel-call cancellations.
 
-### Step 0.5 — Code-Index Initialization (required before any code-index tool call)
-
-Call `set_project_path` with the repo root where this skill was invoked (not a worktree path):
-
-```
-mcp__code-index__set_project_path(path="{PROJECT_ROOT}")
-```
-
-Code-index tools require **project-relative paths**. Always use paths like:
-
-    src/<your_package>/some_module.py
-
-NOT absolute paths like:
-
-    /absolute/path/to/src/<your_package>/some_module.py
-
-> **Note:** Code-index tools (`find_files`, `search_code_advanced`, `get_file_summary`,
-> `get_symbol_body`) are only available when the `code-index` MCP server is configured.
-> If `set_project_path` returns an error, fall back to native `Glob` and `Grep` tools
-> for the same searches — they provide equivalent results without the code-index server.
-
-Agents launched via `run_skill` inherit no code-index state from the parent session — this
-call is mandatory at the start of every headless session that uses code-index tools.
-
 ### Step 1: Parse the Investigation Target
 
 Identify what needs investigation:

--- a/src/autoskillit/skills_extended/make-groups/SKILL.md
+++ b/src/autoskillit/skills_extended/make-groups/SKILL.md
@@ -81,30 +81,6 @@ tool **before** beginning any analysis. Use the returned `content` field as the 
 
 Read the full document. Inventory every requirement (REQ-*), feature, and deliverable. Build a raw list with original IDs preserved.
 
-### Step 1.5 — Code-Index Initialization (required before any code-index tool call)
-
-Call `set_project_path` with the repo root where this skill was invoked (not a worktree path):
-
-```
-mcp__code-index__set_project_path(path="{PROJECT_ROOT}")
-```
-
-Code-index tools require **project-relative paths**. Always use paths like:
-
-    src/<your_package>/some_module.py
-
-NOT absolute paths like:
-
-    /absolute/path/to/src/<your_package>/some_module.py
-
-> **Note:** Code-index tools (`find_files`, `search_code_advanced`, `get_file_summary`,
-> `get_symbol_body`) are only available when the `code-index` MCP server is configured.
-> If `set_project_path` returns an error, fall back to native `Glob` and `Grep` tools
-> for the same searches — they provide equivalent results without the code-index server.
-
-Agents launched via `run_skill` inherit no code-index state from the parent session — this
-call is mandatory at the start of every headless session that uses code-index tools.
-
 ### Step 2: Verify Against Codebase
 
 Launch **parallel Explore subagents** to understand:

--- a/src/autoskillit/skills_extended/make-plan/SKILL.md
+++ b/src/autoskillit/skills_extended/make-plan/SKILL.md
@@ -66,30 +66,6 @@ tool **before** beginning any analysis. Use the returned `content` field as the 
 
 ## Planning Steps
 
-**Step 0 — Code-Index Initialization (required before any code-index tool call)**
-
-Call `set_project_path` with the repo root where this skill was invoked (not a worktree path):
-
-```
-mcp__code-index__set_project_path(path="{PROJECT_ROOT}")
-```
-
-Code-index tools require **project-relative paths**. Always use paths like:
-
-    src/<your_package>/some_module.py
-
-NOT absolute paths like:
-
-    /absolute/path/to/src/<your_package>/some_module.py
-
-> **Note:** Code-index tools (`find_files`, `search_code_advanced`, `get_file_summary`,
-> `get_symbol_body`) are only available when the `code-index` MCP server is configured.
-> If `set_project_path` returns an error, fall back to native `Glob` and `Grep` tools
-> for the same searches — they provide equivalent results without the code-index server.
-
-Agents launched via `run_skill` inherit no code-index state from the parent session — this
-call is mandatory at the start of every headless session that uses code-index tools.
-
 1. **Understand related systems and validate details** - Use subagents to study the architecture, how components work together, their purpose, patterns, and standards. Validate any details provided in the task description.
 
 2. **Explore and design approaches** - Use subagents to investigate different ways to solve the problem. Use subagents with web search to research modern solutions, approaches, designs, and architectures relevant to the problem. For each approach, focus on:

--- a/src/autoskillit/skills_extended/rectify/SKILL.md
+++ b/src/autoskillit/skills_extended/rectify/SKILL.md
@@ -71,30 +71,6 @@ exist (e.g., plan file arguments, `{{AUTOSKILLIT_TEMP}}/investigate/` reports, e
 `Glob` or `ls` to confirm the path exists first. This prevents ENOENT errors that cascade into
 sibling parallel-call cancellations.
 
-### Step 1.5 — Code-Index Initialization (required before any code-index tool call)
-
-Call `set_project_path` with the repo root where this skill was invoked (not a worktree path):
-
-```
-mcp__code-index__set_project_path(path="{PROJECT_ROOT}")
-```
-
-Code-index tools require **project-relative paths**. Always use paths like:
-
-    src/<your_package>/some_module.py
-
-NOT absolute paths like:
-
-    /absolute/path/to/src/<your_package>/some_module.py
-
-> **Note:** Code-index tools (`find_files`, `search_code_advanced`, `get_file_summary`,
-> `get_symbol_body`) are only available when the `code-index` MCP server is configured.
-> If `set_project_path` returns an error, fall back to native `Glob` and `Grep` tools
-> for the same searches — they provide equivalent results without the code-index server.
-
-Agents launched via `run_skill` inherit no code-index state from the parent session — this
-call is mandatory at the start of every headless session that uses code-index tools.
-
 ### Step 2: Deep Exploration with Subagents
 
 Launch parallel subagents to investigate (some of the listed aspects may require multiple subagents):

--- a/src/autoskillit/skills_extended/resolve-claims-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-claims-review/SKILL.md
@@ -96,25 +96,6 @@ validation_timeout = cr_cfg.get("validation_timeout", 120)
 If either positional arg is missing, abort with:
 `"Usage: /autoskillit:resolve-claims-review <worktree_path> <base_branch>"`
 
-### Step 0.5 — Code-Index Initialization (required before any code-index tool call)
-
-Call `set_project_path` with the repo root where this skill was invoked (not a worktree path):
-
-```
-mcp__code-index__set_project_path(path="{PROJECT_ROOT}")
-```
-
-Code-index tools require **project-relative paths**. Always use paths like:
-
-    src/mypackage/core/module.py
-
-NOT absolute paths like:
-
-    /path/to/project/src/mypackage/core/module.py
-
-Agents launched via `run_skill` inherit no code-index state from the parent session — this
-call is mandatory at the start of every headless session that uses code-index tools.
-
 ### Step 1: Find the Open PR
 
 ```bash

--- a/src/autoskillit/skills_extended/resolve-failures/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-failures/SKILL.md
@@ -99,30 +99,6 @@ Read the configured test command from `.autoskillit/config.yaml` (key: `test_che
    sibling parallel-call cancellations.
 4. Check for development environment in worktree, recreate if missing. Use the project's configured `worktree_setup.command`, or: `cd "${worktree_path}" && task install-worktree`
 
-### Step 0.3 — Code-Index Initialization (required before any code-index tool call)
-
-Call `set_project_path` with the repo root where this skill was invoked (not a worktree path):
-
-```
-mcp__code-index__set_project_path(path="{PROJECT_ROOT}")
-```
-
-Code-index tools require **project-relative paths**. Always use paths like:
-
-    src/<your_package>/some_module.py
-
-NOT absolute paths like:
-
-    /absolute/path/to/src/<your_package>/some_module.py
-
-> **Note:** Code-index tools (`find_files`, `search_code_advanced`, `get_file_summary`,
-> `get_symbol_body`) are only available when the `code-index` MCP server is configured.
-> If `set_project_path` returns an error, fall back to native `Glob` and `Grep` tools
-> for the same searches — they provide equivalent results without the code-index server.
-
-Agents launched via `run_skill` inherit no code-index state from the parent session — this
-call is mandatory at the start of every headless session that uses code-index tools.
-
 ### Step 0.5: Commit Uncommitted Files
 1. Run `git -C {worktree_path} status --porcelain`
 2. If output is non-empty (dirty tree):
@@ -130,20 +106,6 @@ call is mandatory at the start of every headless session that uses code-index to
    - Run `git -C {worktree_path} commit -m "chore: commit auto-generated files"`
    - Log: "Committed {N} uncommitted file(s) before test run"
 3. If output is empty: continue (worktree is clean)
-
-### Step 0.7: Switch Code-Index to Worktree
-
-Call `set_project_path` with the worktree path so all subsequent code-index
-queries (`find_files`, `search_code_advanced`, `get_file_summary`, `get_symbol_body`)
-return worktree-relative paths instead of source-repo paths:
-
-```
-mcp__code-index__set_project_path(path="{worktree_path}")
-```
-
-This prevents the model from being exposed to source-repo absolute paths during
-investigation and fixing. Note: code-index tools are read-only; this switch does not
-affect git operations, which always use `git -C {worktree_path}` explicitly.
 
 ### Step 1: Understand Context
 1. Read the plan file to understand what was implemented and why

--- a/src/autoskillit/skills_extended/retry-worktree/SKILL.md
+++ b/src/autoskillit/skills_extended/retry-worktree/SKILL.md
@@ -138,16 +138,6 @@ Then assess what has been implemented:
    - Which phase is partially complete
    - Which phases haven't started
 
-### Step 1.5: Initialize Code Index for Worktree
-
-Set the MCP code-index project path to the worktree so code searches operate on the correct files:
-
-```
-mcp__code-index__set_project_path(path="{WORKTREE_PATH}")
-```
-
-This must happen before any code-index searches or Explore subagents.
-
 ### Step 2: Targeted Exploration (Only If Needed)
 
 Only explore systems related to the **remaining** phases. Do NOT re-explore already-completed work. Use Explore subagents for:
@@ -215,16 +205,6 @@ phases_implemented = ${PHASES_IMPLEMENTED}
 
 Where `PHASES_IMPLEMENTED` is the count from Step 3. If Step 3 was skipped entirely
 (all phases already complete), emit `phases_implemented = 0`.
-
-### Step 6.5: Reset Code Index to Original Project (REQUIRED)
-
-After worktree cleanup, reset the MCP code-index project path back to the original project directory:
-
-```
-mcp__code-index__set_project_path(path="{ORIGINAL_PROJECT_PATH}")
-```
-
-Failure to do this leaves code-index pointing at a deleted worktree path, breaking all subsequent code searches.
 
 ## Error Handling
 

--- a/src/autoskillit/skills_extended/review-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/review-pr/SKILL.md
@@ -64,25 +64,6 @@ escalation_user=$(gh api user -q .login 2>/dev/null || echo "")
 If `escalation_user` is non-empty, set `escalation_user_mention="@${escalation_user}"`.
 If empty (gh unavailable or not authenticated), set `escalation_user_mention=""`.
 
-### Step 0.5 — Code-Index Initialization (required before any code-index tool call)
-
-Call `set_project_path` with the repo root where this skill was invoked (not a worktree path):
-
-```
-mcp__code-index__set_project_path(path="{PROJECT_ROOT}")
-```
-
-Code-index tools require **project-relative paths**. Always use paths like:
-
-    src/mypackage/core/module.py
-
-NOT absolute paths like:
-
-    /path/to/project/src/mypackage/core/module.py
-
-Agents launched via `run_skill` inherit no code-index state from the parent session — this
-call is mandatory at the start of every headless session that uses code-index tools.
-
 ### Step 1: Find the Open PR
 
 ```bash

--- a/src/autoskillit/skills_extended/review-research-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/review-research-pr/SKILL.md
@@ -76,25 +76,6 @@ escalation_user=$(gh api user -q .login 2>/dev/null || echo "")
 If `escalation_user` is non-empty, set `escalation_user_mention="@${escalation_user}"`.
 If empty (gh unavailable or not authenticated), set `escalation_user_mention=""`.
 
-### Step 0.5 — Code-Index Initialization (required before any code-index tool call)
-
-Call `set_project_path` with the repo root where this skill was invoked (not a worktree path):
-
-```
-mcp__code-index__set_project_path(path="{PROJECT_ROOT}")
-```
-
-Code-index tools require **project-relative paths**. Always use paths like:
-
-    src/mypackage/core/module.py
-
-NOT absolute paths like:
-
-    /path/to/project/src/mypackage/core/module.py
-
-Agents launched via `run_skill` inherit no code-index state from the parent session — this
-call is mandatory at the start of every headless session that uses code-index tools.
-
 ### Step 1: Find the Open PR
 
 ```bash

--- a/src/autoskillit/skills_extended/triage-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/triage-issues/SKILL.md
@@ -58,30 +58,6 @@ Parse optional arguments from the user's invocation:
                Skips issues that already have a `## Requirements` section (idempotent).
                No effect on `recipe:remediation` issues.
 
-### Step 0.5 — Code-Index Initialization (required before any code-index tool call)
-
-Call `set_project_path` with the repo root where this skill was invoked (not a worktree path):
-
-```
-mcp__code-index__set_project_path(path="{PROJECT_ROOT}")
-```
-
-Code-index tools require **project-relative paths**. Always use paths like:
-
-    src/<your_package>/some_module.py
-
-NOT absolute paths like:
-
-    /absolute/path/to/src/<your_package>/some_module.py
-
-> **Note:** Code-index tools (`find_files`, `search_code_advanced`, `get_file_summary`,
-> `get_symbol_body`) are only available when the `code-index` MCP server is configured.
-> If `set_project_path` returns an error, fall back to native `Glob` and `Grep` tools
-> for the same searches — they provide equivalent results without the code-index server.
-
-Agents launched via `run_skill` inherit no code-index state from the parent session — this
-call is mandatory at the start of every headless session that uses code-index tools.
-
 ### Step 1: Authenticate and Fetch Issues
 
 ```bash

--- a/src/autoskillit/skills_extended/troubleshoot-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/troubleshoot-experiment/SKILL.md
@@ -38,19 +38,12 @@ Called by the `research` recipe on `implement_phase` failure before routing to
 - Abort when session data is missing — emit `failure_type=unknown`, `is_fixable=false` and exit cleanly
 
 **ALWAYS:**
-- Initialize code-index before any search
 - Write the diagnosis file before emitting output tokens
 - Emit the three output tokens (`diagnosis_path`, `failure_type`, `is_fixable`) at the end
 
 ## Workflow
 
-### Step 1: Initialize Code Index
-
-```
-mcp__code-index__set_project_path(path="{worktree_path}")
-```
-
-### Step 2: Locate the Most Recent Failed Session for this Worktree
+### Step 1: Locate the Most Recent Failed Session for this Worktree
 
 Query the global session index:
 ```bash

--- a/src/autoskillit/skills_extended/validate-audit/SKILL.md
+++ b/src/autoskillit/skills_extended/validate-audit/SKILL.md
@@ -63,17 +63,6 @@ signal downstream processing.
 
 ## Workflow
 
-### Step 0 — Code-Index Initialization
-
-Call `set_project_path` with the repo root:
-
-```
-mcp__code-index__set_project_path(path="{PROJECT_ROOT}")
-```
-
-Use project-relative paths in all code-index queries (e.g., `src/autoskillit/pipeline/`).
-Fall back to native Grep/Glob if the code-index server is unavailable.
-
 ### Step 1 — Detect Audit Format and Parse Findings
 
 Read the audit report file. Detect its source by examining the document title or preamble:

--- a/tests/execution/test_headless.py
+++ b/tests/execution/test_headless.py
@@ -2444,12 +2444,11 @@ class TestInjectCwdAnchor:
         result = _inject_cwd_anchor(original, "/clone/dir")
         assert result.startswith(original)
 
-    def test_directive_mentions_temp_and_read_only(self):
+    def test_directive_mentions_temp(self):
         from autoskillit.execution.commands import _inject_cwd_anchor
 
         result = _inject_cwd_anchor("cmd", "/wd")
         assert ".autoskillit/temp/" in result
-        assert "READ-ONLY" in result
 
     def test_skips_when_cwd_empty(self):
         from autoskillit.execution.commands import _inject_cwd_anchor

--- a/tests/infra/test_claude_md_critical_rules.py
+++ b/tests/infra/test_claude_md_critical_rules.py
@@ -21,26 +21,6 @@ def claude_md() -> str:
     return (REPO_ROOT / "CLAUDE.md").read_text()
 
 
-def test_claude_md_code_index_requires_set_project_path(claude_md: str) -> None:
-    """§3.3 must instruct agents to call set_project_path before using code-index tools.
-
-    Without this call every code-index tool fails with 'Project path not set',
-    cascading into parallel call cancellations (FRICT-1B-3).
-    """
-    # Find the §3.3 section using the full heading to avoid false matches
-    assert "### **3.3" in claude_md, "§3.3 section not found in CLAUDE.md"
-    section_start = claude_md.index("### **3.3")
-    # Find the next top-level section heading (### 3.) to bound the search
-    next_section = claude_md.find("### **3.", section_start + 1)
-    section_text = (
-        claude_md[section_start:next_section] if next_section != -1 else claude_md[section_start:]
-    )
-    assert "set_project_path" in section_text, (
-        "CLAUDE.md §3.3 (Code Index MCP Usage) must instruct agents to call "
-        "set_project_path before using any code-index tool in a new session (FRICT-1B-3)."
-    )
-
-
 def test_claude_md_critical_rules_require_precommit(claude_md: str) -> None:
     """§3.1 (Code and Implementation) must include a pre-commit critical rule.
 

--- a/tests/skills/test_skill_genericization.py
+++ b/tests/skills/test_skill_genericization.py
@@ -62,25 +62,6 @@ def test_merge_pr_uses_generic_ci_check_name() -> None:
     )
 
 
-def test_code_index_examples_are_generic() -> None:
-    """No bundled SKILL.md may use src/autoskillit/ as a code-index path example."""
-    skills_with_violations: list[str] = []
-    for skill_dir in SKILLS_DIR.iterdir():
-        if not skill_dir.is_dir():
-            continue
-        skill_md = skill_dir / "SKILL.md"
-        if not skill_md.exists():
-            continue
-        content = skill_md.read_text()
-        # Check for the specific AutoSkillit path example in code-index instructions
-        if "src/autoskillit/execution/headless.py" in content:
-            skills_with_violations.append(skill_dir.name)
-    assert not skills_with_violations, (
-        f"These skills have AutoSkillit-specific code-index path examples: "
-        f"{skills_with_violations}. Replace with generic placeholders (REQ-GEN-004)."
-    )
-
-
 def test_scope_has_no_hardcoded_metrics_rs() -> None:
     """scope/SKILL.md must not reference the hardcoded src/metrics.rs path."""
     content = (SKILLS_EXTENDED_DIR / "scope" / "SKILL.md").read_text()

--- a/tests/skills/test_skill_output_compliance.py
+++ b/tests/skills/test_skill_output_compliance.py
@@ -259,23 +259,6 @@ def test_output_path_tokens_synchronized() -> None:
     )
 
 
-def test_resolve_failures_skill_switches_code_index_to_worktree():
-    """resolve-failures must set_project_path to worktree_path after env setup."""
-    skill_md = (pkg_root() / "skills_extended" / "resolve-failures" / "SKILL.md").read_text()
-    # Must contain a set_project_path call with worktree_path as the path argument.
-    # Use a regex so minor whitespace or quoting variations don't cause false failures.
-    worktree_switch = re.search(r"set_project_path\([^)]*worktree_path[^)]*\)", skill_md)
-    assert worktree_switch is not None, (
-        "resolve-failures SKILL.md must switch code-index to {worktree_path} after env setup"
-    )
-    # The worktree switch must come after the initial PROJECT_ROOT init.
-    project_root_idx = skill_md.find("PROJECT_ROOT")
-    assert project_root_idx != -1, "resolve-failures SKILL.md must reference PROJECT_ROOT"
-    assert worktree_switch.start() > project_root_idx, (
-        "worktree_path code-index switch must appear after initial PROJECT_ROOT init"
-    )
-
-
 # ---------------------------------------------------------------------------
 # Path-capture structured output compliance
 # ---------------------------------------------------------------------------

--- a/tests/skills/test_skill_preambles.py
+++ b/tests/skills/test_skill_preambles.py
@@ -8,8 +8,6 @@ These encode behavioral contracts derived from friction analysis (issue #250):
 - FRICT-5-3: external repo path validation
 """
 
-import pytest
-
 from autoskillit.workspace.skills import DefaultSkillResolver
 
 
@@ -17,39 +15,6 @@ def _skill_md(skill_name: str) -> str:
     result = DefaultSkillResolver().resolve(skill_name)
     assert result is not None, f"Skill {skill_name!r} not found in any bundled skills directory"
     return result.path.read_text()
-
-
-CODE_INDEX_SKILLS = [
-    "investigate",
-    "audit-impl",
-    "make-plan",
-    "make-groups",
-    "rectify",
-    "triage-issues",
-    "resolve-failures",
-]
-
-
-@pytest.mark.parametrize("skill_name", CODE_INDEX_SKILLS)
-def test_code_index_skills_have_set_project_path(skill_name):
-    """Each code-index skill must call set_project_path in its workflow preamble."""
-    content = _skill_md(skill_name)
-    assert "set_project_path" in content, (
-        f"{skill_name}/SKILL.md is missing a set_project_path call. "
-        "Agents using code-index tools without initialization fail with "
-        "'Project path not set' (FRICT-1B-1)."
-    )
-
-
-@pytest.mark.parametrize("skill_name", CODE_INDEX_SKILLS)
-def test_code_index_skills_have_relative_path_example(skill_name):
-    """Each updated skill must include a project-relative path example."""
-    content = _skill_md(skill_name)
-    assert "src/" in content, (
-        f"{skill_name}/SKILL.md is missing a project-relative path example "
-        "(e.g., src/<your_package>/some_module.py). Agents copy absolute "
-        "paths from Read output and code-index rejects them (FRICT-1C-2)."
-    )
 
 
 def test_implement_worktree_has_pre_implementation_checklist():


### PR DESCRIPTION
## Summary

Remove all references to the `code-index` MCP server (`johnhuang316/code-index-mcp`) from the AutoSkillit codebase. This includes:
- Deleting CLAUDE.md §3.3 ("Code Index MCP Usage") and renumbering subsequent sections
- Stripping `set_project_path` preamble blocks from 19 skill SKILL.md files across three usage categories
- Deleting 4 code-index enforcement tests across 4 test files
- Updating `src/autoskillit/execution/commands.py` to remove code-index language from the WORKING_DIRECTORY_ANCHOR directive injected into headless commands

The change eliminates a non-load-bearing integration that has never functioned correctly, consumed initialization turns with no return, and caused a cascade failure (session `a268d30c`, issue #1164). Native Grep/Glob/Read tools — already the de-facto fallback in every session — become the sole exploration tools.

## Architecture Impact

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;

    %% ── L0: FOUNDATION ────────────────────────────────────────────── %%
    subgraph L0 ["L0 — FOUNDATION (core/)"]
        direction LR
        CORE_ENV["core/_claude_env.py<br/>━━━━━━━━━━<br/>build_claude_env()<br/>IDE-scrubbing env builder"]
        CORE_TYPES["core/types.py<br/>━━━━━━━━━━<br/>ResumeSpec, ClaudeFlags<br/>ValidatedAddDir, constants<br/>(SESSION_TYPE_*, *_ENV_VAR)"]
    end

    %% ── L1: EXECUTION ─────────────────────────────────────────────── %%
    subgraph L1_EXEC ["L1 — EXECUTION (execution/)"]
        direction TB
        CMD["● execution/commands.py<br/>━━━━━━━━━━<br/>ClaudeInteractiveCmd / HeadlessCmd<br/>build_*_cmd() factories<br/>argv + env assembly"]
        EXEC_INIT["execution/__init__.py<br/>━━━━━━━━━━<br/>Public re-export surface"]
        HEADLESS["execution/headless.py<br/>━━━━━━━━━━<br/>Headless session orchestration<br/>Consumes ClaudeHeadlessCmd"]
    end

    %% ── L1: WORKSPACE ─────────────────────────────────────────────── %%
    subgraph L1_WS ["L1 — WORKSPACE (workspace/)"]
        direction TB
        SKILLS_MOD["workspace/skills.py<br/>━━━━━━━━━━<br/>DefaultSkillResolver<br/>Enumerates skills/ + skills_extended/"]
        SESSION_SKILLS["workspace/session_skills.py<br/>━━━━━━━━━━<br/>SkillsDirectoryProvider<br/>Gating + per-session ephemeral dirs<br/>Produces ValidatedAddDir"]
    end

    %% ── CONTENT LAYER ─────────────────────────────────────────────── %%
    subgraph CONTENT ["CONTENT — skills_extended/ (SKILL.md files, not Python)"]
        direction LR
        SKILL_IMPL["● implement-worktree/SKILL.md<br/>implement-worktree-no-merge/SKILL.md<br/>retry-worktree/SKILL.md"]
        SKILL_REVIEW["● review-pr/SKILL.md<br/>review-research-pr/SKILL.md<br/>resolve-claims-review/SKILL.md"]
        SKILL_AUDIT["● audit-claims/SKILL.md<br/>audit-cohesion/SKILL.md<br/>audit-impl/SKILL.md<br/>validate-audit/SKILL.md"]
        SKILL_MISC["● investigate/SKILL.md<br/>make-plan/SKILL.md<br/>make-groups/SKILL.md<br/>triage-issues/SKILL.md<br/>diagnose-ci/SKILL.md<br/>rectify/SKILL.md<br/>resolve-failures/SKILL.md<br/>build-execution-map/SKILL.md<br/>troubleshoot-experiment/SKILL.md"]
    end

    %% ── L3: CONSUMERS (context only) ──────────────────────────────── %%
    subgraph L3 ["L3 — CONSUMERS (partial context)"]
        direction LR
        CLI["cli/app.py<br/>━━━━━━━━━━<br/>Instantiates DefaultSkillResolver<br/>for skills/recipes subcommands"]
        SERVER["server/tools_execution.py<br/>━━━━━━━━━━<br/>Calls headless session via<br/>execution layer"]
    end

    %% ── TESTS ─────────────────────────────────────────────────────── %%
    subgraph TESTS ["TESTS (modified)"]
        direction TB
        T_HEADLESS["● tests/execution/test_headless.py<br/>━━━━━━━━━━<br/>Tests headless.py helpers<br/>+ commands.py private fns<br/>(_ensure_skill_prefix,<br/>_inject_completion_directive)"]
        T_CLAUDE_MD["● tests/infra/test_claude_md_critical_rules.py<br/>━━━━━━━━━━<br/>CLAUDE.md contract assertions<br/>(no autoskillit imports)"]
        T_GENERIC["● tests/skills/test_skill_genericization.py<br/>━━━━━━━━━━<br/>No project-internal refs<br/>in SKILL.md files"]
        T_OUTPUT["● tests/skills/test_skill_output_compliance.py<br/>━━━━━━━━━━<br/>HHMMSS timestamps +<br/>key = value token format<br/>(uses DefaultSkillResolver)"]
        T_PREAMBLE["● tests/skills/test_skill_preambles.py<br/>━━━━━━━━━━<br/>Preamble contracts<br/>from friction analysis<br/>(uses DefaultSkillResolver)"]
    end

    %% ── VALID DEPENDENCIES ────────────────────────────────────────── %%
    CORE_ENV  -->|"build_claude_env()"| CMD
    CORE_TYPES -->|"ResumeSpec, ClaudeFlags,<br/>ValidatedAddDir, env-var constants"| CMD
    CMD -->|"re-exports public surface"| EXEC_INIT
    CMD -->|"ClaudeHeadlessCmd consumed by"| HEADLESS
    SKILLS_MOD -->|"scans & resolves SKILL.md files"| CONTENT
    SESSION_SKILLS -->|"wraps resolver,<br/>produces ValidatedAddDir"| SKILLS_MOD
    SESSION_SKILLS -->|"ValidatedAddDir passed as --add-dir"| CMD

    %% L3 consumers (downward — valid)
    CLI -->|"instantiates"| SKILLS_MOD
    SERVER -->|"invokes headless session"| HEADLESS

    %% Test dependencies
    T_HEADLESS -->|"imports private fns"| CMD
    T_HEADLESS -->|"imports helpers"| HEADLESS
    T_OUTPUT   -->|"uses DefaultSkillResolver"| SKILLS_MOD
    T_PREAMBLE -->|"uses DefaultSkillResolver"| SKILLS_MOD
    T_GENERIC  -->|"reads SKILL.md on disk"| CONTENT
    T_CLAUDE_MD -.->|"path-only (pathlib)"| CONTENT

    %% CLASS ASSIGNMENTS %%
    class CORE_ENV,CORE_TYPES stateNode;
    class CMD handler;
    class EXEC_INIT,HEADLESS phase;
    class SKILLS_MOD,SESSION_SKILLS phase;
    class SKILL_IMPL,SKILL_REVIEW,SKILL_AUDIT,SKILL_MISC output;
    class CLI,SERVER cli;
    class T_HEADLESS,T_CLAUDE_MD,T_GENERIC,T_OUTPUT,T_PREAMBLE detector;
```

Closes #1186

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260424-141832-259179/.autoskillit/temp/make-plan/remove_code_index_mcp_plan_2026-04-24_141832.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 107 | 13.5k | 359.8k | 40.4k | 1 | 5m 2s |
| verify | 134 | 12.6k | 687.9k | 47.0k | 1 | 3m 53s |
| implement | 142 | 15.0k | 815.5k | 82.4k | 1 | 4m 24s |
| retry_worktree | 332 | 13.5k | 2.1M | 60.1k | 1 | 11m 31s |
| fix | 70 | 3.5k | 236.2k | 27.8k | 1 | 3m 3s |
| prepare_pr | 52 | 5.0k | 159.0k | 25.6k | 1 | 1m 19s |
| run_arch_lenses | 77 | 7.0k | 243.1k | 27.0k | 1 | 4m 16s |
| compose_pr | 51 | 4.6k | 152.8k | 22.1k | 1 | 1m 28s |
| **Total** | 965 | 74.7k | 4.7M | 332.3k | | 34m 59s |