### PR TITLE
P4: extract _guards.py from helpers.py and migrate consumers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,6 +301,7 @@ generic_automation_mcp/
 │   ├── __init__.py          #   FastMCP app, kitchen gating, headless tool reveal
 │   ├── git.py               #   Merge workflow for merge_worktree
 │   ├── _editable_guard.py   #   Pre-deletion editable install guard (stdlib-only)
+│   ├── _guards.py           #   Tier/gate guard functions: _require_enabled, _require_orchestrator_*, _require_fleet, _check_dry_walkthrough, _validate_skill_command
 │   ├── _lifespan.py         #   FastMCP lifespan: recorder teardown on shutdown
 │   ├── _session_type.py     #   Session-type tag visibility dispatcher (3-branch startup logic)
 │   ├── _wire_compat.py      #   Claude Code wire-format sanitization middleware

--- a/src/autoskillit/server/_guards.py
+++ b/src/autoskillit/server/_guards.py
@@ -1,0 +1,147 @@
+"""Tier/gate guard functions for MCP tool access control."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from autoskillit.core import SessionType, extract_path_arg, session_type
+from autoskillit.pipeline import gate_error_result, headless_error_result
+
+
+def _get_ctx():  # type: ignore[return]
+    from autoskillit.server._state import _get_ctx as _ctx_fn
+
+    return _ctx_fn()
+
+
+def _get_config():  # type: ignore[return]
+    from autoskillit.server._state import _get_config as _cfg_fn
+
+    return _cfg_fn()
+
+
+def _require_orchestrator_or_higher(tool_name: str = "") -> str | None:
+    """Return headless_error JSON if session is leaf-tier; None if permitted.
+
+    Interactive sessions (HEADLESS not set) always pass.
+    Headless sessions must be orchestrator or fleet tier.
+    Fail-closed: unset/invalid SESSION_TYPE → LEAF → deny.
+    """
+    if os.environ.get("AUTOSKILLIT_HEADLESS") != "1":
+        return None
+
+    st = session_type()
+    if st in (SessionType.ORCHESTRATOR, SessionType.FLEET):
+        return None
+
+    msg = (
+        f"{tool_name} cannot be called from leaf sessions. "
+        "Only orchestrator or fleet sessions may call this tool."
+        if tool_name
+        else None
+    )
+    return headless_error_result(msg)
+
+
+def _require_orchestrator_exact(tool_name: str = "") -> str | None:
+    """Return headless_error JSON if session is not orchestrator-tier; None if permitted.
+
+    Interactive sessions (HEADLESS not set) always pass.
+    Headless sessions must be exactly orchestrator tier.
+    Fleet and leaf tiers are denied.
+    """
+    if os.environ.get("AUTOSKILLIT_HEADLESS") != "1":
+        return None
+
+    st = session_type()
+    if st is SessionType.ORCHESTRATOR:
+        return None
+
+    if st is SessionType.FLEET:
+        msg = (
+            f"{tool_name} cannot be called from {st.value} sessions. "
+            f"{st.value.capitalize()} sessions have an auto-opened gate."
+            " open_kitchen is unnecessary."
+            if tool_name
+            else None
+        )
+    else:
+        msg = (
+            f"{tool_name} cannot be called from leaf sessions. "
+            "Only the orchestrator may call this tool."
+            if tool_name
+            else None
+        )
+    return headless_error_result(msg)
+
+
+def _require_fleet(tool_name: str = "") -> str | None:
+    """Return headless_error JSON if session is not fleet-tier; None if permitted.
+
+    No interactive bypass — fleet is a specific tier, not a headless guard.
+    """
+    st = session_type()
+    if st is SessionType.FLEET:
+        return None
+
+    msg = (
+        f"{tool_name} requires a fleet session. Current session type is not fleet."
+        if tool_name
+        else None
+    )
+    return headless_error_result(msg)
+
+
+def _require_enabled() -> str | None:
+    """Return error JSON if tools are not enabled, None if OK.
+
+    All tools are gated by default and can only be activated by the user
+    typing the open_kitchen prompt. The prompt name is prefixed by Claude
+    Code based on how the server was loaded (plugin vs --plugin-dir).
+    This survives --dangerously-skip-permissions because MCP prompts are
+    outside the permission system.
+    """
+    if not _get_ctx().gate.enabled:
+        return gate_error_result()
+    return None
+
+
+def _validate_skill_command(skill_command: str) -> str | None:
+    """Return error JSON if skill_command does not start with '/', None if OK."""
+    if not skill_command.strip().startswith("/"):
+        return gate_error_result(
+            "run_skill requires a slash-command as skill_command.\n"
+            f"Got: {skill_command!r}\n"
+            "Expected: skill_command must start with '/' "
+            "(e.g. /autoskillit:investigate, /autoskillit:make-plan, /audit-arch).\n"
+            "Prose task descriptions are not valid skill invocations."
+        )
+    return None
+
+
+def _check_dry_walkthrough(skill_command: str, cwd: str) -> str | None:
+    """If skill_command is an implement skill, verify the plan has been dry-walked.
+
+    Returns an error JSON string if validation fails, None if OK.
+    """
+    tokens = skill_command.strip().split()
+    if not tokens or tokens[0] not in _get_config().implement_gate.skill_names:
+        return None
+    skill_name = tokens[0]
+    plan_path_str = extract_path_arg(skill_command)
+    if plan_path_str is None:
+        return gate_error_result(f"Missing plan path argument for {skill_name}")
+    plan_path = Path(cwd) / plan_path_str
+    if not plan_path.is_file():
+        return gate_error_result(f"Plan file not found: {plan_path}")
+
+    first_line = plan_path.read_text().split("\n", 1)[0].strip()
+    if first_line != _get_config().implement_gate.marker:
+        return gate_error_result(
+            f"Plan has NOT been dry-walked. Run /dry-walkthrough on the plan first. "
+            f"Expected first line: {_get_config().implement_gate.marker!r}, "
+            f"actual: {first_line[:100]!r}"
+        )
+
+    return None

--- a/src/autoskillit/server/helpers.py
+++ b/src/autoskillit/server/helpers.py
@@ -1,11 +1,10 @@
-"""Subprocess wrapper, dry-walkthrough check, and shared helpers for MCP tools."""
+"""Subprocess wrapper and shared helpers for MCP tools."""
 
 from __future__ import annotations
 
 import asyncio
 import functools
 import json
-import os
 import time
 from collections.abc import Awaitable, Callable, Mapping
 from datetime import UTC, datetime
@@ -14,11 +13,8 @@ from typing import TYPE_CHECKING, Any
 
 from autoskillit.core import (
     RESERVED_LOG_RECORD_KEYS,
-    SessionType,
     TerminationReason,
-    extract_path_arg,
     get_logger,
-    session_type,
 )
 from autoskillit.execution import (
     SCENARIO_STEP_NAME_ENV,  # noqa: F401 — re-exported for tools_execution.py
@@ -31,7 +27,6 @@ from autoskillit.execution import (
     write_telemetry_clear_marker,  # noqa: F401 — used by tools_status.py
 )
 from autoskillit.hooks import _HOOK_CONFIG_PATH_COMPONENTS
-from autoskillit.pipeline import gate_error_result, headless_error_result
 from autoskillit.workspace import clone_registry  # noqa: F401 — re-exported for tools_clone.py
 
 if TYPE_CHECKING:
@@ -182,105 +177,6 @@ def track_response_size(
     return decorator
 
 
-def _require_orchestrator_or_higher(tool_name: str = "") -> str | None:
-    """Return headless_error JSON if session is leaf-tier; None if permitted.
-
-    Interactive sessions (HEADLESS not set) always pass.
-    Headless sessions must be orchestrator or fleet tier.
-    Fail-closed: unset/invalid SESSION_TYPE → LEAF → deny.
-    """
-    if os.environ.get("AUTOSKILLIT_HEADLESS") != "1":
-        return None
-
-    st = session_type()
-    if st in (SessionType.ORCHESTRATOR, SessionType.FLEET):
-        return None
-
-    msg = (
-        f"{tool_name} cannot be called from leaf sessions. "
-        "Only orchestrator or fleet sessions may call this tool."
-        if tool_name
-        else None
-    )
-    return headless_error_result(msg)
-
-
-def _require_orchestrator_exact(tool_name: str = "") -> str | None:
-    """Return headless_error JSON if session is not orchestrator-tier; None if permitted.
-
-    Interactive sessions (HEADLESS not set) always pass.
-    Headless sessions must be exactly orchestrator tier.
-    Fleet and leaf tiers are denied.
-    """
-    if os.environ.get("AUTOSKILLIT_HEADLESS") != "1":
-        return None
-
-    st = session_type()
-    if st is SessionType.ORCHESTRATOR:
-        return None
-
-    if st is SessionType.FLEET:
-        msg = (
-            f"{tool_name} cannot be called from {st.value} sessions. "
-            f"{st.value.capitalize()} sessions have an auto-opened gate."
-            " open_kitchen is unnecessary."
-            if tool_name
-            else None
-        )
-    else:
-        msg = (
-            f"{tool_name} cannot be called from leaf sessions. "
-            "Only the orchestrator may call this tool."
-            if tool_name
-            else None
-        )
-    return headless_error_result(msg)
-
-
-def _require_fleet(tool_name: str = "") -> str | None:
-    """Return headless_error JSON if session is not fleet-tier; None if permitted.
-
-    No interactive bypass — fleet is a specific tier, not a headless guard.
-    """
-    st = session_type()
-    if st is SessionType.FLEET:
-        return None
-
-    msg = (
-        f"{tool_name} requires a fleet session. Current session type is not fleet."
-        if tool_name
-        else None
-    )
-    return headless_error_result(msg)
-
-
-def _require_enabled() -> str | None:
-    """Return error JSON if tools are not enabled, None if OK.
-
-    All tools are gated by default and can only be activated by the user
-    typing the open_kitchen prompt. The prompt name is prefixed by Claude
-    Code based on how the server was loaded (plugin vs --plugin-dir).
-    This survives --dangerously-skip-permissions because MCP prompts are
-    outside the permission system.
-    """
-    if not _get_ctx().gate.enabled:
-        return gate_error_result()
-    return None
-
-
-def _validate_skill_command(skill_command: str) -> str | None:
-    """Return error JSON if skill_command does not start with '/', None if OK."""
-    if not skill_command.strip().startswith("/"):
-        return gate_error_result(
-            "run_skill requires a slash-command as skill_command.\n"
-            f"Got: {skill_command!r}\n"
-            "Expected: skill_command must start with '/' "
-            "(e.g. /autoskillit:investigate, /autoskillit:make-plan, /audit-arch).\n"
-            "Prose task descriptions are not valid skill invocations."
-        )
-    return None
-
-
 def _extract_block(text: str, start_delim: str, end_delim: str) -> list[str]:
     """Return all lines between start_delim and end_delim (exclusive).
 
