### PR TITLE
Implementation Plan: Self-Registering Gate Pattern (Issue #1141)

### DIFF
--- a/src/autoskillit/core/__init__.py
+++ b/src/autoskillit/core/__init__.py
@@ -41,7 +41,12 @@ from ._terminal_table import _render_terminal_table as _render_terminal_table
 from ._version_snapshot import collect_version_snapshot as collect_version_snapshot
 from .branch_guard import is_protected_branch
 from .claude_conventions import ClaudeDirectoryConventions, LayoutError, validate_add_dir
-from .feature_flags import is_feature_enabled as is_feature_enabled
+from .feature_flags import (
+    _collect_disabled_feature_tags as _collect_disabled_feature_tags,
+)
+from .feature_flags import (
+    is_feature_enabled as is_feature_enabled,
+)
 from .github_url import _parse_issue_ref as _parse_issue_ref
 from .github_url import normalize_owner_repo as normalize_owner_repo
 from .github_url import parse_github_repo as parse_github_repo
@@ -115,7 +120,6 @@ from .types import (
     CONTEXT_EXHAUSTION_MARKER,
     DISPATCH_ID_ENV_VAR,
     FEATURE_REGISTRY,
-    FEATURE_REVEAL_TAGS,
     FLEET_DISPATCH_MODE,
     FLEET_DISPATCH_TOOLS,
     FLEET_ERROR_CODES,
@@ -300,7 +304,6 @@ __all__ = [
     "CONTEXT_EXHAUSTION_MARKER",
     "RETIRED_READINESS_TOKENS",
     "FEATURE_REGISTRY",
-    "FEATURE_REVEAL_TAGS",
     "FLEET_DISPATCH_TOOLS",
     "FLEET_ERROR_CODES",
     "FLEET_MENU_TOOLS",

--- a/src/autoskillit/core/_type_constants.py
+++ b/src/autoskillit/core/_type_constants.py
@@ -23,7 +23,6 @@ __all__ = [
     "HEADLESS_TOOLS",
     "FLEET_TOOLS",
     "FLEET_MENU_TOOLS",
-    "FEATURE_REVEAL_TAGS",
     "FREE_RANGE_TOOLS",
     "UNGATED_TOOLS",
     "MUTATING_TOOLS",
@@ -233,12 +232,6 @@ FLEET_DISPATCH_TOOLS: frozenset[str] = frozenset(
 # Tools that appear in the Fleet group in the cook menu and open_kitchen response.
 # Defined here (L0) so menu modules can import the constant without loading the fleet package.
 FLEET_MENU_TOOLS: tuple[str, ...] = ("dispatch_food_truck",)
-
-# Tags that are EXCLUSIVELY used for feature-gated visibility (not general kitchen tags).
-# When a feature is disabled, these tags are the ones suppressed via disable_components.
-# Tools with these tags AND a kitchen-core tag remain visible via the kitchen-core tag
-# (FastMCP union model: any enabled tag keeps the tool visible).
-FEATURE_REVEAL_TAGS: frozenset[str] = frozenset({"fleet"})
 
 FLEET_ERROR_CODES: frozenset[str] = frozenset(FleetErrorCode)
 

--- a/src/autoskillit/core/feature_flags.py
+++ b/src/autoskillit/core/feature_flags.py
@@ -35,3 +35,21 @@ def is_feature_enabled(name: str, features: dict[str, bool]) -> bool:
     if defn is None:
         raise KeyError(f"Unknown feature: {name!r}")
     return features.get(name, defn.default_enabled)
+
+
+def _collect_disabled_feature_tags(features: dict[str, bool]) -> frozenset[str]:
+    """Return feature tags that should be suppressed.
+
+    Single source of truth used by _fleet_auto_gate_boot and _redisable_subsets.
+    The registry is the sole authority on which tags belong to which feature.
+    """
+    enabled_tags: set[str] = set()
+    disabled_tags: set[str] = set()
+    for name, defn in FEATURE_REGISTRY.items():
+        if not defn.tool_tags:
+            continue
+        if is_feature_enabled(name, features):
+            enabled_tags |= defn.tool_tags
+        else:
+            disabled_tags |= defn.tool_tags
+    return frozenset(disabled_tags - enabled_tags)

--- a/src/autoskillit/server/__init__.py
+++ b/src/autoskillit/server/__init__.py
@@ -76,10 +76,7 @@ from autoskillit.server import (  # noqa: E402, F401
     tools_workspace,
 )
 from autoskillit.server._factory import make_context  # noqa: E402, F401
-from autoskillit.server._session_type import (  # noqa: E402, F401
-    _apply_session_type_visibility,
-    _fleet_gate,
-)
+from autoskillit.server._session_type import _apply_session_type_visibility  # noqa: E402, F401
 from autoskillit.server.tools_kitchen import _build_tool_category_listing  # noqa: E402, F401
 
 # Apply global visibility transform: all sessions start with kitchen tools hidden.
@@ -92,4 +89,4 @@ from autoskillit.server._wire_compat import ClaudeCodeCompatMiddleware  # noqa: 
 
 mcp.add_middleware(ClaudeCodeCompatMiddleware())
 
-_apply_session_type_visibility(feature_gates=[_fleet_gate])
+_apply_session_type_visibility()

--- a/src/autoskillit/server/_lifespan.py
+++ b/src/autoskillit/server/_lifespan.py
@@ -155,23 +155,12 @@ async def _fleet_auto_gate_boot(ctx: Any) -> None:
     ctx.gate.enable()
     logger.info("fleet_auto_gate_boot", gate_state="open", kitchen_id=ctx.kitchen_id)
 
-    # Enforce config-based feature suppression immediately after gate open.
-    # Mirrors _redisable_subsets pass 2 without requiring a FastMCP Context.
-    # Must run at lifespan time so fleet tools are hidden before any tool call arrives.
     try:
-        from autoskillit.core import FEATURE_REGISTRY, FEATURE_REVEAL_TAGS, is_feature_enabled
+        from autoskillit.core import _collect_disabled_feature_tags
         from autoskillit.server import mcp as _mcp
 
         _features = ctx.config.features if ctx.config is not None else {}
-        _enabled_tags: set[str] = set()
-        _disabled_tags: set[str] = set()
-        for _feat_name, _feat_def in FEATURE_REGISTRY.items():
-            _reveal = FEATURE_REVEAL_TAGS & _feat_def.tool_tags
-            if is_feature_enabled(_feat_name, _features):
-                _enabled_tags |= _reveal
-            else:
-                _disabled_tags |= _reveal
-        for _tag in _disabled_tags - _enabled_tags:
+        for _tag in _collect_disabled_feature_tags(_features):
             _mcp.disable(tags={_tag})
     except Exception:
         logger.warning("fleet_auto_gate_boot_feature_suppression_failed", exc_info=True)

--- a/src/autoskillit/server/_session_type.py
+++ b/src/autoskillit/server/_session_type.py
@@ -7,7 +7,6 @@ sub-package __init__ files.
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING
 
 from autoskillit.core import (
     CATEGORY_TAGS,
@@ -18,9 +17,6 @@ from autoskillit.core import (
     get_logger,
 )
 from autoskillit.core import session_type as _resolve_session_type
-
-if TYPE_CHECKING:
-    pass
 
 _log = get_logger(__name__)
 

--- a/src/autoskillit/server/_session_type.py
+++ b/src/autoskillit/server/_session_type.py
@@ -7,13 +7,10 @@ sub-package __init__ files.
 from __future__ import annotations
 
 import os
-from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from autoskillit.core import (
     CATEGORY_TAGS,
-    FEATURE_REGISTRY,
-    FEATURE_REVEAL_TAGS,
     FLEET_DISPATCH_MODE,
     FLEET_MODE_ENV_VAR,
     HEADLESS_ENV_VAR,
@@ -23,22 +20,17 @@ from autoskillit.core import (
 from autoskillit.core import session_type as _resolve_session_type
 
 if TYPE_CHECKING:
-    from fastmcp import FastMCP
+    pass
 
 _log = get_logger(__name__)
 
-FeatureGate = Callable[["FastMCP", SessionType], None]
 
-
-def _apply_session_type_visibility(
-    *,
-    feature_gates: list[FeatureGate] | None = None,
-) -> None:
+def _apply_session_type_visibility() -> None:
     """Apply FastMCP tag visibility based on session type + HEADLESS.
 
-    Phase 1: session-type dispatch (existing logic, unchanged).
-    Phase 2: feature gates — always run after phase 1, structurally
-             enforcing feature gates as an override layer.
+    Session-type dispatch only — feature gate suppression is handled at lifespan
+    time by _fleet_auto_gate_boot (fleet sessions) and _redisable_subsets
+    (open_kitchen sessions) where the full config pipeline is available.
     """
     from autoskillit.server import mcp
 
@@ -72,21 +64,3 @@ def _apply_session_type_visibility(
         mcp.enable(tags={"headless"})
     # ORCHESTRATOR+interactive and LEAF+interactive: no pre-reveal.
     # Cook unlocks via open_kitchen (orchestrator) or stays minimal (leaf).
-
-    # Phase 2: feature gates — execute after phase 1 to enforce override semantics
-    for gate in feature_gates or []:
-        gate(mcp, _session)
-
-
-def _fleet_gate(mcp: FastMCP, session: SessionType) -> None:  # noqa: ARG001
-    """Disable fleet-tagged tools when the fleet feature is off.
-
-    Intentionally reads only the AUTOSKILLIT_FEATURES__FLEET env var.
-    This function runs at import time before config is loaded, so the
-    config file is not available here. The deferred config-based check
-    is performed by _fleet_auto_gate_boot() in _lifespan.py once the
-    server context (ctx.config.features) is available.
-    """
-    fleet_val = os.environ.get("AUTOSKILLIT_FEATURES__FLEET", "").strip().lower()
-    if fleet_val in ("false", "0", "no"):
-        mcp.disable(tags=set(FEATURE_REVEAL_TAGS & FEATURE_REGISTRY["fleet"].tool_tags))

--- a/src/autoskillit/server/tools_kitchen.py
+++ b/src/autoskillit/server/tools_kitchen.py
@@ -20,10 +20,10 @@ from autoskillit import __version__
 from autoskillit.config import iter_display_categories, resolve_ingredient_defaults
 from autoskillit.core import (
     PIPELINE_FORBIDDEN_TOOLS,
+    _collect_disabled_feature_tags,
     atomic_write,
     find_latest_session_id,
     get_logger,
-    is_feature_enabled,
     pkg_root,
 )
 from autoskillit.pipeline import create_background_task
@@ -184,37 +184,20 @@ async def _redisable_subsets(
     Pass 1 (existing): Re-disable config-disabled subset tags so dual-tagged tools
     (e.g. kitchen+github) that are server-disabled are not accidentally revealed.
 
-    Pass 2 (new): For each feature disabled in config, suppress FEATURE_REVEAL_TAGS
-    that belong to that feature. Shared tools with kitchen-core retain visibility
-    via the kitchen-core tag (FastMCP union model).
+    Pass 2: Suppress tool tags for disabled features via `_collect_disabled_feature_tags`.
+    Shared tools with kitchen-core retain visibility via the kitchen-core tag
+    (FastMCP union model).
 
     ``features`` defaults to ``None`` (treated as ``{}``, i.e. all features use
     ``FeatureDef.default_enabled``). Pass ``config.features`` from the call site.
-
-    For tools with ONLY a feature tag (no kitchen-core fallback), a per-tool
-    suppression constant and path is needed here once such tools exist.
     """
     # Pass 1: subset re-disable (existing)
     for subset in disabled:
         await ctx.disable_components(tags={subset})
 
-    # Pass 2: feature gate — suppress feature-reveal tags for disabled features
-    from autoskillit.core import (  # noqa: PLC0415
-        FEATURE_REGISTRY,
-        FEATURE_REVEAL_TAGS,
-    )
-
-    # Union model: a tag is suppressed only when no enabled feature claims it.
+    # Pass 2: feature gate — suppress tool tags for disabled features
     _features = features or {}
-    enabled_tags: set[str] = set()
-    disabled_tags: set[str] = set()
-    for feature_name, feature_def in FEATURE_REGISTRY.items():
-        reveal = FEATURE_REVEAL_TAGS & feature_def.tool_tags
-        if is_feature_enabled(feature_name, _features):
-            enabled_tags |= reveal
-        else:
-            disabled_tags |= reveal
-    for tag in disabled_tags - enabled_tags:
+    for tag in _collect_disabled_feature_tags(_features):
         await ctx.disable_components(tags={tag})
 
 

--- a/tests/core/test_feature_flags.py
+++ b/tests/core/test_feature_flags.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-pytestmark = [pytest.mark.layer("core"), pytest.mark.fast]
+pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
 
 
 class TestCollectDisabledFeatureTags:

--- a/tests/core/test_feature_flags.py
+++ b/tests/core/test_feature_flags.py
@@ -1,0 +1,92 @@
+"""Tests for core/feature_flags.py — _collect_disabled_feature_tags helper."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.layer("core"), pytest.mark.fast]
+
+
+class TestCollectDisabledFeatureTags:
+    def test_returns_frozenset(self):
+        from autoskillit.core.feature_flags import _collect_disabled_feature_tags
+
+        result = _collect_disabled_feature_tags({})
+        assert isinstance(result, frozenset)
+
+    def test_disabled_fleet_returns_fleet_tag(self):
+        from autoskillit.core.feature_flags import _collect_disabled_feature_tags
+
+        result = _collect_disabled_feature_tags({"fleet": False})
+        assert "fleet" in result
+
+    def test_enabled_fleet_not_in_result(self):
+        from autoskillit.core.feature_flags import _collect_disabled_feature_tags
+
+        result = _collect_disabled_feature_tags({"fleet": True})
+        assert "fleet" not in result
+
+    def test_planner_skipped_empty_tool_tags(self):
+        from autoskillit.core.feature_flags import _collect_disabled_feature_tags
+
+        # "planner" FeatureDef has tool_tags=frozenset() — must be skipped
+        result = _collect_disabled_feature_tags({"fleet": False, "planner": False})
+        assert result == frozenset({"fleet"})
+
+    def test_default_disabled_fleet(self):
+        from autoskillit.core.feature_flags import _collect_disabled_feature_tags
+
+        # fleet.default_enabled is False → fleet disabled when key absent
+        result = _collect_disabled_feature_tags({})
+        assert "fleet" in result
+
+    def test_hypothetical_third_feature_auto_discovered(self, monkeypatch):
+        from autoskillit.core import feature_flags as ff
+        from autoskillit.core._type_constants import FEATURE_REGISTRY, FeatureDef, FeatureLifecycle
+        from autoskillit.core.feature_flags import _collect_disabled_feature_tags
+
+        fake_def = FeatureDef(
+            name="testgate",
+            lifecycle=FeatureLifecycle.EXPERIMENTAL,
+            description="Test-only gate",
+            tool_tags=frozenset({"testgate-tool"}),
+            skill_categories=frozenset(),
+            import_package=None,
+            default_enabled=False,
+        )
+        patched_registry = {**FEATURE_REGISTRY, "testgate": fake_def}
+        monkeypatch.setattr(ff, "FEATURE_REGISTRY", patched_registry)
+
+        result = _collect_disabled_feature_tags({})
+        assert "testgate-tool" in result
+
+    def test_union_model_tag_claimed_by_enabled_feature(self, monkeypatch):
+        from autoskillit.core import feature_flags as ff
+        from autoskillit.core._type_constants import FEATURE_REGISTRY, FeatureDef, FeatureLifecycle
+        from autoskillit.core.feature_flags import _collect_disabled_feature_tags
+
+        shared_tag = frozenset({"shared-tag"})
+        def_a = FeatureDef(
+            name="feat_a",
+            lifecycle=FeatureLifecycle.EXPERIMENTAL,
+            description="A",
+            tool_tags=shared_tag,
+            skill_categories=frozenset(),
+            import_package=None,
+            default_enabled=False,
+        )
+        def_b = FeatureDef(
+            name="feat_b",
+            lifecycle=FeatureLifecycle.EXPERIMENTAL,
+            description="B",
+            tool_tags=shared_tag,
+            skill_categories=frozenset(),
+            import_package=None,
+            default_enabled=True,
+        )
+        patched = {**FEATURE_REGISTRY, "feat_a": def_a, "feat_b": def_b}
+        monkeypatch.setattr(ff, "FEATURE_REGISTRY", patched)
+
+        result = _collect_disabled_feature_tags({"feat_a": False, "feat_b": True})
+        # feat_b enabled claims the tag → must not appear in result
+        assert "shared-tag" not in result

--- a/tests/core/test_import_isolation.py
+++ b/tests/core/test_import_isolation.py
@@ -1,4 +1,4 @@
-"""REQ-IMP-006: fleet package must not be imported at startup when fleet is disabled."""
+"""Fleet package must not be imported at server startup via lazy-import structure."""
 
 from __future__ import annotations
 
@@ -10,40 +10,31 @@ import pytest
 pytestmark = [pytest.mark.layer("core"), pytest.mark.medium]
 
 
-def _run_isolation_check(import_stmt: str) -> set[str]:
-    """Return the set of autoskillit.fleet.* modules loaded after import_stmt runs."""
+def test_server_import_does_not_load_fleet_package_lazily() -> None:
+    """
+    Fleet module loading is deferred to lifespan/tool-call time via lazy imports.
+    A bare `import autoskillit.server` must not pull in autoskillit.fleet.* —
+    not because of an env-var gate, but because no top-level fleet import exists.
+    """
     code = (
-        f"{import_stmt}\n"
-        "import sys\n"
-        "print('\\n'.join(k for k in sys.modules if k.startswith('autoskillit.fleet')))"
+        "import sys; import autoskillit.server; "
+        "fleet_modules = [k for k in sys.modules if k.startswith('autoskillit.fleet')]; "
+        "print(fleet_modules)"
     )
     result = subprocess.run(
-        [sys.executable, "-c", code],
-        capture_output=True,
-        text=True,
-        env={
-            **__import__("os").environ,
-            "AUTOSKILLIT_FEATURES__FLEET": "false",
-        },
+        [sys.executable, "-c", code], capture_output=True, text=True, check=True
     )
-    assert result.returncode == 0, f"Import failed:\n{result.stderr}"
-    loaded = {line.strip() for line in result.stdout.splitlines() if line.strip()}
-    return loaded
-
-
-def test_server_import_does_not_load_fleet_package() -> None:
-    """Importing autoskillit.server must not trigger fleet package init when fleet=false."""
-    loaded = _run_isolation_check("import autoskillit.server")
-    assert not loaded, (
-        f"autoskillit.server import triggered fleet package init. "
-        f"Loaded fleet modules: {sorted(loaded)}"
-    )
+    assert result.stdout.strip() == "[]", f"Fleet modules leaked: {result.stdout}"
 
 
 def test_cli_app_import_does_not_load_fleet_package() -> None:
-    """Importing autoskillit.cli.app must not trigger fleet package init when fleet=false."""
-    loaded = _run_isolation_check("import autoskillit.cli.app")
-    assert not loaded, (
-        f"autoskillit.cli.app import triggered fleet package init. "
-        f"Loaded fleet modules: {sorted(loaded)}"
+    """Importing autoskillit.cli.app must not trigger fleet package init."""
+    code = (
+        "import sys; import autoskillit.cli.app; "
+        "fleet_modules = [k for k in sys.modules if k.startswith('autoskillit.fleet')]; "
+        "print(fleet_modules)"
     )
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, check=True
+    )
+    assert result.stdout.strip() == "[]", f"Fleet modules leaked: {result.stdout}"

--- a/tests/core/test_type_constants.py
+++ b/tests/core/test_type_constants.py
@@ -142,11 +142,10 @@ def test_recipe_pack_def_importable_from_core() -> None:
     assert all(isinstance(v, RecipePackDef) for v in RECIPE_PACK_REGISTRY.values())
 
 
-def test_feature_reveal_tags_exists() -> None:
-    from autoskillit.core import FEATURE_REVEAL_TAGS
-
-    assert isinstance(FEATURE_REVEAL_TAGS, frozenset)
-    assert "fleet" in FEATURE_REVEAL_TAGS
+def test_feature_reveal_tags_removed() -> None:
+    """FEATURE_REVEAL_TAGS was intentionally removed in #1141."""
+    with pytest.raises(ImportError):
+        from autoskillit.core import FEATURE_REVEAL_TAGS  # noqa: F401
 
 
 def test_exclusive_feature_tools_removed() -> None:

--- a/tests/fleet/test_fleet_rename_integrity.py
+++ b/tests/fleet/test_fleet_rename_integrity.py
@@ -62,14 +62,6 @@ def test_feature_registry_franchise_entry_gone() -> None:
     assert "franchise" not in FEATURE_REGISTRY
 
 
-def test_feature_reveal_tags_fleet_removed() -> None:
-    """FEATURE_REVEAL_TAGS was removed in #1141 — this tombstone guards against re-introduction."""
-    import pytest
-
-    with pytest.raises(ImportError):
-        from autoskillit.core import FEATURE_REVEAL_TAGS  # noqa: F401
-
-
 def test_session_type_no_franchise() -> None:
     from autoskillit.core._type_enums import SessionType
 

--- a/tests/fleet/test_fleet_rename_integrity.py
+++ b/tests/fleet/test_fleet_rename_integrity.py
@@ -62,10 +62,12 @@ def test_feature_registry_franchise_entry_gone() -> None:
     assert "franchise" not in FEATURE_REGISTRY
 
 
-def test_feature_reveal_tags_fleet() -> None:
-    from autoskillit.core import FEATURE_REVEAL_TAGS
+def test_feature_reveal_tags_fleet_removed() -> None:
+    """FEATURE_REVEAL_TAGS was removed in #1141 — this tombstone guards against re-introduction."""
+    import pytest
 
-    assert FEATURE_REVEAL_TAGS == frozenset({"fleet"})
+    with pytest.raises(ImportError):
+        from autoskillit.core import FEATURE_REVEAL_TAGS  # noqa: F401
 
 
 def test_session_type_no_franchise() -> None:

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -128,7 +128,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/server/_lifespan.py", 56),
     # tools_kitchen.py — hook config dict
     ("src/autoskillit/server/tools_kitchen.py", 123),
-    ("src/autoskillit/server/tools_kitchen.py", 536),
+    ("src/autoskillit/server/tools_kitchen.py", 519),
     # tools_status.py — mcp_data dict
     ("src/autoskillit/server/tools_status.py", 400),
     # tools_github.py — bug report dict

--- a/tests/server/test_server_init.py
+++ b/tests/server/test_server_init.py
@@ -1095,10 +1095,38 @@ class TestFleetAutoGateBoot:
         for name in FLEET_TOOLS:
             assert name not in tool_names, f"{name} should be hidden when fleet feature disabled"
 
+    @pytest.mark.anyio
+    async def test_fleet_auto_gate_boot_calls_shared_helper(self, tool_ctx, monkeypatch):
+        """_fleet_auto_gate_boot delegates to _collect_disabled_feature_tags, not inline logic."""
+        import dataclasses
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from autoskillit.pipeline.gate import DefaultGateState
+        from autoskillit.server._lifespan import _fleet_auto_gate_boot
+
+        tool_ctx.gate = DefaultGateState(enabled=False)
+        tool_ctx.quota_refresh_task = None
+        tool_ctx.config = dataclasses.replace(tool_ctx.config, features={"fleet": False})
+
+        monkeypatch.setattr("autoskillit.server._lifespan._get_ctx_or_none", lambda: tool_ctx)
+
+        with patch("autoskillit.core._collect_disabled_feature_tags") as mock_helper:
+            mock_helper.return_value = frozenset({"fleet"})
+            with patch("autoskillit.server.tools_kitchen._write_hook_config"):
+                with patch("autoskillit.server.helpers._prime_quota_cache", new=AsyncMock()):
+                    with patch(
+                        "autoskillit.pipeline.create_background_task",
+                        return_value=MagicMock(),
+                    ):
+                        with patch("autoskillit.core.register_active_kitchen"):
+                            await _fleet_auto_gate_boot(tool_ctx)
+
+        mock_helper.assert_called_once_with(tool_ctx.config.features)
+
 
 @pytest.mark.feature("fleet")
 class TestFeatureGateVisibility:
-    """Feature gate override layer in _apply_session_type_visibility."""
+    """Session-type dispatch in _apply_session_type_visibility (phase 1 only)."""
 
     @pytest.fixture(autouse=True)
     def _reset_mcp_visibility(self):
@@ -1112,190 +1140,30 @@ class TestFeatureGateVisibility:
         mcp.disable(tags={"kitchen"})
 
     @pytest.mark.anyio
-    async def test_fleet_tools_hidden_when_feature_disabled(self, monkeypatch):
-        """SESSION_TYPE=fleet + AUTOSKILLIT_FEATURES__FLEET=false → no fleet tools."""
-        from autoskillit.core import FLEET_TOOLS
-        from autoskillit.server import mcp
-        from autoskillit.server._session_type import (
-            _apply_session_type_visibility,
-            _fleet_gate,
-        )
-
-        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
-        monkeypatch.setenv("AUTOSKILLIT_FEATURES__FLEET", "false")
-        _apply_session_type_visibility(feature_gates=[_fleet_gate])
-
-        tools = list(await mcp.list_tools())
-        tool_names = {t.name for t in tools}
-        for name in FLEET_TOOLS:
-            assert name not in tool_names, (
-                f"{name} should be hidden when fleet feature is disabled"
-            )
-
-    @pytest.mark.anyio
     async def test_fleet_tools_visible_when_feature_enabled(self, monkeypatch):
-        """SESSION_TYPE=fleet with no override → fleet tools visible (default_enabled)."""
-        from autoskillit.core import FLEET_TOOLS
-        from autoskillit.server import mcp
-        from autoskillit.server._session_type import (
-            _apply_session_type_visibility,
-            _fleet_gate,
-        )
-
-        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
-        monkeypatch.delenv("AUTOSKILLIT_FEATURES__FLEET", raising=False)
-        _apply_session_type_visibility(feature_gates=[_fleet_gate])
-
-        tools = list(await mcp.list_tools())
-        tool_names = {t.name for t in tools}
-        for name in FLEET_TOOLS:
-            assert name in tool_names, (
-                f"{name} should be visible for fleet session when feature is enabled"
-            )
-
-    @pytest.mark.anyio
-    async def test_session_type_fleet_respects_gate(self, monkeypatch):
-        """fleet session + feature disabled → no fleet tools, non-fleet hidden too."""
-        from autoskillit.core import FLEET_TOOLS, GATED_TOOLS
-        from autoskillit.server import mcp
-        from autoskillit.server._session_type import (
-            _apply_session_type_visibility,
-            _fleet_gate,
-        )
-
-        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
-        monkeypatch.setenv("AUTOSKILLIT_FEATURES__FLEET", "false")
-        _apply_session_type_visibility(feature_gates=[_fleet_gate])
-
-        tools = list(await mcp.list_tools())
-        tool_names = {t.name for t in tools}
-        # No fleet tool visible — gate neutralized the pre-reveal
-        for name in FLEET_TOOLS:
-            assert name not in tool_names, f"{name} should be hidden after fleet gate override"
-        # Non-fleet kitchen tools also absent (only fleet was pre-revealed)
-        for name in GATED_TOOLS - FLEET_TOOLS:
-            assert name not in tool_names, (
-                f"{name} (non-fleet kitchen) should be hidden for fleet session"
-            )
-
-    def test_feature_gate_ordering(self, monkeypatch):
-        """Feature gates execute AFTER session-type dispatch (structural ordering test)."""
-        from unittest.mock import patch
-
-        from autoskillit.core import SessionType
-        from autoskillit.server._session_type import _apply_session_type_visibility
-
-        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
-
-        call_order: list[str] = []
-
-        # Monkeypatch mcp.enable to record dispatch happening
-        import autoskillit.server._session_type as st_mod
-
-        def recording_gate(mcp_instance, session: SessionType) -> None:
-            call_order.append("gate")
-
-        with patch.object(st_mod, "_resolve_session_type", return_value=SessionType.FLEET):
-            import autoskillit.server as server_mod
-
-            real_enable = server_mod.mcp.enable
-
-            def patched_enable(*, tags):
-                call_order.append("dispatch_enable")
-                return real_enable(tags=tags)
-
-            with patch.object(server_mod.mcp, "enable", patched_enable):
-                _apply_session_type_visibility(feature_gates=[recording_gate])
-
-        # Gate must be called, and after dispatch_enable
-        assert "gate" in call_order, "Gate was never called"
-        dispatch_idx = next((i for i, v in enumerate(call_order) if v == "dispatch_enable"), None)
-        gate_idx = next((i for i, v in enumerate(call_order) if v == "gate"), None)
-        assert dispatch_idx is not None, "Dispatch enable was never called"
-        assert gate_idx > dispatch_idx, (
-            f"Gate (idx={gate_idx}) must run AFTER dispatch (idx={dispatch_idx})"
-        )
-
-    @pytest.mark.anyio
-    async def test_apply_session_type_visibility_accepts_no_gates(self, monkeypatch):
-        """Backward compat: _apply_session_type_visibility() with no args behaves identically."""
+        """SESSION_TYPE=fleet → fleet tools visible (session-type dispatch only)."""
         from autoskillit.core import FLEET_TOOLS
         from autoskillit.server import mcp
         from autoskillit.server._session_type import _apply_session_type_visibility
 
         monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
-        monkeypatch.delenv("AUTOSKILLIT_FEATURES__FLEET", raising=False)
-        # Call with no feature_gates argument (backward-compatible call)
         _apply_session_type_visibility()
 
         tools = list(await mcp.list_tools())
         tool_names = {t.name for t in tools}
-        # Phase 1 still works: fleet tools visible
         for name in FLEET_TOOLS:
             assert name in tool_names, (
-                f"{name} should be visible with no-gate backward-compatible call"
+                f"{name} should be visible for fleet session (phase-1 reveal)"
             )
 
-    @pytest.mark.anyio
-    async def test_fleet_gate_disables_tools_via_fleet_env_var(self, monkeypatch):
-        """AUTOSKILLIT_FEATURES__FLEET=false disables fleet-tagged tools."""
-        from autoskillit.core import FLEET_TOOLS
-        from autoskillit.server import mcp
-        from autoskillit.server._session_type import _apply_session_type_visibility, _fleet_gate
+    def test_apply_session_type_visibility_sole_calling_convention(self):
+        """No feature_gates parameter exists — session-type dispatch only."""
+        import inspect
 
-        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
-        monkeypatch.setenv("AUTOSKILLIT_FEATURES__FLEET", "false")
-        _apply_session_type_visibility(feature_gates=[_fleet_gate])
+        from autoskillit.server._session_type import _apply_session_type_visibility
 
-        tools = list(await mcp.list_tools())
-        tool_names = {t.name for t in tools}
-        assert FLEET_TOOLS
-        for tool in FLEET_TOOLS:
-            assert tool not in tool_names
-
-    @pytest.mark.anyio
-    async def test_fleet_gate_franchise_env_var_has_no_effect(self, monkeypatch):
-        """AUTOSKILLIT_FEATURES__FRANCHISE=false is no longer honored (T2 removed backward compat).
-
-        Only AUTOSKILLIT_FEATURES__FLEET controls fleet tool visibility.
-        Setting the old FRANCHISE env var has no effect — tools remain visible.
-        """
-        from autoskillit.core import FLEET_TOOLS
-        from autoskillit.server import mcp
-        from autoskillit.server._session_type import _apply_session_type_visibility, _fleet_gate
-
-        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
-        monkeypatch.setenv("AUTOSKILLIT_FEATURES__FRANCHISE", "false")
-        monkeypatch.delenv("AUTOSKILLIT_FEATURES__FLEET", raising=False)
-        _apply_session_type_visibility(feature_gates=[_fleet_gate])
-
-        tools = list(await mcp.list_tools())
-        tool_names = {t.name for t in tools}
-        # AUTOSKILLIT_FEATURES__FRANCHISE is ignored — fleet tools remain visible
-        assert FLEET_TOOLS
-        for tool in FLEET_TOOLS:
-            assert tool in tool_names, (
-                f"{tool} should still be visible: FRANCHISE env var is no longer honored"
-            )
-
-    @pytest.mark.anyio
-    async def test_fleet_gate_fleet_env_var_takes_precedence_over_franchise(self, monkeypatch):
-        """AUTOSKILLIT_FEATURES__FLEET=true enables fleet tools; FRANCHISE env var is ignored."""
-        from autoskillit.core import FLEET_TOOLS
-        from autoskillit.server import mcp
-        from autoskillit.server._session_type import _apply_session_type_visibility, _fleet_gate
-
-        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
-        monkeypatch.setenv("AUTOSKILLIT_FEATURES__FLEET", "true")
-        # AUTOSKILLIT_FEATURES__FRANCHISE is no longer read; setting it has no effect
-        monkeypatch.setenv("AUTOSKILLIT_FEATURES__FRANCHISE", "false")
-        _apply_session_type_visibility(feature_gates=[_fleet_gate])
-
-        tools = list(await mcp.list_tools())
-        tool_names = {t.name for t in tools}
-        assert FLEET_TOOLS
-        for tool in FLEET_TOOLS:
-            assert tool in tool_names
+        sig = inspect.signature(_apply_session_type_visibility)
+        assert "feature_gates" not in sig.parameters
 
     @pytest.mark.anyio
     async def test_session_type_fleet_enables_fleet_tags(self, monkeypatch):
@@ -1306,7 +1174,6 @@ class TestFeatureGateVisibility:
 
         monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
         monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
-        monkeypatch.delenv("AUTOSKILLIT_FEATURES__FLEET", raising=False)
         _apply_session_type_visibility()
 
         tools = list(await mcp.list_tools())

--- a/tests/server/test_tools_kitchen.py
+++ b/tests/server/test_tools_kitchen.py
@@ -1347,6 +1347,22 @@ async def test_redisable_subsets_does_not_disable_kitchen_core_tag() -> None:
     )
 
 
+@pytest.mark.anyio
+async def test_redisable_subsets_uses_shared_helper() -> None:
+    """_redisable_subsets delegates Pass 2 to _collect_disabled_feature_tags."""
+    from unittest.mock import AsyncMock, patch
+
+    from autoskillit.server.tools_kitchen import _redisable_subsets
+
+    mock_ctx = AsyncMock()
+
+    with patch("autoskillit.server.tools_kitchen._collect_disabled_feature_tags") as mock_h:
+        mock_h.return_value = frozenset({"fleet"})
+        await _redisable_subsets(mock_ctx, [], features={"fleet": False})
+
+    mock_h.assert_called_once_with({"fleet": False})
+
+
 # ---------------------------------------------------------------------------
 # T7 — _kitchen_failure_envelope default hint says autoskillit install not reinstall
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Replace three manually-maintained inline copies of feature-tag resolution logic with a single
shared helper `_collect_disabled_feature_tags()` in `core/feature_flags.py`. The import-time
`_fleet_gate` function (which reads raw env vars) is removed; feature gating shifts entirely to
lifespan time where the full config pipeline is available. `FEATURE_REVEAL_TAGS` is deleted as a
now-redundant indirection. Adding a future feature gate becomes: add a `FeatureDef` with
`tool_tags` to `FEATURE_REGISTRY` — no other production files change.

## Architecture Impact

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ─────────────────────────────────────────────
    %% LAYER 0 — CORE (zero autoskillit imports)
    %% ─────────────────────────────────────────────
    subgraph CoreLayer ["LAYER 0 — CORE (stdlib-only)"]
        direction TB

        TYPE_ENUMS["_type_enums.py<br/>━━━━━━━━━━<br/>FeatureLifecycle<br/>FleetErrorCode"]

        TYPE_CONSTANTS["● _type_constants.py<br/>━━━━━━━━━━<br/>FEATURE_REGISTRY<br/>FeatureDef · RETIRED_FEATURES<br/>GATED_TOOLS · UNGATED_TOOLS<br/>tool-set constants"]

        FEATURE_FLAGS["● feature_flags.py<br/>━━━━━━━━━━<br/>is_feature_enabled()<br/>_collect_disabled_feature_tags()"]

        CORE_INIT["● core/__init__.py<br/>━━━━━━━━━━<br/>Re-export façade<br/>(100+ names)"]
    end

    %% ─────────────────────────────────────────────
    %% LAYER 3 — SERVER
    %% ─────────────────────────────────────────────
    subgraph ServerLayer ["LAYER 3 — SERVER"]
        direction TB

        SERVER_INIT["● server/__init__.py<br/>━━━━━━━━━━<br/>FastMCP app · gate setup<br/>_apply_session_type_visibility()<br/>_build_tool_category_listing()"]

        LIFESPAN["● server/_lifespan.py<br/>━━━━━━━━━━<br/>_autoskillit_lifespan()<br/>startup drift/hook checks<br/>_fleet_auto_gate_boot()"]

        SESSION_TYPE["● server/_session_type.py<br/>━━━━━━━━━━<br/>_apply_session_type_visibility()<br/>tag enable/disable dispatch"]

        TOOLS_KITCHEN["● server/tools_kitchen.py<br/>━━━━━━━━━━<br/>open_kitchen · close_kitchen<br/>disable_quota_guard · reload_session<br/>_build_tool_category_listing()"]
    end

    %% ─────────────────────────────────────────────
    %% TESTS
    %% ─────────────────────────────────────────────
    subgraph TestLayer ["TESTS"]
        direction LR

        T_FEATURE_FLAGS["★ tests/core/test_feature_flags.py<br/>━━━━━━━━━━<br/>_collect_disabled_feature_tags<br/>FEATURE_REGISTRY contract"]

        T_TYPE_CONSTANTS["● tests/core/test_type_constants.py<br/>━━━━━━━━━━<br/>FEATURE_REGISTRY shape<br/>removed: FEATURE_REVEAL_TAGS<br/>removed: EXCLUSIVE_FEATURE_TOOLS"]

        T_IMPORT_ISO["● tests/core/test_import_isolation.py<br/>━━━━━━━━━━<br/>server/cli do NOT eagerly<br/>load fleet.* at import time"]

        T_SERVER_INIT["● tests/server/test_server_init.py<br/>━━━━━━━━━━<br/>kitchen gate visibility<br/>session-type dispatch<br/>fleet lifespan auto-gate"]

        T_TOOLS_KITCHEN["● tests/server/test_tools_kitchen.py<br/>━━━━━━━━━━<br/>open/close handlers<br/>hook config lifecycle<br/>quota guard"]

        T_FLEET["● tests/fleet/test_fleet_rename_integrity.py<br/>━━━━━━━━━━<br/>FleetErrorCode · SessionType.FLEET<br/>old franchise names gone"]

        T_SCHEMA["● tests/infra/test_schema_version_convention.py<br/>━━━━━━━━━━<br/>atomic_write allowlist ratchet<br/>tools_kitchen.py line guard"]
    end

    %% ─────────────────────────────────────────────
    %% INTRA-CORE DEPENDENCIES (L0 → L0)
    %% ─────────────────────────────────────────────
    TYPE_ENUMS -->|"FeatureLifecycle<br/>FleetErrorCode"| TYPE_CONSTANTS
    TYPE_CONSTANTS -->|"FEATURE_REGISTRY"| FEATURE_FLAGS
    FEATURE_FLAGS -->|"is_feature_enabled<br/>_collect_disabled_feature_tags"| CORE_INIT
    TYPE_CONSTANTS -->|"GATED_TOOLS · UNGATED_TOOLS<br/>tool-set constants"| CORE_INIT

    %% ─────────────────────────────────────────────
    %% SERVER → CORE DEPENDENCIES (L3 → L0)
    %% ─────────────────────────────────────────────
    CORE_INIT -->|"GATED_TOOLS · UNGATED_TOOLS<br/>get_logger · …"| SERVER_INIT
    CORE_INIT -->|"_collect_disabled_feature_tags<br/>write/cleanup_readiness_sentinel"| LIFESPAN
    CORE_INIT -->|"CATEGORY_TAGS · SessionType<br/>HEADLESS_ENV_VAR · …"| SESSION_TYPE
    CORE_INIT -->|"_collect_disabled_feature_tags<br/>PIPELINE_FORBIDDEN_TOOLS · …"| TOOLS_KITCHEN

    %% ─────────────────────────────────────────────
    %% INTRA-SERVER DEPENDENCIES (L3 → L3)
    %% ─────────────────────────────────────────────
    SESSION_TYPE -->|"_apply_session_type_visibility()"| SERVER_INIT
    TOOLS_KITCHEN -->|"_build_tool_category_listing()"| SERVER_INIT
    LIFESPAN -->|"_autoskillit_lifespan"| SERVER_INIT
    TOOLS_KITCHEN -->|"_write_hook_config()"| LIFESPAN

    %% ─────────────────────────────────────────────
    %% TEST → SOURCE DEPENDENCIES
    %% ─────────────────────────────────────────────
    T_FEATURE_FLAGS -->|"tests"| FEATURE_FLAGS
    T_FEATURE_FLAGS -.->|"also tests"| TYPE_CONSTANTS
    T_TYPE_CONSTANTS -->|"tests"| TYPE_CONSTANTS
    T_IMPORT_ISO -->|"subprocess isolation check"| SERVER_INIT
    T_SERVER_INIT -->|"tests"| SERVER_INIT
    T_TOOLS_KITCHEN -->|"tests"| TOOLS_KITCHEN
    T_FLEET -.->|"rename contract"| TYPE_CONSTANTS
    T_SCHEMA -.->|"AST ratchet"| TOOLS_KITCHEN

    %% CLASS ASSIGNMENTS %%
    class TYPE_ENUMS stateNode;
    class TYPE_CONSTANTS stateNode;
    class FEATURE_FLAGS handler;
    class CORE_INIT phase;
    class SERVER_INIT cli;
    class LIFESPAN handler;
    class SESSION_TYPE handler;
    class TOOLS_KITCHEN handler;
    class T_FEATURE_FLAGS newComponent;
    class T_TYPE_CONSTANTS,T_IMPORT_ISO,T_SERVER_INIT,T_TOOLS_KITCHEN,T_FLEET,T_SCHEMA output;
```

Closes #1141

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260426-002023-261028/.autoskillit/temp/make-plan/self_registering_gate_plan_2026-04-26_000100.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 137 | 13.8k | 640.3k | 53.7k | 1 | 5m 35s |
| verify | 124 | 14.1k | 813.0k | 66.9k | 1 | 4m 3s |
| implement | 504 | 31.3k | 4.4M | 93.3k | 1 | 11m 19s |
| fix | 126 | 4.2k | 579.8k | 43.4k | 1 | 5m 54s |
| prepare_pr | 76 | 7.0k | 287.3k | 34.1k | 1 | 1m 53s |
| run_arch_lenses | 1.5k | 7.5k | 158.2k | 69.5k | 1 | 2m 46s |
| compose_pr | 51 | 4.1k | 154.4k | 22.4k | 1 | 1m 15s |
| **Total** | 2.5k | 82.0k | 7.0M | 383.3k | | 32m 47s |