### PR TITLE
Planner Manifest Robustness — FS-Lag Tolerance + Positional Argument Fragility

### DIFF
--- a/src/autoskillit/planner/manifests.py
+++ b/src/autoskillit/planner/manifests.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import time
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -61,12 +62,22 @@ def check_remaining(manifest_path: str, pass_name: str, output_dir: str) -> dict
                 if pass_name == "work_packages":
                     _backstop_wp_index(item["id"], result_path, out_dir)
             else:
-                _logger.warning(
-                    "check_remaining: no result file — marking failed",
-                    item_id=item["id"],
-                    result_path=str(result_path),
-                )
-                item["status"] = "failed"
+                for _attempt in range(2):
+                    time.sleep(1)
+                    if result_path.exists():
+                        break
+                else:
+                    _logger.warning(
+                        "check_remaining: no result file after retries — marking failed",
+                        item_id=item["id"],
+                        result_path=str(result_path),
+                    )
+                    item["status"] = "failed"
+                    continue
+                item["status"] = "done"
+                item["result_path"] = str(result_path)
+                if pass_name == "work_packages":
+                    _backstop_wp_index(item["id"], result_path, out_dir)
 
     next_item = next((item for item in items if item["status"] == "pending"), None)
 

--- a/src/autoskillit/planner/manifests.py
+++ b/src/autoskillit/planner/manifests.py
@@ -56,12 +56,7 @@ def check_remaining(manifest_path: str, pass_name: str, output_dir: str) -> dict
     for item in items:
         if item["status"] == "processing":
             result_path = out_dir / f"{item['id']}_result.json"
-            if result_path.exists():
-                item["status"] = "done"
-                item["result_path"] = str(result_path)
-                if pass_name == "work_packages":
-                    _backstop_wp_index(item["id"], result_path, out_dir)
-            else:
+            if not result_path.exists():
                 for _attempt in range(2):
                     time.sleep(1)
                     if result_path.exists():
@@ -74,10 +69,10 @@ def check_remaining(manifest_path: str, pass_name: str, output_dir: str) -> dict
                     )
                     item["status"] = "failed"
                     continue
-                item["status"] = "done"
-                item["result_path"] = str(result_path)
-                if pass_name == "work_packages":
-                    _backstop_wp_index(item["id"], result_path, out_dir)
+            item["status"] = "done"
+            item["result_path"] = str(result_path)
+            if pass_name == "work_packages":
+                _backstop_wp_index(item["id"], result_path, out_dir)
 
     next_item = next((item for item in items if item["status"] == "pending"), None)
 

--- a/src/autoskillit/recipes/planner.yaml
+++ b/src/autoskillit/recipes/planner.yaml
@@ -53,8 +53,10 @@ steps:
   extract_domain:
     tool: run_skill
     with:
-      skill_command: "/autoskillit:planner-extract-domain _ _ {{AUTOSKILLIT_TEMP}}/planner/analysis.json"
+      skill_command: "/autoskillit:planner-extract-domain"
       cwd: "${{ inputs.source_dir }}"
+      env:
+        PLANNER_ANALYSIS_FILE: "{{AUTOSKILLIT_TEMP}}/planner/analysis.json"
     on_success: generate_phases
     on_failure: generate_phases
 

--- a/src/autoskillit/skills_extended/planner-extract-domain/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-extract-domain/SKILL.md
@@ -22,9 +22,7 @@ Extract domain knowledge, naming conventions, and structural patterns specific t
 
 ## Arguments
 
-- **$1** — (unused, reserved)
-- **$2** — (unused, reserved)
-- **$3** — Absolute path to `analysis.json` produced by `planner-analyze`
+- **`PLANNER_ANALYSIS_FILE`** (env-var) — Absolute path to `analysis.json` produced by `planner-analyze`. Set by the recipe via the step's `env:` block.
 
 ## Critical Constraints
 
@@ -33,7 +31,7 @@ Extract domain knowledge, naming conventions, and structural patterns specific t
 - Abort the calling recipe on failure — log a warning and return gracefully
 
 **ALWAYS:**
