### PR TITLE
planner — Finalize Callables (validate_plan, compile_plan)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,8 +184,10 @@ generic_automation_mcp/
 │   └── worktree.py
 │
 ├── planner/                 # L1
-│   ├── __init__.py          #   Progressive resolution planner — re-exports check_remaining, build_assignment_manifest, build_wp_manifest
-│   └── manifests.py         #   check_remaining, build_assignment_manifest, build_wp_manifest — manifest state machine callables
+│   ├── __init__.py          #   Progressive resolution planner — re-exports check_remaining, build_assignment_manifest, build_wp_manifest, validate_plan, compile_plan
+│   ├── manifests.py         #   check_remaining, build_assignment_manifest, build_wp_manifest — manifest state machine callables
+│   ├── validation.py        #   validate_plan — DAG cycle check, structural completeness, sizing bounds, duplicate-deliverable detection
+│   └── compiler.py          #   compile_plan — topological sort, issue body generation, milestone definitions, plan artifacts
 │
 ├── recipe/                  # L2
 │   ├── __init__.py

--- a/src/autoskillit/planner/__init__.py
+++ b/src/autoskillit/planner/__init__.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
+from autoskillit.planner.compiler import compile_plan
 from autoskillit.planner.manifests import (
     build_assignment_manifest,
     build_wp_manifest,
     check_remaining,
 )
+from autoskillit.planner.validation import validate_plan
 
-__all__ = ["check_remaining", "build_assignment_manifest", "build_wp_manifest"]
+__all__ = [
+    "check_remaining",
+    "build_assignment_manifest",
+    "build_wp_manifest",
+    "validate_plan",
+    "compile_plan",
+]

--- a/src/autoskillit/planner/compiler.py
+++ b/src/autoskillit/planner/compiler.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import json
+from collections import deque
+from pathlib import Path
+
+from autoskillit.core import atomic_write, get_logger, write_versioned_json
+from autoskillit.planner.validation import (
+    _load_assignment_results,
+    _load_phase_results,
+    _load_wp_results,
+)
+
+_logger = get_logger(__name__)
+
+
+def _topological_sort(wp_results: dict[str, dict]) -> list[str]:
+    in_degree: dict[str, int] = {wp_id: 0 for wp_id in wp_results}
+    adjacency: dict[str, list[str]] = {wp_id: [] for wp_id in wp_results}
+    for wp_id, wp in wp_results.items():
+        for dep in wp.get("depends_on", []):
+            if dep in wp_results:
+                adjacency[dep].append(wp_id)
+                in_degree[wp_id] += 1
+
+    queue: deque[str] = deque(sorted(k for k, v in in_degree.items() if v == 0))
+    order: list[str] = []
+    while queue:
+        node = queue.popleft()
+        order.append(node)
+        for neighbor in sorted(adjacency[node]):
+            in_degree[neighbor] -= 1
+            if in_degree[neighbor] == 0:
+                queue.append(neighbor)
+
+    if len(order) < len(wp_results):
+        cycle_nodes = [n for n in wp_results if n not in set(order)]
+        raise RuntimeError(f"Cycle detected among WPs: {', '.join(sorted(cycle_nodes))}")
+    return order
+
+
+def _inject_forward_deps(wp_results: dict[str, dict], dep_graph: dict) -> None:
+    for wp_id, dependents in dep_graph.get("forward_deps", {}).items():
+        if wp_id in wp_results:
+            wp_results[wp_id]["depended_on_by"] = list(dependents)
+
+
+def _build_phase_lookup(phase_results: dict[str, dict]) -> dict[int, dict]:
+    return {v["phase_number"]: v for v in phase_results.values()}
+
+
+def _build_assignment_lookup(
+    assignment_results: dict[str, dict],
+) -> dict[tuple[int, int], dict]:
+    return {(v["phase_number"], v["assignment_number"]): v for v in assignment_results.values()}
+
+
+def _parse_wp_id(wp_id: str) -> tuple[int, int, int]:
+    parts = wp_id.split("-")
+    return int(parts[0][1:]), int(parts[1][1:]), int(parts[2][2:])
+
+
+def _render_issue_body(wp: dict, phase: dict, assignment: dict) -> str:
+    phase_num = phase["phase_number"]
+    phase_name = phase["name"]
+    phase_slug = phase["name_slug"]
+    milestone = f"{phase_num}-{phase_slug}"
+    assign_id = f"P{phase['phase_number']}-A{assignment['assignment_number']}"
+    assign_name = assignment.get("name", "")
+
+    depends_on = wp.get("depends_on", [])
+    depended_on_by = wp.get("depended_on_by", [])
+
+    depends_str = ", ".join(depends_on) if depends_on else "None"
+    depended_str = ", ".join(depended_on_by) if depended_on_by else "None"
+
+    deliverables_md = "\n".join(f"- `{d}`" for d in wp.get("deliverables", []))
+    steps_md = "\n".join(f"{i + 1}. {s}" for i, s in enumerate(wp.get("technical_steps", [])))
+    criteria_md = "\n".join(f"- {c}" for c in wp.get("acceptance_criteria", []))
+
+    return f"""## Goal
+
+{wp.get("goal", wp.get("summary", ""))}
+
+## Context
+
+- Phase: {phase_name} (Milestone: {milestone})
+- Assignment: {assign_id} ({assign_name})
+- Depends on: {depends_str}
+- Depended on by: {depended_str}
+
+## Deliverables
+
+{deliverables_md}
+
+## Technical Steps
+
+{steps_md}
+
+## Acceptance Criteria
+
+{criteria_md}
+"""
+
+
+def compile_plan(output_dir: str, task: str, source_dir: str) -> dict[str, str]:
+    root = Path(output_dir)
+
+    phase_results = _load_phase_results(root)
+    assignment_results = _load_assignment_results(root)
+    wp_results = _load_wp_results(root)
+
+    validation_path = root / "validation.json"
+    if validation_path.exists():
+        validation = json.loads(validation_path.read_text())
+        if validation.get("verdict") != "pass":
+            _logger.warning(
+                "compile_plan called with non-passing validation",
+                verdict=validation.get("verdict"),
+            )
+
+    dep_graph: dict = {}
+    dep_graph_path = root / "dep_graph.json"
+    if dep_graph_path.exists():
+        dep_graph = json.loads(dep_graph_path.read_text())
+
+    _inject_forward_deps(wp_results, dep_graph)
+
+    execution_order = _topological_sort(wp_results)
+    phase_lookup = _build_phase_lookup(phase_results)
+    assign_lookup = _build_assignment_lookup(assignment_results)
+
+    issues_dir = root / "issues"
+    issues_dir.mkdir(exist_ok=True)
+
+    issue_paths: dict[str, str] = {}
+    for wp_id in execution_order:
+        wp = wp_results[wp_id]
+        phase_num, assign_num, _ = _parse_wp_id(wp_id)
+        phase = phase_lookup[phase_num]
+        assignment = assign_lookup[(phase_num, assign_num)]
+        body = _render_issue_body(wp, phase, assignment)
+        issue_path = issues_dir / f"{wp_id}_issue.md"
+        atomic_write(issue_path, body)
+        issue_paths[wp_id] = str(issue_path)
+
+    milestones = [
+        {
+            "phase_number": phase["phase_number"],
+            "name": phase["name"],
+            "name_slug": phase["name_slug"],
+        }
+        for phase in sorted(phase_results.values(), key=lambda p: p["phase_number"])
+    ]
+    milestones_path = root / "milestones.json"
+    write_versioned_json(milestones_path, {"milestones": milestones}, schema_version=1)
+
+    phases_nested = []
+    for phase_id in sorted(phase_results, key=lambda k: phase_results[k]["phase_number"]):
+        phase = phase_results[phase_id]
+        phase_num = phase["phase_number"]
+        assignments_nested = []
+        for (pn, an), assign in sorted(assign_lookup.items()):
+            if pn != phase_num:
+                continue
+            wps_in_assign = [
+                wp_results[wid]
+                for wid in execution_order
+                if wp_results[wid].get("id", wid).startswith(f"P{pn}-A{an}-")
+            ]
+            assignments_nested.append({**assign, "work_packages": wps_in_assign})
+        phases_nested.append({**phase, "assignments": assignments_nested})
+
+    plan_json_path = root / "plan.json"
+    write_versioned_json(
+        plan_json_path,
+        {
+            "task": task,
+            "source_dir": source_dir,
+            "phases": phases_nested,
+            "execution_order": execution_order,
+        },
+        schema_version=1,
+    )
+
+    md_lines = [f"# Plan: {task}", ""]
+    for phase in sorted(phase_results.values(), key=lambda p: p["phase_number"]):
+        phase_num = phase["phase_number"]
+        md_lines.append(f"## Phase {phase_num}: {phase['name']}")
+        md_lines.append("")
+        for wp_id in execution_order:
+            pn, an, _ = _parse_wp_id(wp_id)
+            if pn != phase_num:
+                continue
+            wp = wp_results[wp_id]
+            md_lines.append(f"### {wp_id}: {wp.get('name', '')}")
+            md_lines.append("")
+            md_lines.append(wp.get("summary", wp.get("goal", "")))
+            md_lines.append("")
+
+    plan_md_path = root / "plan.md"
+    atomic_write(plan_md_path, "\n".join(md_lines))
+
+    manifest_path = root / "manifest.json"
+    write_versioned_json(
+        manifest_path,
+        {
+            "task": task,
+            "source_dir": source_dir,
+            "execution_order": execution_order,
+            "issues": issue_paths,
+        },
+        schema_version=1,
+    )
+
+    plan_parts = "\n".join(issue_paths[wp_id] for wp_id in execution_order)
+
+    _logger.info("compile_plan", wp_count=len(execution_order))
+    return {
+        "plan_path": str(plan_md_path),
+        "plan_json_path": str(plan_json_path),
+        "plan_parts": plan_parts,
+    }

