### PR TITLE
Implementation Plan: Docs audit: skills/ + recipes/ docs — catalog, authoring, visibility, subsets (DOC-010–014, 029–030, 032)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 AutoSkillit is a Claude Code plugin that runs YAML recipes through a two-tier
 orchestrator. Bundled recipes turn GitHub issues into merged PRs by chaining
 plan, dry-walkthrough, worktree, test, and PR-review skills against 48 MCP
-tools and 124 bundled skills.
+tools and 125 bundled skills.
 
 https://github.com/user-attachments/assets/bcd910c8-7269-46d6-a496-53b2cb24d212
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 AutoSkillit is a Claude Code plugin that runs YAML recipes through a
 two-tier orchestrator. The bundled recipes implement issue → plan → worktree
-→ tests → PR → merge pipelines using 48 MCP tools and 124 bundled skills.
+→ tests → PR → merge pipelines using 48 MCP tools and 125 bundled skills.
 
 ## Start here
 

--- a/docs/developer/end-turn-hazards.md
+++ b/docs/developer/end-turn-hazards.md
@@ -190,7 +190,7 @@ two detectors on every SKILL.md in the project:
 | `_check_loop_boundary()` | "For each" loops with tool invocations but no anti-prose guard |
 
 These run as part of `test_no_text_then_tool_in_any_step`, a parametrized
-test that scans all 124 bundled skills. Any new skill with an unguarded
+test that scans all 125 bundled skills. Any new skill with an unguarded
 loop fails CI automatically.
 
 ## If This Gets Fixed Upstream

--- a/docs/execution/architecture.md
+++ b/docs/execution/architecture.md
@@ -4,7 +4,7 @@ How AutoSkillit runs a recipe end to end: orchestrator, kitchen gating, clone an
 
 ## Overview
 
-AutoSkillit is a Claude Code plugin that orchestrates automated workflows using headless sessions. It provides 48 MCP tools and 124 bundled skills, organized into a gated visibility system.
+AutoSkillit is a Claude Code plugin that orchestrates automated workflows using headless sessions. It provides 48 MCP tools and 125 bundled skills, organized into a gated visibility system.
 
 ## Core Concepts
 

--- a/docs/recipes/authoring.md
+++ b/docs/recipes/authoring.md
@@ -6,8 +6,8 @@ contract / migration / staleness pipeline keeps recipes from rotting.
 ## Family vs bundled
 
 A **bundled recipe** lives under `src/autoskillit/recipes/*.yaml` and ships
-with the plugin (5 today: `implementation`, `implementation-groups`,
-`merge-prs`, `remediation`, `research`). A **project-local recipe** lives
+with the plugin (6 today: `implementation`, `implementation-groups`,
+`merge-prs`, `planner`, `remediation`, `research`). A **project-local recipe** lives
 under `.autoskillit/recipes/*.yaml` in a downstream project and overrides
 the bundled name.
 
@@ -29,8 +29,8 @@ top-level keys (defined in `recipe/schema.py:Recipe`):
 | `requires_packs` | list[str] | Sub-recipes or named packs to import |
 | `steps` | list[RecipeStep] | The sequenced step graph |
 
-`RecipeStep` adds: `id`, `tool`, `params`, `capture`, `verdict_routes`,
-`skip_when_false`, `retry`.
+`RecipeStep` adds: `name`, `tool`, `with_args`, `capture`, `on_result`,
+`skip_when_false`, `retries`.
 
 ## Authoring flow
 
@@ -44,32 +44,39 @@ top-level keys (defined in `recipe/schema.py:Recipe`):
 5. Add the recipe to your project's `.autoskillit/recipes/` and run a small
    `order` against a sandbox issue.
 
-## The 17 semantic rule families
+## The 24 semantic rule families
 
 `validate_recipe` runs every rule registered with `recipe/registry.py:semantic_rule`.
-The rule families live in `src/autoskillit/recipe/rules_*.py` (17 files):
+The rule families live in `src/autoskillit/recipe/rules_*.py` (24 files):
 
 | File | What it catches |
 |------|-----------------|
+| `rules_actions.py` | Action-type semantic rules: `stop-step-has-no-routing`, `recipe-has-terminal-step`, `route-step-requires-on-result` |
+| `rules_blocks.py` | Block-level budget rules: per-block `run_cmd` and `run_skill` call-count budgets |
 | `rules_bypass.py` | `skip_when_false` routes that have no fallthrough — a step that gets bypassed must also have a downstream consumer that handles the bypass |
+| `rules_campaign.py` | Campaign recipe structural rules (step count, required ingredient presence for campaign mode) |
 | `rules_ci.py` | CI polling steps written as inline shell commands instead of `wait_for_ci` |
 | `rules_clone.py` | Clone/push workflow integrity — every `clone_repo` must be paired with a `register_clone_status` and a `remove_clone` route |
 | `rules_cmd.py` | `run_cmd` echo-capture alignment and `find` rediscovery anti-patterns |
 | `rules_contracts.py` | Skills referenced in steps that are missing required output patterns in their contract card |
 | `rules_dataflow.py` | Capture/output dataflow — a captured value must be consumed by a downstream step or removed |
