### PR TITLE
Tool Call Sequence Diagnostics — Cross-Session DFG Analysis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,8 @@ generic_automation_mcp/
 │   ├── _plugin_ids.py       #   DIRECT_PREFIX, MARKETPLACE_PREFIX, detect_autoskillit_mcp_prefix (stdlib-only)
 │   ├── feature_flags.py     #   is_feature_enabled() — L0 feature gate resolution primitive
 │   ├── readiness.py         #   Filesystem readiness sentinel primitives for MCP server startup (L0)
-│   └── session_registry.py  #   Session registry: maps autoskillit launch IDs to Claude Code session UUIDs
+│   ├── session_registry.py  #   Session registry: maps autoskillit launch IDs to Claude Code session UUIDs
+│   └── tool_sequence_analysis.py #  Cross-session tool call sequence DFG analysis (stdlib-only, L0)
 │
 ├── config/                  # L1
 │   ├── __init__.py
@@ -300,6 +301,7 @@ generic_automation_mcp/
 │   ├── _features.py         #   features subcommand group: list/status commands for feature gate inspection
 │   ├── _workspace.py        #   Workspace clean helpers
 │   ├── _session_picker.py   #   Scoped resume picker: filters sessions by type (cook/order) via registry + heuristic
+│   ├── _sessions.py         #   sessions analyze CLI subcommand for cross-session DFG visualization
 │   └── app.py               #   CLI entry: serve, init, config, skills, recipes, doctor, update, etc.
 │
 ├── hooks/                   # Claude Code PreToolUse/PostToolUse/SessionStart scripts

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 AutoSkillit is a Claude Code plugin that runs YAML recipes through a
 two-tier orchestrator. The bundled recipes implement issue → plan → worktree
-→ tests → PR → merge pipelines using 47 MCP tools and 121 bundled skills.
+→ tests → PR → merge pipelines using 48 MCP tools and 121 bundled skills.
 
 ## Start here
 

--- a/docs/execution/architecture.md
+++ b/docs/execution/architecture.md
@@ -68,7 +68,7 @@ AutoSkillit supports four session modes with different tool and skill visibility
   `$ claude`); `/open-kitchen` reveals kitchen tools.
 
 - **`$ autoskillit order`**: Pipeline orchestrator session. Kitchen is pre-opened at startup —
-  all 47 MCP tools are available immediately. All skill tiers are accessible. The orchestrator
+  all 48 MCP tools are available immediately. All skill tiers are accessible. The orchestrator
   delegates work through `run_skill` (headless sessions) and `run_cmd` (shell commands).
 
 - **`run_skill` (headless)**: Worker sessions launched by the orchestrator. Sees 3 Free Range

--- a/docs/execution/architecture.md
+++ b/docs/execution/architecture.md
@@ -4,7 +4,7 @@ How AutoSkillit runs a recipe end to end: orchestrator, kitchen gating, clone an
 
 ## Overview
 
-AutoSkillit is a Claude Code plugin that orchestrates automated workflows using headless sessions. It provides 47 MCP tools and 121 bundled skills, organized into a gated visibility system.
+AutoSkillit is a Claude Code plugin that orchestrates automated workflows using headless sessions. It provides 48 MCP tools and 121 bundled skills, organized into a gated visibility system.
 
 ## Core Concepts
 

--- a/docs/execution/tool-access.md
+++ b/docs/execution/tool-access.md
@@ -1,6 +1,6 @@
 # MCP Tool Access Control
 
-AutoSkillit provides 47 MCP tools organized into three access levels that control which
+AutoSkillit provides 48 MCP tools organized into three access levels that control which
 session types can see each tool.
 
 ## Three Access Levels
@@ -65,7 +65,7 @@ Server startup sequence:
    → reveals test_check only (the sole headless-tagged tool)
 
 4. When open_kitchen is called:
