### PR TITLE
Implementation Plan: Tests audit: Quick assertion + path fixes (P1-F07, F09, F11, P2-F13, P3-F19)

### DIFF
--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -446,6 +446,7 @@ LAYER_CASCADE_AGGRESSIVE: dict[str, frozenset[str]] = {
     "_llm_triage": frozenset({"test_llm_triage.py"}),
     "smoke_utils": frozenset({"test_smoke_utils.py"}),
     "version": frozenset({"test_version.py"}),
+    "_test_filter": frozenset({"arch", "contracts"}),
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_cook_env_scrub.py
+++ b/tests/cli/test_cook_env_scrub.py
@@ -38,7 +38,7 @@ def test_launch_cook_session_env_excludes_ide_vars(
     ):
         _launch_cook_session("system prompt", initial_message="hello")
 
-    assert mock_run.call_args is not None
+    mock_run.assert_called_once()
     env = mock_run.call_args.kwargs["env"]
     assert "CLAUDE_CODE_SSE_PORT" not in env
     assert "ENABLE_IDE_INTEGRATION" not in env
@@ -139,7 +139,7 @@ def test_cook_command_env_excludes_ide_vars(
 
         cook()
 
-    assert mock_run.call_args is not None
+    mock_run.assert_called_once()
     env = mock_run.call_args.kwargs["env"]
     assert "CLAUDE_CODE_SSE_PORT" not in env
     assert "ENABLE_IDE_INTEGRATION" not in env

--- a/tests/cli/test_plugin_cache.py
+++ b/tests/cli/test_plugin_cache.py
@@ -38,7 +38,7 @@ def test_retire_old_versions_registers_different_version(
     entries = data["retiring"]
     assert len(entries) == 1
     assert entries[0]["version"] == "0.8.0"
-    assert datetime.fromisoformat(entries[0]["retired_at"]) is not None
+    assert isinstance(datetime.fromisoformat(entries[0]["retired_at"]), datetime)
 
 
 def test_retire_old_versions_multiple_old_dirs(

--- a/tests/core/test_kitchen_state.py
+++ b/tests/core/test_kitchen_state.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from datetime import UTC, datetime
+from pathlib import Path
 
 import pytest
 
@@ -78,7 +79,7 @@ def test_get_state_dir_namespaces_by_campaign_id(tmp_path, monkeypatch):
 
     monkeypatch.delenv("AUTOSKILLIT_STATE_DIR", raising=False)
     monkeypatch.setenv("AUTOSKILLIT_CAMPAIGN_ID", "camp-42")
-    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(Path, "cwd", classmethod(lambda cls: tmp_path))
     result = get_state_dir()
     assert result == tmp_path / ".autoskillit" / "temp" / "kitchen_state" / "camp-42"
 
@@ -87,11 +88,10 @@ def test_get_state_dir_no_campaign_id_flat(tmp_path, monkeypatch):
     """get_state_dir returns flat path when AUTOSKILLIT_CAMPAIGN_ID is absent."""
     from autoskillit.core.kitchen_state import get_state_dir
 
-    monkeypatch.delenv("AUTOSKILLIT_STATE_DIR", raising=False)
+    monkeypatch.setenv("AUTOSKILLIT_STATE_DIR", str(tmp_path))
     monkeypatch.delenv("AUTOSKILLIT_CAMPAIGN_ID", raising=False)
-    monkeypatch.chdir(tmp_path)
     result = get_state_dir()
-    assert result == tmp_path / ".autoskillit" / "temp" / "kitchen_state"
+    assert result == tmp_path / "kitchen_state"
 
 
 def test_concurrent_campaigns_disjoint_dirs(tmp_path, monkeypatch):
@@ -99,7 +99,7 @@ def test_concurrent_campaigns_disjoint_dirs(tmp_path, monkeypatch):
     from autoskillit.core.kitchen_state import get_state_dir
 
     monkeypatch.delenv("AUTOSKILLIT_STATE_DIR", raising=False)
-    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(Path, "cwd", classmethod(lambda cls: tmp_path))
 
     monkeypatch.setenv("AUTOSKILLIT_CAMPAIGN_ID", "campaign-a")
     dir_a = get_state_dir()

--- a/tests/core/test_kitchen_state.py
+++ b/tests/core/test_kitchen_state.py
@@ -79,7 +79,7 @@ def test_get_state_dir_namespaces_by_campaign_id(tmp_path, monkeypatch):
 
     monkeypatch.delenv("AUTOSKILLIT_STATE_DIR", raising=False)
     monkeypatch.setenv("AUTOSKILLIT_CAMPAIGN_ID", "camp-42")
-    monkeypatch.setattr(Path, "cwd", classmethod(lambda cls: tmp_path))
+    monkeypatch.setattr(Path, "cwd", lambda: tmp_path)
     result = get_state_dir()
     assert result == tmp_path / ".autoskillit" / "temp" / "kitchen_state" / "camp-42"
 
@@ -99,7 +99,7 @@ def test_concurrent_campaigns_disjoint_dirs(tmp_path, monkeypatch):
     from autoskillit.core.kitchen_state import get_state_dir
 
     monkeypatch.delenv("AUTOSKILLIT_STATE_DIR", raising=False)
-    monkeypatch.setattr(Path, "cwd", classmethod(lambda cls: tmp_path))
+    monkeypatch.setattr(Path, "cwd", lambda: tmp_path)
 
     monkeypatch.setenv("AUTOSKILLIT_CAMPAIGN_ID", "campaign-a")
     dir_a = get_state_dir()

--- a/tests/workspace/test_clone_timeouts.py
+++ b/tests/workspace/test_clone_timeouts.py
@@ -14,7 +14,7 @@ _GIT_NETWORK_SUBCOMMANDS = {"push", "clone", "fetch", "pull", "ls-remote"}
 
 def test_git_network_commands_have_timeout() -> None:
     """All subprocess.run() calls with git network commands must have timeout=."""
-    src = Path("src/autoskillit/workspace/clone.py").read_text()
+    src = (Path(__file__).parent.parent.parent / "src/autoskillit/workspace/clone.py").read_text()
     tree = ast.parse(src)
     for node in ast.walk(tree):
         if not (


### PR DESCRIPTION
## Summary

Five independent 1–3 line fixes across four test files and one test-infrastructure file: anchoring a relative path in `test_clone_timeouts.py` to `__file__` for xdist safety, replacing unconditionally-true `is not None` assertions in `test_plugin_cache.py` and `test_cook_env_scrub.py` with substantive checks, eliminating `monkeypatch.chdir` calls in `test_kitchen_state.py` in favour of env-var and `setattr` isolation, and adding the missing `"_test_filter"` entry to `LAYER_CASCADE_AGGRESSIVE` in `tests/_test_filter.py`.

## Architecture Impact

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% TEST LAYER — All 5 files modified %%
    subgraph TESTS ["TEST LAYER — Modified Files (●)"]
        direction LR
        TF["● tests/_test_filter.py<br/>━━━━━━━━━━<br/>Filter utility module<br/>small · no test functions"]
        TCE["● tests/cli/test_cook_env_scrub.py<br/>━━━━━━━━━━<br/>Cook env scrubbing assertions<br/>small · layer:cli"]
        TCP["● tests/cli/test_plugin_cache.py<br/>━━━━━━━━━━<br/>Plugin cache lifecycle<br/>medium · layer:cli"]
        TKS["● tests/core/test_kitchen_state.py<br/>━━━━━━━━━━<br/>Kitchen marker + namespacing<br/>small · layer:core"]
        TCT["● tests/workspace/test_clone_timeouts.py<br/>━━━━━━━━━━<br/>Git network timeout guards<br/>small · layer:workspace"]
    end

    %% CLI L3 %%
    subgraph CLI_L3 ["CLI — L3"]
        direction LR
        COOK["cli._cook<br/>━━━━━━━━━━<br/>Cook session launcher<br/>env scrubbing"]
        APP["cli.app<br/>━━━━━━━━━━<br/>_launch_cook_session"]
        SESSION_L["cli._session_launch<br/>━━━━━━━━━━<br/>subprocess.run call site"]
        INIT_H["cli._init_helpers<br/>━━━━━━━━━━<br/>_is_plugin_installed"]
    end

    %% L1 — Workspace / Execution / Config %%
    subgraph L1_LAYER ["WORKSPACE / EXECUTION / CONFIG — L1"]
        direction LR
        CLONE["workspace.clone<br/>━━━━━━━━━━<br/>Clone isolation<br/>git network cmds"]
        WORKSPACE_L["workspace<br/>━━━━━━━━━━<br/>DefaultSessionSkillManager"]
        EXEC["execution<br/>━━━━━━━━━━<br/>_MAX_MCP_OUTPUT_TOKENS_VALUE<br/>build_interactive_cmd"]
        CONFIG["config<br/>━━━━━━━━━━<br/>iter_display_categories<br/>load_config"]
    end

    %% CORE L0 %%
    subgraph CORE_L0 ["CORE — L0"]
        direction LR
        KS["core.kitchen_state<br/>━━━━━━━━━━<br/>stdlib-only markers<br/>write / read / sweep"]
        PC["core._plugin_cache<br/>━━━━━━━━━━<br/>Plugin cache lifecycle<br/>install locking · PID guard"]
        TF_SRC["_test_filter.py<br/>━━━━━━━━━━<br/>build_test_scope<br/>Bucket A · layer cascade"]
        CORE_IO["core.io<br/>━━━━━━━━━━<br/>write_versioned_json"]
        CORE_LOG["core.logging<br/>━━━━━━━━━━<br/>get_logger"]
        CORE_PUB["core public API<br/>━━━━━━━━━━<br/>pkg_root · LAUNCH_ID_ENV_VAR<br/>write_registry_entry · load_yaml"]
    end

    %% EXTERNAL DEPS %%
    subgraph EXT ["EXTERNAL DEPS"]
        direction LR
        PSUTIL["psutil<br/>━━━━━━━━━━<br/>PID liveness check"]
        PATHSPEC["pathspec<br/>━━━━━━━━━━<br/>gitignore matching"]
    end

    %% TEST → SOURCE (exercises / covers) %%
    TF -->|"imports · exercises"| TF_SRC
    TCE -->|"deferred import · exercises"| COOK
    TCE -->|"deferred import · exercises"| APP
    TCE -->|"imports constant"| EXEC
    TCP -->|"deferred import · exercises"| PC
    TKS -->|"deferred import · exercises"| KS
    TCT -.->|"static AST analysis only"| CLONE

    %% SOURCE MODULE DEPENDENCIES (valid downward) %%
    APP -->|"calls"| SESSION_L
    APP -->|"uses"| INIT_H
    COOK -->|"imports"| EXEC
    COOK -->|"imports"| WORKSPACE_L
    COOK -->|"imports"| CONFIG
    COOK -->|"imports"| CORE_PUB
    CLONE -->|"imports"| CORE_PUB
    TF_SRC -->|"imports load_yaml"| CORE_PUB
    PC -->|"imports"| CORE_IO
    PC -->|"imports"| CORE_LOG
    PC -->|"imports"| PSUTIL
    TF_SRC -->|"imports"| PATHSPEC

    %% CLASS ASSIGNMENTS %%
    class TF,TCE,TCP,TKS,TCT detector;
    class COOK,APP,SESSION_L,INIT_H cli;
    class CLONE,WORKSPACE_L,EXEC,CONFIG handler;
    class KS,TF_SRC,CORE_IO,CORE_LOG,CORE_PUB stateNode;
    class PC phase;
    class PSUTIL,PATHSPEC integration;
```

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph InitOnly ["INIT_ONLY — Frozen After Construction"]
        direction LR
        KM["● KitchenMarker<br/>━━━━━━━━━━<br/>session_id · opened_at<br/>recipe_name · marker_version<br/>content_hash · composite_hash<br/>(frozen=True)"]
        CSR["● CloneSourceResolution<br/>━━━━━━━━━━<br/>reason · url · stderr<br/>(frozen=True)<br/>reason∈ok|timeout|error|no_origin"]
        ENV_C["● build_claude_env constants<br/>━━━━━━━━━━<br/>IDE_ENV_DENYLIST (frozenset/9)<br/>IDE_ENV_PREFIX_DENYLIST (tuple/2)<br/>IDE_ENV_ALWAYS_EXTRAS (MappingProxy)"]
        TF_C["● _test_filter constants<br/>━━━━━━━━━━<br/>BUCKET_A_PATTERNS · LAYER_CASCADE_*<br/>MODULE_CASCADE_CORE (frozenset values)<br/>_LARGE_CHANGESET_THRESHOLD=30"]
    end

    subgraph AppendOnly ["APPEND_ONLY — Grows, Never Shrinks (within lifecycle)"]
        direction LR
        RIDS["● seen_reload_ids<br/>━━━━━━━━━━<br/>set[str] — .add() only<br/>Never cleared in cook() loop<br/>Bounds: max 10 entries"]
        RET["● retiring_cache.json<br/>━━━━━━━━━━<br/>list[RetireEntry] under LOCK_EX<br/>append_retiring_entry()<br/>Swept after grace_hours=2h"]
        AIMP["● ASTImportWalker.imports<br/>━━━━━━━━━━<br/>list[tuple[str,ImportContext]]<br/>.append() in visit_Import/From/Call<br/>Never cleared after __init__"]
        CREG["● CloneRegistry._entries<br/>━━━━━━━━━━<br/>append() path: grow only<br/>prune_deleted() replaces list<br/>Flushed via atomic_write on dirty"]
    end

    subgraph Mutable ["MUTABLE — Controlled Updates"]
        direction LR
        RS["● current_resume_spec<br/>━━━━━━━━━━<br/>ResumeSpec discriminated union<br/>NoResume → NamedResume<br/>Replaced each reload iteration"]
        AK["● active_kitchens.json<br/>━━━━━━━━━━<br/>register / unregister under LOCK_EX<br/>Opportunistic sweep on<br/>any_kitchen_open() liveness probe"]
        CSTK["● _context_stack<br/>━━━━━━━━━━<br/>list[ImportContext] — LIFO<br/>.append()/.pop() in scope visitors<br/>Drives _current_context property"]
        DRTY["● CloneRegistry._dirty<br/>━━━━━━━━━━<br/>False→True one-way latch<br/>Set by append() and prune_deleted()<br/>Guards disk flush on __exit__"]
    end

    subgraph Gates ["VALIDATION GATES — Corruption Prevention"]
        direction TB
        G1["● path-sep injection guard<br/>━━━━━━━━━━<br/>get_state_dir():<br/>ValueError if '/' in CAMPAIGN_ID<br/>Prevents path traversal"]
        G2["● PID liveness + recycle guard<br/>━━━━━━━━━━<br/>_pid_alive(): os.kill(pid,0)<br/>+ psutil create_time (&lt;1.0s tol)<br/>Prevents stale-PID false-positives"]
        G3["● reload count gate<br/>━━━━━━━━━━<br/>len(seen_reload_ids) ≥ 10<br/>→ SystemExit<br/>Prevents unbounded loops"]
        G4["● duplicate reload gate<br/>━━━━━━━━━━<br/>reload_id in seen_reload_ids<br/>→ SystemExit<br/>Prevents identical-session cycles"]
        G5["● env 3-layer scrub<br/>━━━━━━━━━━<br/>exact match IDE denylist<br/>+ private vars strip<br/>+ prefix strip → MappingProxyType seal"]
        G6["● test-scope 5-gate (fail-open)<br/>━━━━━━━━━━<br/>mode=NONE | no-changes | &gt;30 files<br/>| bucket-A match | unknown-file-class<br/>→ return None (run full suite)"]
        G7["● timeout static enforcement<br/>━━━━━━━━━━<br/>AST walk: all subprocess.run(<br/>git push|clone|fetch|ls-remote)<br/>must carry timeout= keyword"]
    end

    subgraph Resume ["RESUME DETECTION TIERS"]
        direction TB
        RT1["● Tier 1 — Explicit checkpoint<br/>━━━━━━━━━━<br/>cook(): reload_session_id returned<br/>→ NamedResume(session_id=...)<br/>Threaded into next Claude invocation"]
        RT2["● Tier 2 — Disk hydration<br/>━━━━━━━━━━<br/>CloneRegistry.__enter__:<br/>load _entries from disk if exists<br/>Fresh start if file absent"]
        RT3["● Tier 3 — Cross-process probe<br/>━━━━━━━━━━<br/>read_marker(): reconstruct from JSON<br/>Soft: returns None on any error<br/>Hook subprocess liveness signal"]
    end

    subgraph SealedOut ["MUTATION-SEALED OUTPUT"]
        direction LR
        MPROXY["● MappingProxyType env<br/>━━━━━━━━━━<br/>build_claude_env() return<br/>Post-build mutation structurally blocked<br/>Caller extras applied last"]
        ATWRITE["● atomic_write<br/>━━━━━━━━━━<br/>tmp + os.replace pattern<br/>KitchenMarker.write_marker()<br/>CloneRegistry.__exit__ (when dirty)"]
    end

    %% LIFECYCLE FLOWS %%
    InitOnly -->|"immutable — no gate needed"| SealedOut
    AppendOnly -->|"guarded by"| Gates
    Mutable -->|"guarded by"| Gates
    Gates -->|"validated state"| Resume
    Gates -->|"sealed writes"| SealedOut

    %% SPECIFIC GATE BINDINGS %%
    G3 -.->|"reads"| RIDS
    G4 -.->|"reads"| RIDS
    G2 -.->|"sweeps"| AK
    G1 -.->|"guards path for"| KM
    G5 -.->|"produces"| MPROXY
    G7 -.->|"enforces timeouts on"| CSR

    %% RESUME BINDING %%
    RS -.->|"checkpoint"| RT1
    CREG -.->|"hydrates"| RT2
    KM -.->|"probed by"| RT3

    %% CLASS ASSIGNMENTS %%
    class KM,CSR,ENV_C,TF_C detector;
    class RIDS,RET,AIMP,CREG handler;
    class RS,AK,CSTK,DRTY phase;
    class G1,G2,G3,G4,G5,G6,G7 stateNode;
    class RT1,RT2,RT3 gap;
    class MPROXY,ATWRITE output;
```

### Scenarios Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    subgraph S1 ["SCENARIO 1: Test Scope Resolution  (● _test_filter.py)"]
        direction LR
        S1_GIT["git diff<br/>━━━━━━━━━━<br/>changed file paths"]
        S1_FILTER["● build_test_scope<br/>━━━━━━━━━━<br/>Bucket A + content-aware check<br/>cascade maps + coverage oracle"]
        S1_SCOPE["test directory set<br/>━━━━━━━━━━<br/>set[str] | None<br/>passed to conftest deselect"]
    end

    subgraph S2 ["SCENARIO 2: Kitchen Marker Cross-Process State  (● test_kitchen_state.py)"]
        direction LR
        S2_TOOL["open_kitchen MCP tool<br/>━━━━━━━━━━<br/>server process"]
        S2_WRITE["write_marker<br/>━━━━━━━━━━<br/>kitchen_state.py<br/>campaign-namespaced dir"]
        S2_JSON["● KitchenMarker JSON<br/>━━━━━━━━━━<br/>content_hash + composite_hash<br/>session_id + timestamp"]
        S2_HOOK["PreToolUse hook<br/>━━━━━━━━━━<br/>fresh subprocess"]
        S2_READ["read_marker<br/>━━━━━━━━━━<br/>kitchen_state.py<br/>graceful hash defaulting"]
    end

    subgraph S3 ["SCENARIO 3: Cook Session IDE Env Scrub  (● test_cook_env_scrub.py)"]
        direction LR
        S3_CLI["autoskillit cook<br/>━━━━━━━━━━<br/>CLI entry point"]
        S3_LAUNCH["● _launch_cook_session<br/>━━━━━━━━━━<br/>_session_launch.py<br/>shared session prelude"]
        S3_ENV["build_interactive_cmd<br/>━━━━━━━━━━<br/>strip IDE vars<br/>inject CLAUDE_CODE_AUTO_CONNECT_IDE=0<br/>MAX_MCP_OUTPUT_TOKENS + MCP_CONNECTION_NONBLOCKING=0"]
        S3_PROC["subprocess.run<br/>━━━━━━━━━━<br/>Claude Code child process<br/>clean env"]
    end

    subgraph S4 ["SCENARIO 4: Plugin Cache Retire + Kitchen Registry  (● test_plugin_cache.py)"]
        direction LR
        S4_INSTALL["plugin install<br/>━━━━━━━━━━<br/>_InstallLock (fcntl)<br/>serialises concurrent installs"]
        S4_RETIRE["_retire_old_versions<br/>━━━━━━━━━━<br/>grace-period: 2 h default<br/>same-version → delete immediately"]
        S4_JSON["● retiring_cache.json<br/>━━━━━━━━━━<br/>timestamped retire entries<br/>atomic write via core.io"]
        S4_SWEEP["sweep_retiring_cache<br/>━━━━━━━━━━<br/>deletes expired dirs<br/>skips missing-retired_at entries"]
        S4_KIT["● any_kitchen_open<br/>━━━━━━━━━━<br/>active_kitchens.json<br/>prunes dead PIDs as side-effect"]
    end

    subgraph S5 ["SCENARIO 5: Clone Network Timeout Static Guard  (● test_clone_timeouts.py)"]
        direction LR
        S5_AST["● AST walker<br/>━━━━━━━━━━<br/>reads clone.py source text<br/>no runtime import"]
        S5_FIND["find subprocess.run<br/>━━━━━━━━━━<br/>git network calls:<br/>push · clone · fetch · pull · ls-remote"]
        S5_ASSERT["assert timeout= present<br/>━━━━━━━━━━<br/>ls-remote 15 s<br/>clone 300 s · push 120 s"]
    end

    %% SCENARIO 1 FLOW %%
    S1_GIT -->|"reads changed files"| S1_FILTER
    S1_FILTER -->|"writes scope"| S1_SCOPE

    %% SCENARIO 2 FLOW %%
    S2_TOOL -->|"calls"| S2_WRITE
    S2_WRITE -->|"writes JSON to disk"| S2_JSON
    S2_JSON -->|"read by"| S2_HOOK
    S2_HOOK -->|"calls"| S2_READ

    %% SCENARIO 3 FLOW %%
    S3_CLI -->|"calls"| S3_LAUNCH
    S3_LAUNCH -->|"calls"| S3_ENV
    S3_ENV -->|"passes scrubbed env="| S3_PROC

    %% SCENARIO 4 FLOW %%
    S4_INSTALL -->|"calls"| S4_RETIRE
    S4_RETIRE -->|"writes entry"| S4_JSON
    S4_JSON -->|"read by"| S4_SWEEP
    S4_SWEEP -.->|"independent lifecycle"| S4_KIT

    %% SCENARIO 5 FLOW %%
    S5_AST -->|"finds"| S5_FIND
    S5_FIND -->|"asserts"| S5_ASSERT

    %% CLASS ASSIGNMENTS %%
    class S1_GIT,S3_CLI cli;
    class S1_FILTER,S3_ENV,S4_RETIRE,S4_SWEEP,S5_FIND handler;
    class S1_SCOPE,S2_JSON,S4_JSON stateNode;
    class S2_TOOL,S4_INSTALL phase;
    class S2_WRITE,S3_LAUNCH output;
    class S2_HOOK,S2_READ,S3_PROC,S4_KIT,S5_AST,S5_ASSERT detector;
```

Closes #1400

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260427-143948-832764/.autoskillit/temp/make-plan/tests_audit_quick_assertion_path_fixes_plan_2026-04-27_000001.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 171 | 23.9k | 930.5k | 63.9k | 1 | 7m 50s |
| verify | 132 | 11.1k | 713.1k | 48.7k | 1 | 3m 22s |
| implement | 188 | 7.4k | 903.0k | 38.2k | 1 | 2m 53s |
| prepare_pr | 76 | 6.1k | 262.4k | 27.3k | 1 | 1m 51s |
| run_arch_lenses | 3.2k | 28.1k | 556.7k | 166.5k | 3 | 11m 34s |
| compose_pr | 67 | 7.8k | 256.1k | 35.9k | 1 | 2m 12s |
| **Total** | 3.8k | 84.5k | 3.6M | 380.5k | | 29m 44s |