### PR TITLE
P2 — Execution Layer Test Coverage Gaps (A4 + A5 + A6)

### DIFF
--- a/tests/execution/test_headless_core.py
+++ b/tests/execution/test_headless_core.py
@@ -170,6 +170,76 @@ class TestSessionLogDir:
         assert result.exists()
         assert result.is_dir()
 
+    def test_session_log_dir_mkdir_oserror_reraises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from unittest.mock import Mock
+
+        from autoskillit.execution.headless import _session_log_dir
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "nonexistent_home")
+        monkeypatch.setattr(Path, "mkdir", Mock(side_effect=OSError("disk full")))
+
+        with pytest.raises(OSError, match="disk full"):
+            _session_log_dir(str(tmp_path / "some_project"))
+
+
+class TestRunHeadlessCoreFilesystemWrites:
+    """Tests that fs_writes_detected reflects filesystem changes in the skill temp dir."""
+
+    @pytest.mark.anyio
+    async def test_fs_writes_detected_true_when_file_created(
+        self, minimal_ctx, tmp_path: Path
+    ) -> None:
+        from autoskillit.execution.headless import run_headless_core
+        from tests.fakes import MockSubprocessRunner
+
+        skill_temp = tmp_path / ".autoskillit" / "temp" / "probe"
+        skill_temp.mkdir(parents=True)
+
+        class _FileSideEffectRunner:
+            def __init__(self, inner: MockSubprocessRunner, write_file: Path) -> None:
+                self._inner = inner
+                self._write_file = write_file
+
+            async def __call__(self, cmd, *, cwd, timeout, **kwargs):
+                self._write_file.touch()
+                return await self._inner(cmd, cwd=cwd, timeout=timeout, **kwargs)
+
+        base_runner = MockSubprocessRunner()
+        base_runner.set_default(_sr(0, _success_session_json("done"), ""))
+        minimal_ctx.runner = _FileSideEffectRunner(base_runner, skill_temp / "output.txt")
+
+        result = await run_headless_core(
+            "/autoskillit:probe",
+            str(tmp_path),
+            minimal_ctx,
+        )
+
+        assert result.fs_writes_detected is True
+
+    @pytest.mark.anyio
+    async def test_fs_writes_detected_false_when_no_file_created(
+        self, minimal_ctx, tmp_path: Path
+    ) -> None:
+        from autoskillit.execution.headless import run_headless_core
+        from tests.fakes import MockSubprocessRunner
+
+        skill_temp = tmp_path / ".autoskillit" / "temp" / "probe"
+        skill_temp.mkdir(parents=True)
+
+        runner = MockSubprocessRunner()
+        runner.set_default(_sr(0, _success_session_json("done"), ""))
+        minimal_ctx.runner = runner
+
+        result = await run_headless_core(
+            "/autoskillit:probe",
+            str(tmp_path),
+            minimal_ctx,
+        )
+
+        assert result.fs_writes_detected is False
+
 
 class TestResolveSessionId:
     """Unit tests for _resolve_skill_session_id — the session UUID resolution helper."""

--- a/tests/execution/test_headless_dispatch.py
+++ b/tests/execution/test_headless_dispatch.py
@@ -257,6 +257,68 @@ class TestDispatchFoodTruckPackInjection:
         assert "AUTOSKILLIT_L2_TOOL_TAGS" not in env
 
 
