### PR TITLE
feat: extend TestCheckConfig with ordered commands list for multi-surface test gates

### DIFF
--- a/src/autoskillit/cli/_cook.py
+++ b/src/autoskillit/cli/_cook.py
@@ -112,7 +112,6 @@ def cook(*, resume: bool = False, session_id: str | None = None) -> None:
     from autoskillit.core import (
         _AUTOSKILLIT_PLUGIN_KEY,
         LAUNCH_ID_ENV_VAR,
-        MARKETPLACE_PREFIX,
         SESSION_TYPE_COOK,
         SESSION_TYPE_ENV_VAR,
         BareResume,

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -118,7 +118,7 @@ def serve(*, verbose: Annotated[bool, Parameter(name=["--verbose", "-v"])] = Fal
     get_logger(__name__).info(
         "serve_startup",
         config_path=resolved_path,
-        test_check_command=cfg.test_check.command,
+        test_check_command=cfg.test_check.commands or cfg.test_check.command,
     )
 
     # Inject config-derived protected branches so hook scripts read consistent values.

--- a/src/autoskillit/config/defaults.yaml
+++ b/src/autoskillit/config/defaults.yaml
@@ -13,6 +13,7 @@ test_check:
   timeout: 600
   filter_mode: null
   base_ref: null
+  commands: null
 
 classify_fix:
   path_prefixes: []

--- a/src/autoskillit/config/defaults.yaml
+++ b/src/autoskillit/config/defaults.yaml
@@ -7,9 +7,6 @@
 #   5. AUTOSKILLIT_SECTION__KEY=value environment variables
 
 test_check:
-  command:
-    - task
-    - test-check
   timeout: 600
   filter_mode: null
   base_ref: null

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -45,23 +45,33 @@ _SECRETS_ONLY_KEYS: frozenset[str] = frozenset({"github.token"})
 _METADATA_KEYS: frozenset[str] = frozenset({"version"})
 
 
-_DEFAULT_COMMAND: list[str] = ["task", "test-check"]
+_DEFAULT_COMMAND: tuple[str, ...] = ("task", "test-check")
+
+# Unique sentinel object — identity check in __post_init__ detects whether
+# `command` was explicitly supplied by the caller or left at its default.
+_COMMAND_UNSET: list[str] = []
 
 
 @dataclass
 class TestCheckConfig:
-    command: list[str] = field(default_factory=lambda: list(_DEFAULT_COMMAND))
+    command: list[str] = field(default_factory=lambda: _COMMAND_UNSET)
     timeout: int = 600
     filter_mode: str | None = None
     base_ref: str | None = None
     commands: list[list[str]] | None = None
 
     def __post_init__(self) -> None:
-        if self.commands is not None and self.command != _DEFAULT_COMMAND:
+        if self.command is _COMMAND_UNSET:
+            self.command = list(_DEFAULT_COMMAND)
+        elif self.commands is not None:
             raise ConfigSchemaError(
                 "test_check: 'command' and 'commands' are mutually exclusive; "
                 "omit 'command' when using 'commands'"
             )
+
+    @property
+    def effective_commands(self) -> list[list[str]]:
+        return self.commands if self.commands is not None else [self.command]
 
 
 @dataclass
@@ -482,9 +492,10 @@ class AutomationConfig:
             dict(feat) if isinstance(feat, dict) else {}
         )
 
+        _raw_command = val(tc, "command", None)
         result = cls(
             test_check=TestCheckConfig(
-                command=list(val(tc, "command", _tc["command"])),
+                command=list(_raw_command) if _raw_command is not None else _COMMAND_UNSET,
                 timeout=int(val(tc, "timeout", _tc["timeout"])),
                 filter_mode=val(tc, "filter_mode", _tc["filter_mode"]) or None,
                 base_ref=val(tc, "base_ref", _tc["base_ref"]) or None,
@@ -804,6 +815,8 @@ def _to_optional_commands(value: Any) -> list[list[str]] | None:
     """Return None if value is falsy, else coerce to list[list[str]]."""
     if not value:
         return None
+    if not isinstance(value, list) or any(not isinstance(cmd, (list, tuple)) for cmd in value):
+        raise ConfigSchemaError(f"test_check.commands must be a list of lists, got: {value!r}")
     return [list(cmd) for cmd in value]
 
 

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -45,12 +45,23 @@ _SECRETS_ONLY_KEYS: frozenset[str] = frozenset({"github.token"})
 _METADATA_KEYS: frozenset[str] = frozenset({"version"})
 
 
+_DEFAULT_COMMAND: list[str] = ["task", "test-check"]
+
+
 @dataclass
 class TestCheckConfig:
-    command: list[str] = field(default_factory=lambda: ["task", "test-check"])
+    command: list[str] = field(default_factory=lambda: list(_DEFAULT_COMMAND))
     timeout: int = 600
     filter_mode: str | None = None
     base_ref: str | None = None
+    commands: list[list[str]] | None = None
+
+    def __post_init__(self) -> None:
+        if self.commands is not None and self.command != _DEFAULT_COMMAND:
+            raise ConfigSchemaError(
+                "test_check: 'command' and 'commands' are mutually exclusive; "
+                "omit 'command' when using 'commands'"
+            )
 
 
 @dataclass
@@ -477,6 +488,7 @@ class AutomationConfig:
                 timeout=int(val(tc, "timeout", _tc["timeout"])),
                 filter_mode=val(tc, "filter_mode", _tc["filter_mode"]) or None,
                 base_ref=val(tc, "base_ref", _tc["base_ref"]) or None,
+                commands=_to_optional_commands(val(tc, "commands", _tc["commands"])),
             ),
             classify_fix=ClassifyFixConfig(
                 path_prefixes=list(val(cf, "path_prefixes", _cf["path_prefixes"])),
@@ -786,6 +798,13 @@ def _to_optional_list(value: Any) -> list[str] | None:
     if not value:
         return None
     return list(value)
+
+
+def _to_optional_commands(value: Any) -> list[list[str]] | None:
+    """Return None if value is falsy, else coerce to list[list[str]]."""
+    if not value:
+        return None
+    return [list(cmd) for cmd in value]
 
 
 def _apply_layer(base: dict[str, Any], override: dict[str, Any]) -> None:

--- a/src/autoskillit/execution/testing.py
+++ b/src/autoskillit/execution/testing.py
@@ -201,7 +201,7 @@ class DefaultTestRunner:
         self._runner = runner
 
     async def run(self, cwd: Path) -> TestResult:
-        command = self._config.test_check.command
+        effective_commands = self._config.test_check.commands or [self._config.test_check.command]
         timeout = float(self._config.test_check.timeout)
         env = build_sanitized_env()
 
@@ -217,21 +217,38 @@ class DefaultTestRunner:
         if base_ref:
             env["AUTOSKILLIT_TEST_BASE_REF"] = base_ref
 
-        # Create sidecar for conftest to write filter stats into
         fd, sidecar_path = tempfile.mkstemp(suffix=".json", prefix="filter-stats-")
         os.close(fd)
         env["AUTOSKILLIT_FILTER_STATS_FILE"] = sidecar_path
 
+        total = len(effective_commands)
+        stdout_parts: list[str] = []
+        last_result = None
         elapsed: float = 0.0
         stat_filter_mode: str | None = None
         stat_tests_selected: int | None = None
         stat_tests_deselected: int | None = None
         start = time.monotonic()
+        deadline = start + timeout
+
         try:
-            result = await self._runner(command, cwd=cwd, timeout=timeout, env=env)
+            for idx, command in enumerate(effective_commands, 1):
+                remaining = deadline - time.monotonic()
+                if remaining < 0.01:
+                    break
+                result = await self._runner(command, cwd=cwd, timeout=remaining, env=env)
+                last_result = result
+                if total > 1:
+                    stdout_parts.append(
+                        f"=== [{idx}/{total}] {' '.join(command)} ===\n{result.stdout}"
+                    )
+                else:
+                    stdout_parts.append(result.stdout)
+                if result.returncode != 0:
+                    break
+
             elapsed = time.monotonic() - start
 
-            # Read filter stats sidecar (written by conftest pytest_sessionfinish)
             sidecar = Path(sidecar_path)
             if sidecar.is_file() and sidecar.stat().st_size > 0:
                 try:
@@ -248,11 +265,15 @@ class DefaultTestRunner:
         finally:
             Path(sidecar_path).unlink(missing_ok=True)
 
-        passed = check_test_passed(result.returncode, result.stdout, result.stderr)
+        combined_stdout = "\n".join(stdout_parts)
+        final_returncode = last_result.returncode if last_result is not None else 1
+        final_stderr = last_result.stderr if last_result is not None else ""
+
+        passed = check_test_passed(final_returncode, combined_stdout, final_stderr)
         return TestResult(
             passed=passed,
-            stdout=result.stdout,
-            stderr=result.stderr,
+            stdout=combined_stdout,
+            stderr=final_stderr,
             duration_seconds=elapsed,
             filter_mode=stat_filter_mode,
             tests_selected=stat_tests_selected,

--- a/src/autoskillit/execution/testing.py
+++ b/src/autoskillit/execution/testing.py
@@ -201,7 +201,7 @@ class DefaultTestRunner:
         self._runner = runner
 
     async def run(self, cwd: Path) -> TestResult:
-        effective_commands = self._config.test_check.commands or [self._config.test_check.command]
+        effective_commands = self._config.test_check.effective_commands
         timeout = float(self._config.test_check.timeout)
         env = build_sanitized_env()
 
@@ -266,8 +266,13 @@ class DefaultTestRunner:
             Path(sidecar_path).unlink(missing_ok=True)
 
         combined_stdout = "\n".join(stdout_parts)
-        final_returncode = last_result.returncode if last_result is not None else 1
-        final_stderr = last_result.stderr if last_result is not None else ""
+        if last_result is not None:
+            final_returncode = last_result.returncode
+            final_stderr = last_result.stderr
+        else:
+            final_returncode = 1
+            final_stderr = "timeout exhausted before first command could run"
+            logger.warning("test_runner_timeout_before_first_command", timeout=timeout)
 
         passed = check_test_passed(final_returncode, combined_stdout, final_stderr)
         return TestResult(

--- a/src/autoskillit/skills_extended/dry-walkthrough/SKILL.md
+++ b/src/autoskillit/skills_extended/dry-walkthrough/SKILL.md
@@ -128,11 +128,11 @@ PROJECT RULES CHECKLIST:
 [ ] No PR breakdown sections
 [ ] Follows existing architectural patterns
 [ ] Uses existing utilities (not reinventing) unless refactoring is part of plan or provides major improvement
-[ ] Test command uses the project's configured `test_check.command` (from `.autoskillit/config.yaml`, default: `task test-check`) — no unconfigured direct test runner invocations (pytest, python -m pytest, etc.)
+[ ] Test command uses the project's configured `test_check.commands` (list of commands, if set) or `test_check.command` (from `.autoskillit/config.yaml`, default: `task test-check`) — no unconfigured direct test runner invocations (pytest, python -m pytest, etc.)
 [ ] Worktree setup uses `worktree_setup.command` or `task install-worktree` — no hardcoded `uv venv`, `pip install`, or direct package manager invocations
 ```
 
-**Test command enforcement:** Scan the entire plan for any test invocation. Read the project's configured test command from `test_check.command` in `.autoskillit/config.yaml` (default: `task test-check` if absent or unconfigured). If the plan contains `pytest`, `python -m pytest`, `make test`, or any other unconfigured test runner invocation, replace it with the config-driven command.
+**Test command enforcement:** Scan the entire plan for any test invocation. Read the project's configured test commands from `.autoskillit/config.yaml`: check `test_check.commands` first (list of ordered commands, if set); fall back to `test_check.command` (single command, default: `task test-check`). If the plan contains `pytest`, `python -m pytest`, `make test`, or any other unconfigured test runner invocation, replace it with the config-driven command(s).
 
 **Worktree setup enforcement:** Scan the plan for any worktree environment setup. The plan should reference the project's configured `worktree_setup.command` or `task install-worktree`. If the plan contains hardcoded `uv venv`, `uv pip install`, `pip install -e`, `npm install` (as worktree setup, not as a configured command), flag it and replace with the config-driven approach.
 

--- a/src/autoskillit/skills_extended/implement-worktree/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-worktree/SKILL.md
@@ -147,7 +147,7 @@ missed registration generates 5–30 cascading test failures that require a seco
 
 ### Step 5: Final Verification
 
-Read the configured test command from `.autoskillit/config.yaml` (key: `test_check.command`). Use this command wherever `{test_command}` appears below. If no config exists, use `task test-check` as the default.
+Read the configured test command(s) from `.autoskillit/config.yaml`: check `test_check.commands` (ordered list of commands, if set) or `test_check.command` (single command, default: `task test-check`). The `test_check` MCP tool runs all configured commands automatically.
 
 Run the project's code quality checks and test suite from the worktree.
 

--- a/src/autoskillit/skills_extended/resolve-failures/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-failures/SKILL.md
@@ -75,7 +75,7 @@ edits are committed and the downstream merge gate receives a clean worktree.
 
 ## Workflow
 
-Read the configured test command from `.autoskillit/config.yaml` (key: `test_check.command`). Use this command wherever `{test_command}` appears in these instructions. If no config exists, use the `test_check` MCP tool (which resolves the command from the project's config automatically).
+Read the configured test command(s) from `.autoskillit/config.yaml`: check `test_check.commands` first (ordered list of commands); fall back to `test_check.command` (single command). Use the `test_check` MCP tool (which runs all configured commands automatically and returns a single pass/fail).
 
 ### Step 0: Validate Arguments
 1. Parse positional args using **path detection**: scan all tokens after the

--- a/src/autoskillit/skills_extended/resolve-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-review/SKILL.md
@@ -67,8 +67,8 @@ review fixes are committed and the downstream push step receives a clean branch.
 
 ## Workflow
 
-Read `test_check.command` from `.autoskillit/config.yaml` (default: `task test-check`).
-Store the resolved command as `{test_command}` for use in all test-running steps.
+Read test configuration from `.autoskillit/config.yaml`: check `test_check.commands` (ordered list, if set) or `test_check.command` (single command, default: `task test-check`).
+The `test_check` MCP tool runs all configured commands automatically.
 
 ### Step 0: Validate Arguments
 

--- a/src/autoskillit/skills_extended/setup-project/SKILL.md
+++ b/src/autoskillit/skills_extended/setup-project/SKILL.md
@@ -203,7 +203,12 @@ If no config exists, present the suggested config in full. If config exists, onl
 Suggested config template:
 ```yaml
 test_check:
+  # Single command (most projects):
   command: {detected test command as list}
+  # Multi-surface projects (e.g. Rust + Python e2e):
+  # commands:
+  #   - [cargo, nextest, run]
+  #   - [task, e2e-check]
   # timeout: 600
 
 # classify_fix:

--- a/tests/execution/test_testing.py
+++ b/tests/execution/test_testing.py
@@ -678,3 +678,181 @@ async def test_default_test_runner_passes_default_base_branch(
     runner = DefaultTestRunner(config=config, runner=capturing_runner)
     await runner.run(cwd=tmp_path)
     assert captured_kwargs["env"].get("AUTOSKILLIT_TEST_BASE_REF") == "integration"
+
+
+# ---------------------------------------------------------------------------
+# Multi-command (commands: list[list[str]]) tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_multi_command_sequential_pass(tmp_path: Path) -> None:
+    from tests.conftest import _make_result
+    from tests.fakes import MockSubprocessRunner
+
+    runner = MockSubprocessRunner()
+    runner.push(_make_result(returncode=0, stdout="cmd1 output"))
+    runner.push(_make_result(returncode=0, stdout="cmd2 output"))
+    cfg = make_test_config(
+        test_check=make_test_check_config(
+            commands=[["cargo", "test"], ["task", "e2e"]],
+        )
+    )
+    result = await DefaultTestRunner(cfg, runner).run(tmp_path)
+    assert result.passed is True
+    assert "cmd1 output" in result.stdout
+    assert "cmd2 output" in result.stdout
+
+
+@pytest.mark.anyio
+async def test_multi_command_fail_fast(tmp_path: Path) -> None:
+    from tests.conftest import _make_result
+    from tests.fakes import MockSubprocessRunner
+
+    runner = MockSubprocessRunner()
+    runner.push(_make_result(returncode=1, stdout="cmd1 failed"))
+    cfg = make_test_config(
+        test_check=make_test_check_config(
+            commands=[["cargo", "test"], ["task", "e2e"]],
+        )
+    )
+    result = await DefaultTestRunner(cfg, runner).run(tmp_path)
+    assert result.passed is False
+    assert len(runner.call_args_list) == 1
+
+
+@pytest.mark.anyio
+async def test_multi_command_second_fails(tmp_path: Path) -> None:
+    from tests.conftest import _make_result
+    from tests.fakes import MockSubprocessRunner
+
+    runner = MockSubprocessRunner()
+    runner.push(_make_result(returncode=0, stdout="cmd1 ok"))
+    runner.push(_make_result(returncode=1, stdout="cmd2 failed"))
+    cfg = make_test_config(
+        test_check=make_test_check_config(
+            commands=[["cargo", "test"], ["task", "e2e"]],
+        )
+    )
+    result = await DefaultTestRunner(cfg, runner).run(tmp_path)
+    assert result.passed is False
+    assert "cmd1 ok" in result.stdout
+    assert "cmd2 failed" in result.stdout
+
+
+@pytest.mark.anyio
+async def test_multi_command_timeout_ceiling(tmp_path: Path) -> None:
+    from tests.conftest import _make_result
+    from tests.fakes import MockSubprocessRunner
+
+    runner = MockSubprocessRunner()
+    runner.push(_make_result(returncode=0, stdout="cmd1"))
+    runner.push(_make_result(returncode=0, stdout="cmd2"))
+    cfg = make_test_config(
+        test_check=make_test_check_config(
+            commands=[["a"], ["b"]],
+            timeout=10,
+        )
+    )
+    await DefaultTestRunner(cfg, runner).run(tmp_path)
+    t1 = runner.call_args_list[0][2]
+    t2 = runner.call_args_list[1][2]
+    assert t2 <= t1
+
+
+@pytest.mark.anyio
+async def test_multi_command_empty_commands_falls_back(tmp_path: Path) -> None:
+    from tests.conftest import _make_result
+    from tests.fakes import MockSubprocessRunner
+
+    runner = MockSubprocessRunner()
+    runner.push(_make_result(returncode=0, stdout="fallback"))
+    cfg = make_test_config(
+        test_check=make_test_check_config(
+            command=["task", "test-check"],
+            commands=None,
+        )
+    )
+    result = await DefaultTestRunner(cfg, runner).run(tmp_path)
+    assert result.passed is True
+    assert runner.call_args_list[0][0] == ["task", "test-check"]
+
+
+@pytest.mark.anyio
+async def test_multi_command_single_entry_equivalent(tmp_path: Path) -> None:
+    from tests.conftest import _make_result
+    from tests.fakes import MockSubprocessRunner
+
+    runner_a = MockSubprocessRunner()
+    runner_a.push(_make_result(returncode=0, stdout="out"))
+    runner_b = MockSubprocessRunner()
+    runner_b.push(_make_result(returncode=0, stdout="out"))
+    cfg_single = make_test_config(test_check=make_test_check_config(command=["task", "t"]))
+    cfg_multi = make_test_config(test_check=make_test_check_config(commands=[["task", "t"]]))
+    r1 = await DefaultTestRunner(cfg_single, runner_a).run(tmp_path)
+    r2 = await DefaultTestRunner(cfg_multi, runner_b).run(tmp_path)
+    assert r1.passed == r2.passed
+
+
+def test_commands_and_command_mutual_exclusion() -> None:
+    from autoskillit.config.settings import ConfigSchemaError
+
+    with pytest.raises(ConfigSchemaError):
+        make_test_check_config(
+            command=["cargo", "test"],
+            commands=[["cargo", "test"], ["task", "e2e"]],
+        )
+
+
+@pytest.mark.anyio
+async def test_multi_command_env_vars_propagated(tmp_path: Path) -> None:
+    captured_envs: list[dict] = []
+
+    async def capturing_runner(cmd, *, cwd, timeout, env, **kwargs):
+        captured_envs.append(dict(env))
+        from tests.conftest import _make_result
+
+        return _make_result(returncode=0, stdout="")
+
+    cfg = make_test_config(
+        test_check=make_test_check_config(
+            commands=[["a"], ["b"]],
+            filter_mode="conservative",
+        )
+    )
+    await DefaultTestRunner(cfg, capturing_runner).run(tmp_path)
+    assert all("AUTOSKILLIT_TEST_FILTER" in e for e in captured_envs)
+
+
+@pytest.mark.anyio
+async def test_multi_command_section_headers(tmp_path: Path) -> None:
+    from tests.conftest import _make_result
+    from tests.fakes import MockSubprocessRunner
+
+    runner = MockSubprocessRunner()
+    runner.push(_make_result(returncode=0, stdout="out1"))
+    runner.push(_make_result(returncode=0, stdout="out2"))
+    cfg = make_test_config(
+        test_check=make_test_check_config(
+            commands=[["cargo", "test"], ["task", "e2e"]],
+        )
+    )
+    result = await DefaultTestRunner(cfg, runner).run(tmp_path)
+    assert "=== [1/2]" in result.stdout
+    assert "=== [2/2]" in result.stdout
+
+
+def test_defaults_yaml_has_commands_null() -> None:
+    import yaml
+
+    from autoskillit.core.paths import pkg_root
+
+    defaults = yaml.safe_load((pkg_root() / "config" / "defaults.yaml").read_text())
+    assert "commands" in defaults["test_check"]
+    assert defaults["test_check"]["commands"] is None
+
+
+def test_test_check_config_has_commands_field() -> None:
+    cfg = make_test_check_config()
+    assert hasattr(cfg, "commands")
+    assert cfg.commands is None

--- a/tests/execution/test_testing.py
+++ b/tests/execution/test_testing.py
@@ -741,9 +741,21 @@ async def test_multi_command_second_fails(tmp_path: Path) -> None:
 
 
 @pytest.mark.anyio
-async def test_multi_command_timeout_ceiling(tmp_path: Path) -> None:
+async def test_multi_command_timeout_ceiling(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import autoskillit.execution.testing as testing_mod
     from tests.conftest import _make_result
     from tests.fakes import MockSubprocessRunner
+
+    # Simulate 3 seconds elapsed between start and the second command's remaining check.
+    # monotonic() call sequence: start, loop1-remaining, loop2-remaining, elapsed
+    _times = iter([0.0, 0.0, 3.0, 3.0])
+    monkeypatch.setattr(
+        testing_mod,
+        "time",
+        type("_FakeTime", (), {"monotonic": staticmethod(lambda: next(_times))})(),
+    )
 
     runner = MockSubprocessRunner()
     runner.push(_make_result(returncode=0, stdout="cmd1"))
@@ -757,7 +769,9 @@ async def test_multi_command_timeout_ceiling(tmp_path: Path) -> None:
     await DefaultTestRunner(cfg, runner).run(tmp_path)
     t1 = runner.call_args_list[0][2]
     t2 = runner.call_args_list[1][2]
-    assert t2 <= t1
+    assert t1 == pytest.approx(10.0)
+    assert t2 == pytest.approx(7.0)
+    assert t2 < t1
 
 
 @pytest.mark.anyio

--- a/tests/execution/test_testing.py
+++ b/tests/execution/test_testing.py
@@ -795,9 +795,7 @@ async def test_multi_command_single_entry_equivalent(tmp_path: Path) -> None:
 
 
 def test_commands_and_command_mutual_exclusion() -> None:
-    from autoskillit.config.settings import ConfigSchemaError
-
-    with pytest.raises(ConfigSchemaError):
+    with pytest.raises(ValueError, match="mutually exclusive"):
         make_test_check_config(
             command=["cargo", "test"],
             commands=[["cargo", "test"], ["task", "e2e"]],

--- a/tests/server/test_server_tool_registration.py
+++ b/tests/server/test_server_tool_registration.py
@@ -249,7 +249,7 @@ class TestConfigDrivenBehavior:
         await test_check(worktree_path="/tmp/wt")
 
         assert tool_ctx.runner.call_args_list[0][0] == ["pytest", "-x"]
-        assert tool_ctx.runner.call_args_list[0][2] == 300.0
+        assert tool_ctx.runner.call_args_list[0][2] == pytest.approx(300.0, abs=1.0)
 
     @pytest.mark.anyio
     async def test_classify_fix_uses_config_prefixes(self, tool_ctx, tmp_path):


### PR DESCRIPTION
## Summary

Adds `commands: list[list[str]] | None` to `TestCheckConfig`, enabling polyglot projects to configure multiple ordered test commands under a single `test_check` gate. `DefaultTestRunner.run()` is refactored to loop over effective commands with fail-fast semantics and a shared deadline-based timeout ceiling. Output from each command is concatenated with section headers. Backward compatibility is exact: existing configs using `command` (singular) hit a single-iteration loop and produce identical output without headers.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START: test_check MCP tool invoked])
    COMPLETE([COMPLETE: TestResult returned])
    ERROR([ERROR: ConfigSchemaError])

    subgraph ConfigPhase ["● Phase 1 — Config Resolution (settings.py / defaults.yaml)"]
        direction TB
        LayerMerge["● _make_dynaconf()<br/>━━━━━━━━━━<br/>Merge defaults → user → project → secrets<br/>Apply AUTOSKILLIT_* env overrides"]
        TCBuild["● TestCheckConfig construction<br/>━━━━━━━━━━<br/>command: list[str] (default: task test-check)<br/>commands: list[list[str]] | None (NEW)<br/>timeout / filter_mode / base_ref"]
        MutexCheck{"● __post_init__ guard<br/>━━━━━━━━━━<br/>commands set AND<br/>command ≠ default?"}
    end

    subgraph EnvPhase ["● Phase 2 — Env & Deadline Setup (testing.py)"]
        direction TB
        EffCmds["● effective_commands derivation<br/>━━━━━━━━━━<br/>commands or [command]<br/>Determines single vs multi-surface run"]
        EnvBuild["● build_sanitized_env()<br/>━━━━━━━━━━<br/>Clone os.environ<br/>Strip AUTOSKILLIT_PRIVATE_ENV_VARS"]
        FilterEnv{"filter_mode set?<br/>━━━━━━━━━━<br/>Inject AUTOSKILLIT_TEST_FILTER"}
        BaseRefResolve["● _resolve_base_ref()<br/>━━━━━━━━━━<br/>config_base_ref → sidecar → git @{upstream}<br/>→ default_base_branch → None"]
        BaseRefEnv{"base_ref resolved?<br/>━━━━━━━━━━<br/>Inject AUTOSKILLIT_TEST_BASE_REF"}
        SidecarCreate["tempfile.mkstemp()<br/>━━━━━━━━━━<br/>AUTOSKILLIT_FILTER_STATS_FILE<br/>Written by pytest filter plugin"]
        DeadlineSet["● Deadline calculation<br/>━━━━━━━━━━<br/>deadline = monotonic() + timeout<br/>Shared across all commands"]
    end

    subgraph LoopPhase ["● Phase 3 — Multi-Command Execution Loop (testing.py)"]
        direction TB
        LoopEntry["● for idx, command in enumerate(effective_commands, 1)<br/>━━━━━━━━━━<br/>Ordered iteration — fail-fast semantics"]
        DeadlineCheck{"● remaining = deadline − now()<br/>━━━━━━━━━━<br/>remaining < 0.01s?"}
        RunCmd["● self._runner(command, cwd, timeout=remaining, env)<br/>━━━━━━━━━━<br/>SubprocessRunner — deadline-clamped per command<br/>Captures returncode / stdout / stderr"]
        HeaderCheck{"total > 1?<br/>━━━━━━━━━━<br/>Multiple surface run?"}
        AppendWithHeader["● Append section header<br/>━━━━━━━━━━<br/>=== [idx/total] cmd ===<br/>+ result.stdout"]
        AppendRaw["Append result.stdout<br/>━━━━━━━━━━<br/>Single command — no header"]
        FailFastCheck{"● result.returncode ≠ 0?<br/>━━━━━━━━━━<br/>Fail-fast break"}
        LoopContinue{"More commands<br/>AND not broken?"}
    end

    subgraph AggPhase ["● Phase 4 — Results Aggregation (testing.py)"]
        direction TB
        SidecarRead["Read AUTOSKILLIT_FILTER_STATS_FILE<br/>━━━━━━━━━━<br/>filter_mode / tests_selected / tests_deselected<br/>Best-effort: silently skips on error"]
        StdoutJoin["● combined_stdout = '\\n'.join(stdout_parts)<br/>━━━━━━━━━━<br/>Section-headed or plain<br/>Based on total command count"]
        Adjudicate["● check_test_passed(returncode, stdout, stderr)<br/>━━━━━━━━━━<br/>Exit code primary; cross-validate pytest summary<br/>Detects failed/error counts in output"]
    end

    %% FLOW %%
    START --> LayerMerge
    LayerMerge --> TCBuild
    TCBuild --> MutexCheck
    MutexCheck -->|"commands AND command both set"| ERROR
    MutexCheck -->|"valid config"| EffCmds

    EffCmds --> EnvBuild
    EnvBuild --> FilterEnv
    FilterEnv -->|"yes"| BaseRefResolve
    FilterEnv -->|"no"| BaseRefResolve
    BaseRefResolve --> BaseRefEnv
    BaseRefEnv -->|"yes"| SidecarCreate
    BaseRefEnv -->|"no"| SidecarCreate
    SidecarCreate --> DeadlineSet

    DeadlineSet --> LoopEntry
    LoopEntry --> DeadlineCheck
    DeadlineCheck -->|"yes — budget exhausted"| SidecarRead
    DeadlineCheck -->|"no — budget remains"| RunCmd
    RunCmd --> HeaderCheck
    HeaderCheck -->|"yes"| AppendWithHeader
    HeaderCheck -->|"no"| AppendRaw
    AppendWithHeader --> FailFastCheck
    AppendRaw --> FailFastCheck
    FailFastCheck -->|"yes — non-zero exit"| SidecarRead
    FailFastCheck -->|"no — continue"| LoopContinue
    LoopContinue -->|"yes"| LoopEntry
    LoopContinue -->|"no — all done"| SidecarRead

    SidecarRead --> StdoutJoin
    StdoutJoin --> Adjudicate
    Adjudicate --> COMPLETE

    %% CLASS ASSIGNMENTS %%
    class START,COMPLETE,ERROR terminal;
    class LayerMerge,TCBuild handler;
    class MutexCheck,DeadlineCheck,FailFastCheck,LoopContinue,HeaderCheck,FilterEnv,BaseRefEnv detector;
    class EffCmds,EnvBuild,BaseRefResolve,SidecarCreate,DeadlineSet phase;
    class LoopEntry,RunCmd,AppendWithHeader,AppendRaw handler;
    class SidecarRead,StdoutJoin,Adjudicate output;
```

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph ConfigSources ["CONFIGURATION SOURCES"]
        direction LR
        Defaults["● defaults.yaml<br/>━━━━━━━━━━<br/>command: [task, test-check]<br/>● commands: null<br/>timeout: 600 / filter_mode: null"]
        UserOverrides["user config / env vars<br/>━━━━━━━━━━<br/>Layered Dynaconf resolution<br/>AUTOSKILLIT_TEST_CHECK__*"]
    end

    subgraph Construction ["● CONSTRUCTION PATH (settings.py)"]
        direction TB
        FromDynaconf["● from_dynaconf()<br/>━━━━━━━━━━<br/>Reads AutomationConfig.test_check section<br/>Casts each field to target type"]
        Coerce["● _to_optional_commands()<br/>━━━━━━━━━━<br/>falsy → None<br/>else: [list(cmd) for cmd in value]"]
    end

    subgraph FieldCategories ["● TestCheckConfig FIELDS — ALL INIT_ONLY (settings.py)"]
        direction LR
        CmdField["command: list[str]<br/>━━━━━━━━━━<br/>Default: [task, test-check]<br/>Fallback when commands is None"]
        CommandsField["● commands: list[list[str]] | None<br/>━━━━━━━━━━<br/>Default: None<br/>Primary ordered multi-surface list"]
        TimeoutField["timeout: int<br/>━━━━━━━━━━<br/>Default: 600s<br/>Shared deadline budget"]
        FilterField["filter_mode: str | None<br/>━━━━━━━━━━<br/>Default: None<br/>→ AUTOSKILLIT_TEST_FILTER"]
        BaseRefField["base_ref: str | None<br/>━━━━━━━━━━<br/>Default: None<br/>→ AUTOSKILLIT_TEST_BASE_REF"]
    end

    subgraph MutexGate ["● MUTUAL EXCLUSION GATE (__post_init__)"]
        direction TB
        Check{"● commands is not None<br/>AND command ≠ DEFAULT?"}
        Err["ConfigSchemaError<br/>━━━━━━━━━━<br/>'command and commands are<br/>mutually exclusive'<br/>Omit command when using commands"]
        Pass["GATE PASS<br/>━━━━━━━━━━<br/>commands + default command: valid<br/>commands wins at runtime dispatch"]
    end

    subgraph RuntimeDispatch ["● RUNTIME DISPATCH (testing.py DefaultTestRunner.run())"]
        direction TB
        Dispatch["● effective_commands =<br/>commands or [command]<br/>━━━━━━━━━━<br/>MULTI: sequential execution<br/>stop-on-first-failure<br/>NIL: single command fallback"]
        SharedTimeout["● Shared Timeout Budget<br/>━━━━━━━━━━<br/>deadline = now + timeout<br/>Each cmd gets: deadline − now<br/>Budget shared, not per-command"]
        EnvVars["Env Var Injection<br/>━━━━━━━━━━<br/>AUTOSKILLIT_TEST_FILTER<br/>AUTOSKILLIT_TEST_BASE_REF<br/>Propagated to ALL commands"]
    end

    AppLog["● app.py startup log<br/>━━━━━━━━━━<br/>cfg.test_check.commands or<br/>cfg.test_check.command<br/>(diagnostic only — no gate)"]

    %% FLOW %%
    Defaults --> FromDynaconf
    UserOverrides --> FromDynaconf
    FromDynaconf --> Coerce
    Coerce --> CommandsField
    FromDynaconf --> CmdField
    FromDynaconf --> TimeoutField
    FromDynaconf --> FilterField
    FromDynaconf --> BaseRefField

    CommandsField --> Check
    CmdField --> Check
    Check -->|"FAIL: both explicit"| Err
    Check -->|"PASS"| Pass

    Pass --> Dispatch
    TimeoutField --> SharedTimeout
    FilterField --> EnvVars
    BaseRefField --> EnvVars
    Dispatch --> SharedTimeout
    Dispatch --> EnvVars
    Dispatch --> AppLog

    %% CLASS ASSIGNMENTS %%
    class Defaults,UserOverrides stateNode;
    class FromDynaconf,Coerce phase;
    class CmdField,TimeoutField,FilterField,BaseRefField stateNode;
    class CommandsField handler;
    class Check detector;
    class Err gap;
    class Pass output;
    class Dispatch handler;
    class SharedTimeout,EnvVars output;
    class AppLog cli;
```

Closes #1358

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260426-235121-208495/.autoskillit/temp/make-plan/extend_testcheckconfig_commands_plan_2026-04-26_235121.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 4.9k | 18.5k | 769.3k | 62.4k | 1 | 7m 27s |
| review | 52 | 5.1k | 147.1k | 55.5k | 1 | 3m 22s |
| verify | 188 | 13.7k | 1.2M | 60.3k | 1 | 3m 57s |
| implement | 981 | 15.0k | 1.6M | 58.1k | 1 | 5m 22s |
| fix | 150 | 7.2k | 801.2k | 49.8k | 1 | 7m 17s |
| prepare_pr | 52 | 4.3k | 174.8k | 32.3k | 1 | 1m 32s |
| run_arch_lenses | 2.0k | 14.4k | 434.9k | 77.6k | 2 | 4m 51s |
| compose_pr | 67 | 5.7k | 230.2k | 28.5k | 1 | 1m 52s |
| **Total** | 8.4k | 83.8k | 5.3M | 424.4k | | 35m 43s |