### PR TITLE
fix: fleet runtime gate consistency — three gate paths with unified authority

### DIFF
--- a/src/autoskillit/core/_type_enums.py
+++ b/src/autoskillit/core/_type_enums.py
@@ -395,6 +395,7 @@ class FleetErrorCode(StrEnum):
     FLEET_RECIPE_NOT_FOUND = "fleet_recipe_not_found"
     FLEET_INVALID_RECIPE_KIND = "fleet_invalid_recipe_kind"
     FLEET_HARD_REFUSAL_HEADLESS = "fleet_hard_refusal_headless"
+    FLEET_FEATURE_DISABLED = "fleet_feature_disabled"
     FLEET_MANIFEST_MISSING = "fleet_manifest_missing"
     FLEET_MANIFEST_CORRUPTED = "fleet_manifest_corrupted"
     FLEET_LOCK_NOT_INITIALIZED = "fleet_lock_not_initialized"

--- a/src/autoskillit/server/_lifespan.py
+++ b/src/autoskillit/server/_lifespan.py
@@ -155,6 +155,27 @@ async def _fleet_auto_gate_boot(ctx: Any) -> None:
     ctx.gate.enable()
     logger.info("fleet_auto_gate_boot", gate_state="open", kitchen_id=ctx.kitchen_id)
 
+    # Enforce config-based feature suppression immediately after gate open.
+    # Mirrors _redisable_subsets pass 2 without requiring a FastMCP Context.
+    # Must run at lifespan time so fleet tools are hidden before any tool call arrives.
+    try:
+        from autoskillit.core import FEATURE_REGISTRY, FEATURE_REVEAL_TAGS, is_feature_enabled
+        from autoskillit.server import mcp as _mcp
+
+        _features = ctx.config.features if ctx.config is not None else {}
+        _enabled_tags: set[str] = set()
+        _disabled_tags: set[str] = set()
+        for _feat_name, _feat_def in FEATURE_REGISTRY.items():
+            _reveal = FEATURE_REVEAL_TAGS & _feat_def.tool_tags
+            if is_feature_enabled(_feat_name, _features):
+                _enabled_tags |= _reveal
+            else:
+                _disabled_tags |= _reveal
+        for _tag in _disabled_tags - _enabled_tags:
+            _mcp.disable(tags={_tag})
+    except Exception:
+        logger.warning("fleet_auto_gate_boot_feature_suppression_failed", exc_info=True)
+
     try:
         _write_hook_config()
     except Exception:

