### PR TITLE
Fix hooks→execution/test_quota.py False Negative in Cascade Map

### DIFF
--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -290,6 +290,7 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             "cli",
             "fleet",
             "server",
+            "execution/test_quota.py",
         }
     ),
     "hook_registry": frozenset(

--- a/tests/test_test_filter_cascade.py
+++ b/tests/test_test_filter_cascade.py
@@ -71,6 +71,13 @@ class TestCascadeNewEntries:
                 ["test_version.py"],
                 ["test_version.py"],
             ),
+            # Conservative: quota_guard.py cascades into hooks tests + execution/test_quota.py
+            (
+                "src/autoskillit/hooks/quota_guard.py",
+                FilterMode.CONSERVATIVE,
+                ["hooks", "execution", "execution/test_quota.py"],
+                ["hooks", "test_quota.py"],
+            ),
         ],
     )
     def test_cascade_new_entries_not_full_run(


### PR DESCRIPTION
## Summary

`LAYER_CASCADE_CONSERVATIVE["hooks"]` in `tests/_test_filter.py` is missing `"execution/test_quota.py"`. The test at `tests/execution/test_quota.py:646` contains a deferred import `from autoskillit.hooks.quota_guard import main` inside `TestIntegration.test_write_cache_then_quota_check_main_reads_it`. Because `"execution"` (or any file-level entry pointing to this test) is absent from the `"hooks"` cascade, changes to `hooks/quota_guard.py` will not trigger this test under the conservative filter — a false negative that allows format drift between `execution.quota._write_cache` and `hooks.quota_guard.main` to go undetected.

The fix is two targeted changes: add one string to one frozenset, and add one parametrize case to one test class.

## Requirements

### REQ-HOOK-FN-001: Add file-level entry to hooks cascade

Add `"execution/test_quota.py"` to `LAYER_CASCADE_CONSERVATIVE["hooks"]` in `tests/_test_filter.py`.

**Current entry:**
```python
"hooks": frozenset({"hooks", "infra", "cli", "fleet", "server"})
```

**Target entry:**
```python
"hooks": frozenset({"hooks", "infra", "cli", "fleet", "server", "execution/test_quota.py"})
```

### REQ-HOOK-FN-002: Update cascade guard tests

Update any hardcoded cascade expectations in `tests/test_test_filter_cascade.py` or similar test files that validate the hooks cascade contents.

## Architecture Impact

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph L3 ["L3 — TEST HARNESS"]
        CONFTEST["tests/conftest.py<br/>━━━━━━━━━━<br/>pytest_configure<br/>pytest_collection_modifyitems<br/>test scope driver"]
    end

    subgraph L2 ["L2 — CASCADE VALIDATION"]
        CASCADE_TEST["● tests/test_test_filter_cascade.py<br/>━━━━━━━━━━<br/>REQ-FILT-003 regression guard<br/>+1 parametrize case<br/>(hooks/quota_guard cascade)"]
    end

    subgraph L1_TESTS ["L1 — TEST FILTER CORE (tests/)"]
        TEST_FILTER["● tests/_test_filter.py<br/>━━━━━━━━━━<br/>FilterMode, build_test_scope<br/>LAYER_CASCADE_CONSERVATIVE<br/>LAYER_CASCADE_AGGRESSIVE<br/>+execution/test_quota.py in hooks entry"]
    end

    subgraph L1_SRC ["L1 — SRC FILTER (src/autoskillit/)"]
        SRC_FILTER["src/autoskillit/_test_filter.py<br/>━━━━━━━━━━<br/>load_manifest, apply_manifest<br/>non-Python file routing only"]
    end

    subgraph L0_SRC ["L0 — SOURCE MODULES"]
        QUOTA_GUARD["src/autoskillit/hooks/quota_guard.py<br/>━━━━━━━━━━<br/>PreToolUse hook<br/>blocks run_skill on quota limit"]
        QUOTA_SRC["src/autoskillit/execution/quota.py<br/>━━━━━━━━━━<br/>QuotaStatus, QuotaWindowEntry<br/>check_and_sleep_if_needed"]
    end

    subgraph L0_TESTS ["L0 — TEST TARGETS"]
        QUOTA_TEST["tests/execution/test_quota.py<br/>━━━━━━━━━━<br/>TestIntegration: _write_cache →<br/>quota_guard.main round-trip<br/>(was silently skipped before fix)"]
    end

    subgraph EXT ["EXTERNAL"]
        CORE_LY["autoskillit.core<br/>━━━━━━━━━━<br/>load_yaml"]
        PATHSPEC["pathspec<br/>━━━━━━━━━━<br/>gitwildmatch matching"]
    end

    %% L3 → L1 imports %%
    CONFTEST -->|"imports FilterMode<br/>build_test_scope<br/>git_changed_files<br/>load_manifest"| TEST_FILTER

    %% L2 → L1 imports %%
    CASCADE_TEST -->|"imports FilterMode<br/>build_test_scope"| TEST_FILTER

    %% L1 SRC imports %%
    SRC_FILTER -->|"imports load_yaml"| CORE_LY
    SRC_FILTER -->|"imports pathspec"| PATHSPEC
    TEST_FILTER -->|"imports pathspec"| PATHSPEC

    %% Cascade map relationships (data, not code imports) %%
    TEST_FILTER -->|"CASCADE_CONSERVATIVE[hooks]<br/>now includes execution/test_quota.py"| QUOTA_TEST
    QUOTA_GUARD -.->|"source change triggers cascade<br/>→ hooks + cli + server + ...<br/>+ execution/test_quota.py (FIXED)"| TEST_FILTER

    %% Test → source relationships %%
    QUOTA_TEST -->|"tests integration path"| QUOTA_SRC
    QUOTA_TEST -->|"tests TestIntegration<br/>_write_cache format contract"| QUOTA_GUARD

    %% CLASS ASSIGNMENTS %%
    class CONFTEST cli;
    class CASCADE_TEST detector;
    class TEST_FILTER stateNode;
    class SRC_FILTER handler;
    class QUOTA_GUARD,QUOTA_SRC phase;
    class QUOTA_TEST output;
    class CORE_LY,PATHSPEC integration;
```

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START: build_test_scope])
    FULLRUN([FULL RUN: return None])
    COMPLETE([COMPLETE: return set of Paths])

    subgraph Guards ["Phase 1 — Entry Guards"]
        direction TB
        G1{"mode == NONE?"}
        G2{"changed_files is None?"}
        G3{"len > 30 files?"}
        G4{"Bucket A triggered?<br/>━━━━━━━━━━<br/>check_bucket_a_content_aware<br/>or check_bucket_a"}
    end

    subgraph Classify ["Phase 2 — Per-File Classification"]
        direction TB
        CLS{"file type?"}
        DIRECT["Add to direct_test_files<br/>━━━━━━━━━━<br/>tests/*.py → verbatim path"]
        PKG["_file_to_package(f)<br/>━━━━━━━━━━<br/>extracts autoskillit subpkg"]
        PKGCHK{"pkg in cascade_map?"}
        CORECHK{"pkg == core &<br/>mode == CONSERVATIVE?"}
        CORE_MOD["MODULE_CASCADE_CORE[stem]<br/>━━━━━━━━━━<br/>module-level narrow cascade"]
        CORE_UNIV["cascade_map[core]<br/>━━━━━━━━━━<br/>full core fan-out (all layers)"]
        HOOKS_CASCADE["● LAYER_CASCADE_CONSERVATIVE[hooks]<br/>━━━━━━━━━━<br/>hooks, infra, cli, fleet, server<br/>+ execution/test_quota.py"]
        OTHER_CASCADE["cascade_map[pkg]<br/>━━━━━━━━━━<br/>layer-appropriate dirs"]
        MANIFEST["apply_manifest(file)<br/>━━━━━━━━━━<br/>non-Python → YAML manifest lookup"]
    end

    subgraph Closure ["Phase 3 — Re-export Closure"]
        direction TB
        RE_EXPAND["_expand_reexport_closure<br/>━━━━━━━━━━<br/>walk parent __init__.py files<br/>via AST; add re-exporters"]
        RE_CASCADE["Cascade-classify expanded files<br/>━━━━━━━━━━<br/>same pkg→cascade logic"]
    end

    subgraph ConservativeTiers ["Phase 4 — Conservative Always-Run Tiers"]
        direction TB
        ARCH_CONTRACTS["arch + contracts always<br/>━━━━━━━━━━<br/>_ALWAYS_RUN_CONSERVATIVE_UNCONDITIONAL"]
        DOCS_CHK{"docs/ or README.md<br/>changed?"}
        DOCS_FULL["Add docs/ dir"]
        DOCS_COUNT["Add test_doc_counts.py only"]
        INFRA_UNCOND["9 structural infra files always<br/>━━━━━━━━━━<br/>_INFRA_UNCONDITIONAL_FILES"]
        INFRA_CHK{"hooks/ or .github/ or<br/>pyproject/taskfile changed?"}
        INFRA_FULL["Add full infra/ dir"]
    end

    subgraph Oracle ["Phase 5 — Aggressive Coverage Oracle"]
        direction TB
        COV_CHK{"coverage_map_path<br/>provided & fresh?"}
        COV_REFINE["Replace dir entries with<br/>━━━━━━━━━━<br/>specific test file paths<br/>from coverage map"]
        COV_SKIP["Keep directory-level entry<br/>━━━━━━━━━━<br/>fail-open: no oracle data"]
    end

    subgraph Resolve ["Phase 6 — Path Resolution"]
        direction TB
        RESOLVE["Resolve test_dirs + direct_test_files<br/>━━━━━━━━━━<br/>tests_root / d for dirs<br/>Path(f) for direct files"]
    end

    subgraph TestValidation ["● Test: test_test_filter_cascade.py"]
        direction TB
        PARA_CASE["● parametrize case:<br/>━━━━━━━━━━<br/>quota_guard.py → hooks cascade<br/>expects hooks + test_quota.py in result"]
        ASSERT["assert result is not None<br/>assert 'hooks' in result_names<br/>assert 'test_quota.py' in result_names"]
    end

    %% MAIN FLOW %%
    START --> G1
    G1 -->|"yes"| FULLRUN
    G1 -->|"no"| G2
    G2 -->|"yes"| FULLRUN
    G2 -->|"no"| G3
    G3 -->|"yes"| FULLRUN
    G3 -->|"no"| G4
    G4 -->|"triggered"| FULLRUN
    G4 -->|"not triggered"| CLS

    %% FILE CLASSIFICATION %%
    CLS -->|"tests/*.py"| DIRECT
    CLS -->|"src/*.py"| PKG
    CLS -->|"non-Python"| MANIFEST
    CLS -->|"other .py (fail-open)"| FULLRUN
    PKG --> PKGCHK
    PKGCHK -->|"pkg not found"| FULLRUN
    PKGCHK -->|"pkg == hooks"| HOOKS_CASCADE
    PKGCHK -->|"found"| CORECHK
    CORECHK -->|"yes + universal stem"| CORE_UNIV
    CORECHK -->|"yes + specific stem"| CORE_MOD
    CORECHK -->|"no"| OTHER_CASCADE
    MANIFEST -->|"no pattern match (fail-open)"| FULLRUN

    %% RE-EXPORT CLOSURE %%
    DIRECT --> RE_EXPAND
    HOOKS_CASCADE --> RE_EXPAND
    CORE_UNIV --> RE_EXPAND
    CORE_MOD --> RE_EXPAND
    OTHER_CASCADE --> RE_EXPAND
    MANIFEST --> RE_EXPAND
    RE_EXPAND --> RE_CASCADE

    %% CONSERVATIVE TIERS %%
    RE_CASCADE --> ARCH_CONTRACTS
    ARCH_CONTRACTS --> DOCS_CHK
    DOCS_CHK -->|"yes"| DOCS_FULL
    DOCS_CHK -->|"no"| DOCS_COUNT
    DOCS_FULL --> INFRA_UNCOND
    DOCS_COUNT --> INFRA_UNCOND
    INFRA_UNCOND --> INFRA_CHK
    INFRA_CHK -->|"triggered"| INFRA_FULL
    INFRA_CHK -->|"not triggered"| Oracle

    %% ORACLE %%
    INFRA_FULL --> Oracle
    COV_CHK -->|"aggressive + fresh map"| COV_REFINE
    COV_CHK -->|"conservative or stale"| COV_SKIP
    COV_REFINE --> Resolve
    COV_SKIP --> Resolve

    %% RESOLVE %%
    RESOLVE --> COMPLETE

    %% TEST VALIDATION LINK %%
    HOOKS_CASCADE -.->|"verified by"| PARA_CASE
    PARA_CASE --> ASSERT

    %% CLASS ASSIGNMENTS %%
    class START,COMPLETE,FULLRUN terminal;
    class G1,G2,G3,G4,CLS,PKGCHK,CORECHK,DOCS_CHK,INFRA_CHK,COV_CHK stateNode;
    class DIRECT,PKG,MANIFEST,RE_EXPAND,RE_CASCADE,ARCH_CONTRACTS,INFRA_UNCOND,RESOLVE handler;
    class CORE_UNIV,CORE_MOD,OTHER_CASCADE,DOCS_FULL,DOCS_COUNT,INFRA_FULL phase;
    class HOOKS_CASCADE detector;
    class COV_REFINE,COV_SKIP output;
    class PARA_CASE,ASSERT detector;
```

Closes #1380

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-1380-20260427-121247-954426/.autoskillit/temp/make-plan/fix_hooks_execution_test_quota_cascade_plan_2026-04-27_121700.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 119 | 11.8k | 561.9k | 55.2k | 1 | 7m 3s |
| verify | 148 | 8.9k | 797.7k | 48.7k | 1 | 3m 2s |
| implement | 100 | 3.4k | 384.5k | 29.0k | 1 | 1m 22s |
| prepare_pr | 60 | 4.7k | 188.7k | 25.4k | 1 | 1m 32s |
| run_arch_lenses | 2.1k | 12.7k | 452.3k | 105.3k | 2 | 4m 43s |
| compose_pr | 67 | 6.4k | 235.3k | 29.8k | 1 | 1m 51s |
| **Total** | 2.6k | 47.9k | 2.6M | 293.5k | | 19m 35s |