### PR TITLE
Implementation Plan: Docs Audit — Remaining Doc Fixes (DOC-019–025, 028, 033–034)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 AutoSkillit is a Claude Code plugin that runs YAML recipes through a two-tier
 orchestrator. Bundled recipes turn GitHub issues into merged PRs by chaining
-plan, dry-walkthrough, worktree, test, and PR-review skills against 42 MCP
+plan, dry-walkthrough, worktree, test, and PR-review skills against 48 MCP
 tools and 124 bundled skills.
 
 https://github.com/user-attachments/assets/bcd910c8-7269-46d6-a496-53b2cb24d212
@@ -33,8 +33,8 @@ autoskillit order implementation
 ## What it does
 
 Each bundled recipe is a sequenced graph of skill invocations. The orchestrator
-holds a kitchen of 42 kitchen-tagged MCP tools plus 3 free range tools (`open_kitchen`,
-`close_kitchen`, `disable_quota_guard`), launches headless Claude sessions for the heavy work, and
+holds a kitchen of 44 kitchen-tagged MCP tools plus 4 free range tools (`open_kitchen`,
+`close_kitchen`, `disable_quota_guard`, `reload_session`), launches headless Claude sessions for the heavy work, and
 routes verdicts through retry, merge, and review gates. The 5 bundled recipes
 are `implementation`, `implementation-groups`, `merge-prs`, `remediation`, and
 `research`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -146,7 +146,7 @@ quota_guard:
     - sonnet
     - opus
   buffer_seconds: 60             # extra buffer after quota reset before resuming
-  cache_max_age: 60              # seconds before a live quota fetch is triggered
+  cache_max_age: 300             # seconds before a live quota fetch is triggered
 ```
 
 Check current quota: `autoskillit quota-status`.
@@ -271,7 +271,7 @@ read_db:
 
 ```yaml
 report_bug:
-  output_dir: null  # null = {cwd}/.autoskillit/temp/bug-reports/
+  report_dir: null  # null = {cwd}/.autoskillit/temp/bug-reports/
   timeout: 600
   github_filing: true
   github_labels: ["autoreported", "bug"]

--- a/docs/execution/architecture.md
+++ b/docs/execution/architecture.md
@@ -21,14 +21,14 @@ When you run `autoskillit order`, Claude Code acts as a pipeline orchestrator. I
 
 AutoSkillit uses a three-tier tool visibility model:
 
-- **Free-range (3 tools)**: Always visible — `open_kitchen`, `close_kitchen`, `disable_quota_guard`
+- **Free-range (4 tools)**: Always visible — `open_kitchen`, `close_kitchen`, `disable_quota_guard`, `reload_session`
 - **Headless tools (1 tool)**: Revealed in headless sessions via `mcp.enable({'headless'})` — `test_check`
-- **Kitchen-tagged tools (42 tools total)**: Gated behind `open_kitchen` — `run_skill`,
+- **Kitchen-tagged tools (44 tools total)**: Gated behind `open_kitchen` — `run_skill`,
   `run_cmd`, `run_python`, `merge_worktree`, `clone_repo`, `push_to_remote`, and 31 more.
   One kitchen tool (`test_check`) also carries the `headless` tag and is additionally
   pre-enabled in headless sessions.
 
-When you call `open_kitchen` (automatically done by `order`), all 42 kitchen-tagged tools become
+When you call `open_kitchen` (automatically done by `order`), all 44 kitchen-tagged tools become
 available for that session. This keeps normal Claude Code sessions clean — no pipeline tools
 cluttering the tool list.
 
@@ -59,8 +59,8 @@ Within the clone, implementation happens in git worktrees:
 AutoSkillit supports four session modes with different tool and skill visibility:
 
 - **`$ claude` (plugin, no kitchen)**: Regular Claude Code session with the AutoSkillit plugin
-  loaded. Sees 3 Free Range MCP tools (`open_kitchen`, `close_kitchen`, `disable_quota_guard`) and Tier 1 skills only
-  (`open-kitchen`, `close-kitchen`). After calling `/open-kitchen`, all 42 kitchen-tagged MCP
+  loaded. Sees 4 Free Range MCP tools (`open_kitchen`, `close_kitchen`, `disable_quota_guard`, `reload_session`) and Tier 1 skills only
+  (`open-kitchen`, `close-kitchen`). After calling `/open-kitchen`, all 44 kitchen-tagged MCP
   tools become available.
 
 - **`$ autoskillit cook`**: Interactive development session. Sees all three skill tiers
