### PR TITLE
Add `arch_lenses` Ingredient to Skip Architecture Lens Steps

### DIFF
--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -28,6 +28,9 @@ ingredients:
   open_pr:
     description: PR instead of direct merge
     default: "true"
+  arch_lenses:
+    description: Generate architecture lens diagrams for the PR
+    default: "true"
   auto_merge:
     description: >-
       Automatically merge the PR after required checks pass —
@@ -58,6 +61,9 @@ kitchen_rules:
     directly. The push step publishes the feature branch, then prepare_pr → run_arch_lenses → compose_pr
     opens a PR to base_branch. When open_pr=false, merges target base_branch
     directly and prepare_pr is skipped."
+  - "When arch_lenses=false (and open_pr=true), prepare_pr still runs but
+    routes directly to compose_pr, skipping run_arch_lenses. The PR is
+    created without architecture lens diagrams."
   - "SOURCE ISOLATION: After clone_repo returns, the source_dir is strictly
     off-limits. Never run any command in source_dir — no git checkout, git
     fetch, git reset, git pull, run_cmd, run_skill, or any other operation.
@@ -458,8 +464,10 @@ steps:
       selected_lenses: "${{ result.selected_lenses }}"
       lens_context_paths: "${{ result.lens_context_paths }}"
     on_result:
-      - when: "${{ result.prep_path }}"
+      - when: "${{ result.prep_path }} and ${{ inputs.arch_lenses }} != 'false'"
         route: run_arch_lenses
+      - when: "${{ result.prep_path }}"
+        route: compose_pr
       - route: release_issue_failure
     on_failure: release_issue_failure
     on_context_limit: release_issue_failure

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -28,6 +28,9 @@ ingredients:
   open_pr:
     description: PR instead of direct merge
     default: "true"
+  arch_lenses:
+    description: Generate architecture lens diagrams for the PR
+    default: "true"
   auto_merge:
     description: >-
       Automatically merge the PR after required checks pass —
@@ -64,6 +67,9 @@ kitchen_rules:
     directly. The push step publishes the feature branch, then prepare_pr → run_arch_lenses → compose_pr
     opens a PR to base_branch. When open_pr=false, merges target base_branch
     directly and prepare_pr is skipped."
+  - "When arch_lenses=false (and open_pr=true), prepare_pr still runs but
+    routes directly to compose_pr, skipping run_arch_lenses. The PR is
+    created without architecture lens diagrams."
   - "SOURCE ISOLATION: After clone_repo returns, the source_dir is strictly
     off-limits. Never run any command in source_dir — no git checkout, git
     fetch, git reset, git pull, run_cmd, run_skill, or any other operation.
@@ -442,8 +448,10 @@ steps:
       selected_lenses: "${{ result.selected_lenses }}"
       lens_context_paths: "${{ result.lens_context_paths }}"
     on_result:
-      - when: "${{ result.prep_path }}"
+      - when: "${{ result.prep_path }} and ${{ inputs.arch_lenses }} != 'false'"
         route: run_arch_lenses
+      - when: "${{ result.prep_path }}"
+        route: compose_pr
       - route: release_issue_failure
     on_failure: release_issue_failure
     on_context_limit: release_issue_failure

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -23,6 +23,9 @@ kitchen_rules:
     directly. The push step publishes the feature branch, then prepare_pr → run_arch_lenses → compose_pr
     opens a PR to base_branch. When open_pr=false, merges target base_branch
     directly and prepare_pr is skipped."
+  - "When arch_lenses=false (and open_pr=true), prepare_pr still runs but
+    routes directly to compose_pr, skipping run_arch_lenses. The PR is
+    created without architecture lens diagrams."
   - "SOURCE ISOLATION: After clone_repo returns, the source_dir is strictly
     off-limits. Never run any command in source_dir — no git checkout, git
     fetch, git reset, git pull, run_cmd, run_skill, or any other operation.
@@ -52,6 +55,9 @@ ingredients:
     default: "false"
   open_pr:
     description: PR instead of direct merge
+    default: "true"
+  arch_lenses:
+    description: Generate architecture lens diagrams for the PR
     default: "true"
   auto_merge:
     description: >-
@@ -440,8 +446,10 @@ steps:
       selected_lenses: "${{ result.selected_lenses }}"
       lens_context_paths: "${{ result.lens_context_paths }}"
     on_result:
-      - when: "${{ result.prep_path }}"
+      - when: "${{ result.prep_path }} and ${{ inputs.arch_lenses }} != 'false'"
         route: run_arch_lenses
+      - when: "${{ result.prep_path }}"
+        route: compose_pr
       - route: release_issue_failure
     on_failure: release_issue_failure
     on_context_limit: release_issue_failure

--- a/tests/recipe/test_implementation_groups_pr_decomposition.py
+++ b/tests/recipe/test_implementation_groups_pr_decomposition.py
@@ -19,6 +19,10 @@ def test_arch_lenses_ingredient_declared(recipe):
     assert "arch_lenses" in recipe.ingredients
 
 
+def test_arch_lenses_is_not_hidden(recipe):
+    assert recipe.ingredients["arch_lenses"].hidden is False
+
+
 def test_arch_lenses_defaults_to_true(recipe):
     assert recipe.ingredients["arch_lenses"].default == "true"
 

--- a/tests/recipe/test_implementation_groups_pr_decomposition.py
+++ b/tests/recipe/test_implementation_groups_pr_decomposition.py
@@ -1,0 +1,49 @@
+"""Verify implementation-groups.yaml has arch_lenses ingredient and routing."""
+
+import pytest
+
+from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
+from autoskillit.recipe.validator import validate_recipe
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+RECIPE_PATH = builtin_recipes_dir() / "implementation-groups.yaml"
+
+
+@pytest.fixture(scope="module")
+def recipe():
+    return load_recipe(RECIPE_PATH)
+
+
+def test_arch_lenses_ingredient_declared(recipe):
+    assert "arch_lenses" in recipe.ingredients
+
+
+def test_arch_lenses_defaults_to_true(recipe):
+    assert recipe.ingredients["arch_lenses"].default == "true"
+
+
+def test_prepare_pr_routes_to_compose_pr_when_arch_lenses_false(recipe):
+    step = recipe.steps["prepare_pr"]
+    routes = [c.route for c in step.on_result.conditions if c.when and "prep_path" in c.when]
+    assert "compose_pr" in routes
+
+
+def test_prepare_pr_arch_lenses_route_checks_ingredient(recipe):
+    step = recipe.steps["prepare_pr"]
+    arch_lens_condition = next(
+        (c for c in step.on_result.conditions if c.route == "run_arch_lenses" and c.when),
+        None,
+    )
+    assert arch_lens_condition is not None
+    assert "arch_lenses" in arch_lens_condition.when
+
+
+def test_run_arch_lenses_still_gated_on_open_pr(recipe):
+    step = recipe.steps["run_arch_lenses"]
+    assert step.skip_when_false == "inputs.open_pr"
+
+
+def test_recipe_validates_clean(recipe):
+    errors = validate_recipe(recipe)
+    assert not errors, f"Validation errors: {errors}"

--- a/tests/recipe/test_implementation_groups_pr_decomposition.py
+++ b/tests/recipe/test_implementation_groups_pr_decomposition.py
@@ -25,8 +25,13 @@ def test_arch_lenses_defaults_to_true(recipe):
 
 def test_prepare_pr_routes_to_compose_pr_when_arch_lenses_false(recipe):
     step = recipe.steps["prepare_pr"]
-    routes = [c.route for c in step.on_result.conditions if c.when and "prep_path" in c.when]
-    assert "compose_pr" in routes
+    compose_cond = next(
+        (c for c in step.on_result.conditions if c.route == "compose_pr" and c.when),
+        None,
+    )
+    assert compose_cond is not None
+    assert "prep_path" in compose_cond.when
+    assert "arch_lenses" not in compose_cond.when
 
 
 def test_prepare_pr_arch_lenses_route_checks_ingredient(recipe):

--- a/tests/recipe/test_implementation_pr_decomposition.py
+++ b/tests/recipe/test_implementation_pr_decomposition.py
@@ -66,6 +66,40 @@ def test_compose_pr_captures_pr_url(recipe):
     assert "pr_url" in (step.capture or {})
 
 
