### PR TITLE
Planner Validation — Severity Levels for Findings

### DIFF
--- a/src/autoskillit/planner/__init__.py
+++ b/src/autoskillit/planner/__init__.py
@@ -30,6 +30,7 @@ from autoskillit.planner.schema import (
     PlanDocument,
     PlannerManifest,
     PlannerManifestItem,
+    ValidationFinding,
     WPElaborated,
     WPShort,
     resolve_wp_id,
@@ -68,4 +69,5 @@ __all__ = [
     "resolve_wp_id",
     "validate_refined_assignments",
     "validate_refined_plan",
+    "ValidationFinding",
 ]

--- a/src/autoskillit/planner/schema.py
+++ b/src/autoskillit/planner/schema.py
@@ -138,6 +138,12 @@ class RunDirResult(TypedDict):
     planner_dir: str
 
 
+class ValidationFinding(TypedDict):
+    message: str
+    severity: str  # "error" | "warning"
+    check: str
+
+
 _PHASE_ID_RE = re.compile(r"^P\d+$")
 _ASSIGN_ID_RE = re.compile(r"^P\d+-A\d+$")
 _WP_ID_RE = re.compile(r"^P\d+-A\d+-WP\d+$")

--- a/src/autoskillit/planner/schema.py
+++ b/src/autoskillit/planner/schema.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 import warnings
-from typing import Any, TypedDict
+from typing import Any, Literal, TypedDict
 
 
 class PhaseResult(TypedDict):
@@ -140,7 +140,7 @@ class RunDirResult(TypedDict):
 
 class ValidationFinding(TypedDict):
     message: str
-    severity: str  # "error" | "warning"
+    severity: Literal["error", "warning"]
     check: str
 
 

--- a/src/autoskillit/planner/validation.py
+++ b/src/autoskillit/planner/validation.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from autoskillit.core import get_logger, write_versioned_json
 from autoskillit.planner.schema import (
+    ValidationFinding,
     validate_assignment_result,
     validate_phase_result,
     validate_wp_result,
@@ -83,25 +84,37 @@ def _inject_backward_deps(wp_results: dict[str, dict], dep_graph: dict) -> None:
 def _check_phase_completeness(
     phase_results: dict[str, dict],
     assignment_results: dict[str, dict],
-) -> list[str]:
-    findings: list[str] = []
+) -> list[ValidationFinding]:
+    findings: list[ValidationFinding] = []
     assigned_phase_nums = {v["phase_number"] for v in assignment_results.values()}
     for phase_id, phase in phase_results.items():
         if phase["phase_number"] not in assigned_phase_nums:
-            findings.append(f"Phase {phase_id} has no assignments")
+            findings.append(
+                {
+                    "message": f"Phase {phase_id} has no assignments",
+                    "severity": "error",
+                    "check": "phase_completeness",
+                }
+            )
     return findings
 
 
 def _check_assignment_completeness(
     assignment_results: dict[str, dict],
     wp_results: dict[str, dict],
-) -> list[str]:
-    findings: list[str] = []
+) -> list[ValidationFinding]:
+    findings: list[ValidationFinding] = []
     wp_pairs: set[tuple[int, int]] = set()
     for wp_id in wp_results:
         parts = wp_id.split("-")
         if len(parts) < 2:
-            findings.append(f"WP {wp_id!r} has malformed id (expected PX-AY-WPZ)")
+            findings.append(
+                {
+                    "message": f"WP {wp_id!r} has malformed id (expected PX-AY-WPZ)",
+                    "severity": "error",
+                    "check": "assignment_completeness",
+                }
+            )
             continue
         phase_num = int(parts[0][1:])
         assign_num = int(parts[1][1:])
