### PR TITLE
Formalize Orchestration Hierarchy (L0-L3) with Reference Document

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -408,6 +408,11 @@ generic_automation_mcp/
 
 **CRITICAL**: When using subagents, invoke with `CLAUDE_CODE_EXIT_AFTER_STOP_DELAY=120000` to ensure subagents exit when finished.
 
+**Import layer vs. orchestration level:** Module docstrings and import-linter
+contracts use IL-N labels (IL-001–IL-009 in `pyproject.toml`) for the import
+dependency hierarchy — these are separate from the L0–L3 orchestration levels
+defined in `docs/orchestration-levels.md`.
+
 ## 7. Session Diagnostics
 
 **Path components use hyphens, not underscores.** Log directory names and session folder names are hyphen-separated. Never assume underscores when constructing or searching for log paths — hyphen mismatch causes ENOENT (session f9170655 pattern).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # AutoSkillit documentation
 
 AutoSkillit is a Claude Code plugin that runs YAML recipes through a
-two-tier orchestrator. The bundled recipes implement issue → plan → worktree
+multi-level orchestrator. The bundled recipes implement issue → plan → worktree
 → tests → PR → merge pipelines using 49 MCP tools and 127 bundled skills.
 
 ## Start here
@@ -16,6 +16,7 @@ two-tier orchestrator. The bundled recipes implement issue → plan → worktree
 - [update-checks.md](update-checks.md) — update checks, dismissal windows, `autoskillit update`
 - [faq.md](faq.md) — common questions
 - [glossary.md](glossary.md) — canonical terms
+- [orchestration-levels.md](orchestration-levels.md) — L0–L3 orchestration hierarchy
 
 ## Topic-based subdirectories
 

--- a/docs/execution/README.md
+++ b/docs/execution/README.md
@@ -5,4 +5,5 @@ merge gates.
 
 - [architecture.md](architecture.md) — orchestrator, kitchen, sous-chef
 - [tool-access.md](tool-access.md) — kitchen vs free range, the 42 MCP tools
-- [orchestration.md](orchestration.md) — tier model, retry reasons, merge decision tree
+- [orchestration.md](orchestration.md) — orchestration levels, retry reasons, merge decision tree
+- [orchestration-levels.md](../orchestration-levels.md) — L0–L3 level definitions, mapping table

--- a/docs/execution/orchestration.md
+++ b/docs/execution/orchestration.md
@@ -9,7 +9,8 @@ the merge pipeline decides whether a worktree is ready to land.
 
 ## Multi-level orchestration model
 
-AutoSkillit splits agent execution into two layers:
+AutoSkillit defines four orchestration levels (L0–L3). The recipe execution
+pipeline directly connects the two levels involved in running a recipe:
 
 - **L2 — orchestrator.** A Claude Code session running the
   `autoskillit order` CLI command, with the kitchen pre-opened. Sees all 42

--- a/docs/execution/orchestration.md
+++ b/docs/execution/orchestration.md
@@ -1,18 +1,21 @@
 # Orchestration
 
-How AutoSkillit routes work between the Tier 1 orchestrator and the Tier 2/3
+> **See also:** [`docs/orchestration-levels.md`](../orchestration-levels.md) for
+> the formal definition of the L0–L3 orchestration hierarchy.
+
+How AutoSkillit routes work between the **L2** orchestrator and the **L1**
 worker sessions, what the orchestrator does on every retry verdict, and how
 the merge pipeline decides whether a worktree is ready to land.
 
-## Two-tier model
+## Multi-level orchestration model
 
 AutoSkillit splits agent execution into two layers:
 
-- **Tier 1 — orchestrator.** A Claude Code session running the
+- **L2 — orchestrator.** A Claude Code session running the
   `autoskillit order` CLI command, with the kitchen pre-opened. Sees all 42
   MCP tools, spawns headless workers, and routes verdicts. Never reads or
   writes code itself.