+def test_arch_lenses_ingredient_declared(recipe):
+    assert "arch_lenses" in recipe.ingredients
+
+
+def test_arch_lenses_defaults_to_true(recipe):
+    assert recipe.ingredients["arch_lenses"].default == "true"
+
+
+def test_arch_lenses_is_not_hidden(recipe):
+    assert recipe.ingredients["arch_lenses"].hidden is False
+
+
+def test_prepare_pr_routes_to_compose_pr_when_arch_lenses_false(recipe):
+    step = recipe.steps["prepare_pr"]
+    assert step.on_result is not None
+    routes = [c.route for c in step.on_result.conditions if c.when and "prep_path" in c.when]
+    assert "compose_pr" in routes
+
+
+def test_prepare_pr_arch_lenses_route_checks_ingredient(recipe):
+    step = recipe.steps["prepare_pr"]
+    arch_lens_condition = next(
+        (c for c in step.on_result.conditions if c.route == "run_arch_lenses" and c.when),
+        None,
+    )
+    assert arch_lens_condition is not None
+    assert "arch_lenses" in arch_lens_condition.when
+
+
+def test_run_arch_lenses_still_gated_on_open_pr(recipe):
+    step = recipe.steps["run_arch_lenses"]
+    assert step.skip_when_false == "inputs.open_pr"
+
+
 def test_implementation_recipe_validates_after_decomposition(recipe):
     errors = validate_recipe(recipe)
     assert not errors, f"Validation errors: {errors}"

--- a/tests/recipe/test_remediation_pr_decomposition.py
+++ b/tests/recipe/test_remediation_pr_decomposition.py
@@ -64,6 +64,40 @@ def test_compose_pr_captures_pr_url(recipe):
     assert "pr_url" in (step.capture or {})
 
 
+def test_arch_lenses_ingredient_declared(recipe):
+    assert "arch_lenses" in recipe.ingredients
+
+
+def test_arch_lenses_defaults_to_true(recipe):
+    assert recipe.ingredients["arch_lenses"].default == "true"
+
+
+def test_arch_lenses_is_not_hidden(recipe):
+    assert recipe.ingredients["arch_lenses"].hidden is False
+
+
+def test_prepare_pr_routes_to_compose_pr_when_arch_lenses_false(recipe):
+    step = recipe.steps["prepare_pr"]
+    assert step.on_result is not None
+    routes = [c.route for c in step.on_result.conditions if c.when and "prep_path" in c.when]
+    assert "compose_pr" in routes
+
+
+def test_prepare_pr_arch_lenses_route_checks_ingredient(recipe):
+    step = recipe.steps["prepare_pr"]
+    arch_lens_condition = next(
+        (c for c in step.on_result.conditions if c.route == "run_arch_lenses" and c.when),
+        None,
+    )
+    assert arch_lens_condition is not None
+    assert "arch_lenses" in arch_lens_condition.when
+
+
+def test_run_arch_lenses_still_gated_on_open_pr(recipe):
+    step = recipe.steps["run_arch_lenses"]
+    assert step.skip_when_false == "inputs.open_pr"
+
+
 def test_remediation_recipe_validates_after_decomposition(recipe):
     errors = validate_recipe(recipe)
     assert not errors, f"Validation errors: {errors}"


### PR DESCRIPTION
## Summary

Add a new `arch_lenses` boolean ingredient (default: `"true"`) to `implementation.yaml`, `implementation-groups.yaml`, and `remediation.yaml` that controls whether the `run_arch_lenses` step executes, independently of the `open_pr` ingredient. When `arch_lenses=false`, `prepare_pr` routes directly to `compose_pr`, bypassing `run_arch_lenses`. Default behavior is preserved (lenses run when `open_pr=true`).

**Key design decision:** The `skip_when_false` field only supports a single `inputs.<name>` reference (validated by `rules_bypass.py:66`). Compound conditions like `inputs.open_pr AND inputs.arch_lenses` are rejected by the static validator. The solution uses `prepare_pr`'s `on_result` routing to check `arch_lenses`, while keeping `run_arch_lenses`'s `skip_when_false: "inputs.open_pr"` unchanged. This matches the established `action: route` + `on_result` pattern used elsewhere (e.g., `route_queue_mode` at `implementation.yaml:860`).

## Architecture Impact

