### PR TITLE
Rectify: Manifest-Encoded Result Directory Contract for check_remaining

### DIFF
--- a/src/autoskillit/execution/linux_tracing.py
+++ b/src/autoskillit/execution/linux_tracing.py
@@ -396,24 +396,24 @@ def read_proc_snapshot(pid: int, *, process: psutil.Process | None = None) -> Pr
     # Read process name from /proc/{pid}/comm (max 15 chars, kernel-truncated)
     try:
         comm = Path(f"/proc/{pid}/comm").read_text().strip()
-    except (FileNotFoundError, PermissionError):
+    except (FileNotFoundError, PermissionError, ProcessLookupError):
         comm = ""
 
     # Hand-rolled /proc reads for fields psutil doesn't expose
     try:
         status_content = Path(f"/proc/{pid}/status").read_text()
-    except (FileNotFoundError, PermissionError):
+    except (FileNotFoundError, PermissionError, ProcessLookupError):
         return None
     sig_fields = _parse_proc_status(status_content)
 
     try:
         oom = int(Path(f"/proc/{pid}/oom_score").read_text().strip())
-    except (FileNotFoundError, PermissionError, ValueError):
+    except (FileNotFoundError, PermissionError, ProcessLookupError, ValueError):
         oom = -1
 
     try:
         wchan = Path(f"/proc/{pid}/wchan").read_text().strip()
-    except (FileNotFoundError, PermissionError):
+    except (FileNotFoundError, PermissionError, ProcessLookupError):
         wchan = ""
 
     # Best-effort: /proc/{pid}/net/tcp and tcp6 (Linux network namespace for this PID)

--- a/src/autoskillit/planner/__init__.py
+++ b/src/autoskillit/planner/__init__.py
@@ -10,6 +10,8 @@ from autoskillit.planner.schema import (  # noqa: F401
     ASSIGNMENT_REQUIRED_KEYS,
     PHASE_REQUIRED_KEYS,
     WP_REQUIRED_KEYS,
+    PlannerManifest,
+    PlannerManifestItem,
 )
 from autoskillit.planner.validation import validate_plan
 
@@ -19,4 +21,6 @@ __all__ = [
     "build_wp_manifest",
     "validate_plan",
     "compile_plan",
+    "PlannerManifest",
+    "PlannerManifestItem",
 ]

--- a/src/autoskillit/planner/manifests.py
+++ b/src/autoskillit/planner/manifests.py
@@ -54,9 +54,17 @@ def check_remaining(manifest_path: str, pass_name: str, output_dir: str) -> dict
             f" (got {type(items).__name__})"
         )
 
+    result_dir_str = manifest.get("result_dir")
+    if not result_dir_str:
+        raise ValueError(
+            f"Manifest at {manifest_file} is missing required 'result_dir' field. "
+            f"Re-run build_assignment_manifest or build_wp_manifest to regenerate."
+        )
+    result_dir = Path(result_dir_str)
+
     for item in items:
         if item["status"] == "processing":
-            result_path = out_dir / f"{item['id']}_result.json"
+            result_path = result_dir / f"{item['id']}_result.json"
             if not result_path.exists():
                 for _attempt in range(2):
                     time.sleep(1)
@@ -103,11 +111,12 @@ def check_remaining(manifest_path: str, pass_name: str, output_dir: str) -> dict
 def build_assignment_manifest(
     phases_dir: str, assignments_dir: str, output_dir: str
 ) -> dict[str, str]:
-    if not phases_dir or not output_dir:
-        raise ValueError("phases_dir and output_dir must not be empty")
+    if not phases_dir or not assignments_dir or not output_dir:
+        raise ValueError("phases_dir, assignments_dir, and output_dir must not be empty")
 
     phases_path = Path(phases_dir)
     out_dir = Path(output_dir)
+    assign_dir = Path(assignments_dir).resolve()
 
     phase_files = sorted(phases_path.glob("*_result.json"))
     parsed_phases = []
