### PR TITLE
CI Watch — Backoff Floors, Timeout Bump, Timed-Out Guidance & Semantic Rule

### DIFF
--- a/src/autoskillit/execution/ci.py
+++ b/src/autoskillit/execution/ci.py
@@ -457,7 +457,7 @@ class DefaultCIWatcher:
                     "run_id": run_id,
                     "conclusion": "timed_out",
                     "failed_jobs": [],
-                    "run_status": "in_progress",
+                    "run_status": run_data.get("status", "in_progress"),
                     "hint": (
                         f"CI run {run_id} is still in progress (not failed). "
                         "Call wait_for_ci again to continue watching."

--- a/src/autoskillit/execution/ci.py
+++ b/src/autoskillit/execution/ci.py
@@ -27,9 +27,8 @@ from autoskillit.execution.github import github_headers
 
 _log = get_logger(__name__)
 
-# Backoff schedule constants
-_BACKOFF_BASE = 5  # seconds
-_BACKOFF_CAP = 30  # seconds
+# Backoff schedule: (floor, ceiling) per attempt band.
+_BACKOFF_BANDS: tuple[tuple[int, int], ...] = ((5, 10), (10, 20), (15, 30))
 
 # All GitHub Actions check run conclusion values known to be returned by the REST API.
 # https://docs.github.com/en/rest/checks/runs
@@ -61,9 +60,9 @@ FAILED_CONCLUSIONS: frozenset[str] = frozenset(
 
 
 def _jittered_sleep(attempt: int) -> float:
-    """Compute full-jitter exponential backoff: random(0, min(cap, base * 2^attempt))."""
-    ceiling = min(_BACKOFF_CAP, _BACKOFF_BASE * (2**attempt))
-    return random.uniform(0, ceiling)
+    """Full-jitter exponential backoff with per-attempt floor bands."""
+    floor, ceiling = _BACKOFF_BANDS[min(attempt, len(_BACKOFF_BANDS) - 1)]
+    return random.uniform(floor, ceiling)
 
 
 def _validate_run_matches_scope(run: dict[str, Any], scope: CIRunScope) -> bool:
@@ -454,7 +453,16 @@ class DefaultCIWatcher:
                     attempt += 1
 
                 _log.warning("ci_watcher_timeout", run_id=run_id, timeout=timeout_seconds)
-                return {"run_id": run_id, "conclusion": "timed_out", "failed_jobs": []}
+                return {
+                    "run_id": run_id,
+                    "conclusion": "timed_out",
+                    "failed_jobs": [],
+                    "run_status": "in_progress",
+                    "hint": (
+                        f"CI run {run_id} is still in progress (not failed). "
+                        "Call wait_for_ci again to continue watching."
+                    ),
+                }
 
         except httpx.HTTPStatusError as exc:
             _log.warning("ci_watcher_http_error", status=exc.response.status_code, branch=branch)

--- a/src/autoskillit/recipe/rules_ci.py
+++ b/src/autoskillit/recipe/rules_ci.py
@@ -186,6 +186,48 @@ def _check_ci_no_runs_unguarded(ctx: ValidationContext) -> list[RuleFinding]:
     return findings
 
 
+@semantic_rule(
+    name="ci-timed-out-unguarded",
+    description=(
+        "Flags wait_for_ci steps whose on_result routing lacks an explicit "
+        "condition for conclusion='timed_out'. A catch-all arm is NOT "
+        "sufficient — timed_out means CI is still running, not failed."
+    ),
+    severity=Severity.ERROR,
+)
+def _check_ci_timed_out_unguarded(ctx: ValidationContext) -> list[RuleFinding]:
+    timed_out_re = re.compile(r"""==\s*['"]?timed_out['"]?""")
+    findings: list[RuleFinding] = []
+    for name, step in ctx.recipe.steps.items():
+        if step.tool != "wait_for_ci":
+            continue
+        if not (step.on_success or step.on_result):
+            continue
+        has_explicit_timed_out = False
+        if step.on_result and step.on_result.conditions:
+            has_explicit_timed_out = any(
+                c.when and timed_out_re.search(c.when) for c in step.on_result.conditions
+            )
+        if has_explicit_timed_out:
+            continue
+        target = step.on_success or "on_result routing"
+        findings.append(
+            RuleFinding(
+                rule="ci-timed-out-unguarded",
+                severity=Severity.ERROR,
+                step_name=name,
+                message=(
+                    f"Step '{name}' uses wait_for_ci without an on_result condition "
+                    "that intercepts conclusion='timed_out'. timed_out means CI is "
+                    "still in progress — routing it through a catch-all to the CI "
+                    f"failure path is semantically wrong. Add an explicit timed_out "
+                    f"arm before '{target}'."
+                ),
+            )
+        )
+    return findings
+
+
 _CI_EVENT_SCOPE_TOOLS = {"wait_for_ci", "get_ci_status"}
 
 

--- a/src/autoskillit/recipe/rules_graph.py
+++ b/src/autoskillit/recipe/rules_graph.py
@@ -51,23 +51,24 @@ def _check_unbounded_cycles(ctx: ValidationContext) -> list[RuleFinding]:
                 reported_cycles.add(cycle_key)
                 cycle_set = set(cycle_steps)
 
-                # Scoped to run_python only: shell-based (run_cmd) counters use external
-                # file state and are not structural bounds.
+                # Tools whose on_result conditions are structural (not external
+                # file state): run_python (counter-based) and wait_for_ci
+                # (API conclusion values guarantee eventual exit).
+                _STRUCTURAL_ON_RESULT_TOOLS = {"run_python", "wait_for_ci"}
                 has_on_result_exit = False
                 for s in cycle_steps:
                     if s not in recipe.steps:
                         continue
                     step = recipe.steps[s]
-                    if step.tool != "run_python" or step.on_result is None:
+                    if step.tool not in _STRUCTURAL_ON_RESULT_TOOLS or step.on_result is None:
                         continue
                     targets: set[str] = set()
                     if step.on_result.conditions:
                         targets = {c.route for c in step.on_result.conditions}
                     elif step.on_result.routes:
                         targets = set(step.on_result.routes.values())
-                    routes_in = targets & cycle_set
                     routes_out = targets - cycle_set
-                    if routes_in and routes_out:
+                    if routes_out:
                         has_on_result_exit = True
                         break
 

--- a/src/autoskillit/recipe/rules_graph.py
+++ b/src/autoskillit/recipe/rules_graph.py
@@ -15,6 +15,8 @@ from autoskillit.recipe.registry import RuleFinding, semantic_rule
 
 logger = get_logger(__name__)
 
+_STRUCTURAL_ON_RESULT_TOOLS = {"run_python", "wait_for_ci"}
+
 
 @semantic_rule(
     name="unbounded-cycle",
@@ -51,10 +53,6 @@ def _check_unbounded_cycles(ctx: ValidationContext) -> list[RuleFinding]:
                 reported_cycles.add(cycle_key)
                 cycle_set = set(cycle_steps)
 
-                # Tools whose on_result conditions are structural (not external
-                # file state): run_python (counter-based) and wait_for_ci
-                # (API conclusion values guarantee eventual exit).
-                _STRUCTURAL_ON_RESULT_TOOLS = {"run_python", "wait_for_ci"}
                 has_on_result_exit = False
                 for s in cycle_steps:
                     if s not in recipe.steps:

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -717,7 +717,8 @@ steps:
       Skipped when open_pr=false — no remote feature branch is opened in that mode.
       Routes on result.conclusion: success → check_repo_merge_state,
       no_runs → handle_no_ci_runs (auto_trigger fires first: empty commit + force-push +
-      re-poll; handle_no_ci_runs reached only when push fails), failure → detect_ci_conflict.
+      re-poll; handle_no_ci_runs reached only when push fails),
+      timed_out → self (re-watch), failure → detect_ci_conflict.
 
   handle_no_ci_runs:
     tool: check_repo_merge_state

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -704,6 +704,8 @@ steps:
         route: check_repo_merge_state
       - when: "${{ result.conclusion }} == 'no_runs'"
         route: handle_no_ci_runs
+      - when: "${{ result.conclusion }} == 'timed_out'"
+        route: ci_watch
       - route: detect_ci_conflict
     on_failure: detect_ci_conflict
     optional: true
@@ -1131,7 +1133,7 @@ steps:
     with:
       branch: "${{ context.merge_target }}"
       event: "${{ context.ci_event }}"
-      timeout_seconds: 300
+      timeout_seconds: 600
       cwd: "${{ context.work_dir }}"
       remote_url: "${{ context.remote_url }}"
     capture:
@@ -1142,6 +1144,8 @@ steps:
         route: reenter_merge_queue
       - when: "${{ result.conclusion }} == 'no_runs'"
         route: release_issue_failure
+      - when: "${{ result.conclusion }} == 'timed_out'"
+        route: ci_watch_post_queue_fix
       - route: detect_ci_conflict
     on_failure: detect_ci_conflict
     skip_when_false: "inputs.open_pr"
@@ -1149,7 +1153,7 @@ steps:
       Validates CI on the rebased feature branch after queue ejection fix and re-push.
       Routes on result.conclusion: success → reenter_merge_queue,
       no_runs → release_issue_failure (post-queue-fix is already a retry path),
-      failure → detect_ci_conflict.
+      timed_out → self (re-watch), failure → detect_ci_conflict.
 
   reenter_merge_queue:
     tool: enqueue_pr

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -686,6 +686,8 @@ steps:
         route: check_repo_merge_state
       - when: "${{ result.conclusion }} == 'no_runs'"
         route: handle_no_ci_runs
+      - when: "${{ result.conclusion }} == 'timed_out'"
+        route: ci_watch
       - route: detect_ci_conflict
     on_failure: detect_ci_conflict
     optional: true
@@ -1032,7 +1034,7 @@ steps:
     with:
       branch: "${{ context.merge_target }}"
       event: "${{ context.ci_event }}"
-      timeout_seconds: 300
+      timeout_seconds: 600
       cwd: "${{ context.work_dir }}"
       remote_url: "${{ context.remote_url }}"
     capture:
@@ -1043,6 +1045,8 @@ steps:
         route: reenter_merge_queue
       - when: "${{ result.conclusion }} == 'no_runs'"
         route: release_issue_failure
+      - when: "${{ result.conclusion }} == 'timed_out'"
+        route: ci_watch_post_queue_fix
       - route: detect_ci_conflict
     on_failure: detect_ci_conflict
     skip_when_false: "inputs.open_pr"
@@ -1050,7 +1054,7 @@ steps:
       Validates CI on the rebased feature branch after queue ejection fix and re-push.
       Routes on result.conclusion: success → reenter_merge_queue,
       no_runs → release_issue_failure (post-queue-fix is already a retry path),
-      failure → detect_ci_conflict.
+      timed_out → self (re-watch), failure → detect_ci_conflict.
 
   reenter_merge_queue:
     tool: enqueue_pr

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -699,7 +699,8 @@ steps:
       Skipped when open_pr=false — no remote feature branch is opened in that mode.
       Routes on result.conclusion: success → check_repo_merge_state,
       no_runs → handle_no_ci_runs (auto_trigger fires first: empty commit + force-push +
-      re-poll; handle_no_ci_runs reached only when push fails), failure → detect_ci_conflict.
+      re-poll; handle_no_ci_runs reached only when push fails),
+      timed_out → self (re-watch), failure → detect_ci_conflict.
 
   handle_no_ci_runs:
     tool: check_repo_merge_state

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -386,13 +386,15 @@ steps:
     on_result:
       - when: "${{ result.conclusion }} == 'success'"
         route: reenter_queue
+      - when: "${{ result.conclusion }} == 'timed_out'"
+        route: ci_watch_post_queue_fix
       - route: register_clone_failure
     on_failure: register_clone_failure
     note: >
       Validates CI passes on the rebased branch before re-entering the merge queue.
       Prevents re-enqueue of a broken branch that would be ejected again.
       Routes on result.conclusion: success → reenter_queue,
-      no_runs/failure → register_clone_failure.
+      timed_out → self (re-watch), no_runs/failure → register_clone_failure.
 
   reenter_queue:
     tool: enqueue_pr
@@ -749,13 +751,15 @@ steps:
     on_result:
       - when: "${{ result.conclusion }} == 'success'"
         route: merge_conflict_pr
+      - when: "${{ result.conclusion }} == 'timed_out'"
+        route: wait_for_conflict_ci
       - route: register_clone_failure
     on_failure: register_clone_failure
     note: >
       Waits for CI to pass on the worktree branch before merging.
       600 second timeout matches the merge-pr skill poll timeout.
       Routes on result.conclusion: success → merge_conflict_pr,
-      no_runs/failure → register_clone_failure.
+      timed_out → self (re-watch), no_runs/failure → register_clone_failure.
 
   merge_conflict_pr:
     tool: run_cmd
@@ -1113,12 +1117,15 @@ steps:
     on_result:
       - when: "${{ result.conclusion }} == 'success'"
         route: register_clone_success
+      - when: "${{ result.conclusion }} == 'timed_out'"
+        route: ci_watch_pr
       - route: register_clone_failure
     on_failure: diagnose_ci
     note: >
       Waits for the GitHub Actions CI run on context.integration_branch to complete
       using the wait_for_ci MCP tool (timeout: 300 s). Routes on result.conclusion:
-      success → register_clone_success, no_runs/failure → register_clone_failure.
+      success → register_clone_success, timed_out → self (re-watch),
+      no_runs/failure → register_clone_failure.
       Tool-level failure routes to diagnose_ci for log capture.
 
   diagnose_ci:

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -697,7 +697,8 @@ steps:
       Skipped when open_pr=false — no remote feature branch is opened in that mode.
       Routes on result.conclusion: success → check_repo_merge_state,
       no_runs → handle_no_ci_runs (auto_trigger fires first: empty commit + force-push +
-      re-poll; handle_no_ci_runs reached only when push fails), failure → detect_ci_conflict.
+      re-poll; handle_no_ci_runs reached only when push fails),
+      timed_out → self (re-watch), failure → detect_ci_conflict.
 
   handle_no_ci_runs:
     tool: check_repo_merge_state

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -684,6 +684,8 @@ steps:
         route: check_repo_merge_state
       - when: "${{ result.conclusion }} == 'no_runs'"
         route: handle_no_ci_runs
