### PR TITLE
Rectify: open_kitchen First-Call Race — MCP Retry Instruction Structural Immunity

### DIFF
--- a/src/autoskillit/cli/_cook.py
+++ b/src/autoskillit/cli/_cook.py
@@ -107,7 +107,6 @@ def cook(*, resume: bool = False, session_id: str | None = None) -> None:
     if confirm.lower() in ("n", "no"):
         return
 
-    from autoskillit.cli._init_helpers import _is_plugin_installed
     from autoskillit.cli._onboarding import is_first_run, run_onboarding_menu
     from autoskillit.core import (
         LAUNCH_ID_ENV_VAR,
@@ -121,6 +120,7 @@ def cook(*, resume: bool = False, session_id: str | None = None) -> None:
         resume_spec_from_cli,
         write_registry_entry,
     )
+    from autoskillit.core._plugin_ids import MARKETPLACE_PREFIX, detect_autoskillit_mcp_prefix
     from autoskillit.execution import build_interactive_cmd
 
     configure_logging()
@@ -142,7 +142,7 @@ def cook(*, resume: bool = False, session_id: str | None = None) -> None:
         session_id_local, cook_session=True, config=config, project_dir=project_dir
     )
 
-    plugin_dir = None if _is_plugin_installed() else pkg_root()
+    plugin_dir = None if detect_autoskillit_mcp_prefix() == MARKETPLACE_PREFIX else pkg_root()
 
     if isinstance(resume_spec, BareResume):
         from autoskillit.cli._session_picker import pick_session

--- a/src/autoskillit/cli/_cook.py
+++ b/src/autoskillit/cli/_cook.py
@@ -110,17 +110,18 @@ def cook(*, resume: bool = False, session_id: str | None = None) -> None:
     from autoskillit.cli._onboarding import is_first_run, run_onboarding_menu
     from autoskillit.core import (
         LAUNCH_ID_ENV_VAR,
+        MARKETPLACE_PREFIX,
         SESSION_TYPE_COOK,
         SESSION_TYPE_ENV_VAR,
         BareResume,
         NamedResume,
         NoResume,
         configure_logging,
+        detect_autoskillit_mcp_prefix,
         pkg_root,
         resume_spec_from_cli,
         write_registry_entry,
     )
-    from autoskillit.core._plugin_ids import MARKETPLACE_PREFIX, detect_autoskillit_mcp_prefix
     from autoskillit.execution import build_interactive_cmd
 
     configure_logging()

--- a/src/autoskillit/cli/_prompts.py
+++ b/src/autoskillit/cli/_prompts.py
@@ -20,7 +20,10 @@ _OPEN_KITCHEN_CHOICE: str = "__open_kitchen__"
 
 # Shared retry instruction for both orchestrator and open-kitchen prompts.
 _MCP_RETRY_INSTRUCTION: str = (
-    'If open_kitchen returns "No such tool available", retry the call once immediately.\n'
+    "If calling open_kitchen produces ANY error — including"
+    ' "No such tool available", a tool_use_error, or any is_error response —'
+    " retry the call once immediately. Do not explain the error or suggest"
+    " troubleshooting steps to the user. Just retry silently.\n"
     'If the retry also fails, output "AutoSkillit MCP server did not start — ending session."'
     " and end."
 )

