### PR TITLE
Logger Convention Standardization (C4 — ARCH-009)

### DIFF
--- a/src/autoskillit/cli/_doctor.py
+++ b/src/autoskillit/cli/_doctor.py
@@ -31,7 +31,7 @@ from autoskillit.hook_registry import (
     find_broken_hook_scripts,
 )
 
-_log = get_logger(__name__)
+logger = get_logger(__name__)
 _NON_PROBLEM: frozenset[Severity] = frozenset({Severity.OK, Severity.INFO})
 _STALE_THRESHOLD_DAYS = 7
 
@@ -472,7 +472,7 @@ def _check_source_version_drift(home: Path | None = None) -> DoctorResult:
         )
 
     except Exception:
-        _log.debug("Source drift check failed", exc_info=True)
+        logger.debug("Source drift check failed", exc_info=True)
         return DoctorResult(
             Severity.OK, check_name, "Source drift check skipped (unexpected error)"
         )
@@ -500,7 +500,7 @@ def _check_install_classification() -> DoctorResult:
             f"commit_id={commit_short}",
         )
     except Exception:
-        _log.debug("Install classification check failed", exc_info=True)
+        logger.debug("Install classification check failed", exc_info=True)
         return DoctorResult(
             Severity.OK, check_name, "Install classification check skipped (unexpected error)"
         )
@@ -532,7 +532,7 @@ def _check_update_dismissal_state(home: Path | None = None) -> DoctorResult:
             f"update_prompt dismissed until {expiry}; conditions={conditions}",
         )
     except Exception:
-        _log.debug("Update dismissal state check failed", exc_info=True)
+        logger.debug("Update dismissal state check failed", exc_info=True)
         return DoctorResult(
             Severity.OK, check_name, "Update dismissal state check skipped (unexpected error)"
         )
@@ -547,7 +547,7 @@ def _check_quota_cache_schema(cache_path: Path | None = None) -> DoctorResult:
     try:
         raw = json.loads(path.read_text())
     except Exception as exc:
