### PR TITLE
[FIX] Add version-epoch to fetch cache and invalidate after install/update

### DIFF
--- a/src/autoskillit/cli/_marketplace.py
+++ b/src/autoskillit/cli/_marketplace.py
@@ -204,6 +204,9 @@ def install(*, scope: str = "user") -> bool:
     sweep_all_scopes_for_orphans(Path.cwd())
     settings_path = _hooks_mod._claude_settings_path(scope)
     sync_hooks_to_settings(settings_path)
+    from autoskillit.cli._update_checks import invalidate_fetch_cache
+
+    invalidate_fetch_cache(Path.home())
     return True
 
 

--- a/src/autoskillit/cli/_update.py
+++ b/src/autoskillit/cli/_update.py
@@ -27,6 +27,7 @@ def run_update_command(home: Path | None = None) -> None:
         _read_dismiss_state,
         _verify_update_result,
         _write_dismiss_state,
+        invalidate_fetch_cache,
     )
 
     _home = home or Path.home()
@@ -85,4 +86,5 @@ def run_update_command(home: Path | None = None) -> None:
         state.pop("update_prompt", None)
         state.pop("binary_snoozed", None)
         _write_dismiss_state(_home, state)
+        invalidate_fetch_cache(_home)
         print("AutoSkillit updated successfully.", flush=True)

--- a/src/autoskillit/cli/_update_checks.py
+++ b/src/autoskillit/cli/_update_checks.py
@@ -131,6 +131,14 @@ def _write_fetch_cache(home: Path, data: dict[str, Any]) -> None:
         logger.debug("Failed to write fetch cache", exc_info=False)
 
 
+def invalidate_fetch_cache(home: Path) -> None:
+    """Delete the GitHub fetch cache. Call after install/update."""
+    try:
+        _fetch_cache_path(home).unlink(missing_ok=True)
+    except OSError:
+        logger.debug("Failed to invalidate fetch cache", exc_info=True)
+
+
 def _scrub_auth(text: str) -> str:
     """Remove any GITHUB_TOKEN value or ``Bearer …`` token from a string."""
     if not text:
