### PR TITLE
Implementation Plan: P1 — Type Annotation Tightening in Core

### DIFF
--- a/src/autoskillit/core/_type_protocols_recipe.py
+++ b/src/autoskillit/core/_type_protocols_recipe.py
@@ -29,7 +29,7 @@ class RecipeRepository(Protocol):
     def load_and_validate(
         self,
         name: str,
-        project_dir: Any,
+        project_dir: Path | str,
         *,
         suppressed: Sequence[str] | None = None,
         resolved_defaults: dict[str, str] | None = None,

--- a/src/autoskillit/core/_type_subprocess.py
+++ b/src/autoskillit/core/_type_subprocess.py
@@ -16,7 +16,6 @@ from ._type_enums import ChannelConfirmation, KillReason, TerminationReason
 __all__ = [
     "SubprocessResult",
     "SubprocessRunner",
-    "_TERMINATION_CONTRACT",
 ]
 
 #: Semantic contract for SubprocessResult fields per TerminationReason.

--- a/src/autoskillit/recipe/repository.py
+++ b/src/autoskillit/recipe/repository.py
@@ -77,7 +77,7 @@ class DefaultRecipeRepository:
     def load_and_validate(
         self,
         name: str,
-        project_dir: Any,
+        project_dir: Path | str,
         *,
         suppressed: Sequence[str] | None = None,
         resolved_defaults: dict[str, str] | None = None,
@@ -85,6 +85,7 @@ class DefaultRecipeRepository:
         temp_dir: Path | None = None,
         temp_dir_relpath: str | None = None,
     ) -> dict[str, Any]:
+        project_dir = Path(project_dir)
         recipe_info = self.find(name, project_dir)
         return cast(
             dict[str, Any],

--- a/tests/contracts/test_protocol_definitions.py
+++ b/tests/contracts/test_protocol_definitions.py
@@ -45,3 +45,16 @@ def test_skill_resolver_satisfies_skill_lister() -> None:
 
     instance: SkillLister = DefaultSkillResolver()
     assert callable(instance.list_all)
+
+
+def test_recipe_repository_load_and_validate_project_dir_annotation() -> None:
+    import typing
+    from pathlib import Path
+
+    from autoskillit.core._type_protocols_recipe import RecipeRepository
+
+    hints = typing.get_type_hints(RecipeRepository.load_and_validate)
+    ann = hints["project_dir"]
+    args = typing.get_args(ann)
+    assert Path in args, f"Expected Path in annotation args, got: {ann}"
+    assert str in args, f"Expected str in annotation args, got: {ann}"

--- a/tests/core/test_types_structure.py
+++ b/tests/core/test_types_structure.py
@@ -94,6 +94,6 @@ def test_subprocess_shard_all() -> None:
 
 
 def test_subprocess_termination_contract_variable_still_defined() -> None:
-    from autoskillit.core._type_subprocess import _TERMINATION_CONTRACT
+    import autoskillit.core._type_subprocess as m
 
-    assert _TERMINATION_CONTRACT is None
+    assert hasattr(m, "_TERMINATION_CONTRACT")

--- a/tests/core/test_types_structure.py
+++ b/tests/core/test_types_structure.py
@@ -84,3 +84,16 @@ def test_supports_debug_in_core_all() -> None:
     import autoskillit.core as core_mod
 
     assert hasattr(core_mod, "SupportsDebug")
+
+
+def test_subprocess_shard_all() -> None:
+    from autoskillit.core._type_subprocess import __all__
+
+    assert set(__all__) == {"SubprocessResult", "SubprocessRunner"}
+    assert "_TERMINATION_CONTRACT" not in __all__
+
+
+def test_subprocess_termination_contract_variable_still_defined() -> None:
+    from autoskillit.core._type_subprocess import _TERMINATION_CONTRACT
+
+    assert _TERMINATION_CONTRACT is None

--- a/tests/recipe/test_repository.py
+++ b/tests/recipe/test_repository.py
@@ -224,3 +224,21 @@ def test_in_memory_recipe_repo_rejects_recipe_objects() -> None:
     repo = InMemoryRecipeRepository()
     with pytest.raises(TypeError, match="RecipeInfo"):
         repo.add_recipe("x", Recipe(name="x", description="x"))
+
+
+def test_load_and_validate_coerces_str_project_dir_to_path(tmp_path: Path) -> None:
+    mock_api = MagicMock(return_value={})
+    foo = _make_recipe_info("test-recipe", tmp_path / "test-recipe.yaml")
+    str_dir = str(tmp_path)
+
+    with patch("autoskillit.recipe._api.load_and_validate", mock_api):
+        with patch("autoskillit.recipe.repository.list_recipes", return_value=_load_result(foo)):
+            with patch("autoskillit.recipe.repository._dir_mtime", return_value=1.0):
+                repo = DefaultRecipeRepository()
+                repo.load_and_validate("test-recipe", str_dir)
+
+    call_kwargs = mock_api.call_args
+    assert isinstance(call_kwargs.kwargs["project_dir"], Path), (
+        f"Expected Path, got {type(call_kwargs.kwargs['project_dir'])}"
+    )
+    assert call_kwargs.kwargs["project_dir"] == tmp_path


### PR DESCRIPTION
## Summary

Three focused type-hygiene fixes in the core layer:

1. **WP1** — Tighten `RecipeRepository.load_and_validate()` Protocol signature: `project_dir: Any` → `project_dir: Path | str` in `_type_protocols_recipe.py`.
2. **WP2** — Match the concrete `DefaultRecipeRepository.load_and_validate()` in `recipe/repository.py`: same parameter tightening plus a `Path(project_dir)` coercion guard before first use.
3. **WP3** — Remove `_TERMINATION_CONTRACT` from `_type_subprocess.__all__` while leaving the variable definition intact.

No new abstractions are required. Changes are surgical: two parameter annotation edits, one coercion line inserted, one `__all__` entry removed.

Closes #1526

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-1526-20260429-131442-048814/.autoskillit/temp/make-plan/p1_type_annotation_tightening_plan_2026-04-29_131442.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 87 | 8.5k | 382.8k | 42.2k | 1 | 5m 44s |
| verify | 49 | 16.2k | 1.2M | 72.8k | 1 | 8m 38s |
| implement | 132 | 6.7k | 753.2k | 53.6k | 1 | 1m 50s |
| prepare_pr | 60 | 4.3k | 183.8k | 47.4k | 1 | 1m 17s |
| compose_pr | 51 | 1.9k | 155.5k | 18.5k | 1 | 42s |
| review_pr | 118 | 18.4k | 519.0k | 58.5k | 1 | 3m 40s |
| resolve_review | 205 | 7.3k | 978.7k | 42.1k | 1 | 5m 53s |
| **Total** | 702 | 63.3k | 4.1M | 335.1k | | 27m 46s |