### PR TITLE
Implementation Plan: Diff-Aware Deselection for Parametrized Arch Tests

### DIFF
--- a/tests/arch/_deselection.py
+++ b/tests/arch/_deselection.py
@@ -26,6 +26,9 @@ def deselect_arch_items(
             selected.append(item)
             continue
         source_file: Path = item.callspec.params["source_file"]
+        if not isinstance(source_file, Path):
+            selected.append(item)
+            continue
         if source_file.resolve() in changed_abs:
             selected.append(item)
         else:

--- a/tests/arch/_deselection.py
+++ b/tests/arch/_deselection.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def deselect_arch_items(
+    items: list[pytest.Item],
+    changed_abs: set[Path],
+    arch_dir: Path,
+) -> tuple[list[pytest.Item], list[pytest.Item]]:
+    """Return (selected, deselected) splitting items by source_file membership.
+
+    Only items inside arch_dir whose callspec has a ``source_file`` param are
+    candidates for deselection. All others (one-shot tests, non-arch items,
+    and parametrized tests using different param names) pass through unchanged.
+    """
+    selected: list[pytest.Item] = []
+    deselected: list[pytest.Item] = []
+    for item in items:
+        if not Path(str(item.fspath)).is_relative_to(arch_dir):
+            selected.append(item)
+            continue
+        if not hasattr(item, "callspec") or "source_file" not in item.callspec.params:
+            selected.append(item)
+            continue
+        source_file: Path = item.callspec.params["source_file"]
+        if source_file.resolve() in changed_abs:
+            selected.append(item)
+        else:
+            deselected.append(item)
+    return selected, deselected

--- a/tests/arch/conftest.py
+++ b/tests/arch/conftest.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from tests._test_filter import git_changed_files
+from tests.arch._deselection import deselect_arch_items
+
+_ARCH_DIR = Path(__file__).parent
+_PROJECT_ROOT = _ARCH_DIR.parent.parent
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config,
+    items: list[pytest.Item],
+) -> None:
+    """Deselect source_file-parametrized arch cases for unchanged files.
+
+    Fail-open: any error (git failure, env parse error, exception) leaves
+    all items selected.
+    """
+    filter_mode = os.environ.get("AUTOSKILLIT_TEST_FILTER", "").strip().lower()
+    if not filter_mode or filter_mode in ("0", "false", "no", "none"):
+        return
+    try:
+        changed = git_changed_files(cwd=_PROJECT_ROOT)
+        if changed is None:
+            return
+        changed_abs = {(_PROJECT_ROOT / f).resolve() for f in changed}
+        selected, deselected = deselect_arch_items(items, changed_abs, _ARCH_DIR)
+        if deselected:
+            config.hook.pytest_deselected(items=deselected)
+            items[:] = selected
+    except Exception:
+        return

--- a/tests/arch/conftest.py
+++ b/tests/arch/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import warnings
 from pathlib import Path
 
 import pytest
