### PR TITLE
Implementation Plan: Diff-Scoped Context Pre-Step for resolve-review

### DIFF
--- a/src/autoskillit/skills_extended/resolve-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-review/SKILL.md
@@ -136,6 +136,26 @@ If the GraphQL call fails (e.g., token lacks `read:discussion` scope), log a war
 set `comment_id_to_thread_id = {}`. Thread resolution will be silently skipped in Step 6.
 Flag this in the Step 7 report for human review.
 
+**Load Pre-Built Context (if available):**
+
+After saving the raw review responses, check for the handoff file from review-pr:
+
+```bash
+DIFF_CONTEXT_PATH="{{AUTOSKILLIT_TEMP}}/review-pr/diff_context_${PR_NUMBER}.json"
+```
+
+If the file exists:
+- Parse it as JSON
+- Build `diff_context_map: dict[tuple[str, int], str]` where key is `(entry.path, entry.line)`
+  and value is `entry.code_region`
+- Log: `"Loaded pre-built context for N findings from review-pr handoff (schema_version: {v})"`
+
+If the file is absent or cannot be parsed:
+- Set `diff_context_map = {}`
+- Log: `"No pre-built context file found — will read files in Step 3.5 (fallback)"`
+
+This lookup is used in Steps 3.5 and 4 to avoid redundant file reads.
+
 ### Step 3: Parse and Classify Findings
 
 From **inline comments**, extract per comment:
@@ -183,7 +203,12 @@ the Task tool (`model: "sonnet"`).
 
 **Sub-agent prompt template** — each sub-agent receives:
 - The list of comments in its domain group (with `path`, `line`, `body`, `diff_hunk`)
-- Instructions to read the actual code at each flagged line (±30 lines context)
+- Instructions for reading code context: if a pre-built code_region for this finding's
+  `(path, line)` is available in `diff_context_map`, include it directly in the prompt
+  under "Pre-built code region (from review-pr, ±50 diff lines):" and instruct the
+  sub-agent to use it — do **not** instruct it to read the file for context. If
+  `diff_context_map` has no entry for this finding, instruct the sub-agent to read
+  the actual code at the flagged line (±30 lines context) as before.
 - Instructions to run `git log --follow -p --max-count=5 -- {path}` to trace original intent via git history
 - Instructions to classify each comment as `ACCEPT`, `REJECT`, or `DISCUSS` with:
   - `verdict`: the classification (`ACCEPT` / `REJECT` / `DISCUSS`)
@@ -214,6 +239,20 @@ the Task tool (`model: "sonnet"`).
 ]
 ```
 
+**Building sub-agent prompts with pre-built context:**
+
+When `diff_context_map` has an entry for `(comment.path, comment.line)`:
+```
+Pre-built code region (from review-pr, ±50 diff lines):
+{diff_context_map[(comment.path, comment.line)]}
+
+Use the above region for context. Do NOT read the file — the region is already provided.
+Run `git log --follow -p --max-count=5 -- {path}` for history context as usual.
+```
+
+When `diff_context_map` has no entry: fall back to current behavior — instruct the
+sub-agent to read `±30 lines` from the file.
+
 **Fallback:** If a sub-agent fails or times out, classify all comments in that group as
 `DISCUSS` (safe fallback — no code is changed, human reviews). Log the failure including
 the error message, domain group name, and affected comment IDs.
@@ -238,7 +277,12 @@ Initialize `addressed_thread_ids: list[str] = []` before processing findings.
 For each finding where the classification map shows `verdict = ACCEPT`
 (process critical findings first, then warnings):
 
-1. Read the referenced file and ±20 lines of context around the comment line
+1. **Context for understanding:** If `diff_context_map[(path, line)]` is present,
+   use the pre-built code_region for initial understanding — skip the ±20 line read.
+   The pre-built region is already available from the review-pr handoff.
+   If `diff_context_map` has no entry, read the referenced file and ±20 lines of
+   context as before. In both cases, still read the file when actually applying
+   the edit — the pre-built context covers understanding only, not the write.
 2. Understand what the reviewer is requesting
 3. Apply the fix
 4. Stage and commit:

--- a/src/autoskillit/skills_extended/resolve-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-review/SKILL.md
@@ -241,10 +241,10 @@ the Task tool (`model: "sonnet"`).
 
 **Building sub-agent prompts with pre-built context:**
 
-When `diff_context_map` has an entry for `(comment.path, comment.line)`:
+When `diff_context_map.get((comment.path, comment.line))` returns a value:
 ```
 Pre-built code region (from review-pr, ±50 diff lines):