--- a/src/autoskillit/planner/compiler.py
+++ b/src/autoskillit/planner/compiler.py
@@ -117,7 +117,10 @@ def compile_plan(output_dir: str, task: str, source_dir: str) -> dict[str, str]:
 
     validation_path = root / "validation.json"
     if validation_path.exists():
-        validation = json.loads(validation_path.read_text())
+        try:
+            validation = json.loads(validation_path.read_text())
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"Malformed validation file {validation_path}: {exc}") from exc
         if validation.get("verdict") != "pass":
             _logger.warning(
                 "compile_plan called with non-passing validation",
@@ -127,7 +130,10 @@ def compile_plan(output_dir: str, task: str, source_dir: str) -> dict[str, str]:
     dep_graph: dict = {}
     dep_graph_path = root / "dep_graph.json"
     if dep_graph_path.exists():
-        dep_graph = json.loads(dep_graph_path.read_text())
+        try:
+            dep_graph = json.loads(dep_graph_path.read_text())
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"Malformed dep graph file {dep_graph_path}: {exc}") from exc
 
     _inject_forward_deps(wp_results, dep_graph)
 

--- a/src/autoskillit/planner/compiler.py
+++ b/src/autoskillit/planner/compiler.py
@@ -57,7 +57,12 @@ def _build_assignment_lookup(
 
 def _parse_wp_id(wp_id: str) -> tuple[int, int, int]:
     parts = wp_id.split("-")
-    return int(parts[0][1:]), int(parts[1][1:]), int(parts[2][2:])
+    if len(parts) != 3:
+        raise ValueError(f"Invalid WP id format (expected PX-AY-WPZ): {wp_id!r}")
+    try:
+        return int(parts[0][1:]), int(parts[1][1:]), int(parts[2][2:])
+    except (IndexError, ValueError) as exc:
+        raise ValueError(f"Invalid WP id format (expected PX-AY-WPZ): {wp_id!r}") from exc
 
 
 def _render_issue_body(wp: dict, phase: dict, assignment: dict) -> str:
@@ -137,7 +142,16 @@ def compile_plan(output_dir: str, task: str, source_dir: str) -> dict[str, str]:
     for wp_id in execution_order:
         wp = wp_results[wp_id]
         phase_num, assign_num, _ = _parse_wp_id(wp_id)
+        if phase_num not in phase_lookup:
+            raise RuntimeError(
+                f"WP {wp_id!r} references phase {phase_num} not in loaded phase results"
+            )
         phase = phase_lookup[phase_num]
+        if (phase_num, assign_num) not in assign_lookup:
+            raise RuntimeError(
+                f"WP {wp_id!r} references assignment P{phase_num}-A{assign_num}"
+                " not in loaded assignment results"
+            )
         assignment = assign_lookup[(phase_num, assign_num)]
         body = _render_issue_body(wp, phase, assignment)
         issue_path = issues_dir / f"{wp_id}_issue.md"
@@ -164,9 +178,7 @@ def compile_plan(output_dir: str, task: str, source_dir: str) -> dict[str, str]:
             if pn != phase_num:
                 continue
             wps_in_assign = [
-                wp_results[wid]
-                for wid in execution_order
-                if wp_results[wid].get("id", wid).startswith(f"P{pn}-A{an}-")
+                wp_results[wid] for wid in execution_order if wid.startswith(f"P{pn}-A{an}-")
             ]
             assignments_nested.append({**assign, "work_packages": wps_in_assign})
         phases_nested.append({**phase, "assignments": assignments_nested})

--- a/src/autoskillit/planner/validation.py
+++ b/src/autoskillit/planner/validation.py
@@ -27,8 +27,11 @@ def _load_assignment_results(root: Path) -> dict[str, dict]:
     if not assign_dir.exists():
         return results
     for f in sorted(assign_dir.glob("*_result.json")):
-        data = json.loads(f.read_text())
-        assign_id = f"P{data['phase_number']}-A{data['assignment_number']}"
+        try:
+            data = json.loads(f.read_text())
+            assign_id = f"P{data['phase_number']}-A{data['assignment_number']}"
+        except (json.JSONDecodeError, KeyError) as exc:
+            raise RuntimeError(f"Malformed assignment result file {f}: {exc}") from exc
         results[assign_id] = data
     return results
 
@@ -53,7 +56,10 @@ def _load_wp_manifest(root: Path) -> dict | None:
     manifest_path = root / "work_packages" / "wp_manifest.json"
     if not manifest_path.exists():
         return None
-    return json.loads(manifest_path.read_text())
+    try:
+        return json.loads(manifest_path.read_text())
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Malformed WP manifest file {manifest_path}: {exc}") from exc
 
 
 def _inject_backward_deps(wp_results: dict[str, dict], dep_graph: dict) -> None:
@@ -86,6 +92,9 @@ def _check_assignment_completeness(
     wp_pairs: set[tuple[int, int]] = set()
     for wp_id in wp_results:
         parts = wp_id.split("-")
+        if len(parts) < 2:
+            findings.append(f"WP {wp_id!r} has malformed id (expected PX-AY-WPZ)")
+            continue
         phase_num = int(parts[0][1:])
         assign_num = int(parts[1][1:])
         wp_pairs.add((phase_num, assign_num))
@@ -172,7 +181,10 @@ def validate_plan(output_dir: str) -> dict[str, str]:
 
     dep_graph_path = root / "dep_graph.json"
     if dep_graph_path.exists():
-        dep_graph = json.loads(dep_graph_path.read_text())
+        try:
+            dep_graph = json.loads(dep_graph_path.read_text())
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"Malformed dep graph file {dep_graph_path}: {exc}") from exc
         _inject_backward_deps(wp_results, dep_graph)
 
     findings: list[str] = []

--- a/src/autoskillit/planner/validation.py
+++ b/src/autoskillit/planner/validation.py
@@ -12,8 +12,11 @@ _logger = get_logger(__name__)
 def _load_phase_results(root: Path) -> dict[str, dict]:
     results: dict[str, dict] = {}
     for f in sorted((root / "phases").glob("*_result.json")):
-        data = json.loads(f.read_text())
-        phase_id = f"P{data['phase_number']}"
+        try:
+            data = json.loads(f.read_text())
+            phase_id = f"P{data['phase_number']}"
+        except (json.JSONDecodeError, KeyError) as exc:
+            raise RuntimeError(f"Malformed phase result file {f}: {exc}") from exc
         results[phase_id] = data
     return results
 
@@ -38,8 +41,11 @@ def _load_wp_results(root: Path) -> dict[str, dict]:
     for f in sorted(wp_dir.glob("*_result.json")):
         if f.name in ("wp_manifest.json", "wp_index.json"):
             continue
-        data = json.loads(f.read_text())
-        results[data["id"]] = data
+        try:
+            data = json.loads(f.read_text())
+            results[data["id"]] = data
+        except (json.JSONDecodeError, KeyError) as exc:
+            raise RuntimeError(f"Malformed WP result file {f}: {exc}") from exc
     return results
 
 
@@ -153,7 +159,7 @@ def _check_failed_wps(wp_manifest: dict | None) -> list[str]:
     findings: list[str] = []
     for item in wp_manifest.get("items", []):
         if item.get("status") == "failed":
-            findings.append(f"WP {item['id']} has status 'failed'")
+            findings.append(f"WP {item.get('id', '<unknown>')} has status 'failed'")
     return findings
 
 

--- a/src/autoskillit/planner/validation.py
+++ b/src/autoskillit/planner/validation.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import json
+from collections import deque
+from pathlib import Path
+
+from autoskillit.core import get_logger, write_versioned_json
+
+_logger = get_logger(__name__)
+
+
+def _load_phase_results(root: Path) -> dict[str, dict]:
+    results: dict[str, dict] = {}
+    for f in sorted((root / "phases").glob("*_result.json")):
+        data = json.loads(f.read_text())
+        phase_id = f"P{data['phase_number']}"
+        results[phase_id] = data
+    return results
+
+
+def _load_assignment_results(root: Path) -> dict[str, dict]:
+    results: dict[str, dict] = {}
+    assign_dir = root / "assignments"
+    if not assign_dir.exists():
+        return results
+    for f in sorted(assign_dir.glob("*_result.json")):
+        data = json.loads(f.read_text())
+        assign_id = f"P{data['phase_number']}-A{data['assignment_number']}"
+        results[assign_id] = data
+    return results
+
+
+def _load_wp_results(root: Path) -> dict[str, dict]:
+    results: dict[str, dict] = {}
+    wp_dir = root / "work_packages"
+    if not wp_dir.exists():
+        return results
+    for f in sorted(wp_dir.glob("*_result.json")):
+        if f.name in ("wp_manifest.json", "wp_index.json"):
+            continue
+        data = json.loads(f.read_text())
+        results[data["id"]] = data
+    return results
+
+
+def _load_wp_manifest(root: Path) -> dict | None:
+    manifest_path = root / "work_packages" / "wp_manifest.json"
+    if not manifest_path.exists():
+        return None
+    return json.loads(manifest_path.read_text())
+
+
+def _inject_backward_deps(wp_results: dict[str, dict], dep_graph: dict) -> None:
+    for wp_id, extra_deps in dep_graph.get("added_backward_deps", {}).items():
+        if wp_id not in wp_results:
+            continue
+        existing = wp_results[wp_id].setdefault("depends_on", [])
+        for dep in extra_deps:
+            if dep not in existing:
+                existing.append(dep)
+
+
+def _check_phase_completeness(
+    phase_results: dict[str, dict],
+    assignment_results: dict[str, dict],
+) -> list[str]:
+    findings: list[str] = []
+    assigned_phase_nums = {v["phase_number"] for v in assignment_results.values()}
+    for phase_id, phase in phase_results.items():
+        if phase["phase_number"] not in assigned_phase_nums:
+            findings.append(f"Phase {phase_id} has no assignments")
+    return findings
+
+
+def _check_assignment_completeness(
+    assignment_results: dict[str, dict],
+    wp_results: dict[str, dict],
+) -> list[str]:
+    findings: list[str] = []
+    wp_pairs: set[tuple[int, int]] = set()
+    for wp_id in wp_results:
+        parts = wp_id.split("-")
+        phase_num = int(parts[0][1:])
+        assign_num = int(parts[1][1:])
+        wp_pairs.add((phase_num, assign_num))
+    for assign_id, assign in assignment_results.items():
+        pair = (assign["phase_number"], assign["assignment_number"])
+        if pair not in wp_pairs:
+            findings.append(f"Assignment {assign_id} has no work packages")
+    return findings
+
+
+def _check_dep_references(wp_results: dict[str, dict]) -> list[str]:
+    findings: list[str] = []
+    for wp_id, wp in wp_results.items():
+        for dep in wp.get("depends_on", []):
+            if dep not in wp_results:
+                findings.append(f"WP {wp_id} depends on unknown WP {dep}")
+    return findings
+
+
+def _check_dag_acyclic(wp_results: dict[str, dict]) -> list[str]:
+    in_degree: dict[str, int] = {wp_id: 0 for wp_id in wp_results}
+    adjacency: dict[str, list[str]] = {wp_id: [] for wp_id in wp_results}
+    for wp_id, wp in wp_results.items():
+        for dep in wp.get("depends_on", []):
+            if dep in wp_results:
+                adjacency[dep].append(wp_id)
+                in_degree[wp_id] += 1
+
+    queue: deque[str] = deque(k for k, v in in_degree.items() if v == 0)
+    sorted_nodes: list[str] = []
+    while queue:
+        node = queue.popleft()
+        sorted_nodes.append(node)
+        for neighbor in adjacency[node]:
+            in_degree[neighbor] -= 1
+            if in_degree[neighbor] == 0:
+                queue.append(neighbor)
+
+    if len(sorted_nodes) < len(wp_results):
+        cycle_nodes = [n for n in wp_results if n not in set(sorted_nodes)]
+        return [f"Cycle detected among WPs: {', '.join(sorted(cycle_nodes))}"]
+    return []
+
+
+def _check_sizing_bounds(wp_results: dict[str, dict]) -> list[str]:
+    findings: list[str] = []
+    for wp_id, wp in wp_results.items():
+        count = len(wp.get("deliverables", []))
+        if not (1 <= count <= 5):
+            findings.append(f"WP {wp_id} has {count} deliverables (must be 1–5)")
+    return findings
+
+
+def _check_duplicate_deliverables(wp_results: dict[str, dict]) -> list[str]:
+    deliverable_map: dict[str, list[str]] = {}
+    for wp_id, wp in wp_results.items():
+        for d in wp.get("deliverables", []):
+            deliverable_map.setdefault(d, []).append(wp_id)
+    findings: list[str] = []
+    for path, owners in deliverable_map.items():
+        if len(owners) > 1:
+            findings.append(
+                f"Deliverable '{path}' claimed by multiple WPs: {', '.join(sorted(owners))}"
+            )
+    return findings
+
+
+def _check_failed_wps(wp_manifest: dict | None) -> list[str]:
+    if wp_manifest is None:
+        return []
+    findings: list[str] = []
+    for item in wp_manifest.get("items", []):
+        if item.get("status") == "failed":
+            findings.append(f"WP {item['id']} has status 'failed'")
+    return findings
+
+
+def validate_plan(output_dir: str) -> dict[str, str]:
+    root = Path(output_dir)
+    phase_results = _load_phase_results(root)
+    assignment_results = _load_assignment_results(root)
+    wp_results = _load_wp_results(root)
+    wp_manifest = _load_wp_manifest(root)
+
+    dep_graph_path = root / "dep_graph.json"
+    if dep_graph_path.exists():
+        dep_graph = json.loads(dep_graph_path.read_text())
+        _inject_backward_deps(wp_results, dep_graph)
+
+    findings: list[str] = []
+    findings.extend(_check_phase_completeness(phase_results, assignment_results))
+    findings.extend(_check_assignment_completeness(assignment_results, wp_results))
+    findings.extend(_check_dep_references(wp_results))
+    findings.extend(_check_dag_acyclic(wp_results))
+    findings.extend(_check_sizing_bounds(wp_results))
+    findings.extend(_check_duplicate_deliverables(wp_results))
+    findings.extend(_check_failed_wps(wp_manifest))
+
+    verdict = "pass" if not findings else "fail"
+    validation_path = root / "validation.json"
+    write_versioned_json(
+        validation_path,
+        {"verdict": verdict, "findings": findings},
+        schema_version=1,
+    )
+    _logger.info("validate_plan", verdict=verdict, issue_count=len(findings))
+    return {
+        "verdict": verdict,
+        "validation_path": str(validation_path),
+        "issue_count": str(len(findings)),
+    }

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -1803,3 +1803,19 @@ callable_contracts:
       type: file_path
     - name: total_count
       type: str
+  autoskillit.planner.validate_plan:
+    outputs:
+    - name: verdict
+      type: str
+    - name: validation_path
+      type: file_path
+    - name: issue_count
+      type: str
+  autoskillit.planner.compile_plan:
+    outputs:
+    - name: plan_path
+      type: file_path
+    - name: plan_json_path
+      type: file_path
+    - name: plan_parts
+      type: str

--- a/tests/planner/test_compiler.py
+++ b/tests/planner/test_compiler.py
@@ -1,0 +1,246 @@
+"""Tests for compile_plan callable."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from autoskillit.planner.compiler import compile_plan
+
+pytestmark = [pytest.mark.layer("planner"), pytest.mark.small]
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_json(path: Path, data: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data))
+
+
+def _make_valid_output_dir(
+    tmp_path: Path,
+    *,
+    num_phases: int = 1,
+    with_dep_graph: bool = False,
+    dependency_chain: bool = False,
+) -> Path:
+    """Build a valid output_dir with validation.json verdict=pass."""
+    phases_dir = tmp_path / "phases"
+    assigns_dir = tmp_path / "assignments"
+    wps_dir = tmp_path / "work_packages"
+
+    for p in range(1, num_phases + 1):
+        _write_json(
+            phases_dir / f"P{p}_result.json",
+            {
+                "phase_number": p,
+                "name": f"Phase {p}",
+                "name_slug": f"phase-{p}",
+                "assignments": [f"P{p}-A1"],
+            },
+        )
+        _write_json(
+            assigns_dir / f"P{p}-A1_result.json",
+            {
+                "phase_number": p,
+                "assignment_number": 1,
+                "name": f"Test Assignment P{p}",
+                "proposed_work_packages": [f"P{p}-A1-WP1"],
+            },
+        )
+        deps: list[str] = []
+        if dependency_chain and p > 1:
+            deps = [f"P{p - 1}-A1-WP1"]
+        _write_json(
+            wps_dir / f"P{p}-A1-WP1_result.json",
+            {
+                "id": f"P{p}-A1-WP1",
+                "name": f"WP P{p}-A1-WP1",
+                "summary": f"Summary P{p}",
+                "goal": f"Goal P{p}",
+                "deliverables": [f"src/mod_p{p}.py"],
+                "technical_steps": [f"step for p{p}"],
+                "acceptance_criteria": [f"criterion for p{p}"],
+                "depends_on": deps,
+            },
+        )
+
+    manifest_items = [{"id": f"P{p}-A1-WP1", "status": "done"} for p in range(1, num_phases + 1)]
+    _write_json(
+        wps_dir / "wp_manifest.json", {"pass_name": "work_packages", "items": manifest_items}
+    )
+
+    _write_json(
+        tmp_path / "validation.json", {"verdict": "pass", "findings": [], "schema_version": 1}
+    )
+
+    if with_dep_graph:
+        _write_json(
+            tmp_path / "dep_graph.json",
+            {
+                "added_backward_deps": {},
+                "forward_deps": {"P1-A1-WP1": ["P1-A1-WP2"]},
+            },
+        )
+
+    return tmp_path
+
+
+def _make_chain_3_wps(tmp_path: Path) -> Path:
+    """3 WPs: WP1 → WP2 → WP3."""
+    phases_dir = tmp_path / "phases"
+    assigns_dir = tmp_path / "assignments"
+    wps_dir = tmp_path / "work_packages"
+
+    _write_json(
+        phases_dir / "P1_result.json",
+        {
+            "phase_number": 1,
+            "name": "Foundation",
+            "name_slug": "foundation",
+            "assignments": ["P1-A1"],
+        },
+    )
+    _write_json(
+        assigns_dir / "P1-A1_result.json",
+        {
+            "phase_number": 1,
+            "assignment_number": 1,
+            "name": "Test Assignment",
+            "proposed_work_packages": ["P1-A1-WP1", "P1-A1-WP2", "P1-A1-WP3"],
+        },
+    )
+    for i, deps in [(1, []), (2, ["P1-A1-WP1"]), (3, ["P1-A1-WP2"])]:
+        _write_json(
+            wps_dir / f"P1-A1-WP{i}_result.json",
+            {
+                "id": f"P1-A1-WP{i}",
+                "name": f"WP {i}",
+                "summary": f"Summary {i}",
+                "goal": f"Goal {i}",
+                "deliverables": [f"src/mod{i}.py"],
+                "technical_steps": [f"step {i}"],
+                "acceptance_criteria": [f"criterion {i}"],
+                "depends_on": deps,
+            },
+        )
+    manifest_items = [{"id": f"P1-A1-WP{i}", "status": "done"} for i in range(1, 4)]
+    _write_json(
+        wps_dir / "wp_manifest.json", {"pass_name": "work_packages", "items": manifest_items}
+    )
+    _write_json(
+        tmp_path / "validation.json", {"verdict": "pass", "findings": [], "schema_version": 1}
+    )
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_compile_plan_topological_sort_order(tmp_path: Path) -> None:
+    _make_chain_3_wps(tmp_path)
+    compile_plan(str(tmp_path), "test task", "/src")
+    manifest = json.loads((tmp_path / "manifest.json").read_text())
+    assert manifest["execution_order"] == ["P1-A1-WP1", "P1-A1-WP2", "P1-A1-WP3"]
+
+
+def test_compile_plan_issue_body_sections(tmp_path: Path) -> None:
+    _make_valid_output_dir(tmp_path)
+    compile_plan(str(tmp_path), "test task", "/src")
+    issue = (tmp_path / "issues" / "P1-A1-WP1_issue.md").read_text()
+    for section in [
+        "## Goal",
+        "## Context",
+        "## Deliverables",
+        "## Technical Steps",
+        "## Acceptance Criteria",
+    ]:
+        assert section in issue
+
+
+def test_compile_plan_issue_body_context_fields(tmp_path: Path) -> None:
+    _make_valid_output_dir(tmp_path)
+    compile_plan(str(tmp_path), "test task", "/src")
+    issue = (tmp_path / "issues" / "P1-A1-WP1_issue.md").read_text()
+    assert "Phase 1 (Milestone: 1-phase-1)" in issue
+    assert "P1-A1 (Test Assignment P1)" in issue
+
+
+def test_compile_plan_depends_on_cross_ref(tmp_path: Path) -> None:
+    _make_chain_3_wps(tmp_path)
+    compile_plan(str(tmp_path), "test task", "/src")
+    issue_wp2 = (tmp_path / "issues" / "P1-A1-WP2_issue.md").read_text()
+    assert "P1-A1-WP1" in issue_wp2
+
+
+def test_compile_plan_depended_on_by_cross_ref(tmp_path: Path) -> None:
+    _make_chain_3_wps(tmp_path)
+    _write_json(
+        tmp_path / "dep_graph.json",
+        {
+            "added_backward_deps": {},
+            "forward_deps": {"P1-A1-WP1": ["P1-A1-WP2"]},
+        },
+    )
+    compile_plan(str(tmp_path), "test task", "/src")
+    issue_wp1 = (tmp_path / "issues" / "P1-A1-WP1_issue.md").read_text()
+    assert "P1-A1-WP2" in issue_wp1
+
+
+def test_compile_plan_milestones_one_per_phase(tmp_path: Path) -> None:
+    _make_valid_output_dir(tmp_path, num_phases=2, dependency_chain=True)
+    compile_plan(str(tmp_path), "test task", "/src")
+    milestones_data = json.loads((tmp_path / "milestones.json").read_text())
+    assert len(milestones_data["milestones"]) == 2
+    for entry in milestones_data["milestones"]:
+        assert "phase_number" in entry
+        assert "name" in entry
+        assert "name_slug" in entry
+
+
+def test_compile_plan_plan_md_is_valid_markdown(tmp_path: Path) -> None:
+    _make_valid_output_dir(tmp_path)
+    result = compile_plan(str(tmp_path), "my task", "/src")
+    plan_md = Path(result["plan_path"]).read_text()
+    assert plan_md.startswith("#")
+    assert "my task" in plan_md
+
+
+def test_compile_plan_manifest_json_schema(tmp_path: Path) -> None:
+    _make_valid_output_dir(tmp_path)
+    compile_plan(str(tmp_path), "test task", "/src")
+    manifest = json.loads((tmp_path / "manifest.json").read_text())
+    assert "task" in manifest
+    assert "source_dir" in manifest
+    assert "execution_order" in manifest
+    assert "issues" in manifest
+    assert isinstance(manifest["execution_order"], list)
+    assert isinstance(manifest["issues"], dict)
+
+
+def test_compile_plan_plan_parts_matches_issue_file_count(tmp_path: Path) -> None:
+    _make_chain_3_wps(tmp_path)
+    result = compile_plan(str(tmp_path), "test task", "/src")
+    parts = [p for p in result["plan_parts"].split("\n") if p]
+    assert len(parts) == 3
+    for part_path in parts:
+        assert Path(part_path).exists()
+
+
+def test_compile_plan_return_values_are_strings(tmp_path: Path) -> None:
+    _make_valid_output_dir(tmp_path)
+    result = compile_plan(str(tmp_path), "test task", "/src")
+    assert all(isinstance(v, str) for v in result.values())
+
+
+def test_compile_plan_creates_issues_directory(tmp_path: Path) -> None:
+    _make_valid_output_dir(tmp_path)
+    compile_plan(str(tmp_path), "task", "/src")
+    assert (tmp_path / "issues").is_dir()

--- a/tests/planner/test_planner.py
+++ b/tests/planner/test_planner.py
@@ -14,7 +14,13 @@ def test_planner_package_importable() -> None:
 def test_planner_all_exports_callables() -> None:
     from autoskillit.planner import __all__
 
-    assert set(__all__) == {"check_remaining", "build_assignment_manifest", "build_wp_manifest"}
+    assert set(__all__) == {
+        "check_remaining",
+        "build_assignment_manifest",
+        "build_wp_manifest",
+        "validate_plan",
+        "compile_plan",
+    }
 
 
 def test_planner_feature_skill_categories() -> None:

--- a/tests/planner/test_validation.py
+++ b/tests/planner/test_validation.py
@@ -1,0 +1,240 @@
+"""Tests for validate_plan callable."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from autoskillit.planner.validation import validate_plan
+
+pytestmark = [pytest.mark.layer("planner"), pytest.mark.small]
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_json(path: Path, data: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data))
+
+
+def _make_minimal_output_dir(
+    tmp_path: Path,
+    *,
+    num_phases: int = 1,
+    wps_per_assignment: int = 1,
+    deliverables_override: list[str] | None = None,
+    depends_on_override: dict[str, list[str]] | None = None,
+    extra_phases: list[int] | None = None,
+    extra_assignments: list[tuple[int, int]] | None = None,
+) -> Path:
+    """Build a minimal valid output_dir structure."""
+    phases_dir = tmp_path / "phases"
+    assigns_dir = tmp_path / "assignments"
+    wps_dir = tmp_path / "work_packages"
+
+    for p in range(1, num_phases + 1):
+        _write_json(
+            phases_dir / f"P{p}_result.json",
+            {
+                "phase_number": p,
+                "name": f"Phase {p}",
+                "name_slug": f"phase-{p}",
+                "assignments": [f"P{p}-A1"],
+            },
+        )
+
+    for p in range(1, num_phases + 1):
+        for a in range(1, 2):
+            _write_json(
+                assigns_dir / f"P{p}-A{a}_result.json",
+                {
+                    "phase_number": p,
+                    "assignment_number": a,
+                    "name": f"Assignment P{p}-A{a}",
+                    "proposed_work_packages": [
+                        f"P{p}-A{a}-WP{w}" for w in range(1, wps_per_assignment + 1)
+                    ],
+                },
+            )
+
+    for p in range(1, num_phases + 1):
+        for a in range(1, 2):
+            for w in range(1, wps_per_assignment + 1):
+                wp_id = f"P{p}-A{a}-WP{w}"
+                deliverables = (
+                    deliverables_override
+                    if deliverables_override is not None
+                    else [f"src/mod_{wp_id}.py"]
+                )
+                deps = (depends_on_override or {}).get(wp_id, [])
+                _write_json(
+                    wps_dir / f"{wp_id}_result.json",
+                    {
+                        "id": wp_id,
+                        "name": f"WP {wp_id}",
+                        "summary": "summary",
+                        "goal": "goal",
+                        "deliverables": deliverables,
+                        "technical_steps": ["step 1"],
+                        "acceptance_criteria": ["criterion 1"],
+                        "depends_on": deps,
+                    },
+                )
+
+    manifest_items = []
+    for p in range(1, num_phases + 1):
+        for a in range(1, 2):
+            for w in range(1, wps_per_assignment + 1):
+                manifest_items.append({"id": f"P{p}-A{a}-WP{w}", "status": "done"})
+    _write_json(
+        wps_dir / "wp_manifest.json",
+        {"pass_name": "work_packages", "items": manifest_items},
+    )
+
+    if extra_phases:
+        for p in extra_phases:
+            _write_json(
+                phases_dir / f"P{p}_result.json",
+                {
+                    "phase_number": p,
+                    "name": f"Phase {p}",
+                    "name_slug": f"phase-{p}",
+                    "assignments": [],
+                },
+            )
+
+    if extra_assignments:
+        for p, a in extra_assignments:
+            _write_json(
+                assigns_dir / f"P{p}-A{a}_result.json",
+                {
+                    "phase_number": p,
+                    "assignment_number": a,
+                    "name": f"Orphan assignment P{p}-A{a}",
+                    "proposed_work_packages": [],
+                },
+            )
+
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_validate_plan_valid_returns_pass(tmp_path: Path) -> None:
+    _make_minimal_output_dir(tmp_path)
+    result = validate_plan(str(tmp_path))
+    assert result["verdict"] == "pass"
+    assert result["issue_count"] == "0"
+
+
+def test_validate_plan_cyclic_dep_fails(tmp_path: Path) -> None:
+    _make_minimal_output_dir(tmp_path, wps_per_assignment=2)
+    wp1 = "P1-A1-WP1"
+    wp2 = "P1-A1-WP2"
+    wp_dir = tmp_path / "work_packages"
+    data1 = json.loads((wp_dir / f"{wp1}_result.json").read_text())
+    data1["depends_on"] = [wp2]
+    (wp_dir / f"{wp1}_result.json").write_text(json.dumps(data1))
+    data2 = json.loads((wp_dir / f"{wp2}_result.json").read_text())
+    data2["depends_on"] = [wp1]
+    (wp_dir / f"{wp2}_result.json").write_text(json.dumps(data2))
+
+    result = validate_plan(str(tmp_path))
+    assert result["verdict"] == "fail"
+    validation = json.loads((tmp_path / "validation.json").read_text())
+    assert any(wp1 in f and wp2 in f for f in validation["findings"])
+
+
+def test_validate_plan_missing_dep_ref_fails(tmp_path: Path) -> None:
+    _make_minimal_output_dir(tmp_path, depends_on_override={"P1-A1-WP1": ["P1-A1-WP99"]})
+    result = validate_plan(str(tmp_path))
+    assert result["verdict"] == "fail"
+
+
+def test_validate_plan_phase_no_assignments_fails(tmp_path: Path) -> None:
+    _make_minimal_output_dir(tmp_path, extra_phases=[2])
+    result = validate_plan(str(tmp_path))
+    assert result["verdict"] == "fail"
+
+
+def test_validate_plan_assignment_no_wps_fails(tmp_path: Path) -> None:
+    _make_minimal_output_dir(tmp_path, extra_assignments=[(1, 2)])
+    result = validate_plan(str(tmp_path))
+    assert result["verdict"] == "fail"
+
+
+def test_validate_plan_wp_zero_deliverables_fails(tmp_path: Path) -> None:
+    _make_minimal_output_dir(tmp_path, deliverables_override=[])
+    result = validate_plan(str(tmp_path))
+    assert result["verdict"] == "fail"
+
+
+def test_validate_plan_wp_too_many_deliverables_fails(tmp_path: Path) -> None:
+    _make_minimal_output_dir(tmp_path, deliverables_override=["a", "b", "c", "d", "e", "f"])
+    result = validate_plan(str(tmp_path))
+    assert result["verdict"] == "fail"
+
+
+def test_validate_plan_duplicate_deliverables_fails(tmp_path: Path) -> None:
+    _make_minimal_output_dir(tmp_path, wps_per_assignment=2, deliverables_override=["src/foo.py"])
+    result = validate_plan(str(tmp_path))
+    assert result["verdict"] == "fail"
+
+
+def test_validate_plan_failed_wp_flagged_but_not_sole_fail_cause(tmp_path: Path) -> None:
+    _make_minimal_output_dir(tmp_path)
+    manifest_path = tmp_path / "work_packages" / "wp_manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["items"][0]["status"] = "failed"
+    manifest_path.write_text(json.dumps(manifest))
+
+    result = validate_plan(str(tmp_path))
+    assert result["verdict"] == "fail"
+    validation = json.loads((tmp_path / "validation.json").read_text())
+    assert any("P1-A1-WP1" in f for f in validation["findings"])
+
+
+def test_validate_plan_dep_graph_backward_dep_injection(tmp_path: Path) -> None:
+    _make_minimal_output_dir(tmp_path, wps_per_assignment=2)
+    _write_json(
+        tmp_path / "dep_graph.json",
+        {"added_backward_deps": {"P1-A1-WP2": ["P1-A1-WP1"]}, "forward_deps": {}},
+    )
+    result = validate_plan(str(tmp_path))
+    assert result["verdict"] == "pass"
+
+
+def test_validate_plan_dep_graph_creates_cycle_fails(tmp_path: Path) -> None:
+    _make_minimal_output_dir(
+        tmp_path, wps_per_assignment=2, depends_on_override={"P1-A1-WP1": ["P1-A1-WP2"]}
+    )
+    _write_json(
+        tmp_path / "dep_graph.json",
+        {"added_backward_deps": {"P1-A1-WP2": ["P1-A1-WP1"]}, "forward_deps": {}},
+    )
+    result = validate_plan(str(tmp_path))
+    assert result["verdict"] == "fail"
+
+
+def test_validate_plan_writes_validation_json(tmp_path: Path) -> None:
+    _make_minimal_output_dir(tmp_path)
+    result = validate_plan(str(tmp_path))
+    validation_path = tmp_path / "validation.json"
+    assert validation_path.exists()
+    data = json.loads(validation_path.read_text())
+    assert "verdict" in data
+    assert result["validation_path"] == str(validation_path)
+
+
+def test_validate_plan_return_values_are_strings(tmp_path: Path) -> None:
+    _make_minimal_output_dir(tmp_path)
+    result = validate_plan(str(tmp_path))
+    assert all(isinstance(v, str) for v in result.values())


