### PR TITLE
Rectify: CLI Auto-Update Re-exec Gap — NoReturn Process Restart Contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -283,6 +283,7 @@ generic_automation_mcp/
 │   ├── _cook.py             #   cook: ephemeral skill session launcher
 │   ├── _fleet.py            #   fleet sub-app: run, list, status campaign commands
 │   ├── _reload.py           #   consume_reload_sentinel: reload sentinel detection for re-launch loops
+│   ├── _restart.py          #   perform_restart() -> NoReturn: sets SKIP_UPDATE_CHECK, calls os.execv
 │   ├── _session_launch.py   #   _run_interactive_session: shared interactive session launch prelude
 │   ├── _doctor.py           #   16 project setup checks
 │   ├── _hooks.py            #   PreToolUse hook registration helpers

--- a/src/autoskillit/cli/_restart.py
+++ b/src/autoskillit/cli/_restart.py
@@ -1,0 +1,12 @@
+"""Process restart contract for post-upgrade re-exec."""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import NoReturn
+
+
+def perform_restart() -> NoReturn:
+    os.environ["AUTOSKILLIT_SKIP_UPDATE_CHECK"] = "1"
+    os.execv(sys.executable, [sys.executable] + sys.argv)

--- a/src/autoskillit/cli/_update.py
+++ b/src/autoskillit/cli/_update.py
@@ -12,6 +12,7 @@ import subprocess
 from pathlib import Path
 
 from autoskillit.cli._install_info import comparison_branch, detect_install, upgrade_command
+from autoskillit.cli._restart import perform_restart
 from autoskillit.cli._terminal import terminal_guard
 
 
@@ -88,3 +89,4 @@ def run_update_command(home: Path | None = None) -> None:
         _write_dismiss_state(_home, state)
         invalidate_fetch_cache(_home)
         print("AutoSkillit updated successfully.", flush=True)
+        perform_restart()

--- a/src/autoskillit/cli/_update_checks.py
+++ b/src/autoskillit/cli/_update_checks.py
@@ -36,6 +36,7 @@ from autoskillit.cli._install_info import (
     dismissal_window,
     upgrade_command,
 )
+from autoskillit.cli._restart import perform_restart
 from autoskillit.cli._terminal import terminal_guard
 from autoskillit.core import AUTOSKILLIT_INSTALLED_VERSION, atomic_write, get_logger
 from autoskillit.hook_registry import _count_hook_registry_drift
@@ -653,6 +654,7 @@ def _run_update_sequence(
         state.pop("binary_snoozed", None)
         _write_dismiss_state(home, state)
         invalidate_fetch_cache(home)
+        perform_restart()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -705,7 +705,9 @@ def test_no_subpackage_exceeds_10_files() -> None:
         sessions by type (cook/order) using the session registry.
         _sessions.py adds the sessions analyze CLI subcommand for cross-session
         tool call sequence diagnostics.
-        Exempt at 26 files.
+        _restart.py adds the perform_restart() NoReturn contract for post-upgrade
+        process re-exec, keeping the restart logic isolated from update orchestration.
+        Exempt at 27 files.
       hooks/ — REQ-CNST-003-E6: hooks/ hosts one standalone script per hook event
         (PreToolUse, PostToolUse, SessionStart). Each script must remain a separate
         file so Claude Code can invoke it directly as a subprocess. pretty_output_hook.py
@@ -723,7 +725,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "recipe": 38,
         "execution": 26,
         "core": 26,
-        "cli": 26,
+        "cli": 27,
         "hooks": 27,
     }
     violations: list[str] = []