-- **Tier 2/3 — worker.** A headless Claude session launched by `run_skill`.
+- **L1 — worker.** A headless Claude session launched by `run_skill`.
   Sees the 2 free range tools plus `test_check` (the only `headless`-tagged
   tool). Cannot call `run_skill`, `run_cmd`, or `run_python`.
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -54,12 +54,25 @@ A composition pattern (see `recipe/registry.py`) where one recipe references
 sub-recipes via `requires_packs` instead of inlining their steps. Distinct from
 sub-recipes themselves.
 
+### food truck
+
+A headless L2 session dispatched by an L3 fleet orchestrator. Self-contained:
+clones the target repository, runs a full recipe, and returns results via the
+campaign sidecar. Named by analogy — the fleet (L3) dispatches food trucks (L2)
+to remote jobs.
+
 ### free range tools
 
 The 4 MCP tools that are always visible regardless of kitchen state:
 `open_kitchen`, `close_kitchen`, `disable_quota_guard`, and `reload_session`. Tagged
 only with `autoskillit`, never with `kitchen`. Always two words, no hyphen. Common
 mistake: `free-range tools`.
+
+### Ghost Kitchen
+
+The remote compute adapter system for dispatching food trucks to cloud
+infrastructure. An L3 fleet sends work to a Ghost Kitchen when the L2 workers
+need to run outside the local machine.
 
 ### kitchen
 
@@ -76,6 +89,30 @@ Synonym for the 44 kitchen-tagged MCP tools. Two words, no hyphen.
 The unique identifier assigned to a kitchen instance (typically a session
 UUID). Recorded in pipeline telemetry.
 
+### L0
+
+Leaf subagent. Terminal node in the orchestration hierarchy. Cannot launch
+sub-agents or headless sessions. Spawned by an L1 via Claude Code's Agent/Task
+tool. See `docs/orchestration-levels.md`.
+
+### L1
+
+A Claude Code session (interactive or headless) that can launch L0 subagents.
+When headless, spawned by an L2 via `run_skill`. Interactive variant:
+`autoskillit cook`. See `docs/orchestration-levels.md`.
+
+### L2
+
+Orchestrator of sessions. Launches L1 headless sessions via `run_skill`.
+Interactive: `autoskillit order`. Headless: food truck (dispatched by L3).
+See `docs/orchestration-levels.md`.
+
+### L3
+
+Fleet dispatcher. Launches L2 food trucks. Interactive: `autoskillit fleet`.
+No headless variant (no L4 exists to dispatch it).
+See `docs/orchestration-levels.md`.
+
 ### order
 
 A single execution of a recipe via `autoskillit order <recipe>`. The
@@ -88,7 +125,7 @@ and used to correlate logs.
 
 ### orchestrator
 
-The Tier 1 Claude Code session that runs `autoskillit order`. It reads the
+The L2 Claude Code session that runs `autoskillit order`. It reads the
 recipe, calls MCP tools, and spawns headless worker sessions via `run_skill`.
 Never reads or writes code itself.
 
@@ -145,7 +182,7 @@ that runs many sibling implementations in parallel waves rather than serially.
 
 ### worker
 
-A headless Claude session spawned by the orchestrator via `run_skill`. Tier 2
+A headless Claude session spawned by the orchestrator via `run_skill`. L1
 boundary — workers cannot call `run_skill`, `run_cmd`, or `run_python`.
 
 ### worktree

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -92,8 +92,9 @@ UUID). Recorded in pipeline telemetry.
 ### L0
 
 Leaf subagent. Terminal node in the orchestration hierarchy. Cannot launch
-sub-agents or headless sessions. Spawned by an L1 via Claude Code's Agent/Task
-tool. See `docs/orchestration-levels.md`.
+sub-agents or headless sessions. Cannot call `run_skill`, `run_cmd`, or
+`run_python` (enforced by `leaf_orchestration_guard.py`). Spawned by an L1
+via Claude Code's Agent/Task tool. See `docs/orchestration-levels.md`.
 
 ### L1
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -99,7 +99,8 @@ via Claude Code's Agent/Task tool. See `docs/orchestration-levels.md`.
 ### L1
 
 A Claude Code session (interactive or headless) that can launch L0 subagents.
