### PR TITLE
Review Gate State Preservation on Kitchen Cycle

### DIFF
--- a/src/autoskillit/server/tools_kitchen.py
+++ b/src/autoskillit/server/tools_kitchen.py
@@ -227,22 +227,26 @@ def _close_kitchen_handler() -> None:
         logger.warning("hook_config_remove_failed", path=str(hook_cfg_path))
     review_gate_path = Path.cwd() / ".autoskillit" / "temp" / "review_gate_state.json"
     try:
-        if review_gate_path.exists():
-            try:
-                state = json.loads(review_gate_path.read_text())
-                loop_active = state.get("gate") == "LOOP_REQUIRED" and not state.get(
-                    "check_review_loop_called", False
-                )
-            except (json.JSONDecodeError, OSError):
-                loop_active = False
-            if loop_active:
-                logger.warning(
-                    "close_kitchen_review_gate_preserved",
-                    path=str(review_gate_path),
-                    reason="active_review_loop",
-                )
-            else:
-                review_gate_path.unlink(missing_ok=True)
+        try:
+            state = json.loads(review_gate_path.read_text())
+            loop_active = (
+                isinstance(state, dict)
+                and state.get("gate") == "LOOP_REQUIRED"
+                and not state.get("check_review_loop_called", False)
+            )
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.debug(
+                "review_gate_state_read_failed", path=str(review_gate_path), error=str(exc)
+            )
+            loop_active = False
+        if loop_active:
+            logger.warning(
+                "close_kitchen_review_gate_preserved",
+                path=str(review_gate_path),
+                reason="active_review_loop",
+            )
+        else:
+            review_gate_path.unlink(missing_ok=True)
     except OSError:
         logger.warning("review_gate_state_remove_failed", path=str(review_gate_path))
 

--- a/src/autoskillit/server/tools_kitchen.py
+++ b/src/autoskillit/server/tools_kitchen.py
@@ -227,7 +227,22 @@ def _close_kitchen_handler() -> None:
         logger.warning("hook_config_remove_failed", path=str(hook_cfg_path))
     review_gate_path = Path.cwd() / ".autoskillit" / "temp" / "review_gate_state.json"
     try:
-        review_gate_path.unlink(missing_ok=True)
+        if review_gate_path.exists():
+            try:
+                state = json.loads(review_gate_path.read_text())
+                loop_active = state.get("gate") == "LOOP_REQUIRED" and not state.get(
+                    "check_review_loop_called", False
+                )
+            except (json.JSONDecodeError, OSError):
+                loop_active = False
+            if loop_active:
+                logger.warning(
+                    "close_kitchen_review_gate_preserved",
+                    path=str(review_gate_path),
+                    reason="active_review_loop",
+                )
+            else:
+                review_gate_path.unlink(missing_ok=True)
     except OSError:
         logger.warning("review_gate_state_remove_failed", path=str(review_gate_path))
 

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -130,7 +130,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/server/_lifespan.py", 56),
     # tools_kitchen.py — hook config dict
     ("src/autoskillit/server/tools_kitchen.py", 117),
-    ("src/autoskillit/server/tools_kitchen.py", 554),
+    ("src/autoskillit/server/tools_kitchen.py", 558),
     # tools_status.py — mcp_data dict
     ("src/autoskillit/server/tools_status.py", 486),
     # tools_github.py — bug report dict

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -130,7 +130,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/server/_lifespan.py", 56),
     # tools_kitchen.py — hook config dict
     ("src/autoskillit/server/tools_kitchen.py", 117),
-    ("src/autoskillit/server/tools_kitchen.py", 539),
+    ("src/autoskillit/server/tools_kitchen.py", 554),
     # tools_status.py — mcp_data dict
     ("src/autoskillit/server/tools_status.py", 486),
     # tools_github.py — bug report dict

--- a/tests/server/test_tools_kitchen_gate.py
+++ b/tests/server/test_tools_kitchen_gate.py
@@ -399,12 +399,11 @@ _REVIEW_GATE_STATE_RELPATH = (".autoskillit", "temp", "review_gate_state.json")
 
 
 # T5-1
