### PR TITLE
Add fleet to server cascade in LAYER_CASCADE_CONSERVATIVE

### DIFF
--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -272,6 +272,7 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
         {
             "server",
             "cli",
+            "fleet",
         }
     ),
     "cli": frozenset(

--- a/tests/test_test_filter.py
+++ b/tests/test_test_filter.py
@@ -290,7 +290,7 @@ class TestBuildTestScope:
 
     def test_scope_l3_server_conservative(self, tmp_path: Path) -> None:
         tests_root = tmp_path / "tests"
-        for d in ["server", "cli", "infra", "arch", "contracts", "docs"]:
+        for d in ["server", "cli", "fleet", "infra", "arch", "contracts", "docs"]:
             (tests_root / d).mkdir(parents=True, exist_ok=True)
 
         result = build_test_scope(
@@ -302,6 +302,7 @@ class TestBuildTestScope:
         dir_names = {p.name for p in result}
         assert "server" in dir_names
         assert "cli" in dir_names
+        assert "fleet" in dir_names
         result_names = {p.name for p in result}
         from tests._test_filter import _INFRA_UNCONDITIONAL_FILES
 


### PR DESCRIPTION
## Summary

Add `"fleet"` to `LAYER_CASCADE_CONSERVATIVE["server"]` in `tests/_test_filter.py` so that changes to `src/autoskillit/server/` trigger fleet tests. Two fleet test files (`tests/fleet/conftest.py`, `tests/fleet/test_pack_enforcement.py`) import directly from `autoskillit.server`, creating a test-side coupling that the current cascade misses. This is a correctness fix preventing false negatives where server changes could break fleet tests undetected.

## Architecture Impact

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;

    subgraph L3 ["LAYER 3 — APPLICATION"]
        direction LR
        SERVER["server/<br/>━━━━━━━━━━<br/>FastMCP tools<br/>Fan-out: 5 · Fan-in: 8"]
        CLI["cli/<br/>━━━━━━━━━━<br/>CLI entry points<br/>Fan-out: 7 · Fan-in: 1"]
    end

    subgraph L2 ["LAYER 2 — DOMAIN"]
        direction LR
        FLEET["fleet/<br/>━━━━━━━━━━<br/>Campaign dispatch<br/>Fan-out: 1 · Fan-in: 5"]
        RECIPE["recipe/<br/>━━━━━━━━━━<br/>Recipe engine<br/>Fan-out: 2 · Fan-in: 4"]
        MIGRATION["migration/<br/>━━━━━━━━━━<br/>Schema migration"]
    end

    subgraph L1 ["LAYER 1 — INFRASTRUCTURE"]
        direction LR
        PIPELINE["pipeline/<br/>━━━━━━━━━━<br/>Gate & telemetry"]
        EXECUTION["execution/<br/>━━━━━━━━━━<br/>Headless sessions"]
        WORKSPACE["workspace/<br/>━━━━━━━━━━<br/>Clone & worktree"]
        CONFIG["config/<br/>━━━━━━━━━━<br/>Settings"]
    end

    subgraph L0 ["LAYER 0 — FOUNDATION"]
        CORE["core/<br/>━━━━━━━━━━<br/>Types, IO, paths<br/>Fan-in: 14"]
    end

    subgraph TestInfra ["TEST INFRASTRUCTURE"]
        direction LR
        TF["● tests/_test_filter<br/>━━━━━━━━━━<br/>LAYER_CASCADE_CONSERVATIVE<br/>FilterMode · build_test_scope<br/>14+ test consumers"]
        TTF["● tests/test_test_filter<br/>━━━━━━━━━━<br/>Cascade invariant tests<br/>Manifest integration tests"]
        SRC_TF["src/_test_filter<br/>━━━━━━━━━━<br/>Manifest pathspec filter<br/>load_manifest · apply_manifest"]
    end

    subgraph CascadeConsumers ["CASCADE MAP CONSUMERS"]
        direction LR
        CONFTEST["tests/conftest<br/>━━━━━━━━━━<br/>FilterMode gate"]
        ARCH_GUARD["tests/arch/<br/>━━━━━━━━━━<br/>REQ-GUARD-002/003<br/>Cascade completeness"]
        INFRA_TESTS["tests/infra/<br/>━━━━━━━━━━<br/>Filter activation<br/>Manifest completeness"]
    end

    %% L3 → L2 VALID DEPENDENCIES %%
    SERVER -->|"imports"| FLEET
    SERVER -->|"imports"| RECIPE
    SERVER -->|"imports"| MIGRATION
    CLI -->|"imports"| FLEET
    CLI -->|"imports"| RECIPE

    %% L3 → L1 %%
    SERVER -->|"imports"| PIPELINE
    SERVER -->|"imports"| EXECUTION
    SERVER -->|"imports"| WORKSPACE
    CLI -->|"imports"| EXECUTION
    CLI -->|"imports"| CONFIG
    CLI -->|"imports"| PIPELINE
    CLI -->|"imports"| WORKSPACE

    %% L2 → L0 %%
    FLEET -->|"imports"| CORE
    RECIPE -->|"imports"| CORE
    MIGRATION -->|"imports"| CORE

    %% L1 → L0 %%
    PIPELINE -->|"imports"| CORE
    EXECUTION -->|"imports"| CORE
    WORKSPACE -->|"imports"| CORE
    CONFIG -->|"imports"| CORE

    %% Test infra dependencies %%
    TTF -->|"imports 14 symbols"| TF
    TTF -->|"imports manifest API"| SRC_TF
    SRC_TF -->|"imports load_yaml"| CORE
    CONFTEST -->|"imports FilterMode"| TF
    ARCH_GUARD -->|"imports cascade maps"| TF
    INFRA_TESTS -->|"imports load_manifest"| TF

    %% THE KEY RELATIONSHIP: server→fleet cascade %%
    TF -.->|"CASCADE FIX: server → fleet<br/>added to LAYER_CASCADE_CONSERVATIVE"| SERVER

    %% CLASS ASSIGNMENTS %%
    class SERVER,CLI cli;
    class FLEET,RECIPE,MIGRATION phase;
    class PIPELINE,EXECUTION,WORKSPACE,CONFIG handler;
    class CORE stateNode;
    class TF,TTF newComponent;
    class SRC_TF output;
    class CONFTEST,ARCH_GUARD,INFRA_TESTS detector;
```

Closes #1298

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-1298-20260426-125724-518052/.autoskillit/temp/make-plan/add_fleet_to_server_cascade_plan_2026-04-26_130300.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 84 | 6.9k | 875.4k | 47.4k | 1 | 5m 14s |
| verify | 33 | 4.2k | 170.1k | 30.7k | 1 | 2m 10s |
| implement | 29 | 3.1k | 297.0k | 43.2k | 1 | 2m 1s |
| prepare_pr | 25 | 2.7k | 168.8k | 31.7k | 1 | 1m 3s |
| run_arch_lenses | 34 | 4.8k | 235.0k | 37.6k | 1 | 3m 47s |
| compose_pr | 22 | 3.7k | 123.6k | 21.3k | 1 | 1m 1s |
| **Total** | 227 | 25.4k | 1.9M | 211.9k | | 15m 18s |