### PR TITLE
Implementation Plan: Formalize Orchestration Levels in SessionType Enum, Guards, and Retire Legacy Tier Language

### DIFF
--- a/docs/execution/orchestration.md
+++ b/docs/execution/orchestration.md
@@ -10,7 +10,7 @@ the merge pipeline decides whether a worktree is ready to land.
 ## Multi-level orchestration model
 
 AutoSkillit defines four orchestration levels (L0–L3). The recipe execution
-pipeline directly connects the two levels involved in running a recipe:
+pipeline primarily connects the L2 orchestrator and L1 workers:
 
 - **L2 — orchestrator.** A Claude Code session running the
   `autoskillit order` CLI command, with the kitchen pre-opened. Sees all 42

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -163,19 +163,31 @@ The Haiku-assisted contract-card freshness check implemented in
 
 ### Tier 1
 
-The free range tier — 3 skills under `src/autoskillit/skills/`
+The free range **skill access tier** — 3 skills under `src/autoskillit/skills/`
 (`open-kitchen`, `close-kitchen`, `sous-chef`). Capitalised, space between
 `Tier` and the digit. Common mistake: `tier-1`, `tier 1` (lowercase).
+
+> Not to be confused with orchestration levels (L0–L3). Skill access tiers
+> control which skills are visible in which session modes. See
+> `docs/orchestration-levels.md`.
 
 ### Tier 2
 
 Cook + headless skills under `src/autoskillit/skills_extended/`. Same
 capitalisation rules as Tier 1.
 
+> Not to be confused with orchestration levels (L0–L3). Skill access tiers
+> control which skills are visible in which session modes. See
+> `docs/orchestration-levels.md`.
+
 ### Tier 3
 
 Pipeline / automation skills under `src/autoskillit/skills_extended/`. Same
 capitalisation rules as Tier 1.
+
+> Not to be confused with orchestration levels (L0–L3). Skill access tiers
+> control which skills are visible in which session modes. See
+> `docs/orchestration-levels.md`.
 
 ### wavefront scheduling
 

--- a/src/autoskillit/core/_type_enums.py
+++ b/src/autoskillit/core/_type_enums.py
@@ -335,11 +335,21 @@ class PRState(StrEnum):
 
 
 class SessionType(StrEnum):
-    """Tier discriminator for fleet session hierarchy.
+    """Orchestration level discriminator for the session hierarchy.
 
