### PR TITLE
Implementation Plan: P4 ToolContext Sentinel Guards and Factory Cleanup

### DIFF
--- a/src/autoskillit/pipeline/context.py
+++ b/src/autoskillit/pipeline/context.py
@@ -46,6 +46,7 @@ from autoskillit.core import (
 from autoskillit.pipeline.background import DefaultBackgroundSupervisor
 from autoskillit.pipeline.mcp_response import DefaultMcpResponseLog
 
+# Must-supply-or-raise: fields defaulting to _MISSING are required by __post_init__.
 _MISSING: Any = object()
 
 

--- a/src/autoskillit/pipeline/context.py
+++ b/src/autoskillit/pipeline/context.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 from autoskillit.config import AutomationConfig
 from autoskillit.core import (
@@ -44,6 +45,8 @@ from autoskillit.core import (
 )
 from autoskillit.pipeline.background import DefaultBackgroundSupervisor
 from autoskillit.pipeline.mcp_response import DefaultMcpResponseLog
+
+_MISSING: Any = object()
 
 
 @dataclass
@@ -82,18 +85,16 @@ class ToolContext:
                           to the current kitchen session lifetime.
     active_recipe_packs:  frozenset[str] | None — pack names declared by the loaded recipe
                           (frozenset() when kitchen open but no recipe loaded; None when closed)
-    temp_dir:             Resolved temp directory for this project. MUST be supplied explicitly
-                          by callers outside make_context(). The default_factory falls back to
-                          Path.cwd() / ".autoskillit" / "temp", which is cwd-dependent and
-                          ignores the configured workspace.temp_dir.
+    temp_dir:             Resolved temp directory for this project. Sentinel-guarded: raises
+                          TypeError if not supplied explicitly. Use make_context() or pass
+                          temp_dir=<path>.
     token_factory:        Optional callable that resolves a GitHub token via the
                           config → GITHUB_TOKEN env → gh CLI fallback chain.
                           Set by make_context(); None in test ToolContext instances
                           unless explicitly provided.
-    project_dir:          Resolved project root directory. Defaults to Path.cwd(); make_context()
-                          resolves from AUTOSKILLIT_PROJECT_DIR env var and supplies it explicitly.
-                          Used by food truck dispatches to resolve recipes against L3's root
-                          (not the subprocess cwd).
+    project_dir:          Resolved project root directory. Sentinel-guarded: raises TypeError
+                          if not supplied explicitly. Use make_context() or pass
+                          project_dir=<path>.
     """
 
     config: AutomationConfig
@@ -103,14 +104,8 @@ class ToolContext:
     gate: GateState
     plugin_source: PluginSource
     runner: SubprocessRunner | None
-    # Always supply temp_dir explicitly when constructing ToolContext directly.
-    # The default captures Path.cwd() at field-instantiation time, which is
-    # cwd-dependent and will differ from the configured workspace.temp_dir.
-    # Production callers must use make_context() (server/_factory.py), which
-    # resolves temp_dir from config via resolve_temp_dir(). Direct construction
-    # (e.g. in tests) must override this field before any file I/O that uses it.
-    temp_dir: Path = field(default_factory=lambda: Path.cwd() / ".autoskillit" / "temp")
-    project_dir: Path = field(default_factory=Path.cwd)
+    temp_dir: Path = field(default=_MISSING)
+    project_dir: Path = field(default=_MISSING)
     response_log: McpResponseLog = field(default_factory=DefaultMcpResponseLog)
     executor: HeadlessExecutor | None = field(default=None)
     tester: TestRunner | None = field(default=None)
@@ -141,6 +136,16 @@ class ToolContext:
     build_protected_campaign_ids: CampaignProtector | None = field(default=None)
 
     def __post_init__(self) -> None:
+        if self.temp_dir is _MISSING:
+            raise TypeError(
+                "temp_dir must be supplied explicitly — do not rely on defaults. "
+                "Use make_context() or pass temp_dir=<path> directly."
+            )
+        if self.project_dir is _MISSING:
+            raise TypeError(
+                "project_dir must be supplied explicitly — do not rely on defaults. "
+                "Use make_context() or pass project_dir=<path> directly."
+            )
         if self.background is None:
             self.background = DefaultBackgroundSupervisor(audit=self.audit)
 

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -74,7 +74,7 @@ logger = get_logger(__name__)
 _UNSET: Any = object()
 
 
-class TokenFactory:
+class _LazyTokenFactory:
     """Lazy-resolving, caching token factory.
 
     Wraps the config -> env -> gh CLI token resolution chain.  Does NOT
@@ -137,6 +137,25 @@ def _gh_cli_token() -> str | None:
 def _check_plugin_installed() -> bool:
     """Detect if autoskillit is marketplace-installed via installed_plugins.json."""
     return detect_autoskillit_mcp_prefix() == MARKETPLACE_PREFIX
+
+
+def _resolve_project_dir() -> Path:
+    """Resolve the project root: AUTOSKILLIT_PROJECT_DIR env -> git toplevel -> cwd."""
+    env_project_dir = os.environ.get("AUTOSKILLIT_PROJECT_DIR", "")
+    if env_project_dir:
+        return Path(env_project_dir)
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return Path(result.stdout.strip())
+    except Exception:
+        pass
+    return Path.cwd()
 
 
 def make_context(
@@ -229,7 +248,7 @@ def make_context(
     # The _gh_cli_token() subprocess (up to 5s) is deferred until the first
     # gated tool actually needs a GitHub token, keeping the MCP server startup
     # path free of subprocess calls (REQ-STARTUP-001).
-    token_factory = TokenFactory(
+    token_factory = _LazyTokenFactory(
         lambda: config.github.token or os.environ.get("GITHUB_TOKEN") or _gh_cli_token()
     )
 
@@ -254,8 +273,7 @@ def make_context(
     plugin_source = resolved_plugin_source
     gate = DefaultGateState(enabled=False)
 
-    env_project_dir = os.environ.get("AUTOSKILLIT_PROJECT_DIR", "")
-    project_dir = Path(env_project_dir) if env_project_dir else Path.cwd()
+    project_dir = _resolve_project_dir()
     temp_dir = resolve_temp_dir(project_dir, config.workspace.temp_dir)
     temp_dir_relpath = temp_dir_display_str(config.workspace.temp_dir)
 

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -153,7 +153,7 @@ def _resolve_project_dir() -> Path:
         )
         if result.returncode == 0 and result.stdout.strip():
             return Path(result.stdout.strip())
-    except Exception:
+    except (OSError, subprocess.SubprocessError):
         pass
     return Path.cwd()
 

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -70,7 +70,7 @@ from autoskillit.workspace import (
 
 logger = get_logger(__name__)
 
-# Sentinel: distinguish "caller passed runner=None explicitly" from "not provided"
+# Optional-override: _UNSET means "not provided, use factory-computed default" (None is valid).
 _UNSET: Any = object()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -272,6 +272,7 @@ def minimal_ctx(tmp_path):
         plugin_source=DirectInstall(plugin_dir=tmp_path),
         runner=None,
         temp_dir=tmp_path / ".autoskillit" / "temp",
+        project_dir=tmp_path,
     )
     return ctx
 

--- a/tests/contracts/test_protocol_satisfaction_five.py
+++ b/tests/contracts/test_protocol_satisfaction_five.py
@@ -76,7 +76,7 @@ def test_quota_refresh_task_satisfied_by_minimal_cancel_class():
 
 def test_token_factory_satisfied_by_server_concrete_class():
     from autoskillit.core import TokenFactory
-    from autoskillit.server._factory import TokenFactory as ConcreteTokenFactory
+    from autoskillit.server._factory import _LazyTokenFactory as ConcreteTokenFactory
 
     instance = ConcreteTokenFactory(lambda: None)
     assert isinstance(instance, TokenFactory)

--- a/tests/pipeline/test_context.py
+++ b/tests/pipeline/test_context.py
@@ -29,13 +29,15 @@ def test_tool_context_fields_accessible(tmp_path):
         gate=DefaultGateState(enabled=True),
         plugin_source=DirectInstall(plugin_dir=tmp_path),
         runner=None,
+        temp_dir=tmp_path / ".autoskillit" / "temp",
+        project_dir=tmp_path,
     )
     assert ctx.gate.enabled is True
     assert isinstance(ctx.plugin_source, DirectInstall)
     assert ctx.plugin_source.plugin_dir == tmp_path
 
 
-def test_tool_context_audit_isolation():
+def test_tool_context_audit_isolation(tmp_path):
     """Two ToolContext instances have independent AuditLog instances."""
     ctx_a = ToolContext(
         config=AutomationConfig(),
@@ -43,8 +45,10 @@ def test_tool_context_audit_isolation():
         token_log=DefaultTokenLog(),
         timing_log=DefaultTimingLog(),
         gate=DefaultGateState(),
-        plugin_source=DirectInstall(plugin_dir=Path("/a")),
+        plugin_source=DirectInstall(plugin_dir=tmp_path / "a"),
         runner=None,
+        temp_dir=tmp_path / "a" / ".autoskillit" / "temp",
+        project_dir=tmp_path / "a",
     )
     ctx_b = ToolContext(
         config=AutomationConfig(),
@@ -52,8 +56,10 @@ def test_tool_context_audit_isolation():
         token_log=DefaultTokenLog(),
         timing_log=DefaultTimingLog(),
         gate=DefaultGateState(),
-        plugin_source=DirectInstall(plugin_dir=Path("/b")),
+        plugin_source=DirectInstall(plugin_dir=tmp_path / "b"),
         runner=None,
+        temp_dir=tmp_path / "b" / ".autoskillit" / "temp",
+        project_dir=tmp_path / "b",
     )
     ctx_a.audit.record_failure(
         FailureRecord(
@@ -70,7 +76,7 @@ def test_tool_context_audit_isolation():
     assert len(ctx_b.audit.get_report()) == 0
 
 
-def test_gate_state_replacement():
+def test_gate_state_replacement(tmp_path):
     """ToolContext allows gate field replacement via plain assignment."""
     ctx = ToolContext(
         config=AutomationConfig(),
@@ -78,8 +84,10 @@ def test_gate_state_replacement():
         token_log=DefaultTokenLog(),
         timing_log=DefaultTimingLog(),
         gate=DefaultGateState(enabled=False),
-        plugin_source=DirectInstall(plugin_dir=Path("/x")),
+        plugin_source=DirectInstall(plugin_dir=tmp_path),
         runner=None,
+        temp_dir=tmp_path / ".autoskillit" / "temp",
+        project_dir=tmp_path,
     )
     assert ctx.gate.enabled is False
     ctx.gate = DefaultGateState(enabled=True)
@@ -96,6 +104,8 @@ def test_toolcontext_new_optional_fields_default_none(tmp_path):
         gate=DefaultGateState(enabled=True),
         plugin_source=DirectInstall(plugin_dir=tmp_path),
         runner=None,
+        temp_dir=tmp_path / ".autoskillit" / "temp",
+        project_dir=tmp_path,
     )
     assert ctx.executor is None
     assert ctx.tester is None
@@ -194,6 +204,8 @@ def _make_ctx(tmp_path: Path) -> ToolContext:
         gate=DefaultGateState(enabled=True),
         plugin_source=DirectInstall(plugin_dir=tmp_path),
         runner=None,
+        temp_dir=tmp_path / ".autoskillit" / "temp",
+        project_dir=tmp_path,
     )
 
 
@@ -245,6 +257,8 @@ async def test_toolcontext_default_background_wired_with_audit(tmp_path):
         gate=DefaultGateState(),
         plugin_source=DirectInstall(plugin_dir=tmp_path),
         runner=None,
+        temp_dir=tmp_path / ".autoskillit" / "temp",
+        project_dir=tmp_path,
     )
     assert isinstance(ctx.background, DefaultBackgroundSupervisor)
 
@@ -311,3 +325,50 @@ def test_toolcontext_has_project_dir_field():
 
     field_names = {f.name for f in dataclasses.fields(ToolContext)}
     assert "project_dir" in field_names
+
+
+# --- Sentinel guard tests ---
+
+
+def test_toolcontext_raises_typeerror_when_temp_dir_unset(tmp_path):
+    with pytest.raises(TypeError, match="temp_dir"):
+        ToolContext(
+            config=AutomationConfig(),
+            audit=DefaultAuditLog(),
+            token_log=DefaultTokenLog(),
+            timing_log=DefaultTimingLog(),
+            gate=DefaultGateState(),
+            plugin_source=DirectInstall(plugin_dir=tmp_path),
+            runner=None,
+            project_dir=tmp_path,
+        )
+
+
+def test_toolcontext_raises_typeerror_when_project_dir_unset(tmp_path):
+    with pytest.raises(TypeError, match="project_dir"):
+        ToolContext(
+            config=AutomationConfig(),
+            audit=DefaultAuditLog(),
+            token_log=DefaultTokenLog(),
+            timing_log=DefaultTimingLog(),
+            gate=DefaultGateState(),
+            plugin_source=DirectInstall(plugin_dir=tmp_path),
+            runner=None,
+            temp_dir=tmp_path / ".autoskillit" / "temp",
+        )
+
+
+def test_toolcontext_accepts_explicit_path_fields(tmp_path):
+    ctx = ToolContext(
+        config=AutomationConfig(),
+        audit=DefaultAuditLog(),
+        token_log=DefaultTokenLog(),
+        timing_log=DefaultTimingLog(),
+        gate=DefaultGateState(),
+        plugin_source=DirectInstall(plugin_dir=tmp_path),
+        runner=None,
+        temp_dir=tmp_path / ".autoskillit" / "temp",
+        project_dir=tmp_path,
+    )
+    assert ctx.temp_dir == tmp_path / ".autoskillit" / "temp"
+    assert ctx.project_dir == tmp_path

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -130,6 +130,7 @@ def build_ctx(tmp_path):
             plugin_source=DirectInstall(plugin_dir=tmp_path),
             runner=None,
             temp_dir=tmp_path / ".autoskillit" / "temp",
+            project_dir=tmp_path,
         )
         for field_name, value in overrides.items():
             setattr(ctx, field_name, value)

--- a/tests/server/test_factory.py
+++ b/tests/server/test_factory.py
@@ -20,7 +20,7 @@ from autoskillit.recipe.contracts import (
     resolve_skill_name,
 )
 from autoskillit.recipe.repository import DefaultRecipeRepository
-from autoskillit.server._factory import TokenFactory, _gh_cli_token, make_context
+from autoskillit.server._factory import _gh_cli_token, _LazyTokenFactory, make_context
 from autoskillit.workspace import DefaultCloneManager, SkillResolver
 from autoskillit.workspace.cleanup import DefaultWorkspaceManager
 from tests.fakes import MockSubprocessRunner
@@ -381,7 +381,7 @@ def test_token_factory_resolves_lazily():
         call_count += 1
         return "ghp_test_token"
 
-    factory = TokenFactory(_resolver)
+    factory = _LazyTokenFactory(_resolver)
     assert call_count == 0, "TokenFactory resolved eagerly at construction"
     assert not factory.is_resolved
 
@@ -405,7 +405,7 @@ def test_token_factory_caches_none():
         call_count += 1
         return None
 
-    factory = TokenFactory(_resolver)
+    factory = _LazyTokenFactory(_resolver)
     assert factory() is None
     assert call_count == 1
     assert factory() is None
@@ -482,8 +482,55 @@ def test_make_context_reads_project_dir_env(tmp_path, monkeypatch):
     assert ctx.project_dir == tmp_path
 
 
-def test_make_context_project_dir_cwd_fallback(monkeypatch):
-    """make_context falls back to Path.cwd() when AUTOSKILLIT_PROJECT_DIR is not set."""
+def test_make_context_project_dir_git_root_fallback(monkeypatch):
+    """make_context resolves project_dir via git toplevel when env var is not set."""
     monkeypatch.delenv("AUTOSKILLIT_PROJECT_DIR", raising=False)
     ctx = make_context(AutomationConfig(), runner=_runner())
-    assert ctx.project_dir == Path.cwd()
+    import subprocess as _sp
+
+    expected = Path(
+        _sp.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    )
+    assert ctx.project_dir == expected
+
+
+# --- _resolve_project_dir unit tests ---
+
+
+def test_resolve_project_dir_env_var(tmp_path, monkeypatch):
+    from autoskillit.server._factory import _resolve_project_dir
+
+    monkeypatch.setenv("AUTOSKILLIT_PROJECT_DIR", str(tmp_path))
+    assert _resolve_project_dir() == tmp_path
+
+
+def test_resolve_project_dir_git_root(monkeypatch):
+    import subprocess as _subprocess
+
+    from autoskillit.server._factory import _resolve_project_dir
+
+    monkeypatch.delenv("AUTOSKILLIT_PROJECT_DIR", raising=False)
+
+    def fake_run(cmd, *, capture_output, text, timeout):
+        return _subprocess.CompletedProcess(cmd, 0, stdout="/fake/git/root\n", stderr="")
+
+    monkeypatch.setattr("autoskillit.server._factory.subprocess.run", fake_run)
+    assert _resolve_project_dir() == Path("/fake/git/root")
+
+
+def test_resolve_project_dir_cwd_fallback(monkeypatch):
+    import subprocess as _subprocess
+
+    from autoskillit.server._factory import _resolve_project_dir
+
+    monkeypatch.delenv("AUTOSKILLIT_PROJECT_DIR", raising=False)
+
+    def fake_run(cmd, *, capture_output, text, timeout):
+        return _subprocess.CompletedProcess(cmd, 1, stdout="", stderr="not a git repo")
+
+    monkeypatch.setattr("autoskillit.server._factory.subprocess.run", fake_run)
+    assert _resolve_project_dir() == Path.cwd()


### PR DESCRIPTION
## Summary

Replace `ToolContext`'s implicit `Path.cwd()` defaults on `temp_dir` and `project_dir` with a `_MISSING` sentinel that raises `TypeError` in `__post_init__`, rename the concrete `TokenFactory` class to `_LazyTokenFactory` (preserving the Protocol), extract `_resolve_project_dir()` with a three-step resolution chain (env var, git rev-parse, cwd fallback), and add 6 new tests.

Closes #1545

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-1545-20260429-203138-804392/.autoskillit/temp/make-plan/p4_toolcontext_sentinel_guards_and_factory_cleanup_plan_2026-04-29_203700.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 58 | 13.8k | 1.4M | 78.7k | 1 | 6m 38s |
| verify | 32 | 8.0k | 657.8k | 49.8k | 1 | 3m 27s |
| implement | 91 | 18.2k | 3.3M | 69.5k | 1 | 6m 45s |
| prepare_pr | 33 | 4.3k | 183.1k | 28.7k | 1 | 1m 23s |
| compose_pr | 23 | 1.5k | 158.6k | 18.0k | 1 | 44s |
| review_pr | 70 | 22.3k | 405.6k | 57.4k | 1 | 6m 36s |
| resolve_review | 1.0k | 7.2k | 769.2k | 43.7k | 1 | 6m 38s |
| **Total** | 1.3k | 75.3k | 6.9M | 345.9k | | 32m 14s |