### PR TITLE
Rectify: Kitchen-Open Guard Over-Scoped — Blocks Updates and Auto-Checks Across Unrelated Sessions

### DIFF
--- a/src/autoskillit/cli/_marketplace.py
+++ b/src/autoskillit/cli/_marketplace.py
@@ -165,7 +165,12 @@ def install(*, scope: str = "user") -> bool:
     from autoskillit.core import _InstallLock
 
     with _InstallLock():
-        _clear_plugin_cache()
+        from autoskillit.core import any_kitchen_open
+
+        if any_kitchen_open(project_path=str(Path.cwd())):
+            print("Kitchen open for this project — skipping plugin cache clear.")
+        else:
+            _clear_plugin_cache()
 
         # Regenerate hooks.json from the canonical registry with absolute paths
         hooks_json_path = pkg_root() / "hooks" / "hooks.json"

--- a/src/autoskillit/cli/_update.py
+++ b/src/autoskillit/cli/_update.py
@@ -41,8 +41,11 @@ def run_update_command(home: Path | None = None) -> None:
 
     from autoskillit.core import any_kitchen_open
 
-    if any_kitchen_open():
-        print("A kitchen is currently open. Close it or wait for the pipeline to finish.")
+    if any_kitchen_open(project_path=str(Path.cwd())):
+        print(
+            "A kitchen is currently open for this project. "
+            "Close it or wait for the pipeline to finish.",
+        )
         raise SystemExit(1)
 
     info = detect_install()

--- a/src/autoskillit/cli/_update_checks.py
+++ b/src/autoskillit/cli/_update_checks.py
@@ -690,7 +690,11 @@ def run_update_checks(home: Path | None = None) -> None:
 
     from autoskillit.core import any_kitchen_open  # noqa: PLC0415
 