-def test_close_kitchen_removes_review_gate_state(tmp_path, monkeypatch):
-    """_close_kitchen_handler() must remove review_gate_state.json when present."""
+def test_close_kitchen_preserves_review_gate_when_loop_active(tmp_path, monkeypatch):
+    """Preserve review_gate_state.json when an active review loop is in progress."""
     monkeypatch.chdir(tmp_path)
     mock_ctx = _make_mock_ctx()
 
-    # Write the state file before closing the kitchen
     state_path = tmp_path.joinpath(*_REVIEW_GATE_STATE_RELPATH)
     state_path.parent.mkdir(parents=True, exist_ok=True)
     state_path.write_text(
@@ -426,7 +425,7 @@ def test_close_kitchen_removes_review_gate_state(tmp_path, monkeypatch):
 
             _close_kitchen_handler()
 
-    assert not state_path.exists(), "review_gate_state.json must be removed by close_kitchen"
+    assert state_path.exists(), "Active review loop state must survive close_kitchen"
 
 
 # T5-2
@@ -442,6 +441,82 @@ def test_close_kitchen_no_review_gate_state_no_error(tmp_path, monkeypatch):
             _close_kitchen_handler()  # Must not raise
 
     assert not tmp_path.joinpath(*_REVIEW_GATE_STATE_RELPATH).exists()
+
+
+# T5-3
+def test_close_kitchen_removes_review_gate_when_loop_complete(tmp_path, monkeypatch):
+    """Remove review_gate_state.json when check_review_loop_called is True."""
+    monkeypatch.chdir(tmp_path)
+    mock_ctx = _make_mock_ctx()
+
+    state_path = tmp_path.joinpath(*_REVIEW_GATE_STATE_RELPATH)
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        json.dumps(
+            {
+                "gate": "LOOP_REQUIRED",
+                "review_verdict": "changes_requested",
+                "check_review_loop_called": True,
+                "pr_number": "1290",
+                "set_at": "2026-04-26T04:30:00+00:00",
+            }
+        )
+    )
+
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        with patch("autoskillit.server.logger"):
+            from autoskillit.server.tools_kitchen import _close_kitchen_handler
+
+            _close_kitchen_handler()
+
+    assert not state_path.exists(), "Completed loop state must be cleaned up on close"
+
+
+# T5-4
+def test_close_kitchen_removes_review_gate_when_gate_not_loop_required(tmp_path, monkeypatch):
+    """_close_kitchen_handler() must remove review_gate_state.json when gate != LOOP_REQUIRED."""
+    monkeypatch.chdir(tmp_path)
+    mock_ctx = _make_mock_ctx()
+
+    state_path = tmp_path.joinpath(*_REVIEW_GATE_STATE_RELPATH)
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        json.dumps(
+            {
+                "gate": "CLEAR",
+                "check_review_loop_called": False,
+                "pr_number": "1290",
+                "set_at": "2026-04-26T04:30:00+00:00",
+            }
+        )
+    )
+
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        with patch("autoskillit.server.logger"):
+            from autoskillit.server.tools_kitchen import _close_kitchen_handler
+
+            _close_kitchen_handler()
+
+    assert not state_path.exists(), "Non-LOOP_REQUIRED gate state must be cleaned up on close"
+
+
+# T5-5
+def test_close_kitchen_removes_review_gate_on_corrupt_json(tmp_path, monkeypatch):
+    """Delete review_gate_state.json when JSON is malformed (fail-safe)."""
+    monkeypatch.chdir(tmp_path)
+    mock_ctx = _make_mock_ctx()
+
+    state_path = tmp_path.joinpath(*_REVIEW_GATE_STATE_RELPATH)
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text("{not valid json")
+
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        with patch("autoskillit.server.logger"):
+            from autoskillit.server.tools_kitchen import _close_kitchen_handler
+
+            _close_kitchen_handler()
+
+    assert not state_path.exists(), "Corrupt gate state must be deleted (fail-safe)"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

