### PR TITLE
Implementation Plan: Fleet T9 — Campaign Data Flow (capture: on CampaignDispatch)

### DIFF
--- a/src/autoskillit/cli/_prompts.py
+++ b/src/autoskillit/cli/_prompts.py
@@ -87,7 +87,8 @@ Execute dispatches SEQUENTIALLY via {mcp_prefix}dispatch_food_truck. Do NOT atte
 parallel dispatch — fleet_lock enforces serial execution and concurrent calls will fail.
 
 Each dispatch is an independent L2 session with its own kitchen context. There is NO
-cross-dispatch state sharing and NO cross-dispatch token aggregation.
+cross-dispatch state sharing managed by you — the runtime handles it
+via capture:. There is NO cross-dispatch token aggregation.
 
 After startup, only these 6 tools should be used for all campaign operations:
 - {mcp_prefix}dispatch_food_truck
@@ -99,6 +100,28 @@ After startup, only these 6 tools should be used for all campaign operations:
 
 Explicitly FORBIDDEN: open_kitchen, close_kitchen, run_skill, and all GitHub/CI tools.
 Use ONLY {mcp_prefix}dispatch_food_truck to dispatch — never run_skill.
+
+## CAPTURE & DATA FLOW
+
+Some dispatches declare a `capture:` block and some use `${{{{ campaign.* }}}}` references
+in their `ingredients:`. The runtime handles all value extraction and interpolation
+automatically — you do not need to parse, store, or forward captured values yourself.
+
+Your only responsibility: pass the `capture` dict from the manifest YAML directly to
+`{mcp_prefix}dispatch_food_truck` on every call:
+
+```python
+dispatch_food_truck(
+    recipe="...",
+    task="...",
+    ingredients={{...}},       # may contain ${{{{ campaign.* }}}} — resolved by runtime
+    capture={{...}},            # copied verbatim from the dispatch manifest
+)
+```
+
+If a dispatch has no `capture:` field, pass `capture={{}}` or omit the parameter.
+The `${{{{ campaign.* }}}}` references in ingredients are resolved before the L2 session
+is started — the L2 agent always receives concrete values.
 
 ## FAILURE RECOVERY
 

