### PR TITLE
P4 — Extract _subprocess.py from helpers.py and Migrate Consumers

### DIFF
--- a/src/autoskillit/server/_subprocess.py
+++ b/src/autoskillit/server/_subprocess.py
@@ -1,0 +1,78 @@
+"""Subprocess execution helpers for MCP tools."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from autoskillit.core import TerminationReason
+
+if TYPE_CHECKING:
+    from autoskillit.core import SubprocessResult
+
+
+def _get_ctx():  # type: ignore[return]
+    """Deferred import of _get_ctx from _state to avoid circular imports."""
+    from autoskillit.server._state import _get_ctx as _ctx_fn
+
+    return _ctx_fn()
+
+
+def _process_runner_result(
+    result: SubprocessResult,
+    timeout: float,
+) -> tuple[int, str, str]:
+    """Convert a SubprocessResult to (returncode, stdout, stderr).
+
+    Translates TIMED_OUT termination into (-1, stdout, "Process timed out after {timeout}s").
+    """
+    if result.termination == TerminationReason.TIMED_OUT:
+        return -1, result.stdout, f"Process timed out after {timeout}s"
+    return result.returncode, result.stdout, result.stderr
+
+
+_GH_API_SUBCOMMANDS: frozenset[str] = frozenset(
+    {"api", "pr", "issue", "repo", "release", "run", "workflow", "search"}
+)
+
+
+def _is_github_cli_call(cmd: list[str]) -> bool:
+    return len(cmd) >= 2 and cmd[0] == "gh" and cmd[1] in _GH_API_SUBCOMMANDS
+
+
+async def _run_subprocess(
+    cmd: list[str],
+    *,
+    cwd: str,
+    timeout: float,
+    env: Mapping[str, str] | None = None,
+) -> tuple[int, str, str]:
+    """Run a subprocess asynchronously with timeout. Returns (returncode, stdout, stderr).
+
+    Delegates to run_managed_async which uses temp file I/O (immune to
+    pipe-blocking from child FD inheritance) and psutil process tree cleanup.
+    """
+    runner = _get_ctx().runner
+    assert runner is not None, "No subprocess runner configured"
+
+    is_gh = _is_github_cli_call(cmd)
+    start = time.monotonic() if is_gh else 0.0
+
+    result = await runner(cmd, cwd=Path(cwd), timeout=timeout, env=env)
+    returncode, stdout, stderr = _process_runner_result(result, timeout)
+
+    if is_gh:
+        latency_ms = (time.monotonic() - start) * 1000.0
+        log = _get_ctx().github_api_log
+        if log is not None:
+            await log.record_gh_cli(
+                subcommand=" ".join(str(c) for c in cmd[:3]),
+                exit_code=returncode,
+                latency_ms=latency_ms,
+                timestamp=datetime.now(UTC).isoformat(),
+            )
+
+    return returncode, stdout, stderr

--- a/src/autoskillit/server/git.py
+++ b/src/autoskillit/server/git.py
@@ -20,12 +20,12 @@ from autoskillit.core import (
     MergeFailedStep,
     MergeState,
     SubprocessRunner,
-    TerminationReason,
     get_logger,
     is_protected_branch,
     truncate_text,
 )
 from autoskillit.server._editable_guard import scan_editable_installs_for_worktree
+from autoskillit.server._subprocess import _process_runner_result
 from autoskillit.workspace import remove_git_worktree, remove_worktree_sidecar
 
 if TYPE_CHECKING:
@@ -71,9 +71,7 @@ async def _run_git(
     Returns (returncode, stdout, stderr). Handles TIMED_OUT termination.
     """
     result = await runner(cmd, cwd=Path(cwd), timeout=timeout)
-    if result.termination == TerminationReason.TIMED_OUT:
-        return -1, result.stdout, f"Process timed out after {timeout}s"
-    return result.returncode, result.stdout, result.stderr
+    return _process_runner_result(result, timeout)
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/autoskillit/server/helpers.py
+++ b/src/autoskillit/server/helpers.py
@@ -213,8 +213,6 @@ async def _apply_triage_gate(
     )
 
 
