### PR TITLE
[FIX] Fix Planner Artifact Desync After Refine + Minor Planner Cleanup

### DIFF
--- a/src/autoskillit/planner/__init__.py
+++ b/src/autoskillit/planner/__init__.py
@@ -6,7 +6,6 @@ from autoskillit.planner.compiler import compile_plan
 from autoskillit.planner.manifests import (
     build_phase_assignment_manifest,
     build_phase_wp_manifest,
-    build_pre_elab_snapshot,
     create_run_dir,
     expand_assignments,
     expand_wps,
@@ -42,7 +41,6 @@ from autoskillit.planner.validation import validate_plan
 __all__ = [
     "build_phase_assignment_manifest",
     "build_phase_wp_manifest",
-    "build_pre_elab_snapshot",
     "compile_plan",
     "create_run_dir",
     "expand_assignments",

--- a/src/autoskillit/planner/compiler.py
+++ b/src/autoskillit/planner/compiler.py
@@ -1,9 +1,7 @@
 """Planner compiler: topological sort, issue body generation, plan artifacts.
 
-Imports ``_load_*_results()`` from ``validation.py`` — reads individual
-``*_result.json`` files only.  Combined documents (``combined_*.json``,
-``refined_*.json``) are intermediate orchestration artifacts and are never
-consumed by the compiler.
+Imports ``_load_*_results()`` from ``validation.py`` — see that module's
+docstring for the combined-document exclusion rationale.
 """
 
 from __future__ import annotations

--- a/src/autoskillit/planner/compiler.py
+++ b/src/autoskillit/planner/compiler.py
@@ -1,3 +1,11 @@
+"""Planner compiler: topological sort, issue body generation, plan artifacts.
+
+Imports ``_load_*_results()`` from ``validation.py`` — reads individual
+``*_result.json`` files only.  Combined documents (``combined_*.json``,
+``refined_*.json``) are intermediate orchestration artifacts and are never
+consumed by the compiler.
+"""
+
 from __future__ import annotations
 
 import json

--- a/src/autoskillit/planner/manifests.py
+++ b/src/autoskillit/planner/manifests.py
@@ -44,38 +44,6 @@ def create_run_dir(temp_dir: str) -> RunDirResult:
     return RunDirResult(planner_dir=str(run_dir))
 
 
-def build_pre_elab_snapshot(manifest_path: str, output_dir: str) -> dict[str, str]:
-    manifest_file = Path(manifest_path)
-    out_dir = Path(output_dir)
-    try:
-        manifest = json.loads(manifest_file.read_text())
-    except json.JSONDecodeError as exc:
-        raise json.JSONDecodeError(
-            f"Failed to parse {manifest_file}: {exc.msg}", exc.doc, exc.pos
-        ) from exc
-    items = manifest.get("items", [])
-    phases = []
-    for item in items:
-        metadata = item.get("metadata", {})
-        phases.append(
-            {
-                "id": item["id"],
-                "name": item.get("name", ""),
-                "goal": metadata.get("goal", ""),
-                "scope": metadata.get("scope", []),
-                "ordering": metadata.get("ordering", 0),
-            }
-        )
-    phases.sort(key=lambda p: p["ordering"])
-    snapshot_path = out_dir / "plan_snapshot.json"
-    write_versioned_json(
-        snapshot_path,
-        {"task": "", "source_dir": "", "phases": phases},
-        schema_version=1,
-    )
-    return {"snapshot_path": str(snapshot_path)}
-
-
 def _build_index_entry(result_data: dict[str, object]) -> dict[str, object]:
     return {
         "id": result_data.get("id", ""),

--- a/src/autoskillit/planner/merge.py
+++ b/src/autoskillit/planner/merge.py
@@ -77,9 +77,10 @@ def merge_files(
                 key: existing_items,
             }
             enriched = {**document, "schema_version": 1}
+            payload = json.dumps(enriched).encode()
             fh.seek(0)
             fh.truncate()
-            fh.write(json.dumps(enriched).encode())
+            fh.write(payload)
             fh.flush()
         finally:
             fcntl.flock(fh, fcntl.LOCK_UN)
@@ -141,9 +142,10 @@ def replace_item(
                     if item.get("id") == item_id:
                         tier[idx] = replacement
                         enriched = {**data, "schema_version": 1}
+                        payload = json.dumps(enriched).encode()
                         fh.seek(0)
                         fh.truncate()
-                        fh.write(json.dumps(enriched).encode())
+                        fh.write(payload)
                         fh.flush()
                         found = True
                         break

--- a/src/autoskillit/planner/merge.py
+++ b/src/autoskillit/planner/merge.py
@@ -76,7 +76,11 @@ def merge_files(
                 "source_dir": existing_source_dir,
                 key: existing_items,
             }
-            write_versioned_json(out, document, schema_version=1)
+            enriched = {**document, "schema_version": 1}
+            fh.seek(0)
+            fh.truncate()
+            fh.write(json.dumps(enriched).encode())
+            fh.flush()
         finally:
             fcntl.flock(fh, fcntl.LOCK_UN)
 
@@ -127,7 +131,7 @@ def replace_item(
     src = Path(source_path)
 
     found = False
-    with open(src, "rb") as fh:
+    with open(src, "r+b") as fh:
         try:
             fcntl.flock(fh, fcntl.LOCK_EX)
             data: dict[str, Any] = json.loads(fh.read())
@@ -136,7 +140,11 @@ def replace_item(
                 for idx, item in enumerate(tier):
                     if item.get("id") == item_id:
                         tier[idx] = replacement
-                        write_versioned_json(src, data, schema_version=1)
+                        enriched = {**data, "schema_version": 1}
+                        fh.seek(0)
+                        fh.truncate()
+                        fh.write(json.dumps(enriched).encode())
+                        fh.flush()
                         found = True
                         break
                 if found:

--- a/src/autoskillit/planner/validation.py
+++ b/src/autoskillit/planner/validation.py
@@ -1,3 +1,12 @@
+"""Planner validation: structural completeness, DAG acyclicity, sizing bounds.
+
+All loaders read from individual ``*_result.json`` files in the ``phases/``,
+``assignments/``, and ``work_packages/`` subdirectories.  Combined documents
+(``combined_*.json``, ``refined_*.json``) are intermediate orchestration
+artifacts produced by the merge/refine cycle — they are **not** authoritative
+and are never consumed here.
+"""
+
 from __future__ import annotations
 
 import json

--- a/src/autoskillit/skills_extended/planner-refine/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine/SKILL.md
@@ -136,6 +136,11 @@ Write all modified files back atomically (read current → apply change → writ
 files may include: `_result.json` files, `wp_manifest.json`, `wp_index.json`,
 `dep_graph.json`.
 
+> **Note:** Combined documents (`combined_*.json`, `refined_*.json`) are intermediate
+> orchestration artifacts and are NOT updated by this skill. Downstream consumers
+> (`validate_plan`, `compile_plan`) read from individual `*_result.json` files directly,
+> so stale combined documents do not affect pipeline correctness.
+
 ### Step 5: Emit output tokens
 
 ```

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -156,7 +156,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/smoke_utils.py", 87),
     ("src/autoskillit/smoke_utils.py", 272),
     # planner/manifests.py — finalize_wp_manifest: wp_index.json rebuild (list payload)
-    ("src/autoskillit/planner/manifests.py", 275),
+    ("src/autoskillit/planner/manifests.py", 243),
 }
 
 

--- a/tests/planner/conftest.py
+++ b/tests/planner/conftest.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from typing import Any
 
 from autoskillit.planner.schema import (
@@ -53,3 +55,9 @@ def make_wp_result(wp_id: str, **overrides: Any) -> dict[str, Any]:
         **overrides,
     }
     return validate_wp_result(data)
+
+
+def write_json(path: Path, data: object) -> None:
+    """Write ``data`` as JSON to ``path``, creating parent dirs as needed."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data))

--- a/tests/planner/test_compiler.py
+++ b/tests/planner/test_compiler.py
@@ -8,7 +8,12 @@ from pathlib import Path
 import pytest
 
 from autoskillit.planner.compiler import compile_plan
-from tests.planner.conftest import make_assignment_result, make_phase_result, make_wp_result
+from tests.planner.conftest import (
+    make_assignment_result,
+    make_phase_result,
+    make_wp_result,
+    write_json,
+)
 
 pytestmark = [pytest.mark.layer("planner"), pytest.mark.small, pytest.mark.feature("planner")]
 
@@ -16,11 +21,6 @@ pytestmark = [pytest.mark.layer("planner"), pytest.mark.small, pytest.mark.featu
 # ---------------------------------------------------------------------------
 # Fixture helpers
 # ---------------------------------------------------------------------------
-
-
-def _write_json(path: Path, data: object) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(data))
 
 
 def _make_valid_output_dir(
@@ -36,11 +36,11 @@ def _make_valid_output_dir(
     wps_dir = tmp_path / "work_packages"
 
     for p in range(1, num_phases + 1):
-        _write_json(
+        write_json(
             phases_dir / f"P{p}_result.json",
             make_phase_result(p, name=f"Phase {p}"),
         )
-        _write_json(
+        write_json(
             assigns_dir / f"P{p}-A1_result.json",
             make_assignment_result(
                 p,
@@ -52,7 +52,7 @@ def _make_valid_output_dir(
         deps: list[str] = []
         if dependency_chain and p > 1:
             deps = [f"P{p - 1}-A1-WP1"]
-        _write_json(
+        write_json(
             wps_dir / f"P{p}-A1-WP1_result.json",
             make_wp_result(
                 f"P{p}-A1-WP1",
@@ -67,17 +67,17 @@ def _make_valid_output_dir(
         )
 
     manifest_items = [{"id": f"P{p}-A1-WP1", "status": "done"} for p in range(1, num_phases + 1)]
-    _write_json(
+    write_json(
         wps_dir / "wp_manifest.json", {"pass_name": "work_packages", "items": manifest_items}
     )
 
-    _write_json(
+    write_json(
         tmp_path / "validation.json",
         {"verdict": "pass", "findings": [], "warnings": [], "schema_version": 2},
     )
 
     if with_dep_graph:
-        _write_json(
+        write_json(
             tmp_path / "dep_graph.json",
             {
                 "added_backward_deps": {},
@@ -94,11 +94,11 @@ def _make_chain_3_wps(tmp_path: Path) -> Path:
     assigns_dir = tmp_path / "assignments"
     wps_dir = tmp_path / "work_packages"
 
-    _write_json(
+    write_json(
         phases_dir / "P1_result.json",
         make_phase_result(1, name="Foundation"),
     )
-    _write_json(
+    write_json(
         assigns_dir / "P1-A1_result.json",
         make_assignment_result(
             1,
@@ -108,7 +108,7 @@ def _make_chain_3_wps(tmp_path: Path) -> Path:
         ),
     )
     for i, deps in [(1, []), (2, ["P1-A1-WP1"]), (3, ["P1-A1-WP2"])]:
-        _write_json(
+        write_json(
             wps_dir / f"P1-A1-WP{i}_result.json",
             make_wp_result(
                 f"P1-A1-WP{i}",
@@ -122,10 +122,10 @@ def _make_chain_3_wps(tmp_path: Path) -> Path:
             ),
         )
     manifest_items = [{"id": f"P1-A1-WP{i}", "status": "done"} for i in range(1, 4)]
-    _write_json(
+    write_json(
         wps_dir / "wp_manifest.json", {"pass_name": "work_packages", "items": manifest_items}
     )
-    _write_json(
+    write_json(
         tmp_path / "validation.json",
         {"verdict": "pass", "findings": [], "warnings": [], "schema_version": 2},
     )
@@ -175,7 +175,7 @@ def test_compile_plan_depends_on_cross_ref(tmp_path: Path) -> None:
 
 def test_compile_plan_depended_on_by_cross_ref(tmp_path: Path) -> None:
     _make_chain_3_wps(tmp_path)
-    _write_json(
+    write_json(
         tmp_path / "dep_graph.json",
         {
             "added_backward_deps": {},

--- a/tests/planner/test_pipeline_integration.py
+++ b/tests/planner/test_pipeline_integration.py
@@ -12,14 +12,14 @@ from pathlib import Path
 
 import pytest
 
-from tests.planner.conftest import make_assignment_result, make_phase_result, make_wp_result
+from tests.planner.conftest import (
+    make_assignment_result,
+    make_phase_result,
+    make_wp_result,
+    write_json,
+)
 
 pytestmark = [pytest.mark.layer("planner"), pytest.mark.small, pytest.mark.feature("planner")]
-
-
-def _write_json(path: Path, data: object) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(data))
 
 
 def test_multi_phase_pipeline_end_to_end(tmp_path: Path) -> None:
@@ -33,7 +33,7 @@ def test_multi_phase_pipeline_end_to_end(tmp_path: Path) -> None:
     )
 
     # Phase results (needed by validate_plan/compile_plan)
-    _write_json(
+    write_json(
         tmp_path / "phases" / "P1_result.json",
         {
             "id": "P1",
@@ -45,7 +45,7 @@ def test_multi_phase_pipeline_end_to_end(tmp_path: Path) -> None:
             "assignments_preview": ["Core setup"],
         },
     )
-    _write_json(
+    write_json(
         tmp_path / "phases" / "P2_result.json",
         {
             "id": "P2",
@@ -58,7 +58,7 @@ def test_multi_phase_pipeline_end_to_end(tmp_path: Path) -> None:
         },
     )
 
-    _write_json(
+    write_json(
         tmp_path / "refined_plan.json",
         {
             "phases": [
@@ -80,7 +80,7 @@ def test_multi_phase_pipeline_end_to_end(tmp_path: Path) -> None:
 
     expand_assignments(str(tmp_path / "refined_plan.json"), str(tmp_path))
 
-    _write_json(
+    write_json(
         tmp_path / "assignments" / "P1-A1_result.json",
         {
             "id": "P1-A1",
@@ -98,7 +98,7 @@ def test_multi_phase_pipeline_end_to_end(tmp_path: Path) -> None:
             ],
         },
     )
-    _write_json(
+    write_json(
         tmp_path / "assignments" / "P2-A1_result.json",
         {
             "id": "P2-A1",
@@ -117,7 +117,7 @@ def test_multi_phase_pipeline_end_to_end(tmp_path: Path) -> None:
         },
     )
 
-    _write_json(
+    write_json(
         tmp_path / "refined_assignments.json",
         {
             "assignments": [
@@ -148,11 +148,11 @@ def test_multi_phase_pipeline_end_to_end(tmp_path: Path) -> None:
     expand_wps(str(tmp_path / "refined_assignments.json"), str(tmp_path))
 
     wp_dir = tmp_path / "work_packages"
-    _write_json(
+    write_json(
         wp_dir / "P1-A1-WP1_result.json",
         make_wp_result("P1-A1-WP1", deliverables=["src/core.py"]),
     )
-    _write_json(
+    write_json(
         wp_dir / "P2-A1-WP1_result.json",
         make_wp_result("P2-A1-WP1", deliverables=["src/app.py"], depends_on=["P1-A1-WP1"]),
     )
@@ -185,23 +185,23 @@ def test_pipeline_factory_fixtures_are_schema_compliant(tmp_path: Path) -> None:
     from autoskillit.planner import compile_plan, validate_plan
 
     # Build everything using factory functions (SKILL.md-derived, not raw backend fields)
-    _write_json(
+    write_json(
         tmp_path / "phases" / "P1_result.json",
         make_phase_result(1, name="Schema Alignment"),
     )
-    _write_json(
+    write_json(
         tmp_path / "assignments" / "P1-A1_result.json",
         make_assignment_result(1, 1, name="Implement schema"),
     )
-    _write_json(
+    write_json(
         tmp_path / "work_packages" / "P1-A1-WP1_result.json",
         make_wp_result("P1-A1-WP1"),
     )
-    _write_json(
+    write_json(
         tmp_path / "work_packages" / "wp_manifest.json",
         {"pass_name": "work_packages", "items": [{"id": "P1-A1-WP1", "status": "done"}]},
     )
-    _write_json(
+    write_json(
         tmp_path / "validation.json",
         {"verdict": "pass", "findings": [], "warnings": [], "schema_version": 2},
     )

--- a/tests/planner/test_planner.py
+++ b/tests/planner/test_planner.py
@@ -21,7 +21,6 @@ def test_planner_all_exports() -> None:
     assert set(__all__) == {
         "build_phase_assignment_manifest",
         "build_phase_wp_manifest",
-        "build_pre_elab_snapshot",
         "compile_plan",
         "create_run_dir",
         "expand_assignments",
@@ -415,3 +414,59 @@ def test_expand_wps_raises_on_missing_id_and_suffix(tmp_path) -> None:
     )
     with pytest.raises(ValueError, match="neither 'id' nor 'id_suffix'"):
         expand_wps(str(refined), str(tmp_path))
+
+
+def test_write_json_helper_in_conftest() -> None:
+    from tests.planner.conftest import write_json
+
+    assert callable(write_json)
+
+
+def test_merge_files_does_not_use_atomic_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """merge_files must write directly under flock, not via atomic_write/os.replace."""
+    from unittest.mock import MagicMock
+
+    from autoskillit.planner.merge import merge_files
+
+    spy = MagicMock(side_effect=AssertionError("atomic_write must not be called"))
+    monkeypatch.setattr("autoskillit.planner.merge.write_versioned_json", spy)
+
+    results_dir = tmp_path / "phases"
+    results_dir.mkdir()
+    (results_dir / "P1_result.json").write_text(
+        json.dumps({"id": "P1", "name": "Phase 1", "ordering": 1})
+    )
+
+    out = tmp_path / "combined.json"
+    result = merge_files([str(results_dir / "P1_result.json")], str(out), "phases")
+    assert result["item_count"] == "1"
+    merged = json.loads(out.read_text())
+    assert merged["schema_version"] == 1
+    assert len(merged["phases"]) == 1
+    spy.assert_not_called()
+
+
+def test_replace_item_does_not_use_atomic_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """replace_item must write directly under flock, not via atomic_write/os.replace."""
+    from unittest.mock import MagicMock
+
+    from autoskillit.planner.merge import replace_item
+
+    spy = MagicMock(side_effect=AssertionError("atomic_write must not be called"))
+    monkeypatch.setattr("autoskillit.planner.merge.write_versioned_json", spy)
+
+    src = tmp_path / "combined.json"
+    src.write_text(json.dumps({"phases": [{"id": "P1", "name": "Old"}], "schema_version": 1}))
+    repl = tmp_path / "replacement.json"
+    repl.write_text(json.dumps({"id": "P1", "name": "New"}))
+
+    result = replace_item(str(src), "P1", str(repl))
+    assert result["replaced_id"] == "P1"
+    data = json.loads(src.read_text())
+    assert data["phases"][0]["name"] == "New"
+    assert data["schema_version"] == 1
+    spy.assert_not_called()

--- a/tests/planner/test_planner.py
+++ b/tests/planner/test_planner.py
@@ -416,11 +416,6 @@ def test_expand_wps_raises_on_missing_id_and_suffix(tmp_path) -> None:
         expand_wps(str(refined), str(tmp_path))
 
 
-def test_write_json_helper_in_conftest() -> None:
-    from tests.planner.conftest import write_json
-
-    assert callable(write_json)
-
 
 def test_merge_files_does_not_use_atomic_write(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/planner/test_planner.py
+++ b/tests/planner/test_planner.py
@@ -416,7 +416,6 @@ def test_expand_wps_raises_on_missing_id_and_suffix(tmp_path) -> None:
         expand_wps(str(refined), str(tmp_path))
 
 
-
 def test_merge_files_does_not_use_atomic_write(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/planner/test_schema_conformance.py
+++ b/tests/planner/test_schema_conformance.py
@@ -12,13 +12,9 @@ from pathlib import Path
 import pytest
 
 from autoskillit.planner.validation import _load_assignment_results, _load_phase_results
+from tests.planner.conftest import write_json
 
 pytestmark = [pytest.mark.layer("planner"), pytest.mark.small, pytest.mark.feature("planner")]
-
-
-def _write_json(path: Path, data: object) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(data))
 
 
 # ---------------------------------------------------------------------------
@@ -29,7 +25,7 @@ def _write_json(path: Path, data: object) -> None:
 def test_skill_compliant_phase_data_accepted_and_normalized(tmp_path: Path) -> None:
     phases_dir = tmp_path / "phases"
     phases_dir.mkdir()
-    _write_json(
+    write_json(
         phases_dir / "P1_result.json",
         {
             "id": "P1",
@@ -61,7 +57,7 @@ def test_skill_compliant_phase_data_accepted_and_normalized(tmp_path: Path) -> N
 def test_skill_compliant_assignment_data_accepted_and_normalized(tmp_path: Path) -> None:
     assign_dir = tmp_path / "assignments"
     assign_dir.mkdir()
-    _write_json(
+    write_json(
         assign_dir / "P1-A2_result.json",
         {
             "id": "P1-A2",
@@ -88,7 +84,7 @@ def test_skill_compliant_assignment_data_accepted_and_normalized(tmp_path: Path)
 def test_expand_assignments_with_skill_md_field_names(tmp_path: Path) -> None:
     from autoskillit.planner import expand_assignments
 
-    _write_json(
+    write_json(
         tmp_path / "refined_plan.json",
         {
             "phases": [
@@ -127,7 +123,7 @@ def test_expand_assignments_with_skill_md_field_names(tmp_path: Path) -> None:
 def test_compile_plan_derives_name_slug_from_name(tmp_path: Path) -> None:
     from autoskillit.planner.compiler import compile_plan
 
-    _write_json(
+    write_json(
         tmp_path / "phases" / "P1_result.json",
         {
             "id": "P1",
@@ -139,7 +135,7 @@ def test_compile_plan_derives_name_slug_from_name(tmp_path: Path) -> None:
             "assignments_preview": [],
         },
     )
-    _write_json(
+    write_json(
         tmp_path / "assignments" / "P1-A1_result.json",
         {
             "id": "P1-A1",
@@ -150,7 +146,7 @@ def test_compile_plan_derives_name_slug_from_name(tmp_path: Path) -> None:
             "proposed_work_packages": [],
         },
     )
-    _write_json(
+    write_json(
         tmp_path / "work_packages" / "P1-A1-WP1_result.json",
         {
             "id": "P1-A1-WP1",
@@ -162,11 +158,11 @@ def test_compile_plan_derives_name_slug_from_name(tmp_path: Path) -> None:
             "depends_on": [],
         },
     )
-    _write_json(
+    write_json(
         tmp_path / "work_packages" / "wp_manifest.json",
         {"pass_name": "work_packages", "items": [{"id": "P1-A1-WP1", "status": "done"}]},
     )
-    _write_json(
+    write_json(
         tmp_path / "validation.json",
         {"verdict": "pass", "findings": [], "warnings": [], "schema_version": 2},
     )
@@ -192,7 +188,7 @@ def test_skill_output_through_full_pipeline(tmp_path: Path) -> None:
         validate_plan,
     )
 
-    _write_json(
+    write_json(
         tmp_path / "phases" / "P1_result.json",
         {
             "id": "P1",
@@ -205,7 +201,7 @@ def test_skill_output_through_full_pipeline(tmp_path: Path) -> None:
         },
     )
 
-    _write_json(
+    write_json(
         tmp_path / "refined_plan.json",
         {
             "phases": [
@@ -224,7 +220,7 @@ def test_skill_output_through_full_pipeline(tmp_path: Path) -> None:
 
     expand_assignments(str(tmp_path / "refined_plan.json"), str(tmp_path))
 
-    _write_json(
+    write_json(
         tmp_path / "assignments" / "P1-A1_result.json",
         {
             "id": "P1-A1",
@@ -242,7 +238,7 @@ def test_skill_output_through_full_pipeline(tmp_path: Path) -> None:
             ],
         },
     )
-    _write_json(
+    write_json(
         tmp_path / "assignments" / "P1-A2_result.json",
         {
             "id": "P1-A2",
@@ -261,7 +257,7 @@ def test_skill_output_through_full_pipeline(tmp_path: Path) -> None:
         },
     )
 
-    _write_json(
+    write_json(
         tmp_path / "refined_assignments.json",
         {
             "assignments": [
@@ -292,7 +288,7 @@ def test_skill_output_through_full_pipeline(tmp_path: Path) -> None:
     expand_wps(str(tmp_path / "refined_assignments.json"), str(tmp_path))
 
     for wp_id in ["P1-A1-WP1", "P1-A2-WP1"]:
-        _write_json(
+        write_json(
             tmp_path / "work_packages" / f"{wp_id}_result.json",
             {
                 "id": wp_id,

--- a/tests/planner/test_validation.py
+++ b/tests/planner/test_validation.py
@@ -8,7 +8,12 @@ from pathlib import Path
 import pytest
 
 from autoskillit.planner.validation import validate_plan
-from tests.planner.conftest import make_assignment_result, make_phase_result, make_wp_result
+from tests.planner.conftest import (
+    make_assignment_result,
+    make_phase_result,
+    make_wp_result,
+    write_json,
+)
 
 pytestmark = [pytest.mark.layer("planner"), pytest.mark.small, pytest.mark.feature("planner")]
 
@@ -16,11 +21,6 @@ pytestmark = [pytest.mark.layer("planner"), pytest.mark.small, pytest.mark.featu
 # ---------------------------------------------------------------------------
 # Fixture helpers
 # ---------------------------------------------------------------------------
-
-
-def _write_json(path: Path, data: object) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(data))
 
 
 def _make_minimal_output_dir(
@@ -39,14 +39,14 @@ def _make_minimal_output_dir(
     wps_dir = tmp_path / "work_packages"
 
     for p in range(1, num_phases + 1):
-        _write_json(
+        write_json(
             phases_dir / f"P{p}_result.json",
             make_phase_result(p, name=f"Phase {p}"),
         )
 
     for p in range(1, num_phases + 1):
         for a in range(1, 2):
-            _write_json(
+            write_json(
                 assigns_dir / f"P{p}-A{a}_result.json",
                 make_assignment_result(
                     p,
@@ -68,7 +68,7 @@ def _make_minimal_output_dir(
                     else [f"src/mod_{wp_id}.py"]
                 )
                 deps = (depends_on_override or {}).get(wp_id, [])
-                _write_json(
+                write_json(
                     wps_dir / f"{wp_id}_result.json",
                     make_wp_result(wp_id, deliverables=deliverables, depends_on=deps),
                 )
@@ -78,21 +78,21 @@ def _make_minimal_output_dir(
         for a in range(1, 2):
             for w in range(1, wps_per_assignment + 1):
                 manifest_items.append({"id": f"P{p}-A{a}-WP{w}", "status": "done"})
-    _write_json(
+    write_json(
         wps_dir / "wp_manifest.json",
         {"pass_name": "work_packages", "items": manifest_items},
     )
 
     if extra_phases:
         for p in extra_phases:
-            _write_json(
+            write_json(
                 phases_dir / f"P{p}_result.json",
                 make_phase_result(p, name=f"Phase {p}"),
             )
 
     if extra_assignments:
         for p, a in extra_assignments:
-            _write_json(
+            write_json(
                 assigns_dir / f"P{p}-A{a}_result.json",
                 make_assignment_result(p, a, name=f"Orphan assignment P{p}-A{a}"),
             )
@@ -181,7 +181,7 @@ def test_validate_plan_failed_wp_flagged_but_not_sole_fail_cause(tmp_path: Path)
 
 def test_validate_plan_dep_graph_backward_dep_injection(tmp_path: Path) -> None:
     _make_minimal_output_dir(tmp_path, wps_per_assignment=2)
-    _write_json(
+    write_json(
         tmp_path / "dep_graph.json",
         {"added_backward_deps": {"P1-A1-WP2": ["P1-A1-WP1"]}, "forward_deps": {}},
     )
@@ -193,7 +193,7 @@ def test_validate_plan_dep_graph_creates_cycle_fails(tmp_path: Path) -> None:
     _make_minimal_output_dir(
         tmp_path, wps_per_assignment=2, depends_on_override={"P1-A1-WP1": ["P1-A1-WP2"]}
     )
-    _write_json(
+    write_json(
         tmp_path / "dep_graph.json",
         {"added_backward_deps": {"P1-A1-WP2": ["P1-A1-WP1"]}, "forward_deps": {}},
     )


### PR DESCRIPTION
## Summary

Five targeted fixes to the planner module addressing a data integrity documentation gap, a file-lock correctness issue, dead code, and test helper duplication:

1. **REQ-DESYNC-001 + REQ-DESYNC-002**: Document that `combined_*.json` and `refined_*.json` are intermediate orchestration artifacts, not authoritative sources. `validate_plan` and `compile_plan` already read from individual `*_result.json` files — codify this as an invariant via module docstrings and a SKILL.md update.
2. **REQ-LOCK-001**: Fix `merge_files` and `replace_item` in `merge.py` to write directly under the `fcntl.flock` instead of delegating to `write_versioned_json` (which does `atomic_write` → `os.replace`, effectively escaping the lock's inode scope).
3. **REQ-DEAD-001**: Remove `build_pre_elab_snapshot` from `manifests.py` and `__init__.py` — it is never called by any recipe, skill, or production code.
4. **REQ-DRY-001**: Move the duplicated `_write_json` helper to `tests/planner/conftest.py` and update the four consumer test files.

## Requirements

### REQ-DESYNC-001: Document or enforce artifact update policy in planner-refine
The `planner-refine` SKILL.md (Step 4: Write corrected artifacts) lists `_result.json` files, `wp_manifest.json`, `wp_index.json`, and `dep_graph.json` as modified files. It does not mention `refined_wps.json`. Either:
- (a) Add `refined_wps.json` to the list of artifacts the refine skill must regenerate after structural changes, or
- (b) Ensure `validate_plan` and `compile_plan` never read from combined documents (they currently read from individual result files, which is correct — document this as an invariant)

### REQ-DESYNC-002: Add an invariant comment or assertion in validation/compiler
`validate_plan` and `compile_plan` both load from individual `*_result.json` files via `_load_*_results()`. This is the correct source of truth. Add a brief docstring or module-level note documenting that combined documents (`combined_*.json`, `refined_*.json`) are intermediate orchestration artifacts, not authoritative sources.

### REQ-LOCK-001: Fix merge_files file lock not covering the atomic write
`merge.py:merge_files` acquires `LOCK_EX` on the output file and reads existing content under the lock, but then calls `write_versioned_json` which does an atomic `os.replace` via a *separate* file handle — outside the lock's effective scope. Either:
- (a) Write directly under the lock instead of delegating to `write_versioned_json`, or
- (b) Accept the current behavior (sequential recipe flow means no actual concurrency) and add a comment documenting the limitation

### REQ-DEAD-001: Remove or test `build_pre_elab_snapshot`
`manifests.py:build_pre_elab_snapshot` is exported in `__init__.py` but never called by the planner recipe and has zero test coverage. Either remove it or add test coverage.

### REQ-DRY-001: Deduplicate `_write_json` test helper
The identical `_write_json(path, data)` helper is copy-pasted in `test_validation.py:22`, `test_compiler.py:22`, `test_schema_conformance.py:20`, and `test_pipeline_integration.py:18`. Move it to `tests/planner/conftest.py` alongside the existing factory functions and update all four files.

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;

    START([START])
    COMPLETE([COMPLETE])
    ERROR([ERROR])

    subgraph Init ["Initialization"]
        direction TB
        CR["● create_run_dir<br/>━━━━━━━━━━<br/>manifests.py — Bootstrap<br/>phases/ assignments/ work_packages/"]
    end

    subgraph AssignExpand ["Assignment Expansion"]
        direction TB
        EA["● expand_assignments<br/>━━━━━━━━━━<br/>manifests.py — Read refined_plan.json<br/>writes context + manifest (pending)"]
        EA_VAL{"● validate_refined_plan<br/>━━━━━━━━━━<br/>Schema gate?"}
        EA_LLM["LLM Elaboration<br/>━━━━━━━━━━<br/>Per-context → *_result.json"]
    end

    subgraph MergeAssembly ["Merge & Assembly"]
        direction TB
        MF["● merge_files / merge_tier_dir<br/>━━━━━━━━━━<br/>merge.py — flock LOCK_EX<br/>dedup by ID → combined_*.json"]
        MF_MODE{"● strict mode?<br/>━━━━━━━━━━<br/>strict=True: raise<br/>strict=False: accumulate"}
        RI["● replace_item<br/>━━━━━━━━━━<br/>merge.py — Targeted write-back<br/>after refinement cycle"]
    end

    subgraph WPExpand ["WP Expansion"]
        direction TB
        EW["● expand_wps<br/>━━━━━━━━━━<br/>manifests.py — Read refined assignments<br/>writes WP context + manifest (pending)"]
        EW_VAL{"● validate_refined_assignments<br/>━━━━━━━━━━<br/>Schema gate?"}
        EW_LLM["LLM Elaboration<br/>━━━━━━━━━━<br/>Per-phase → WP *_result.json"]
    end

    subgraph Finalize ["WP Finalization"]
        direction TB
        FWP["● finalize_wp_manifest<br/>━━━━━━━━━━<br/>manifests.py — Glob *_result.json<br/>status: pending → done<br/>writes wp_manifest + wp_index"]
    end

    subgraph Validation ["Validation Gate"]
        direction TB
        VP["● validate_plan<br/>━━━━━━━━━━<br/>validation.py — 8 structural checks<br/>writes validation.json"]
        VP_CHECKS["● Checks Pipeline<br/>━━━━━━━━━━<br/>phase completeness │ assignment completeness<br/>dep references │ DAG acyclic<br/>sizing bounds │ dup deliverables<br/>dup files_touched │ failed WPs"]
        VP_VERDICT{"● Verdict<br/>━━━━━━━━━━<br/>errors exist?"}
    end

    subgraph Refine ["Refinement Loop (planner-refine)"]
        direction TB
        RF_CLASS["● Classify Findings<br/>━━━━━━━━━━<br/>SKILL.md — Regex-match<br/>8 finding categories"]
        RF_DECIDE{"● Addressable?<br/>━━━━━━━━━━<br/>fix vs. escalate"}
        RF_FIX["● Apply Fixes<br/>━━━━━━━━━━<br/>failed_wps → re-elaborate<br/>sizing → split/merge<br/>dup deliverables → reassign<br/>dep refs → replace/remove"]
        RF_ESC["● Escalate CRITICAL<br/>━━━━━━━━━━<br/>missing / malformed_id<br/>dag_cycle → human review"]
    end

    subgraph Compile ["Compilation"]
        direction TB
        CP_SORT["● _topological_sort<br/>━━━━━━━━━━<br/>compiler.py — Kahn's algorithm<br/>deterministic stable sort"]
        CP_GEN["● compile_plan<br/>━━━━━━━━━━<br/>compiler.py — Generate issues/<br/>plan.json │ plan.md │ manifest.json<br/>milestones.json"]
        CP_CYCLE{"● Cycle detected?<br/>━━━━━━━━━━<br/>RuntimeError"}
    end

    %% FLOW %%
    START --> CR
    CR -->|"reads temp_dir"| EA

    EA --> EA_VAL
    EA_VAL -->|"valid"| EA_LLM
    EA_VAL -->|"invalid schema"| ERROR

    EA_LLM -->|"writes *_result.json"| MF
    MF --> MF_MODE
    MF_MODE -->|"strict: raise on error"| ERROR
    MF_MODE -->|"success / non-strict"| RI
    RI -->|"reads refined combined doc"| EW

    EW --> EW_VAL
    EW_VAL -->|"valid"| EW_LLM
    EW_VAL -->|"invalid schema"| ERROR

    EW_LLM -->|"writes WP *_result.json"| FWP

    FWP -->|"reads wp_manifest"| VP
    VP --> VP_CHECKS
    VP_CHECKS --> VP_VERDICT

    VP_VERDICT -->|"verdict: pass"| CP_SORT
    VP_VERDICT -->|"verdict: fail"| RF_CLASS

    RF_CLASS --> RF_DECIDE
    RF_DECIDE -->|"failed_wps / sizing /<br/>dup deliverables / dep refs"| RF_FIX
    RF_DECIDE -->|"missing / malformed_id /<br/>dag_cycle"| RF_ESC

    RF_FIX -->|"writes corrected artifacts"| VP
    RF_ESC -->|"retries < 3"| VP
    RF_ESC -->|"retries exhausted"| ERROR

    CP_SORT --> CP_CYCLE
    CP_CYCLE -->|"no cycle"| CP_GEN
    CP_CYCLE -->|"cycle found"| ERROR

    CP_GEN -->|"writes plan.json, plan.md,<br/>issues/, manifest.json"| COMPLETE

    %% CLASS ASSIGNMENTS %%
    class START,COMPLETE,ERROR terminal;
    class CR,EA,EW,FWP handler;
    class EA_VAL,EW_VAL,MF_MODE,VP_VERDICT,RF_DECIDE,CP_CYCLE stateNode;
    class MF,RI,EA_LLM,EW_LLM phase;
    class VP,VP_CHECKS detector;
    class RF_CLASS,RF_FIX,RF_ESC detector;
    class CP_SORT,CP_GEN output;
```

### Data Lineage Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart LR
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    subgraph Origins ["Data Origins"]
        direction TB
        TASK["task + source_dir<br/>━━━━━━━━━━<br/>CLI / recipe strings"]
        LLM_RESULTS["LLM Sub-Agent Output<br/>━━━━━━━━━━<br/>phases/*_result.json<br/>assignments/*_result.json<br/>work_packages/*_result.json"]
        REFINED["LLM Refine Output<br/>━━━━━━━━━━<br/>refined_plan.json<br/>refined_assignments.json"]
        DEP_GRAPH["dep_graph.json<br/>━━━━━━━━━━<br/>Optional cross-WP deps"]
    end

    subgraph Expansion ["● Manifest Expansion (manifests.py)"]
        direction TB
        EXPAND_A["● expand_assignments<br/>━━━━━━━━━━<br/>Phase → assignment buckets<br/>Writes context_PX.json"]
        EXPAND_WP["● expand_wps<br/>━━━━━━━━━━<br/>Assignment → WP buckets<br/>Inits wp_index.json"]
        FINALIZE["● finalize_wp_manifest<br/>━━━━━━━━━━<br/>Mark items done<br/>Write wp_index summary"]
    end

    subgraph Merging ["● Merge Layer (merge.py)"]
        direction TB
        MERGE_FILES["● merge_files / merge_tier_dir<br/>━━━━━━━━━━<br/>Dedup by id, flock write<br/>→ combined_*.json"]
        SNAPSHOT["● build_plan_snapshot<br/>━━━━━━━━━━<br/>Compact PhaseShort list"]
        REPLACE["● replace_item / extract_item<br/>━━━━━━━━━━<br/>Surgical in-place update<br/>flock-protected"]
    end

    subgraph Validation ["● Validation (validation.py)"]
        direction TB
        VALIDATE["● validate_plan<br/>━━━━━━━━━━<br/>DAG acyclicity (Kahn's)<br/>Sizing bounds, completeness<br/>Duplicate detection"]
    end

    subgraph Compilation ["● Compilation (compiler.py)"]
        direction TB
        COMPILE["● compile_plan<br/>━━━━━━━━━━<br/>Topological sort<br/>Forward dep injection<br/>Issue body rendering"]
    end

    subgraph Repair ["● Repair Loop (planner-refine)"]
        direction TB
        REFINE["● planner-refine skill<br/>━━━━━━━━━━<br/>Reads validation findings<br/>Corrects *_result.json<br/>Updates wp_manifest"]
    end

    subgraph PrimaryStorage ["Primary Storage (Source of Truth)"]
        direction TB
        MANIFESTS[("Manifests<br/>━━━━━━━━━━<br/>phase_assignment_manifest.json<br/>phase_wp_manifest.json<br/>wp_manifest.json")]
        WP_INDEX[("wp_index.json<br/>━━━━━━━━━━<br/>WP id/name/summary")]
        COMBINED[("combined_*.json<br/>━━━━━━━━━━<br/>Tier-merged documents")]
        PLAN_JSON[("plan.json<br/>━━━━━━━━━━<br/>Full nested plan")]
        MILESTONES[("milestones.json<br/>━━━━━━━━━━<br/>Phase milestone defs")]
        MANIFEST_JSON[("manifest.json<br/>━━━━━━━━━━<br/>Execution order + paths")]
        VALIDATION_JSON[("validation.json<br/>━━━━━━━━━━<br/>Verdict + findings")]
        CONTEXT[("context_PX.json<br/>━━━━━━━━━━<br/>Per-phase LLM context")]
    end

    subgraph Artifacts ["Write-Only Artifacts"]
        direction TB
        ISSUES["issues/*_issue.md<br/>━━━━━━━━━━<br/>GitHub issue bodies"]
        PLAN_MD["plan.md<br/>━━━━━━━━━━<br/>Human-readable summary"]
    end

    %% === FLOWS === %%

    REFINED -->|"phases list"| EXPAND_A
    REFINED -->|"assignments list"| EXPAND_WP
    LLM_RESULTS -->|"WP results"| FINALIZE

    EXPAND_A -->|"write versioned"| MANIFESTS
    EXPAND_A -->|"write"| CONTEXT
    EXPAND_WP -->|"write versioned"| MANIFESTS
    EXPAND_WP -->|"init"| WP_INDEX
    FINALIZE -->|"write versioned"| MANIFESTS
    FINALIZE -->|"atomic_write"| WP_INDEX

    LLM_RESULTS -->|"*_result.json"| MERGE_FILES
    TASK -->|"task, source_dir"| MERGE_FILES
    MERGE_FILES -->|"flock + write"| COMBINED
    LLM_RESULTS -->|"phases/*"| SNAPSHOT
    TASK -->|"task, source_dir"| SNAPSHOT
    SNAPSHOT -->|"write versioned"| COMBINED
    COMBINED -->|"read-modify-write"| REPLACE

    LLM_RESULTS -->|"all tiers"| VALIDATE
    DEP_GRAPH -->|"optional deps"| VALIDATE
    MANIFESTS -.->|"read wp_manifest"| VALIDATE
    VALIDATE -->|"write"| VALIDATION_JSON

    LLM_RESULTS -->|"all tiers"| COMPILE
    DEP_GRAPH -->|"optional deps"| COMPILE
    TASK -->|"task, source_dir"| COMPILE
    COMPILE -->|"write versioned"| PLAN_JSON
    COMPILE -->|"write versioned"| MILESTONES
    COMPILE -->|"write versioned"| MANIFEST_JSON
    COMPILE -.->|"write-only"| ISSUES
    COMPILE -.->|"write-only"| PLAN_MD

    VALIDATION_JSON -->|"findings"| REFINE
    REFINE -->|"correct in-place"| LLM_RESULTS
    REFINE -->|"update"| MANIFESTS
    REFINE -->|"update"| WP_INDEX

    %% === CLASS ASSIGNMENTS === %%
    class TASK,LLM_RESULTS,REFINED,DEP_GRAPH cli;
    class EXPAND_A,EXPAND_WP,FINALIZE handler;
    class MERGE_FILES,SNAPSHOT,REPLACE handler;
    class VALIDATE detector;
    class COMPILE phase;
    class REFINE integration;
    class MANIFESTS,WP_INDEX,COMBINED,PLAN_JSON,MILESTONES,MANIFEST_JSON,VALIDATION_JSON,CONTEXT stateNode;
    class ISSUES,PLAN_MD output;
```

Closes #1512

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260429-013040-101887/.autoskillit/temp/make-plan/fix_planner_artifact_desync_plan_2026-04-29_013400.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 2.1k | 12.1k | 691.5k | 65.9k | 1 | 6m 32s |
| verify | 31 | 6.4k | 604.5k | 49.4k | 1 | 3m 21s |
| implement | 535 | 12.4k | 1.4M | 66.5k | 1 | 5m 47s |
| prepare_pr | 23 | 3.9k | 138.7k | 26.4k | 1 | 1m 29s |
| run_arch_lenses | 1.4k | 10.7k | 485.0k | 62.2k | 2 | 6m 43s |
| compose_pr | 22 | 6.7k | 147.9k | 31.5k | 1 | 1m 52s |
| review_pr | 1.2k | 45.8k | 1.4M | 196.2k | 2 | 13m 33s |
| resolve_review | 1.6k | 13.7k | 1.4M | 66.8k | 1 | 8m 27s |
| **Total** | 6.9k | 111.9k | 6.3M | 564.9k | | 47m 46s |