-{diff_context_map[(comment.path, comment.line)]}
+{diff_context_map.get((comment.path, comment.line), "")}
 
 Use the above region for context. Do NOT read the file — the region is already provided.
 Run `git log --follow -p --max-count=5 -- {path}` for history context as usual.
@@ -277,7 +277,7 @@ Initialize `addressed_thread_ids: list[str] = []` before processing findings.
 For each finding where the classification map shows `verdict = ACCEPT`
 (process critical findings first, then warnings):
 
-1. **Context for understanding:** If `diff_context_map[(path, line)]` is present,
+1. **Context for understanding:** If `diff_context_map.get((path, line))` returns a value,
    use the pre-built code_region for initial understanding — skip the ±20 line read.
    The pre-built region is already available from the review-pr handoff.
    If `diff_context_map` has no entry, read the referenced file and ±20 lines of

--- a/src/autoskillit/skills_extended/review-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/review-pr/SKILL.md
@@ -621,7 +621,7 @@ Write to `{{AUTOSKILLIT_TEMP}}/review-pr/diff_context_{pr_number}.json`:
 
 ```json
 {
-  "pr_number": "{pr_number}",
+  "pr_number": 1234,
   "schema_version": 1,
   "written_at": "{ISO-8601 timestamp}",
   "context_entries": [

--- a/src/autoskillit/skills_extended/review-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/review-pr/SKILL.md
@@ -597,6 +597,50 @@ These findings target lines not in the diff and could not be posted as inline co
 
 Save findings summary to `{{AUTOSKILLIT_TEMP}}/review-pr/summary_{pr_number}_{timestamp}.md`. (relative to the current working directory)
 
+**Write Diff-Scoped Context Handoff (before emitting verdict):**
+
+After writing the summary file and before emitting the verdict token, write the handoff
+file for resolve-review's pre-built context. This costs zero additional API calls or file
+reads — all data is already in the session's context.
+
+For each finding in `FILTERED_FINDINGS` + `UNPOSTABLE_FINDINGS` where severity is
+`"critical"` or `"warning"`, build a context entry:
+- `path` — the finding's `file` field (the finding schema uses `file`, not `path`;
+  map `finding.file` → `path` in the context entry for resolve-review compatibility)
+- `line` — the finding's line number
+- `severity` — `"critical"` or `"warning"`
+- `dimension` — the audit dimension (arch, tests, bugs, etc.)
+- `message` — the finding's message text
+- `code_region` — extract from `ANNOTATED_DIFF`: find the file's section in the
+  annotated diff (between its `diff --git` header and the next), then collect all
+  lines whose `[LX]` marker has X within ±50 of the finding's `line`. Include those
+  raw annotated-diff lines as-is. If ANNOTATED_DIFF is empty or the file section is
+  not found, set `code_region` to `""`.
+
+Write to `{{AUTOSKILLIT_TEMP}}/review-pr/diff_context_{pr_number}.json`:
+
+```json
+{
+  "pr_number": "{pr_number}",
+  "schema_version": 1,
+  "written_at": "{ISO-8601 timestamp}",
+  "context_entries": [
+    {
+      "path": "src/autoskillit/execution/headless.py",
+      "line": 42,
+      "severity": "critical",
+      "dimension": "arch",
+      "message": "...",
+      "code_region": "[L40] ...\n[L41] ...\n[L42] ..."
+    }
+  ]
+}
+```
+
+Log: `"Wrote diff-scoped context handoff: N entries → {path}"`. If the write fails
+(e.g., temp dir unavailable), log a warning and continue — the handoff file is
+best-effort and its absence is handled gracefully by resolve-review.
+
 Output the verdict as the final line:
 
 > **IMPORTANT:** Emit the structured output tokens as **literal plain text with no

--- a/tests/skills/test_resolve_review_diff_context_consumption.py
+++ b/tests/skills/test_resolve_review_diff_context_consumption.py
@@ -1,29 +1,40 @@
 """Guards: resolve-review loads and uses diff_context handoff file from review-pr."""
+
 from pathlib import Path
 
 SKILL_PATH = (
     Path(__file__).parent.parent.parent
-    / "src" / "autoskillit" / "skills_extended" / "resolve-review" / "SKILL.md"
+    / "src"
+    / "autoskillit"
+    / "skills_extended"
+    / "resolve-review"
+    / "SKILL.md"
 )
-SKILL_TEXT = SKILL_PATH.read_text()
+
+
+def _skill_text() -> str:
+    return SKILL_PATH.read_text()
 
 
 def _step2_section() -> str:
-    start = SKILL_TEXT.find("### Step 2")
-    end = SKILL_TEXT.find("### Step 3", start)
-    return SKILL_TEXT[start:end]
+    text = _skill_text()
+    start = text.find("### Step 2")
+    end = text.find("### Step 3", start)
+    return text[start:end]
 
 
 def _step35_section() -> str:
-    start = SKILL_TEXT.find("### Step 3.5")
-    end = SKILL_TEXT.find("### Step 4", start)
-    return SKILL_TEXT[start:end]
+    text = _skill_text()
+    start = text.find("### Step 3.5")
+    end = text.find("### Step 4", start)
+    return text[start:end]
 
 
 def _step4_section() -> str:
-    start = SKILL_TEXT.find("### Step 4")
-    end = SKILL_TEXT.find("### Step 5", start)
-    return SKILL_TEXT[start:end]
+    text = _skill_text()
+    start = text.find("### Step 4")
+    end = text.find("### Step 5", start)
+    return text[start:end]
 
 
 def test_step2_checks_for_diff_context_file():
@@ -83,5 +94,5 @@ def test_step4_still_reads_file_for_editing():
 
 def test_diff_context_path_matches_review_pr_output_path():
     """resolve-review's diff_context path must match what review-pr writes."""
-    full = SKILL_TEXT
+    full = _skill_text()
     assert "review-pr/diff_context" in full

--- a/tests/skills/test_resolve_review_diff_context_consumption.py
+++ b/tests/skills/test_resolve_review_diff_context_consumption.py
@@ -63,7 +63,7 @@ def test_step2_fallback_when_file_absent():
 def test_step35_uses_prebuilt_code_region():
     """Step 3.5 sub-agent prompt must use pre-loaded code_region when available."""
     section = _step35_section()
-    assert "diff_context_map" in section or "code_region" in section
+    assert "diff_context_map" in section
 
 
 def test_step35_skips_file_read_when_context_available():

--- a/tests/skills/test_resolve_review_diff_context_consumption.py
+++ b/tests/skills/test_resolve_review_diff_context_consumption.py
@@ -26,6 +26,7 @@ def _step2_section() -> str:
 def _step35_section() -> str:
     text = _skill_text()
     start = text.find("### Step 3.5")
+    assert start != -1, "### Step 3.5 not found in SKILL.md"
     end = text.find("### Step 4", start)
     return text[start:end]
 
@@ -33,7 +34,9 @@ def _step35_section() -> str:
 def _step4_section() -> str:
     text = _skill_text()
     start = text.find("### Step 4")
+    assert start != -1, "### Step 4 not found in SKILL.md"
     end = text.find("### Step 5", start)
+    end = end if end != -1 else None
     return text[start:end]
 
 

--- a/tests/skills/test_resolve_review_diff_context_consumption.py
+++ b/tests/skills/test_resolve_review_diff_context_consumption.py
@@ -1,0 +1,87 @@
+"""Guards: resolve-review loads and uses diff_context handoff file from review-pr."""
+from pathlib import Path
+
+SKILL_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src" / "autoskillit" / "skills_extended" / "resolve-review" / "SKILL.md"
+)
+SKILL_TEXT = SKILL_PATH.read_text()
+
+
+def _step2_section() -> str:
+    start = SKILL_TEXT.find("### Step 2")
+    end = SKILL_TEXT.find("### Step 3", start)
+    return SKILL_TEXT[start:end]
+
+
+def _step35_section() -> str:
+    start = SKILL_TEXT.find("### Step 3.5")
+    end = SKILL_TEXT.find("### Step 4", start)
+    return SKILL_TEXT[start:end]
+
+
+def _step4_section() -> str:
+    start = SKILL_TEXT.find("### Step 4")
+    end = SKILL_TEXT.find("### Step 5", start)
+    return SKILL_TEXT[start:end]
+
+
+def test_step2_checks_for_diff_context_file():
+    """Step 2 must check for the review-pr diff_context handoff file."""
+    section = _step2_section()
+    assert "diff_context" in section
+
+
+def test_step2_loads_diff_context_map():
+    """Step 2 must build a diff_context_map lookup structure."""
+    section = _step2_section()
+    assert "diff_context_map" in section
+
+
+def test_step2_fallback_when_file_absent():
+    """Step 2 must fall back to empty map when diff_context file is absent."""
+    section = _step2_section()
+    # Must mention fallback, absence, or empty-map behavior
+    lower = section.lower()
+    assert "absent" in lower or "not found" in lower or "fallback" in lower or "{}" in section
+
+
+def test_step35_uses_prebuilt_code_region():
+    """Step 3.5 sub-agent prompt must use pre-loaded code_region when available."""
+    section = _step35_section()
+    assert "diff_context_map" in section or "code_region" in section
+
+
+def test_step35_skips_file_read_when_context_available():
+    """Step 3.5 must skip 'read file' instruction when pre-built context is present."""
+    section = _step35_section()
+    lower = section.lower()
+    # Must indicate the file-read instruction is conditional or skipped
+    assert (
+        "instead of" in lower
+        or "skip" in lower
+        or "do not read" in lower
+        or "use the pre" in lower
+    )
+
+
+def test_step4_skips_understanding_read_when_context_present():
+    """Step 4 must skip the ±20 line understanding read when diff_context_map has entry."""
+    section = _step4_section()
+    assert "diff_context_map" in section
+    lower = section.lower()
+    assert "skip" in lower or "omit" in lower or "already available" in lower
+
+
+def test_step4_still_reads_file_for_editing():
+    """Step 4 must still read the file for applying actual edits even with pre-built context."""
+    section = _step4_section()
+    lower = section.lower()
+    # Must mention that file read for editing is still needed
+    assert "still read" in lower or "read the file" in lower
+
+
+def test_diff_context_path_matches_review_pr_output_path():
+    """resolve-review's diff_context path must match what review-pr writes."""
+    full = SKILL_TEXT
+    assert "review-pr/diff_context" in full

--- a/tests/skills/test_review_pr_diff_context_handoff.py
+++ b/tests/skills/test_review_pr_diff_context_handoff.py
@@ -26,7 +26,7 @@ def _step8_section() -> str:
 def test_step8_writes_diff_context_file():
     """Step 8 must declare writing diff_context_{pr_number}.json."""
     section = _step8_section()
-    assert "diff_context_{pr_number}.json" in section or "diff_context_" in section
+    assert "diff_context_{pr_number}.json" in section
 
 
 def test_diff_context_path_uses_review_pr_temp_dir():

--- a/tests/skills/test_review_pr_diff_context_handoff.py
+++ b/tests/skills/test_review_pr_diff_context_handoff.py
@@ -1,0 +1,71 @@
+"""Guards: review-pr writes diff_context handoff file in Step 8 before verdict emission."""
+from pathlib import Path
+
+SKILL_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src" / "autoskillit" / "skills_extended" / "review-pr" / "SKILL.md"
+)
+SKILL_TEXT = SKILL_PATH.read_text()
+
+
+def _step8_section() -> str:
+    start = SKILL_TEXT.find("### Step 8")
+    # Step 8 is the last step; take to end of file
+    return SKILL_TEXT[start:]
+
+
+def test_step8_writes_diff_context_file():
+    """Step 8 must declare writing diff_context_{pr_number}.json."""
+    section = _step8_section()
+    assert "diff_context_{pr_number}.json" in section or "diff_context_" in section
+
+
+def test_diff_context_path_uses_review_pr_temp_dir():
+    """Handoff file must live in AUTOSKILLIT_TEMP/review-pr/, not resolve-review/."""
+    section = _step8_section()
+    assert "review-pr/diff_context" in section
+
+
+def test_diff_context_schema_has_context_entries():
+    """Handoff JSON schema must include context_entries field."""
+    section = _step8_section()
+    assert "context_entries" in section
+
+
+def test_diff_context_entries_have_code_region():
+    """Each context entry must include a code_region field."""
+    section = _step8_section()
+    assert "code_region" in section
+
+
+def test_code_region_extracted_from_annotated_diff():
+    """code_region must be sourced from ANNOTATED_DIFF — no additional file reads."""
+    section = _step8_section()
+    assert "ANNOTATED_DIFF" in section
+    # Must state zero additional reads
+    lower = section.lower()
+    assert "zero" in lower or "no additional" in lower or "no file read" in lower
+
+
+def test_handoff_write_precedes_verdict_emission():
+    """diff_context write must appear before 'verdict = ' in Step 8 text."""
+    section = _step8_section()
+    write_pos = section.find("diff_context")
+    verdict_pos = section.find("verdict = ")
+    assert write_pos != -1, "diff_context not found in Step 8"
+    assert verdict_pos != -1, "verdict = not found in Step 8"
+    assert write_pos < verdict_pos, (
+        "diff_context write must precede verdict = emission"
+    )
+
+
+def test_diff_context_covers_critical_and_warning():
+    """All critical and warning findings must be captured — not just critical."""
+    section = _step8_section()
+    assert "critical" in section and "warning" in section
+
+
+def test_diff_context_schema_version_field():
+    """JSON schema must include schema_version for future-proofing."""
+    section = _step8_section()
+    assert "schema_version" in section

--- a/tests/skills/test_review_pr_diff_context_handoff.py
+++ b/tests/skills/test_review_pr_diff_context_handoff.py
@@ -1,17 +1,26 @@
 """Guards: review-pr writes diff_context handoff file in Step 8 before verdict emission."""
+
 from pathlib import Path
 
 SKILL_PATH = (
     Path(__file__).parent.parent.parent
-    / "src" / "autoskillit" / "skills_extended" / "review-pr" / "SKILL.md"
+    / "src"
+    / "autoskillit"
+    / "skills_extended"
+    / "review-pr"
+    / "SKILL.md"
 )
-SKILL_TEXT = SKILL_PATH.read_text()
+
+
+def _skill_text() -> str:
+    return SKILL_PATH.read_text()
 
 
 def _step8_section() -> str:
-    start = SKILL_TEXT.find("### Step 8")
+    text = _skill_text()
+    start = text.find("### Step 8")
     # Step 8 is the last step; take to end of file
-    return SKILL_TEXT[start:]
+    return text[start:]
 
 
 def test_step8_writes_diff_context_file():
@@ -54,9 +63,7 @@ def test_handoff_write_precedes_verdict_emission():
     verdict_pos = section.find("verdict = ")
     assert write_pos != -1, "diff_context not found in Step 8"
     assert verdict_pos != -1, "verdict = not found in Step 8"
-    assert write_pos < verdict_pos, (
-        "diff_context write must precede verdict = emission"
-    )
+    assert write_pos < verdict_pos, "diff_context write must precede verdict = emission"
 
 
 def test_diff_context_covers_critical_and_warning():


### PR DESCRIPTION
## Summary

Have `review-pr` write a diff-scoped context handoff file (`diff_context_{pr_number}.json`)
as its final artifact before emitting the verdict token. `resolve-review` then loads this
file at startup and uses the pre-built code regions in its Step 3.5 sub-agent prompts and
Step 4 fix loop — replacing redundant file reads with data already computed by `review-pr`.
Backward compatibility is implicit: if the file is absent, `resolve-review` falls back to
its current behavior.

The changes are **SKILL.md-only** — two files, no Python code changes.

Closes #1569

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260430-185933-438375/.autoskillit/temp/make-plan/diff_scoped_context_pre_step_for_resolve_review_plan_2026-04-30_000001.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 3.5k | 16.9k | 402.0k | 59.9k | 1 | 11m 32s |
| verify | 662 | 7.0k | 636.7k | 56.3k | 1 | 4m 4s |
| implement | 172 | 9.3k | 871.3k | 53.8k | 1 | 4m 23s |
| prepare_pr | 68 | 3.9k | 251.3k | 27.6k | 1 | 1m 31s |
| compose_pr | 59 | 2.2k | 192.3k | 19.4k | 1 | 44s |
| review_pr | 382 | 123.0k | 2.3M | 224.8k | 3 | 26m 18s |
| resolve_review | 801 | 48.7k | 5.1M | 188.5k | 3 | 24m 17s |
| **Total** | 5.6k | 211.0k | 9.8M | 630.5k | | 1h 12m |