### PR TITLE
docs: overhaul hooks.md — fix stale names, counts, and 7 undocumented hooks

### DIFF
--- a/docs/safety/hooks.md
+++ b/docs/safety/hooks.md
@@ -1,13 +1,13 @@
 # Hooks
 
-AutoSkillit registers 14 Claude Code hook scripts: 10 PreToolUse, 3 PostToolUse,
+AutoSkillit registers 21 Claude Code hook scripts: 16 PreToolUse, 4 PostToolUse,
 and 1 SessionStart. Every script is stdlib-only Python so it can run before the
 project virtualenv is on the path. Scripts live in `src/autoskillit/hooks/`
 and are bound to event types in `src/autoskillit/hook_registry.py` via the
 `HOOK_REGISTRY` list of `HookDef` entries; `generate_hooks_json()` then
 materializes the canonical `hooks.json` that Claude Code reads.
 
-## PreToolUse hooks (10)
+## PreToolUse hooks (16)
 
 ### `branch_protection_guard.py`
 **Guarded tools:** `merge_worktree`, `push_to_remote`
@@ -15,13 +15,13 @@ Denies merges and pushes targeting branches in `safety.protected_branches`
 (`main`, `integration`, `stable` by default). Pure-function check via
 `core/branch_guard.is_protected_branch`.
 
-### `quota_check.py`
+### `quota_guard.py`
 **Guarded tool:** `run_skill`
 Blocks launching new headless sessions when the cached binding window marks
 `should_block=True`. The threshold is per-window: short windows (e.g.
 `five_hour`) use `quota_guard.short_window_threshold` (default 85.0%); long
 windows matched by `quota_guard.long_window_patterns` (default `weekly`,
-`sonnet`, `opus`) use `quota_guard.long_window_threshold` (default 98.0%).
+`sonnet`, `opus`) use `quota_guard.long_window_threshold` (default 95.0%).
 Reports the exact sleep duration the orchestrator must wait.
 
 ### `skill_command_guard.py`
@@ -30,7 +30,7 @@ Blocks `run_skill` calls where `skill_command` does not start with `/`.
 Catches the case where the orchestrator passed prose instead of a slash
 command.
 
-### `skill_cmd_check.py`
+### `skill_cmd_guard.py`
 **Guarded tool:** `run_skill`
 Validates that path-argument skills (`implement-worktree-no-merge`,
 `resolve-failures`, etc.) receive the file path as the first token rather
@@ -46,6 +46,13 @@ unintended deletion of clones that may still have unpushed work.
 Blocks `open_kitchen` from running inside a headless session. Only human
 operators may open the kitchen.
 
+### `ask_user_question_guard.py`
+**Guarded tool:** `AskUserQuestion`
+Blocks `AskUserQuestion` in headless sessions unless a fresh kitchen-open
+marker exists (TTL: 24 hours). Prevents leaf workers from attempting
+interactive user prompts that can never be answered. Fails open on parse
+errors or missing session ID. Session scope: headless only.
+
 ### `leaf_orchestration_guard.py`
 **Guarded tools:** `run_skill`, `run_cmd`, `run_python`
 Blocks orchestration tools from leaf-tier sessions. Enforces the tier
@@ -57,11 +64,34 @@ leaf workers use native Claude Code tools only.
 Denies `run_cmd` calls that perform editable installs without `--python
 .venv`. Prevents pollution of the global Python environment.
 
+### `pr_create_guard.py`
+**Guarded tool:** `run_cmd`
+Blocks `gh pr create` called via `run_cmd` while the kitchen is open. Uses
+`shlex.split` tokenisation to avoid false positives from quoted shell
+arguments (e.g. `echo 'do not gh pr create'` does not match). Directs the
+caller to use the `prepare_pr → compose_pr` pipeline instead.
+
 ### `generated_file_write_guard.py`
 **Guarded tools:** `Write`, `Edit`
 Denies writes to generated files (`hooks.json`, `settings.json`). The hooks
 file must be regenerated through `generate_hooks_json()`, never edited by
 hand.