### PR DESCRIPTION
## Summary

Implement two finalization callables for the progressive resolution planner:

- `validate_plan` (`src/autoskillit/planner/validation.py`) — pure-Python DAG cycle check, structural completeness, sizing bounds, and duplicate-deliverable detection across all pass outputs. Writes `validation.json` and returns verdict + finding count.
- `compile_plan` (`src/autoskillit/planner/compiler.py`) — topological sort of the WP DAG, GitHub issue body generation from a Markdown template, milestone definitions, full plan artifacts (`plan.json`, `plan.md`, `manifest.json`). Returns paths to the generated files.

Both callables are registered in `skill_contracts.yaml` and exported from `planner/__init__.py`.

## Architecture Impact

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph TestLayer ["TESTS — tests/planner/"]
        direction LR
        TC["★ test_compiler.py<br/>━━━━━━━━━━<br/>compile_plan E2E<br/>topo-sort, issue gen"]
        TV["★ test_validation.py<br/>━━━━━━━━━━<br/>validate_plan scenarios<br/>DAG cycles, bounds"]
        TP["● test_planner.py<br/>━━━━━━━━━━<br/>__all__ surface check<br/>FEATURE_REGISTRY assert"]
    end

    subgraph PlannerLayer ["PLANNER — src/autoskillit/planner/ (L1)"]
        direction TB
        INIT["● planner/__init__.py<br/>━━━━━━━━━━<br/>Public surface: compile_plan<br/>validate_plan, check_remaining<br/>build_assignment_manifest<br/>build_wp_manifest"]
        COMP["★ planner/compiler.py<br/>━━━━━━━━━━<br/>compile_plan<br/>topological sort<br/>issue body gen, plan.md<br/>milestones.json, manifest.json"]
        VAL["★ planner/validation.py<br/>━━━━━━━━━━<br/>validate_plan<br/>DAG cycle check, sizing bounds<br/>duplicate-deliverable detection<br/>_load_*_results (private loaders)"]
        MAN["planner/manifests.py<br/>━━━━━━━━━━<br/>check_remaining<br/>build_assignment_manifest<br/>build_wp_manifest"]
    end

    subgraph CoreLayer ["CORE — src/autoskillit/core/ (L0)"]
        direction LR
        IO["core/io.py<br/>━━━━━━━━━━<br/>atomic_write<br/>write_versioned_json"]
        LOG["core/logging.py<br/>━━━━━━━━━━<br/>get_logger"]
    end

    %% TEST → PLANNER IMPORTS %%
    TC -->|"imports compile_plan"| COMP
    TV -->|"imports validate_plan"| VAL
    TP -->|"imports __all__"| INIT

    %% __init__ RE-EXPORTS %%
    INIT -->|"re-exports"| COMP
    INIT -->|"re-exports"| VAL
    INIT -->|"re-exports"| MAN

    %% INTRA-PLANNER COUPLING %%
    COMP -->|"imports _load_assignment_results<br/>_load_phase_results, _load_wp_results"| VAL

    %% PLANNER → CORE %%
    COMP -->|"atomic_write<br/>write_versioned_json"| IO
    COMP -->|"get_logger"| LOG
    VAL -->|"write_versioned_json"| IO
    VAL -->|"get_logger"| LOG
    MAN -->|"atomic_write<br/>write_versioned_json"| IO
    MAN -->|"get_logger"| LOG

    %% CLASS ASSIGNMENTS %%
    class TC,TV newComponent;
    class TP phase;
    class INIT phase;
    class COMP,VAL newComponent;
    class MAN handler;
    class IO,LOG stateNode;