@@ -109,20 +122,32 @@ def _check_assignment_completeness(
     for assign_id, assign in assignment_results.items():
         pair = (assign["phase_number"], assign["assignment_number"])
         if pair not in wp_pairs:
-            findings.append(f"Assignment {assign_id} has no work packages")
+            findings.append(
+                {
+                    "message": f"Assignment {assign_id} has no work packages",
+                    "severity": "error",
+                    "check": "assignment_completeness",
+                }
+            )
     return findings
 
 
-def _check_dep_references(wp_results: dict[str, dict]) -> list[str]:
-    findings: list[str] = []
+def _check_dep_references(wp_results: dict[str, dict]) -> list[ValidationFinding]:
+    findings: list[ValidationFinding] = []
     for wp_id, wp in wp_results.items():
         for dep in wp.get("depends_on", []):
             if dep not in wp_results:
-                findings.append(f"WP {wp_id} depends on unknown WP {dep}")
+                findings.append(
+                    {
+                        "message": f"WP {wp_id} depends on unknown WP {dep}",
+                        "severity": "error",
+                        "check": "dep_references",
+                    }
+                )
     return findings
 
 
-def _check_dag_acyclic(wp_results: dict[str, dict]) -> list[str]:
+def _check_dag_acyclic(wp_results: dict[str, dict]) -> list[ValidationFinding]:
     in_degree: dict[str, int] = {wp_id: 0 for wp_id in wp_results}
     adjacency: dict[str, list[str]] = {wp_id: [] for wp_id in wp_results}
     for wp_id, wp in wp_results.items():
@@ -143,52 +168,85 @@ def _check_dag_acyclic(wp_results: dict[str, dict]) -> list[str]:
 
     if len(sorted_nodes) < len(wp_results):
         cycle_nodes = [n for n in wp_results if n not in set(sorted_nodes)]
-        return [f"Cycle detected among WPs: {', '.join(sorted(cycle_nodes))}"]
+        return [
+            {
+                "message": f"Cycle detected among WPs: {', '.join(sorted(cycle_nodes))}",
+                "severity": "error",
+                "check": "dag_acyclic",
+            }
+        ]
     return []
 
 
-def _check_sizing_bounds(wp_results: dict[str, dict]) -> list[str]:
-    findings: list[str] = []
+def _check_sizing_bounds(wp_results: dict[str, dict]) -> list[ValidationFinding]:
+    findings: list[ValidationFinding] = []
     for wp_id, wp in wp_results.items():
         count = len(wp.get("deliverables", []))
         if not (1 <= count <= 5):
-            findings.append(f"WP {wp_id} has {count} deliverables (must be 1–5)")
-    return findings
-
-
-def _check_duplicate_deliverables(wp_results: dict[str, dict]) -> list[str]:
-    deliverable_map: dict[str, list[str]] = {}
-    for wp_id, wp in wp_results.items():
-        for d in wp.get("deliverables", []):
-            deliverable_map.setdefault(d, []).append(wp_id)
-    findings: list[str] = []
-    for path, owners in deliverable_map.items():
-        if len(owners) > 1:
             findings.append(
-                f"Deliverable '{path}' claimed by multiple WPs: {', '.join(sorted(owners))}"
+                {
+                    "message": f"WP {wp_id} has {count} deliverables (must be 1–5)",
+                    "severity": "error",
+                    "check": "sizing_bounds",
+                }
             )
     return findings
 
 
-def _check_duplicate_files_touched(wp_results: dict[str, dict]) -> list[str]:
+def _check_duplicate_deliverables(wp_results: dict[str, dict]) -> list[ValidationFinding]:
+    deliverable_map: dict[str, list[str]] = {}
+    for wp_id, wp in wp_results.items():
+        for d in wp.get("deliverables", []):
+            deliverable_map.setdefault(d, []).append(wp_id)
+    findings: list[ValidationFinding] = []
+    for path, owners in deliverable_map.items():
+        if len(owners) > 1:
+            findings.append(
+                {
+                    "message": (
+                        f"Deliverable '{path}' claimed by multiple WPs: "
+                        f"{', '.join(sorted(owners))}"
+                    ),
+                    "severity": "error",
+                    "check": "duplicate_deliverables",
+                }
+            )
+    return findings
+
+
+def _check_duplicate_files_touched(wp_results: dict[str, dict]) -> list[ValidationFinding]:
     file_map: dict[str, list[str]] = {}
     for wp_id, wp in wp_results.items():
         for path in wp.get("files_touched", []):
             file_map.setdefault(path, []).append(wp_id)
-    findings: list[str] = []
+    findings: list[ValidationFinding] = []
     for path, owners in file_map.items():
         if len(owners) > 1:
-            findings.append(f"File '{path}' touched by multiple WPs: {', '.join(sorted(owners))}")
+            findings.append(
+                {
+                    "message": (
+                        f"File '{path}' touched by multiple WPs: {', '.join(sorted(owners))}"
+                    ),
+                    "severity": "warning",
+                    "check": "duplicate_files_touched",
+                }
+            )
     return findings
 
 
-def _check_failed_wps(wp_manifest: dict | None) -> list[str]:
+def _check_failed_wps(wp_manifest: dict | None) -> list[ValidationFinding]:
     if wp_manifest is None:
         return []
-    findings: list[str] = []
+    findings: list[ValidationFinding] = []
     for item in wp_manifest.get("items", []):
         if item.get("status") == "failed":
-            findings.append(f"WP {item.get('id', '<unknown>')} has status 'failed'")
+            findings.append(
+                {
+                    "message": f"WP {item.get('id', '<unknown>')} has status 'failed'",
+                    "severity": "error",
+                    "check": "failed_wps",
+                }
+            )
     return findings
 
 
@@ -207,26 +265,29 @@ def validate_plan(output_dir: str) -> dict[str, str]:
             raise RuntimeError(f"Malformed dep graph file {dep_graph_path}: {exc}") from exc
         _inject_backward_deps(wp_results, dep_graph)
 
-    findings: list[str] = []
-    findings.extend(_check_phase_completeness(phase_results, assignment_results))
-    findings.extend(_check_assignment_completeness(assignment_results, wp_results))
-    findings.extend(_check_dep_references(wp_results))
-    findings.extend(_check_dag_acyclic(wp_results))
-    findings.extend(_check_sizing_bounds(wp_results))
-    findings.extend(_check_duplicate_deliverables(wp_results))
-    findings.extend(_check_duplicate_files_touched(wp_results))
-    findings.extend(_check_failed_wps(wp_manifest))
+    all_findings: list[ValidationFinding] = []
+    all_findings.extend(_check_phase_completeness(phase_results, assignment_results))
+    all_findings.extend(_check_assignment_completeness(assignment_results, wp_results))
+    all_findings.extend(_check_dep_references(wp_results))
+    all_findings.extend(_check_dag_acyclic(wp_results))
+    all_findings.extend(_check_sizing_bounds(wp_results))
+    all_findings.extend(_check_duplicate_deliverables(wp_results))
+    all_findings.extend(_check_duplicate_files_touched(wp_results))
+    all_findings.extend(_check_failed_wps(wp_manifest))
 
-    verdict = "pass" if not findings else "fail"
+    errors = [f for f in all_findings if f["severity"] == "error"]
+    warnings = [f for f in all_findings if f["severity"] == "warning"]
+
+    verdict = "pass" if not errors else "fail"
     validation_path = root / "validation.json"
     write_versioned_json(
         validation_path,
-        {"verdict": verdict, "findings": findings},
-        schema_version=1,
+        {"verdict": verdict, "findings": errors, "warnings": warnings},
+        schema_version=2,
     )
-    logger.info("validate_plan", verdict=verdict, issue_count=len(findings))
+    logger.info("validate_plan", verdict=verdict, issue_count=len(errors))
     return {
         "verdict": verdict,
         "validation_path": str(validation_path),
-        "issue_count": str(len(findings)),
+        "issue_count": str(len(errors)),
     }

--- a/src/autoskillit/planner/validation.py
+++ b/src/autoskillit/planner/validation.py
@@ -277,6 +277,10 @@ def validate_plan(output_dir: str) -> dict[str, str]:
 
     errors = [f for f in all_findings if f["severity"] == "error"]
     warnings = [f for f in all_findings if f["severity"] == "warning"]
+    unrecognized = [f for f in all_findings if f["severity"] not in ("error", "warning")]
+    if unrecognized:
+        sev_vals = {f["severity"] for f in unrecognized}
+        raise ValueError(f"Unrecognized severity values in findings: {sev_vals}")
 
     verdict = "pass" if not errors else "fail"
     validation_path = root / "validation.json"
@@ -290,4 +294,5 @@ def validate_plan(output_dir: str) -> dict[str, str]:
         "verdict": verdict,
         "validation_path": str(validation_path),
         "issue_count": str(len(errors)),
+        "warning_count": str(len(warnings)),
     }

