### PR TITLE
P3 — Planner Test Coverage (Manifests, Merge, Compiler)

### DIFF
--- a/tests/planner/test_compiler.py
+++ b/tests/planner/test_compiler.py
@@ -237,3 +237,50 @@ def test_compile_plan_creates_issues_directory(tmp_path: Path) -> None:
     _make_valid_output_dir(tmp_path)
     compile_plan(str(tmp_path), "task", "/src")
     assert (tmp_path / "issues").is_dir()
+
+
+class TestCompilePlanEdgeCases:
+    def test_nonpassing_verdict_returns_dict(self, tmp_path: Path) -> None:
+        _make_valid_output_dir(tmp_path)
+        (tmp_path / "validation.json").write_text(
+            json.dumps(
+                {
+                    "verdict": "fail",
+                    "findings": [{"message": "test", "severity": "error", "check": "test"}],
+                    "warnings": [],
+                    "schema_version": 2,
+                }
+            )
+        )
+
+        result = compile_plan(str(tmp_path), "t", "s")
+
+        assert isinstance(result, dict)
+        assert "plan_path" in result
+
+    def test_wp_references_absent_phase_raises(self, tmp_path: Path) -> None:
+        _make_valid_output_dir(tmp_path)
+        wps_dir = tmp_path / "work_packages"
+        write_json(wps_dir / "P99-A1-WP1_result.json", make_wp_result("P99-A1-WP1"))
+
+        with pytest.raises(RuntimeError, match="references phase"):
+            compile_plan(str(tmp_path), "t", "s")
+
+    def test_wp_references_absent_assignment_raises(self, tmp_path: Path) -> None:
+        _make_valid_output_dir(tmp_path)
+        wps_dir = tmp_path / "work_packages"
+        write_json(wps_dir / "P1-A99-WP1_result.json", make_wp_result("P1-A99-WP1"))
+
+        with pytest.raises(RuntimeError, match="references assignment"):
+            compile_plan(str(tmp_path), "t", "s")
+
+    def test_malformed_wp_id_raises(self, tmp_path: Path) -> None:
+        _make_valid_output_dir(tmp_path)
+        wps_dir = tmp_path / "work_packages"
+        write_json(
+            wps_dir / "BADID_result.json",
+            {"id": "BADID", "name": "Bad", "deliverables": ["x.py"]},
+        )
+
+        with pytest.raises(ValueError, match="Invalid WP id format"):
+            compile_plan(str(tmp_path), "t", "s")

--- a/tests/planner/test_compiler.py
+++ b/tests/planner/test_compiler.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 
 import pytest
+import structlog.testing
 
 from autoskillit.planner.compiler import compile_plan
 from tests.planner.conftest import (
@@ -253,10 +254,15 @@ class TestCompilePlanEdgeCases:
             )
         )
 
-        result = compile_plan(str(tmp_path), "t", "s")
+        with structlog.testing.capture_logs() as logs:
+            result = compile_plan(str(tmp_path), "t", "s")
 
-        assert isinstance(result, dict)
-        assert "plan_path" in result
+        assert {"plan_path", "plan_json_path", "plan_parts"} == result.keys()
+        warning_logs = [e for e in logs if e.get("log_level") == "warning"]
+        assert any(
+            "non-passing" in e.get("event", "") and e.get("verdict") == "fail"
+            for e in warning_logs
+        ), f"expected non-passing warning log, got: {warning_logs}"
 
     def test_wp_references_absent_phase_raises(self, tmp_path: Path) -> None:
         _make_valid_output_dir(tmp_path)

--- a/tests/planner/test_manifests.py
+++ b/tests/planner/test_manifests.py
@@ -396,3 +396,120 @@ def test_finalize_wp_manifest_regenerates_wp_index(tmp_path):
         assert "id" in entry
         assert "name" in entry
         assert "summary" in entry
