### PR TITLE
Implementation Plan: Test Infrastructure Improvements — Deduplication, Cache Safety, Assertion Quality

### DIFF
--- a/tests/arch/test_feature_markers.py
+++ b/tests/arch/test_feature_markers.py
@@ -21,14 +21,16 @@ _TESTS_ROOT = Path(__file__).parent.parent
 _FLEET_DIR_FILES = sorted((_TESTS_ROOT / "fleet").glob("test_*.py"))
 
 # Cross-directory fleet test files — require deliberate enumeration
-_FLEET_CROSS_DIR_FILES = [
-    _TESTS_ROOT / "cli" / "test_fleet_cli.py",
-    _TESTS_ROOT / "server" / "test_tools_dispatch.py",
-    _TESTS_ROOT / "cli" / "test_food_truck_prompt.py",
-    _TESTS_ROOT / "cli" / "test_l3_orchestrator_prompt.py",
-    _TESTS_ROOT / "cli" / "test_reap.py",
-    _TESTS_ROOT / "cli" / "test_signal_guard.py",
-]
+_FLEET_CROSS_DIR_FILES: frozenset[Path] = frozenset(
+    [
+        _TESTS_ROOT / "cli" / "test_fleet_cli.py",
+        _TESTS_ROOT / "server" / "test_tools_dispatch.py",
+        _TESTS_ROOT / "cli" / "test_food_truck_prompt.py",
+        _TESTS_ROOT / "cli" / "test_l3_orchestrator_prompt.py",
+        _TESTS_ROOT / "cli" / "test_reap.py",
+        _TESTS_ROOT / "cli" / "test_signal_guard.py",
+    ]
+)
 
 # Union: all files requiring pytestmark feature("fleet")
 _ALL_FLEET_FILES = [*_FLEET_DIR_FILES, *_FLEET_CROSS_DIR_FILES]
@@ -204,6 +206,11 @@ def test_no_feature_marker_on_infrastructure_tests():
         "Infrastructure tests must not carry feature('fleet') pytestmark:\n"
         + "\n".join(f"  {r}" for r in unexpected)
     )
+
+
+def test_fleet_cross_dir_files_no_duplicates():
+    paths = list(_FLEET_CROSS_DIR_FILES)
+    assert len(paths) == len(set(paths)), "Duplicate paths in _FLEET_CROSS_DIR_FILES"
 
 
 def test_import_safety_with_features_disabled():

--- a/tests/cli/test_features_cli.py
+++ b/tests/cli/test_features_cli.py
@@ -29,6 +29,13 @@ def test_features_list_shows_registry(
     out = capsys.readouterr().out
     assert "fleet" in out
     assert "experimental" in out
+    assert "FEATURE" in out
+    assert "LIFECYCLE" in out
+    assert "EFFECTIVE" in out
+    fleet_line = next(
+        line for line in out.splitlines() if "fleet" in line and "FEATURE" not in line
+    )
+    assert len(fleet_line.split()) >= 6
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_terminal.py
+++ b/tests/cli/test_terminal.py
@@ -436,7 +436,7 @@ class TestCookTerminalGuard:
         )
         monkeypatch.setattr("autoskillit.cli._terminal.termios.error", termios.error)
         monkeypatch.setattr(
-            "subprocess.run",
+            "autoskillit.cli._cook.subprocess.run",
             lambda *a, **kw: (_ for _ in ()).throw(KeyboardInterrupt()),
         )
         monkeypatch.setattr("shutil.which", lambda cmd: "/usr/bin/claude")
@@ -483,7 +483,7 @@ class TestCookTerminalGuard:
         monkeypatch.setattr("autoskillit.cli._terminal.termios.error", termios.error)
         monkeypatch.setattr("autoskillit.cli._init_helpers._is_plugin_installed", lambda: False)
         monkeypatch.setattr(
-            "subprocess.run",
+            "autoskillit.cli._session_launch.subprocess.run",
             lambda *a, **kw: (_ for _ in ()).throw(KeyboardInterrupt()),
         )
         monkeypatch.setattr("shutil.which", lambda cmd: "/usr/bin/claude")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -415,6 +415,12 @@ def _resolve_test_config() -> "AutomationConfig | None":
         return None
 
 