--- a/src/autoskillit/skills_extended/planner-refine/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine/SKILL.md
@@ -49,7 +49,8 @@ retries) before escalation.
 
 ### Step 1: Load validation.json
 
-Read `$1`. Extract the `findings` array. Group by type:
+Read `$1`. Extract the `findings` array (contains only error-severity findings as structured
+dicts). Extract the `message` field from each finding for classification. Group by type:
 
 - **failed_wps**: Findings matching `WP .* has status 'failed'`
 - **sizing_violations**: Findings matching `WP .* has \d+ deliverables`
@@ -58,6 +59,7 @@ Read `$1`. Extract the `findings` array. Group by type:
 - **missing**: Findings matching `Phase .* has no assignments` or `Assignment .* has no work packages`
 - **malformed_id**: Findings matching `WP .* has malformed id`
 - **dag_cycle**: Findings matching `Cycle detected among WPs`
+- **files_touched_overlap** (informational): Findings matching `File '.*' touched by multiple WPs` — these appear in the `warnings` array, not `findings`. No action needed; skip if encountered in `findings`.
 
 ### Step 2: Load required artifacts
 
@@ -141,6 +143,7 @@ refinement_complete = true
 issues_fixed = <N>
 ```
 
-`N` = count of findings addressed (failed_wps + sizing_violations + duplicate_deliverables
-+ dep_references). Missing-element, malformed-ID, and DAG-cycle findings are excluded from
-the count (they are escalated as critical, not fixed).
+`N` = count of findings addressed from the `findings` array (failed_wps + sizing_violations +
+duplicate_deliverables + dep_references). Missing-element, malformed-ID, and DAG-cycle findings
+are excluded from the count (they are escalated as critical, not fixed). Files-touched overlap
+findings are in the `warnings` array and are not actionable.

--- a/tests/planner/test_compiler.py
+++ b/tests/planner/test_compiler.py
@@ -72,7 +72,8 @@ def _make_valid_output_dir(
     )
 
     _write_json(
-        tmp_path / "validation.json", {"verdict": "pass", "findings": [], "schema_version": 1}
+        tmp_path / "validation.json",
+        {"verdict": "pass", "findings": [], "warnings": [], "schema_version": 2},
     )
 
     if with_dep_graph:
@@ -125,7 +126,8 @@ def _make_chain_3_wps(tmp_path: Path) -> Path:
         wps_dir / "wp_manifest.json", {"pass_name": "work_packages", "items": manifest_items}
     )
     _write_json(
-        tmp_path / "validation.json", {"verdict": "pass", "findings": [], "schema_version": 1}
+        tmp_path / "validation.json",
+        {"verdict": "pass", "findings": [], "warnings": [], "schema_version": 2},
     )
     return tmp_path
 

--- a/tests/planner/test_pipeline_integration.py
+++ b/tests/planner/test_pipeline_integration.py
@@ -203,7 +203,7 @@ def test_pipeline_factory_fixtures_are_schema_compliant(tmp_path: Path) -> None:
     )
     _write_json(
         tmp_path / "validation.json",
-        {"verdict": "pass", "findings": [], "schema_version": 1},
+        {"verdict": "pass", "findings": [], "warnings": [], "schema_version": 2},
     )
 
     validate_result = validate_plan(str(tmp_path))

--- a/tests/planner/test_planner.py
+++ b/tests/planner/test_planner.py
@@ -48,6 +48,7 @@ def test_planner_all_exports() -> None:
         "resolve_wp_id",
         "validate_refined_assignments",
         "validate_refined_plan",
+        "ValidationFinding",
     }
 
 

--- a/tests/planner/test_schema_conformance.py
+++ b/tests/planner/test_schema_conformance.py
@@ -168,7 +168,7 @@ def test_compile_plan_derives_name_slug_from_name(tmp_path: Path) -> None:
     )
     _write_json(
         tmp_path / "validation.json",
-        {"verdict": "pass", "findings": [], "schema_version": 1},
+        {"verdict": "pass", "findings": [], "warnings": [], "schema_version": 2},
     )
 
     compile_plan(str(tmp_path), "test task", "/src")

--- a/tests/planner/test_validation.py
+++ b/tests/planner/test_validation.py
@@ -127,7 +127,7 @@ def test_validate_plan_cyclic_dep_fails(tmp_path: Path) -> None:
     result = validate_plan(str(tmp_path))
     assert result["verdict"] == "fail"
     validation = json.loads((tmp_path / "validation.json").read_text())
-    assert any(wp1 in f and wp2 in f for f in validation["findings"])
+    assert any(wp1 in f["message"] and wp2 in f["message"] for f in validation["findings"])
 
 
 def test_validate_plan_missing_dep_ref_fails(tmp_path: Path) -> None:
@@ -176,7 +176,7 @@ def test_validate_plan_failed_wp_flagged_but_not_sole_fail_cause(tmp_path: Path)
     result = validate_plan(str(tmp_path))
     assert result["verdict"] == "fail"
     validation = json.loads((tmp_path / "validation.json").read_text())
-    assert any("P1-A1-WP1" in f for f in validation["findings"])
+    assert any("P1-A1-WP1" in f["message"] for f in validation["findings"])
 
 
 def test_validate_plan_dep_graph_backward_dep_injection(tmp_path: Path) -> None:
@@ -232,9 +232,9 @@ def test_check_duplicate_files_touched_detects_overlap() -> None:
     }
     findings = _check_duplicate_files_touched(wp_results)
     assert len(findings) == 1
-    assert "src/foo.py" in findings[0]
-    assert "P1-A1-WP1" in findings[0]
-    assert "P2-A1-WP1" in findings[0]
+    assert "src/foo.py" in findings[0]["message"]
+    assert "P1-A1-WP1" in findings[0]["message"]
+    assert "P2-A1-WP1" in findings[0]["message"]
 
 
 def test_check_duplicate_files_touched_no_false_positives() -> None:
@@ -250,8 +250,74 @@ def test_check_duplicate_files_touched_no_false_positives() -> None:
 
 
 def test_validate_plan_includes_duplicate_files_touched(tmp_path: Path) -> None:
-    """T14: validate_plan detects files_touched overlap and fails."""
+    """T14: validate_plan detects files_touched overlap as warning, not error."""
     _make_minimal_output_dir(tmp_path, wps_per_assignment=2)
+    wp_dir = tmp_path / "work_packages"
+    for wp_id in ("P1-A1-WP1", "P1-A1-WP2"):
+        result_path = wp_dir / f"{wp_id}_result.json"
+        data = json.loads(result_path.read_text())
+        data["files_touched"] = ["src/shared.py"]
+        result_path.write_text(json.dumps(data))
+
+    result = validate_plan(str(tmp_path))
+    assert result["verdict"] == "pass"
+    validation = json.loads((tmp_path / "validation.json").read_text())
+    assert any("src/shared.py" in w["message"] for w in validation["warnings"])
+
+
+# ---------------------------------------------------------------------------
+# Severity-level tests (T15–T19)
+# ---------------------------------------------------------------------------
+
+
+def test_warning_severity_does_not_fail_verdict(tmp_path: Path) -> None:
+    """T15: files_touched overlap is a warning, not an error — verdict stays pass."""
+    _make_minimal_output_dir(tmp_path, wps_per_assignment=2)
+    wp_dir = tmp_path / "work_packages"
+    for wp_id in ("P1-A1-WP1", "P1-A1-WP2"):
+        result_path = wp_dir / f"{wp_id}_result.json"
+        data = json.loads(result_path.read_text())
+        data["files_touched"] = ["src/shared.py"]
+        result_path.write_text(json.dumps(data))
+
+    result = validate_plan(str(tmp_path))
+    assert result["verdict"] == "pass"
+    assert result["issue_count"] == "0"
+    validation = json.loads((tmp_path / "validation.json").read_text())
+    assert len(validation["findings"]) == 0
+    assert len(validation["warnings"]) == 1
+    assert validation["warnings"][0]["severity"] == "warning"
+    assert validation["warnings"][0]["check"] == "duplicate_files_touched"
+    assert "src/shared.py" in validation["warnings"][0]["message"]
+
+
+def test_error_findings_have_structured_fields(tmp_path: Path) -> None:
+    """T16: Error findings contain message, severity, and check fields."""
+    _make_minimal_output_dir(tmp_path, wps_per_assignment=2)
+    wp1 = "P1-A1-WP1"
+    wp2 = "P1-A1-WP2"
+    wp_dir = tmp_path / "work_packages"
+    data1 = json.loads((wp_dir / f"{wp1}_result.json").read_text())
+    data1["depends_on"] = [wp2]
+    (wp_dir / f"{wp1}_result.json").write_text(json.dumps(data1))
+    data2 = json.loads((wp_dir / f"{wp2}_result.json").read_text())
+    data2["depends_on"] = [wp1]
+    (wp_dir / f"{wp2}_result.json").write_text(json.dumps(data2))
+
+    validate_plan(str(tmp_path))
+    validation = json.loads((tmp_path / "validation.json").read_text())
+    for finding in validation["findings"]:
+        assert "message" in finding
+        assert "severity" in finding
+        assert "check" in finding
+        assert finding["severity"] == "error"
+    cycle_findings = [f for f in validation["findings"] if f["check"] == "dag_acyclic"]
+    assert len(cycle_findings) == 1
+
+
+def test_mixed_errors_and_warnings(tmp_path: Path) -> None:
+    """T17: Sizing violation (error) + files_touched overlap (warning) coexist."""
+    _make_minimal_output_dir(tmp_path, wps_per_assignment=2, deliverables_override=[])
     wp_dir = tmp_path / "work_packages"
     for wp_id in ("P1-A1-WP1", "P1-A1-WP2"):
         result_path = wp_dir / f"{wp_id}_result.json"
@@ -262,4 +328,31 @@ def test_validate_plan_includes_duplicate_files_touched(tmp_path: Path) -> None:
     result = validate_plan(str(tmp_path))
     assert result["verdict"] == "fail"
     validation = json.loads((tmp_path / "validation.json").read_text())
-    assert any("src/shared.py" in f for f in validation["findings"])
+    error_findings = [f for f in validation["findings"] if f["severity"] == "error"]
+    assert len(error_findings) >= 1
+    assert len(validation["warnings"]) == 1
+    assert validation["warnings"][0]["severity"] == "warning"
+
+
+def test_validation_json_schema_version_2(tmp_path: Path) -> None:
+    """T18: validation.json uses schema_version 2 and includes warnings key."""
+    _make_minimal_output_dir(tmp_path)
+    validate_plan(str(tmp_path))
+    validation = json.loads((tmp_path / "validation.json").read_text())
+    assert validation["schema_version"] == 2
+    assert "warnings" in validation
+
+
+def test_check_duplicate_files_touched_returns_structured_findings() -> None:
+    """T19: _check_duplicate_files_touched returns dicts with message/severity/check."""
+    from autoskillit.planner.validation import _check_duplicate_files_touched
+
+    wp_results = {
+        "P1-A1-WP1": {"files_touched": ["src/foo.py"]},
+        "P2-A1-WP1": {"files_touched": ["src/foo.py"]},
+    }
+    findings = _check_duplicate_files_touched(wp_results)
+    assert len(findings) == 1
+    assert findings[0]["severity"] == "warning"
+    assert findings[0]["check"] == "duplicate_files_touched"
+    assert "message" in findings[0]


### PR DESCRIPTION
## Summary

The planner's `validate_plan` function treats every finding as a blocking error. This causes the validate→refine loop to fail when `_check_duplicate_files_touched` produces dozens of informational findings that no component can fix or dismiss. The fix adds a `ValidationFinding` TypedDict with `message`, `severity`, and `check` fields, classifies `files_touched` overlap as `warning` severity, splits the output into `findings` (errors) and `warnings`, and computes the verdict only from error-severity findings. The planner-refine skill is updated to extract `f["message"]` from the now-structured findings and skip `files_touched` overlap entries.

## Architecture Impact

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START([Pipeline Entry])

    subgraph InitOnly ["INIT_ONLY — Set Once, Never Modify"]
        direction TB
        PLANID["PlanDocument.task<br/>━━━━━━━━━━<br/>Immutable after creation"]
        ENTITYIDS["Phase/Assignment/WP IDs<br/>━━━━━━━━━━<br/>Frozen: P1, P1-A2, P1-A2-WP3"]
        REQKEYS["● REQUIRED_KEYS frozensets<br/>━━━━━━━━━━<br/>PHASE / ASSIGNMENT / WP"]
    end

    subgraph InitPreserve ["INIT_PRESERVE — Derived at Ingestion, Kept Through Pipeline"]
        direction TB
        DERIVED_FIELDS["phase_number, name_slug<br/>━━━━━━━━━━<br/>Normalized by validate_*_result<br/>Preserved: never re-derived"]
    end

    subgraph Mutable ["MUTABLE — In-Place Mutation Points"]
        direction TB
        BACKDEPS["● WP.depends_on<br/>━━━━━━━━━━<br/>_inject_backward_deps<br/>Mutates before validation"]
        FWDDEPS["WP.depended_on_by<br/>━━━━━━━━━━<br/>_inject_forward_deps<br/>Added at compile time"]
    end

    subgraph SchemaGates ["SCHEMA GATES — Hard Abort (raise ValueError)"]
        direction TB
        VPHASE["● validate_phase_result<br/>━━━━━━━━━━<br/>Requires: id, name, ordering<br/>FAIL-FAST: ValueError"]
        VASSIGN["● validate_assignment_result<br/>━━━━━━━━━━<br/>Requires: id, name, proposed_work_packages<br/>FAIL-FAST: ValueError"]
        VWP["● validate_wp_result<br/>━━━━━━━━━━<br/>Requires: id, name, deliverables<br/>FAIL-FAST: ValueError"]
    end

    subgraph FindingType ["● ValidationFinding — Severity-Tagged Output"]
        direction TB
        FINDING["● ValidationFinding TypedDict<br/>━━━━━━━━━━<br/>message: str<br/>severity: error │ warning<br/>check: str"]
    end

    subgraph ErrorGates ["● STRUCTURAL GATES — Error Findings (Block Verdict)"]
        direction TB
        CK_PHASE["● phase_completeness<br/>━━━━━━━━━━<br/>severity: error"]
        CK_ASSIGN["● assignment_completeness<br/>━━━━━━━━━━<br/>severity: error"]
        CK_DEPS["● dep_references<br/>━━━━━━━━━━<br/>severity: error"]
        CK_DAG["● dag_acyclic<br/>━━━━━━━━━━<br/>severity: error<br/>Kahn's algorithm"]
        CK_SIZE["● sizing_bounds<br/>━━━━━━━━━━<br/>severity: error<br/>1-5 deliverables"]
        CK_DUP["● duplicate_deliverables<br/>━━━━━━━━━━<br/>severity: error"]
        CK_FAIL["● failed_wps<br/>━━━━━━━━━━<br/>severity: error"]
    end

    subgraph WarningGates ["● ADVISORY GATES — Warning Findings (Never Block)"]
        direction TB
        CK_FILES["● duplicate_files_touched<br/>━━━━━━━━━━<br/>severity: warning<br/>Overlap is advisory"]
    end

    subgraph SeveritySplit ["● SEVERITY SEPARATION — Append-Only Accumulation"]
        direction TB
        ALL_FINDINGS["● all_findings: list<br/>━━━━━━━━━━<br/>APPEND_ONLY accumulator"]
        ERRORS["● errors list<br/>━━━━━━━━━━<br/>severity == error<br/>Written to findings key"]
        WARNINGS["● warnings list<br/>━━━━━━━━━━<br/>severity == warning<br/>Written to warnings key"]
    end

    subgraph Verdict ["● DERIVED STATE — Verdict + Output"]
        direction TB
        VERDICT["● verdict: pass │ fail<br/>━━━━━━━━━━<br/>DERIVED: pass iff errors empty"]
        VALFILE["● validation.json<br/>━━━━━━━━━━<br/>schema_version: 2<br/>verdict + findings + warnings"]
        RETURN["● Return dict<br/>━━━━━━━━━━<br/>verdict, validation_path,<br/>issue_count (errors only)"]
    end

    subgraph CompileGate ["COMPILE GATE — Weak Enforcement"]
        direction TB
        COMPILER["compile_plan<br/>━━━━━━━━━━<br/>Reads validation.json<br/>Logs warning, does NOT abort<br/>Re-runs cycle detection independently"]
    end

    %% FLOW %%
    START --> PLANID
    START --> ENTITYIDS
    START --> REQKEYS

    ENTITYIDS --> VPHASE
    ENTITYIDS --> VASSIGN
    ENTITYIDS --> VWP
    REQKEYS --> VPHASE
    REQKEYS --> VASSIGN
    REQKEYS --> VWP

    VPHASE --> DERIVED_FIELDS
    VASSIGN --> DERIVED_FIELDS

    DERIVED_FIELDS --> BACKDEPS
    VWP --> BACKDEPS

    BACKDEPS --> CK_PHASE
    BACKDEPS --> CK_ASSIGN
    BACKDEPS --> CK_DEPS
    BACKDEPS --> CK_DAG
    BACKDEPS --> CK_SIZE
    BACKDEPS --> CK_DUP
    BACKDEPS --> CK_FAIL
    BACKDEPS --> CK_FILES

    CK_PHASE --> ALL_FINDINGS
    CK_ASSIGN --> ALL_FINDINGS
    CK_DEPS --> ALL_FINDINGS
    CK_DAG --> ALL_FINDINGS
    CK_SIZE --> ALL_FINDINGS
    CK_DUP --> ALL_FINDINGS
    CK_FAIL --> ALL_FINDINGS
    CK_FILES --> ALL_FINDINGS

    ALL_FINDINGS --> ERRORS
    ALL_FINDINGS --> WARNINGS
    FINDING -.->|type contract| ALL_FINDINGS

    ERRORS --> VERDICT
    WARNINGS --> VALFILE
    VERDICT --> VALFILE
    VALFILE --> RETURN
    RETURN --> COMPILER
    FWDDEPS -.->|added at compile| COMPILER

    %% CLASS ASSIGNMENTS %%
    class PLANID,ENTITYIDS,REQKEYS detector;
    class DERIVED_FIELDS gap;
    class BACKDEPS,FWDDEPS phase;
    class VPHASE,VASSIGN,VWP stateNode;
    class FINDING handler;
    class CK_PHASE,CK_ASSIGN,CK_DEPS,CK_DAG,CK_SIZE,CK_DUP,CK_FAIL detector;
    class CK_FILES gap;
    class ALL_FINDINGS,ERRORS,WARNINGS handler;
    class VERDICT,VALFILE,RETURN output;
    class COMPILER cli;
    class START terminal;
```

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START: validate_plan invoked])
    PASS_END([PASS: verdict=pass])
    FAIL_END([FAIL: verdict=fail])
    HARD_ERROR([HARD ERROR: RuntimeError])

    subgraph Loading ["● Data Loading Phase"]
        direction TB
        LP["● _load_phase_results<br/>━━━━━━━━━━<br/>phases/*_result.json<br/>→ validate_phase_result"]
        LA["● _load_assignment_results<br/>━━━━━━━━━━<br/>assignments/*_result.json<br/>→ validate_assignment_result"]
        LW["● _load_wp_results<br/>━━━━━━━━━━<br/>work_packages/*_result.json<br/>→ validate_wp_result"]
        LM["_load_wp_manifest<br/>━━━━━━━━━━<br/>wp_manifest.json<br/>→ dict or None"]
        PARSE_CHECK{"JSON parse /<br/>schema valid?"}
    end

    subgraph DepInjection ["Dependency Injection"]
        direction TB
        DEP_CHECK{"dep_graph.json<br/>exists?"}
        INJECT["_inject_backward_deps<br/>━━━━━━━━━━<br/>Mutate WP depends_on<br/>from dep_graph edges"]
    end

    subgraph Checks ["● Validation Checks (all run, no short-circuit)"]
        direction TB
        C1["_check_phase_completeness<br/>━━━━━━━━━━<br/>severity: error"]
        C2["_check_assignment_completeness<br/>━━━━━━━━━━<br/>severity: error"]
        C3["_check_dep_references<br/>━━━━━━━━━━<br/>severity: error"]
        C4["_check_dag_acyclic<br/>━━━━━━━━━━<br/>Kahn's algorithm<br/>severity: error"]
        C5["_check_sizing_bounds<br/>━━━━━━━━━━<br/>1–5 deliverables<br/>severity: error"]
        C6["_check_duplicate_deliverables<br/>━━━━━━━━━━<br/>severity: error"]
        C7["● _check_duplicate_files_touched<br/>━━━━━━━━━━<br/>severity: warning"]
        C8["_check_failed_wps<br/>━━━━━━━━━━<br/>severity: error"]
    end

    subgraph Verdict ["● Verdict & Output"]
        direction TB
        SPLIT["● Split findings<br/>━━━━━━━━━━<br/>errors = severity==error<br/>warnings = severity==warning"]
        VERDICT_CHECK{"errors list<br/>empty?"}
        WRITE_JSON["● write validation.json<br/>━━━━━━━━━━<br/>schema_version: 2<br/>findings: errors<br/>warnings: warnings"]
    end

    subgraph Refine ["● Downstream: planner-refine Skill"]
        direction TB
        LOAD_VAL["Step 1: Load validation.json<br/>━━━━━━━━━━<br/>Read findings array only<br/>Skip warnings"]
        CLASSIFY{"Step 1: Classify<br/>by check type"}
        FIX["Step 3: Auto-fix<br/>━━━━━━━━━━<br/>failed_wps / sizing /<br/>dup_deliverables / dep_refs"]
        ESCALATE["Step 3: Escalate CRITICAL<br/>━━━━━━━━━━<br/>dag_cycle / missing /<br/>malformed_id"]
        REVALIDATE["Step 5: Emit tokens<br/>━━━━━━━━━━<br/>refinement_complete=true<br/>issues_fixed=N"]
    end

    %% FLOW — Loading %%
    START --> LP
    START --> LA
    START --> LW
    START --> LM
    LP --> PARSE_CHECK
    LA --> PARSE_CHECK
    LW --> PARSE_CHECK
    LM --> PARSE_CHECK
    PARSE_CHECK -->|"invalid"| HARD_ERROR
    PARSE_CHECK -->|"valid"| DEP_CHECK

    %% FLOW — Dep Injection %%
    DEP_CHECK -->|"yes"| INJECT
    DEP_CHECK -->|"no"| C1
    INJECT --> C1

    %% FLOW — Checks (sequential, all accumulate into all_findings) %%
    C1 -->|"accumulate"| C2
    C2 -->|"accumulate"| C3
    C3 -->|"accumulate"| C4
    C4 -->|"accumulate"| C5
    C5 -->|"accumulate"| C6
    C6 -->|"accumulate"| C7
    C7 -->|"accumulate"| C8

    %% FLOW — Verdict %%
    C8 --> SPLIT
    SPLIT --> VERDICT_CHECK
    VERDICT_CHECK -->|"yes: no errors"| WRITE_JSON
    VERDICT_CHECK -->|"no: has errors"| WRITE_JSON
    WRITE_JSON -->|"verdict=pass"| PASS_END
    WRITE_JSON -->|"verdict=fail"| FAIL_END

    %% FLOW — Downstream Refine %%
    FAIL_END -.->|"caller invokes<br/>planner-refine"| LOAD_VAL
    LOAD_VAL --> CLASSIFY
    CLASSIFY -->|"auto-fixable"| FIX
    CLASSIFY -->|"not fixable"| ESCALATE
    FIX --> REVALIDATE
    ESCALATE --> REVALIDATE

    %% CLASS ASSIGNMENTS %%
    class START,PASS_END,FAIL_END,HARD_ERROR terminal;
    class LP,LA,LW,LM handler;
    class PARSE_CHECK,DEP_CHECK,VERDICT_CHECK,CLASSIFY stateNode;
    class INJECT phase;
    class C1,C2,C3,C4,C5,C6,C8 detector;
    class C7 handler;
    class SPLIT,WRITE_JSON phase;
    class LOAD_VAL,FIX,REVALIDATE handler;
    class ESCALATE detector;
