### PR TITLE
CI Watcher head_sha Mismatch — Safety Net + API Param Fix

### DIFF
--- a/src/autoskillit/execution/ci.py
+++ b/src/autoskillit/execution/ci.py
@@ -180,16 +180,10 @@ class DefaultCIWatcher:
         }
         if scope.workflow:
             params["workflow_id"] = scope.workflow
-        if scope.head_sha:
-            params["head_sha"] = scope.head_sha
         if scope.event:
             params["event"] = scope.event
 
         data = await self._get_with_etag(client, headers, url, params)
-
-        # SHA is a content-addressable identifier — time is irrelevant when identity is known
-        if scope.head_sha:
-            return list(data.get("workflow_runs", []))
 
         runs = []
         for run in data.get("workflow_runs", []):
@@ -219,8 +213,6 @@ class DefaultCIWatcher:
         }
         if scope.workflow:
             params["workflow_id"] = scope.workflow
-        if scope.head_sha:
-            params["head_sha"] = scope.head_sha
         if scope.event:
             params["event"] = scope.event
 
@@ -325,10 +317,15 @@ class DefaultCIWatcher:
                         r for r in completed if _validate_run_matches_scope(r, scope)
                     ]
                     if not valid_completed:
+                        found_shas = list(
+                            {r.get("head_sha") for r in completed if r.get("head_sha")}
+                        )
                         logger.warning(
                             "ci_watcher_scope_mismatch",
                             count=len(completed),
                             scope=str(scope),
+                            expected_sha=scope.head_sha,
+                            found_shas=found_shas,
                         )
                     else:
                         run = valid_completed[0]

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -752,7 +752,7 @@ steps:
       - when: "${{ result.max_exceeded }} == true"
         route: check_active_trigger_loop
       - route: ci_watch
-    on_failure: escalate_stop_no_ci
+    on_failure: check_ci_already_passed
     optional_context_refs:
       - ci_loop_count
     note: >
@@ -771,9 +771,9 @@ steps:
       active_trigger_count: "${{ result.next_iteration }}"
     on_result:
       - when: "${{ result.max_exceeded }} == true"
-        route: escalate_stop_no_ci
+        route: check_ci_already_passed
       - route: trigger_ci_actively
-    on_failure: escalate_stop_no_ci
+    on_failure: check_ci_already_passed
     optional_context_refs:
       - active_trigger_count
     note: >
@@ -788,15 +788,38 @@ steps:
       cwd: "${{ context.work_dir }}"
       step_name: "trigger_ci_actively"
     on_success: ci_watch
-    on_failure: escalate_stop_no_ci
+    on_failure: check_ci_already_passed
     retries: 1
-    on_exhausted: escalate_stop_no_ci
+    on_exhausted: check_ci_already_passed
     note: >
       Active CI trigger remediation: closes and reopens the PR to force GitHub
       webhook re-delivery. This re-creates the pull_request event and the
       refs/pull/N/merge ref (if the PR is mergeable). Routes back to ci_watch
       for one final attempt. If the close/reopen fails or the subsequent
       ci_watch still returns no_runs, escalates to escalate_stop_no_ci.
+
+  check_ci_already_passed:
+    tool: run_cmd
+    with:
+      cmd: >-
+        gh pr view '${{ context.pr_number }}' --json statusCheckRollup
+        --jq '.statusCheckRollup | if length == 0 then "false" elif
+        all(.state == "SUCCESS" or .state == "NEUTRAL" or .state == "SKIPPED")
+        then "true" else "false" end'
+      cwd: "${{ context.work_dir }}"
+      step_name: "check_ci_already_passed"
+    on_result:
+      - when: "${{ result.stdout | trim }} == true"
+        route: check_repo_merge_state
+      - route: escalate_stop_no_ci
+    on_failure: escalate_stop_no_ci
+    skip_when_false: "inputs.open_pr"
+    note: >
+      Safety net before terminal escalation: checks if CI already passed
+      despite the watcher failing to observe it (e.g. post-force-push SHA
+      staleness). Uses statusCheckRollup as the authoritative signal.
+      Routes to merge queue gate if all checks are SUCCESS/NEUTRAL/SKIPPED;
+      otherwise falls through to the terminal stop.
 
   escalate_stop_no_ci:
     action: stop

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -734,7 +734,7 @@ steps:
       - when: "${{ result.max_exceeded }} == true"
         route: check_active_trigger_loop
       - route: ci_watch
-    on_failure: escalate_stop_no_ci
+    on_failure: check_ci_already_passed
     optional_context_refs:
       - ci_loop_count
     note: >
@@ -753,9 +753,9 @@ steps:
       active_trigger_count: "${{ result.next_iteration }}"
     on_result:
       - when: "${{ result.max_exceeded }} == true"
