### PR TITLE
P3 — Recipe Semantic Rule Test Coverage

### DIFF
--- a/tests/recipe/test_rules_actions.py
+++ b/tests/recipe/test_rules_actions.py
@@ -93,3 +93,24 @@ def test_route_step_with_on_result_passes():
     )
     findings = [f for f in run_semantic_rules(recipe) if f.rule == "route-step-requires-on-result"]
     assert len(findings) == 0
+
+
+class TestStopStepMessageQuality:
+    def test_short_message_fires_warning(self):
+        recipe = _make_recipe({"done": {"action": "stop", "message": "bye"}})
+        findings = [f for f in run_semantic_rules(recipe) if f.rule == "stop-step-message-quality"]
+        assert len(findings) == 1
+        assert findings[0].severity == Severity.WARNING
+
+    def test_placeholder_message_fires_warning(self):
+        recipe = _make_recipe({"done": {"action": "stop", "message": "done"}})
+        findings = [f for f in run_semantic_rules(recipe) if f.rule == "stop-step-message-quality"]
+        assert len(findings) == 1
+        assert findings[0].severity == Severity.WARNING
+
+    def test_meaningful_message_is_clean(self):
+        recipe = _make_recipe(
+            {"done": {"action": "stop", "message": "Pipeline completed successfully"}}
+        )
+        findings = [f for f in run_semantic_rules(recipe) if f.rule == "stop-step-message-quality"]
+        assert len(findings) == 0

--- a/tests/recipe/test_rules_blocks.py
+++ b/tests/recipe/test_rules_blocks.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import pytest
 
+from autoskillit.core import Severity
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.recipe.registry import run_semantic_rules
+from autoskillit.recipe.schema import Recipe, RecipeStep
 
 pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
