### PR TITLE
Implementation Plan: planner — Scaffold + Feature Registration + Architecture Test Updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,9 @@ generic_automation_mcp/
 │   ├── skills.py            #   SkillResolver — bundled skill listing
 │   └── worktree.py
 │
+├── planner/                 # L1
+│   └── __init__.py          #   Progressive resolution planner — __all__ = []
+│
 ├── recipe/                  # L2
 │   ├── __init__.py
 │   ├── contracts.py         #   Contract card generation + staleness triage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "autoskillit"
-version = "0.9.118"
+version = "0.9.119"
 description = "MCP server for orchestrating automated skill-driven workflows with Claude Code"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/autoskillit/.claude-plugin/plugin.json
+++ b/src/autoskillit/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "autoskillit",
-  "version": "0.9.118",
+  "version": "0.9.119",
   "description": "Orchestrated skill-driven workflows using Claude Code headless sessions"
 }

--- a/src/autoskillit/config/defaults.yaml
+++ b/src/autoskillit/config/defaults.yaml
@@ -258,3 +258,4 @@ franchise:
 
 features:
   franchise: false  # Disabled by default; enabled via project config on integration
+  planner: false  # EXPERIMENTAL — off by default

--- a/src/autoskillit/core/_type_constants.py
+++ b/src/autoskillit/core/_type_constants.py
@@ -369,6 +369,20 @@ FEATURE_REGISTRY: dict[str, FeatureDef] = {
         default_enabled=False,
         since_version="0.9.51",
     ),
+    "planner": FeatureDef(
+        name="planner",
+        lifecycle=FeatureLifecycle.EXPERIMENTAL,
+        description=(
+            "Progressive resolution planner — 3-pass sequential decomposition"
+            " into GitHub-issue-ready work packages"
+        ),
+        tool_tags=frozenset(),
+        skill_categories=frozenset(),
+        import_package="autoskillit.planner",
+        tier=1,
+        default_enabled=False,
+        since_version="0.9.119",
+    ),
 }
 
 RETIRED_FEATURES: frozenset[str] = frozenset()

--- a/src/autoskillit/planner/__init__.py
+++ b/src/autoskillit/planner/__init__.py
@@ -1,0 +1,5 @@
+"""Progressive resolution planner — L1 module."""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/src/autoskillit/planner/__init__.py
+++ b/src/autoskillit/planner/__init__.py
@@ -1,5 +1,3 @@
-"""Progressive resolution planner — L1 module."""
-
 from __future__ import annotations
 
 __all__: list[str] = []