@@ -71,7 +71,7 @@ AutoSkillit supports four session modes with different tool and skill visibility
   all 48 MCP tools are available immediately. All skill tiers are accessible. The orchestrator
   delegates work through `run_skill` (headless sessions) and `run_cmd` (shell commands).
 
-- **`run_skill` (headless)**: Worker sessions launched by the orchestrator. Sees 3 Free Range
+- **`run_skill` (headless)**: Worker sessions launched by the orchestrator. Sees 4 Free Range
   tools + `test_check` (headless-tagged). Cannot call `run_skill`, `run_cmd`, or `run_python`
   — enforced by hooks and code guards. Has access to all native Claude Code tools (Read, Write,
   Bash, etc.) and all skill tiers via `--add-dir skills_extended/`.

--- a/docs/execution/tool-access.md
+++ b/docs/execution/tool-access.md
@@ -89,7 +89,7 @@ missing kitchen visibility.
 All 48 tools with their access level, tags, source file, and functional category.
 
 **Tag abbreviations**: AS = `autoskillit`, K = `kitchen`, HL = `headless`,
-GH = `github`, CI = `ci`, CL = `clone`, TL = `telemetry`
+GH = `github`, CI = `ci`, CL = `clone`, TL = `telemetry`, FL = `fleet`
 
 ---
 
@@ -143,7 +143,7 @@ GH = `github`, CI = `ci`, CL = `clone`, TL = `telemetry`
 | `remove_clone` | AS, K, CL | `server/tools_clone.py` |
 | `push_to_remote` | AS, K, GH | `server/tools_clone.py` |
 | `register_clone_status` | AS, K, CL | `server/tools_clone.py` |
-| `batch_cleanup_clones` | AS, K, CL | `server/tools_clone.py` |
+| `batch_cleanup_clones` | AS, K, CL, FL | `server/tools_clone.py` |
 
 ---
 
@@ -156,6 +156,7 @@ GH = `github`, CI = `ci`, CL = `clone`, TL = `telemetry`
 | `wait_for_merge_queue` | AS, K, CI | `server/tools_ci.py` |
 | `check_repo_merge_state` | AS, K, CI | `server/tools_ci.py` |
 | `toggle_auto_merge` | AS, K, CI | `server/tools_ci.py` |
+| `enqueue_pr` | AS, K, CI | `server/tools_ci.py` |
 | `set_commit_status` | AS, K, GH | `server/tools_ci.py` |
 
 ---
@@ -187,6 +188,7 @@ GH = `github`, CI = `ci`, CL = `clone`, TL = `telemetry`
 | `get_quota_events` | AS, K, TL | `server/tools_status.py` |
 | `write_telemetry_files` | AS, K, TL | `server/tools_status.py` |
 | `read_db` | AS, K | `server/tools_status.py` |
+| `analyze_tool_sequences` | AS, K, TL | `server/tools_status.py` |
 
 ---
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -56,19 +56,20 @@ sub-recipes themselves.
 
 ### free range tools
 
-The 2 MCP tools that are always visible regardless of kitchen state:
-`open_kitchen` and `close_kitchen`. Tagged only with `autoskillit`, never with
-`kitchen`. Always two words, no hyphen. Common mistake: `free-range tools`.
+The 4 MCP tools that are always visible regardless of kitchen state:
+`open_kitchen`, `close_kitchen`, `disable_quota_guard`, and `reload_session`. Tagged
+only with `autoskillit`, never with `kitchen`. Always two words, no hyphen. Common
+mistake: `free-range tools`.
 
 ### kitchen
 
-The collection of 40 kitchen-tagged MCP tools that the orchestrator must
+The collection of 44 kitchen-tagged MCP tools that the orchestrator must
 explicitly reveal via `open_kitchen` before they can be called. Hidden at
 server startup via `mcp.disable(tags={'kitchen'})`.
 
 ### kitchen tools
 
-Synonym for the 40 kitchen-tagged MCP tools. Two words, no hyphen.
+Synonym for the 44 kitchen-tagged MCP tools. Two words, no hyphen.
 
 ### kitchen_id
 

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -69,9 +69,9 @@ Per-session layout:
 ```
 sessions/
   <session-uuid>/
-    proc.jsonl          # ProcSnapshot stream
+    proc_trace.jsonl    # ProcSnapshot stream
     anomalies.jsonl     # detected anomalies
-    stdout.log          # captured headless stdout
+    raw_stdout.jsonl    # captured headless stdout
 sessions.jsonl          # one summary line per session
 ```
 
