### PR TITLE
Planner Recipe — Adopt Run-Scoped Output Directories

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,6 +231,7 @@ generic_automation_mcp/
 │   ├── rules_recipe.py
 │   ├── rules_skill_content.py
 │   ├── rules_skills.py
+│   ├── rules_temp_path.py
 │   ├── rules_tools.py
 │   ├── rules_verdict.py
 │   ├── rules_worktree.py     #   Semantic validation rule modules

--- a/src/autoskillit/planner/__init__.py
+++ b/src/autoskillit/planner/__init__.py
@@ -5,6 +5,7 @@ from autoskillit.planner.manifests import (
     build_assignment_manifest,
     build_wp_manifest,
     check_remaining,
+    create_run_dir,
 )
 from autoskillit.planner.schema import (  # noqa: F401
     ASSIGNMENT_REQUIRED_KEYS,
@@ -16,11 +17,12 @@ from autoskillit.planner.schema import (  # noqa: F401
 from autoskillit.planner.validation import validate_plan
 
 __all__ = [
-    "check_remaining",
     "build_assignment_manifest",
     "build_wp_manifest",
-    "validate_plan",
+    "check_remaining",
     "compile_plan",
+    "create_run_dir",
     "PlannerManifest",
     "PlannerManifestItem",
+    "validate_plan",
 ]

--- a/src/autoskillit/planner/manifests.py
+++ b/src/autoskillit/planner/manifests.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import secrets
 import time
 from datetime import UTC, datetime
 from pathlib import Path
@@ -13,8 +14,11 @@ _logger = get_logger(__name__)
 
 
 def create_run_dir() -> dict[str, str]:
-    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-    run_dir = Path(os.environ["AUTOSKILLIT_TEMP"]) / "planner" / f"run-{stamp}"
+    temp = os.environ.get("AUTOSKILLIT_TEMP")
+    if not temp:
+        raise RuntimeError("AUTOSKILLIT_TEMP must be set before calling create_run_dir()")
+    stamp = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
+    run_dir = Path(temp) / "planner" / f"run-{stamp}-{secrets.token_hex(4)}"
     for sub in ("phases", "assignments", "work_packages"):
         (run_dir / sub).mkdir(parents=True, exist_ok=True)
     return {"planner_dir": str(run_dir)}

--- a/src/autoskillit/planner/manifests.py
+++ b/src/autoskillit/planner/manifests.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import time
 from datetime import UTC, datetime
 from pathlib import Path
@@ -9,6 +10,14 @@ from autoskillit.core import atomic_write, get_logger, write_versioned_json
 from autoskillit.planner.schema import validate_assignment_result, validate_phase_result
 
 _logger = get_logger(__name__)
+
+
+def create_run_dir() -> dict[str, str]:
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    run_dir = Path(os.environ["AUTOSKILLIT_TEMP"]) / "planner" / f"run-{stamp}"
+    for sub in ("phases", "assignments", "work_packages"):
+        (run_dir / sub).mkdir(parents=True, exist_ok=True)
+    return {"planner_dir": str(run_dir)}
 
 
 def _build_index_entry(result_data: dict[str, object]) -> dict[str, object]:

--- a/src/autoskillit/planner/manifests.py
+++ b/src/autoskillit/planner/manifests.py
@@ -8,12 +8,16 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from autoskillit.core import atomic_write, get_logger, write_versioned_json
-from autoskillit.planner.schema import validate_assignment_result, validate_phase_result
+from autoskillit.planner.schema import (
+    RunDirResult,
+    validate_assignment_result,
+    validate_phase_result,
+)
 
 _logger = get_logger(__name__)
 
 
-def create_run_dir() -> dict[str, str]:
+def create_run_dir() -> RunDirResult:
     temp = os.environ.get("AUTOSKILLIT_TEMP")
     if not temp:
         raise RuntimeError("AUTOSKILLIT_TEMP must be set before calling create_run_dir()")
@@ -21,7 +25,7 @@ def create_run_dir() -> dict[str, str]:
     run_dir = Path(temp) / "planner" / f"run-{stamp}-{secrets.token_hex(4)}"
     for sub in ("phases", "assignments", "work_packages"):
         (run_dir / sub).mkdir(parents=True, exist_ok=True)
-    return {"planner_dir": str(run_dir)}
+    return RunDirResult(planner_dir=str(run_dir))
 
 
 def _build_index_entry(result_data: dict[str, object]) -> dict[str, object]:

--- a/src/autoskillit/planner/schema.py
+++ b/src/autoskillit/planner/schema.py
@@ -57,6 +57,10 @@ class PlannerManifest(TypedDict):
     items: list[PlannerManifestItem]
 
 
+class RunDirResult(TypedDict):
+    planner_dir: str
+
+
 PHASE_REQUIRED_KEYS: frozenset[str] = frozenset({"id", "name", "ordering"})
 ASSIGNMENT_REQUIRED_KEYS: frozenset[str] = frozenset({"id", "name", "proposed_work_packages"})
 WP_REQUIRED_KEYS: frozenset[str] = frozenset({"id", "name", "deliverables"})

--- a/src/autoskillit/recipe/__init__.py
+++ b/src/autoskillit/recipe/__init__.py
@@ -26,6 +26,7 @@ from autoskillit.recipe import rules_reachability as _rules_reachability  # noqa
 from autoskillit.recipe import rules_recipe as _rules_recipe  # noqa: E402 F401
 from autoskillit.recipe import rules_skill_content as _rules_skill_content  # noqa: E402 F401
 from autoskillit.recipe import rules_skills as _rules_skills  # noqa: E402 F401
+from autoskillit.recipe import rules_temp_path as _rules_temp_path  # noqa: E402 F401
 from autoskillit.recipe import rules_tools as _rules_tools  # noqa: E402 F401
 from autoskillit.recipe import rules_verdict as _rules_verdict  # noqa: E402 F401
 from autoskillit.recipe import rules_worktree as _rules_worktree  # noqa: E402 F401

--- a/src/autoskillit/recipe/rules_temp_path.py
+++ b/src/autoskillit/recipe/rules_temp_path.py
@@ -1,0 +1,56 @@
+"""Lint rule: reject bare {{AUTOSKILLIT_TEMP}}/ paths without a context-variable scope prefix."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+
+from autoskillit.core import Severity
+from autoskillit.recipe._analysis import ValidationContext
+from autoskillit.recipe.registry import RuleFinding, semantic_rule
+from autoskillit.recipe.schema import RecipeStep
+
+_BARE_TEMP_RE = re.compile(r"\{\{AUTOSKILLIT_TEMP\}\}/")
+_CONTEXT_SCOPED_RE = re.compile(r"\$\{\{\s*context\.\w+\s*\}\}")
+_SKIP_KEYS = frozenset({"step_name", "callable", "pass_name"})
+
+
+def _iter_path_values(step: RecipeStep) -> Iterator[tuple[str, str]]:
+    for key, val in (step.with_args or {}).items():
+        if key in _SKIP_KEYS:
+            continue
+        if key == "env" and isinstance(val, dict):
+            for env_key, env_val in val.items():
+                if isinstance(env_val, str):
+                    yield f"env.{env_key}", env_val
+        elif isinstance(val, str):
+            yield key, val
+
+
+@semantic_rule(
+    name="non-unique-output-path",
+    description=(
+        "Recipe steps must scope output paths through a per-run context variable. "
+        "Bare {{AUTOSKILLIT_TEMP}}/ paths are shared across runs and cause stale-artifact failures."
+    ),
+    severity=Severity.ERROR,
+)
+def _check_non_unique_output_path(ctx: ValidationContext) -> list[RuleFinding]:
+    findings = []
+    for step_name, step in ctx.recipe.steps.items():
+        for key, val in _iter_path_values(step):
+            if _BARE_TEMP_RE.search(val) and not _CONTEXT_SCOPED_RE.search(val):
+                findings.append(
+                    RuleFinding(
+                        rule="non-unique-output-path",
+                        severity=Severity.ERROR,
+                        step_name=step_name,
+                        message=(
+                            f"Step '{step_name}' references a bare '{{{{AUTOSKILLIT_TEMP}}}}/' path "
+                            f"in '{key}' without a context-variable scope prefix. "
+                            "Capture a unique per-run directory in the init step "
+                            "and reference it via ${{{{ context.run_dir }}}} or similar."
+                        ),
+                    )
+                )
+    return findings

--- a/src/autoskillit/recipe/rules_temp_path.py
+++ b/src/autoskillit/recipe/rules_temp_path.py
@@ -31,7 +31,8 @@ def _iter_path_values(step: RecipeStep) -> Iterator[tuple[str, str]]:
     name="non-unique-output-path",
     description=(
         "Recipe steps must scope output paths through a per-run context variable. "
-        "Bare {{AUTOSKILLIT_TEMP}}/ paths are shared across runs and cause stale-artifact failures."
+        "Bare {{AUTOSKILLIT_TEMP}}/ paths are shared across runs and cause "
+        "stale-artifact failures."
     ),
     severity=Severity.ERROR,
 )
@@ -46,8 +47,8 @@ def _check_non_unique_output_path(ctx: ValidationContext) -> list[RuleFinding]:
                         severity=Severity.ERROR,
                         step_name=step_name,
                         message=(
-                            f"Step '{step_name}' references a bare '{{{{AUTOSKILLIT_TEMP}}}}/' path "
-                            f"in '{key}' without a context-variable scope prefix. "
+                            f"Step '{step_name}' uses a bare '{{{{AUTOSKILLIT_TEMP}}}}/' "
+                            f"path in '{key}' without a context-variable scope prefix. "
                             "Capture a unique per-run directory in the init step "
                             "and reference it via ${{{{ context.run_dir }}}} or similar."
                         ),

--- a/src/autoskillit/recipe/rules_temp_path.py
+++ b/src/autoskillit/recipe/rules_temp_path.py
@@ -25,6 +25,10 @@ def _iter_path_values(step: RecipeStep) -> Iterator[tuple[str, str]]:
                     yield f"env.{env_key}", env_val
         elif isinstance(val, str):
             yield key, val
+        elif isinstance(val, list):
+            for i, item in enumerate(val):
+                if isinstance(item, str):
+                    yield f"{key}[{i}]", item
 
 
 @semantic_rule(

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -1793,7 +1793,7 @@ skills:
     expected_output_patterns:
     - "phase_manifest_path\\s*=\\s*\\S+"
     pattern_examples:
-    - "phase_manifest_path = /tmp/autoskillit/planner/phases/phase_manifest.json\n%%ORDER_UP%%"
+    - "phase_manifest_path = /tmp/autoskillit/planner/run-20260101-120000/phases/phase_manifest.json\n%%ORDER_UP%%"
     write_behavior: always
   planner-elaborate-phase:
     inputs: []

--- a/src/autoskillit/recipes/contracts/planner.yaml
+++ b/src/autoskillit/recipes/contracts/planner.yaml
@@ -1,12 +1,12 @@
-generated_at: '2026-04-26T20:57:11.410246+00:00'
+generated_at: '2026-04-27T04:03:03.096931+00:00'
 bundled_manifest_version: 0.1.0
 skill_hashes:
-  planner-analyze: sha256:493f4753b98943dc593966ebb1e107b03446a41cec1017513cd81ac6051c1247
-  planner-extract-domain: sha256:94cd2bf02dbd1c0d8d28053d61dc18564be8ccdfbc861368b91326cbe4a785dd
-  planner-generate-phases: sha256:e1346c639aca2daa460b0342ea7e78fefe0729e47e91cdc8d5c8916370b070a3
-  planner-elaborate-phase: sha256:110a53c28b82d8f9d1fba1eb227f44f938b27660013cf176c6a402ca41438e87
-  planner-elaborate-assignment: sha256:683f1b24bf2d5e6d5c8447ad42083df2de3152ca48c197e333b9da77a7625345
-  planner-elaborate-wp: sha256:e19ab9995a24293124ecf8562b536121ca257c124c2b6b0d3169922e206b7997
+  planner-analyze: sha256:e9785980a9e68b849de28ffc90bfdcc2d31e7c4e1c75450db2d4384f9fd5d3d6
+  planner-extract-domain: sha256:a6cdccd877e0d7d46d44fe559100e0c7638e1534e34dc18d2b77c6b7681f2f90
+  planner-generate-phases: sha256:8c69291d11a254035aee782e739720790fbd99197828ca99a6729132bd33a8b0
+  planner-elaborate-phase: sha256:3c6bfc60d8ba26270529734c21e7571db3f8d907309b8ad106df0ede82eadff4
+  planner-elaborate-assignment: sha256:5b14748317b972deabaf41f6a6a71bb1de747105ac4466c32f0bbfae7e27df2b
+  planner-elaborate-wp: sha256:75d9e33fd3373080d39a7c09a3172d20362dcbff72c971b09ef68b410071557d
   planner-reconcile-deps: sha256:350fd62e7eade27ad11bf1bea7971e1fdb06aa3e8aec092b374fdc9fb5de0743
   planner-refine: sha256:83ccf798e0e641588d5d7f52f445ef77a974ae197a903499b87c030a1ce0ed9d
 skills:
@@ -28,7 +28,7 @@ skills:
     expected_output_patterns:
     - phase_manifest_path\s*=\s*\S+
     pattern_examples:
-    - 'phase_manifest_path = /tmp/autoskillit/planner/phases/phase_manifest.json
+    - 'phase_manifest_path = /tmp/autoskillit/planner/run-20260101-120000/phases/phase_manifest.json
 
       %%ORDER_UP%%'
     write_behavior: always
@@ -63,21 +63,25 @@ dataflow:
   - source_dir
   - task
   required: []
-  produced: []
+  produced:
+  - planner_dir
 - step: analyze
   available:
+  - planner_dir
   - source_dir
   - task
   required: []
   produced: []
 - step: extract_domain
   available:
+  - planner_dir
   - source_dir
   - task
   required: []
   produced: []
 - step: generate_phases
   available:
+  - planner_dir
   - source_dir
   - task
   required: []
@@ -87,6 +91,7 @@ dataflow:
 - step: check_phases
   available:
   - phase_manifest_path
+  - planner_dir
   - source_dir
   - task
   required: []
@@ -98,6 +103,7 @@ dataflow:
   - current_item_path
   - has_remaining
   - phase_manifest_path
+  - planner_dir
   - source_dir
   - task
   required: []
@@ -107,6 +113,7 @@ dataflow:
   - current_item_path
   - has_remaining
   - phase_manifest_path
+  - planner_dir
   - source_dir
   - task
   required: []
@@ -118,6 +125,7 @@ dataflow:
   - current_item_path
   - has_remaining
   - phase_manifest_path
+  - planner_dir
   - source_dir
   - task
   required: []
@@ -130,6 +138,7 @@ dataflow:
   - current_item_path
   - has_remaining
   - phase_manifest_path
+  - planner_dir
   - source_dir
   - task
   required: []
@@ -140,6 +149,7 @@ dataflow:
   - current_item_path
   - has_remaining
   - phase_manifest_path
+  - planner_dir
   - source_dir
   - task
   required: []
@@ -151,6 +161,7 @@ dataflow:
   - current_item_path
   - has_remaining
   - phase_manifest_path
+  - planner_dir
   - source_dir
   - task
   - wp_manifest_path
@@ -164,6 +175,7 @@ dataflow:
   - current_item_path
   - has_remaining
   - phase_manifest_path
+  - planner_dir
   - source_dir
   - task
   - wp_manifest_path
@@ -175,18 +187,19 @@ dataflow:
   - current_item_path
   - has_remaining
   - phase_manifest_path
+  - planner_dir
   - source_dir
   - task
   - wp_manifest_path
   required: []
   produced: []
-  positional_args: 1
 - step: validate
   available:
   - assignment_manifest_path
   - current_item_path
   - has_remaining
   - phase_manifest_path
+  - planner_dir
   - source_dir
   - task
   - wp_manifest_path
@@ -199,6 +212,7 @@ dataflow:
   - current_item_path
   - has_remaining
   - phase_manifest_path
+  - planner_dir
   - source_dir
   - task
   - verdict
@@ -211,19 +225,21 @@ dataflow:
   - current_item_path
   - has_remaining
   - phase_manifest_path
+  - planner_dir
   - source_dir
   - task
   - verdict
   - wp_manifest_path
   required: []
   produced: []
-  positional_args: 2
+  positional_args: 1
 - step: compile
   available:
   - assignment_manifest_path
   - current_item_path
   - has_remaining
   - phase_manifest_path
+  - planner_dir
   - source_dir
   - task
   - verdict
@@ -236,6 +252,7 @@ dataflow:
   - current_item_path
   - has_remaining
   - phase_manifest_path
+  - planner_dir
   - source_dir
   - task
   - verdict
@@ -248,6 +265,7 @@ dataflow:
   - current_item_path
   - has_remaining
   - phase_manifest_path
+  - planner_dir
   - source_dir
   - task
   - verdict

--- a/src/autoskillit/recipes/planner.yaml
+++ b/src/autoskillit/recipes/planner.yaml
@@ -30,15 +30,12 @@ ingredients:
 steps:
 
   init:
-    tool: run_cmd
+    tool: run_python
     with:
       step_name: "init"
-      command: >
-        mkdir -p
-        {{AUTOSKILLIT_TEMP}}/planner/phases
-        {{AUTOSKILLIT_TEMP}}/planner/assignments
-        {{AUTOSKILLIT_TEMP}}/planner/work_packages
-      cwd: "${{ inputs.source_dir }}"
+      callable: "autoskillit.planner.create_run_dir"
+    capture:
+      planner_dir: "${{ result.planner_dir }}"
     on_success: analyze
     on_failure: escalate_stop
 
@@ -56,7 +53,7 @@ steps:
       skill_command: "/autoskillit:planner-extract-domain"
       cwd: "${{ inputs.source_dir }}"
       env:
-        PLANNER_ANALYSIS_FILE: "{{AUTOSKILLIT_TEMP}}/planner/analysis.json"
+        PLANNER_ANALYSIS_FILE: "${{ context.planner_dir }}/analysis.json"
     on_success: generate_phases
     on_failure: generate_phases
 
@@ -65,8 +62,8 @@ steps:
     with:
       skill_command: >
         /autoskillit:planner-generate-phases
-        {{AUTOSKILLIT_TEMP}}/planner/analysis.json
-        {{AUTOSKILLIT_TEMP}}/planner/domain_knowledge.md
+        ${{ context.planner_dir }}/analysis.json
+        ${{ context.planner_dir }}/domain_knowledge.md
       cwd: "${{ inputs.source_dir }}"
     capture:
       phase_manifest_path: "${{ result.phase_manifest_path }}"
@@ -79,7 +76,7 @@ steps:
       callable: "autoskillit.planner.check_remaining"
       manifest_path: "${{ context.phase_manifest_path }}"
       pass_name: "phases"
-      output_dir: "{{AUTOSKILLIT_TEMP}}/planner"
+      output_dir: "${{ context.planner_dir }}"
     capture:
       has_remaining: "${{ result.has_remaining }}"
       current_item_path: "${{ result.current_item_path }}"
@@ -92,7 +89,7 @@ steps:
   elaborate_phase:
     tool: run_skill
     with:
-      skill_command: "/autoskillit:planner-elaborate-phase ${{ context.current_item_path }}"
+      skill_command: "/autoskillit:planner-elaborate-phase ${{ context.current_item_path }} ${{ context.planner_dir }}"
       cwd: "${{ inputs.source_dir }}"
     optional_context_refs: [current_item_path]
     retries: 1
@@ -104,9 +101,9 @@ steps:
     tool: run_python
     with:
       callable: "autoskillit.planner.build_assignment_manifest"
-      phases_dir: "{{AUTOSKILLIT_TEMP}}/planner/phases"
-      assignments_dir: "{{AUTOSKILLIT_TEMP}}/planner/assignments"
-      output_dir: "{{AUTOSKILLIT_TEMP}}/planner"
+      phases_dir: "${{ context.planner_dir }}/phases"
+      assignments_dir: "${{ context.planner_dir }}/assignments"
+      output_dir: "${{ context.planner_dir }}"
     capture:
       assignment_manifest_path: "${{ result.manifest_path }}"
     on_success: check_assignments
@@ -118,7 +115,7 @@ steps:
       callable: "autoskillit.planner.check_remaining"
       manifest_path: "${{ context.assignment_manifest_path }}"
       pass_name: "assignments"
-      output_dir: "{{AUTOSKILLIT_TEMP}}/planner"
+      output_dir: "${{ context.planner_dir }}"
     capture:
       has_remaining: "${{ result.has_remaining }}"
       current_item_path: "${{ result.current_item_path }}"
@@ -131,7 +128,7 @@ steps:
   elaborate_assignment:
     tool: run_skill
     with:
-      skill_command: "/autoskillit:planner-elaborate-assignment ${{ context.current_item_path }}"
+      skill_command: "/autoskillit:planner-elaborate-assignment ${{ context.current_item_path }} ${{ context.planner_dir }}"
       cwd: "${{ inputs.source_dir }}"
     optional_context_refs: [current_item_path]
     retries: 1
@@ -143,9 +140,9 @@ steps:
     tool: run_python
     with:
       callable: "autoskillit.planner.build_wp_manifest"
-      assignments_dir: "{{AUTOSKILLIT_TEMP}}/planner/assignments"
-      work_packages_dir: "{{AUTOSKILLIT_TEMP}}/planner/work_packages"
-      output_dir: "{{AUTOSKILLIT_TEMP}}/planner"
+      assignments_dir: "${{ context.planner_dir }}/assignments"
+      work_packages_dir: "${{ context.planner_dir }}/work_packages"
+      output_dir: "${{ context.planner_dir }}"
     capture:
       wp_manifest_path: "${{ result.manifest_path }}"
     on_success: check_wps
@@ -157,7 +154,7 @@ steps:
       callable: "autoskillit.planner.check_remaining"
       manifest_path: "${{ context.wp_manifest_path }}"
       pass_name: "work_packages"
-      output_dir: "{{AUTOSKILLIT_TEMP}}/planner"
+      output_dir: "${{ context.planner_dir }}"
     capture:
       has_remaining: "${{ result.has_remaining }}"
       current_item_path: "${{ result.current_item_path }}"
@@ -170,7 +167,7 @@ steps:
   elaborate_wp:
     tool: run_skill
     with:
-      skill_command: "/autoskillit:planner-elaborate-wp ${{ context.current_item_path }}"
+      skill_command: "/autoskillit:planner-elaborate-wp ${{ context.current_item_path }} ${{ context.planner_dir }}"
       cwd: "${{ inputs.source_dir }}"
     optional_context_refs: [current_item_path]
     retries: 2
@@ -182,7 +179,7 @@ steps:
   reconcile_deps:
     tool: run_skill
     with:
-      skill_command: "/autoskillit:planner-reconcile-deps {{AUTOSKILLIT_TEMP}}/planner"
+      skill_command: "/autoskillit:planner-reconcile-deps ${{ context.planner_dir }}"
       cwd: "${{ inputs.source_dir }}"
     on_success: validate
     on_failure: escalate_stop
@@ -191,7 +188,7 @@ steps:
     tool: run_python
     with:
       callable: "autoskillit.planner.validate_plan"
-      output_dir: "{{AUTOSKILLIT_TEMP}}/planner"
+      output_dir: "${{ context.planner_dir }}"
     capture:
       verdict: "${{ result.verdict }}"
     on_success: check_verdict
@@ -209,8 +206,8 @@ steps:
     with:
       skill_command: >
         /autoskillit:planner-refine
-        {{AUTOSKILLIT_TEMP}}/planner/validation.json
-        {{AUTOSKILLIT_TEMP}}/planner
+        ${{ context.planner_dir }}/validation.json
+        ${{ context.planner_dir }}
       cwd: "${{ inputs.source_dir }}"
     retries: 2
     on_success: validate
@@ -221,7 +218,7 @@ steps:
     tool: run_python
     with:
       callable: "autoskillit.planner.compile_plan"
-      output_dir: "{{AUTOSKILLIT_TEMP}}/planner"
+      output_dir: "${{ context.planner_dir }}"
       task: "${{ inputs.task }}"
       source_dir: "${{ inputs.source_dir }}"
     on_success: done
@@ -230,7 +227,7 @@ steps:
   done:
     action: stop
     message: >
-      Planning complete. Plan artifacts written to {{AUTOSKILLIT_TEMP}}/planner/.
+      Planning complete. Plan artifacts written to ${{ context.planner_dir }}/.
       Use compile output to create GitHub issues and milestones.
 
   escalate_stop:

--- a/src/autoskillit/recipes/planner.yaml
+++ b/src/autoskillit/recipes/planner.yaml
@@ -42,7 +42,7 @@ steps:
   analyze:
     tool: run_skill
     with:
-      skill_command: "/autoskillit:planner-analyze"
+      skill_command: "/autoskillit:planner-analyze ${{ context.planner_dir }}"
       cwd: "${{ inputs.source_dir }}"
     on_success: extract_domain
     on_failure: escalate_stop

--- a/src/autoskillit/skills_extended/planner-analyze/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-analyze/SKILL.md
@@ -22,13 +22,13 @@ Detect language, framework, test infrastructure, project structure, and existing
 
 ## Arguments
 
-No positional arguments. Reads the target project from the current working directory.
+- **$1** — Absolute path to the run-scoped planner directory (e.g., `/path/to/.autoskillit/temp/planner/run-YYYYMMDD-HHMMSS`). Created by the `init` step.
 
 ## Critical Constraints
 
 **NEVER:**
 - Modify any target project files
-- Write output outside `{{AUTOSKILLIT_TEMP}}/planner/`
+- Write analysis.json outside `$1/`
 
 **ALWAYS:**
 - Use Explore subagents for all file reads
@@ -55,7 +55,7 @@ Merge all four agent outputs into a single `analysis.json` document matching the
 
 ### Step 3: Write output
 
-Write to `{{AUTOSKILLIT_TEMP}}/planner/analysis.json`. Create the directory if it does not exist.
+Write to `$1/analysis.json`. The directory was created by the `init` step.
 
 ## Output Schema
 

--- a/src/autoskillit/skills_extended/planner-analyze/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-analyze/SKILL.md
@@ -22,7 +22,7 @@ Detect language, framework, test infrastructure, project structure, and existing
 
 ## Arguments
 
-- **$1** — Absolute path to the run-scoped planner directory (e.g., `/path/to/.autoskillit/temp/planner/run-YYYYMMDD-HHMMSS`). Created by the `init` step.
+- **$1** — Absolute path to the run-scoped planner directory (e.g., `{{AUTOSKILLIT_TEMP}}/planner/run-YYYYMMDD-HHMMSS`). Created by the `init` step.
 
 ## Critical Constraints
 

--- a/src/autoskillit/skills_extended/planner-elaborate-assignment/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-assignment/SKILL.md
@@ -25,7 +25,7 @@ Produces the `proposed_work_packages` array — the critical bridge to Pass 3.
 ## Arguments
 
 - **$1** — Absolute path to the context file written by `check_remaining`
-- **$2** — Absolute path to the run-scoped planner directory (e.g., `/path/to/.autoskillit/temp/planner/run-YYYYMMDD-HHMMSS`)
+- **$2** — Absolute path to the run-scoped planner directory (e.g., `{{AUTOSKILLIT_TEMP}}/planner/run-YYYYMMDD-HHMMSS`)
 
 ## Critical Constraints
 

--- a/src/autoskillit/skills_extended/planner-elaborate-assignment/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-assignment/SKILL.md
@@ -25,13 +25,14 @@ Produces the `proposed_work_packages` array — the critical bridge to Pass 3.
 ## Arguments
 
 - **$1** — Absolute path to the context file written by `check_remaining`
+- **$2** — Absolute path to the run-scoped planner directory (e.g., `/path/to/.autoskillit/temp/planner/run-YYYYMMDD-HHMMSS`)
 
 ## Critical Constraints
 
 **NEVER:**
 - Omit `proposed_work_packages` from the result — it is mandatory
 - Use freeform strings in WP entries — every entry must have `id_suffix`, `name`, `scope`, `estimated_files`
-- Write output outside `{{AUTOSKILLIT_TEMP}}/planner/assignments/`
+- Write output outside `$2/assignments/`
 - Make `estimated_files` exhaustive — it is guidance, not a contract
 
 **ALWAYS:**
@@ -87,7 +88,7 @@ For each WP, define:
 
 ### Step 4: Write assignment result
 
-Write to `{{AUTOSKILLIT_TEMP}}/planner/assignments/{id}_result.json` (relative to the current working directory):
+Write to `$2/assignments/{id}_result.json`:
 ```json
 {
   "id": "P1-A2",

--- a/src/autoskillit/skills_extended/planner-elaborate-phase/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-phase/SKILL.md
@@ -25,7 +25,7 @@ describing one phase and all prior phase results, then writes a complete phase r
 ## Arguments
 
 - **$1** — Absolute path to the context file written by `check_remaining`
-- **$2** — Absolute path to the run-scoped planner directory (e.g., `/path/to/.autoskillit/temp/planner/run-YYYYMMDD-HHMMSS`)
+- **$2** — Absolute path to the run-scoped planner directory (e.g., `{{AUTOSKILLIT_TEMP}}/planner/run-YYYYMMDD-HHMMSS`)
 
 ## Critical Constraints
 

--- a/src/autoskillit/skills_extended/planner-elaborate-phase/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-phase/SKILL.md
@@ -25,17 +25,18 @@ describing one phase and all prior phase results, then writes a complete phase r
 ## Arguments
 
 - **$1** — Absolute path to the context file written by `check_remaining`
+- **$2** — Absolute path to the run-scoped planner directory (e.g., `/path/to/.autoskillit/temp/planner/run-YYYYMMDD-HHMMSS`)
 
 ## Critical Constraints
 
 **NEVER:**
-- Write output outside `{{AUTOSKILLIT_TEMP}}/planner/phases/`
+- Write output outside `$2/phases/`
 - Omit `relationship_notes` from the result
 
 **ALWAYS:**
 - Read all prior phase results listed in the context file before writing
 - Set `relationship_notes` based on actual dependencies identified in prior results
-- Write the result to `{{AUTOSKILLIT_TEMP}}/planner/phases/{id}_result.json` where `{id}` comes from the context file (the context file does NOT contain a `result_path` field)
+- Write the result to `$2/phases/{id}_result.json` where `{id}` comes from the context file (the context file does NOT contain a `result_path` field)
 - Emit `phase_result_path` output token
 
 ## Workflow
@@ -65,7 +66,7 @@ on any prior phase's deliverables?
 
 ### Step 3: Write phase result
 
-Write to `{{AUTOSKILLIT_TEMP}}/planner/phases/{id}_result.json` (relative to the current working directory):
+Write to `$2/phases/{id}_result.json`:
 ```json
 {
   "id": "P4",

--- a/src/autoskillit/skills_extended/planner-elaborate-wp/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-wp/SKILL.md
@@ -25,12 +25,13 @@ details that become GitHub issues. Runs once per work package in its own headles
 ## Arguments
 
 - **$1** — Absolute path to the context file written by `check_remaining` (the skill runs in the recipe clone as the current working directory)
+- **$2** — Absolute path to the run-scoped planner directory (e.g., `/path/to/.autoskillit/temp/planner/run-YYYYMMDD-HHMMSS`)
 
 ## Critical Constraints
 
 **NEVER:**
 - Omit any mandatory result field — all fields listed in Step 6 are required
-- Write output outside `{{AUTOSKILLIT_TEMP}}/planner/work_packages/`
+- Write output outside `$2/work_packages/`
 - Exceed 5 deliverables — WPs must be completable in one implement-worktree session
 - Declare a `depends_on` pointing to a WP later in execution order (forward deps only)
 - Skip the `wp_index.json` append — this is a mandatory contract, not optional
@@ -140,7 +141,7 @@ note the scope mismatch but keep deliverables ≤ 5 — flag it in acceptance cr
 
 ### Step 7: Write WP result
 
-Write to `{{AUTOSKILLIT_TEMP}}/planner/work_packages/{id}_result.json`
+Write to `$2/work_packages/{id}_result.json`
 where `{id}` comes from the context file (e.g., `P1-A2-WP1`).
 
 ```json
@@ -183,7 +184,7 @@ entry if this step is missed — but the backstop entry lacks `files_touched` an
 
 Read `wp_index_path`, parse the JSON array, append the new compact entry, write back.
 
-Set `result_path` to the exact path written in Step 7: `{{AUTOSKILLIT_TEMP}}/planner/work_packages/{id}_result.json`. Using any other value will break downstream `result_path` lookups in subsequent WP elaborations.
+Set `result_path` to the exact path written in Step 7: `$2/work_packages/{id}_result.json` where `$2` is the planner directory passed as the second argument. Using any other value will break downstream `result_path` lookups in subsequent WP elaborations.
 
 ```json
 {

--- a/src/autoskillit/skills_extended/planner-elaborate-wp/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-wp/SKILL.md
@@ -25,7 +25,7 @@ details that become GitHub issues. Runs once per work package in its own headles
 ## Arguments
 
 - **$1** — Absolute path to the context file written by `check_remaining` (the skill runs in the recipe clone as the current working directory)
-- **$2** — Absolute path to the run-scoped planner directory (e.g., `/path/to/.autoskillit/temp/planner/run-YYYYMMDD-HHMMSS`)
+- **$2** — Absolute path to the run-scoped planner directory (e.g., `{{AUTOSKILLIT_TEMP}}/planner/run-YYYYMMDD-HHMMSS`)
 
 ## Critical Constraints
 

--- a/src/autoskillit/skills_extended/planner-extract-domain/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-extract-domain/SKILL.md
@@ -61,4 +61,4 @@ Merge all agent outputs into a coherent `domain_knowledge.md` Markdown document 
 
 ### Step 4: Write output (non-fatal)
 
-Write to `{{AUTOSKILLIT_TEMP}}/planner/domain_knowledge.md` (relative to the current working directory). If any step fails, log a warning to stdout and exit with code 0 — do not propagate the error to the recipe.
+Write to `$(dirname $PLANNER_ANALYSIS_FILE)/domain_knowledge.md`. If any step fails, log a warning to stdout and exit with code 0 — do not propagate the error to the recipe.

--- a/src/autoskillit/skills_extended/planner-extract-domain/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-extract-domain/SKILL.md
@@ -61,4 +61,12 @@ Merge all agent outputs into a coherent `domain_knowledge.md` Markdown document 
 
 ### Step 4: Write output (non-fatal)
 
+Before computing the write path, validate that `PLANNER_ANALYSIS_FILE` is non-empty:
+```bash
+if [ -z "$PLANNER_ANALYSIS_FILE" ]; then
+  echo "[planner-extract-domain] WARNING: PLANNER_ANALYSIS_FILE is unset — skipping domain knowledge write"
+  exit 0
+fi
+```
+
 Write to `$(dirname $PLANNER_ANALYSIS_FILE)/domain_knowledge.md`. If any step fails, log a warning to stdout and exit with code 0 — do not propagate the error to the recipe.

--- a/src/autoskillit/skills_extended/planner-generate-phases/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-generate-phases/SKILL.md
@@ -31,12 +31,12 @@ Pass 1 entry point. Read the analysis file (and optionally domain knowledge) and
 
 **NEVER:**
 - Produce fewer than 3 or more than 6 phases
-- Write output outside `{{AUTOSKILLIT_TEMP}}/planner/phases/`
+- Write output outside `$(dirname $1)/phases/`
 - Use freeform text instead of the required JSON schema
 
 **ALWAYS:**
-- Write `{{AUTOSKILLIT_TEMP}}/planner/phases/{phase_id}_result.json` for every phase
-- Write `{{AUTOSKILLIT_TEMP}}/planner/phases/phase_manifest.json` with every item status=`done`
+- Write `$(dirname $1)/phases/{phase_id}_result.json` for every phase
+- Write `$(dirname $1)/phases/phase_manifest.json` with every item status=`done`
 - Use sequential `ordering` values starting at 1
 - Emit `phase_manifest_path` and `phase_count` output tokens
 
@@ -67,7 +67,7 @@ For each phase, generate:
 
 ### Step 3: Write phase results
 
-For each phase, write to `{{AUTOSKILLIT_TEMP}}/planner/phases/{phase_id}_result.json` (relative to the current working directory):
+For each phase, write to `$(dirname $1)/phases/{phase_id}_result.json`:
 
 ```json
 {
@@ -87,7 +87,7 @@ The backend derives two additional fields at load time — do not write them:
 
 ### Step 4: Write phase manifest
 
-Write `{{AUTOSKILLIT_TEMP}}/planner/phases/phase_manifest.json`. Set every item's status to
+Write `$(dirname $1)/phases/phase_manifest.json`. Set every item's status to
 `done` (Pass 1 is coarse-grained enough to resolve in one shot; the elaborate loop exists
 only as a fallback). Set `result_path` to the absolute path of the corresponding result file.
 

--- a/src/autoskillit/skills_extended/write-recipe/SKILL.md
+++ b/src/autoskillit/skills_extended/write-recipe/SKILL.md
@@ -40,6 +40,25 @@ No positional arguments. The skill prompts interactively for workflow details.
 - Call `validate_recipe` after saving and fix any errors
 - Use "recipe" terminology (not "skill script")
 
+## Output Path Isolation (Required)
+
+Every recipe that produces output files MUST scope its write destinations through a
+per-run context variable captured in the `init` step:
+
+- Use `init` to create a unique timestamped directory and capture its path as
+  `${{ context.work_dir }}`, `${{ context.planner_dir }}`, or similar.
+- All downstream steps reference their output directories via
+  `${{ context.<var> }}/subdir/` — never via bare `{{AUTOSKILLIT_TEMP}}/name/...`.
+- The `non-unique-output-path` lint rule (severity: ERROR) rejects any recipe step
+  that uses a bare `{{AUTOSKILLIT_TEMP}}/` path without a context-variable prefix.
+
+**Valid patterns:**
+- `${{ context.planner_dir }}/phases/` (run-scoped via captured unique dir)
+- `${{ context.work_dir }}/output/` (clone-scoped)
+
+**Invalid pattern (rejected by lint):**
+- `{{AUTOSKILLIT_TEMP}}/myrecipe/data/` (bare — shared across runs, causes stale artifacts)
+
 ## How Scripts Are Loaded
 
 Recipes have their own discovery and invocation mechanism — completely

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -663,6 +663,8 @@ def test_no_subpackage_exceeds_10_files() -> None:
         rules_reachability.py adds symbolic BFS reachability rules, bringing the count to 33.
         rules_fixing.py adds conditional-write-skill ungated-push detection,
         bringing the count to 34.
+        rules_temp_path.py adds the non-unique-output-path lint rule for output path
+        isolation enforcement, bringing the count to 39.
       execution/ — REQ-CNST-003-E3: execution/ decomposes process lifecycle into
         focused single-concern modules (_process_io, _process_kill, _process_race,
         etc.) that cannot be merged without re-introducing the coupling they isolate.
@@ -722,7 +724,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
     """
     EXEMPTIONS: dict[str, int] = {
         "server": 20,
-        "recipe": 38,
+        "recipe": 39,
         "execution": 26,
         "core": 26,
         "cli": 27,

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -663,6 +663,9 @@ def test_no_subpackage_exceeds_10_files() -> None:
         rules_reachability.py adds symbolic BFS reachability rules, bringing the count to 33.
         rules_fixing.py adds conditional-write-skill ungated-push detection,
         bringing the count to 34.
+        rules_campaign.py, rules_features.py, rules_graph.py, and rules_merge.py add
+        campaign scheduling, feature-gate, graph, and merge-workflow semantic rules,
+        bringing the count to 38.
         rules_temp_path.py adds the non-unique-output-path lint rule for output path
         isolation enforcement, bringing the count to 39.
       execution/ — REQ-CNST-003-E3: execution/ decomposes process lifecycle into

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -270,7 +270,7 @@ def test_retry_reason_value_count_is_11() -> None:
 
 
 def test_semantic_rule_family_count_is_22() -> None:
-    assert _count_semantic_rule_files() == 22
+    assert _count_semantic_rule_files() == 23
 
 
 # ----- per-doc count assertions (run once docs exist) -------------------------

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -154,7 +154,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/smoke_utils.py", 87),
     ("src/autoskillit/smoke_utils.py", 169),
     # planner/manifests.py — _backstop_wp_index: list payload (index is a list, not dict)
-    ("src/autoskillit/planner/manifests.py", 51),
+    ("src/autoskillit/planner/manifests.py", 55),
 }
 
 

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -154,7 +154,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/smoke_utils.py", 87),
     ("src/autoskillit/smoke_utils.py", 169),
     # planner/manifests.py — _backstop_wp_index: list payload (index is a list, not dict)
-    ("src/autoskillit/planner/manifests.py", 38),
+    ("src/autoskillit/planner/manifests.py", 47),
 }
 
 

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -154,7 +154,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/smoke_utils.py", 87),
     ("src/autoskillit/smoke_utils.py", 169),
     # planner/manifests.py — _backstop_wp_index: list payload (index is a list, not dict)
-    ("src/autoskillit/planner/manifests.py", 47),
+    ("src/autoskillit/planner/manifests.py", 51),
 }
 
 