--- a/tests/cli/test_app_main.py
+++ b/tests/cli/test_app_main.py
@@ -1,0 +1,35 @@
+"""Tests for autoskillit.cli.app.main() entry point behaviour."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
+
+
+def test_main_does_not_call_app_after_update_restart(monkeypatch: pytest.MonkeyPatch) -> None:
+    """main() must not call app() when run_update_checks triggers a process exit."""
+    import autoskillit.cli.app as app_module
+
+    app_called: list[bool] = []
+    monkeypatch.setattr(app_module, "app", lambda: app_called.append(True))
+
+    monkeypatch.setattr(
+        "autoskillit.cli._init_helpers.evict_direct_mcp_entry", lambda *a, **kw: None
+    )
+
+    def fake_run_update_checks() -> None:
+        raise SystemExit(0)
+
+    monkeypatch.setattr("autoskillit.cli._update_checks.run_update_checks", fake_run_update_checks)
+    monkeypatch.setattr(sys, "argv", ["autoskillit", "order"])
+
+    try:
+        app_module.main()
+    except SystemExit:
+        pass
+
+    assert not app_called, "app() must not be called when update path exits the process"

--- a/tests/cli/test_app_main.py
+++ b/tests/cli/test_app_main.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+import importlib
 import sys
-from unittest.mock import patch
 
 import pytest
 
@@ -12,7 +12,8 @@ pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
 
 def test_main_does_not_call_app_after_update_restart(monkeypatch: pytest.MonkeyPatch) -> None:
     """main() must not call app() when run_update_checks triggers a process exit."""
-    import autoskillit.cli.app as app_module
+
+    app_module = importlib.import_module("autoskillit.cli.app")
 
     app_called: list[bool] = []
     monkeypatch.setattr(app_module, "app", lambda: app_called.append(True))

--- a/tests/cli/test_restart.py
+++ b/tests/cli/test_restart.py
@@ -18,6 +18,7 @@ def test_perform_restart_sets_skip_env_and_execs() -> None:
     captured: dict[str, object] = {}
 
     def fake_execv(exe: str, args: list[str]) -> None:
+        assert os.environ.get("AUTOSKILLIT_SKIP_UPDATE_CHECK") == "1"
         captured["exe"] = exe
         captured["args"] = args
         raise SystemExit(0)
@@ -29,7 +30,6 @@ def test_perform_restart_sets_skip_env_and_execs() -> None:
             except SystemExit:
                 pass
 
-        assert os.environ.get("AUTOSKILLIT_SKIP_UPDATE_CHECK") == "1"
         assert captured["exe"] == sys.executable
         assert captured["args"] == [sys.executable] + sys.argv
 

--- a/tests/cli/test_restart.py
+++ b/tests/cli/test_restart.py
@@ -29,9 +29,9 @@ def test_perform_restart_sets_skip_env_and_execs() -> None:
             except SystemExit:
                 pass
 
-    assert os.environ.get("AUTOSKILLIT_SKIP_UPDATE_CHECK") == "1"
-    assert captured["exe"] == sys.executable
-    assert captured["args"] == [sys.executable] + sys.argv
+        assert os.environ.get("AUTOSKILLIT_SKIP_UPDATE_CHECK") == "1"
+        assert captured["exe"] == sys.executable
+        assert captured["args"] == [sys.executable] + sys.argv
 
 
 def test_perform_restart_is_noreturn_typed() -> None:

--- a/tests/cli/test_restart.py
+++ b/tests/cli/test_restart.py
@@ -1,0 +1,44 @@
+"""Tests for cli/_restart.py — NoReturn process restart contract."""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
+
+
+def test_perform_restart_sets_skip_env_and_execs() -> None:
+    """perform_restart must set AUTOSKILLIT_SKIP_UPDATE_CHECK=1 then call os.execv."""
+    from autoskillit.cli._restart import perform_restart
+
+    captured: dict[str, object] = {}
+
+    def fake_execv(exe: str, args: list[str]) -> None:
+        captured["exe"] = exe
+        captured["args"] = args
+        raise SystemExit(0)
+
+    with patch.dict(os.environ, {}, clear=False):
+        with patch("autoskillit.cli._restart.os.execv", fake_execv):
+            try:
+                perform_restart()
+            except SystemExit:
+                pass
+
+    assert os.environ.get("AUTOSKILLIT_SKIP_UPDATE_CHECK") == "1"
+    assert captured["exe"] == sys.executable
+    assert captured["args"] == [sys.executable] + sys.argv
+
+
+def test_perform_restart_is_noreturn_typed() -> None:
+    """perform_restart must be annotated as -> NoReturn."""
+    import typing
+
+    from autoskillit.cli._restart import perform_restart
+
+    hints = typing.get_type_hints(perform_restart)
+    assert hints.get("return") is typing.NoReturn

--- a/tests/cli/test_update_checks.py
+++ b/tests/cli/test_update_checks.py
@@ -667,6 +667,7 @@ def test_yes_runs_upgrade_command_from_install_info_not_hardcoded(
     monkeypatch.setattr(
         "autoskillit.cli._update_checks._fetch_latest_version", lambda *a, **kw: "0.9.0"
     )
+    monkeypatch.setattr("autoskillit.cli._update_checks.perform_restart", lambda: None)
     expected_cmd = upgrade_command(info)
     run_update_checks(home=tmp_path)
     assert expected_cmd in run_calls, (
@@ -695,6 +696,7 @@ def test_yes_runs_autoskillit_install_after_upgrade_command(
     monkeypatch.setattr(
         "autoskillit.cli._update_checks._verify_update_result", lambda *a, **kw: True
     )
+    monkeypatch.setattr("autoskillit.cli._update_checks.perform_restart", lambda: None)
     run_update_checks(home=tmp_path)
     # ["autoskillit", "install"] must be among the calls
     assert any(cmd[:2] == ["autoskillit", "install"] for cmd in run_calls)
@@ -723,6 +725,7 @@ def test_yes_passes_skip_env_to_subprocess(
     monkeypatch.setattr(
         "autoskillit.cli._update_checks._verify_update_result", lambda *a, **kw: True
     )
+    monkeypatch.setattr("autoskillit.cli._update_checks.perform_restart", lambda: None)
     run_update_checks(home=tmp_path)
     for env in env_passed:
         assert env.get("AUTOSKILLIT_SKIP_STALE_CHECK") == "1"
@@ -752,6 +755,7 @@ def test_yes_single_invocation_exits_without_any_other_prompt(
     monkeypatch.setattr(
         "autoskillit.cli._update_checks._verify_update_result", lambda *a, **kw: True
     )
+    monkeypatch.setattr("autoskillit.cli._update_checks.perform_restart", lambda: None)
     run_update_checks(home=tmp_path)
     assert len(input_calls) == 1
 
@@ -2191,6 +2195,7 @@ def test_run_update_sequence_warns_on_install_failure(
     monkeypatch.setattr(
         "autoskillit.cli._update_checks._verify_update_result", lambda *a, **kw: True
     )
+    monkeypatch.setattr("autoskillit.cli._update_checks.perform_restart", lambda: None)
     _run_update_sequence(info, "0.9.0", tmp_path, {}, {})
     out = capsys.readouterr().out
     assert "autoskillit install" in out

--- a/tests/cli/test_update_checks.py
+++ b/tests/cli/test_update_checks.py
@@ -1753,6 +1753,7 @@ def test_run_update_sequence_invalidates_fetch_cache(
     monkeypatch.setattr(
         "autoskillit.cli._update_checks._verify_update_result", lambda *a, **kw: True
     )
+    monkeypatch.setattr("autoskillit.cli._update_checks.perform_restart", lambda: None)
     _run_update_sequence(info, "0.9.0", tmp_path, {}, {})
     assert not cache_file.exists(), "Fetch cache must be deleted after successful update"
 
@@ -1794,6 +1795,7 @@ def test_run_update_command_invalidates_fetch_cache(
     monkeypatch.setattr(
         "autoskillit.cli._update_checks._fetch_latest_version", lambda *a, **kw: "0.9.1"
     )
+    monkeypatch.setattr("autoskillit.cli._update.perform_restart", lambda: None)
 
     run_update_command(home=tmp_path)
     assert not cache_file.exists(), "Fetch cache must be deleted after successful update command"
@@ -2198,6 +2200,46 @@ def test_run_update_sequence_warns_on_install_failure(
 # ---------------------------------------------------------------------------
 # T6 — binary_snoozed is never written by _verify_update_result
 # ---------------------------------------------------------------------------
+
+
+def test_run_update_sequence_restarts_on_success(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """After a successful upgrade, _run_update_sequence must call perform_restart."""
+    from autoskillit.cli._update_checks import _run_update_sequence
+
+    info = _make_stable_info()
+    upgrade_ok = subprocess.CompletedProcess([], returncode=0)
+    install_ok = subprocess.CompletedProcess([], returncode=0)
+    calls = iter([upgrade_ok, install_ok])
+    monkeypatch.setattr(
+        "autoskillit.cli._update_checks.subprocess.run", lambda *a, **kw: next(calls)
+    )
+
+    class FakeTG:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr("autoskillit.cli._update_checks.terminal_guard", FakeTG)
+    monkeypatch.setattr(
+        "autoskillit.cli._update_checks._fetch_latest_version", lambda *a, **kw: "0.9.1"
+    )
+    monkeypatch.setattr(
+        "autoskillit.cli._update_checks._verify_update_result", lambda *a, **kw: True
+    )
+
+    restart_called: list[bool] = []
+    monkeypatch.setattr(
+        "autoskillit.cli._update_checks.perform_restart", lambda: restart_called.append(True)
+    )
+
+    _run_update_sequence(info, "0.9.0", tmp_path, {}, {})
+    assert restart_called, (
+        "_run_update_sequence must call perform_restart() after successful upgrade"
+    )
 
 
 def test_verify_update_result_does_not_write_binary_snoozed(

--- a/tests/cli/test_update_command.py
+++ b/tests/cli/test_update_command.py
@@ -59,6 +59,7 @@ def _setup_run_update(
     import importlib.metadata
 
     monkeypatch.setattr(importlib.metadata, "version", lambda _name: new_version)
+    monkeypatch.setattr("autoskillit.cli._update.perform_restart", lambda: None)
     return run_calls
 
 
@@ -150,6 +151,7 @@ def test_update_passes_skip_env_to_subprocess(
     import importlib.metadata
 
     monkeypatch.setattr(importlib.metadata, "version", lambda _name: "0.9.0")
+    monkeypatch.setattr("autoskillit.cli._update.perform_restart", lambda: None)
     run_update_command(home=tmp_path)
 
     for env in env_passed:
@@ -228,6 +230,7 @@ def test_update_clears_dismissal_state_on_success(
     monkeypatch.setattr(importlib.metadata, "version", lambda _name: "0.9.0")
 
     monkeypatch.setattr("builtins.print", lambda *a, **kw: None)
+    monkeypatch.setattr("autoskillit.cli._update.perform_restart", lambda: None)
     run_update_command(home=tmp_path)
     state = _read_dismiss_state(tmp_path)
     assert "update_prompt" not in state
@@ -276,6 +279,45 @@ def test_run_update_command_warns_on_install_failure(
     import importlib.metadata
 
     monkeypatch.setattr(importlib.metadata, "version", lambda _: "0.9.1")
+    monkeypatch.setattr("autoskillit.cli._update.perform_restart", lambda: None)
     run_update_command(home=tmp_path)
     out = capsys.readouterr().out
     assert "autoskillit install" in out
+
+
+def test_run_update_command_restarts_on_success(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """After a successful upgrade, run_update_command must call perform_restart."""
+    from autoskillit.cli._update import run_update_command
+
+    info = _make_info(InstallType.GIT_VCS, revision="stable")
+    monkeypatch.setattr("autoskillit.cli._update.detect_install", lambda: info)
+    monkeypatch.setattr("autoskillit.cli._update.terminal_guard", FakeTG)
+    monkeypatch.setattr("autoskillit.core.any_kitchen_open", lambda: False)
+    monkeypatch.setattr(
+        "autoskillit.cli._update.subprocess.run",
+        lambda *a, **kw: subprocess.CompletedProcess([], 0),
+    )
+    monkeypatch.setattr(
+        "autoskillit.cli._update_checks._fetch_latest_version", lambda *a, **kw: "0.9.1"
+    )
+
+    import autoskillit as _pkg
+
+    monkeypatch.setattr(_pkg, "__version__", "0.9.0")
+
+    import importlib.metadata
+
+    monkeypatch.setattr(importlib.metadata, "version", lambda _name: "0.9.1")
+    monkeypatch.setattr("builtins.print", lambda *a, **kw: None)
+
+    restart_called: list[bool] = []
+    monkeypatch.setattr(
+        "autoskillit.cli._update.perform_restart", lambda: restart_called.append(True)
+    )
+
+    run_update_command(home=tmp_path)
+    assert restart_called, (
+        "run_update_command must call perform_restart() after successful upgrade"
+    )

--- a/tests/contracts/test_core_public_api_surface.py
+++ b/tests/contracts/test_core_public_api_surface.py
@@ -14,8 +14,7 @@ def test_all_public_symbols_importable() -> None:
     failures: list[str] = []
     for symbol in core_module.__all__:
         try:
-            result = getattr(core_module, symbol)
-            assert result is not None or True  # trigger the lazy-load
+            getattr(core_module, symbol)
         except (ImportError, AttributeError) as exc:
             failures.append(f"{symbol}: {exc}")
     assert not failures, "Public API surface broken:\n" + "\n".join(failures)

--- a/tests/contracts/test_core_public_api_surface.py
+++ b/tests/contracts/test_core_public_api_surface.py
@@ -8,7 +8,7 @@ pytestmark = [pytest.mark.layer("contracts"), pytest.mark.small]
 
 
 def test_all_public_symbols_importable() -> None:
-    """Every symbol in autoskillit.core.__all__ must be importable via 'from autoskillit.core import X'."""
+    """Every symbol in autoskillit.core.__all__ must be importable via the public gateway."""
     import autoskillit.core as core_module
 
     failures: list[str] = []

--- a/tests/contracts/test_core_public_api_surface.py
+++ b/tests/contracts/test_core_public_api_surface.py
@@ -1,0 +1,21 @@
+"""Validates that every symbol in autoskillit.core.__all__ is importable via the public gateway."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.layer("contracts"), pytest.mark.small]
+
+
+def test_all_public_symbols_importable() -> None:
+    """Every symbol in autoskillit.core.__all__ must be importable via 'from autoskillit.core import X'."""
+    import autoskillit.core as core_module
+
+    failures: list[str] = []
+    for symbol in core_module.__all__:
+        try:
+            result = getattr(core_module, symbol)
+            assert result is not None or True  # trigger the lazy-load
+        except (ImportError, AttributeError) as exc:
+            failures.append(f"{symbol}: {exc}")
+    assert not failures, "Public API surface broken:\n" + "\n".join(failures)

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -146,9 +146,9 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _marketplace.py — hooks.json (co-owned)
     ("src/autoskillit/cli/_marketplace.py", 172),
     # _update_checks.py — dismissal state file
