### PR TITLE
fix: close feature gate gaps for run_python callables and sprint-planner skill

### DIFF
--- a/src/autoskillit/recipe/rules_features.py
+++ b/src/autoskillit/recipe/rules_features.py
@@ -78,7 +78,6 @@ def check_feature_gated_tools(ctx: ValidationContext) -> list[RuleFinding]:
                     )
                 )
 
-            # --- run_python callable check ---
             if (
                 step.tool == "run_python"
                 and fdef.import_package is not None

--- a/src/autoskillit/recipe/rules_features.py
+++ b/src/autoskillit/recipe/rules_features.py
@@ -78,6 +78,27 @@ def check_feature_gated_tools(ctx: ValidationContext) -> list[RuleFinding]:
                     )
                 )
 
+            # --- run_python callable check ---
+            if (
+                step.tool == "run_python"
+                and fdef.import_package is not None
+                and (step.with_args or {}).get("callable", "").startswith(fdef.import_package)
+            ):
+                findings.append(
+                    RuleFinding(
+                        rule="feature-gate-tool-reference",
+                        severity=Severity.ERROR,
+                        step_name=step_name,
+                        message=(
+                            f"step '{step_name}': run_python callable "
+                            f"'{(step.with_args or {}).get('callable', '')}' "
+                            f"belongs to disabled feature '{fdef.name}'. "
+                            f"Enable '{fdef.name}' in .autoskillit/config.yaml "
+                            f"features to use this callable."
+                        ),
+                    )
+                )
+
             # --- Skill check (only when the feature gates skill categories) ---
             if step.tool not in SKILL_TOOLS or not fdef.skill_categories:
                 continue

--- a/src/autoskillit/recipes/planner.yaml
+++ b/src/autoskillit/recipes/planner.yaml
@@ -1,5 +1,5 @@
 name: planner
-autoskillit_version: "0.9.148"
+autoskillit_version: "0.9.149"
 recipe_version: "1"
 description: |
   Progressive decomposition pipeline. Analyzes a codebase, generates phases, elaborates

--- a/src/autoskillit/skills_extended/sprint-planner/SKILL.md
+++ b/src/autoskillit/skills_extended/sprint-planner/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: sprint-planner
 description: Select a focused, conflict-free sprint from an existing triage manifest. Use when orchestrating a sprint planning step that needs issue overlap analysis and sprint manifest production.
+categories: [planner]
 hooks:
   PreToolUse:
     - matcher: "*"

--- a/tests/execution/test_process_channel_b.py
+++ b/tests/execution/test_process_channel_b.py
@@ -222,6 +222,9 @@ class TestChannelBDrainWait:
         drain wait times out — i.e. Channel A never confirmed stdout data.
         _phase1_timeout=120: must exceed outer timeout (60s) to prevent Phase 1 from
         firing STALE before the outer guard when subprocess startup is slow under load.