--- a/tests/planner/test_planner.py
+++ b/tests/planner/test_planner.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import time
+from pathlib import Path
+
 import pytest
 
 pytestmark = [pytest.mark.layer("planner"), pytest.mark.small, pytest.mark.feature("planner")]
@@ -22,7 +25,35 @@ def test_planner_all_exports_callables() -> None:
         "compile_plan",
         "PlannerManifest",
         "PlannerManifestItem",
+        "create_run_dir",
     }
+
+
+def test_create_run_dir_creates_timestamped_directory(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("AUTOSKILLIT_TEMP", str(tmp_path))
+    from autoskillit.planner import create_run_dir
+
+    result = create_run_dir()
+
+    assert "planner_dir" in result
+    planner_dir = Path(result["planner_dir"])
+    assert planner_dir.exists()
+    assert planner_dir.parent.name == "planner"
+    assert planner_dir.name.startswith("run-")
+    assert (planner_dir / "phases").is_dir()
+    assert (planner_dir / "assignments").is_dir()
+    assert (planner_dir / "work_packages").is_dir()
+
+
+def test_create_run_dir_unique_across_calls(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("AUTOSKILLIT_TEMP", str(tmp_path))
+    from autoskillit.planner import create_run_dir
+
+    r1 = create_run_dir()
+    time.sleep(1.1)
+    r2 = create_run_dir()
+
+    assert r1["planner_dir"] != r2["planner_dir"]
 
 
 def test_planner_feature_skill_categories() -> None:

--- a/tests/planner/test_planner.py
+++ b/tests/planner/test_planner.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import time
 from pathlib import Path
 
 import pytest
@@ -50,10 +49,16 @@ def test_create_run_dir_unique_across_calls(tmp_path, monkeypatch) -> None:
     from autoskillit.planner import create_run_dir
 
     r1 = create_run_dir()
-    time.sleep(1.1)
     r2 = create_run_dir()
 
     assert r1["planner_dir"] != r2["planner_dir"]
+    planner_dir2 = Path(r2["planner_dir"])
+    assert planner_dir2.exists()
+    assert planner_dir2.parent.name == "planner"
+    assert planner_dir2.name.startswith("run-")
+    assert (planner_dir2 / "phases").is_dir()
+    assert (planner_dir2 / "assignments").is_dir()
+    assert (planner_dir2 / "work_packages").is_dir()
 
 
 def test_planner_feature_skill_categories() -> None:

--- a/tests/recipe/test_planner_recipe.py
+++ b/tests/recipe/test_planner_recipe.py
@@ -113,3 +113,24 @@ def test_planner_recipe_extract_domain_uses_env_var(planner_recipe):
     assert "_ _" not in skill_cmd, "Must not have reserved-slot placeholders"
     env = step.with_args.get("env", {})
     assert "PLANNER_ANALYSIS_FILE" in env, "env must declare PLANNER_ANALYSIS_FILE"
+
+
+def test_planner_init_captures_planner_dir(planner_recipe):
+    init_step = planner_recipe.steps["init"]
+    assert init_step.tool == "run_python"
+    assert init_step.with_args.get("callable") == "autoskillit.planner.create_run_dir"
+    assert "planner_dir" in (init_step.capture or {})
+
+
+def test_planner_steps_use_context_planner_dir():
+    import yaml
+
+    from autoskillit.recipe.io import builtin_recipes_dir
+
+    raw = yaml.safe_load((builtin_recipes_dir() / "planner.yaml").read_text())
+    raw_steps = raw.get("steps", {})
+    for step_name, step_dict in raw_steps.items():
+        step_str = str(step_dict)
+        assert "{{AUTOSKILLIT_TEMP}}/planner" not in step_str, (
+            f"Step '{step_name}' still references bare AUTOSKILLIT_TEMP/planner path"
+        )

--- a/tests/recipe/test_rules_temp_path.py
+++ b/tests/recipe/test_rules_temp_path.py
@@ -82,6 +82,24 @@ class TestNonUniqueOutputPath:
         findings = run_semantic_rules(wf)
         assert not any(f.rule == "non-unique-output-path" for f in findings)
 
+    def test_bare_temp_path_in_list_arg_errors(self) -> None:
+        wf = _make_workflow(
+            {
+                "list_step": {
+                    "tool": "run_python",
+                    "with": {
+                        "callable": "some.callable",
+                        "paths": ["{{AUTOSKILLIT_TEMP}}/planner/out.json"],
+                    },
+                    "on_success": "done",
+                },
+                "done": {"action": "stop", "message": "Done."},
+            }
+        )
+        findings = run_semantic_rules(wf)
+        errors = [f for f in findings if f.rule == "non-unique-output-path"]
+        assert any(f.severity == Severity.ERROR and f.step_name == "list_step" for f in errors)
+
     def test_message_field_not_flagged(self) -> None:
         wf = _make_workflow(
             {

--- a/tests/recipe/test_rules_temp_path.py
+++ b/tests/recipe/test_rules_temp_path.py
@@ -1,0 +1,95 @@
+"""Tests for the non-unique-output-path lint rule."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.core import Severity
+from autoskillit.recipe.validator import run_semantic_rules
+from tests.recipe.conftest import _make_workflow
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+
+class TestNonUniqueOutputPath:
+    def test_bare_temp_path_in_output_dir_errors(self) -> None:
+        wf = _make_workflow(
+            {
+                "init_step": {
+                    "tool": "run_python",
+                    "with": {
+                        "callable": "some.callable",
+                        "output_dir": "{{AUTOSKILLIT_TEMP}}/planner",
+                    },
+                    "on_success": "done",
+                },
+                "done": {"action": "stop", "message": "Done."},
+            }
+        )
+        findings = run_semantic_rules(wf)
+        errors = [f for f in findings if f.rule == "non-unique-output-path"]
+        assert any(f.severity == Severity.ERROR and f.step_name == "init_step" for f in errors)
+
+    def test_bare_temp_path_in_cmd_errors(self) -> None:
+        wf = _make_workflow(
+            {
+                "mk_step": {
+                    "tool": "run_cmd",
+                    "with": {
+                        "command": "mkdir -p {{AUTOSKILLIT_TEMP}}/myrecipe/data",
+                    },
+                    "on_success": "done",
+                },
+                "done": {"action": "stop", "message": "Done."},
+            }
+        )
+        findings = run_semantic_rules(wf)
+        errors = [f for f in findings if f.rule == "non-unique-output-path"]
+        assert any(f.severity == Severity.ERROR and f.step_name == "mk_step" for f in errors)
+
+    def test_bare_temp_path_in_env_var_errors(self) -> None:
+        wf = _make_workflow(
+            {
+                "env_step": {
+                    "tool": "run_cmd",
+                    "with": {
+                        "command": "/some-skill",
+                        "env": {"MY_FILE": "{{AUTOSKILLIT_TEMP}}/recipe/data.json"},
+                    },
+                    "on_success": "done",
+                },
+                "done": {"action": "stop", "message": "Done."},
+            }
+        )
+        findings = run_semantic_rules(wf)
+        errors = [f for f in findings if f.rule == "non-unique-output-path"]
+        assert any(f.severity == Severity.ERROR and f.step_name == "env_step" for f in errors)
+
+    def test_context_scoped_path_passes(self) -> None:
+        wf = _make_workflow(
+            {
+                "scoped_step": {
+                    "tool": "run_python",
+                    "with": {
+                        "callable": "some.callable",
+                        "output_dir": "${{ context.planner_dir }}",
+                    },
+                    "on_success": "done",
+                },
+                "done": {"action": "stop", "message": "Done."},
+            }
+        )
+        findings = run_semantic_rules(wf)
+        assert not any(f.rule == "non-unique-output-path" for f in findings)
+
+    def test_message_field_not_flagged(self) -> None:
+        wf = _make_workflow(
+            {
+                "done": {
+                    "action": "stop",
+                    "message": "Output at {{AUTOSKILLIT_TEMP}}/planner/",
+                },
+            }
+        )
+        findings = run_semantic_rules(wf)
+        assert not any(f.rule == "non-unique-output-path" for f in findings)


### PR DESCRIPTION
## Summary

The planner recipe wrote all artifacts to fixed shared paths under `{{AUTOSKILLIT_TEMP}}/planner/`, violating the structural uniqueness pattern every other recipe follows. A second run would find stale artifacts from a prior run, causing `planner-generate-phases` to skip writing entirely and trigger the `zero_writes` gate failure.

The fix mirrors the `clone_repo` → `${{ context.work_dir }}` pattern: a new `create_run_dir()` callable in `manifests.py` mints a timestamped `run-{timestamp}/` directory; the `init` step is changed from `run_cmd`/`mkdir -p` to `run_python`/`create_run_dir` with a `capture: planner_dir` block; and `${{ context.planner_dir }}` is threaded through all 20 path references across 12 downstream steps. A new `non-unique-output-path` lint rule in `rules_temp_path.py` enforces context-scoped output paths at recipe-load time, preventing future regressions.

## Requirements

### REQ-PLN-001: Run-scoped planner output directory
The planner recipe `init` step MUST create a timestamped unique directory and capture its path as `${{ context.planner_dir }}`. New callable `create_run_dir` must be added to `manifests.py` and exported via `__init__.py` / `__all__`.

### REQ-PLN-002: Context variable threading
All 12 downstream recipe steps (20 functional path references) that reference `{{AUTOSKILLIT_TEMP}}/planner` MUST be updated to use `${{ context.planner_dir }}`. The `done` step message should also be updated.

### REQ-PLN-003: Argument-driven skill output paths
All 6 planner skills with hardcoded `{{AUTOSKILLIT_TEMP}}/planner` paths MUST derive their write targets from arguments or env vars:
- `planner-analyze`: add `$1` = planner dir argument
- `planner-extract-domain`: derive from `dirname $PLANNER_ANALYSIS_FILE`
- `planner-generate-phases`: derive from `dirname $1`
- `planner-elaborate-phase`: update NEVER/ALWAYS constraints to context-relative language
- `planner-elaborate-assignment`: update NEVER constraint to context-relative language
- `planner-elaborate-wp`: update NEVER constraint, write target, and `result_path` contract (line 186 is highest risk)

### REQ-PLN-004: `non-unique-output-path` lint rule
A new semantic rule MUST flag ERROR when any recipe step references bare `{{AUTOSKILLIT_TEMP}}/...` paths without a context-variable scope prefix. The rule module must be explicitly imported in `src/autoskillit/recipe/__init__.py` (no auto-discovery).

### REQ-PLN-005: `write-recipe` SKILL.md update
The `write-recipe` skill MUST include guidance requiring output path isolation via per-run context variables.

### REQ-PLN-006: Contract and test updates
- Contract card regeneration for `contracts/planner.yaml`
- `skill_contracts.yaml` `pattern_examples` update for `planner-generate-phases`
- New test: `test_planner_init_captures_planner_dir` (asserts `init` uses `run_python` with capture block)
- New test: `create_run_dir` callable unit test
- New tests: `non-unique-output-path` lint rule coverage

## Architecture Impact

### Data Lineage Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ── INPUTS ─────────────────────────────────────────────── %%
    subgraph Inputs ["Data Origins"]
        ENV["AUTOSKILLIT_TEMP<br/>━━━━━━━━━━<br/>env var<br/>base temp dir"]
        TASK["inputs.task<br/>━━━━━━━━━━<br/>user string<br/>feature description"]
        SRCDIR["inputs.source_dir<br/>━━━━━━━━━━<br/>user string<br/>repo root path"]
    end

    %% ── RUN SCOPE CREATION ──────────────────────────────────── %%
    subgraph Scope ["★ Run-Scope Creation (new)"]
        CREATERUNDIR["★ ● create_run_dir()<br/>━━━━━━━━━━<br/>manifests.py<br/>mints run-{timestamp} dir<br/>+ phases/ assignments/ work_packages/"]
        PLANNERDIR[("● context.planner_dir<br/>━━━━━━━━━━<br/>$AUTOSKILLIT_TEMP/planner/run-{ts}<br/>per-run scope root")]
    end

    %% ── PLANNER PIPELINE ────────────────────────────────────── %%
    subgraph Pipeline ["● planner.yaml — Pipeline Steps"]
        direction TB
        ANALYZE["analyze<br/>━━━━━━━━━━<br/>run_skill: planner-analyze<br/>writes analysis.json"]
        EXTRACT["extract_domain<br/>━━━━━━━━━━<br/>run_skill: planner-extract-domain<br/>writes domain_knowledge.md"]
        GENPHASES["generate_phases<br/>━━━━━━━━━━<br/>run_skill: planner-generate-phases<br/>reads analysis.json + domain_knowledge.md"]
        CHECK_PH["● check_phases / check_remaining<br/>━━━━━━━━━━<br/>run_python: planner.check_remaining<br/>reads+writes phase_manifest.json<br/>writes context_{id}.json"]
        ELAB_PH["elaborate_phase<br/>━━━━━━━━━━<br/>run_skill: planner-elaborate-phase<br/>writes phases/{id}_result.json"]
        BUILD_AM["● build_assignment_manifest<br/>━━━━━━━━━━<br/>run_python: planner.build_assignment_manifest<br/>reads phases/*_result.json<br/>writes assignment_manifest.json"]
        CHECK_AS["● check_assignments / check_remaining<br/>━━━━━━━━━━<br/>run_python: planner.check_remaining<br/>reads+writes assignment_manifest.json<br/>writes context_{id}.json"]
        ELAB_AS["elaborate_assignment<br/>━━━━━━━━━━<br/>run_skill: planner-elaborate-assignment<br/>writes assignments/{id}_result.json"]
        BUILD_WP["● build_wp_manifest<br/>━━━━━━━━━━<br/>run_python: planner.build_wp_manifest<br/>reads assignments/*_result.json<br/>writes wp_manifest.json + wp_index.json"]
        CHECK_WP["● check_wps / check_remaining<br/>━━━━━━━━━━<br/>run_python: planner.check_remaining<br/>reads+writes wp_manifest.json<br/>writes context_{id}.json"]
        ELAB_WP["elaborate_wp<br/>━━━━━━━━━━<br/>run_skill: planner-elaborate-wp<br/>writes work_packages/{id}_result.json"]
        RECONCILE["reconcile_deps<br/>━━━━━━━━━━<br/>run_skill: planner-reconcile-deps<br/>reads all artifacts"]
        VALIDATE["● validate<br/>━━━━━━━━━━<br/>run_python: planner.validate_plan<br/>reads all; writes validation.json"]
        COMPILE["compile<br/>━━━━━━━━━━<br/>run_python: planner.compile_plan<br/>reads all; writes final plan"]
    end

    %% ── PRIMARY STORAGE (scoped artifacts) ──────────────────── %%
    subgraph Storage ["Primary Storage — run-scoped artifacts"]
        direction TB
        ANALYSIS[("analysis.json<br/>━━━━━━━━━━<br/>planner_dir/analysis.json")]
        DOMAIN[("domain_knowledge.md<br/>━━━━━━━━━━<br/>planner_dir/domain_knowledge.md")]
        PH_MANIFEST[("● phase_manifest.json<br/>━━━━━━━━━━<br/>planner_dir/phase_manifest.json")]
        PH_RESULTS[("phases/*_result.json<br/>━━━━━━━━━━<br/>planner_dir/phases/")]
        AS_MANIFEST[("● assignment_manifest.json<br/>━━━━━━━━━━<br/>planner_dir/")]
        AS_RESULTS[("assignments/*_result.json<br/>━━━━━━━━━━<br/>planner_dir/assignments/")]
        WP_MANIFEST[("● wp_manifest.json<br/>━━━━━━━━━━<br/>planner_dir/")]
        WP_INDEX[("● wp_index.json<br/>━━━━━━━━━━<br/>planner_dir/")]
        WP_RESULTS[("work_packages/*_result.json<br/>━━━━━━━━━━<br/>planner_dir/work_packages/")]
        VALIDATION[("validation.json<br/>━━━━━━━━━━<br/>planner_dir/validation.json")]
        PLAN_OUT[("final plan artifacts<br/>━━━━━━━━━━<br/>planner_dir/ (compile output)")]
    end

    %% ── LINT ENFORCEMENT ────────────────────────────────────── %%
    subgraph LintLayer ["★ Lint Enforcement (new)"]
        RULE["★ non-unique-output-path rule<br/>━━━━━━━━━━<br/>rules_temp_path.py<br/>rejects bare {{AUTOSKILLIT_TEMP}}/<br/>without context-variable scope prefix"]
        REGISTRY["● recipe/__init__.py<br/>━━━━━━━━━━<br/>registers rules_temp_path<br/>via @semantic_rule decorator"]
        VALIDATOR["validate_recipe / run_semantic_rules<br/>━━━━━━━━━━<br/>dispatches all registered rules<br/>returns RuleFinding list"]
    end

    %% ── INPUT → SCOPE ───────────────────────────────────────── %%
    ENV -->|"base dir"| CREATERUNDIR
    CREATERUNDIR -->|"returns planner_dir"| PLANNERDIR

    %% ── SCOPE → PIPELINE ────────────────────────────────────── %%
    TASK -->|"passed to compile"| COMPILE
    SRCDIR -->|"cwd for all skills"| ANALYZE
    PLANNERDIR -->|"${{ context.planner_dir }}"| ANALYZE
    PLANNERDIR -->|"${{ context.planner_dir }}"| CHECK_PH
    PLANNERDIR -->|"${{ context.planner_dir }}"| BUILD_AM
    PLANNERDIR -->|"${{ context.planner_dir }}"| CHECK_AS
    PLANNERDIR -->|"${{ context.planner_dir }}"| BUILD_WP
    PLANNERDIR -->|"${{ context.planner_dir }}"| CHECK_WP
    PLANNERDIR -->|"${{ context.planner_dir }}"| RECONCILE
    PLANNERDIR -->|"${{ context.planner_dir }}"| VALIDATE
    PLANNERDIR -->|"${{ context.planner_dir }}"| COMPILE

    %% ── PIPELINE → STORAGE ──────────────────────────────────── %%
    ANALYZE -->|"write"| ANALYSIS
    EXTRACT -->|"write"| DOMAIN
    ANALYSIS -->|"read"| EXTRACT
    ANALYSIS -->|"read"| GENPHASES
    DOMAIN -->|"read"| GENPHASES
    GENPHASES -->|"creates manifest"| PH_MANIFEST
    CHECK_PH -->|"read/write"| PH_MANIFEST
    ELAB_PH -->|"write result"| PH_RESULTS
    PH_RESULTS -->|"read"| BUILD_AM
    BUILD_AM -->|"write"| AS_MANIFEST
    CHECK_AS -->|"read/write"| AS_MANIFEST
    ELAB_AS -->|"write result"| AS_RESULTS
    AS_RESULTS -->|"read"| BUILD_WP
    BUILD_WP -->|"write"| WP_MANIFEST
    BUILD_WP -->|"write"| WP_INDEX
    CHECK_WP -->|"read/write"| WP_MANIFEST
    CHECK_WP -->|"backstop write"| WP_INDEX
    ELAB_WP -->|"write result"| WP_RESULTS
    WP_RESULTS -->|"read"| RECONCILE
    RECONCILE -->|"read all"| VALIDATE
    VALIDATE -->|"write"| VALIDATION
    VALIDATION -->|"read on fail"| VALIDATE
    COMPILE -->|"write"| PLAN_OUT

    %% ── PIPELINE CONTROL ────────────────────────────────────── %%
    CHECK_PH -->|"has_remaining=true"| ELAB_PH
    ELAB_PH -->|"loop back"| CHECK_PH
    CHECK_AS -->|"has_remaining=true"| ELAB_AS
    ELAB_AS -->|"loop back"| CHECK_AS
    CHECK_WP -->|"has_remaining=true"| ELAB_WP
    ELAB_WP -->|"loop back"| CHECK_WP

    %% ── LINT ENFORCEMENT ────────────────────────────────────── %%
    REGISTRY -->|"import triggers registration"| RULE
    RULE -->|"registered in"| VALIDATOR
    ENV -.->|"pattern inspected at recipe-load"| RULE

    class ENV,TASK,SRCDIR cli;
    class CREATERUNDIR,PLANNERDIR newComponent;
    class ANALYZE,EXTRACT,GENPHASES,ELAB_PH,ELAB_AS,ELAB_WP,RECONCILE handler;
    class CHECK_PH,CHECK_AS,CHECK_WP,BUILD_AM,BUILD_WP,VALIDATE,COMPILE phase;
    class ANALYSIS,DOMAIN,PH_MANIFEST,PH_RESULTS,AS_MANIFEST,AS_RESULTS,WP_MANIFEST,WP_INDEX,WP_RESULTS,VALIDATION stateNode;
    class PLAN_OUT output;
    class RULE,VALIDATOR detector;
    class REGISTRY phase;
```

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START])
    PLAN_DONE([PLAN COMPLETE])
    VALID_OK([VALID — no bare paths])
    VALID_FAIL([ERROR — bare path detected])
    ESCALATE([ESCALATE STOP])

    %% ── TRACK A: RULE REGISTRATION ── %%
    subgraph RuleReg ["★/● Rule Registration — Import Time (recipe/__init__.py)"]
        direction LR
        RecipeInit["● recipe/__init__.py<br/>━━━━━━━━━━<br/>imports rules_temp_path"]
        TempPathMod["★ rules_temp_path.py<br/>━━━━━━━━━━<br/>@semantic_rule decorator<br/>severity = ERROR"]
        RuleRegistry[("_RULE_REGISTRY<br/>━━━━━━━━━━<br/>non-unique-output-path<br/>registered")]
        RecipeInit --> TempPathMod --> RuleRegistry
    end

    %% ── TRACK A: VALIDATION FLOW ── %%
    subgraph RecipeVal ["★ Recipe Validation — non-unique-output-path Rule"]
        direction TB
        RunSemantic["run_semantic_rules<br/>━━━━━━━━━━<br/>iterates _RULE_REGISTRY"]
        IterPaths["★ _iter_path_values(step)<br/>━━━━━━━━━━<br/>yields (key, val) from with_args<br/>skips: step_name, callable, pass_name<br/>expands env dict entries"]
        BareCheck{"bare {{AUTOSKILLIT_TEMP}}/<br/>━━━━━━━━━━<br/>WITHOUT ${{context.<var>}}?"}
        EmitFinding["★ RuleFinding ERROR<br/>━━━━━━━━━━<br/>rule: non-unique-output-path<br/>message: capture run_dir first"]
        RunSemantic -->|"for each step"| IterPaths
        IterPaths --> BareCheck
        BareCheck -->|"bare path found"| EmitFinding
        BareCheck -->|"context-scoped or no temp ref"| VALID_OK
        EmitFinding --> VALID_FAIL
    end

    %% ── TRACK B: PLANNER RECIPE ── %%
    subgraph PlannerInit ["● Planner Init — Run-Scoped Directory Creation"]
        direction TB
        InitStep["● init step<br/>━━━━━━━━━━<br/>run_python: create_run_dir()"]
        CreateRunDir["● create_run_dir()<br/>━━━━━━━━━━<br/>$AUTOSKILLIT_TEMP/planner/run-{stamp}<br/>mkdir phases/ assignments/ work_packages/"]
        PlannerDirCtx[("planner_dir context var<br/>━━━━━━━━━━<br/>${{context.planner_dir}}<br/>unique per run")]
        InitStep --> CreateRunDir --> PlannerDirCtx
    end

    subgraph PhasesLoop ["● Phases Loop"]
        direction TB
        Analyze["● analyze<br/>━━━━━━━━━━<br/>planner-analyze<br/>writes analysis.json → $planner_dir"]
        ExtractDomain["extract_domain<br/>━━━━━━━━━━<br/>reads $planner_dir/analysis.json"]
        GeneratePhases["generate_phases<br/>━━━━━━━━━━<br/>writes phase_manifest_path"]
        CheckPhases["● check_phases<br/>━━━━━━━━━━<br/>check_remaining()<br/>output_dir = $planner_dir"]
        PhaseDecision{"has_remaining?"}
        ElaboratePhase["● elaborate_phase (retries=1)<br/>━━━━━━━━━━<br/>$current_item_path $planner_dir<br/>writes phases/{id}_result.json"]
        Analyze --> ExtractDomain --> GeneratePhases --> CheckPhases --> PhaseDecision
        PhaseDecision -->|"true"| ElaboratePhase
        ElaboratePhase -->|"loop"| CheckPhases
    end

    subgraph AssignLoop ["● Assignments Loop"]
        direction TB
        BuildAssign["● build_assignment_manifest<br/>━━━━━━━━━━<br/>reads $planner_dir/phases/<br/>writes assignment_manifest.json"]
        CheckAssign["● check_assignments<br/>━━━━━━━━━━<br/>check_remaining()<br/>output_dir = $planner_dir"]
        AssignDecision{"has_remaining?"}
        ElaborateAssign["● elaborate_assignment (retries=1)<br/>━━━━━━━━━━<br/>$current_item_path $planner_dir<br/>writes assignments/{id}_result.json"]
        BuildAssign --> CheckAssign --> AssignDecision
        AssignDecision -->|"true"| ElaborateAssign
        ElaborateAssign -->|"loop"| CheckAssign
    end

    subgraph WPLoop ["● Work Packages Loop"]
        direction TB
        BuildWP["● build_wp_manifest<br/>━━━━━━━━━━<br/>reads $planner_dir/assignments/<br/>writes wp_manifest.json + wp_index.json"]
        CheckWPs["● check_wps<br/>━━━━━━━━━━<br/>check_remaining()<br/>output_dir = $planner_dir"]
        WPDecision{"has_remaining?"}
        ElaborateWP["● elaborate_wp (retries=2)<br/>━━━━━━━━━━<br/>$current_item_path $planner_dir<br/>writes work_packages/{id}_result.json<br/>on_exhausted → continue"]
        BuildWP --> CheckWPs --> WPDecision
        WPDecision -->|"true"| ElaborateWP
        ElaborateWP -->|"loop / exhausted"| CheckWPs
    end

    subgraph ValidateCycle ["● Validate / Refine Cycle"]
        direction TB
        ReconcileDeps["reconcile_deps<br/>━━━━━━━━━━<br/>planner-reconcile-deps $planner_dir"]
        ValidateStep["● validate<br/>━━━━━━━━━━<br/>validate_plan()<br/>reads $planner_dir"]
        VerdictCheck{"verdict == fail?"}
        RefineStep["refine (max 2 retries)<br/>━━━━━━━━━━<br/>planner-refine $planner_dir<br/>on_exhausted → escalate_stop"]
        CompileStep["● compile<br/>━━━━━━━━━━<br/>compile_plan()<br/>writes plan artifacts → $planner_dir"]
        ReconcileDeps --> ValidateStep --> VerdictCheck
        VerdictCheck -->|"fail"| RefineStep
        RefineStep -->|"retry"| ValidateStep
        VerdictCheck -->|"pass"| CompileStep
    end

    %% ── CROSS-SUBGRAPH EDGES ── %%
    START --> RuleReg
    RuleRegistry -->|"rules registered"| RunSemantic

    START --> PlannerInit
    PlannerDirCtx -->|"${{context.planner_dir}}"| Analyze
    PhaseDecision -->|"false — all phases done"| BuildAssign
    AssignDecision -->|"false — all assignments done"| BuildWP
    WPDecision -->|"false — all WPs done"| ReconcileDeps
    CompileStep --> PLAN_DONE
    ElaboratePhase -->|"on_exhausted"| ESCALATE
    ElaborateAssign -->|"on_exhausted"| ESCALATE
    RefineStep -->|"on_exhausted"| ESCALATE

    %% ── CLASS ASSIGNMENTS ── %%
    class START,PLAN_DONE,VALID_OK,VALID_FAIL,ESCALATE terminal;
    class RecipeInit,CheckPhases,CheckAssign,CheckWPs,ValidateStep,InitStep,ElaboratePhase,ElaborateAssign,ElaborateWP phase;
    class TempPathMod,IterPaths,EmitFinding,CreateRunDir newComponent;
    class RuleRegistry,PlannerDirCtx stateNode;
    class RunSemantic,Analyze,ExtractDomain,GeneratePhases,ReconcileDeps,RefineStep handler;
    class BareCheck,PhaseDecision,AssignDecision,WPDecision,VerdictCheck stateNode;
    class BuildAssign,BuildWP,CompileStep output;
    class EmitFinding detector;
```

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ─────────────── L3 APPLICATION ─────────────── %%
    subgraph L3 ["LAYER 3 — APPLICATION (unchanged consumers)"]
        direction LR
        SERVER["server/<br/>━━━━━━━━━━<br/>MCP tools (fan-in: planner+recipe)"]
        CLI["cli/<br/>━━━━━━━━━━<br/>User-facing commands (fan-in: recipe×17)"]
    end

    %% ─────────────── L2 DOMAIN ─────────────── %%
    subgraph L2 ["LAYER 2 — DOMAIN"]
        direction TB
        RECIPE_INIT["● recipe/__init__.py<br/>━━━━━━━━━━<br/>Wires in rules_temp_path module"]
        RULES_TEMP["★ recipe/rules_temp_path.py<br/>━━━━━━━━━━<br/>non-unique-output-path lint rule<br/>Rejects bare AUTOSKILLIT_TEMP paths<br/>Requires context.&lt;var&gt; scope prefix"]
        RULE_REG["recipe/registry.py<br/>━━━━━━━━━━<br/>@semantic_rule decorator (unchanged)"]
        VALIDATOR["recipe/validator.py<br/>━━━━━━━━━━<br/>Rule dispatch (unchanged)"]
    end

    %% ─────────────── L1 SERVICES ─────────────── %%
    subgraph L1 ["LAYER 1 — SERVICES"]
        direction TB
        PLANNER_INIT["● planner/__init__.py<br/>━━━━━━━━━━<br/>Exports create_run_dir (new)"]
        PLANNER_MAN["● planner/manifests.py<br/>━━━━━━━━━━<br/>★ create_run_dir()<br/>stamps AUTOSKILLIT_TEMP/planner/run-&lt;ts&gt;/<br/>with phases/ assignments/ work_packages/"]
        CORE["core/<br/>━━━━━━━━━━<br/>ensure_project_temp, paths, types<br/>fan-in: 132 files"]
    end

    %% ─────────────── ASSETS ─────────────── %%
    subgraph ASSETS ["ASSETS — Recipe + Skill Docs"]
        direction TB
        PLANNER_YML["● recipes/planner.yaml<br/>━━━━━━━━━━<br/>Uses create_run_dir in init step<br/>Passes run_dir via context"]
        CONTRACTS_YML["● recipes/contracts/planner.yaml<br/>━━━━━━━━━━<br/>Regenerated contract card"]
        SKILL_CONTRACTS["● recipe/skill_contracts.yaml<br/>━━━━━━━━━━<br/>Updated skill-level contracts"]
        SKILL_DOCS["● skills_extended/planner-*/SKILL.md<br/>● skills_extended/write-recipe/SKILL.md<br/>━━━━━━━━━━<br/>7 SKILL.md docs updated<br/>with run-scoped path guidance"]
    end

    %% ─────────────── RUNTIME TEMP DIRS ─────────────── %%
    subgraph RUNTIME ["RUNTIME OUTPUT (enforced by this PR)"]
        SCOPED_DIR["AUTOSKILLIT_TEMP/planner/run-&lt;ts&gt;/<br/>━━━━━━━━━━<br/>phases/  assignments/  work_packages/<br/>(unique per invocation)"]
        BARE_BLOCKED["BLOCKED: bare AUTOSKILLIT_TEMP/<br/>━━━━━━━━━━<br/>non-unique-output-path rule rejects<br/>steps without context.&lt;var&gt; scoping"]
    end

    %% ─────────────── DEPENDENCIES ─────────────── %%

    %% L3 → L2 (valid downward) %%
    SERVER -->|"imports recipe, planner"| RECIPE_INIT
    CLI -->|"imports recipe×17"| RECIPE_INIT

    %% L3 → L1 (valid downward) %%
    SERVER -->|"imports planner"| PLANNER_INIT

    %% L2 → L1 (valid downward) %%
    RECIPE_INIT -->|"registers module"| RULES_TEMP
    RULES_TEMP -->|"uses @semantic_rule"| RULE_REG
    RULE_REG -->|"feeds"| VALIDATOR

    %% L2 → L0 %%
    RECIPE_INIT -->|"imports core"| CORE
    RULES_TEMP -->|"imports core"| CORE

    %% L1 → L0 %%
    PLANNER_INIT -->|"re-exports"| PLANNER_MAN
    PLANNER_MAN -->|"imports core (ensure_project_temp)"| CORE

    %% Assets → L1 %%
    PLANNER_YML -->|"run_python: create_run_dir()"| PLANNER_INIT
    PLANNER_YML -->|"validated by"| VALIDATOR

    %% Assets → Assets %%
    PLANNER_YML -->|"contract generated from"| CONTRACTS_YML
    SKILL_DOCS -.->|"references run-scoped paths"| SCOPED_DIR

    %% Runtime outputs %%
    PLANNER_MAN -->|"creates"| SCOPED_DIR
    RULES_TEMP -->|"rejects"| BARE_BLOCKED

    %% CLASS ASSIGNMENTS %%
    class SERVER,CLI cli;
    class CORE stateNode;
    class PLANNER_MAN,PLANNER_INIT phase;
    class RECIPE_INIT,RULE_REG,VALIDATOR handler;
    class RULES_TEMP newComponent;
    class PLANNER_YML,CONTRACTS_YML,SKILL_CONTRACTS,SKILL_DOCS output;
    class SCOPED_DIR output;
    class BARE_BLOCKED detector;
```

Closes #1334

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260426-203515-421663/.autoskillit/temp/make-plan/planner_recipe_run_scoped_output_plan_2026-04-26_204500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 155 | 26.4k | 757.8k | 64.8k | 1 | 9m 39s |
| verify | 116 | 11.4k | 569.4k | 40.7k | 1 | 4m 49s |
| implement | 620 | 34.9k | 6.1M | 124.0k | 1 | 16m 22s |
| fix | 190 | 11.4k | 1.1M | 60.3k | 1 | 10m 8s |
| prepare_pr | 60 | 9.6k | 222.4k | 39.3k | 1 | 2m 44s |
| run_arch_lenses | 203 | 21.4k | 626.7k | 155.7k | 3 | 8m 29s |
| compose_pr | 67 | 11.1k | 264.0k | 49.1k | 1 | 3m 1s |
| **Total** | 1.4k | 126.3k | 9.7M | 533.8k | | 55m 14s |