-    ("src/autoskillit/cli/_update_checks.py", 102),
+    ("src/autoskillit/cli/_update_checks.py", 103),
     # _update_checks.py — fetch cache
-    ("src/autoskillit/cli/_update_checks.py", 129),
+    ("src/autoskillit/cli/_update_checks.py", 130),
     # smoke_utils.py — domain partitions dict, hunk ranges list, merge queue list
     ("src/autoskillit/smoke_utils.py", 57),
     ("src/autoskillit/smoke_utils.py", 87),


### PR DESCRIPTION
## Summary

After a successful auto-upgrade, both `_run_update_sequence()` (in `_update_checks.py`) and `run_update_command()` (in `_update.py`) return to their caller. `main()` then unconditionally calls `app()`, which triggers deferred imports against new on-disk modules while `sys.modules` still caches old module objects. The immediate symptom is `ImportError: cannot import name 'CORE_PACKS' from 'autoskillit.core'`.

The architectural weakness is that the "upgrade succeeded" path has no enforced postcondition. Both functions are free to return after a successful upgrade, and nothing prevents `app()` from executing against a hybrid module state. The fix is not merely adding `os.execv` in two places; it is extracting a `perform_restart() -> NoReturn` contract into a dedicated module, making the postcondition structurally unbypassable and instantly testable.