-
-
 async def _import_and_call(
     dotted_path: str,
     args: dict[str, object] | None = None,

--- a/src/autoskillit/server/helpers.py
+++ b/src/autoskillit/server/helpers.py
@@ -1,19 +1,16 @@
-"""Subprocess wrapper and shared helpers for MCP tools."""
+"""Shared helpers for MCP tools."""
 
 from __future__ import annotations
 
 import asyncio
 import functools
 import json
-import time
-from collections.abc import Awaitable, Callable, Mapping
-from datetime import UTC, datetime
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from autoskillit.core import (
     RESERVED_LOG_RECORD_KEYS,
-    TerminationReason,
     get_logger,
 )
 from autoskillit.execution import (
@@ -33,7 +30,6 @@ if TYPE_CHECKING:
     from fastmcp import Context
 
     from autoskillit.config import QuotaGuardConfig
-    from autoskillit.core import SubprocessResult
 
 logger = get_logger(__name__)
 
@@ -217,62 +213,6 @@ async def _apply_triage_gate(
     )
 
 
-def _process_runner_result(
-    result: SubprocessResult,
-    timeout: float,
-) -> tuple[int, str, str]:
-    """Convert a SubprocessResult to (returncode, stdout, stderr).
-
-    Translates TIMED_OUT termination into (-1, stdout, "Process timed out after {timeout}s").
-    Shared by _run_subprocess (helpers.py) and _run_git (git.py).
-    """
-    if result.termination == TerminationReason.TIMED_OUT:
-        return -1, result.stdout, f"Process timed out after {timeout}s"
-    return result.returncode, result.stdout, result.stderr
-
-
-_GH_API_SUBCOMMANDS: frozenset[str] = frozenset(
-    {"api", "pr", "issue", "repo", "release", "run", "workflow", "search"}
-)
-
-
-def _is_github_cli_call(cmd: list[str]) -> bool:
-    return len(cmd) >= 2 and cmd[0] == "gh" and cmd[1] in _GH_API_SUBCOMMANDS
-
-
-async def _run_subprocess(
-    cmd: list[str],
-    *,
-    cwd: str,
-    timeout: float,
-    env: Mapping[str, str] | None = None,
-) -> tuple[int, str, str]:
-    """Run a subprocess asynchronously with timeout. Returns (returncode, stdout, stderr).
-
-    Delegates to run_managed_async which uses temp file I/O (immune to
-    pipe-blocking from child FD inheritance) and psutil process tree cleanup.
-    """
-    runner = _get_ctx().runner
-    assert runner is not None, "No subprocess runner configured"
-
-    is_gh = _is_github_cli_call(cmd)
-    start = time.monotonic() if is_gh else 0.0
-
-    result = await runner(cmd, cwd=Path(cwd), timeout=timeout, env=env)
-    returncode, stdout, stderr = _process_runner_result(result, timeout)
-
-    if is_gh:
-        latency_ms = (time.monotonic() - start) * 1000.0
-        log = _get_ctx().github_api_log
-        if log is not None:
-            await log.record_gh_cli(
-                subcommand=" ".join(str(c) for c in cmd[:3]),
-                exit_code=returncode,
-                latency_ms=latency_ms,
-                timestamp=datetime.now(UTC).isoformat(),
-            )
-
-    return returncode, stdout, stderr
 
 
 async def _import_and_call(

--- a/src/autoskillit/server/tools_ci.py
+++ b/src/autoskillit/server/tools_ci.py
@@ -13,8 +13,8 @@ from fastmcp.dependencies import CurrentContext
 from autoskillit.core import DirectInstall, MarketplaceInstall, get_logger
 from autoskillit.server import mcp
 from autoskillit.server._guards import _require_enabled
+from autoskillit.server._subprocess import _run_subprocess
 from autoskillit.server.helpers import (
-    _run_subprocess,
     fetch_repo_merge_state,
     resolve_repo_from_remote,
     track_response_size,

--- a/src/autoskillit/server/tools_ci_watch.py
+++ b/src/autoskillit/server/tools_ci_watch.py
@@ -15,9 +15,9 @@ from autoskillit.core import CIRunScope, get_logger
 from autoskillit.pipeline import ToolContext
 from autoskillit.server import mcp
 from autoskillit.server._guards import _require_enabled
+from autoskillit.server._subprocess import _run_subprocess
 from autoskillit.server.helpers import (
     _notify,
-    _run_subprocess,
     resolve_repo_from_remote,
     track_response_size,
 )

--- a/src/autoskillit/server/tools_execution.py
+++ b/src/autoskillit/server/tools_execution.py
@@ -28,11 +28,11 @@ from autoskillit.server._guards import (
     _require_orchestrator_or_higher,
     _validate_skill_command,
 )
+from autoskillit.server._subprocess import _run_subprocess
 from autoskillit.server.helpers import (
     SCENARIO_STEP_NAME_ENV,
     _import_and_call,
     _notify,
-    _run_subprocess,
     track_response_size,
 )
 

--- a/src/autoskillit/server/tools_git.py
+++ b/src/autoskillit/server/tools_git.py
@@ -13,9 +13,9 @@ from fastmcp.dependencies import CurrentContext
 from autoskillit.core import RestartScope, get_logger
 from autoskillit.server import mcp
 from autoskillit.server._guards import _require_enabled
+from autoskillit.server._subprocess import _run_subprocess
 from autoskillit.server.helpers import (
     _notify,
-    _run_subprocess,
     track_response_size,
 )
 

--- a/src/autoskillit/server/tools_pr_ops.py
+++ b/src/autoskillit/server/tools_pr_ops.py
@@ -14,9 +14,9 @@ from fastmcp.dependencies import CurrentContext
 from autoskillit.core import atomic_write, get_logger
 from autoskillit.server import mcp
 from autoskillit.server._guards import _require_enabled
+from autoskillit.server._subprocess import _run_subprocess
 from autoskillit.server.helpers import (
     _notify,
-    _run_subprocess,
     track_response_size,
 )
 

--- a/src/autoskillit/server/tools_workspace.py
+++ b/src/autoskillit/server/tools_workspace.py
@@ -14,9 +14,9 @@ from fastmcp.dependencies import CurrentContext
 from autoskillit.core import get_logger, truncate_text
 from autoskillit.server import mcp
 from autoskillit.server._guards import _require_enabled
+from autoskillit.server._subprocess import _run_subprocess
 from autoskillit.server.helpers import (
     _notify,
-    _run_subprocess,
     track_response_size,
 )
 

--- a/tests/arch/test_import_paths.py
+++ b/tests/arch/test_import_paths.py
@@ -209,6 +209,9 @@ def test_req_imp_005_git_only_core_at_runtime() -> None:
     _ALLOWED = frozenset(
         {
             "autoskillit.server._editable_guard",
+            # _subprocess is a same-package helper with no upward layer imports;
+            # git.py delegates timeout result processing to _process_runner_result.
+            "autoskillit.server._subprocess",
             # workspace is L1; git.py delegates worktree removal to the
             # single L1 implementation rather than inlining subprocess calls.
             "autoskillit.workspace",

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -550,9 +550,10 @@ def test_server_file_count_under_limit() -> None:
     Limit updated from 20 to 22 after tools_ci.py was split into
     tools_ci_watch.py and tools_ci_merge_queue.py submodules.
     Limit updated from 22 to 23 after _guards.py was extracted from helpers.py.
+    Limit updated from 23 to 24 after _subprocess.py was extracted from helpers.py.
     """
     py_files = list((SRC_ROOT / "server").glob("*.py"))
-    assert len(py_files) <= 23, f"server/ has {len(py_files)} files, max is 23"
+    assert len(py_files) <= 24, f"server/ has {len(py_files)} files, max is 24"
 
 
 def test_tools_integrations_replaced_by_split_modules() -> None:

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -765,7 +765,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         server/ tests. Exempt at 11 files.
     """
     EXEMPTIONS: dict[str, int] = {
-        "server": 23,
+        "server": 24,
         "recipe": 48,
         "execution": 35,
         "core": 32,

--- a/tests/contracts/test_protocol_satisfaction.py
+++ b/tests/contracts/test_protocol_satisfaction.py
@@ -477,20 +477,20 @@ class TestGroupDApiContractPreservation:
             f"{runtime_import.group()!r}"
         )
 
-    def test_req_api_004_server_helpers_subprocess_result_under_type_checking(self):
-        """server/helpers.py must import SubprocessResult only under TYPE_CHECKING."""
-        source = (self._pkg_root() / "server" / "helpers.py").read_text()
+    def test_req_api_004_server_subprocess_result_under_type_checking(self):
+        """server/_subprocess.py must import SubprocessResult only under TYPE_CHECKING."""
+        source = (self._pkg_root() / "server" / "_subprocess.py").read_text()
         assert "SubprocessResult" in source, (
-            "SubprocessResult reference vanished from server/helpers.py entirely"
+            "SubprocessResult reference vanished from server/_subprocess.py entirely"
         )
-        assert "TYPE_CHECKING" in source, "TYPE_CHECKING guard removed from server/helpers.py"
+        assert "TYPE_CHECKING" in source, "TYPE_CHECKING guard removed from server/_subprocess.py"
         runtime_import = re.search(
             r"^from\s+\S+\s+import\s+.*SubprocessResult",
             source,
             re.MULTILINE,
         )
         assert runtime_import is None, (
-            f"SubprocessResult has a runtime import in server/helpers.py: "
+            f"SubprocessResult has a runtime import in server/_subprocess.py: "
             f"{runtime_import.group()!r}"
         )
 

--- a/tests/server/test_tools_github_api_tracking.py
+++ b/tests/server/test_tools_github_api_tracking.py
@@ -25,9 +25,9 @@ async def test_gh_cli_call_is_recorded(build_ctx):
     )
     ctx.runner = runner
 
-    from autoskillit.server.helpers import _run_subprocess
+    from autoskillit.server._subprocess import _run_subprocess
 
-    with patch("autoskillit.server.helpers._get_ctx", return_value=ctx):
+    with patch("autoskillit.server._subprocess._get_ctx", return_value=ctx):
         await _run_subprocess(["gh", "pr", "list", "--json", "number"], cwd="/tmp", timeout=30)
 
     usage = log.to_usage("sess-1")
@@ -53,9 +53,9 @@ async def test_non_gh_command_is_not_recorded(build_ctx):
     )
     ctx.runner = runner
 
-    from autoskillit.server.helpers import _run_subprocess
+    from autoskillit.server._subprocess import _run_subprocess
 
-    with patch("autoskillit.server.helpers._get_ctx", return_value=ctx):
+    with patch("autoskillit.server._subprocess._get_ctx", return_value=ctx):
         await _run_subprocess(["git", "status"], cwd="/tmp", timeout=30)
 
     assert log.to_usage("sess-1") is None
@@ -78,7 +78,7 @@ async def test_gh_cli_records_exit_code_and_latency(build_ctx):
     )
     ctx.runner = runner
 
-    from autoskillit.server.helpers import _run_subprocess
+    from autoskillit.server._subprocess import _run_subprocess
 
     _tick = 0.0
 
@@ -88,8 +88,8 @@ async def test_gh_cli_records_exit_code_and_latency(build_ctx):
         return _tick
 
     with (
-        patch("autoskillit.server.helpers._get_ctx", return_value=ctx),
-        patch("autoskillit.server.helpers.time.monotonic", _fake_monotonic),
+        patch("autoskillit.server._subprocess._get_ctx", return_value=ctx),
+        patch("autoskillit.server._subprocess.time.monotonic", _fake_monotonic),
     ):
         await _run_subprocess(["gh", "api", "repos/o/r/issues"], cwd="/tmp", timeout=30)
 

--- a/tests/server/test_tools_run_cmd.py
+++ b/tests/server/test_tools_run_cmd.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import structlog.testing
 
-from autoskillit.server.helpers import _run_subprocess
+from autoskillit.server._subprocess import _run_subprocess
 from autoskillit.server.tools_execution import run_cmd, run_python
 from tests.conftest import _make_result, _make_timeout_result
 
@@ -65,12 +65,12 @@ class TestRunSubprocessDelegatesToManaged:
 
 
 class TestProcessRunnerResult:
-    """_process_runner_result shared helper lives in server.helpers."""
+    """_process_runner_result shared helper lives in server._subprocess."""
 
     def test_normal_exit_preserves_fields(self):
         from autoskillit.core import TerminationReason
         from autoskillit.execution.process import SubprocessResult
-        from autoskillit.server.helpers import _process_runner_result
+        from autoskillit.server._subprocess import _process_runner_result
 
         result = SubprocessResult(
             returncode=0,
@@ -87,7 +87,7 @@ class TestProcessRunnerResult:
     def test_timed_out_returns_minus_one_with_message(self):
         from autoskillit.core import TerminationReason
         from autoskillit.execution.process import SubprocessResult
-        from autoskillit.server.helpers import _process_runner_result
+        from autoskillit.server._subprocess import _process_runner_result
 
         result = SubprocessResult(
             returncode=-1,


### PR DESCRIPTION
## Summary

Extract the subprocess execution concern (`_run_subprocess`, `_process_runner_result`, `_GH_API_SUBCOMMANDS`, `_is_github_cli_call`) from `server/helpers.py` into a new `server/_subprocess.py` module, along with a duplicate of the `_get_ctx` deferred-import shim they depend on (the original stays in `helpers.py` for its remaining callers). Migrate all 6 tool-file consumers and 2 test files to import from the new location. Delete the extracted symbols and their orphaned imports from `helpers.py`. No re-export shim.

Closes #1542

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-1542-20260429-203136-929608/.autoskillit/temp/make-plan/p4_extract_subprocess_py_plan_2026-04-29_203300.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 61 | 9.4k | 760.3k | 54.1k | 1 | 4m 40s |
| verify | 1.1k | 8.6k | 728.8k | 47.9k | 1 | 5m 44s |
| implement | 48 | 11.4k | 1.0M | 69.6k | 1 | 3m 58s |
| prepare_pr | 24 | 3.7k | 174.4k | 25.2k | 1 | 1m 10s |
| compose_pr | 22 | 1.4k | 128.9k | 18.2k | 1 | 40s |
| review_pr | 136 | 17.7k | 596.7k | 52.4k | 1 | 6m 20s |
| resolve_review | 45 | 7.1k | 1.2M | 58.5k | 1 | 7m 25s |
| resolve_queue_merge_conflicts | 61 | 24.1k | 2.6M | 163.4k | 1 | 8m 34s |
| diagnose_ci | 32 | 3.4k | 525.0k | 35.1k | 1 | 1m 42s |
| resolve_ci | 44 | 3.6k | 700.3k | 37.3k | 1 | 4m 9s |
| **Total** | 1.6k | 90.4k | 8.4M | 561.7k | | 44m 27s |