-        route: escalate_stop_no_ci
+        route: check_ci_already_passed
       - route: trigger_ci_actively
-    on_failure: escalate_stop_no_ci
+    on_failure: check_ci_already_passed
     optional_context_refs:
       - active_trigger_count
     note: >
@@ -770,15 +770,38 @@ steps:
       cwd: "${{ context.work_dir }}"
       step_name: "trigger_ci_actively"
     on_success: ci_watch
-    on_failure: escalate_stop_no_ci
+    on_failure: check_ci_already_passed
     retries: 1
-    on_exhausted: escalate_stop_no_ci
+    on_exhausted: check_ci_already_passed
     note: >
       Active CI trigger remediation: closes and reopens the PR to force GitHub
       webhook re-delivery. This re-creates the pull_request event and the
       refs/pull/N/merge ref (if the PR is mergeable). Routes back to ci_watch
       for one final attempt. If the close/reopen fails or the subsequent
       ci_watch still returns no_runs, escalates to escalate_stop_no_ci.
+
+  check_ci_already_passed:
+    tool: run_cmd
+    with:
+      cmd: >-
+        gh pr view '${{ context.pr_number }}' --json statusCheckRollup
+        --jq '.statusCheckRollup | if length == 0 then "false" elif
+        all(.state == "SUCCESS" or .state == "NEUTRAL" or .state == "SKIPPED")
+        then "true" else "false" end'
+      cwd: "${{ context.work_dir }}"
+      step_name: "check_ci_already_passed"
+    on_result:
+      - when: "${{ result.stdout | trim }} == true"
+        route: check_repo_merge_state
+      - route: escalate_stop_no_ci
+    on_failure: escalate_stop_no_ci
+    skip_when_false: "inputs.open_pr"
+    note: >
+      Safety net before terminal escalation: checks if CI already passed
+      despite the watcher failing to observe it (e.g. post-force-push SHA
+      staleness). Uses statusCheckRollup as the authoritative signal.
+      Routes to merge queue gate if all checks are SUCCESS/NEUTRAL/SKIPPED;
+      otherwise falls through to the terminal stop.
 
   escalate_stop_no_ci:
     action: stop

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -732,7 +732,7 @@ steps:
       - when: "${{ result.max_exceeded }} == true"
         route: check_active_trigger_loop
       - route: ci_watch
-    on_failure: escalate_stop_no_ci
+    on_failure: check_ci_already_passed
     optional_context_refs:
       - ci_loop_count
     note: >
@@ -751,9 +751,9 @@ steps:
       active_trigger_count: "${{ result.next_iteration }}"
     on_result:
       - when: "${{ result.max_exceeded }} == true"
-        route: escalate_stop_no_ci
+        route: check_ci_already_passed
       - route: trigger_ci_actively
-    on_failure: escalate_stop_no_ci
+    on_failure: check_ci_already_passed
     optional_context_refs:
       - active_trigger_count
     note: >
@@ -768,15 +768,38 @@ steps:
       cwd: "${{ context.work_dir }}"
       step_name: "trigger_ci_actively"
     on_success: ci_watch
-    on_failure: escalate_stop_no_ci
+    on_failure: check_ci_already_passed
     retries: 1
-    on_exhausted: escalate_stop_no_ci
+    on_exhausted: check_ci_already_passed
     note: >
       Active CI trigger remediation: closes and reopens the PR to force GitHub
       webhook re-delivery. This re-creates the pull_request event and the
       refs/pull/N/merge ref (if the PR is mergeable). Routes back to ci_watch
       for one final attempt. If the close/reopen fails or the subsequent
       ci_watch still returns no_runs, escalates to escalate_stop_no_ci.
+
+  check_ci_already_passed:
+    tool: run_cmd
+    with:
+      cmd: >-
+        gh pr view '${{ context.pr_number }}' --json statusCheckRollup
+        --jq '.statusCheckRollup | if length == 0 then "false" elif
+        all(.state == "SUCCESS" or .state == "NEUTRAL" or .state == "SKIPPED")
+        then "true" else "false" end'
+      cwd: "${{ context.work_dir }}"
+      step_name: "check_ci_already_passed"
+    on_result:
+      - when: "${{ result.stdout | trim }} == true"
+        route: check_repo_merge_state
+      - route: escalate_stop_no_ci
+    on_failure: escalate_stop_no_ci
+    skip_when_false: "inputs.open_pr"
+    note: >
+      Safety net before terminal escalation: checks if CI already passed
+      despite the watcher failing to observe it (e.g. post-force-push SHA
+      staleness). Uses statusCheckRollup as the authoritative signal.
+      Routes to merge queue gate if all checks are SUCCESS/NEUTRAL/SKIPPED;
+      otherwise falls through to the terminal stop.
 
   escalate_stop_no_ci:
     action: stop

