### PR TITLE
P1 — Protocol @runtime_checkable Cleanup and Satisfaction Tests

### DIFF
--- a/src/autoskillit/core/_type_protocols_infra.py
+++ b/src/autoskillit/core/_type_protocols_infra.py
@@ -90,6 +90,7 @@ class TokenFactory(Protocol):
     def __call__(self) -> str | None: ...
 
 
+@runtime_checkable
 class CampaignProtector(Protocol):
     """Protocol for resolving the set of protected campaign IDs for session retention.
 

--- a/src/autoskillit/core/_type_protocols_logging.py
+++ b/src/autoskillit/core/_type_protocols_logging.py
@@ -150,12 +150,14 @@ class GitHubApiLog(Protocol):
     def clear(self) -> None: ...
 
 
+# Not @runtime_checkable: structural (duck-typing) protocol; isinstance() checks not needed.
 class SupportsDebug(Protocol):
     """Structural logger protocol — only the debug() method is required."""
 
     def debug(self, event: str, **kwargs: Any) -> None: ...
 
 
+# Not @runtime_checkable: structural (duck-typing) protocol; isinstance() checks not needed.
 class SupportsLogger(SupportsDebug, Protocol):
     """Structural logger protocol — debug() and error() methods required."""
 

--- a/tests/contracts/test_protocol_satisfaction_five.py
+++ b/tests/contracts/test_protocol_satisfaction_five.py
@@ -1,0 +1,133 @@
+"""Protocol satisfaction tests — Group Five (issue #1523).
+
+Covers: OutputPatternResolver, WriteExpectedResolver, QuotaRefreshTask,
+TokenFactory, CampaignProtector.
+
+Tests 7–9 require WP2 (@runtime_checkable on CampaignProtector) to pass.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+# ── WP3-1: OutputPatternResolver ──────────────────────────────────────────────
+
+
+def test_output_pattern_resolver_satisfied_by_minimal_callable():
+    from autoskillit.core import OutputPatternResolver
+
+    class _Resolver:
+        def __call__(self, skill_command: str) -> list[str]:
+            return []
+
+    assert isinstance(_Resolver(), OutputPatternResolver)
+
+
+# ── WP3-2: WriteExpectedResolver ──────────────────────────────────────────────
+
+
+def test_write_expected_resolver_satisfied_by_minimal_callable():
+    from autoskillit.core import WriteExpectedResolver
+
+    class _Resolver:
+        def __call__(self, skill_command: str) -> None:
+            pass
+
+    assert isinstance(_Resolver(), WriteExpectedResolver)
+
+
+# ── WP3-3: QuotaRefreshTask — asyncio.Task ────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_quota_refresh_task_satisfied_by_asyncio_task():
+    """asyncio.Task has a cancel() method — satisfies QuotaRefreshTask."""
+    import asyncio
+
+    from autoskillit.core import QuotaRefreshTask
+
+    async def _noop() -> None:
+        pass
+
+    task = asyncio.ensure_future(_noop())
+    try:
+        assert isinstance(task, QuotaRefreshTask)
+    finally:
+        task.cancel()
+
+
+# ── WP3-4: QuotaRefreshTask — minimal cancel class ────────────────────────────
+
+
+def test_quota_refresh_task_satisfied_by_minimal_cancel_class():
+    from autoskillit.core import QuotaRefreshTask
+
+    class _MinimalTask:
+        def cancel(self, msg: object = None) -> bool:
+            return True
+
+    assert isinstance(_MinimalTask(), QuotaRefreshTask)
+
+
+# ── WP3-5: TokenFactory — concrete server class ───────────────────────────────
+
+
+def test_token_factory_satisfied_by_server_concrete_class():
+    from autoskillit.core import TokenFactory
+    from autoskillit.server._factory import TokenFactory as ConcreteTokenFactory
+
+    instance = ConcreteTokenFactory(lambda: None)
+    assert isinstance(instance, TokenFactory)
+
+
+# ── WP3-6: TokenFactory — minimal callable ────────────────────────────────────
+
+
+def test_token_factory_satisfied_by_minimal_callable():
+    from autoskillit.core import TokenFactory
+
+    class _MinimalFactory:
+        def __call__(self) -> str | None:
+            return None
+
+    assert isinstance(_MinimalFactory(), TokenFactory)
+
+
+# ── WP3-7: CampaignProtector — is runtime_checkable ──────────────────────────
+
+
+def test_campaign_protector_is_runtime_checkable():
+    """Requires WP2: @runtime_checkable added to CampaignProtector."""
+    from autoskillit.core import CampaignProtector
+
+    assert getattr(CampaignProtector, "_is_runtime_protocol", False), (
+        "CampaignProtector must be decorated with @runtime_checkable"
+    )
+
+
+# ── WP3-8: CampaignProtector — build_protected_campaign_ids ──────────────────
+
+
+def test_campaign_protector_satisfied_by_build_protected_campaign_ids():
+    """Requires WP2: @runtime_checkable added to CampaignProtector."""
+    from autoskillit.core import CampaignProtector
+    from autoskillit.fleet import build_protected_campaign_ids
+
+    assert isinstance(build_protected_campaign_ids, CampaignProtector)
+
+
+# ── WP3-9: CampaignProtector — minimal callable ───────────────────────────────
+
+
+def test_campaign_protector_satisfied_by_minimal_callable():
+    """Requires WP2: @runtime_checkable added to CampaignProtector."""
+    from autoskillit.core import CampaignProtector
+
+    class _MinimalProtector:
+        def __call__(self, project_dir: Path) -> frozenset[str]:
+            return frozenset()
+
+    assert isinstance(_MinimalProtector(), CampaignProtector)

--- a/tests/contracts/test_protocol_satisfaction_five.py
+++ b/tests/contracts/test_protocol_satisfaction_five.py
@@ -12,7 +12,6 @@ from pathlib import Path
 
 import pytest
 
-
 # ── WP3-1: OutputPatternResolver ──────────────────────────────────────────────
 
 

--- a/tests/core/test_type_protocol_shards.py
+++ b/tests/core/test_type_protocol_shards.py
@@ -97,10 +97,9 @@ def test_pyi_stub_exports_skill_constants():
 
 
 def test_runtime_checkable_flags():
-    from autoskillit.core._type_protocols_infra import CampaignProtector
     from autoskillit.core._type_protocols_logging import SupportsDebug, SupportsLogger
 
-    for proto in (SupportsDebug, SupportsLogger, CampaignProtector):
+    for proto in (SupportsDebug, SupportsLogger):
         assert not getattr(proto, "_is_runtime_protocol", False), (
             f"{proto.__name__} must not be @runtime_checkable"
         )


### PR DESCRIPTION
## Summary

Three work packages from GitHub issue #1523:

1. **WP1** — Add `# Not @runtime_checkable` comments above `SupportsDebug` and `SupportsLogger` in `src/autoskillit/core/_type_protocols_logging.py` to document the intentional omission.
2. **WP2** — Add `@runtime_checkable` to `class CampaignProtector(Protocol):` in `src/autoskillit/core/_type_protocols_infra.py`.
3. **WP3** — Create `tests/contracts/test_protocol_satisfaction_five.py` with 9 satisfaction tests covering `OutputPatternResolver`, `WriteExpectedResolver`, `QuotaRefreshTask`, `TokenFactory`, and `CampaignProtector`.

The P1 shard migration (issue #1532) has already landed as commit `36fdb534`, so target the shard files (`_type_protocols_logging.py`, `_type_protocols_infra.py`) — not the old monolithic `_type_protocols.py`.

Closes #1523

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-1523-20260429-131442-612589/.autoskillit/temp/make-plan/p1_protocol_runtime_checkable_cleanup_plan_2026-04-29_131442.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 2.2k | 14.4k | 687.3k | 59.4k | 1 | 7m 31s |
| verify | 31 | 8.4k | 501.2k | 41.2k | 1 | 4m 54s |
| implement | 116 | 5.0k | 469.9k | 28.5k | 1 | 1m 52s |
| prepare_pr | 84 | 5.0k | 308.0k | 26.4k | 1 | 1m 26s |
| compose_pr | 51 | 1.9k | 155.8k | 18.6k | 1 | 43s |
| review_pr | 108 | 24.8k | 529.0k | 65.0k | 1 | 4m 12s |
| **Total** | 2.6k | 59.6k | 2.7M | 239.1k | | 20m 40s |