@@ -61,8 +63,6 @@ def _make_synthetic_recipe_with_two_gh_api_run_cmds_in_block(block_name: str):
 
     Used by the synthetic block budget test below.
     """
-    from autoskillit.recipe.schema import Recipe, RecipeStep
-
     step_a = RecipeStep(
         tool="run_cmd",
         with_args={"cmd": "gh api /repos/o/r/pulls"},
@@ -95,3 +95,168 @@ def test_synthetic_block_with_two_run_cmds_emits_block_run_cmd_budget_finding():
     matching = [f for f in findings if f.rule == "block-run-cmd-budget"]
     assert len(matching) == 1
     assert "test_block" in matching[0].message
+
+
+def _make_block_recipe(steps: dict[str, RecipeStep]) -> Recipe:
+    """Minimal Recipe factory for block rule tests."""
+    return Recipe(
+        name="synthetic",
+        description="synthetic test recipe",
+        ingredients={},
+        steps=steps,
+        kitchen_rules=[],
+        version=None,
+        experimental=False,
+        requires_packs=[],
+    )
+
+
+class TestBlockMcpToolBudget:
+    def test_two_mcp_tools_in_pre_queue_gate_fires_error(self):
+        step_a = RecipeStep(
+            tool="check_repo_merge_state", block="pre_queue_gate", on_success="step_b"
+        )
+        step_b = RecipeStep(
+            tool="check_repo_merge_state", block="pre_queue_gate", on_success="done"
+        )
+        stop = RecipeStep(action="stop", message="Pre-queue gate complete.")
+        recipe = _make_block_recipe({"step_a": step_a, "step_b": step_b, "done": stop})
+        findings = run_semantic_rules(recipe)
+        matching = [f for f in findings if f.rule == "block-mcp-tool-budget"]
+        assert len(matching) == 1
+        assert matching[0].severity == Severity.ERROR
+        assert "pre_queue_gate" in matching[0].message
+
+    def test_one_mcp_tool_in_pre_queue_gate_is_clean(self):
+        step_a = RecipeStep(
+            tool="check_repo_merge_state", block="pre_queue_gate", on_success="done"
+        )
+        stop = RecipeStep(action="stop", message="Pre-queue gate complete.")
+        recipe = _make_block_recipe({"step_a": step_a, "done": stop})
+        findings = run_semantic_rules(recipe)
+        matching = [f for f in findings if f.rule == "block-mcp-tool-budget"]
+        assert len(matching) == 0
+
+
+class TestBlockGhApiForbidden:
+    def test_gh_api_in_pre_queue_gate_fires_error(self):
+        step_a = RecipeStep(
+            tool="run_cmd",
+            with_args={"cmd": "gh api /repos/o/r"},
+            block="pre_queue_gate",
+            on_success="done",
+        )
+        stop = RecipeStep(action="stop", message="Pre-queue gate complete.")
+        recipe = _make_block_recipe({"step_a": step_a, "done": stop})
+        findings = run_semantic_rules(recipe)
+        matching = [f for f in findings if f.rule == "block-gh-api-forbidden"]
+        assert len(matching) == 1
+        assert matching[0].severity == Severity.ERROR
+
+    def test_run_cmd_without_gh_api_is_clean(self):
+        step_a = RecipeStep(
+            tool="run_cmd",
+            with_args={"cmd": "echo ok"},
+            block="pre_queue_gate",
+            on_success="done",
+        )
+        stop = RecipeStep(action="stop", message="Pre-queue gate complete.")
+        recipe = _make_block_recipe({"step_a": step_a, "done": stop})
+        findings = run_semantic_rules(recipe)
+        matching = [f for f in findings if f.rule == "block-gh-api-forbidden"]
+        assert len(matching) == 0
+
+
+class TestBlockSingleProducer:
+    def test_duplicate_capture_key_fires_warning(self):
+        step_a = RecipeStep(
+            tool="run_cmd",
+            with_args={"cmd": "echo a"},
+            block="test_block",
+            capture={"shared_key": "a"},
+            on_success="step_b",
+        )
+        step_a.name = "step_a"
+        step_b = RecipeStep(
+            tool="run_cmd",
+            with_args={"cmd": "echo b"},
+            block="test_block",
+            capture={"shared_key": "b"},
+            on_success="done",
+        )
+        step_b.name = "step_b"
+        stop = RecipeStep(action="stop", message="Block single producer test done.")
+        recipe = _make_block_recipe({"step_a": step_a, "step_b": step_b, "done": stop})
+        findings = run_semantic_rules(recipe)
+        matching = [f for f in findings if f.rule == "block-single-producer"]
+        assert len(matching) == 1
+        assert matching[0].severity == Severity.WARNING
+        assert "shared_key" in matching[0].message
+
+    def test_distinct_capture_keys_is_clean(self):
+        step_a = RecipeStep(
+            tool="run_cmd",
+            with_args={"cmd": "echo a"},
+            block="test_block",
+            capture={"key_a": "a"},
+            on_success="step_b",
+        )
+        step_a.name = "step_a"
+        step_b = RecipeStep(
+            tool="run_cmd",
+            with_args={"cmd": "echo b"},
+            block="test_block",
+            capture={"key_b": "b"},
+            on_success="done",
+        )
+        step_b.name = "step_b"
+        stop = RecipeStep(action="stop", message="Block single producer test done.")
+        recipe = _make_block_recipe({"step_a": step_a, "step_b": step_b, "done": stop})
+        findings = run_semantic_rules(recipe)
+        matching = [f for f in findings if f.rule == "block-single-producer"]
+        assert len(matching) == 0
+
+
+class TestBlockEntryExitReachable:
+    def test_disconnected_block_steps_fire_warning(self):
+        step_a = RecipeStep(
+            tool="run_cmd",
+            with_args={"cmd": "echo a"},
+            block="test_block",
+            on_success="done",
+        )
+        step_a.name = "step_a"
+        step_b = RecipeStep(
+            tool="run_cmd",
+            with_args={"cmd": "echo b"},
+            block="test_block",
+            on_success="done",
+        )
+        step_b.name = "step_b"
+        stop = RecipeStep(action="stop", message="Block entry exit test done.")
+        recipe = _make_block_recipe({"step_a": step_a, "step_b": step_b, "done": stop})
+        findings = run_semantic_rules(recipe)
+        matching = [f for f in findings if f.rule == "block-entry-exit-reachable"]
+        assert len(matching) == 2
+        assert all(f.severity == Severity.WARNING for f in matching)
+
+    def test_linear_block_chain_is_clean(self):
+        step_a = RecipeStep(
+            tool="run_cmd",
+            with_args={"cmd": "echo a"},
+            block="test_block",
+            on_success="step_b",
+        )
+        step_a.name = "step_a"
+        step_b = RecipeStep(
+            tool="run_cmd",
+            with_args={"cmd": "echo b"},
+            block="test_block",
+            on_success="done",
+        )
+        step_b.name = "step_b"
+        stop = RecipeStep(action="stop", message="Block entry exit test done.")
+        recipe = _make_block_recipe({"step_a": step_a, "step_b": step_b, "done": stop})
+        findings = run_semantic_rules(recipe)
+        matching = [f for f in findings if f.rule == "block-entry-exit-reachable"]
+        assert len(matching) == 0

--- a/tests/recipe/test_rules_ci.py
+++ b/tests/recipe/test_rules_ci.py
@@ -879,3 +879,49 @@ def test_bundled_recipes_no_literal_merge_group_event() -> None:
             f"Recipe '{yaml_path.stem}' hardcodes event='merge_group': "
             + ", ".join(f.message for f in mg_findings)
         )
+
+
+class TestCiTimeoutMinimum:
+    def test_timeout_below_minimum_fires_warning(self) -> None:
+        steps = {
+            "ci": RecipeStep(
+                tool="wait_for_ci",
+                with_args={"branch": "main", "event": "push", "timeout_seconds": "300"},
+                on_success="done",
+                on_failure="done",
+            ),
+            "done": RecipeStep(action="stop", message="CI check complete."),
+        }
+        recipe = _make_recipe(steps)
+        findings = [f for f in run_semantic_rules(recipe) if f.rule == "ci-timeout-minimum"]
+        assert len(findings) == 1
+        assert findings[0].severity == Severity.WARNING
+        assert "300" in findings[0].message
+
+    def test_timeout_at_boundary_is_clean(self) -> None:
+        steps = {
+            "ci": RecipeStep(
+                tool="wait_for_ci",
+                with_args={"branch": "main", "event": "push", "timeout_seconds": "600"},
+                on_success="done",
+                on_failure="done",
+            ),
+            "done": RecipeStep(action="stop", message="CI check complete."),
+        }
+        recipe = _make_recipe(steps)
+        findings = [f for f in run_semantic_rules(recipe) if f.rule == "ci-timeout-minimum"]
+        assert len(findings) == 0
+
+    def test_missing_timeout_key_is_clean(self) -> None:
+        steps = {
+            "ci": RecipeStep(
+                tool="wait_for_ci",
+                with_args={"branch": "main", "event": "push"},
+                on_success="done",
+                on_failure="done",
+            ),
+            "done": RecipeStep(action="stop", message="CI check complete."),
+        }
+        recipe = _make_recipe(steps)
+        findings = [f for f in run_semantic_rules(recipe) if f.rule == "ci-timeout-minimum"]
+        assert len(findings) == 0

--- a/tests/recipe/test_rules_inputs.py
+++ b/tests/recipe/test_rules_inputs.py
@@ -9,7 +9,7 @@ import pytest
 
 from autoskillit.core import Severity
 from autoskillit.recipe.registry import run_semantic_rules
-from autoskillit.recipe.schema import Recipe, RecipeStep
+from autoskillit.recipe.schema import Recipe, RecipeIngredient, RecipeStep
 
 pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
@@ -171,3 +171,61 @@ def test_required_hidden_ingredient_without_default_no_warning():
     findings = run_semantic_rules(recipe)
     warning_findings = [f for f in findings if f.rule == "required-ingredient-no-default"]
     assert len(warning_findings) == 0
+
+
+class TestResearchOutputModeEnum:
+    def test_bogus_default_fires_error(self):
+        recipe = Recipe(
+            name="research",
+            description="Test research recipe",
+            ingredients={
+                "output_mode": RecipeIngredient(
+                    description="Output mode for research results",
+                    default="bogus",
+                )
+            },
+            steps={"done": RecipeStep(action="stop", message="Research complete.")},
+        )
+        findings = [f for f in run_semantic_rules(recipe) if f.rule == "research-output-mode-enum"]
+        assert len(findings) == 1
+        assert findings[0].severity == Severity.ERROR
+
+    def test_valid_pr_default_is_clean(self):
+        recipe = Recipe(
+            name="research",
+            description="Test research recipe",
+            ingredients={
+                "output_mode": RecipeIngredient(
+                    description="Output mode for research results",
+                    default="pr",
+                )
+            },
+            steps={"done": RecipeStep(action="stop", message="Research complete.")},
+        )
+        findings = [f for f in run_semantic_rules(recipe) if f.rule == "research-output-mode-enum"]
+        assert len(findings) == 0
+
+    def test_no_output_mode_ingredient_is_clean(self):
+        recipe = Recipe(
+            name="research",
+            description="Test research recipe",
+            ingredients={},
+            steps={"done": RecipeStep(action="stop", message="Research complete.")},
+        )
+        findings = [f for f in run_semantic_rules(recipe) if f.rule == "research-output-mode-enum"]
+        assert len(findings) == 0
+
+    def test_non_research_recipe_is_clean(self):
+        recipe = Recipe(
+            name="other",
+            description="Test other recipe",
+            ingredients={
+                "output_mode": RecipeIngredient(
+                    description="Output mode",
+                    default="bogus",
+                )
+            },
+            steps={"done": RecipeStep(action="stop", message="Other recipe complete.")},
+        )
+        findings = [f for f in run_semantic_rules(recipe) if f.rule == "research-output-mode-enum"]
+        assert len(findings) == 0

--- a/tests/recipe/test_rules_tools.py
+++ b/tests/recipe/test_rules_tools.py
@@ -388,3 +388,42 @@ def test_tool_params_matches_mcp_handler_signatures() -> None:
     assert not mismatches, (
         "_TOOL_PARAMS is out of sync with MCP handler signatures:\n" + "\n".join(mismatches)
     )
+
+
+class TestConstantStepWithArgs:
+    def test_constant_with_args_fires_error(self):
+        recipe = Recipe(
+            name="test-recipe",
+            description="Test constant rule",
+            steps={
+                "s": RecipeStep(constant="val", with_args={"x": "1"}, on_success="done"),
+                "done": RecipeStep(action="stop", message="Done checking constant."),
+            },
+        )
+        findings = [f for f in run_semantic_rules(recipe) if f.rule == "constant-step-with-args"]
+        assert len(findings) == 1
+        assert findings[0].severity == Severity.ERROR
+
+    def test_constant_only_is_clean(self):
+        recipe = Recipe(
+            name="test-recipe",
+            description="Test constant rule",
+            steps={
+                "s": RecipeStep(constant="val", on_success="done"),
+                "done": RecipeStep(action="stop", message="Done checking constant."),
+            },
+        )
+        findings = [f for f in run_semantic_rules(recipe) if f.rule == "constant-step-with-args"]
+        assert len(findings) == 0
+
+    def test_with_args_only_is_clean(self):
+        recipe = Recipe(
+            name="test-recipe",
+            description="Test constant rule",
+            steps={
+                "s": RecipeStep(tool="run_cmd", with_args={"cmd": "echo hi"}, on_success="done"),
+                "done": RecipeStep(action="stop", message="Done checking constant."),
+            },
+        )
+        findings = [f for f in run_semantic_rules(recipe) if f.rule == "constant-step-with-args"]
+        assert len(findings) == 0


### PR DESCRIPTION
## Summary

Add test coverage for 8 untested recipe semantic validation rules across 5 test files. Pure test additions — no source files modified. Each rule gets a dedicated test class with violation and clean paths, following existing test patterns (inline `Recipe`/`RecipeStep` construction, `run_semantic_rules()` invocation, finding-filtered assertions). ~20 test methods total, all xdist-safe.

Closes #1539

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260430-081121-610236/.autoskillit/temp/make-plan/p3_recipe_semantic_rule_test_coverage_plan_2026-04-30_081500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 2.8k | 9.2k | 715.9k | 53.8k | 1 | 6m 9s |
| verify | 4.2k | 15.4k | 2.3M | 81.4k | 1 | 7m 49s |
| implement | 292 | 26.9k | 2.7M | 95.0k | 1 | 7m 50s |
| prepare_pr | 52 | 3.6k | 174.0k | 28.3k | 1 | 1m 13s |
| compose_pr | 59 | 2.1k | 189.7k | 18.7k | 1 | 39s |
| review_pr | 94 | 16.8k | 482.0k | 119.5k | 1 | 7m 25s |
| **Total** | 7.5k | 74.0k | 6.5M | 396.7k | | 31m 6s |