### PR TITLE
Rectify: ci_event Derivation — Decouple merge_group From Event Filter

### DIFF
--- a/src/autoskillit/execution/merge_queue.py
+++ b/src/autoskillit/execution/merge_queue.py
@@ -799,6 +799,8 @@ def _has_merge_group_trigger(text: str) -> bool:
         return "merge_group" in text
     if not isinstance(parsed, dict):
         return False
+    # PyYAML (YAML 1.1) parses the bare key `on` as boolean True.
+    # Accept both to be safe.
     on_value = parsed.get(True, parsed.get("on"))
     if on_value == "merge_group":
         return True

--- a/src/autoskillit/execution/merge_queue.py
+++ b/src/autoskillit/execution/merge_queue.py
@@ -13,7 +13,7 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Any, TypedDict, assert_never
+from typing import Any, Literal, TypedDict, assert_never
 
 import httpx
 
@@ -786,6 +786,29 @@ def _push_trigger_applies_to_branch(text: str, branch: str) -> bool:
     return True
 
 
+def _has_merge_group_trigger(text: str) -> bool:
+    """Return True if the workflow declares a merge_group trigger.
+
+    Parses YAML to inspect the on: key rather than relying on substring
+    matching, which can false-positive on comments or shell strings.
+    Falls back to substring heuristic on YAML parse failure.
+    """
+    try:
+        parsed = load_yaml(text)
+    except YAMLError:
+        return "merge_group" in text
+    if not isinstance(parsed, dict):
+        return False
+    on_value = parsed.get(True, parsed.get("on"))
+    if on_value == "merge_group":
+        return True
+    if isinstance(on_value, list):
+        return "merge_group" in on_value
+    if isinstance(on_value, dict):
+        return "merge_group" in on_value
+    return False
+
+
 _RATE_LIMIT_MAX_ATTEMPTS = 3
 _RATE_LIMIT_SECONDARY_MARKER = "secondary rate limit"
 