+| `rules_features.py` | Feature-flag gating rules: steps that reference features not declared in `requires_packs` |
+| `rules_fixing.py` | Fixing/Rectify workflow rules: rectify loops missing a terminal success route |
 | `rules_graph.py` | Step graph reachability and cycle detection |
 | `rules_inputs.py` | Ingredient/version validation — required ingredients are present, types are correct |
 | `rules_isolation.py` | Workspace isolation breaches: `source-isolation-violation` and `git-mutation-on-source` |
 | `rules_merge.py` | `merge_worktree` routing completeness — every `MergeFailedStep` value must have a route |
 | `rules_packs.py` | Unknown pack names referenced in `requires_packs` |
+| `rules_reachability.py` | Symbolic reachability: `capture-inversion-detection`, `event-scope-requires-upstream-capture` |
 | `rules_recipe.py` | Unknown sub-recipe references inside a `requires_packs` entry |
 | `rules_skill_content.py` | SKILL.md bash-block placeholder validation (`undefined-bash-placeholder`) |
+| `rules_temp_path.py` | Temp-path hygiene: steps that write to paths outside `.autoskillit/temp/` |
 | `rules_skills.py` | `skill_command` resolvability against the bundled skill registry (`unknown-skill-command`) |
 | `rules_tools.py` | MCP tool name and parameter validity (`unknown-tool`, `dead-with-param`) |
 | `rules_verdict.py` | Skill verdict routing completeness — every emitted verdict value must be routed |
 | `rules_worktree.py` | Worktree retry lifecycle — every step that creates a worktree must have a downstream merge or cleanup |
 
-The 17-family count is enforced by `tests/docs/test_doc_counts.py`.
+The 24-family count is enforced by `tests/docs/test_doc_counts.py`.
 
 ## Contract cards
 

--- a/docs/skills/catalog.md
+++ b/docs/skills/catalog.md
@@ -37,8 +37,7 @@ Located under `src/autoskillit/skills_extended/`. Grouped by purpose:
 `generate-report`, `troubleshoot-experiment`
 
 ### Research and review
-`review-design`, `stage-data`, `bundle-local-report`, `reload-session`,
-`compose-research-pr`, `prepare-research-pr`, `review-research-pr`
+`review-design`, `stage-data`, `bundle-local-report`, `reload-session`
 
 ## Tier 3 — pipeline / automation
 
@@ -49,7 +48,8 @@ runs:
 `resolve-review`, `implement-worktree-no-merge`, `resolve-failures`,
 `retry-worktree`, `resolve-merge-conflicts`, `audit-impl`, `smoke-task`,
 `report-bug`, `pipeline-summary`, `diagnose-ci`, `verify-diag`,
-`resolve-claims-review`, `resolve-design-review`, `resolve-research-review`
+`resolve-claims-review`, `resolve-design-review`, `resolve-research-review`,
+`compose-research-pr`, `prepare-research-pr`, `review-research-pr`
 
 ## arch-lens family (13)
 

--- a/docs/skills/catalog.md
+++ b/docs/skills/catalog.md
@@ -1,7 +1,7 @@
 # Skill catalog
 
-The complete list of bundled skills (109 total: 3 in `src/autoskillit/skills/`,
-106 in `src/autoskillit/skills_extended/`). Filesystem walk this directory if
+The complete list of bundled skills (125 total: 3 in `src/autoskillit/skills/`,
+122 in `src/autoskillit/skills_extended/`). Filesystem walk this directory if
 you need an exhaustive listing; this catalog groups by purpose.
 
 ## Tier 1 — free range (3)
@@ -19,31 +19,37 @@ Located under `src/autoskillit/skills_extended/`. Grouped by purpose:
 ### Plan and implementation
 `investigate`, `make-plan`, `dry-walkthrough`, `review-approach`,
 `implement-worktree`, `rectify`, `make-groups`, `mermaid`, `make-arch-diag`,
-`make-experiment-diag`
+`make-experiment-diag`, `build-execution-map`, `plan-visualization`
 
 ### Audit suite
 `audit-arch`, `audit-cohesion`, `audit-tests`, `audit-defense-standards`,
-`audit-bugs`, `audit-friction`, `validate-audit`
+`audit-bugs`, `audit-friction`, `validate-audit`,
+`audit-claims`, `audit-docs`, `audit-feature-gates`
 
 ### Requirements and planning
 `make-req`, `elaborate-phase`, `write-recipe`, `migrate-recipes`,
 `setup-project`, `design-guards`, `triage-issues`,
 `collapse-issues`, `issue-splitter`, `enrich-issues`, `prepare-issue`,
-`process-issues`
+`process-issues`, `make-campaign`
 
 ### Experiment family
 `scope`, `plan-experiment`, `implement-experiment`, `run-experiment`,
 `generate-report`, `troubleshoot-experiment`
