### PR TITLE
Implementation Plan: Module-level Cascade Map for core/ Submodules

### DIFF
--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -71,6 +71,53 @@ ALWAYS_RUN_AGGRESSIVE: frozenset[str] = frozenset(
 _LARGE_CHANGESET_THRESHOLD: int = 30
 
 # ---------------------------------------------------------------------------
+# core/ module-level cascade classification
+# ---------------------------------------------------------------------------
+
+_CORE_UNIVERSAL_MODULES: frozenset[str] = frozenset(
+    {
+        "io",
+        "logging",
+        "types",
+        "_type_constants",
+        "_type_protocols",
+        "_type_enums",
+        "_type_subprocess",
+        "_type_results",
+        "_type_resume",
+        "_type_helpers",
+    }
+)
+
+MODULE_CASCADE_CORE: dict[str, frozenset[str]] = {
+    "readiness": frozenset({"core", "server"}),
+    "feature_flags": frozenset({"core", "cli", "config", "server", "workspace"}),
+    "kitchen_state": frozenset({"core", "cli"}),
+    "branch_guard": frozenset({"core", "pipeline", "server", "workspace"}),
+    "_plugin_ids": frozenset({"core", "cli", "server"}),
+    "_terminal_table": frozenset({"core", "cli", "pipeline", "recipe"}),
+    "_linux_proc": frozenset({"core", "cli", "execution", "franchise"}),
+    "_plugin_cache": frozenset({"core", "cli", "server"}),
+    "github_url": frozenset({"core", "cli", "execution", "server"}),
+    "paths": frozenset(
+        {
+            "core",
+            "cli",
+            "config",
+            "execution",
+            "franchise",
+            "migration",
+            "recipe",
+            "server",
+            "workspace",
+        }
+    ),
+    "_claude_env": frozenset({"core", "execution"}),
+    "_version_snapshot": frozenset({"core", "execution"}),
+    "claude_conventions": frozenset({"core", "server", "workspace"}),
+}
+
+# ---------------------------------------------------------------------------
 # Layer cascade maps
 # ---------------------------------------------------------------------------
 
@@ -690,7 +737,15 @@ def build_test_scope(
             direct_test_files.add(f)
         elif f.startswith("src/") and f.endswith(".py"):
             pkg = _file_to_package(f)
-            if pkg and pkg in cascade_map:
+            if pkg == "core" and mode == FilterMode.CONSERVATIVE:
+                stem = Path(f).stem
+                if stem in _CORE_UNIVERSAL_MODULES or stem == "__init__":
+                    test_dirs.update(cascade_map["core"])
+                elif stem in MODULE_CASCADE_CORE:
+                    test_dirs.update(MODULE_CASCADE_CORE[stem])
+                else:
+                    test_dirs.update(cascade_map["core"])  # fail-open: unknown stem
+            elif pkg and pkg in cascade_map:
                 test_dirs.update(cascade_map[pkg])
             else:
                 return None
@@ -711,7 +766,15 @@ def build_test_scope(
             for f in expanded - changed_src_py:
                 if f.startswith("src/") and f.endswith(".py"):
                     pkg = _file_to_package(f)
-                    if pkg and pkg in cascade_map:
+                    if pkg == "core" and mode == FilterMode.CONSERVATIVE:
+                        stem = Path(f).stem
+                        if stem in _CORE_UNIVERSAL_MODULES or stem == "__init__":
+                            test_dirs.update(cascade_map["core"])
+                        elif stem in MODULE_CASCADE_CORE:
+                            test_dirs.update(MODULE_CASCADE_CORE[stem])
+                        else:
+                            test_dirs.update(cascade_map["core"])
+                    elif pkg and pkg in cascade_map:
                         test_dirs.update(cascade_map[pkg])
         except Exception:
             logging.getLogger(__name__).debug(  # noqa: TID251

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -773,7 +773,7 @@ def build_test_scope(
                         elif stem in MODULE_CASCADE_CORE:
                             test_dirs.update(MODULE_CASCADE_CORE[stem])
                         else:
-                            test_dirs.update(cascade_map["core"])
+                            test_dirs.update(cascade_map["core"])  # fail-open: unknown stem
                     elif pkg and pkg in cascade_map:
                         test_dirs.update(cascade_map[pkg])
         except Exception:

--- a/tests/test_test_filter_core_cascade.py
+++ b/tests/test_test_filter_core_cascade.py
@@ -1,0 +1,220 @@
+"""REQ-CORE-001..004: module-level cascade map for core/ submodules."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests._test_filter import (
+    MODULE_CASCADE_CORE,
+    FilterMode,
+    _CORE_UNIVERSAL_MODULES,
+    build_test_scope,
+)
+
+
+class TestCoreUniversalModules:
+    """REQ-CORE-001: _CORE_UNIVERSAL_MODULES must exist and contain the right stems."""
+
+    def test_is_frozenset(self) -> None:
+        assert isinstance(_CORE_UNIVERSAL_MODULES, frozenset)
+
+    def test_required_stems_present(self) -> None:
+        required = {
+            "io",
+            "logging",
+            "types",
+            "_type_constants",
+            "_type_protocols",
+            "_type_enums",
+            "_type_subprocess",
+            "_type_results",
+            "_type_resume",
+            "_type_helpers",
+        }
+        assert required <= _CORE_UNIVERSAL_MODULES
+
+    def test_paths_and_init_not_in_universal(self) -> None:
+        # __init__ handled separately by stem == "__init__" check, not via this frozenset
+        assert "__init__" not in _CORE_UNIVERSAL_MODULES
+
+
+class TestModuleCascadeCore:
+    """REQ-CORE-002: MODULE_CASCADE_CORE must exist with validated consumer sets."""
+
+    def test_is_dict(self) -> None:
+        assert isinstance(MODULE_CASCADE_CORE, dict)
+
+    def test_all_values_are_frozensets(self) -> None:
+        for stem, consumers in MODULE_CASCADE_CORE.items():
+            assert isinstance(consumers, frozenset), f"{stem} value must be frozenset"
+
+    def test_all_consumers_include_core(self) -> None:
+        # Every narrow module's cascade must include 'core' (its own tests)
+        for stem, consumers in MODULE_CASCADE_CORE.items():
+            assert "core" in consumers, f"{stem} cascade missing 'core'"
+
+    def test_kitchen_state_cascade(self) -> None:
+        assert MODULE_CASCADE_CORE["kitchen_state"] == frozenset({"core", "cli"})
+
+    def test_readiness_cascade(self) -> None:
+        assert MODULE_CASCADE_CORE["readiness"] == frozenset({"core", "server"})
+
+    def test_feature_flags_cascade(self) -> None:
+        assert MODULE_CASCADE_CORE["feature_flags"] == frozenset(
+            {"core", "cli", "config", "server", "workspace"}
+        )
+
+    def test_branch_guard_cascade(self) -> None:
+        assert MODULE_CASCADE_CORE["branch_guard"] == frozenset(
+            {"core", "pipeline", "server", "workspace"}
+        )
+
+    def test_no_universal_stem_in_map(self) -> None:
+        # Universal modules must not appear in MODULE_CASCADE_CORE
+        overlap = _CORE_UNIVERSAL_MODULES & set(MODULE_CASCADE_CORE.keys())
+        assert not overlap, f"Universal modules in MODULE_CASCADE_CORE: {overlap}"
+
+    def test_all_13_entries_present(self) -> None:
+        expected_stems = {
+            "readiness",
+            "feature_flags",
+            "kitchen_state",
+            "branch_guard",
+            "_plugin_ids",
+            "_terminal_table",
+            "_linux_proc",
+            "_plugin_cache",
+            "github_url",
+            "paths",
+            "_claude_env",
+            "_version_snapshot",
+            "claude_conventions",
+        }
+        assert set(MODULE_CASCADE_CORE.keys()) == expected_stems
+
+
+class TestBuildTestScopeCoreCascade:
+    """REQ-CORE-003/004: build_test_scope routes core modules correctly."""
+
+    def _make_tests_root(self, tmp_path: Path, dirs: list[str]) -> Path:
+        tests_root = tmp_path / "tests"
+        for d in dirs:
+            (tests_root / d).mkdir(parents=True, exist_ok=True)
+        return tests_root
+
+    ALL_DIRS = [
+        "core", "config", "execution", "pipeline", "workspace",
+        "recipe", "migration", "franchise", "server", "cli",
+        "hooks", "skills", "arch", "contracts", "infra", "docs",
+    ]
+
+    def test_universal_module_triggers_full_cascade(self, tmp_path: Path) -> None:
+        """io.py is universal → full 12-package cascade."""
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        result = build_test_scope(
+            changed_files={"src/autoskillit/core/io.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        for pkg in ["core", "config", "execution", "pipeline", "workspace",
+                    "recipe", "migration", "server", "cli", "hooks", "skills"]:
+            assert pkg in dir_names, f"universal io.py should cascade to {pkg}"
+
+    def test_init_triggers_full_cascade(self, tmp_path: Path) -> None:
+        """__init__.py always triggers full cascade."""
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        result = build_test_scope(
+            changed_files={"src/autoskillit/core/__init__.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        for pkg in ["core", "config", "execution", "server", "cli"]:
+            assert pkg in dir_names
+
+    def test_kitchen_state_narrow_cascade(self, tmp_path: Path) -> None:
+        """kitchen_state.py → only {core, cli} + always-run."""
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        result = build_test_scope(
+            changed_files={"src/autoskillit/core/kitchen_state.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        assert "core" in dir_names
+        assert "cli" in dir_names
+        # Must NOT include packages kitchen_state doesn't touch
+        for excluded in ["execution", "pipeline", "workspace", "recipe",
+                         "migration", "server", "hooks"]:
+            assert excluded not in dir_names, (
+                f"kitchen_state narrow cascade should not include {excluded}"
+            )
+        # Always-run are still present
+        for always in ["arch", "contracts", "infra", "docs"]:
+            assert always in dir_names
+
+    def test_unknown_core_module_fails_open_to_full_cascade(self, tmp_path: Path) -> None:
+        """An unknown core module stem → full cascade (fail-open, not None)."""
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        result = build_test_scope(
+            changed_files={"src/autoskillit/core/_new_future_module.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        # Fail-open: should include all packages
+        for pkg in ["core", "config", "execution", "server", "cli"]:
+            assert pkg in dir_names, f"fail-open should include {pkg}"
+
+    def test_aggressive_mode_unaffected(self, tmp_path: Path) -> None:
+        """AGGRESSIVE mode still maps core → {core} regardless of stem."""
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        result = build_test_scope(
+            changed_files={"src/autoskillit/core/kitchen_state.py"},
+            mode=FilterMode.AGGRESSIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        assert "core" in dir_names
+        # AGGRESSIVE only maps core → core, no other dirs (except always-run)
+        for excluded in ["execution", "pipeline", "workspace", "recipe",
+                         "migration", "server", "cli", "hooks"]:
+            assert excluded not in dir_names
+
+    def test_paths_cascade_includes_most_packages(self, tmp_path: Path) -> None:
+        """paths.py is used by almost everything → large but not full cascade."""
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        result = build_test_scope(
+            changed_files={"src/autoskillit/core/paths.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        for pkg in ["core", "cli", "config", "execution", "franchise",
+                    "migration", "recipe", "server", "workspace"]:
+            assert pkg in dir_names
+
+    def test_readiness_cascade_includes_only_server(self, tmp_path: Path) -> None:
+        """readiness.py only used by server → {core, server} + always-run."""
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        result = build_test_scope(
+            changed_files={"src/autoskillit/core/readiness.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        assert "core" in dir_names
+        assert "server" in dir_names
+        for excluded in ["execution", "pipeline", "workspace", "recipe",
+                         "migration", "cli", "hooks"]:
+            assert excluded not in dir_names

--- a/tests/test_test_filter_core_cascade.py
+++ b/tests/test_test_filter_core_cascade.py
@@ -4,21 +4,16 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from tests._test_filter import (
+    _CORE_UNIVERSAL_MODULES,
     MODULE_CASCADE_CORE,
     FilterMode,
-    _CORE_UNIVERSAL_MODULES,
     build_test_scope,
 )
 
 
 class TestCoreUniversalModules:
     """REQ-CORE-001: _CORE_UNIVERSAL_MODULES must exist and contain the right stems."""
-
-    def test_is_frozenset(self) -> None:
-        assert isinstance(_CORE_UNIVERSAL_MODULES, frozenset)
 
     def test_required_stems_present(self) -> None:
         required = {
@@ -42,9 +37,6 @@ class TestCoreUniversalModules:
 
 class TestModuleCascadeCore:
     """REQ-CORE-002: MODULE_CASCADE_CORE must exist with validated consumer sets."""
-
-    def test_is_dict(self) -> None:
-        assert isinstance(MODULE_CASCADE_CORE, dict)
 
     def test_all_values_are_frozensets(self) -> None:
         for stem, consumers in MODULE_CASCADE_CORE.items():
@@ -105,9 +97,22 @@ class TestBuildTestScopeCoreCascade:
         return tests_root
 
     ALL_DIRS = [
-        "core", "config", "execution", "pipeline", "workspace",
-        "recipe", "migration", "franchise", "server", "cli",
-        "hooks", "skills", "arch", "contracts", "infra", "docs",
+        "core",
+        "config",
+        "execution",
+        "pipeline",
+        "workspace",
+        "recipe",
+        "migration",
+        "franchise",
+        "server",
+        "cli",
+        "hooks",
+        "skills",
+        "arch",
+        "contracts",
+        "infra",
+        "docs",
     ]
 
     def test_universal_module_triggers_full_cascade(self, tmp_path: Path) -> None:
@@ -120,8 +125,19 @@ class TestBuildTestScopeCoreCascade:
         )
         assert result is not None
         dir_names = {p.name for p in result}
-        for pkg in ["core", "config", "execution", "pipeline", "workspace",
-                    "recipe", "migration", "server", "cli", "hooks", "skills"]:
+        for pkg in [
+            "core",
+            "config",
+            "execution",
+            "pipeline",
+            "workspace",
+            "recipe",
+            "migration",
+            "server",
+            "cli",
+            "hooks",
+            "skills",
+        ]:
             assert pkg in dir_names, f"universal io.py should cascade to {pkg}"
 
     def test_init_triggers_full_cascade(self, tmp_path: Path) -> None:
@@ -150,8 +166,15 @@ class TestBuildTestScopeCoreCascade:
         assert "core" in dir_names
         assert "cli" in dir_names
         # Must NOT include packages kitchen_state doesn't touch
-        for excluded in ["execution", "pipeline", "workspace", "recipe",
-                         "migration", "server", "hooks"]:
+        for excluded in [
+            "execution",
+            "pipeline",
+            "workspace",
+            "recipe",
+            "migration",
+            "server",
+            "hooks",
+        ]:
             assert excluded not in dir_names, (
                 f"kitchen_state narrow cascade should not include {excluded}"
             )
@@ -185,8 +208,16 @@ class TestBuildTestScopeCoreCascade:
         dir_names = {p.name for p in result}
         assert "core" in dir_names
         # AGGRESSIVE only maps core → core, no other dirs (except always-run)
-        for excluded in ["execution", "pipeline", "workspace", "recipe",
-                         "migration", "server", "cli", "hooks"]:
+        for excluded in [
+            "execution",
+            "pipeline",
+            "workspace",
+            "recipe",
+            "migration",
+            "server",
+            "cli",
+            "hooks",
+        ]:
             assert excluded not in dir_names
 
     def test_paths_cascade_includes_most_packages(self, tmp_path: Path) -> None:
@@ -199,8 +230,17 @@ class TestBuildTestScopeCoreCascade:
         )
         assert result is not None
         dir_names = {p.name for p in result}
-        for pkg in ["core", "cli", "config", "execution", "franchise",
-                    "migration", "recipe", "server", "workspace"]:
+        for pkg in [
+            "core",
+            "cli",
+            "config",
+            "execution",
+            "franchise",
+            "migration",
+            "recipe",
+            "server",
+            "workspace",
+        ]:
             assert pkg in dir_names
 
     def test_readiness_cascade_includes_only_server(self, tmp_path: Path) -> None:
@@ -215,6 +255,13 @@ class TestBuildTestScopeCoreCascade:
         dir_names = {p.name for p in result}
         assert "core" in dir_names
         assert "server" in dir_names
-        for excluded in ["execution", "pipeline", "workspace", "recipe",
-                         "migration", "cli", "hooks"]:
+        for excluded in [
+            "execution",
+            "pipeline",
+            "workspace",
+            "recipe",
+            "migration",
+            "cli",
+            "hooks",
+        ]:
             assert excluded not in dir_names


### PR DESCRIPTION
## Summary

Add `_CORE_UNIVERSAL_MODULES` and `MODULE_CASCADE_CORE` to `tests/_test_filter.py`, and extend `build_test_scope` to route `core/` file changes through per-module consumer sets rather than always triggering the full 12-package cascade. When a changed file is in `core/` and mode is CONSERVATIVE, the stem is checked: universal modules and `__init__` fall through to the full cascade; known narrow modules route through `MODULE_CASCADE_CORE[stem]`; unknown stems fail-open to the full cascade. AGGRESSIVE mode is unaffected (already maps `core` → `{core}`).

## Requirements

### REQ-CORE-001: Define `_CORE_UNIVERSAL_MODULES` frozenset

Modules that are imported by all/most packages and should trigger the full core cascade:
`io`, `logging`, `types`, `_type_constants`, `_type_protocols`, `_type_enums`, `_type_subprocess`, `_type_results`, `_type_resume`, `_type_helpers`

### REQ-CORE-002: Define `MODULE_CASCADE_CORE` dict

Map each narrow module stem to its validated consumer set (verified against actual imports):

| Module | Cascade |
|---|---|
| `readiness` | core, server |
| `feature_flags` | core, cli, config, server, workspace |
| `kitchen_state` | core, cli |
| `branch_guard` | core, pipeline, server, workspace |
| `_plugin_ids` | core, cli, server |
| `_terminal_table` | core, cli, pipeline, recipe |
| `_linux_proc` | core, cli, execution, franchise |
| `_plugin_cache` | core, cli, server |
| `github_url` | core, cli, execution, server |
| `paths` | core, cli, config, execution, franchise, migration, recipe, server, workspace |
| `_claude_env` | core, execution |
| `_version_snapshot` | core, execution |
| `claude_conventions` | core, server, workspace |

### REQ-CORE-003: Insert conditional block in `build_test_scope`

Between lines 684-685 (after `pkg = _file_to_package(f)` returns "core" and before `cascade_map[pkg]` lookup):

- If `pkg == "core"` and mode is CONSERVATIVE:
  - Extract `Path(f).stem`
  - If stem is in `_CORE_UNIVERSAL_MODULES` or is `__init__` → full cascade (fail-open)
  - If stem is in `MODULE_CASCADE_CORE` → use narrow cascade
  - If stem is unknown → full cascade (fail-open)
- Otherwise: existing behavior

### REQ-CORE-004: Tests for module-level cascade

Add test cases verifying:
- `kitchen_state.py` change → cascade includes only `{core, cli}` + always-run
- `io.py` change → full core cascade (universal module)
- `__init__.py` change → full core cascade
- Unknown module → full core cascade (fail-open)

## Architecture Impact

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph TestConsumers ["TEST CONSUMERS (tests/test_*.py)"]
        direction LR
        NewCascadeTest["★ test_test_filter_core_cascade.py<br/>━━━━━━━━━━<br/>REQ-CORE-001..004<br/>Validates cascade classification<br/>Imports: MODULE_CASCADE_CORE,<br/>_CORE_UNIVERSAL_MODULES,<br/>build_test_scope, FilterMode"]
        OtherTests["test_test_filter.py<br/>test_test_filter_cascade.py<br/>test_test_filter_content_aware.py<br/>test_test_filter_step7.py<br/>━━━━━━━━━━<br/>Existing filter algorithm tests"]
    end

    subgraph TestLib ["TEST LIBRARY (tests/_test_filter.py) — self-contained, no prod imports"]
        direction TB
        TestFilterLib["● tests/_test_filter.py<br/>━━━━━━━━━━<br/>Full filter algorithm brain<br/>FilterMode, ASTImportWalker<br/>git_changed_files()<br/>build_test_scope()"]
        NewConstants["● New exports added by PR<br/>━━━━━━━━━━<br/>_CORE_UNIVERSAL_MODULES: frozenset[str]<br/>(10 stems: io, logging, types, ...)<br/>MODULE_CASCADE_CORE: dict[str, frozenset[str]]<br/>(13 narrow-cascade entries)"]
    end

    subgraph ProdLayer ["PRODUCTION MODULE (src/autoskillit/_test_filter.py)"]
        ProdFilter["src/autoskillit/_test_filter.py<br/>━━━━━━━━━━<br/>Thin manifest wrapper<br/>load_manifest()<br/>apply_manifest()"]
    end

    subgraph CoreL0 ["CORE/ SUBMODULES — L0 Foundation (src/autoskillit/core/)"]
        direction LR
        UniversalMods["Universal Modules (10 stems)<br/>━━━━━━━━━━<br/>io · logging · types<br/>_type_constants · _type_protocols<br/>_type_enums · _type_subprocess<br/>_type_results · _type_resume<br/>_type_helpers<br/>→ Cascade: ALL 12 test packages"]
        NarrowMods["Narrow Cascade Modules (13 stems)<br/>━━━━━━━━━━<br/>readiness → {core, server}<br/>feature_flags → {core, cli, config, server, workspace}<br/>kitchen_state → {core, cli}<br/>branch_guard → {core, pipeline, server, workspace}<br/>_plugin_ids → {core, cli, server}<br/>_terminal_table → {core, cli, pipeline, recipe}<br/>_linux_proc → {core, cli, execution, franchise}<br/>_plugin_cache → {core, cli, server}<br/>github_url → {core, cli, execution, server}<br/>paths → {core, cli, config, execution,<br/>franchise, migration, recipe, server, workspace}<br/>_claude_env → {core, execution}<br/>_version_snapshot → {core, execution}<br/>claude_conventions → {core, server, workspace}"]
    end

    subgraph ConsumerPkgs ["CONSUMER TEST PACKAGES (resolved at CI time)"]
        direction LR
        Packages["core · cli · config · execution<br/>pipeline · recipe · migration<br/>franchise · server · workspace<br/>planner · infra<br/>━━━━━━━━━━<br/>Minimal set routed to<br/>by build_test_scope()"]
    end

    %% IMPORT RELATIONSHIPS %%
    NewCascadeTest -->|"imports<br/>MODULE_CASCADE_CORE<br/>_CORE_UNIVERSAL_MODULES<br/>build_test_scope, FilterMode"| TestLib
    OtherTests -->|"imports<br/>build_test_scope, FilterMode<br/>check_bucket_a, etc."| TestLib
    NewConstants -.->|"contained in"| TestFilterLib

    %% TEST LIB DATA REFERENCES (no actual imports — classification data only) %%
    TestFilterLib -.->|"classifies stems<br/>(data only, no import)"| UniversalMods
    TestFilterLib -.->|"classifies stems<br/>(data only, no import)"| NarrowMods

    %% PRODUCTION MODULE IMPORTS CORE %%
    ProdFilter -->|"imports load_yaml"| CoreL0

    %% CASCADE RESOLUTION %%
    UniversalMods -->|"triggers full cascade<br/>→ all 12 packages"| Packages
    NarrowMods -->|"triggers narrow cascade<br/>→ specific subset"| Packages

    %% CLASS ASSIGNMENTS %%
    class NewCascadeTest newComponent;
    class OtherTests phase;
    class TestFilterLib handler;
    class NewConstants stateNode;
    class ProdFilter integration;
    class UniversalMods detector;
    class NarrowMods output;
    class Packages cli;
```

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START<br/>━━━━━━━━━━<br/>build_test_scope called])
    FULL_RUN([FULL RUN<br/>━━━━━━━━━━<br/>return None])
    SCOPED_RUN([SCOPED RUN<br/>━━━━━━━━━━<br/>return set of Paths])

    subgraph Guards ["Early Exit Guards"]
        direction TB
        ModeCheck{"mode == NONE?"}
        NullCheck{"changed_files<br/>is None?"}
        LargeSet{"len > 30<br/>files?"}
        BucketA["● BucketA Check<br/>━━━━━━━━━━<br/>check_bucket_a_content_aware()<br/>skips version-only pyproject/uv.lock diffs"]
        BucketAHit{"Bucket A<br/>triggered?"}
    end

    subgraph Classify ["File Classification Loop (per changed file)"]
        direction TB
        FileType{"File type?"}
        DirectTest["Direct Test File<br/>━━━━━━━━━━<br/>tests/**/*.py<br/>added to direct_test_files"]
        GetPkg["● _file_to_package()<br/>━━━━━━━━━━<br/>extract autoskillit subpackage<br/>from src/**/*.py path"]
        UnknownPkg{"pkg in<br/>cascade_map?"}
        NonPython["● apply_manifest()<br/>━━━━━━━━━━<br/>match via gitwildmatch<br/>test-filter-manifest.yaml"]
        ManifestHit{"any file<br/>unmatched?"}
        LookupLayer["Layer Cascade Lookup<br/>━━━━━━━━━━<br/>cascade_map[pkg]<br/>adds dirs to test_dirs"]
    end

    subgraph CoreRouter ["● Core Submodule Router (CONSERVATIVE only)"]
        direction TB
        IsCore{"pkg == core AND<br/>mode == CONSERVATIVE?"}
        UniversalCheck{"stem in<br/>_CORE_UNIVERSAL_MODULES<br/>or stem == __init__?"}
        NarrowCheck{"● stem in<br/>MODULE_CASCADE_CORE?"}
        FullCoreCascade["Full Core Cascade<br/>━━━━━━━━━━<br/>cascade_map[core]<br/>→ all 12 test dirs"]
        NarrowCascade["● Narrow Cascade<br/>━━━━━━━━━━<br/>MODULE_CASCADE_CORE[stem]<br/>e.g. kitchen_state→{core,cli}"]
        FailOpenCore["Fail-Open Core<br/>━━━━━━━━━━<br/>unknown stem<br/>→ full cascade_map[core]"]
    end

    subgraph PostClass ["Post-Classification Processing"]
        direction TB
        ReexportWalk["Re-export Closure Walk<br/>━━━━━━━━━━<br/>_expand_reexport_closure()<br/>AST-scan parent __init__.py files"]
        AlwaysRun["Always-Run Union<br/>━━━━━━━━━━<br/>CONSERVATIVE: arch,contracts,infra,docs<br/>AGGRESSIVE: arch,contracts"]
        CoverageMode{"mode == AGGRESSIVE<br/>AND coverage map<br/>exists + fresh?"}
        CoverageRefine["Coverage Oracle Refinement<br/>━━━━━━━━━━<br/>replace directory entries<br/>with specific test files<br/>where oracle has full coverage data"]
    end

    subgraph TestValidation ["★ Test Validation Layer (new)"]
        direction TB
        TestUniversal["★ TestCoreUniversalModules<br/>━━━━━━━━━━<br/>REQ-CORE-001<br/>validates _CORE_UNIVERSAL_MODULES<br/>membership + __init__ exclusion"]
        TestCascadeMap["★ TestModuleCascadeCore<br/>━━━━━━━━━━<br/>REQ-CORE-002<br/>validates MODULE_CASCADE_CORE<br/>structure + 13 exact entries"]
        TestIntegration["★ TestBuildTestScopeCoreCascade<br/>━━━━━━━━━━<br/>REQ-CORE-003/004<br/>7 integration tests via tmp_path<br/>verifies routing decisions end-to-end"]
    end

    PathResolve["Path Resolution<br/>━━━━━━━━━━<br/>test_dirs → tests_root/dir<br/>only if is_dir() or is_file()"]

    %% MAIN FLOW %%
    START --> ModeCheck
    ModeCheck -->|"yes"| FULL_RUN
    ModeCheck -->|"no"| NullCheck
    NullCheck -->|"yes"| FULL_RUN
    NullCheck -->|"no"| LargeSet
    LargeSet -->|"yes"| FULL_RUN
    LargeSet -->|"no"| BucketA
    BucketA --> BucketAHit
    BucketAHit -->|"yes"| FULL_RUN
    BucketAHit -->|"no"| FileType

    %% CLASSIFICATION LOOP %%
    FileType -->|"tests/*.py"| DirectTest
    FileType -->|"src/*.py"| GetPkg
    FileType -->|"non-Python / other"| NonPython
    NonPython --> ManifestHit
    ManifestHit -->|"yes (fail-open)"| FULL_RUN
    ManifestHit -->|"no"| DirectTest
    GetPkg --> IsCore
    IsCore -->|"yes"| UniversalCheck
    IsCore -->|"no"| UnknownPkg
    UnknownPkg -->|"unknown pkg"| FULL_RUN
    UnknownPkg -->|"known pkg"| LookupLayer

    %% CORE SUBMODULE ROUTING %%
    UniversalCheck -->|"yes"| FullCoreCascade
    UniversalCheck -->|"no"| NarrowCheck
    NarrowCheck -->|"yes"| NarrowCascade
    NarrowCheck -->|"no (unknown stem)"| FailOpenCore

    %% CONVERGE after classification %%
    DirectTest --> ReexportWalk
    LookupLayer --> ReexportWalk
    FullCoreCascade --> ReexportWalk
    NarrowCascade --> ReexportWalk
    FailOpenCore --> ReexportWalk

    %% POST-CLASSIFICATION %%
    ReexportWalk -->|"re-classify any new __init__ hits"| AlwaysRun
    AlwaysRun --> CoverageMode
    CoverageMode -->|"yes"| CoverageRefine
    CoverageMode -->|"no"| PathResolve
    CoverageRefine --> PathResolve
    PathResolve --> SCOPED_RUN

    %% TEST VALIDATION (parallel verification) %%
    TestUniversal -.->|"asserts membership"| UniversalCheck
    TestCascadeMap -.->|"asserts 13 entries + structure"| NarrowCheck
    TestIntegration -.->|"end-to-end routing assertions"| IsCore

    %% CLASS ASSIGNMENTS %%
    class START,FULL_RUN,SCOPED_RUN terminal;
    class ModeCheck,NullCheck,LargeSet,BucketAHit,FileType,IsCore,UniversalCheck,ManifestHit,UnknownPkg,CoverageMode stateNode;
    class NarrowCheck detector;
    class BucketA,GetPkg,ReexportWalk,AlwaysRun,CoverageRefine,PathResolve,LookupLayer,NonPython phase;
    class DirectTest,FullCoreCascade,FailOpenCore handler;
    class NarrowCascade,TestUniversal,TestCascadeMap,TestIntegration newComponent;
```

Closes #1217

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260425-000255-728038/.autoskillit/temp/make-plan/module_level_cascade_map_core_submodules_plan_2026-04-25_000255.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 189 | 12.7k | 925.4k | 56.2k | 1 | 7m 20s |
| verify | 92 | 5.9k | 369.4k | 31.5k | 1 | 3m 9s |
| implement | 156 | 8.0k | 772.6k | 40.7k | 1 | 2m 27s |
| prepare_pr | 68 | 6.5k | 225.6k | 28.2k | 1 | 2m 0s |
| run_arch_lenses | 116 | 11.7k | 312.2k | 94.5k | 2 | 6m 29s |
| compose_pr | 59 | 6.6k | 206.6k | 28.3k | 1 | 2m 7s |
| **Total** | 680 | 51.4k | 2.8M | 279.4k | | 23m 34s |