@@ -835,10 +858,9 @@ async def fetch_repo_merge_state(
     - ``merge_group_trigger``: at least one CI workflow declares the
       ``merge_group`` event trigger (bool).
     - ``auto_merge_available``: the repository has auto-merge enabled (bool).
-    - ``ci_event``: the recommended CI event to poll — ``"push"`` when any
-      workflow declares a push trigger, ``"merge_group"`` when only merge_group
-      triggers are found, or ``None`` when no push/merge_group triggers exist
-      (ci.py scope.event=None matches any trigger).
+    - ``ci_event``: ``"push"`` when any workflow declares a push trigger
+      that fires for the given branch, or ``None`` otherwise (match-any —
+      ci.py scope.event=None lets head_sha provide correctness).
 
     Null-handling:
     - ``mergeQueue is null`` → ``queue_available: False``  (no queue)
@@ -912,18 +934,12 @@ async def fetch_repo_merge_state(
             text = blob.get("text")
             if text is None:
                 continue  # binary or oversized blob — skip
-            if "merge_group" in text:
+            if _has_merge_group_trigger(text):
                 merge_group_trigger = True
             if _push_trigger_applies_to_branch(text, branch):
                 has_push_trigger = True
 
-    # Derive ci_event: prefer push for historical compatibility when both are present.
-    if has_push_trigger:
-        ci_event: str | None = "push"
-    elif merge_group_trigger:
-        ci_event = "merge_group"
-    else:
-        ci_event = None  # schedule-only or workflow_dispatch-only: match any
+    ci_event: Literal["push"] | None = "push" if has_push_trigger else None
 
     return {
         "queue_available": queue_available,

--- a/src/autoskillit/recipe/rules_ci.py
+++ b/src/autoskillit/recipe/rules_ci.py
@@ -381,3 +381,33 @@ def _check_wait_for_merge_queue_routing_conforms_to_expected_targets(
                 )
             )
     return findings
+
+
+@semantic_rule(
+    name="ci-event-literal-merge-group",
+    description=(
+        "Flags wait_for_ci steps that hardcode event='merge_group' — use context.ci_event instead"
+    ),
+    severity=Severity.ERROR,
+)
+def _check_ci_event_literal_merge_group(ctx: ValidationContext) -> list[RuleFinding]:
+    """Flag wait_for_ci steps that hardcode event='merge_group'."""
+    findings: list[RuleFinding] = []
+    for name, step in ctx.recipe.steps.items():
+        if step.tool != "wait_for_ci":
+            continue
+        event_value = (step.with_args or {}).get("event", "")
+        if event_value == "merge_group":
+            findings.append(
+                RuleFinding(
+                    rule="ci-event-literal-merge-group",
+                    severity=Severity.ERROR,
+                    step_name=name,
+                    message=(
+                        "wait_for_ci must not hardcode event='merge_group'. "
+                        "Use context.ci_event (which is 'push' or null) for pre-queue CI, "
+                        "or add a lifecycle-aware condition for in-queue CI."
+                    ),
+                )
+            )
+    return findings

--- a/src/autoskillit/recipe/rules_ci.py
+++ b/src/autoskillit/recipe/rules_ci.py
@@ -396,7 +396,7 @@ def _check_ci_event_literal_merge_group(ctx: ValidationContext) -> list[RuleFind
     for name, step in ctx.recipe.steps.items():
         if step.tool != "wait_for_ci":
             continue
-        event_value = (step.with_args or {}).get("event", "")
+        event_value = (step.with_args or {}).get("event")
         if event_value == "merge_group":
             findings.append(
                 RuleFinding(

--- a/tests/execution/test_check_repo_merge_state.py
+++ b/tests/execution/test_check_repo_merge_state.py
@@ -261,9 +261,6 @@ async def test_ci_event_is_always_push_or_none(
     )
     result = await fetch_repo_merge_state(owner="o", repo="r", branch=branch, token=None)
     assert result["ci_event"] == expected_ci_event
-    assert result["ci_event"] in ("push", None), (
-        f"ci_event must be 'push' or None, got {result['ci_event']!r}"
-    )
 
 
 @pytest.mark.anyio

--- a/tests/execution/test_check_repo_merge_state.py
+++ b/tests/execution/test_check_repo_merge_state.py
@@ -122,15 +122,14 @@ def test_repo_state_query_is_distinct_module_constant_from_pr_state_query():
 async def test_check_repo_merge_state_returns_merge_group_as_ci_event(
     httpx_mock, merge_group_only_repo_state
 ):
-    """check_repo_merge_state must derive ci_event='merge_group' when the only
-    workflow trigger is merge_group. This capture is what ci_watch reads to avoid
-    the event='push' timeout on repos that only trigger on merge_group."""
+    """merge_group-only repo: ci_event must be None (match-any via head_sha), not 'merge_group'.
+    merge_group_trigger remains True for queue routing."""
     httpx_mock.add_response(
         url="https://api.github.com/graphql",
         json=merge_group_only_repo_state["graphql_response"],
     )
     result = await fetch_repo_merge_state(owner="o", repo="r", branch="main", token=None)
-    assert result["ci_event"] == "merge_group"
+    assert result["ci_event"] is None
     assert result["merge_group_trigger"] is True
 
 
@@ -201,6 +200,87 @@ async def test_push_trigger_branch_filter_excludes_feature_branch(httpx_mock):
         token=None,
     )
     assert result["ci_event"] is None
+
+
+@pytest.mark.anyio
+async def test_push_excluded_with_merge_group_present_returns_none(httpx_mock):
+    """When push excludes the branch but merge_group exists, ci_event must be None (match-any)."""
+    workflow_text = textwrap.dedent("""\
+        on:
+          push:
+            branches:
+              - main
+              - stable
+          pull_request:
+            branches: [main, integration, stable]
+          merge_group:
+    """)
+    httpx_mock.add_response(
+        url="https://api.github.com/graphql",
+        json=_make_repo_state_response([("tests.yml", workflow_text)]),
+    )
+    result = await fetch_repo_merge_state(
+        owner="org",
+        repo="repo",
+        branch="feature/impl-20260401-123456",
+        token=None,
+    )
+    assert result["ci_event"] is None
+    assert result["merge_group_trigger"] is True
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "workflow_text, branch, expected_ci_event",
+    [
+        ("on: [push, merge_group]", "main", "push"),
+        ("on:\n  push:\n    branches: [main]\n  merge_group:", "main", "push"),
+        ("on:\n  push:\n    branches: [main]\n  merge_group:", "feature/x", None),
+        ("on: [merge_group]", "feature/x", None),
+        ("on: [pull_request]", "feature/x", None),
+        ("on:\n  schedule:\n    - cron: '0 0 * * *'", "main", None),
+        ("on: push", "any-branch", "push"),
+    ],
+    ids=[
+        "push_and_mg_push_applies",
+        "push_branches_match_with_mg",
+        "push_excluded_mg_present",
+        "mg_only",
+        "pr_only",
+        "schedule_only",
+        "push_no_filter",
+    ],
+)
+async def test_ci_event_is_always_push_or_none(
+    httpx_mock, workflow_text, branch, expected_ci_event
+):
+    """ci_event must only ever be 'push' or None — never 'merge_group' or any other value."""
+    httpx_mock.add_response(
+        url="https://api.github.com/graphql",
+        json=_make_repo_state_response([("tests.yml", workflow_text)]),
+    )
+    result = await fetch_repo_merge_state(owner="o", repo="r", branch=branch, token=None)
+    assert result["ci_event"] == expected_ci_event
+    assert result["ci_event"] in ("push", None), (
+        f"ci_event must be 'push' or None, got {result['ci_event']!r}"
+    )
+
+
+@pytest.mark.anyio
+async def test_merge_group_in_comment_is_not_detected(httpx_mock):
+    """A YAML comment containing 'merge_group' must not set merge_group_trigger."""
+    workflow_text = textwrap.dedent("""\
+        # merge_group is not enabled for this repo
+        on:
+          push:
+            branches: [main]
+    """)
+    httpx_mock.add_response(
+        url="https://api.github.com/graphql",
+        json=_make_repo_state_response([("tests.yml", workflow_text)]),
+    )
+    result = await fetch_repo_merge_state(owner="o", repo="r", branch="main", token=None)
+    assert result["merge_group_trigger"] is False
 
 
 @pytest.mark.anyio

--- a/tests/execution/test_push_trigger_applies.py
+++ b/tests/execution/test_push_trigger_applies.py
@@ -1,8 +1,11 @@
-"""Unit tests for _push_trigger_applies_to_branch — the branch-aware push trigger parser."""
+"""Unit tests for _push_trigger_applies_to_branch and _has_merge_group_trigger."""
 
 import pytest
 
-from autoskillit.execution.merge_queue import _push_trigger_applies_to_branch
+from autoskillit.execution.merge_queue import (
+    _has_merge_group_trigger,
+    _push_trigger_applies_to_branch,
+)
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
@@ -58,3 +61,37 @@ def test_no_push_trigger_returns_false():
 def test_yaml_parse_failure_falls_back_to_heuristic_safe():
     # Invalid YAML that doesn't contain any push trigger substrings
     assert _push_trigger_applies_to_branch(": [\n", "main") is False
+
+
+# ---------------------------------------------------------------------------
+# _has_merge_group_trigger tests
+# ---------------------------------------------------------------------------
+
+
+def test_merge_group_in_on_list():
+    assert _has_merge_group_trigger("on: [push, merge_group]") is True
+
+
+def test_merge_group_as_dict_key():
+    assert _has_merge_group_trigger("on:\n  merge_group:\n  push:") is True
+
+
+def test_merge_group_scalar():
+    assert _has_merge_group_trigger("on: merge_group") is True
+
+
+def test_no_merge_group_trigger():
+    assert _has_merge_group_trigger("on: [push, pull_request]") is False
+
+
+def test_merge_group_in_comment_only():
+    assert _has_merge_group_trigger("# merge_group\non: push") is False
+
+
+def test_merge_group_in_shell_string():
+    text = "on: push\njobs:\n  test:\n    steps:\n      - run: echo merge_group"
+    assert _has_merge_group_trigger(text) is False
+
+
+def test_yaml_parse_failure_falls_back_to_heuristic():
+    assert _has_merge_group_trigger("{invalid yaml merge_group") is True

--- a/tests/recipe/test_rules_ci.py
+++ b/tests/recipe/test_rules_ci.py
@@ -709,3 +709,67 @@ def test_bundled_recipes_no_runs_guarded() -> None:
             f"Recipe '{yaml_path.stem}' has unguarded no_runs paths: "
             + ", ".join(f.message for f in no_runs_findings)
         )
+
+
+# ---------------------------------------------------------------------------
+# ci-event-literal-merge-group rule tests
+# ---------------------------------------------------------------------------
+
+_CI_EVENT_MG_RULE = "ci-event-literal-merge-group"
+
+
+def test_wait_for_ci_with_literal_merge_group_event_is_flagged() -> None:
+    """wait_for_ci with event='merge_group' must trigger ci-event-literal-merge-group ERROR."""
+    steps = {
+        "ci_watch": RecipeStep(
+            tool="wait_for_ci",
+            with_args={"branch": "main", "event": "merge_group"},
+        ),
+    }
+    recipe = _make_recipe(steps)
+    findings = run_semantic_rules(recipe)
+    mg_findings = [f for f in findings if f.rule == _CI_EVENT_MG_RULE]
+    assert len(mg_findings) == 1
+    assert mg_findings[0].severity == Severity.ERROR
+    assert mg_findings[0].step_name == "ci_watch"
+    assert "merge_group" in mg_findings[0].message
+
+
+def test_wait_for_ci_with_push_event_not_flagged() -> None:
+    """wait_for_ci with event='push' must not trigger ci-event-literal-merge-group."""
+    steps = {
+        "ci_watch": RecipeStep(
+            tool="wait_for_ci",
+            with_args={"branch": "main", "event": "push"},
+        ),
+    }
+    recipe = _make_recipe(steps)
+    findings = run_semantic_rules(recipe)
+    mg_findings = [f for f in findings if f.rule == _CI_EVENT_MG_RULE]
+    assert len(mg_findings) == 0
+
+
+def test_wait_for_ci_without_event_not_flagged() -> None:
+    """wait_for_ci with no event arg must not trigger ci-event-literal-merge-group."""
+    steps = {
+        "ci_watch": RecipeStep(
+            tool="wait_for_ci",
+            with_args={"branch": "main"},
+        ),
+    }
+    recipe = _make_recipe(steps)
+    findings = run_semantic_rules(recipe)
+    mg_findings = [f for f in findings if f.rule == _CI_EVENT_MG_RULE]
+    assert len(mg_findings) == 0
+
+
+def test_bundled_recipes_no_literal_merge_group_event() -> None:
+    """No bundled recipe must hardcode event='merge_group' in a wait_for_ci step."""
+    for yaml_path in sorted(builtin_recipes_dir().glob("*.yaml")):
+        recipe = load_recipe(yaml_path)
+        findings = run_semantic_rules(recipe)
+        mg_findings = [f for f in findings if f.rule == _CI_EVENT_MG_RULE]
+        assert len(mg_findings) == 0, (
+            f"Recipe '{yaml_path.stem}' hardcodes event='merge_group': "
+            + ", ".join(f.message for f in mg_findings)
+        )


### PR DESCRIPTION
## Summary

The `ci_event` derivation in `fetch_repo_merge_state` (`merge_queue.py`) conflated two separate concerns: CI event filtering and queue routing. When `push` didn't apply to the feature branch but a `merge_group` trigger existed in any workflow file, the derivation returned `"merge_group"` as `ci_event` — structurally wrong, since `merge_group` CI runs only fire inside the merge queue, guaranteeing zero results when used for pre-queue feature branch polling.

The architectural fix decouples these concerns: `ci_event` becomes binary (`"push"` or `None`), and `merge_group_trigger` remains a separate boolean for queue routing. A `Literal["push"] | None` type annotation makes the type system enforce this invariant. Companion changes upgrade the `merge_group` trigger detection from substring matching to YAML-parsed analysis (matching the quality level of the push trigger detection added in PR #1278), and add parametrized guard tests that make the class of bug structurally impossible to reintroduce.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START])
    END_OK([COMPLETE])
    END_ERR([ERROR])

    %% ============================================================
    %% PHASE A: fetch_repo_merge_state
    %% ============================================================
    subgraph PhaseA ["● fetch_repo_merge_state — Repo State Detection"]
        direction TB
        A1["Init HTTP client<br/>━━━━━━━━━━<br/>attempt=0..2"]
        A2["POST _REPO_STATE_QUERY<br/>━━━━━━━━━━<br/>owner/repo/branch → GraphQL"]
        A3{"Rate limited?<br/>429 or secondary<br/>403?"}
        A4["Sleep Retry-After<br/>━━━━━━━━━━<br/>or jitter backoff<br/>attempt++"]
        A5{"Max attempts<br/>exceeded?"}
        A6["Parse repo_data<br/>━━━━━━━━━━<br/>mergeQueue / autoMergeAllowed<br/>object.entries (workflows)"]
        A7{"GHES compat:<br/>autoMergeAllowed<br/>field error?"}

        subgraph TriggerScan ["Workflow Trigger Scan (per .github/workflows/*.yml)"]
            direction LR
            B1{"blob.text<br/>null?"}
            B2["● _has_merge_group_trigger<br/>━━━━━━━━━━<br/>load_yaml → on: key<br/>YAML parse fallback"]
            B3{"YAML parse<br/>success?"}
            B4["Check on: dict/list/scalar<br/>━━━━━━━━━━<br/>merge_group in on_value"]
            B5["Substring fallback<br/>━━━━━━━━━━<br/>'merge_group' in text"]
            B6["● _push_trigger_applies_to_branch<br/>━━━━━━━━━━<br/>load_yaml → push: branches filter<br/>fnmatch glob patterns"]
            B7{"YAML parse<br/>success?"}
            B8["branches filter<br/>━━━━━━━━━━<br/>fnmatch(branch, pat)<br/>or branches-ignore"]
            B9["Heuristic fallback<br/>━━━━━━━━━━<br/>'on: [push' | 'push:' in text"]
            B10(["set merge_group_trigger=True"])
            B11(["set has_push_trigger=True"])
        end

        A8["● Derive ci_event<br/>━━━━━━━━━━<br/>ci_event='push' if has_push_trigger<br/>else None"]
        A9[/"Return dict:<br/>queue_available, merge_group_trigger<br/>auto_merge_available, ci_event"/]
    end

    %% ============================================================
    %% PHASE C: DefaultMergeQueueWatcher.wait() — Polling Loop
    %% ============================================================
    subgraph PhaseC ["● DefaultMergeQueueWatcher.wait() — Polling Loop"]
        direction TB
        C1["Init counters<br/>━━━━━━━━━━<br/>deadline / stall_retries<br/>not_in_queue_cycles / ever_enrolled"]
        C2{"time < deadline?"}
        C3["● _fetch_pr_and_queue_state<br/>━━━━━━━━━━<br/>GraphQL _QUERY<br/>PR + queue entries"]
        C4{"fetch<br/>failed?"}
        C5["sleep(poll_interval)<br/>retry"]
        C6{"in_queue or<br/>auto_merge_present?"}
        C7["ever_enrolled = True"]
        C8{"in_queue?"}
        C9["Reset not_in_queue_cycles=0<br/>inconclusive_count=0"]
        C10{"queue_state ==<br/>UNMERGEABLE?"}
        C11["not_in_queue_cycles++"]
        C12["_classify_pr_state<br/>━━━━━━━━━━<br/>positive-signal classifier<br/>ever_enrolled context"]
        C13{"CIStillRunning<br/>raised?"}
        C14{"NoPositiveSignal<br/>raised?"}
        C15{"confirmation<br/>window met?"}
        C16["inconclusive_count++"]
        C17{"inconclusive >=<br/>max_inconclusive?"}

        subgraph TerminalDispatch ["Post-Confirmation Terminal Dispatch"]
            direction TB
            D1{"MERGED?"}
            D2{"CLOSED?"}
            D3{"STALLED?"}
            D4{"stall within<br/>grace period?"}
            D5{"stall_retries <<br/>max_stall_retries?"}
            D6["● _toggle_auto_merge<br/>━━━━━━━━━━<br/>auto_merge_available?<br/>→ toggle or direct enqueue"]
            D7["Exp backoff<br/>not_in_queue_cycles=0"]
        end
    end

    %% ============================================================
    %% PHASE D: _classify_pr_state (pure function)
    %% ============================================================
    subgraph PhaseD ["_classify_pr_state — Positive-Signal Classifier"]
        direction TB
        E1{"merged == True?"}
        E2{"state == CLOSED?"}
        E3{"checks_state in<br/>FAILURE/ERROR?"}
        E4{"_is_positive_stall?<br/>auto_merge_enabled_at<br/>+ CLEAN/HAS_HOOKS"}
        E5{"mergeable ==<br/>CONFLICTING?"}
        E6{"_is_positive_dropped_healthy?<br/>ever_enrolled + OPEN +<br/>CLEAN + no auto_merge"}
        E7{"_is_not_enrolled?<br/>never enrolled +<br/>OPEN + CLEAN"}
        E8{"checks_state in<br/>PENDING/EXPECTED?"}
        E9[/"raise NoPositiveSignal"/]
        MERGED_R(["→ PRState.MERGED"])
        EJECTED_R(["→ PRState.EJECTED / EJECTED_CI_FAILURE"])
        STALLED_R(["→ PRState.STALLED"])
        CONFLICT_R(["→ PRState.EJECTED (conflicting)"])
        DROPPED_R(["→ PRState.DROPPED_HEALTHY"])
        NOT_ENR_R(["→ PRState.NOT_ENROLLED"])
        CI_RUNNING(["raise CIStillRunning"])
    end

    %% ============================================================
    %% PHASE E: rules_ci.py — CI Semantic Rules (static analysis)
    %% ============================================================
    subgraph PhaseE ["● rules_ci.py — CI Semantic Rule Validation"]
        direction TB
        R1["Iterate recipe steps<br/>━━━━━━━━━━<br/>wait_for_ci / get_ci_status"]
        R2{"● ci-event-literal-merge-group<br/>event == 'merge_group'?"}
        R3["FINDING: ERROR<br/>━━━━━━━━━━<br/>Use context.ci_event instead"]
        R4{"ci-missing-event-scope<br/>'event' in with_args?"}
        R5["FINDING: ERROR<br/>━━━━━━━━━━<br/>Missing event scope"]
        R6{"ci-no-runs-unguarded<br/>no_runs condition?"}
        R7["FINDING: ERROR<br/>━━━━━━━━━━<br/>Add on_result no_runs guard"]
        R8["wait_for_merge_queue steps<br/>━━━━━━━━━━<br/>PRState coverage check (I7)<br/>target conformance (I8)"]
        R9[/"RuleFinding[] returned"/]
    end

    %% ============================================================
    %% TOP-LEVEL FLOW
    %% ============================================================
    START --> A1
    A1 --> A2
    A2 --> A3
    A3 -->|"yes"| A4
    A4 --> A5
    A5 -->|"yes"| END_ERR
    A5 -->|"no"| A2
    A3 -->|"no"| A6
    A6 --> A7
    A7 -->|"yes: auto_merge=False"| TriggerScan
    A7 -->|"no"| TriggerScan

    B1 -->|"null — skip"| B1
    B1 -->|"has text"| B2
    B2 --> B3
    B3 -->|"yes"| B4
    B3 -->|"no"| B5
    B4 -->|"merge_group found"| B10
    B5 -->|"substring match"| B10
    B2 --> B6
    B6 --> B7
    B7 -->|"yes"| B8
    B7 -->|"no"| B9
    B8 -->|"branch matches"| B11
    B9 -->|"heuristic match"| B11

    TriggerScan --> A8
    A8 --> A9
    A9 --> END_OK

    %% Polling loop flow
    C1 --> C2
    C2 -->|"deadline exceeded"| END_ERR
    C2 -->|"within deadline"| C3
    C3 --> C4
    C4 -->|"yes"| C5
    C5 --> C2
    C4 -->|"no"| C6
    C6 -->|"yes"| C7
    C7 --> C8
    C6 -->|"no"| C8
    C8 -->|"yes — in queue"| C9
    C9 --> C10
    C10 -->|"yes"| END_ERR
    C10 -->|"no"| C5
    C8 -->|"no"| C11
    C11 --> C12
    C12 --> PhaseD
    PhaseD --> C13
    C13 -->|"yes"| C5
    C13 -->|"no"| C14
    C14 -->|"yes"| C15
    C15 -->|"window not met"| C5
    C15 -->|"met"| C16
    C16 --> C17
    C17 -->|"yes"| END_ERR
    C17 -->|"no"| C5
    C14 -->|"no — classified"| TerminalDispatch

    D1 -->|"yes"| END_OK
    D1 -->|"no"| D2
    D2 -->|"yes"| END_ERR
    D2 -->|"no"| D3
    D3 -->|"no — other terminal"| END_ERR
    D3 -->|"yes"| D4
    D4 -->|"yes — too soon"| C5
    D4 -->|"no"| D5
    D5 -->|"yes"| D6
    D6 --> D7
    D7 --> C2
    D5 -->|"no — max retries"| END_ERR

    %% Classifier internal flow
    E1 -->|"yes"| MERGED_R
    E1 -->|"no"| E2
    E2 -->|"yes"| E3
    E3 -->|"CI failure"| EJECTED_R
    E3 -->|"no"| EJECTED_R
    E2 -->|"no"| E3
    E3 -->|"open + failure"| EJECTED_R
    E3 -->|"no"| E4
    E4 -->|"yes"| STALLED_R
    E4 -->|"no"| E5
    E5 -->|"yes"| CONFLICT_R
    E5 -->|"no"| E6
    E6 -->|"yes"| DROPPED_R
    E6 -->|"no"| E7
    E7 -->|"yes"| NOT_ENR_R
    E7 -->|"no"| E8
    E8 -->|"yes"| CI_RUNNING
    E8 -->|"no"| E9

    %% Rules validation flow
    R1 --> R2
    R2 -->|"yes"| R3
    R2 -->|"no"| R4
    R3 --> R4
    R4 -->|"missing"| R5
    R4 -->|"present"| R6
    R5 --> R6
    R6 -->|"unguarded"| R7
    R6 -->|"guarded"| R8
    R7 --> R8
    R8 --> R9

    %% CLASS ASSIGNMENTS %%
    class START,END_OK,END_ERR terminal;
    class A1,A2,A6,A8 handler;
    class A3,A5,C4,C6,C8,C10,C13,C14,C15,C17 stateNode;
    class A4,C5,C9,C11,C16,D7 phase;
    class A7 detector;
    class B1,B3,B7 stateNode;
    class B2,B6,C3,C12,D6,R1 handler;
    class B4,B8 phase;
    class B5,B9 detector;
    class B10,B11,A9,A9,R9 output;
    class C1,C7 stateNode;
    class D1,D2,D3,D4,D5 stateNode;
    class MERGED_R,EJECTED_R,STALLED_R,CONFLICT_R,DROPPED_R,NOT_ENR_R,CI_RUNNING,E9 output;
    class E1,E2,E3,E4,E5,E6,E7,E8 stateNode;
    class R2,R3,R4,R5,R6,R7,R8 detector;
    class TriggerScan,PhaseD,PhaseE phase;
```

### Error/Resilience Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 52, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;

    %% ── IMPORT-TIME INVARIANTS ─────────────────────────────────────────────
    subgraph ImportGuards ["IMPORT-TIME INVARIANTS — fail on process startup"]
        IG1["● Schema Drift Guard<br/>━━━━━━━━━━<br/>_QUERY_FIELD_MAP keys ↔ PRFetchState keys<br/>RuntimeError with diff on mismatch"]
        IG2["● Query Field Guard<br/>━━━━━━━━━━<br/>Every _QUERY_FIELD_MAP key appears in _QUERY<br/>RuntimeError on missing GraphQL field"]
        IG3["assert 'CLEAN' in KNOWN_MQ_MERGE_STATE_STATUSES<br/>━━━━━━━━━━<br/>Frozenset drift guard — AssertionError on import"]
    end

    T_ABORT([PROCESS ABORT<br/>import RuntimeError / AssertionError])

    IG1 -->|mismatch| T_ABORT
    IG2 -->|missing field| T_ABORT
    IG3 -->|drift| T_ABORT

    class IG1,IG2,IG3 detector;
    class T_ABORT terminal;

    %% ── YAML TRIGGER PARSING ───────────────────────────────────────────────
    subgraph YAMLParsing ["YAML TRIGGER ANALYSIS (● merge_queue.py — upgraded from text heuristics)"]
        PUSH_PARSE["● _push_trigger_applies_to_branch<br/>━━━━━━━━━━<br/>Parse workflow YAML<br/>Check push trigger + branch filters<br/>glob pattern matching"]
        MG_PARSE["● _has_merge_group_trigger<br/>━━━━━━━━━━<br/>Parse workflow YAML<br/>Detect merge_group trigger"]
        PUSH_YAML_FAIL["YAMLError — push path<br/>━━━━━━━━━━<br/>Conservative fallback → False<br/>(no false positives)"]
        MG_YAML_FAIL["YAMLError — merge_group path<br/>━━━━━━━━━━<br/>Heuristic substring fallback<br/>fail-open: True if string present"]
        CI_EVENT["● ci_event derivation<br/>━━━━━━━━━━<br/>'push' if branch matches<br/>None if no match / merge_group only<br/>None = match-any sentinel<br/>NEVER 'merge_group' literal"]
        PUSH_PARSE -->|YAMLError| PUSH_YAML_FAIL
        MG_PARSE -->|YAMLError| MG_YAML_FAIL
        PUSH_PARSE -->|success| CI_EVENT
        MG_PARSE -->|success| CI_EVENT
        PUSH_YAML_FAIL --> CI_EVENT
        MG_YAML_FAIL --> CI_EVENT
    end

    class PUSH_PARSE,MG_PARSE,CI_EVENT handler;
    class PUSH_YAML_FAIL,MG_YAML_FAIL gap;

    %% ── FETCH LAYER ────────────────────────────────────────────────────────
    subgraph FetchLayer ["FETCH LAYER (● fetch_repo_merge_state — single GraphQL round-trip)"]
        GQL_CALL["Single GraphQL Call<br/>━━━━━━━━━━<br/>mergeQueue + autoMergeAllowed<br/>+ workflow blobs + ci_event"]
        HTTP_ERR["HTTP 4xx/5xx<br/>━━━━━━━━━━<br/>raise_for_status() propagates up"]
        RATE_429["HTTP 429 / secondary 403<br/>━━━━━━━━━━<br/>Rate-limit detected<br/>_is_secondary_rate_limit() safe-default on body-read error"]
        RATE_RETRY["Rate-Limit Retry<br/>━━━━━━━━━━<br/>max 3 attempts<br/>Retry-After header priority<br/>full-jitter exp backoff fallback<br/>ValueError/AttributeError on parse → silently ignored"]
        GHES_DEGRADE["GHES Compatibility<br/>━━━━━━━━━━<br/>autoMergeAllowed field absent<br/>→ auto_merge_available=False<br/>(graceful degradation, no raise)"]
        GQL_ERR["GraphQL errors / null pullRequest<br/>━━━━━━━━━━<br/>→ RuntimeError (propagates up)"]
        DATE_ERR["ISO date parse failure<br/>━━━━━━━━━━<br/>→ RuntimeError from ValueError<br/>(cause chaining)"]
        BLOB_NULL["Blob.text = None<br/>━━━━━━━━━━<br/>binary / oversized file<br/>→ merge_group_trigger=False<br/>ci_event=None (not a crash)"]
        MISSING_DIR["object=None (no .github/workflows)<br/>━━━━━━━━━━<br/>→ merge_group_trigger=False<br/>queue_available=False<br/>ci_event=None (not a crash)"]

        GQL_CALL -->|"429 / secondary 403"| RATE_429
        RATE_429 --> RATE_RETRY
        RATE_RETRY -->|attempt < 3| GQL_CALL
        RATE_RETRY -->|exhausted| HTTP_ERR
        GQL_CALL -->|"autoMergeAllowed absent (GHES)"| GHES_DEGRADE
        GQL_CALL -->|"GraphQL errors / null"| GQL_ERR
        GQL_CALL -->|invalid date| DATE_ERR
        GQL_CALL -->|null Blob.text| BLOB_NULL
        GQL_CALL -->|missing workflows dir| MISSING_DIR
        GQL_CALL -->|4xx/5xx| HTTP_ERR
    end

    class GQL_CALL handler;
    class HTTP_ERR,RATE_429,GQL_ERR,DATE_ERR,BLOB_NULL,MISSING_DIR gap;
    class RATE_RETRY,GHES_DEGRADE output;

    %% ── POLL LOOP ──────────────────────────────────────────────────────────
    subgraph PollLoop ["WAIT() POLL LOOP — never raises (deadline-bounded)"]
        INPUT_VAL["Input validation<br/>━━━━━━━━━━<br/>pr_number / repo required<br/>→ structured dict on fail (no raise)"]
        POLL_ITER["Poll iteration<br/>━━━━━━━━━━<br/>_fetch_pr_and_queue_state"]
        FETCH_EXC["Any fetch exception<br/>━━━━━━━━━━<br/>log WARNING + sleep poll_interval<br/>continue (no count limit — only deadline)"]
        CLASSIFY["_classify_pr_state<br/>━━━━━━━━━━<br/>→ PRClassification or raises<br/>ClassifierInconclusive"]
        CB_RUNNING["CIStillRunning caught<br/>━━━━━━━━━━<br/>sleep + continue<br/>NO budget consumed"]
        CB_SIGNAL["NoPositiveSignal caught<br/>━━━━━━━━━━<br/>inconclusive_count++"]
        INCONC_CB{"inconclusive_count<br/>≥ max (5)?"}
        ASSERT_NEVER["assert_never(terminal)<br/>━━━━━━━━━━<br/>Exhaustiveness guard<br/>mypy + runtime on unknown PRState"]

        INPUT_VAL -->|valid| POLL_ITER
        POLL_ITER -->|exception| FETCH_EXC
        FETCH_EXC -->|retry| POLL_ITER
        POLL_ITER -->|success| CLASSIFY
        CLASSIFY -->|CIStillRunning| CB_RUNNING
        CB_RUNNING -->|sleep| POLL_ITER
        CLASSIFY -->|NoPositiveSignal| CB_SIGNAL
        CB_SIGNAL --> INCONC_CB
        INCONC_CB -->|"No — keep polling"| POLL_ITER
        CLASSIFY -->|unknown PRState| ASSERT_NEVER
    end

    class INPUT_VAL,ASSERT_NEVER detector;
    class POLL_ITER,CLASSIFY handler;
    class FETCH_EXC,CB_RUNNING,CB_SIGNAL gap;
    class INCONC_CB stateNode;

    %% ── STALL RECOVERY ─────────────────────────────────────────────────────
    subgraph StallRecovery ["STALL RECOVERY (● wait() — inside poll loop)"]
        CONF_WINDOW["not-in-queue confirmation window<br/>━━━━━━━━━━<br/>N consecutive cycles required<br/>before acting (API propagation guard)"]
        TOGGLE_OP["_toggle_auto_merge<br/>━━━━━━━━━━<br/>disable → re-enable auto-merge<br/>ValueError on empty pr_node_id"]
        TOGGLE_FAIL["Toggle exception<br/>━━━━━━━━━━<br/>log WARNING<br/>stall_retries++ — non-fatal<br/>budget still consumed"]
        STALL_BUDGET{"stall_retries<br/>< max (3)?"}
        STALL_BACKOFF["Capped exp backoff<br/>━━━━━━━━━━<br/>min(30 × 2^attempt, 120)s<br/>confirmation window reset"]

        CONF_WINDOW -->|"N cycles confirmed"| TOGGLE_OP
        TOGGLE_OP -->|exception| TOGGLE_FAIL
        TOGGLE_FAIL --> STALL_BUDGET
        TOGGLE_OP -->|success| STALL_BUDGET
        STALL_BUDGET -->|"Yes — retry"| STALL_BACKOFF
        STALL_BACKOFF --> CONF_WINDOW
    end

    class CONF_WINDOW detector;
    class TOGGLE_OP handler;
    class TOGGLE_FAIL gap;
    class STALL_BUDGET,STALL_BACKOFF stateNode;

    %% ── PUBLIC API — NEVER RAISES ──────────────────────────────────────────
    subgraph PublicAPI ["PUBLIC API — Never Raises (structured dict returns)"]
        WAIT_API["● wait()<br/>━━━━━━━━━━<br/>All paths → structured result dict<br/>pr_state: merged | closed | dropped<br/>dropped_healthy | stalled | timeout"]
        TOGGLE_API["toggle()<br/>━━━━━━━━━━<br/>broad except Exception<br/>→ {success: False, error: ...}"]
        ENQUEUE_API["enqueue()<br/>━━━━━━━━━━<br/>broad except Exception<br/>→ {success: False, error: ...}"]
    end

    class WAIT_API,TOGGLE_API,ENQUEUE_API output;

    %% ── RECIPE SEMANTIC RULES ──────────────────────────────────────────────
    subgraph RecipeRules ["RECIPE SEMANTIC VALIDATION (● rules_ci.py — pre-execution guards)"]
        R_EVENT["● ci-missing-event-scope [ERROR]<br/>━━━━━━━━━━<br/>wait_for_ci / get_ci_status missing<br/>event: param → silent no-results on<br/>feature branches"]
        R_LITMERGE["● ci-event-literal-merge-group [ERROR]<br/>━━━━━━━━━━<br/>event='merge_group' hardcoded<br/>→ must use context.ci_event"]
        R_NORUNS["● ci-no-runs-unguarded [ERROR]<br/>━━━━━━━━━━<br/>on_success / on_result routing<br/>lacks conclusion='no_runs' arm"]
        R_CONFLICT["ci-failure-missing-conflict-gate [ERROR]<br/>━━━━━━━━━━<br/>BFS: wait_for_ci failure path →<br/>resolve-failures without<br/>merge-base / conflict-resolution gate"]
        R_POLLING["ci-polling-inline-shell [WARNING]<br/>━━━━━━━━━━<br/>gh run watch/list in run_cmd<br/>→ use structured wait_for_ci"]
        R_MQ_COV["wait-for-merge-queue-routing<br/>-covers-all-pr-states [ERROR]<br/>━━━━━━━━━━<br/>PRState enum drives required arms<br/>new enum members auto-trigger"]
        R_MQ_CONF["wait-for-merge-queue-routing<br/>-conforms-to-expected-targets [ERROR]<br/>━━━━━━━━━━<br/>fallback + on_failure must route to<br/>register_clone_unconfirmed"]
    end

    class R_EVENT,R_LITMERGE,R_NORUNS,R_CONFLICT,R_MQ_COV,R_MQ_CONF detector;
    class R_POLLING phase;

    %% ── TERMINAL STATES ────────────────────────────────────────────────────
    T_SUCCESS([RESULT: merged / closed / dropped<br/>dropped_healthy / stalled])
    T_TIMEOUT([RESULT: timeout dict])
    T_STRUCTFAIL([STRUCTURED FAILURE DICT<br/>toggle / enqueue failure])
    T_LINT([RECIPE LINT: ERROR / WARNING<br/>blocks recipe execution])

    class T_SUCCESS,T_TIMEOUT,T_STRUCTFAIL,T_LINT terminal;

    %% ── CROSS-SUBGRAPH WIRING ──────────────────────────────────────────────
    YAMLParsing --> FetchLayer
    FetchLayer -->|fetch errors propagate| POLL_ITER
    GQL_ERR -->|RuntimeError| FETCH_EXC
    DATE_ERR -->|RuntimeError| FETCH_EXC
    HTTP_ERR -->|raise_for_status| FETCH_EXC

    PollLoop --> StallRecovery
    POLL_ITER -.->|not-in-queue path| CONF_WINDOW
    STALL_BUDGET -->|"No — exhausted"| POLL_ITER

    INCONC_CB -->|"Yes — timeout"| T_TIMEOUT
    CLASSIFY -->|"terminal: merged/closed/..."| T_SUCCESS
    INPUT_VAL -->|invalid| T_TIMEOUT

    PollLoop --> WAIT_API
    WAIT_API --> T_SUCCESS
    WAIT_API --> T_TIMEOUT
    TOGGLE_API --> T_STRUCTFAIL
    ENQUEUE_API --> T_STRUCTFAIL

    RecipeRules --> T_LINT
```

Closes #1319

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260426-151411-452229/.autoskillit/temp/rectify/rectify_ci_event_derivation_2026-04-26_153300.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| investigate | 98 | 9.5k | 312.1k | 58.5k | 1 | 5m 52s |
| rectify | 79 | 15.1k | 337.1k | 54.4k | 1 | 6m 24s |
| dry_walkthrough | 60 | 9.7k | 232.6k | 37.4k | 1 | 6m 28s |
| implement | 284 | 13.0k | 1.7M | 53.6k | 1 | 5m 56s |
| assess | 176 | 6.0k | 894.3k | 47.7k | 1 | 7m 56s |
| prepare_pr | 68 | 5.3k | 236.9k | 29.7k | 1 | 1m 56s |
| **Total** | 765 | 58.6k | 3.8M | 281.4k | | 34m 34s |