### PR TITLE
Implementation Plan: API & Registry Hygiene — Naming, Redundancy, and Convention Cleanup

### DIFF
--- a/src/autoskillit/cli/_fleet.py
+++ b/src/autoskillit/cli/_fleet.py
@@ -653,9 +653,6 @@ def fleet_dispatch() -> None:
     if os.environ.get("AUTOSKILLIT_SESSION_TYPE") == "leaf":
         print("ERROR: 'fleet dispatch' cannot run inside a leaf session.")
         sys.exit(1)
-    if shutil.which("claude") is None:
-        print("ERROR: 'claude' not found. Install: https://docs.anthropic.com/en/docs/claude-code")
-        sys.exit(1)
 
     from autoskillit.config import load_config
 
@@ -678,9 +675,6 @@ def fleet_campaign(
         sys.exit(1)
     if os.environ.get("AUTOSKILLIT_SESSION_TYPE") == "leaf":
         print("ERROR: 'fleet campaign' cannot run inside a leaf session.")
-        sys.exit(1)
-    if shutil.which("claude") is None:
-        print("ERROR: 'claude' not found. Install: https://docs.anthropic.com/en/docs/claude-code")
         sys.exit(1)
 
     from autoskillit.config import load_config

--- a/src/autoskillit/core/_type_constants.py
+++ b/src/autoskillit/core/_type_constants.py
@@ -368,7 +368,6 @@ TOOL_SUBSET_TAGS: dict[str, frozenset[str]] = {
 class FeatureDef:
     """Definition of a named feature gate."""
 
-    name: str
     lifecycle: FeatureLifecycle
     description: str
     tool_tags: frozenset[str]
@@ -383,7 +382,6 @@ class FeatureDef:
 
 FEATURE_REGISTRY: dict[str, FeatureDef] = {
     "fleet": FeatureDef(
-        name="fleet",
         lifecycle=FeatureLifecycle.EXPERIMENTAL,
         description="L3 Fleet Orchestrator — multi-session campaign dispatch",
         tool_tags=frozenset({"fleet"}),
@@ -394,7 +392,6 @@ FEATURE_REGISTRY: dict[str, FeatureDef] = {
         since_version="0.9.119",
     ),
     "planner": FeatureDef(
-        name="planner",
         lifecycle=FeatureLifecycle.EXPERIMENTAL,
         description=(
             "Progressive resolution planner — 3-pass sequential decomposition"
@@ -424,11 +421,6 @@ if not all(
         "FeatureDef.tool_tags contains a tag not present in TOOL_SUBSET_TAGS values. "
         "Add the tag to the appropriate tool entry in TOOL_SUBSET_TAGS first."
     )
-
-# Guard: FEATURE_REGISTRY key must equal FeatureDef.name — checked at import time.
-_mismatches = {k: defn.name for k, defn in FEATURE_REGISTRY.items() if k != defn.name}
-if _mismatches:
-    raise AssertionError(f"FEATURE_REGISTRY key/name mismatch: {_mismatches}")
 
 
 # Canonical prefix required for all skill_command values passed to run_skill.

--- a/src/autoskillit/hooks/fleet_dispatch_guard.py
+++ b/src/autoskillit/hooks/fleet_dispatch_guard.py
@@ -24,7 +24,10 @@ def main() -> None:
         sys.stderr.write("fleet_dispatch_guard: unexpected JSON root type — failing open\n")
         sys.exit(0)
 
-    # Interactive sessions always pass
+    # AUTOSKILLIT_HEADLESS is the sole discriminator. Hook payload cross-check
+    # (session_type field) would add defence-in-depth against local env
+    # manipulation, but the attack surface is narrowly local and the env var
+    # is set by our own launcher — not user-supplied input.
     if os.environ.get("AUTOSKILLIT_HEADLESS") != "1":
         sys.exit(0)
 

--- a/src/autoskillit/recipe/_analysis.py
+++ b/src/autoskillit/recipe/_analysis.py
@@ -393,7 +393,7 @@ def extract_blocks(
 # ---------------------------------------------------------------------------
 
 
-def _bfs_reachable(graph: dict[str, set[str]], start: str) -> set[str]:
+def bfs_reachable(graph: dict[str, set[str]], start: str) -> set[str]:
     """Return all step names reachable from ``start`` in the routing graph (excluding start)."""
     visited: set[str] = set()
     queue = list(graph.get(start, set()))
@@ -694,7 +694,7 @@ def _detect_dead_outputs(recipe: Recipe, graph: dict[str, set[str]]) -> list[Dat
             continue
 
         # BFS: collect all steps reachable from this step
-        reachable = _bfs_reachable(graph, step_name)
+        reachable = bfs_reachable(graph, step_name)
 
         # Collect all context.X references in reachable steps' with_args and
         # on_result condition when-expressions (route actions gate on context vars).

--- a/src/autoskillit/recipe/repository.py
+++ b/src/autoskillit/recipe/repository.py
@@ -62,6 +62,13 @@ class DefaultRecipeRepository:
         return next((r for r in result.items if r.name == name), None)
 
     def load(self, path: Path) -> Recipe:
+        """Load and parse the recipe at *path*.
+
+        Exceptions raised by :func:`load_recipe` (e.g. ``FileNotFoundError``,
+        ``yaml.YAMLError``, ``ValidationError``) are intentionally not wrapped —
+        thin delegation is the contract. Callers that need a uniform error type
+        should catch at the call site.
+        """
         return load_recipe(path)
 
     def list(self, project_dir: Path) -> LoadResult[RecipeInfo]:

--- a/src/autoskillit/recipe/rules_features.py
+++ b/src/autoskillit/recipe/rules_features.py
@@ -24,9 +24,9 @@ def _tools_for_feature(fdef: FeatureDef) -> frozenset[str]:
     return frozenset(tool for tool, tags in TOOL_SUBSET_TAGS.items() if fdef.tool_tags & tags)
 
 
-def _get_disabled_feature_defs(ctx: ValidationContext) -> list[FeatureDef]:
-    """Return FeatureDef objects for all features named in ctx.disabled_features."""
-    return [fdef for name, fdef in FEATURE_REGISTRY.items() if name in ctx.disabled_features]
+def _get_disabled_feature_defs(ctx: ValidationContext) -> dict[str, FeatureDef]:
+    """Return {feature_name: FeatureDef} for all features named in ctx.disabled_features."""
+    return {name: fdef for name, fdef in FEATURE_REGISTRY.items() if name in ctx.disabled_features}
 
 
 def _get_skill_category_map(lister: SkillLister | None = None) -> dict[str, frozenset[str]]:
@@ -55,13 +55,13 @@ def check_feature_gated_tools(ctx: ValidationContext) -> list[RuleFinding]:
     findings: list[RuleFinding] = []
 
     # Hoist per-feature tool sets and category_map outside the step loop
-    feature_tools = {fdef: _tools_for_feature(fdef) for fdef in disabled_fdefs}
+    feature_tools = {fdef: _tools_for_feature(fdef) for fdef in disabled_fdefs.values()}
     category_map = (
         ctx.skill_category_map if ctx.skill_category_map is not None else _get_skill_category_map()
     )
 
     for step_name, step in ctx.recipe.steps.items():
-        for fdef in disabled_fdefs:
+        for fname, fdef in disabled_fdefs.items():
             # --- Tool check ---
             if step.tool and step.tool in feature_tools[fdef]:
                 findings.append(
@@ -71,8 +71,8 @@ def check_feature_gated_tools(ctx: ValidationContext) -> list[RuleFinding]:
                         step_name=step_name,
                         message=(
                             f"step '{step_name}': tool '{step.tool}' belongs to "
-                            f"disabled feature '{fdef.name}'. "
-                            f"Enable '{fdef.name}' in .autoskillit/config.yaml "
+                            f"disabled feature '{fname}'. "
+                            f"Enable '{fname}' in .autoskillit/config.yaml "
                             f"features to use this tool."
                         ),
                     )
@@ -91,8 +91,8 @@ def check_feature_gated_tools(ctx: ValidationContext) -> list[RuleFinding]:
                         message=(
                             f"step '{step_name}': run_python callable "
                             f"'{(step.with_args or {}).get('callable', '')}' "
-                            f"belongs to disabled feature '{fdef.name}'. "
-                            f"Enable '{fdef.name}' in .autoskillit/config.yaml "
+                            f"belongs to disabled feature '{fname}'. "
+                            f"Enable '{fname}' in .autoskillit/config.yaml "
                             f"features to use this callable."
                         ),
                     )
@@ -115,8 +115,8 @@ def check_feature_gated_tools(ctx: ValidationContext) -> list[RuleFinding]:
                         message=(
                             f"step '{step_name}': skill_command '{skill_cmd}' references "
                             f"skill '{skill_name}' which belongs to disabled feature "
-                            f"'{fdef.name}'. "
-                            f"Enable '{fdef.name}' in .autoskillit/config.yaml "
+                            f"'{fname}'. "
+                            f"Enable '{fname}' in .autoskillit/config.yaml "
                             f"features to use this skill."
                         ),
                     )

--- a/src/autoskillit/recipe/rules_merge.py
+++ b/src/autoskillit/recipe/rules_merge.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 
 from autoskillit.core import MergeFailedStep, Severity, get_logger
-from autoskillit.recipe._analysis import ValidationContext, _bfs_reachable
+from autoskillit.recipe._analysis import ValidationContext, bfs_reachable
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
 
 logger = get_logger(__name__)
@@ -302,7 +302,7 @@ def _check_merge_enrollment_auto_consistency(ctx: ValidationContext) -> list[Rul
                     no_auto_targets.add(cond.route)
 
     for target in no_auto_targets:
-        reachable = _bfs_reachable(ctx.step_graph, target) | {target}
+        reachable = bfs_reachable(ctx.step_graph, target) | {target}
         for reached in reachable:
             if _is_auto_flagged_step(reached, ctx):
                 findings.append(

--- a/src/autoskillit/recipe/rules_reachability.py
+++ b/src/autoskillit/recipe/rules_reachability.py
@@ -24,8 +24,8 @@ import re
 from autoskillit.core import Severity
 from autoskillit.recipe._analysis import (
     ValidationContext,
-    _bfs_reachable,
     _bfs_with_facts,
+    bfs_reachable,
 )
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
 
@@ -61,7 +61,7 @@ def _find_capture_producers(ctx: ValidationContext, var: str) -> list[str]:
 
 def _ancestors(ctx: ValidationContext, step_name: str) -> set[str]:
     """Return all steps reachable via backward BFS from step_name (i.e. ancestors)."""
-    return _bfs_reachable(ctx.predecessors, step_name)
+    return bfs_reachable(ctx.predecessors, step_name)
 
 
 @semantic_rule(

--- a/src/autoskillit/recipe/schema.py
+++ b/src/autoskillit/recipe/schema.py
@@ -10,7 +10,7 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Final
 
-from autoskillit.core import RecipeSource
+from autoskillit.core import RECIPE_PACK_TAGS, RecipeSource
 
 AUTOSKILLIT_VERSION_KEY: Final = "autoskillit_version"
 RECIPE_VERSION_KEY: Final = "recipe_version"
@@ -150,10 +150,14 @@ class Recipe:
     composite_hash: str = ""
     experimental: bool = False
     requires_packs: list[str] = field(default_factory=list)
+    # Keys from PACK_REGISTRY (skill pack names, e.g. "fleet", "planner").
+    # Named 'requires_packs' (not 'requires_skill_packs') for brevity.
     kind: RecipeKind = RecipeKind.STANDARD
     categories: list[str] = field(default_factory=list)
     dispatches: list[CampaignDispatch] = field(default_factory=list)
     requires_recipe_packs: list[str] = field(default_factory=list)
+    # Keys from RECIPE_PACK_REGISTRY. Named 'requires_recipe_packs' to
+    # distinguish from 'requires_packs'; the asymmetry is intentional.
     allowed_recipes: list[str] = field(default_factory=list)
     continue_on_failure: bool = False
     # Populated by extract_blocks() during load; empty tuple for recipes with no block: anchors.
@@ -164,6 +168,11 @@ class Recipe:
         self.description = self.description.strip()
         self.summary = self.summary.strip()
         self.kitchen_rules = [rule.strip() for rule in self.kitchen_rules]
+        unknown_cats = set(self.categories) - RECIPE_PACK_TAGS
+        if unknown_cats:
+            raise ValueError(
+                f"Unknown categories {sorted(unknown_cats)!r}. Valid: {sorted(RECIPE_PACK_TAGS)}"
+            )
 
 
 @dataclass

--- a/src/autoskillit/recipes/planner.yaml
+++ b/src/autoskillit/recipes/planner.yaml
@@ -8,7 +8,7 @@ description: |
 summary: "init > analyze > [extract_domain?] > phases-loop > assignments-loop > wps-loop > reconcile > validate/refine > compile"
 
 requires_packs: [kitchen-core]
-categories: [planner]
+categories: [orchestration-family]
 
 kitchen_rules:
   - Never invoke native Claude Code tools (Read, Grep, Glob, Edit, Write, Bash, Agent,

--- a/src/autoskillit/server/_session_type.py
+++ b/src/autoskillit/server/_session_type.py
@@ -10,6 +10,7 @@ import os
 
 from autoskillit.core import (
     CATEGORY_TAGS,
+    FEATURE_REGISTRY,
     FLEET_DISPATCH_MODE,
     FLEET_MODE_ENV_VAR,
     HEADLESS_ENV_VAR,
@@ -19,6 +20,11 @@ from autoskillit.core import (
 from autoskillit.core import session_type as _resolve_session_type
 
 _log = get_logger(__name__)
+
+
+def _collect_fleet_tool_tags() -> frozenset[str]:
+    """Return the union of all tool_tags across FEATURE_REGISTRY entries."""
+    return frozenset().union(*(fdef.tool_tags for fdef in FEATURE_REGISTRY.values()))
 
 
 def _apply_session_type_visibility() -> None:
@@ -34,7 +40,9 @@ def _apply_session_type_visibility() -> None:
     _headless = os.environ.get(HEADLESS_ENV_VAR) == "1"
 
     if _session is SessionType.FLEET:
-        mcp.enable(tags={"fleet"})
+        fleet_tags = _collect_fleet_tool_tags()
+        if fleet_tags:
+            mcp.enable(tags=set(fleet_tags))
         if os.environ.get(FLEET_MODE_ENV_VAR) == FLEET_DISPATCH_MODE:
             mcp.enable(tags={"fleet-dispatch"})
     elif _session is SessionType.ORCHESTRATOR and _headless:

--- a/tests/arch/test_feature_registry.py
+++ b/tests/arch/test_feature_registry.py
@@ -30,22 +30,14 @@ def test_feature_registry_keys_are_sorted():
     assert keys == sorted(keys), f"FEATURE_REGISTRY keys not sorted: {keys}"
 
 
-def test_feature_registry_key_name_consistency() -> None:
-    """FEATURE_REGISTRY key must equal FeatureDef.name for every entry."""
-    from autoskillit.core._type_constants import FEATURE_REGISTRY
-
-    mismatches = {k: defn.name for k, defn in FEATURE_REGISTRY.items() if k != defn.name}
-    assert not mismatches, f"FEATURE_REGISTRY key/name mismatch: {mismatches}"
-
-
 def test_feature_tool_tags_exist_in_subset_tags():
     """Every FeatureDef.tool_tags entry exists in TOOL_SUBSET_TAGS tag values."""
     from autoskillit.core._type_constants import FEATURE_REGISTRY, TOOL_SUBSET_TAGS
 
     all_tags = frozenset(tag for tags in TOOL_SUBSET_TAGS.values() for tag in tags)
     violations = [
-        f"{defn.name}.tool_tags contains {tag!r} not in TOOL_SUBSET_TAGS"
-        for defn in FEATURE_REGISTRY.values()
+        f"{k}.tool_tags contains {tag!r} not in TOOL_SUBSET_TAGS"
+        for k, defn in FEATURE_REGISTRY.items()
         for tag in defn.tool_tags
         if tag not in all_tags
     ]
@@ -57,13 +49,13 @@ def test_feature_import_package_exists():
     from autoskillit.core._type_constants import FEATURE_REGISTRY
 
     failures = []
-    for defn in FEATURE_REGISTRY.values():
+    for k, defn in FEATURE_REGISTRY.items():
         if defn.import_package is None:
             continue
         try:
             importlib.import_module(defn.import_package)
         except ImportError as e:
-            failures.append(f"{defn.name}.import_package={defn.import_package!r}: {e}")
+            failures.append(f"{k}.import_package={defn.import_package!r}: {e}")
     assert not failures, "\n".join(failures)
 
 
@@ -81,8 +73,8 @@ def test_stable_features_are_default_enabled():
     from autoskillit.core._type_enums import FeatureLifecycle
 
     violations = [
-        defn.name
-        for defn in FEATURE_REGISTRY.values()
+        k
+        for k, defn in FEATURE_REGISTRY.items()
         if defn.lifecycle == FeatureLifecycle.STABLE and not defn.default_enabled
     ]
     assert not violations, f"STABLE features must be default_enabled=True: {violations}"
@@ -94,8 +86,8 @@ def test_sunset_dates_not_expired():
 
     today = date.today()
     expired = [
-        f"{defn.name} (sunset={defn.sunset_date})"
-        for defn in FEATURE_REGISTRY.values()
+        f"{k} (sunset={defn.sunset_date})"
+        for k, defn in FEATURE_REGISTRY.items()
         if defn.sunset_date is not None and defn.sunset_date < today
     ]
     assert not expired, f"Features with expired sunset_date: {expired}"
@@ -106,8 +98,8 @@ def test_feature_depends_on_references_valid_features():
     from autoskillit.core._type_constants import FEATURE_REGISTRY
 
     violations = [
-        f"{defn.name}.depends_on contains unknown {dep!r}"
-        for defn in FEATURE_REGISTRY.values()
+        f"{k}.depends_on contains unknown {dep!r}"
+        for k, defn in FEATURE_REGISTRY.items()
         for dep in defn.depends_on
         if dep not in FEATURE_REGISTRY
     ]
@@ -145,11 +137,8 @@ def test_feature_skill_categories_match_real_skills():
                 all_category_tags.update(str(c) for c in cats)
 
     violations = [
-        (
-            f"{defn.name}.skill_categories contains {cat!r}:"
-            " no skill declares this category in frontmatter"
-        )
-        for defn in FEATURE_REGISTRY.values()
+        (f"{k}.skill_categories contains {cat!r}: no skill declares this category in frontmatter")
+        for k, defn in FEATURE_REGISTRY.items()
         for cat in defn.skill_categories
         if cat not in all_category_tags
     ]
@@ -222,7 +211,6 @@ def test_config_dependency_validation(monkeypatch):
 
     # Temporarily patch FEATURE_REGISTRY with a dep-requiring entry for this test
     dep_feature = FeatureDef(
-        name="test_dep_b",
         lifecycle=FeatureLifecycle.EXPERIMENTAL,
         description="test dep B",
         tool_tags=frozenset(),
@@ -231,7 +219,6 @@ def test_config_dependency_validation(monkeypatch):
         depends_on=frozenset({"test_dep_a"}),
     )
     dep_parent = FeatureDef(
-        name="test_dep_a",
         lifecycle=FeatureLifecycle.EXPERIMENTAL,
         description="test dep A",
         tool_tags=frozenset(),
@@ -284,12 +271,6 @@ def test_fleet_in_feature_registry():
     assert "fleet" in FEATURE_REGISTRY
 
 
-def test_fleet_feature_def_name_matches_key():
-    from autoskillit.core._type_constants import FEATURE_REGISTRY
-
-    assert FEATURE_REGISTRY["fleet"].name == "fleet"
-
-
 def test_fleet_feature_tool_tags_in_tool_subset_tags():
     from autoskillit.core._type_constants import FEATURE_REGISTRY, TOOL_SUBSET_TAGS
 
@@ -331,7 +312,6 @@ def test_is_feature_enabled_disabled_lifecycle_always_false(monkeypatch):
     from autoskillit.core.feature_flags import is_feature_enabled
 
     disabled_def = FeatureDef(
-        name="test_disabled_feat",
         lifecycle=FeatureLifecycle.DISABLED,
         description="disabled test feature",
         tool_tags=frozenset(),
@@ -356,7 +336,6 @@ def test_build_features_dict_rejects_enabling_disabled_feature(monkeypatch):
     from autoskillit.core._type_enums import FeatureLifecycle
 
     disabled_def = FeatureDef(
-        name="test_cannot_enable",
         lifecycle=FeatureLifecycle.DISABLED,
         description="cannot enable",
         tool_tags=frozenset(),
@@ -381,7 +360,6 @@ def test_is_feature_enabled_experimental_blanket(monkeypatch):
     from autoskillit.core.feature_flags import is_feature_enabled
 
     exp_def = FeatureDef(
-        name="test_exp_feat",
         lifecycle=FeatureLifecycle.EXPERIMENTAL,
         description="experimental",
         tool_tags=frozenset(),
@@ -406,7 +384,6 @@ def test_is_feature_enabled_stable_unaffected_by_experimental_enabled(monkeypatc
     from autoskillit.core.feature_flags import is_feature_enabled
 
     stable_def = FeatureDef(
-        name="test_stable_feat",
         lifecycle=FeatureLifecycle.STABLE,
         description="stable",
         tool_tags=frozenset(),

--- a/tests/arch/test_layer_enforcement.py
+++ b/tests/arch/test_layer_enforcement.py
@@ -444,7 +444,7 @@ def test_layer_enforcement_detects_upward_import(tmp_path: Path) -> None:
 def test_l0_no_dynamic_internal_imports() -> None:
     """L0 code must not dynamically import autoskillit subpackages."""
     violations = []
-    for src_file in sorted(_CORE_SRC.glob("*.py")):
+    for src_file in sorted(_CORE_SRC.rglob("*.py")):
         tree = ast.parse(src_file.read_text(), filename=str(src_file))
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call):

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -2353,7 +2353,6 @@ class TestGroupNFeatureGateDoctorChecks:
         from autoskillit.core._type_constants import FeatureDef, FeatureLifecycle
 
         fake_feature = FeatureDef(
-            name="test_feature",
             lifecycle=FeatureLifecycle.EXPERIMENTAL,
             description="test feature with dep",
             tool_tags=frozenset(),
@@ -2380,7 +2379,6 @@ class TestGroupNFeatureGateDoctorChecks:
         from autoskillit.core._type_constants import FeatureDef, FeatureLifecycle
 
         fake_feature = FeatureDef(
-            name="test_feature",
             lifecycle=FeatureLifecycle.EXPERIMENTAL,
             description="test feature with dep",
             tool_tags=frozenset(),
@@ -2425,7 +2423,6 @@ class TestGroupNFeatureGateDoctorChecks:
         from autoskillit.core._type_constants import FeatureDef, FeatureLifecycle
 
         bad_feature = FeatureDef(
-            name="bad_feature",
             lifecycle=FeatureLifecycle.EXPERIMENTAL,
             description="feature with bad import",
             tool_tags=frozenset(),

--- a/tests/core/test_feature_flags.py
+++ b/tests/core/test_feature_flags.py
@@ -46,7 +46,6 @@ class TestCollectDisabledFeatureTags:
         from autoskillit.core.feature_flags import _collect_disabled_feature_tags
 
         fake_def = FeatureDef(
-            name="testgate",
             lifecycle=FeatureLifecycle.EXPERIMENTAL,
             description="Test-only gate",
             tool_tags=frozenset({"testgate-tool"}),
@@ -67,7 +66,6 @@ class TestCollectDisabledFeatureTags:
 
         shared_tag = frozenset({"shared-tag"})
         def_a = FeatureDef(
-            name="feat_a",
             lifecycle=FeatureLifecycle.EXPERIMENTAL,
             description="A",
             tool_tags=shared_tag,
@@ -76,7 +74,6 @@ class TestCollectDisabledFeatureTags:
             default_enabled=False,
         )
         def_b = FeatureDef(
-            name="feat_b",
             lifecycle=FeatureLifecycle.EXPERIMENTAL,
             description="B",
             tool_tags=shared_tag,

--- a/tests/core/test_type_constants.py
+++ b/tests/core/test_type_constants.py
@@ -218,3 +218,18 @@ def test_fleet_menu_tools_not_in_fleet_init() -> None:
     assert result.stdout.strip() == "False", (
         "FLEET_MENU_TOOLS still lives in fleet.__init__; move it to core._type_constants"
     )
+
+
+# ---------------------------------------------------------------------------
+# T1: FeatureDef has no redundant name field (Finding 3)
+# ---------------------------------------------------------------------------
+
+
+def test_feature_def_has_no_name_field() -> None:
+    """FeatureDef.name is redundant with the FEATURE_REGISTRY dict key and must not exist."""
+    import dataclasses
+
+    from autoskillit.core._type_constants import FeatureDef
+
+    field_names = {f.name for f in dataclasses.fields(FeatureDef)}
+    assert "name" not in field_names, "FeatureDef.name is redundant with FEATURE_REGISTRY dict key"

--- a/tests/recipe/test_analysis_public_api.py
+++ b/tests/recipe/test_analysis_public_api.py
@@ -1,0 +1,43 @@
+"""Tests for public API surface of recipe._analysis (Finding 6)."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+
+# ---------------------------------------------------------------------------
+# T4: bfs_reachable is a public symbol (Finding 6)
+# ---------------------------------------------------------------------------
+
+
+def test_bfs_reachable_is_public() -> None:
+    """bfs_reachable must be importable from autoskillit.recipe._analysis."""
+    from autoskillit.recipe._analysis import bfs_reachable  # must not raise ImportError
+
+    assert callable(bfs_reachable)
+
+
+def test_bfs_reachable_private_name_gone() -> None:
+    """_bfs_reachable private name must be absent after promotion to public."""
+    import autoskillit.recipe._analysis as mod
+
+    assert not hasattr(mod, "_bfs_reachable"), (
+        "_bfs_reachable private name must be removed after promotion to bfs_reachable"
+    )
+
+
+def test_bfs_reachable_traverses_graph() -> None:
+    """bfs_reachable returns all reachable nodes from start, excluding start itself."""
+    from autoskillit.recipe._analysis import bfs_reachable
+
+    graph = {
+        "a": {"b", "c"},
+        "b": {"d"},
+        "c": set(),
+        "d": set(),
+    }
+    assert bfs_reachable(graph, "a") == {"b", "c", "d"}
+    assert bfs_reachable(graph, "b") == {"d"}
+    assert bfs_reachable(graph, "d") == set()

--- a/tests/recipe/test_rules_features.py
+++ b/tests/recipe/test_rules_features.py
@@ -79,7 +79,6 @@ def test_feature_gate_rule_fires_on_disabled_feature_skill(monkeypatch) -> None:
 
     # Inject a test feature with skill_categories into the registry
     test_fdef = FeatureDef(
-        name="test-skill-gate",
         lifecycle=FeatureLifecycle.EXPERIMENTAL,
         description="Test feature gating a skill category",
         tool_tags=frozenset(),
@@ -124,7 +123,6 @@ def test_feature_gate_rule_with_multiple_features(monkeypatch) -> None:
 
     # A second test feature that controls 'ci' tools
     test_ci_fdef = FeatureDef(
-        name="test-ci-gate",
         lifecycle=FeatureLifecycle.EXPERIMENTAL,
         description="Test feature gating ci tools",
         tool_tags=frozenset({"ci"}),
@@ -251,7 +249,6 @@ def test_feature_gate_run_python_no_finding_when_fdef_has_no_import_package(monk
     from autoskillit.recipe.schema import Recipe, RecipeStep
 
     no_pkg_fdef = FeatureDef(
-        name="no-pkg-feature",
         lifecycle=FeatureLifecycle.EXPERIMENTAL,
         description="Feature with no import_package",
         tool_tags=frozenset(),

--- a/tests/recipe/test_schema.py
+++ b/tests/recipe/test_schema.py
@@ -493,3 +493,32 @@ def test_recipe_info_experimental_can_be_set_true() -> None:
         experimental=True,
     )
     assert r.experimental is True
+
+
+# ---------------------------------------------------------------------------
+# T3: categories validation (Finding 5)
+# ---------------------------------------------------------------------------
+
+
+def test_recipe_rejects_unknown_category() -> None:
+    """Recipe.__post_init__ raises ValueError for unknown category values."""
+    from autoskillit.recipe.schema import Recipe
+
+    with pytest.raises(ValueError, match="Unknown categories"):
+        Recipe(name="x", description="d", categories=["no_such_category"])
+
+
+def test_recipe_accepts_valid_category() -> None:
+    """Recipe accepts a valid RECIPE_PACK_TAGS member in categories."""
+    from autoskillit.recipe.schema import Recipe
+
+    r = Recipe(name="x", description="d", categories=["implementation-family"])
+    assert r.categories == ["implementation-family"]
+
+
+def test_recipe_accepts_empty_categories() -> None:
+    """Recipe accepts an empty categories list."""
+    from autoskillit.recipe.schema import Recipe
+
+    r = Recipe(name="x", description="d", categories=[])
+    assert r.categories == []

--- a/tests/server/test_session_type_tags.py
+++ b/tests/server/test_session_type_tags.py
@@ -1,0 +1,28 @@
+"""Tests for _collect_fleet_tool_tags in server._session_type (Finding 1)."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+
+# ---------------------------------------------------------------------------
+# T5: _collect_fleet_tool_tags auto-discovers tags from FEATURE_REGISTRY
+# ---------------------------------------------------------------------------
+
+
+def test_collect_fleet_tool_tags_is_union_of_registry() -> None:
+    """_collect_fleet_tool_tags() equals the union of all FeatureDef.tool_tags."""
+    from autoskillit.core._type_constants import FEATURE_REGISTRY
+    from autoskillit.server._session_type import _collect_fleet_tool_tags
+
+    expected = frozenset().union(*(fdef.tool_tags for fdef in FEATURE_REGISTRY.values()))
+    assert _collect_fleet_tool_tags() == expected
+
+
+def test_collect_fleet_tool_tags_includes_fleet() -> None:
+    """The 'fleet' tag from the fleet FeatureDef must appear in the collected tags."""
+    from autoskillit.server._session_type import _collect_fleet_tool_tags
+
+    assert "fleet" in _collect_fleet_tool_tags()

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -261,7 +261,6 @@ def test_is_test_feature_enabled_respects_experimental_enabled(monkeypatch):
 
     monkeypatch.delenv("AUTOSKILLIT_TEST_FEATURES", raising=False)
     exp_feat = FeatureDef(
-        name="conftest_test_exp",
         lifecycle=FeatureLifecycle.EXPERIMENTAL,
         description="test",
         tool_tags=frozenset(),
@@ -288,7 +287,6 @@ def test_is_test_feature_enabled_disabled_lifecycle_always_false(monkeypatch):
 
     monkeypatch.delenv("AUTOSKILLIT_TEST_FEATURES", raising=False)
     disabled_feat = FeatureDef(
-        name="conftest_test_disabled",
         lifecycle=FeatureLifecycle.DISABLED,
         description="disabled test",
         tool_tags=frozenset(),


### PR DESCRIPTION
## Summary

Nine low-severity hygiene issues from deferred PR review findings. Five require code changes; four require documentation-only changes (docstrings or comments). No breaking schema changes. Changes are scoped to `core/_type_constants.py`, `recipe/schema.py`, `recipe/_analysis.py`, `recipe/rules_features.py`, `recipe/rules_merge.py`, `recipe/rules_reachability.py`, `server/_session_type.py`, `recipe/repository.py`, `cli/_fleet.py`, `hooks/fleet_dispatch_guard.py`, plus associated tests.

**Code changes (6):**
1. Remove `FeatureDef.name` redundant field; update callers to use dict key (Finding 3)
2. Add `categories` validation in `Recipe.__post_init__` (Finding 5)
3. Rename `_bfs_reachable` → `bfs_reachable` in `recipe._analysis` (Finding 6)
4. Remove redundant `shutil.which("claude")` guards in `cli._fleet` (Finding 7)
5. Switch `glob("*.py")` → `rglob("*.py")` in `test_layer_enforcement` (Finding 9)
6. Auto-discover fleet tool tags from `FEATURE_REGISTRY` in `server._session_type` (Finding 1)

**Documentation changes (3):**
7. Docstring on `DefaultRecipeRepository.load()` for re-raise contract (Finding 2)
8. Clarifying docstring on `requires_packs` / `requires_recipe_packs` in `schema.py` (Finding 4)
9. Comment in `fleet_dispatch_guard.py` on single-source headless detection (Finding 8)

Closes #1235

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260426-063437-990356/.autoskillit/temp/make-plan/api_registry_hygiene_plan_2026-04-26_063437.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 163 | 23.7k | 819.6k | 59.6k | 1 | 10m 38s |
| verify | 212 | 25.4k | 1.4M | 69.0k | 1 | 9m 27s |
| implement | 852 | 32.9k | 8.4M | 126.2k | 1 | 15m 17s |
| fix | 134 | 5.1k | 666.1k | 45.4k | 1 | 7m 45s |
| prepare_pr | 52 | 4.7k | 168.9k | 28.0k | 1 | 1m 22s |
| compose_pr | 59 | 2.4k | 168.9k | 17.4k | 1 | 57s |
| **Total** | 1.5k | 94.3k | 11.7M | 345.5k | | 45m 28s |