+
+### `recipe_write_advisor.py`
+**Matched tools:** `Write`, `Edit`
+Non-blocking advisory: suggests `/autoskillit:write-recipe` or
+`/autoskillit:make-campaign` when writing recipe YAML files in
+`.autoskillit/recipes/` or `src/autoskillit/recipes/`. Silently skips
+headless sessions to avoid noise in automated runs. Never blocks tool
+execution. Session scope: interactive only.
+
+### `grep_pattern_lint_guard.py`
+**Guarded tool:** `Grep`
+Denies `Grep` calls that contain `\|` (POSIX BRE alternation) in the
+pattern. The Grep tool wraps ripgrep, which uses ERE/PCRE syntax where bare
+`|` is alternation; `\|` matches a literal backslash-pipe, causing silent
+zero-result failures. Returns the corrected ERE pattern (replacing `\|` with
+`|`) in the deny message.
 
 ### `mcp_health_guard.py`
 **Matched tools:** `Bash`, `Write`, `Edit`, `Read`, `Glob`, `Grep`
@@ -70,28 +100,52 @@ PID liveness. Injects informational message suggesting `/MCP` reconnection when
 all registered server PIDs for the project are dead. Never blocks tool execution.
 Interactive sessions only.
 
-## PostToolUse hooks (3)
+### `fleet_dispatch_guard.py`
+**Guarded tool:** `dispatch_food_truck`
+Blocks `dispatch_food_truck` from headless callers. Prevents recursive
+L3→L3 fleet session creation where a headless session launches another fleet
+of headless sessions. Fails open on malformed input. Session scope: headless
+calls are denied; interactive callers pass through.
 
-### `pretty_output.py`
+### `review_loop_gate.py`
+**Guarded tools:** `wait_for_ci`, `enqueue_pr`
+Blocks these tools when `review_gate_state.json` has `gate == "LOOP_REQUIRED"`
+and `check_review_loop` has not yet been called. Enforces the review-loop
+invariant: after a `changes_requested` verdict the orchestrator must call
+`run_python` with `callable='autoskillit.smoke_utils.check_review_loop'`
+before proceeding to CI/merge steps.
+
+## PostToolUse hooks (4)
+
+### `pretty_output_hook.py`
 **Guarded tools:** all AutoSkillit MCP tools
 Reformats raw JSON responses into Markdown key-value pairs for readable
 display and reduced token usage.
 
-### `token_summary_appender.py`
+### `token_summary_hook.py`
 **Guarded tool:** `run_skill`
 After `run_skill` returns a GitHub PR URL, appends a `## Token Usage Summary`
 table to the PR body so reviewers can see per-step token cost.
 
-### `quota_post_check.py`
+### `quota_post_hook.py`
 **Guarded tool:** `run_skill`
 After `run_skill` returns, appends a quota warning to the tool output when
 the cached binding window marks `should_block=True` (per-window threshold —
-see `quota_check.py` above). Gives the orchestrator a chance to back off
+see `quota_guard.py` above). Gives the orchestrator a chance to back off
 voluntarily before the PreToolUse hook starts denying.
+
+### `review_gate_post_hook.py`
+**Guarded tools:** `run_skill`, `run_python`
+Writes, updates, or clears `review_gate_state.json` in response to gate
+sentinel tags in `run_skill` output: `%%REVIEW_GATE::LOOP_REQUIRED%%` sets
+the gate and records the PR number; `%%REVIEW_GATE::CLEAR%%` removes the
+state file. When `run_python` calls `check_review_loop`, marks
+`check_review_loop_called: True` in the state so `review_loop_gate.py` will
+unblock `wait_for_ci`/`enqueue_pr`.
 
 ## SessionStart hook (1)
 
-### `session_start_reminder.py`
+### `session_start_hook.py`
 Injects a reminder to call `/autoskillit:open-kitchen` when resuming a
 prior session (transcript_path size > 0). Without this, resumed orchestrator
 sessions silently lose access to the kitchen tools.
@@ -126,7 +180,7 @@ safety:
 quota_guard:
   enabled: true
   short_window_threshold: 85.0