-When headless, spawned by an L2 via `run_skill`. Interactive variant:
+When headless, spawned by an L2 via `run_skill`. Headless L1 workers cannot
+call `run_skill`, `run_cmd`, or `run_python`. Interactive variant:
 `autoskillit cook`. See `docs/orchestration-levels.md`.
 
 ### L2

--- a/docs/orchestration-levels.md
+++ b/docs/orchestration-levels.md
@@ -28,7 +28,8 @@ an L2 orchestrator.
 Key properties:
 
 - Interactive variant: `autoskillit cook`
-- Headless variant: `run_skill` worker (SessionType `LEAF`)
+- Headless variant: `run_skill` worker
+- SessionType: `LEAF` (both interactive and headless)
 - Can spawn L0 subagents via Agent/Task tool
 - Cannot call `run_skill` (enforced by `leaf_orchestration_guard.py` and
   `skill_cmd_guard.py`)
@@ -90,7 +91,7 @@ L3 (interactive fleet)
 | Orchestration Level | SessionType enum | CLI command | Headless variant |
 |---|---|---|---|
 | L0 (leaf) | n/a — Claude Agent | n/a | Always headless |
-| L1 (session) | `LEAF` (when headless) | `autoskillit cook` | `run_skill` worker |
+| L1 (session) | `LEAF` | `autoskillit cook` | `run_skill` worker |
 | L2 (orchestrator) | `ORCHESTRATOR` | `autoskillit order` | Food truck |
 | L3 (fleet) | `FLEET` | `autoskillit fleet` | None — no L4 exists |
 
@@ -100,8 +101,10 @@ L3 (interactive fleet)
   FastMCP visibility tags, the `leaf_orchestration_guard.py` PreToolUse hook,
   and the `_require_orchestrator_or_higher()` runtime guard in
   `tools_execution.py`. All three must independently agree.
-- **L0 agents cannot launch anything.** They are terminal nodes — no
-  `run_skill`, no Agent tool, no sub-sessions.
+- **L0 agents cannot launch anything.** They are terminal nodes — they cannot
+  call `run_skill`, cannot invoke the Agent tool to spawn sub-agents, and
+  cannot open sub-sessions. (L0 agents are themselves spawned via Agent/Task
+  by an L1 — the constraint is on outbound calls only.)
 - **L3 has no headless variant.** There is no L4 to dispatch an L3. Fleet
   always runs interactively.
 - **Spawning is strictly downward.** An L2 dispatches L1, an L1 spawns L0.