-   ctx.enable_components(tags={"kitchen"})   → reveals all 43 kitchen tools
+   ctx.enable_components(tags={"kitchen"})   → reveals all 44 kitchen tools
    ctx.disable_components(tags={subset})     → re-hides each disabled subset
    (session-level enable overwrites server-level disable, so re-disabling is required)
 ```
@@ -86,7 +86,7 @@ missing kitchen visibility.
 
 ## Complete MCP Tool Access Control Map
 
-All 47 tools with their access level, tags, source file, and functional category.
+All 48 tools with their access level, tags, source file, and functional category.
 
 **Tag abbreviations**: AS = `autoskillit`, K = `kitchen`, HL = `headless`,
 GH = `github`, CI = `ci`, CL = `clone`, TL = `telemetry`
@@ -209,7 +209,7 @@ GH = `github`, CI = `ci`, CL = `clone`, TL = `telemetry`
 
 ---
 
-**Total: 47 tools** — 4 Free Range + 43 Kitchen-tagged (of which 1, `test_check`, additionally carries the `headless` tag and is revealed inside headless sessions)
+**Total: 48 tools** — 4 Free Range + 44 Kitchen-tagged (of which 1, `test_check`, additionally carries the `headless` tag and is revealed inside headless sessions)
 
 For subset configuration that can hide functional-category tools, see
 [Subset Categories](../skills/subsets.md).

--- a/docs/skills/visibility.md
+++ b/docs/skills/visibility.md
@@ -84,7 +84,7 @@ and `/autoskillit:close-kitchen`. Skills in `skills_extended/` are never seen.
 
 Order is similar to cook: AutoSkillit launches Claude Code with access to all tiers.
 The key difference is the orchestrator (`sous-chef` skill) is injected and the kitchen
-is pre-opened so all 47 MCP tools are available from the start.
+is pre-opened so all 48 MCP tools are available from the start.
 
 ### Headless session (launched by `run_skill`)
 

--- a/src/autoskillit/cli/_sessions.py
+++ b/src/autoskillit/cli/_sessions.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import sys
+
+from cyclopts import App
+
+sessions_app = App(name="sessions", help="Session diagnostics and analysis.")
+
+
+@sessions_app.command(name="analyze")
+def sessions_analyze(
+    recipe: str = "",
+    *,
+    format: str = "table",
+    top: int = 20,
+    min_count: int = 1,
+    output: str = "",
+) -> None:
+    """Analyze cross-session tool call sequence patterns.
+
+    Reads all session summary.json files from the configured log directory
+    and renders a Data Flow Graph of tool call transitions.
+    """
+    import pathlib
+
+    from autoskillit.config.settings import load_config
+    from autoskillit.execution.session_log import resolve_log_dir
+    from autoskillit.execution.tool_sequence_analysis import (
+        compute_analysis,
+        parse_sessions_from_summary_dir,
+        render_adjacency_table,
+        render_dot,
+        render_mermaid,
+    )
+
+    cfg = load_config()
+    log_root = resolve_log_dir(cfg.linux_tracing.log_dir)
+    sessions = list(parse_sessions_from_summary_dir(log_root))
+
+    if not sessions:
+        print("No sessions with tool call data found.", file=sys.stderr)
+        raise SystemExit(1)
+
+    if recipe:
+        sessions = [s for s in sessions if s.recipe_name == recipe]
+        if not sessions:
+            print(f"No sessions found for recipe '{recipe}'.", file=sys.stderr)
+            raise SystemExit(1)
+
+    result = compute_analysis(sessions)
+    dfg = result.global_dfg if not recipe else result.by_recipe.get(recipe, result.global_dfg)
+
+    fmt = format.lower()
+    if fmt == "mermaid":
+        rendered = render_mermaid(dfg, min_count=min_count, top_n=top)
+    elif fmt == "dot":
+        rendered = render_dot(dfg, min_count=min_count, top_n=top)
+    else:
+        rendered = render_adjacency_table(dfg, top_n=top)
+
+    if output:
+        pathlib.Path(output).write_text(rendered, encoding="utf-8")
+        print(f"Written to {output}")
+    else:
+        print(rendered)
+
+    print(
+        f"\n{result.session_count} sessions | {len(result.by_recipe)} recipe(s)",
+        file=sys.stderr,
+    )

--- a/src/autoskillit/cli/_sessions.py
+++ b/src/autoskillit/cli/_sessions.py
@@ -21,17 +21,16 @@ def sessions_analyze(
     Reads all session summary.json files from the configured log directory
     and renders a Data Flow Graph of tool call transitions.
     """
-    import pathlib
-
-    from autoskillit.config.settings import load_config
-    from autoskillit.execution.session_log import resolve_log_dir
-    from autoskillit.execution.tool_sequence_analysis import (
+    from autoskillit.config import load_config
+    from autoskillit.core import (
+        atomic_write,
         compute_analysis,
         parse_sessions_from_summary_dir,
         render_adjacency_table,
         render_dot,
         render_mermaid,
     )
+    from autoskillit.execution import resolve_log_dir
 
     cfg = load_config()
     log_root = resolve_log_dir(cfg.linux_tracing.log_dir)
@@ -59,7 +58,9 @@ def sessions_analyze(
         rendered = render_adjacency_table(dfg, top_n=top)
 
     if output:
-        pathlib.Path(output).write_text(rendered, encoding="utf-8")
+        import pathlib
+
+        atomic_write(pathlib.Path(output), rendered)
         print(f"Written to {output}")
     else:
         print(rendered)

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -17,6 +17,7 @@ import anyio
 from autoskillit.cli._features import features_app
 from autoskillit.cli._fleet import fleet_app
 from autoskillit.cli._serve_guard import serve_with_signal_guard
+from autoskillit.cli._sessions import sessions_app
 
 if TYPE_CHECKING:
     from autoskillit.recipe import Recipe, RecipeInfo
@@ -60,6 +61,7 @@ app.command(recipes_app)
 app.command(workspace_app)
 app.command(fleet_app)
 app.command(features_app)
+app.command(sessions_app)
 
 
 class CliError(Exception):

--- a/src/autoskillit/config/ingredient_defaults.py
+++ b/src/autoskillit/config/ingredient_defaults.py
@@ -62,6 +62,7 @@ _DISPLAY_CATEGORIES: tuple[tuple[str, tuple[str, ...]], ...] = (
             "get_token_summary",
             "get_timing_summary",
             "get_quota_events",
+            "analyze_tool_sequences",
         ),
     ),
     ("Fleet", FLEET_MENU_TOOLS),

--- a/src/autoskillit/core/__init__.py
+++ b/src/autoskillit/core/__init__.py
@@ -111,6 +111,51 @@ from .session_registry import (
 from .session_registry import (
     write_registry_entry as write_registry_entry,
 )
+from .tool_sequence_analysis import (
+    DFG as DFG,
+)
+from .tool_sequence_analysis import (
+    AnalysisResult as AnalysisResult,
+)
+from .tool_sequence_analysis import (
+    GapStats as GapStats,
+)
+from .tool_sequence_analysis import (
+    TurnSequence as TurnSequence,
+)
+from .tool_sequence_analysis import (
+    build_dfg as build_dfg,
+)
+from .tool_sequence_analysis import (
+    build_dfg_by_recipe as build_dfg_by_recipe,
+)
+from .tool_sequence_analysis import (
+    compute_analysis as compute_analysis,
+)
+from .tool_sequence_analysis import (
+    compute_gap_stats as compute_gap_stats,
+)
+from .tool_sequence_analysis import (
+    filter_sessions_by_recipe as filter_sessions_by_recipe,
+)
+from .tool_sequence_analysis import (
+    format_top_bigrams as format_top_bigrams,
+)
+from .tool_sequence_analysis import (
+    parse_raw_cc_jsonl as parse_raw_cc_jsonl,
+)
+from .tool_sequence_analysis import (
+    parse_sessions_from_summary_dir as parse_sessions_from_summary_dir,
+)
+from .tool_sequence_analysis import (
+    render_adjacency_table as render_adjacency_table,
+)
+from .tool_sequence_analysis import (
+    render_dot as render_dot,
+)
+from .tool_sequence_analysis import (
+    render_mermaid as render_mermaid,
+)
 from .types import (
     AUTOSKILLIT_INSTALLED_VERSION,
     AUTOSKILLIT_PRIVATE_ENV_VARS,
@@ -413,4 +458,20 @@ __all__ = [
     "detect_autoskillit_mcp_prefix",
     # feature_flags
     "is_feature_enabled",
+    # tool_sequence_analysis
+    "AnalysisResult",
+    "DFG",
+    "GapStats",
+    "TurnSequence",
+    "build_dfg",
+    "build_dfg_by_recipe",
+    "compute_analysis",
+    "compute_gap_stats",
+    "filter_sessions_by_recipe",
+    "format_top_bigrams",
+    "parse_raw_cc_jsonl",
+    "parse_sessions_from_summary_dir",
+    "render_adjacency_table",
+    "render_dot",
+    "render_mermaid",
 ]

--- a/src/autoskillit/core/_type_constants.py
+++ b/src/autoskillit/core/_type_constants.py
@@ -339,7 +339,7 @@ TOOL_SUBSET_TAGS: dict[str, frozenset[str]] = {
     "get_timing_summary": frozenset({"kitchen-core", "telemetry", "fleet"}),
     "write_telemetry_files": frozenset({"kitchen-core", "telemetry"}),
     "get_quota_events": frozenset({"kitchen-core", "telemetry", "fleet"}),
-    "analyze_tool_sequences": frozenset({"telemetry"}),
+    "analyze_tool_sequences": frozenset({"kitchen-core", "telemetry"}),
     # kitchen-core — execution
     "run_cmd": frozenset({"kitchen-core"}),
     "run_python": frozenset({"kitchen-core"}),

--- a/src/autoskillit/core/_type_constants.py
+++ b/src/autoskillit/core/_type_constants.py
@@ -189,6 +189,7 @@ GATED_TOOLS: frozenset[str] = frozenset(
         "bulk_close_issues",
         "check_pr_mergeable",
         "set_commit_status",
+        "analyze_tool_sequences",
         # Formerly ungated — now kitchen-gated:
         "fetch_github_issue",
         "get_issue_title",
@@ -338,6 +339,7 @@ TOOL_SUBSET_TAGS: dict[str, frozenset[str]] = {
     "get_timing_summary": frozenset({"kitchen-core", "telemetry", "fleet"}),
     "write_telemetry_files": frozenset({"kitchen-core", "telemetry"}),
     "get_quota_events": frozenset({"kitchen-core", "telemetry", "fleet"}),
+    "analyze_tool_sequences": frozenset({"telemetry"}),
     # kitchen-core — execution
     "run_cmd": frozenset({"kitchen-core"}),
     "run_python": frozenset({"kitchen-core"}),

--- a/src/autoskillit/core/tool_sequence_analysis.py
+++ b/src/autoskillit/core/tool_sequence_analysis.py
@@ -230,3 +230,25 @@ def render_dot(dfg: DFG, *, min_count: int = 1, top_n: int = 30) -> str:
         lines.append(f'    "{a}" -> "{b}" [label="{count}"];')
     lines.append("}")
     return "\n".join(lines)
+
+
+def filter_sessions_by_recipe(
+    sessions: Sequence[TurnSequence], recipe: str
+) -> list[TurnSequence]:
+    """Return sessions matching recipe_name == recipe."""
+    result = []
+    for s in sessions:
+        if s.recipe_name == recipe:
+            result.append(s)
+    return result
+
+
+def format_top_bigrams(
+    dfg: DFG, top_n: int, min_count: int
+) -> list[dict[str, object]]:
+    """Return top-N bigrams as a list of dicts for JSON serialization."""
+    result: list[dict[str, object]] = []
+    for (a, b), c in dfg.bigrams.most_common(top_n):
+        if c >= min_count:
+            result.append({"from": a, "to": b, "count": c})
+    return result

--- a/src/autoskillit/core/tool_sequence_analysis.py
+++ b/src/autoskillit/core/tool_sequence_analysis.py
@@ -87,13 +87,13 @@ def parse_sessions_from_summary_dir(log_root: pathlib.Path) -> Iterator[TurnSequ
         try:
             data = json.loads(summary_path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as exc:
-            print(f"[tool_sequence_analysis] skipping {summary_path}: {exc}", file=sys.stderr)
+            sys.stderr.write(f"[tool_sequence_analysis] skipping {summary_path}: {exc}\n")
             continue
         turns = data.get("turn_tool_calls", [])
         if not isinstance(turns, list):
-            print(
-                f"[tool_sequence_analysis] skipping {summary_path}: turn_tool_calls is not a list",
-                file=sys.stderr,
+            sys.stderr.write(
+                f"[tool_sequence_analysis] skipping {summary_path}:"
+                " turn_tool_calls is not a list\n"
             )
             continue
         if not turns:

--- a/src/autoskillit/core/tool_sequence_analysis.py
+++ b/src/autoskillit/core/tool_sequence_analysis.py
@@ -4,9 +4,9 @@ import json
 import pathlib
 import statistics
 from collections import Counter
+from collections.abc import Iterator, Sequence
 from dataclasses import dataclass, field
 from itertools import islice
-from typing import Iterator, Sequence
 
 _TOOL_USE_CAP = 8
 _MAX_NGRAM_LEN = 5
@@ -43,9 +43,7 @@ class AnalysisResult:
     session_count: int
 
 
-def parse_raw_cc_jsonl(
-    jsonl_path: pathlib.Path, *, cap: int = _TOOL_USE_CAP
-) -> list[list[str]]:
+def parse_raw_cc_jsonl(jsonl_path: pathlib.Path, *, cap: int = _TOOL_USE_CAP) -> list[list[str]]:
     """Parse a Claude Code session JSONL into per-turn tool call lists."""
     result: list[list[str]] = []
     seen: set[str] = set()
@@ -191,11 +189,7 @@ def _safe_id(name: str) -> str:
 def render_mermaid(dfg: DFG, *, min_count: int = 1, top_n: int = 30) -> str:
     """Render bigram DFG as Mermaid flowchart LR. Returns the diagram string."""
     lines = ["flowchart LR"]
-    top = [
-        (pair, count)
-        for pair, count in dfg.bigrams.most_common(top_n)
-        if count >= min_count
-    ]
+    top = [(pair, count) for pair, count in dfg.bigrams.most_common(top_n) if count >= min_count]
     if not top:
         lines.append("    empty[No data]")
         return "\n".join(lines)
@@ -232,9 +226,7 @@ def render_dot(dfg: DFG, *, min_count: int = 1, top_n: int = 30) -> str:
     return "\n".join(lines)
 
 
-def filter_sessions_by_recipe(
-    sessions: Sequence[TurnSequence], recipe: str
-) -> list[TurnSequence]:
+def filter_sessions_by_recipe(sessions: Sequence[TurnSequence], recipe: str) -> list[TurnSequence]:
     """Return sessions matching recipe_name == recipe."""
     result = []
     for s in sessions:
@@ -243,9 +235,7 @@ def filter_sessions_by_recipe(
     return result
 
 
-def format_top_bigrams(
-    dfg: DFG, top_n: int, min_count: int
-) -> list[dict[str, object]]:
+def format_top_bigrams(dfg: DFG, top_n: int, min_count: int) -> list[dict[str, object]]:
     """Return top-N bigrams as a list of dicts for JSON serialization."""
     result: list[dict[str, object]] = []
     for (a, b), c in dfg.bigrams.most_common(top_n):

--- a/src/autoskillit/core/tool_sequence_analysis.py
+++ b/src/autoskillit/core/tool_sequence_analysis.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import pathlib
 import statistics
+import sys
 from collections import Counter
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass, field
@@ -85,9 +86,16 @@ def parse_sessions_from_summary_dir(log_root: pathlib.Path) -> Iterator[TurnSequ
     for summary_path in sorted(log_root.glob("sessions/*/summary.json")):
         try:
             data = json.loads(summary_path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"[tool_sequence_analysis] skipping {summary_path}: {exc}", file=sys.stderr)
             continue
         turns = data.get("turn_tool_calls", [])
+        if not isinstance(turns, list):
+            print(
+                f"[tool_sequence_analysis] skipping {summary_path}: turn_tool_calls is not a list",
+                file=sys.stderr,
+            )
+            continue
         if not turns:
             continue
         yield TurnSequence(
@@ -129,6 +137,8 @@ def build_dfg(sessions: Sequence[TurnSequence]) -> DFG:
             for tool in turn:
                 # Check if any prior tool has been waiting for this tool
                 for prev_tool, prev_turn in last_seen.items():
+                    if prev_tool == tool:
+                        continue
                     pair = (prev_tool, tool)
                     gap = turn_idx - prev_turn
                     if gap > 0:
@@ -160,6 +170,8 @@ def compute_analysis(sessions: Sequence[TurnSequence]) -> AnalysisResult:
 
 def compute_gap_stats(gaps: list[int]) -> GapStats:
     """Compute median, p25, p75, max from a list of turn gaps."""
+    if not gaps:
+        return GapStats(0.0, 0.0, 0.0, 0)
     sorted_gaps = sorted(gaps)
     n = len(sorted_gaps)
     median = statistics.median(sorted_gaps)

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -166,6 +166,7 @@ def flush_session_log(
 
     _cb_request_ids: list[str] = []
     _cb_turn_timestamps: list[str] = []
+    _cb_turn_tool_calls: list[list[str]] = []
     if cc_log and cc_log.exists():
         seen_request_ids: set[str] = set()
         try:
@@ -186,6 +187,17 @@ def flush_session_log(
                     _cb_request_ids.append(str(rid))
                     if ts:
                         _cb_turn_timestamps.append(str(ts))
+                    _message = rec.get("message")
+                    _content = _message.get("content", []) if isinstance(_message, dict) else []
+                    _tools = [
+                        str(blk["name"])
+                        for blk in _content
+                        if isinstance(blk, dict)
+                        and blk.get("type") == "tool_use"
+                        and isinstance(blk.get("name"), str)
+                        and blk["name"]
+                    ]
+                    _cb_turn_tool_calls.append(_tools[:8])
         except OSError:
             logger.debug("channel_b_log_read_error", path=cc_log_str, exc_info=True)
 
@@ -316,6 +328,7 @@ def flush_session_log(
         "last_stop_reason": last_stop_reason,
         "request_ids": _cb_request_ids,
         "turn_timestamps": _cb_turn_timestamps,
+        "turn_tool_calls": _cb_turn_tool_calls,
         "campaign_id": campaign_id,
         "dispatch_id": dispatch_id,
     }

--- a/src/autoskillit/execution/tool_sequence_analysis.py
+++ b/src/autoskillit/execution/tool_sequence_analysis.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import json
+import pathlib
+import statistics
+from collections import Counter
+from dataclasses import dataclass, field
+from itertools import islice
+from typing import Iterator, Sequence
+
+_TOOL_USE_CAP = 8
+_MAX_NGRAM_LEN = 5
+
+
+@dataclass
+class TurnSequence:
+    session_id: str
+    recipe_name: str
+    turns: list[list[str]]
+    timestamps: list[str] = field(default_factory=list)
+
+
+@dataclass
+class GapStats:
+    median: float
+    p25: float
+    p75: float
+    maximum: int
+
+
+@dataclass
+class DFG:
+    bigrams: Counter  # type: ignore[type-arg]
+    ngrams: Counter  # type: ignore[type-arg]
+    pair_gaps: dict[tuple[str, str], list[int]]
+    total_turns: int
+
+
+@dataclass
+class AnalysisResult:
+    global_dfg: DFG
+    by_recipe: dict[str, DFG]
+    session_count: int
+
+
+def parse_raw_cc_jsonl(
+    jsonl_path: pathlib.Path, *, cap: int = _TOOL_USE_CAP
+) -> list[list[str]]:
+    """Parse a Claude Code session JSONL into per-turn tool call lists."""
+    result: list[list[str]] = []
+    seen: set[str] = set()
+    try:
+        text = jsonl_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return result
+    for raw_line in text.splitlines():
+        raw_line = raw_line.strip()
+        if not raw_line:
+            continue
+        try:
+            rec = json.loads(raw_line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(rec, dict) or rec.get("type") != "assistant":
+            continue
+        rid = rec.get("requestId", "")
+        if rid and rid in seen:
+            continue
+        if rid:
+            seen.add(rid)
+        message = rec.get("message")
+        content = message.get("content", []) if isinstance(message, dict) else []
+        tools = [
+            str(blk["name"])
+            for blk in content
+            if isinstance(blk, dict)
+            and blk.get("type") == "tool_use"
+            and isinstance(blk.get("name"), str)
+            and blk["name"]
+        ]
+        result.append(tools[:cap])
+    return result
+
+
+def parse_sessions_from_summary_dir(log_root: pathlib.Path) -> Iterator[TurnSequence]:
+    """Scan log_root/sessions/*/summary.json and load TurnSequences."""
+    for summary_path in sorted(log_root.glob("sessions/*/summary.json")):
+        try:
+            data = json.loads(summary_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        turns = data.get("turn_tool_calls", [])
+        if not turns:
+            continue
+        yield TurnSequence(
+            session_id=summary_path.parent.name,
+            recipe_name=data.get("recipe_name", ""),
+            turns=turns,
+            timestamps=data.get("turn_timestamps", []),
+        )
+
+
+def build_dfg(sessions: Sequence[TurnSequence]) -> DFG:
+    """Build bigrams (cross-turn), n-grams (within-turn), and gap analysis."""
+    bigrams: Counter[tuple[str, str]] = Counter()
+    ngrams: Counter[tuple[str, ...]] = Counter()
+    pair_gaps: dict[tuple[str, str], list[int]] = {}
+    total_turns = 0
+
+    for seq in sessions:
+        total_turns += len(seq.turns)
+
+        # Bigrams: across the flattened sequence (including cross-turn)
+        flat: list[str] = []
+        for turn in seq.turns:
+            flat.extend(turn)
+        for i in range(len(flat) - 1):
+            bigrams[(flat[i], flat[i + 1])] += 1
+
+        # N-grams: within each turn (length 2-5)
+        for turn in seq.turns:
+            for length in range(2, _MAX_NGRAM_LEN + 1):
+                for start in range(len(turn) - length + 1):
+                    ngrams[tuple(turn[start : start + length])] += 1
+
+        # Gap analysis: for each (A, B) pair, record turn distance
+        # For each turn i, for each tool A in turn i, find the next turn j > i
+        # where B appears, record j - i.
+        last_seen: dict[str, int] = {}
+        for turn_idx, turn in enumerate(seq.turns):
+            for tool in turn:
+                # Check if any prior tool has been waiting for this tool
+                for prev_tool, prev_turn in last_seen.items():
+                    pair = (prev_tool, tool)
+                    gap = turn_idx - prev_turn
+                    if gap > 0:
+                        pair_gaps.setdefault(pair, []).append(gap)
+            for tool in turn:
+                last_seen[tool] = turn_idx
+
+    return DFG(bigrams=bigrams, ngrams=ngrams, pair_gaps=pair_gaps, total_turns=total_turns)
+
+
+def build_dfg_by_recipe(sessions: Sequence[TurnSequence]) -> dict[str, DFG]:
+    """Return per-recipe DFG keyed by recipe_name (empty string = unrecorded)."""
+    by_recipe: dict[str, list[TurnSequence]] = {}
+    for seq in sessions:
+        by_recipe.setdefault(seq.recipe_name, []).append(seq)
+    return {recipe: build_dfg(seqs) for recipe, seqs in by_recipe.items()}
+
+
+def compute_analysis(sessions: Sequence[TurnSequence]) -> AnalysisResult:
+    """Convenience wrapper: build global + per-recipe DFGs."""
+    global_dfg = build_dfg(sessions)
+    by_recipe = build_dfg_by_recipe(sessions)
+    return AnalysisResult(
+        global_dfg=global_dfg,
+        by_recipe=by_recipe,
+        session_count=len(sessions),
+    )
+
+
+def compute_gap_stats(gaps: list[int]) -> GapStats:
+    """Compute median, p25, p75, max from a list of turn gaps."""
+    sorted_gaps = sorted(gaps)
+    n = len(sorted_gaps)
+    median = statistics.median(sorted_gaps)
+
+    def _percentile(data: list[int], pct: float) -> float:
+        idx = (n - 1) * pct
+        lo = int(idx)
+        hi = lo + 1
+        if hi >= n:
+            return float(data[lo])
+        frac = idx - lo
+        return data[lo] + frac * (data[hi] - data[lo])
+
+    return GapStats(
+        median=float(median),
+        p25=_percentile(sorted_gaps, 0.25),
+        p75=_percentile(sorted_gaps, 0.75),
+        maximum=sorted_gaps[-1],
+    )
+
+
+def _safe_id(name: str) -> str:
+    """Convert a tool name to a Mermaid-safe node ID."""
+    return name.replace("-", "_").replace(".", "_").replace("/", "_").replace(":", "_")
+
+
+def render_mermaid(dfg: DFG, *, min_count: int = 1, top_n: int = 30) -> str:
+    """Render bigram DFG as Mermaid flowchart LR. Returns the diagram string."""
+    lines = ["flowchart LR"]
+    top = [
+        (pair, count)
+        for pair, count in dfg.bigrams.most_common(top_n)
+        if count >= min_count
+    ]
+    if not top:
+        lines.append("    empty[No data]")
+        return "\n".join(lines)
+    for (a, b), count in top:
+        aid = _safe_id(a)
+        bid = _safe_id(b)
+        lines.append(f'    {aid}["{a}"] -->|"{count}"| {bid}["{b}"]')
+    return "\n".join(lines)
+
+
+def render_adjacency_table(dfg: DFG, *, top_n: int = 20) -> str:
+    """Render top-N bigrams as a plain-text ASCII table."""
+    top = list(islice(dfg.bigrams.most_common(top_n), top_n))
+    col_a = max((len(a) for (a, _), _ in top), default=6)
+    col_b = max((len(b) for (_, b), _ in top), default=6)
+    col_a = max(col_a, len("tool_a"))
+    col_b = max(col_b, len("tool_b"))
+    header = f"{'tool_a':<{col_a}}  {'tool_b':<{col_b}}  count"
+    sep = "-" * len(header)
+    rows = [header, sep]
+    for (a, b), count in top:
+        rows.append(f"{a:<{col_a}}  {b:<{col_b}}  {count}")
+    return "\n".join(rows)
+
+
+def render_dot(dfg: DFG, *, min_count: int = 1, top_n: int = 30) -> str:
+    """Render bigram DFG as Graphviz DOT digraph."""
+    lines = ["digraph tool_sequences {", '    rankdir="LR";']
+    for (a, b), count in dfg.bigrams.most_common(top_n):
+        if count < min_count:
+            continue
+        lines.append(f'    "{a}" -> "{b}" [label="{count}"];')
+    lines.append("}")
+    return "\n".join(lines)

--- a/src/autoskillit/hooks/pretty_output_hook.py
+++ b/src/autoskillit/hooks/pretty_output_hook.py
@@ -195,6 +195,7 @@ _UNFORMATTED_TOOLS: frozenset[str] = frozenset(
         "batch_cleanup_clones",  # bulk delete summary dict
         "dispatch_food_truck",  # JSON dispatch envelope, generic renders correctly
         "reload_session",  # simple status dict, generic renders correctly
+        "analyze_tool_sequences",  # DFG analysis result, generic renders correctly
     }
 )
 

--- a/src/autoskillit/server/__init__.py
+++ b/src/autoskillit/server/__init__.py
@@ -1,6 +1,6 @@
 """MCP server for orchestrating automated skill-driven workflows.
 
-Kitchen tools (43 kitchen-tagged: 42 gated + 1 headless-tagged) are hidden at startup
+Kitchen tools (44 kitchen-tagged: 43 gated + 1 headless-tagged) are hidden at startup
 via FastMCP v3 mcp.disable(tags={'kitchen'}) applied once after all tool modules are
 imported. Each new session sees only the 4 free-range tools (open_kitchen, close_kitchen,
 disable_quota_guard, and reload_session).

--- a/src/autoskillit/server/tools_status.py
+++ b/src/autoskillit/server/tools_status.py
@@ -260,6 +260,78 @@ async def get_timing_summary(clear: bool = False, format: str = "json", order_id
         return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
 
 
+@mcp.tool(
+    tags={"autoskillit", "kitchen", "kitchen-core", "telemetry"},
+    annotations={"readOnlyHint": True},
+)
+@track_response_size("analyze_tool_sequences")
+async def analyze_tool_sequences(
+    recipe: str = "",
+    format: str = "table",
+    top_n: int = 20,
+    min_count: int = 1,
+) -> str:
+    """Analyze cross-session tool call sequences and return a DFG summary.
+
+    Args:
+        recipe: Filter to a specific recipe name (empty = all recipes).
+        format: Output format — "table", "mermaid", or "dot".
+        top_n: Limit rendering to top-N bigrams by frequency.
+        min_count: Exclude bigrams with count below this threshold.
+
+    Returns JSON with fields: session_count, recipe_count, top_bigrams,
+    top_ngrams, rendering (the formatted DFG string).
+    Never raises.
+    """
+    if (gate := _require_enabled()) is not None:
+        return gate
+    try:
+        structlog.contextvars.clear_contextvars()
+        with structlog.contextvars.bound_contextvars(tool="analyze_tool_sequences"):
+            from autoskillit.execution.tool_sequence_analysis import (
+                compute_analysis,
+                parse_sessions_from_summary_dir,
+                render_adjacency_table,
+                render_dot,
+                render_mermaid,
+            )
+
+            log_root = _get_log_root()
+            sessions = list(parse_sessions_from_summary_dir(log_root))
+            if recipe:
+                sessions = [s for s in sessions if s.recipe_name == recipe]
+            result = compute_analysis(sessions)
+            dfg = (
+                result.global_dfg
+                if not recipe
+                else result.by_recipe.get(recipe, result.global_dfg)
+            )
+
+            if format == "mermaid":
+                rendering = render_mermaid(dfg, min_count=min_count, top_n=top_n)
+            elif format == "dot":
+                rendering = render_dot(dfg, min_count=min_count, top_n=top_n)
+            else:
+                rendering = render_adjacency_table(dfg, top_n=top_n)
+
+            return json.dumps(
+                {
+                    "success": True,
+                    "session_count": result.session_count,
+                    "recipe_count": len(result.by_recipe),
+                    "top_bigrams": [
+                        {"from": a, "to": b, "count": c}
+                        for (a, b), c in dfg.bigrams.most_common(top_n)
+                        if c >= min_count
+                    ],
+                    "rendering": rendering,
+                }
+            )
+    except Exception as exc:
+        logger.error("analyze_tool_sequences unhandled exception", exc_info=True)
+        return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
+
+
 def _read_quota_events(log_root: Path, n: int) -> tuple[list[dict], int]:
     """Read the last n events from quota_events.jsonl (most recent first).
 

--- a/src/autoskillit/server/tools_status.py
+++ b/src/autoskillit/server/tools_status.py
@@ -280,11 +280,23 @@ async def analyze_tool_sequences(
         min_count: Exclude bigrams with count below this threshold.
 
     Returns JSON with fields: session_count, recipe_count, top_bigrams,
-    top_ngrams, rendering (the formatted DFG string).
+    rendering (the formatted DFG string).
     Never raises.
     """
     if (gate := _require_enabled()) is not None:
         return gate
+    _valid_formats = {"table", "mermaid", "dot"}
+    if format not in _valid_formats:
+        return json.dumps(
+            {
+                "success": False,
+                "error": f"Invalid format '{format}'; must be one of {sorted(_valid_formats)}",
+            }
+        )
+    if top_n < 1:
+        return json.dumps({"success": False, "error": f"top_n must be >= 1, got {top_n}"})
+    if min_count < 1:
+        return json.dumps({"success": False, "error": f"min_count must be >= 1, got {min_count}"})
     try:
         structlog.contextvars.clear_contextvars()
         with structlog.contextvars.bound_contextvars(tool="analyze_tool_sequences"):

--- a/src/autoskillit/server/tools_status.py
+++ b/src/autoskillit/server/tools_status.py
@@ -288,8 +288,10 @@ async def analyze_tool_sequences(
     try:
         structlog.contextvars.clear_contextvars()
         with structlog.contextvars.bound_contextvars(tool="analyze_tool_sequences"):
-            from autoskillit.execution.tool_sequence_analysis import (
+            from autoskillit.core import (
                 compute_analysis,
+                filter_sessions_by_recipe,
+                format_top_bigrams,
                 parse_sessions_from_summary_dir,
                 render_adjacency_table,
                 render_dot,
@@ -299,7 +301,7 @@ async def analyze_tool_sequences(
             log_root = _get_log_root()
             sessions = list(parse_sessions_from_summary_dir(log_root))
             if recipe:
-                sessions = [s for s in sessions if s.recipe_name == recipe]
+                sessions = filter_sessions_by_recipe(sessions, recipe)
             result = compute_analysis(sessions)
             dfg = (
                 result.global_dfg
@@ -319,11 +321,7 @@ async def analyze_tool_sequences(
                     "success": True,
                     "session_count": result.session_count,
                     "recipe_count": len(result.by_recipe),
-                    "top_bigrams": [
-                        {"from": a, "to": b, "count": c}
-                        for (a, b), c in dfg.bigrams.most_common(top_n)
-                        if c >= min_count
-                    ],
+                    "top_bigrams": format_top_bigrams(dfg, top_n, min_count),
                     "rendering": rendering,
                 }
             )

--- a/src/autoskillit/server/tools_status.py
+++ b/src/autoskillit/server/tools_status.py
@@ -285,21 +285,25 @@ async def analyze_tool_sequences(
     """
     if (gate := _require_enabled()) is not None:
         return gate
-    _valid_formats = {"table", "mermaid", "dot"}
-    if format not in _valid_formats:
-        return json.dumps(
-            {
-                "success": False,
-                "error": f"Invalid format '{format}'; must be one of {sorted(_valid_formats)}",
-            }
-        )
-    if top_n < 1:
-        return json.dumps({"success": False, "error": f"top_n must be >= 1, got {top_n}"})
-    if min_count < 1:
-        return json.dumps({"success": False, "error": f"min_count must be >= 1, got {min_count}"})
     try:
         structlog.contextvars.clear_contextvars()
         with structlog.contextvars.bound_contextvars(tool="analyze_tool_sequences"):
+            _valid_formats = {"table", "mermaid", "dot"}
+            if format not in _valid_formats:
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": (
+                            f"Invalid format '{format}'; must be one of {sorted(_valid_formats)}"
+                        ),
+                    }
+                )
+            if top_n < 1:
+                return json.dumps({"success": False, "error": f"top_n must be >= 1, got {top_n}"})
+            if min_count < 1:
+                return json.dumps(
+                    {"success": False, "error": f"min_count must be >= 1, got {min_count}"}
+                )
             from autoskillit.core import (
                 compute_analysis,
                 filter_sessions_by_recipe,

--- a/tests/arch/_rules.py
+++ b/tests/arch/_rules.py
@@ -70,6 +70,7 @@ _PRINT_EXEMPT = frozenset(
         "_doctor.py",
         "_marketplace.py",
         "_prompts.py",
+        "_sessions.py",
         "_workspace.py",
         "branch_protection_guard.py",
         "open_kitchen_guard.py",

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -81,6 +81,7 @@ SINGLETON_ALLOWED_MODULES: frozenset[str] = frozenset(
         "hook_registry",  # hook_registry.py: HOOK_REGISTRY_HASH = compute_registry_hash(...)
         "_fleet",  # cli/_fleet.py: fleet_app = App(name="fleet", ...)
         "_features",  # cli/_features.py: features_app = App(name="features", ...)
+        "_sessions",  # cli/_sessions.py: sessions_app = App(name="sessions", ...)
     }
 )
 _SINGLETON_SAFE_CALL_NAMES: frozenset[str] = frozenset(
@@ -700,7 +701,9 @@ def test_no_subpackage_exceeds_10_files() -> None:
         _features.py adds feature gate inspection subcommand (list/status).
         _session_picker.py adds the scoped session resume picker that filters
         sessions by type (cook/order) using the session registry.
-        Exempt at 25 files.
+        _sessions.py adds the sessions analyze CLI subcommand for cross-session
+        tool call sequence diagnostics.
+        Exempt at 26 files.
       hooks/ — REQ-CNST-003-E6: hooks/ hosts one standalone script per hook event
         (PreToolUse, PostToolUse, SessionStart). Each script must remain a separate
         file so Claude Code can invoke it directly as a subprocess. pretty_output_hook.py
@@ -716,7 +719,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "recipe": 38,
         "execution": 26,
         "core": 25,
-        "cli": 25,
+        "cli": 26,
         "hooks": 24,
     }
     violations: list[str] = []

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -689,7 +689,9 @@ def test_no_subpackage_exceeds_10_files() -> None:
         session_registry.py adds the stdlib-only session registry mapping
         autoskillit launch IDs to Claude Code session UUIDs for the scoped
         resume picker.
-        Exempt at 25 files.
+        tool_sequence_analysis.py adds the stdlib-only cross-session tool call
+        sequence DFG analysis (L0; must live in core/ to be importable by server/).
+        Exempt at 26 files.
       cli/ — REQ-CNST-003-E5: cli/ retains _terminal_table.py as a re-export shim
         for backward-compatible cli/ imports; canonical implementation lives in
         core/_terminal_table.py. Also contains _terminal.py — the terminal state
@@ -718,7 +720,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "server": 20,
         "recipe": 38,
         "execution": 26,
-        "core": 25,
+        "core": 26,
         "cli": 26,
         "hooks": 24,
     }

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -200,9 +200,8 @@ def _count_semantic_rule_files() -> int:
 
 
 def test_kitchen_tagged_tool_count_is_44() -> None:
-    assert _count_kitchen_tools() == 44, (
-        f"Expected 44 kitchen-tagged tools; found {_count_kitchen_tools()}"
-    )
+    count = _count_kitchen_tools()
+    assert count == 44, f"Expected 44 kitchen-tagged tools; found {count}"
 
 
 def test_free_range_tool_count_is_4() -> None:

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -199,9 +199,9 @@ def _count_semantic_rule_files() -> int:
 # ----- tests ------------------------------------------------------------------
 
 
-def test_kitchen_tagged_tool_count_is_43() -> None:
-    assert _count_kitchen_tools() == 43, (
-        f"Expected 43 kitchen-tagged tools; found {_count_kitchen_tools()}"
+def test_kitchen_tagged_tool_count_is_44() -> None:
+    assert _count_kitchen_tools() == 44, (
+        f"Expected 44 kitchen-tagged tools; found {_count_kitchen_tools()}"
     )
 
 
@@ -292,8 +292,8 @@ def _assert_doc_states_number(doc: Path, label: str, expected: int) -> None:
         DOCS_DIR / "execution" / "tool-access.md",
     ],
 )
-def test_docs_state_47_mcp_tools(doc_path: Path) -> None:
-    _assert_doc_states_number(doc_path, "MCP tools", 47)
+def test_docs_state_48_mcp_tools(doc_path: Path) -> None:
+    _assert_doc_states_number(doc_path, "MCP tools", 48)
 
 
 @pytest.mark.parametrize(

--- a/tests/execution/test_session_log.py
+++ b/tests/execution/test_session_log.py
@@ -1207,6 +1207,7 @@ def test_turn_tool_calls_capped_at_8_per_turn(tmp_path, monkeypatch):
     )
     summary = json.loads((tmp_path / "sessions" / "s" / "summary.json").read_text())
     assert len(summary["turn_tool_calls"][0]) == 8
+    assert summary["turn_tool_calls"][0] == [f"Tool{i}" for i in range(8)]
 
 
 def test_turn_tool_calls_empty_for_text_only_turn(tmp_path, monkeypatch):
@@ -1238,12 +1239,6 @@ def test_turn_tool_calls_empty_for_text_only_turn(tmp_path, monkeypatch):
     )
     summary = json.loads((tmp_path / "sessions" / "s" / "summary.json").read_text())
     assert summary["turn_tool_calls"] == [[]]
-
-
-def test_turn_tool_calls_absent_from_older_summary_handled_by_get(tmp_path):
-    # Validates caller contract: .get("turn_tool_calls", []) is safe on old summaries.
-    old_summary = {"session_id": "old", "success": True}
-    assert old_summary.get("turn_tool_calls", []) == []
 
 
 def test_turn_tool_calls_parallel_to_request_ids(tmp_path, monkeypatch):

--- a/tests/execution/test_session_log.py
+++ b/tests/execution/test_session_log.py
@@ -1137,6 +1137,147 @@ def test_flush_session_log_summary_contains_per_turn_fields(tmp_path, monkeypatc
     assert summary["turn_timestamps"] == ["2026-04-15T07:00:00Z", "2026-04-15T07:00:05Z"]
 
 
+# turn_tool_calls
+
+
+def test_flush_session_log_summary_contains_turn_tool_calls(tmp_path, monkeypatch):
+    cb_log = tmp_path / "s.jsonl"
+    cb_log.write_text(
+        json.dumps(
+            {
+                "type": "assistant",
+                "requestId": "req-001",
+                "message": {
+                    "content": [
+                        {"type": "tool_use", "name": "ToolA"},
+                        {"type": "tool_use", "name": "ToolB"},
+                    ]
+                },
+            }
+        )
+        + "\n"
+    )
+    import autoskillit.execution.session_log as sl_mod
+
+    monkeypatch.setattr(sl_mod, "claude_code_log_path", lambda cwd, sid: cb_log)
+
+    flush_session_log(
+        log_dir=str(tmp_path),
+        cwd="/tmp",
+        session_id="s",
+        pid=1,
+        skill_command="test",
+        success=True,
+        subtype="completed",
+        exit_code=0,
+        start_ts="2026-04-15T07:00:00Z",
+        proc_snapshots=None,
+    )
+    summary = json.loads((tmp_path / "sessions" / "s" / "summary.json").read_text())
+    assert summary["turn_tool_calls"] == [["ToolA", "ToolB"]]
+
+
+def test_turn_tool_calls_capped_at_8_per_turn(tmp_path, monkeypatch):
+    tools = [{"type": "tool_use", "name": f"Tool{i}"} for i in range(10)]
+    cb_log = tmp_path / "s.jsonl"
+    cb_log.write_text(
+        json.dumps(
+            {
+                "type": "assistant",
+                "requestId": "req-001",
+                "message": {"content": tools},
+            }
+        )
+        + "\n"
+    )
+    import autoskillit.execution.session_log as sl_mod
+
+    monkeypatch.setattr(sl_mod, "claude_code_log_path", lambda cwd, sid: cb_log)
+    flush_session_log(
+        log_dir=str(tmp_path),
+        cwd="/tmp",
+        session_id="s",
+        pid=1,
+        skill_command="test",
+        success=True,
+        subtype="completed",
+        exit_code=0,
+        start_ts="2026-04-15T07:00:00Z",
+        proc_snapshots=None,
+    )
+    summary = json.loads((tmp_path / "sessions" / "s" / "summary.json").read_text())
+    assert len(summary["turn_tool_calls"][0]) == 8
+
+
+def test_turn_tool_calls_empty_for_text_only_turn(tmp_path, monkeypatch):
+    cb_log = tmp_path / "s.jsonl"
+    cb_log.write_text(
+        json.dumps(
+            {
+                "type": "assistant",
+                "requestId": "req-001",
+                "message": {"content": [{"type": "text", "text": "hello"}]},
+            }
+        )
+        + "\n"
+    )
+    import autoskillit.execution.session_log as sl_mod
+
+    monkeypatch.setattr(sl_mod, "claude_code_log_path", lambda cwd, sid: cb_log)
+    flush_session_log(
+        log_dir=str(tmp_path),
+        cwd="/tmp",
+        session_id="s",
+        pid=1,
+        skill_command="test",
+        success=True,
+        subtype="completed",
+        exit_code=0,
+        start_ts="2026-04-15T07:00:00Z",
+        proc_snapshots=None,
+    )
+    summary = json.loads((tmp_path / "sessions" / "s" / "summary.json").read_text())
+    assert summary["turn_tool_calls"] == [[]]
+
+
+def test_turn_tool_calls_absent_from_older_summary_handled_by_get(tmp_path):
+    # Validates caller contract: .get("turn_tool_calls", []) is safe on old summaries.
+    old_summary = {"session_id": "old", "success": True}
+    assert old_summary.get("turn_tool_calls", []) == []
+
+
+def test_turn_tool_calls_parallel_to_request_ids(tmp_path, monkeypatch):
+    records = [
+        json.dumps(
+            {
+                "type": "assistant",
+                "requestId": f"req-{i}",
+                "message": {"content": [{"type": "tool_use", "name": f"Tool{i}"}]},
+            }
+        )
+        for i in range(3)
+    ]
+    cb_log = tmp_path / "s.jsonl"
+    cb_log.write_text("\n".join(records) + "\n")
+    import autoskillit.execution.session_log as sl_mod
+
+    monkeypatch.setattr(sl_mod, "claude_code_log_path", lambda cwd, sid: cb_log)
+    flush_session_log(
+        log_dir=str(tmp_path),
+        cwd="/tmp",
+        session_id="s",
+        pid=1,
+        skill_command="test",
+        success=True,
+        subtype="completed",
+        exit_code=0,
+        start_ts="2026-04-15T07:00:00Z",
+        proc_snapshots=None,
+    )
+    summary = json.loads((tmp_path / "sessions" / "s" / "summary.json").read_text())
+    assert len(summary["turn_tool_calls"]) == len(summary["request_ids"]) == 3
+
+
 # ---------------------------------------------------------------------------
 # Silent gap, outcome anomaly, and exit snapshot tests
 # ---------------------------------------------------------------------------

--- a/tests/execution/test_tool_sequence_analysis.py
+++ b/tests/execution/test_tool_sequence_analysis.py
@@ -6,10 +6,8 @@ from collections import Counter
 
 import pytest
 
-from autoskillit.execution.tool_sequence_analysis import (
-    AnalysisResult,
+from autoskillit.core.tool_sequence_analysis import (
     DFG,
-    GapStats,
     TurnSequence,
     build_dfg,
     build_dfg_by_recipe,
@@ -72,8 +70,16 @@ class TestParseRawCCJsonl:
 
     def test_skips_records_not_of_type_assistant(self, tmp_path: pathlib.Path) -> None:
         records = [
-            {"type": "user", "requestId": "r1", "message": {"content": [{"type": "tool_use", "name": "X"}]}},
-            {"type": "tool_result", "requestId": "r2", "message": {"content": [{"type": "tool_use", "name": "Y"}]}},
+            {
+                "type": "user",
+                "requestId": "r1",
+                "message": {"content": [{"type": "tool_use", "name": "X"}]},
+            },
+            {
+                "type": "tool_result",
+                "requestId": "r2",
+                "message": {"content": [{"type": "tool_use", "name": "Y"}]},
+            },
         ]
         log = tmp_path / "session.jsonl"
         log.write_text("\n".join(json.dumps(r) for r in records) + "\n")
@@ -104,11 +110,13 @@ class TestParseRawCCJsonl:
         assert result == []
 
     def test_malformed_json_line_skipped(self, tmp_path: pathlib.Path) -> None:
-        good = json.dumps({
-            "type": "assistant",
-            "requestId": "r1",
-            "message": {"content": [{"type": "tool_use", "name": "GoodTool"}]},
-        })
+        good = json.dumps(
+            {
+                "type": "assistant",
+                "requestId": "r1",
+                "message": {"content": [{"type": "tool_use", "name": "GoodTool"}]},
+            }
+        )
         log = tmp_path / "session.jsonl"
         log.write_text("NOT_JSON\n" + good + "\n")
         result = parse_raw_cc_jsonl(log)
@@ -184,7 +192,8 @@ class TestBuildDFGByRecipe:
     def test_global_aggregate_includes_all_sessions(self) -> None:
         s1 = TurnSequence(session_id="s1", recipe_name="lint", turns=[["A", "B"]])
         s2 = TurnSequence(session_id="s2", recipe_name="review", turns=[["C", "D"]])
-        from autoskillit.execution.tool_sequence_analysis import compute_analysis
+        from autoskillit.core.tool_sequence_analysis import compute_analysis
+
         result = compute_analysis([s1, s2])
         assert ("A", "B") in result.global_dfg.bigrams
         assert ("C", "D") in result.global_dfg.bigrams
@@ -255,7 +264,7 @@ class TestRenderAdjacencyTable:
         dfg = self._make_dfg(bigrams)
         output = render_adjacency_table(dfg, top_n=3)
         # header + sep + 3 data rows = 5 lines
-        data_lines = [l for l in output.splitlines() if l and not l.startswith("-")]
+        data_lines = [line for line in output.splitlines() if line and not line.startswith("-")]
         # subtract 1 for header
         assert len(data_lines) - 1 <= 3
 

--- a/tests/execution/test_tool_sequence_analysis.py
+++ b/tests/execution/test_tool_sequence_analysis.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import json
+import pathlib
+from collections import Counter
+
+import pytest
+
+from autoskillit.execution.tool_sequence_analysis import (
+    AnalysisResult,
+    DFG,
+    GapStats,
+    TurnSequence,
+    build_dfg,
+    build_dfg_by_recipe,
+    compute_gap_stats,
+    parse_raw_cc_jsonl,
+    parse_sessions_from_summary_dir,
+    render_adjacency_table,
+    render_dot,
+    render_mermaid,
+)
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.medium]
+
+
+# ---------------------------------------------------------------------------
+# TestParseRawCCJsonl
+# ---------------------------------------------------------------------------
+
+
+class TestParseRawCCJsonl:
+    def test_extracts_tool_names_from_assistant_content(self, tmp_path: pathlib.Path) -> None:
+        record = {
+            "type": "assistant",
+            "requestId": "r1",
+            "message": {
+                "content": [
+                    {"type": "text", "text": "hello"},
+                    {"type": "tool_use", "name": "ToolA"},
+                    {"type": "tool_use", "name": "ToolB"},
+                ]
+            },
+        }
+        log = tmp_path / "session.jsonl"
+        log.write_text(json.dumps(record) + "\n")
+        result = parse_raw_cc_jsonl(log)
+        assert result == [["ToolA", "ToolB"]]
+
+    def test_deduplicates_same_request_id(self, tmp_path: pathlib.Path) -> None:
+        record = {
+            "type": "assistant",
+            "requestId": "dup",
+            "message": {"content": [{"type": "tool_use", "name": "ToolA"}]},
+        }
+        log = tmp_path / "session.jsonl"
+        log.write_text(json.dumps(record) + "\n" + json.dumps(record) + "\n")
+        result = parse_raw_cc_jsonl(log)
+        assert len(result) == 1
+
+    def test_cap_applied_at_n_8(self, tmp_path: pathlib.Path) -> None:
+        tools = [{"type": "tool_use", "name": f"Tool{i}"} for i in range(12)]
+        record = {
+            "type": "assistant",
+            "requestId": "r1",
+            "message": {"content": tools},
+        }
+        log = tmp_path / "session.jsonl"
+        log.write_text(json.dumps(record) + "\n")
+        result = parse_raw_cc_jsonl(log)
+        assert len(result[0]) == 8
+
+    def test_skips_records_not_of_type_assistant(self, tmp_path: pathlib.Path) -> None:
+        records = [
+            {"type": "user", "requestId": "r1", "message": {"content": [{"type": "tool_use", "name": "X"}]}},
+            {"type": "tool_result", "requestId": "r2", "message": {"content": [{"type": "tool_use", "name": "Y"}]}},
+        ]
+        log = tmp_path / "session.jsonl"
+        log.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+        result = parse_raw_cc_jsonl(log)
+        assert result == []
+
+    def test_skips_tool_use_blocks_with_empty_name(self, tmp_path: pathlib.Path) -> None:
+        record = {
+            "type": "assistant",
+            "requestId": "r1",
+            "message": {
+                "content": [
+                    {"type": "tool_use", "name": ""},
+                    {"type": "tool_use"},
+                    {"type": "tool_use", "name": "ValidTool"},
+                ]
+            },
+        }
+        log = tmp_path / "session.jsonl"
+        log.write_text(json.dumps(record) + "\n")
+        result = parse_raw_cc_jsonl(log)
+        assert result == [["ValidTool"]]
+
+    def test_empty_jsonl_returns_empty_list(self, tmp_path: pathlib.Path) -> None:
+        log = tmp_path / "session.jsonl"
+        log.write_text("")
+        result = parse_raw_cc_jsonl(log)
+        assert result == []
+
+    def test_malformed_json_line_skipped(self, tmp_path: pathlib.Path) -> None:
+        good = json.dumps({
+            "type": "assistant",
+            "requestId": "r1",
+            "message": {"content": [{"type": "tool_use", "name": "GoodTool"}]},
+        })
+        log = tmp_path / "session.jsonl"
+        log.write_text("NOT_JSON\n" + good + "\n")
+        result = parse_raw_cc_jsonl(log)
+        assert result == [["GoodTool"]]
+
+    def test_message_field_absent_returns_empty_turn(self, tmp_path: pathlib.Path) -> None:
+        record = {"type": "assistant", "requestId": "r1"}
+        log = tmp_path / "session.jsonl"
+        log.write_text(json.dumps(record) + "\n")
+        result = parse_raw_cc_jsonl(log)
+        assert result == [[]]
+
+
+# ---------------------------------------------------------------------------
+# TestBuildDFG
+# ---------------------------------------------------------------------------
+
+
+class TestBuildDFG:
+    def _make_seq(self, turns: list[list[str]], recipe: str = "") -> TurnSequence:
+        return TurnSequence(session_id="s1", recipe_name=recipe, turns=turns)
+
+    def test_bigram_counts_across_turns(self) -> None:
+        sessions = [self._make_seq([["A", "B"], ["B", "C"]])]
+        dfg = build_dfg(sessions)
+        assert dfg.bigrams[("A", "B")] == 1
+        assert dfg.bigrams[("B", "B")] == 1
+        assert dfg.bigrams[("B", "C")] == 1
+
+    def test_ngrams_mined_within_single_turn(self) -> None:
+        sessions = [self._make_seq([["A", "B", "C"]])]
+        dfg = build_dfg(sessions)
+        assert ("A", "B") in dfg.ngrams
+        assert ("B", "C") in dfg.ngrams
+        assert ("A", "B", "C") in dfg.ngrams
+
+    def test_ngrams_max_length_5(self) -> None:
+        sessions = [self._make_seq([["A", "B", "C", "D", "E", "F"]])]
+        dfg = build_dfg(sessions)
+        for key in dfg.ngrams:
+            assert len(key) <= 5
+
+    def test_gap_analysis_correct_turn_distance(self) -> None:
+        sessions = [self._make_seq([["A"], [], [], ["B"]])]
+        dfg = build_dfg(sessions)
+        assert ("A", "B") in dfg.pair_gaps
+        assert 3 in dfg.pair_gaps[("A", "B")]
+
+    def test_gap_analysis_multiple_sessions_aggregated(self) -> None:
+        s1 = TurnSequence(session_id="s1", recipe_name="", turns=[["A"], [], ["B"]])
+        s2 = TurnSequence(session_id="s2", recipe_name="", turns=[["A"], [], ["B"]])
+        dfg = build_dfg([s1, s2])
+        assert dfg.pair_gaps[("A", "B")] == [2, 2]
+
+    def test_empty_sessions_list_returns_zero_dfg(self) -> None:
+        dfg = build_dfg([])
+        assert len(dfg.bigrams) == 0
+        assert len(dfg.ngrams) == 0
+        assert len(dfg.pair_gaps) == 0
+        assert dfg.total_turns == 0
+
+
+class TestBuildDFGByRecipe:
+    def test_stratification_separates_recipes(self) -> None:
+        s1 = TurnSequence(session_id="s1", recipe_name="lint", turns=[["A", "B"]])
+        s2 = TurnSequence(session_id="s2", recipe_name="review", turns=[["C", "D"]])
+        result = build_dfg_by_recipe([s1, s2])
+        assert "lint" in result
+        assert "review" in result
+        assert ("A", "B") in result["lint"].bigrams
+        assert ("A", "B") not in result["review"].bigrams
+
+    def test_global_aggregate_includes_all_sessions(self) -> None:
+        s1 = TurnSequence(session_id="s1", recipe_name="lint", turns=[["A", "B"]])
+        s2 = TurnSequence(session_id="s2", recipe_name="review", turns=[["C", "D"]])
+        from autoskillit.execution.tool_sequence_analysis import compute_analysis
+        result = compute_analysis([s1, s2])
+        assert ("A", "B") in result.global_dfg.bigrams
+        assert ("C", "D") in result.global_dfg.bigrams
+
+
+class TestComputeGapStats:
+    def test_median_and_percentiles_correct(self) -> None:
+        stats = compute_gap_stats([1, 2, 3, 4, 5])
+        assert stats.median == 3.0
+        assert stats.p25 == 2.0
+        assert stats.p75 == 4.0
+        assert stats.maximum == 5
+
+    def test_single_gap_all_stats_equal(self) -> None:
+        stats = compute_gap_stats([7])
+        assert stats.median == 7.0
+        assert stats.p25 == 7.0
+        assert stats.p75 == 7.0
+        assert stats.maximum == 7
+
+
+# ---------------------------------------------------------------------------
+# TestRenderMermaid
+# ---------------------------------------------------------------------------
+
+
+class TestRenderMermaid:
+    def _make_dfg(self, bigrams: dict[tuple[str, str], int]) -> DFG:
+        return DFG(bigrams=Counter(bigrams), ngrams=Counter(), pair_gaps={}, total_turns=1)
+
+    def test_output_starts_with_flowchart_lr(self) -> None:
+        dfg = self._make_dfg({("A", "B"): 1})
+        output = render_mermaid(dfg)
+        first_line = output.splitlines()[0]
+        assert first_line.startswith("flowchart LR")
+
+    def test_bigram_edges_present_in_output(self) -> None:
+        dfg = self._make_dfg({("A", "B"): 5})
+        output = render_mermaid(dfg)
+        assert "A" in output
+        assert "B" in output
+        assert "5" in output
+
+    def test_empty_dfg_renders_without_error(self) -> None:
+        dfg = DFG(bigrams=Counter(), ngrams=Counter(), pair_gaps={}, total_turns=0)
+        output = render_mermaid(dfg)
+        assert len(output) > 0
+
+
+# ---------------------------------------------------------------------------
+# TestRenderAdjacencyTable
+# ---------------------------------------------------------------------------
+
+
+class TestRenderAdjacencyTable:
+    def _make_dfg(self, bigrams: dict[tuple[str, str], int]) -> DFG:
+        return DFG(bigrams=Counter(bigrams), ngrams=Counter(), pair_gaps={}, total_turns=1)
+
+    def test_table_has_header_row(self) -> None:
+        dfg = self._make_dfg({("A", "B"): 1})
+        output = render_adjacency_table(dfg)
+        lower = output.lower()
+        assert "tool_a" in lower
+        assert "tool_b" in lower
+
+    def test_top_n_limits_rows(self) -> None:
+        bigrams = {(f"A{i}", f"B{i}"): i for i in range(10, 0, -1)}
+        dfg = self._make_dfg(bigrams)
+        output = render_adjacency_table(dfg, top_n=3)
+        # header + sep + 3 data rows = 5 lines
+        data_lines = [l for l in output.splitlines() if l and not l.startswith("-")]
+        # subtract 1 for header
+        assert len(data_lines) - 1 <= 3
+
+
+# ---------------------------------------------------------------------------
+# TestRenderDot
+# ---------------------------------------------------------------------------
+
+
+class TestRenderDot:
+    def _make_dfg(self, bigrams: dict[tuple[str, str], int]) -> DFG:
+        return DFG(bigrams=Counter(bigrams), ngrams=Counter(), pair_gaps={}, total_turns=1)
+
+    def test_dot_output_starts_with_digraph(self) -> None:
+        dfg = self._make_dfg({("A", "B"): 1})
+        output = render_dot(dfg)
+        assert output.startswith("digraph")
+
+    def test_dot_edge_correct_format(self) -> None:
+        dfg = self._make_dfg({("A", "B"): 3})
+        output = render_dot(dfg)
+        assert '"A" -> "B"' in output
+        assert "3" in output
+
+
+# ---------------------------------------------------------------------------
+# TestParseSessionsFromSummaryDir
+# ---------------------------------------------------------------------------
+
+
+class TestParseSessionsFromSummaryDir:
+    def test_yields_turn_sequences_from_summary_json(self, tmp_path: pathlib.Path) -> None:
+        session_dir = tmp_path / "sessions" / "abc123"
+        session_dir.mkdir(parents=True)
+        summary = {
+            "turn_tool_calls": [["ToolA", "ToolB"], ["ToolC"]],
+            "recipe_name": "test-recipe",
+            "turn_timestamps": ["2026-01-01T00:00:00Z", "2026-01-01T00:00:01Z"],
+        }
+        (session_dir / "summary.json").write_text(json.dumps(summary))
+        sessions = list(parse_sessions_from_summary_dir(tmp_path))
+        assert len(sessions) == 1
+        assert sessions[0].session_id == "abc123"
+        assert sessions[0].recipe_name == "test-recipe"
+        assert sessions[0].turns == [["ToolA", "ToolB"], ["ToolC"]]
+
+    def test_skips_summary_without_turn_tool_calls(self, tmp_path: pathlib.Path) -> None:
+        session_dir = tmp_path / "sessions" / "old"
+        session_dir.mkdir(parents=True)
+        (session_dir / "summary.json").write_text(json.dumps({"recipe_name": "r"}))
+        sessions = list(parse_sessions_from_summary_dir(tmp_path))
+        assert sessions == []
+
+    def test_skips_malformed_summary_json(self, tmp_path: pathlib.Path) -> None:
+        session_dir = tmp_path / "sessions" / "bad"
+        session_dir.mkdir(parents=True)
+        (session_dir / "summary.json").write_text("NOT_JSON")
+        sessions = list(parse_sessions_from_summary_dir(tmp_path))
+        assert sessions == []

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -130,7 +130,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/server/tools_kitchen.py", 123),
     ("src/autoskillit/server/tools_kitchen.py", 519),
     # tools_status.py — mcp_data dict
-    ("src/autoskillit/server/tools_status.py", 470),
+    ("src/autoskillit/server/tools_status.py", 486),
     # tools_github.py — bug report dict
     ("src/autoskillit/server/tools_github.py", 276),
     # _hooks.py — settings.json dict (co-owned with Claude CLI)

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -111,10 +111,10 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # core/io.py — write_versioned_json itself (the blessed helper) uses atomic_write+json.dumps
     ("src/autoskillit/core/io.py", 118),
     # session_log.py — summary dict, meta.json sidecar, token_usage dict, step_timing dict
-    ("src/autoskillit/execution/session_log.py", 337),
-    ("src/autoskillit/execution/session_log.py", 341),
-    ("src/autoskillit/execution/session_log.py", 363),
-    ("src/autoskillit/execution/session_log.py", 366),
+    ("src/autoskillit/execution/session_log.py", 350),
+    ("src/autoskillit/execution/session_log.py", 354),
+    ("src/autoskillit/execution/session_log.py", 376),
+    ("src/autoskillit/execution/session_log.py", 379),
     # migration/store.py — failure store dicts
     ("src/autoskillit/migration/store.py", 54),
     ("src/autoskillit/migration/store.py", 64),
@@ -130,7 +130,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/server/tools_kitchen.py", 123),
     ("src/autoskillit/server/tools_kitchen.py", 519),
     # tools_status.py — mcp_data dict
-    ("src/autoskillit/server/tools_status.py", 400),
+    ("src/autoskillit/server/tools_status.py", 470),
     # tools_github.py — bug report dict
     ("src/autoskillit/server/tools_github.py", 276),
     # _hooks.py — settings.json dict (co-owned with Claude CLI)

--- a/tests/pipeline/test_gate.py
+++ b/tests/pipeline/test_gate.py
@@ -52,6 +52,7 @@ def test_gated_tools_contains_expected_names():
         "register_clone_status",
         "batch_cleanup_clones",
         "dispatch_food_truck",
+        "analyze_tool_sequences",
     }
     assert GATED_TOOLS == expected
 

--- a/tests/server/test_server_tool_registration.py
+++ b/tests/server/test_server_tool_registration.py
@@ -92,6 +92,7 @@ class TestToolRegistration:
             "batch_cleanup_clones",
             "dispatch_food_truck",
             "reload_session",
+            "analyze_tool_sequences",
         }
         assert expected == tool_names
 


### PR DESCRIPTION
## Summary

This PR implements cross-session tool call sequence diagnostics for AutoSkillit. A new stdlib-only L0 module `tool_sequence_analysis.py` parses Claude Code JSONL records, builds bigram/n-gram Data Flow Graphs, computes gap statistics, stratifies results by recipe, and renders output as Mermaid flowcharts, adjacency tables, or Graphviz DOT. `flush_session_log()` is extended to extract per-turn tool call lists from the Claude Code JSONL during session flushing, persisting `turn_tool_calls: list[list[str]]` in `summary.json` alongside the existing `turn_timestamps` and `request_ids` fields. Exposure is via a new `autoskillit sessions analyze` CLI subcommand and a new kitchen-gated MCP tool `analyze_tool_sequences` added to `tools_status.py`.

## Architecture Impact

### Data Lineage Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph Origins ["Data Origins"]
        direction TB
        CC_JSONL["Claude Code Session JSONL<br/>━━━━━━━━━━<br/>~/.config/Claude/projects/<br/>.../{session_uuid}.jsonl<br/>(type=assistant, tool_use blocks)"]
        SHM["Linux /dev/shm<br/>━━━━━━━━━━<br/>autoskillit_trace_{pid}.jsonl<br/>autoskillit_enrollment_{pid}.json<br/>(proc snapshots, boot identity)"]
        CLI_IN["★ CLI: sessions analyze<br/>━━━━━━━━━━<br/>--recipe --format --top<br/>--min-count --output"]
        MCP_IN["MCP Tool Call<br/>━━━━━━━━━━<br/>analyze_tool_sequences<br/>recipe, format, top_n, min_count"]
    end

    subgraph SessionLogLayer ["● session_log.py — Extraction & Persistence"]
        direction TB
        EXTRACT["● flush_session_log()<br/>━━━━━━━━━━<br/>parse requestId-deduped<br/>tool_use blocks<br/>→ turn_tool_calls (cap=8/turn)<br/>→ turn_timestamps<br/>→ request_ids"]
        PROC_AGG["proc snapshot aggregation<br/>━━━━━━━━━━<br/>peak_rss_kb, peak_oom_score<br/>peak_fd_ratio, tracked_comm<br/>anomaly detection"]
    end

    subgraph LogStore ["Primary Storage — {log_root}/sessions/{session_id}/"]
        direction TB
        SUMMARY[("★ summary.json<br/>━━━━━━━━━━<br/>turn_tool_calls ← NEW<br/>turn_timestamps ← NEW<br/>recipe_name, session_id<br/>success, subtype, exit_code")]
        SESSIONS_IDX[("● sessions.jsonl<br/>━━━━━━━━━━<br/>append-only index<br/>recipe_name, recipe_content_hash<br/>turn_tool_calls absent here")]
        PROC_TRACE[("proc_trace.jsonl<br/>━━━━━━━━━━<br/>per-snapshot JSONL<br/>vm_rss_kb, fd_count, event")]
        OTHER["write-only artifacts<br/>━━━━━━━━━━<br/>anomalies.jsonl<br/>meta.json, raw_stdout.jsonl<br/>token_usage.json, step_timing.json<br/>crash_exception.txt, audit_log.json"]
    end

    subgraph DFGLayer ["★ tool_sequence_analysis.py — DFG Construction"]
        direction TB
        PARSER["★ parse_sessions_from_summary_dir()<br/>━━━━━━━━━━<br/>reads turn_tool_calls + recipe_name<br/>yields TurnSequence objects"]
        BUILD["★ build_dfg()<br/>━━━━━━━━━━<br/>bigrams (cross-turn Counter)<br/>ngrams (within-turn, len 2-5)<br/>pair_gaps (turn-delta dict)"]
        ANALYSIS["★ compute_analysis()<br/>━━━━━━━━━━<br/>global_dfg + by_recipe dict<br/>session_count"]
    end

    subgraph RenderLayer ["★ Rendering — in-memory string transforms"]
        direction TB
        RENDER["★ render_mermaid() / render_dot()<br/>render_adjacency_table()<br/>━━━━━━━━━━<br/>top-N bigrams filtered by min_count<br/>format: Mermaid LR / DOT digraph / ASCII"]
        BIGRAMS["★ format_top_bigrams()<br/>━━━━━━━━━━<br/>list[dict{from, to, count}]<br/>for MCP JSON envelope"]
    end

    subgraph CLIOutput ["★ _sessions.py — sessions analyze CLI"]
        direction TB
        STDOUT_OUT["stdout<br/>━━━━━━━━━━<br/>rendered string<br/>(table / mermaid / dot)"]
        FILE_OUT["atomic_write(output)<br/>━━━━━━━━━━<br/>optional --output file<br/>rendered string"]
        STDERR_OUT["stderr<br/>━━━━━━━━━━<br/>N sessions | M recipe(s)"]
    end

    subgraph MCPOutput ["● analyze_tool_sequences — MCP Tool (tools_status.py)"]
        direction TB
        MCP_JSON["● JSON response envelope<br/>━━━━━━━━━━<br/>{success, session_count<br/>recipe_count, top_bigrams<br/>rendering}"]
        HOOK["● pretty_output_hook.py<br/>━━━━━━━━━━<br/>MCP JSON → Markdown-KV<br/>reformatter for display"]
    end

    %% PRIMARY DATA FLOWS %%
    CC_JSONL -->|"parse assistant turns<br/>requestId dedup"| EXTRACT
    SHM -->|"proc snapshots<br/>crash recovery"| PROC_AGG
    EXTRACT -->|"turn_tool_calls<br/>turn_timestamps"| SUMMARY
    PROC_AGG -->|"peak metrics<br/>anomalies"| PROC_TRACE
    EXTRACT -->|"recipe_name<br/>session metadata"| SESSIONS_IDX
    EXTRACT -.->|"write-only"| OTHER

    SUMMARY -->|"read all sessions/*/<br/>summary.json"| PARSER
    PARSER -->|"list[TurnSequence]"| BUILD
    BUILD -->|"DFG{bigrams,ngrams,pair_gaps}"| ANALYSIS

    CLI_IN -->|"--recipe filter<br/>--format --top"| ANALYSIS
    ANALYSIS -->|"global_dfg or by_recipe DFG"| RENDER
    RENDER -->|"rendered string"| STDOUT_OUT
    RENDER -->|"rendered string"| FILE_OUT
    RENDER -.->|"session count"| STDERR_OUT

    MCP_IN -->|"recipe filter<br/>format, top_n"| ANALYSIS
    ANALYSIS -->|"DFG"| BIGRAMS
    BIGRAMS -->|"top_bigrams list"| MCP_JSON
    RENDER -->|"rendering string"| MCP_JSON
    MCP_JSON -->|"hook intercepts<br/>tool output"| HOOK

    %% CLASS ASSIGNMENTS %%
    class CC_JSONL,SHM integration;
    class CLI_IN,MCP_IN cli;
    class EXTRACT,PROC_AGG handler;
    class SUMMARY,SESSIONS_IDX,PROC_TRACE stateNode;
    class OTHER output;
    class PARSER,BUILD,ANALYSIS,RENDER,BIGRAMS newComponent;
    class STDOUT_OUT,FILE_OUT,STDERR_OUT output;
    class MCP_JSON,HOOK phase;
```

Closes #1255

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260426-013706-542672/.autoskillit/temp/make-plan/tool_call_sequence_diagnostics_plan_2026-04-26_000100.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 139 | 20.3k | 613.1k | 56.4k | 1 | 8m 30s |
| verify | 2.1k | 8.1k | 567.5k | 38.5k | 1 | 4m 10s |
| implement | 416 | 28.3k | 3.4M | 93.3k | 1 | 8m 32s |
| fix | 840 | 52.0k | 11.2M | 149.1k | 1 | 29m 57s |
| prepare_pr | 60 | 6.5k | 217.5k | 32.1k | 1 | 1m 56s |
| run_arch_lenses | 3.3k | 7.2k | 170.0k | 61.0k | 1 | 3m 17s |
| compose_pr | 59 | 4.3k | 187.3k | 23.0k | 1 | 1m 36s |
| **Total** | 6.9k | 126.5k | 16.4M | 453.5k | | 58m 1s |