### PR TITLE
fix: order --resume <uuid> UUID misroute, redundant validation, and system prompt duplication

### DIFF
--- a/src/autoskillit/cli/_session_launch.py
+++ b/src/autoskillit/cli/_session_launch.py
@@ -24,7 +24,7 @@ def _run_interactive_session(
         sys.exit(1)
     from autoskillit.cli._init_helpers import _is_plugin_installed
     from autoskillit.cli._terminal import terminal_guard
-    from autoskillit.core import ClaudeFlags, NoResume, pkg_root
+    from autoskillit.core import BareResume, ClaudeFlags, NamedResume, NoResume, pkg_root
     from autoskillit.execution import build_interactive_cmd
 
     spec = build_interactive_cmd(
@@ -33,13 +33,13 @@ def _run_interactive_session(
         env_extras=extra_env,
     )
     plugin_flags = [] if _is_plugin_installed() else [ClaudeFlags.PLUGIN_DIR, str(pkg_root())]
+    _is_resume = isinstance(resume_spec, (BareResume, NamedResume))
     cmd = [
         *spec.cmd,
         *plugin_flags,
         ClaudeFlags.TOOLS,
         "AskUserQuestion",
-        ClaudeFlags.APPEND_SYSTEM_PROMPT,
-        system_prompt,
+        *([] if _is_resume else [ClaudeFlags.APPEND_SYSTEM_PROMPT, system_prompt]),
     ]
     with terminal_guard():
         result = subprocess.run(cmd, env=spec.env)

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -6,6 +6,7 @@ import dataclasses
 import json
 import os
 import random
+import re
 import sys
 from datetime import UTC
 from pathlib import Path
@@ -568,6 +569,22 @@ def order(recipe: str | None = None, session_id: str | None = None, *, resume: b
         sys.exit(1)
     _resume = resume or (session_id is not None)
     resume_spec = resume_spec_from_cli(resume=_resume, session_id=session_id)
+
+    _UUID_RE = re.compile(r"^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$", re.IGNORECASE)
+    if _resume and recipe is not None and session_id is None and _UUID_RE.match(recipe):
+        session_id = recipe
+        recipe = None
+        resume_spec = resume_spec_from_cli(resume=True, session_id=session_id)
+
+    if _resume and recipe is None:
+        from autoskillit.cli._prompts import _OPEN_KITCHEN_GREETINGS
+
+        _launch_cook_session(
+            "",
+            initial_message=random.choice(_OPEN_KITCHEN_GREETINGS),
+            resume_spec=resume_spec,
+        )
+        return
 
     mcp_prefix = detect_autoskillit_mcp_prefix()
 

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -43,6 +43,8 @@ from autoskillit.core import (
     resume_spec_from_cli,
 )
 
+_UUID_RE = re.compile(r"^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$", re.IGNORECASE)
+
 app = App(
     name="autoskillit",
     help="MCP server for executing recipes with Claude Code.",
@@ -570,7 +572,6 @@ def order(recipe: str | None = None, session_id: str | None = None, *, resume: b
     _resume = resume or (session_id is not None)
     resume_spec = resume_spec_from_cli(resume=_resume, session_id=session_id)
 
-    _UUID_RE = re.compile(r"^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$", re.IGNORECASE)
     if _resume and recipe is not None and session_id is None and _UUID_RE.match(recipe):
         session_id = recipe
         recipe = None

--- a/tests/cli/test_cook.py
+++ b/tests/cli/test_cook.py
@@ -1556,7 +1556,7 @@ class TestOrderResumeParsing:
 
         find_called = []
         monkeypatch.setattr(
-            "autoskillit.cli.app.find_recipe_by_name",
+            "autoskillit.recipe.find_recipe_by_name",
             lambda *a, **kw: find_called.append(a) or None,
         )
 

--- a/tests/cli/test_cook.py
+++ b/tests/cli/test_cook.py
@@ -1498,3 +1498,70 @@ class TestOrderResumeParsing:
         assert captured["resume_spec"] == NamedResume(
             session_id="fa910a41-d1ca-4cae-b878-01028a0c7c1c"
         )
+
+    def test_order_resume_uuid_without_recipe_routes_correctly(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """order --resume <uuid> (no recipe name) reroutes UUID to session_id — REQ-CLI-003."""
+        from autoskillit.cli.app import app
+        from autoskillit.core import NamedResume, NoResume
+
+        monkeypatch.delenv("CLAUDECODE", raising=False)
+        monkeypatch.chdir(tmp_path)
+
+        captured: dict = {}
+
+        def fake_launch(prompt, *, initial_message=None, extra_env=None, resume_spec=NoResume()):
+            captured["resume_spec"] = resume_spec
+
+        with patch("autoskillit.cli.app._launch_cook_session", side_effect=fake_launch):
+            with pytest.raises(SystemExit) as exc_info:
+                app(["order", "--resume", "4b581974-1f19-4aec-8405-78c5ede5e233"])
+            assert exc_info.value.code == 0
+
+        assert captured["resume_spec"] == NamedResume(
+            session_id="4b581974-1f19-4aec-8405-78c5ede5e233"
+        )
+
+    def test_order_bare_resume_skips_recipe_validation(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """order --resume (no uuid, no recipe) calls _launch_cook_session with BareResume."""
+        from autoskillit.cli.app import app
+        from autoskillit.core import BareResume, NoResume
+
+        monkeypatch.delenv("CLAUDECODE", raising=False)
+        monkeypatch.chdir(tmp_path)
+
+        captured: dict = {}
+
+        def fake_launch(prompt, *, initial_message=None, extra_env=None, resume_spec=NoResume()):
+            captured["resume_spec"] = resume_spec
+
+        with patch("autoskillit.cli.app._launch_cook_session", side_effect=fake_launch):
+            with pytest.raises(SystemExit) as exc_info:
+                app(["order", "--resume"])
+            assert exc_info.value.code == 0
+
+        assert captured["resume_spec"] == BareResume()
+
+    def test_order_resume_uuid_does_not_validate_recipe(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """order --resume <uuid> bypasses find_recipe_by_name — UUID is not a recipe name."""
+        from autoskillit.cli.app import app
+
+        monkeypatch.delenv("CLAUDECODE", raising=False)
+        monkeypatch.chdir(tmp_path)
+
+        find_called = []
+        monkeypatch.setattr(
+            "autoskillit.cli.app.find_recipe_by_name",
+            lambda *a, **kw: find_called.append(a) or None,
+        )
+
+        with patch("autoskillit.cli.app._launch_cook_session"):
+            with pytest.raises(SystemExit):
+                app(["order", "--resume", "4b581974-1f19-4aec-8405-78c5ede5e233"])
+
+        assert find_called == [], "find_recipe_by_name must NOT be called on resume without recipe"

--- a/tests/cli/test_cook.py
+++ b/tests/cli/test_cook.py
@@ -1561,7 +1561,8 @@ class TestOrderResumeParsing:
         )
 
         with patch("autoskillit.cli.app._launch_cook_session"):
-            with pytest.raises(SystemExit):
+            with pytest.raises(SystemExit) as exc_info:
                 app(["order", "--resume", "4b581974-1f19-4aec-8405-78c5ede5e233"])
+            assert exc_info.value.code == 0
 
         assert find_called == [], "find_recipe_by_name must NOT be called on resume without recipe"

--- a/tests/cli/test_session_launch.py
+++ b/tests/cli/test_session_launch.py
@@ -119,3 +119,55 @@ def test_run_interactive_session_no_plugin_dir_when_installed(
     captured = _capture_subprocess(monkeypatch)
     _run_interactive_session(system_prompt="test")
     assert ClaudeFlags.PLUGIN_DIR not in captured["cmd"]
+
+
+# ---------------------------------------------------------------------------
+# system prompt suppressed for resume sessions
+# ---------------------------------------------------------------------------
+
+
+def test_run_interactive_session_suppresses_system_prompt_on_named_resume(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_run_interactive_session omits --append-system-prompt when resume_spec is NamedResume."""
+    from autoskillit.core import NamedResume
+
+    _stub_plugin_installed(monkeypatch)
+    captured = _capture_subprocess(monkeypatch)
+    _run_interactive_session(
+        system_prompt="should-not-appear",
+        resume_spec=NamedResume(session_id="4b581974-1f19-4aec-8405-78c5ede5e233"),
+    )
+    assert ClaudeFlags.APPEND_SYSTEM_PROMPT not in captured["cmd"]
+
+
+def test_run_interactive_session_suppresses_system_prompt_on_bare_resume(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_run_interactive_session omits --append-system-prompt when resume_spec is BareResume."""
+    from autoskillit.core import BareResume
+
+    _stub_plugin_installed(monkeypatch)
+    captured = _capture_subprocess(monkeypatch)
+    _run_interactive_session(
+        system_prompt="should-not-appear",
+        resume_spec=BareResume(),
+    )
+    assert ClaudeFlags.APPEND_SYSTEM_PROMPT not in captured["cmd"]
+
+
+def test_run_interactive_session_appends_system_prompt_on_fresh_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_run_interactive_session appends --append-system-prompt for fresh (NoResume) sessions."""
+    from autoskillit.core import NoResume
+
+    _stub_plugin_installed(monkeypatch)
+    captured = _capture_subprocess(monkeypatch)
+    _run_interactive_session(
+        system_prompt="my-prompt",
+        resume_spec=NoResume(),
+    )
+    assert ClaudeFlags.APPEND_SYSTEM_PROMPT in captured["cmd"]
+    idx = captured["cmd"].index(ClaudeFlags.APPEND_SYSTEM_PROMPT)
+    assert captured["cmd"][idx + 1] == "my-prompt"


### PR DESCRIPTION
## Summary

Three bugs prevent `autoskillit order --resume <uuid>` from working. This fix addresses all three in a single cohesive change:

1. **UUID Misroute** (`app.py:540`): When `--resume` is a bool flag, the UUID falls into the `recipe` positional. A UUID-detection reroute at the top of `order()` moves it to `session_id`.
2. **Redundant Recipe Validation** (`app.py:565-722`): Resume sessions already have the recipe loaded; the entire validation gauntlet must be bypassed when resuming without a recipe name.
3. **System Prompt Duplication** (`_session_launch.py:36-43`): `--append-system-prompt` is unconditionally appended to every claude invocation, including resumes. When resuming, Claude Code restores the original session history (which already has the system prompt); the second injection causes "FIRST ACTION" confusion. The system prompt must be suppressed when `resume_spec` is `BareResume` or `NamedResume`.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START])
    COMPLETE([COMPLETE])
    ERROR([ERROR])

    subgraph Entry ["● CLI Entry — app.order()"]
        direction TB
        EnvCheck{"CLAUDECODE<br/>set?"}
        ParseArgs["● Parse CLI Args<br/>━━━━━━━━━━<br/>recipe positional<br/>session_id, --resume"]
        MakeResumeSpec["resume_spec_from_cli()<br/>━━━━━━━━━━<br/>NoResume / BareResume /<br/>NamedResume"]
    end

    subgraph UUIDGate ["● UUID Detection Gate"]
        direction TB
        UUIDCheck{"_resume=True AND<br/>recipe looks like UUID AND<br/>session_id is None?"}
        Reroute["● Reroute UUID<br/>━━━━━━━━━━<br/>session_id = recipe<br/>recipe = None<br/>resume_spec = NamedResume(uuid)"]
    end

    subgraph ResumeShortCircuit ["Resume Short-Circuit"]
        direction TB
        ResumeNoRecipe{"_resume=True AND<br/>recipe is None?"}
        LaunchOpenKitchen["Launch Open Kitchen<br/>━━━━━━━━━━<br/>_launch_cook_session()<br/>resume_spec passed through<br/>recipe validation SKIPPED"]
    end

    subgraph RecipePath ["Recipe Validation Path"]
        direction TB
        NeedPicker{"recipe is None?<br/>(picker)"}
        ShowPicker["Show Recipe Picker<br/>━━━━━━━━━━<br/>list_recipes() + timed_prompt()"]
        FindRecipe["find_recipe_by_name()<br/>━━━━━━━━━━<br/>project + bundled search"]
        LoadValidate["load_recipe() + validate_recipe()<br/>━━━━━━━━━━<br/>YAML parse + schema validation"]
        SubsetGate{"Disabled subsets<br/>required?"}
        SubsetPrompt["Subset Prompt<br/>━━━━━━━━━━<br/>1=temp env override<br/>2=update config<br/>3=cancel"]
        PackGate{"Default-disabled<br/>packs required?"}
        PackPrompt["Pack Prompt<br/>━━━━━━━━━━<br/>1=temp env override<br/>2=update config<br/>3=cancel"]
        ConfirmLaunch["show_cook_preview() + Confirm<br/>━━━━━━━━━━<br/>timed_prompt() Enter/n"]
    end

    subgraph SessionLaunch ["● Session Launch — _run_interactive_session()"]
        direction TB
        BuildCmd["build_interactive_cmd()<br/>━━━━━━━━━━<br/>resume_spec → --resume flag<br/>env_extras merged"]
        PluginCheck{"plugin<br/>installed?"}
        AssembleCmd["Assemble Final CMD<br/>━━━━━━━━━━<br/>base cmd + plugin_flags<br/>+ --tools AskUserQuestion"]
        SysPromptGate{"● is_resume?<br/>BareResume or NamedResume?"}
        AppendSysPrompt["Append System Prompt<br/>━━━━━━━━━━<br/>--append-system-prompt<br/>orchestrator prompt"]
        SuppressSysPrompt["● Suppress System Prompt<br/>━━━━━━━━━━<br/>no --append-system-prompt<br/>prevents duplication on resume"]
        SubprocRun["subprocess.run(cmd, env)<br/>━━━━━━━━━━<br/>terminal_guard() context"]
    end

    %% MAIN FLOW %%
    START --> EnvCheck
    EnvCheck -->|"set"| ERROR
    EnvCheck -->|"clear"| ParseArgs
    ParseArgs --> MakeResumeSpec
    MakeResumeSpec --> UUIDCheck

    UUIDCheck -->|"yes — UUID fix"| Reroute
    UUIDCheck -->|"no"| ResumeNoRecipe
    Reroute --> ResumeNoRecipe

    ResumeNoRecipe -->|"yes — skip validation"| LaunchOpenKitchen
    ResumeNoRecipe -->|"no — has recipe or fresh"| NeedPicker
    LaunchOpenKitchen --> BuildCmd

    NeedPicker -->|"yes"| ShowPicker
    NeedPicker -->|"no"| FindRecipe
    ShowPicker --> FindRecipe
    FindRecipe -->|"not found"| ERROR
    FindRecipe -->|"found"| LoadValidate
    LoadValidate -->|"parse / schema error"| ERROR
    LoadValidate -->|"valid"| SubsetGate

    SubsetGate -->|"yes"| SubsetPrompt
    SubsetGate -->|"no"| PackGate
    SubsetPrompt -->|"1: temp env"| PackGate
    SubsetPrompt -->|"2: update config"| PackGate
    SubsetPrompt -->|"3: cancel"| COMPLETE

    PackGate -->|"yes"| PackPrompt
    PackGate -->|"no"| ConfirmLaunch
    PackPrompt -->|"1: temp env"| ConfirmLaunch
    PackPrompt -->|"2: update config"| ConfirmLaunch
    PackPrompt -->|"3: cancel"| COMPLETE

    ConfirmLaunch -->|"n / no"| COMPLETE
    ConfirmLaunch -->|"Enter: confirm"| BuildCmd

    BuildCmd --> PluginCheck
    PluginCheck -->|"not installed"| AssembleCmd
    PluginCheck -->|"installed"| AssembleCmd
    AssembleCmd --> SysPromptGate
    SysPromptGate -->|"yes — resume"| SuppressSysPrompt
    SysPromptGate -->|"no — fresh session"| AppendSysPrompt
    SuppressSysPrompt --> SubprocRun
    AppendSysPrompt --> SubprocRun
    SubprocRun -->|"returncode = 0"| COMPLETE
    SubprocRun -->|"returncode ≠ 0"| ERROR

    %% CLASS ASSIGNMENTS %%
    class START,COMPLETE,ERROR terminal;
    class EnvCheck,UUIDCheck,ResumeNoRecipe,NeedPicker,SubsetGate,PackGate,SysPromptGate detector;
    class ParseArgs,MakeResumeSpec,Reroute,LaunchOpenKitchen handler;
    class ShowPicker,FindRecipe,LoadValidate,SubsetPrompt,PackPrompt,ConfirmLaunch phase;
    class BuildCmd,AssembleCmd,AppendSysPrompt,SuppressSysPrompt,SubprocRun handler;
    class PluginCheck stateNode;
```

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 65, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START(["CLI: autoskillit order"]):::terminal

    subgraph CLIArgs ["CLI ARGUMENT FIELDS"]
        direction LR
        recipe_arg["MUTABLE: recipe<br/>━━━━━━━━━━<br/>Recipe name OR UUID<br/>Cleared on reroute"]
        session_id_arg["MUTABLE: session_id<br/>━━━━━━━━━━<br/>Explicit session UUID<br/>Set from recipe on reroute"]
        resume_flag["DERIVED: _is_resume<br/>━━━━━━━━━━<br/>resume OR session_id≠None<br/>Read-only after compute"]
    end

    subgraph Gate1 ["GATE 1 — CLAUDECODE GUARD (INIT_ONLY)"]
        env_guard["CLAUDECODE env check<br/>━━━━━━━━━━<br/>Blocks execution inside<br/>active Claude session<br/>FAIL-FAST → exit 1"]
    end

    subgraph Gate2 ["● GATE 2 — UUID REROUTE (STATE MUTATION)"]
        uuid_check{"_is_resume AND<br/>recipe≠None AND<br/>session_id=None AND<br/>recipe matches UUID?"}
        uuid_reroute["MUTATE STATE<br/>━━━━━━━━━━<br/>session_id ← recipe<br/>recipe ← None<br/>resume_spec ← NamedResume(session_id)"]
    end

    subgraph Gate3 ["● GATE 3 — RESUME BYPASS (VALIDATION SKIP)"]
        resume_bypass{"_is_resume AND<br/>recipe=None?"}
        skip_validation["SKIP VALIDATION<br/>━━━━━━━━━━<br/>Launch directly via<br/>_launch_cook_session<br/>No recipe lookup"]
    end

    subgraph Gate4 ["GATE 4 — RECIPE VALIDATION"]
        recipe_lookup["find_recipe_by_name<br/>━━━━━━━━━━<br/>FAIL → exit 1"]
        yaml_parse["load_recipe (YAML)<br/>━━━━━━━━━━<br/>YAMLError → exit 1<br/>ValueError → exit 1"]
        schema_valid["validate_recipe<br/>━━━━━━━━━━<br/>errors → exit 1"]
    end

    subgraph Gate5 ["GATE 5 — SUBSET / PACK GATE"]
        subset_gate["Subset-disabled check<br/>━━━━━━━━━━<br/>Prompt: temp/perm/cancel"]
        pack_gate["Pack-disabled check<br/>━━━━━━━━━━<br/>Prompt: temp/perm/cancel"]
    end

    subgraph ResumeSpec ["INIT_ONLY: resume_spec (discriminated union)"]
        no_resume["NoResume<br/>━━━━━━━━━━<br/>Fresh session<br/>No --resume flag"]
        bare_resume["BareResume<br/>━━━━━━━━━━<br/>resume=True, no UUID<br/>Bare --resume flag"]
        named_resume["NamedResume(session_id)<br/>━━━━━━━━━━<br/>Explicit UUID<br/>--resume <uuid> flag"]
    end

    subgraph SessionLaunch ["● _run_interactive_session (SYSTEM PROMPT GATE)"]
        is_resume_check{"isinstance(resume_spec,<br/>(BareResume, NamedResume))?"}
        suppress_prompt["INIT_PRESERVE: system_prompt<br/>━━━━━━━━━━<br/>Omit --append-system-prompt<br/>Resume: keep prior context"]
        inject_prompt["INIT_PRESERVE: system_prompt<br/>━━━━━━━━━━<br/>Inject --append-system-prompt<br/>Fresh: install instructions"]
    end

    CMD_OUT(["subprocess: claude <flags>"]):::terminal

    %% FLOW %%
    START --> recipe_arg & session_id_arg & resume_flag
    recipe_arg & session_id_arg & resume_flag --> env_guard

    env_guard -->|"PASS"| uuid_check
    env_guard -->|"FAIL"| BLOCKED(["exit 1"]):::terminal

    uuid_check -->|"YES"| uuid_reroute
    uuid_reroute --> resume_bypass
    uuid_check -->|"NO"| resume_bypass

    resume_bypass -->|"YES"| skip_validation
    resume_bypass -->|"NO"| recipe_lookup

    recipe_lookup --> yaml_parse --> schema_valid --> subset_gate --> pack_gate

    skip_validation --> no_resume & bare_resume & named_resume
    pack_gate --> no_resume & bare_resume & named_resume

    no_resume --> is_resume_check
    bare_resume --> is_resume_check
    named_resume --> is_resume_check

    is_resume_check -->|"BareResume or NamedResume"| suppress_prompt
    is_resume_check -->|"NoResume"| inject_prompt

    suppress_prompt --> CMD_OUT
    inject_prompt --> CMD_OUT

    %% CLASS ASSIGNMENTS %%
    class recipe_arg,session_id_arg stateNode;
    class resume_flag phase;
    class env_guard detector;
    class uuid_check,resume_bypass phase;
    class uuid_reroute gap;
    class recipe_lookup,yaml_parse,schema_valid detector;
    class subset_gate,pack_gate handler;
    class no_resume,bare_resume,named_resume cli;
    class is_resume_check phase;
    class suppress_prompt gap;
    class inject_prompt output;
    class skip_validation output;
    class START,BLOCKED,CMD_OUT terminal;
```

### Scenarios Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ================================================================
    %% SCENARIO 1: Fresh order <recipe> — happy path
    %% ================================================================
    subgraph S1 ["SCENARIO 1: Fresh order &lt;recipe&gt; — system prompt injected"]
        direction LR
        S1_CLI["● app.order<br/>━━━━━━━━━━<br/>recipe='my-recipe'<br/>resume=False"]
        S1_VAL["validate_recipe<br/>━━━━━━━━━━<br/>load_recipe + validate<br/>subset/pack gates"]
        S1_PROMPT["_build_orchestrator_prompt<br/>━━━━━━━━━━<br/>recipe name + MCP prefix<br/>+ ingredients table"]
        S1_LAUNCH["_launch_cook_session<br/>━━━━━━━━━━<br/>resume_spec=NoResume"]
        S1_SESSION["● _run_interactive_session<br/>━━━━━━━━━━<br/>NoResume → appends<br/>--append-system-prompt"]
        S1_CLAUDE["claude subprocess<br/>━━━━━━━━━━<br/>--tools AskUserQuestion<br/>--append-system-prompt &lt;prompt&gt;"]
    end

    S1_CLI -->|"finds recipe"| S1_VAL
    S1_VAL -->|"valid"| S1_PROMPT
    S1_PROMPT -->|"prompt built"| S1_LAUNCH
    S1_LAUNCH -->|"NoResume"| S1_SESSION
    S1_SESSION -->|"system prompt included"| S1_CLAUDE

    %% ================================================================
    %% SCENARIO 2: order --resume <uuid> — UUID misroute fix
    %% ================================================================
    subgraph S2 ["SCENARIO 2: order --resume &lt;uuid&gt; — UUID rerouted, prompt suppressed"]
        direction LR
        S2_CLI["● app.order<br/>━━━━━━━━━━<br/>recipe='4b581974-...'<br/>resume=True, session_id=None"]
        S2_DETECT["● UUID detector<br/>━━━━━━━━━━<br/>_UUID_RE.match(recipe)<br/>→ session_id=UUID, recipe=None"]
        S2_RESUME["resume_spec_from_cli<br/>━━━━━━━━━━<br/>NamedResume(session_id=UUID)"]
        S2_LAUNCH["_launch_cook_session<br/>━━━━━━━━━━<br/>resume_spec=NamedResume"]
        S2_SESSION["● _run_interactive_session<br/>━━━━━━━━━━<br/>NamedResume → suppresses<br/>--append-system-prompt"]
        S2_CLAUDE["claude subprocess<br/>━━━━━━━━━━<br/>--resume &lt;uuid&gt;<br/>--tools AskUserQuestion"]
    end

    S2_CLI -->|"UUID in recipe arg"| S2_DETECT
    S2_DETECT -->|"rerouted to session_id"| S2_RESUME
    S2_RESUME -->|"NamedResume"| S2_LAUNCH
    S2_LAUNCH -->|"NamedResume"| S2_SESSION
    S2_SESSION -->|"NO system prompt"| S2_CLAUDE

    %% ================================================================
    %% SCENARIO 3: order <recipe> --resume <uuid> — named resume
    %% ================================================================
    subgraph S3 ["SCENARIO 3: order &lt;recipe&gt; --resume &lt;uuid&gt; — validates recipe, prompt suppressed"]
        direction LR
        S3_CLI["● app.order<br/>━━━━━━━━━━<br/>recipe='my-recipe'<br/>session_id='fa910a41-...'"]
        S3_VAL["validate_recipe<br/>━━━━━━━━━━<br/>recipe found + validated<br/>(name not a UUID)"]
        S3_LAUNCH["_launch_cook_session<br/>━━━━━━━━━━<br/>resume_spec=NamedResume"]
        S3_SESSION["● _run_interactive_session<br/>━━━━━━━━━━<br/>isinstance NamedResume<br/>→ suppresses system prompt"]
        S3_CLAUDE["claude subprocess<br/>━━━━━━━━━━<br/>--resume fa910a41-...<br/>--tools AskUserQuestion"]
    end

    S3_CLI -->|"non-UUID recipe name"| S3_VAL
    S3_VAL -->|"valid"| S3_LAUNCH
    S3_LAUNCH -->|"NamedResume"| S3_SESSION
    S3_SESSION -->|"NO system prompt"| S3_CLAUDE

    %% ================================================================
    %% SCENARIO 4: order --resume (bare) — skips recipe validation
    %% ================================================================
    subgraph S4 ["SCENARIO 4: order --resume (bare) — open kitchen, prompt suppressed"]
        direction LR
        S4_CLI["● app.order<br/>━━━━━━━━━━<br/>recipe=None<br/>resume=True"]
        S4_BARERESUME["resume_spec_from_cli<br/>━━━━━━━━━━<br/>BareResume()<br/>no recipe lookup"]
        S4_LAUNCH["_launch_cook_session<br/>━━━━━━━━━━<br/>empty system_prompt<br/>resume_spec=BareResume"]
        S4_SESSION["● _run_interactive_session<br/>━━━━━━━━━━<br/>isinstance BareResume<br/>→ suppresses system prompt"]
        S4_CLAUDE["claude subprocess<br/>━━━━━━━━━━<br/>bare --resume<br/>--tools AskUserQuestion"]
    end

    S4_CLI -->|"resume=True, no recipe"| S4_BARERESUME
    S4_BARERESUME -->|"BareResume"| S4_LAUNCH
    S4_LAUNCH -->|"BareResume"| S4_SESSION
    S4_SESSION -->|"NO system prompt"| S4_CLAUDE

    %% CLASS ASSIGNMENTS %%
    class S1_CLI,S2_CLI,S3_CLI,S4_CLI cli;
    class S1_VAL,S3_VAL phase;
    class S1_PROMPT handler;
    class S2_DETECT detector;
    class S2_RESUME,S4_BARERESUME stateNode;
    class S1_LAUNCH,S2_LAUNCH,S3_LAUNCH,S4_LAUNCH handler;
    class S1_SESSION,S2_SESSION,S3_SESSION,S4_SESSION handler;
    class S1_CLAUDE,S2_CLAUDE,S3_CLAUDE,S4_CLAUDE output;
```

Closes #1194

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260424-192339-259031/.autoskillit/temp/make-plan/order_resume_uuid_fix_plan_2026-04-24_000000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| retry_worktree | 108 | 3.1k | 452.0k | 34.9k | 1 | 2m 24s |
| prepare_pr | 52 | 4.9k | 188.0k | 35.3k | 1 | 1m 28s |
| run_arch_lenses | 140 | 17.2k | 472.6k | 143.0k | 2 | 6m 6s |
| **Total** | 300 | 25.2k | 1.1M | 213.2k | | 10m 0s |