### PR TITLE
Replace TestRecipeCascadeFragilityGuard with generalized TestFileLevelCascadeDriftGuard (REQ-GUARD-005)

### DIFF
--- a/tests/arch/test_cascade_map_guard.py
+++ b/tests/arch/test_cascade_map_guard.py
@@ -1,5 +1,5 @@
 """
-REQ-GUARD-001..003: CI guard validating cascade maps against the AST-derived
+REQ-GUARD-001..003, 005: CI guard validating cascade maps against the AST-derived
 reverse import graph.  Zero runtime cost — pure static analysis.
 """
 
@@ -9,7 +9,6 @@ import ast
 import warnings
 from collections import defaultdict
 from pathlib import Path
-from typing import ClassVar
 
 import pytest
 
@@ -185,49 +184,68 @@ class TestLayerCascadeConservativeGuard:
         )
 
 
-class TestRecipeCascadeFragilityGuard:
-    """REQ-GUARD-004: File-level recipe cascade entries must cover all importers."""
+class TestFileLevelCascadeDriftGuard:
+    """REQ-GUARD-005: File-level cascade entries must cover all test-file importers."""
 
-    _NARROWED_DIRS: ClassVar[frozenset[str]] = frozenset(
-        {
-            "execution",
-            "infra",
-            "skills",
-            "core",
-        }
-    )
-
-    def test_no_recipe_importing_test_file_missing_from_cascade(self) -> None:
-        recipe_cascade = LAYER_CASCADE_CONSERVATIVE["recipe"]
-        declared_files: dict[str, set[str]] = {}
-        for entry in recipe_cascade:
-            if "/" in entry:
-                parts = entry.split("/", 1)
-                declared_files.setdefault(parts[0], set()).add(parts[1])
+    def test_no_importing_test_file_missing_from_file_level_entries(self) -> None:
+        by_dir: dict[str, dict[str, set[str]]] = {}
+        for pkg, cascade_set in LAYER_CASCADE_CONSERVATIVE.items():
+            dir_entries = {e for e in cascade_set if "/" not in e}
+            for entry in cascade_set:
+                if "/" not in entry:
+                    continue
+                dir_name, fname = entry.split("/", 1)
+                if dir_name not in dir_entries:
+                    by_dir.setdefault(dir_name, {}).setdefault(pkg, set()).add(fname)
 
         tests_root = Path(__file__).parent.parent
         violations: list[str] = []
-        for dir_name in self._NARROWED_DIRS:
+
+        for dir_name, pkg_map in sorted(by_dir.items()):
             dir_path = tests_root / dir_name
             if not dir_path.is_dir():
                 continue
             for test_file in sorted(dir_path.glob("test_*.py")):
-                tree = ast.parse(test_file.read_text(encoding="utf-8"))
+                try:
+                    tree = ast.parse(test_file.read_text(encoding="utf-8"))
+                except SyntaxError:
+                    continue
+                imported_pkgs: set[str] = set()
                 for node in ast.walk(tree):
                     if (
                         isinstance(node, ast.ImportFrom)
                         and node.module
-                        and node.module.startswith("autoskillit.recipe")
+                        and node.module.startswith("autoskillit.")
                     ):
-                        fname = test_file.name
-                        if fname not in declared_files.get(dir_name, set()):
-                            violations.append(f"{dir_name}/{fname}")
-                        break
+                        parts = node.module.split(".")
+                        if len(parts) >= 2:
+                            imported_pkgs.add(parts[1])
+
+                fname = test_file.name
+                for pkg, declared_files in pkg_map.items():
+                    if pkg in imported_pkgs and fname not in declared_files:
+                        violations.append(f"{dir_name}/{fname} imports autoskillit.{pkg}")
+
         assert not violations, (
-            "Test files import from autoskillit.recipe but are not in "
-            "LAYER_CASCADE_CONSERVATIVE['recipe'] file-level entries:\n"
+            "Test files import from packages with file-level cascade entries "
+            "but are not declared in LAYER_CASCADE_CONSERVATIVE:\n"
             + "\n".join(f"  {v}" for v in violations)
-            + "\nAdd them to the recipe cascade in tests/_test_filter.py."
+            + "\nAdd the missing file-level entries to tests/_test_filter.py."
+        )
+
+    def test_every_file_level_entry_references_existing_test(self) -> None:
+        tests_root = Path(__file__).parent.parent
+        stale: list[str] = []
+        for pkg, cascade_set in sorted(LAYER_CASCADE_CONSERVATIVE.items()):
+            for entry in sorted(cascade_set):
+                if "/" not in entry:
+                    continue
+                if not (tests_root / entry).is_file():
+                    stale.append(f"{pkg}: {entry} (not found at tests/{entry})")
+        assert not stale, (
+            "File-level cascade entries reference nonexistent test files:\n"
+            + "\n".join(f"  {s}" for s in stale)
+            + "\nRemove the stale entry or update the filename in tests/_test_filter.py."
         )
 
 