+      - when: "${{ result.conclusion }} == 'timed_out'"
+        route: ci_watch
       - route: detect_ci_conflict
     on_failure: detect_ci_conflict
     optional: true
@@ -1032,7 +1034,7 @@ steps:
     with:
       branch: "${{ context.merge_target }}"
       event: "${{ context.ci_event }}"
-      timeout_seconds: 300
+      timeout_seconds: 600
       cwd: "${{ context.work_dir }}"
       remote_url: "${{ context.remote_url }}"
     capture:
@@ -1043,6 +1045,8 @@ steps:
         route: reenter_merge_queue
       - when: "${{ result.conclusion }} == 'no_runs'"
         route: release_issue_failure
+      - when: "${{ result.conclusion }} == 'timed_out'"
+        route: ci_watch_post_queue_fix
       - route: detect_ci_conflict
     on_failure: detect_ci_conflict
     skip_when_false: "inputs.open_pr"
@@ -1050,7 +1054,7 @@ steps:
       Validates CI on the rebased feature branch after queue ejection fix and re-push.
       Routes on result.conclusion: success → reenter_merge_queue,
       no_runs → release_issue_failure (post-queue-fix is already a retry path),
-      failure → detect_ci_conflict.
+      timed_out → self (re-watch), failure → detect_ci_conflict.
 
   reenter_merge_queue:
     tool: enqueue_pr