--- a/docs/orchestration-levels.md
+++ b/docs/orchestration-levels.md
@@ -1,0 +1,117 @@
+# Orchestration Levels
+
+AutoSkillit uses four orchestration levels (L0–L3) that describe *who can spawn
+whom* at runtime. These are entirely separate from the import-layer IL-N labels
+used in module docstrings and `pyproject.toml` import-linter contracts.
+
+## Level Definitions
+
+### L0 — Leaf Subagent
+
+A terminal node in the execution graph. L0 agents are always headless, spawned
+by an L1 session via Claude Code's Agent or Task tool. They cannot launch
+sub-agents or headless sessions of their own.
+
+Key properties:
+
+- Always headless (never interactive)
+- Spawned via the Agent/Task tool, not `run_skill`
+- Cannot call `run_skill`, `run_cmd`, or `run_python`
+- Session type: n/a (Claude Agent, not a full session)
+
+### L1 — Session
+
+A Claude Code session (interactive or headless) that can spawn L0 leaf
+subagents. When running headless, an L1 is a `run_skill` worker dispatched by
+an L2 orchestrator.
+
+Key properties:
+
+- Interactive variant: `autoskillit cook`
+- Headless variant: `run_skill` worker (SessionType `LEAF`)
+- Can spawn L0 subagents via Agent/Task tool
+- Cannot call `run_skill` (enforced by `leaf_orchestration_guard.py` and
+  `skill_cmd_guard.py`)
+
+```
+L1 (interactive cook)
+└── L0 subagent  (Agent/Task tool)
+    └── [terminal — spawns nothing]
+
+L1 (headless run_skill worker)
+└── L0 subagent  (Agent/Task tool)
+    └── [terminal — spawns nothing]
+```
+
+### L2 — Orchestrator
+
+Orchestrates L1 headless sessions by dispatching them via `run_skill`. The L2
+reads the recipe, calls MCP tools, and routes verdicts. It never reads or writes
+code itself.
+
+Key properties:
+
+- Interactive variant: `autoskillit order` (SessionType `ORCHESTRATOR`)
+- Headless variant: food truck (dispatched by L3, SessionType `ORCHESTRATOR`)
+- Spawns L1 workers via `run_skill`
+- Has full kitchen access (44 kitchen-tagged MCP tools)
+
+```
+L2 (interactive order)
+└── L1 worker  (run_skill)
+    └── L0 subagent  (Agent/Task tool)
+
+L2 (headless food truck, dispatched by L3)
+└── L1 worker  (run_skill)
+    └── L0 subagent  (Agent/Task tool)
+```
+
+### L3 — Fleet Dispatcher
+
+Manages a fleet of L2 food trucks, dispatching them to process batches of
+issues or repositories. There is no L4, so L3 has no headless variant.
+
+Key properties:
+
+- Interactive only: `autoskillit fleet` (SessionType `FLEET`)
+- No headless variant (nothing above L3 to dispatch it)
+- Dispatches L2 food trucks via `run_skill`
+- Manages campaign state via the sidecar JSONL file
+
+```
+L3 (interactive fleet)
+└── L2 food truck  (run_skill → headless L2)
+    └── L1 worker  (run_skill)
+        └── L0 subagent  (Agent/Task tool)
+```
+
+## Mapping Table
+
+| Orchestration Level | SessionType enum | CLI command | Headless variant |
+|---|---|---|---|
+| L0 (leaf) | n/a — Claude Agent | n/a | Always headless |
+| L1 (session) | `LEAF` (when headless) | `autoskillit cook` | `run_skill` worker |
+| L2 (orchestrator) | `ORCHESTRATOR` | `autoskillit order` | Food truck |
+| L3 (fleet) | `FLEET` | `autoskillit fleet` | None — no L4 exists |
+
+## Key Rules
+
+- **L1 workers cannot call `run_skill`.** The boundary is enforced three ways:
+  FastMCP visibility tags, the `leaf_orchestration_guard.py` PreToolUse hook,
+  and the `_require_orchestrator_or_higher()` runtime guard in
+  `tools_execution.py`. All three must independently agree.
+- **L0 agents cannot launch anything.** They are terminal nodes — no
+  `run_skill`, no Agent tool, no sub-sessions.
+- **L3 has no headless variant.** There is no L4 to dispatch an L3. Fleet
+  always runs interactively.
+- **Spawning is strictly downward.** An L2 dispatches L1, an L1 spawns L0.
+  No level can spawn a peer or a higher level.
+- **food trucks are L2, not L1.** A food truck is a headless L2 session
+  dispatched by an L3 fleet. It retains full orchestrator capabilities
+  (it can call `run_skill` to spawn L1 workers).
+
+## Disambiguation
+
+> Module docstrings and import-linter comments use IL-N (IL-0 through IL-3) for
+> the import dependency hierarchy — these are NOT orchestration levels. See the
+> import-linter contracts IL-001 through IL-009 in `pyproject.toml`.

--- a/tests/docs/test_orchestration_levels.py
+++ b/tests/docs/test_orchestration_levels.py
@@ -35,7 +35,7 @@ def test_glossary_has_orchestration_level_entries():
 
 
 def test_glossary_orchestrator_entry_uses_l2():
-    text = GLOSSARY.read_text()
+    text = GLOSSARY.read_text().replace("\r\n", "\n")
     match = re.search(r"### orchestrator\n(.+?)(?=\n###|\Z)", text, re.DOTALL)
     assert match, "Glossary missing ### orchestrator entry"
     section = match.group(1)
@@ -44,7 +44,7 @@ def test_glossary_orchestrator_entry_uses_l2():
 
 
 def test_glossary_worker_entry_uses_l1():
