### PR TITLE
Group Recipes in `autoskillit order` Picker by Source Category

### DIFF
--- a/src/autoskillit/cli/_cook.py
+++ b/src/autoskillit/cli/_cook.py
@@ -11,6 +11,36 @@ from pathlib import Path
 from autoskillit.cli._terminal import terminal_guard
 
 
+def _print_recipes_list() -> None:
+    """Print available recipes grouped by category to stdout."""
+    from autoskillit.core import RecipeSource
+    from autoskillit.recipe import list_recipes
+
+    _GROUP_LABELS = {0: "Family Recipes", 1: "Bundled Recipes", 2: "Experimental"}
+
+    def _rank(r: object) -> int:
+        if r.experimental:  # type: ignore[attr-defined]
+            return 2
+        return 0 if r.source == RecipeSource.PROJECT else 1  # type: ignore[attr-defined]
+
+    recipes = list_recipes(Path.cwd()).items
+    if not recipes:
+        print("No recipes found.")
+        return
+
+    name_w = max(len(r.name) for r in recipes)
+    src_w = max(len(r.source) for r in recipes)
+    current_rank = -1
+    for r in recipes:
+        rank = _rank(r)
+        if rank != current_rank:
+            current_rank = rank
+            print(f"\n{_GROUP_LABELS[rank]}")
+            print(f"{'NAME':<{name_w}}  {'SOURCE':<{src_w}}  DESCRIPTION")
+            print(f"{'-' * name_w}  {'-' * src_w}  {'-' * 11}")
+        print(f"{r.name:<{name_w}}  {r.source:<{src_w}}  {r.description}")
+
+
 def _run_cook_session(
     *,
     cmd: list[str],

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -403,7 +403,15 @@ def workspace_clean(
 @recipes_app.command(name="list")
 def recipes_list():
     """List available recipes with sources."""
+    from autoskillit.core import RecipeSource
     from autoskillit.recipe import list_recipes
+
+    _GROUP_NAMES = {0: "Family Recipes", 1: "Bundled Recipes", 2: "Experimental"}
+
+    def _rank(r: object) -> int:
+        if r.experimental:  # type: ignore[attr-defined]
+            return 2
+        return 0 if r.source == RecipeSource.PROJECT else 1  # type: ignore[attr-defined]
 
     recipes = list_recipes(Path.cwd()).items
     if not recipes:
@@ -412,9 +420,14 @@ def recipes_list():
 
     name_w = max(len(r.name) for r in recipes)
     src_w = max(len(r.source) for r in recipes)
-    print(f"{'NAME':<{name_w}}  {'SOURCE':<{src_w}}  DESCRIPTION")
-    print(f"{'-' * name_w}  {'-' * src_w}  {'-' * 11}")
+    current_rank = -1
     for r in recipes:
+        rank = _rank(r)
+        if rank != current_rank:
+            current_rank = rank
+            print(f"\n{_GROUP_NAMES[rank]}")
+            print(f"{'NAME':<{name_w}}  {'SOURCE':<{src_w}}  DESCRIPTION")
+            print(f"{'-' * name_w}  {'-' * src_w}  {'-' * 11}")
         print(f"{r.name:<{name_w}}  {r.source:<{src_w}}  {r.description}")
 
 
@@ -591,9 +604,21 @@ def order(recipe: str | None = None, session_id: str | None = None, *, resume: b
         if not available:
             print("No recipes found. Run 'autoskillit recipes list' to check.")
             sys.exit(1)
+        _GROUP_HEADERS = {0: "Family Recipes", 1: "Bundled Recipes", 2: "Experimental"}
+
+        def _recipe_rank(r: object) -> int:
+            if r.experimental:  # type: ignore[attr-defined]
+                return 2
+            return 0 if r.source == RecipeSource.PROJECT else 1  # type: ignore[attr-defined]
+
         print("Available recipes:")
         print("  0. Open kitchen (no recipe)")
+        current_rank: int = -1
         for i, r in enumerate(available, 1):
+            rank = _recipe_rank(r)
+            if rank != current_rank:
+                current_rank = rank
+                print(f"\n  {_GROUP_HEADERS[rank]}")
             print(f"  {i}. {r.name}")
         raw = timed_prompt(
             f"Select recipe [0-{len(available)}]:",

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -403,32 +403,9 @@ def workspace_clean(
 @recipes_app.command(name="list")
 def recipes_list():
     """List available recipes with sources."""
-    from autoskillit.core import RecipeSource
-    from autoskillit.recipe import list_recipes
+    from autoskillit.cli._cook import _print_recipes_list
 
-    _GROUP_NAMES = {0: "Family Recipes", 1: "Bundled Recipes", 2: "Experimental"}
-
-    def _rank(r: object) -> int:
-        if r.experimental:  # type: ignore[attr-defined]
-            return 2
-        return 0 if r.source == RecipeSource.PROJECT else 1  # type: ignore[attr-defined]
-
-    recipes = list_recipes(Path.cwd()).items
-    if not recipes:
-        print("No recipes found.")
-        return
-
-    name_w = max(len(r.name) for r in recipes)
-    src_w = max(len(r.source) for r in recipes)
-    current_rank = -1
-    for r in recipes:
-        rank = _rank(r)
-        if rank != current_rank:
-            current_rank = rank
-            print(f"\n{_GROUP_NAMES[rank]}")
-            print(f"{'NAME':<{name_w}}  {'SOURCE':<{src_w}}  DESCRIPTION")
-            print(f"{'-' * name_w}  {'-' * src_w}  {'-' * 11}")
-        print(f"{r.name:<{name_w}}  {r.source:<{src_w}}  {r.description}")
+    _print_recipes_list()
 
 
 @recipes_app.command(name="show")

--- a/src/autoskillit/recipe/io.py
+++ b/src/autoskillit/recipe/io.py
@@ -67,6 +67,14 @@ def load_recipe(path: Path, temp_dir_relpath: str = ".autoskillit/temp") -> Reci
     return recipe
 
 
+def _group_rank(r: RecipeInfo) -> int:
+    if r.experimental:
+        return 2
+    if r.source == RecipeSource.PROJECT:
+        return 0
+    return 1
+
+
 def list_recipes(
     project_dir: Path,
     exclude_kinds: frozenset[RecipeKind] = frozenset(),
@@ -84,7 +92,7 @@ def list_recipes(
 
     filtered = [r for r in items if r.kind not in exclude_kinds] if exclude_kinds else items
     return LoadResult(
-        items=sorted(filtered, key=lambda r: (r.source != RecipeSource.BUILTIN, r.name)),
+        items=sorted(filtered, key=lambda r: (_group_rank(r), r.name)),
         errors=errors,
     )
 
@@ -416,6 +424,7 @@ def _collect_recipes(
                             content_hash=_crh(f),
                             content=raw,
                             kind=recipe.kind,
+                            experimental=recipe.experimental,
                         )
                     )
             except Exception as exc:

--- a/src/autoskillit/recipe/schema.py
+++ b/src/autoskillit/recipe/schema.py
@@ -178,6 +178,7 @@ class RecipeInfo:
     content_hash: str = ""
     content: str | None = None  # raw YAML text; None when set via parse_recipe_metadata
     kind: RecipeKind = RecipeKind.STANDARD
+    experimental: bool = False
 
 
 @dataclass

--- a/tests/cli/test_cook.py
+++ b/tests/cli/test_cook.py
@@ -1079,6 +1079,170 @@ class TestCLIOrder:
         env = mock_run.call_args[1].get("env") or {}
         assert "AUTOSKILLIT_LAUNCH_ID" in env
 
+    def test_order_picker_renders_family_recipes_header(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Picker must print 'Family Recipes' header when project recipes exist."""
+        from autoskillit.core import RecipeSource
+        from autoskillit.recipe.schema import RecipeInfo
+
+        project_recipe = RecipeInfo(
+            name="proj-recipe",
+            description="d",
+            source=RecipeSource.PROJECT,
+            path=tmp_path / "proj.yaml",
+            experimental=False,
+        )
+        monkeypatch.setattr(
+            "autoskillit.recipe.list_recipes",
+            lambda *a, **kw: type("R", (), {"items": [project_recipe]})(),
+        )
+        monkeypatch.setattr("autoskillit.cli._timed_input.timed_prompt", lambda *a, **kw: "0")
+        monkeypatch.chdir(tmp_path)
+
+        import autoskillit.cli.app as app_mod
+
+        with pytest.raises(SystemExit):
+            app_mod.order()
+
+        out = capsys.readouterr().out
+        assert "Family Recipes" in out
+
+    def test_order_picker_renders_bundled_recipes_header(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Picker must print 'Bundled Recipes' header when builtin recipes exist."""
+        from autoskillit.core import RecipeSource
+        from autoskillit.recipe.schema import RecipeInfo
+
+        builtin_recipe = RecipeInfo(
+            name="impl",
+            description="d",
+            source=RecipeSource.BUILTIN,
+            path=tmp_path / "impl.yaml",
+            experimental=False,
+        )
+        monkeypatch.setattr(
+            "autoskillit.recipe.list_recipes",
+            lambda *a, **kw: type("R", (), {"items": [builtin_recipe]})(),
+        )
+        monkeypatch.setattr("autoskillit.cli._timed_input.timed_prompt", lambda *a, **kw: "0")
+        monkeypatch.chdir(tmp_path)
+
+        import autoskillit.cli.app as app_mod
+
+        with pytest.raises(SystemExit):
+            app_mod.order()
+
+        out = capsys.readouterr().out
+        assert "Bundled Recipes" in out
+
+    def test_order_picker_renders_experimental_header(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Picker must print 'Experimental' header when experimental recipes exist."""
+        from autoskillit.core import RecipeSource
+        from autoskillit.recipe.schema import RecipeInfo
+
+        exp_recipe = RecipeInfo(
+            name="research",
+            description="d",
+            source=RecipeSource.BUILTIN,
+            path=tmp_path / "research.yaml",
+            experimental=True,
+        )
+        monkeypatch.setattr(
+            "autoskillit.recipe.list_recipes",
+            lambda *a, **kw: type("R", (), {"items": [exp_recipe]})(),
+        )
+        monkeypatch.setattr("autoskillit.cli._timed_input.timed_prompt", lambda *a, **kw: "0")
+        monkeypatch.chdir(tmp_path)
+
+        import autoskillit.cli.app as app_mod
+
+        with pytest.raises(SystemExit):
+            app_mod.order()
+
+        out = capsys.readouterr().out
+        assert "Experimental" in out
+
+    def test_order_picker_omits_empty_group_header(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Picker must not print 'Family Recipes' header when no project recipes exist."""
+        from autoskillit.core import RecipeSource
+        from autoskillit.recipe.schema import RecipeInfo
+
+        builtin_recipe = RecipeInfo(
+            name="impl",
+            description="d",
+            source=RecipeSource.BUILTIN,
+            path=tmp_path / "impl.yaml",
+            experimental=False,
+        )
+        monkeypatch.setattr(
+            "autoskillit.recipe.list_recipes",
+            lambda *a, **kw: type("R", (), {"items": [builtin_recipe]})(),
+        )
+        monkeypatch.setattr("autoskillit.cli._timed_input.timed_prompt", lambda *a, **kw: "0")
+        monkeypatch.chdir(tmp_path)
+
+        import autoskillit.cli.app as app_mod
+
+        with pytest.raises(SystemExit):
+            app_mod.order()
+
+        out = capsys.readouterr().out
+        assert "Family Recipes" not in out
+
+    def test_order_picker_contiguous_numbering_across_groups(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Picker numbering must be contiguous across all groups (1, 2, 3...)."""
+        import re
+
+        from autoskillit.core import RecipeSource
+        from autoskillit.recipe.schema import RecipeInfo
+
+        recipes = [
+            RecipeInfo(
+                name="proj-a",
+                description="d",
+                source=RecipeSource.PROJECT,
+                path=tmp_path / "a.yaml",
+                experimental=False,
+            ),
+            RecipeInfo(
+                name="impl",
+                description="d",
+                source=RecipeSource.BUILTIN,
+                path=tmp_path / "b.yaml",
+                experimental=False,
+            ),
+            RecipeInfo(
+                name="exp-r",
+                description="d",
+                source=RecipeSource.BUILTIN,
+                path=tmp_path / "c.yaml",
+                experimental=True,
+            ),
+        ]
+        monkeypatch.setattr(
+            "autoskillit.recipe.list_recipes", lambda *a, **kw: type("R", (), {"items": recipes})()
+        )
+        monkeypatch.setattr("autoskillit.cli._timed_input.timed_prompt", lambda *a, **kw: "0")
+        monkeypatch.chdir(tmp_path)
+
+        import autoskillit.cli.app as app_mod
+
+        with pytest.raises(SystemExit):
+            app_mod.order()
+
+        out = capsys.readouterr().out
+        numbered = re.findall(r"^\s+(\d+)\.", out, re.MULTILINE)
+        numbered_ints = [int(n) for n in numbered]
+        assert numbered_ints == list(range(1, len(recipes) + 1))
+
 
 class TestOrderDisplayOwnership:
     """order() delegates recipe display to the Claude session via load_recipe."""

--- a/tests/cli/test_cook.py
+++ b/tests/cli/test_cook.py
@@ -1098,12 +1098,12 @@ class TestCLIOrder:
             lambda *a, **kw: type("R", (), {"items": [project_recipe]})(),
         )
         monkeypatch.setattr("autoskillit.cli._timed_input.timed_prompt", lambda *a, **kw: "0")
+        monkeypatch.setattr(shutil, "which", lambda cmd: None)
+        monkeypatch.delenv("CLAUDECODE", raising=False)
         monkeypatch.chdir(tmp_path)
 
-        import autoskillit.cli.app as app_mod
-
         with pytest.raises(SystemExit):
-            app_mod.order()
+            cli.order()
 
         out = capsys.readouterr().out
         assert "Family Recipes" in out
@@ -1127,12 +1127,12 @@ class TestCLIOrder:
             lambda *a, **kw: type("R", (), {"items": [builtin_recipe]})(),
         )
         monkeypatch.setattr("autoskillit.cli._timed_input.timed_prompt", lambda *a, **kw: "0")
+        monkeypatch.setattr(shutil, "which", lambda cmd: None)
+        monkeypatch.delenv("CLAUDECODE", raising=False)
         monkeypatch.chdir(tmp_path)
 
-        import autoskillit.cli.app as app_mod
-
         with pytest.raises(SystemExit):
-            app_mod.order()
+            cli.order()
 
         out = capsys.readouterr().out
         assert "Bundled Recipes" in out
@@ -1156,12 +1156,12 @@ class TestCLIOrder:
             lambda *a, **kw: type("R", (), {"items": [exp_recipe]})(),
         )
         monkeypatch.setattr("autoskillit.cli._timed_input.timed_prompt", lambda *a, **kw: "0")
+        monkeypatch.setattr(shutil, "which", lambda cmd: None)
+        monkeypatch.delenv("CLAUDECODE", raising=False)
         monkeypatch.chdir(tmp_path)
 
-        import autoskillit.cli.app as app_mod
-
         with pytest.raises(SystemExit):
-            app_mod.order()
+            cli.order()
 
         out = capsys.readouterr().out
         assert "Experimental" in out
@@ -1185,12 +1185,12 @@ class TestCLIOrder:
             lambda *a, **kw: type("R", (), {"items": [builtin_recipe]})(),
         )
         monkeypatch.setattr("autoskillit.cli._timed_input.timed_prompt", lambda *a, **kw: "0")
+        monkeypatch.setattr(shutil, "which", lambda cmd: None)
+        monkeypatch.delenv("CLAUDECODE", raising=False)
         monkeypatch.chdir(tmp_path)
 
-        import autoskillit.cli.app as app_mod
-
         with pytest.raises(SystemExit):
-            app_mod.order()
+            cli.order()
 
         out = capsys.readouterr().out
         assert "Family Recipes" not in out
@@ -1231,12 +1231,12 @@ class TestCLIOrder:
             "autoskillit.recipe.list_recipes", lambda *a, **kw: type("R", (), {"items": recipes})()
         )
         monkeypatch.setattr("autoskillit.cli._timed_input.timed_prompt", lambda *a, **kw: "0")
+        monkeypatch.setattr(shutil, "which", lambda cmd: None)
+        monkeypatch.delenv("CLAUDECODE", raising=False)
         monkeypatch.chdir(tmp_path)
 
-        import autoskillit.cli.app as app_mod
-
         with pytest.raises(SystemExit):
-            app_mod.order()
+            cli.order()
 
         out = capsys.readouterr().out
         numbered = re.findall(r"^\s+(\d+)\.", out, re.MULTILINE)

--- a/tests/cli/test_cook.py
+++ b/tests/cli/test_cook.py
@@ -1239,7 +1239,7 @@ class TestCLIOrder:
             cli.order()
 
         out = capsys.readouterr().out
-        numbered = re.findall(r"^\s+(\d+)\.", out, re.MULTILINE)
+        numbered = re.findall(r"^\s+([1-9]\d*)\.", out, re.MULTILINE)
         numbered_ints = [int(n) for n in numbered]
         assert numbered_ints == list(range(1, len(recipes) + 1))
 

--- a/tests/recipe/test_io.py
+++ b/tests/recipe/test_io.py
@@ -488,24 +488,22 @@ class TestListRecipes:
         assert len(recipes) > 0
         assert all(r.source.value in ("project", "builtin") for r in recipes)
 
-    def test_list_recipes_bundled_appear_before_project(self, tmp_path: Path) -> None:
-        """Bundled recipes must appear before project recipes in list_recipes() output."""
+    def test_list_recipes_project_appear_before_bundled(self, tmp_path: Path) -> None:
+        """Project recipes must appear before bundled recipes in list_recipes() output."""
         recipes_dir = tmp_path / ".autoskillit" / "recipes"
         recipes_dir.mkdir(parents=True)
-        # Write a project recipe whose name would sort before bundled "implementation"
         (recipes_dir / "aardvark.yaml").write_text(
             "name: aardvark\ndescription: test\nsteps: {}\n"
         )
         result = list_recipes(tmp_path)
-        sources = [r.source for r in result.items]
-        # All BUILTIN items must precede all PROJECT items
-        seen_project = False
+        sources = [r.source for r in result.items if not r.experimental]
+        seen_builtin = False
         for source in sources:
-            if source == RecipeSource.PROJECT:
-                seen_project = True
-            elif source == RecipeSource.BUILTIN:
-                assert not seen_project, (
-                    "A BUILTIN recipe appeared after a PROJECT recipe — ordering is broken"
+            if source == RecipeSource.BUILTIN:
+                seen_builtin = True
+            elif source == RecipeSource.PROJECT:
+                assert not seen_builtin, (
+                    "A PROJECT recipe appeared after a BUILTIN recipe — ordering is broken"
                 )
 
     def test_list_recipes_alphabetical_within_bundled_tier(self, tmp_path: Path) -> None:
@@ -563,6 +561,79 @@ class TestListRecipes:
         kinds = {r.name: r.kind for r in result.items}
         assert kinds["std"] == RecipeKind.STANDARD
         assert kinds["camp"] == RecipeKind.CAMPAIGN
+
+    def test_recipe_info_experimental_field_false_by_default(self, tmp_path: Path) -> None:
+        """RecipeInfo.experimental must default to False for standard recipes."""
+        recipe_dir = tmp_path / ".autoskillit" / "recipes"
+        recipe_dir.mkdir(parents=True)
+        (recipe_dir / "plain.yaml").write_text("name: plain\ndescription: plain\nsteps: {}\n")
+        result = list_recipes(tmp_path)
+        r = next(r for r in result.items if r.name == "plain")
+        assert r.experimental is False
+
+    def test_recipe_info_experimental_field_true_when_set(self, tmp_path: Path) -> None:
+        """RecipeInfo.experimental must be True when YAML sets experimental: true."""
+        recipe_dir = tmp_path / ".autoskillit" / "recipes"
+        recipe_dir.mkdir(parents=True)
+        (recipe_dir / "research.yaml").write_text(
+            "name: research\ndescription: exp\nexperimental: true\nsteps: {}\n"
+        )
+        result = list_recipes(tmp_path)
+        r = next(r for r in result.items if r.name == "research")
+        assert r.experimental is True
+
+    def test_list_recipes_project_before_bundled_before_experimental(self, tmp_path: Path) -> None:
+        """list_recipes must order: PROJECT → BUILTIN-non-experimental → experimental."""
+        recipe_dir = tmp_path / ".autoskillit" / "recipes"
+        recipe_dir.mkdir(parents=True)
+        (recipe_dir / "proj.yaml").write_text("name: proj\ndescription: p\nsteps: {}\n")
+        (recipe_dir / "exp-proj.yaml").write_text(
+            "name: exp-proj\ndescription: ep\nexperimental: true\nsteps: {}\n"
+        )
+        result = list_recipes(tmp_path)
+        ranks = []
+        for r in result.items:
+            if r.experimental:
+                rank = 2
+            elif r.source == RecipeSource.PROJECT:
+                rank = 0
+            else:
+                rank = 1
+            if not ranks or ranks[-1] != rank:
+                ranks.append(rank)
+        assert ranks == sorted(ranks), f"Groups interleaved: {ranks}"
+        assert 0 in ranks and 1 in ranks
+        assert ranks.index(0) < ranks.index(1)
+        assert 2 in ranks
+        assert ranks[-1] == 2
+
+    def test_list_recipes_alphabetical_within_experimental_group(self, tmp_path: Path) -> None:
+        """Experimental recipes must be sorted alphabetically by name within their group."""
+        recipe_dir = tmp_path / ".autoskillit" / "recipes"
+        recipe_dir.mkdir(parents=True)
+        for name in ("zebra-exp", "apple-exp", "mango-exp"):
+            (recipe_dir / f"{name}.yaml").write_text(
+                f"name: {name}\ndescription: test\nexperimental: true\nsteps: {{}}\n"
+            )
+        result = list_recipes(tmp_path)
+        exp_names = [r.name for r in result.items if r.experimental]
+        assert exp_names == sorted(exp_names)
+
+    def test_list_recipes_bundled_experimental_sorted_last(self, tmp_path: Path) -> None:
+        """A BUILTIN recipe with experimental: true must appear after non-experimental builtins."""
+        result = list_recipes(tmp_path)
+        non_exp_builtin_indices = [
+            i
+            for i, r in enumerate(result.items)
+            if r.source == RecipeSource.BUILTIN and not r.experimental
+        ]
+        exp_builtin_indices = [
+            i
+            for i, r in enumerate(result.items)
+            if r.source == RecipeSource.BUILTIN and r.experimental
+        ]
+        if non_exp_builtin_indices and exp_builtin_indices:
+            assert max(non_exp_builtin_indices) < min(exp_builtin_indices)
 
 
 class TestBuiltinRecipesDir:

--- a/tests/recipe/test_schema.py
+++ b/tests/recipe/test_schema.py
@@ -464,3 +464,32 @@ def test_campaign_recipe_construction() -> None:
     assert r.requires_packs == []
     assert r.allowed_recipes == []
     assert r.categories == []
+
+
+def test_recipe_info_has_experimental_field() -> None:
+    """RecipeInfo must have an experimental field defaulting to False."""
+    from pathlib import Path
+
+    from autoskillit.core import RecipeSource
+    from autoskillit.recipe.schema import RecipeInfo
+
+    r = RecipeInfo(name="x", description="d", source=RecipeSource.BUILTIN, path=Path("/x.yaml"))
+    assert hasattr(r, "experimental")
+    assert r.experimental is False
+
+
+def test_recipe_info_experimental_can_be_set_true() -> None:
+    """RecipeInfo.experimental must be settable to True."""
+    from pathlib import Path
+
+    from autoskillit.core import RecipeSource
+    from autoskillit.recipe.schema import RecipeInfo
+
+    r = RecipeInfo(
+        name="x",
+        description="d",
+        source=RecipeSource.BUILTIN,
+        path=Path("/x.yaml"),
+        experimental=True,
+    )
+    assert r.experimental is True


### PR DESCRIPTION
## Summary

The `autoskillit order` interactive picker and `recipes list` CLI currently display recipes in a flat list with builtins before project recipes. This change adds three visual groups — **Family Recipes** (project-local), **Bundled Recipes** (non-experimental builtins), and **Experimental** (any recipe with `experimental: true`) — sorted in that order with section headers rendered between groups.

Four changes are required:
1. Add `experimental: bool = False` to `RecipeInfo` dataclass (`schema.py`)
2. Forward `recipe.experimental` when constructing `RecipeInfo` in `_collect_recipes` (`io.py`)
3. Replace the 2-tuple sort key in `list_recipes` with a 3-bucket `_group_rank` function (`io.py`)
4. Render group headers in the `order` picker and `recipes list` CLI (`app.py`)

Closes #1263

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260426-053020-331782/.autoskillit/temp/make-plan/feat_group_recipes_in_order_picker_plan_2026-04-26_053343.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 155 | 13.3k | 650.7k | 54.2k | 1 | 5m 44s |
| verify | 92 | 12.9k | 392.6k | 39.5k | 1 | 7m 32s |
| implement | 300 | 13.2k | 1.6M | 52.5k | 1 | 5m 25s |
| fix | 336 | 42.2k | 3.4M | 109.3k | 1 | 19m 47s |
| prepare_pr | 60 | 4.7k | 203.9k | 27.5k | 1 | 1m 29s |
| compose_pr | 51 | 2.0k | 141.3k | 16.6k | 1 | 44s |
| **Total** | 994 | 88.4k | 6.4M | 299.6k | | 40m 43s |