--- a/tests/execution/test_ci.py
+++ b/tests/execution/test_ci.py
@@ -55,10 +55,22 @@ def _jobs_response(*jobs: tuple[str, str]) -> dict:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("attempt", range(10))
-def test_jittered_sleep_bounded(attempt: int) -> None:
-    val = _jittered_sleep(attempt)
-    assert 0 <= val <= 30  # cap is 30
+@pytest.mark.parametrize(
+    ("attempt", "expected_floor", "expected_ceiling"),
+    [
+        (0, 5, 10),
+        (1, 10, 20),
+        (2, 15, 30),
+        (3, 15, 30),
+        (9, 15, 30),
+    ],
+)
+def test_jittered_sleep_bounded(
+    attempt: int, expected_floor: float, expected_ceiling: float
+) -> None:
+    for _ in range(50):
+        val = _jittered_sleep(attempt)
+        assert expected_floor <= val <= expected_ceiling
 
 
 def test_jittered_sleep_variance():
@@ -269,6 +281,9 @@ async def test_timeout_exceeded():
     assert result["run_id"] == 666
     assert result["conclusion"] == "timed_out"
     assert result["failed_jobs"] == []
+    assert result["run_status"] == "in_progress"
+    assert "still in progress" in result["hint"]
+    assert "666" in result["hint"]
 
 
 @pytest.mark.anyio
@@ -298,9 +313,9 @@ async def test_exponential_backoff_with_jitter():
         result = await watcher.wait("main", repo="owner/repo", timeout_seconds=600)
 
     assert result["conclusion"] == "success"
-    # All sleep durations should be bounded by [0, 30]
+    # All sleep durations should respect backoff band floors (min 5s)
     for d in sleep_durations:
-        assert 0 <= d <= 30
+        assert 5 <= d <= 30
 
 
 @pytest.mark.anyio

--- a/tests/recipe/test_rules_ci.py
+++ b/tests/recipe/test_rules_ci.py
@@ -712,6 +712,89 @@ def test_bundled_recipes_no_runs_guarded() -> None:
 
 
 # ---------------------------------------------------------------------------
