### PR TITLE
Implementation Plan: P1 — Relocate session_type() from _type_enums.py to _type_helpers.py

### DIFF
--- a/src/autoskillit/core/_type_enums.py
+++ b/src/autoskillit/core/_type_enums.py
@@ -5,8 +5,6 @@ Zero autoskillit imports. Provides the shared enum vocabulary for all higher lay
 
 from __future__ import annotations
 
-import os
-import warnings
 from enum import StrEnum, unique
 
 __all__ = [
@@ -28,7 +26,6 @@ __all__ = [
     "ChannelBStatus",
     "PRState",
     "SessionType",
-    "session_type",
     "FleetErrorCode",
     "FeatureLifecycle",
     "DispatchGateType",
@@ -348,40 +345,6 @@ class SessionType(StrEnum):
     FLEET = "fleet"
     ORCHESTRATOR = "orchestrator"
     LEAF = "leaf"
-
-
-_SESSION_TYPE_ENV_VAR = "AUTOSKILLIT_SESSION_TYPE"
-_HEADLESS_ENV_VAR = "AUTOSKILLIT_HEADLESS"
-
-
-def session_type() -> SessionType:
-    """Resolve current session type from AUTOSKILLIT_SESSION_TYPE env var.
-
-    Fail-closed: returns LEAF on unset or invalid values.
-    Transitional bridge: HEADLESS=1 without SESSION_TYPE emits DeprecationWarning.
-    """
-    raw = os.environ.get(_SESSION_TYPE_ENV_VAR, "")
-    if raw:
-        raw_lower = raw.lower()
-        try:
-            return SessionType(raw_lower)
-        except ValueError:
-            warnings.warn(
-                f"Invalid {_SESSION_TYPE_ENV_VAR}={raw!r}, defaulting to LEAF. "
-                f"Valid values: {', '.join(m.value for m in SessionType)}",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            return SessionType.LEAF
-    # Transitional bridge: HEADLESS=1 without SESSION_TYPE → LEAF with warning
-    if os.environ.get(_HEADLESS_ENV_VAR) == "1":
-        warnings.warn(
-            f"{_HEADLESS_ENV_VAR}=1 without {_SESSION_TYPE_ENV_VAR} set. "
-            "Defaulting to LEAF. Set AUTOSKILLIT_SESSION_TYPE explicitly.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-    return SessionType.LEAF
 
 
 @unique

--- a/src/autoskillit/core/_type_helpers.py
+++ b/src/autoskillit/core/_type_helpers.py
@@ -1,17 +1,25 @@
 """Core skill name resolution and text-processing helpers.
 
 Zero autoskillit imports outside this sub-package. Provides extract_skill_name,
-extract_path_arg, resolve_target_skill, truncate_text, and fleet_error.
+extract_path_arg, resolve_target_skill, truncate_text, fleet_error, and session_type.
 """
 
 from __future__ import annotations
 
 import json
+import os
 import re
+import warnings
 from typing import Any
 
-from ._type_constants import AUTOSKILLIT_SKILL_PREFIX, FLEET_ERROR_CODES, SKILL_COMMAND_PREFIX
-from ._type_enums import SkillSource
+from ._type_constants import (
+    AUTOSKILLIT_SKILL_PREFIX,
+    FLEET_ERROR_CODES,
+    HEADLESS_ENV_VAR,
+    SESSION_TYPE_ENV_VAR,
+    SKILL_COMMAND_PREFIX,
+)
+from ._type_enums import SessionType, SkillSource
 from ._type_protocols_workspace import SkillResolver
 
 __all__ = [
@@ -19,6 +27,7 @@ __all__ = [
     "extract_skill_name",
     "fleet_error",
     "resolve_target_skill",
+    "session_type",
     "truncate_text",
 ]
 
@@ -124,3 +133,33 @@ def fleet_error(
             "details": details,
         }
     )
+
+
+def session_type() -> SessionType:
+    """Resolve current session type from AUTOSKILLIT_SESSION_TYPE env var.
+
+    Fail-closed: returns LEAF on unset or invalid values.
+    Transitional bridge: HEADLESS=1 without SESSION_TYPE emits DeprecationWarning.
+    """
+    raw = os.environ.get(SESSION_TYPE_ENV_VAR, "")
+    if raw:
+        raw_lower = raw.lower()
+        try:
+            return SessionType(raw_lower)
+        except ValueError:
+            warnings.warn(
+                f"Invalid {SESSION_TYPE_ENV_VAR}={raw!r}, defaulting to LEAF. "
+                f"Valid values: {', '.join(m.value for m in SessionType)}",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return SessionType.LEAF
+    # Transitional bridge: HEADLESS=1 without SESSION_TYPE → LEAF with warning
+    if os.environ.get(HEADLESS_ENV_VAR) == "1":
+        warnings.warn(
+            f"{HEADLESS_ENV_VAR}=1 without {SESSION_TYPE_ENV_VAR} set. "
+            "Defaulting to LEAF. Set AUTOSKILLIT_SESSION_TYPE explicitly.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+    return SessionType.LEAF

--- a/src/autoskillit/core/_type_helpers.py
+++ b/src/autoskillit/core/_type_helpers.py
@@ -154,7 +154,6 @@ def session_type() -> SessionType:
                 stacklevel=2,
             )
             return SessionType.LEAF
-    # Transitional bridge: HEADLESS=1 without SESSION_TYPE → LEAF with warning
     if os.environ.get(HEADLESS_ENV_VAR) == "1":
         warnings.warn(
             f"{HEADLESS_ENV_VAR}=1 without {SESSION_TYPE_ENV_VAR} set. "

--- a/tests/core/test_session_type.py
+++ b/tests/core/test_session_type.py
@@ -154,8 +154,10 @@ def test_session_type_is_defined_in_type_helpers():
     from autoskillit.core._type_helpers import session_type as fn_helpers
 
     type_enums = importlib.import_module("autoskillit.core._type_enums")
+    importlib.reload(type_enums)
     assert not hasattr(type_enums, "session_type"), (
         "session_type must not be defined in _type_enums after relocation"
     )
 
     assert inspect.getmodule(fn_helpers).__name__ == "autoskillit.core._type_helpers"
+    assert inspect.getfile(fn_helpers).endswith("_type_helpers.py")

--- a/tests/core/test_session_type.py
+++ b/tests/core/test_session_type.py
@@ -139,3 +139,23 @@ def test_session_type_fleet_constant_matches_enum():
     from autoskillit.core._type_constants import SESSION_TYPE_FLEET
 
     assert SessionType.FLEET.value == SESSION_TYPE_FLEET
+
+
+# ---------------------------------------------------------------------------
+# Group D — Module placement
+# ---------------------------------------------------------------------------
+
+
+def test_session_type_is_defined_in_type_helpers():
+    """session_type() must live in _type_helpers, not _type_enums."""
+    import importlib
+    import inspect
+
+    from autoskillit.core._type_helpers import session_type as fn_helpers
+
+    type_enums = importlib.import_module("autoskillit.core._type_enums")
+    assert not hasattr(type_enums, "session_type"), (
+        "session_type must not be defined in _type_enums after relocation"
+    )
+
+    assert inspect.getmodule(fn_helpers).__name__ == "autoskillit.core._type_helpers"


### PR DESCRIPTION
## Summary

`session_type()` is a runtime env-reader function that currently lives in `_type_enums.py` — a file whose stated purpose is "Core StrEnum discriminators. Zero autoskillit imports." Runtime logic that reads env vars and emits warnings has no place in a pure type-definition module. The function belongs in `_type_helpers.py`, which already houses runtime helpers.

The function also uses two private constants (`_SESSION_TYPE_ENV_VAR`, `_HEADLESS_ENV_VAR`) that duplicate public constants already defined in `_type_constants.py` (`SESSION_TYPE_ENV_VAR`, `HEADLESS_ENV_VAR`). Moving the function eliminates this duplication.

The export chain is unaffected: `types.py` star-imports from both `_type_enums` and `_type_helpers`, so `from autoskillit.core import session_type` continues to resolve correctly. The `__init__.pyi` stub already has `from .types import session_type as session_type`.

Closes #1524

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-1524-20260429-131441-118370/.autoskillit/temp/make-plan/p1_relocate_session_type_plan_2026-04-29_131500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 181 | 10.4k | 946.0k | 54.3k | 1 | 4m 31s |
| verify | 1.3k | 6.2k | 618.1k | 60.0k | 1 | 4m 3s |
| implement | 140 | 6.4k | 624.9k | 33.7k | 1 | 2m 6s |
| prepare_pr | 76 | 4.0k | 254.6k | 38.7k | 1 | 1m 13s |
| compose_pr | 59 | 1.9k | 185.4k | 18.5k | 1 | 35s |
| review_pr | 124 | 22.8k | 669.4k | 51.4k | 1 | 4m 34s |
| resolve_review | 259 | 13.9k | 1.4M | 50.4k | 1 | 6m 29s |
| **Total** | 2.1k | 65.7k | 4.7M | 307.1k | | 23m 32s |