+@pytest.fixture(autouse=True)
+def _clear_resolve_test_config_cache():
+    yield
+    _resolve_test_config.cache_clear()
+
+
 def _is_test_feature_enabled(feature_name: str, *, env_val: str | None) -> bool:
     """Return True if feature_name is enabled for this test run.
 

--- a/tests/fleet/_helpers.py
+++ b/tests/fleet/_helpers.py
@@ -29,3 +29,35 @@ def compute_food_truck_tool_surface(recipe_name: str) -> frozenset[str]:
     for pack in recipe.requires_packs or []:
         expected |= TOOLS_BY_PACK.get(pack, frozenset())
     return frozenset(expected)
+
+
+def _make_recipe_info(name: str = "test-recipe", path_prefix: str = "/fake/"):
+    from pathlib import Path
+
+    from autoskillit.recipe.schema import RecipeInfo, RecipeSource
+
+    return RecipeInfo(
+        name=name,
+        description="test",
+        source=RecipeSource.PROJECT,
+        path=Path(f"{path_prefix}{name}.yaml"),
+    )
+
+
+def _setup_dispatch(tool_ctx, monkeypatch, recipe_name: str = "test-recipe"):
+    """Wire tool_ctx for dispatch tests."""
+    import asyncio
+
+    from autoskillit.recipe.schema import Recipe, RecipeKind
+    from tests.fakes import InMemoryHeadlessExecutor, InMemoryRecipeRepository
+
+    tool_ctx.fleet_lock = asyncio.Lock()
+    repo = InMemoryRecipeRepository()
+    recipe_info = _make_recipe_info(recipe_name)
+    repo.add_recipe(recipe_name, recipe_info)
+    repo.add_full_recipe(
+        recipe_info.path,
+        Recipe(name=recipe_name, description="test", kind=RecipeKind.STANDARD, ingredients={}),
+    )
+    tool_ctx.recipes = repo
+    tool_ctx.executor = InMemoryHeadlessExecutor()

--- a/tests/fleet/test_dispatch_failure_semantics.py
+++ b/tests/fleet/test_dispatch_failure_semantics.py
@@ -2,27 +2,14 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
 
 import pytest
 
-from tests.fakes import InMemoryHeadlessExecutor, InMemoryRecipeRepository
+from tests.fakes import InMemoryHeadlessExecutor
+from tests.fleet._helpers import _setup_dispatch
 
 pytestmark = [pytest.mark.layer("fleet"), pytest.mark.small, pytest.mark.feature("fleet")]
-
-
-def _make_recipe_info(name: str = "test-recipe"):
-    from pathlib import Path
-
-    from autoskillit.recipe.schema import RecipeInfo, RecipeSource
-
-    return RecipeInfo(
-        name=name,
-        description="test",
-        source=RecipeSource.PROJECT,
-        path=Path(f"/fake/{name}.yaml"),
-    )
 
 
 def _simple_prompt_builder(**kwargs) -> str:
@@ -41,22 +28,6 @@ async def _no_sleep_quota_checker(config, **kwargs) -> dict:
 
 async def _noop_quota_refresher(config, **kwargs) -> None:
     pass
-
-
-def _setup_dispatch(tool_ctx, monkeypatch, recipe_name: str = "test-recipe"):
-    """Wire tool_ctx for dispatch tests."""
-    from autoskillit.recipe.schema import Recipe, RecipeKind
-
-    tool_ctx.fleet_lock = asyncio.Lock()
-    repo = InMemoryRecipeRepository()
-    recipe_info = _make_recipe_info(recipe_name)
-    repo.add_recipe(recipe_name, recipe_info)
-    repo.add_full_recipe(
-        recipe_info.path,
-        Recipe(name=recipe_name, description="test", kind=RecipeKind.STANDARD, ingredients={}),
-    )
-    tool_ctx.recipes = repo
-    tool_ctx.executor = InMemoryHeadlessExecutor()
 
 
 async def _run(tool_ctx, recipe: str = "test-recipe") -> dict:

--- a/tests/fleet/test_dispatch_lifespan.py
+++ b/tests/fleet/test_dispatch_lifespan.py
@@ -2,27 +2,14 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
 
 import pytest
 
-from tests.fakes import InMemoryHeadlessExecutor, InMemoryRecipeRepository
+from tests.fakes import InMemoryHeadlessExecutor
+from tests.fleet._helpers import _setup_dispatch
 
 pytestmark = [pytest.mark.layer("fleet"), pytest.mark.small, pytest.mark.feature("fleet")]
-
-
-def _make_recipe_info(name: str = "test-recipe"):
-    from pathlib import Path
-
-    from autoskillit.recipe.schema import RecipeInfo, RecipeSource
-
-    return RecipeInfo(
-        name=name,
-        description="test",
-        source=RecipeSource.PROJECT,
-        path=Path(f"/fake/{name}.yaml"),
-    )
 
 
 def _simple_prompt_builder(**kwargs) -> str:
@@ -41,21 +28,6 @@ async def _no_sleep_quota_checker(config, **kwargs) -> dict:
 
 async def _noop_quota_refresher(config, **kwargs) -> None:
     pass
-
-
-def _setup_dispatch(tool_ctx, monkeypatch, recipe_name: str = "test-recipe"):
-    from autoskillit.recipe.schema import Recipe, RecipeKind
-
-    tool_ctx.fleet_lock = asyncio.Lock()
-    repo = InMemoryRecipeRepository()
-    recipe_info = _make_recipe_info(recipe_name)
-    repo.add_recipe(recipe_name, recipe_info)
-    repo.add_full_recipe(
-        recipe_info.path,
-        Recipe(name=recipe_name, description="test", kind=RecipeKind.STANDARD, ingredients={}),
-    )
-    tool_ctx.recipes = repo
-    tool_ctx.executor = InMemoryHeadlessExecutor()
 
 
 async def _run(tool_ctx, recipe: str = "test-recipe") -> dict:

--- a/tests/fleet/test_helpers_exports.py
+++ b/tests/fleet/test_helpers_exports.py
@@ -1,0 +1,28 @@
+"""Tests that shared helpers are importable from tests.fleet._helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.layer("fleet"), pytest.mark.small, pytest.mark.feature("fleet")]
+
+
+def test_make_recipe_info_exported_from_fleet_helpers():
+    from tests.fleet._helpers import _make_recipe_info
+
+    info = _make_recipe_info("my-recipe")
+    assert info.name == "my-recipe"
+    assert str(info.path) == "/fake/my-recipe.yaml"
+
+
+def test_make_recipe_info_custom_prefix():
+    from tests.fleet._helpers import _make_recipe_info
+
+    info = _make_recipe_info("my-recipe", path_prefix="/fake/recipes/")
+    assert str(info.path) == "/fake/recipes/my-recipe.yaml"
+
+
+def test_setup_dispatch_exported_from_fleet_helpers():
+    from tests.fleet._helpers import _setup_dispatch
+
+    assert callable(_setup_dispatch)

