### PR TITLE
Implementation Plan: Fleet Prompt Accuracy & MCP Readiness

### DIFF
--- a/src/autoskillit/cli/_prompts.py
+++ b/src/autoskillit/cli/_prompts.py
@@ -89,7 +89,7 @@ parallel dispatch — fleet_lock enforces serial execution and concurrent calls 
 Each dispatch is an independent L2 session with its own kitchen context. There is NO
 cross-dispatch state sharing and NO cross-dispatch token aggregation.
 
-Only these 6 tools are available in this session:
+After startup, only these 6 tools should be used for all campaign operations:
 - {mcp_prefix}dispatch_food_truck
 - {mcp_prefix}batch_cleanup_clones
 - {mcp_prefix}get_pipeline_report
@@ -288,23 +288,24 @@ def _build_orchestrator_prompt(
 You are a pipeline orchestrator. Execute the recipe '{recipe_name}' step-by-step.
 
 {_ing_section}FIRST ACTION — before prompting for any inputs:
-0. Call Bash(command="sleep 2") — this ensures MCP plugin tools are fully registered
-   before proceeding. Bash is a built-in tool, always available. DO NOT SKIP THIS STEP.
-1. Call ToolSearch(query='select:{mcp_prefix}open_kitchen') to ensure its schema is loaded.
-   ToolSearch is a no-op if the schema is already loaded, but required if the tool appears
-   in Claude Code's deferred-tool list. Always call it — no conditional check needed.
-2. Call {mcp_prefix}open_kitchen(name='{recipe_name}') to activate pipeline tools and open
+0. Call ToolSearch(query='select:{mcp_prefix}open_kitchen') to load its schema:
+   - If the schema IS returned: proceed to step 1 immediately.
+   - If the schema is NOT returned (tool not yet registered): call Bash(command="sleep 2"),
+     then retry ToolSearch(query='select:{mcp_prefix}open_kitchen') once.
+   - If still not returned after the retry: output
+     "MCP server not ready — open_kitchen schema unavailable after retry" and end the session.
+1. Call {mcp_prefix}open_kitchen(name='{recipe_name}') to activate pipeline tools and open
    the kitchen gate. open_kitchen is REQUIRED to enable all gated AutoSkillit tools —
    the ingredients table above (when present) is provided for reference only.
    DO NOT call AskUserQuestion or any other tool before open_kitchen.
-3. The response contains a pre-formatted ingredients table
+2. The response contains a pre-formatted ingredients table
    between --- INGREDIENTS TABLE --- and --- END TABLE --- markers.
    Display it verbatim in your response — do not reformat or re-render it.
    Then ask for the required fields (marked with *). If the recipe has both
    a task and an issue_url ingredient, mention that a GitHub issue URL can
    be provided as the task. Keep it to one or two short sentences.
-4. Collect ingredient values conversationally from the user's response.
-5. Execute the pipeline steps.
+3. Collect ingredient values conversationally from the user's response.
+4. Execute the pipeline steps.
 
 During pipeline execution, only use AutoSkillit MCP tools:
 - Read, Grep, Glob (code investigation) — not used here because investigation
@@ -443,9 +444,11 @@ def _build_open_kitchen_prompt(mcp_prefix: str) -> str:
 
     _forbidden_list = ", ".join(PIPELINE_FORBIDDEN_TOOLS)
     text = (
-        f'Call Bash(command="sleep 2") first — this ensures MCP plugin tools are fully '
-        f"registered before proceeding. Bash is a built-in tool, always available.\n"
-        f"Then call ToolSearch(query='select:{mcp_prefix}open_kitchen') to load the schema.\n"
+        f"Call ToolSearch(query='select:{mcp_prefix}open_kitchen') to check MCP readiness:\n"
+        f"- If the schema IS returned: proceed to call {mcp_prefix}open_kitchen immediately.\n"
+        f'- If NOT returned: call Bash(command="sleep 2"), then retry ToolSearch once.\n'
+        f"- If still not returned: output "
+        f'"MCP server not ready — open_kitchen unavailable after retry" and end the session.\n'
         f"Then call {mcp_prefix}open_kitchen to open the AutoSkillit kitchen.\n\n"
         "IMPORTANT — Orchestrator Discipline:\n"
         f"NEVER use native Claude Code tools ({_forbidden_list}) "

--- a/tests/cli/test_cli_prompts.py
+++ b/tests/cli/test_cli_prompts.py
@@ -710,8 +710,11 @@ def test_open_kitchen_prompt_toolsearch_has_retry_on_miss():
 
     prompt = _build_open_kitchen_prompt(mcp_prefix=DIRECT_PREFIX)
     ts_idx = prompt.index("ToolSearch")
-    ok_idx = prompt.index("open_kitchen", ts_idx + 1)
-    startup_section = prompt[ts_idx:ok_idx]
+    # "Then call" marks the end of the conditional block and the start of the actual call.
+    # We cannot use prompt.index("open_kitchen", ts_idx + 1) here because open_kitchen
+    # also appears inside the ToolSearch query string, giving a section that's too short.
+    then_idx = prompt.index("Then call", ts_idx)
+    startup_section = prompt[ts_idx:then_idx]
     lower = startup_section.lower()
     assert "sleep" in lower, "Open-kitchen startup must mention sleep as fallback"
     assert "retry" in lower or "again" in lower, (

--- a/tests/cli/test_cli_prompts.py
+++ b/tests/cli/test_cli_prompts.py
@@ -453,7 +453,7 @@ def test_orchestrator_prompt_has_no_deferred_tool_recovery_conditional():
 
 
 def test_first_action_step0_calls_toolsearch_unconditionally():
-    """Step 0 is Bash sleep; ToolSearch is still present in FIRST ACTION (step 1)."""
+    """Step 0 is ToolSearch; Bash appears as conditional fallback in step 0."""
     from autoskillit.cli._mcp_names import DIRECT_PREFIX
     from autoskillit.cli._prompts import _build_orchestrator_prompt
 
@@ -463,11 +463,10 @@ def test_first_action_step0_calls_toolsearch_unconditionally():
     end = prompt.index("During pipeline execution", start)
     first_action = prompt[start:end]
 
-    # Step 0 is now Bash sleep, not ToolSearch
+    # Step 0 is now ToolSearch, not Bash sleep
     step0_end = first_action.index("\n1.")
     step0_text = first_action[:step0_end]
-    assert "Bash" in step0_text, "Step 0 must be a Bash sleep gate"
-    assert "sleep" in step0_text.lower(), "Step 0 must contain a sleep command"
+    assert "ToolSearch" in step0_text, "Step 0 must be a ToolSearch readiness check"
 
     # ToolSearch is still present in the FIRST ACTION section
     assert "ToolSearch" in first_action
@@ -490,12 +489,12 @@ def test_first_action_toolsearch_index_precedes_open_kitchen():
 
 
 def test_open_kitchen_prompt_has_bash_sleep_and_toolsearch():
-    """_build_open_kitchen_prompt must have Bash sleep and ToolSearch (no conditionals)."""
+    """_build_open_kitchen_prompt must have Bash sleep and ToolSearch (Bash as fallback)."""
     from autoskillit.cli._mcp_names import DIRECT_PREFIX
     from autoskillit.cli._prompts import _build_open_kitchen_prompt
 
     prompt = _build_open_kitchen_prompt(mcp_prefix=DIRECT_PREFIX)
-    assert "Bash" in prompt, "Open kitchen prompt must include Bash sleep gate"
+    assert "Bash" in prompt, "Open kitchen prompt must include Bash sleep as conditional fallback"
     assert "sleep" in prompt.lower()
     assert "ToolSearch" in prompt
     lower = prompt.lower()
@@ -592,7 +591,7 @@ def test_orchestrator_prompt_contains_skill_command_format_guidance():
 
 
 def test_first_action_step0_is_bash_sleep():
-    """Step 0 of FIRST ACTION must be a Bash sleep gate, not ToolSearch."""
+    """Step 0 of FIRST ACTION must be a ToolSearch readiness check, not a bare Bash sleep."""
     from autoskillit.cli._mcp_names import DIRECT_PREFIX
     from autoskillit.cli._prompts import _build_orchestrator_prompt
 
@@ -603,12 +602,12 @@ def test_first_action_step0_is_bash_sleep():
 
     step0_end = first_action.index("\n1.")
     step0_text = first_action[:step0_end]
-    assert "Bash" in step0_text, "Step 0 must be a Bash sleep gate"
-    assert "sleep" in step0_text.lower(), "Step 0 must contain a sleep command"
+    assert "ToolSearch" in step0_text, "Step 0 must call ToolSearch for open_kitchen schema"
+    assert "open_kitchen" in step0_text, "Step 0 ToolSearch must target open_kitchen"
 
 
 def test_first_action_bash_sleep_precedes_toolsearch():
-    """Bash sleep gate must appear before ToolSearch in FIRST ACTION."""
+    """ToolSearch must appear before Bash (conditional fallback) in FIRST ACTION."""
     from autoskillit.cli._mcp_names import DIRECT_PREFIX
     from autoskillit.cli._prompts import _build_orchestrator_prompt
 
@@ -619,11 +618,26 @@ def test_first_action_bash_sleep_precedes_toolsearch():
 
     bash_idx = first_action.index("Bash")
     ts_idx = first_action.index("ToolSearch")
-    assert bash_idx < ts_idx, "Bash sleep must appear before ToolSearch"
+    assert ts_idx < bash_idx, (
+        "ToolSearch must appear before Bash (which is a conditional fallback)"
+    )
 
 
-def test_first_action_bash_sleep_is_unconditional():
-    """Step 0 Bash sleep must not be gated by any conditional."""
+def test_open_kitchen_prompt_has_bash_sleep_before_toolsearch():
+    """_build_open_kitchen_prompt must have ToolSearch before Bash (conditional fallback)."""
+    from autoskillit.cli._mcp_names import DIRECT_PREFIX
+    from autoskillit.cli._prompts import _build_open_kitchen_prompt
+
+    prompt = _build_open_kitchen_prompt(mcp_prefix=DIRECT_PREFIX)
+    assert "Bash" in prompt, "Open kitchen prompt must include Bash sleep as conditional fallback"
+    assert "sleep" in prompt.lower()
+    bash_idx = prompt.lower().index("bash")
+    ts_idx = prompt.index("ToolSearch")
+    assert ts_idx < bash_idx, "ToolSearch must precede Bash (which is a conditional fallback)"
+
+
+def test_first_action_step0_is_toolsearch_not_bash():
+    """Step 0 of FIRST ACTION must be ToolSearch, not a Bash sleep gate."""
     from autoskillit.cli._mcp_names import DIRECT_PREFIX
     from autoskillit.cli._prompts import _build_orchestrator_prompt
 
@@ -633,20 +647,130 @@ def test_first_action_bash_sleep_is_unconditional():
     first_action = prompt[start:end]
 
     step0_end = first_action.index("\n1.")
-    step0_text = first_action[:step0_end].lower()
-    assert "if " not in step0_text, "Step 0 Bash sleep must be unconditional"
-    assert "only if" not in step0_text
-    assert "when the" not in step0_text
+    step0_text = first_action[:step0_end]
+    assert "ToolSearch" in step0_text, "Step 0 must call ToolSearch for open_kitchen schema"
+    assert "open_kitchen" in step0_text, "Step 0 ToolSearch must target open_kitchen"
+    assert not step0_text.lstrip().startswith("Call Bash"), (
+        "Step 0 must not open with a Bash sleep — use ToolSearch-based readiness check"
+    )
 
 
-def test_open_kitchen_prompt_has_bash_sleep_before_toolsearch():
-    """_build_open_kitchen_prompt must have Bash sleep before ToolSearch."""
+def test_first_action_step0_toolsearch_has_sleep_retry_fallback():
+    """When ToolSearch misses, step 0 must instruct: sleep 2, retry once."""
+    from autoskillit.cli._mcp_names import DIRECT_PREFIX
+    from autoskillit.cli._prompts import _build_orchestrator_prompt
+
+    prompt = _build_orchestrator_prompt("my_recipe", mcp_prefix=DIRECT_PREFIX)
+    start = prompt.index("FIRST ACTION")
+    step0_end = prompt.index("\n1.", start)
+    step0 = prompt[start:step0_end]
+
+    assert "sleep" in step0.lower(), "Step 0 must mention sleep as fallback on schema miss"
+    assert "retry" in step0.lower() or "again" in step0.lower(), (
+        "Step 0 must describe retrying ToolSearch after sleep"
+    )
+
+
+def test_first_action_step0_toolsearch_permanent_failure_reports_error():
+    """If ToolSearch still fails after retry, step 0 must instruct the LLM to report error."""
+    from autoskillit.cli._mcp_names import DIRECT_PREFIX
+    from autoskillit.cli._prompts import _build_orchestrator_prompt
+
+    prompt = _build_orchestrator_prompt("my_recipe", mcp_prefix=DIRECT_PREFIX)
+    start = prompt.index("FIRST ACTION")
+    step0_end = prompt.index("\n1.", start)
+    step0 = prompt[start:step0_end]
+
+    lower = step0.lower()
+    assert "error" in lower or "not ready" in lower or "unavailable" in lower, (
+        "Step 0 must instruct the LLM to report an error if ToolSearch fails after retry"
+    )
+    assert "end" in lower or "stop" in lower or "unavailable" in lower, (
+        "Step 0 must end the session on permanent ToolSearch failure, not proceed silently"
+    )
+
+
+def test_open_kitchen_prompt_step0_is_toolsearch_not_bash():
+    """_build_open_kitchen_prompt step 0 must be ToolSearch, not Bash sleep."""
     from autoskillit.cli._mcp_names import DIRECT_PREFIX
     from autoskillit.cli._prompts import _build_open_kitchen_prompt
 
     prompt = _build_open_kitchen_prompt(mcp_prefix=DIRECT_PREFIX)
-    assert "Bash" in prompt, "Open kitchen prompt must include Bash sleep gate"
-    assert "sleep" in prompt.lower()
-    bash_idx = prompt.index("Bash")
     ts_idx = prompt.index("ToolSearch")
-    assert bash_idx < ts_idx, "Bash sleep must precede ToolSearch"
+    ok_idx = prompt.index("open_kitchen")
+    assert ts_idx < ok_idx, "ToolSearch must precede open_kitchen in open-kitchen prompt"
+    bash_idx = prompt.lower().index("bash")
+    assert ts_idx < bash_idx, "Bash sleep must come after ToolSearch as a conditional fallback"
+
+
+def test_open_kitchen_prompt_toolsearch_has_retry_on_miss():
+    """_build_open_kitchen_prompt must describe sleep-and-retry if ToolSearch misses."""
+    from autoskillit.cli._mcp_names import DIRECT_PREFIX
+    from autoskillit.cli._prompts import _build_open_kitchen_prompt
+
+    prompt = _build_open_kitchen_prompt(mcp_prefix=DIRECT_PREFIX)
+    ts_idx = prompt.index("ToolSearch")
+    ok_idx = prompt.index("open_kitchen", ts_idx + 1)
+    startup_section = prompt[ts_idx:ok_idx]
+    lower = startup_section.lower()
+    assert "sleep" in lower, "Open-kitchen startup must mention sleep as fallback"
+    assert "retry" in lower or "again" in lower, (
+        "Open-kitchen startup must describe retrying ToolSearch after sleep"
+    )
+
+
+def test_campaign_prompt_tool_claim_has_after_startup_qualifier():
+    """Fleet campaign prompt must qualify the 6-tool claim as applying after startup only."""
+    from unittest.mock import MagicMock
+
+    from autoskillit.cli._prompts import _build_fleet_campaign_prompt
+
+    recipe = MagicMock()
+    recipe.name = "test-campaign"
+    recipe.description = "Test"
+    recipe.dispatches = [MagicMock()]
+    recipe.continue_on_failure = False
+
+    prompt = _build_fleet_campaign_prompt(
+        campaign_recipe=recipe,
+        manifest_yaml="dispatches: []",
+        completed_dispatches="",
+        mcp_prefix="mcp__autoskillit__",
+        campaign_id="abc-123",
+    )
+
+    assert "Only these 6 tools are available in this session" not in prompt, (
+        "The absolute 'only 6 tools available' claim is factually false during startup "
+        "— must be qualified as 'after startup' or 'for campaign operations'"
+    )
+    lower = prompt.lower()
+    assert "after startup" in lower or "startup" in lower or "operational" in lower, (
+        "Campaign prompt must qualify the tool list as post-startup / operational tools"
+    )
+
+
+def test_campaign_prompt_tool_list_still_enumerates_six_tools():
+    """The 6 operational tools must still be listed in the campaign prompt after the fix."""
+    from unittest.mock import MagicMock
+
+    from autoskillit.cli._prompts import _build_fleet_campaign_prompt
+
+    recipe = MagicMock()
+    recipe.name = "test-campaign"
+    recipe.description = "Test"
+    recipe.dispatches = [MagicMock()]
+    recipe.continue_on_failure = False
+
+    prompt = _build_fleet_campaign_prompt(
+        campaign_recipe=recipe,
+        manifest_yaml="dispatches: []",
+        completed_dispatches="",
+        mcp_prefix="mcp__autoskillit__",
+        campaign_id="abc-123",
+    )
+    assert "dispatch_food_truck" in prompt
+    assert "batch_cleanup_clones" in prompt
+    assert "get_pipeline_report" in prompt
+    assert "get_token_summary" in prompt
+    assert "get_timing_summary" in prompt
+    assert "get_quota_events" in prompt

--- a/tests/cli/test_cli_prompts.py
+++ b/tests/cli/test_cli_prompts.py
@@ -590,7 +590,7 @@ def test_orchestrator_prompt_contains_skill_command_format_guidance():
     )
 
 
-def test_first_action_step0_is_bash_sleep():
+def test_first_action_step0_is_toolsearch():
     """Step 0 of FIRST ACTION must be a ToolSearch readiness check, not a bare Bash sleep."""
     from autoskillit.cli._mcp_names import DIRECT_PREFIX
     from autoskillit.cli._prompts import _build_orchestrator_prompt
@@ -606,7 +606,7 @@ def test_first_action_step0_is_bash_sleep():
     assert "open_kitchen" in step0_text, "Step 0 ToolSearch must target open_kitchen"
 
 
-def test_first_action_bash_sleep_precedes_toolsearch():
+def test_first_action_toolsearch_precedes_bash_sleep():
     """ToolSearch must appear before Bash (conditional fallback) in FIRST ACTION."""
     from autoskillit.cli._mcp_names import DIRECT_PREFIX
     from autoskillit.cli._prompts import _build_orchestrator_prompt
@@ -623,7 +623,7 @@ def test_first_action_bash_sleep_precedes_toolsearch():
     )
 
 
-def test_open_kitchen_prompt_has_bash_sleep_before_toolsearch():
+def test_open_kitchen_prompt_has_toolsearch_before_bash_sleep():
     """_build_open_kitchen_prompt must have ToolSearch before Bash (conditional fallback)."""
     from autoskillit.cli._mcp_names import DIRECT_PREFIX
     from autoskillit.cli._prompts import _build_open_kitchen_prompt

--- a/tests/cli/test_orchestrator_prompt_contract.py
+++ b/tests/cli/test_orchestrator_prompt_contract.py
@@ -93,26 +93,25 @@ class TestFirstActionAskUserQuestionProhibition:
 
 
 class TestFirstActionTimingResilience:
-    """FIRST ACTION step 0 must be a Bash sleep gate before ToolSearch and open_kitchen."""
+    """FIRST ACTION step 0 must be a ToolSearch readiness check before open_kitchen."""
 
-    def test_first_action_step0_is_bash_sleep_gate(self):
-        """Step 0 in FIRST ACTION must be a Bash sleep gate — not a direct open_kitchen
-        or ToolSearch call. The sleep ensures MCP plugin tools are registered."""
+    def test_first_action_step0_is_toolsearch_gate(self):
+        """Step 0 in FIRST ACTION must be a ToolSearch readiness check — not a bare Bash sleep."""
         prompt = _get_prompt()
         first_action_start = prompt.index("FIRST ACTION")
         first_action_end = prompt.index("During pipeline execution", first_action_start)
         first_action_section = prompt[first_action_start:first_action_end]
 
-        # Step 0 must be Bash sleep
+        # Step 0 must be ToolSearch
         step0_end = first_action_section.index("\n1.")
         step0 = first_action_section[:step0_end]
-        assert "Bash" in step0, "Step 0 must be a Bash sleep gate"
-        assert "sleep" in step0.lower(), "Step 0 must contain a sleep command"
+        assert "ToolSearch" in step0, "Step 0 must be a ToolSearch readiness check"
+        assert "open_kitchen" in step0, "Step 0 ToolSearch must target open_kitchen"
 
-        # Step 0 must not be conditional
-        step0_lower = step0.lower()
-        assert "if the session" not in step0_lower
-        assert "if deferred" not in step0_lower
+        # Step 0 must not open with a Bash call
+        assert not step0.lstrip().startswith("Bash"), (
+            "Step 0 must not begin with Bash — ToolSearch is the first instruction"
+        )
 
-        # ToolSearch must still appear in FIRST ACTION (as step 1)
+        # ToolSearch must still appear in FIRST ACTION
         assert "ToolSearch" in first_action_section


### PR DESCRIPTION
## Summary

Two prompt-string fixes in `src/autoskillit/cli/_prompts.py`:

1. **MCP readiness loop** (`_build_orchestrator_prompt`, `_build_open_kitchen_prompt`): Replace the blind `Bash(command="sleep 2")` heuristic in step 0 of `FIRST ACTION` with an event-driven ToolSearch-based readiness check — try ToolSearch, sleep-and-retry once on miss, error on second miss. This eliminates the race condition where MCP registration takes >2 s.

2. **Tool-count wording** (`_build_fleet_campaign_prompt`): The "Only these 6 tools are available in this session" claim is factually false during startup (Bash and ToolSearch are also available). Amend to "After startup, only these 6 tools should be used for all campaign operations:" to remove the contradiction.

No new modules, no new functions, no new abstractions. Both changes are targeted prompt-string edits plus corresponding test updates.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 52, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START<br/>autoskillit cook])
    COMPLETE([COMPLETE<br/>pipeline done])
    MCP_ERROR([ERROR<br/>MCP not ready after retry])
    KITCHEN_ERROR([ERROR<br/>open_kitchen failed])

    subgraph PromptBuilderPhase ["Prompt Builder Dispatch (host process)"]
        direction TB
        SessionTypeQ{"Session type?"}
        BuildOrch["● _build_orchestrator_prompt<br/>━━━━━━━━━━<br/>recipe_name + mcp_prefix<br/>+ ingredients_table"]
        BuildOpenKitchen["● _build_open_kitchen_prompt<br/>━━━━━━━━━━<br/>mcp_prefix only<br/>no recipe"]
        BuildFleetCampaign["_build_fleet_campaign_prompt<br/>━━━━━━━━━━<br/>campaign_recipe + manifest_yaml<br/>no ToolSearch check"]
        BuildFleetDispatch["_build_fleet_dispatch_prompt<br/>━━━━━━━━━━<br/>10-tool surface<br/>no ToolSearch check"]
    end

    subgraph SessionLaunchPhase ["Session Launch (host process)"]
        direction TB
        LaunchSession["_launch_cook_session<br/>━━━━━━━━━━<br/>--append-system-prompt<br/>reload loop max 10"]
    end

    subgraph MCPReadinessPhase ["● MCP Readiness Check (inside Claude session — injected prompt)"]
        direction TB
        ToolSearchStep0["● ToolSearch<br/>━━━━━━━━━━<br/>select:{mcp_prefix}open_kitchen<br/>STEP 0 — first action"]
        SchemaQ{"● Schema<br/>returned?"}
        ConditionalSleep["● Bash(sleep 2)<br/>━━━━━━━━━━<br/>only on miss<br/>not unconditional"]
        ToolSearchRetry["● ToolSearch retry<br/>━━━━━━━━━━<br/>select:{mcp_prefix}open_kitchen<br/>max 1 retry"]
        SchemaQ2{"● Schema<br/>returned<br/>after retry?"}
    end

    subgraph KitchenPhase ["Kitchen Open Phase (inside Claude session)"]
        direction TB
        CallOpenKitchen["open_kitchen(name=recipe_name)<br/>━━━━━━━━━━<br/>activates all gated tools<br/>returns ingredients table"]
        OpenKitchenPredicateQ{"Failure<br/>predicate?<br/>success=false OR<br/>missing table marker"}
        DisplayTable["Display ingredients table<br/>━━━━━━━━━━<br/>verbatim between markers<br/>ask for required fields (*)"]
        CollectIngredients["Collect ingredient values<br/>━━━━━━━━━━<br/>conversationally<br/>from user response"]
    end

    subgraph PipelinePhase ["Pipeline Execution Phase (inside Claude session)"]
        direction TB
        ExecuteStep["Execute pipeline step<br/>━━━━━━━━━━<br/>route per step action<br/>run_skill / run_cmd / confirm"]
        StepResultQ{"Step result?<br/>failure predicates<br/>+ needs_retry routing"}
        RouteNext["Route to next step<br/>━━━━━━━━━━<br/>on_success / on_failure<br/>on_context_limit"]
    end

    %% FLOW %%
    START --> SessionTypeQ

    SessionTypeQ -->|"recipe cook"| BuildOrch
    SessionTypeQ -->|"open kitchen<br/>no recipe"| BuildOpenKitchen
    SessionTypeQ -->|"fleet campaign<br/>L3 dispatcher"| BuildFleetCampaign
    SessionTypeQ -->|"fleet dispatch<br/>ad-hoc"| BuildFleetDispatch

    BuildOrch --> LaunchSession
    BuildOpenKitchen --> LaunchSession
    BuildFleetCampaign --> LaunchSession
    BuildFleetDispatch --> LaunchSession

    LaunchSession -->|"session starts<br/>prompt injected"| ToolSearchStep0

    ToolSearchStep0 --> SchemaQ

    SchemaQ -->|"YES — fast path<br/>0 sleeps"| CallOpenKitchen
    SchemaQ -->|"NO — MCP not ready yet"| ConditionalSleep

    ConditionalSleep -->|"sleep 2s"| ToolSearchRetry
    ToolSearchRetry --> SchemaQ2

    SchemaQ2 -->|"YES — retry succeeded"| CallOpenKitchen
    SchemaQ2 -->|"NO — still unavailable"| MCP_ERROR

    CallOpenKitchen --> OpenKitchenPredicateQ

    OpenKitchenPredicateQ -->|"success=false OR<br/>no table marker"| KITCHEN_ERROR
    OpenKitchenPredicateQ -->|"success=true AND<br/>table marker present"| DisplayTable

    DisplayTable --> CollectIngredients
    CollectIngredients --> ExecuteStep

    ExecuteStep --> StepResultQ
    StepResultQ -->|"success or<br/>skip_when_false=false"| RouteNext
    StepResultQ -->|"failure"| RouteNext
    RouteNext -->|"more steps"| ExecuteStep
    RouteNext -->|"pipeline done"| COMPLETE

    %% CLASS ASSIGNMENTS %%
    class START,COMPLETE,MCP_ERROR,KITCHEN_ERROR terminal;
    class SessionTypeQ,SchemaQ,SchemaQ2,OpenKitchenPredicateQ,StepResultQ stateNode;
    class BuildOrch,BuildOpenKitchen handler;
    class BuildFleetCampaign,BuildFleetDispatch handler;
    class LaunchSession phase;
    class ToolSearchStep0,ConditionalSleep,ToolSearchRetry detector;
    class CallOpenKitchen,DisplayTable,CollectIngredients,ExecuteStep,RouteNext handler;
```

Closes #1231

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260426-002023-874027/.autoskillit/temp/make-plan/fleet_prompt_accuracy_mcp_readiness_plan_2026-04-26_002023.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 115 | 15.9k | 520.5k | 67.0k | 1 | 4m 41s |
| verify | 672 | 4.6k | 130.8k | 28.6k | 1 | 2m 17s |
| implement | 230 | 15.6k | 1.3M | 51.7k | 1 | 5m 36s |
| fix | 176 | 7.2k | 924.8k | 48.5k | 1 | 3m 39s |
| prepare_pr | 52 | 4.2k | 163.0k | 25.6k | 1 | 1m 20s |
| run_arch_lenses | 69 | 6.3k | 272.4k | 43.2k | 1 | 3m 51s |
| compose_pr | 67 | 4.6k | 216.5k | 22.2k | 1 | 1m 38s |
| **Total** | 1.4k | 58.5k | 3.5M | 286.7k | | 23m 5s |