### PR TITLE
Update/Install Flow Cleanup

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -25,7 +25,7 @@ Register AutoSkillit as a Claude Code plugin.
 3. Installs the plugin
 4. Syncs hooks to `settings.json`
 
-Run after every upgrade.
+Syncs hooks and plugin cache. Called automatically by `autoskillit update`.
 
 ---
 
@@ -82,14 +82,15 @@ Run health checks on your setup.
 **Flags:**
 - `--output-json` — Output results as JSON
 
-Runs 14 checks enumerated by `run_doctor` in `cli/_doctor.py` (12 numbered
-plus the lettered sub-checks `4b` *Config secrets placement* and `7b` *Hook
-registry drift*). The checks cover stale MCP servers, plugin registration,
-PATH, project config, secrets placement, version consistency, hook health,
-hook registration, hook registry drift, recipe version health, gitignore
-completeness, secret-scanning hook, editable install source, and stale entry
-points. See [installation.md](installation.md#post-install-verification) for
-the full table.
+Runs 28 checks (up to 33 with franchise enabled) enumerated by `run_doctor` in
+`cli/_doctor.py` — 23 numbered plus lettered sub-checks `2b`, `2c`, `2d`,
+`4b`, and `7b`. The checks cover stale MCP servers, plugin registration, PATH,
+project config, secrets placement, version consistency, hook health, hook
+registration, hook registry drift, recipe version health, gitignore
+completeness, secret-scanning hook, editable install source, stale entry
+points, source drift, quota cache schema, process state, install classification,
+update dismissal state, ambient env leaks, and feature gate consistency. See
+[installation.md](installation.md#post-install-verification) for the full table.
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -67,17 +67,20 @@ projects need.
 
     autoskillit doctor
 
-Doctor runs 17 checks (15 numbered + 2 lettered sub-checks `4b` and `7b`),
-enumerated by `run_doctor` in `src/autoskillit/cli/_doctor.py`:
+Doctor runs 28 checks (23 numbered + 5 lettered sub-checks: `2b`, `2c`, `2d`, `4b`, `7b`); up to 33 with the franchise feature enabled.
+Enumerated by `run_doctor` in `src/autoskillit/cli/_doctor.py`:
 
 | # | Check | What it verifies |
 |---|-------|------------------|
 | 1 | Stale MCP servers | No dead binaries or nonexistent paths in `~/.claude.json` |
 | 2 | MCP server registered | AutoSkillit MCP server is registered (direct entry or via plugin) |
+| 2b | Dual MCP registration | No duplicate direct + marketplace registration |
+| 2c | Plugin cache exists | `~/.claude/plugins/cache/autoskillit-local/` directory exists |
+| 2d | installed_plugins.json | AutoSkillit entry present in installed_plugins.json |
 | 3 | `autoskillit` on PATH | The CLI command is reachable |
 | 4 | Config exists | `.autoskillit/config.yaml` is present |
 | 4b | Config secrets placement | Secrets live in `.autoskillit/.secrets.yaml`, never in `config.yaml` |
-| 5 | Version consistency | Installed package version matches `plugin.json` |
+| 5 | Version consistency | Cached plugin.json version matches installed package version |
 | 6 | Hook executability | Deployed hook scripts exist and are executable for every event type |
 | 7 | Hook registration | Hooks are registered in `settings.json` |
 | 7b | Hook registry drift | Structural diff against `generate_hooks_json()` from `hook_registry.py` |
@@ -91,6 +94,13 @@ enumerated by `run_doctor` in `src/autoskillit/cli/_doctor.py`:
 | 15 | Claude process state | Reports D-state and CPU breakdown of running `claude` processes via `ps` |
 | 16 | Install classification | `direct_url.json` classifies the install type and requested revision |
 | 17 | Update dismissal state | Active update-prompt dismissal window and conditions, if any |
+| 18 | Ambient SESSION_TYPE=leaf | No stray `SESSION_TYPE=leaf` env var in interactive shell |
+| 19 | Ambient SESSION_TYPE=orchestrator | No stray `SESSION_TYPE=orchestrator` env var |
+| 20 | Ambient SESSION_TYPE=franchise | No stray `SESSION_TYPE=franchise` env var |
+| 21 | Ambient CAMPAIGN_ID | No stray `CAMPAIGN_ID` env var in interactive shell |
+| 22 | Feature dependency consistency | Enabled features satisfy their declared dependencies |
+| 23 | Feature registry import consistency | All feature gate modules import without errors |
+| 24–28 | Franchise infrastructure | Sous-chef skill, dispatch guard, stale state, onboarding, clone collisions (franchise feature only) |
 
 See **[Hooks](safety/hooks.md)** for what each PreToolUse / PostToolUse /
 SessionStart hook actually enforces.
@@ -141,7 +151,13 @@ If missing, run `autoskillit init` in your project directory.
 
 ### Upgrading
 
+The recommended upgrade path:
+
+    autoskillit update
+
+This fetches the latest version and runs `autoskillit install` automatically.
+
+For manual upgrades (fallback):
+
     uv tool install --force "git+https://github.com/TalonT-Org/AutoSkillit.git@stable"
     autoskillit install
-
-Always run `autoskillit install` after upgrading to sync the plugin cache and hooks.

--- a/src/autoskillit/cli/_doctor.py
+++ b/src/autoskillit/cli/_doctor.py
@@ -332,6 +332,13 @@ def _check_editable_install_source_exists() -> DoctorResult:
     )
 
 
+def _format_upgrade_cmd(info: object) -> str:
+    from autoskillit.cli._install_info import upgrade_command
+
+    cmd = upgrade_command(info)  # type: ignore[arg-type]
+    return " ".join(cmd) if cmd else "autoskillit update"
+
+
 def _check_stale_entry_points() -> DoctorResult:
     """Detect autoskillit binaries on PATH outside ~/.local/bin (stale/poisoned installs)."""
     check_name = "stale_entry_points"
@@ -356,11 +363,10 @@ def _check_stale_entry_points() -> DoctorResult:
         return DoctorResult(Severity.OK, check_name, "No stale autoskillit entry points found")
 
     stale_list = ", ".join(stale)
-    from autoskillit.cli._install_info import detect_install, upgrade_command
+    from autoskillit.cli._install_info import detect_install
 
     _info = detect_install()
-    _cmd = upgrade_command(_info)
-    _cmd_str = " ".join(_cmd) if _cmd else "autoskillit update"
+    _cmd_str = _format_upgrade_cmd(_info)
     return DoctorResult(
         Severity.WARNING,
         check_name,
@@ -425,7 +431,7 @@ def _check_source_version_drift(home: Path | None = None) -> DoctorResult:
     _home = home or Path.home()
 
     try:
-        from autoskillit.cli._install_info import InstallType, detect_install, upgrade_command
+        from autoskillit.cli._install_info import InstallType, detect_install
         from autoskillit.cli._update_checks import resolve_reference_sha
 
         info = detect_install()
@@ -457,8 +463,7 @@ def _check_source_version_drift(home: Path | None = None) -> DoctorResult:
 
         installed_short = (info.commit_id or "unknown")[:8]
         ref_short = ref_sha[:8]
-        _cmd = upgrade_command(info)
-        _cmd_str = " ".join(_cmd) if _cmd else "autoskillit update"
+        _cmd_str = _format_upgrade_cmd(info)
         return DoctorResult(
             Severity.WARNING,
             check_name,

--- a/src/autoskillit/cli/_doctor.py
+++ b/src/autoskillit/cli/_doctor.py
@@ -328,7 +328,7 @@ def _check_editable_install_source_exists() -> DoctorResult:
         Severity.ERROR,
         check_name,
         f"autoskillit is installed from a deleted directory: {src_path}. "
-        f"Fix: uv tool install --force autoskillit && autoskillit install",
+        f"Fix: restore the editable source directory or re-run installation.",
     )
 
 
@@ -356,12 +356,17 @@ def _check_stale_entry_points() -> DoctorResult:
         return DoctorResult(Severity.OK, check_name, "No stale autoskillit entry points found")
 
     stale_list = ", ".join(stale)
+    from autoskillit.cli._install_info import detect_install, upgrade_command
+
+    _info = detect_install()
+    _cmd = upgrade_command(_info)
+    _cmd_str = " ".join(_cmd) if _cmd else "autoskillit update"
     return DoctorResult(
         Severity.WARNING,
         check_name,
         f"Found autoskillit entry point(s) outside ~/.local/bin: {stale_list}. "
         f"These may be stale editable installs. "
-        f"Fix: uv tool install --force autoskillit && autoskillit install",
+        f"Fix: {_cmd_str} && autoskillit install",
     )
 
 
@@ -420,7 +425,7 @@ def _check_source_version_drift(home: Path | None = None) -> DoctorResult:
     _home = home or Path.home()
 
     try:
-        from autoskillit.cli._install_info import InstallType, detect_install
+        from autoskillit.cli._install_info import InstallType, detect_install, upgrade_command
         from autoskillit.cli._update_checks import resolve_reference_sha
 
         info = detect_install()
@@ -452,11 +457,13 @@ def _check_source_version_drift(home: Path | None = None) -> DoctorResult:
 
         installed_short = (info.commit_id or "unknown")[:8]
         ref_short = ref_sha[:8]
+        _cmd = upgrade_command(info)
+        _cmd_str = " ".join(_cmd) if _cmd else "autoskillit update"
         return DoctorResult(
             Severity.WARNING,
             check_name,
             f"Source drift: installed={installed_short}, reference={ref_short}. "
-            f"Run the appropriate install command to update.",
+            f"Run: {_cmd_str} && autoskillit install",
         )
 
     except Exception:
@@ -1046,22 +1053,19 @@ def run_doctor(*, output_json: bool = False) -> None:
     # Check 4b: Config secrets placement
     results.append(_check_config_layers_for_secrets())
 
-    # Check 5: Version consistency — package version must match plugin.json
-    import importlib.metadata
-    import importlib.resources as _ir
+    # Check 5: Version consistency — cached plugin.json must match installed package
+    from autoskillit.version import version_info as _version_info
 
-    pkg_version = importlib.metadata.version("autoskillit")
-    plugin_json_path = Path(str(_ir.files("autoskillit"))) / ".claude-plugin" / "plugin.json"
-    try:
-        plugin_version = json.loads(plugin_json_path.read_text()).get("version")
-    except (json.JSONDecodeError, OSError):
-        plugin_version = None
-    if plugin_version == pkg_version:
+    _cache_plugin_dir = (
+        Path.home() / ".claude" / "plugins" / "cache" / "autoskillit-local" / "autoskillit"
+    )
+    vi = _version_info(plugin_dir=str(_cache_plugin_dir))
+    if vi["match"]:
         results.append(
             DoctorResult(
                 Severity.OK,
                 "version_consistency",
-                f"Version {pkg_version} installed",
+                f"Version {vi['package_version']} — plugin cache is current",
             )
         )
     else:
@@ -1069,8 +1073,9 @@ def run_doctor(*, output_json: bool = False) -> None:
             DoctorResult(
                 Severity.WARNING,
                 "version_consistency",
-                f"Package version {pkg_version} does not match "
-                f"plugin.json {plugin_version!r}. Reinstall autoskillit to fix.",
+                f"Plugin cache version {vi['plugin_json_version']!r} does not match "
+                f"installed package {vi['package_version']!r}. "
+                f"Run 'autoskillit install' to sync.",
             )
         )
 

--- a/src/autoskillit/cli/_install_info.py
+++ b/src/autoskillit/cli/_install_info.py
@@ -122,6 +122,7 @@ def dismissal_window(info: InstallInfo) -> timedelta:
     - ``integration`` / ``LOCAL_EDITABLE`` → ``timedelta(hours=12)``
     """
     rev = info.requested_revision or ""
+    # LOCAL_EDITABLE is reachable only via AUTOSKILLIT_FORCE_UPDATE_CHECK; not dead code.
     if rev == "integration" or info.install_type == InstallType.LOCAL_EDITABLE:
         return timedelta(hours=12)
     return timedelta(days=7)

--- a/src/autoskillit/cli/_installed_plugins.py
+++ b/src/autoskillit/cli/_installed_plugins.py
@@ -10,12 +10,13 @@ nesting contract is defined in exactly one place.
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from typing import Any
 
-from autoskillit.core import atomic_write, get_logger
+from autoskillit.core import atomic_write
 
-_log = get_logger(__name__)
+_log = logging.getLogger(__name__)  # noqa: TID251
 
 
 def _default_path() -> Path:

--- a/src/autoskillit/cli/_installed_plugins.py
+++ b/src/autoskillit/cli/_installed_plugins.py
@@ -13,7 +13,9 @@ import json
 from pathlib import Path
 from typing import Any
 
-from autoskillit.core import atomic_write
+from autoskillit.core import atomic_write, get_logger
+
+_log = get_logger(__name__)
 
 
 def _default_path() -> Path:
@@ -38,7 +40,11 @@ class InstalledPluginsFile:
             return {}
         try:
             return json.loads(self._path.read_text())
-        except (json.JSONDecodeError, OSError):
+        except json.JSONDecodeError as exc:
+            _log.warning("installed_plugins.json is corrupt (%s): %s", self._path, exc)
+            return {}
+        except OSError as exc:
+            _log.warning("Could not read installed_plugins.json (%s): %s", self._path, exc)
             return {}
 
     def get_plugins(self) -> dict[str, Any]:

--- a/src/autoskillit/cli/_update.py
+++ b/src/autoskillit/cli/_update.py
@@ -57,6 +57,9 @@ def run_update_command(home: Path | None = None) -> None:
 
     current: str = getattr(_pkg, "__version__", "0.0.0")
 
+    install_result: subprocess.CompletedProcess[bytes] = subprocess.CompletedProcess(
+        args=["autoskillit", "install"], returncode=0
+    )
     with terminal_guard():
         subprocess.run(cmd, check=False, env=_skip_env)
         install_result = subprocess.run(["autoskillit", "install"], check=False, env=_skip_env)

--- a/src/autoskillit/cli/_update.py
+++ b/src/autoskillit/cli/_update.py
@@ -34,7 +34,7 @@ def run_update_command(home: Path | None = None) -> None:
         **os.environ,
         "AUTOSKILLIT_SKIP_STALE_CHECK": "1",
         "AUTOSKILLIT_SKIP_UPDATE_CHECK": "1",
-        "AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK": "1",  # deprecated alias, kept for compat
+        "AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK": "1",
     }
 
     from autoskillit.core import any_kitchen_open

--- a/src/autoskillit/cli/_update.py
+++ b/src/autoskillit/cli/_update.py
@@ -33,7 +33,8 @@ def run_update_command(home: Path | None = None) -> None:
     _skip_env: dict[str, str] = {
         **os.environ,
         "AUTOSKILLIT_SKIP_STALE_CHECK": "1",
-        "AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK": "1",
+        "AUTOSKILLIT_SKIP_UPDATE_CHECK": "1",
+        "AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK": "1",  # deprecated alias, kept for compat
     }
 
     from autoskillit.core import any_kitchen_open
@@ -58,7 +59,14 @@ def run_update_command(home: Path | None = None) -> None:
 
     with terminal_guard():
         subprocess.run(cmd, check=False, env=_skip_env)
-        subprocess.run(["autoskillit", "install"], check=False, env=_skip_env)
+        install_result = subprocess.run(["autoskillit", "install"], check=False, env=_skip_env)
+    if install_result.returncode != 0:
+        print(
+            "\nautoskillit install exited with an error. "
+            "Hooks and plugin cache may be stale. "
+            "Run 'autoskillit install' manually to fix.",
+            flush=True,
+        )
 
     state = _read_dismiss_state(_home)
     target_branch = comparison_branch(info)
@@ -67,7 +75,7 @@ def run_update_command(home: Path | None = None) -> None:
         if target_branch is not None
         else current
     )
-    succeeded = _verify_update_result(current, latest, _home, state)
+    succeeded = _verify_update_result(info, current, latest, _home, state)
 
     if succeeded:
         # Clear any active dismissal state so prompts are fresh

--- a/src/autoskillit/cli/_update_checks.py
+++ b/src/autoskillit/cli/_update_checks.py
@@ -623,6 +623,9 @@ def _run_update_sequence(
         if target_branch is not None
         else current
     )
+    install_result: subprocess.CompletedProcess[bytes] = subprocess.CompletedProcess(
+        args=["autoskillit", "install"], returncode=0
+    )
     with terminal_guard():
         subprocess.run(cmd, check=False, env=skip_env)
         install_result = subprocess.run(["autoskillit", "install"], check=False, env=skip_env)
@@ -633,7 +636,11 @@ def _run_update_sequence(
             "Run 'autoskillit install' manually to fix.",
             flush=True,
         )
-    _verify_update_result(info, current, latest, home, state)
+    succeeded = _verify_update_result(info, current, latest, home, state)
+    if succeeded:
+        state.pop("update_prompt", None)
+        state.pop("binary_snoozed", None)
+        _write_dismiss_state(home, state)
 
 
 # ---------------------------------------------------------------------------

--- a/src/autoskillit/cli/_update_checks.py
+++ b/src/autoskillit/cli/_update_checks.py
@@ -668,7 +668,7 @@ def run_update_checks(home: Path | None = None) -> None:
         or os.environ.get("CI")
         or os.environ.get("AUTOSKILLIT_SKIP_STALE_CHECK")
         or os.environ.get("AUTOSKILLIT_SKIP_UPDATE_CHECK")
-        or os.environ.get("AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK")  # deprecated alias
+        or os.environ.get("AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK")
         or not sys.stdin.isatty()
         or not sys.stdout.isatty()
     ):
@@ -683,7 +683,7 @@ def run_update_checks(home: Path | None = None) -> None:
         **os.environ,
         "AUTOSKILLIT_SKIP_STALE_CHECK": "1",
         "AUTOSKILLIT_SKIP_UPDATE_CHECK": "1",
-        "AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK": "1",  # deprecated alias, kept for compat
+        "AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK": "1",
     }
 
     info = detect_install()

--- a/src/autoskillit/cli/_update_checks.py
+++ b/src/autoskillit/cli/_update_checks.py
@@ -419,6 +419,7 @@ def _api_sha(rev: str, home: Path, *, network: bool = True) -> str | None:
 
 
 def _verify_update_result(
+    info: InstallInfo,
     current: str,
     latest: str,
     home: Path,
@@ -431,7 +432,6 @@ def _verify_update_result(
 
     Returns True if the version advanced (update succeeded).
     Returns False if the version is unchanged (update silently failed).
-    On False, writes a binary_snoozed record and prints an actionable warning.
     """
     import importlib.metadata
 
@@ -444,17 +444,17 @@ def _verify_update_result(
     if new_version != current:
         return True
 
-    state["binary_snoozed"] = {
-        "snoozed_at": datetime.now(UTC).isoformat(),
-        "attempted_version": latest,
-    }
-    _write_dismiss_state(home, state)
+    from autoskillit.cli._install_info import upgrade_command
+
+    cmd = upgrade_command(info)
+    cmd_str = " ".join(cmd) if cmd else "autoskillit update"
     print(
         f"\nUpdate attempted but version is still {current}. "
-        f"If you have an editable install, run:\n"
-        f"  uv pip install -e <project_dir>\n"
-        f"Or for a tool install:\n"
-        f"  uv tool upgrade autoskillit",
+        f"To upgrade, run:\n"
+        f"  autoskillit update\n"
+        f"Or manually:\n"
+        f"  {cmd_str}\n"
+        f"  autoskillit install",
         flush=True,
     )
     return False
@@ -625,8 +625,15 @@ def _run_update_sequence(
     )
     with terminal_guard():
         subprocess.run(cmd, check=False, env=skip_env)
-        subprocess.run(["autoskillit", "install"], check=False, env=skip_env)
-    _verify_update_result(current, latest, home, state)
+        install_result = subprocess.run(["autoskillit", "install"], check=False, env=skip_env)
+    if install_result.returncode != 0:
+        print(
+            "\nautoskillit install exited with an error. "
+            "Hooks and plugin cache may be stale. "
+            "Run 'autoskillit install' manually to fix.",
+            flush=True,
+        )
+    _verify_update_result(info, current, latest, home, state)
 
 
 # ---------------------------------------------------------------------------
@@ -642,7 +649,8 @@ def run_update_checks(home: Path | None = None) -> None:
     - ``CLAUDECODE=1`` — headless/MCP session
     - ``CI=1`` — generic CI environment
     - ``AUTOSKILLIT_SKIP_STALE_CHECK=1`` — explicit bypass
-    - ``AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK=1`` — explicit bypass
+    - ``AUTOSKILLIT_SKIP_UPDATE_CHECK=1`` — explicit bypass (preferred name)
+    - ``AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK=1`` — deprecated alias for the above
     - Non-TTY stdin or stdout
 
     Install types ``LOCAL_EDITABLE``, ``LOCAL_PATH``, and ``UNKNOWN`` are
@@ -652,7 +660,8 @@ def run_update_checks(home: Path | None = None) -> None:
         os.environ.get("CLAUDECODE")
         or os.environ.get("CI")
         or os.environ.get("AUTOSKILLIT_SKIP_STALE_CHECK")
-        or os.environ.get("AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK")
+        or os.environ.get("AUTOSKILLIT_SKIP_UPDATE_CHECK")
+        or os.environ.get("AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK")  # deprecated alias
         or not sys.stdin.isatty()
         or not sys.stdout.isatty()
     ):
@@ -666,7 +675,8 @@ def run_update_checks(home: Path | None = None) -> None:
     _skip_env: dict[str, str] = {
         **os.environ,
         "AUTOSKILLIT_SKIP_STALE_CHECK": "1",
-        "AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK": "1",
+        "AUTOSKILLIT_SKIP_UPDATE_CHECK": "1",
+        "AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK": "1",  # deprecated alias, kept for compat
     }
 
     info = detect_install()

--- a/src/autoskillit/core/_type_constants.py
+++ b/src/autoskillit/core/_type_constants.py
@@ -73,6 +73,7 @@ AUTOSKILLIT_PRIVATE_ENV_VARS: frozenset[str] = frozenset(
     {
         "AUTOSKILLIT_HEADLESS",
         "AUTOSKILLIT_SKIP_STALE_CHECK",
+        "AUTOSKILLIT_SKIP_UPDATE_CHECK",
         "AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK",
         "AUTOSKILLIT_FORCE_UPDATE_CHECK",
         # Franchise tier vars — must not leak into user-code subprocesses

--- a/src/autoskillit/server/tools_kitchen.py
+++ b/src/autoskillit/server/tools_kitchen.py
@@ -53,7 +53,8 @@ def _kitchen_failure_envelope(
     """
     msg = user_hint or (
         f"open_kitchen failed during {stage}: {type(exc).__name__}. "
-        f"Run 'autoskillit doctor' to diagnose, or reinstall if the failure persists."
+        f"Run 'autoskillit doctor' to diagnose, "
+        f"or run 'autoskillit install' if the failure persists."
     )
     return json.dumps(
         {

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -90,10 +90,16 @@ class TestCLIDoctor:
         (tmp_path / ".pre-commit-config.yaml").write_text(
             "repos:\n  - repo: dummy\n    hooks:\n      - id: gitleaks\n"
         )
-        # Create plugin cache directory for Check 2c
-        (tmp_path / ".claude" / "plugins" / "cache" / "autoskillit-local" / "autoskillit").mkdir(
-            parents=True, exist_ok=True
+        # Create plugin cache directory for Check 2c + version_consistency plugin.json
+        import importlib.metadata
+
+        _cache_dir = (
+            tmp_path / ".claude" / "plugins" / "cache" / "autoskillit-local" / "autoskillit"
         )
+        _cache_dir.mkdir(parents=True, exist_ok=True)
+        _plugin_json = _cache_dir / ".claude-plugin" / "plugin.json"
+        _plugin_json.parent.mkdir(parents=True, exist_ok=True)
+        _plugin_json.write_text(json.dumps({"version": importlib.metadata.version("autoskillit")}))
         # Create installed_plugins.json for Check 2d
         (tmp_path / ".claude" / "plugins" / "installed_plugins.json").write_text(
             json.dumps({"version": 2, "plugins": {"autoskillit@autoskillit-local": {}}})

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -203,7 +203,11 @@ class TestCLIDoctor:
         assert Severity.WARNING not in _NON_PROBLEM, "WARNING must not be in _NON_PROBLEM"
 
     def test_doctor_passes_when_versions_match(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture,
+        request: pytest.FixtureRequest,
     ) -> None:
         """doctor reports ok when cached plugin.json version matches package."""
         import importlib.metadata
@@ -220,7 +224,7 @@ class TestCLIDoctor:
         from autoskillit.version import version_info as _vi
 
         _vi.cache_clear()
-        monkeypatch.addfinalizer(_vi.cache_clear)
+        request.addfinalizer(_vi.cache_clear)
         cli.doctor(output_json=True)
         captured = capsys.readouterr()
         data = json.loads(captured.out)
@@ -2444,7 +2448,10 @@ class TestGroupNFeatureGateDoctorChecks:
 
 
 def test_doctor_version_consistency_detects_stale_cache(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+    request: pytest.FixtureRequest,
 ) -> None:
     """Check 5 warns when the CACHED plugin.json version is behind the package."""
     import importlib.metadata
@@ -2460,7 +2467,7 @@ def test_doctor_version_consistency_detects_stale_cache(
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(importlib.metadata, "version", lambda _: "0.9.0")
     _vi.cache_clear()
-    monkeypatch.addfinalizer(_vi.cache_clear)
+    request.addfinalizer(_vi.cache_clear)
     cli.doctor(output_json=True)
     data = json.loads(capsys.readouterr().out)
     vc = next(r for r in data["results"] if r["check"] == "version_consistency")
@@ -2469,7 +2476,10 @@ def test_doctor_version_consistency_detects_stale_cache(
 
 
 def test_doctor_version_consistency_ok_when_cache_matches(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+    request: pytest.FixtureRequest,
 ) -> None:
     """Check 5 reports OK when cached plugin.json version matches the package."""
     import importlib.metadata
@@ -2485,7 +2495,7 @@ def test_doctor_version_consistency_ok_when_cache_matches(
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(importlib.metadata, "version", lambda _: "0.9.0")
     _vi.cache_clear()
-    monkeypatch.addfinalizer(_vi.cache_clear)
+    request.addfinalizer(_vi.cache_clear)
     cli.doctor(output_json=True)
     data = json.loads(capsys.readouterr().out)
     vc = next(r for r in data["results"] if r["check"] == "version_consistency")

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -199,9 +199,21 @@ class TestCLIDoctor:
     def test_doctor_passes_when_versions_match(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
     ) -> None:
-        """doctor reports ok when plugin.json version matches package."""
+        """doctor reports ok when cached plugin.json version matches package."""
+        import importlib.metadata
+
+        pkg_version = importlib.metadata.version("autoskillit")
+        cache_dir = (
+            tmp_path / ".claude" / "plugins" / "cache" / "autoskillit-local" / "autoskillit"
+        )
+        plugin_json = cache_dir / ".claude-plugin" / "plugin.json"
+        plugin_json.parent.mkdir(parents=True)
+        plugin_json.write_text(json.dumps({"version": pkg_version}))
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         monkeypatch.chdir(tmp_path)
+        from autoskillit.version import version_info as _vi
+
+        _vi.cache_clear()
         cli.doctor(output_json=True)
         captured = capsys.readouterr()
         data = json.loads(captured.out)
@@ -2417,3 +2429,86 @@ class TestGroupNFeatureGateDoctorChecks:
         assert result.severity == Severity.ERROR
         assert "bad_feature" in result.message
         assert "nonexistent.pkg" in result.message
+
+
+# ---------------------------------------------------------------------------
+# T3 — version_consistency reads cache dir, not source tree
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_version_consistency_detects_stale_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """Check 5 warns when the CACHED plugin.json version is behind the package."""
+    import importlib.metadata
+
+    from autoskillit.version import version_info as _vi
+
+    cache_dir = tmp_path / ".claude" / "plugins" / "cache" / "autoskillit-local" / "autoskillit"
+    plugin_json = cache_dir / ".claude-plugin" / "plugin.json"
+    plugin_json.parent.mkdir(parents=True)
+    plugin_json.write_text('{"version": "0.8.0"}')
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(importlib.metadata, "version", lambda _: "0.9.0")
+    _vi.cache_clear()
+    cli.doctor(output_json=True)
+    data = json.loads(capsys.readouterr().out)
+    vc = next(r for r in data["results"] if r["check"] == "version_consistency")
+    assert vc["severity"] == "warning"
+    assert "autoskillit install" in vc["message"]
+
+
+def test_doctor_version_consistency_ok_when_cache_matches(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """Check 5 reports OK when cached plugin.json version matches the package."""
+    import importlib.metadata
+
+    from autoskillit.version import version_info as _vi
+
+    cache_dir = tmp_path / ".claude" / "plugins" / "cache" / "autoskillit-local" / "autoskillit"
+    plugin_json = cache_dir / ".claude-plugin" / "plugin.json"
+    plugin_json.parent.mkdir(parents=True)
+    plugin_json.write_text('{"version": "0.9.0"}')
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(importlib.metadata, "version", lambda _: "0.9.0")
+    _vi.cache_clear()
+    cli.doctor(output_json=True)
+    data = json.loads(capsys.readouterr().out)
+    vc = next(r for r in data["results"] if r["check"] == "version_consistency")
+    assert vc["severity"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# T4 — _check_source_version_drift remediation uses specific upgrade command
+# ---------------------------------------------------------------------------
+
+
+def test_source_version_drift_remediation_contains_upgrade_command(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """_check_source_version_drift WARNING message contains the install-type-specific command."""
+    from autoskillit.cli._doctor import _check_source_version_drift
+    from autoskillit.cli._install_info import InstallInfo, InstallType
+    from autoskillit.core import Severity
+
+    info = InstallInfo(
+        install_type=InstallType.GIT_VCS,
+        commit_id="aaaa1111bbbb",
+        requested_revision="stable",
+        url="https://github.com/TalonT-Org/AutoSkillit.git",
+        editable_source=None,
+    )
+    monkeypatch.setattr("autoskillit.cli._install_info.detect_install", lambda: info)
+    monkeypatch.setattr(
+        "autoskillit.cli._update_checks.resolve_reference_sha",
+        lambda *a, **kw: "bbbb2222cccc",
+    )
+    result = _check_source_version_drift(home=tmp_path)
+    assert result.severity == Severity.WARNING
+    assert "uv tool upgrade autoskillit" in result.message
+    assert "appropriate" not in result.message

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -220,6 +220,7 @@ class TestCLIDoctor:
         from autoskillit.version import version_info as _vi
 
         _vi.cache_clear()
+        monkeypatch.addfinalizer(_vi.cache_clear)
         cli.doctor(output_json=True)
         captured = capsys.readouterr()
         data = json.loads(captured.out)
@@ -2459,6 +2460,7 @@ def test_doctor_version_consistency_detects_stale_cache(
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(importlib.metadata, "version", lambda _: "0.9.0")
     _vi.cache_clear()
+    monkeypatch.addfinalizer(_vi.cache_clear)
     cli.doctor(output_json=True)
     data = json.loads(capsys.readouterr().out)
     vc = next(r for r in data["results"] if r["check"] == "version_consistency")
@@ -2483,6 +2485,7 @@ def test_doctor_version_consistency_ok_when_cache_matches(
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(importlib.metadata, "version", lambda _: "0.9.0")
     _vi.cache_clear()
+    monkeypatch.addfinalizer(_vi.cache_clear)
     cli.doctor(output_json=True)
     data = json.loads(capsys.readouterr().out)
     vc = next(r for r in data["results"] if r["check"] == "version_consistency")

--- a/tests/cli/test_installed_plugins_file.py
+++ b/tests/cli/test_installed_plugins_file.py
@@ -85,17 +85,23 @@ def test_remove_is_noop_when_file_absent(tmp_path: Path) -> None:
     assert not p.exists()
 
 
-def test_installed_plugins_read_logs_on_json_error(
-    tmp_path: Path, caplog: pytest.LogCaptureFixture
-) -> None:
+def test_installed_plugins_read_logs_on_json_error(tmp_path: Path) -> None:
     """_read() emits a WARNING log when installed_plugins.json contains invalid JSON."""
     import logging
 
     p = tmp_path / "installed_plugins.json"
     p.write_text("{invalid json}")
 
-    store = InstalledPluginsFile(p)
-    with caplog.at_level(logging.WARNING, logger="autoskillit.cli._installed_plugins"):
-        result = store.get_plugins()
+    # caplog is unreliable under xdist when structlog's autouse fixture intercepts the
+    # handler chain. Attach a handler directly to the specific logger instead.
+    captured: list[logging.LogRecord] = []
+    handler = logging.Handler()
+    handler.emit = captured.append  # type: ignore[assignment]
+    logger = logging.getLogger("autoskillit.cli._installed_plugins")  # noqa: TID251
+    logger.addHandler(handler)
+    try:
+        result = InstalledPluginsFile(p).get_plugins()
+    finally:
+        logger.removeHandler(handler)
     assert result == {}
-    assert any("installed_plugins" in r.message.lower() for r in caplog.records)
+    assert any("installed_plugins" in r.getMessage().lower() for r in captured)

--- a/tests/cli/test_installed_plugins_file.py
+++ b/tests/cli/test_installed_plugins_file.py
@@ -83,3 +83,19 @@ def test_remove_is_noop_when_file_absent(tmp_path: Path) -> None:
     p = tmp_path / "no_file.json"
     InstalledPluginsFile(p).remove("autoskillit@autoskillit-local")  # should not raise
     assert not p.exists()
+
+
+def test_installed_plugins_read_logs_on_json_error(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """_read() emits a WARNING log when installed_plugins.json contains invalid JSON."""
+    import logging
+
+    p = tmp_path / "installed_plugins.json"
+    p.write_text("{invalid json}")
+
+    store = InstalledPluginsFile(p)
+    with caplog.at_level(logging.WARNING, logger="autoskillit.cli._installed_plugins"):
+        result = store.get_plugins()
+    assert result == {}
+    assert any("installed_plugins" in r.message.lower() for r in caplog.records)

--- a/tests/cli/test_update_checks.py
+++ b/tests/cli/test_update_checks.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import io
 import json
+import subprocess
 import sys
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -87,6 +88,7 @@ def _make_mock_client(
         ("CLAUDECODE", "1"),
         ("CI", "1"),
         ("AUTOSKILLIT_SKIP_STALE_CHECK", "1"),
+        ("AUTOSKILLIT_SKIP_UPDATE_CHECK", "1"),
         ("AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK", "1"),
     ],
 )
@@ -102,6 +104,7 @@ def test_run_update_checks_skips_on_guard_env_var(
         "CLAUDECODE",
         "CI",
         "AUTOSKILLIT_SKIP_STALE_CHECK",
+        "AUTOSKILLIT_SKIP_UPDATE_CHECK",
         "AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK",
     ]:
         if other != env_var:
@@ -124,6 +127,7 @@ def test_run_update_checks_skips_non_tty_stdin(
     monkeypatch.delenv("CLAUDECODE", raising=False)
     monkeypatch.delenv("CI", raising=False)
     monkeypatch.delenv("AUTOSKILLIT_SKIP_STALE_CHECK", raising=False)
+    monkeypatch.delenv("AUTOSKILLIT_SKIP_UPDATE_CHECK", raising=False)
     monkeypatch.delenv("AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK", raising=False)
     fake_stdin = io.StringIO()
     fake_stdout = io.StringIO()
@@ -144,6 +148,7 @@ def test_run_update_checks_skips_non_tty_stdout(
     monkeypatch.delenv("CLAUDECODE", raising=False)
     monkeypatch.delenv("CI", raising=False)
     monkeypatch.delenv("AUTOSKILLIT_SKIP_STALE_CHECK", raising=False)
+    monkeypatch.delenv("AUTOSKILLIT_SKIP_UPDATE_CHECK", raising=False)
     monkeypatch.delenv("AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK", raising=False)
 
     fake_stdin = MagicMock()
@@ -170,6 +175,7 @@ def test_run_update_checks_skips_local_and_unknown_install_types(
     monkeypatch.delenv("CLAUDECODE", raising=False)
     monkeypatch.delenv("CI", raising=False)
     monkeypatch.delenv("AUTOSKILLIT_SKIP_STALE_CHECK", raising=False)
+    monkeypatch.delenv("AUTOSKILLIT_SKIP_UPDATE_CHECK", raising=False)
     monkeypatch.delenv("AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK", raising=False)
     monkeypatch.delenv("AUTOSKILLIT_FORCE_UPDATE_CHECK", raising=False)
 
@@ -493,6 +499,7 @@ def _setup_run_checks(
     monkeypatch.delenv("CLAUDECODE", raising=False)
     monkeypatch.delenv("CI", raising=False)
     monkeypatch.delenv("AUTOSKILLIT_SKIP_STALE_CHECK", raising=False)
+    monkeypatch.delenv("AUTOSKILLIT_SKIP_UPDATE_CHECK", raising=False)
     monkeypatch.delenv("AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK", raising=False)
     monkeypatch.delenv("AUTOSKILLIT_FORCE_UPDATE_CHECK", raising=False)
 
@@ -651,7 +658,7 @@ def test_yes_runs_upgrade_command_from_install_info_not_hardcoded(
     run_calls: list[list[str]] = []
     monkeypatch.setattr(
         "autoskillit.cli._update_checks.subprocess.run",
-        lambda cmd, **kw: run_calls.append(list(cmd)),
+        lambda cmd, **kw: run_calls.append(list(cmd)) or subprocess.CompletedProcess(cmd, 0),
     )
     monkeypatch.setattr("autoskillit.cli._update_checks.terminal_guard", MagicMock())
     monkeypatch.setattr(
@@ -683,7 +690,7 @@ def test_yes_runs_autoskillit_install_after_upgrade_command(
     monkeypatch.setattr("autoskillit.cli._update_checks.terminal_guard", FakeTG)
     monkeypatch.setattr(
         "autoskillit.cli._update_checks.subprocess.run",
-        lambda cmd, **kw: run_calls.append(list(cmd)),
+        lambda cmd, **kw: run_calls.append(list(cmd)) or subprocess.CompletedProcess(cmd, 0),
     )
     monkeypatch.setattr(
         "autoskillit.cli._update_checks._verify_update_result", lambda *a, **kw: True
@@ -709,7 +716,9 @@ def test_yes_passes_skip_env_to_subprocess(
     monkeypatch.setattr("autoskillit.cli._update_checks.terminal_guard", FakeTG)
     monkeypatch.setattr(
         "autoskillit.cli._update_checks.subprocess.run",
-        lambda cmd, **kw: env_passed.append(kw.get("env", {})),
+        lambda cmd, **kw: (
+            env_passed.append(kw.get("env", {})) or subprocess.CompletedProcess(cmd, 0)
+        ),
     )
     monkeypatch.setattr(
         "autoskillit.cli._update_checks._verify_update_result", lambda *a, **kw: True
@@ -717,6 +726,7 @@ def test_yes_passes_skip_env_to_subprocess(
     run_update_checks(home=tmp_path)
     for env in env_passed:
         assert env.get("AUTOSKILLIT_SKIP_STALE_CHECK") == "1"
+        assert env.get("AUTOSKILLIT_SKIP_UPDATE_CHECK") == "1"
         assert env.get("AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK") == "1"
 
 
@@ -735,7 +745,10 @@ def test_yes_single_invocation_exits_without_any_other_prompt(
             return False
 
     monkeypatch.setattr("autoskillit.cli._update_checks.terminal_guard", FakeTG)
-    monkeypatch.setattr("autoskillit.cli._update_checks.subprocess.run", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        "autoskillit.cli._update_checks.subprocess.run",
+        lambda *a, **kw: subprocess.CompletedProcess([], 0),
+    )
     monkeypatch.setattr(
         "autoskillit.cli._update_checks._verify_update_result", lambda *a, **kw: True
     )
@@ -1589,3 +1602,96 @@ def test_all_dismissed_signals_produce_no_interactive_prompt(
     assert "autoskillit update" in combined, (
         "All-dismissed signals must produce passive notification containing 'autoskillit update'"
     )
+
+
+# ---------------------------------------------------------------------------
+# T1 — _verify_update_result uses install-type-aware upgrade command
+# ---------------------------------------------------------------------------
+
+
+def test_verify_update_result_prints_git_vcs_stable_command(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    import importlib.metadata
+
+    from autoskillit.cli._update_checks import _verify_update_result
+
+    info = _make_stable_info()
+    with patch.object(importlib.metadata, "version", return_value="0.9.0"):
+        result = _verify_update_result(info, "0.9.0", "0.9.1", tmp_path, {})
+    assert result is False
+    out = capsys.readouterr().out
+    assert "uv tool upgrade autoskillit" in out
+    assert "autoskillit update" in out
+
+
+def test_verify_update_result_prints_git_vcs_integration_command(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    import importlib.metadata
+
+    from autoskillit.cli._update_checks import _verify_update_result
+
+    info = _make_integration_info()
+    with patch.object(importlib.metadata, "version", return_value="0.9.0"):
+        result = _verify_update_result(info, "0.9.0", "0.9.1", tmp_path, {})
+    assert result is False
+    out = capsys.readouterr().out
+    assert "git+" in out
+    assert "uv tool upgrade autoskillit" not in out
+
+
+# ---------------------------------------------------------------------------
+# T2 — _run_update_sequence warns when autoskillit install exits non-zero
+# ---------------------------------------------------------------------------
+
+
+def test_run_update_sequence_warns_on_install_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    from autoskillit.cli._update_checks import _run_update_sequence
+
+    class FakeTG:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    info = _make_stable_info()
+    upgrade_ok = subprocess.CompletedProcess([], returncode=0)
+    install_fail = subprocess.CompletedProcess([], returncode=1)
+    calls = iter([upgrade_ok, install_fail])
+    monkeypatch.setattr(
+        "autoskillit.cli._update_checks.subprocess.run", lambda *a, **kw: next(calls)
+    )
+    monkeypatch.setattr("autoskillit.cli._update_checks.terminal_guard", FakeTG)
+    monkeypatch.setattr(
+        "autoskillit.cli._update_checks._fetch_latest_version", lambda *a, **kw: "0.9.1"
+    )
+    monkeypatch.setattr(
+        "autoskillit.cli._update_checks._verify_update_result", lambda *a, **kw: True
+    )
+    _run_update_sequence(info, "0.9.0", tmp_path, {}, {})
+    out = capsys.readouterr().out
+    assert "install" in out.lower()
+    assert "stale" in out.lower() or "autoskillit install" in out
+
+
+# ---------------------------------------------------------------------------
+# T6 — binary_snoozed is never written by _verify_update_result
+# ---------------------------------------------------------------------------
+
+
+def test_verify_update_result_does_not_write_binary_snoozed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import importlib.metadata
+
+    from autoskillit.cli._update_checks import _verify_update_result
+
+    info = _make_stable_info(commit_id="abc")
+    state: dict = {}
+    with patch.object(importlib.metadata, "version", return_value="0.9.0"):
+        _verify_update_result(info, "0.9.0", "0.9.1", tmp_path, state)
+    assert "binary_snoozed" not in state

--- a/tests/cli/test_update_checks.py
+++ b/tests/cli/test_update_checks.py
@@ -1674,8 +1674,8 @@ def test_run_update_sequence_warns_on_install_failure(
     )
     _run_update_sequence(info, "0.9.0", tmp_path, {}, {})
     out = capsys.readouterr().out
-    assert "install" in out.lower()
-    assert "stale" in out.lower() or "autoskillit install" in out
+    assert "autoskillit install" in out
+    assert "stale" in out.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_update_command.py
+++ b/tests/cli/test_update_command.py
@@ -188,7 +188,7 @@ def test_update_verifies_version_advance_and_warns_on_failure(
     )
     run_update_command(home=tmp_path)
     combined = " ".join(printed)
-    assert "still" in combined or "unchanged" in combined or "still 0.7.77" in combined
+    assert "still 0.7.77" in combined
 
 
 def test_update_clears_dismissal_state_on_success(

--- a/tests/cli/test_update_command.py
+++ b/tests/cli/test_update_command.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -47,7 +48,7 @@ def _setup_run_update(
     run_calls: list[list[str]] = []
     monkeypatch.setattr(
         "autoskillit.cli._update.subprocess.run",
-        lambda cmd, **kw: run_calls.append(list(cmd)),
+        lambda cmd, **kw: run_calls.append(list(cmd)) or subprocess.CompletedProcess(cmd, 0),
     )
 
     import autoskillit as _pkg
@@ -136,7 +137,9 @@ def test_update_passes_skip_env_to_subprocess(
     env_passed: list[dict] = []
     monkeypatch.setattr(
         "autoskillit.cli._update.subprocess.run",
-        lambda cmd, **kw: env_passed.append(kw.get("env", {})),
+        lambda cmd, **kw: (
+            env_passed.append(kw.get("env", {})) or subprocess.CompletedProcess(cmd, 0)
+        ),
     )
 
     import autoskillit as _pkg
@@ -150,6 +153,7 @@ def test_update_passes_skip_env_to_subprocess(
 
     for env in env_passed:
         assert env.get("AUTOSKILLIT_SKIP_STALE_CHECK") == "1"
+        assert env.get("AUTOSKILLIT_SKIP_UPDATE_CHECK") == "1"
         assert env.get("AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK") == "1"
 
 
@@ -157,12 +161,14 @@ def test_update_verifies_version_advance_and_warns_on_failure(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     from autoskillit.cli._update import run_update_command
-    from autoskillit.cli._update_checks import _read_dismiss_state
 
     info = _make_info(InstallType.GIT_VCS, revision="stable")
     monkeypatch.setattr("autoskillit.cli._update.detect_install", lambda: info)
     monkeypatch.setattr("autoskillit.cli._update.terminal_guard", FakeTG)
-    monkeypatch.setattr("autoskillit.cli._update.subprocess.run", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        "autoskillit.cli._update.subprocess.run",
+        lambda *a, **kw: subprocess.CompletedProcess([], 0),
+    )
     monkeypatch.setattr(
         "autoskillit.cli._update_checks._fetch_latest_version", lambda *a, **kw: "0.9.0"
     )
@@ -183,18 +189,6 @@ def test_update_verifies_version_advance_and_warns_on_failure(
     run_update_command(home=tmp_path)
     combined = " ".join(printed)
     assert "still" in combined or "unchanged" in combined or "still 0.7.77" in combined
-
-    # Verify binary_snoozed disk state records the correct attempted_version
-    state = _read_dismiss_state(tmp_path)
-    assert "binary_snoozed" in state, (
-        f"Expected 'binary_snoozed' key in dismiss state after failed update; got {list(state)}"
-    )
-    snooze = state["binary_snoozed"]
-    assert isinstance(snooze, dict), f"Expected dict for binary_snoozed; got {type(snooze)}"
-    assert snooze.get("attempted_version") == "0.9.0", (
-        f"Expected attempted_version='0.9.0' (from _fetch_latest_version); "
-        f"got {snooze.get('attempted_version')!r}"
-    )
 
 
 def test_update_clears_dismissal_state_on_success(
@@ -219,7 +213,10 @@ def test_update_clears_dismissal_state_on_success(
     info = _make_info(InstallType.GIT_VCS, revision="stable")
     monkeypatch.setattr("autoskillit.cli._update.detect_install", lambda: info)
     monkeypatch.setattr("autoskillit.cli._update.terminal_guard", FakeTG)
-    monkeypatch.setattr("autoskillit.cli._update.subprocess.run", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        "autoskillit.cli._update.subprocess.run",
+        lambda *a, **kw: subprocess.CompletedProcess([], 0),
+    )
 
     import autoskillit as _pkg
 
@@ -251,3 +248,31 @@ def test_update_reports_actionable_error_on_unknown_install_type(
     assert exc_info.value.code == 2
     combined = " ".join(printed)
     assert "Unknown install type" in combined or "install.sh" in combined
+
+
+def test_run_update_command_warns_on_install_failure(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture, tmp_path: Path
+) -> None:
+    """run_update_command warns user when autoskillit install step exits non-zero."""
+    from autoskillit.cli._update import run_update_command
+
+    info = _make_info(InstallType.GIT_VCS, revision="stable")
+    monkeypatch.setattr("autoskillit.cli._update.detect_install", lambda: info)
+    monkeypatch.setattr("autoskillit.cli._update.terminal_guard", FakeTG)
+
+    upgrade_ok = subprocess.CompletedProcess([], returncode=0)
+    install_fail = subprocess.CompletedProcess([], returncode=1)
+    calls = iter([upgrade_ok, install_fail])
+    monkeypatch.setattr("autoskillit.cli._update.subprocess.run", lambda *a, **kw: next(calls))
+    monkeypatch.setattr(
+        "autoskillit.cli._update_checks._fetch_latest_version", lambda *a, **kw: "0.9.1"
+    )
+    import autoskillit as _pkg
+
+    monkeypatch.setattr(_pkg, "__version__", "0.9.0")
+    import importlib.metadata
+
+    monkeypatch.setattr(importlib.metadata, "version", lambda _: "0.9.1")
+    run_update_command(home=tmp_path)
+    out = capsys.readouterr().out
+    assert "autoskillit install" in out

--- a/tests/cli/test_update_command.py
+++ b/tests/cli/test_update_command.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -262,13 +263,15 @@ def test_run_update_command_warns_on_install_failure(
 
     upgrade_ok = subprocess.CompletedProcess([], returncode=0)
     install_fail = subprocess.CompletedProcess([], returncode=1)
-    calls = iter([upgrade_ok, install_fail])
-    monkeypatch.setattr("autoskillit.cli._update.subprocess.run", lambda *a, **kw: next(calls))
+    mock_run = MagicMock(side_effect=[upgrade_ok, install_fail])
+    monkeypatch.setattr("autoskillit.cli._update.subprocess.run", mock_run)
     monkeypatch.setattr(
         "autoskillit.cli._update_checks._fetch_latest_version", lambda *a, **kw: "0.9.1"
     )
     import autoskillit as _pkg
 
+    # Simulate pre-update state: process-cached __version__ is stale (0.9.0),
+    # but post-install metadata already reflects the new version (0.9.1).
     monkeypatch.setattr(_pkg, "__version__", "0.9.0")
     import importlib.metadata
 

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -127,8 +127,8 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _lifespan.py — hooks.json self-heal on startup drift (co-owned with Claude plugin system)
     ("src/autoskillit/server/_lifespan.py", 56),
     # tools_kitchen.py — hook config dict
-    ("src/autoskillit/server/tools_kitchen.py", 180),
-    ("src/autoskillit/server/tools_kitchen.py", 596),
+    ("src/autoskillit/server/tools_kitchen.py", 181),
+    ("src/autoskillit/server/tools_kitchen.py", 597),
     # tools_status.py — mcp_data dict
     ("src/autoskillit/server/tools_status.py", 400),
     # tools_github.py — bug report dict
@@ -140,7 +140,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _init_helpers.py — evict_direct_mcp_entry write-back to ~/.claude.json (co-owned)
     ("src/autoskillit/cli/_init_helpers.py", 395),
     # _installed_plugins.py — installed_plugins.json (co-owned with Claude plugin system)
-    ("src/autoskillit/cli/_installed_plugins.py", 65),
+    ("src/autoskillit/cli/_installed_plugins.py", 72),
     # _marketplace.py — marketplace.json (co-owned)
     ("src/autoskillit/cli/_marketplace.py", 92),
     # _marketplace.py — hooks.json (co-owned)

--- a/tests/server/test_tools_kitchen.py
+++ b/tests/server/test_tools_kitchen.py
@@ -1344,3 +1344,17 @@ async def test_redisable_subsets_does_not_disable_kitchen_core_tag() -> None:
     assert not any("kitchen-core" in t for t in disabled_tags), (
         "kitchen-core tag must never be disabled by the feature gate pass"
     )
+
+
+# ---------------------------------------------------------------------------
+# T7 — _kitchen_failure_envelope default hint says autoskillit install not reinstall
+# ---------------------------------------------------------------------------
+
+
+def test_kitchen_failure_envelope_hint_says_install_not_reinstall() -> None:
+    from autoskillit.server.tools_kitchen import _kitchen_failure_envelope
+
+    result = json.loads(_kitchen_failure_envelope(exc=RuntimeError("x"), stage="test"))
+    msg = result["user_visible_message"]
+    assert "autoskillit install" in msg
+    assert "reinstall" not in msg


### PR DESCRIPTION
## Summary

Fix a cluster of bugs in the update/install flow: wrong upgrade command in the `_verify_update_result` fallback message, silent `autoskillit install` failures after upgrade, the `version_consistency` doctor check reading the wrong `plugin.json`, stale documentation with incorrect check counts and outdated upgrade instructions, and a set of minor remediation message inconsistencies throughout `_doctor.py`, `tools_kitchen.py`, and `_installed_plugins.py`.

No new features. All changes are correctness fixes and cleanups.

## Architecture Impact

### Error/Resilience Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 42, 'rankSpacing': 54, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ── ENTRY POINTS ── %%
    CMD_UPDATE([● autoskillit update])
    CMD_STARTUP([● startup update check])
    CMD_DOCTOR([● autoskillit doctor])
    CMD_KITCHEN([● open_kitchen / close_kitchen / disable_quota_guard])

    %% ═══════════════════════════════════════════════════════ %%
    subgraph InstallGates ["● _update.py — Explicit Fail-Fast Gates"]
        direction TB
        G_KITCHEN{"kitchen<br/>open?"}
        G_INSTALL{"install type<br/>upgradeable?"}
        SYSEXIT1(["SystemExit(1)<br/>━━━━━━━━━━<br/>Kitchen must be<br/>closed first"])
        SYSEXIT2(["SystemExit(2)<br/>━━━━━━━━━━<br/>UNKNOWN / LOCAL_PATH<br/>— no upgrade path"])
    end

    %% ═══════════════════════════════════════════════════════ %%
    subgraph StartupGates ["● _update_checks.py — Silent-Exit Gates (run_update_checks)"]
        direction LR
        SG1["CLAUDECODE=1<br/>CI=1<br/>non-TTY<br/>━━━━━━━━━━<br/>return immediately"]
        SG2["any_kitchen_open()<br/>━━━━━━━━━━<br/>return immediately"]
        SG3["● install type gate<br/>━━━━━━━━━━<br/>LOCAL_EDITABLE /<br/>LOCAL_PATH / UNKNOWN<br/>→ return unless<br/>FORCE env set"]
    end

    %% ═══════════════════════════════════════════════════════ %%
    subgraph SignalGathering ["● _update_checks.py — Signal Gathering (all fail-open → None on any error)"]
        direction LR
        SIG_BIN["● _binary_signal()<br/>━━━━━━━━━━<br/>except Exception → None<br/>version comparison"]
        SIG_HOOK["● _hooks_signal()<br/>━━━━━━━━━━<br/>except Exception → None<br/>hook drift check"]
        SIG_DRIFT["● _source_drift_signal()<br/>━━━━━━━━━━<br/>except Exception → None<br/>source SHA drift"]
        SIG_ZERO{"all signals<br/>None?"}
    end

    %% ═══════════════════════════════════════════════════════ %%
    subgraph FetchChain ["● _update_checks.py — Network Fetch (cached, never retried)"]
        direction TB
        FC_CACHE["disk cache hit?<br/>━━━━━━━━━━<br/>TTL: configurable<br/>except → {} fallback"]
        FC_NET["httpx.Client.get()<br/>━━━━━━━━━━<br/>except Exception → None<br/>status ≠ 200/304 → None"]
        FC_PARSE["parse pyproject.toml<br/>━━━━━━━━━━<br/>except Exception → None<br/>no version line → None"]
        FC_NONE(["returns None<br/>━━━━━━━━━━<br/>signal suppressed"])
    end

    %% ═══════════════════════════════════════════════════════ %%
    subgraph SHAResolution ["● _update_checks.py — SHA Resolution (two-tier fallback)"]
        direction LR
        SHA_SKIP{"requested_revision<br/>is None?"}
        SHA_GIT["● _git_ls_remote_sha()<br/>━━━━━━━━━━<br/>subprocess.SubprocessError<br/>FileNotFoundError OSError<br/>IndexError → continue"]
        SHA_API["● _api_sha()<br/>━━━━━━━━━━<br/>isinstance guards<br/>no try/except<br/>network=False offline fallback"]
        SHA_NONE(["returns None<br/>━━━━━━━━━━<br/>drift check skipped"])
    end

    %% ═══════════════════════════════════════════════════════ %%
    subgraph UpdateExec ["● _update.py — Update Execution"]
        direction TB
        UE_RUN["subprocess.run(..., check=False)<br/>━━━━━━━━━━<br/>returncode checked manually<br/>non-zero → WARNING printed<br/>execution continues"]
        UE_FETCH["_fetch_latest_version(...) or current<br/>━━━━━━━━━━<br/>None fallback prevents<br/>None propagation"]
        UE_VERIFY["● _verify_update_result()<br/>━━━━━━━━━━<br/>except Exception → fallback to current<br/>version advanced? True/False"]
        UE_DISMISS["pop update_prompt<br/>pop binary_snoozed<br/>━━━━━━━━━━<br/>.pop(k, None) — KeyError-safe"]
    end

    %% ═══════════════════════════════════════════════════════ %%
    subgraph DoctorChecks ["● _doctor.py — Doctor Check Resilience"]
        direction TB
        DR_CLAUDE["run_doctor() reads ~/.claude.json<br/>━━━━━━━━━━<br/>(JSONDecodeError, OSError)<br/>→ ERROR result + _stale_parse_error flag<br/>→ data = {} continues"]
        DR_NAMED["Named checks<br/>_check_mcp_server_registered<br/>_check_hook_registry_drift etc.<br/>━━━━━━━━━━<br/>Named exceptions → ERROR/WARNING result<br/>Never raise; always DoctorResult"]
        DR_BROAD["Broad-catch checks<br/>_check_source_version_drift<br/>_check_install_classification<br/>● _check_update_dismissal_state<br/>━━━━━━━━━━<br/>except Exception → OK 'skipped'<br/>Graceful degradation"]
        DR_RESULT(["DoctorResult(severity)<br/>━━━━━━━━━━<br/>ERROR / WARNING / OK<br/>Never propagates exceptions"])
    end

    %% ═══════════════════════════════════════════════════════ %%
    subgraph PluginRegistry ["● _installed_plugins.py — InstalledPluginsFile"]
        direction LR
        IP_READ["_read()<br/>━━━━━━━━━━<br/>FileNotFoundError → {}<br/>JSONDecodeError → {} + WARNING<br/>OSError → {} + WARNING"]
        IP_REMOVE["remove()<br/>━━━━━━━━━━<br/>file absent → no-op return<br/>key absent → no-op return<br/>atomic write on success"]
    end

    %% ═══════════════════════════════════════════════════════ %%
    subgraph KitchenGate ["● tools_kitchen.py — Kitchen Gate Error Architecture"]
        direction TB
        KG_ORCH["_require_orchestrator_exact()<br/>━━━━━━━━━━<br/>First check on all 3 tools<br/>headless caller → denial envelope<br/>never raises"]
        KG_STAGES["_open_kitchen_handler() stages<br/>━━━━━━━━━━<br/>_write_hook_config<br/>_prime_quota_cache<br/>create_background_task<br/>each wrapped independently"]
        KG_FATAL{"stage<br/>exception?"}
        KG_DISABLE["ctx.gate.disable()<br/>━━━━━━━━━━<br/>Gate left closed<br/>on any stage failure"]
        KG_ENVELOPE["● _kitchen_failure_envelope()<br/>━━━━━━━━━━<br/>success: False<br/>kitchen: 'failed'<br/>stage + error fields"]
        KG_NONFATAL["register_active_kitchen()<br/>unregister_active_kitchen()<br/>━━━━━━━━━━<br/>except Exception → WARNING log<br/>Gate NOT rolled back<br/>Truly non-fatal"]
        KG_OUTERMOST["Outermost except Exception<br/>━━━━━━━━━━<br/>logs ERROR<br/>returns failure envelope<br/>unhandled escape hatch"]
    end

    %% ── TERMINAL STATES ── %%
    T_SILENT(["SILENT RETURN<br/>━━━━━━━━━━<br/>No output shown"])
    T_UPDATE_OK(["UPDATE COMPLETE<br/>━━━━━━━━━━<br/>version advanced"])
    T_UPDATE_FAIL(["UPDATE UNVERIFIED<br/>━━━━━━━━━━<br/>version unchanged"])
    T_KITCHEN_OK(["KITCHEN OPEN<br/>━━━━━━━━━━<br/>gate enabled"])
    T_KITCHEN_FAIL(["KITCHEN FAILED<br/>━━━━━━━━━━<br/>gate disabled"])

    %% ══════════════════════════════════════ %%
    %% CONNECTIONS
    %% ══════════════════════════════════════ %%

    CMD_UPDATE --> G_KITCHEN
    G_KITCHEN -->|"open"| SYSEXIT1
    G_KITCHEN -->|"closed"| G_INSTALL
    G_INSTALL -->|"UNKNOWN / LOCAL_PATH"| SYSEXIT2
    G_INSTALL -->|"pipx / pip / git"| UE_RUN

    CMD_STARTUP --> SG1
    CMD_STARTUP --> SG2
    CMD_STARTUP --> SG3
    SG1 --> T_SILENT
    SG2 --> T_SILENT
    SG3 --> T_SILENT

    CMD_STARTUP --> SIG_BIN
    CMD_STARTUP --> SIG_HOOK
    CMD_STARTUP --> SIG_DRIFT

    SIG_BIN --> FetchChain
    FC_CACHE -->|"hit"| FC_PARSE
    FC_CACHE -->|"miss"| FC_NET
    FC_NET -->|"success"| FC_PARSE
    FC_NET -->|"error/non-200"| FC_NONE
    FC_PARSE -->|"parsed"| SIG_ZERO
    FC_PARSE -->|"error/missing"| FC_NONE
    FC_NONE --> SIG_ZERO

    SIG_DRIFT --> SHAResolution
    SHA_SKIP -->|"None"| SHA_NONE
    SHA_SKIP -->|"has revision"| SHA_GIT
    SHA_GIT -->|"found"| SIG_ZERO
    SHA_GIT -->|"not found"| SHA_API
    SHA_API -->|"found"| SIG_ZERO
    SHA_API -->|"not found"| SHA_NONE
    SHA_NONE --> SIG_ZERO

    SIG_HOOK --> SIG_ZERO
    SIG_ZERO -->|"all None"| T_SILENT
    SIG_ZERO -->|"≥1 signal"| UE_RUN

    UE_RUN -->|"returncode = 0"| UE_FETCH
    UE_RUN -->|"returncode ≠ 0"| UE_FETCH
    UE_FETCH --> UE_VERIFY
    UE_VERIFY -->|"version advanced"| UE_DISMISS
    UE_VERIFY -->|"version unchanged"| T_UPDATE_FAIL
    UE_DISMISS --> T_UPDATE_OK

    CMD_DOCTOR --> DR_CLAUDE
    DR_CLAUDE --> DR_NAMED
    DR_CLAUDE --> DR_BROAD
    DR_NAMED --> DR_RESULT
    DR_BROAD --> DR_RESULT

    CMD_KITCHEN --> KG_ORCH
    KG_ORCH -->|"headless caller"| KG_ENVELOPE
    KG_ORCH -->|"orchestrator"| KG_STAGES
    KG_STAGES --> KG_FATAL
    KG_FATAL -->|"yes"| KG_DISABLE
    KG_DISABLE --> KG_ENVELOPE
    KG_ENVELOPE --> T_KITCHEN_FAIL
    KG_FATAL -->|"no"| KG_NONFATAL
    KG_NONFATAL --> KG_OUTERMOST
    KG_OUTERMOST -->|"escape"| KG_ENVELOPE
    KG_OUTERMOST -->|"normal"| T_KITCHEN_OK

    CMD_KITCHEN -.->|"uses"| IP_READ
    IP_READ --> IP_REMOVE

    %% CLASS ASSIGNMENTS %%
    class CMD_UPDATE,CMD_STARTUP,CMD_DOCTOR,CMD_KITCHEN cli;
    class G_KITCHEN,G_INSTALL,SIG_ZERO,KG_FATAL,SHA_SKIP detector;
    class SG1,SG2,SG3 detector;
    class SYSEXIT1,SYSEXIT2 gap;
    class SIG_BIN,SIG_HOOK,SIG_DRIFT handler;
    class FC_CACHE,FC_NET,FC_PARSE stateNode;
    class FC_NONE gap;
    class SHA_GIT,SHA_API stateNode;
    class SHA_NONE gap;
    class UE_RUN,UE_FETCH,UE_VERIFY,UE_DISMISS handler;
    class DR_CLAUDE,DR_NAMED,DR_BROAD phase;
    class IP_READ,IP_REMOVE stateNode;
    class KG_ORCH,KG_STAGES detector;
    class KG_DISABLE,KG_NONFATAL,KG_OUTERMOST handler;
    class KG_ENVELOPE output;
    class DR_RESULT,T_SILENT,T_UPDATE_OK,T_UPDATE_FAIL,T_KITCHEN_OK,T_KITCHEN_FAIL terminal;
```

### Operational Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 65, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph CLICommands ["CLI ENTRY POINTS"]
        direction TB
        UPDATE["● autoskillit update<br/>━━━━━━━━━━<br/>Self-upgrade to latest release<br/>Blocks if kitchen is open"]
        DOCTOR["● autoskillit doctor<br/>━━━━━━━━━━<br/>28 diagnostic checks<br/>--output-json flag; read-only"]
        STARTUP_CHECK["● run_update_checks()<br/>━━━━━━━━━━<br/>Auto-runs on interactive start<br/>Timed 30s [Y/n] prompt<br/>4 signal kinds: binary/hooks/<br/>source_drift/dual_mcp"]
    end

    subgraph InstallPolicy ["● INSTALL POLICY (_install_info.py)"]
        direction TB
        DETECT["● detect_install()<br/>━━━━━━━━━━<br/>Reads direct_url.json<br/>InstallType: GIT_VCS | LOCAL_EDITABLE<br/>LOCAL_PATH | UNKNOWN"]
        UPGRADE_CMD["● upgrade_command()<br/>━━━━━━━━━━<br/>GIT_VCS → uv tool upgrade<br/>integration → uv tool install --force<br/>editable → uv pip install -e<br/>UNKNOWN → None"]
        COMPARE_BRANCH["● comparison_branch()<br/>━━━━━━━━━━<br/>stable/tag → releases/latest<br/>integration/editable → integration"]
        DISMISS_WINDOW["● dismissal_window()<br/>━━━━━━━━━━<br/>stable/main → 7 days<br/>integration/editable → 12 hours"]
    end

    subgraph PluginState ["● PLUGIN STATE (_installed_plugins.py)"]
        direction TB
        PLUGINS_FILE["● InstalledPluginsFile<br/>━━━━━━━━━━<br/>R/W: ~/.claude/plugins/installed_plugins.json<br/>Schema version: 2<br/>ops: get_plugins / contains / remove"]
    end

    subgraph EnvConfig ["ENVIRONMENT GUARDS"]
        direction TB
        ENV_SKIP["Env: AUTOSKILLIT_SKIP_*<br/>━━━━━━━━━━<br/>SKIP_STALE_CHECK<br/>SKIP_UPDATE_CHECK<br/>CLAUDECODE=1 / CI=1"]
        ENV_FORCE["Env: AUTOSKILLIT_FORCE_UPDATE_CHECK<br/>━━━━━━━━━━<br/>Override TTY/CI silence"]
        ENV_GITHUB["Env: GITHUB_TOKEN<br/>━━━━━━━━━━<br/>Authenticated GitHub API<br/>Used by startup checks"]
    end

    subgraph StateFiles ["STATE FILES (read/write)"]
        direction TB
        UPDATE_JSON["~/.autoskillit/update_check.json<br/>━━━━━━━━━━<br/>Dismissal records<br/>update_prompt / binary_snoozed<br/>Cleared on successful update"]
        GH_CACHE["~/.autoskillit/github_fetch_cache.json<br/>━━━━━━━━━━<br/>GitHub version fetch cache<br/>TTL: 1800s (AUTOSKILLIT_FETCH_CACHE_TTL_SECONDS)<br/>Written by startup checks"]
        HOOK_CONFIG[".autoskillit/temp/.hook_config.json<br/>━━━━━━━━━━<br/>Quota guard config + session state<br/>Written: open_kitchen<br/>Deleted: close_kitchen<br/>Mutated: disable_quota_guard"]
    end

    subgraph MCP_Tools ["● MCP TOOLS (tools_kitchen.py)"]
        direction TB
        OPEN_K["● open_kitchen(name?, overrides?)<br/>━━━━━━━━━━<br/>Enables kitchen gate<br/>Writes .hook_config.json<br/>Primes quota cache<br/>Starts background refresh loop"]
        CLOSE_K["● close_kitchen()<br/>━━━━━━━━━━<br/>Disables gate<br/>Cancels quota refresh task<br/>Deletes .hook_config.json"]
        DISABLE_QG["● disable_quota_guard()<br/>━━━━━━━━━━<br/>Sets quota_guard.disabled=true<br/>Session-scoped; non-persistent"]
    end

    subgraph DoctorChecks ["● DOCTOR CHECK GROUPS (_doctor.py)"]
        direction TB
        CHK_INSTALL["● Install & Registration<br/>━━━━━━━━━━<br/>install_classification<br/>stale_mcp_servers<br/>dual_mcp_registration<br/>installed_plugins_entry<br/>plugin_cache_exists"]
        CHK_HOOKS["● Hook Health<br/>━━━━━━━━━━<br/>hook_health (all scopes)<br/>hook_registration<br/>hook_registry_drift<br/>script_version_health"]
        CHK_DRIFT["● Version & Drift<br/>━━━━━━━━━━<br/>version_consistency<br/>source_version_drift (network+cache)<br/>update_dismissal_state<br/>editable_install_source_exists"]
    end

    %% FLOWS: update command %%
    UPDATE --> DETECT
    DETECT --> UPGRADE_CMD
    DETECT --> COMPARE_BRANCH
    UPDATE --> UPDATE_JSON
    UPGRADE_CMD -.->|"set on entry"| ENV_SKIP

    %% FLOWS: startup checks %%
    STARTUP_CHECK --> ENV_SKIP
    STARTUP_CHECK --> ENV_FORCE
    STARTUP_CHECK --> ENV_GITHUB
    STARTUP_CHECK --> GH_CACHE
    STARTUP_CHECK --> UPDATE_JSON
    STARTUP_CHECK --> DISMISS_WINDOW
    STARTUP_CHECK --> PLUGINS_FILE

    %% FLOWS: doctor %%
    DOCTOR --> CHK_INSTALL
    DOCTOR --> CHK_HOOKS
    DOCTOR --> CHK_DRIFT
    CHK_INSTALL --> PLUGINS_FILE
    CHK_DRIFT --> GH_CACHE
    CHK_DRIFT --> COMPARE_BRANCH

    %% FLOWS: kitchen tools %%
    OPEN_K --> HOOK_CONFIG
    CLOSE_K --> HOOK_CONFIG
    DISABLE_QG --> HOOK_CONFIG

    %% CLASS ASSIGNMENTS %%
    class UPDATE,DOCTOR,STARTUP_CHECK cli;
    class DETECT,UPGRADE_CMD,COMPARE_BRANCH,DISMISS_WINDOW handler;
    class PLUGINS_FILE stateNode;
    class ENV_SKIP,ENV_FORCE,ENV_GITHUB phase;
    class UPDATE_JSON,GH_CACHE,HOOK_CONFIG stateNode;
    class OPEN_K,CLOSE_K,DISABLE_QG integration;
    class CHK_INSTALL,CHK_HOOKS,CHK_DRIFT detector;
```

Closes #150

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260424-200346-050735/.autoskillit/temp/make-plan/update_install_flow_plan_2026-04-24_200000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 251 | 23.1k | 1.4M | 65.5k | 1 | 8m 56s |
| verify | 212 | 19.1k | 1.4M | 59.0k | 1 | 6m 40s |
| implement | 924 | 58.0k | 10.3M | 138.2k | 1 | 18m 8s |
| fix | 358 | 31.7k | 3.0M | 88.9k | 1 | 18m 27s |
| prepare_pr | 52 | 4.1k | 175.8k | 30.1k | 1 | 1m 31s |
| run_arch_lenses | 122 | 15.4k | 373.4k | 57.1k | 2 | 5m 56s |
| compose_pr | 59 | 8.2k | 206.2k | 31.8k | 1 | 2m 24s |
| **Total** | 2.0k | 159.6k | 16.8M | 470.6k | | 1h 2m |