+
+
+# ---------------------------------------------------------------------------
+# build_phase_assignment_manifest error branches
+# ---------------------------------------------------------------------------
+
+
+def test_build_phase_assignment_manifest_corrupt_json_raises(tmp_path):
+    from autoskillit.planner import build_phase_assignment_manifest
+
+    phases_dir = tmp_path / "phases"
+    phases_dir.mkdir()
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    (phases_dir / "bad_result.json").write_text("{not json")
+
+    with pytest.raises(json.JSONDecodeError, match="Failed to parse"):
+        build_phase_assignment_manifest(str(phases_dir), str(output_dir))
+
+
+def test_build_phase_assignment_manifest_missing_required_keys_raises(tmp_path):
+    from autoskillit.planner import build_phase_assignment_manifest
+
+    phases_dir = tmp_path / "phases"
+    phases_dir.mkdir()
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    (phases_dir / "bad_result.json").write_text(json.dumps({"foo": "bar"}))
+
+    with pytest.raises(ValueError, match="Invalid phase result in"):
+        build_phase_assignment_manifest(str(phases_dir), str(output_dir))
+
+
+def test_build_phase_assignment_manifest_empty_string_dir_raises(tmp_path):
+    from autoskillit.planner import build_phase_assignment_manifest
+
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+
+    with pytest.raises(ValueError, match="phases_dir and output_dir must not be empty"):
+        build_phase_assignment_manifest("", str(output_dir))
+
+
+# ---------------------------------------------------------------------------
+# build_phase_wp_manifest error branches
+# ---------------------------------------------------------------------------
+
+
+def test_build_phase_wp_manifest_corrupt_json_raises(tmp_path):
+    from autoskillit.planner import build_phase_wp_manifest
+
+    assignments_dir = tmp_path / "assignments"
+    assignments_dir.mkdir()
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    (assignments_dir / "bad_result.json").write_text("{not json")
+
+    with pytest.raises(json.JSONDecodeError, match="Failed to parse"):
+        build_phase_wp_manifest(str(assignments_dir), str(output_dir))
+
+
+def test_build_phase_wp_manifest_empty_string_raises(tmp_path):
+    from autoskillit.planner import build_phase_wp_manifest
+
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+
+    with pytest.raises(ValueError, match="assignments_dir and output_dir must not be empty"):
+        build_phase_wp_manifest("", str(output_dir))
+
+
+def test_build_phase_wp_manifest_nonexistent_dir_raises(tmp_path):
+    from autoskillit.planner import build_phase_wp_manifest
+
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+
+    with pytest.raises(FileNotFoundError, match="assignments_dir does not exist"):
+        build_phase_wp_manifest(str(tmp_path / "nonexistent"), str(output_dir))
+
+
+# ---------------------------------------------------------------------------
+# finalize_wp_manifest error branches
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_wp_manifest_corrupt_json_raises(tmp_path):
+    from autoskillit.planner import finalize_wp_manifest
+
+    wp_dir = tmp_path / "work_packages"
+    wp_dir.mkdir()
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    (wp_dir / "bad_result.json").write_text("{not json")
+
+    with pytest.raises(json.JSONDecodeError, match="Failed to parse"):
+        finalize_wp_manifest(str(wp_dir), str(output_dir))
+
+
+def test_finalize_wp_manifest_empty_string_raises(tmp_path):
+    from autoskillit.planner import finalize_wp_manifest
+
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+
+    with pytest.raises(ValueError, match="work_packages_dir and output_dir must not be empty"):
+        finalize_wp_manifest("", str(output_dir))
+
+
+def test_finalize_wp_manifest_nonexistent_dir_raises(tmp_path):
+    from autoskillit.planner import finalize_wp_manifest
+
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+
+    with pytest.raises(FileNotFoundError, match="work_packages_dir does not exist"):
+        finalize_wp_manifest(str(tmp_path / "nonexistent"), str(output_dir))

--- a/tests/planner/test_merge.py
+++ b/tests/planner/test_merge.py
@@ -4,7 +4,14 @@ import json
 
 import pytest
 
