### PR TITLE
Implementation Plan: Reorder Recipe Picker — Bundled Recipes Before Family Recipes

### DIFF
--- a/src/autoskillit/cli/_cook.py
+++ b/src/autoskillit/cli/_cook.py
@@ -27,7 +27,7 @@ def _print_recipes_list() -> None:
         rank = group_rank(r)
         if rank != current_rank:
             current_rank = rank
-            print(f"\n{GROUP_LABELS[rank]}")
+            print(f"\n{GROUP_LABELS.get(rank, str(rank))}")
             print(f"{'NAME':<{name_w}}  {'SOURCE':<{src_w}}  DESCRIPTION")
             print(f"{'-' * name_w}  {'-' * src_w}  {'-' * 11}")
         print(f"{r.name:<{name_w}}  {r.source:<{src_w}}  {r.description}")

--- a/src/autoskillit/cli/_cook.py
+++ b/src/autoskillit/cli/_cook.py
@@ -13,14 +13,7 @@ from autoskillit.cli._terminal import terminal_guard
 
 def _print_recipes_list() -> None:
     """Print available recipes grouped by category to stdout."""
-    from autoskillit.recipe import _group_rank, list_recipes
-
-    _GROUP_LABELS = {
-        0: "Bundled Recipes",
-        1: "Bundled Add-ons",
-        2: "Family Recipes",
-        3: "Experimental",
-    }
+    from autoskillit.recipe import GROUP_LABELS, group_rank, list_recipes
 
     recipes = list_recipes(Path.cwd()).items
     if not recipes:
@@ -31,10 +24,10 @@ def _print_recipes_list() -> None:
     src_w = max(len(r.source) for r in recipes)
     current_rank = -1
     for r in recipes:
-        rank = _group_rank(r)
+        rank = group_rank(r)
         if rank != current_rank:
             current_rank = rank
-            print(f"\n{_GROUP_LABELS[rank]}")
+            print(f"\n{GROUP_LABELS[rank]}")
             print(f"{'NAME':<{name_w}}  {'SOURCE':<{src_w}}  DESCRIPTION")
             print(f"{'-' * name_w}  {'-' * src_w}  {'-' * 11}")
         print(f"{r.name:<{name_w}}  {r.source:<{src_w}}  {r.description}")

--- a/src/autoskillit/cli/_cook.py
+++ b/src/autoskillit/cli/_cook.py
@@ -13,8 +13,7 @@ from autoskillit.cli._terminal import terminal_guard
 
 def _print_recipes_list() -> None:
     """Print available recipes grouped by category to stdout."""
