### PR TITLE
Implementation Plan: resolve-review SKILL.md Token Optimizations (Easy Wins)

### DIFF
--- a/src/autoskillit/skills_extended/resolve-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-review/SKILL.md
@@ -292,6 +292,16 @@ For findings where the classification map shows `verdict = REJECT` or `verdict =
 - For REJECT: no code changes are applied; record `(file, line, reason="classifier: REJECT — {evidence}")`.
 - For DISCUSS: record `(file, line, reason="classifier: DISCUSS — {context}")`.
 
+**`thread_node_id` Tracking:**
+
+| Outcome | Append to `addressed_thread_ids`? |
+|---------|-----------------------------------|
+| ACCEPT — fix committed | Yes (if `thread_node_id` is not `None`) |
+| REJECT — no code change | Yes (if `thread_node_id` is not `None`) |
+| DISCUSS — awaiting human decision | No — do not add DISCUSS findings to `addressed_thread_ids` |
+| Skipped finding (stale, missing file, unclear) | No |
+| File-level comment (`line` is null) | No |
+
 **Skip a finding if:**
 - The comment is a file-level comment (`line` is null) — these have no code anchor
 - The referenced file does not exist in the current branch
@@ -303,16 +313,6 @@ Record each skip with: `(file, line, reason)`.
 
 **Skip a finding flow:** When skipping a finding (stale comment, missing file, unclear guidance, contradiction):
 - Record `(file, line, reason)` as before.
-
-**`thread_node_id` Tracking:**
-
-| Outcome | Append to `addressed_thread_ids`? |
-|---------|-----------------------------------|
-| ACCEPT — fix committed | Yes (if `thread_node_id` is not `None`) |
-| REJECT — no code change | Yes (if `thread_node_id` is not `None`) |
-| DISCUSS — awaiting human decision | No — thread remains open |
-| Skipped finding (stale, missing file, unclear) | No |
-| File-level comment (`line` is null) | No |
 
 ### Step 5: Run Tests
 

--- a/src/autoskillit/skills_extended/resolve-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-review/SKILL.md
@@ -170,7 +170,7 @@ From **inline comments**, extract per comment:
 **File-level comment guard:** If `line` is null (file-level comment posted by
 review-pr), skip this finding entirely — file-level comments have no code anchor and
 cannot be resolved by code changes. Record: `(path, null, reason="file-level comment — no
-line anchor")`.
+line anchor")`. See the thread_node_id tracking table in Step 4 for the no-add disposition.
 
 From **top-level reviews**, extract:
 - `state` — APPROVED, CHANGES_REQUESTED, COMMENTED

--- a/src/autoskillit/skills_extended/resolve-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-review/SKILL.md
@@ -170,7 +170,7 @@ From **inline comments**, extract per comment:
 **File-level comment guard:** If `line` is null (file-level comment posted by
 review-pr), skip this finding entirely — file-level comments have no code anchor and
 cannot be resolved by code changes. Record: `(path, null, reason="file-level comment — no
-line anchor")`. Do not add its `thread_node_id` to `addressed_thread_ids`.
+line anchor")`.
 
 From **top-level reviews**, extract:
 - `state` — APPROVED, CHANGES_REQUESTED, COMMENTED
@@ -198,6 +198,12 @@ their `path` field:
 - `tests/skills/test_foo.py` → group `tests`
 - `src/autoskillit/server/tools_ci.py` → group `server`
 
+**Inline classification shortcut:** If there are 3 or fewer findings AND they all
+fall in a single domain group, classify them inline — read each unique file once
+(±30 lines around all flagged lines), run `git log` once per unique path, then
+emit a verdict for each finding — without spawning a Task sub-agent. The
+classification criteria and output format are identical to the sub-agent path.
+
 This produces 3–6 groups on a typical PR. Launch one parallel sub-agent per group using
 the Task tool (`model: "sonnet"`).
 
@@ -207,9 +213,10 @@ the Task tool (`model: "sonnet"`).
   `(path, line)` is available in `diff_context_map`, include it directly in the prompt
   under "Pre-built code region (from review-pr, ±50 diff lines):" and instruct the
   sub-agent to use it — do **not** instruct it to read the file for context. If
-  `diff_context_map` has no entry for this finding, instruct the sub-agent to read
-  the actual code at the flagged line (±30 lines context) as before.
-- Instructions to run `git log --follow -p --max-count=5 -- {path}` to trace original intent via git history
+  `diff_context_map` has no entry for this finding, instruct the sub-agent: "For each unique file in the group, read the file
+  once, spanning all flagged lines with ±30 lines margin. Classify each
+  finding from the already-read content — do not re-read the file per finding."
+- Instructions to run `git log --follow -p --max-count=5 -- {path}` once per unique path (not once per finding) to trace original intent
 - Instructions to classify each comment as `ACCEPT`, `REJECT`, or `DISCUSS` with:
   - `verdict`: the classification (`ACCEPT` / `REJECT` / `DISCUSS`)
   - `evidence`: specific references (line numbers, function names, API docs, contracts)
@@ -224,20 +231,7 @@ the Task tool (`model: "sonnet"`).
 - `DISCUSS` — the comment raises a valid design question that requires a human decision;
   flag for human review, do NOT change the code automatically
 
-**Output from each sub-agent** — a JSON array:
-```json
-[
-  {
-    "comment_id": 123,
-    "path": "src/autoskillit/execution/headless.py",
-    "line": 42,
-    "verdict": "REJECT",
-    "evidence": "The method never raises — this is contractual (see docstring line 12 and callers in tools_execution.py:88)",
-    "category": "false_positive_intentional_pattern",
-    "commit_sha_hint": "abc1234"
-  }
-]
-```
+**Output from each sub-agent** — a JSON array of objects with fields: `comment_id`, `path`, `line`, `verdict`, `evidence`, `category` (REJECT only), `commit_sha_hint`.
 
 **Building sub-agent prompts with pre-built context:**
 
@@ -293,17 +287,10 @@ For each finding where the classification map shows `verdict = ACCEPT`
    git commit -m "fix(review): {brief description of reviewer's request}"
    ```
 
-**Apply the fix flow:** After committing the fix:
-- Append the finding's `thread_node_id` to `addressed_thread_ids` (if not `None`).
-
 **Classification gate — REJECT/DISCUSS bypass:**
 For findings where the classification map shows `verdict = REJECT` or `verdict = DISCUSS`:
 - For REJECT: no code changes are applied; record `(file, line, reason="classifier: REJECT — {evidence}")`.
-  Append the finding's `thread_node_id` to `addressed_thread_ids` (if not `None`) — a resolved
-  thread with an "Investigated — this is intentional" reply is the correct end state.
 - For DISCUSS: record `(file, line, reason="classifier: DISCUSS — {context}")`.
-  Do NOT add DISCUSS findings' `thread_node_id` to `addressed_thread_ids` — these threads
-  remain open for human decision.
 
 **Skip a finding if:**
 - The comment is a file-level comment (`line` is null) — these have no code anchor
@@ -316,7 +303,16 @@ Record each skip with: `(file, line, reason)`.
 
 **Skip a finding flow:** When skipping a finding (stale comment, missing file, unclear guidance, contradiction):
 - Record `(file, line, reason)` as before.
-- Do NOT add the finding's `thread_node_id` to `addressed_thread_ids`.
+
+**`thread_node_id` Tracking:**
+
+| Outcome | Append to `addressed_thread_ids`? |
+|---------|-----------------------------------|
+| ACCEPT — fix committed | Yes (if `thread_node_id` is not `None`) |
+| REJECT — no code change | Yes (if `thread_node_id` is not `None`) |
+| DISCUSS — awaiting human decision | No — thread remains open |
+| Skipped finding (stale, missing file, unclear) | No |
+| File-level comment (`line` is null) | No |
 
 ### Step 5: Run Tests
 
@@ -357,9 +353,8 @@ Track:
 - `resolved_count: int` — successfully resolved threads
 - `resolve_failed_count: int` — threads that could not be resolved (permissions, network)
 
-This step is a best-effort operation. Failure to resolve any thread must never cause the
-overall skill to exit non-zero. Thread resolution failure does not affect the exit code of
-the overall skill.
+This step is best-effort — failure to resolve any thread never affects the exit code.
+The same applies to Step 6.5 (inline replies).
 
 ### Step 6.5: Post Inline Replies
 
@@ -396,8 +391,6 @@ suitable for future automated mining.
 Track:
 - `reply_posted_count: int` — successfully posted replies
 - `reply_failed_count: int` — replies that failed (log warning, continue)
-
-This step is best-effort: failure to post any reply must not affect the exit code.
 
 ### Step 6.6: Persist Reject Patterns
 
@@ -495,7 +488,5 @@ fixes_applied = {N}
 Where `{N}` is the count of ACCEPT findings where code changes were committed.
 `verdict = real_fix` means fixes were applied; `verdict = already_green` means
 all review findings were already addressed and no code changes were needed.
-
-When no PR is found (graceful degradation), no structured tokens are emitted.
 
 Summary written to: `{{AUTOSKILLIT_TEMP}}/resolve-review/report_{pr_number}_{ts}.md` (relative to the current working directory)

--- a/tests/skills/test_resolve_review_severity_and_reject_resolution.py
+++ b/tests/skills/test_resolve_review_severity_and_reject_resolution.py
@@ -51,7 +51,7 @@ def test_intent_validation_restricted_to_critical_and_warning() -> None:
 
 
 def test_info_findings_do_not_enter_step_35() -> None:
-    """Step 3.5 intro must say 'validate every critical and warning finding', not 'every finding'."""
+    """Step 3.5 intro must say 'validate every critical and warning finding'."""
     step35_idx = SKILL_TEXT.find("### Step 3.5")
     assert step35_idx != -1, "SKILL.md must have a Step 3.5 section"
     step4_idx = SKILL_TEXT.find("### Step 4")

--- a/tests/skills/test_resolve_review_token_optimizations.py
+++ b/tests/skills/test_resolve_review_token_optimizations.py
@@ -36,11 +36,12 @@ def test_addressed_thread_ids_consolidated_decision_table() -> None:
 def test_addressed_thread_ids_not_repeated_in_accept_flow() -> None:
     """After ACCEPT fix commit, inline 'append addressed_thread_ids' must be removed."""
     step4_idx = SKILL_TEXT.find("### Step 4")
+    assert step4_idx != -1, "### Step 4 must exist in SKILL.md"
     step5_idx = SKILL_TEXT.find("### Step 5", step4_idx)
     step4_text = SKILL_TEXT[step4_idx:step5_idx]
-    # Count occurrences of the old inline rule inside Step 4's commit block
+    # Verify absence of the old inline rule inside Step 4's commit block
     accept_block_end = step4_text.find("**Classification gate")
-    accept_block = step4_text[:accept_block_end] if accept_block_end != -1 else step4_text[:800]
+    accept_block = step4_text[:accept_block_end] if accept_block_end != -1 else step4_text
     assert "Append the finding's `thread_node_id` to `addressed_thread_ids`" not in accept_block, (
         "The inline 'append thread_node_id' after ACCEPT commit must be removed; "
         "use the consolidated decision table instead"
@@ -51,7 +52,10 @@ def test_addressed_thread_ids_not_in_skip_flow() -> None:
     """The 'skip a finding' flow must not repeat addressed_thread_ids guidance."""
     skip_idx = SKILL_TEXT.lower().find("skip a finding flow")
     assert skip_idx != -1, "SKILL.md must have a 'skip a finding flow' section"
-    skip_section = SKILL_TEXT[skip_idx : skip_idx + 400]
+    next_section_idx = SKILL_TEXT.find("\n###", skip_idx + 1)
+    skip_section = (
+        SKILL_TEXT[skip_idx:next_section_idx] if next_section_idx != -1 else SKILL_TEXT[skip_idx:]
+    )
     assert "`addressed_thread_ids`" not in skip_section, (
         "The 'skip a finding flow' section must not repeat thread_node_id guidance; "
         "all cases are covered by the consolidated decision table"
@@ -182,7 +186,7 @@ def test_inline_classification_shortcut_documented() -> None:
     assert (
         "3 or fewer" in step35_section.lower()
         or "≤3" in step35_section
-        or "inline" in step35_section.lower()
+        or "inline classification" in step35_section.lower()
     ), "Step 3.5 must document an inline classification shortcut for PRs with 3 or fewer findings"
 
 
@@ -192,7 +196,9 @@ def test_inline_shortcut_requires_single_domain_group() -> None:
     assert step35_idx != -1
     step4_idx = SKILL_TEXT.find("### Step 4", step35_idx)
     step35_section = SKILL_TEXT[step35_idx:step4_idx]
-    inline_idx = step35_section.lower().find("inline")
+    inline_idx = step35_section.lower().find("inline classification")
+    if inline_idx == -1:
+        inline_idx = step35_section.lower().find("inline")
     assert inline_idx != -1, "Step 3.5 must mention 'inline' classification"
     inline_context = step35_section[max(0, inline_idx - 200) : inline_idx + 400].lower()
     assert (
@@ -200,3 +206,7 @@ def test_inline_shortcut_requires_single_domain_group() -> None:
         or "one domain" in inline_context
         or ("single" in inline_context and "group" in inline_context)
     ), "The inline classification shortcut must require a single domain group condition"
+    assert "3 or fewer" in inline_context or "≤3" in inline_context, (
+        "The inline classification shortcut must co-locate the ≤3 findings count condition "
+        "with the domain condition"
+    )

--- a/tests/skills/test_resolve_review_token_optimizations.py
+++ b/tests/skills/test_resolve_review_token_optimizations.py
@@ -1,0 +1,196 @@
+"""Structural guards for resolve-review SKILL.md token-optimization edits.
+
+Enforces that redundant addressed_thread_ids rules are collapsed to a single decision
+table, best-effort language is unified across Steps 6 and 6.5, the Output section is
+pruned of redundant graceful-degradation detail, the Step 3.5 JSON example is removed,
+per-finding file/git-log reads are deduplicated, and the inline classification shortcut
+for simple PRs is documented.
+"""
+
+from pathlib import Path
+
+SKILL_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src"
+    / "autoskillit"
+    / "skills_extended"
+    / "resolve-review"
+    / "SKILL.md"
+)
+assert SKILL_PATH.exists(), f"SKILL.md not found at {SKILL_PATH}"
+SKILL_TEXT = SKILL_PATH.read_text()
+
+
+# ── 1. addressed_thread_ids decision table ────────────────────────────────────
+
+def test_addressed_thread_ids_consolidated_decision_table() -> None:
+    """All thread_node_id tracking rules must live in a single decision table."""
+    # The plan collapses 5 scattered rules into one table.
+    # Require the table header row that summarises all four cases.
+    assert "Append to `addressed_thread_ids`" in SKILL_TEXT, (
+        "SKILL.md must contain a consolidated decision table for thread_node_id tracking"
+    )
+
+
+def test_addressed_thread_ids_not_repeated_in_accept_flow() -> None:
+    """After ACCEPT fix commit, inline 'append addressed_thread_ids' must be removed."""
+    step4_idx = SKILL_TEXT.find("### Step 4")
+    step5_idx = SKILL_TEXT.find("### Step 5", step4_idx)
+    step4_text = SKILL_TEXT[step4_idx:step5_idx]
+    # Count occurrences of the old inline rule inside Step 4's commit block
+    accept_block_end = step4_text.find("**Classification gate")
+    accept_block = step4_text[:accept_block_end] if accept_block_end != -1 else step4_text[:800]
+    assert "Append the finding's `thread_node_id` to `addressed_thread_ids`" not in accept_block, (
+        "The inline 'append thread_node_id' after ACCEPT commit must be removed; "
+        "use the consolidated decision table instead"
+    )
+
+
+def test_addressed_thread_ids_not_in_skip_flow() -> None:
+    """The 'skip a finding' flow must not repeat addressed_thread_ids guidance."""
+    skip_idx = SKILL_TEXT.lower().find("skip a finding flow")
+    assert skip_idx != -1, "SKILL.md must have a 'skip a finding flow' section"
+    skip_section = SKILL_TEXT[skip_idx : skip_idx + 400]
+    assert "`addressed_thread_ids`" not in skip_section, (
+        "The 'skip a finding flow' section must not repeat thread_node_id guidance; "
+        "all cases are covered by the consolidated decision table"
+    )
+
+
+def test_addressed_thread_ids_not_in_file_level_guard() -> None:
+    """File-level comment guard must not repeat addressed_thread_ids guidance."""
+    guard_idx = SKILL_TEXT.find("File-level comment guard")
+    assert guard_idx != -1, "SKILL.md must have a file-level comment guard"
+    guard_section = SKILL_TEXT[guard_idx : guard_idx + 300]
+    assert "`addressed_thread_ids`" not in guard_section, (
+        "File-level comment guard must not repeat thread_node_id guidance; "
+        "the consolidated decision table covers this case"
+    )
+
+
+# ── 2. Best-effort language unified ──────────────────────────────────────────
+
+def test_best_effort_unified_across_steps_6_and_65() -> None:
+    """Step 6 best-effort statement must cover both Steps 6 and 6.5."""
+    step6_idx = SKILL_TEXT.find("### Step 6:")
+    if step6_idx == -1:
+        step6_idx = SKILL_TEXT.find("### Step 6\n")
+    step65_idx = SKILL_TEXT.find("### Step 6.5", step6_idx)
+    step6_section = SKILL_TEXT[step6_idx:step65_idx]
+    assert "6.5" in step6_section, (
+        "Step 6's best-effort statement must reference Step 6.5 so it covers both steps"
+    )
+
+
+def test_step65_no_standalone_best_effort_statement() -> None:
+    """Step 6.5 must not repeat a standalone 'best-effort' / exit-code statement."""
+    step65_idx = SKILL_TEXT.find("### Step 6.5")
+    assert step65_idx != -1, "SKILL.md must have a Step 6.5 section"
+    step66_idx = SKILL_TEXT.find("### Step 6.6", step65_idx)
+    step65_section = (
+        SKILL_TEXT[step65_idx:step66_idx]
+        if step66_idx != -1
+        else SKILL_TEXT[step65_idx : step65_idx + 1200]
+    )
+    assert "best-effort: failure to post any reply must not affect the exit code" not in step65_section, (
+        "Step 6.5 must not contain a standalone best-effort/exit-code statement; "
+        "that is now unified in Step 6"
+    )
+
+
+# ── 3. Output section pruned ─────────────────────────────────────────────────
+
+def test_output_section_no_graceful_degradation_detail() -> None:
+    """The ## Output section must not repeat 'graceful degradation' detail."""
+    output_idx = SKILL_TEXT.rfind("## Output")
+    assert output_idx != -1, "SKILL.md must have an ## Output section"
+    output_section = SKILL_TEXT[output_idx:]
+    assert "graceful degradation" not in output_section.lower(), (
+        "## Output section must not repeat graceful-degradation language; "
+        "Step 1 and Step 7 already state this"
+    )
+
+
+# ── 4. Step 3.5 JSON example removed ─────────────────────────────────────────
+
+def test_step35_json_example_removed() -> None:
+    """The illustrative JSON example block (comment_id: 123) must be removed from Step 3.5."""
+    assert '"comment_id": 123' not in SKILL_TEXT, (
+        "The Step 3.5 JSON example block must be removed; "
+        "the schema is fully described by the preceding field list"
+    )
+
+
+# ── 5. Per-unique-file read in sub-agent instructions ────────────────────────
+
+def test_per_unique_file_read_instruction() -> None:
+    """Sub-agent instructions must say to read each unique file once, not once per finding."""
+    step35_idx = SKILL_TEXT.find("### Step 3.5")
+    assert step35_idx != -1, "SKILL.md must have a Step 3.5 section"
+    step4_idx = SKILL_TEXT.find("### Step 4", step35_idx)
+    step35_section = SKILL_TEXT[step35_idx:step4_idx]
+    assert "unique file" in step35_section.lower(), (
+        "Step 3.5 sub-agent instructions must say 'unique file' (read once per file, "
+        "not once per finding)"
+    )
+
+
+def test_per_finding_read_instruction_removed() -> None:
+    """The old 'read the actual code at each flagged line' per-finding phrasing must be gone."""
+    step35_idx = SKILL_TEXT.find("### Step 3.5")
+    assert step35_idx != -1
+    step4_idx = SKILL_TEXT.find("### Step 4", step35_idx)
+    step35_section = SKILL_TEXT[step35_idx:step4_idx]
+    assert "read the actual code at the flagged line" not in step35_section.lower(), (
+        "The old per-finding file-read instruction must be replaced with the per-unique-file "
+        "read instruction"
+    )
+
+
+# ── 6. Per-unique-path git log ────────────────────────────────────────────────
+
+def test_per_unique_path_git_log() -> None:
+    """Git log instruction must say 'once per unique path, not once per finding'."""
+    step35_idx = SKILL_TEXT.find("### Step 3.5")
+    assert step35_idx != -1
+    step4_idx = SKILL_TEXT.find("### Step 4", step35_idx)
+    step35_section = SKILL_TEXT[step35_idx:step4_idx]
+    assert (
+        "once per unique path" in step35_section.lower()
+        or "per unique path" in step35_section.lower()
+    ), (
+        "Step 3.5 git log instruction must say 'once per unique path' (not once per finding)"
+    )
+
+
+# ── 7. Inline classification shortcut for simple PRs ─────────────────────────
+
+def test_inline_classification_shortcut_documented() -> None:
+    """Step 3.5 must document an inline classification path for ≤3 findings."""
+    step35_idx = SKILL_TEXT.find("### Step 3.5")
+    assert step35_idx != -1
+    step4_idx = SKILL_TEXT.find("### Step 4", step35_idx)
+    step35_section = SKILL_TEXT[step35_idx:step4_idx]
+    assert (
+        "3 or fewer" in step35_section.lower()
+        or "≤3" in step35_section
+        or "inline" in step35_section.lower()
+    ), (
+        "Step 3.5 must document an inline classification shortcut for PRs with 3 or fewer findings"
+    )
+
+
+def test_inline_shortcut_requires_single_domain_group() -> None:
+    """The inline shortcut condition must require both ≤3 findings AND a single domain group."""
+    step35_idx = SKILL_TEXT.find("### Step 3.5")
+    assert step35_idx != -1
+    step4_idx = SKILL_TEXT.find("### Step 4", step35_idx)
+    step35_section = SKILL_TEXT[step35_idx:step4_idx]
+    inline_idx = step35_section.lower().find("inline")
+    assert inline_idx != -1, "Step 3.5 must mention 'inline' classification"
+    inline_context = step35_section[max(0, inline_idx - 200) : inline_idx + 400].lower()
+    assert "single domain" in inline_context or "one domain" in inline_context or (
+        "single" in inline_context and "group" in inline_context
+    ), (
+        "The inline classification shortcut must require a single domain group condition"
+    )

--- a/tests/skills/test_resolve_review_token_optimizations.py
+++ b/tests/skills/test_resolve_review_token_optimizations.py
@@ -23,6 +23,7 @@ SKILL_TEXT = SKILL_PATH.read_text()
 
 # ── 1. addressed_thread_ids decision table ────────────────────────────────────
 
+
 def test_addressed_thread_ids_consolidated_decision_table() -> None:
     """All thread_node_id tracking rules must live in a single decision table."""
     # The plan collapses 5 scattered rules into one table.
@@ -70,6 +71,7 @@ def test_addressed_thread_ids_not_in_file_level_guard() -> None:
 
 # ── 2. Best-effort language unified ──────────────────────────────────────────
 
+
 def test_best_effort_unified_across_steps_6_and_65() -> None:
     """Step 6 best-effort statement must cover both Steps 6 and 6.5."""
     step6_idx = SKILL_TEXT.find("### Step 6:")
@@ -92,13 +94,17 @@ def test_step65_no_standalone_best_effort_statement() -> None:
         if step66_idx != -1
         else SKILL_TEXT[step65_idx : step65_idx + 1200]
     )
-    assert "best-effort: failure to post any reply must not affect the exit code" not in step65_section, (
+    assert (
+        "best-effort: failure to post any reply must not affect the exit code"
+        not in step65_section
+    ), (
         "Step 6.5 must not contain a standalone best-effort/exit-code statement; "
         "that is now unified in Step 6"
     )
 
 
 # ── 3. Output section pruned ─────────────────────────────────────────────────
+
 
 def test_output_section_no_graceful_degradation_detail() -> None:
     """The ## Output section must not repeat 'graceful degradation' detail."""
@@ -113,6 +119,7 @@ def test_output_section_no_graceful_degradation_detail() -> None:
 
 # ── 4. Step 3.5 JSON example removed ─────────────────────────────────────────
 
+
 def test_step35_json_example_removed() -> None:
     """The illustrative JSON example block (comment_id: 123) must be removed from Step 3.5."""
     assert '"comment_id": 123' not in SKILL_TEXT, (
@@ -122,6 +129,7 @@ def test_step35_json_example_removed() -> None:
 
 
 # ── 5. Per-unique-file read in sub-agent instructions ────────────────────────
+
 
 def test_per_unique_file_read_instruction() -> None:
     """Sub-agent instructions must say to read each unique file once, not once per finding."""
@@ -149,6 +157,7 @@ def test_per_finding_read_instruction_removed() -> None:
 
 # ── 6. Per-unique-path git log ────────────────────────────────────────────────
 
+
 def test_per_unique_path_git_log() -> None:
     """Git log instruction must say 'once per unique path, not once per finding'."""
     step35_idx = SKILL_TEXT.find("### Step 3.5")
@@ -158,12 +167,11 @@ def test_per_unique_path_git_log() -> None:
     assert (
         "once per unique path" in step35_section.lower()
         or "per unique path" in step35_section.lower()
-    ), (
-        "Step 3.5 git log instruction must say 'once per unique path' (not once per finding)"
-    )
+    ), "Step 3.5 git log instruction must say 'once per unique path' (not once per finding)"
 
 
 # ── 7. Inline classification shortcut for simple PRs ─────────────────────────
+
 
 def test_inline_classification_shortcut_documented() -> None:
     """Step 3.5 must document an inline classification path for ≤3 findings."""
@@ -175,9 +183,7 @@ def test_inline_classification_shortcut_documented() -> None:
         "3 or fewer" in step35_section.lower()
         or "≤3" in step35_section
         or "inline" in step35_section.lower()
-    ), (
-        "Step 3.5 must document an inline classification shortcut for PRs with 3 or fewer findings"
-    )
+    ), "Step 3.5 must document an inline classification shortcut for PRs with 3 or fewer findings"
 
 
 def test_inline_shortcut_requires_single_domain_group() -> None:
@@ -189,8 +195,8 @@ def test_inline_shortcut_requires_single_domain_group() -> None:
     inline_idx = step35_section.lower().find("inline")
     assert inline_idx != -1, "Step 3.5 must mention 'inline' classification"
     inline_context = step35_section[max(0, inline_idx - 200) : inline_idx + 400].lower()
-    assert "single domain" in inline_context or "one domain" in inline_context or (
-        "single" in inline_context and "group" in inline_context
-    ), (
-        "The inline classification shortcut must require a single domain group condition"
-    )
+    assert (
+        "single domain" in inline_context
+        or "one domain" in inline_context
+        or ("single" in inline_context and "group" in inline_context)
+    ), "The inline classification shortcut must require a single domain group condition"


### PR DESCRIPTION
## Summary

Apply nine targeted SKILL.md-only edits to `src/autoskillit/skills_extended/resolve-review/SKILL.md`
that eliminate ~150–200 words of pure redundancy and reduce sub-agent token waste. Every change is
zero-quality-loss — the same rules and logic apply; duplicate statements, scattered decision rules,
and unnecessary example blocks are removed. A new inline classification shortcut eliminates Task
sub-agent overhead for simple PRs (≤3 findings, single domain group).

**No Python code changes.** All changes are confined to the SKILL.md file and a new test file
`tests/skills/test_resolve_review_token_optimizations.py`.

Closes #1568

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260430-212458-759191/.autoskillit/temp/make-plan/resolve_review_token_optimizations_plan_2026-04-30_212805.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 169 | 18.8k | 933.5k | 68.5k | 1 | 6m 24s |
| verify | 39 | 8.0k | 1.0M | 59.4k | 1 | 3m 47s |
| implement | 204 | 12.9k | 1.2M | 46.7k | 1 | 4m 19s |
| prepare_pr | 68 | 3.7k | 258.3k | 29.0k | 1 | 1m 15s |
| compose_pr | 59 | 2.0k | 192.5k | 19.1k | 1 | 51s |
| review_pr | 268 | 69.4k | 1.7M | 141.1k | 2 | 17m 57s |
| resolve_review | 269 | 20.5k | 1.9M | 73.0k | 1 | 14m 15s |
| **Total** | 1.1k | 135.2k | 7.3M | 436.9k | | 48m 50s |