### PR TITLE
Rectify: CI Watch Branch-Unaware Event Derivation

### DIFF
--- a/src/autoskillit/execution/merge_queue.py
+++ b/src/autoskillit/execution/merge_queue.py
@@ -17,8 +17,7 @@ from typing import Any, TypedDict, assert_never
 
 import httpx
 
-from autoskillit.core import PRState, get_logger
-from autoskillit.core.io import YAMLError, load_yaml
+from autoskillit.core import PRState, YAMLError, get_logger, load_yaml
 from autoskillit.execution.github import github_headers
 
 _log = get_logger(__name__)

--- a/src/autoskillit/execution/merge_queue.py
+++ b/src/autoskillit/execution/merge_queue.py
@@ -16,9 +16,9 @@ from datetime import UTC, datetime
 from typing import Any, TypedDict, assert_never
 
 import httpx
-import yaml
 
 from autoskillit.core import PRState, get_logger
+from autoskillit.core.io import YAMLError, load_yaml
 from autoskillit.execution.github import github_headers
 
 _log = get_logger(__name__)
@@ -755,14 +755,16 @@ def _push_trigger_applies_to_branch(text: str, branch: str) -> bool:
     (e.g. 'feature/**', 'release-*').
     """
     try:
-        parsed = yaml.safe_load(text)
-    except yaml.YAMLError:
+        parsed = load_yaml(text)
+    except YAMLError:
         return _text_has_push_trigger(text)
 
     if not isinstance(parsed, dict):
         return False
 
-    on_value = parsed.get("on")
+    # PyYAML (YAML 1.1) parses the bare key `on` as boolean True.
+    # Accept both to be safe.
+    on_value = parsed.get(True, parsed.get("on"))
     if on_value == "push":
         return True
     if isinstance(on_value, list):

--- a/src/autoskillit/execution/merge_queue.py
+++ b/src/autoskillit/execution/merge_queue.py
@@ -6,6 +6,7 @@ Never raises. All errors are returned as structured results.
 from __future__ import annotations
 
 import asyncio
+import fnmatch
 import random
 import re
 import time
@@ -15,6 +16,7 @@ from datetime import UTC, datetime
 from typing import Any, TypedDict, assert_never
 
 import httpx
+import yaml
 
 from autoskillit.core import PRState, get_logger
 from autoskillit.execution.github import github_headers
@@ -744,6 +746,45 @@ def _text_has_push_trigger(text: str) -> bool:
     return any(pat in text for pat in ("on: [push", "on: push", "push:"))
 
 
+def _push_trigger_applies_to_branch(text: str, branch: str) -> bool:
+    """Return True if the workflow push trigger fires for the given branch.
+
+    Parses the YAML to inspect push.branches / push.branches-ignore filters.
+    Falls back to presence-only heuristic on YAML parse failure (safe for
+    ambiguous/binary blobs). Supports GitHub's fnmatch-compatible glob patterns
+    (e.g. 'feature/**', 'release-*').
+    """
+    try:
+        parsed = yaml.safe_load(text)
+    except yaml.YAMLError:
+        return _text_has_push_trigger(text)
+
+    if not isinstance(parsed, dict):
+        return False
+
+    on_value = parsed.get("on")
+    if on_value == "push":
+        return True
+    if isinstance(on_value, list):
+        return "push" in on_value
+    if not isinstance(on_value, dict) or "push" not in on_value:
+        return False
+
+    push_cfg = on_value["push"]
+    if not isinstance(push_cfg, dict) or not push_cfg:
+        # push: null or push: {} — no branch filter, fires for all branches
+        return True
+
+    branches = push_cfg.get("branches")
+    branches_ignore = push_cfg.get("branches-ignore")
+
+    if branches is not None:
+        return any(fnmatch.fnmatch(branch, pat) for pat in branches)
+    if branches_ignore is not None:
+        return not any(fnmatch.fnmatch(branch, pat) for pat in branches_ignore)
+    return True
+
+
 _RATE_LIMIT_MAX_ATTEMPTS = 3
 _RATE_LIMIT_SECONDARY_MARKER = "secondary rate limit"
 
@@ -872,7 +913,7 @@ async def fetch_repo_merge_state(
                 continue  # binary or oversized blob — skip
             if "merge_group" in text:
                 merge_group_trigger = True
-            if _text_has_push_trigger(text):
+            if _push_trigger_applies_to_branch(text, branch):
                 has_push_trigger = True
 
     # Derive ci_event: prefer push for historical compatibility when both are present.

--- a/src/autoskillit/recipe/rules_ci.py
+++ b/src/autoskillit/recipe/rules_ci.py
@@ -150,8 +150,10 @@ _CI_EVENT_SCOPE_TOOLS = {"wait_for_ci", "get_ci_status"}
 
 @semantic_rule(
     name="ci-missing-event-scope",
-    description="CI tool step without event parameter risks cross-event confusion",
-    severity=Severity.WARNING,
+    description=(
+        "CI tool step without event parameter causes silent run exclusion on feature branches"
+    ),
+    severity=Severity.ERROR,
 )
 def _check_ci_missing_event_scope(ctx: ValidationContext) -> list[RuleFinding]:
     findings: list[RuleFinding] = []
@@ -162,13 +164,15 @@ def _check_ci_missing_event_scope(ctx: ValidationContext) -> list[RuleFinding]:
             findings.append(
                 RuleFinding(
                     rule="ci-missing-event-scope",
-                    severity=Severity.WARNING,
+                    severity=Severity.ERROR,
                     step_name=step_name,
                     message=(
                         f"Step '{step_name}' calls {step.tool} without an 'event' parameter. "
-                        f"Without event filtering, a passing pull_request run can mask a "
-                        f"failing push run. Add event: 'push' (or the appropriate trigger "
-                        f"event) to the step's with_args, or set ci.event in project config."
+                        f"On feature branches excluded from push triggers, the push-scoped "
+                        f"filter returns no runs even when pull_request CI is active, causing "
+                        f"no_runs timeout. Add event: '${{{{ context.ci_event }}}}' "
+                        f"(requires check_repo_ci_event to run first) "
+                        f"or set ci.event in project config."
                     ),
                 )
             )

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -565,11 +565,11 @@ steps:
       - when: "${{ result.verdict }} == approved_with_comments"
         route: resolve_review
       - when: "${{ result.verdict }} == needs_human"
-        route: ci_watch
+        route: check_repo_ci_event
       - when: "true"
-        route: ci_watch
+        route: check_repo_ci_event
     on_failure: resolve_review
-    on_context_limit: ci_watch
+    on_context_limit: check_repo_ci_event
     optional: true
     skip_when_false: "inputs.open_pr"
     optional_context_refs:
@@ -579,7 +579,7 @@ steps:
       headless session to leave inline review comments on the PR. The skill finds
       the open PR by feature branch name (context.merge_target). Captures verdict
       as review_verdict and routes via on_result: changes_requested/approved_with_comments
-      → resolve_review, needs_human → ci_watch (explicit), approved → ci_watch. On
+      → resolve_review, needs_human → check_repo_ci_event (explicit), approved → check_repo_ci_event. On
       tool-level failure (MCP error, gh unavailable), routes to resolve_review.
       Skipped when open_pr=false.
 
@@ -640,8 +640,8 @@ steps:
     on_result:
       - when: "${{ result.had_blocking }} == true and ${{ result.max_exceeded }} == false"
         route: review_pr
-      - route: ci_watch
-    on_failure: ci_watch
+      - route: check_repo_ci_event
+    on_failure: check_repo_ci_event
     skip_when_false: "inputs.open_pr"
     optional_context_refs:
       - review_loop_count
@@ -649,12 +649,31 @@ steps:
     note: >
       Compound iteration + blocking guard. Routes back to review_pr only when the
       previous verdict was changes_requested (had_blocking=true) AND the iteration
-      budget is not exhausted (max_exceeded=false); otherwise proceeds to ci_watch.
+      budget is not exhausted (max_exceeded=false); otherwise proceeds to check_repo_ci_event.
+
+  check_repo_ci_event:
+    tool: check_repo_merge_state
+    with:
+      branch: "${{ context.merge_target }}"
+      cwd: "${{ context.work_dir }}"
+      remote_url: "${{ context.remote_url }}"
+      step_name: "check_repo_ci_event"
+    capture:
+      ci_event: "${{ result.ci_event }}"
+    on_success: ci_watch
+    on_failure: ci_watch
+    skip_when_false: "inputs.open_pr"
+    note: >
+      Derives ci_event for the feature branch BEFORE ci_watch runs.
+      Uses context.merge_target (feature branch) so push.branches filter
+      is evaluated against the actual branch being pushed, not the base branch.
+      Non-blocking: on_failure routes to ci_watch with ci_event=null (match-any).
 
   ci_watch:
     tool: wait_for_ci
     with:
       branch: "${{ context.merge_target }}"
+      event: "${{ context.ci_event }}"
       timeout_seconds: 300
       cwd: "${{ context.work_dir }}"
       remote_url: "${{ context.remote_url }}"
@@ -748,12 +767,12 @@ steps:
       remote_url: "${{ context.remote_url }}"
       branch: "${{ context.merge_target }}"
       force: "true"
-    on_success: ci_watch
+    on_success: check_repo_ci_event
     on_failure: release_issue_failure
     note: >
       Pushes the CI-fixed feature branch back to the remote after resolve_ci succeeds.
-      Routes back to ci_watch to verify the fix resolves CI. On push failure, escalates
-      via release_issue_failure.
+      Routes to check_repo_ci_event to derive ci_event before ci_watch verifies the fix.
+      On push failure, escalates via release_issue_failure.
 
   check_repo_merge_state:
     tool: check_repo_merge_state

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -563,11 +563,11 @@ steps:
       - when: "${{ result.verdict }} == approved_with_comments"
         route: resolve_review
       - when: "${{ result.verdict }} == needs_human"
-        route: ci_watch
+        route: check_repo_ci_event
       - when: "true"
-        route: ci_watch
+        route: check_repo_ci_event
     on_failure: resolve_review
-    on_context_limit: ci_watch
+    on_context_limit: check_repo_ci_event
     optional: true
     skip_when_false: "inputs.open_pr"
     optional_context_refs:
@@ -577,7 +577,7 @@ steps:
       headless session to leave inline review comments on the PR. The skill finds
       the open PR by feature branch name (context.merge_target). Captures verdict
       as review_verdict and routes via on_result: changes_requested/approved_with_comments
-      → resolve_review, needs_human → ci_watch (explicit), approved → ci_watch. On
+      → resolve_review, needs_human → check_repo_ci_event (explicit), approved → check_repo_ci_event. On
       tool-level failure (MCP error, gh unavailable), routes to resolve_review.
       Skipped when open_pr=false.
 
@@ -638,8 +638,8 @@ steps:
     on_result:
       - when: "${{ result.had_blocking }} == true and ${{ result.max_exceeded }} == false"
         route: review_pr
-      - route: ci_watch
-    on_failure: ci_watch
+      - route: check_repo_ci_event
+    on_failure: check_repo_ci_event
     skip_when_false: "inputs.open_pr"
     optional_context_refs:
       - review_loop_count
@@ -647,12 +647,31 @@ steps:
     note: >
       Compound iteration + blocking guard. Routes back to review_pr only when the
       previous verdict was changes_requested (had_blocking=true) AND the iteration
-      budget is not exhausted (max_exceeded=false); otherwise proceeds to ci_watch.
+      budget is not exhausted (max_exceeded=false); otherwise proceeds to check_repo_ci_event.
+
+  check_repo_ci_event:
+    tool: check_repo_merge_state
+    with:
+      branch: "${{ context.merge_target }}"
+      cwd: "${{ context.work_dir }}"
+      remote_url: "${{ context.remote_url }}"
+      step_name: "check_repo_ci_event"
+    capture:
+      ci_event: "${{ result.ci_event }}"
+    on_success: ci_watch
+    on_failure: ci_watch
+    skip_when_false: "inputs.open_pr"
+    note: >
+      Derives ci_event for the feature branch BEFORE ci_watch runs.
+      Uses context.merge_target (feature branch) so push.branches filter
+      is evaluated against the actual branch being pushed, not the base branch.
+      Non-blocking: on_failure routes to ci_watch with ci_event=null (match-any).
 
   ci_watch:
     tool: wait_for_ci
     with:
       branch: "${{ context.merge_target }}"
+      event: "${{ context.ci_event }}"
       timeout_seconds: 300
       cwd: "${{ context.work_dir }}"
       remote_url: "${{ context.remote_url }}"
@@ -1238,12 +1257,12 @@ steps:
       remote_url: "${{ context.remote_url }}"
       branch: "${{ context.merge_target }}"
       force: "true"
-    on_success: ci_watch
+    on_success: check_repo_ci_event
     on_failure: release_issue_failure
     note: >
       Pushes the CI-fixed feature branch back to the remote after resolve_ci succeeds.
-      Routes back to ci_watch to verify the fix resolves CI. On push failure, escalates
-      via release_issue_failure.
+      Routes to check_repo_ci_event to derive ci_event before ci_watch verifies the fix.
+      On push failure, escalates via release_issue_failure.
 
   detect_ci_conflict:
     tool: run_cmd

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -552,11 +552,11 @@ steps:
       - when: "${{ result.verdict }} == approved_with_comments"
         route: resolve_review
       - when: "${{ result.verdict }} == needs_human"
-        route: ci_watch
+        route: check_repo_ci_event
       - when: "true"
-        route: ci_watch
+        route: check_repo_ci_event
     on_failure: resolve_review
-    on_context_limit: ci_watch
+    on_context_limit: check_repo_ci_event
     optional: true
     skip_when_false: "inputs.open_pr"
     optional_context_refs:
@@ -566,7 +566,7 @@ steps:
       headless session to leave inline review comments on the PR. The skill finds
       the open PR by feature branch name (context.merge_target). Captures verdict
       as review_verdict and routes via on_result: changes_requested/approved_with_comments
-      → resolve_review, needs_human → ci_watch (explicit), approved → ci_watch. On
+      → resolve_review, needs_human → check_repo_ci_event (explicit), approved → check_repo_ci_event. On
       tool-level failure (MCP error, gh unavailable), routes to resolve_review.
       Skipped when open_pr=false.
 
@@ -627,8 +627,8 @@ steps:
     on_result:
       - when: "${{ result.had_blocking }} == true and ${{ result.max_exceeded }} == false"
         route: review_pr
-      - route: ci_watch
-    on_failure: ci_watch
+      - route: check_repo_ci_event
+    on_failure: check_repo_ci_event
     skip_when_false: "inputs.open_pr"
     optional_context_refs:
       - review_loop_count
@@ -636,12 +636,31 @@ steps:
     note: >
       Compound iteration + blocking guard. Routes back to review_pr only when the
       previous verdict was changes_requested (had_blocking=true) AND the iteration
-      budget is not exhausted (max_exceeded=false); otherwise proceeds to ci_watch.
+      budget is not exhausted (max_exceeded=false); otherwise proceeds to check_repo_ci_event.
+
+  check_repo_ci_event:
+    tool: check_repo_merge_state
+    with:
+      branch: "${{ context.merge_target }}"
+      cwd: "${{ context.work_dir }}"
+      remote_url: "${{ context.remote_url }}"
+      step_name: "check_repo_ci_event"
+    capture:
+      ci_event: "${{ result.ci_event }}"
+    on_success: ci_watch
+    on_failure: ci_watch
+    skip_when_false: "inputs.open_pr"
+    note: >
+      Derives ci_event for the feature branch BEFORE ci_watch runs.
+      Uses context.merge_target (feature branch) so push.branches filter
+      is evaluated against the actual branch being pushed, not the base branch.
+      Non-blocking: on_failure routes to ci_watch with ci_event=null (match-any).
 
   ci_watch:
     tool: wait_for_ci
     with:
       branch: "${{ context.merge_target }}"
+      event: "${{ context.ci_event }}"
       timeout_seconds: 300
       cwd: "${{ context.work_dir }}"
       remote_url: "${{ context.remote_url }}"
@@ -1229,12 +1248,12 @@ steps:
       remote_url: "${{ context.remote_url }}"
       branch: "${{ context.merge_target }}"
       force: "true"
-    on_success: ci_watch
+    on_success: check_repo_ci_event
     on_failure: release_issue_failure
     note: >
       Pushes the CI-fixed feature branch back to the remote after resolve_ci succeeds.
-      Routes back to ci_watch to verify the fix resolves CI. On push failure, escalates
-      via release_issue_failure.
+      Routes to check_repo_ci_event to derive ci_event before ci_watch verifies the fix.
+      On push failure, escalates via release_issue_failure.
 
   detect_ci_conflict:
     tool: run_cmd

--- a/tests/execution/test_check_repo_merge_state.py
+++ b/tests/execution/test_check_repo_merge_state.py
@@ -200,7 +200,7 @@ async def test_push_trigger_branch_filter_excludes_feature_branch(httpx_mock):
         branch="feature/impl-20260401-123456",
         token=None,
     )
-    assert result["ci_event"] != "push"
+    assert result["ci_event"] is None
 
 
 @pytest.mark.anyio

--- a/tests/execution/test_check_repo_merge_state.py
+++ b/tests/execution/test_check_repo_merge_state.py
@@ -7,6 +7,8 @@ must come from a single HTTP round-trip to the GitHub GraphQL endpoint.
 
 from __future__ import annotations
 
+import textwrap
+
 import pytest
 
 from autoskillit.execution.merge_queue import fetch_repo_merge_state
@@ -157,3 +159,104 @@ async def test_check_repo_merge_state_returns_null_ci_event_for_no_trigger(httpx
     )
     result = await fetch_repo_merge_state(owner="o", repo="r", branch="main", token=None)
     assert result["ci_event"] is None
+
+
+def _make_repo_state_response(workflow_entries):
+    """Helper: build a mock graphql response with given workflow YAML entries."""
+    return {
+        "data": {
+            "repository": {
+                "mergeQueue": None,
+                "autoMergeAllowed": True,
+                "object": {
+                    "entries": [
+                        {"name": name, "object": {"text": text}} for name, text in workflow_entries
+                    ]
+                },
+            }
+        }
+    }
+
+
+@pytest.mark.anyio
+async def test_push_trigger_branch_filter_excludes_feature_branch(httpx_mock):
+    """Feature branch not in push.branches must not produce ci_event='push'."""
+    workflow_text = textwrap.dedent("""\
+        on:
+          push:
+            branches:
+              - main
+              - stable
+          pull_request:
+            branches: [main, integration, stable]
+    """)
+    httpx_mock.add_response(
+        url="https://api.github.com/graphql",
+        json=_make_repo_state_response([("tests.yml", workflow_text)]),
+    )
+    result = await fetch_repo_merge_state(
+        owner="org",
+        repo="repo",
+        branch="feature/impl-20260401-123456",
+        token=None,
+    )
+    assert result["ci_event"] != "push"
+
+
+@pytest.mark.anyio
+async def test_push_trigger_no_branch_filter_applies_to_all_branches(httpx_mock):
+    """push trigger with no branches: filter → ci_event='push' for any branch."""
+    workflow_text = "on:\n  push:\n  pull_request:\n    branches: [main]\n"
+    httpx_mock.add_response(
+        url="https://api.github.com/graphql",
+        json=_make_repo_state_response([("tests.yml", workflow_text)]),
+    )
+    result = await fetch_repo_merge_state(
+        owner="org",
+        repo="repo",
+        branch="feature/anything",
+        token=None,
+    )
+    assert result["ci_event"] == "push"
+
+
+@pytest.mark.anyio
+async def test_push_trigger_branch_filter_matches_target_branch(httpx_mock):
+    """When queried branch IS in push.branches → ci_event='push'."""
+    workflow_text = textwrap.dedent("""\
+        on:
+          push:
+            branches: [main, stable]
+    """)
+    httpx_mock.add_response(
+        url="https://api.github.com/graphql",
+        json=_make_repo_state_response([("tests.yml", workflow_text)]),
+    )
+    result = await fetch_repo_merge_state(
+        owner="org",
+        repo="repo",
+        branch="main",
+        token=None,
+    )
+    assert result["ci_event"] == "push"
+
+
+@pytest.mark.anyio
+async def test_push_trigger_branches_ignore_allows_feature_branch(httpx_mock):
+    """branches-ignore: [main, stable] → push fires on feature branches → ci_event='push'."""
+    workflow_text = textwrap.dedent("""\
+        on:
+          push:
+            branches-ignore: [main, stable]
+    """)
+    httpx_mock.add_response(
+        url="https://api.github.com/graphql",
+        json=_make_repo_state_response([("tests.yml", workflow_text)]),
+    )
+    result = await fetch_repo_merge_state(
+        owner="org",
+        repo="repo",
+        branch="feature/impl-20260401",
+        token=None,
+    )
+    assert result["ci_event"] == "push"

--- a/tests/execution/test_push_trigger_applies.py
+++ b/tests/execution/test_push_trigger_applies.py
@@ -1,0 +1,60 @@
+"""Unit tests for _push_trigger_applies_to_branch — the branch-aware push trigger parser."""
+
+import pytest
+
+from autoskillit.execution.merge_queue import _push_trigger_applies_to_branch
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+
+def test_branch_filter_excludes_feature():
+    text = "on:\n  push:\n    branches:\n      - main\n      - stable\n"
+    assert _push_trigger_applies_to_branch(text, "feature/foo") is False
+
+
+def test_branch_filter_matches_listed_branch():
+    text = "on:\n  push:\n    branches:\n      - main\n      - stable\n"
+    assert _push_trigger_applies_to_branch(text, "main") is True
+
+
+def test_no_branch_filter_matches_all():
+    text = "on:\n  push:\n"
+    assert _push_trigger_applies_to_branch(text, "feature/anything") is True
+
+
+def test_scalar_push_form_matches_all():
+    assert _push_trigger_applies_to_branch("on: push\n", "feature/x") is True
+
+
+def test_list_push_form_matches_all():
+    assert _push_trigger_applies_to_branch("on: [push, pull_request]\n", "feature/x") is True
+
+
+def test_branches_ignore_excludes_listed():
+    text = "on:\n  push:\n    branches-ignore:\n      - main\n      - stable\n"
+    assert _push_trigger_applies_to_branch(text, "main") is False
+
+
+def test_branches_ignore_allows_unlisted():
+    text = "on:\n  push:\n    branches-ignore:\n      - main\n      - stable\n"
+    assert _push_trigger_applies_to_branch(text, "feature/foo") is True
+
+
+def test_glob_pattern_matches():
+    text = "on:\n  push:\n    branches:\n      - 'feature/**'\n"
+    assert _push_trigger_applies_to_branch(text, "feature/impl-20260401") is True
+
+
+def test_glob_pattern_excludes_non_matching():
+    text = "on:\n  push:\n    branches:\n      - 'feature/**'\n"
+    assert _push_trigger_applies_to_branch(text, "main") is False
+
+
+def test_no_push_trigger_returns_false():
+    text = "on:\n  pull_request:\n    branches: [main]\n"
+    assert _push_trigger_applies_to_branch(text, "main") is False
+
+
+def test_yaml_parse_failure_falls_back_to_heuristic_safe():
+    # Invalid YAML that doesn't contain any push trigger substrings
+    assert _push_trigger_applies_to_branch(": [\n", "main") is False

--- a/tests/recipe/test_bundled_recipes.py
+++ b/tests/recipe/test_bundled_recipes.py
@@ -79,7 +79,7 @@ def _assert_ci_steps(recipe) -> None:
     assert "re_push" in recipe.steps
     re_push = recipe.steps["re_push"]
     assert re_push.tool == "push_to_remote"
-    assert re_push.on_success == "ci_watch"
+    assert re_push.on_success == "check_repo_ci_event"
     assert re_push.on_failure == "release_issue_failure"
 
 
@@ -1236,13 +1236,13 @@ class TestReviewPrRecipeIntegration:
         assert step.skip_when_false == "inputs.open_pr"
 
     def test_review_pr_routes_to_ci_watch_on_success(self, recipe: object) -> None:
-        """T_RP4: review_pr has on_result with catch-all route to ci_watch."""
+        """T_RP4: review_pr has on_result with catch-all route to check_repo_ci_event."""
         step = recipe.steps["review_pr"]  # type: ignore[attr-defined]
         assert step.on_result is not None
         default_conditions = [
             c for c in step.on_result.conditions if c.when is None or c.when == "true"
         ]
-        assert any(c.route == "ci_watch" for c in default_conditions)
+        assert any(c.route == "check_repo_ci_event" for c in default_conditions)
 
     def test_review_pr_captures_verdict(self, recipe: object) -> None:
         """T_RP4b: review_pr captures the verdict output as review_verdict to avoid clobber."""

--- a/tests/recipe/test_implementation.py
+++ b/tests/recipe/test_implementation.py
@@ -56,12 +56,12 @@ def test_check_review_loop_on_result_routes_to_review_pr_when_had_blocking_and_n
 
 # T_IP_LOOP5
 def test_check_review_loop_on_result_default_routes_to_ci_watch(recipe) -> None:
-    """check_review_loop on_result routes to ci_watch as default (no blocking or max exceeded)."""
+    """check_review_loop on_result falls through to check_repo_ci_event when no blocking."""
     step = recipe.steps["check_review_loop"]
     assert step.on_result is not None
     default_conditions = [c for c in step.on_result.conditions if c.when is None]
     assert default_conditions, "No default (when=None) condition found"
-    assert default_conditions[0].route == "ci_watch"
+    assert default_conditions[0].route == "check_repo_ci_event"
 
 
 # T_IP_LOOP6
@@ -69,7 +69,7 @@ def test_check_review_loop_has_on_failure(recipe) -> None:
     """check_review_loop must declare on_failure because it uses on_result
     (on-result-missing-failure-route semantic rule requires it)."""
     step = recipe.steps["check_review_loop"]
-    assert step.on_failure == "ci_watch"
+    assert step.on_failure == "check_repo_ci_event"
 
 
 # T_IP_LOOP7

--- a/tests/recipe/test_implementation_groups_review_loop.py
+++ b/tests/recipe/test_implementation_groups_review_loop.py
@@ -52,7 +52,7 @@ def test_check_review_loop_has_on_failure(recipe) -> None:
     """check_review_loop must declare on_failure because it uses on_result
     (on-result-missing-failure-route semantic rule requires it)."""
     step = recipe.steps["check_review_loop"]
-    assert step.on_failure == "ci_watch"
+    assert step.on_failure == "check_repo_ci_event"
 
 
 # T_IG_LOOP5

--- a/tests/recipe/test_recipe_ci_watch_event.py
+++ b/tests/recipe/test_recipe_ci_watch_event.py
@@ -1,4 +1,5 @@
 """Structural tests: primary ci_watch steps must have event: and be preceded by ci_event derivation."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/recipe/test_recipe_ci_watch_event.py
