### PR TITLE
Implementation Plan: Arch Audit Code Dedup + IL Contract Guard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,6 +256,7 @@ generic_automation_mcp/
 │   ├── rules_verdict.py
 │   ├── rules_worktree.py     #   Semantic validation rule modules
 │   ├── _git_helpers.py      #   Shared git-remote regex (_GIT_REMOTE_COMMAND_RE, _LITERAL_ORIGIN_RE) for lint rules
+│   ├── _skill_helpers.py        #   Shared helpers for skill-related semantic rules
 │   ├── _skill_placeholder_parser.py
 │   ├── identity.py          #   Recipe identity hashing — content and composite fingerprints
 │   ├── schema.py            #   Recipe, RecipeStep, DataFlowWarning

--- a/src/autoskillit/recipe/_skill_helpers.py
+++ b/src/autoskillit/recipe/_skill_helpers.py
@@ -1,0 +1,14 @@
+"""Shared helpers for skill-related semantic rules."""
+
+from __future__ import annotations
+
+from autoskillit.core import SkillLister
+
+
+def _get_skill_category_map(lister: SkillLister | None = None) -> dict[str, frozenset[str]]:
+    """Return {skill_name: categories} for all bundled skills."""
+    if lister is None:
+        from autoskillit.workspace import DefaultSkillResolver  # noqa: PLC0415
+
+        lister = DefaultSkillResolver()
+    return {s.name: s.categories for s in lister.list_all()}

--- a/src/autoskillit/recipe/rules_features.py
+++ b/src/autoskillit/recipe/rules_features.py
@@ -12,9 +12,9 @@ from autoskillit.core import (
     TOOL_SUBSET_TAGS,
     FeatureDef,
     Severity,
-    SkillLister,
 )
 from autoskillit.recipe._analysis import ValidationContext
+from autoskillit.recipe._skill_helpers import _get_skill_category_map
 from autoskillit.recipe.contracts import resolve_skill_name
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
 
@@ -27,15 +27,6 @@ def _tools_for_feature(fdef: FeatureDef) -> frozenset[str]:
 def _get_disabled_feature_defs(ctx: ValidationContext) -> dict[str, FeatureDef]:
     """Return {feature_name: FeatureDef} for all features named in ctx.disabled_features."""
     return {name: fdef for name, fdef in FEATURE_REGISTRY.items() if name in ctx.disabled_features}