--- a/tests/execution/test_ci.py
+++ b/tests/execution/test_ci.py
@@ -564,33 +564,6 @@ async def test_ci_etag_stores_on_200(httpx_mock):
     assert requests[1].headers.get("if-none-match") == '"abc123"'
 
 
-# ---------------------------------------------------------------------------
-# SHA-aware filter bypass — immunity tests
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.anyio
-async def test_fetch_completed_runs_sha_bypasses_time_filter(httpx_mock):
-    """When scope.head_sha is set, stale runs ARE returned (SHA = identity)."""
-    stale_time = (datetime.now(UTC) - timedelta(minutes=30)).isoformat()
-    httpx_mock.add_response(
-        json=_runs_response(_run(run_id=42, head_sha="sha123", updated_at=stale_time)),
-    )
-    watcher = DefaultCIWatcher(token="tok")
-
-    async with httpx.AsyncClient() as client:
-        runs = await watcher._fetch_completed_runs(
-            client,
-            watcher._headers(),
-            "owner/repo",
-            "main",
-            scope=CIRunScope(head_sha="sha123"),
-            cutoff_dt=datetime.now(UTC) - timedelta(seconds=120),
-        )
-    assert len(runs) == 1
-    assert runs[0]["id"] == 42
-
-
 @pytest.mark.anyio
 async def test_fetch_completed_runs_no_sha_rejects_stale(httpx_mock):
     """When scope.head_sha is NOT set, stale runs are filtered out."""

--- a/tests/execution/test_ci.py
+++ b/tests/execution/test_ci.py
@@ -135,7 +135,7 @@ async def test_lookback_finds_completed_failed_run():
 
 @pytest.mark.anyio
 async def test_lookback_filters_by_head_sha():
-    """When scope.head_sha is provided, the API filters server-side."""
+    """Client-side scope.head_sha still filters via _validate_run_matches_scope."""
     watcher = DefaultCIWatcher(token="tok")
     matching_run = _run(run_id=222, head_sha="abc123")
     watcher._fetch_completed_runs = AsyncMock(  # type: ignore[method-assign]
@@ -150,7 +150,7 @@ async def test_lookback_filters_by_head_sha():
         timeout_seconds=60,
     )
     assert result["run_id"] == 222
-    # Verify scope.head_sha was passed to the API call
+    # scope.head_sha is still passed through to _fetch_completed_runs
     call_kwargs = watcher._fetch_completed_runs.call_args
     assert call_kwargs[0][4].head_sha == "abc123"  # positional arg: scope
 
@@ -167,6 +167,33 @@ async def test_lookback_without_head_sha_matches_any():
     result = await watcher.wait("feature-x", repo="owner/repo", timeout_seconds=60)
     assert result["run_id"] == 333
     assert result["conclusion"] == "success"
+
+
+@pytest.mark.anyio
+async def test_scope_mismatch_log_includes_found_shas():
+    """ci_watcher_scope_mismatch warning includes expected_sha and found_shas."""
+    watcher = DefaultCIWatcher(token="tok")
+    stale_run = _run(run_id=999, head_sha="old-sha", conclusion="success")
+    watcher._fetch_completed_runs = AsyncMock(  # type: ignore[method-assign]
+        return_value=[stale_run]
+    )
+    watcher._fetch_active_runs = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
+    import structlog.testing
+
+    with structlog.testing.capture_logs() as cap:
+        await watcher.wait(
+            "feature-x",
+            repo="owner/repo",
+            scope=CIRunScope(head_sha="new-sha"),
+            timeout_seconds=1,
+        )
+
+    mismatch_events = [e for e in cap if e.get("event") == "ci_watcher_scope_mismatch"]
+    assert mismatch_events, "Expected ci_watcher_scope_mismatch warning to be logged"
+    evt = mismatch_events[0]
+    assert evt.get("expected_sha") == "new-sha"
+    assert "old-sha" in (evt.get("found_shas") or [])
 
 
 @pytest.mark.anyio

--- a/tests/execution/test_ci.py
+++ b/tests/execution/test_ci.py
@@ -150,7 +150,6 @@ async def test_lookback_filters_by_head_sha():
         timeout_seconds=60,
     )
     assert result["run_id"] == 222
-    # scope.head_sha is still passed through to _fetch_completed_runs
     call_kwargs = watcher._fetch_completed_runs.call_args
     assert call_kwargs[0][4].head_sha == "abc123"  # positional arg: scope
 

--- a/tests/execution/test_ci_params.py
+++ b/tests/execution/test_ci_params.py
@@ -88,23 +88,44 @@ async def test_completed_runs_always_sends_branch(httpx_mock):
 
 
 @pytest.mark.anyio