+++ b/tests/recipe/test_recipe_ci_watch_event.py
@@ -1,0 +1,51 @@
+"""Structural tests: primary ci_watch steps must have event: and be preceded by ci_event derivation."""
+from __future__ import annotations
+
+import pytest
+import yaml
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+RECIPE_FILES = [
+    "src/autoskillit/recipes/implementation.yaml",
+    "src/autoskillit/recipes/remediation.yaml",
+    "src/autoskillit/recipes/implementation-groups.yaml",
+]
+
+
+@pytest.mark.parametrize("recipe_path", RECIPE_FILES)
+def test_ci_watch_step_has_event_parameter(recipe_path: str) -> None:
+    """Primary ci_watch steps must pass event: to prevent branch-event mismatch."""
+    with open(recipe_path) as f:
+        recipe = yaml.safe_load(f)
+    steps = recipe["steps"]
+    assert "ci_watch" in steps, f"{recipe_path}: no ci_watch step found"
+    ci_watch = steps["ci_watch"]
+    with_args = ci_watch.get("with") or {}
+    assert "event" in with_args, (
+        f"{recipe_path}: ci_watch missing event: parameter. "
+        f"Feature branches excluded from push triggers will see no_runs timeout."
+    )
+
+
+@pytest.mark.parametrize("recipe_path", RECIPE_FILES)
+def test_check_repo_ci_event_step_exists_before_ci_watch(recipe_path: str) -> None:
+    """Each recipe must have a check_repo_ci_event step that routes to ci_watch."""
+    with open(recipe_path) as f:
+        recipe = yaml.safe_load(f)
+    steps = recipe["steps"]
+    assert "check_repo_ci_event" in steps, (
+        f"{recipe_path}: missing check_repo_ci_event step. "
+        f"ci_event must be derived before ci_watch runs."
+    )
+    early_step = steps["check_repo_ci_event"]
+    capture = early_step.get("capture") or {}
+    assert "ci_event" in capture, (
+        f"{recipe_path}: check_repo_ci_event must capture ci_event into context"
+    )
+    assert early_step.get("on_success") == "ci_watch", (
+        f"{recipe_path}: check_repo_ci_event.on_success must be ci_watch"
+    )
+    assert early_step.get("on_failure") == "ci_watch", (
+        f"{recipe_path}: check_repo_ci_event.on_failure must be ci_watch (non-blocking)"
+    )