A secondary architectural gap is that many tests import from private `autoskillit.core._type_constants` instead of the public `autoskillit.core` gateway. This means lazy-loader regressions (the class of failure that produced the ImportError) are invisible to the test suite.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 42, 'rankSpacing': 52, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START_CHECK([CLI startup<br/>run_update_checks])
    START_CMD([autoskillit update<br/>run_update_command])
    END_SKIP([return — skipped])
    END_DISMISS([return — dismissed])
    END_TIMEOUT([return — timeout])
    END_FAIL([SystemExit / error])
    RESTART([★ perform_restart<br/>━━━━━━━━━━<br/>os.execv → NoReturn<br/>sets SKIP_UPDATE_CHECK=1])

    %% ─── PATH A: startup check ───────────────────────────────────────── %%
    subgraph GuardPhase ["Guard Phase — run_update_checks (●_update_checks.py)"]
        direction TB
        G1{"CLAUDECODE=1<br/>or CI=1<br/>or SKIP env vars<br/>or non-TTY?"}
        G2{"any_kitchen_open?"}
        G3{"install type<br/>LOCAL_EDITABLE /<br/>LOCAL_PATH /<br/>UNKNOWN?"}
    end

    subgraph SignalPhase ["Signal Gathering — parallel checks"]
        direction LR
        SIG_BIN["_binary_signal<br/>━━━━━━━━━━<br/>GitHub releases API<br/>version compare"]
        SIG_HOOKS["_hooks_signal<br/>━━━━━━━━━━<br/>hook registry drift<br/>orphaned / missing"]
        SIG_DRIFT["_source_drift_signal<br/>━━━━━━━━━━<br/>resolve_reference_sha<br/>commit lag check"]
        SIG_DUAL["_dual_mcp_signal<br/>━━━━━━━━━━<br/>dual MCP registration<br/>detection"]
    end

    subgraph DismissPhase ["Dismissal Partition"]
        direction TB
        PART{"any signals<br/>fired?"}
        DISMISS_CHK{"all signals<br/>dismissed?"}
        IS_DISMISSED["_is_dismissed<br/>━━━━━━━━━━<br/>time window +<br/>version delta check"]
    end

    subgraph PromptPhase ["Interactive Prompt"]
        direction TB
        PROMPT["timed_prompt<br/>━━━━━━━━━━<br/>30s timeout<br/>Update now? [Y/n]"]
        ANS{"answer?"}
        WRITE_DISMISS["_write_dismiss_state<br/>━━━━━━━━━━<br/>record conditions +<br/>dismissed_version"]
    end

    %% ─── PATH B: explicit update command ─────────────────────────────── %%
    subgraph UpdateCmd ["● run_update_command (_update.py)"]
        direction TB
        UC_KITCHEN{"any_kitchen_open?"}
        UC_DETECT["detect_install<br/>━━━━━━━━━━<br/>reads direct_url.json"]
        UC_CMD{"upgrade_command<br/>returns None?"}
    end

    %% ─── SHARED: upgrade sequence ────────────────────────────────────── %%
    subgraph UpgradeSeq ["Upgrade Sequence (shared logic)"]
        direction TB
        RUN_UPGRADE["subprocess.run upgrade_cmd<br/>━━━━━━━━━━<br/>uv pip install / git pull<br/>inside terminal_guard"]
        RUN_INSTALL["subprocess.run autoskillit install<br/>━━━━━━━━━━<br/>sync hooks + plugin cache"]
        VERIFY["_verify_update_result<br/>━━━━━━━━━━<br/>importlib.metadata.version<br/>bypasses lru_cache"]
        VER_ADV{"version<br/>advanced?"}
        CLEAR_STATE["clear dismiss state<br/>invalidate_fetch_cache"]
    end

    %% ─── FLOWS ───────────────────────────────────────────────────────── %%

    %% Path A: startup check
    START_CHECK --> G1
    G1 -->|"yes"| END_SKIP
    G1 -->|"no"| G2
    G2 -->|"yes"| END_SKIP
    G2 -->|"no"| G3
    G3 -->|"yes (no FORCE flag)"| END_SKIP
    G3 -->|"no"| SIG_BIN & SIG_HOOKS & SIG_DRIFT & SIG_DUAL
    SIG_BIN & SIG_HOOKS & SIG_DRIFT & SIG_DUAL --> PART

    PART -->|"none fired"| END_SKIP
    PART -->|"some fired"| IS_DISMISSED
    IS_DISMISSED --> DISMISS_CHK
    DISMISS_CHK -->|"all dismissed"| END_DISMISS
    DISMISS_CHK -->|"undismissed exist"| PROMPT

    PROMPT --> ANS
    ANS -->|"timeout"| END_TIMEOUT
    ANS -->|"N"| WRITE_DISMISS
    WRITE_DISMISS --> END_DISMISS
    ANS -->|"Y"| RUN_UPGRADE

    %% Path B: explicit command
    START_CMD --> UC_KITCHEN
    UC_KITCHEN -->|"yes"| END_FAIL
    UC_KITCHEN -->|"no"| UC_DETECT
    UC_DETECT --> UC_CMD
    UC_CMD -->|"yes"| END_FAIL
    UC_CMD -->|"no"| RUN_UPGRADE

    %% Shared upgrade sequence
    RUN_UPGRADE --> RUN_INSTALL
    RUN_INSTALL --> VERIFY
    VERIFY --> VER_ADV
    VER_ADV -->|"no — version unchanged"| END_FAIL
    VER_ADV -->|"yes"| CLEAR_STATE
    CLEAR_STATE --> RESTART

    %% CLASS ASSIGNMENTS %%
    class START_CHECK,START_CMD cli;
    class END_SKIP,END_DISMISS,END_TIMEOUT,END_FAIL terminal;
    class RESTART newComponent;
    class G1,G2,G3,PART,DISMISS_CHK,ANS,UC_KITCHEN,UC_CMD,VER_ADV stateNode;
    class SIG_BIN,SIG_HOOKS,SIG_DRIFT,SIG_DUAL detector;
    class IS_DISMISSED,WRITE_DISMISS,CLEAR_STATE phase;
    class PROMPT,RUN_UPGRADE,RUN_INSTALL,VERIFY,UC_DETECT handler;