-async def test_completed_runs_sends_head_sha(httpx_mock):
-    """When scope.head_sha is set, head_sha must appear in API params."""
-    import httpx
-
-    httpx_mock.add_response(json={"workflow_runs": []})
+async def test_completed_runs_omits_head_sha_from_params(httpx_mock):
+    """_fetch_completed_runs must NOT include head_sha as a query param."""
+    httpx_mock.add_response(
+        json={"workflow_runs": []},
+        headers={"ETag": '"abc"'},
+    )
     watcher = DefaultCIWatcher(token="tok")
     async with httpx.AsyncClient() as client:
         await watcher._fetch_completed_runs(
             client,
             watcher._headers(),
             "owner/repo",
-            "main",
-            scope=CIRunScope(head_sha="abc123"),
-            cutoff_dt=datetime.now(UTC) - timedelta(seconds=300),
+            "feature-x",
+            CIRunScope(head_sha="abc123"),
+            cutoff_dt=None,
         )
     req = httpx_mock.get_requests()[0]
-    assert httpx.URL(str(req.url)).params["head_sha"] == "abc123"
+    assert "head_sha" not in req.url.params
+
+
+@pytest.mark.anyio
+async def test_active_runs_omits_head_sha_from_params(httpx_mock):
+    """_fetch_active_runs must NOT include head_sha as a query param."""
+    httpx_mock.add_response(
+        json={"workflow_runs": []},
+        headers={"ETag": '"xyz"'},
+    )
+    watcher = DefaultCIWatcher(token="tok")
+    async with httpx.AsyncClient() as client:
+        await watcher._fetch_active_runs(
+            client,
+            watcher._headers(),
+            "owner/repo",
+            "feature-x",
+            CIRunScope(head_sha="abc123"),
+        )
+    req = httpx_mock.get_requests()[0]
+    assert "head_sha" not in req.url.params
 
 
 # ---------------------------------------------------------------------------

--- a/tests/recipe/test_check_ci_already_passed_routing.py
+++ b/tests/recipe/test_check_ci_already_passed_routing.py
@@ -1,0 +1,77 @@
+"""Tests verifying the check_ci_already_passed safety net step in CI watch recipes."""
+
+import pytest
+from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+RECIPE_NAMES = ["implementation", "remediation", "implementation-groups"]
+
+
+@pytest.fixture(params=RECIPE_NAMES)
+def recipe(request):
+    return load_recipe(builtin_recipes_dir() / f"{request.param}.yaml")
+
+
+def test_check_ci_already_passed_step_exists(recipe):
+    """New safety net step is present in each recipe."""
+    assert "check_ci_already_passed" in recipe.steps
+
+
+def test_check_ci_already_passed_routes_to_merge_state_on_success(recipe):
+    """stdout == 'true' routes to check_repo_merge_state."""
+    step = recipe.steps["check_ci_already_passed"]
+    assert step.on_result is not None
+    success_routes = [
+        c.route
+        for c in (step.on_result.conditions or [])
+        if c.when and "true" in c.when
+    ]
+    assert "check_repo_merge_state" in success_routes
+
+
+def test_check_ci_already_passed_fallthrough_routes_to_escalate(recipe):
+    """Default (non-matching) on_result condition routes to escalate_stop_no_ci."""
+    step = recipe.steps["check_ci_already_passed"]
+    assert step.on_result is not None
+    conditions = step.on_result.conditions or []
+    fallthrough_routes = [c.route for c in conditions if not c.when]
+    assert "escalate_stop_no_ci" in fallthrough_routes
+
+
+def test_check_ci_already_passed_on_failure_routes_to_escalate(recipe):
+    """on_failure routes to escalate_stop_no_ci (gh CLI failure)."""
+    step = recipe.steps["check_ci_already_passed"]
+    assert step.on_failure == "escalate_stop_no_ci"
+
+
+def test_check_ci_already_passed_uses_run_cmd(recipe):
+    """Step uses run_cmd tool (shell invocation of gh CLI)."""
+    step = recipe.steps["check_ci_already_passed"]
+    assert step.tool == "run_cmd"
+
+
+def test_check_ci_already_passed_references_pr_number(recipe):
+    """Step command references context.pr_number."""
+    step = recipe.steps["check_ci_already_passed"]
+    assert "context.pr_number" in step.with_args.get("cmd", "")
+
+
+def test_check_ci_already_passed_has_skip_when_false(recipe):
+    """Step only runs when inputs.open_pr is set (no PR context -> no-op)."""
+    step = recipe.steps["check_ci_already_passed"]
+    assert step.skip_when_false == "inputs.open_pr"
+
+
+def test_no_direct_escalate_stop_no_ci_callers_except_safety_net(recipe):
+    """Only check_ci_already_passed and escalate_stop_no_ci itself reference escalate_stop_no_ci."""
+    EXCLUDED = {"check_ci_already_passed", "escalate_stop_no_ci"}
+    for name, step in recipe.steps.items():
+        if name in EXCLUDED:
+            continue
+        direct_routes = {step.on_success, step.on_failure, step.on_exhausted}
+        for cond in (step.on_result.conditions if step.on_result else []) or []:
+            direct_routes.add(cond.route)
+        assert "escalate_stop_no_ci" not in direct_routes, (
+            f"Step '{name}' still routes directly to escalate_stop_no_ci"
+        )

