### PR TITLE
Add Automated GitHub API Request Tracking Per Session

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,7 @@ generic_automation_mcp/
 │   ├── background.py        #   DefaultBackgroundSupervisor
 │   ├── context.py           #   ToolContext DI container
 │   ├── gate.py              #   DefaultGateState, gate_error_result
+│   ├── github_api_log.py    #   DefaultGitHubApiLog — session-scoped GitHub API request accumulator
 │   ├── mcp_response.py      #   Per-tool response size tracking
 │   ├── telemetry_fmt.py     #   Canonical token/timing display
 │   ├── timings.py

--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -116,6 +116,7 @@ from .types import FleetErrorCode as FleetErrorCode
 from .types import FleetLock as FleetLock
 from .types import GATED_TOOLS as GATED_TOOLS
 from .types import GateState as GateState
+from .types import GitHubApiLog as GitHubApiLog
 from .types import GitHubFetcher as GitHubFetcher
 from .types import HEADLESS_ENV_VAR as HEADLESS_ENV_VAR
 from .types import HEADLESS_TOOLS as HEADLESS_TOOLS

--- a/src/autoskillit/core/_type_protocols.py
+++ b/src/autoskillit/core/_type_protocols.py
@@ -31,6 +31,7 @@ __all__ = [
     "TokenLog",
     "TimingLog",
     "McpResponseLog",
+    "GitHubApiLog",
     "TestRunner",
     "HeadlessExecutor",
     "RecipeRepository",
@@ -165,6 +166,37 @@ class McpResponseLog(Protocol):
     def get_report(self) -> list[dict[str, Any]]: ...
 
     def compute_total(self) -> dict[str, Any]: ...
+
+    def clear(self) -> None: ...
+
+
+@runtime_checkable
+class GitHubApiLog(Protocol):
+    """Protocol for session-scoped GitHub API request accumulation."""
+
+    async def record_httpx(
+        self,
+        *,
+        method: str,
+        path: str,
+        status_code: int,
+        latency_ms: float,
+        rate_limit_remaining: int,
+        rate_limit_used: int,
+        rate_limit_reset: int,
+        timestamp: str,
+    ) -> None: ...
+
+    async def record_gh_cli(
+        self,
+        *,
+        subcommand: str,
+        exit_code: int,
+        latency_ms: float,
+        timestamp: str,
+    ) -> None: ...
+
+    def to_usage(self, session_id: str) -> dict[str, Any] | None: ...
 
     def clear(self) -> None: ...
 
@@ -371,7 +403,9 @@ class GitHubFetcher(Protocol):
 
     async def fetch_issue(
         self,
-        issue_ref: str,
+        issue_ref_or_owner: str,
+        repo: str | None = None,
+        number: int | None = None,
         *,
         include_comments: bool = True,
     ) -> dict[str, Any]: ...

--- a/src/autoskillit/execution/ci.py
+++ b/src/autoskillit/execution/ci.py
@@ -18,12 +18,15 @@ import time
 import urllib.parse
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import httpx
 
 from autoskillit.core import CIRunScope, get_logger
-from autoskillit.execution.github import github_headers
+from autoskillit.execution.github import github_headers, make_tracked_httpx_client
+
+if TYPE_CHECKING:
+    from autoskillit.core._type_protocols import GitHubApiLog
 
 logger = get_logger(__name__)
 
@@ -88,7 +91,12 @@ class DefaultCIWatcher:
 
     _UNRESOLVED = object()
 
-    def __init__(self, *, token: str | None | Callable[[], str | None] = None) -> None:
+    def __init__(
+        self,
+        *,
+        token: str | None | Callable[[], str | None] = None,
+        tracker: GitHubApiLog | None = None,
+    ) -> None:
         self._token_factory: Callable[[], str | None] | None
         if callable(token):
             self._token_factory = token
@@ -96,6 +104,7 @@ class DefaultCIWatcher:
         else:
             self._token_factory = None
             self._token = token
+        self._tracker = tracker
         self._etag_cache: dict[str, tuple[str, Any]] = {}  # url -> (etag, cached_json)
 
     def _resolve_token(self) -> str | None:
@@ -290,7 +299,11 @@ class DefaultCIWatcher:
         cutoff_dt = datetime.now(UTC) - timedelta(seconds=lookback_seconds)
 
         try:
-            async with httpx.AsyncClient(timeout=httpx.Timeout(15.0, connect=5.0)) as client:
+            async with make_tracked_httpx_client(
+                self._tracker,
+                timeout=httpx.Timeout(15.0, connect=5.0),
+                headers=github_headers(self._resolve_token()),
+            ) as client:
                 # Phase 1: Look-back — check for recently-completed runs
                 logger.info(
                     "ci_watcher_lookback",
@@ -508,7 +521,11 @@ class DefaultCIWatcher:
         headers = self._headers()
 
         try:
-            async with httpx.AsyncClient(timeout=httpx.Timeout(15.0, connect=5.0)) as client:
+            async with make_tracked_httpx_client(
+                self._tracker,
+                timeout=httpx.Timeout(15.0, connect=5.0),
+                headers=github_headers(self._resolve_token()),
+            ) as client:
                 if run_id is not None:
                     run_data = await self._poll_run_status(
                         client,

--- a/src/autoskillit/execution/github.py
+++ b/src/autoskillit/execution/github.py
@@ -10,11 +10,15 @@ import asyncio
 import re
 import time
 from collections.abc import Callable
-from typing import Any
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
 
 import httpx
 
 from autoskillit.core import _parse_issue_ref, get_logger
+
+if TYPE_CHECKING:
+    from autoskillit.core._type_protocols import GitHubApiLog
 
 logger = get_logger(__name__)
 
@@ -80,6 +84,66 @@ def github_headers(token: str | None) -> dict[str, str]:
     return h
 
 
+class _TrackingTransport(httpx.AsyncBaseTransport):
+    """httpx transport wrapper that records each request into a GitHubApiLog."""
+
+    def __init__(
+        self,
+        wrapped: httpx.AsyncBaseTransport,
+        tracker: GitHubApiLog,
+    ) -> None:
+        self._wrapped = wrapped
+        self._tracker = tracker
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        start = time.monotonic()
+        response = await self._wrapped.handle_async_request(request)
+        latency_ms = (time.monotonic() - start) * 1000.0
+        headers = response.headers
+
+        def _int(key: str) -> int:
+            try:
+                return int(headers.get(key, "-1"))
+            except ValueError:
+                return -1
+
+        await self._tracker.record_httpx(
+            method=request.method,
+            path=str(request.url.path),
+            status_code=response.status_code,
+            latency_ms=latency_ms,
+            rate_limit_remaining=_int("x-ratelimit-remaining"),
+            rate_limit_used=_int("x-ratelimit-used"),
+            rate_limit_reset=_int("x-ratelimit-reset"),
+            timestamp=datetime.now(UTC).isoformat(),
+        )
+        return response
+
+    async def aclose(self) -> None:
+        await self._wrapped.aclose()
+
+
+def make_tracked_httpx_client(
+    tracker: GitHubApiLog | None,
+    *,
+    timeout: httpx.Timeout,
+    headers: dict[str, str] | None = None,
+    limits: httpx.Limits | None = None,
+    base_url: str | None = None,
+) -> httpx.AsyncClient:
+    """Build an httpx.AsyncClient, optionally wrapping transport with tracking."""
+    kwargs: dict[str, Any] = {"timeout": timeout}
+    if headers is not None:
+        kwargs["headers"] = headers
+    if limits is not None:
+        kwargs["limits"] = limits
+    if base_url is not None:
+        kwargs["base_url"] = base_url
+    if tracker is not None:
+        kwargs["transport"] = _TrackingTransport(httpx.AsyncHTTPTransport(), tracker)
+    return httpx.AsyncClient(**kwargs)
+
+
 def parse_merge_queue_response(data: dict[str, Any]) -> list[dict[str, Any]]:
     """Parse a GitHub GraphQL merge queue response into a sorted entry list.
 
@@ -127,7 +191,13 @@ class DefaultGitHubFetcher:
 
     _UNRESOLVED = object()
 
-    def __init__(self, *, token: str | None | Callable[[], str | None] = None) -> None:
+    def __init__(
+        self,
+        *,
+        token: str | None | Callable[[], str | None] = None,
+        tracker: GitHubApiLog | None = None,
+        base_url: str = "https://api.github.com",
+    ) -> None:
         self._token_factory: Callable[[], str | None] | None
         if callable(token):
             self._token_factory = token
@@ -135,6 +205,8 @@ class DefaultGitHubFetcher:
         else:
             self._token_factory = None
             self._token = token
+        self._tracker = tracker
+        self._base_url = base_url.rstrip("/")
         self._last_mutating_ts: float = 0.0
         self._mutating_lock: asyncio.Lock = asyncio.Lock()
         self._label_cache: set[tuple[str, str, str]] = set()
@@ -168,25 +240,37 @@ class DefaultGitHubFetcher:
 
     async def fetch_issue(
         self,
-        issue_ref: str,
+        issue_ref_or_owner: str,
+        repo: str | None = None,
+        number: int | None = None,
         *,
         include_comments: bool = True,
     ) -> dict[str, Any]:
         """Fetch a GitHub issue. Returns structured data + Markdown content.
 
-        Never raises.
+        Accepts either a single issue_ref string ("owner/repo#N") or separate
+        (owner, repo, number) positional arguments. Never raises.
         """
-        try:
-            owner, repo, number = _parse_issue_ref(issue_ref)
-        except ValueError as exc:
-            return {"success": False, "error": str(exc)}
+        if repo is not None and number is not None:
+            owner = issue_ref_or_owner
+            issue_ref = f"{owner}/{repo}#{number}"
+        else:
+            try:
+                owner, repo, number = _parse_issue_ref(issue_ref_or_owner)
+            except ValueError as exc:
+                return {"success": False, "error": str(exc)}
+            issue_ref = issue_ref_or_owner
 
-        headers = self._headers()
-        base = f"https://api.github.com/repos/{owner}/{repo}/issues/{number}"
+        path = f"/repos/{owner}/{repo}/issues/{number}"
 
         try:
-            async with httpx.AsyncClient(timeout=httpx.Timeout(15.0, connect=5.0)) as client:
-                resp = await client.get(base, headers=headers)
+            async with make_tracked_httpx_client(
+                self._tracker,
+                timeout=httpx.Timeout(15.0, connect=5.0),
+                headers=github_headers(self._resolve_token()),
+                base_url=self._base_url,
+            ) as client:
+                resp = await client.get(path)
                 if resp.status_code == 404:
                     if not self.has_token:
                         return {
@@ -206,9 +290,7 @@ class DefaultGitHubFetcher:
 
                 comments: list[dict[str, str]] = []
                 if include_comments and issue_data.get("comments", 0) > 0:
-                    c_resp = await client.get(
-                        f"{base}/comments", headers=headers, params={"per_page": 100}
-                    )
+                    c_resp = await client.get(f"{path}/comments", params={"per_page": 100})
                     c_resp.raise_for_status()
                     comments = [
                         {"author": c["user"]["login"], "body": c["body"] or ""}
@@ -273,12 +355,15 @@ class DefaultGitHubFetcher:
         Never raises.
         """
         search_query = f'repo:{owner}/{repo} is:issue state:{state} "{query}"'
-        headers = self._headers()
         try:
-            async with httpx.AsyncClient(timeout=httpx.Timeout(15.0, connect=5.0)) as client:
+            async with make_tracked_httpx_client(
+                self._tracker,
+                timeout=httpx.Timeout(15.0, connect=5.0),
+                headers=github_headers(self._resolve_token()),
+                base_url=self._base_url,
+            ) as client:
                 resp = await client.get(
-                    "https://api.github.com/search/issues",
-                    headers=headers,
+                    "/search/issues",
                     params={"q": search_query, "per_page": 5},
                 )
                 resp.raise_for_status()
@@ -318,15 +403,18 @@ class DefaultGitHubFetcher:
         Returns {success, issue_number, url}. Never raises.
         """
         await self._throttle_mutating()
-        headers = self._headers()
         payload: dict[str, Any] = {"title": title, "body": body}
         if labels:
             payload["labels"] = labels
         try:
-            async with httpx.AsyncClient(timeout=httpx.Timeout(15.0, connect=5.0)) as client:
+            async with make_tracked_httpx_client(
+                self._tracker,
+                timeout=httpx.Timeout(15.0, connect=5.0),
+                headers=github_headers(self._resolve_token()),
+                base_url=self._base_url,
+            ) as client:
                 resp = await client.post(
-                    f"https://api.github.com/repos/{owner}/{repo}/issues",
-                    headers=headers,
+                    f"/repos/{owner}/{repo}/issues",
                     json=payload,
                 )
                 resp.raise_for_status()
@@ -359,12 +447,15 @@ class DefaultGitHubFetcher:
         Returns {success, issue_url}. Never raises.
         """
         await self._throttle_mutating()
-        headers = self._headers()
         try:
-            async with httpx.AsyncClient(timeout=httpx.Timeout(15.0, connect=5.0)) as client:
+            async with make_tracked_httpx_client(
+                self._tracker,
+                timeout=httpx.Timeout(15.0, connect=5.0),
+                headers=github_headers(self._resolve_token()),
+                base_url=self._base_url,
+            ) as client:
                 resp = await client.patch(
-                    f"https://api.github.com/repos/{owner}/{repo}/issues/{issue_number}",
-                    headers=headers,
+                    f"/repos/{owner}/{repo}/issues/{issue_number}",
                     json={"body": new_body},
                 )
                 resp.raise_for_status()
@@ -398,10 +489,15 @@ class DefaultGitHubFetcher:
             owner, repo, number = _parse_issue_ref(issue_url)
         except ValueError as exc:
             return {"success": False, "error": str(exc)}
-        url = f"https://api.github.com/repos/{owner}/{repo}/issues/{number}"
+        path = f"/repos/{owner}/{repo}/issues/{number}"
         try:
-            async with httpx.AsyncClient(timeout=httpx.Timeout(15.0, connect=5.0)) as client:
-                resp = await client.get(url, headers=self._headers())
+            async with make_tracked_httpx_client(
+                self._tracker,
+                timeout=httpx.Timeout(15.0, connect=5.0),
+                headers=github_headers(self._resolve_token()),
+                base_url=self._base_url,
+            ) as client:
+                resp = await client.get(path)
                 if resp.status_code == 404:
                     hint = (
                         " Set github.token in .autoskillit/.secrets.yaml,"
@@ -437,12 +533,15 @@ class DefaultGitHubFetcher:
     ) -> dict[str, Any]:
         """Add labels to an issue. Returns {success, labels}. Never raises."""
         await self._throttle_mutating()
-        headers = self._headers()
         try:
-            async with httpx.AsyncClient(timeout=httpx.Timeout(15.0, connect=5.0)) as client:
+            async with make_tracked_httpx_client(
+                self._tracker,
+                timeout=httpx.Timeout(15.0, connect=5.0),
+                headers=github_headers(self._resolve_token()),
+                base_url=self._base_url,
+            ) as client:
                 resp = await client.post(
-                    f"https://api.github.com/repos/{owner}/{repo}/issues/{issue_number}/labels",
-                    headers=headers,
+                    f"/repos/{owner}/{repo}/issues/{issue_number}/labels",
                     json={"labels": labels},
                 )
                 resp.raise_for_status()
@@ -469,13 +568,16 @@ class DefaultGitHubFetcher:
         """Remove a label from an issue. 404 is treated as success (idempotent).
         Returns {success}. Never raises."""
         await self._throttle_mutating()
-        headers = self._headers()
         encoded = label.replace(" ", "%20")
         try:
-            async with httpx.AsyncClient(timeout=httpx.Timeout(15.0, connect=5.0)) as client:
+            async with make_tracked_httpx_client(
+                self._tracker,
+                timeout=httpx.Timeout(15.0, connect=5.0),
+                headers=github_headers(self._resolve_token()),
+                base_url=self._base_url,
+            ) as client:
                 resp = await client.delete(
-                    f"https://api.github.com/repos/{owner}/{repo}/issues/{issue_number}/labels/{encoded}",
-                    headers=headers,
+                    f"/repos/{owner}/{repo}/issues/{issue_number}/labels/{encoded}",
                 )
                 if resp.status_code == 404:
                     return {"success": True}  # already removed — idempotent
@@ -509,13 +611,16 @@ class DefaultGitHubFetcher:
 
         Returns {success, labels}. Never raises.
         """
-        headers = self._headers()
         try:
-            async with httpx.AsyncClient(timeout=httpx.Timeout(15.0, connect=5.0)) as client:
+            async with make_tracked_httpx_client(
+                self._tracker,
+                timeout=httpx.Timeout(15.0, connect=5.0),
+                headers=github_headers(self._resolve_token()),
+                base_url=self._base_url,
+            ) as client:
                 # Step 1: GET current labels (read-only, no throttle needed)
                 get_resp = await client.get(
-                    f"https://api.github.com/repos/{owner}/{repo}/issues/{issue_number}/labels",
-                    headers=headers,
+                    f"/repos/{owner}/{repo}/issues/{issue_number}/labels",
                 )
                 get_resp.raise_for_status()
                 current = {lbl["name"] for lbl in get_resp.json()}
@@ -528,8 +633,7 @@ class DefaultGitHubFetcher:
                 # Step 3: PUT atomically (throttle the single mutating call)
                 await self._throttle_mutating()
                 put_resp = await client.put(
-                    f"https://api.github.com/repos/{owner}/{repo}/issues/{issue_number}/labels",
-                    headers=headers,
+                    f"/repos/{owner}/{repo}/issues/{issue_number}/labels",
                     json={"labels": target},
                 )
                 put_resp.raise_for_status()
@@ -563,12 +667,15 @@ class DefaultGitHubFetcher:
             return {"success": True, "created": False}
 
         await self._throttle_mutating()
-        headers = self._headers()
         try:
-            async with httpx.AsyncClient(timeout=httpx.Timeout(15.0, connect=5.0)) as client:
+            async with make_tracked_httpx_client(
+                self._tracker,
+                timeout=httpx.Timeout(15.0, connect=5.0),
+                headers=github_headers(self._resolve_token()),
+                base_url=self._base_url,
+            ) as client:
                 resp = await client.post(
-                    f"https://api.github.com/repos/{owner}/{repo}/labels",
-                    headers=headers,
+                    f"/repos/{owner}/{repo}/labels",
                     json={"name": label, "color": color, "description": description},
                 )
                 if resp.status_code == 422:

--- a/src/autoskillit/execution/github.py
+++ b/src/autoskillit/execution/github.py
@@ -251,6 +251,8 @@ class DefaultGitHubFetcher:
         Accepts either a single issue_ref string ("owner/repo#N") or separate
         (owner, repo, number) positional arguments. Never raises.
         """
+        if (repo is None) != (number is None):
+            return {"success": False, "error": "repo and number must both be provided together"}
         if repo is not None and number is not None:
             owner = issue_ref_or_owner
             issue_ref = f"{owner}/{repo}#{number}"

--- a/src/autoskillit/execution/merge_queue.py
+++ b/src/autoskillit/execution/merge_queue.py
@@ -13,12 +13,15 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Any, Literal, TypedDict, assert_never
+from typing import TYPE_CHECKING, Any, Literal, TypedDict, assert_never
 
 import httpx
 
 from autoskillit.core import PRState, YAMLError, get_logger, load_yaml
-from autoskillit.execution.github import github_headers
+from autoskillit.execution.github import github_headers, make_tracked_httpx_client
+
+if TYPE_CHECKING:
+    from autoskillit.core._type_protocols import GitHubApiLog
 
 logger = get_logger(__name__)
 
@@ -309,26 +312,31 @@ class DefaultMergeQueueWatcher:
     def __init__(
         self,
         token: str | None | Callable[[], str | None],
+        *,
+        tracker: GitHubApiLog | None = None,
     ) -> None:
         self._token_factory: Callable[[], str | None] | None
+        self._tracker = tracker
         if callable(token):
             self._token_factory = token
             self._client: httpx.AsyncClient | None = None
         else:
             self._token_factory = None
-            self._client = httpx.AsyncClient(
+            self._client = make_tracked_httpx_client(
+                self._tracker,
+                timeout=httpx.Timeout(30.0),
                 headers=github_headers(token),
                 limits=httpx.Limits(keepalive_expiry=60),
-                timeout=30.0,
             )
 
     def _ensure_client(self) -> httpx.AsyncClient:
         if self._client is None:
             resolved = self._token_factory() if self._token_factory is not None else None
-            self._client = httpx.AsyncClient(
+            self._client = make_tracked_httpx_client(
+                self._tracker,
+                timeout=httpx.Timeout(30.0),
                 headers=github_headers(resolved),
                 limits=httpx.Limits(keepalive_expiry=60),
-                timeout=30.0,
             )
         return self._client
 

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -16,7 +16,10 @@ import time
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from autoskillit.core._type_protocols import GitHubApiLog
 
 import psutil
 
@@ -132,6 +135,7 @@ def flush_session_log(
     recipe_content_hash: str = "",
     recipe_composite_hash: str = "",
     recipe_version: str = "",
+    github_api_log: GitHubApiLog | None = None,
 ) -> None:
     """Flush session diagnostics to disk.
 
@@ -293,6 +297,17 @@ def flush_session_log(
         except ValueError:
             pass
 
+    # Compute GitHub API usage and write github_api_usage.json
+    github_api_requests = 0
+    if github_api_log is not None:
+        usage = github_api_log.to_usage(session_id)
+        if usage is not None:
+            atomic_write(
+                session_dir / "github_api_usage.json",
+                json.dumps(usage, sort_keys=True, indent=2) + "\n",
+            )
+            github_api_requests = usage["total_requests"]
+
     # Write summary.json
     summary = {
         "session_id": session_id,
@@ -331,6 +346,7 @@ def flush_session_log(
         "turn_tool_calls": _cb_turn_tool_calls,
         "campaign_id": campaign_id,
         "dispatch_id": dispatch_id,
+        "github_api_requests": github_api_requests,
     }
     if versions is not None:
         effective_model_id = model_identifier or _primary_model_identifier(token_usage)
@@ -423,6 +439,7 @@ def flush_session_log(
         "recipe_composite_hash": recipe_composite_hash,
         "recipe_version": recipe_version,
         "duration_seconds": duration_seconds,
+        "github_api_requests": github_api_requests,
     }
     index_path = log_root / "sessions.jsonl"
     with index_path.open("a") as f:

--- a/src/autoskillit/pipeline/__init__.py
+++ b/src/autoskillit/pipeline/__init__.py
@@ -28,6 +28,7 @@ from autoskillit.pipeline.gate import (
     gate_error_result,
     headless_error_result,
 )
+from autoskillit.pipeline.github_api_log import DefaultGitHubApiLog
 from autoskillit.pipeline.mcp_response import DefaultMcpResponseLog, McpResponseEntry
 from autoskillit.pipeline.pr_gates import (
     is_ci_passing,
@@ -70,6 +71,8 @@ __all__ = [
     "write_status",
     # context
     "ToolContext",
+    # github_api_log
+    "DefaultGitHubApiLog",
     # pr_gates
     "is_ci_passing",
     "is_review_passing",

--- a/src/autoskillit/pipeline/context.py
+++ b/src/autoskillit/pipeline/context.py
@@ -21,6 +21,7 @@ from autoskillit.core import (
     DatabaseReader,
     FleetLock,
     GateState,
+    GitHubApiLog,
     GitHubFetcher,
     HeadlessExecutor,
     McpResponseLog,
@@ -120,6 +121,7 @@ class ToolContext:
     github_client: GitHubFetcher | None = field(default=None)
     ci_watcher: CIWatcher | None = field(default=None)
     merge_queue_watcher: MergeQueueWatcher | None = field(default=None)
+    github_api_log: GitHubApiLog | None = field(default=None)
     background: BackgroundSupervisor | None = field(default=None)
     output_pattern_resolver: OutputPatternResolver | None = field(default=None)
     write_expected_resolver: WriteExpectedResolver | None = field(default=None)

--- a/src/autoskillit/pipeline/github_api_log.py
+++ b/src/autoskillit/pipeline/github_api_log.py
@@ -1,0 +1,141 @@
+"""Session-scoped GitHub API request accumulator.
+
+Mirrors the tokens.py / timings.py pattern: a lock-guarded list of entries
+aggregated on demand by to_usage(). Flushed to github_api_usage.json at
+session log-write time via flush_session_log().
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class GitHubApiEntry:
+    method: str
+    path: str
+    status_code: int
+    latency_ms: float
+    rate_limit_remaining: int
+    rate_limit_used: int
+    rate_limit_reset: int
+    timestamp: str
+    source: str  # "httpx" or "gh_cli"
+    subcommand: str = field(default="")
+
+
+_CATEGORY_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"^/repos/[^/]+/[^/]+/issues"), "issues"),
+    (re.compile(r"^/repos/[^/]+/[^/]+/pulls"), "pulls"),
+    (re.compile(r"^/repos/[^/]+/[^/]+/actions"), "actions"),
+    (re.compile(r"^/search/"), "search"),
+    (re.compile(r"^/graphql$"), "graphql"),
+]
+
+
+def _categorize(path: str) -> str:
+    for pattern, category in _CATEGORY_PATTERNS:
+        if pattern.match(path):
+            return category
+    return "other"
+
+
+class DefaultGitHubApiLog:
+    """asyncio.Lock-guarded accumulator of GitHub API call entries."""
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._entries: list[GitHubApiEntry] = []
+
+    async def record_httpx(
+        self,
+        *,
+        method: str,
+        path: str,
+        status_code: int,
+        latency_ms: float,
+        rate_limit_remaining: int,
+        rate_limit_used: int,
+        rate_limit_reset: int,
+        timestamp: str,
+    ) -> None:
+        async with self._lock:
+            self._entries.append(
+                GitHubApiEntry(
+                    method=method,
+                    path=path,
+                    status_code=status_code,
+                    latency_ms=latency_ms,
+                    rate_limit_remaining=rate_limit_remaining,
+                    rate_limit_used=rate_limit_used,
+                    rate_limit_reset=rate_limit_reset,
+                    timestamp=timestamp,
+                    source="httpx",
+                )
+            )
+
+    async def record_gh_cli(
+        self,
+        *,
+        subcommand: str,
+        exit_code: int,
+        latency_ms: float,
+        timestamp: str,
+    ) -> None:
+        async with self._lock:
+            self._entries.append(
+                GitHubApiEntry(
+                    method="",
+                    path="",
+                    status_code=exit_code,
+                    latency_ms=latency_ms,
+                    rate_limit_remaining=-1,
+                    rate_limit_used=0,
+                    rate_limit_reset=0,
+                    timestamp=timestamp,
+                    source="gh_cli",
+                    subcommand=subcommand,
+                )
+            )
+
+    def to_usage(self, session_id: str) -> dict[str, Any] | None:
+        if not self._entries:
+            return None
+        by_category: dict[str, int] = {}
+        by_source: dict[str, int] = {}
+        total_latency = 0.0
+        min_remaining: int | None = None
+        errors: dict[str, int] = {"4xx": 0, "5xx": 0}
+        timestamps = [e.timestamp for e in self._entries if e.timestamp]
+        for e in self._entries:
+            cat = _categorize(e.path) if e.source == "httpx" else "other"
+            by_category[cat] = by_category.get(cat, 0) + 1
+            by_source[e.source] = by_source.get(e.source, 0) + 1
+            total_latency += e.latency_ms
+            if e.source == "httpx" and e.rate_limit_remaining >= 0:
+                if min_remaining is None or e.rate_limit_remaining < min_remaining:
+                    min_remaining = e.rate_limit_remaining
+            if e.source == "httpx":
+                if 400 <= e.status_code < 500:
+                    errors["4xx"] += 1
+                elif 500 <= e.status_code < 600:
+                    errors["5xx"] += 1
+        count = len(self._entries)
+        return {
+            "session_id": session_id,
+            "total_requests": count,
+            "by_category": by_category,
+            "by_source": by_source,
+            "total_latency_ms": round(total_latency, 2),
+            "avg_latency_ms": round(total_latency / count, 2) if count else 0.0,
+            "min_rate_limit_remaining": min_remaining,
+            "errors": errors,
+            "first_request_ts": min(timestamps) if timestamps else None,
+            "last_request_ts": max(timestamps) if timestamps else None,
+        }
+
+    def clear(self) -> None:
+        self._entries = []

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -50,11 +50,11 @@ from autoskillit.pipeline import (
     DefaultAuditLog,
     DefaultBackgroundSupervisor,
     DefaultGateState,
+    DefaultGitHubApiLog,
     DefaultTimingLog,
     DefaultTokenLog,
     ToolContext,
 )
-from autoskillit.pipeline.github_api_log import DefaultGitHubApiLog
 from autoskillit.recipe import (
     DefaultRecipeRepository,
     get_skill_contract,

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -54,6 +54,7 @@ from autoskillit.pipeline import (
     DefaultTokenLog,
     ToolContext,
 )
+from autoskillit.pipeline.github_api_log import DefaultGitHubApiLog
 from autoskillit.recipe import (
     DefaultRecipeRepository,
     get_skill_contract,
@@ -264,6 +265,7 @@ def make_context(
     session_mgr = DefaultSessionSkillManager(provider, ephemeral_root)
 
     audit = DefaultAuditLog()
+    github_api_log = DefaultGitHubApiLog()
     ctx = ToolContext(
         config=config,
         audit=audit,
@@ -280,9 +282,10 @@ def make_context(
         db_reader=DefaultDatabaseReader(),
         workspace_mgr=DefaultWorkspaceManager(),
         clone_mgr=DefaultCloneManager(),
-        github_client=DefaultGitHubFetcher(token=token_factory),
-        ci_watcher=DefaultCIWatcher(token=token_factory),
-        merge_queue_watcher=DefaultMergeQueueWatcher(token=token_factory),
+        github_client=DefaultGitHubFetcher(token=token_factory, tracker=github_api_log),
+        ci_watcher=DefaultCIWatcher(token=token_factory, tracker=github_api_log),
+        merge_queue_watcher=DefaultMergeQueueWatcher(token=token_factory, tracker=github_api_log),
+        github_api_log=github_api_log,
         session_skill_manager=session_mgr,
         skill_resolver=provider.resolver,
         quota_refresh_task=None,

--- a/src/autoskillit/server/helpers.py
+++ b/src/autoskillit/server/helpers.py
@@ -6,7 +6,9 @@ import asyncio
 import functools
 import json
 import os
+import time
 from collections.abc import Awaitable, Callable, Mapping
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -333,6 +335,15 @@ def _process_runner_result(
     return result.returncode, result.stdout, result.stderr
 
 
+_GH_API_SUBCOMMANDS: frozenset[str] = frozenset(
+    {"api", "pr", "issue", "repo", "release", "run", "workflow", "search"}
+)
+
+
+def _is_github_cli_call(cmd: list[str]) -> bool:
+    return len(cmd) >= 2 and cmd[0] == "gh" and cmd[1] in _GH_API_SUBCOMMANDS
+
+
 async def _run_subprocess(
     cmd: list[str],
     *,
@@ -347,8 +358,25 @@ async def _run_subprocess(
     """
     runner = _get_ctx().runner
     assert runner is not None, "No subprocess runner configured"
+
+    is_gh = _is_github_cli_call(cmd)
+    start = time.monotonic() if is_gh else 0.0
+
     result = await runner(cmd, cwd=Path(cwd), timeout=timeout, env=env)
-    return _process_runner_result(result, timeout)
+    returncode, stdout, stderr = _process_runner_result(result, timeout)
+
+    if is_gh:
+        latency_ms = (time.monotonic() - start) * 1000.0
+        log = _get_ctx().github_api_log
+        if log is not None:
+            await log.record_gh_cli(
+                subcommand=" ".join(str(c) for c in cmd[:3]),
+                exit_code=returncode,
+                latency_ms=latency_ms,
+                timestamp=datetime.now(UTC).isoformat(),
+            )
+
+    return returncode, stdout, stderr
 
 
 def _check_dry_walkthrough(skill_command: str, cwd: str) -> str | None:

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -724,6 +724,9 @@ def test_no_subpackage_exceeds_10_files() -> None:
         input-validation guard for Grep tool BRE pattern syntax. review_gate_post_hook.py
         and review_loop_gate.py add the review gate enforcement hooks. recipe_write_advisor.py
         adds a non-blocking advisory hook for recipe YAML writes. Exempt at 27 files.
+      pipeline/ — REQ-CNST-003-E7: pipeline/ added github_api_log.py for session-scoped
+        GitHub API request tracking (DefaultGitHubApiLog accumulator + GitHubApiEntry).
+        Exempt at 12 files.
     """
     EXEMPTIONS: dict[str, int] = {
         "server": 20,
@@ -732,6 +735,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "core": 27,
         "cli": 27,
         "hooks": 27,
+        "pipeline": 12,
     }
     violations: list[str] = []
     for sub_dir in sorted(SRC_ROOT.iterdir()):

--- a/tests/execution/test_github_api_tracking_http.py
+++ b/tests/execution/test_github_api_tracking_http.py
@@ -12,8 +12,11 @@ pytestmark = [
 _api_sim_http = pytest.importorskip("api_simulator.http")
 PyResponseSpec = _api_sim_http.MockResponseSpec
 
-from autoskillit.execution.github import DefaultGitHubFetcher, make_tracked_httpx_client
-from tests.fakes import InMemoryGitHubApiLog
+from autoskillit.execution.github import (  # noqa: E402
+    DefaultGitHubFetcher,
+    make_tracked_httpx_client,
+)
+from tests.fakes import InMemoryGitHubApiLog  # noqa: E402
 
 
 @pytest.fixture

--- a/tests/execution/test_github_api_tracking_http.py
+++ b/tests/execution/test_github_api_tracking_http.py
@@ -1,0 +1,100 @@
+import sys
+import pytest
+from unittest.mock import AsyncMock
+
+pytestmark = [
+    pytest.mark.skipif(sys.platform != "linux", reason="api-simulator Linux-only"),
+    pytest.mark.layer("execution"),
+    pytest.mark.anyio,
+    pytest.mark.medium,
+]
+
+PyResponseSpec = pytest.importorskip("api_simulator.http").PyResponseSpec
+
+from autoskillit.execution.github import DefaultGitHubFetcher, make_tracked_httpx_client
+from autoskillit.pipeline.github_api_log import DefaultGitHubApiLog
+
+
+@pytest.fixture
+def _reset_mock(mock_http_server):
+    mock_http_server.reset()
+    yield
+
+
+async def test_tracking_transport_records_request(mock_http_server, _reset_mock):
+    mock_http_server.register(
+        "GET", "/repos/owner/repo/issues/1",
+        PyResponseSpec(
+            body={"number": 1, "title": "T", "body": "", "labels": [], "state": "open"},
+            headers={"X-RateLimit-Remaining": "4900", "X-RateLimit-Used": "100", "X-RateLimit-Reset": "1714000000"},
+        )
+    )
+    log = DefaultGitHubApiLog()
+    fetcher = DefaultGitHubFetcher(token="test-token", tracker=log, base_url=mock_http_server.url)
+    await fetcher.fetch_issue("owner", "repo", 1)
+    usage = log.to_usage("sess-1")
+    assert usage is not None
+    assert usage["total_requests"] == 1
+    assert usage["by_source"]["httpx"] == 1
+    assert usage["by_category"]["issues"] == 1
+
+
+async def test_tracking_transport_captures_rate_limit_headers(mock_http_server, _reset_mock):
+    mock_http_server.register(
+        "GET", "/repos/owner/repo/issues/1",
+        PyResponseSpec(
+            body={"number": 1, "title": "T", "body": "", "labels": [], "state": "open"},
+            headers={"X-RateLimit-Remaining": "42", "X-RateLimit-Used": "4958", "X-RateLimit-Reset": "1714000000"},
+        )
+    )
+    log = DefaultGitHubApiLog()
+    fetcher = DefaultGitHubFetcher(token="test-token", tracker=log, base_url=mock_http_server.url)
+    await fetcher.fetch_issue("owner", "repo", 1)
+    usage = log.to_usage("sess-1")
+    assert usage["min_rate_limit_remaining"] == 42
+
+
+async def test_tracking_transport_records_4xx_error(mock_http_server, _reset_mock):
+    mock_http_server.register(
+        "GET", "/repos/owner/repo/issues/999",
+        PyResponseSpec(status=404, body={"message": "Not Found"}),
+    )
+    log = DefaultGitHubApiLog()
+    fetcher = DefaultGitHubFetcher(token="test-token", tracker=log, base_url=mock_http_server.url)
+    with pytest.raises(Exception):
+        await fetcher.fetch_issue("owner", "repo", 999)
+    usage = log.to_usage("sess-1")
+    assert usage["errors"]["4xx"] == 1
+    assert usage["total_requests"] == 1
+
+
+async def test_tracking_transport_records_latency(mock_http_server, _reset_mock):
+    mock_http_server.register(
+        "GET", "/repos/owner/repo/issues/1",
+        PyResponseSpec(
+            body={"number": 1, "title": "T", "body": "", "labels": [], "state": "open"},
+            delay_ms=50,
+        )
+    )
+    log = DefaultGitHubApiLog()
+    fetcher = DefaultGitHubFetcher(token="test-token", tracker=log, base_url=mock_http_server.url)
+    await fetcher.fetch_issue("owner", "repo", 1)
+    usage = log.to_usage("sess-1")
+    assert usage["total_latency_ms"] >= 50.0
+
+
+async def test_no_tracker_still_works(mock_http_server, _reset_mock):
+    mock_http_server.register(
+        "GET", "/repos/owner/repo/issues/1",
+        PyResponseSpec(body={"number": 1, "title": "T", "body": "", "labels": [], "state": "open"}),
+    )
+    fetcher = DefaultGitHubFetcher(token="test-token", tracker=None, base_url=mock_http_server.url)
+    result = await fetcher.fetch_issue("owner", "repo", 1)
+    assert result is not None
+
+
+async def test_make_tracked_httpx_client_without_tracker_is_normal_client():
+    import httpx
+    client = make_tracked_httpx_client(None, timeout=httpx.Timeout(10.0))
+    assert isinstance(client, httpx.AsyncClient)
+    await client.aclose()

--- a/tests/execution/test_github_api_tracking_http.py
+++ b/tests/execution/test_github_api_tracking_http.py
@@ -28,11 +28,11 @@ async def test_tracking_transport_records_request(mock_http_server, _reset_mock)
         "/repos/owner/repo/issues/1",
         PyResponseSpec(
             body={"number": 1, "title": "T", "body": "", "labels": [], "state": "open"},
-            headers={
-                "X-RateLimit-Remaining": "4900",
-                "X-RateLimit-Used": "100",
-                "X-RateLimit-Reset": "1714000000",
-            },
+            headers=[
+                ("X-RateLimit-Remaining", "4900"),
+                ("X-RateLimit-Used", "100"),
+                ("X-RateLimit-Reset", "1714000000"),
+            ],
         ),
     )
     log = InMemoryGitHubApiLog()
@@ -50,11 +50,11 @@ async def test_tracking_transport_captures_rate_limit_headers(mock_http_server, 
         "/repos/owner/repo/issues/1",
         PyResponseSpec(
             body={"number": 1, "title": "T", "body": "", "labels": [], "state": "open"},
-            headers={
-                "X-RateLimit-Remaining": "42",
-                "X-RateLimit-Used": "4958",
-                "X-RateLimit-Reset": "1714000000",
-            },
+            headers=[
+                ("X-RateLimit-Remaining", "42"),
+                ("X-RateLimit-Used", "4958"),
+                ("X-RateLimit-Reset", "1714000000"),
+            ],
         ),
     )
     log = InMemoryGitHubApiLog()
@@ -72,8 +72,8 @@ async def test_tracking_transport_records_4xx_error(mock_http_server, _reset_moc
     )
     log = InMemoryGitHubApiLog()
     fetcher = DefaultGitHubFetcher(token="test-token", tracker=log, base_url=mock_http_server.url)
-    with pytest.raises(Exception):
-        await fetcher.fetch_issue("owner", "repo", 999)
+    # fetch_issue never raises — 404 is returned as {"success": False, ...}
+    await fetcher.fetch_issue("owner", "repo", 999)
     assert len(log.httpx_calls) == 1
     assert log.httpx_calls[0]["status_code"] == 404
 

--- a/tests/execution/test_github_api_tracking_http.py
+++ b/tests/execution/test_github_api_tracking_http.py
@@ -1,6 +1,6 @@
 import sys
+
 import pytest
-from unittest.mock import AsyncMock
 
 pytestmark = [
     pytest.mark.skipif(sys.platform != "linux", reason="api-simulator Linux-only"),
@@ -9,10 +9,11 @@ pytestmark = [
     pytest.mark.medium,
 ]
 
-PyResponseSpec = pytest.importorskip("api_simulator.http").PyResponseSpec
+_api_sim_http = pytest.importorskip("api_simulator.http")
+PyResponseSpec = _api_sim_http.MockResponseSpec
 
 from autoskillit.execution.github import DefaultGitHubFetcher, make_tracked_httpx_client
-from autoskillit.pipeline.github_api_log import DefaultGitHubApiLog
+from tests.fakes import InMemoryGitHubApiLog
 
 
 @pytest.fixture
@@ -23,70 +24,83 @@ def _reset_mock(mock_http_server):
 
 async def test_tracking_transport_records_request(mock_http_server, _reset_mock):
     mock_http_server.register(
-        "GET", "/repos/owner/repo/issues/1",
+        "GET",
+        "/repos/owner/repo/issues/1",
         PyResponseSpec(
             body={"number": 1, "title": "T", "body": "", "labels": [], "state": "open"},
-            headers={"X-RateLimit-Remaining": "4900", "X-RateLimit-Used": "100", "X-RateLimit-Reset": "1714000000"},
-        )
+            headers={
+                "X-RateLimit-Remaining": "4900",
+                "X-RateLimit-Used": "100",
+                "X-RateLimit-Reset": "1714000000",
+            },
+        ),
     )
-    log = DefaultGitHubApiLog()
+    log = InMemoryGitHubApiLog()
     fetcher = DefaultGitHubFetcher(token="test-token", tracker=log, base_url=mock_http_server.url)
     await fetcher.fetch_issue("owner", "repo", 1)
-    usage = log.to_usage("sess-1")
-    assert usage is not None
-    assert usage["total_requests"] == 1
-    assert usage["by_source"]["httpx"] == 1
-    assert usage["by_category"]["issues"] == 1
+    assert len(log.httpx_calls) == 1
+    call = log.httpx_calls[0]
+    assert call["path"] == "/repos/owner/repo/issues/1"
+    assert call["status_code"] == 200
 
 
 async def test_tracking_transport_captures_rate_limit_headers(mock_http_server, _reset_mock):
     mock_http_server.register(
-        "GET", "/repos/owner/repo/issues/1",
+        "GET",
+        "/repos/owner/repo/issues/1",
         PyResponseSpec(
             body={"number": 1, "title": "T", "body": "", "labels": [], "state": "open"},
-            headers={"X-RateLimit-Remaining": "42", "X-RateLimit-Used": "4958", "X-RateLimit-Reset": "1714000000"},
-        )
+            headers={
+                "X-RateLimit-Remaining": "42",
+                "X-RateLimit-Used": "4958",
+                "X-RateLimit-Reset": "1714000000",
+            },
+        ),
     )
-    log = DefaultGitHubApiLog()
+    log = InMemoryGitHubApiLog()
     fetcher = DefaultGitHubFetcher(token="test-token", tracker=log, base_url=mock_http_server.url)
     await fetcher.fetch_issue("owner", "repo", 1)
-    usage = log.to_usage("sess-1")
-    assert usage["min_rate_limit_remaining"] == 42
+    assert len(log.httpx_calls) == 1
+    assert log.httpx_calls[0]["rate_limit_remaining"] == 42
 
 
 async def test_tracking_transport_records_4xx_error(mock_http_server, _reset_mock):
     mock_http_server.register(
-        "GET", "/repos/owner/repo/issues/999",
+        "GET",
+        "/repos/owner/repo/issues/999",
         PyResponseSpec(status=404, body={"message": "Not Found"}),
     )
-    log = DefaultGitHubApiLog()
+    log = InMemoryGitHubApiLog()
     fetcher = DefaultGitHubFetcher(token="test-token", tracker=log, base_url=mock_http_server.url)
     with pytest.raises(Exception):
         await fetcher.fetch_issue("owner", "repo", 999)
-    usage = log.to_usage("sess-1")
-    assert usage["errors"]["4xx"] == 1
-    assert usage["total_requests"] == 1
+    assert len(log.httpx_calls) == 1
+    assert log.httpx_calls[0]["status_code"] == 404
 
 
 async def test_tracking_transport_records_latency(mock_http_server, _reset_mock):
     mock_http_server.register(
-        "GET", "/repos/owner/repo/issues/1",
+        "GET",
+        "/repos/owner/repo/issues/1",
         PyResponseSpec(
             body={"number": 1, "title": "T", "body": "", "labels": [], "state": "open"},
             delay_ms=50,
-        )
+        ),
     )
-    log = DefaultGitHubApiLog()
+    log = InMemoryGitHubApiLog()
     fetcher = DefaultGitHubFetcher(token="test-token", tracker=log, base_url=mock_http_server.url)
     await fetcher.fetch_issue("owner", "repo", 1)
-    usage = log.to_usage("sess-1")
-    assert usage["total_latency_ms"] >= 50.0
+    assert len(log.httpx_calls) == 1
+    assert log.httpx_calls[0]["latency_ms"] >= 50.0
 
 
 async def test_no_tracker_still_works(mock_http_server, _reset_mock):
     mock_http_server.register(
-        "GET", "/repos/owner/repo/issues/1",
-        PyResponseSpec(body={"number": 1, "title": "T", "body": "", "labels": [], "state": "open"}),
+        "GET",
+        "/repos/owner/repo/issues/1",
+        PyResponseSpec(
+            body={"number": 1, "title": "T", "body": "", "labels": [], "state": "open"}
+        ),
     )
     fetcher = DefaultGitHubFetcher(token="test-token", tracker=None, base_url=mock_http_server.url)
     result = await fetcher.fetch_issue("owner", "repo", 1)
@@ -95,6 +109,7 @@ async def test_no_tracker_still_works(mock_http_server, _reset_mock):
 
 async def test_make_tracked_httpx_client_without_tracker_is_normal_client():
     import httpx
+
     client = make_tracked_httpx_client(None, timeout=httpx.Timeout(10.0))
     assert isinstance(client, httpx.AsyncClient)
     await client.aclose()

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -589,6 +589,30 @@ class InMemoryDatabaseReader(DatabaseReader):
 # ---------------------------------------------------------------------------
 
 
+class InMemoryGitHubApiLog:
+    """In-memory fake for the GitHubApiLog protocol. Records calls for assertions."""
+
+    def __init__(self) -> None:
+        self.httpx_calls: list[dict[str, Any]] = []
+        self.gh_cli_calls: list[dict[str, Any]] = []
+
+    async def record_httpx(self, **kwargs: Any) -> None:
+        self.httpx_calls.append(kwargs)
+
+    async def record_gh_cli(self, **kwargs: Any) -> None:
+        self.gh_cli_calls.append(kwargs)
+
+    def to_usage(self, session_id: str) -> dict[str, Any] | None:
+        total = len(self.httpx_calls) + len(self.gh_cli_calls)
+        if total == 0:
+            return None
+        return {"session_id": session_id, "total_requests": total}
+
+    def clear(self) -> None:
+        self.httpx_calls.clear()
+        self.gh_cli_calls.clear()
+
+
 class MockSubprocessRunner(SubprocessRunner):
     """Test double for SubprocessRunner. Queues predetermined results.
 

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -110,7 +110,8 @@ def _is_yaml_dump(node: ast.expr) -> bool:
 _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # core/io.py — write_versioned_json itself (the blessed helper) uses atomic_write+json.dumps
     ("src/autoskillit/core/io.py", 118),
-    # session_log.py — github_api_usage dict, summary dict, meta.json sidecar, token_usage dict, step_timing dict
+    # session_log.py — github_api_usage dict, summary dict, meta.json sidecar,
+    # token_usage dict, step_timing dict
     ("src/autoskillit/execution/session_log.py", 305),
     ("src/autoskillit/execution/session_log.py", 366),
     ("src/autoskillit/execution/session_log.py", 370),

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -110,11 +110,12 @@ def _is_yaml_dump(node: ast.expr) -> bool:
 _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # core/io.py — write_versioned_json itself (the blessed helper) uses atomic_write+json.dumps
     ("src/autoskillit/core/io.py", 118),
-    # session_log.py — summary dict, meta.json sidecar, token_usage dict, step_timing dict
-    ("src/autoskillit/execution/session_log.py", 350),
-    ("src/autoskillit/execution/session_log.py", 354),
-    ("src/autoskillit/execution/session_log.py", 376),
-    ("src/autoskillit/execution/session_log.py", 379),
+    # session_log.py — github_api_usage dict, summary dict, meta.json sidecar, token_usage dict, step_timing dict
+    ("src/autoskillit/execution/session_log.py", 305),
+    ("src/autoskillit/execution/session_log.py", 366),
+    ("src/autoskillit/execution/session_log.py", 370),
+    ("src/autoskillit/execution/session_log.py", 392),
+    ("src/autoskillit/execution/session_log.py", 395),
     # migration/store.py — failure store dicts
     ("src/autoskillit/migration/store.py", 54),
     ("src/autoskillit/migration/store.py", 64),

--- a/tests/pipeline/test_github_api_log.py
+++ b/tests/pipeline/test_github_api_log.py
@@ -1,0 +1,161 @@
+import asyncio
+import pytest
+from autoskillit.pipeline.github_api_log import DefaultGitHubApiLog
+
+pytestmark = [pytest.mark.layer("pipeline"), pytest.mark.anyio]
+
+
+async def test_empty_log_returns_none_usage():
+    log = DefaultGitHubApiLog()
+    assert log.to_usage("sess-1") is None
+
+
+async def test_record_httpx_increments_total():
+    log = DefaultGitHubApiLog()
+    await log.record_httpx(
+        method="GET", path="/repos/owner/repo/issues/1",
+        status_code=200, latency_ms=120.0,
+        rate_limit_remaining=4900, rate_limit_used=100, rate_limit_reset=1714000000,
+        timestamp="2026-04-27T10:00:00Z",
+    )
+    usage = log.to_usage("sess-1")
+    assert usage is not None
+    assert usage["total_requests"] == 1
+    assert usage["by_source"]["httpx"] == 1
+
+
+async def test_record_gh_cli_increments_total():
+    log = DefaultGitHubApiLog()
+    await log.record_gh_cli(
+        subcommand="gh pr list", exit_code=0,
+        latency_ms=85.0, timestamp="2026-04-27T10:00:01Z",
+    )
+    usage = log.to_usage("sess-1")
+    assert usage is not None
+    assert usage["total_requests"] == 1
+    assert usage["by_source"]["gh_cli"] == 1
+
+
+async def test_endpoint_categorization():
+    log = DefaultGitHubApiLog()
+    paths = [
+        ("/repos/o/r/issues/1", "issues"),
+        ("/repos/o/r/pulls/2", "pulls"),
+        ("/repos/o/r/actions/runs", "actions"),
+        ("/search/issues", "search"),
+        ("/graphql", "graphql"),
+        ("/repos/o/r/labels", "other"),
+    ]
+    for path, expected_category in paths:
+        await log.record_httpx(
+            method="GET", path=path, status_code=200, latency_ms=10.0,
+            rate_limit_remaining=4999, rate_limit_used=1, rate_limit_reset=0,
+            timestamp="2026-04-27T10:00:00Z",
+        )
+    usage = log.to_usage("sess-1")
+    assert usage["by_category"]["issues"] == 1
+    assert usage["by_category"]["pulls"] == 1
+    assert usage["by_category"]["actions"] == 1
+    assert usage["by_category"]["search"] == 1
+    assert usage["by_category"]["graphql"] == 1
+    assert usage["by_category"]["other"] == 1
+
+
+async def test_min_rate_limit_remaining_tracks_minimum():
+    log = DefaultGitHubApiLog()
+    for remaining in [4900, 4500, 4800]:
+        await log.record_httpx(
+            method="GET", path="/repos/o/r/issues/1", status_code=200,
+            latency_ms=10.0, rate_limit_remaining=remaining,
+            rate_limit_used=0, rate_limit_reset=0, timestamp="2026-04-27T10:00:00Z",
+        )
+    usage = log.to_usage("sess-1")
+    assert usage["min_rate_limit_remaining"] == 4500
+
+
+async def test_error_categorization():
+    log = DefaultGitHubApiLog()
+    await log.record_httpx(
+        method="GET", path="/repos/o/r/issues/1", status_code=404,
+        latency_ms=50.0, rate_limit_remaining=4999, rate_limit_used=1,
+        rate_limit_reset=0, timestamp="2026-04-27T10:00:00Z",
+    )
+    await log.record_httpx(
+        method="POST", path="/repos/o/r/issues", status_code=500,
+        latency_ms=200.0, rate_limit_remaining=4998, rate_limit_used=2,
+        rate_limit_reset=0, timestamp="2026-04-27T10:00:01Z",
+    )
+    usage = log.to_usage("sess-1")
+    assert usage["errors"]["4xx"] == 1
+    assert usage["errors"]["5xx"] == 1
+
+
+async def test_latency_aggregation():
+    log = DefaultGitHubApiLog()
+    await log.record_httpx(
+        method="GET", path="/repos/o/r/issues/1", status_code=200,
+        latency_ms=100.0, rate_limit_remaining=4999, rate_limit_used=1,
+        rate_limit_reset=0, timestamp="2026-04-27T10:00:00Z",
+    )
+    await log.record_httpx(
+        method="GET", path="/repos/o/r/issues/2", status_code=200,
+        latency_ms=200.0, rate_limit_remaining=4998, rate_limit_used=2,
+        rate_limit_reset=0, timestamp="2026-04-27T10:00:01Z",
+    )
+    usage = log.to_usage("sess-1")
+    assert usage["total_latency_ms"] == pytest.approx(300.0)
+    assert usage["avg_latency_ms"] == pytest.approx(150.0)
+
+
+async def test_first_last_timestamps():
+    log = DefaultGitHubApiLog()
+    await log.record_httpx(
+        method="GET", path="/repos/o/r/issues/1", status_code=200,
+        latency_ms=10.0, rate_limit_remaining=4999, rate_limit_used=1,
+        rate_limit_reset=0, timestamp="2026-04-27T10:00:00Z",
+    )
+    await log.record_httpx(
+        method="GET", path="/repos/o/r/issues/2", status_code=200,
+        latency_ms=10.0, rate_limit_remaining=4998, rate_limit_used=2,
+        rate_limit_reset=0, timestamp="2026-04-27T10:04:32Z",
+    )
+    usage = log.to_usage("sess-1")
+    assert usage["first_request_ts"] == "2026-04-27T10:00:00Z"
+    assert usage["last_request_ts"] == "2026-04-27T10:04:32Z"
+
+
+async def test_clear_resets_state():
+    log = DefaultGitHubApiLog()
+    await log.record_httpx(
+        method="GET", path="/repos/o/r/issues/1", status_code=200,
+        latency_ms=10.0, rate_limit_remaining=4999, rate_limit_used=1,
+        rate_limit_reset=0, timestamp="2026-04-27T10:00:00Z",
+    )
+    log.clear()
+    assert log.to_usage("sess-1") is None
+
+
+async def test_concurrent_record_is_safe():
+    log = DefaultGitHubApiLog()
+
+    async def _record(i: int) -> None:
+        await log.record_httpx(
+            method="GET", path=f"/repos/o/r/issues/{i}", status_code=200,
+            latency_ms=10.0, rate_limit_remaining=4999, rate_limit_used=1,
+            rate_limit_reset=0, timestamp="2026-04-27T10:00:00Z",
+        )
+
+    await asyncio.gather(*[_record(i) for i in range(50)])
+    usage = log.to_usage("sess-1")
+    assert usage["total_requests"] == 50
+
+
+async def test_session_id_in_usage():
+    log = DefaultGitHubApiLog()
+    await log.record_httpx(
+        method="GET", path="/repos/o/r/issues/1", status_code=200,
+        latency_ms=10.0, rate_limit_remaining=4999, rate_limit_used=1,
+        rate_limit_reset=0, timestamp="2026-04-27T10:00:00Z",
+    )
+    usage = log.to_usage("my-session-123")
+    assert usage["session_id"] == "my-session-123"

--- a/tests/pipeline/test_github_api_log.py
+++ b/tests/pipeline/test_github_api_log.py
@@ -1,8 +1,10 @@
 import asyncio
+
 import pytest
+
 from autoskillit.pipeline.github_api_log import DefaultGitHubApiLog
 
-pytestmark = [pytest.mark.layer("pipeline"), pytest.mark.anyio]
+pytestmark = [pytest.mark.layer("pipeline"), pytest.mark.small, pytest.mark.anyio]
 
 
 async def test_empty_log_returns_none_usage():
@@ -13,9 +15,13 @@ async def test_empty_log_returns_none_usage():
 async def test_record_httpx_increments_total():
     log = DefaultGitHubApiLog()
     await log.record_httpx(
-        method="GET", path="/repos/owner/repo/issues/1",
-        status_code=200, latency_ms=120.0,
-        rate_limit_remaining=4900, rate_limit_used=100, rate_limit_reset=1714000000,
+        method="GET",
+        path="/repos/owner/repo/issues/1",
+        status_code=200,
+        latency_ms=120.0,
+        rate_limit_remaining=4900,
+        rate_limit_used=100,
+        rate_limit_reset=1714000000,
         timestamp="2026-04-27T10:00:00Z",
     )
     usage = log.to_usage("sess-1")
@@ -27,8 +33,10 @@ async def test_record_httpx_increments_total():
 async def test_record_gh_cli_increments_total():
     log = DefaultGitHubApiLog()
     await log.record_gh_cli(
-        subcommand="gh pr list", exit_code=0,
-        latency_ms=85.0, timestamp="2026-04-27T10:00:01Z",
+        subcommand="gh pr list",
+        exit_code=0,
+        latency_ms=85.0,
+        timestamp="2026-04-27T10:00:01Z",
     )
     usage = log.to_usage("sess-1")
     assert usage is not None
@@ -48,8 +56,13 @@ async def test_endpoint_categorization():
     ]
     for path, expected_category in paths:
         await log.record_httpx(
-            method="GET", path=path, status_code=200, latency_ms=10.0,
-            rate_limit_remaining=4999, rate_limit_used=1, rate_limit_reset=0,
+            method="GET",
+            path=path,
+            status_code=200,
+            latency_ms=10.0,
+            rate_limit_remaining=4999,
+            rate_limit_used=1,
+            rate_limit_reset=0,
             timestamp="2026-04-27T10:00:00Z",
         )
     usage = log.to_usage("sess-1")
@@ -65,9 +78,14 @@ async def test_min_rate_limit_remaining_tracks_minimum():
     log = DefaultGitHubApiLog()
     for remaining in [4900, 4500, 4800]:
         await log.record_httpx(
-            method="GET", path="/repos/o/r/issues/1", status_code=200,
-            latency_ms=10.0, rate_limit_remaining=remaining,
-            rate_limit_used=0, rate_limit_reset=0, timestamp="2026-04-27T10:00:00Z",
+            method="GET",
+            path="/repos/o/r/issues/1",
+            status_code=200,
+            latency_ms=10.0,
+            rate_limit_remaining=remaining,
+            rate_limit_used=0,
+            rate_limit_reset=0,
+            timestamp="2026-04-27T10:00:00Z",
         )
     usage = log.to_usage("sess-1")
     assert usage["min_rate_limit_remaining"] == 4500
@@ -76,14 +94,24 @@ async def test_min_rate_limit_remaining_tracks_minimum():
 async def test_error_categorization():
     log = DefaultGitHubApiLog()
     await log.record_httpx(
-        method="GET", path="/repos/o/r/issues/1", status_code=404,
-        latency_ms=50.0, rate_limit_remaining=4999, rate_limit_used=1,
-        rate_limit_reset=0, timestamp="2026-04-27T10:00:00Z",
+        method="GET",
+        path="/repos/o/r/issues/1",
+        status_code=404,
+        latency_ms=50.0,
+        rate_limit_remaining=4999,
+        rate_limit_used=1,
+        rate_limit_reset=0,
+        timestamp="2026-04-27T10:00:00Z",
     )
     await log.record_httpx(
-        method="POST", path="/repos/o/r/issues", status_code=500,
-        latency_ms=200.0, rate_limit_remaining=4998, rate_limit_used=2,
-        rate_limit_reset=0, timestamp="2026-04-27T10:00:01Z",
+        method="POST",
+        path="/repos/o/r/issues",
+        status_code=500,
+        latency_ms=200.0,
+        rate_limit_remaining=4998,
+        rate_limit_used=2,
+        rate_limit_reset=0,
+        timestamp="2026-04-27T10:00:01Z",
     )
     usage = log.to_usage("sess-1")
     assert usage["errors"]["4xx"] == 1
@@ -93,14 +121,24 @@ async def test_error_categorization():
 async def test_latency_aggregation():
     log = DefaultGitHubApiLog()
     await log.record_httpx(
-        method="GET", path="/repos/o/r/issues/1", status_code=200,
-        latency_ms=100.0, rate_limit_remaining=4999, rate_limit_used=1,
-        rate_limit_reset=0, timestamp="2026-04-27T10:00:00Z",
+        method="GET",
+        path="/repos/o/r/issues/1",
+        status_code=200,
+        latency_ms=100.0,
+        rate_limit_remaining=4999,
+        rate_limit_used=1,
+        rate_limit_reset=0,
+        timestamp="2026-04-27T10:00:00Z",
     )
     await log.record_httpx(
-        method="GET", path="/repos/o/r/issues/2", status_code=200,
-        latency_ms=200.0, rate_limit_remaining=4998, rate_limit_used=2,
-        rate_limit_reset=0, timestamp="2026-04-27T10:00:01Z",
+        method="GET",
+        path="/repos/o/r/issues/2",
+        status_code=200,
+        latency_ms=200.0,
+        rate_limit_remaining=4998,
+        rate_limit_used=2,
+        rate_limit_reset=0,
+        timestamp="2026-04-27T10:00:01Z",
     )
     usage = log.to_usage("sess-1")
     assert usage["total_latency_ms"] == pytest.approx(300.0)
@@ -110,14 +148,24 @@ async def test_latency_aggregation():
 async def test_first_last_timestamps():
     log = DefaultGitHubApiLog()
     await log.record_httpx(
-        method="GET", path="/repos/o/r/issues/1", status_code=200,
-        latency_ms=10.0, rate_limit_remaining=4999, rate_limit_used=1,
-        rate_limit_reset=0, timestamp="2026-04-27T10:00:00Z",
+        method="GET",
+        path="/repos/o/r/issues/1",
+        status_code=200,
+        latency_ms=10.0,
+        rate_limit_remaining=4999,
+        rate_limit_used=1,
+        rate_limit_reset=0,
+        timestamp="2026-04-27T10:00:00Z",
     )
     await log.record_httpx(
-        method="GET", path="/repos/o/r/issues/2", status_code=200,
-        latency_ms=10.0, rate_limit_remaining=4998, rate_limit_used=2,
-        rate_limit_reset=0, timestamp="2026-04-27T10:04:32Z",
+        method="GET",
+        path="/repos/o/r/issues/2",
+        status_code=200,
+        latency_ms=10.0,
+        rate_limit_remaining=4998,
+        rate_limit_used=2,
+        rate_limit_reset=0,
+        timestamp="2026-04-27T10:04:32Z",
     )
     usage = log.to_usage("sess-1")
     assert usage["first_request_ts"] == "2026-04-27T10:00:00Z"
@@ -127,9 +175,14 @@ async def test_first_last_timestamps():
 async def test_clear_resets_state():
     log = DefaultGitHubApiLog()
     await log.record_httpx(
-        method="GET", path="/repos/o/r/issues/1", status_code=200,
-        latency_ms=10.0, rate_limit_remaining=4999, rate_limit_used=1,
-        rate_limit_reset=0, timestamp="2026-04-27T10:00:00Z",
+        method="GET",
+        path="/repos/o/r/issues/1",
+        status_code=200,
+        latency_ms=10.0,
+        rate_limit_remaining=4999,
+        rate_limit_used=1,
+        rate_limit_reset=0,
+        timestamp="2026-04-27T10:00:00Z",
     )
     log.clear()
     assert log.to_usage("sess-1") is None
@@ -140,9 +193,14 @@ async def test_concurrent_record_is_safe():
 
     async def _record(i: int) -> None:
         await log.record_httpx(
-            method="GET", path=f"/repos/o/r/issues/{i}", status_code=200,
-            latency_ms=10.0, rate_limit_remaining=4999, rate_limit_used=1,
-            rate_limit_reset=0, timestamp="2026-04-27T10:00:00Z",
+            method="GET",
+            path=f"/repos/o/r/issues/{i}",
+            status_code=200,
+            latency_ms=10.0,
+            rate_limit_remaining=4999,
+            rate_limit_used=1,
+            rate_limit_reset=0,
+            timestamp="2026-04-27T10:00:00Z",
         )
 
     await asyncio.gather(*[_record(i) for i in range(50)])
@@ -153,9 +211,14 @@ async def test_concurrent_record_is_safe():
 async def test_session_id_in_usage():
     log = DefaultGitHubApiLog()
     await log.record_httpx(
-        method="GET", path="/repos/o/r/issues/1", status_code=200,
-        latency_ms=10.0, rate_limit_remaining=4999, rate_limit_used=1,
-        rate_limit_reset=0, timestamp="2026-04-27T10:00:00Z",
+        method="GET",
+        path="/repos/o/r/issues/1",
+        status_code=200,
+        latency_ms=10.0,
+        rate_limit_remaining=4999,
+        rate_limit_used=1,
+        rate_limit_reset=0,
+        timestamp="2026-04-27T10:00:00Z",
     )
     usage = log.to_usage("my-session-123")
     assert usage["session_id"] == "my-session-123"

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -107,3 +107,32 @@ _SUCCESS_JSON = (
     '{"type": "result", "subtype": "success", "is_error": false,'
     ' "result": "done", "session_id": "s1"}'
 )
+
+
+@pytest.fixture
+def build_ctx(tmp_path):
+    """Factory: build_ctx(**overrides) → minimal ToolContext with overrides applied."""
+    from autoskillit.config.settings import AutomationConfig
+    from autoskillit.core.types import DirectInstall
+    from autoskillit.pipeline.audit import DefaultAuditLog
+    from autoskillit.pipeline.context import ToolContext
+    from autoskillit.pipeline.gate import DefaultGateState
+    from autoskillit.pipeline.timings import DefaultTimingLog
+    from autoskillit.pipeline.tokens import DefaultTokenLog
+
+    def _factory(**overrides):
+        ctx = ToolContext(
+            config=AutomationConfig(features={"fleet": True}),
+            audit=DefaultAuditLog(),
+            token_log=DefaultTokenLog(),
+            timing_log=DefaultTimingLog(),
+            gate=DefaultGateState(enabled=True),
+            plugin_source=DirectInstall(plugin_dir=tmp_path),
+            runner=None,
+            temp_dir=tmp_path / ".autoskillit" / "temp",
+        )
+        for field_name, value in overrides.items():
+            setattr(ctx, field_name, value)
+        return ctx
+
+    return _factory

--- a/tests/server/test_tools_github_api_tracking.py
+++ b/tests/server/test_tools_github_api_tracking.py
@@ -1,0 +1,106 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from autoskillit.core._type_subprocess import TerminationReason, SubprocessResult
+from tests.fakes import MockSubprocessRunner
+
+pytestmark = [pytest.mark.layer("server"), pytest.mark.anyio]
+
+
+async def test_gh_cli_call_is_recorded(build_ctx):
+    from autoskillit.pipeline.github_api_log import DefaultGitHubApiLog
+    log = DefaultGitHubApiLog()
+    ctx = build_ctx(github_api_log=log)
+    runner = MockSubprocessRunner()
+    runner.set_default(SubprocessResult(
+        returncode=0, stdout="[]", stderr="",
+        termination=TerminationReason.NATURAL_EXIT, pid=1,
+    ))
+    ctx.runner = runner
+
+    from autoskillit.server.helpers import _run_subprocess
+    with patch("autoskillit.server.helpers._get_ctx", return_value=ctx):
+        await _run_subprocess(["gh", "pr", "list", "--json", "number"], cwd="/tmp", timeout=30)
+
+    usage = log.to_usage("sess-1")
+    assert usage is not None
+    assert usage["total_requests"] == 1
+    assert usage["by_source"]["gh_cli"] == 1
+
+
+async def test_non_gh_command_is_not_recorded(build_ctx):
+    from autoskillit.pipeline.github_api_log import DefaultGitHubApiLog
+    log = DefaultGitHubApiLog()
+    ctx = build_ctx(github_api_log=log)
+    runner = MockSubprocessRunner()
+    runner.set_default(SubprocessResult(
+        returncode=0, stdout="ok", stderr="",
+        termination=TerminationReason.NATURAL_EXIT, pid=1,
+    ))
+    ctx.runner = runner
+
+    from autoskillit.server.helpers import _run_subprocess
+    with patch("autoskillit.server.helpers._get_ctx", return_value=ctx):
+        await _run_subprocess(["git", "status"], cwd="/tmp", timeout=30)
+
+    assert log.to_usage("sess-1") is None
+
+
+async def test_gh_cli_records_exit_code_and_latency(build_ctx):
+    from autoskillit.pipeline.github_api_log import DefaultGitHubApiLog
+    log = DefaultGitHubApiLog()
+    ctx = build_ctx(github_api_log=log)
+    runner = MockSubprocessRunner()
+    runner.set_default(SubprocessResult(
+        returncode=1, stdout="", stderr="error",
+        termination=TerminationReason.NATURAL_EXIT, pid=1,
+    ))
+    ctx.runner = runner
+
+    from autoskillit.server.helpers import _run_subprocess
+    with patch("autoskillit.server.helpers._get_ctx", return_value=ctx):
+        await _run_subprocess(["gh", "api", "repos/o/r/issues"], cwd="/tmp", timeout=30)
+
+    usage = log.to_usage("sess-1")
+    assert usage["total_requests"] == 1
+    assert usage["total_latency_ms"] >= 0
+
+
+async def test_flush_session_log_writes_github_api_usage(tmp_path):
+    from autoskillit.pipeline.github_api_log import DefaultGitHubApiLog
+    from autoskillit.execution.session_log import flush_session_log
+    import json
+
+    log = DefaultGitHubApiLog()
+    await log.record_httpx(
+        method="GET", path="/repos/o/r/issues/1", status_code=200,
+        latency_ms=100.0, rate_limit_remaining=4900, rate_limit_used=100,
+        rate_limit_reset=0, timestamp="2026-04-27T10:00:00Z",
+    )
+
+    flush_session_log(
+        log_dir=str(tmp_path),
+        cwd="/tmp",
+        session_id="test-session",
+        pid=1234,
+        skill_command="test",
+        success=True,
+        subtype="headless",
+        exit_code=0,
+        start_ts="2026-04-27T10:00:00Z",
+        proc_snapshots=None,
+        github_api_log=log,
+    )
+
+    usage_file = tmp_path / "sessions" / "test-session" / "github_api_usage.json"
+    assert usage_file.exists()
+    data = json.loads(usage_file.read_text())
+    assert data["session_id"] == "test-session"
+    assert data["total_requests"] == 1
+
+    summary_file = tmp_path / "sessions" / "test-session" / "summary.json"
+    summary = json.loads(summary_file.read_text())
+    assert summary["github_api_requests"] == 1
+
+    index_file = tmp_path / "sessions.jsonl"
+    lines = [json.loads(l) for l in index_file.read_text().splitlines()]
+    assert lines[0]["github_api_requests"] == 1

--- a/tests/server/test_tools_github_api_tracking.py
+++ b/tests/server/test_tools_github_api_tracking.py
@@ -85,7 +85,8 @@ async def test_gh_cli_records_exit_code_and_latency(build_ctx):
 
     usage = log.to_usage("sess-1")
     assert usage["total_requests"] == 1
-    assert usage["total_latency_ms"] >= 0
+    assert usage["total_latency_ms"] > 0
+    assert log._entries[0].status_code == 1
 
 
 async def test_flush_session_log_writes_github_api_usage(tmp_path):
@@ -131,5 +132,5 @@ async def test_flush_session_log_writes_github_api_usage(tmp_path):
     assert summary["github_api_requests"] == 1
 
     index_file = tmp_path / "sessions.jsonl"
-    lines = [json.loads(l) for l in index_file.read_text().splitlines()]
+    lines = [json.loads(line) for line in index_file.read_text().splitlines()]
     assert lines[0]["github_api_requests"] == 1

--- a/tests/server/test_tools_github_api_tracking.py
+++ b/tests/server/test_tools_github_api_tracking.py
@@ -1,23 +1,32 @@
+from unittest.mock import patch
+
 import pytest
-from unittest.mock import patch, MagicMock
-from autoskillit.core._type_subprocess import TerminationReason, SubprocessResult
+
+from autoskillit.core._type_subprocess import SubprocessResult, TerminationReason
 from tests.fakes import MockSubprocessRunner
 
-pytestmark = [pytest.mark.layer("server"), pytest.mark.anyio]
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small, pytest.mark.anyio]
 
 
 async def test_gh_cli_call_is_recorded(build_ctx):
     from autoskillit.pipeline.github_api_log import DefaultGitHubApiLog
+
     log = DefaultGitHubApiLog()
     ctx = build_ctx(github_api_log=log)
     runner = MockSubprocessRunner()
-    runner.set_default(SubprocessResult(
-        returncode=0, stdout="[]", stderr="",
-        termination=TerminationReason.NATURAL_EXIT, pid=1,
-    ))
+    runner.set_default(
+        SubprocessResult(
+            returncode=0,
+            stdout="[]",
+            stderr="",
+            termination=TerminationReason.NATURAL_EXIT,
+            pid=1,
+        )
+    )
     ctx.runner = runner
 
     from autoskillit.server.helpers import _run_subprocess
+
     with patch("autoskillit.server.helpers._get_ctx", return_value=ctx):
         await _run_subprocess(["gh", "pr", "list", "--json", "number"], cwd="/tmp", timeout=30)
 
@@ -29,16 +38,23 @@ async def test_gh_cli_call_is_recorded(build_ctx):
 
 async def test_non_gh_command_is_not_recorded(build_ctx):
     from autoskillit.pipeline.github_api_log import DefaultGitHubApiLog
+
     log = DefaultGitHubApiLog()
     ctx = build_ctx(github_api_log=log)
     runner = MockSubprocessRunner()
-    runner.set_default(SubprocessResult(
-        returncode=0, stdout="ok", stderr="",
-        termination=TerminationReason.NATURAL_EXIT, pid=1,
-    ))
+    runner.set_default(
+        SubprocessResult(
+            returncode=0,
+            stdout="ok",
+            stderr="",
+            termination=TerminationReason.NATURAL_EXIT,
+            pid=1,
+        )
+    )
     ctx.runner = runner
 
     from autoskillit.server.helpers import _run_subprocess
+
     with patch("autoskillit.server.helpers._get_ctx", return_value=ctx):
         await _run_subprocess(["git", "status"], cwd="/tmp", timeout=30)
 
@@ -47,16 +63,23 @@ async def test_non_gh_command_is_not_recorded(build_ctx):
 
 async def test_gh_cli_records_exit_code_and_latency(build_ctx):
     from autoskillit.pipeline.github_api_log import DefaultGitHubApiLog
+
     log = DefaultGitHubApiLog()
     ctx = build_ctx(github_api_log=log)
     runner = MockSubprocessRunner()
-    runner.set_default(SubprocessResult(
-        returncode=1, stdout="", stderr="error",
-        termination=TerminationReason.NATURAL_EXIT, pid=1,
-    ))
+    runner.set_default(
+        SubprocessResult(
+            returncode=1,
+            stdout="",
+            stderr="error",
+            termination=TerminationReason.NATURAL_EXIT,
+            pid=1,
+        )
+    )
     ctx.runner = runner
 
     from autoskillit.server.helpers import _run_subprocess
+
     with patch("autoskillit.server.helpers._get_ctx", return_value=ctx):
         await _run_subprocess(["gh", "api", "repos/o/r/issues"], cwd="/tmp", timeout=30)
 
@@ -66,15 +89,21 @@ async def test_gh_cli_records_exit_code_and_latency(build_ctx):
 
 
 async def test_flush_session_log_writes_github_api_usage(tmp_path):
-    from autoskillit.pipeline.github_api_log import DefaultGitHubApiLog
-    from autoskillit.execution.session_log import flush_session_log
     import json
+
+    from autoskillit.execution.session_log import flush_session_log
+    from autoskillit.pipeline.github_api_log import DefaultGitHubApiLog
 
     log = DefaultGitHubApiLog()
     await log.record_httpx(
-        method="GET", path="/repos/o/r/issues/1", status_code=200,
-        latency_ms=100.0, rate_limit_remaining=4900, rate_limit_used=100,
-        rate_limit_reset=0, timestamp="2026-04-27T10:00:00Z",
+        method="GET",
+        path="/repos/o/r/issues/1",
+        status_code=200,
+        latency_ms=100.0,
+        rate_limit_remaining=4900,
+        rate_limit_used=100,
+        rate_limit_reset=0,
+        timestamp="2026-04-27T10:00:00Z",
     )
 
     flush_session_log(


### PR DESCRIPTION
## Summary

Add transparent, session-scoped GitHub API request tracking that intercepts all GitHub calls
(httpx-based and `gh` CLI-based) without modifying callsites. Introduces a
`DefaultGitHubApiLog` accumulator in `pipeline/` (matching the `tokens.py`/`timings.py`
pattern), a `_TrackingTransport` wrapper in `execution/github.py`, and `gh` CLI detection
in `server/helpers.py`. Flushes `github_api_usage.json` per session at log-write time,
consistent with existing JSON flush artifacts.

## Requirements

### R1: Automated httpx-layer interception

All GitHub API calls made via `httpx` flow through `github_headers()` in `execution/github.py`. Introduce a shared `httpx` event hook or custom transport that captures per-request metadata without modifying callsites:

- **Endpoint** (method + path, e.g. `GET /repos/{owner}/{repo}/issues/{n}`)
- **HTTP status code**
- **Latency** (ms)
- **Rate-limit headers** (`X-RateLimit-Remaining`, `X-RateLimit-Used`, `X-RateLimit-Reset`)
- **Timestamp** (ISO 8601)

The three httpx-based clients (`DefaultGitHubFetcher`, `DefaultCIWatcher`, `DefaultMergeQueueWatcher`) must all route through this layer.

### R2: `gh` CLI call interception

GitHub API calls via `gh` CLI subprocess (used in `tools_pr_ops.py`, `tools_ci.py`, `tools_issue_lifecycle.py`, etc.) must also be tracked. Wrap or instrument the `_run_subprocess` path in `server/helpers.py` to detect `gh api` / `gh pr` / `gh issue` invocations and record:

- **Subcommand** (e.g. `gh api repos/.../pulls/123/reviews`)
- **Exit code**
- **Latency** (ms)
- **Timestamp**

### R3: Session-scoped accumulation

Track per-session counters keyed by the session ID from `session_registry.py`:

- Total request count
- Counts by endpoint category (issues, pulls, actions, search, graphql)
- Total latency (for avg calculation)
- Min remaining rate-limit observed during the session
- Error count (4xx, 5xx)

### R4: Session log integration

On session flush (`flush_session_log`), write a `github_api_usage.json` file to the session directory alongside `summary.json`, `token_usage.json`, etc.

Also add a `github_api_requests` count to the `summary.json` top-level fields and the `sessions.jsonl` index entry for quick querying.

### R5: Efficiency constraints

- **No per-request disk I/O.** Accumulate in-memory; flush once at session end.
- **No new dependencies.** Use stdlib + httpx (already a dependency).
- **Thread/async safe.** Counters must handle concurrent calls within a session (use `asyncio.Lock` or `threading.Lock` as appropriate).
- **Zero overhead when no GitHub calls are made.** Lazy initialization only.

## Architecture Impact

### Data Lineage Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph Origins ["Data Origins"]
        direction TB
        HTTP_SRC["● GitHub REST/GraphQL<br/>━━━━━━━━━━<br/>httpx clients in:<br/>ci.py · github.py<br/>merge_queue.py<br/>(issues, actions, graphql)"]
        CLI_SRC["● gh CLI subprocesses<br/>━━━━━━━━━━<br/>api · pr · issue · repo<br/>run · workflow · search<br/>via run_cmd/helpers.py"]
    end

    subgraph Intercept ["★ Interception Layer"]
        direction TB
        TRANSPORT["★ _TrackingTransport<br/>━━━━━━━━━━<br/>httpx transport wrapper<br/>handle_async_request()<br/>extracts: method, path,<br/>status_code, latency_ms,<br/>x-ratelimit-* headers"]
        HOOK["● _run_subprocess()<br/>━━━━━━━━━━<br/>helpers.py gh CLI hook<br/>reads ctx.github_api_log<br/>extracts: subcommand,<br/>exit_code, latency_ms,<br/>timestamp"]
    end

    subgraph Accumulator ["★ In-Memory Accumulator (pipeline/github_api_log.py)"]
        direction TB
        API_LOG["★ DefaultGitHubApiLog<br/>━━━━━━━━━━<br/>_entries: list[GitHubApiEntry]<br/>asyncio.Lock guarded<br/>record_httpx() · record_gh_cli()"]
        ENTRY["★ GitHubApiEntry<br/>━━━━━━━━━━<br/>method · path · status_code<br/>latency_ms · source<br/>rate_limit_remaining/used/reset<br/>timestamp · subcommand"]
    end

    subgraph Aggregation ["Aggregation"]
        AGG["★ to_usage(session_id)<br/>━━━━━━━━━━<br/>Aggregates _entries →<br/>total_requests, by_category<br/>(issues/pulls/actions/<br/>search/graphql/other),<br/>by_source (httpx/gh_cli),<br/>total/avg latency_ms,<br/>min_rate_limit_remaining,<br/>errors (4xx / 5xx counts)"]
    end

    subgraph Storage ["Storage Destinations"]
        direction TB
        API_JSON["★ github_api_usage.json<br/>━━━━━━━━━━<br/>session_dir/<br/>Full usage dict<br/>atomic_write, pretty JSON<br/>(primary detail store)"]
        SUMMARY["● summary.json<br/>━━━━━━━━━━<br/>session_dir/<br/>github_api_requests: int<br/>(count only)"]
        SESSIONS["● sessions.jsonl<br/>━━━━━━━━━━<br/>log_root/<br/>Append-only index<br/>github_api_requests: int<br/>(count only)"]
    end

    subgraph DI ["● Composition Root (_factory.py)"]
        direction TB
        FACTORY["● make_context()<br/>━━━━━━━━━━<br/>Instantiates DefaultGitHubApiLog<br/>passes tracker= to fetchers<br/>stores as ctx.github_api_log"]
        FACTORY2["★ make_tracked_httpx_client()<br/>━━━━━━━━━━<br/>Wraps transport with<br/>_TrackingTransport when<br/>tracker is not None"]
        CTX["● ToolContext<br/>━━━━━━━━━━<br/>github_api_log: GitHubApiLog|None<br/>DI injection point"]
    end

    %% FLOWS %%
    HTTP_SRC -->|"HTTP response"| TRANSPORT
    CLI_SRC -->|"exit + timing"| HOOK
    TRANSPORT -->|"record_httpx()"| API_LOG
    HOOK -->|"record_gh_cli()"| API_LOG
    API_LOG --- ENTRY
    API_LOG -->|"flush_session_log()"| AGG
    AGG -->|"atomic_write full dict"| API_JSON
    AGG -.->|"total_requests only"| SUMMARY
    AGG -.->|"total_requests only"| SESSIONS

    %% DI wiring %%
    FACTORY -->|"instantiates"| API_LOG
    FACTORY -->|"tracker="| FACTORY2
    FACTORY2 -->|"wraps transport"| TRANSPORT
    FACTORY --> CTX
    CTX -->|"ctx.github_api_log"| HOOK

    %% CLASS ASSIGNMENTS %%
    class HTTP_SRC,CLI_SRC cli;
    class TRANSPORT,HOOK handler;
    class API_LOG,ENTRY newComponent;
    class AGG phase;
    class API_JSON output;
    class SUMMARY,SESSIONS stateNode;
    class FACTORY,FACTORY2 integration;
    class CTX stateNode;
```

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([Session Open])
    FLUSH_END([Session End / Flush Complete])
    ERROR([ERROR])

    subgraph Wiring ["● Session Wiring — server/_factory.py: make_context()"]
        direction TB
        MakeLog["★ DefaultGitHubApiLog()<br/>━━━━━━━━━━<br/>asyncio.Lock-guarded list<br/>github_api_log.py"]
        WireFetcher["● DefaultGitHubFetcher<br/>━━━━━━━━━━<br/>tracker=github_api_log<br/>execution/github.py"]
        WireCI["● DefaultCIWatcher<br/>━━━━━━━━━━<br/>tracker=github_api_log<br/>execution/ci.py"]
        WireMQ["● DefaultMergeQueueWatcher<br/>━━━━━━━━━━<br/>tracker=github_api_log<br/>execution/merge_queue.py"]
        WireCtx["● ToolContext.github_api_log<br/>━━━━━━━━━━<br/>field set on ToolContext<br/>pipeline/context.py"]
    end

    subgraph ClientBuild ["● Client Construction — execution/github.py"]
        direction TB
        MakeClient["● make_tracked_httpx_client()<br/>━━━━━━━━━━<br/>wraps AsyncHTTPTransport<br/>with _TrackingTransport<br/>when tracker is not None"]
        TrackerCheck{"tracker is None?"}
        PlainClient["plain httpx.AsyncClient<br/>━━━━━━━━━━<br/>no tracking transport"]
        WrappedClient["● httpx.AsyncClient<br/>━━━━━━━━━━<br/>transport=_TrackingTransport"]
    end

    subgraph Interception ["● HTTP Interception — execution/github.py: _TrackingTransport"]
        direction TB
        HandleReq["● _TrackingTransport<br/>.handle_async_request()<br/>━━━━━━━━━━<br/>wraps underlying transport"]
        TimeStart["record start = time.monotonic()"]
        WrapTransport["await wrapped.handle_async_request(request)<br/>━━━━━━━━━━<br/>actual GitHub API call"]
        CalcLatency["latency_ms = (elapsed) × 1000<br/>━━━━━━━━━━<br/>extract x-ratelimit-* headers"]
    end

    subgraph RecordHTTPX ["★ record_httpx() — pipeline/github_api_log.py"]
        direction TB
        AcquireLock["await asyncio.Lock acquire<br/>━━━━━━━━━━<br/>serialize concurrent callers"]
        AppendHTTPX["★ GitHubApiEntry(source='httpx')<br/>━━━━━━━━━━<br/>method, path, status_code<br/>latency_ms, rate_limit_*<br/>timestamp, source"]
        ReleaseLock["release lock"]
    end

    subgraph GHCli ["★ record_gh_cli() — pipeline/github_api_log.py"]
        direction TB
        AcquireLockCLI["await asyncio.Lock acquire"]
        AppendCLI["★ GitHubApiEntry(source='gh_cli')<br/>━━━━━━━━━━<br/>subcommand, exit_code<br/>latency_ms, timestamp<br/>path='' rate_limit=-1"]
        ReleaseLockCLI["release lock"]
    end

    subgraph Aggregate ["★ to_usage() — pipeline/github_api_log.py"]
        direction TB
        EmptyCheck{"self._entries<br/>empty?"}
        CatLoop["iterate entries<br/>━━━━━━━━━━<br/>_categorize(path) per httpx entry<br/>by_category, by_source counts<br/>total_latency, min_remaining<br/>4xx/5xx error counts"]
        BuildUsage["★ build usage dict<br/>━━━━━━━━━━<br/>session_id, total_requests<br/>by_category, by_source<br/>avg/total latency_ms<br/>min_rate_limit_remaining<br/>errors, first/last_request_ts"]
    end

    subgraph FlushPath ["● Session Flush — execution/session_log.py: flush_session_log()"]
        direction TB
        NullCheck{"github_api_log<br/>is None?"}
        CallToUsage["github_api_log.to_usage(session_id)"]
        WriteJson["★ atomic_write(github_api_usage.json)<br/>━━━━━━━━━━<br/>session_dir/github_api_usage.json"]
        InjectCount["inject github_api_requests<br/>into summary.json<br/>and sessions.jsonl index"]
    end

    %% FLOW %%
    START --> MakeLog
    MakeLog -->|"passed as tracker="| WireFetcher
    MakeLog -->|"passed as tracker="| WireCI
    MakeLog -->|"passed as tracker="| WireMQ
    MakeLog -->|"stored as field"| WireCtx

    WireFetcher --> MakeClient
    WireCI --> MakeClient
    WireMQ --> MakeClient

    MakeClient --> TrackerCheck
    TrackerCheck -->|"yes (no tracking)"| PlainClient
    TrackerCheck -->|"no (tracking active)"| WrappedClient

    WrappedClient --> HandleReq
    HandleReq --> TimeStart
    TimeStart --> WrapTransport
    WrapTransport --> CalcLatency
    CalcLatency --> AcquireLock
    AcquireLock --> AppendHTTPX
    AppendHTTPX --> ReleaseLock

    WireCtx -.->|"gh CLI callers pass latency+subcommand"| AcquireLockCLI
    AcquireLockCLI --> AppendCLI
    AppendCLI --> ReleaseLockCLI

    WireCtx -->|"session end trigger"| NullCheck
    NullCheck -->|"yes → skip"| FLUSH_END
    NullCheck -->|"no"| CallToUsage
    CallToUsage --> EmptyCheck
    EmptyCheck -->|"yes → return None"| FLUSH_END
    EmptyCheck -->|"no"| CatLoop
    CatLoop --> BuildUsage
    BuildUsage --> WriteJson
    WriteJson --> InjectCount
    InjectCount --> FLUSH_END

    WrapTransport -->|"httpx error"| ERROR

    %% CLASS ASSIGNMENTS %%
    class START,FLUSH_END,ERROR terminal;
    class MakeLog,AppendHTTPX,AppendCLI,BuildUsage,WriteJson newComponent;
    class WireFetcher,WireCI,WireMQ,WireCtx,MakeClient,HandleReq,TimeStart,WrapTransport,CalcLatency,CallToUsage,InjectCount handler;
    class AcquireLock,ReleaseLock,AcquireLockCLI,ReleaseLockCLI,CatLoop phase;
    class TrackerCheck,EmptyCheck,NullCheck detector;
    class WrappedClient,PlainClient stateNode;
```

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph L0 ["L0 — CORE FOUNDATION (stdlib-only)"]
        direction LR
        PROTO["● GitHubApiLog Protocol<br/>━━━━━━━━━━<br/>core/_type_protocols.py<br/>Fan-In: 5 dependents"]
    end

    subgraph L1 ["L1 — EXECUTION (GitHub API callers)"]
        direction LR
        GITHUB["● execution/github.py<br/>━━━━━━━━━━<br/>_TrackingTransport<br/>make_tracked_httpx_client()"]
        CI["● execution/ci.py<br/>━━━━━━━━━━<br/>DefaultCIWatcher<br/>tracker= injection"]
        MERGE["● execution/merge_queue.py<br/>━━━━━━━━━━<br/>DefaultMergeQueueWatcher<br/>tracker= injection"]
        SESSLOG["● execution/session_log.py<br/>━━━━━━━━━━<br/>flush_session_log()<br/>github_api_usage.json"]
    end

    subgraph L2 ["L2 — PIPELINE (tracking accumulator)"]
        direction LR
        APILOG["★ pipeline/github_api_log.py<br/>━━━━━━━━━━<br/>DefaultGitHubApiLog<br/>GitHubApiEntry<br/>stdlib-only, no autoskillit imports"]
        CTX["● pipeline/context.py<br/>━━━━━━━━━━<br/>ToolContext<br/>github_api_log: GitHubApiLog | None"]
        PIPINIT["● pipeline/__init__.py<br/>━━━━━━━━━━<br/>re-exports DefaultGitHubApiLog"]
    end

    subgraph L3 ["L3 — SERVER (composition root & gh CLI tracking)"]
        direction LR
        FACTORY["● server/_factory.py<br/>━━━━━━━━━━<br/>make_context()<br/>instantiates DefaultGitHubApiLog<br/>injects tracker= into 3 services"]
        HELPERS["● server/helpers.py<br/>━━━━━━━━━━<br/>_run_subprocess()<br/>records gh CLI calls"]
    end

    %% VALID DOWNWARD DEPENDENCIES %%
    FACTORY -->|"imports DefaultGitHubApiLog"| PIPINIT
    FACTORY -->|"builds ToolContext"| CTX
    FACTORY -->|"injects tracker="| CI
    FACTORY -->|"injects tracker="| MERGE
    FACTORY -->|"injects tracker="| GITHUB
    HELPERS -->|"ctx.github_api_log.record_gh_cli()"| CTX

    PIPINIT -->|"re-exports"| APILOG
    CTX -->|"imports GitHubApiLog"| PROTO
    SESSLOG -->|"imports GitHubApiLog (TYPE_CHECKING)"| PROTO
    SESSLOG -->|"calls to_usage()"| APILOG

    CI -->|"imports make_tracked_httpx_client"| GITHUB
    MERGE -->|"imports make_tracked_httpx_client"| GITHUB
    GITHUB -->|"imports GitHubApiLog (TYPE_CHECKING)"| PROTO
    CI -->|"imports GitHubApiLog (TYPE_CHECKING)"| PROTO
    MERGE -->|"imports GitHubApiLog (TYPE_CHECKING)"| PROTO

    APILOG -->|"satisfies protocol"| PROTO

    %% CLASS ASSIGNMENTS %%
    class PROTO stateNode;
    class GITHUB,CI,MERGE handler;
    class SESSLOG output;
    class APILOG newComponent;
    class CTX,PIPINIT phase;
    class FACTORY,HELPERS cli;
```

Closes #1466

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260427-224111-873821/.autoskillit/temp/make-plan/add_github_api_tracking_plan_2026-04-27_000000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| build_execution_map | 4.7k | 16.4k | 268.6k | 53.8k | 1 | 6m 21s |
| **Total** | 4.7k | 16.4k | 268.6k | 53.8k | | 6m 21s |