--- a/src/autoskillit/server/_session_type.py
+++ b/src/autoskillit/server/_session_type.py
@@ -81,8 +81,11 @@ def _apply_session_type_visibility(
 def _fleet_gate(mcp: FastMCP, session: SessionType) -> None:  # noqa: ARG001
     """Disable fleet-tagged tools when the fleet feature is off.
 
-    Reads AUTOSKILLIT_FEATURES__FLEET env var.
-    Safe to call at import time — no config or _ctx dependency.
+    Intentionally reads only the AUTOSKILLIT_FEATURES__FLEET env var.
+    This function runs at import time before config is loaded, so the
+    config file is not available here. The deferred config-based check
+    is performed by _fleet_auto_gate_boot() in _lifespan.py once the
+    server context (ctx.config.features) is available.
     """
     fleet_val = os.environ.get("AUTOSKILLIT_FEATURES__FLEET", "").strip().lower()
     if fleet_val in ("false", "0", "no"):

--- a/src/autoskillit/server/tools_execution.py
+++ b/src/autoskillit/server/tools_execution.py
@@ -425,20 +425,20 @@ async def dispatch_food_truck(
     if (gate := _require_enabled()) is not None:
         return gate
 
-    # Feature guard: config authority check independent of MCP visibility state.
-    # Fleet sessions open the gate unconditionally at boot; this catch-all ensures
-    # dispatch_food_truck never executes when features.fleet is disabled in config.
-    from autoskillit.core import FleetErrorCode, fleet_error, is_feature_enabled
-    from autoskillit.server import _get_ctx as _get_ctx_for_feature_check
-
-    _feature_ctx = _get_ctx_for_feature_check()
-    if not is_feature_enabled("fleet", _feature_ctx.config.features):
-        return fleet_error(
-            FleetErrorCode.FLEET_FEATURE_DISABLED,
-            "Fleet feature is disabled in configuration. Set features.fleet: true to enable.",
-        )
-
     try:
+        # Feature guard: config authority check independent of MCP visibility state.
+        # Fleet sessions open the gate unconditionally at boot; this catch-all ensures
+        # dispatch_food_truck never executes when features.fleet is disabled in config.
+        from autoskillit.core import FleetErrorCode, fleet_error, is_feature_enabled
+        from autoskillit.server import _get_ctx as _get_ctx_for_feature_check
+
+        _feature_ctx = _get_ctx_for_feature_check()
+        if not is_feature_enabled("fleet", _feature_ctx.config.features):
+            return fleet_error(
+                FleetErrorCode.FLEET_FEATURE_DISABLED,
+                "Fleet feature is disabled in configuration. Set features.fleet: true to enable.",
+            )
+
         if os.environ.get("AUTOSKILLIT_HEADLESS") == "1":
             from autoskillit.core import FleetErrorCode, fleet_error
 

--- a/src/autoskillit/server/tools_execution.py
+++ b/src/autoskillit/server/tools_execution.py
@@ -424,6 +424,20 @@ async def dispatch_food_truck(
     """
     if (gate := _require_enabled()) is not None:
         return gate
+
+    # Feature guard: config authority check independent of MCP visibility state.
+    # Fleet sessions open the gate unconditionally at boot; this catch-all ensures
+    # dispatch_food_truck never executes when features.fleet is disabled in config.
+    from autoskillit.core import FleetErrorCode, fleet_error, is_feature_enabled
+    from autoskillit.server import _get_ctx as _get_ctx_for_feature_check
+
+    _feature_ctx = _get_ctx_for_feature_check()
+    if not is_feature_enabled("fleet", _feature_ctx.config.features):
+        return fleet_error(
+            FleetErrorCode.FLEET_FEATURE_DISABLED,
+            "Fleet feature is disabled in configuration. Set features.fleet: true to enable.",
+        )
+
     try:
         if os.environ.get("AUTOSKILLIT_HEADLESS") == "1":
             from autoskillit.core import FleetErrorCode, fleet_error

--- a/src/autoskillit/server/tools_execution.py
+++ b/src/autoskillit/server/tools_execution.py
@@ -440,8 +440,6 @@ async def dispatch_food_truck(
             )
 
         if os.environ.get("AUTOSKILLIT_HEADLESS") == "1":
-            from autoskillit.core import FleetErrorCode, fleet_error
-
             return fleet_error(
                 FleetErrorCode.FLEET_HARD_REFUSAL_HEADLESS,
                 "dispatch_food_truck cannot be called from headless sessions.",

--- a/tests/fleet/test_error_envelope.py
+++ b/tests/fleet/test_error_envelope.py
@@ -30,6 +30,7 @@ class TestFleetErrorCodeEnum:
             "fleet_recipe_not_found",
             "fleet_invalid_recipe_kind",
             "fleet_hard_refusal_headless",
+            "fleet_feature_disabled",
             "fleet_manifest_missing",
             "fleet_manifest_corrupted",
             "fleet_lock_not_initialized",

--- a/tests/server/test_server_init.py
+++ b/tests/server/test_server_init.py
@@ -1122,6 +1122,7 @@ class TestFleetAutoGateBoot:
         async with Client(mcp) as client:
             tools = await client.list_tools()
         tool_names = {t.name for t in tools}
+        assert FLEET_TOOLS, "FLEET_TOOLS must not be empty — loop would pass vacuously"
         for name in FLEET_TOOLS:
             assert name not in tool_names, f"{name} should be hidden when fleet feature disabled"
 

--- a/tests/server/test_server_init.py
+++ b/tests/server/test_server_init.py
@@ -1077,6 +1077,45 @@ class TestFleetAutoGateBoot:
             for entry in logs
         )
 
+    @pytest.mark.anyio
+    async def test_fleet_auto_gate_boot_suppresses_fleet_tools_when_feature_disabled(
+        self, tool_ctx, monkeypatch
+    ):
+        """_fleet_auto_gate_boot with features.fleet: false → fleet MCP tags disabled."""
+        import dataclasses
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from fastmcp.client import Client
+
+        from autoskillit.core import FLEET_TOOLS
+        from autoskillit.pipeline.gate import DefaultGateState
+        from autoskillit.server import mcp
+        from autoskillit.server._lifespan import _fleet_auto_gate_boot
+
+        # First enable fleet tag (as import-time phase 1 would)
+        mcp.enable(tags={"fleet"})
+
+        tool_ctx.gate = DefaultGateState(enabled=False)
+        tool_ctx.quota_refresh_task = None
+        tool_ctx.config = dataclasses.replace(tool_ctx.config, features={"fleet": False})
+
+        monkeypatch.setattr("autoskillit.server._lifespan._get_ctx_or_none", lambda: tool_ctx)
+
+        with patch("autoskillit.server.tools_kitchen._write_hook_config"):
+            with patch("autoskillit.server.helpers._prime_quota_cache", new=AsyncMock()):
+                with patch(
+                    "autoskillit.pipeline.create_background_task",
+                    return_value=MagicMock(),
+                ):
+                    with patch("autoskillit.core.register_active_kitchen"):
+                        await _fleet_auto_gate_boot(tool_ctx)
+
+        async with Client(mcp) as client:
+            tools = await client.list_tools()
+        tool_names = {t.name for t in tools}
+        for name in FLEET_TOOLS:
+            assert name not in tool_names, f"{name} should be hidden when fleet feature disabled"
+
 
 class TestFeatureGateVisibility:
     """Feature gate override layer in _apply_session_type_visibility."""

--- a/tests/server/test_server_init.py
+++ b/tests/server/test_server_init.py
@@ -917,6 +917,15 @@ class TestSessionTypeVisibility:
 class TestFleetAutoGateBoot:
     """Fleet lifespan auto-gate: _fleet_auto_gate_boot opens gate before first tool call."""
 
+    @pytest.fixture(autouse=True)
+    def _reset_mcp_visibility(self):
+        """Reset gated tag visibility on the shared mcp singleton before/after each test."""
+        from autoskillit.server import mcp
+
+        mcp.disable(tags={"fleet", "kitchen", "headless"})
+        yield
+        mcp.disable(tags={"fleet", "kitchen", "headless"})
+
     @pytest.mark.anyio
     async def test_fleet_lifespan_auto_opens_gate(self, tool_ctx):
         """Fleet session: gate is open after _fleet_auto_gate_boot() runs."""

--- a/tests/server/test_tools_dispatch.py
+++ b/tests/server/test_tools_dispatch.py
@@ -112,6 +112,24 @@ class TestDispatchFoodTruckGates:
         assert result["success"] is False
         assert result["error"] == "fleet_parallel_refused"
 
+    @pytest.mark.anyio
+    async def test_dispatch_food_truck_refuses_when_fleet_feature_disabled(
+        self, tool_ctx, monkeypatch
+    ):
+        """features.fleet: false in config → fleet_feature_disabled, regardless of gate state."""
+        import dataclasses
+
+        from autoskillit.server.tools_execution import dispatch_food_truck
+
+        # Gate is open (fleet session already booted), env var absent
+        # Only config file has fleet disabled
+        monkeypatch.delenv("AUTOSKILLIT_FEATURES__FLEET", raising=False)
+        tool_ctx.config = dataclasses.replace(tool_ctx.config, features={"fleet": False})
+
+        result = json.loads(await dispatch_food_truck(recipe="r", task="t"))
+        assert result["success"] is False
+        assert result["error"] == "fleet_feature_disabled"
+
 
 # ---------------------------------------------------------------------------
 # Class TestDispatchFoodTruckValidation — recipe kind, ingredient keys, non-string values


### PR DESCRIPTION
## Summary

The fleet feature had three runtime gate mechanisms consulting different data sources, creating a validated bypass: `SESSION_TYPE=fleet` + absent `AUTOSKILLIT_FEATURES__FLEET` env var + `features.fleet: false` in config = fleet tools callable. The fix establishes unified authority by (1) adding a config-based feature guard in `dispatch_food_truck`, (2) calling feature suppression in `_fleet_auto_gate_boot()` at lifespan time, and (3) documenting `_fleet_gate()`'s intentional env-var-only behavior. A new `FLEET_FEATURE_DISABLED` error code is added to `FleetErrorCode` to complete the path.

## Requirements

- [ ] REQ-RGC-001: Add `is_feature_enabled("fleet", config.features)` check inside `dispatch_food_truck` handler, after `_require_enabled()` — return `fleet_error(FleetErrorCode.FEATURE_DISABLED, ...)` if fleet is disabled
- [ ] REQ-RGC-002: Call `_redisable_subsets()` (or an equivalent feature-suppression pass) inside `_fleet_auto_gate_boot()` so fleet sessions enforce config-based feature suppression
- [ ] REQ-RGC-003: Document the intentional design of `_fleet_gate()` reading env vars directly (it runs at import time before config is available) — OR — add a deferred config check that fires after config is loaded
- [ ] REQ-RGC-004: Add test: `SESSION_TYPE=fleet` + `features.fleet: false` in config + no `AUTOSKILLIT_FEATURES__FLEET` env var → fleet tools must NOT be callable
- [ ] REQ-RGC-005: Add test: `_fleet_auto_gate_boot()` with `features.fleet: false` → fleet tools must be suppressed after boot

## Architecture Impact

### Security (Trust Boundaries) Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% SESSION ENTRY POINTS %%
    FLEET(["FLEET Session<br/>SessionType.FLEET"])
    ORCH(["ORCHESTRATOR Session<br/>AUTOSKILLIT_HEADLESS=1"])
    LEAF(["LEAF Session<br/>Lowest privilege tier"])

    %% BOUNDARY 0: Hook-level gate %%
    subgraph B0 ["TRUST BOUNDARY 0 — PreToolUse Hook"]
        HookGuard["fleet_dispatch_guard.py<br/>━━━━━━━━━━<br/>HEADLESS=1 → permissionDecision:deny<br/>Fail-open on stdin parse error<br/>Prevents L3→L3 recursion"]
    end

    %% BOUNDARY 0.5: Type system fail-closed defaults %%
    subgraph TypeSys ["● FAIL-CLOSED TYPE SYSTEM (_type_enums.py)"]
        SessionTypeEnum["● session_type() → LEAF fallback<br/>━━━━━━━━━━<br/>Invalid/unset env var → LEAF<br/>DeprecationWarning on bad value<br/>Never escalates on misconfiguration"]
        FleetErrCodes["● FleetErrorCode (@unique)<br/>━━━━━━━━━━<br/>FLEET_FEATURE_DISABLED<br/>FLEET_HARD_REFUSAL_HEADLESS<br/>FLEET_PARALLEL_REFUSED"]
        ClaudeFlags["ClaudeFlags registry<br/>━━━━━━━━━━<br/>DANGEROUSLY_SKIP_PERMISSIONS<br/>All flag strings auditable via constants<br/>No hardcoding at call sites"]
    end

    %% BOUNDARY 1: Import-time visibility gate %%
    subgraph B1 ["TRUST BOUNDARY 1 — Import-Time (env-var only)"]
        FleetGate["● _fleet_gate()<br/>━━━━━━━━━━<br/>Reads AUTOSKILLIT_FEATURES__FLEET<br/>Config not available at import time<br/>mcp.disable(tags) if false"]
        VisibilityDispatch["● _apply_session_type_visibility()<br/>━━━━━━━━━━<br/>FLEET → enable fleet tags<br/>ORCH+headless → AUTOSKILLIT_L2_TOOL_TAGS<br/>LEAF+headless → headless tags only<br/>Interactive → no pre-reveal"]
        UnknownPack["Unknown pack names<br/>━━━━━━━━━━<br/>Validated vs CATEGORY_TAGS<br/>Logged + skipped (not silently exposed)<br/>ERR: unrecognized packs blocked"]
    end

    %% BOUNDARY 2: Lifespan-time gate %%
    subgraph B2 ["● TRUST BOUNDARY 2 — Lifespan-Time (_lifespan.py, before yield)"]
        AutoBoot["● _fleet_auto_gate_boot()<br/>━━━━━━━━━━<br/>FLEET sessions only<br/>gate.enable() → immutable kitchen_id<br/>Runs before yield (before any tool call)"]
        FeatSuppress["● Feature Suppression Pass<br/>━━━━━━━━━━<br/>Iterates FEATURE_REGISTRY<br/>is_feature_enabled() per feature<br/>mcp.disable(tags) if config says off<br/>Config-file overrides env-var state"]
        LifespanOrder["Ordering invariant<br/>━━━━━━━━━━<br/>Suppression completes before yield<br/>No tool call can arrive during setup<br/>Partial failures log + continue"]
    end

    %% BOUNDARY 3A: Standard tool guards %%
    subgraph B3A ["TRUST BOUNDARY 3A — Run-Time Standard (tools_execution.py)"]
        TierGuard["_require_orchestrator_or_higher()<br/>━━━━━━━━━━<br/>Rejects LEAF sessions at handler<br/>Defense-in-depth: after visibility gate"]
        KitchenGuard["_require_enabled()<br/>━━━━━━━━━━<br/>Kitchen gate must be open<br/>Applies to run_cmd + run_skill"]
        InputVal["Input Validation<br/>━━━━━━━━━━<br/>_validate_skill_command()<br/>_is_absolute_path(cwd) — rejects relative<br/>safety.require_dry_walkthrough check"]
    end

    %% BOUNDARY 3B: Dispatch-specific 3-gate path %%
    subgraph B3B ["● TRUST BOUNDARY 3B — dispatch_food_truck (3 Independent Gates)"]
        DispGate1["Gate 1: _require_enabled()<br/>━━━━━━━━━━<br/>Kitchen gate check<br/>Shared with standard tools"]
        DispGate2["● Gate 2: is_feature_enabled('fleet')<br/>━━━━━━━━━━<br/>Config authority catch-all<br/>Guards if B2 suppression was bypassed<br/>→ FLEET_FEATURE_DISABLED"]
        DispGate3["● Gate 3: AUTOSKILLIT_HEADLESS check<br/>━━━━━━━━━━<br/>os.environ.get('AUTOSKILLIT_HEADLESS')<br/>Headless=1 → hard block regardless<br/>→ FLEET_HARD_REFUSAL_HEADLESS"]
    end

    %% OUTPUTS %%
    EXEC_OK(["Tool Execution Proceeds<br/>Isolated headless session<br/>Unique session_id + allow_only frozenset"])
    DENY_DISABLED(["FLEET_FEATURE_DISABLED<br/>Structured error envelope"])
    DENY_HEADLESS(["FLEET_HARD_REFUSAL_HEADLESS<br/>Structured error envelope"])
    DENY_HOOK(["permissionDecision: deny<br/>Hook-level block"])

    %% FLOWS %%
    FLEET --> HookGuard
    ORCH --> HookGuard
    LEAF --> HookGuard

    HookGuard -->|"interactive: pass"| B1
    HookGuard -->|"headless dispatch: deny"| DENY_HOOK

    SessionTypeEnum -.->|"fail-closed tier default"| VisibilityDispatch
    FleetErrCodes -.->|"typed error envelopes"| DispGate2

    FleetGate --> VisibilityDispatch
    VisibilityDispatch --> UnknownPack
    UnknownPack --> AutoBoot

    AutoBoot --> FeatSuppress --> LifespanOrder

    LifespanOrder --> TierGuard
    LifespanOrder --> DispGate1

    TierGuard --> KitchenGuard --> InputVal --> EXEC_OK

    DispGate1 --> DispGate2
    DispGate2 -->|"fleet disabled"| DENY_DISABLED
    DispGate2 -->|"fleet enabled"| DispGate3
    DispGate3 -->|"headless=1"| DENY_HEADLESS
    DispGate3 -->|"interactive"| EXEC_OK

    %% CLASS ASSIGNMENTS %%
    class FLEET,ORCH,LEAF cli;
    class HookGuard detector;
    class SessionTypeEnum,FleetErrCodes,ClaudeFlags stateNode;
    class FleetGate,VisibilityDispatch,UnknownPack detector;
    class AutoBoot,FeatSuppress handler;
    class LifespanOrder phase;
    class TierGuard,KitchenGuard,InputVal detector;
    class DispGate1,DispGate2,DispGate3 detector;
    class EXEC_OK output;
    class DENY_DISABLED,DENY_HEADLESS,DENY_HOOK gap;
```

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START([Server Import / Startup])

    subgraph Phase1 ["PHASE 1 — SESSION-TYPE DISPATCH  ● _session_type.py"]
        direction LR
        FleetBranch["SESSION=fleet<br/>━━━━━━━━━━<br/>mcp.enable(tags={fleet})<br/>Visibility: fleet tools shown"]
        OrchestratorBranch["SESSION=orchestrator<br/>━━━━━━━━━━<br/>HEADLESS: kitchen or kitchen-core<br/>Interactive: no pre-reveal"]
        LeafBranch["SESSION=leaf<br/>━━━━━━━━━━<br/>HEADLESS: headless tag only<br/>Interactive: no pre-reveal"]
    end

    subgraph Phase2 ["GATE PATH 1 — ENV-VAR FEATURE GATE  ● _session_type.py"]
        FleetGate["● _fleet_gate()<br/>━━━━━━━━━━<br/>Reads AUTOSKILLIT_FEATURES__FLEET only<br/>Config NOT loaded yet at import time<br/>mcp.disable(tags={fleet}) if false/0/no"]
    end

    subgraph LifespanInit ["GATE PATH 2 — LIFESPAN CONFIG GATE  ● _lifespan.py"]
        direction TB
        FleetBootCheck{"session_type()<br/>== FLEET?"}
        FleetAutoBoot["● _fleet_auto_gate_boot()<br/>━━━━━━━━━━<br/>INIT_ONLY: ctx.kitchen_id = uuid4()<br/>INIT_ONLY: ctx.active_recipe_packs = frozenset()<br/>MUTABLE: gate.enable() → enabled=True"]
        ConfigSuppression["Config-Based Suppression<br/>━━━━━━━━━━<br/>is_feature_enabled(feat, ctx.config.features)<br/>→ mcp.disable(fleet) if config says false<br/>Deferred check once config is loaded<br/>Fails open: each step individually try/except"]
    end

    subgraph InitOnlyState ["INIT_ONLY FIELD CONTRACT  (written by _fleet_auto_gate_boot)"]
        direction LR
        KitchenId["ctx.kitchen_id<br/>━━━━━━━━━━<br/>uuid4() at fleet boot<br/>NEVER reassigned"]
        ActivePacks["ctx.active_recipe_packs<br/>━━━━━━━━━━<br/>frozenset() at fleet boot<br/>NEVER reassigned"]
    end

    subgraph ToolGuards ["GATE PATH 3 — RUNTIME TOOL GUARDS  ● tools_execution.py"]
        direction TB
        HeadlessGuard["Headless Refusal Guard<br/>━━━━━━━━━━<br/>AUTOSKILLIT_HEADLESS=1 present?<br/>→ FLEET_HARD_REFUSAL_HEADLESS<br/>Checked before kitchen gate"]
        KitchenGateGuard["Kitchen Gate Guard<br/>━━━━━━━━━━<br/>gate.enabled is False?<br/>→ gate_error_result (subtype=gate_error)<br/>MUTABLE: gate state read at call time"]
        FeatureGuard["● Feature Disabled Guard<br/>━━━━━━━━━━<br/>is_feature_enabled(fleet, config.features)<br/>→ FLEET_FEATURE_DISABLED<br/>Defense-in-depth: independent of MCP visibility"]
    end

    subgraph ErrorRegistry ["FLEET ERROR CODE REGISTRY  ● _type_enums.py"]
        direction LR
        HardRefusal["● FLEET_HARD_REFUSAL_HEADLESS<br/>━━━━━━━━━━<br/>Registered enum value<br/>fleet_error() validates on use"]
        FeatureDisabled["● FLEET_FEATURE_DISABLED<br/>━━━━━━━━━━<br/>Registered enum value<br/>fleet_error() validates on use"]
    end

    DISPATCH_OK([dispatch_food_truck proceeds])

    %% CONNECTIONS %%
    START --> FleetBranch & OrchestratorBranch & LeafBranch
    FleetBranch --> FleetGate
    OrchestratorBranch --> FleetGate
    LeafBranch --> FleetGate

    FleetGate --> FleetBootCheck
    FleetBootCheck -->|Yes: FLEET session| FleetAutoBoot
    FleetBootCheck -->|No: other session| HeadlessGuard
    FleetAutoBoot --> ConfigSuppression
    FleetAutoBoot --> KitchenId
    FleetAutoBoot --> ActivePacks
    ConfigSuppression --> HeadlessGuard

    HeadlessGuard -->|HEADLESS=1| HardRefusal
    HeadlessGuard -->|HEADLESS absent| KitchenGateGuard
    KitchenGateGuard -->|gate closed| DISPATCH_OK
    KitchenGateGuard -->|gate open| FeatureGuard
    FeatureGuard -->|feature disabled| FeatureDisabled
    FeatureGuard -->|feature enabled| DISPATCH_OK

    %% CLASS ASSIGNMENTS %%
    class START terminal;
    class FleetBranch,OrchestratorBranch,LeafBranch phase;
    class FleetGate detector;
    class FleetBootCheck phase;
    class FleetAutoBoot handler;
    class ConfigSuppression detector;
    class KitchenId,ActivePacks stateNode;
    class HeadlessGuard,KitchenGateGuard,FeatureGuard detector;
    class HardRefusal,FeatureDisabled output;
    class DISPATCH_OK terminal;
```

### Error/Resilience Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 42, 'rankSpacing': 52, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    %% ENTRY %%
    MCP_START([MCP Server Start])

    %% PATH 1 — IMPORT-TIME ENV-VAR GATE %%
    subgraph Path1 ["PATH 1 — IMPORT TIME (_session_type.py)"]
        direction TB
        APPLY_VIS["● _apply_session_type_visibility()<br/>━━━━━━━━━━<br/>Phase 1: session type dispatch<br/>Phase 2: feature gates override"]
        FLEET_GATE["● _fleet_gate()<br/>━━━━━━━━━━<br/>reads AUTOSKILLIT_FEATURES__FLEET<br/>env-var only (config not yet loaded)"]
        P1_DISABLE["mcp.disable(fleet tags)<br/>━━━━━━━━━━<br/>Tools hidden before any call arrives"]
    end

    %% PATH 2 — LIFESPAN CONFIG GATE %%
    subgraph Path2 ["PATH 2 — LIFESPAN TIME (_lifespan.py)"]
        direction TB
        LIFESPAN["● _autoskillit_lifespan()<br/>━━━━━━━━━━<br/>write_readiness_sentinel()<br/>launch background tasks"]
        FLEET_BOOT["● _fleet_auto_gate_boot()<br/>━━━━━━━━━━<br/>FLEET session only<br/>gate.enable() before yield"]
        FEAT_SUPPRESS["● Config feature suppression<br/>━━━━━━━━━━<br/>iterates FEATURE_REGISTRY<br/>mcp.disable(disabled − enabled tags)"]
        BOOT_STEPS["write_hook_config → quota prime<br/>quota_refresh_loop → register_kitchen<br/>━━━━━━━━━━<br/>each step: try/except → log warning"]
    end

    %% PATH 3 — RUNTIME FUNCTION GUARD %%
    subgraph Path3 ["PATH 3 — RUNTIME (tools_execution.py)"]
        direction TB
        GATE_ENABLED{"_require_enabled()<br/>gate.enabled?"}
        GATE_HEADLESS{"AUTOSKILLIT_HEADLESS==1?"}
        GATE_FEATURE{"● is_feature_enabled()<br/>config.features[fleet]?"}
        GATE_LOCK{"fleet_lock.locked()?"}
        DISPATCH_EXEC["execute_dispatch()<br/>━━━━━━━━━━<br/>recipe validation → L2 session"]
    end

    %% FLEET ERROR ENVELOPE %%
    subgraph Errors ["FLEET ERROR ENVELOPE (fleet_error() registry)"]
        direction TB
        ERR_GATE["gate_error_result()<br/>━━━━━━━━━━<br/>subtype=gate_error"]
        ERR_HEADLESS["FLEET_HARD_REFUSAL_HEADLESS<br/>━━━━━━━━━━<br/>structural: no headless callers"]
        ERR_FEATURE["● FLEET_FEATURE_DISABLED<br/>━━━━━━━━━━<br/>config authority catch-all"]
        ERR_LOCK["FLEET_PARALLEL_REFUSED<br/>━━━━━━━━━━<br/>concurrent dispatch"]
        ERR_RECIPE["FLEET_RECIPE_NOT_FOUND<br/>FLEET_INVALID_RECIPE_KIND<br/>FLEET_UNKNOWN_INGREDIENT"]
        ERR_INFRA["FLEET_MANIFEST_MISSING<br/>L2_TIMEOUT / L2_PARSE_FAILED<br/>L2_STARTUP_OR_CRASH"]
        FLEET_ERR_BUILDER["fleet_error(code, msg)<br/>━━━━━━━━━━<br/>validates code ∈ FLEET_ERROR_CODES<br/>raises ValueError if unregistered"]
    end

    %% STARTUP BACKGROUND TASKS %%
    subgraph BgTasks ["STARTUP BACKGROUND TASKS (fail-open)"]
        DRIFT["run_startup_drift_check()<br/>━━━━━━━━━━<br/>hooks.json hash → self-heal<br/>exception: log+swallow"]
        HOOK_HEALTH["run_startup_hook_health_check()<br/>━━━━━━━━━━<br/>stale hook paths detection<br/>exception: log+swallow"]
        DEFERRED["deferred_initialize()<br/>━━━━━━━━━━<br/>audit load / recovery<br/>signals ready_event"]
    end

    %% SESSION TYPE RESOLUTION %%
    subgraph SessionRes ["SESSION TYPE RESOLUTION (● session_type() — fail-closed)"]
        ST_ENV[("AUTOSKILLIT_SESSION_TYPE<br/>env var")]
        ST_RESOLVE["● session_type()<br/>━━━━━━━━━━<br/>invalid/unset → LEAF<br/>DeprecationWarning: HEADLESS=1 w/o SESSION_TYPE"]
    end

    %% TERMINAL STATES %%
    T_SUCCESS([DISPATCH SUCCESS])
    T_FLEET_ERR([FLEET ERROR RETURNED])
    T_GATE_ERR([GATE ERROR RETURNED])
    T_TEARDOWN([LIFESPAN TEARDOWN])

    %% TEARDOWN %%
    subgraph Teardown ["TEARDOWN (lifespan finally)"]
        TDN_TASKS["cancel bg_tasks<br/>gather(return_exceptions=True)"]
        TDN_SENTINEL["cleanup_readiness_sentinel()<br/>━━━━━━━━━━<br/>exception: log+suppress"]
        TDN_KITCHEN["clear_kitchens_for_pid()<br/>━━━━━━━━━━<br/>exception: log+suppress"]
        TDN_RECORDER["_finalize_recorder()<br/>━━━━━━━━━━<br/>writes scenario.json<br/>exception: log+suppress"]
    end

    %% CONNECTIONS %%
    MCP_START --> SessionRes
    MCP_START --> Path1
    ST_ENV --> ST_RESOLVE
    ST_RESOLVE --> APPLY_VIS
    APPLY_VIS --> FLEET_GATE
    FLEET_GATE -->|"fleet disabled in env"| P1_DISABLE

    MCP_START --> LIFESPAN
    LIFESPAN --> DRIFT
    LIFESPAN --> HOOK_HEALTH
    LIFESPAN --> DEFERRED
    LIFESPAN -->|"SessionType.FLEET"| FLEET_BOOT
    FLEET_BOOT --> FEAT_SUPPRESS
    FEAT_SUPPRESS -->|"exception: log warning, continue"| BOOT_STEPS

    GATE_ENABLED -->|"gate closed"| ERR_GATE
    GATE_ENABLED -->|"gate open"| GATE_HEADLESS
    GATE_HEADLESS -->|"HEADLESS=1"| ERR_HEADLESS
    GATE_HEADLESS -->|"interactive"| GATE_FEATURE
    GATE_FEATURE -->|"fleet disabled in config"| ERR_FEATURE
    GATE_FEATURE -->|"fleet enabled"| GATE_LOCK
    GATE_LOCK -->|"locked"| ERR_LOCK
    GATE_LOCK -->|"free"| DISPATCH_EXEC
    DISPATCH_EXEC -->|"recipe/ingredient error"| ERR_RECIPE
    DISPATCH_EXEC -->|"L2 error"| ERR_INFRA
    DISPATCH_EXEC -->|"success"| T_SUCCESS

    ERR_GATE --> T_GATE_ERR
    ERR_HEADLESS --> FLEET_ERR_BUILDER
    ERR_FEATURE --> FLEET_ERR_BUILDER
    ERR_LOCK --> FLEET_ERR_BUILDER
    ERR_RECIPE --> FLEET_ERR_BUILDER
    ERR_INFRA --> FLEET_ERR_BUILDER
    FLEET_ERR_BUILDER --> T_FLEET_ERR

    LIFESPAN --> T_TEARDOWN
    T_TEARDOWN --> TDN_TASKS
    TDN_TASKS --> TDN_SENTINEL
    TDN_SENTINEL --> TDN_KITCHEN
    TDN_KITCHEN --> TDN_RECORDER

    %% CLASS ASSIGNMENTS %%
    class MCP_START terminal;
    class APPLY_VIS,FLEET_GATE,P1_DISABLE phase;
    class LIFESPAN,FLEET_BOOT handler;
    class FEAT_SUPPRESS,BOOT_STEPS phase;
    class GATE_ENABLED,GATE_HEADLESS,GATE_FEATURE,GATE_LOCK detector;
    class DISPATCH_EXEC handler;
    class DRIFT,HOOK_HEALTH,DEFERRED output;
    class ST_ENV stateNode;
    class ST_RESOLVE output;
    class ERR_GATE,ERR_HEADLESS,ERR_FEATURE,ERR_LOCK,ERR_RECIPE,ERR_INFRA gap;
    class FLEET_ERR_BUILDER integration;
    class TDN_TASKS,TDN_SENTINEL,TDN_KITCHEN,TDN_RECORDER output;
    class T_SUCCESS,T_FLEET_ERR,T_GATE_ERR,T_TEARDOWN terminal;
```

Closes #1250

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-1250-20260425-100136-722273/.autoskillit/temp/make-plan/fleet_runtime_gate_consistency_plan_2026-04-25_100524.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 243 | 16.9k | 1.6M | 74.6k | 1 | 5m 28s |
| verify | 108 | 10.8k | 475.1k | 47.8k | 1 | 4m 13s |
| implement | 2.2k | 12.7k | 1.0M | 45.5k | 1 | 5m 30s |
| fix | 588 | 33.7k | 4.1M | 144.5k | 3 | 26m 30s |
| prepare_pr | 60 | 5.7k | 192.6k | 25.6k | 1 | 1m 48s |
| run_arch_lenses | 2.6k | 27.4k | 866.7k | 136.4k | 3 | 11m 55s |
| compose_pr | 67 | 9.7k | 262.5k | 36.9k | 1 | 2m 52s |
| **Total** | 5.8k | 116.9k | 8.5M | 511.2k | | 58m 19s |