### PR TITLE
Implementation Plan: Test Marker Enforcement Gaps — Missing Fleet Markers, Zero Planner Enforcement, Campaign Recipe Exposure

### DIFF
--- a/src/autoskillit/core/_type_protocols.py
+++ b/src/autoskillit/core/_type_protocols.py
@@ -263,7 +263,12 @@ class RecipeRepository(Protocol):
         self, script_path: Any, temp_dir_relpath: str = ".autoskillit/temp"
     ) -> dict[str, Any]: ...
 
-    def list_all(self, project_dir: Any | None = None) -> dict[str, Any]: ...
+    def list_all(
+        self,
+        project_dir: Any | None = None,
+        *,
+        features: dict[str, bool] | None = None,
+    ) -> dict[str, Any]: ...
 
     async def apply_triage_gate(
         self,

--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -274,7 +274,7 @@ def list_all(
         {"recipes": list[{"name", "description", "summary"}]}
         Includes "errors" key when recipes fail to parse.
     """
-    from autoskillit.core.feature_flags import is_feature_enabled  # noqa: PLC0415
+    from autoskillit.core import is_feature_enabled  # noqa: PLC0415
     from autoskillit.recipe.schema import RecipeKind  # noqa: PLC0415
 
     _pdir = project_dir if project_dir is not None else Path.cwd()

--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -263,15 +263,25 @@ def format_recipe_list_response(result: LoadResult[RecipeInfo]) -> dict[str, obj
     return response
 
 
-def list_all(project_dir: Path | None = None) -> dict[str, Any]:
+def list_all(
+    project_dir: Path | None = None,
+    *,
+    features: dict[str, bool] | None = None,
+) -> dict[str, Any]:
     """List all recipes from project and built-in sources.
 
     Returns:
         {"recipes": list[{"name", "description", "summary"}]}
         Includes "errors" key when recipes fail to parse.
     """
+    from autoskillit.core.feature_flags import is_feature_enabled  # noqa: PLC0415
+    from autoskillit.recipe.schema import RecipeKind  # noqa: PLC0415
+
     _pdir = project_dir if project_dir is not None else Path.cwd()
-    result = list_recipes(_pdir)
+    _features = features or {}
+    fleet_enabled = is_feature_enabled("fleet", _features)
+    exclude_kinds = frozenset() if fleet_enabled else frozenset({RecipeKind.CAMPAIGN})
+    result = list_recipes(_pdir, exclude_kinds=exclude_kinds)
     return format_recipe_list_response(result)
 
 

--- a/src/autoskillit/recipe/io.py
+++ b/src/autoskillit/recipe/io.py
@@ -67,7 +67,10 @@ def load_recipe(path: Path, temp_dir_relpath: str = ".autoskillit/temp") -> Reci
     return recipe
 
 
-def list_recipes(project_dir: Path) -> LoadResult[RecipeInfo]:
+def list_recipes(
+    project_dir: Path,
+    exclude_kinds: frozenset[RecipeKind] = frozenset(),
+) -> LoadResult[RecipeInfo]:
     """Find available recipes from project and built-in sources."""
     seen: set[str] = set()
     items: list[RecipeInfo] = []
@@ -79,8 +82,9 @@ def list_recipes(project_dir: Path) -> LoadResult[RecipeInfo]:
     builtin_dir = pkg_root() / "recipes"
     _collect_recipes(RecipeSource.BUILTIN, builtin_dir, seen, items, errors)
 
+    filtered = [r for r in items if r.kind not in exclude_kinds] if exclude_kinds else items
     return LoadResult(
-        items=sorted(items, key=lambda r: (r.source != RecipeSource.BUILTIN, r.name)),
+        items=sorted(filtered, key=lambda r: (r.source != RecipeSource.BUILTIN, r.name)),
         errors=errors,
     )
 
@@ -410,6 +414,7 @@ def _collect_recipes(
                             recipe_version=recipe.recipe_version,
                             content_hash=_crh(f),
                             content=raw,
+                            kind=recipe.kind,
                         )
                     )
             except Exception as exc:

--- a/src/autoskillit/recipe/repository.py
+++ b/src/autoskillit/recipe/repository.py
@@ -98,8 +98,13 @@ class DefaultRecipeRepository:
     ) -> dict[str, Any]:
         return _api.validate_from_path(script_path, temp_dir_relpath=temp_dir_relpath)
 
-    def list_all(self, project_dir: Any | None = None) -> dict[str, Any]:
-        return _api.list_all(project_dir=project_dir)
+    def list_all(
+        self,
+        project_dir: Any | None = None,
+        *,
+        features: dict[str, bool] | None = None,
+    ) -> dict[str, Any]:
+        return _api.list_all(project_dir=project_dir, features=features)
 
     async def apply_triage_gate(
         self,

--- a/src/autoskillit/recipe/schema.py
+++ b/src/autoskillit/recipe/schema.py
@@ -174,6 +174,7 @@ class RecipeInfo:
     recipe_version: str | None = None
     content_hash: str = ""
     content: str | None = None  # raw YAML text; None when set via parse_recipe_metadata
+    kind: RecipeKind = RecipeKind.STANDARD
 
 
 @dataclass

--- a/src/autoskillit/server/tools_recipe.py
+++ b/src/autoskillit/server/tools_recipe.py
@@ -55,7 +55,7 @@ async def list_recipes() -> str:
         tool_ctx = _get_ctx_or_none()
         if tool_ctx is None or tool_ctx.recipes is None:
             return json.dumps([])
-        result = tool_ctx.recipes.list_all(Path.cwd())
+        result = tool_ctx.recipes.list_all(Path.cwd(), features=tool_ctx.config.features)
         return json.dumps(result)
     except Exception:
         logger.error("list_recipes unhandled exception", exc_info=True)

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -131,7 +131,7 @@ _CORE_UNIVERSAL_MODULES: frozenset[str] = frozenset(
 
 MODULE_CASCADE_CORE: dict[str, frozenset[str]] = {
     "readiness": frozenset({"core", "server"}),
-    "feature_flags": frozenset({"core", "cli", "config", "server", "workspace"}),
+    "feature_flags": frozenset({"core", "cli", "config", "recipe", "server", "workspace"}),
     "kitchen_state": frozenset({"core", "cli", "server"}),
     "branch_guard": frozenset({"core", "pipeline", "server", "workspace"}),
     "_plugin_ids": frozenset({"core", "cli", "server"}),

--- a/tests/arch/test_feature_markers.py
+++ b/tests/arch/test_feature_markers.py
@@ -45,6 +45,9 @@ _FLEET_FUNC_MARKERS: dict[str, set[str]] = {
         "test_A12_require_fleet_denies_orchestrator",
         "test_A13_require_fleet_denies_interactive_no_session_type",
     },
+    "server/test_tools_recipe.py": {
+        "test_list_recipes_mcp_tool_hides_campaign_when_fleet_disabled",
+    },
 }
 
 # Auto-discover all test files in the planner directory — self-maintaining
@@ -103,7 +106,7 @@ def _func_has_feature_decorator(source: str, func_name: str, feature_name: str) 
     """Return True if func_name has @pytest.mark.feature(feature_name) in its decorator list."""
     tree = ast.parse(source)
     for node in ast.walk(tree):
-        if not isinstance(node, ast.FunctionDef) or node.name != func_name:
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) or node.name != func_name:
             continue
         for dec in node.decorator_list:
             if (

--- a/tests/arch/test_feature_markers.py
+++ b/tests/arch/test_feature_markers.py
@@ -32,8 +32,23 @@ _ALL_FLEET_FILES = [*_FLEET_DIR_FILES, *_FLEET_CROSS_DIR_FILES]
 
 # Classes within mixed files that MUST carry @pytest.mark.feature("fleet")
 _FLEET_CLASS_MARKERS: dict[str, set[str]] = {
-    "server/test_server_init.py": {"TestSessionTypeVisibility"},
+    "server/test_server_init.py": {"TestSessionTypeVisibility", "TestFeatureGateVisibility"},
+    "server/test_tools_execution.py": {"TestTierAwareGateEnforcement"},
+    "cli/test_doctor.py": {"TestGroupMFranchiseDoctorChecks", "TestGroupNFeatureGateDoctorChecks"},
 }
+
+# Standalone functions within mixed files that MUST carry @pytest.mark.feature("fleet")
+_FLEET_FUNC_MARKERS: dict[str, set[str]] = {
+    "cli/test_reload_loop.py": {"test_fleet_reload_relaunches_without_resume"},
+    "server/test_helpers_tier_guards.py": {
+        "test_A11_require_fleet_permits_fleet_session",
+        "test_A12_require_fleet_denies_orchestrator",
+        "test_A13_require_fleet_denies_interactive_no_session_type",
+    },
+}
+
+# Auto-discover all test files in the planner directory — self-maintaining
+_PLANNER_DIR_FILES = sorted((_TESTS_ROOT / "planner").glob("test_*.py"))
 
 # Infrastructure files that must NOT have a feature("fleet") pytestmark
 _INFRASTRUCTURE_FILE_EXCLUSIONS = [
@@ -84,6 +99,25 @@ def _class_has_feature_decorator(source: str, class_name: str, feature_name: str
     return False
 
 
+def _func_has_feature_decorator(source: str, func_name: str, feature_name: str) -> bool:
+    """Return True if func_name has @pytest.mark.feature(feature_name) in its decorator list."""
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef) or node.name != func_name:
+            continue
+        for dec in node.decorator_list:
+            if (
+                isinstance(dec, ast.Call)
+                and isinstance(dec.func, ast.Attribute)
+                and dec.func.attr == "feature"
+                and dec.args
+                and isinstance(dec.args[0], ast.Constant)
+                and dec.args[0].value == feature_name
+            ):
+                return True
+    return False
+
+
 def test_fleet_test_files_carry_feature_marker():
     """Every fleet-specific test file must have feature('fleet') in its pytestmark."""
     missing = []
@@ -110,6 +144,35 @@ def test_fleet_class_markers_present():
                 missing.append(f"{rel}::{cls}")
     assert not missing, "These classes are missing @pytest.mark.feature('fleet'):\n" + "\n".join(
         f"  {r}" for r in missing
+    )
+
+
+def test_fleet_func_markers_present():
+    """Specific test functions in mixed files must carry @pytest.mark.feature('fleet')."""
+    missing = []
+    for rel, func_names in _FLEET_FUNC_MARKERS.items():
+        path = _TESTS_ROOT / rel
+        assert path.exists(), f"Expected test file not found: {path}"
+        source = path.read_text()
+        for fn in func_names:
+            if not _func_has_feature_decorator(source, fn, "fleet"):
+                missing.append(f"{rel}::{fn}")
+    assert not missing, "These functions are missing @pytest.mark.feature('fleet'):\n" + "\n".join(
+        f"  {r}" for r in missing
+    )
+
+
+def test_planner_test_files_carry_feature_marker():
+    """Every planner test file must have feature('planner') in its pytestmark."""
+    missing = []
+    for path in _PLANNER_DIR_FILES:
+        rel = path.relative_to(_TESTS_ROOT)
+        assert path.exists(), f"Expected planner test file not found: {path}"
+        if not _pytestmark_has_feature(path.read_text(), "planner"):
+            missing.append(str(rel))
+    assert not missing, (
+        "These files are missing pytest.mark.feature('planner') in pytestmark:\n"
+        + "\n".join(f"  {r}" for r in missing)
     )
 
 

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -1938,6 +1938,7 @@ def test_check_installed_plugins_entry_flat_structure_is_warning(tmp_path: Path)
     assert result.severity == Severity.WARNING
 
 
+@pytest.mark.feature("fleet")
 class TestGroupMFranchiseDoctorChecks:
     """Group M: Fleet doctor checks (ambient env detection + infra health + campaign ops)."""
 
@@ -2251,6 +2252,7 @@ class TestGroupMFranchiseDoctorChecks:
         assert fleet_checks <= check_names
 
 
+@pytest.mark.feature("fleet")
 class TestGroupNFeatureGateDoctorChecks:
     """N1–N8: Feature-gate checks and FleetConfig conditional validation."""
 

--- a/tests/cli/test_reload_loop.py
+++ b/tests/cli/test_reload_loop.py
@@ -188,6 +188,7 @@ def test_interactive_session_reload_uses_named_resume(
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.feature("fleet")
 def test_fleet_reload_relaunches_without_resume(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/planner/test_compiler.py
+++ b/tests/planner/test_compiler.py
@@ -9,7 +9,7 @@ import pytest
 
 from autoskillit.planner.compiler import compile_plan
 
-pytestmark = [pytest.mark.layer("planner"), pytest.mark.small]
+pytestmark = [pytest.mark.layer("planner"), pytest.mark.small, pytest.mark.feature("planner")]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/planner/test_manifests.py
+++ b/tests/planner/test_manifests.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = [pytest.mark.layer("planner"), pytest.mark.small]
+pytestmark = [pytest.mark.layer("planner"), pytest.mark.small, pytest.mark.feature("planner")]
 
 
 def test_check_remaining_pending_to_processing(tmp_path):

--- a/tests/planner/test_planner.py
+++ b/tests/planner/test_planner.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-pytestmark = [pytest.mark.layer("planner"), pytest.mark.small]
+pytestmark = [pytest.mark.layer("planner"), pytest.mark.small, pytest.mark.feature("planner")]
 
 
 def test_planner_package_importable() -> None:

--- a/tests/planner/test_validation.py
+++ b/tests/planner/test_validation.py
@@ -9,7 +9,7 @@ import pytest
 
 from autoskillit.planner.validation import validate_plan
 
-pytestmark = [pytest.mark.layer("planner"), pytest.mark.small]
+pytestmark = [pytest.mark.layer("planner"), pytest.mark.small, pytest.mark.feature("planner")]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/recipe/test_io.py
+++ b/tests/recipe/test_io.py
@@ -17,6 +17,7 @@ from autoskillit.recipe.io import (
 )
 from autoskillit.recipe.schema import (
     Recipe,
+    RecipeKind,
     RecipeStep,
     StepResultRoute,
 )
@@ -528,6 +529,40 @@ class TestListRecipes:
         assert project_names == sorted(project_names), (
             f"Project recipes not in alphabetical order: {project_names}"
         )
+
+    def test_list_recipes_excludes_campaign_when_fleet_disabled(self, tmp_path: Path) -> None:
+        """list_recipes with exclude_kinds={CAMPAIGN} must omit campaign-kind recipes."""
+        recipe_dir = tmp_path / ".autoskillit" / "recipes"
+        recipe_dir.mkdir(parents=True)
+        (recipe_dir / "my-campaign.yaml").write_text(
+            "name: my-campaign\ndescription: test\nkind: campaign\nsteps: {}\n"
+        )
+        result = list_recipes(tmp_path, exclude_kinds=frozenset({RecipeKind.CAMPAIGN}))
+        assert all(r.kind != RecipeKind.CAMPAIGN for r in result.items)
+
+    def test_list_recipes_includes_campaign_when_fleet_enabled(self, tmp_path: Path) -> None:
+        """list_recipes with no exclusions must include campaign-kind recipes."""
+        recipe_dir = tmp_path / ".autoskillit" / "recipes"
+        recipe_dir.mkdir(parents=True)
+        (recipe_dir / "my-campaign.yaml").write_text(
+            "name: my-campaign\ndescription: test\nkind: campaign\nsteps: {}\n"
+        )
+        result = list_recipes(tmp_path)
+        names = [r.name for r in result.items]
+        assert "my-campaign" in names
+
+    def test_recipe_info_kind_field_populated(self, tmp_path: Path) -> None:
+        """RecipeInfo.kind must be populated from the YAML kind field."""
+        recipe_dir = tmp_path / ".autoskillit" / "recipes"
+        recipe_dir.mkdir(parents=True)
+        (recipe_dir / "std.yaml").write_text("name: std\ndescription: standard\nsteps: {}\n")
+        (recipe_dir / "camp.yaml").write_text(
+            "name: camp\ndescription: campaign\nkind: campaign\nsteps: {}\n"
+        )
+        result = list_recipes(tmp_path)
+        kinds = {r.name: r.kind for r in result.items}
+        assert kinds["std"] == RecipeKind.STANDARD
+        assert kinds["camp"] == RecipeKind.CAMPAIGN
 
 
 class TestBuiltinRecipesDir:

--- a/tests/recipe/test_repository.py
+++ b/tests/recipe/test_repository.py
@@ -183,7 +183,7 @@ def test_list_all_delegates_to_api() -> None:
         result = repo.list_all()
 
     assert result == expected
-    mock_api.assert_called_once_with(project_dir=None)
+    mock_api.assert_called_once_with(project_dir=None, features=None)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/server/test_helpers_tier_guards.py
+++ b/tests/server/test_helpers_tier_guards.py
@@ -128,6 +128,7 @@ def test_A10_require_orchestrator_exact_denies_headless_leaf(monkeypatch) -> Non
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.feature("fleet")
 def test_A11_require_fleet_permits_fleet_session(monkeypatch) -> None:
     monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
     from autoskillit.server.helpers import _require_fleet
@@ -135,6 +136,7 @@ def test_A11_require_fleet_permits_fleet_session(monkeypatch) -> None:
     assert _require_fleet() is None
 
 
+@pytest.mark.feature("fleet")
 def test_A12_require_fleet_denies_orchestrator(monkeypatch) -> None:
     monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "orchestrator")
     from autoskillit.server.helpers import _require_fleet
@@ -145,6 +147,7 @@ def test_A12_require_fleet_denies_orchestrator(monkeypatch) -> None:
     assert data["subtype"] == "headless_error"
 
 
+@pytest.mark.feature("fleet")
 def test_A13_require_fleet_denies_interactive_no_session_type(monkeypatch) -> None:
     monkeypatch.delenv("AUTOSKILLIT_SESSION_TYPE", raising=False)
     monkeypatch.delenv("AUTOSKILLIT_HEADLESS", raising=False)

--- a/tests/server/test_server_init.py
+++ b/tests/server/test_server_init.py
@@ -1096,6 +1096,7 @@ class TestFleetAutoGateBoot:
             assert name not in tool_names, f"{name} should be hidden when fleet feature disabled"
 
 
+@pytest.mark.feature("fleet")
 class TestFeatureGateVisibility:
     """Feature gate override layer in _apply_session_type_visibility."""
 

--- a/tests/server/test_tools_execution.py
+++ b/tests/server/test_tools_execution.py
@@ -965,6 +965,7 @@ class TestHeadlessGateEnforcement:
         assert result["subtype"] == "headless_error"
 
 
+@pytest.mark.feature("fleet")
 class TestTierAwareGateEnforcement:
     """T_TAGE: tier-aware guard permits orchestrator, denies leaf and fleet as appropriate."""
 

--- a/tests/server/test_tools_recipe.py
+++ b/tests/server/test_tools_recipe.py
@@ -456,6 +456,7 @@ async def test_validate_recipe_no_recipes_returns_error(tool_ctx, tmp_path):
 
 # T7: list_recipes MCP tool hides campaign when fleet disabled
 @pytest.mark.anyio
+@pytest.mark.feature("fleet")
 async def test_list_recipes_mcp_tool_hides_campaign_when_fleet_disabled(
     tool_ctx, tmp_path, monkeypatch
 ):

--- a/tests/server/test_tools_recipe.py
+++ b/tests/server/test_tools_recipe.py
@@ -7,6 +7,7 @@ import re
 
 import pytest
 
+from autoskillit.server.tools_recipe import list_recipes as list_recipes_tool
 from autoskillit.server.tools_recipe import validate_recipe
 
 pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
@@ -451,6 +452,29 @@ async def test_validate_recipe_no_recipes_returns_error(tool_ctx, tmp_path):
     tool_ctx.recipes = None
     result = json.loads(await validate_recipe(script_path=str(tmp_path / "x.yaml")))
     assert result.get("valid") is False
+
+
+# T7: list_recipes MCP tool hides campaign when fleet disabled
+@pytest.mark.anyio
+async def test_list_recipes_mcp_tool_hides_campaign_when_fleet_disabled(
+    tool_ctx, tmp_path, monkeypatch
+):
+    """list_recipes MCP tool must exclude campaign recipes when fleet feature is disabled."""
+    from pathlib import Path
+
+    recipe_dir = tmp_path / ".autoskillit" / "recipes"
+    recipe_dir.mkdir(parents=True)
+    (recipe_dir / "my-campaign.yaml").write_text(
+        "name: my-campaign\ndescription: test\nkind: campaign\nsteps: {}\n"
+    )
+    tool_ctx.config.features["fleet"] = False
+    monkeypatch.setattr(Path, "cwd", lambda: tmp_path)
+    raw = await list_recipes_tool()
+    result = json.loads(raw)
+    recipe_names = [r["name"] for r in result.get("recipes", [])]
+    assert "my-campaign" not in recipe_names, (
+        "Campaign recipe must not appear when fleet feature is disabled"
+    )
 
 
 # P5F2-T4  (import hygiene check)

--- a/tests/test_test_filter_core_cascade.py
+++ b/tests/test_test_filter_core_cascade.py
@@ -55,7 +55,7 @@ class TestModuleCascadeCore:
 
     def test_feature_flags_cascade(self) -> None:
         assert MODULE_CASCADE_CORE["feature_flags"] == frozenset(
-            {"core", "cli", "config", "server", "workspace"}
+            {"core", "cli", "config", "recipe", "server", "workspace"}
         )
 
     def test_branch_guard_cascade(self) -> None:


### PR DESCRIPTION
## Summary

Three enforcement gaps in the feature-gate infrastructure are addressed: (1) five mixed-mode test files exercising fleet code lacked `@pytest.mark.feature("fleet")` markers and the AST enforcer was incomplete; (2) all four `tests/planner/` files omitted `pytest.mark.feature("planner")` with zero planner enforcement in `test_feature_markers.py`; (3) `list_recipes`/`_collect_recipes` in `recipe/io.py` had no `kind` filter and `RecipeInfo` carried no `kind` field, exposing campaign-kind recipes regardless of fleet feature state.

The fix adds markers to the affected test files, extends the AST enforcer for both function-level fleet markers and planner file markers, adds `kind` to `RecipeInfo`, and threads a `features`-driven filter through `list_recipes` → `list_all`.

## Requirements

- [ ] REQ-TME-001: Add `pytest.mark.feature("fleet")` to `test_reload_loop.py` (file-level or on fleet-specific test functions)
- [ ] REQ-TME-002: Add `pytest.mark.feature("fleet")` to fleet test classes in `test_doctor.py` (`TestGroupMFranchiseDoctorChecks`, `TestGroupNFeatureGateDoctorChecks`)
- [ ] REQ-TME-003: Add `pytest.mark.feature("fleet")` to fleet test functions/classes in `test_helpers_tier_guards.py`
- [ ] REQ-TME-004: Add `TestTierAwareGateEnforcement` to `_FLEET_CLASS_MARKERS` for `test_tools_execution.py` and `TestFeatureGateVisibility` to `_FLEET_CLASS_MARKERS` for `test_server_init.py`
- [ ] REQ-TME-005: Update `_FLEET_CROSS_DIR_FILES` with `test_reload_loop.py`, `test_doctor.py`, `test_helpers_tier_guards.py` entries (or use class-level markers via `_FLEET_CLASS_MARKERS`)
- [ ] REQ-TME-006: Add planner enforcement to `test_feature_markers.py` — create `_PLANNER_DIR_FILES` (all 4 files in `tests/planner/`), add `test_planner_test_files_carry_feature_marker()` test
- [ ] REQ-TME-007: Add `pytest.mark.feature("planner")` to all 4 `tests/planner/test_*.py` files
- [ ] REQ-TME-008: Filter `kind: campaign` recipes from `list_recipes` output when fleet feature is disabled, or add a `feature_gate` field to `RecipeKind.CAMPAIGN` that ties it to the fleet feature

## Architecture Impact

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph L3 ["L3 — SERVER LAYER"]
        direction LR
        TOOLS_RECIPE["● server/tools_recipe<br/>━━━━━━━━━━<br/>MCP: list_recipes, load_recipe<br/>validate_recipe, migrate_recipe<br/>Fleet-gated campaign filtering"]
    end

    subgraph L2 ["L2 — RECIPE DOMAIN"]
        direction TB
        REPO["● recipe/repository<br/>━━━━━━━━━━<br/>DefaultRecipeRepository<br/>Implements RecipeRepository<br/>protocol; delegates to _api"]
        API["● recipe/_api<br/>━━━━━━━━━━<br/>load_and_validate(lister?)<br/>list_all, format_recipe_list<br/>Orchestration API"]
        IO["● recipe/io<br/>━━━━━━━━━━<br/>load_recipe, list_recipes<br/>_parse_recipe, iter_steps<br/>RecipeKind population"]
        SCHEMA["● recipe/schema<br/>━━━━━━━━━━<br/>Recipe, RecipeInfo, RecipeKind<br/>RecipeIngredient, RecipeStep<br/>CampaignDispatch"]
    end

    subgraph L1 ["L1 — PIPELINE"]
        direction LR
        PIPELINE["pipeline<br/>━━━━━━━━━━<br/>GATED_TOOLS<br/>UNGATED_TOOLS"]
    end

    subgraph L0 ["L0 — FOUNDATION (CORE)"]
        direction LR
        PROTOCOLS["● core/_type_protocols<br/>━━━━━━━━━━<br/>RecipeRepository (Protocol)<br/>SkillLister (Protocol)<br/>MigrationService, etc."]
        RESULTS["core/_type_results<br/>━━━━━━━━━━<br/>LoadResult, LoadReport<br/>SkillResult, etc."]
        CONSTANTS["core/_type_constants<br/>━━━━━━━━━━<br/>FLEET_TOOLS, SKILL_TOOLS<br/>GATED_TOOLS, etc."]
    end

    subgraph EXT ["EXTERNAL"]
        direction LR
        FASTMCP["fastmcp<br/>━━━━━━━━━━<br/>MCP server framework"]
        STDLIB["stdlib / YAML<br/>━━━━━━━━━━<br/>pathlib, typing, pyyaml"]
    end

    subgraph TESTS ["TESTS (modified)"]
        direction TB
        T_MARKERS["● tests/arch/test_feature_markers<br/>━━━━━━━━━━<br/>Enforces pytestmark fleet/planner<br/>per-file & per-class/fn"]
        T_REPO["● tests/recipe/test_repository<br/>━━━━━━━━━━<br/>DefaultRecipeRepository behavior<br/>RecipeRepository protocol shape"]
        T_IO["● tests/recipe/test_io<br/>━━━━━━━━━━<br/>RecipeKind parsing, YAML fields<br/>schema-drift guard"]
        T_SRV["● tests/server/test_tools_recipe<br/>━━━━━━━━━━<br/>Fleet filter, docstring contracts<br/>validate_recipe tool"]
        T_PLANNER["● tests/planner/* (4 files)<br/>━━━━━━━━━━<br/>Marker & tier guard updates"]
        T_SERVER["● tests/server/* (3 files)<br/>━━━━━━━━━━<br/>Marker, init, execution updates"]
    end

    %% VALID DEPENDENCIES (Downward) %%
    TOOLS_RECIPE -->|"ctx.recipes : RecipeRepository"| REPO
    TOOLS_RECIPE -->|"GATED/UNGATED_TOOLS"| PIPELINE
    TOOLS_RECIPE -->|"RecipeRepository protocol type"| PROTOCOLS
    TOOLS_RECIPE -->|"get_logger, temp_dir_display_str"| RESULTS

    REPO -->|"delegates load_and_validate<br/>list_all, validate_from_path"| API
    REPO -->|"list_recipes, load_recipe<br/>builtin_recipes_dir"| IO
    REPO -.->|"implements protocol"| PROTOCOLS

    API -->|"_parse_recipe, list_recipes<br/>iter_steps_with_context"| IO
    API -->|"Recipe, RecipeInfo, RecipeKind"| SCHEMA
    API -->|"LoadResult, RecipeSource<br/>SkillLister, pkg_root"| PROTOCOLS
    API -->|"LoadResult, LoadReport"| RESULTS

    IO -->|"Recipe, RecipeInfo, RecipeKind<br/>RecipeStep, CampaignDispatch"| SCHEMA
    IO -->|"LoadResult, RecipeSource<br/>load_yaml, pkg_root"| RESULTS

    SCHEMA -->|"RecipeSource"| CONSTANTS
    PROTOCOLS -->|"LoadResult, SkillResult"| RESULTS
    PROTOCOLS -.->|"TYPE_CHECKING only:<br/>Recipe, RecipeInfo"| SCHEMA

    PIPELINE -->|"GATED_TOOLS, FREE_RANGE_TOOLS"| CONSTANTS

    TOOLS_RECIPE -->|"mcp, _state"| FASTMCP
    IO -->|"YAML parsing"| STDLIB
    SCHEMA -->|"dataclasses, typing"| STDLIB

    %% TEST DEPENDENCIES %%
    T_MARKERS -.->|"tests"| PROTOCOLS
    T_MARKERS -.->|"tests"| CONSTANTS
    T_REPO -.->|"tests"| REPO
    T_REPO -.->|"tests"| PROTOCOLS
    T_IO -.->|"tests"| IO
    T_IO -.->|"tests"| SCHEMA
    T_SRV -.->|"tests"| TOOLS_RECIPE
    T_SRV -.->|"tests"| FASTMCP

    %% CLASS ASSIGNMENTS %%
    class TOOLS_RECIPE cli;
    class PROTOCOLS,RESULTS,CONSTANTS stateNode;
    class REPO,API handler;
    class IO,SCHEMA phase;
    class PIPELINE output;
    class FASTMCP,STDLIB integration;
    class T_MARKERS,T_REPO,T_IO,T_SRV,T_PLANNER,T_SERVER detector;
```

### Scenarios Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph S1 ["SCENARIO 1: Fleet-Gated Recipe Listing"]
        direction LR
        S1_TOOL["● tools_recipe.py<br/>━━━━━━━━━━<br/>list_recipes MCP tool<br/>passes config.features"]
        S1_REPO["● DefaultRecipeRepository<br/>━━━━━━━━━━<br/>list_all(features=dict)<br/>● protocol: features param"]
        S1_API["● _api.list_all()<br/>━━━━━━━━━━<br/>calls is_feature_enabled<br/>builds exclude_kinds"]
        S1_GATE{"fleet<br/>enabled?"}
        S1_IO["● io.list_recipes()<br/>━━━━━━━━━━<br/>filter: r.kind not in<br/>exclude_kinds"]
        S1_OUT["RecipeInfo list<br/>━━━━━━━━━━<br/>campaign recipes absent<br/>when fleet=False"]
    end

    subgraph S2 ["SCENARIO 2: Recipe Load with Kind Resolution"]
        direction LR
        S2_TOOL["● tools_recipe.py<br/>━━━━━━━━━━<br/>load_recipe MCP tool<br/>name + overrides"]
        S2_REPO["● repository.find()<br/>━━━━━━━━━━<br/>mtime-cached lookup<br/>returns RecipeInfo"]
        S2_API["● _api.load_and_validate()<br/>━━━━━━━━━━<br/>reads YAML file<br/>substitutes placeholders"]
        S2_PARSE["● io._parse_recipe()<br/>━━━━━━━━━━<br/>reads kind: field<br/>defaults to standard"]
        S2_SCHEMA["● schema.RecipeKind<br/>━━━━━━━━━━<br/>STANDARD | CAMPAIGN<br/>on Recipe + RecipeInfo"]
    end

    subgraph S3 ["SCENARIO 3: Feature Marker AST Enforcement"]
        direction LR
        S3_ENTRY["test_feature_markers.py<br/>━━━━━━━━━━<br/>pytest collection time<br/>no imports of tested modules"]
        S3_GLOB["_ALL_FLEET_FILES glob<br/>━━━━━━━━━━<br/>tests/fleet/ + 4 cross-dir<br/>_PLANNER_DIR_FILES glob"]
        S3_PARSE["ast.parse(source)<br/>━━━━━━━━━━<br/>_pytestmark_has_feature<br/>_class/func_has_feature_decorator"]
        S3_CHECK{"marker<br/>present?"}
        S3_PASS["assert not missing<br/>━━━━━━━━━━<br/>fleet files: pytest.mark.feature(fleet)<br/>planner files: pytest.mark.feature(planner)"]
        S3_FAIL["test FAIL<br/>━━━━━━━━━━<br/>offending paths listed<br/>_INFRASTRUCTURE_FILE_EXCLUSIONS"]
    end

    subgraph S4 ["SCENARIO 4: Server Tier Guard — _require_fleet"]
        direction LR
        S4_CALL["fleet MCP tool call<br/>━━━━━━━━━━<br/>e.g. dispatch_food_truck<br/>SESSION_TYPE env present"]
        S4_PROTO["● RecipeRepository protocol<br/>━━━━━━━━━━<br/>_type_protocols.py<br/>list_all signature updated"]
        S4_GUARD["server/helpers.py<br/>━━━━━━━━━━<br/>_require_fleet()<br/>reads SESSION_TYPE"]
        S4_CHECK{"session_type<br/>== fleet?"}
        S4_OK["tool handler proceeds<br/>━━━━━━━━━━<br/>fleet session passes<br/>returns None (no error)"]
        S4_DENY["error result<br/>━━━━━━━━━━<br/>subtype: headless_error<br/>orchestrator/leaf denied"]
    end

    subgraph S5 ["SCENARIO 5: Planner Feature Registry Gate"]
        direction LR
        S5_SKILL["planner skill invoked<br/>━━━━━━━━━━<br/>e.g. build_assignment_manifest<br/>via run_skill or CLI"]
        S5_REG["FEATURE_REGISTRY[planner]<br/>━━━━━━━━━━<br/>skill_categories={planner}<br/>default_enabled=False"]
        S5_FLAG["is_feature_enabled()<br/>━━━━━━━━━━<br/>reads features dict<br/>core/feature_flags.py"]
        S5_CHECK{"planner<br/>enabled?"}
        S5_ALLOWED["skill executes<br/>━━━━━━━━━━<br/>session_skills.py filters<br/>by skill_categories"]
        S5_BLOCKED["skill unavailable<br/>━━━━━━━━━━<br/>planner category excluded<br/>from session skill set"]
    end

    %% SCENARIO 1 FLOW %%
    S1_TOOL -->|"features=config.features"| S1_REPO
    S1_REPO -->|"delegates"| S1_API
    S1_API --> S1_GATE
    S1_GATE -->|"False: exclude CAMPAIGN"| S1_IO
    S1_GATE -->|"True: exclude_kinds=empty"| S1_IO
    S1_IO -->|"filtered list"| S1_OUT

    %% SCENARIO 2 FLOW %%
    S2_TOOL -->|"name lookup"| S2_REPO
    S2_REPO -->|"RecipeInfo + path"| S2_API
    S2_API -->|"YAML data"| S2_PARSE
    S2_PARSE -->|"kind field"| S2_SCHEMA

    %% SCENARIO 3 FLOW %%
    S3_ENTRY -->|"resolve paths"| S3_GLOB
    S3_GLOB -->|"read_text()"| S3_PARSE
    S3_PARSE --> S3_CHECK
    S3_CHECK -->|"present"| S3_PASS
    S3_CHECK -->|"missing"| S3_FAIL

    %% SCENARIO 4 FLOW %%
    S4_CALL -->|"context"| S4_PROTO
    S4_PROTO -->|"type boundary"| S4_GUARD
    S4_GUARD --> S4_CHECK
    S4_CHECK -->|"fleet"| S4_OK
    S4_CHECK -->|"other"| S4_DENY

    %% SCENARIO 5 FLOW %%
    S5_SKILL -->|"feature lookup"| S5_REG
    S5_REG -->|"calls"| S5_FLAG
    S5_FLAG --> S5_CHECK
    S5_CHECK -->|"True"| S5_ALLOWED
    S5_CHECK -->|"False"| S5_BLOCKED

    %% CLASS ASSIGNMENTS %%
    class S1_TOOL,S2_TOOL,S4_CALL,S5_SKILL cli;
    class S1_REPO,S2_REPO,S1_API,S2_API handler;
    class S1_IO,S2_PARSE phase;
    class S1_OUT,S2_SCHEMA,S3_PASS,S4_OK,S5_ALLOWED output;
    class S1_GATE,S3_CHECK,S4_CHECK,S5_CHECK phase;
    class S3_ENTRY,S3_GLOB integration;
    class S3_PARSE,S3_FAIL,S4_DENY,S5_BLOCKED detector;
    class S4_GUARD,S4_PROTO,S5_REG,S5_FLAG stateNode;
```

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 65, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START([RECIPE LOAD REQUEST])

    subgraph FieldLifecycles ["FIELD LIFECYCLE CATEGORIES (● schema.py, ● io.py)"]
        direction LR
        FROZEN["RecipeBlock — INIT_ONLY<br/>━━━━━━━━━━<br/>frozen=True dataclass<br/>name, entry, exit, members<br/>tool_counts, gh_api_occurrences<br/>Immutable after extract_blocks()"]
        DEFERRED["● Recipe — DEFERRED_INIT<br/>━━━━━━━━━━<br/>content_hash ← compute_recipe_hash()<br/>composite_hash ← sub-recipe merge<br/>blocks ← extract_blocks() post-load<br/>step.name ← YAML dict key"]
        KIND_SENTINEL["● RecipeInfo — INIT fields<br/>━━━━━━━━━━<br/>kind: RecipeKind = STANDARD<br/>  Set in _collect_recipes()<br/>content: str | None<br/>  None = metadata-only sentinel"]
        MUTABLE["Recipe fields — MUTABLE<br/>━━━━━━━━━━<br/>name, description, summary<br/>ingredients, steps, kitchen_rules<br/>Normalised via __post_init__"]
        APPEND["suggestions[] — APPEND_ONLY<br/>━━━━━━━━━━<br/>[] → extend() at 4 sites<br/>semantic + contract + diagram<br/>+ staleness findings<br/>Never shrinks in a load pass"]
    end

    subgraph ValidationGates ["VALIDATION GATES (● tools_recipe.py, ● _api.py, ● io.py)"]
        direction TB
        GATE_IMPORT["_PARSE_STEP_HANDLED_FIELDS<br/>━━━━━━━━━━<br/>IMPORT-TIME schema sync guard<br/>frozenset assertion at module load<br/>Fails if RecipeStep fields drift<br/>from _parse_step coverage"]
        GATE_POSTINIT["__post_init__ normalisation<br/>━━━━━━━━━━<br/>RecipeIngredient + Recipe<br/>Strip whitespace, collapse newlines<br/>kitchen_rules must be list<br/>recipe_version must be string"]
        GATE_KITCHEN["● _require_enabled()<br/>━━━━━━━━━━<br/>KITCHEN OPEN GATE<br/>All 4 tools_recipe handlers<br/>Returns gate string if closed<br/>Short-circuits before any IO"]
        GATE_FLEET["● is_feature_enabled('fleet')<br/>━━━━━━━━━━<br/>FLEET FEATURE GATE<br/>fleet=False → exclude_kinds={CAMPAIGN}<br/>Reads config.features from tools layer<br/>Filters RecipeInfo by .kind field"]
        GATE_STRUCT["validate_recipe() + run_semantic_rules()<br/>━━━━━━━━━━<br/>STRUCTURAL: DAG cycles, field rules<br/>SEMANTIC: model-on-non-skill, dead-output<br/>CONTRACT: validate_recipe_cards()<br/>All three sources feed validity"]
        GATE_VALID["● compute_recipe_validity()<br/>━━━━━━━━━━<br/>DERIVED valid bool<br/>errors ∪ semantic_findings<br/>∪ contract_findings → bool<br/>Written to LoadRecipeResult"]
    end

    subgraph CacheCheckpoint ["CACHE / CHECKPOINT STATE (● _api.py, ● repository.py)"]
        direction LR
        LOAD_CACHE["● _LOAD_CACHE (in-memory)<br/>━━━━━━━━━━<br/>threading.Lock protected dict<br/>5-key freshness check:<br/>mtime + size + pkg_version<br/>+ project_dir_mtime + builtin_dir_mtime"]
        REPO_CACHE["● DefaultRecipeRepository cache<br/>━━━━━━━━━━<br/>4-key invalidation:<br/>_cached_list, _cached_project_dir<br/>_cached_project_mtime<br/>_cached_builtin_mtime"]
        STALENESS["● recipe_staleness_cache.json<br/>━━━━━━━━━━<br/>Disk checkpoint: StalenessEntry<br/>triage_result: None→cosmetic→meaningful<br/>Cache key: recipe_hash + manifest_version<br/>apply_triage_gate() reads + writes"]
        AUDIT_RESUME["AuditLog.load_from_log_dir()<br/>━━━━━━━━━━<br/>RESUME pattern (Protocol)<br/>Reconstructs failure state from disk<br/>Filters: since + kitchen_id<br/>+ campaign_id + cwd_filter"]
    end

    subgraph MarkerEnforcement ["● FEATURE MARKER AST ENFORCEMENT (tests/arch/test_feature_markers.py)"]
        direction TB
        FLEET_MARKER["● test_fleet_*_feature_marker<br/>━━━━━━━━━━<br/>AST walk: pytestmark assignment<br/>+ class/func decorator checks<br/>_ALL_FLEET_FILES must carry<br/>pytest.mark.feature('fleet')"]
        PLANNER_MARKER["● test_planner_*_feature_marker<br/>━━━━━━━━━━<br/>AST walk: tests/planner/ dir<br/>pytest.mark.feature('planner')<br/>Import-safe smoke: FEATURES=''<br/>checks clean import path"]
        INFRA_EXCLUSION["● test_no_feature_marker_infra<br/>━━━━━━━━━━<br/>NEGATIVE guard<br/>Infrastructure files must NOT<br/>carry fleet marker<br/>_INFRASTRUCTURE_FILE_EXCLUSIONS"]
        TOOL_GATE_TEST["● test_tool_listing_matches_feature_state<br/>━━━━━━━━━━<br/>fleet=True → FLEET_TOOLS present<br/>fleet=False → FLEET_TOOLS absent<br/>Validates runtime gate<br/>matches feature flag state"]
    end

    %% FLOW %%
    START --> GATE_IMPORT
    GATE_IMPORT --> GATE_POSTINIT
    GATE_POSTINIT --> GATE_KITCHEN

    GATE_KITCHEN -->|kitchen open| REPO_CACHE
    GATE_KITCHEN -->|kitchen closed| BLOCK(["BLOCKED — gate string returned"])

    REPO_CACHE -->|cache miss| GATE_FLEET
    REPO_CACHE -->|cache hit| CACHED(["RETURN cached LoadResult"])

    GATE_FLEET -->|fleet disabled| FILTERED(["FILTERED — CAMPAIGN excluded"])
    GATE_FLEET -->|fleet enabled| LOAD_CACHE

    LOAD_CACHE -->|cache miss| DEFERRED
    LOAD_CACHE -->|cache hit| CACHED

    DEFERRED --> KIND_SENTINEL
    KIND_SENTINEL --> MUTABLE
    MUTABLE --> FROZEN
    FROZEN --> GATE_STRUCT

    GATE_STRUCT --> APPEND
    APPEND --> GATE_VALID
    GATE_VALID --> STALENESS
    STALENESS -->|triage done| AUDIT_RESUME

    GATE_FLEET -.->|kind field drives filter| KIND_SENTINEL
    FLEET_MARKER -.->|enforces markers on| TOOL_GATE_TEST
    PLANNER_MARKER -.->|negative guard| INFRA_EXCLUSION

    %% CLASS ASSIGNMENTS %%
    class FROZEN detector;
    class DEFERRED,KIND_SENTINEL stateNode;
    class MUTABLE phase;
    class APPEND gap;
    class GATE_IMPORT,GATE_POSTINIT detector;
    class GATE_KITCHEN,GATE_FLEET,GATE_STRUCT,GATE_VALID handler;
    class LOAD_CACHE,REPO_CACHE,STALENESS,AUDIT_RESUME output;
    class FLEET_MARKER,PLANNER_MARKER,INFRA_EXCLUSION,TOOL_GATE_TEST newComponent;
    class START,BLOCK,CACHED,FILTERED terminal;
```

Closes #1252

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-1252-20260425-181939-391357/.autoskillit/temp/make-plan/test_marker_enforcement_gaps_plan_2026-04-25_182000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 259 | 23.9k | 1.6M | 124.5k | 1 | 8m 59s |
| verify | 2.0k | 17.1k | 755.1k | 48.5k | 1 | 6m 59s |
| implement | 500 | 21.3k | 3.5M | 69.7k | 1 | 8m 44s |
| fix | 144 | 5.8k | 709.1k | 47.8k | 1 | 7m 39s |
| prepare_pr | 60 | 8.4k | 203.5k | 32.5k | 1 | 2m 2s |
| run_arch_lenses | 193 | 24.2k | 598.0k | 128.4k | 3 | 11m 21s |
| compose_pr | 67 | 10.2k | 269.3k | 38.4k | 1 | 2m 54s |
| **Total** | 3.3k | 111.0k | 7.6M | 489.9k | | 48m 41s |