### PR TITLE
Planner Redesign — JSON Interchange Schemas & Merge Tooling

### DIFF
--- a/src/autoskillit/planner/__init__.py
+++ b/src/autoskillit/planner/__init__.py
@@ -7,22 +7,50 @@ from autoskillit.planner.manifests import (
     check_remaining,
     create_run_dir,
 )
+from autoskillit.planner.merge import (
+    build_plan_snapshot,
+    extract_item,
+    merge_files,
+    replace_item,
+)
 from autoskillit.planner.schema import (  # noqa: F401
     ASSIGNMENT_REQUIRED_KEYS,
     PHASE_REQUIRED_KEYS,
     WP_REQUIRED_KEYS,
+    AssignmentElaborated,
+    AssignmentShort,
+    PhaseElaborated,
+    PhaseShort,
+    PlanDocument,
     PlannerManifest,
     PlannerManifestItem,
+    WPElaborated,
+    WPShort,
 )
 from autoskillit.planner.validation import validate_plan
 
 __all__ = [
+    # Existing manifest/compile/validate callables
+    "check_remaining",
     "build_assignment_manifest",
     "build_wp_manifest",
-    "check_remaining",
     "compile_plan",
     "create_run_dir",
+    "validate_plan",
+    # Existing TypedDicts
     "PlannerManifest",
     "PlannerManifestItem",
-    "validate_plan",
+    # New merge callables (Issue 01)
+    "merge_files",
+    "extract_item",
+    "replace_item",
+    "build_plan_snapshot",
+    # New interchange TypedDicts (Issue 01)
+    "PlanDocument",
+    "PhaseShort",
+    "PhaseElaborated",
+    "AssignmentShort",
+    "AssignmentElaborated",
+    "WPShort",
+    "WPElaborated",
 ]