```

### Error/Resilience Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;

    T_SKIP([SKIP — silent return])
    T_ABORT([ABORT — SystemExit])
    T_DISMISS([DISMISSED — one-liner printed])
    T_RESTART([★ DONE — os.execv re-launch])
    T_NOUPDATE([NO UPDATE — version unchanged])

    subgraph Gates ["● VALIDATION GATES (Fail-Fast)"]
        G_ENV["● Headless / CI / Skip Guard<br/>━━━━━━━━━━<br/>CLAUDECODE=1, CI=1<br/>SKIP_UPDATE_CHECK, non-TTY"]
        G_KITCHEN_CHK["● Kitchen Open Guard<br/>━━━━━━━━━━<br/>run_update_checks:<br/>any_kitchen_open() → return"]
        G_KITCHEN_CMD["● Kitchen Open Guard<br/>━━━━━━━━━━<br/>run_update_command:<br/>any_kitchen_open() → SystemExit(1)"]
        G_INSTALL["● Install Type Guard<br/>━━━━━━━━━━<br/>UNKNOWN / LOCAL_PATH /<br/>LOCAL_EDITABLE → skip"]
        G_CMD["● Upgrade Command Guard<br/>━━━━━━━━━━<br/>upgrade_command() → None<br/>→ SystemExit(2)"]
    end

    subgraph Signals ["● Signal Gathering (All Fail-Open → None)"]
        S_BINARY["● _binary_signal()<br/>━━━━━━━━━━<br/>GitHub releases API<br/>packaging.version compare"]
        S_HOOKS["● _hooks_signal()<br/>━━━━━━━━━━<br/>Hook registry drift<br/>orphaned / missing count"]
        S_DRIFT["● _source_drift_signal()<br/>━━━━━━━━━━<br/>resolve_reference_sha()<br/>git ls-remote → API fallback"]
        S_MCP["● _dual_mcp_signal()<br/>━━━━━━━━━━<br/>Dual MCP registration<br/>_check_dual_mcp_files (never raises)"]
    end

    subgraph FetchCache ["● Network / Disk Cache Layer"]
        FC_HIT{"Cache Hit?<br/>━━━━━━━━━━<br/>30-min TTL<br/>+ version key"}
        FC_HTTP["● _fetch_with_cache()<br/>━━━━━━━━━━<br/>httpx connect=2s read=1s<br/>ETag / If-None-Match"]
        FC_ERR["Network Failure<br/>━━━━━━━━━━<br/>timeout / DNS / 4xx/5xx<br/>→ return None (logged debug)"]
        FC_SCRUB["_scrub_auth()<br/>━━━━━━━━━━<br/>Redacts GITHUB_TOKEN<br/>Bearer *** from logs"]
    end

    subgraph DismissState ["● Dismissal State Machine"]
        DS_READ["● _read_dismiss_state()<br/>━━━━━━━━━━<br/>~/.autoskillit/update_check.json<br/>→ {} on any read/parse error"]
        DS_PARTITION{"● _is_dismissed()<br/>━━━━━━━━━━<br/>window expired?<br/>version delta expired?<br/>condition in entry?"}
        DS_WRITE["● _write_dismiss_state()<br/>━━━━━━━━━━<br/>atomic_write()<br/>records conditions + dismissed_at"]
    end

    subgraph UpdateSeq ["● Update Execution — _run_update_sequence()"]
        U_RUN["● Run upgrade_command()<br/>━━━━━━━━━━<br/>subprocess.run(check=False)<br/>SKIP_UPDATE_CHECK env set"]
        U_INSTALL["● autoskillit install<br/>━━━━━━━━━━<br/>subprocess.run(check=False)<br/>rc != 0 → warn, continue"]
        U_VERIFY["● _verify_update_result()<br/>━━━━━━━━━━<br/>importlib.metadata.version()<br/>bypasses lru_cache"]
        U_INVAL["● invalidate_fetch_cache()<br/>━━━━━━━━━━<br/>unlink(missing_ok=True)<br/>silent on OSError"]
    end

    subgraph RestartContract ["★ Restart Contract — _restart.py (NEW)"]
        R_ENV["★ Set SKIP_UPDATE_CHECK=1<br/>━━━━━━━━━━<br/>os.environ mutation<br/>prevents re-check import loop"]
        R_EXEC["★ perform_restart() → NoReturn<br/>━━━━━━━━━━<br/>os.execv(sys.executable, argv)<br/>replaces process image"]
    end

    %% ── GATE FLOW ──────────────────────────────────── %%
    G_ENV -->|"headless / CI / non-TTY"| T_SKIP
    G_ENV -->|"interactive TTY"| G_KITCHEN_CHK
    G_KITCHEN_CHK -->|"kitchen open"| T_SKIP
    G_KITCHEN_CHK -->|"kitchen closed"| G_INSTALL
    G_INSTALL -->|"unknown / local type"| T_SKIP
    G_INSTALL -->|"trackable install"| DS_READ

    G_KITCHEN_CMD -->|"kitchen open"| T_ABORT
    G_KITCHEN_CMD -->|"kitchen closed"| G_CMD
    G_CMD -->|"cmd is None"| T_ABORT
    G_CMD -->|"cmd resolved"| U_RUN

    %% ── SIGNAL + FETCH ──────────────────────────────── %%
    DS_READ --> S_BINARY & S_HOOKS & S_DRIFT & S_MCP
    S_BINARY & S_DRIFT --> FC_HIT
    FC_HIT -->|"fresh + version match"| S_BINARY
    FC_HIT -->|"miss / stale / version mismatch"| FC_HTTP
    FC_HTTP -->|"200 OK — update cache"| FC_HIT
    FC_HTTP -->|"304 — refresh cached_at"| FC_HIT
    FC_HTTP -->|"error / timeout"| FC_SCRUB
    FC_SCRUB --> FC_ERR
    FC_ERR -->|"→ None"| S_BINARY

    %% ── DISMISSAL ───────────────────────────────────── %%
    S_BINARY & S_HOOKS & S_DRIFT & S_MCP --> DS_PARTITION
    DS_PARTITION -->|"all signals dismissed"| DS_WRITE
    DS_WRITE -->|"passive one-liner"| T_DISMISS
    DS_PARTITION -->|"undismissed signals exist"| U_RUN

    %% ── UPDATE SEQUENCE ─────────────────────────────── %%
    U_RUN --> U_INSTALL
    U_INSTALL -->|"rc=0"| U_VERIFY
    U_INSTALL -->|"rc!=0: warn + continue"| U_VERIFY
    U_VERIFY -->|"version unchanged"| T_NOUPDATE
    U_VERIFY -->|"version advanced"| U_INVAL
    U_INVAL --> R_ENV

    %% ── RESTART ─────────────────────────────────────── %%
    R_ENV --> R_EXEC
    R_EXEC --> T_RESTART

    %% ── CLASS ASSIGNMENTS ───────────────────────────── %%
    class G_ENV,G_KITCHEN_CHK,G_KITCHEN_CMD,G_INSTALL,G_CMD detector;
    class S_BINARY,S_HOOKS,S_DRIFT,S_MCP handler;
    class FC_HTTP,FC_SCRUB handler;
    class FC_HIT,DS_PARTITION stateNode;
    class FC_ERR gap;
    class DS_READ,DS_WRITE,U_INVAL output;
    class U_RUN,U_INSTALL,U_VERIFY phase;
    class R_ENV,R_EXEC newComponent;
    class T_SKIP,T_ABORT,T_DISMISS,T_RESTART,T_NOUPDATE terminal;
```

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START([CLI invocation<br/>autoskillit …])

    subgraph EntryGuards ["● ENTRY GUARDS — run_update_checks()"]
        direction TB
        G_ENV["Env / TTY Guard<br/>━━━━━━━━━━<br/>CLAUDECODE=1 → skip<br/>CI=1 → skip<br/>SKIP_UPDATE_CHECK=1 → skip<br/>non-TTY → skip"]
        G_KITCHEN["Kitchen Open Guard<br/>━━━━━━━━━━<br/>any_kitchen_open() → skip<br/>pipeline running → silent exit"]
        G_INSTALL["Install-Type Guard<br/>━━━━━━━━━━<br/>LOCAL_EDITABLE → skip<br/>LOCAL_PATH → skip<br/>UNKNOWN → skip<br/>(unless FORCE flag)"]
    end

    subgraph DismissState ["● DISMISS STATE — update_check.json (INIT_PRESERVE)"]
        direction TB
        DS_READ["_read_dismiss_state()<br/>━━━━━━━━━━<br/>Reads update_prompt entry<br/>fail-open: {} on any error"]
        DS_CHECK["_is_dismissed()<br/>━━━━━━━━━━<br/>axis 1: time window elapsed?<br/>axis 2: version advanced past<br/>         dismissed_version?<br/>axis 3: condition in list?"]
        DS_WRITE_N["_write_dismiss_state() — N path<br/>━━━━━━━━━━<br/>writes: dismissed_at, dismissed_version<br/>conditions=[fired signal kinds]"]
        DS_CLEAR["state.pop() + _write_dismiss_state()<br/>━━━━━━━━━━<br/>clears: update_prompt, binary_snoozed<br/>on successful upgrade"]
    end

    subgraph SignalGather ["● SIGNAL GATHERING (MUTABLE — fresh per invocation)"]
        direction LR
        SG_BIN["_binary_signal()<br/>━━━━━━━━━━<br/>fetch latest release<br/>version compare"]
        SG_HOOK["_hooks_signal()<br/>━━━━━━━━━━<br/>hook registry drift<br/>orphaned / missing"]
        SG_DRIFT["_source_drift_signal()<br/>━━━━━━━━━━<br/>resolve_reference_sha()<br/>commit_id compare"]
        SG_DUAL["_dual_mcp_signal()<br/>━━━━━━━━━━<br/>dual MCP registration<br/>check ~/.claude.json"]
    end

    subgraph FetchCache ["FETCH CACHE — github_fetch_cache.json (APPEND_ONLY/MUTABLE)"]
        direction TB
        FC["_fetch_with_cache()<br/>━━━━━━━━━━<br/>disk TTL: 30 min<br/>ETag / If-None-Match<br/>version-keyed entries<br/>APPEND_ONLY per URL"]
        FC_INVAL["invalidate_fetch_cache()<br/>━━━━━━━━━━<br/>unlink on success<br/>forces re-fetch post-upgrade"]
    end

    subgraph UpdateExec ["● UPDATE EXECUTION — _run_update_sequence()"]
        direction TB
        UE_CMD["upgrade_command()<br/>━━━━━━━━━━<br/>install-type-aware<br/>runs uv / pip upgrade"]
        UE_INSTALL["autoskillit install<br/>━━━━━━━━━━<br/>syncs hooks + plugin cache<br/>non-fatal on non-zero exit"]
        UE_VERIFY["● _verify_update_result()<br/>━━━━━━━━━━<br/>importlib.metadata.version()<br/>bypasses lru_cache<br/>new_version != current?"]
    end

    subgraph RestartContract ["★ NOREVERSE RESTART CONTRACT — _restart.py (NEW FILE)"]
        direction TB
        RC_ENV["Set AUTOSKILLIT_SKIP_UPDATE_CHECK=1<br/>━━━━━━━━━━<br/>INIT_ONLY write<br/>prevents re-exec loop"]
        RC_EXEC["os.execv(sys.executable, argv)<br/>━━━━━━━━━━<br/>process REPLACES itself<br/>→ NoReturn contract<br/>type-annotated: -> NoReturn"]
    end

    SKIP([Skip — return silently])
    DISMISS([Dismiss — write state<br/>suppress window])
    FAIL_UPDATE([Update failed —<br/>print guidance<br/>no restart])

    %% FLOW %%
    START --> G_ENV
    G_ENV -->|"SKIP flags set<br/>or non-TTY"| SKIP
    G_ENV -->|"interactive TTY"| G_KITCHEN
    G_KITCHEN -->|"kitchen open"| SKIP
    G_KITCHEN -->|"kitchen closed"| G_INSTALL
    G_INSTALL -->|"skip type"| SKIP
    G_INSTALL -->|"trackable install"| DS_READ

    DS_READ --> SG_BIN & SG_HOOK & SG_DRIFT & SG_DUAL
    SG_BIN & SG_HOOK & SG_DRIFT & SG_DUAL --> DS_CHECK

    SG_BIN --> FC
    SG_DRIFT --> FC

    DS_CHECK -->|"all dismissed"| DISMISS
    DS_CHECK -->|"undismissed signals"| UE_CMD
    DS_CHECK -->|"user answers N"| DS_WRITE_N
    DS_WRITE_N --> DISMISS

    UE_CMD --> UE_INSTALL --> UE_VERIFY
    UE_VERIFY -->|"version unchanged"| FAIL_UPDATE
    UE_VERIFY -->|"version advanced"| DS_CLEAR
    DS_CLEAR --> FC_INVAL
    FC_INVAL --> RC_ENV
    RC_ENV --> RC_EXEC

    %% CLASS ASSIGNMENTS %%
    class START,SKIP,DISMISS,FAIL_UPDATE terminal;
    class G_ENV,G_KITCHEN,G_INSTALL detector;
    class DS_READ,DS_CHECK stateNode;
    class DS_WRITE_N,DS_CLEAR output;
    class SG_BIN,SG_HOOK,SG_DRIFT,SG_DUAL phase;
    class FC,FC_INVAL handler;
    class UE_CMD,UE_INSTALL handler;
    class UE_VERIFY detector;
    class RC_ENV gap;
    class RC_EXEC newComponent;
```

Closes #1337

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260426-203124-369733/.autoskillit/temp/rectify/rectify_cli-auto-update-re-exec_2026-04-26_000001.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| rectify | 3.7k | 13.7k | 422.4k | 46.2k | 1 | 7m 45s |
| dry_walkthrough | 148 | 12.8k | 829.5k | 49.2k | 1 | 7m 40s |
| implement | 336 | 22.7k | 2.3M | 131.3k | 1 | 8m 16s |
| assess | 328 | 29.5k | 2.8M | 87.3k | 1 | 11m 42s |
| prepare_pr | 76 | 5.6k | 282.9k | 30.0k | 1 | 1m 55s |
| run_arch_lenses | 191 | 20.2k | 692.6k | 114.1k | 3 | 6m 42s |
| compose_pr | 59 | 9.5k | 219.5k | 35.9k | 1 | 2m 53s |
| **Total** | 4.8k | 113.8k | 7.5M | 494.1k | | 46m 56s |