@@ -33,5 +34,9 @@ def pytest_collection_modifyitems(
         if deselected:
             config.hook.pytest_deselected(items=deselected)
             items[:] = selected
-    except Exception:
+    except Exception as exc:
+        warnings.warn(
+            f"arch deselection failed (fail-open): {exc!r}",
+            stacklevel=2,
+        )
         return

--- a/tests/arch/test_arch_deselection.py
+++ b/tests/arch/test_arch_deselection.py
@@ -1,0 +1,110 @@
+"""Tests for diff-aware parametrized deselection — REQ-ARCH-004."""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.arch._deselection import deselect_arch_items
+
+pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+_ARCH_DIR = Path(__file__).parent
+_SRC_ROOT = Path(__file__).parent.parent.parent / "src" / "autoskillit"
+
+
+def _src(rel: str) -> Path:
+    return (_SRC_ROOT / rel).resolve()
+
+
+def _make_arch_item(source_file: Path) -> SimpleNamespace:
+    item = SimpleNamespace()
+    item.fspath = str(_ARCH_DIR / "test_ast_rules.py")
+    item.callspec = SimpleNamespace(params={"source_file": source_file})
+    return item
+
+
+def _make_oneshot_item() -> SimpleNamespace:
+    item = SimpleNamespace()
+    item.fspath = str(_ARCH_DIR / "test_import_linter_contracts.py")
+    return item  # no callspec
+
+
+def _make_nonarch_item() -> SimpleNamespace:
+    item = SimpleNamespace()
+    item.fspath = str(_ARCH_DIR.parent / "core" / "test_paths.py")
+    item.callspec = SimpleNamespace(params={"source_file": _src("core/paths.py")})
+    return item
+
+
+class TestDeselectArchItems:
+    def test_only_changed_source_files_selected(self) -> None:
+        a, b, c = _src("core/io.py"), _src("core/paths.py"), _src("core/logging.py")
+        all_files = [a, b, c, _src("core/types.py"), _src("core/feature_flags.py")]
+        items = [_make_arch_item(f) for f in all_files]
+        selected, deselected = deselect_arch_items(items, {a, b, c}, _ARCH_DIR)
+        assert len(selected) == 3
+        assert len(deselected) == 2
+        assert {i.callspec.params["source_file"] for i in selected} == {a, b, c}
+
+    def test_oneshot_always_selected(self) -> None:
+        oneshot = _make_oneshot_item()
+        param_item = _make_arch_item(_src("core/io.py"))
+        selected, deselected = deselect_arch_items(
+            [oneshot, param_item], set(), _ARCH_DIR
+        )
+        assert oneshot in selected
+        assert param_item in deselected
+
+    def test_nonarch_items_pass_through(self) -> None:
+        nonarch = _make_nonarch_item()
+        selected, deselected = deselect_arch_items([nonarch], set(), _ARCH_DIR)
+        assert nonarch in selected
+        assert not deselected
+
+    def test_empty_changed_deselects_all_param_items(self) -> None:
+        items = [_make_arch_item(_src(f"core/{n}.py")) for n in ("io", "paths", "logging")]
+        selected, deselected = deselect_arch_items(items, set(), _ARCH_DIR)
+        assert not selected
+        assert len(deselected) == 3
+
+
+class TestPytestCollectionModifyItemsHook:
+    def test_filter_inactive_is_noop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from tests.arch import conftest as arch_conftest
+        monkeypatch.delenv("AUTOSKILLIT_TEST_FILTER", raising=False)
+        items = [_make_arch_item(_src("core/io.py"))]
+        original = list(items)
+        mock_config = MagicMock()
+        arch_conftest.pytest_collection_modifyitems(mock_config, items)
+        mock_config.hook.pytest_deselected.assert_not_called()
+        assert items == original
+
+    def test_failopen_on_git_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from tests.arch import conftest as arch_conftest
+        monkeypatch.setenv("AUTOSKILLIT_TEST_FILTER", "conservative")
+        items = [_make_arch_item(_src("core/io.py"))]
+        original = list(items)
+        mock_config = MagicMock()
+        with patch.object(arch_conftest, "git_changed_files", return_value=None):
+            arch_conftest.pytest_collection_modifyitems(mock_config, items)
+        mock_config.hook.pytest_deselected.assert_not_called()
+        assert items == original
+
+    def test_changed_files_deselects_unchanged_param_items(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from tests.arch import conftest as arch_conftest
+        monkeypatch.setenv("AUTOSKILLIT_TEST_FILTER", "conservative")
+        changed_rel = "src/autoskillit/core/io.py"
+        changed = _src("core/io.py")
+        unchanged = _src("core/paths.py")
+        items = [_make_arch_item(changed), _make_arch_item(unchanged)]
+        mock_config = MagicMock()
+        with patch.object(arch_conftest, "git_changed_files", return_value={changed_rel}):
+            arch_conftest.pytest_collection_modifyitems(mock_config, items)
+        mock_config.hook.pytest_deselected.assert_called_once()
+        assert len(items) == 1
+        assert items[0].callspec.params["source_file"] == changed

--- a/tests/arch/test_arch_deselection.py
+++ b/tests/arch/test_arch_deselection.py
@@ -1,4 +1,5 @@
 """Tests for diff-aware parametrized deselection — REQ-ARCH-004."""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -52,9 +53,7 @@ class TestDeselectArchItems:
     def test_oneshot_always_selected(self) -> None:
         oneshot = _make_oneshot_item()
         param_item = _make_arch_item(_src("core/io.py"))
-        selected, deselected = deselect_arch_items(
-            [oneshot, param_item], set(), _ARCH_DIR
-        )
+        selected, deselected = deselect_arch_items([oneshot, param_item], set(), _ARCH_DIR)
         assert oneshot in selected
         assert param_item in deselected
 
@@ -74,6 +73,7 @@ class TestDeselectArchItems:
 class TestPytestCollectionModifyItemsHook:
     def test_filter_inactive_is_noop(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from tests.arch import conftest as arch_conftest
+
         monkeypatch.delenv("AUTOSKILLIT_TEST_FILTER", raising=False)
         items = [_make_arch_item(_src("core/io.py"))]
         original = list(items)
@@ -84,6 +84,7 @@ class TestPytestCollectionModifyItemsHook:
 
     def test_failopen_on_git_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from tests.arch import conftest as arch_conftest
+
         monkeypatch.setenv("AUTOSKILLIT_TEST_FILTER", "conservative")
         items = [_make_arch_item(_src("core/io.py"))]
         original = list(items)
@@ -97,14 +98,17 @@ class TestPytestCollectionModifyItemsHook:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         from tests.arch import conftest as arch_conftest
+
         monkeypatch.setenv("AUTOSKILLIT_TEST_FILTER", "conservative")
         changed_rel = "src/autoskillit/core/io.py"
         changed = _src("core/io.py")
         unchanged = _src("core/paths.py")
-        items = [_make_arch_item(changed), _make_arch_item(unchanged)]
+        changed_item = _make_arch_item(changed)
+        unchanged_item = _make_arch_item(unchanged)
+        items = [changed_item, unchanged_item]
         mock_config = MagicMock()
         with patch.object(arch_conftest, "git_changed_files", return_value={changed_rel}):
             arch_conftest.pytest_collection_modifyitems(mock_config, items)
-        mock_config.hook.pytest_deselected.assert_called_once()
+        mock_config.hook.pytest_deselected.assert_called_once_with(items=[unchanged_item])
         assert len(items) == 1
         assert items[0].callspec.params["source_file"] == changed


### PR DESCRIPTION
## Summary

Add `tests/arch/conftest.py` with a `pytest_collection_modifyitems` hook that deselects
per-file parametrized arch test cases for unchanged source files when test-path filtering
is active. The hook targets items with a `source_file` callspec parameter (currently
`test_ast_rules.py::test_no_violations` and two tests in `test_subpackage_isolation.py`)
and leaves all one-shot and non-`source_file` parametrized tests untouched.
A companion module `tests/arch/_deselection.py` isolates the pure filtering logic for
direct unit testing.

## Requirements

### REQ-ARCH-001: Add `tests/arch/conftest.py` with collection hook

Implement `pytest_collection_modifyitems` that:
1. Checks `AUTOSKILLIT_TEST_FILTER` env var — if unset, do nothing (full run)
2. Gets changed source files from git diff (reuse `git_changed_files` from `_test_filter`)
3. For items with a `source_file` callspec parameter, deselects items whose source file is not in the changed set
4. Leaves all non-parametrized (one-shot) tests untouched — they scan all files internally and enforce global invariants

### REQ-ARCH-002: Preserve one-shot test integrity

Tests that do their own `rglob("*.py")` internally (about half the arch logic) must NOT be affected. These check global structural invariants where a change to a helper could violate rules in unchanged files. Only per-file parametrized tests (those using `_SOURCE_FILES` from `tests/arch/_helpers.py`) are candidates for deselection.

### REQ-ARCH-003: Fail-open on any error

If git diff fails, env var parsing fails, or any exception occurs, fall back to running all tests (no deselection).

### REQ-ARCH-004: Tests

Add test cases verifying:
- With filter active and 3 changed files → only 3 source_file-parametrized cases selected per test function
- With filter inactive → all cases selected
- One-shot tests (no `source_file` param) → always selected regardless of filter state

## Architecture Impact

### Development Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START([pytest collect])

    subgraph EnvConfig ["ENVIRONMENT / CONFIG"]
        direction LR
        FILTER_ENV["AUTOSKILLIT_TEST_FILTER<br/>━━━━━━━━━━<br/>conservative | aggressive | none"]
        BASE_REF["AUTOSKILLIT_TEST_BASE_REF<br/>━━━━━━━━━━<br/>git diff base ref<br/>(or GITHUB_BASE_REF)"]
    end

    subgraph ArchTests ["tests/arch/ — PARAMETRIZED ARCH TESTS"]
        direction TB
        ARCH_PARAM["source_file-parametrized tests<br/>━━━━━━━━━━<br/>test_ast_rules.py<br/>test_layer_enforcement.py<br/>test_subpackage_isolation.py …"]
        ARCH_ONESHOT["one-shot arch tests<br/>━━━━━━━━━━<br/>test_import_linter_contracts.py<br/>test_registry.py<br/>(no callspec — always run)"]
    end

    subgraph NewHook ["★ tests/arch/conftest.py — COLLECTION HOOK"]
        direction TB
        HOOK["★ pytest_collection_modifyitems<br/>━━━━━━━━━━<br/>Reads AUTOSKILLIT_TEST_FILTER<br/>Fail-open on any error"]
    end

    subgraph GitDiff ["tests/_test_filter.py — GIT DIFF RESOLVER"]
        direction TB
        GIT_FN["git_changed_files()<br/>━━━━━━━━━━<br/>merge-base HEAD base_ref<br/>+ ls-files --others<br/>Returns None on error"]
    end

    subgraph DeselectionLogic ["★ tests/arch/_deselection.py — DESELECTION HELPER"]
        direction TB
        DESEL_FN["★ deselect_arch_items()<br/>━━━━━━━━━━<br/>items × changed_abs → (selected, deselected)<br/>Only arch items with source_file param<br/>are candidates; others pass through"]
    end

    subgraph DeselectionTests ["★ tests/arch/test_arch_deselection.py — UNIT TESTS"]
        direction TB
        TEST_DESEL["★ TestDeselectArchItems<br/>━━━━━━━━━━<br/>only_changed_selected<br/>oneshot_always_selected<br/>nonarch_pass_through<br/>empty_changed_deselects_all"]
        TEST_HOOK["★ TestPytestCollectionModifyItemsHook<br/>━━━━━━━━━━<br/>filter_inactive_is_noop<br/>failopen_on_git_none<br/>changed_files_deselects_unchanged"]
    end

    subgraph QualityGates ["PRE-COMMIT QUALITY GATES"]
        direction LR
        RUFF_FMT["ruff format<br/>━━━━━━━━━━<br/>auto-fixes style"]
        RUFF_LINT["ruff check<br/>━━━━━━━━━━<br/>auto-fixes lint"]
        MYPY["mypy<br/>━━━━━━━━━━<br/>type checking"]
        UV_LOCK["uv lock check<br/>━━━━━━━━━━<br/>lockfile sync"]
    end

    subgraph TestRunner ["TASK RUNNER (Taskfile.yml)"]
        direction LR
        TASK_TEST["task test-check<br/>━━━━━━━━━━<br/>pytest -n 4<br/>/dev/shm tmpfs"]
        TASK_FILTERED["task test-filtered<br/>━━━━━━━━━━<br/>AUTOSKILLIT_TEST_FILTER=conservative"]
    end

    SELECTED(["selected items → run"])
    DESELECTED(["deselected items → skip"])

    %% FLOW %%
    START --> ARCH_PARAM
    START --> ARCH_ONESHOT

    ARCH_PARAM --> HOOK
    ARCH_ONESHOT --> HOOK

    FILTER_ENV -->|"active?"| HOOK
    BASE_REF --> GIT_FN

    HOOK -->|"filter active"| GIT_FN
    GIT_FN -->|"changed_abs set"| DESEL_FN

    ARCH_PARAM -->|"items list"| DESEL_FN
    ARCH_ONESHOT -->|"items list"| DESEL_FN

    DESEL_FN -->|"source_file in changed_abs"| SELECTED
    DESEL_FN -->|"source_file NOT in changed_abs"| DESELECTED
    HOOK -->|"filter inactive / error"| SELECTED

    DESEL_FN -.->|"tested by"| TEST_DESEL
    HOOK -.->|"tested by"| TEST_HOOK

    TASK_TEST --> START
    TASK_FILTERED --> FILTER_ENV

    RUFF_FMT --> RUFF_LINT --> MYPY --> UV_LOCK --> TASK_TEST

    %% CLASS ASSIGNMENTS %%
    class FILTER_ENV,BASE_REF cli;
    class ARCH_PARAM,ARCH_ONESHOT stateNode;
    class HOOK newComponent;
    class GIT_FN handler;
    class DESEL_FN newComponent;
    class TEST_DESEL,TEST_HOOK newComponent;
    class RUFF_FMT,RUFF_LINT detector;
    class MYPY,UV_LOCK detector;
    class TASK_TEST,TASK_FILTERED phase;
    class SELECTED output;
    class DESELECTED terminal;
    class START terminal;
```

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph L2 ["LAYER 2 — ARCH TEST FEATURE (tests/arch/)"]
        direction LR
        CONFTEST["★ conftest.py<br/>━━━━━━━━━━<br/>pytest_collection_modifyitems<br/>Diff-aware deselection hook"]
        TEST_DESEL["★ test_arch_deselection.py<br/>━━━━━━━━━━<br/>REQ-ARCH-004 unit tests<br/>Tests deselect + hook logic"]
    end

    subgraph L1 ["LAYER 1 — TEST INFRASTRUCTURE"]
        direction LR
        DESEL["★ tests/arch/_deselection.py<br/>━━━━━━━━━━<br/>deselect_arch_items()<br/>Splits items by source_file param"]
        FILTER["tests/_test_filter.py<br/>━━━━━━━━━━<br/>git_changed_files()<br/>Git diff helper (stdlib-only)"]
        ROOT_CONF["tests/conftest.py<br/>━━━━━━━━━━<br/>Root scope-based deselection<br/>Broader path-scoping pass"]
    end

    subgraph L0 ["LAYER 0 — EXTERNAL &amp; PARAMETRIZED TARGETS"]
        direction LR
        PYTEST["pytest<br/>━━━━━━━━━━<br/>Item / callspec / stash API<br/>Third-party framework"]
        AST_RULES["tests/arch/test_ast_rules.py<br/>━━━━━━━━━━<br/>@parametrize source_file<br/>Primary deselection target"]
        SUBPKG["tests/arch/test_subpackage_isolation.py<br/>━━━━━━━━━━<br/>@parametrize source_file<br/>Primary deselection target"]
    end

    %% L2 → L1: static imports %%
    CONFTEST -->|"imports git_changed_files"| FILTER
    CONFTEST -->|"imports deselect_arch_items"| DESEL

    %% L2 → L2: inline import inside test methods (same-layer) %%
    TEST_DESEL -.->|"inline import in test methods"| CONFTEST

    %% L2 → L0: direct pytest dependency %%
    CONFTEST -->|"imports pytest"| PYTEST

    %% L2 → L1: test imports utility under test %%
    TEST_DESEL -->|"imports deselect_arch_items"| DESEL

    %% L1 → L0: utility uses pytest API %%
    DESEL -->|"imports pytest.Item / callspec"| PYTEST

    %% Runtime relationship (dashed): conftest deselects parametrized items %%
    CONFTEST -.->|"deselects unchanged params at runtime"| AST_RULES
    CONFTEST -.->|"deselects unchanged params at runtime"| SUBPKG

    %% Orthogonal pass ordering (dashed): root conftest runs before arch conftest %%
    ROOT_CONF -.->|"orthogonal pass (runs first via pytest conftest order)"| CONFTEST

    %% CLASS ASSIGNMENTS %%
    class CONFTEST,TEST_DESEL,DESEL newComponent;
    class FILTER,ROOT_CONF handler;
    class PYTEST integration;
    class AST_RULES,SUBPKG phase;
```

Closes #1220

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260425-035221-511515/.autoskillit/temp/make-plan/diff_aware_arch_deselection_plan_2026-04-25_000001.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 147 | 22.5k | 698.5k | 57.5k | 1 | 10m 24s |
| verify | 132 | 11.7k | 545.6k | 36.6k | 1 | 3m 43s |
| implement | 100 | 4.9k | 368.5k | 26.4k | 1 | 2m 10s |
| fix | 70 | 3.0k | 231.1k | 27.1k | 1 | 3m 44s |
| prepare_pr | 60 | 5.1k | 192.6k | 24.9k | 1 | 1m 24s |
| run_arch_lenses | 132 | 11.3k | 406.7k | 83.6k | 2 | 5m 2s |
| compose_pr | 59 | 5.9k | 200.3k | 26.1k | 1 | 1m 58s |
| **Total** | 700 | 64.5k | 2.6M | 282.1k | | 28m 27s |