### PR TITLE
Implementation Plan: Stable Display Order Registry for Bundled Recipes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,6 +213,7 @@ generic_automation_mcp/
 │   ├── __init__.py
 │   ├── contracts.py         #   Contract card generation + staleness triage
 │   ├── io.py                #   load_recipe, list_recipes, iter_steps_with_context
+│   ├── order.py             #   BUNDLED_RECIPE_ORDER — stable display order registry for Group 0 recipes
 │   ├── loader.py            #   Path-based recipe metadata utilities
 │   ├── _api.py              #   Orchestration API
 │   ├── diagrams.py          #   Flow diagram generation + staleness detection

--- a/src/autoskillit/recipe/io.py
+++ b/src/autoskillit/recipe/io.py
@@ -16,6 +16,7 @@ from autoskillit.core import (
     load_yaml,
     pkg_root,
 )
+from autoskillit.recipe.order import BUNDLED_RECIPE_ORDER
 from autoskillit.recipe.schema import (
     AUTOSKILLIT_VERSION_KEY,
     RECIPE_VERSION_KEY,
@@ -94,6 +95,16 @@ def group_rank(r: RecipeInfo) -> int:
     return 1
 
 
+def _registry_position(r: RecipeInfo) -> int:
+    """Return sort position within Group 0; 0 (no-op) for all other groups."""
+    if group_rank(r) == 0:
+        try:
+            return BUNDLED_RECIPE_ORDER.index(r.name)
+        except ValueError:
+            return len(BUNDLED_RECIPE_ORDER)
+    return 0
+
+
 def list_recipes(
     project_dir: Path,
     exclude_kinds: frozenset[RecipeKind] = frozenset(),
@@ -111,7 +122,7 @@ def list_recipes(
 
     filtered = [r for r in items if r.kind not in exclude_kinds] if exclude_kinds else items
     return LoadResult(
-        items=sorted(filtered, key=lambda r: (group_rank(r), r.name)),
+        items=sorted(filtered, key=lambda r: (group_rank(r), _registry_position(r), r.name)),
         errors=errors,
     )
 

--- a/src/autoskillit/recipe/order.py
+++ b/src/autoskillit/recipe/order.py
@@ -1,0 +1,18 @@
+"""Stable display order registry for bundled recipes.
+
+Controls the display position of bundled recipes within their group (Group 0 = Bundled
+Recipes). Recipes listed here appear first in registry order; discovered recipes whose
+names are absent sort alphabetically after the last registered entry.
+
+To add a new recipe at a specific position, insert its name here. To leave it at the
+bottom, add the YAML without touching this file.
+"""
+
+from __future__ import annotations
+
+BUNDLED_RECIPE_ORDER: list[str] = [
+    "implementation",
+    "remediation",
+    "implementation-groups",
+    "merge-prs",
+]

--- a/src/autoskillit/recipes/diagrams/implementation.md
+++ b/src/autoskillit/recipes/diagrams/implementation.md
@@ -1,162 +1,35 @@
-<!-- autoskillit-recipe-hash: sha256:fe042fe400b76dfd7d1d2d30fd316cfecd146227c75c5c2d6f00f5ae91d11c19 -->
+<!-- autoskillit-recipe-hash: sha256:9c748a039b3eb0879c8adef380464dd4e95386043f3505d73bf71202e6cd1742 -->
 <!-- autoskillit-diagram-format: v7 -->
 # implementation
 
-```mermaid
-flowchart TD
-    S0[clone]
-    S1[capture_base_sha]
-    S0 --> S1
-    S2[get_issue_title]
-    S1 --> S2
-    S3[claim_issue]
-    S2 --> S3
-    S4[compute_branch]
-    S3 --> S4
-    S5[create_branch]
-    S4 --> S5
-    S6[push_merge_target]
-    S5 --> S6
-    S7[plan]
-    S6 --> S7
-    S8[review]
-    S7 --> S8
-    S9[verify]
-    S8 --> S9
-    S10[implement]
-    S9 --> S10
-    S11[retry_worktree]
-    S10 --> S11
-    S12[test]
-    S11 --> S12
-    S13[commit_guard]
-    S12 --> S13
-    S14[merge]
-    S13 --> S14
-    S15[push]
-    S14 --> S15
-    S16[fix]
-    S15 --> S16
-    S17[next_or_done]
-    S16 --> S17
-    S18[audit_impl]
-    S17 --> S18
-    S19[remediate]
-    S18 --> S19
-    S20[prepare_pr]
-    S19 --> S20
-    S21[run_arch_lenses]
-    S20 --> S21
-    S22[compose_pr]
-    S21 --> S22
-    S23[extract_pr_number]
-    S22 --> S23
-    S24[annotate_pr_diff]
-    S23 --> S24
-    S25[review_pr]
-    S24 --> S25
-    S26[resolve_review]
-    S25 --> S26
-    S27[re_push_review]
-    S26 --> S27
-    S28[check_review_loop]
-    S27 --> S28
-    S29[check_repo_ci_event]
-    S28 --> S29
-    S30[check_pr_state]
-    S29 --> S30
-    S31[ci_watch]
-    S30 --> S31
-    S32[handle_no_ci_runs]
-    S31 --> S32
-    S33[check_ci_loop]
-    S32 --> S33
-    S34[check_active_trigger_loop]
-    S33 --> S34
-    S35[trigger_ci_actively]
-    S34 --> S35
-    S36[check_ci_already_passed]
-    S35 --> S36
-    S37[escalate_stop_no_ci]
-    S36 --> S37
-    S38[check_repo_merge_state]
-    S37 --> S38
-    S39[route_queue_mode]
-    S38 --> S39
-    S40[enqueue_to_queue]
-    S39 --> S40
-    S41[verify_queue_enrollment]
-    S40 --> S41
-    S42[wait_for_queue]
-    S41 --> S42
-    S43[reenroll_stalled_pr]
-    S42 --> S43
-    S44[check_stall_loop]
-    S43 --> S44
-    S45[check_eject_limit]
-    S44 --> S45
-    S46[queue_ejected_fix]
-    S45 --> S46
-    S47[resolve_queue_merge_conflicts]
-    S46 --> S47
-    S48[re_push_queue_fix]
-    S47 --> S48
-    S49[ci_watch_post_queue_fix]
-    S48 --> S49
-    S50[reenter_merge_queue]
-    S49 --> S50
-    S51[reenter_merge_queue_cheap]
-    S50 --> S51
-    S52[direct_merge]
-    S51 --> S52
-    S53[wait_for_direct_merge]
-    S52 --> S53
-    S54[direct_merge_conflict_fix]
-    S53 --> S54
-    S55[resolve_direct_merge_conflicts]
-    S54 --> S55
-    S56[re_push_direct_fix]
-    S55 --> S56
-    S57[redirect_merge]
-    S56 --> S57
-    S58[immediate_merge]
-    S57 --> S58
-    S59[wait_for_immediate_merge]
-    S58 --> S59
-    S60[immediate_merge_conflict_fix]
-    S59 --> S60
-    S61[resolve_immediate_merge_conflicts]
-    S60 --> S61
-    S62[re_push_immediate_fix]
-    S61 --> S62
-    S63[remerge_immediate]
-    S62 --> S63
-    S64[diagnose_ci]
-    S63 --> S64
-    S65[resolve_ci]
-    S64 --> S65
-    S66[pre_resolve_rebase]
-    S65 --> S66
-    S67[re_push]
-    S66 --> S67
-    S68[detect_ci_conflict]
-    S67 --> S68
-    S69[ci_conflict_fix]
-    S68 --> S69
-    S70[release_issue_success]
-    S69 --> S70
-    S71[patch_token_summary]
-    S70 --> S71
-    S72[register_clone_unconfirmed]
-    S71 --> S72
-    S73[release_issue_failure]
-    S72 --> S73
-    S74[register_clone_success]
-    S73 --> S74
-    S75[register_clone_failure]
-    S74 --> S75
-    S76[done]
-    S75 --> S76
-    S77[escalate_stop]
-    S76 --> S77
+```
+      clone → get_issue_title → claim_issue → compute_branch
+      |
+      +-- create_branch (optional)
+      |
+      plan
+      |
+      +-- review (optional)
+      |
+ +----+ FOR EACH PLAN PART:
+ |    |
+ |    verify → implement → test ↔ [fix on failure]
+ |    |
+ |    merge → push → next_or_done
+ |
+ +----+
+      |
+      +-- audit_impl → remediate (optional)
+      |
+      +-- [open-pr] (optional):
+      |     prepare_pr → compose_pr → review_pr → resolve_review
+      |     ci_watch → check_repo_merge_state
+      |     → [queue | direct | immediate] merge path
+      |     → diagnose_ci → resolve_ci (on CI failure)
+      |
+      release_issue_success / release_issue_failure
+      |
+      +-- patch_token_summary (optional)
+      |
+      register_clone_success / register_clone_failure
 ```

--- a/src/autoskillit/recipes/diagrams/implementation.md
+++ b/src/autoskillit/recipes/diagrams/implementation.md
@@ -1,35 +1,162 @@
-<!-- autoskillit-recipe-hash: sha256:9c748a039b3eb0879c8adef380464dd4e95386043f3505d73bf71202e6cd1742 -->
+<!-- autoskillit-recipe-hash: sha256:fe042fe400b76dfd7d1d2d30fd316cfecd146227c75c5c2d6f00f5ae91d11c19 -->
 <!-- autoskillit-diagram-format: v7 -->
 # implementation
 
-```
-      clone → get_issue_title → claim_issue → compute_branch
-      |
-      +-- create_branch (optional)
-      |
-      plan
-      |
-      +-- review (optional)
-      |
- +----+ FOR EACH PLAN PART:
- |    |
- |    verify → implement → test ↔ [fix on failure]
- |    |
- |    merge → push → next_or_done
- |
- +----+
-      |
-      +-- audit_impl → remediate (optional)
-      |
-      +-- [open-pr] (optional):
-      |     prepare_pr → compose_pr → review_pr → resolve_review
-      |     ci_watch → check_repo_merge_state
-      |     → [queue | direct | immediate] merge path
-      |     → diagnose_ci → resolve_ci (on CI failure)
-      |
-      release_issue_success / release_issue_failure
-      |
-      +-- patch_token_summary (optional)
-      |
-      register_clone_success / register_clone_failure
+```mermaid
+flowchart TD
+    S0[clone]
+    S1[capture_base_sha]
+    S0 --> S1
+    S2[get_issue_title]
+    S1 --> S2
+    S3[claim_issue]
+    S2 --> S3
+    S4[compute_branch]
+    S3 --> S4
+    S5[create_branch]
+    S4 --> S5
+    S6[push_merge_target]
+    S5 --> S6
+    S7[plan]
+    S6 --> S7
+    S8[review]
+    S7 --> S8
+    S9[verify]
+    S8 --> S9
+    S10[implement]
+    S9 --> S10
+    S11[retry_worktree]
+    S10 --> S11
+    S12[test]
+    S11 --> S12
+    S13[commit_guard]
+    S12 --> S13
+    S14[merge]
+    S13 --> S14
+    S15[push]
+    S14 --> S15
+    S16[fix]
+    S15 --> S16
+    S17[next_or_done]
+    S16 --> S17
+    S18[audit_impl]
+    S17 --> S18
+    S19[remediate]
+    S18 --> S19
+    S20[prepare_pr]
+    S19 --> S20
+    S21[run_arch_lenses]
+    S20 --> S21
+    S22[compose_pr]
+    S21 --> S22
+    S23[extract_pr_number]
+    S22 --> S23
+    S24[annotate_pr_diff]
+    S23 --> S24
+    S25[review_pr]
+    S24 --> S25
+    S26[resolve_review]
+    S25 --> S26
+    S27[re_push_review]
+    S26 --> S27
+    S28[check_review_loop]
+    S27 --> S28
+    S29[check_repo_ci_event]
+    S28 --> S29
+    S30[check_pr_state]
+    S29 --> S30
+    S31[ci_watch]
+    S30 --> S31
+    S32[handle_no_ci_runs]
+    S31 --> S32
+    S33[check_ci_loop]
+    S32 --> S33
+    S34[check_active_trigger_loop]
+    S33 --> S34
+    S35[trigger_ci_actively]
+    S34 --> S35
+    S36[check_ci_already_passed]
+    S35 --> S36
+    S37[escalate_stop_no_ci]
+    S36 --> S37
+    S38[check_repo_merge_state]
+    S37 --> S38
+    S39[route_queue_mode]
+    S38 --> S39
+    S40[enqueue_to_queue]
+    S39 --> S40
+    S41[verify_queue_enrollment]
+    S40 --> S41
+    S42[wait_for_queue]
+    S41 --> S42
+    S43[reenroll_stalled_pr]
+    S42 --> S43
+    S44[check_stall_loop]
+    S43 --> S44
+    S45[check_eject_limit]
+    S44 --> S45
+    S46[queue_ejected_fix]
+    S45 --> S46
+    S47[resolve_queue_merge_conflicts]
+    S46 --> S47
+    S48[re_push_queue_fix]
+    S47 --> S48
+    S49[ci_watch_post_queue_fix]
+    S48 --> S49
+    S50[reenter_merge_queue]
+    S49 --> S50
+    S51[reenter_merge_queue_cheap]
+    S50 --> S51
+    S52[direct_merge]
+    S51 --> S52
+    S53[wait_for_direct_merge]
+    S52 --> S53
+    S54[direct_merge_conflict_fix]
+    S53 --> S54
+    S55[resolve_direct_merge_conflicts]
+    S54 --> S55
+    S56[re_push_direct_fix]
+    S55 --> S56
+    S57[redirect_merge]
+    S56 --> S57
+    S58[immediate_merge]
+    S57 --> S58
+    S59[wait_for_immediate_merge]
+    S58 --> S59
+    S60[immediate_merge_conflict_fix]
+    S59 --> S60
+    S61[resolve_immediate_merge_conflicts]
+    S60 --> S61
+    S62[re_push_immediate_fix]
+    S61 --> S62
+    S63[remerge_immediate]
+    S62 --> S63
+    S64[diagnose_ci]
+    S63 --> S64
+    S65[resolve_ci]
+    S64 --> S65
+    S66[pre_resolve_rebase]
+    S65 --> S66
+    S67[re_push]
+    S66 --> S67
+    S68[detect_ci_conflict]
+    S67 --> S68
+    S69[ci_conflict_fix]
+    S68 --> S69
+    S70[release_issue_success]
+    S69 --> S70
+    S71[patch_token_summary]
+    S70 --> S71
+    S72[register_clone_unconfirmed]
+    S71 --> S72
+    S73[release_issue_failure]
+    S72 --> S73
+    S74[register_clone_success]
+    S73 --> S74
+    S75[register_clone_failure]
+    S74 --> S75
+    S76[done]
+    S75 --> S76
+    S77[escalate_stop]
+    S76 --> S77
 ```

--- a/src/autoskillit/recipes/diagrams/implementation.md
+++ b/src/autoskillit/recipes/diagrams/implementation.md
@@ -2,161 +2,34 @@
 <!-- autoskillit-diagram-format: v7 -->
 # implementation
 
-```mermaid
-flowchart TD
-    S0[clone]
-    S1[capture_base_sha]
-    S0 --> S1
-    S2[get_issue_title]
-    S1 --> S2
-    S3[claim_issue]
-    S2 --> S3
-    S4[compute_branch]
-    S3 --> S4
-    S5[create_branch]
-    S4 --> S5
-    S6[push_merge_target]
-    S5 --> S6
-    S7[plan]
-    S6 --> S7
-    S8[review]
-    S7 --> S8
-    S9[verify]
-    S8 --> S9
-    S10[implement]
-    S9 --> S10
-    S11[retry_worktree]
-    S10 --> S11
-    S12[test]
-    S11 --> S12
-    S13[commit_guard]
-    S12 --> S13
-    S14[merge]
-    S13 --> S14
-    S15[push]
-    S14 --> S15
-    S16[fix]
-    S15 --> S16
-    S17[next_or_done]
-    S16 --> S17
-    S18[audit_impl]
-    S17 --> S18
-    S19[remediate]
-    S18 --> S19
-    S20[prepare_pr]
-    S19 --> S20
-    S21[run_arch_lenses]
-    S20 --> S21
-    S22[compose_pr]
-    S21 --> S22
-    S23[extract_pr_number]
-    S22 --> S23
-    S24[annotate_pr_diff]
-    S23 --> S24
-    S25[review_pr]
-    S24 --> S25
-    S26[resolve_review]
-    S25 --> S26
-    S27[re_push_review]
-    S26 --> S27
-    S28[check_review_loop]
-    S27 --> S28
-    S29[check_repo_ci_event]
-    S28 --> S29
-    S30[check_pr_state]
-    S29 --> S30
-    S31[ci_watch]
-    S30 --> S31
-    S32[handle_no_ci_runs]
-    S31 --> S32
-    S33[check_ci_loop]
-    S32 --> S33
-    S34[check_active_trigger_loop]
-    S33 --> S34
-    S35[trigger_ci_actively]
-    S34 --> S35
-    S36[check_ci_already_passed]
-    S35 --> S36
-    S37[escalate_stop_no_ci]
-    S36 --> S37
-    S38[check_repo_merge_state]
-    S37 --> S38
-    S39[route_queue_mode]
-    S38 --> S39
-    S40[enqueue_to_queue]
-    S39 --> S40
-    S41[verify_queue_enrollment]
-    S40 --> S41
-    S42[wait_for_queue]
-    S41 --> S42
-    S43[reenroll_stalled_pr]
-    S42 --> S43
-    S44[check_stall_loop]
-    S43 --> S44
-    S45[check_eject_limit]
-    S44 --> S45
-    S46[queue_ejected_fix]
-    S45 --> S46
-    S47[resolve_queue_merge_conflicts]
-    S46 --> S47
-    S48[re_push_queue_fix]
-    S47 --> S48
-    S49[ci_watch_post_queue_fix]
-    S48 --> S49
-    S50[reenter_merge_queue]
-    S49 --> S50
-    S51[reenter_merge_queue_cheap]
-    S50 --> S51
-    S52[direct_merge]
-    S51 --> S52
-    S53[wait_for_direct_merge]
-    S52 --> S53
-    S54[direct_merge_conflict_fix]
-    S53 --> S54
-    S55[resolve_direct_merge_conflicts]
-    S54 --> S55
-    S56[re_push_direct_fix]
-    S55 --> S56
-    S57[redirect_merge]
-    S56 --> S57
-    S58[immediate_merge]
-    S57 --> S58
-    S59[wait_for_immediate_merge]
-    S58 --> S59
-    S60[immediate_merge_conflict_fix]
-    S59 --> S60
-    S61[resolve_immediate_merge_conflicts]
-    S60 --> S61
-    S62[re_push_immediate_fix]
-    S61 --> S62
-    S63[remerge_immediate]
-    S62 --> S63
-    S64[diagnose_ci]
-    S63 --> S64
-    S65[resolve_ci]
-    S64 --> S65
-    S66[pre_resolve_rebase]
-    S65 --> S66
-    S67[re_push]
-    S66 --> S67
-    S68[detect_ci_conflict]
-    S67 --> S68
-    S69[ci_conflict_fix]
-    S68 --> S69
-    S70[release_issue_success]
-    S69 --> S70
-    S71[patch_token_summary]
-    S70 --> S71
-    S72[register_clone_unconfirmed]
-    S71 --> S72
-    S73[release_issue_failure]
-    S72 --> S73
-    S74[register_clone_success]
-    S73 --> S74
-    S75[register_clone_failure]
-    S74 --> S75
-    S76[done]
-    S75 --> S76
-    S77[escalate_stop]
-    S76 --> S77
+```
+      clone → get_issue_title → claim_issue → compute_branch
+      |
+      +-- create_branch (optional)
+      |
+      plan
+      |
+      +-- review (optional)
+      |
+ +----+ FOR EACH PLAN PART:
+ |    |
+ |    verify → implement → test ↔ [fix on failure]
+ |    |
+ |    merge → push → next_or_done
+ |
+ +----+
+      |
+      +-- audit_impl → remediate (optional)
+      |
+      +-- [open-pr] (optional):
+      |     prepare_pr → compose_pr → review_pr → resolve_review
+      |     ci_watch → check_repo_merge_state
+      |     → [queue | direct | immediate] merge path
+      |     → diagnose_ci → resolve_ci (on CI failure)
+      |
+      release_issue_success / release_issue_failure
+      |
+      +-- patch_token_summary (optional)
+      |
+      register_clone_success / register_clone_failure
 ```

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -668,6 +668,10 @@ def test_no_subpackage_exceeds_10_files() -> None:
         bringing the count to 38.
         rules_temp_path.py adds the non-unique-output-path lint rule for output path
         isolation enforcement, bringing the count to 39.
+        identity.py adds recipe identity hashing (content and composite fingerprints),
+        bringing the count to 40.
+        order.py adds the stable display order registry (BUNDLED_RECIPE_ORDER) for
+        Group 0 bundled recipes, bringing the count to 41.
       execution/ — REQ-CNST-003-E3: execution/ decomposes process lifecycle into
         focused single-concern modules (_process_io, _process_kill, _process_race,
         etc.) that cannot be merged without re-introducing the coupling they isolate.
@@ -730,7 +734,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
     """
     EXEMPTIONS: dict[str, int] = {
         "server": 20,
-        "recipe": 40,
+        "recipe": 41,
         "execution": 26,
         "core": 27,
         "cli": 27,

--- a/tests/recipe/test_io_discovery.py
+++ b/tests/recipe/test_io_discovery.py
@@ -47,8 +47,11 @@ class TestListRecipes:
                 )
 
     def test_list_recipes_alphabetical_within_bundled_tiers(self, tmp_path: Path) -> None:
-        """Each bundled tier (core and add-on) must be alphabetically sorted within its tier."""
+        """Unregistered core bundled recipes are alphabetical after registered ones.
+        Add-on bundled recipes remain alphabetical.
+        """
         from autoskillit.core._type_constants import CORE_PACKS
+        from autoskillit.recipe.order import BUNDLED_RECIPE_ORDER
 
         result = list_recipes(tmp_path)
         core_names = [
@@ -65,8 +68,19 @@ class TestListRecipes:
             and not r.experimental
             and not all(p in CORE_PACKS for p in r.requires_packs)
         ]
-        assert core_names == sorted(core_names), (
-            f"Core bundled recipes not in alphabetical order: {core_names}"
+        # Registered entries appear first; the unregistered tail must be alphabetical
+        unregistered_core = [n for n in core_names if n not in BUNDLED_RECIPE_ORDER]
+        registered_core = [n for n in core_names if n in BUNDLED_RECIPE_ORDER]
+        if registered_core:
+            last_registered_idx = core_names.index(registered_core[-1])
+            first_unregistered_idx = (
+                core_names.index(unregistered_core[0]) if unregistered_core else len(core_names)
+            )
+            assert last_registered_idx < first_unregistered_idx, (
+                "Registered core recipes must appear before unregistered ones"
+            )
+        assert unregistered_core == sorted(unregistered_core), (
+            f"Unregistered core recipes not alphabetical: {unregistered_core}"
         )
         assert addon_names == sorted(addon_names), (
             f"Add-on bundled recipes not in alphabetical order: {addon_names}"

--- a/tests/recipe/test_io_discovery.py
+++ b/tests/recipe/test_io_discovery.py
@@ -71,14 +71,17 @@ class TestListRecipes:
         # Registered entries appear first; the unregistered tail must be alphabetical
         unregistered_core = [n for n in core_names if n not in BUNDLED_RECIPE_ORDER]
         registered_core = [n for n in core_names if n in BUNDLED_RECIPE_ORDER]
-        if registered_core:
-            last_registered_idx = core_names.index(registered_core[-1])
-            first_unregistered_idx = (
-                core_names.index(unregistered_core[0]) if unregistered_core else len(core_names)
-            )
-            assert last_registered_idx < first_unregistered_idx, (
-                "Registered core recipes must appear before unregistered ones"
-            )
+        assert registered_core, (
+            "BUNDLED_RECIPE_ORDER is empty at test time — registered_core must be non-empty "
+            "for the ordering contract to be verifiable"
+        )
+        last_registered_idx = core_names.index(registered_core[-1])
+        first_unregistered_idx = (
+            core_names.index(unregistered_core[0]) if unregistered_core else len(core_names)
+        )
+        assert last_registered_idx < first_unregistered_idx, (
+            "Registered core recipes must appear before unregistered ones"
+        )
         assert unregistered_core == sorted(unregistered_core), (
             f"Unregistered core recipes not alphabetical: {unregistered_core}"
         )

--- a/tests/recipe/test_recipe_order.py
+++ b/tests/recipe/test_recipe_order.py
@@ -50,6 +50,11 @@ def test_unregistered_group0_recipes_alphabetical_after_registered(
     result = list_recipes(tmp_path)
     group0 = [r.name for r in result.items if group_rank(r) == 0]
     unregistered = group0[1:]
+    if not unregistered:
+        pytest.skip(
+            "No unregistered Group-0 recipes — all Group-0 recipes are registered; "
+            "alphabetical-tail contract cannot be verified"
+        )
     assert unregistered == sorted(unregistered), (
         f"Unregistered Group-0 recipes not alphabetical: {unregistered}"
     )
@@ -63,12 +68,26 @@ def test_adding_unregistered_recipe_does_not_shift_registered(
 
     monkeypatch.setattr(recipe_io, "BUNDLED_RECIPE_ORDER", ["implementation", "remediation"])
     result = list_recipes(tmp_path)
-    group0_before = [r.name for r in result.items if group_rank(r) == 0]
-    impl_idx_before = group0_before.index("implementation")
-    remed_idx_before = group0_before.index("remediation")
+    group0 = [r.name for r in result.items if group_rank(r) == 0]
+    impl_idx = group0.index("implementation")
+    remed_idx = group0.index("remediation")
 
     # Confirm registry order is honoured
-    assert impl_idx_before < remed_idx_before, "'implementation' must come before 'remediation'"
+    assert impl_idx < remed_idx, "'implementation' must come before 'remediation'"
+
+    # Verify unregistered recipes that alphabetically precede 'implementation'
+    # (e.g. 'bem-wrapper') do not displace it from its registered position
+    unregistered = [n for n in group0 if n not in {"implementation", "remediation"}]
+    preceding = [n for n in unregistered if n < "implementation"]
+    assert preceding, (
+        "Expected at least one unregistered Group-0 recipe alphabetically before "
+        "'implementation' (e.g. 'bem-wrapper') to verify the shift-invariant"
+    )
+    for name in preceding:
+        assert group0.index(name) > impl_idx, (
+            f"Unregistered recipe {name!r} (alphabetically before 'implementation') "
+            f"displaced it — registry position-stability contract violated: {group0}"
+        )
 
 
 def test_registry_does_not_affect_addon_group(

--- a/tests/recipe/test_recipe_order.py
+++ b/tests/recipe/test_recipe_order.py
@@ -1,0 +1,99 @@
+"""Tests for stable display order registry — recipe/order.py and its effect on list_recipes."""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import pytest
+
+from autoskillit.core.types import RecipeSource
+from autoskillit.recipe.io import group_rank, list_recipes
+from autoskillit.recipe.order import BUNDLED_RECIPE_ORDER
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.medium]
+
+
+def test_implementation_appears_before_remediation(tmp_path: Path) -> None:
+    """'implementation' must appear before 'remediation' in list_recipes output."""
+    result = list_recipes(tmp_path)
+    names = [r.name for r in result.items]
+    assert "implementation" in names and "remediation" in names
+    assert names.index("implementation") < names.index("remediation")
+
+
+def test_registered_recipes_precede_unregistered_in_group0(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Registered Group-0 recipes must appear before any unregistered Group-0 recipe."""
+    import autoskillit.recipe.io as recipe_io
+
+    monkeypatch.setattr(recipe_io, "BUNDLED_RECIPE_ORDER", ["implementation"])
+    result = list_recipes(tmp_path)
+    group0 = [r.name for r in result.items if group_rank(r) == 0]
+    assert group0[0] == "implementation"
+
+
+def test_unregistered_group0_recipes_alphabetical_after_registered(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unregistered Group-0 recipes must sort alphabetically after all registered ones."""
+    import autoskillit.recipe.io as recipe_io
+
+    monkeypatch.setattr(recipe_io, "BUNDLED_RECIPE_ORDER", ["implementation"])
+    result = list_recipes(tmp_path)
+    group0 = [r.name for r in result.items if group_rank(r) == 0]
+    unregistered = group0[1:]
+    assert unregistered == sorted(unregistered), (
+        f"Unregistered Group-0 recipes not alphabetical: {unregistered}"
+    )
+
+
+def test_adding_unregistered_recipe_does_not_shift_registered(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Inserting a name before 'implementation' alphabetically must not shift its position."""
+    import autoskillit.recipe.io as recipe_io
+
+    monkeypatch.setattr(recipe_io, "BUNDLED_RECIPE_ORDER", ["implementation", "remediation"])
+    result = list_recipes(tmp_path)
+    group0_before = [r.name for r in result.items if group_rank(r) == 0]
+    impl_idx_before = group0_before.index("implementation")
+    remed_idx_before = group0_before.index("remediation")
+
+    # Confirm registry order is honoured
+    assert impl_idx_before < remed_idx_before, (
+        "'implementation' must come before 'remediation'"
+    )
+
+
+def test_registry_does_not_affect_addon_group(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """BUNDLED_RECIPE_ORDER must not alter relative order of Group-1 Add-on recipes."""
+    import autoskillit.recipe.io as recipe_io
+
+    result_before = list_recipes(tmp_path)
+    addon_before = [r.name for r in result_before.items if group_rank(r) == 1]
+
+    monkeypatch.setattr(recipe_io, "BUNDLED_RECIPE_ORDER", ["implementation"] + addon_before)
+    result_after = list_recipes(tmp_path)
+    addon_after = [r.name for r in result_after.items if group_rank(r) == 1]
+
+    assert addon_after == sorted(addon_after), (
+        "Group-1 Add-on recipes must remain alphabetical regardless of registry"
+    )
+
+
+def test_bundled_recipe_order_covers_all_group0_recipes(tmp_path: Path) -> None:
+    """Warn (do not fail) if a Group-0 bundled recipe is missing from BUNDLED_RECIPE_ORDER."""
+    result = list_recipes(tmp_path)
+    group0_names = [r.name for r in result.items if group_rank(r) == 0]
+    missing = [n for n in group0_names if n not in BUNDLED_RECIPE_ORDER]
+    if missing:
+        warnings.warn(
+            f"Group-0 bundled recipes missing from BUNDLED_RECIPE_ORDER: {missing}. "
+            "Add them to src/autoskillit/recipe/order.py to pin their display position.",
+            UserWarning,
+            stacklevel=1,
+        )

--- a/tests/recipe/test_recipe_order.py
+++ b/tests/recipe/test_recipe_order.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 import pytest
 
-from autoskillit.core.types import RecipeSource
 from autoskillit.recipe.io import group_rank, list_recipes
 from autoskillit.recipe.order import BUNDLED_RECIPE_ORDER
 
@@ -62,9 +61,7 @@ def test_adding_unregistered_recipe_does_not_shift_registered(
     remed_idx_before = group0_before.index("remediation")
 
     # Confirm registry order is honoured
-    assert impl_idx_before < remed_idx_before, (
-        "'implementation' must come before 'remediation'"
-    )
+    assert impl_idx_before < remed_idx_before, "'implementation' must come before 'remediation'"
 
 
 def test_registry_does_not_affect_addon_group(

--- a/tests/recipe/test_recipe_order.py
+++ b/tests/recipe/test_recipe_order.py
@@ -31,6 +31,13 @@ def test_registered_recipes_precede_unregistered_in_group0(
     result = list_recipes(tmp_path)
     group0 = [r.name for r in result.items if group_rank(r) == 0]
     assert group0[0] == "implementation"
+    unregistered = [n for n in group0 if n != "implementation"]
+    assert unregistered, (
+        "Expected at least one unregistered Group-0 recipe to verify the ordering contract"
+    )
+    assert all(group0.index(n) > 0 for n in unregistered), (
+        f"Some unregistered Group-0 recipes appear before 'implementation': {group0}"
+    )
 
 
 def test_unregistered_group0_recipes_alphabetical_after_registered(


### PR DESCRIPTION
## Summary

Add `src/autoskillit/recipe/order.py` — a dedicated registry module containing `BUNDLED_RECIPE_ORDER: list[str]` that controls display position of Group 0 (Bundled Recipes) within `list_recipes`. Modify `recipe/io.py` to import this registry and use it as a sort tiebreaker: `(group_rank(r), _registry_position(r), r.name)`. Registered recipes appear first in registry order; unregistered recipes fall to the back alphabetically. Group 1 (Add-ons) and all other groups are unaffected. One existing test that asserts alphabetical ordering for core bundled recipes must be updated to reflect the new ordering contract.

**Initial registry order (Group 0):** `implementation` → `remediation` → `implementation-groups` → `merge-prs`

## Architecture Impact

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ── L3 APPLICATION LAYER ────────────────────────────────────── %%
    subgraph L3 ["L3 — APPLICATION (server/ · cli/)"]
        direction LR
        SERVER_FACTORY["server/_factory.py<br/>━━━━━━━━━━<br/>make_context()<br/>wires recipe pkg"]
        CLI_APP["cli/app.py<br/>━━━━━━━━━━<br/>list_recipes()<br/>find_recipe_by_name()"]
        CLI_COOK["cli/_cook.py<br/>━━━━━━━━━━<br/>group_rank()<br/>list_recipes()"]
    end

    %% ── L2 RECIPE PACKAGE GATEWAY ───────────────────────────────── %%
    subgraph L2_GW ["L2 — recipe/ (gateway __init__.py)"]
        RECIPE_PKG["recipe/__init__.py<br/>━━━━━━━━━━<br/>Re-exports: list_recipes,<br/>load_recipe, group_rank,<br/>GROUP_LABELS, …"]
    end

    %% ── L2 RECIPE INTERNALS ─────────────────────────────────────── %%
    subgraph L2_INT ["L2 — recipe/ (internal modules)"]
        direction TB

        RECIPE_IO["● recipe/io.py<br/>━━━━━━━━━━<br/>list_recipes()<br/>_registry_position()<br/>load_recipe()<br/>group_rank()"]

        RECIPE_ORDER["★ recipe/order.py<br/>━━━━━━━━━━<br/>BUNDLED_RECIPE_ORDER<br/>[implementation, remediation,<br/>implementation-groups,<br/>merge-prs]"]

        RECIPE_SCHEMA["recipe/schema.py<br/>━━━━━━━━━━<br/>Recipe, RecipeStep<br/>RecipeInfo, RecipeKind"]

        RECIPE_STALE["recipe/staleness_cache.py<br/>━━━━━━━━━━<br/>compute_recipe_hash()<br/>(deferred import in io.py)"]

        RECIPE_ANALYSIS["recipe/_analysis.py<br/>━━━━━━━━━━<br/>extract_blocks()<br/>imports iter_steps_with_context<br/>(deferred import in io.py)"]

        RULES_INPUTS["recipe/rules_inputs.py<br/>━━━━━━━━━━<br/>imports iter_steps_with_context<br/>from recipe.io directly"]
    end

    %% ── L0 CORE ─────────────────────────────────────────────────── %%
    subgraph L0 ["L0 — core/"]
        CORE["core/__init__.py<br/>━━━━━━━━━━<br/>CORE_PACKS, DispatchGateType<br/>LoadResult, RecipeSource<br/>get_logger, load_yaml, pkg_root"]
    end

    %% ── TEST LAYER ───────────────────────────────────────────────── %%
    subgraph TESTS ["TESTS — enforcement & verification"]
        direction LR
        TEST_ORDER["★ tests/recipe/<br/>test_recipe_order.py<br/>━━━━━━━━━━<br/>Verifies BUNDLED_RECIPE_ORDER<br/>sort ordering in list_recipes"]
        TEST_IO["● tests/recipe/<br/>test_io_discovery.py<br/>━━━━━━━━━━<br/>Recipe discovery tests<br/>(updated for new sort)"]
        TEST_ARCH["● tests/arch/<br/>test_subpackage_isolation.py<br/>━━━━━━━━━━<br/>recipe/ file-count limit<br/>bumped 40 → 41"]
    end

    %% ── VALID DEPENDENCIES ────────────────────────────────────────── %%

    %% L3 → L2 gateway (all via recipe package, not direct sub-module)
    SERVER_FACTORY -->|"from autoskillit.recipe import …"| RECIPE_PKG
    CLI_APP -->|"from autoskillit.recipe import …"| RECIPE_PKG
    CLI_COOK -->|"from autoskillit.recipe import …"| RECIPE_PKG

    %% Gateway → io (re-export)
    RECIPE_PKG -->|"re-exports from io"| RECIPE_IO

    %% io → order (NEW direct import — the key change)
    RECIPE_IO -->|"★ NEW: from recipe.order<br/>import BUNDLED_RECIPE_ORDER"| RECIPE_ORDER

    %% io → schema (existing)
    RECIPE_IO -->|"imports types"| RECIPE_SCHEMA

    %% io → staleness_cache (deferred, breaks circular)
    RECIPE_IO -.->|"deferred import<br/>(compute_recipe_hash)"| RECIPE_STALE

    %% io → _analysis (deferred, breaks circular)
    RECIPE_IO -.->|"deferred import<br/>(extract_blocks)"| RECIPE_ANALYSIS

    %% _analysis → io (circular; deferred import breaks the cycle)
    RECIPE_ANALYSIS -.->|"deferred import<br/>(iter_steps_with_context)"| RECIPE_IO

    %% rules_inputs direct import from io (existing)
    RULES_INPUTS -->|"from recipe.io import<br/>iter_steps_with_context"| RECIPE_IO

    %% io → core (existing)
    RECIPE_IO -->|"from autoskillit.core import …"| CORE

    %% order → nothing (leaf module — no autoskillit imports)
    %% (no arrows from order)

    %% Test imports
    TEST_ORDER -->|"imports from recipe.io<br/>and recipe.order"| RECIPE_IO
    TEST_ORDER -->|"imports BUNDLED_RECIPE_ORDER"| RECIPE_ORDER
    TEST_IO -->|"exercises list_recipes()"| RECIPE_IO
    TEST_ARCH -.->|"AST-enforces file count<br/>(recipe/ ≤ 41 files)"| RECIPE_IO

    %% CLASS ASSIGNMENTS %%
    class SERVER_FACTORY,CLI_APP,CLI_COOK cli;
    class RECIPE_PKG stateNode;
    class RECIPE_IO handler;
    class RECIPE_ORDER newComponent;
    class RECIPE_SCHEMA,CORE phase;
    class RECIPE_STALE,RECIPE_ANALYSIS output;
    class RULES_INPUTS handler;
    class TEST_ORDER newComponent;
    class TEST_IO,TEST_ARCH detector;
```

### Data Lineage Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;

    subgraph Inputs ["Data Origins"]
        YAML["Recipe YAML Files<br/>━━━━━━━━━━<br/>src/autoskillit/recipes/<br/>.autoskillit/recipes/"]
        ORDER["★ BUNDLED_RECIPE_ORDER<br/>━━━━━━━━━━<br/>recipe/order.py<br/>list[str] — static registry"]
    end

    subgraph Collection ["● Collection & Classification<br/>recipe/io.py"]
        COLLECT["● _collect_recipes()<br/>━━━━━━━━━━<br/>Reads YAML → RecipeInfo<br/>Deduplicates by name"]
        RANK["group_rank()<br/>━━━━━━━━━━<br/>RecipeSource + packs →<br/>Group 0 / 1 / 2 / 3"]
    end

    subgraph SortKey ["● Sort Key Computation<br/>recipe/io.py"]
        REGPOS["★ _registry_position()<br/>━━━━━━━━━━<br/>name → index in registry<br/>len(registry) if absent"]
        SORTKEY["sort key tuple<br/>━━━━━━━━━━<br/>(group_rank, registry_pos, name)<br/>alphabetical fallback"]
    end

    subgraph Output ["Primary Output"]
        RESULT["● list_recipes() → LoadResult<br/>━━━━━━━━━━<br/>Stable-ordered list[RecipeInfo]<br/>Group 0 registered → unregistered α"]
    end

    subgraph Consumers ["Downstream Consumers"]
        MCPTOOL["tools_recipe.py<br/>━━━━━━━━━━<br/>MCP: list_recipes tool"]
        CLI["app.py<br/>━━━━━━━━━━<br/>CLI: autoskillit recipes"]
    end

    subgraph Tests ["★ Test Coverage<br/>tests/recipe/"]
        TORDER["★ test_recipe_order.py<br/>━━━━━━━━━━<br/>Registry position contracts<br/>Group isolation invariants"]
        TIODIS["● test_io_discovery.py<br/>━━━━━━━━━━<br/>Ordering within bundled tiers<br/>Registered vs unregistered α"]
    end

    %% DATA FLOWS %%
    YAML -->|"read_text() + load_yaml()"| COLLECT
    COLLECT -->|"RecipeInfo list"| RANK
    ORDER -->|"BUNDLED_RECIPE_ORDER"| REGPOS
    RANK -->|"group int"| SORTKEY
    REGPOS -->|"position int"| SORTKEY
    SORTKEY -->|"sorted(items, key=...)"| RESULT
    RESULT -->|"LoadResult[RecipeInfo]"| MCPTOOL
    RESULT -->|"LoadResult[RecipeInfo]"| CLI

    %% TEST FLOWS (dashed — write-only, not read back by production) %%
    RESULT -.->|"assertions"| TORDER
    RESULT -.->|"assertions"| TIODIS
    ORDER -.->|"monkeypatched in tests"| TORDER

    %% CLASS ASSIGNMENTS %%
    class YAML cli;
    class ORDER newComponent;
    class COLLECT handler;
    class RANK phase;
    class REGPOS newComponent;
    class SORTKEY phase;
    class RESULT stateNode;
    class MCPTOOL integration;
    class CLI integration;
    class TORDER newComponent;
    class TIODIS output;
```

Closes #1478

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260428-094254-137086/.autoskillit/temp/make-plan/stable_display_order_registry_bundled_recipes_plan_2026-04-28_094500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 87 | 13.4k | 422.6k | 72.3k | 1 | 6m 48s |
| verify | 84 | 10.6k | 419.1k | 52.9k | 1 | 3m 5s |
| implement | 148 | 6.6k | 621.3k | 33.3k | 1 | 2m 31s |
| prepare_pr | 68 | 4.5k | 224.1k | 26.8k | 1 | 1m 32s |
| run_arch_lenses | 140 | 10.9k | 549.2k | 151.5k | 2 | 3m 30s |
| compose_pr | 59 | 6.0k | 209.0k | 29.6k | 1 | 1m 52s |
| review_pr | 102 | 25.1k | 484.6k | 56.1k | 1 | 6m 23s |
| resolve_review | 245 | 17.0k | 1.4M | 60.0k | 1 | 7m 4s |
| **Total** | 933 | 94.2k | 4.3M | 482.4k | | 32m 47s |