-- Read the analysis file from argument $3 before spawning subagents
+- Read the analysis file from the path in the PLANNER_ANALYSIS_FILE environment variable before spawning subagents
 - Use Explore subagents for all file reads
 - Spawn subagents in parallel
 
@@ -41,7 +39,7 @@ Extract domain knowledge, naming conventions, and structural patterns specific t
 
 ### Step 1: Read analysis
 
-Read the `analysis.json` file from argument $3. Use its `language`, `framework`, `architecture_style`, and `key_patterns` fields to focus subagent queries.
+Read the `analysis.json` file from the path in the PLANNER_ANALYSIS_FILE environment variable. Use its `language`, `framework`, `architecture_style`, and `key_patterns` fields to focus subagent queries.
 
 ### Step 2: Launch 3–5 parallel Explore subagents
 

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -154,7 +154,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/smoke_utils.py", 87),
     ("src/autoskillit/smoke_utils.py", 169),
     # planner/manifests.py — _backstop_wp_index: list payload (index is a list, not dict)
-    ("src/autoskillit/planner/manifests.py", 36),
+    ("src/autoskillit/planner/manifests.py", 37),
 }
 
 

--- a/tests/planner/test_manifests.py
+++ b/tests/planner/test_manifests.py
@@ -186,7 +186,7 @@ def test_check_remaining_processing_fails_after_all_retries_exhausted(tmp_path):
     updated = json.loads(manifest_path.read_text())
     items = {i["id"]: i for i in updated["items"]}
     assert items["A1"]["status"] == "failed"
-    assert mock_sleep.call_count == 2  # 2 retries with 1s sleep each
+    assert mock_sleep.call_count == 2  # one sleep per range(2) iteration
 
 
 def test_check_remaining_sleep_called_with_one_second(tmp_path):

--- a/tests/planner/test_manifests.py
+++ b/tests/planner/test_manifests.py
@@ -2,10 +2,28 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
 pytestmark = [pytest.mark.layer("planner"), pytest.mark.small, pytest.mark.feature("planner")]
+
+
+def _make_manifest(items: list[dict]) -> dict:
+    return {
+        "pass_name": "phases",
+        "created_at": "2026-04-24T00:00:00Z",
+        "items": [
+            {
+                "id": item["id"],
+                "name": item.get("name", item["id"]),
+                "status": item.get("status", "pending"),
+                "result_path": item.get("result_path", None),
+                "metadata": item.get("metadata", {}),
+            }
+            for item in items
+        ],
+    }
 
 
 def test_check_remaining_pending_to_processing(tmp_path):
@@ -108,13 +126,82 @@ def test_check_remaining_processing_becomes_failed_when_no_result(tmp_path):
     manifest_path = tmp_path / "assignment_manifest.json"
     manifest_path.write_text(json.dumps(manifest))
 
-    result = check_remaining(str(manifest_path), "assignments", str(output_dir))
+    with patch("time.sleep"):
+        result = check_remaining(str(manifest_path), "assignments", str(output_dir))
 
     updated = json.loads(manifest_path.read_text())
     assert updated["items"][0]["status"] == "failed"
     assert result["has_remaining"] == "true"
     ctx = json.loads(Path(result["current_item_path"]).read_text())
     assert ctx["id"] == "P1-A2"
