### PR TITLE
Implementation Plan: Feature Flag Lifecycle — EXPERIMENTAL on by Default, DISABLED State, Test Marker Parity

### DIFF
--- a/.autoskillit/config.yaml
+++ b/.autoskillit/config.yaml
@@ -31,5 +31,3 @@ ci:
 github:
   default_repo: "TalonT-Org/AutoSkillit"
 
-features:
-  fleet: true  # Enable fleet on integration for active development

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -379,3 +379,35 @@ as their CI passes.
 **Location:** GitHub → Repository Settings → Branches → Branch protection rules →
 select the integration ruleset → Merge queue → "Minimum entries to merge — wait X minutes".
 Set to `0`.
+
+## Feature Flags
+
+Features are gated by lifecycle state. The `features:` config section and
+`AUTOSKILLIT_FEATURES__*` env vars let you override individual features.
+
+### Lifecycle States
+
+| Lifecycle | Behavior | Can Override? |
+|-----------|----------|---------------|
+| STABLE | On everywhere | Yes — opt out via `features: {name: false}` |
+| EXPERIMENTAL | On when `experimental_enabled: true` (default on integration; off on main) | Yes — per-feature entry overrides blanket |
+| DEPRECATED | Follows `default_enabled`; may be removed without warning | Yes |
+| DISABLED | Always off; cannot be enabled | No — config entry setting `true` is rejected |
+
+### Blanket Toggle
+
+`experimental_enabled: true` in `defaults.yaml` means all `EXPERIMENTAL` features are
+active on integration, worktrees, and feature branches without any per-feature config.
+
+Main and stable branches commit `features: {experimental_enabled: false}` to opt out.
+
+### Per-Feature Override
+
+Any config layer can override an individual feature regardless of the blanket toggle:
+
+```yaml
+features:
+  planner: false    # disable planner even on integration
+```
+
+Env var takes highest priority: `AUTOSKILLIT_FEATURES__PLANNER=false`.

--- a/src/autoskillit/cli/_cook.py
+++ b/src/autoskillit/cli/_cook.py
@@ -66,7 +66,9 @@ def cook(*, resume: bool = False, session_id: str | None = None) -> None:
 
     print(f"{_B}{_C}AUTOSKILLIT {__version__}{_R} {_D}Kitchen open. All tools active.{_R}")
     skip = {"Telemetry & Diagnostics", "Kitchen"}
-    for name, tools in iter_display_categories(config.features):
+    for name, tools in iter_display_categories(
+        config.features, experimental_enabled=config.experimental_enabled
+    ):
         if name in skip:
             continue
         tool_list = f"{_D}, {_R}".join(f"{_G}{t}{_R}" for t in tools)

--- a/src/autoskillit/cli/_doctor.py
+++ b/src/autoskillit/cli/_doctor.py
@@ -1205,7 +1205,7 @@ def run_doctor(*, output_json: bool = False) -> None:
     results.append(_check_feature_registry_consistency())
 
     # Checks 24–28: Fleet infrastructure — only when fleet feature is enabled
-    if is_feature_enabled("fleet", cfg.features):
+    if is_feature_enabled("fleet", cfg.features, experimental_enabled=cfg.experimental_enabled):
         # Check 24: Sous-chef skill directory exists
         results.append(_check_sous_chef_bundled())
 

--- a/src/autoskillit/cli/_features.py
+++ b/src/autoskillit/cli/_features.py
@@ -20,6 +20,7 @@ def features_list() -> None:
         _render_terminal_table,
         is_feature_enabled,
     )
+    from autoskillit.core._type_enums import FeatureLifecycle
 
     cfg = load_config(Path.cwd())
 
@@ -28,21 +29,38 @@ def features_list() -> None:
         TerminalColumn("TIER", 5, ">"),
         TerminalColumn("LIFECYCLE", 14, "<"),
         TerminalColumn("DEFAULT", 9, "<"),
-        TerminalColumn("EFFECTIVE", 10, "<"),
-        TerminalColumn("SOURCE", 10, "<"),
+        TerminalColumn("EFFECTIVE", 18, "<"),
+        TerminalColumn("SOURCE", 14, "<"),
     ]
 
     rows = []
     for name, defn in sorted(FEATURE_REGISTRY.items()):
-        effective = is_feature_enabled(name, cfg.features)
-        source = "config" if name in cfg.features else "default"
+        effective = is_feature_enabled(
+            name, cfg.features, experimental_enabled=cfg.experimental_enabled
+        )
+        if (
+            defn.lifecycle == FeatureLifecycle.EXPERIMENTAL
+            and effective
+            and name not in cfg.features
+        ):
+            effective_str = "on (experimental)"
+            source = "experimental"
+        elif name in cfg.features and not effective:
+            effective_str = "off (override)"
+            source = "config"
+        elif name in cfg.features:
+            effective_str = str(effective).lower()
+            source = "config"
+        else:
+            effective_str = str(effective).lower()
+            source = "default"
         rows.append(
             (
                 name,
                 str(defn.tier),
                 str(defn.lifecycle),
                 str(defn.default_enabled).lower(),
-                str(effective).lower(),
+                effective_str,
                 source,
             )
         )
@@ -55,6 +73,7 @@ def features_status(name: str) -> None:
     """Show detailed state for a single feature."""
     from autoskillit.config import load_config
     from autoskillit.core import FEATURE_REGISTRY, is_feature_enabled
+    from autoskillit.core._type_enums import FeatureLifecycle
 
     if name not in FEATURE_REGISTRY:
         known = sorted(FEATURE_REGISTRY.keys())
@@ -66,9 +85,16 @@ def features_status(name: str) -> None:
 
     defn = FEATURE_REGISTRY[name]
     cfg = load_config(Path.cwd())
-    effective = is_feature_enabled(name, cfg.features)
+    effective = is_feature_enabled(
+        name, cfg.features, experimental_enabled=cfg.experimental_enabled
+    )
 
-    source = "overridden by config" if name in cfg.features else "default"
+    if defn.lifecycle == FeatureLifecycle.EXPERIMENTAL and effective and name not in cfg.features:
+        source = "on by experimental_enabled blanket"
+    elif name in cfg.features:
+        source = "overridden by config"
+    else:
+        source = "default"
     enabled_str = f"{'true' if effective else 'false'} ({source})"
 
     tool_tags = ", ".join(sorted(defn.tool_tags)) if defn.tool_tags else "(none)"

--- a/src/autoskillit/cli/_features.py
+++ b/src/autoskillit/cli/_features.py
@@ -16,11 +16,11 @@ def features_list() -> None:
     from autoskillit.config import load_config
     from autoskillit.core import (
         FEATURE_REGISTRY,
+        FeatureLifecycle,
         TerminalColumn,
         _render_terminal_table,
         is_feature_enabled,
     )
-    from autoskillit.core._type_enums import FeatureLifecycle
 
     cfg = load_config(Path.cwd())
 
@@ -72,8 +72,7 @@ def features_list() -> None:
 def features_status(name: str) -> None:
     """Show detailed state for a single feature."""
     from autoskillit.config import load_config
-    from autoskillit.core import FEATURE_REGISTRY, is_feature_enabled
-    from autoskillit.core._type_enums import FeatureLifecycle
+    from autoskillit.core import FEATURE_REGISTRY, FeatureLifecycle, is_feature_enabled
 
     if name not in FEATURE_REGISTRY:
         known = sorted(FEATURE_REGISTRY.keys())

--- a/src/autoskillit/cli/_fleet.py
+++ b/src/autoskillit/cli/_fleet.py
@@ -29,10 +29,12 @@ _log = get_logger(__name__)
 
 def _require_fleet(cfg: AutomationConfig) -> None:
     """Exit with clear message if fleet feature is not enabled."""
-    if not is_feature_enabled("fleet", cfg.features):
+    if not is_feature_enabled(
+        "fleet", cfg.features, experimental_enabled=cfg.experimental_enabled
+    ):
         print(
             "The 'fleet' feature is not enabled.\n"
-            "Enable it with: features.fleet: true in your config\n"
+            "Enable it with: features.experimental_enabled: true in your config\n"
             "Or set: AUTOSKILLIT_FEATURES__FLEET=true",
             file=sys.stderr,
         )

--- a/src/autoskillit/config/defaults.yaml
+++ b/src/autoskillit/config/defaults.yaml
@@ -268,5 +268,4 @@ fleet:
   default_timeout_sec: 3600
 
 features:
-  fleet: false  # Disabled by default; enabled via project config on integration
-  planner: false  # EXPERIMENTAL — off by default
+  experimental_enabled: true

--- a/src/autoskillit/config/ingredient_defaults.py
+++ b/src/autoskillit/config/ingredient_defaults.py
@@ -72,11 +72,14 @@ _DISPLAY_CATEGORIES: tuple[tuple[str, tuple[str, ...]], ...] = (
 
 def iter_display_categories(
     features: dict[str, bool],
+    *,
+    experimental_enabled: bool = False,
 ) -> tuple[tuple[str, tuple[str, ...]], ...]:
     return tuple(
         (name, tools)
         for name, tools in _DISPLAY_CATEGORIES
-        if name != "Fleet" or is_feature_enabled("fleet", features)
+        if name != "Fleet"
+        or is_feature_enabled("fleet", features, experimental_enabled=experimental_enabled)
     )
 
 

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -373,7 +373,7 @@ class AutomationConfig:
                     f"got {type(value).__name__!r}: {value!r}"
                 )
             if value is True:
-                from autoskillit.core._type_enums import FeatureLifecycle
+                from autoskillit.core import FeatureLifecycle
 
                 if FEATURE_REGISTRY[name].lifecycle == FeatureLifecycle.DISABLED:
                     raise ConfigSchemaError(

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -339,17 +339,23 @@ class AutomationConfig:
     workspace: WorkspaceConfig = field(default_factory=WorkspaceConfig)
     fleet: FleetConfig = field(default_factory=FleetConfig)
     features: dict[str, bool] = field(default_factory=dict)
+    experimental_enabled: bool = False
 
     @staticmethod
-    def _build_features_dict(raw: dict[str, Any]) -> dict[str, bool]:
+    def _build_features_dict(raw: dict[str, Any]) -> tuple[dict[str, bool], bool]:
         """Validate and coerce the features section from a raw config dict.
+
+        Returns (features_dict, experimental_enabled).
 
         Raises ConfigSchemaError for:
         - Unknown feature names (not in FEATURE_REGISTRY)
+        - Attempting to enable a DISABLED lifecycle feature
         - Dependency violations: enabling feature B without its required feature A
 
         Coerces all values to bool.
         """
+        raw = dict(raw)  # copy to avoid mutating caller's dict
+        experimental_enabled: bool = bool(raw.pop("experimental_enabled", False))
         result: dict[str, bool] = {}
         for name, value in raw.items():
             if not isinstance(name, str):
@@ -366,6 +372,14 @@ class AutomationConfig:
                     f"Feature {name!r} value must be a bool, "
                     f"got {type(value).__name__!r}: {value!r}"
                 )
+            if value is True:
+                from autoskillit.core._type_enums import FeatureLifecycle
+
+                if FEATURE_REGISTRY[name].lifecycle == FeatureLifecycle.DISABLED:
+                    raise ConfigSchemaError(
+                        f"Feature {name!r} has lifecycle DISABLED"
+                        " and cannot be explicitly enabled."
+                    )
             result[name] = value
 
         # Dependency validation
@@ -388,7 +402,7 @@ class AutomationConfig:
                         f"Enable {dep!r} first."
                     )
 
-        return result
+        return result, experimental_enabled
 
     @classmethod
     def from_dynaconf(cls, d: Dynaconf) -> AutomationConfig:
@@ -453,6 +467,10 @@ class AutomationConfig:
         _sk = _field_defaults(SkillsConfig)
         _wsc = _field_defaults(WorkspaceConfig)
         _fr = _field_defaults(FleetConfig)
+
+        _features_dict, _exp_enabled = AutomationConfig._build_features_dict(
+            dict(feat) if isinstance(feat, dict) else {}
+        )
 
         result = cls(
             test_check=TestCheckConfig(
@@ -602,12 +620,15 @@ class AutomationConfig:
                     val(fr, "default_timeout_sec", _fr["default_timeout_sec"])
                 ),
             ),
-            features=AutomationConfig._build_features_dict(
-                dict(feat) if isinstance(feat, dict) else {}
-            ),
+            features=_features_dict,
+            experimental_enabled=_exp_enabled,
         )
         try:
-            result.fleet.validate(is_feature_enabled("fleet", result.features))
+            result.fleet.validate(
+                is_feature_enabled(
+                    "fleet", result.features, experimental_enabled=result.experimental_enabled
+                )
+            )
         except ValueError as exc:
             raise ValueError(f"fleet config: {exc}") from exc
         return result
@@ -619,7 +640,12 @@ def _build_config_schema() -> dict[str, frozenset[str]]:
     for f in dataclasses.fields(AutomationConfig):
         # Special case: features is a dict[str, bool]; valid sub-keys come from FEATURE_REGISTRY
         if f.name == "features":
-            schema["features"] = frozenset(FEATURE_REGISTRY.keys())
+            schema["features"] = frozenset(FEATURE_REGISTRY.keys()) | frozenset(
+                {"experimental_enabled"}
+            )
+            continue
+        # Skip the scalar experimental_enabled field — it is handled under the features section
+        if f.name == "experimental_enabled":
             continue
         sub_type: type | None = None
         if f.default_factory is not dataclasses.MISSING:  # type: ignore[misc]

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 from autoskillit.core import (
     CATEGORY_TAGS,
     FEATURE_REGISTRY,
+    FeatureLifecycle,
     OutputFormat,
     atomic_write,
     dump_yaml_str,
@@ -373,8 +374,6 @@ class AutomationConfig:
                     f"got {type(value).__name__!r}: {value!r}"
                 )
             if value is True:
-                from autoskillit.core import FeatureLifecycle
-
                 if FEATURE_REGISTRY[name].lifecycle == FeatureLifecycle.DISABLED:
                     raise ConfigSchemaError(
                         f"Feature {name!r} has lifecycle DISABLED"

--- a/src/autoskillit/core/_type_enums.py
+++ b/src/autoskillit/core/_type_enums.py
@@ -411,11 +411,13 @@ class FleetErrorCode(StrEnum):
 class FeatureLifecycle(StrEnum):
     """Lifecycle stage of a registered feature gate.
 
-    EXPERIMENTAL — Off by default; explicit opt-in required via config or env var.
-    STABLE       — On by default; opt-out possible via config.
-    DEPRECATED   — Scheduled for removal; may be disabled without warning.
+    EXPERIMENTAL — On by default when experimental_enabled=True; disabled on main/stable.
+    STABLE       — On by default everywhere; opt-out via config.
+    DEPRECATED   — Scheduled for removal; follows default_enabled.
+    DISABLED     — Never enabled; config cannot override. For in-progress/unsafe features.
     """
 
     EXPERIMENTAL = "experimental"
     STABLE = "stable"
     DEPRECATED = "deprecated"
+    DISABLED = "disabled"

--- a/src/autoskillit/core/feature_flags.py
+++ b/src/autoskillit/core/feature_flags.py
@@ -44,16 +44,12 @@ def is_feature_enabled(
     defn = FEATURE_REGISTRY.get(name)
     if defn is None:
         raise KeyError(f"Unknown feature: {name!r}")
-    # Step 1: DISABLED is unconditional — cannot be overridden by any config
     if defn.lifecycle == FeatureLifecycle.DISABLED:
         return False
-    # Step 2: explicit per-feature entry always wins
     if name in features:
         return features[name]
-    # Step 3: blanket experimental enablement
     if experimental_enabled and defn.lifecycle == FeatureLifecycle.EXPERIMENTAL:
         return True
-    # Step 4: registry default
     return defn.default_enabled
 
 

--- a/src/autoskillit/core/feature_flags.py
+++ b/src/autoskillit/core/feature_flags.py
@@ -8,9 +8,15 @@ full AutomationConfig to keep core/ free of config/ imports.
 from __future__ import annotations
 
 from ._type_constants import FEATURE_REGISTRY
+from ._type_enums import FeatureLifecycle
 
 
-def is_feature_enabled(name: str, features: dict[str, bool]) -> bool:
+def is_feature_enabled(
+    name: str,
+    features: dict[str, bool],
+    *,
+    experimental_enabled: bool = False,
+) -> bool:
     """Check whether a named feature is enabled.
 
     Parameters
@@ -20,11 +26,15 @@ def is_feature_enabled(name: str, features: dict[str, bool]) -> bool:
     features:
         Resolved features dict from ``AutomationConfig.features``. Typically
         passed as ``config.features`` at call sites; never pass the full config.
+    experimental_enabled:
+        When True, all EXPERIMENTAL lifecycle features are enabled unless explicitly
+        overridden by a per-feature entry in ``features``.
 
     Returns
     -------
     bool
-        ``features[name]`` if the key is present; otherwise ``FeatureDef.default_enabled``.
+        Resolution order:
+        DISABLED hard-off → explicit override → experimental blanket → default_enabled.
 
     Raises
     ------
@@ -34,10 +44,24 @@ def is_feature_enabled(name: str, features: dict[str, bool]) -> bool:
     defn = FEATURE_REGISTRY.get(name)
     if defn is None:
         raise KeyError(f"Unknown feature: {name!r}")
-    return features.get(name, defn.default_enabled)
+    # Step 1: DISABLED is unconditional — cannot be overridden by any config
+    if defn.lifecycle == FeatureLifecycle.DISABLED:
+        return False
+    # Step 2: explicit per-feature entry always wins
+    if name in features:
+        return features[name]
+    # Step 3: blanket experimental enablement
+    if experimental_enabled and defn.lifecycle == FeatureLifecycle.EXPERIMENTAL:
+        return True
+    # Step 4: registry default
+    return defn.default_enabled
 
 
-def _collect_disabled_feature_tags(features: dict[str, bool]) -> frozenset[str]:
+def _collect_disabled_feature_tags(
+    features: dict[str, bool],
+    *,
+    experimental_enabled: bool = False,
+) -> frozenset[str]:
     """Return feature tags that should be suppressed.
 
     Single source of truth used by _fleet_auto_gate_boot and _redisable_subsets.
@@ -48,7 +72,7 @@ def _collect_disabled_feature_tags(features: dict[str, bool]) -> frozenset[str]:
     for name, defn in FEATURE_REGISTRY.items():
         if not defn.tool_tags:
             continue
-        if is_feature_enabled(name, features):
+        if is_feature_enabled(name, features, experimental_enabled=experimental_enabled):
             enabled_tags |= defn.tool_tags
         else:
             disabled_tags |= defn.tool_tags

--- a/src/autoskillit/server/_lifespan.py
+++ b/src/autoskillit/server/_lifespan.py
@@ -160,7 +160,8 @@ async def _fleet_auto_gate_boot(ctx: Any) -> None:
         from autoskillit.server import mcp as _mcp
 
         _features = ctx.config.features if ctx.config is not None else {}
-        for _tag in _collect_disabled_feature_tags(_features):
+        _exp_enabled = ctx.config.experimental_enabled if ctx.config is not None else False
+        for _tag in _collect_disabled_feature_tags(_features, experimental_enabled=_exp_enabled):
             _mcp.disable(tags={_tag})
     except Exception:
         logger.warning("fleet_auto_gate_boot_feature_suppression_failed", exc_info=True)

--- a/src/autoskillit/server/tools_execution.py
+++ b/src/autoskillit/server/tools_execution.py
@@ -437,10 +437,14 @@ async def dispatch_food_truck(
         from autoskillit.server import _get_ctx as _get_ctx_for_feature_check
 
         _feature_ctx = _get_ctx_for_feature_check()
-        if not is_feature_enabled("fleet", _feature_ctx.config.features):
+        if not is_feature_enabled(
+            "fleet",
+            _feature_ctx.config.features,
+            experimental_enabled=_feature_ctx.config.experimental_enabled,
+        ):
             return fleet_error(
                 FleetErrorCode.FLEET_FEATURE_DISABLED,
-                "Fleet feature is disabled in configuration. Set features.fleet: true to enable.",
+                "Fleet feature is disabled. Set features.experimental_enabled: true to enable.",
             )
 
         if os.environ.get("AUTOSKILLIT_HEADLESS") == "1":

--- a/src/autoskillit/server/tools_kitchen.py
+++ b/src/autoskillit/server/tools_kitchen.py
@@ -178,6 +178,8 @@ async def _redisable_subsets(
     ctx: Context,
     disabled: list[str],
     features: dict[str, bool] | None = None,
+    *,
+    experimental_enabled: bool = False,
 ) -> None:
     """Re-disable subset-tagged and feature-disabled tools after enabling kitchen.
 
@@ -197,7 +199,9 @@ async def _redisable_subsets(
 
     # Pass 2: feature gate — suppress tool tags for disabled features
     _features = features or {}
-    for tag in _collect_disabled_feature_tags(_features):
+    for tag in _collect_disabled_feature_tags(
+        _features, experimental_enabled=experimental_enabled
+    ):
         await ctx.disable_components(tags={tag})
 
 
@@ -241,10 +245,14 @@ def get_recipe(name: str) -> str:
     return match.path.read_text()
 
 
-def _build_tool_category_listing(features: dict[str, bool]) -> str:
+def _build_tool_category_listing(
+    features: dict[str, bool], *, experimental_enabled: bool = False
+) -> str:
     """Return a formatted string listing all tool categories."""
     lines = []
-    for name, tools in iter_display_categories(features):
+    for name, tools in iter_display_categories(
+        features, experimental_enabled=experimental_enabled
+    ):
         lines.append(f"  {name}: {', '.join(tools)}")
     return "\n".join(lines)
 
@@ -304,13 +312,22 @@ async def open_kitchen(
             return _kitchen_failure_envelope(exc, stage="enable_components")
 
         try:
-            await _redisable_subsets(ctx, disabled_subsets, _get_ctx().config.features)
+            _kctx = _get_ctx()
+            await _redisable_subsets(
+                ctx,
+                disabled_subsets,
+                _kctx.config.features,
+                experimental_enabled=_kctx.config.experimental_enabled,
+            )
         except Exception as exc:
             logger.warning("open_kitchen_failure", stage="redisable_subsets", exc_info=True)
             return _kitchen_failure_envelope(exc, stage="redisable_subsets")
 
         _forbidden_list = ", ".join(PIPELINE_FORBIDDEN_TOOLS)
-        _categories = _build_tool_category_listing(_get_ctx().config.features)
+        _ctx = _get_ctx()
+        _categories = _build_tool_category_listing(
+            _ctx.config.features, experimental_enabled=_ctx.config.experimental_enabled
+        )
 
         if name is not None:
             tool_ctx = _get_ctx()

--- a/src/autoskillit/workspace/session_skills.py
+++ b/src/autoskillit/workspace/session_skills.py
@@ -402,7 +402,7 @@ class DefaultSessionSkillManager:
             effective_custom_tags = dict(config.subsets.custom_tags)
 
         packs_enabled: list[str] = [] if config is None else list(config.packs.enabled)
-        from autoskillit.core._type_enums import FeatureLifecycle
+        from autoskillit.core import FeatureLifecycle
 
         session_features: dict[str, bool] = (
             {

--- a/src/autoskillit/workspace/session_skills.py
+++ b/src/autoskillit/workspace/session_skills.py
@@ -152,6 +152,8 @@ def _is_skill_disabled(
     disabled: list[str],
     custom_tags: dict[str, list[str]],
     features: dict[str, bool],
+    *,
+    experimental_enabled: bool = False,
 ) -> bool:
     """Return True if skill should be excluded due to a disabled subset.
 
@@ -174,7 +176,7 @@ def _is_skill_disabled(
     enabled_cats: set[str] = set()
     disabled_cats: set[str] = set()
     for feat_name, feat_def in FEATURE_REGISTRY.items():
-        if is_feature_enabled(feat_name, features):
+        if is_feature_enabled(feat_name, features, experimental_enabled=experimental_enabled):
             enabled_cats |= feat_def.skill_categories
         else:
             disabled_cats |= feat_def.skill_categories
@@ -221,6 +223,7 @@ def _should_inject_skill(
     effective_disabled: frozenset[str],
     effective_custom_tags: dict[str, list[str]],
     features: dict[str, bool],
+    experimental_enabled: bool = False,
 ) -> bool:
     """Return True if this skill should be written to the ephemeral session dir.
 
@@ -235,7 +238,13 @@ def _should_inject_skill(
     if skill_info.name in overrides:
         return False
     # Apply effective filtering
-    if _is_skill_disabled(skill_info, list(effective_disabled), effective_custom_tags, features):
+    if _is_skill_disabled(
+        skill_info,
+        list(effective_disabled),
+        effective_custom_tags,
+        features,
+        experimental_enabled=experimental_enabled,
+    ):
         return False
     return True
 
@@ -393,8 +402,14 @@ class DefaultSessionSkillManager:
             effective_custom_tags = dict(config.subsets.custom_tags)
 
         packs_enabled: list[str] = [] if config is None else list(config.packs.enabled)
+        from autoskillit.core._type_enums import FeatureLifecycle
+
         session_features: dict[str, bool] = (
-            {name: True for name in FEATURE_REGISTRY}
+            {
+                name: True
+                for name, defn in FEATURE_REGISTRY.items()
+                if defn.lifecycle != FeatureLifecycle.DISABLED
+            }
             if cook_session
             else (config.features if config is not None else {})
         )
@@ -404,7 +419,11 @@ class DefaultSessionSkillManager:
             enabled_tool_tags: set[str] = set()
             disabled_tool_tags: set[str] = set()
             for feature_name, feature_def in FEATURE_REGISTRY.items():
-                if is_feature_enabled(feature_name, config.features):
+                if is_feature_enabled(
+                    feature_name,
+                    config.features,
+                    experimental_enabled=config.experimental_enabled,
+                ):
                     enabled_tool_tags |= feature_def.tool_tags
                 else:
                     disabled_tool_tags |= feature_def.tool_tags
@@ -437,6 +456,11 @@ class DefaultSessionSkillManager:
                 effective_disabled=effective_disabled,
                 effective_custom_tags=effective_custom_tags,
                 features=session_features,
+                experimental_enabled=(
+                    config.experimental_enabled
+                    if config is not None and not cook_session
+                    else False
+                ),
             ):
                 if skill_info.source == SkillSource.BUNDLED:
                     _log.debug("init_session_plugin_dir_skip", skill=skill_info.name)

--- a/tests/arch/test_feature_markers.py
+++ b/tests/arch/test_feature_markers.py
@@ -141,13 +141,19 @@ def test_all_feature_dir_test_files_carry_feature_marker():
     from autoskillit.core import FEATURE_REGISTRY
 
     missing = []
+    checked_count = 0
     for feat_name in FEATURE_REGISTRY:
         feat_dir = _TESTS_ROOT / feat_name
         if not feat_dir.is_dir():
             continue
         for path in sorted(feat_dir.glob("test_*.py")):
+            checked_count += 1
             if not _pytestmark_has_feature(path.read_text(), feat_name):
                 missing.append(f"{path.relative_to(_TESTS_ROOT)} (feature={feat_name!r})")
+    assert checked_count > 0, (
+        "No feature test directories found — FEATURE_REGISTRY has no tests/{name}/ directories. "
+        "Add at least one feature directory under tests/ or update FEATURE_REGISTRY."
+    )
     assert not missing, "Files missing pytest.mark.feature(name) in pytestmark:\n" + "\n".join(
         f"  {r}" for r in missing
     )

--- a/tests/arch/test_feature_markers.py
+++ b/tests/arch/test_feature_markers.py
@@ -3,6 +3,7 @@
 Also contains:
 - off-state smoke test: package imports cleanly regardless of feature env state
 - visibility round-trip: MCP tool listing respects fleet feature state
+- generic marker test: all feature-dir test files carry appropriate feature markers
 """
 
 from __future__ import annotations
@@ -25,6 +26,8 @@ _FLEET_CROSS_DIR_FILES = [
     _TESTS_ROOT / "server" / "test_tools_dispatch.py",
     _TESTS_ROOT / "cli" / "test_food_truck_prompt.py",
     _TESTS_ROOT / "cli" / "test_l3_orchestrator_prompt.py",
+    _TESTS_ROOT / "cli" / "test_reap.py",
+    _TESTS_ROOT / "cli" / "test_signal_guard.py",
 ]
 
 # Union: all files requiring pytestmark feature("fleet")
@@ -49,9 +52,6 @@ _FLEET_FUNC_MARKERS: dict[str, set[str]] = {
         "test_list_recipes_mcp_tool_hides_campaign_when_fleet_disabled",
     },
 }
-
-# Auto-discover all test files in the planner directory — self-maintaining
-_PLANNER_DIR_FILES = sorted((_TESTS_ROOT / "planner").glob("test_*.py"))
 
 # Infrastructure files that must NOT have a feature("fleet") pytestmark
 _INFRASTRUCTURE_FILE_EXCLUSIONS = [
@@ -135,6 +135,24 @@ def test_fleet_test_files_carry_feature_marker():
     )
 
 
+def test_all_feature_dir_test_files_carry_feature_marker():
+    """For every feature in FEATURE_REGISTRY with a tests/{name}/ directory,
+    all test_*.py files carry pytest.mark.feature(name) in pytestmark."""
+    from autoskillit.core import FEATURE_REGISTRY
+
+    missing = []
+    for feat_name in FEATURE_REGISTRY:
+        feat_dir = _TESTS_ROOT / feat_name
+        if not feat_dir.is_dir():
+            continue
+        for path in sorted(feat_dir.glob("test_*.py")):
+            if not _pytestmark_has_feature(path.read_text(), feat_name):
+                missing.append(f"{path.relative_to(_TESTS_ROOT)} (feature={feat_name!r})")
+    assert not missing, "Files missing pytest.mark.feature(name) in pytestmark:\n" + "\n".join(
+        f"  {r}" for r in missing
+    )
+
+
 def test_fleet_class_markers_present():
     """Specific test classes must carry @pytest.mark.feature('fleet') decorator."""
     missing = []
@@ -162,20 +180,6 @@ def test_fleet_func_markers_present():
                 missing.append(f"{rel}::{fn}")
     assert not missing, "These functions are missing @pytest.mark.feature('fleet'):\n" + "\n".join(
         f"  {r}" for r in missing
-    )
-
-
-def test_planner_test_files_carry_feature_marker():
-    """Every planner test file must have feature('planner') in its pytestmark."""
-    missing = []
-    for path in _PLANNER_DIR_FILES:
-        rel = path.relative_to(_TESTS_ROOT)
-        assert path.exists(), f"Expected planner test file not found: {path}"
-        if not _pytestmark_has_feature(path.read_text(), "planner"):
-            missing.append(str(rel))
-    assert not missing, (
-        "These files are missing pytest.mark.feature('planner') in pytestmark:\n"
-        + "\n".join(f"  {r}" for r in missing)
     )
 
 

--- a/tests/arch/test_feature_registry.py
+++ b/tests/arch/test_feature_registry.py
@@ -11,13 +11,14 @@ import pytest
 
 
 def test_feature_lifecycle_enum_exists():
-    """FeatureLifecycle StrEnum exists with 3 members."""
+    """FeatureLifecycle StrEnum exists with 4 members."""
     from autoskillit.core._type_enums import FeatureLifecycle
 
     assert set(FeatureLifecycle) == {
         FeatureLifecycle.EXPERIMENTAL,
         FeatureLifecycle.STABLE,
         FeatureLifecycle.DEPRECATED,
+        FeatureLifecycle.DISABLED,
     }
 
 
@@ -159,25 +160,35 @@ def test_feature_skill_categories_match_real_skills():
 
 
 def test_is_feature_enabled_defaults():
-    """is_feature_enabled uses FeatureDef.default_enabled when key absent from dict."""
+    """is_feature_enabled uses FeatureDef.default_enabled when experimental_enabled=False."""
     from autoskillit.core._type_constants import FEATURE_REGISTRY
+    from autoskillit.core._type_enums import FeatureLifecycle
     from autoskillit.core.feature_flags import is_feature_enabled
 
     for name, defn in FEATURE_REGISTRY.items():
-        assert is_feature_enabled(name, {}) == defn.default_enabled, (
-            f"{name}: is_feature_enabled({name!r}, {{}}) should be {defn.default_enabled}"
+        expected = False if defn.lifecycle == FeatureLifecycle.DISABLED else defn.default_enabled
+        result = is_feature_enabled(name, {}, experimental_enabled=False)
+        assert result == expected, (
+            f"{name}: is_feature_enabled({name!r}, {{}}, experimental_enabled=False)"
+            f" should be {expected}"
         )
 
 
 def test_is_feature_enabled_override():
-    """is_feature_enabled respects explicit overrides in the features dict."""
+    """is_feature_enabled respects explicit overrides in the features dict (except DISABLED)."""
     from autoskillit.core._type_constants import FEATURE_REGISTRY
+    from autoskillit.core._type_enums import FeatureLifecycle
     from autoskillit.core.feature_flags import is_feature_enabled
 
     assert len(FEATURE_REGISTRY) > 0, "FEATURE_REGISTRY must not be empty"
-    for name in FEATURE_REGISTRY:
-        assert is_feature_enabled(name, {name: True}) is True
-        assert is_feature_enabled(name, {name: False}) is False
+    for name, defn in FEATURE_REGISTRY.items():
+        if defn.lifecycle == FeatureLifecycle.DISABLED:
+            # DISABLED cannot be enabled by any override
+            assert is_feature_enabled(name, {name: True}) is False
+            assert is_feature_enabled(name, {name: False}) is False
+        else:
+            assert is_feature_enabled(name, {name: True}) is True
+            assert is_feature_enabled(name, {name: False}) is False
 
 
 def test_is_feature_enabled_unknown():
@@ -236,7 +247,8 @@ def test_config_dependency_validation(monkeypatch):
     with pytest.raises(ConfigSchemaError):
         AutomationConfig._build_features_dict({"test_dep_b": True, "test_dep_a": False})
     # B enabled with A → no error
-    AutomationConfig._build_features_dict({"test_dep_b": True, "test_dep_a": True})
+    result, _ = AutomationConfig._build_features_dict({"test_dep_b": True, "test_dep_a": True})
+    assert result["test_dep_b"] is True
 
 
 def test_no_unregistered_feature_tag_on_tools():
@@ -296,8 +308,9 @@ def test_fleet_feature_default_disabled():
 def test_build_features_dict_accepts_fleet_key():
     from autoskillit.config.settings import AutomationConfig
 
-    result = AutomationConfig._build_features_dict({"fleet": True})
+    result, exp_enabled = AutomationConfig._build_features_dict({"fleet": True})
     assert result == {"fleet": True}
+    assert exp_enabled is False
 
 
 def test_build_features_dict_franchise_raises_config_schema_error():
@@ -306,3 +319,172 @@ def test_build_features_dict_franchise_raises_config_schema_error():
 
     with pytest.raises(ConfigSchemaError, match="franchise"):
         AutomationConfig._build_features_dict({"franchise": True})
+
+
+# ── T1: DISABLED lifecycle ──────────────────────────────────────────────────
+
+
+def test_is_feature_enabled_disabled_lifecycle_always_false(monkeypatch):
+    """DISABLED lifecycle features return False regardless of config or experimental_enabled."""
+    import autoskillit.core._type_constants as tc
+    from autoskillit.core._type_constants import FeatureDef
+    from autoskillit.core._type_enums import FeatureLifecycle
+    from autoskillit.core.feature_flags import is_feature_enabled
+
+    disabled_def = FeatureDef(
+        name="test_disabled_feat",
+        lifecycle=FeatureLifecycle.DISABLED,
+        description="disabled test feature",
+        tool_tags=frozenset(),
+        skill_categories=frozenset(),
+        import_package=None,
+    )
+    monkeypatch.setitem(tc.FEATURE_REGISTRY, "test_disabled_feat", disabled_def)
+    assert is_feature_enabled("test_disabled_feat", {}, experimental_enabled=False) is False
+    assert (
+        is_feature_enabled(
+            "test_disabled_feat", {"test_disabled_feat": True}, experimental_enabled=True
+        )
+        is False
+    )
+
+
+def test_build_features_dict_rejects_enabling_disabled_feature(monkeypatch):
+    """_build_features_dict raises ConfigSchemaError if a DISABLED feature is set to True."""
+    import autoskillit.core._type_constants as tc
+    from autoskillit.config.settings import AutomationConfig, ConfigSchemaError
+    from autoskillit.core._type_constants import FeatureDef
+    from autoskillit.core._type_enums import FeatureLifecycle
+
+    disabled_def = FeatureDef(
+        name="test_cannot_enable",
+        lifecycle=FeatureLifecycle.DISABLED,
+        description="cannot enable",
+        tool_tags=frozenset(),
+        skill_categories=frozenset(),
+        import_package=None,
+    )
+    monkeypatch.setitem(tc.FEATURE_REGISTRY, "test_cannot_enable", disabled_def)
+    with pytest.raises(ConfigSchemaError, match="DISABLED"):
+        AutomationConfig._build_features_dict({"test_cannot_enable": True})
+    # Setting to False is fine
+    result, _ = AutomationConfig._build_features_dict({"test_cannot_enable": False})
+    assert result["test_cannot_enable"] is False
+
+
+# ── T2: experimental_enabled blanket toggle ────────────────────────────────
+
+
+def test_is_feature_enabled_experimental_blanket(monkeypatch):
+    """EXPERIMENTAL feature is True when experimental_enabled=True and no override."""
+    import autoskillit.core._type_constants as tc
+    from autoskillit.core._type_constants import FeatureDef
+    from autoskillit.core._type_enums import FeatureLifecycle
+    from autoskillit.core.feature_flags import is_feature_enabled
+
+    exp_def = FeatureDef(
+        name="test_exp_feat",
+        lifecycle=FeatureLifecycle.EXPERIMENTAL,
+        description="experimental",
+        tool_tags=frozenset(),
+        skill_categories=frozenset(),
+        import_package=None,
+        default_enabled=False,
+    )
+    monkeypatch.setitem(tc.FEATURE_REGISTRY, "test_exp_feat", exp_def)
+    assert is_feature_enabled("test_exp_feat", {}, experimental_enabled=False) is False
+    assert is_feature_enabled("test_exp_feat", {}, experimental_enabled=True) is True
+    assert (
+        is_feature_enabled("test_exp_feat", {"test_exp_feat": False}, experimental_enabled=True)
+        is False
+    )
+
+
+def test_is_feature_enabled_stable_unaffected_by_experimental_enabled(monkeypatch):
+    """experimental_enabled has no effect on STABLE features."""
+    import autoskillit.core._type_constants as tc
+    from autoskillit.core._type_constants import FeatureDef
+    from autoskillit.core._type_enums import FeatureLifecycle
+    from autoskillit.core.feature_flags import is_feature_enabled
+
+    stable_def = FeatureDef(
+        name="test_stable_feat",
+        lifecycle=FeatureLifecycle.STABLE,
+        description="stable",
+        tool_tags=frozenset(),
+        skill_categories=frozenset(),
+        import_package=None,
+        default_enabled=True,
+    )
+    monkeypatch.setitem(tc.FEATURE_REGISTRY, "test_stable_feat", stable_def)
+    assert is_feature_enabled("test_stable_feat", {}, experimental_enabled=True) is True
+    assert is_feature_enabled("test_stable_feat", {}, experimental_enabled=False) is True
+
+
+# ── T3: AutomationConfig.experimental_enabled field ────────────────────────
+
+
+def test_automation_config_experimental_enabled_field():
+    """AutomationConfig has experimental_enabled: bool defaulting to False."""
+    from autoskillit.config.settings import AutomationConfig
+
+    cfg = AutomationConfig()
+    assert hasattr(cfg, "experimental_enabled")
+    assert cfg.experimental_enabled is False
+
+
+def test_build_features_dict_extracts_experimental_enabled():
+    """_build_features_dict returns (dict, bool) and strips experimental_enabled from dict."""
+    from autoskillit.config.settings import AutomationConfig
+
+    result, exp_enabled = AutomationConfig._build_features_dict({"experimental_enabled": True})
+    assert exp_enabled is True
+    assert "experimental_enabled" not in result
+
+
+def test_build_features_dict_experimental_enabled_defaults_false():
+    """_build_features_dict returns experimental_enabled=False when key absent."""
+    from autoskillit.config.settings import AutomationConfig
+
+    result, exp_enabled = AutomationConfig._build_features_dict({})
+    assert exp_enabled is False
+    assert result == {}
+
+
+def test_build_config_schema_accepts_experimental_enabled():
+    """validate_layer_keys does not raise for features.experimental_enabled."""
+    from autoskillit.config.settings import validate_layer_keys
+
+    validate_layer_keys(
+        {"features": {"experimental_enabled": True}},
+        layer_path="test",
+        is_secrets_layer=False,
+    )
+
+
+# ── T4: defaults.yaml ships experimental_enabled: true ─────────────────────
+
+
+def test_defaults_yaml_has_experimental_enabled_true():
+    """Package defaults.yaml sets experimental_enabled=true; no per-feature entries."""
+    import yaml
+
+    from autoskillit.core.paths import pkg_root
+
+    defaults = yaml.safe_load((pkg_root() / "config" / "defaults.yaml").read_text())
+    features = defaults.get("features", {})
+    assert features.get("experimental_enabled") is True
+    assert "fleet" not in features, "fleet entry removed from defaults.yaml"
+    assert "planner" not in features, "planner entry removed from defaults.yaml"
+
+
+def test_load_config_integration_experimental_enabled(tmp_path):
+    """load_config resolves cfg.experimental_enabled=True from defaults.yaml."""
+    import os
+    from unittest.mock import patch
+
+    from autoskillit.config.settings import load_config
+
+    with patch.dict(os.environ, {}, clear=False):
+        cfg = load_config(tmp_path)
+    assert cfg.experimental_enabled is True

--- a/tests/arch/test_feature_registry.py
+++ b/tests/arch/test_feature_registry.py
@@ -183,7 +183,6 @@ def test_is_feature_enabled_override():
     assert len(FEATURE_REGISTRY) > 0, "FEATURE_REGISTRY must not be empty"
     for name, defn in FEATURE_REGISTRY.items():
         if defn.lifecycle == FeatureLifecycle.DISABLED:
-            # DISABLED cannot be enabled by any override
             assert is_feature_enabled(name, {name: True}) is False
             assert is_feature_enabled(name, {name: False}) is False
         else:
@@ -367,7 +366,6 @@ def test_build_features_dict_rejects_enabling_disabled_feature(monkeypatch):
     monkeypatch.setitem(tc.FEATURE_REGISTRY, "test_cannot_enable", disabled_def)
     with pytest.raises(ConfigSchemaError, match="DISABLED"):
         AutomationConfig._build_features_dict({"test_cannot_enable": True})
-    # Setting to False is fine
     result, _ = AutomationConfig._build_features_dict({"test_cannot_enable": False})
     assert result["test_cannot_enable"] is False
 

--- a/tests/cli/test_features_cli.py
+++ b/tests/cli/test_features_cli.py
@@ -20,7 +20,8 @@ def test_features_list_shows_registry(
     """features list output includes all registered feature names and lifecycle values."""
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(
-        "autoskillit.config.load_config", lambda path: type("C", (), {"features": {}})()
+        "autoskillit.config.load_config",
+        lambda path: type("C", (), {"features": {}, "experimental_enabled": False})(),
     )
     from autoskillit.cli._features import features_list
 
@@ -42,7 +43,9 @@ def test_features_list_shows_effective_state(
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(
         "autoskillit.config.load_config",
-        lambda path: type("C", (), {"features": {"fleet": False}})(),
+        lambda path: type(
+            "C", (), {"features": {"fleet": False}, "experimental_enabled": False}
+        )(),
     )
     from autoskillit.cli._features import features_list
 
@@ -65,7 +68,8 @@ def test_features_status_detail(
     """features status fleet shows all FeatureDef fields."""
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(
-        "autoskillit.config.load_config", lambda path: type("C", (), {"features": {}})()
+        "autoskillit.config.load_config",
+        lambda path: type("C", (), {"features": {}, "experimental_enabled": False})(),
     )
     from autoskillit.cli._features import features_status
 
@@ -87,7 +91,8 @@ def test_features_status_unknown(monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     """features status exits 1 for an unknown feature name."""
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(
-        "autoskillit.config.load_config", lambda path: type("C", (), {"features": {}})()
+        "autoskillit.config.load_config",
+        lambda path: type("C", (), {"features": {}, "experimental_enabled": False})(),
     )
     from autoskillit.cli._features import features_status
 

--- a/tests/cli/test_fleet_cli.py
+++ b/tests/cli/test_fleet_cli.py
@@ -791,10 +791,13 @@ def test_fleet_dispatch_exits_when_disabled(
     checked_features: list[str] = []
     monkeypatch.setattr(
         "autoskillit.cli._fleet.is_feature_enabled",
-        lambda name, features: checked_features.append(name) or False,
+        lambda name, features, *, experimental_enabled=False: (
+            checked_features.append(name) or False
+        ),
     )
     monkeypatch.setattr(
-        "autoskillit.config.load_config", lambda path: type("C", (), {"features": {}})()
+        "autoskillit.config.load_config",
+        lambda path: type("C", (), {"features": {}, "experimental_enabled": False})(),
     )
     with pytest.raises(SystemExit) as exc_info:
         _fleet_dispatch()
@@ -811,10 +814,13 @@ def test_fleet_campaign_exits_when_disabled(
     checked_features: list[str] = []
     monkeypatch.setattr(
         "autoskillit.cli._fleet.is_feature_enabled",
-        lambda name, features: checked_features.append(name) or False,
+        lambda name, features, *, experimental_enabled=False: (
+            checked_features.append(name) or False
+        ),
     )
     monkeypatch.setattr(
-        "autoskillit.config.load_config", lambda path: type("C", (), {"features": {}})()
+        "autoskillit.config.load_config",
+        lambda path: type("C", (), {"features": {}, "experimental_enabled": False})(),
     )
     with pytest.raises(SystemExit) as exc_info:
         _fleet_campaign("any-campaign")
@@ -833,10 +839,13 @@ def test_fleet_list_exits_when_disabled(monkeypatch: pytest.MonkeyPatch, tmp_pat
     checked_features: list[str] = []
     monkeypatch.setattr(
         "autoskillit.cli._fleet.is_feature_enabled",
-        lambda name, features: checked_features.append(name) or False,
+        lambda name, features, *, experimental_enabled=False: (
+            checked_features.append(name) or False
+        ),
     )
     monkeypatch.setattr(
-        "autoskillit.config.load_config", lambda path: type("C", (), {"features": {}})()
+        "autoskillit.config.load_config",
+        lambda path: type("C", (), {"features": {}, "experimental_enabled": False})(),
     )
     with pytest.raises(SystemExit) as exc_info:
         _fleet_list()
@@ -855,10 +864,13 @@ def test_fleet_status_exits_when_disabled(monkeypatch: pytest.MonkeyPatch, tmp_p
     checked_features: list[str] = []
     monkeypatch.setattr(
         "autoskillit.cli._fleet.is_feature_enabled",
-        lambda name, features: checked_features.append(name) or False,
+        lambda name, features, *, experimental_enabled=False: (
+            checked_features.append(name) or False
+        ),
     )
     monkeypatch.setattr(
-        "autoskillit.config.load_config", lambda path: type("C", (), {"features": {}})()
+        "autoskillit.config.load_config",
+        lambda path: type("C", (), {"features": {}, "experimental_enabled": False})(),
     )
     with pytest.raises(SystemExit) as exc_info:
         _fleet_status(None)
@@ -877,9 +889,13 @@ def test_fleet_dispatch_proceeds_when_enabled(
     """fleet_dispatch passes the feature guard and proceeds to campaign resolution."""
     _stub_guards(monkeypatch)
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr("autoskillit.cli._fleet.is_feature_enabled", lambda name, features: True)
     monkeypatch.setattr(
-        "autoskillit.config.load_config", lambda path: type("C", (), {"features": {}})()
+        "autoskillit.cli._fleet.is_feature_enabled",
+        lambda name, features, *, experimental_enabled=False: True,
+    )
+    monkeypatch.setattr(
+        "autoskillit.config.load_config",
+        lambda path: type("C", (), {"features": {}, "experimental_enabled": False})(),
     )
     captured = _capture_subprocess(monkeypatch)
     _fleet_dispatch()

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -1293,22 +1293,8 @@ def test_defaults_yaml_fleet_false() -> None:
     assert data["features"]["fleet"] is False
 
 
-def test_project_config_has_fleet_override() -> None:
-    """Integration's project config enables fleet."""
-    from pathlib import Path
-
-    import yaml
-
-    config_path = Path(__file__).resolve().parents[2] / ".autoskillit" / "config.yaml"
-    if not config_path.exists():
-        pytest.skip("project config not present (clean clone or CI)")
-    with open(config_path) as f:
-        data = yaml.safe_load(f)
-    assert data.get("features", {}).get("fleet") is True
-
-
-def test_config_resolution_fleet_enabled_via_project_config() -> None:
-    """Full config resolution picks up project-level fleet override."""
+def test_project_config_experimental_enabled_or_fleet_enabled() -> None:
+    """Integration's resolved config enables fleet via experimental_enabled blanket."""
     from pathlib import Path
 
     from autoskillit.config.settings import load_config
@@ -1318,4 +1304,25 @@ def test_config_resolution_fleet_enabled_via_project_config() -> None:
     if not (project_root / ".autoskillit" / "config.yaml").exists():
         pytest.skip("project config not present (clean clone or CI)")
     cfg = load_config(project_root)
-    assert is_feature_enabled("fleet", cfg.features) is True
+    assert (
+        is_feature_enabled("fleet", cfg.features, experimental_enabled=cfg.experimental_enabled)
+        is True
+    )
+
+
+def test_config_resolution_fleet_enabled_via_experimental() -> None:
+    """Full config resolution enables fleet via experimental_enabled=True from defaults."""
+    from pathlib import Path
+
+    from autoskillit.config.settings import load_config
+    from autoskillit.core.feature_flags import is_feature_enabled
+
+    project_root = Path(__file__).resolve().parents[2]
+    if not (project_root / ".autoskillit" / "config.yaml").exists():
+        pytest.skip("project config not present (clean clone or CI)")
+    cfg = load_config(project_root)
+    assert cfg.experimental_enabled is True
+    assert (
+        is_feature_enabled("fleet", cfg.features, experimental_enabled=cfg.experimental_enabled)
+        is True
+    )

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -1282,17 +1282,6 @@ class TestFleetConfig:
             load_config(tmp_path)
 
 
-def test_defaults_yaml_fleet_false() -> None:
-    """Package default has fleet disabled."""
-    import yaml
-
-    from autoskillit.core.paths import pkg_root
-
-    with open(pkg_root() / "config" / "defaults.yaml") as f:
-        data = yaml.safe_load(f)
-    assert data["features"]["fleet"] is False
-
-
 def test_project_config_experimental_enabled_or_fleet_enabled() -> None:
     """Integration's resolved config enables fleet via experimental_enabled blanket."""
     from pathlib import Path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -402,7 +402,8 @@ def _resolve_test_config() -> "AutomationConfig | None":
         # rather than Path.cwd(), which varies across IDE runners and monkeypatch.chdir.
         repo_root = Path(__file__).resolve().parent.parent
         cfg = load_config(repo_root)
-        assert isinstance(cfg, _AutomationConfig)
+        if not isinstance(cfg, _AutomationConfig):
+            raise TypeError(f"load_config returned {type(cfg)!r}, expected AutomationConfig")
         return cfg
     except Exception as exc:
         import warnings

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,12 @@
 import functools
 import os
 from pathlib import Path as _Path
+from typing import TYPE_CHECKING
 
 import pytest
+
+if TYPE_CHECKING:
+    from autoskillit.config.settings import AutomationConfig
 
 from autoskillit.core.types import (
     ChannelConfirmation,
@@ -381,23 +385,25 @@ def pytest_configure(config: pytest.Config) -> None:
 
 
 @functools.lru_cache(maxsize=1)
-def _resolve_test_features() -> dict[str, bool]:
-    """Resolve feature flags for test collection via full config resolution.
+def _resolve_test_config() -> "AutomationConfig | None":
+    """Resolve full config for test collection via full config resolution.
 
     Uses the same dynaconf chain as production: defaults.yaml → project config → env vars.
-    Returns empty dict on any failure (fail-open: individual features fall back to
+    Returns None on any failure (fail-open: individual features fall back to
     FEATURE_REGISTRY[name].default_enabled).
     """
     try:
         from pathlib import Path
 
+        from autoskillit.config.settings import AutomationConfig as _AutomationConfig
         from autoskillit.config.settings import load_config
 
         # Anchor to repo root via this file's known location (tests/conftest.py)
         # rather than Path.cwd(), which varies across IDE runners and monkeypatch.chdir.
         repo_root = Path(__file__).resolve().parent.parent
         cfg = load_config(repo_root)
-        return dict(cfg.features)
+        assert isinstance(cfg, _AutomationConfig)
+        return cfg
     except Exception as exc:
         import warnings
 
@@ -405,7 +411,7 @@ def _resolve_test_features() -> dict[str, bool]:
             f"Feature flag config resolution failed, falling back to defaults: {exc}",
             stacklevel=1,
         )
-        return {}
+        return None
 
 
 def _is_test_feature_enabled(feature_name: str, *, env_val: str | None) -> bool:
@@ -415,8 +421,8 @@ def _is_test_feature_enabled(feature_name: str, *, env_val: str | None) -> bool:
     1. If AUTOSKILLIT_TEST_FEATURES is set (including empty string), parse it
        as a comma-separated whitelist.  Only listed names are enabled.
     2. If unset, resolve via full config chain (defaults.yaml → project config
-       → env vars) using load_config().  This respects project-level overrides
-       like .autoskillit/config.yaml features.fleet: true.
+       → env vars) using load_config().  This respects experimental_enabled and
+       per-feature config overrides.
     3. If config resolution fails, fall back to FEATURE_REGISTRY[name].default_enabled.
        Unknown feature names return True (fail-open).
 
@@ -428,11 +434,8 @@ def _is_test_feature_enabled(feature_name: str, *, env_val: str | None) -> bool:
         enabled = {f.strip() for f in env_val.split(",") if f.strip()}
         return feature_name in enabled
 
-    resolved = _resolve_test_features()
-    if feature_name in resolved:
-        return resolved[feature_name]
-
     from autoskillit.core import FEATURE_REGISTRY
+    from autoskillit.core.feature_flags import is_feature_enabled
 
     defn = FEATURE_REGISTRY.get(feature_name)
     if defn is None:
@@ -444,7 +447,14 @@ def _is_test_feature_enabled(feature_name: str, *, env_val: str | None) -> bool:
             stacklevel=4,
         )
         return True
-    return defn.default_enabled
+
+    cfg = _resolve_test_config()
+    if cfg is None:
+        return defn.default_enabled
+
+    return is_feature_enabled(
+        feature_name, cfg.features, experimental_enabled=cfg.experimental_enabled
+    )
 
 
 def pytest_collection_modifyitems(

--- a/tests/core/test_type_constants.py
+++ b/tests/core/test_type_constants.py
@@ -170,10 +170,12 @@ def test_fleet_default_enabled_is_false() -> None:
 
 
 def test_is_feature_enabled_fleet_defaults_false() -> None:
-    """Without explicit config, fleet resolves to disabled."""
+    """Without explicit config, fleet resolves to disabled when experimental_enabled=False."""
     from autoskillit.core.feature_flags import is_feature_enabled
 
-    assert is_feature_enabled("fleet", {}) is False
+    assert is_feature_enabled("fleet", {}, experimental_enabled=False) is False
+    # fleet is EXPERIMENTAL, so blanket enables it
+    assert is_feature_enabled("fleet", {}, experimental_enabled=True) is True
 
 
 def test_fleet_dispatch_tools_constant_exists() -> None:

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -128,7 +128,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/server/_lifespan.py", 56),
     # tools_kitchen.py — hook config dict
     ("src/autoskillit/server/tools_kitchen.py", 123),
-    ("src/autoskillit/server/tools_kitchen.py", 519),
+    ("src/autoskillit/server/tools_kitchen.py", 536),
     # tools_status.py — mcp_data dict
     ("src/autoskillit/server/tools_status.py", 486),
     # tools_github.py — bug report dict

--- a/tests/server/test_server_init.py
+++ b/tests/server/test_server_init.py
@@ -1121,7 +1121,9 @@ class TestFleetAutoGateBoot:
                         with patch("autoskillit.core.register_active_kitchen"):
                             await _fleet_auto_gate_boot(tool_ctx)
 
-        mock_helper.assert_called_once_with(tool_ctx.config.features)
+        mock_helper.assert_called_once_with(
+            tool_ctx.config.features, experimental_enabled=tool_ctx.config.experimental_enabled
+        )
 
 
 @pytest.mark.feature("fleet")

--- a/tests/server/test_tools_kitchen.py
+++ b/tests/server/test_tools_kitchen.py
@@ -1360,7 +1360,7 @@ async def test_redisable_subsets_uses_shared_helper() -> None:
         mock_h.return_value = frozenset({"fleet"})
         await _redisable_subsets(mock_ctx, [], features={"fleet": False})
 
-    mock_h.assert_called_once_with({"fleet": False})
+    mock_h.assert_called_once_with({"fleet": False}, experimental_enabled=False)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -226,27 +226,79 @@ def test_minimal_ctx_provides_isolated_gate(minimal_ctx):
 
 
 def test_is_test_feature_enabled_reads_project_config(monkeypatch):
-    """When AUTOSKILLIT_TEST_FEATURES is unset, conftest resolves features via config."""
+    """When AUTOSKILLIT_TEST_FEATURES is unset, fleet resolves True via experimental_enabled."""
     monkeypatch.delenv("AUTOSKILLIT_TEST_FEATURES", raising=False)
-    from tests.conftest import _is_test_feature_enabled, _resolve_test_features
+    from tests.conftest import _is_test_feature_enabled, _resolve_test_config
 
-    _resolve_test_features.cache_clear()
+    _resolve_test_config.cache_clear()
     try:
         result = _is_test_feature_enabled("fleet", env_val=None)
         assert result is True
     finally:
-        _resolve_test_features.cache_clear()
+        _resolve_test_config.cache_clear()
 
 
 def test_is_test_feature_enabled_dynaconf_env_overrides(monkeypatch):
-    """AUTOSKILLIT_FEATURES__FLEET=false overrides project config in test resolution."""
+    """AUTOSKILLIT_FEATURES__FLEET=false overrides experimental_enabled in test resolution."""
     monkeypatch.delenv("AUTOSKILLIT_TEST_FEATURES", raising=False)
     monkeypatch.setenv("AUTOSKILLIT_FEATURES__FLEET", "false")
-    from tests.conftest import _is_test_feature_enabled, _resolve_test_features
+    from tests.conftest import _is_test_feature_enabled, _resolve_test_config
 
-    _resolve_test_features.cache_clear()
+    _resolve_test_config.cache_clear()
     try:
         result = _is_test_feature_enabled("fleet", env_val=None)
         assert result is False
     finally:
-        _resolve_test_features.cache_clear()
+        _resolve_test_config.cache_clear()
+
+
+def test_is_test_feature_enabled_respects_experimental_enabled(monkeypatch):
+    """EXPERIMENTAL feature resolves True via experimental_enabled=True in config."""
+    import autoskillit.core._type_constants as tc
+    from autoskillit.core._type_constants import FeatureDef
+    from autoskillit.core._type_enums import FeatureLifecycle
+    from tests.conftest import _is_test_feature_enabled, _resolve_test_config
+
+    monkeypatch.delenv("AUTOSKILLIT_TEST_FEATURES", raising=False)
+    exp_feat = FeatureDef(
+        name="conftest_test_exp",
+        lifecycle=FeatureLifecycle.EXPERIMENTAL,
+        description="test",
+        tool_tags=frozenset(),
+        skill_categories=frozenset(),
+        import_package=None,
+        default_enabled=False,
+    )
+    monkeypatch.setitem(tc.FEATURE_REGISTRY, "conftest_test_exp", exp_feat)
+    _resolve_test_config.cache_clear()
+    try:
+        # defaults.yaml has experimental_enabled=true, so EXPERIMENTAL features are enabled
+        result = _is_test_feature_enabled("conftest_test_exp", env_val=None)
+        assert result is True
+    finally:
+        _resolve_test_config.cache_clear()
+
+
+def test_is_test_feature_enabled_disabled_lifecycle_always_false(monkeypatch):
+    """_is_test_feature_enabled returns False for DISABLED feature regardless of config."""
+    import autoskillit.core._type_constants as tc
+    from autoskillit.core._type_constants import FeatureDef
+    from autoskillit.core._type_enums import FeatureLifecycle
+    from tests.conftest import _is_test_feature_enabled, _resolve_test_config
+
+    monkeypatch.delenv("AUTOSKILLIT_TEST_FEATURES", raising=False)
+    disabled_feat = FeatureDef(
+        name="conftest_test_disabled",
+        lifecycle=FeatureLifecycle.DISABLED,
+        description="disabled test",
+        tool_tags=frozenset(),
+        skill_categories=frozenset(),
+        import_package=None,
+    )
+    monkeypatch.setitem(tc.FEATURE_REGISTRY, "conftest_test_disabled", disabled_feat)
+    _resolve_test_config.cache_clear()
+    try:
+        result = _is_test_feature_enabled("conftest_test_disabled", env_val=None)
+        assert result is False
+    finally:
+        _resolve_test_config.cache_clear()


### PR DESCRIPTION
## Summary

Make `FeatureLifecycle.EXPERIMENTAL` authoritative: a single `experimental_enabled: true`
in `defaults.yaml` enables all EXPERIMENTAL features on integration and non-main branches.
Add a `DISABLED` lifecycle hard-off state. Add `AutomationConfig.experimental_enabled: bool`
to carry the blanket toggle through the config pipeline into `is_feature_enabled()`. Update
`defaults.yaml`, integration's `.autoskillit/config.yaml`, and the test infrastructure to
reflect the new semantics. Generalize the feature-marker arch test to cover all registry
features rather than hardcoded fleet + planner.

## Requirements

### R1: Blanket experimental enablement

- Add `experimental_enabled: true` to `defaults.yaml` under `features:`
- Remove `fleet: false` and `planner: false` from `defaults.yaml`
- Add `AutomationConfig.experimental_enabled: bool` field
- `_build_features_dict()` extracts `experimental_enabled` before the per-feature validation loop
- `_build_config_schema()` adds `experimental_enabled` to the valid features sub-key set (both validators must accept it)
- `is_feature_enabled()` implements the resolution order above
- Remove `features: {fleet: true}` from integration's `.autoskillit/config.yaml`
- Add `features: {experimental_enabled: false}` to main's `.autoskillit/config.yaml`

### R2: Feature marker enforcement generalized

`tests/arch/test_feature_markers.py` currently hardcodes fleet-specific file lists. Generalize:
- Auto-discover `tests/{feature_name}/test_*.py` for every feature in `FEATURE_REGISTRY`
- Assert each carries `pytest.mark.feature("{name}")` in `pytestmark`
- Support cross-directory and class-level markers via a registry dict keyed by feature name
- Add missing fleet cross-dir entries: `tests/cli/test_reap.py` and `tests/cli/test_signal_guard.py`

### R3: Planner test files get feature markers

Add `pytest.mark.feature("planner")` to `pytestmark` in:
- `tests/planner/test_compiler.py`
- `tests/planner/test_manifests.py`
- `tests/planner/test_planner.py`
- `tests/planner/test_validation.py`

### R4: Add DISABLED lifecycle state

- Add `FeatureLifecycle.DISABLED = "disabled"` to the enum
- Update `FeatureLifecycle.EXPERIMENTAL` docstring to reflect "on by default" semantics
- `is_feature_enabled()` returns `False` for DISABLED regardless of config
- `_build_features_dict()` rejects explicit enable of DISABLED features
- `session_skills.py` cook-session dict filters out DISABLED features

### R5: Test infrastructure updates

- `_is_test_feature_enabled()` in `conftest.py` must call `is_feature_enabled()` with the new lifecycle logic rather than reading `cfg.features` directly and falling back to `defn.default_enabled` — otherwise experimental feature tests would be incorrectly skipped on integration
- Update `test_feature_registry.py`: lifecycle enum member count assertion (3 → 4), `is_feature_enabled` default behavior assertions
- Update `test_type_constants.py`: `default_enabled` assertions
- Update `test_conftest.py`: `_is_test_feature_enabled` coverage for `experimental_enabled` resolution

### R6: Server startup gate

`_fleet_gate()` in `_session_type.py` reads `AUTOSKILLIT_FEATURES__FLEET` directly from `os.environ` — it does not read config or know about `experimental_enabled`. Update it to respect the resolved config state so that on main (where `experimental_enabled: false`), fleet tools are correctly hidden at MCP startup. Coordinate with PR #1260 (fleet runtime gate consistency) which also modifies this function.

### R7: CLI and documentation

- `features list` shows lifecycle-aware status: EXPERIMENTAL features show `on (experimental)` when blanket is active, `off (override)` when per-feature disabled
- `features status` (single-feature detail) also shows lifecycle-aware source
- Document in `docs/configuration.md`: EXPERIMENTAL (on by default, main opts out), STABLE (on everywhere), DISABLED (off everywhere, cannot override), DEPRECATED (follows default_enabled)

## Architecture Impact

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START([PROCESS START])

    %% ── LAYER 1: INIT_ONLY — Frozen Registry ── %%
    subgraph Registry ["INIT_ONLY — Frozen Feature Registry (module import)"]
        direction TB
        FD["● FeatureDef<br/>━━━━━━━━━━<br/>@dataclass(frozen=True)<br/>name · lifecycle · tool_tags<br/>skill_categories · default_enabled<br/>depends_on · since_version"]
        LC["● FeatureLifecycle<br/>━━━━━━━━━━<br/>EXPERIMENTAL · STABLE<br/>DEPRECATED · ● DISABLED<br/>(StrEnum — immutable values)"]
        FR["FEATURE_REGISTRY<br/>━━━━━━━━━━<br/>dict[str, FeatureDef]<br/>fleet · planner (EXPERIMENTAL)<br/>append-only at import time"]
        IG1["Import Guard 1<br/>━━━━━━━━━━<br/>tool_tags ⊆ TOOL_SUBSET_TAGS<br/>AssertionError at import"]
        IG2["Import Guard 2<br/>━━━━━━━━━━<br/>dict key == FeatureDef.name<br/>AssertionError at import"]
    end

    %% ── LAYER 2: Config Load + Validation Gates ── %%
    subgraph ConfigLoad ["● MUTABLE — Config Load + Validation (_build_features_dict)"]
        direction TB
        CG1["Gate 1: Key type<br/>━━━━━━━━━━<br/>Must be str<br/>→ ConfigSchemaError"]
        CG2["Gate 2: Registry membership<br/>━━━━━━━━━━<br/>Key ∈ FEATURE_REGISTRY<br/>→ ConfigSchemaError"]
        CG3["Gate 3: Value type<br/>━━━━━━━━━━<br/>Must be bool (strict)<br/>→ ConfigSchemaError"]
        CG4["● Gate 4: DISABLED lifecycle<br/>━━━━━━━━━━<br/>value=True + lifecycle==DISABLED<br/>→ ConfigSchemaError (cannot enable)"]
        CG5["Gate 5: Dependency<br/>━━━━━━━━━━<br/>depends_on features must<br/>also be enabled<br/>→ ConfigSchemaError"]
        CFG["● AutomationConfig<br/>━━━━━━━━━━<br/>features: dict[str, bool]<br/>● experimental_enabled: bool<br/>(from features.experimental_enabled YAML key)<br/>Read-only post-load"]
    end

    %% ── LAYER 3: Resolution Function (DERIVED) ── %%
    subgraph Resolution ["● DERIVED — is_feature_enabled() Resolution Chain"]
        direction TB
        R1["● Priority 1: DISABLED hard-off<br/>━━━━━━━━━━<br/>lifecycle==DISABLED → False<br/>No config can override"]
        R2["Priority 2: Explicit override<br/>━━━━━━━━━━<br/>name ∈ features → features[name]"]
        R3["● Priority 3: Blanket experimental<br/>━━━━━━━━━━<br/>experimental_enabled=True<br/>+ lifecycle==EXPERIMENTAL → True"]
        R4["Priority 4: Registry default<br/>━━━━━━━━━━<br/>defn.default_enabled (False)"]
    end

    %% ── LAYER 4: MCP Gate Application ── %%
    subgraph GateApply ["● MCP Tool Gate Application (Two Entry Points)"]
        direction LR
        OKG["● open_kitchen Gate<br/>━━━━━━━━━━<br/>_redisable_subsets()<br/>_collect_disabled_feature_tags()<br/>ctx.disable_components(tags)"]
        FLG["● Fleet Auto-Gate Boot<br/>━━━━━━━━━━<br/>_fleet_auto_gate_boot()<br/>in _lifespan<br/>_mcp.disable(tags)<br/>before lifespan yield"]
    end

    %% ── LAYER 5: INIT_PRESERVE — Kitchen Session State ── %%
    subgraph KitchenState ["INIT_PRESERVE — Kitchen Session State (open_kitchen → run_skill)"]
        direction TB
        KS1["● ctx.gate<br/>━━━━━━━━━━<br/>Set: open_kitchen<br/>Cleared: close_kitchen<br/>Read: _require_enabled()"]
        KS2["ctx.kitchen_id<br/>━━━━━━━━━━<br/>Set: open_kitchen<br/>Read: run_skill → executor<br/>Cleared: close_kitchen"]
        KS3["ctx.recipe_* hashes<br/>━━━━━━━━━━<br/>Set: open_kitchen after load<br/>Read: run_skill → executor<br/>Must match on resume or<br/>provenance inconsistency"]
        KS4["ctx.active_recipe_packs<br/>━━━━━━━━━━<br/>Reset to frozenset() first<br/>Set after recipe load<br/>Read: run_skill → init_session"]
    end

    %% ── LAYER 6: Session Skill Filtering ── %%
    subgraph SkillFilter ["● Session Skill Filtering (init_session)"]
        direction LR
        COOK["● Cook Session Path<br/>━━━━━━━━━━<br/>Force-enables all features<br/>lifecycle != DISABLED<br/>Ignores experimental_enabled<br/>(orchestrator sees all)"]
        PIPE["● Pipeline Session Path<br/>━━━━━━━━━━<br/>Uses config.features verbatim<br/>+ experimental_enabled<br/>Feature-gated skills suppressed<br/>from skill directory"]
    end

    %% ── LAYER 7: Runtime Tool Gates ── %%
    subgraph ToolGates ["Runtime Tool Gates (run_skill / dispatch_food_truck)"]
        direction TB
        TG1["Gate: Session type<br/>━━━━━━━━━━<br/>_require_orchestrator_or_higher()<br/>Headless → denied"]
        TG2["Gate: Kitchen open<br/>━━━━━━━━━━<br/>_require_enabled()<br/>ctx.gate closed → denied"]
        TG3["● Gate: Fleet feature<br/>━━━━━━━━━━<br/>is_feature_enabled('fleet')<br/>Dual-layer guard beyond MCP<br/>visibility (dispatch_food_truck)"]
    end

    END_OK(["TOOL EXECUTED"])
    END_FAIL(["GATE DENIED"])

    %% ── CONNECTIONS ── %%
    START --> Registry
    FD --> LC
    LC --> FR
    FR --> IG1
    FR --> IG2

    Registry --> ConfigLoad
    IG1 & IG2 -->|"Import assertion passes"| CG1
    CG1 --> CG2 --> CG3 --> CG4 --> CG5 --> CFG

    CFG --> Resolution
    FR --> R1
    CFG --> R2
    CFG --> R3
    FR --> R4
    R1 --> R2 --> R3 --> R4

    Resolution --> GateApply
    OKG -->|"Kitchen open path"| KitchenState
    FLG -->|"Fleet session path"| ToolGates

    KitchenState --> SkillFilter
    COOK & PIPE --> ToolGates

    TG1 --> TG2 --> TG3
    TG3 -->|"All gates pass"| END_OK
    TG1 & TG2 & TG3 -->|"Any gate fails"| END_FAIL

    CG1 & CG2 & CG3 & CG4 & CG5 -->|"Validation error"| END_FAIL

    %% ── CLASS ASSIGNMENTS ── %%
    class FD,LC detector;
    class FR stateNode;
    class IG1,IG2 detector;
    class CG1,CG2,CG3,CG4,CG5 stateNode;
    class CFG gap;
    class R1,R2,R3,R4 phase;
    class OKG,FLG handler;
    class KS1 detector;
    class KS2,KS3,KS4 gap;
    class COOK,PIPE handler;
    class TG1,TG2,TG3 stateNode;
    class START,END_OK,END_FAIL terminal;
```

Closes #1261

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260426-034917-731188/.autoskillit/temp/make-plan/feature_flag_lifecycle_plan_2026-04-26_000100.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 5.6k | 21.3k | 473.1k | 67.4k | 1 | 9m 8s |
| verify | 156 | 14.6k | 916.6k | 51.6k | 1 | 8m 16s |
| implement | 1.0k | 52.9k | 12.6M | 148.7k | 1 | 22m 15s |
| fix | 326 | 17.8k | 2.5M | 138.3k | 1 | 9m 58s |
| prepare_pr | 52 | 8.2k | 184.1k | 37.1k | 1 | 2m 16s |
| run_arch_lenses | 3.0k | 8.2k | 172.4k | 34.5k | 1 | 4m 5s |
| compose_pr | 59 | 5.4k | 201.3k | 26.4k | 1 | 1m 54s |
| **Total** | 10.3k | 128.4k | 17.1M | 504.0k | | 57m 55s |