### PR TITLE
fix: switch quota guard sleep 
  from run_cmd to asyncio.sleep (#1222)

### DIFF
--- a/src/autoskillit/recipes/planner.yaml
+++ b/src/autoskillit/recipes/planner.yaml
@@ -1,5 +1,5 @@
 name: planner
-autoskillit_version: "0.9.145"
+autoskillit_version: "0.9.146"
 recipe_version: "1"
 description: |
   Progressive decomposition pipeline. Analyzes a codebase, generates phases, elaborates

--- a/src/autoskillit/server/tools_execution.py
+++ b/src/autoskillit/server/tools_execution.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
+import re
 import time
 from pathlib import Path
 
@@ -33,6 +35,11 @@ from autoskillit.server.helpers import (
 )
 
 logger = get_logger(__name__)
+
+_PURE_SLEEP_RE = re.compile(
+    r'^(?:python3?\s+-c\s+["\']import time;\s*time\.sleep\((\d+(?:\.\d+)?)\)["\']'
+    r"|sleep\s+(\d+(?:\.\d+)?))$"
+)
 
 
 def _is_absolute_path(path: str) -> bool:
@@ -76,6 +83,11 @@ async def run_cmd(
         tool_ctx = _get_ctx()
         _start = time.monotonic()
         try:
+            m = _PURE_SLEEP_RE.match(cmd.strip())
+            if m:
+                seconds = float(m.group(1) or m.group(2))
+                await asyncio.sleep(seconds)
+                return json.dumps({"success": True, "exit_code": 0, "stdout": "", "stderr": ""})
             _env: dict[str, str] | None = (
                 {**os.environ, SCENARIO_STEP_NAME_ENV: step_name} if step_name else None
             )

--- a/src/autoskillit/server/tools_execution.py
+++ b/src/autoskillit/server/tools_execution.py
@@ -37,8 +37,8 @@ from autoskillit.server.helpers import (
 logger = get_logger(__name__)
 
 _PURE_SLEEP_RE = re.compile(
-    r'^(?:python3?\s+-c\s+["\']import time;\s*time\.sleep\((\d+(?:\.\d+)?)\)["\']'
-    r"|sleep\s+(\d+(?:\.\d+)?))$"
+    r'^(?:python3?\s+-c\s+["\']import time;\s*time\.sleep\((?P<py_secs>\d+(?:\.\d+)?)\)["\']'
+    r"|sleep\s+(?P<sh_secs>\d+(?:\.\d+)?))$"
 )
 
 
@@ -85,7 +85,7 @@ async def run_cmd(
         try:
             m = _PURE_SLEEP_RE.match(cmd.strip())
             if m:
-                seconds = float(m.group(1) or m.group(2))
+                seconds = float(m.group("py_secs") or m.group("sh_secs"))
                 await asyncio.sleep(seconds)
                 return json.dumps({"success": True, "exit_code": 0, "stdout": "", "stderr": ""})
             _env: dict[str, str] | None = (

--- a/tests/server/test_tools_run_cmd.py
+++ b/tests/server/test_tools_run_cmd.py
@@ -252,4 +252,5 @@ class TestRunCmdSleepInterception:
     @pytest.mark.anyio
     async def test_step_name_timing_recorded(self, tool_ctx):
         await run_cmd(cmd="sleep 0", cwd="/tmp", step_name="quota_wait")
+        assert len(tool_ctx.runner.call_args_list) == 0
         assert any(e["step_name"] == "quota_wait" for e in tool_ctx.timing_log.get_report())

--- a/tests/server/test_tools_run_cmd.py
+++ b/tests/server/test_tools_run_cmd.py
@@ -40,7 +40,7 @@ class TestRunCmd:
     @pytest.mark.anyio
     async def test_custom_timeout(self, tool_ctx):
         tool_ctx.runner.push(_make_result(0, "", ""))
-        await run_cmd(cmd="sleep 1", cwd="/tmp", timeout=30)
+        await run_cmd(cmd="echo timeout_test", cwd="/tmp", timeout=30)
 
         assert tool_ctx.runner.call_args_list[-1][2] == 30.0
 
@@ -201,3 +201,55 @@ class TestRunPython:
         assert any("timed out" in log.get("event", "").lower() for log in logs), (
             f"Expected 'timed out' in warning event, got: {logs}"
         )
+
+
+class TestRunCmdSleepInterception:
+    """Sleep commands are intercepted and converted to asyncio.sleep."""
+
+    @pytest.mark.anyio
+    async def test_python_sleep_intercepted(self, tool_ctx):
+        result = json.loads(
+            await run_cmd(cmd='python3 -c "import time; time.sleep(60)"', cwd="/tmp")
+        )
+        assert result == {"success": True, "exit_code": 0, "stdout": "", "stderr": ""}
+        assert len(tool_ctx.runner.call_args_list) == 0
+
+    @pytest.mark.anyio
+    async def test_bare_sleep_intercepted(self, tool_ctx):
+        result = json.loads(await run_cmd(cmd="sleep 300", cwd="/tmp"))
+        assert result["success"] is True
+        assert len(tool_ctx.runner.call_args_list) == 0
+
+    @pytest.mark.anyio
+    async def test_python3_single_quotes_intercepted(self, tool_ctx):
+        result = json.loads(
+            await run_cmd(cmd="python3 -c 'import time; time.sleep(120)'", cwd="/tmp")
+        )
+        assert result["success"] is True
+        assert len(tool_ctx.runner.call_args_list) == 0
+
+    @pytest.mark.anyio
+    async def test_non_sleep_uses_subprocess(self, tool_ctx):
+        tool_ctx.runner.push(_make_result(0, "hello", ""))
+        await run_cmd(cmd="echo hello", cwd="/tmp")
+        assert len(tool_ctx.runner.call_args_list) == 1
+        assert tool_ctx.runner.call_args_list[0][0] == ["bash", "-c", "echo hello"]
+
+    @pytest.mark.anyio
+    async def test_decimal_seconds_intercepted(self, tool_ctx):
+        result = json.loads(
+            await run_cmd(cmd='python3 -c "import time; time.sleep(60.5)"', cwd="/tmp")
+        )
+        assert result["success"] is True
+        assert len(tool_ctx.runner.call_args_list) == 0
+
+    @pytest.mark.anyio
+    async def test_compound_sleep_not_intercepted(self, tool_ctx):
+        tool_ctx.runner.push(_make_result(0, "", ""))
+        await run_cmd(cmd="echo before && sleep 10 && echo after", cwd="/tmp")
+        assert len(tool_ctx.runner.call_args_list) == 1
+
+    @pytest.mark.anyio
+    async def test_step_name_timing_recorded(self, tool_ctx):
+        await run_cmd(cmd="sleep 0", cwd="/tmp", step_name="quota_wait")
+        assert any(e["step_name"] == "quota_wait" for e in tool_ctx.timing_log.get_report())

--- a/tests/server/test_tools_run_cmd.py
+++ b/tests/server/test_tools_run_cmd.py
@@ -209,21 +209,21 @@ class TestRunCmdSleepInterception:
     @pytest.mark.anyio
     async def test_python_sleep_intercepted(self, tool_ctx):
         result = json.loads(
-            await run_cmd(cmd='python3 -c "import time; time.sleep(60)"', cwd="/tmp")
+            await run_cmd(cmd='python3 -c "import time; time.sleep(0)"', cwd="/tmp")
         )
         assert result == {"success": True, "exit_code": 0, "stdout": "", "stderr": ""}
         assert len(tool_ctx.runner.call_args_list) == 0
 
     @pytest.mark.anyio
     async def test_bare_sleep_intercepted(self, tool_ctx):
-        result = json.loads(await run_cmd(cmd="sleep 300", cwd="/tmp"))
+        result = json.loads(await run_cmd(cmd="sleep 0", cwd="/tmp"))
         assert result["success"] is True
         assert len(tool_ctx.runner.call_args_list) == 0
 
     @pytest.mark.anyio
     async def test_python3_single_quotes_intercepted(self, tool_ctx):
         result = json.loads(
-            await run_cmd(cmd="python3 -c 'import time; time.sleep(120)'", cwd="/tmp")
+            await run_cmd(cmd="python3 -c 'import time; time.sleep(0)'", cwd="/tmp")
         )
         assert result["success"] is True
         assert len(tool_ctx.runner.call_args_list) == 0
@@ -238,7 +238,7 @@ class TestRunCmdSleepInterception:
     @pytest.mark.anyio
     async def test_decimal_seconds_intercepted(self, tool_ctx):
         result = json.loads(
-            await run_cmd(cmd='python3 -c "import time; time.sleep(60.5)"', cwd="/tmp")
+            await run_cmd(cmd='python3 -c "import time; time.sleep(0.5)"', cwd="/tmp")
         )
         assert result["success"] is True
         assert len(tool_ctx.runner.call_args_list) == 0

--- a/tests/server/test_tools_run_cmd.py
+++ b/tests/server/test_tools_run_cmd.py
@@ -238,7 +238,7 @@ class TestRunCmdSleepInterception:
     @pytest.mark.anyio
     async def test_decimal_seconds_intercepted(self, tool_ctx):
         result = json.loads(
-            await run_cmd(cmd='python3 -c "import time; time.sleep(0.5)"', cwd="/tmp")
+            await run_cmd(cmd='python3 -c "import time; time.sleep(0.0)"', cwd="/tmp")
         )
         assert result["success"] is True
         assert len(tool_ctx.runner.call_args_list) == 0


### PR DESCRIPTION
Intercepts pure-sleep commands in run_cmd and converts to asyncio.sleep(). Prevents MCP disconnect on ESC during quota waits. Closes #1222