```

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START<br/>━━━━━━━━━━<br/>output_dir provided])
    COMPLETE([COMPLETE<br/>━━━━━━━━━━<br/>plan.json + manifest.json])
    ERROR([ERROR<br/>━━━━━━━━━━<br/>cycle / missing file])

    subgraph PhasePass ["Phase Analysis Pass (external)"]
        direction TB
        PhaseAI["Phase AI Analysis<br/>━━━━━━━━━━<br/>LLM generates phase results"]
        PhaseJSON["phases/*_result.json<br/>━━━━━━━━━━<br/>phase_number, name, assignments[]"]
    end

    subgraph AssignManifest ["● build_assignment_manifest<br/>manifests.py"]
        direction TB
        ReadPhases["Read phases/*_result.json<br/>━━━━━━━━━━<br/>sorted by phase_number"]
        BuildItems["Build items list<br/>━━━━━━━━━━<br/>P{n}-A{seq} for each assignment"]
        WriteAssignManifest["Write assignment_manifest.json<br/>━━━━━━━━━━<br/>status: pending for all items"]
    end

    subgraph AssignLoop ["● check_remaining — assignments loop<br/>manifests.py"]
        direction TB
        CheckAssign{"has_remaining?<br/>━━━━━━━━━━<br/>pending items exist"}
        MarkProcessing["Mark item processing<br/>━━━━━━━━━━<br/>write context_{id}.json"]
        AssignAI["Assignment AI Analysis<br/>━━━━━━━━━━<br/>LLM writes {id}_result.json"]
        CheckResultA{"result file exists?<br/>━━━━━━━━━━<br/>status → done or failed"}
    end

    subgraph WPManifest ["● build_wp_manifest<br/>manifests.py"]
        direction TB
        ReadAssigns["Read assignments/*_result.json<br/>━━━━━━━━━━<br/>sorted by phase+assignment_number"]
        BuildWPItems["Build WP items list<br/>━━━━━━━━━━<br/>P{n}-A{m}-WP{seq} for each WP"]
        WriteWPManifest["Write wp_manifest.json + wp_index.json<br/>━━━━━━━━━━<br/>status: pending for all WPs"]
    end

    subgraph WPLoop ["● check_remaining — WPs loop<br/>manifests.py"]
        direction TB
        CheckWP{"has_remaining?<br/>━━━━━━━━━━<br/>pending WP items exist"}
        MarkWPProcessing["Mark WP processing<br/>━━━━━━━━━━<br/>write context_{id}.json"]
        WPAI["WP AI Analysis<br/>━━━━━━━━━━<br/>LLM writes {id}_result.json"]
        CheckResultWP{"result file exists?<br/>━━━━━━━━━━<br/>status → done; backstop wp_index"}
    end

    subgraph ValidationPass ["★ validate_plan — Validation Pass<br/>validation.py (NEW)"]
        direction TB
        LoadData["Load phase + assign + WP results<br/>━━━━━━━━━━<br/>_load_phase/assignment/wp_results()"]
        LoadManifest["Load wp_manifest.json<br/>━━━━━━━━━━<br/>_load_wp_manifest()"]
        CheckDepGraph{"dep_graph.json exists?<br/>━━━━━━━━━━<br/>inject backward deps"}
        InjectBackDeps["_inject_backward_deps()<br/>━━━━━━━━━━<br/>augment depends_on lists"]
        RunChecks["Run 7 validation checks<br/>━━━━━━━━━━<br/>phase completeness<br/>assign completeness<br/>dep references<br/>DAG acyclic (Kahn BFS)<br/>sizing bounds (1–5 deliverables)<br/>duplicate deliverables<br/>failed WPs in manifest"]
        VerdictGate{"findings empty?<br/>━━━━━━━━━━<br/>pass or fail"}
        WriteValidation["Write validation.json<br/>━━━━━━━━━━<br/>verdict + findings list"]
    end

    subgraph CompilePass ["★ compile_plan — Compilation Pass<br/>compiler.py (NEW)"]
        direction TB
        LoadCompileData["Load phase + assign + WP results<br/>━━━━━━━━━━<br/>(re-load for compilation)"]
        CheckValidation{"validation.json verdict?<br/>━━━━━━━━━━<br/>warn if non-passing"}
        LoadDepGraph["Load dep_graph.json<br/>━━━━━━━━━━<br/>_inject_forward_deps()"]
        TopoSort["★ _topological_sort()<br/>━━━━━━━━━━<br/>Kahn BFS over depends_on<br/>raises RuntimeError on cycle"]
        BuildLookups["Build phase + assignment lookups<br/>━━━━━━━━━━<br/>dict[phase_num] / dict[phase,assign]"]
        IssueLoop["For each WP in execution_order<br/>━━━━━━━━━━<br/>_render_issue_body()<br/>atomic_write issues/{id}_issue.md"]
        WriteArtifacts["Write plan artifacts<br/>━━━━━━━━━━<br/>milestones.json<br/>plan.json<br/>plan.md<br/>manifest.json"]
    end

    %% FLOW %%
    START --> PhaseAI
    PhaseAI -->|"writes"| PhaseJSON
    PhaseJSON --> ReadPhases
    ReadPhases --> BuildItems --> WriteAssignManifest
    WriteAssignManifest --> CheckAssign
    CheckAssign -->|"yes — next pending"| MarkProcessing
    MarkProcessing --> AssignAI
    AssignAI -->|"writes result"| CheckResultA
    CheckResultA -->|"done"| CheckAssign
    CheckResultA -->|"missing — failed"| CheckAssign
    CheckAssign -->|"no remaining"| ReadAssigns
    ReadAssigns --> BuildWPItems --> WriteWPManifest
    WriteWPManifest --> CheckWP
    CheckWP -->|"yes — next pending"| MarkWPProcessing
    MarkWPProcessing --> WPAI
    WPAI -->|"writes result"| CheckResultWP
    CheckResultWP -->|"done + backstop index"| CheckWP
    CheckWP -->|"no remaining"| LoadData
    LoadData --> LoadManifest --> CheckDepGraph
    CheckDepGraph -->|"yes"| InjectBackDeps --> RunChecks
    CheckDepGraph -->|"no"| RunChecks
    RunChecks --> VerdictGate
    VerdictGate -->|"pass"| WriteValidation
    VerdictGate -->|"fail"| WriteValidation
    WriteValidation --> LoadCompileData
    LoadCompileData --> CheckValidation
    CheckValidation -->|"non-pass → warn"| LoadDepGraph
    CheckValidation -->|"pass"| LoadDepGraph
    LoadDepGraph --> TopoSort
    TopoSort -->|"cycle"| ERROR
    TopoSort -->|"sorted order"| BuildLookups
    BuildLookups --> IssueLoop
    IssueLoop --> WriteArtifacts
    WriteArtifacts --> COMPLETE

    %% CLASS ASSIGNMENTS %%
    class START,COMPLETE,ERROR terminal;
    class PhaseAI,AssignAI,WPAI handler;
    class PhaseJSON,WriteAssignManifest,WriteWPManifest,WriteValidation,WriteArtifacts,IssueLoop output;
    class ReadPhases,BuildItems,ReadAssigns,BuildWPItems,LoadData,LoadManifest,LoadCompileData,LoadDepGraph phase;
    class CheckDepGraph,CheckAssign,CheckResultA,CheckWP,CheckResultWP,VerdictGate,CheckValidation stateNode;
    class InjectBackDeps,MarkProcessing,MarkWPProcessing,RunChecks,BuildLookups detector;
    class TopoSort,BuildWPItems newComponent;
```

