### PR TITLE
CI Guard Test for Cascade Map and MODULE_CASCADE_CORE Drift Detection

### DIFF
--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -132,7 +132,7 @@ _CORE_UNIVERSAL_MODULES: frozenset[str] = frozenset(
 MODULE_CASCADE_CORE: dict[str, frozenset[str]] = {
     "readiness": frozenset({"core", "server"}),
     "feature_flags": frozenset({"core", "cli", "config", "server", "workspace"}),
-    "kitchen_state": frozenset({"core", "cli"}),
+    "kitchen_state": frozenset({"core", "cli", "server"}),
     "branch_guard": frozenset({"core", "pipeline", "server", "workspace"}),
     "_plugin_ids": frozenset({"core", "cli", "server"}),
     "_terminal_table": frozenset({"core", "cli", "pipeline", "recipe"}),
@@ -146,13 +146,14 @@ MODULE_CASCADE_CORE: dict[str, frozenset[str]] = {
             "config",
             "execution",
             "fleet",
+            "hook_registry",
             "migration",
             "recipe",
             "server",
             "workspace",
         }
     ),
-    "_claude_env": frozenset({"core", "execution"}),
+    "_claude_env": frozenset({"core", "execution", "_llm_triage"}),
     "_version_snapshot": frozenset({"core", "execution"}),
     "claude_conventions": frozenset({"core", "server", "workspace"}),
 }
@@ -177,12 +178,18 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             "cli",
             "hooks",
             "skills",
+            "_llm_triage",
+            "_test_filter",
+            "hook_registry",
+            "planner",
+            "smoke_utils",
         }
     ),
     # L1
     "config": frozenset(
         {
             "config",
+            "execution",
             "pipeline",
             "workspace",
             "server",
@@ -199,6 +206,8 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             "cli",
             "infra",
             "skills",
+            "_llm_triage",
+            "smoke_utils",
         }
     ),
     "pipeline": frozenset(
@@ -207,6 +216,8 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             "execution",
             "server",
             "infra",
+            "cli",
+            "fleet",
         }
     ),
     "workspace": frozenset(
@@ -217,6 +228,7 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             "server",
             "cli",
             "skills",
+            "_llm_triage",
         }
     ),
     # L2
@@ -228,12 +240,17 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             "cli",
             "infra",
             "skills",
+            "_llm_triage",
+            "core",
+            "hooks",
+            "migration",
         }
     ),
     "migration": frozenset(
         {
             "migration",
             "server",
+            "cli",
         }
     ),
     "fleet": frozenset(
@@ -253,6 +270,7 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
     "cli": frozenset(
         {
             "cli",
+            "__main__",
         }
     ),
     # Infra (non-layered)
@@ -261,6 +279,8 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             "hooks",
             "infra",
             "cli",
+            "fleet",
+            "server",
         }
     ),
     "hook_registry": frozenset(
@@ -277,7 +297,7 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
     "_llm_triage": frozenset({"test_llm_triage.py", "execution", "server", "recipe"}),
     "_test_filter": frozenset({"arch", "infra", "contracts"}),
     "smoke_utils": frozenset({"test_smoke_utils.py", "recipe"}),
-    "version": frozenset({"test_version.py", "server"}),
+    "version": frozenset({"test_version.py", "server", "cli"}),
 }
 
 LAYER_CASCADE_AGGRESSIVE: dict[str, frozenset[str]] = {

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -275,6 +275,7 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
     # Standalone modules (not subpackage directories)
     "planner": frozenset({"planner"}),
     "_llm_triage": frozenset({"test_llm_triage.py", "execution", "server", "recipe"}),
+    "_test_filter": frozenset({"arch", "infra", "contracts"}),
     "smoke_utils": frozenset({"test_smoke_utils.py", "recipe"}),
     "version": frozenset({"test_version.py", "server"}),
 }

--- a/tests/arch/test_cascade_map_guard.py
+++ b/tests/arch/test_cascade_map_guard.py
@@ -6,6 +6,7 @@ reverse import graph.  Zero runtime cost — pure static analysis.
 from __future__ import annotations
 
 import ast
+import warnings
 from collections import defaultdict
 from pathlib import Path
 