`_close_kitchen_handler()` unconditionally deletes `review_gate_state.json` on every kitchen close. When a review loop is active (`gate == "LOOP_REQUIRED"` and `check_review_loop_called == false`), this destroys the gate state mid-loop. On the next `open_kitchen`, `review_loop_gate.py` finds no state file, fails open, and lets `wait_for_ci`/`enqueue_pr` through unchallenged — defeating the entire review gate mechanism.

**Fix:** In `_close_kitchen_handler()`, read and inspect `review_gate_state.json` before deleting it. If an active review loop is detected, preserve the file. Only delete when the loop is complete or the gate is not engaged. This is a minimal, surgical change with no new abstractions.

## Architecture Impact

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START([run_skill emits<br/>REVIEW_GATE tag])

    subgraph Lifecycles ["FIELD LIFECYCLE — review_gate_state.json"]
        direction TB
        INIT["INIT_ONLY fields<br/>━━━━━━━━━━<br/>gate: LOOP_REQUIRED<br/>review_verdict: changes_requested<br/>set_at: ISO timestamp"]
        MUTABLE["MUTABLE field<br/>━━━━━━━━━━<br/>check_review_loop_called<br/>false → true (once)"]
        DERIVED["DERIVED field<br/>━━━━━━━━━━<br/>pr_number<br/>Best-effort regex extract"]
    end

    subgraph Writer ["● WRITER — review_gate_post_hook.py"]
        direction TB
        W_SET["PostToolUse: SET<br/>━━━━━━━━━━<br/>%%REVIEW_GATE::LOOP_REQUIRED%%<br/>Atomic write all 5 fields"]
        W_FLIP["PostToolUse: FLIP<br/>━━━━━━━━━━<br/>check_review_loop callable<br/>Sets called=true"]
        W_CLEAR["PostToolUse: CLEAR<br/>━━━━━━━━━━<br/>%%REVIEW_GATE::CLEAR%%<br/>Deletes file"]
    end

    subgraph Gate ["VALIDATION GATE — review_loop_gate.py"]
        direction TB
        GATE_CHECK{"PreToolUse<br/>━━━━━━━━━━<br/>wait_for_ci /<br/>enqueue_pr"}
        BLOCK["DENY<br/>━━━━━━━━━━<br/>REVIEW LOOP<br/>REQUIRED"]
        PASS["ALLOW<br/>━━━━━━━━━━<br/>Gate satisfied or<br/>file absent"]
    end

    subgraph KitchenClose ["● KITCHEN CLOSE — tools_kitchen.py"]
        direction TB
        CLOSE_READ["Read gate state<br/>━━━━━━━━━━<br/>Parse JSON or<br/>handle absent/corrupt"]
        ACTIVE_CHECK{"Active loop?<br/>━━━━━━━━━━<br/>gate=LOOP_REQUIRED<br/>AND called=false"}
        PRESERVE["PRESERVE file<br/>━━━━━━━━━━<br/>Log warning:<br/>active_review_loop"]
        DELETE["DELETE file<br/>━━━━━━━━━━<br/>Loop complete,<br/>gate cleared, or<br/>corrupt JSON"]
    end

    NEXT_SESSION(["Next session<br/>resumes with<br/>preserved gate"])

    %% FLOW %%
    START --> W_SET
    W_SET --> INIT
    W_SET --> MUTABLE
    W_SET --> DERIVED

    INIT --> GATE_CHECK
    MUTABLE --> GATE_CHECK
    GATE_CHECK -->|"called=false"| BLOCK
    GATE_CHECK -->|"called=true<br/>or file absent"| PASS

    BLOCK -.->|"Agent must call<br/>check_review_loop"| W_FLIP
    W_FLIP --> PASS

    PASS --> W_CLEAR

    INIT --> CLOSE_READ
    MUTABLE --> CLOSE_READ
    CLOSE_READ --> ACTIVE_CHECK
    ACTIVE_CHECK -->|"Yes — active loop"| PRESERVE
    ACTIVE_CHECK -->|"No — complete/cleared/corrupt"| DELETE

    PRESERVE --> NEXT_SESSION

    %% CLASS ASSIGNMENTS %%
    class START terminal;
    class INIT detector;
    class MUTABLE phase;
    class DERIVED gap;
    class W_SET,W_FLIP,W_CLEAR handler;
    class GATE_CHECK,BLOCK detector;
    class PASS stateNode;
    class CLOSE_READ stateNode;
    class ACTIVE_CHECK phase;
    class PRESERVE output;
    class DELETE handler;
    class NEXT_SESSION cli;