+        natural_exit_grace_seconds=0.1: script never exits naturally (time.sleep(3600)),
+        so shorten grace window to reduce total test time and avoid asyncio-waitpid
+        thread contention under CI load (default 3.0s grace + 3.0s kill = 6s total).
         """
         session_dir = tmp_path / "session"
         session_dir.mkdir()
@@ -235,6 +238,7 @@ class TestChannelBDrainWait:
             session_log_dir=session_dir,
             completion_marker="%%ORDER_UP%%",
             completion_drain_timeout=0.1,
+            natural_exit_grace_seconds=0.1,
             _phase1_poll=0.01,
             _phase2_poll=0.05,
             _session_id_timeout=0.01,

--- a/tests/recipe/test_rules_features.py
+++ b/tests/recipe/test_rules_features.py
@@ -151,3 +151,127 @@ def test_feature_gate_rule_with_multiple_features(monkeypatch) -> None:
     assert "fleet_step" in step_names, "fleet tool not flagged"
     assert "ci_step" in step_names, "ci tool not flagged"
     assert all(f.severity == Severity.ERROR for f in findings)
+
+
+def test_feature_gate_rule_fires_on_run_python_planner_callable() -> None:
+    """ERROR when run_python callable starts with planner import_package and planner disabled."""
+    from autoskillit.core import Severity
+    from autoskillit.recipe._analysis import make_validation_context
+    from autoskillit.recipe.registry import run_semantic_rules
+    from autoskillit.recipe.schema import Recipe, RecipeStep
+
+    recipe = Recipe(
+        name="r",
+        description="d",
+        version="0.2.0",
+        kitchen_rules="k",
+        steps={
+            "plan": RecipeStep(
+                tool="run_python",
+                with_args={"callable": "autoskillit.planner.validate_plan"},
+            )
+        },
+    )
+    ctx = make_validation_context(recipe, disabled_features=frozenset({"planner"}))
+    findings = [f for f in run_semantic_rules(ctx) if f.rule == "feature-gate-tool-reference"]
+    assert findings, "expected feature-gate-tool-reference finding for disabled planner callable"
+    assert all(f.severity == Severity.ERROR for f in findings)
+    assert any("planner" in f.message for f in findings)
+    assert any("plan" in f.step_name for f in findings)
+
+
+def test_feature_gate_rule_no_false_positive_run_python_non_feature_callable() -> None:
+    """No finding when run_python callable does not belong to any disabled feature."""
+    from autoskillit.recipe._analysis import make_validation_context
+    from autoskillit.recipe.registry import run_semantic_rules
+    from autoskillit.recipe.schema import Recipe, RecipeStep
+
+    recipe = Recipe(
+        name="r",
+        description="d",
+        version="0.2.0",
+        kitchen_rules="k",
+        steps={
+            "smoke": RecipeStep(
+                tool="run_python",
+                with_args={"callable": "autoskillit.smoke_utils.check_something"},
+            )
+        },
+    )
+    ctx = make_validation_context(recipe, disabled_features=frozenset({"planner"}))
+    findings = [f for f in run_semantic_rules(ctx) if f.rule == "feature-gate-tool-reference"]
+    assert not findings, f"unexpected finding for non-feature callable: {findings}"
+
+
+def test_feature_gate_rule_fires_on_sprint_planner_skill_when_planner_disabled() -> None:
+    """ERROR when recipe uses sprint-planner skill and planner feature is disabled."""
+    from autoskillit.core import Severity
+    from autoskillit.recipe._analysis import (
+        ValidationContext,
+        _build_step_graph,
+        analyze_dataflow,
+    )
+    from autoskillit.recipe.registry import run_semantic_rules
+    from autoskillit.recipe.schema import Recipe, RecipeStep
+
+    recipe = Recipe(
+        name="r",
+        description="d",
+        version="0.2.0",
+        kitchen_rules="k",
+        steps={
+            "plan": RecipeStep(
+                tool="run_skill",
+                with_args={"skill_command": "/autoskillit:sprint-planner"},
+            )
+        },
+    )
+    step_graph = _build_step_graph(recipe)
+    ctx = ValidationContext(
+        recipe=recipe,
+        step_graph=step_graph,
+        dataflow=analyze_dataflow(recipe, step_graph=step_graph),
+        disabled_features=frozenset({"planner"}),
+        skill_category_map={"sprint-planner": frozenset({"planner"})},
+    )
+    findings = [f for f in run_semantic_rules(ctx) if f.rule == "feature-gate-tool-reference"]
+    assert findings, (
+        "expected feature-gate-tool-reference for sprint-planner when planner disabled"
+    )
+    assert all(f.severity == Severity.ERROR for f in findings)
+    assert any("planner" in f.message for f in findings)
+
+
+def test_feature_gate_run_python_no_finding_when_fdef_has_no_import_package(monkeypatch) -> None:
+    """No false positive when feature has no import_package (import_package=None)."""
+    import autoskillit.core._type_constants as _consts
+    from autoskillit.core import FeatureDef, FeatureLifecycle
+    from autoskillit.recipe._analysis import make_validation_context
+    from autoskillit.recipe.registry import run_semantic_rules
+    from autoskillit.recipe.schema import Recipe, RecipeStep
+
+    no_pkg_fdef = FeatureDef(
+        name="no-pkg-feature",
+        lifecycle=FeatureLifecycle.EXPERIMENTAL,
+        description="Feature with no import_package",
+        tool_tags=frozenset(),
+        skill_categories=frozenset(),
+        import_package=None,
+    )
+    monkeypatch.setitem(_consts.FEATURE_REGISTRY, "no-pkg-feature", no_pkg_fdef)
+
+    recipe = Recipe(
+        name="r",
+        description="d",
+        version="0.2.0",
+        kitchen_rules="k",
+        steps={
+            "s": RecipeStep(
+                tool="run_python",
+                with_args={"callable": "autoskillit.planner.validate_plan"},
+            )
+        },
+    )
+    ctx = make_validation_context(recipe, disabled_features=frozenset({"no-pkg-feature"}))
+    findings = [f for f in run_semantic_rules(ctx) if f.rule == "feature-gate-tool-reference"]
+    assert not findings, f"unexpected finding when import_package is None: {findings}"


### PR DESCRIPTION
## Summary

Two structural gaps allowed planner code to execute when the `planner` feature is disabled. **Gap A**: `check_feature_gated_tools` in `rules_features.py` only checked `run_skill` steps for skill-category violations — a recipe step using `tool: run_python` with `callable: autoskillit.planner.*` bypassed both the tool-tag check and the skill-category check. **Gap B**: `sprint-planner/SKILL.md` had no `categories` frontmatter, so the skill-category gate resolved its categories to `frozenset()` and never fired.

The fix adds a `run_python` callable check branch to `check_feature_gated_tools` that matches callable prefixes against `fdef.import_package`, and adds `categories: [planner]` to `sprint-planner/SKILL.md` frontmatter.

## Requirements

- [ ] REQ-PFG-001: Extend `check_feature_gated_tools` in `rules_features.py` to check `run_python` steps — when `step.tool == "run_python"` and `step.with_args.get("callable", "")` starts with a feature's `import_package`, flag it if the feature is disabled
- [ ] REQ-PFG-002: Add `categories: [planner]` to `sprint-planner/SKILL.md` frontmatter (confirm intent — if sprint-planner is a general-purpose skill that happens to do planning, this may not be desired)
- [ ] REQ-PFG-003: Add test in `test_rules_features.py`: recipe with `tool: run_python` + `callable: autoskillit.planner.validate_plan` + `disabled_features=frozenset({"planner"})` → finding fires
- [ ] REQ-PFG-004: Add test: recipe with `tool: run_python` + non-feature callable (e.g., `autoskillit.smoke_utils.some_func`) + disabled features → no finding fires (no false positive)

## Architecture Impact

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph L0 ["L0 — core/ (zero autoskillit imports)"]
        direction LR
        FEAT_REG["FEATURE_REGISTRY<br/>━━━━━━━━━━<br/>_type_constants.py<br/>planner: import_package<br/>skill_categories · tool_tags"]
        FEAT_FLAGS["is_feature_enabled()<br/>━━━━━━━━━━<br/>feature_flags.py<br/>KeyError on unknown name<br/>fallback to default_enabled"]
        CORE_TYPES["FeatureDef · Severity<br/>━━━━━━━━━━<br/>SKILL_TOOLS · TOOL_SUBSET_TAGS<br/>SkillLister (protocol)"]
    end

    subgraph L1_Recipe ["L1 — recipe/ (semantic rule framework)"]
        direction LR
        REGISTRY["registry.py<br/>━━━━━━━━━━<br/>@semantic_rule decorator<br/>RuleFinding dataclass<br/>_RULE_REGISTRY"]
        ANALYSIS["_analysis.py<br/>━━━━━━━━━━<br/>ValidationContext<br/>make_validation_context()"]
        CONTRACTS["contracts.py<br/>━━━━━━━━━━<br/>resolve_skill_name()"]
        RULES_FEAT["● rules_features.py<br/>━━━━━━━━━━<br/>check_feature_gated_tools<br/>run_python callable check<br/>run_skill category check"]
        RECIPE_INIT["recipe/__init__.py<br/>━━━━━━━━━━<br/>side-effect import<br/>registers all rules_*"]
    end

    subgraph L1_Planner ["L1 — planner/ (callable implementations)"]
        PLANNER_MOD["autoskillit.planner.*<br/>━━━━━━━━━━<br/>check_remaining<br/>build_assignment_manifest<br/>build_wp_manifest<br/>validate_plan · compile_plan"]
    end

    subgraph L1_Workspace ["L1 — workspace/ (skill resolution)"]
        SESSION_SKILLS["session_skills.py<br/>━━━━━━━━━━<br/>suppresses skills by category<br/>union model: all features disabled"]
        SKILL_RESOLVER["DefaultSkillResolver<br/>━━━━━━━━━━<br/>workspace/__init__.py<br/>builds skill category map"]
    end

    subgraph L2_Server ["L2 — server/ (runtime gating)"]
        TOOLS_KITCHEN["tools_kitchen.py<br/>━━━━━━━━━━<br/>gates MCP tools by tool_tags<br/>planner: tool_tags=empty"]
    end

    subgraph L3_Artifacts ["L3 — Artifacts"]
        PLANNER_YAML["● recipes/planner.yaml<br/>━━━━━━━━━━<br/>categories: [planner]<br/>run_python: autoskillit.planner.*<br/>run_skill: planner-* skills"]
        SPRINT_SKILL["● sprint-planner/SKILL.md<br/>━━━━━━━━━━<br/>categories: [planner]<br/>delegates to issue-splitter<br/>collapse-issues · enrich-issues"]
    end

    subgraph L4_Tests ["L4 — Tests"]
        TEST_FEAT["● test_rules_features.py<br/>━━━━━━━━━━<br/>tests check_feature_gated_tools<br/>run_python + run_skill branches<br/>uses FeatureDef · FeatureLifecycle"]
    end

    %% L0 internal
    FEAT_REG --> FEAT_FLAGS

    %% rules_features imports from L0 core
    RULES_FEAT -->|"FEATURE_REGISTRY<br/>FeatureDef · Severity<br/>SKILL_TOOLS · TOOL_SUBSET_TAGS"| FEAT_REG
    RULES_FEAT -->|"SkillLister protocol"| CORE_TYPES

    %% rules_features imports from recipe/
    RULES_FEAT -->|"ValidationContext"| ANALYSIS
    RULES_FEAT -->|"resolve_skill_name()"| CONTRACTS
    RULES_FEAT -->|"@semantic_rule<br/>RuleFinding"| REGISTRY

    %% recipe/__init__ registers rules_features via side-effect import
    RECIPE_INIT -->|"side-effect import<br/>registers rule"| RULES_FEAT

    %% deferred import (runtime only, noqa PLC0415)
    RULES_FEAT -.->|"deferred import<br/>(linter: noqa PLC0415)"| SKILL_RESOLVER

    %% Runtime gating chain (L1/L2 → L0)
    SESSION_SKILLS -->|"calls is_feature_enabled()"| FEAT_FLAGS
    SESSION_SKILLS -->|"reads skill_categories"| FEAT_REG
    TOOLS_KITCHEN -->|"calls is_feature_enabled()"| FEAT_FLAGS
    TOOLS_KITCHEN -->|"reads tool_tags"| FEAT_REG

    %% Artifacts validated/gated
    PLANNER_YAML -->|"validated: callable prefix<br/>vs import_package"| RULES_FEAT
    PLANNER_YAML -->|"calls callables in"| PLANNER_MOD
    SPRINT_SKILL -->|"gated by skill_categories<br/>at session load"| SESSION_SKILLS

    %% Tests
    TEST_FEAT -->|"exercises rule logic"| RULES_FEAT
    TEST_FEAT -->|"make_validation_context()"| ANALYSIS
    TEST_FEAT -->|"run_semantic_rules()"| REGISTRY

    %% Class assignments
    class FEAT_REG stateNode;
    class FEAT_FLAGS handler;
    class CORE_TYPES stateNode;
    class REGISTRY phase;
    class ANALYSIS stateNode;
    class CONTRACTS handler;
    class RULES_FEAT handler;
    class RECIPE_INIT phase;
    class PLANNER_MOD handler;
    class SESSION_SKILLS handler;
    class SKILL_RESOLVER handler;
    class TOOLS_KITCHEN handler;
    class PLANNER_YAML output;
    class SPRINT_SKILL output;
    class TEST_FEAT detector;
```

### Security Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 42, 'rankSpacing': 52, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ENTRY %%
    RECIPE_INPUT(["Recipe YAML<br/>━━━━━━━━━━<br/>Untrusted external input"])

    subgraph FeatureConfig ["FEATURE CONFIGURATION"]
        direction LR
        FEAT_REG["FEATURE_REGISTRY<br/>━━━━━━━━━━<br/>planner: default_enabled=False<br/>fleet: default_enabled=False"]
        IS_ENABLED["is_feature_enabled()<br/>━━━━━━━━━━<br/>config.yaml override<br/>→ resolved bool"]
        FEAT_REG --> IS_ENABLED
    end

    subgraph ValidationBoundary ["TRUST BOUNDARY 1: Static Recipe Validation (rules_features.py)"]
        direction TB
        RULE["feature-gate-tool-reference<br/>━━━━━━━━━━<br/>Severity.ERROR<br/>semantic rule"]

        subgraph CheckA ["Check A — Tool Tag"]
            TOOL_TAG["Tool-tag gate<br/>━━━━━━━━━━<br/>step.tool tag ∩ fdef.tool_tags<br/>e.g. fleet tools"]
        end

        subgraph CheckB ["● Check B — run_python Callable (Gap A Fix)"]
            CALLABLE_CHECK["● Callable prefix gate<br/>━━━━━━━━━━<br/>step.tool == run_python<br/>callable.startswith(fdef.import_package)<br/>e.g. autoskillit.planner.*"]
        end

        subgraph CheckC ["● Check C — Skill Category (Gap B Fix)"]
            SKILL_CAT["Skill-category gate<br/>━━━━━━━━━━<br/>skill categories ∩ fdef.skill_categories<br/>sprint-planner now tagged [planner]"]
        end

        BLOCKED["ERROR Finding<br/>━━━━━━━━━━<br/>Recipe rejected<br/>before execution"]

        RULE --> TOOL_TAG
        RULE --> CALLABLE_CHECK
        RULE --> SKILL_CAT
        TOOL_TAG -->|"disabled feature"| BLOCKED
        CALLABLE_CHECK -->|"disabled feature"| BLOCKED
        SKILL_CAT -->|"disabled feature"| BLOCKED
    end

    subgraph PlannerRecipe ["● planner.yaml — Gated Recipe Steps"]
        direction LR
        RUN_PY["● 7× run_python steps<br/>━━━━━━━━━━<br/>autoskillit.planner.check_remaining<br/>autoskillit.planner.build_assignment_manifest<br/>autoskillit.planner.build_wp_manifest<br/>autoskillit.planner.validate_plan<br/>autoskillit.planner.compile_plan"]
        RUN_SKILL["run_skill steps<br/>━━━━━━━━━━<br/>/autoskillit:planner-analyze<br/>/autoskillit:planner-generate-phases<br/>etc."]
    end

    subgraph SprintPlanner ["● sprint-planner/SKILL.md"]
        SPRINT_CAT["● categories: [planner]<br/>━━━━━━━━━━<br/>Added — was missing<br/>Now caught by Check C"]
    end

    subgraph ExecutionBoundary ["TRUST BOUNDARY 2: Execution Layer"]
        direction LR

        subgraph InProcess ["run_python — In-Process (NO SANDBOX)"]
            IMPORT_CALL["_import_and_call()<br/>━━━━━━━━━━<br/>importlib.import_module + getattr<br/>Runs with MCP server trust<br/>Sole gate = static validation"]
            PLANNER_PKG["autoskillit.planner.*<br/>━━━━━━━━━━<br/>In-process planner functions<br/>check_remaining, validate_plan<br/>compile_plan, etc."]
            IMPORT_CALL --> PLANNER_PKG
        end

        subgraph SubprocessIsolated ["run_skill — Isolated Subprocess"]
            HEADLESS["Headless Claude session<br/>━━━━━━━━━━<br/>OS-level process isolation<br/>AUTOSKILLIT_HEADLESS=1<br/>Separate permissions + tools"]
            PLANNER_SKILLS["Planner skills<br/>━━━━━━━━━━<br/>planner-analyze, sprint-planner<br/>etc. run in isolated session"]
            HEADLESS --> PLANNER_SKILLS
        end
    end

    subgraph TestCoverage ["● test_rules_features.py — Enforcement Verification"]
        TESTS["● New test cases<br/>━━━━━━━━━━<br/>callable prefix gate fires on ERROR<br/>sprint-planner category gate fires<br/>enabled feature passes through"]
    end

    %% TOP-LEVEL FLOW %%
    RECIPE_INPUT --> IS_ENABLED
    IS_ENABLED --> RULE
    RECIPE_INPUT --> RUN_PY
    RECIPE_INPUT --> RUN_SKILL
    RECIPE_INPUT --> SPRINT_CAT

    RUN_PY -->|"validated"| CALLABLE_CHECK
    RUN_SKILL -->|"validated"| SKILL_CAT
    SPRINT_CAT -->|"category declared"| SKILL_CAT

    RULE -->|"passes: feature enabled"| InProcess
    RULE -->|"passes: feature enabled"| SubprocessIsolated

    ValidationBoundary --> TESTS

    %% CLASS ASSIGNMENTS %%
    class RECIPE_INPUT cli;
    class FEAT_REG,IS_ENABLED stateNode;
    class RULE detector;
    class TOOL_TAG detector;
    class CALLABLE_CHECK detector;
    class SKILL_CAT detector;
    class BLOCKED gap;
    class RUN_PY handler;
    class RUN_SKILL handler;
    class SPRINT_CAT newComponent;
    class IMPORT_CALL,HEADLESS phase;
    class PLANNER_PKG,PLANNER_SKILLS output;
    class TESTS stateNode;
```

### Scenarios Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 45, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph S1 ["SCENARIO 1: Planner Recipe Executes (Feature Enabled)"]
        direction LR
        S1_YAML["● planner.yaml<br/>━━━━━━━━━━<br/>7x run_python steps<br/>autoskillit.planner.*"]
        S1_VAL["validate_recipe()<br/>━━━━━━━━━━<br/>structural checks pass"]
        S1_CTX["ValidationContext<br/>━━━━━━━━━━<br/>planner: enabled<br/>disabled_features = ∅"]
        S1_GATE["● check_feature_gated_tools()<br/>━━━━━━━━━━<br/>disabled_features empty<br/>→ early return []"]
        S1_EXEC["run_python<br/>━━━━━━━━━━<br/>autoskillit.planner.*<br/>callable invoked"]
        S1_OUT["planner artifacts<br/>━━━━━━━━━━<br/>manifests, plan, compile"]
    end

    subgraph S2 ["SCENARIO 2: run_python Callable Blocked (NEW FIX ●)"]
        direction LR
        S2_STEP["recipe step<br/>━━━━━━━━━━<br/>tool: run_python<br/>callable: autoskillit.planner.validate_plan"]
        S2_CTX["ValidationContext<br/>━━━━━━━━━━<br/>disabled_features = {planner}<br/>import_package = autoskillit.planner"]
        S2_GATE["● check_feature_gated_tools()<br/>━━━━━━━━━━<br/>callable.startswith(import_package)<br/>→ sub-check fires"]
        S2_ERR["RuleFinding ERROR<br/>━━━━━━━━━━<br/>feature-gate-tool-reference<br/>recipe marked invalid"]
    end

    subgraph S3 ["SCENARIO 3: sprint-planner Skill Blocked (NEW FIX ●)"]
        direction LR
        S3_STEP["recipe step<br/>━━━━━━━━━━<br/>tool: run_skill<br/>skill_command: sprint-planner"]
        S3_SKILL["● sprint-planner/SKILL.md<br/>━━━━━━━━━━<br/>categories: [planner]<br/>(newly declared)"]
        S3_MAP["skill_category_map<br/>━━━━━━━━━━<br/>sprint-planner →<br/>frozenset({planner})"]
        S3_GATE["● check_feature_gated_tools()<br/>━━━━━━━━━━<br/>categories ∩ {planner}<br/>→ non-empty, check fires"]
        S3_ERR["RuleFinding ERROR<br/>━━━━━━━━━━<br/>feature-gate-tool-reference<br/>recipe marked invalid"]
    end

    subgraph S4 ["SCENARIO 4: Non-Feature Callable Passes Gate (No False Positive)"]
        direction LR
        S4_STEP["recipe step<br/>━━━━━━━━━━<br/>tool: run_python<br/>callable: autoskillit.smoke_utils.*"]
        S4_CTX["ValidationContext<br/>━━━━━━━━━━<br/>disabled_features = {planner}<br/>import_package = autoskillit.planner"]
        S4_GATE["● check_feature_gated_tools()<br/>━━━━━━━━━━<br/>smoke_utils prefix mismatch<br/>→ no finding"]
        S4_EXEC["run_python<br/>━━━━━━━━━━<br/>smoke_utils callable<br/>executes normally"]
    end

    %% SCENARIO 1 FLOW %%
    S1_YAML -->|"loads"| S1_VAL
    S1_VAL -->|"builds"| S1_CTX
    S1_CTX -->|"dispatches to"| S1_GATE
    S1_GATE -->|"no errors → passes"| S1_EXEC
    S1_EXEC -->|"writes"| S1_OUT

    %% SCENARIO 2 FLOW %%
    S2_STEP -->|"builds"| S2_CTX
    S2_CTX -->|"dispatches to"| S2_GATE
    S2_GATE -->|"callable prefix match"| S2_ERR

    %% SCENARIO 3 FLOW %%
    S3_STEP -->|"resolves skill"| S3_SKILL
    S3_SKILL -->|"populates"| S3_MAP
    S3_MAP -->|"consulted by"| S3_GATE
    S3_GATE -->|"category intersection"| S3_ERR

    %% SCENARIO 4 FLOW %%
    S4_STEP -->|"builds"| S4_CTX
    S4_CTX -->|"dispatches to"| S4_GATE
    S4_GATE -->|"prefix mismatch → passes"| S4_EXEC

    %% CLASS ASSIGNMENTS %%
    class S1_YAML,S2_STEP,S3_STEP,S4_STEP stateNode;
    class S1_VAL,S1_CTX,S2_CTX,S4_CTX phase;
    class S1_GATE,S2_GATE,S3_GATE,S4_GATE detector;
    class S1_EXEC,S4_EXEC handler;
    class S1_OUT output;
    class S2_ERR,S3_ERR detector;
    class S3_SKILL,S3_MAP stateNode;
```

Closes #1251

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-1251-20260425-100137-275268/.autoskillit/temp/make-plan/bug_planner_feature_gate_gaps_plan_2026-04-25_100137.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 157 | 11.6k | 715.0k | 51.7k | 1 | 5m 43s |
| verify | 100 | 9.7k | 482.4k | 44.2k | 1 | 4m 3s |
| implement | 132 | 7.6k | 697.5k | 48.5k | 1 | 2m 29s |
| fix | 160 | 5.4k | 765.4k | 43.3k | 1 | 7m 48s |
| prepare_pr | 60 | 5.8k | 206.9k | 28.9k | 1 | 2m 0s |
| run_arch_lenses | 4.6k | 22.7k | 506.8k | 173.5k | 3 | 11m 9s |
| compose_pr | 67 | 8.3k | 254.1k | 34.2k | 1 | 2m 24s |
| **Total** | 5.3k | 71.1k | 3.6M | 424.2k | | 35m 38s |