--- a/tests/recipe/test_remediation_recipe.py
+++ b/tests/recipe/test_remediation_recipe.py
@@ -68,7 +68,7 @@ def test_check_review_loop_has_on_failure(recipe) -> None:
     """check_review_loop must declare on_failure because it uses on_result
     (on-result-missing-failure-route semantic rule requires it)."""
     step = recipe.steps["check_review_loop"]
-    assert step.on_failure == "ci_watch"
+    assert step.on_failure == "check_repo_ci_event"
 
 
 # T_REM_LOOP5

--- a/tests/recipe/test_review_loop_routing_integration.py
+++ b/tests/recipe/test_review_loop_routing_integration.py
@@ -48,7 +48,7 @@ def test_review_loop_routes_to_review_pr_after_resolve_cycle(recipe_name: str) -
 
 @pytest.mark.parametrize("recipe_name", RECIPE_NAMES)
 def test_review_loop_routes_to_ci_watch_at_max_iterations(recipe_name: str) -> None:
-    """When max_iterations is exhausted, routing must fall through to ci_watch."""
+    """When max_iterations is exhausted, routing must fall through to check_repo_ci_event."""
     result = check_review_loop(
         pr_number="42",
         cwd="/tmp",
@@ -67,10 +67,10 @@ def test_review_loop_routes_to_ci_watch_at_max_iterations(recipe_name: str) -> N
     for key, value in result.items():
         when_expr = when_expr.replace(f"${{{{ result.{key} }}}}", value)
 
-    # The first condition must NOT be satisfied — falls through to default ci_watch
+    # The first condition must NOT be satisfied — falls through to default check_repo_ci_event
     # when_expr becomes "true == true and true == false" — second clause is False
     assert not _eval_compound_condition(when_expr)
-    assert conditions[1].route == "ci_watch"
+    assert conditions[1].route == "check_repo_ci_event"
 
 
 @pytest.mark.parametrize("recipe_name", RECIPE_NAMES)

--- a/tests/recipe/test_rules_ci.py
+++ b/tests/recipe/test_rules_ci.py
@@ -247,8 +247,45 @@ def test_ci_failure_no_on_failure_skips_rule() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_wait_for_ci_without_event_is_warning() -> None:
-    """wait_for_ci step with no event param should trigger ci-missing-event-scope."""
+def test_ci_missing_event_scope_is_error_severity() -> None:
+    """ci-missing-event-scope must be ERROR to prevent unscoped CI watch steps."""
+    recipe = _make_workflow(
+        steps={
+            "my_ci_watch": {
+                "tool": "wait_for_ci",
+                "with": {"branch": "main", "timeout_seconds": 300},
+            }
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    scope_findings = [f for f in findings if f.rule == "ci-missing-event-scope"]
+    assert scope_findings, "expected ci-missing-event-scope finding"
+    assert all(f.severity == Severity.ERROR for f in scope_findings), (
+        "ci-missing-event-scope must be ERROR, not WARNING"
+    )
+
+
+def test_ci_watch_with_event_produces_no_scope_finding() -> None:
+    """wait_for_ci with event: present must not trigger ci-missing-event-scope."""
+    recipe = _make_workflow(
+        steps={
+            "my_ci_watch": {
+                "tool": "wait_for_ci",
+                "with": {
+                    "branch": "main",
+                    "event": "${{ context.ci_event }}",
+                    "timeout_seconds": 300,
+                },
+            }
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    scope_findings = [f for f in findings if f.rule == "ci-missing-event-scope"]
+    assert not scope_findings
+
+
+def test_wait_for_ci_without_event_is_error() -> None:
+    """wait_for_ci step with no event param should trigger ci-missing-event-scope at ERROR."""
     recipe = _make_recipe(
         {
             "ci": RecipeStep(
@@ -263,7 +300,7 @@ def test_wait_for_ci_without_event_is_warning() -> None:
     findings = run_semantic_rules(recipe)
     event_findings = [f for f in findings if f.rule == "ci-missing-event-scope"]
     assert len(event_findings) == 1
-    assert event_findings[0].severity == Severity.WARNING
+    assert event_findings[0].severity == Severity.ERROR
 
 
 def test_wait_for_ci_with_event_is_clean() -> None:
@@ -284,8 +321,8 @@ def test_wait_for_ci_with_event_is_clean() -> None:
     assert event_findings == []
 
 
-def test_get_ci_status_without_event_is_warning() -> None:
-    """get_ci_status step with no event param should trigger ci-missing-event-scope."""
+def test_get_ci_status_without_event_is_error() -> None:
+    """get_ci_status step with no event param should trigger ci-missing-event-scope at ERROR."""
     recipe = _make_recipe(
         {
             "ci": RecipeStep(
@@ -300,7 +337,7 @@ def test_get_ci_status_without_event_is_warning() -> None:
     findings = run_semantic_rules(recipe)
     event_findings = [f for f in findings if f.rule == "ci-missing-event-scope"]
     assert len(event_findings) == 1
-    assert event_findings[0].severity == Severity.WARNING
+    assert event_findings[0].severity == Severity.ERROR
     assert "get_ci_status" in event_findings[0].message
 
 


### PR DESCRIPTION
## Summary

`_text_has_push_trigger` in `merge_queue.py` is a pure string-match heuristic that sets `ci_event="push"` whenever any workflow YAML contains `"push:"` — regardless of whether the push trigger's `branches:` filter covers the current branch. For feature branches excluded from push triggers (e.g., `push: branches: [main, stable]`), this returns the wrong event. `wait_for_ci` then filters GitHub Actions API results to only push-event runs — which don't exist for feature branches — and times out with `no_runs`.

Part A fixes the root cause: replace the string-match heuristic with a YAML-parsed, branch-aware function, and wire it into `fetch_repo_merge_state`. Part B will add recipe step ordering and semantic rule enforcement (separate task).

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 52, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([PR Review Complete])
    END_OK([Release Issue Success])
    END_FAIL([Release Issue Failure])

    %% ── CI EVENT DERIVATION PHASE ── %%
    subgraph EventPhase ["● CI Event Derivation Phase (implementation/remediation recipes)"]
        direction TB
        CheckCIEvent["● check_repo_ci_event<br/>━━━━━━━━━━<br/>tool: check_repo_merge_state<br/>branch: context.merge_target<br/>capture: ci_event → context<br/>skip_when_false: inputs.open_pr"]

        subgraph FetchInner ["● fetch_repo_merge_state() — merge_queue.py"]
            direction LR
            FetchGQL["● GitHub GraphQL fetch<br/>━━━━━━━━━━<br/>_REPO_STATE_QUERY<br/>workflow YAML content<br/>rate-limit retry: 3x + Retry-After"]
            ParseYAML["● _push_trigger_applies_to_branch()<br/>━━━━━━━━━━<br/>parse on: push branches/branches-ignore<br/>scalar / list / map YAML forms<br/>glob matching via fnmatch<br/>YAML 1.1 'on' key fix"]
            CIEventOut["ci_event: str | None<br/>━━━━━━━━━━<br/>push / merge_group / null"]
        end

        CIEventDec{"derivation<br/>succeeded?"}
    end

    %% ── CI WATCH PHASE ── %%
    subgraph WatchPhase ["CI Watch Phase"]
        direction TB
        CIWatch["● ci_watch<br/>━━━━━━━━━━<br/>tool: wait_for_ci<br/>event: context.ci_event<br/>branch: context.merge_target<br/>timeout: 300s | optional: true"]
        CIResult{"CI result?"}
    end

    %% ── CI FAILURE HANDLING ── %%
    subgraph FailPhase ["CI Failure Handling"]
        direction TB
        DetectConflict["detect_ci_conflict<br/>━━━━━━━━━━<br/>run_cmd: git merge-base check<br/>stale base detection"]
        ConflictDec{"stale base?"}
        CIConflictFix["ci_conflict_fix<br/>━━━━━━━━━━<br/>skill: resolve-merge-conflicts<br/>retries: 1"]
        DiagnoseCI["diagnose_ci<br/>━━━━━━━━━━<br/>skill: diagnose-ci | optional: true"]
        ResolveCI["resolve_ci<br/>━━━━━━━━━━<br/>skill: resolve-failures<br/>retries: 2"]
        ResolveDec{"resolve verdict?"}
        PreRebase["pre_resolve_rebase<br/>━━━━━━━━━━<br/>git fetch + rebase onto base"]
        RePush["● re_push<br/>━━━━━━━━━━<br/>push_to_remote force: true<br/>→ loops to check_repo_ci_event"]
    end

    %% ── MERGE ROUTING PHASE ── %%
    subgraph MergePhase ["Merge Routing"]
        direction TB
        CheckMergeState["check_repo_merge_state<br/>━━━━━━━━━━<br/>route_queue_mode decision"]
        MergeDec{"merge strategy?"}
        WaitQueue["wait_for_merge_queue<br/>━━━━━━━━━━<br/>stall toggle: exp backoff 3x<br/>confirmation window: 2 cycles<br/>inconclusive budget: 5"]
        QueueDec{"MQ result?<br/>━━━━━━━━━━<br/>MERGED / EJECTED /<br/>STALLED / TIMEOUT"}
    end

    %% ── RECIPE VALIDATION LAYER ── %%
    subgraph ValidationLayer ["● Recipe Validation Layer — rules_ci.py (static, per recipe load)"]
        direction LR
        RuleMissing["● ci-missing-event-scope<br/>━━━━━━━━━━<br/>ERROR: event: absent in<br/>wait_for_ci / get_ci_status"]
        RuleConflict["ci-failure-missing-conflict-gate<br/>━━━━━━━━━━<br/>ERROR: on_failure bypasses<br/>conflict-gate via BFS"]
        RuleMQRouting["wait-for-merge-queue-routing-*<br/>━━━━━━━━━━<br/>ERROR: missing PRState coverage<br/>ERROR: wrong fallback target"]
    end

    %% ── NEW TESTS ── %%
    subgraph TestLayer ["★ New Regression Tests"]
        direction LR
        TestPushTrigger["★ test_push_trigger_applies<br/>━━━━━━━━━━<br/>_push_trigger_applies_to_branch()<br/>scalar/list/map/glob/ignore forms<br/>YAML parse failure fallback"]
        TestCIEvent["★ test_recipe_ci_watch_event<br/>━━━━━━━━━━<br/>event: arg present in ci_watch<br/>check_repo_ci_event step exists<br/>on_success + on_failure → ci_watch"]
    end

    %% ── CONNECTIONS ── %%
    START -->|"open_pr = true"| CheckCIEvent
    CheckCIEvent --> FetchGQL
    FetchGQL --> ParseYAML
    ParseYAML --> CIEventOut
    CIEventOut --> CIEventDec
    CIEventDec -->|"success: ci_event in context"| CIWatch
    CIEventDec -->|"failure: ci_event=null non-blocking"| CIWatch

    CIWatch --> CIResult
    CIResult -->|"success"| CheckMergeState
    CIResult -->|"failure"| DetectConflict

    DetectConflict --> ConflictDec
    ConflictDec -->|"stale base"| CIConflictFix
    ConflictDec -->|"real failure"| DiagnoseCI
    CIConflictFix -->|"resolved"| RePush
    CIConflictFix -->|"escalation_required"| END_FAIL

    DiagnoseCI --> ResolveCI
    ResolveCI --> ResolveDec
    ResolveDec -->|"real_fix / flake_suspected"| RePush
    ResolveDec -->|"already_green"| PreRebase
    ResolveDec -->|"ci_only_failure / exhausted"| END_FAIL
    PreRebase -->|"rebased"| DiagnoseCI
    PreRebase -->|"conflict"| END_FAIL

    RePush -->|"re-derive ci_event before re-watch"| CheckCIEvent

    CheckMergeState --> MergeDec
    MergeDec -->|"merge_group trigger"| WaitQueue
    MergeDec -->|"auto-merge / direct"| WaitQueue
    WaitQueue --> QueueDec
    QueueDec -->|"MERGED"| END_OK
    QueueDec -->|"EJECTED_CI_FAILURE"| DiagnoseCI
    QueueDec -->|"STALLED: retries exhausted"| END_FAIL
    QueueDec -->|"TIMEOUT / NOT_ENROLLED"| END_FAIL
    QueueDec -->|"EJECTED: rebase + re-enqueue"| RePush

    %% VALIDATION ANNOTATIONS %%
    RuleMissing -.->|"validates event: on"| CIWatch
    RuleConflict -.->|"validates on_failure path of"| CIWatch
    RuleMQRouting -.->|"validates routing coverage of"| WaitQueue
    TestPushTrigger -.->|"tests parser inside"| FetchGQL
    TestCIEvent -.->|"tests step contract of"| CheckCIEvent

    %% CLASS ASSIGNMENTS %%
    class START,END_OK,END_FAIL terminal;
    class CheckCIEvent,CIWatch,DetectConflict,CheckMergeState handler;
    class FetchGQL,DiagnoseCI,ResolveCI,CIConflictFix,PreRebase,WaitQueue phase;
    class ParseYAML,CIEventOut stateNode;
    class CIEventDec,CIResult,ConflictDec,ResolveDec,MergeDec,QueueDec stateNode;
    class RePush handler;
    class RuleMissing,RuleConflict,RuleMQRouting detector;
    class TestPushTrigger,TestCIEvent newComponent;
```

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 65, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START([RECIPE STEP: check_repo_ci_event])

    %% ── PHASE 1: ci_event DERIVATION ────────────────────────────────────── %%
    subgraph Derivation ["● ci_event DERIVATION  (merge_queue.fetch_repo_merge_state)"]
        direction TB
        GQL["_REPO_STATE_QUERY<br/>━━━━━━━━━━<br/>Single GraphQL call<br/>.github/workflows/** blobs<br/>+ queue + autoMerge fields"]
        MergeGroupScan["merge_group trigger scan<br/>━━━━━━━━━━<br/>substring: 'merge_group'<br/>→ merge_group_trigger=True"]
        PushScan["★ _push_trigger_applies_to_branch()<br/>━━━━━━━━━━<br/>YAML parse + fnmatch<br/>branches: allowlist<br/>branches-ignore: denylist<br/>→ has_push_trigger=True/False"]
        CiEventField["ci_event  [INIT_ONLY]<br/>━━━━━━━━━━<br/>'push'  if has_push_trigger<br/>'merge_group'  if merge_group only<br/>None  if neither (match-all)"]
    end

    %% ── PHASE 2: RECIPE CONTEXT PROPAGATION ─────────────────────────────── %%
    subgraph Propagation ["RECIPE CONTEXT PROPAGATION  (context.ci_event)"]
        direction TB
        ContextVar["context.ci_event  [INIT_ONLY]<br/>━━━━━━━━━━<br/>Set once by check_repo_ci_event<br/>Downstream steps READ ONLY<br/>Never overwritten"]
        EventParam["event: '${{ context.ci_event }}'<br/>━━━━━━━━━━<br/>Passed to wait_for_ci<br/>and get_ci_status steps<br/>Scopes polling to correct event"]
    end

    %% ── PHASE 3: CONTRACT ENFORCEMENT ───────────────────────────────────── %%
    subgraph Gates ["● CONTRACT ENFORCEMENT  (rules_ci semantic rules)"]
        direction TB
        MissingEventRule["● ci-missing-event-scope  [ERROR]<br/>━━━━━━━━━━<br/>wait_for_ci / get_ci_status<br/>without event: param → ERROR<br/>'push-scoped filter returns<br/>no runs on feature branches'"]
        ConflictGateRule["● ci-failure-missing-conflict-gate  [ERROR]<br/>━━━━━━━━━━<br/>BFS from wait_for_ci on_failure<br/>resolve-failures reachable before<br/>conflict gate → ERROR<br/>conflict gate = merge-base check<br/>or resolve-merge-conflicts skill"]
        MQRoutingRule["wait-for-merge-queue-routing  [ERROR]<br/>━━━━━━━━━━<br/>Every PRState enum value must have<br/>explicit when arm in on_result<br/>Dynamic from PRState enum — future<br/>values auto-detected as missing"]
    end

    %% ── PHASE 4: MERGE QUEUE POLL STATE ─────────────────────────────────── %%
    subgraph PollState ["● MERGE QUEUE POLL STATE  (wait() loop-local)"]
        direction TB
        PRFetchStateNode["● PRFetchState  [MUTABLE]<br/>━━━━━━━━━━<br/>merged / state / mergeable<br/>merge_state_status / checks_state<br/>in_queue / queue_state<br/>auto_merge_present/enabled_at<br/>RESET each GraphQL poll cycle"]
        EverEnrolled["ever_enrolled  [INIT_ONLY / latch]<br/>━━━━━━━━━━<br/>False → True on first in_queue<br/>or auto_merge_present sighting<br/>NEVER reset in session<br/>Session restart = safety gap"]
        Counters["Counters  [APPEND_ONLY]<br/>━━━━━━━━━━<br/>stall_retries_attempted++<br/>not_in_queue_cycles++ / reset<br/>inconclusive_count++ / reset<br/>Drive timeout/retry budgets"]
    end

    %% ── PHASE 5: CLASSIFIER GATES ────────────────────────────────────────── %%
    subgraph Classifiers ["PR STATE CLASSIFIER GATES  (pure functions)"]
        direction TB
        StallGate["_is_positive_stall()<br/>━━━━━━━━━━<br/>auto_merge_enabled_at ≠ None<br/>AND merge_state_status<br/>∈ {CLEAN, HAS_HOOKS}"]
        DroppedGate["_is_positive_dropped_healthy()<br/>━━━━━━━━━━<br/>ever_enrolled=True<br/>state=OPEN, mergeable=MERGEABLE<br/>merge_state_status=CLEAN<br/>checks_state ∈ (None, SUCCESS)<br/>auto_merge_present=False<br/>in_queue=False"]
        NotEnrolledGate["_is_not_enrolled()<br/>━━━━━━━━━━<br/>ever_enrolled=False<br/>same field conditions<br/>as DROPPED_HEALTHY"]
        ClassifyDispatch["_classify_pr_state()<br/>━━━━━━━━━━<br/>Priority dispatch — raises<br/>CIStillRunning or<br/>NoPositiveSignal on no-match<br/>No fall-through to EJECTED"]
    end

    %% ── NEW TEST COVERAGE ────────────────────────────────────────────────── %%
    subgraph Tests ["★ NEW TEST COVERAGE"]
        direction LR
        TestPushTrigger["★ test_push_trigger_applies.py<br/>━━━━━━━━━━<br/>Unit: _push_trigger_applies_to_branch<br/>branches:/branches-ignore:/globs<br/>3 shorthand forms<br/>YAML parse failure → False"]
        TestCiEvent["★ test_recipe_ci_watch_event.py<br/>━━━━━━━━━━<br/>Structural: bundled recipe YAMLs<br/>ci_watch must have event:<br/>check_repo_ci_event must precede<br/>on_success+on_failure → ci_watch"]
    end

    %% FLOW %%
    START --> GQL
    GQL --> MergeGroupScan
    GQL --> PushScan
    MergeGroupScan --> CiEventField
    PushScan --> CiEventField

    CiEventField --> ContextVar
    ContextVar --> EventParam

    EventParam --> MissingEventRule
    EventParam --> ConflictGateRule
    MissingEventRule --> MQRoutingRule

    GQL --> PRFetchStateNode
    PRFetchStateNode --> EverEnrolled
    PRFetchStateNode --> Counters
    PRFetchStateNode --> ClassifyDispatch

    EverEnrolled --> DroppedGate
    EverEnrolled --> NotEnrolledGate
    PRFetchStateNode --> StallGate
    StallGate --> ClassifyDispatch
    DroppedGate --> ClassifyDispatch
    NotEnrolledGate --> ClassifyDispatch

    PushScan -.->|"contract tested by"| TestPushTrigger
    ContextVar -.->|"contract tested by"| TestCiEvent
    MissingEventRule -.->|"rule tested by"| TestCiEvent

    %% CLASS ASSIGNMENTS %%
    class START terminal;
    class GQL cli;
    class PushScan newComponent;
    class MergeGroupScan phase;
    class CiEventField detector;
    class ContextVar,EventParam stateNode;
    class MissingEventRule,ConflictGateRule,MQRoutingRule detector;
    class PRFetchStateNode handler;
    class EverEnrolled gap;
    class Counters handler;
    class StallGate,DroppedGate,NotEnrolledGate,ClassifyDispatch phase;
    class TestPushTrigger,TestCiEvent newComponent;
```

### Error/Resilience Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph ImportGuards ["IMPORT-TIME DRIFT GUARDS (merge_queue.py)"]
        MQ_DRIFT["● Structural Invariants<br/>━━━━━━━━━━<br/>assert CLEAN in KNOWN_MQ_MERGE_STATE_STATUSES<br/>RuntimeError: _QUERY_FIELD_MAP != PRFetchState<br/>RuntimeError: field absent from GraphQL query"]
    end

    subgraph RecipeStructural ["★ RECIPE STRUCTURAL GUARDS"]
        CHECK_CI_EVENT["★ check_repo_ci_event step<br/>━━━━━━━━━━<br/>Must exist before ci_watch step<br/>captures ci_event into context<br/>on_failure routes to ci_watch (non-blocking)"]
        CI_WATCH_SCOPED["● ci_watch with event param<br/>━━━━━━━━━━<br/>event: context.ci_event<br/>Prevents no_runs on feature branches<br/>excluded from push triggers"]
    end

    subgraph SemanticRules ["● SEMANTIC RULE VALIDATION (rules_ci.py)"]
        R_MISSING_EVENT["● ci-missing-event-scope<br/>━━━━━━━━━━<br/>Severity.ERROR — elevated from WARNING<br/>wait_for_ci or get_ci_status<br/>missing event: parameter"]
        R_CONFLICT_GATE["ci-failure-missing-conflict-gate<br/>━━━━━━━━━━<br/>Severity.ERROR<br/>BFS from on_failure: resolve-failures<br/>reachable before conflict gate"]
        R_MQ_COVERS["wait-for-merge-queue-routing<br/>━━━━━━━━━━<br/>Severity.ERROR<br/>Missing PRState arms in on_result<br/>ERROR and NOT_ENROLLED exempt"]
    end

    subgraph YAMLParse ["● YAML BRANCH-TRIGGER PARSING (merge_queue.py)"]
        YAML_PARSE["● _push_trigger_applies_to_branch<br/>━━━━━━━━━━<br/>Parse on.push.branches filter<br/>branches-ignore, glob patterns,<br/>scalar push, list push forms"]
        YAML_FALLBACK["★ Regex Heuristic Fallback<br/>━━━━━━━━━━<br/>YAMLError: _text_has_push_trigger<br/>Presence-only check — safe fail<br/>★ test_yaml_parse_failure_falls_back"]
    end

    subgraph CIWatcherErrors ["CI WATCHER ERROR HANDLING (ci.py)"]
        CI_REPO_GUARD["Repo Resolution Guard<br/>━━━━━━━━━━<br/>owner_repo is None<br/>return no_runs — no network I/O"]
        CI_SCOPE_FILTER["_validate_run_matches_scope<br/>━━━━━━━━━━<br/>scope.event mismatch: skip run<br/>All skipped: scope_mismatch WARNING<br/>falls through to Phase 2"]
        CI_PHASE2["Phase 2: Poll for Run<br/>━━━━━━━━━━<br/>deadline loop; sleep per interval<br/>found_run is None on expiry"]
        CI_PHASE3["Phase 3: Wait Completion<br/>━━━━━━━━━━<br/>deadline loop; active run<br/>active past deadline: timed_out"]
        CI_HTTP["HTTP Error Handler<br/>━━━━━━━━━━<br/>HTTPStatusError: conclusion error<br/>RequestError: conclusion error<br/>Never raises — always structured"]
    end

    subgraph MQWatcherErrors ["● MERGE QUEUE WATCHER ERROR HANDLING (merge_queue.py)"]
        MQ_REPO_GUARD["● Repo Format Guard<br/>━━━━━━━━━━<br/>not repo or slash-not-in-repo<br/>return PRState.ERROR — never raises"]
        MQ_GQL_VALIDATE["● GraphQL Response Gates<br/>━━━━━━━━━━<br/>errors key: raise RuntimeError<br/>null pullRequest: raise RuntimeError<br/>missing repository: raise RuntimeError<br/>invalid enabledAt datetime: raise RuntimeError"]
        MQ_FETCH_RETRY["Fetch Retry Loop<br/>━━━━━━━━━━<br/>except Exception: sleep + continue<br/>RuntimeErrors caught here, not propagated"]
        MQ_CLASSIFIER["_classify_pr_state<br/>━━━━━━━━━━<br/>7 positive-signal gates; no default<br/>UNMERGEABLE queue: early exit EJECTED<br/>assert_never for unhandled PRState"]
        MQ_STALL["● Stall Backoff<br/>━━━━━━━━━━<br/>backoff = min(30 x 2^attempt, 120s)<br/>_toggle_auto_merge failure swallowed<br/>max_stall_retries=3"]
        MQ_RATE["Rate-Limit Retry<br/>━━━━━━━━━━<br/>HTTP 429 or secondary 403<br/>_retry_after_seconds with jitter<br/>max 3 attempts"]
    end

    subgraph CircuitBreakers ["CIRCUIT BREAKERS"]
        CB_CI_DEADLINE{"CI Deadline<br/>monotonic >= deadline"}
        CB_MQ_DEADLINE{"MQ Deadline<br/>monotonic >= deadline"}
        CB_INCONCLUSIVE{"Inconclusive Budget<br/>count >= max_inconclusive_retries (5)"}
        CB_STALL{"Stall Budget<br/>attempts >= max_stall_retries (3)"}
        CB_RATE{"Rate-Limit Max<br/>attempts >= 3"}
    end

    subgraph Terminals ["TERMINAL STATES"]
        T_SUCCESS([CI: conclusion returned])
        T_NO_RUNS([CI: no_runs])
        T_TIMED_OUT([CI: timed_out])
        T_CI_ERROR([CI: error])
        T_RULE_CLEAN([RULE: CLEAN])
        T_RULE_ERROR([RULE: ERROR finding])
        T_MQ_MERGED([MQ: MERGED])
        T_MQ_EJECTED([MQ: EJECTED])
        T_MQ_STALLED([MQ: STALLED])
        T_MQ_TIMEOUT([MQ: TIMEOUT])
    end

    %% RECIPE STRUCTURAL FLOW %%
    CHECK_CI_EVENT -->|"captures ci_event"| CI_WATCH_SCOPED
    CHECK_CI_EVENT -->|"on_failure non-blocking"| CI_WATCH_SCOPED

    %% YAML PARSE FALLBACK %%
    YAML_PARSE -->|"YAMLError"| YAML_FALLBACK

    %% SEMANTIC RULE OUTCOMES %%
    R_MISSING_EVENT -->|"event: present"| T_RULE_CLEAN
    R_MISSING_EVENT -->|"event: absent"| T_RULE_ERROR
    R_CONFLICT_GATE -->|"gate missing in BFS path"| T_RULE_ERROR
    R_MQ_COVERS -->|"missing PRState arm"| T_RULE_ERROR

    %% CI WATCHER FLOW %%
    CI_REPO_GUARD -->|"no_runs"| T_NO_RUNS
    CI_REPO_GUARD -->|"resolved"| CI_SCOPE_FILTER
    CI_SCOPE_FILTER -->|"run matched"| CI_PHASE3
    CI_SCOPE_FILTER -->|"all scoped out / miss"| CI_PHASE2
    CI_PHASE2 --> CB_CI_DEADLINE
    CB_CI_DEADLINE -->|"exceeded"| T_NO_RUNS
    CB_CI_DEADLINE -->|"ok"| CI_PHASE3
    CI_PHASE3 --> CB_CI_DEADLINE
    CB_CI_DEADLINE -->|"exceeded"| T_TIMED_OUT
    CI_PHASE3 -->|"completed"| T_SUCCESS
    CI_PHASE2 --> CI_HTTP
    CI_PHASE3 --> CI_HTTP
    CI_HTTP --> T_CI_ERROR

    %% MERGE QUEUE WATCHER FLOW %%
    MQ_REPO_GUARD -->|"invalid"| T_MQ_TIMEOUT
    MQ_REPO_GUARD -->|"valid"| MQ_FETCH_RETRY
    MQ_GQL_VALIDATE -->|"error"| MQ_FETCH_RETRY
    MQ_FETCH_RETRY -->|"fetch ok"| MQ_CLASSIFIER
    MQ_FETCH_RETRY --> CB_MQ_DEADLINE
    CB_MQ_DEADLINE -->|"exceeded"| T_MQ_TIMEOUT
    CB_MQ_DEADLINE -->|"ok"| MQ_FETCH_RETRY
    MQ_FETCH_RETRY --> MQ_RATE
    MQ_RATE --> CB_RATE
    CB_RATE -->|"ok — sleep then retry"| MQ_RATE
    CB_RATE -->|"exhausted: raise_for_status"| T_MQ_TIMEOUT
    MQ_CLASSIFIER -->|"MERGED"| T_MQ_MERGED
    MQ_CLASSIFIER -->|"EJECTED / CI_FAILURE"| T_MQ_EJECTED
    MQ_CLASSIFIER -->|"CIStillRunning — no budget cost"| MQ_FETCH_RETRY
    MQ_CLASSIFIER -->|"NoPositiveSignal"| CB_INCONCLUSIVE
    CB_INCONCLUSIVE -->|"budget ok"| MQ_FETCH_RETRY
    CB_INCONCLUSIVE -->|"exhausted"| T_MQ_TIMEOUT
    MQ_CLASSIFIER -->|"STALLED"| CB_STALL
    CB_STALL -->|"budget ok"| MQ_STALL
    MQ_STALL -->|"backoff sleep"| MQ_FETCH_RETRY
    CB_STALL -->|"exhausted"| T_MQ_STALLED

    %% CLASS ASSIGNMENTS %%
    class MQ_DRIFT detector;
    class CHECK_CI_EVENT,CI_WATCH_SCOPED newComponent;
    class YAML_PARSE handler;
    class YAML_FALLBACK output;
    class R_MISSING_EVENT,R_CONFLICT_GATE,R_MQ_COVERS detector;
    class CI_REPO_GUARD,CI_SCOPE_FILTER detector;
    class CI_PHASE2,CI_PHASE3 handler;
    class CI_HTTP gap;
    class MQ_REPO_GUARD,MQ_GQL_VALIDATE detector;
    class MQ_FETCH_RETRY,MQ_CLASSIFIER handler;
    class MQ_STALL,MQ_RATE output;
    class CB_CI_DEADLINE,CB_MQ_DEADLINE,CB_INCONCLUSIVE,CB_STALL,CB_RATE stateNode;
    class T_SUCCESS,T_NO_RUNS,T_TIMED_OUT,T_CI_ERROR,T_RULE_CLEAN,T_RULE_ERROR,T_MQ_MERGED,T_MQ_EJECTED,T_MQ_STALLED,T_MQ_TIMEOUT terminal;
```

Closes #1273

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260425-191024-276829/.autoskillit/temp/rectify/rectify_ci_watch_branch_unaware_event_derivation_2026-04-25_191024_part_a.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| analyze | 18 | 498 | 34.0k | 11.1k | 1 | 22s |
| **Total** | 18 | 498 | 34.0k | 11.1k | | 22s |