### PR TITLE
Recipe Gap — No Active CI Trigger Fallback When GitHub Webhook Delivery Fails

### DIFF
--- a/src/autoskillit/core/_type_constants.py
+++ b/src/autoskillit/core/_type_constants.py
@@ -255,6 +255,7 @@ MUTATING_TOOLS: frozenset[str] = frozenset(
     {
         "toggle_auto_merge",
         "enqueue_pr",
+        "wait_for_ci",
         "wait_for_merge_queue",
         "register_clone_status",
         "batch_cleanup_clones",

--- a/src/autoskillit/recipe/rules_tools.py
+++ b/src/autoskillit/recipe/rules_tools.py
@@ -77,6 +77,7 @@ _TOOL_PARAMS: dict[str, frozenset[str]] = {
     # --- CI tools ---
     "wait_for_ci": frozenset(
         {
+            "auto_trigger",
             "branch",
             "repo",
             "remote_url",

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -677,6 +677,7 @@ steps:
       timeout_seconds: 300
       cwd: "${{ context.work_dir }}"
       remote_url: "${{ context.remote_url }}"
+      auto_trigger: "true"
     capture:
       ci_conclusion: "${{ result.conclusion }}"
       ci_failed_jobs: "${{ result.failed_jobs }}"
@@ -695,7 +696,8 @@ steps:
       (conclusion + failed job names) for downstream resolve_ci.
       Skipped when open_pr=false — no remote feature branch is opened in that mode.
       Routes on result.conclusion: success → check_repo_merge_state,
-      no_runs → handle_no_ci_runs (re-derive event + retry), failure → detect_ci_conflict.
+      no_runs → handle_no_ci_runs (auto_trigger fires first: empty commit + force-push +
+      re-poll; handle_no_ci_runs reached only when push fails), failure → detect_ci_conflict.
 
   handle_no_ci_runs:
     tool: check_repo_merge_state

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -659,6 +659,7 @@ steps:
       timeout_seconds: 300
       cwd: "${{ context.work_dir }}"
       remote_url: "${{ context.remote_url }}"
+      auto_trigger: "true"
     capture:
       ci_conclusion: "${{ result.conclusion }}"
       ci_failed_jobs: "${{ result.failed_jobs }}"
@@ -677,7 +678,8 @@ steps:
       (conclusion + failed job names) for downstream resolve_ci.
       Skipped when open_pr=false — no remote feature branch is opened in that mode.
       Routes on result.conclusion: success → check_repo_merge_state,
-      no_runs → handle_no_ci_runs (re-derive event + retry), failure → detect_ci_conflict.
+      no_runs → handle_no_ci_runs (auto_trigger fires first: empty commit + force-push +
+      re-poll; handle_no_ci_runs reached only when push fails), failure → detect_ci_conflict.
 
   handle_no_ci_runs:
     tool: check_repo_merge_state

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -657,6 +657,7 @@ steps:
       timeout_seconds: 300
       cwd: "${{ context.work_dir }}"
       remote_url: "${{ context.remote_url }}"
+      auto_trigger: "true"
     capture:
       ci_conclusion: "${{ result.conclusion }}"
       ci_failed_jobs: "${{ result.failed_jobs }}"
@@ -675,7 +676,8 @@ steps:
       (conclusion + failed job names) for downstream resolve_ci.
       Skipped when open_pr=false — no remote feature branch is opened in that mode.
       Routes on result.conclusion: success → check_repo_merge_state,
-      no_runs → handle_no_ci_runs (re-derive event + retry), failure → detect_ci_conflict.
+      no_runs → handle_no_ci_runs (auto_trigger fires first: empty commit + force-push +
+      re-poll; handle_no_ci_runs reached only when push fails), failure → detect_ci_conflict.
 
   handle_no_ci_runs:
     tool: check_repo_merge_state

--- a/src/autoskillit/server/tools_ci.py
+++ b/src/autoskillit/server/tools_ci.py
@@ -14,6 +14,7 @@ from fastmcp import Context
 from fastmcp.dependencies import CurrentContext
 
 from autoskillit.core import CIRunScope, get_logger
+from autoskillit.pipeline.context import ToolContext
 from autoskillit.server import mcp
 from autoskillit.server.helpers import (
     _notify,
@@ -698,7 +699,7 @@ async def _auto_trigger_ci(
     result: dict[str, Any],
     scope: CIRunScope,
     resolved_repo: str | None,
-    tool_ctx: Any,
+    tool_ctx: ToolContext,
     timeout_seconds: int,
 ) -> dict[str, Any]:
     """Active CI trigger recovery: empty commit + force-push + re-poll.
@@ -735,7 +736,7 @@ async def _auto_trigger_ci(
 
     # 3. Capture new HEAD SHA for scoped CI polling
     rc_sha, sha_out, _ = await _run_subprocess(["git", "rev-parse", "HEAD"], cwd=cwd, timeout=5.0)
-    new_head_sha = sha_out.strip() if rc_sha == 0 else None
+    new_head_sha = (sha_out.strip() or None) if rc_sha == 0 else None
 
     # 4. Force-push to trigger webhook delivery
     rc_p, _, err_p = await _run_subprocess(
@@ -745,6 +746,7 @@ async def _auto_trigger_ci(
     )
     if rc_p != 0:
         logger.warning("auto_trigger: push failed", stderr=err_p)
+        await _run_subprocess(["git", "reset", "--soft", "HEAD~1"], cwd=cwd, timeout=10.0)
         return result
 
     # 5. Re-poll CI with new SHA and fresh timeout
@@ -753,10 +755,11 @@ async def _auto_trigger_ci(
         head_sha=new_head_sha,
         event=scope.event,
     )
+    assert tool_ctx.ci_watcher is not None
     try:
         triggered_result = await tool_ctx.ci_watcher.wait(
             branch,
-            repo=resolved_repo or None,
+            repo=resolved_repo,
             scope=new_scope,
             timeout_seconds=timeout_seconds,
             cwd=cwd,
@@ -766,4 +769,4 @@ async def _auto_trigger_ci(
         return {**triggered_result, "triggered": True}
     except Exception:
         logger.error("auto_trigger: second CI poll failed", exc_info=True)
-        return result
+        return {**result, "conclusion": "auto_trigger_failed", "triggered": False}

--- a/src/autoskillit/server/tools_ci.py
+++ b/src/autoskillit/server/tools_ci.py
@@ -4,6 +4,7 @@ wait_for_merge_queue (gated).
 
 from __future__ import annotations
 
+import asyncio
 import json
 import time
 from typing import Any, Literal
@@ -14,6 +15,7 @@ from fastmcp import Context
 from fastmcp.dependencies import CurrentContext
 
 from autoskillit.core import CIRunScope, get_logger
+from autoskillit.execution.remote_resolver import resolve_remote_name
 from autoskillit.pipeline import ToolContext
 from autoskillit.server import mcp
 from autoskillit.server.helpers import (
@@ -709,22 +711,22 @@ async def _auto_trigger_ci(
     On any failure (merge conflict, push rejected, etc.) returns original
     no_runs result so the recipe routes to handle_no_ci_runs as fallback.
     """
-    # 1. Check PR mergeability — CONFLICTING means CI won't run even after push
     rc_m, out_m, _ = await _run_subprocess(
         ["gh", "pr", "view", branch, "--json", "mergeable"],
         cwd=cwd,
         timeout=15.0,
     )
-    if rc_m == 0:
-        try:
-            mergeable = json.loads(out_m).get("mergeable", "UNKNOWN")
-        except Exception:
-            logger.warning("auto_trigger: failed to parse gh pr view JSON", exc_info=True)
-            mergeable = "UNKNOWN"
-        if mergeable == "CONFLICTING":
-            return {**result, "conclusion": "merge_conflict", "triggered": False}
+    if rc_m != 0:
+        logger.warning("auto_trigger: gh pr view failed, cannot check mergeability", rc=rc_m)
+        return {**result, "conclusion": "gh_view_failed", "triggered": False}
+    try:
+        mergeable = json.loads(out_m).get("mergeable", "UNKNOWN")
+    except json.JSONDecodeError:
+        logger.warning("auto_trigger: failed to parse gh pr view JSON", exc_info=True)
+        mergeable = "UNKNOWN"
+    if mergeable == "CONFLICTING":
+        return {**result, "conclusion": "merge_conflict", "triggered": False}
 
-    # 2. Create empty commit to force webhook re-delivery
     rc_c, _, err_c = await _run_subprocess(
         ["git", "commit", "--allow-empty", "-m", "ci: trigger"],
         cwd=cwd,
@@ -734,28 +736,31 @@ async def _auto_trigger_ci(
         logger.warning("auto_trigger: empty commit failed", stderr=err_c)
         return result
 
-    # 3. Capture new HEAD SHA for scoped CI polling
     rc_sha, sha_out, _ = await _run_subprocess(["git", "rev-parse", "HEAD"], cwd=cwd, timeout=5.0)
     new_head_sha = (sha_out.strip() or None) if rc_sha == 0 else None
 
-    # 4. Force-push to trigger webhook delivery
+    remote_name = await resolve_remote_name(cwd)
     rc_p, _, err_p = await _run_subprocess(
-        ["git", "push", "--force-with-lease", "upstream", branch],
+        ["git", "push", "--force-with-lease", remote_name, branch],
         cwd=cwd,
         timeout=60.0,
     )
     if rc_p != 0:
         logger.warning("auto_trigger: push failed", stderr=err_p)
-        await _run_subprocess(["git", "reset", "--soft", "HEAD~1"], cwd=cwd, timeout=10.0)
+        rc_reset, _, _ = await _run_subprocess(
+            ["git", "reset", "--soft", "HEAD~1"], cwd=cwd, timeout=10.0
+        )
+        if rc_reset != 0:
+            logger.warning("auto_trigger: cleanup reset failed; branch may be diverged")
         return result
 
-    # 5. Re-poll CI with new SHA and fresh timeout
     new_scope = CIRunScope(
         workflow=scope.workflow,
         head_sha=new_head_sha,
         event=scope.event,
     )
-    assert tool_ctx.ci_watcher is not None
+    if tool_ctx.ci_watcher is None:
+        raise RuntimeError("auto_trigger: ci_watcher not configured on tool_ctx")
     try:
         triggered_result = await tool_ctx.ci_watcher.wait(
             branch,
@@ -767,6 +772,8 @@ async def _auto_trigger_ci(
         if new_head_sha:
             triggered_result = {**triggered_result, "head_sha": new_head_sha}
         return {**triggered_result, "triggered": True}
+    except asyncio.CancelledError:
+        raise
     except Exception:
         logger.error("auto_trigger: second CI poll failed", exc_info=True)
         return {**result, "conclusion": "auto_trigger_failed", "triggered": False}

--- a/src/autoskillit/server/tools_ci.py
+++ b/src/autoskillit/server/tools_ci.py
@@ -15,7 +15,6 @@ from fastmcp import Context
 from fastmcp.dependencies import CurrentContext
 
 from autoskillit.core import CIRunScope, get_logger
-from autoskillit.execution.remote_resolver import resolve_remote_name
 from autoskillit.pipeline import ToolContext
 from autoskillit.server import mcp
 from autoskillit.server.helpers import (
@@ -739,7 +738,14 @@ async def _auto_trigger_ci(
     rc_sha, sha_out, _ = await _run_subprocess(["git", "rev-parse", "HEAD"], cwd=cwd, timeout=5.0)
     new_head_sha = (sha_out.strip() or None) if rc_sha == 0 else None
 
-    remote_name = await resolve_remote_name(cwd)
+    remote_name = "origin"
+    for _candidate in ("upstream", "origin"):
+        rc_r, url_r, _ = await _run_subprocess(
+            ["git", "remote", "get-url", _candidate], cwd=cwd, timeout=5.0
+        )
+        if rc_r == 0 and not url_r.strip().startswith("file://"):
+            remote_name = _candidate
+            break
     rc_p, _, err_p = await _run_subprocess(
         ["git", "push", "--force-with-lease", remote_name, branch],
         cwd=cwd,

--- a/src/autoskillit/server/tools_ci.py
+++ b/src/autoskillit/server/tools_ci.py
@@ -718,6 +718,7 @@ async def _auto_trigger_ci(
         try:
             mergeable = json.loads(out_m).get("mergeable", "UNKNOWN")
         except Exception:
+            logger.warning("auto_trigger: failed to parse gh pr view JSON", exc_info=True)
             mergeable = "UNKNOWN"
         if mergeable == "CONFLICTING":
             return {**result, "conclusion": "merge_conflict", "triggered": False}

--- a/src/autoskillit/server/tools_ci.py
+++ b/src/autoskillit/server/tools_ci.py
@@ -14,7 +14,7 @@ from fastmcp import Context
 from fastmcp.dependencies import CurrentContext
 
 from autoskillit.core import CIRunScope, get_logger
-from autoskillit.pipeline.context import ToolContext
+from autoskillit.pipeline import ToolContext
 from autoskillit.server import mcp
 from autoskillit.server.helpers import (
     _notify,

--- a/src/autoskillit/server/tools_ci.py
+++ b/src/autoskillit/server/tools_ci.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import json
 import time
-from typing import Literal
+from typing import Any, Literal
 
 import httpx
 import structlog
@@ -27,7 +27,7 @@ from autoskillit.server.helpers import (
 logger = get_logger(__name__)
 
 
-@mcp.tool(tags={"autoskillit", "kitchen", "ci"}, annotations={"readOnlyHint": True})
+@mcp.tool(tags={"autoskillit", "kitchen", "ci"}, annotations={"readOnlyHint": False})
 @track_response_size("wait_for_ci")
 async def wait_for_ci(
     branch: str,
@@ -39,6 +39,7 @@ async def wait_for_ci(
     timeout_seconds: int = 300,
     cwd: str = ".",
     step_name: str = "",
+    auto_trigger: bool = False,
     ctx: Context = CurrentContext(),
 ) -> str:
     """Wait for a GitHub Actions CI run to complete on the given branch.
@@ -62,6 +63,11 @@ async def wait_for_ci(
         timeout_seconds: Maximum time to wait (default 300s).
         cwd: Working directory for git operations.
         step_name: Optional YAML step key for wall-clock timing accumulation.
+        auto_trigger: When True and ci_watcher returns "no_runs", performs an active
+                      self-healing sequence: checks PR mergeability, creates an empty
+                      commit, and force-pushes the branch to re-trigger webhook delivery,
+                      then re-polls CI with a fresh timeout. Result includes
+                      "triggered": true when the sequence fires. Default False.
 
     Returns:
         JSON with run_id, conclusion ("success", "failure", "cancelled",
@@ -140,6 +146,17 @@ async def wait_for_ci(
             # CI results correspond to the current HEAD after a force-push.
             if scope.head_sha:
                 result = {**result, "head_sha": scope.head_sha}
+
+            if auto_trigger and result.get("conclusion") == "no_runs":
+                result = await _auto_trigger_ci(
+                    branch=branch,
+                    cwd=cwd,
+                    result=result,
+                    scope=scope,
+                    resolved_repo=resolved_repo,
+                    tool_ctx=tool_ctx,
+                    timeout_seconds=timeout_seconds,
+                )
 
             conclusion = result.get("conclusion", "unknown")
             level = "info" if conclusion == "success" else "error"
@@ -672,3 +689,80 @@ async def check_repo_merge_state(
                 "ci_event": None,
             }
         )
+
+
+async def _auto_trigger_ci(
+    *,
+    branch: str,
+    cwd: str,
+    result: dict[str, Any],
+    scope: CIRunScope,
+    resolved_repo: str | None,
+    tool_ctx: Any,
+    timeout_seconds: int,
+) -> dict[str, Any]:
+    """Active CI trigger recovery: empty commit + force-push + re-poll.
+
+    Called when wait_for_ci returns no_runs and auto_trigger=True.
+    Returns result dict augmented with "triggered" key.
+    On any failure (merge conflict, push rejected, etc.) returns original
+    no_runs result so the recipe routes to handle_no_ci_runs as fallback.
+    """
+    # 1. Check PR mergeability — CONFLICTING means CI won't run even after push
+    rc_m, out_m, _ = await _run_subprocess(
+        ["gh", "pr", "view", branch, "--json", "mergeable"],
+        cwd=cwd,
+        timeout=15.0,
+    )
+    if rc_m == 0:
+        try:
+            mergeable = json.loads(out_m).get("mergeable", "UNKNOWN")
+        except Exception:
+            mergeable = "UNKNOWN"
+        if mergeable == "CONFLICTING":
+            return {**result, "conclusion": "merge_conflict", "triggered": False}
+
+    # 2. Create empty commit to force webhook re-delivery
+    rc_c, _, err_c = await _run_subprocess(
+        ["git", "commit", "--allow-empty", "-m", "ci: trigger"],
+        cwd=cwd,
+        timeout=30.0,
+    )
+    if rc_c != 0:
+        logger.warning("auto_trigger: empty commit failed", stderr=err_c)
+        return result
+
+    # 3. Capture new HEAD SHA for scoped CI polling
+    rc_sha, sha_out, _ = await _run_subprocess(["git", "rev-parse", "HEAD"], cwd=cwd, timeout=5.0)
+    new_head_sha = sha_out.strip() if rc_sha == 0 else None
+
+    # 4. Force-push to trigger webhook delivery
+    rc_p, _, err_p = await _run_subprocess(
+        ["git", "push", "--force-with-lease", "upstream", branch],
+        cwd=cwd,
+        timeout=60.0,
+    )
+    if rc_p != 0:
+        logger.warning("auto_trigger: push failed", stderr=err_p)
+        return result
+
+    # 5. Re-poll CI with new SHA and fresh timeout
+    new_scope = CIRunScope(
+        workflow=scope.workflow,
+        head_sha=new_head_sha,
+        event=scope.event,
+    )
+    try:
+        triggered_result = await tool_ctx.ci_watcher.wait(
+            branch,
+            repo=resolved_repo or None,
+            scope=new_scope,
+            timeout_seconds=timeout_seconds,
+            cwd=cwd,
+        )
+        if new_head_sha:
+            triggered_result = {**triggered_result, "head_sha": new_head_sha}
+        return {**triggered_result, "triggered": True}
+    except Exception:
+        logger.error("auto_trigger: second CI poll failed", exc_info=True)
+        return result

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -380,12 +380,14 @@ class InMemoryCIWatcher(CIWatcher):
         self,
         wait_result: dict[str, Any] | None = None,
         status_result: dict[str, Any] | None = None,
+        wait_results: list[dict[str, Any]] | None = None,
     ) -> None:
         self._wait_result = wait_result or {
             "run_id": 0,
             "conclusion": "success",
             "failed_jobs": [],
         }
+        self._wait_results_queue: list[dict[str, Any]] = list(wait_results) if wait_results else []
         self._status_result = status_result or {"runs": []}
         self.wait_calls: list[dict[str, Any]] = []
         self.status_calls: list[dict[str, Any]] = []
@@ -414,6 +416,8 @@ class InMemoryCIWatcher(CIWatcher):
         )
         if self.wait_side_effect is not None:
             return _resolve_side_effect(self.wait_side_effect)
+        if self._wait_results_queue:
+            return self._wait_results_queue.pop(0)
         return self._wait_result
 
     async def status(

--- a/tests/server/test_tools_ci.py
+++ b/tests/server/test_tools_ci.py
@@ -857,19 +857,17 @@ class TestWaitForCiAutoTrigger:
         assert result["failed_jobs"] == []
 
     @pytest.mark.anyio
-    async def test_auto_trigger_proceeds_on_gh_view_failure(self, tool_ctx):
-        watcher = InMemoryCIWatcher(wait_results=[_NO_RUNS, _SUCCESS])
+    async def test_auto_trigger_returns_gh_view_failed_on_gh_failure(self, tool_ctx):
+        watcher = InMemoryCIWatcher(wait_result=_NO_RUNS)
         tool_ctx.ci_watcher = watcher
         tool_ctx.runner.push(_sub(0, "abc123\n"))  # git rev-parse HEAD (initial)
         tool_ctx.runner.push(_sub(1))  # gh pr view — CLI failure (no PR)
-        tool_ctx.runner.push(_sub(0))  # git commit --allow-empty
-        tool_ctx.runner.push(_sub(0, "def456\n"))  # git rev-parse HEAD (new)
-        tool_ctx.runner.push(_sub(0))  # git push --force-with-lease
 
         result = json.loads(await wait_for_ci("branch", cwd="/repo", auto_trigger=True))
 
-        assert len(watcher.wait_calls) == 2
-        assert result["triggered"] is True
+        assert len(watcher.wait_calls) == 1
+        assert result["conclusion"] == "gh_view_failed"
+        assert result["triggered"] is False
 
     @pytest.mark.anyio
     async def test_auto_trigger_commit_failure_returns_no_runs(self, tool_ctx):
@@ -896,9 +894,14 @@ class TestWaitForCiAutoTrigger:
         tool_ctx.runner.push(_sub(0))  # git commit --allow-empty
         tool_ctx.runner.push(_sub(0, "def456\n"))  # git rev-parse HEAD (new)
         tool_ctx.runner.push(_sub(1, stderr="error: remote rejected"))  # git push fails
+        tool_ctx.runner.push(_sub(0))  # git reset --soft HEAD~1 (cleanup)
 
         result = json.loads(await wait_for_ci("branch", cwd="/repo", auto_trigger=True))
 
+        reset_cmd = tool_ctx.runner.call_args_list[-1][0]
+        assert reset_cmd == ["git", "reset", "--soft", "HEAD~1"], (
+            f"Expected reset, got: {reset_cmd}"
+        )
         assert len(watcher.wait_calls) == 1
         assert result["conclusion"] == "no_runs"
         assert "triggered" not in result

--- a/tests/server/test_tools_ci.py
+++ b/tests/server/test_tools_ci.py
@@ -783,3 +783,130 @@ async def test_check_repo_merge_state_error_includes_http_status(tool_ctx, monke
     result = json.loads(await check_repo_merge_state(branch="main"))
     assert "http_status" in result
     assert result["http_status"] == 403
+
+
+# ---------------------------------------------------------------------------
+# wait_for_ci auto_trigger
+# ---------------------------------------------------------------------------
+
+_NO_RUNS = {"conclusion": "no_runs", "run_id": None, "failed_jobs": []}
+_SUCCESS = {"conclusion": "success", "run_id": 42, "failed_jobs": []}
+
+
+def _sub(returncode: int, stdout: str = "", stderr: str = "") -> SubprocessResult:
+    return SubprocessResult(
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+        termination=TerminationReason.NATURAL_EXIT,
+        pid=0,
+    )
+
+
+class TestWaitForCiAutoTrigger:
+    """wait_for_ci auto_trigger=True: active webhook recovery."""
+
+    @pytest.mark.anyio
+    async def test_auto_trigger_default_false_does_not_fire(self, tool_ctx):
+        watcher = InMemoryCIWatcher(wait_result=_NO_RUNS)
+        tool_ctx.ci_watcher = watcher
+        tool_ctx.runner.push(_sub(0, "abc123\n"))
+
+        result = json.loads(await wait_for_ci("branch", cwd="/repo"))
+
+        assert len(watcher.wait_calls) == 1
+        assert len(tool_ctx.runner.call_args_list) == 1
+        assert result["conclusion"] == "no_runs"
+        assert "triggered" not in result
+
+    @pytest.mark.anyio
+    async def test_auto_trigger_fires_on_no_runs(self, tool_ctx):
+        watcher = InMemoryCIWatcher(wait_results=[_NO_RUNS, _SUCCESS])
+        tool_ctx.ci_watcher = watcher
+        tool_ctx.runner.push(_sub(0, "abc123\n"))  # git rev-parse HEAD (initial)
+        tool_ctx.runner.push(_sub(0, '{"mergeable":"MERGEABLE"}\n'))  # gh pr view
+        tool_ctx.runner.push(_sub(0))  # git commit --allow-empty
+        tool_ctx.runner.push(_sub(0, "def456\n"))  # git rev-parse HEAD (new)
+        tool_ctx.runner.push(_sub(0))  # git push --force-with-lease
+
+        result = json.loads(await wait_for_ci("feature-branch", cwd="/repo", auto_trigger=True))
+
+        assert len(watcher.wait_calls) == 2
+        assert watcher.wait_calls[1]["scope"].head_sha == "def456"
+        assert result["conclusion"] == "success"
+        assert result["triggered"] is True
+        assert result["head_sha"] == "def456"
+
+    @pytest.mark.anyio
+    async def test_auto_trigger_skips_on_conflicting_pr(self, tool_ctx):
+        watcher = InMemoryCIWatcher(wait_result=_NO_RUNS)
+        tool_ctx.ci_watcher = watcher
+        tool_ctx.runner.push(_sub(0, "abc123\n"))  # git rev-parse HEAD
+        tool_ctx.runner.push(_sub(0, '{"mergeable":"CONFLICTING"}\n'))  # gh pr view
+
+        result = json.loads(await wait_for_ci("branch", cwd="/repo", auto_trigger=True))
+
+        assert len(watcher.wait_calls) == 1
+        assert result["conclusion"] == "merge_conflict"
+        assert result["triggered"] is False
+
+    @pytest.mark.anyio
+    async def test_auto_trigger_proceeds_on_gh_view_failure(self, tool_ctx):
+        watcher = InMemoryCIWatcher(wait_results=[_NO_RUNS, _SUCCESS])
+        tool_ctx.ci_watcher = watcher
+        tool_ctx.runner.push(_sub(0, "abc123\n"))  # git rev-parse HEAD (initial)
+        tool_ctx.runner.push(_sub(1))  # gh pr view — CLI failure (no PR)
+        tool_ctx.runner.push(_sub(0))  # git commit --allow-empty
+        tool_ctx.runner.push(_sub(0, "def456\n"))  # git rev-parse HEAD (new)
+        tool_ctx.runner.push(_sub(0))  # git push --force-with-lease
+
+        result = json.loads(await wait_for_ci("branch", cwd="/repo", auto_trigger=True))
+
+        assert len(watcher.wait_calls) == 2
+        assert result["triggered"] is True
+
+    @pytest.mark.anyio
+    async def test_auto_trigger_commit_failure_returns_no_runs(self, tool_ctx):
+        watcher = InMemoryCIWatcher(wait_result=_NO_RUNS)
+        tool_ctx.ci_watcher = watcher
+        tool_ctx.runner.push(_sub(0, "abc123\n"))  # git rev-parse HEAD
+        tool_ctx.runner.push(_sub(0, '{"mergeable":"MERGEABLE"}\n'))  # gh pr view
+        tool_ctx.runner.push(
+            _sub(128, stderr="error: pre-commit hook rejected commit")
+        )  # git commit fails
+
+        result = json.loads(await wait_for_ci("branch", cwd="/repo", auto_trigger=True))
+
+        assert len(watcher.wait_calls) == 1
+        assert result["conclusion"] == "no_runs"
+        assert "triggered" not in result
+
+    @pytest.mark.anyio
+    async def test_auto_trigger_push_failure_returns_no_runs(self, tool_ctx):
+        watcher = InMemoryCIWatcher(wait_result=_NO_RUNS)
+        tool_ctx.ci_watcher = watcher
+        tool_ctx.runner.push(_sub(0, "abc123\n"))  # git rev-parse HEAD
+        tool_ctx.runner.push(_sub(0, '{"mergeable":"MERGEABLE"}\n'))  # gh pr view
+        tool_ctx.runner.push(_sub(0))  # git commit --allow-empty
+        tool_ctx.runner.push(_sub(0, "def456\n"))  # git rev-parse HEAD (new)
+        tool_ctx.runner.push(_sub(1, stderr="error: remote rejected"))  # git push fails
+
+        result = json.loads(await wait_for_ci("branch", cwd="/repo", auto_trigger=True))
+
+        assert len(watcher.wait_calls) == 1
+        assert result["conclusion"] == "no_runs"
+        assert "triggered" not in result
+
+    @pytest.mark.anyio
+    async def test_auto_trigger_result_includes_triggered_false_on_merge_conflict(self, tool_ctx):
+        watcher = InMemoryCIWatcher(wait_result=_NO_RUNS)
+        tool_ctx.ci_watcher = watcher
+        tool_ctx.runner.push(_sub(0, "abc123\n"))
+        tool_ctx.runner.push(_sub(0, '{"mergeable":"CONFLICTING"}\n'))
+
+        result = json.loads(await wait_for_ci("branch", cwd="/repo", auto_trigger=True))
+
+        assert result["conclusion"] == "merge_conflict"
+        assert result["triggered"] is False
+        assert result["run_id"] is None
+        assert result["failed_jobs"] == []

--- a/tests/server/test_tools_ci.py
+++ b/tests/server/test_tools_ci.py
@@ -831,6 +831,9 @@ class TestWaitForCiAutoTrigger:
         tool_ctx.runner.push(
             _sub(0, "def456\n")
         )  # git rev-parse HEAD — new HEAD after empty commit
+        tool_ctx.runner.push(
+            _sub(0, "https://github.com/org/repo\n")
+        )  # git remote get-url upstream
         tool_ctx.runner.push(_sub(0))  # git push --force-with-lease
 
         result = json.loads(await wait_for_ci("feature-branch", cwd="/repo", auto_trigger=True))
@@ -893,6 +896,9 @@ class TestWaitForCiAutoTrigger:
         tool_ctx.runner.push(_sub(0, '{"mergeable":"MERGEABLE"}\n'))  # gh pr view
         tool_ctx.runner.push(_sub(0))  # git commit --allow-empty
         tool_ctx.runner.push(_sub(0, "def456\n"))  # git rev-parse HEAD (new)
+        tool_ctx.runner.push(
+            _sub(0, "https://github.com/org/repo\n")
+        )  # git remote get-url upstream
         tool_ctx.runner.push(_sub(1, stderr="error: remote rejected"))  # git push fails
         tool_ctx.runner.push(_sub(0))  # git reset --soft HEAD~1 (cleanup)
 
@@ -927,6 +933,9 @@ class TestWaitForCiAutoTrigger:
         tool_ctx.runner.push(
             _sub(0, "def456\n")
         )  # git rev-parse HEAD — new HEAD after empty commit
+        tool_ctx.runner.push(
+            _sub(0, "https://github.com/org/repo\n")
+        )  # git remote get-url upstream
         tool_ctx.runner.push(_sub(0))  # git push --force-with-lease
 
         result = json.loads(await wait_for_ci("branch", cwd="/repo", auto_trigger=True))

--- a/tests/server/test_tools_ci.py
+++ b/tests/server/test_tools_ci.py
@@ -823,10 +823,14 @@ class TestWaitForCiAutoTrigger:
     async def test_auto_trigger_fires_on_no_runs(self, tool_ctx):
         watcher = InMemoryCIWatcher(wait_results=[_NO_RUNS, _SUCCESS])
         tool_ctx.ci_watcher = watcher
-        tool_ctx.runner.push(_sub(0, "abc123\n"))  # git rev-parse HEAD (initial)
+        tool_ctx.runner.push(
+            _sub(0, "abc123\n")
+        )  # git rev-parse HEAD — wait_for_ci initial HEAD inference
         tool_ctx.runner.push(_sub(0, '{"mergeable":"MERGEABLE"}\n'))  # gh pr view
         tool_ctx.runner.push(_sub(0))  # git commit --allow-empty
-        tool_ctx.runner.push(_sub(0, "def456\n"))  # git rev-parse HEAD (new)
+        tool_ctx.runner.push(
+            _sub(0, "def456\n")
+        )  # git rev-parse HEAD — new HEAD after empty commit
         tool_ctx.runner.push(_sub(0))  # git push --force-with-lease
 
         result = json.loads(await wait_for_ci("feature-branch", cwd="/repo", auto_trigger=True))
@@ -849,6 +853,8 @@ class TestWaitForCiAutoTrigger:
         assert len(watcher.wait_calls) == 1
         assert result["conclusion"] == "merge_conflict"
         assert result["triggered"] is False
+        assert result["run_id"] is None
+        assert result["failed_jobs"] == []
 
     @pytest.mark.anyio
     async def test_auto_trigger_proceeds_on_gh_view_failure(self, tool_ctx):
@@ -898,15 +904,30 @@ class TestWaitForCiAutoTrigger:
         assert "triggered" not in result
 
     @pytest.mark.anyio
-    async def test_auto_trigger_result_includes_triggered_false_on_merge_conflict(self, tool_ctx):
+    async def test_auto_trigger_ci_poll_exception_returns_auto_trigger_failed(self, tool_ctx):
+        call_count_holder = [0]
+
+        def poll_raises_on_second_call() -> dict:
+            call_count_holder[0] += 1
+            if call_count_holder[0] >= 2:
+                raise RuntimeError("auto_trigger poll failed")
+            return _NO_RUNS
+
         watcher = InMemoryCIWatcher(wait_result=_NO_RUNS)
+        watcher.wait_side_effect = poll_raises_on_second_call
         tool_ctx.ci_watcher = watcher
-        tool_ctx.runner.push(_sub(0, "abc123\n"))
-        tool_ctx.runner.push(_sub(0, '{"mergeable":"CONFLICTING"}\n'))
+        tool_ctx.runner.push(
+            _sub(0, "abc123\n")
+        )  # git rev-parse HEAD — wait_for_ci initial HEAD inference
+        tool_ctx.runner.push(_sub(0, '{"mergeable":"MERGEABLE"}\n'))  # gh pr view
+        tool_ctx.runner.push(_sub(0))  # git commit --allow-empty
+        tool_ctx.runner.push(
+            _sub(0, "def456\n")
+        )  # git rev-parse HEAD — new HEAD after empty commit
+        tool_ctx.runner.push(_sub(0))  # git push --force-with-lease
 
         result = json.loads(await wait_for_ci("branch", cwd="/repo", auto_trigger=True))
 
-        assert result["conclusion"] == "merge_conflict"
+        assert len(watcher.wait_calls) == 2
+        assert result["conclusion"] == "auto_trigger_failed"
         assert result["triggered"] is False
-        assert result["run_id"] is None
-        assert result["failed_jobs"] == []


### PR DESCRIPTION
## Summary

Add `auto_trigger: bool = False` to `wait_for_ci` in `tools_ci.py`. When `True` and the first CI poll returns `no_runs`, the tool runs an active self-healing sequence: checks PR mergeability, creates an empty commit, force-pushes the branch to force webhook re-delivery, then re-runs CI polling with a fresh timeout and the new HEAD SHA. The result includes `"triggered": true` for observability. Three recipe files (`implementation.yaml`, `remediation.yaml`, `implementation-groups.yaml`) each add one line: `auto_trigger: "true"` to their `ci_watch` step. The existing `handle_no_ci_runs` step is preserved as the fallback path for the cases where the push itself fails.

## Architecture Impact

### Error/Resilience Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 42, 'rankSpacing': 58, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;

    %% IMPORT-TIME INVARIANTS %%
    subgraph ImportGuards ["IMPORT-TIME STRUCTURAL GUARDS (● _type_constants.py)"]
        direction LR
        MUT_CHECK["● MUTATING_TOOLS ⊆ ALL_REGISTERED<br/>━━━━━━━━━━<br/>Includes wait_for_ci synced in PR<br/>RuntimeError on violation"]
        TAG_CHECK["Tag coverage invariants<br/>━━━━━━━━━━<br/>TOOL_SUBSET_TAGS non-empty<br/>RuntimeError if broken"]
    end

    T_STARTUP_FAIL([SERVER STARTUP FAILS<br/>RuntimeError at import])

    MUT_CHECK -->|"violated at import"| T_STARTUP_FAIL
    TAG_CHECK -->|"violated at import"| T_STARTUP_FAIL

    %% RECIPE VALIDATION %%
    subgraph RecipeRules ["RECIPE VALIDATION RULES (● rules_tools.py)"]
        direction LR
        DEAD_PARAM["● dead-with-param rule<br/>━━━━━━━━━━<br/>auto_trigger ∈ _TOOL_PARAMS<br/>WARNING if key misspelled"]
        UNKNOWN_TOOL["unknown-tool rule<br/>━━━━━━━━━━<br/>tool name ∈ _ALL_TOOLS<br/>ERROR if typo"]
    end

    T_RULE_WARN([RuleFinding WARNING<br/>dead-with-param])
    T_RULE_ERR([RuleFinding ERROR<br/>unknown-tool])

    DEAD_PARAM -->|"unknown key"| T_RULE_WARN
    UNKNOWN_TOOL -->|"tool not found"| T_RULE_ERR

    %% RECIPE CONFIG %%
    RECIPE_CFG["● ci_watch steps (3 recipes)<br/>━━━━━━━━━━<br/>auto_trigger: 'true'<br/>implementation / implementation-groups / remediation"]

    DEAD_PARAM -.->|"validates"| RECIPE_CFG
    UNKNOWN_TOOL -.->|"validates"| RECIPE_CFG

    %% RUNTIME VALIDATION GATES %%
    subgraph Gates ["VALIDATION GATES (● tools_ci.py — fail-fast)"]
        KITCHEN_GATE["● _require_enabled()<br/>━━━━━━━━━━<br/>Kitchen must be open<br/>Every tool entry point"]
        WATCHER_GATE["● ci_watcher is None?<br/>━━━━━━━━━━<br/>CI watcher must be configured<br/>Checked before any poll"]
    end

    T_GATE_ERR([gate_error<br/>subtype: gate_error<br/>success: false])
    T_UNCFG([error: CI watcher not configured<br/>conclusion: error])

    RECIPE_CFG --> KITCHEN_GATE
    KITCHEN_GATE -->|"kitchen closed"| T_GATE_ERR
    KITCHEN_GATE -->|"open"| WATCHER_GATE
    WATCHER_GATE -->|"None"| T_UNCFG
    WATCHER_GATE -->|"configured"| CI_POLL

    %% EXECUTION %%
    subgraph Execution ["EXECUTION (● tools_ci.py)"]
        CI_POLL["● ci_watcher.wait()<br/>━━━━━━━━━━<br/>GitHub Actions polling<br/>timeout_seconds, CIRunScope"]
        AT_DECISION{"auto_trigger=true<br/>AND<br/>conclusion==no_runs?"}
        OUTER_CATCH["● outer except Exception<br/>━━━━━━━━━━<br/>Never-raises contract<br/>→ {success:false, error:str(exc)}"]
    end

    CI_POLL --> AT_DECISION
    CI_POLL -->|"unexpected exception"| OUTER_CATCH
    AT_DECISION -->|"no — pass through"| T_PASS

    T_PASS([success / failure / cancelled<br/>timed_out / unknown<br/>conclusion passed through])
    OUTER_CATCH --> T_OUTER_ERR
    T_OUTER_ERR([error: ExcType: msg<br/>success: false])

    %% AUTO-TRIGGER RECOVERY %%
    subgraph AutoTrigger ["AUTO_TRIGGER RECOVERY — _auto_trigger_ci (● tools_ci.py)"]
        direction TB
        MERGE_PRE["● Mergeability pre-check<br/>━━━━━━━━━━<br/>gh pr view --json mergeable<br/>gh fail → treat as UNKNOWN → proceed"]
        COMMIT["● git commit --allow-empty<br/>━━━━━━━━━━<br/>ci: trigger message<br/>timeout 30s"]
        SHA_CAP["● git rev-parse HEAD<br/>━━━━━━━━━━<br/>capture new HEAD SHA<br/>timeout 5s — None if fails"]
        PUSH["● git push --force-with-lease<br/>━━━━━━━━━━<br/>upstream/<branch><br/>timeout 60s"]
        REPOLL["● ci_watcher.wait() re-poll<br/>━━━━━━━━━━<br/>new CIRunScope(head_sha=new_sha)<br/>same timeout_seconds"]
    end

    AT_DECISION -->|"yes — fire recovery"| MERGE_PRE

    T_CONFLICT([merge_conflict<br/>conclusion: merge_conflict<br/>triggered: false])
    T_NO_RUNS_COMMIT([no_runs fallback<br/>conclusion: no_runs<br/>triggered absent — commit failed])
    T_NO_RUNS_PUSH([no_runs fallback<br/>conclusion: no_runs<br/>triggered absent — push failed])
    T_NO_RUNS_POLL([no_runs fallback<br/>conclusion: no_runs<br/>triggered absent — re-poll exception])
    T_RECOVERED([recovered<br/>conclusion from re-poll<br/>triggered: true])

    MERGE_PRE -->|"mergeable == CONFLICTING"| T_CONFLICT
    MERGE_PRE -->|"MERGEABLE or gh fails"| COMMIT
    COMMIT -->|"rc != 0 (hook rejected / detached HEAD)"| T_NO_RUNS_COMMIT
    COMMIT -->|"rc == 0"| SHA_CAP
    SHA_CAP --> PUSH
    PUSH -->|"rc != 0 (remote rejected)"| T_NO_RUNS_PUSH
    PUSH -->|"rc == 0"| REPOLL
    REPOLL -->|"exception raised"| T_NO_RUNS_POLL
    REPOLL -->|"conclusion returned"| T_RECOVERED

    %% CLASS ASSIGNMENTS %%
    class MUT_CHECK,TAG_CHECK detector;
    class DEAD_PARAM,UNKNOWN_TOOL detector;
    class RECIPE_CFG stateNode;
    class KITCHEN_GATE,WATCHER_GATE detector;
    class CI_POLL,COMMIT,SHA_CAP,PUSH,REPOLL handler;
    class AT_DECISION stateNode;
    class OUTER_CATCH phase;
    class MERGE_PRE detector;
    class T_STARTUP_FAIL,T_RULE_WARN,T_RULE_ERR,T_GATE_ERR,T_UNCFG terminal;
    class T_CONFLICT,T_NO_RUNS_COMMIT,T_NO_RUNS_PUSH,T_NO_RUNS_POLL gap;
    class T_PASS,T_OUTER_ERR,T_RECOVERED terminal;
```

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START<br/>━━━━━━━━━━<br/>Recipe engine step dispatch])
    DONE([DONE<br/>━━━━━━━━━━<br/>Result returned to recipe])
    ERROR([ERROR<br/>━━━━━━━━━━<br/>Unhandled exception — never raises])

    %% ── PHASE 0: RECIPE GATE ── %%
    subgraph RecipeGate ["Phase 0 — Recipe ci_watch Step Dispatch"]
        direction TB
        SkipCheck{"skip_when_false<br/>━━━━━━━━━━<br/>inputs.open_pr?"}
        CiWatchStep["● ci_watch step<br/>━━━━━━━━━━<br/>tool: wait_for_ci<br/>auto_trigger: true<br/>timeout: 300s<br/>(impl / impl-groups / remediation)"]
    end

    %% ── PHASE 1: TOOL ENTRY ── %%
    subgraph ToolEntry ["Phase 1 — wait_for_ci Tool Entry"]
        direction TB
        GateCheck{"_require_enabled()<br/>━━━━━━━━━━<br/>Kitchen open?"}
        WatcherCheck{"ci_watcher<br/>━━━━━━━━━━<br/>present?"}
        SHAInfer["Infer head_sha<br/>━━━━━━━━━━<br/>git rev-parse HEAD<br/>(timeout 5s, cwd)"]
        ScopeConstruct["Build CIRunScope<br/>━━━━━━━━━━<br/>workflow + head_sha + event"]
        RepoResolve["infer_repo_from_remote()<br/>━━━━━━━━━━<br/>remote_url > repo > git remote"]
    end

    %% ── PHASE 2: PRIMARY CI POLL ── %%
    subgraph PrimaryPoll ["Phase 2 — Primary CI Poll"]
        direction TB
        CIWait["● ci_watcher.wait()<br/>━━━━━━━━━━<br/>branch / repo / scope<br/>timeout_seconds=300"]
        AutoTrigDecision{"auto_trigger=True<br/>AND<br/>conclusion == no_runs?"}
    end

    %% ── PHASE 3: AUTO-TRIGGER RECOVERY ── %%
    subgraph AutoTrigger ["Phase 3 — ● _auto_trigger_ci() — 5-Step Recovery"]
        direction TB
        MergeCheck["gh pr view {branch}<br/>━━━━━━━━━━<br/>--json mergeable<br/>(timeout 15s)"]
        MergeDecision{"mergeable ==<br/>CONFLICTING?"}
        GHFailDecision{"gh rc != 0 or<br/>JSON parse error?"}
        EmptyCommit["git commit --allow-empty<br/>━━━━━━━━━━<br/>-m 'ci: trigger'<br/>(timeout 30s)"]
        CommitDecision{"commit rc != 0?"}
        NewSHA["git rev-parse HEAD<br/>━━━━━━━━━━<br/>capture new_head_sha<br/>(timeout 5s)"]
        ForcePush["git push --force-with-lease<br/>━━━━━━━━━━<br/>upstream {branch}<br/>(timeout 60s)"]
        PushDecision{"push rc != 0?"}
        RePoll["● ci_watcher.wait()<br/>━━━━━━━━━━<br/>NEW scope: head_sha=new_head_sha<br/>timeout_seconds=300"]
        RePollDecision{"re-poll raises<br/>exception?"}
    end

    %% ── PHASE 4: RESULT ROUTING ── %%
    subgraph ResultRouting ["Phase 4 — Recipe Result Routing"]
        direction TB
        HeadSHAEnrich["Enrich result<br/>━━━━━━━━━━<br/>head_sha → result dict<br/>triggered: True / False"]
        RouteSuccess{"conclusion?"}
        MergeStateStep["check_repo_merge_state<br/>━━━━━━━━━━<br/>merge queue detection"]
        NoRunsStep["handle_no_ci_runs<br/>━━━━━━━━━━<br/>re-derive ci_event<br/>retry ci_watch (retries:1)"]
        ConflictStep["detect_ci_conflict<br/>━━━━━━━━━━<br/>failure / timed_out / cancelled"]
    end

    %% FLOW %%

    START --> SkipCheck
    SkipCheck -->|"open_pr=false"| DONE
    SkipCheck -->|"open_pr=true"| CiWatchStep

    CiWatchStep --> GateCheck
    GateCheck -->|"closed"| ERROR
    GateCheck -->|"open"| WatcherCheck
    WatcherCheck -->|"None"| ERROR
    WatcherCheck -->|"configured"| SHAInfer
    SHAInfer -->|"rc=0 → head_sha set<br/>rc!=0 → head_sha=None"| ScopeConstruct
    ScopeConstruct --> RepoResolve
    RepoResolve --> CIWait

    CIWait -->|"raises"| ERROR
    CIWait -->|"returns result"| AutoTrigDecision
    AutoTrigDecision -->|"No (auto_trigger=False<br/>or conclusion != no_runs)"| HeadSHAEnrich
    AutoTrigDecision -->|"Yes"| MergeCheck

    MergeCheck --> MergeDecision
    MergeDecision -->|"CONFLICTING"| HeadSHAEnrich
    MergeDecision -->|"not CONFLICTING"| GHFailDecision
    GHFailDecision -->|"fail (fail-open)"| EmptyCommit
    GHFailDecision -->|"success"| EmptyCommit
    EmptyCommit --> CommitDecision
    CommitDecision -->|"rc!=0 → return original no_runs"| HeadSHAEnrich
    CommitDecision -->|"rc=0"| NewSHA
    NewSHA --> ForcePush
    ForcePush --> PushDecision
    PushDecision -->|"rc!=0 → return original no_runs"| HeadSHAEnrich
    PushDecision -->|"rc=0"| RePoll
    RePoll --> RePollDecision
    RePollDecision -->|"raises → return original no_runs"| HeadSHAEnrich
    RePollDecision -->|"success → triggered=True"| HeadSHAEnrich

    HeadSHAEnrich --> RouteSuccess
    RouteSuccess -->|"success"| MergeStateStep
    RouteSuccess -->|"no_runs"| NoRunsStep
    RouteSuccess -->|"merge_conflict / failure<br/>timed_out / cancelled"| ConflictStep
    MergeStateStep --> DONE
    NoRunsStep -->|"re-enters ci_watch (bounded)"| CiWatchStep
    ConflictStep --> DONE
    ERROR --> DONE

    %% CLASS ASSIGNMENTS %%
    class START,DONE,ERROR terminal;
    class SkipCheck,AutoTrigDecision,MergeDecision,GHFailDecision,CommitDecision,PushDecision,RePollDecision,RouteSuccess stateNode;
    class CiWatchStep,CIWait,RePoll handler;
    class GateCheck,WatcherCheck detector;
    class SHAInfer,ScopeConstruct,RepoResolve,MergeCheck,EmptyCommit,NewSHA,ForcePush phase;
    class HeadSHAEnrich,MergeStateStep,NoRunsStep,ConflictStep output;
```

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START([wait_for_ci invoked])

    subgraph Contracts ["FIELD LIFECYCLE CONTRACTS"]
        direction TB
        INIT_ONLY["INIT_ONLY<br/>━━━━━━━━━━<br/>branch · repo · head_sha<br/>workflow · event · cwd<br/>Resolved once at entry"]
        MUTABLE_P["● MUTABLE: auto_trigger<br/>━━━━━━━━━━<br/>bool param, default False<br/>Controls recovery branch<br/>New in this PR"]
        APPEND_LOG["APPEND_ONLY<br/>━━━━━━━━━━<br/>timing_log.record(elapsed)<br/>wait_calls list in watcher<br/>Write-only audit trail"]
        DERIVED_SHA["DERIVED: new_head_sha<br/>━━━━━━━━━━<br/>git rev-parse HEAD<br/>Transient — not stored<br/>Passed directly to re-poll"]
    end

    subgraph Gates ["VALIDATION GATES"]
        direction TB
        GATE_KITCHEN["_require_enabled()<br/>━━━━━━━━━━<br/>kitchen gate · FAIL-FAST<br/>reads gate.enabled"]
        GATE_WATCHER["ci_watcher is None?<br/>━━━━━━━━━━<br/>Error: not configured<br/>FAIL-FAST before any I/O"]
        GATE_PARAMS["● _TOOL_PARAMS contract<br/>━━━━━━━━━━<br/>dead-with-param rule<br/>auto_trigger now valid<br/>Sync: MUTATING_TOOLS"]
    end

    subgraph Watcher ["● CI WATCHER STATE (fakes.py)"]
        direction TB
        W_QUEUE["● _wait_results_queue<br/>━━━━━━━━━━<br/>FIFO list — pops per call<br/>Enables multi-call test<br/>Drain → fallback"]
        W_DEFAULT["_wait_result<br/>━━━━━━━━━━<br/>Static default result<br/>Used when queue empty<br/>INIT_PRESERVE"]
        W_CALLS["wait_calls<br/>━━━━━━━━━━<br/>APPEND_ONLY call log<br/>Assertion target in tests"]
    end

    POLL_RESULT{"conclusion?"}

    subgraph AutoTrigger ["● AUTO-TRIGGER RECOVERY (_auto_trigger_ci)"]
        direction TB
        MERGE_CHECK["mergeability guard<br/>━━━━━━━━━━<br/>gh pr view · CONFLICTING?<br/>Abort if conflicting"]
        EMPTY_COMMIT["empty commit<br/>━━━━━━━━━━<br/>git commit --allow-empty<br/>Failure → original result"]
        FORCE_PUSH["force-push upstream<br/>━━━━━━━━━━<br/>git push --force-with-lease<br/>Failure → original result"]
        REPOLL["re-poll CI<br/>━━━━━━━━━━<br/>new CIRunScope + new sha<br/>ci_watcher.wait() call #2"]
    end

    subgraph Recipes ["● RECIPE CAPTURES (3 recipes)"]
        direction TB
        CAP_CONCLUSION["● ci_conclusion<br/>━━━━━━━━━━<br/>capture: result.conclusion<br/>Routes: success / no_runs<br/>/ detect_ci_conflict"]
        CAP_JOBS["ci_failed_jobs<br/>━━━━━━━━━━<br/>capture: result.failed_jobs<br/>Input to remediation"]
    end

    ABORT(["conclusion: error / conflict<br/>triggered: False"])
    DONE(["ci_watch complete<br/>timing_log flushed"])

    START --> GATE_KITCHEN
    GATE_KITCHEN -->|"gate=False"| ABORT
    GATE_KITCHEN -->|"gate=True"| GATE_WATCHER
    GATE_WATCHER -->|"None"| ABORT
    GATE_WATCHER -->|"configured"| GATE_PARAMS
    GATE_PARAMS --> INIT_ONLY
    GATE_PARAMS --> MUTABLE_P
    INIT_ONLY --> W_QUEUE
    MUTABLE_P --> W_QUEUE
    W_QUEUE -->|"queue non-empty: pop(0)"| POLL_RESULT
    W_QUEUE -->|"queue empty"| W_DEFAULT
    W_DEFAULT --> POLL_RESULT
    POLL_RESULT -->|"success / failure / timeout"| CAP_CONCLUSION
    POLL_RESULT -->|"no_runs AND auto_trigger=True"| MERGE_CHECK
    MERGE_CHECK -->|"CONFLICTING"| ABORT
    MERGE_CHECK -->|"ok"| EMPTY_COMMIT
    EMPTY_COMMIT -->|"commit failed"| CAP_CONCLUSION
    EMPTY_COMMIT -->|"ok"| FORCE_PUSH
    FORCE_PUSH -->|"push failed"| CAP_CONCLUSION
    FORCE_PUSH -->|"ok"| DERIVED_SHA
    DERIVED_SHA --> REPOLL
    REPOLL -->|"triggered=True"| CAP_CONCLUSION
    W_CALLS -.->|"append on each wait()"| APPEND_LOG
    CAP_CONCLUSION --> CAP_JOBS
    CAP_CONCLUSION --> APPEND_LOG
    CAP_JOBS --> DONE
    APPEND_LOG --> DONE

    class START,ABORT,DONE terminal;
    class INIT_ONLY detector;
    class MUTABLE_P phase;
    class APPEND_LOG handler;
    class DERIVED_SHA gap;
    class GATE_KITCHEN,GATE_WATCHER,GATE_PARAMS detector;
    class W_QUEUE stateNode;
    class W_DEFAULT stateNode;
    class W_CALLS handler;
    class POLL_RESULT phase;
    class MERGE_CHECK detector;
    class EMPTY_COMMIT,FORCE_PUSH,REPOLL handler;
    class CAP_CONCLUSION,CAP_JOBS output;
```

Closes #1335

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260426-204530-617870/.autoskillit/temp/make-plan/recipe_gap_no_active_ci_trigger_fallback_plan_2026-04-26_210000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 10.0k | 22.2k | 1.3M | 140.4k | 1 | 8m 9s |
| verify | 132 | 12.9k | 680.5k | 43.5k | 1 | 7m 18s |
| implement | 326 | 20.4k | 2.1M | 67.2k | 1 | 6m 11s |
| fix | 150 | 5.9k | 720.2k | 41.4k | 1 | 6m 59s |
| prepare_pr | 92 | 4.8k | 337.3k | 28.3k | 1 | 1m 59s |
| run_arch_lenses | 8.2k | 27.4k | 592.4k | 150.3k | 3 | 13m 16s |
| compose_pr | 67 | 9.1k | 258.7k | 37.1k | 1 | 2m 45s |
| **Total** | 19.0k | 102.6k | 5.9M | 508.1k | | 46m 38s |