--- a/tests/arch/test_cascade_map_guard.py
+++ b/tests/arch/test_cascade_map_guard.py
@@ -212,14 +212,17 @@ class TestFileLevelCascadeDriftGuard:
                     continue
                 imported_pkgs: set[str] = set()
                 for node in ast.walk(tree):
-                    if (
-                        isinstance(node, ast.ImportFrom)
-                        and node.module
-                        and node.module.startswith("autoskillit.")
-                    ):
-                        parts = node.module.split(".")
-                        if len(parts) >= 2:
-                            imported_pkgs.add(parts[1])
+                    if isinstance(node, ast.ImportFrom) and node.module:
+                        if node.module.startswith("autoskillit."):
+                            parts = node.module.split(".")
+                            if len(parts) >= 2:
+                                imported_pkgs.add(parts[1])
+                    elif isinstance(node, ast.Import):
+                        for alias in node.names:
+                            if alias.name.startswith("autoskillit."):
+                                parts = alias.name.split(".")
+                                if len(parts) >= 2:
+                                    imported_pkgs.add(parts[1])
 
                 fname = test_file.name
                 for pkg, declared_files in pkg_map.items():
@@ -227,8 +230,9 @@ class TestFileLevelCascadeDriftGuard:
                         violations.append(f"{dir_name}/{fname} imports autoskillit.{pkg}")
 
         assert not violations, (
-            "Test files import from packages with file-level cascade entries "
-            "but are not declared in LAYER_CASCADE_CONSERVATIVE:\n"
+            "Test files import from packages in directories with partial "
+            "(file-level) cascade entries but are not declared in "
+            "LAYER_CASCADE_CONSERVATIVE:\n"
             + "\n".join(f"  {v}" for v in violations)
             + "\nAdd the missing file-level entries to tests/_test_filter.py."
         )


### PR DESCRIPTION
## Summary

Replace the hardcoded `TestRecipeCascadeFragilityGuard` (REQ-GUARD-004) with a generalized `TestFileLevelCascadeDriftGuard` (REQ-GUARD-005) that automatically discovers all file-level cascade entries across every key in `LAYER_CASCADE_CONSERVATIVE` and validates them against AST-derived test file imports. This eliminates the need to manually maintain per-package guards and catches drift in any cascade entry that uses file-level narrowing.

**Core insight:** When a cascade value contains file-level entries like `"execution/test_headless.py"` (entries with `/`) alongside directory-level entries like `"server"` (bare names), the file-level entries represent a narrowed scope — only those specific test files run when the package changes. If a new test file in that narrowed directory imports from the package without being listed, the test filter silently misses it. The current guard only catches this for `recipe`; the generalized guard catches it for all packages.