@@ -92,8 +92,8 @@ jq 'select(.anomaly_count > 0)' ~/.local/share/autoskillit/logs/sessions.jsonl
 ## 500-directory retention
 
 `execution/session_log.py` keeps the most recent 500 session directories and
-prunes older ones at every new session start. The `sessions.jsonl` index is
-append-only and is not pruned.
+prunes older ones at every new session start. `sessions.jsonl` is also rewritten
+on each prune to remove entries for deleted session directories.
 
 ## Recording and replay
 

--- a/docs/update-checks.md
+++ b/docs/update-checks.md
@@ -45,8 +45,9 @@ For unknown install types (e.g. installed from PyPI without a VCS reference),
 
 ## Escape hatches
 
-Set either env var to silence all update checks for a single invocation:
+Set any of these env vars to silence all update checks for a single invocation:
 
+    AUTOSKILLIT_SKIP_UPDATE_CHECK=1 autoskillit <command>
     AUTOSKILLIT_SKIP_STALE_CHECK=1 autoskillit <command>
     AUTOSKILLIT_SKIP_SOURCE_DRIFT_CHECK=1 autoskillit <command>
 

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -302,8 +302,8 @@ def test_docs_state_48_mcp_tools(doc_path: Path) -> None:
         DOCS_DIR / "execution" / "tool-access.md",
     ],
 )
-def test_docs_state_42_kitchen_tools(doc_path: Path) -> None:
-    _assert_doc_states_number(doc_path, "kitchen tools", 42)
+def test_docs_state_44_kitchen_tools(doc_path: Path) -> None:
+    _assert_doc_states_number(doc_path, "kitchen tools", 44)
 
 
 def test_skill_visibility_states_124_skills() -> None:


### PR DESCRIPTION
## Summary

Fix 10 stale documentation findings across 7 files. All corrections are factual: wrong field names, incorrect default values, outdated tool counts, missing tool entries, and a missing environment variable. No code changes — documentation-only.

## Architecture Impact