-    FLEET — top-level campaign coordinator
-    ORCHESTRATOR — mid-tier recipe runner (interactive or headless)
-    LEAF — bottom-tier single-task worker (headless test_check only)
+    Each level can only call the level directly below it:
+
+        L3 (FLEET) -> L2 (ORCHESTRATOR) -> L1 (headless worker) -> L0 (subagent)
+
+    FLEET        -- L3: top-level campaign dispatcher.
+                    Launches L2 food trucks via dispatch_food_truck.
+    ORCHESTRATOR -- L2: recipe runner (interactive via order, or headless food truck).
+                    Launches L1 headless workers via run_skill.
+    LEAF         -- L1 headless worker (or L0 subagent -- both are terminal from
+                    AutoSkillit's perspective since neither can call run_skill).
+
+    Note: interactive L1 sessions (autoskillit cook, bare Claude Code) have no
+    SessionType value -- they bypass tier checks because AUTOSKILLIT_HEADLESS is unset.
     """
 
     FLEET = "fleet"

--- a/src/autoskillit/core/_type_enums.py
+++ b/src/autoskillit/core/_type_enums.py
@@ -347,6 +347,8 @@ class SessionType(StrEnum):
                     Launches L1 headless workers via run_skill.
     LEAF         -- L1 headless worker (or L0 subagent -- both are terminal from
                     AutoSkillit's perspective since neither can call run_skill).
+                    L0 subagents never set AUTOSKILLIT_SESSION_TYPE so they share
+                    this terminal slot rather than having a distinct enum value.
 
     Note: interactive L1 sessions (autoskillit cook, bare Claude Code) have no
     SessionType value -- they bypass tier checks because AUTOSKILLIT_HEADLESS is unset.

--- a/src/autoskillit/hooks/leaf_orchestration_guard.py
+++ b/src/autoskillit/hooks/leaf_orchestration_guard.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-"""PreToolUse hook — blocks orchestration tools from leaf-tier sessions.
+"""PreToolUse hook — blocks orchestration tools from L1 leaf sessions.
 
 Leaf sessions (AUTOSKILLIT_SESSION_TYPE=leaf or unset in headless mode) must
 never call run_skill, run_cmd, or run_python. This is defense-in-depth over
 the in-handler gate check in each tool.
 
-Tier invariant: orchestrator and fleet tiers may call orchestration tools.
+L2+ invariant: orchestrator (L2) and fleet (L3) sessions may call orchestration tools.
 Leaf workers use native Claude Code tools only.
 """
 

--- a/src/autoskillit/pipeline/gate.py
+++ b/src/autoskillit/pipeline/gate.py
@@ -69,8 +69,9 @@ def gate_error_result(message: str | None = None) -> str:
 
 _DEFAULT_HEADLESS_MESSAGE = (
     "This tool cannot be called from headless sessions. "
-    "Headless workers (Tier 2) may only use native Claude Code tools and "
-    "HEADLESS_TOOLS. Orchestration tools are reserved for Tier 1 sessions."
+    "L1 headless workers may only use native Claude Code tools and "
+    "HEADLESS_TOOLS. Orchestration tools are reserved for L2+ sessions "
+    "(orchestrator or fleet)."
 )
 
 

--- a/src/autoskillit/server/_guards.py
+++ b/src/autoskillit/server/_guards.py
@@ -80,6 +80,7 @@ def _require_fleet(tool_name: str = "") -> str | None:
     """Return headless_error JSON if session is not L3 (fleet); None if permitted.
 
     No interactive bypass — fleet is a specific orchestration level, not a headless guard.
+    L1 (leaf) and L2 (orchestrator) sessions are both denied.
     """
     st = session_type()
     if st is SessionType.FLEET:

--- a/src/autoskillit/server/_guards.py
+++ b/src/autoskillit/server/_guards.py
@@ -1,4 +1,4 @@
-"""Tier/gate guard functions for MCP tool access control."""
+"""Orchestration-level gate functions for MCP tool access control."""
 
 from __future__ import annotations
 
@@ -22,10 +22,10 @@ def _get_config():  # type: ignore[return]
 
 
 def _require_orchestrator_or_higher(tool_name: str = "") -> str | None:
-    """Return headless_error JSON if session is leaf-tier; None if permitted.
+    """Return headless_error JSON if session is L1 (leaf); None if permitted.
 
     Interactive sessions (HEADLESS not set) always pass.
-    Headless sessions must be orchestrator or fleet tier.
+    Headless sessions must be L2 (orchestrator) or L3 (fleet).
     Fail-closed: unset/invalid SESSION_TYPE → LEAF → deny.
     """
     if os.environ.get("AUTOSKILLIT_HEADLESS") != "1":
@@ -45,11 +45,11 @@ def _require_orchestrator_or_higher(tool_name: str = "") -> str | None:
 
 
 def _require_orchestrator_exact(tool_name: str = "") -> str | None:
-    """Return headless_error JSON if session is not orchestrator-tier; None if permitted.
+    """Return headless_error JSON if session is not exactly L2; None if permitted.
 
     Interactive sessions (HEADLESS not set) always pass.
-    Headless sessions must be exactly orchestrator tier.
-    Fleet and leaf tiers are denied.
+    Headless sessions must be exactly L2 (orchestrator).
+    L1 (leaf) and L3 (fleet) are both denied.
     """
     if os.environ.get("AUTOSKILLIT_HEADLESS") != "1":
         return None
@@ -77,9 +77,9 @@ def _require_orchestrator_exact(tool_name: str = "") -> str | None:
 
 
 def _require_fleet(tool_name: str = "") -> str | None:
-    """Return headless_error JSON if session is not fleet-tier; None if permitted.
+    """Return headless_error JSON if session is not L3 (fleet); None if permitted.
 
-    No interactive bypass — fleet is a specific tier, not a headless guard.
+    No interactive bypass — fleet is a specific orchestration level, not a headless guard.
     """
     st = session_type()
     if st is SessionType.FLEET:

--- a/src/autoskillit/workspace/session_skills.py
+++ b/src/autoskillit/workspace/session_skills.py
@@ -320,10 +320,10 @@ class SkillsDirectoryProvider:
         """Return SKILL.md content with gating frontmatter injected when required.
 
         - gated=True  → ensure disable-model-invocation: true is present
-        - gated=False → return unmodified content (cook session or Tier 1)
+        - gated=False → return unmodified content (cook session or Tier 1 skill-access tier)
 
         Substitutes ``{{AUTOSKILLIT_TEMP}}`` with the configured temp dir relpath.
-        Tier 1 skills (which contain no placeholder) are unaffected.
+        Tier 1 skill-access tier skills (which contain no placeholder) are unaffected.
         """
         skill_info = self._resolver.resolve(name)
         if skill_info is None:
@@ -365,7 +365,7 @@ class DefaultSessionSkillManager:
         """Create ephemeral skill dir for session_id.
 
         Returns path to the created skills directory.
-        For non-cook sessions, Tier 2 skills (from config.skills.tier2) get
+        For non-cook sessions, Tier 2 skill-access tier skills (from config.skills.tier2) get
         disable-model-invocation injected. Unknown skill names in config are
         logged as warnings and ignored.
         """

--- a/src/autoskillit/workspace/session_skills.py
+++ b/src/autoskillit/workspace/session_skills.py
@@ -320,10 +320,10 @@ class SkillsDirectoryProvider:
         """Return SKILL.md content with gating frontmatter injected when required.
 
         - gated=True  → ensure disable-model-invocation: true is present
-        - gated=False → return unmodified content (cook session or Tier 1 skill-access tier)
+        - gated=False → return unmodified content (cook session or Tier 1 skills)
 
         Substitutes ``{{AUTOSKILLIT_TEMP}}`` with the configured temp dir relpath.
-        Tier 1 skill-access tier skills (which contain no placeholder) are unaffected.
+        Tier 1 skills (which contain no placeholder) are unaffected.
         """
         skill_info = self._resolver.resolve(name)
         if skill_info is None:
@@ -365,7 +365,7 @@ class DefaultSessionSkillManager:
         """Create ephemeral skill dir for session_id.
 
         Returns path to the created skills directory.
-        For non-cook sessions, Tier 2 skill-access tier skills (from config.skills.tier2) get
+        For non-cook sessions, Tier 2 skills (from config.skills.tier2) get
         disable-model-invocation injected. Unknown skill names in config are
         logged as warnings and ignored.
         """

--- a/tests/core/test_session_type.py
+++ b/tests/core/test_session_type.py
@@ -172,6 +172,9 @@ def test_session_type_docstring_references_orchestration_levels():
     assert "L2" in doc
     assert "L1" in doc
     assert "L0" in doc
+    assert "FLEET" in doc
+    assert "ORCHESTRATOR" in doc
+    assert "LEAF" in doc
     assert "mid-tier" not in doc
     assert "bottom-tier" not in doc
     assert "Tier discriminator" not in doc

--- a/tests/core/test_session_type.py
+++ b/tests/core/test_session_type.py
@@ -161,3 +161,17 @@ def test_session_type_is_defined_in_type_helpers():
 
     assert inspect.getmodule(fn_helpers).__name__ == "autoskillit.core._type_helpers"
     assert inspect.getfile(fn_helpers).endswith("_type_helpers.py")
+
+
+def test_session_type_docstring_references_orchestration_levels():
+    """SessionType docstring must reference L1/L2/L3 level labels."""
+    from autoskillit.core import SessionType
+
+    doc = SessionType.__doc__ or ""
+    assert "L3" in doc
+    assert "L2" in doc
+    assert "L1" in doc
+    assert "L0" in doc
+    assert "mid-tier" not in doc
+    assert "bottom-tier" not in doc
+    assert "Tier discriminator" not in doc

--- a/tests/pipeline/test_gate.py
+++ b/tests/pipeline/test_gate.py
@@ -247,3 +247,12 @@ def test_headless_error_result_accepts_custom_message():
     parsed = json.loads(headless_error_result("Custom headless error"))
     assert parsed["result"] == "Custom headless error"
     assert parsed["subtype"] == "headless_error"
+
+
+def test_headless_message_uses_l_numbers():
+    from autoskillit.pipeline.gate import _DEFAULT_HEADLESS_MESSAGE
+
+    assert "L1" in _DEFAULT_HEADLESS_MESSAGE
+    assert "L2" in _DEFAULT_HEADLESS_MESSAGE
+    assert "Tier 1" not in _DEFAULT_HEADLESS_MESSAGE
+    assert "Tier 2" not in _DEFAULT_HEADLESS_MESSAGE

--- a/tests/server/test_guards_module.py
+++ b/tests/server/test_guards_module.py
@@ -64,3 +64,5 @@ def test_require_fleet_doc_mentions_l3():
 
     doc = _require_fleet.__doc__ or ""
     assert "L3" in doc
+    assert "L1" in doc
+    assert "L2" in doc

--- a/tests/server/test_guards_module.py
+++ b/tests/server/test_guards_module.py
@@ -39,3 +39,26 @@ def test_validate_skill_command_importable():
     from autoskillit.server._guards import _validate_skill_command
 
     assert callable(_validate_skill_command)
+
+
+def test_require_orchestrator_or_higher_doc_mentions_l1():
+    from autoskillit.server._guards import _require_orchestrator_or_higher
+
+    doc = _require_orchestrator_or_higher.__doc__ or ""
+    assert "L1" in doc
+
+
+def test_require_orchestrator_exact_doc_mentions_l2():
+    from autoskillit.server._guards import _require_orchestrator_exact
+
+    doc = _require_orchestrator_exact.__doc__ or ""
+    assert "L2" in doc
+    assert "L1" in doc
+    assert "L3" in doc
+
+
+def test_require_fleet_doc_mentions_l3():
+    from autoskillit.server._guards import _require_fleet
+
+    doc = _require_fleet.__doc__ or ""
+    assert "L3" in doc

--- a/tests/server/test_guards_module.py
+++ b/tests/server/test_guards_module.py
@@ -46,6 +46,8 @@ def test_require_orchestrator_or_higher_doc_mentions_l1():
 
     doc = _require_orchestrator_or_higher.__doc__ or ""
     assert "L1" in doc
+    assert "L2" in doc
+    assert "L3" in doc
 
 
 def test_require_orchestrator_exact_doc_mentions_l2():

--- a/tests/test_no_orchestration_tier_language.py
+++ b/tests/test_no_orchestration_tier_language.py
@@ -8,6 +8,8 @@ import pytest
 
 pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
 
+_REPO_ROOT = pathlib.Path(__file__).parent.parent
+
 _ORCHESTRATION_FILES = [
     "src/autoskillit/core/_type_enums.py",
     "src/autoskillit/pipeline/gate.py",
@@ -32,8 +34,6 @@ _FORBIDDEN = [
 def test_no_legacy_orchestration_tier_language_in_source():
     """Old ad-hoc tier language must be absent from orchestration-critical files."""
     for rel in _ORCHESTRATION_FILES:
-        text = pathlib.Path(rel).read_text()
+        text = (_REPO_ROOT / rel).read_text()
         for phrase in _FORBIDDEN:
-            assert phrase not in text, (
-                f"Legacy tier phrase {phrase!r} found in {rel}"
-            )
+            assert phrase not in text, f"Legacy tier phrase {phrase!r} found in {rel}"

--- a/tests/test_no_orchestration_tier_language.py
+++ b/tests/test_no_orchestration_tier_language.py
@@ -1,0 +1,39 @@
+"""Guard: legacy orchestration-tier language must not appear in critical source files."""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
+
+_ORCHESTRATION_FILES = [
+    "src/autoskillit/core/_type_enums.py",
+    "src/autoskillit/pipeline/gate.py",
+    "src/autoskillit/server/_guards.py",
+    "src/autoskillit/hooks/leaf_orchestration_guard.py",
+]
+
+_FORBIDDEN = [
+    "Tier 1 session",
+    "Tier 2 worker",
+    "mid-tier",
+    "bottom-tier",
+    "Tier discriminator",
+    "Tier 2) may",
+    "leaf-tier",
+    "Tier invariant",
+    "orchestrator-tier",
+    "fleet-tier",
+]
+
+
+def test_no_legacy_orchestration_tier_language_in_source():
+    """Old ad-hoc tier language must be absent from orchestration-critical files."""
+    for rel in _ORCHESTRATION_FILES:
+        text = pathlib.Path(rel).read_text()
+        for phrase in _FORBIDDEN:
+            assert phrase not in text, (
+                f"Legacy tier phrase {phrase!r} found in {rel}"
+            )


### PR DESCRIPTION
## Summary

The `SessionType` enum and surrounding guard code use pre-formal vocabulary ("Tier discriminator",
"mid-tier", "bottom-tier", "Tier 1 sessions", "Tier 2 workers") that conflicts with the
**skill-access tiers** (`SkillsConfig.tier1/tier2/tier3`) — two unrelated concepts sharing
identical labels. `docs/orchestration-levels.md` now defines the canonical L0–L3 hierarchy, so
this refactor aligns docstrings and inline comments across seven files with that vocabulary, and
adds disambiguation notes to the glossary.

No runtime behavior changes. No enum value renames. No config key renames. Pure
documentation/comment surgery.

Closes #1575

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260430-224601-795023/.autoskillit/temp/make-plan/refactor_orchestration_levels_sessiontype_plan_2026-04-30_224834.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 79 | 9.2k | 300.5k | 37.5k | 1 | 4m 5s |
| verify | 50 | 12.1k | 1.9M | 76.9k | 1 | 5m 50s |
| implement | 260 | 10.9k | 1.5M | 46.9k | 1 | 3m 41s |
| prepare_pr | 76 | 5.3k | 305.7k | 31.0k | 1 | 1m 49s |
| compose_pr | 51 | 2.3k | 150.0k | 34.0k | 1 | 37s |
| review_pr | 357 | 51.3k | 1.5M | 116.5k | 2 | 11m 48s |
| resolve_review | 582 | 26.5k | 3.6M | 102.8k | 2 | 12m 54s |
| **Total** | 1.5k | 117.6k | 9.3M | 445.6k | | 40m 46s |