-    from autoskillit.recipe import list_recipes
-    from autoskillit.recipe.io import _group_rank
+    from autoskillit.recipe import _group_rank, list_recipes
 
     _GROUP_LABELS = {
         0: "Bundled Recipes",

--- a/src/autoskillit/cli/_cook.py
+++ b/src/autoskillit/cli/_cook.py
@@ -13,15 +13,15 @@ from autoskillit.cli._terminal import terminal_guard
 
 def _print_recipes_list() -> None:
     """Print available recipes grouped by category to stdout."""
-    from autoskillit.core import RecipeSource
     from autoskillit.recipe import list_recipes
+    from autoskillit.recipe.io import _group_rank
 
-    _GROUP_LABELS = {0: "Family Recipes", 1: "Bundled Recipes", 2: "Experimental"}
-
-    def _rank(r: object) -> int:
-        if r.experimental:  # type: ignore[attr-defined]
-            return 2
-        return 0 if r.source == RecipeSource.PROJECT else 1  # type: ignore[attr-defined]
+    _GROUP_LABELS = {
+        0: "Bundled Recipes",
+        1: "Bundled Add-ons",
+        2: "Family Recipes",
+        3: "Experimental",
+    }
 
     recipes = list_recipes(Path.cwd()).items
     if not recipes:
@@ -32,7 +32,7 @@ def _print_recipes_list() -> None:
     src_w = max(len(r.source) for r in recipes)
     current_rank = -1
     for r in recipes:
-        rank = _rank(r)
+        rank = _group_rank(r)
         if rank != current_rank:
             current_rank = rank
             print(f"\n{_GROUP_LABELS[rank]}")

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -574,7 +574,7 @@ def order(recipe: str | None = None, session_id: str | None = None, *, resume: b
             _build_open_kitchen_prompt,
             _resolve_recipe_input,
         )
-        from autoskillit.recipe.io import _group_rank
+        from autoskillit.recipe import _group_rank
 
         available = list_recipes(Path.cwd()).items
         if not available:

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -574,23 +574,24 @@ def order(recipe: str | None = None, session_id: str | None = None, *, resume: b
             _build_open_kitchen_prompt,
             _resolve_recipe_input,
         )
+        from autoskillit.recipe.io import _group_rank
 
         available = list_recipes(Path.cwd()).items
         if not available:
             print("No recipes found. Run 'autoskillit recipes list' to check.")
             sys.exit(1)
-        _GROUP_HEADERS = {0: "Family Recipes", 1: "Bundled Recipes", 2: "Experimental"}
-
-        def _recipe_rank(r: object) -> int:
-            if r.experimental:  # type: ignore[attr-defined]
-                return 2
-            return 0 if r.source == RecipeSource.PROJECT else 1  # type: ignore[attr-defined]
+        _GROUP_HEADERS = {
+            0: "Bundled Recipes",
+            1: "Bundled Add-ons",
+            2: "Family Recipes",
+            3: "Experimental",
+        }
 
         print("Available recipes:")
         print("  0. Open kitchen (no recipe)")
         current_rank: int = -1
         for i, r in enumerate(available, 1):
-            rank = _recipe_rank(r)
+            rank = _group_rank(r)
             if rank != current_rank:
                 current_rank = rank
                 print(f"\n  {_GROUP_HEADERS[rank]}")

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -574,27 +574,21 @@ def order(recipe: str | None = None, session_id: str | None = None, *, resume: b
             _build_open_kitchen_prompt,
             _resolve_recipe_input,
         )
-        from autoskillit.recipe import _group_rank
+        from autoskillit.recipe import GROUP_LABELS, group_rank
 
         available = list_recipes(Path.cwd()).items
         if not available:
             print("No recipes found. Run 'autoskillit recipes list' to check.")
             sys.exit(1)
-        _GROUP_HEADERS = {
-            0: "Bundled Recipes",
-            1: "Bundled Add-ons",
-            2: "Family Recipes",
-            3: "Experimental",
-        }
 
         print("Available recipes:")
         print("  0. Open kitchen (no recipe)")
         current_rank: int = -1
         for i, r in enumerate(available, 1):
-            rank = _group_rank(r)
+            rank = group_rank(r)
             if rank != current_rank:
                 current_rank = rank
-                print(f"\n  {_GROUP_HEADERS[rank]}")
+                print(f"\n  {GROUP_LABELS[rank]}")
             print(f"  {i}. {r.name}")
         raw = timed_prompt(
             f"Select recipe [0-{len(available)}]:",

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -588,7 +588,7 @@ def order(recipe: str | None = None, session_id: str | None = None, *, resume: b
             rank = group_rank(r)
             if rank != current_rank:
                 current_rank = rank
-                print(f"\n  {GROUP_LABELS[rank]}")
+                print(f"\n  {GROUP_LABELS.get(rank, str(rank))}")
             print(f"  {i}. {r.name}")
         raw = timed_prompt(
             f"Select recipe [0-{len(available)}]:",

--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -137,6 +137,7 @@ from .types import PackDef as PackDef
 from .types import QuotaRefreshTask as QuotaRefreshTask
 from .types import RECIPE_PACK_REGISTRY as RECIPE_PACK_REGISTRY
 from .types import RECIPE_PACK_TAGS as RECIPE_PACK_TAGS
+from .types import CORE_PACKS as CORE_PACKS
 from .types import RESERVED_LOG_RECORD_KEYS as RESERVED_LOG_RECORD_KEYS
 from .types import RETIRED_FEATURES as RETIRED_FEATURES
 from .types import RETIRED_READINESS_TOKENS as RETIRED_READINESS_TOKENS

--- a/src/autoskillit/core/_type_constants.py
+++ b/src/autoskillit/core/_type_constants.py
@@ -31,6 +31,7 @@ __all__ = [
     "RecipePackDef",
     "RECIPE_PACK_REGISTRY",
     "RECIPE_PACK_TAGS",
+    "CORE_PACKS",
     "CATEGORY_TAGS",
     "TOOL_SUBSET_TAGS",
     "ALL_VISIBILITY_TAGS",
@@ -306,6 +307,8 @@ RECIPE_PACK_REGISTRY: dict[str, RecipePackDef] = {
 }
 
 RECIPE_PACK_TAGS: frozenset[str] = frozenset(RECIPE_PACK_REGISTRY.keys())
+
+CORE_PACKS: frozenset[str] = frozenset({"github", "ci", "clone", "telemetry"})
 
 # Maps each MCP tool name to its functional category subset tags.
 # Mirrors the FastMCP @mcp.tool(tags=...) category assignments in the server layer.

--- a/src/autoskillit/recipe/__init__.py
+++ b/src/autoskillit/recipe/__init__.py
@@ -64,11 +64,12 @@ from autoskillit.recipe.identity import (  # noqa: E402
     find_prior_runs,
 )
 from autoskillit.recipe.io import (  # noqa: E402
-    _group_rank,
+    GROUP_LABELS,
     builtin_sub_recipes_dir,
     find_campaign_by_name,
     find_recipe_by_name,
     find_sub_recipe_by_name,
+    group_rank,
     iter_steps_with_context,
     list_campaign_recipes,
     list_recipes,
@@ -106,7 +107,8 @@ from autoskillit.recipe.validator import (  # noqa: E402
 )
 
 __all__ = [
-    "_group_rank",
+    "GROUP_LABELS",
+    "group_rank",
     "ListRecipesResult",
     "LoadRecipeResult",
     "RecipeListItem",

--- a/src/autoskillit/recipe/__init__.py
+++ b/src/autoskillit/recipe/__init__.py
@@ -64,6 +64,7 @@ from autoskillit.recipe.identity import (  # noqa: E402
     find_prior_runs,
 )
 from autoskillit.recipe.io import (  # noqa: E402
+    _group_rank,
     builtin_sub_recipes_dir,
     find_campaign_by_name,
     find_recipe_by_name,
@@ -105,6 +106,7 @@ from autoskillit.recipe.validator import (  # noqa: E402
 )
 
 __all__ = [
+    "_group_rank",
     "ListRecipesResult",
     "LoadRecipeResult",
     "RecipeListItem",

--- a/src/autoskillit/recipe/io.py
+++ b/src/autoskillit/recipe/io.py
@@ -88,7 +88,7 @@ def group_rank(r: RecipeInfo) -> int:
         return 3
     if r.source == RecipeSource.PROJECT:
         return 2
-    if all(p in CORE_PACKS for p in r.requires_packs):
+    if r.requires_packs and all(p in CORE_PACKS for p in r.requires_packs):
         return 0
     return 1
 

--- a/src/autoskillit/recipe/io.py
+++ b/src/autoskillit/recipe/io.py
@@ -6,7 +6,15 @@ from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
-from autoskillit.core import LoadReport, LoadResult, RecipeSource, get_logger, load_yaml, pkg_root
+from autoskillit.core import (
+    CORE_PACKS,
+    LoadReport,
+    LoadResult,
+    RecipeSource,
+    get_logger,
+    load_yaml,
+    pkg_root,
+)
 from autoskillit.recipe.schema import (
     AUTOSKILLIT_VERSION_KEY,
     RECIPE_VERSION_KEY,
@@ -69,8 +77,10 @@ def load_recipe(path: Path, temp_dir_relpath: str = ".autoskillit/temp") -> Reci
 
 def _group_rank(r: RecipeInfo) -> int:
     if r.experimental:
-        return 2
+        return 3
     if r.source == RecipeSource.PROJECT:
+        return 2
+    if all(p in CORE_PACKS for p in r.requires_packs):
         return 0
     return 1
 
@@ -425,6 +435,7 @@ def _collect_recipes(
                             content=raw,
                             kind=recipe.kind,
                             experimental=recipe.experimental,
+                            requires_packs=recipe.requires_packs,
                         )
                     )
             except Exception as exc:

--- a/src/autoskillit/recipe/io.py
+++ b/src/autoskillit/recipe/io.py
@@ -75,7 +75,15 @@ def load_recipe(path: Path, temp_dir_relpath: str = ".autoskillit/temp") -> Reci
     return recipe
 
 
-def _group_rank(r: RecipeInfo) -> int:
+GROUP_LABELS: dict[int, str] = {
+    0: "Bundled Recipes",
+    1: "Bundled Add-ons",
+    2: "Family Recipes",
+    3: "Experimental",
+}
+
+
+def group_rank(r: RecipeInfo) -> int:
     if r.experimental:
         return 3
     if r.source == RecipeSource.PROJECT:
@@ -102,7 +110,7 @@ def list_recipes(
 
     filtered = [r for r in items if r.kind not in exclude_kinds] if exclude_kinds else items
     return LoadResult(
-        items=sorted(filtered, key=lambda r: (_group_rank(r), r.name)),
+        items=sorted(filtered, key=lambda r: (group_rank(r), r.name)),
         errors=errors,
     )
 

--- a/src/autoskillit/recipe/schema.py
+++ b/src/autoskillit/recipe/schema.py
@@ -188,6 +188,7 @@ class RecipeInfo:
     content: str | None = None  # raw YAML text; None when set via parse_recipe_metadata
     kind: RecipeKind = RecipeKind.STANDARD
     experimental: bool = False
+    requires_packs: list[str] = field(default_factory=list)
 
 
 @dataclass

--- a/tests/cli/test_cook.py
+++ b/tests/cli/test_cook.py
@@ -1195,6 +1195,36 @@ class TestCLIOrder:
         out = capsys.readouterr().out
         assert "Family Recipes" not in out
 
+    def test_order_picker_renders_bundled_add_ons_header(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Picker must print 'Bundled Add-ons' header for BUILTIN recipes with non-core packs."""
+        from autoskillit.core import RecipeSource
+        from autoskillit.recipe.schema import RecipeInfo
+
+        addon_recipe = RecipeInfo(
+            name="planner",
+            description="d",
+            source=RecipeSource.BUILTIN,
+            path=tmp_path / "planner.yaml",
+            experimental=False,
+            requires_packs=["kitchen-core"],
+        )
+        monkeypatch.setattr(
+            "autoskillit.recipe.list_recipes",
+            lambda *a, **kw: type("R", (), {"items": [addon_recipe]})(),
+        )
+        monkeypatch.setattr("autoskillit.cli._timed_input.timed_prompt", lambda *a, **kw: "0")
+        monkeypatch.setattr(shutil, "which", lambda cmd: None)
+        monkeypatch.delenv("CLAUDECODE", raising=False)
+        monkeypatch.chdir(tmp_path)
+
+        with pytest.raises(SystemExit):
+            cli.order()
+
+        out = capsys.readouterr().out
+        assert "Bundled Add-ons" in out
+
     def test_order_picker_contiguous_numbering_across_groups(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ) -> None:

--- a/tests/cli/test_cook.py
+++ b/tests/cli/test_cook.py
@@ -1121,6 +1121,7 @@ class TestCLIOrder:
             source=RecipeSource.BUILTIN,
             path=tmp_path / "impl.yaml",
             experimental=False,
+            requires_packs=["github"],
         )
         monkeypatch.setattr(
             "autoskillit.recipe.list_recipes",

--- a/tests/core/test_type_constants.py
+++ b/tests/core/test_type_constants.py
@@ -8,6 +8,14 @@ pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
 
 
 # REQ-PACK-001: PACK_REGISTRY defines all packs with default_enabled
+def test_core_packs_constant_defined() -> None:
+    """CORE_PACKS must be a frozenset defined in _type_constants and exported via core."""
+    from autoskillit.core._type_constants import CORE_PACKS
+
+    assert isinstance(CORE_PACKS, frozenset)
+    assert CORE_PACKS == frozenset({"github", "ci", "clone", "telemetry"})
+
+
 def test_pack_registry_contains_all_packs() -> None:
     from autoskillit.core import PACK_REGISTRY
 

--- a/tests/recipe/test_io.py
+++ b/tests/recipe/test_io.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from autoskillit.core.types import RecipeSource
+from autoskillit.core.types import CORE_PACKS, RecipeSource
 from autoskillit.recipe.io import (
     _parse_recipe,
     _parse_step,
@@ -684,14 +684,16 @@ class TestListRecipes:
             for i, r in enumerate(result.items)
             if r.source == RecipeSource.BUILTIN
             and not r.experimental
-            and r.name in ("implementation", "remediation", "implementation-groups", "merge-prs")
+            and r.requires_packs
+            and all(p in CORE_PACKS for p in r.requires_packs)
         ]
         addon_indices = [
             i
             for i, r in enumerate(result.items)
             if r.source == RecipeSource.BUILTIN
             and not r.experimental
-            and r.name in ("planner", "research")
+            and r.requires_packs
+            and not all(p in CORE_PACKS for p in r.requires_packs)
         ]
         if core_indices and addon_indices:
             assert max(core_indices) < min(addon_indices), (

--- a/tests/recipe/test_io.py
+++ b/tests/recipe/test_io.py
@@ -488,30 +488,48 @@ class TestListRecipes:
         assert len(recipes) > 0
         assert all(r.source.value in ("project", "builtin") for r in recipes)
 
-    def test_list_recipes_project_appear_before_bundled(self, tmp_path: Path) -> None:
-        """Project recipes must appear before bundled recipes in list_recipes() output."""
+    def test_list_recipes_bundled_appear_before_project(self, tmp_path: Path) -> None:
+        """Non-experimental BUILTIN recipes must appear before PROJECT recipes."""
         recipes_dir = tmp_path / ".autoskillit" / "recipes"
         recipes_dir.mkdir(parents=True)
         (recipes_dir / "aardvark.yaml").write_text(
             "name: aardvark\ndescription: test\nsteps: {}\n"
         )
         result = list_recipes(tmp_path)
-        sources = [r.source for r in result.items if not r.experimental]
-        seen_builtin = False
-        for source in sources:
-            if source == RecipeSource.BUILTIN:
-                seen_builtin = True
-            elif source == RecipeSource.PROJECT:
-                assert not seen_builtin, (
-                    "A PROJECT recipe appeared after a BUILTIN recipe — ordering is broken"
+        non_exp = [r for r in result.items if not r.experimental]
+        seen_project = False
+        for r in non_exp:
+            if r.source == RecipeSource.PROJECT:
+                seen_project = True
+            elif r.source == RecipeSource.BUILTIN:
+                assert not seen_project, (
+                    "A BUILTIN recipe appeared after a PROJECT recipe — ordering is broken"
                 )
 
-    def test_list_recipes_alphabetical_within_bundled_tier(self, tmp_path: Path) -> None:
-        """Bundled recipes must be sorted alphabetically by name within their tier."""
+    def test_list_recipes_alphabetical_within_bundled_tiers(self, tmp_path: Path) -> None:
+        """Each bundled tier (core and add-on) must be alphabetically sorted within its tier."""
+        from autoskillit.core._type_constants import CORE_PACKS
+
         result = list_recipes(tmp_path)
-        builtin_names = [r.name for r in result.items if r.source == RecipeSource.BUILTIN]
-        assert builtin_names == sorted(builtin_names), (
-            f"Bundled recipes not in alphabetical order: {builtin_names}"
+        core_names = [
+            r.name
+            for r in result.items
+            if r.source == RecipeSource.BUILTIN
+            and not r.experimental
+            and all(p in CORE_PACKS for p in r.requires_packs)
+        ]
+        addon_names = [
+            r.name
+            for r in result.items
+            if r.source == RecipeSource.BUILTIN
+            and not r.experimental
+            and not all(p in CORE_PACKS for p in r.requires_packs)
+        ]
+        assert core_names == sorted(core_names), (
+            f"Core bundled recipes not in alphabetical order: {core_names}"
+        )
+        assert addon_names == sorted(addon_names), (
+            f"Add-on bundled recipes not in alphabetical order: {addon_names}"
         )
 
     def test_list_recipes_alphabetical_within_project_tier(self, tmp_path: Path) -> None:
@@ -582,8 +600,10 @@ class TestListRecipes:
         r = next(r for r in result.items if r.name == "research")
         assert r.experimental is True
 
-    def test_list_recipes_project_before_bundled_before_experimental(self, tmp_path: Path) -> None:
-        """list_recipes must order: PROJECT → BUILTIN-non-experimental → experimental."""
+    def test_list_recipes_bundled_before_family_before_experimental(self, tmp_path: Path) -> None:
+        """list_recipes must order: BUILTIN-non-experimental → PROJECT → experimental."""
+        from autoskillit.core._type_constants import CORE_PACKS
+
         recipe_dir = tmp_path / ".autoskillit" / "recipes"
         recipe_dir.mkdir(parents=True)
         (recipe_dir / "proj.yaml").write_text("name: proj\ndescription: p\nsteps: {}\n")
@@ -594,18 +614,26 @@ class TestListRecipes:
         ranks = []
         for r in result.items:
             if r.experimental:
-                rank = 2
+                rank = 3
             elif r.source == RecipeSource.PROJECT:
+                rank = 2
+            elif all(p in CORE_PACKS for p in r.requires_packs):
                 rank = 0
             else:
                 rank = 1
             if not ranks or ranks[-1] != rank:
                 ranks.append(rank)
         assert ranks == sorted(ranks), f"Groups interleaved: {ranks}"
-        assert 0 in ranks and 1 in ranks
-        assert ranks.index(0) < ranks.index(1)
-        assert 2 in ranks
-        assert ranks[-1] == 2
+        # bundled (0 or 1) must appear before family (2)
+        family_idx = ranks.index(2) if 2 in ranks else len(ranks)
+        for r_val in ranks:
+            if r_val in (0, 1):
+                assert ranks.index(r_val) < family_idx, (
+                    f"Bundled rank {r_val} does not appear before family rank 2"
+                )
+        # experimental must be last
+        assert 3 in ranks
+        assert ranks[-1] == 3
 
     def test_list_recipes_alphabetical_within_experimental_group(self, tmp_path: Path) -> None:
         """Experimental recipes must be sorted alphabetically by name within their group."""
@@ -634,6 +662,62 @@ class TestListRecipes:
         ]
         if non_exp_builtin_indices and exp_builtin_indices:
             assert max(non_exp_builtin_indices) < min(exp_builtin_indices)
+
+    def test_recipe_info_has_requires_packs_field(self, tmp_path: Path) -> None:
+        """RecipeInfo must have a requires_packs field defaulting to empty list."""
+        from autoskillit.recipe.schema import RecipeInfo
+
+        r = RecipeInfo(
+            name="x", description="d", source=RecipeSource.BUILTIN, path=tmp_path / "x.yaml"
+        )
+        assert r.requires_packs == []
+
+    def test_requires_packs_forwarded_to_recipe_info(self, tmp_path: Path) -> None:
+        """_collect_recipes must populate RecipeInfo.requires_packs from YAML."""
+        recipe_dir = tmp_path / ".autoskillit" / "recipes"
+        recipe_dir.mkdir(parents=True)
+        (recipe_dir / "custom.yaml").write_text(
+            "name: custom\ndescription: d\nrequires_packs: [github, ci]\nsteps: {}\n"
+        )
+        result = list_recipes(tmp_path)
+        r = next(r for r in result.items if r.name == "custom")
+        assert r.requires_packs == ["github", "ci"]
+
+    def test_list_recipes_bundled_appear_before_family(self, tmp_path: Path) -> None:
+        """Non-experimental BUILTIN recipes must appear before PROJECT recipes."""
+        recipe_dir = tmp_path / ".autoskillit" / "recipes"
+        recipe_dir.mkdir(parents=True)
+        (recipe_dir / "proj.yaml").write_text("name: proj\ndescription: p\nsteps: {}\n")
+        result = list_recipes(tmp_path)
+        non_exp = [r for r in result.items if not r.experimental]
+        seen_project = False
+        for s in [r.source for r in non_exp]:
+            if s == RecipeSource.PROJECT:
+                seen_project = True
+            elif s == RecipeSource.BUILTIN:
+                assert not seen_project, "BUILTIN recipe appeared after PROJECT recipe"
+
+    def test_core_bundled_before_addon_bundled(self, tmp_path: Path) -> None:
+        """Core bundled recipes (CORE_PACKS only) must sort before add-on bundled recipes."""
+        result = list_recipes(tmp_path)
+        core_indices = [
+            i
+            for i, r in enumerate(result.items)
+            if r.source == RecipeSource.BUILTIN
+            and not r.experimental
+            and r.name in ("implementation", "remediation", "implementation-groups", "merge-prs")
+        ]
+        addon_indices = [
+            i
+            for i, r in enumerate(result.items)
+            if r.source == RecipeSource.BUILTIN
+            and not r.experimental
+            and r.name in ("planner", "research")
+        ]
+        if core_indices and addon_indices:
+            assert max(core_indices) < min(addon_indices), (
+                "Core bundled recipes must appear before add-on bundled recipes"
+            )
 
 
 class TestBuiltinRecipesDir:

--- a/tests/recipe/test_io.py
+++ b/tests/recipe/test_io.py
@@ -624,13 +624,6 @@ class TestListRecipes:
             if not ranks or ranks[-1] != rank:
                 ranks.append(rank)
         assert ranks == sorted(ranks), f"Groups interleaved: {ranks}"
-        # bundled (0 or 1) must appear before family (2)
-        family_idx = ranks.index(2) if 2 in ranks else len(ranks)
-        for r_val in ranks:
-            if r_val in (0, 1):
-                assert ranks.index(r_val) < family_idx, (
-                    f"Bundled rank {r_val} does not appear before family rank 2"
-                )
         # experimental must be last
         assert 3 in ranks
         assert ranks[-1] == 3
@@ -682,20 +675,6 @@ class TestListRecipes:
         result = list_recipes(tmp_path)
         r = next(r for r in result.items if r.name == "custom")
         assert r.requires_packs == ["github", "ci"]
-
-    def test_list_recipes_bundled_appear_before_family(self, tmp_path: Path) -> None:
-        """Non-experimental BUILTIN recipes must appear before PROJECT recipes."""
-        recipe_dir = tmp_path / ".autoskillit" / "recipes"
-        recipe_dir.mkdir(parents=True)
-        (recipe_dir / "proj.yaml").write_text("name: proj\ndescription: p\nsteps: {}\n")
-        result = list_recipes(tmp_path)
-        non_exp = [r for r in result.items if not r.experimental]
-        seen_project = False
-        for s in [r.source for r in non_exp]:
-            if s == RecipeSource.PROJECT:
-                seen_project = True
-            elif s == RecipeSource.BUILTIN:
-                assert not seen_project, "BUILTIN recipe appeared after PROJECT recipe"
 
     def test_core_bundled_before_addon_bundled(self, tmp_path: Path) -> None:
         """Core bundled recipes (CORE_PACKS only) must sort before add-on bundled recipes."""


### PR DESCRIPTION
## Summary

The `autoskillit order` and `autoskillit recipes list` pickers currently display **Family Recipes** (PROJECT source) before **Bundled Recipes** (BUILTIN source). This PR corrects the ordering to: **Core Bundled → Bundled Add-ons → Family Recipes → Experimental**. It adds `CORE_PACKS` to `_type_constants.py`, expands `_group_rank()` to 4 tiers, re-exports it via `recipe/__init__.py`, and consolidates the duplicate rank logic in both CLI entry points.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START])
    DONE([COMPLETE])
    SESS_END([SESSION END])
    ERR([ERROR / SystemExit])

    subgraph CLIEntry ["● CLI Entry Points (app.py · _cook.py)"]
        RECIPES_LIST["● autoskillit recipes list<br/>━━━━━━━━━━<br/>app.py → _print_recipes_list()"]
        ORDER_INT["● autoskillit order<br/>━━━━━━━━━━<br/>no recipe arg → interactive picker"]
        COOK_CMD["● autoskillit cook<br/>━━━━━━━━━━<br/>→ cook_interactive()"]
    end

    subgraph ListRecipes ["● list_recipes() — recipe/io.py"]
        PROJ_SCAN["● Scan PROJECT recipes<br/>━━━━━━━━━━<br/>.autoskillit/recipes/*.yaml<br/>populates seen set"]
        BUILTIN_SCAN["● Scan BUILTIN recipes<br/>━━━━━━━━━━<br/>pkg_root()/recipes/*.yaml<br/>skips names already in seen"]
        KIND_CHK{"recipe.kind in<br/>exclude_kinds?"}
        DISCARD["Skip recipe"]
        EXP_CHK{"r.experimental?"}
        SRC_CHK{"r.source == PROJECT?"}
        PACKS_CHK{"all packs in<br/>● CORE_PACKS?<br/>github · ci · clone · telemetry"}
        T0["Rank 0 — Bundled Recipes<br/>━━━━━━━━━━<br/>builtin + core deps only"]
        T1["Rank 1 — Bundled Add-ons<br/>━━━━━━━━━━<br/>builtin + extra pack deps"]
        T2["Rank 2 — Family Recipes<br/>━━━━━━━━━━<br/>PROJECT source"]
        T3["Rank 3 — Experimental<br/>━━━━━━━━━━<br/>experimental: true"]
        SORT["● sorted(filtered)<br/>━━━━━━━━━━<br/>key=(_group_rank, name)<br/>bundled before family"]
    end

    subgraph DisplayLoop ["● Display Loop (_cook.py · app.py)"]
        TIER_CHK{"rank != current_rank?<br/>━━━━━━━━━━<br/>tier boundary"}
        HDR["● Print tier header<br/>━━━━━━━━━━<br/>_GROUP_LABELS[rank]"]
        ROW["Print recipe row<br/>━━━━━━━━━━<br/>name · source · description"]
        MORE{"more recipes?"}
    end

    subgraph OrderPick ["order — Interactive Selection (● app.py)"]
        PROMPT["timed_prompt() · 120s<br/>━━━━━━━━━━<br/>user selects recipe"]
        RESOLVE["_resolve_recipe_input()<br/>━━━━━━━━━━<br/>match input to RecipeInfo"]
        LAUNCH["launch order session<br/>━━━━━━━━━━<br/>headless Claude + recipe"]
    end

    subgraph CookLoop ["● cook() Reload Loop (_cook.py)"]
        BUILD["build_interactive_cmd()<br/>━━━━━━━━━━<br/>build claude CLI args<br/>with current resume_spec"]
        RUN["_run_cook_session()<br/>━━━━━━━━━━<br/>subprocess: blocks until exit"]
        RELOAD{"reload sentinel?<br/>━━━━━━━━━━<br/>consume_reload_sentinel()"}
        CAP{"≥ max_reloads (10)<br/>or ID seen before?"}
        UPDATE["● Update resume_spec<br/>━━━━━━━━━━<br/>NamedResume(reload_id)<br/>first_run = False"]
    end

    %% FLOW %%
    START --> RECIPES_LIST & ORDER_INT & COOK_CMD

    RECIPES_LIST --> PROJ_SCAN
    ORDER_INT --> PROJ_SCAN
    PROJ_SCAN --> BUILTIN_SCAN
    BUILTIN_SCAN --> KIND_CHK
    KIND_CHK -->|"yes — excluded"| DISCARD
    KIND_CHK -->|"no — keep"| EXP_CHK
    EXP_CHK -->|"true"| T3
    EXP_CHK -->|"false"| SRC_CHK
    SRC_CHK -->|"true"| T2
    SRC_CHK -->|"false"| PACKS_CHK
    PACKS_CHK -->|"true"| T0
    PACKS_CHK -->|"false"| T1
    T0 & T1 & T2 & T3 --> SORT

    SORT --> TIER_CHK
    TIER_CHK -->|"yes — new tier"| HDR
    HDR --> ROW
    TIER_CHK -->|"no — same tier"| ROW
    ROW --> MORE
    MORE -->|"yes"| TIER_CHK
    MORE -->|"no · recipes list path"| DONE
    MORE -->|"no · order path"| PROMPT

    PROMPT --> RESOLVE
    RESOLVE --> LAUNCH
    LAUNCH --> DONE

    COOK_CMD --> BUILD
    BUILD --> RUN
    RUN --> RELOAD
    RELOAD -->|"nil — normal exit"| SESS_END
    RELOAD -->|"id returned"| CAP
    CAP -->|"over cap / repeated ID"| ERR
    CAP -->|"ok"| UPDATE
    UPDATE -->|"loop ↩"| BUILD

    %% CLASS ASSIGNMENTS %%
    class RECIPES_LIST,ORDER_INT,COOK_CMD cli;
    class PROJ_SCAN,BUILTIN_SCAN,SORT,HDR,ROW,UPDATE,LAUNCH phase;
    class T0,T1,T2,T3 output;
    class KIND_CHK,EXP_CHK,SRC_CHK,PACKS_CHK,TIER_CHK,MORE,RELOAD,CAP detector;
    class PROMPT,RESOLVE,BUILD,RUN stateNode;
    class DISCARD handler;
    class START,DONE,SESS_END,ERR terminal;
```

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph L3 ["L3 — CLI APPLICATION"]
        direction LR
        APP["● cli/app.py<br/>━━━━━━━━━━<br/>Entry point / CLI router<br/>imports: RecipeSource from core"]
        COOK["● cli/_cook.py<br/>━━━━━━━━━━<br/>Cook session orchestrator<br/>deferred: _group_rank, list_recipes"]
    end

    subgraph L2 ["L2 — RECIPE LAYER"]
        direction TB
        RINIT["● recipe/__init__.py<br/>━━━━━━━━━━<br/>Public surface / re-export hub<br/>now re-exports: _group_rank"]
        RIO["● recipe/io.py<br/>━━━━━━━━━━<br/>NEW: _group_rank() 4-tier fn<br/>list_recipes() sorts by tier"]
        RSCHEMA["● recipe/schema.py<br/>━━━━━━━━━━<br/>Recipe, RecipeInfo, RecipeKind<br/>imports: RECIPE_PACK_TAGS, RecipeSource"]
    end

    subgraph L0 ["L0 — CORE FOUNDATION"]
        direction LR
        TSTUB["● core/__init__.pyi<br/>━━━━━━━━━━<br/>Public stub / re-export surface"]
        TCONST["● core/_type_constants.py<br/>━━━━━━━━━━<br/>CORE_PACKS, RecipeSource<br/>PackDef, RecipePackDef, PACK_REGISTRY"]
    end

    subgraph EXT ["EXTERNAL"]
        direction LR
        STDLIB["stdlib<br/>━━━━━━━━━━<br/>pathlib, dataclasses, enum"]
        CYCLOPTS["cyclopts / anyio<br/>━━━━━━━━━━<br/>CLI framework"]
    end

    %% L3 → L2 dependencies %%
    APP -->|"imports cook_interactive"| COOK
    COOK -.->|"deferred import<br/>_group_rank, list_recipes"| RINIT

    %% L3 → L0 %%
    APP -->|"imports RecipeSource"| TSTUB

    %% L2 internal %%
    RINIT -->|"star import + explicit<br/>_group_rank (new)"| RIO
    RINIT -->|"star import"| RSCHEMA
    RIO -->|"imports Recipe, RecipeInfo<br/>RecipeKind, RecipeStep..."| RSCHEMA

    %% L2 → L0 %%
    RIO -->|"imports CORE_PACKS<br/>RecipeSource, LoadResult<br/>pkg_root, load_yaml"| TSTUB
    RSCHEMA -->|"imports RECIPE_PACK_TAGS<br/>RecipeSource"| TSTUB

    %% L0 internal %%
    TSTUB -->|"re-exports"| TCONST

    %% L0 → External %%
    TCONST --> STDLIB

    %% L3 → External %%
    APP --> CYCLOPTS

    %% CLASS ASSIGNMENTS %%
    class APP,COOK cli;
    class RINIT phase;
    class RIO handler;
    class RSCHEMA stateNode;
    class TSTUB,TCONST output;
    class STDLIB,CYCLOPTS integration;
```

Closes #1309

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260426-165528-752068/.autoskillit/temp/make-plan/reorder_recipe_picker_plan_2026-04-26_000000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 195 | 14.7k | 1.1M | 65.4k | 1 | 5m 22s |
| verify | 124 | 16.7k | 673.7k | 46.4k | 1 | 9m 10s |
| implement | 3.1k | 18.0k | 2.1M | 68.6k | 1 | 5m 51s |
| fix | 126 | 5.2k | 590.6k | 42.7k | 1 | 7m 52s |
| prepare_pr | 52 | 3.8k | 170.5k | 28.4k | 1 | 1m 20s |
| run_arch_lenses | 959 | 17.4k | 351.2k | 80.8k | 2 | 5m 55s |
| compose_pr | 67 | 5.8k | 227.0k | 26.2k | 1 | 1m 56s |
| **Total** | 4.6k | 81.6k | 5.3M | 358.5k | | 37m 27s |