@@ -34,11 +35,14 @@ def _build_core_reexport_map() -> dict[str, str]:
     """
     init_path = _SRC_ROOT / "core" / "__init__.py"
     if not init_path.exists():
-        return {}
+        pytest.skip(f"core/__init__.py not found at {init_path} — guard would pass vacuously")
     reexport_map: dict[str, str] = {}
     try:
         tree = ast.parse(init_path.read_text(encoding="utf-8"))
-    except SyntaxError:
+    except SyntaxError as exc:
+        warnings.warn(
+            f"SyntaxError parsing {init_path}: {exc} — re-export map is empty", stacklevel=2
+        )
         return {}
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom) and node.level == 1 and node.module:
@@ -65,7 +69,11 @@ def _build_package_reverse_graph() -> dict[str, set[str]]:
             continue
         try:
             tree = ast.parse(filepath.read_text(encoding="utf-8"))
-        except SyntaxError:
+        except SyntaxError as exc:
+            warnings.warn(
+                f"SyntaxError parsing {filepath}: {exc} — skipping file in package reverse graph",
+                stacklevel=2,
+            )
             continue
         for node in ast.walk(tree):
             if not (isinstance(node, ast.ImportFrom) and node.module):
@@ -94,7 +102,11 @@ def _build_module_reverse_graph() -> dict[str, set[str]]:
             continue
         try:
             tree = ast.parse(filepath.read_text(encoding="utf-8"))
-        except SyntaxError:
+        except SyntaxError as exc:
+            warnings.warn(
+                f"SyntaxError parsing {filepath}: {exc} — skipping file in module reverse graph",
+                stacklevel=2,
+            )
             continue
         for node in ast.walk(tree):
             if not (isinstance(node, ast.ImportFrom) and node.module):
@@ -155,9 +167,7 @@ class TestLayerCascadeConservativeGuard:
         graph = _build_package_reverse_graph()
         violations: dict[str, dict[str, list[str]]] = {}
         for pkg, declared in LAYER_CASCADE_CONSERVATIVE.items():
-            actual_all = graph.get(pkg, set())
-            # Exclude standalone test-file values (entries like "test_smoke_utils.py")
-            actual_pkgs = {c for c in actual_all if not c.endswith(".py")}
+            actual_pkgs = graph.get(pkg, set())
             missing = actual_pkgs - declared
             if missing:
                 violations[pkg] = {

--- a/tests/arch/test_cascade_map_guard.py
+++ b/tests/arch/test_cascade_map_guard.py
@@ -1,0 +1,190 @@
+"""
+REQ-GUARD-001..003: CI guard validating cascade maps against the AST-derived
+reverse import graph.  Zero runtime cost — pure static analysis.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import defaultdict
+from pathlib import Path
+
+import pytest
+
+from tests._test_filter import (
+    LAYER_CASCADE_CONSERVATIVE,
+    MODULE_CASCADE_CORE,
+    _file_to_package,
+)
+
+pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+_SRC_ROOT = Path(__file__).parent.parent.parent / "src" / "autoskillit"
+
+
+def _all_src_files() -> list[Path]:
+    return sorted(_SRC_ROOT.rglob("*.py"))
+
+
+def _build_core_reexport_map() -> dict[str, str]:
+    """
+    Parse core/__init__.py relative imports to map re-exported names → submodule stem.
+
+    `from .feature_flags import is_feature_enabled` → {"is_feature_enabled": "feature_flags"}
+    """
+    init_path = _SRC_ROOT / "core" / "__init__.py"
+    if not init_path.exists():
+        return {}
+    reexport_map: dict[str, str] = {}
+    try:
+        tree = ast.parse(init_path.read_text(encoding="utf-8"))
+    except SyntaxError:
+        return {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.level == 1 and node.module:
+            stem = node.module
+            for alias in node.names:
+                reexport_map[alias.name] = stem
+    return reexport_map
+
+
+_AUTOSKILLIT_DUNDER_STEMS: frozenset[str] = frozenset({"__init__", "__main__"})
+
+
+def _build_package_reverse_graph() -> dict[str, set[str]]:
+    """
+    REQ-GUARD-001 (package level).
+
+    Scans all src files for `from autoskillit.{pkg}[.anything] import ...`.
+    Returns {source_pkg: set[consuming_pkg]}.
+    """
+    graph: defaultdict[str, set[str]] = defaultdict(set)
+    for filepath in _all_src_files():
+        consumer_pkg = _file_to_package(str(filepath))
+        if consumer_pkg is None:
+            continue
+        try:
+            tree = ast.parse(filepath.read_text(encoding="utf-8"))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.ImportFrom) and node.module):
+                continue
+            parts = node.module.split(".")
+            if parts[0] == "autoskillit" and len(parts) >= 2:
+                graph[parts[1]].add(consumer_pkg)
+    return dict(graph)
+
+
+def _build_module_reverse_graph() -> dict[str, set[str]]:
+    """
+    REQ-GUARD-001 (module level, core submodules).
+
+    Tracks direct `from autoskillit.core.{stem} import ...` and
+    re-exported names `from autoskillit.core import {name}` resolved
+    through core/__init__.py.
+
+    Returns {core_module_stem: set[consuming_pkg]}.
+    """
+    core_reexports = _build_core_reexport_map()
+    graph: defaultdict[str, set[str]] = defaultdict(set)
+    for filepath in _all_src_files():
+        consumer_pkg = _file_to_package(str(filepath))
+        if consumer_pkg is None:
+            continue
+        try:
+            tree = ast.parse(filepath.read_text(encoding="utf-8"))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.ImportFrom) and node.module):
+                continue
+            parts = node.module.split(".")
+            if parts[0] != "autoskillit":
+                continue
+            # Direct: from autoskillit.core.{stem} import ...
+            if len(parts) >= 3 and parts[1] == "core":
+                graph[parts[2]].add(consumer_pkg)
+            # Via re-export: from autoskillit.core import {name}
+            elif len(parts) == 2 and parts[1] == "core":
+                for alias in node.names:
+                    stem = core_reexports.get(alias.name)
+                    if stem:
+                        graph[stem].add(consumer_pkg)
+    return dict(graph)
+
+
+class TestModuleCascadeCoreGuard:
+    """REQ-GUARD-002: MODULE_CASCADE_CORE declared sets must be supersets of actual consumers."""
+
+    def test_module_cascade_core_is_superset_of_ast_consumers(self) -> None:
+        graph = _build_module_reverse_graph()
+        violations: dict[str, dict[str, list[str]]] = {}
+        for stem, declared in MODULE_CASCADE_CORE.items():
+            actual = graph.get(stem, set())
+            missing = actual - declared
+            if missing:
+                violations[stem] = {
+                    "declared": sorted(declared),
+                    "actual": sorted(actual),
+                    "missing": sorted(missing),
+                }
+        assert not violations, (
+            "MODULE_CASCADE_CORE entries are too narrow — update tests/_test_filter.py:\n"
+            + "\n".join(
+                f"  {stem}: add {v['missing']} (declared={v['declared']}, actual={v['actual']})"
+                for stem, v in sorted(violations.items())
+            )
+        )
+
+    def test_module_cascade_core_has_no_phantom_stems(self) -> None:
+        graph = _build_module_reverse_graph()
+        phantoms = [stem for stem in MODULE_CASCADE_CORE if not graph.get(stem)]
+        assert not phantoms, (
+            "MODULE_CASCADE_CORE contains stems with zero AST consumers — "
+            "the source file may have been renamed or deleted:\n"
+            f"  {sorted(phantoms)}\n"
+            "Remove the stale entry or rename it to match the current module."
+        )
+
+
+class TestLayerCascadeConservativeGuard:
+    """REQ-GUARD-002 (extended): LAYER_CASCADE_CONSERVATIVE values must cover actual consumers."""
+
+    def test_layer_cascade_conservative_is_superset_of_ast_consumers(self) -> None:
+        graph = _build_package_reverse_graph()
+        violations: dict[str, dict[str, list[str]]] = {}
+        for pkg, declared in LAYER_CASCADE_CONSERVATIVE.items():
+            actual_all = graph.get(pkg, set())
+            # Exclude standalone test-file values (entries like "test_smoke_utils.py")
+            actual_pkgs = {c for c in actual_all if not c.endswith(".py")}
+            missing = actual_pkgs - declared
+            if missing:
+                violations[pkg] = {
+                    "declared": sorted(declared),
+                    "actual": sorted(actual_pkgs),
+                    "missing": sorted(missing),
+                }
+        assert not violations, (
+            "LAYER_CASCADE_CONSERVATIVE entries are too narrow — update tests/_test_filter.py:\n"
+            + "\n".join(f"  {pkg}: add {v['missing']}" for pkg, v in sorted(violations.items()))
+        )
+
+
+class TestUnmappedPackageGuard:
+    """REQ-GUARD-003: Every package found in src/ must be a key in LAYER_CASCADE_CONSERVATIVE."""
+
+    def test_no_src_package_missing_from_conservative_cascade(self) -> None:
+        all_files = _all_src_files()
+        src_packages = {
+            pkg
+            for f in all_files
+            if (pkg := _file_to_package(str(f))) is not None
+            and pkg not in _AUTOSKILLIT_DUNDER_STEMS
+        }
+        missing = src_packages - set(LAYER_CASCADE_CONSERVATIVE.keys())
+        assert not missing, (
+            "New packages found in src/autoskillit/ with no LAYER_CASCADE_CONSERVATIVE entry.\n"
+            f"  Unmapped: {sorted(missing)}\n"
+            "Add an entry for each to LAYER_CASCADE_CONSERVATIVE in tests/_test_filter.py."
+        )