--- a/tests/recipe/test_check_ci_already_passed_routing.py
+++ b/tests/recipe/test_check_ci_already_passed_routing.py
@@ -1,6 +1,7 @@
 """Tests verifying the check_ci_already_passed safety net step in CI watch recipes."""
 
 import pytest
+
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 
 pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
@@ -23,9 +24,7 @@ def test_check_ci_already_passed_routes_to_merge_state_on_success(recipe):
     step = recipe.steps["check_ci_already_passed"]
     assert step.on_result is not None
     success_routes = [
-        c.route
-        for c in (step.on_result.conditions or [])
-        if c.when and "true" in c.when
+        c.route for c in (step.on_result.conditions or []) if c.when and "true" in c.when
     ]
     assert "check_repo_merge_state" in success_routes
 

--- a/tests/recipe/test_check_ci_already_passed_routing.py
+++ b/tests/recipe/test_check_ci_already_passed_routing.py
@@ -63,13 +63,14 @@ def test_check_ci_already_passed_has_skip_when_false(recipe):
 
 
 def test_no_direct_escalate_stop_no_ci_callers_except_safety_net(recipe):
-    """Only check_ci_already_passed and escalate_stop_no_ci itself reference escalate_stop_no_ci."""
+    """Only check_ci_already_passed and escalate_stop_no_ci itself reference
+    escalate_stop_no_ci."""
     EXCLUDED = {"check_ci_already_passed", "escalate_stop_no_ci"}
     for name, step in recipe.steps.items():
         if name in EXCLUDED:
             continue
         direct_routes = {step.on_success, step.on_failure, step.on_exhausted}