--- a/src/autoskillit/planner/__init__.py
+++ b/src/autoskillit/planner/__init__.py
@@ -30,22 +30,18 @@ from autoskillit.planner.schema import (  # noqa: F401
 from autoskillit.planner.validation import validate_plan
 
 __all__ = [
-    # Existing manifest/compile/validate callables
     "check_remaining",
     "build_assignment_manifest",
     "build_wp_manifest",
     "compile_plan",
     "create_run_dir",
     "validate_plan",
-    # Existing TypedDicts
     "PlannerManifest",
     "PlannerManifestItem",
-    # New merge callables (Issue 01)
     "merge_files",
     "extract_item",
     "replace_item",
     "build_plan_snapshot",
-    # New interchange TypedDicts (Issue 01)
     "PlanDocument",
     "PhaseShort",
     "PhaseElaborated",

--- a/src/autoskillit/planner/merge.py
+++ b/src/autoskillit/planner/merge.py
@@ -118,7 +118,12 @@ def replace_item(
     replacement_path: str,
     **kwargs: Any,
 ) -> dict[str, Any]:
-    replacement: dict[str, Any] = json.loads(Path(replacement_path).read_text())
+    try:
+        replacement: dict[str, Any] = json.loads(Path(replacement_path).read_text())
+    except FileNotFoundError:
+        raise ValueError(f"Replacement file not found: {replacement_path}") from None
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON in {replacement_path}: {exc}") from exc
     src = Path(source_path)
 
     found = False

--- a/src/autoskillit/planner/merge.py
+++ b/src/autoskillit/planner/merge.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from autoskillit.core import get_logger, write_versioned_json
+from autoskillit.planner.schema import validate_phase_result
 
 _logger = get_logger(__name__)
 
@@ -21,52 +22,67 @@ def merge_files(
     strict: bool = True,
     **kwargs: Any,
 ) -> dict[str, Any]:
+    if key not in _TIER_KEYS:
+        raise ValueError(f"Invalid key {key!r}; must be one of {_TIER_KEYS}")
+
     out = Path(output_path)
     errors: list[str] = []
+    skipped: int = 0
+    existing_items: list[dict[str, Any]] = []
 
-    existing: dict[str, Any] = {}
-    if out.exists():
-        existing = json.loads(out.read_text())
-
-    existing_task = existing.get("task", task)
-    existing_source_dir = existing.get("source_dir", source_dir)
-
-    existing_items: list[dict[str, Any]] = existing.get(key, [])
-    existing_ids: set[str] = {item["id"] for item in existing_items if "id" in item}
-
-    for fp in file_paths:
-        p = Path(fp)
-        if not p.exists():
-            msg = f"File not found: {fp}"
-            if strict:
-                raise ValueError(msg)
-            errors.append(msg)
-            continue
+    with open(out, "a+b") as fh:
+        fcntl.flock(fh, fcntl.LOCK_EX)
         try:
-            item = json.loads(p.read_text())
-        except json.JSONDecodeError as exc:
-            msg = f"Invalid JSON in {fp}: {exc}"
-            if strict:
-                raise ValueError(msg) from exc
-            errors.append(msg)
-            continue
-        item_id = item.get("id")
-        if item_id not in existing_ids:
-            existing_items.append(item)
-            if item_id is not None:
-                existing_ids.add(item_id)
+            fh.seek(0)
+            content = fh.read()
+            existing: dict[str, Any] = json.loads(content) if content else {}
 
-    document: dict[str, Any] = {
-        "task": existing_task,
-        "source_dir": existing_source_dir,
-        key: existing_items,
-    }
-    write_versioned_json(out, document, schema_version=1)
+            existing_task = existing.get("task", task)
+            existing_source_dir = existing.get("source_dir", source_dir)
+
+            existing_items = existing.get(key, [])
+            existing_ids: set[str] = {item["id"] for item in existing_items if "id" in item}
+
+            for fp in file_paths:
+                p = Path(fp)
+                if not p.exists():
+                    msg = f"File not found: {fp}"
+                    if strict:
+                        raise ValueError(msg)
+                    errors.append(msg)
+                    continue
+                try:
+                    item = json.loads(p.read_text())
+                except json.JSONDecodeError as exc:
+                    msg = f"Invalid JSON in {fp}: {exc}"
+                    if strict:
+                        raise ValueError(msg) from exc
+                    errors.append(msg)
+                    continue
+                item_id = item.get("id")
+                if item_id not in existing_ids:
+                    existing_items.append(item)
+                    if item_id is not None:
+                        existing_ids.add(item_id)
+                else:
+                    _logger.debug("Skipping duplicate id %r from %s", item_id, fp)
+                    skipped += 1
+
+            document: dict[str, Any] = {
+                "task": existing_task,
+                "source_dir": existing_source_dir,
+                key: existing_items,
+            }
+            write_versioned_json(out, document, schema_version=1)
+        finally:
+            fcntl.flock(fh, fcntl.LOCK_UN)
 
     result: dict[str, Any] = {
         "merged_path": str(output_path),
         "item_count": str(len(existing_items)),
     }
+    if skipped:
+        result["skipped_count"] = str(skipped)
     if errors:
         result["errors"] = errors
     return result
@@ -78,7 +94,13 @@ def extract_item(
     output_path: str,
     **kwargs: Any,
 ) -> dict[str, Any]:
-    data: dict[str, Any] = json.loads(Path(source_path).read_text())
+    src = Path(source_path)
+    try:
+        data: dict[str, Any] = json.loads(src.read_text())
+    except FileNotFoundError:
+        raise ValueError(f"Source file not found: {source_path}") from None
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON in {source_path}: {exc}") from exc
     for tier_key in _TIER_KEYS:
         for item in data.get(tier_key, []):
             if item.get("id") == item_id:
@@ -100,7 +122,7 @@ def replace_item(
     with open(src, "rb") as fh:
         try:
             fcntl.flock(fh, fcntl.LOCK_EX)
-            data: dict[str, Any] = json.loads(src.read_text())
+            data: dict[str, Any] = json.loads(fh.read())
             for tier_key in _TIER_KEYS:
                 tier: list[dict[str, Any]] = data.get(tier_key, [])
                 for idx, item in enumerate(tier):
@@ -126,9 +148,7 @@ def build_plan_snapshot(
     source_dir: str = "",
     **kwargs: Any,
 ) -> dict[str, Any]:
-    from autoskillit.planner.schema import validate_phase_result
-
-    phases: list[dict[str, Any]] = []
+    phase_pairs: list[tuple[int, dict[str, Any]]] = []
     for p in sorted(Path(phases_dir).glob("*_result.json")):
         try:
             raw = json.loads(p.read_text())
@@ -142,9 +162,10 @@ def build_plan_snapshot(
             "goal": validated.get("goal", ""),
             "scope": validated.get("scope", []),
         }
-        phases.append(short)
+        phase_pairs.append((int(validated["ordering"]), short))
 
-    phases.sort(key=lambda ph: int(str(ph["id"])[1:]))
+    phase_pairs.sort(key=lambda x: x[0])
+    phases = [pair[1] for pair in phase_pairs]
 
     document: dict[str, Any] = {
         "task": task,

--- a/src/autoskillit/planner/merge.py
+++ b/src/autoskillit/planner/merge.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from autoskillit.core import atomic_write, get_logger, write_versioned_json
+from autoskillit.core import get_logger, write_versioned_json
 
 _logger = get_logger(__name__)
 
@@ -82,7 +82,7 @@ def extract_item(
     for tier_key in _TIER_KEYS:
         for item in data.get(tier_key, []):
             if item.get("id") == item_id:
-                atomic_write(Path(output_path), json.dumps(item))
+                write_versioned_json(Path(output_path), item, schema_version=1)
                 return {"extracted_path": str(output_path)}
     raise ValueError(f"Item {item_id!r} not found in {source_path}")
 

--- a/src/autoskillit/planner/merge.py
+++ b/src/autoskillit/planner/merge.py
@@ -60,10 +60,13 @@ def merge_files(
                     errors.append(msg)
                     continue
                 item_id = item.get("id")
+                if item_id is None:
+                    _logger.debug("Skipping item with no 'id' field from %s", fp)
+                    skipped += 1
+                    continue
                 if item_id not in existing_ids:
                     existing_items.append(item)
-                    if item_id is not None:
-                        existing_ids.add(item_id)
+                    existing_ids.add(item_id)
                 else:
                     _logger.debug("Skipping duplicate id %r from %s", item_id, fp)
                     skipped += 1

--- a/src/autoskillit/planner/merge.py
+++ b/src/autoskillit/planner/merge.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import fcntl
+import json
+from pathlib import Path
+from typing import Any
+
+from autoskillit.core import atomic_write, get_logger, write_versioned_json
+
+_logger = get_logger(__name__)
+
+_TIER_KEYS = ("phases", "assignments", "work_packages")
+
+
+def merge_files(
+    file_paths: list[str],
+    output_path: str,
+    key: str,
+    task: str = "",
+    source_dir: str = "",
+    strict: bool = True,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    out = Path(output_path)
+    errors: list[str] = []
+
+    existing: dict[str, Any] = {}
+    if out.exists():
+        existing = json.loads(out.read_text())
+
+    existing_task = existing.get("task", task)
+    existing_source_dir = existing.get("source_dir", source_dir)
+
+    existing_items: list[dict[str, Any]] = existing.get(key, [])
+    existing_ids: set[str] = {item["id"] for item in existing_items if "id" in item}
+
+    for fp in file_paths:
+        p = Path(fp)
+        if not p.exists():
+            msg = f"File not found: {fp}"
+            if strict:
+                raise ValueError(msg)
+            errors.append(msg)
+            continue
+        try:
+            item = json.loads(p.read_text())
+        except json.JSONDecodeError as exc:
+            msg = f"Invalid JSON in {fp}: {exc}"
+            if strict:
+                raise ValueError(msg) from exc
+            errors.append(msg)
+            continue
+        item_id = item.get("id")
+        if item_id not in existing_ids:
+            existing_items.append(item)
+            if item_id is not None:
+                existing_ids.add(item_id)
+
+    document: dict[str, Any] = {
+        "task": existing_task,
+        "source_dir": existing_source_dir,
+        key: existing_items,
+    }
+    write_versioned_json(out, document, schema_version=1)
+
+    result: dict[str, Any] = {
+        "merged_path": str(output_path),
+        "item_count": str(len(existing_items)),
+    }
+    if errors:
+        result["errors"] = errors
+    return result
+
+
+def extract_item(
+    source_path: str,
+    item_id: str,
+    output_path: str,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    data: dict[str, Any] = json.loads(Path(source_path).read_text())
+    for tier_key in _TIER_KEYS:
+        for item in data.get(tier_key, []):
+            if item.get("id") == item_id:
+                atomic_write(Path(output_path), json.dumps(item))
+                return {"extracted_path": str(output_path)}
+    raise ValueError(f"Item {item_id!r} not found in {source_path}")
+
+
+def replace_item(
+    source_path: str,
+    item_id: str,
+    replacement_path: str,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    replacement: dict[str, Any] = json.loads(Path(replacement_path).read_text())
+    src = Path(source_path)
+
+    found = False
+    with open(src, "rb") as fh:
+        try:
+            fcntl.flock(fh, fcntl.LOCK_EX)
+            data: dict[str, Any] = json.loads(src.read_text())
+            for tier_key in _TIER_KEYS:
+                tier: list[dict[str, Any]] = data.get(tier_key, [])
+                for idx, item in enumerate(tier):
+                    if item.get("id") == item_id:
+                        tier[idx] = replacement
+                        write_versioned_json(src, data, schema_version=1)
+                        found = True
+                        break
+                if found:
+                    break
+        finally:
+            fcntl.flock(fh, fcntl.LOCK_UN)
+
+    if not found:
+        raise ValueError(f"Item {item_id!r} not found in {source_path}")
+    return {"replaced_id": item_id, "updated_path": str(source_path)}
+
+
+def build_plan_snapshot(
+    phases_dir: str,
+    output_path: str,
+    task: str = "",
+    source_dir: str = "",
+    **kwargs: Any,
+) -> dict[str, Any]:
+    from autoskillit.planner.schema import validate_phase_result
+
+    phases: list[dict[str, Any]] = []
+    for p in sorted(Path(phases_dir).glob("*_result.json")):
+        try:
+            raw = json.loads(p.read_text())
+            validated = validate_phase_result(raw)
+        except (ValueError, json.JSONDecodeError) as exc:
+            _logger.warning("Skipping malformed phase file %s: %s", p, exc)
+            continue
+        short: dict[str, Any] = {
+            "id": validated["id"],
+            "name": validated["name"],
+            "goal": validated.get("goal", ""),
+            "scope": validated.get("scope", []),
+        }
+        phases.append(short)
+
+    phases.sort(key=lambda ph: int(str(ph["id"])[1:]))
+
+    document: dict[str, Any] = {
+        "task": task,
+        "source_dir": source_dir,
+        "phases": phases,
+    }
+    write_versioned_json(Path(output_path), document, schema_version=1)
+
+    return {
+        "snapshot_path": str(output_path),
+        "phase_ids": ",".join(ph["id"] for ph in phases),
+    }

--- a/src/autoskillit/planner/schema.py
+++ b/src/autoskillit/planner/schema.py
@@ -83,6 +83,7 @@ class WPShort(TypedDict):
     assignment_id: str
     phase_id: str
     name: str
+    goal: str
     scope: str
     estimated_files: list[str]
 

--- a/src/autoskillit/planner/schema.py
+++ b/src/autoskillit/planner/schema.py
@@ -42,6 +42,80 @@ class WPResult(TypedDict):
     acceptance_criteria: list[str]
 
 
+class PhaseShort(TypedDict):
+    id: str
+    name: str
+    goal: str
+    scope: list[str]
+
+
+class PhaseElaborated(TypedDict):
+    id: str
+    name: str
+    goal: str
+    scope: list[str]
+    technical_approach: str
+    relationship_notes: str
+    assignments_preview: list[str]
+    ordering: int
+
+
+class AssignmentShort(TypedDict):
+    id: str
+    phase_id: str
+    name: str
+    goal: str
+
+
+class AssignmentElaborated(TypedDict):
+    id: str
+    phase_id: str
+    name: str
+    goal: str
+    technical_approach: str
+    proposed_work_packages: list[dict]
+    dependency_notes: str
+    overlap_notes: str
+
+
+class WPShort(TypedDict):
+    id: str
+    assignment_id: str
+    phase_id: str
+    name: str
+    scope: str
+    estimated_files: list[str]
+
+
+class WPElaborated(TypedDict):
+    id: str
+    assignment_id: str
+    phase_id: str
+    name: str
+    scope: str
+    estimated_files: list[str]
+    goal: str
+    summary: str
+    technical_steps: list[str]
+    files_touched: list[str]
+    apis_defined: list[str]
+    apis_consumed: list[str]
+    depends_on: list[str]
+    deliverables: list[str]
+    acceptance_criteria: list[str]
+
+
+class _PlanDocumentBase(TypedDict):
+    task: str
+    source_dir: str
+
+
+class PlanDocument(_PlanDocumentBase, total=False):
+    phases: list[PhaseElaborated]
+    assignments: list[AssignmentElaborated]
+    work_packages: list[WPElaborated]
+
+
 class PlannerManifestItem(TypedDict):
     id: str
     name: str

--- a/src/autoskillit/planner/schema.py
+++ b/src/autoskillit/planner/schema.py
@@ -13,7 +13,7 @@ class PhaseResult(TypedDict):
     scope: list[str]
     ordering: int
     assignments_preview: list[str]
-    assignments: list[dict]
+    assignments: list[dict[str, Any]]
     relationship_notes: str
 
 
@@ -25,7 +25,7 @@ class AssignmentResult(TypedDict):
     phase_id: str
     goal: str
     technical_approach: str
-    proposed_work_packages: list[dict]
+    proposed_work_packages: list[dict[str, Any]]
 
 
 class WPResult(TypedDict):
@@ -73,7 +73,7 @@ class AssignmentElaborated(TypedDict):
     name: str
     goal: str
     technical_approach: str
-    proposed_work_packages: list[dict]
+    proposed_work_packages: list[dict[str, Any]]
     dependency_notes: str
     overlap_notes: str
 
@@ -111,9 +111,9 @@ class _PlanDocumentBase(TypedDict):
 
 
 class PlanDocument(_PlanDocumentBase, total=False):
-    phases: list[PhaseElaborated]
-    assignments: list[AssignmentElaborated]
-    work_packages: list[WPElaborated]
+    phases: list[PhaseShort | PhaseElaborated]
+    assignments: list[AssignmentShort | AssignmentElaborated]
+    work_packages: list[WPShort | WPElaborated]
 
 
 class PlannerManifestItem(TypedDict):

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -1780,6 +1780,8 @@ skills:
     outputs:
     - name: phase_manifest_path
       type: file_path
+    - name: phase_ids
+      type: str
     result_fields:
     - name: id
       type: str
@@ -1868,4 +1870,26 @@ callable_contracts:
     - name: plan_json_path
       type: file_path
     - name: plan_parts
+      type: str
+  autoskillit.planner.merge.merge_files:
+    outputs:
+    - name: merged_path
+      type: file_path
+    - name: item_count
+      type: str
+  autoskillit.planner.merge.extract_item:
+    outputs:
+    - name: extracted_path
+      type: file_path
+  autoskillit.planner.merge.replace_item:
+    outputs:
+    - name: updated_path
+      type: file_path
+    - name: replaced_id
+      type: str
+  autoskillit.planner.merge.build_plan_snapshot:
+    outputs:
+    - name: snapshot_path
+      type: file_path
+    - name: phase_ids
       type: str

--- a/src/autoskillit/skills_extended/planner-generate-phases/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-generate-phases/SKILL.md
@@ -38,7 +38,7 @@ Pass 1 entry point. Read the analysis file (and optionally domain knowledge) and
 - Write `$(dirname $1)/phases/{phase_id}_result.json` for every phase
 - Write `$(dirname $1)/phases/phase_manifest.json` with every item status=`done`
 - Use sequential `ordering` values starting at 1
-- Emit `phase_manifest_path` and `phase_count` output tokens
+- Emit `phase_manifest_path`, `phase_count`, and `phase_ids` output tokens
 
 ## Workflow
 
@@ -113,4 +113,5 @@ Manifest structure:
 ```
 phase_manifest_path = <absolute path to phase_manifest.json>
 phase_count = <N>
+phase_ids = <comma-separated list of phase IDs, e.g. P1,P2,P3>
 ```

--- a/tests/planner/test_merge.py
+++ b/tests/planner/test_merge.py
@@ -4,6 +4,8 @@ import json
 
 import pytest
 
+from autoskillit.planner.merge import build_plan_snapshot, extract_item, merge_files, replace_item
+
 pytestmark = [pytest.mark.layer("planner"), pytest.mark.small, pytest.mark.feature("planner")]
 
 
@@ -17,7 +19,6 @@ def test_merge_files_creates_combined_document(tmp_path):
         file_paths.append(str(p))
 
     out = tmp_path / "combined.json"
-    from autoskillit.planner.merge import merge_files
 
     result = merge_files(
         file_paths=file_paths,
@@ -41,8 +42,6 @@ def test_merge_files_schema_version_1(tmp_path):
     p.write_text(json.dumps({"id": "P1", "name": "x"}))
     out = tmp_path / "combined.json"
 
-    from autoskillit.planner.merge import merge_files
-
     merge_files(file_paths=[str(p)], output_path=str(out), key="phases")
 
     assert json.loads(out.read_text())["schema_version"] == 1
@@ -61,8 +60,6 @@ def test_merge_files_accumulates_existing(tmp_path):
     new_file = tmp_path / "p2.json"
     new_file.write_text(json.dumps({"id": "P2", "name": "Phase 2"}))
 
-    from autoskillit.planner.merge import merge_files
-
     result = merge_files(file_paths=[str(new_file)], output_path=str(out), key="phases")
 
     data = json.loads(out.read_text())
@@ -79,8 +76,6 @@ def test_merge_files_deduplicates_by_id(tmp_path):
     dup_file = tmp_path / "p1_dup.json"
     dup_file.write_text(json.dumps(item))
 
-    from autoskillit.planner.merge import merge_files
-
     merge_files(file_paths=[str(dup_file)], output_path=str(out), key="phases")
 
     assert len(json.loads(out.read_text())["phases"]) == 1
@@ -88,8 +83,6 @@ def test_merge_files_deduplicates_by_id(tmp_path):
 
 def test_merge_files_strict_raises_on_missing_file(tmp_path):
     """strict=True (default) raises ValueError for nonexistent input file."""
-    from autoskillit.planner.merge import merge_files
-
     with pytest.raises(ValueError, match="File not found"):
         merge_files(
             file_paths=["/nonexistent/path.json"],
@@ -100,8 +93,6 @@ def test_merge_files_strict_raises_on_missing_file(tmp_path):
 
 def test_merge_files_non_strict_collects_errors(tmp_path):
     """strict=False collects errors for missing files and continues."""
-    from autoskillit.planner.merge import merge_files
-
     result = merge_files(
         file_paths=["/nonexistent/path.json"],
         output_path=str(tmp_path / "out.json"),
@@ -116,7 +107,6 @@ def test_merge_files_non_strict_invalid_json(tmp_path):
     """strict=False collects errors for malformed JSON and continues."""
     bad = tmp_path / "bad.json"
     bad.write_text("not json{{{")
-    from autoskillit.planner.merge import merge_files
 
     result = merge_files(
         file_paths=[str(bad)],
@@ -127,6 +117,16 @@ def test_merge_files_non_strict_invalid_json(tmp_path):
     assert "errors" in result
 
 
+def test_merge_files_invalid_key_raises(tmp_path):
+    """merge_files raises ValueError for an unrecognised tier key."""
+    with pytest.raises(ValueError, match="Invalid key"):
+        merge_files(
+            file_paths=[],
+            output_path=str(tmp_path / "out.json"),
+            key="unknown_tier",
+        )
+
+
 def test_extract_item_writes_extracted_item(tmp_path):
     phases = [{"id": "P1", "name": "Phase 1"}, {"id": "P2", "name": "Phase 2"}]
     doc = {"task": "", "source_dir": "", "phases": phases, "schema_version": 1}
@@ -134,12 +134,12 @@ def test_extract_item_writes_extracted_item(tmp_path):
     src.write_text(json.dumps(doc))
     out = tmp_path / "extracted.json"
 
-    from autoskillit.planner.merge import extract_item
-
     result = extract_item(source_path=str(src), item_id="P2", output_path=str(out))
 
     assert result["extracted_path"] == str(out)
-    assert json.loads(out.read_text())["id"] == "P2"
+    extracted = json.loads(out.read_text())
+    assert extracted["id"] == "P2"
+    assert extracted["schema_version"] == 1
 
 
 def test_extract_item_missing_id_raises(tmp_path):
@@ -147,12 +147,19 @@ def test_extract_item_missing_id_raises(tmp_path):
     src = tmp_path / "combined.json"
     src.write_text(json.dumps(doc))
 
-    from autoskillit.planner.merge import extract_item
-
     with pytest.raises(ValueError, match="not found"):
         extract_item(
             source_path=str(src),
             item_id="MISSING",
+            output_path=str(tmp_path / "out.json"),
+        )
+
+
+def test_extract_item_missing_file_raises(tmp_path):
+    with pytest.raises(ValueError, match="Source file not found"):
+        extract_item(
+            source_path=str(tmp_path / "nonexistent.json"),
+            item_id="P1",
             output_path=str(tmp_path / "out.json"),
         )
 
@@ -171,8 +178,6 @@ def test_extract_item_searches_all_tiers(tmp_path):
     src.write_text(json.dumps(doc))
     out = tmp_path / "extracted.json"
 
-    from autoskillit.planner.merge import extract_item
-
     extract_item(source_path=str(src), item_id="P1-A1-WP1", output_path=str(out))
     assert json.loads(out.read_text())["id"] == "P1-A1-WP1"
 
@@ -185,8 +190,6 @@ def test_replace_item_updates_combined_document(tmp_path):
     rep_file = tmp_path / "rep.json"
     rep_file.write_text(json.dumps({"id": "P1", "name": "New", "goal": "updated"}))
 
-    from autoskillit.planner.merge import replace_item
-
     result = replace_item(source_path=str(src), item_id="P1", replacement_path=str(rep_file))
 
     assert result["replaced_id"] == "P1"
@@ -198,14 +201,58 @@ def test_replace_item_updates_combined_document(tmp_path):
     assert len(data["phases"]) == 2
 
 
+def test_replace_item_in_assignments_tier(tmp_path):
+    """replace_item correctly updates items in the assignments tier."""
+    doc = {
+        "task": "",
+        "source_dir": "",
+        "phases": [],
+        "assignments": [{"id": "P1-A1", "name": "Old assignment"}],
+        "schema_version": 1,
+    }
+    src = tmp_path / "combined.json"
+    src.write_text(json.dumps(doc))
+    rep_file = tmp_path / "rep.json"
+    rep_file.write_text(json.dumps({"id": "P1-A1", "name": "Updated assignment"}))
+
+    result = replace_item(source_path=str(src), item_id="P1-A1", replacement_path=str(rep_file))
+
+    assert result["replaced_id"] == "P1-A1"
+    data = json.loads(src.read_text())
+    a1 = next(a for a in data["assignments"] if a["id"] == "P1-A1")
+    assert a1["name"] == "Updated assignment"
+
+
+def test_replace_item_in_work_packages_tier(tmp_path):
+    """replace_item correctly updates items in the work_packages tier."""
+    doc = {
+        "task": "",
+        "source_dir": "",
+        "phases": [],
+        "work_packages": [{"id": "P1-A1-WP1", "name": "Old WP"}],
+        "schema_version": 1,
+    }
+    src = tmp_path / "combined.json"
+    src.write_text(json.dumps(doc))
+    rep_file = tmp_path / "rep.json"
+    rep_file.write_text(json.dumps({"id": "P1-A1-WP1", "name": "Updated WP"}))
+
+    result = replace_item(
+        source_path=str(src), item_id="P1-A1-WP1", replacement_path=str(rep_file)
+    )
+
+    assert result["replaced_id"] == "P1-A1-WP1"
+    data = json.loads(src.read_text())
+    wp1 = next(w for w in data["work_packages"] if w["id"] == "P1-A1-WP1")
+    assert wp1["name"] == "Updated WP"
+
+
 def test_replace_item_missing_id_raises(tmp_path):
     doc = {"task": "", "source_dir": "", "phases": [], "schema_version": 1}
     src = tmp_path / "combined.json"
     src.write_text(json.dumps(doc))
     rep_file = tmp_path / "rep.json"
     rep_file.write_text(json.dumps({"id": "MISSING"}))
-
-    from autoskillit.planner.merge import replace_item
 
     with pytest.raises(ValueError, match="not found"):
         replace_item(source_path=str(src), item_id="MISSING", replacement_path=str(rep_file))
@@ -223,8 +270,6 @@ def test_replace_item_preserves_schema_version(tmp_path):
     rep_file = tmp_path / "rep.json"
     rep_file.write_text(json.dumps({"id": "P1", "name": "updated"}))
 
-    from autoskillit.planner.merge import replace_item
-
     replace_item(source_path=str(src), item_id="P1", replacement_path=str(rep_file))
 
     assert json.loads(src.read_text())["schema_version"] == 1
@@ -241,8 +286,6 @@ def test_build_plan_snapshot_produces_phase_ids(tmp_path):
         }
         (phases_dir / f"{phase_id}_result.json").write_text(json.dumps(r))
     out = tmp_path / "snapshot.json"
-
-    from autoskillit.planner.merge import build_plan_snapshot
 
     result = build_plan_snapshot(
         phases_dir=str(phases_dir),
@@ -263,6 +306,7 @@ def test_build_plan_snapshot_writes_short_form_only(tmp_path):
     r = {
         "id": "P1",
         "name": "Phase One",
+        "goal": "some goal",
         "ordering": 1,
         "scope": ["s1"],
         "relationship_notes": "should not appear",
@@ -270,8 +314,6 @@ def test_build_plan_snapshot_writes_short_form_only(tmp_path):
     }
     (phases_dir / "P1_result.json").write_text(json.dumps(r))
     out = tmp_path / "snapshot.json"
-
-    from autoskillit.planner.merge import build_plan_snapshot
 
     build_plan_snapshot(
         phases_dir=str(phases_dir), output_path=str(out), task="t", source_dir="/s"

--- a/tests/planner/test_merge.py
+++ b/tests/planner/test_merge.py
@@ -29,7 +29,7 @@ def test_merge_files_creates_combined_document(tmp_path):
     )
 
     assert result["merged_path"] == str(out)
-    assert result["item_count"] == "2"
+    assert result["item_count"] == "2"  # item_count is always str per MCP tool contract
     data = json.loads(out.read_text())
     assert data["task"] == "my task"
     assert data["source_dir"] == "/src"
@@ -64,7 +64,7 @@ def test_merge_files_accumulates_existing(tmp_path):
 
     data = json.loads(out.read_text())
     assert len(data["phases"]) == 2
-    assert result["item_count"] == "2"
+    assert result["item_count"] == "2"  # item_count is always str per MCP tool contract
 
 
 def test_merge_files_deduplicates_by_id(tmp_path):

--- a/tests/planner/test_merge.py
+++ b/tests/planner/test_merge.py
@@ -187,9 +187,7 @@ def test_replace_item_updates_combined_document(tmp_path):
 
     from autoskillit.planner.merge import replace_item
 
-    result = replace_item(
-        source_path=str(src), item_id="P1", replacement_path=str(rep_file)
-    )
+    result = replace_item(source_path=str(src), item_id="P1", replacement_path=str(rep_file))
 
     assert result["replaced_id"] == "P1"
     assert result["updated_path"] == str(src)
@@ -210,9 +208,7 @@ def test_replace_item_missing_id_raises(tmp_path):
     from autoskillit.planner.merge import replace_item
 
     with pytest.raises(ValueError, match="not found"):
-        replace_item(
-            source_path=str(src), item_id="MISSING", replacement_path=str(rep_file)
-        )
+        replace_item(source_path=str(src), item_id="MISSING", replacement_path=str(rep_file))
 
 
 def test_replace_item_preserves_schema_version(tmp_path):

--- a/tests/planner/test_merge.py
+++ b/tests/planner/test_merge.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytestmark = [pytest.mark.layer("planner"), pytest.mark.small, pytest.mark.feature("planner")]
+
+
+def test_merge_files_creates_combined_document(tmp_path):
+    """merge_files writes a PlanDocument with the given key populated."""
+    items = [{"id": "P1", "name": "Phase 1"}, {"id": "P2", "name": "Phase 2"}]
+    file_paths = []
+    for item in items:
+        p = tmp_path / f"{item['id']}_result.json"
+        p.write_text(json.dumps(item))
+        file_paths.append(str(p))
+
+    out = tmp_path / "combined.json"
+    from autoskillit.planner.merge import merge_files
+
+    result = merge_files(
+        file_paths=file_paths,
+        output_path=str(out),
+        key="phases",
+        task="my task",
+        source_dir="/src",
+    )
+
+    assert result["merged_path"] == str(out)
+    assert result["item_count"] == "2"
+    data = json.loads(out.read_text())
+    assert data["task"] == "my task"
+    assert data["source_dir"] == "/src"
+    assert {p["id"] for p in data["phases"]} == {"P1", "P2"}
+
+
+def test_merge_files_schema_version_1(tmp_path):
+    """Output always carries schema_version: 1."""
+    p = tmp_path / "p1.json"
+    p.write_text(json.dumps({"id": "P1", "name": "x"}))
+    out = tmp_path / "combined.json"
+
+    from autoskillit.planner.merge import merge_files
+
+    merge_files(file_paths=[str(p)], output_path=str(out), key="phases")
+
+    assert json.loads(out.read_text())["schema_version"] == 1
+
+
+def test_merge_files_accumulates_existing(tmp_path):
+    """merge_files appends to existing key list when output already exists."""
+    existing = {
+        "task": "t",
+        "source_dir": "/s",
+        "phases": [{"id": "P1", "name": "Phase 1"}],
+        "schema_version": 1,
+    }
+    out = tmp_path / "combined.json"
+    out.write_text(json.dumps(existing))
+    new_file = tmp_path / "p2.json"
+    new_file.write_text(json.dumps({"id": "P2", "name": "Phase 2"}))
+
+    from autoskillit.planner.merge import merge_files
+
+    result = merge_files(file_paths=[str(new_file)], output_path=str(out), key="phases")
+
+    data = json.loads(out.read_text())
+    assert len(data["phases"]) == 2
+    assert result["item_count"] == "2"
+
+
+def test_merge_files_deduplicates_by_id(tmp_path):
+    """Re-merging a file with same id does not create duplicates."""
+    item = {"id": "P1", "name": "Phase 1"}
+    existing = {"task": "", "source_dir": "", "phases": [item], "schema_version": 1}
+    out = tmp_path / "combined.json"
+    out.write_text(json.dumps(existing))
+    dup_file = tmp_path / "p1_dup.json"
+    dup_file.write_text(json.dumps(item))
+
+    from autoskillit.planner.merge import merge_files
+
+    merge_files(file_paths=[str(dup_file)], output_path=str(out), key="phases")
+
+    assert len(json.loads(out.read_text())["phases"]) == 1
+
+
+def test_merge_files_strict_raises_on_missing_file(tmp_path):
+    """strict=True (default) raises ValueError for nonexistent input file."""
+    from autoskillit.planner.merge import merge_files
+
+    with pytest.raises(ValueError, match="File not found"):
+        merge_files(
+            file_paths=["/nonexistent/path.json"],
+            output_path=str(tmp_path / "out.json"),
+            key="phases",
+        )
+
+
+def test_merge_files_non_strict_collects_errors(tmp_path):
+    """strict=False collects errors for missing files and continues."""
+    from autoskillit.planner.merge import merge_files
+
+    result = merge_files(
+        file_paths=["/nonexistent/path.json"],
+        output_path=str(tmp_path / "out.json"),
+        key="phases",
+        strict=False,
+    )
+    assert "errors" in result
+    assert len(result["errors"]) == 1
+
+
+def test_merge_files_non_strict_invalid_json(tmp_path):
+    """strict=False collects errors for malformed JSON and continues."""
+    bad = tmp_path / "bad.json"
+    bad.write_text("not json{{{")
+    from autoskillit.planner.merge import merge_files
+
+    result = merge_files(
+        file_paths=[str(bad)],
+        output_path=str(tmp_path / "out.json"),
+        key="phases",
+        strict=False,
+    )
+    assert "errors" in result
+
+
+def test_extract_item_writes_extracted_item(tmp_path):
+    phases = [{"id": "P1", "name": "Phase 1"}, {"id": "P2", "name": "Phase 2"}]
+    doc = {"task": "", "source_dir": "", "phases": phases, "schema_version": 1}
+    src = tmp_path / "combined.json"
+    src.write_text(json.dumps(doc))
+    out = tmp_path / "extracted.json"
+
+    from autoskillit.planner.merge import extract_item
+
+    result = extract_item(source_path=str(src), item_id="P2", output_path=str(out))
+
+    assert result["extracted_path"] == str(out)
+    assert json.loads(out.read_text())["id"] == "P2"
+
+
+def test_extract_item_missing_id_raises(tmp_path):
+    doc = {"task": "", "source_dir": "", "phases": [], "schema_version": 1}
+    src = tmp_path / "combined.json"
+    src.write_text(json.dumps(doc))
+
+    from autoskillit.planner.merge import extract_item
+
+    with pytest.raises(ValueError, match="not found"):
+        extract_item(
+            source_path=str(src),
+            item_id="MISSING",
+            output_path=str(tmp_path / "out.json"),
+        )
+
+
+def test_extract_item_searches_all_tiers(tmp_path):
+    """extract_item finds items in phases, assignments, and work_packages."""
+    doc = {
+        "task": "",
+        "source_dir": "",
+        "phases": [{"id": "P1"}],
+        "assignments": [{"id": "P1-A1"}],
+        "work_packages": [{"id": "P1-A1-WP1"}],
+        "schema_version": 1,
+    }
+    src = tmp_path / "combined.json"
+    src.write_text(json.dumps(doc))
+    out = tmp_path / "extracted.json"
+
+    from autoskillit.planner.merge import extract_item
+
+    extract_item(source_path=str(src), item_id="P1-A1-WP1", output_path=str(out))
+    assert json.loads(out.read_text())["id"] == "P1-A1-WP1"
+
+
+def test_replace_item_updates_combined_document(tmp_path):
+    phases = [{"id": "P1", "name": "Old"}, {"id": "P2", "name": "Phase 2"}]
+    doc = {"task": "", "source_dir": "", "phases": phases, "schema_version": 1}
+    src = tmp_path / "combined.json"
+    src.write_text(json.dumps(doc))
+    rep_file = tmp_path / "rep.json"
+    rep_file.write_text(json.dumps({"id": "P1", "name": "New", "goal": "updated"}))
+
+    from autoskillit.planner.merge import replace_item
+
+    result = replace_item(
+        source_path=str(src), item_id="P1", replacement_path=str(rep_file)
+    )
+
+    assert result["replaced_id"] == "P1"
+    assert result["updated_path"] == str(src)
+    data = json.loads(src.read_text())
+    p1 = next(p for p in data["phases"] if p["id"] == "P1")
+    assert p1["name"] == "New"
+    assert p1["goal"] == "updated"
+    assert len(data["phases"]) == 2
+
+
+def test_replace_item_missing_id_raises(tmp_path):
+    doc = {"task": "", "source_dir": "", "phases": [], "schema_version": 1}
+    src = tmp_path / "combined.json"
+    src.write_text(json.dumps(doc))
+    rep_file = tmp_path / "rep.json"
+    rep_file.write_text(json.dumps({"id": "MISSING"}))
+
+    from autoskillit.planner.merge import replace_item
+
+    with pytest.raises(ValueError, match="not found"):
+        replace_item(
+            source_path=str(src), item_id="MISSING", replacement_path=str(rep_file)
+        )
+
+
+def test_replace_item_preserves_schema_version(tmp_path):
+    doc = {
+        "task": "",
+        "source_dir": "",
+        "phases": [{"id": "P1", "name": "x"}],
+        "schema_version": 1,
+    }
+    src = tmp_path / "combined.json"
+    src.write_text(json.dumps(doc))
+    rep_file = tmp_path / "rep.json"
+    rep_file.write_text(json.dumps({"id": "P1", "name": "updated"}))
+
+    from autoskillit.planner.merge import replace_item
+
+    replace_item(source_path=str(src), item_id="P1", replacement_path=str(rep_file))
+
+    assert json.loads(src.read_text())["schema_version"] == 1
+
+
+def test_build_plan_snapshot_produces_phase_ids(tmp_path):
+    phases_dir = tmp_path / "phases"
+    phases_dir.mkdir()
+    for phase_id in ["P1", "P2"]:
+        r = {
+            "id": phase_id,
+            "name": f"Phase {phase_id[1:]}",
+            "ordering": int(phase_id[1:]),
+        }
+        (phases_dir / f"{phase_id}_result.json").write_text(json.dumps(r))
+    out = tmp_path / "snapshot.json"
+
+    from autoskillit.planner.merge import build_plan_snapshot
+
+    result = build_plan_snapshot(
+        phases_dir=str(phases_dir),
+        output_path=str(out),
+        task="my task",
+        source_dir="/src",
+    )
+
+    assert result["snapshot_path"] == str(out)
+    assert "P1" in result["phase_ids"]
+    assert "P2" in result["phase_ids"]
+
+
+def test_build_plan_snapshot_writes_short_form_only(tmp_path):
+    """Snapshot phases contain only PhaseShort fields: id, name, goal, scope."""
+    phases_dir = tmp_path / "phases"
+    phases_dir.mkdir()
+    r = {
+        "id": "P1",
+        "name": "Phase One",
+        "ordering": 1,
+        "scope": ["s1"],
+        "relationship_notes": "should not appear",
+        "assignments_preview": ["A1"],
+    }
+    (phases_dir / "P1_result.json").write_text(json.dumps(r))
+    out = tmp_path / "snapshot.json"
+
+    from autoskillit.planner.merge import build_plan_snapshot
+
+    build_plan_snapshot(
+        phases_dir=str(phases_dir), output_path=str(out), task="t", source_dir="/s"
+    )
+
+    data = json.loads(out.read_text())
+    assert data["task"] == "t"
+    assert data["source_dir"] == "/s"
+    assert data["schema_version"] == 1
+    phase = data["phases"][0]
+    assert set(phase.keys()) == {"id", "name", "goal", "scope"}

--- a/tests/planner/test_planner.py
+++ b/tests/planner/test_planner.py
@@ -17,7 +17,6 @@ def test_planner_all_exports_callables() -> None:
     from autoskillit.planner import __all__
 
     assert set(__all__) == {
-        # Existing
         "check_remaining",
         "build_assignment_manifest",
         "build_wp_manifest",
@@ -26,7 +25,6 @@ def test_planner_all_exports_callables() -> None:
         "PlannerManifest",
         "PlannerManifestItem",
         "create_run_dir",
-        # New in Issue 01
         "merge_files",
         "extract_item",
         "replace_item",

--- a/tests/planner/test_planner.py
+++ b/tests/planner/test_planner.py
@@ -17,6 +17,7 @@ def test_planner_all_exports_callables() -> None:
     from autoskillit.planner import __all__
 
     assert set(__all__) == {
+        # Existing
         "check_remaining",
         "build_assignment_manifest",
         "build_wp_manifest",
@@ -25,6 +26,18 @@ def test_planner_all_exports_callables() -> None:
         "PlannerManifest",
         "PlannerManifestItem",
         "create_run_dir",
+        # New in Issue 01
+        "merge_files",
+        "extract_item",
+        "replace_item",
+        "build_plan_snapshot",
+        "PlanDocument",
+        "PhaseShort",
+        "PhaseElaborated",
+        "AssignmentShort",
+        "AssignmentElaborated",
+        "WPShort",
+        "WPElaborated",
     }
 
 


### PR DESCRIPTION
## Summary

Define the JSON interchange TypedDicts for all three planner tiers (short-form and
elaborated) and build three run_python callables (`merge_files`, `extract_item`,
`replace_item`) plus a `build_plan_snapshot` callable in a new
`src/autoskillit/planner/merge.py` module. Also update `planner-generate-phases`
skill_contracts.yaml entry to emit `phase_ids`. This is the foundation layer for all
subsequent planner redesign issues — no runtime behavior changes, only new schema
definitions and file-manipulation primitives.

## Architecture Impact

### Data Lineage Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph Inputs ["Data Origins"]
        ANALYSIS["analysis.json<br/>━━━━━━━━━━<br/>planner-analyze output<br/>Project decomposition"]
        DOMAIN["domain_knowledge.md<br/>━━━━━━━━━━<br/>Optional domain context<br/>planner-extract-domain"]
    end

    subgraph SkillGen ["● planner-generate-phases (modified SKILL.md)"]
        SKILL["planner-generate-phases<br/>━━━━━━━━━━<br/>LLM skill session<br/>Produces 3–6 phases"]
    end

    subgraph ResultFiles ["Per-Item Result Files (.autoskillit/temp/planner/)"]
        direction TB
        PHASE_RESULT["phases/{id}_result.json<br/>━━━━━━━━━━<br/>id, name, goal, scope<br/>ordering, assignments_preview"]
        ASSIGN_RESULT["assignments/{id}_result.json<br/>━━━━━━━━━━<br/>id, phase_id, goal<br/>proposed_work_packages"]
        WP_RESULT["work_packages/{id}_result.json<br/>━━━━━━━━━━<br/>id, name, deliverables<br/>files_touched, apis_defined"]
    end

    subgraph SchemaValidation ["● planner/schema.py — Validation & TypedDicts"]
        direction TB
        VAL_PHASE["validate_phase_result()<br/>━━━━━━━━━━<br/>Derives phase_number<br/>name_slug, assignments[]"]
        VAL_ASSIGN["validate_assignment_result()<br/>━━━━━━━━━━<br/>Derives phase_number<br/>assignment_number, phase_id"]
        VAL_WP["validate_wp_result()<br/>━━━━━━━━━━<br/>Defaults summary, goal<br/>technical_steps, depends_on"]
        TYPED_DICTS["TypedDicts (new interchange)<br/>━━━━━━━━━━<br/>PlanDocument<br/>PhaseShort / PhaseElaborated<br/>AssignmentShort / AssignmentElaborated<br/>WPShort / WPElaborated"]
    end

    subgraph Manifests ["Manifest Storage (source of truth for pass state)"]
        direction TB
        PHASE_MANIFEST["phases/phase_manifest.json<br/>━━━━━━━━━━<br/>PlannerManifest schema<br/>pass_name, result_dir, items[]"]
        ASSIGN_MANIFEST["assignments/assignment_manifest.json<br/>━━━━━━━━━━<br/>PlannerManifest schema<br/>items: pending→processing→done"]
        WP_MANIFEST["work_packages/wp_manifest.json<br/>━━━━━━━━━━<br/>PlannerManifest schema<br/>+ wp_index.json (id/name/summary)"]
        CONTEXT_JSON["context_{id}.json<br/>━━━━━━━━━━<br/>check_remaining() output<br/>prior_results, wp_index_path"]
    end

    subgraph MergeTooling ["★ planner/merge.py — New Interchange Operations"]
        direction TB
        MERGE_FILES["merge_files()<br/>━━━━━━━━━━<br/>Multi-file aggregation<br/>Dedup by item ID<br/>→ PlanDocument"]
        BUILD_SNAP["build_plan_snapshot()<br/>━━━━━━━━━━<br/>Scans *_result.json<br/>Validates via schema<br/>→ phases PlanDocument"]
        EXTRACT["extract_item()<br/>━━━━━━━━━━<br/>Searches tiers:<br/>phases/assignments/wps<br/>→ single item JSON"]
        REPLACE["replace_item()<br/>━━━━━━━━━━<br/>flock atomic R-M-W<br/>Replaces item by ID<br/>in PlanDocument"]
    end

    subgraph PlanDocs ["★ PlanDocument Files (versioned interchange, schema_version=1)"]
        direction TB
        PLAN_DOC["merged_plan.json<br/>━━━━━━━━━━<br/>PlanDocument schema<br/>task + source_dir<br/>+ phases[] / assignments[] / wps[]"]
        PHASE_SNAP["phases_snapshot.json<br/>━━━━━━━━━━<br/>PlanDocument schema<br/>PhaseShort[] tier only<br/>Built from *_result.json"]
    end

    subgraph Artifacts ["Write-Only Artifacts"]
        WP_INDEX["wp_index.json<br/>━━━━━━━━━━<br/>id/name/summary index<br/>For WP lookup"]
    end

    %% INPUT → SKILL
    ANALYSIS -->|"$1 arg"| SKILL
    DOMAIN -->|"$2 optional"| SKILL

    %% SKILL → RESULT FILES
    SKILL -->|"write JSON"| PHASE_RESULT
    SKILL -->|"write JSON"| PHASE_MANIFEST

    %% RESULT FILES → SCHEMA VALIDATION
    PHASE_RESULT -->|"json.loads()"| VAL_PHASE
    ASSIGN_RESULT -->|"json.loads()"| VAL_ASSIGN
    WP_RESULT -->|"json.loads()"| VAL_WP

    %% VALIDATION → MANIFESTS
    VAL_PHASE -->|"build_assignment_manifest()"| ASSIGN_MANIFEST
    VAL_ASSIGN -->|"build_wp_manifest()"| WP_MANIFEST
    WP_MANIFEST -.->|"atomic_write([])"| WP_INDEX

    %% MANIFESTS → CONTEXT (check_remaining)
    PHASE_MANIFEST -->|"check_remaining()"| CONTEXT_JSON
    ASSIGN_MANIFEST -->|"check_remaining()"| CONTEXT_JSON

    %% RESULT FILES → MERGE TOOLING
    PHASE_RESULT -->|"file_paths[]"| MERGE_FILES
    ASSIGN_RESULT -->|"file_paths[]"| MERGE_FILES
    WP_RESULT -->|"file_paths[]"| MERGE_FILES

    %% build_plan_snapshot reads phase results via validate
    PHASE_RESULT -->|"glob *_result.json"| BUILD_SNAP
    VAL_PHASE -->|"validate_phase_result()"| BUILD_SNAP

    %% MERGE → PLAN DOCS
    MERGE_FILES -->|"write_versioned_json"| PLAN_DOC
    BUILD_SNAP -->|"write_versioned_json"| PHASE_SNAP

    %% EXTRACT / REPLACE operate on PlanDocs
    PLAN_DOC -->|"json.loads()"| EXTRACT
    PLAN_DOC -->|"flock + json.loads()"| REPLACE
    EXTRACT -.->|"write_versioned_json"| WP_RESULT
    REPLACE -->|"write_versioned_json in-place"| PLAN_DOC

    %% SCHEMA TYPED DICTS (informational)
    TYPED_DICTS -. "defines shape" .-> PLAN_DOC

    %% CLASS ASSIGNMENTS %%
    class ANALYSIS,DOMAIN cli;
    class SKILL integration;
    class PHASE_RESULT,ASSIGN_RESULT,WP_RESULT stateNode;
    class VAL_PHASE,VAL_ASSIGN,VAL_WP handler;
    class TYPED_DICTS phase;
    class PHASE_MANIFEST,ASSIGN_MANIFEST,WP_MANIFEST,CONTEXT_JSON stateNode;
    class MERGE_FILES,BUILD_SNAP,EXTRACT,REPLACE newComponent;
    class PLAN_DOC,PHASE_SNAP newComponent;
    class WP_INDEX output;
```

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph L2 ["LAYER 2 — RECIPE"]
        direction LR
        RCONTRACTS["● recipe/rules_contracts.py<br/>━━━━━━━━━━<br/>Skill contract validation<br/>fan-in: PHASE/ASSIGN/WP keys"]
    end

    subgraph L1 ["LAYER 1 — PLANNER PACKAGE"]
        direction TB
        PINIT["● planner/__init__.py<br/>━━━━━━━━━━<br/>Public API gateway<br/>re-exports all 19 symbols<br/>compile_plan · check_remaining<br/>merge_files · extract_item · replace_item<br/>build_plan_snapshot · validate_plan<br/>TypedDicts · required-key frozensets"]

        subgraph PlannerSubs ["Planner Submodules"]
            direction LR
            PMERGE["★ planner/merge.py<br/>━━━━━━━━━━<br/>merge_files · extract_item<br/>replace_item · build_plan_snapshot<br/>file-level JSON merge/extract/replace"]
            PMANIFESTS["planner/manifests.py<br/>━━━━━━━━━━<br/>build_assignment_manifest<br/>build_wp_manifest · check_remaining<br/>manifest state machine"]
            PCOMPILER["planner/compiler.py<br/>━━━━━━━━━━<br/>compile_plan<br/>topological sort<br/>issue body + milestone gen"]
            PVALIDATION["planner/validation.py<br/>━━━━━━━━━━<br/>validate_plan<br/>DAG cycle check · sizing bounds<br/>_load_*_results (private)"]
            PSCHEMA["● planner/schema.py<br/>━━━━━━━━━━<br/>TypedDicts: PlanDocument<br/>PlannerManifest · Phase/WP/Assignment<br/>validate_*_result functions<br/>pure stdlib — leaf node"]
        end
    end

    subgraph L0 ["LAYER 0 — CORE"]
        direction LR
        CORE["autoskillit.core<br/>━━━━━━━━━━<br/>get_logger<br/>atomic_write<br/>write_versioned_json"]
    end

    subgraph Tests ["TESTS (deferred imports only)"]
        direction LR
        TMERGE["★ tests/planner/test_merge.py<br/>━━━━━━━━━━<br/>merge_files · extract_item<br/>replace_item · build_plan_snapshot"]
        TPLANNER["● tests/planner/test_planner.py<br/>━━━━━━━━━━<br/>autoskillit.planner API surface<br/>__all__ completeness"]
    end

    %% LAYER 2 → LAYER 1 (deferred, REQ-COMP-009) %%
    RCONTRACTS -.->|"deferred import<br/>REQ-COMP-009"| PINIT

    %% __init__ → submodules (re-export aggregation) %%
    PINIT --> PMERGE
    PINIT --> PMANIFESTS
    PINIT --> PCOMPILER
    PINIT --> PSCHEMA
    PINIT --> PVALIDATION

    %% Intra-planner dependencies %%
    PMERGE -.->|"deferred import<br/>(inside build_plan_snapshot)"| PSCHEMA
    PMANIFESTS -->|"validate_assignment_result<br/>validate_phase_result"| PSCHEMA
    PVALIDATION -->|"validate_*_result × 3"| PSCHEMA
    PCOMPILER -->|"_load_*_results × 3<br/>(private loader fns)"| PVALIDATION

    %% Planner submodules → Core %%
    PMERGE -->|"get_logger<br/>write_versioned_json"| CORE
    PMANIFESTS -->|"atomic_write<br/>get_logger<br/>write_versioned_json"| CORE
    PVALIDATION -->|"get_logger<br/>write_versioned_json"| CORE
    PCOMPILER -->|"atomic_write<br/>get_logger<br/>write_versioned_json"| CORE

    %% Tests → Planner (all deferred, inside test functions) %%
    TMERGE -.->|"deferred imports<br/>in test functions"| PMERGE
    TPLANNER -.->|"deferred imports<br/>in test functions"| PINIT

    %% CLASS ASSIGNMENTS %%
    class RCONTRACTS phase;
    class PINIT handler;
    class PMERGE newComponent;
    class PMANIFESTS,PCOMPILER handler;
    class PVALIDATION detector;
    class PSCHEMA stateNode;
    class CORE integration;
    class TMERGE newComponent;
    class TPLANNER phase;
```

Closes #1348

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260426-235028-638953/.autoskillit/temp/make-plan/planner_redesign_json_interchange_schemas_merge_tooling_plan_2026-04-26_235500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 163 | 28.8k | 838.2k | 71.9k | 1 | 8m 56s |
| verify | 188 | 14.2k | 1.2M | 104.3k | 1 | 4m 21s |
| implement | 236 | 14.0k | 1.4M | 53.1k | 1 | 6m 3s |
| fix | 166 | 5.7k | 914.9k | 52.9k | 1 | 5m 32s |
| prepare_pr | 60 | 3.9k | 198.4k | 43.3k | 1 | 1m 15s |
| run_arch_lenses | 142 | 14.5k | 426.0k | 129.6k | 2 | 4m 59s |
| compose_pr | 59 | 7.1k | 206.5k | 30.9k | 1 | 2m 7s |
| **Total** | 1.0k | 88.1k | 5.2M | 486.0k | | 33m 15s |