--- a/src/autoskillit/fleet/__init__.py
+++ b/src/autoskillit/fleet/__init__.py
@@ -17,8 +17,10 @@ from .state import (
     build_protected_campaign_ids,
     mark_dispatch_interrupted,
     mark_dispatch_running,
+    read_all_campaign_captures,
     read_state,
     resume_campaign_from_state,
+    write_captured_values,
     write_initial_state,
 )
 from .summary import (
@@ -60,7 +62,9 @@ __all__ = [
     "build_protected_campaign_ids",
     "mark_dispatch_interrupted",
     "mark_dispatch_running",
+    "read_all_campaign_captures",
     "read_state",
     "resume_campaign_from_state",
+    "write_captured_values",
     "write_initial_state",
 ]

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -19,13 +19,13 @@ from autoskillit.core import (
     get_logger,
 )
 from autoskillit.fleet.result_parser import parse_l2_result_block
-from autoskillit.recipe import CAMPAIGN_REF_RE
 
 if TYPE_CHECKING:
     from autoskillit.pipeline.context import ToolContext
 
 logger = get_logger(__name__)
 
+_CAMPAIGN_REF_RE = re.compile(r"\$\{\{\s*campaign\.(\w+)\s*\}\}")
 _RESULT_REF_RE = re.compile(r"^\$\{\{\s*result\.([\w-]+)\s*\}\}$")
 
 
@@ -71,7 +71,7 @@ def _interpolate_campaign_refs(
                 )
             return captured[ref]
 
-        out[k] = CAMPAIGN_REF_RE.sub(_replace, v)
+        out[k] = _CAMPAIGN_REF_RE.sub(_replace, v)
     return out
 
 
@@ -257,7 +257,7 @@ async def _run_dispatch(
     dispatches_dir = tool_ctx.temp_dir / "dispatches"
     accumulated_captures = read_all_campaign_captures(dispatches_dir, tool_ctx.kitchen_id)
 
-    _has_campaign_refs = any(CAMPAIGN_REF_RE.search(v) for v in effective_ingredients.values())
+    _has_campaign_refs = any(_CAMPAIGN_REF_RE.search(v) for v in effective_ingredients.values())
     if _has_campaign_refs:
         try:
             effective_ingredients = _interpolate_campaign_refs(

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -258,7 +258,7 @@ async def _run_dispatch(
     accumulated_captures = read_all_campaign_captures(dispatches_dir, tool_ctx.kitchen_id)
 
     _has_campaign_refs = any(_CAMPAIGN_REF_RE.search(v) for v in effective_ingredients.values())
-    if _has_campaign_refs or accumulated_captures:
+    if _has_campaign_refs:
         try:
             effective_ingredients = _interpolate_campaign_refs(
                 effective_ingredients, accumulated_captures

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 import time
 from collections.abc import Callable
 from pathlib import Path
@@ -23,6 +24,55 @@ if TYPE_CHECKING:
     from autoskillit.pipeline.context import ToolContext
 
 logger = get_logger(__name__)
+
+_CAMPAIGN_REF_RE = re.compile(r"\$\{\{\s*campaign\.(\w+)\s*\}\}")
+_RESULT_REF_RE = re.compile(r"^\$\{\{\s*result\.([\w-]+)\s*\}\}$")
+
+
+def _extract_captures(
+    capture_spec: dict[str, str],
+    payload: dict[str, object],
+) -> dict[str, str]:
+    """Extract captured values from an L2 result payload.
+
+    For each entry in `capture_spec` whose value matches ``${{ result.field }}``,
+    reads `payload[field]` and converts it to str. Missing payload keys are skipped.
+    """
+    result: dict[str, str] = {}
+    for key, template in capture_spec.items():
+        m = _RESULT_REF_RE.match(template.strip())
+        if m is None:
+            continue
+        field_name = m.group(1)
+        if field_name in payload:
+            result[key] = str(payload[field_name])
+    return result
+
+
+def _interpolate_campaign_refs(
+    ingredients: dict[str, str],
+    captured: dict[str, str],
+) -> dict[str, str]:
+    """Resolve ``${{ campaign.key }}`` references in ingredient values.
+
+    Raises ValueError if a campaign reference cannot be resolved.
+    Non-campaign values are returned unchanged.
+    """
+    out: dict[str, str] = {}
+    for k, v in ingredients.items():
+
+        def _replace(m: re.Match, _k: str = k) -> str:
+            ref = m.group(1)
+            if ref not in captured:
+                raise ValueError(
+                    f"Ingredient '{_k}' references ${{{{ campaign.{ref} }}}} "
+                    f"but '{ref}' has not been captured by any prior dispatch. "
+                    f"Available: {sorted(captured)}"
+                )
+            return captured[ref]
+
+        out[k] = _CAMPAIGN_REF_RE.sub(_replace, v)
+    return out
 
 
 def _write_pid(
@@ -88,6 +138,7 @@ async def execute_dispatch(
     quota_checker: Callable[..., Any],
     quota_refresher: Callable[..., Any],
     cache_invalidator: Callable[[str], None] | None = None,
+    capture: dict[str, str] | None = None,
 ) -> str:
     """Execute a single food truck dispatch.
 
@@ -127,6 +178,7 @@ async def execute_dispatch(
             quota_checker=quota_checker,
             quota_refresher=quota_refresher,
             cache_invalidator=cache_invalidator,
+            capture=capture,
         )
     except asyncio.CancelledError:
         raise
@@ -151,6 +203,7 @@ async def _run_dispatch(
     quota_checker: Callable[..., Any],
     quota_refresher: Callable[..., Any],
     cache_invalidator: Callable[[str], None] | None = None,
+    capture: dict[str, str] | None = None,
 ) -> str:
     """Inner dispatch body — called after lock acquisition."""
     from autoskillit.fleet.state import (
@@ -197,6 +250,23 @@ async def _run_dispatch(
                 FleetErrorCode.FLEET_UNKNOWN_INGREDIENT,
                 f"Unknown ingredient keys: {sorted(unknown)}. "
                 f"Valid keys: {sorted(full_recipe.ingredients.keys())}",
+            )
+
+    from autoskillit.fleet.state import read_all_campaign_captures  # noqa: PLC0415
+
+    dispatches_dir = tool_ctx.temp_dir / "dispatches"
+    accumulated_captures = read_all_campaign_captures(dispatches_dir, tool_ctx.kitchen_id)
+
+    _has_campaign_refs = any(_CAMPAIGN_REF_RE.search(v) for v in effective_ingredients.values())
+    if _has_campaign_refs or accumulated_captures:
+        try:
+            effective_ingredients = _interpolate_campaign_refs(
+                effective_ingredients, accumulated_captures
+            )
+        except ValueError as exc:
+            return fleet_error(
+                FleetErrorCode.FLEET_UNKNOWN_INGREDIENT,
+                str(exc),
             )
 
     quota_result = await quota_checker(tool_ctx.config.quota_guard)
@@ -322,6 +392,13 @@ async def _run_dispatch(
             ended_at=ended_at,
         ),
     )
+
+    if final_status == DispatchStatus.SUCCESS and capture and parsed.payload:
+        from autoskillit.fleet.state import write_captured_values  # noqa: PLC0415
+
+        extracted = _extract_captures(capture, parsed.payload)
+        if extracted:
+            write_captured_values(state_path, extracted)
 
     _post_dispatch_cleanup(tool_ctx, skill_result, cache_invalidator, quota_refresher)
 

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -19,13 +19,13 @@ from autoskillit.core import (
     get_logger,
 )
 from autoskillit.fleet.result_parser import parse_l2_result_block
+from autoskillit.recipe.schema import CAMPAIGN_REF_RE
 
 if TYPE_CHECKING:
     from autoskillit.pipeline.context import ToolContext
 
 logger = get_logger(__name__)
 
-_CAMPAIGN_REF_RE = re.compile(r"\$\{\{\s*campaign\.(\w+)\s*\}\}")
 _RESULT_REF_RE = re.compile(r"^\$\{\{\s*result\.([\w-]+)\s*\}\}$")
 
 
@@ -71,7 +71,7 @@ def _interpolate_campaign_refs(
                 )
             return captured[ref]
 
-        out[k] = _CAMPAIGN_REF_RE.sub(_replace, v)
+        out[k] = CAMPAIGN_REF_RE.sub(_replace, v)
     return out
 
 
@@ -257,7 +257,7 @@ async def _run_dispatch(
     dispatches_dir = tool_ctx.temp_dir / "dispatches"
     accumulated_captures = read_all_campaign_captures(dispatches_dir, tool_ctx.kitchen_id)
 
-    _has_campaign_refs = any(_CAMPAIGN_REF_RE.search(v) for v in effective_ingredients.values())
+    _has_campaign_refs = any(CAMPAIGN_REF_RE.search(v) for v in effective_ingredients.values())
     if _has_campaign_refs:
         try:
             effective_ingredients = _interpolate_campaign_refs(

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -19,7 +19,7 @@ from autoskillit.core import (
     get_logger,
 )
 from autoskillit.fleet.result_parser import parse_l2_result_block
-from autoskillit.recipe.schema import CAMPAIGN_REF_RE
+from autoskillit.recipe import CAMPAIGN_REF_RE
 
 if TYPE_CHECKING:
     from autoskillit.pipeline.context import ToolContext

--- a/src/autoskillit/fleet/state.py
+++ b/src/autoskillit/fleet/state.py
@@ -17,7 +17,7 @@ from autoskillit.core import get_logger, write_versioned_json
 
 _log = get_logger(__name__)
 
-_SCHEMA_VERSION = 2
+_SCHEMA_VERSION = 3
 
 
 class DispatchStatus(StrEnum):
@@ -67,6 +67,7 @@ class CampaignState:
     manifest_path: str
     started_at: float
     dispatches: list[DispatchRecord] = field(default_factory=list)
+    captured_values: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -165,6 +166,7 @@ def read_state(state_path: Path) -> CampaignState | None:
             manifest_path=data["manifest_path"],
             started_at=data["started_at"],
             dispatches=dispatches,
+            captured_values=data.get("captured_values", {}),
         )
     except (KeyError, ValueError, TypeError) as exc:
         _log.warning("read_state: schema mismatch or corrupt payload in %s: %s", state_path, exc)
@@ -179,6 +181,7 @@ def _write_state(state_path: Path, state: CampaignState) -> None:
         "manifest_path": state.manifest_path,
         "started_at": state.started_at,
         "dispatches": [d.to_dict() for d in state.dispatches],
+        "captured_values": state.captured_values,
     }
     write_versioned_json(state_path, payload, schema_version=state.schema_version)
 
@@ -302,6 +305,50 @@ def build_protected_campaign_ids(project_dir: Path) -> frozenset[str]:
     except Exception:
         _log.warning("campaign_ids_protection_error", exc_info=True)
         return frozenset(protected)
+
+
+def write_captured_values(state_path: Path, captures: dict[str, str]) -> None:
+    """Atomically merge new captures into an existing state file.
+
+    Merges `captures` into the existing `captured_values` dict (new keys win).
+    No-op if state file is missing or corrupted (logs a warning).
+    """
+    state = read_state(state_path)
+    if state is None:
+        _log.warning("write_captured_values: state not found at %s", state_path)
+        return
+    state.captured_values = {**state.captured_values, **captures}
+    _write_state(state_path, state)
+
+
+def read_all_campaign_captures(
+    dispatches_dir: Path,
+    campaign_id: str,
+) -> dict[str, str]:
+    """Accumulate captured_values from all SUCCESS dispatches for a campaign.
+
+    Scans all *.json files in `dispatches_dir`. For each file matching
+    `campaign_id` where every dispatch record has status SUCCESS, merges
+    its `captured_values` into the result. Later files win on key collision.
+    """
+    result: dict[str, str] = {}
+    if not dispatches_dir.is_dir():
+        return result
+    for path in dispatches_dir.glob("*.json"):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if data.get("campaign_id") != campaign_id:
+                continue
+            caps = data.get("captured_values", {})
+            if not caps:
+                continue
+            dispatches = data.get("dispatches", [])
+            all_success = all(d.get("status") == DispatchStatus.SUCCESS for d in dispatches)
+            if all_success and dispatches:
+                result.update(caps)
+        except (json.JSONDecodeError, OSError):
+            continue
+    return result
 
 
 def resume_campaign_from_state(

--- a/src/autoskillit/fleet/state.py
+++ b/src/autoskillit/fleet/state.py
@@ -346,7 +346,8 @@ def read_all_campaign_captures(
             all_success = all(d.get("status") == DispatchStatus.SUCCESS for d in dispatches)
             if all_success and dispatches:
                 result.update(caps)
-        except (json.JSONDecodeError, OSError):
+        except (json.JSONDecodeError, OSError) as exc:
+            _log.warning("read_all_campaign_captures: skipping %s: %s", path, exc)
             continue
     return result
 

--- a/src/autoskillit/recipe/__init__.py
+++ b/src/autoskillit/recipe/__init__.py
@@ -78,6 +78,7 @@ from autoskillit.recipe.loader import parse_recipe_metadata  # noqa: E402
 from autoskillit.recipe.repository import DefaultRecipeRepository  # noqa: E402
 from autoskillit.recipe.schema import (  # noqa: E402
     AUTOSKILLIT_VERSION_KEY,
+    CAMPAIGN_REF_RE,
     CampaignDispatch,
     DataFlowReport,
     Recipe,
@@ -114,6 +115,7 @@ __all__ = [
     "RecipeIngredient",
     "RecipeStep",
     "AUTOSKILLIT_VERSION_KEY",
+    "CAMPAIGN_REF_RE",
     "StepResultCondition",
     "StepResultRoute",
     "DataFlowReport",

--- a/src/autoskillit/recipe/io.py
+++ b/src/autoskillit/recipe/io.py
@@ -296,6 +296,7 @@ def _parse_recipe(data: dict[str, Any]) -> Recipe:
                     task=d.get("task", ""),
                     ingredients=d.get("ingredients") or {},
                     depends_on=d.get("depends_on") or [],
+                    capture=d.get("capture") or {},
                 )
             )
 

--- a/src/autoskillit/recipe/rules_campaign.py
+++ b/src/autoskillit/recipe/rules_campaign.py
@@ -393,6 +393,115 @@ def _check_campaign_task_non_empty(ctx: ValidationContext) -> list[RuleFinding]:
     return findings
 
 
+_IDENT_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+_RESULT_TEMPLATE_RE = re.compile(r"^\$\{\{\s*result\.[\w-]+\s*\}\}$")
+_CAMPAIGN_REF_RE_RULES = re.compile(r"\$\{\{\s*campaign\.(\w+)\s*\}\}")
+
+
+@semantic_rule(
+    name="dispatch-capture-keys-are-identifiers",
+    description="Capture keys must be valid Python identifiers",
+    severity=Severity.ERROR,
+)
+def _check_dispatch_capture_keys_are_identifiers(ctx: ValidationContext) -> list[RuleFinding]:
+    if ctx.recipe.kind != RecipeKind.CAMPAIGN:
+        return []
+    findings = []
+    for d in ctx.recipe.dispatches:
+        for key in d.capture:
+            if not _IDENT_RE.match(key):
+                findings.append(
+                    RuleFinding(
+                        rule="dispatch-capture-keys-are-identifiers",
+                        severity=Severity.ERROR,
+                        step_name="(top-level)",
+                        message=(
+                            f"Dispatch {d.name!r} capture key {key!r} is not a valid"
+                            " identifier. Use only letters, digits, and underscores"
+                            " (must start with letter or _)."
+                        ),
+                    )
+                )
+    return findings
+
+
+@semantic_rule(
+    name="dispatch-capture-value-references-result",
+    description="Capture values must use ${{ result.field }} syntax",
+    severity=Severity.ERROR,
+)
+def _check_dispatch_capture_value_references_result(ctx: ValidationContext) -> list[RuleFinding]:
+    if ctx.recipe.kind != RecipeKind.CAMPAIGN:
+        return []
+    findings = []
+    for d in ctx.recipe.dispatches:
+        for key, val in d.capture.items():
+            if not _RESULT_TEMPLATE_RE.match(val.strip()):
+                findings.append(
+                    RuleFinding(
+                        rule="dispatch-capture-value-references-result",
+                        severity=Severity.ERROR,
+                        step_name="(top-level)",
+                        message=(
+                            f"Dispatch {d.name!r} capture[{key!r}] value {val!r} must use "
+                            "${{ result.<field_name> }} syntax."
+                        ),
+                    )
+                )
+    return findings
+
+
+def _build_ancestors(name: str, adjacency: dict[str, list[str]]) -> set[str]:
+    """Transitive closure of depends_on for a given dispatch name."""
+    ancestors: set[str] = set()
+    queue = list(adjacency.get(name, []))
+    while queue:
+        dep = queue.pop()
+        if dep not in ancestors:
+            ancestors.add(dep)
+            queue.extend(adjacency.get(dep, []))
+    return ancestors
+
+
+@semantic_rule(
+    name="campaign-ingredient-refs-have-prior-capture",
+    description="${{ campaign.key }} in ingredients must be captured by an ancestor dispatch",
+    severity=Severity.ERROR,
+)
+def _check_campaign_ingredient_refs_have_prior_capture(
+    ctx: ValidationContext,
+) -> list[RuleFinding]:
+    if ctx.recipe.kind != RecipeKind.CAMPAIGN:
+        return []
+    adjacency = {d.name: list(d.depends_on) for d in ctx.recipe.dispatches}
+    dispatch_by_name = {d.name: d for d in ctx.recipe.dispatches}
+    findings = []
+    for d in ctx.recipe.dispatches:
+        ancestors = _build_ancestors(d.name, adjacency)
+        available_captures: set[str] = set()
+        for ancestor_name in ancestors:
+            ancestor = dispatch_by_name.get(ancestor_name)
+            if ancestor:
+                available_captures.update(ancestor.capture.keys())
+        for ing_key, ing_val in d.ingredients.items():
+            for ref in _CAMPAIGN_REF_RE_RULES.findall(ing_val):
+                if ref not in available_captures:
+                    findings.append(
+                        RuleFinding(
+                            rule="campaign-ingredient-refs-have-prior-capture",
+                            severity=Severity.ERROR,
+                            step_name="(top-level)",
+                            message=(
+                                f"Dispatch {d.name!r} ingredient {ing_key!r} references "
+                                f"${{{{ campaign.{ref} }}}} but no ancestor dispatch "
+                                f"(via depends_on) captures {ref!r}. "
+                                f"Available captured keys: {sorted(available_captures)}"
+                            ),
+                        )
+                    )
+    return findings
+
+
 @semantic_rule(
     name="autoskillit-version-compatible",
     description="Campaign recipe version requirement must be satisfied by installed version",

--- a/src/autoskillit/recipe/rules_campaign.py
+++ b/src/autoskillit/recipe/rules_campaign.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 from autoskillit.core import RECIPE_PACK_REGISTRY, Severity, get_logger
 from autoskillit.recipe._analysis import ValidationContext
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
-from autoskillit.recipe.schema import CampaignDispatch, RecipeKind
+from autoskillit.recipe.schema import CAMPAIGN_REF_RE, CampaignDispatch, RecipeKind
 
 if TYPE_CHECKING:
     from autoskillit.recipe.schema import Recipe
@@ -395,7 +395,6 @@ def _check_campaign_task_non_empty(ctx: ValidationContext) -> list[RuleFinding]:
 
 _IDENT_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 _RESULT_TEMPLATE_RE = re.compile(r"^\$\{\{\s*result\.[\w-]+\s*\}\}$")
-_CAMPAIGN_REF_RE_RULES = re.compile(r"\$\{\{\s*campaign\.(\w+)\s*\}\}")
 
 
 @semantic_rule(
@@ -486,7 +485,7 @@ def _check_campaign_ingredient_refs_have_prior_capture(
         for ing_key, ing_val in d.ingredients.items():
             if not isinstance(ing_val, str):
                 continue
-            for ref in _CAMPAIGN_REF_RE_RULES.findall(ing_val):
+            for ref in CAMPAIGN_REF_RE.findall(ing_val):
                 if ref not in available_captures:
                     findings.append(
                         RuleFinding(

--- a/src/autoskillit/recipe/rules_campaign.py
+++ b/src/autoskillit/recipe/rules_campaign.py
@@ -484,6 +484,8 @@ def _check_campaign_ingredient_refs_have_prior_capture(
             if ancestor:
                 available_captures.update(ancestor.capture.keys())
         for ing_key, ing_val in d.ingredients.items():
+            if not isinstance(ing_val, str):
+                continue
             for ref in _CAMPAIGN_REF_RE_RULES.findall(ing_val):
                 if ref not in available_captures:
                     findings.append(

--- a/src/autoskillit/recipe/schema.py
+++ b/src/autoskillit/recipe/schema.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
+import re
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from enum import StrEnum
@@ -13,6 +14,7 @@ from autoskillit.core import RecipeSource
 
 AUTOSKILLIT_VERSION_KEY: Final = "autoskillit_version"
 RECIPE_VERSION_KEY: Final = "recipe_version"
+CAMPAIGN_REF_RE: Final = re.compile(r"\$\{\{\s*campaign\.(\w+)\s*\}\}")
 
 
 class RecipeKind(StrEnum):

--- a/src/autoskillit/recipe/schema.py
+++ b/src/autoskillit/recipe/schema.py
@@ -131,6 +131,7 @@ class CampaignDispatch:
         default_factory=dict
     )  # string-only: YAML pass-through key-value pairs, not structured RecipeIngredient objects
     depends_on: list[str] = field(default_factory=list)
+    capture: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass

--- a/src/autoskillit/server/tools_execution.py
+++ b/src/autoskillit/server/tools_execution.py
@@ -405,6 +405,7 @@ async def dispatch_food_truck(
     ingredients: dict[str, str] | None = None,
     dispatch_name: str | None = None,
     timeout_sec: int | None = None,
+    capture: dict[str, str] | None = None,
     ctx: Context = CurrentContext(),
 ) -> str:
     """Dispatch a single food truck L2 session for one recipe.
@@ -419,6 +420,9 @@ async def dispatch_food_truck(
         ingredients: Optional ingredient overrides (all values must be strings).
         dispatch_name: Optional display name for the dispatch record.
         timeout_sec: Optional L2 session timeout override in seconds.
+        capture: Optional dict mapping capture keys to "${{ result.field }}" templates.
+            Extracted values are persisted in the campaign context for downstream
+            dispatches to reference via "${{ campaign.key }}" in their ingredients.
 
     Never raises.
     """
@@ -465,6 +469,7 @@ async def dispatch_food_truck(
             quota_checker=check_and_sleep_if_needed,
             quota_refresher=_refresh_quota_cache,
             cache_invalidator=invalidate_cache,
+            capture=capture,
         )
     except Exception as exc:
         logger.error("dispatch_food_truck unhandled exception", exc_info=True)

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -236,7 +236,6 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
         {
             "recipe",
             "execution",
-            "fleet",
             "server",
             "cli",
             "infra",

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -236,6 +236,7 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
         {
             "recipe",
             "execution",
+            "fleet",
             "server",
             "cli",
             "infra",

--- a/tests/fleet/test_campaign_capture.py
+++ b/tests/fleet/test_campaign_capture.py
@@ -1,0 +1,315 @@
+"""Tests for campaign capture extraction and ingredient interpolation (Group J)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.layer("fleet"), pytest.mark.small, pytest.mark.feature("fleet")]
+
+
+# ---------------------------------------------------------------------------
+# Capture extraction tests
+# ---------------------------------------------------------------------------
+
+
+def test_extract_captures_from_payload():
+    from autoskillit.fleet._api import _extract_captures
+
+    result = _extract_captures(
+        {"sources_manifest": "${{ result.sources_manifest }}"},
+        {"sources_manifest": "/tmp/sources.json", "extra": "ignored"},
+    )
+    assert result == {"sources_manifest": "/tmp/sources.json"}
+
+
+def test_extract_captures_missing_field_skipped():
+    from autoskillit.fleet._api import _extract_captures
+
+    result = _extract_captures(
+        {"missing_key": "${{ result.missing_key }}"},
+        {"other": "value"},
+    )
+    assert "missing_key" not in result
+
+
+def test_extract_captures_non_result_template_skipped():
+    from autoskillit.fleet._api import _extract_captures
+
+    result = _extract_captures(
+        {"a": "plain_string", "b": "${{ inputs.x }}"},
+        {"plain_string": "val", "x": "val2"},
+    )
+    assert result == {}
+
+
+def test_extract_captures_converts_value_to_str():
+    from autoskillit.fleet._api import _extract_captures
+
+    result = _extract_captures(
+        {"count": "${{ result.count }}"},
+        {"count": 42},
+    )
+    assert result == {"count": "42"}
+
+
+# ---------------------------------------------------------------------------
+# Ingredient interpolation tests
+# ---------------------------------------------------------------------------
+
+
+def test_interpolate_campaign_refs_basic():
+    from autoskillit.fleet._api import _interpolate_campaign_refs
+
+    result = _interpolate_campaign_refs({"k": "${{ campaign.v }}"}, {"v": "resolved"})
+    assert result == {"k": "resolved"}
+
+
+def test_interpolate_unresolved_ref_raises_value_error():
+    from autoskillit.fleet._api import _interpolate_campaign_refs
+
+    with pytest.raises(ValueError, match="missing"):
+        _interpolate_campaign_refs({"k": "${{ campaign.missing }}"}, {})
+
+
+def test_interpolate_passthrough_non_campaign_values():
+    from autoskillit.fleet._api import _interpolate_campaign_refs
+
+    result = _interpolate_campaign_refs(
+        {"a": "${{ inputs.x }}", "b": "plain"},
+        {},
+    )
+    assert result == {"a": "${{ inputs.x }}", "b": "plain"}
+
+
+def test_interpolate_multiple_refs_in_one_value():
+    from autoskillit.fleet._api import _interpolate_campaign_refs
+
+    result = _interpolate_campaign_refs(
+        {"path": "${{ campaign.a }}/${{ campaign.b }}"},
+        {"a": "foo", "b": "bar"},
+    )
+    assert result == {"path": "foo/bar"}
+
+
+# ---------------------------------------------------------------------------
+# Integration path via execute_dispatch
+# ---------------------------------------------------------------------------
+
+
+def _make_recipe_info(name: str = "test-recipe"):
+    from autoskillit.recipe.schema import RecipeInfo, RecipeSource
+
+    return RecipeInfo(
+        name=name,
+        description="test",
+        source=RecipeSource.PROJECT,
+        path=Path(f"/fake/{name}.yaml"),
+    )
+
+
+def _simple_prompt_builder(**kwargs) -> str:
+    return f"prompt-for-{kwargs.get('recipe', 'unknown')}"
+
+
+async def _no_sleep_quota_checker(config, **kwargs) -> dict:
+    return {
+        "should_sleep": False,
+        "sleep_seconds": 0,
+        "utilization": None,
+        "resets_at": None,
+        "window_name": None,
+    }
+
+
+async def _noop_quota_refresher(config, **kwargs) -> None:
+    pass
+
+
+def _setup_dispatch(tool_ctx, recipe_name: str = "test-recipe", ingredients: dict | None = None):
+    from autoskillit.recipe.schema import Recipe, RecipeKind
+    from tests.fakes import InMemoryHeadlessExecutor, InMemoryRecipeRepository
+
+    tool_ctx.fleet_lock = asyncio.Lock()
+    repo = InMemoryRecipeRepository()
+    recipe_info = _make_recipe_info(recipe_name)
+    repo.add_recipe(recipe_name, recipe_info)
+    repo.add_full_recipe(
+        recipe_info.path,
+        Recipe(
+            name=recipe_name,
+            description="test",
+            kind=RecipeKind.STANDARD,
+            ingredients=ingredients or {},
+        ),
+    )
+    tool_ctx.recipes = repo
+    tool_ctx.executor = InMemoryHeadlessExecutor()
+
+
+def _make_success_result(payload: dict):
+    import dataclasses
+
+    from autoskillit.core.types import SkillResult
+
+    body = json.dumps(payload)
+    sentinel_id_placeholder = "PLACEHOLDER"
+    stdout = f"%%L2_DONE::{sentinel_id_placeholder}%%\n---l2-result---\n{body}\n---end-l2-result---"
+    return SkillResult(
+        success=True,
+        result=stdout,
+        session_id="sess-123",
+        subtype="success",
+        is_error=False,
+        exit_code=0,
+        needs_retry=False,
+        retry_reason="none",
+        stderr="",
+        token_usage=None,
+    )
+
+
+def _read_state_file(tool_ctx) -> dict:
+    state_files = list((tool_ctx.temp_dir / "dispatches").glob("*.json"))
+    assert len(state_files) == 1, f"Expected 1 state file, found {len(state_files)}"
+    return json.loads(state_files[0].read_text())
+
+
+@pytest.mark.anyio
+async def test_dispatch_captures_extracted_and_written_to_state(tool_ctx, monkeypatch):
+    """After a successful dispatch with capture spec, state file has captured_values."""
+    import dataclasses
+
+    from autoskillit.core.types import SkillResult
+    from autoskillit.fleet._api import execute_dispatch
+    from tests.fakes import InMemoryHeadlessExecutor, InMemoryRecipeRepository
+
+    _setup_dispatch(tool_ctx)
+
+    payload = {"success": True, "reason": "", "out": "hello"}
+
+    # The actual dispatch ID isn't known ahead of time; we patch parse_l2_result_block
+    # to return a clean result with the payload.
+    from autoskillit.fleet.result_parser import L2ParseResult
+
+    monkeypatch.setattr(
+        "autoskillit.fleet._api.parse_l2_result_block",
+        lambda **kwargs: L2ParseResult(
+            outcome="completed_clean",
+            payload=payload,
+            raw_body=None,
+            parse_error=None,
+            source="stdout",
+        ),
+    )
+
+    raw = await execute_dispatch(
+        tool_ctx=tool_ctx,
+        recipe="test-recipe",
+        task="t",
+        ingredients=None,
+        dispatch_name=None,
+        timeout_sec=None,
+        capture={"out": "${{ result.out }}"},
+        prompt_builder=_simple_prompt_builder,
+        quota_checker=_no_sleep_quota_checker,
+        quota_refresher=_noop_quota_refresher,
+    )
+
+    result = json.loads(raw)
+    assert result["success"] is True
+
+    state_data = _read_state_file(tool_ctx)
+    assert state_data.get("captured_values") == {"out": "hello"}
+
+
+@pytest.mark.anyio
+async def test_dispatch_ingredients_interpolated_from_captured_values(tool_ctx, monkeypatch):
+    """Prior captured_values in state file are resolved into ingredients before dispatch."""
+    import json as _json
+
+    from autoskillit.fleet._api import execute_dispatch
+    from autoskillit.fleet.result_parser import L2ParseResult
+    from autoskillit.fleet.state import write_initial_state, write_captured_values, DispatchRecord
+
+    # Pre-create a state file for the same campaign_id with captured_values
+    campaign_id = tool_ctx.kitchen_id
+    dispatches_dir = tool_ctx.temp_dir / "dispatches"
+    dispatches_dir.mkdir(parents=True, exist_ok=True)
+    prior_state_path = dispatches_dir / "prior.json"
+    write_initial_state(
+        prior_state_path,
+        campaign_id=campaign_id,
+        campaign_name="prior-dispatch",
+        manifest_path="",
+        dispatches=[DispatchRecord(name="prior-dispatch")],
+    )
+    from autoskillit.fleet.state import DispatchStatus, append_dispatch_record
+    append_dispatch_record(
+        prior_state_path,
+        DispatchRecord(name="prior-dispatch", status=DispatchStatus.SUCCESS),
+    )
+    write_captured_values(prior_state_path, {"v": "injected"})
+
+    _setup_dispatch(tool_ctx, ingredients={"x": ""})
+
+    received_ingredients: list[dict] = []
+
+    def _capturing_prompt_builder(**kwargs):
+        received_ingredients.append(kwargs.get("ingredients", {}))
+        return "prompt"
+
+    monkeypatch.setattr(
+        "autoskillit.fleet._api.parse_l2_result_block",
+        lambda **kwargs: L2ParseResult(
+            outcome="completed_clean",
+            payload={"success": True, "reason": ""},
+            raw_body=None,
+            parse_error=None,
+            source="stdout",
+        ),
+    )
+
+    await execute_dispatch(
+        tool_ctx=tool_ctx,
+        recipe="test-recipe",
+        task="t",
+        ingredients={"x": "${{ campaign.v }}"},
+        dispatch_name=None,
+        timeout_sec=None,
+        capture=None,
+        prompt_builder=_capturing_prompt_builder,
+        quota_checker=_no_sleep_quota_checker,
+        quota_refresher=_noop_quota_refresher,
+    )
+
+    assert received_ingredients, "prompt_builder was not called"
+    assert received_ingredients[0].get("x") == "injected"
+
+
+@pytest.mark.anyio
+async def test_unresolved_campaign_ref_in_ingredients_returns_fleet_error(tool_ctx, monkeypatch):
+    """Dispatch with ${{ campaign.missing }} and no prior captures returns fleet_error."""
+    from autoskillit.fleet._api import execute_dispatch
+
+    _setup_dispatch(tool_ctx, ingredients={"x": ""})
+
+    raw = await execute_dispatch(
+        tool_ctx=tool_ctx,
+        recipe="test-recipe",
+        task="t",
+        ingredients={"x": "${{ campaign.missing }}"},
+        dispatch_name=None,
+        timeout_sec=None,
+        capture=None,
+        prompt_builder=_simple_prompt_builder,
+        quota_checker=_no_sleep_quota_checker,
+        quota_refresher=_noop_quota_refresher,
+    )
+
+    result = json.loads(raw)
+    assert result["success"] is False
+    assert "error" in result

--- a/tests/fleet/test_campaign_capture.py
+++ b/tests/fleet/test_campaign_capture.py
@@ -175,7 +175,6 @@ def _make_success_result(payload: dict):
 
 def _read_state_file(tool_ctx) -> dict:
     state_files = list((tool_ctx.temp_dir / "dispatches").glob("*.json"))
-    assert len(state_files) == 1, f"Expected 1 state file, found {len(state_files)}"
     return json.loads(state_files[0].read_text())
 
 
@@ -220,6 +219,8 @@ async def test_dispatch_captures_extracted_and_written_to_state(tool_ctx, monkey
     result = json.loads(raw)
     assert result["success"] is True
 
+    dispatch_files = list((tool_ctx.temp_dir / "dispatches").glob("*.json"))
+    assert len(dispatch_files) == 1, f"Expected 1 state file, found {len(dispatch_files)}"
     state_data = _read_state_file(tool_ctx)
     assert state_data.get("captured_values") == {"out": "hello"}
 
@@ -285,6 +286,7 @@ async def test_dispatch_ingredients_interpolated_from_captured_values(tool_ctx, 
     )
 
     assert received_ingredients, "prompt_builder was not called"
+    assert len(received_ingredients) == 1
     assert received_ingredients[0].get("x") == "injected"
 
 

--- a/tests/fleet/test_campaign_capture.py
+++ b/tests/fleet/test_campaign_capture.py
@@ -151,13 +151,14 @@ def _setup_dispatch(tool_ctx, recipe_name: str = "test-recipe", ingredients: dic
 
 
 def _make_success_result(payload: dict):
-    import dataclasses
 
     from autoskillit.core.types import SkillResult
 
     body = json.dumps(payload)
     sentinel_id_placeholder = "PLACEHOLDER"
-    stdout = f"%%L2_DONE::{sentinel_id_placeholder}%%\n---l2-result---\n{body}\n---end-l2-result---"
+    stdout = (
+        f"%%L2_DONE::{sentinel_id_placeholder}%%\n---l2-result---\n{body}\n---end-l2-result---"
+    )
     return SkillResult(
         success=True,
         result=stdout,
@@ -181,11 +182,8 @@ def _read_state_file(tool_ctx) -> dict:
 @pytest.mark.anyio
 async def test_dispatch_captures_extracted_and_written_to_state(tool_ctx, monkeypatch):
     """After a successful dispatch with capture spec, state file has captured_values."""
-    import dataclasses
 
-    from autoskillit.core.types import SkillResult
     from autoskillit.fleet._api import execute_dispatch
-    from tests.fakes import InMemoryHeadlessExecutor, InMemoryRecipeRepository
 
     _setup_dispatch(tool_ctx)
 
@@ -229,11 +227,10 @@ async def test_dispatch_captures_extracted_and_written_to_state(tool_ctx, monkey
 @pytest.mark.anyio
 async def test_dispatch_ingredients_interpolated_from_captured_values(tool_ctx, monkeypatch):
     """Prior captured_values in state file are resolved into ingredients before dispatch."""
-    import json as _json
 
     from autoskillit.fleet._api import execute_dispatch
     from autoskillit.fleet.result_parser import L2ParseResult
-    from autoskillit.fleet.state import write_initial_state, write_captured_values, DispatchRecord
+    from autoskillit.fleet.state import DispatchRecord, write_captured_values, write_initial_state
 
     # Pre-create a state file for the same campaign_id with captured_values
     campaign_id = tool_ctx.kitchen_id
@@ -248,6 +245,7 @@ async def test_dispatch_ingredients_interpolated_from_captured_values(tool_ctx, 
         dispatches=[DispatchRecord(name="prior-dispatch")],
     )
     from autoskillit.fleet.state import DispatchStatus, append_dispatch_record
+
     append_dispatch_record(
         prior_state_path,
         DispatchRecord(name="prior-dispatch", status=DispatchStatus.SUCCESS),

--- a/tests/fleet/test_state.py
+++ b/tests/fleet/test_state.py
@@ -22,8 +22,6 @@ from autoskillit.fleet import (
     write_captured_values,
     write_initial_state,
 )
-from autoskillit.fleet.state import _SCHEMA_VERSION
-
 pytestmark = [pytest.mark.layer("fleet"), pytest.mark.small, pytest.mark.feature("fleet")]
 
 
@@ -200,11 +198,6 @@ class TestReadStateRejectsCorrupted:
 
         result = read_state(sp)
         assert result is None
-
-
-class TestSchemaVersion:
-    def test_schema_version_is_3(self) -> None:
-        assert _SCHEMA_VERSION == 3
 
 
 class TestCapturedValuesRoundTrip:

--- a/tests/fleet/test_state.py
+++ b/tests/fleet/test_state.py
@@ -22,6 +22,7 @@ from autoskillit.fleet import (
     write_captured_values,
     write_initial_state,
 )
+
 pytestmark = [pytest.mark.layer("fleet"), pytest.mark.small, pytest.mark.feature("fleet")]
 
 

--- a/tests/fleet/test_state.py
+++ b/tests/fleet/test_state.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import errno
+import json
 import os
 import threading
 from pathlib import Path
@@ -15,10 +16,13 @@ from autoskillit.fleet import (
     DispatchStatus,
     append_dispatch_record,
     mark_dispatch_running,
+    read_all_campaign_captures,
     read_state,
     resume_campaign_from_state,
+    write_captured_values,
     write_initial_state,
 )
+from autoskillit.fleet.state import _SCHEMA_VERSION
 
 pytestmark = [pytest.mark.layer("fleet"), pytest.mark.small, pytest.mark.feature("fleet")]
 
@@ -39,7 +43,7 @@ class TestInitialState:
 
         state = read_state(sp)
         assert state is not None
-        assert state.schema_version == 2
+        assert state.schema_version == 3
         assert state.campaign_id == "cid-1"
         assert state.campaign_name == "my-campaign"
         assert state.manifest_path == "/m.yaml"
@@ -196,3 +200,71 @@ class TestReadStateRejectsCorrupted:
 
         result = read_state(sp)
         assert result is None
+
+
+class TestSchemaVersion:
+    def test_schema_version_is_3(self) -> None:
+        assert _SCHEMA_VERSION == 3
+
+
+class TestCapturedValuesRoundTrip:
+    def test_captured_values_round_trip(self, tmp_path: Path) -> None:
+        sp = _state_path(tmp_path)
+        write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("a"))
+        write_captured_values(sp, {"k": "v"})
+
+        state = read_state(sp)
+        assert state is not None
+        assert state.captured_values == {"k": "v"}
+
+
+class TestReadV2StateFileDefaultsCapturedValues:
+    def test_read_v2_state_file_defaults_captured_values(self, tmp_path: Path) -> None:
+        sp = _state_path(tmp_path)
+        sp.parent.mkdir(parents=True, exist_ok=True)
+        v2_data = {
+            "schema_version": 2,
+            "campaign_id": "cid",
+            "campaign_name": "camp",
+            "manifest_path": "/m.yaml",
+            "started_at": 0.0,
+            "dispatches": [],
+        }
+        sp.write_text(json.dumps(v2_data), encoding="utf-8")
+
+        state = read_state(sp)
+        assert state is not None
+        assert state.captured_values == {}
+
+
+class TestReadAllCampaignCaptures:
+    def test_read_all_campaign_captures_merges_across_dispatches(self, tmp_path: Path) -> None:
+        dispatches_dir = tmp_path / "dispatches"
+        dispatches_dir.mkdir()
+
+        for i, (key, val) in enumerate([("a", "1"), ("b", "2")]):
+            sp = dispatches_dir / f"state{i}.json"
+            write_initial_state(sp, "cid-merge", "camp", "/m.yaml", _make_dispatches(f"d{i}"))
+            append_dispatch_record(sp, DispatchRecord(name=f"d{i}", status=DispatchStatus.SUCCESS))
+            write_captured_values(sp, {key: val})
+
+        result = read_all_campaign_captures(dispatches_dir, "cid-merge")
+        assert result == {"a": "1", "b": "2"}
+
+    def test_read_all_campaign_captures_ignores_non_success_dispatches(
+        self, tmp_path: Path
+    ) -> None:
+        dispatches_dir = tmp_path / "dispatches"
+        dispatches_dir.mkdir()
+
+        sp = dispatches_dir / "failure.json"
+        write_initial_state(sp, "cid-fail", "camp", "/m.yaml", _make_dispatches("d1"))
+        append_dispatch_record(sp, DispatchRecord(name="d1", status=DispatchStatus.FAILURE))
+        write_captured_values(sp, {"k": "should-not-appear"})
+
+        result = read_all_campaign_captures(dispatches_dir, "cid-fail")
+        assert result == {}
+
+    def test_read_all_campaign_captures_empty_dir(self, tmp_path: Path) -> None:
+        result = read_all_campaign_captures(tmp_path / "nonexistent", "any-id")
+        assert result == {}

--- a/tests/fleet/test_state_schema.py
+++ b/tests/fleet/test_state_schema.py
@@ -63,8 +63,8 @@ class TestDispatchRecordSchemaV2:
         assert dispatch_raw["l2_starttime_ticks"] == 42
         assert dispatch_raw["l2_boot_id"] == "abc-boot"
 
-    def test_schema_version_is_2(self) -> None:
-        assert _SCHEMA_VERSION == 2
+    def test_schema_version_is_3(self) -> None:
+        assert _SCHEMA_VERSION == 3
 
     def test_read_state_handles_v1_without_ticks(self, tmp_path: Path) -> None:
         """read_state on a v1 file missing l2_starttime_ticks/l2_boot_id returns defaults."""

--- a/tests/recipe/test_rules_campaign.py
+++ b/tests/recipe/test_rules_campaign.py
@@ -424,3 +424,121 @@ def test_campaign_valid_passes_all_rules():
     assert not warning_findings, (
         f"Valid campaign must not have WARNING findings: {warning_findings}"
     )
+
+
+# ---------------------------------------------------------------------------
+# T32: dispatch-capture-keys-are-identifiers
+# ---------------------------------------------------------------------------
+
+
+def test_capture_key_must_be_identifier():
+    recipe = _campaign(
+        dispatches=[
+            CampaignDispatch(
+                name="phase-one",
+                recipe="implementation",
+                task="t",
+                capture={"bad-key": "${{ result.v }}"},
+            )
+        ]
+    )
+    findings = _findings(recipe, "dispatch-capture-keys-are-identifiers")
+    assert len(findings) == 1
+    assert findings[0].severity == Severity.ERROR
+
+
+# ---------------------------------------------------------------------------
+# T33: dispatch-capture-value-references-result
+# ---------------------------------------------------------------------------
+
+
+def test_capture_value_must_reference_result():
+    recipe = _campaign(
+        dispatches=[
+            CampaignDispatch(
+                name="phase-one",
+                recipe="implementation",
+                task="t",
+                capture={"k": "not_a_template"},
+            )
+        ]
+    )
+    findings = _findings(recipe, "dispatch-capture-value-references-result")
+    assert len(findings) == 1
+    assert findings[0].severity == Severity.ERROR
+
+
+# ---------------------------------------------------------------------------
+# T34: campaign-ingredient-refs-have-prior-capture (unresolvable ref)
+# ---------------------------------------------------------------------------
+
+
+def test_campaign_ingredient_ref_requires_prior_capture():
+    recipe = _campaign(
+        dispatches=[
+            CampaignDispatch(
+                name="phase-one",
+                recipe="implementation",
+                task="t",
+            ),
+            CampaignDispatch(
+                name="phase-two",
+                recipe="implementation",
+                task="t",
+                ingredients={"x": "${{ campaign.x }}"},
+                depends_on=["phase-one"],
+            ),
+        ]
+    )
+    findings = _findings(recipe, "campaign-ingredient-refs-have-prior-capture")
+    assert len(findings) == 1
+    assert findings[0].severity == Severity.ERROR
+
+
+# ---------------------------------------------------------------------------
+# T35: campaign-ingredient-refs-have-prior-capture (satisfied by ancestor)
+# ---------------------------------------------------------------------------
+
+
+def test_campaign_ingredient_ref_satisfied_by_ancestor():
+    recipe = _campaign(
+        dispatches=[
+            CampaignDispatch(
+                name="phase-one",
+                recipe="implementation",
+                task="t",
+                capture={"x": "${{ result.x }}"},
+            ),
+            CampaignDispatch(
+                name="phase-two",
+                recipe="implementation",
+                task="t",
+                ingredients={"x": "${{ campaign.x }}"},
+                depends_on=["phase-one"],
+            ),
+        ]
+    )
+    findings = _findings(recipe, "campaign-ingredient-refs-have-prior-capture")
+    assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# T36: valid capture spec passes
+# ---------------------------------------------------------------------------
+
+
+def test_valid_capture_spec_passes():
+    recipe = _campaign(
+        dispatches=[
+            CampaignDispatch(
+                name="phase-one",
+                recipe="implementation",
+                task="t",
+                capture={"out_file": "${{ result.out_file }}"},
+            )
+        ]
+    )
+    capture_key_findings = _findings(recipe, "dispatch-capture-keys-are-identifiers")
+    capture_val_findings = _findings(recipe, "dispatch-capture-value-references-result")
+    assert capture_key_findings == []
+    assert capture_val_findings == []


### PR DESCRIPTION
## Summary

Add `capture:` field support to `CampaignDispatch` so results from one dispatch can feed
into the next dispatch's ingredients. The flow is:

1. A dispatch declares `capture: { key: "${{ result.field }}" }` in its YAML.
2. After dispatch completes successfully, Python extracts values from the L2 result payload.
3. Captured values are persisted in the dispatch's `state.json` under a new `captured_values` field.
4. Before the next dispatch, Python scans all state files for the same campaign, accumulates
   all captured values, and resolves any `${{ campaign.* }}` references in the dispatch's
   `ingredients` dict.
5. The campaign dispatcher prompt is updated to tell the L3 agent to pass the `capture:` block
   from the manifest YAML as the new `capture` parameter on each `dispatch_food_truck` call.
6. Three new validation rules catch malformed capture specs and forward references at YAML
   load time.

## Architecture Impact

### Data Lineage Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph Input ["Data Origins"]
        YAML["Campaign Recipe YAML<br/>━━━━━━━━━━<br/>dispatches[*].capture:<br/>{key: '${{ result.field }}'}"]
    end

    subgraph Schema ["● Schema Layer<br/>recipe/schema.py + recipe/io.py"]
        direction TB
        DISPATCH["● CampaignDispatch<br/>━━━━━━━━━━<br/>.capture: dict[str,str]<br/>(new field)"]
        PARSE["● load_recipe / io.py<br/>━━━━━━━━━━<br/>d.get('capture') or {}"]
    end

    subgraph Validation ["● Recipe Validation<br/>recipe/rules_campaign.py"]
        direction TB
        R1["● dispatch-capture-keys-are-identifiers<br/>━━━━━━━━━━<br/>key matches [a-zA-Z_][a-zA-Z0-9_]*"]
        R2["● dispatch-capture-value-references-result<br/>━━━━━━━━━━<br/>val matches \$\{\{ result.field \}\}"]
        R3["● campaign-ingredient-refs-have-prior-capture<br/>━━━━━━━━━━<br/>${{ campaign.key }} has ancestor capture"]
    end

    subgraph Dispatch ["● MCP Dispatch Layer<br/>server/tools_execution.py + fleet/_api.py"]
        direction TB
        TOOL["● dispatch_food_truck MCP tool<br/>━━━━━━━━━━<br/>capture: dict[str,str] | None<br/>(new param)"]
        EXEC["● execute_dispatch()<br/>━━━━━━━━━━<br/>reads accumulated captures<br/>interpolates ingredients"]
        INTERP["● _interpolate_campaign_refs()<br/>━━━━━━━━━━<br/>${{ campaign.key }} → captured value<br/>raises ValueError if unresolved"]
    end

    subgraph L2Result ["L2 Session Output"]
        L2["L2 Headless Claude<br/>━━━━━━━━━━<br/>stdout: JSON result block<br/>parsed.payload: dict"]
    end

    subgraph Extract ["● Capture Extraction<br/>fleet/_api.py"]
        EXTFN["● _extract_captures()<br/>━━━━━━━━━━<br/>capture_spec + payload<br/>→ dict[str,str]"]
    end

    subgraph Storage ["Primary Storage (Source of Truth)"]
        STATEFILE[("● dispatches/{dispatch_id}.json<br/>━━━━━━━━━━<br/>captured_values: dict[str,str]<br/>schema_version: 3")]
        WRITECAP["● write_captured_values()<br/>━━━━━━━━━━<br/>atomic merge, new keys win<br/>fleet/state.py"]
        READALL["● read_all_campaign_captures()<br/>━━━━━━━━━━<br/>scans *.json for campaign_id<br/>only SUCCESS dispatches"]
    end

    subgraph Tests ["★ New Tests<br/>tests/fleet/test_campaign_capture.py"]
        TC["★ test_campaign_capture.py<br/>━━━━━━━━━━<br/>_extract_captures<br/>_interpolate_campaign_refs<br/>write/read_captured_values"]
    end

    %% PRIMARY DATA FLOW %%
    YAML -->|"YAML text"| PARSE
    PARSE -->|"CampaignDispatch"| DISPATCH
    DISPATCH --> R1
    DISPATCH --> R2
    DISPATCH --> R3

    YAML -->|"capture dict"| TOOL
    TOOL -->|"capture kwarg"| EXEC
    EXEC -->|"read prior captures"| READALL
    READALL -->|"accumulated dict[str,str]"| INTERP
    INTERP -->|"effective_ingredients"| L2

    L2 -->|"parsed.payload JSON"| EXTFN
    EXTFN -->|"extracted dict[str,str]"| WRITECAP
    WRITECAP -->|"atomic os.replace"| STATEFILE
    STATEFILE -->|"*.json scan"| READALL

    %% TEST COVERAGE (dashed)
    EXTFN -.->|"tested by"| TC
    INTERP -.->|"tested by"| TC
    WRITECAP -.->|"tested by"| TC
    READALL -.->|"tested by"| TC

    %% CLASS ASSIGNMENTS %%
    class YAML cli;
    class DISPATCH,PARSE stateNode;
    class R1,R2,R3 detector;
    class TOOL,EXEC handler;
    class INTERP phase;
    class L2 integration;
    class EXTFN handler;
    class STATEFILE stateNode;
    class WRITECAP,READALL handler;
    class TC newComponent;
```

Closes #1203

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260426-013705-819027/.autoskillit/temp/make-plan/fleet_t9_campaign_data_flow_plan_2026-04-26_000001.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 187 | 20.7k | 1.1M | 82.0k | 1 | 14m 55s |
| verify | 100 | 9.9k | 484.3k | 39.9k | 1 | 3m 49s |
| implement | 420 | 26.5k | 3.9M | 101.0k | 1 | 8m 49s |
| fix | 136 | 4.6k | 656.6k | 45.6k | 1 | 6m 47s |
| prepare_pr | 52 | 4.6k | 170.8k | 28.4k | 1 | 1m 7s |
| run_arch_lenses | 87 | 6.3k | 354.3k | 118.6k | 1 | 1m 46s |
| compose_pr | 59 | 3.6k | 180.6k | 21.4k | 1 | 1m 19s |
| **Total** | 1.0k | 76.3k | 6.9M | 436.9k | | 38m 34s |