--- a/tests/server/test_tools_dispatch.py
+++ b/tests/server/test_tools_dispatch.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from tests.fakes import InMemoryHeadlessExecutor, InMemoryRecipeRepository
+from tests.fleet._helpers import _make_recipe_info as _fleet_make_recipe_info
 
 pytestmark = [pytest.mark.layer("server"), pytest.mark.medium, pytest.mark.feature("fleet")]
 
@@ -19,15 +20,7 @@ pytestmark = [pytest.mark.layer("server"), pytest.mark.medium, pytest.mark.featu
 
 
 def _make_recipe_info(name: str = "test-recipe"):
-    """Return a minimal RecipeInfo for InMemoryRecipeRepository."""
-    from autoskillit.recipe.schema import RecipeInfo, RecipeSource
-
-    return RecipeInfo(
-        name=name,
-        description="test",
-        source=RecipeSource.PROJECT,
-        path=Path(f"/fake/recipes/{name}.yaml"),
-    )
+    return _fleet_make_recipe_info(name, path_prefix="/fake/recipes/")
 
 
 def _make_standard_recipe(name: str = "test-recipe", ingredient_keys: list[str] | None = None):


### PR DESCRIPTION
## Summary

Six targeted test-quality fixes across five test files. All changes are confined to the test suite; no production code is touched. The work falls into three categories: (1) eliminating duplicate helper functions by promoting them to `tests/fleet/_helpers.py`, (2) fixing two correctness risks (an overly-broad monkeypatch target and a stale `lru_cache`), and (3) strengthening structural assertions and uniqueness guarantees.

Closes #1234

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260426-053019-742113/.autoskillit/temp/make-plan/test_infrastructure_improvements_plan_2026-04-26_053019.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 235 | 15.7k | 1.3M | 62.3k | 1 | 5m 20s |
| verify | 84 | 11.5k | 349.4k | 37.0k | 1 | 7m 4s |
| implement | 1.3k | 14.3k | 2.1M | 70.6k | 1 | 5m 52s |
| prepare_pr | 60 | 3.9k | 176.0k | 35.5k | 1 | 1m 5s |
| compose_pr | 59 | 2.0k | 168.1k | 16.4k | 1 | 50s |
| **Total** | 1.7k | 47.3k | 4.1M | 221.7k | | 20m 14s |