--- a/src/autoskillit/cli/_session_launch.py
+++ b/src/autoskillit/cli/_session_launch.py
@@ -26,10 +26,10 @@ def _run_interactive_session(
     if shutil.which("claude") is None:
         print("ERROR: 'claude' not found. Install: https://docs.anthropic.com/en/docs/claude-code")
         sys.exit(1)
-    from autoskillit.cli._init_helpers import _is_plugin_installed
     from autoskillit.cli._reload import consume_reload_sentinel
     from autoskillit.cli._terminal import terminal_guard
     from autoskillit.core import BareResume, ClaudeFlags, NamedResume, NoResume, pkg_root
+    from autoskillit.core._plugin_ids import MARKETPLACE_PREFIX, detect_autoskillit_mcp_prefix
     from autoskillit.execution import build_interactive_cmd
 
     _project_dir = project_dir if project_dir is not None else Path.cwd()
@@ -38,7 +38,11 @@ def _run_interactive_session(
         resume_spec=resume_spec if resume_spec is not None else NoResume(),
         env_extras=extra_env,
     )
-    plugin_flags = [] if _is_plugin_installed() else [ClaudeFlags.PLUGIN_DIR, str(pkg_root())]
+    plugin_flags = (
+        []
+        if detect_autoskillit_mcp_prefix() == MARKETPLACE_PREFIX
+        else [ClaudeFlags.PLUGIN_DIR, str(pkg_root())]
+    )
     _is_resume = isinstance(resume_spec, (BareResume, NamedResume))
     cmd = [
         *spec.cmd,

--- a/src/autoskillit/cli/_session_launch.py
+++ b/src/autoskillit/cli/_session_launch.py
@@ -28,8 +28,15 @@ def _run_interactive_session(
         sys.exit(1)
     from autoskillit.cli._reload import consume_reload_sentinel
     from autoskillit.cli._terminal import terminal_guard
-    from autoskillit.core import BareResume, ClaudeFlags, NamedResume, NoResume, pkg_root
-    from autoskillit.core._plugin_ids import MARKETPLACE_PREFIX, detect_autoskillit_mcp_prefix
+    from autoskillit.core import (
+        MARKETPLACE_PREFIX,
+        BareResume,
+        ClaudeFlags,
+        NamedResume,
+        NoResume,
+        detect_autoskillit_mcp_prefix,
+        pkg_root,
+    )
     from autoskillit.execution import build_interactive_cmd
 
     _project_dir = project_dir if project_dir is not None else Path.cwd()

--- a/src/autoskillit/server/tools_kitchen.py
+++ b/src/autoskillit/server/tools_kitchen.py
@@ -259,7 +259,7 @@ def _build_tool_category_listing(
 @mcp.tool(
     tags={"autoskillit"},
     annotations={"readOnlyHint": True},
-    meta={"anthropic/maxResultSizeChars": 100_000},
+    meta={"anthropic/maxResultSizeChars": 100_000, "anthropic/alwaysLoad": True},
 )
 @track_response_size("open_kitchen")
 async def open_kitchen(
@@ -477,7 +477,9 @@ async def open_kitchen(
         return _kitchen_failure_envelope(exc, stage="unhandled")
 
 
-@mcp.tool(tags={"autoskillit"}, annotations={"readOnlyHint": True})
+@mcp.tool(
+    tags={"autoskillit"}, annotations={"readOnlyHint": True}, meta={"anthropic/alwaysLoad": True}
+)
 @track_response_size("close_kitchen")
 async def close_kitchen(ctx: Context = CurrentContext()) -> str:
     """Close the AutoSkillit kitchen.
@@ -495,7 +497,9 @@ async def close_kitchen(ctx: Context = CurrentContext()) -> str:
         return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})
 
 
-@mcp.tool(tags={"autoskillit"}, annotations={"readOnlyHint": False})
+@mcp.tool(
+    tags={"autoskillit"}, annotations={"readOnlyHint": False}, meta={"anthropic/alwaysLoad": True}
+)
 @track_response_size("disable_quota_guard")
 async def disable_quota_guard() -> str:
     """Disable the quota guard for the remainder of this kitchen session.
@@ -595,7 +599,9 @@ def _reload_session_handler() -> dict[str, str]:
     }
 
 
-@mcp.tool(tags={"autoskillit"}, annotations={"readOnlyHint": False})
+@mcp.tool(
+    tags={"autoskillit"}, annotations={"readOnlyHint": False}, meta={"anthropic/alwaysLoad": True}
+)
 @track_response_size("reload_session")
 async def reload_session() -> dict[str, str]:
     """Signal the parent autoskillit process to reload this session with the full

--- a/tests/arch/test_ast_rules.py
+++ b/tests/arch/test_ast_rules.py
@@ -772,3 +772,44 @@ def test_no_raw_pid_attr_to_start_linux_tracing() -> None:
         "Use resolve_trace_target() (PTY mode) or trace_target_from_pid() (direct mode) "
         "to get a TraceTarget first (issue #806):\n" + "\n".join(f"  {v}" for v in violations)
     )
+
+
+# ── ARCH-009: _is_plugin_installed banned from session launch path ──────────
+
+
+def test_no_is_plugin_installed_in_session_launch() -> None:
+    """_run_interactive_session must not call _is_plugin_installed.
+
+    _is_plugin_installed runs 'claude plugin list' as a subprocess (up to 10s).
+    This pre-launch delay widens the MCP first-call race window.
+    Replacement: detect_autoskillit_mcp_prefix() == MARKETPLACE_PREFIX (µs filesystem read).
+    """
+    source = Path("src/autoskillit/cli/_session_launch.py").read_text()
+    tree = ast.parse(source)
+    calls = [
+        n.func.id
+        for n in ast.walk(tree)
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+    ]
+    assert "_is_plugin_installed" not in calls, (
+        "_session_launch.py calls _is_plugin_installed — replace with "
+        "detect_autoskillit_mcp_prefix() == MARKETPLACE_PREFIX"
+    )
+
+
+def test_no_is_plugin_installed_in_cook() -> None:
+    """cook() must not call _is_plugin_installed.
+
+    Same rationale as test_no_is_plugin_installed_in_session_launch.
+    """
+    source = Path("src/autoskillit/cli/_cook.py").read_text()
+    tree = ast.parse(source)
+    calls = [
+        n.func.id
+        for n in ast.walk(tree)
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+    ]
+    assert "_is_plugin_installed" not in calls, (
+        "_cook.py calls _is_plugin_installed — replace with "
+        "detect_autoskillit_mcp_prefix() == MARKETPLACE_PREFIX"
+    )

--- a/tests/cli/test_cook.py
+++ b/tests/cli/test_cook.py
@@ -105,9 +105,13 @@ class TestCLIOrder:
         monkeypatch.setattr("sys.stdin.isatty", lambda: True)
 
     @pytest.fixture(autouse=True)
-    def _stub_is_plugin_installed(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Stub _is_plugin_installed to False to prevent subprocess.run collision."""
-        monkeypatch.setattr("autoskillit.cli._init_helpers._is_plugin_installed", lambda: False)
+    def _stub_detect_mcp_prefix(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Stub detect_autoskillit_mcp_prefix for deterministic PLUGIN_DIR behavior."""
+        from autoskillit.core._plugin_ids import DIRECT_PREFIX
+
+        monkeypatch.setattr(
+            "autoskillit.core._plugin_ids.detect_autoskillit_mcp_prefix", lambda: DIRECT_PREFIX
+        )
 
     @pytest.fixture(autouse=True)
     def _stub_ingredients_table(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -474,7 +478,12 @@ class TestCLIOrder:
         (scripts_dir / "my-script.yaml").write_text(_SCRIPT_YAML)
         monkeypatch.setattr(shutil, "which", lambda cmd: "/usr/bin/claude")
         monkeypatch.setattr("builtins.input", lambda _prompt="": "")
-        monkeypatch.setattr("autoskillit.cli._init_helpers._is_plugin_installed", lambda: True)
+        from autoskillit.core._plugin_ids import MARKETPLACE_PREFIX
+
+        monkeypatch.setattr(
+            "autoskillit.core._plugin_ids.detect_autoskillit_mcp_prefix",
+            lambda: MARKETPLACE_PREFIX,
+        )
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="", stderr=""
         )
@@ -500,7 +509,11 @@ class TestCLIOrder:
         (scripts_dir / "my-script.yaml").write_text(_SCRIPT_YAML)
         monkeypatch.setattr(shutil, "which", lambda cmd: "/usr/bin/claude")
         monkeypatch.setattr("builtins.input", lambda _prompt="": "")
-        monkeypatch.setattr("autoskillit.cli._init_helpers._is_plugin_installed", lambda: False)
+        from autoskillit.core._plugin_ids import DIRECT_PREFIX
+
+        monkeypatch.setattr(
+            "autoskillit.core._plugin_ids.detect_autoskillit_mcp_prefix", lambda: DIRECT_PREFIX
+        )
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="", stderr=""
         )
@@ -1374,9 +1387,13 @@ class TestOrderSubsetGate:
         )
 
     @pytest.fixture(autouse=True)
-    def _stub_is_plugin_installed(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Stub _is_plugin_installed to False to prevent subprocess.run collision."""
-        monkeypatch.setattr("autoskillit.cli._init_helpers._is_plugin_installed", lambda: False)
+    def _stub_detect_mcp_prefix(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Stub detect_autoskillit_mcp_prefix for deterministic PLUGIN_DIR behavior."""
+        from autoskillit.core._plugin_ids import DIRECT_PREFIX
+
+        monkeypatch.setattr(
+            "autoskillit.core._plugin_ids.detect_autoskillit_mcp_prefix", lambda: DIRECT_PREFIX
+        )
 
     @pytest.fixture(autouse=True)
     def _stub_ingredients_table(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1568,9 +1585,13 @@ class TestOrderMcpPrefixSelection:
         monkeypatch.setattr("sys.stdin.isatty", lambda: True)
 
     @pytest.fixture(autouse=True)
-    def _stub_is_plugin_installed(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Stub _is_plugin_installed to False to prevent subprocess.run collision."""
-        monkeypatch.setattr("autoskillit.cli._init_helpers._is_plugin_installed", lambda: False)
+    def _stub_detect_mcp_prefix(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Stub detect_autoskillit_mcp_prefix for deterministic PLUGIN_DIR behavior."""
+        from autoskillit.core._plugin_ids import DIRECT_PREFIX
+
+        monkeypatch.setattr(
+            "autoskillit.core._plugin_ids.detect_autoskillit_mcp_prefix", lambda: DIRECT_PREFIX
+        )
 
     @pytest.fixture(autouse=True)
     def _stub_ingredients_table(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/cli/test_cook.py
+++ b/tests/cli/test_cook.py
@@ -18,6 +18,15 @@ from autoskillit.core import ClaudeFlags
 
 pytestmark = [pytest.mark.layer("cli"), pytest.mark.medium]
 
+
+@pytest.fixture(autouse=True)
+def _stub_detect_mcp_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub detect_autoskillit_mcp_prefix for deterministic PLUGIN_DIR behavior."""
+    from autoskillit.core._plugin_ids import DIRECT_PREFIX
+
+    monkeypatch.setattr("autoskillit.core.detect_autoskillit_mcp_prefix", lambda: DIRECT_PREFIX)
+
+
 _SCRIPT_YAML = """\
 name: test-script
 description: A test script
@@ -103,15 +112,6 @@ class TestCLIOrder:
     def _interactive_stdin(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Most order() paths require an interactive TTY — default to True for this class."""
         monkeypatch.setattr("sys.stdin.isatty", lambda: True)
-
-    @pytest.fixture(autouse=True)
-    def _stub_detect_mcp_prefix(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Stub detect_autoskillit_mcp_prefix for deterministic PLUGIN_DIR behavior."""
-        from autoskillit.core._plugin_ids import DIRECT_PREFIX
-
-        monkeypatch.setattr(
-            "autoskillit.core._plugin_ids.detect_autoskillit_mcp_prefix", lambda: DIRECT_PREFIX
-        )
 
     @pytest.fixture(autouse=True)
     def _stub_ingredients_table(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -481,7 +481,7 @@ class TestCLIOrder:
         from autoskillit.core._plugin_ids import MARKETPLACE_PREFIX
 
         monkeypatch.setattr(
-            "autoskillit.core._plugin_ids.detect_autoskillit_mcp_prefix",
+            "autoskillit.core.detect_autoskillit_mcp_prefix",
             lambda: MARKETPLACE_PREFIX,
         )
         mock_run.return_value = subprocess.CompletedProcess(
@@ -512,7 +512,7 @@ class TestCLIOrder:
         from autoskillit.core._plugin_ids import DIRECT_PREFIX
 
         monkeypatch.setattr(
-            "autoskillit.core._plugin_ids.detect_autoskillit_mcp_prefix", lambda: DIRECT_PREFIX
+            "autoskillit.core.detect_autoskillit_mcp_prefix", lambda: DIRECT_PREFIX
         )
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="", stderr=""
@@ -1387,15 +1387,6 @@ class TestOrderSubsetGate:
         )
 
     @pytest.fixture(autouse=True)
-    def _stub_detect_mcp_prefix(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Stub detect_autoskillit_mcp_prefix for deterministic PLUGIN_DIR behavior."""
-        from autoskillit.core._plugin_ids import DIRECT_PREFIX
-
-        monkeypatch.setattr(
-            "autoskillit.core._plugin_ids.detect_autoskillit_mcp_prefix", lambda: DIRECT_PREFIX
-        )
-
-    @pytest.fixture(autouse=True)
     def _stub_ingredients_table(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Stub _get_ingredients_table in app.py to prevent subprocess.run git calls."""
         import importlib
@@ -1583,15 +1574,6 @@ class TestOrderMcpPrefixSelection:
     @pytest.fixture(autouse=True)
     def _interactive_stdin(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr("sys.stdin.isatty", lambda: True)
-
-    @pytest.fixture(autouse=True)
-    def _stub_detect_mcp_prefix(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Stub detect_autoskillit_mcp_prefix for deterministic PLUGIN_DIR behavior."""
-        from autoskillit.core._plugin_ids import DIRECT_PREFIX
-
-        monkeypatch.setattr(
-            "autoskillit.core._plugin_ids.detect_autoskillit_mcp_prefix", lambda: DIRECT_PREFIX
-        )
 
     @pytest.fixture(autouse=True)
     def _stub_ingredients_table(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/cli/test_orchestrator_prompt_contract.py
+++ b/tests/cli/test_orchestrator_prompt_contract.py
@@ -135,6 +135,50 @@ class TestOpenKitchenRetryOnUnavailable:
             "_build_open_kitchen_prompt retry must reference 'No such tool' or 'unavailable'"
         )
 
+    def test_mcp_retry_instruction_covers_is_error_block_shape(self) -> None:
+        """_MCP_RETRY_INSTRUCTION must explicitly cover the is_error:true wire format.
+
+        Claude Code delivers MCP transport failures as is_error: true tool_use_error blocks,
+        not as string returns. The instruction must cover "any error" or explicitly mention
+        error blocks — not just the string-return case.
+        """
+        from autoskillit.cli._prompts import _MCP_RETRY_INSTRUCTION
+
+        instr = _MCP_RETRY_INSTRUCTION.lower()
+        assert any(
+            phrase in instr for phrase in ("any error", "tool error", "tool_use_error", "is_error")
+        ), (
+            "_MCP_RETRY_INSTRUCTION does not cover is_error:true wire format. "
+            "Claude Code sends MCP failures as is_error blocks, not string returns."
+        )
+
+    def test_mcp_retry_instruction_does_not_gate_on_string_return_only(self) -> None:
+        """Instruction must not use 'returns' as the sole trigger for retry.
+
+        'If open_kitchen returns X' is a string-return pattern. The actual error arrives
+        as is_error: true with a tool_use_error content block — not a function return.
+        """
+        from autoskillit.cli._prompts import _MCP_RETRY_INSTRUCTION
+
+        assert '"returns"' not in _MCP_RETRY_INSTRUCTION and (
+            "returns" not in _MCP_RETRY_INSTRUCTION
+            or "any error" in _MCP_RETRY_INSTRUCTION.lower()
+            or "error" in _MCP_RETRY_INSTRUCTION.lower()
+        ), "_MCP_RETRY_INSTRUCTION uses 'returns' as sole trigger — misses is_error:true shape."
+
+    def test_mcp_retry_instruction_covers_silent_retry(self) -> None:
+        """Instruction must direct LLM to retry silently without troubleshooting.
+
+        Session 5f08b230 showed LLM gave troubleshooting advice instead of retrying.
+        Instruction must explicitly prohibit explaining the error to the user.
+        """
+        from autoskillit.cli._prompts import _MCP_RETRY_INSTRUCTION
+
+        instr = _MCP_RETRY_INSTRUCTION.lower()
+        assert "silently" in instr or "do not explain" in instr or "do not" in instr, (
+            "_MCP_RETRY_INSTRUCTION does not prohibit LLM from explaining the error to the user."
+        )
+
 
 class TestFirstActionDirectOpenKitchen:
     """FIRST ACTION must call open_kitchen directly — no ToolSearch or Bash preamble."""

--- a/tests/cli/test_orchestrator_prompt_contract.py
+++ b/tests/cli/test_orchestrator_prompt_contract.py
@@ -160,7 +160,7 @@ class TestOpenKitchenRetryOnUnavailable:
         """
         from autoskillit.cli._prompts import _MCP_RETRY_INSTRUCTION
 
-        assert '"returns"' not in _MCP_RETRY_INSTRUCTION and (
+        assert (
             "returns" not in _MCP_RETRY_INSTRUCTION
             or "any error" in _MCP_RETRY_INSTRUCTION.lower()
             or "error" in _MCP_RETRY_INSTRUCTION.lower()

--- a/tests/cli/test_session_launch.py
+++ b/tests/cli/test_session_launch.py
@@ -37,9 +37,7 @@ def _stub_plugin_installed(monkeypatch: pytest.MonkeyPatch, *, installed: bool =
     from autoskillit.core._plugin_ids import DIRECT_PREFIX, MARKETPLACE_PREFIX
 
     prefix = MARKETPLACE_PREFIX if installed else DIRECT_PREFIX
-    monkeypatch.setattr(
-        "autoskillit.core._plugin_ids.detect_autoskillit_mcp_prefix", lambda: prefix
-    )
+    monkeypatch.setattr("autoskillit.core.detect_autoskillit_mcp_prefix", lambda: prefix)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_session_launch.py
+++ b/tests/cli/test_session_launch.py
@@ -33,8 +33,13 @@ def _capture_subprocess(monkeypatch: pytest.MonkeyPatch) -> dict:
 
 
 def _stub_plugin_installed(monkeypatch: pytest.MonkeyPatch, *, installed: bool = True) -> None:
-    """Stub _is_plugin_installed to return the given value."""
-    monkeypatch.setattr("autoskillit.cli._init_helpers._is_plugin_installed", lambda: installed)
+    """Stub detect_autoskillit_mcp_prefix to simulate marketplace/direct install."""
+    from autoskillit.core._plugin_ids import DIRECT_PREFIX, MARKETPLACE_PREFIX
+
+    prefix = MARKETPLACE_PREFIX if installed else DIRECT_PREFIX
+    monkeypatch.setattr(
+        "autoskillit.core._plugin_ids.detect_autoskillit_mcp_prefix", lambda: prefix
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -44,7 +49,7 @@ def _stub_plugin_installed(monkeypatch: pytest.MonkeyPatch, *, installed: bool =
 
 def test_run_interactive_session_passes_plugin_flags(monkeypatch: pytest.MonkeyPatch) -> None:
     """_run_interactive_session adds --plugin-dir when plugin not installed."""
-    monkeypatch.setattr("autoskillit.cli._init_helpers._is_plugin_installed", lambda: False)
+    _stub_plugin_installed(monkeypatch, installed=False)
     captured = _capture_subprocess(monkeypatch)
     _run_interactive_session(system_prompt="test")
     assert ClaudeFlags.PLUGIN_DIR in captured["cmd"]

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -128,7 +128,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/server/_lifespan.py", 56),
     # tools_kitchen.py — hook config dict
     ("src/autoskillit/server/tools_kitchen.py", 117),
-    ("src/autoskillit/server/tools_kitchen.py", 535),
+    ("src/autoskillit/server/tools_kitchen.py", 539),
     # tools_status.py — mcp_data dict
     ("src/autoskillit/server/tools_status.py", 486),
     # tools_github.py — bug report dict

--- a/tests/server/test_tools_kitchen.py
+++ b/tests/server/test_tools_kitchen.py
@@ -1449,3 +1449,20 @@ def test_close_kitchen_no_review_gate_state_no_error(tmp_path, monkeypatch):
             _close_kitchen_handler()  # Must not raise
 
     assert not tmp_path.joinpath(*_REVIEW_GATE_STATE_RELPATH).exists()
+
+
+@pytest.mark.anyio
+async def test_open_kitchen_has_always_load_meta() -> None:
+    """open_kitchen must carry anthropic/alwaysLoad: true in its MCP meta.
+
+    alwaysLoad ensures open_kitchen is always in the initial tool context for
+    direct 'claude' sessions (where ToolSearch is enabled). Defense-in-depth
+    against the MCP first-call race for non-order/cook sessions.
+    """
+    from autoskillit.server import mcp
+
+    tool = await mcp.get_tool("open_kitchen")
+    assert tool is not None
+    assert tool.meta is not None and tool.meta.get("anthropic/alwaysLoad") is True, (
+        "open_kitchen missing anthropic/alwaysLoad:true — add to @mcp.tool(meta={...})"
+    )


### PR DESCRIPTION
## Summary

Claude Code's interactive mode fires `processInitialMessage` before MCP servers finish connecting. The only application-level defense is `_MCP_RETRY_INSTRUCTION` — a plain string injected via `--append-system-prompt` that tells the LLM to retry `open_kitchen` if it encounters the race. This instruction is **structurally underspecified**: it only covers the case where `open_kitchen` *returns* the string `"No such tool available"`, but Claude Code actually delivers MCP transport failures as `is_error: true` content blocks with `tool_use_error` — a fundamentally different wire-format shape that the instruction does not mention.

The result: the session confirmed in issue evidence (session `5f08b230`) showed the LLM receiving an `is_error: true` error, not recognizing it as the covered case, and **ignoring the retry instruction** entirely (no thinking block, immediately gave troubleshooting advice).

The architectural solution is not a bigger string. It is:
1. A precise, wire-format-aware retry instruction that covers all error shapes Claude Code can produce
2. Contract tests that pin the instruction's coverage and make any regression instantly visible
3. `alwaysLoad` meta on `FREE_RANGE_TOOLS` as structural defense-in-depth
4. Removal of `_is_plugin_installed()` from the session launch path — a 10s blocking subprocess that widens the race window before Claude Code even starts

## Architecture Impact

### Error/Resilience Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 52, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START([CLI: order / cook])

    subgraph CLIGates ["● VALIDATION GATES — CLI (_cook.py · _session_launch.py)"]
        direction TB
        BinGuard{"claude on PATH?<br/>━━━━━━━━━━<br/>shutil.which check"}
        SubExit1(["SystemExit(1)<br/>binary missing"])
    end

    subgraph SessionLaunch ["● SESSION LAUNCH (_session_launch.py · _cook.py)"]
        direction TB
        Launch["_run_interactive_session()<br/>━━━━━━━━━━<br/>subprocess: claude CLI<br/>● _is_plugin_installed() removed<br/>from critical path"]
        ReloadCheck{"reload sentinel<br/>written?"}
        ExitProp(["sys.exit(returncode)<br/>subprocess failure"])
        ReloadLoop["consume_reload_sentinel()<br/>━━━━━━━━━━<br/>seen_reload_ids tracking"]
        DepthGuard{"len seen ≥ 10<br/>OR same id?"}
        AbuseExit(["SystemExit<br/>reload abuse"])
        ResumeNext["NamedResume(reload_id)<br/>━━━━━━━━━━<br/>reset initial_message → None"]
    end

    subgraph MCPRace ["● MCP FIRST-CALL RACE DEFENSE (_prompts.py · tools_kitchen.py)"]
        direction TB
        AlwaysLoad["● alwaysLoad meta<br/>━━━━━━━━━━<br/>anthropic/alwaysLoad: true<br/>on open_kitchen, close_kitchen,<br/>disable_quota_guard, reload_session<br/>→ tool defs always present"]
        RetryInstr["● _MCP_RETRY_INSTRUCTION<br/>━━━━━━━━━━<br/>injected into orchestrator +<br/>open_kitchen system prompts<br/>covers: No such tool · tool_use_error<br/>· is_error:true (NEW coverage)"]
        MCPErr{"any error on<br/>open_kitchen call?"}
        SilentRetry["silent retry (once)<br/>━━━━━━━━━━<br/>no explanation to user"]
        MCPFatal(["session end<br/>MCP server did not start"])
    end

    subgraph KitchenInit ["● open_kitchen STAGED INIT (tools_kitchen.py)"]
        direction TB
        HeadlessGuard{"AUTOSKILLIT_HEADLESS<br/>set?"}
        HeadlessFail(["failure envelope<br/>stage: headless_guard"])
        Stage1{"write_hook_config<br/>━━━━━━━━━━<br/>OSError swallowed internally<br/>but outer Exception fatal"}
        Stage2{"prime_quota_cache<br/>━━━━━━━━━━<br/>TypeError / RuntimeError<br/>→ gate.disable() + envelope"}
        Stage3{"start_quota_refresh<br/>━━━━━━━━━━<br/>create_background_task fail<br/>→ gate.disable() + envelope"}
        Stage4["register_active_kitchen<br/>━━━━━━━━━━<br/>NON-FATAL: swallowed<br/>kitchen proceeds regardless"]
        RecipeGate{"ctx.recipes None<br/>OR load error<br/>OR triage error?"}
        SousChef["sous-chef read<br/>━━━━━━━━━━<br/>named-recipe: non-fatal<br/>no-recipe path: fatal"]
        OuterCatch(["failure envelope<br/>stage: unhandled<br/>'never raises' guarantee"])
        KitchenOpen(["kitchen: open ✓"])
    end

    subgraph StageFailures ["STAGED-INIT FAILURE TERMINALS"]
        SF1(["envelope: write_hook_config"])
        SF2(["envelope: prime_quota_cache"])
        SF3(["envelope: start_quota_refresh"])
        SF4(["envelope: enable_components"])
        SF5(["envelope: recipe_context / load / triage"])
        SF6(["envelope: hook_diagnostic"])
        SF7(["envelope: read_sous_chef"])
    end

    %% FLOW %%
    START --> BinGuard
    BinGuard -->|"None"| SubExit1
    BinGuard -->|"found"| Launch

    Launch --> ReloadCheck
    ReloadCheck -->|"no sentinel<br/>returncode ≠ 0"| ExitProp
    ReloadCheck -->|"sentinel found"| ReloadLoop
    ReloadLoop --> DepthGuard
    DepthGuard -->|"abuse detected"| AbuseExit
    DepthGuard -->|"safe"| ResumeNext
    ResumeNext -->|"re-launch"| Launch

    Launch -->|"claude agent calls<br/>open_kitchen"| MCPErr
    AlwaysLoad -.->|"defense: tool defs<br/>always loaded"| MCPErr
    RetryInstr -.->|"agent behavior contract"| MCPErr
    MCPErr -->|"error (1st call)"| SilentRetry
    SilentRetry -->|"2nd error"| MCPFatal
    SilentRetry -->|"success"| HeadlessGuard

    MCPErr -->|"no error"| HeadlessGuard
    HeadlessGuard -->|"headless=1"| HeadlessFail
    HeadlessGuard -->|"interactive"| Stage1
    Stage1 -->|"Exception"| SF1
    Stage1 -->|"ok"| Stage2
    Stage2 -->|"Exception"| SF2
    Stage2 -->|"ok"| Stage3
    Stage3 -->|"Exception"| SF3
    Stage3 -->|"ok"| Stage4
    Stage4 --> RecipeGate
    RecipeGate -->|"enable_components fail"| SF4
    RecipeGate -->|"recipe/triage fail"| SF5
    RecipeGate -->|"hook_diagnostic fail"| SF6
    RecipeGate -->|"ok"| SousChef
    SousChef -->|"no-recipe path OSError"| SF7
    SousChef -->|"success or named-recipe graceful"| KitchenOpen
    KitchenOpen -.->|"outer catch-all wraps all"| OuterCatch

    %% CLASS ASSIGNMENTS %%
    class START cli;
    class BinGuard,HeadlessGuard,MCPErr,DepthGuard,ReloadCheck,RecipeGate,Stage1,Stage2,Stage3 detector;
    class Launch,ReloadLoop,SousChef handler;
    class Stage4,ResumeNext output;
    class AlwaysLoad,RetryInstr phase;
    class SilentRetry stateNode;
    class SubExit1,ExitProp,AbuseExit,HeadlessFail,MCPFatal,OuterCatch,SF1,SF2,SF3,SF4,SF5,SF6,SF7 gap;
    class KitchenOpen terminal;
```

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START — autoskillit cook / order])
    CLAUDE_RUNNING([Claude Code subprocess running])
    DONE([DONE])
    ERROR_EXIT([ERROR EXIT])

    subgraph PreLaunch ["Pre-Launch Checks  (_cook.py  ●)"]
        direction TB
        BinaryCheck{"shutil.which('claude')?<br/>━━━━━━━━━━<br/>binary on PATH?"}
        ConfigLoad["load_config()<br/>━━━━━━━━━━<br/>print banner + tool categories<br/>permissions_warning()"]
        ConfirmPrompt{"timed_prompt()<br/>━━━━━━━━━━<br/>120s timeout<br/>user confirms launch?"}
    end

    subgraph SessionSetup ["Session Setup  (_cook.py  ●)"]
        direction TB
        LoggingResume["configure_logging()<br/>━━━━━━━━━━<br/>resume_spec_from_cli()"]
        OnboardCheck{"is_first_run()?<br/>━━━━━━━━━━<br/>first time in project?"}
        Onboarding["run_onboarding_menu()<br/>━━━━━━━━━━<br/>sets initial_prompt"]
        RegistrySkills["write_registry_entry()<br/>━━━━━━━━━━<br/>init_session() → skills_dir<br/>cleanup_stale()"]
        PrefixDetect["● detect_autoskillit_mcp_prefix()<br/>━━━━━━━━━━<br/>reads ~/.claude/plugins/installed_plugins.json<br/>µs filesystem read — NO subprocess<br/>(replaced 10s _is_plugin_installed() subprocess)"]
        PluginDirDecide{"marketplace prefix?<br/>━━━━━━━━━━<br/>MARKETPLACE_PREFIX?"}
        PluginDirNone["plugin_dir = None<br/>━━━━━━━━━━<br/>marketplace handles plugin<br/>no --plugin-dir flag"]
        PluginDirPkg["plugin_dir = pkg_root()<br/>━━━━━━━━━━<br/>direct install path<br/>pass --plugin-dir"]
        ResumeCheck{"BareResume?<br/>━━━━━━━━━━<br/>resume flag without ID?"}
        SessionPicker["pick_session()<br/>━━━━━━━━━━<br/>list recent cook sessions<br/>user picks or skips"]
    end

    subgraph ReloadLoop ["Reload Loop  (_cook.py  ●)"]
        direction TB
        BuildCmd["● build_interactive_cmd()<br/>━━━━━━━━━━<br/>assemble cmd + env<br/>plugin_dir, skills_dir, resume_spec"]
        RunSession["_run_cook_session()<br/>━━━━━━━━━━<br/>terminal_guard()<br/>subprocess.run(cmd, env)"]
        ConsumeReload{"consume_reload_sentinel()?<br/>━━━━━━━━━━<br/>reload_sentinel file present?"}
        ReloadGuard{"max reloads / repeated ID?<br/>━━━━━━━━━━<br/>≥10 reloads or seen ID?"}
        UpdateResume["current_resume_spec = NamedResume<br/>━━━━━━━━━━<br/>reset initial_prompt = None<br/>add ID to seen_reload_ids"]
        ReturnCode{"returncode == 0?"}
        MarkOnboarded["mark_onboarded(project_dir)<br/>━━━━━━━━━━<br/>first-run + had initial prompt"]
    end

    subgraph SessionLaunch ["_run_interactive_session()  (_session_launch.py  ●)"]
        direction TB
        SLBuildCmd["build_interactive_cmd()<br/>━━━━━━━━━━<br/>initial_message, resume_spec, env_extras"]
        SLPrefixDetect["● detect_autoskillit_mcp_prefix()<br/>━━━━━━━━━━<br/>µs filesystem read<br/>same fast path as cook()"]
        SLPluginFlags{"marketplace prefix?<br/>━━━━━━━━━━<br/>determine plugin_flags"}
        SLAssembleCmd["assemble cmd<br/>━━━━━━━━━━<br/>spec.cmd + plugin_flags<br/>+ --allowedTools AskUserQuestion<br/>+ --append-system-prompt (if not resume)"]
        SLRun["terminal_guard()<br/>━━━━━━━━━━<br/>subprocess.run(cmd, env)"]
        SLSentinel{"consume_reload_sentinel()?"}
    end

    subgraph OpenKitchen ["open_kitchen() MCP Tool  (tools_kitchen.py  ●)"]
        direction TB
        HeadlessGuard{"_require_orchestrator_exact()<br/>━━━━━━━━━━<br/>headless session calling<br/>open_kitchen?"}
        HeadlessDeny["return failure envelope<br/>━━━━━━━━━━<br/>HeadlessDenied error<br/>stage: headless_guard"]
        KitchenHandler["_open_kitchen_handler()<br/>━━━━━━━━━━<br/>ctx.gate.enable()<br/>ctx.kitchen_id = uuid4()<br/>_write_hook_config()<br/>_prime_quota_cache()<br/>start quota_refresh_loop bg task<br/>register_active_kitchen()"]
        EnableComponents["ctx.enable_components({'kitchen'})<br/>━━━━━━━━━━<br/>reveal gated FastMCP tools"]
        RedisableSubsets["_redisable_subsets()<br/>━━━━━━━━━━<br/>re-disable config-disabled subsets<br/>suppress feature-disabled tool tags"]
        RecipeCheck{"name provided?<br/>━━━━━━━━━━<br/>named recipe requested?"}
        LoadValidate["load_and_validate(name)<br/>━━━━━━━━━━<br/>_apply_triage_gate()<br/>inject sous-chef discipline<br/>_build_hook_diagnostic_warning()"]
        GenericOpen["build generic open text<br/>━━━━━━━━━━<br/>tool categories list<br/>sous-chef rules<br/>upgrade hint if needed"]
        OKReturnJSON["return JSON response<br/>━━━━━━━━━━<br/>success: true, kitchen: open<br/>ingredients_table / content"]
    end

    %% FLOW — Pre-launch %%
    START --> BinaryCheck
    BinaryCheck -->|"not found"| ERROR_EXIT
    BinaryCheck -->|"found"| ConfigLoad
    ConfigLoad --> ConfirmPrompt
    ConfirmPrompt -->|"n / no"| DONE
    ConfirmPrompt -->|"Enter / yes"| LoggingResume

    %% FLOW — Session Setup %%
    LoggingResume --> OnboardCheck
    OnboardCheck -->|"yes"| Onboarding
    OnboardCheck -->|"no"| RegistrySkills
    Onboarding --> RegistrySkills
    RegistrySkills --> PrefixDetect
    PrefixDetect --> PluginDirDecide
    PluginDirDecide -->|"yes"| PluginDirNone
    PluginDirDecide -->|"no"| PluginDirPkg
    PluginDirNone --> ResumeCheck
    PluginDirPkg --> ResumeCheck
    ResumeCheck -->|"yes"| SessionPicker
    ResumeCheck -->|"no"| BuildCmd
    SessionPicker -->|"session selected → NamedResume"| BuildCmd
    SessionPicker -->|"skipped → NoResume"| BuildCmd

    %% FLOW — Reload Loop %%
    BuildCmd --> RunSession
    RunSession --> ConsumeReload
    ConsumeReload -->|"sentinel present"| ReloadGuard
    ConsumeReload -->|"no sentinel"| ReturnCode
    ReloadGuard -->|"limit exceeded / repeated ID"| ERROR_EXIT
    ReloadGuard -->|"ok"| UpdateResume
    UpdateResume --> BuildCmd
    ReturnCode -->|"non-zero"| ERROR_EXIT
    ReturnCode -->|"zero"| MarkOnboarded
    MarkOnboarded --> DONE

    %% FLOW — _run_interactive_session (separate entry) %%
    SLBuildCmd --> SLPrefixDetect
    SLPrefixDetect --> SLPluginFlags
    SLPluginFlags -->|"marketplace"| SLAssembleCmd
    SLPluginFlags -->|"direct"| SLAssembleCmd
    SLAssembleCmd --> SLRun
    SLRun --> SLSentinel
    SLSentinel -->|"yes → return session_id"| DONE
    SLSentinel -->|"no → check returncode"| DONE

    %% FLOW — open_kitchen %%
    CLAUDE_RUNNING -->|"first tool call after session start"| HeadlessGuard
    HeadlessGuard -->|"headless caller"| HeadlessDeny
    HeadlessGuard -->|"orchestrator ok"| KitchenHandler
    KitchenHandler -->|"error at any stage"| HeadlessDeny
    KitchenHandler -->|"success"| EnableComponents
    EnableComponents --> RedisableSubsets
    RedisableSubsets --> RecipeCheck
    RecipeCheck -->|"yes"| LoadValidate
    RecipeCheck -->|"no"| GenericOpen
    LoadValidate --> OKReturnJSON
    GenericOpen --> OKReturnJSON

    %% CLASS ASSIGNMENTS %%
    class START,DONE,ERROR_EXIT,CLAUDE_RUNNING terminal;
    class BinaryCheck,ConfirmPrompt,PluginDirDecide,ResumeCheck,ConsumeReload,ReloadGuard,ReturnCode,SLPluginFlags,SLSentinel,HeadlessGuard,RecipeCheck detector;
    class ConfigLoad,LoggingResume,Onboarding,RegistrySkills,PluginDirNone,PluginDirPkg,SessionPicker,BuildCmd,RunSession,UpdateResume,MarkOnboarded,SLBuildCmd,SLAssembleCmd,SLRun,KitchenHandler,EnableComponents,RedisableSubsets,LoadValidate,GenericOpen,OKReturnJSON handler;
    class OnboardCheck phase;
    class PrefixDetect,SLPrefixDetect newComponent;
    class HeadlessDeny output;
```

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START([PROCESS START])

    subgraph ImportTime ["IMPORT-TIME INTEGRITY GUARDS (INIT_ONLY)"]
        direction TB
        ConstGuard["_type_constants.py GUARDS<br/>━━━━━━━━━━<br/>MUTATING_TOOLS ≤ ALL_REGISTERED<br/>VIS_TAGS cover all tool tags<br/>FeatureDef tags registered<br/>Fires at module import — not call time"]
        FreeRange["● FREE_RANGE_TOOLS (alwaysLoad:true)<br/>━━━━━━━━━━<br/>open_kitchen · close_kitchen<br/>disable_quota_guard · reload_session<br/>meta={'anthropic/alwaysLoad': True}<br/>Always in initial tool context"]
        GatedTools["GATED_TOOLS (43 tools)<br/>━━━━━━━━━━<br/>Hidden via kitchen tag at startup<br/>run_skill, run_cmd, github/* ..."]
    end

    subgraph ServerInit ["SERVER INIT (INIT_ONLY — set once, never cleared)"]
        direction TB
        CtxSingleton["_ctx singleton<br/>━━━━━━━━━━<br/>_initialize() sets once before mcp.run()<br/>_get_ctx() raises RuntimeError if None<br/>_get_ctx_or_none() for FREE_RANGE tools"]
        GlobalDisable["mcp.disable(tags={'kitchen'})<br/>━━━━━━━━━━<br/>Baseline: all 43 gated tools hidden<br/>Applied ONCE at startup"]
        SessionTypeVis["_apply_session_type_visibility()<br/>━━━━━━━━━━<br/>FLEET → fleet tag<br/>ORCH+HEADLESS → kitchen-core + L2 tags<br/>LEAF+HEADLESS → headless (test_check only)"]
    end

    subgraph ResumeDetect ["● RESUME DETECTION — Discriminated Union (_cook.py · _session_launch.py)"]
        direction LR
        Named["Tier 1: NamedResume<br/>━━━━━━━━━━<br/>--session-id explicit<br/>Exact session continuation"]
        Bare["Tier 2: BareResume<br/>━━━━━━━━━━<br/>--resume without ID<br/>→ interactive picker<br/>→ Named | NoResume"]
        NoRes["Tier 3: NoResume<br/>━━━━━━━━━━<br/>No indicators present<br/>Fresh session start"]
    end

    subgraph SysPromptGate ["● SYSTEM PROMPT INJECTION GATE (_session_launch.py)"]
        direction TB
        PromptGuard["_is_resume = isinstance(spec, Named|Bare)<br/>━━━━━━━━━━<br/>Resume → suppress --append-system-prompt<br/>Fresh → inject behavioral prompt<br/>Prevents context-conflict corruption"]
    end

    subgraph ReloadLoop ["● RELOAD LOOP STATE GUARDS (_cook.py · _session_launch.py)"]
        direction TB
        SeenIds["seen_reload_ids: set[str]<br/>━━━━━━━━━━<br/>APPEND_ONLY per loop execution<br/>Identity dedup: repeated ID → SystemExit"]
        MaxGuard["_max_reloads = 10<br/>━━━━━━━━━━<br/>Cardinality guard<br/>len(seen) >= 10 → SystemExit"]
        ResumeSpecMut["resume_spec: LOOP_MUTABLE<br/>━━━━━━━━━━<br/>NamedResume(reload_id) after each cycle<br/>_first_run + _initial_prompt cleared post-iter"]
    end

    subgraph KitchenOpen ["● OPEN_KITCHEN STATE MUTATION SEQUENCE (tools_kitchen.py)"]
        direction TB
        OKGuard["GATE 1: _require_orchestrator_exact<br/>━━━━━━━━━━<br/>Deny non-orchestrator tier BEFORE any state<br/>FAIL-FAST — zero state side-effects on reject"]
        GateEnable["ctx.gate.enable()<br/>━━━━━━━━━━<br/>gate.enabled: False → True<br/>SESSION_SCOPED"]
        KitchenId["ctx.kitchen_id = uuid4()<br/>━━━━━━━━━━<br/>New UUID each open_kitchen call<br/>SESSION_SCOPED"]
        RecipePacks["ctx.active_recipe_packs = frozenset()<br/>━━━━━━━━━━<br/>frozenset() = open, no recipe loaded<br/>None = closed-kitchen sentinel"]
        HookConfig[".hook_config.json written<br/>━━━━━━━━━━<br/>quota settings + kitchen_id for hooks<br/>Cross-process hook handshake artifact"]
        KitchenReveal["ctx.enable_components(tags={'kitchen'})<br/>━━━━━━━━━━<br/>Reveals all 43 gated tools<br/>_redisable_subsets() re-hides config-off packs"]
        OpenRollback["ROLLBACK GATE (3 checkpoints)<br/>━━━━━━━━━━<br/>write_hook_config | prime_quota | refresh_loop<br/>Any failure → ctx.gate.disable() + return failure"]
    end

    subgraph KitchenMarker ["KITCHEN MARKER — Disk State (INIT_ONLY per write)"]
        direction TB
        MarkerFields["KitchenMarker (frozen=True)<br/>━━━━━━━━━━<br/>session_id · opened_at · recipe_name<br/>content_hash · composite_hash<br/>All fields INIT_ONLY — no update path"]
        MarkerWrite["write_marker() — atomic write<br/>━━━━━━━━━━<br/>mkstemp + os.replace (crash-safe)<br/>Overwrites prior marker; never patches"]
        MarkerFresh["is_marker_fresh() TTL = 24 h<br/>━━━━━━━━━━<br/>Expired → sweep_stale_markers()<br/>Malformed → deleted (fail-safe)"]
    end

    subgraph CloseKitchen ["● CLOSE_KITCHEN STATE RESET SEQUENCE (tools_kitchen.py)"]
        direction TB
        RefreshCancel["quota_refresh_task.cancel() → None<br/>━━━━━━━━━━<br/>Background task torn down<br/>SESSION_SCOPED cleanup"]
        GateDisable["ctx.gate.disable()<br/>━━━━━━━━━━<br/>gate.enabled: True → False"]
        RecipeReset["recipe_name/hash/version → ''<br/>━━━━━━━━━━<br/>active_recipe_packs → None<br/>Closed-kitchen sentinel"]
        VisReset["ctx.reset_visibility()<br/>━━━━━━━━━━<br/>All tag visibility to startup defaults<br/>43 gated tools hidden again"]
        DiskCleanup[".hook_config.json + review_gate_state.json<br/>━━━━━━━━━━<br/>Unlinked atomically on close<br/>Prevents stale cross-process state"]
    end

    subgraph AppendOnly ["APPEND_ONLY — Never Cleared (process lifetime)"]
        direction LR
        AuditLog["audit: AuditLog<br/>━━━━━━━━━━<br/>Pipeline failures<br/>Accumulate forever"]
        TokenLog["token_log: TokenLog<br/>━━━━━━━━━━<br/>Per-step tokens<br/>Cumulative"]
        TimingLog["timing_log: TimingLog<br/>━━━━━━━━━━<br/>Wall-clock durations<br/>Cumulative"]
    end

    %% CONNECTIONS %%
    START --> ImportTime
    ImportTime --> ServerInit
    ServerInit --> ResumeDetect
    ResumeDetect --> SysPromptGate
    SysPromptGate --> ReloadLoop
    ReloadLoop --> KitchenOpen
    KitchenOpen --> KitchenMarker
    KitchenMarker --> CloseKitchen
    CloseKitchen --> AppendOnly

    %% CLASS ASSIGNMENTS %%
    class ConstGuard,OKGuard,MarkerFresh,MaxGuard,OpenRollback detector;
    class FreeRange,GatedTools,CtxSingleton,GlobalDisable,SessionTypeVis,MarkerFields stateNode;
    class GateEnable,KitchenId,RecipePacks,HookConfig,KitchenReveal,GateDisable,RecipeReset,RefreshCancel,VisReset,DiskCleanup phase;
    class PromptGuard,SeenIds,ResumeSpecMut handler;
    class MarkerWrite output;
    class Named,Bare,NoRes cli;
    class AuditLog,TokenLog,TimingLog gap;
    class START terminal;
```

Closes #1330

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260426-203123-751564/.autoskillit/temp/rectify/rectify_open_kitchen_first_call_race_2026-04-26_203625.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| rectify | 6.7k | 16.2k | 416.3k | 57.7k | 1 | 7m 48s |
| dry_walkthrough | 92 | 12.2k | 444.0k | 43.0k | 1 | 6m 36s |
| implement | 220 | 12.7k | 1.2M | 54.0k | 1 | 4m 22s |
| assess | 280 | 18.8k | 2.0M | 78.9k | 1 | 6m 53s |
| prepare_pr | 60 | 5.2k | 208.0k | 29.6k | 1 | 1m 34s |
| run_arch_lenses | 7.6k | 23.4k | 735.0k | 125.6k | 3 | 11m 9s |
| compose_pr | 67 | 10.7k | 266.1k | 38.4k | 1 | 3m 26s |
| **Total** | 15.0k | 99.2k | 5.4M | 427.3k | | 41m 51s |