### Process Flow Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    %% TERMINALS %%
    START([START<br/>━━━━━━━━━━<br/>merge completes<br/>push_to_remote done])
    COMPLETE([COMPLETE<br/>━━━━━━━━━━<br/>PR opened, CI/merge<br/>pipeline continues])
    ERROR([ERROR<br/>━━━━━━━━━━<br/>release_issue_failure])

    %% INGREDIENT INPUTS %%
    subgraph Ingredients ["● Ingredient Inputs"]
        direction LR
        ING_OPEN_PR["open_pr<br/>━━━━━━━━━━<br/>default: true"]
        ING_ARCH["● arch_lenses<br/>━━━━━━━━━━<br/>default: true<br/>NEW ingredient"]
    end

    subgraph PrePR ["Pre-PR Guard"]
        direction TB
        SKIP_CHECK{"open_pr?<br/>━━━━━━━━━━<br/>skip_when_false<br/>guard"}
    end

    subgraph PRPrep ["● PR Preparation Phase"]
        direction TB
        PREPARE["● prepare_pr<br/>━━━━━━━━━━<br/>run_skill: prepare-pr<br/>captures: prep_path,<br/>selected_lenses,<br/>lens_context_paths"]
        ROUTE_LENSES{"● arch_lenses<br/>routing gate<br/>━━━━━━━━━━<br/>MODIFIED<br/>on_result cascade"}
    end

    subgraph ArchLens ["Arch Lens Execution"]
        direction TB
        RUN_LENSES["run_arch_lenses<br/>━━━━━━━━━━<br/>run_skill: arch-lens-slug<br/>per lens in parallel<br/>captures: all_diagram_paths"]
    end

    subgraph PRCompose ["PR Composition"]
        direction TB
        COMPOSE["compose_pr<br/>━━━━━━━━━━<br/>run_skill: compose-pr<br/>captures: pr_url"]
        EXTRACT["extract_pr_number<br/>━━━━━━━━━━<br/>run_cmd: parse PR#"]
        ANNOTATE["annotate_pr_diff<br/>━━━━━━━━━━<br/>run_python: diff annotation"]
    end

    subgraph ReviewLoop ["Review Loop"]
        direction TB
        REVIEW_PR["review_pr<br/>━━━━━━━━━━<br/>run_skill: review-pr"]
        REVIEW_DECIDE{"review<br/>verdict?"}
        RESOLVE["resolve_review<br/>━━━━━━━━━━<br/>run_skill: resolve-review<br/>re_push_review"]
        CHECK_LOOP{"check_review_loop<br/>━━━━━━━━━━<br/>max retries?"}
    end

    subgraph CIMerge ["CI & Merge"]
        direction TB
        CI_WATCH["check_repo_ci_event<br/>━━━━━━━━━━<br/>CI watch pipeline"]
        MERGE_ROUTE{"route_queue_mode<br/>━━━━━━━━━━<br/>queue / direct /<br/>immediate"}
        RELEASE_OK["release_issue_success<br/>━━━━━━━━━━<br/>patch_token_summary<br/>register_clone"]
    end

    %% CONNECTIONS %%
    START --> SKIP_CHECK
    ING_OPEN_PR -.->|"gates"| SKIP_CHECK
    ING_ARCH -.->|"gates"| ROUTE_LENSES

    SKIP_CHECK -->|"open_pr = true"| PREPARE
    SKIP_CHECK -->|"open_pr = false<br/>skip entire PR phase"| COMPLETE

    PREPARE --> ROUTE_LENSES
    PREPARE -->|"failure / context_limit"| ERROR

    ROUTE_LENSES -->|"prep_path AND<br/>arch_lenses != false"| RUN_LENSES
    ROUTE_LENSES -->|"prep_path AND<br/>arch_lenses = false<br/>● NEW ROUTE"| COMPOSE
    ROUTE_LENSES -->|"no prep_path"| ERROR

    RUN_LENSES -->|"success / failure /<br/>context_limit"| COMPOSE

    COMPOSE --> EXTRACT --> ANNOTATE --> REVIEW_PR

    REVIEW_PR --> REVIEW_DECIDE
    REVIEW_DECIDE -->|"changes_requested /<br/>approved_with_comments"| RESOLVE
    REVIEW_DECIDE -->|"approved /<br/>needs_human"| CI_WATCH
    RESOLVE --> CHECK_LOOP
    CHECK_LOOP -->|"had_blocking AND<br/>retries remaining"| REVIEW_PR
    CHECK_LOOP -->|"max exceeded OR<br/>no blocking"| CI_WATCH

    CI_WATCH --> MERGE_ROUTE
    MERGE_ROUTE --> RELEASE_OK
    RELEASE_OK --> COMPLETE

    REVIEW_PR -->|"failure"| ERROR

    %% CLASS ASSIGNMENTS %%
    class START,COMPLETE,ERROR terminal;
    class ING_OPEN_PR,ING_ARCH stateNode;
    class SKIP_CHECK,ROUTE_LENSES,REVIEW_DECIDE,MERGE_ROUTE,CHECK_LOOP stateNode;
    class PREPARE,RUN_LENSES handler;
    class COMPOSE,EXTRACT,ANNOTATE handler;
    class REVIEW_PR,RESOLVE handler;
    class CI_WATCH,RELEASE_OK phase;
