### PR TITLE
Rectify: PluginSource Discriminated Union

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,7 @@ generic_automation_mcp/
 │   ├── _type_protocols.py   #   Protocols: GatePolicy, HeadlessExecutor, CIWatcher, etc.
 │   ├── _type_helpers.py
 │   ├── _type_resume.py      #   ResumeSpec discriminated union: NoResume, BareResume, NamedResume
+│   ├── _type_plugin_source.py #  PluginSource discriminated union: DirectInstall | MarketplaceInstall
 │   ├── _linux_proc.py       #   read_boot_id, read_starttime_ticks — Linux /proc helpers (L0)
 │   ├── _claude_env.py       #   IDE-scrubbing canonical env builder for claude subprocesses
 │   ├── _terminal_table.py   #   L0 color-agnostic terminal table primitive

--- a/src/autoskillit/cli/_cook.py
+++ b/src/autoskillit/cli/_cook.py
@@ -107,6 +107,7 @@ def cook(*, resume: bool = False, session_id: str | None = None) -> None:
     if confirm.lower() in ("n", "no"):
         return
 
+    from autoskillit.cli._installed_plugins import InstalledPluginsFile
     from autoskillit.cli._onboarding import is_first_run, run_onboarding_menu
     from autoskillit.core import (
         LAUNCH_ID_ENV_VAR,
@@ -114,6 +115,8 @@ def cook(*, resume: bool = False, session_id: str | None = None) -> None:
         SESSION_TYPE_COOK,
         SESSION_TYPE_ENV_VAR,
         BareResume,
+        DirectInstall,
+        MarketplaceInstall,
         NamedResume,
         NoResume,
         configure_logging,
@@ -122,6 +125,7 @@ def cook(*, resume: bool = False, session_id: str | None = None) -> None:
         resume_spec_from_cli,
         write_registry_entry,
     )
+    from autoskillit.core._plugin_ids import _AUTOSKILLIT_PLUGIN_KEY
     from autoskillit.execution import build_interactive_cmd
 
     configure_logging()
@@ -143,7 +147,14 @@ def cook(*, resume: bool = False, session_id: str | None = None) -> None:
         session_id_local, cook_session=True, config=config, project_dir=project_dir
     )
 
-    plugin_dir = None if detect_autoskillit_mcp_prefix() == MARKETPLACE_PREFIX else pkg_root()
+    _plugins = InstalledPluginsFile().get_plugins()
+    plugin_source: MarketplaceInstall | DirectInstall
+    if _AUTOSKILLIT_PLUGIN_KEY in _plugins:
+        plugin_source = MarketplaceInstall(
+            cache_path=Path(_plugins[_AUTOSKILLIT_PLUGIN_KEY]["installPath"])
+        )
+    else:
+        plugin_source = DirectInstall(plugin_dir=pkg_root())
 
     if isinstance(resume_spec, BareResume):
         from autoskillit.cli._session_picker import pick_session
@@ -167,7 +178,7 @@ def cook(*, resume: bool = False, session_id: str | None = None) -> None:
     seen_reload_ids: set[str] = set()
     while True:
         spec = build_interactive_cmd(
-            plugin_dir=plugin_dir,
+            plugin_source=plugin_source,
             add_dirs=[skills_dir],
             initial_prompt=_current_initial_prompt,
             resume_spec=current_resume_spec,

--- a/src/autoskillit/cli/_cook.py
+++ b/src/autoskillit/cli/_cook.py
@@ -122,11 +122,13 @@ def cook(*, resume: bool = False, session_id: str | None = None) -> None:
         NoResume,
         _get_autoskillit_install_path,
         configure_logging,
-        detect_autoskillit_mcp_prefix,
+        get_logger,
         pkg_root,
         resume_spec_from_cli,
         write_registry_entry,
     )
+
+    logger = get_logger(__name__)
     from autoskillit.execution import build_interactive_cmd
 
     configure_logging()
@@ -150,7 +152,14 @@ def cook(*, resume: bool = False, session_id: str | None = None) -> None:
 
     plugin_source: MarketplaceInstall | DirectInstall
     if InstalledPluginsFile().contains(_AUTOSKILLIT_PLUGIN_KEY):
-        plugin_source = MarketplaceInstall(cache_path=_get_autoskillit_install_path())
+        try:
+            plugin_source = MarketplaceInstall(cache_path=_get_autoskillit_install_path())
+        except (KeyError, ValueError) as exc:
+            logger.warning(
+                "marketplace install path unavailable (%s) — falling back to direct install",
+                exc,
+            )
+            plugin_source = DirectInstall(plugin_dir=pkg_root())
     else:
         plugin_source = DirectInstall(plugin_dir=pkg_root())
 

--- a/src/autoskillit/cli/_cook.py
+++ b/src/autoskillit/cli/_cook.py
@@ -110,6 +110,7 @@ def cook(*, resume: bool = False, session_id: str | None = None) -> None:
     from autoskillit.cli._installed_plugins import InstalledPluginsFile
     from autoskillit.cli._onboarding import is_first_run, run_onboarding_menu
     from autoskillit.core import (
+        _AUTOSKILLIT_PLUGIN_KEY,
         LAUNCH_ID_ENV_VAR,
         MARKETPLACE_PREFIX,
         SESSION_TYPE_COOK,
@@ -119,13 +120,13 @@ def cook(*, resume: bool = False, session_id: str | None = None) -> None:
         MarketplaceInstall,
         NamedResume,
         NoResume,
+        _get_autoskillit_install_path,
         configure_logging,
         detect_autoskillit_mcp_prefix,
         pkg_root,
         resume_spec_from_cli,
         write_registry_entry,
     )
-    from autoskillit.core._plugin_ids import _AUTOSKILLIT_PLUGIN_KEY
     from autoskillit.execution import build_interactive_cmd
 
     configure_logging()
@@ -147,12 +148,9 @@ def cook(*, resume: bool = False, session_id: str | None = None) -> None:
         session_id_local, cook_session=True, config=config, project_dir=project_dir
     )
 
-    _plugins = InstalledPluginsFile().get_plugins()
     plugin_source: MarketplaceInstall | DirectInstall
-    if _AUTOSKILLIT_PLUGIN_KEY in _plugins:
-        plugin_source = MarketplaceInstall(
-            cache_path=Path(_plugins[_AUTOSKILLIT_PLUGIN_KEY]["installPath"])
-        )
+    if InstalledPluginsFile().contains(_AUTOSKILLIT_PLUGIN_KEY):
+        plugin_source = MarketplaceInstall(cache_path=_get_autoskillit_install_path())
     else:
         plugin_source = DirectInstall(plugin_dir=pkg_root())
 

--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -9,6 +9,9 @@ from ._plugin_cache import clear_kitchens_for_pid as clear_kitchens_for_pid
 from ._plugin_cache import register_active_kitchen as register_active_kitchen
 from ._plugin_cache import sweep_retiring_cache as sweep_retiring_cache
 from ._plugin_cache import unregister_active_kitchen as unregister_active_kitchen
+from ._plugin_ids import _AUTOSKILLIT_PLUGIN_KEY as _AUTOSKILLIT_PLUGIN_KEY
+from ._plugin_ids import _get_autoskillit_install_path as _get_autoskillit_install_path
+from ._plugin_ids import _installed_plugins_path as _installed_plugins_path
 from ._plugin_ids import DIRECT_PREFIX as DIRECT_PREFIX
 from ._plugin_ids import MARKETPLACE_PREFIX as MARKETPLACE_PREFIX
 from ._plugin_ids import detect_autoskillit_mcp_prefix as detect_autoskillit_mcp_prefix

--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -96,6 +96,7 @@ from .types import CloneResult as CloneResult
 from .types import CloneSuccessResult as CloneSuccessResult
 from .types import DISPATCH_ID_ENV_VAR as DISPATCH_ID_ENV_VAR
 from .types import DatabaseReader as DatabaseReader
+from .types import DirectInstall as DirectInstall
 from .types import FEATURE_REGISTRY as FEATURE_REGISTRY
 from .types import FLEET_DISPATCH_MODE as FLEET_DISPATCH_MODE
 from .types import FLEET_DISPATCH_TOOLS as FLEET_DISPATCH_TOOLS
@@ -121,6 +122,7 @@ from .types import LAUNCH_ID_ENV_VAR as LAUNCH_ID_ENV_VAR
 from .types import LoadReport as LoadReport
 from .types import LoadResult as LoadResult
 from .types import MUTATING_TOOLS as MUTATING_TOOLS
+from .types import MarketplaceInstall as MarketplaceInstall
 from .types import McpResponseLog as McpResponseLog
 from .types import MergeFailedStep as MergeFailedStep
 from .types import MergeQueueWatcher as MergeQueueWatcher
@@ -134,6 +136,7 @@ from .types import PACK_REGISTRY as PACK_REGISTRY
 from .types import PIPELINE_FORBIDDEN_TOOLS as PIPELINE_FORBIDDEN_TOOLS
 from .types import PRState as PRState
 from .types import PackDef as PackDef
+from .types import PluginSource as PluginSource
 from .types import QuotaRefreshTask as QuotaRefreshTask
 from .types import RECIPE_PACK_REGISTRY as RECIPE_PACK_REGISTRY
 from .types import RECIPE_PACK_TAGS as RECIPE_PACK_TAGS

--- a/src/autoskillit/core/_plugin_ids.py
+++ b/src/autoskillit/core/_plugin_ids.py
@@ -29,13 +29,24 @@ def _get_autoskillit_install_path() -> Path:
 
     The plugin value can be a dict {"installPath": ...} (old format) or
     a list [{"installPath": ...}] (new scoped format). Raises KeyError if
-    the plugin is not present; raises ValueError if the format is unexpected.
+    the plugin is not present; raises ValueError if the file is unreadable,
+    unparseable, or the entry format is unexpected.
     """
-    data = json.loads(_installed_plugins_path().read_text())
+    try:
+        data = json.loads(_installed_plugins_path().read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"Cannot read installed_plugins.json: {exc}") from exc
     entry = data["plugins"][_AUTOSKILLIT_PLUGIN_KEY]
     if isinstance(entry, list):
+        if not entry:
+            raise ValueError(f"Empty install entry list for {_AUTOSKILLIT_PLUGIN_KEY!r}")
         entry = entry[0]
-    return Path(entry["installPath"])
+    install_path = entry.get("installPath") if isinstance(entry, dict) else None
+    if install_path is None:
+        raise ValueError(
+            f"Missing 'installPath' in entry for {_AUTOSKILLIT_PLUGIN_KEY!r}: {entry!r}"
+        )
+    return Path(install_path)
 
 
 def detect_autoskillit_mcp_prefix() -> str:

--- a/src/autoskillit/core/_plugin_ids.py
+++ b/src/autoskillit/core/_plugin_ids.py
@@ -24,6 +24,20 @@ def _installed_plugins_path() -> Path:
     return Path.home() / ".claude" / "plugins" / "installed_plugins.json"
 
 
+def _get_autoskillit_install_path() -> Path:
+    """Return the installPath for autoskillit from installed_plugins.json.
+
+    The plugin value can be a dict {"installPath": ...} (old format) or
+    a list [{"installPath": ...}] (new scoped format). Raises KeyError if
+    the plugin is not present; raises ValueError if the format is unexpected.
+    """
+    data = json.loads(_installed_plugins_path().read_text())
+    entry = data["plugins"][_AUTOSKILLIT_PLUGIN_KEY]
+    if isinstance(entry, list):
+        entry = entry[0]
+    return Path(entry["installPath"])
+
+
 def detect_autoskillit_mcp_prefix() -> str:
     """Return the MCP prefix that autoskillit tools will use in a spawned session.
 

