### PR TITLE
Fix SkillResult.to_json() Missing fs_writes_detected Field

### DIFF
--- a/src/autoskillit/core/_type_results.py
+++ b/src/autoskillit/core/_type_results.py
@@ -180,6 +180,7 @@ class SkillResult:
             "token_usage": self.token_usage,
             "write_path_warnings": self.write_path_warnings,
             "write_call_count": self.write_call_count,
+            "fs_writes_detected": self.fs_writes_detected,
             "last_stop_reason": self.last_stop_reason,
             "lifespan_started": self.lifespan_started,
         }

--- a/tests/execution/test_headless_core.py
+++ b/tests/execution/test_headless_core.py
@@ -818,6 +818,7 @@ class TestBuildSkillResultCrossValidation:
         "token_usage",
         "write_path_warnings",
         "write_call_count",
+        "fs_writes_detected",
     }
 
     def test_empty_stdout_exit_zero_is_failure(self):

--- a/tests/execution/test_session_parsing.py
+++ b/tests/execution/test_session_parsing.py
@@ -543,6 +543,7 @@ class TestSkillResult:
             "token_usage",
             "write_path_warnings",
             "write_call_count",
+            "fs_writes_detected",
         }
         assert set(parsed.keys()) == expected
 

--- a/tests/execution/test_zero_write_detection.py
+++ b/tests/execution/test_zero_write_detection.py
@@ -670,8 +670,8 @@ class TestFilesystemWriteDetection:
         assert sr.success is False
         assert sr.subtype == "zero_writes"
 
-    def test_fs_writes_detected_in_to_json_excluded(self) -> None:
-        """fs_writes_detected must NOT appear in to_json() output."""
+    def test_fs_writes_detected_in_to_json_included(self) -> None:
+        """fs_writes_detected must appear in to_json() output."""
         stdout = _ndjson_with_tool_uses(["Edit"])
         sr = _build_skill_result(
             _make_result(returncode=0, stdout=stdout),
@@ -680,7 +680,7 @@ class TestFilesystemWriteDetection:
             fs_writes_detected=True,
         )
         json_data = json.loads(sr.to_json())
-        assert "fs_writes_detected" not in json_data
+        assert json_data["fs_writes_detected"] is True
 
 
 class TestTempDirSnapshot:


### PR DESCRIPTION
## Summary

`SkillResult.to_json()` serializes the SkillResult envelope for the `run_skill` MCP tool response but omits the `fs_writes_detected` boolean field. The fix adds the field unconditionally to the `data` dict in `to_json()`, matching the pattern of other boolean fields (`success`, `is_error`, `needs_retry`, `lifespan_started`). Three tests must be updated: one that asserts the field is absent (flip to assert it is present) and two that assert the full key set (add the new key to each, bringing the count from 16 to 17).

Closes #1525

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-1525-20260429-113839-885099/.autoskillit/temp/make-plan/fix_skillresult_to_json_missing_fs_writes_detected_plan_2026-04-29_140000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 87 | 6.2k | 382.1k | 43.8k | 1 | 2m 49s |
| verify | 32 | 5.3k | 556.5k | 54.4k | 1 | 5m 10s |
| implement | 100 | 4.4k | 385.4k | 30.7k | 1 | 1m 19s |
| prepare_pr | 60 | 4.4k | 198.2k | 24.7k | 1 | 1m 38s |
| compose_pr | 83 | 3.0k | 278.0k | 19.7k | 1 | 60s |
| review_pr | 108 | 14.6k | 484.0k | 39.1k | 1 | 3m 0s |
| **Total** | 470 | 37.8k | 2.3M | 212.3k | | 14m 57s |