-    if any_kitchen_open():
+    if any_kitchen_open(project_path=str(Path.cwd())):
+        print(
+            "Skipping update check: a kitchen is open for this project. "
+            "Run 'autoskillit update' manually after the pipeline finishes.",
+        )
         return
 
     _skip_env: dict[str, str] = {

--- a/src/autoskillit/core/_plugin_cache.py
+++ b/src/autoskillit/core/_plugin_cache.py
@@ -237,7 +237,7 @@ def clear_kitchens_for_pid(pid: int) -> None:
         fh.close()
 
 
-def any_kitchen_open() -> bool:
+def any_kitchen_open(project_path: str | None = None) -> bool:
     akp = _active_kitchens_path()
     lock = _active_kitchens_lock()
     if not akp.exists():
@@ -264,6 +264,8 @@ def any_kitchen_open() -> bool:
                 write_versioned_json(akp, {"kitchens": survivors}, schema_version=_SCHEMA_VERSION)
             except OSError as exc:
                 logger.warning("any_kitchen_open: failed to persist pruned kitchens: %s", exc)
+        if project_path is not None:
+            return any(entry.get("project_path") == project_path for entry in survivors)
         return len(survivors) > 0
     finally:
         fh.close()

--- a/src/autoskillit/core/_plugin_cache.py
+++ b/src/autoskillit/core/_plugin_cache.py
@@ -265,7 +265,10 @@ def any_kitchen_open(project_path: str | None = None) -> bool:
             except OSError as exc:
                 logger.warning("any_kitchen_open: failed to persist pruned kitchens: %s", exc)
         if project_path is not None:
-            return any(entry.get("project_path") == project_path for entry in survivors)
+            return any(
+                entry.get("project_path") is None or entry.get("project_path") == project_path
+                for entry in survivors
+            )
         return len(survivors) > 0
     finally:
         fh.close()

--- a/src/autoskillit/recipes/diagrams/implementation.md
+++ b/src/autoskillit/recipes/diagrams/implementation.md
@@ -1,158 +1,31 @@
-<!-- autoskillit-recipe-hash: sha256:dcb5955bae118041160b3100f4837bb735caadfcd1aad6cb40b1ba346a11902f -->
+<!-- autoskillit-recipe-hash: sha256:d47cab45ad7b2d7b64bb3dd723cdbbf2cbc98dceb71ceea8b533646da81bbdda -->
 <!-- autoskillit-diagram-format: v7 -->
 # implementation
 
-```mermaid
-flowchart TD
-    S0[clone]
-    S1[capture_base_sha]
-    S0 --> S1
-    S2[get_issue_title]
-    S1 --> S2
-    S3[claim_issue]
-    S2 --> S3
-    S4[compute_branch]
-    S3 --> S4
-    S5[create_branch]
-    S4 --> S5
-    S6[push_merge_target]
-    S5 --> S6
-    S7[plan]
-    S6 --> S7
-    S8[review]
-    S7 --> S8
-    S9[verify]
-    S8 --> S9
-    S10[implement]
-    S9 --> S10
-    S11[retry_worktree]
-    S10 --> S11
-    S12[test]
-    S11 --> S12
-    S13[commit_guard]
-    S12 --> S13
-    S14[merge]
-    S13 --> S14
-    S15[push]
-    S14 --> S15
-    S16[fix]
-    S15 --> S16
-    S17[next_or_done]
-    S16 --> S17
-    S18[audit_impl]
-    S17 --> S18
-    S19[remediate]
-    S18 --> S19
-    S20[prepare_pr]
-    S19 --> S20
-    S21[run_arch_lenses]
-    S20 --> S21
-    S22[compose_pr]
-    S21 --> S22
-    S23[extract_pr_number]
-    S22 --> S23
-    S24[annotate_pr_diff]
-    S23 --> S24
-    S25[review_pr]
-    S24 --> S25
-    S26[resolve_review]
-    S25 --> S26
-    S27[re_push_review]
-    S26 --> S27
-    S28[check_review_loop]
-    S27 --> S28
-    S29[check_repo_ci_event]
-    S28 --> S29
-    S30[check_pr_state]
-    S29 --> S30
-    S31[ci_watch]
-    S30 --> S31
-    S32[handle_no_ci_runs]
-    S31 --> S32
-    S33[check_ci_loop]
-    S32 --> S33
-    S34[check_active_trigger_loop]
-    S33 --> S34
-    S35[trigger_ci_actively]
-    S34 --> S35
-    S36[escalate_stop_no_ci]
-    S35 --> S36
-    S37[check_repo_merge_state]
-    S36 --> S37
-    S38[route_queue_mode]
-    S37 --> S38
-    S39[enqueue_to_queue]
-    S38 --> S39
-    S40[verify_queue_enrollment]
-    S39 --> S40
-    S41[wait_for_queue]
-    S40 --> S41
-    S42[reenroll_stalled_pr]
-    S41 --> S42
-    S43[check_stall_loop]
-    S42 --> S43
-    S44[check_eject_limit]
-    S43 --> S44
-    S45[queue_ejected_fix]
-    S44 --> S45
-    S46[resolve_queue_merge_conflicts]
-    S45 --> S46
-    S47[re_push_queue_fix]
-    S46 --> S47
-    S48[ci_watch_post_queue_fix]
-    S47 --> S48
-    S49[reenter_merge_queue]
-    S48 --> S49
-    S50[reenter_merge_queue_cheap]
-    S49 --> S50
-    S51[direct_merge]
-    S50 --> S51
-    S52[wait_for_direct_merge]
-    S51 --> S52
-    S53[direct_merge_conflict_fix]
-    S52 --> S53
-    S54[resolve_direct_merge_conflicts]
-    S53 --> S54
-    S55[re_push_direct_fix]
-    S54 --> S55
-    S56[redirect_merge]
-    S55 --> S56
-    S57[immediate_merge]
-    S56 --> S57
-    S58[wait_for_immediate_merge]
-    S57 --> S58
-    S59[immediate_merge_conflict_fix]
-    S58 --> S59
-    S60[resolve_immediate_merge_conflicts]
-    S59 --> S60
-    S61[re_push_immediate_fix]
-    S60 --> S61
-    S62[remerge_immediate]
-    S61 --> S62
-    S63[diagnose_ci]
-    S62 --> S63
-    S64[resolve_ci]
-    S63 --> S64
-    S65[pre_resolve_rebase]
-    S64 --> S65
-    S66[re_push]
-    S65 --> S66
-    S67[detect_ci_conflict]
-    S66 --> S67
-    S68[ci_conflict_fix]
-    S67 --> S68
-    S69[release_issue_success]
-    S68 --> S69
-    S70[register_clone_unconfirmed]
-    S69 --> S70
-    S71[release_issue_failure]
-    S70 --> S71
-    S72[register_clone_success]
-    S71 --> S72
-    S73[register_clone_failure]
-    S72 --> S73
-    S74[done]
-    S73 --> S74
-    S75[escalate_stop]
-    S74 --> S75
+```
+      clone → get_issue_title → claim_issue → compute_branch
+      |
+      +-- create_branch (optional)
+      |
+      plan
+      |
+      +-- review (optional)
+      |
+ +----+ FOR EACH PLAN PART:
+ |    |
+ |    verify → implement → test ↔ [fix on failure]
+ |    |
+ |    merge → push → next_or_done
+ |
+ +----+
+      |
+      +-- audit_impl → remediate (optional)
+      |
+      +-- [open-pr] (optional):
+      |     prepare_pr → compose_pr → review_pr → resolve_review
+      |     ci_watch → check_repo_merge_state
+      |     → [queue | direct | immediate] merge path
+      |     → diagnose_ci → resolve_ci (on CI failure)
+      |
+      release_issue_success / release_issue_failure
 ```

--- a/src/autoskillit/recipes/diagrams/implementation.md
+++ b/src/autoskillit/recipes/diagrams/implementation.md
@@ -1,31 +1,158 @@
-<!-- autoskillit-recipe-hash: sha256:d47cab45ad7b2d7b64bb3dd723cdbbf2cbc98dceb71ceea8b533646da81bbdda -->
+<!-- autoskillit-recipe-hash: sha256:dcb5955bae118041160b3100f4837bb735caadfcd1aad6cb40b1ba346a11902f -->
 <!-- autoskillit-diagram-format: v7 -->
 # implementation
 
-```
-      clone → get_issue_title → claim_issue → compute_branch
-      |
-      +-- create_branch (optional)
-      |
-      plan
-      |
-      +-- review (optional)
-      |
- +----+ FOR EACH PLAN PART:
- |    |
- |    verify → implement → test ↔ [fix on failure]
- |    |
- |    merge → push → next_or_done
- |
- +----+
-      |
-      +-- audit_impl → remediate (optional)
-      |
-      +-- [open-pr] (optional):
-      |     prepare_pr → compose_pr → review_pr → resolve_review
-      |     ci_watch → check_repo_merge_state
-      |     → [queue | direct | immediate] merge path
-      |     → diagnose_ci → resolve_ci (on CI failure)
-      |
-      release_issue_success / release_issue_failure
+```mermaid
+flowchart TD
+    S0[clone]
+    S1[capture_base_sha]
+    S0 --> S1
+    S2[get_issue_title]
+    S1 --> S2
+    S3[claim_issue]
+    S2 --> S3
+    S4[compute_branch]
+    S3 --> S4
+    S5[create_branch]
+    S4 --> S5
+    S6[push_merge_target]
+    S5 --> S6
+    S7[plan]
+    S6 --> S7
+    S8[review]
+    S7 --> S8
+    S9[verify]
+    S8 --> S9
+    S10[implement]
+    S9 --> S10
+    S11[retry_worktree]
+    S10 --> S11
+    S12[test]
+    S11 --> S12
+    S13[commit_guard]
+    S12 --> S13
+    S14[merge]
+    S13 --> S14
+    S15[push]
+    S14 --> S15
+    S16[fix]
+    S15 --> S16
+    S17[next_or_done]
+    S16 --> S17
+    S18[audit_impl]
+    S17 --> S18
+    S19[remediate]
+    S18 --> S19
+    S20[prepare_pr]
+    S19 --> S20
+    S21[run_arch_lenses]
+    S20 --> S21
+    S22[compose_pr]
+    S21 --> S22
+    S23[extract_pr_number]
+    S22 --> S23
+    S24[annotate_pr_diff]
+    S23 --> S24
+    S25[review_pr]
+    S24 --> S25
+    S26[resolve_review]
+    S25 --> S26
+    S27[re_push_review]
+    S26 --> S27
+    S28[check_review_loop]
+    S27 --> S28
+    S29[check_repo_ci_event]
+    S28 --> S29
+    S30[check_pr_state]
+    S29 --> S30
+    S31[ci_watch]
+    S30 --> S31
+    S32[handle_no_ci_runs]
+    S31 --> S32
+    S33[check_ci_loop]
+    S32 --> S33
+    S34[check_active_trigger_loop]
+    S33 --> S34
+    S35[trigger_ci_actively]
+    S34 --> S35
+    S36[escalate_stop_no_ci]
+    S35 --> S36
+    S37[check_repo_merge_state]
+    S36 --> S37
+    S38[route_queue_mode]
+    S37 --> S38
+    S39[enqueue_to_queue]
+    S38 --> S39
+    S40[verify_queue_enrollment]
+    S39 --> S40
+    S41[wait_for_queue]
+    S40 --> S41
+    S42[reenroll_stalled_pr]
+    S41 --> S42
+    S43[check_stall_loop]
+    S42 --> S43
+    S44[check_eject_limit]
+    S43 --> S44
+    S45[queue_ejected_fix]
+    S44 --> S45
+    S46[resolve_queue_merge_conflicts]
+    S45 --> S46
+    S47[re_push_queue_fix]
+    S46 --> S47
+    S48[ci_watch_post_queue_fix]
+    S47 --> S48
+    S49[reenter_merge_queue]
+    S48 --> S49
+    S50[reenter_merge_queue_cheap]
+    S49 --> S50
+    S51[direct_merge]
+    S50 --> S51
+    S52[wait_for_direct_merge]
+    S51 --> S52
+    S53[direct_merge_conflict_fix]
+    S52 --> S53
+    S54[resolve_direct_merge_conflicts]
+    S53 --> S54
+    S55[re_push_direct_fix]
+    S54 --> S55
+    S56[redirect_merge]
+    S55 --> S56
+    S57[immediate_merge]
+    S56 --> S57
+    S58[wait_for_immediate_merge]
+    S57 --> S58
+    S59[immediate_merge_conflict_fix]
+    S58 --> S59
+    S60[resolve_immediate_merge_conflicts]
+    S59 --> S60
+    S61[re_push_immediate_fix]
+    S60 --> S61
+    S62[remerge_immediate]
+    S61 --> S62
+    S63[diagnose_ci]
+    S62 --> S63
+    S64[resolve_ci]
+    S63 --> S64
+    S65[pre_resolve_rebase]
+    S64 --> S65
+    S66[re_push]
+    S65 --> S66
+    S67[detect_ci_conflict]
+    S66 --> S67
+    S68[ci_conflict_fix]
+    S67 --> S68
+    S69[release_issue_success]
+    S68 --> S69
+    S70[register_clone_unconfirmed]
+    S69 --> S70
+    S71[release_issue_failure]
+    S70 --> S71
+    S72[register_clone_success]
+    S71 --> S72
+    S73[register_clone_failure]
+    S72 --> S73
+    S74[done]
+    S73 --> S74
+    S75[escalate_stop]
+    S74 --> S75
 ```

--- a/src/autoskillit/recipes/diagrams/implementation.md
+++ b/src/autoskillit/recipes/diagrams/implementation.md
@@ -1,4 +1,4 @@
-<!-- autoskillit-recipe-hash: sha256:d47cab45ad7b2d7b64bb3dd723cdbbf2cbc98dceb71ceea8b533646da81bbdda -->
+<!-- autoskillit-recipe-hash: sha256:dcb5955bae118041160b3100f4837bb735caadfcd1aad6cb40b1ba346a11902f -->
 <!-- autoskillit-diagram-format: v7 -->
 # implementation
 

--- a/tests/arch/test_kitchen_guard_scoping.py
+++ b/tests/arch/test_kitchen_guard_scoping.py
@@ -1,0 +1,86 @@
+"""Architectural enforcement: any_kitchen_open call-site scoping and test helper isolation."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.layer("arch")]
+
+_SRC_ROOT = Path(__file__).parents[2] / "src" / "autoskillit"
+_TEST_ROOT = Path(__file__).parents[2] / "tests"
+
+# File that defines any_kitchen_open — not a call site.
+_DEFINITION_FILE = "core/_plugin_cache.py"
+
+
+def _has_project_path_kwarg(call_node: ast.Call) -> bool:
+    return any(kw.arg == "project_path" for kw in call_node.keywords)
+
+
+def _is_any_kitchen_open_call(call_node: ast.Call) -> bool:
+    func = call_node.func
+    if isinstance(func, ast.Name):
+        return func.id == "any_kitchen_open"
+    if isinstance(func, ast.Attribute):
+        return func.attr == "any_kitchen_open"
+    return False
+
+
+def test_any_kitchen_open_callers_pass_project_path() -> None:
+    violations: list[str] = []
+    for py_file in sorted(_SRC_ROOT.rglob("*.py")):
+        rel = py_file.relative_to(_SRC_ROOT)
+        if str(rel) == _DEFINITION_FILE:
+            continue
+        source = py_file.read_text(encoding="utf-8")
+        if "any_kitchen_open" not in source:
+            continue
+        tree = ast.parse(source, filename=str(py_file))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and _is_any_kitchen_open_call(node):
+                if not _has_project_path_kwarg(node):
+                    violations.append(f"{rel}:{node.lineno}")
+    assert not violations, (
+        f"any_kitchen_open called without project_path= at: {violations}. "
+        "All production callers must pass project_path to scope the guard to the current project."
+    )
+
+
+def _function_body_has_any_kitchen_open_patch(func_node: ast.FunctionDef) -> bool:
+    """Return True if the function contains monkeypatch.setattr with 'any_kitchen_open'."""
+    for node in ast.walk(func_node):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "setattr"):
+            continue
+        for arg in node.args:
+            if isinstance(arg, ast.Constant) and "any_kitchen_open" in str(arg.value):
+                return True
+    return False
+
+
+def test_setup_helpers_must_patch_any_kitchen_open() -> None:
+    helpers = [
+        (_TEST_ROOT / "cli" / "test_update_command.py", "_setup_run_update"),
+        (_TEST_ROOT / "cli" / "test_update_checks_prompt.py", "_setup_run_checks"),
+    ]
+    missing: list[str] = []
+    for file_path, func_name in helpers:
+        source = file_path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(file_path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == func_name:
+                if not _function_body_has_any_kitchen_open_patch(node):
+                    missing.append(f"{file_path.name}::{func_name}")
+                break
+        else:
+            missing.append(f"{file_path.name}::{func_name} (function not found)")
+    assert not missing, (
+        f"Test helpers do not patch any_kitchen_open: {missing}. "
+        "Add monkeypatch.setattr('autoskillit.core.any_kitchen_open', lambda **kw: False) "
+        "to prevent silent dependency on real $HOME kitchen state."
+    )

--- a/tests/arch/test_kitchen_guard_scoping.py
+++ b/tests/arch/test_kitchen_guard_scoping.py
@@ -57,9 +57,12 @@ def _function_body_has_any_kitchen_open_patch(func_node: ast.FunctionDef) -> boo
         func = node.func
         if not (isinstance(func, ast.Attribute) and func.attr == "setattr"):
             continue
-        for arg in node.args:
-            if isinstance(arg, ast.Constant) and "any_kitchen_open" in str(arg.value):
-                return True
+        if (
+            len(node.args) >= 2
+            and isinstance(node.args[1], ast.Constant)
+            and "any_kitchen_open" in str(node.args[1].value)
+        ):
+            return True
     return False
 
 

--- a/tests/arch/test_kitchen_guard_scoping.py
+++ b/tests/arch/test_kitchen_guard_scoping.py
@@ -57,10 +57,13 @@ def _function_body_has_any_kitchen_open_patch(func_node: ast.FunctionDef) -> boo
         func = node.func
         if not (isinstance(func, ast.Attribute) and func.attr == "setattr"):
             continue
+        # 2-arg string form: setattr("dotted.path.name", value) → name at args[0]
+        # 3-arg form: setattr(target, "name", value) → name at args[1]
+        name_arg_idx = 0 if len(node.args) == 2 else 1
         if (
             len(node.args) >= 2
-            and isinstance(node.args[1], ast.Constant)
-            and "any_kitchen_open" in str(node.args[1].value)
+            and isinstance(node.args[name_arg_idx], ast.Constant)
+            and "any_kitchen_open" in str(node.args[name_arg_idx].value)
         ):
             return True
     return False

--- a/tests/cli/test_cli_marketplace.py
+++ b/tests/cli/test_cli_marketplace.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import contextlib
+import subprocess
+from pathlib import Path
+
 import pytest
 
 pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
@@ -66,3 +70,54 @@ def test_upgrade_is_registered_as_cli_command():
 def test_marketplace_module_still_importable():
     """_marketplace module is still importable (not deleted)."""
     import autoskillit.cli._marketplace  # noqa: F401
+
+
+# MK-GUARD-1
+def test_install_guards_same_version_when_kitchen_open(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """install() must skip _clear_plugin_cache when a kitchen is open for the current project."""
+    from autoskillit.cli._marketplace import install
+
+    monkeypatch.delenv("CLAUDECODE", raising=False)
+    monkeypatch.setattr("autoskillit.cli._marketplace.shutil.which", lambda cmd: "/usr/bin/claude")
+    monkeypatch.setattr("autoskillit.cli._marketplace._ensure_marketplace", lambda: tmp_path)
+    monkeypatch.setattr("autoskillit.cli._marketplace._ensure_workspace_ready", lambda: None)
+
+    @contextlib.contextmanager
+    def _fake_lock():
+        yield
+
+    monkeypatch.setattr("autoskillit.core._InstallLock", _fake_lock)
+    monkeypatch.setattr("autoskillit.core.any_kitchen_open", lambda **kw: True)
+
+    clear_called: list[bool] = []
+    monkeypatch.setattr(
+        "autoskillit.cli._marketplace._clear_plugin_cache",
+        lambda: clear_called.append(True),
+    )
+    monkeypatch.setattr("autoskillit.cli._marketplace.generate_hooks_json", lambda: {})
+    monkeypatch.setattr("autoskillit.cli._marketplace.atomic_write", lambda *a, **kw: None)
+    monkeypatch.setattr("autoskillit.cli._marketplace.pkg_root", lambda: tmp_path)
+    monkeypatch.setattr(
+        "autoskillit.cli._marketplace.subprocess.run",
+        lambda *a, **kw: subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+    )
+    monkeypatch.setattr("autoskillit.cli._marketplace.evict_direct_mcp_entry", lambda *a: False)
+    monkeypatch.setattr(
+        "autoskillit.cli._marketplace.sweep_all_scopes_for_orphans", lambda *a: None
+    )
+    monkeypatch.setattr("autoskillit.cli._marketplace.sync_hooks_to_settings", lambda *a: None)
+    monkeypatch.setattr(
+        "autoskillit.cli._marketplace._user_claude_json_path", lambda: tmp_path / "claude.json"
+    )
+    monkeypatch.setattr(
+        "autoskillit.cli._hooks._claude_settings_path", lambda *a: tmp_path / "settings.json"
+    )
+    monkeypatch.setattr("autoskillit.cli._update_checks.invalidate_fetch_cache", lambda *a: None)
+
+    install()
+
+    assert not clear_called, "_clear_plugin_cache must be skipped when kitchen is open"
+    out = capsys.readouterr().out
+    assert "kitchen" in out.lower(), "install must print a notification when skipping cache clear"

--- a/tests/cli/test_cli_marketplace.py
+++ b/tests/cli/test_cli_marketplace.py
@@ -112,7 +112,7 @@ def test_install_guards_same_version_when_kitchen_open(
         "autoskillit.cli._marketplace._user_claude_json_path", lambda: tmp_path / "claude.json"
     )
     monkeypatch.setattr(
-        "autoskillit.cli._hooks._claude_settings_path", lambda *a: tmp_path / "settings.json"
+        "autoskillit.cli._claude_settings_path", lambda *a: tmp_path / "settings.json"
     )
     monkeypatch.setattr("autoskillit.cli._update_checks.invalidate_fetch_cache", lambda *a: None)
 

--- a/tests/cli/test_plugin_cache.py
+++ b/tests/cli/test_plugin_cache.py
@@ -486,3 +486,28 @@ def test_any_kitchen_open_true_for_live_pid(
 
     result = any_kitchen_open()
     assert result is True
+
+
+def test_any_kitchen_open_scoped_excludes_other_project(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from autoskillit.core._plugin_cache import any_kitchen_open, register_active_kitchen
+
+    project_a = "/project_A"
+    project_b = "/project_B"
+    register_active_kitchen("test-kitchen-007", os.getpid(), project_a)
+
+    assert any_kitchen_open(project_path=project_b) is False
+    assert any_kitchen_open(project_path=project_a) is True
+
+
+def test_any_kitchen_open_no_project_path_returns_global(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from autoskillit.core._plugin_cache import any_kitchen_open, register_active_kitchen
+
+    register_active_kitchen("test-kitchen-008", os.getpid(), "/project_A")
+
+    assert any_kitchen_open() is True

--- a/tests/cli/test_update_checks_fetch.py
+++ b/tests/cli/test_update_checks_fetch.py
@@ -540,7 +540,7 @@ def test_run_update_command_invalidates_fetch_cache(
     info = _make_stable_info()
     monkeypatch.setattr("autoskillit.cli._update.detect_install", lambda: info)
     monkeypatch.setattr("autoskillit.cli._update.terminal_guard", FakeTG)
-    monkeypatch.setattr("autoskillit.core.any_kitchen_open", lambda: False)
+    monkeypatch.setattr("autoskillit.core.any_kitchen_open", lambda **kw: False)
 
     upgrade_ok = subprocess.CompletedProcess([], returncode=0)
     install_ok = subprocess.CompletedProcess([], returncode=0)

--- a/tests/cli/test_update_checks_prompt.py
+++ b/tests/cli/test_update_checks_prompt.py
@@ -113,6 +113,8 @@ def _setup_run_checks(
     input_calls: list[str] = []
     monkeypatch.setattr("builtins.input", lambda _="": input_calls.append("called") or answer)
 
+    monkeypatch.setattr("autoskillit.core.any_kitchen_open", lambda **kw: False)
+
     return printed, input_calls
 
 
@@ -814,4 +816,28 @@ def test_all_dismissed_signals_produce_no_interactive_prompt(
     combined = " ".join(printed)
     assert "autoskillit update" in combined, (
         "All-dismissed signals must produce passive notification containing 'autoskillit update'"
+    )
+
+
+def test_run_update_checks_shows_notification_when_kitchen_open(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    printed, input_calls = _setup_run_checks(monkeypatch, tmp_path, binary_signal=True)
+    monkeypatch.setattr("autoskillit.core.any_kitchen_open", lambda **kw: True)
+
+    binary_signal_calls: list[bool] = []
+    monkeypatch.setattr(
+        "autoskillit.cli._update_checks._binary_signal",
+        lambda *a, **kw: binary_signal_calls.append(True) or None,
+    )
+
+    run_update_checks(home=tmp_path)
+
+    combined = " ".join(printed)
+    assert "kitchen" in combined.lower(), (
+        "run_update_checks must print a notification mentioning 'kitchen' when kitchen is open"
+    )
+    assert not input_calls, "run_update_checks must not prompt interactively when kitchen is open"
+    assert not binary_signal_calls, (
+        "run_update_checks must not proceed to signal checks when kitchen is open"
     )

--- a/tests/cli/test_update_command.py
+++ b/tests/cli/test_update_command.py
@@ -60,6 +60,7 @@ def _setup_run_update(
 
     monkeypatch.setattr(importlib.metadata, "version", lambda _name: new_version)
     monkeypatch.setattr("autoskillit.cli._update.perform_restart", lambda: None)
+    monkeypatch.setattr("autoskillit.core.any_kitchen_open", lambda **kw: False)
     return run_calls
 
 
@@ -294,7 +295,7 @@ def test_run_update_command_restarts_on_success(
     info = _make_info(InstallType.GIT_VCS, revision="stable")
     monkeypatch.setattr("autoskillit.cli._update.detect_install", lambda: info)
     monkeypatch.setattr("autoskillit.cli._update.terminal_guard", FakeTG)
-    monkeypatch.setattr("autoskillit.core.any_kitchen_open", lambda: False)
+    monkeypatch.setattr("autoskillit.core.any_kitchen_open", lambda **kw: False)
     monkeypatch.setattr(
         "autoskillit.cli._update.subprocess.run",
         lambda *a, **kw: subprocess.CompletedProcess([], 0),
@@ -320,4 +321,53 @@ def test_run_update_command_restarts_on_success(
     run_update_command(home=tmp_path)
     assert restart_called, (
         "run_update_command must call perform_restart() after successful upgrade"
+    )
+
+
+def test_run_update_command_blocks_when_same_project_kitchen_open(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from autoskillit.cli._update import run_update_command
+
+    monkeypatch.setattr("autoskillit.core.any_kitchen_open", lambda **kw: True)
+    with pytest.raises(SystemExit) as exc_info:
+        run_update_command(home=tmp_path)
+    assert exc_info.value.code == 1
+
+
+def test_run_update_command_passes_project_path_to_kitchen_check(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from autoskillit.cli._update import run_update_command
+
+    calls: list[dict] = []
+
+    def _spy(**kw):
+        calls.append(kw)
+        return False
+
+    info = _make_info(InstallType.GIT_VCS, revision="stable")
+    monkeypatch.setattr("autoskillit.cli._update.detect_install", lambda: info)
+    monkeypatch.setattr("autoskillit.cli._update.terminal_guard", FakeTG)
+    monkeypatch.setattr("autoskillit.core.any_kitchen_open", _spy)
+    monkeypatch.setattr(
+        "autoskillit.cli._update.subprocess.run",
+        lambda *a, **kw: subprocess.CompletedProcess([], 0),
+    )
+    monkeypatch.setattr(
+        "autoskillit.cli._update_checks._fetch_latest_version", lambda *a, **kw: "0.9.1"
+    )
+    import autoskillit as _pkg
+
+    monkeypatch.setattr(_pkg, "__version__", "0.9.0")
+    import importlib.metadata
+
+    monkeypatch.setattr(importlib.metadata, "version", lambda _name: "0.9.1")
+    monkeypatch.setattr("builtins.print", lambda *a, **kw: None)
+    monkeypatch.setattr("autoskillit.cli._update.perform_restart", lambda: None)
+
+    run_update_command(home=tmp_path)
+    assert calls, "any_kitchen_open was not called"
+    assert "project_path" in calls[0], (
+        "run_update_command must pass project_path to any_kitchen_open"
     )

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -146,7 +146,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _marketplace.py — marketplace.json (co-owned)
     ("src/autoskillit/cli/_marketplace.py", 92),
     # _marketplace.py — hooks.json (co-owned)
-    ("src/autoskillit/cli/_marketplace.py", 172),
+    ("src/autoskillit/cli/_marketplace.py", 177),
     # _update_checks.py — dismissal state file
     ("src/autoskillit/cli/_update_checks.py", 103),
     # _update_checks.py — fetch cache


### PR DESCRIPTION
## Summary

The `any_kitchen_open()` function in `core/_plugin_cache.py` was a global boolean guard that reads `~/.autoskillit/active_kitchens.json` and returns `True` if *any* live-PID kitchen entry exists across the entire machine — regardless of which project that kitchen belongs to. This blocked `autoskillit update` (hard `SystemExit(1)`) and silently suppressed startup update checks for all sessions whenever any session on any project had a kitchen open.

The fix propagates the project-scoping pattern (already present in `mcp_health_guard.py`) into `any_kitchen_open()` and all its callers, adds the missing kitchen guard to `install()`, and introduces a structural arch test (`test_kitchen_guard_scoping.py`) that AST-walks all production call sites to enforce the `project_path=` kwarg contract permanently.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([PreToolUse: open_kitchen called])
    COMPLETE([Kitchen Open — marker written])
    ERROR([Denied / Blocked])

    %% ── PHASE 1: Kitchen Open Hook ── %%
    subgraph HookPhase ["● open_kitchen_guard.py — PreToolUse Hook"]
        direction TB
        H1{"Headless<br/>session?"}
        H2{"Session type<br/>== fleet?"}
        H3{"Session type<br/>== orchestrator?"}
        H4["Write kitchen marker<br/>━━━━━━━━━━<br/>kitchen_state/{session_id}.json<br/>includes project_path"]
    end

    %% ── PHASE 2: Registry (any_kitchen_open) ── %%
    subgraph RegistryPhase ["● _plugin_cache.py — any_kitchen_open() Guard"]
        direction TB
        R1["Read ~/.autoskillit/<br/>active_kitchens.json<br/>━━━━━━━━━━<br/>fcntl LOCK_EX"]
        R2["Iterate entries<br/>━━━━━━━━━━<br/>prune dead PIDs<br/>via _pid_alive()"]
        R3{"project_path<br/>arg provided?"}
        R4{"Any entry matches<br/>project_path?"}
        R5{"Any live<br/>entry exists?"}
        R6["Write survivors back<br/>━━━━━━━━━━<br/>active_kitchens.json"]
    end
    OPEN_TRUE(["→ True: kitchen open"])
    OPEN_FALSE(["→ False: no kitchen open"])

    %% ── PHASE 3: Update Command ── %%
    subgraph UpdateCmd ["● _update.py — run_update_command()"]
        direction TB
        U1["● any_kitchen_open<br/>━━━━━━━━━━<br/>project_path=cwd"]
        U2{"Kitchen open<br/>for project?"}
        U3["Run upgrade subprocess<br/>+ autoskillit install<br/>━━━━━━━━━━<br/>SKIP_UPDATE_CHECK env set"]
        U4["Invalidate fetch cache<br/>+ perform_restart()"]
    end

    %% ── PHASE 4: Update Checks ── %%
    subgraph UpdateChecks ["● _update_checks.py — run_update_checks()"]
        direction TB
        C1{"CLAUDECODE / CI /<br/>skip env / non-TTY?"}
        C2["● any_kitchen_open<br/>━━━━━━━━━━<br/>project_path=cwd"]
        C3{"Kitchen open<br/>for project?"}
        C4["Gather 4 signals<br/>━━━━━━━━━━<br/>binary / hooks /<br/>source drift / dual-mcp"]
        C5{"Undismissed<br/>signals?"}
        C6["30s [Y/n] prompt<br/>━━━━━━━━━━<br/>timeout = silent return"]
    end

    %% ── PHASE 5: Install / Cache Clear ── %%
    subgraph InstallPhase ["● _marketplace.py — install()"]
        direction TB
        I1["● any_kitchen_open<br/>━━━━━━━━━━<br/>project_path=cwd<br/>(under _InstallLock)"]
        I2{"Kitchen open<br/>for project?"}
        I3["SKIP cache clear<br/>━━━━━━━━━━<br/>avoid disrupting<br/>running sessions"]
        I4["Clear plugin cache<br/>━━━━━━━━━━<br/>remove snapshot +<br/>installed_plugins.json entry"]
        I5["Write symlink,<br/>marketplace.json,<br/>hooks.json, settings"]
    end

    %% ── PHASE 6: Arch Test Enforcement ── %%
    subgraph ArchTest ["★ test_kitchen_guard_scoping.py — Arch Test"]
        direction TB
        T1["AST walk src/**/*.py<br/>━━━━━━━━━━<br/>find all any_kitchen_open()<br/>call sites"]
        T2{"project_path=<br/>kwarg present<br/>at every call?"}
        T3["Verify test helpers<br/>monkeypatch any_kitchen_open<br/>━━━━━━━━━━<br/>prevent real FS reads in tests"]
    end

    %% ── FLOWS ── %%

    START --> H1
    H1 -->|"yes"| H2
    H1 -->|"no"| H4
    H2 -->|"yes"| ERROR
    H2 -->|"no"| H3
    H3 -->|"no (leaf/unset)"| ERROR
    H3 -->|"yes"| H4
    H4 --> COMPLETE

    %% Registry consumed by callers %%
    COMPLETE -.->|"marker written; callers read registry"| R1
    R1 --> R2
    R2 --> R3
    R3 -->|"yes"| R4
    R3 -->|"no (global check)"| R5
    R4 -->|"match found"| R6
    R4 -->|"no match"| R6
    R5 -->|"live entry found"| R6
    R5 -->|"none"| R6
    R6 -->|"match found"| OPEN_TRUE
    R6 -->|"no match / none"| OPEN_FALSE

    %% Update command flow %%
    U1 --> U2
    U2 -->|"open"| ERROR
    U2 -->|"not open"| U3
    U3 --> U4

    %% Update checks flow %%
    C1 -->|"yes"| OPEN_FALSE
    C1 -->|"no"| C2
    C2 --> C3
    C3 -->|"open"| OPEN_TRUE
    C3 -->|"not open"| C4
    C4 --> C5
    C5 -->|"yes"| C6
    C5 -->|"all dismissed"| OPEN_FALSE

    %% Install flow %%
    I1 --> I2
    I2 -->|"open"| I3
    I2 -->|"not open"| I4
    I3 --> I5
    I4 --> I5

    %% Arch test flow %%
    T1 --> T2
    T2 -->|"all present — PASS"| T3
    T2 -->|"missing kwarg — FAIL"| ERROR

    %% CLASS ASSIGNMENTS %%
    class START,COMPLETE terminal;
    class ERROR detector;
    class H1,H2,H3 stateNode;
    class H4 handler;
    class R1,R2,R6 handler;
    class R3,R4,R5 stateNode;
    class OPEN_TRUE,OPEN_FALSE output;
    class U1,C2,I1 phase;
    class U2,C1,C3,C5,I2 stateNode;
    class U3,U4,C4,C6,I3,I4,I5 handler;
    class T1,T3 newComponent;
    class T2 detector;
```

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 65, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START([OPEN / UPDATE / INSTALL OPERATION])

    %% ── KITCHEN MARKER STATE ──────────────────────────────────────────── %%
    subgraph KitchenMarkerState ["KITCHEN MARKER STATE  (kitchen_state.py)"]
        direction TB
        KM["KitchenMarker ●<br/>━━━━━━━━━━<br/>INIT_ONLY (frozen=True)<br/>session_id · opened_at<br/>recipe_name · marker_version<br/>content_hash · composite_hash"]
        KMWrite["● write_marker()<br/>━━━━━━━━━━<br/>mkstemp + os.replace<br/>Atomic overwrite only"]
        KMRead["read_marker(session_id)<br/>━━━━━━━━━━<br/>Returns None on:<br/>missing · bad JSON · schema mismatch"]
        KMTTL["is_marker_fresh()<br/>━━━━━━━━━━<br/>TTL gate: age < 24 h<br/>Stale → treat as absent"]
        KMSweep["sweep_stale_markers()<br/>━━━━━━━━━━<br/>Deletes age ≥ 24 h<br/>or malformed files"]
    end

    %% ── ACTIVE KITCHENS REGISTRY ─────────────────────────────────────── %%
    subgraph ActiveKitchenReg ["● ACTIVE KITCHENS REGISTRY  (_plugin_cache.py)"]
        direction TB
        AKEntry["● active_kitchens.json entry<br/>━━━━━━━━━━<br/>MUTABLE (atomic rewrite)<br/>kitchen_id · pid · create_time<br/>project_path · opened_at"]
        PIDGate["_pid_alive(pid, create_time)<br/>━━━━━━━━━━<br/>os.kill probe → PermissionError<br/>→ psutil create_time ±1 s check<br/>Guards PID-reuse false positives"]
        AKOpen["● any_kitchen_open(project_path=)<br/>━━━━━━━━━━<br/>LOCK_EX flock<br/>Lazy GC: prune dead PIDs<br/>Filter: entry[project_path] == arg<br/>Returns bool (scoped to project)"]
        AKArch["★ test_kitchen_guard_scoping<br/>━━━━━━━━━━<br/>AST-scans all callers<br/>VIOLATION if project_path= absent<br/>Enforces no bare any_kitchen_open()"]
    end

    %% ── PLUGIN CACHE LIFECYCLE ───────────────────────────────────────── %%
    subgraph PluginCache ["PLUGIN CACHE LIFECYCLE  (_plugin_cache.py / _marketplace.py)"]
        direction TB
        RetCache["retiring_cache.json<br/>━━━━━━━━━━<br/>APPEND_ONLY entries<br/>version · path · retired_at"]
        RetAppend["append_retiring_entry()<br/>━━━━━━━━━━<br/>Read-append-atomic-write<br/>Never overwrites existing"]
        RetSweep["sweep_retiring_cache(grace_hours=2)<br/>━━━━━━━━━━<br/>Deletes dirs older than grace period<br/>Survivors rewritten atomically"]
        CacheClearGate["● _clear_plugin_cache() gate<br/>━━━━━━━━━━<br/>any_kitchen_open(project_path=cwd)<br/>→ True: SKIP cache clear<br/>→ False: retire old dirs + sweep"]
    end

    %% ── UPDATE CHECK STATE ───────────────────────────────────────────── %%
    subgraph UpdateCheckState ["● UPDATE CHECK STATE  (_update_checks.py / _update.py)"]
        direction TB
        DismissState["update_check.json<br/>━━━━━━━━━━<br/>MUTABLE (key-level replace)<br/>update_prompt: {dismissed_at,<br/>dismissed_version, conditions}<br/>binary_snoozed (INIT_PRESERVE)"]
        FetchCache["github_fetch_cache.json<br/>━━━━━━━━━━<br/>MUTABLE per-URL entry<br/>body · etag · cached_at<br/>installed_version (version guard)"]
        DismissExpiry["● _is_dismissed() gate<br/>━━━━━━━━━━<br/>Expired if: time window elapsed<br/>OR version upgraded<br/>OR new Signal.kind not in conditions"]
        KitchenGate["● Kitchen-scope update gate<br/>━━━━━━━━━━<br/>any_kitchen_open(project_path=cwd)<br/>_update_checks: soft skip + msg<br/>_marketplace: skip cache-clear only<br/>_update: hard SystemExit(1)"]
        UpdateSuccess["● On successful update<br/>━━━━━━━━━━<br/>pop(update_prompt)<br/>pop(binary_snoozed)<br/>invalidate_fetch_cache()<br/>perform_restart()"]
    end

    %% ── VALIDATION GATE FLOW ─────────────────────────────────────────── %%
    subgraph ValidationGates ["VALIDATION GATES (ordered)"]
        direction TB
        G1["Env / TTY guards<br/>━━━━━━━━━━<br/>CLAUDECODE · CI · SKIP_ vars<br/>stdin/stdout isatty()"]
        G2["● Project-scope kitchen guard<br/>━━━━━━━━━━<br/>any_kitchen_open(project_path=cwd)<br/>Blocks mutation when kitchen live"]
        G3["Install type guard<br/>━━━━━━━━━━<br/>LOCAL_EDITABLE · LOCAL_PATH<br/>UNKNOWN → skip unless FORCE"]
        G4["Worktree guard<br/>━━━━━━━━━━<br/>is_git_worktree(pkg_dir)<br/>→ SystemExit (no symlink from worktree)"]
        G5["PID-reuse guard<br/>━━━━━━━━━━<br/>create_time ±1 s tolerance<br/>Prevents ghost kitchen entries"]
    end

    %% ── CONNECTIONS ─────────────────────────────────────────────────── %%
    START --> G1
    G1 -->|"pass"| G2
    G2 -->|"no kitchen open<br/>(scoped to project)"| G3
    G2 -->|"kitchen OPEN → block / skip"| KitchenGate
    G3 -->|"installable type"| G4
    G4 -->|"not worktree"| KMWrite
    KMWrite --> KM
    KM --> KMRead
    KMRead --> KMTTL
    KMTTL -->|"fresh"| AKEntry
    KMTTL -->|"stale"| KMSweep

    AKEntry --> PIDGate
    PIDGate -->|"alive + create_time match"| AKOpen
    PIDGate -->|"dead / PID-reused"| G5
    G5 --> AKOpen
    AKOpen -->|"project_path= required"| AKArch
    AKOpen -->|"returns bool"| G2

    G3 -->|"cache ops allowed"| CacheClearGate
    CacheClearGate -->|"no kitchen open"| RetAppend
    RetAppend --> RetCache
    RetCache --> RetSweep

    G1 -->|"pass"| DismissState
    DismissState --> DismissExpiry
    DismissExpiry -->|"not dismissed"| FetchCache
    FetchCache -->|"update available"| KitchenGate
    KitchenGate -->|"kitchen closed"| UpdateSuccess
    UpdateSuccess --> DismissState

    %% CLASS ASSIGNMENTS %%
    class KM stateNode;
    class KMWrite,KMRead handler;
    class KMTTL,KMSweep detector;
    class AKEntry stateNode;
    class PIDGate,G5 detector;
    class AKOpen phase;
    class AKArch newComponent;
    class RetCache stateNode;
    class RetAppend,RetSweep handler;
    class CacheClearGate phase;
    class DismissState,FetchCache stateNode;
    class DismissExpiry,KitchenGate detector;
    class UpdateSuccess output;
    class G1,G2,G3,G4 detector;
    class START terminal;
```

### Operational Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 65, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    subgraph CLILayer ["CLI ENTRY POINTS"]
        direction TB
        UPDATE["● autoskillit update<br/>━━━━━━━━━━<br/>_update.py<br/>Blocks if kitchen open<br/>(project-scoped)"]
        INSTALL["● autoskillit install<br/>━━━━━━━━━━<br/>_marketplace.py<br/>Skips cache clear<br/>if kitchen open"]
        SESSION["autoskillit cook / order<br/>━━━━━━━━━━<br/>Interactive or headless<br/>Triggers startup checks"]
    end

    subgraph StartupCheck ["STARTUP UPDATE CHECK (_update_checks.py ●)"]
        direction TB
        RUN_CHECKS["● run_update_checks()<br/>━━━━━━━━━━<br/>Signals: binary · hooks · drift · dual-mcp<br/>Skips (non-fatal) if kitchen open<br/>Skips entirely: CI=1, CLAUDECODE=1,<br/>non-TTY, SKIP_UPDATE_CHECK=1"]
    end

    subgraph GuardLayer ["KITCHEN GUARD (_plugin_cache.py ●)"]
        direction TB
        ANY_KITCHEN["● any_kitchen_open(<br/>  project_path=str(Path.cwd()))<br/>━━━━━━━━━━<br/>Prunes dead PIDs on each read<br/>Scoped to current project<br/>(PR change: was global)"]
        REGISTRY["active_kitchens.json<br/>━━━━━━━━━━<br/>~/.autoskillit/<br/>PID · kitchen_id · project_path<br/>+ psutil create time<br/>(fcntl-locked)"]
    end

    subgraph StateFiles ["STATE & CACHE (read/write)"]
        direction TB
        UPDATE_STATE["update_check.json<br/>━━━━━━━━━━<br/>~/.autoskillit/<br/>update_prompt · binary_snoozed<br/>Dismissal windows: 7d / 12h"]
        GH_CACHE["github_fetch_cache.json<br/>━━━━━━━━━━<br/>~/.autoskillit/<br/>GitHub API response cache<br/>TTL 30 min · ETag-conditional"]
        KITCHEN_MARKERS["kitchen_state/{session}.json<br/>━━━━━━━━━━<br/>.autoskillit/temp/<br/>Session open marker<br/>(written by open_kitchen_guard hook)"]
    end

    subgraph ArchGuard ["ARCHITECTURE TEST (★ new)"]
        direction TB
        SCOPE_TEST["★ test_kitchen_guard_scoping.py<br/>━━━━━━━━━━<br/>AST scan: ALL any_kitchen_open callers<br/>in src/ must pass project_path=<br/>Test helpers must mock any_kitchen_open<br/>(prevents real ~/.autoskillit reads in tests)"]
    end

    %% FLOWS %%
    UPDATE -->|"SystemExit(1)<br/>if open"| ANY_KITCHEN
    INSTALL -->|"skips _clear_plugin_cache<br/>if open"| ANY_KITCHEN
    SESSION --> RUN_CHECKS
    RUN_CHECKS -->|"silent skip<br/>if open"| ANY_KITCHEN
    ANY_KITCHEN -->|"reads + prunes"| REGISTRY
    KITCHEN_MARKERS -.->|"register_active_kitchen<br/>on open_kitchen call"| REGISTRY
    RUN_CHECKS -->|"reads dismissal<br/>writes snooze"| UPDATE_STATE
    RUN_CHECKS -->|"reads cached<br/>GitHub data"| GH_CACHE
    UPDATE -->|"clears on<br/>successful upgrade"| UPDATE_STATE
    UPDATE -->|"invalidates<br/>on upgrade"| GH_CACHE

    SCOPE_TEST -.->|"enforces scoping<br/>contract at test-time"| ANY_KITCHEN

    %% CLASS ASSIGNMENTS %%
    class UPDATE,INSTALL,SESSION cli;
    class RUN_CHECKS handler;
    class ANY_KITCHEN detector;
    class REGISTRY stateNode;
    class UPDATE_STATE,GH_CACHE,KITCHEN_MARKERS output;
    class SCOPE_TEST newComponent;
```

Closes #1415

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260428-070957-123956/.autoskillit/temp/rectify/rectify_kitchen-open-guard-over-scoped_2026-04-28_143500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 77 | 25.7k | 1.5M | 85.0k | 1 | 14m 51s |
| verify | 4.1k | 11.0k | 1.2M | 55.0k | 1 | 5m 13s |
| implement | 4.1k | 33.5k | 7.2M | 127.7k | 1 | 21m 26s |
| **Total** | 8.3k | 70.2k | 9.9M | 267.8k | | 41m 31s |