+
+### Research and review
+`review-design`, `stage-data`, `bundle-local-report`, `reload-session`,
+`compose-research-pr`, `prepare-research-pr`, `review-research-pr`
 
 ## Tier 3 — pipeline / automation
 
 Also under `src/autoskillit/skills_extended/`. Used by recipes for unattended
 runs:
 
-`open-pr`, `open-integration-pr`, `merge-pr`, `analyze-prs`, `review-pr`,
+`prepare-pr`, `compose-pr`, `open-integration-pr`, `merge-pr`, `analyze-prs`, `review-pr`,
 `resolve-review`, `implement-worktree-no-merge`, `resolve-failures`,
 `retry-worktree`, `resolve-merge-conflicts`, `audit-impl`, `smoke-task`,
-`report-bug`, `pipeline-summary`, `diagnose-ci`, `verify-diag`
+`report-bug`, `pipeline-summary`, `diagnose-ci`, `verify-diag`,
+`resolve-claims-review`, `resolve-design-review`, `resolve-research-review`
 
 ## arch-lens family (13)
 
@@ -112,6 +118,16 @@ figure set:
 | 11 | `vis-lens-story-arc` | Narrative | Do the figures tell a coherent story across the report? | P2 |
 | 12 | `vis-lens-reproducibility` | Replicative | Can the figures be reproduced from the data and code? | P2 |
 