@@ -143,6 +152,7 @@ def build_assignment_manifest(
 
     manifest = {
         "pass_name": "assignments",
+        "result_dir": str(assign_dir),
         "created_at": datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "items": items,
     }
@@ -151,12 +161,15 @@ def build_assignment_manifest(
     return {"manifest_path": str(manifest_path), "total_count": str(len(items))}
 
 
-def build_wp_manifest(assignments_dir: str, output_dir: str) -> dict[str, str]:
+def build_wp_manifest(
+    assignments_dir: str, output_dir: str, work_packages_dir: str = ""
+) -> dict[str, str]:
     if not assignments_dir or not output_dir:
         raise ValueError("assignments_dir and output_dir must not be empty")
 
     assign_path = Path(assignments_dir)
     out_dir = Path(output_dir)
+    wp_dir = Path(work_packages_dir).resolve() if work_packages_dir else out_dir / "work_packages"
 
     assign_files = list(assign_path.glob("*_result.json"))
     parsed_assignments = []
@@ -196,6 +209,7 @@ def build_wp_manifest(assignments_dir: str, output_dir: str) -> dict[str, str]:
 
     manifest = {
         "pass_name": "work_packages",
+        "result_dir": str(wp_dir),
         "created_at": datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "items": items,
     }

--- a/src/autoskillit/planner/manifests.py
+++ b/src/autoskillit/planner/manifests.py
@@ -55,7 +55,7 @@ def check_remaining(manifest_path: str, pass_name: str, output_dir: str) -> dict
         )
 
     result_dir_str = manifest.get("result_dir")
-    if not result_dir_str:
+    if result_dir_str is None:
         raise ValueError(
             f"Manifest at {manifest_file} is missing required 'result_dir' field. "
             f"Re-run build_assignment_manifest or build_wp_manifest to regenerate."
@@ -169,7 +169,11 @@ def build_wp_manifest(
 
     assign_path = Path(assignments_dir)
     out_dir = Path(output_dir)
-    wp_dir = Path(work_packages_dir).resolve() if work_packages_dir else out_dir / "work_packages"
+    wp_dir = (
+        Path(work_packages_dir).resolve()
+        if work_packages_dir
+        else (out_dir / "work_packages").resolve()
+    )
 
     assign_files = list(assign_path.glob("*_result.json"))
     parsed_assignments = []

--- a/src/autoskillit/planner/schema.py
+++ b/src/autoskillit/planner/schema.py
@@ -47,7 +47,7 @@ class PlannerManifestItem(TypedDict):
     name: str
     status: str
     result_path: str | None
-    metadata: dict
+    metadata: dict[str, Any]
 
 
 class PlannerManifest(TypedDict):

--- a/src/autoskillit/planner/schema.py
+++ b/src/autoskillit/planner/schema.py
@@ -42,6 +42,21 @@ class WPResult(TypedDict):
     acceptance_criteria: list[str]
 
 
+class PlannerManifestItem(TypedDict):
+    id: str
+    name: str
+    status: str
+    result_path: str | None
+    metadata: dict
+
+
+class PlannerManifest(TypedDict):
+    pass_name: str
+    result_dir: str
+    created_at: str
+    items: list[PlannerManifestItem]
+
+
 PHASE_REQUIRED_KEYS: frozenset[str] = frozenset({"id", "name", "ordering"})
 ASSIGNMENT_REQUIRED_KEYS: frozenset[str] = frozenset({"id", "name", "proposed_work_packages"})
 WP_REQUIRED_KEYS: frozenset[str] = frozenset({"id", "name", "deliverables"})

--- a/src/autoskillit/recipes/planner.yaml
+++ b/src/autoskillit/recipes/planner.yaml
@@ -144,6 +144,7 @@ steps:
     with:
       callable: "autoskillit.planner.build_wp_manifest"
       assignments_dir: "{{AUTOSKILLIT_TEMP}}/planner/assignments"
+      work_packages_dir: "{{AUTOSKILLIT_TEMP}}/planner/work_packages"
       output_dir: "{{AUTOSKILLIT_TEMP}}/planner"
     capture:
       wp_manifest_path: "${{ result.manifest_path }}"

--- a/tests/planner/test_manifests.py
+++ b/tests/planner/test_manifests.py
@@ -11,9 +11,10 @@ from tests.planner.conftest import make_assignment_result, make_phase_result
 pytestmark = [pytest.mark.layer("planner"), pytest.mark.small, pytest.mark.feature("planner")]
 
 
-def _make_manifest(items: list[dict]) -> dict:
+def _make_manifest(items: list[dict], result_dir: str) -> dict:
     return {
         "pass_name": "phases",
+        "result_dir": result_dir,
         "created_at": "2026-04-24T00:00:00Z",
         "items": [
             {
@@ -32,8 +33,11 @@ def test_check_remaining_pending_to_processing(tmp_path):
     """First call marks first pending item as processing and returns it."""
     from autoskillit.planner import check_remaining
 
+    assignments_dir = tmp_path / "assignments"
+    assignments_dir.mkdir()
     manifest = {
         "pass_name": "assignments",
+        "result_dir": str(assignments_dir),
         "created_at": "2026-04-24T00:00:00Z",
         "items": [
             {
@@ -62,12 +66,15 @@ def test_check_remaining_processing_becomes_done_when_result_exists(tmp_path):
     """processing item with a result file is marked done."""
     from autoskillit.planner import check_remaining
 
+    assignments_dir = tmp_path / "assignments"
+    assignments_dir.mkdir()
     output_dir = tmp_path / "out"
     output_dir.mkdir()
-    (output_dir / "P1-A1_result.json").write_text('{"ok": true}')
+    (assignments_dir / "P1-A1_result.json").write_text('{"ok": true}')
 
     manifest = {
         "pass_name": "assignments",
+        "result_dir": str(assignments_dir),
         "created_at": "2026-04-24T00:00:00Z",
         "items": [
             {
@@ -101,12 +108,15 @@ def test_check_remaining_processing_becomes_failed_when_no_result(tmp_path):
     """processing item without a result file is marked failed."""
     from autoskillit.planner import check_remaining
 
+    assignments_dir = tmp_path / "assignments"
+    assignments_dir.mkdir()
     output_dir = tmp_path / "out"
     output_dir.mkdir()
     # No result file present
 
     manifest = {
         "pass_name": "assignments",
+        "result_dir": str(assignments_dir),
         "created_at": "2026-04-24T00:00:00Z",
         "items": [
             {
@@ -143,7 +153,7 @@ def test_check_remaining_processing_does_not_fail_on_first_miss(tmp_path):
     Item must become done, not failed."""
     from autoskillit.planner import check_remaining
 
-    manifest = _make_manifest([{"id": "A1", "status": "processing"}])
+    manifest = _make_manifest([{"id": "A1", "status": "processing"}], result_dir=str(tmp_path))
     manifest_path = tmp_path / "manifest.json"
     manifest_path.write_text(json.dumps(manifest))
     result_path = tmp_path / "A1_result.json"
@@ -176,7 +186,8 @@ def test_check_remaining_processing_fails_after_all_retries_exhausted(tmp_path):
         [
             {"id": "A1", "status": "processing"},
             {"id": "A2", "status": "pending"},
-        ]
+        ],
+        result_dir=str(tmp_path),
     )
     manifest_path = tmp_path / "manifest.json"
     manifest_path.write_text(json.dumps(manifest))
@@ -195,7 +206,7 @@ def test_check_remaining_sleep_called_with_one_second(tmp_path):
     """Each retry sleep must be exactly 1 second."""
     from autoskillit.planner import check_remaining
 
-    manifest = _make_manifest([{"id": "A1", "status": "processing"}])
+    manifest = _make_manifest([{"id": "A1", "status": "processing"}], result_dir=str(tmp_path))
     manifest_path = tmp_path / "manifest.json"
     manifest_path.write_text(json.dumps(manifest))
 
@@ -210,12 +221,15 @@ def test_check_remaining_all_done_returns_false(tmp_path):
     """When no pending items remain, has_remaining is 'false' and current_item_path is empty."""
     from autoskillit.planner import check_remaining
 
+    assignments_dir = tmp_path / "assignments"
+    assignments_dir.mkdir()
     output_dir = tmp_path / "out"
     output_dir.mkdir()
-    (output_dir / "P1-A1_result.json").write_text('{"ok": true}')
+    (assignments_dir / "P1-A1_result.json").write_text('{"ok": true}')
 
     manifest = {
         "pass_name": "assignments",
+        "result_dir": str(assignments_dir),
         "created_at": "2026-04-24T00:00:00Z",
         "items": [
             {
@@ -240,11 +254,14 @@ def test_check_remaining_context_file_written(tmp_path):
     """A context file is written for the newly-processing item."""
     from autoskillit.planner import check_remaining
 
+    assignments_dir = tmp_path / "assignments"
+    assignments_dir.mkdir()
     output_dir = tmp_path / "out"
     output_dir.mkdir()
 
     manifest = {
         "pass_name": "assignments",
+        "result_dir": str(assignments_dir),
         "created_at": "2026-04-24T00:00:00Z",
         "items": [
             {
@@ -273,10 +290,13 @@ def test_check_remaining_return_values_are_strings(tmp_path):
     """All returned values are plain strings, never booleans or other types."""
     from autoskillit.planner import check_remaining
 
+    assignments_dir = tmp_path / "assignments"
+    assignments_dir.mkdir()
     output_dir = tmp_path / "out"
     output_dir.mkdir()
     manifest = {
         "pass_name": "assignments",
+        "result_dir": str(assignments_dir),
         "created_at": "2026-04-24T00:00:00Z",
         "items": [
             {
@@ -301,10 +321,12 @@ def test_check_remaining_wp_backstop_rebuilds_missing_index_entry(tmp_path):
     """Recovery backstop: if a WP result exists but isn't in wp_index.json, rebuild the entry."""
     from autoskillit.planner import check_remaining
 
+    wps_dir = tmp_path / "work_packages"
+    wps_dir.mkdir()
     output_dir = tmp_path / "out"
     output_dir.mkdir()
     wp_id = "P1-A1-WP1"
-    (output_dir / f"{wp_id}_result.json").write_text(
+    (wps_dir / f"{wp_id}_result.json").write_text(
         json.dumps({"id": wp_id, "name": "First WP", "summary": "done"})
     )
 
@@ -314,6 +336,7 @@ def test_check_remaining_wp_backstop_rebuilds_missing_index_entry(tmp_path):
 
     manifest = {
         "pass_name": "work_packages",
+        "result_dir": str(wps_dir),
         "created_at": "2026-04-24T00:00:00Z",
         "items": [
             {
@@ -336,6 +359,162 @@ def test_check_remaining_wp_backstop_rebuilds_missing_index_entry(tmp_path):
     entry = next(e for e in index if e["id"] == wp_id)
     assert entry["name"] == "First WP"
     assert entry["summary"] == "done"
+
+
+def test_check_remaining_finds_result_in_subdir_produced_by_build_manifest(tmp_path):
+    """Round-trip: result written to subdirectory designated by build_assignment_manifest
+    must be found by check_remaining."""
+    from autoskillit.planner import build_assignment_manifest, check_remaining
+
+    phases_dir = tmp_path / "phases"
+    assignments_dir = tmp_path / "assignments"
+    output_dir = tmp_path
+    phases_dir.mkdir()
+    assignments_dir.mkdir()
+
+    (phases_dir / "P1_result.json").write_text(
+        json.dumps(
+            {
+                "phase_number": 1,
+                "phase_name": "Alpha",
+                "id": "P1",
+                "name": "Alpha",
+                "ordering": 1,
+                "assignments": [
+                    {"assignment_number": 1, "title": "Do X", "name": "Do X", "metadata": {}}
+                ],
+                "assignments_preview": ["Do X"],
+            }
+        )
+    )
+
+    result = build_assignment_manifest(
+        phases_dir=str(phases_dir),
+        assignments_dir=str(assignments_dir),
+        output_dir=str(output_dir),
+    )
+    manifest_path = result["manifest_path"]
+
+    cr1 = check_remaining(manifest_path, "assignments", str(output_dir))
+    assert cr1["has_remaining"] == "true"
+
+    (assignments_dir / "P1-A1_result.json").write_text(json.dumps({"ok": True}))
+
+    check_remaining(manifest_path, "assignments", str(output_dir))
+    manifest = json.loads(Path(manifest_path).read_text())
+    done_item = next(i for i in manifest["items"] if i["id"] == "P1-A1")
+    assert done_item["status"] == "done"
+    assert done_item["result_path"] == str(assignments_dir / "P1-A1_result.json")
+
+
+def test_check_remaining_prior_results_populated_from_done_items(tmp_path):
+    """After one item transitions to done, the next item's context file must include
+    that item's result_path in prior_results."""
+    from autoskillit.planner import build_assignment_manifest, check_remaining
+
+    phases_dir = tmp_path / "phases"
+    assignments_dir = tmp_path / "assignments"
+    phases_dir.mkdir()
+    assignments_dir.mkdir()
+
+    (phases_dir / "P1_result.json").write_text(
+        json.dumps(
+            {
+                "id": "P1",
+                "name": "Alpha",
+                "ordering": 1,
+                "assignments_preview": ["A1", "A2"],
+            }
+        )
+    )
+    result = build_assignment_manifest(
+        phases_dir=str(phases_dir),
+        assignments_dir=str(assignments_dir),
+        output_dir=str(tmp_path),
+    )
+    manifest_path = result["manifest_path"]
+
+    check_remaining(manifest_path, "assignments", str(tmp_path))
+    p1a1_result = assignments_dir / "P1-A1_result.json"
+    p1a1_result.write_text(json.dumps({"ok": True}))
+    cr2 = check_remaining(manifest_path, "assignments", str(tmp_path))
+    context = json.loads(Path(cr2["current_item_path"]).read_text())
+    assert str(p1a1_result) in context["prior_results"]
+
+
+def test_check_remaining_raises_on_missing_result_dir(tmp_path):
+    """Manifests without result_dir must fail loudly, not silently mark items failed."""
+    from autoskillit.planner import check_remaining
+
+    manifest = {
+        "pass_name": "assignments",
+        "items": [
+            {
+                "id": "P1-A1",
+                "name": "X",
+                "status": "processing",
+                "metadata": {},
+                "result_path": None,
+            }
+        ],
+    }
+    mf = tmp_path / "manifest.json"
+    mf.write_text(json.dumps(manifest))
+    with pytest.raises(ValueError, match="result_dir"):
+        check_remaining(str(mf), "assignments", str(tmp_path))
+
+
+def test_build_assignment_manifest_stores_result_dir(tmp_path):
+    """build_assignment_manifest embeds result_dir in the manifest it produces."""
+    from autoskillit.planner import build_assignment_manifest
+
+    phases_dir = tmp_path / "phases"
+    phases_dir.mkdir()
+    assignments_dir = tmp_path / "assignments"
+    assignments_dir.mkdir()
+    (phases_dir / "P1_result.json").write_text(
+        json.dumps(
+            {
+                "id": "P1",
+                "name": "A",
+                "ordering": 1,
+                "assignments_preview": ["X"],
+            }
+        )
+    )
+    result = build_assignment_manifest(
+        phases_dir=str(phases_dir),
+        assignments_dir=str(assignments_dir),
+        output_dir=str(tmp_path),
+    )
+    manifest = json.loads(Path(result["manifest_path"]).read_text())
+    assert manifest["result_dir"] == str(assignments_dir.resolve())
+
+
+def test_build_wp_manifest_stores_result_dir(tmp_path):
+    """build_wp_manifest embeds result_dir in the manifest it produces."""
+    from autoskillit.planner import build_wp_manifest
+
+    assignments_dir = tmp_path / "assignments"
+    assignments_dir.mkdir()
+    wp_dir = tmp_path / "work_packages"
+    wp_dir.mkdir()
+    (assignments_dir / "P1-A1_result.json").write_text(
+        json.dumps(
+            {
+                "id": "P1-A1",
+                "name": "A1",
+                "proposed_work_packages": [{"title": "WP1", "name": "WP1", "metadata": {}}],
+            }
+        )
+    )
+    result = build_wp_manifest(
+        assignments_dir=str(assignments_dir),
+        work_packages_dir=str(wp_dir),
+        output_dir=str(tmp_path),
+    )
+    manifest = json.loads(Path(result["manifest_path"]).read_text())
+    assert manifest["result_dir"] == str(wp_dir.resolve())
 
 
 def test_build_assignment_manifest_basic(tmp_path):

--- a/tests/planner/test_planner.py
+++ b/tests/planner/test_planner.py
@@ -20,6 +20,8 @@ def test_planner_all_exports_callables() -> None:
         "build_wp_manifest",
         "validate_plan",
         "compile_plan",
+        "PlannerManifest",
+        "PlannerManifestItem",
     }
 
 


### PR DESCRIPTION
## Summary

`check_remaining` was constructing result file paths flat under the planner root directory, while skills write to a named subdirectory (`assignments/`, `work_packages/`). Every polling attempt resolved to a path that will never exist, exhausting retries and marking every item `"failed"` — `prior_results` was always empty and the WP pass failed identically.

The fix makes the manifest self-describing: `build_assignment_manifest` and `build_wp_manifest` now embed a `result_dir` field in the manifests they produce. `check_remaining` reads `result_dir` from the manifest instead of guessing from `output_dir`. The path contract is now explicit, versioned with the manifest, and enforced with a `ValueError` guard and test coverage in isolation.

## Architecture Impact

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START([BUILD])

    %% ── SCHEMA VALIDATION GATES ─────────────────────────────────────────── %%
    subgraph SchemaGates ["VALIDATION GATES  ●schema.py"]
        direction LR
        GatePhase["● validate_phase_result<br/>━━━━━━━━━━<br/>REQUIRES: id, name, ordering<br/>DERIVES: phase_number, name_slug<br/>BACKFILLS: goal, scope, assignments"]
        GateAssign["● validate_assignment_result<br/>━━━━━━━━━━<br/>REQUIRES: id, name, proposed_work_packages<br/>DERIVES: phase_number, assignment_number<br/>BACKFILLS: phase_id, goal, technical_approach"]
        GateWP["● validate_wp_result<br/>━━━━━━━━━━<br/>REQUIRES: id, name, deliverables<br/>BACKFILLS: summary, goal, steps,<br/>files_touched, apis, depends_on"]
    end

    %% ── MANIFEST BUILD ───────────────────────────────────────────────────── %%
    subgraph BuildPhase ["MANIFEST BUILD  ●manifests.py"]
        direction TB
        BuildAssign["● build_assignment_manifest<br/>━━━━━━━━━━<br/>Writes assignment_manifest.json<br/>Embeds result_dir = Path(assignments_dir).resolve()<br/>Items: P{N}-A{N} IDs, status=pending"]
        BuildWP["● build_wp_manifest<br/>━━━━━━━━━━<br/>Writes wp_manifest.json<br/>Embeds result_dir = Path(wp_dir).resolve()<br/>Inits wp_index.json = []<br/>Items: P{N}-A{N}-WP{N} IDs, status=pending"]
    end

    %% ── INIT_ONLY MANIFEST FIELDS ────────────────────────────────────────── %%
    subgraph InitFields ["INIT_ONLY MANIFEST FIELDS  ●schema.py"]
        direction LR
        ResultDir["● result_dir<br/>━━━━━━━━━━<br/>RESOLVED absolute path<br/>Written ONCE at build time<br/>READ by check_remaining for every<br/>result file lookup — NEVER modified"]
        PassName["pass_name<br/>━━━━━━━━━━<br/>assignments | work_packages<br/>Gates WP backstop logic"]
        ItemID["item.id<br/>━━━━━━━━━━<br/>P{N}-A{N} / P{N}-A{N}-WP{N}<br/>INIT_ONLY — used for file names<br/>and context routing"]
    end

    %% ── RUNTIME PATH CONTRACT ────────────────────────────────────────────── %%
    subgraph RuntimeGate ["RUNTIME PATH GATE  ●check_remaining"]
        direction TB
        PathGuard["● result_dir guard<br/>━━━━━━━━━━<br/>Raises ValueError if absent<br/>msg: Re-run build_*_manifest<br/>PROTECTS against path mismatch"]
        PathCheck["result_dir/{item.id}_result.json<br/>━━━━━━━━━━<br/>Path.exists() × 2 retries<br/>sleep(1) between attempts<br/>Tolerates 1 FS-lag miss"]
    end

    %% ── STATUS STATE MACHINE ─────────────────────────────────────────────── %%
    subgraph StatusMachine ["ITEM STATUS STATE MACHINE  ●manifests.py / ●schema.py"]
        direction LR
        Pending["pending<br/>━━━━━━━━━━<br/>Initial state<br/>Promoted by check_remaining"]
        Processing["processing<br/>━━━━━━━━━━<br/>In-flight<br/>awaiting result file"]
        Done["done<br/>━━━━━━━━━━<br/>result_path set ONCE<br/>populates prior_results<br/>for next item"]
        Failed["failed<br/>━━━━━━━━━━<br/>2 retries exhausted<br/>does NOT block queue<br/>next pending still promoted"]
    end

    %% ── RESUME DETECTION ─────────────────────────────────────────────────── %%
    subgraph Resume ["RESUME DETECTION (stateless)"]
        direction TB
        ResumePoint["Implicit resume point<br/>━━━━━━━━━━<br/>First item with status=pending<br/>No explicit flag / checkpoint needed<br/>Re-call check_remaining to continue"]
        ContextOut["context_{id}.json<br/>━━━━━━━━━━<br/>id · name · metadata<br/>prior_results (from done items)<br/>wp_index_path"]
    end

    %% ── WP RECOVERY ──────────────────────────────────────────────────────── %%
    subgraph Recovery ["WP RECOVERY (APPEND_ONLY)"]
        direction TB
        Backstop["_backstop_wp_index<br/>━━━━━━━━━━<br/>APPEND-ONLY to wp_index.json<br/>Repairs missing entry if id absent<br/>Called only on pass_name=work_packages"]
    end

    END_NODE([DONE / EXHAUSTED])

    %% ── CONNECTIONS ──────────────────────────────────────────────────────── %%
    START --> SchemaGates
    GatePhase --> BuildAssign
    GateAssign --> BuildAssign
    GateAssign --> BuildWP
    GateWP --> BuildWP

    BuildAssign --> ResultDir
    BuildWP --> ResultDir
    BuildAssign --> PassName
    BuildWP --> PassName
    BuildAssign --> ItemID
    BuildWP --> ItemID

    ResultDir -->|"read every iteration"| PathGuard
    PathGuard -->|"result_dir present"| PathCheck
    PathGuard -->|"result_dir ABSENT"| VE["ValueError<br/>force rebuild"]

    PathCheck --> StatusMachine
    Pending -->|"check_remaining promotes"| Processing
    Processing -->|"file found"| Done
    Processing -->|"2 retries fail"| Failed

    Done --> Backstop
    Done --> ResumePoint
    Failed --> ResumePoint

    ResumePoint -->|"prior_results from Done items"| ContextOut
    ContextOut --> END_NODE

    %% ── CLASS ASSIGNMENTS ────────────────────────────────────────────────── %%
    class GatePhase,GateAssign,GateWP detector;
    class BuildAssign,BuildWP handler;
    class ResultDir,PassName,ItemID stateNode;
    class PathGuard,PathCheck phase;
    class VE gap;
    class Pending,Processing cli;
    class Done output;
    class Failed gap;
    class ResumePoint,ContextOut cli;
    class Backstop handler;
    class START,END_NODE terminal;
```

### Data Lineage Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ── ORIGINS ─────────────────────────────────────────────────────── %%
    subgraph Input ["Recipe Inputs"]
        TASK["task<br/>━━━━━━━━━━<br/>Feature description<br/>(ingredient)"]
        SRC["source_dir<br/>━━━━━━━━━━<br/>Repo root path<br/>(ingredient)"]
    end

    %% ── PHASE PASS ───────────────────────────────────────────────────── %%
    subgraph PhasePass ["Pass 1 — Phases"]
        direction TB
        ANALYZE["planner-analyze<br/>+ planner-generate-phases<br/>━━━━━━━━━━<br/>Headless skill sessions"]
        PHASE_RES[("phases/<br/>*_result.json<br/>━━━━━━━━━━<br/>id, ordering,<br/>assignments_preview")]
        VAL_PHASE["● validate_phase_result()<br/>━━━━━━━━━━<br/>schema.py<br/>Derives phase_number,<br/>name_slug, assignments"]
        BUILD_AM["● build_assignment_manifest()<br/>━━━━━━━━━━<br/>manifests.py<br/>Flattens phases → items<br/>Embeds result_dir"]
        AM[("● assignment_manifest.json<br/>━━━━━━━━━━<br/>pass_name, result_dir,<br/>created_at, items[]")]
    end

    %% ── ASSIGNMENT PASS ──────────────────────────────────────────────── %%
    subgraph AssignPass ["Pass 2 — Assignments"]
        direction TB
        CHECK_A["● check_remaining()<br/>━━━━━━━━━━<br/>manifests.py<br/>Reads result_dir from manifest<br/>pending→processing→done/failed"]
        CTX_A["context_{id}.json<br/>━━━━━━━━━━<br/>id, name, metadata,<br/>prior_results, wp_index_path"]
        ELAB_A["planner-elaborate-assignment<br/>━━━━━━━━━━<br/>Headless skill session"]
        ASSIGN_RES[("assignments/<br/>*_result.json<br/>━━━━━━━━━━<br/>id, phase_number,<br/>proposed_work_packages")]
        VAL_ASSIGN["● validate_assignment_result()<br/>━━━━━━━━━━<br/>schema.py<br/>Derives phase_number,<br/>assignment_number"]
    end

    %% ── WP PASS ──────────────────────────────────────────────────────── %%
    subgraph WPPass ["Pass 3 — Work Packages"]
        direction TB
        BUILD_WP["● build_wp_manifest()<br/>━━━━━━━━━━<br/>manifests.py<br/>Flattens assignments → items<br/>Embeds result_dir<br/>Inits wp_index.json"]
        WPM[("● wp_manifest.json<br/>━━━━━━━━━━<br/>pass_name, result_dir,<br/>created_at, items[]")]
        WPI[("wp_index.json<br/>━━━━━━━━━━<br/>[ ] → [{id,name,summary}]<br/>Appended on backstop")]
        CHECK_WP["● check_remaining()<br/>━━━━━━━━━━<br/>manifests.py<br/>+ _backstop_wp_index()"]
        CTX_WP["context_{id}.json<br/>━━━━━━━━━━<br/>id, name, metadata,<br/>prior_results, wp_index_path"]
        ELAB_WP["planner-elaborate-wp<br/>━━━━━━━━━━<br/>Headless skill session"]
        WP_RES[("work_packages/<br/>*_result.json<br/>━━━━━━━━━━<br/>id, name, summary,<br/>deliverables, depends_on")]
    end

    %% ── TERMINAL ─────────────────────────────────────────────────────── %%
    COMPILE(["compile_plan()<br/>+ validate_plan()"])

    %% ── FLOWS ────────────────────────────────────────────────────────── %%
    TASK -->|"env var"| ANALYZE
    SRC  -->|"cwd"| ANALYZE
    ANALYZE -->|"write"| PHASE_RES
    PHASE_RES -->|"read + validate"| VAL_PHASE
    VAL_PHASE -->|"sorted phases"| BUILD_AM
    BUILD_AM -->|"write (result_dir embedded)"| AM

    AM -->|"read manifest"| CHECK_A
    CHECK_A -.->|"write context"| CTX_A
    CTX_A -->|"path arg"| ELAB_A
    ELAB_A -->|"write result"| ASSIGN_RES
    ASSIGN_RES -->|"result_dir lookup"| CHECK_A
    CHECK_A -->|"update status"| AM

    ASSIGN_RES -->|"read + validate"| VAL_ASSIGN
    VAL_ASSIGN -->|"sorted assignments"| BUILD_WP
    BUILD_WP -->|"write (result_dir embedded)"| WPM
    BUILD_WP -->|"init empty"| WPI

    WPM -->|"read manifest"| CHECK_WP
    WPI -->|"backstop read"| CHECK_WP
    CHECK_WP -.->|"write context"| CTX_WP
    CTX_WP -->|"path arg"| ELAB_WP
    ELAB_WP -->|"write result"| WP_RES
    WP_RES -->|"result_dir lookup"| CHECK_WP
    CHECK_WP -->|"update status"| WPM
    CHECK_WP -->|"backstop append"| WPI

    WP_RES -->|"all done"| COMPILE
    AM -.->|"read phases"| COMPILE

    %% ── CLASS ASSIGNMENTS ────────────────────────────────────────────── %%
    class TASK,SRC cli;
    class PHASE_RES,AM,ASSIGN_RES,WPM,WPI,WP_RES stateNode;
    class VAL_PHASE,VAL_ASSIGN,BUILD_AM,BUILD_WP handler;
    class CHECK_A,CHECK_WP phase;
    class CTX_A,CTX_WP output;
    class ANALYZE,ELAB_A,ELAB_WP integration;
    class COMPILE terminal;
```

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 45, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START])
    DONE([DONE])
    ERROR([ESCALATE_STOP])

    %% ── PHASE 1: PIPELINE BOOTSTRAP ── %%
    subgraph Bootstrap ["Phase 1 · Pipeline Bootstrap"]
        direction TB
        Init["init<br/>━━━━━━━━━━<br/>mkdir phases/ assignments/<br/>work_packages/"]
        Analyze["analyze<br/>━━━━━━━━━━<br/>run_skill: planner-analyze<br/>→ analysis.json"]
        ExtractDomain["extract_domain<br/>━━━━━━━━━━<br/>run_skill: planner-extract-domain<br/>(optional — fails-forward)"]
        GenPhases["generate_phases<br/>━━━━━━━━━━<br/>run_skill: planner-generate-phases<br/>captures phase_manifest_path"]
    end

    %% ── PHASE 2: MANIFEST BUILDERS ── %%
    subgraph Builders ["Phase 2 · ● Manifest Builders (result_dir embedded)"]
        direction LR
        BuildAssign["● build_assignment_manifest<br/>━━━━━━━━━━<br/>reads phases/*_result.json<br/>writes assignment_manifest.json<br/>result_dir = assignments_dir.resolve()"]
        BuildWP["● build_wp_manifest<br/>━━━━━━━━━━<br/>reads assignments/*_result.json<br/>writes wp_manifest.json + wp_index.json<br/>result_dir = work_packages_dir.resolve()"]
    end

    %% ── PHASE 3: check_remaining STATE MACHINE ── %%
    subgraph CheckRemaining ["Phase 3 · ● check_remaining — Item Status State Machine"]
        direction TB
        ReadManifest["● Read manifest<br/>━━━━━━━━━━<br/>parse items list<br/>read result_dir from manifest<br/>(not inferred from output_dir)"]
        ScanProcessing{"item status<br/>== processing?"}
        ResultExists{"result file<br/>exists in result_dir?"}
        RetryLoop["retry loop<br/>━━━━━━━━━━<br/>sleep(1) × 2 attempts"]
        RetryCheck{"file found<br/>after retry?"}
        MarkDone["mark → done<br/>━━━━━━━━━━<br/>set result_path<br/>backstop wp_index if WP pass"]
        MarkFailed["mark → failed<br/>━━━━━━━━━━<br/>log warning<br/>continue to next item"]
        WPBackstop["● _backstop_wp_index<br/>━━━━━━━━━━<br/>if id missing from wp_index.json<br/>→ rebuild entry atomically"]
        FindPending{"next item<br/>status == pending?"}
        MarkProcessing["mark → processing<br/>━━━━━━━━━━<br/>write context_{id}.json<br/>(id, name, metadata,<br/>prior_results, wp_index_path)<br/>update manifest"]
    end

    %% ── PHASE 4: ELABORATE LOOPS ── %%
    subgraph ElaborateLoops ["Phase 4 · Elaborate Loops (recipe routing)"]
        direction TB
        ElabPhase["elaborate_phase<br/>━━━━━━━━━━<br/>run_skill: planner-elaborate-phase<br/>retries: 1"]
        ElabAssign["elaborate_assignment<br/>━━━━━━━━━━<br/>run_skill: planner-elaborate-assignment<br/>retries: 1"]
        ElabWP["elaborate_wp<br/>━━━━━━━━━━<br/>run_skill: planner-elaborate-wp<br/>retries: 2 / stale_threshold: 600s<br/>on_exhausted: check_wps (continue)"]
    end

    %% ── PHASE 5: VALIDATE / COMPILE ── %%
    subgraph Finalize ["Phase 5 · Validate & Compile"]
        direction TB
        Reconcile["reconcile_deps<br/>━━━━━━━━━━<br/>run_skill: planner-reconcile-deps"]
        Validate["validate<br/>━━━━━━━━━━<br/>callable: validate_plan<br/>captures verdict"]
        VerdictGate{"verdict<br/>== fail?"}
        Refine["refine<br/>━━━━━━━━━━<br/>run_skill: planner-refine<br/>retries: 2"]
        Compile["compile<br/>━━━━━━━━━━<br/>callable: compile_plan<br/>writes plan artifacts"]
    end

    %% ── ARTIFACTS ── %%
    subgraph Artifacts ["Manifest Artifacts (● schema updated)"]
        direction LR
        AManifest["● assignment_manifest.json<br/>━━━━━━━━━━<br/>pass_name, result_dir,<br/>created_at, items[]"]
        WPManifest["● wp_manifest.json<br/>━━━━━━━━━━<br/>pass_name, result_dir,<br/>created_at, items[]"]
        WPIndex["wp_index.json<br/>━━━━━━━━━━<br/>id / name / summary<br/>index of completed WPs"]
        ContextFile["context_{id}.json<br/>━━━━━━━━━━<br/>item context for skill<br/>includes prior_results"]
        PlanOut["plan artifacts<br/>━━━━━━━━━━<br/>issue body, milestones,<br/>compiled plan"]
    end

    %% ═══════════════════════════════════
    %%  CONNECTIONS
    %% ═══════════════════════════════════

    START --> Init
    Init --> Analyze
    Analyze --> ExtractDomain
    ExtractDomain -->|"success or failure"| GenPhases
    GenPhases -->|"phase_manifest_path"| CheckRemaining

    %% check_remaining internal flow
    CheckRemaining -.->|"calls"| ReadManifest
    ReadManifest --> ScanProcessing
    ScanProcessing -->|"yes"| ResultExists
    ScanProcessing -->|"no (all done/failed)"| FindPending
    ResultExists -->|"yes"| MarkDone
    ResultExists -->|"no"| RetryLoop
    RetryLoop --> RetryCheck
    RetryCheck -->|"yes (found on retry)"| MarkDone
    RetryCheck -->|"no"| MarkFailed
    MarkDone -->|"pass_name == work_packages"| WPBackstop
    WPBackstop --> FindPending
    MarkDone --> FindPending
    MarkFailed --> FindPending
    FindPending -->|"yes → set processing"| MarkProcessing
    MarkProcessing -->|"writes"| ContextFile
    MarkProcessing -->|"has_remaining=true"| ElabPhase
    MarkProcessing -->|"has_remaining=true"| ElabAssign
    MarkProcessing -->|"has_remaining=true"| ElabWP
    FindPending -->|"no → has_remaining=false"| BuildAssign

    %% elaborate loops
    ElabPhase -->|"on_success: check_phases"| CheckRemaining
    ElabAssign -->|"on_success: check_assignments"| CheckRemaining
    ElabWP -->|"on_success / on_exhausted: check_wps"| CheckRemaining

    %% manifest build pipeline
    BuildAssign -->|"writes"| AManifest
    AManifest -->|"manifest_path"| CheckRemaining
    FindPending -->|"phases exhausted"| BuildAssign
    BuildAssign --> BuildWP
    BuildWP -->|"writes"| WPManifest
    BuildWP -->|"writes"| WPIndex
    WPManifest -->|"manifest_path"| CheckRemaining

    %% finalize
    CheckRemaining -->|"WP pass exhausted"| Reconcile
    Reconcile --> Validate
    Validate --> VerdictGate
    VerdictGate -->|"fail"| Refine
    Refine -->|"retry → validate"| Validate
    Refine -->|"exhausted"| ERROR
    VerdictGate -->|"pass"| Compile
    Compile -->|"writes"| PlanOut
    Compile --> DONE

    Init -->|"failure"| ERROR
    Analyze -->|"failure"| ERROR
    GenPhases -->|"failure"| ERROR
    BuildAssign -->|"failure"| ERROR
    BuildWP -->|"failure"| ERROR
    Reconcile -->|"failure"| ERROR
    Validate -->|"failure"| ERROR

    %% CLASS ASSIGNMENTS %%
    class START,DONE,ERROR terminal;
    class Init,Analyze,ExtractDomain,GenPhases handler;
    class BuildAssign,BuildWP handler;
    class ReadManifest,MarkDone,MarkFailed,MarkProcessing,WPBackstop handler;
    class ScanProcessing,ResultExists,RetryCheck,FindPending,VerdictGate stateNode;
    class RetryLoop detector;
    class ElabPhase,ElabAssign,ElabWP phase;
    class Reconcile,Validate,Refine,Compile phase;
    class AManifest,WPManifest,WPIndex,ContextFile,PlanOut output;
```

Closes #1332

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260426-194943-646729/.autoskillit/temp/rectify/rectify_check_remaining_manifest_result_dir_contract_2026-04-26_120000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->
