### PR TITLE
Fix _llm_triage Cascade Direction

### DIFF
--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -303,7 +303,7 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
     ),
     # Standalone modules (not subpackage directories)
     "planner": frozenset({"planner", "recipe"}),
-    "_llm_triage": frozenset({"test_llm_triage.py", "execution", "server", "recipe"}),
+    "_llm_triage": frozenset({"test_llm_triage.py", "server"}),
     "_test_filter": frozenset({"arch", "infra", "contracts"}),
     "smoke_utils": frozenset({"test_smoke_utils.py", "recipe"}),
     "version": frozenset({"test_version.py", "server", "cli"}),

--- a/tests/test_test_filter_cascade.py
+++ b/tests/test_test_filter_cascade.py
@@ -22,12 +22,12 @@ class TestCascadeNewEntries:
                 ["planner"],
                 ["planner"],
             ),
-            # Conservative: _llm_triage cascades into execution/server/recipe + direct test file
+            # Conservative: _llm_triage cascades into server + direct test file
             (
                 "src/autoskillit/_llm_triage.py",
                 FilterMode.CONSERVATIVE,
-                ["execution", "server", "recipe", "test_llm_triage.py"],
-                ["execution", "server", "recipe", "test_llm_triage.py"],
+                ["server", "test_llm_triage.py"],
+                ["server", "test_llm_triage.py"],
             ),
             # Conservative: smoke_utils cascades into recipe + direct test file
             (


### PR DESCRIPTION
## Summary

`LAYER_CASCADE_CONSERVATIVE["_llm_triage"]` in `tests/_test_filter.py` incorrectly listed `"execution"` and `"recipe"` as downstream test targets. The direction is backwards: `_llm_triage.py` imports FROM both modules (`parse_session_result`, `run_managed_async` from execution; `StaleItem`, `load_bundled_manifest` from recipe). A change to `_llm_triage.py` cannot break execution or recipe tests. Only `server` is a legitimate downstream — `server/helpers.py` imports `triage_staleness` from `_llm_triage`. Removing the two wrong-direction entries saves ~3,082 tests per `_llm_triage.py`-only change.

Two files need changes: the cascade map and its test expectations.

## Requirements

### REQ-TRIAGE-001: Narrow _llm_triage cascade

Change `LAYER_CASCADE_CONSERVATIVE["_llm_triage"]` from:
```python
"_llm_triage": frozenset({"test_llm_triage.py", "execution", "server", "recipe"})
```
to:
```python
"_llm_triage": frozenset({"test_llm_triage.py", "server"})
```

### REQ-TRIAGE-002: Update cascade tests

Update `tests/test_test_filter_cascade.py` or equivalent hardcoded cascade expectations.

### REQ-TRIAGE-003: Validate no reverse dependency exists

Verify via grep that no file in `tests/execution/` or `tests/recipe/` imports from `autoskillit._llm_triage`. If any do, add them as file-level entries instead.

## Architecture Impact

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ─────────────── PRODUCTION LAYERS ─────────────── %%

    subgraph L3 ["LAYER 3 — SERVER"]
        direction LR
        ServerHelpers["server/helpers.py<br/>━━━━━━━━━━<br/>deferred import of<br/>triage_staleness"]
    end

    subgraph L2 ["LAYER 2 — TOP-LEVEL STANDALONE"]
        direction LR
        LlmTriage["_llm_triage.py<br/>━━━━━━━━━━<br/>triage_staleness()<br/>Imports: core+execution<br/>+recipe+workspace"]
    end

    subgraph L1 ["LAYER 1 — INFRASTRUCTURE"]
        direction LR
        Execution["execution/<br/>━━━━━━━━━━<br/>parse_session_result<br/>run_managed_async"]
        Recipe["recipe/<br/>━━━━━━━━━━<br/>StaleItem<br/>load_bundled_manifest"]
        Workspace["workspace/<br/>━━━━━━━━━━<br/>bundled_skills_dir"]
    end

    subgraph L0 ["LAYER 0 — CORE (zero autoskillit deps)"]
        direction LR
        Core["core/<br/>━━━━━━━━━━<br/>ClaudeFlags, OutputFormat<br/>build_claude_env, get_logger<br/>load_yaml"]
    end

    subgraph SrcFilter ["SRC TEST FILTER (top-level standalone)"]
        direction LR
        SrcTestFilter["src/autoskillit/_test_filter.py<br/>━━━━━━━━━━<br/>load_manifest()<br/>apply_manifest()<br/>pathspec + core.load_yaml"]
    end

    %% ─────────────── TEST INFRASTRUCTURE ─────────────── %%

    subgraph TestInfra ["TEST INFRASTRUCTURE (stdlib + pathspec only — no autoskillit imports)"]
        direction LR
        TestsFilter["● tests/_test_filter.py<br/>━━━━━━━━━━<br/>FilterMode, build_test_scope<br/>LAYER_CASCADE_CONSERVATIVE<br/>LAYER_CASCADE_AGGRESSIVE<br/>MODULE_CASCADE_CORE<br/>ASTImportWalker"]
    end

    subgraph TestCascade ["TEST — CASCADE CONTRACTS (REQ-FILT-003)"]
        direction LR
        TestFilterCascade["● tests/test_test_filter_cascade.py<br/>━━━━━━━━━━<br/>Validates _llm_triage, planner<br/>smoke_utils, version cascade entries<br/>FilterMode + build_test_scope"]
    end

    subgraph TestValidators ["TEST VALIDATORS (import from both src + tests filter)"]
        direction TB
        TestFilterMain["tests/test_test_filter.py<br/>━━━━━━━━━━<br/>imports BOTH autoskillit._test_filter<br/>AND tests._test_filter"]
        CascadeGuard["tests/arch/test_cascade_map_guard.py<br/>━━━━━━━━━━<br/>LAYER_CASCADE_CONSERVATIVE<br/>MODULE_CASCADE_CORE<br/>_file_to_package"]
        FilterContracts["tests/arch/test_filter_contracts.py<br/>━━━━━━━━━━<br/>AST contract enforcement<br/>src vs tests _test_filter"]
        ArchConftest["tests/arch/conftest.py<br/>━━━━━━━━━━<br/>git_changed_files"]
        Conftest["tests/conftest.py<br/>━━━━━━━━━━<br/>build_test_scope (deferred)<br/>runtime test scoping"]
        ManifestTest["tests/infra/test_manifest_completeness.py<br/>━━━━━━━━━━<br/>autoskillit._test_filter.load_manifest"]
    end

    %% ─────────────── PRODUCTION DEPENDENCIES ─────────────── %%
    ServerHelpers -->|"deferred import<br/>triage_staleness"| LlmTriage
    LlmTriage -->|"core L0"| Core
    LlmTriage -->|"execution L1"| Execution
    LlmTriage -->|"recipe L2"| Recipe
    LlmTriage -->|"workspace"| Workspace
    Execution -->|"core L0"| Core
    Recipe -->|"core L0"| Core
    Workspace -->|"core L0"| Core
    SrcTestFilter -->|"core.load_yaml"| Core

    %% ─────────────── TEST INFRASTRUCTURE DEPS ─────────────── %%
    TestFilterCascade -->|"FilterMode, build_test_scope"| TestsFilter
    TestFilterMain -->|"many exports"| TestsFilter
    TestFilterMain -->|"apply_manifest, load_manifest"| SrcTestFilter
    CascadeGuard -->|"cascade maps<br/>_file_to_package"| TestsFilter
    FilterContracts -->|"AST contract"| TestsFilter
    FilterContracts -->|"AST contract"| SrcTestFilter
    ArchConftest -->|"git_changed_files"| TestsFilter
    Conftest -->|"build_test_scope (deferred)"| TestsFilter
    ManifestTest -->|"load_manifest"| SrcTestFilter

    %% ─────────────── WHAT THE CASCADE MAP ENCODES ─────────────── %%
    TestsFilter -.->|"cascade entry:<br/>_llm_triage → {test_llm_triage.py, server}<br/>(conservative)"| LlmTriage
    TestsFilter -.->|"cascade entry:<br/>_llm_triage → {test_llm_triage.py}<br/>(aggressive)"| LlmTriage

    %% CLASS ASSIGNMENTS %%
    class ServerHelpers cli;
    class LlmTriage stateNode;
    class Execution,Recipe,Workspace,Core handler;
    class SrcTestFilter phase;
    class TestsFilter,TestFilterCascade detector;
    class TestFilterMain,CascadeGuard,FilterContracts,ArchConftest,Conftest,ManifestTest output;
```

Closes #1381

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-1381-20260427-121248-842450/.autoskillit/temp/make-plan/fix_llm_triage_cascade_direction_plan_2026-04-27_121248.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 145 | 13.2k | 696.1k | 51.1k | 1 | 5m 45s |
| verify | 68 | 6.1k | 260.6k | 36.0k | 1 | 2m 3s |
| implement | 100 | 3.4k | 353.5k | 24.8k | 1 | 1m 20s |
| prepare_pr | 60 | 4.2k | 196.2k | 26.3k | 1 | 1m 14s |
| run_arch_lenses | 3.1k | 6.3k | 138.3k | 66.0k | 1 | 3m 12s |
| compose_pr | 59 | 4.3k | 191.7k | 24.9k | 1 | 1m 20s |
| **Total** | 3.5k | 37.5k | 1.8M | 229.2k | | 14m 56s |