### PR TITLE
Remove Dead Bash Sleep + ToolSearch Steps from Orchestrator FIRST ACTION

### DIFF
--- a/src/autoskillit/cli/_prompts.py
+++ b/src/autoskillit/cli/_prompts.py
@@ -462,7 +462,7 @@ def _build_open_kitchen_prompt(mcp_prefix: str) -> str:
     _forbidden_list = ", ".join(PIPELINE_FORBIDDEN_TOOLS)
     text = (
         f"Call {mcp_prefix}open_kitchen to open the AutoSkillit kitchen.\n"
-        f"DO NOT call Bash, ToolSearch, or any other tool before open_kitchen.\n\n"
+        f"DO NOT call any other tool before open_kitchen.\n\n"
         "IMPORTANT — Orchestrator Discipline:\n"
         f"NEVER use native Claude Code tools ({_forbidden_list}) "
         "in this session. All code reading, searching, editing, and "

--- a/src/autoskillit/cli/_prompts.py
+++ b/src/autoskillit/cli/_prompts.py
@@ -311,12 +311,6 @@ def _build_orchestrator_prompt(
 You are a pipeline orchestrator. Execute the recipe '{recipe_name}' step-by-step.
 
 {_ing_section}FIRST ACTION — before prompting for any inputs:
-0. Call ToolSearch(query='select:{mcp_prefix}open_kitchen') to load its schema:
-   - If the schema IS returned: proceed to step 1 immediately.
-   - If the schema is NOT returned (tool not yet registered): call Bash(command="sleep 2"),
-     then retry ToolSearch(query='select:{mcp_prefix}open_kitchen') once.
-   - If still not returned after the retry: output
-     "MCP server not ready — open_kitchen schema unavailable after retry" and end the session.
 1. Call {mcp_prefix}open_kitchen(name='{recipe_name}') to activate pipeline tools and open
    the kitchen gate. open_kitchen is REQUIRED to enable all gated AutoSkillit tools —
    the ingredients table above (when present) is provided for reference only.
@@ -467,12 +461,8 @@ def _build_open_kitchen_prompt(mcp_prefix: str) -> str:
 
     _forbidden_list = ", ".join(PIPELINE_FORBIDDEN_TOOLS)
     text = (
-        f"Call ToolSearch(query='select:{mcp_prefix}open_kitchen') to check MCP readiness:\n"
-        f"- If the schema IS returned: proceed to call {mcp_prefix}open_kitchen immediately.\n"
-        f'- If NOT returned: call Bash(command="sleep 2"), then retry ToolSearch once.\n'
-        f"- If still not returned: output "
-        f'"MCP server not ready — open_kitchen unavailable after retry" and end the session.\n'
-        f"Then call {mcp_prefix}open_kitchen to open the AutoSkillit kitchen.\n\n"
+        f"Call {mcp_prefix}open_kitchen to open the AutoSkillit kitchen.\n"
+        f"DO NOT call Bash, ToolSearch, or any other tool before open_kitchen.\n\n"
         "IMPORTANT — Orchestrator Discipline:\n"
         f"NEVER use native Claude Code tools ({_forbidden_list}) "
         "in this session. All code reading, searching, editing, and "

--- a/tests/cli/test_cli_prompts.py
+++ b/tests/cli/test_cli_prompts.py
@@ -406,26 +406,6 @@ def test_orchestrator_prompt_contains_quota_routing():
     assert "QUOTA DENIAL ROUTING" in prompt
 
 
-def test_orchestrator_prompt_calls_toolsearch_unconditionally():
-    """Step 0 of FIRST ACTION must call ToolSearch unconditionally."""
-    from autoskillit.cli._mcp_names import DIRECT_PREFIX
-    from autoskillit.cli._prompts import _build_orchestrator_prompt
-
-    prompt = _build_orchestrator_prompt("my_recipe", mcp_prefix=DIRECT_PREFIX)
-    assert "ToolSearch" in prompt
-    assert "select:" in prompt
-    assert "open_kitchen" in prompt
-
-
-def test_open_kitchen_prompt_calls_toolsearch_unconditionally():
-    from autoskillit.cli._mcp_names import DIRECT_PREFIX
-    from autoskillit.cli._prompts import _build_open_kitchen_prompt
-
-    prompt = _build_open_kitchen_prompt(mcp_prefix=DIRECT_PREFIX)
-    assert "ToolSearch" in prompt
-    assert "open_kitchen" in prompt
-
-
 def test_orchestrator_prompt_has_no_server_startup_recovery_block():
     """SERVER-STARTUP RECOVERY block must be removed — it misdiagnoses schema deferral
     as server startup latency."""

--- a/tests/cli/test_cli_prompts.py
+++ b/tests/cli/test_cli_prompts.py
@@ -443,8 +443,7 @@ def test_orchestrator_prompt_has_no_server_startup_recovery_block():
 
 
 def test_orchestrator_prompt_has_no_deferred_tool_recovery_conditional():
-    """The conditional DEFERRED-TOOL RECOVERY block must be removed — it is subsumed
-    by the unconditional ToolSearch step 0."""
+    """The conditional DEFERRED-TOOL RECOVERY block must not be present."""
     from autoskillit.cli._mcp_names import DIRECT_PREFIX
     from autoskillit.cli._prompts import _build_orchestrator_prompt
 
@@ -452,53 +451,52 @@ def test_orchestrator_prompt_has_no_deferred_tool_recovery_conditional():
     assert "schemas NOT loaded — calling directly will fail" not in prompt
 
 
-def test_first_action_step0_calls_toolsearch_unconditionally():
-    """Step 0 is ToolSearch; Bash appears as conditional fallback in step 0."""
+def test_first_action_no_toolsearch_or_bash():
+    """FIRST ACTION must not reference ToolSearch or Bash."""
     from autoskillit.cli._mcp_names import DIRECT_PREFIX
     from autoskillit.cli._prompts import _build_orchestrator_prompt
 
     prompt = _build_orchestrator_prompt("my_recipe", mcp_prefix=DIRECT_PREFIX)
-
     start = prompt.index("FIRST ACTION")
     end = prompt.index("During pipeline execution", start)
     first_action = prompt[start:end]
-
-    # Step 0 is now ToolSearch, not Bash sleep
-    step0_end = first_action.index("\n1.")
-    step0_text = first_action[:step0_end]
-    assert "ToolSearch" in step0_text, "Step 0 must be a ToolSearch readiness check"
-
-    # ToolSearch is still present in the FIRST ACTION section
-    assert "ToolSearch" in first_action
+    assert "ToolSearch" not in first_action
+    assert "Bash" not in first_action
+    assert "sleep" not in first_action.lower()
 
 
-def test_first_action_toolsearch_index_precedes_open_kitchen():
-    """Within FIRST ACTION step 0, ToolSearch must appear before open_kitchen."""
+def test_first_action_opens_with_open_kitchen():
+    """FIRST ACTION step 1 must call open_kitchen directly — no preamble step."""
     from autoskillit.cli._mcp_names import DIRECT_PREFIX
     from autoskillit.cli._prompts import _build_orchestrator_prompt
 
     prompt = _build_orchestrator_prompt("my_recipe", mcp_prefix=DIRECT_PREFIX)
-
     start = prompt.index("FIRST ACTION")
     end = prompt.index("During pipeline execution", start)
     first_action = prompt[start:end]
+    assert "open_kitchen" in first_action
+    assert "\n0." not in first_action, "Step 0 must not exist — open_kitchen is step 1"
+    assert "\n1." in first_action
 
-    ts_idx = first_action.index("ToolSearch")
-    ok_idx = first_action.index("open_kitchen")
-    assert ts_idx < ok_idx, "ToolSearch must appear before open_kitchen in FIRST ACTION"
 
-
-def test_open_kitchen_prompt_has_bash_sleep_and_toolsearch():
-    """_build_open_kitchen_prompt must have Bash sleep and ToolSearch (Bash as fallback)."""
+def test_open_kitchen_prompt_no_toolsearch_or_bash():
+    """_build_open_kitchen_prompt must not reference ToolSearch or Bash."""
     from autoskillit.cli._mcp_names import DIRECT_PREFIX
     from autoskillit.cli._prompts import _build_open_kitchen_prompt
 
     prompt = _build_open_kitchen_prompt(mcp_prefix=DIRECT_PREFIX)
-    assert "Bash" in prompt, "Open kitchen prompt must include Bash sleep as conditional fallback"
-    assert "sleep" in prompt.lower()
-    assert "ToolSearch" in prompt
-    lower = prompt.lower()
-    assert "if the session's deferred-tool list" not in lower
+    assert "ToolSearch" not in prompt
+    assert "Bash" not in prompt
+    assert "sleep" not in prompt.lower()
+
+
+def test_open_kitchen_prompt_calls_open_kitchen_directly():
+    """_build_open_kitchen_prompt must instruct a direct open_kitchen call."""
+    from autoskillit.cli._mcp_names import DIRECT_PREFIX
+    from autoskillit.cli._prompts import _build_open_kitchen_prompt
+
+    prompt = _build_open_kitchen_prompt(mcp_prefix=DIRECT_PREFIX)
+    assert "open_kitchen" in prompt
 
 
 def test_orchestrator_prompt_contains_anti_skip_rule():
@@ -587,138 +585,6 @@ def test_orchestrator_prompt_contains_skill_command_format_guidance():
     assert "SKILL_COMMAND FORMATTING" in prompt, (
         "Orchestrator prompt must contain a SKILL_COMMAND FORMATTING section. "
         "This prevents the LLM from adding markdown headers to skill_command values."
-    )
-
-
-def test_first_action_step0_is_toolsearch():
-    """Step 0 of FIRST ACTION must be a ToolSearch readiness check, not a bare Bash sleep."""
-    from autoskillit.cli._mcp_names import DIRECT_PREFIX
-    from autoskillit.cli._prompts import _build_orchestrator_prompt
-
-    prompt = _build_orchestrator_prompt("my_recipe", mcp_prefix=DIRECT_PREFIX)
-    start = prompt.index("FIRST ACTION")
-    end = prompt.index("During pipeline execution", start)
-    first_action = prompt[start:end]
-
-    step0_end = first_action.index("\n1.")
-    step0_text = first_action[:step0_end]
-    assert "ToolSearch" in step0_text, "Step 0 must call ToolSearch for open_kitchen schema"
-    assert "open_kitchen" in step0_text, "Step 0 ToolSearch must target open_kitchen"
-
-
-def test_first_action_toolsearch_precedes_bash_sleep():
-    """ToolSearch must appear before Bash (conditional fallback) in FIRST ACTION."""
-    from autoskillit.cli._mcp_names import DIRECT_PREFIX
-    from autoskillit.cli._prompts import _build_orchestrator_prompt
-
-    prompt = _build_orchestrator_prompt("my_recipe", mcp_prefix=DIRECT_PREFIX)
-    start = prompt.index("FIRST ACTION")
-    end = prompt.index("During pipeline execution", start)
-    first_action = prompt[start:end]
-
-    bash_idx = first_action.index("Bash")
-    ts_idx = first_action.index("ToolSearch")
-    assert ts_idx < bash_idx, (
-        "ToolSearch must appear before Bash (which is a conditional fallback)"
-    )
-
-
-def test_open_kitchen_prompt_has_toolsearch_before_bash_sleep():
-    """_build_open_kitchen_prompt must have ToolSearch before Bash (conditional fallback)."""
-    from autoskillit.cli._mcp_names import DIRECT_PREFIX
-    from autoskillit.cli._prompts import _build_open_kitchen_prompt
-
-    prompt = _build_open_kitchen_prompt(mcp_prefix=DIRECT_PREFIX)
-    assert "Bash" in prompt, "Open kitchen prompt must include Bash sleep as conditional fallback"
-    assert "sleep" in prompt.lower()
-    bash_idx = prompt.lower().index("bash")
-    ts_idx = prompt.index("ToolSearch")
-    assert ts_idx < bash_idx, "ToolSearch must precede Bash (which is a conditional fallback)"
-
-
-def test_first_action_step0_is_toolsearch_not_bash():
-    """Step 0 of FIRST ACTION must be ToolSearch, not a Bash sleep gate."""
-    from autoskillit.cli._mcp_names import DIRECT_PREFIX
-    from autoskillit.cli._prompts import _build_orchestrator_prompt
-
-    prompt = _build_orchestrator_prompt("my_recipe", mcp_prefix=DIRECT_PREFIX)
-    start = prompt.index("FIRST ACTION")
-    end = prompt.index("During pipeline execution", start)
-    first_action = prompt[start:end]
-
-    step0_end = first_action.index("\n1.")
-    step0_text = first_action[:step0_end]
-    assert "ToolSearch" in step0_text, "Step 0 must call ToolSearch for open_kitchen schema"
-    assert "open_kitchen" in step0_text, "Step 0 ToolSearch must target open_kitchen"
-    assert not step0_text.lstrip().startswith("Call Bash"), (
-        "Step 0 must not open with a Bash sleep — use ToolSearch-based readiness check"
-    )
-
-
-def test_first_action_step0_toolsearch_has_sleep_retry_fallback():
-    """When ToolSearch misses, step 0 must instruct: sleep 2, retry once."""
-    from autoskillit.cli._mcp_names import DIRECT_PREFIX
-    from autoskillit.cli._prompts import _build_orchestrator_prompt
-
-    prompt = _build_orchestrator_prompt("my_recipe", mcp_prefix=DIRECT_PREFIX)
-    start = prompt.index("FIRST ACTION")
-    step0_end = prompt.index("\n1.", start)
-    step0 = prompt[start:step0_end]
-
-    assert "sleep" in step0.lower(), "Step 0 must mention sleep as fallback on schema miss"
-    assert "retry" in step0.lower() or "again" in step0.lower(), (
-        "Step 0 must describe retrying ToolSearch after sleep"
-    )
-
-
-def test_first_action_step0_toolsearch_permanent_failure_reports_error():
-    """If ToolSearch still fails after retry, step 0 must instruct the LLM to report error."""
-    from autoskillit.cli._mcp_names import DIRECT_PREFIX
-    from autoskillit.cli._prompts import _build_orchestrator_prompt
-
-    prompt = _build_orchestrator_prompt("my_recipe", mcp_prefix=DIRECT_PREFIX)
-    start = prompt.index("FIRST ACTION")
-    step0_end = prompt.index("\n1.", start)
-    step0 = prompt[start:step0_end]
-
-    lower = step0.lower()
-    assert "error" in lower or "not ready" in lower or "unavailable" in lower, (
-        "Step 0 must instruct the LLM to report an error if ToolSearch fails after retry"
-    )
-    assert "end" in lower or "stop" in lower or "unavailable" in lower, (
-        "Step 0 must end the session on permanent ToolSearch failure, not proceed silently"
-    )
-
-
-def test_open_kitchen_prompt_step0_is_toolsearch_not_bash():
-    """_build_open_kitchen_prompt step 0 must be ToolSearch, not Bash sleep."""
-    from autoskillit.cli._mcp_names import DIRECT_PREFIX
-    from autoskillit.cli._prompts import _build_open_kitchen_prompt
-
-    prompt = _build_open_kitchen_prompt(mcp_prefix=DIRECT_PREFIX)
-    ts_idx = prompt.index("ToolSearch")
-    ok_idx = prompt.index("open_kitchen")
-    assert ts_idx < ok_idx, "ToolSearch must precede open_kitchen in open-kitchen prompt"
-    bash_idx = prompt.lower().index("bash")
-    assert ts_idx < bash_idx, "Bash sleep must come after ToolSearch as a conditional fallback"
-
-
-def test_open_kitchen_prompt_toolsearch_has_retry_on_miss():
-    """_build_open_kitchen_prompt must describe sleep-and-retry if ToolSearch misses."""
-    from autoskillit.cli._mcp_names import DIRECT_PREFIX
-    from autoskillit.cli._prompts import _build_open_kitchen_prompt
-
-    prompt = _build_open_kitchen_prompt(mcp_prefix=DIRECT_PREFIX)
-    ts_idx = prompt.index("ToolSearch")
-    # "Then call" marks the end of the conditional block and the start of the actual call.
-    # We cannot use prompt.index("open_kitchen", ts_idx + 1) here because open_kitchen
-    # also appears inside the ToolSearch query string, giving a section that's too short.
-    then_idx = prompt.index("Then call", ts_idx)
-    startup_section = prompt[ts_idx:then_idx]
-    lower = startup_section.lower()
-    assert "sleep" in lower, "Open-kitchen startup must mention sleep as fallback"
-    assert "retry" in lower or "again" in lower, (
-        "Open-kitchen startup must describe retrying ToolSearch after sleep"
     )
 
 

--- a/tests/cli/test_cli_prompts.py
+++ b/tests/cli/test_cli_prompts.py
@@ -460,14 +460,17 @@ def test_first_action_opens_with_open_kitchen():
 
 
 def test_open_kitchen_prompt_no_toolsearch_or_bash():
-    """_build_open_kitchen_prompt must not reference ToolSearch or Bash."""
+    """open_kitchen call instruction must not reference ToolSearch or Bash."""
     from autoskillit.cli._mcp_names import DIRECT_PREFIX
     from autoskillit.cli._prompts import _build_open_kitchen_prompt
 
     prompt = _build_open_kitchen_prompt(mcp_prefix=DIRECT_PREFIX)
-    assert "ToolSearch" not in prompt
-    assert "Bash" not in prompt
-    assert "sleep" not in prompt.lower()
+    # Scope to the call instruction before the discipline block
+    discipline_idx = prompt.index("IMPORTANT")
+    preamble = prompt[:discipline_idx]
+    assert "ToolSearch" not in preamble
+    assert "Bash" not in preamble
+    assert "sleep" not in preamble.lower()
 
 
 def test_open_kitchen_prompt_calls_open_kitchen_directly():

--- a/tests/cli/test_orchestrator_prompt_contract.py
+++ b/tests/cli/test_orchestrator_prompt_contract.py
@@ -92,26 +92,30 @@ class TestFirstActionAskUserQuestionProhibition:
         assert "DO NOT call AskUserQuestion" in first_action_section
 
 
-class TestFirstActionTimingResilience:
-    """FIRST ACTION step 0 must be a ToolSearch readiness check before open_kitchen."""
+class TestFirstActionDirectOpenKitchen:
+    """FIRST ACTION must call open_kitchen directly — no ToolSearch or Bash preamble."""
 
-    def test_first_action_step0_is_toolsearch_gate(self):
-        """Step 0 in FIRST ACTION must be a ToolSearch readiness check — not a bare Bash sleep."""
+    def test_first_action_no_step0(self):
+        """FIRST ACTION must not contain a step 0."""
         prompt = _get_prompt()
-        first_action_start = prompt.index("FIRST ACTION")
-        first_action_end = prompt.index("During pipeline execution", first_action_start)
-        first_action_section = prompt[first_action_start:first_action_end]
+        fa_start = prompt.index("FIRST ACTION")
+        fa_end = prompt.index("During pipeline execution", fa_start)
+        first_action = prompt[fa_start:fa_end]
+        assert "\n0." not in first_action
 
-        # Step 0 must be ToolSearch
-        step0_end = first_action_section.index("\n1.")
-        step0 = first_action_section[:step0_end]
-        assert "ToolSearch" in step0, "Step 0 must be a ToolSearch readiness check"
-        assert "open_kitchen" in step0, "Step 0 ToolSearch must target open_kitchen"
+    def test_first_action_no_toolsearch(self):
+        """FIRST ACTION must not reference ToolSearch."""
+        prompt = _get_prompt()
+        fa_start = prompt.index("FIRST ACTION")
+        fa_end = prompt.index("During pipeline execution", fa_start)
+        first_action = prompt[fa_start:fa_end]
+        assert "ToolSearch" not in first_action
 
-        # Step 0 must not open with a Bash call
-        assert not step0.lstrip().startswith("Bash"), (
-            "Step 0 must not begin with Bash — ToolSearch is the first instruction"
-        )
-
-        # ToolSearch must still appear in FIRST ACTION
-        assert "ToolSearch" in first_action_section
+    def test_first_action_no_bash_sleep(self):
+        """FIRST ACTION must not reference Bash or sleep."""
+        prompt = _get_prompt()
+        fa_start = prompt.index("FIRST ACTION")
+        fa_end = prompt.index("During pipeline execution", fa_start)
+        first_action = prompt[fa_start:fa_end]
+        assert "Bash" not in first_action
+        assert "sleep" not in first_action.lower()

--- a/tests/contracts/test_exogenous_string_coupling.py
+++ b/tests/contracts/test_exogenous_string_coupling.py
@@ -49,3 +49,25 @@ def test_quota_post_warning_trigger_coupled_to_sous_chef_skill():
         f"sous-chef SKILL.md must reference quota_post_hook.QUOTA_POST_WARNING_TRIGGER "
         f"({QUOTA_POST_WARNING_TRIGGER!r}) verbatim"
     )
+
+
+class TestPromptToolsWhitelistCoupling:
+    """FIRST ACTION must not reference native tools blocked by --tools AskUserQuestion."""
+
+    def test_first_action_references_no_blocked_native_tools(self):
+        """Extract CamelCase native tool names from FIRST ACTION; assert none are blocked."""
+        import re
+
+        from autoskillit.cli._mcp_names import DIRECT_PREFIX
+        from autoskillit.cli._prompts import _build_orchestrator_prompt
+
+        prompt = _build_orchestrator_prompt("test", mcp_prefix=DIRECT_PREFIX)
+        start = prompt.index("FIRST ACTION")
+        end = prompt.index("During pipeline execution", start)
+        first_action = prompt[start:end]
+
+        native_tools = re.findall(r"[Cc]all ([A-Z][a-zA-Z]+)\(", first_action)
+        assert native_tools == [], (
+            f"FIRST ACTION references native tools {native_tools} that are blocked "
+            f"by --tools AskUserQuestion in _session_launch.py"
+        )

--- a/tests/contracts/test_exogenous_string_coupling.py
+++ b/tests/contracts/test_exogenous_string_coupling.py
@@ -55,19 +55,18 @@ class TestPromptToolsWhitelistCoupling:
     """FIRST ACTION must not reference native tools blocked by --tools AskUserQuestion."""
 
     def test_first_action_references_no_blocked_native_tools(self):
-        """Extract CamelCase native tool names from FIRST ACTION; assert none are blocked."""
-        import re
-
+        """FIRST ACTION must not mention any PIPELINE_FORBIDDEN_TOOLS by name."""
         from autoskillit.cli._mcp_names import DIRECT_PREFIX
         from autoskillit.cli._prompts import _build_orchestrator_prompt
+        from autoskillit.core._type_constants import PIPELINE_FORBIDDEN_TOOLS
 
         prompt = _build_orchestrator_prompt("test", mcp_prefix=DIRECT_PREFIX)
         start = prompt.index("FIRST ACTION")
         end = prompt.index("During pipeline execution", start)
         first_action = prompt[start:end]
 
-        native_tools = re.findall(r"[Cc]all ([A-Z][a-zA-Z]+)\(", first_action)
-        assert native_tools == [], (
-            f"FIRST ACTION references native tools {native_tools} that are blocked "
+        found = [t for t in PIPELINE_FORBIDDEN_TOOLS if t in first_action]
+        assert found == [], (
+            f"FIRST ACTION references forbidden native tools {found} that are blocked "
             f"by --tools AskUserQuestion in _session_launch.py"
         )


### PR DESCRIPTION
## Summary

Remove the ToolSearch readiness check (step 0) and its Bash `sleep 2` retry fallback from both `_build_orchestrator_prompt` and `_build_open_kitchen_prompt` in `src/autoskillit/cli/_prompts.py`. Replace with a direct `open_kitchen` call as step 1 — mirroring the proven food truck pattern (`fleet/_prompts.py:92-95`) that has operated reliably across 53+ sessions without ToolSearch or Bash sleep. Both steps are dead code: `--tools AskUserQuestion` in `_session_launch.py:46-47` blocks native tools, and `MCP_CONNECTION_NONBLOCKING=0` (set in `commands.py:133`) already eliminates the MCP startup race the sleep was designed to guard.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START: User invokes CLI])
    SESSION([SESSION LAUNCHED])
    ERROR([ERROR: Invalid selection])

    subgraph Entry ["CLI Entry — app.py"]
        direction TB
        ORDER["order command<br/>━━━━━━━━━━<br/>app.order()"]
        FLEET["fleet command<br/>━━━━━━━━━━<br/>_fleet._launch_fleet_session()"]
    end

    subgraph Selection ["Prompt Selection — _resolve_recipe_input()"]
        direction TB
        PICKER{"User picks<br/>━━━━━━━━━━<br/>0 / 1-N / name?"}
        RECIPE_ARG{"recipe arg<br/>━━━━━━━━━━<br/>provided on CLI?"}
        FLEET_DECISION{"campaign YAML<br/>━━━━━━━━━━<br/>present?"}
    end

    subgraph Builders ["● Prompt Builders — _prompts.py"]
        direction TB
        BUILD_ORCH["● _build_orchestrator_prompt<br/>━━━━━━━━━━<br/>Recipe pipeline prompt<br/>Removed: ToolSearch step 0"]
        BUILD_OPEN["● _build_open_kitchen_prompt<br/>━━━━━━━━━━<br/>Open-kitchen prompt<br/>Removed: ToolSearch preamble"]
        BUILD_CAMPAIGN["_build_fleet_campaign_prompt<br/>━━━━━━━━━━<br/>L3 campaign dispatcher"]
        BUILD_DISPATCH["_build_fleet_dispatch_prompt<br/>━━━━━━━━━━<br/>Ad-hoc fleet dispatcher"]
    end

    subgraph FirstAction ["FIRST ACTION Sequence (in generated prompt)"]
        direction TB
        CALL_OK["● Step 1: open_kitchen<br/>━━━━━━━━━━<br/>Direct call — no preamble<br/>Previously: Step 0 ToolSearch → sleep → retry"]
        OK_CHECK{"open_kitchen<br/>success?"}
        COLLECT["Step 2-4: Display table,<br/>collect ingredients,<br/>execute pipeline"]
    end

    subgraph Launch ["Session Launch — _session_launch.py"]
        direction TB
        RUN_SESSION["_run_interactive_session<br/>━━━━━━━━━━<br/>--append-system-prompt"]
    end

    subgraph Contracts ["● Contract Tests"]
        direction TB
        T_PROMPTS["● test_cli_prompts.py<br/>━━━━━━━━━━<br/>Removed: ToolSearch-present tests<br/>Kept: routing, predicate, content tests"]
        T_CONTRACT["● test_orchestrator_prompt_contract.py<br/>━━━━━━━━━━<br/>TestFirstActionDirectOpenKitchen:<br/>no step 0, no ToolSearch, no Bash, no sleep"]
        T_COUPLING["● test_exogenous_string_coupling.py<br/>━━━━━━━━━━<br/>New: test_first_action_references_<br/>no_blocked_native_tools"]
        T_INVARIANT["Contract invariant:<br/>━━━━━━━━━━<br/>FIRST ACTION starts at step 1,<br/>calls open_kitchen directly"]
    end

    %% FLOW — CLI Entry %%
    START --> ORDER
    START --> FLEET

    %% FLOW — Order path %%
    ORDER --> RECIPE_ARG
    RECIPE_ARG -->|"yes"| BUILD_ORCH
    RECIPE_ARG -->|"no — show picker"| PICKER
    PICKER -->|"0 = open kitchen"| BUILD_OPEN
    PICKER -->|"1-N or name"| BUILD_ORCH
    PICKER -->|"invalid"| ERROR

    %% FLOW — Fleet path %%
    FLEET --> FLEET_DECISION
    FLEET_DECISION -->|"yes"| BUILD_CAMPAIGN
    FLEET_DECISION -->|"no"| BUILD_DISPATCH

    %% FLOW — Builders to session %%
    BUILD_ORCH --> RUN_SESSION
    BUILD_OPEN --> RUN_SESSION
    BUILD_CAMPAIGN --> RUN_SESSION
    BUILD_DISPATCH --> RUN_SESSION

    %% FLOW — First Action (runtime) %%
    RUN_SESSION --> CALL_OK
    CALL_OK --> OK_CHECK
    OK_CHECK -->|"success: true +<br/>INGREDIENTS TABLE marker"| COLLECT
    OK_CHECK -->|"success: false or<br/>no table marker"| ERROR
    COLLECT --> SESSION

    %% FLOW — Contract tests verify builders %%
    BUILD_ORCH -.->|"verified by"| T_PROMPTS
    BUILD_ORCH -.->|"verified by"| T_CONTRACT
    BUILD_OPEN -.->|"verified by"| T_PROMPTS
    BUILD_ORCH -.->|"verified by"| T_COUPLING
    T_PROMPTS -.-> T_INVARIANT
    T_CONTRACT -.-> T_INVARIANT
    T_COUPLING -.-> T_INVARIANT

    %% CLASS ASSIGNMENTS %%
    class START,SESSION,ERROR terminal;
    class ORDER,FLEET cli;
    class PICKER,RECIPE_ARG,FLEET_DECISION,OK_CHECK stateNode;
    class BUILD_ORCH,BUILD_OPEN,BUILD_CAMPAIGN,BUILD_DISPATCH handler;
    class CALL_OK,COLLECT,RUN_SESSION phase;
    class T_PROMPTS,T_CONTRACT,T_COUPLING detector;
    class T_INVARIANT output;
```

Closes #1279

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260426-092158-646253/.autoskillit/temp/make-plan/fix_remove_dead_bash_sleep_toolsearch_steps_plan_2026-04-26_092600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| analyze | 22 | 2.8k | 104.0k | 40.7k | 1 | 3m 44s |
| extract_domain | 33 | 7.3k | 170.0k | 28.2k | 1 | 3m 39s |
| generate_phases | 28 | 3.8k | 319.8k | 23.9k | 1 | 1m 47s |
| reconcile_deps | 23 | 745 | 135.1k | 14.1k | 1 | 28s |
| **Total** | 106 | 14.6k | 728.9k | 106.9k | | 9m 40s |