-from autoskillit.planner.merge import build_plan_snapshot, extract_item, merge_files, replace_item
+from autoskillit.planner.merge import (
+    build_plan_snapshot,
+    extract_item,
+    merge_files,
+    merge_tier_dir,
+    replace_item,
+)
+from tests.planner.conftest import make_phase_result
 
 pytestmark = [pytest.mark.layer("planner"), pytest.mark.small, pytest.mark.feature("planner")]
 
@@ -348,3 +355,117 @@ def test_build_plan_snapshot_projects_ordering(tmp_path) -> None:
     doc = json.loads(out.read_text())
     phase = doc["phases"][0]
     assert phase["ordering"] == 1
+
+
+# ---------------------------------------------------------------------------
+# WP1: build_plan_snapshot additional tests
+# ---------------------------------------------------------------------------
+
+
+def test_build_plan_snapshot_happy_path_two_phases_sorted(tmp_path) -> None:
+    phases_dir = tmp_path / "phases"
+    phases_dir.mkdir()
+    for phase_num, ordering in [(2, 2), (1, 1)]:
+        (phases_dir / f"P{phase_num}_result.json").write_text(
+            json.dumps(make_phase_result(phase_num))
+        )
+    out = tmp_path / "snapshot.json"
+
+    result = build_plan_snapshot(str(phases_dir), str(out))
+
+    data = json.loads(out.read_text())
+    assert len(data["phases"]) == 2
+    assert data["phases"][0]["ordering"] == 1
+    assert data["phases"][1]["ordering"] == 2
+    assert "P1" in result["phase_ids"]
+    assert "P2" in result["phase_ids"]
+
+
+def test_build_plan_snapshot_corrupt_json_skipped(tmp_path) -> None:
+    phases_dir = tmp_path / "phases"
+    phases_dir.mkdir()
+    (phases_dir / "P1_result.json").write_text(json.dumps(make_phase_result(1)))
+    (phases_dir / "bad_result.json").write_text("{not json")
+    out = tmp_path / "snapshot.json"
+
+    result = build_plan_snapshot(str(phases_dir), str(out))
+
+    data = json.loads(out.read_text())
+    assert len(data["phases"]) == 1
+    assert result["phase_ids"] == "P1"
+
+
+def test_build_plan_snapshot_nonexistent_phases_dir(tmp_path) -> None:
+    out = tmp_path / "snapshot.json"
+
+    result = build_plan_snapshot(str(tmp_path / "nonexistent"), str(out))
+
+    data = json.loads(out.read_text())
+    assert data["phases"] == []
+    assert result["phase_ids"] == ""
+
+
+def test_build_plan_snapshot_empty_dir_produces_empty_phases(tmp_path) -> None:
+    phases_dir = tmp_path / "phases"
+    phases_dir.mkdir()
+    out = tmp_path / "snapshot.json"
+
+    result = build_plan_snapshot(str(phases_dir), str(out))
+
+    data = json.loads(out.read_text())
+    assert data["phases"] == []
+    assert result["phase_ids"] == ""
+
+
+# ---------------------------------------------------------------------------
+# WP3: merge_tier_dir tests
+# ---------------------------------------------------------------------------
+
+
+def test_merge_tier_dir_empty_dir_raises(tmp_path) -> None:
+    empty_dir = tmp_path / "phases"
+    empty_dir.mkdir()
+    out = tmp_path / "combined.json"
+
+    with pytest.raises(ValueError, match="No \\*_result.json files found"):
+        merge_tier_dir(str(empty_dir), str(out), "phases")
+
+
+def test_merge_tier_dir_single_file(tmp_path) -> None:
+    results_dir = tmp_path / "phases"
+    results_dir.mkdir()
+    (results_dir / "P1_result.json").write_text(
+        json.dumps({"id": "P1", "name": "Phase 1", "ordering": 1})
+    )
+    out = tmp_path / "combined.json"
+
+    result = merge_tier_dir(str(results_dir), str(out), "phases")
+
+    assert result["item_count"] == "1"
+    assert out.exists()
+    data = json.loads(out.read_text())
+    assert len(data["phases"]) == 1
+    assert data["phases"][0]["id"] == "P1"
+
+
+# ---------------------------------------------------------------------------
+# WP4: replace_item error branches
+# ---------------------------------------------------------------------------
+
+
+def test_replace_item_nonexistent_replacement_file_raises(tmp_path) -> None:
+    src = tmp_path / "combined.json"
+    src.write_text(json.dumps({"phases": [{"id": "P1", "name": "x"}], "schema_version": 1}))
+
+    with pytest.raises(ValueError, match="Replacement file not found"):
+        replace_item(str(src), "P1", str(tmp_path / "nonexistent.json"))
+
+
+def test_replace_item_corrupt_replacement_json_raises(tmp_path) -> None:
+    src = tmp_path / "combined.json"
+    src.write_text(json.dumps({"phases": [{"id": "P1", "name": "x"}], "schema_version": 1}))
+    corrupt = tmp_path / "corrupt.json"
+    corrupt.write_text("{not json")
+
+    with pytest.raises(ValueError, match="Invalid JSON"):
+        replace_item(str(src), "P1", str(corrupt))

