### PR TITLE
fix: thread inputs.task through planner pipeline to fix task-blindness

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 AutoSkillit is a Claude Code plugin that runs YAML recipes through a two-tier
 orchestrator. Bundled recipes turn GitHub issues into merged PRs by chaining
 plan, dry-walkthrough, worktree, test, and PR-review skills against 48 MCP
-tools and 126 bundled skills.
+tools and 127 bundled skills.
 
 https://github.com/user-attachments/assets/bcd910c8-7269-46d6-a496-53b2cb24d212
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 AutoSkillit is a Claude Code plugin that runs YAML recipes through a
 two-tier orchestrator. The bundled recipes implement issue → plan → worktree
-→ tests → PR → merge pipelines using 48 MCP tools and 126 bundled skills.
+→ tests → PR → merge pipelines using 48 MCP tools and 127 bundled skills.
 
 ## Start here
 

--- a/docs/developer/end-turn-hazards.md
+++ b/docs/developer/end-turn-hazards.md
@@ -190,7 +190,7 @@ two detectors on every SKILL.md in the project:
 | `_check_loop_boundary()` | "For each" loops with tool invocations but no anti-prose guard |
 
 These run as part of `test_no_text_then_tool_in_any_step`, a parametrized
-test that scans all 126 bundled skills. Any new skill with an unguarded
+test that scans all 127 bundled skills. Any new skill with an unguarded
 loop fails CI automatically.
 
 ## If This Gets Fixed Upstream

--- a/docs/execution/architecture.md
+++ b/docs/execution/architecture.md
@@ -4,7 +4,7 @@ How AutoSkillit runs a recipe end to end: orchestrator, kitchen gating, clone an
 
 ## Overview
 
-AutoSkillit is a Claude Code plugin that orchestrates automated workflows using headless sessions. It provides 48 MCP tools and 126 bundled skills, organized into a gated visibility system.
+AutoSkillit is a Claude Code plugin that orchestrates automated workflows using headless sessions. It provides 48 MCP tools and 127 bundled skills, organized into a gated visibility system.
 
 ## Core Concepts
 

--- a/docs/skills/catalog.md
+++ b/docs/skills/catalog.md
@@ -1,7 +1,7 @@
 # Skill catalog
 
-The complete list of bundled skills (126 total: 3 in `src/autoskillit/skills/`,
-123 in `src/autoskillit/skills_extended/`). Filesystem walk this directory if
+The complete list of bundled skills (127 total: 3 in `src/autoskillit/skills/`,
+124 in `src/autoskillit/skills_extended/`). Filesystem walk this directory if
 you need an exhaustive listing; this catalog groups by purpose.
 
 ## Tier 1 — free range (3)
@@ -119,15 +119,15 @@ figure set:
 | 11 | `vis-lens-story-arc` | Narrative | Do the figures tell a coherent story across the report? | P2 |
 | 12 | `vis-lens-reproducibility` | Replicative | Can the figures be reproduced from the data and code? | P2 |
 
-## Planner family (11)
+## Planner family (12)
 
-11 progressive-decomposition sub-skills under `skills_extended/planner-*/`. Invoked
+12 progressive-decomposition sub-skills under `skills_extended/planner-*/`. Invoked
 internally by the `planner` recipe to break a roadmap into GitHub milestones and issues:
 
 `planner-analyze`, `planner-elaborate-assignments`, `planner-elaborate-phase`,
 `planner-elaborate-wps`, `planner-extract-domain`, `planner-generate-phases`,
 `planner-reconcile-deps`, `planner-refine`, `planner-refine-assignments`,
-`planner-refine-phases`, `planner-refine-wps`
+`planner-refine-phases`, `planner-refine-wps`, `planner-validate-task-alignment`
 
 ## Rectify doctrine
 

--- a/docs/skills/visibility.md
+++ b/docs/skills/visibility.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-AutoSkillit's 126 bundled skills are organized into three tiers that control when and where
+AutoSkillit's 127 bundled skills are organized into three tiers that control when and where
 they appear as slash commands. The tier system is orthogonal to subset categories — you can
 disable a subset across all tiers simultaneously, or reclassify individual skills between
 tiers. See [Subset Categories](subsets.md) for subset configuration.

--- a/docs/skills/visibility.md
+++ b/docs/skills/visibility.md
@@ -22,12 +22,12 @@ tiers. See [Subset Categories](subsets.md) for subset configuration.
 ### Tier 2 — Cook (Interactive Skills)
 
 - **Location**: `src/autoskillit/skills_extended/` (NOT plugin-scanned)
-- **Default members** (99 total):
+- **Default members** (100 total):
   `investigate`, `make-plan`, `implement-worktree`, `rectify`,
   `dry-walkthrough`, `make-groups`, `review-approach`, `mermaid`, `make-arch-diag`,
   `make-experiment-diag`, `build-execution-map`, `plan-visualization`,
   all 13 `arch-lens-*` skills, all 18 `exp-lens-*` skills, all 12 `vis-lens-*` skills,
-  all 11 `planner-*` skills,
+  all 12 `planner-*` skills,
   `audit-arch`, `audit-cohesion`, `audit-tests`,
   `audit-defense-standards`, `audit-bugs`, `audit-friction`, `validate-audit`,
   `audit-claims`, `audit-docs`, `audit-feature-gates`,

--- a/src/autoskillit/config/defaults.yaml
+++ b/src/autoskillit/config/defaults.yaml
@@ -232,6 +232,7 @@ skills:
     - planner-refine-assignments
     - planner-refine-phases
     - planner-refine-wps
+    - planner-validate-task-alignment
     - reload-session
   tier3:
     - prepare-pr

--- a/src/autoskillit/planner/manifests.py
+++ b/src/autoskillit/planner/manifests.py
@@ -256,6 +256,7 @@ def expand_assignments(
         ) from exc
     plan = validate_refined_plan(plan)
     phases = plan.get("phases", [])
+    task = plan.get("task", "")
     assign_dir = Path(output_dir) / "assignments"
     assign_dir.mkdir(parents=True, exist_ok=True)
 
@@ -294,6 +295,7 @@ def expand_assignments(
         context: dict[str, object] = {
             "id": phase_id,
             "name": phase.get("name", ""),
+            "task": task,
             "metadata": metadata,
             "prior_results": [],
         }
@@ -327,6 +329,7 @@ def expand_wps(refined_assignments_path: str, output_dir: str, **kwargs: object)
         ) from exc
     data = validate_refined_assignments(data)
     assignments = data.get("assignments", [])
+    task = data.get("task", "")
     out_dir = Path(output_dir)
     wp_dir = out_dir / "work_packages"
     wp_dir.mkdir(parents=True, exist_ok=True)
@@ -384,6 +387,7 @@ def expand_wps(refined_assignments_path: str, output_dir: str, **kwargs: object)
         context: dict[str, object] = {
             "id": phase_id,
             "name": bucket["name"],
+            "task": task,
             "metadata": metadata,
             "prior_results": [],
             "wp_index_path": str(out_dir / "wp_index.json"),

--- a/src/autoskillit/recipe/_analysis_detectors.py
+++ b/src/autoskillit/recipe/_analysis_detectors.py
@@ -117,6 +117,7 @@ _OBSERVABILITY_CAPTURES: frozenset[tuple[str, str]] = frozenset(
         ("pr_url", "compose-pr"),
         ("html_path", "bundle-local-report"),
         ("resource_report", "stage-data"),
+        ("alignment_findings_path", "planner-validate-task-alignment"),
     }
 )
 

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -1914,6 +1914,28 @@ skills:
     pattern_examples:
       - "refined_wps_path = /tmp/autoskillit/planner/run-20260101-120000/refined_wps.json\n%%ORDER_UP%%"
     write_behavior: always
+  planner-validate-task-alignment:
+    inputs:
+      - name: refined_wps_path
+        type: file_path
+        required: true
+      - name: refined_plan_path
+        type: file_path
+        required: true
+      - name: output_dir
+        type: directory_path
+        required: true
+    outputs:
+      - name: alignment_findings_path
+        type: file_path
+      - name: alignment_finding_count
+        type: str
+    expected_output_patterns:
+      - "alignment_findings_path\\s*=\\s*\\S+"
+      - "alignment_finding_count\\s*=\\s*\\d+"
+    pattern_examples:
+      - "alignment_findings_path = /tmp/autoskillit/planner/run-20260101-120000/task_alignment.json\n%%ORDER_UP%%"
+    write_behavior: always
   audit-tests:
     inputs: []
     outputs:

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -1934,7 +1934,7 @@ skills:
       - "alignment_findings_path\\s*=\\s*\\S+"
       - "alignment_finding_count\\s*=\\s*\\d+"
     pattern_examples:
-      - "alignment_findings_path = /tmp/autoskillit/planner/run-20260101-120000/task_alignment.json\n%%ORDER_UP%%"
+      - "alignment_findings_path = /tmp/autoskillit/planner/run-20260101-120000/task_alignment.json\nalignment_finding_count = 0\n%%ORDER_UP%%"
     write_behavior: always
   audit-tests:
     inputs: []

--- a/src/autoskillit/recipes/contracts/planner.yaml
+++ b/src/autoskillit/recipes/contracts/planner.yaml
@@ -162,6 +162,33 @@ skills:
 
       %%ORDER_UP%%'
     write_behavior: always
+  planner-validate-task-alignment:
+    inputs:
+    - name: refined_wps_path
+      type: file_path
+      required: true
+      recommended: false
+    - name: refined_plan_path
+      type: file_path
+      required: true
+      recommended: false
+    - name: output_dir
+      type: directory_path
+      required: true
+      recommended: false
+    outputs:
+    - name: alignment_findings_path
+      type: file_path
+    - name: alignment_finding_count
+      type: str
+    expected_output_patterns:
+    - alignment_findings_path\s*=\s*\S+
+    - alignment_finding_count\s*=\s*\d+
+    pattern_examples:
+    - 'alignment_findings_path = /tmp/autoskillit/planner/run-20260101-120000/task_alignment.json
+
+      %%ORDER_UP%%'
+    write_behavior: always
   planner-reconcile-deps:
     inputs: []
     outputs: []
