### PR TITLE
P2 — Decompose session.py into Sub-Module Facade (A1 + A2 + A3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,6 +199,8 @@ generic_automation_mcp/
 │   ├── _merge_queue_repo_state.py #  fetch_repo_merge_state, _text_has_push_trigger, _has_merge_group_trigger
 │   ├── github.py            #   GitHub issue fetcher
 │   ├── session.py           #   ClaudeSessionResult, extract_token_usage (facade)
+│   ├── _retry_fsm.py        #   _KILL_ANOMALY_SUBTYPES, _is_kill_anomaly, _compute_retry
+│   ├── _session_outcome.py  #   _compute_success, _compute_outcome
 │   ├── _session_model.py    #   ContentState, ClaudeSessionResult, extract_token_usage, parse_session_result
 │   ├── _session_content.py  #   _check_expected_patterns, _check_session_content, _evaluate_content_state
 │   ├── remote_resolver.py   #   upstream > origin, clone-aware

--- a/src/autoskillit/execution/_headless_result.py
+++ b/src/autoskillit/execution/_headless_result.py
@@ -17,6 +17,7 @@ from autoskillit.core import (
     TerminationReason,
     WriteBehaviorSpec,
     get_logger,
+    truncate_text,
 )
 from autoskillit.execution._headless_path_tokens import (
     _extract_output_paths,
@@ -30,21 +31,21 @@ from autoskillit.execution._headless_recovery import (
     _synthesize_from_write_artifacts,
 )
 from autoskillit.execution._headless_scan import _scan_jsonl_write_paths
+from autoskillit.execution._session_content import _check_expected_patterns
+from autoskillit.execution._session_model import (
+    ClaudeSessionResult,
+    parse_session_result,
+)
 from autoskillit.execution._session_outcome import (
     _compute_outcome,
     _compute_success,
-)
-from autoskillit.execution.session import (
-    ClaudeSessionResult,
-    _check_expected_patterns,
-    _truncate,
-    parse_session_result,
 )
 
 if TYPE_CHECKING:
     from autoskillit.core import AuditLog, SubprocessResult
 
 logger = get_logger(__name__)
+_truncate = truncate_text
 
 # Re-export so facade's `from autoskillit.execution._headless_result import _OUTPUT_PATH_PATTERN`
 # resolves correctly even though _OUTPUT_PATH_PATTERN is defined in _headless_path_tokens.

--- a/src/autoskillit/execution/_headless_result.py
+++ b/src/autoskillit/execution/_headless_result.py
@@ -30,11 +30,13 @@ from autoskillit.execution._headless_recovery import (
     _synthesize_from_write_artifacts,
 )
 from autoskillit.execution._headless_scan import _scan_jsonl_write_paths
+from autoskillit.execution._session_outcome import (
+    _compute_outcome,
+    _compute_success,
+)
 from autoskillit.execution.session import (
     ClaudeSessionResult,
     _check_expected_patterns,
-    _compute_outcome,
-    _compute_success,
     _truncate,
     parse_session_result,
 )

--- a/src/autoskillit/execution/_retry_fsm.py
+++ b/src/autoskillit/execution/_retry_fsm.py
@@ -1,0 +1,181 @@
+"""Retry FSM sub-module for headless session adjudication."""
+
+from __future__ import annotations
+
+from typing import assert_never
+
+from autoskillit.core import (
+    ChannelConfirmation,
+    CliSubtype,
+    RetryReason,
+    TerminationReason,
+    get_logger,
+)
+from autoskillit.execution._session_model import ClaudeSessionResult
+
+logger = get_logger(__name__)
+
+__all__ = ["_KILL_ANOMALY_SUBTYPES", "_is_kill_anomaly", "_compute_retry"]
+
+
+_KILL_ANOMALY_SUBTYPES: frozenset[CliSubtype] = frozenset(
+    {
+        CliSubtype.UNPARSEABLE,  # killed mid-write → partial NDJSON
+        CliSubtype.EMPTY_OUTPUT,  # killed before any stdout was written
+        CliSubtype.INTERRUPTED,  # killed mid-generation → real Claude CLI subtype
+    }
+)
+
+
+def _is_kill_anomaly(session: ClaudeSessionResult) -> bool:
+    """True if the session result looks like a kill-induced incomplete flush.
+
+    Covers anomalies from both infrastructure kills (COMPLETED) and voluntary
+    self-exits (NATURAL_EXIT with returncode==0). Callers must apply their own
+    termination-specific discriminators before calling this function.
+
+    Covers:
+    - unparseable: process killed mid-write, stdout is partial NDJSON
+    - empty_output: process killed before any stdout was written
+    - interrupted: process killed mid-generation (real Claude CLI subtype)
+    - success with empty result: kill occurred after result record was written
+      but with empty content (Channel B / Channel A drain-race, or
+      CLAUDE_CODE_EXIT_AFTER_STOP_DELAY timer-based self-exit)
+    """
+    if session.subtype in _KILL_ANOMALY_SUBTYPES:
+        return True
+    if session.subtype == CliSubtype.SUCCESS and not session.result.strip():
+        return True
+    return False
+
+
+def _compute_retry(
+    session: ClaudeSessionResult,
+    returncode: int,
+    termination: TerminationReason,
+    channel_confirmation: ChannelConfirmation = ChannelConfirmation.UNMONITORED,
+    completion_marker: str = "",
+) -> tuple[bool, RetryReason]:
+    """Compute whether the session result warrants a retry.
+
+    Phase 1: API-level signals are termination-agnostic.
+    Phase 2: Exhaustive match dispatch over TerminationReason ensures mypy
+             flags any unhandled value when the enum is extended.
+
+    When ``channel_confirmation=CHANNEL_B`` and ``termination=COMPLETED``,
+    the provenance bypass applies: Channel B's session-JSONL signal is
+    authoritative, so kill-anomaly appearance is a drain-race artifact.
+    No retry is needed.
+    """
+    # Phase 1: API-level retry signals (context exhaustion, max_turns)
+    if session.needs_retry:
+        logger.debug("compute_retry_api_signal", needs_retry=True, reason="resume")
+        return True, RetryReason.RESUME
+
+    # Phase 2: Exhaustive termination dispatch
+    match termination:
+        case TerminationReason.NATURAL_EXIT:
+            if channel_confirmation in (
+                ChannelConfirmation.CHANNEL_A,
+                ChannelConfirmation.CHANNEL_B,
+            ):
+                logger.debug(
+                    "compute_retry_result",
+                    termination="NATURAL_EXIT",
+                    channel=str(channel_confirmation),
+                    needs_retry=False,
+                )
+                return False, RetryReason.NONE
+            if returncode == 0 and _is_kill_anomaly(session):
+                reason = (
+                    RetryReason.RESUME
+                    if session._is_context_exhausted()
+                    else RetryReason.EMPTY_OUTPUT
+                )
+                logger.debug(
+                    "compute_retry_result",
+                    termination="NATURAL_EXIT",
+                    channel=str(channel_confirmation),
+                    needs_retry=True,
+                    kill_anomaly=True,
+                    context_exhausted=reason == RetryReason.RESUME,
+                )
+                return True, reason
+            # EARLY_STOP: model produced substantive output but stopped before
+            # emitting the completion marker (text-then-tool boundary).
+            if (
+                returncode == 0
+                and session.subtype == CliSubtype.SUCCESS
+                and session.result.strip()
+                and completion_marker
+                and completion_marker not in session.result
+            ):
+                skill_tool_calls = [t for t in session.tool_uses if t.get("name") == "Skill"]
+                logger.debug(
+                    "compute_retry_early_stop",
+                    termination="NATURAL_EXIT",
+                    has_skill_calls=bool(skill_tool_calls),
+                    skill_call_count=len(skill_tool_calls),
+                )
+                return True, RetryReason.EARLY_STOP
+            logger.debug(
+                "compute_retry_result",
+                termination="NATURAL_EXIT",
+                channel=str(channel_confirmation),
+                needs_retry=False,
+            )
+            return False, RetryReason.NONE
+
+        case TerminationReason.COMPLETED:
+            # Infrastructure killed the process. SIGTERM/SIGKILL produce nonzero
+            # returncode by design — do not gate on returncode here.
+            # Exhaustive ChannelConfirmation dispatch (ARCH-007 extension):
+            match channel_confirmation:
+                case ChannelConfirmation.CHANNEL_B:
+                    # Channel B is authoritative — kill-anomaly appearance is
+                    # a drain-race artifact, not a real incomplete flush.
+                    logger.debug(
+                        "compute_retry_result",
+                        termination="COMPLETED",
+                        channel="CHANNEL_B",
+                        needs_retry=False,
+                    )
+                    return False, RetryReason.NONE
+                case (
+                    ChannelConfirmation.CHANNEL_A
+                    | ChannelConfirmation.UNMONITORED
+                    | ChannelConfirmation.DIR_MISSING
+                ):
+                    is_anomaly = _is_kill_anomaly(session)
+                    logger.debug(
+                        "compute_retry_result",
+                        termination="COMPLETED",
+                        channel=str(channel_confirmation),
+                        needs_retry=is_anomaly,
+                        kill_anomaly=is_anomaly,
+                    )
+                    if is_anomaly:
+                        return True, RetryReason.RESUME
+                    return False, RetryReason.NONE
+                case _ as _unreachable_cc:
+                    assert_never(_unreachable_cc)
+
+        case TerminationReason.STALE:
+            # _build_skill_result intercepts STALE before calling _compute_retry.
+            # Explicit arm exists for exhaustiveness; unreachable in production.
+            logger.debug("compute_retry_result", termination="STALE", needs_retry=False)
+            return False, RetryReason.NONE
+
+        case TerminationReason.IDLE_STALL:
+            # _build_skill_result intercepts IDLE_STALL before calling _compute_retry.
+            # Explicit arm exists for exhaustiveness; unreachable in production.
+            logger.debug("compute_retry_result", termination="IDLE_STALL", needs_retry=False)
+            return False, RetryReason.NONE
+
+        case TerminationReason.TIMED_OUT:
+            # Wall-clock timeout: non-retriable (permanent infrastructure limit).
+            logger.debug("compute_retry_result", termination="TIMED_OUT", needs_retry=False)
+            return False, RetryReason.NONE
+
+        case _ as unreachable:
+            assert_never(unreachable)

--- a/src/autoskillit/execution/_session_outcome.py
+++ b/src/autoskillit/execution/_session_outcome.py
@@ -1,0 +1,237 @@
+"""Session outcome adjudication sub-module."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import assert_never
+
+from autoskillit.core import (
+    ChannelConfirmation,
+    CliSubtype,
+    RetryReason,
+    SessionOutcome,
+    TerminationReason,
+    get_logger,
+)
+from autoskillit.execution._retry_fsm import _compute_retry, _is_kill_anomaly
+from autoskillit.execution._session_content import (
+    _check_expected_patterns,
+    _check_session_content,
+    _evaluate_content_state,
+)
+from autoskillit.execution._session_model import ClaudeSessionResult, ContentState
+
+logger = get_logger(__name__)
+
+__all__ = ["_compute_success", "_compute_outcome"]
+
+
+def _compute_success(
+    session: ClaudeSessionResult,
+    returncode: int,
+    termination: TerminationReason,
+    completion_marker: str = "",
+    channel_confirmation: ChannelConfirmation = ChannelConfirmation.UNMONITORED,
+    expected_output_patterns: Sequence[str] = (),
+) -> bool:
+    """Cross-validate all signals to determine unambiguous success/failure.
+
+    Exhaustive match dispatch over TerminationReason ensures mypy flags any
+    unhandled value when the enum is extended (ARCH-007).
+
+    Gate 0.5 (provenance bypass): when ``channel_confirmation=CHANNEL_B``,
+    Channel B's session-JSONL marker is the authoritative signal that the
+    session completed successfully. Stdout content is not required.
+    """
+    # Gate 0.5: Channel B provenance bypass — session JSONL is authoritative.
+    match channel_confirmation:
+        case ChannelConfirmation.CHANNEL_B:
+            if expected_output_patterns and not session.session_complete:
+                logger.debug(
+                    "channel_b_bypass_skipped_incomplete_session",
+                    subtype=str(session.subtype),
+                    is_error=session.is_error,
+                    pattern_count=len(expected_output_patterns),
+                )
+            else:
+                if not _check_expected_patterns(session.result.strip(), expected_output_patterns):
+                    logger.debug(
+                        "channel_b_content_check_failed",
+                        result_len=len(session.result),
+                        pattern_count=len(expected_output_patterns),
+                    )
+                    return False
+                logger.debug("compute_success_bypass", channel="CHANNEL_B", result=True)
+                return True
+        case (
+            ChannelConfirmation.CHANNEL_A
+            | ChannelConfirmation.UNMONITORED
+            | ChannelConfirmation.DIR_MISSING
+        ):
+            pass  # fall through to termination dispatch
+        case _ as _unreachable_cc:
+            assert_never(_unreachable_cc)
+
+    match termination:
+        case TerminationReason.TIMED_OUT:
+            return False
+
+        case TerminationReason.STALE:
+            return False
+
+        case TerminationReason.IDLE_STALL:
+            return False
+
+        case TerminationReason.COMPLETED:
+            # The process was killed by our own async_kill_process_tree
+            # (signal -15 or -9), so a non-zero returncode is expected and
+            # trustworthy when the session envelope says "success".
+            if returncode != 0 and not (
+                session.subtype == CliSubtype.SUCCESS and session.result.strip()
+            ):
+                return False
+            content_ok = _check_session_content(
+                session, completion_marker, expected_output_patterns
+            )
+            logger.debug(
+                "compute_success_termination",
+                termination="COMPLETED",
+                returncode=returncode,
+                content_check=content_ok,
+            )
+            return content_ok
+
+        case TerminationReason.NATURAL_EXIT:
+            # The process exited on its own. A non-zero returncode is normally
+            # authoritative evidence of failure — no asymmetric bypass.
+            #
+            # Post-completion kill bypass: when an external watchdog kills the
+            # process AFTER it finished its work (e.g. trailing async task cleanup),
+            # the signal is a teardown artifact. The completion marker in the result
+            # provides strong evidence of completion — trust it over the returncode.
+            if returncode != 0:
+                if (
+                    session.subtype == CliSubtype.SUCCESS
+                    and session.result.strip()
+                    and completion_marker
+                    and completion_marker in session.result
+                ):
+                    content_ok = _check_session_content(
+                        session, completion_marker, expected_output_patterns
+                    )
+                    logger.debug(
+                        "compute_success_natural_exit_post_completion_kill",
+                        returncode=returncode,
+                        content_check=content_ok,
+                    )
+                    return content_ok
+                return False
+            content_ok = _check_session_content(
+                session, completion_marker, expected_output_patterns
+            )
+            logger.debug(
+                "compute_success_termination",
+                termination="NATURAL_EXIT",
+                returncode=returncode,
+                content_check=content_ok,
+            )
+            return content_ok
+
+        case _ as unreachable:
+            assert_never(unreachable)
+
+
+def _compute_outcome(
+    session: ClaudeSessionResult,
+    returncode: int,
+    termination: TerminationReason,
+    completion_marker: str = "",
+    channel_confirmation: ChannelConfirmation = ChannelConfirmation.UNMONITORED,
+    expected_output_patterns: Sequence[str] = (),
+) -> tuple[SessionOutcome, RetryReason]:
+    """Compose _compute_success and _compute_retry into a (SessionOutcome, RetryReason) pair.
+
+    Applies contradiction guard (retry demotes success) and dead-end guard (ABSENT
+    drain-race promotes to RETRIABLE) before mapping to the bijective SessionOutcome enum.
+    """
+    success = _compute_success(
+        session,
+        returncode,
+        termination,
+        completion_marker,
+        channel_confirmation,
+        expected_output_patterns,
+    )
+    needs_retry, retry_reason = _compute_retry(
+        session, returncode, termination, channel_confirmation, completion_marker
+    )
+
+    logger.debug(
+        "compute_outcome_inputs",
+        success=success,
+        needs_retry=needs_retry,
+        retry_reason=str(retry_reason),
+        returncode=returncode,
+        termination=str(termination),
+        channel=str(channel_confirmation),
+        subtype=session.subtype,
+        is_error=session.is_error,
+        result_empty=not session.result.strip(),
+    )
+
+    # Contradiction guard: retry signal is authoritative over the channel bypass.
+    if success and needs_retry:
+        success = False
+        logger.debug(
+            "contradiction_guard",
+            action="demoted_success",
+            reason="retry_signal_authoritative",
+        )
+
+    # Dead-end guard: channel confirmation means the session signalled completion, but
+    # content checks failed and no retry was scheduled by _compute_retry.
+    # Only promote to RETRIABLE when the failure is a drain-race artifact (ABSENT state):
+    #   - empty result → stdout not fully flushed
+    #   - marker missing → partial flush
+    # Do NOT promote CONTRACT_VIOLATION or SESSION_ERROR — these are terminal failures
+    # that retrying will never resolve.
+    if not success and not needs_retry:
+        match channel_confirmation:
+            case ChannelConfirmation.CHANNEL_A | ChannelConfirmation.CHANNEL_B:
+                content_state = _evaluate_content_state(
+                    session, completion_marker, expected_output_patterns
+                )
+                if content_state == ContentState.ABSENT:
+                    needs_retry = True
+                    retry_reason = RetryReason.DRAIN_RACE
+                    logger.debug(
+                        "dead_end_guard",
+                        action="promoted_to_retriable",
+                        content_state=content_state.value,
+                        channel=channel_confirmation.value,
+                    )
+                else:
+                    logger.debug(
+                        "dead_end_guard",
+                        action="terminal_failure_not_promoted",
+                        content_state=content_state.value,
+                        channel=channel_confirmation.value,
+                    )
+            case ChannelConfirmation.UNMONITORED | ChannelConfirmation.DIR_MISSING:
+                pass  # legitimate terminal failure — no channel confirmed completion
+            case _ as unreachable_cc:
+                assert_never(unreachable_cc)
+
+    if success:
+        outcome = SessionOutcome.SUCCEEDED
+    elif needs_retry:
+        outcome = SessionOutcome.RETRIABLE
+    else:
+        outcome = SessionOutcome.FAILED
+
+    logger.debug(
+        "compute_outcome_result",
+        outcome=str(outcome),
+        retry_reason=str(retry_reason),
+    )
+    return outcome, retry_reason

--- a/src/autoskillit/execution/_session_outcome.py
+++ b/src/autoskillit/execution/_session_outcome.py
@@ -13,7 +13,7 @@ from autoskillit.core import (
     TerminationReason,
     get_logger,
 )
-from autoskillit.execution._retry_fsm import _compute_retry, _is_kill_anomaly
+from autoskillit.execution._retry_fsm import _compute_retry
 from autoskillit.execution._session_content import (
     _check_expected_patterns,
     _check_session_content,

--- a/src/autoskillit/execution/session.py
+++ b/src/autoskillit/execution/session.py
@@ -10,16 +10,9 @@ _session_outcome sub-modules.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-from typing import assert_never
-
 from autoskillit.core import (
-    ChannelConfirmation,
     CliSubtype,
-    RetryReason,
-    SessionOutcome,
     SkillResult,
-    TerminationReason,
     get_logger,
     truncate_text,
 )
@@ -29,230 +22,23 @@ from autoskillit.execution._retry_fsm import (
     _is_kill_anomaly,  # noqa: F401 — re-export for callers
 )
 from autoskillit.execution._session_content import (
-    _check_expected_patterns,
-    _check_session_content,
-    _evaluate_content_state,
+    _check_expected_patterns,  # noqa: F401 — re-export for callers
+    _check_session_content,  # noqa: F401 — re-export for callers
+    _evaluate_content_state,  # noqa: F401 — re-export for callers
 )
 from autoskillit.execution._session_model import (
     FAILURE_SUBTYPES,  # noqa: F401 — re-export for callers
-    ClaudeSessionResult,
-    ContentState,
+    ClaudeSessionResult,  # noqa: F401 — re-export for callers
+    ContentState,  # noqa: F401 — re-export for callers
     extract_token_usage,  # noqa: F401 — re-export for callers
     parse_session_result,  # noqa: F401 — re-export for callers
+)
+from autoskillit.execution._session_outcome import (
+    _compute_outcome,  # noqa: F401 — re-export for callers
+    _compute_success,  # noqa: F401 — re-export for callers
 )
 
 logger = get_logger(__name__)
 _truncate = truncate_text
 # Re-export SkillResult so existing callers can import from this module.
 __all__ = ["CliSubtype", "SkillResult"]
-
-
-def _compute_success(
-    session: ClaudeSessionResult,
-    returncode: int,
-    termination: TerminationReason,
-    completion_marker: str = "",
-    channel_confirmation: ChannelConfirmation = ChannelConfirmation.UNMONITORED,
-    expected_output_patterns: Sequence[str] = (),
-) -> bool:
-    """Cross-validate all signals to determine unambiguous success/failure.
-
-    Exhaustive match dispatch over TerminationReason ensures mypy flags any
-    unhandled value when the enum is extended (ARCH-007).
-
-    Gate 0.5 (provenance bypass): when ``channel_confirmation=CHANNEL_B``,
-    Channel B's session-JSONL marker is the authoritative signal that the
-    session completed successfully. Stdout content is not required.
-    """
-    # Gate 0.5: Channel B provenance bypass — session JSONL is authoritative.
-    match channel_confirmation:
-        case ChannelConfirmation.CHANNEL_B:
-            if expected_output_patterns and not session.session_complete:
-                logger.debug(
-                    "channel_b_bypass_skipped_incomplete_session",
-                    subtype=str(session.subtype),
-                    is_error=session.is_error,
-                    pattern_count=len(expected_output_patterns),
-                )
-            else:
-                if not _check_expected_patterns(session.result.strip(), expected_output_patterns):
-                    logger.debug(
-                        "channel_b_content_check_failed",
-                        result_len=len(session.result),
-                        pattern_count=len(expected_output_patterns),
-                    )
-                    return False
-                logger.debug("compute_success_bypass", channel="CHANNEL_B", result=True)
-                return True
-        case (
-            ChannelConfirmation.CHANNEL_A
-            | ChannelConfirmation.UNMONITORED
-            | ChannelConfirmation.DIR_MISSING
-        ):
-            pass  # fall through to termination dispatch
-        case _ as _unreachable_cc:
-            assert_never(_unreachable_cc)
-
-    match termination:
-        case TerminationReason.TIMED_OUT:
-            return False
-
-        case TerminationReason.STALE:
-            return False
-
-        case TerminationReason.IDLE_STALL:
-            return False
-
-        case TerminationReason.COMPLETED:
-            # The process was killed by our own async_kill_process_tree
-            # (signal -15 or -9), so a non-zero returncode is expected and
-            # trustworthy when the session envelope says "success".
-            if returncode != 0 and not (
-                session.subtype == CliSubtype.SUCCESS and session.result.strip()
-            ):
-                return False
-            content_ok = _check_session_content(
-                session, completion_marker, expected_output_patterns
-            )
-            logger.debug(
-                "compute_success_termination",
-                termination="COMPLETED",
-                returncode=returncode,
-                content_check=content_ok,
-            )
-            return content_ok
-
-        case TerminationReason.NATURAL_EXIT:
-            # The process exited on its own. A non-zero returncode is normally
-            # authoritative evidence of failure — no asymmetric bypass.
-            #
-            # Post-completion kill bypass: when an external watchdog kills the
-            # process AFTER it finished its work (e.g. trailing async task cleanup),
-            # the signal is a teardown artifact. The completion marker in the result
-            # provides strong evidence of completion — trust it over the returncode.
-            if returncode != 0:
-                if (
-                    session.subtype == CliSubtype.SUCCESS
-                    and session.result.strip()
-                    and completion_marker
-                    and completion_marker in session.result
-                ):
-                    content_ok = _check_session_content(
-                        session, completion_marker, expected_output_patterns
-                    )
-                    logger.debug(
-                        "compute_success_natural_exit_post_completion_kill",
-                        returncode=returncode,
-                        content_check=content_ok,
-                    )
-                    return content_ok
-                return False
-            content_ok = _check_session_content(
-                session, completion_marker, expected_output_patterns
-            )
-            logger.debug(
-                "compute_success_termination",
-                termination="NATURAL_EXIT",
-                returncode=returncode,
-                content_check=content_ok,
-            )
-            return content_ok
-
-        case _ as unreachable:
-            assert_never(unreachable)
-
-
-def _compute_outcome(
-    session: ClaudeSessionResult,
-    returncode: int,
-    termination: TerminationReason,
-    completion_marker: str = "",
-    channel_confirmation: ChannelConfirmation = ChannelConfirmation.UNMONITORED,
-    expected_output_patterns: Sequence[str] = (),
-) -> tuple[SessionOutcome, RetryReason]:
-    """Compose _compute_success and _compute_retry into a (SessionOutcome, RetryReason) pair.
-
-    Applies contradiction guard (retry demotes success) and dead-end guard (ABSENT
-    drain-race promotes to RETRIABLE) before mapping to the bijective SessionOutcome enum.
-    """
-    success = _compute_success(
-        session,
-        returncode,
-        termination,
-        completion_marker,
-        channel_confirmation,
-        expected_output_patterns,
-    )
-    needs_retry, retry_reason = _compute_retry(
-        session, returncode, termination, channel_confirmation, completion_marker
-    )
-
-    logger.debug(
-        "compute_outcome_inputs",
-        success=success,
-        needs_retry=needs_retry,
-        retry_reason=str(retry_reason),
-        returncode=returncode,
-        termination=str(termination),
-        channel=str(channel_confirmation),
-        subtype=session.subtype,
-        is_error=session.is_error,
-        result_empty=not session.result.strip(),
-    )
-
-    # Contradiction guard: retry signal is authoritative over the channel bypass.
-    if success and needs_retry:
-        success = False
-        logger.debug(
-            "contradiction_guard",
-            action="demoted_success",
-            reason="retry_signal_authoritative",
-        )
-
-    # Dead-end guard: channel confirmation means the session signalled completion, but
-    # content checks failed and no retry was scheduled by _compute_retry.
-    # Only promote to RETRIABLE when the failure is a drain-race artifact (ABSENT state):
-    #   - empty result → stdout not fully flushed
-    #   - marker missing → partial flush
-    # Do NOT promote CONTRACT_VIOLATION or SESSION_ERROR — these are terminal failures
-    # that retrying will never resolve.
-    if not success and not needs_retry:
-        match channel_confirmation:
-            case ChannelConfirmation.CHANNEL_A | ChannelConfirmation.CHANNEL_B:
-                content_state = _evaluate_content_state(
-                    session, completion_marker, expected_output_patterns
-                )
-                if content_state == ContentState.ABSENT:
-                    needs_retry = True
-                    retry_reason = RetryReason.DRAIN_RACE
-                    logger.debug(
-                        "dead_end_guard",
-                        action="promoted_to_retriable",
-                        content_state=content_state.value,
-                        channel=channel_confirmation.value,
-                    )
-                else:
-                    logger.debug(
-                        "dead_end_guard",
-                        action="terminal_failure_not_promoted",
-                        content_state=content_state.value,
-                        channel=channel_confirmation.value,
-                    )
-            case ChannelConfirmation.UNMONITORED | ChannelConfirmation.DIR_MISSING:
-                pass  # legitimate terminal failure — no channel confirmed completion
-            case _ as unreachable_cc:
-                assert_never(unreachable_cc)
-
-    if success:
-        outcome = SessionOutcome.SUCCEEDED
-    elif needs_retry:
-        outcome = SessionOutcome.RETRIABLE
-    else:
-        outcome = SessionOutcome.FAILED
-
-    logger.debug(
-        "compute_outcome_result",
-        outcome=str(outcome),
-        retry_reason=str(retry_reason),
-    )
-    return outcome, retry_reason

--- a/src/autoskillit/execution/session.py
+++ b/src/autoskillit/execution/session.py
@@ -4,7 +4,8 @@ L2 module: imports only from L0 (types, _logging). No server side-effects.
 Centralizes all session-parsing concerns so callers can work with typed
 objects instead of raw JSON strings.
 
-Facade: re-exports from _session_model and _session_content sub-modules.
+Facade: re-exports from _session_model, _session_content, _retry_fsm, and
+_session_outcome sub-modules.
 """
 
 from __future__ import annotations
@@ -21,6 +22,11 @@ from autoskillit.core import (
     TerminationReason,
     get_logger,
     truncate_text,
+)
+from autoskillit.execution._retry_fsm import (
+    _KILL_ANOMALY_SUBTYPES,  # noqa: F401 — re-export for callers
+    _compute_retry,  # noqa: F401 — re-export for callers
+    _is_kill_anomaly,  # noqa: F401 — re-export for callers
 )
 from autoskillit.execution._session_content import (
     _check_expected_patterns,
@@ -39,37 +45,6 @@ logger = get_logger(__name__)
 _truncate = truncate_text
 # Re-export SkillResult so existing callers can import from this module.
 __all__ = ["CliSubtype", "SkillResult"]
-
-
-_KILL_ANOMALY_SUBTYPES: frozenset[CliSubtype] = frozenset(
-    {
-        CliSubtype.UNPARSEABLE,  # killed mid-write → partial NDJSON
-        CliSubtype.EMPTY_OUTPUT,  # killed before any stdout was written
-        CliSubtype.INTERRUPTED,  # killed mid-generation → real Claude CLI subtype
-    }
-)
-
-
-def _is_kill_anomaly(session: ClaudeSessionResult) -> bool:
-    """True if the session result looks like a kill-induced incomplete flush.
-
-    Covers anomalies from both infrastructure kills (COMPLETED) and voluntary
-    self-exits (NATURAL_EXIT with returncode==0). Callers must apply their own
-    termination-specific discriminators before calling this function.
-
-    Covers:
-    - unparseable: process killed mid-write, stdout is partial NDJSON
-    - empty_output: process killed before any stdout was written
-    - interrupted: process killed mid-generation (real Claude CLI subtype)
-    - success with empty result: kill occurred after result record was written
-      but with empty content (Channel B / Channel A drain-race, or
-      CLAUDE_CODE_EXIT_AFTER_STOP_DELAY timer-based self-exit)
-    """
-    if session.subtype in _KILL_ANOMALY_SUBTYPES:
-        return True
-    if session.subtype == CliSubtype.SUCCESS and not session.result.strip():
-        return True
-    return False
 
 
 def _compute_success(
@@ -182,138 +157,6 @@ def _compute_success(
                 content_check=content_ok,
             )
             return content_ok
-
-        case _ as unreachable:
-            assert_never(unreachable)
-
-
-def _compute_retry(
-    session: ClaudeSessionResult,
-    returncode: int,
-    termination: TerminationReason,
-    channel_confirmation: ChannelConfirmation = ChannelConfirmation.UNMONITORED,
-    completion_marker: str = "",
-) -> tuple[bool, RetryReason]:
-    """Compute whether the session result warrants a retry.
-
-    Phase 1: API-level signals are termination-agnostic.
-    Phase 2: Exhaustive match dispatch over TerminationReason ensures mypy
-             flags any unhandled value when the enum is extended.
-
-    When ``channel_confirmation=CHANNEL_B`` and ``termination=COMPLETED``,
-    the provenance bypass applies: Channel B's session-JSONL signal is
-    authoritative, so kill-anomaly appearance is a drain-race artifact.
-    No retry is needed.
-    """
-    # Phase 1: API-level retry signals (context exhaustion, max_turns)
-    if session.needs_retry:
-        logger.debug("compute_retry_api_signal", needs_retry=True, reason="resume")
-        return True, RetryReason.RESUME
-
-    # Phase 2: Exhaustive termination dispatch
-    match termination:
-        case TerminationReason.NATURAL_EXIT:
-            if channel_confirmation in (
-                ChannelConfirmation.CHANNEL_A,
-                ChannelConfirmation.CHANNEL_B,
-            ):
-                logger.debug(
-                    "compute_retry_result",
-                    termination="NATURAL_EXIT",
-                    channel=str(channel_confirmation),
-                    needs_retry=False,
-                )
-                return False, RetryReason.NONE
-            if returncode == 0 and _is_kill_anomaly(session):
-                reason = (
-                    RetryReason.RESUME
-                    if session._is_context_exhausted()
-                    else RetryReason.EMPTY_OUTPUT
-                )
-                logger.debug(
-                    "compute_retry_result",
-                    termination="NATURAL_EXIT",
-                    channel=str(channel_confirmation),
-                    needs_retry=True,
-                    kill_anomaly=True,
-                    context_exhausted=reason == RetryReason.RESUME,
-                )
-                return True, reason
-            # EARLY_STOP: model produced substantive output but stopped before
-            # emitting the completion marker (text-then-tool boundary).
-            if (
-                returncode == 0
-                and session.subtype == CliSubtype.SUCCESS
-                and session.result.strip()
-                and completion_marker
-                and completion_marker not in session.result
-            ):
-                skill_tool_calls = [t for t in session.tool_uses if t.get("name") == "Skill"]
-                logger.debug(
-                    "compute_retry_early_stop",
-                    termination="NATURAL_EXIT",
-                    has_skill_calls=bool(skill_tool_calls),
-                    skill_call_count=len(skill_tool_calls),
-                )
-                return True, RetryReason.EARLY_STOP
-            logger.debug(
-                "compute_retry_result",
-                termination="NATURAL_EXIT",
-                channel=str(channel_confirmation),
-                needs_retry=False,
-            )
-            return False, RetryReason.NONE
-
-        case TerminationReason.COMPLETED:
-            # Infrastructure killed the process. SIGTERM/SIGKILL produce nonzero
-            # returncode by design — do not gate on returncode here.
-            # Exhaustive ChannelConfirmation dispatch (ARCH-007 extension):
-            match channel_confirmation:
-                case ChannelConfirmation.CHANNEL_B:
-                    # Channel B is authoritative — kill-anomaly appearance is
-                    # a drain-race artifact, not a real incomplete flush.
-                    logger.debug(
-                        "compute_retry_result",
-                        termination="COMPLETED",
-                        channel="CHANNEL_B",
-                        needs_retry=False,
-                    )
-                    return False, RetryReason.NONE
-                case (
-                    ChannelConfirmation.CHANNEL_A
-                    | ChannelConfirmation.UNMONITORED
-                    | ChannelConfirmation.DIR_MISSING
-                ):
-                    is_anomaly = _is_kill_anomaly(session)
-                    logger.debug(
-                        "compute_retry_result",
-                        termination="COMPLETED",
-                        channel=str(channel_confirmation),
-                        needs_retry=is_anomaly,
-                        kill_anomaly=is_anomaly,
-                    )
-                    if is_anomaly:
-                        return True, RetryReason.RESUME
-                    return False, RetryReason.NONE
-                case _ as _unreachable_cc:
-                    assert_never(_unreachable_cc)
-
-        case TerminationReason.STALE:
-            # _build_skill_result intercepts STALE before calling _compute_retry.
-            # Explicit arm exists for exhaustiveness; unreachable in production.
-            logger.debug("compute_retry_result", termination="STALE", needs_retry=False)
-            return False, RetryReason.NONE
-
-        case TerminationReason.IDLE_STALL:
-            # _build_skill_result intercepts IDLE_STALL before calling _compute_retry.
-            # Explicit arm exists for exhaustiveness; unreachable in production.
-            logger.debug("compute_retry_result", termination="IDLE_STALL", needs_retry=False)
-            return False, RetryReason.NONE
-
-        case TerminationReason.TIMED_OUT:
-            # Wall-clock timeout: non-retriable (permanent infrastructure limit).
-            logger.debug("compute_retry_result", termination="TIMED_OUT", needs_retry=False)
-            return False, RetryReason.NONE
 
         case _ as unreachable:
             assert_never(unreachable)

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -70,9 +70,14 @@ NEW_SESSION_MODULES = ["_session_model.py", "_session_content.py"]
 NEW_MQ_MODULES = ["_merge_queue_classifier.py", "_merge_queue_repo_state.py"]
 
 SESSION_SIZE_BUDGETS = {
-    "session.py": 420,
+    "session.py": 60,  # was 420; facade is ~40 lines after P2
     "_session_model.py": 370,
     "_session_content.py": 200,
+}
+NEW_SESSION_FSM_MODULES = ["_retry_fsm.py", "_session_outcome.py"]
+SESSION_FSM_SIZE_BUDGETS = {
+    "_retry_fsm.py": 200,
+    "_session_outcome.py": 260,
 }
 MQ_SIZE_BUDGETS = {
     "merge_queue.py": 500,
@@ -119,6 +124,34 @@ def test_session_facade_does_not_define_content_functions():
         "def _strip_markdown_from_tokens",
     ):
         assert sym not in src, f"{sym} must live in _session_content.py"
+
+
+# ---------------------------------------------------------------------------
+# P2: session.py FSM/outcome sub-module guards
+# ---------------------------------------------------------------------------
+
+
+def test_new_session_fsm_modules_exist():
+    for name in NEW_SESSION_FSM_MODULES:
+        assert (SRC_EXECUTION / name).exists(), f"Missing: {name}"
+
+
+def test_session_fsm_modules_under_budget():
+    for name, limit in SESSION_FSM_SIZE_BUDGETS.items():
+        lines = len((SRC_EXECUTION / name).read_text().splitlines())
+        assert lines <= limit, f"{name}: {lines} lines exceeds budget of {limit}"
+
+
+def test_session_facade_does_not_define_retry_outcome():
+    src = (SRC_EXECUTION / "session.py").read_text()
+    for sym in (
+        "_KILL_ANOMALY_SUBTYPES: frozenset",
+        "def _is_kill_anomaly",
+        "def _compute_retry",
+        "def _compute_success",
+        "def _compute_outcome",
+    ):
+        assert sym not in src, f"{sym} must live in _retry_fsm.py or _session_outcome.py"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -765,7 +765,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
     EXEMPTIONS: dict[str, int] = {
         "server": 22,
         "recipe": 48,
-        "execution": 33,
+        "execution": 35,
         "core": 32,
         "cli": 42,
         "hooks": 28,


### PR DESCRIPTION
## Summary

Extract all logic from the 416-line `session.py` into two new private sub-modules
(`_retry_fsm.py` and `_session_outcome.py`) and reduce `session.py` to a ~40-line
re-export facade. This follows the established `_headless_*.py` extraction pattern
already used in the execution package. After the change, `session.py` owns no function
or class definitions — it is a pure import/re-export hub.

The three sub-tasks from the issue (A1, A2, A3) map directly to three ordered
implementation steps below. No public API changes; all existing callers continue to
import from `autoskillit.execution.session` without modification.

Closes #1536

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-1536-20260429-183754-645354/.autoskillit/temp/make-plan/p2_decompose_session_py_plan_2026-04-29_183900.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 129 | 12.4k | 761.4k | 65.9k | 1 | 6m 38s |
| verify | 92 | 9.5k | 552.9k | 55.5k | 1 | 2m 52s |
| implement | 268 | 19.4k | 2.2M | 76.3k | 1 | 4m 52s |
| prepare_pr | 26 | 4.0k | 259.2k | 28.6k | 1 | 1m 24s |
| compose_pr | 22 | 1.4k | 126.8k | 18.2k | 1 | 42s |
| review_pr | 37 | 25.8k | 459.1k | 65.1k | 1 | 6m 4s |
| resolve_review | 836 | 9.5k | 1.0M | 41.0k | 1 | 6m 52s |
| **Total** | 1.4k | 81.9k | 5.4M | 350.6k | | 29m 26s |