### PR TITLE
Fix `escalate_stop_no_ci` Orphaned Label and Unregistered Clone

### DIFF
--- a/src/autoskillit/config/_config_dataclasses.py
+++ b/src/autoskillit/config/_config_dataclasses.py
@@ -165,6 +165,7 @@ class GitHubConfig:
     default_repo: str | None = None
     in_progress_label: str = "in-progress"
     staged_label: str = "staged"
+    fail_label: str = "fail"
     allowed_labels: list[str] = field(default_factory=list)
 
     def check_label_allowed(self, label: str) -> str | None:

--- a/src/autoskillit/config/defaults.yaml
+++ b/src/autoskillit/config/defaults.yaml
@@ -82,11 +82,13 @@ github:
   default_repo: null
   in_progress_label: "in-progress"
   staged_label: "staged"
+  fail_label: "fail"
   allowed_labels:
     - "bug"
     - "enhancement"
     - "in-progress"
     - "staged"
+    - "fail"
     - "autoreported"
     - "recipe:implementation"
     - "recipe:remediation"

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -363,6 +363,7 @@ class AutomationConfig:
                 default_repo=val(gh, "default_repo", _gh["default_repo"]) or None,
                 in_progress_label=str(val(gh, "in_progress_label", _gh["in_progress_label"])),
                 staged_label=str(val(gh, "staged_label", _gh["staged_label"])),
+                fail_label=str(val(gh, "fail_label", _gh["fail_label"])),
                 allowed_labels=list(val(gh, "allowed_labels", _gh["allowed_labels"])),
             ),
             report_bug=ReportBugConfig(

--- a/src/autoskillit/recipe/rules_tools.py
+++ b/src/autoskillit/recipe/rules_tools.py
@@ -164,7 +164,9 @@ _TOOL_PARAMS: dict[str, frozenset[str]] = {
     ),
     "enrich_issues": frozenset({"issue_number", "batch", "dry_run", "repo"}),
     "claim_issue": frozenset({"issue_url", "label", "allow_reentry"}),
-    "release_issue": frozenset({"issue_url", "label", "target_branch", "staged_label"}),
+    "release_issue": frozenset(
+        {"issue_url", "label", "target_branch", "staged_label", "fail_label"}
+    ),
     "fetch_github_issue": frozenset({"issue_url", "include_comments"}),
     "get_issue_title": frozenset({"issue_url"}),
     # --- Status tools ---

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -811,8 +811,8 @@ steps:
     on_result:
       - when: "${{ result.stdout | trim }} == true"
         route: check_repo_merge_state
-      - route: escalate_stop_no_ci
-    on_failure: escalate_stop_no_ci
+      - route: mark_issue_failed_no_ci
+    on_failure: mark_issue_failed_no_ci
     skip_when_false: "inputs.open_pr"
     note: >
       Safety net before terminal escalation: checks if CI already passed
@@ -820,6 +820,27 @@ steps:
       staleness). Uses statusCheckRollup as the authoritative signal.
       Routes to merge queue gate if all checks are SUCCESS/NEUTRAL/SKIPPED;
       otherwise falls through to the terminal stop.
+
+  mark_issue_failed_no_ci:
+    description: "Swap in-progress → fail label before CI failure escalation"
+    tool: release_issue
+    optional: true
+    skip_when_false: inputs.issue_url
+    with:
+      issue_url: ${{ inputs.issue_url }}
+      fail_label: "fail"
+    on_success: register_clone_no_ci
+    on_failure: register_clone_no_ci
+
+  register_clone_no_ci:
+    description: "Register clone as preserved (no-CI error pipeline)"
+    tool: register_clone_status
+    with:
+      clone_path: "${{ context.work_dir }}"
+      status: "error"
+      step_name: register_clone_no_ci
+    on_success: escalate_stop_no_ci
+    on_failure: escalate_stop_no_ci
 
   escalate_stop_no_ci:
     action: stop

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -793,8 +793,8 @@ steps:
     on_result:
       - when: "${{ result.stdout | trim }} == true"
         route: check_repo_merge_state
-      - route: escalate_stop_no_ci
-    on_failure: escalate_stop_no_ci
+      - route: mark_issue_failed_no_ci
+    on_failure: mark_issue_failed_no_ci
     skip_when_false: "inputs.open_pr"
     note: >
       Safety net before terminal escalation: checks if CI already passed
@@ -802,6 +802,27 @@ steps:
       staleness). Uses statusCheckRollup as the authoritative signal.
       Routes to merge queue gate if all checks are SUCCESS/NEUTRAL/SKIPPED;
       otherwise falls through to the terminal stop.
+
+  mark_issue_failed_no_ci:
+    description: "Swap in-progress → fail label before CI failure escalation"
+    tool: release_issue
+    optional: true
+    skip_when_false: inputs.issue_url
+    with:
+      issue_url: ${{ inputs.issue_url }}
+      fail_label: "fail"
+    on_success: register_clone_no_ci
+    on_failure: register_clone_no_ci
+
+  register_clone_no_ci:
+    description: "Register clone as preserved (no-CI error pipeline)"
+    tool: register_clone_status
+    with:
+      clone_path: "${{ context.work_dir }}"
+      status: "error"
+      step_name: register_clone_no_ci
+    on_success: escalate_stop_no_ci
+    on_failure: escalate_stop_no_ci
 
   escalate_stop_no_ci:
     action: stop

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -791,8 +791,8 @@ steps:
     on_result:
       - when: "${{ result.stdout | trim }} == true"
         route: check_repo_merge_state
-      - route: escalate_stop_no_ci
-    on_failure: escalate_stop_no_ci
+      - route: mark_issue_failed_no_ci
+    on_failure: mark_issue_failed_no_ci
     skip_when_false: "inputs.open_pr"
     note: >
       Safety net before terminal escalation: checks if CI already passed
@@ -800,6 +800,27 @@ steps:
       staleness). Uses statusCheckRollup as the authoritative signal.
       Routes to merge queue gate if all checks are SUCCESS/NEUTRAL/SKIPPED;
       otherwise falls through to the terminal stop.
+
+  mark_issue_failed_no_ci:
+    description: "Swap in-progress → fail label before CI failure escalation"
+    tool: release_issue
+    optional: true
+    skip_when_false: inputs.issue_url
+    with:
+      issue_url: ${{ inputs.issue_url }}
+      fail_label: "fail"
+    on_success: register_clone_no_ci
+    on_failure: register_clone_no_ci
+
+  register_clone_no_ci:
+    description: "Register clone as preserved (no-CI error pipeline)"
+    tool: register_clone_status
+    with:
+      clone_path: "${{ context.work_dir }}"
+      status: "error"
+      step_name: register_clone_no_ci
+    on_success: escalate_stop_no_ci
+    on_failure: escalate_stop_no_ci
 
   escalate_stop_no_ci:
     action: stop