## Architecture Impact

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph CIGuard ["CI GUARD LAYER — Static Analysis at Test Time"]
        direction LR
        GUARD["● test_cascade_map_guard.py<br/>━━━━━━━━━━<br/>REQ-GUARD-001..003, 005<br/>AST reverse-graph builder<br/>Validates cascade maps"]
    end

    subgraph TestInfra ["TEST INFRASTRUCTURE — Cascade Map Definitions"]
        direction LR
        FILTER["_test_filter.py<br/>━━━━━━━━━━<br/>LAYER_CASCADE_CONSERVATIVE<br/>MODULE_CASCADE_CORE<br/>_file_to_package()"]
        CONFTEST["conftest.py<br/>━━━━━━━━━━<br/>pytest_collection_modifyitems<br/>build_test_scope()"]
        FILTER_TESTS["test_test_filter*.py<br/>━━━━━━━━━━<br/>5 files testing filter logic"]
    end

    subgraph L3 ["L3 — APPLICATION"]
        direction LR
        SERVER["server/<br/>━━━━━━━━━━<br/>FastMCP tools<br/>18 self-consumers"]
        CLI["cli/<br/>━━━━━━━━━━<br/>Entry points<br/>app.py, cook, fleet"]
    end

    subgraph L2 ["L2 — ORCHESTRATION"]
        direction LR
        RECIPE["recipe/<br/>━━━━━━━━━━<br/>YAML recipes, rules<br/>46 consumers"]
        MIGRATION["migration/<br/>━━━━━━━━━━<br/>Version migrations"]
        FLEET["fleet/<br/>━━━━━━━━━━<br/>Campaign orchestration"]
    end

    subgraph L1 ["L1 — SERVICES"]
        direction LR
        CONFIG["config/<br/>━━━━━━━━━━<br/>Settings, defaults<br/>23 consumers"]
        PIPELINE["pipeline/<br/>━━━━━━━━━━<br/>Gate, audit, tokens<br/>16 consumers"]
        EXECUTION["execution/<br/>━━━━━━━━━━<br/>Headless, process<br/>22 consumers"]
        WORKSPACE["workspace/<br/>━━━━━━━━━━<br/>Clone, skills, cleanup"]
    end

    subgraph L0 ["L0 — FOUNDATION"]
        direction LR
        CORE["core/<br/>━━━━━━━━━━<br/>Types, paths, IO<br/>Fan-in: 132 files"]
    end

    subgraph Standalone ["STANDALONE MODULES"]
        direction LR
        HOOKS["hooks/<br/>━━━━━━━━━━<br/>Pre/PostToolUse scripts"]
        HOOKREG["hook_registry.py<br/>━━━━━━━━━━<br/>HookDef, HOOK_REGISTRY"]
        PLANNER["planner/<br/>━━━━━━━━━━<br/>Plan compilation"]
    end

    %% === CI Guard reads cascade maps from _test_filter === %%
    GUARD -->|"imports CASCADE maps<br/>+ _file_to_package"| FILTER

    %% === CI Guard AST-parses all src/ to build reverse graph === %%
    GUARD -.->|"AST parses<br/>all src/*.py"| CORE
    GUARD -.->|"AST parses"| CONFIG
    GUARD -.->|"AST parses"| PIPELINE
    GUARD -.->|"AST parses"| EXECUTION
    GUARD -.->|"AST parses"| WORKSPACE
    GUARD -.->|"AST parses"| RECIPE
    GUARD -.->|"AST parses"| SERVER
    GUARD -.->|"AST parses"| CLI

    %% === _test_filter consumed by conftest for collection === %%
    CONFTEST -->|"imports build_test_scope<br/>FilterMode, git helpers"| FILTER
    FILTER_TESTS -->|"imports cascade maps<br/>+ filter functions"| FILTER

    %% === Production layer dependencies (valid downward) === %%
    CLI -->|"imports"| SERVER
    CLI -->|"imports"| RECIPE
    CLI -->|"imports"| EXECUTION
    CLI -->|"imports"| CONFIG
    CLI -->|"imports"| CORE

    SERVER -->|"imports"| RECIPE
    SERVER -->|"imports"| EXECUTION
    SERVER -->|"imports"| PIPELINE
    SERVER -->|"imports"| WORKSPACE
    SERVER -->|"imports"| CONFIG
    SERVER -->|"imports"| CORE

    RECIPE -->|"imports"| CORE
    MIGRATION -->|"imports"| RECIPE
    MIGRATION -->|"imports"| CORE
    FLEET -->|"imports"| CORE

    CONFIG -->|"imports"| CORE
    PIPELINE -->|"imports"| CORE
    EXECUTION -->|"imports"| CORE
    WORKSPACE -->|"imports"| CORE

    HOOKS -->|"imports"| CORE
    HOOKREG -->|"imports"| CORE
    PLANNER -->|"imports"| CORE

    %% CLASS ASSIGNMENTS %%
    class GUARD detector;
    class FILTER,CONFTEST,FILTER_TESTS stateNode;
    class SERVER,CLI cli;
    class RECIPE,MIGRATION,FLEET phase;
    class CONFIG,PIPELINE,EXECUTION,WORKSPACE handler;
    class CORE output;
    class HOOKS,HOOKREG,PLANNER integration;