### Operational Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph CLI_Ops ["CLI OPERATOR ENTRY POINTS"]
        direction TB
        SERVE["autoskillit serve<br/>━━━━━━━━━━<br/>Start MCP server<br/>--verbose"]
        DOCTOR["autoskillit doctor<br/>━━━━━━━━━━<br/>28 health checks<br/>--output-json"]
        QUOTA["autoskillit quota-status<br/>━━━━━━━━━━<br/>Rate-limit utilization<br/>exits 0; JSON out"]
        CFGSHOW["autoskillit config show<br/>━━━━━━━━━━<br/>Resolved config JSON"]
        FEATURES["autoskillit features list/status<br/>━━━━━━━━━━<br/>Feature gate inspection"]
        UPDATE["autoskillit update<br/>━━━━━━━━━━<br/>Upgrade to latest"]
    end

    subgraph Config ["● CONFIGURATION HIERARCHY<br/>(docs/configuration.md)"]
        direction TB
        ENVVARS["Environment Variables<br/>━━━━━━━━━━<br/>AUTOSKILLIT_SECTION__KEY<br/>Highest priority"]
        SECRETS[".autoskillit/.secrets.yaml<br/>━━━━━━━━━━<br/>github.token only<br/>Schema-validated"]
        PROJCFG[".autoskillit/config.yaml<br/>━━━━━━━━━━<br/>Project config<br/>Schema-validated"]
        USERCFG["~/.autoskillit/config.yaml<br/>━━━━━━━━━━<br/>User config<br/>Schema-validated"]
        DEFAULTS["config/defaults.yaml<br/>━━━━━━━━━━<br/>Package defaults<br/>Lowest priority"]
        ENVVARS -->|"overrides"| SECRETS -->|"overrides"| PROJCFG -->|"overrides"| USERCFG -->|"overrides"| DEFAULTS
    end

    subgraph ToolAccess ["● TOOL ACCESS LAYERS<br/>(docs/execution/tool-access.md)"]
        direction TB
        GATED["GATED_TOOLS<br/>━━━━━━━━━━<br/>Require open_kitchen<br/>Hidden until kitchen open"]
        FREE["FREE_RANGE_TOOLS<br/>━━━━━━━━━━<br/>Always visible<br/>open/close/status"]
        SKILL["SKILL_TOOLS<br/>━━━━━━━━━━<br/>run_skill + test_check<br/>Kitchen-gated"]
    end

    subgraph UpdateChecks ["● UPDATE CHECK SIGNALS<br/>(docs/update-checks.md)"]
        direction TB
        VCHECK["Version Check<br/>━━━━━━━━━━<br/>Package vs plugin cache<br/>Network: source repo"]
        HOOKCHK["Hook Drift Check<br/>━━━━━━━━━━<br/>HOOK_REGISTRY vs deployed<br/>SHA256 hash guard"]
        SRCCHK["Source Drift Check<br/>━━━━━━━━━━<br/>editable install source<br/>still present"]
        DISMISS["Dismissal Window<br/>━━━━━━━━━━<br/>Branch-aware TTL<br/>AUTOSKILLIT_SKIP_*"]
    end

    subgraph Observability ["● OBSERVABILITY OUTPUTS<br/>(docs/operations/observability.md)"]
        direction TB
        SESSLOG["Session Diagnostics<br/>━━━━━━━━━━<br/>~/.local/share/autoskillit/logs/<br/>sessions.jsonl index"]
        SESSDIR["sessions/<session_id>/<br/>━━━━━━━━━━<br/>summary.json, proc_trace.jsonl<br/>anomalies.jsonl, token_usage.json"]
        QUOTAEVT["quota_events.jsonl<br/>━━━━━━━━━━<br/>Approve/block per run_skill<br/>Last N via get_quota_events"]
        MCPSTATUS["kitchen_status MCP tool<br/>━━━━━━━━━━<br/>Gate state, versions,<br/>token verbosity"]
        PIPELINE["get_pipeline_report<br/>get_token_summary<br/>get_timing_summary<br/>━━━━━━━━━━<br/>Accumulated run_skill telemetry"]
    end

    subgraph DocTest ["● DOC-COUNT VALIDATION<br/>(tests/docs/test_doc_counts.py)"]
        direction TB
        CHECKDOCS["task check-docs<br/>━━━━━━━━━━<br/>scripts/check_doc_counts.py<br/>Counts vs AST source map"]
        TESTCHECK["task test-check<br/>━━━━━━━━━━<br/>pytest -n 4<br/>TEST_RESULT=PASS|FAIL"]
    end

    %% FLOWS %%
    CFGSHOW --> ENVVARS
    CFGSHOW --> DEFAULTS
    SERVE --> GATED
    SERVE --> FREE
    SERVE --> SKILL
    SERVE --> MCPSTATUS
    SERVE --> PIPELINE
    DOCTOR --> VCHECK
    DOCTOR --> HOOKCHK
    DOCTOR --> SRCCHK
    UPDATE --> VCHECK
    SESSLOG --> SESSDIR
    SERVE --> SESSLOG
    SERVE --> QUOTAEVT
    CHECKDOCS --> TESTCHECK

    %% CLASS ASSIGNMENTS %%
    class SERVE,DOCTOR,QUOTA,CFGSHOW,FEATURES,UPDATE cli;
    class ENVVARS,SECRETS,PROJCFG,USERCFG,DEFAULTS phase;
    class GATED,FREE,SKILL stateNode;
    class VCHECK,HOOKCHK,SRCCHK,DISMISS detector;
    class SESSLOG,SESSDIR,QUOTAEVT,MCPSTATUS,PIPELINE output;
    class CHECKDOCS,TESTCHECK handler;