+## Planner family (11)
+
+11 progressive-decomposition sub-skills under `skills_extended/planner-*/`. Invoked
+internally by the `planner` recipe to break a roadmap into GitHub milestones and issues:
+
+`planner-analyze`, `planner-elaborate-assignments`, `planner-elaborate-phase`,
+`planner-elaborate-wps`, `planner-extract-domain`, `planner-generate-phases`,
+`planner-reconcile-deps`, `planner-refine`, `planner-refine-assignments`,
+`planner-refine-phases`, `planner-refine-wps`
+
 ## Rectify doctrine
 
 Several Tier 2 skills (`rectify`, `audit-bugs`, `design-guards`,
@@ -121,8 +137,8 @@ symptom, and the audit suite is updated so the same class of bug cannot
 recur. Commit messages prefix with `Rectify:` for traceability; the count of
 `Rectify:` commits is reported in `docs/developer/contributing.md`.
 
-## Total: 109
+## Total: 125
 
-3 (Tier 1) + 106 (`skills_extended/`) = 109 bundled skills. The total is
+3 (Tier 1) + 122 (`skills_extended/`) = 125 bundled skills. The total is
 verified by `tests/docs/test_doc_counts.py` against a filesystem walk so any
 addition or removal is caught immediately.

--- a/docs/skills/subsets.md
+++ b/docs/skills/subsets.md
@@ -20,6 +20,10 @@ manually reclassifying each of its tools and skills one by one. A project withou
 | `telemetry` | `get_token_summary`, `get_timing_summary`, `write_telemetry_files`, `get_quota_events` | — |
 | `arch-lens` | — | All 13 `arch-lens-*` skills, `make-arch-diag`, `verify-diag` |
 | `audit` | — | `audit-arch`, `audit-cohesion`, `audit-tests`, `audit-defense-standards`, `audit-bugs`, `audit-friction`, `audit-impl` |
+| `exp-lens` | — | All 18 `exp-lens-*` skills |
+| `kitchen-core` | `run_cmd`, `run_python`, `run_skill`, `test_check`, `reset_test_dir`, `reset_workspace`, `classify_fix`, `list_recipes`, `load_recipe`, `validate_recipe`, `migrate_recipe`, `kitchen_status`, `read_db`, `get_pipeline_report`, `dispatch_food_truck`, `merge_worktree`, `get_token_summary`, `get_timing_summary`, `write_telemetry_files`, `get_quota_events`, `analyze_tool_sequences` | — |
+| `research` | — | `compose-research-pr`, `prepare-research-pr`, `review-research-pr`, `resolve-research-review` |
+| `vis-lens` | — | All 12 `vis-lens-*` skills, `plan-visualization` |
 
 ## Disabling a Subset
 

--- a/docs/skills/subsets.md
+++ b/docs/skills/subsets.md
@@ -22,7 +22,7 @@ manually reclassifying each of its tools and skills one by one. A project withou
 | `audit` | — | `audit-arch`, `audit-cohesion`, `audit-tests`, `audit-defense-standards`, `audit-bugs`, `audit-friction`, `audit-impl` |
 | `exp-lens` | — | All 18 `exp-lens-*` skills |
 | `kitchen-core` | `run_cmd`, `run_python`, `run_skill`, `test_check`, `reset_test_dir`, `reset_workspace`, `classify_fix`, `list_recipes`, `load_recipe`, `validate_recipe`, `migrate_recipe`, `kitchen_status`, `read_db`, `get_pipeline_report`, `dispatch_food_truck`, `merge_worktree`, `get_token_summary`, `get_timing_summary`, `write_telemetry_files`, `get_quota_events`, `analyze_tool_sequences` | — |
-| `research` | — | `compose-research-pr`, `prepare-research-pr`, `review-research-pr`, `resolve-research-review` |
+| `research` | — | `compose-research-pr`, `prepare-research-pr`, `review-research-pr`, `resolve-research-review`, `resolve-claims-review`, `resolve-design-review` |
 | `vis-lens` | — | All 12 `vis-lens-*` skills, `plan-visualization` |
 
 ## Disabling a Subset

--- a/docs/skills/visibility.md
+++ b/docs/skills/visibility.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-AutoSkillit's 124 bundled skills are organized into three tiers that control when and where
+AutoSkillit's 125 bundled skills are organized into three tiers that control when and where
 they appear as slash commands. The tier system is orthogonal to subset categories — you can
 disable a subset across all tiers simultaneously, or reclassify individual skills between
 tiers. See [Subset Categories](subsets.md) for subset configuration.
@@ -22,14 +22,21 @@ tiers. See [Subset Categories](subsets.md) for subset configuration.
 ### Tier 2 — Cook (Interactive Skills)
 
 - **Location**: `src/autoskillit/skills_extended/` (NOT plugin-scanned)
-- **Default members** (41 total):
+- **Default members** (99 total):
   `investigate`, `make-plan`, `implement-worktree`, `rectify`,
   `dry-walkthrough`, `make-groups`, `review-approach`, `mermaid`, `make-arch-diag`,
-  all 13 `arch-lens-*` skills, `audit-arch`, `audit-cohesion`, `audit-tests`,
-  `audit-defense-standards`, `audit-bugs`, `audit-friction`, `make-req`,
-  `elaborate-phase`, `write-recipe`, `migrate-recipes`, `setup-project`,
+  `make-experiment-diag`, `build-execution-map`, `plan-visualization`,
+  all 13 `arch-lens-*` skills, all 18 `exp-lens-*` skills, all 12 `vis-lens-*` skills,
+  all 11 `planner-*` skills,
+  `audit-arch`, `audit-cohesion`, `audit-tests`,
+  `audit-defense-standards`, `audit-bugs`, `audit-friction`, `validate-audit`,
+  `audit-claims`, `audit-docs`, `audit-feature-gates`,
+  `make-req`, `elaborate-phase`, `write-recipe`, `migrate-recipes`, `setup-project`,
   `design-guards`, `triage-issues`, `collapse-issues`,
-  `issue-splitter`, `enrich-issues`, `prepare-issue`, `process-issues`
+  `issue-splitter`, `enrich-issues`, `prepare-issue`, `process-issues`, `make-campaign`,
+  `scope`, `plan-experiment`, `implement-experiment`, `run-experiment`,
+  `generate-report`, `troubleshoot-experiment`,
+  `review-design`, `stage-data`, `bundle-local-report`, `reload-session`
 - **Visible in**: cook and headless sessions
 - **Mechanism**: copied to an ephemeral session directory (cook) or exposed via
   `--add-dir` (headless sessions launched by `run_skill`)
@@ -37,11 +44,13 @@ tiers. See [Subset Categories](subsets.md) for subset configuration.
 ### Tier 3 — Pipeline-Only (Automation Skills)
 
 - **Location**: `src/autoskillit/skills_extended/` (same directory as Tier 2)
-- **Default members** (16 total):
-  `open-pr`, `open-integration-pr`, `merge-pr`, `analyze-prs`,
+- **Default members** (23 total):
+  `prepare-pr`, `compose-pr`, `open-integration-pr`, `merge-pr`, `analyze-prs`,
   `review-pr`, `resolve-review`, `implement-worktree-no-merge`, `resolve-failures`,
   `retry-worktree`, `resolve-merge-conflicts`, `audit-impl`, `smoke-task`,
-  `report-bug`, `pipeline-summary`, `diagnose-ci`, `verify-diag`
+  `report-bug`, `pipeline-summary`, `diagnose-ci`, `verify-diag`,
+  `compose-research-pr`, `prepare-research-pr`, `resolve-claims-review`,
+  `resolve-design-review`, `resolve-research-review`, `review-research-pr`
 - **Visible in**: cook and headless sessions
 - **Distinction from Tier 2**: semantic only — both tiers live in `skills_extended/` and
   are available in the same session modes. The tier distinction lets users reclassify

--- a/scripts/check_doc_counts.py
+++ b/scripts/check_doc_counts.py
@@ -22,21 +22,13 @@ TYPES_FILE = PROJECT_ROOT / "src" / "autoskillit" / "core" / "_type_constants.py
 
 
 def count_skills() -> int:
-    """Count public skills in skills/ and skills_extended/.
-
-    Only counts skills whose SKILL.md begins with YAML frontmatter (``---``),
-    matching the behaviour of DefaultSkillResolver().list_all() which excludes
-    internal bootstrap documents such as sous-chef.
-    """
+    """Count all bundled skill directories in skills/ and skills_extended/."""
     count = 0
     for skills_dir in (SKILLS_DIR, SKILLS_EXTENDED_DIR):
         if skills_dir.is_dir():
             for d in skills_dir.iterdir():
-                skill_md = d / "SKILL.md"
-                if d.is_dir() and skill_md.exists():
-                    text = skill_md.read_text(encoding="utf-8")
-                    if text.startswith("---\n"):
-                        count += 1
+                if d.is_dir():
+                    count += 1
     return count
 
 

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -392,7 +392,7 @@ def test_catalog_lists_all_skills_in_extended_dir() -> None:
 def test_authoring_bundled_recipe_count_mentions_6() -> None:
     """authoring.md prose must reference 6 bundled recipes (planner was missing)."""
     authoring = (DOCS_DIR / "recipes" / "authoring.md").read_text()
-    assert "6" in authoring and "planner" in authoring, (
+    assert "6 today" in authoring and "planner" in authoring, (
         "authoring.md should mention 6 bundled recipes including planner"
     )
 
@@ -400,7 +400,7 @@ def test_authoring_bundled_recipe_count_mentions_6() -> None:
 def test_authoring_recipe_step_fields_match_schema() -> None:
     """authoring.md field summary must use actual RecipeStep field names."""
     authoring = (DOCS_DIR / "recipes" / "authoring.md").read_text()
-    assert "`name`" in authoring or "name" in authoring
+    assert "`name`" in authoring
     assert "`with_args`" in authoring
     assert "`on_result`" in authoring
     assert "`retries`" in authoring

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -362,11 +362,13 @@ def test_catalog_states_vis_lens_count_is_12() -> None:
 
 def test_catalog_count_matches_filesystem() -> None:
     """Header in catalog.md must match the actual skill-dir count."""
-    catalog = (DOCS_DIR / "skills" / "catalog.md").read_text()
+    catalog = (DOCS_DIR / "skills" / "catalog.md").read_text(encoding="utf-8")
     skills_dir = SRC_DIR / "skills"
     extended_dir = SRC_DIR / "skills_extended"
-    tier1_count = sum(1 for p in skills_dir.iterdir() if p.is_dir())
-    extended_count = sum(1 for p in extended_dir.iterdir() if p.is_dir())
+    tier1_count = sum(1 for p in skills_dir.iterdir() if p.is_dir() and p.name != "__pycache__")
+    extended_count = sum(
+        1 for p in extended_dir.iterdir() if p.is_dir() and p.name != "__pycache__"
+    )
     total = tier1_count + extended_count
     assert f"{total} total" in catalog, f"catalog.md header should claim {total} total skills"
 
@@ -419,6 +421,6 @@ def test_authoring_recipe_step_fields_match_schema() -> None:
 
 def test_subsets_lists_required_packs() -> None:
     """subsets.md must document all four missing built-in pack categories."""
-    subsets = (DOCS_DIR / "skills" / "subsets.md").read_text()
+    subsets = (DOCS_DIR / "skills" / "subsets.md").read_text(encoding="utf-8")
     for pack in ("kitchen-core", "research", "exp-lens", "vis-lens"):
         assert pack in subsets, f"subsets.md missing pack category: {pack}"

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -404,9 +404,13 @@ def test_authoring_recipe_step_fields_match_schema() -> None:
     assert "`with_args`" in authoring
     assert "`on_result`" in authoring
     assert "`retries`" in authoring
-    field_summary_line = [
-        line for line in authoring.splitlines() if "with_args" in line or "id`," in line
-    ][0]
+    field_summary_line = next(
+        (line for line in authoring.splitlines() if "with_args" in line or "id`," in line),
+        None,
+    )
+    assert field_summary_line is not None, (
+        "authoring.md must contain a line listing RecipeStep fields (with_args or id`,)"
+    )
     assert "id`," not in field_summary_line
     assert "params`," not in field_summary_line
     assert "verdict_routes`" not in field_summary_line

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -306,8 +306,8 @@ def test_docs_state_44_kitchen_tools(doc_path: Path) -> None:
     _assert_doc_states_number(doc_path, "kitchen tools", 44)
 
 
-def test_skill_visibility_states_124_skills() -> None:
-    _assert_doc_states_number(DOCS_DIR / "skills" / "visibility.md", "skills total", 124)
+def test_skill_visibility_states_125_skills() -> None:
+    _assert_doc_states_number(DOCS_DIR / "skills" / "visibility.md", "skills total", 125)
 
 
 def test_safety_hooks_states_21_hooks() -> None:
@@ -339,8 +339,8 @@ def test_orchestration_states_11_retry_reasons() -> None:
     _assert_doc_states_number(DOCS_DIR / "execution" / "orchestration.md", "retry reasons", 11)
 
 
-def test_authoring_states_17_rule_families() -> None:
-    _assert_doc_states_number(DOCS_DIR / "recipes" / "authoring.md", "rule families", 17)
+def test_authoring_states_24_rule_families() -> None:
+    _assert_doc_states_number(DOCS_DIR / "recipes" / "authoring.md", "rule families", 24)
 
 
 def test_catalog_states_arch_and_exp_lens_counts() -> None:
@@ -358,3 +358,63 @@ def test_catalog_states_vis_lens_count_is_12() -> None:
         pytest.skip("docs/skills/catalog.md not present")
     text = _read(catalog)
     assert "12" in text, "skills/catalog.md does not state 12 vis-lens skills"
+
+
+def test_catalog_count_matches_filesystem() -> None:
+    """Header in catalog.md must match the actual skill-dir count."""
+    catalog = (DOCS_DIR / "skills" / "catalog.md").read_text()
+    skills_dir = SRC_DIR / "skills"
+    extended_dir = SRC_DIR / "skills_extended"
+    tier1_count = sum(1 for p in skills_dir.iterdir() if p.is_dir())
+    extended_count = sum(1 for p in extended_dir.iterdir() if p.is_dir())
+    total = tier1_count + extended_count
+    assert f"{total} total" in catalog, f"catalog.md header should claim {total} total skills"
+
+
+def test_catalog_does_not_reference_open_pr() -> None:
+    """open-pr was decomposed into prepare-pr + compose-pr in PR #659."""
+    catalog = (DOCS_DIR / "skills" / "catalog.md").read_text()
+    assert "`open-pr`" not in catalog
+
+
+def test_catalog_lists_all_skills_in_extended_dir() -> None:
+    """Every directory in skills_extended/ must appear at least once in catalog.md."""
+    catalog = (DOCS_DIR / "skills" / "catalog.md").read_text()
+    extended_dir = SRC_DIR / "skills_extended"
+    missing = [
+        p.name
+        for p in sorted(extended_dir.iterdir())
+        if p.is_dir() and f"`{p.name}`" not in catalog
+    ]
+    assert missing == [], f"Skills in skills_extended/ not listed in catalog.md: {missing}"
+
+
+def test_authoring_bundled_recipe_count_mentions_6() -> None:
+    """authoring.md prose must reference 6 bundled recipes (planner was missing)."""
+    authoring = (DOCS_DIR / "recipes" / "authoring.md").read_text()
+    assert "6" in authoring and "planner" in authoring, (
+        "authoring.md should mention 6 bundled recipes including planner"
+    )
+
+
+def test_authoring_recipe_step_fields_match_schema() -> None:
+    """authoring.md field summary must use actual RecipeStep field names."""
+    authoring = (DOCS_DIR / "recipes" / "authoring.md").read_text()
+    assert "`name`" in authoring or "name" in authoring
+    assert "`with_args`" in authoring
+    assert "`on_result`" in authoring
+    assert "`retries`" in authoring
+    field_summary_line = [
+        line for line in authoring.splitlines() if "with_args" in line or "id`," in line
+    ][0]
+    assert "id`," not in field_summary_line
+    assert "params`," not in field_summary_line
+    assert "verdict_routes`" not in field_summary_line
+    assert "retry`." not in field_summary_line
+
+
+def test_subsets_lists_required_packs() -> None:
+    """subsets.md must document all four missing built-in pack categories."""
+    subsets = (DOCS_DIR / "skills" / "subsets.md").read_text()
+    for pack in ("kitchen-core", "research", "exp-lens", "vis-lens"):
+        assert pack in subsets, f"subsets.md missing pack category: {pack}"


### PR DESCRIPTION
## Summary

Fix eight stale claims across four documentation files and update two test assertions that enforce those claims. All changes are documentation-only — no source code logic changes required. The ground truth for every fix lives in the filesystem (skill dirs, rule modules, recipe YAMLs, schema dataclass) and is enumerated explicitly below.

## Architecture Impact

### Repository/Data Access Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph Callers ["CALLERS"]
        CI["CI / pytest<br/>━━━━━━━━━━<br/>task test-all"]
        CLIRun["CLI Runner<br/>━━━━━━━━━━<br/>python check_doc_counts.py"]
    end

    subgraph Verification ["● VERIFICATION LAYER"]
        ChkScript["● check_doc_counts.py<br/>━━━━━━━━━━<br/>count_skills()<br/>count_recipes()<br/>count_tools()<br/>scan_docs()"]
        TestDoc["● test_doc_counts.py<br/>━━━━━━━━━━<br/>_count_mcp_tools()<br/>_count_skills_total()<br/>_count_arch_lens_skills()<br/>_count_hooks_by_event()"]
    end

    subgraph SourceTruth ["SOURCE OF TRUTH (reads)"]
        direction TB
        SkillsFS[("skills/ + skills_extended/<br/>━━━━━━━━━━<br/>iterdir() scan")]
        RecipesFS[("recipes/*.yaml<br/>━━━━━━━━━━<br/>glob scan")]
        TypeConsts["core/_type_constants.py<br/>━━━━━━━━━━<br/>GATED_TOOLS<br/>HEADLESS_TOOLS<br/>FREE_RANGE_TOOLS"]
        ServerTools["server/tools_*.py<br/>━━━━━━━━━━<br/>@mcp.tool decorators<br/>regex extraction"]
        HookReg["hook_registry.HOOK_REGISTRY<br/>━━━━━━━━━━<br/>Python import<br/>HookDef list"]
        ConfigYAML[("config/defaults.yaml<br/>━━━━━━━━━━<br/>yaml.safe_load")]
        DoctorFile["cli/_doctor.py<br/>━━━━━━━━━━<br/>run_doctor() body<br/>regex scan"]
        EnumsFile["core/_type_enums.py<br/>━━━━━━━━━━<br/>RetryReason StrEnum"]
        RulesFiles["recipe/rules_*.py<br/>━━━━━━━━━━<br/>glob('rules_*.py')"]
    end

    subgraph DocFiles ["● VALIDATED DOCS"]
        direction TB
        Readme["● README.md<br/>● docs/README.md"]
        DevDocs["● end-turn-hazards.md<br/>● execution/architecture.md"]
        SkillsDocs["● catalog.md<br/>● subsets.md<br/>● visibility.md"]
        RecipeDocs["● authoring.md"]
    end

    CI -->|invokes| TestDoc
    CLIRun -->|invokes| ChkScript

    ChkScript -->|"reads (iterdir)"| SkillsFS
    ChkScript -->|"reads (glob)"| RecipesFS
    ChkScript -->|"reads (regex)"| TypeConsts
    ChkScript -->|"scans for claims"| Readme
    ChkScript -->|"scans for claims"| DevDocs
    ChkScript -->|"scans for claims"| SkillsDocs
    ChkScript -->|"scans for claims"| RecipeDocs

    TestDoc -->|"reads (iterdir)"| SkillsFS
    TestDoc -->|"reads (regex)"| ServerTools
    TestDoc -->|"imports"| HookReg
    TestDoc -->|"reads (yaml)"| ConfigYAML
    TestDoc -->|"reads (regex)"| DoctorFile
    TestDoc -->|"reads (glob)"| RecipesFS
    TestDoc -->|"reads (regex)"| EnumsFile
    TestDoc -->|"reads (glob)"| RulesFiles
    TestDoc -->|"asserts counts in"| Readme
    TestDoc -->|"asserts counts in"| DevDocs
    TestDoc -->|"asserts counts in"| SkillsDocs
    TestDoc -->|"asserts counts in"| RecipeDocs

    %% CLASS ASSIGNMENTS %%
    class CI,CLIRun cli;
    class ChkScript,TestDoc handler;
    class SkillsFS,RecipesFS,ConfigYAML integration;
    class TypeConsts,ServerTools,HookReg,DoctorFile,EnumsFile,RulesFiles stateNode;
    class Readme,DevDocs,SkillsDocs,RecipeDocs output;
```

### Scenarios Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 55, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    %% ── SCENARIO 1: Skill Count Enforcement ── %%
    subgraph S1 ["SCENARIO 1 — Skill Count Enforcement (125 skills)"]
        direction LR
        S1_SRC["skills/ + skills_extended/<br/>━━━━━━━━━━<br/>Source of truth: 125 skill dirs"]
        S1_CHK["● check_doc_counts.py<br/>━━━━━━━━━━<br/>Scans filesystem → counts 125<br/>Validates numeric claims in docs"]
        S1_CAT["● docs/skills/catalog.md<br/>━━━━━━━━━━<br/>Lists all 125 skills by tier/family"]
        S1_VIS["● docs/skills/visibility.md<br/>━━━━━━━━━━<br/>Tier counts: T1=3, T2=99, T3=23"]
        S1_ETH["● docs/developer/end-turn-hazards.md<br/>━━━━━━━━━━<br/>References 125 skills in compliance test"]
        S1_TST["● tests/docs/test_doc_counts.py<br/>━━━━━━━━━━<br/>Pins '125' in visibility.md, catalog.md<br/>end-turn-hazards.md"]
    end

    S1_SRC -->|"counts dirs"| S1_CHK
    S1_CHK -->|"validates"| S1_CAT
    S1_CHK -->|"validates"| S1_VIS
    S1_CHK -->|"validates"| S1_ETH
    S1_TST -->|"asserts '125' present"| S1_CAT
    S1_TST -->|"asserts '125' present"| S1_VIS
    S1_TST -->|"asserts '125' present"| S1_ETH

    %% ── SCENARIO 2: Recipe & Rule Family Sync ── %%
    subgraph S2 ["SCENARIO 2 — Recipe & Rule Family Sync"]
        direction LR
        S2_RSRC["recipes/ (6 YAML files)<br/>━━━━━━━━━━<br/>Source of truth: bundled recipes"]
        S2_RULE["recipe/rules_*.py (24 modules)<br/>━━━━━━━━━━<br/>Semantic rule families"]
        S2_AUTH["● docs/recipes/authoring.md<br/>━━━━━━━━━━<br/>Documents 6 recipes, 24 rule families<br/>RecipeStep schema fields"]
        S2_TST["● tests/docs/test_doc_counts.py<br/>━━━━━━━━━━<br/>Pins '24' rule families in authoring.md<br/>Pins '6' bundled recipes"]
    end

    S2_RSRC -->|"count YAMLs"| S2_AUTH
    S2_RULE -->|"count modules"| S2_AUTH
    S2_TST -->|"asserts '24', '6' present"| S2_AUTH

    %% ── SCENARIO 3: MCP Tool Count Consistency ── %%
    subgraph S3 ["SCENARIO 3 — MCP Tool Count Consistency (48 tools)"]
        direction LR
        S3_CONST["core/_type_constants.py<br/>━━━━━━━━━━<br/>GATED_TOOLS (44) + FREE_RANGE_TOOLS (4)<br/>= 48 total"]
        S3_CHK["● check_doc_counts.py<br/>━━━━━━━━━━<br/>Parses constants → validates docs"]
        S3_ARCH["● docs/execution/architecture.md<br/>━━━━━━━━━━<br/>Documents 48 tools, 44 kitchen-tagged<br/>4 free-range, 1 headless"]
        S3_README["● README.md<br/>━━━━━━━━━━<br/>Kitchen-tagged tool count"]
        S3_DREAD["● docs/README.md<br/>━━━━━━━━━━<br/>Total tool count"]
        S3_TST["● tests/docs/test_doc_counts.py<br/>━━━━━━━━━━<br/>Pins 44 kitchen, 4 free-range<br/>48 total in architecture.md"]
    end

    S3_CONST -->|"source of truth"| S3_CHK
    S3_CHK -->|"validates"| S3_ARCH
    S3_CHK -->|"validates"| S3_README
    S3_CHK -->|"validates"| S3_DREAD
    S3_TST -->|"asserts counts"| S3_ARCH

    %% ── SCENARIO 4: Subset Documentation ── %%
    subgraph S4 ["SCENARIO 4 — Subset Documentation Coverage (9 subsets)"]
        direction LR
        S4_CFG["config/defaults.yaml<br/>━━━━━━━━━━<br/>Subset tag definitions<br/>kitchen-core, research, exp-lens, vis-lens"]
        S4_SUB["● docs/skills/subsets.md<br/>━━━━━━━━━━<br/>Documents 9 built-in subsets<br/>+ members per subset"]
        S4_CHK["● check_doc_counts.py<br/>━━━━━━━━━━<br/>Validates subset member counts<br/>in subsets.md"]
    end

    S4_CFG -->|"defines subsets"| S4_SUB
    S4_CHK -->|"validates member counts"| S4_SUB

    %% ── SCENARIO 5: CI Gate ── %%
    subgraph S5 ["SCENARIO 5 — CI Gate: Doc Drift Detection"]
        direction LR
        S5_PR["PR opened / pushed<br/>━━━━━━━━━━<br/>Branch: docs-audit-*"]
        S5_CHK["● check_doc_counts.py<br/>━━━━━━━━━━<br/>Exit 0 = all counts match<br/>Exit 1 = mismatch list"]
        S5_TST["● tests/docs/test_doc_counts.py<br/>━━━━━━━━━━<br/>pytest assertions on pinned counts"]
        S5_CI["CI Pipeline<br/>━━━━━━━━━━<br/>task test-all → lint + tests"]
        S5_PASS["PASS<br/>━━━━━━━━━━<br/>Docs consistent with source"]
        S5_FAIL["FAIL<br/>━━━━━━━━━━<br/>Count mismatch → fix docs"]
    end

    S5_PR -->|"triggers"| S5_CI
    S5_CI -->|"runs"| S5_CHK
    S5_CI -->|"runs"| S5_TST
    S5_CHK -->|"exit 0"| S5_PASS
    S5_CHK -->|"exit 1"| S5_FAIL
    S5_TST -->|"all pass"| S5_PASS
    S5_TST -->|"assertion error"| S5_FAIL

    %% CLASS ASSIGNMENTS %%
    class S1_SRC,S2_RSRC,S2_RULE,S3_CONST,S4_CFG stateNode;
    class S1_CHK,S2_TST,S3_CHK,S3_TST,S4_CHK,S5_CHK,S5_TST handler;
    class S1_CAT,S1_VIS,S1_ETH,S2_AUTH,S3_ARCH,S3_README,S3_DREAD,S4_SUB output;
    class S5_PR cli;
    class S5_CI phase;
    class S5_PASS output;
    class S5_FAIL detector;
```

Closes #1438

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260427-195603-805415/.autoskillit/temp/make-plan/docs_audit_skills_recipes_plan_2026-04-27_000000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 155 | 33.1k | 831.6k | 74.2k | 1 | 12m 58s |
| verify | 76 | 7.8k | 337.5k | 44.5k | 1 | 4m 1s |
| implement | 444 | 42.4k | 4.0M | 104.9k | 1 | 10m 27s |
| prepare_pr | 68 | 4.5k | 230.3k | 28.5k | 1 | 1m 25s |
| run_arch_lenses | 717 | 13.7k | 397.9k | 79.7k | 2 | 4m 33s |
| compose_pr | 75 | 6.2k | 274.5k | 30.5k | 1 | 1m 32s |
| **Total** | 1.5k | 107.8k | 6.0M | 362.3k | | 35m 0s |