+
+
+def test_check_remaining_processing_does_not_fail_on_first_miss(tmp_path):
+    """processing item: result_path.exists() returns False only on first call, True after.
+    Item must become done, not failed."""
+    from autoskillit.planner import check_remaining
+
+    manifest = _make_manifest([{"id": "A1", "status": "processing"}])
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest))
+    result_path = tmp_path / "A1_result.json"
+
+    call_count = 0
+    original_exists = Path.exists
+
+    def lagged_exists(self):
+        nonlocal call_count
+        if str(self) == str(result_path):
+            call_count += 1
+            if call_count == 1:
+                return False  # first check: FS lag
+            result_path.write_text('{"id":"A1","name":"","summary":""}')
+            return True
+        return original_exists(self)
+
+    with patch("time.sleep"), patch.object(Path, "exists", lagged_exists):
+        check_remaining(str(manifest_path), "phases", str(tmp_path))
+
+    updated = json.loads(manifest_path.read_text())
+    assert updated["items"][0]["status"] == "done"
+
+
+def test_check_remaining_processing_fails_after_all_retries_exhausted(tmp_path):
+    """processing item with no result file at all: must become failed after retries."""
+    from autoskillit.planner import check_remaining
+
+    manifest = _make_manifest(
+        [
+            {"id": "A1", "status": "processing"},
+            {"id": "A2", "status": "pending"},
+        ]
+    )
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest))
+    # No result file for A1
+
+    with patch("time.sleep") as mock_sleep:
+        check_remaining(str(manifest_path), "phases", str(tmp_path))
+
+    updated = json.loads(manifest_path.read_text())
+    items = {i["id"]: i for i in updated["items"]}
+    assert items["A1"]["status"] == "failed"
+    assert mock_sleep.call_count == 2  # 2 retries with 1s sleep each
+
+
+def test_check_remaining_sleep_called_with_one_second(tmp_path):
+    """Each retry sleep must be exactly 1 second."""
+    from autoskillit.planner import check_remaining
+
+    manifest = _make_manifest([{"id": "A1", "status": "processing"}])
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest))
+
+    with patch("time.sleep") as mock_sleep:
+        check_remaining(str(manifest_path), "phases", str(tmp_path))
+
+    for call in mock_sleep.call_args_list:
+        assert call.args[0] == 1
 
 
 def test_check_remaining_all_done_returns_false(tmp_path):

--- a/tests/recipe/test_planner_recipe.py
+++ b/tests/recipe/test_planner_recipe.py
@@ -103,3 +103,13 @@ def test_planner_recipe_validation_has_no_errors(planner_recipe):
 def test_planner_recipe_contract_exists():
     contracts_dir = builtin_recipes_dir() / "contracts"
     assert (contracts_dir / "planner.yaml").exists(), "Run: autoskillit recipes validate planner"
+
+
+def test_planner_recipe_extract_domain_uses_env_var(planner_recipe):
+    """extract_domain step must use PLANNER_ANALYSIS_FILE env-var, not positional $3."""
+    step = planner_recipe.steps["extract_domain"]
+    skill_cmd = step.with_args.get("skill_command", "")
+    assert "$3" not in skill_cmd, "Must not use positional $3"
+    assert "_ _" not in skill_cmd, "Must not have reserved-slot placeholders"
+    env = step.with_args.get("env", {})
+    assert "PLANNER_ANALYSIS_FILE" in env, "env must declare PLANNER_ANALYSIS_FILE"

--- a/tests/skills/test_planner_extract_domain.py
+++ b/tests/skills/test_planner_extract_domain.py
@@ -1,0 +1,13 @@
+import pytest
+
+from autoskillit.core.paths import pkg_root
+
+pytestmark = [pytest.mark.layer("skills"), pytest.mark.small]
+
+
+def test_planner_extract_domain_skill_uses_env_var():
+    """SKILL.md must reference PLANNER_ANALYSIS_FILE, not $3."""
+    skill_dir = pkg_root() / "skills_extended" / "planner-extract-domain"
+    content = (skill_dir / "SKILL.md").read_text()
+    assert "$3" not in content
+    assert "PLANNER_ANALYSIS_FILE" in content


### PR DESCRIPTION
## Summary

Two targeted fixes to the planner subsystem:

1. **FS-lag tolerance in `check_remaining`**: Add a 2-retry grace window (1s sleep between checks) before transitioning a `processing` manifest item to `failed` when its result file is absent. This prevents permanent state poisoning when the result file exists on disk but hasn't yet flushed to visibility at the time of the check.