-        _log.warning("quota_cache_parse_error", path=str(path), exc_info=True)
+        logger.warning("quota_cache_parse_error", path=str(path), exc_info=True)
         return DoctorResult(
             Severity.WARNING,
             check_name,

--- a/src/autoskillit/cli/_fleet.py
+++ b/src/autoskillit/cli/_fleet.py
@@ -24,7 +24,7 @@ from cyclopts import App, Parameter
 
 from autoskillit.core import TerminalColumn, get_logger, is_feature_enabled
 
-_log = get_logger(__name__)
+logger = get_logger(__name__)
 
 
 def _require_fleet(cfg: AutomationConfig) -> None:
@@ -289,7 +289,7 @@ def _watch_loop(state_path: Path) -> int:
         state = read_state(state_path)
         return _compute_exit_code(state) if state else 3
     except Exception as exc:
-        _log.error("unexpected error in --watch loop: %s", exc, exc_info=True)
+        logger.error("unexpected error in --watch loop: %s", exc, exc_info=True)
         sys.stderr.write(f"ERROR: unexpected error in --watch loop: {exc}\n")
         return 3
     finally:
@@ -308,7 +308,7 @@ def _remove_clone_fn(path: str, _flag: str) -> dict[str, str]:
         shutil.rmtree(path)
         return {"removed": "true"}
     except Exception as exc:
-        _log.warning("Failed to remove clone %s: %s", path, exc, exc_info=True)
+        logger.warning("Failed to remove clone %s: %s", path, exc, exc_info=True)
         return {"removed": "false", "reason": str(exc)}
 
 
@@ -436,7 +436,7 @@ async def _fleet_signal_guard(
                                         reason=f"signal_{signame}",
                                     )
                                 except Exception:
-                                    _log.warning(
+                                    logger.warning(
                                         "signal_guard: failed to mark dispatch interrupted",
                                         exc_info=True,
                                     )
@@ -452,12 +452,12 @@ async def _fleet_signal_guard(
                                     try:
                                         await async_kill_process_tree(dispatch.l2_pid, timeout=5.0)
                                     except Exception:
-                                        _log.warning(
+                                        logger.warning(
                                             "signal_guard: kill_process_tree failed",
                                             exc_info=True,
                                         )
                                 else:
-                                    _log.warning(
+                                    logger.warning(
                                         "signal_guard: PID %d recycled (ticks mismatch)",
                                         dispatch.l2_pid,
                                     )
@@ -467,7 +467,7 @@ async def _fleet_signal_guard(
                                     try:
                                         await async_kill_process_tree(dispatch.l2_pid, timeout=5.0)
                                     except Exception:
-                                        _log.warning(
+                                        logger.warning(
                                             "signal_guard: kill_process_tree failed (non-linux)",
                                             exc_info=True,
                                         )
@@ -479,7 +479,7 @@ async def _fleet_signal_guard(
                                     reason=f"signal_{signame}",
                                 )
                             except Exception:
-                                _log.warning(
+                                logger.warning(
                                     "signal_guard: failed to mark dispatch interrupted",
                                     exc_info=True,
                                 )
@@ -493,7 +493,7 @@ async def _fleet_signal_guard(
                             mgr = DefaultWorkspaceManager()
                             mgr.delete_contents(workspace_dir)
                         except Exception:
-                            _log.warning("signal_guard: workspace cleanup failed", exc_info=True)
+                            logger.warning("signal_guard: workspace cleanup failed", exc_info=True)
 
                     if campaign_name is not None:
                         resume_cmd = (
@@ -532,7 +532,7 @@ def _reap_stale_dispatches(state_path: Path, *, dry_run: bool = False) -> None:
     current_boot_id = read_boot_id()
 
     if not state_path.exists():
-        _log.info("reap: state file not found, nothing to reap: %s", state_path)
+        logger.info("reap: state file not found, nothing to reap: %s", state_path)
         return
 
     with open(state_path, "r+") as _lock_fh:
@@ -540,15 +540,15 @@ def _reap_stale_dispatches(state_path: Path, *, dry_run: bool = False) -> None:
         try:
             state = read_state(state_path)
             if state is None:
-                _log.warning("reap: cannot read state file: %s", state_path)
+                logger.warning("reap: cannot read state file: %s", state_path)
                 return
 
             running = [d for d in state.dispatches if d.status == DispatchStatus.RUNNING]
             if not running:
-                _log.info("reap: no running dispatches in campaign %s", state.campaign_id)
+                logger.info("reap: no running dispatches in campaign %s", state.campaign_id)
                 return
 
-            _log.info(
+            logger.info(
                 "reap: scanning %d dispatches in campaign %s", len(running), state.campaign_id
             )
 
@@ -559,13 +559,13 @@ def _reap_stale_dispatches(state_path: Path, *, dry_run: bool = False) -> None:
                 if pid == 0:
                     _action = "reaped_dead_pid"
                     if dry_run:
-                        _log.info("reap: [WOULD MARK]  %s  pid=0  (no PID recorded)", name)
+                        logger.info("reap: [WOULD MARK]  %s  pid=0  (no PID recorded)", name)
                     else:
                         try:
                             mark_dispatch_interrupted(state_path, name, reason=_action)
-                            _log.info("reap: [MARKED]      %s  (no PID recorded)", name)
+                            logger.info("reap: [MARKED]      %s  (no PID recorded)", name)
                         except ValueError:
-                            _log.info("reap: [SKIPPED]     %s  (already terminal)", name)
+                            logger.info("reap: [SKIPPED]     %s  (already terminal)", name)
                     continue
 
                 # Boot ID check: if machine rebooted, all PIDs are recycled
@@ -575,7 +575,7 @@ def _reap_stale_dispatches(state_path: Path, *, dry_run: bool = False) -> None:
                     and dispatch.l2_boot_id != current_boot_id
                 ):
                     if dry_run:
-                        _log.info(
+                        logger.info(
                             "reap: [WOULD MARK]  %s  pid=%d  (rebooted, pid_recycled)", name, pid
                         )
                     else:
@@ -583,48 +583,52 @@ def _reap_stale_dispatches(state_path: Path, *, dry_run: bool = False) -> None:
                             mark_dispatch_interrupted(
                                 state_path, name, reason="reaped_pid_recycled"
                             )
-                            _log.info(
+                            logger.info(
                                 "reap: [MARKED]      %s  pid=%d  (rebooted, pid_recycled)",
                                 name,
                                 pid,
                             )
                         except ValueError:
-                            _log.info("reap: [SKIPPED]     %s  (already terminal)", name)
+                            logger.info("reap: [SKIPPED]     %s  (already terminal)", name)
                     continue
 
                 if not psutil.pid_exists(pid):
                     if dry_run:
-                        _log.info("reap: [WOULD MARK]  %s  pid=%d  (process dead)", name, pid)
+                        logger.info("reap: [WOULD MARK]  %s  pid=%d  (process dead)", name, pid)
                     else:
                         try:
                             mark_dispatch_interrupted(state_path, name, reason="reaped_dead_pid")
-                            _log.info("reap: [MARKED]      %s  pid=%d  (process dead)", name, pid)
+                            logger.info(
+                                "reap: [MARKED]      %s  pid=%d  (process dead)", name, pid
+                            )
                         except ValueError:
-                            _log.info("reap: [SKIPPED]     %s  (already terminal)", name)
+                            logger.info("reap: [SKIPPED]     %s  (already terminal)", name)
                     continue
 
                 # Process is alive — check identity
                 current_ticks = read_starttime_ticks(pid)
                 if current_ticks is not None and current_ticks == dispatch.l2_starttime_ticks:
                     if dry_run:
-                        _log.info(
+                        logger.info(
                             "reap: [WOULD KILL]  %s  pid=%d  (orphan, identity match)", name, pid
                         )
                     else:
                         try:
                             kill_process_tree(pid)
                         except Exception:
-                            _log.warning(
+                            logger.warning(
                                 "reap: kill_process_tree failed for pid=%d", pid, exc_info=True
                             )
                         try:
                             mark_dispatch_interrupted(state_path, name, reason="reaped_orphan")
-                            _log.info("reap: [KILLED]      %s  pid=%d  (orphan reaped)", name, pid)
+                            logger.info(
+                                "reap: [KILLED]      %s  pid=%d  (orphan reaped)", name, pid
+                            )
                         except ValueError:
-                            _log.info("reap: [SKIPPED]     %s  (already terminal)", name)
+                            logger.info("reap: [SKIPPED]     %s  (already terminal)", name)
                 else:
                     if dry_run:
-                        _log.info(
+                        logger.info(
                             "reap: [WOULD MARK]  %s  pid=%d  (PID recycled, no kill)", name, pid
                         )
                     else:
@@ -632,13 +636,13 @@ def _reap_stale_dispatches(state_path: Path, *, dry_run: bool = False) -> None:
                             mark_dispatch_interrupted(
                                 state_path, name, reason="reaped_pid_recycled"
                             )
-                            _log.info(
+                            logger.info(
                                 "reap: [MARKED]      %s  pid=%d  (PID recycled, no kill)",
                                 name,
                                 pid,
                             )
                         except ValueError:
-                            _log.info("reap: [SKIPPED]     %s  (already terminal)", name)
+                            logger.info("reap: [SKIPPED]     %s  (already terminal)", name)
         finally:
             fcntl.flock(_lock_fh, fcntl.LOCK_UN)
 
@@ -827,7 +831,7 @@ def fleet_status(
                         skill_mgr.cleanup_session(d.l2_session_id)
                 skill_mgr.cleanup_session(campaign_id)
             except Exception:
-                _log.warning(
+                logger.warning(
                     "Session skill cleanup failed for campaign %s", campaign_id, exc_info=True
                 )
             sweep_stale_markers()

--- a/src/autoskillit/cli/_installed_plugins.py
+++ b/src/autoskillit/cli/_installed_plugins.py
@@ -10,13 +10,12 @@ nesting contract is defined in exactly one place.
 from __future__ import annotations
 
 import json
-import logging
 from pathlib import Path
 from typing import Any
 
-from autoskillit.core import atomic_write
+from autoskillit.core import atomic_write, get_logger
 
-_log = logging.getLogger(__name__)  # noqa: TID251
+logger = get_logger(__name__)
 
 
 def _default_path() -> Path:
@@ -42,10 +41,10 @@ class InstalledPluginsFile:
         try:
             return json.loads(self._path.read_text())
         except json.JSONDecodeError as exc:
-            _log.warning("installed_plugins.json is corrupt (%s): %s", self._path, exc)
+            logger.warning("installed_plugins.json is corrupt (%s): %s", self._path, exc)
             return {}
         except OSError as exc:
-            _log.warning("Could not read installed_plugins.json (%s): %s", self._path, exc)
+            logger.warning("Could not read installed_plugins.json (%s): %s", self._path, exc)
             return {}
 
     def get_plugins(self) -> dict[str, Any]:

--- a/src/autoskillit/cli/_onboarding.py
+++ b/src/autoskillit/cli/_onboarding.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from autoskillit.core import get_logger
 
-_log = get_logger(__name__)
+logger = get_logger(__name__)
 
 
 def is_first_run(project_dir: Path) -> bool:
@@ -21,7 +21,7 @@ def is_first_run(project_dir: Path) -> bool:
             if any(recipes_dir.iterdir()):
                 return False
         except OSError:
-            _log.debug("Could not list recipes dir %s", recipes_dir, exc_info=True)
+            logger.debug("Could not list recipes dir %s", recipes_dir, exc_info=True)
     from autoskillit.workspace import detect_project_local_overrides
 
     if detect_project_local_overrides(project_dir):

--- a/src/autoskillit/cli/_serve_guard.py
+++ b/src/autoskillit/cli/_serve_guard.py
@@ -20,7 +20,7 @@ import anyio
 
 from autoskillit.core import get_logger
 
-_log = get_logger(__name__)
+logger = get_logger(__name__)
 
 
 async def serve_with_signal_guard(mcp_server: Any) -> None:
@@ -39,7 +39,7 @@ async def serve_with_signal_guard(mcp_server: Any) -> None:
         with anyio.open_signal_receiver(signal.SIGTERM, signal.SIGINT, signal.SIGHUP) as signals:
             task_status.started()  # signal receiver is now armed
             async for sig in signals:
-                _log.info("serve_with_signal_guard: received %s — initiating shutdown", sig.name)
+                logger.info("serve_with_signal_guard: received %s — initiating shutdown", sig.name)
                 scope.cancel()
                 return
 

--- a/src/autoskillit/cli/_terminal.py
+++ b/src/autoskillit/cli/_terminal.py
@@ -20,7 +20,7 @@ from typing import NamedTuple
 
 from autoskillit.core import get_logger
 
-_log = get_logger(__name__)
+logger = get_logger(__name__)
 
 _KBP_TERMINALS = frozenset({"kitty", "WezTerm", "ghostty", "iTerm.app"})
 
@@ -122,7 +122,7 @@ def terminal_guard() -> Generator[None, None, None]:
             try:
                 termios.tcsetattr(fd, termios.TCSAFLUSH, old_settings)
             except termios.error:
-                _log.debug("tcsetattr failed; falling back to stty sane")
+                logger.debug("tcsetattr failed; falling back to stty sane")
                 os.system("stty sane 2>/dev/null")
         if fd is not None:
             try:

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import dataclasses
 import inspect
-import logging
 import os
 import tempfile
 from dataclasses import dataclass, field
@@ -26,6 +25,7 @@ from autoskillit.core import (
     OutputFormat,
     atomic_write,
     dump_yaml_str,
+    get_logger,
     is_feature_enabled,
     load_yaml,
     pkg_root,
@@ -34,7 +34,7 @@ from autoskillit.core import (
 if TYPE_CHECKING:
     from dynaconf import Dynaconf
 
-_logger = logging.getLogger(__name__)  # noqa: TID251
+logger = get_logger(__name__)
 
 
 class ConfigSchemaError(ValueError):
@@ -774,7 +774,7 @@ def _build_subsets_config(raw: dict[str, Any]) -> SubsetsConfig:
         if isinstance(v, list):
             custom_tags[str(k)] = [str(item) for item in v]
         else:
-            _logger.warning(
+            logger.warning(
                 "Ignoring non-list value for custom_tags entry %r: %r",
                 k,
                 v,
@@ -782,7 +782,7 @@ def _build_subsets_config(raw: dict[str, Any]) -> SubsetsConfig:
     known_categories = CATEGORY_TAGS | frozenset(custom_tags.keys())
     for tag in disabled:
         if tag not in known_categories:
-            _logger.warning(
+            logger.warning(
                 "Unknown category %r in subsets.disabled"
                 " (not in CATEGORY_TAGS and not a custom_tag)",
                 tag,
@@ -797,7 +797,7 @@ def _build_packs_config(raw: dict[str, Any]) -> PacksConfig:
     enabled = list(raw.get("enabled", []))
     for pack_name in enabled:
         if pack_name not in PACK_REGISTRY:
-            _logger.warning(
+            logger.warning(
                 "Unknown pack name %r in packs.enabled (not in PACK_REGISTRY)",
                 pack_name,
             )

--- a/src/autoskillit/core/_version_snapshot.py
+++ b/src/autoskillit/core/_version_snapshot.py
@@ -18,7 +18,7 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
-_logger = logging.getLogger(__name__)  # noqa: TID251 — L0 module, no autoskillit imports allowed
+logger = logging.getLogger(__name__)  # noqa: TID251 — L0 module, no autoskillit imports allowed
 
 
 @functools.lru_cache(maxsize=1)
@@ -47,7 +47,7 @@ def _autoskillit_version() -> str:
     try:
         return importlib.metadata.version("autoskillit")
     except Exception:
-        _logger.warning("Failed to read autoskillit version", exc_info=True)
+        logger.warning("Failed to read autoskillit version", exc_info=True)
         return ""
 
 
@@ -73,7 +73,7 @@ def _install_info() -> dict[str, Any]:
             return {"install_type": "local-path", "commit_id": None}
         return {"install_type": "unknown", "commit_id": None}
     except Exception:
-        _logger.warning("Failed to parse install info from direct_url.json", exc_info=True)
+        logger.warning("Failed to parse install info from direct_url.json", exc_info=True)
         return {"install_type": "unknown", "commit_id": None}
 
 
@@ -94,12 +94,12 @@ def _claude_code_version() -> str:
             timeout=5,
         )
         if result.returncode != 0:
-            _logger.warning("claude --version exited with code %d", result.returncode)
+            logger.warning("claude --version exited with code %d", result.returncode)
         return result.stdout.strip() or result.stderr.strip()
     except subprocess.TimeoutExpired:
         return ""
     except Exception:
-        _logger.warning("Failed to run claude --version", exc_info=True)
+        logger.warning("Failed to run claude --version", exc_info=True)
         return ""
 
 
@@ -132,5 +132,5 @@ def _plugins() -> list[dict[str, Any]]:
             entries.append(entry)
         return entries
     except Exception:
-        _logger.warning("Failed to read installed_plugins.json", exc_info=True)
+        logger.warning("Failed to read installed_plugins.json", exc_info=True)
         return []

--- a/src/autoskillit/core/logging.py
+++ b/src/autoskillit/core/logging.py
@@ -53,7 +53,7 @@ def get_logger(name: str | None = None) -> Any:
     record emitted through this logger — regardless of the configured
     renderer (JSON, ConsoleRenderer, or testing capture).
     """
-    proxy = structlog.get_logger()
+    logger = structlog.get_logger()
     if name is not None:
         # Why _initial_values instead of .bind(): .bind() resolves the lazy proxy
         # into a concrete BoundLoggerFilteringAtNotset, freezing the current config.
@@ -61,8 +61,8 @@ def get_logger(name: str | None = None) -> Any:
         # first log call (after configure_logging() runs).
         # Why not structlog.get_logger(logger=name): the "logger" kwarg collides with
         # wrap_logger()'s first positional parameter, raising TypeError.
-        proxy._initial_values["logger"] = name
-    return proxy
+        logger._initial_values["logger"] = name
+    return logger
 
 
 def configure_logging(

--- a/src/autoskillit/execution/ci.py
+++ b/src/autoskillit/execution/ci.py
@@ -25,7 +25,7 @@ import httpx
 from autoskillit.core import CIRunScope, get_logger
 from autoskillit.execution.github import github_headers
 
-_log = get_logger(__name__)
+logger = get_logger(__name__)
 
 # Backoff schedule: (floor, ceiling) per attempt band.
 _BACKOFF_BANDS: tuple[tuple[int, int], ...] = ((5, 10), (10, 20), (15, 30))
@@ -292,7 +292,7 @@ class DefaultCIWatcher:
         try:
             async with httpx.AsyncClient(timeout=httpx.Timeout(15.0, connect=5.0)) as client:
                 # Phase 1: Look-back — check for recently-completed runs
-                _log.info(
+                logger.info(
                     "ci_watcher_lookback",
                     branch=branch,
                     repo=owner_repo,
@@ -312,7 +312,7 @@ class DefaultCIWatcher:
                         r for r in completed if _validate_run_matches_scope(r, scope)
                     ]
                     if not valid_completed:
-                        _log.warning(
+                        logger.warning(
                             "ci_watcher_scope_mismatch",
                             count=len(completed),
                             scope=str(scope),
@@ -331,7 +331,9 @@ class DefaultCIWatcher:
                             if conclusion in FAILED_CONCLUSIONS
                             else []
                         )
-                        _log.info("ci_watcher_lookback_hit", run_id=run_id, conclusion=conclusion)
+                        logger.info(
+                            "ci_watcher_lookback_hit", run_id=run_id, conclusion=conclusion
+                        )
                         return {
                             "run_id": run_id,
                             "conclusion": conclusion,
@@ -339,7 +341,7 @@ class DefaultCIWatcher:
                         }
 
                 # Phase 2: Poll for active runs
-                _log.info("ci_watcher_polling", branch=branch, repo=owner_repo)
+                logger.info("ci_watcher_polling", branch=branch, repo=owner_repo)
                 attempt = 0
                 found_run: dict[str, Any] | None = None
                 while time.monotonic() < deadline:
@@ -397,7 +399,7 @@ class DefaultCIWatcher:
 
                 if found_run is None:
                     poll_duration = time.monotonic() - _start_time
-                    _log.warning(
+                    logger.warning(
                         "ci_watcher_no_runs",
                         branch=branch,
                         repo=owner_repo,
@@ -421,7 +423,7 @@ class DefaultCIWatcher:
 
                 # Phase 3: Wait for the found run to complete
                 run_id = found_run["id"]
-                _log.info("ci_watcher_waiting", run_id=run_id)
+                logger.info("ci_watcher_waiting", run_id=run_id)
                 attempt = 0
                 while time.monotonic() < deadline:
                     run_data = await self._poll_run_status(
@@ -442,7 +444,7 @@ class DefaultCIWatcher:
                             if conclusion in FAILED_CONCLUSIONS
                             else []
                         )
-                        _log.info("ci_watcher_completed", run_id=run_id, conclusion=conclusion)
+                        logger.info("ci_watcher_completed", run_id=run_id, conclusion=conclusion)
                         return {
                             "run_id": run_id,
                             "conclusion": conclusion,
@@ -456,7 +458,7 @@ class DefaultCIWatcher:
                     await asyncio.sleep(min(sleep_duration, remaining))
                     attempt += 1
 
-                _log.warning("ci_watcher_timeout", run_id=run_id, timeout=timeout_seconds)
+                logger.warning("ci_watcher_timeout", run_id=run_id, timeout=timeout_seconds)
                 return {
                     "run_id": run_id,
                     "conclusion": "timed_out",
@@ -469,7 +471,7 @@ class DefaultCIWatcher:
                 }
 
         except httpx.HTTPStatusError as exc:
-            _log.warning("ci_watcher_http_error", status=exc.response.status_code, branch=branch)
+            logger.warning("ci_watcher_http_error", status=exc.response.status_code, branch=branch)
             return {
                 "run_id": None,
                 "conclusion": "error",
@@ -477,7 +479,7 @@ class DefaultCIWatcher:
                 "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
         except httpx.RequestError as exc:
-            _log.warning("ci_watcher_request_error", branch=branch, error=str(exc))
+            logger.warning("ci_watcher_request_error", branch=branch, error=str(exc))
             return {
                 "run_id": None,
                 "conclusion": "error",
@@ -568,11 +570,11 @@ class DefaultCIWatcher:
                 return {"runs": runs}
 
         except httpx.HTTPStatusError as exc:
-            _log.warning("ci_status_http_error", status=exc.response.status_code)
+            logger.warning("ci_status_http_error", status=exc.response.status_code)
             return {
                 "runs": [],
                 "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
         except httpx.RequestError as exc:
-            _log.warning("ci_status_request_error", error=str(exc))
+            logger.warning("ci_status_request_error", error=str(exc))
             return {"runs": [], "error": f"Request error: {exc}"}

--- a/src/autoskillit/execution/github.py
+++ b/src/autoskillit/execution/github.py
@@ -16,7 +16,7 @@ import httpx
 
 from autoskillit.core import _parse_issue_ref, get_logger
 
-_log = get_logger(__name__)
+logger = get_logger(__name__)
 
 
 def _slugify(title: str) -> str:
@@ -94,7 +94,7 @@ def parse_merge_queue_response(data: dict[str, Any]) -> list[dict[str, Any]]:
     rather than skipped, so callers can inspect and handle partial entries.
     """
     if "errors" in data:
-        _log.warning("parse_merge_queue_response graphql errors", errors=data["errors"])
+        logger.warning("parse_merge_queue_response graphql errors", errors=data["errors"])
         return []
     try:
         queue = data.get("data", {}).get("repository", {}).get("mergeQueue") or {}
@@ -216,7 +216,7 @@ class DefaultGitHubFetcher:
                     ]
 
         except httpx.HTTPStatusError as exc:
-            _log.warning(
+            logger.warning(
                 "github fetch http error",
                 status=exc.response.status_code,
                 ref=issue_ref,
@@ -226,7 +226,7 @@ class DefaultGitHubFetcher:
                 "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
         except httpx.RequestError as exc:
-            _log.warning("github fetch request error", ref=issue_ref, error=str(exc))
+            logger.warning("github fetch request error", ref=issue_ref, error=str(exc))
             return {"success": False, "error": f"Request error: {exc}"}
 
         labels = [lbl["name"] for lbl in issue_data.get("labels", [])]
@@ -284,10 +284,12 @@ class DefaultGitHubFetcher:
                 resp.raise_for_status()
                 data = resp.json()
         except httpx.HTTPStatusError as exc:
-            _log.warning("github search http error", status=exc.response.status_code, query=query)
+            logger.warning(
+                "github search http error", status=exc.response.status_code, query=query
+            )
             return {"success": False, "error": f"HTTP {exc.response.status_code}"}
         except httpx.RequestError as exc:
-            _log.warning("github search request error", query=query, error=str(exc))
+            logger.warning("github search request error", query=query, error=str(exc))
             return {"success": False, "error": f"Request error: {exc}"}
 
         items = [
@@ -330,13 +332,13 @@ class DefaultGitHubFetcher:
                 resp.raise_for_status()
                 data = resp.json()
         except httpx.HTTPStatusError as exc:
-            _log.warning("github create_issue http error", status=exc.response.status_code)
+            logger.warning("github create_issue http error", status=exc.response.status_code)
             return {
                 "success": False,
                 "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
         except httpx.RequestError as exc:
-            _log.warning("github create_issue request error", error=str(exc))
+            logger.warning("github create_issue request error", error=str(exc))
             return {"success": False, "error": f"Request error: {exc}"}
 
         return {
@@ -368,7 +370,7 @@ class DefaultGitHubFetcher:
                 resp.raise_for_status()
                 data = resp.json()
         except httpx.HTTPStatusError as exc:
-            _log.warning(
+            logger.warning(
                 "github update_issue_body http error",
                 status=exc.response.status_code,
                 issue=issue_number,
@@ -379,7 +381,7 @@ class DefaultGitHubFetcher:
                 "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
         except httpx.RequestError as exc:
-            _log.warning(
+            logger.warning(
                 "github update_issue_body request error", issue=issue_number, error=str(exc)
             )
             return {"success": False, "error": f"Request error: {exc}"}
@@ -446,13 +448,13 @@ class DefaultGitHubFetcher:
                 resp.raise_for_status()
                 data = resp.json()
         except httpx.HTTPStatusError as exc:
-            _log.warning("github add_labels http error", status=exc.response.status_code)
+            logger.warning("github add_labels http error", status=exc.response.status_code)
             return {
                 "success": False,
                 "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
         except httpx.RequestError as exc:
-            _log.warning("github add_labels request error", error=str(exc))
+            logger.warning("github add_labels request error", error=str(exc))
             return {"success": False, "error": f"Request error: {exc}"}
         applied = [lbl["name"] for lbl in data]
         return {"success": True, "labels": applied}
@@ -479,13 +481,13 @@ class DefaultGitHubFetcher:
                     return {"success": True}  # already removed — idempotent
                 resp.raise_for_status()
         except httpx.HTTPStatusError as exc:
-            _log.warning("github remove_label http error", status=exc.response.status_code)
+            logger.warning("github remove_label http error", status=exc.response.status_code)
             return {
                 "success": False,
                 "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
         except httpx.RequestError as exc:
-            _log.warning("github remove_label request error", error=str(exc))
+            logger.warning("github remove_label request error", error=str(exc))
             return {"success": False, "error": f"Request error: {exc}"}
         return {"success": True}
 
@@ -533,13 +535,13 @@ class DefaultGitHubFetcher:
                 put_resp.raise_for_status()
                 applied = [lbl["name"] for lbl in put_resp.json()]
         except httpx.HTTPStatusError as exc:
-            _log.warning("github swap_labels http error", status=exc.response.status_code)
+            logger.warning("github swap_labels http error", status=exc.response.status_code)
             return {
                 "success": False,
                 "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
         except httpx.RequestError as exc:
-            _log.warning("github swap_labels request error", error=str(exc))
+            logger.warning("github swap_labels request error", error=str(exc))
             return {"success": False, "error": f"Request error: {exc}"}
         return {"success": True, "labels": applied}
 
@@ -574,13 +576,13 @@ class DefaultGitHubFetcher:
                     return {"success": True, "created": False}
                 resp.raise_for_status()
         except httpx.HTTPStatusError as exc:
-            _log.warning("github ensure_label http error", status=exc.response.status_code)
+            logger.warning("github ensure_label http error", status=exc.response.status_code)
             return {
                 "success": False,
                 "error": f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
             }
         except httpx.RequestError as exc:
-            _log.warning("github ensure_label request error", error=str(exc))
+            logger.warning("github ensure_label request error", error=str(exc))
             return {"success": False, "error": f"Request error: {exc}"}
         self._label_cache.add(cache_key)
         return {"success": True, "created": True}

--- a/src/autoskillit/execution/merge_queue.py
+++ b/src/autoskillit/execution/merge_queue.py
@@ -20,7 +20,7 @@ import httpx
 from autoskillit.core import PRState, YAMLError, get_logger, load_yaml
 from autoskillit.execution.github import github_headers
 
-_log = get_logger(__name__)
+logger = get_logger(__name__)
 
 # All GitHub merge_state_status values known to be returned by the GraphQL API.
 # https://docs.github.com/en/graphql/reference/enums#mergestatestatus
@@ -414,7 +414,7 @@ class DefaultMergeQueueWatcher:
                     pr_number, owner, repo_name, target_branch
                 )
             except Exception:
-                _log.warning("fetch_pr_and_queue_state failed, retrying", exc_info=True)
+                logger.warning("fetch_pr_and_queue_state failed, retrying", exc_info=True)
                 await asyncio.sleep(poll_interval)
                 continue
 
@@ -481,7 +481,7 @@ class DefaultMergeQueueWatcher:
                     continue
                 if stall_retries_attempted < max_stall_retries:
                     backoff = min(30 * (2**stall_retries_attempted), 120)
-                    _log.info(
+                    logger.info(
                         "merge_queue_stall_detected",
                         stall_duration=stall_duration,
                         attempt=stall_retries_attempted + 1,
@@ -493,7 +493,7 @@ class DefaultMergeQueueWatcher:
                             auto_merge_available=auto_merge_available,
                         )
                     except Exception:
-                        _log.warning("toggle_auto_merge failed", exc_info=True)
+                        logger.warning("toggle_auto_merge failed", exc_info=True)
                     stall_retries_attempted += 1
                     not_in_queue_cycles = 0
                     await asyncio.sleep(backoff)
@@ -618,7 +618,7 @@ class DefaultMergeQueueWatcher:
             await self._toggle_auto_merge(state["pr_node_id"])
             return {"success": True, "pr_number": pr_number}
         except Exception as exc:
-            _log.warning("toggle_auto_merge failed", exc_info=True)
+            logger.warning("toggle_auto_merge failed", exc_info=True)
             return {"success": False, "error": f"toggle failed: {exc}"}
 
     async def _enqueue_direct(self, pr_node_id: str) -> None:
@@ -692,7 +692,7 @@ class DefaultMergeQueueWatcher:
                 "enrollment_method": enrollment_method,
             }
         except Exception as exc:
-            _log.warning("enqueue failed", exc_info=True)
+            logger.warning("enqueue failed", exc_info=True)
             return {"success": False, "error": f"enqueue failed: {exc}"}
 
     async def _toggle_auto_merge(
@@ -827,7 +827,7 @@ def _is_secondary_rate_limit(resp: httpx.Response) -> bool:
     try:
         text = resp.text.lower()
     except Exception:
-        _log.warning("Failed to read response body for rate-limit check", exc_info=True)
+        logger.warning("Failed to read response body for rate-limit check", exc_info=True)
         return False
     return _RATE_LIMIT_SECONDARY_MARKER in text
 
@@ -893,7 +893,7 @@ async def fetch_repo_merge_state(
             )
         if resp.status_code == 429 or _is_secondary_rate_limit(resp):
             sleep_secs = _retry_after_seconds(attempt, resp)
-            _log.warning(
+            logger.warning(
                 "fetch_repo_merge_state rate limited",
                 status=resp.status_code,
                 attempt=attempt,

--- a/src/autoskillit/execution/quota.py
+++ b/src/autoskillit/execution/quota.py
@@ -17,7 +17,7 @@ import httpx
 
 from autoskillit.core import get_logger, write_versioned_json
 
-_log = get_logger(__name__)
+logger = get_logger(__name__)
 
 _DEFAULT_BASE_URL: str = "https://api.anthropic.com"
 
@@ -195,7 +195,7 @@ def _read_cache(cache_path: str, max_age: int) -> QuotaStatus | None:
             cache_key = str(Path(cache_path).expanduser())
             if cache_key not in _SCHEMA_DRIFT_LOGGED:
                 _SCHEMA_DRIFT_LOGGED.add(cache_key)
-                _log.warning(
+                logger.warning(
                     "quota_cache_schema_drift",
                     cache_path=cache_key,
                     observed=raw.get("schema_version"),
@@ -245,7 +245,7 @@ def _write_cache(cache_path: str, result: QuotaFetchResult) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
         write_versioned_json(path, payload, schema_version=QUOTA_CACHE_SCHEMA_VERSION)
     except OSError as exc:
-        _log.warning("quota cache write failed", path=cache_path, error=str(exc))
+        logger.warning("quota cache write failed", path=cache_path, error=str(exc))
 
 
 def invalidate_cache(cache_path: str) -> None:
@@ -258,7 +258,7 @@ def invalidate_cache(cache_path: str) -> None:
     except FileNotFoundError:
         pass
     except OSError as exc:
-        _log.warning("quota cache invalidation failed", path=cache_path, error=str(exc))
+        logger.warning("quota cache invalidation failed", path=cache_path, error=str(exc))
 
 
 async def _fetch_quota(
@@ -296,7 +296,7 @@ async def _fetch_quota(
             )
     novel = {name for name in windows if name not in KNOWN_QUOTA_WINDOW_NAMES}
     if novel:
-        _log.warning(
+        logger.warning(
             "Anthropic quota API returned unknown quota window names. "
             "If this is a new rate-limit window, add it to KNOWN_QUOTA_WINDOW_NAMES in quota.py "
             "and update LONG_WINDOW_NAMES and long_window_patterns if it is a long window.",
@@ -407,7 +407,7 @@ async def check_and_sleep_if_needed(
 
         if status.resets_at is None:
             fallback_seconds = max(config.buffer_seconds, 60)
-            _log.warning(
+            logger.warning(
                 "quota above threshold but resets_at is None — blocking with fallback",
                 utilization=status.utilization,
                 fallback_sleep_seconds=fallback_seconds,
@@ -429,7 +429,7 @@ async def check_and_sleep_if_needed(
 
         if status.resets_at is None:
             fallback_seconds = max(config.buffer_seconds, 60)
-            _log.warning(
+            logger.warning(
                 "quota above threshold but resets_at is None after re-fetch"
                 " — blocking with fallback",
                 utilization=status.utilization,
@@ -448,7 +448,7 @@ async def check_and_sleep_if_needed(
         now = datetime.now(UTC)
         wake_at = status.resets_at + timedelta(seconds=config.buffer_seconds)
         sleep_secs = max(0, int((wake_at - now).total_seconds()))
-        _log.info(
+        logger.info(
             "quota threshold exceeded — caller should sleep",
             utilization=status.utilization,
             effective_threshold=status.effective_threshold,
@@ -480,14 +480,14 @@ async def check_and_sleep_if_needed(
             httpx.HTTPError,
         )
         if isinstance(exc, _operational_types):
-            _log.warning(
+            logger.warning(
                 "quota check failed — continuing without sleep",
                 error=str(exc),
                 error_type=type(exc).__name__,
                 exc_info=True,
             )
         else:
-            _log.error(
+            logger.error(
                 "quota check failed (unexpected error) — continuing without sleep",
                 error=str(exc),
                 error_type=type(exc).__name__,

--- a/src/autoskillit/execution/remote_resolver.py
+++ b/src/autoskillit/execution/remote_resolver.py
@@ -10,7 +10,7 @@ import asyncio
 
 from autoskillit.core import get_logger, normalize_owner_repo, parse_github_repo
 
-_log = get_logger(__name__)
+logger = get_logger(__name__)
 
 # Canonical remote precedence order: upstream before origin encodes the clone
 # isolation contract (upstream = real GitHub URL; origin = file:// local path).
@@ -59,7 +59,7 @@ async def resolve_remote_repo(
                 proc.kill()
                 await proc.wait()
                 await asyncio.gather(io_task, return_exceptions=True)
-                _log.warning("Timed out getting URL for remote %r in %r", remote, cwd)
+                logger.warning("Timed out getting URL for remote %r in %r", remote, cwd)
                 continue
             stdout, _ = await io_task
             if proc.returncode == 0:
@@ -67,7 +67,7 @@ async def resolve_remote_repo(
                 if parsed:
                     return parsed
         except OSError:
-            _log.warning("Failed to get URL for remote %r in %r", remote, cwd, exc_info=True)
+            logger.warning("Failed to get URL for remote %r in %r", remote, cwd, exc_info=True)
 
     return None
 

--- a/src/autoskillit/fleet/state.py
+++ b/src/autoskillit/fleet/state.py
@@ -15,7 +15,7 @@ from typing import Any
 
 from autoskillit.core import get_logger, write_versioned_json
 
-_log = get_logger(__name__)
+logger = get_logger(__name__)
 
 _SCHEMA_VERSION = 3
 
@@ -169,7 +169,7 @@ def read_state(state_path: Path) -> CampaignState | None:
             captured_values=data.get("captured_values", {}),
         )
     except (KeyError, ValueError, TypeError) as exc:
-        _log.warning("read_state: schema mismatch or corrupt payload in %s: %s", state_path, exc)
+        logger.warning("read_state: schema mismatch or corrupt payload in %s: %s", state_path, exc)
         return None
 
 
@@ -303,7 +303,7 @@ def build_protected_campaign_ids(project_dir: Path) -> frozenset[str]:
                 continue
         return frozenset(protected)
     except Exception:
-        _log.warning("campaign_ids_protection_error", exc_info=True)
+        logger.warning("campaign_ids_protection_error", exc_info=True)
         return frozenset(protected)
 
 
@@ -315,7 +315,7 @@ def write_captured_values(state_path: Path, captures: dict[str, str]) -> None:
     """
     state = read_state(state_path)
     if state is None:
-        _log.warning("write_captured_values: state not found at %s", state_path)
+        logger.warning("write_captured_values: state not found at %s", state_path)
         return
     state.captured_values = {**state.captured_values, **captures}
     _write_state(state_path, state)
@@ -347,7 +347,7 @@ def read_all_campaign_captures(
             if all_success and dispatches:
                 result.update(caps)
         except (json.JSONDecodeError, OSError) as exc:
-            _log.warning("read_all_campaign_captures: skipping %s: %s", path, exc)
+            logger.warning("read_all_campaign_captures: skipping %s: %s", path, exc)
             continue
     return result
 

--- a/src/autoskillit/planner/compiler.py
+++ b/src/autoskillit/planner/compiler.py
@@ -11,7 +11,7 @@ from autoskillit.planner.validation import (
     _load_wp_results,
 )
 
-_logger = get_logger(__name__)
+logger = get_logger(__name__)
 
 
 def _topological_sort(wp_results: dict[str, dict]) -> list[str]:
@@ -122,7 +122,7 @@ def compile_plan(output_dir: str, task: str, source_dir: str) -> dict[str, str]:
         except json.JSONDecodeError as exc:
             raise RuntimeError(f"Malformed validation file {validation_path}: {exc}") from exc
         if validation.get("verdict") != "pass":
-            _logger.warning(
+            logger.warning(
                 "compile_plan called with non-passing validation",
                 verdict=validation.get("verdict"),
             )
@@ -233,7 +233,7 @@ def compile_plan(output_dir: str, task: str, source_dir: str) -> dict[str, str]:
 
     plan_parts = "\n".join(issue_paths[wp_id] for wp_id in execution_order)
 
-    _logger.info("compile_plan", wp_count=len(execution_order))
+    logger.info("compile_plan", wp_count=len(execution_order))
     return {
         "plan_path": str(plan_md_path),
         "plan_json_path": str(plan_json_path),

--- a/src/autoskillit/planner/merge.py
+++ b/src/autoskillit/planner/merge.py
@@ -8,7 +8,7 @@ from typing import Any
 from autoskillit.core import get_logger, write_versioned_json
 from autoskillit.planner.schema import validate_phase_result
 
-_logger = get_logger(__name__)
+logger = get_logger(__name__)
 
 _TIER_KEYS = ("phases", "assignments", "work_packages")
 
@@ -61,14 +61,14 @@ def merge_files(
                     continue
                 item_id = item.get("id")
                 if item_id is None:
-                    _logger.debug("Skipping item with no 'id' field from %s", fp)
+                    logger.debug("Skipping item with no 'id' field from %s", fp)
                     skipped += 1
                     continue
                 if item_id not in existing_ids:
                     existing_items.append(item)
                     existing_ids.add(item_id)
                 else:
-                    _logger.debug("Skipping duplicate id %r from %s", item_id, fp)
+                    logger.debug("Skipping duplicate id %r from %s", item_id, fp)
                     skipped += 1
 
             document: dict[str, Any] = {
@@ -182,7 +182,7 @@ def build_plan_snapshot(
             raw = json.loads(p.read_text())
             validated = validate_phase_result(raw)
         except (ValueError, json.JSONDecodeError) as exc:
-            _logger.warning("Skipping malformed phase file %s: %s", p, exc)
+            logger.warning("Skipping malformed phase file %s: %s", p, exc)
             continue
         short: dict[str, Any] = {
             "id": validated["id"],

--- a/src/autoskillit/planner/validation.py
+++ b/src/autoskillit/planner/validation.py
@@ -11,7 +11,7 @@ from autoskillit.planner.schema import (
     validate_wp_result,
 )
 
-_logger = get_logger(__name__)
+logger = get_logger(__name__)
 
 
 def _load_phase_results(root: Path) -> dict[str, dict]:
@@ -224,7 +224,7 @@ def validate_plan(output_dir: str) -> dict[str, str]:
         {"verdict": verdict, "findings": findings},
         schema_version=1,
     )
-    _logger.info("validate_plan", verdict=verdict, issue_count=len(findings))
+    logger.info("validate_plan", verdict=verdict, issue_count=len(findings))
     return {
         "verdict": verdict,
         "validation_path": str(validation_path),

--- a/src/autoskillit/recipe/__init__.py
+++ b/src/autoskillit/recipe/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from autoskillit.core import get_logger
 
-_logger = get_logger(__name__)
+logger = get_logger(__name__)
 
 # Rule registration — import triggers @semantic_rule registration.
 from autoskillit.recipe import rules_actions as _rules_actions  # noqa: E402 F401

--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -58,7 +58,7 @@ from autoskillit.recipe.validator import (
     validate_recipe,
 )
 
-_logger = get_logger(__name__)
+logger = get_logger(__name__)
 
 # ---------------------------------------------------------------------------
 # GFM ingredient table column specs
@@ -200,7 +200,7 @@ def _t(label: str, t0: float, name: str) -> float:
     filtering without requiring an explicit isEnabledFor() guard.
     """
     elapsed_ms = (time.perf_counter() - t0) * 1000
-    _logger.debug("load_recipe_stage", recipe=name, stage=label, elapsed_ms=round(elapsed_ms, 1))
+    logger.debug("load_recipe_stage", recipe=name, stage=label, elapsed_ms=round(elapsed_ms, 1))
     return time.perf_counter()
 
 
@@ -633,7 +633,7 @@ def load_and_validate(
             and rm == cached.recipe_mtime
             and rs == cached.recipe_size
         ):
-            _logger.debug("load_recipe_cache_hit", recipe=name)
+            logger.debug("load_recipe_cache_hit", recipe=name)
             return cached.result
 
     t0 = time.perf_counter()
@@ -757,7 +757,7 @@ def load_and_validate(
             t0 = _t("yaml_parse", t0, name)
 
     except YAMLError as exc:
-        _logger.warning("Recipe YAML parse error", name=name, exc_info=True)
+        logger.warning("Recipe YAML parse error", name=name, exc_info=True)
         suggestions.append(
             {
                 "rule": "validation-error",
@@ -768,7 +768,7 @@ def load_and_validate(
         )
         valid = False
     except ValueError as exc:
-        _logger.warning("Recipe structure invalid", name=name, exc_info=True)
+        logger.warning("Recipe structure invalid", name=name, exc_info=True)
         suggestions.append(
             {
                 "rule": "validation-error",
@@ -779,7 +779,7 @@ def load_and_validate(
         )
         valid = False
     except (FileNotFoundError, OSError) as exc:
-        _logger.warning("Recipe file not found or unreadable", name=name, exc_info=True)
+        logger.warning("Recipe file not found or unreadable", name=name, exc_info=True)
         suggestions.append(
             {
                 "rule": "validation-error",

--- a/src/autoskillit/recipe/experiment_type_registry.py
+++ b/src/autoskillit/recipe/experiment_type_registry.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from autoskillit.core import get_logger, load_yaml, pkg_root
 
-_log = get_logger(__name__)
+logger = get_logger(__name__)
 
 BUNDLED_EXPERIMENT_TYPES_DIR: Path = pkg_root() / "recipes" / "experiment-types"
 
@@ -55,7 +55,7 @@ def _load_types_from_dir(directory: Path) -> dict[str, ExperimentTypeSpec]:
                 spec = _parse_experiment_type(data, path)
                 result[spec.name] = spec
         except Exception:
-            _log.warning("Skipping malformed experiment type file: %s", path, exc_info=True)
+            logger.warning("Skipping malformed experiment type file: %s", path, exc_info=True)
     return result
 
 

--- a/src/autoskillit/recipe/rules_actions.py
+++ b/src/autoskillit/recipe/rules_actions.py
@@ -7,7 +7,7 @@ from autoskillit.recipe._analysis import ValidationContext
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
 from autoskillit.recipe.schema import RecipeKind
 
-_logger = get_logger(__name__)
+logger = get_logger(__name__)
 
 _PLACEHOLDER_MESSAGES: frozenset[str] = frozenset(
     {"done", "ok", "complete", "finished", "end", "stop", "exit"}

--- a/src/autoskillit/recipes/diagrams/implementation.md
+++ b/src/autoskillit/recipes/diagrams/implementation.md
@@ -1,31 +1,158 @@
-<!-- autoskillit-recipe-hash: sha256:31cc4041bae3dd8dfcbc7ab8518ba33c8aeeab99515f1181a273bd8812ae0e90 -->
+<!-- autoskillit-recipe-hash: sha256:91c8aa0bf0adcb9b5f8bdd92b297efe31446a96166fa710c73fbc73d9dfbade3 -->
 <!-- autoskillit-diagram-format: v7 -->
 # implementation
 
-```
-      clone → get_issue_title → claim_issue → compute_branch
-      |
-      +-- create_branch (optional)
-      |
-      plan
-      |
-      +-- review (optional)
-      |
- +----+ FOR EACH PLAN PART:
- |    |
- |    verify → implement → test ↔ [fix on failure]
- |    |
- |    merge → push → next_or_done
- |
- +----+
-      |
-      +-- audit_impl → remediate (optional)
-      |
-      +-- [open-pr] (optional):
-      |     prepare_pr → compose_pr → review_pr → resolve_review
-      |     ci_watch → check_repo_merge_state
-      |     → [queue | direct | immediate] merge path
-      |     → diagnose_ci → resolve_ci (on CI failure)
-      |
-      release_issue_success / release_issue_failure
+```mermaid
+flowchart TD
+    S0[clone]
+    S1[capture_base_sha]
+    S0 --> S1
+    S2[get_issue_title]
+    S1 --> S2
+    S3[claim_issue]
+    S2 --> S3
+    S4[compute_branch]
+    S3 --> S4
+    S5[create_branch]
+    S4 --> S5
+    S6[push_merge_target]
+    S5 --> S6
+    S7[plan]
+    S6 --> S7
+    S8[review]
+    S7 --> S8
+    S9[verify]
+    S8 --> S9
+    S10[implement]
+    S9 --> S10
+    S11[retry_worktree]
+    S10 --> S11
+    S12[test]
+    S11 --> S12
+    S13[commit_guard]
+    S12 --> S13
+    S14[merge]
+    S13 --> S14
+    S15[push]
+    S14 --> S15
+    S16[fix]
+    S15 --> S16
+    S17[next_or_done]
+    S16 --> S17
+    S18[audit_impl]
+    S17 --> S18
+    S19[remediate]
+    S18 --> S19
+    S20[prepare_pr]
+    S19 --> S20
+    S21[run_arch_lenses]
+    S20 --> S21
+    S22[compose_pr]
+    S21 --> S22
+    S23[extract_pr_number]
+    S22 --> S23
+    S24[annotate_pr_diff]
+    S23 --> S24
+    S25[review_pr]
+    S24 --> S25
+    S26[resolve_review]
+    S25 --> S26
+    S27[re_push_review]
+    S26 --> S27
+    S28[check_review_loop]
+    S27 --> S28
+    S29[check_repo_ci_event]
+    S28 --> S29
+    S30[check_pr_state]
+    S29 --> S30
+    S31[ci_watch]
+    S30 --> S31
+    S32[handle_no_ci_runs]
+    S31 --> S32
+    S33[check_ci_loop]
+    S32 --> S33
+    S34[check_active_trigger_loop]
+    S33 --> S34
+    S35[trigger_ci_actively]
+    S34 --> S35
+    S36[escalate_stop_no_ci]
+    S35 --> S36
+    S37[check_repo_merge_state]
+    S36 --> S37
+    S38[route_queue_mode]
+    S37 --> S38
+    S39[enqueue_to_queue]
+    S38 --> S39
+    S40[verify_queue_enrollment]
+    S39 --> S40
+    S41[wait_for_queue]
+    S40 --> S41
+    S42[reenroll_stalled_pr]
+    S41 --> S42
+    S43[check_stall_loop]
+    S42 --> S43
+    S44[check_eject_limit]
+    S43 --> S44
+    S45[queue_ejected_fix]
+    S44 --> S45
+    S46[resolve_queue_merge_conflicts]
+    S45 --> S46
+    S47[re_push_queue_fix]
+    S46 --> S47
+    S48[ci_watch_post_queue_fix]
+    S47 --> S48
+    S49[reenter_merge_queue]
+    S48 --> S49
+    S50[reenter_merge_queue_cheap]
+    S49 --> S50
+    S51[direct_merge]
+    S50 --> S51
+    S52[wait_for_direct_merge]
+    S51 --> S52
+    S53[direct_merge_conflict_fix]
+    S52 --> S53
+    S54[resolve_direct_merge_conflicts]
+    S53 --> S54
+    S55[re_push_direct_fix]
+    S54 --> S55
+    S56[redirect_merge]
+    S55 --> S56
+    S57[immediate_merge]
+    S56 --> S57
+    S58[wait_for_immediate_merge]
+    S57 --> S58
+    S59[immediate_merge_conflict_fix]
+    S58 --> S59
+    S60[resolve_immediate_merge_conflicts]
+    S59 --> S60
+    S61[re_push_immediate_fix]
+    S60 --> S61
+    S62[remerge_immediate]
+    S61 --> S62
+    S63[diagnose_ci]
+    S62 --> S63
+    S64[resolve_ci]
+    S63 --> S64
+    S65[pre_resolve_rebase]
+    S64 --> S65
+    S66[re_push]
+    S65 --> S66
+    S67[detect_ci_conflict]
+    S66 --> S67
+    S68[ci_conflict_fix]
+    S67 --> S68
+    S69[release_issue_success]
+    S68 --> S69
+    S70[register_clone_unconfirmed]
+    S69 --> S70
+    S71[release_issue_failure]
+    S70 --> S71
+    S72[register_clone_success]
+    S71 --> S72
+    S73[register_clone_failure]
+    S72 --> S73
+    S74[done]
+    S73 --> S74
+    S75[escalate_stop]
+    S74 --> S75
 ```

--- a/src/autoskillit/recipes/diagrams/implementation.md
+++ b/src/autoskillit/recipes/diagrams/implementation.md
@@ -2,157 +2,30 @@
 <!-- autoskillit-diagram-format: v7 -->
 # implementation
 
-```mermaid
-flowchart TD
-    S0[clone]
-    S1[capture_base_sha]
-    S0 --> S1
-    S2[get_issue_title]
-    S1 --> S2
-    S3[claim_issue]
-    S2 --> S3
-    S4[compute_branch]
-    S3 --> S4
-    S5[create_branch]
-    S4 --> S5
-    S6[push_merge_target]
-    S5 --> S6
-    S7[plan]
-    S6 --> S7
-    S8[review]
-    S7 --> S8
-    S9[verify]
-    S8 --> S9
-    S10[implement]
-    S9 --> S10
-    S11[retry_worktree]
-    S10 --> S11
-    S12[test]
-    S11 --> S12
-    S13[commit_guard]
-    S12 --> S13
-    S14[merge]
-    S13 --> S14
-    S15[push]
-    S14 --> S15
-    S16[fix]
-    S15 --> S16
-    S17[next_or_done]
-    S16 --> S17
-    S18[audit_impl]
-    S17 --> S18
-    S19[remediate]
-    S18 --> S19
-    S20[prepare_pr]
-    S19 --> S20
-    S21[run_arch_lenses]
-    S20 --> S21
-    S22[compose_pr]
-    S21 --> S22
-    S23[extract_pr_number]
-    S22 --> S23
-    S24[annotate_pr_diff]
-    S23 --> S24
-    S25[review_pr]
-    S24 --> S25
-    S26[resolve_review]
-    S25 --> S26
-    S27[re_push_review]
-    S26 --> S27
-    S28[check_review_loop]
-    S27 --> S28
-    S29[check_repo_ci_event]
-    S28 --> S29
-    S30[check_pr_state]
-    S29 --> S30
-    S31[ci_watch]
-    S30 --> S31
-    S32[handle_no_ci_runs]
-    S31 --> S32
-    S33[check_ci_loop]
-    S32 --> S33
-    S34[check_active_trigger_loop]
-    S33 --> S34
-    S35[trigger_ci_actively]
-    S34 --> S35
-    S36[escalate_stop_no_ci]
-    S35 --> S36
-    S37[check_repo_merge_state]
-    S36 --> S37
-    S38[route_queue_mode]
-    S37 --> S38
-    S39[enqueue_to_queue]
-    S38 --> S39
-    S40[verify_queue_enrollment]
-    S39 --> S40
-    S41[wait_for_queue]
-    S40 --> S41
-    S42[reenroll_stalled_pr]
-    S41 --> S42
-    S43[check_stall_loop]
-    S42 --> S43
-    S44[check_eject_limit]
-    S43 --> S44
-    S45[queue_ejected_fix]
-    S44 --> S45
-    S46[resolve_queue_merge_conflicts]
-    S45 --> S46
-    S47[re_push_queue_fix]
-    S46 --> S47
-    S48[ci_watch_post_queue_fix]
-    S47 --> S48
-    S49[reenter_merge_queue]
-    S48 --> S49
-    S50[reenter_merge_queue_cheap]
-    S49 --> S50
-    S51[direct_merge]
-    S50 --> S51
-    S52[wait_for_direct_merge]
-    S51 --> S52
-    S53[direct_merge_conflict_fix]
-    S52 --> S53
-    S54[resolve_direct_merge_conflicts]
-    S53 --> S54
-    S55[re_push_direct_fix]
-    S54 --> S55
-    S56[redirect_merge]
-    S55 --> S56
-    S57[immediate_merge]
-    S56 --> S57
-    S58[wait_for_immediate_merge]
-    S57 --> S58
-    S59[immediate_merge_conflict_fix]
-    S58 --> S59
-    S60[resolve_immediate_merge_conflicts]
-    S59 --> S60
-    S61[re_push_immediate_fix]
-    S60 --> S61
-    S62[remerge_immediate]
-    S61 --> S62
-    S63[diagnose_ci]
-    S62 --> S63
-    S64[resolve_ci]
-    S63 --> S64
-    S65[pre_resolve_rebase]
-    S64 --> S65
-    S66[re_push]
-    S65 --> S66
-    S67[detect_ci_conflict]
-    S66 --> S67
-    S68[ci_conflict_fix]
-    S67 --> S68
-    S69[release_issue_success]
-    S68 --> S69
-    S70[register_clone_unconfirmed]
-    S69 --> S70
-    S71[release_issue_failure]
-    S70 --> S71
-    S72[register_clone_success]
-    S71 --> S72
-    S73[register_clone_failure]
-    S72 --> S73
-    S74[done]
-    S73 --> S74
-    S75[escalate_stop]
-    S74 --> S75
+```
+      clone → get_issue_title → claim_issue → compute_branch
+      |
+      +-- create_branch (optional)
+      |
+      plan
+      |
+      +-- review (optional)
+      |
+ +----+ FOR EACH PLAN PART:
+ |    |
+ |    verify → implement → test ↔ [fix on failure]
+ |    |
+ |    merge → push → next_or_done
+ |
+ +----+
+      |
+      +-- audit_impl → remediate (optional)
+      |
+      +-- [open-pr] (optional):
+      |     prepare_pr → compose_pr → review_pr → resolve_review
+      |     ci_watch → check_repo_merge_state
+      |     → [queue | direct | immediate] merge path
+      |     → diagnose_ci → resolve_ci (on CI failure)
+      |
+      release_issue_success / release_issue_failure
 ```

--- a/src/autoskillit/recipes/diagrams/implementation.md
+++ b/src/autoskillit/recipes/diagrams/implementation.md
@@ -1,31 +1,158 @@
-<!-- autoskillit-recipe-hash: sha256:91c8aa0bf0adcb9b5f8bdd92b297efe31446a96166fa710c73fbc73d9dfbade3 -->
+<!-- autoskillit-recipe-hash: sha256:04a976ae0115ca1280bba1db38f8a5066690aa1dc95927286b110c3ffaea136a -->
 <!-- autoskillit-diagram-format: v7 -->
 # implementation
 
-```
-      clone → get_issue_title → claim_issue → compute_branch
-      |
-      +-- create_branch (optional)
-      |
-      plan
-      |
-      +-- review (optional)
-      |
- +----+ FOR EACH PLAN PART:
- |    |
- |    verify → implement → test ↔ [fix on failure]
- |    |
- |    merge → push → next_or_done
- |
- +----+
-      |
-      +-- audit_impl → remediate (optional)
-      |
-      +-- [open-pr] (optional):
-      |     prepare_pr → compose_pr → review_pr → resolve_review
-      |     ci_watch → check_repo_merge_state
-      |     → [queue | direct | immediate] merge path
-      |     → diagnose_ci → resolve_ci (on CI failure)
-      |
-      release_issue_success / release_issue_failure
+```mermaid
+flowchart TD
+    S0[clone]
+    S1[capture_base_sha]
+    S0 --> S1
+    S2[get_issue_title]
+    S1 --> S2
+    S3[claim_issue]
+    S2 --> S3
+    S4[compute_branch]
+    S3 --> S4
+    S5[create_branch]
+    S4 --> S5
+    S6[push_merge_target]
+    S5 --> S6
+    S7[plan]
+    S6 --> S7
+    S8[review]
+    S7 --> S8
+    S9[verify]
+    S8 --> S9
+    S10[implement]
+    S9 --> S10
+    S11[retry_worktree]
+    S10 --> S11
+    S12[test]
+    S11 --> S12
+    S13[commit_guard]
+    S12 --> S13
+    S14[merge]
+    S13 --> S14
+    S15[push]
+    S14 --> S15
+    S16[fix]
+    S15 --> S16
+    S17[next_or_done]
+    S16 --> S17
+    S18[audit_impl]
+    S17 --> S18
+    S19[remediate]
+    S18 --> S19
+    S20[prepare_pr]
+    S19 --> S20
+    S21[run_arch_lenses]
+    S20 --> S21
+    S22[compose_pr]
+    S21 --> S22
+    S23[extract_pr_number]
+    S22 --> S23
+    S24[annotate_pr_diff]
+    S23 --> S24
+    S25[review_pr]
+    S24 --> S25
+    S26[resolve_review]
+    S25 --> S26
+    S27[re_push_review]
+    S26 --> S27
+    S28[check_review_loop]
+    S27 --> S28
+    S29[check_repo_ci_event]
+    S28 --> S29
+    S30[check_pr_state]
+    S29 --> S30
+    S31[ci_watch]
+    S30 --> S31
+    S32[handle_no_ci_runs]
+    S31 --> S32
+    S33[check_ci_loop]
+    S32 --> S33
+    S34[check_active_trigger_loop]
+    S33 --> S34
+    S35[trigger_ci_actively]
+    S34 --> S35
+    S36[escalate_stop_no_ci]
+    S35 --> S36
+    S37[check_repo_merge_state]
+    S36 --> S37
+    S38[route_queue_mode]
+    S37 --> S38
+    S39[enqueue_to_queue]
+    S38 --> S39
+    S40[verify_queue_enrollment]
+    S39 --> S40
+    S41[wait_for_queue]
+    S40 --> S41
+    S42[reenroll_stalled_pr]
+    S41 --> S42
+    S43[check_stall_loop]
+    S42 --> S43
+    S44[check_eject_limit]
+    S43 --> S44
+    S45[queue_ejected_fix]
+    S44 --> S45
+    S46[resolve_queue_merge_conflicts]
+    S45 --> S46
+    S47[re_push_queue_fix]
+    S46 --> S47
+    S48[ci_watch_post_queue_fix]
+    S47 --> S48
+    S49[reenter_merge_queue]
+    S48 --> S49
+    S50[reenter_merge_queue_cheap]
+    S49 --> S50
+    S51[direct_merge]
+    S50 --> S51
+    S52[wait_for_direct_merge]
+    S51 --> S52
+    S53[direct_merge_conflict_fix]
+    S52 --> S53
+    S54[resolve_direct_merge_conflicts]
+    S53 --> S54
+    S55[re_push_direct_fix]
+    S54 --> S55
+    S56[redirect_merge]
+    S55 --> S56
+    S57[immediate_merge]
+    S56 --> S57
+    S58[wait_for_immediate_merge]
+    S57 --> S58
+    S59[immediate_merge_conflict_fix]
+    S58 --> S59
+    S60[resolve_immediate_merge_conflicts]
+    S59 --> S60
+    S61[re_push_immediate_fix]
+    S60 --> S61
+    S62[remerge_immediate]
+    S61 --> S62
+    S63[diagnose_ci]
+    S62 --> S63
+    S64[resolve_ci]
+    S63 --> S64
+    S65[pre_resolve_rebase]
+    S64 --> S65
+    S66[re_push]
+    S65 --> S66
+    S67[detect_ci_conflict]
+    S66 --> S67
+    S68[ci_conflict_fix]
+    S67 --> S68
+    S69[release_issue_success]
+    S68 --> S69
+    S70[register_clone_unconfirmed]
+    S69 --> S70
+    S71[release_issue_failure]
+    S70 --> S71
+    S72[register_clone_success]
+    S71 --> S72
+    S73[register_clone_failure]
+    S72 --> S73
+    S74[done]
+    S73 --> S74
+    S75[escalate_stop]
+    S74 --> S75
 ```

--- a/src/autoskillit/server/_session_type.py
+++ b/src/autoskillit/server/_session_type.py
@@ -19,7 +19,7 @@ from autoskillit.core import (
 )
 from autoskillit.core import session_type as _resolve_session_type
 
-_log = get_logger(__name__)
+logger = get_logger(__name__)
 
 
 def _collect_fleet_tool_tags() -> frozenset[str]:
@@ -54,7 +54,7 @@ def _apply_session_type_visibility() -> None:
                 if not pack:
                     continue
                 if pack not in CATEGORY_TAGS:
-                    _log.warning(
+                    logger.warning(
                         "Unknown pack %r in AUTOSKILLIT_L2_TOOL_TAGS — skipping mcp.enable(); "
                         "valid packs: %s",
                         pack,

--- a/src/autoskillit/workspace/clone_registry.py
+++ b/src/autoskillit/workspace/clone_registry.py
@@ -25,7 +25,7 @@ from autoskillit.core import (
     resolve_temp_dir,
 )
 
-_log = get_logger(__name__)
+logger = get_logger(__name__)
 
 CloneStatus = Literal["success", "error", "unconfirmed"]
 _DEFAULT_REGISTRY_NAME = "clone-cleanup-registry.json"
@@ -74,7 +74,7 @@ class CloneRegistry:
             try:
                 self._entries = json.loads(self._path.read_text()).get("clones", [])
             except (json.JSONDecodeError, OSError, AttributeError) as exc:
-                _log.warning("clone_registry: could not read %s: %s", self._path, exc)
+                logger.warning("clone_registry: could not read %s: %s", self._path, exc)
                 self._entries = []
         return self
 
@@ -168,7 +168,7 @@ def read_registry(
     try:
         return json.loads(path.read_text()).get("clones", [])
     except (json.JSONDecodeError, OSError) as exc:
-        _log.warning("clone_registry: could not read %s: %s", path, exc)
+        logger.warning("clone_registry: could not read %s: %s", path, exc)
         return []
 
 

--- a/tests/arch/_helpers.py
+++ b/tests/arch/_helpers.py
@@ -156,6 +156,25 @@ class ArchitectureViolationVisitor(ast.NodeVisitor):
 
         self.generic_visit(node)
 
+    def visit_Assign(self, node: ast.Assign) -> None:  # ARCH-009
+        """logger variable name: get_logger() result must be bound to 'logger'."""
+        if isinstance(node.value, ast.Call):
+            call = node.value
+            func_name: str | None = None
+            if isinstance(call.func, ast.Name):
+                func_name = call.func.id
+            elif isinstance(call.func, ast.Attribute):
+                func_name = call.func.attr
+            if func_name == "get_logger":
+                for target in node.targets:
+                    if isinstance(target, ast.Name) and target.id != "logger":
+                        self._add(
+                            node,
+                            _RULE["ARCH-009"],
+                            f"get_logger() result bound to '{target.id}'; must be named 'logger'",
+                        )
+        self.generic_visit(node)
+
     def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
         """Rule ARCH-003 (visitor): broad except without logger or re-raise -> silent swallow."""
         is_broad = node.type is None or (

--- a/tests/arch/_rules.py
+++ b/tests/arch/_rules.py
@@ -270,6 +270,7 @@ RULES: tuple[RuleDescriptor, ...] = (
         ),
         exemptions=frozenset(),
         severity="error",
+        defense_standard="DS-009",
     ),
 )
 

--- a/tests/arch/_rules.py
+++ b/tests/arch/_rules.py
@@ -114,7 +114,7 @@ _DISPATCH_TABLE_EXEMPT_FUNCTIONS = frozenset(
     }
 )
 
-# ── RULES tuple — 8 entries ───────────────────────────────────────────────────
+# ── RULES tuple — 9 entries ───────────────────────────────────────────────────
 
 RULES: tuple[RuleDescriptor, ...] = (
     RuleDescriptor(
@@ -257,6 +257,19 @@ RULES: tuple[RuleDescriptor, ...] = (
         exemptions=frozenset(),
         severity="error",
         defense_standard="DS-008",
+    ),
+    RuleDescriptor(
+        rule_id="ARCH-009",
+        name="logger-variable-name",
+        lens="operational",
+        description="The variable receiving get_logger() must be named 'logger'.",
+        rationale=(
+            "A single canonical name eliminates the _log/_logger/logger split across 90+ files. "
+            "Consistent naming makes logger call sites instantly recognizable at a glance "
+            "and removes ambiguity about module-level binding conventions."
+        ),
+        exemptions=frozenset(),
+        severity="error",
     ),
 )
 

--- a/tests/arch/test_ast_rules.py
+++ b/tests/arch/test_ast_rules.py
@@ -1,4 +1,4 @@
-"""Architectural enforcement: AST-based visitor rules (ARCH-001 through ARCH-007).
+"""Architectural enforcement: AST-based visitor rules (ARCH-001 through ARCH-009).
 
 Rules enforced here (compile-time, no execution required):
   1. No print() calls in production code
@@ -8,6 +8,8 @@ Rules enforced here (compile-time, no execution required):
   5. get_logger() must be called with __name__
   6. No f-string interpolation of sensitive variables in logger positional args
   7. Exhaustive TerminationReason dispatch (match/case + assert_never)
+  8. No raw .pid attribute passed to start_linux_tracing()
+  9. get_logger() result must be bound to variable named 'logger'
 
 Note: `import logging` and `logging.getLogger()` are enforced by ruff TID251
 at pre-commit time (see pyproject.toml [tool.ruff.lint.flake8-tidy-imports]).
@@ -575,6 +577,28 @@ def test_get_logger_no_bind() -> None:
             )
             return
     pytest.fail("get_logger() function not found in core/logging.py")
+
+
+def test_logger_variable_name_violation_underscore_log(tmp_path: Path) -> None:
+    f = tmp_path / "bad.py"
+    f.write_text("from autoskillit.core import get_logger\n_log = get_logger(__name__)\n")
+    violations = _scan(f)
+    assert any(v.rule_id == "ARCH-009" for v in violations)
+
+
+def test_logger_variable_name_violation_underscore_logger(tmp_path: Path) -> None:
+    f = tmp_path / "bad.py"
+    f.write_text("from autoskillit.core import get_logger\n_logger = get_logger(__name__)\n")
+    violations = _scan(f)
+    assert any(v.rule_id == "ARCH-009" for v in violations)
+
+
+def test_logger_variable_name_accepts_logger(tmp_path: Path) -> None:
+    f = tmp_path / "good.py"
+    f.write_text("from autoskillit.core import get_logger\nlogger = get_logger(__name__)\n")
+    violations = _scan(f)
+    arch009_violations = [v for v in violations if v.rule_id == "ARCH-009"]
+    assert not arch009_violations
 
 
 # ── Kill-path structural guards (1f) ─────────────────────────────────────────

--- a/tests/arch/test_registry.py
+++ b/tests/arch/test_registry.py
@@ -94,6 +94,7 @@ def test_rule_registry_completeness() -> None:
             "ARCH-006",
             "ARCH-007",
             "ARCH-008",
+            "ARCH-009",
         }
     )
     actual_ids = frozenset(rule_ids)

--- a/tests/cli/test_installed_plugins_file.py
+++ b/tests/cli/test_installed_plugins_file.py
@@ -87,21 +87,12 @@ def test_remove_is_noop_when_file_absent(tmp_path: Path) -> None:
 
 def test_installed_plugins_read_logs_on_json_error(tmp_path: Path) -> None:
     """_read() emits a WARNING log when installed_plugins.json contains invalid JSON."""
-    import logging
+    import structlog.testing
 
     p = tmp_path / "installed_plugins.json"
     p.write_text("{invalid json}")
 
-    # caplog is unreliable under xdist when structlog's autouse fixture intercepts the
-    # handler chain. Attach a handler directly to the specific logger instead.
-    captured: list[logging.LogRecord] = []
-    handler = logging.Handler()
-    handler.emit = captured.append  # type: ignore[assignment]
-    logger = logging.getLogger("autoskillit.cli._installed_plugins")  # noqa: TID251
-    logger.addHandler(handler)
-    try:
+    with structlog.testing.capture_logs() as cap_logs:
         result = InstalledPluginsFile(p).get_plugins()
-    finally:
-        logger.removeHandler(handler)
     assert result == {}
-    assert any("installed_plugins" in r.getMessage().lower() for r in captured)
+    assert any("installed_plugins" in entry.get("event", "").lower() for entry in cap_logs)

--- a/tests/config/test_packs_config.py
+++ b/tests/config/test_packs_config.py
@@ -41,21 +41,14 @@ class TestPacksConfig:
         assert config.packs.enabled == []
 
     def test_load_config_unknown_pack_in_packs_enabled_logs_warning(self, tmp_path) -> None:
-        import logging
+        import structlog.testing
 
         from autoskillit.config import load_config
 
         config_dir = tmp_path / ".autoskillit"
         config_dir.mkdir()
         (config_dir / "config.yaml").write_text("packs:\n  enabled:\n    - nonexistent-pack\n")
-        captured: list[logging.LogRecord] = []
-        handler = logging.Handler()
-        handler.emit = captured.append  # type: ignore[assignment]
-        logger = logging.getLogger("autoskillit.config.settings")  # noqa: TID251
-        logger.addHandler(handler)
-        try:
+        with structlog.testing.capture_logs() as cap_logs:
             config = load_config(tmp_path)
-        finally:
-            logger.removeHandler(handler)
         assert config.packs.enabled == ["nonexistent-pack"]  # preserved as-is
-        assert any("nonexistent-pack" in r.getMessage() for r in captured)
+        assert any("nonexistent-pack" in str(entry) for entry in cap_logs)

--- a/tests/config/test_packs_config.py
+++ b/tests/config/test_packs_config.py
@@ -51,4 +51,4 @@ class TestPacksConfig:
         with structlog.testing.capture_logs() as cap_logs:
             config = load_config(tmp_path)
         assert config.packs.enabled == ["nonexistent-pack"]  # preserved as-is
-        assert any("nonexistent-pack" in str(entry) for entry in cap_logs)
+        assert any("nonexistent-pack" in entry.get("event", "") for entry in cap_logs)

--- a/tests/config/test_subsets_config.py
+++ b/tests/config/test_subsets_config.py
@@ -104,7 +104,7 @@ class TestSubsetsConfig:
         with structlog.testing.capture_logs() as cap_logs:
             cfg = load_config(tmp_path)
         assert cfg.subsets.disabled == ["totally-unknown-category"]  # preserved as-is
-        assert any("totally-unknown-category" in str(entry) for entry in cap_logs)
+        assert any("totally-unknown-category" in entry.get("event", "") for entry in cap_logs)
 
     def test_load_config_known_disabled_category_no_warning(self, tmp_path, caplog) -> None:
         import logging

--- a/tests/config/test_subsets_config.py
+++ b/tests/config/test_subsets_config.py
@@ -94,27 +94,17 @@ class TestSubsetsConfig:
     # T4 — Unknown category warning, no crash
 
     def test_load_config_unknown_disabled_category_logs_warning_not_crash(self, tmp_path) -> None:
-        import logging
+        import structlog.testing
 
         config_dir = tmp_path / ".autoskillit"
         config_dir.mkdir()
         (config_dir / "config.yaml").write_text(
             "subsets:\n  disabled:\n    - totally-unknown-category\n"
         )
-        # Attach a handler directly to the logger to capture warnings reliably.
-        # caplog is unreliable here because the structlog capture_logs() autouse
-        # fixture can intercept the handler chain under xdist worker ordering.
-        captured: list[logging.LogRecord] = []
-        handler = logging.Handler()
-        handler.emit = captured.append  # type: ignore[assignment]
-        logger = logging.getLogger("autoskillit.config.settings")  # noqa: TID251
-        logger.addHandler(handler)
-        try:
+        with structlog.testing.capture_logs() as cap_logs:
             cfg = load_config(tmp_path)
-        finally:
-            logger.removeHandler(handler)
         assert cfg.subsets.disabled == ["totally-unknown-category"]  # preserved as-is
-        assert any("totally-unknown-category" in r.getMessage() for r in captured)
+        assert any("totally-unknown-category" in str(entry) for entry in cap_logs)
 
     def test_load_config_known_disabled_category_no_warning(self, tmp_path, caplog) -> None:
         import logging

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -140,7 +140,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _init_helpers.py — evict_direct_mcp_entry write-back to ~/.claude.json (co-owned)
     ("src/autoskillit/cli/_init_helpers.py", 395),
     # _installed_plugins.py — installed_plugins.json (co-owned with Claude plugin system)
-    ("src/autoskillit/cli/_installed_plugins.py", 72),
+    ("src/autoskillit/cli/_installed_plugins.py", 71),
     # _marketplace.py — marketplace.json (co-owned)
     ("src/autoskillit/cli/_marketplace.py", 92),
     # _marketplace.py — hooks.json (co-owned)

--- a/tests/server/test_tools_load_recipe.py
+++ b/tests/server/test_tools_load_recipe.py
@@ -167,7 +167,7 @@ class TestLoadRecipeTools:
                 "autoskillit.recipe._api.run_semantic_rules",
                 side_effect=ValueError("injected crash"),
             ),
-            patch("autoskillit.recipe._api._logger") as mock_logger,
+            patch("autoskillit.recipe._api.logger") as mock_logger,
         ):
             result = json.loads(await load_recipe(name="test"))
 

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -99,7 +99,7 @@ def test_structlog_does_not_write_to_stdout_in_tests(capsys):
     writes to sys.stdout. The autouse _structlog_to_null fixture must intercept
     all log output before it reaches stdout.
     """
-    from autoskillit.execution.quota import _log as quota_log
+    from autoskillit.execution.quota import logger as quota_log
 
     quota_log.warning("test_sentinel_should_not_reach_stdout", probe=True)
     captured = capsys.readouterr()


### PR DESCRIPTION
## Summary

Standardize all 23 non-conforming module-level logger variable declarations from `_log` (15 files) and `_logger` (8 files) to `logger`, concurrently migrating 2 of those files (`config/settings.py` and `cli/_installed_plugins.py`) from raw `logging.getLogger` to `get_logger`. Add ARCH-009 to `ArchitectureViolationVisitor` to enforce the naming convention at test-time and prevent regression.

The ARCH-009 rule fires on any `visit_Assign` node where the right-hand side is a `get_logger()` call and the left-hand side variable name is not `logger`. The rule is added to `tests/arch/_rules.py::RULES` and wired into `tests/arch/_helpers.py`.

Files that use `logging.getLogger` (not `get_logger`) with `# noqa: TID251` exemptions are handled differently:
- `core/_version_snapshot.py` — L0 bootstrap module; rename `_logger` → `logger` but keep `logging.getLogger` and `# noqa: TID251` intact (ARCH-009 does not fire on `logging.getLogger` calls, only on `get_logger` calls).
- `config/settings.py` — migrate fully to `get_logger`, removing the TID251 exemption.
- `cli/_installed_plugins.py` — migrate fully to `get_logger`, removing the TID251 exemption.

## Architecture Impact

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 55, 'rankSpacing': 75, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;

    subgraph L3 ["L3 — APPLICATION"]
        direction LR
        CLI["● cli/<br/>━━━━━━━━━━<br/>_doctor · _fleet · _installed_plugins<br/>_onboarding · _serve_guard · _terminal<br/>(6 files modified)"]
        SERVER["● server/<br/>━━━━━━━━━━<br/>_session_type.py"]
    end

    subgraph L2 ["L2 — BUSINESS LOGIC"]
        direction LR
        RECIPE["● recipe/<br/>━━━━━━━━━━<br/>__init__ · _api<br/>experiment_type_registry · rules_actions<br/>(4 files modified)"]
        FLEET["● fleet/<br/>━━━━━━━━━━<br/>state.py"]
    end

    subgraph L1 ["L1 — SERVICES / INFRASTRUCTURE"]
        direction LR
        PLANNER["● planner/<br/>━━━━━━━━━━<br/>compiler · merge · validation<br/>(3 files modified)"]
        EXEC["● execution/<br/>━━━━━━━━━━<br/>ci · github · merge_queue<br/>quota · remote_resolver<br/>(5 files modified)"]
        WORKSPACE["● workspace/<br/>━━━━━━━━━━<br/>clone_registry.py"]
        CONFIG["● config/<br/>━━━━━━━━━━<br/>settings.py"]
    end

    subgraph L0 ["L0 — FOUNDATION"]
        CORE["● core/<br/>━━━━━━━━━━<br/>_version_snapshot.py<br/>HIGH FAN-IN (8 dependents)"]
    end

    HOOK_REG["hook_registry<br/>━━━━━━━━━━<br/>HOOK_REGISTRY<br/>(context — unmodified)"]

    %% VALID DOWNWARD DEPENDENCIES %%
    CLI -->|"imports core.*"| CORE
    CLI -->|"_doctor imports"| CONFIG
    CLI -->|"_doctor imports"| EXEC
    CLI -->|"_doctor imports"| HOOK_REG
    SERVER -->|"imports core.*"| CORE
    RECIPE -->|"imports core.*"| CORE
    FLEET -->|"imports core.*"| CORE
    PLANNER -->|"imports core.*"| CORE
    EXEC -->|"imports core.*"| CORE
    WORKSPACE -->|"imports core.*"| CORE
    CONFIG -->|"imports core.*"| CORE

    %% INTRA-LAYER (L1 execution internal) %%
    EXEC -->|"ci, merge_queue<br/>→ github (intra-layer)"| EXEC

    %% PLANNER INTERNAL %%
    PLANNER -->|"compiler → validation<br/>(intra-layer)"| PLANNER

    %% RECIPE INTERNAL %%
    RECIPE -->|"__init__ aggregates<br/>all submodules (intra-layer)"| RECIPE

    %% CLASS ASSIGNMENTS %%
    class CLI,SERVER cli;
    class RECIPE,FLEET phase;
    class PLANNER,EXEC,WORKSPACE,CONFIG handler;
    class CORE stateNode;
    class HOOK_REG integration;
```

### Operational Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph CLI ["● CLI ENTRY POINTS"]
        direction TB
        DOCTOR["● autoskillit doctor<br/>━━━━━━━━━━<br/>28 health checks<br/>MCP · hooks · config · version · fleet<br/>--json flag"]
        SERVE["● autoskillit serve<br/>━━━━━━━━━━<br/>MCP server + signal guard<br/>SIGTERM/SIGINT/SIGHUP → clean lifespan"]
        FLEET_DISPATCH["● fleet dispatch<br/>━━━━━━━━━━<br/>Free-flow fleet session<br/>Blocked in leaf / Claude Code"]
        FLEET_CAMPAIGN["● fleet campaign name<br/>━━━━━━━━━━<br/>--resume id<br/>Run named campaign recipe"]
        FLEET_LIST["● fleet list<br/>━━━━━━━━━━<br/>Available campaign recipes"]
        FLEET_STATUS["● fleet status<br/>━━━━━━━━━━<br/>--cleanup --reap --dry-run<br/>--watch --json"]
    end

    subgraph Config ["● CONFIGURATION (read-only)"]
        direction TB
        SETTINGS["● AutomationConfig<br/>━━━━━━━━━━<br/>dynaconf layered resolution:<br/>pkg defaults → user → project<br/>→ secrets → AUTOSKILLIT_* env"]
        VERSION_SNAP["● _version_snapshot<br/>━━━━━━━━━━<br/>autoskillit + Claude CLI versions<br/>install type · installed plugins<br/>lru_cache — process-scoped"]
    end

    subgraph Integration ["● EXECUTION / INTEGRATION"]
        direction TB
        REMOTE["● remote_resolver<br/>━━━━━━━━━━<br/>upstream > origin precedence<br/>async subprocess · 15s timeout"]
        GITHUB["● DefaultGitHubFetcher<br/>━━━━━━━━━━<br/>REST: issues/PRs/labels<br/>github_headers() · label cache<br/>≥1s between mutating calls"]
        CI["● DefaultCIWatcher<br/>━━━━━━━━━━<br/>GitHub Actions 3-phase poll<br/>ETag cache · exponential backoff"]
        MQ["● DefaultMergeQueueWatcher<br/>━━━━━━━━━━<br/>GraphQL queue poll<br/>stall recovery · auto-merge toggle"]
        QUOTA["● QuotaStatus<br/>━━━━━━━━━━<br/>GET /api/oauth/usage<br/>short/long window thresholds<br/>~/.claude/.credentials.json"]
    end

    subgraph State ["● STATE TRACKING (read/write)"]
        direction TB
        CAMP_STATE["● CampaignState<br/>━━━━━━━━━━<br/>DispatchRecord lifecycle<br/>pending→running→success/fail/interrupted<br/>.autoskillit/temp/dispatches/"]
        CLONE_REG["● CloneRegistry<br/>━━━━━━━━━━<br/>clone-cleanup-registry.json<br/>fcntl locking · deferred batch delete<br/>owner = CAMPAIGN_ID / KITCHEN_SESSION_ID"]
    end

    subgraph Planner ["● PLANNER PIPELINE"]
        direction LR
        MERGE_PLAN["● merge_files()<br/>━━━━━━━━━━<br/>Tier JSON aggregation<br/>fcntl concurrent-safe"]
        VALIDATE_PLAN["● validate_plan()<br/>━━━━━━━━━━<br/>DAG cycles · completeness<br/>sizing bounds · duplicates"]
        COMPILE_PLAN["● compile_plan()<br/>━━━━━━━━━━<br/>Topo-sort WPs<br/>GitHub issue MD bodies"]
    end

    subgraph Recipe ["● RECIPE PIPELINE"]
        direction TB
        EXP_TYPES["● ExperimentTypeSpec<br/>━━━━━━━━━━<br/>recipes/experiment-types/<br/>user overrides at .autoskillit/"]
        RULES_ACT["● rules_actions<br/>━━━━━━━━━━<br/>4 @semantic_rule validators:<br/>stop · route · terminal · quality"]
        LOAD_VAL["● load_and_validate()<br/>━━━━━━━━━━<br/>Sub-recipe compose<br/>mtime cache · contract + staleness check"]
    end

    subgraph Server ["● SERVER"]
        direction TB
        SESSION_TYPE["● _session_type.py<br/>━━━━━━━━━━<br/>FastMCP tag visibility:<br/>fleet / orchestrator / leaf<br/>HEADLESS env + AUTOSKILLIT_L2_TOOL_TAGS"]
    end

    subgraph Artifacts ["OUTPUT ARTIFACTS (write-only)"]
        direction TB
        PLAN_OUT["plan.json · plan.md<br/>━━━━━━━━━━<br/>milestones.json · manifest.json"]
        VALID_OUT["validation.json<br/>━━━━━━━━━━<br/>pass/fail verdict + findings"]
        QUOTA_CACHE["Quota Cache<br/>━━━━━━━━━━<br/>~/.claude/autoskillit_quota_cache.json<br/>versioned JSON"]
        DIAG_LOG["Session Diagnostics<br/>━━━━━━━━━━<br/>~/.local/share/autoskillit/logs/<br/>sessions.jsonl"]
    end

    subgraph Tasks ["TASK COMMANDS"]
        direction TB
        TEST_CHECK["task test-check<br/>━━━━━━━━━━<br/>TEST_RESULT=PASS/FAIL<br/>automation-safe"]
        TEST_ALL["task test-all<br/>━━━━━━━━━━<br/>4 parallel workers<br/>temp/test-*.txt"]
        SYNC_VER["task sync-versions<br/>━━━━━━━━━━<br/>pyproject.toml → all files"]
    end

    %% CONFIG → INTEGRATION %%
    SETTINGS --> CI
    SETTINGS --> GITHUB
    SETTINGS --> MQ
    SETTINGS --> QUOTA

    %% CLI → CONFIG %%
    DOCTOR --> SETTINGS
    DOCTOR --> VERSION_SNAP

    %% CLI → STATE %%
    FLEET_CAMPAIGN --> CAMP_STATE
    FLEET_STATUS --> CAMP_STATE
    FLEET_STATUS --> CLONE_REG

    %% CLI → SERVER %%
    SERVE --> SESSION_TYPE

    %% INTEGRATION CHAIN %%
    REMOTE --> GITHUB
    GITHUB --> CI
    GITHUB --> MQ
    QUOTA --> QUOTA_CACHE

    %% PLANNER FLOW %%
    MERGE_PLAN --> VALIDATE_PLAN
    VALIDATE_PLAN --> VALID_OUT
    VALIDATE_PLAN --> COMPILE_PLAN
    COMPILE_PLAN --> PLAN_OUT

    %% RECIPE FLOW %%
    EXP_TYPES --> LOAD_VAL
    RULES_ACT --> LOAD_VAL
    SESSION_TYPE --> LOAD_VAL

    %% VERSION → DIAG %%
    VERSION_SNAP --> DIAG_LOG

    %% CLASS ASSIGNMENTS %%
    class DOCTOR,SERVE,FLEET_DISPATCH,FLEET_CAMPAIGN,FLEET_LIST,FLEET_STATUS cli;
    class SETTINGS,VERSION_SNAP phase;
    class REMOTE,GITHUB,CI,MQ integration;
    class QUOTA detector;
    class CAMP_STATE,CLONE_REG stateNode;
    class MERGE_PLAN,VALIDATE_PLAN,COMPILE_PLAN handler;
    class EXP_TYPES,RULES_ACT,LOAD_VAL handler;
    class SESSION_TYPE handler;
    class PLAN_OUT,VALID_OUT,QUOTA_CACHE,DIAG_LOG output;
    class TEST_CHECK,TEST_ALL,SYNC_VER phase;
```

Closes #1422

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-1422-20260427-232440-634104/.autoskillit/temp/make-plan/logger_convention_standardization_plan_2026-04-27_000001.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 113 | 16.2k | 524.2k | 51.5k | 1 | 6m 36s |
| verify | 180 | 17.7k | 1.1M | 57.5k | 1 | 4m 40s |
| implement | 384 | 16.3k | 2.2M | 53.6k | 1 | 6m 17s |
| fix | 540 | 26.7k | 4.1M | 142.6k | 2 | 14m 54s |
| prepare_pr | 60 | 6.7k | 200.2k | 29.7k | 1 | 1m 52s |
| run_arch_lenses | 2.0k | 16.1k | 319.3k | 104.9k | 2 | 5m 44s |
| compose_pr | 59 | 5.5k | 199.1k | 29.8k | 1 | 1m 37s |
| **Total** | 3.3k | 105.2k | 8.7M | 469.7k | | 41m 43s |