-
-
-def _get_skill_category_map(lister: SkillLister | None = None) -> dict[str, frozenset[str]]:
-    """Return {skill_name: categories} for all bundled skills."""
-    if lister is None:
-        from autoskillit.workspace import DefaultSkillResolver  # noqa: PLC0415
-
-        lister = DefaultSkillResolver()
-    return {s.name: s.categories for s in lister.list_all()}
 
 
 @semantic_rule(

--- a/src/autoskillit/recipe/rules_skills.py
+++ b/src/autoskillit/recipe/rules_skills.py
@@ -6,6 +6,7 @@ import re
 
 from autoskillit.core import AUTOSKILLIT_SKILL_PREFIX, SKILL_TOOLS, Severity, SkillLister
 from autoskillit.recipe._analysis import ValidationContext
+from autoskillit.recipe._skill_helpers import _get_skill_category_map
 from autoskillit.recipe.contracts import resolve_skill_name
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
 
@@ -16,15 +17,6 @@ def _get_bundled_skill_names(lister: SkillLister | None = None) -> frozenset[str
 
         lister = DefaultSkillResolver()
     return frozenset(s.name for s in lister.list_all())
-
-
-def _get_skill_category_map(lister: SkillLister | None = None) -> dict[str, frozenset[str]]:
-    """Return {skill_name: categories} for all bundled skills."""
-    if lister is None:
-        from autoskillit.workspace import DefaultSkillResolver  # noqa: PLC0415
-
-        lister = DefaultSkillResolver()
-    return {s.name: s.categories for s in lister.list_all()}
 
 
 _SKILL_TOKEN_RE = re.compile(r"/autoskillit:(\S+)")

--- a/src/autoskillit/recipes/diagrams/implementation.md
+++ b/src/autoskillit/recipes/diagrams/implementation.md
@@ -2,34 +2,161 @@
 <!-- autoskillit-diagram-format: v7 -->
 # implementation
 
-```
-      clone → get_issue_title → claim_issue → compute_branch
-      |
-      +-- create_branch (optional)
-      |
-      plan
-      |
-      +-- review (optional)
-      |
- +----+ FOR EACH PLAN PART:
- |    |
- |    verify → implement → test ↔ [fix on failure]
- |    |
- |    merge → push → next_or_done
- |
- +----+
-      |
-      +-- audit_impl → remediate (optional)
-      |
-      +-- [open-pr] (optional):
-      |     prepare_pr → compose_pr → review_pr → resolve_review
-      |     ci_watch → check_repo_merge_state
-      |     → [queue | direct | immediate] merge path
-      |     → diagnose_ci → resolve_ci (on CI failure)
-      |
-      release_issue_success / release_issue_failure
-      |
-      +-- patch_token_summary (optional)
-      |
-      register_clone_success / register_clone_failure
+```mermaid
+flowchart TD
+    S0[clone]
+    S1[capture_base_sha]
+    S0 --> S1
+    S2[get_issue_title]
+    S1 --> S2
+    S3[claim_issue]
+    S2 --> S3
+    S4[compute_branch]
+    S3 --> S4
+    S5[create_branch]
+    S4 --> S5
+    S6[push_merge_target]
+    S5 --> S6
+    S7[plan]
+    S6 --> S7
+    S8[review]
+    S7 --> S8
+    S9[verify]
+    S8 --> S9
+    S10[implement]
+    S9 --> S10
+    S11[retry_worktree]
+    S10 --> S11
+    S12[test]
+    S11 --> S12
+    S13[commit_guard]
+    S12 --> S13
+    S14[merge]
+    S13 --> S14
+    S15[push]
+    S14 --> S15
+    S16[fix]
+    S15 --> S16
+    S17[next_or_done]
+    S16 --> S17
+    S18[audit_impl]
+    S17 --> S18
+    S19[remediate]
+    S18 --> S19
+    S20[prepare_pr]
+    S19 --> S20
+    S21[run_arch_lenses]
+    S20 --> S21
+    S22[compose_pr]
+    S21 --> S22
+    S23[extract_pr_number]
+    S22 --> S23
+    S24[annotate_pr_diff]
+    S23 --> S24
+    S25[review_pr]
+    S24 --> S25
+    S26[resolve_review]
+    S25 --> S26
+    S27[re_push_review]
+    S26 --> S27
+    S28[check_review_loop]
+    S27 --> S28
+    S29[check_repo_ci_event]
+    S28 --> S29
+    S30[check_pr_state]
+    S29 --> S30
+    S31[ci_watch]
+    S30 --> S31
+    S32[handle_no_ci_runs]
+    S31 --> S32
+    S33[check_ci_loop]
+    S32 --> S33
+    S34[check_active_trigger_loop]
+    S33 --> S34
+    S35[trigger_ci_actively]
+    S34 --> S35
+    S36[check_ci_already_passed]
+    S35 --> S36
+    S37[escalate_stop_no_ci]
+    S36 --> S37
+    S38[check_repo_merge_state]
+    S37 --> S38
+    S39[route_queue_mode]
+    S38 --> S39
+    S40[enqueue_to_queue]
+    S39 --> S40
+    S41[verify_queue_enrollment]
+    S40 --> S41
+    S42[wait_for_queue]
+    S41 --> S42
+    S43[reenroll_stalled_pr]
+    S42 --> S43
+    S44[check_stall_loop]
+    S43 --> S44
+    S45[check_eject_limit]
+    S44 --> S45
+    S46[queue_ejected_fix]
+    S45 --> S46
+    S47[resolve_queue_merge_conflicts]
+    S46 --> S47
+    S48[re_push_queue_fix]
+    S47 --> S48
+    S49[ci_watch_post_queue_fix]
+    S48 --> S49
+    S50[reenter_merge_queue]
+    S49 --> S50
+    S51[reenter_merge_queue_cheap]
+    S50 --> S51
+    S52[direct_merge]
+    S51 --> S52
+    S53[wait_for_direct_merge]
+    S52 --> S53
+    S54[direct_merge_conflict_fix]
+    S53 --> S54
+    S55[resolve_direct_merge_conflicts]
+    S54 --> S55
+    S56[re_push_direct_fix]
+    S55 --> S56
+    S57[redirect_merge]
+    S56 --> S57
+    S58[immediate_merge]
+    S57 --> S58
+    S59[wait_for_immediate_merge]
+    S58 --> S59
+    S60[immediate_merge_conflict_fix]
+    S59 --> S60
+    S61[resolve_immediate_merge_conflicts]
+    S60 --> S61
+    S62[re_push_immediate_fix]
+    S61 --> S62
+    S63[remerge_immediate]
+    S62 --> S63
+    S64[diagnose_ci]
+    S63 --> S64
+    S65[resolve_ci]
+    S64 --> S65
+    S66[pre_resolve_rebase]
+    S65 --> S66
+    S67[re_push]
+    S66 --> S67
+    S68[detect_ci_conflict]
+    S67 --> S68
+    S69[ci_conflict_fix]
+    S68 --> S69
+    S70[release_issue_success]
+    S69 --> S70
+    S71[patch_token_summary]
+    S70 --> S71
+    S72[register_clone_unconfirmed]
+    S71 --> S72
+    S73[release_issue_failure]
+    S72 --> S73
+    S74[register_clone_success]
+    S73 --> S74
+    S75[register_clone_failure]
+    S74 --> S75
+    S76[done]
+    S75 --> S76
+    S77[escalate_stop]
+    S76 --> S77
 ```

--- a/src/autoskillit/recipes/diagrams/implementation.md
+++ b/src/autoskillit/recipes/diagrams/implementation.md
@@ -2,161 +2,34 @@
 <!-- autoskillit-diagram-format: v7 -->
 # implementation
 
-```mermaid
-flowchart TD
-    S0[clone]
-    S1[capture_base_sha]
-    S0 --> S1
-    S2[get_issue_title]
-    S1 --> S2
-    S3[claim_issue]
-    S2 --> S3
-    S4[compute_branch]
-    S3 --> S4
-    S5[create_branch]
-    S4 --> S5
-    S6[push_merge_target]
-    S5 --> S6
-    S7[plan]
-    S6 --> S7
-    S8[review]
-    S7 --> S8
-    S9[verify]
-    S8 --> S9
-    S10[implement]
-    S9 --> S10
-    S11[retry_worktree]
-    S10 --> S11
-    S12[test]
-    S11 --> S12
-    S13[commit_guard]
-    S12 --> S13
-    S14[merge]
-    S13 --> S14
-    S15[push]
-    S14 --> S15
-    S16[fix]
-    S15 --> S16
-    S17[next_or_done]
-    S16 --> S17
-    S18[audit_impl]
-    S17 --> S18
-    S19[remediate]
-    S18 --> S19
-    S20[prepare_pr]
-    S19 --> S20
-    S21[run_arch_lenses]
-    S20 --> S21
-    S22[compose_pr]
-    S21 --> S22
-    S23[extract_pr_number]
-    S22 --> S23
-    S24[annotate_pr_diff]
-    S23 --> S24
-    S25[review_pr]
-    S24 --> S25
-    S26[resolve_review]
-    S25 --> S26
-    S27[re_push_review]
-    S26 --> S27
-    S28[check_review_loop]
-    S27 --> S28
-    S29[check_repo_ci_event]
-    S28 --> S29
-    S30[check_pr_state]
-    S29 --> S30
-    S31[ci_watch]
-    S30 --> S31
-    S32[handle_no_ci_runs]
-    S31 --> S32
-    S33[check_ci_loop]
-    S32 --> S33
-    S34[check_active_trigger_loop]
-    S33 --> S34
-    S35[trigger_ci_actively]
-    S34 --> S35
-    S36[check_ci_already_passed]
-    S35 --> S36
-    S37[escalate_stop_no_ci]
-    S36 --> S37
-    S38[check_repo_merge_state]
-    S37 --> S38
-    S39[route_queue_mode]
-    S38 --> S39
-    S40[enqueue_to_queue]
-    S39 --> S40
-    S41[verify_queue_enrollment]
-    S40 --> S41
-    S42[wait_for_queue]
-    S41 --> S42
-    S43[reenroll_stalled_pr]
-    S42 --> S43
-    S44[check_stall_loop]
-    S43 --> S44
-    S45[check_eject_limit]
-    S44 --> S45
-    S46[queue_ejected_fix]
-    S45 --> S46
-    S47[resolve_queue_merge_conflicts]
-    S46 --> S47
-    S48[re_push_queue_fix]
-    S47 --> S48
-    S49[ci_watch_post_queue_fix]
-    S48 --> S49
-    S50[reenter_merge_queue]
-    S49 --> S50
-    S51[reenter_merge_queue_cheap]
-    S50 --> S51
-    S52[direct_merge]
-    S51 --> S52
-    S53[wait_for_direct_merge]
-    S52 --> S53
-    S54[direct_merge_conflict_fix]
-    S53 --> S54
-    S55[resolve_direct_merge_conflicts]
-    S54 --> S55
-    S56[re_push_direct_fix]
-    S55 --> S56
-    S57[redirect_merge]
-    S56 --> S57
-    S58[immediate_merge]
-    S57 --> S58
-    S59[wait_for_immediate_merge]
-    S58 --> S59
-    S60[immediate_merge_conflict_fix]
-    S59 --> S60
-    S61[resolve_immediate_merge_conflicts]
-    S60 --> S61
-    S62[re_push_immediate_fix]
-    S61 --> S62
-    S63[remerge_immediate]
-    S62 --> S63
-    S64[diagnose_ci]
-    S63 --> S64
-    S65[resolve_ci]
-    S64 --> S65
-    S66[pre_resolve_rebase]
-    S65 --> S66
-    S67[re_push]
-    S66 --> S67
-    S68[detect_ci_conflict]
-    S67 --> S68
-    S69[ci_conflict_fix]
-    S68 --> S69
-    S70[release_issue_success]
-    S69 --> S70
-    S71[patch_token_summary]
-    S70 --> S71
-    S72[register_clone_unconfirmed]
-    S71 --> S72
-    S73[release_issue_failure]
-    S72 --> S73
-    S74[register_clone_success]
-    S73 --> S74
-    S75[register_clone_failure]
-    S74 --> S75
-    S76[done]
-    S75 --> S76
-    S77[escalate_stop]
-    S76 --> S77
+```
+      clone → get_issue_title → claim_issue → compute_branch
+      |
+      +-- create_branch (optional)
+      |
+      plan
+      |
+      +-- review (optional)
+      |
+ +----+ FOR EACH PLAN PART:
+ |    |
+ |    verify → implement → test ↔ [fix on failure]
+ |    |
+ |    merge → push → next_or_done
+ |
+ +----+
+      |
+      +-- audit_impl → remediate (optional)
+      |
+      +-- [open-pr] (optional):
+      |     prepare_pr → compose_pr → review_pr → resolve_review
+      |     ci_watch → check_repo_merge_state
+      |     → [queue | direct | immediate] merge path
+      |     → diagnose_ci → resolve_ci (on CI failure)
+      |
+      release_issue_success / release_issue_failure
+      |
+      +-- patch_token_summary (optional)
+      |
+      register_clone_success / register_clone_failure
 ```

--- a/tests/arch/test_import_linter_contracts.py
+++ b/tests/arch/test_import_linter_contracts.py
@@ -36,3 +36,32 @@ def test_il003_pipeline_config_exception_documented() -> None:
     assert '"autoskillit.config"' not in fm_section, (
         "IL-003 forbidden_modules must continue to omit autoskillit.config."
     )
+
+
+def test_il_contract_count_is_guarded() -> None:
+    """All 9 IL-* contracts must be present in pyproject.toml.
+
+    Silently removing a contract from pyproject.toml would cause lint-imports
+    to stop enforcing that layer boundary with no pytest signal. This test
+    catches that drift.
+
+    If you add a new contract: update the expected_count below and add its
+    IL-NNN comment tag. If you remove a contract: restore it or obtain explicit
+    sign-off and update this test.
+    """
+    pyproject_path = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    raw = pyproject_path.read_text()
+
+    expected_count = 9
+    actual_count = raw.count("[[tool.importlinter.contracts]]")
+    assert actual_count == expected_count, (
+        f"Expected {expected_count} importlinter contracts in pyproject.toml, "
+        f"found {actual_count}. Update this count when adding/removing contracts."
+    )
+
+    expected_ids = [f"IL-{str(i).zfill(3)}" for i in range(1, expected_count + 1)]
+    missing = [il_id for il_id in expected_ids if il_id not in raw]
+    assert not missing, (
+        f"Import-linter contract ID tags missing from pyproject.toml: {missing}. "
+        "Each contract block must carry its IL-NNN comment tag."
+    )

--- a/tests/arch/test_layer_enforcement.py
+++ b/tests/arch/test_layer_enforcement.py
@@ -1081,6 +1081,9 @@ def test_default_classes_only_instantiated_inside_factory_or_allowlist() -> None
         Path("recipe/rules_features.py"): {
             "DefaultSkillResolver"
         },  # deferred default factory fallback
+        Path("recipe/_skill_helpers.py"): {
+            "DefaultSkillResolver"
+        },  # shared helper, deferred default factory fallback
         Path("workspace/session_skills.py"): {
             "DefaultSkillResolver"
         },  # ephemeral session resolver fallback

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -676,7 +676,10 @@ def test_no_subpackage_exceeds_10_files() -> None:
         Group 0 bundled recipes, bringing the count to 41.
         Monolithic file splits (_api.py → _recipe_ingredients + _recipe_composition;
         _analysis.py → _analysis_graph + _analysis_bfs + _analysis_blocks +
-        _analysis_detectors) add 6 files, bringing the count to 47. Exempt at 47 files.
+        _analysis_detectors) add 6 files, bringing the count to 47.
+        _skill_helpers.py extracts the shared _get_skill_category_map helper from
+        rules_skills.py and rules_features.py to eliminate duplication,
+        bringing the count to 48. Exempt at 48 files.
       execution/ — REQ-CNST-003-E3: execution/ decomposes process lifecycle into
         focused single-concern modules (_process_io, _process_kill, _process_race,
         etc.) that cannot be merged without re-introducing the coupling they isolate.
@@ -744,7 +747,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
     """
     EXEMPTIONS: dict[str, int] = {
         "server": 22,
-        "recipe": 47,
+        "recipe": 48,
         "execution": 26,
         "core": 27,
         "cli": 27,

--- a/tests/recipe/test_rules_dedup.py
+++ b/tests/recipe/test_rules_dedup.py
@@ -1,0 +1,25 @@
+"""Guard against re-introduction of _get_skill_category_map duplication.
+
+Asserts that both rule modules share the exact same function object, meaning
+the function is defined once in a shared helper and imported in both places.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+
+def test_skill_category_map_not_duplicated() -> None:
+    """rules_skills and rules_features must share _get_skill_category_map identity.
+
+    If this test fails, someone re-introduced a local definition in one of the
+    two files. The function must live solely in _skill_helpers and be imported.
+    """
+    from autoskillit.recipe import rules_features, rules_skills
+
+    assert rules_skills._get_skill_category_map is rules_features._get_skill_category_map, (
+        "_get_skill_category_map must be the same object in rules_skills and "
+        "rules_features — define it once in recipe/_skill_helpers.py and import it "
+        "in both modules."
+    )

--- a/tests/recipe/test_rules_dedup.py
+++ b/tests/recipe/test_rules_dedup.py
@@ -12,11 +12,6 @@ pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
 
 def test_skill_category_map_not_duplicated() -> None:
-    """rules_skills and rules_features must share _get_skill_category_map identity.
-
-    If this test fails, someone re-introduced a local definition in one of the
-    two files. The function must live solely in _skill_helpers and be imported.
-    """
     from autoskillit.recipe import rules_features, rules_skills
 
     assert rules_skills._get_skill_category_map is rules_features._get_skill_category_map, (

--- a/tests/recipe/test_rules_dedup.py
+++ b/tests/recipe/test_rules_dedup.py
@@ -3,6 +3,7 @@
 Asserts that both rule modules share the exact same function object, meaning
 the function is defined once in a shared helper and imported in both places.
 """
+
 from __future__ import annotations
 
 import pytest


### PR DESCRIPTION
## Summary

Two independent fixes from issue #1388: extract a shared `_get_skill_category_map` helper from duplicated definitions in `rules_skills.py` and `rules_features.py` into a new `recipe/_skill_helpers.py` module, guarded by an identity assertion test. Additionally, strengthen `test_import_linter_contracts.py` to assert the exact count and presence of all nine IL-* contracts so that silently removing any contract would be caught by pytest.

## Architecture Impact

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ─── L0: FOUNDATION ─────────────────────────────────────────── %%
    subgraph L0 ["L0 — FOUNDATION: core/"]
        direction LR
        CORE["autoskillit.core<br/>━━━━━━━━━━<br/>SkillLister, FEATURE_REGISTRY<br/>SKILL_TOOLS, TOOL_SUBSET_TAGS<br/>AUTOSKILLIT_SKILL_PREFIX, Severity<br/>FeatureDef"]
    end

    %% ─── L1: INFRASTRUCTURE ──────────────────────────────────────── %%
    subgraph L1 ["L1 — INFRASTRUCTURE: workspace/"]
        direction LR
        WORKSPACE["autoskillit.workspace<br/>━━━━━━━━━━<br/>DefaultSkillResolver<br/>detect_project_local_overrides"]
    end

    %% ─── L2: RECIPE DOMAIN ───────────────────────────────────────── %%
    subgraph L2 ["L2 — DOMAIN: recipe/"]
        direction TB

        subgraph RecipeSupport ["Recipe Infrastructure"]
            direction LR
            ANALYSIS["recipe._analysis<br/>━━━━━━━━━━<br/>ValidationContext"]
            CONTRACTS["recipe.contracts<br/>━━━━━━━━━━<br/>resolve_skill_name"]
            REGISTRY["recipe.registry<br/>━━━━━━━━━━<br/>RuleFinding, semantic_rule"]
        end

        SKILL_HELPERS["★ recipe._skill_helpers<br/>━━━━━━━━━━<br/>_get_skill_category_map()<br/>[shared helper — extracted<br/>to prevent duplication]"]

        subgraph RuleModules ["Semantic Rule Modules"]
            direction LR
            RULES_FEATURES["● recipe.rules_features<br/>━━━━━━━━━━<br/>check_feature_gated_tools<br/>@semantic_rule"]
            RULES_SKILLS["● recipe.rules_skills<br/>━━━━━━━━━━<br/>_check_unknown_skill_command<br/>_check_subset_disabled_skill<br/>_check_project_local_skill_override<br/>@semantic_rule"]
        end
    end

    %% ─── TESTS ───────────────────────────────────────────────────── %%
    subgraph Tests ["TESTS"]
        direction LR
        TEST_DEDUP["★ tests/recipe/test_rules_dedup.py<br/>━━━━━━━━━━<br/>Identity guard:<br/>rules_skills._get_skill_category_map<br/>is rules_features._get_skill_category_map"]

        TEST_IL["● tests/arch/test_import_linter_contracts.py<br/>━━━━━━━━━━<br/>Guards IL contract count == 9<br/>Guards IL-003 exception documented"]

        TEST_LAYER["● tests/arch/test_layer_enforcement.py<br/>━━━━━━━━━━<br/>AST-based layer enforcement<br/>SUBPACKAGE_LAYERS registry<br/>L0–L3 import direction rules"]

        TEST_ISO["● tests/arch/test_subpackage_isolation.py<br/>━━━━━━━━━━<br/>Subpackage isolation rules<br/>Line-limit guards<br/>Singleton locality rules"]
    end

    %% ─── VALID DEPENDENCIES (downward / same-layer) ──────────────── %%
    SKILL_HELPERS -->|"imports: SkillLister"| CORE
    SKILL_HELPERS -.->|"deferred import<br/>DefaultSkillResolver"| WORKSPACE

    RULES_FEATURES -->|"imports: _get_skill_category_map"| SKILL_HELPERS
    RULES_SKILLS   -->|"imports: _get_skill_category_map"| SKILL_HELPERS

    RULES_FEATURES -->|"imports: ValidationContext"| ANALYSIS
    RULES_FEATURES -->|"imports: resolve_skill_name"| CONTRACTS
    RULES_FEATURES -->|"imports: RuleFinding, semantic_rule"| REGISTRY
    RULES_FEATURES -->|"imports: FEATURE_REGISTRY,SKILL_TOOLS<br/>TOOL_SUBSET_TAGS, FeatureDef, Severity"| CORE

    RULES_SKILLS -->|"imports: ValidationContext"| ANALYSIS
    RULES_SKILLS -->|"imports: resolve_skill_name"| CONTRACTS
    RULES_SKILLS -->|"imports: RuleFinding, semantic_rule"| REGISTRY
    RULES_SKILLS -->|"imports: AUTOSKILLIT_SKILL_PREFIX<br/>SKILL_TOOLS, Severity, SkillLister"| CORE
    RULES_SKILLS -.->|"deferred imports:<br/>DefaultSkillResolver<br/>detect_project_local_overrides"| WORKSPACE

    %% ─── TEST → PRODUCTION VALIDATION ARROWS ─────────────────────── %%
    TEST_DEDUP -->|"validates identity:<br/>same function object"| SKILL_HELPERS
    TEST_DEDUP -->|"imports rules_features"| RULES_FEATURES
    TEST_DEDUP -->|"imports rules_skills"| RULES_SKILLS

    TEST_IL -->|"validates pyproject.toml<br/>IL contract count (AST-free)"| L2

    TEST_LAYER -->|"AST analysis of<br/>all source files"| L0
    TEST_LAYER -->|"AST analysis of<br/>all source files"| L1
    TEST_LAYER -->|"AST analysis of<br/>all source files"| L2

    TEST_ISO -->|"isolation rules,<br/>file-count limits"| L2

    %% ─── CLASS ASSIGNMENTS ────────────────────────────────────────── %%
    class CORE stateNode;
    class WORKSPACE handler;
    class ANALYSIS,CONTRACTS,REGISTRY phase;
    class SKILL_HELPERS newComponent;
    class RULES_FEATURES,RULES_SKILLS handler;
    class TEST_DEDUP newComponent;
    class TEST_IL,TEST_LAYER,TEST_ISO detector;
```

Closes #1388

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-1388-20260428-093248-972399/.autoskillit/temp/make-plan/arch_audit_dedup_il_contract_guard_plan_2026-04-28_093749.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 129 | 12.9k | 656.7k | 58.6k | 1 | 5m 19s |
| verify | 116 | 7.4k | 574.3k | 42.3k | 1 | 2m 7s |
| implement | 156 | 7.6k | 857.1k | 59.6k | 1 | 2m 14s |
| prepare_pr | 52 | 3.4k | 161.2k | 25.3k | 1 | 1m 4s |
| run_arch_lenses | 63 | 6.8k | 173.4k | 61.4k | 1 | 3m 30s |
| compose_pr | 51 | 3.9k | 158.8k | 24.8k | 1 | 1m 15s |
| review_pr | 102 | 19.9k | 453.5k | 49.5k | 1 | 4m 53s |
| resolve_review | 189 | 10.5k | 885.7k | 88.5k | 1 | 5m 32s |
| ci_conflict_fix | 312 | 13.8k | 1.7M | 97.5k | 2 | 5m 10s |
| diagnose_ci | 84 | 2.2k | 326.0k | 31.4k | 1 | 1m 11s |
| resolve_ci | 110 | 3.9k | 651.4k | 55.6k | 1 | 3m 40s |
| **Total** | 1.4k | 92.4k | 6.6M | 594.6k | | 36m 1s |