+# ci-timed-out-unguarded rule tests
+# ---------------------------------------------------------------------------
+
+_TIMED_OUT_RULE = "ci-timed-out-unguarded"
+
+
+def test_ci_timed_out_unguarded_fires_with_only_catch_all() -> None:
+    recipe = _make_workflow(
+        {
+            "ci_watch": {
+                "tool": "wait_for_ci",
+                "with": {"branch": "main", "event": "push", "timeout_seconds": 300},
+                "on_result": [
+                    {"when": "${{ result.conclusion }} == 'success'", "route": "merge"},
+                    {"when": "${{ result.conclusion }} == 'no_runs'", "route": "handle_no_runs"},
+                    {"route": "detect_ci_conflict"},
+                ],
+            },
+            "merge": {"tool": "run_cmd", "with": {"cmd": "echo merge"}},
+            "handle_no_runs": {"tool": "run_cmd", "with": {"cmd": "echo no_runs"}},
+            "detect_ci_conflict": {"tool": "run_cmd", "with": {"cmd": "echo conflict"}},
+        }
+    )
+    findings = [f for f in run_semantic_rules(recipe) if f.rule == _TIMED_OUT_RULE]
+    assert len(findings) == 1
+    assert findings[0].severity == Severity.ERROR
+    assert findings[0].step_name == "ci_watch"
+
+
+def test_ci_timed_out_unguarded_passes_with_explicit_arm() -> None:
+    recipe = _make_workflow(
+        {
+            "ci_watch": {
+                "tool": "wait_for_ci",
+                "with": {"branch": "main", "event": "push", "timeout_seconds": 300},
+                "on_result": [
+                    {"when": "${{ result.conclusion }} == 'success'", "route": "merge"},
+                    {"when": "${{ result.conclusion }} == 'timed_out'", "route": "ci_watch"},
+                    {"route": "detect_ci_conflict"},
+                ],
+            },
+            "merge": {"tool": "run_cmd", "with": {"cmd": "echo merge"}},
+            "detect_ci_conflict": {"tool": "run_cmd", "with": {"cmd": "echo conflict"}},
+        }
+    )
+    findings = [f for f in run_semantic_rules(recipe) if f.rule == _TIMED_OUT_RULE]
+    assert len(findings) == 0
+
+
+def test_ci_timed_out_unguarded_silent_for_non_ci_tools() -> None:
+    recipe = _make_workflow(
+        {
+            "run_tests": {
+                "tool": "run_cmd",
+                "with": {"cmd": "pytest"},
+                "on_result": [{"route": "done"}],
+            },
+            "done": {"tool": "run_cmd", "with": {"cmd": "echo done"}},
+        }
+    )
+    findings = [f for f in run_semantic_rules(recipe) if f.rule == _TIMED_OUT_RULE]
+    assert len(findings) == 0
+
+
+def test_bundled_recipes_timed_out_guarded() -> None:
+    for yaml_path in sorted(builtin_recipes_dir().glob("*.yaml")):
+        recipe = load_recipe(yaml_path)
+        findings = [f for f in run_semantic_rules(recipe) if f.rule == _TIMED_OUT_RULE]
+        assert not findings, f"{yaml_path.name}: {[f.message for f in findings]}"
+
+
+def test_ci_watch_post_queue_fix_timeout_600s() -> None:
+    target_recipes = ["implementation.yaml", "remediation.yaml", "implementation-groups.yaml"]
+    for name in target_recipes:
+        recipe = load_recipe(builtin_recipes_dir() / name)
+        step = recipe.steps["ci_watch_post_queue_fix"]
+        assert step.with_args["timeout_seconds"] == 600, (
+            f"{name}: ci_watch_post_queue_fix timeout_seconds is "
+            f"{step.with_args['timeout_seconds']}, expected 600"
+        )
+
+
+# ---------------------------------------------------------------------------
 # ci-event-literal-merge-group rule tests
 # ---------------------------------------------------------------------------
 

--- a/tests/recipe/test_rules_ci.py
+++ b/tests/recipe/test_rules_ci.py
@@ -718,6 +718,29 @@ def test_bundled_recipes_no_runs_guarded() -> None:
 _TIMED_OUT_RULE = "ci-timed-out-unguarded"
 
 