-    text = GLOSSARY.read_text()
+    text = GLOSSARY.read_text().replace("\r\n", "\n")
     match = re.search(r"### worker\n(.+?)(?=\n###|\Z)", text, re.DOTALL)
     assert match, "Glossary missing ### worker entry"
     section = match.group(1)

--- a/tests/docs/test_orchestration_levels.py
+++ b/tests/docs/test_orchestration_levels.py
@@ -1,0 +1,65 @@
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parents[2]
+ORCH_DOC = REPO_ROOT / "docs" / "orchestration-levels.md"
+GLOSSARY = REPO_ROOT / "docs" / "glossary.md"
+
+
+def test_orchestration_levels_doc_exists():
+    assert ORCH_DOC.exists(), "docs/orchestration-levels.md must be created"
+
+
+def test_orchestration_levels_has_required_sections():
+    text = ORCH_DOC.read_text()
+    for heading in ["## Level Definitions", "## Mapping Table", "## Key Rules",
+                    "## Disambiguation"]:
+        assert heading in text, f"Missing section: {heading}"
+
+
+def test_orchestration_levels_has_ascii_trees():
+    text = ORCH_DOC.read_text()
+    # ASCII trees use box-drawing or plain characters; check L-nodes appear
+    for level in ["L0", "L1", "L2", "L3"]:
+        assert level in text
+
+
+def test_glossary_has_orchestration_level_entries():
+    text = GLOSSARY.read_text()
+    for term in ["### L0", "### L1", "### L2", "### L3",
+                 "### food truck", "### Ghost Kitchen"]:
+        assert term in text, f"Glossary missing entry: {term}"
+
+
+def test_glossary_orchestrator_entry_uses_l2():
+    text = GLOSSARY.read_text()
+    # Find the orchestrator section
+    match = re.search(r"### orchestrator\n(.+?)(?=\n###|\Z)", text, re.DOTALL)
+    assert match, "Glossary missing ### orchestrator entry"
+    section = match.group(1)
+    assert "L2" in section, "'orchestrator' glossary entry must reference L2"
+    assert "Tier 1" not in section, "'orchestrator' entry must not use 'Tier 1' language"
+
+
+def test_glossary_worker_entry_uses_l1():
+    text = GLOSSARY.read_text()
+    match = re.search(r"### worker\n(.+?)(?=\n###|\Z)", text, re.DOTALL)
+    assert match, "Glossary missing ### worker entry"
+    section = match.group(1)
+    assert "L1" in section, "'worker' glossary entry must reference L1"
+    assert "Tier 2" not in section, "'worker' entry must not use 'Tier 2' language"
+
+
+def test_orchestration_doc_cross_references_levels():
+    orch_exec = REPO_ROOT / "docs" / "execution" / "orchestration.md"
+    text = orch_exec.read_text()
+    assert "orchestration-levels.md" in text, \
+        "docs/execution/orchestration.md must cross-reference orchestration-levels.md"
+
+
+def test_claude_md_has_il_disambiguation():
+    claude_md = REPO_ROOT / "CLAUDE.md"
+    text = claude_md.read_text()
+    # The disambiguation must mention import layers and IL-N notation
+    assert "IL-" in text and "import" in text.lower(), \
+        "CLAUDE.md Section 6 must contain IL-N disambiguation sentence"

--- a/tests/docs/test_orchestration_levels.py
+++ b/tests/docs/test_orchestration_levels.py
@@ -12,28 +12,29 @@ def test_orchestration_levels_doc_exists():
 
 def test_orchestration_levels_has_required_sections():
     text = ORCH_DOC.read_text()
-    for heading in ["## Level Definitions", "## Mapping Table", "## Key Rules",
-                    "## Disambiguation"]:
+    for heading in [
+        "## Level Definitions",
+        "## Mapping Table",
+        "## Key Rules",
+        "## Disambiguation",
+    ]:
         assert heading in text, f"Missing section: {heading}"
 
 
-def test_orchestration_levels_has_ascii_trees():
+def test_orchestration_levels_has_l_identifiers():
     text = ORCH_DOC.read_text()