2. **Named env-var for `planner-extract-domain`**: Replace the fragile `$1`/`$2` reserved-slot / `$3` analysis-file-path positional convention with a named env-var (`PLANNER_ANALYSIS_FILE`) passed via the recipe step's `env:` block. Recipe reordering will no longer silently break the path.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START])
    COMPLETE([COMPLETE])
    ERROR([ERROR — JSONDecodeError / ValueError])

    %% ── TRACK A: Manifest Building ── %%
    subgraph ManifestBuild ["● Manifest Building — manifests.py"]
        direction TB
        BuildAssign["● build_assignment_manifest<br/>━━━━━━━━━━<br/>Reads *_result.json from phases_dir<br/>Sorts by phase_number int<br/>IDs: P{N}-A{seq}"]
        BuildWP["● build_wp_manifest<br/>━━━━━━━━━━<br/>Reads *_result.json from assignments_dir<br/>Sorts by phase_number, assignment_number<br/>IDs: P{N}-A{N}-WP{N}"]
        AssignOut["assignment_manifest.json<br/>━━━━━━━━━━<br/>schema_version=1 · items=[pending…]"]
        WPOut["wp_manifest.json<br/>━━━━━━━━━━<br/>schema_version=1"]
        WPIndexInit["wp_index.json ← []<br/>━━━━━━━━━━<br/>atomic_write — always overwritten"]
    end

    %% ── TRACK B: check_remaining() Queue State Machine ── %%
    subgraph CheckRemaining ["● check_remaining() — Queue State Machine — manifests.py"]
        direction TB
        ReadManifest["● Read manifest.json<br/>━━━━━━━━━━<br/>Raises JSONDecodeError if malformed<br/>Raises ValueError if items not list"]

        subgraph Phase1 ["Phase 1 — Resolve In-Flight (processing) Items"]
            direction TB
            IterProcessing{"item.status<br/>== processing?"}
            CheckFirst{"result_file.exists()<br/>━━━━━━━━━━<br/>Initial check — no sleep"}
            TransitionDone["status → done<br/>━━━━━━━━━━<br/>Set item.result_path"]
            Backstop["_backstop_wp_index()<br/>━━━━━━━━━━<br/>Guard: pass_name == work_packages<br/>Repairs missing wp_index entries<br/>atomic_write if entry absent"]

            subgraph RetryLoop ["● FS-Lag Retry Loop (NEW)"]
                direction TB
                RetryGate{"attempt in range 2<br/>━━━━━━━━━━<br/>sleep(1s) before check"}
                CheckRetry{"result_file.exists()<br/>━━━━━━━━━━<br/>After 1 s sleep"}
                RetryBreak["break<br/>━━━━━━━━━━<br/>File appeared — exit loop"]
                MarkFailed["status → failed<br/>━━━━━━━━━━<br/>else-branch fires<br/>LOG WARNING · continue"]
            end
        end

        subgraph Phase2 ["Phase 2 — Advance Queue"]
            direction TB
            FindPending{"next item<br/>status == pending?"}
            Activate["status → processing<br/>━━━━━━━━━━<br/>Build context dict<br/>prior_results=[done paths]"]
            WriteCtx["write context_{id}.json<br/>━━━━━━━━━━<br/>schema_version=1<br/>Includes wp_index_path key"]
            WriteManifest["● write manifest.json<br/>━━━━━━━━━━<br/>Serialize all status mutations<br/>Called on BOTH return paths"]
            ReturnMore["has_remaining=true<br/>━━━━━━━━━━<br/>current_item_path → caller<br/>Caller loops back"]
            ReturnDone["has_remaining=false<br/>━━━━━━━━━━<br/>current_item_path=''<br/>Queue drained"]
        end
    end

    %% ── TRACK C: planner-extract-domain Skill ── %%
    subgraph ExtractDomain ["● planner-extract-domain Skill — SKILL.md"]
        direction TB
        EnvVarInject["● Recipe injects PLANNER_ANALYSIS_FILE<br/>━━━━━━━━━━<br/>via step env: block<br/>Replaces old positional arg $3"]
        ReadAnalysis["Read analysis.json at env path<br/>━━━━━━━━━━<br/>language · framework<br/>architecture_style · key_patterns"]
        AgentGate{"Spawn conditional agents?<br/>━━━━━━━━━━<br/>>20 modules OR<br/>style ∈ {layered, hexagonal}"}
        Agents123["Agents 1-3 (always concurrent)<br/>━━━━━━━━━━<br/>Domain Vocabulary<br/>Existing Abstractions<br/>Integration Points"]
        Agents45["Agents 4-5 (conditional)<br/>━━━━━━━━━━<br/>Extended analysis<br/>model: sonnet"]
        Synthesize["Synthesize → domain_knowledge.md<br/>━━━━━━━━━━<br/>AUTOSKILLIT_TEMP/planner/<br/>Non-fatal: any failure → exit 0"]
    end

    %% ── TRACK D: New Contract Test ── %%
    subgraph ContractTest ["★ test_planner_extract_domain.py (NEW)"]
        direction TB
        ContentGuard["★ test_planner_extract_domain_skill_uses_env_var<br/>━━━━━━━━━━<br/>Reads SKILL.md content at runtime<br/>Assert: '$3' NOT in content<br/>Assert: 'PLANNER_ANALYSIS_FILE' IN content"]
    end

    %% ── CONNECTIONS — Track A ── %%
    START --> BuildAssign & BuildWP
    BuildAssign --> AssignOut
    BuildWP --> WPOut & WPIndexInit
    AssignOut & WPOut --> ReadManifest

    %% ── CONNECTIONS — Track B ── %%
    ReadManifest -->|"parse OK"| IterProcessing
    ReadManifest -->|"malformed"| ERROR
    IterProcessing -->|"yes — each processing item"| CheckFirst
    IterProcessing -->|"none remain"| FindPending
    CheckFirst -->|"exists immediately"| TransitionDone
    CheckFirst -->|"not found"| RetryGate
    RetryGate -->|"sleep 1s"| CheckRetry
    CheckRetry -->|"exists"| RetryBreak
    CheckRetry -->|"not found, attempt < 2"| RetryGate
    CheckRetry -->|"attempt == 1 — else fires"| MarkFailed
    RetryBreak --> TransitionDone
    TransitionDone -->|"pass_name == work_packages"| Backstop
    Backstop --> IterProcessing
    MarkFailed --> IterProcessing
    FindPending -->|"pending item found"| Activate
    Activate --> WriteCtx --> WriteManifest --> ReturnMore
    FindPending -->|"none pending"| WriteManifest
    WriteManifest --> ReturnDone
    ReturnMore -->|"caller re-invokes"| ReadManifest
    ReturnDone --> COMPLETE

    %% ── CONNECTIONS — Track C ── %%
    START --> EnvVarInject
    EnvVarInject --> ReadAnalysis --> AgentGate
    AgentGate -->|"always"| Agents123
    AgentGate -->|">20 modules OR layered/hexagonal"| Agents45
    Agents123 & Agents45 --> Synthesize --> COMPLETE

    %% ── CONNECTIONS — Track D ── %%
    ContentGuard -.->|"contract guards regression to $3"| EnvVarInject

    %% ── CLASS ASSIGNMENTS ── %%
    class START,COMPLETE,ERROR terminal;
    class BuildAssign,BuildWP phase;
    class AssignOut,WPOut,WPIndexInit,WriteCtx,Synthesize output;
    class ReadManifest,IterProcessing,CheckFirst,FindPending,AgentGate detector;
    class TransitionDone,Activate,Agents123,Agents45,Backstop handler;
    class RetryGate,CheckRetry,RetryBreak,MarkFailed,WriteManifest,ReturnMore,ReturnDone phase;
    class EnvVarInject,ReadAnalysis stateNode;
    class ContentGuard newComponent;
```

Closes #1230

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260425-213022-895377/.autoskillit/temp/make-plan/planner_manifest_robustness_plan_2026-04-25_000000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 179 | 19.5k | 892.5k | 57.2k | 1 | 8m 58s |
| verify | 124 | 18.2k | 847.2k | 65.9k | 1 | 5m 10s |
| implement | 228 | 13.3k | 1.4M | 67.6k | 1 | 5m 0s |
| fix | 166 | 5.6k | 797.9k | 42.9k | 1 | 3m 19s |
| prepare_pr | 60 | 4.9k | 194.5k | 25.5k | 1 | 1m 28s |
| run_arch_lenses | 53 | 7.9k | 153.8k | 27.9k | 1 | 3m 36s |
| compose_pr | 59 | 5.1k | 190.2k | 23.5k | 1 | 1m 31s |
| **Total** | 869 | 74.6k | 4.5M | 310.5k | | 29m 4s |