@@ -173,7 +181,8 @@ def _fetch_with_cache(url: str, *, home: Path, ttl: int | None = None) -> dict[s
         body = entry.get("body")
         if isinstance(cached_at, (int, float)) and isinstance(body, dict):
             if now - cached_at < effective_ttl:
-                return body
+                if entry.get("installed_version") == AUTOSKILLIT_INSTALLED_VERSION:
+                    return body
 
     headers: dict[str, str] = {
         "Accept": "application/vnd.github+json",
@@ -201,6 +210,7 @@ def _fetch_with_cache(url: str, *, home: Path, ttl: int | None = None) -> dict[s
                     "body": body,
                     "etag": entry.get("etag"),
                     "cached_at": now,
+                    "installed_version": AUTOSKILLIT_INSTALLED_VERSION,
                 }
                 _write_fetch_cache(home, cache)
                 return body
@@ -214,6 +224,7 @@ def _fetch_with_cache(url: str, *, home: Path, ttl: int | None = None) -> dict[s
                 "body": body,
                 "etag": etag,
                 "cached_at": now,
+                "installed_version": AUTOSKILLIT_INSTALLED_VERSION,
             }
             _write_fetch_cache(home, cache)
             return body
@@ -641,6 +652,7 @@ def _run_update_sequence(
         state.pop("update_prompt", None)
         state.pop("binary_snoozed", None)
         _write_dismiss_state(home, state)
+        invalidate_fetch_cache(home)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_update_checks.py
+++ b/tests/cli/test_update_checks.py
@@ -1068,12 +1068,14 @@ def test_fetch_latest_version_uses_cache_within_ttl(tmp_path: Path) -> None:
     import time
 
     from autoskillit.cli._update_checks import _fetch_latest_version
+    from autoskillit.core import AUTOSKILLIT_INSTALLED_VERSION
 
     cache_data = {
         "https://api.github.com/repos/TalonT-Org/AutoSkillit/releases/latest": {
             "body": {"tag_name": "v0.9.0"},
             "etag": '"test-etag"',
             "cached_at": time.time() - 1,
+            "installed_version": AUTOSKILLIT_INSTALLED_VERSION,
         }
     }
     (tmp_path / ".autoskillit").mkdir(parents=True, exist_ok=True)
@@ -1602,6 +1604,517 @@ def test_all_dismissed_signals_produce_no_interactive_prompt(
     assert "autoskillit update" in combined, (
         "All-dismissed signals must produce passive notification containing 'autoskillit update'"
     )
+
+
+# ---------------------------------------------------------------------------
+# UC-11 Fetch cache lifecycle — version-epoch and invalidation
+# ---------------------------------------------------------------------------
+
+
+def test_stale_fetch_cache_after_install_detected_by_epoch(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Cache entry with stale installed_version is treated as a miss even within TTL."""
+    import time
+
+    from autoskillit.core._type_constants import (
+        AUTOSKILLIT_INSTALLED_VERSION as _REAL_VERSION,
+    )
+
+    old_version = "0.9.170"
+    assert old_version != _REAL_VERSION
+
+    url = "https://api.github.com/repos/TalonT-Org/AutoSkillit/releases/latest"
+    cache_data = {
+        url: {
+            "body": {"tag_name": "v0.9.170"},
+            "etag": '"old-etag"',
+            "cached_at": time.time() - 1,
+            "installed_version": old_version,
+        }
+    }
+    (tmp_path / ".autoskillit").mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".autoskillit" / "github_fetch_cache.json").write_text(
+        json.dumps(cache_data), encoding="utf-8"
+    )
+
+    network_hit = [False]
+
+    class TrackingClient:
+        def __init__(self, **kw):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def get(self, url, **kw):
+            network_hit[0] = True
+            r = MagicMock()
+            r.status_code = 200
+            r.json.return_value = {"tag_name": "v0.9.175"}
+            r.headers = {"ETag": '"new-etag"'}
+            return r
+
+    with patch("httpx.Client", TrackingClient):
+        result = _fetch_with_cache(url, home=tmp_path)
+
+    assert network_hit[0], "Epoch mismatch must force a network fetch"
+    assert result == {"tag_name": "v0.9.175"}
+
+
+def test_stale_fetch_cache_after_install_resolve_reference_sha_path2(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """PATH 2 (no source repo, fallback to _api_sha): stale epoch forces fresh fetch."""
+    import time
+
+    from autoskillit.cli._update_checks import resolve_reference_sha
+
+    url = "https://api.github.com/repos/TalonT-Org/AutoSkillit/git/refs/heads/integration"
+    stale_sha = "a" * 40
+    fresh_sha = "b" * 40
+
+    cache_data = {
+        url: {
+            "body": {
+                "object": {"sha": stale_sha, "type": "commit"},
+                "ref": "refs/heads/integration",
+            },
+            "etag": '"old-etag"',
+            "cached_at": time.time() - 1,
+            "installed_version": "0.9.170",
+        }
+    }
+    (tmp_path / ".autoskillit").mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".autoskillit" / "github_fetch_cache.json").write_text(
+        json.dumps(cache_data), encoding="utf-8"
+    )
+
+    monkeypatch.setattr("autoskillit.cli._update_checks.find_source_repo", lambda: None)
+
+    class FreshClient:
+        def __init__(self, **kw):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def get(self, url, **kw):
+            r = MagicMock()
+            r.status_code = 200
+            r.json.return_value = {
+                "object": {"sha": fresh_sha, "type": "commit"},
+                "ref": "refs/heads/integration",
+            }
+            r.headers = {"ETag": '"fresh-etag"'}
+            return r
+
+    info = _make_integration_info(commit_id=stale_sha)
+    with patch("httpx.Client", FreshClient):
+        result = resolve_reference_sha(info, tmp_path)
+
+    assert result == fresh_sha, f"Expected fresh SHA {fresh_sha!r}, got {result!r}"
+
+
+def test_run_update_sequence_invalidates_fetch_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """_run_update_sequence must delete github_fetch_cache.json on success."""
+    from autoskillit.cli._update_checks import _run_update_sequence
+
+    cache_file = tmp_path / ".autoskillit" / "github_fetch_cache.json"
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    cache_file.write_text('{"some": "data"}', encoding="utf-8")
+
+    class FakeTG:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    info = _make_stable_info()
+    upgrade_ok = subprocess.CompletedProcess([], returncode=0)
+    install_ok = subprocess.CompletedProcess([], returncode=0)
+    calls = iter([upgrade_ok, install_ok])
+    monkeypatch.setattr(
+        "autoskillit.cli._update_checks.subprocess.run", lambda *a, **kw: next(calls)
+    )
+    monkeypatch.setattr("autoskillit.cli._update_checks.terminal_guard", FakeTG)
+    monkeypatch.setattr(
+        "autoskillit.cli._update_checks._fetch_latest_version", lambda *a, **kw: "0.9.1"
+    )
+    monkeypatch.setattr(
+        "autoskillit.cli._update_checks._verify_update_result", lambda *a, **kw: True
+    )
+    _run_update_sequence(info, "0.9.0", tmp_path, {}, {})
+    assert not cache_file.exists(), "Fetch cache must be deleted after successful update"
+
+
+def test_run_update_command_invalidates_fetch_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """run_update_command must delete github_fetch_cache.json on success."""
+    from autoskillit.cli._update import run_update_command
+
+    cache_file = tmp_path / ".autoskillit" / "github_fetch_cache.json"
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    cache_file.write_text('{"some": "data"}', encoding="utf-8")
+
+    class FakeTG:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    info = _make_stable_info()
+    monkeypatch.setattr("autoskillit.cli._update.detect_install", lambda: info)
+    monkeypatch.setattr("autoskillit.cli._update.terminal_guard", FakeTG)
+    monkeypatch.setattr("autoskillit.cli._update.any_kitchen_open", lambda: False)
+
+    upgrade_ok = subprocess.CompletedProcess([], returncode=0)
+    install_ok = subprocess.CompletedProcess([], returncode=0)
+    mock_run = MagicMock(side_effect=[upgrade_ok, install_ok])
+    monkeypatch.setattr("autoskillit.cli._update.subprocess.run", mock_run)
+
+    import autoskillit as _pkg
+
+    monkeypatch.setattr(_pkg, "__version__", "0.9.0")
+
+    import importlib.metadata
+
+    monkeypatch.setattr(importlib.metadata, "version", lambda _: "0.9.1")
+    monkeypatch.setattr(
+        "autoskillit.cli._update_checks._fetch_latest_version", lambda *a, **kw: "0.9.1"
+    )
+
+    run_update_command(home=tmp_path)
+    assert not cache_file.exists(), "Fetch cache must be deleted after successful update command"
+
+
+def test_install_invalidates_fetch_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """_marketplace.install() must delete github_fetch_cache.json after install."""
+    import importlib
+
+    _app_mod = importlib.import_module("autoskillit.cli._marketplace")
+
+    cache_file = tmp_path / ".autoskillit" / "github_fetch_cache.json"
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    cache_file.write_text('{"some": "data"}', encoding="utf-8")
+
+    monkeypatch.setattr(_app_mod, "is_git_worktree", lambda path: False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(Path, "cwd", lambda: tmp_path)
+    monkeypatch.delenv("CLAUDECODE", raising=False)
+    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/claude")
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *a, **kw: type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})(),
+    )
+    monkeypatch.setattr("autoskillit.cli._marketplace.evict_direct_mcp_entry", lambda _: False)
+    monkeypatch.setattr(
+        "autoskillit.cli._marketplace.sweep_all_scopes_for_orphans", lambda _: None
+    )
+    monkeypatch.setattr("autoskillit.cli._marketplace.sync_hooks_to_settings", lambda _: None)
+    monkeypatch.setattr("autoskillit.cli._marketplace.generate_hooks_json", lambda: {})
+    monkeypatch.setattr("autoskillit.cli._marketplace.atomic_write", lambda *a, **kw: None)
+
+    from autoskillit.cli._marketplace import install as _install
+
+    _install(scope="user")
+    assert not cache_file.exists(), "Fetch cache must be deleted after plugin install"
+
+
+def test_api_sha_with_seeded_cache_returns_cached_sha(tmp_path: Path) -> None:
+    """_api_sha returns cached SHA when cache epoch matches current version."""
+    import time
+
+    from autoskillit.cli._update_checks import _api_sha
+    from autoskillit.core import AUTOSKILLIT_INSTALLED_VERSION
+
+    sha = "c" * 40
+    url = "https://api.github.com/repos/TalonT-Org/AutoSkillit/git/refs/heads/integration"
+    cache_data = {
+        url: {
+            "body": {"object": {"sha": sha, "type": "commit"}, "ref": "refs/heads/integration"},
+            "etag": '"test-etag"',
+            "cached_at": time.time() - 1,
+            "installed_version": AUTOSKILLIT_INSTALLED_VERSION,
+        }
+    }
+    (tmp_path / ".autoskillit").mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".autoskillit" / "github_fetch_cache.json").write_text(
+        json.dumps(cache_data), encoding="utf-8"
+    )
+
+    class NoNetworkClient:
+        def __init__(self, **kw):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def get(self, url, **kw):
+            raise AssertionError("Should not hit network when epoch matches")
+
+    with patch("httpx.Client", NoNetworkClient):
+        result = _api_sha("integration", tmp_path)
+
+    assert result == sha
+
+
+def test_api_sha_with_stale_epoch_forces_network(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """_api_sha issues a network request when cache epoch is stale."""
+    import time
+
+    from autoskillit.cli._update_checks import _api_sha
+
+    stale_sha = "d" * 40
+    fresh_sha = "e" * 40
+    url = "https://api.github.com/repos/TalonT-Org/AutoSkillit/git/refs/heads/integration"
+    cache_data = {
+        url: {
+            "body": {
+                "object": {"sha": stale_sha, "type": "commit"},
+                "ref": "refs/heads/integration",
+            },
+            "etag": '"old-etag"',
+            "cached_at": time.time() - 1,
+            "installed_version": "0.9.170",
+        }
+    }
+    (tmp_path / ".autoskillit").mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".autoskillit" / "github_fetch_cache.json").write_text(
+        json.dumps(cache_data), encoding="utf-8"
+    )
+
+    network_hit = [False]
+
+    class FreshClient:
+        def __init__(self, **kw):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def get(self, url, **kw):
+            network_hit[0] = True
+            r = MagicMock()
+            r.status_code = 200
+            r.json.return_value = {
+                "object": {"sha": fresh_sha, "type": "commit"},
+                "ref": "refs/heads/integration",
+            }
+            r.headers = {"ETag": '"fresh-etag"'}
+            return r
+
+    with patch("httpx.Client", FreshClient):
+        result = _api_sha("integration", tmp_path)
+
+    assert network_hit[0], "Stale epoch must force network fetch"
+    assert result == fresh_sha
+
+
+def test_api_sha_network_false_reads_raw_cache_no_epoch(tmp_path: Path) -> None:
+    """_api_sha(network=False) reads raw cache regardless of epoch (doctor mode)."""
+    import time
+
+    from autoskillit.cli._update_checks import _api_sha
+
+    sha = "f" * 40
+    url = "https://api.github.com/repos/TalonT-Org/AutoSkillit/git/refs/heads/integration"
+    cache_data = {
+        url: {
+            "body": {"object": {"sha": sha, "type": "commit"}, "ref": "refs/heads/integration"},
+            "etag": '"cached-etag"',
+            "cached_at": time.time() - 1,
+            "installed_version": "0.0.0",
+        }
+    }
+    (tmp_path / ".autoskillit").mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".autoskillit" / "github_fetch_cache.json").write_text(
+        json.dumps(cache_data), encoding="utf-8"
+    )
+
+    result = _api_sha("integration", tmp_path, network=False)
+    assert result == sha, "Doctor mode must read cache body regardless of epoch"
+
+
+def test_api_sha_tags_url_prefix(tmp_path: Path) -> None:
+    """_api_sha('v0.9.174', ...) constructs a refs/tags/ URL."""
+    from autoskillit.cli._update_checks import _api_sha
+
+    (tmp_path / ".autoskillit").mkdir(parents=True, exist_ok=True)
+    captured_urls: list[str] = []
+
+    class UrlCapturingClient:
+        def __init__(self, **kw):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def get(self, url, **kw):
+            captured_urls.append(url)
+            r = MagicMock()
+            r.status_code = 200
+            r.json.return_value = {"object": {"sha": "a" * 40, "type": "commit"}}
+            r.headers = {}
+            return r
+
+    with patch("httpx.Client", UrlCapturingClient):
+        _api_sha("v0.9.174", tmp_path)
+
+    assert len(captured_urls) == 1
+    assert "refs/tags/v0.9.174" in captured_urls[0]
+
+
+# ---------------------------------------------------------------------------
+# UC-12 State transitions — cross-hemisphere lifecycle tests
+# ---------------------------------------------------------------------------
+
+
+def test_full_lifecycle_install_clears_stale_cache_then_check_detects_new_version(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Full lifecycle: install invalidates cache, next binary_signal detects new version."""
+    import time
+
+    from autoskillit.cli._update_checks import _binary_signal, invalidate_fetch_cache
+    from autoskillit.core import AUTOSKILLIT_INSTALLED_VERSION
+
+    url = "https://api.github.com/repos/TalonT-Org/AutoSkillit/releases/latest"
+    cache_data = {
+        url: {
+            "body": {"tag_name": "v0.9.170"},
+            "etag": '"old-etag"',
+            "cached_at": time.time(),
+            "installed_version": "0.9.170",
+        },
+        "https://api.github.com/repos/TalonT-Org/AutoSkillit/git/refs/heads/integration": {
+            "body": {"object": {"sha": "a" * 40}},
+            "etag": '"ref-etag"',
+            "cached_at": time.time(),
+            "installed_version": "0.9.170",
+        },
+    }
+    cache_file = tmp_path / ".autoskillit" / "github_fetch_cache.json"
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    cache_file.write_text(json.dumps(cache_data), encoding="utf-8")
+
+    invalidate_fetch_cache(tmp_path)
+    assert not cache_file.exists(), "invalidate must remove cache file"
+
+    mock_client = _make_mock_client(
+        status_code=200,
+        json_body={"tag_name": "v0.9.175"},
+        etag='"new-etag"',
+    )
+    info = _make_stable_info()
+    with patch("httpx.Client", return_value=mock_client):
+        signal = _binary_signal(info, tmp_path, AUTOSKILLIT_INSTALLED_VERSION)
+
+    assert signal is not None, "Binary signal must fire after cache invalidation"
+    assert "0.9.175" in signal.detail
+
+
+@pytest.mark.parametrize(
+    "entry_kwargs,expect_hit",
+    [
+        pytest.param(
+            {"installed_version": "_CURRENT_"},
+            True,
+            id="matching-epoch-fresh-ttl",
+        ),
+        pytest.param(
+            {"installed_version": "0.0.1"},
+            False,
+            id="mismatched-epoch-fresh-ttl",
+        ),
+        pytest.param(
+            {},
+            False,
+            id="missing-epoch-fresh-ttl",
+        ),
+        pytest.param(
+            {"installed_version": "_CURRENT_", "cached_at_offset": -3601},
+            False,
+            id="matching-epoch-expired-ttl",
+        ),
+    ],
+)
+def test_fetch_with_cache_epoch_check_contract(
+    tmp_path: Path,
+    entry_kwargs: dict,
+    expect_hit: bool,
+) -> None:
+    """Parametrized contract: epoch + TTL together determine cache hit/miss."""
+    import time
+
+    from autoskillit.core import AUTOSKILLIT_INSTALLED_VERSION
+
+    cached_at_offset = entry_kwargs.pop("cached_at_offset", -1)
+    url = "https://api.github.com/repos/TalonT-Org/AutoSkillit/releases/latest"
+    entry: dict[str, Any] = {
+        "body": {"tag_name": "v0.8.0"},
+        "etag": '"test-etag"',
+        "cached_at": time.time() + cached_at_offset,
+    }
+    for k, v in entry_kwargs.items():
+        entry[k] = AUTOSKILLIT_INSTALLED_VERSION if v == "_CURRENT_" else v
+
+    cache_data = {url: entry}
+    (tmp_path / ".autoskillit").mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".autoskillit" / "github_fetch_cache.json").write_text(
+        json.dumps(cache_data), encoding="utf-8"
+    )
+
+    network_hit = [False]
+
+    class DetectingClient:
+        def __init__(self, **kw):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def get(self, url, **kw):
+            network_hit[0] = True
+            r = MagicMock()
+            r.status_code = 200
+            r.json.return_value = {"tag_name": "v0.9.0"}
+            r.headers = {"ETag": '"fresh-etag"'}
+            return r
+
+    with patch("httpx.Client", DetectingClient):
+        result = _fetch_with_cache(url, home=tmp_path)
+
+    if expect_hit:
+        assert not network_hit[0], "Expected cache hit but network was called"
+        assert result == {"tag_name": "v0.8.0"}
+    else:
+        assert network_hit[0], "Expected cache miss but network was not called"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_update_checks.py
+++ b/tests/cli/test_update_checks.py
@@ -2001,19 +2001,22 @@ def test_full_lifecycle_install_clears_stale_cache_then_check_detects_new_versio
     from autoskillit.cli._update_checks import _binary_signal, invalidate_fetch_cache
     from autoskillit.core import AUTOSKILLIT_INSTALLED_VERSION
 
+    stale_version = "0.0.0-stale"
+    newer_version = "99.99.99"
+
     url = "https://api.github.com/repos/TalonT-Org/AutoSkillit/releases/latest"
     cache_data = {
         url: {
-            "body": {"tag_name": "v0.9.170"},
+            "body": {"tag_name": f"v{stale_version}"},
             "etag": '"old-etag"',
             "cached_at": time.time(),
-            "installed_version": "0.9.170",
+            "installed_version": stale_version,
         },
         "https://api.github.com/repos/TalonT-Org/AutoSkillit/git/refs/heads/integration": {
             "body": {"object": {"sha": "a" * 40}},
             "etag": '"ref-etag"',
             "cached_at": time.time(),
-            "installed_version": "0.9.170",
+            "installed_version": stale_version,
         },
     }
     cache_file = tmp_path / ".autoskillit" / "github_fetch_cache.json"
@@ -2025,7 +2028,7 @@ def test_full_lifecycle_install_clears_stale_cache_then_check_detects_new_versio
 
     mock_client = _make_mock_client(
         status_code=200,
-        json_body={"tag_name": "v0.9.175"},
+        json_body={"tag_name": f"v{newer_version}"},
         etag='"new-etag"',
     )
     info = _make_stable_info()
@@ -2033,7 +2036,7 @@ def test_full_lifecycle_install_clears_stale_cache_then_check_detects_new_versio
         signal = _binary_signal(info, tmp_path, AUTOSKILLIT_INSTALLED_VERSION)
 
     assert signal is not None, "Binary signal must fire after cache invalidation"
-    assert "0.9.175" in signal.message
+    assert newer_version in signal.message
 
 
 @pytest.mark.parametrize(

--- a/tests/cli/test_update_checks.py
+++ b/tests/cli/test_update_checks.py
@@ -1777,7 +1777,7 @@ def test_run_update_command_invalidates_fetch_cache(
     info = _make_stable_info()
     monkeypatch.setattr("autoskillit.cli._update.detect_install", lambda: info)
     monkeypatch.setattr("autoskillit.cli._update.terminal_guard", FakeTG)
-    monkeypatch.setattr("autoskillit.cli._update.any_kitchen_open", lambda: False)
+    monkeypatch.setattr("autoskillit.core.any_kitchen_open", lambda: False)
 
     upgrade_ok = subprocess.CompletedProcess([], returncode=0)
     install_ok = subprocess.CompletedProcess([], returncode=0)
@@ -2033,7 +2033,7 @@ def test_full_lifecycle_install_clears_stale_cache_then_check_detects_new_versio
         signal = _binary_signal(info, tmp_path, AUTOSKILLIT_INSTALLED_VERSION)
 
     assert signal is not None, "Binary signal must fire after cache invalidation"
-    assert "0.9.175" in signal.detail
+    assert "0.9.175" in signal.message
 
 
 @pytest.mark.parametrize(

--- a/tests/cli/test_update_checks.py
+++ b/tests/cli/test_update_checks.py
@@ -1621,7 +1621,7 @@ def test_stale_fetch_cache_after_install_detected_by_epoch(
         AUTOSKILLIT_INSTALLED_VERSION as _REAL_VERSION,
     )
 
-    old_version = "0.9.170"
+    old_version = "0.0.0-stale"
     assert old_version != _REAL_VERSION
 
     url = "https://api.github.com/repos/TalonT-Org/AutoSkillit/releases/latest"
@@ -2071,6 +2071,7 @@ def test_fetch_with_cache_epoch_check_contract(
 
     from autoskillit.core import AUTOSKILLIT_INSTALLED_VERSION
 
+    entry_kwargs = dict(entry_kwargs)
     cached_at_offset = entry_kwargs.pop("cached_at_offset", -1)
     url = "https://api.github.com/repos/TalonT-Org/AutoSkillit/releases/latest"
     entry: dict[str, Any] = {


### PR DESCRIPTION
## Summary

`github_fetch_cache.json` is a TTL-only cache with no event-driven invalidation. Three mutation paths (`_run_update_sequence`, `run_update_command`, `install`) change the installed version but leave the fetch cache holding a stale SHA or release version that matches the now-installed commit. The next startup check within the 30-minute TTL window reads the stale entry and concludes no update exists — silently suppressing drift detection.

The fix adds a version-epoch field (`installed_version`) to every cache entry. On read, if the entry's epoch mismatches the running version, the cache hit is discarded regardless of TTL freshness. Additionally, explicit `invalidate_fetch_cache()` calls are added to all three install/update paths as a belt-and-suspenders layer. Tests cover the cross-hemisphere state transition (cache populated → install mutates version → next read detects staleness).

## Requirements

### Summary

The update check system (`_update_checks.py`) silently fails to detect source drift when running from any directory other than the autoskillit source repo. This is caused by a cache invalidation bug: `github_fetch_cache.json` retains a stale SHA that matches the installed commit, making the system believe no updates exist even when the remote has advanced.

### Reproduction (deterministic)

1. Install autoskillit from integration: `uv tool install --force git+https://github.com/TalonT-Org/AutoSkillit.git@integration`
2. Push a new commit to integration (advancing the remote HEAD)
3. Run `autoskillit order` from the source repo directory → **update check fires** (shows version, prompts for update)
4. Run `autoskillit order` from ANY other directory → **update check is completely silent** (no version, no prompt)

Wait 30 minutes (cache TTL expiry), repeat step 4 → update check now fires correctly.

### Root Cause

`resolve_reference_sha()` (lines 350-357 of `_update_checks.py`) has two resolution paths:

- PATH 1 (from source repo): `find_source_repo()` finds the local autoskillit checkout → `git ls-remote origin integration` → returns the LIVE remote HEAD → compares against installed commit → drift detected.
- PATH 2 (from any other directory): `find_source_repo()` returns `None` → `_api_sha()` reads `github_fetch_cache.json` → if cache is <30 min old, returns the cached SHA without network request → cached SHA equals installed commit → no signal fires.

The critical failure: no install or update path invalidates the fetch cache.

## Architecture Impact

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START([CLI Startup])

    subgraph EntryGates ["ENTRY GATES — ● _update_checks.py"]
        direction TB
        G_ENV{"ENV guards<br/>━━━━━━━━━━<br/>CLAUDECODE / CI /<br/>SKIP_* env vars"}
        G_TTY{"TTY gate<br/>━━━━━━━━━━<br/>stdin + stdout<br/>must be TTY"}
        G_INSTALL{"Install-type gate<br/>━━━━━━━━━━<br/>LOCAL_EDITABLE /<br/>LOCAL_PATH / UNKNOWN<br/>→ skip unless FORCE"}
        G_KITCHEN{"Kitchen gate<br/>━━━━━━━━━━<br/>any_kitchen_open()<br/>→ skip"}
    end

    subgraph FetchCache ["FETCH CACHE — ● _update_checks.py"]
        direction TB
        FC_FILE[("● github_fetch_cache.json<br/>━━━━━━━━━━<br/>MUTABLE per-URL entries<br/>body / etag / cached_at /<br/>installed_version")]
        FC_TTL{"TTL gate<br/>━━━━━━━━━━<br/>now − cached_at<br/>< effective_ttl?"}
        FC_EPOCH{"● Version epoch gate<br/>━━━━━━━━━━<br/>entry.installed_version<br/>== INSTALLED_VERSION?"}
        FC_ETAG["ETag conditional GET<br/>━━━━━━━━━━<br/>If-None-Match header<br/>304 → refresh timestamps"]
        FC_FRESH["Cache HIT<br/>━━━━━━━━━━<br/>Return cached body"]
        FC_FETCH["Network FETCH<br/>━━━━━━━━━━<br/>HTTP GET → write entry<br/>stamp installed_version"]
    end

    subgraph Signals ["SIGNAL GENERATION — ● _update_checks.py"]
        direction TB
        SIG_BIN["Signal: binary<br/>━━━━━━━━━━<br/>INIT_ONLY frozen<br/>latest > current"]
        SIG_HOOK["Signal: hooks<br/>━━━━━━━━━━<br/>INIT_ONLY frozen<br/>missing/orphaned hooks"]
        SIG_DRIFT["Signal: source_drift<br/>━━━━━━━━━━<br/>INIT_ONLY frozen<br/>commit SHA lag"]
        SIG_DUAL["Signal: dual_mcp<br/>━━━━━━━━━━<br/>INIT_ONLY frozen<br/>dual MCP registered"]
    end

    subgraph DismissState ["DISMISS STATE — ● _update_checks.py"]
        direction TB
        DS_FILE[("● update_check.json<br/>━━━━━━━━━━<br/>INIT_PRESERVE<br/>dismissed_at / dismissed_version /<br/>conditions[]")]
        DS_TIME{"Time window gate<br/>━━━━━━━━━━<br/>7d stable / 12h dev<br/>now − dismissed_at < window?"}
        DS_VER{"Version delta gate<br/>━━━━━━━━━━<br/>current ≤ dismissed_version?<br/>Advance → re-prompt"}
        DS_COND{"Condition gate<br/>━━━━━━━━━━<br/>signal.kind in<br/>conditions[]?"}
    end

    subgraph Prompt ["INTERACTIVE PROMPT — ● _update_checks.py"]
        direction TB
        PROMPT_SHOW["Consolidated prompt<br/>━━━━━━━━━━<br/>All undismissed signals<br/>→ single input()"]
        PROMPT_YES["YES path<br/>━━━━━━━━━━<br/>Run upgrade + install"]
        PROMPT_NO["NO path<br/>━━━━━━━━━━<br/>Write dismissal record"]
    end

    subgraph Invalidation ["CACHE INVALIDATION — ● _update.py / ● _marketplace.py"]
        direction TB
        INV_UPDATE["● run_update_command<br/>━━━━━━━━━━<br/>Pop update_prompt +<br/>binary_snoozed<br/>Write dismiss state"]
        INV_INSTALL["● marketplace.install<br/>━━━━━━━━━━<br/>Post-install cleanup"]
        INV_SEQ["● _run_update_sequence<br/>━━━━━━━━━━<br/>Pop keys + write state"]
        INV_DELETE["● invalidate_fetch_cache<br/>━━━━━━━━━━<br/>DELETE entire<br/>github_fetch_cache.json"]
    end

    END([Done])

    %% FLOW %%
    START --> G_ENV
    G_ENV -->|pass| G_TTY
    G_ENV -->|fail| END
    G_TTY -->|pass| G_INSTALL
    G_TTY -->|fail| END
    G_INSTALL -->|pass| G_KITCHEN
    G_INSTALL -->|fail| END
    G_KITCHEN -->|pass| FC_FILE
    G_KITCHEN -->|fail| END

    FC_FILE --> FC_TTL
    FC_TTL -->|expired| FC_EPOCH
    FC_TTL -->|fresh| FC_EPOCH
    FC_EPOCH -->|match + fresh TTL| FC_FRESH
    FC_EPOCH -->|mismatch or expired| FC_ETAG
    FC_ETAG -->|304| FC_FRESH
    FC_ETAG -->|miss/no etag| FC_FETCH
    FC_FETCH --> FC_FRESH

    FC_FRESH --> SIG_BIN
    FC_FRESH --> SIG_HOOK
    FC_FRESH --> SIG_DRIFT
    FC_FRESH --> SIG_DUAL

    SIG_BIN --> DS_FILE
    SIG_HOOK --> DS_FILE
    SIG_DRIFT --> DS_FILE
    SIG_DUAL --> DS_FILE

    DS_FILE --> DS_TIME
    DS_TIME -->|within window| DS_VER
    DS_TIME -->|expired| PROMPT_SHOW
    DS_VER -->|no advance| DS_COND
    DS_VER -->|version advanced| PROMPT_SHOW
    DS_COND -->|in conditions| END
    DS_COND -->|not in conditions| PROMPT_SHOW

    PROMPT_SHOW --> PROMPT_YES
    PROMPT_SHOW --> PROMPT_NO

    PROMPT_YES --> INV_SEQ
    PROMPT_NO --> DS_FILE

    INV_UPDATE --> INV_DELETE
    INV_INSTALL --> INV_DELETE
    INV_SEQ --> INV_DELETE
    INV_DELETE --> FC_FILE

    INV_UPDATE --> END
    INV_INSTALL --> END
    INV_SEQ --> END

    %% CLASS ASSIGNMENTS %%
    class START,END terminal;
    class G_ENV,G_TTY,G_INSTALL,G_KITCHEN detector;
    class FC_FILE,DS_FILE stateNode;
    class FC_TTL,FC_EPOCH,DS_TIME,DS_VER,DS_COND detector;
    class FC_ETAG,FC_FETCH handler;
    class FC_FRESH output;
    class SIG_BIN,SIG_HOOK,SIG_DRIFT,SIG_DUAL phase;
    class PROMPT_SHOW,PROMPT_YES,PROMPT_NO cli;
    class INV_UPDATE,INV_INSTALL,INV_SEQ,INV_DELETE gap;
```

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;

    START([START: CLI Invocation])
    SKIP([SILENT RETURN])
    APP([PROCEED TO APP])
    ERROR([ERROR EXIT])

    subgraph EntryGuards ["● Entry Guards — _update_checks.py"]
        direction TB
        RUC["● run_update_checks<br/>━━━━━━━━━━<br/>Unified startup entry point"]
        ENVG{"Env guards?<br/>━━━━━━━━━━<br/>CLAUDECODE / CI /<br/>SKIP envvars / !TTY"}
        KITG{"any_kitchen_open?"}
        INST["detect_install<br/>━━━━━━━━━━<br/>Classify InstallInfo<br/>from direct_url.json"]
        TYPG{"Install type?<br/>━━━━━━━━━━<br/>UNKNOWN / LOCAL_PATH /<br/>LOCAL_EDITABLE"}
    end

    subgraph SignalGather ["● Signal Gathering — _update_checks.py"]
        direction TB
        BSIG["● _binary_signal<br/>━━━━━━━━━━<br/>Compare installed vs<br/>latest release version"]
        HSIG["_hooks_signal<br/>━━━━━━━━━━<br/>Hook registry drift<br/>from settings.json"]
        DSIG["_source_drift_signal<br/>━━━━━━━━━━<br/>Compare installed SHA<br/>vs branch HEAD SHA"]
        MSIG["_dual_mcp_signal<br/>━━━━━━━━━━<br/>Both direct + marketplace<br/>MCP registered"]
        SFILT{"Any signals<br/>fired?"}
    end

    subgraph FetchCache ["● Fetch Cache Engine — _update_checks.py"]
        direction TB
        CREAD["● _read_fetch_cache<br/>━━━━━━━━━━<br/>Load github_fetch_cache.json"]
        CTTL{"Cache valid?<br/>━━━━━━━━━━<br/>TTL < 30min AND<br/>installed_version<br/>== current epoch"}
        HTTP["HTTP GET<br/>━━━━━━━━━━<br/>Conditional: If-None-Match<br/>with cached ETag"]
        HSTAT{"HTTP status?"}
        CWRITE["● _write_fetch_cache<br/>━━━━━━━━━━<br/>Store body + etag +<br/>cached_at + installed_version"]
    end

    subgraph DismissCheck ["● Dismissal Engine — _update_checks.py"]
        direction TB
        DPART["Partition signals<br/>━━━━━━━━━━<br/>undismissed vs dismissed"]
        DCHK{"_is_dismissed?<br/>━━━━━━━━━━<br/>1. time window elapsed?<br/>2. version advanced?<br/>3. condition in set?"}
        DALL{"All dismissed?"}
    end

    subgraph UserPrompt ["● Interactive Prompt — _update_checks.py"]
        direction TB
        PROMPT["timed_prompt<br/>━━━━━━━━━━<br/>Update now? Y/n<br/>30s timeout"]
        PANS{"User answer?"}
        DISMISS["Write dismiss record<br/>━━━━━━━━━━<br/>dismissed_at + version<br/>+ condition kinds"]
        PASSIVE["Passive one-liner<br/>━━━━━━━━━━<br/>Silenced until expiry date"]
    end

    subgraph UpdateExec ["● Update Sequence — _update_checks.py"]
        direction TB
        UPGR["● _run_update_sequence<br/>━━━━━━━━━━<br/>upgrade_command → subprocess<br/>autoskillit install"]
        VERIFY["● _verify_update_result<br/>━━━━━━━━━━<br/>importlib.metadata.version<br/>bypasses lru_cache"]
        VCHK{"Version<br/>advanced?"}
        CLEAR["Clear dismiss state<br/>━━━━━━━━━━<br/>Pop update_prompt +<br/>binary_snoozed"]
    end

    subgraph ExplicitUpdate ["● Explicit Update — _update.py"]
        direction TB
        RUCMD["● run_update_command<br/>━━━━━━━━━━<br/>autoskillit update subcommand"]
        EKITG{"any_kitchen_open?"}
        EUPGR["upgrade_command → subprocess<br/>━━━━━━━━━━<br/>autoskillit install<br/>then verify + clear state"]
    end

    subgraph PostInstall ["● Post-Install — _marketplace.py"]
        direction TB
        INST_CMD["● install<br/>━━━━━━━━━━<br/>Plugin marketplace install<br/>+ hook sync"]
        INVAL["● invalidate_fetch_cache<br/>━━━━━━━━━━<br/>Delete github_fetch_cache.json<br/>unconditionally"]
    end

    %% MAIN FLOW: Startup update check
    START --> RUC
    RUC --> ENVG
    ENVG -->|"any set"| SKIP
    ENVG -->|"none set"| KITG
    KITG -->|"yes"| SKIP
    KITG -->|"no"| INST
    INST --> TYPG
    TYPG -->|"LOCAL/UNKNOWN<br/>no force flag"| SKIP
    TYPG -->|"DIRECT/MARKETPLACE/<br/>forced"| BSIG

    %% Signal gathering (parallel in code, sequential in diagram)
    BSIG --> HSIG
    HSIG --> DSIG
    DSIG --> MSIG
    MSIG --> SFILT

    %% Fetch cache (used by binary + drift signals)
    BSIG -.->|"reads"| CREAD
    DSIG -.->|"reads"| CREAD
    CREAD --> CTTL
    CTTL -->|"hit: TTL ok +<br/>version epoch match"| SFILT
    CTTL -->|"miss: stale / epoch<br/>mismatch / absent"| HTTP
    HTTP --> HSTAT
    HSTAT -->|"200"| CWRITE
    HSTAT -->|"304"| CWRITE
    HSTAT -->|"error/timeout"| SFILT
    CWRITE --> SFILT

    %% No signals
    SFILT -->|"none fired"| SKIP

    %% Dismissal check
    SFILT -->|"signals fired"| DPART
    DPART --> DCHK
    DCHK --> DALL
    DALL -->|"all dismissed"| PASSIVE
    PASSIVE --> APP

    %% Undismissed prompt
    DALL -->|"some undismissed"| PROMPT
    PROMPT --> PANS
    PANS -->|"timeout"| APP
    PANS -->|"N"| DISMISS
    DISMISS --> APP
    PANS -->|"Y"| UPGR

    %% Update execution
    UPGR --> VERIFY
    VERIFY --> VCHK
    VCHK -->|"yes"| CLEAR
    CLEAR --> INVAL
    VCHK -->|"no: version unchanged"| APP
    INVAL --> APP

    %% Explicit update command (separate entry)
    RUCMD --> EKITG
    EKITG -->|"yes"| ERROR
    EKITG -->|"no"| EUPGR
    EUPGR --> INVAL

    %% Post-install (separate entry)
    INST_CMD --> INVAL

    %% CLASS ASSIGNMENTS
    class START,SKIP,APP,ERROR terminal;
    class RUC,RUCMD,INST_CMD handler;
    class ENVG,KITG,TYPG,SFILT,DALL,PANS,VCHK,EKITG,CTTL,HSTAT stateNode;
    class BSIG,HSIG,DSIG,MSIG phase;
    class DPART,DCHK,PROMPT,PASSIVE,DISMISS phase;
    class CREAD,CWRITE,HTTP output;
    class UPGR,VERIFY,EUPGR,CLEAR,INVAL handler;
    class INST detector;
```

Closes #1314

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260426-132652-294751/.autoskillit/temp/rectify/rectify_fetch_cache_invalidation_2026-04-26_134500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->