--- a/src/autoskillit/server/tools_issue_lifecycle.py
+++ b/src/autoskillit/server/tools_issue_lifecycle.py
@@ -457,12 +457,16 @@ async def claim_issue(
             description="Issue is actively being processed by a pipeline session",
         )
 
-        add_result = await tool_ctx.github_client.add_labels(
-            owner, repo, issue_number, [effective_label]
+        swap_result = await tool_ctx.github_client.swap_labels(
+            owner,
+            repo,
+            issue_number,
+            remove_labels=[tool_ctx.config.github.fail_label],
+            add_labels=[effective_label],
         )
-        if not add_result.get("success"):
+        if not swap_result.get("success"):
             return json.dumps(
-                {"success": False, "error": add_result.get("error", "add_labels failed")}
+                {"success": False, "error": swap_result.get("error", "swap_labels failed")}
             )
 
         return json.dumps(
@@ -485,6 +489,7 @@ async def release_issue(
     label: str | None = None,
     target_branch: str | None = None,
     staged_label: str | None = None,
+    fail_label: str | None = None,
 ) -> str:
     """Remove the in-progress label from a GitHub issue to release it.
 
@@ -494,6 +499,9 @@ async def release_issue(
     When target_branch is provided and differs from the configured default base branch,
     also applies a 'staged' label to indicate the work is merged and awaiting promotion.
 
+    When fail_label is provided (and target_branch is NOT), swaps in-progress for the
+    fail label to mark the issue as failed without releasing it back to the queue.
+
     Returns JSON with: success, issue_number, label, staged, staged_label.
     On gate closed or no token: {success: false, error: "..."}.
 
@@ -502,6 +510,7 @@ async def release_issue(
         label: Label name to remove. Defaults to github.in_progress_label from config.
         target_branch: Branch the PR was merged into. When non-default, applies staged label.
         staged_label: Label name for staged state. Defaults to github.staged_label from config.
+        fail_label: Label name for failure state. When provided, swaps in-progress for this label.
 
     Never raises.
     """
@@ -532,6 +541,7 @@ async def release_issue(
         should_stage = target_branch is not None and target_branch != promotion_target
 
         staged = False
+        config_fail_label = tool_ctx.config.github.fail_label
         effective_staged_label = staged_label or tool_ctx.config.github.staged_label
 
         if should_stage:
@@ -545,7 +555,6 @@ async def release_issue(
                     }
                 )
 
-            # Ensure the staged label definition exists in the repo (no label set mutation yet)
             ensure_result = await tool_ctx.github_client.ensure_label(
                 owner,
                 repo,
@@ -567,12 +576,14 @@ async def release_issue(
                     }
                 )
 
-            # Atomic swap: remove in-progress, add staged in one PUT
+            remove_set = [effective_label]
+            if config_fail_label:
+                remove_set.append(config_fail_label)
             swap_result = await tool_ctx.github_client.swap_labels(
                 owner,
                 repo,
                 issue_number,
-                remove_labels=[effective_label],
+                remove_labels=remove_set,
                 add_labels=[effective_staged_label],
             )
             if not swap_result.get("success"):
@@ -585,13 +596,70 @@ async def release_issue(
                     }
                 )
             staged = True
-        else:
-            # Just remove in-progress atomically (no staging)
+        elif fail_label is not None:
+            if err := tool_ctx.config.github.check_label_allowed(fail_label):
+                return json.dumps(
+                    {
+                        "success": False,
+                        "issue_number": issue_number,
+                        "label": fail_label,
+                        "error": err,
+                    }
+                )
+
+            ensure_result = await tool_ctx.github_client.ensure_label(
+                owner,
+                repo,
+                fail_label,
+                color="d73a4a",
+            )
+            if not ensure_result.get("success"):
+                return json.dumps(
+                    {
+                        "success": False,
+                        "issue_number": issue_number,
+                        "label": effective_label,
+                        "error": (
+                            f"Failed to ensure fail label: {ensure_result.get('error', '?')}"
+                        ),
+                    }
+                )
+
             swap_result = await tool_ctx.github_client.swap_labels(
                 owner,
                 repo,
                 issue_number,
                 remove_labels=[effective_label],
+                add_labels=[fail_label],
+            )
+            if not swap_result.get("success"):
+                return json.dumps(
+                    {
+                        "success": False,
+                        "issue_number": issue_number,
+                        "label": effective_label,
+                        "error": f"Failed to apply fail label: {swap_result.get('error', '?')}",
+                    }
+                )
+
+            return json.dumps(
+                {
+                    "success": True,
+                    "issue_number": issue_number,
+                    "label": effective_label,
+                    "failed": True,
+                    "fail_label": fail_label,
+                }
+            )
+        else:
+            remove_set = [effective_label]
+            if config_fail_label:
+                remove_set.append(config_fail_label)
+            swap_result = await tool_ctx.github_client.swap_labels(
+                owner,
+                repo,
+                issue_number,
+                remove_labels=remove_set,
                 add_labels=[],
             )
             if not swap_result.get("success"):

--- a/src/autoskillit/server/tools_issue_lifecycle.py
+++ b/src/autoskillit/server/tools_issue_lifecycle.py
@@ -544,6 +544,10 @@ async def release_issue(
         config_fail_label = tool_ctx.config.github.fail_label
         effective_staged_label = staged_label or tool_ctx.config.github.staged_label
 
+        remove_set = [effective_label]
+        if config_fail_label:
+            remove_set.append(config_fail_label)
+
         if should_stage:
             if err := tool_ctx.config.github.check_label_allowed(effective_staged_label):
                 return json.dumps(
@@ -576,9 +580,6 @@ async def release_issue(
                     }
                 )
 
-            remove_set = [effective_label]
-            if config_fail_label:
-                remove_set.append(config_fail_label)
             swap_result = await tool_ctx.github_client.swap_labels(
                 owner,
                 repo,
@@ -652,9 +653,6 @@ async def release_issue(
                 }
             )
         else:
-            remove_set = [effective_label]
-            if config_fail_label:
-                remove_set.append(config_fail_label)
             swap_result = await tool_ctx.github_client.swap_labels(
                 owner,
                 repo,

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -723,6 +723,12 @@ class TestDynaconfIntegration:
         cfg = GitHubConfig()
         assert cfg.in_progress_label == "in-progress"
 
+    def test_github_config_has_fail_label(self):
+        from autoskillit.config.settings import GitHubConfig
+
+        cfg = GitHubConfig()
+        assert cfg.fail_label == "fail"
+
 
 def test_secrets_only_keys_covers_all_github_secret_fields() -> None:
     """_SECRETS_ONLY_KEYS must include every field in GitHubConfig that holds a secret.

--- a/tests/config/test_settings_allowed_labels.py
+++ b/tests/config/test_settings_allowed_labels.py
@@ -86,3 +86,10 @@ class TestDefaultsYamlAllowedLabels:
             "recipe:remediation",
         }
         assert expected.issubset(set(cfg.github.allowed_labels))
+
+    def test_fail_label_in_allowed_labels_default(self, tmp_path):
+        """defaults.yaml whitelist includes 'fail' label for CI failure marking."""
+        from autoskillit.config import load_config
+
+        cfg = load_config(tmp_path)
+        assert "fail" in cfg.github.allowed_labels

--- a/tests/recipe/test_check_ci_already_passed_routing.py
+++ b/tests/recipe/test_check_ci_already_passed_routing.py
@@ -30,18 +30,18 @@ def test_check_ci_already_passed_routes_to_merge_state_on_success(recipe):
 
 
 def test_check_ci_already_passed_fallthrough_routes_to_escalate(recipe):
-    """Default (non-matching) on_result condition routes to escalate_stop_no_ci."""
+    """Default (non-matching) on_result condition routes to mark_issue_failed_no_ci."""
     step = recipe.steps["check_ci_already_passed"]
     assert step.on_result is not None
     conditions = step.on_result.conditions or []
     fallthrough_routes = [c.route for c in conditions if not c.when]
-    assert "escalate_stop_no_ci" in fallthrough_routes
+    assert "mark_issue_failed_no_ci" in fallthrough_routes
 
 
 def test_check_ci_already_passed_on_failure_routes_to_escalate(recipe):
-    """on_failure routes to escalate_stop_no_ci (gh CLI failure)."""
+    """on_failure routes to mark_issue_failed_no_ci (gh CLI failure)."""
     step = recipe.steps["check_ci_already_passed"]
-    assert step.on_failure == "escalate_stop_no_ci"
+    assert step.on_failure == "mark_issue_failed_no_ci"
 
 
 def test_check_ci_already_passed_uses_run_cmd(recipe):
@@ -65,7 +65,12 @@ def test_check_ci_already_passed_has_skip_when_false(recipe):
 def test_no_direct_escalate_stop_no_ci_callers_except_safety_net(recipe):
     """Only check_ci_already_passed and escalate_stop_no_ci itself reference
     escalate_stop_no_ci."""
-    EXCLUDED = {"check_ci_already_passed", "escalate_stop_no_ci"}
+    EXCLUDED = {
+        "check_ci_already_passed",
+        "escalate_stop_no_ci",
+        "mark_issue_failed_no_ci",
+        "register_clone_no_ci",
+    }
     for name, step in recipe.steps.items():
         if name in EXCLUDED:
             continue
@@ -75,3 +80,35 @@ def test_no_direct_escalate_stop_no_ci_callers_except_safety_net(recipe):
         assert "escalate_stop_no_ci" not in direct_routes, (
             f"Step '{name}' still routes directly to escalate_stop_no_ci"
         )
+
+
+def test_mark_issue_failed_no_ci_routes_to_register_clone_no_ci(recipe):
+    """mark_issue_failed_no_ci calls release_issue with fail_label and routes to register_clone."""
+    step = recipe.steps["mark_issue_failed_no_ci"]
+    assert step.tool == "release_issue"
+    assert step.on_success == "register_clone_no_ci"
+    assert step.on_failure == "register_clone_no_ci"
+    assert step.with_args.get("fail_label") == "fail"
+
+
+def test_register_clone_no_ci_routes_to_escalate_stop_no_ci(recipe):
+    """register_clone_no_ci registers clone as error and routes to escalate_stop."""
+    step = recipe.steps["register_clone_no_ci"]
+    assert step.tool == "register_clone_status"
+    assert step.on_success == "escalate_stop_no_ci"
+    assert step.on_failure == "escalate_stop_no_ci"
+    assert step.with_args.get("status") == "error"
+
+
+def test_no_ci_failure_chain_complete(recipe):
+    """Full chain: check_ci_already_passed -> mark_issue_failed -> register_clone -> escalate."""
+    ci_step = recipe.steps["check_ci_already_passed"]
+    conditions = ci_step.on_result.conditions or []
+    fallthrough_routes = [c.route for c in conditions if not c.when]
+    assert "mark_issue_failed_no_ci" in fallthrough_routes
+
+    mark_step = recipe.steps["mark_issue_failed_no_ci"]
+    assert mark_step.on_success == "register_clone_no_ci"
+
+    reg_step = recipe.steps["register_clone_no_ci"]
+    assert reg_step.on_success == "escalate_stop_no_ci"

--- a/tests/server/test_release_issue_fail_label.py
+++ b/tests/server/test_release_issue_fail_label.py
@@ -31,9 +31,7 @@ class TestReleaseIssueFailLabel:
         assert result["success"] is True
         assert result["failed"] is True
         assert result["fail_label"] == "fail"
-        mock_client.ensure_label.assert_called_once_with(
-            "owner", "repo", "fail", color="d73a4a"
-        )
+        mock_client.ensure_label.assert_called_once_with("owner", "repo", "fail", color="d73a4a")
         mock_client.swap_labels.assert_called_once_with(
             "owner",
             "repo",

--- a/tests/server/test_release_issue_fail_label.py
+++ b/tests/server/test_release_issue_fail_label.py
@@ -1,0 +1,117 @@
+"""Tests for release_issue fail_label path and fail label cleanup on claim/release."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from autoskillit.server.tools_issue_lifecycle import claim_issue, release_issue
+
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+
+class TestReleaseIssueFailLabel:
+    @pytest.mark.anyio
+    async def test_release_issue_fail_label_swap(self, tool_ctx, monkeypatch):
+        """fail_label swaps in-progress for fail label."""
+        mock_client = AsyncMock()
+        mock_client.ensure_label.return_value = {"success": True, "created": True}
+        mock_client.swap_labels.return_value = {"success": True, "labels": ["fail"]}
+        monkeypatch.setattr(tool_ctx, "github_client", mock_client)
+
+        result = json.loads(
+            await release_issue(
+                issue_url="https://github.com/owner/repo/issues/42",
+                fail_label="fail",
+            )
+        )
+
+        assert result["success"] is True
+        assert result["failed"] is True
+        assert result["fail_label"] == "fail"
+        mock_client.ensure_label.assert_called_once_with(
+            "owner", "repo", "fail", color="d73a4a"
+        )
+        mock_client.swap_labels.assert_called_once_with(
+            "owner",
+            "repo",
+            42,
+            remove_labels=["in-progress"],
+            add_labels=["fail"],
+        )
+
+    @pytest.mark.anyio
+    async def test_release_issue_success_removes_fail_label(self, tool_ctx, monkeypatch):
+        """Staging path includes fail label in remove_labels for cleanup."""
+        mock_client = AsyncMock()
+        mock_client.ensure_label.return_value = {"success": True, "created": True}
+        mock_client.swap_labels.return_value = {"success": True, "labels": ["staged"]}
+        monkeypatch.setattr(tool_ctx, "github_client", mock_client)
+
+        result = json.loads(
+            await release_issue(
+                issue_url="https://github.com/owner/repo/issues/42",
+                target_branch="integration",
+            )
+        )
+
+        assert result["success"] is True
+        assert result["staged"] is True
+        swap_call = mock_client.swap_labels.call_args
+        assert "in-progress" in swap_call.kwargs["remove_labels"]
+        assert "fail" in swap_call.kwargs["remove_labels"]
+        assert "staged" in swap_call.kwargs["add_labels"]
+
+    @pytest.mark.anyio
+    async def test_release_issue_simple_remove_cleans_fail_label(self, tool_ctx, monkeypatch):
+        """Simple release (no staging, no fail_label) also removes fail label."""
+        mock_client = AsyncMock()
+        mock_client.swap_labels.return_value = {"success": True, "labels": []}
+        monkeypatch.setattr(tool_ctx, "github_client", mock_client)
+
+        result = json.loads(
+            await release_issue(
+                issue_url="https://github.com/owner/repo/issues/42",
+            )
+        )
+
+        assert result["success"] is True
+        swap_call = mock_client.swap_labels.call_args
+        assert "in-progress" in swap_call.kwargs["remove_labels"]
+        assert "fail" in swap_call.kwargs["remove_labels"]
+
+
+class TestClaimIssueFailLabelCleanup:
+    @pytest.mark.anyio
+    async def test_claim_issue_removes_fail_label_on_claim(self, tool_ctx, monkeypatch):
+        """claim_issue uses swap_labels to remove fail label while adding in-progress."""
+        mock_client = AsyncMock()
+        mock_client.fetch_issue.return_value = {
+            "success": True,
+            "labels": [{"name": "bug"}],
+        }
+        mock_client.ensure_label.return_value = {"success": True, "created": False}
+        mock_client.swap_labels.return_value = {
+            "success": True,
+            "labels": ["in-progress"],
+        }
+        monkeypatch.setattr(tool_ctx, "github_client", mock_client)
+
+        result = json.loads(
+            await claim_issue(
+                issue_url="https://github.com/owner/repo/issues/42",
+            )
+        )
+
+        assert result["success"] is True
+        assert result["claimed"] is True
+        mock_client.swap_labels.assert_called_once_with(
+            "owner",
+            "repo",
+            42,
+            remove_labels=["fail"],
+            add_labels=["in-progress"],
+        )
+        mock_client.add_labels.assert_not_called()

--- a/tests/server/test_tools_integrations.py
+++ b/tests/server/test_tools_integrations.py
@@ -136,7 +136,7 @@ class TestClaimIssueTool:
         mock_client = AsyncMock()
         mock_client.fetch_issue.return_value = {"success": True, "labels": []}
         mock_client.ensure_label.return_value = {"success": True, "created": True}
-        mock_client.add_labels.return_value = {"success": True, "labels": ["in-progress"]}
+        mock_client.swap_labels.return_value = {"success": True, "labels": ["in-progress"]}
         tool_ctx.github_client = mock_client
         result = json.loads(
             await claim_issue("https://github.com/owner/repo/issues/42", allow_reentry=True)
@@ -144,7 +144,9 @@ class TestClaimIssueTool:
         assert result["success"] is True
         assert result["claimed"] is True
         assert result.get("reentry", False) is False
-        mock_client.add_labels.assert_called_once_with("owner", "repo", 42, ["in-progress"])
+        mock_client.swap_labels.assert_called_once_with(
+            "owner", "repo", 42, remove_labels=["fail"], add_labels=["in-progress"]
+        )
 
 
 class TestReleaseIssueTool:

--- a/tests/server/test_tools_issue_lifecycle.py
+++ b/tests/server/test_tools_issue_lifecycle.py
@@ -330,7 +330,7 @@ async def test_claim_issue_success(tool_ctx) -> None:
     tool_ctx.github_client = AsyncMock()
     tool_ctx.github_client.fetch_issue = AsyncMock(return_value=issue_data)
     tool_ctx.github_client.ensure_label = AsyncMock(return_value={"success": True})
-    tool_ctx.github_client.add_labels = AsyncMock(return_value={"success": True})
+    tool_ctx.github_client.swap_labels = AsyncMock(return_value={"success": True})
 
     result = json.loads(
         await claim_issue(
@@ -380,7 +380,7 @@ async def test_release_issue_stages_when_different_branch(
     tool_ctx.github_client = AsyncMock()
     tool_ctx.github_client.remove_label = AsyncMock(return_value={"success": True})
     tool_ctx.github_client.ensure_label = AsyncMock(return_value={"success": True})
-    tool_ctx.github_client.add_labels = AsyncMock(return_value={"success": True})
+    tool_ctx.github_client.swap_labels = AsyncMock(return_value={"success": True})
 
     result = json.loads(
         await release_issue(

--- a/tests/server/test_tools_label_validation.py
+++ b/tests/server/test_tools_label_validation.py
@@ -29,7 +29,7 @@ class TestClaimIssueWhitelist:
         assert result["success"] is False
         assert "unlisted-label" in result["error"]
         mock_client.ensure_label.assert_not_called()
-        mock_client.add_labels.assert_not_called()
+        mock_client.swap_labels.assert_not_called()
 
     @pytest.mark.anyio
     async def test_claim_issue_allows_whitelisted_label(self, tool_ctx, monkeypatch):
@@ -41,7 +41,7 @@ class TestClaimIssueWhitelist:
             "labels": [],
         }
         mock_client.ensure_label.return_value = {"success": True, "created": True}
-        mock_client.add_labels.return_value = {"success": True, "labels": ["in-progress"]}
+        mock_client.swap_labels.return_value = {"success": True, "labels": ["in-progress"]}
         monkeypatch.setattr(tool_ctx, "github_client", mock_client)
 
         result = json.loads(
@@ -59,7 +59,7 @@ class TestClaimIssueWhitelist:
         mock_client = AsyncMock()
         mock_client.fetch_issue.return_value = {"success": True, "labels": []}
         mock_client.ensure_label.return_value = {"success": True, "created": True}
-        mock_client.add_labels.return_value = {"success": True, "labels": ["any-label"]}
+        mock_client.swap_labels.return_value = {"success": True, "labels": ["any-label"]}
         monkeypatch.setattr(tool_ctx, "github_client", mock_client)
 
         result = json.loads(


### PR DESCRIPTION
## Summary

`escalate_stop_no_ci` is a bare `action: stop` in `implementation.yaml`, `remediation.yaml`, and `implementation-groups.yaml`. When the CI watch loop exhausts all retry mechanisms and reaches this terminal step, the `in-progress` label is never removed from the issue and the clone directory is never registered for deferred cleanup. This contrasts with every other failure terminal path, which routes through `release_issue_failure` -> `register_clone_failure` -> `escalate_stop`.

The fix inserts a two-step cleanup chain (`mark_issue_failed_no_ci` -> `register_clone_no_ci`) between `check_ci_already_passed` and `escalate_stop_no_ci`, extends the `release_issue` MCP tool with a `fail_label` parameter for atomic `in-progress` -> `fail` label swaps, and enhances `claim_issue` and `release_issue` success paths to handle the `fail` label during resume and promotion scenarios.

## Requirements

### Group: RECIPE — Recipe YAML Routing Changes

**REQ-RECIPE-001:** The `escalate_stop_no_ci` step must only be reachable after an atomic label swap from `in-progress` → `fail` has been performed on the claimed issue.

**REQ-RECIPE-002:** The `escalate_stop_no_ci` step must only be reachable after `register_clone_failure` has been called to register the clone directory for deferred cleanup.

**REQ-RECIPE-003:** The failure cleanup chain (`mark_issue_failed` → `register_clone_failure` → `escalate_stop_no_ci`) must be applied identically in `implementation.yaml`, `remediation.yaml`, and `implementation-groups.yaml`.

**REQ-RECIPE-004:** The `check_ci_already_passed` step's `on_result` (false branch) and `on_failure` paths must route through the failure cleanup chain rather than directly to `escalate_stop_no_ci`.

### Group: LABEL — Label Swap Semantics

**REQ-LABEL-001:** The `fail` label must be created if it does not exist (idempotent `gh label create --force`).

**REQ-LABEL-002:** The label swap from `in-progress` → `fail` must be atomic: a single `gh issue edit --remove-label "in-progress" --add-label "fail"` call.

**REQ-LABEL-003:** When a session resumes work on a `fail`-labeled issue and succeeds, it must swap `fail` back to `in-progress` before continuing the pipeline.

**REQ-LABEL-004:** When `release_issue_success` or the promotion step detects `in-progress` is absent but `fail` is present, it must swap `fail` → `staged` rather than failing or leaving the label orphaned.

### Group: TEST — Test Updates

**REQ-TEST-001:** The test `test_no_direct_escalate_stop_no_ci_callers_except_safety_net` must be updated to reflect the new intermediate cleanup steps between `check_ci_already_passed` and `escalate_stop_no_ci`.

**REQ-TEST-002:** Tests asserting `check_ci_already_passed` routing (`test_check_ci_already_passed_fallthrough_routes_to_escalate`, `test_check_ci_already_passed_on_failure_routes_to_escalate`) must be updated to assert routing to the new cleanup entry step rather than directly to `escalate_stop_no_ci`.

**REQ-TEST-003:** A new test must verify that the failure cleanup chain performs both the `in-progress` → `fail` label swap and `register_clone_failure` before reaching `escalate_stop_no_ci`.

**REQ-TEST-004:** A new test must verify that `release_issue_success` handles the `fail` label correctly (swaps `fail` → `staged` when `in-progress` is absent).

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START<br/>Recipe begins])
    DONE([DONE<br/>Pipeline complete])
    ESCALATE_STOP([escalate_stop<br/>Generic failure])
    ESCALATE_STOP_NO_CI(["● escalate_stop_no_ci<br/>━━━━━━━━━━<br/>action: stop<br/>CI watch exhausted"])

    subgraph Validation ["● Label Validation Gate"]
        direction TB
        VAL_CHECK{"● check_label_allowed<br/>━━━━━━━━━━<br/>allowed_labels<br/>empty?"}
        VAL_REJECT["● Reject<br/>━━━━━━━━━━<br/>Error: label not in<br/>allowed list"]
    end

    subgraph Claim ["● Issue Claim Phase"]
        direction TB
        CLAIM["● claim_issue<br/>━━━━━━━━━━<br/>resolve effective_label<br/>fetch current labels"]
        CLAIM_DEC{"Label already<br/>present?"}
        CLAIM_REENTRY{"allow_reentry?"}
        CLAIM_SWAP["● swap_labels<br/>━━━━━━━━━━<br/>remove: fail<br/>add: in-progress"]
    end

    subgraph CIWatch ["CI Watch & Retry Loops"]
        direction TB
        CI_WATCH["ci_watch<br/>━━━━━━━━━━<br/>wait_for_ci"]
        CI_DEC{"conclusion?"}
        HANDLE_NO_CI["handle_no_ci_runs<br/>━━━━━━━━━━<br/>check_repo_merge_state"]
        CI_LOOP{"● check_ci_loop<br/>━━━━━━━━━━<br/>max_exceeded?<br/>max=2"}
        TRIGGER_LOOP{"check_active_<br/>trigger_loop<br/>━━━━━━━━━━<br/>max_exceeded?<br/>max=2"}
        TRIGGER_CI["trigger_ci_actively<br/>━━━━━━━━━━<br/>gh pr close/reopen"]
    end

    subgraph CICheck ["● CI Already Passed Gate"]
        direction TB
        CHECK_PASSED{"● check_ci_already_passed<br/>━━━━━━━━━━<br/>gh pr view<br/>statusCheckRollup"}
    end

    subgraph NoCIChain ["● No-CI Failure Chain"]
        direction TB
        MARK_FAILED["● mark_issue_failed_no_ci<br/>━━━━━━━━━━<br/>release_issue<br/>fail_label: fail<br/>optional: skip if no issue_url"]
        REG_CLONE_NO_CI["● register_clone_no_ci<br/>━━━━━━━━━━<br/>register_clone_status<br/>status: error"]
    end

    subgraph Release ["● Release Issue Paths"]
        direction TB
        REL_DEC{"● Release<br/>branch?"}
        REL_STAGING["● Branch A: Staging<br/>━━━━━━━━━━<br/>swap_labels<br/>remove: in-progress, fail<br/>add: staged"]
        REL_FAIL["● Branch B: Fail Label<br/>━━━━━━━━━━<br/>swap_labels<br/>remove: in-progress<br/>add: fail"]
        REL_CLEAN["● Branch C: Clean<br/>━━━━━━━━━━<br/>swap_labels<br/>remove: in-progress, fail<br/>add: none"]
    end

    subgraph Config ["● Configuration Layer"]
        direction LR
        DEFAULTS["● defaults.yaml<br/>━━━━━━━━━━<br/>fail_label: fail<br/>allowed_labels: 8 entries"]
        GH_CONFIG["● GitHubConfig<br/>━━━━━━━━━━<br/>fail_label field<br/>from_dynaconf builder"]
    end

    subgraph Tests ["★ Test Coverage"]
        direction LR
        TEST_FAIL_LABEL["★ test_release_issue_fail_label<br/>━━━━━━━━━━<br/>4 tests: swap, staging<br/>cleanup, bare cleanup,<br/>claim cleanup"]
        TEST_ROUTING["● test_check_ci_routing<br/>━━━━━━━━━━<br/>chain completeness,<br/>no direct callers guard"]
        TEST_ALLOWED["● test_settings_allowed_labels<br/>━━━━━━━━━━<br/>fail in default whitelist"]
    end

    %% FLOW: Validation %%
    START --> VAL_CHECK
    VAL_CHECK -->|"allowed_labels empty"| CLAIM
    VAL_CHECK -->|"label in list"| CLAIM
    VAL_CHECK -->|"label NOT in list"| VAL_REJECT
    VAL_REJECT --> ESCALATE_STOP

    %% FLOW: Claim %%
    CLAIM --> CLAIM_DEC
    CLAIM_DEC -->|"no"| CLAIM_SWAP
    CLAIM_DEC -->|"yes"| CLAIM_REENTRY
    CLAIM_REENTRY -->|"true"| CI_WATCH
    CLAIM_REENTRY -->|"false"| ESCALATE_STOP
    CLAIM_SWAP -->|"reads fail_label from config"| CI_WATCH

    %% FLOW: CI Watch %%
    CI_WATCH --> CI_DEC
    CI_DEC -->|"success"| REL_DEC
    CI_DEC -->|"timed_out"| CI_WATCH
    CI_DEC -->|"no_runs"| HANDLE_NO_CI
    CI_DEC -->|"failure"| REL_DEC
    HANDLE_NO_CI -->|"on_success"| CI_LOOP
    HANDLE_NO_CI -->|"on_failure"| REL_CLEAN
    CI_LOOP -->|"false"| CI_WATCH
    CI_LOOP -->|"true"| TRIGGER_LOOP
    TRIGGER_LOOP -->|"false"| TRIGGER_CI
    TRIGGER_LOOP -->|"true"| CHECK_PASSED
    TRIGGER_CI -->|"on_success"| CI_WATCH
    TRIGGER_CI -->|"on_failure"| CHECK_PASSED

    %% FLOW: CI Already Passed Gate %%
    CHECK_PASSED -->|"all SUCCESS/NEUTRAL/SKIPPED"| REL_DEC
    CHECK_PASSED -->|"otherwise"| MARK_FAILED
    CHECK_PASSED -->|"on_failure"| MARK_FAILED

    %% FLOW: No-CI Failure Chain %%
    MARK_FAILED -->|"writes fail label"| REG_CLONE_NO_CI
    REG_CLONE_NO_CI --> ESCALATE_STOP_NO_CI

    %% FLOW: Release %%
    REL_DEC -->|"target != promotion_target"| REL_STAGING
    REL_DEC -->|"fail_label arg set"| REL_FAIL
    REL_DEC -->|"default / main"| REL_CLEAN
    REL_STAGING -->|"removes fail + in-progress"| DONE
    REL_FAIL -->|"swaps in-progress → fail"| ESCALATE_STOP
    REL_CLEAN -->|"removes fail + in-progress"| DONE

    %% FLOW: Config feeds into runtime %%
    DEFAULTS -.->|"loads"| GH_CONFIG
    GH_CONFIG -.->|"fail_label default"| CLAIM_SWAP
    GH_CONFIG -.->|"allowed_labels"| VAL_CHECK
    GH_CONFIG -.->|"fail_label"| REL_DEC

    %% FLOW: Tests verify %%
    TEST_FAIL_LABEL -.->|"verifies"| CLAIM_SWAP
    TEST_FAIL_LABEL -.->|"verifies"| REL_FAIL
    TEST_FAIL_LABEL -.->|"verifies"| REL_STAGING
    TEST_FAIL_LABEL -.->|"verifies"| REL_CLEAN
    TEST_ROUTING -.->|"verifies"| MARK_FAILED
    TEST_ROUTING -.->|"verifies"| REG_CLONE_NO_CI
    TEST_ROUTING -.->|"verifies"| ESCALATE_STOP_NO_CI
    TEST_ALLOWED -.->|"verifies"| DEFAULTS

    %% CLASS ASSIGNMENTS %%
    class START,DONE,ESCALATE_STOP terminal;
    class ESCALATE_STOP_NO_CI detector;
    class VAL_CHECK,CLAIM_DEC,CLAIM_REENTRY,CI_DEC,CI_LOOP,TRIGGER_LOOP,CHECK_PASSED,REL_DEC stateNode;
    class VAL_REJECT detector;
    class CLAIM,CLAIM_SWAP,CI_WATCH,HANDLE_NO_CI,TRIGGER_CI handler;
    class MARK_FAILED,REG_CLONE_NO_CI handler;
    class REL_STAGING,REL_FAIL,REL_CLEAN handler;
    class DEFAULTS,GH_CONFIG phase;
    class TEST_FAIL_LABEL newComponent;
    class TEST_ROUTING,TEST_ALLOWED output;
```

### Error/Resilience Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% ENTRY %%
    RECIPE(["Recipe Step Invocation<br/>━━━━━━━━━━<br/>claim / release / prepare"])

    subgraph Gates ["VALIDATION GATES — Fail-Fast"]
        GATE_EN["● _require_enabled<br/>━━━━━━━━━━<br/>Feature gate check"]
        GATE_CLIENT["github_client guard<br/>━━━━━━━━━━<br/>Token required"]
        GATE_EXEC["executor guard<br/>━━━━━━━━━━<br/>Headless executor configured"]
        GATE_URL["_parse_issue_ref<br/>━━━━━━━━━━<br/>ValueError on bad URL"]
        GATE_LABEL["● check_label_allowed<br/>━━━━━━━━━━<br/>Whitelist validation<br/>allowed_labels gate"]
    end

    subgraph Config ["● CONFIG LAYER"]
        CFG_GH["● GitHubConfig<br/>━━━━━━━━━━<br/>fail_label, allowed_labels<br/>from_dynaconf builder"]
        CFG_DEF["● defaults.yaml<br/>━━━━━━━━━━<br/>fail_label: fail<br/>allowed_labels allowlist"]
    end

    subgraph Execution ["● ISSUE LIFECYCLE HANDLERS"]
        CLAIM["● claim_issue<br/>━━━━━━━━━━<br/>swap_labels: remove fail,<br/>add in-progress"]
        RELEASE["● release_issue<br/>━━━━━━━━━━<br/>Three-branch routing"]
        PREPARE["prepare_issue<br/>━━━━━━━━━━<br/>Headless skill session"]
    end

    subgraph ReleaseBranches ["● RELEASE DECISION TREE"]
        direction TB
        RB_STAGE{"Staging<br/>path?"}
        RB_FAIL{"fail_label<br/>provided?"}
        RB_PLAIN["Plain Release<br/>━━━━━━━━━━<br/>Remove in-progress<br/>+ config fail_label"]
        RB_STAGED["Staged Release<br/>━━━━━━━━━━<br/>Remove in-progress<br/>+ fail_label → add staged"]
        RB_FAILED["● Fail Label Path<br/>━━━━━━━━━━<br/>ensure_label fail d73a4a<br/>swap: in-progress → fail"]
    end

    subgraph LabelOps ["GITHUB LABEL OPERATIONS"]
        ENSURE["ensure_label<br/>━━━━━━━━━━<br/>Idempotent create<br/>with color"]
        SWAP["● swap_labels<br/>━━━━━━━━━━<br/>Atomic remove + add<br/>Single API call"]
    end

    subgraph Recovery ["ERROR BUILDERS — Never Raises"]
        ERR_BUILD["_build_headless_error_response<br/>━━━━━━━━━━<br/>Canonical error dict builder<br/>success, session_id, stderr"]
        ERR_RETRY["_retry_reason_to_error<br/>━━━━━━━━━━<br/>Fallback chain:<br/>RetryReason → subtype → generic"]
        ERR_BLOCK["_BLOCK_PARSE_ERRORS<br/>━━━━━━━━━━<br/>frozenset sentinel<br/>no block / invalid JSON"]
        ERR_CATCH["except Exception<br/>━━━━━━━━━━<br/>Catch-all on every handler<br/>Logs exc_info, returns JSON"]
    end

    subgraph RecipeEscalation ["● RECIPE ESCALATION PATHS"]
        CHECK_CI["check_ci_already_passed<br/>━━━━━━━━━━<br/>statusCheckRollup"]
        MARK_FAIL["● mark_issue_failed_no_ci<br/>━━━━━━━━━━<br/>release_issue<br/>fail_label: fail"]
        ESC_NOCI(["● escalate_stop_no_ci<br/>━━━━━━━━━━<br/>Pipeline stop — no CI"])
        REL_FAIL["release_issue_failure<br/>━━━━━━━━━━<br/>Plain label removal"]
        REG_CLONE["register_clone_failure"]
        ESC_STOP(["escalate_stop<br/>━━━━━━━━━━<br/>Human intervention needed"])
    end

    subgraph Tests ["★ TEST COVERAGE"]
        T_FAIL["★ test_release_issue_fail_label<br/>━━━━━━━━━━<br/>swap, cleanup, claim"]
        T_LABEL["● test_tools_label_validation<br/>━━━━━━━━━━<br/>Whitelist enforcement"]
        T_LIFE["● test_tools_issue_lifecycle<br/>━━━━━━━━━━<br/>All handler error paths"]
        T_CFG["● test_settings_allowed_labels<br/>━━━━━━━━━━<br/>Config defaults + check"]
    end

    %% TERMINAL STATES %%
    T_SUCCESS(["SUCCESS<br/>━━━━━━━━━━<br/>JSON: success=true"])
    T_ERROR(["ERROR<br/>━━━━━━━━━━<br/>JSON: success=false<br/>Never raises"])

    %% === CONNECTIONS === %%

    %% Entry → Gates %%
    RECIPE --> GATE_EN
    GATE_EN -->|"disabled"| T_ERROR
    GATE_EN -->|"enabled"| GATE_CLIENT
    GATE_CLIENT -->|"None"| T_ERROR
    GATE_CLIENT -->|"present"| GATE_URL
    GATE_URL -->|"ValueError"| T_ERROR
    GATE_URL -->|"valid"| GATE_LABEL

    %% Config feeds gates %%
    CFG_DEF --> CFG_GH
    CFG_GH -->|"allowed_labels"| GATE_LABEL

    %% Gates → Execution %%
    GATE_LABEL -->|"disallowed"| T_ERROR
    GATE_LABEL -->|"allowed"| CLAIM
    GATE_LABEL -->|"allowed"| RELEASE

    %% Executor gate for headless path %%
    GATE_EN -->|"enabled"| GATE_EXEC
    GATE_EXEC -->|"None"| T_ERROR
    GATE_EXEC -->|"present"| PREPARE

    %% Claim issue %%
    CLAIM -->|"swap_labels"| SWAP
    SWAP -->|"failed"| T_ERROR
    SWAP -->|"success"| T_SUCCESS

    %% Release routing %%
    RELEASE --> RB_STAGE
    RB_STAGE -->|"yes"| RB_STAGED
    RB_STAGE -->|"no"| RB_FAIL
    RB_FAIL -->|"yes"| RB_FAILED
    RB_FAIL -->|"no"| RB_PLAIN

    %% Label operations from release branches %%
    RB_STAGED --> ENSURE
    RB_FAILED --> ENSURE
    ENSURE -->|"failed"| T_ERROR
    ENSURE -->|"success"| SWAP
    RB_PLAIN --> SWAP

    %% Prepare → error builders %%
    PREPARE -->|"session failed"| ERR_BUILD
    PREPARE -->|"empty output"| ERR_BUILD
    PREPARE -->|"parse error"| ERR_BLOCK
    ERR_BUILD --> ERR_RETRY
    ERR_RETRY --> T_ERROR
    ERR_BLOCK --> ERR_BUILD
    PREPARE -->|"success"| T_SUCCESS

    %% Catch-all %%
    ERR_CATCH -.->|"wraps all handlers"| T_ERROR

    %% Recipe escalation %%
    CHECK_CI -->|"no CI passing"| MARK_FAIL
    MARK_FAIL -->|"release_issue<br/>fail_label=fail"| RELEASE
    MARK_FAIL --> ESC_NOCI
    REL_FAIL -->|"plain release"| RELEASE
    REL_FAIL --> REG_CLONE
    REG_CLONE --> ESC_STOP

    %% Test coverage connections %%
    T_FAIL -.->|"validates"| RB_FAILED
    T_FAIL -.->|"validates"| CLAIM
    T_LABEL -.->|"validates"| GATE_LABEL
    T_LIFE -.->|"validates"| ERR_BUILD
    T_CFG -.->|"validates"| CFG_GH

    %% CLASS ASSIGNMENTS %%
    class RECIPE,T_SUCCESS,T_ERROR,ESC_NOCI,ESC_STOP terminal;
    class GATE_EN,GATE_CLIENT,GATE_EXEC,GATE_URL,GATE_LABEL detector;
    class CFG_GH,CFG_DEF stateNode;
    class CLAIM,RELEASE,PREPARE handler;
    class RB_STAGE,RB_FAIL stateNode;
    class RB_PLAIN,RB_STAGED handler;
    class RB_FAILED newComponent;
    class ENSURE,SWAP handler;
    class ERR_BUILD,ERR_RETRY,ERR_BLOCK,ERR_CATCH output;
    class CHECK_CI,MARK_FAIL,REL_FAIL,REG_CLONE phase;
    class T_FAIL,T_LABEL,T_LIFE,T_CFG newComponent;
```

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START([Issue Enters Lifecycle])

    subgraph Config ["● INIT_PRESERVE — GitHubConfig"]
        direction TB
        IPL["● in_progress_label<br/>━━━━━━━━━━<br/>Default: in-progress"]
        SL["● staged_label<br/>━━━━━━━━━━<br/>Default: staged"]
        FL["● fail_label<br/>━━━━━━━━━━<br/>Default: fail<br/>NEW: from_dynaconf builder"]
        AL["● allowed_labels<br/>━━━━━━━━━━<br/>8-entry allowlist<br/>includes fail"]
    end

    subgraph Gates ["● VALIDATION GATES — Ordered"]
        direction TB
        G1["Gate 1: _require_enabled<br/>━━━━━━━━━━<br/>Kitchen must be open<br/>FAIL → abort"]
        G2["Gate 2: github_client<br/>━━━━━━━━━━<br/>Service wired?<br/>FAIL → error"]
        G3["Gate 3: _parse_issue_ref<br/>━━━━━━━━━━<br/>URL validity<br/>FAIL → error"]
        G4["● Gate 4: check_label_allowed<br/>━━━━━━━━━━<br/>Label in allowlist?<br/>FAIL → error + alternatives"]
    end

    subgraph Claim ["● MUTABLE — claim_issue"]
        direction TB
        FETCH["fetch_issue<br/>━━━━━━━━━━<br/>Read current labels"]
        REENTRY{"Reentry?<br/>in_progress<br/>already set?"}
        SWAP_CLAIM["● swap_labels<br/>━━━━━━━━━━<br/>REMOVE: fail_label<br/>ADD: in_progress_label"]
        REUSE["Resume Path<br/>━━━━━━━━━━<br/>No swap needed<br/>allow_reentry=true"]
    end

    subgraph Release ["● MUTABLE — release_issue"]
        direction TB
        REL_STAGE["Release: Staged<br/>━━━━━━━━━━<br/>REMOVE: in_progress + fail<br/>ADD: staged_label"]
        REL_FAIL["● Release: Failed<br/>━━━━━━━━━━<br/>REMOVE: in_progress<br/>ADD: fail_label"]
        REL_CLEAN["Release: Clean<br/>━━━━━━━━━━<br/>REMOVE: in_progress + fail<br/>ADD: none"]
    end

    subgraph Escalation ["● ESCALATION TERMINALS"]
        direction TB
        ESC_STD["escalate_stop<br/>━━━━━━━━━━<br/>Standard abort<br/>Label already released"]
        ESC_NOCI["● escalate_stop_no_ci<br/>━━━━━━━━━━<br/>CI exhaustion abort<br/>fail_label applied<br/>Clone registered"]
    end

    subgraph CloneReg ["APPEND_ONLY — Clone Registry"]
        direction TB
        CR_OK["register_clone: success<br/>━━━━━━━━━━<br/>Reapable"]
        CR_ERR["register_clone: error<br/>━━━━━━━━━━<br/>Preserved for debug"]
        CR_UNC["register_clone: unconfirmed<br/>━━━━━━━━━━<br/>in_progress retained"]
    end

    subgraph Tests ["★● TEST COVERAGE"]
        direction TB
        T1["★ test_release_issue_fail_label<br/>━━━━━━━━━━<br/>fail_label swap contract"]
        T2["● test_tools_label_validation<br/>━━━━━━━━━━<br/>Allowlist enforcement"]
        T3["● test_settings_allowed_labels<br/>━━━━━━━━━━<br/>Config gate coverage"]
    end

    END_OK([Label Settled])
    END_FAIL([Escalation Stop])

    %% FLOW %%
    START --> G1
    G1 --> G2
    G2 --> G3
    G3 --> G4

    FL -.->|validates against| G4
    AL -.->|enforces| G4

    G4 --> FETCH
    FETCH --> REENTRY
    REENTRY -->|No: fresh claim| SWAP_CLAIM
    REENTRY -->|Yes: resume| REUSE
    IPL -.->|add target| SWAP_CLAIM
    FL -.->|remove target| SWAP_CLAIM

    SWAP_CLAIM --> REL_STAGE
    SWAP_CLAIM --> REL_FAIL
    SWAP_CLAIM --> REL_CLEAN
    REUSE --> REL_STAGE
    REUSE --> REL_FAIL
    REUSE --> REL_CLEAN

    REL_STAGE --> CR_OK
    REL_FAIL --> CR_ERR
    REL_FAIL --> ESC_NOCI
    REL_CLEAN --> CR_ERR
    REL_CLEAN --> ESC_STD

    CR_OK --> END_OK
    CR_ERR --> END_FAIL
    CR_UNC --> END_OK
    ESC_NOCI --> END_FAIL
    ESC_STD --> END_FAIL

    T1 -.->|covers| REL_FAIL
    T2 -.->|covers| G4
    T3 -.->|covers| AL

    %% CLASS ASSIGNMENTS %%
    class IPL,SL,FL,AL stateNode;
    class G1,G2,G3 detector;
    class G4 detector;
    class FETCH,REENTRY phase;
    class SWAP_CLAIM handler;
    class REUSE output;
    class REL_STAGE,REL_CLEAN handler;
    class REL_FAIL handler;
    class ESC_STD,ESC_NOCI gap;
    class CR_OK,CR_ERR,CR_UNC stateNode;
    class T1 newComponent;
    class T2,T3 phase;
    class START,END_OK,END_FAIL terminal;
```

Closes #1492

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260428-161332-549235/.autoskillit/temp/make-plan/escalate_stop_no_ci_cleanup_plan_2026-04-28_163500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 65 | 14.5k | 989.6k | 68.6k | 1 | 8m 36s |
| verify | 45 | 9.6k | 905.6k | 61.1k | 1 | 6m 14s |
| implement | 69 | 21.2k | 3.3M | 78.0k | 1 | 9m 57s |
| prepare_pr | 22 | 6.6k | 99.5k | 29.1k | 1 | 1m 49s |
| run_arch_lenses | 2.7k | 17.2k | 631.4k | 97.0k | 3 | 9m 44s |
| compose_pr | 24 | 11.2k | 231.6k | 40.1k | 1 | 3m 51s |
| review_pr | 28 | 20.6k | 462.2k | 56.0k | 1 | 6m 23s |
| resolve_review | 40 | 10.7k | 1.0M | 47.7k | 1 | 8m 41s |
| ci_conflict_fix | 38 | 9.7k | 908.6k | 49.1k | 1 | 5m 28s |
| **Total** | 3.0k | 121.5k | 8.6M | 526.8k | | 1h 0m |