--- a/src/autoskillit/core/_type_plugin_source.py
+++ b/src/autoskillit/core/_type_plugin_source.py
@@ -20,7 +20,10 @@ class DirectInstall:
 
 @dataclass(frozen=True)
 class MarketplaceInstall:
-    """Plugin loaded via Claude marketplace. cache_path is the installPath from installed_plugins.json."""
+    """Plugin loaded via Claude marketplace.
+
+    cache_path is the installPath field from installed_plugins.json.
+    """
 
     cache_path: Path
 

--- a/src/autoskillit/core/_type_plugin_source.py
+++ b/src/autoskillit/core/_type_plugin_source.py
@@ -1,0 +1,28 @@
+"""PluginSource discriminated union — how autoskillit is loaded into Claude Code.
+
+Replaces the `plugin_dir: str | None` nullable sentinel in ToolContext.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+__all__ = ["DirectInstall", "MarketplaceInstall", "PluginSource"]
+
+
+@dataclass(frozen=True)
+class DirectInstall:
+    """Plugin loaded via --plugin-dir. plugin_dir is the package root (pkg_root())."""
+
+    plugin_dir: Path
+
+
+@dataclass(frozen=True)
+class MarketplaceInstall:
+    """Plugin loaded via Claude marketplace. cache_path is the installPath from installed_plugins.json."""
+
+    cache_path: Path
+
+
+PluginSource = DirectInstall | MarketplaceInstall

--- a/src/autoskillit/core/types.py
+++ b/src/autoskillit/core/types.py
@@ -16,6 +16,8 @@ from ._type_protocols import *  # noqa: F401, F403
 from ._type_protocols import __all__ as _protocols_all
 from ._type_results import *  # noqa: F401, F403
 from ._type_results import __all__ as _results_all
+from ._type_plugin_source import *  # noqa: F401, F403
+from ._type_plugin_source import __all__ as _plugin_source_all
 from ._type_resume import *  # noqa: F401, F403
 from ._type_resume import __all__ as _resume_all
 from ._type_subprocess import *  # noqa: F401, F403
@@ -25,6 +27,7 @@ __all__ = (
     _constants_all
     + _enums_all
     + _helpers_all
+    + _plugin_source_all
     + _protocols_all
     + _results_all
     + _resume_all

--- a/src/autoskillit/core/types.py
+++ b/src/autoskillit/core/types.py
@@ -12,12 +12,12 @@ from ._type_enums import *  # noqa: F401, F403
 from ._type_enums import __all__ as _enums_all
 from ._type_helpers import *  # noqa: F401, F403
 from ._type_helpers import __all__ as _helpers_all
+from ._type_plugin_source import *  # noqa: F401, F403
+from ._type_plugin_source import __all__ as _plugin_source_all
 from ._type_protocols import *  # noqa: F401, F403
 from ._type_protocols import __all__ as _protocols_all
 from ._type_results import *  # noqa: F401, F403
 from ._type_results import __all__ as _results_all
-from ._type_plugin_source import *  # noqa: F401, F403
-from ._type_plugin_source import __all__ as _plugin_source_all
 from ._type_resume import *  # noqa: F401, F403
 from ._type_resume import __all__ as _resume_all
 from ._type_subprocess import *  # noqa: F401, F403

--- a/src/autoskillit/execution/commands.py
+++ b/src/autoskillit/execution/commands.py
@@ -15,8 +15,11 @@ from autoskillit.core import (
     SESSION_TYPE_ORCHESTRATOR,
     BareResume,
     ClaudeFlags,
+    DirectInstall,
+    MarketplaceInstall,
     NamedResume,
     NoResume,
+    PluginSource,
     ResumeSpec,
     ValidatedAddDir,
     build_claude_env,
@@ -55,7 +58,7 @@ def build_interactive_cmd(
     *,
     initial_prompt: str | None = None,
     model: str | None = None,
-    plugin_dir: Path | None = None,
+    plugin_source: PluginSource | None = None,
     add_dirs: Sequence[Path | str | ValidatedAddDir] = (),
     resume_spec: ResumeSpec = NoResume(),
     env_extras: Mapping[str, str] | None = None,
@@ -70,8 +73,10 @@ def build_interactive_cmd(
         session start.
     model
         Optional model override.
-    plugin_dir
-        When provided, appended as ``--plugin-dir <path>``.
+    plugin_source
+        When provided, determines the ``--plugin-dir`` flag. DirectInstall uses
+        the plugin_dir path; MarketplaceInstall omits the flag (parent session
+        already has it loaded).
     add_dirs
         Each entry is appended as ``--add-dir <path>``.
     resume_spec
@@ -91,8 +96,13 @@ def build_interactive_cmd(
             pass
     if model:
         cmd += [ClaudeFlags.MODEL, model]
-    if plugin_dir is not None:
-        cmd += [ClaudeFlags.PLUGIN_DIR, str(plugin_dir)]
+    match plugin_source:
+        case DirectInstall(plugin_dir=p):
+            cmd += [ClaudeFlags.PLUGIN_DIR, str(p)]
+        case MarketplaceInstall():
+            pass  # parent session already has the marketplace plugin loaded
+        case None:
+            pass
     for d in add_dirs:
         cmd += [ClaudeFlags.ADD_DIR, str(d)]
     if initial_prompt is not None:
@@ -160,7 +170,7 @@ def build_headless_resume_cmd(
     resume_session_id: str,
     prompt: str,
     output_format: str = "json",
-    plugin_dir: Path | None = None,
+    plugin_source: PluginSource | None = None,
     env_extras: Mapping[str, str] | None = None,
 ) -> ClaudeHeadlessCmd:
     """Build a headless resume command for contract recovery nudge.
@@ -179,8 +189,13 @@ def build_headless_resume_cmd(
         ClaudeFlags.OUTPUT_FORMAT,
         output_format,
     ]
-    if plugin_dir is not None:
-        cmd += [ClaudeFlags.PLUGIN_DIR, str(plugin_dir)]
+    match plugin_source:
+        case DirectInstall(plugin_dir=p):
+            cmd += [ClaudeFlags.PLUGIN_DIR, str(p)]
+        case MarketplaceInstall():
+            pass  # parent session already has the marketplace plugin loaded
+        case None:
+            pass
     merged: dict[str, str] = dict(_SESSION_BASELINE_ENV)
     if env_extras:
         merged.update(env_extras)