```

### State Lifecycle Diagram

```mermaid
%%{init: {'flowchart': {'nodeSpacing': 50, 'rankSpacing': 60, 'curve': 'basis'}}}%%
flowchart TB
    %% CLASS DEFINITIONS %%
    classDef cli fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;
    classDef stateNode fill:#004d40,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef handler fill:#e65100,stroke:#ffb74d,stroke-width:2px,color:#fff;
    classDef phase fill:#6a1b9a,stroke:#ba68c8,stroke-width:2px,color:#fff;
    classDef newComponent fill:#2e7d32,stroke:#81c784,stroke-width:2px,color:#fff;
    classDef output fill:#00695c,stroke:#4db6ac,stroke-width:2px,color:#fff;
    classDef detector fill:#b71c1c,stroke:#ef5350,stroke-width:2px,color:#fff;
    classDef gap fill:#ff6f00,stroke:#ffa726,stroke-width:2px,color:#000;
    classDef terminal fill:#1a237e,stroke:#7986cb,stroke-width:2px,color:#fff;

    START([START: Recipe Load])

    subgraph InitOnly ["INIT_ONLY — Frozen at Parse"]
        direction TB
        RECIPE_IDENT["Recipe Identity<br/>━━━━━━━━━━<br/>name, version, kind<br/>recipe_version: str guard"]
        STEP_DEFS["RecipeStep Definitions<br/>━━━━━━━━━━<br/>tool, action, routing<br/>capture, capture_list"]
        INGR_DECL["● Ingredient Declarations<br/>━━━━━━━━━━<br/>● arch_lenses: default true<br/>open_pr, open_issue"]
    end

    subgraph ParseGates ["VALIDATION GATES — Import & Load Time"]
        direction TB
        FIELD_SYNC["_PARSE_STEP_HANDLED_FIELDS<br/>━━━━━━━━━━<br/>Import-time sync guard<br/>Fails if RecipeStep field<br/>missing from _parse_step"]
        VERSION_GUARD["recipe_version Type Guard<br/>━━━━━━━━━━<br/>Must be str or absent<br/>ValueError before construction"]
        STRUCT_VALID["validate_recipe<br/>━━━━━━━━━━<br/>Discriminator exclusivity<br/>Route target existence<br/>Capture template syntax"]
    end

    subgraph SemanticGates ["SEMANTIC RULES — Post-Validation"]
        direction TB
        SKIP_RULE["skip-when-false-undeclared<br/>━━━━━━━━━━<br/>inputs.X must name<br/>declared ingredient"]
        DATAFLOW["contract-unsatisfied-input<br/>━━━━━━━━━━<br/>Required skill inputs<br/>must be capturable"]
        REACHABILITY["on_result route validation<br/>━━━━━━━━━━<br/>All condition routes<br/>must reach known steps"]
    end

    subgraph ComputedState ["INIT_PRESERVE — Computed Once"]
        direction TB
        HASH["content_hash<br/>━━━━━━━━━━<br/>compute_recipe_hash<br/>After _parse_recipe"]
        BLOCKS["blocks: tuple<br/>━━━━━━━━━━<br/>extract_blocks from<br/>step graph — immutable"]
    end

    subgraph RoutingGate ["● INGREDIENT ROUTING GATE — on_result Predicate"]
        direction TB
        PREP_PR["● prepare_pr Step<br/>━━━━━━━━━━<br/>capture: prep_path,<br/>selected_lenses,<br/>lens_context_paths"]
        COND_CHECK{"● on_result Predicate<br/>━━━━━━━━━━<br/>prep_path AND<br/>arch_lenses != false?"}
        ARCH_LENS["● run_arch_lenses Step<br/>━━━━━━━━━━<br/>capture_list:<br/>all_diagram_paths<br/>APPEND_ONLY"]
        COMPOSE_PR["● compose_pr Step<br/>━━━━━━━━━━<br/>capture: pr_url<br/>success+failure → here"]
    end

    subgraph RuntimeCtx ["MUTABLE — Runtime Context Variables"]
        direction TB
        CTX_SCALAR["Scalar Captures<br/>━━━━━━━━━━<br/>prep_path, pr_url<br/>selected_lenses"]
        CTX_LIST["List Captures<br/>━━━━━━━━━━<br/>all_diagram_paths<br/>APPEND_ONLY growth"]
    end

    subgraph ResumeDetect ["RESUME DETECTION — Routing-Based"]
        direction TB
        TIER1["Tier 1: on_context_limit<br/>━━━━━━━━━━<br/>Re-entry step declared<br/>per RecipeStep field"]
        TIER2["Tier 2: on_exhausted<br/>━━━━━━━━━━<br/>After retry budget<br/>Default: escalate"]
        TIER3["Tier 3: Fresh Start<br/>━━━━━━━━━━<br/>No checkpoint state<br/>Begin from first step"]
    end

    END([END: Pipeline Continues])

    %% FLOW %%
    START --> RECIPE_IDENT
    START --> STEP_DEFS
    START --> INGR_DECL

    RECIPE_IDENT --> FIELD_SYNC
    STEP_DEFS --> FIELD_SYNC
    INGR_DECL --> FIELD_SYNC

    FIELD_SYNC --> VERSION_GUARD
    VERSION_GUARD --> STRUCT_VALID
    STRUCT_VALID --> SKIP_RULE
    SKIP_RULE --> DATAFLOW
    DATAFLOW --> REACHABILITY

    REACHABILITY --> HASH
    REACHABILITY --> BLOCKS

    HASH --> PREP_PR
    BLOCKS --> PREP_PR

    PREP_PR --> COND_CHECK
    COND_CHECK -- "arch_lenses=true" --> ARCH_LENS
    COND_CHECK -- "arch_lenses=false" --> COMPOSE_PR
    ARCH_LENS -- "success OR failure" --> COMPOSE_PR

    COMPOSE_PR --> CTX_SCALAR
    ARCH_LENS --> CTX_LIST

    COMPOSE_PR --> TIER1
    TIER1 --> TIER2
    TIER2 --> TIER3
    TIER3 --> END

    %% CLASS ASSIGNMENTS %%
    class RECIPE_IDENT,STEP_DEFS detector;
    class INGR_DECL gap;
    class FIELD_SYNC,VERSION_GUARD,STRUCT_VALID stateNode;
    class SKIP_RULE,DATAFLOW,REACHABILITY detector;
    class HASH,BLOCKS output;
    class PREP_PR,COMPOSE_PR handler;
    class COND_CHECK phase;
    class ARCH_LENS handler;
    class CTX_SCALAR phase;
    class CTX_LIST handler;
    class TIER1,TIER2,TIER3 cli;
    class START,END terminal;
```

Closes #1435

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260429-082256-841069/.autoskillit/temp/make-plan/add_arch_lenses_ingredient_plan_2026-04-29_083500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 72 | 26.1k | 1.8M | 86.3k | 1 | 15m 25s |
| verify | 2.5k | 7.2k | 650.6k | 52.4k | 1 | 5m 4s |
| implement | 42 | 10.8k | 1.2M | 56.9k | 1 | 4m 57s |
| prepare_pr | 24 | 3.0k | 145.1k | 50.1k | 1 | 1m 2s |
| run_arch_lenses | 1.8k | 10.5k | 477.6k | 66.3k | 2 | 7m 17s |
| compose_pr | 23 | 6.2k | 182.2k | 29.6k | 1 | 1m 41s |
| review_pr | 28 | 17.4k | 408.1k | 46.6k | 1 | 4m 46s |
| resolve_review | 41 | 6.5k | 976.5k | 40.4k | 1 | 5m 56s |
| **Total** | 4.6k | 87.5k | 5.9M | 428.6k | | 46m 13s |