-  long_window_threshold: 98.0
+  long_window_threshold: 95.0
   long_window_patterns: ["weekly", "sonnet", "opus"]
   buffer_seconds: 60
 ```

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -310,8 +310,8 @@ def test_skill_visibility_states_124_skills() -> None:
     _assert_doc_states_number(DOCS_DIR / "skills" / "visibility.md", "skills total", 124)
 
 
-def test_safety_hooks_states_14_hooks() -> None:
-    _assert_doc_states_number(DOCS_DIR / "safety" / "hooks.md", "hooks total", 14)
+def test_safety_hooks_states_21_hooks() -> None:
+    _assert_doc_states_number(DOCS_DIR / "safety" / "hooks.md", "hooks total", 21)
 
 
 def test_configuration_states_quota_thresholds() -> None:


### PR DESCRIPTION
## Summary

`docs/safety/hooks.md` documents the Claude Code hook system but was severely stale:
six script names were renamed (old names now in `RETIRED_SCRIPT_BASENAMES`), the hook
count was wrong (14 stated vs 21 actual), seven hooks were entirely undocumented, and
the `long_window_threshold` default was wrong (98.0 stated vs 95.0 actual). This PR
fully rewrites `docs/safety/hooks.md` and updates the corresponding regression guard in
`tests/docs/test_doc_counts.py`.

## Architecture Impact

### Operational Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 45, 'rankSpacing': 65, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph Registry ["HOOK REGISTRY  (hook_registry.py)"]
        direction TB
        HOOK_REG["HOOK_REGISTRY<br/>━━━━━━━━━━<br/>18 HookDef entries<br/>21 unique scripts<br/>HOOK_REGISTRY_HASH"]
        RETIRED["RETIRED_SCRIPT_BASENAMES<br/>━━━━━━━━━━<br/>8 retired hook names<br/>guards test_no_retired_name_has_live_file"]
        GEN["generate_hooks_json()<br/>━━━━━━━━━━<br/>materialises hooks.json<br/>called by autoskillit init"]
    end

    subgraph PreHooks ["PRE-TOOL-USE HOOKS  (16 unique scripts)"]
        direction TB
        QUOTA_G["quota_guard.py<br/>━━━━━━━━━━<br/>Blocks run_skill on quota<br/>reads quota_cache.json"]
        KITCHEN_G["open_kitchen_guard.py<br/>━━━━━━━━━━<br/>Blocks open_kitchen in headless<br/>writes kitchen_state/ marker"]
        BRANCH_G["branch_protection_guard.py<br/>━━━━━━━━━━<br/>merge_worktree + push_to_remote<br/>protected branches list"]
        SAFETY_G["leaf_orchestration_guard<br/>fleet_dispatch_guard<br/>review_loop_gate<br/>━━━━━━━━━━<br/>Tier / recursion guards"]
        QUALITY_G["grep_pattern_lint_guard<br/>generated_file_write_guard<br/>pr_create_guard<br/>unsafe_install_guard<br/>━━━━━━━━━━<br/>Code quality guards"]
        SESSION_G["ask_user_question_guard<br/>mcp_health_guard<br/>━━━━━━━━━━<br/>Session integrity"]
        SKILL_G["skill_cmd_guard<br/>skill_command_guard<br/>remove_clone_guard<br/>recipe_write_advisor<br/>━━━━━━━━━━<br/>Skill / recipe guards"]
    end

    subgraph PostHooks ["POST-TOOL-USE HOOKS  (4 unique scripts)"]
        direction TB
        PRETTY["pretty_output_hook.py<br/>━━━━━━━━━━<br/>JSON → Markdown-KV<br/>30–77% token reduction"]
        QUOTA_POST["quota_post_hook.py<br/>━━━━━━━━━━<br/>Appends quota warning<br/>writes quota_events.jsonl"]
        REVIEW_POST["review_gate_post_hook.py<br/>━━━━━━━━━━<br/>LOOP_REQUIRED / CLEAR tags<br/>writes review_gate_state.json"]
        TOKEN_POST["token_summary_hook.py<br/>━━━━━━━━━━<br/>Appends Token Usage table<br/>to GitHub PR body"]
    end

    subgraph SessionStart ["SESSION-START HOOK  (1 script)"]
        direction TB
        SESS_HOOK["session_start_hook.py<br/>━━━━━━━━━━<br/>open-kitchen reminder on resume<br/>sweeps stale kitchen markers (24h TTL)"]
    end

    subgraph DocVerification ["DOCUMENTATION VERIFICATION CHAIN"]
        direction TB
        HOOKS_MD["● docs/safety/hooks.md<br/>━━━━━━━━━━<br/>Claims: 21 hooks total<br/>16 PreToolUse + 4 PostToolUse + 1 SessionStart<br/>Each hook: name + guarded tools + behaviour"]
        TEST_COUNTS["● tests/docs/test_doc_counts.py<br/>━━━━━━━━━━<br/>test_safety_hooks_states_21_hooks()<br/>asserts literal '21' present in hooks.md<br/>_count_hooks_by_event() via HOOK_REGISTRY"]
        CHECK_DOCS["scripts/check_doc_counts.py<br/>━━━━━━━━━━<br/>task check-docs<br/>skills · recipes · tools counts<br/>(does NOT verify hook counts)"]
    end

    subgraph TaskAutomation ["TASK AUTOMATION"]
        direction TB
        TASK_TEST["task test-all / test-check<br/>━━━━━━━━━━<br/>pytest -n 4<br/>runs test_doc_counts.py"]
        TASK_HOOKS["task sync-hooks-hash<br/>━━━━━━━━━━<br/>regenerates registry.sha256<br/>from live HOOK_REGISTRY"]
        TASK_DOCS["task check-docs<br/>━━━━━━━━━━<br/>scripts/check_doc_counts.py<br/>skills · recipes · tools only"]
    end

    subgraph HooksOutput ["HOOKS INSTALLATION OUTPUT"]
        direction TB
        HOOKS_JSON["src/autoskillit/hooks/hooks.json<br/>━━━━━━━━━━<br/>generated by generate_hooks_json()<br/>registered in ~/.claude.json<br/>READ-ONLY (generated file write guard)"]
        REG_HASH["src/autoskillit/hooks/registry.sha256<br/>━━━━━━━━━━<br/>SHA-256 of HOOK_REGISTRY<br/>updated by task sync-hooks-hash"]
    end

    %% REGISTRY → INSTALLATION %%
    HOOK_REG -->|"generates"| GEN
    GEN -->|"writes"| HOOKS_JSON
    HOOK_REG -->|"hashed to"| REG_HASH

    %% REGISTRY → DOC VERIFICATION %%
    HOOK_REG -->|"_count_hooks_by_event()"| TEST_COUNTS
    TEST_COUNTS -->|"asserts count in"| HOOKS_MD

    %% TASK AUTOMATION %%
    TASK_TEST -->|"executes"| TEST_COUNTS
    TASK_HOOKS -->|"rebuilds"| REG_HASH
    TASK_DOCS -->|"executes"| CHECK_DOCS

    %% HOOK ENTRIES FROM REGISTRY %%
    HOOK_REG -->|"18 HookDef entries"| QUOTA_G
    HOOK_REG -->|"18 HookDef entries"| KITCHEN_G
    HOOK_REG -->|"18 HookDef entries"| BRANCH_G
    HOOK_REG -->|"18 HookDef entries"| SAFETY_G
    HOOK_REG -->|"18 HookDef entries"| QUALITY_G
    HOOK_REG -->|"18 HookDef entries"| SESSION_G
    HOOK_REG -->|"18 HookDef entries"| SKILL_G
    HOOK_REG -->|"18 HookDef entries"| PRETTY
    HOOK_REG -->|"18 HookDef entries"| QUOTA_POST
    HOOK_REG -->|"18 HookDef entries"| REVIEW_POST
    HOOK_REG -->|"18 HookDef entries"| TOKEN_POST
    HOOK_REG -->|"18 HookDef entries"| SESS_HOOK

    %% CLASS ASSIGNMENTS %%
    class HOOK_REG,RETIRED stateNode;
    class GEN handler;
    class QUOTA_G,KITCHEN_G,BRANCH_G,SAFETY_G,QUALITY_G,SESSION_G,SKILL_G detector;
    class PRETTY,QUOTA_POST,REVIEW_POST,TOKEN_POST,SESS_HOOK handler;
    class HOOKS_MD,TEST_COUNTS phase;
    class CHECK_DOCS,TASK_TEST,TASK_HOOKS,TASK_DOCS cli;
    class HOOKS_JSON,REG_HASH output;
```

Closes #1437

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260427-195602-874283/.autoskillit/temp/make-plan/docs_audit_hooks_md_overhaul_plan_2026-04-27_000001.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 153 | 17.4k | 799.3k | 69.9k | 1 | 6m 16s |
| verify | 92 | 7.4k | 435.8k | 43.4k | 1 | 2m 9s |
| implement | 116 | 6.5k | 476.8k | 37.0k | 1 | 2m 24s |
| prepare_pr | 52 | 2.6k | 151.7k | 36.2k | 1 | 48s |
| run_arch_lenses | 87 | 11.3k | 315.0k | 84.2k | 1 | 6m 10s |
| compose_pr | 59 | 4.8k | 188.4k | 25.5k | 1 | 1m 34s |
| **Total** | 559 | 50.1k | 2.4M | 296.2k | | 19m 23s |