### PR TITLE
Skip Info-Level Findings from resolve-review Intent Validation

### DIFF
--- a/src/autoskillit/skills_extended/resolve-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-review/SKILL.md
@@ -165,14 +165,14 @@ From **top-level reviews**, extract:
 
 When a finding matches multiple tiers, use the highest severity.
 
-All three severity levels proceed to intent validation.
+Critical and warning findings proceed to intent validation (Step 3.5). Info findings are auto-classified as `DISCUSS` — they do not enter Step 3.5.
 
 ### Step 3.5: Intent Validation (Parallel Sub-Agents — BEFORE any code changes)
 
-Before applying any fix, validate every finding (critical, warning, and info) against the actual
+Before applying any fix, validate every critical and warning finding against the actual
 codebase and git history. This analysis phase runs entirely before code changes are made.
 
-**Domain grouping:** Group all findings by the top-level path segment of
+**Domain grouping:** Group all critical and warning findings by the top-level path segment of
 their `path` field:
 - `src/autoskillit/execution/headless.py` → group `execution`
 - `tests/skills/test_foo.py` → group `tests`
@@ -319,9 +319,9 @@ the overall skill.
 
 ### Step 6.5: Post Inline Replies
 
-For every comment that was analyzed (i.e., every finding that reached intent validation in
-Step 3.5), post an inline reply using the GitHub comment reply API. Each analyzed
-comment receives exactly one reply based on its classification.
+For every finding (those classified via intent validation in Step 3.5 and info findings
+auto-classified as DISCUSS in Step 3), post an inline reply using the GitHub comment reply
+API. Each finding receives exactly one reply based on its classification.
 
 ```bash
 # Build reply body based on classification:
@@ -331,6 +331,8 @@ BODY="Agreed — fixed in ${commit_sha}. ${evidence}"
 BODY="Investigated — this is intentional. ${evidence}"
 # DISCUSS:
 BODY="Valid observation — flagged for design decision. ${evidence}"
+# INFO (auto-classified DISCUSS):
+BODY="Acknowledged — minor suggestion noted."
 
 gh api repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies \
   --method POST \

--- a/tests/skills/test_resolve_review_severity_and_reject_resolution.py
+++ b/tests/skills/test_resolve_review_severity_and_reject_resolution.py
@@ -12,42 +12,73 @@ assert SKILL_PATH.exists(), f"SKILL.md not found at {SKILL_PATH}"
 SKILL_TEXT = SKILL_PATH.read_text()
 
 
-def test_info_findings_not_filtered_out() -> None:
-    """Step 3 must NOT filter out info findings — no 'skip info findings entirely' instruction."""
-    assert "Skip `info` findings entirely" not in SKILL_TEXT, (
-        "Step 3 must not drop info findings — they must flow to Step 3.5"
-    )
-    assert "skipped — below threshold" not in SKILL_TEXT, (
-        "Step 3 must not mark info findings as 'skipped — below threshold'"
-    )
+def test_info_findings_auto_classified_as_discuss() -> None:
+    """Step 3 must state info findings are auto-classified as DISCUSS, bypassing Step 3.5."""
+    step3_idx = SKILL_TEXT.find("### Step 3:")
+    if step3_idx == -1:
+        step3_idx = SKILL_TEXT.find("### Step 3")
+    assert step3_idx != -1, "SKILL.md must have a Step 3 section"
+    step35_idx = SKILL_TEXT.find("### Step 3.5")
+    assert step35_idx != -1, "SKILL.md must have a Step 3.5 section"
+    step3_section = SKILL_TEXT[step3_idx:step35_idx]
+    assert (
+        "auto-classified" in step3_section.lower()
+        or "auto-classify" in step3_section.lower()
+        or ("discuss" in step3_section and "info" in step3_section.lower())
+    ), "Step 3 must state that info findings are auto-classified as DISCUSS"
+    assert (
+        "do not enter" in step3_section.lower()
+        or "bypass" in step3_section.lower()
+        or (
+            "not enter step 3.5" in step3_section.lower()
+            or "do not enter step" in step3_section.lower()
+        )
+    ), "Step 3 must state that info findings do not enter Step 3.5"
 
 
-def test_info_findings_reach_intent_validation() -> None:
-    """Step 3.5 domain grouping must cover all findings, not just critical+warning."""
-    assert "critical+warning findings" not in SKILL_TEXT, (
-        "Domain grouping instruction must include all severities, not restrict to critical+warning"
-    )
-    # Verify the new all-severity phrasing is present
+def test_intent_validation_restricted_to_critical_and_warning() -> None:
+    """Step 3.5 domain grouping must cover only critical and warning, not all findings."""
     step35_idx = SKILL_TEXT.find("### Step 3.5")
     assert step35_idx != -1, "SKILL.md must have a Step 3.5 section"
     step4_idx = SKILL_TEXT.find("### Step 4")
     step35_section = SKILL_TEXT[step35_idx:step4_idx]
-    assert "Group all findings" in step35_section, (
-        "Step 3.5 domain grouping must say 'Group all findings' (all severities)"
+    assert "Group all findings" not in step35_section, (
+        "Step 3.5 must not say 'Group all findings' — info findings no longer enter Step 3.5"
+    )
+    assert "critical and warning" in step35_section.lower(), (
+        "Step 3.5 domain grouping must restrict to critical and warning findings"
     )
 
 
-def test_intent_validation_scope_includes_all_severities() -> None:
-    """Step 3.5 intro must validate every finding, not just critical and warning."""
-    assert "validate every critical and warning finding" not in SKILL_TEXT, (
-        "Step 3.5 must not restrict validation to only critical and warning findings"
-    )
+def test_info_findings_do_not_enter_step_35() -> None:
+    """Step 3.5 intro must say 'validate every critical and warning finding', not 'every finding'."""
     step35_idx = SKILL_TEXT.find("### Step 3.5")
     assert step35_idx != -1, "SKILL.md must have a Step 3.5 section"
     step4_idx = SKILL_TEXT.find("### Step 4")
     step35_section = SKILL_TEXT[step35_idx:step4_idx]
-    assert "validate every finding" in step35_section, (
-        "Step 3.5 must say 'validate every finding' (all severities)"
+    assert "validate every finding" not in step35_section, (
+        "Step 3.5 must not say 'validate every finding' — info findings are now excluded"
+    )
+    assert "validate every critical and warning finding" in step35_section, (
+        "Step 3.5 must say 'validate every critical and warning finding'"
+    )
+
+
+def test_info_reply_template_uses_acknowledged() -> None:
+    """Step 6.5 must include a templated reply for info (auto-classified) findings."""
+    step65_idx = SKILL_TEXT.find("### Step 6.5")
+    assert step65_idx != -1, "SKILL.md must have a Step 6.5 section"
+    step66_idx = SKILL_TEXT.find("### Step 6.6", step65_idx)
+    step65_section = (
+        SKILL_TEXT[step65_idx:step66_idx]
+        if step66_idx != -1
+        else SKILL_TEXT[step65_idx : step65_idx + 1200]
+    )
+    assert "acknowledged" in step65_section.lower(), (
+        "Step 6.5 must include 'Acknowledged' template for info findings"
+    )
+    assert "minor suggestion" in step65_section.lower(), (
+        "Step 6.5 must include 'minor suggestion noted' in the info reply template"
     )
 
 


### PR DESCRIPTION
## Summary

Info-severity findings (nit, optional, minor, style, cosmetic, could) in the `resolve-review` skill currently flow through the full Step 3.5 sub-agent intent-validation pipeline. Because info findings almost never produce `ACCEPT` verdicts, this wastes 20-40% of sub-agent budget on findings that will always end up as `DISCUSS` or `REJECT` with no code changes. The fix: auto-classify info findings as `DISCUSS` at Step 3 and bypass Step 3.5 entirely. Info findings still receive an inline reply in Step 6.5 using a templated acknowledgment. Three existing tests that enforced the old all-severities behavior are replaced with tests that enforce the new correct behavior.

Closes #1570

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260430-185933-805187/.autoskillit/temp/make-plan/skip_info_level_findings_from_resolve_review_intent_validation_plan_2026-04-30_000000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 177 | 19.7k | 1.0M | 69.9k | 1 | 4m 58s |
| verify | 48 | 10.1k | 1.2M | 70.2k | 1 | 7m 53s |
| implement | 182 | 7.7k | 1.0M | 57.2k | 1 | 4m 59s |
| prepare_pr | 60 | 4.3k | 212.5k | 27.1k | 1 | 1m 28s |
| compose_pr | 59 | 2.2k | 192.3k | 19.3k | 1 | 56s |
| review_pr | 94 | 21.0k | 476.2k | 49.3k | 1 | 4m 0s |
| **Total** | 620 | 64.9k | 4.1M | 293.0k | | 24m 16s |