+class TestDispatchFoodTruckGuards:
+    """Guard-path tests for dispatch_food_truck: conflict detection and skip_clone_guard."""
+
+    @pytest.mark.anyio
+    async def test_dispatch_food_truck_l2_tool_tags_conflict_raises(
+        self, minimal_ctx, tmp_path: Path
+    ) -> None:
+        from autoskillit.core._type_plugin_source import DirectInstall
+        from autoskillit.execution.headless import DefaultHeadlessExecutor
+
+        minimal_ctx.plugin_source = DirectInstall(plugin_dir=tmp_path)
+        executor = DefaultHeadlessExecutor(minimal_ctx)
+
+        with pytest.raises(ValueError, match="AUTOSKILLIT_L2_TOOL_TAGS"):
+            await executor.dispatch_food_truck(
+                "some prompt",
+                str(tmp_path),
+                completion_marker="DONE",
+                requires_packs=["ci"],
+                env_extras={"AUTOSKILLIT_L2_TOOL_TAGS": "ci"},
+            )
+
+    @pytest.mark.anyio
+    async def test_dispatch_food_truck_skip_clone_guard_prevents_snapshot(
+        self, minimal_ctx, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from unittest.mock import AsyncMock
+
+        from autoskillit.core._type_plugin_source import DirectInstall
+        from autoskillit.core.types import SubprocessResult, TerminationReason
+        from autoskillit.execution.headless import DefaultHeadlessExecutor
+        from tests.fakes import MockSubprocessRunner
+
+        mock_snapshot = AsyncMock()
+        monkeypatch.setattr(
+            "autoskillit.execution.headless.snapshot_clone_state",
+            mock_snapshot,
+        )
+
+        runner = MockSubprocessRunner()
+        runner.set_default(
+            SubprocessResult(
+                returncode=0,
+                stdout=_make_success_stdout(),
+                stderr="",
+                termination=TerminationReason.NATURAL_EXIT,
+                pid=12345,
+            )
+        )
+        minimal_ctx.runner = runner
+        minimal_ctx.plugin_source = DirectInstall(plugin_dir=tmp_path)
+        executor = DefaultHeadlessExecutor(minimal_ctx)
+
+        await executor.dispatch_food_truck(
+            "some prompt",
+            str(tmp_path),
+            completion_marker="DONE",
+        )
+
+        assert mock_snapshot.call_count == 0
+
+
 def test_default_executor_satisfies_protocol_with_dispatch(minimal_ctx) -> None:
     """DefaultHeadlessExecutor satisfies HeadlessExecutor protocol with dispatch_food_truck."""
     from autoskillit.core import HeadlessExecutor

--- a/tests/execution/test_idle_output_env.py
+++ b/tests/execution/test_idle_output_env.py
@@ -125,6 +125,27 @@ class TestExecuteClaudeHeadlessIdleEnv:
         actual = kwargs.get("idle_output_timeout")
         assert actual is None, f"Expected idle_output_timeout=None when env=0, got {actual!r}"
 
+    @pytest.mark.anyio
+    async def test_idle_output_env_invalid_float_falls_back_to_config(
+        self, minimal_ctx, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from autoskillit.execution.headless import run_headless_core
+
+        monkeypatch.setenv("AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT", "not-a-number")
+        minimal_ctx.config.run_skill.idle_output_timeout = 45
+
+        runner = MockSubprocessRunner()
+        runner.set_default(_success_result())
+        minimal_ctx.runner = runner
+
+        await run_headless_core(
+            "/autoskillit:some-skill",
+            str(tmp_path),
+            minimal_ctx,
+        )
+        idle = runner.call_args_list[-1][3].get("idle_output_timeout")
+        assert idle == 45.0
+
 
 class TestDispatchFoodTruckIdleEnvInjection:
     @pytest.mark.anyio


### PR DESCRIPTION
## Summary

Add 6 targeted tests covering untested error/edge branches in the execution layer. No source files
are modified — this is a pure test-only change. The 6 tests are distributed across 3 existing test
files and cover: the `AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT` invalid-float `ValueError` fallback, the
`_session_log_dir` `OSError` re-raise path, the `dispatch_food_truck` L2_TOOL_TAGS conflict guard,
the `dispatch_food_truck` `skip_clone_guard` skip behavior, and both poles of `fs_writes_detected`
propagation through `run_headless_core`.

Closes #1537

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-1537-20260429-183755-219457/.autoskillit/temp/make-plan/p2_execution_layer_test_coverage_gaps_plan_2026-04-29_184500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 145 | 22.2k | 863.4k | 66.1k | 1 | 12m 22s |
| verify | 116 | 15.9k | 704.1k | 55.7k | 1 | 7m 38s |
| implement | 180 | 9.8k | 1.1M | 55.1k | 1 | 5m 16s |
| prepare_pr | 24 | 3.4k | 176.2k | 26.2k | 1 | 1m 14s |
| compose_pr | 23 | 1.5k | 155.8k | 18.1k | 1 | 47s |
| review_pr | 230 | 22.3k | 365.1k | 49.0k | 1 | 4m 22s |
| **Total** | 718 | 75.1k | 3.4M | 270.2k | | 31m 40s |