```

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;

    START([START<br/>pytest collection])
    PASS([ALL GUARDS PASS])
    FAIL([ASSERTION ERROR<br/>CI blocks merge])

    subgraph Build ["Phase 1 · AST Reverse Graph Construction"]
        direction TB
        SCAN["_all_src_files<br/>━━━━━━━━━━<br/>rglob src/autoskillit/**/*.py"]
        PKG_GRAPH["_build_package_reverse_graph<br/>━━━━━━━━━━<br/>from autoskillit.{pkg} → consumer_pkg<br/>reads all src files"]
        REEXPORT["_build_core_reexport_map<br/>━━━━━━━━━━<br/>parse core/__init__.py<br/>relative imports → stem map"]
        MOD_GRAPH["_build_module_reverse_graph<br/>━━━━━━━━━━<br/>core.{stem} direct + re-export<br/>reads all src files + reexport map"]
    end

    subgraph ModGuard ["Phase 2 · ● TestModuleCascadeCoreGuard"]
        direction TB
        MOD_SUP{"MODULE_CASCADE_CORE<br/>declared ⊇ actual?"}
        MOD_PHANTOM{"Phantom stems?<br/>━━━━━━━━━━<br/>stem in map but<br/>zero AST consumers"}
    end

    subgraph LayerGuard ["Phase 3 · ● TestLayerCascadeConservativeGuard"]
        direction TB
        LAY_SUP{"LAYER_CASCADE_CONSERVATIVE<br/>dir entries ∪ file prefixes<br/>⊇ actual consumers?"}
    end

    subgraph FileGuard ["Phase 4 · ● TestFileLevelCascadeDriftGuard"]
        direction TB
        FILE_MISS{"File-level entries<br/>━━━━━━━━━━<br/>Every importing test_*.py<br/>declared in cascade?"}
        FILE_STALE{"Stale entries?<br/>━━━━━━━━━━<br/>Every file-level entry<br/>references existing test?"}
    end

    subgraph UnmapGuard ["Phase 5 · ● TestUnmappedPackageGuard"]
        direction TB
        UNMAP{"Every src/ package<br/>━━━━━━━━━━<br/>has a key in<br/>LAYER_CASCADE_CONSERVATIVE?"}
    end

    subgraph Cascade ["Downstream Consumer · Test Path Filter"]
        direction TB
        FILTER["build_test_scope<br/>━━━━━━━━━━<br/>Consumes LAYER_CASCADE_CONSERVATIVE<br/>+ MODULE_CASCADE_CORE at runtime"]
        SCOPE["pytest_collection_modifyitems<br/>━━━━━━━━━━<br/>Deselects tests outside scope"]
    end

    %% FLOW %%
    START --> SCAN
    SCAN -->|"reads"| PKG_GRAPH
    SCAN -->|"reads"| REEXPORT
    REEXPORT -->|"reexport map"| MOD_GRAPH
    SCAN -->|"reads"| MOD_GRAPH

    MOD_GRAPH --> MOD_SUP
    MOD_SUP -->|"yes — superset"| MOD_PHANTOM
    MOD_SUP -->|"no — missing consumers"| FAIL
    MOD_PHANTOM -->|"none"| LAY_SUP
    MOD_PHANTOM -->|"phantoms found"| FAIL

    PKG_GRAPH --> LAY_SUP
    LAY_SUP -->|"yes — covered"| FILE_MISS
    LAY_SUP -->|"no — missing packages"| FAIL

    FILE_MISS -->|"all declared"| FILE_STALE
    FILE_MISS -->|"missing entries"| FAIL
    FILE_STALE -->|"all exist"| UNMAP
    FILE_STALE -->|"stale paths"| FAIL

    UNMAP -->|"all mapped"| PASS
    UNMAP -->|"no — unmapped packages"| FAIL

    PASS -.->|"guards ensure correctness of"| FILTER
    FILTER --> SCOPE

    %% CLASS ASSIGNMENTS %%
    class START,PASS,FAIL terminal;
    class SCAN,PKG_GRAPH,REEXPORT,MOD_GRAPH handler;
    class MOD_SUP,MOD_PHANTOM,LAY_SUP,FILE_MISS,FILE_STALE,UNMAP detector;
    class FILTER,SCOPE phase;
```

Closes #1301

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-1301-20260426-125725-060590/.autoskillit/temp/make-plan/ci_guard_cascade_drift_detection_plan_2026-04-26_130300.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 2.6k | 12.9k | 953.1k | 66.7k | 1 | 7m 6s |
| verify | 40 | 10.5k | 562.9k | 50.6k | 1 | 8m 29s |
| implement | 34 | 4.7k | 623.6k | 67.6k | 1 | 2m 33s |
| prepare_pr | 25 | 3.4k | 176.9k | 33.9k | 1 | 1m 21s |
| run_arch_lenses | 80 | 10.7k | 1.0M | 81.0k | 2 | 4m 41s |
| compose_pr | 24 | 5.1k | 196.2k | 26.0k | 1 | 1m 33s |
| **Total** | 2.8k | 47.4k | 3.5M | 325.8k | | 25m 45s |