@@ -248,7 +263,7 @@ def build_leaf_headless_cmd(
     cwd: str,
     completion_marker: str,
     model: str | None,
-    plugin_dir: str | Path | None,
+    plugin_source: PluginSource | None,
     output_format_value: str,
     output_format_required_flags: Sequence[str] = (),
     add_dirs: Sequence[ValidatedAddDir] = (),
@@ -278,8 +293,9 @@ def build_leaf_headless_cmd(
         Marker string appended to the prompt as a completion directive.
     model
         Optional model override; passed through to ``build_headless_cmd``.
-    plugin_dir
-        Path passed as ``--plugin-dir`` flag.
+    plugin_source
+        PluginSource determining the ``--plugin-dir`` flag. DirectInstall uses the
+        path; MarketplaceInstall omits the flag.
     output_format_value
         String value passed as ``--output-format`` flag.
     output_format_required_flags
@@ -318,8 +334,13 @@ def build_leaf_headless_cmd(
     filtered_base = {k: v for k, v in os.environ.items() if k not in _HEADLESS_EXCLUSIVE_VARS}
     spec = build_headless_cmd(prompt, model=model, env_extras=extras, base=filtered_base)
     cmd: list[str] = [*spec.cmd]
-    if plugin_dir is not None:
-        cmd += [ClaudeFlags.PLUGIN_DIR, str(plugin_dir)]
+    match plugin_source:
+        case DirectInstall(plugin_dir=p):
+            cmd += [ClaudeFlags.PLUGIN_DIR, str(p)]
+        case MarketplaceInstall():
+            pass  # parent session already has the marketplace plugin loaded
+        case None:
+            pass
     cmd += [ClaudeFlags.OUTPUT_FORMAT, output_format_value]
     for flag in output_format_required_flags:
         if flag not in cmd:
@@ -333,7 +354,7 @@ def build_leaf_headless_cmd(
 def build_food_truck_cmd(
     *,
     orchestrator_prompt: str,
-    plugin_dir: str | Path,
+    plugin_source: PluginSource,
     cwd: str,
     completion_marker: str,
     model: str | None = None,
@@ -351,13 +372,17 @@ def build_food_truck_cmd(
     - Sets ``SESSION_TYPE=orchestrator`` (not ``leaf``)
     - Accepts caller-provided ``env_extras`` for campaign-specific variables
       (CAMPAIGN_ID, CAMPAIGN_STATE_PATH, PROJECT_DIR, L2_TOOL_TAGS, etc.)
+    - Always emits ``--plugin-dir``: DirectInstall uses plugin_dir, MarketplaceInstall
+      uses cache_path (food truck sessions are fresh subprocesses that need explicit
+      plugin loading, unlike leaf sessions where the parent already has it).
 
     Parameters
     ----------
     orchestrator_prompt
         Complete system prompt built by the fleet caller.
-    plugin_dir
-        Path passed as ``--plugin-dir`` flag.
+    plugin_source
+        PluginSource determining the ``--plugin-dir`` path. Both DirectInstall and
+        MarketplaceInstall produce a ``--plugin-dir`` flag (paths differ).
     cwd
         Absolute path to the working directory. Injected as anchor directive.
     completion_marker
@@ -399,7 +424,12 @@ def build_food_truck_cmd(
     spec = build_headless_cmd(prompt, model=model, env_extras=extras, base=filtered_base)
 
     cmd: list[str] = [*spec.cmd]
-    cmd += [ClaudeFlags.PLUGIN_DIR, str(plugin_dir)]
+    # Both install modes require --plugin-dir for food truck sessions (fresh subprocess).
+    match plugin_source:
+        case DirectInstall(plugin_dir=p):
+            cmd += [ClaudeFlags.PLUGIN_DIR, str(p)]
+        case MarketplaceInstall(cache_path=cp):
+            cmd += [ClaudeFlags.PLUGIN_DIR, str(cp)]
     cmd += [ClaudeFlags.OUTPUT_FORMAT, output_format_value]
     cmd += [ClaudeFlags.TOOLS, "AskUserQuestion"]
 

--- a/src/autoskillit/execution/headless.py
+++ b/src/autoskillit/execution/headless.py
@@ -1339,14 +1339,13 @@ async def run_headless_core(
         skill_command=original_skill_command[:100],
         step_name=step_name or None,
     ):
-        effective_plugin_dir = ctx.plugin_dir
         resolved_model = _resolve_model(model, ctx.config)
         spec = build_leaf_headless_cmd(
             skill_command,
             cwd=cwd,
             completion_marker=effective_marker,
             model=resolved_model,
-            plugin_dir=effective_plugin_dir,
+            plugin_source=ctx.plugin_source,
             output_format_value=cfg.output_format.value,
             output_format_required_flags=cfg.output_format.required_cli_flags,
             add_dirs=add_dirs,
@@ -1364,7 +1363,7 @@ async def run_headless_core(
             resolved_model=resolved_model,
             timeout=effective_timeout,
             stale_threshold=effective_stale,
-            plugin_dir=str(effective_plugin_dir),
+            plugin_source=repr(ctx.plugin_source),
             add_dirs=list(add_dirs) if add_dirs else None,
         )
 
@@ -1467,12 +1466,6 @@ class DefaultHeadlessExecutor:
         resolved_model = _resolve_model(model, cfg)
         fleet_cfg = cfg.fleet
 
-        plugin_dir = self._ctx.plugin_dir
-        if plugin_dir is None:
-            raise ValueError(
-                "dispatch_food_truck requires a configured plugin_dir; ctx.plugin_dir is None"
-            )
-
         merged_extras: dict[str, str] = dict(env_extras) if env_extras else {}
         if requires_packs:
             if "AUTOSKILLIT_L2_TOOL_TAGS" in merged_extras:
@@ -1488,7 +1481,7 @@ class DefaultHeadlessExecutor:
 
         spec = build_food_truck_cmd(
             orchestrator_prompt=orchestrator_prompt,
-            plugin_dir=plugin_dir,
+            plugin_source=self._ctx.plugin_source,
             cwd=cwd,
             completion_marker=completion_marker,
             model=resolved_model,

--- a/src/autoskillit/pipeline/context.py
+++ b/src/autoskillit/pipeline/context.py
@@ -27,6 +27,7 @@ from autoskillit.core import (
     MergeQueueWatcher,
     MigrationService,
     OutputPatternResolver,
+    PluginSource,
     QuotaRefreshTask,
     RecipeRepository,
     SessionSkillManager,
@@ -59,8 +60,8 @@ class ToolContext:
     timing_log:           TimingLog — per-step wall-clock duration tracking
     response_log:         McpResponseLog — per-tool MCP response size tracking
     gate:                 GateState — enables/disables gated tools
-    plugin_dir:           Absolute path string to the autoskillit package directory, or None if
-                          the marketplace plugin is installed and `--plugin-dir` should be omitted.
+    plugin_source:        PluginSource — DirectInstall (dev/editable) or MarketplaceInstall.
+                          Encodes how autoskillit is loaded into Claude Code sessions.
     runner:               SubprocessRunner implementation (DefaultSubprocessRunner in production,
                           MockSubprocessRunner in tests)
     executor:             HeadlessExecutor — runs headless Claude Code sessions
@@ -98,7 +99,7 @@ class ToolContext:
     token_log: TokenLog
     timing_log: TimingLog
     gate: GateState
-    plugin_dir: str | None
+    plugin_source: PluginSource
     runner: SubprocessRunner | None
     # Always supply temp_dir explicitly when constructing ToolContext directly.
     # The default captures Path.cwd() at field-instantiation time, which is

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -163,7 +163,8 @@ def make_context(
                 tester (useful in tests that don't need real subprocess execution).
         plugin_dir: Absolute path to the autoskillit plugin directory for a
                     direct install. When omitted (sentinel), auto-detects via
-                    _check_plugin_installed(). Superseded by plugin_source.
+                    _check_plugin_installed(). When plugin_source is also provided,
+                    plugin_source takes precedence.
         plugin_source: PluginSource override. When supplied, used directly
                        without detection. For tests and CLI that construct
                        install mode explicitly.
@@ -238,7 +239,16 @@ def make_context(
     elif plugin_dir is not _UNSET and isinstance(plugin_dir, (str, Path)):
         resolved_plugin_source = DirectInstall(plugin_dir=Path(plugin_dir))
     elif _check_plugin_installed():
-        resolved_plugin_source = MarketplaceInstall(cache_path=_resolve_marketplace_cache_path())
+        try:
+            resolved_plugin_source = MarketplaceInstall(
+                cache_path=_resolve_marketplace_cache_path()
+            )
+        except (KeyError, ValueError) as exc:
+            logger.warning(
+                "marketplace install path unavailable (%s) — falling back to direct install",
+                exc,
+            )
+            resolved_plugin_source = DirectInstall(plugin_dir=_default_plugin_dir())
     else:
         resolved_plugin_source = DirectInstall(plugin_dir=_default_plugin_dir())
     plugin_source = resolved_plugin_source

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -108,12 +108,9 @@ def _default_plugin_dir() -> Path:
 
 def _resolve_marketplace_cache_path() -> Path:
     """Read the installPath for autoskillit from installed_plugins.json."""
-    import json
+    from autoskillit.core import _get_autoskillit_install_path
 
-    from autoskillit.core._plugin_ids import _AUTOSKILLIT_PLUGIN_KEY, _installed_plugins_path
-
-    data = json.loads(_installed_plugins_path().read_text())
-    return Path(data["plugins"][_AUTOSKILLIT_PLUGIN_KEY]["installPath"])
+    return _get_autoskillit_install_path()
 
 
 def _gh_cli_token() -> str | None:

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -19,7 +19,10 @@ from typing import Any
 from autoskillit.config import AutomationConfig
 from autoskillit.core import (
     MARKETPLACE_PREFIX,
+    DirectInstall,
     FleetLock,
+    MarketplaceInstall,
+    PluginSource,
     SubprocessRunner,
     WriteBehaviorSpec,
     detect_autoskillit_mcp_prefix,
@@ -98,9 +101,19 @@ class TokenFactory:
         return self._resolved is not self._UNRESOLVED
 
 
-def _default_plugin_dir() -> str:
+def _default_plugin_dir() -> Path:
     """Resolve the autoskillit package root."""
-    return str(pkg_root())
+    return pkg_root()
+
+
+def _resolve_marketplace_cache_path() -> Path:
+    """Read the installPath for autoskillit from installed_plugins.json."""
+    import json
+
+    from autoskillit.core._plugin_ids import _AUTOSKILLIT_PLUGIN_KEY, _installed_plugins_path
+
+    data = json.loads(_installed_plugins_path().read_text())
+    return Path(data["plugins"][_AUTOSKILLIT_PLUGIN_KEY]["installPath"])
 
 
 def _gh_cli_token() -> str | None:
@@ -134,6 +147,7 @@ def make_context(
     *,
     runner: SubprocessRunner | None = _UNSET,
     plugin_dir: str | None = _UNSET,
+    plugin_source: PluginSource = _UNSET,
     fleet_lock: FleetLock | None = None,
 ) -> ToolContext:
     """Create a fully-wired ToolContext with all 22 service fields populated.
@@ -150,10 +164,12 @@ def make_context(
         runner: Subprocess runner implementation. Defaults to DefaultSubprocessRunner()
                 for production use. Pass runner=None explicitly to disable the
                 tester (useful in tests that don't need real subprocess execution).
-        plugin_dir: Absolute path to the autoskillit plugin directory.
-                    Pass None explicitly to indicate the plugin is installed
-                    (marketplace install; no --plugin-dir needed). When omitted
-                    (sentinel), auto-detects via _check_plugin_installed().
+        plugin_dir: Absolute path to the autoskillit plugin directory for a
+                    direct install. When omitted (sentinel), auto-detects via
+                    _check_plugin_installed(). Superseded by plugin_source.
+        plugin_source: PluginSource override. When supplied, used directly
+                       without detection. For tests and CLI that construct
+                       install mode explicitly.
         fleet_lock: FleetLock implementation to inject. Defaults to
                         asyncio.Lock() when None. Pass a custom implementation
                         in tests to substitute the lock without monkey-patching.
@@ -219,11 +235,16 @@ def make_context(
         lambda: config.github.token or os.environ.get("GITHUB_TOKEN") or _gh_cli_token()
     )
 
-    resolved_dir = (
-        plugin_dir
-        if plugin_dir is not _UNSET
-        else (_default_plugin_dir() if not _check_plugin_installed() else None)
-    )
+    resolved_plugin_source: PluginSource
+    if plugin_source is not _UNSET:
+        resolved_plugin_source = plugin_source  # type: ignore[assignment]
+    elif plugin_dir is not _UNSET and isinstance(plugin_dir, (str, Path)):
+        resolved_plugin_source = DirectInstall(plugin_dir=Path(plugin_dir))
+    elif _check_plugin_installed():
+        resolved_plugin_source = MarketplaceInstall(cache_path=_resolve_marketplace_cache_path())
+    else:
+        resolved_plugin_source = DirectInstall(plugin_dir=_default_plugin_dir())
+    plugin_source = resolved_plugin_source
     gate = DefaultGateState(enabled=False)
 
     env_project_dir = os.environ.get("AUTOSKILLIT_PROJECT_DIR", "")
@@ -243,7 +264,7 @@ def make_context(
         token_log=DefaultTokenLog(),
         timing_log=DefaultTimingLog(),
         gate=gate,
-        plugin_dir=resolved_dir,
+        plugin_source=plugin_source,
         runner=runner,
         temp_dir=temp_dir,
         project_dir=project_dir,

--- a/src/autoskillit/server/_state.py
+++ b/src/autoskillit/server/_state.py
@@ -21,7 +21,7 @@ import asyncio
 from datetime import UTC
 
 from autoskillit.config import AutomationConfig
-from autoskillit.core import get_logger
+from autoskillit.core import DirectInstall, MarketplaceInstall, get_logger
 from autoskillit.pipeline import ToolContext
 
 logger = get_logger(__name__)
@@ -175,8 +175,14 @@ def _get_config() -> AutomationConfig:
 
 
 def _get_plugin_dir() -> str | None:
-    """Return plugin_dir from the current server context, or None if uninitialized."""
-    return _ctx.plugin_dir if _ctx is not None else None
+    """Return the plugin path from the current server context, or None if uninitialized."""
+    if _ctx is None:
+        return None
+    match _ctx.plugin_source:
+        case DirectInstall(plugin_dir=p):
+            return str(p)
+        case MarketplaceInstall(cache_path=cp):
+            return str(cp)
 
 
 def _check_rerun(log_dir: str, composite_hash: str) -> dict[str, object] | None:
@@ -194,5 +200,5 @@ def version_info() -> dict:
     """Return version health information for the running server."""
     from autoskillit.version import version_info as _compute_version
 
-    plugin_dir = _ctx.plugin_dir if _ctx is not None else None
+    plugin_dir = _get_plugin_dir()
     return _compute_version(plugin_dir)

--- a/src/autoskillit/server/tools_ci.py
+++ b/src/autoskillit/server/tools_ci.py
@@ -14,7 +14,7 @@ import structlog
 from fastmcp import Context
 from fastmcp.dependencies import CurrentContext
 
-from autoskillit.core import CIRunScope, get_logger
+from autoskillit.core import CIRunScope, DirectInstall, MarketplaceInstall, get_logger
 from autoskillit.pipeline import ToolContext
 from autoskillit.server import mcp
 from autoskillit.server.helpers import (
@@ -231,7 +231,14 @@ async def set_commit_status(
         from autoskillit.server import _get_ctx
 
         tool_ctx = _get_ctx()
-        effective_cwd = cwd or tool_ctx.plugin_dir or "."
+        if cwd:
+            effective_cwd = cwd
+        else:
+            match tool_ctx.plugin_source:
+                case DirectInstall(plugin_dir=p):
+                    effective_cwd = str(p)
+                case MarketplaceInstall(cache_path=cp):
+                    effective_cwd = str(cp)
 
         # Resolve owner/repo if not provided
         owner_repo = repo

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -724,7 +724,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "server": 20,
         "recipe": 38,
         "execution": 26,
-        "core": 26,
+        "core": 27,
         "cli": 27,
         "hooks": 27,
     }
@@ -935,7 +935,7 @@ def test_tool_context_service_fields_use_protocol_types() -> None:
     """REQ-ARCH-002: Every non-exempt ToolContext field must use a Protocol from core/types.py.
 
     Exempt fields:
-    - plugin_dir: str primitive (explicitly stated in the requirement)
+    - plugin_source: PluginSource discriminated union (value type, not a service interface)
     - config: AutomationConfig dataclass (configuration container, not a service interface)
     """
     AUTOSKILLIT_ROOT = SRC_ROOT
@@ -965,7 +965,7 @@ def test_tool_context_service_fields_use_protocol_types() -> None:
     context_path = AUTOSKILLIT_ROOT / "pipeline" / "context.py"
     context_tree = ast.parse(context_path.read_text())
 
-    EXEMPT = {"plugin_dir", "config", "active_recipe_packs", "temp_dir", "project_dir"}
+    EXEMPT = {"plugin_source", "config", "active_recipe_packs", "temp_dir", "project_dir"}
     violations: list[str] = []
 
     for node in ast.walk(context_tree):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -256,6 +256,7 @@ def minimal_ctx(tmp_path):
     use tool_ctx instead.
     """
     from autoskillit.config import AutomationConfig
+    from autoskillit.core._type_plugin_source import DirectInstall
     from autoskillit.pipeline.audit import DefaultAuditLog
     from autoskillit.pipeline.context import ToolContext
     from autoskillit.pipeline.gate import DefaultGateState
@@ -268,7 +269,7 @@ def minimal_ctx(tmp_path):
         token_log=DefaultTokenLog(),
         timing_log=DefaultTimingLog(),
         gate=DefaultGateState(enabled=True),
-        plugin_dir=None,
+        plugin_source=DirectInstall(plugin_dir=tmp_path),
         runner=None,
         temp_dir=tmp_path / ".autoskillit" / "temp",
     )
@@ -291,6 +292,7 @@ def tool_ctx(monkeypatch, tmp_path):
     migrations) are wired via make_context() so routing tests work correctly.
     """
     from autoskillit.config import AutomationConfig
+    from autoskillit.core._type_plugin_source import DirectInstall
     from autoskillit.pipeline.gate import DefaultGateState
     from autoskillit.server import _state
     from autoskillit.server._factory import make_context
@@ -299,7 +301,7 @@ def tool_ctx(monkeypatch, tmp_path):
     ctx = make_context(
         AutomationConfig(features={"fleet": True}),
         runner=mock_runner,
-        plugin_dir=str(tmp_path),
+        plugin_source=DirectInstall(plugin_dir=tmp_path),
     )
     ctx.gate = DefaultGateState(enabled=True)
     ctx.config.linux_tracing.log_dir = str(tmp_path / "session_logs")
@@ -307,6 +309,33 @@ def tool_ctx(monkeypatch, tmp_path):
     # Anchor temp_dir to tmp_path so server tools that read from ctx.temp_dir
     # (e.g. _apply_triage_gate's staleness cache) write under the per-test
     # tmp directory rather than the cwd captured at fixture-init time.
+    ctx.temp_dir = tmp_path / ".autoskillit" / "temp"
+    monkeypatch.setattr(_state, "_ctx", ctx)
+    monkeypatch.setattr(_state, "_startup_ready", None)
+    return ctx
+
+
+@pytest.fixture
+def tool_ctx_marketplace(monkeypatch, tmp_path):
+    """ToolContext simulating a marketplace install: plugin_source = MarketplaceInstall."""
+    from autoskillit.config import AutomationConfig
+    from autoskillit.core._type_plugin_source import MarketplaceInstall
+    from autoskillit.pipeline.gate import DefaultGateState
+    from autoskillit.server import _state
+    from autoskillit.server._factory import make_context
+
+    fake_cache = tmp_path / "marketplace_cache"
+    fake_cache.mkdir()
+
+    mock_runner = MockSubprocessRunner()
+    ctx = make_context(
+        AutomationConfig(features={"fleet": True}),
+        runner=mock_runner,
+        plugin_source=MarketplaceInstall(cache_path=fake_cache),
+    )
+    ctx.gate = DefaultGateState(enabled=True)
+    ctx.config.linux_tracing.log_dir = str(tmp_path / "session_logs")
+    ctx.config.linux_tracing.tmpfs_path = str(tmp_path / "shm")
     ctx.temp_dir = tmp_path / ".autoskillit" / "temp"
     monkeypatch.setattr(_state, "_ctx", ctx)
     monkeypatch.setattr(_state, "_startup_ready", None)

--- a/tests/contracts/test_package_gateways.py
+++ b/tests/contracts/test_package_gateways.py
@@ -217,7 +217,10 @@ def test_factory_make_context_returns_toolcontext(monkeypatch):
     assert ctx.gate.enabled is False  # starts closed
     assert isinstance(ctx.audit, DefaultAuditLog)
     assert ctx.token_log is not None
-    assert ctx.plugin_dir == str(pkg_root())
+    from autoskillit.core._type_plugin_source import DirectInstall
+
+    assert isinstance(ctx.plugin_source, DirectInstall)
+    assert ctx.plugin_source.plugin_dir == pkg_root()
 
 
 def test_factory_make_context_accepts_runner():
@@ -230,10 +233,12 @@ def test_factory_make_context_accepts_runner():
 
 def test_factory_make_context_accepts_plugin_dir(tmp_path):
     from autoskillit.config import AutomationConfig
+    from autoskillit.core._type_plugin_source import DirectInstall
     from autoskillit.server._factory import make_context
 
     ctx = make_context(AutomationConfig(), plugin_dir=str(tmp_path))
-    assert ctx.plugin_dir == str(tmp_path)
+    assert isinstance(ctx.plugin_source, DirectInstall)
+    assert ctx.plugin_source.plugin_dir == tmp_path
 
 
 # ---------------------------------------------------------------------------

--- a/tests/execution/test_commands.py
+++ b/tests/execution/test_commands.py
@@ -6,7 +6,14 @@ from pathlib import Path
 
 import pytest
 
-from autoskillit.core import BareResume, ClaudeFlags, NamedResume, NoResume
+from autoskillit.core import (
+    BareResume,
+    ClaudeFlags,
+    DirectInstall,
+    MarketplaceInstall,
+    NamedResume,
+    NoResume,
+)
 from autoskillit.execution.commands import (
     _HEADLESS_EXCLUSIVE_VARS,
     _MAX_MCP_OUTPUT_TOKENS_VALUE,
@@ -108,13 +115,13 @@ class TestBuildInteractiveCmd:
 
 
 class TestBuildInteractiveCmdExtended:
-    def test_accepts_plugin_dir(self, tmp_path: Path) -> None:
-        """build_interactive_cmd with plugin_dir includes --plugin-dir flag."""
-        plugin_dir = Path(tmp_path)
-        result = build_interactive_cmd(plugin_dir=plugin_dir)
+    def test_accepts_plugin_source_direct_install(self, tmp_path: Path) -> None:
+        """build_interactive_cmd with DirectInstall includes --plugin-dir flag."""
+        plugin_source = DirectInstall(plugin_dir=tmp_path)
+        result = build_interactive_cmd(plugin_source=plugin_source)
         assert "--plugin-dir" in result.cmd
         idx = result.cmd.index("--plugin-dir")
-        assert result.cmd[idx + 1] == str(plugin_dir)
+        assert result.cmd[idx + 1] == str(tmp_path)
 
     def test_accepts_add_dirs(self, tmp_path: Path) -> None:
         """build_interactive_cmd with add_dirs includes --add-dir for each entry."""
@@ -122,8 +129,13 @@ class TestBuildInteractiveCmdExtended:
         result = build_interactive_cmd(add_dirs=[d1, d2])
         assert result.cmd.count("--add-dir") == 2
 
-    def test_plugin_dir_none_omits_flag(self) -> None:
-        """build_interactive_cmd with plugin_dir=None does not emit --plugin-dir."""
+    def test_marketplace_install_omits_plugin_dir_flag(self, tmp_path: Path) -> None:
+        """build_interactive_cmd with MarketplaceInstall does not emit --plugin-dir."""
+        result = build_interactive_cmd(plugin_source=MarketplaceInstall(cache_path=tmp_path))
+        assert "--plugin-dir" not in result.cmd
+
+    def test_no_plugin_source_omits_plugin_dir_flag(self) -> None:
+        """build_interactive_cmd with no plugin_source does not emit --plugin-dir."""
         result = build_interactive_cmd()
         assert "--plugin-dir" not in result.cmd
 
@@ -151,7 +163,7 @@ class TestBuildInteractiveCmdExtended:
 
         actual_cmd = mock_run.call_args[0][0]
         expected_prefix = build_interactive_cmd(
-            plugin_dir=pkg_root(), add_dirs=[fake_skills_dir]
+            plugin_source=DirectInstall(plugin_dir=pkg_root()), add_dirs=[fake_skills_dir]
         ).cmd
         assert actual_cmd == expected_prefix
 
@@ -218,9 +230,11 @@ class TestBuildHeadlessResumeCmd:
         result = build_headless_resume_cmd(resume_session_id="abc-123", prompt="Emit token")
         assert ClaudeFlags.PLUGIN_DIR not in result.cmd
 
-    def test_with_plugin_dir(self) -> None:
+    def test_with_plugin_source_direct_install(self) -> None:
         result = build_headless_resume_cmd(
-            resume_session_id="abc-123", prompt="Emit token", plugin_dir=Path("/tmp/plugin")
+            resume_session_id="abc-123",
+            prompt="Emit token",
+            plugin_source=DirectInstall(plugin_dir=Path("/tmp/plugin")),
         )
         assert ClaudeFlags.PLUGIN_DIR in result.cmd
         idx = result.cmd.index(ClaudeFlags.PLUGIN_DIR)
@@ -232,7 +246,7 @@ class TestBuildLeafHeadlessCmd:
         cwd="/repo",
         completion_marker="DONE",
         model=None,
-        plugin_dir="/plugins",
+        plugin_source=DirectInstall(plugin_dir=Path("/plugins")),
         output_format_value="stream-json",
         output_format_required_flags=["--verbose"],
         add_dirs=[],
@@ -293,11 +307,16 @@ class TestBuildLeafHeadlessCmd:
         spec = build_leaf_headless_cmd("/investigate foo", **self.BASE)
         assert spec.env["CLAUDE_CODE_AUTO_CONNECT_IDE"] == "0"
 
-    def test_plugin_dir_present(self):
+    def test_plugin_source_direct_install_present(self):
         spec = build_leaf_headless_cmd("/investigate foo", **self.BASE)
         assert "--plugin-dir" in spec.cmd
         idx = spec.cmd.index("--plugin-dir")
         assert spec.cmd[idx + 1] == "/plugins"
+
+    def test_marketplace_install_omits_plugin_dir(self, tmp_path: Path):
+        params = {**self.BASE, "plugin_source": MarketplaceInstall(cache_path=tmp_path)}
+        spec = build_leaf_headless_cmd("/investigate foo", **params)
+        assert "--plugin-dir" not in spec.cmd
 
     def test_output_format_present(self):
         spec = build_leaf_headless_cmd("/investigate foo", **self.BASE)
@@ -434,7 +453,7 @@ class TestBuildLeafHeadlessCmd:
 class TestBuildFoodTruckCmd:
     BASE = dict(
         orchestrator_prompt="You are an L2 food truck orchestrator...",
-        plugin_dir="/plugins",
+        plugin_source=DirectInstall(plugin_dir=Path("/plugins")),
         cwd="/repo",
         completion_marker="%%L2_DONE::abc12345%%",
         model=None,
@@ -485,6 +504,24 @@ class TestBuildFoodTruckCmd:
         assert ClaudeFlags.PLUGIN_DIR in spec.cmd
         idx = spec.cmd.index(ClaudeFlags.PLUGIN_DIR)
         assert spec.cmd[idx + 1] == "/plugins"
+
+    def test_build_food_truck_cmd_marketplace_uses_cache_path(self, tmp_path: Path):
+        """build_food_truck_cmd with MarketplaceInstall uses cache_path for --plugin-dir."""
+        cache = tmp_path / "marketplace_cache"
+        cache.mkdir()
+        cmd = build_food_truck_cmd(
+            **{**self.BASE, "plugin_source": MarketplaceInstall(cache_path=cache)}
+        )
+        idx = cmd.cmd.index("--plugin-dir")
+        assert cmd.cmd[idx + 1] == str(cache)
+
+    def test_build_food_truck_cmd_direct_uses_plugin_dir(self, tmp_path: Path):
+        """build_food_truck_cmd with DirectInstall uses plugin_dir for --plugin-dir."""
+        cmd = build_food_truck_cmd(
+            **{**self.BASE, "plugin_source": DirectInstall(plugin_dir=tmp_path)}
+        )
+        idx = cmd.cmd.index("--plugin-dir")
+        assert cmd.cmd[idx + 1] == str(tmp_path)
 
     def test_output_format_present(self):
         spec = build_food_truck_cmd(**self.BASE)
@@ -553,7 +590,7 @@ class TestBuildFoodTruckCmdPackTags:
         """env_extras containing AUTOSKILLIT_L2_TOOL_TAGS reaches subprocess env."""
         spec = build_food_truck_cmd(
             orchestrator_prompt="...",
-            plugin_dir="/plugins",
+            plugin_source=DirectInstall(plugin_dir=Path("/plugins")),
             cwd="/repo",
             completion_marker="%%DONE%%",
             env_extras={"AUTOSKILLIT_L2_TOOL_TAGS": "github,ci,clone,telemetry"},
@@ -580,13 +617,13 @@ def test_headless_exclusive_vars_contains_max_mcp_output_tokens() -> None:
             cwd="/tmp",
             completion_marker="%%DONE%%",
             model=None,
-            plugin_dir=None,
+            plugin_source=None,
             output_format_value="stream-json",
         ),
         lambda: build_headless_resume_cmd(resume_session_id="abc", prompt="Emit"),
         lambda: build_food_truck_cmd(
             orchestrator_prompt="You are an L2 orchestrator",
-            plugin_dir="/plugins",
+            plugin_source=DirectInstall(plugin_dir=Path("/plugins")),
             cwd="/tmp",
             completion_marker="%%DONE%%",
         ),
@@ -621,13 +658,13 @@ def test_interactive_cmd_env_has_mcp_connection_nonblocking() -> None:
             cwd="/tmp",
             completion_marker="%%DONE%%",
             model=None,
-            plugin_dir=None,
+            plugin_source=None,
             output_format_value="stream-json",
         ),
         lambda: build_headless_resume_cmd(resume_session_id="abc", prompt="Emit"),
         lambda: build_food_truck_cmd(
             orchestrator_prompt="You are an L2 orchestrator",
-            plugin_dir="/plugins",
+            plugin_source=DirectInstall(plugin_dir=Path("/plugins")),
             cwd="/tmp",
             completion_marker="%%DONE%%",
         ),

--- a/tests/execution/test_headless.py
+++ b/tests/execution/test_headless.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
+from autoskillit.core._type_plugin_source import DirectInstall, MarketplaceInstall
 from autoskillit.core.types import (
     CONTEXT_EXHAUSTION_MARKER,
     ChannelConfirmation,
@@ -4274,7 +4275,7 @@ class TestDispatchFoodTruck:
             )
         )
         minimal_ctx.runner = runner
-        minimal_ctx.plugin_dir = str(tmp_path)
+        minimal_ctx.plugin_source = DirectInstall(plugin_dir=tmp_path)
 
         executor = DefaultHeadlessExecutor(minimal_ctx)
         await executor.dispatch_food_truck(
@@ -4309,7 +4310,7 @@ class TestDispatchFoodTruck:
             )
         )
         minimal_ctx.runner = runner
-        minimal_ctx.plugin_dir = str(tmp_path)
+        minimal_ctx.plugin_source = DirectInstall(plugin_dir=tmp_path)
 
         executor = DefaultHeadlessExecutor(minimal_ctx)
         result = await executor.dispatch_food_truck(
@@ -4338,7 +4339,7 @@ class TestDispatchFoodTruck:
             )
         )
         minimal_ctx.runner = runner
-        minimal_ctx.plugin_dir = str(tmp_path)
+        minimal_ctx.plugin_source = DirectInstall(plugin_dir=tmp_path)
 
         spawned_pids: list[int] = []
 
@@ -4369,7 +4370,7 @@ class TestDispatchFoodTruck:
             )
         )
         minimal_ctx.runner = runner
-        minimal_ctx.plugin_dir = str(tmp_path)
+        minimal_ctx.plugin_source = DirectInstall(plugin_dir=tmp_path)
 
         executor = DefaultHeadlessExecutor(minimal_ctx)
         result = await executor.dispatch_food_truck(
@@ -4381,6 +4382,40 @@ class TestDispatchFoodTruck:
 
         assert isinstance(result, SkillResult)
         assert result.success is True
+
+    @pytest.mark.anyio
+    async def test_dispatch_food_truck_marketplace_install_does_not_raise(
+        self, minimal_ctx, tmp_path: Path
+    ):
+        """dispatch_food_truck with MarketplaceInstall resolves cache_path — no ValueError."""
+        from autoskillit.core.types import SubprocessResult, TerminationReason
+        from autoskillit.execution.headless import DefaultHeadlessExecutor
+        from tests.fakes import MockSubprocessRunner
+
+        cache = tmp_path / "marketplace_cache"
+        cache.mkdir()
+        runner = MockSubprocessRunner()
+        runner.set_default(
+            SubprocessResult(
+                returncode=0,
+                stdout=self._make_success_stdout(),
+                stderr="",
+                termination=TerminationReason.NATURAL_EXIT,
+                pid=55555,
+            )
+        )
+        minimal_ctx.runner = runner
+        minimal_ctx.plugin_source = MarketplaceInstall(cache_path=cache)
+
+        executor = DefaultHeadlessExecutor(minimal_ctx)
+        await executor.dispatch_food_truck(
+            "You are an L2 orchestrator",
+            str(tmp_path),
+            completion_marker="%%FT_DONE%%",
+        )
+        cmd, _cwd, _timeout, _kwargs = runner.call_args_list[0]
+        assert "--plugin-dir" in cmd
+        assert str(cache) in cmd
 
 
 class TestDispatchFoodTruckPackInjection:
@@ -4417,7 +4452,7 @@ class TestDispatchFoodTruckPackInjection:
             )
         )
         minimal_ctx.runner = runner
-        minimal_ctx.plugin_dir = str(tmp_path)
+        minimal_ctx.plugin_source = DirectInstall(plugin_dir=tmp_path)
 
         executor = DefaultHeadlessExecutor(minimal_ctx)
         await executor.dispatch_food_truck(
@@ -4451,7 +4486,7 @@ class TestDispatchFoodTruckPackInjection:
             )
         )
         minimal_ctx.runner = runner
-        minimal_ctx.plugin_dir = str(tmp_path)
+        minimal_ctx.plugin_source = DirectInstall(plugin_dir=tmp_path)
 
         executor = DefaultHeadlessExecutor(minimal_ctx)
         await executor.dispatch_food_truck(

--- a/tests/execution/test_idle_output_env.py
+++ b/tests/execution/test_idle_output_env.py
@@ -171,7 +171,9 @@ class TestDispatchFoodTruckIdleEnvInjection:
             _fake_execute,
         )
 
-        minimal_ctx.plugin_dir = str(tmp_path / "plugin")
+        from autoskillit.core._type_plugin_source import DirectInstall
+
+        minimal_ctx.plugin_source = DirectInstall(plugin_dir=tmp_path / "plugin")
         executor = DefaultHeadlessExecutor(minimal_ctx)
         await executor.dispatch_food_truck(
             orchestrator_prompt="test",

--- a/tests/execution/test_recording.py
+++ b/tests/execution/test_recording.py
@@ -9,7 +9,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from autoskillit.core.types import SubprocessRunner, TerminationReason
+from autoskillit.core.types import DirectInstall, SubprocessRunner, TerminationReason
 from autoskillit.execution.commands import build_leaf_headless_cmd
 from autoskillit.execution.recording import (
     RecordingSubprocessRunner,
@@ -175,7 +175,7 @@ _BASE_CMD_ARGS = dict(
     cwd="/tmp",
     completion_marker="DONE",
     model=None,
-    plugin_dir="/plugins",
+    plugin_source=DirectInstall(plugin_dir=Path("/plugins")),
     output_format_value="stream-json",
 )
 

--- a/tests/pipeline/test_context.py
+++ b/tests/pipeline/test_context.py
@@ -9,6 +9,7 @@ import pytest
 
 from autoskillit.config import AutomationConfig
 from autoskillit.core import GitHubFetcher
+from autoskillit.core._type_plugin_source import DirectInstall
 from autoskillit.pipeline.audit import DefaultAuditLog, FailureRecord
 from autoskillit.pipeline.context import ToolContext
 from autoskillit.pipeline.gate import DefaultGateState
@@ -26,11 +27,12 @@ def test_tool_context_fields_accessible(tmp_path):
         token_log=DefaultTokenLog(),
         timing_log=DefaultTimingLog(),
         gate=DefaultGateState(enabled=True),
-        plugin_dir=str(tmp_path),
+        plugin_source=DirectInstall(plugin_dir=tmp_path),
         runner=None,
     )
     assert ctx.gate.enabled is True
-    assert ctx.plugin_dir == str(tmp_path)
+    assert isinstance(ctx.plugin_source, DirectInstall)
+    assert ctx.plugin_source.plugin_dir == tmp_path
 
 
 def test_tool_context_audit_isolation():
@@ -41,7 +43,7 @@ def test_tool_context_audit_isolation():
         token_log=DefaultTokenLog(),
         timing_log=DefaultTimingLog(),
         gate=DefaultGateState(),
-        plugin_dir="/a",
+        plugin_source=DirectInstall(plugin_dir=Path("/a")),
         runner=None,
     )
     ctx_b = ToolContext(
@@ -50,7 +52,7 @@ def test_tool_context_audit_isolation():
         token_log=DefaultTokenLog(),
         timing_log=DefaultTimingLog(),
         gate=DefaultGateState(),
-        plugin_dir="/b",
+        plugin_source=DirectInstall(plugin_dir=Path("/b")),
         runner=None,
     )
     ctx_a.audit.record_failure(
@@ -76,7 +78,7 @@ def test_gate_state_replacement():
         token_log=DefaultTokenLog(),
         timing_log=DefaultTimingLog(),
         gate=DefaultGateState(enabled=False),
-        plugin_dir="/x",
+        plugin_source=DirectInstall(plugin_dir=Path("/x")),
         runner=None,
     )
     assert ctx.gate.enabled is False
@@ -92,7 +94,7 @@ def test_toolcontext_new_optional_fields_default_none(tmp_path):
         token_log=DefaultTokenLog(),
         timing_log=DefaultTimingLog(),
         gate=DefaultGateState(enabled=True),
-        plugin_dir=str(tmp_path),
+        plugin_source=DirectInstall(plugin_dir=tmp_path),
         runner=None,
     )
     assert ctx.executor is None
@@ -184,14 +186,13 @@ def test_recipe_repository_protocol_has_rich_methods() -> None:
 
 def _make_ctx(tmp_path: Path) -> ToolContext:
     """Helper: minimal ToolContext with no optional fields."""
-    plugin_dir = str(tmp_path)
     return ToolContext(
         config=AutomationConfig(),
         audit=DefaultAuditLog(),
         token_log=DefaultTokenLog(),
         timing_log=DefaultTimingLog(),
         gate=DefaultGateState(enabled=True),
-        plugin_dir=plugin_dir,
+        plugin_source=DirectInstall(plugin_dir=tmp_path),
         runner=None,
     )
 
@@ -242,7 +243,7 @@ async def test_toolcontext_default_background_wired_with_audit(tmp_path):
         token_log=DefaultTokenLog(),
         timing_log=DefaultTimingLog(),
         gate=DefaultGateState(),
-        plugin_dir=str(tmp_path),
+        plugin_source=DirectInstall(plugin_dir=tmp_path),
         runner=None,
     )
     assert isinstance(ctx.background, DefaultBackgroundSupervisor)

--- a/tests/server/test_factory.py
+++ b/tests/server/test_factory.py
@@ -460,23 +460,37 @@ def test_gh_cli_token_not_called_during_make_context(monkeypatch):
     assert gh_calls == [], f"_gh_cli_token() called during make_context: {gh_calls}"
 
 
-def test_make_context_sets_plugin_dir_none_when_plugin_installed(
-    monkeypatch: pytest.MonkeyPatch,
+def test_make_context_marketplace_install_yields_marketplace_plugin_source(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """make_context() sets plugin_dir=None when marketplace plugin is installed."""
+    """make_context() with a marketplace-detected install produces MarketplaceInstall."""
+    from autoskillit.core._type_plugin_source import MarketplaceInstall
+
+    fake_cache = tmp_path / "cache" / "autoskillit-local" / "autoskillit" / "1.0.0"
+    fake_cache.mkdir(parents=True)
+
     monkeypatch.setattr("autoskillit.server._factory._check_plugin_installed", lambda: True)
+    monkeypatch.setattr(
+        "autoskillit.server._factory._resolve_marketplace_cache_path",
+        lambda: fake_cache,
+    )
+
     ctx = make_context(AutomationConfig(), runner=None)
-    assert ctx.plugin_dir is None
+    assert isinstance(ctx.plugin_source, MarketplaceInstall)
+    assert ctx.plugin_source.cache_path == fake_cache
 
 
-def test_make_context_sets_plugin_dir_when_plugin_not_installed(
-    monkeypatch: pytest.MonkeyPatch,
+def test_make_context_direct_install_yields_direct_plugin_source(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """make_context() sets plugin_dir to package root when plugin is not installed."""
+    """make_context() with a direct install produces DirectInstall with pkg_root."""
+    from autoskillit.core._type_plugin_source import DirectInstall
+
     monkeypatch.setattr("autoskillit.server._factory._check_plugin_installed", lambda: False)
-    ctx = make_context(AutomationConfig(), runner=None)
-    assert ctx.plugin_dir is not None
-    assert ctx.plugin_dir != ""
+
+    ctx = make_context(AutomationConfig(), runner=None, plugin_dir=str(tmp_path))
+    assert isinstance(ctx.plugin_source, DirectInstall)
+    assert ctx.plugin_source.plugin_dir == tmp_path
 
 
 def test_make_context_sets_token_factory(tmp_path):

--- a/tests/server/test_server_init.py
+++ b/tests/server/test_server_init.py
@@ -308,7 +308,9 @@ class TestOpenKitchenVersionReporting:
         (plugin_dir / "plugin.json").write_text(
             json.dumps({"name": "autoskillit", "version": "0.0.0"})
         )
-        tool_ctx.plugin_dir = str(tmp_path)
+        from autoskillit.core._type_plugin_source import DirectInstall
+
+        tool_ctx.plugin_source = DirectInstall(plugin_dir=tmp_path)
         with patch.object(tools_kitchen_mod, "_prime_quota_cache", new=AsyncMock()):
             with patch.object(tools_kitchen_mod, "_write_hook_config"):
                 await open_kitchen(ctx=mock_ctx)

--- a/tests/server/test_server_version_telemetry.py
+++ b/tests/server/test_server_version_telemetry.py
@@ -38,24 +38,24 @@ class TestPluginMetadataExists:
 
 
 class TestPluginDirConstant:
-    """T6: tool_ctx.plugin_dir defaults to the package root directory."""
+    """T6: tool_ctx.plugin_source defaults to a DirectInstall for the package root."""
 
-    def test_plugin_dir_assignment_is_visible_via_get_ctx(self, tool_ctx):
-        """By default tool_ctx.plugin_dir is set to tmp_path by the fixture.
+    def test_plugin_source_assignment_is_visible_via_get_plugin_dir(self, tool_ctx):
+        """By default tool_ctx.plugin_source is set to DirectInstall(tmp_path) by the fixture.
 
         The real package dir is what the server uses at runtime (set by cli.py serve()).
-        This test verifies that the fixture wires plugin_dir through _ctx correctly.
+        This test verifies that the fixture wires plugin_source through _ctx correctly.
         """
         import autoskillit
+        from autoskillit.core._type_plugin_source import DirectInstall
+        from autoskillit.server._state import _get_plugin_dir
 
         # The real package dir is what the server sets at startup.
-        # We verify the attribute path works (tool_ctx.plugin_dir is accessible).
-        real_pkg_dir = str(Path(autoskillit.__file__).parent)
+        real_pkg_dir = Path(autoskillit.__file__).parent
         # tool_ctx uses tmp_path; set it to verify end-to-end wiring
-        tool_ctx.plugin_dir = real_pkg_dir
-        from autoskillit.server import _get_ctx
+        tool_ctx.plugin_source = DirectInstall(plugin_dir=real_pkg_dir)
 
-        assert _get_ctx().plugin_dir == real_pkg_dir
+        assert _get_plugin_dir() == str(real_pkg_dir)
 
 
 class TestVersionInfo:
@@ -73,6 +73,7 @@ class TestVersionInfo:
         assert info["match"] is True
 
     def test_version_info_detects_mismatch(self, tmp_path, tool_ctx):
+        from autoskillit.core._type_plugin_source import DirectInstall
         from autoskillit.server import version_info
 
         plugin_dir = tmp_path / ".claude-plugin"
@@ -80,16 +81,17 @@ class TestVersionInfo:
         (plugin_dir / "plugin.json").write_text(
             json.dumps({"name": "autoskillit", "version": "0.0.0"})
         )
-        tool_ctx.plugin_dir = str(tmp_path)
+        tool_ctx.plugin_source = DirectInstall(plugin_dir=tmp_path)
         info = version_info()
         assert info["match"] is False
         assert info["package_version"] != info["plugin_json_version"]
         assert info["plugin_json_version"] == "0.0.0"
 
     def test_version_info_handles_missing_plugin_json(self, tmp_path, tool_ctx):
+        from autoskillit.core._type_plugin_source import DirectInstall
         from autoskillit.server import version_info
 
-        tool_ctx.plugin_dir = str(tmp_path)
+        tool_ctx.plugin_source = DirectInstall(plugin_dir=tmp_path)
         info = version_info()
         assert info["plugin_json_version"] is None
         assert info["match"] is False

--- a/tests/server/test_set_commit_status.py
+++ b/tests/server/test_set_commit_status.py
@@ -181,7 +181,7 @@ async def test_set_commit_status_infers_repo_from_cwd(tool_ctx, monkeypatch):
 
 @pytest.mark.anyio
 async def test_set_commit_status_falls_back_to_plugin_dir_when_no_cwd(tool_ctx, monkeypatch):
-    """When neither repo nor cwd is provided, tool falls back to plugin_dir for inference."""
+    """When neither repo nor cwd is provided, tool falls back to plugin_source for inference."""
     infer_calls: list[str] = []
 
     async def fake_infer(cwd: str, hint: object = None) -> str:
@@ -195,7 +195,7 @@ async def test_set_commit_status_falls_back_to_plugin_dir_when_no_cwd(tool_ctx, 
         sha="abc003",
         state="pending",
         context="autoskillit/ai-review",
-        # neither repo nor cwd — falls back to tool_ctx.plugin_dir
+        # neither repo nor cwd — falls back to tool_ctx.plugin_source
     )
     result = json.loads(raw)
 

--- a/tests/server/test_state.py
+++ b/tests/server/test_state.py
@@ -16,8 +16,10 @@ pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 def _make_mock_ctx(tmp_path: Path) -> MagicMock:
     """Return a minimal mock ToolContext for _initialize tests."""
+    from autoskillit.core._type_plugin_source import MarketplaceInstall
+
     ctx = MagicMock()
-    ctx.plugin_dir = None
+    ctx.plugin_source = MarketplaceInstall(cache_path=tmp_path)
     # Provide a minimal linux_tracing config stub
     tracing_cfg = MagicMock()
     tracing_cfg.tmpfs_path = str(tmp_path / "tmpfs")

--- a/tests/server/test_tools_dispatch.py
+++ b/tests/server/test_tools_dispatch.py
@@ -719,3 +719,35 @@ class TestDispatchFoodTruckExecution:
 
         result = json.loads(result_json)
         assert result["success"] is True
+
+
+@pytest.mark.anyio
+async def test_dispatch_food_truck_marketplace_install_succeeds(tool_ctx_marketplace, monkeypatch):
+    """dispatch_food_truck does not raise when plugin_source is MarketplaceInstall.
+
+    This test was impossible before the fix — it would raise ValueError.
+    """
+    from autoskillit.fleet._api import execute_dispatch
+
+    tool_ctx_marketplace.fleet_lock = asyncio.Lock()
+    repo = InMemoryRecipeRepository()
+    recipe_info = _make_recipe_info("test-recipe")
+    repo.add_recipe("test-recipe", recipe_info)
+    repo.add_full_recipe(recipe_info.path, _make_standard_recipe("test-recipe", ["task"]))
+    tool_ctx_marketplace.recipes = repo
+    tool_ctx_marketplace.executor = InMemoryHeadlessExecutor()
+
+    result = json.loads(
+        await execute_dispatch(
+            tool_ctx=tool_ctx_marketplace,
+            recipe="test-recipe",
+            task="t",
+            ingredients=None,
+            dispatch_name=None,
+            timeout_sec=None,
+            prompt_builder=_simple_prompt_builder,
+            quota_checker=_no_sleep_quota_checker,
+            quota_refresher=_noop_quota_refresher,
+        )
+    )
+    assert result["success"] is True

--- a/tests/server/test_tools_dispatch.py
+++ b/tests/server/test_tools_dispatch.py
@@ -728,6 +728,18 @@ async def test_dispatch_food_truck_marketplace_install_succeeds(tool_ctx_marketp
     This test was impossible before the fix — it would raise ValueError.
     """
     from autoskillit.fleet._api import execute_dispatch
+    from autoskillit.fleet.result_parser import L2ParseResult
+
+    monkeypatch.setattr(
+        "autoskillit.fleet._api.parse_l2_result_block",
+        lambda **_kwargs: L2ParseResult(
+            outcome="completed_clean",
+            payload={"success": True},
+            raw_body=None,
+            parse_error=None,
+            source="stdout",
+        ),
+    )
 
     tool_ctx_marketplace.fleet_lock = asyncio.Lock()
     repo = InMemoryRecipeRepository()

--- a/tests/server/test_tools_execution.py
+++ b/tests/server/test_tools_execution.py
@@ -66,7 +66,10 @@ class TestRunSkillPluginDir:
         cmd = tool_ctx.runner.call_args_list[0][0]
         assert "--plugin-dir" in cmd
         plugin_dir_idx = cmd.index("--plugin-dir")
-        assert cmd[plugin_dir_idx + 1] == tool_ctx.plugin_dir
+        from autoskillit.core._type_plugin_source import DirectInstall
+
+        assert isinstance(tool_ctx.plugin_source, DirectInstall)
+        assert cmd[plugin_dir_idx + 1] == str(tool_ctx.plugin_source.plugin_dir)
         # --output-format and stream-json must be present
         assert "--output-format" in cmd
         assert cmd[cmd.index("--output-format") + 1] == "stream-json"

--- a/tests/server/test_tools_status.py
+++ b/tests/server/test_tools_status.py
@@ -65,8 +65,9 @@ class TestKitchenStatus:
     @pytest.mark.anyio
     async def test_status_returns_version_info(self, tool_ctx):
         import autoskillit
+        from autoskillit.core._type_plugin_source import DirectInstall
 
-        tool_ctx.plugin_dir = str(Path(autoskillit.__file__).parent)
+        tool_ctx.plugin_source = DirectInstall(plugin_dir=Path(autoskillit.__file__).parent)
         from autoskillit import __version__
 
         result = json.loads(await kitchen_status())
@@ -82,7 +83,9 @@ class TestKitchenStatus:
         (plugin_dir / "plugin.json").write_text(
             json.dumps({"name": "autoskillit", "version": "0.0.0"})
         )
-        tool_ctx.plugin_dir = str(tmp_path)
+        from autoskillit.core._type_plugin_source import DirectInstall
+
+        tool_ctx.plugin_source = DirectInstall(plugin_dir=tmp_path)
         result = json.loads(await kitchen_status())
         assert result["versions_match"] is False
         assert "warning" in result


### PR DESCRIPTION
## Summary

`ToolContext.plugin_dir: str | None` encoded install-mode semantics (marketplace vs. direct) in a nullable primitive — `None` meant "marketplace, omit `--plugin-dir`", a string meant "direct install, use this path". This implicit encoding forced every consumer to rediscover and branch on the `None` sentinel independently. When `dispatch_food_truck` was written as an exception — requiring a real path for food truck subprocesses even on marketplace installs — there was no type-level mechanism to express that requirement, so it guarded with a `ValueError` that fires unconditionally for marketplace users.

The architectural solution replaces `plugin_dir: str | None` with a typed discriminated union `PluginSource = DirectInstall | MarketplaceInstall`, following the `ResumeSpec` pattern already established in `core/_type_resume.py`. This makes the install-mode contract explicit, pushes the marketplace path resolution into the `MarketplaceInstall` dataclass at construction time, and allows `build_food_truck_cmd` to handle both variants via `match` — emitting `--plugin-dir` in both cases, using the correct path for each. The architectural change makes the entire class of "unexpected None at dispatch time" bugs impossible: any new consumer either handles both variants or causes a type error.

## Architecture Impact

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph L0 ["LAYER 0 — CORE (Foundation · stdlib-only)"]
        direction LR
        PS["★ _type_plugin_source.py<br/>━━━━━━━━━━<br/>DirectInstall | MarketplaceInstall<br/>PluginSource discriminated union"]
        PI["● _plugin_ids.py<br/>━━━━━━━━━━<br/>DIRECT_PREFIX · MARKETPLACE_PREFIX<br/>detect_autoskillit_mcp_prefix"]
        TY["● types.py<br/>━━━━━━━━━━<br/>Re-export hub<br/>+PluginSource wildcard"]
        SB["● __init__.pyi<br/>━━━━━━━━━━<br/>Public API stub<br/>explicit re-exports"]
    end

    subgraph L1E ["LAYER 1 — EXECUTION"]
        CMD["● execution/commands.py<br/>━━━━━━━━━━<br/>build_food_truck_cmd<br/>PluginSource · DirectInstall · MarketplaceInstall"]
        HEAD["● execution/headless.py<br/>━━━━━━━━━━<br/>HeadlessExecutor orchestration<br/>imports execution/commands"]
    end

    subgraph L1P ["LAYER 1 — PIPELINE"]
        CTX["● pipeline/context.py<br/>━━━━━━━━━━<br/>ToolContext DI container<br/>PluginSource as field type"]
    end

    subgraph L3S ["LAYER 3 — SERVER"]
        FAC["● server/_factory.py<br/>━━━━━━━━━━<br/>make_context · Composition Root<br/>PluginSource · DirectInstall · MarketplaceInstall"]
        STA["● server/_state.py<br/>━━━━━━━━━━<br/>Lazy plugin dir resolution<br/>DirectInstall · MarketplaceInstall"]
        CI["● server/tools_ci.py<br/>━━━━━━━━━━<br/>dispatch_food_truck<br/>DirectInstall · MarketplaceInstall"]
    end

    subgraph L3C ["LAYER 3 — CLI"]
        COOK["● cli/_cook.py<br/>━━━━━━━━━━<br/>cook subcommand<br/>(PluginSource-unrelated change)"]
    end

    %% L0 INTERNAL WIRING %%
    PS -->|"wildcard import"| TY
    PI -->|"wildcard import"| TY
    TY -->|"re-exports all types"| SB

    %% L0 → L1 (valid downward) %%
    SB -->|"PluginSource<br/>via autoskillit.core"| CMD
    SB -->|"PluginSource<br/>via autoskillit.core"| CTX

    %% L0 → L3 (valid downward) %%
    SB -->|"PluginSource · DirectInstall<br/>MarketplaceInstall via autoskillit.core"| FAC
    SB -->|"DirectInstall · MarketplaceInstall<br/>via autoskillit.core"| STA
    SB -->|"DirectInstall · MarketplaceInstall<br/>via autoskillit.core"| CI

    %% L1 INTERNAL %%
    CMD -->|"imports commands"| HEAD

    %% L1 → L3 (valid downward) %%
    CTX -->|"ToolContext"| FAC

    %% CLASS ASSIGNMENTS %%
    class PS newComponent;
    class PI,TY,SB stateNode;
    class CMD,HEAD handler;
    class CTX phase;
    class FAC,STA,CI output;
    class COOK cli;
```

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 65, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START([START: Plugin Load])

    subgraph VariantDef ["★ PLUGINSOURCE UNION — _type_plugin_source.py"]
        direction LR
        DI["★ DirectInstall<br/>━━━━━━━━━━<br/>plugin_dir: Path<br/>frozen=True / INIT_ONLY<br/>Dev / editable installs"]
        MI["★ MarketplaceInstall<br/>━━━━━━━━━━<br/>cache_path: Path<br/>frozen=True / INIT_ONLY<br/>Claude marketplace installs"]
    end

    subgraph DetectionGates ["VARIANT SELECTION GATES"]
        direction TB
        G1["● detect_autoskillit_mcp_prefix()<br/>━━━━━━━━━━<br/>_plugin_ids.py<br/>Reads installed_plugins.json<br/>MARKETPLACE_PREFIX → installed"]
        G2["● _check_plugin_installed()<br/>━━━━━━━━━━<br/>_factory.py<br/>prefix == MARKETPLACE_PREFIX<br/>Boolean gate — selects variant"]
        G3["● InstalledPluginsFile.contains()<br/>━━━━━━━━━━<br/>_cook.py<br/>Direct marketplace key check<br/>Cook-path construction gate"]
    end

    subgraph Construction ["● CONSTRUCTION SITES — 4-Level Priority (make_context)"]
        direction TB
        P1["Priority 1: Explicit override<br/>━━━━━━━━━━<br/>plugin_source= kwarg<br/>Sentinel: _UNSET distinguishes<br/>'not provided' from None"]
        P2["Priority 2: plugin_dir kwarg<br/>━━━━━━━━━━<br/>str|Path → DirectInstall(plugin_dir)<br/>Test injection path"]
        P3["Priority 3: Marketplace detected<br/>━━━━━━━━━━<br/>MarketplaceInstall(cache_path=<br/>_resolve_marketplace_cache_path())"]
        P4["Priority 4: Fallback<br/>━━━━━━━━━━<br/>DirectInstall(plugin_dir=pkg_root())<br/>Always available"]
        P1 --> P2 --> P3 --> P4
    end

    subgraph Storage ["INIT_PRESERVE — ToolContext Storage"]
        direction TB
        CTX["● ToolContext.plugin_source<br/>━━━━━━━━━━<br/>Required field / no default<br/>Stored opaquely as PluginSource<br/>Never mutated after __init__"]
        CTX_SINGLETON["● _ctx singleton (_state.py)<br/>━━━━━━━━━━<br/>Set ONCE by _initialize(ctx)<br/>_get_ctx() raises RuntimeError<br/>if None (hard init guard)"]
    end

    subgraph KitchenMutable ["MUTABLE — Kitchen Lifecycle Fields"]
        direction TB
        KM1["recipe_name / recipe_version<br/>━━━━━━━━━━<br/>Written: open_kitchen<br/>Cleared: close_kitchen"]
        KM2["kitchen_id / active_recipe_packs<br/>━━━━━━━━━━<br/>Written: open_kitchen<br/>Cleared: close_kitchen"]
        KM3["executor / migrations<br/>━━━━━━━━━━<br/>Post-construction mutation<br/>Circular dependency workaround<br/>Set in make_context() after ctx built"]
    end

    subgraph AppendOnly ["APPEND_ONLY — Log Accumulation"]
        direction TB
        AL1["timing_log entries<br/>━━━━━━━━━━<br/>record(step_name, elapsed)<br/>in finally blocks"]
        AL2["audit / failure_records<br/>━━━━━━━━━━<br/>FailureRecord appended<br/>Never removed"]
    end

    subgraph ValidationGates ["VALIDATION GATES — Tool Layer"]
        direction TB
        VG1["_require_enabled()<br/>━━━━━━━━━━<br/>Gate-level: kitchen open?<br/>All gated tools check FIRST"]
        VG2["_get_ctx() / _get_ctx_or_none()<br/>━━━━━━━━━━<br/>Init guard: ctx not None<br/>Hard fail vs soft None"]
        VG3["Null-watcher guards<br/>━━━━━━━━━━<br/>ci_watcher is None → error JSON<br/>Per-tool optional dependency check"]
    end

    subgraph PatternMatch ["● PATTERN MATCH CONSUMPTION"]
        direction TB
        PM1["● commands.py builders<br/>━━━━━━━━━━<br/>build_leaf_headless_cmd: DirectInstall→--plugin-dir, Marketplace→omit<br/>build_food_truck_cmd: BOTH variants→--plugin-dir (fresh subprocess)"]
        PM2["● _state.py _get_plugin_dir()<br/>━━━━━━━━━━<br/>match plugin_source:<br/>DirectInstall→str(plugin_dir)<br/>MarketplaceInstall→str(cache_path)"]
        PM3["● tools_ci.py set_commit_status<br/>━━━━━━━━━━<br/>cwd fallback: both variants<br/>→ stringify their path field"]
    end

    subgraph ResumeDetection ["RESUME DETECTION"]
        direction TB
        RD1["● ResumeSpec discriminated union<br/>━━━━━━━━━━<br/>NoResume | BareResume | NamedResume<br/>Constructed once from CLI args<br/>INIT_ONLY (frozen=True)"]
        RD2["● _check_rerun() in _state.py<br/>━━━━━━━━━━<br/>Reads recipe_composite_hash<br/>Checks sessions.jsonl for prior runs<br/>NOT based on plugin_source"]
        RD3["● _cook.py reload loop<br/>━━━━━━━━━━<br/>plugin_source NOT re-detected on reload<br/>Same frozen object reused<br/>resume_spec updated to NamedResume"]
        RD4["! Nudge Gap (_attempt_contract_nudge)<br/>━━━━━━━━━━<br/>build_headless_resume_cmd called<br/>WITHOUT plugin_source forwarded<br/>Contract recovery runs plugin-dir-less"]
    end

    START --> VariantDef

    G1 --> G2
    G1 --> G3
    G2 --> P3
    G3 --> MI

    VariantDef --> DetectionGates
    DetectionGates --> Construction
    Construction --> Storage
    P3 --> MI
    P4 --> DI

    Storage --> KitchenMutable
    Storage --> AppendOnly
    Storage --> ValidationGates

    ValidationGates --> PatternMatch
    Storage --> ResumeDetection

    PM1 --> LEAF["Leaf Sessions<br/>no --plugin-dir<br/>(marketplace)"]
    PM1 --> TRUCK["Food Truck Sessions<br/>always --plugin-dir<br/>(both variants)"]

    RD4 --> GAP_OUT["! Gap: Nudge resume<br/>inherits prior session<br/>state implicitly"]

    %% CLASS ASSIGNMENTS %%
    class DI,MI newComponent;
    class G1,G2,G3 detector;
    class P1,P2,P3,P4 phase;
    class CTX,CTX_SINGLETON stateNode;
    class KM1,KM2,KM3 handler;
    class AL1,AL2 handler;
    class VG1,VG2,VG3 detector;
    class PM1,PM2,PM3 output;
    class RD1,RD2,RD3 cli;
    class RD4 gap;
    class LEAF,TRUCK output;
    class GAP_OUT gap;
    class START terminal;
```

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START: autoskillit cook])
    COMPLETE([COMPLETE: Session exits cleanly])
    ERROR([ERROR: Exit / Abort])

    subgraph Phase1 ["● Cook Startup (_cook.py)"]
        direction TB
        PathCheck{"claude on PATH?"}
        UserConfirm{"User confirms<br/>launch? (120s timeout)"}
        FirstRun{"is_first_run<br/>(project_dir)?"}
        Onboarding["Onboarding Menu<br/>━━━━━━━━━━<br/>Run guided menu<br/>Capture initial_prompt"]
        SessionReg["Register Session<br/>━━━━━━━━━━<br/>SESSION_TYPE_COOK<br/>session_id_local (16-char)"]
        WorkspaceSetup["Workspace Setup<br/>━━━━━━━━━━<br/>Ephemeral root +<br/>DefaultSessionSkillManager<br/>Stale session cleanup"]
    end

    subgraph Phase2 ["★ PluginSource Resolution (_type_plugin_source.py + _plugin_ids.py)"]
        direction TB
        PluginCheck{"InstalledPluginsFile<br/>contains autoskillit<br/>plugin key?"}
        MarketplaceNode["★ MarketplaceInstall<br/>━━━━━━━━━━<br/>cache_path = installPath<br/>from installed_plugins.json<br/>(dict or list[0] format)"]
        DirectNode["★ DirectInstall<br/>━━━━━━━━━━<br/>plugin_dir = pkg_root()<br/>Source / editable install"]
    end

    subgraph Phase3 ["● Context Construction (_factory.py make_context)"]
        direction TB
        RunnerResolution["● Runner Resolution<br/>━━━━━━━━━━<br/>REPLAY_SCENARIO → ReplayRunner<br/>RECORD_SCENARIO → RecordingRunner<br/>else → DefaultSubprocessRunner"]
        ExplicitOverride{"Explicit plugin_source<br/>or plugin_dir arg<br/>passed to make_context?"}
        MarketplaceAutoDetect{"_check_plugin_installed()<br/>━━━━━━━━━━<br/>reads installed_plugins.json<br/>DIRECT_PREFIX vs<br/>MARKETPLACE_PREFIX"}
        CtxBuild["● Build ToolContext<br/>━━━━━━━━━━<br/>22 services wired<br/>executor → migrations<br/>(circular dep break)<br/>fleet_lock injected"]
    end

    subgraph Phase4 ["● Command Building (commands.py)"]
        direction TB
        SessionTypeCheck{"Session type?"}
        InteractiveLeaf["● Interactive / Leaf / Resume<br/>━━━━━━━━━━<br/>DirectInstall → --plugin-dir plugin_dir<br/>MarketplaceInstall → omit flag<br/>(parent session inherits plugin)"]
        FoodTruckCmd["● Food Truck (L2 Orchestrator)<br/>━━━━━━━━━━<br/>DirectInstall → --plugin-dir plugin_dir<br/>MarketplaceInstall → --plugin-dir cache_path<br/>(fresh subprocess; always explicit)<br/>+ --tools AskUserQuestion"]
    end

    subgraph Phase5 ["● Fleet Dispatch Guard (fleet_dispatch_guard.py)"]
        direction TB
        HeadlessCheck{"AUTOSKILLIT_HEADLESS<br/>== '1'?"}
        ToolNameCheck{"stripped tool name<br/>== dispatch_food_truck?"}
        GuardDeny["● Guard: DENY<br/>━━━━━━━━━━<br/>permissionDecision: deny<br/>L3→L3 recursion blocked<br/>Headless callers cannot<br/>spawn food trucks"]
        GuardPermit["Guard: PERMIT<br/>━━━━━━━━━━<br/>exit(0), no deny payload<br/>Tool call proceeds"]
    end

    subgraph Phase6 ["● Headless Execution (headless.py)"]
        direction TB
        PreCreateLogDir["● Pre-create session_log_dir<br/>━━━━━━━━━━<br/>_session_log_dir(cwd)<br/>Prevents false EMPTY_OUTPUT<br/>on fresh clone paths"]
        SubprocLaunch["Launch Claude Subprocess<br/>━━━━━━━━━━<br/>SubprocessRunner.run()<br/>JSONL output stream<br/>AUTOSKILLIT_HEADLESS=1"]
        ParseResult["● parse_session_result()<br/>━━━━━━━━━━<br/>Reads JSONL stdout<br/>→ ClaudeSessionResult<br/>→ SkillResult"]
        MarkerRecovery{"Subtype is<br/>UNPARSEABLE or<br/>EMPTY_OUTPUT?"}
        ChannelBRecover["Channel B Recovery<br/>━━━━━━━━━━<br/>_recover_from_separate_marker()<br/>Drain-race: marker emitted<br/>as standalone final message"]
    end

    %% FLOW %%
    START --> PathCheck
    PathCheck -->|"not found"| ERROR
    PathCheck -->|"found"| UserConfirm
    UserConfirm -->|"n / no"| ERROR
    UserConfirm -->|"enter / default"| FirstRun
    FirstRun -->|"yes"| Onboarding
    FirstRun -->|"no"| SessionReg
    Onboarding --> SessionReg
    SessionReg --> WorkspaceSetup
    WorkspaceSetup --> PluginCheck

    PluginCheck -->|"yes"| MarketplaceNode
    PluginCheck -->|"no / OSError / JSONDecodeError"| DirectNode
    MarketplaceNode --> RunnerResolution
    DirectNode --> RunnerResolution

    RunnerResolution --> ExplicitOverride
    ExplicitOverride -->|"yes: use directly"| CtxBuild
    ExplicitOverride -->|"no"| MarketplaceAutoDetect
    MarketplaceAutoDetect -->|"marketplace prefix"| CtxBuild
    MarketplaceAutoDetect -->|"direct prefix / error fallback"| CtxBuild

    CtxBuild --> SessionTypeCheck
    SessionTypeCheck -->|"interactive / leaf / resume"| InteractiveLeaf
    SessionTypeCheck -->|"food_truck (L2 orchestrator)"| FoodTruckCmd

    InteractiveLeaf --> HeadlessCheck
    FoodTruckCmd --> HeadlessCheck

    HeadlessCheck -->|"no: interactive caller"| GuardPermit
    HeadlessCheck -->|"yes: headless session"| ToolNameCheck
    ToolNameCheck -->|"other tool"| GuardPermit
    ToolNameCheck -->|"dispatch_food_truck"| GuardDeny

    GuardPermit --> PreCreateLogDir
    GuardDeny --> ERROR

    PreCreateLogDir --> SubprocLaunch
    SubprocLaunch --> ParseResult
    ParseResult --> MarkerRecovery
    MarkerRecovery -->|"yes"| ChannelBRecover
    MarkerRecovery -->|"no: normal result"| COMPLETE
    ChannelBRecover --> COMPLETE

    %% CLASS ASSIGNMENTS %%
    class START,COMPLETE,ERROR terminal;
    class PathCheck,UserConfirm,FirstRun,SessionTypeCheck,HeadlessCheck,ToolNameCheck,MarkerRecovery,ExplicitOverride,PluginCheck,MarketplaceAutoDetect stateNode;
    class Onboarding,SessionReg,WorkspaceSetup,RunnerResolution,CtxBuild,InteractiveLeaf,FoodTruckCmd,PreCreateLogDir,SubprocLaunch,ParseResult handler;
    class MarketplaceNode,DirectNode newComponent;
    class GuardDeny detector;
    class GuardPermit,ChannelBRecover phase;
```

Closes #1339

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260426-205010-398241/.autoskillit/temp/rectify/rectify_plugin_source_discriminated_union_2026-04-26_205410.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| rectify | 5.3k | 12.8k | 269.5k | 64.8k | 1 | 5m 51s |
| review | 1.5k | 4.9k | 165.6k | 29.6k | 1 | 3m 11s |
| dry_walkthrough | 3.3k | 21.3k | 609.0k | 53.1k | 1 | 11m 4s |
| implement | 1.1k | 65.1k | 14.5M | 165.3k | 1 | 26m 46s |
| retry_worktree | 708 | 38.5k | 8.0M | 254.9k | 1 | 21m 12s |
| prepare_pr | 60 | 6.8k | 201.8k | 32.5k | 1 | 1m 58s |
| run_arch_lenses | 9.3k | 24.4k | 567.6k | 144.8k | 3 | 9m 52s |
| compose_pr | 67 | 8.3k | 257.3k | 36.4k | 1 | 2m 34s |
| **Total** | 21.3k | 182.1k | 24.5M | 781.3k | | 1h 22m |