+def test_ci_timed_out_unguarded_detects_bare_on_success() -> None:
+    """wait_for_ci with on_success but no on_result must be flagged."""
+    recipe = _make_workflow(
+        {
+            "ci_watch": {
+                "tool": "wait_for_ci",
+                "on_success": "merge_step",
+                "on_failure": "handle_failure",
+                "with": {"event": "${{ context.ci_event }}", "branch": "main"},
+            },
+            "merge_step": {"tool": "enqueue_pr"},
+            "handle_failure": {
+                "tool": "run_skill",
+                "with": {"skill_command": "/autoskillit:diagnose-ci b - -"},
+            },
+        }
+    )
+    findings = [f for f in run_semantic_rules(recipe) if f.rule == _TIMED_OUT_RULE]
+    assert len(findings) == 1
+    assert findings[0].severity == Severity.ERROR
+    assert findings[0].step_name == "ci_watch"
+
+
 def test_ci_timed_out_unguarded_fires_with_only_catch_all() -> None:
     recipe = _make_workflow(
         {


### PR DESCRIPTION
## Summary

Four coordinated changes to the CI watcher subsystem:

1. **Backoff floors** in `_jittered_sleep` — eliminate near-zero sleeps that cause API burst risk
2. **Timeout bump** — raise `ci_watch_post_queue_fix` from 300s to 600s in three implementation-family recipes
3. **Enriched `timed_out` response** — add `run_status` and `hint` fields so orchestrators know CI is still running (not failed)
4. **`ci-timed-out-unguarded` semantic rule** — flag `wait_for_ci` steps whose `on_result` routing lacks an explicit `timed_out` arm (catch-all does NOT satisfy the guard, unlike `ci-no-runs-unguarded`), plus recipe updates to add explicit `timed_out` self-loop routing to all affected steps

## Architecture Impact

### Error/Resilience Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ENTRY %%
    ENTRY([Recipe Step Invokes wait_for_ci])

    subgraph CIWatcher ["● CI WATCHER — execution/ci.py"]
        direction TB

        RESOLVE{"Resolve<br/>owner/repo"}
        RESOLVE -->|"missing"| NO_REPO["conclusion: error<br/>━━━━━━━━━━<br/>Could not determine repo"]

        RESOLVE -->|"resolved"| PHASE1["Phase 1: Lookback<br/>━━━━━━━━━━<br/>_fetch_completed_runs<br/>lookback_seconds=120"]

        PHASE1 -->|"scope match"| EVAL_CONCLUSION
        PHASE1 -->|"no match / empty"| PHASE2

        subgraph BackoffLoop ["● BACKOFF POLLING LOOP"]
            direction TB
            PHASE2["Phase 2: Poll Active Runs<br/>━━━━━━━━━━<br/>_fetch_active_runs"]
            SLEEP["● Jittered Sleep<br/>━━━━━━━━━━<br/>Band 0: 5–10 s<br/>Band 1: 10–20 s<br/>Band 2+: 15–30 s floor"]
            DEADLINE{"deadline<br/>exceeded?"}
            PHASE2 -->|"no active run"| SLEEP
            SLEEP --> DEADLINE
            DEADLINE -->|"no"| PHASE2
            DEADLINE -->|"yes, no run found"| NO_RUNS
        end

        PHASE2 -->|"run found"| PHASE3

        subgraph WaitLoop ["COMPLETION WAIT LOOP"]
            direction TB
            PHASE3["Phase 3: Poll Run Status<br/>━━━━━━━━━━<br/>GET /runs/{id}"]
            SLEEP3["● Jittered Sleep<br/>━━━━━━━━━━<br/>Bands reset to 0<br/>capped by remaining"]
            DEADLINE3{"deadline<br/>exceeded?"}
            PHASE3 -->|"still in_progress"| SLEEP3
            SLEEP3 --> DEADLINE3
            DEADLINE3 -->|"no"| PHASE3
            DEADLINE3 -->|"yes"| CLIENT_TIMEOUT
        end

        PHASE3 -->|"run completed"| EVAL_CONCLUSION

        EVAL_CONCLUSION{"Evaluate<br/>conclusion"}
    end

    subgraph HTTPErrors ["● HTTP ERROR HANDLING — ci.py"]
        direction TB
        HTTP_STATUS["httpx.HTTPStatusError<br/>━━━━━━━━━━<br/>4xx / 5xx response"]
        HTTP_REQ["httpx.RequestError<br/>━━━━━━━━━━<br/>DNS / transport failure"]
        HTTP_OUT["conclusion: error<br/>━━━━━━━━━━<br/>status + first 200 chars"]
        HTTP_STATUS --> HTTP_OUT
        HTTP_REQ --> HTTP_OUT
    end

    subgraph Conclusions ["CI CONCLUSION ROUTING"]
        direction TB
        SUCCESS["conclusion: success"]
        FAILURE["conclusion: failure<br/>━━━━━━━━━━<br/>+ failed_jobs list"]
        GH_TIMEOUT["conclusion: timed_out<br/>━━━━━━━━━━<br/>GitHub-side timeout<br/>failed_jobs populated"]
        CLIENT_TIMEOUT["● conclusion: timed_out<br/>━━━━━━━━━━<br/>Client deadline exceeded<br/>run_status: in_progress<br/>hint: call again"]
        NO_RUNS["conclusion: no_runs<br/>━━━━━━━━━━<br/>No run in window<br/>+ branch, poll_duration_s"]
        CANCELLED["conclusion: cancelled /<br/>startup_failure"]
        ACTION_REQ["conclusion: action_required<br/>━━━━━━━━━━<br/>Billing / permissions gate"]
    end

    subgraph RecipeRouting ["● RECIPE timed_out SELF-LOOP ROUTING"]
        direction TB
        CI_WATCH["ci_watch<br/>━━━━━━━━━━<br/>timeout: 300 s"]
        CI_POST["ci_watch_post_queue_fix<br/>━━━━━━━━━━<br/>● timeout: 600 s"]
        CI_PR["ci_watch_pr<br/>━━━━━━━━━━<br/>timeout: 300 s<br/>(merge-prs only)"]
        CI_CONFLICT["wait_for_conflict_ci<br/>━━━━━━━━━━<br/>timeout: 600 s<br/>(merge-prs only)"]

        CI_WATCH -->|"● timed_out → self"| CI_WATCH
        CI_POST -->|"● timed_out → self"| CI_POST
        CI_PR -->|"● timed_out → self"| CI_PR
        CI_CONFLICT -->|"● timed_out → self"| CI_CONFLICT
    end

    subgraph ValidationGates ["● STATIC VALIDATION GATES — rules_ci.py / rules_graph.py"]
        direction TB
        RULE_TIMEOUT["● ci-timed-out-unguarded<br/>━━━━━━━━━━<br/>ERROR: no explicit<br/>timed_out arm in on_result<br/>catch-all insufficient"]
        RULE_NORUNS["ci-no-runs-unguarded<br/>━━━━━━━━━━<br/>ERROR: no explicit<br/>no_runs condition"]
        RULE_CONFLICT["ci-failure-missing-<br/>conflict-gate<br/>━━━━━━━━━━<br/>ERROR: no stale-base<br/>gate before resolve"]
        RULE_CYCLE["● unbounded-cycle<br/>━━━━━━━━━━<br/>ERROR/WARN: cycle<br/>with no exit edge<br/>wait_for_ci on_result exempt"]
        RULE_ONFAIL["on-result-missing-<br/>failure-route<br/>━━━━━━━━━━<br/>ERROR: on_result<br/>without on_failure"]
        RULE_EVENT["ci-missing-event-scope<br/>━━━━━━━━━━<br/>ERROR: wait_for_ci<br/>without event param"]
    end

    subgraph RecipeRecovery ["RECIPE-LEVEL RECOVERY PATHS"]
        direction TB
        FIX["resolve-failures skill<br/>━━━━━━━━━━<br/>Test failure recovery<br/>retries: 2–3"]
        DETECT_CI["detect_ci_conflict<br/>━━━━━━━━━━<br/>Stale-base detection"]
        DIAGNOSE["diagnose_ci<br/>━━━━━━━━━━<br/>Full CI failure analysis"]
        RESOLVE_CI["resolve_ci<br/>━━━━━━━━━━<br/>retries: 2"]
        HANDLE_NORUNS["handle_no_ci_runs<br/>━━━━━━━━━━<br/>retries: 1<br/>→ trigger_ci_actively"]
        QUEUE_EJECT["Queue ejection recovery<br/>━━━━━━━━━━<br/>check_eject_limit ≤ 3<br/>→ rebase → re-push<br/>→ ci_watch_post_queue_fix"]
    end

    subgraph Terminals ["TERMINAL STATES"]
        T_DONE([done — Pipeline complete])
        T_RELEASE([release_issue_failure<br/>Issue released, clone preserved])
        T_ESCALATE([escalate_stop<br/>Human intervention needed])
        T_UNCONFIRMED([register_clone_unconfirmed<br/>Merge unconfirmed, label kept])
        T_NO_CI([escalate_stop_no_ci<br/>CI watch loop exhausted])
    end

    %% ENTRY CONNECTIONS %%
    ENTRY --> RESOLVE

    %% HTTP ERRORS (any phase) %%
    PHASE1 -.->|"HTTP exception"| HTTP_STATUS
    PHASE2 -.->|"HTTP exception"| HTTP_REQ
    PHASE3 -.->|"HTTP exception"| HTTP_STATUS
    HTTP_OUT --> T_ESCALATE

    %% CONCLUSION EVALUATION %%
    EVAL_CONCLUSION -->|"success"| SUCCESS
    EVAL_CONCLUSION -->|"failure / startup_failure / cancelled"| FAILURE
    EVAL_CONCLUSION -->|"timed_out (GitHub)"| GH_TIMEOUT
    EVAL_CONCLUSION -->|"action_required"| ACTION_REQ

    %% CONCLUSION → RECIPE ROUTING %%
    SUCCESS -->|"on_result"| T_DONE
    CLIENT_TIMEOUT -->|"● on_result timed_out"| CI_WATCH
    NO_RUNS -->|"on_result no_runs"| HANDLE_NORUNS
    FAILURE -->|"on_failure / fallthrough"| DETECT_CI
    GH_TIMEOUT -->|"on_failure / fallthrough"| DETECT_CI

    %% RECIPE RECOVERY %%
    DETECT_CI --> DIAGNOSE
    DIAGNOSE --> RESOLVE_CI
    RESOLVE_CI -->|"exhausted"| T_RELEASE
    HANDLE_NORUNS -->|"exhausted"| T_RELEASE
    HANDLE_NORUNS -->|"trigger_ci_actively exhausted"| T_NO_CI
    FIX -->|"exhausted / ci_only"| T_RELEASE
    QUEUE_EJECT -->|"eject_limit > 3"| T_RELEASE

    %% RECIPE CI STEPS → DONE %%
    CI_WATCH -->|"success"| T_DONE
    CI_POST -->|"success"| T_DONE
    CI_PR -->|"success"| T_DONE

    %% VALIDATION GATE OUTPUTS %%
    RULE_TIMEOUT -->|"blocks deploy"| T_ESCALATE
    RULE_CYCLE -->|"blocks deploy"| T_ESCALATE

    %% CLASS ASSIGNMENTS %%
    class ENTRY,T_DONE,T_ESCALATE,T_NO_CI terminal;
    class RESOLVE,DEADLINE,DEADLINE3,EVAL_CONCLUSION stateNode;
    class PHASE1,PHASE2,PHASE3 handler;
    class SLEEP,SLEEP3 phase;
    class HTTP_STATUS,HTTP_REQ,HTTP_OUT gap;
    class NO_REPO,NO_RUNS,CLIENT_TIMEOUT,FAILURE,GH_TIMEOUT,CANCELLED,ACTION_REQ gap;
    class SUCCESS output;
    class CI_WATCH,CI_POST,CI_PR,CI_CONFLICT handler;
    class RULE_TIMEOUT,RULE_NORUNS,RULE_CONFLICT,RULE_CYCLE,RULE_ONFAIL,RULE_EVENT detector;
    class FIX,DETECT_CI,DIAGNOSE,RESOLVE_CI,HANDLE_NORUNS,QUEUE_EJECT output;
    class T_RELEASE,T_UNCONFIRMED phase;
```

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START: recipe step<br/>calls wait_for_ci])
    DONE([DONE: route to<br/>next recipe step])
    ERROR([ERROR: httpx<br/>exception caught])

    subgraph P1 ["● Phase 1 — Lookback Window"]
        direction TB
        P1_FETCH["● _fetch_completed_runs<br/>━━━━━━━━━━<br/>GET /actions/runs?status=completed<br/>Filter by lookback_seconds"]
        P1_SCOPE{"● _validate_run_matches_scope<br/>━━━━━━━━━━<br/>Event & SHA<br/>match?"}
        P1_FOUND{"Completed run<br/>in window?"}
    end

    subgraph P2 ["● Phase 2 — Poll for Active Run"]
        direction TB
        P2_FETCH["● _fetch_active_runs<br/>━━━━━━━━━━<br/>GET /actions/runs?per_page=1<br/>Client-side !completed filter"]
        P2_ACTIVE{"Active run<br/>found?"}
        P2_RECHECK["Re-check completed<br/>━━━━━━━━━━<br/>_fetch_completed_runs again<br/>in case CI finished"]
        P2_RECHECK_HIT{"Newly<br/>completed?"}
        P2_BACKOFF["● _jittered_sleep<br/>━━━━━━━━━━<br/>Band 0: 5–10s floor<br/>Band 1: 10–20s<br/>Band 2+: 15–30s"]
        P2_DEADLINE{"Deadline<br/>expired?"}
    end

    subgraph P3 ["● Phase 3 — Wait for Completion"]
        direction TB
        P3_POLL["● _poll_run_status<br/>━━━━━━━━━━<br/>GET /actions/runs/{run_id}<br/>Fresh status, no ETag"]
        P3_COMPLETE{"status ==<br/>completed?"}
        P3_BACKOFF["● _jittered_sleep<br/>━━━━━━━━━━<br/>Same band-based floors"]
        P3_DEADLINE{"Deadline<br/>expired?"}
    end

    subgraph RESULT ["● Conclusion Routing"]
        direction TB
        CONCLUSION{"conclusion<br/>value?"}
        R_SUCCESS["success / neutral / skipped<br/>━━━━━━━━━━<br/>returns conclusion +<br/>empty failed_jobs"]
        R_FAIL["● failure / cancelled /<br/>startup_failure<br/>━━━━━━━━━━<br/>_fetch_failed_jobs<br/>returns job names"]
        R_NORUNS["no_runs<br/>━━━━━━━━━━<br/>No repo resolved or<br/>deadline expired with<br/>no active/completed runs"]
        R_TIMEOUT["● timed_out<br/>━━━━━━━━━━<br/>Deadline expired, run<br/>still in_progress<br/>hint: call again"]
        R_ERROR["error<br/>━━━━━━━━━━<br/>httpx exception<br/>caught by try/except"]
    end

    subgraph RECIPE ["● Recipe-Level timed_out Self-Loop"]
        direction TB
        ON_RESULT{"● on_result<br/>━━━━━━━━━━<br/>Route by<br/>conclusion"}
        SELF_LOOP["● timed_out → self<br/>━━━━━━━━━━<br/>ci_watch → ci_watch<br/>Restarts 300s/600s window"]
        NO_RUNS_HANDLE["handle_no_ci_runs<br/>━━━━━━━━━━<br/>Re-derive ci_event<br/>or escalate"]
        CI_FAIL_PATH["detect_ci_conflict<br/>━━━━━━━━━━<br/>Conflict gate →<br/>resolve-failures"]
        CI_SUCCESS_PATH["check_repo_merge_state<br/>━━━━━━━━━━<br/>Proceed to merge<br/>or queue enrollment"]
    end

    subgraph RULES ["● Validation Rules (Static Analysis)"]
        direction TB
        RULE_TIMEOUT["● ci-timed-out-unguarded<br/>━━━━━━━━━━<br/>ERROR if no explicit<br/>timed_out arm in on_result<br/>Catch-all NOT sufficient"]
        RULE_NORUNS["● ci-no-runs-unguarded<br/>━━━━━━━━━━<br/>ERROR if no explicit<br/>no_runs arm or catch-all"]
        RULE_CYCLE["● unbounded-cycle<br/>━━━━━━━━━━<br/>Exempts wait_for_ci cycles<br/>when on_result exits cycle"]
        RULE_CONFLICT["● ci-failure-missing-<br/>conflict-gate<br/>━━━━━━━━━━<br/>BFS: failure path must<br/>hit gate before resolve"]
    end

    %% === MAIN FLOW === %%
    START --> P1_FETCH
    P1_FETCH --> P1_FOUND
    P1_FOUND -->|"yes"| P1_SCOPE
    P1_FOUND -->|"no"| P2_FETCH
    P1_SCOPE -->|"match"| CONCLUSION
    P1_SCOPE -->|"mismatch"| P2_FETCH

    P2_FETCH --> P2_ACTIVE
    P2_ACTIVE -->|"yes, scope valid"| P3_POLL
    P2_ACTIVE -->|"no"| P2_RECHECK
    P2_RECHECK --> P2_RECHECK_HIT
    P2_RECHECK_HIT -->|"yes"| CONCLUSION
    P2_RECHECK_HIT -->|"no"| P2_BACKOFF
    P2_BACKOFF --> P2_DEADLINE
    P2_DEADLINE -->|"no"| P2_FETCH
    P2_DEADLINE -->|"yes"| R_NORUNS

    P3_POLL --> P3_COMPLETE
    P3_COMPLETE -->|"yes"| CONCLUSION
    P3_COMPLETE -->|"no"| P3_BACKOFF
    P3_BACKOFF --> P3_DEADLINE
    P3_DEADLINE -->|"no"| P3_POLL
    P3_DEADLINE -->|"yes"| R_TIMEOUT

    CONCLUSION -->|"success/neutral/skipped"| R_SUCCESS
    CONCLUSION -->|"failure/cancelled/timed_out*"| R_FAIL
    CONCLUSION -->|"no_runs"| R_NORUNS
    CONCLUSION -->|"error"| R_ERROR

    R_SUCCESS --> ON_RESULT
    R_FAIL --> ON_RESULT
    R_NORUNS --> ON_RESULT
    R_TIMEOUT --> ON_RESULT
    R_ERROR --> ERROR

    ON_RESULT -->|"timed_out"| SELF_LOOP
    SELF_LOOP -->|"re-enter"| START
    ON_RESULT -->|"no_runs"| NO_RUNS_HANDLE
    ON_RESULT -->|"success"| CI_SUCCESS_PATH
    ON_RESULT -->|"failure"| CI_FAIL_PATH
    CI_SUCCESS_PATH --> DONE
    NO_RUNS_HANDLE --> DONE
    CI_FAIL_PATH --> DONE

    %% === VALIDATION CROSS-CUTS === %%
    RULE_TIMEOUT -.->|"enforces explicit arm"| ON_RESULT
    RULE_NORUNS -.->|"enforces explicit arm"| ON_RESULT
    RULE_CYCLE -.->|"exempts self-loop"| SELF_LOOP
    RULE_CONFLICT -.->|"enforces gate before resolve"| CI_FAIL_PATH

    %% CLASS ASSIGNMENTS %%
    class START,DONE,ERROR terminal;
    class P1_FETCH,P2_FETCH,P2_RECHECK,P3_POLL handler;
    class P1_FOUND,P1_SCOPE,P2_ACTIVE,P2_RECHECK_HIT,P3_COMPLETE,P2_DEADLINE,P3_DEADLINE,CONCLUSION,ON_RESULT stateNode;
    class P2_BACKOFF,P3_BACKOFF phase;
    class R_SUCCESS,R_FAIL,R_NORUNS,R_TIMEOUT,R_ERROR output;
    class SELF_LOOP,NO_RUNS_HANDLE,CI_FAIL_PATH,CI_SUCCESS_PATH handler;
    class RULE_TIMEOUT,RULE_NORUNS,RULE_CYCLE,RULE_CONFLICT detector;
```

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START([wait_for_ci invocation])

    subgraph InitOnly ["INIT_ONLY — Frozen at Construction"]
        direction TB
        SCOPE["● CIRunScope<br/>━━━━━━━━━━<br/>workflow, head_sha, event<br/>frozen=True dataclass"]
        BANDS["● _BACKOFF_BANDS<br/>━━━━━━━━━━<br/>floors: 5s → 10s → 15s<br/>ceilings: 10s → 20s → 30s"]
        DEADLINE["deadline<br/>━━━━━━━━━━<br/>monotonic + timeout_seconds<br/>Set once at entry"]
    end

    subgraph Mutable ["MUTABLE — Tracked Per-Loop"]
        direction TB
        ATTEMPT["● attempt counter<br/>━━━━━━━━━━<br/>Indexes into BACKOFF_BANDS<br/>Reset per phase, inc per iter"]
        FOUND["found_run<br/>━━━━━━━━━━<br/>None → run dict<br/>Phase 2→3 gate"]
        ETAG["_etag_cache<br/>━━━━━━━━━━<br/>url → etag, json<br/>Append-only within call"]
    end

    subgraph Derived ["DERIVED — Computed Per Iteration"]
        direction TB
        SLEEP["● sleep_duration<br/>━━━━━━━━━━<br/>_jittered_sleep output<br/>Clamped to remaining"]
        REMAINING["remaining<br/>━━━━━━━━━━<br/>deadline − monotonic<br/>Oversleep guard"]
        RESULT["● Result dict<br/>━━━━━━━━━━<br/>conclusion, hint,<br/>run_status, failed_jobs"]
    end

    subgraph Gates ["● VALIDATION GATES — Semantic Rules"]
        direction TB
        G_SCOPE["● _validate_run_matches_scope<br/>━━━━━━━━━━<br/>Filters runs by event + sha<br/>Defense-in-depth"]
        G_TIMEOUT["● ci-timed-out-unguarded<br/>━━━━━━━━━━<br/>Requires EXPLICIT timed_out arm<br/>Catch-all insufficient"]
        G_NORUNS["ci-no-runs-unguarded<br/>━━━━━━━━━━<br/>Requires no_runs in on_result<br/>Catch-all acceptable"]
        G_CONFLICT["ci-failure-missing-conflict-gate<br/>━━━━━━━━━━<br/>Failure → resolve needs<br/>merge-base barrier"]
        G_CYCLE["● unbounded-cycle<br/>━━━━━━━━━━<br/>DFS cycle detection<br/>Exempts wait_for_ci on_result exits"]
    end

    subgraph Routing ["● RECIPE ROUTING — timed_out Contract"]
        direction TB
        ROUTE_SUCCESS["on_result: success<br/>━━━━━━━━━━<br/>→ next step"]
        ROUTE_TIMEOUT["● on_result: timed_out<br/>━━━━━━━━━━<br/>→ SELF re-watch<br/>CI still in progress"]
        ROUTE_NORUNS["on_result: no_runs<br/>━━━━━━━━━━<br/>→ domain-specific handler"]
        ROUTE_CATCHALL["on_result: catch-all<br/>━━━━━━━━━━<br/>→ failure path"]
    end

    %% FLOW %%
    START --> SCOPE
    SCOPE --> DEADLINE
    BANDS --> SLEEP

    DEADLINE --> ATTEMPT
    ATTEMPT --> FOUND
    FOUND --> ETAG
    ETAG --> G_SCOPE

    G_SCOPE -->|"runs filtered"| REMAINING
    REMAINING -->|"remaining > 0"| SLEEP
    SLEEP -->|"async sleep"| ATTEMPT

    REMAINING -->|"remaining ≤ 0"| RESULT
    FOUND -->|"completed"| RESULT

    RESULT --> G_TIMEOUT
    RESULT --> G_NORUNS
    G_TIMEOUT --> ROUTE_TIMEOUT
    G_NORUNS --> ROUTE_NORUNS
    G_CONFLICT --> ROUTE_CATCHALL
    G_CYCLE --> ROUTE_TIMEOUT

    ROUTE_TIMEOUT -->|"self-loop"| START
    ROUTE_SUCCESS --> END([Done])

    %% CLASS ASSIGNMENTS %%
    class SCOPE,BANDS,DEADLINE detector;
    class ATTEMPT,FOUND,ETAG phase;
    class SLEEP,REMAINING,RESULT output;
    class G_SCOPE,G_TIMEOUT,G_NORUNS,G_CONFLICT,G_CYCLE stateNode;
    class ROUTE_SUCCESS,ROUTE_NORUNS,ROUTE_CATCHALL handler;
    class ROUTE_TIMEOUT gap;
    class START,END terminal;
```

Closes #1369

## Implementation Plan

Plan file: `.autoskillit/temp/make-plan/ci_watch_backoff_floors_timeout_bump_timed_out_guidance_sema_plan_2026-04-27_073801.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| audit_feature_gates | 4.7k | 5.9k | 193.1k | 43.6k | 1 | 4m 28s |
| audit_arch | 15 | 8.2k | 514.6k | 12.6k | 1 | 12m 9s |
| audit_docs | 12.7k | 11.8k | 1.2M | 92.8k | 1 | 21m 19s |
| audit_cohesion | 29.7k | 22.6k | 977.5k | 131.8k | 1 | 28m 42s |
| **Total** | 47.1k | 48.6k | 2.9M | 280.8k | | 1h 6m |