### Data Lineage Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph Inputs ["Data Origins (output_dir/)"]
        direction TB
        PHR["phases/*_result.json<br/>━━━━━━━━━━<br/>phase_number<br/>name, assignments[]"]
        ASR["assignments/*_result.json<br/>━━━━━━━━━━<br/>phase_number<br/>assignment_number<br/>proposed_work_packages[]"]
        WPR["work_packages/*_result.json<br/>━━━━━━━━━━<br/>id, goal, depends_on<br/>deliverables, steps<br/>acceptance_criteria"]
        DEP["dep_graph.json<br/>━━━━━━━━━━<br/>added_backward_deps<br/>forward_deps<br/>(optional)"]
        PARAMS["● API Params<br/>━━━━━━━━━━<br/>output_dir: str<br/>task: str<br/>source_dir: str"]
    end

    subgraph Loaders ["★ Shared Loaders<br/>(validation.py)"]
        direction TB
        LP["_load_phase_results()<br/>━━━━━━━━━━<br/>→ dict[str, dict]<br/>key: 'P{n}'"]
        LA["_load_assignment_results()<br/>━━━━━━━━━━<br/>→ dict[str, dict]<br/>key: 'P{n}-A{m}'"]
        LW["_load_wp_results()<br/>━━━━━━━━━━<br/>→ dict[str, dict]<br/>key: wp id"]
    end

    subgraph Validation ["★ validate_plan()<br/>(validation.py)"]
        direction TB
        VCHECK["7 Structural Checks<br/>━━━━━━━━━━<br/>phase completeness<br/>assignment completeness<br/>dep reference validity<br/>DAG acyclicity<br/>deliverable count 1–5<br/>duplicate deliverables<br/>failed WPs in manifest"]
        VOUT[("validation.json<br/>━━━━━━━━━━<br/>verdict: pass|fail<br/>findings: list[str]")]
    end

    subgraph Compilation ["★ compile_plan()<br/>(compiler.py)"]
        direction TB
        TOPO["_topological_sort()<br/>━━━━━━━━━━<br/>Kahn's algorithm<br/>on depends_on edges<br/>→ ordered list[str]"]
        RENDER["_render_issue_body()<br/>━━━━━━━━━━<br/>goal, depends_on<br/>depended_on_by<br/>deliverables<br/>technical_steps<br/>acceptance_criteria<br/>phase/assignment ctx"]
    end

    subgraph Artifacts ["Write-Only Artifacts"]
        direction TB
        ISS["★ issues/{wp_id}_issue.md<br/>━━━━━━━━━━<br/>Markdown issue body<br/>per WP in topo order"]
        MILES["★ milestones.json<br/>━━━━━━━━━━<br/>schema_version=1<br/>phase_number, name<br/>name_slug"]
        PLAN_JSON["★ plan.json<br/>━━━━━━━━━━<br/>schema_version=1<br/>task, source_dir<br/>phases hierarchy<br/>execution_order"]
        PLAN_MD["★ plan.md<br/>━━━━━━━━━━<br/>Markdown summary<br/>grouped by phase"]
        MANIF["★ manifest.json<br/>━━━━━━━━━━<br/>schema_version=1<br/>execution_order<br/>issues: {wp_id: path}"]
    end

    subgraph PublicAPI ["● planner/__init__.py<br/>(public re-exports)"]
        INIT["validate_plan<br/>compile_plan<br/>check_remaining<br/>build_assignment_manifest<br/>build_wp_manifest"]
    end

    %% LOADER READS %%
    PHR -->|"glob phases/"| LP
    ASR -->|"glob assignments/"| LA
    WPR -->|"glob work_packages/"| LW

    %% VALIDATION FLOW %%
    LP -->|"phase dicts"| VCHECK
    LA -->|"assignment dicts"| VCHECK
    LW -->|"wp dicts"| VCHECK
    DEP -->|"backward_deps injected"| VCHECK
    VCHECK -->|"atomic_write"| VOUT

    %% COMPILATION FLOW %%
    VOUT -->|"reads verdict<br/>(warns if fail)"| TOPO
    LP -->|"phase dicts"| TOPO
    LA -->|"assignment dicts"| TOPO
    LW -->|"wp dicts"| TOPO
    DEP -->|"forward_deps injected"| TOPO
    PARAMS -->|"task + source_dir"| RENDER
    TOPO -->|"ordered WP list"| RENDER

    %% ARTIFACT WRITES %%
    RENDER -.->|"atomic_write (one per WP)"| ISS
    RENDER -.->|"atomic_write"| MILES
    RENDER -.->|"atomic_write"| PLAN_JSON
    RENDER -.->|"atomic_write"| PLAN_MD
    RENDER -.->|"atomic_write"| MANIF

    %% PUBLIC API %%
    INIT -->|"re-exports"| VCHECK
    INIT -->|"re-exports"| RENDER

    %% CLASS ASSIGNMENTS %%
    class PHR,ASR,WPR,DEP cli;
    class PARAMS integration;
    class LP,LA,LW newComponent;
    class VCHECK detector;
    class VOUT stateNode;
    class TOPO,RENDER newComponent;
    class ISS,MILES,PLAN_JSON,PLAN_MD,MANIF output;
    class INIT phase;
```

Closes #1126

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260424-214117-410369/.autoskillit/temp/make-plan/planner_finalize_callables_plan_2026-04-24_000000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 97 | 16.0k | 383.4k | 45.7k | 1 | 8m 34s |
| verify | 116 | 6.4k | 551.4k | 40.4k | 1 | 2m 29s |
| implement | 1.6k | 17.7k | 1.5M | 58.8k | 1 | 11m 0s |
| prepare_pr | 52 | 4.7k | 172.9k | 30.1k | 1 | 1m 32s |
| run_arch_lenses | 187 | 17.1k | 515.0k | 139.9k | 3 | 6m 53s |
| compose_pr | 59 | 8.6k | 208.9k | 32.4k | 1 | 2m 21s |
| **Total** | 2.1k | 70.5k | 3.3M | 347.3k | | 32m 51s |