```

### Deployment Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    subgraph DevMachine ["DEVELOPER MACHINE"]
        direction TB

        subgraph Sessions ["Session Processes"]
            direction LR
            COOK["autoskillit cook<br/>━━━━━━━━━━<br/>Interactive dev session<br/>Tier 1+2+3 skills"]
            ORCH["● Claude Code<br/>Orchestrator<br/>━━━━━━━━━━<br/>order/cook session<br/>48 tools when kitchen open"]
            MCP["● autoskillit serve<br/>━━━━━━━━━━<br/>FastMCP — stdio<br/>44 tools kitchen-gated"]
            LEAF["● Headless Leaf Workers<br/>━━━━━━━━━━<br/>claude --print subprocess<br/>5 tools visible · N parallel"]
        end

        GH_CLI["gh CLI<br/>━━━━━━━━━━<br/>GitHub proxy<br/>HTTPS/443"]
    end

    subgraph LocalStorage ["LOCAL STORAGE"]
        direction LR

        subgraph Config ["● Configuration (layered)"]
            direction TB
            CFG_PKG["pkg defaults.yaml<br/>━━━━━━━━━━<br/>autoskillit/config/"]
            CFG_USER["~/.autoskillit/config.yaml<br/>━━━━━━━━━━<br/>User overrides"]
            CFG_PROJ[".autoskillit/config.yaml<br/>━━━━━━━━━━<br/>Project overrides"]
            CFG_SEC[".autoskillit/.secrets.yaml<br/>━━━━━━━━━━<br/>Secrets — never commit"]
        end

        subgraph Logs ["● Session Diagnostics"]
            direction TB
            SESS_LOG["~/.local/share/autoskillit/<br/>logs/sessions/<uuid>/<br/>━━━━━━━━━━<br/>proc_trace.jsonl<br/>anomalies.jsonl · raw_stdout.jsonl"]
            SESS_IDX["sessions.jsonl<br/>━━━━━━━━━━<br/>500-session rolling index<br/>pruned on each new start"]
        end

        CC_LOGS[".claude/projects/<cwd>/<br/>━━━━━━━━━━<br/>Claude Code session JSONL<br/>headless stdout stream"]

        KITCHEN_STATE[".autoskillit/temp/<br/>━━━━━━━━━━<br/>kitchen_state/ · fleet/<br/>dispatches/ · bug-reports/"]

        subgraph Caches ["Caches"]
            direction TB
            QUOTA_CACHE["● ~/.claude/<br/>autoskillit_quota_cache.json<br/>━━━━━━━━━━<br/>API utilization · TTL 300s"]
            UPD_CACHE["● ~/.autoskillit/<br/>update_check.json<br/>━━━━━━━━━━<br/>Last-seen version marker"]
        end
    end

    subgraph External ["EXTERNAL SERVICES"]
        direction LR
        ANTHROPIC["Anthropic API<br/>━━━━━━━━━━<br/>api.anthropic.com<br/>OAuth quota · HTTPS/443"]
        GH_API["● GitHub REST API<br/>━━━━━━━━━━<br/>api.github.com<br/>Releases · CI · Issues · HTTPS/443"]
    end

    %% CONNECTIONS %%
    COOK -->|"stdio · spawns"| MCP
    ORCH -->|"stdio · MCP calls"| MCP
    MCP -->|"spawns subprocess"| LEAF

    ORCH -->|"reads config"| CFG_PROJ
    ORCH -->|"reads config"| CFG_USER
    LEAF -->|"writes"| SESS_LOG
    LEAF -->|"writes"| CC_LOGS
    SESS_LOG -->|"rolls into"| SESS_IDX
    MCP -->|"reads/writes"| KITCHEN_STATE

    ORCH -->|"polls quota · reads/writes"| QUOTA_CACHE
    QUOTA_CACHE -->|"live fetch HTTPS"| ANTHROPIC

    MCP -->|"reads layered"| CFG_PKG
    MCP -->|"reads layered"| CFG_USER
    MCP -->|"reads layered"| CFG_PROJ
    MCP -->|"reads layered"| CFG_SEC

    ORCH -->|"update check · reads/writes"| UPD_CACHE
    UPD_CACHE -->|"HTTPS release check"| GH_API

    ORCH -->|"invokes"| GH_CLI
    GH_CLI -->|"HTTPS/443"| GH_API

    %% CLASS ASSIGNMENTS %%
    class COOK,ORCH,MCP,LEAF cli;
    class GH_CLI handler;
    class CFG_PKG,CFG_USER,CFG_PROJ,CFG_SEC,SESS_LOG,SESS_IDX,CC_LOGS,KITCHEN_STATE stateNode;
    class QUOTA_CACHE,UPD_CACHE output;
    class ANTHROPIC,GH_API integration;
```

Closes #1439

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260427-195604-197006/.autoskillit/temp/make-plan/docs_audit_remaining_fixes_plan_2026-04-27_000001.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 165 | 13.5k | 708.9k | 52.6k | 1 | 4m 51s |
| verify | 1.3k | 14.0k | 322.7k | 43.8k | 1 | 4m 36s |
| implement | 284 | 10.0k | 1.4M | 51.5k | 1 | 3m 11s |
| fix | 128 | 3.6k | 591.3k | 44.1k | 1 | 2m 10s |
| prepare_pr | 76 | 5.0k | 259.3k | 27.8k | 1 | 2m 13s |
| run_arch_lenses | 1.8k | 12.1k | 373.6k | 127.5k | 2 | 5m 39s |
| compose_pr | 67 | 5.6k | 233.5k | 29.2k | 1 | 1m 35s |
| **Total** | 3.8k | 63.9k | 3.9M | 376.4k | | 24m 18s |