### PR TITLE
P4 — Wire Compat Middleware Edge-Case Tests

### DIFF
--- a/tests/server/test_wire_compat.py
+++ b/tests/server/test_wire_compat.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+
+class TestClaudeCodeCompatMiddlewareEdgeCases:
+    """Edge-case coverage for ClaudeCodeCompatMiddleware.on_list_tools."""
+
+    @pytest.mark.anyio
+    async def test_empty_tool_list(self):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from autoskillit.server._wire_compat import ClaudeCodeCompatMiddleware
+
+        mw = ClaudeCodeCompatMiddleware()
+        ctx = MagicMock()
+        call_next = AsyncMock(return_value=[])
+
+        result = await mw.on_list_tools(ctx, call_next)
+
+        assert result == []
+
+    @pytest.mark.anyio
+    async def test_title_stripped_when_output_schema_already_none(self):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from autoskillit.server._wire_compat import ClaudeCodeCompatMiddleware
+
+        mw = ClaudeCodeCompatMiddleware()
+        tool = MagicMock()
+        tool.name = "titled_tool"
+        tool.title = "My Tool"
+        tool.output_schema = None
+        tool.model_copy.return_value = MagicMock(
+            name="titled_tool",
+            output_schema=None,
+            title=None,
+        )
+
+        ctx = MagicMock()
+        call_next = AsyncMock(return_value=[tool])
+
+        result = await mw.on_list_tools(ctx, call_next)
+
+        assert result[0].title is None
+        tool.model_copy.assert_called_once_with(
+            update={"output_schema": None, "title": None},
+        )
+
+    @pytest.mark.anyio
+    async def test_model_copy_called_unconditionally_when_fields_already_none(self):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from autoskillit.server._wire_compat import ClaudeCodeCompatMiddleware
+
+        mw = ClaudeCodeCompatMiddleware()
+        tool = MagicMock()
+        tool.name = "clean_tool"
+        tool.output_schema = None
+        tool.title = None
+        tool.model_copy.return_value = MagicMock(
+            name="clean_tool",
+            output_schema=None,
+            title=None,
+        )
+
+        ctx = MagicMock()
+        call_next = AsyncMock(return_value=[tool])
+
+        result = await mw.on_list_tools(ctx, call_next)
+
+        tool.model_copy.assert_called_once_with(
+            update={"output_schema": None, "title": None},
+        )
+        assert result[0] is tool.model_copy.return_value
+
+    @pytest.mark.anyio
+    async def test_mixed_tool_list_all_cleaned(self):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from autoskillit.server._wire_compat import ClaudeCodeCompatMiddleware
+
+        mw = ClaudeCodeCompatMiddleware()
+        tool_a = MagicMock()
+        tool_a.name = "tool_a"
+        tool_a.output_schema = {"type": "string"}
+        tool_a.title = "Tool A"
+        tool_a.model_copy.return_value = MagicMock(
+            name="tool_a",
+            output_schema=None,
+            title=None,
+        )
+
+        tool_b = MagicMock()
+        tool_b.name = "tool_b"
+        tool_b.output_schema = None
+        tool_b.title = None
+        tool_b.model_copy.return_value = MagicMock(
+            name="tool_b",
+            output_schema=None,
+            title=None,
+        )
+
+        ctx = MagicMock()
+        call_next = AsyncMock(return_value=[tool_a, tool_b])
+
+        result = await mw.on_list_tools(ctx, call_next)
+
+        assert len(result) == 2
+        assert result[0].output_schema is None
+        assert result[0].title is None
+        assert result[1].output_schema is None
+        assert result[1].title is None


### PR DESCRIPTION
## Summary

Create `tests/server/test_wire_compat.py` with 4 async edge-case tests for `ClaudeCodeCompatMiddleware` covering: empty tool list passthrough, title stripping when output_schema is already None, unconditional `model_copy` invocation when both fields are already None, and mixed tool list cleaning. All tests are pure unit tests using `MagicMock`/`AsyncMock` — no server import, no fixtures beyond `anyio_backend`.

Closes #1546

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-1546-20260429-203139-214889/.autoskillit/temp/make-plan/p4_wire_compat_middleware_edge_case_tests_plan_2026-04-29_203600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 46 | 6.0k | 397.1k | 37.8k | 1 | 4m 6s |
| verify | 30 | 4.4k | 507.5k | 42.1k | 1 | 1m 48s |
| implement | 30 | 4.0k | 441.7k | 51.0k | 1 | 4m 30s |
| prepare_pr | 23 | 3.3k | 138.3k | 24.7k | 1 | 1m 6s |
| compose_pr | 22 | 1.4k | 128.2k | 17.9k | 1 | 39s |
| review_pr | 139 | 19.3k | 488.2k | 54.7k | 1 | 5m 33s |
| **Total** | 290 | 38.3k | 2.1M | 228.1k | | 17m 44s |