@@ -377,40 +273,6 @@ async def _run_subprocess(
             )
 
     return returncode, stdout, stderr
-
-
-def _check_dry_walkthrough(skill_command: str, cwd: str) -> str | None:
-    """If skill_command is an implement skill, verify the plan has been dry-walked.
-
-    Returns an error JSON string if validation fails, None if OK.
-    """
-    tokens = skill_command.strip().split()
-    if not tokens or tokens[0] not in _get_config().implement_gate.skill_names:
-        return None
-    skill_name = tokens[0]
-    plan_path_str = extract_path_arg(skill_command)
-    if plan_path_str is None:
-        return gate_error_result(f"Missing plan path argument for {skill_name}")
-    plan_path = Path(cwd) / plan_path_str
-    if not plan_path.is_file():
-        return gate_error_result(f"Plan file not found: {plan_path}")
-
-    # TOCTOU acceptance (option c, per P1-5): This function reads the plan file
-    # once here. If the file is modified or deleted between this gate check and
-    # the headless session acting on it, the gate condition will be stale.
-    # This is an accepted limitation: the plan file is user-controlled, and
-    # modification between check and execution is a user error. Options (a) and
-    # (b) — passing file content via stdin or re-verifying via content hash —
-    # involve significant scope and are deferred.
-    first_line = plan_path.read_text().split("\n", 1)[0].strip()
-    if first_line != _get_config().implement_gate.marker:
-        return gate_error_result(
-            f"Plan has NOT been dry-walked. Run /dry-walkthrough on the plan first. "
-            f"Expected first line: {_get_config().implement_gate.marker!r}, "
-            f"actual: {first_line[:100]!r}"
-        )
-
-    return None
 
 
 async def _import_and_call(

--- a/src/autoskillit/server/tools_ci.py
+++ b/src/autoskillit/server/tools_ci.py
@@ -12,8 +12,8 @@ from fastmcp.dependencies import CurrentContext
 
 from autoskillit.core import DirectInstall, MarketplaceInstall, get_logger
 from autoskillit.server import mcp
+from autoskillit.server._guards import _require_enabled
 from autoskillit.server.helpers import (
-    _require_enabled,
     _run_subprocess,
     fetch_repo_merge_state,
     resolve_repo_from_remote,

--- a/src/autoskillit/server/tools_ci_merge_queue.py
+++ b/src/autoskillit/server/tools_ci_merge_queue.py
@@ -11,9 +11,9 @@ from fastmcp.dependencies import CurrentContext
 
 from autoskillit.core import get_logger
 from autoskillit.server import mcp
+from autoskillit.server._guards import _require_enabled
 from autoskillit.server.helpers import (
     _notify,
-    _require_enabled,
     resolve_repo_from_remote,
     track_response_size,
 )

--- a/src/autoskillit/server/tools_ci_watch.py
+++ b/src/autoskillit/server/tools_ci_watch.py
@@ -14,9 +14,9 @@ from fastmcp.dependencies import CurrentContext
 from autoskillit.core import CIRunScope, get_logger
 from autoskillit.pipeline import ToolContext
 from autoskillit.server import mcp
+from autoskillit.server._guards import _require_enabled
 from autoskillit.server.helpers import (
     _notify,
-    _require_enabled,
     _run_subprocess,
     resolve_repo_from_remote,
     track_response_size,

--- a/src/autoskillit/server/tools_clone.py
+++ b/src/autoskillit/server/tools_clone.py
@@ -15,9 +15,9 @@ from fastmcp.dependencies import CurrentContext
 
 from autoskillit.core import CAMPAIGN_ID_ENV_VAR, get_logger
 from autoskillit.server import mcp
+from autoskillit.server._guards import _require_enabled
 from autoskillit.server.helpers import (
     _notify,
-    _require_enabled,
     clone_registry,
     track_response_size,
 )

--- a/src/autoskillit/server/tools_execution.py
+++ b/src/autoskillit/server/tools_execution.py
@@ -22,15 +22,17 @@ from autoskillit.core import (
     validate_add_dir,
 )
 from autoskillit.server import mcp
-from autoskillit.server.helpers import (
-    SCENARIO_STEP_NAME_ENV,
+from autoskillit.server._guards import (
     _check_dry_walkthrough,
-    _import_and_call,
-    _notify,
     _require_enabled,
     _require_orchestrator_or_higher,
-    _run_subprocess,
     _validate_skill_command,
+)
+from autoskillit.server.helpers import (
+    SCENARIO_STEP_NAME_ENV,
+    _import_and_call,
+    _notify,
+    _run_subprocess,
     track_response_size,
 )
 

--- a/src/autoskillit/server/tools_git.py
+++ b/src/autoskillit/server/tools_git.py
@@ -12,9 +12,9 @@ from fastmcp.dependencies import CurrentContext
 
 from autoskillit.core import RestartScope, get_logger
 from autoskillit.server import mcp
+from autoskillit.server._guards import _require_enabled
 from autoskillit.server.helpers import (
     _notify,
-    _require_enabled,
     _run_subprocess,
     track_response_size,
 )

--- a/src/autoskillit/server/tools_github.py
+++ b/src/autoskillit/server/tools_github.py
@@ -15,10 +15,10 @@ from fastmcp.dependencies import CurrentContext
 from autoskillit.core import atomic_write, get_logger
 from autoskillit.pipeline import write_status
 from autoskillit.server import mcp
+from autoskillit.server._guards import _require_enabled
 from autoskillit.server.helpers import (
     _extract_block,
     _notify,
-    _require_enabled,
     resolve_log_dir,
     track_response_size,
 )

--- a/src/autoskillit/server/tools_issue_lifecycle.py
+++ b/src/autoskillit/server/tools_issue_lifecycle.py
@@ -12,10 +12,10 @@ from fastmcp.dependencies import CurrentContext
 
 from autoskillit.core import RetryReason, _parse_issue_ref, get_logger
 from autoskillit.server import mcp
+from autoskillit.server._guards import _require_enabled
 from autoskillit.server.helpers import (
     _extract_block,
     _notify,
-    _require_enabled,
     track_response_size,
 )
 

--- a/src/autoskillit/server/tools_kitchen.py
+++ b/src/autoskillit/server/tools_kitchen.py
@@ -27,13 +27,13 @@ from autoskillit.core import (
 )
 from autoskillit.pipeline import create_background_task
 from autoskillit.server import mcp
+from autoskillit.server._guards import _require_orchestrator_exact
 from autoskillit.server.helpers import (
     _apply_triage_gate,
     _build_hook_diagnostic_warning,
     _hook_config_path,
     _prime_quota_cache,
     _quota_refresh_loop,
-    _require_orchestrator_exact,
     track_response_size,
 )
 

--- a/src/autoskillit/server/tools_pr_ops.py
+++ b/src/autoskillit/server/tools_pr_ops.py
@@ -13,9 +13,9 @@ from fastmcp.dependencies import CurrentContext
 
 from autoskillit.core import atomic_write, get_logger
 from autoskillit.server import mcp
+from autoskillit.server._guards import _require_enabled
 from autoskillit.server.helpers import (
     _notify,
-    _require_enabled,
     _run_subprocess,
     track_response_size,
 )

--- a/src/autoskillit/server/tools_recipe.py
+++ b/src/autoskillit/server/tools_recipe.py
@@ -13,11 +13,11 @@ from autoskillit.config import resolve_ingredient_defaults
 from autoskillit.core import get_logger, temp_dir_display_str
 from autoskillit.pipeline import GATED_TOOLS, UNGATED_TOOLS  # noqa: F401
 from autoskillit.server import mcp
+from autoskillit.server._guards import _require_enabled
 from autoskillit.server._state import _get_ctx_or_none
 from autoskillit.server.helpers import (
     _apply_triage_gate,
     _notify,
-    _require_enabled,
     track_response_size,
 )
 

--- a/src/autoskillit/server/tools_status.py
+++ b/src/autoskillit/server/tools_status.py
@@ -14,9 +14,9 @@ from fastmcp.dependencies import CurrentContext
 from autoskillit.core import atomic_write, get_logger
 from autoskillit.pipeline import TelemetryFormatter
 from autoskillit.server import mcp
+from autoskillit.server._guards import _require_enabled
 from autoskillit.server.helpers import (
     _notify,
-    _require_enabled,
     resolve_log_dir,
     track_response_size,
     write_telemetry_clear_marker,

--- a/src/autoskillit/server/tools_workspace.py
+++ b/src/autoskillit/server/tools_workspace.py
@@ -13,9 +13,9 @@ from fastmcp.dependencies import CurrentContext
 
 from autoskillit.core import get_logger, truncate_text
 from autoskillit.server import mcp
+from autoskillit.server._guards import _require_enabled
 from autoskillit.server.helpers import (
     _notify,
-    _require_enabled,
     _run_subprocess,
     track_response_size,
 )

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -549,9 +549,10 @@ def test_server_file_count_under_limit() -> None:
     session-type tag visibility dispatch (3-branch startup logic).
     Limit updated from 20 to 22 after tools_ci.py was split into
     tools_ci_watch.py and tools_ci_merge_queue.py submodules.
+    Limit updated from 22 to 23 after _guards.py was extracted from helpers.py.
     """
     py_files = list((SRC_ROOT / "server").glob("*.py"))
-    assert len(py_files) <= 22, f"server/ has {len(py_files)} files, max is 22"
+    assert len(py_files) <= 23, f"server/ has {len(py_files)} files, max is 23"
 
 
 def test_tools_integrations_replaced_by_split_modules() -> None:
@@ -763,7 +764,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         server/ tests. Exempt at 11 files.
     """
     EXEMPTIONS: dict[str, int] = {
-        "server": 22,
+        "server": 23,
         "recipe": 48,
         "execution": 35,
         "core": 32,

--- a/tests/server/test_guards_module.py
+++ b/tests/server/test_guards_module.py
@@ -1,0 +1,56 @@
+"""Smoke test: all 6 guards are importable from _guards."""
+
+import pytest
+
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+
+def test_require_enabled_importable():
+    from autoskillit.server._guards import _require_enabled
+
+    assert callable(_require_enabled)
+
+
+def test_require_orchestrator_or_higher_importable():
+    from autoskillit.server._guards import _require_orchestrator_or_higher
+
+    assert callable(_require_orchestrator_or_higher)
+
+
+def test_require_orchestrator_exact_importable():
+    from autoskillit.server._guards import _require_orchestrator_exact
+
+    assert callable(_require_orchestrator_exact)
+
+
+def test_require_fleet_importable():
+    from autoskillit.server._guards import _require_fleet
+
+    assert callable(_require_fleet)
+
+
+def test_check_dry_walkthrough_importable():
+    from autoskillit.server._guards import _check_dry_walkthrough
+
+    assert callable(_check_dry_walkthrough)
+
+
+def test_validate_skill_command_importable():
+    from autoskillit.server._guards import _validate_skill_command
+
+    assert callable(_validate_skill_command)
+
+
+def test_guards_not_in_helpers():
+    """After extraction, no guard function should remain in helpers."""
+    import autoskillit.server.helpers as h
+
+    for name in (
+        "_require_enabled",
+        "_require_orchestrator_or_higher",
+        "_require_orchestrator_exact",
+        "_require_fleet",
+        "_check_dry_walkthrough",
+        "_validate_skill_command",
+    ):
+        assert not hasattr(h, name), f"{name} still defined in helpers.py"

--- a/tests/server/test_helpers_gate.py
+++ b/tests/server/test_helpers_gate.py
@@ -32,7 +32,7 @@ class TestGateDisabledSchema:
     def test_gate_disabled_schema(self, tool_ctx):
         """Gate-disabled response has standard keys."""
         from autoskillit.pipeline.gate import DefaultGateState
-        from autoskillit.server.helpers import _require_enabled
+        from autoskillit.server._guards import _require_enabled
 
         tool_ctx.gate = DefaultGateState(enabled=False)
         response = json.loads(_require_enabled())

--- a/tests/server/test_helpers_tier_guards.py
+++ b/tests/server/test_helpers_tier_guards.py
@@ -17,7 +17,7 @@ pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
 
 def test_A1_require_orchestrator_or_higher_permits_interactive(monkeypatch) -> None:
     monkeypatch.delenv("AUTOSKILLIT_HEADLESS", raising=False)
-    from autoskillit.server.helpers import _require_orchestrator_or_higher
+    from autoskillit.server._guards import _require_orchestrator_or_higher
 
     assert _require_orchestrator_or_higher("run_cmd") is None
 
@@ -25,7 +25,7 @@ def test_A1_require_orchestrator_or_higher_permits_interactive(monkeypatch) -> N
 def test_A2_require_orchestrator_or_higher_permits_headless_orchestrator(monkeypatch) -> None:
     monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
     monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "orchestrator")
-    from autoskillit.server.helpers import _require_orchestrator_or_higher
+    from autoskillit.server._guards import _require_orchestrator_or_higher
 
     assert _require_orchestrator_or_higher("run_cmd") is None
 
@@ -33,7 +33,7 @@ def test_A2_require_orchestrator_or_higher_permits_headless_orchestrator(monkeyp
 def test_A3_require_orchestrator_or_higher_permits_headless_fleet(monkeypatch) -> None:
     monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
     monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
-    from autoskillit.server.helpers import _require_orchestrator_or_higher
+    from autoskillit.server._guards import _require_orchestrator_or_higher
 
     assert _require_orchestrator_or_higher("run_cmd") is None
 
@@ -41,7 +41,7 @@ def test_A3_require_orchestrator_or_higher_permits_headless_fleet(monkeypatch) -
 def test_A4_require_orchestrator_or_higher_denies_headless_leaf(monkeypatch) -> None:
     monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
     monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "leaf")
-    from autoskillit.server.helpers import _require_orchestrator_or_higher
+    from autoskillit.server._guards import _require_orchestrator_or_higher
 
     result = _require_orchestrator_or_higher("run_cmd")
     assert result is not None
@@ -54,7 +54,7 @@ def test_A5_require_orchestrator_or_higher_denies_headless_unset_session_type(
 ) -> None:
     monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
     monkeypatch.delenv("AUTOSKILLIT_SESSION_TYPE", raising=False)
-    from autoskillit.server.helpers import _require_orchestrator_or_higher
+    from autoskillit.server._guards import _require_orchestrator_or_higher
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
@@ -69,7 +69,7 @@ def test_A6_require_orchestrator_or_higher_denies_headless_invalid_session_type(
 ) -> None:
     monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
     monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "bogus")
-    from autoskillit.server.helpers import _require_orchestrator_or_higher
+    from autoskillit.server._guards import _require_orchestrator_or_higher
 
     with warnings.catch_warnings(record=True):
         warnings.simplefilter("always")
@@ -86,7 +86,7 @@ def test_A6_require_orchestrator_or_higher_denies_headless_invalid_session_type(
 
 def test_A7_require_orchestrator_exact_permits_interactive(monkeypatch) -> None:
     monkeypatch.delenv("AUTOSKILLIT_HEADLESS", raising=False)
-    from autoskillit.server.helpers import _require_orchestrator_exact
+    from autoskillit.server._guards import _require_orchestrator_exact
 
     assert _require_orchestrator_exact("open_kitchen") is None
 
@@ -94,7 +94,7 @@ def test_A7_require_orchestrator_exact_permits_interactive(monkeypatch) -> None:
 def test_A8_require_orchestrator_exact_permits_headless_orchestrator(monkeypatch) -> None:
     monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
     monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "orchestrator")
-    from autoskillit.server.helpers import _require_orchestrator_exact
+    from autoskillit.server._guards import _require_orchestrator_exact
 
     assert _require_orchestrator_exact("open_kitchen") is None
 
@@ -102,7 +102,7 @@ def test_A8_require_orchestrator_exact_permits_headless_orchestrator(monkeypatch
 def test_A9_require_orchestrator_exact_denies_headless_fleet(monkeypatch) -> None:
     monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
     monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
-    from autoskillit.server.helpers import _require_orchestrator_exact
+    from autoskillit.server._guards import _require_orchestrator_exact
 
     result = _require_orchestrator_exact("open_kitchen")
     assert result is not None
@@ -115,7 +115,7 @@ def test_A9_require_orchestrator_exact_denies_headless_fleet(monkeypatch) -> Non
 def test_A10_require_orchestrator_exact_denies_headless_leaf(monkeypatch) -> None:
     monkeypatch.setenv("AUTOSKILLIT_HEADLESS", "1")
     monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "leaf")
-    from autoskillit.server.helpers import _require_orchestrator_exact
+    from autoskillit.server._guards import _require_orchestrator_exact
 
     result = _require_orchestrator_exact("open_kitchen")
     assert result is not None
@@ -131,7 +131,7 @@ def test_A10_require_orchestrator_exact_denies_headless_leaf(monkeypatch) -> Non
 @pytest.mark.feature("fleet")
 def test_A11_require_fleet_permits_fleet_session(monkeypatch) -> None:
     monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
-    from autoskillit.server.helpers import _require_fleet
+    from autoskillit.server._guards import _require_fleet
 
     assert _require_fleet() is None
 
@@ -139,7 +139,7 @@ def test_A11_require_fleet_permits_fleet_session(monkeypatch) -> None:
 @pytest.mark.feature("fleet")
 def test_A12_require_fleet_denies_orchestrator(monkeypatch) -> None:
     monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "orchestrator")
-    from autoskillit.server.helpers import _require_fleet
+    from autoskillit.server._guards import _require_fleet
 
     result = _require_fleet()
     assert result is not None
@@ -151,7 +151,7 @@ def test_A12_require_fleet_denies_orchestrator(monkeypatch) -> None:
 def test_A13_require_fleet_denies_interactive_no_session_type(monkeypatch) -> None:
     monkeypatch.delenv("AUTOSKILLIT_SESSION_TYPE", raising=False)
     monkeypatch.delenv("AUTOSKILLIT_HEADLESS", raising=False)
-    from autoskillit.server.helpers import _require_fleet
+    from autoskillit.server._guards import _require_fleet
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")

--- a/tests/server/test_server_init_gate.py
+++ b/tests/server/test_server_init_gate.py
@@ -10,7 +10,7 @@ import pytest
 import structlog.testing
 
 from autoskillit.pipeline.gate import DefaultGateState
-from autoskillit.server.helpers import _require_enabled
+from autoskillit.server._guards import _require_enabled
 from autoskillit.server.tools_kitchen import _close_kitchen_handler, _open_kitchen_handler
 
 pytestmark = [pytest.mark.layer("server"), pytest.mark.medium]

--- a/tests/server/test_server_tool_registration.py
+++ b/tests/server/test_server_tool_registration.py
@@ -354,7 +354,7 @@ class TestConfigDrivenBehavior:
     def test_dry_walkthrough_uses_config_marker(self, tool_ctx, tmp_path):
         """S7: Gate checks config.implement_gate.marker."""
         from autoskillit.config import ImplementGateConfig
-        from autoskillit.server.helpers import _check_dry_walkthrough
+        from autoskillit.server._guards import _check_dry_walkthrough
 
         tool_ctx.config = AutomationConfig(
             implement_gate=ImplementGateConfig(marker="CUSTOM MARKER")
@@ -372,7 +372,7 @@ class TestConfigDrivenBehavior:
     def test_dry_walkthrough_uses_config_skill_names(self, tool_ctx, tmp_path):
         """S8: Gate checks config.implement_gate.skill_names."""
         from autoskillit.config import ImplementGateConfig
-        from autoskillit.server.helpers import _check_dry_walkthrough
+        from autoskillit.server._guards import _check_dry_walkthrough
 
         tool_ctx.config = AutomationConfig(
             implement_gate=ImplementGateConfig(skill_names={"/custom-impl"})

--- a/tests/server/test_tools_execution_input_gates.py
+++ b/tests/server/test_tools_execution_input_gates.py
@@ -6,10 +6,8 @@ import json
 
 import pytest
 
-from autoskillit.server.helpers import (
-    _check_dry_walkthrough,
-    _get_config,
-)
+from autoskillit.server._guards import _check_dry_walkthrough
+from autoskillit.server.helpers import _get_config
 from autoskillit.server.tools_execution import run_skill
 
 pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
@@ -220,17 +218,17 @@ class TestValidateSkillCommand:
     """Unit tests for _validate_skill_command helper."""
 
     def test_returns_none_for_slash_command(self, tool_ctx):
-        from autoskillit.server.helpers import _validate_skill_command
+        from autoskillit.server._guards import _validate_skill_command
 
         assert _validate_skill_command("/autoskillit:investigate") is None
 
     def test_returns_none_for_bare_slash_command(self, tool_ctx):
-        from autoskillit.server.helpers import _validate_skill_command
+        from autoskillit.server._guards import _validate_skill_command
 
         assert _validate_skill_command("/audit-arch") is None
 
     def test_returns_error_json_for_prose(self, tool_ctx):
-        from autoskillit.server.helpers import _validate_skill_command
+        from autoskillit.server._guards import _validate_skill_command
 
         result = _validate_skill_command("Fix the bug")
         assert result is not None
@@ -239,13 +237,13 @@ class TestValidateSkillCommand:
         assert parsed["subtype"] == "gate_error"
 
     def test_returns_error_json_for_empty_string(self, tool_ctx):
-        from autoskillit.server.helpers import _validate_skill_command
+        from autoskillit.server._guards import _validate_skill_command
 
         result = _validate_skill_command("")
         assert result is not None
 
     def test_strips_whitespace_before_check(self, tool_ctx):
-        from autoskillit.server.helpers import _validate_skill_command
+        from autoskillit.server._guards import _validate_skill_command
 
         # Leading whitespace before slash → valid
         assert _validate_skill_command("  /autoskillit:investigate") is None

--- a/tests/server/test_tools_execution_results.py
+++ b/tests/server/test_tools_execution_results.py
@@ -26,7 +26,7 @@ class TestGateErrorSchemaNormalization:
     def test_require_enabled_gate_returns_standard_schema(self, tool_ctx):
         """Gate errors must use the same schema as normal responses."""
         from autoskillit.pipeline.gate import DefaultGateState
-        from autoskillit.server.helpers import _require_enabled
+        from autoskillit.server._guards import _require_enabled
 
         tool_ctx.gate = DefaultGateState(enabled=False)
         gate_result = _require_enabled()
@@ -39,7 +39,7 @@ class TestGateErrorSchemaNormalization:
 
     def test_dry_walkthrough_gate_returns_standard_schema(self, tool_ctx, tmp_path):
         """Dry-walkthrough gate errors must use the standard response schema."""
-        from autoskillit.server.helpers import _check_dry_walkthrough
+        from autoskillit.server._guards import _check_dry_walkthrough
 
         plan = tmp_path / "plan.md"
         plan.write_text("No marker here")


### PR DESCRIPTION
## Summary

Extract the 6 tier/gate guard functions (`_require_enabled`, `_require_orchestrator_or_higher`, `_require_orchestrator_exact`, `_require_fleet`, `_check_dry_walkthrough`, `_validate_skill_command`) from `server/helpers.py` into a new `server/_guards.py` module with its own `_get_ctx`/`_get_config` deferred-import wrappers. Migrate all 13 source-file consumers and 6 test-file consumers to import from `_guards`. Delete the function definitions from `helpers.py` and remove orphaned imports. No re-export shim.

Closes #1543

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-1543-20260429-203137-869668/.autoskillit/temp/make-plan/p4_extract_guards_py_plan_2026-04-29_203500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 46 | 9.2k | 412.2k | 43.9k | 1 | 5m 56s |
| verify | 1.3k | 9.6k | 998.6k | 56.0k | 1 | 5m 10s |
| implement | 54 | 16.5k | 1.7M | 146.2k | 1 | 6m 34s |
| prepare_pr | 24 | 6.1k | 181.5k | 28.6k | 1 | 1m 52s |
| compose_pr | 22 | 1.3k | 129.4k | 18.4k | 1 | 40s |
| review_pr | 133 | 25.4k | 513.7k | 71.8k | 1 | 8m 17s |
| **Total** | 1.6k | 68.1k | 3.9M | 364.7k | | 28m 30s |