-    # ASCII trees use box-drawing or plain characters; check L-nodes appear
     for level in ["L0", "L1", "L2", "L3"]:
         assert level in text
 
 
 def test_glossary_has_orchestration_level_entries():
     text = GLOSSARY.read_text()
-    for term in ["### L0", "### L1", "### L2", "### L3",
-                 "### food truck", "### Ghost Kitchen"]:
+    for term in ["### L0", "### L1", "### L2", "### L3", "### food truck", "### Ghost Kitchen"]:
         assert term in text, f"Glossary missing entry: {term}"
 
 
 def test_glossary_orchestrator_entry_uses_l2():
     text = GLOSSARY.read_text()
-    # Find the orchestrator section
     match = re.search(r"### orchestrator\n(.+?)(?=\n###|\Z)", text, re.DOTALL)
     assert match, "Glossary missing ### orchestrator entry"
     section = match.group(1)
@@ -52,14 +53,17 @@ def test_glossary_worker_entry_uses_l1():
 
 def test_orchestration_doc_cross_references_levels():
     orch_exec = REPO_ROOT / "docs" / "execution" / "orchestration.md"
+    assert orch_exec.exists(), "docs/execution/orchestration.md must exist"
     text = orch_exec.read_text()
-    assert "orchestration-levels.md" in text, \
+    assert "orchestration-levels.md" in text, (
         "docs/execution/orchestration.md must cross-reference orchestration-levels.md"
+    )
 
 
 def test_claude_md_has_il_disambiguation():
     claude_md = REPO_ROOT / "CLAUDE.md"
     text = claude_md.read_text()
-    # The disambiguation must mention import layers and IL-N notation
-    assert "IL-" in text and "import" in text.lower(), \
-        "CLAUDE.md Section 6 must contain IL-N disambiguation sentence"
+    paragraphs = text.split("\n\n")
+    assert any("IL-" in p and "import" in p.lower() for p in paragraphs), (
+        "CLAUDE.md Section 6 must contain a paragraph with both IL-N notation and 'import'"
+    )

--- a/tests/docs/test_orchestration_levels.py
+++ b/tests/docs/test_orchestration_levels.py
@@ -2,6 +2,7 @@ import re
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).parents[2]
+assert (REPO_ROOT / "pyproject.toml").exists(), "REPO_ROOT detection broken"
 ORCH_DOC = REPO_ROOT / "docs" / "orchestration-levels.md"
 GLOSSARY = REPO_ROOT / "docs" / "glossary.md"
 


### PR DESCRIPTION
## Summary

Create `docs/orchestration-levels.md` as the canonical reference for the
orchestration hierarchy (L0=leaf, L1=session, L2=orchestrator, L3=fleet), update
`docs/glossary.md` with six new entries and two corrected entries, update
`docs/execution/orchestration.md` to use L-number vocabulary, and add a one-sentence
disambiguation to `CLAUDE.md` Section 6.

The core problem is that "L0/L1/L2/L3" labels appear in both the import-layer
architecture and the orchestration hierarchy but mean completely different things —
the docs fix this by naming the orchestration levels definitively and pointing to
the import-linter contracts (IL-001–IL-009) for the import-layer meaning.

Closes #1573

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260430-213648-897264/.autoskillit/temp/make-plan/formalize_orchestration_hierarchy_plan_2026-04-30_214134.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 79 | 12.4k | 329.5k | 42.8k | 1 | 6m 25s |
| verify | 40 | 8.2k | 1.3M | 65.6k | 1 | 5m 58s |
| implement | 252 | 11.9k | 1.4M | 43.0k | 1 | 4m 25s |
| prepare_pr | 52 | 3.7k | 170.2k | 42.6k | 1 | 1m 12s |
| compose_pr | 59 | 2.0k | 181.9k | 32.2k | 1 | 42s |
| review_pr | 266 | 55.1k | 1.5M | 127.3k | 2 | 15m 7s |
| resolve_review | 590 | 43.6k | 4.3M | 154.6k | 2 | 20m 24s |
| **Total** | 1.3k | 137.0k | 9.2M | 508.1k | | 54m 14s |