--- a/tests/test_test_filter_core_cascade.py
+++ b/tests/test_test_filter_core_cascade.py
@@ -48,7 +48,7 @@ class TestModuleCascadeCore:
             assert "core" in consumers, f"{stem} cascade missing 'core'"
 
     def test_kitchen_state_cascade(self) -> None:
-        assert MODULE_CASCADE_CORE["kitchen_state"] == frozenset({"core", "cli"})
+        assert MODULE_CASCADE_CORE["kitchen_state"] == frozenset({"core", "cli", "server"})
 
     def test_readiness_cascade(self) -> None:
         assert MODULE_CASCADE_CORE["readiness"] == frozenset({"core", "server"})
@@ -154,7 +154,7 @@ class TestBuildTestScopeCoreCascade:
             assert pkg in dir_names
 
     def test_kitchen_state_narrow_cascade(self, tmp_path: Path) -> None:
-        """kitchen_state.py → only {core, cli} + always-run."""
+        """kitchen_state.py → only {core, cli, server} + always-run."""
         tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
         result = build_test_scope(
             changed_files={"src/autoskillit/core/kitchen_state.py"},
@@ -165,6 +165,7 @@ class TestBuildTestScopeCoreCascade:
         dir_names = {p.name for p in result}
         assert "core" in dir_names
         assert "cli" in dir_names
+        assert "server" in dir_names
         # Must NOT include packages kitchen_state doesn't touch
         for excluded in [
             "execution",
@@ -172,7 +173,6 @@ class TestBuildTestScopeCoreCascade:
             "workspace",
             "recipe",
             "migration",
-            "server",
             "hooks",
         ]:
             assert excluded not in dir_names, (


### PR DESCRIPTION
## Summary

Add `tests/arch/test_cascade_map_guard.py` — an AST-based architecture guard that auto-generates a reverse import graph from `src/autoskillit/**/*.py` and validates that `MODULE_CASCADE_CORE` and `LAYER_CASCADE_CONSERVATIVE` in `tests/_test_filter.py` are supersets of actual AST-derived consumer relationships. Prevents silent cascade-map staleness from narrowing the diff-aware test filter.

Three guard classes cover all four requirements:
- **REQ-GUARD-001**: Two graph builders (`_build_package_reverse_graph`, `_build_module_reverse_graph`) with re-export awareness via `_build_core_reexport_map`.
- **REQ-GUARD-002**: `TestModuleCascadeCoreGuard` — superset check on `MODULE_CASCADE_CORE` values.
- **REQ-GUARD-003**: `TestUnmappedPackageGuard` — key-completeness check on `LAYER_CASCADE_CONSERVATIVE`.
- **REQ-GUARD-004**: File placed in `tests/arch/`.

## Requirements

### REQ-GUARD-001: Auto-generate reverse import graph from AST

Write a helper that:
1. AST-parses all `src/autoskillit/**/*.py` files
2. Extracts `from autoskillit.X import Y` and `from autoskillit.X.Y import Z` statements
3. Builds a reverse map: `{source_module -> set of consuming_packages}`
4. Handles both direct imports and re-exports via `__init__.py`

### REQ-GUARD-002: Assert cascade maps are supersets

For each entry in `MODULE_CASCADE_CORE`:
- The declared cascade set must be a superset of the AST-derived consumer set
- If a cascade entry is too narrow (missing a consumer), the test fails with a diff showing the missing packages

For each entry in `LAYER_CASCADE_CONSERVATIVE`:
- Verify no new packages exist in `src/autoskillit/` that are missing from the cascade map entirely

### REQ-GUARD-003: Detect unmapped packages

Assert that every unique return value of `_file_to_package(f)` for all `src/autoskillit/**/*.py` files exists as a key in `LAYER_CASCADE_CONSERVATIVE`. This catches the class of bug where a new package is added without a cascade entry.

### REQ-GUARD-004: Place test in `tests/arch/`

This is an architectural invariant test. It should be in `tests/arch/` with the other structural guards.

## Architecture Impact

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 55, 'rankSpacing': 75, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph L3_Guard ["L3 — ARCH GUARD TESTS (tests/arch/)"]
        direction LR
        GUARD["★ test_cascade_map_guard.py<br/>━━━━━━━━━━<br/>REQ-GUARD-001..003<br/>AST reverse-import validation<br/>mark: layer('arch'), small"]
    end

    subgraph L2_Consumers ["L2 — TEST CONSUMERS"]
        direction LR
        SCOPE["● test_test_filter_scope_extras.py<br/>━━━━━━━━━━<br/>FilterMode + build_test_scope<br/>coverage: scope resolution paths"]
        CONFTEST["tests/arch/conftest.py<br/>━━━━━━━━━━<br/>pytest_collection_modifyitems hook<br/>git_changed_files → deselect_arch_items"]
    end

    subgraph L1_Hub ["L1 — TEST UTILITY HUB (tests/_test_filter.py) ●"]
        direction TB
        MAPS["● Cascade Map Constants<br/>━━━━━━━━━━<br/>MODULE_CASCADE_CORE<br/>LAYER_CASCADE_CONSERVATIVE<br/>LAYER_CASCADE_AGGRESSIVE"]
        SCOPE_FN["● Filter Engine<br/>━━━━━━━━━━<br/>build_test_scope()<br/>FilterMode StrEnum<br/>git_changed_files()<br/>_file_to_package()"]
    end

    subgraph L0_Source ["L0 — PRODUCTION SOURCE (AST-scanned, not imported)"]
        direction LR
        SRC["src/autoskillit/<br/>━━━━━━━━━━<br/>core/ config/ pipeline/<br/>execution/ recipe/ server/<br/>cli/ fleet/ migration/"]
    end

    subgraph L0_Ext ["L0 — EXTERNAL DEPENDENCIES"]
        direction LR
        PATHSPEC["pathspec<br/>━━━━━━━━━━<br/>gitignore-style<br/>pattern matching"]
        YAML["yaml (PyYAML)<br/>━━━━━━━━━━<br/>manifest loading<br/>(deferred import)"]
        STDLIB["stdlib<br/>━━━━━━━━━━<br/>ast, enum, re, subprocess<br/>pathlib, fnmatch, json"]
    end

    %% GUARD TEST IMPORTS %%
    GUARD -->|"imports: MODULE_CASCADE_CORE<br/>LAYER_CASCADE_CONSERVATIVE<br/>_file_to_package"| MAPS
    GUARD -->|"imports: _file_to_package"| SCOPE_FN

    %% SCOPE TEST IMPORTS %%
    SCOPE -->|"imports: FilterMode<br/>build_test_scope"| SCOPE_FN

    %% CONFTEST IMPORTS %%
    CONFTEST -->|"imports: git_changed_files"| SCOPE_FN

    %% GUARD AST-SCANS SRC (no Python import) %%
    GUARD -.->|"AST-scans at runtime<br/>(no Python import)"| SRC

    %% HUB EXTERNAL DEPS %%
    SCOPE_FN --> PATHSPEC
    SCOPE_FN --> YAML
    MAPS --> STDLIB
    SCOPE_FN --> STDLIB

    %% CLASS ASSIGNMENTS %%
    class GUARD newComponent;
    class SCOPE,CONFTEST phase;
    class MAPS stateNode;
    class SCOPE_FN handler;
    class SRC output;
    class PATHSPEC,YAML,STDLIB integration;
```

### Scenarios Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ─── SCENARIO 1: Cascade Map Staleness Detection ─── %%
    subgraph S1 ["SCENARIO 1 · Cascade Map Staleness Detection (REQ-GUARD-002)"]
        direction LR
        S1_SRC["src/autoskillit/**/*.py<br/>━━━━━━━━━━<br/>New import added<br/>to source file"]
        S1_AST["★ _build_module_reverse_graph()<br/>━━━━━━━━━━<br/>AST-parses every src file<br/>builds actual consumer set"]
        S1_CORE["★ _build_core_reexport_map()<br/>━━━━━━━━━━<br/>Resolves core/__init__.py<br/>re-export aliases"]
        S1_MAP["● MODULE_CASCADE_CORE<br/>━━━━━━━━━━<br/>Declared stem→consumers<br/>in tests/_test_filter.py"]
        S1_CMP["★ TestModuleCascadeCoreGuard<br/>━━━━━━━━━━<br/>declared ⊇ actual?<br/>superset assertion"]
        S1_FAIL["Guard FAILS<br/>━━━━━━━━━━<br/>Diff output: add pkg<br/>to MODULE_CASCADE_CORE"]
        S1_PASS["Guard PASSES<br/>━━━━━━━━━━<br/>Map is correct<br/>No drift"]
    end

    S1_SRC -->|"reads all .py"| S1_AST
    S1_AST -->|"resolves aliases via"| S1_CORE
    S1_CORE -->|"actual graph"| S1_CMP
    S1_MAP -->|"declared set"| S1_CMP
    S1_CMP -->|"underdeclared"| S1_FAIL
    S1_CMP -->|"superset OK"| S1_PASS

    %% ─── SCENARIO 2: Conservative Test Scope Resolution ─── %%
    subgraph S2 ["SCENARIO 2 · Conservative Test Scope Resolution (Happy Path)"]
        direction LR
        S2_GIT["git diff --name-only<br/>━━━━━━━━━━<br/>Changed files from<br/>merge-base"]
        S2_BKT["check_bucket_a_content_aware()<br/>━━━━━━━━━━<br/>Global-impact files<br/>→ full run guard"]
        S2_PKG["_file_to_package()<br/>━━━━━━━━━━<br/>src/autoskillit/X.py<br/>→ package name"]
        S2_CORE_CHK{"core submodule?"}
        S2_MOD["● MODULE_CASCADE_CORE<br/>━━━━━━━━━━<br/>Narrow stem lookup<br/>→ affected packages"]
        S2_LAYER["● LAYER_CASCADE_CONSERVATIVE<br/>━━━━━━━━━━<br/>Package lookup<br/>→ test directories"]
        S2_ALWAYS["_ALWAYS_RUN_CONSERVATIVE<br/>━━━━━━━━━━<br/>arch + contracts<br/>always appended"]
        S2_SCOPE["build_test_scope() result<br/>━━━━━━━━━━<br/>set[Path] of dirs<br/>to run"]
        S2_CONF["conftest.py<br/>pytest_collection_modifyitems<br/>━━━━━━━━━━<br/>Deselects tests<br/>outside scope"]
    end

    S2_GIT -->|"changed files set"| S2_BKT
    S2_BKT -->|"not Bucket A"| S2_PKG
    S2_PKG -->|"package = 'core'"| S2_CORE_CHK
    S2_CORE_CHK -->|"yes: narrow stem"| S2_MOD
    S2_CORE_CHK -->|"no: package-level"| S2_LAYER
    S2_MOD -->|"consumers → cascade"| S2_LAYER
    S2_LAYER -->|"dirs set"| S2_SCOPE
    S2_ALWAYS -->|"merged in"| S2_SCOPE
    S2_SCOPE -->|"filters collection"| S2_CONF

    %% ─── SCENARIO 3: Phantom Stem Detection ─── %%
    subgraph S3 ["SCENARIO 3 · Phantom Stem Detection (REQ-GUARD-002 + stale entry)"]
        direction LR
        S3_DEL["Developer renames<br/>or deletes<br/>core/{stem}.py"]
        S3_AST2["★ _build_module_reverse_graph()<br/>━━━━━━━━━━<br/>Rebuilt AST graph<br/>stem has 0 consumers"]
        S3_MAP2["● MODULE_CASCADE_CORE<br/>━━━━━━━━━━<br/>Stale stem entry<br/>still present"]
        S3_PHANTOM["★ test_module_cascade_core_has_no_phantom_stems<br/>━━━━━━━━━━<br/>stem in map<br/>but graph[stem] = ∅"]
        S3_FAIL2["Guard FAILS<br/>━━━━━━━━━━<br/>Remove stale stem<br/>from MODULE_CASCADE_CORE"]
    end

    S3_DEL -->|"graph no longer has stem"| S3_AST2
    S3_AST2 -->|"∅ consumers"| S3_PHANTOM
    S3_MAP2 -->|"declared non-empty set"| S3_PHANTOM
    S3_PHANTOM -->|"phantom detected"| S3_FAIL2

    %% ─── SCENARIO 4: Manifest-Driven Non-Python Routing ─── %%
    subgraph S4 ["SCENARIO 4 · Manifest Non-Python Routing (AC3 + AC4)"]
        direction LR
        S4_FILE["Non-Python file changed<br/>━━━━━━━━━━<br/>e.g. some/config.json<br/>skills_extended/foo/SKILL.md"]
        S4_MAN["test-filter-manifest.yaml<br/>━━━━━━━━━━<br/>pathspec gitwildmatch<br/>patterns → test dirs"]
        S4_APPLY["● apply_manifest()<br/>━━━━━━━━━━<br/>Match changed file<br/>to pattern entries"]
        S4_FILE_ENT["● File-level entries<br/>━━━━━━━━━━<br/>Manifest value points<br/>to test_version.py (AC3)"]
        S4_DIR_ENT["Directory entries<br/>━━━━━━━━━━<br/>Manifest value points<br/>to skills_extended/ (AC4)"]
        S4_SCOPE2["Resolved scope<br/>━━━━━━━━━━<br/>is_file() + is_dir()<br/>both accepted"]
        S4_NONE["fail-open → None<br/>━━━━━━━━━━<br/>Unmatched file<br/>→ full run"]
    end

    S4_FILE -->|"pattern match"| S4_APPLY
    S4_MAN -->|"reads patterns"| S4_APPLY
    S4_APPLY -->|"file entry matched (AC3)"| S4_FILE_ENT
    S4_APPLY -->|"dir entry matched (AC4)"| S4_DIR_ENT
    S4_APPLY -->|"no match"| S4_NONE
    S4_FILE_ENT -->|"is_file() → include"| S4_SCOPE2
    S4_DIR_ENT -->|"is_dir() → include"| S4_SCOPE2

    %% ─── SCENARIO 5: Unmapped Package Detection ─── %%
    subgraph S5 ["SCENARIO 5 · Unmapped Package Detection (REQ-GUARD-003)"]
        direction LR
        S5_NEW["New package added<br/>━━━━━━━━━━<br/>src/autoskillit/new_pkg/__init__.py"]
        S5_GLOB["★ _all_src_files()<br/>━━━━━━━━━━<br/>Globs all .py under<br/>src/autoskillit/"]
        S5_PKG2["★ _file_to_package()<br/>━━━━━━━━━━<br/>Extracts package names<br/>from all paths"]
        S5_CHECK["★ TestUnmappedPackageGuard<br/>━━━━━━━━━━<br/>Every pkg must be a key<br/>in LAYER_CASCADE_CONSERVATIVE"]
        S5_LAYER2["● LAYER_CASCADE_CONSERVATIVE<br/>━━━━━━━━━━<br/>Checked for key existence<br/>new_pkg missing"]
        S5_FAIL3["Guard FAILS<br/>━━━━━━━━━━<br/>Add new_pkg entry<br/>to LAYER_CASCADE_CONSERVATIVE"]
    end

    S5_NEW -->|"discovered by glob"| S5_GLOB
    S5_GLOB -->|"all src paths"| S5_PKG2
    S5_PKG2 -->|"pkg names set"| S5_CHECK
    S5_LAYER2 -->|"key lookup"| S5_CHECK
    S5_CHECK -->|"pkg not a key"| S5_FAIL3

    %% CLASS ASSIGNMENTS %%
    class S1_SRC,S2_GIT,S3_DEL,S4_FILE,S5_NEW cli;
    class S1_MAP,S2_LAYER,S2_ALWAYS,S3_MAP2,S4_MAN,S5_LAYER2 stateNode;
    class S1_AST,S1_CORE,S2_PKG,S2_BKT,S3_AST2,S4_APPLY,S5_GLOB,S5_PKG2 phase;
    class S2_CORE_CHK phase;
    class S2_MOD,S4_FILE_ENT,S4_DIR_ENT handler;
    class S1_CMP,S3_PHANTOM,S2_CONF,S5_CHECK detector;
    class S1_PASS,S2_SCOPE,S4_SCOPE2 output;
    class S1_FAIL,S3_FAIL2,S4_NONE,S5_FAIL3 gap;
    class S1_CMP,S3_PHANTOM,S1_AST,S1_CORE,S3_AST2,S5_CHECK,S5_GLOB,S5_PKG2 newComponent;
```

### Data Lineage Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
flowchart LR
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph Origins ["Data Origins"]
        SRC["src/autoskillit/**/*.py<br/>━━━━━━━━━━<br/>~60 source files<br/>Python AST"]
        MANIFEST[".autoskillit/<br/>test-filter-manifest.yaml<br/>━━━━━━━━━━<br/>glob → test-dirs<br/>YAML"]
        COV_MAP[".autoskillit/<br/>test-source-map.json<br/>━━━━━━━━━━<br/>src path → test files<br/>JSON"]
        GIT["git subprocess<br/>━━━━━━━━━━<br/>git diff / merge-base<br/>changed_files: set[str]"]
    end

    subgraph CascadeMaps ["● Cascade Maps (tests/_test_filter.py)"]
        direction TB
        MOD_CORE["● MODULE_CASCADE_CORE<br/>━━━━━━━━━━<br/>13 core stems<br/>→ frozenset[consumers]"]
        LAYER_CONS["● LAYER_CASCADE_CONSERVATIVE<br/>━━━━━━━━━━<br/>19 packages<br/>→ frozenset[test-dirs]"]
        LAYER_AGG["LAYER_CASCADE_AGGRESSIVE<br/>━━━━━━━━━━<br/>19 packages<br/>→ frozenset (tight)"]
    end

    subgraph ASTAnalysis ["★ AST Guard Analysis (test_cascade_map_guard.py)"]
        direction TB
        MOD_GRAPH["★ _build_module_reverse_graph<br/>━━━━━━━━━━<br/>core stem → actual consumers<br/>from AST imports"]
        PKG_GRAPH["★ _build_package_reverse_graph<br/>━━━━━━━━━━<br/>package → actual consumers<br/>from AST imports"]
        FILE_PKG["_file_to_package()<br/>━━━━━━━━━━<br/>file path → pkg name"]
    end

    subgraph ScopeEngine ["Scope Resolution (build_test_scope)"]
        BUCKET_A{"Bucket A<br/>full-run trigger?"}
        CLASSIFY["Classify changed files<br/>━━━━━━━━━━<br/>src/.py → cascade lookup<br/>non-.py → manifest match"]
        REEXPORT["Reexport closure<br/>━━━━━━━━━━<br/>AST scan __init__.py<br/>re-exports"]
        ALWAYS_RUN["Always-run additions<br/>━━━━━━━━━━<br/>arch / contracts / infra<br/>(REQ-TIER-001..003)"]
    end

    subgraph ScopeExtras ["● test_test_filter_scope_extras.py"]
        TMP["tmp_path<br/>━━━━━━━━━━<br/>synthetic filesystem<br/>(pytest fixture)"]
        AC3["● test_file_entries_from_manifest<br/>━━━━━━━━━━<br/>bare filename in manifest<br/>→ resolves to Path (AC3)"]
        AC4["● test_skills_extended_manifest<br/>━━━━━━━━━━<br/>SKILL.md change<br/>→ skills_extended/ in scope (AC4)"]
    end

    subgraph Outputs ["Outputs"]
        SCOPE_OUT["set[Path]<br/>━━━━━━━━━━<br/>pytest test scope<br/>passed to runner"]
        FULL_RUN["None — full run<br/>━━━━━━━━━━<br/>all tests executed"]
        GUARD_PASS["Guard: PASS<br/>━━━━━━━━━━<br/>maps consistent<br/>with AST"]
        GUARD_FAIL["Guard: FAIL<br/>━━━━━━━━━━<br/>stale map detected<br/>→ update _test_filter.py"]
    end

    %% Origins → AST Guard
    SRC -->|"rglob *.py"| MOD_GRAPH
    SRC -->|"rglob *.py"| PKG_GRAPH
    SRC -->|"rglob *.py"| FILE_PKG
    SRC -->|"AST scan __init__"| REEXPORT

    %% Origins → Scope Engine
    GIT -->|"changed_files"| BUCKET_A
    GIT -->|"changed_files"| CLASSIFY
    MANIFEST -->|"load_manifest()"| CLASSIFY
    COV_MAP -.->|"aggressive mode only"| CLASSIFY

    %% Cascade Maps → Guard (validation path)
    MOD_CORE -->|"declared consumers"| MOD_GRAPH
    LAYER_CONS -->|"declared consumers"| PKG_GRAPH
    LAYER_CONS -->|"declared packages"| FILE_PKG

    %% Cascade Maps → Scope Engine (runtime path)
    MOD_CORE -->|"core module routing"| CLASSIFY
    LAYER_CONS -->|"conservative cascade"| CLASSIFY
    LAYER_AGG -->|"aggressive cascade"| CLASSIFY

    %% Scope Engine flow
    BUCKET_A -->|"yes → None"| FULL_RUN
    BUCKET_A -->|"no"| CLASSIFY
    CLASSIFY -->|"src changes"| REEXPORT
    CLASSIFY -->|"merged dirs"| ALWAYS_RUN
    REEXPORT -->|"expanded set"| ALWAYS_RUN
    ALWAYS_RUN -->|"set[Path]"| SCOPE_OUT

    %% Guard outputs
    MOD_GRAPH -->|"superset OK"| GUARD_PASS
    MOD_GRAPH -->|"narrowing detected"| GUARD_FAIL
    PKG_GRAPH -->|"superset OK"| GUARD_PASS
    PKG_GRAPH -->|"narrowing detected"| GUARD_FAIL
    FILE_PKG -->|"all pkgs mapped"| GUARD_PASS
    FILE_PKG -->|"new pkg missing"| GUARD_FAIL

    %% Scope extras tests
    TMP -->|"synthetic FS"| AC3
    TMP -->|"synthetic FS"| AC4
    MANIFEST -.->|"synthetic manifest dict"| AC3
    MANIFEST -.->|"synthetic manifest dict"| AC4
    AC3 -->|"assert scope contains"| SCOPE_OUT
    AC4 -->|"assert scope contains"| SCOPE_OUT

    %% Class assignments
    class SRC,GIT cli;
    class MANIFEST,COV_MAP stateNode;
    class MOD_CORE,LAYER_CONS,LAYER_AGG stateNode;
    class MOD_GRAPH,PKG_GRAPH,FILE_PKG newComponent;
    class BUCKET_A,CLASSIFY,REEXPORT phase;
    class ALWAYS_RUN handler;
    class TMP cli;
    class AC3,AC4 handler;
    class SCOPE_OUT,FULL_RUN,GUARD_PASS output;
    class GUARD_FAIL detector;
```

Closes #1221

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260425-053451-991728/.autoskillit/temp/make-plan/ci_guard_cascade_map_module_cascade_core_drift_plan_2026-04-25_124224.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 139 | 20.1k | 624.4k | 50.0k | 1 | 9m 1s |
| verify | 172 | 27.5k | 1.3M | 72.5k | 1 | 9m 17s |
| implement | 188 | 9.0k | 979.6k | 46.0k | 1 | 4m 4s |
| fix | 198 | 14.7k | 1.2M | 56.7k | 1 | 5m 24s |
| prepare_pr | 68 | 5.1k | 221.2k | 26.0k | 1 | 1m 49s |
| run_arch_lenses | 3.1k | 22.2k | 578.8k | 160.1k | 3 | 10m 1s |
| compose_pr | 67 | 9.2k | 261.0k | 36.3k | 1 | 3m 11s |
| **Total** | 3.9k | 107.7k | 5.1M | 447.5k | | 42m 50s |