### PR TITLE
[FIX] Fix closure walk to use MODULE_CASCADE_CORE for core/ submodules

### DIFF
--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -828,8 +828,22 @@ def build_test_scope(
                     pkg = _file_to_package(f)
                     if pkg == "core" and mode == FilterMode.CONSERVATIVE:
                         stem = Path(f).stem
-                        if stem in _CORE_UNIVERSAL_MODULES or stem == "__init__":
+                        if stem in _CORE_UNIVERSAL_MODULES:
                             test_dirs.update(cascade_map["core"])
+                        elif stem == "__init__":
+                            core_cause_stems = {
+                                Path(c).stem
+                                for c in changed_src_py
+                                if _file_to_package(c) == "core" and Path(c).stem != "__init__"
+                            }
+                            if core_cause_stems and all(
+                                s in MODULE_CASCADE_CORE and s not in _CORE_UNIVERSAL_MODULES
+                                for s in core_cause_stems
+                            ):
+                                for s in core_cause_stems:
+                                    test_dirs.update(MODULE_CASCADE_CORE[s])
+                            else:
+                                test_dirs.update(cascade_map["core"])
                         elif stem in MODULE_CASCADE_CORE:
                             test_dirs.update(MODULE_CASCADE_CORE[stem])
                         else:

--- a/tests/test_test_filter_core_cascade.py
+++ b/tests/test_test_filter_core_cascade.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
+import tests._test_filter as tf_mod
 from tests._test_filter import (
     _CORE_UNIVERSAL_MODULES,
     MODULE_CASCADE_CORE,
@@ -272,3 +275,193 @@ class TestBuildTestScopeCoreCascade:
             "hooks",
         ]:
             assert excluded not in dir_names
+
+
+class TestClosureCoreNarrowCascade:
+    """Closure-added core/__init__.py uses MODULE_CASCADE_CORE when all causes are narrow."""
+
+    ALL_DIRS = [
+        "core",
+        "config",
+        "execution",
+        "pipeline",
+        "workspace",
+        "recipe",
+        "migration",
+        "fleet",
+        "server",
+        "cli",
+        "hooks",
+        "skills",
+        "arch",
+        "contracts",
+        "infra",
+        "docs",
+    ]
+
+    def _make_core_layout(self, tmp_path: Path, modules: dict[str, str]) -> Path:
+        core_dir = tmp_path / "src" / "autoskillit" / "core"
+        core_dir.mkdir(parents=True)
+        for name, content in modules.items():
+            (core_dir / name).write_text(content)
+        tests_root = tmp_path / "tests"
+        for d in self.ALL_DIRS:
+            (tests_root / d).mkdir(parents=True, exist_ok=True)
+        return tests_root
+
+    def test_closure_init_uses_narrow_cascade_single_module(self, tmp_path: Path) -> None:
+        """Single narrow cause → closure __init__.py uses that cause's MODULE_CASCADE_CORE."""
+        tests_root = self._make_core_layout(
+            tmp_path,
+            {
+                "kitchen_state.py": "",
+                "__init__.py": "from .kitchen_state import KitchenState\n",
+            },
+        )
+        result = build_test_scope(
+            changed_files={"src/autoskillit/core/kitchen_state.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        for pkg in ["core", "cli", "server"]:
+            assert pkg in dir_names, f"narrow cascade should include {pkg}"
+        for excluded in [
+            "execution",
+            "pipeline",
+            "workspace",
+            "recipe",
+            "migration",
+            "hooks",
+        ]:
+            assert excluded not in dir_names, (
+                f"narrow cascade should not include {excluded}"
+            )
+
+    def test_closure_init_uses_union_for_multiple_modules(self, tmp_path: Path) -> None:
+        """Multiple narrow causes → union of their MODULE_CASCADE_CORE entries."""
+        tests_root = self._make_core_layout(
+            tmp_path,
+            {
+                "kitchen_state.py": "",
+                "readiness.py": "",
+                "__init__.py": (
+                    "from .kitchen_state import KitchenState\n"
+                    "from .readiness import is_ready\n"
+                ),
+            },
+        )
+        result = build_test_scope(
+            changed_files={
+                "src/autoskillit/core/kitchen_state.py",
+                "src/autoskillit/core/readiness.py",
+            },
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        # Union: kitchen_state={core,cli,server} ∪ readiness={core,server}
+        for pkg in ["core", "cli", "server"]:
+            assert pkg in dir_names, f"union cascade should include {pkg}"
+        for excluded in [
+            "execution",
+            "pipeline",
+            "workspace",
+            "recipe",
+            "migration",
+            "hooks",
+        ]:
+            assert excluded not in dir_names, (
+                f"union cascade should not include {excluded}"
+            )
+
+    def test_closure_init_falls_back_when_universal_cause_present(
+        self, tmp_path: Path
+    ) -> None:
+        """A universal cause among the core changes → full cascade (fail-open)."""
+        tests_root = self._make_core_layout(
+            tmp_path,
+            {
+                "io.py": "",
+                "kitchen_state.py": "",
+                "__init__.py": (
+                    "from .io import atomic_write\n"
+                    "from .kitchen_state import KitchenState\n"
+                ),
+            },
+        )
+        result = build_test_scope(
+            changed_files={
+                "src/autoskillit/core/io.py",
+                "src/autoskillit/core/kitchen_state.py",
+            },
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        # io is universal → full cascade
+        for pkg in ["core", "execution", "pipeline", "server", "cli"]:
+            assert pkg in dir_names, f"universal fallback should include {pkg}"
+
+    def test_closure_init_falls_back_when_unknown_cause(self, tmp_path: Path) -> None:
+        """An unmapped cause → full cascade (fail-open)."""
+        tests_root = self._make_core_layout(
+            tmp_path,
+            {
+                "kitchen_state.py": "",
+                "_brand_new_module.py": "",
+                "__init__.py": (
+                    "from .kitchen_state import KitchenState\n"
+                    "from ._brand_new_module import something\n"
+                ),
+            },
+        )
+        result = build_test_scope(
+            changed_files={
+                "src/autoskillit/core/kitchen_state.py",
+                "src/autoskillit/core/_brand_new_module.py",
+            },
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        for pkg in ["core", "execution", "pipeline", "server", "cli"]:
+            assert pkg in dir_names, f"unknown-cause fallback should include {pkg}"
+
+    def test_closure_init_falls_back_when_no_core_causes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No core files in changed_src_py → full cascade (fail-open)."""
+        tests_root = self._make_core_layout(
+            tmp_path,
+            {
+                "__init__.py": "from .kitchen_state import KitchenState\n",
+                "kitchen_state.py": "",
+            },
+        )
+
+        original_expand = tf_mod._expand_reexport_closure
+
+        def _patched_expand(
+            changed_src_files: set[str], src_root: str | Path
+        ) -> set[str]:
+            result = original_expand(changed_src_files, src_root)
+            result.add("src/autoskillit/core/__init__.py")
+            return result
+
+        monkeypatch.setattr(tf_mod, "_expand_reexport_closure", _patched_expand)
+
+        result = build_test_scope(
+            changed_files={"src/autoskillit/server/__init__.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        # No core causes → full cascade for the closure-added __init__
+        for pkg in ["core", "execution", "pipeline", "server", "cli"]:
+            assert pkg in dir_names, f"no-causes fallback should include {pkg}"

--- a/tests/test_test_filter_core_cascade.py
+++ b/tests/test_test_filter_core_cascade.py
@@ -335,9 +335,7 @@ class TestClosureCoreNarrowCascade:
             "migration",
             "hooks",
         ]:
-            assert excluded not in dir_names, (
-                f"narrow cascade should not include {excluded}"
-            )
+            assert excluded not in dir_names, f"narrow cascade should not include {excluded}"
 
     def test_closure_init_uses_union_for_multiple_modules(self, tmp_path: Path) -> None:
         """Multiple narrow causes → union of their MODULE_CASCADE_CORE entries."""
@@ -347,8 +345,7 @@ class TestClosureCoreNarrowCascade:
                 "kitchen_state.py": "",
                 "readiness.py": "",
                 "__init__.py": (
-                    "from .kitchen_state import KitchenState\n"
-                    "from .readiness import is_ready\n"
+                    "from .kitchen_state import KitchenState\nfrom .readiness import is_ready\n"
                 ),
             },
         )
@@ -373,13 +370,9 @@ class TestClosureCoreNarrowCascade:
             "migration",
             "hooks",
         ]:
-            assert excluded not in dir_names, (
-                f"union cascade should not include {excluded}"
-            )
+            assert excluded not in dir_names, f"union cascade should not include {excluded}"
 
-    def test_closure_init_falls_back_when_universal_cause_present(
-        self, tmp_path: Path
-    ) -> None:
+    def test_closure_init_falls_back_when_universal_cause_present(self, tmp_path: Path) -> None:
         """A universal cause among the core changes → full cascade (fail-open)."""
         tests_root = self._make_core_layout(
             tmp_path,
@@ -387,8 +380,7 @@ class TestClosureCoreNarrowCascade:
                 "io.py": "",
                 "kitchen_state.py": "",
                 "__init__.py": (
-                    "from .io import atomic_write\n"
-                    "from .kitchen_state import KitchenState\n"
+                    "from .io import atomic_write\nfrom .kitchen_state import KitchenState\n"
                 ),
             },
         )
@@ -446,9 +438,7 @@ class TestClosureCoreNarrowCascade:
 
         original_expand = tf_mod._expand_reexport_closure
 
-        def _patched_expand(
-            changed_src_files: set[str], src_root: str | Path
-        ) -> set[str]:
+        def _patched_expand(changed_src_files: set[str], src_root: str | Path) -> set[str]:
             result = original_expand(changed_src_files, src_root)
             result.add("src/autoskillit/core/__init__.py")
             return result


### PR DESCRIPTION
## Summary

The closure expansion loop in `build_test_scope` (`tests/_test_filter.py:831`) unconditionally triggers `cascade_map["core"]` (17 directories, ~6,406 test functions) whenever `core/__init__.py` is closure-added — even when the causing module has a narrow `MODULE_CASCADE_CORE` entry. This makes `MODULE_CASCADE_CORE` completely inert for closure-added `__init__.py` files, producing zero test reduction for 47% of `test_check` runs.

The fix reconstructs which `core/` modules caused the closure addition directly in `build_test_scope` (Option B from the issue), then uses the union of their `MODULE_CASCADE_CORE` entries when all causes are narrowly mapped. No change to `_expand_reexport_closure`'s return type.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;

    START([START<br/>build_test_scope called])
    FULL_RUN([FULL RUN<br/>return None])
    SCOPED([SCOPED RUN<br/>return set of Path])

    subgraph Guards ["Entry Guards"]
        direction TB
        G1{"mode == NONE?"}
        G2{"changed_files<br/>is None?"}
        G3{"len > 30<br/>large changeset?"}
        G4{"Bucket A<br/>triggered?"}
    end

    subgraph Classification ["Per-File Classification Loop"]
        direction TB
        LOOP["For each file f<br/>in changed_files"]
        CF1{"f starts with<br/>tests/*.py?"}
        CF2{"f starts with<br/>src/*.py?"}
        CF3{"f ends .py<br/>but unclassified?"}
        CF4["Non-Python file<br/>━━━━━━━━━━<br/>apply_manifest"]
        CF5["● _file_to_package<br/>━━━━━━━━━━<br/>extract pkg name"]
        PKG{"pkg == core<br/>AND conservative?"}
    end

    subgraph CoreCascade ["● Core Cascade Decision"]
        direction TB
        STEM["Extract stem<br/>━━━━━━━━━━<br/>Path.stem"]
        CC1{"stem in<br/>_CORE_UNIVERSAL<br/>_MODULES?"}
        CC2{"stem ==<br/>__init__?"}
        CC3{"stem in<br/>● MODULE_CASCADE<br/>_CORE?"}
        NARROW["● Narrow cascade<br/>━━━━━━━━━━<br/>MODULE_CASCADE_CORE<br/>e.g. kitchen_state<br/>→ core,cli,server"]
        WIDE["Full core cascade<br/>━━━━━━━━━━<br/>LAYER_CASCADE<br/>all 16+ dirs"]
        UNKNOWN["Unknown stem<br/>━━━━━━━━━━<br/>fail-open →<br/>full cascade"]
    end

    subgraph ClosureWalk ["● Closure Walk — _expand_reexport_closure"]
        direction TB
        CW1["Walk parent dirs<br/>━━━━━━━━━━<br/>find __init__.py<br/>that re-exports<br/>changed modules"]
        CW2["AST parse<br/>━━━━━━━━━━<br/>match import<br/>bare_name == stem"]
        CW3{"closure-added<br/>__init__.py<br/>pkg == core?"}
        CW4["● Compute<br/>core_cause_stems<br/>━━━━━━━━━━<br/>which changed core<br/>files caused this"]
        CW5{"ALL causes in<br/>● MODULE_CASCADE<br/>_CORE and none<br/>universal/unknown?"}
        CW_NARROW["● Union of narrow<br/>cascades per cause<br/>━━━━━━━━━━<br/>preserves scoping"]
        CW_WIDE["Full cascade<br/>━━━━━━━━━━<br/>any universal/<br/>unknown cause"]
    end

    subgraph AlwaysRun ["Always-Run & Resolve"]
        direction TB
        AR1["Tiered always-run<br/>━━━━━━━━━━<br/>arch + contracts<br/>+ conditional docs<br/>+ conditional infra"]
        AR2["Resolve paths<br/>━━━━━━━━━━<br/>tests_root / dir<br/>+ direct test files"]
    end

    START --> G1
    G1 -->|"yes"| FULL_RUN
    G1 -->|"no"| G2
    G2 -->|"yes"| FULL_RUN
    G2 -->|"no"| G3
    G3 -->|"yes"| FULL_RUN
    G3 -->|"no"| G4
    G4 -->|"yes"| FULL_RUN
    G4 -->|"no"| LOOP

    LOOP --> CF1
    CF1 -->|"yes: direct test file"| LOOP
    CF1 -->|"no"| CF2
    CF2 -->|"no"| CF3
    CF3 -->|"yes"| FULL_RUN
    CF3 -->|"no: non-Python"| CF4
    CF4 -->|"unmatched"| FULL_RUN
    CF4 -->|"matched dirs"| LOOP

    CF2 -->|"yes"| CF5
    CF5 --> PKG
    PKG -->|"no: other pkg"| LOOP
    PKG -->|"yes"| STEM

    STEM --> CC1
    CC1 -->|"yes: io, logging,<br/>types, _type_*"| WIDE
    CC1 -->|"no"| CC2
    CC2 -->|"yes"| WIDE
    CC2 -->|"no"| CC3
    CC3 -->|"yes: 13 mapped<br/>modules"| NARROW
    CC3 -->|"no"| UNKNOWN
    UNKNOWN --> WIDE
    NARROW --> LOOP
    WIDE --> LOOP

    LOOP -->|"all files<br/>classified"| CW1
    CW1 --> CW2
    CW2 --> CW3
    CW3 -->|"no: non-core"| AR1
    CW3 -->|"yes"| CW4
    CW4 --> CW5
    CW5 -->|"yes: all narrow"| CW_NARROW
    CW5 -->|"no: universal/<br/>unknown/empty"| CW_WIDE
    CW_NARROW --> AR1
    CW_WIDE --> AR1

    AR1 --> AR2
    AR2 --> SCOPED

    class START,FULL_RUN,SCOPED terminal;
    class G1,G2,G3,G4 detector;
    class LOOP phase;
    class CF1,CF2,CF3,PKG,CC1,CC2,CC3,CW3,CW5 stateNode;
    class CF4,CF5,STEM,NARROW,WIDE,UNKNOWN handler;
    class CW1,CW2,CW4,CW_NARROW,CW_WIDE handler;
    class AR1,AR2 output;
```

Closes #1296

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-1296-20260426-114810-322336/.autoskillit/temp/make-plan/fix_closure_walk_module_cascade_core_plan_2026-04-26_120500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 62 | 10.3k | 773.4k | 53.7k | 1 | 5m 34s |
| verify | 35 | 7.3k | 761.8k | 46.3k | 1 | 4m 3s |
| implement | 1.3k | 8.6k | 990.5k | 43.5k | 1 | 3m 53s |
| prepare_pr | 25 | 2.6k | 189.9k | 22.2k | 1 | 1m 17s |
| run_arch_lenses | 33 | 4.5k | 189.2k | 26.5k | 1 | 3m 30s |
| compose_pr | 23 | 4.1k | 158.2k | 22.1k | 1 | 1m 8s |
| **Total** | 1.5k | 37.5k | 3.1M | 214.2k | | 19m 27s |