-        for cond in (step.on_result.conditions if step.on_result else []) or []:
+        for cond in step.on_result.conditions if step.on_result else []:
             direct_routes.add(cond.route)
         assert "escalate_stop_no_ci" not in direct_routes, (
             f"Step '{name}' still routes directly to escalate_stop_no_ci"


### PR DESCRIPTION
## Summary

The CI watcher returns `no_runs` after force-pushes (rebases and `auto_trigger` empty commits) because `head_sha` filtering matches against SHAs that no longer exist on the branch. This PR implements the two highest-impact fixes from Issue #1412:

- **Part A**: Insert a `check_ci_already_passed` safety net step before the terminal `escalate_stop_no_ci` in all 3 recipe YAMLs. Uses `gh pr view --json statusCheckRollup` to detect CI-passed state regardless of SHA staleness. Redirects all 5 existing callers through the new gate.

- **Part B**: Remove `head_sha` from server-side API params in `_fetch_completed_runs` and `_fetch_active_runs`. This makes scope-mismatch failures visible via the existing `ci_watcher_scope_mismatch` warning (previously silenced by the API returning zero results), and enhances the warning to report found vs. expected SHAs.

Part C (recency-based SHA relaxation) is deferred as optional.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 52, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START(["START<br/>recipe: ci_watch step"])
    TERM_STOP(["STOP<br/>escalate_stop_no_ci"])
    TERM_MERGE(["CONTINUE<br/>check_repo_merge_state"])
    TERM_CONFLICT(["BRANCH<br/>detect_ci_conflict"])

    %% ── RECIPE LAYER ─────────────────────────────── %%
    subgraph RecipeLayer ["Recipe Layer — CI Watch Orchestration (implementation / remediation / implementation-groups)"]
        direction TB

        CI_WATCH["● ci_watch<br/>━━━━━━━━━━<br/>tool: wait_for_ci<br/>branch: context.merge_target<br/>timeout_seconds: 600<br/>skip_when_false: inputs.open_pr"]

        RESULT_ROUTE{"conclusion?"}

        HANDLE_NO_CI["handle_no_ci_runs<br/>━━━━━━━━━━<br/>auto-trigger retry loop<br/>exhausts after max attempts"]

        CHECK_CI["★ check_ci_already_passed<br/>━━━━━━━━━━<br/>tool: run_cmd<br/>gh pr view statusCheckRollup<br/>skip_when_false: inputs.open_pr"]

        ALL_PASS{"all checks<br/>SUCCESS / NEUTRAL<br/>/ SKIPPED?"}
    end

    %% ── DEFAULTCIWATCHER.WAIT() ───────────────────── %%
    subgraph WatcherAlgo ["● DefaultCIWatcher.wait() — 3-Phase Algorithm (execution/ci.py)"]
        direction TB

        subgraph P1 ["Phase 1: Look-back (race-condition guard)"]
            direction TB
            FETCH_COMP["● _fetch_completed_runs<br/>━━━━━━━━━━<br/>GET /repos/{owner}/actions/runs<br/>params: branch, status=completed<br/>● head_sha REMOVED from params<br/>event / workflow included if set"]
            VALIDATE["● _validate_run_matches_scope<br/>━━━━━━━━━━<br/>Client-side filter: event + head_sha<br/>Defense-in-depth vs server params"]
            MISMATCH{"valid completed<br/>run found?"}
        end

        subgraph P2 ["Phase 2: Poll for active runs"]
            direction TB
            FETCH_ACTIVE["● _fetch_active_runs<br/>━━━━━━━━━━<br/>GET /repos/{owner}/actions/runs<br/>params: branch, per_page=1<br/>● head_sha REMOVED from params"]
            FOUND_ACTIVE{"active run<br/>found &<br/>scope matches?"}
            RECHECK["Re-check completed<br/>━━━━━━━━━━<br/>Anchored cutoff_dt prevents<br/>clock-drift run loss"]
            RECHECK_VALID{"valid completed<br/>run in<br/>re-check?"}
            BACKOFF2["_jittered_sleep<br/>━━━━━━━━━━<br/>attempt 0: 5-10s<br/>attempt 1: 10-20s<br/>attempt 2+: 15-30s"]
            DEADLINE2{"deadline<br/>exceeded?"}
        end

        subgraph P3 ["Phase 3: Wait for found run"]
            direction TB
            POLL["_poll_run_status<br/>━━━━━━━━━━<br/>GET /runs/{run_id}<br/>ETag conditional requests"]
            COMPLETED{"status ==<br/>completed?"}
            BACKOFF3["_jittered_sleep<br/>━━━━━━━━━━<br/>Same backoff bands"]
            DEADLINE3{"deadline<br/>exceeded?"}
            FETCH_JOBS["_fetch_failed_jobs<br/>━━━━━━━━━━<br/>GET /runs/{id}/jobs<br/>Only if conclusion in<br/>FAILED_CONCLUSIONS"]
        end
    end

    %% ── FLOW: Recipe → Watcher ─────────────────────── %%
    START --> CI_WATCH
    CI_WATCH --> FETCH_COMP

    %% ── FLOW: Phase 1 ──────────────────────────────── %%
    FETCH_COMP --> VALIDATE
    VALIDATE --> MISMATCH
    MISMATCH -->|"yes — scope matches"| FETCH_JOBS
    MISMATCH -->|"no runs or SHA/event mismatch<br/>(logs ci_watcher_scope_mismatch<br/>with expected_sha + found_shas)"| FETCH_ACTIVE

    %% ── FLOW: Phase 2 ──────────────────────────────── %%
    FETCH_ACTIVE --> FOUND_ACTIVE
    FOUND_ACTIVE -->|"yes"| POLL
    FOUND_ACTIVE -->|"no"| RECHECK
    RECHECK --> RECHECK_VALID
    RECHECK_VALID -->|"yes"| FETCH_JOBS
    RECHECK_VALID -->|"no"| BACKOFF2
    BACKOFF2 --> DEADLINE2
    DEADLINE2 -->|"no — keep polling"| FETCH_ACTIVE
    DEADLINE2 -->|"yes → conclusion: no_runs"| RESULT_ROUTE

    %% ── FLOW: Phase 3 ──────────────────────────────── %%
    POLL --> COMPLETED
    COMPLETED -->|"yes"| FETCH_JOBS
    COMPLETED -->|"no"| BACKOFF3
    BACKOFF3 --> DEADLINE3
    DEADLINE3 -->|"no — keep waiting"| POLL
    DEADLINE3 -->|"yes → conclusion: timed_out<br/>with hint to re-call wait_for_ci"| RESULT_ROUTE

    %% ── FLOW: Result → Recipe routing ────────────────── %%
    FETCH_JOBS --> RESULT_ROUTE
    RESULT_ROUTE -->|"success"| TERM_MERGE
    RESULT_ROUTE -->|"timed_out"| CI_WATCH
    RESULT_ROUTE -->|"failure / cancelled / other"| TERM_CONFLICT
    RESULT_ROUTE -->|"no_runs"| HANDLE_NO_CI

    %% ── FLOW: Safety net path ─────────────────────── %%
    HANDLE_NO_CI -->|"loop exhausted<br/>or on_failure"| CHECK_CI
    CHECK_CI --> ALL_PASS
    ALL_PASS -->|"yes — CI completed<br/>since watcher ran"| TERM_MERGE
    ALL_PASS -->|"no — or gh CLI failure"| TERM_STOP

    %% ── CLASS ASSIGNMENTS ──────────────────────────── %%
    class START,TERM_STOP,TERM_MERGE,TERM_CONFLICT terminal;
    class CI_WATCH,HANDLE_NO_CI handler;
    class CHECK_CI newComponent;
    class FETCH_COMP,FETCH_ACTIVE,VALIDATE,RECHECK,POLL,FETCH_JOBS phase;
    class MISMATCH,FOUND_ACTIVE,RECHECK_VALID,COMPLETED stateNode;
    class DEADLINE2,DEADLINE3,RESULT_ROUTE,ALL_PASS stateNode;
    class BACKOFF2,BACKOFF3 detector;
```

### Error/Resilience Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    WAIT_FOR_CI(["wait_for_ci<br/>Recipe Entry"])

    subgraph CIWatcher ["● DefaultCIWatcher.wait() — Never-Raises Contract (execution/ci.py)"]
        direction TB
        RESOLVE["_resolve_repo()<br/>━━━━━━━━━━<br/>git remote → owner/repo"]
        GATE_REPO{"repo<br/>resolved?"}
        NO_REPO["no owner/repo<br/>━━━━━━━━━━<br/>conclusion=no_runs<br/>error field set"]

        subgraph Phase1 ["PHASE 1: Look-back (race-condition guard)"]
            LOOKBACK["_fetch_completed_runs()<br/>━━━━━━━━━━<br/>status=completed, last N sec<br/>ETag conditional GET"]
            SCOPE_VALIDATE["● _validate_run_matches_scope()<br/>━━━━━━━━━━<br/>Client-side defense-in-depth<br/>head_sha removed from API params"]
            SCOPE_MISS["ci_watcher_scope_mismatch<br/>━━━━━━━━━━<br/>warning log: expected vs found SHAs<br/>fall through to Phase 2"]
            LOOKBACK_HIT["Look-back hit<br/>━━━━━━━━━━<br/>Runs matched scope → return early"]
        end

        subgraph Phase2 ["PHASE 2: Poll for Active Runs (exponential backoff + jitter)"]
            POLL["_fetch_active_runs()<br/>━━━━━━━━━━<br/>Bands: 5-10s / 10-20s / 15-30s"]
            POLL_SCOPE["● _validate_run_matches_scope()<br/>━━━━━━━━━━<br/>Client-side filter on active runs"]
            RECHECK["Re-check completed runs<br/>━━━━━━━━━━<br/>Race window: finished between phases"]
            TIMEOUT_POLL["ci_watcher_no_runs<br/>━━━━━━━━━━<br/>conclusion=no_runs<br/>scope_used dict in response"]
        end

        subgraph Phase3 ["PHASE 3: Wait for Found Run"]
            POLL_RUN["_poll_run_status()<br/>━━━━━━━━━━<br/>Poll single run until status=completed"]
            TIMEOUT_RUN["ci_watcher_timeout<br/>━━━━━━━━━━<br/>conclusion=timed_out<br/>hint: call again to continue"]
        end

        subgraph ErrorBoundary ["OUTER ERROR BOUNDARY"]
            HTTP_ERR["httpx.HTTPStatusError<br/>━━━━━━━━━━<br/>conclusion=error<br/>HTTP status + truncated body"]
            REQ_ERR["httpx.RequestError<br/>━━━━━━━━━━<br/>conclusion=error<br/>Request error string"]
        end

        FETCH_JOBS["_fetch_failed_jobs()<br/>━━━━━━━━━━<br/>Only when conclusion in<br/>FAILED_CONCLUSIONS"]
    end

    subgraph RecipeLayer ["Recipe CI Error Recovery Chain (●  implementation / remediation / implementation-groups)"]
        direction TB
        CI_WATCH["● ci_watch step<br/>━━━━━━━━━━<br/>wait_for_ci, timeout=600s<br/>captures ci_conclusion + ci_failed_jobs"]
        NO_RUNS_HANDLER["handle_no_ci_runs<br/>━━━━━━━━━━<br/>Re-derive ci_event from PR"]
        CI_LOOP["check_ci_loop<br/>━━━━━━━━━━<br/>Iteration guard, max=2"]
        TRIGGER_LOOP["check_active_trigger_loop<br/>━━━━━━━━━━<br/>gh pr close+reopen to trigger CI"]
        SAFETY_NET["● check_ci_already_passed<br/>━━━━━━━━━━<br/>gh pr view --json statusCheckRollup<br/>skip_when_false: inputs.open_pr"]
        TIMED_OUT_LOOP["timed_out self-loop<br/>━━━━━━━━━━<br/>Re-enters ci_watch"]
    end

    subgraph Terminals ["TERMINAL STATES"]
        T_SUCCESS(["SUCCESS<br/>check_repo_merge_state"])
        T_FAIL(["FAILURE<br/>detect_ci_conflict"])
        T_STOP(["STOP<br/>escalate_stop_no_ci"])
        T_ERROR(["ERROR<br/>conclusion=error dict"])
    end

    NEW_TESTS["★ test_check_ci_already_passed_routing.py<br/>━━━━━━━━━━<br/>9 tests: step exists, routes to<br/>check_repo_merge_state on true,<br/>escalate_stop_no_ci on fallthrough/failure,<br/>verified across all 3 recipes"]

    %% Entry %%
    WAIT_FOR_CI --> RESOLVE
    RESOLVE --> GATE_REPO
    GATE_REPO -->|"no"| NO_REPO
    GATE_REPO -->|"yes"| LOOKBACK

    %% Phase 1 %%
    LOOKBACK --> SCOPE_VALIDATE
    SCOPE_VALIDATE -->|"valid scope match"| LOOKBACK_HIT
    SCOPE_VALIDATE -->|"sha/event mismatch"| SCOPE_MISS
    SCOPE_MISS -->|"skip, fall through"| POLL
    LOOKBACK_HIT --> FETCH_JOBS
    LOOKBACK -->|"no completed runs"| POLL

    %% Phase 2 %%
    POLL --> POLL_SCOPE
    POLL_SCOPE -->|"valid active run"| Phase3
    POLL_SCOPE -->|"no valid active"| RECHECK
    RECHECK -->|"completed found"| FETCH_JOBS
    RECHECK -->|"deadline exceeded"| TIMEOUT_POLL

    %% Phase 3 %%
    POLL_RUN -->|"status=completed"| FETCH_JOBS
    POLL_RUN -->|"deadline exceeded"| TIMEOUT_RUN

    %% Failed jobs → terminal %%
    FETCH_JOBS -->|"success/neutral/skipped"| T_SUCCESS
    FETCH_JOBS -->|"failure/timed_out/cancelled"| T_FAIL

    %% Error boundary %%
    HTTP_ERR --> T_ERROR
    REQ_ERR --> T_ERROR
    NO_REPO --> T_ERROR
    TIMEOUT_RUN --> T_ERROR

    %% Recipe layer %%
    TIMEOUT_POLL --> CI_WATCH
    CI_WATCH -->|"success"| T_SUCCESS
    CI_WATCH -->|"no_runs"| NO_RUNS_HANDLER
    CI_WATCH -->|"timed_out"| TIMED_OUT_LOOP
    TIMED_OUT_LOOP -->|"retry"| CI_WATCH
    CI_WATCH -->|"failure / on_failure"| T_FAIL

    NO_RUNS_HANDLER --> CI_LOOP
    CI_LOOP -->|"budget remaining"| CI_WATCH
    CI_LOOP -->|"budget exceeded / on_failure"| TRIGGER_LOOP
    TRIGGER_LOOP -->|"budget exceeded / failure / on_failure"| SAFETY_NET

    SAFETY_NET -->|"stdout == true"| T_SUCCESS
    SAFETY_NET -->|"otherwise / on_failure"| T_STOP

    NEW_TESTS -.->|"verifies routing contracts"| SAFETY_NET

    %% Class assignments %%
    class WAIT_FOR_CI terminal;
    class RESOLVE,LOOKBACK,POLL,POLL_RUN,FETCH_JOBS handler;
    class SCOPE_VALIDATE,POLL_SCOPE detector;
    class SCOPE_MISS,TIMEOUT_POLL gap;
    class HTTP_ERR,REQ_ERR integration;
    class CI_WATCH,NO_RUNS_HANDLER,CI_LOOP,TRIGGER_LOOP phase;
    class SAFETY_NET,TIMED_OUT_LOOP output;
    class RECHECK,ETAG,GATE_REPO stateNode;
    class T_SUCCESS,T_FAIL,T_STOP,T_ERROR terminal;
    class NEW_TESTS newComponent;
    class NO_REPO,TIMEOUT_RUN gap;
```

Closes #1412

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260428-070821-560004/.autoskillit/temp/make-plan/ci_watcher_head_sha_mismatch_plan_2026-04-28_000000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 171 | 21.5k | 974.9k | 67.8k | 1 | 11m 9s |
| verify | 713 | 9.2k | 221.4k | 53.8k | 1 | 6m 54s |
| implement | 316 | 19.5k | 2.1M | 64.1k | 1 | 5m 29s |
| fix | 192 | 6.0k | 999.5k | 49.2k | 1 | 5m 37s |
| prepare_pr | 60 | 5.1k | 204.3k | 31.6k | 1 | 1m 37s |
| run_arch_lenses | 138 | 17.8k | 609.1k | 104.9k | 2 | 6m 29s |
| compose_pr | 67 | 6.9k | 246.1k | 32.4k | 1 | 1m 55s |
| **Total** | 1.7k | 86.0k | 5.3M | 403.8k | | 39m 14s |