```

### Data Lineage Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart LR
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    subgraph Origins ["Data Origins"]
        direction TB
        REFINED_PLAN["refined_plan.json<br/>━━━━━━━━━━<br/>Upstream skill output<br/>Phases + task desc"]:::cli
        REFINED_ASSIGN["refined_assignments.json<br/>━━━━━━━━━━<br/>Upstream skill output<br/>Assignments + WPs"]:::cli
        RESULT_FILES["*_result.json<br/>━━━━━━━━━━<br/>Per-item elaboration<br/>phases/ assignments/ work_packages/"]:::cli
        DEP_GRAPH["dep_graph.json<br/>━━━━━━━━━━<br/>Optional WP deps<br/>added_backward_deps"]:::cli
    end

    subgraph Normalize ["● Normalization (schema.py)"]
        direction TB
        VAL_PHASE["validate_phase_result()<br/>━━━━━━━━━━<br/>Fills phase_number,<br/>name_slug, defaults"]:::handler
        VAL_ASSIGN["validate_assignment_result()<br/>━━━━━━━━━━<br/>Fills phase_number,<br/>assignment_number"]:::handler
        VAL_WP["validate_wp_result()<br/>━━━━━━━━━━<br/>Checks WP ID regex<br/>Fills list defaults"]:::handler
        VAL_REFINED["validate_refined_plan()<br/>validate_refined_assignments()<br/>━━━━━━━━━━<br/>Gate validators<br/>resolve_wp_id()"]:::handler
    end

    subgraph Expand ["Expansion (manifests.py)"]
        direction TB
        EXPAND_A["expand_assignments()<br/>━━━━━━━━━━<br/>Fan-out per-phase<br/>context + manifest"]:::phase
        EXPAND_WP["expand_wps()<br/>━━━━━━━━━━<br/>Fan-out WPs per-phase<br/>sentinels + index"]:::phase
        FINALIZE["finalize_wp_manifest()<br/>━━━━━━━━━━<br/>Collect all WPs<br/>status=done"]:::phase
    end

    subgraph MergeStore ["Concurrent Store (merge.py)"]
        direction TB
        MERGE["merge_files()<br/>━━━━━━━━━━<br/>fcntl LOCK_EX<br/>Deduplicate by ID"]:::handler
        REPLACE["replace_item()<br/>━━━━━━━━━━<br/>In-place update<br/>File-locked"]:::handler
    end

    subgraph Validate ["● Validation (validation.py)"]
        direction TB
        VALIDATE["validate_plan()<br/>━━━━━━━━━━<br/>8 structural checks<br/>DAG cycle detection"]:::detector
        FINDINGS["● ValidationFinding<br/>━━━━━━━━━━<br/>message: str<br/>severity: error｜warning<br/>check: str"]:::detector
    end

    subgraph Compile ["Compilation (compiler.py)"]
        direction TB
        COMPILE["compile_plan()<br/>━━━━━━━━━━<br/>Topological sort<br/>Markdown rendering"]:::phase
    end

    subgraph PrimaryStorage ["Primary Storage (Source of Truth)"]
        direction TB
        PLAN_DOC[("PlanDocument JSON<br/>━━━━━━━━━━<br/>task, source_dir<br/>phases, assignments<br/>work_packages")]:::stateNode
        MANIFESTS[("PlannerManifest JSON<br/>━━━━━━━━━━<br/>pass_name, items[]<br/>status per item")]:::stateNode
        VALIDATION_JSON[("validation.json<br/>━━━━━━━━━━<br/>verdict: pass｜fail<br/>findings: errors[]<br/>warnings: warnings[]")]:::stateNode
    end

    subgraph Artifacts ["Write-Only Artifacts"]
        direction TB
        PLAN_JSON["plan.json<br/>━━━━━━━━━━<br/>Nested phases→WPs<br/>execution_order"]:::output
        PLAN_MD["plan.md<br/>━━━━━━━━━━<br/>Human-readable<br/>summary"]:::output
        ISSUES["issues/WP_ID_issue.md<br/>━━━━━━━━━━<br/>One per WP<br/>GitHub issue body"]:::output
        MILESTONES["milestones.json<br/>━━━━━━━━━━<br/>Per-phase milestone<br/>name + slug"]:::output
        MANIFEST_OUT["manifest.json<br/>━━━━━━━━━━<br/>execution_order<br/>issue path index"]:::output
    end

    subgraph Downstream ["Downstream Consumer"]
        direction TB
        RECIPE["Recipe Layer<br/>━━━━━━━━━━<br/>Reads manifest.json<br/>Creates GitHub Issues"]:::integration
    end

    %% INPUT → NORMALIZATION %%
    REFINED_PLAN -->|"read JSON"| VAL_REFINED
    REFINED_ASSIGN -->|"read JSON"| VAL_REFINED
    RESULT_FILES -->|"read JSON"| VAL_PHASE
    RESULT_FILES -->|"read JSON"| VAL_ASSIGN
    RESULT_FILES -->|"read JSON"| VAL_WP

    %% NORMALIZATION → EXPANSION %%
    VAL_REFINED -->|"validated dict"| EXPAND_A
    VAL_REFINED -->|"validated dict"| EXPAND_WP
    VAL_PHASE -->|"PhaseResult"| FINALIZE
    VAL_ASSIGN -->|"AssignmentResult"| FINALIZE
    VAL_WP -->|"WPResult"| FINALIZE

    %% EXPANSION → PRIMARY STORAGE %%
    EXPAND_A -->|"write"| MANIFESTS
    EXPAND_WP -->|"write"| MANIFESTS
    FINALIZE -->|"write wp_manifest"| MANIFESTS

    %% MERGE → PRIMARY STORAGE %%
    RESULT_FILES -->|"glob *_result"| MERGE
    MERGE -->|"dedupe + append"| PLAN_DOC
    REPLACE -->|"locked update"| PLAN_DOC

    %% VALIDATION FLOW %%
    RESULT_FILES -->|"load phases/<br/>assignments/<br/>work_packages/"| VALIDATE
    DEP_GRAPH -.->|"inject deps"| VALIDATE
    VALIDATE -->|"collect"| FINDINGS
    FINDINGS -->|"split by severity"| VALIDATION_JSON

    %% COMPILATION FLOW %%
    VALIDATION_JSON -->|"check verdict"| COMPILE
    RESULT_FILES -->|"load all tiers"| COMPILE
    DEP_GRAPH -.->|"forward_deps"| COMPILE

    %% COMPILE → ARTIFACTS %%
    COMPILE -->|"write nested"| PLAN_JSON
    COMPILE -->|"render markdown"| PLAN_MD
    COMPILE -->|"per-WP render"| ISSUES
    COMPILE -->|"per-phase"| MILESTONES
    COMPILE -->|"index"| MANIFEST_OUT

    %% DOWNSTREAM %%
    MANIFEST_OUT -.->|"read"| RECIPE
    ISSUES -.->|"read bodies"| RECIPE
```

Closes #1510

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260429-002654-180395/.autoskillit/temp/make-plan/planner-validation-severity-levels_plan_2026-04-29_004500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 1.8k | 9.0k | 840.0k | 64.5k | 1 | 6m 28s |
| verify | 4.8k | 9.3k | 818.3k | 63.9k | 1 | 7m 4s |
| implement | 1.0k | 18.7k | 3.7M | 86.1k | 1 | 8m 49s |
| prepare_pr | 23 | 3.9k | 141.7k | 28.6k | 1 | 1m 47s |
| run_arch_lenses | 1.5k | 16.3k | 632.3k | 92.0k | 3 | 9m 38s |
| compose_pr | 23 | 9.3k | 199.1k | 37.1k | 1 | 2m 31s |
| review_pr | 28 | 24.4k | 438.4k | 60.3k | 1 | 7m 11s |
| resolve_review | 796 | 9.8k | 1.2M | 48.9k | 1 | 7m 23s |
| **Total** | 10.0k | 100.7k | 8.0M | 481.2k | | 50m 54s |