--- a/tests/planner/test_planner.py
+++ b/tests/planner/test_planner.py
@@ -118,6 +118,13 @@ def test_create_run_dir_unique_across_calls(tmp_path) -> None:
     assert (planner_dir2 / "work_packages").is_dir()
 
 
+def test_create_run_dir_empty_string_raises_value_error() -> None:
+    from autoskillit.planner import create_run_dir
+
+    with pytest.raises(ValueError, match="non-empty"):
+        create_run_dir("")
+
+
 def test_planner_feature_skill_categories() -> None:
     from autoskillit.core._type_constants import FEATURE_REGISTRY
 


### PR DESCRIPTION
## Summary

Add ~22 test methods across 4 existing test files covering error branches and edge cases in the planner subsystem: `build_plan_snapshot`, `create_run_dir`, `merge_tier_dir`, `replace_item`, manifest builders (`build_phase_assignment_manifest`, `build_phase_wp_manifest`, `finalize_wp_manifest`), and `compile_plan`. No source files are modified — tests only.

**Issue correction:** The issue references `build_pre_elab_snapshot` (WP1) but this function does not exist. The correct function is `build_plan_snapshot` in `src/autoskillit/planner/merge.py`. Existing tests for this function already live in `tests/planner/test_merge.py`, so WP1 tests are placed there (not in `test_manifests.py` as the issue suggests).

**Behavioral correction (WP1):** The issue states corrupt JSON raises `json.JSONDecodeError` and missing file raises `FileNotFoundError`. In reality, `build_plan_snapshot` **swallows** both errors via a `try/except (ValueError, json.JSONDecodeError)` block and logs a warning. Tests must verify the actual skip-and-warn behavior, not exception propagation.

Closes #1540

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260430-081121-173068/.autoskillit/temp/make-plan/p3_planner_test_coverage_plan_2026-04-30_082100.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 58 | 11.9k | 640.2k | 72.7k | 1 | 7m 13s |
| verify | 51 | 16.1k | 3.0M | 100.7k | 1 | 8m 51s |
| implement | 252 | 16.9k | 2.3M | 83.4k | 1 | 7m 42s |
| prepare_pr | 52 | 4.3k | 172.1k | 27.8k | 1 | 1m 22s |
| compose_pr | 67 | 2.0k | 219.7k | 18.8k | 1 | 43s |
| review_pr | 198 | 38.6k | 1.2M | 70.1k | 1 | 7m 37s |
| resolve_review | 219 | 8.7k | 1.2M | 59.6k | 1 | 5m 18s |
| **Total** | 897 | 98.5k | 8.7M | 433.0k | | 38m 49s |