```

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;

    START([START: open_kitchen called])
    OPEN_DONE([KITCHEN OPEN])
    CLOSE_START([START: close_kitchen called])
    CLOSED([KITCHEN CLOSED])
    ERROR([ERROR: gate rollback])

    subgraph OpenPhase ["● Kitchen Open — _open_kitchen_handler"]
        direction TB
        HL_GUARD{"Headless<br/>Guard<br/>━━━━━━━━━━<br/>AUTOSKILLIT_HEADLESS?"}
        GATE_ENABLE["gate.enable()<br/>━━━━━━━━━━<br/>Gate: closed → open"]
        WRITE_HOOK["● _write_hook_config<br/>━━━━━━━━━━<br/>writes .hook_config.json<br/>quota settings + kitchen_id"]
        PRIME_QUOTA["_prime_quota_cache<br/>━━━━━━━━━━<br/>Pre-warm quota data"]
        START_REFRESH["Start quota_refresh_task<br/>━━━━━━━━━━<br/>Background asyncio.Task"]
        REG_KITCHEN["register_active_kitchen<br/>━━━━━━━━━━<br/>writes kitchen_state/uuid.json"]
    end

    subgraph ReviewGate ["Review Gate Lifecycle — hooks"]
        direction TB
        RG_TRIGGER{"PostToolUse<br/>Tag Router<br/>━━━━━━━━━━<br/>run_skill output?"}
        RG_WRITE["review_gate_post_hook<br/>━━━━━━━━━━<br/>writes review_gate_state.json<br/>gate=LOOP_REQUIRED"]
        RG_CLEAR["review_gate_post_hook<br/>━━━━━━━━━━<br/>deletes review_gate_state.json"]
        RG_ACK["review_gate_post_hook<br/>━━━━━━━━━━<br/>sets check_review_loop_called=True"]
        RG_BLOCK["review_loop_gate<br/>━━━━━━━━━━<br/>PreToolUse: denies<br/>wait_for_ci / enqueue_pr"]
    end

    subgraph ClosePhase ["● Kitchen Close — _close_kitchen_handler"]
        direction TB
        HL_GUARD2{"Headless<br/>Guard<br/>━━━━━━━━━━<br/>AUTOSKILLIT_HEADLESS?"}
        CANCEL_QUOTA["Cancel quota_refresh_task<br/>━━━━━━━━━━<br/>task.cancel()"]
        GATE_DISABLE["gate.disable()<br/>━━━━━━━━━━<br/>Gate: open → closed"]
        UNREG["unregister_active_kitchen<br/>━━━━━━━━━━<br/>deletes kitchen_state/uuid.json"]
        RESET_RECIPE["Reset recipe context<br/>━━━━━━━━━━<br/>name, hashes, packs → None"]
        DEL_HOOK["Delete .hook_config.json<br/>━━━━━━━━━━<br/>unlink missing_ok=True"]
        RG_DECISION{"● review_gate_state<br/>Decision<br/>━━━━━━━━━━<br/>gate=LOOP_REQUIRED<br/>AND loop not called?"}
        RG_PRESERVE["● PRESERVE file<br/>━━━━━━━━━━<br/>State survives<br/>kitchen cycle"]
        RG_DELETE["DELETE file<br/>━━━━━━━━━━<br/>Loop done or<br/>gate inactive"]
        RESET_VIS["ctx.reset_visibility<br/>━━━━━━━━━━<br/>Hide kitchen-tagged tools"]
    end

    %% OPEN FLOW %%
    START --> HL_GUARD
    HL_GUARD -->|"headless=True"| ERROR
    HL_GUARD -->|"headless=False"| GATE_ENABLE
    GATE_ENABLE --> WRITE_HOOK
    WRITE_HOOK -->|"OSError"| ERROR
    WRITE_HOOK -->|"success"| PRIME_QUOTA
    PRIME_QUOTA -->|"failure"| ERROR
    PRIME_QUOTA -->|"success"| START_REFRESH
    START_REFRESH -->|"failure"| ERROR
    START_REFRESH -->|"success"| REG_KITCHEN
    REG_KITCHEN --> OPEN_DONE

    %% REVIEW GATE FLOW (while kitchen is open) %%
    OPEN_DONE -.->|"tool calls occur"| RG_TRIGGER
    RG_TRIGGER -->|"%%REVIEW_GATE::LOOP_REQUIRED%%"| RG_WRITE
    RG_TRIGGER -->|"%%REVIEW_GATE::CLEAR%%"| RG_CLEAR
    RG_TRIGGER -->|"check_review_loop callable"| RG_ACK
    RG_WRITE -->|"gate armed"| RG_BLOCK
    RG_ACK -->|"loop acknowledged"| RG_BLOCK

    %% CLOSE FLOW %%
    OPEN_DONE -.->|"close_kitchen called"| CLOSE_START
    CLOSE_START --> HL_GUARD2
    HL_GUARD2 -->|"headless=True"| CLOSED
    HL_GUARD2 -->|"headless=False"| CANCEL_QUOTA
    CANCEL_QUOTA --> GATE_DISABLE
    GATE_DISABLE --> UNREG
    UNREG --> RESET_RECIPE
    RESET_RECIPE --> DEL_HOOK
    DEL_HOOK --> RG_DECISION
    RG_DECISION -->|"active loop: gate=LOOP_REQUIRED<br/>AND check_review_loop_called=False"| RG_PRESERVE
    RG_DECISION -->|"loop done / gate inactive /<br/>corrupt JSON / file absent"| RG_DELETE
    RG_PRESERVE --> RESET_VIS
    RG_DELETE --> RESET_VIS
    RESET_VIS --> CLOSED

    %% CLASS ASSIGNMENTS %%
    class START,OPEN_DONE,CLOSE_START,CLOSED terminal;
    class ERROR detector;
    class HL_GUARD,HL_GUARD2,RG_TRIGGER,RG_DECISION stateNode;
    class GATE_ENABLE,GATE_DISABLE,CANCEL_QUOTA,UNREG,RESET_RECIPE,DEL_HOOK,RESET_VIS phase;
    class WRITE_HOOK,PRIME_QUOTA,START_REFRESH,REG_KITCHEN handler;
    class RG_WRITE,RG_CLEAR,RG_ACK,RG_BLOCK handler;
    class RG_PRESERVE,RG_DELETE output;
```

Closes #1389

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-1389-20260428-191740-935754/.autoskillit/temp/make-plan/review_gate_state_preservation_plan_2026-04-29_022205.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 95 | 8.9k | 387.3k | 42.9k | 1 | 5m 24s |
| verify | 29 | 4.7k | 421.3k | 36.8k | 1 | 3m 9s |
| implement | 35 | 6.9k | 657.4k | 39.3k | 1 | 3m 28s |
| prepare_pr | 24 | 3.2k | 167.4k | 23.6k | 1 | 1m 12s |
| run_arch_lenses | 66 | 9.1k | 412.4k | 57.2k | 2 | 5m 39s |
| compose_pr | 22 | 5.4k | 142.6k | 28.1k | 1 | 1m 51s |
| review_pr | 27 | 14.6k | 338.6k | 41.4k | 1 | 4m 11s |
| resolve_review | 70 | 14.0k | 1.4M | 95.4k | 2 | 14m 12s |
| **Total** | 368 | 66.8k | 3.9M | 364.7k | | 39m 8s |