@@ -391,6 +418,17 @@ dataflow:
   - output_dir
   produced:
   - refined_wps_path
+- step: validate_task_alignment
+  available:
+  - combined_wps_path
+  - planner_dir
+  - refined_assignments_path
+  - refined_plan_path
+  - refined_wps_path
+  - source_dir
+  - task
+  required: []
+  produced: []
 - step: reconcile_deps
   available:
   - assignment_context_paths

--- a/src/autoskillit/recipes/contracts/planner.yaml
+++ b/src/autoskillit/recipes/contracts/planner.yaml
@@ -187,6 +187,8 @@ skills:
     pattern_examples:
     - 'alignment_findings_path = /tmp/autoskillit/planner/run-20260101-120000/task_alignment.json
 
+      alignment_finding_count = 0
+
       %%ORDER_UP%%'
     write_behavior: always
   planner-reconcile-deps:

--- a/src/autoskillit/recipes/planner.yaml
+++ b/src/autoskillit/recipes/planner.yaml
@@ -277,6 +277,9 @@ steps:
         ${{ context.refined_plan_path }}
         ${{ context.planner_dir }}
       cwd: "${{ inputs.source_dir }}"
+    capture:
+      alignment_findings_path: "${{ result.alignment_findings_path }}"
+      alignment_finding_count: "${{ result.alignment_finding_count }}"
     on_success: reconcile_deps
     on_failure: reconcile_deps
 

--- a/src/autoskillit/recipes/planner.yaml
+++ b/src/autoskillit/recipes/planner.yaml
@@ -66,6 +66,7 @@ steps:
       cwd: "${{ inputs.source_dir }}"
       env:
         PLANNER_ANALYSIS_FILE: "${{ context.planner_dir }}/analysis.json"
+        PLANNER_TASK: "${{ inputs.task }}"
     on_success: generate_phases
     on_failure: generate_phases
 
@@ -77,6 +78,8 @@ steps:
         ${{ context.planner_dir }}/analysis.json
         ${{ context.planner_dir }}/domain_knowledge.md
       cwd: "${{ inputs.source_dir }}"
+      env:
+        PLANNER_TASK: "${{ inputs.task }}"
     capture:
       phase_manifest_path: "${{ result.phase_manifest_path }}"
     on_success: build_plan_snapshot
@@ -262,8 +265,20 @@ steps:
       cwd: "${{ inputs.source_dir }}"
     capture:
       refined_wps_path: "${{ result.refined_wps_path }}"
-    on_success: reconcile_deps
+    on_success: validate_task_alignment
     on_failure: escalate_stop
+
+  validate_task_alignment:
+    tool: run_skill
+    with:
+      skill_command: >
+        /autoskillit:planner-validate-task-alignment
+        ${{ context.refined_wps_path }}
+        ${{ context.refined_plan_path }}
+        ${{ context.planner_dir }}
+      cwd: "${{ inputs.source_dir }}"
+    on_success: reconcile_deps
+    on_failure: reconcile_deps
 
   # --- FINALIZATION ---
 

--- a/src/autoskillit/recipes/planner.yaml
+++ b/src/autoskillit/recipes/planner.yaml
@@ -279,7 +279,6 @@ steps:
       cwd: "${{ inputs.source_dir }}"
     capture:
       alignment_findings_path: "${{ result.alignment_findings_path }}"
-      alignment_finding_count: "${{ result.alignment_finding_count }}"
     on_success: reconcile_deps
     on_failure: reconcile_deps
 

--- a/src/autoskillit/skills_extended/planner-elaborate-assignments/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-assignments/SKILL.md
@@ -30,7 +30,7 @@ is the sole writer for this phase's assignments — no concurrent write races.
 - Let an L0 failure abort the phase — always write a stub and continue
 - Write output outside `$2/assignments/`
 - Spawn L0s sequentially — always in parallel
-- Read `.autoskillit/temp/` artifacts outside your designated input files and output directory
+- Read `{{AUTOSKILLIT_TEMP}}` artifacts outside your designated input files and output directory
 - Explore parent directories of your input paths (e.g., `ls $(dirname $1)/..`)
 - Read result files from other phases
 

--- a/src/autoskillit/skills_extended/planner-elaborate-assignments/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-assignments/SKILL.md
@@ -30,6 +30,9 @@ is the sole writer for this phase's assignments — no concurrent write races.
 - Let an L0 failure abort the phase — always write a stub and continue
 - Write output outside `$2/assignments/`
 - Spawn L0s sequentially — always in parallel
+- Read `.autoskillit/temp/` artifacts outside your designated input files and output directory
+- Explore parent directories of your input paths (e.g., `ls $(dirname $1)/..`)
+- Read result files from other phases
 
 **ALWAYS:**
 - Spawn all L0 subagents in parallel using the native Agent/Task tool (NOT run_skill — leaf guard blocks it)
@@ -54,6 +57,10 @@ Read `$2/phases/{id}_result.json` (the elaborated phase result). Extract:
 - `scope` — phase-level scope list
 - `technical_approach` — overall technical approach for the phase
 - `assignments` — array of assignment objects with `name`, `goal`, `metadata`
+
+Read the `task` field from the context file at $1. Every assignment elaboration — its `goal`,
+`scope`, `deliverables`, and `work_packages_preview` — must serve the stated task. Do not
+elaborate into work not requested by the task.
 
 ### Step 3: Build per-L0 context packets
 

--- a/src/autoskillit/skills_extended/planner-elaborate-phase/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-phase/SKILL.md
@@ -37,7 +37,7 @@ independently and writes a single elaborated phase result. No dependency on
 - Read any `*_result.json` file from other phases (you have only the snapshot)
 - Require or read a context file from `check_remaining`
 - Communicate with other parallel worker instances
-- Read `.autoskillit/temp/` artifacts outside your designated input files and output directory
+- Read `{{AUTOSKILLIT_TEMP}}` artifacts outside your designated input files and output directory
 - Explore parent directories of your input paths (e.g., `ls $(dirname $1)/..`)
 
 **ALWAYS:**

--- a/src/autoskillit/skills_extended/planner-elaborate-phase/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-phase/SKILL.md
@@ -37,6 +37,8 @@ independently and writes a single elaborated phase result. No dependency on
 - Read any `*_result.json` file from other phases (you have only the snapshot)
 - Require or read a context file from `check_remaining`
 - Communicate with other parallel worker instances
+- Read `.autoskillit/temp/` artifacts outside your designated input files and output directory
+- Explore parent directories of your input paths (e.g., `ls $(dirname $1)/..`)
 
 **ALWAYS:**
 - Derive `relationship_notes` from snapshot context + codebase analysis, NOT from prior result files
