### PR TITLE
Rectify: Planner Pipeline Schema Contract Immunity

### DIFF
--- a/src/autoskillit/planner/__init__.py
+++ b/src/autoskillit/planner/__init__.py
@@ -6,6 +6,11 @@ from autoskillit.planner.manifests import (
     build_wp_manifest,
     check_remaining,
 )
+from autoskillit.planner.schema import (
+    ASSIGNMENT_REQUIRED_KEYS,
+    PHASE_REQUIRED_KEYS,
+    WP_REQUIRED_KEYS,
+)
 from autoskillit.planner.validation import validate_plan
 
 __all__ = [
@@ -14,4 +19,7 @@ __all__ = [
     "build_wp_manifest",
     "validate_plan",
     "compile_plan",
+    "PHASE_REQUIRED_KEYS",
+    "ASSIGNMENT_REQUIRED_KEYS",
+    "WP_REQUIRED_KEYS",
 ]

--- a/src/autoskillit/planner/__init__.py
+++ b/src/autoskillit/planner/__init__.py
@@ -6,6 +6,11 @@ from autoskillit.planner.manifests import (
     build_wp_manifest,
     check_remaining,
 )
+from autoskillit.planner.schema import (  # noqa: F401
+    ASSIGNMENT_REQUIRED_KEYS,
+    PHASE_REQUIRED_KEYS,
+    WP_REQUIRED_KEYS,
+)
 from autoskillit.planner.validation import validate_plan
 
 __all__ = [

--- a/src/autoskillit/planner/__init__.py
+++ b/src/autoskillit/planner/__init__.py
@@ -6,11 +6,6 @@ from autoskillit.planner.manifests import (
     build_wp_manifest,
     check_remaining,
 )
-from autoskillit.planner.schema import (
-    ASSIGNMENT_REQUIRED_KEYS,
-    PHASE_REQUIRED_KEYS,
-    WP_REQUIRED_KEYS,
-)
 from autoskillit.planner.validation import validate_plan
 
 __all__ = [
@@ -19,7 +14,4 @@ __all__ = [
     "build_wp_manifest",
     "validate_plan",
     "compile_plan",
-    "PHASE_REQUIRED_KEYS",
-    "ASSIGNMENT_REQUIRED_KEYS",
-    "WP_REQUIRED_KEYS",
 ]

--- a/src/autoskillit/planner/manifests.py
+++ b/src/autoskillit/planner/manifests.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from autoskillit.core import atomic_write, get_logger, write_versioned_json
+from autoskillit.planner.schema import validate_assignment_result, validate_phase_result
 
 _logger = get_logger(__name__)
 
@@ -112,23 +113,22 @@ def build_assignment_manifest(
     parsed_phases = []
     for f in phase_files:
         try:
-            data = json.loads(f.read_text())
+            raw = json.loads(f.read_text())
         except json.JSONDecodeError as exc:
             raise json.JSONDecodeError(
                 f"Failed to parse {f}: {exc.msg}", exc.doc, exc.pos
             ) from exc
-        pn = data.get("phase_number", 0)
-        if not isinstance(pn, int):
-            raise TypeError(
-                f"phase_number in {f} must be an integer, got {type(pn).__name__}: {pn!r}"
-            )
+        try:
+            data = validate_phase_result(raw)
+        except ValueError as exc:
+            raise ValueError(f"Invalid phase result in {f}: {exc}") from exc
         parsed_phases.append(data)
-    parsed_phases.sort(key=lambda d: d.get("phase_number", 0))
+    parsed_phases.sort(key=lambda d: d["phase_number"])
 
     items = []
     for phase_data in parsed_phases:
-        phase_number = phase_data.get("phase_number", 0)
-        assignments = phase_data.get("assignments", [])
+        phase_number = phase_data["phase_number"]
+        assignments = phase_data["assignments"]
         for seq, assignment in enumerate(assignments, start=1):
             item_id = f"P{phase_number}-A{seq}"
             items.append(
@@ -162,20 +162,22 @@ def build_wp_manifest(assignments_dir: str, output_dir: str) -> dict[str, str]:
     parsed_assignments = []
     for f in assign_files:
         try:
-            data = json.loads(f.read_text())
+            raw = json.loads(f.read_text())
         except json.JSONDecodeError as exc:
             raise json.JSONDecodeError(
                 f"Failed to parse {f}: {exc.msg}", exc.doc, exc.pos
             ) from exc
+        try:
+            data = validate_assignment_result(raw)
+        except ValueError as exc:
+            raise ValueError(f"Invalid assignment result in {f}: {exc}") from exc
         parsed_assignments.append(data)
-    parsed_assignments.sort(
-        key=lambda d: (d.get("phase_number", 0), d.get("assignment_number", 0))
-    )
+    parsed_assignments.sort(key=lambda d: (d["phase_number"], d["assignment_number"]))
 
     items = []
     for assign_data in parsed_assignments:
-        phase_number = assign_data.get("phase_number", 0)
-        assignment_number = assign_data.get("assignment_number", 0)
+        phase_number = assign_data["phase_number"]
+        assignment_number = assign_data["assignment_number"]
         work_packages = assign_data.get("proposed_work_packages", [])
         for wp_seq, wp in enumerate(work_packages, start=1):
             wp_id = f"P{phase_number}-A{assignment_number}-WP{wp_seq}"

--- a/src/autoskillit/planner/manifests.py
+++ b/src/autoskillit/planner/manifests.py
@@ -120,7 +120,7 @@ def build_assignment_manifest(
             ) from exc
         try:
             data = validate_phase_result(raw)
-        except ValueError as exc:
+        except (ValueError, KeyError) as exc:
             raise ValueError(f"Invalid phase result in {f}: {exc}") from exc
         parsed_phases.append(data)
     parsed_phases.sort(key=lambda d: d["phase_number"])

--- a/src/autoskillit/planner/manifests.py
+++ b/src/autoskillit/planner/manifests.py
@@ -169,7 +169,7 @@ def build_wp_manifest(assignments_dir: str, output_dir: str) -> dict[str, str]:
             ) from exc
         try:
             data = validate_assignment_result(raw)
-        except ValueError as exc:
+        except (ValueError, KeyError) as exc:
             raise ValueError(f"Invalid assignment result in {f}: {exc}") from exc
         parsed_assignments.append(data)
     parsed_assignments.sort(key=lambda d: (d["phase_number"], d["assignment_number"]))

--- a/src/autoskillit/planner/schema.py
+++ b/src/autoskillit/planner/schema.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import re
+from typing import Any, TypedDict
+
+
+class PhaseResult(TypedDict):
+    id: str
+    phase_number: int
+    name: str
+    name_slug: str
+    goal: str
+    scope: list[str]
+    ordering: int
+    assignments_preview: list[str]
+    assignments: list[dict]
+    relationship_notes: str
+
+
+class AssignmentResult(TypedDict):
+    id: str
+    phase_number: int
+    assignment_number: int
+    name: str
+    phase_id: str
+    goal: str
+    technical_approach: str
+    proposed_work_packages: list[dict]
+
+
+class WPResult(TypedDict):
+    id: str
+    name: str
+    summary: str
+    goal: str
+    technical_steps: list[str]
+    files_touched: list[str]
+    apis_defined: list[str]
+    apis_consumed: list[str]
+    depends_on: list[str]
+    deliverables: list[str]
+    acceptance_criteria: list[str]
+
+
+PHASE_REQUIRED_KEYS: frozenset[str] = frozenset({"id", "name", "ordering"})
+ASSIGNMENT_REQUIRED_KEYS: frozenset[str] = frozenset({"id", "name", "proposed_work_packages"})
+WP_REQUIRED_KEYS: frozenset[str] = frozenset({"id", "name", "deliverables"})
+
+
+def _slugify(name: str) -> str:
+    slug = name.lower()
+    slug = re.sub(r"[^a-z0-9]+", "-", slug)
+    return slug.strip("-")
+
+
+def _parse_phase_number(data: dict[str, Any]) -> int:
+    if "ordering" in data:
+        return int(data["ordering"])
+    # Parse from id: "P3" → 3
+    return int(str(data["id"])[1:])
+
+
+def _parse_assignment_numbers(data: dict[str, Any]) -> tuple[int, int]:
+    parts = str(data["id"]).split("-")
+    return int(parts[0][1:]), int(parts[1][1:])
+
+
+def validate_phase_result(data: dict[str, Any]) -> dict[str, Any]:
+    missing = PHASE_REQUIRED_KEYS - data.keys()
+    if missing:
+        raise ValueError(f"Phase result missing required keys: {sorted(missing)}")
+
+    result: dict[str, Any] = dict(data)
+
+    if "phase_number" not in result:
+        result["phase_number"] = _parse_phase_number(data)
+
+    if "name_slug" not in result:
+        result["name_slug"] = _slugify(data["name"])
+
+    if "assignments" not in result:
+        preview = result.get("assignments_preview", [])
+        result["assignments"] = [{"name": name, "metadata": {}} for name in preview]
+
+    result.setdefault("assignments_preview", [])
+    result.setdefault("goal", "")
+    result.setdefault("scope", [])
+    result.setdefault("relationship_notes", "")
+
+    return result
+
+
+def validate_assignment_result(data: dict[str, Any]) -> dict[str, Any]:
+    missing = ASSIGNMENT_REQUIRED_KEYS - data.keys()
+    if missing:
+        raise ValueError(f"Assignment result missing required keys: {sorted(missing)}")
+
+    result: dict[str, Any] = dict(data)
+
+    if "phase_number" not in result or "assignment_number" not in result:
+        pn, an = _parse_assignment_numbers(data)
+        result.setdefault("phase_number", pn)
+        result.setdefault("assignment_number", an)
+
+    result.setdefault("phase_id", f"P{result['phase_number']}")
+    result.setdefault("goal", "")
+    result.setdefault("technical_approach", "")
+
+    return result
+
+
+def validate_wp_result(data: dict[str, Any]) -> dict[str, Any]:
+    missing = WP_REQUIRED_KEYS - data.keys()
+    if missing:
+        raise ValueError(f"WP result missing required keys: {sorted(missing)}")
+
+    result: dict[str, Any] = dict(data)
+    result.setdefault("summary", "")
+    result.setdefault("goal", "")
+    result.setdefault("technical_steps", [])
+    result.setdefault("files_touched", [])
+    result.setdefault("apis_defined", [])
+    result.setdefault("apis_consumed", [])
+    result.setdefault("depends_on", [])
+    result.setdefault("acceptance_criteria", [])
+
+    return result

--- a/src/autoskillit/planner/schema.py
+++ b/src/autoskillit/planner/schema.py
@@ -56,7 +56,6 @@ def _slugify(name: str) -> str:
 def _parse_phase_number(data: dict[str, Any]) -> int:
     if "ordering" in data:
         return int(data["ordering"])
-    # Parse from id: "P3" → 3
     return int(str(data["id"])[1:])
 
 

--- a/src/autoskillit/planner/schema.py
+++ b/src/autoskillit/planner/schema.py
@@ -61,8 +61,14 @@ def _parse_phase_number(data: dict[str, Any]) -> int:
 
 
 def _parse_assignment_numbers(data: dict[str, Any]) -> tuple[int, int]:
-    parts = str(data["id"]).split("-")
-    return int(parts[0][1:]), int(parts[1][1:])
+    raw_id = str(data["id"])
+    parts = raw_id.split("-")
+    if len(parts) < 2:
+        raise ValueError(f"Assignment id {raw_id!r} is missing '-' separator")
+    try:
+        return int(parts[0][1:]), int(parts[1][1:])
+    except ValueError:
+        raise ValueError(f"Assignment id {raw_id!r} has malformed numeric segment") from None
 
 
 def validate_phase_result(data: dict[str, Any]) -> dict[str, Any]:

--- a/src/autoskillit/planner/validation.py
+++ b/src/autoskillit/planner/validation.py
@@ -5,6 +5,11 @@ from collections import deque
 from pathlib import Path
 
 from autoskillit.core import get_logger, write_versioned_json
+from autoskillit.planner.schema import (
+    validate_assignment_result,
+    validate_phase_result,
+    validate_wp_result,
+)
 
 _logger = get_logger(__name__)
 
@@ -13,9 +18,10 @@ def _load_phase_results(root: Path) -> dict[str, dict]:
     results: dict[str, dict] = {}
     for f in sorted((root / "phases").glob("*_result.json")):
         try:
-            data = json.loads(f.read_text())
+            raw = json.loads(f.read_text())
+            data = validate_phase_result(raw)
             phase_id = f"P{data['phase_number']}"
-        except (json.JSONDecodeError, KeyError) as exc:
+        except (json.JSONDecodeError, KeyError, ValueError) as exc:
             raise RuntimeError(f"Malformed phase result file {f}: {exc}") from exc
         results[phase_id] = data
     return results
@@ -28,9 +34,10 @@ def _load_assignment_results(root: Path) -> dict[str, dict]:
         return results
     for f in sorted(assign_dir.glob("*_result.json")):
         try:
-            data = json.loads(f.read_text())
+            raw = json.loads(f.read_text())
+            data = validate_assignment_result(raw)
             assign_id = f"P{data['phase_number']}-A{data['assignment_number']}"
-        except (json.JSONDecodeError, KeyError) as exc:
+        except (json.JSONDecodeError, KeyError, ValueError) as exc:
             raise RuntimeError(f"Malformed assignment result file {f}: {exc}") from exc
         results[assign_id] = data
     return results
@@ -45,9 +52,10 @@ def _load_wp_results(root: Path) -> dict[str, dict]:
         if f.name in ("wp_manifest.json", "wp_index.json"):
             continue
         try:
-            data = json.loads(f.read_text())
+            raw = json.loads(f.read_text())
+            data = validate_wp_result(raw)
             results[data["id"]] = data
-        except (json.JSONDecodeError, KeyError) as exc:
+        except (json.JSONDecodeError, KeyError, ValueError) as exc:
             raise RuntimeError(f"Malformed WP result file {f}: {exc}") from exc
     return results
 

--- a/src/autoskillit/recipe/contracts.py
+++ b/src/autoskillit/recipe/contracts.py
@@ -183,14 +183,19 @@ def get_skill_contract(skill_name: str, manifest: dict[str, Any]) -> SkillContra
     examples = skill_data.get("pattern_examples", [])
     write_behavior = skill_data.get("write_behavior")
     write_expected_when = skill_data.get("write_expected_when", [])
-    result_fields = [
-        ResultFieldSpec(
-            name=rf["name"],
-            type=rf["type"],
-            required=rf.get("required", True),
-        )
-        for rf in skill_data.get("result_fields", [])
-    ]
+    try:
+        result_fields = [
+            ResultFieldSpec(
+                name=rf["name"],
+                type=rf["type"],
+                required=rf.get("required", True),
+            )
+            for rf in skill_data.get("result_fields", [])
+        ]
+    except KeyError as exc:
+        raise KeyError(
+            f"Malformed result_fields entry for skill '{skill_name}': missing key {exc}"
+        ) from exc
     return SkillContract(
         inputs=inputs,
         outputs=outputs,

--- a/src/autoskillit/recipe/contracts.py
+++ b/src/autoskillit/recipe/contracts.py
@@ -53,6 +53,13 @@ class SkillOutput:
     type: str
 
 
+@dataclasses.dataclass(frozen=True)
+class ResultFieldSpec:
+    name: str
+    type: str
+    required: bool = True
+
+
 @dataclasses.dataclass
 class SkillContract:
     inputs: list[SkillInput]
@@ -61,6 +68,7 @@ class SkillContract:
     pattern_examples: list[str] = dataclasses.field(default_factory=list)
     write_behavior: str | None = None
     write_expected_when: list[str] = dataclasses.field(default_factory=list)
+    result_fields: tuple[ResultFieldSpec, ...] = dataclasses.field(default_factory=tuple)
 
 
 @dataclasses.dataclass
@@ -175,6 +183,14 @@ def get_skill_contract(skill_name: str, manifest: dict[str, Any]) -> SkillContra
     examples = skill_data.get("pattern_examples", [])
     write_behavior = skill_data.get("write_behavior")
     write_expected_when = skill_data.get("write_expected_when", [])
+    result_fields = tuple(
+        ResultFieldSpec(
+            name=rf["name"],
+            type=rf["type"],
+            required=rf.get("required", True),
+        )
+        for rf in skill_data.get("result_fields", [])
+    )
     return SkillContract(
         inputs=inputs,
         outputs=outputs,
@@ -182,6 +198,7 @@ def get_skill_contract(skill_name: str, manifest: dict[str, Any]) -> SkillContra
         pattern_examples=examples,
         write_behavior=write_behavior,
         write_expected_when=write_expected_when,
+        result_fields=result_fields,
     )
 
 
@@ -398,9 +415,12 @@ def generate_recipe_card(
                     if contract.write_expected_when:
                         skill_entry["write_expected_when"] = contract.write_expected_when
                     skills[skill_name] = skill_entry
-                    if count_positional_args(skill_cmd) > 0:
-                        # Positional args used — can't verify named inputs by ref
+                    pos_arg_count = count_positional_args(skill_cmd)
+                    if pos_arg_count > 0:
+                        # Positional args used — can't verify named inputs by ref.
+                        # Record the count so downstream rules know args were supplied.
                         entry["required"] = []
+                        entry["positional_args"] = pos_arg_count
                     else:
                         # Named template refs only — flag required inputs not referenced
                         ctx_refs = extract_context_refs(step)

--- a/src/autoskillit/recipe/contracts.py
+++ b/src/autoskillit/recipe/contracts.py
@@ -68,7 +68,7 @@ class SkillContract:
     pattern_examples: list[str] = dataclasses.field(default_factory=list)
     write_behavior: str | None = None
     write_expected_when: list[str] = dataclasses.field(default_factory=list)
-    result_fields: tuple[ResultFieldSpec, ...] = dataclasses.field(default_factory=tuple)
+    result_fields: list[ResultFieldSpec] = dataclasses.field(default_factory=list)
 
 
 @dataclasses.dataclass
@@ -183,14 +183,14 @@ def get_skill_contract(skill_name: str, manifest: dict[str, Any]) -> SkillContra
     examples = skill_data.get("pattern_examples", [])
     write_behavior = skill_data.get("write_behavior")
     write_expected_when = skill_data.get("write_expected_when", [])
-    result_fields = tuple(
+    result_fields = [
         ResultFieldSpec(
             name=rf["name"],
             type=rf["type"],
             required=rf.get("required", True),
         )
         for rf in skill_data.get("result_fields", [])
-    )
+    ]
     return SkillContract(
         inputs=inputs,
         outputs=outputs,

--- a/src/autoskillit/recipe/rules_contracts.py
+++ b/src/autoskillit/recipe/rules_contracts.py
@@ -13,9 +13,7 @@ from autoskillit.recipe.contracts import (
 )
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
 
-# Skill names covered by the result-field-drift rule. The actual frozensets are
-# loaded via deferred import inside _check_result_field_drift to keep recipe/
-# free of module-level planner/ imports (REQ-COMP-009).
+# Skill names covered by the result-field-drift rule.
 _RESULT_FIELD_DRIFT_SKILLS = frozenset(
     {
         "planner-generate-phases",

--- a/src/autoskillit/recipe/rules_contracts.py
+++ b/src/autoskillit/recipe/rules_contracts.py
@@ -13,6 +13,18 @@ from autoskillit.recipe.contracts import (
 )
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
 
+# Skill names covered by the result-field-drift rule. The actual frozensets are
+# loaded via deferred import inside _check_result_field_drift to keep recipe/
+# free of module-level planner/ imports (REQ-COMP-009).
+_RESULT_FIELD_DRIFT_SKILLS = frozenset(
+    {
+        "planner-generate-phases",
+        "planner-elaborate-phase",
+        "planner-elaborate-assignment",
+        "planner-elaborate-wp",
+    }
+)
+
 logger = get_logger(__name__)
 
 
@@ -323,5 +335,79 @@ def _check_always_has_no_write_exit(ctx: ValidationContext) -> list[RuleFinding]
                         )
                         break  # one finding per step is enough
                 break
+
+    return findings
+
+
+@semantic_rule(
+    name="result-field-drift",
+    description=(
+        "result_fields declared in skill_contracts.yaml must match the TypedDict required keys "
+        "in planner/schema.py for planner skills that produce structured result files."
+    ),
+    severity=Severity.ERROR,
+)
+def _check_result_field_drift(ctx: ValidationContext) -> list[RuleFinding]:
+    """Error when a skill's declared result_fields diverge from the canonical TypedDict keys.
+
+    Covers planner-generate-phases, elaborate-phase, elaborate-assignment, and elaborate-wp.
+    Comparison is one-directional: contract required fields vs TypedDict required keys.
+    """
+    # Deferred import: recipe/ must not import planner/ at module level (REQ-COMP-009).
+    # Importing from autoskillit.planner (the package, not a submodule) satisfies
+    # REQ-ARCH-001. planner/ is L1 and does not import recipe/, so no circular risk.
+    from autoskillit.planner import (  # noqa: PLC0415
+        ASSIGNMENT_REQUIRED_KEYS,
+        PHASE_REQUIRED_KEYS,
+        WP_REQUIRED_KEYS,
+    )
+
+    skill_schemas: dict[str, frozenset[str]] = {
+        "planner-generate-phases": PHASE_REQUIRED_KEYS,
+        "planner-elaborate-phase": PHASE_REQUIRED_KEYS,
+        "planner-elaborate-assignment": ASSIGNMENT_REQUIRED_KEYS,
+        "planner-elaborate-wp": WP_REQUIRED_KEYS,
+    }
+
+    findings: list[RuleFinding] = []
+    manifest = load_bundled_manifest()
+
+    for step_name, step in ctx.recipe.steps.items():
+        if step.tool != "run_skill":
+            continue
+
+        skill_cmd = step.with_args.get("skill_command", "")
+        name = resolve_skill_name(skill_cmd)
+        if not name or name not in skill_schemas:
+            continue
+
+        contract = get_skill_contract(name, manifest)
+        if contract is None or not contract.result_fields:
+            continue
+
+        expected_keys = skill_schemas[name]
+        declared_required = {rf.name for rf in contract.result_fields if rf.required}
+
+        added = declared_required - expected_keys
+        removed = expected_keys - declared_required
+
+        if added or removed:
+            parts: list[str] = []
+            if added:
+                parts.append(f"extra in contract: {sorted(added)}")
+            if removed:
+                parts.append(f"missing from contract: {sorted(removed)}")
+            findings.append(
+                RuleFinding(
+                    rule="result-field-drift",
+                    severity=Severity.ERROR,
+                    step_name=step_name,
+                    message=(
+                        f"Skill '{name}' result_fields in skill_contracts.yaml diverge from "
+                        f"the TypedDict required keys in planner/schema.py — {'; '.join(parts)}. "
+                        f"Update result_fields to match the TypedDict definition."
+                    ),
+                )
+            )
 
     return findings

--- a/src/autoskillit/recipe/rules_contracts.py
+++ b/src/autoskillit/recipe/rules_contracts.py
@@ -354,9 +354,8 @@ def _check_result_field_drift(ctx: ValidationContext) -> list[RuleFinding]:
     Comparison is one-directional: contract required fields vs TypedDict required keys.
     """
     # Deferred import: recipe/ must not import planner/ at module level (REQ-COMP-009).
-    # Importing from autoskillit.planner (the package, not a submodule) satisfies
-    # REQ-ARCH-001. planner/ is L1 and does not import recipe/, so no circular risk.
-    from autoskillit.planner import (  # noqa: PLC0415
+    # planner/ is L1 and does not import recipe/, so no circular risk.
+    from autoskillit.planner.schema import (  # noqa: PLC0415
         ASSIGNMENT_REQUIRED_KEYS,
         PHASE_REQUIRED_KEYS,
         WP_REQUIRED_KEYS,

--- a/src/autoskillit/recipe/rules_contracts.py
+++ b/src/autoskillit/recipe/rules_contracts.py
@@ -355,7 +355,7 @@ def _check_result_field_drift(ctx: ValidationContext) -> list[RuleFinding]:
     """
     # Deferred import: recipe/ must not import planner/ at module level (REQ-COMP-009).
     # planner/ is L1 and does not import recipe/, so no circular risk.
-    from autoskillit.planner.schema import (  # noqa: PLC0415
+    from autoskillit.planner import (  # noqa: PLC0415
         ASSIGNMENT_REQUIRED_KEYS,
         PHASE_REQUIRED_KEYS,
         WP_REQUIRED_KEYS,

--- a/src/autoskillit/recipe/rules_dataflow.py
+++ b/src/autoskillit/recipe/rules_dataflow.py
@@ -53,7 +53,7 @@ def _check_weak_constraint_text(ctx: ValidationContext) -> list[RuleFinding]:
 @semantic_rule(
     name="undeclared-capture-key",
     description="result.X captures must match skill output keys in skill_contracts.yaml",
-    severity=Severity.WARNING,
+    severity=Severity.ERROR,
 )
 def _check_capture_output_coverage(ctx: ValidationContext) -> list[RuleFinding]:
     wf = ctx.recipe
@@ -77,7 +77,7 @@ def _check_capture_output_coverage(ctx: ValidationContext) -> list[RuleFinding]:
             findings.append(
                 RuleFinding(
                     rule="undeclared-capture-key",
-                    severity=Severity.WARNING,
+                    severity=Severity.ERROR,
                     step_name=step_name,
                     message=(
                         f"Step '{step_name}' captures from skill '{skill_name}' "
@@ -96,7 +96,7 @@ def _check_capture_output_coverage(ctx: ValidationContext) -> list[RuleFinding]:
                     findings.append(
                         RuleFinding(
                             rule="undeclared-capture-key",
-                            severity=Severity.WARNING,
+                            severity=Severity.ERROR,
                             step_name=step_name,
                             message=(
                                 f"Step '{step_name}' captures result.{ref_key} "
@@ -112,7 +112,7 @@ def _check_capture_output_coverage(ctx: ValidationContext) -> list[RuleFinding]:
                     findings.append(
                         RuleFinding(
                             rule="undeclared-capture-key",
-                            severity=Severity.WARNING,
+                            severity=Severity.ERROR,
                             step_name=step_name,
                             message=(
                                 f"Step '{step_name}' captures result.{ref_key} via capture_list "
@@ -247,7 +247,7 @@ def _check_implicit_handoff(ctx: ValidationContext) -> list[RuleFinding]:
             continue
         if not contract.get("outputs"):
             continue
-        if not step.capture:
+        if not step.capture and not step.capture_list:
             findings.append(
                 RuleFinding(
                     rule="implicit-handoff",
@@ -256,7 +256,7 @@ def _check_implicit_handoff(ctx: ValidationContext) -> list[RuleFinding]:
                     message=(
                         f"Step '{step_name}' calls '/autoskillit:{skill_name}' "
                         f"which declares {len(contract['outputs'])} output(s) "
-                        f"but has no capture: block. Add a capture: block to "
+                        f"but has no capture: or capture_list: block. Add a capture: block to "
                         f"thread the skill's structured output into pipeline context."
                     ),
                 )

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -525,6 +525,17 @@ skills:
     pattern_examples:
     - "triage_report = .autoskillit/temp/triage-issues/triage_report_20260310_120000.md\n%%ORDER_UP%%"
 
+  sprint-planner:
+    inputs: []
+    outputs:
+    - name: sprint_manifest
+      type: file_path
+    expected_output_patterns:
+    - "sprint_manifest\\s*=\\s*\\S+"
+    pattern_examples:
+    - "sprint_manifest = /tmp/autoskillit/sprint-planner/sprint_manifest.json\n%%ORDER_UP%%"
+    write_behavior: always
+
   review-pr:
     inputs:
     - name: feature_branch
@@ -1147,7 +1158,9 @@ skills:
 
   prepare-issue:
     inputs: []
-    outputs: []
+    outputs:
+    - name: issue_url
+      type: str
     expected_output_patterns:
     - "---prepare-issue-result---"
     pattern_examples:
@@ -1188,7 +1201,9 @@ skills:
 
   process-issues:
     inputs: []
-    outputs: []
+    outputs:
+    - name: dispatch_results
+      type: str
     expected_output_patterns:
     - "---process-issues-result---"
     pattern_examples:
@@ -1765,11 +1780,47 @@ skills:
     write_behavior: conditional
     write_expected_when:
     - "html_path\\s*=\\s*\\S+"
+  planner-analyze:
+    inputs: []
+    outputs: []
+  planner-extract-domain:
+    inputs: []
+    outputs: []
   planner-generate-phases:
     inputs: []
     outputs:
     - name: phase_manifest_path
       type: file_path
+    result_fields:
+    - name: id
+      type: str
+      required: true
+    - name: name
+      type: str
+      required: true
+    - name: ordering
+      type: int
+      required: true
+    expected_output_patterns:
+    - "phase_manifest_path\\s*=\\s*\\S+"
+    pattern_examples:
+    - "phase_manifest_path = /tmp/autoskillit/planner/phases/phase_manifest.json\n%%ORDER_UP%%"
+    write_behavior: always
+  planner-elaborate-phase:
+    inputs: []
+    outputs: []
+  planner-elaborate-assignment:
+    inputs: []
+    outputs: []
+  planner-elaborate-wp:
+    inputs: []
+    outputs: []
+  planner-reconcile-deps:
+    inputs: []
+    outputs: []
+  planner-refine:
+    inputs: []
+    outputs: []
 callable_contracts:
   autoskillit.smoke_utils.check_review_loop:
     outputs:

--- a/src/autoskillit/recipes/contracts/planner.yaml
+++ b/src/autoskillit/recipes/contracts/planner.yaml
@@ -1,12 +1,60 @@
-generated_at: '2026-04-25T14:21:41.844319+00:00'
+generated_at: '2026-04-26T20:57:11.410246+00:00'
 bundled_manifest_version: 0.1.0
-skill_hashes: {}
+skill_hashes:
+  planner-analyze: sha256:493f4753b98943dc593966ebb1e107b03446a41cec1017513cd81ac6051c1247
+  planner-extract-domain: sha256:94cd2bf02dbd1c0d8d28053d61dc18564be8ccdfbc861368b91326cbe4a785dd
+  planner-generate-phases: sha256:e1346c639aca2daa460b0342ea7e78fefe0729e47e91cdc8d5c8916370b070a3
+  planner-elaborate-phase: sha256:110a53c28b82d8f9d1fba1eb227f44f938b27660013cf176c6a402ca41438e87
+  planner-elaborate-assignment: sha256:683f1b24bf2d5e6d5c8447ad42083df2de3152ca48c197e333b9da77a7625345
+  planner-elaborate-wp: sha256:e19ab9995a24293124ecf8562b536121ca257c124c2b6b0d3169922e206b7997
+  planner-reconcile-deps: sha256:350fd62e7eade27ad11bf1bea7971e1fdb06aa3e8aec092b374fdc9fb5de0743
+  planner-refine: sha256:83ccf798e0e641588d5d7f52f445ef77a974ae197a903499b87c030a1ce0ed9d
 skills:
+  planner-analyze:
+    inputs: []
+    outputs: []
+    expected_output_patterns: []
+    pattern_examples: []
+  planner-extract-domain:
+    inputs: []
+    outputs: []
+    expected_output_patterns: []
+    pattern_examples: []
   planner-generate-phases:
     inputs: []
     outputs:
     - name: phase_manifest_path
       type: file_path
+    expected_output_patterns:
+    - phase_manifest_path\s*=\s*\S+
+    pattern_examples:
+    - 'phase_manifest_path = /tmp/autoskillit/planner/phases/phase_manifest.json
+
+      %%ORDER_UP%%'
+    write_behavior: always
+  planner-elaborate-phase:
+    inputs: []
+    outputs: []
+    expected_output_patterns: []
+    pattern_examples: []
+  planner-elaborate-assignment:
+    inputs: []
+    outputs: []
+    expected_output_patterns: []
+    pattern_examples: []
+  planner-elaborate-wp:
+    inputs: []
+    outputs: []
+    expected_output_patterns: []
+    pattern_examples: []
+  planner-reconcile-deps:
+    inputs: []
+    outputs: []
+    expected_output_patterns: []
+    pattern_examples: []
+  planner-refine:
+    inputs: []
+    outputs: []
     expected_output_patterns: []
     pattern_examples: []
 dataflow:
@@ -35,6 +83,7 @@ dataflow:
   required: []
   produced:
   - phase_manifest_path
+  positional_args: 2
 - step: check_phases
   available:
   - phase_manifest_path
@@ -131,6 +180,7 @@ dataflow:
   - wp_manifest_path
   required: []
   produced: []
+  positional_args: 1
 - step: validate
   available:
   - assignment_manifest_path
@@ -167,6 +217,7 @@ dataflow:
   - wp_manifest_path
   required: []
   produced: []
+  positional_args: 2
 - step: compile
   available:
   - assignment_manifest_path

--- a/src/autoskillit/skills_extended/planner-elaborate-assignment/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-assignment/SKILL.md
@@ -115,6 +115,10 @@ Write to `{{AUTOSKILLIT_TEMP}}/planner/assignments/{id}_result.json` (relative t
 }
 ```
 
+The backend derives two additional fields at load time — do not write them:
+- `phase_number` (integer): derived by parsing the phase component of `id` (e.g., "P1-A2" → 1)
+- `assignment_number` (integer): derived by parsing the assignment component of `id` (e.g., "P1-A2" → 2)
+
 ### Step 5: Emit output token
 
 ```

--- a/src/autoskillit/skills_extended/planner-elaborate-phase/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-phase/SKILL.md
@@ -78,6 +78,10 @@ Write to `{{AUTOSKILLIT_TEMP}}/planner/phases/{id}_result.json` (relative to the
 }
 ```
 
+The backend derives two additional fields at load time — do not write them:
+- `phase_number` (integer): derived from `ordering`
+- `name_slug` (string): derived by slugifying `name` (e.g., "Notification Layer" → "notification-layer")
+
 ### Step 4: Emit output token
 
 ```

--- a/src/autoskillit/skills_extended/planner-generate-phases/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-generate-phases/SKILL.md
@@ -81,6 +81,10 @@ For each phase, write to `{{AUTOSKILLIT_TEMP}}/planner/phases/{phase_id}_result.
 }
 ```
 
+The backend derives two additional fields at load time — do not write them:
+- `phase_number` (integer): derived from `ordering`
+- `name_slug` (string): derived by slugifying `name` (e.g., "Database Layer" → "database-layer")
+
 ### Step 4: Write phase manifest
 
 Write `{{AUTOSKILLIT_TEMP}}/planner/phases/phase_manifest.json`. Set every item's status to

--- a/src/autoskillit/skills_extended/prepare-issue/SKILL.md
+++ b/src/autoskillit/skills_extended/prepare-issue/SKILL.md
@@ -423,3 +423,9 @@ Emit to stdout for recipe capture:
 }
 ---/prepare-issue-result---
 ```
+
+Also emit the issue URL as a standalone structured token for recipe capture:
+
+```
+issue_url = https://github.com/owner/repo/issues/N
+```

--- a/src/autoskillit/skills_extended/process-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/process-issues/SKILL.md
@@ -359,6 +359,12 @@ Print the structured result for pipeline capture:
 ---end-process-issues-result---
 ```
 
+Also emit the report path as a standalone structured token for recipe capture:
+
+```
+dispatch_results = {{AUTOSKILLIT_TEMP}}/process-issues/process_report_{ts}.md
+```
+
 ## Output Location
 
 ```

--- a/src/autoskillit/skills_extended/sprint-planner/SKILL.md
+++ b/src/autoskillit/skills_extended/sprint-planner/SKILL.md
@@ -65,4 +65,8 @@ array of objects with these fields:
 - `overlap_notes` (string — describe any overlap with other selected issues)
 
 After writing the file, output its absolute path as `sprint_manifest` so the recipe
-orchestrator can capture it.
+orchestrator can capture it. Emit the token on its own line in key=value format:
+
+```
+sprint_manifest = /path/to/sprint_manifest.json
+```

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -301,7 +301,7 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
         }
     ),
     # Standalone modules (not subpackage directories)
-    "planner": frozenset({"planner"}),
+    "planner": frozenset({"planner", "recipe"}),
     "_llm_triage": frozenset({"test_llm_triage.py", "execution", "server", "recipe"}),
     "_test_filter": frozenset({"arch", "infra", "contracts"}),
     "smoke_utils": frozenset({"test_smoke_utils.py", "recipe"}),

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -244,6 +244,7 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             "execution/test_headless.py",
             "execution/test_zero_write_detection.py",
             "infra/test_pretty_output.py",
+            "skills/test_planner_skill_contracts.py",
             "skills/test_skill_placeholder_contracts.py",
             "skills/test_make_campaign_compliance.py",
             "skills/test_review_design_guards.py",

--- a/tests/execution/test_headless.py
+++ b/tests/execution/test_headless.py
@@ -3387,6 +3387,8 @@ class TestOutputPathTokensDerivedFromContracts:
             "execution_map_report",
             # planner-generate-phases output (planner recipe)
             "phase_manifest_path",
+            # sprint-planner output (sprint-prefix sub-recipe)
+            "sprint_manifest",
         }
     )
 

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -154,7 +154,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/smoke_utils.py", 87),
     ("src/autoskillit/smoke_utils.py", 169),
     # planner/manifests.py — _backstop_wp_index: list payload (index is a list, not dict)
-    ("src/autoskillit/planner/manifests.py", 37),
+    ("src/autoskillit/planner/manifests.py", 38),
 }
 
 

--- a/tests/planner/conftest.py
+++ b/tests/planner/conftest.py
@@ -9,7 +9,9 @@ from autoskillit.planner.schema import (
 )
 
 
-def make_phase_result(phase_number: int, *, name: str = "Test Phase", **overrides: Any) -> dict[str, Any]:
+def make_phase_result(
+    phase_number: int, *, name: str = "Test Phase", **overrides: Any
+) -> dict[str, Any]:
     data: dict[str, Any] = {
         "id": f"P{phase_number}",
         "name": name,

--- a/tests/planner/conftest.py
+++ b/tests/planner/conftest.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from typing import Any
+
+from autoskillit.planner.schema import (
+    validate_assignment_result,
+    validate_phase_result,
+    validate_wp_result,
+)
+
+
+def make_phase_result(phase_number: int, *, name: str = "Test Phase", **overrides: Any) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "id": f"P{phase_number}",
+        "name": name,
+        "goal": f"Goal for phase {phase_number}",
+        "scope": [],
+        "ordering": phase_number,
+        "relationship_notes": "",
+        "assignments_preview": [],
+        **overrides,
+    }
+    return validate_phase_result(data)
+
+
+def make_assignment_result(
+    phase_number: int, assignment_number: int, **overrides: Any
+) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "id": f"P{phase_number}-A{assignment_number}",
+        "name": f"Assignment {assignment_number}",
+        "phase_id": f"P{phase_number}",
+        "goal": "Test goal",
+        "technical_approach": "Test approach",
+        "proposed_work_packages": [],
+        **overrides,
+    }
+    return validate_assignment_result(data)
+
+
+def make_wp_result(wp_id: str, **overrides: Any) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "id": wp_id,
+        "name": f"WP {wp_id}",
+        "summary": "summary",
+        "goal": "goal",
+        "deliverables": [f"src/mod_{wp_id}.py"],
+        "technical_steps": ["step 1"],
+        "acceptance_criteria": ["criterion 1"],
+        "depends_on": [],
+        **overrides,
+    }
+    return validate_wp_result(data)

--- a/tests/planner/test_compiler.py
+++ b/tests/planner/test_compiler.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from autoskillit.planner.compiler import compile_plan
+from tests.planner.conftest import make_assignment_result, make_phase_result, make_wp_result
 
 pytestmark = [pytest.mark.layer("planner"), pytest.mark.small, pytest.mark.feature("planner")]
 
@@ -37,37 +38,32 @@ def _make_valid_output_dir(
     for p in range(1, num_phases + 1):
         _write_json(
             phases_dir / f"P{p}_result.json",
-            {
-                "phase_number": p,
-                "name": f"Phase {p}",
-                "name_slug": f"phase-{p}",
-                "assignments": [f"P{p}-A1"],
-            },
+            make_phase_result(p, name=f"Phase {p}"),
         )
         _write_json(
             assigns_dir / f"P{p}-A1_result.json",
-            {
-                "phase_number": p,
-                "assignment_number": 1,
-                "name": f"Test Assignment P{p}",
-                "proposed_work_packages": [f"P{p}-A1-WP1"],
-            },
+            make_assignment_result(
+                p,
+                1,
+                name=f"Test Assignment P{p}",
+                proposed_work_packages=[f"P{p}-A1-WP1"],
+            ),
         )
         deps: list[str] = []
         if dependency_chain and p > 1:
             deps = [f"P{p - 1}-A1-WP1"]
         _write_json(
             wps_dir / f"P{p}-A1-WP1_result.json",
-            {
-                "id": f"P{p}-A1-WP1",
-                "name": f"WP P{p}-A1-WP1",
-                "summary": f"Summary P{p}",
-                "goal": f"Goal P{p}",
-                "deliverables": [f"src/mod_p{p}.py"],
-                "technical_steps": [f"step for p{p}"],
-                "acceptance_criteria": [f"criterion for p{p}"],
-                "depends_on": deps,
-            },
+            make_wp_result(
+                f"P{p}-A1-WP1",
+                name=f"WP P{p}-A1-WP1",
+                summary=f"Summary P{p}",
+                goal=f"Goal P{p}",
+                deliverables=[f"src/mod_p{p}.py"],
+                technical_steps=[f"step for p{p}"],
+                acceptance_criteria=[f"criterion for p{p}"],
+                depends_on=deps,
+            ),
         )
 
     manifest_items = [{"id": f"P{p}-A1-WP1", "status": "done"} for p in range(1, num_phases + 1)]
@@ -99,35 +95,30 @@ def _make_chain_3_wps(tmp_path: Path) -> Path:
 
     _write_json(
         phases_dir / "P1_result.json",
-        {
-            "phase_number": 1,
-            "name": "Foundation",
-            "name_slug": "foundation",
-            "assignments": ["P1-A1"],
-        },
+        make_phase_result(1, name="Foundation"),
     )
     _write_json(
         assigns_dir / "P1-A1_result.json",
-        {
-            "phase_number": 1,
-            "assignment_number": 1,
-            "name": "Test Assignment",
-            "proposed_work_packages": ["P1-A1-WP1", "P1-A1-WP2", "P1-A1-WP3"],
-        },
+        make_assignment_result(
+            1,
+            1,
+            name="Test Assignment",
+            proposed_work_packages=["P1-A1-WP1", "P1-A1-WP2", "P1-A1-WP3"],
+        ),
     )
     for i, deps in [(1, []), (2, ["P1-A1-WP1"]), (3, ["P1-A1-WP2"])]:
         _write_json(
             wps_dir / f"P1-A1-WP{i}_result.json",
-            {
-                "id": f"P1-A1-WP{i}",
-                "name": f"WP {i}",
-                "summary": f"Summary {i}",
-                "goal": f"Goal {i}",
-                "deliverables": [f"src/mod{i}.py"],
-                "technical_steps": [f"step {i}"],
-                "acceptance_criteria": [f"criterion {i}"],
-                "depends_on": deps,
-            },
+            make_wp_result(
+                f"P1-A1-WP{i}",
+                name=f"WP {i}",
+                summary=f"Summary {i}",
+                goal=f"Goal {i}",
+                deliverables=[f"src/mod{i}.py"],
+                technical_steps=[f"step {i}"],
+                acceptance_criteria=[f"criterion {i}"],
+                depends_on=deps,
+            ),
         )
     manifest_items = [{"id": f"P1-A1-WP{i}", "status": "done"} for i in range(1, 4)]
     _write_json(

--- a/tests/planner/test_manifests.py
+++ b/tests/planner/test_manifests.py
@@ -6,6 +6,8 @@ from unittest.mock import patch
 
 import pytest
 
+from tests.planner.conftest import make_assignment_result, make_phase_result
+
 pytestmark = [pytest.mark.layer("planner"), pytest.mark.small, pytest.mark.feature("planner")]
 
 
@@ -347,13 +349,9 @@ def test_build_assignment_manifest_basic(tmp_path):
     output_dir = tmp_path / "out"
     output_dir.mkdir()
 
-    phase_result = {
-        "phase_number": 1,
-        "assignments": [
-            {"id_suffix": "A1", "name": "First assignment", "metadata": {}},
-        ],
-    }
-    (phases_dir / "phase_1_result.json").write_text(json.dumps(phase_result))
+    (phases_dir / "phase_1_result.json").write_text(
+        json.dumps(make_phase_result(1, assignments_preview=["First assignment"]))
+    )
 
     result = build_assignment_manifest(str(phases_dir), str(assignments_dir), str(output_dir))
 
@@ -374,23 +372,10 @@ def test_build_assignment_manifest_ordering(tmp_path):
     output_dir.mkdir()
 
     (phases_dir / "phase_2_result.json").write_text(
-        json.dumps(
-            {
-                "phase_number": 2,
-                "assignments": [{"id_suffix": "A1", "name": "Phase2-A1", "metadata": {}}],
-            }
-        )
+        json.dumps(make_phase_result(2, assignments_preview=["Phase2-A1"]))
     )
     (phases_dir / "phase_1_result.json").write_text(
-        json.dumps(
-            {
-                "phase_number": 1,
-                "assignments": [
-                    {"id_suffix": "A2", "name": "Phase1-A2", "metadata": {}},
-                    {"id_suffix": "A1", "name": "Phase1-A1", "metadata": {}},
-                ],
-            }
-        )
+        json.dumps(make_phase_result(1, assignments_preview=["Phase1-A2", "Phase1-A1"]))
     )
 
     result = build_assignment_manifest(
@@ -446,19 +431,22 @@ def test_build_wp_manifest_basic(tmp_path):
     output_dir = tmp_path / "out"
     output_dir.mkdir()
 
-    assign_result = {
-        "phase_number": 1,
-        "assignment_number": 1,
-        "proposed_work_packages": [
-            {
-                "id_suffix": "WP1",
-                "name": "First WP",
-                "scope": "do thing",
-                "estimated_files": ["a.py"],
-            },
-        ],
-    }
-    (assignments_dir / "P1-A1_result.json").write_text(json.dumps(assign_result))
+    (assignments_dir / "P1-A1_result.json").write_text(
+        json.dumps(
+            make_assignment_result(
+                1,
+                1,
+                proposed_work_packages=[
+                    {
+                        "id_suffix": "WP1",
+                        "name": "First WP",
+                        "scope": "do thing",
+                        "estimated_files": ["a.py"],
+                    }
+                ],
+            )
+        )
+    )
 
     result = build_wp_manifest(str(assignments_dir), str(output_dir))
 
@@ -481,25 +469,25 @@ def test_build_wp_manifest_hierarchical_ids(tmp_path):
 
     (assignments_dir / "P1-A2_result.json").write_text(
         json.dumps(
-            {
-                "phase_number": 1,
-                "assignment_number": 2,
-                "proposed_work_packages": [
-                    {"id_suffix": "WP1", "name": "P1A2WP1", "scope": "", "estimated_files": []},
+            make_assignment_result(
+                1,
+                2,
+                proposed_work_packages=[
+                    {"id_suffix": "WP1", "name": "P1A2WP1", "scope": "", "estimated_files": []}
                 ],
-            }
+            )
         )
     )
     (assignments_dir / "P1-A1_result.json").write_text(
         json.dumps(
-            {
-                "phase_number": 1,
-                "assignment_number": 1,
-                "proposed_work_packages": [
+            make_assignment_result(
+                1,
+                1,
+                proposed_work_packages=[
                     {"id_suffix": "WP2", "name": "P1A1WP2", "scope": "", "estimated_files": []},
                     {"id_suffix": "WP1", "name": "P1A1WP1", "scope": "", "estimated_files": []},
                 ],
-            }
+            )
         )
     )
 

--- a/tests/planner/test_pipeline_integration.py
+++ b/tests/planner/test_pipeline_integration.py
@@ -1,0 +1,161 @@
+"""End-to-end pipeline integration tests.
+
+These tests are the architectural backstop: any future change that breaks the schema
+alignment between SKILL.md output, the Python validation boundary, and the consumers
+will cause at least one test here to fail.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.planner.conftest import make_assignment_result, make_phase_result, make_wp_result
+
+pytestmark = [pytest.mark.layer("planner"), pytest.mark.small, pytest.mark.feature("planner")]
+
+
+def _write_json(path: Path, data: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data))
+
+
+def test_multi_phase_pipeline_end_to_end(tmp_path: Path) -> None:
+    """Two-phase pipeline: SKILL.md-compliant data flows through every pipeline stage."""
+    from autoskillit.planner import build_assignment_manifest, build_wp_manifest, compile_plan, validate_plan
+
+    phases_dir = tmp_path / "phases"
+    assignments_dir = tmp_path / "assignments"
+    wp_dir = tmp_path / "work_packages"
+
+    # Phase 1: Foundation  (SKILL.md field names)
+    _write_json(
+        phases_dir / "P1_result.json",
+        {
+            "id": "P1",
+            "name": "Foundation",
+            "ordering": 1,
+            "goal": "Establish core infrastructure",
+            "scope": ["core"],
+            "relationship_notes": "No prior dependencies",
+            "assignments_preview": ["Core setup"],
+        },
+    )
+    # Phase 2: Application (SKILL.md field names)
+    _write_json(
+        phases_dir / "P2_result.json",
+        {
+            "id": "P2",
+            "name": "Application Layer",
+            "ordering": 2,
+            "goal": "Implement application logic on top of foundation",
+            "scope": ["app"],
+            "relationship_notes": "Depends on Phase 1",
+            "assignments_preview": ["App module"],
+        },
+    )
+
+    # build_assignment_manifest using SKILL.md phase data
+    build_assignment_manifest(str(phases_dir), str(assignments_dir), str(tmp_path))
+
+    # Write assignment results using SKILL.md field names (id, phase_id, not phase_number)
+    _write_json(
+        assignments_dir / "P1-A1_result.json",
+        {
+            "id": "P1-A1",
+            "name": "Core setup",
+            "phase_id": "P1",
+            "goal": "Set up core modules",
+            "technical_approach": "Direct implementation",
+            "proposed_work_packages": [
+                {"id_suffix": "WP1", "name": "Core module", "scope": "core", "estimated_files": ["core.py"]}
+            ],
+        },
+    )
+    _write_json(
+        assignments_dir / "P2-A1_result.json",
+        {
+            "id": "P2-A1",
+            "name": "App module",
+            "phase_id": "P2",
+            "goal": "Build application layer",
+            "technical_approach": "Build on core",
+            "proposed_work_packages": [
+                {"id_suffix": "WP1", "name": "App module", "scope": "app", "estimated_files": ["app.py"]}
+            ],
+        },
+    )
+
+    # build_wp_manifest
+    build_wp_manifest(str(assignments_dir), str(wp_dir))
+
+    # Write WP results
+    _write_json(
+        wp_dir / "P1-A1-WP1_result.json",
+        make_wp_result("P1-A1-WP1", deliverables=["src/core.py"]),
+    )
+    _write_json(
+        wp_dir / "P2-A1-WP1_result.json",
+        make_wp_result("P2-A1-WP1", deliverables=["src/app.py"], depends_on=["P1-A1-WP1"]),
+    )
+
+    # validate_plan
+    validate_result = validate_plan(str(tmp_path))
+    assert validate_result["verdict"] == "pass", validate_result
+
+    # compile_plan
+    compile_result = compile_plan(str(tmp_path), "integration test task", "/src")
+
+    plan_path = Path(compile_result["plan_path"])
+    assert plan_path.exists()
+    plan_md = plan_path.read_text()
+    assert "## Phase 1: Foundation" in plan_md
+    assert "## Phase 2: Application Layer" in plan_md
+
+    milestones = json.loads((tmp_path / "milestones.json").read_text())
+    slugs = [m["name_slug"] for m in milestones["milestones"]]
+    assert "foundation" in slugs
+    assert "application-layer" in slugs
+
+    manifest = json.loads((tmp_path / "manifest.json").read_text())
+    # P1 WP must come before P2 WP (dependency order)
+    order = manifest["execution_order"]
+    assert order.index("P1-A1-WP1") < order.index("P2-A1-WP1")
+
+
+def test_pipeline_factory_fixtures_are_schema_compliant(tmp_path: Path) -> None:
+    """Factory-built fixtures pass through the full pipeline without errors."""
+    from autoskillit.planner import compile_plan, validate_plan
+
+    # Build everything using factory functions (SKILL.md-derived, not raw backend fields)
+    _write_json(
+        tmp_path / "phases" / "P1_result.json",
+        make_phase_result(1, name="Schema Alignment"),
+    )
+    _write_json(
+        tmp_path / "assignments" / "P1-A1_result.json",
+        make_assignment_result(1, 1, name="Implement schema"),
+    )
+    _write_json(
+        tmp_path / "work_packages" / "P1-A1-WP1_result.json",
+        make_wp_result("P1-A1-WP1"),
+    )
+    _write_json(
+        tmp_path / "work_packages" / "wp_manifest.json",
+        {"pass_name": "work_packages", "items": [{"id": "P1-A1-WP1", "status": "done"}]},
+    )
+    _write_json(
+        tmp_path / "validation.json",
+        {"verdict": "pass", "findings": [], "schema_version": 1},
+    )
+
+    validate_result = validate_plan(str(tmp_path))
+    assert validate_result["verdict"] == "pass"
+
+    compile_result = compile_plan(str(tmp_path), "factory test", "/src")
+    assert Path(compile_result["plan_path"]).exists()
+
+    milestones = json.loads((tmp_path / "milestones.json").read_text())
+    assert milestones["milestones"][0]["name_slug"] == "schema-alignment"

--- a/tests/planner/test_pipeline_integration.py
+++ b/tests/planner/test_pipeline_integration.py
@@ -103,10 +103,8 @@ def test_multi_phase_pipeline_end_to_end(tmp_path: Path) -> None:
         },
     )
 
-    # build_wp_manifest
     build_wp_manifest(str(assignments_dir), str(wp_dir))
 
-    # Write WP results
     _write_json(
         wp_dir / "P1-A1-WP1_result.json",
         make_wp_result("P1-A1-WP1", deliverables=["src/core.py"]),
@@ -116,11 +114,9 @@ def test_multi_phase_pipeline_end_to_end(tmp_path: Path) -> None:
         make_wp_result("P2-A1-WP1", deliverables=["src/app.py"], depends_on=["P1-A1-WP1"]),
     )
 
-    # validate_plan
     validate_result = validate_plan(str(tmp_path))
     assert validate_result["verdict"] == "pass", validate_result
 
-    # compile_plan
     compile_result = compile_plan(str(tmp_path), "integration test task", "/src")
 
     plan_path = Path(compile_result["plan_path"])

--- a/tests/planner/test_pipeline_integration.py
+++ b/tests/planner/test_pipeline_integration.py
@@ -24,7 +24,12 @@ def _write_json(path: Path, data: object) -> None:
 
 def test_multi_phase_pipeline_end_to_end(tmp_path: Path) -> None:
     """Two-phase pipeline: SKILL.md-compliant data flows through every pipeline stage."""
-    from autoskillit.planner import build_assignment_manifest, build_wp_manifest, compile_plan, validate_plan
+    from autoskillit.planner import (
+        build_assignment_manifest,
+        build_wp_manifest,
+        compile_plan,
+        validate_plan,
+    )
 
     phases_dir = tmp_path / "phases"
     assignments_dir = tmp_path / "assignments"
@@ -70,7 +75,12 @@ def test_multi_phase_pipeline_end_to_end(tmp_path: Path) -> None:
             "goal": "Set up core modules",
             "technical_approach": "Direct implementation",
             "proposed_work_packages": [
-                {"id_suffix": "WP1", "name": "Core module", "scope": "core", "estimated_files": ["core.py"]}
+                {
+                    "id_suffix": "WP1",
+                    "name": "Core module",
+                    "scope": "core",
+                    "estimated_files": ["core.py"],
+                }
             ],
         },
     )
@@ -83,7 +93,12 @@ def test_multi_phase_pipeline_end_to_end(tmp_path: Path) -> None:
             "goal": "Build application layer",
             "technical_approach": "Build on core",
             "proposed_work_packages": [
-                {"id_suffix": "WP1", "name": "App module", "scope": "app", "estimated_files": ["app.py"]}
+                {
+                    "id_suffix": "WP1",
+                    "name": "App module",
+                    "scope": "app",
+                    "estimated_files": ["app.py"],
+                }
             ],
         },
     )

--- a/tests/planner/test_schema_conformance.py
+++ b/tests/planner/test_schema_conformance.py
@@ -182,7 +182,12 @@ def test_compile_plan_derives_name_slug_from_name(tmp_path: Path) -> None:
 
 
 def test_skill_output_through_full_pipeline(tmp_path: Path) -> None:
-    from autoskillit.planner import build_assignment_manifest, build_wp_manifest, compile_plan, validate_plan
+    from autoskillit.planner import (
+        build_assignment_manifest,
+        build_wp_manifest,
+        compile_plan,
+        validate_plan,
+    )
 
     phases_dir = tmp_path / "phases"
     phases_dir.mkdir()

--- a/tests/planner/test_schema_conformance.py
+++ b/tests/planner/test_schema_conformance.py
@@ -1,0 +1,268 @@
+"""Schema conformance tests: SKILL.md-compliant data flows correctly through the pipeline.
+
+Tests 1a–1d document that SKILL.md field names are accepted and normalized at the
+validation boundary. Test 1f is the end-to-end integration backstop.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from autoskillit.planner.validation import _load_assignment_results, _load_phase_results
+
+pytestmark = [pytest.mark.layer("planner"), pytest.mark.small, pytest.mark.feature("planner")]
+
+
+def _write_json(path: Path, data: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data))
+
+
+# ---------------------------------------------------------------------------
+# 1a: SKILL.md-compliant phase data accepted and normalized by _load_phase_results
+# ---------------------------------------------------------------------------
+
+
+def test_skill_compliant_phase_data_accepted_and_normalized(tmp_path: Path) -> None:
+    phases_dir = tmp_path / "phases"
+    phases_dir.mkdir()
+    _write_json(
+        phases_dir / "P1_result.json",
+        {
+            "id": "P1",
+            "name": "Phase One",
+            "ordering": 1,
+            "goal": "Build the foundation",
+            "scope": ["core"],
+            "relationship_notes": "",
+            "assignments_preview": ["Schema design", "Implementation"],
+        },
+    )
+
+    results = _load_phase_results(tmp_path)
+
+    assert "P1" in results
+    assert results["P1"]["phase_number"] == 1
+    assert results["P1"]["name_slug"] == "phase-one"
+    assert results["P1"]["assignments"] == [
+        {"name": "Schema design", "metadata": {}},
+        {"name": "Implementation", "metadata": {}},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 1b: SKILL.md-compliant assignment data accepted and normalized
+# ---------------------------------------------------------------------------
+
+
+def test_skill_compliant_assignment_data_accepted_and_normalized(tmp_path: Path) -> None:
+    assign_dir = tmp_path / "assignments"
+    assign_dir.mkdir()
+    _write_json(
+        assign_dir / "P1-A2_result.json",
+        {
+            "id": "P1-A2",
+            "name": "Second assignment",
+            "phase_id": "P1",
+            "goal": "Design schema",
+            "technical_approach": "Use TypedDict",
+            "proposed_work_packages": [],
+        },
+    )
+
+    results = _load_assignment_results(tmp_path)
+
+    assert "P1-A2" in results
+    assert results["P1-A2"]["phase_number"] == 1
+    assert results["P1-A2"]["assignment_number"] == 2
+
+
+# ---------------------------------------------------------------------------
+# 1c: build_assignment_manifest with SKILL.md field names produces correct items
+# ---------------------------------------------------------------------------
+
+
+def test_build_assignment_manifest_with_skill_md_field_names(tmp_path: Path) -> None:
+    from autoskillit.planner import build_assignment_manifest
+
+    phases_dir = tmp_path / "phases"
+    phases_dir.mkdir()
+    assignments_dir = tmp_path / "assignments"
+    assignments_dir.mkdir()
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+
+    _write_json(
+        phases_dir / "P1_result.json",
+        {
+            "id": "P1",
+            "name": "Phase One",
+            "ordering": 1,
+            "goal": "test",
+            "scope": [],
+            "relationship_notes": "",
+            "assignments_preview": ["First assignment", "Second assignment"],
+        },
+    )
+
+    result = build_assignment_manifest(str(phases_dir), str(assignments_dir), str(output_dir))
+
+    assert result["total_count"] == "2"
+    manifest = json.loads(Path(result["manifest_path"]).read_text())
+    assert len(manifest["items"]) == 2
+    assert manifest["items"][0]["id"] == "P1-A1"
+    assert manifest["items"][1]["id"] == "P1-A2"
+
+
+# ---------------------------------------------------------------------------
+# 1d: compile_plan derives name_slug from name when not explicitly provided
+# ---------------------------------------------------------------------------
+
+
+def test_compile_plan_derives_name_slug_from_name(tmp_path: Path) -> None:
+    from autoskillit.planner.compiler import compile_plan
+
+    _write_json(
+        tmp_path / "phases" / "P1_result.json",
+        {
+            "id": "P1",
+            "name": "Phase One",
+            "ordering": 1,
+            "goal": "test",
+            "scope": [],
+            "relationship_notes": "",
+            "assignments_preview": [],
+        },
+    )
+    _write_json(
+        tmp_path / "assignments" / "P1-A1_result.json",
+        {
+            "id": "P1-A1",
+            "name": "Assignment 1",
+            "phase_id": "P1",
+            "goal": "test",
+            "technical_approach": "test",
+            "proposed_work_packages": [],
+        },
+    )
+    _write_json(
+        tmp_path / "work_packages" / "P1-A1-WP1_result.json",
+        {
+            "id": "P1-A1-WP1",
+            "name": "WP 1",
+            "goal": "test",
+            "deliverables": ["src/mod.py"],
+            "technical_steps": ["step 1"],
+            "acceptance_criteria": ["criterion 1"],
+            "depends_on": [],
+        },
+    )
+    _write_json(
+        tmp_path / "work_packages" / "wp_manifest.json",
+        {"pass_name": "work_packages", "items": [{"id": "P1-A1-WP1", "status": "done"}]},
+    )
+    _write_json(
+        tmp_path / "validation.json",
+        {"verdict": "pass", "findings": [], "schema_version": 1},
+    )
+
+    compile_plan(str(tmp_path), "test task", "/src")
+
+    issue = (tmp_path / "issues" / "P1-A1-WP1_issue.md").read_text()
+    assert "phase-one" in issue
+
+
+# ---------------------------------------------------------------------------
+# 1f: Full pipeline integration test with SKILL.md-compliant data
+# (this is the architectural backstop — any future schema drift breaks this)
+# ---------------------------------------------------------------------------
+
+
+def test_skill_output_through_full_pipeline(tmp_path: Path) -> None:
+    from autoskillit.planner import build_assignment_manifest, build_wp_manifest, compile_plan, validate_plan
+
+    phases_dir = tmp_path / "phases"
+    phases_dir.mkdir()
+    assignments_dir = tmp_path / "assignments"
+    assignments_dir.mkdir()
+    wp_dir = tmp_path / "work_packages"
+    wp_dir.mkdir()
+
+    _write_json(
+        phases_dir / "P1_result.json",
+        {
+            "id": "P1",
+            "name": "Foundation",
+            "ordering": 1,
+            "goal": "Build foundation",
+            "scope": ["core"],
+            "relationship_notes": "",
+            "assignments_preview": ["Schema design", "Implementation"],
+        },
+    )
+
+    build_assignment_manifest(str(phases_dir), str(assignments_dir), str(tmp_path))
+
+    _write_json(
+        assignments_dir / "P1-A1_result.json",
+        {
+            "id": "P1-A1",
+            "name": "Schema design",
+            "phase_id": "P1",
+            "goal": "Design the schema",
+            "technical_approach": "Use TypedDict",
+            "proposed_work_packages": [
+                {
+                    "id_suffix": "WP1",
+                    "name": "Schema module",
+                    "scope": "core",
+                    "estimated_files": ["schema.py"],
+                }
+            ],
+        },
+    )
+    _write_json(
+        assignments_dir / "P1-A2_result.json",
+        {
+            "id": "P1-A2",
+            "name": "Implementation",
+            "phase_id": "P1",
+            "goal": "Implement the feature",
+            "technical_approach": "Code it",
+            "proposed_work_packages": [
+                {
+                    "id_suffix": "WP1",
+                    "name": "Implementation module",
+                    "scope": "core",
+                    "estimated_files": ["impl.py"],
+                }
+            ],
+        },
+    )
+
+    build_wp_manifest(str(assignments_dir), str(wp_dir))
+
+    for wp_id in ["P1-A1-WP1", "P1-A2-WP1"]:
+        _write_json(
+            wp_dir / f"{wp_id}_result.json",
+            {
+                "id": wp_id,
+                "name": f"WP {wp_id}",
+                "goal": "test goal",
+                "deliverables": [f"src/{wp_id}.py"],
+                "technical_steps": ["step 1"],
+                "acceptance_criteria": ["criterion 1"],
+                "depends_on": [],
+            },
+        )
+
+    validate_result = validate_plan(str(tmp_path))
+    assert validate_result["verdict"] == "pass"
+
+    compile_result = compile_plan(str(tmp_path), "test task", "/src")
+    assert Path(compile_result["plan_path"]).exists()
+    milestones = json.loads((tmp_path / "milestones.json").read_text())
+    assert milestones["milestones"][0]["name_slug"] == "foundation"

--- a/tests/planner/test_typed_dict_conformance.py
+++ b/tests/planner/test_typed_dict_conformance.py
@@ -1,0 +1,137 @@
+"""TypedDict conformance: required-key sets, SKILL.md alignment, factory validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.planner.schema import (
+    ASSIGNMENT_REQUIRED_KEYS,
+    PHASE_REQUIRED_KEYS,
+    WP_REQUIRED_KEYS,
+    AssignmentResult,
+    PhaseResult,
+    WPResult,
+    validate_assignment_result,
+    validate_phase_result,
+    validate_wp_result,
+)
+
+pytestmark = [pytest.mark.layer("planner"), pytest.mark.small, pytest.mark.feature("planner")]
+
+
+def test_phase_required_keys_subset_of_typed_dict_fields() -> None:
+    assert PHASE_REQUIRED_KEYS <= PhaseResult.__required_keys__
+
+
+def test_assignment_required_keys_subset_of_typed_dict_fields() -> None:
+    assert ASSIGNMENT_REQUIRED_KEYS <= AssignmentResult.__required_keys__
+
+
+def test_wp_required_keys_subset_of_typed_dict_fields() -> None:
+    assert WP_REQUIRED_KEYS <= WPResult.__required_keys__
+
+
+def test_validate_phase_result_rejects_missing_required_keys() -> None:
+    with pytest.raises(ValueError, match="missing required keys"):
+        validate_phase_result({"name": "Only Name"})
+
+
+def test_validate_assignment_result_rejects_missing_required_keys() -> None:
+    with pytest.raises(ValueError, match="missing required keys"):
+        validate_assignment_result({"name": "Only Name"})
+
+
+def test_validate_wp_result_rejects_missing_required_keys() -> None:
+    with pytest.raises(ValueError, match="missing required keys"):
+        validate_wp_result({"name": "Only Name"})
+
+
+def test_factory_phase_result_contains_all_backend_keys() -> None:
+    from tests.planner.conftest import make_phase_result
+
+    result = make_phase_result(3, name="Third Phase")
+
+    assert result["phase_number"] == 3
+    assert result["name_slug"] == "third-phase"
+    assert isinstance(result["assignments"], list)
+
+
+def test_factory_assignment_result_contains_all_backend_keys() -> None:
+    from tests.planner.conftest import make_assignment_result
+
+    result = make_assignment_result(2, 4)
+
+    assert result["phase_number"] == 2
+    assert result["assignment_number"] == 4
+    assert result["id"] == "P2-A4"
+
+
+def test_factory_wp_result_contains_required_keys() -> None:
+    from tests.planner.conftest import make_wp_result
+
+    result = make_wp_result("P1-A1-WP2")
+
+    assert result["id"] == "P1-A1-WP2"
+    assert isinstance(result["deliverables"], list)
+    assert len(result["deliverables"]) >= 1
+
+
+@pytest.mark.parametrize(
+    "assignments_preview,expected_count",
+    [
+        ([], 0),
+        (["Schema design"], 1),
+        (["Task A", "Task B", "Task C"], 3),
+    ],
+)
+def test_validate_phase_result_derives_assignments_from_preview(
+    assignments_preview: list[str], expected_count: int
+) -> None:
+    result = validate_phase_result(
+        {
+            "id": "P1",
+            "name": "Phase One",
+            "ordering": 1,
+            "assignments_preview": assignments_preview,
+        }
+    )
+    assert len(result["assignments"]) == expected_count
+    for item in result["assignments"]:
+        assert "name" in item
+        assert "metadata" in item
+
+
+@pytest.mark.parametrize(
+    "assign_id,expected_pn,expected_an",
+    [
+        ("P1-A1", 1, 1),
+        ("P3-A7", 3, 7),
+        ("P10-A2", 10, 2),
+    ],
+)
+def test_validate_assignment_result_parses_id(
+    assign_id: str, expected_pn: int, expected_an: int
+) -> None:
+    result = validate_assignment_result(
+        {
+            "id": assign_id,
+            "name": "Test",
+            "proposed_work_packages": [],
+        }
+    )
+    assert result["phase_number"] == expected_pn
+    assert result["assignment_number"] == expected_an
+
+
+@pytest.mark.parametrize(
+    "name,expected_slug",
+    [
+        ("Phase One", "phase-one"),
+        ("Foundation", "foundation"),
+        ("Schema & Validation", "schema-validation"),
+        ("Phase 1", "phase-1"),
+    ],
+)
+def test_validate_phase_result_slugifies_name(name: str, expected_slug: str) -> None:
+    result = validate_phase_result({"id": "P1", "name": name, "ordering": 1})
+    assert result["name_slug"] == expected_slug

--- a/tests/planner/test_validation.py
+++ b/tests/planner/test_validation.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from autoskillit.planner.validation import validate_plan
+from tests.planner.conftest import make_assignment_result, make_phase_result, make_wp_result
 
 pytestmark = [pytest.mark.layer("planner"), pytest.mark.small, pytest.mark.feature("planner")]
 
@@ -40,26 +41,21 @@ def _make_minimal_output_dir(
     for p in range(1, num_phases + 1):
         _write_json(
             phases_dir / f"P{p}_result.json",
-            {
-                "phase_number": p,
-                "name": f"Phase {p}",
-                "name_slug": f"phase-{p}",
-                "assignments": [f"P{p}-A1"],
-            },
+            make_phase_result(p, name=f"Phase {p}"),
         )
 
     for p in range(1, num_phases + 1):
         for a in range(1, 2):
             _write_json(
                 assigns_dir / f"P{p}-A{a}_result.json",
-                {
-                    "phase_number": p,
-                    "assignment_number": a,
-                    "name": f"Assignment P{p}-A{a}",
-                    "proposed_work_packages": [
+                make_assignment_result(
+                    p,
+                    a,
+                    name=f"Assignment P{p}-A{a}",
+                    proposed_work_packages=[
                         f"P{p}-A{a}-WP{w}" for w in range(1, wps_per_assignment + 1)
                     ],
-                },
+                ),
             )
 
     for p in range(1, num_phases + 1):
@@ -74,16 +70,7 @@ def _make_minimal_output_dir(
                 deps = (depends_on_override or {}).get(wp_id, [])
                 _write_json(
                     wps_dir / f"{wp_id}_result.json",
-                    {
-                        "id": wp_id,
-                        "name": f"WP {wp_id}",
-                        "summary": "summary",
-                        "goal": "goal",
-                        "deliverables": deliverables,
-                        "technical_steps": ["step 1"],
-                        "acceptance_criteria": ["criterion 1"],
-                        "depends_on": deps,
-                    },
+                    make_wp_result(wp_id, deliverables=deliverables, depends_on=deps),
                 )
 
     manifest_items = []
@@ -100,24 +87,14 @@ def _make_minimal_output_dir(
         for p in extra_phases:
             _write_json(
                 phases_dir / f"P{p}_result.json",
-                {
-                    "phase_number": p,
-                    "name": f"Phase {p}",
-                    "name_slug": f"phase-{p}",
-                    "assignments": [],
-                },
+                make_phase_result(p, name=f"Phase {p}"),
             )
 
     if extra_assignments:
         for p, a in extra_assignments:
             _write_json(
                 assigns_dir / f"P{p}-A{a}_result.json",
-                {
-                    "phase_number": p,
-                    "assignment_number": a,
-                    "name": f"Orphan assignment P{p}-A{a}",
-                    "proposed_work_packages": [],
-                },
+                make_assignment_result(p, a, name=f"Orphan assignment P{p}-A{a}"),
             )
 
     return tmp_path

--- a/tests/recipe/test_contracts.py
+++ b/tests/recipe/test_contracts.py
@@ -538,6 +538,8 @@ FILE_PRODUCING_SKILLS_WITH_CONTRACTS: list[str] = [
     "resolve-merge-conflicts",
     "retry-worktree",
     "review-pr",
+    "planner-generate-phases",
+    "sprint-planner",
     "arch-lens-c4-container",
     "arch-lens-concurrency",
     "arch-lens-data-lineage",
@@ -643,7 +645,9 @@ ALWAYS_WRITE_SKILLS = {
     "make-plan",
     "plan-experiment",
     "plan-visualization",
+    "planner-generate-phases",
     "prepare-research-pr",
+    "sprint-planner",
     "rectify",
     "report-bug",
     "resolve-design-review",
@@ -751,3 +755,50 @@ def test_dataflow_entry_uppercase_f() -> None:
     assert not hasattr(m, "DataflowEntry"), "DataflowEntry (lowercase f) must be removed"
     entry = DataFlowEntry(step="s", available=[], required=[], produced=[])
     assert entry.step == "s"
+
+
+def test_all_bundled_recipe_skills_in_master_manifest() -> None:
+    """T1d: every skill name used in a run_skill step across all bundled recipes must have
+    an entry in skill_contracts.yaml (dynamic/template skill names are excluded)."""
+    from autoskillit.recipe.contracts import resolve_skill_name
+    from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
+
+    manifest = load_bundled_manifest()
+    registered_skills = set(manifest.get("skills", {}).keys())
+
+    recipes_dir = builtin_recipes_dir()
+    unregistered: list[str] = []
+
+    for recipe_path in sorted(recipes_dir.glob("*.yaml")):
+        recipe = load_recipe(recipe_path)
+        for step in recipe.steps.values():
+            if step.tool != "run_skill":
+                continue
+            skill_cmd = step.with_args.get("skill_command", "")
+            name = resolve_skill_name(skill_cmd)
+            if name is None:
+                continue  # dynamic skill name — can't validate statically
+            if name not in registered_skills:
+                unregistered.append(f"{recipe_path.name}:{name}")
+
+    assert not unregistered, (
+        f"Skills used in bundled recipes but missing from skill_contracts.yaml: "
+        f"{sorted(set(unregistered))}"
+    )
+
+
+def test_result_field_spec_roundtrip() -> None:
+    """ResultFieldSpec must be parseable from skill_contracts.yaml for planner-generate-phases."""
+    from autoskillit.recipe.contracts import ResultFieldSpec, get_skill_contract
+
+    manifest = load_bundled_manifest()
+    contract = get_skill_contract("planner-generate-phases", manifest)
+    assert contract is not None
+    assert len(contract.result_fields) == 3
+    required_names = {rf.name for rf in contract.result_fields if rf.required}
+    assert required_names == {"id", "name", "ordering"}, (
+        f"planner-generate-phases result_fields required names mismatch: {required_names}"
+    )
+    for rf in contract.result_fields:
+        assert isinstance(rf, ResultFieldSpec)
+        assert rf.required is True

--- a/tests/recipe/test_contracts.py
+++ b/tests/recipe/test_contracts.py
@@ -794,7 +794,6 @@ def test_result_field_spec_roundtrip() -> None:
     manifest = load_bundled_manifest()
     contract = get_skill_contract("planner-generate-phases", manifest)
     assert contract is not None
-    assert len(contract.result_fields) == 3
     required_names = {rf.name for rf in contract.result_fields if rf.required}
     assert required_names == {"id", "name", "ordering"}, (
         f"planner-generate-phases result_fields required names mismatch: {required_names}"

--- a/tests/recipe/test_rules_contracts.py
+++ b/tests/recipe/test_rules_contracts.py
@@ -10,7 +10,7 @@ import pytest
 import autoskillit.recipe.rules_contracts as _rc
 from autoskillit.core.paths import pkg_root
 from autoskillit.core.types import Severity
-from autoskillit.recipe.contracts import SkillContract
+from autoskillit.recipe.contracts import ResultFieldSpec, SkillContract
 from autoskillit.recipe.io import load_recipe
 from autoskillit.recipe.registry import run_semantic_rules
 from autoskillit.recipe.schema import Recipe, RecipeStep
@@ -297,3 +297,118 @@ def test_unreadable_skill_md_emits_warning_finding(
     assert relevant[0].rule == "always-has-no-write-exit"
     assert relevant[0].step_name == "test_step"
     assert "fake-skill" in relevant[0].message
+
+
+# ---------------------------------------------------------------------------
+# result-field-drift tests
+# ---------------------------------------------------------------------------
+
+
+class TestResultFieldDriftRule:
+    def test_matching_result_fields_no_finding(self) -> None:
+        """result_fields that exactly match PHASE_REQUIRED_KEYS must not fire."""
+        recipe = _make_recipe_with_skill(
+            "/autoskillit:planner-generate-phases {{AUTOSKILLIT_TEMP}}/planner/analysis.json"
+        )
+        contract = SkillContract(
+            inputs=[],
+            outputs=[],
+            result_fields=(
+                ResultFieldSpec(name="id", type="str", required=True),
+                ResultFieldSpec(name="name", type="str", required=True),
+                ResultFieldSpec(name="ordering", type="int", required=True),
+            ),
+        )
+        with patch(
+            "autoskillit.recipe.rules_contracts.get_skill_contract",
+            return_value=contract,
+        ):
+            findings = run_semantic_rules(recipe)
+        drift = [f for f in findings if f.rule == "result-field-drift"]
+        assert drift == []
+
+    def test_extra_required_field_fires_error(self) -> None:
+        """A required field in result_fields that is NOT in the TypedDict fires ERROR."""
+        recipe = _make_recipe_with_skill(
+            "/autoskillit:planner-generate-phases {{AUTOSKILLIT_TEMP}}/planner/analysis.json"
+        )
+        contract = SkillContract(
+            inputs=[],
+            outputs=[],
+            result_fields=(
+                ResultFieldSpec(name="id", type="str", required=True),
+                ResultFieldSpec(name="name", type="str", required=True),
+                ResultFieldSpec(name="ordering", type="int", required=True),
+                ResultFieldSpec(name="phantom_field", type="str", required=True),
+            ),
+        )
+        with patch(
+            "autoskillit.recipe.rules_contracts.get_skill_contract",
+            return_value=contract,
+        ):
+            findings = run_semantic_rules(recipe)
+        drift = [f for f in findings if f.rule == "result-field-drift"]
+        assert len(drift) == 1
+        assert drift[0].severity == Severity.ERROR
+        assert "phantom_field" in drift[0].message
+        assert "extra in contract" in drift[0].message
+
+    def test_missing_required_field_fires_error(self) -> None:
+        """A TypedDict required key absent from result_fields fires ERROR."""
+        recipe = _make_recipe_with_skill(
+            "/autoskillit:planner-generate-phases {{AUTOSKILLIT_TEMP}}/planner/analysis.json"
+        )
+        contract = SkillContract(
+            inputs=[],
+            outputs=[],
+            result_fields=(
+                ResultFieldSpec(name="id", type="str", required=True),
+                # 'name' and 'ordering' are missing
+            ),
+        )
+        with patch(
+            "autoskillit.recipe.rules_contracts.get_skill_contract",
+            return_value=contract,
+        ):
+            findings = run_semantic_rules(recipe)
+        drift = [f for f in findings if f.rule == "result-field-drift"]
+        assert len(drift) == 1
+        assert drift[0].severity == Severity.ERROR
+        assert "missing from contract" in drift[0].message
+
+    def test_optional_extra_field_ignored(self) -> None:
+        """A field with required=False in result_fields that is not in the TypedDict is ignored."""
+        recipe = _make_recipe_with_skill(
+            "/autoskillit:planner-generate-phases {{AUTOSKILLIT_TEMP}}/planner/analysis.json"
+        )
+        contract = SkillContract(
+            inputs=[],
+            outputs=[],
+            result_fields=(
+                ResultFieldSpec(name="id", type="str", required=True),
+                ResultFieldSpec(name="name", type="str", required=True),
+                ResultFieldSpec(name="ordering", type="int", required=True),
+                ResultFieldSpec(name="optional_extra", type="str", required=False),
+            ),
+        )
+        with patch(
+            "autoskillit.recipe.rules_contracts.get_skill_contract",
+            return_value=contract,
+        ):
+            findings = run_semantic_rules(recipe)
+        drift = [f for f in findings if f.rule == "result-field-drift"]
+        assert drift == []
+
+    def test_skill_without_result_fields_in_contract_skipped(self) -> None:
+        """Skills not in _SKILL_RESULT_FIELD_SCHEMAS are ignored by the rule."""
+        recipe = _make_recipe_with_skill("/autoskillit:implement-worktree-no-merge")
+        findings = run_semantic_rules(recipe)
+        drift = [f for f in findings if f.rule == "result-field-drift"]
+        assert drift == []
+
+    def test_planner_recipe_has_no_result_field_drift(self) -> None:
+        """The bundled planner recipe must not trigger result-field-drift."""
+        recipe = load_recipe(pkg_root() / "recipes" / "planner.yaml")
+        findings = run_semantic_rules(recipe)
+        drift = [f for f in findings if f.rule == "result-field-drift"]
+        assert drift == [], f"result-field-drift fired on planner recipe: {drift}"

--- a/tests/recipe/test_rules_contracts.py
+++ b/tests/recipe/test_rules_contracts.py
@@ -400,7 +400,7 @@ class TestResultFieldDriftRule:
         assert drift == []
 
     def test_skill_without_result_fields_in_contract_skipped(self) -> None:
-        """Skills not in _SKILL_RESULT_FIELD_SCHEMAS are ignored by the rule."""
+        """Skills not in _RESULT_FIELD_DRIFT_SKILLS are ignored by the rule."""
         recipe = _make_recipe_with_skill("/autoskillit:implement-worktree-no-merge")
         findings = run_semantic_rules(recipe)
         drift = [f for f in findings if f.rule == "result-field-drift"]

--- a/tests/recipe/test_rules_contracts.py
+++ b/tests/recipe/test_rules_contracts.py
@@ -313,11 +313,11 @@ class TestResultFieldDriftRule:
         contract = SkillContract(
             inputs=[],
             outputs=[],
-            result_fields=(
+            result_fields=[
                 ResultFieldSpec(name="id", type="str", required=True),
                 ResultFieldSpec(name="name", type="str", required=True),
                 ResultFieldSpec(name="ordering", type="int", required=True),
-            ),
+            ],
         )
         with patch(
             "autoskillit.recipe.rules_contracts.get_skill_contract",
@@ -335,12 +335,12 @@ class TestResultFieldDriftRule:
         contract = SkillContract(
             inputs=[],
             outputs=[],
-            result_fields=(
+            result_fields=[
                 ResultFieldSpec(name="id", type="str", required=True),
                 ResultFieldSpec(name="name", type="str", required=True),
                 ResultFieldSpec(name="ordering", type="int", required=True),
                 ResultFieldSpec(name="phantom_field", type="str", required=True),
-            ),
+            ],
         )
         with patch(
             "autoskillit.recipe.rules_contracts.get_skill_contract",
@@ -361,10 +361,10 @@ class TestResultFieldDriftRule:
         contract = SkillContract(
             inputs=[],
             outputs=[],
-            result_fields=(
+            result_fields=[
                 ResultFieldSpec(name="id", type="str", required=True),
                 # 'name' and 'ordering' are missing
-            ),
+            ],
         )
         with patch(
             "autoskillit.recipe.rules_contracts.get_skill_contract",
@@ -384,12 +384,12 @@ class TestResultFieldDriftRule:
         contract = SkillContract(
             inputs=[],
             outputs=[],
-            result_fields=(
+            result_fields=[
                 ResultFieldSpec(name="id", type="str", required=True),
                 ResultFieldSpec(name="name", type="str", required=True),
                 ResultFieldSpec(name="ordering", type="int", required=True),
                 ResultFieldSpec(name="optional_extra", type="str", required=False),
-            ),
+            ],
         )
         with patch(
             "autoskillit.recipe.rules_contracts.get_skill_contract",

--- a/tests/recipe/test_rules_dataflow.py
+++ b/tests/recipe/test_rules_dataflow.py
@@ -92,9 +92,9 @@ class TestCaptureOutputCoverageRule:
         undeclared = [f for f in findings if f.rule == "undeclared-capture-key"]
         assert undeclared == []
 
-    def test_capture_undeclared_key_emits_warning(self) -> None:
+    def test_capture_undeclared_key_emits_error(self) -> None:
         """A capture that references a key NOT listed in the skill's outputs contract
-        must produce a Severity.WARNING finding with rule 'undeclared-capture-key'."""
+        must produce a Severity.ERROR finding with rule 'undeclared-capture-key'."""
         recipe_yaml = textwrap.dedent("""\
             name: capture-invalid-key
             description: test
@@ -115,13 +115,13 @@ class TestCaptureOutputCoverageRule:
         findings = run_semantic_rules(recipe)
         undeclared = [f for f in findings if f.rule == "undeclared-capture-key"]
         assert len(undeclared) == 1
-        assert undeclared[0].severity == Severity.WARNING
+        assert undeclared[0].severity == Severity.ERROR
         assert "nonexistent_output" in undeclared[0].message
         assert "implement-worktree-no-merge" in undeclared[0].message
 
-    def test_capture_from_skill_with_no_contract_emits_warning(self) -> None:
+    def test_capture_from_skill_with_no_contract_emits_error(self) -> None:
         """A capture step whose skill has no entry in skill_contracts.yaml at all
-        must produce a Severity.WARNING finding with rule 'undeclared-capture-key'."""
+        must produce a Severity.ERROR finding with rule 'undeclared-capture-key'."""
         recipe_yaml = textwrap.dedent("""\
             name: capture-unknown-skill
             description: test
@@ -142,11 +142,11 @@ class TestCaptureOutputCoverageRule:
         findings = run_semantic_rules(recipe)
         undeclared = [f for f in findings if f.rule == "undeclared-capture-key"]
         assert len(undeclared) == 1
-        assert undeclared[0].severity == Severity.WARNING
+        assert undeclared[0].severity == Severity.ERROR
         assert "not-a-real-skill" in undeclared[0].message
         assert "no outputs contract entry" in undeclared[0].message
 
-    def test_capture_key_from_empty_outputs_skill_emits_warning(self) -> None:
+    def test_capture_key_from_empty_outputs_skill_emits_error(self) -> None:
         """audit-friction has outputs: [] — any capture key from it is undeclared."""
         recipe_yaml = textwrap.dedent("""\
             name: capture-empty-outputs
@@ -168,9 +168,37 @@ class TestCaptureOutputCoverageRule:
         findings = run_semantic_rules(recipe)
         undeclared = [f for f in findings if f.rule == "undeclared-capture-key"]
         assert len(undeclared) == 1
-        assert undeclared[0].severity == Severity.WARNING
+        assert undeclared[0].severity == Severity.ERROR
         assert "report_path" in undeclared[0].message
         assert "audit-friction" in undeclared[0].message
+
+    def test_undeclared_capture_key_blocks_validity(self) -> None:
+        """undeclared-capture-key at ERROR severity must cause compute_recipe_validity=False."""
+        from autoskillit.recipe.registry import compute_recipe_validity
+
+        recipe_yaml = textwrap.dedent("""\
+            name: capture-invalid-blocks-validity
+            description: test
+            steps:
+              implement:
+                tool: run_skill
+                with:
+                  skill_command: /autoskillit:implement-worktree-no-merge ${{ inputs.plan }}
+                capture:
+                  ghost_key: "${{ result.ghost_key }}"
+                on_success: done
+                on_failure: done
+              done:
+                action: stop
+                message: Done
+        """)
+        recipe = _parse_recipe(yaml.safe_load(recipe_yaml))
+        findings = run_semantic_rules(recipe)
+        assert not compute_recipe_validity(
+            errors=[],
+            semantic_findings=findings,
+            contract_findings=[],
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/skills/test_planner_skill_contracts.py
+++ b/tests/skills/test_planner_skill_contracts.py
@@ -2,10 +2,23 @@ import pytest
 import yaml
 
 from autoskillit.core.paths import pkg_root
+from autoskillit.recipe.io import load_recipe
 
 SKILLS_ROOT = pkg_root() / "skills_extended"
+RECIPES_ROOT = pkg_root() / "recipes"
 
 PLANNER_FINALIZATION_SKILLS = [
+    "planner-reconcile-deps",
+    "planner-refine",
+]
+
+ALL_PLANNER_SKILLS = [
+    "planner-analyze",
+    "planner-extract-domain",
+    "planner-generate-phases",
+    "planner-elaborate-phase",
+    "planner-elaborate-assignment",
+    "planner-elaborate-wp",
     "planner-reconcile-deps",
     "planner-refine",
 ]
@@ -72,3 +85,52 @@ def test_skill_in_defaults_yaml_tier2(skill_name: str) -> None:
     defaults = yaml.safe_load((pkg_root() / "config" / "defaults.yaml").read_text())
     tier2 = defaults["skills"]["tier2"]
     assert skill_name in tier2, f"{skill_name} must appear in defaults.yaml skills.tier2"
+
+
+def test_all_planner_recipe_skills_registered_in_contract_card() -> None:
+    """T1a: every run_skill step in planner.yaml must appear in the planner contract card."""
+    recipe = load_recipe(RECIPES_ROOT / "planner.yaml")
+    recipe_skills = {
+        step.with_args.get("skill_command", "").split(":")[1].split()[0]
+        for step in recipe.steps.values()
+        if step.tool == "run_skill" and "/autoskillit:" in step.with_args.get("skill_command", "")
+    }
+
+    card_path = RECIPES_ROOT / "contracts" / "planner.yaml"
+    assert card_path.is_file(), "planner contract card not found — run generate_recipe_card"
+    card = yaml.safe_load(card_path.read_text())
+    registered = set(card.get("skills", {}).keys())
+
+    missing = recipe_skills - registered
+    assert not missing, (
+        f"Planner skills used in recipe but missing from contract card: {sorted(missing)}"
+    )
+
+
+def test_planner_contract_card_records_positional_args_for_generate_phases() -> None:
+    """T1b: the generate_phases dataflow entry must record positional_args > 0."""
+    card_path = RECIPES_ROOT / "contracts" / "planner.yaml"
+    assert card_path.is_file(), "planner contract card not found — run generate_recipe_card"
+    card = yaml.safe_load(card_path.read_text())
+
+    generate_phases_entry = next(
+        (e for e in card.get("dataflow", []) if e.get("step") == "generate_phases"),
+        None,
+    )
+    assert generate_phases_entry is not None, (
+        "generate_phases step not found in planner contract card dataflow"
+    )
+    assert generate_phases_entry.get("positional_args", 0) > 0, (
+        "generate_phases step should record positional_args > 0 in the contract card"
+    )
+
+
+@pytest.mark.parametrize("skill_name", ALL_PLANNER_SKILLS)
+def test_all_planner_skills_in_master_manifest(skill_name: str) -> None:
+    """All 8 planner skills must be registered in skill_contracts.yaml."""
+    from autoskillit.recipe.contracts import load_bundled_manifest
+
+    manifest = load_bundled_manifest()
+    assert skill_name in manifest.get("skills", {}), (
+        f"Planner skill '{skill_name}' is not registered in skill_contracts.yaml"
+    )

--- a/tests/skills/test_skill_output_compliance.py
+++ b/tests/skills/test_skill_output_compliance.py
@@ -251,6 +251,8 @@ def test_output_path_tokens_synchronized() -> None:
             "execution_map_report",
             # planner-generate-phases output (planner recipe)
             "phase_manifest_path",
+            # sprint-planner output (sprint-prefix sub-recipe)
+            "sprint_manifest",
         }
     )
 


### PR DESCRIPTION
## Summary

The planner pipeline had zero shared schema definitions between the three surfaces that must agree on field names: SKILL.md output specifications, Python backend modules (`validation.py`, `manifests.py`, `compiler.py`), and test fixtures. Each surface was authored independently, resulting in 6 bugs where field names diverge (`ordering` vs `phase_number`, `assignments_preview` vs `assignments`, missing `name_slug`, missing `assignment_number`). The architectural solution introduces canonical TypedDict schemas as a single source of truth, validation at the deserialization boundary, and schema-derived test fixtures — making this entire class of drift structurally impossible.

Part B will cover extending the recipe contract system to declare result-file field schemas and adding contract-generation tooling that derives field-level expectations from the TypedDicts.

## Architecture Impact

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 65, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START([Skill emits result JSON])

    %% ── SUBGRAPH 1: Schema Source of Truth ── %%
    subgraph Schema ["★ SCHEMA CONTRACTS — schema.py (NEW)"]
        direction LR
        PHASE_KEYS["★ PHASE_REQUIRED_KEYS<br/>━━━━━━━━━━<br/>frozenset: id · name · ordering<br/>INIT_ONLY — never modify"]
        ASSIGN_KEYS["★ ASSIGNMENT_REQUIRED_KEYS<br/>━━━━━━━━━━<br/>frozenset: id · name<br/>· proposed_work_packages<br/>INIT_ONLY — never modify"]
        WP_KEYS["★ WP_REQUIRED_KEYS<br/>━━━━━━━━━━<br/>frozenset: id · name · deliverables<br/>INIT_ONLY — never modify"]
        DERIVED["★ DERIVED FIELDS<br/>━━━━━━━━━━<br/>phase_number ← ordering / id prefix<br/>name_slug ← name<br/>assignment_number ← id (PX-AY)"]
    end

    %% ── SUBGRAPH 2: Load-time Schema Gate ── %%
    subgraph LoadGate ["● SCHEMA VALIDATION GATE (validation.py — load time)"]
        SCHEMA_GATE["● validate_phase / assignment / wp _result<br/>━━━━━━━━━━<br/>Checks REQUIRED_KEYS presence<br/>FAIL-FAST: RuntimeError on violation"]
    end

    %% ── SUBGRAPH 3: Manifest Item State Machine ── %%
    subgraph StatusMachine ["● MANIFEST ITEM STATE MACHINE (manifests.py)"]
        direction LR
        PENDING["pending<br/>━━━━━━━━━━<br/>Not yet started<br/>MUTABLE → processing only"]
        PROCESSING["processing<br/>━━━━━━━━━━<br/>In flight<br/>MUTABLE → done or failed"]
        DONE["done<br/>━━━━━━━━━━<br/>result_path set<br/>TERMINAL — no further mutation"]
        FAILED["failed<br/>━━━━━━━━━━<br/>No result after retries<br/>TERMINAL — no further mutation"]
        PENDING -->|"advance cursor"| PROCESSING
        PROCESSING -->|"result file found"| DONE
        PROCESSING -->|"retries exhausted"| FAILED
    end

    %% ── SUBGRAPH 4: Structural Validation Gates (validate_plan) ── %%
    subgraph StructGates ["● STRUCTURAL VALIDATION GATES — validate_plan (validation.py)"]
        direction TB
        G1["Gate 1: Phase Completeness<br/>━━━━━━━━━━<br/>Every phase has ≥1 assignment"]
        G2["Gate 2: Assignment Completeness<br/>━━━━━━━━━━<br/>Every assignment has ≥1 WP<br/>WP id must match PX-AY-WPZ"]
        G3["Gate 3: Dep Reference Integrity<br/>━━━━━━━━━━<br/>depends_on IDs must exist in wp_results<br/>APPEND_ONLY: _inject_backward_deps"]
        G4["Gate 4: DAG Acyclicity<br/>━━━━━━━━━━<br/>Kahn's BFS topo sort<br/>Cycle → finding with node set"]
        G5["Gate 5: Sizing Bounds<br/>━━━━━━━━━━<br/>1 ≤ len(deliverables) ≤ 5 per WP"]
        G6["Gate 6: Duplicate Deliverable Detection<br/>━━━━━━━━━━<br/>One file path → exactly one WP<br/>Prevents split-ownership corruption"]
        G7["Gate 7: Failed WP Check<br/>━━━━━━━━━━<br/>No status='failed' items in wp_manifest"]
        G1 --> G2 --> G3 --> G4 --> G5 --> G6 --> G7
    end

    %% ── SUBGRAPH 5: Contract Enforcement Rules ── %%
    subgraph ContractRules ["● CONTRACT ENFORCEMENT (rules_contracts.py · rules_dataflow.py)"]
        direction TB
        DRIFT["● result-field-drift (ERROR)<br/>━━━━━━━━━━<br/>TypedDict REQUIRED_KEYS<br/>↔ skill_contracts.yaml result_fields<br/>Bidirectional: extra + missing"]
        IMPLICIT["● implicit-handoff (ERROR)<br/>━━━━━━━━━━<br/>Producer: skill declares outputs<br/>→ step MUST have capture: block<br/>Prevents silent output discard"]
        CONSUMER["● uncaptured-handoff-consumer (WARNING)<br/>━━━━━━━━━━<br/>Consumer: successor has unwired<br/>optional file_path inputs<br/>Flags missing propagation wiring"]
        DEAD["● dead-output (ERROR)<br/>━━━━━━━━━━<br/>Captured context var<br/>never consumed downstream<br/>Detects orphaned pipeline state"]
        DRIFT --> IMPLICIT --> CONSUMER --> DEAD
    end

    %% ── SUBGRAPH 6: Pipeline Context State ── %%
    subgraph PipelineCtx ["PIPELINE CONTEXT — MUTABLE propagation fields"]
        direction LR
        SENTINELS["● has_remaining / current_item_path<br/>━━━━━━━━━━<br/>Loop iteration sentinels<br/>Re-produced by each check step<br/>MUTABLE — changes every iteration"]
        ARTIFACTS["INIT_PRESERVE artifact paths<br/>━━━━━━━━━━<br/>phase_manifest_path<br/>assignment_manifest_path<br/>wp_manifest_path<br/>Set once, never overwritten"]
        VERDICT["● verdict / validation_path / issue_count<br/>━━━━━━━━━━<br/>Validation output state<br/>MUTABLE — set by validate_plan"]
    end

    VERDICT_FINAL(["validation.json written<br/>verdict: pass | fail"])

    %% ── CONNECTIONS ── %%
    START --> PHASE_KEYS
    START --> ASSIGN_KEYS
    START --> WP_KEYS
    START --> DERIVED

    PHASE_KEYS --> SCHEMA_GATE
    ASSIGN_KEYS --> SCHEMA_GATE
    WP_KEYS --> SCHEMA_GATE
    DERIVED --> SCHEMA_GATE

    SCHEMA_GATE -->|"keys present"| PENDING
    SCHEMA_GATE -->|"keys present"| G1
    SCHEMA_GATE -->|"schema exported"| DRIFT

    DONE --> SENTINELS
    DONE --> ARTIFACTS
    FAILED --> SENTINELS

    G7 --> VERDICT

    IMPLICIT -->|"capture: enforced"| SENTINELS
    CONSUMER -->|"wiring verified"| ARTIFACTS
    DEAD -->|"orphan detection"| VERDICT

    SENTINELS --> ARTIFACTS
    ARTIFACTS --> VERDICT
    VERDICT --> VERDICT_FINAL

    %% ── CLASS ASSIGNMENTS ── %%
    class PHASE_KEYS,ASSIGN_KEYS,WP_KEYS detector;
    class DERIVED gap;
    class SCHEMA_GATE detector;
    class PENDING,PROCESSING phase;
    class DONE output;
    class FAILED handler;
    class G1,G2,G3,G4,G5,G6,G7 stateNode;
    class DRIFT,IMPLICIT,CONSUMER,DEAD detector;
    class SENTINELS phase;
    class ARTIFACTS cli;
    class VERDICT stateNode;
    class START,VERDICT_FINAL terminal;
```

### Data Lineage Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph Skills ["Planner Skills — LLM Execution"]
        PHASE_SK["● planner-generate-phases<br/>━━━━━━━━━━<br/>Writes raw Phase JSON"]
        ASSIGN_SK["● planner-elaborate-phase<br/>● planner-elaborate-assignment<br/>━━━━━━━━━━<br/>Writes raw Assignment JSON"]
        WP_SK["● planner-elaborate-wp<br/>━━━━━━━━━━<br/>Writes raw WP JSON"]
    end

    subgraph RawFS ["Raw Result Files"]
        PHASE_FILES[("phases/<br/>*_result.json<br/>━━━━━━━━━━<br/>Untyped Phase dicts")]
        ASSIGN_FILES[("assignments/<br/>*_result.json<br/>━━━━━━━━━━<br/>Untyped Assignment dicts")]
        WP_FILES[("work_packages/<br/>*_result.json<br/>━━━━━━━━━━<br/>Untyped WP dicts")]
    end

    subgraph SchemaLayer ["★ Schema Validation Layer — schema.py NEW"]
        VPR["★ validate_phase_result<br/>━━━━━━━━━━<br/>TypedDict: PhaseResult<br/>PHASE_REQUIRED_KEYS<br/>injects: phase_number, name_slug,<br/>assignments, defaults"]
        VAR["★ validate_assignment_result<br/>━━━━━━━━━━<br/>TypedDict: AssignmentResult<br/>ASSIGNMENT_REQUIRED_KEYS<br/>injects: phase_number,<br/>assignment_number, phase_id"]
        VWR["★ validate_wp_result<br/>━━━━━━━━━━<br/>TypedDict: WPResult<br/>WP_REQUIRED_KEYS<br/>injects: summary, goal,<br/>steps, files, apis, deps"]
    end

    subgraph ManifestSM ["● Manifest State Machine — manifests.py"]
        BAM["● build_assignment_manifest<br/>━━━━━━━━━━<br/>Phase tree → flat<br/>P{n}-A{seq} item list"]
        BWM["● build_wp_manifest<br/>━━━━━━━━━━<br/>Assignment tree → flat<br/>P{n}-A{m}-WP{k} item list"]
        CHK["check_remaining<br/>━━━━━━━━━━<br/>pending → processing → done<br/>writes context_{id}.json<br/>backstop: wp_index.json"]
    end

    subgraph ManifestFS ["Manifest Primary Storage"]
        AMJSON[("assignment_manifest.json<br/>━━━━━━━━━━<br/>schema_version: 1<br/>items[]: id, name,<br/>status, result_path, metadata")]
        WPMJSON[("wp_manifest.json<br/>━━━━━━━━━━<br/>schema_version: 1<br/>items[]: id, name,<br/>status, result_path, metadata")]
        WPIJSON[("wp_index.json<br/>━━━━━━━━━━<br/>Backstop WP index<br/>[{id, name, summary}]")]
        CTXJSON[("context_{id}.json<br/>━━━━━━━━━━<br/>schema_version: 1<br/>id, name, metadata,<br/>prior_results[], wp_index_path")]
        DGJSON[("dep_graph.json<br/>━━━━━━━━━━<br/>added_backward_deps<br/>forward_deps<br/>Written by planner-reconcile-deps")]
    end

    subgraph ValidateStage ["● Validation — validation.py"]
        VPLAN["● validate_plan<br/>━━━━━━━━━━<br/>phase completeness<br/>assignment completeness<br/>dep references + DAG cycle<br/>sizing bounds (1–5 deliverables)<br/>duplicate deliverables<br/>failed WP items"]
    end

    subgraph CompileStage ["Compilation — compiler.py"]
        CPLAN["compile_plan<br/>━━━━━━━━━━<br/>Topological sort (Kahn's)<br/>inject forward deps<br/>Render issue bodies<br/>Build nested plan tree"]
    end

    subgraph Artifacts ["Write-Only Plan Artifacts"]
        VALJSON["validation.json<br/>━━━━━━━━━━<br/>{verdict, findings[]}"]
        PLANJSON["plan.json<br/>━━━━━━━━━━<br/>Nested phases+assignments<br/>+work_packages+execution_order"]
        PLANMD["plan.md<br/>━━━━━━━━━━<br/>Human-readable<br/>phase/WP summary"]
        MFJSON["manifest.json<br/>━━━━━━━━━━<br/>execution_order[]<br/>issues: {wp_id → path}"]
        MSJSON["milestones.json<br/>━━━━━━━━━━<br/>milestones[]: phase_number,<br/>name, name_slug"]
        ISSUEMD["issues/<br/>{wp_id}_issue.md<br/>━━━━━━━━━━<br/>Goal, Context, Deliverables,<br/>Technical Steps, Acceptance Criteria"]
    end

    subgraph ContractSystem ["● Contract System"]
        SCYAML["● skill_contracts.yaml<br/>━━━━━━━━━━<br/>result_fields (NEW field)<br/>write_behavior, outputs[]"]
        PLANERYAML["● planner.yaml<br/>━━━━━━━━━━<br/>skill_hashes + dataflow steps<br/>available/required/produced"]
        CCONTRACTS["● contracts.py<br/>━━━━━━━━━━<br/>SkillContract + ResultFieldSpec<br/>(NEW dataclass)<br/>staleness detection"]
        RCONTRACTS["● rules_contracts.py<br/>● rules_dataflow.py<br/>━━━━━━━━━━<br/>Lint rules: contract drift,<br/>missing task propagation"]
    end

    %% SKILL → RAW FILES
    PHASE_SK -->|"writes *_result.json"| PHASE_FILES
    ASSIGN_SK -->|"writes *_result.json"| ASSIGN_FILES
    WP_SK -->|"writes *_result.json"| WP_FILES

    %% RAW FILES → SCHEMA VALIDATION (the new conversion boundary)
    PHASE_FILES -->|"json.loads()"| VPR
    ASSIGN_FILES -->|"json.loads()"| VAR
    WP_FILES -->|"json.loads()"| VWR

    %% SCHEMA → MANIFEST STATE MACHINE
    VPR -->|"validated PhaseResult"| BAM
    VAR -->|"validated AssignmentResult"| BWM

    %% MANIFEST STATE MACHINE → STORAGE
    BAM -->|"write_versioned_json"| AMJSON
    BWM -->|"write_versioned_json"| WPMJSON
    BWM -->|"atomic_write []"| WPIJSON
    CHK -->|"write_versioned_json<br/>context"| CTXJSON
    CHK -->|"updates item status"| AMJSON
    CHK -->|"updates item status"| WPMJSON
    CHK -.->|"backstop append"| WPIJSON

    %% MANIFESTS DRIVE CHECK_REMAINING (read-write)
    AMJSON -->|"reads items[]"| CHK
    WPMJSON -->|"reads items[]"| CHK

    %% VALIDATION READS ALL VALIDATED RESULTS
    VPR -->|"PhaseResult dict"| VPLAN
    VAR -->|"AssignmentResult dict"| VPLAN
    VWR -->|"WPResult dict"| VPLAN
    DGJSON -->|"inject_backward_deps"| VPLAN
    WPMJSON -->|"check failed items"| VPLAN
    VPLAN -.->|"write_versioned_json"| VALJSON

    %% COMPILATION
    VALJSON -->|"reads verdict"| CPLAN
    DGJSON -->|"inject_forward_deps"| CPLAN
    VPR -->|"PhaseResult dict"| CPLAN
    VAR -->|"AssignmentResult dict"| CPLAN
    VWR -->|"WPResult dict"| CPLAN
    CPLAN -.->|"atomic_write"| ISSUEMD
    CPLAN -.->|"write_versioned_json"| PLANJSON
    CPLAN -.->|"atomic_write"| PLANMD
    CPLAN -.->|"write_versioned_json"| MFJSON
    CPLAN -.->|"write_versioned_json"| MSJSON

    %% CONTRACT SYSTEM
    SCYAML -->|"load_yaml"| CCONTRACTS
    PLANERYAML -->|"dataflow validation"| RCONTRACTS
    CCONTRACTS -->|"staleness check"| RCONTRACTS

    %% CLASS ASSIGNMENTS
    class PHASE_SK,ASSIGN_SK,WP_SK cli;
    class PHASE_FILES,ASSIGN_FILES,WP_FILES stateNode;
    class AMJSON,WPMJSON,WPIJSON,CTXJSON,DGJSON stateNode;
    class VPR,VAR,VWR newComponent;
    class BAM,BWM,CHK handler;
    class VPLAN,CPLAN phase;
    class VALJSON,PLANJSON,PLANMD,MFJSON,MSJSON,ISSUEMD output;
    class SCYAML,PLANERYAML,CCONTRACTS,RCONTRACTS integration;
```

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph L3_Tests ["L3 — TESTS"]
        direction LR
        T_CONFTEST["★ tests/planner/conftest.py<br/>━━━━━━━━━━<br/>Schema-derived fixtures<br/>shared across planner tests"]
        T_PIPE["★ tests/planner/<br/>test_pipeline_integration.py<br/>━━━━━━━━━━<br/>End-to-end manifest pipeline"]
        T_SCHEMA["★ tests/planner/<br/>test_schema_conformance.py<br/>━━━━━━━━━━<br/>Schema key contract tests"]
        T_TYPED["★ tests/planner/<br/>test_typed_dict_conformance.py<br/>━━━━━━━━━━<br/>TypedDict field coverage"]
        T_MANIFESTS["● tests/planner/test_manifests.py<br/>━━━━━━━━━━<br/>manifests.py unit tests"]
        T_VALIDATION["● tests/planner/test_validation.py<br/>━━━━━━━━━━<br/>validate_plan unit tests"]
        T_COMPILER["● tests/planner/test_compiler.py<br/>━━━━━━━━━━<br/>compile_plan unit tests"]
        T_RCONTRACTS["● tests/recipe/test_rules_contracts.py<br/>━━━━━━━━━━<br/>result-field-drift rule tests"]
        T_RDATAFLOW["● tests/recipe/test_rules_dataflow.py<br/>━━━━━━━━━━<br/>dataflow rule tests"]
        T_CONTRACTS["● tests/recipe/test_contracts.py<br/>━━━━━━━━━━<br/>contract generation tests"]
        T_SKILL_CONTRACTS["● tests/skills/test_planner_skill_contracts.py<br/>━━━━━━━━━━<br/>planner YAML contract validation"]
        T_SKILL_COMPLIANCE["● tests/skills/test_skill_output_compliance.py<br/>━━━━━━━━━━<br/>skill output format compliance"]
    end

    subgraph L2_Recipe ["L2 — RECIPE"]
        direction LR
        R_CONTRACTS["● recipe/contracts.py<br/>━━━━━━━━━━<br/>SkillContract, RecipeCard<br/>generate_recipe_card()"]
        R_RULES_CONTRACTS["● recipe/rules_contracts.py<br/>━━━━━━━━━━<br/>result-field-drift rule<br/>deferred planner import<br/>(REQ-COMP-009)"]
        R_RULES_DATAFLOW["● recipe/rules_dataflow.py<br/>━━━━━━━━━━<br/>dataflow capture rules<br/>undeclared-capture-key"]
        R_ANALYSIS["recipe/_analysis.py<br/>━━━━━━━━━━<br/>ValidationContext<br/>step graph building"]
        R_REGISTRY["recipe/registry.py<br/>━━━━━━━━━━<br/>semantic_rule decorator<br/>RuleFinding"]
        R_SCHEMA["recipe/schema.py<br/>━━━━━━━━━━<br/>Recipe, RecipeBlock"]
        R_IO["recipe/io.py<br/>━━━━━━━━━━<br/>_parse_recipe"]
        R_STALENESS["recipe/staleness_cache.py<br/>━━━━━━━━━━<br/>StalenessEntry, compute_recipe_hash"]
        SKILL_CONTRACTS_YAML["● recipe/skill_contracts.yaml<br/>━━━━━━━━━━<br/>Planner skill output specs"]
        PLANNER_CONTRACT_YAML["● recipes/contracts/planner.yaml<br/>━━━━━━━━━━<br/>Planner recipe contract"]
    end

    subgraph L1_Planner ["L1 — PLANNER"]
        direction TB
        P_SCHEMA["★ planner/schema.py<br/>━━━━━━━━━━<br/>PhaseResult, AssignmentResult<br/>WPResult TypedDicts<br/>PHASE/ASSIGNMENT/WP_REQUIRED_KEYS<br/>validate_*_result()"]
        P_MANIFESTS["● planner/manifests.py<br/>━━━━━━━━━━<br/>check_remaining()<br/>build_assignment_manifest()<br/>build_wp_manifest()"]
        P_VALIDATION["● planner/validation.py<br/>━━━━━━━━━━<br/>validate_plan()<br/>DAG cycle check, sizing bounds"]
        P_INIT["● planner/__init__.py<br/>━━━━━━━━━━<br/>Public surface: check_remaining<br/>build_*_manifest, validate_plan<br/>compile_plan (+schema keys noqa)"]
        P_COMPILER["planner/compiler.py<br/>━━━━━━━━━━<br/>compile_plan()<br/>topological sort, issue bodies"]
    end

    subgraph L0_Core ["L0 — CORE"]
        direction LR
        CORE["core/__init__.py<br/>━━━━━━━━━━<br/>atomic_write, get_logger<br/>write_versioned_json, pkg_root<br/>SKILL_TOOLS, Severity<br/>dump_yaml_str, load_yaml<br/>PIPELINE_FORBIDDEN_TOOLS"]
        WORKSPACE["workspace/<br/>━━━━━━━━━━<br/>DefaultSkillResolver<br/>(deferred from contracts.py)"]
    end

    subgraph L_STDLIB ["STDLIB / EXTERNAL"]
        STDLIB["re, json, pathlib, datetime<br/>typing, collections, hashlib<br/>functools"]
    end

    %% === PLANNER INTERNAL DEPS ===
    P_SCHEMA -->|"stdlib only"| STDLIB
    P_MANIFESTS -->|"imports"| P_SCHEMA
    P_VALIDATION -->|"imports"| P_SCHEMA
    P_INIT -->|"re-exports"| P_MANIFESTS
    P_INIT -->|"re-exports"| P_VALIDATION
    P_INIT -->|"re-exports"| P_COMPILER
    P_INIT -->|"noqa: F401 (schema keys)"| P_SCHEMA

    %% === PLANNER → CORE ===
    P_MANIFESTS -->|"imports"| CORE
    P_VALIDATION -->|"imports"| CORE

    %% === RECIPE INTERNAL DEPS ===
    R_CONTRACTS -->|"imports"| R_IO
    R_CONTRACTS -->|"imports"| R_SCHEMA
    R_CONTRACTS -->|"imports"| R_STALENESS
    R_RULES_CONTRACTS -->|"imports"| R_ANALYSIS
    R_RULES_CONTRACTS -->|"imports"| R_CONTRACTS
    R_RULES_CONTRACTS -->|"imports"| R_REGISTRY
    R_RULES_DATAFLOW -->|"imports"| R_ANALYSIS
    R_RULES_DATAFLOW -->|"imports"| R_CONTRACTS
    R_RULES_DATAFLOW -->|"imports"| R_REGISTRY

    %% === RECIPE → CORE ===
    R_CONTRACTS -->|"imports"| CORE
    R_RULES_CONTRACTS -->|"imports"| CORE
    R_RULES_DATAFLOW -->|"imports"| CORE

    %% === CRITICAL: RECIPE → PLANNER (deferred only) ===
    R_RULES_CONTRACTS -.->|"DEFERRED import only<br/>REQ-COMP-009<br/>PHASE/ASSIGNMENT/WP_REQUIRED_KEYS"| P_INIT

    %% === RECIPE → WORKSPACE (deferred) ===
    R_CONTRACTS -.->|"deferred: DefaultSkillResolver"| WORKSPACE

    %% === TEST DEPS ===
    T_CONFTEST -->|"uses"| P_SCHEMA
    T_SCHEMA -->|"uses"| P_SCHEMA
    T_TYPED -->|"uses"| P_SCHEMA
    T_PIPE -->|"uses"| T_CONFTEST
    T_PIPE -->|"uses"| P_MANIFESTS
    T_MANIFESTS -->|"uses"| T_CONFTEST
    T_VALIDATION -->|"uses"| T_CONFTEST
    T_COMPILER -->|"uses"| T_CONFTEST
    T_RCONTRACTS -->|"validates"| R_RULES_CONTRACTS
    T_RDATAFLOW -->|"validates"| R_RULES_DATAFLOW
    T_CONTRACTS -->|"validates"| R_CONTRACTS
    T_SKILL_CONTRACTS -->|"validates"| SKILL_CONTRACTS_YAML
    T_SKILL_COMPLIANCE -->|"validates"| PLANNER_CONTRACT_YAML

    %% CLASS ASSIGNMENTS %%
    class P_SCHEMA newComponent;
    class T_CONFTEST,T_PIPE,T_SCHEMA,T_TYPED newComponent;
    class P_MANIFESTS,P_VALIDATION,P_INIT handler;
    class P_COMPILER handler;
    class R_CONTRACTS,R_RULES_CONTRACTS,R_RULES_DATAFLOW phase;
    class R_ANALYSIS,R_REGISTRY,R_SCHEMA,R_IO,R_STALENESS stateNode;
    class SKILL_CONTRACTS_YAML,PLANNER_CONTRACT_YAML output;
    class T_MANIFESTS,T_VALIDATION,T_COMPILER,T_RCONTRACTS,T_RDATAFLOW,T_CONTRACTS,T_SKILL_CONTRACTS,T_SKILL_COMPLIANCE detector;
    class CORE,WORKSPACE cli;
    class STDLIB integration;
```

Closes #1305

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260426-121730-405715/.autoskillit/temp/rectify/rectify_planner_schema_contract_immunity_2026-04-26_121730.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| rectify | 4.1k | 13.8k | 777.5k | 64.7k | 1 | 6m 44s |
| dry_walkthrough | 124 | 7.6k | 544.4k | 34.6k | 1 | 3m 40s |
| **Total** | 4.2k | 21.3k | 1.3M | 99.2k | | 10m 25s |