--- a/tests/arch/test_import_paths.py
+++ b/tests/arch/test_import_paths.py
@@ -24,6 +24,7 @@ PACKAGES = frozenset(
         "pipeline",
         "execution",
         "workspace",
+        "planner",
         "recipe",
         "migration",
         "franchise",

--- a/tests/arch/test_layer_enforcement.py
+++ b/tests/arch/test_layer_enforcement.py
@@ -35,6 +35,7 @@ SUBPACKAGE_LAYERS: dict[str, int] = {
     "pipeline": 1,
     "execution": 1,
     "workspace": 1,
+    "planner": 1,
     # Layer 2: domain services — may import from L0 and L1
     "recipe": 2,
     "migration": 2,
@@ -1135,6 +1136,7 @@ _TEST_LAYER_ALLOWED: dict[str, frozenset[str]] = {
     "tests/pipeline": frozenset({"autoskillit.core", "autoskillit.pipeline"}),
     "tests/execution": frozenset({"autoskillit.core", "autoskillit.execution"}),
     "tests/workspace": frozenset({"autoskillit.core", "autoskillit.workspace"}),
+    "tests/planner": frozenset({"autoskillit.core", "autoskillit.planner"}),
     "tests/recipe": frozenset({"autoskillit.core", "autoskillit.recipe"}),
     "tests/migration": frozenset({"autoskillit.core", "autoskillit.migration"}),
     "tests/franchise": frozenset(

--- a/tests/arch/test_layer_markers.py
+++ b/tests/arch/test_layer_markers.py
@@ -15,10 +15,10 @@ LAYER_DIRECTORIES: dict[str, str] = {
     "pipeline": "pipeline",
     "execution": "execution",
     "workspace": "workspace",
+    "planner": "planner",
     "recipe": "recipe",
     "migration": "migration",
     "franchise": "franchise",
-    "planner": "planner",
     "server": "server",
     "cli": "cli",
 }

--- a/tests/arch/test_layer_markers.py
+++ b/tests/arch/test_layer_markers.py
@@ -18,6 +18,7 @@ LAYER_DIRECTORIES: dict[str, str] = {
     "recipe": "recipe",
     "migration": "migration",
     "franchise": "franchise",
+    "planner": "planner",
     "server": "server",
     "cli": "cli",
 }

--- a/tests/arch/test_size_markers.py
+++ b/tests/arch/test_size_markers.py
@@ -17,6 +17,7 @@ SIZE_DIRECTORIES: dict[str, str] = {
     "franchise": "franchise",
     "migration": "migration",
     "pipeline": "pipeline",
+    "planner": "planner",
     "recipe": "recipe",
     "server": "server",
     "workspace": "workspace",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ _LAYER_DIRS: frozenset[str] = frozenset(
         "recipe",
         "migration",
         "franchise",
+        "planner",
         "server",
         "cli",
     }
@@ -38,6 +39,7 @@ _SIZE_DIRS: frozenset[str] = frozenset(
         "franchise",
         "migration",
         "pipeline",
+        "planner",
         "recipe",
         "server",
         "workspace",

--- a/tests/planner/test_planner.py
+++ b/tests/planner/test_planner.py
@@ -1,0 +1,19 @@
+"""Tests for the planner L1 subpackage scaffold."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.layer("planner"), pytest.mark.small]
+
+
+def test_planner_package_importable() -> None:
+    """planner package can be imported without error."""
+    import autoskillit.planner  # noqa: F401
+
+
+def test_planner_all_is_empty() -> None:
+    """__all__ is empty — scaffold only, no public API yet."""
+    from autoskillit.planner import __all__
+
+    assert __all__ == []

--- a/tests/planner/test_planner.py
+++ b/tests/planner/test_planner.py
@@ -8,12 +8,10 @@ pytestmark = [pytest.mark.layer("planner"), pytest.mark.small]
 
 
 def test_planner_package_importable() -> None:
-    """planner package can be imported without error."""
     import autoskillit.planner  # noqa: F401
 
 
 def test_planner_all_is_empty() -> None:
-    """__all__ is empty — scaffold only, no public API yet."""
     from autoskillit.planner import __all__
 
     assert __all__ == []

--- a/uv.lock
+++ b/uv.lock
@@ -73,7 +73,7 @@ wheels = [
 
 [[package]]
 name = "autoskillit"
-version = "0.9.118"
+version = "0.9.119"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

Establish the `autoskillit.planner` L1 subpackage, register it in `FEATURE_REGISTRY`, add its config default, update all architectural test registries, and scaffold the `tests/planner/` directory. Purely additive — no behavioral logic. This is the foundation ticket that unblocks all subsequent planner tickets (#2–#8).

Version bump: `0.9.118` → `0.9.119` (run `task sync-plugin-version && uv lock`).

## Architecture Impact

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% LAYER 0 — FOUNDATION %%
    subgraph L0 ["LAYER 0 — FOUNDATION (core/)"]
        direction LR
        TYPES["● core/_type_constants.py<br/>━━━━━━━━━━<br/>FEATURE_REGISTRY<br/>+ 'planner' entry added<br/>since_version=0.9.119"]
        CORE_INIT["core/__init__.py<br/>━━━━━━━━━━<br/>Re-exports public surface<br/>incl. FEATURE_REGISTRY"]
    end

    %% LAYER 1 — SERVICES %%
    subgraph L1 ["LAYER 1 — SERVICES"]
        direction LR
        PLANNER["★ planner/__init__.py<br/>━━━━━━━━━━<br/>Progressive resolution planner<br/>__all__ = []  (scaffold)<br/>Zero internal imports"]
        CONFIG["config/<br/>━━━━━━━━━━<br/>Settings resolution"]
        PIPELINE["pipeline/<br/>━━━━━━━━━━<br/>Tool context / gate state"]
        EXEC["execution/<br/>━━━━━━━━━━<br/>Headless orchestration"]
        WORKSPACE["workspace/<br/>━━━━━━━━━━<br/>Clone / worktree"]
    end

    %% LAYER 2 — DOMAIN LOGIC %%
    subgraph L2 ["LAYER 2 — DOMAIN LOGIC"]
        direction LR
        RECIPE["recipe/"]
        MIGRATION["migration/"]
        FRANCHISE["franchise/"]
    end

    %% LAYER 3 — APPLICATION %%
    subgraph L3 ["LAYER 3 — APPLICATION"]
        direction LR
        SERVER["server/<br/>━━━━━━━━━━<br/>FastMCP tools"]
        CLI["cli/<br/>━━━━━━━━━━<br/>Entry points"]
    end

    %% TEST INFRASTRUCTURE %%
    subgraph TESTS ["TEST INFRASTRUCTURE"]
        direction TB
        CONFTEST["● tests/conftest.py<br/>━━━━━━━━━━<br/>_LAYER_DIRS += 'planner'<br/>_SIZE_DIRS += 'planner'<br/>_is_test_feature_enabled()"]
        ARCH_LAYER["● tests/arch/<br/>test_layer_enforcement.py<br/>━━━━━━━━━━<br/>SUBPACKAGE_LAYERS[planner]=1<br/>L1: may only import core"]
        ARCH_PATHS["● tests/arch/<br/>test_import_paths.py<br/>━━━━━━━━━━<br/>PACKAGES += 'planner'<br/>IL-008 excludes planner<br/>_TEST_LAYER_ALLOWED[tests/planner]"]
        ARCH_MARKERS["● tests/arch/<br/>test_layer_markers.py<br/>━━━━━━━━━━<br/>LAYER_DIRECTORIES[planner]"]
        ARCH_SIZE["● tests/arch/<br/>test_size_markers.py<br/>━━━━━━━━━━<br/>SIZE_DIRECTORIES += 'planner'"]
        PLANNER_TEST["★ tests/planner/<br/>test_planner.py<br/>━━━━━━━━━━<br/>mark.layer('planner')<br/>mark.small<br/>tests: importable + __all__==[]"]
    end

    %% VALID LAYER DEPENDENCIES (downward) %%
    L3 -->|"imports L0–L2"| L2
    L3 -->|"imports L0–L1"| L1
    L2 -->|"imports L0–L1"| L1
    L1 -->|"imports L0 only"| L0
    PLANNER -.->|"NO imports<br/>(scaffold)"| L0

    %% FEATURE REGISTRY REGISTRATION %%
    TYPES -->|"FEATURE_REGISTRY<br/>registers"| PLANNER
    CORE_INIT -->|"re-exports<br/>FEATURE_REGISTRY"| TYPES

    %% TEST WIRING %%
    CONFTEST -->|"reads FEATURE_REGISTRY<br/>for feature-skip logic"| CORE_INIT
    CONFTEST -->|"validates layer/size dirs"| ARCH_MARKERS
    CONFTEST -->|"validates layer/size dirs"| ARCH_SIZE
    ARCH_LAYER -->|"enforces planner → core only"| PLANNER
    ARCH_PATHS -->|"allows tests/planner<br/>→ {core, planner}"| PLANNER_TEST
    PLANNER_TEST -->|"imports (deferred)"| PLANNER

    %% CLASS ASSIGNMENTS %%
    class TYPES,CORE_INIT stateNode;
    class PLANNER newComponent;
    class CONFIG,PIPELINE,EXEC,WORKSPACE handler;
    class RECIPE,MIGRATION,FRANCHISE phase;
    class SERVER,CLI cli;
    class CONFTEST,ARCH_LAYER,ARCH_PATHS,ARCH_MARKERS,ARCH_SIZE detector;
    class PLANNER_TEST newComponent;
```

### Development Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ── SOURCE LAYER ─────────────────────────────────────── %%
    subgraph Source ["SOURCE CHANGES"]
        direction TB

        subgraph L1New ["★ NEW — L1 Subpackage"]
            PLANNER["★ planner/__init__.py<br/>━━━━━━━━━━<br/>L1 scaffold module<br/>__all__ = []<br/>EXPERIMENTAL"]
        end

        subgraph CoreMod ["● MODIFIED — L0 Core"]
            TYPE_CONSTS["● core/_type_constants.py<br/>━━━━━━━━━━<br/>FEATURE_REGISTRY<br/>+ planner entry<br/>(tier=1, disabled by default)"]
            DEFAULTS["● config/defaults.yaml<br/>━━━━━━━━━━<br/>features.planner: false"]
        end

        subgraph PluginMod ["● MODIFIED — Plugin Metadata"]
            PLUGIN_JSON["● .claude-plugin/plugin.json<br/>━━━━━━━━━━<br/>version → 0.9.119"]
            CLAUDE_MD_NODE["● CLAUDE.md<br/>━━━━━━━━━━<br/>planner/ added to<br/>architecture layout"]
        end
    end

    %% ── BUILD LAYER ──────────────────────────────────────── %%
    subgraph Build ["BUILD / LOCK"]
        direction LR
        PYPROJECT["● pyproject.toml<br/>━━━━━━━━━━<br/>version bump<br/>→ 0.9.119"]
        UVLOCK["● uv.lock<br/>━━━━━━━━━━<br/>lockfile sync"]
    end

    %% ── TEST LAYER ───────────────────────────────────────── %%
    subgraph Tests ["TEST SUITE"]
        direction TB

        subgraph PlannerTests ["★ NEW — Planner Tests"]
            TEST_INIT["★ tests/planner/__init__.py<br/>━━━━━━━━━━<br/>package marker"]
            TEST_PLANNER["★ tests/planner/test_planner.py<br/>━━━━━━━━━━<br/>test_planner_package_importable<br/>test_planner_all_is_empty<br/>mark.layer(planner) + mark.small"]
        end

        subgraph ArchTests ["● MODIFIED — Arch Enforcement Tests"]
            TEST_IMPORT["● test_import_paths.py<br/>━━━━━━━━━━<br/>PACKAGES += 'planner'<br/>REQ-IMP-001..010"]
            TEST_LAYER["● test_layer_enforcement.py<br/>━━━━━━━━━━<br/>SUBPACKAGE_LAYERS<br/>planner → L1"]
            TEST_LMARKERS["● test_layer_markers.py<br/>━━━━━━━━━━<br/>LAYER_DIRECTORIES<br/>+= planner"]
            TEST_SMARKERS["● test_size_markers.py<br/>━━━━━━━━━━<br/>SIZE_DIRECTORIES<br/>+= planner"]
            CONFTEST["● tests/conftest.py<br/>━━━━━━━━━━<br/>_LAYER_DIRS += planner<br/>_SIZE_DIRS += planner"]
        end
    end

    %% ── QUALITY PIPELINE ─────────────────────────────────── %%
    subgraph QGates ["QUALITY GATES (pre-commit → task test-all)"]
        direction LR
        RUFF_FMT["ruff format<br/>━━━━━━━━━━<br/>auto-fix style"]
        RUFF_LINT["ruff check<br/>━━━━━━━━━━<br/>auto-fix lint"]
        MYPY["mypy<br/>━━━━━━━━━━<br/>type-check src/"]
        UVCHECK["uv lock --check<br/>━━━━━━━━━━<br/>lockfile drift"]
        PYTEST["task test-all<br/>━━━━━━━━━━<br/>pytest -n 4<br/>asyncio_mode=auto"]
    end

    %% ── FLOWS ────────────────────────────────────────────── %%
    TYPE_CONSTS -->|registers| PLANNER
    DEFAULTS -->|gates feature| PLANNER
    PYPROJECT -->|version drives| PLUGIN_JSON
    PYPROJECT --> UVLOCK

    PLANNER -->|import tested by| TEST_PLANNER
    TEST_INIT --> TEST_PLANNER

    PLANNER -->|layer boundary enforced by| TEST_LAYER
    PLANNER -->|import rules enforced by| TEST_IMPORT
    TEST_PLANNER -->|marker contract enforced by| TEST_LMARKERS
    TEST_PLANNER -->|size marker enforced by| TEST_SMARKERS
    CONFTEST -->|fixture scope feeds| TEST_LMARKERS
    CONFTEST -->|fixture scope feeds| TEST_SMARKERS

    Source --> RUFF_FMT
    RUFF_FMT --> RUFF_LINT
    RUFF_LINT --> MYPY
    UVLOCK --> UVCHECK
    MYPY --> PYTEST
    UVCHECK --> PYTEST

    %% ── CLASS ASSIGNMENTS ─────────────────────────────────── %%
    class PLANNER newComponent;
    class TEST_INIT,TEST_PLANNER newComponent;
    class TYPE_CONSTS,DEFAULTS stateNode;
    class PLUGIN_JSON,CLAUDE_MD_NODE output;
    class PYPROJECT,UVLOCK phase;
    class TEST_IMPORT,TEST_LAYER,TEST_LMARKERS,TEST_SMARKERS,CONFTEST detector;
    class RUFF_FMT,RUFF_LINT handler;
    class MYPY,UVCHECK detector;
    class PYTEST handler;
```

Closes #1124

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260424-180347-626290/.autoskillit/temp/make-plan/planner_scaffold_feature_registration_plan_2026-04-24_120001.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 163 | 9.1k | 672.7k | 42.9k | 1 | 4m 52s |
| verify | 60 | 7.8k | 206.4k | 30.3k | 1 | 2m 57s |
| implement | 220 | 9.5k | 1.0M | 36.7k | 1 | 3m 22s |
| fix | 168 | 6.8k | 816.4k | 45.0k | 1 | 8m 22s |
| prepare_pr | 60 | 4.8k | 185.1k | 24.7k | 1 | 1m 30s |
| run_arch_lenses | 132 | 14.2k | 371.2k | 93.6k | 2 | 6m 16s |
| compose_pr | 83 | 6.1k | 298.1k | 26.4k | 1 | 1m 59s |
| **Total** | 886 | 58.2k | 3.6M | 299.5k | | 29m 22s |