@@ -64,6 +66,11 @@ Read the plan snapshot at `$1`. It is a `PlanDocument` with a `phases` list of `
 
 Find the entry in `phases` where `id == "$2"` (the target phase). Note its `ordering` to
 understand which phases come before and after it.
+
+After reading `plan_snapshot.json`, extract the `task` field. Every aspect of the elaborated
+phase — its `technical_approach`, `scope`, and `assignments[]` — must serve the stated task.
+Do not elaborate into work not requested by the task. Flag if the phase goal appears
+unrelated to the task.
 
 ### Step 2: Launch parallel codebase exploration subagents
 

--- a/src/autoskillit/skills_extended/planner-elaborate-wps/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-wps/SKILL.md
@@ -31,6 +31,9 @@ is the sole writer for this phase's WPs — no concurrent write races.
 - Write output outside `$2/work_packages/`
 - Spawn L0s sequentially — always in parallel
 - Spawn more than 6 L0s in one batch — if WP count exceeds 6, use sequential batches of 6
+- Read `.autoskillit/temp/` artifacts outside your designated input files and output directory
+- Explore parent directories of your input paths (e.g., `ls $(dirname $1)/..`)
+- Read result files from other phases
 
 **ALWAYS:**
 - Spawn all L0 subagents in parallel using the native Agent/Task tool (NOT run_skill — leaf guard blocks it)
@@ -61,6 +64,10 @@ Read all `$2/assignments/P{N}-A*_result.json` matching this phase to get assignm
 - `goal` — assignment goal
 - `technical_approach` — assignment technical approach
 - `proposed_work_packages` — the WP decomposition from the assignment pass
+
+Read the `task` field from the context file at $1. Every WP elaboration — its `deliverables`,
+`acceptance_criteria`, and `estimated_files` — must serve the stated task. Do not create WPs
+for work not requested by the task.
 
 ### Step 3: Build per-L0 context packets
 

--- a/src/autoskillit/skills_extended/planner-elaborate-wps/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-wps/SKILL.md
@@ -31,7 +31,7 @@ is the sole writer for this phase's WPs — no concurrent write races.
 - Write output outside `$2/work_packages/`
 - Spawn L0s sequentially — always in parallel
 - Spawn more than 6 L0s in one batch — if WP count exceeds 6, use sequential batches of 6
-- Read `.autoskillit/temp/` artifacts outside your designated input files and output directory
+- Read `{{AUTOSKILLIT_TEMP}}` artifacts outside your designated input files and output directory
 - Explore parent directories of your input paths (e.g., `ls $(dirname $1)/..`)
 - Read result files from other phases
 

--- a/src/autoskillit/skills_extended/planner-extract-domain/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-extract-domain/SKILL.md
@@ -23,6 +23,7 @@ Extract domain knowledge, naming conventions, and structural patterns specific t
 ## Arguments
 
 - **`PLANNER_ANALYSIS_FILE`** (env-var) — Absolute path to `analysis.json` produced by `planner-analyze`. Set by the recipe via the step's `env:` block.
+- **`PLANNER_TASK`** (env-var, optional) — The user's task description. When set, focus domain extraction on areas relevant to the stated task rather than performing a full-codebase survey.
 
 ## Critical Constraints
 
@@ -42,6 +43,10 @@ Extract domain knowledge, naming conventions, and structural patterns specific t
 Read the `analysis.json` file from the path in the PLANNER_ANALYSIS_FILE environment variable. Use its `language`, `framework`, `architecture_style`, and `key_patterns` fields to focus subagent queries.
 
 ### Step 2: Launch 3–5 parallel Explore subagents
+
+If `PLANNER_TASK` is set, include it in each subagent's prompt: "Focus exploration on
+domain vocabulary, abstractions, and integration points relevant to this task: {PLANNER_TASK}.
+Prioritize areas the task will touch over exhaustive full-codebase coverage."
 
 Spawn all concurrently with `model: "sonnet"`. Always spawn agents 1–3; spawn agents 4–5 only when the project has >20 modules or architecture_style is layered/hexagonal:
 

--- a/src/autoskillit/skills_extended/planner-generate-phases/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-generate-phases/SKILL.md
@@ -29,7 +29,7 @@ Pass 1 entry point. Read the analysis file (and optionally domain knowledge) and
 
 ### Environment Variables
 
-- **PLANNER_TASK** (required) — The user's task description. All phases MUST serve this task.
+- **PLANNER_TASK** (required) — The user's task description. Every phase MUST serve this task.
 
 ## Critical Constraints
 

--- a/src/autoskillit/skills_extended/planner-generate-phases/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-generate-phases/SKILL.md
@@ -52,7 +52,7 @@ Pass 1 entry point. Read the analysis file (and optionally domain knowledge) and
 ### Step 0: Read task description
 
 Read the task description from the `PLANNER_TASK` environment variable. This is the user's
-statement of what they want planned. All phases generated in Step 2 MUST serve this task.
+statement of what they want planned. Every generated phase MUST serve this task.
 Do not generate phases for work not described in the task. If the task asks for specific
 deliverables (e.g., "split research.yaml into 4 sub-recipes"), the phases should decompose
 that work — not decompose the codebase into architectural layers.

--- a/src/autoskillit/skills_extended/planner-generate-phases/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-generate-phases/SKILL.md
@@ -39,7 +39,7 @@ Pass 1 entry point. Read the analysis file (and optionally domain knowledge) and
 - Use freeform text instead of the required JSON schema
 - Read files outside `$(dirname $1)` or the project's git-tracked source tree
 - Explore parent directories of `$(dirname $1)` (e.g., `ls $(dirname $1)/..`)
-- Read `.autoskillit/temp/` artifacts from other planner runs or pipeline steps
+- Read `{{AUTOSKILLIT_TEMP}}` artifacts from other planner runs or pipeline steps
 
 **ALWAYS:**
 - Write `$(dirname $1)/phases/{phase_id}_result.json` for every phase

--- a/src/autoskillit/skills_extended/planner-generate-phases/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-generate-phases/SKILL.md
@@ -27,12 +27,19 @@ Pass 1 entry point. Read the analysis file (and optionally domain knowledge) and
 - **$1** — Absolute path to `analysis.json` produced by `planner-analyze`
 - **$2** — (optional) Absolute path to `domain_knowledge.md` produced by `planner-extract-domain`
 
+### Environment Variables
+
+- **PLANNER_TASK** (required) — The user's task description. All phases MUST serve this task.
+
 ## Critical Constraints
 
 **NEVER:**
 - Produce fewer than 3 or more than 6 phases
 - Write output outside `$(dirname $1)/phases/`
 - Use freeform text instead of the required JSON schema
+- Read files outside `$(dirname $1)` or the project's git-tracked source tree
+- Explore parent directories of `$(dirname $1)` (e.g., `ls $(dirname $1)/..`)
+- Read `.autoskillit/temp/` artifacts from other planner runs or pipeline steps
 
 **ALWAYS:**
 - Write `$(dirname $1)/phases/{phase_id}_result.json` for every phase
@@ -41,6 +48,14 @@ Pass 1 entry point. Read the analysis file (and optionally domain knowledge) and
 - Emit `phase_manifest_path`, `phase_count`, and `phase_ids` output tokens
 
 ## Workflow
+
+### Step 0: Read task description
+
+Read the task description from the `PLANNER_TASK` environment variable. This is the user's
+statement of what they want planned. All phases generated in Step 2 MUST serve this task.
+Do not generate phases for work not described in the task. If the task asks for specific
+deliverables (e.g., "split research.yaml into 4 sub-recipes"), the phases should decompose
+that work — not decompose the codebase into architectural layers.
 
 ### Step 1: Read inputs
 
@@ -54,7 +69,7 @@ Identify 3–6 high-level phases that partition the implementation work. Phases 
 - Coherent (each phase has a single, clear goal)
 - Ordered by dependency (foundational work first)
 - Non-overlapping in scope
-- Named to reflect architectural or domain boundaries (e.g., "Database Layer", "API Layer")
+- Named to reflect the task's work units, grounded in the codebase's architecture (e.g., if the task is "add user authentication", phases might be "Auth Data Model", "Auth API Endpoints", "Auth UI Integration")
 
 For each phase, generate:
 - `id`: Sequential `P{N}` identifier (P1, P2, ...)

--- a/src/autoskillit/skills_extended/planner-refine-assignments/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine-assignments/SKILL.md
@@ -42,7 +42,7 @@ cross-assignment WP ownership conflicts, applies field-level edits, and writes
 - Emit `refined_assignments_path` before writing `refined_assignments.json`
 - Skip emitting `refined_assignments_path` even if all L0s fail (write unchanged assignments, still emit)
 - Spawn more than 6 L0s in a single parallel batch
-- Read `.autoskillit/temp/` artifacts not passed as positional arguments
+- Read `{{AUTOSKILLIT_TEMP}}` artifacts not passed as positional arguments
 
 **ALWAYS:**
 - Validate each L0 response for `assignment_id`, `changes` (array), `dependency_corrections` (array), `wp_proposal_adjustments` (array)

--- a/src/autoskillit/skills_extended/planner-refine-assignments/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine-assignments/SKILL.md
@@ -42,6 +42,7 @@ cross-assignment WP ownership conflicts, applies field-level edits, and writes
 - Emit `refined_assignments_path` before writing `refined_assignments.json`
 - Skip emitting `refined_assignments_path` even if all L0s fail (write unchanged assignments, still emit)
 - Spawn more than 6 L0s in a single parallel batch
+- Read `.autoskillit/temp/` artifacts not passed as positional arguments
 
 **ALWAYS:**
 - Validate each L0 response for `assignment_id`, `changes` (array), `dependency_corrections` (array), `wp_proposal_adjustments` (array)
@@ -85,6 +86,10 @@ Input schema (PlanDocument with AssignmentElaborated assignments):
 ```
 
 ### Step 2: Build L0 context packets
+
+Read the `task` field from the combined assignments document. Each L0 subagent must verify
+that the assignment's goal, scope, and deliverables serve the stated task. Flag assignments
+that introduce work not requested by the task as scope creep.
 
 For each assignment, build a context packet containing:
 - The full serialized `combined_assignments.json` content (all peers visible)

--- a/src/autoskillit/skills_extended/planner-refine-phases/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine-phases/SKILL.md
@@ -38,7 +38,7 @@ conflicts, applies field-level edits to the plan, and writes `refined_plan.json`
 - Allow an L0 subagent to write files directly (L0s return structured text only)
 - Emit `refined_plan_path` before writing `refined_plan.json`
 - Skip emitting `refined_plan_path` even if all L0s fail (write unchanged plan, still emit)
-- Read `.autoskillit/temp/` artifacts not passed as positional arguments
+- Read `{{AUTOSKILLIT_TEMP}}` artifacts not passed as positional arguments
 
 **ALWAYS:**
 - Validate each L0 response for `phase_id`, `changes` (array), `conflicts` (array)

--- a/src/autoskillit/skills_extended/planner-refine-phases/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine-phases/SKILL.md
@@ -38,6 +38,7 @@ conflicts, applies field-level edits to the plan, and writes `refined_plan.json`
 - Allow an L0 subagent to write files directly (L0s return structured text only)
 - Emit `refined_plan_path` before writing `refined_plan.json`
 - Skip emitting `refined_plan_path` even if all L0s fail (write unchanged plan, still emit)
+- Read `.autoskillit/temp/` artifacts not passed as positional arguments
 
 **ALWAYS:**
 - Validate each L0 response for `phase_id`, `changes` (array), `conflicts` (array)
@@ -76,6 +77,10 @@ Input schema (PlanDocument with PhaseElaborated phases):
 ```
 
 ### Step 2: Spawn parallel L0 subagents
+
+Read the `task` field from the combined plan document. Each L0 subagent reviewing a phase
+must verify that the phase's goal and scope serve the stated task. Phases that appear to
+address codebase concerns not mentioned in the task should be flagged for scope creep.
 
 Spawn one L0 subagent per phase in parallel using the Agent/Task tool. Each L0 receives:
 - The full serialized `combined_plan.json` content (pasted inline or via file read)

--- a/src/autoskillit/skills_extended/planner-refine-wps/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine-wps/SKILL.md
@@ -44,6 +44,7 @@ suggestions, resolves conflicts, and writes `refined_wps.json`.
 - Skip emitting `refined_wps_path` even if all L0s fail (write unchanged WPs, still emit)
 - Spawn more than 6 L0s in a single parallel batch
 - Spawn one L0 per WP — L0s operate per PHASE
+- Read `.autoskillit/temp/` artifacts not passed as positional arguments
 
 **ALWAYS:**
 - Spawn one L0 per phase (NOT per WP) — each L0 reviews ALL WPs in its phase against the full WP set
@@ -97,6 +98,10 @@ Input schema (PlanDocument with WPElaborated work packages):
 ```
 
 ### Step 2: Group WPs by phase and build L0 context packets
+
+Read the `task` field from the combined WPs document. Each L0 subagent reviewing a phase's
+WPs must verify that every WP's deliverables and scope serve the stated task. Flag WPs
+whose deliverables address concerns not mentioned in the task as scope creep.
 
 Group WPs by `phase_id` (extracted from `id` prefix, e.g., `P1-A1-WP1` → `P1`).
 For each phase, build a context packet containing:

--- a/src/autoskillit/skills_extended/planner-refine-wps/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine-wps/SKILL.md
@@ -44,7 +44,7 @@ suggestions, resolves conflicts, and writes `refined_wps.json`.
 - Skip emitting `refined_wps_path` even if all L0s fail (write unchanged WPs, still emit)
 - Spawn more than 6 L0s in a single parallel batch
 - Spawn one L0 per WP — L0s operate per PHASE
-- Read `.autoskillit/temp/` artifacts not passed as positional arguments
+- Read `{{AUTOSKILLIT_TEMP}}` artifacts not passed as positional arguments
 
 **ALWAYS:**
 - Spawn one L0 per phase (NOT per WP) — each L0 reviews ALL WPs in its phase against the full WP set

--- a/src/autoskillit/skills_extended/planner-validate-task-alignment/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-validate-task-alignment/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: planner-validate-task-alignment
+categories: [planner]
+description: Validate that plan phases and WPs align with the stated task
+hooks:
+  PreToolUse:
+    - matcher: "*"
+      hooks:
+        - type: command
+          command: "echo '[SKILL: planner-validate-task-alignment] Validating task alignment...'"
+          once: true
+---
+
+# planner-validate-task-alignment
+
+Post-refinement catch-net. Compares the plan's phases, assignments, and WP descriptions
+against the original task description. Emits warning-severity findings for misalignment.
+This is a safety net — if upstream task injection works correctly, this step should produce
+zero findings.
+
+## Arguments
+
+- **$1** — Absolute path to `refined_wps.json` (PlanDocument with `task`, `work_packages[]`)
+- **$2** — Absolute path to `refined_plan.json` (PlanDocument with `task`, `phases[]`)
+- **$3** — Absolute path to output directory for findings
+
+## Critical Constraints
+
+**NEVER:**
+- Block the pipeline — all findings are `warning` severity
+- Write output outside `$3/`
+- Read files not passed as arguments
+- Modify input files
+
+**ALWAYS:**
+- Read the `task` field from $1 or $2
+- Compare every phase goal and every WP description against the task
+- Write `$3/task_alignment.json` with findings array
+- Emit `alignment_findings_path` and `alignment_finding_count` output tokens
+
+## Workflow
+
+### Step 1: Read inputs
+
+Read `refined_wps.json` from $1 and `refined_plan.json` from $2. Extract:
+- The `task` field (the user's original task description)
+- All phase `goal` and `scope` fields from $2
+- All WP `name`, `deliverables`, and `acceptance_criteria` fields from $1
+
+### Step 2: Spawn alignment-check subagents
+
+Spawn 1-2 subagents (model: "sonnet"):
+
+**Subagent A — Phase alignment:**
+Provide the task description and all phase goals/scopes. Ask: "For each phase, does its
+goal directly serve the stated task? Rate each phase as 'aligned', 'tangential', or
+'unrelated'. A phase is 'aligned' if the task explicitly or implicitly requires the work.
+A phase is 'tangential' if it supports the task but was not requested. A phase is 'unrelated'
+if the task does not mention or imply this work."
+
+**Subagent B — WP alignment:**
+Provide the task description and all WP names/deliverables. Ask: "For each WP, do its
+deliverables serve the stated task? Flag any WP whose deliverables address concerns not
+mentioned in the task."
+
+### Step 3: Collect and write findings
+
+Parse subagent responses. For each phase or WP rated 'tangential' or 'unrelated', emit
+a finding:
+
+```json
+{
+  "message": "Phase P2 ('Protocol Sharding') appears unrelated to the stated task",
+  "severity": "warning",
+  "check": "task_alignment",
+  "entity_id": "P2",
+  "rating": "unrelated"
+}
+```
+
+Write all findings to `$3/task_alignment.json`:
+```json
+{
+  "schema_version": 1,
+  "task": "<original task>",
+  "findings": [],
+  "summary": {
+    "aligned": 4,
+    "tangential": 1,
+    "unrelated": 0
+  }
+}
+```
+
+### Step 4: Emit output tokens
+
+```
+alignment_findings_path = <absolute path to $3/task_alignment.json>
+alignment_finding_count = <N>
+```

--- a/src/autoskillit/skills_extended/write-recipe/SKILL.md
+++ b/src/autoskillit/skills_extended/write-recipe/SKILL.md
@@ -251,7 +251,7 @@ exp-lens-randomization-blocking, exp-lens-reproducibility-artifacts, exp-lens-se
 exp-lens-severity-testing, exp-lens-unit-interference, exp-lens-validity-threats, exp-lens-variance-stability,
 implement-experiment, implement-worktree, implement-worktree-no-merge, investigate, issue-splitter, make-arch-diag,
 make-campaign, make-experiment-diag, make-groups, make-plan, make-req, merge-pr, mermaid, migrate-recipes, open-integration-pr,
-open-kitchen, pipeline-summary, plan-experiment, plan-visualization, planner-analyze, planner-elaborate-assignments, planner-elaborate-phase, planner-elaborate-wps, planner-extract-domain, planner-generate-phases, planner-reconcile-deps, planner-refine, planner-refine-assignments, planner-refine-phases, planner-refine-wps, prepare-issue, prepare-pr, prepare-research-pr, process-issues, promote-to-main, rectify, reload-session, report-bug,
+open-kitchen, pipeline-summary, plan-experiment, plan-visualization, planner-analyze, planner-elaborate-assignments, planner-elaborate-phase, planner-elaborate-wps, planner-extract-domain, planner-generate-phases, planner-reconcile-deps, planner-refine, planner-refine-assignments, planner-refine-phases, planner-refine-wps, planner-validate-task-alignment, prepare-issue, prepare-pr, prepare-research-pr, process-issues, promote-to-main, rectify, reload-session, report-bug,
 resolve-claims-review, resolve-design-review, resolve-failures, resolve-merge-conflicts, resolve-research-review, resolve-review, retry-worktree, review-approach, review-design, review-pr, review-research-pr, run-experiment,
 scope, setup-project, smoke-task, stage-data, triage-issues, troubleshoot-experiment,
 validate-audit, verify-diag,

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -310,8 +310,8 @@ def test_docs_state_44_kitchen_tools(doc_path: Path) -> None:
     _assert_doc_states_number(doc_path, "kitchen tools", 44)
 
 
-def test_skill_visibility_states_126_skills() -> None:
-    _assert_doc_states_number(DOCS_DIR / "skills" / "visibility.md", "skills total", 126)
+def test_skill_visibility_states_127_skills() -> None:
+    _assert_doc_states_number(DOCS_DIR / "skills" / "visibility.md", "skills total", 127)
 
 
 def test_safety_hooks_states_21_hooks() -> None:

--- a/tests/execution/test_headless_path_validation.py
+++ b/tests/execution/test_headless_path_validation.py
@@ -362,6 +362,8 @@ class TestOutputPathTokensDerivedFromContracts:
             "refined_assignments_path",
             # planner-refine-wps output
             "refined_wps_path",
+            # planner-validate-task-alignment output
+            "alignment_findings_path",
             # audit-tests output (bundled full-audit recipe)
             "audit_report_path",
             # validate-audit output (bundled full-audit recipe)

--- a/tests/planner/test_planner.py
+++ b/tests/planner/test_planner.py
@@ -464,3 +464,69 @@ def test_replace_item_does_not_use_atomic_write(
     assert data["phases"][0]["name"] == "New"
     assert data["schema_version"] == 1
     spy.assert_not_called()
+
+
+# --- Task-blindness fix: expand functions include task in context ---
+
+
+def test_expand_assignments_includes_task_in_context(tmp_path: Path) -> None:
+    from autoskillit.planner.manifests import expand_assignments
+
+    refined = {
+        "task": "Split research.yaml into 4 sub-recipes",
+        "phases": [
+            {
+                "id": "P1",
+                "name": "Recipe Split",
+                "assignments_preview": [{"name": "Sub-recipe A"}, {"name": "Sub-recipe B"}],
+            }
+        ],
+    }
+    plan_path = tmp_path / "refined_plan.json"
+    plan_path.write_text(json.dumps(refined))
+    result = expand_assignments(refined_plan_path=str(plan_path), output_dir=str(tmp_path))
+    context_paths = result["context_paths"].split(",")
+    assert context_paths and context_paths[0], "Must produce at least one context path"
+    for cp in context_paths:
+        context = json.loads(Path(cp).read_text())
+        assert "task" in context, "Context file must include task field"
+        assert context["task"] == "Split research.yaml into 4 sub-recipes"
+
+
+def test_expand_wps_includes_task_in_context(tmp_path: Path) -> None:
+    from autoskillit.planner.manifests import expand_wps
+
+    refined = {
+        "schema_version": 2,
+        "task": "Add telemetry to fleet dispatch",
+        "source_dir": "/fake",
+        "assignments": [
+            {
+                "id": "P1-A1",
+                "phase_id": "P1",
+                "phase_number": 1,
+                "assignment_number": 1,
+                "name": "Telemetry",
+                "goal": "Add metrics",
+                "scope": ["fleet"],
+                "deliverables": ["fleet/_api.py"],
+                "proposed_work_packages": [
+                    {
+                        "id": "P1-A1-WP1",
+                        "name": "WP: Instrument dispatch",
+                        "scope": "fleet/_api.py",
+                        "estimated_files": ["fleet/_api.py"],
+                    }
+                ],
+            }
+        ],
+    }
+    plan_path = tmp_path / "refined_assignments.json"
+    plan_path.write_text(json.dumps(refined))
+    result = expand_wps(refined_assignments_path=str(plan_path), output_dir=str(tmp_path))
+    context_paths = result["context_paths"].split(",")
+    assert context_paths and context_paths[0], "Must produce at least one context path"
+    for cp in context_paths:
+        context = json.loads(Path(cp).read_text())
+        assert "task" in context, "Context file must include task field"
+        assert context["task"] == "Add telemetry to fleet dispatch"

--- a/tests/planner/test_planner.py
+++ b/tests/planner/test_planner.py
@@ -466,7 +466,7 @@ def test_replace_item_does_not_use_atomic_write(
     spy.assert_not_called()
 
 
-# --- Task-blindness fix: expand functions include task in context ---
+# --- expand functions propagate task context ---
 
 
 def test_expand_assignments_includes_task_in_context(tmp_path: Path) -> None:
@@ -485,8 +485,8 @@ def test_expand_assignments_includes_task_in_context(tmp_path: Path) -> None:
     plan_path = tmp_path / "refined_plan.json"
     plan_path.write_text(json.dumps(refined))
     result = expand_assignments(refined_plan_path=str(plan_path), output_dir=str(tmp_path))
-    context_paths = result["context_paths"].split(",")
-    assert context_paths and context_paths[0], "Must produce at least one context path"
+    context_paths = [p for p in result["context_paths"].split(",") if p.strip()]
+    assert context_paths, "Must produce at least one context path"
     for cp in context_paths:
         context = json.loads(Path(cp).read_text())
         assert "task" in context, "Context file must include task field"
@@ -524,8 +524,8 @@ def test_expand_wps_includes_task_in_context(tmp_path: Path) -> None:
     plan_path = tmp_path / "refined_assignments.json"
     plan_path.write_text(json.dumps(refined))
     result = expand_wps(refined_assignments_path=str(plan_path), output_dir=str(tmp_path))
-    context_paths = result["context_paths"].split(",")
-    assert context_paths and context_paths[0], "Must produce at least one context path"
+    context_paths = [p for p in result["context_paths"].split(",") if p.strip()]
+    assert context_paths, "Must produce at least one context path"
     for cp in context_paths:
         context = json.loads(Path(cp).read_text())
         assert "task" in context, "Context file must include task field"

--- a/tests/recipe/test_contracts.py
+++ b/tests/recipe/test_contracts.py
@@ -652,6 +652,7 @@ ALWAYS_WRITE_SKILLS = {
     "planner-refine-assignments",
     "planner-refine-phases",
     "planner-refine-wps",
+    "planner-validate-task-alignment",
     "prepare-research-pr",
     "promote-to-main",
     "rectify",

--- a/tests/recipe/test_planner_recipe.py
+++ b/tests/recipe/test_planner_recipe.py
@@ -38,6 +38,7 @@ def test_planner_recipe_has_required_steps(planner_recipe):
         "finalize_wp_manifest",
         "merge_wps",
         "refine_wps",
+        "validate_task_alignment",
         "reconcile_deps",
         "validate",
         "check_verdict",
@@ -246,3 +247,27 @@ def test_merge_steps_use_merge_tier_dir(planner_recipe, step_name):
     step = planner_recipe.steps[step_name]
     assert step.tool == "run_python"
     assert step.with_args.get("callable") == "autoskillit.planner.merge.merge_tier_dir"
+
+
+# --- Task-blindness fix tests ---
+
+
+def test_generate_phases_receives_planner_task_env(planner_recipe):
+    step = planner_recipe.steps["generate_phases"]
+    env = step.with_args.get("env", {})
+    assert "PLANNER_TASK" in env, "generate_phases must pass PLANNER_TASK env var"
+    assert "inputs.task" in env["PLANNER_TASK"], "PLANNER_TASK must reference inputs.task"
+
+
+def test_extract_domain_receives_planner_task_env(planner_recipe):
+    step = planner_recipe.steps["extract_domain"]
+    env = step.with_args.get("env", {})
+    assert "PLANNER_TASK" in env, "extract_domain must pass PLANNER_TASK env var"
+    assert "inputs.task" in env["PLANNER_TASK"], "PLANNER_TASK must reference inputs.task"
+
+
+def test_validate_task_alignment_step_exists(planner_recipe):
+    assert "validate_task_alignment" in planner_recipe.steps
+    step = planner_recipe.steps["validate_task_alignment"]
+    assert step.tool == "run_skill"
+    assert "planner-validate-task-alignment" in step.with_args.get("skill_command", "")

--- a/tests/recipe/test_planner_recipe.py
+++ b/tests/recipe/test_planner_recipe.py
@@ -249,7 +249,7 @@ def test_merge_steps_use_merge_tier_dir(planner_recipe, step_name):
     assert step.with_args.get("callable") == "autoskillit.planner.merge.merge_tier_dir"
 
 
-# --- Task-blindness fix tests ---
+# --- validate_task_alignment step integration ---
 
 
 def test_generate_phases_receives_planner_task_env(planner_recipe):

--- a/tests/skills/test_planner_extract_domain.py
+++ b/tests/skills/test_planner_extract_domain.py
@@ -11,3 +11,8 @@ def test_planner_extract_domain_skill_uses_env_var():
     content = (skill_dir / "SKILL.md").read_text()
     assert "$3" not in content
     assert "PLANNER_ANALYSIS_FILE" in content
+
+
+def test_extract_domain_skill_references_planner_task():
+    content = (pkg_root() / "skills_extended" / "planner-extract-domain" / "SKILL.md").read_text()
+    assert "PLANNER_TASK" in content, "SKILL.md must document PLANNER_TASK env var"

--- a/tests/skills/test_planner_skill_contracts.py
+++ b/tests/skills/test_planner_skill_contracts.py
@@ -24,6 +24,7 @@ ALL_PLANNER_SKILLS = [
     "planner-refine-phases",
     "planner-refine-assignments",
     "planner-refine-wps",
+    "planner-validate-task-alignment",
 ]
 
 
@@ -284,3 +285,60 @@ def test_elaborate_wps_contract_two_inputs() -> None:
     )
     input_names = {i.get("name") for i in inputs}
     assert input_names == {"context_file", "planner_dir"}
+
+
+# --- Task-blindness fix tests ---
+
+pytestmark = [pytest.mark.layer("skills"), pytest.mark.small]
+
+
+def test_generate_phases_skill_references_planner_task():
+    content = (SKILLS_ROOT / "planner-generate-phases" / "SKILL.md").read_text()
+    assert "PLANNER_TASK" in content, "SKILL.md must document PLANNER_TASK env var"
+    assert "task" in content.lower(), "SKILL.md must instruct task-constrained phase generation"
+
+
+TASK_AWARE_SKILLS = [
+    "planner-elaborate-phase",
+    "planner-refine-phases",
+    "planner-elaborate-assignments",
+    "planner-refine-assignments",
+    "planner-elaborate-wps",
+    "planner-refine-wps",
+]
+
+
+@pytest.mark.parametrize("skill_name", TASK_AWARE_SKILLS)
+def test_downstream_skill_has_task_alignment_instruction(skill_name):
+    content = (SKILLS_ROOT / skill_name / "SKILL.md").read_text()
+    assert "task" in content.lower()
+    has_alignment = (
+        "scope creep" in content.lower()
+        or "task alignment" in content.lower()
+        or "serves the stated task" in content.lower()
+        or "requested by the task" in content.lower()
+    )
+    assert has_alignment, f"{skill_name} SKILL.md must contain task-alignment instruction"
+
+
+def test_validate_task_alignment_skill_exists():
+    skill_dir = SKILLS_ROOT / "planner-validate-task-alignment"
+    assert skill_dir.is_dir(), "planner-validate-task-alignment skill must exist"
+    skill_md = skill_dir / "SKILL.md"
+    assert skill_md.is_file(), "SKILL.md must exist"
+    content = skill_md.read_text()
+    parts = content.split("---", 2)
+    data = yaml.safe_load(parts[1])
+    assert "planner" in (data.get("categories") or [])
+    assert "warning" in content.lower(), "Must emit warning-severity findings"
+
+
+def test_generate_phases_has_read_guardrails():
+    content = (SKILLS_ROOT / "planner-generate-phases" / "SKILL.md").read_text()
+    has_guardrail = (
+        "do not explore parent" in content.lower()
+        or "do not read files outside" in content.lower()
+        or "only read files passed" in content.lower()
+        or "explore parent directories" in content.lower()
+    )
+    assert has_guardrail, "SKILL.md must contain filesystem read guardrails"

--- a/tests/skills/test_planner_skill_contracts.py
+++ b/tests/skills/test_planner_skill_contracts.py
@@ -289,8 +289,6 @@ def test_elaborate_wps_contract_two_inputs() -> None:
 
 # --- Task-blindness fix tests ---
 
-pytestmark = [pytest.mark.layer("skills"), pytest.mark.small]
-
 
 def test_generate_phases_skill_references_planner_task():
     content = (SKILLS_ROOT / "planner-generate-phases" / "SKILL.md").read_text()

--- a/tests/skills/test_planner_skill_contracts.py
+++ b/tests/skills/test_planner_skill_contracts.py
@@ -287,7 +287,7 @@ def test_elaborate_wps_contract_two_inputs() -> None:
     assert input_names == {"context_file", "planner_dir"}
 
 
-# --- Task-blindness fix tests ---
+# --- validate_task_alignment skill contract tests ---
 
 
 def test_generate_phases_skill_references_planner_task():
@@ -309,7 +309,6 @@ TASK_AWARE_SKILLS = [
 @pytest.mark.parametrize("skill_name", TASK_AWARE_SKILLS)
 def test_downstream_skill_has_task_alignment_instruction(skill_name):
     content = (SKILLS_ROOT / skill_name / "SKILL.md").read_text()
-    assert "task" in content.lower()
     has_alignment = (
         "scope creep" in content.lower()
         or "task alignment" in content.lower()

--- a/tests/skills/test_skill_output_compliance.py
+++ b/tests/skills/test_skill_output_compliance.py
@@ -265,6 +265,8 @@ def test_output_path_tokens_synchronized() -> None:
             "validated_report_path",
             # promote-to-main skill output (promote-to-main-wrapper recipe)
             "pr_body_path",
+            # planner-validate-task-alignment output
+            "alignment_findings_path",
         }
     )
 

--- a/tests/workspace/test_skills.py
+++ b/tests/workspace/test_skills.py
@@ -440,18 +440,18 @@ class TestSkillResolver:
         names = {d.name for d in bundled_skills_dir().iterdir() if d.is_dir()}
         assert names == {"open-kitchen", "close-kitchen", "sous-chef"}
 
-    def test_122_skills_in_skills_extended(self) -> None:
-        """skills_extended/ contains exactly 123 SKILL.md-carrying directories."""
+    def test_124_skills_in_skills_extended(self) -> None:
+        """skills_extended/ contains exactly 124 SKILL.md-carrying directories."""
         skills = [
             d
             for d in bundled_skills_extended_dir().iterdir()
             if d.is_dir() and (d / "SKILL.md").is_file()
         ]
-        assert len(skills) == 123
+        assert len(skills) == 124
 
     def test_skill_resolver_list_all_total_count(self) -> None:
-        """list_all() returns 125 public skills (2 Tier-1 + 123 extended)."""
-        assert len(DefaultSkillResolver().list_all()) == 125
+        """list_all() returns 126 public skills (2 Tier-1 + 124 extended)."""
+        assert len(DefaultSkillResolver().list_all()) == 126
 
     def test_skill_resolver_resolve_extended_skill(self) -> None:
         """resolve() finds a skill living in skills_extended/ with BUNDLED_EXTENDED source."""


### PR DESCRIPTION
## Summary

The planner recipe's `inputs.task` ingredient — the user's description of what to plan — never reaches the three skills that determine plan content (`planner-analyze` excluded since it's structural). The skills decompose the codebase's architecture instead of the user's requested work. This plan threads `inputs.task` through the entire pipeline: (1) inject `PLANNER_TASK` env var into `generate_phases` and `extract_domain` recipe steps, (2) update 8 SKILL.md files with task-constraint instructions, (3) extend `expand_assignments`/`expand_wps` to include `task` in context files, (4) add a new `planner-validate-task-alignment` skill as a catch-net, and (5) add filesystem read guardrails to prevent stale artifact contamination.

## Requirements

### R1: Inject task into `planner-generate-phases` via env var

**Recipe change** (`planner.yaml`, `generate_phases` step):

```yaml
generate_phases:
  tool: run_skill
  with:
    skill_command: >
      /autoskillit:planner-generate-phases
      ${{ context.planner_dir }}/analysis.json
      ${{ context.planner_dir }}/domain_knowledge.md
    cwd: "${{ inputs.source_dir }}"
    env:
      PLANNER_TASK: "${{ inputs.task }}"
```

An env var is preferred over a positional `$3` because the task string can be multi-paragraph prose or a pasted scoping report. Positional arguments rely on the model's whitespace-based parsing, which breaks for multi-line content. This is consistent with how `extract_domain` receives input via `PLANNER_ANALYSIS_FILE`.

**SKILL.md change** (`planner-generate-phases/SKILL.md`):

- Add `PLANNER_TASK` to the ARGUMENTS section as a required env var
- Add a Step 0: "Read the task description from the `PLANNER_TASK` environment variable. All phases MUST serve this task. Do not generate phases for work not requested by the task. Phases should decompose the stated task into implementation units, not decompose the codebase into architectural layers."
- Change the phase scoping instruction from "Named to reflect architectural or domain boundaries" to "Named to reflect the task's work units, grounded in the codebase's architecture"

### R2: Inject task into `planner-extract-domain` for task-scoped domain extraction

Pass `PLANNER_TASK` env var to `extract_domain` step alongside `PLANNER_ANALYSIS_FILE`. Update the SKILL.md to instruct subagents to focus domain vocabulary extraction on areas relevant to the stated task, rather than performing a generic full-codebase survey.

### R3: Add task-alignment validation as a skill step

Add a new `validate_task_alignment` step after `refine_wps` (or integrate into the existing `validate` step as a subagent-based check). This should:

- Spawn 1-2 subagents that compare phase goals and WP descriptions against the task description
- Flag phases that appear unrelated to the stated task
- Emit findings at `warning` severity (non-blocking per #1510) so the pipeline surfaces misalignment without halting

This serves as a catch-net — if the upstream task injection (R1) works correctly, this step should produce zero findings.

### R4: Add filesystem guardrails to planner skills

Add to `planner-generate-phases/SKILL.md` and other planner skills: "Only read files passed as positional arguments or via env vars. Do not explore parent directories. Do not read files outside `$(dirname $1)` or your designated output directory."

This complements #1334 (run-scoped directories) and #1357 (planner isolation gap). The write guard pattern from #1502 (Three-Layer Write Guard) is the precedent — but planner skills need **read** guardrails specifically, preventing exploration of non-git-tracked directories and other planner runs' output folders. The codebase (git-tracked files) should remain readable for exploration; the constraint is against reading `.autoskillit/temp/` artifacts outside the skill's own scope.

### R5: Propagate task to downstream elaborate/refine skills

Update the SKILL.md for `planner-elaborate-phase`, `planner-refine-phases`, `planner-elaborate-assignments`, `planner-refine-assignments`, `planner-elaborate-wps`, and `planner-refine-wps` to explicitly instruct: "Read the `task` field from the plan snapshot/combined document. Ensure all assignments/WPs serve the stated task. Flag scope creep into work not requested by the task."

The `task` field already exists in `plan_snapshot.json` and `combined_*.json` — the gap is that no SKILL.md tells the model to use it as a constraint.

## Architecture Impact

### Data Lineage Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START(["START<br/>━━━━━━━━━━<br/>Pipeline invocation"])

    subgraph Inputs ["Data Origins"]
        direction LR
        TASK["task<br/>━━━━━━━━━━<br/>String — task description"]
        SRCDIR["source_dir<br/>━━━━━━━━━━<br/>Path — repo root"]
    end

    subgraph Analysis ["Analysis Artifacts — planner_dir/"]
        direction LR
        ANALYSIS[("● analysis.json<br/>━━━━━━━━━━<br/>Codebase analysis<br/>JSON")]
        DOMAIN["● domain_knowledge.md<br/>━━━━━━━━━━<br/>Optional side-input<br/>Markdown"]
    end

    subgraph PhaseGen ["Phase Tier — planner_dir/phases/"]
        direction TB
        PMANIFEST[("● phase_manifest.json<br/>━━━━━━━━━━<br/>Phase IDs + paths<br/>JSON")]
        PRESULTS[("● P*_result.json<br/>━━━━━━━━━━<br/>PhaseResult per phase<br/>JSON")]
        PSNAPSHOT[("plan_snapshot.json<br/>━━━━━━━━━━<br/>PhaseShort list<br/>JSON")]
    end

    subgraph PhaseRefine ["Phase Refinement — planner_dir/"]
        direction TB
        PCOMBINED[("combined_plan.json<br/>━━━━━━━━━━<br/>Merged PhaseElaborated<br/>JSON")]
        PREFINED[("● refined_plan.json<br/>━━━━━━━━━━<br/>Validated phases<br/>JSON — Source of Truth")]
    end

    subgraph AssignGen ["Assignment Tier — planner_dir/assignments/"]
        direction TB
        ACTX[("● context_per_phase.json<br/>━━━━━━━━━━<br/>Per-phase assignment<br/>context — JSON")]
        ARESULTS[("● A*_result.json<br/>━━━━━━━━━━<br/>AssignmentResult per<br/>assignment — JSON")]
    end

    subgraph AssignRefine ["Assignment Refinement — planner_dir/"]
        direction TB
        ACOMBINED[("combined_assignments.json<br/>━━━━━━━━━━<br/>Merged AssignmentElaborated<br/>JSON")]
        AREFINED[("● refined_assignments.json<br/>━━━━━━━━━━<br/>Resolved WP IDs<br/>JSON — Source of Truth")]
    end

    subgraph WPGen ["WP Tier — planner_dir/work_packages/"]
        direction TB
        WCTX[("● context_per_phase.json<br/>━━━━━━━━━━<br/>Per-phase WP context<br/>JSON")]
        WRESULTS[("● WP*_result.json<br/>━━━━━━━━━━<br/>WPResult per WP<br/>JSON")]
        WPMANIFEST[("● wp_manifest.json<br/>━━━━━━━━━━<br/>Final WP manifest<br/>JSON")]
        WPINDEX[("● wp_index.json<br/>━━━━━━━━━━<br/>Slim id/name/summary<br/>JSON")]
    end

    subgraph WPRefine ["WP Refinement — planner_dir/"]
        direction TB
        WCOMBINED[("combined_wps.json<br/>━━━━━━━━━━<br/>Merged WPElaborated<br/>JSON")]
        WREFINED[("● refined_wps.json<br/>━━━━━━━━━━<br/>Cross-tier coherent WPs<br/>JSON — Source of Truth")]
    end

    subgraph Validation ["Validation — planner_dir/"]
        direction TB
        TALIGN[("★ task_alignment.json<br/>━━━━━━━━━━<br/>Per-entity findings<br/>severity + rating<br/>JSON — Write-Only")]
        DEPGRAPH[("dep_graph.json<br/>━━━━━━━━━━<br/>Fwd/bwd dep edges<br/>JSON")]
        VERDICT[("validation.json<br/>━━━━━━━━━━<br/>Verdict + findings<br/>JSON")]
    end

    subgraph Compilation ["Final Artifacts — planner_dir/"]
        direction TB
        PLAN[("plan.json<br/>━━━━━━━━━━<br/>Fully nested phases<br/>→assignments→WPs<br/>JSON")]
        PLANMD["plan.md<br/>━━━━━━━━━━<br/>Human-readable<br/>summary — Markdown"]
        MANIFEST["manifest.json<br/>━━━━━━━━━━<br/>Execution order<br/>+ issue paths — JSON"]
        ISSUES["issues/*.md<br/>━━━━━━━━━━<br/>One GitHub issue<br/>body per WP — Markdown"]
        MILESTONES["milestones.json<br/>━━━━━━━━━━<br/>Phase milestones<br/>JSON"]
    end

    subgraph Contracts ["Contract Registry — src/autoskillit/recipe/"]
        direction LR
        SKILLCONTRACTS[("● skill_contracts.yaml<br/>━━━━━━━━━━<br/>Input/output specs<br/>per skill — YAML")]
        PLANNERCARD[("● contracts/planner.yaml<br/>━━━━━━━━━━<br/>Dataflow card<br/>cumulative vars — YAML")]
    end

    subgraph DetectorLayer ["Dataflow Validation — recipe/"]
        direction LR
        DETECTORS["● _analysis_detectors.py<br/>━━━━━━━━━━<br/>Dead output + ref<br/>invalidation detection"]
    end

    %% === PRIMARY FLOWS === %%
    START --> TASK & SRCDIR

    TASK & SRCDIR -->|"analyze"| ANALYSIS
    ANALYSIS -->|"● extract-domain"| DOMAIN

    ANALYSIS -->|"● generate-phases"| PMANIFEST
    PMANIFEST --> PRESULTS
    PRESULTS -->|"build_plan_snapshot"| PSNAPSHOT

    PSNAPSHOT -->|"● elaborate-phase<br/>parallel per phase"| PRESULTS
    PRESULTS -->|"merge_tier_dir"| PCOMBINED
    PCOMBINED -->|"● refine-phases"| PREFINED

    PREFINED -->|"● expand_assignments"| ACTX
    ACTX -->|"● elaborate-assignments<br/>parallel per phase"| ARESULTS
    ARESULTS -->|"merge_tier_dir"| ACOMBINED
    ACOMBINED -->|"● refine-assignments"| AREFINED
    PREFINED -->|"cross-tier context"| AREFINED

    AREFINED -->|"● expand_wps"| WCTX
    WCTX -->|"● elaborate-wps<br/>sequential per phase"| WRESULTS
    WRESULTS -->|"● finalize_wp_manifest"| WPMANIFEST & WPINDEX
    WRESULTS -->|"merge_tier_dir"| WCOMBINED
    WCOMBINED -->|"● refine-wps"| WREFINED
    PREFINED -->|"cross-tier context"| WREFINED
    AREFINED -->|"cross-tier context"| WREFINED

    %% === VALIDATION FLOWS === %%
    WREFINED -.->|"★ validate-task-alignment"| TALIGN
    PREFINED -.->|"phase goals as<br/>alignment baseline"| TALIGN
    WREFINED -->|"reconcile-deps"| DEPGRAPH
    DEPGRAPH -->|"validate_plan"| VERDICT

    %% === COMPILATION FLOWS === %%
    VERDICT -->|"gate: pass"| PLAN
    DEPGRAPH -->|"topological sort"| PLAN
    PLAN --> PLANMD & MANIFEST & ISSUES & MILESTONES

    %% === CONTRACT REGISTRY FLOWS === %%
    SKILLCONTRACTS -.->|"generate_recipe_card"| PLANNERCARD
    PLANNERCARD -.->|"validate_recipe_cards"| DETECTORS

    %% === CLASS ASSIGNMENTS === %%
    class TASK,SRCDIR cli;
    class START terminal;
    class ANALYSIS,PSNAPSHOT,PCOMBINED,ACOMBINED,WCOMBINED stateNode;
    class PMANIFEST,PRESULTS,ARESULTS,WRESULTS,ACTX,WCTX handler;
    class PREFINED,AREFINED,WREFINED,WPMANIFEST,WPINDEX phase;
    class TALIGN newComponent;
    class DEPGRAPH,VERDICT detector;
    class DOMAIN,PLANMD,ISSUES output;
    class PLAN,MANIFEST,MILESTONES output;
    class SKILLCONTRACTS,PLANNERCARD,DETECTORS integration;
```

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 40, 'rankSpacing': 50, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START])
    DONE([DONE])
    ERROR([ESCALATE_STOP])

    subgraph Setup ["Setup"]
        direction TB
        INIT["init<br/>━━━━━━━━━━<br/>run_python: create_run_dir<br/>Produces: planner_dir"]
    end

    subgraph Analysis ["Analysis"]
        direction TB
        ANALYZE["analyze<br/>━━━━━━━━━━<br/>run_skill: planner-analyze<br/>Writes: analysis.json"]
        DOMAIN["● extract_domain<br/>━━━━━━━━━━<br/>run_skill: planner-extract-domain<br/>Writes: domain_knowledge.md"]
    end

    subgraph PhaseTier ["Phase Tier (T1) — Parallel Dispatch"]
        direction TB
        GEN_PHASES["● generate_phases<br/>━━━━━━━━━━<br/>run_skill: planner-generate-phases<br/>Writes: phase_manifest.json"]
        SNAP["build_plan_snapshot<br/>━━━━━━━━━━<br/>run_python: build_plan_snapshot<br/>Produces: plan_snapshot_path, phase_ids"]
        ELAB_PHASES["● elaborate_phases<br/>━━━━━━━━━━<br/>run_skill: planner-elaborate-phase<br/>Dispatch: ALL phases in parallel"]
        MERGE_PHASES["merge_phases<br/>━━━━━━━━━━<br/>run_python: merge_tier_dir<br/>Writes: combined_plan.json"]
        REFINE_PHASES["● refine_phases<br/>━━━━━━━━━━<br/>run_skill: planner-refine-phases<br/>Writes: refined_plan.json"]
    end

    subgraph AssignTier ["Assignment Tier (T2) — Parallel Dispatch"]
        direction TB
        EXPAND_A["● expand_assignments<br/>━━━━━━━━━━<br/>run_python: expand_assignments<br/>Writes: context_{phase_id}.json"]
        ELAB_A["● elaborate_assignments<br/>━━━━━━━━━━<br/>run_skill: planner-elaborate-assignments<br/>Dispatch: ALL phases in parallel"]
        MERGE_A["merge_assignments<br/>━━━━━━━━━━<br/>run_python: merge_tier_dir<br/>Writes: combined_assignments.json"]
        REFINE_A["● refine_assignments<br/>━━━━━━━━━━<br/>run_skill: planner-refine-assignments<br/>Writes: refined_assignments.json"]
    end

    subgraph WPTier ["Work Package Tier (T3) — Sequential Dispatch"]
        direction TB
        EXPAND_WP["● expand_wps<br/>━━━━━━━━━━<br/>run_python: expand_wps<br/>Writes: context_{phase_id}.json"]
        ELAB_WP["● elaborate_wps<br/>━━━━━━━━━━<br/>run_skill: planner-elaborate-wps<br/>Dispatch: ONE phase at a time"]
        FINAL_WP["finalize_wp_manifest<br/>━━━━━━━━━━<br/>run_python: finalize_wp_manifest<br/>Writes: wp_manifest.json"]
        MERGE_WP["merge_wps<br/>━━━━━━━━━━<br/>run_python: merge_tier_dir<br/>Writes: combined_wps.json"]
        REFINE_WP["● refine_wps<br/>━━━━━━━━━━<br/>run_skill: planner-refine-wps<br/>Writes: refined_wps.json"]
    end

    subgraph TaskAlign ["Task Alignment Check"]
        direction TB
        VALIDATE_ALIGN["★ validate_task_alignment<br/>━━━━━━━━━━<br/>run_skill: planner-validate-task-alignment<br/>Writes: task_alignment.json<br/>NON-FATAL: warnings only"]
    end

    subgraph Finalization ["Dependency Reconciliation"]
        direction TB
        RECONCILE["reconcile_deps<br/>━━━━━━━━━━<br/>run_skill: planner-reconcile-deps<br/>Writes: dep_graph.json"]
    end

    subgraph ValidateLoop ["Validate / Refine Loop (max 3 passes)"]
        direction TB
        VALIDATE["validate<br/>━━━━━━━━━━<br/>run_python: validate_plan<br/>Checks: completeness, DAG,<br/>sizing, duplicates"]
        VERDICT{"check_verdict<br/>━━━━━━━━━━<br/>verdict == fail?"}
        REFINE["refine<br/>━━━━━━━━━━<br/>run_skill: planner-refine<br/>retries: 2"]
    end

    subgraph Compilation ["Compilation"]
        direction TB
        COMPILE["compile<br/>━━━━━━━━━━<br/>run_python: compile_plan<br/>Writes: plan.json, plan.md,<br/>issues/, milestones.json"]
    end

    %% MAIN FLOW %%
    START --> INIT
    INIT --> ANALYZE
    ANALYZE --> DOMAIN

    DOMAIN -->|"success OR failure"| GEN_PHASES

    GEN_PHASES --> SNAP
    SNAP --> ELAB_PHASES
    ELAB_PHASES --> MERGE_PHASES
    MERGE_PHASES --> REFINE_PHASES

    REFINE_PHASES --> EXPAND_A
    EXPAND_A --> ELAB_A
    ELAB_A --> MERGE_A
    MERGE_A --> REFINE_A

    REFINE_A --> EXPAND_WP
    EXPAND_WP --> ELAB_WP
    ELAB_WP --> FINAL_WP
    FINAL_WP --> MERGE_WP
    MERGE_WP --> REFINE_WP

    REFINE_WP --> VALIDATE_ALIGN
    VALIDATE_ALIGN -->|"success OR failure"| RECONCILE

    RECONCILE --> VALIDATE
    VALIDATE --> VERDICT
    VERDICT -->|"pass"| COMPILE
    VERDICT -->|"fail"| REFINE
    REFINE -->|"success"| VALIDATE
    REFINE -->|"exhausted (retries=0)"| ERROR

    COMPILE --> DONE

    %% ERROR PATHS %%
    INIT -->|"failure"| ERROR
    ANALYZE -->|"failure"| ERROR
    GEN_PHASES -->|"failure"| ERROR
    SNAP -->|"failure"| ERROR
    ELAB_PHASES -->|"failure"| ERROR
    MERGE_PHASES -->|"failure"| ERROR
    REFINE_PHASES -->|"failure"| ERROR
    EXPAND_A -->|"failure"| ERROR
    ELAB_A -->|"failure"| ERROR
    MERGE_A -->|"failure"| ERROR
    REFINE_A -->|"failure"| ERROR
    EXPAND_WP -->|"failure"| ERROR
    ELAB_WP -->|"failure"| ERROR
    FINAL_WP -->|"failure"| ERROR
    MERGE_WP -->|"failure"| ERROR
    REFINE_WP -->|"failure"| ERROR
    RECONCILE -->|"failure"| ERROR
    VALIDATE -->|"failure"| ERROR
    COMPILE -->|"failure"| ERROR

    %% CLASS ASSIGNMENTS %%
    class START,DONE,ERROR terminal;
    class INIT phase;
    class ANALYZE,DOMAIN handler;
    class GEN_PHASES,SNAP,ELAB_PHASES,MERGE_PHASES,REFINE_PHASES handler;
    class EXPAND_A,ELAB_A,MERGE_A,REFINE_A handler;
    class EXPAND_WP,ELAB_WP,FINAL_WP,MERGE_WP,REFINE_WP handler;
    class VALIDATE_ALIGN newComponent;
    class RECONCILE handler;
    class VALIDATE,REFINE detector;
    class VERDICT stateNode;
    class COMPILE output;
```

### Module Dependency Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 70, 'curve': 'basis'}}}%%
graph TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef integration fill:#c62828,stroke:#ef9a9a,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    subgraph L3 ["LAYER 3 — SERVER / CLI"]
        direction LR
        FACTORY["server/_factory.py<br/>━━━━━━━━━━<br/>Composition Root"]
    end

    subgraph L2 ["LAYER 2 — RECIPE"]
        direction TB
        DETECTORS["● recipe/_analysis_detectors.py<br/>━━━━━━━━━━<br/>Dead-output &amp; ref invalidation"]
        CONTRACTS["● recipe/contracts.py<br/>━━━━━━━━━━<br/>Contract card generation"]
        SKILL_YAML["● recipe/skill_contracts.yaml<br/>━━━━━━━━━━<br/>Skill contract manifest"]
        RULES_C["recipe/rules_contracts.py<br/>━━━━━━━━━━<br/>Contract validation rules"]
        ANALYSIS["recipe/_analysis.py<br/>━━━━━━━━━━<br/>ValidationContext builder"]
        BFS["recipe/_analysis_bfs.py<br/>━━━━━━━━━━<br/>Symbolic BFS propagation"]
        SCHEMA_R["recipe/schema.py<br/>━━━━━━━━━━<br/>Recipe, RecipeStep"]
        IO_R["recipe/io.py<br/>━━━━━━━━━━<br/>load_recipe, list_recipes"]
    end

    subgraph L1_PLANNER ["LAYER 1 — PLANNER"]
        direction TB
        PLANNER_INIT["● planner/__init__.py<br/>━━━━━━━━━━<br/>Re-exports 26 symbols"]
        MANIFESTS["● planner/manifests.py<br/>━━━━━━━━━━<br/>expand_assignments, expand_wps"]
        SCHEMA_P["planner/schema.py<br/>━━━━━━━━━━<br/>PhaseResult, WPResult"]
        VALIDATION["planner/validation.py<br/>━━━━━━━━━━<br/>validate_plan"]
        COMPILER["planner/compiler.py<br/>━━━━━━━━━━<br/>compile_plan"]
    end

    subgraph L1_WS ["LAYER 1 — WORKSPACE"]
        direction TB
        SKILLS_PY["workspace/skills.py<br/>━━━━━━━━━━<br/>DefaultSkillResolver<br/>Fan-in: 4"]
    end

    subgraph L1_CONFIG ["LAYER 1 — CONFIG"]
        direction TB
        DEFAULTS["● config/defaults.yaml<br/>━━━━━━━━━━<br/>Default settings"]
        LOADER["config/_config_loader.py<br/>━━━━━━━━━━<br/>_make_dynaconf"]
    end

    subgraph L0 ["LAYER 0 — CORE"]
        direction LR
        CORE_IO["core/io.py<br/>━━━━━━━━━━<br/>atomic_write, YAML helpers<br/>Fan-in: 8+"]
        CORE_TYPES["core/types.py<br/>━━━━━━━━━━<br/>SkillSource, enums<br/>Fan-in: 10+"]
        CORE_PATHS["core/paths.py<br/>━━━━━━━━━━<br/>pkg_root()<br/>Fan-in: 12+"]
        CORE_CONST["core/_type_constants.py<br/>━━━━━━━━━━<br/>SKILL_TOOLS"]
    end

    subgraph DATA ["DATA FILES"]
        direction LR
        RECIPE_YAML["● recipes/planner.yaml<br/>━━━━━━━━━━<br/>Planner recipe definition"]
        CONTRACT_YAML["● recipes/contracts/planner.yaml<br/>━━━━━━━━━━<br/>Planner contract card"]
    end

    subgraph SKILLS ["SKILLS_EXTENDED — PLANNER FAMILY"]
        direction LR
        NEW_SKILL["★ planner-validate-task-alignment<br/>━━━━━━━━━━<br/>NEW: task/WP alignment check"]
        MOD_SKILLS["● planner-elaborate-*<br/>● planner-generate-*<br/>● planner-refine-*<br/>● planner-extract-domain<br/>━━━━━━━━━━<br/>8 modified skills"]
    end

    subgraph TESTS ["TESTS"]
        direction LR
        T_PLANNER["● tests/planner/test_planner.py"]
        T_CONTRACTS["● tests/recipe/test_contracts.py"]
        T_PLANNER_R["● tests/recipe/test_planner_recipe.py"]
        T_SKILL_C["● tests/skills/test_planner_skill_contracts.py"]
        T_SKILLS["● tests/workspace/test_skills.py"]
    end

    %% === VALID DOWNWARD DEPENDENCIES === %%

    %% L3 → L2
    FACTORY -->|"imports"| CONTRACTS

    %% L2 internal
    ANALYSIS -->|"imports"| DETECTORS
    DETECTORS -->|"imports"| BFS
    DETECTORS -->|"imports"| CONTRACTS
    DETECTORS -->|"imports"| SCHEMA_R
    DETECTORS -->|"imports"| CORE_CONST
    CONTRACTS -->|"loads"| SKILL_YAML
    RULES_C -->|"imports"| CONTRACTS
    IO_R -->|"discovers"| RECIPE_YAML
    IO_R -->|"discovers"| CONTRACT_YAML

    %% L2 → L0
    CONTRACTS -->|"imports"| CORE_PATHS
    SCHEMA_R -->|"imports"| CORE_TYPES

    %% L1 planner internal
    PLANNER_INIT -->|"re-exports"| MANIFESTS
    PLANNER_INIT -->|"re-exports"| SCHEMA_P
    PLANNER_INIT -->|"re-exports"| VALIDATION
    PLANNER_INIT -->|"re-exports"| COMPILER
    MANIFESTS -->|"imports"| SCHEMA_P
    MANIFESTS -->|"imports"| CORE_IO
    VALIDATION -->|"imports"| SCHEMA_P
    COMPILER -->|"imports"| VALIDATION

    %% L1 config
    LOADER -->|"loads"| DEFAULTS

    %% L1 workspace → L0
    SKILLS_PY -->|"imports"| CORE_TYPES
    SKILLS_PY -->|"imports"| CORE_PATHS
    SKILLS_PY -->|"imports"| CORE_IO

    %% L1 workspace → data
    SKILLS_PY -->|"discovers"| NEW_SKILL
    SKILLS_PY -->|"discovers"| MOD_SKILLS

    %% === VIOLATION === %%
    RULES_C -.->|"⚠ VIOLATION L2→L1<br/>deferred import<br/>PHASE_REQUIRED_KEYS"| PLANNER_INIT

    %% === TEST DEPENDENCIES === %%
    T_PLANNER -->|"imports"| PLANNER_INIT
    T_CONTRACTS -->|"imports"| CONTRACTS
    T_CONTRACTS -->|"imports"| SKILLS_PY
    T_PLANNER_R -->|"imports"| IO_R
    T_SKILL_C -->|"imports"| CORE_PATHS
    T_SKILL_C -->|"imports"| IO_R
    T_SKILLS -->|"imports"| SKILLS_PY
    T_SKILLS -->|"imports"| CORE_TYPES

    %% CLASS ASSIGNMENTS %%
    class FACTORY cli;
    class DETECTORS,CONTRACTS,RULES_C,ANALYSIS,BFS,SCHEMA_R,IO_R phase;
    class SKILL_YAML,RECIPE_YAML,CONTRACT_YAML output;
    class PLANNER_INIT,MANIFESTS,SCHEMA_P,VALIDATION,COMPILER handler;
    class SKILLS_PY handler;
    class DEFAULTS,LOADER handler;
    class CORE_IO,CORE_TYPES,CORE_PATHS,CORE_CONST stateNode;
    class NEW_SKILL newComponent;
    class MOD_SKILLS phase;
    class T_PLANNER,T_CONTRACTS,T_PLANNER_R,T_SKILL_C,T_SKILLS detector;
```

Closes #1519

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260429-080623-335753/.autoskillit/temp/make-plan/planner_task_blindness_plan_2026-04-29_081500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 2.2k | 18.6k | 936.7k | 78.3k | 1 | 8m 41s |
| verify | 1.8k | 16.6k | 3.4M | 92.7k | 1 | 6m 41s |
| implement | 153 | 37.9k | 11.3M | 135.3k | 1 | 27m 56s |
| prepare_pr | 33 | 8.8k | 192.8k | 38.0k | 1 | 2m 30s |
| run_arch_lenses | 6.8k | 19.8k | 648.8k | 108.4k | 3 | 9m 58s |
| compose_pr | 24 | 11.3k | 252.8k | 43.0k | 1 | 3m 44s |
| review_pr | 519 | 23.8k | 633.5k | 116.8k | 1 | 12m 57s |
| resolve_review | 37 | 11.9k | 853.8k | 48.1k | 1 | 7m 59s |
| **Total** | 11.5k | 148.6k | 18.2M | 660.5k | | 1h 20m |