### PR TITLE
Rename Import-Layer L0/L1/L2/L3 Labels to IL-N

### DIFF
--- a/.claude/skills/audit-tests/SKILL.md
+++ b/.claude/skills/audit-tests/SKILL.md
@@ -23,21 +23,21 @@ Audit the test suite to identify useless tests, consolidation opportunities, qua
 
 ## Intended Test Directory Structure
 
-The test suite mirrors the source sub-package hierarchy rather than using a type-based unit/integration split — the project's L0–L3 layer boundaries already encode isolation levels. Each sub-package gets its own test directory. Cross-cutting concerns go in dedicated directories:
+The test suite mirrors the source sub-package hierarchy rather than using a type-based unit/integration split — the project's IL-0–IL-3 layer boundaries already encode isolation levels. Each sub-package gets its own test directory. Cross-cutting concerns go in dedicated directories:
 
 ```
 tests/
 ├── conftest.py          # Shared: MockSubprocessRunner, tool_ctx fixture (wired via make_context)
 ├── CLAUDE.md            # xdist safety guidelines
-├── core/                # L0: tests for autoskillit/core/ (io, logging, paths, types, protocols)
-├── config/              # L1: tests for autoskillit/config/
-├── pipeline/            # L1: tests for autoskillit/pipeline/ (audit, gate, context, tokens)
-├── execution/           # L1: tests for autoskillit/execution/ (db, github, headless, process, quota, session, testing)
-├── workspace/           # L1: tests for autoskillit/workspace/ (cleanup, clone, skills)
-├── recipe/              # L2: tests for autoskillit/recipe/ (io, loader, schema, validator, rules, smoke)
-├── migration/           # L2: tests for autoskillit/migration/ (engine, loader, store)
-├── server/              # L3: tests for autoskillit/server/ (_factory, git, helpers, tools_*)
-├── cli/                 # L3: tests for autoskillit/cli/
+├── core/                # IL-0: tests for autoskillit/core/ (io, logging, paths, types, protocols)
+├── config/              # IL-1: tests for autoskillit/config/
+├── pipeline/            # IL-1: tests for autoskillit/pipeline/ (audit, gate, context, tokens)
+├── execution/           # IL-1: tests for autoskillit/execution/ (db, github, headless, process, quota, session, testing)
+├── workspace/           # IL-1: tests for autoskillit/workspace/ (cleanup, clone, skills)
+├── recipe/              # IL-2: tests for autoskillit/recipe/ (io, loader, schema, validator, rules, smoke)
+├── migration/           # IL-2: tests for autoskillit/migration/ (engine, loader, store)
+├── server/              # IL-3: tests for autoskillit/server/ (_factory, git, helpers, tools_*)
+├── cli/                 # IL-3: tests for autoskillit/cli/
 ├── arch/                # Cross-cutting: AST architecture enforcement, import contracts, layer rules
 ├── contracts/           # Cross-cutting: instruction surface, MCP/API surface, version consistency
 └── infra/               # Cross-cutting: CI/dev config checks (.pre-commit, .gitleaks, .github/)
@@ -162,10 +162,10 @@ Tests placed in the wrong directory relative to the intended sub-package hierarc
 
 **What to look for:**
 - Any test file living at the `tests/` root other than `conftest.py` and `CLAUDE.md` — all test files should be inside sub-directories
-- Tests for L0 (`core/`) modules not in `tests/core/`
-- Tests for L1 modules (`config`, `pipeline`, `execution`, `workspace`) not in their corresponding `tests/<subpackage>/` directory
-- Tests for L2 modules (`recipe`, `migration`) not in their corresponding `tests/<subpackage>/` directory
-- Tests for L3 modules (`server`, `cli`) not in their corresponding `tests/<subpackage>/` directory
+- Tests for IL-0 (`core/`) modules not in `tests/core/`
+- Tests for IL-1 modules (`config`, `pipeline`, `execution`, `workspace`) not in their corresponding `tests/<subpackage>/` directory
+- Tests for IL-2 modules (`recipe`, `migration`) not in their corresponding `tests/<subpackage>/` directory
+- Tests for IL-3 modules (`server`, `cli`) not in their corresponding `tests/<subpackage>/` directory
 - AST-based architecture enforcement tests (import contracts, layer rules, structural checks) outside `tests/arch/`
 - Instruction surface / MCP contract / SKILL.md contract tests outside `tests/contracts/`
 - CI/dev infrastructure tests checking `.pre-commit-config.yaml`, `.gitleaks.toml`, or `.github/workflows/` files outside `tests/infra/`
@@ -234,11 +234,11 @@ Tests and configuration that maintain the path-based test filter's correctness. 
 
 Spawn 6 domain-based subagents. Each covers all issue categories (C1–C11) within its area. Group by source domain, not by issue category. Each subagent must read both test files AND the corresponding production code before making judgements.
 
-- **Group 1 — Core + Config (L0 + L1):** Tests for `core/` and `config/` sub-packages. Also check `conftest.py` for fixture quality.
-- **Group 2 — Pipeline + Workspace (L1):** Tests for `pipeline/` and `workspace/` sub-packages.
-- **Group 3 — Execution (L1):** Tests for `execution/` sub-package.
-- **Group 4 — Recipe + Migration (L2):** Tests for `recipe/` and `migration/` sub-packages.
-- **Group 5 — Server + CLI (L3):** Tests for `server/` and `cli/` sub-packages.
+- **Group 1 — Core + Config (IL-0 + IL-1):** Tests for `core/` and `config/` sub-packages. Also check `conftest.py` for fixture quality.
+- **Group 2 — Pipeline + Workspace (IL-1):** Tests for `pipeline/` and `workspace/` sub-packages.
+- **Group 3 — Execution (IL-1):** Tests for `execution/` sub-package.
+- **Group 4 — Recipe + Migration (IL-2):** Tests for `recipe/` and `migration/` sub-packages.
+- **Group 5 — Server + CLI (IL-3):** Tests for `server/` and `cli/` sub-packages.
 - **Group 6 — Cross-cutting:** Architecture enforcement tests, instruction surface/contract tests, CI/dev infrastructure tests. Also audit `tests/CLAUDE.md` for accuracy against the actual test files on disk. Additionally, perform filter integrity checks: verify filter cascade maps (`LAYER_CASCADE_CONSERVATIVE`, `LAYER_CASCADE_AGGRESSIVE`) against actual source subpackages under `src/autoskillit/`; check manifest completeness against `git ls-files`; verify size marker rollup coverage against `_SIZE_DIRS` in `conftest.py`; check Bucket A minimality (files that could use manifest instead); verify always-run directories (`ALWAYS_RUN_CONSERVATIVE`, `ALWAYS_RUN_AGGRESSIVE`) have appropriate size markers or are exempted from size filtering.
 
 For each finding, note the file, line range, issue category, and a brief explanation of why it's a problem and what should change.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,11 +112,11 @@ generic_automation_mcp/
 ├── smoke_utils.py           # Callables for smoke-test pipeline run_python steps
 ├── hook_registry.py         # HookDef, HOOK_REGISTRY, generate_hooks_json
 ├── _test_filter.py          # Test filter manifest: glob-to-test-directory mapping
-├── version.py               # Version health utilities (L0)
+├── version.py               # Version health utilities (IL-0)
 ├── .claude-plugin/          # plugin.json
 ├── .mcp.json
 │
-├── core/                    # L0 foundation (zero autoskillit imports)
+├── core/                    # IL-0 foundation (zero autoskillit imports)
 │   ├── __init__.py          #   Re-exports public surface
 │   ├── io.py                #   atomic_write, ensure_project_temp, YAML helpers
 │   ├── logging.py
@@ -135,9 +135,9 @@ generic_automation_mcp/
 │   ├── _type_helpers.py
 │   ├── _type_resume.py      #   ResumeSpec discriminated union: NoResume, BareResume, NamedResume
 │   ├── _type_plugin_source.py #  PluginSource discriminated union: DirectInstall | MarketplaceInstall
-│   ├── _linux_proc.py       #   read_boot_id, read_starttime_ticks — Linux /proc helpers (L0)
+│   ├── _linux_proc.py       #   read_boot_id, read_starttime_ticks — Linux /proc helpers (IL-0)
 │   ├── _claude_env.py       #   IDE-scrubbing canonical env builder for claude subprocesses
-│   ├── _terminal_table.py   #   L0 color-agnostic terminal table primitive
+│   ├── _terminal_table.py   #   IL-0 color-agnostic terminal table primitive
 │   ├── _version_snapshot.py #   Process-scoped version snapshot for session telemetry (lru_cache'd)
 │   ├── branch_guard.py
 │   ├── claude_conventions.py #  Skill discovery directory layout constants
@@ -145,12 +145,12 @@ generic_automation_mcp/
 │   ├── kitchen_state.py     #   Kitchen-open session marker (stdlib-only; readable from hooks)
 │   ├── _plugin_cache.py     #   Plugin cache lifecycle: retiring cache, install locking, kitchen registry
 │   ├── _plugin_ids.py       #   DIRECT_PREFIX, MARKETPLACE_PREFIX, detect_autoskillit_mcp_prefix (stdlib-only)
-│   ├── feature_flags.py     #   is_feature_enabled() — L0 feature gate resolution primitive
-│   ├── readiness.py         #   Filesystem readiness sentinel primitives for MCP server startup (L0)
+│   ├── feature_flags.py     #   is_feature_enabled() — IL-0 feature gate resolution primitive
+│   ├── readiness.py         #   Filesystem readiness sentinel primitives for MCP server startup (IL-0)
 │   ├── session_registry.py  #   Session registry: maps autoskillit launch IDs to Claude Code session UUIDs
-│   └── tool_sequence_analysis.py #  Cross-session tool call sequence DFG analysis (stdlib-only, L0)
+│   └── tool_sequence_analysis.py #  Cross-session tool call sequence DFG analysis (stdlib-only, IL-0)
 │
-├── config/                  # L1
+├── config/                  # IL-1
 │   ├── __init__.py
 │   ├── defaults.yaml
 │   ├── ingredient_defaults.py
@@ -158,7 +158,7 @@ generic_automation_mcp/
 │   ├── _config_dataclasses.py #  22 leaf dataclasses + ConfigSchemaError
 │   └── _config_loader.py    #   _make_dynaconf + load_config layer helpers
 │
-├── pipeline/                # L1 pipeline state
+├── pipeline/                # IL-1 pipeline state
 │   ├── __init__.py
 │   ├── audit.py             #   FailureRecord, DefaultAuditLog
 │   ├── background.py        #   DefaultBackgroundSupervisor
@@ -171,7 +171,7 @@ generic_automation_mcp/
 │   ├── tokens.py
 │   └── pr_gates.py          #   is_ci_passing, is_review_passing, partition_prs
 │
-├── execution/               # L1
+├── execution/               # IL-1
 │   ├── __init__.py
 │   ├── commands.py          #   Claude{Interactive,Headless}Cmd builders
 │   ├── db.py                #   Read-only SQLite with defence-in-depth
@@ -208,7 +208,7 @@ generic_automation_mcp/
 │   ├── clone_guard.py       #   Clone contamination guard — detect and revert direct changes to clone CWD
 │   └── pr_analysis.py       #   extract_linked_issues, DOMAIN_PATHS, partition_files_by_domain
 │
-├── workspace/               # L1
+├── workspace/               # IL-1
 │   ├── __init__.py
 │   ├── cleanup.py           #   CleanupResult, preserve list
 │   ├── clone.py             #   clone_repo + push_to_remote + DefaultCloneManager
@@ -219,7 +219,7 @@ generic_automation_mcp/
 │   ├── skills.py            #   SkillResolver — bundled skill listing
 │   └── worktree.py
 │
-├── planner/                 # L1
+├── planner/                 # IL-1
 │   ├── __init__.py          #   Progressive resolution planner — re-exports expand_assignments, expand_wps, finalize_wp_manifest, validate_plan, compile_plan
 │   ├── manifests.py         #   expand_assignments, expand_wps, finalize_wp_manifest, build_phase_assignment_manifest, build_phase_wp_manifest — manifest callables
 │   ├── merge.py             #   merge_tier_dir, merge_files, build_plan_snapshot, extract_item, replace_item — JSON interchange merge tooling
@@ -227,7 +227,7 @@ generic_automation_mcp/
 │   ├── schema.py            #   planner data contracts — PhaseResult, AssignmentResult, WPResult, PlanDocument TypedDicts
 │   └── compiler.py          #   compile_plan — topological sort, issue body generation, milestone definitions, plan artifacts
 │
-├── recipe/                  # L2
+├── recipe/                  # IL-2
 │   ├── __init__.py
 │   ├── contracts.py         #   Contract card generation + staleness triage
 │   ├── io.py                #   load_recipe, list_recipes, iter_steps_with_context
@@ -277,14 +277,14 @@ generic_automation_mcp/
 │   ├── staleness_cache.py
 │   └── validator.py         #   validate_recipe, analyze_dataflow
 │
-├── migration/               # L2
+├── migration/               # IL-2
 │   ├── __init__.py
 │   ├── engine.py            #   MigrationEngine, adapter ABC hierarchy
 │   ├── _api.py              #   check_and_migrate
 │   ├── loader.py            #   Migration note discovery + version chaining
 │   └── store.py             #   FailureStore (JSON, atomic writes)
 │
-├── fleet/                   # L2
+├── fleet/                   # IL-2
 │   ├── __init__.py          #   Re-exports: CampaignSummary, parse_campaign_summary, etc.
 │   ├── _api.py              #   Fleet campaign execution engine — dispatches L2 sessions, resolves campaign/result variable references
 │   ├── _prompts.py          #   Prompt builder for L2 fleet dispatch sessions — assembles sous-chef instruction block from SKILL.md sections
@@ -297,7 +297,7 @@ generic_automation_mcp/
 │   ├── state.py             #   Campaign state persistence — DispatchRecord, DispatchStatus, atomic writes, resume algorithm
 │   └── summary.py           #   Campaign summary schema v1: frozen dataclasses, sentinel parser, validator
 │
-├── server/                  # L3 FastMCP server
+├── server/                  # IL-3 FastMCP server
 │   ├── __init__.py          #   FastMCP app, kitchen gating, headless tool reveal
 │   ├── git.py               #   Merge workflow for merge_worktree
 │   ├── _editable_guard.py   #   Pre-deletion editable install guard (stdlib-only)
@@ -323,7 +323,7 @@ generic_automation_mcp/
 │   ├── _factory.py          #   Composition Root: make_context()
 │   └── _state.py            #   Lazy init, plugin dir resolution
 │
-├── cli/                     # L3 CLI
+├── cli/                     # IL-3 CLI
 │   ├── __init__.py
 │   ├── _ansi.py             #   supports_color, NO_COLOR/TERM=dumb
 │   ├── _terminal.py         #   terminal_guard() TTY restore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,10 +136,10 @@ root_packages = ["autoskillit"]
 exclude_type_checking_imports = true
 
 # IL-001 | Lens: module-dependency | DS-001
-# Rationale: L0 (core) is the foundation layer; it must have zero upward imports to
+# Rationale: IL-0 (core) is the foundation layer; it must have zero upward imports to
 # remain independently testable and importable outside the autoskillit package.
 [[tool.importlinter.contracts]]
-name = "L0 core has no autoskillit upward imports"
+name = "IL-0 core has no autoskillit upward imports"
 type = "forbidden"
 source_modules = ["autoskillit.core"]
 forbidden_modules = [
@@ -154,11 +154,11 @@ forbidden_modules = [
 ]
 
 # IL-002 | Lens: module-dependency | DS-001
-# Rationale: L1 config resolves settings from layered sources; allowing it to import
+# Rationale: IL-1 config resolves settings from layered sources; allowing it to import
 # pipeline/execution/recipe would create hidden initialization-time coupling that
 # breaks independent layered testing.
 [[tool.importlinter.contracts]]
-name = "L1 config imports only L0"
+name = "IL-1 config imports only IL-0"
 type = "forbidden"
 source_modules = ["autoskillit.config"]
 forbidden_modules = [
@@ -172,11 +172,11 @@ forbidden_modules = [
 ]
 
 # IL-003 | Lens: module-dependency | DS-001
-# Rationale: pipeline/ holds cross-session gate and audit state; importing from L2
-# (recipe, migration) would create initialization-order coupling and prevent L1
-# packages from being tested in isolation without a full L2 import graph.
+# Rationale: pipeline/ holds cross-session gate and audit state; importing from IL-2
+# (recipe, migration) would create initialization-order coupling and prevent IL-1
+# packages from being tested in isolation without a full IL-2 import graph.
 [[tool.importlinter.contracts]]
-name = "L1 pipeline does not import L2 or L3"
+name = "IL-1 pipeline does not import IL-2 or IL-3"
 type = "forbidden"
 source_modules = ["autoskillit.pipeline"]
 # EXCEPTION: autoskillit.config is intentionally omitted from the
@@ -198,10 +198,10 @@ forbidden_modules = [
 
 # IL-004 | Lens: module-dependency | DS-001
 # Rationale: execution/ manages subprocess lifecycle; it must not import config,
-# pipeline, workspace, recipe, migration, server, or cli to remain a leaf L1 service
+# pipeline, workspace, recipe, migration, server, or cli to remain a leaf IL-1 service
 # that can be tested without spinning up the full autoskillit stack.
 [[tool.importlinter.contracts]]
-name = "L1 execution imports only L0"
+name = "IL-1 execution imports only IL-0"
 type = "forbidden"
 source_modules = ["autoskillit.execution"]
 forbidden_modules = [
@@ -219,7 +219,7 @@ forbidden_modules = [
 # or pipeline would introduce a circular risk since config and pipeline both may
 # depend on workspace for path resolution.
 [[tool.importlinter.contracts]]
-name = "L1 workspace imports only L0"
+name = "IL-1 workspace imports only IL-0"
 type = "forbidden"
 source_modules = ["autoskillit.workspace"]
 forbidden_modules = [
@@ -233,11 +233,11 @@ forbidden_modules = [
 ]
 
 # IL-006 | Lens: module-dependency | DS-001
-# Rationale: recipe/ is an L2 service that orchestrates validation over workspace
+# Rationale: recipe/ is an IL-2 service that orchestrates validation over workspace
 # artifacts; importing config, pipeline, execution, migration, server, or cli
 # would conflate recipe semantics with runtime session management.
 [[tool.importlinter.contracts]]
-name = "L2 recipe imports only L0 and workspace"
+name = "IL-2 recipe imports only IL-0 and workspace"
 type = "forbidden"
 source_modules = ["autoskillit.recipe"]
 forbidden_modules = [
@@ -253,7 +253,7 @@ forbidden_modules = [
 # Rationale: migration/ must not import config or pipeline to stay independently
 # runnable as a schema-upgrade step without a live pipeline context.
 [[tool.importlinter.contracts]]
-name = "L2 migration does not import L3 or config"
+name = "IL-2 migration does not import IL-3 or config"
 type = "forbidden"
 source_modules = ["autoskillit.migration"]
 forbidden_modules = [
@@ -264,13 +264,13 @@ forbidden_modules = [
 ]
 
 # IL-008 | Lens: module-dependency | DS-001
-# Rationale: The four L1 peers (config, pipeline, execution, workspace) form an
+# Rationale: The four IL-1 peers (config, pipeline, execution, workspace) form an
 # independent service tier. Lateral imports between them create hidden coupling
 # that prevents each package from being tested and deployed in isolation. The
 # independence contract makes this boundary machine-verifiable and surfaces any
 # future regression immediately via lint-imports.
 [[tool.importlinter.contracts]]
-name = "L1 siblings are independent of each other"
+name = "IL-1 siblings are independent of each other"
 type = "independence"
 modules = [
     "autoskillit.config",
@@ -287,9 +287,9 @@ ignore_imports = [
 ]
 
 # IL-009 | Lens: module-dependency | DS-001
-# Rationale: fleet is L2 — imports L0 (core) only; workspace allowed for path utilities
+# Rationale: fleet is IL-2 — imports IL-0 (core) only; workspace allowed for path utilities
 [[tool.importlinter.contracts]]
-name = "L2 fleet does not import L3 or most L1 peers"
+name = "IL-2 fleet does not import IL-3 or most IL-1 peers"
 type = "forbidden"
 source_modules = ["autoskillit.fleet"]
 forbidden_modules = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,7 +183,7 @@ source_modules = ["autoskillit.pipeline"]
 # forbidden_modules list. pipeline.context.ToolContext owns
 # AutomationConfig as the DI wiring point — see the docstrings on
 # pipeline/context.py and pipeline/__init__.py. The coupling is safe
-# because config/ depends only on L0 (enforced by IL-002), so no
+# because config/ depends only on IL-0 (enforced by IL-002), so no
 # cycle is possible. This exception is asserted by
 # tests/arch/test_import_linter_contracts.py
 #     ::test_il003_pipeline_config_exception_documented.
@@ -280,7 +280,7 @@ modules = [
 ]
 # EXCEPTION: autoskillit.pipeline.context may import autoskillit.config.
 # pipeline.context.ToolContext owns AutomationConfig as the DI wiring point.
-# config/ depends only on L0 (IL-002), so no cycle is introduced.
+# config/ depends only on IL-0 (IL-002), so no cycle is introduced.
 # This exception mirrors the one already documented in IL-003.
 ignore_imports = [
     "autoskillit.pipeline.context -> autoskillit.config",

--- a/src/autoskillit/cli/_ansi.py
+++ b/src/autoskillit/cli/_ansi.py
@@ -1,4 +1,4 @@
-"""Terminal color utilities (L3 — CLI layer only)."""
+"""Terminal color utilities (IL-3 — CLI layer only)."""
 
 from __future__ import annotations
 

--- a/src/autoskillit/cli/_prompts.py
+++ b/src/autoskillit/cli/_prompts.py
@@ -30,7 +30,7 @@ _MCP_RETRY_INSTRUCTION: str = (
 
 
 def _read_full_sous_chef() -> str:
-    """Read the full sous-chef SKILL.md for L1/L3 injection."""
+    """Read the full sous-chef SKILL.md for injection into L1/L3 orchestration sessions."""
     path = pkg_root() / "skills" / "sous-chef" / "SKILL.md"
     try:
         return path.read_text()

--- a/src/autoskillit/config/__init__.py
+++ b/src/autoskillit/config/__init__.py
@@ -1,4 +1,4 @@
-"""config/ L1 package: configuration loading with layered YAML resolution.
+"""config/ IL-1 package: configuration loading with layered YAML resolution.
 
 Re-exports the full public surface of config.settings so callers can use
 either `from autoskillit.config import AutomationConfig` or the explicit

--- a/src/autoskillit/core/__init__.py
+++ b/src/autoskillit/core/__init__.py
@@ -1,4 +1,4 @@
-"""L0 foundation sub-package: types, logging, and I/O primitives.
+"""IL-0 foundation sub-package: types, logging, and I/O primitives.
 
 Re-exports the full public surface so callers can do
 ``from autoskillit.core import get_logger`` etc.  Submodules are loaded

--- a/src/autoskillit/core/_linux_proc.py
+++ b/src/autoskillit/core/_linux_proc.py
@@ -1,6 +1,6 @@
 """Minimal /proc filesystem readers for process identity.
 
-Stdlib-only — no psutil, no autoskillit imports. Safe for L0 core.
+Stdlib-only — no psutil, no autoskillit imports. Safe for IL-0 core.
 On non-Linux platforms all functions return None.
 """
 

--- a/src/autoskillit/core/_terminal_table.py
+++ b/src/autoskillit/core/_terminal_table.py
@@ -1,8 +1,8 @@
 """Shared terminal table primitive — color-agnostic, pure stdlib.
 
 This module contains no autoskillit imports and no ANSI sequences. It lives
-at L0 (core/) so it can be imported safely from any layer: cli/ (L3),
-pipeline/ (L1), server/ (L3), etc.
+at IL-0 (core/) so it can be imported safely from any layer: cli/ (IL-3),
+pipeline/ (IL-1), server/ (IL-3), etc.
 
 Public surface: TerminalColumn, _render_terminal_table, _render_gfm_table.
 """

--- a/src/autoskillit/core/_type_constants.py
+++ b/src/autoskillit/core/_type_constants.py
@@ -162,8 +162,8 @@ PIPELINE_FORBIDDEN_TOOLS: tuple[str, ...] = (
 # recipe_validator.py.
 SKILL_TOOLS: frozenset[str] = frozenset({"run_skill"})
 
-# Authoritative MCP tool registries. Defined here (L0) so both pipeline/ (L1)
-# and recipe/ (L2) can reference them without cross-layer import violations.
+# Authoritative MCP tool registries. Defined here (IL-0) so both pipeline/ (IL-1)
+# and recipe/ (IL-2) can reference them without cross-layer import violations.
 GATED_TOOLS: frozenset[str] = frozenset(
     {
         "run_cmd",
@@ -238,7 +238,7 @@ FLEET_DISPATCH_TOOLS: frozenset[str] = frozenset(
 )
 
 # Tools that appear in the Fleet group in the cook menu and open_kitchen response.
-# Defined here (L0) so menu modules can import the constant without loading the fleet package.
+# Defined here (IL-0) so menu modules can import the constant without loading the fleet package.
 FLEET_MENU_TOOLS: tuple[str, ...] = ("dispatch_food_truck", "record_gate_dispatch")
 
 FLEET_ERROR_CODES: frozenset[str] = frozenset(FleetErrorCode)

--- a/src/autoskillit/core/_type_protocols_workspace.py
+++ b/src/autoskillit/core/_type_protocols_workspace.py
@@ -87,10 +87,10 @@ class SkillResolver(Protocol):
 
 @runtime_checkable
 class SkillLister(Protocol):
-    """L0 contract for listing all available skills.
+    """IL-0 contract for listing all available skills.
 
-    Allows L2 recipe rules to type their skill-listing dependency
-    against an L0 protocol instead of binding to the L1 workspace
+    Allows IL-2 recipe rules to type their skill-listing dependency
+    against an IL-0 protocol instead of binding to the IL-1 workspace
     concrete class. The default implementation lives at
     autoskillit.workspace.skills.DefaultSkillResolver and satisfies this
     protocol structurally.

--- a/src/autoskillit/core/_version_snapshot.py
+++ b/src/autoskillit/core/_version_snapshot.py
@@ -1,4 +1,4 @@
-"""Process-scoped version snapshot for session telemetry (L0).
+"""Process-scoped version snapshot for session telemetry (IL-0).
 
 collect_version_snapshot() is cached with lru_cache(maxsize=1) so that the
 subprocess call to `claude --version` and filesystem reads happen once per
@@ -18,7 +18,7 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
-logger = logging.getLogger(__name__)  # noqa: TID251 — L0 module, no autoskillit imports allowed
+logger = logging.getLogger(__name__)  # noqa: TID251 — IL-0 module, no autoskillit imports allowed
 
 
 @functools.lru_cache(maxsize=1)

--- a/src/autoskillit/core/feature_flags.py
+++ b/src/autoskillit/core/feature_flags.py
@@ -1,4 +1,4 @@
-"""Feature flag resolution — L0 (zero autoskillit imports outside core/).
+"""Feature flag resolution — IL-0 (zero autoskillit imports outside core/).
 
 is_feature_enabled() is the single gating primitive for all feature-gated
 code paths. Callers pass config.features (a dict[str, bool]) rather than the

--- a/src/autoskillit/core/github_url.py
+++ b/src/autoskillit/core/github_url.py
@@ -1,6 +1,6 @@
 """Canonical GitHub remote URL parser.
 
-L0 module: stdlib only, zero autoskillit imports.
+IL-0 module: stdlib only, zero autoskillit imports.
 """
 
 from __future__ import annotations

--- a/src/autoskillit/core/readiness.py
+++ b/src/autoskillit/core/readiness.py
@@ -4,7 +4,7 @@ The sentinel file replaces log-line string matching as the subprocess
 synchronization primitive used by integration tests. File existence is
 atomic — there is no string-parse race and no wall-clock settle-sleep.
 
-This is an L0 module: stdlib-only imports plus core.io for ``atomic_write``.
+This is an IL-0 module: stdlib-only imports plus core.io for ``atomic_write``.
 No anyio, no FastMCP, no higher-layer autoskillit imports.
 
 Path resolution follows the same ``AUTOSKILLIT_STATE_DIR`` override pattern as

--- a/src/autoskillit/execution/__init__.py
+++ b/src/autoskillit/execution/__init__.py
@@ -1,4 +1,4 @@
-"""execution/ L1 package: subprocess lifecycle, session parsing, headless runner, testing, DB.
+"""execution/ IL-1 package: subprocess lifecycle, session parsing, headless runner, testing, DB.
 
 Re-exports the full public surface of the six execution sub-modules.
 All sub-modules depend only on autoskillit.core.* at runtime;

--- a/src/autoskillit/execution/_headless_path_tokens.py
+++ b/src/autoskillit/execution/_headless_path_tokens.py
@@ -47,7 +47,7 @@ def _build_path_token_set() -> frozenset[str]:
     and "file_path_list"). The outputs section in skill_contracts.yaml is a list
     of dicts with "name" and "type" keys — not a mapping.
 
-    Loads the YAML directly via L0 core utilities to avoid an upward L1→L2 import.
+    Loads the YAML directly via IL-0 core utilities to avoid an upward IL-1→IL-2 import.
     """
     try:
         manifest_path = pkg_root() / "recipe" / "skill_contracts.yaml"

--- a/src/autoskillit/execution/_headless_scan.py
+++ b/src/autoskillit/execution/_headless_scan.py
@@ -3,7 +3,7 @@
 Extracted from headless.py to keep that module below the 1100-line
 architectural limit (REQ-CNST-010-E2).
 
-L1 module (execution/). No autoskillit imports — stdlib only.
+IL-1 module (execution/). No autoskillit imports — stdlib only.
 """
 
 from __future__ import annotations

--- a/src/autoskillit/execution/ci.py
+++ b/src/autoskillit/execution/ci.py
@@ -1,6 +1,6 @@
 """GitHub Actions CI watcher service.
 
-L1 module: depends only on stdlib, httpx, and core/logging.
+IL-1 module: depends only on stdlib, httpx, and core/logging.
 Never raises — all errors are captured and returned as structured dicts.
 
 Three-phase algorithm eliminates the race condition where CI completes

--- a/src/autoskillit/execution/clone_guard.py
+++ b/src/autoskillit/execution/clone_guard.py
@@ -1,6 +1,6 @@
 """Clone contamination guard — detect and revert direct changes to clone CWD.
 
-L1 module (execution/). Detects when a worktree-based or read-only skill
+IL-1 module (execution/). Detects when a worktree-based or read-only skill
 session modified the clone directory directly and reverts those changes to
 prevent contamination from propagating to retry sessions.
 
@@ -220,7 +220,7 @@ async def check_and_revert_clone_contamination(
 
     For worktree skills, fires only on failure. For read-only skills
     (``readonly_skill=True``), fires on both success and failure to catch
-    any stray writes that bypassed Layer 1.
+    any stray writes that bypassed import layer 1 (IL-1).
 
     Returns (skill_result, reverted) where reverted is True if contamination
     was found and cleaned up.

--- a/src/autoskillit/execution/github.py
+++ b/src/autoskillit/execution/github.py
@@ -1,6 +1,6 @@
 """GitHub issue fetcher.
 
-L1 module: depends only on stdlib, httpx, and core/logging.
+IL-1 module: depends only on stdlib, httpx, and core/logging.
 Never raises — all errors are captured and returned as {"success": False, "error": "..."}.
 """
 

--- a/src/autoskillit/execution/headless.py
+++ b/src/autoskillit/execution/headless.py
@@ -1,6 +1,6 @@
 """Headless Claude Code session orchestration.
 
-L1 module (execution/). Owns the full lifecycle of a headless claude CLI session:
+IL-1 module (execution/). Owns the full lifecycle of a headless claude CLI session:
 command preparation, subprocess invocation via the injected runner, and
 SkillResult construction.
 

--- a/src/autoskillit/execution/merge_queue.py
+++ b/src/autoskillit/execution/merge_queue.py
@@ -1,4 +1,4 @@
-"""Merge queue polling service (L1) — monitors GitHub merge queue for a PR.
+"""Merge queue polling service (IL-1) — monitors GitHub merge queue for a PR.
 
 Never raises. All errors are returned as structured results.
 

--- a/src/autoskillit/execution/quota.py
+++ b/src/autoskillit/execution/quota.py
@@ -1,6 +1,6 @@
 """Quota-aware check for long-running pipeline recipes.
 
-L1 module: depends only on stdlib, httpx (FastMCP transitive dep), and core/logging.
+IL-1 module: depends only on stdlib, httpx (FastMCP transitive dep), and core/logging.
 Does NOT sleep. Returns metadata; the orchestrator sleeps via run_cmd.
 """
 

--- a/src/autoskillit/execution/recording.py
+++ b/src/autoskillit/execution/recording.py
@@ -248,7 +248,7 @@ def build_replay_runner(replay_dir: str) -> ReplayingSubprocessRunner:
     Creates a temporary output directory for the player, then parses the
     scenario manifest and constructs
     the deque-based session map.  All domain logic for replay setup lives here
-    (L1) rather than in the L3 composition root.
+    (IL-1) rather than in the IL-3 composition root.
 
     Args:
         replay_dir: Path to a scenario directory produced by a recording run.

--- a/src/autoskillit/execution/remote_resolver.py
+++ b/src/autoskillit/execution/remote_resolver.py
@@ -1,6 +1,6 @@
 """Canonical GitHub remote repository resolver.
 
-L1 module: resolves 'owner/repo' from a git working directory,
+IL-1 module: resolves 'owner/repo' from a git working directory,
 encoding the clone isolation contract (upstream > origin priority).
 """
 

--- a/src/autoskillit/execution/session.py
+++ b/src/autoskillit/execution/session.py
@@ -1,6 +1,6 @@
 """Domain model for Claude Code headless session results.
 
-L2 module: imports only from L0 (types, _logging). No server side-effects.
+IL-1 module: imports only from IL-0 (types, _logging). No server side-effects.
 Centralizes all session-parsing concerns so callers can work with typed
 objects instead of raw JSON strings.
 

--- a/src/autoskillit/execution/testing.py
+++ b/src/autoskillit/execution/testing.py
@@ -1,8 +1,8 @@
 """Pytest output parsing and test pass/fail adjudication.
 
-L3 service module. Used by server.py test_check tool and git_operations.py
+IL-1 module. Used by server.py (IL-3) test_check tool and git_operations.py
 merge test gate. No autoskillit server imports — depends only on stdlib and
-_logging.
+IL-0 _logging.
 """
 
 from __future__ import annotations

--- a/src/autoskillit/hook_registry.py
+++ b/src/autoskillit/hook_registry.py
@@ -229,8 +229,8 @@ def generate_hooks_json() -> dict:
 
 
 # ---------------------------------------------------------------------------
-# Hook diagnostic utilities — shared between cli/ and server/ (both L3).
-# Placed here (package root, L0-accessible) to avoid L3-to-L3 peer imports.
+# Hook diagnostic utilities — shared between cli/ and server/ (both IL-3).
+# Placed here (package root, IL-0-accessible) to avoid IL-3-to-IL-3 peer imports.
 # ---------------------------------------------------------------------------
 
 

--- a/src/autoskillit/hooks/_fmt_primitives.py
+++ b/src/autoskillit/hooks/_fmt_primitives.py
@@ -2,7 +2,7 @@
 
 Stdlib-only at runtime — runs under any Python interpreter without the
 autoskillit package, so the four ``_fmt_*`` modules and ``pretty_output_hook.py``
-all import directly from this module without going through any L1+ layer.
+all import directly from this module without going through any IL-1+ layer.
 """
 
 from __future__ import annotations

--- a/src/autoskillit/migration/__init__.py
+++ b/src/autoskillit/migration/__init__.py
@@ -1,4 +1,4 @@
-"""L2 migration domain — version graph, adapter dispatch, failure persistence."""
+"""IL-2 migration domain — version graph, adapter dispatch, failure persistence."""
 
 from __future__ import annotations
 

--- a/src/autoskillit/migration/_api.py
+++ b/src/autoskillit/migration/_api.py
@@ -1,6 +1,6 @@
 """Migration API: top-level check_and_migrate convenience function.
 
-Cross-L2 coupling note: migration/ (L2) imports from recipe/ (L2). This is
+Cross-IL-2 coupling note: migration/ (IL-2) imports from recipe/ (IL-2). This is
 architecturally correct — migration inherently needs to discover, parse, and
 validate recipes. The coupling is not extractable without inverting control in a
 way that would complicate callers. The # noqa: PLC0415 comments on the deferred

--- a/src/autoskillit/pipeline/__init__.py
+++ b/src/autoskillit/pipeline/__init__.py
@@ -1,4 +1,4 @@
-"""pipeline/ L1 package: audit log, token tracking, gate policy, and ToolContext.
+"""pipeline/ IL-1 package: audit log, token tracking, gate policy, and ToolContext.
 
 Re-exports the full public surface of the four pipeline sub-modules.
 Only pipeline/context.py imports from config/; the other three modules

--- a/src/autoskillit/pipeline/gate.py
+++ b/src/autoskillit/pipeline/gate.py
@@ -1,10 +1,10 @@
 """Gate policy constants for AutoSkillit MCP tools.
 
-L1 pipeline module. Declares which tools are gated vs. ungated and provides
+IL-1 pipeline module. Declares which tools are gated vs. ungated and provides
 the canonical error response for a closed gate.
 
-GATED_TOOLS and UNGATED_TOOLS are sourced from autoskillit.core.types (L0)
-so that L2 modules (recipe, migration) can also reference the tool registry
+GATED_TOOLS and UNGATED_TOOLS are sourced from autoskillit.core.types (IL-0)
+so that IL-2 modules (recipe, migration) can also reference the tool registry
 without violating layer ordering.
 """
 
@@ -45,7 +45,7 @@ def gate_error_result(message: str | None = None) -> str:
     'tools not enabled' message for gate-closed errors.
 
     Hardcodes retry_reason as "none" (the StrEnum value of RetryReason.NONE)
-    to preserve the L0 zero-internal-imports constraint.
+    to preserve the IL-0 zero-internal-imports constraint.
     """
     return json.dumps(
         {

--- a/src/autoskillit/planner/__init__.py
+++ b/src/autoskillit/planner/__init__.py
@@ -1,4 +1,4 @@
-"""planner/ L1 package: progressive resolution planner — manifests, merge, validation, compiler."""
+"""planner/ IL-1 package: progressive resolution planner — manifests, merge, validation, compiler."""
 
 from __future__ import annotations
 

--- a/src/autoskillit/planner/__init__.py
+++ b/src/autoskillit/planner/__init__.py
@@ -1,4 +1,6 @@
-"""planner/ IL-1 package: progressive resolution planner — manifests, merge, validation, compiler."""
+"""planner/ IL-1 package: progressive resolution planner.
+
+Exports: manifests, merge, validation, compiler."""
 
 from __future__ import annotations
 

--- a/src/autoskillit/recipe/__init__.py
+++ b/src/autoskillit/recipe/__init__.py
@@ -1,4 +1,4 @@
-"""L2 recipe domain — schema, I/O, validation, and contract management."""
+"""IL-2 recipe domain — schema, I/O, validation, and contract management."""
 
 from __future__ import annotations
 

--- a/src/autoskillit/recipe/rules_contracts.py
+++ b/src/autoskillit/recipe/rules_contracts.py
@@ -350,7 +350,7 @@ def _check_result_field_drift(ctx: ValidationContext) -> list[RuleFinding]:
     Comparison is one-directional: contract required fields vs TypedDict required keys.
     """
     # Deferred import: recipe/ must not import planner/ at module level (REQ-COMP-009).
-    # planner/ is L1 and does not import recipe/, so no circular risk.
+    # planner/ is IL-1 and does not import recipe/, so no circular risk.
     from autoskillit.planner import (  # noqa: PLC0415
         PHASE_REQUIRED_KEYS,
     )

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -1,8 +1,8 @@
 """Composition Root: make_context() is the only location that legally instantiates
 all 22 service contracts simultaneously.
 
-server/ is L3 — the only layer permitted to import from both L1 (pipeline/)
-and L2 (recipe/, migration/) at the same time. This module is the canonical
+server/ is IL-3 — the only layer permitted to import from both IL-1 (pipeline/)
+and IL-2 (recipe/, migration/) at the same time. This module is the canonical
 factory for wiring a fully-populated ToolContext, replacing the ad-hoc
 construction scattered across callers.
 """

--- a/src/autoskillit/server/git.py
+++ b/src/autoskillit/server/git.py
@@ -1,6 +1,6 @@
 """Git merge workflow for the merge_worktree MCP tool.
 
-L3 service module. Executes the full merge pipeline:
+IL-3 service module. Executes the full merge pipeline:
 path validation → worktree verification → branch detection → test gate →
 fetch → rebase → main-repo merge → worktree cleanup.
 

--- a/src/autoskillit/skills_extended/audit-feature-gates/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-feature-gates/SKILL.md
@@ -146,7 +146,7 @@ Return findings as structured text. Do NOT create any files.
 field declaration (e.g., `src/autoskillit/pipeline/context.py:NN`).
 
 For each feature:
-- Grep `src/autoskillit/core/` (L0) for feature-specific constants or imports beyond `FeatureDef`/`FEATURE_REGISTRY`
+- Grep `src/autoskillit/core/` (IL-0) for feature-specific constants or imports beyond `FeatureDef`/`FEATURE_REGISTRY`
 - Check `src/autoskillit/pipeline/context.py` for feature-specific fields unconditionally allocated on `ToolContext`
 - Check `src/autoskillit/config/settings.py` for feature-specific config dataclasses parsed without a validation gate
 - Check `src/autoskillit/execution/headless.py` for unconditional reads of feature config

--- a/src/autoskillit/skills_extended/audit-tests/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-tests/SKILL.md
@@ -179,11 +179,11 @@ Tests and configuration that maintain the path-based test filter's correctness. 
 
 Spawn 6 domain-based subagents. Each covers all issue categories (C1–C11) within its area. Group by source domain, not by issue category. Each subagent must read both test files AND the corresponding production code before making judgements.
 
-- **Group 1 — Core + Config (L0 + L1):** Tests for `core/` and `config/` sub-packages. Also check `conftest.py` for fixture quality.
-- **Group 2 — Pipeline + Workspace (L1):** Tests for `pipeline/` and `workspace/` sub-packages.
-- **Group 3 — Execution (L1):** Tests for `execution/` sub-package.
-- **Group 4 — Recipe + Migration (L2):** Tests for `recipe/` and `migration/` sub-packages.
-- **Group 5 — Server + CLI (L3):** Tests for `server/` and `cli/` sub-packages.
+- **Group 1 — Core + Config (IL-0 + IL-1):** Tests for `core/` and `config/` sub-packages. Also check `conftest.py` for fixture quality.
+- **Group 2 — Pipeline + Workspace (IL-1):** Tests for `pipeline/` and `workspace/` sub-packages.
+- **Group 3 — Execution (IL-1):** Tests for `execution/` sub-package.
+- **Group 4 — Recipe + Migration (IL-2):** Tests for `recipe/` and `migration/` sub-packages.
+- **Group 5 — Server + CLI (IL-3):** Tests for `server/` and `cli/` sub-packages.
 - **Group 6 — Cross-cutting:** Architecture enforcement tests, instruction surface/contract tests, CI/dev infrastructure tests. Also audit `tests/CLAUDE.md` for accuracy against the actual test files on disk. Additionally, perform filter integrity checks: verify filter cascade maps (`LAYER_CASCADE_CONSERVATIVE`, `LAYER_CASCADE_AGGRESSIVE`) against actual source subpackages under `src/autoskillit/`; check manifest completeness against `git ls-files`; verify size marker rollup coverage against `_SIZE_DIRS` in `conftest.py`; check Bucket A minimality (files that could use manifest instead); verify always-run directories (`ALWAYS_RUN_CONSERVATIVE`, `ALWAYS_RUN_AGGRESSIVE`) have appropriate size markers or are exempted from size filtering.
 
 For each finding, note the file, line range, issue category, and a brief explanation of why it's a problem and what should change.

--- a/src/autoskillit/version.py
+++ b/src/autoskillit/version.py
@@ -1,8 +1,8 @@
-"""Version health utilities (Layer 0).
+"""Version health utilities (IL-0 — import layer 0).
 
 Zero autoskillit imports — this module is importable before any other
 autoskillit subpackage.  YAML fields are extracted via regex to avoid
-depending on core/io.py (which would violate the L0 contract).
+depending on core/io.py (which would violate the IL-0 contract).
 """
 
 from __future__ import annotations

--- a/src/autoskillit/workspace/__init__.py
+++ b/src/autoskillit/workspace/__init__.py
@@ -1,4 +1,4 @@
-"""workspace/ L1 package: directory cleanup, skill resolution, and clone isolation.
+"""workspace/ IL-1 package: directory cleanup, skill resolution, and clone isolation.
 
 Re-exports the full public surface of cleanup.py, skills.py, and clone.py.
 All sub-modules depend only on autoskillit.core.*.

--- a/src/autoskillit/workspace/clone.py
+++ b/src/autoskillit/workspace/clone.py
@@ -5,7 +5,7 @@ not be touched for any purpose except reading its remote URL in push_to_remote.
 This prohibits git checkout, git fetch, git reset, git pull, run_cmd, run_skill,
 and every other command in source_dir. All pipeline work runs in clone_path.
 
-L1 module: depends only on stdlib and autoskillit.core.logging.
+IL-1 module: depends only on stdlib and autoskillit.core.logging.
 Three callables are registered as run_python entry points in bundled recipes.
 
 Note: The ``clone_local`` strategy (``shutil.copytree``) leverages hardlinks when

--- a/src/autoskillit/workspace/worktree.py
+++ b/src/autoskillit/workspace/worktree.py
@@ -1,4 +1,4 @@
-"""Git worktree lifecycle utilities (L1 workspace service layer).
+"""Git worktree lifecycle utilities (IL-1 workspace service layer).
 
 Provides the single source of truth for worktree creation metadata,
 enumeration via `git worktree list --porcelain`, and removal via

--- a/tests/arch/test_import_layer_labels.py
+++ b/tests/arch/test_import_layer_labels.py
@@ -5,8 +5,8 @@ must use IL-0/IL-1/IL-2/IL-3 for import-layer annotations.  This test
 scans src/autoskillit/ Python files for the patterns that indicate an
 import-layer usage and fails if any bare L-number labels remain.
 """
+
 import re
-from pathlib import Path
 
 import pytest
 

--- a/tests/arch/test_import_layer_labels.py
+++ b/tests/arch/test_import_layer_labels.py
@@ -73,6 +73,8 @@ _SKIP_PATHS = frozenset(
         # cli/_prompts.py builds orchestration-level prompts for L1/L3 sessions;
         # all L-number references in this file are orchestration-level, not import-layer.
         "cli/_prompts.py",
+        # leaf_orchestration_guard.py describes session-type invariants (orchestration L2/L3).
+        "hooks/leaf_orchestration_guard.py",
     ]
 )
 

--- a/tests/arch/test_import_layer_labels.py
+++ b/tests/arch/test_import_layer_labels.py
@@ -88,18 +88,31 @@ def test_no_bare_import_layer_labels_in_src() -> None:
         rel = py_file.relative_to(src_root)
         rel_str = rel.as_posix()
 
-        # Skip orchestration-level fleet files and test files
-        if any(rel_str.endswith(skip) for skip in _SKIP_PATHS):
-            continue
-        if rel_str.startswith("tests/"):
+        if rel_str in _SKIP_PATHS:
             continue
 
         source = py_file.read_text()
-        # Only scan docstrings and comments, not string literals in code
+        in_triple_double = False
+        in_triple_single = False
         for lineno, line in enumerate(source.splitlines(), 1):
             stripped = line.strip()
-            # Check comment lines and lines that are part of docstrings
-            if stripped.startswith("#") or '"""' in stripped or stripped.startswith("'"):
+            # Track multi-line docstring state so body lines are also checked
+            if not in_triple_single and '"""' in stripped:
+                # Count unescaped occurrences to determine open/close toggle
+                count = stripped.count('"""')
+                if count % 2 == 1:
+                    in_triple_double = not in_triple_double
+            elif not in_triple_double and "'''" in stripped:
+                count = stripped.count("'''")
+                if count % 2 == 1:
+                    in_triple_single = not in_triple_single
+            inside_docstring = in_triple_double or in_triple_single
+            if (
+                stripped.startswith("#")
+                or '"""' in stripped
+                or stripped.startswith("'")
+                or inside_docstring
+            ):
                 if _IMPORT_LAYER_PATTERNS.search(line):
                     violations.append(f"{rel_str}:{lineno}: {stripped!r}")
 

--- a/tests/arch/test_import_layer_labels.py
+++ b/tests/arch/test_import_layer_labels.py
@@ -1,0 +1,106 @@
+"""Regression guard: no bare L-number labels in import-layer contexts.
+
+After the IL-N rename (issue #1574), module docstrings and inline comments
+must use IL-0/IL-1/IL-2/IL-3 for import-layer annotations.  This test
+scans src/autoskillit/ Python files for the patterns that indicate an
+import-layer usage and fails if any bare L-number labels remain.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+
+# Patterns that indicate "this L-number is import-layer, not orchestration"
+_IMPORT_LAYER_PATTERNS = re.compile(
+    r"""
+    (?:
+        # "(L0)", "(L1)", "(L2)", "(L3)" in isolation
+        \(L[0-3]\)
+        |
+        # "L0 module", "L1 module", etc.
+        \bL[0-3]\s+module\b
+        |
+        # "L0 foundation", "L1 service"
+        \bL[0-3]\s+(?:foundation|service|module|layer|contract|peer)\b
+        |
+        # "L0 core", "L1 config", "L2 recipe", etc.
+        \bL[0-3]\s+(?:core|config|pipeline|execution|workspace|recipe|migration|fleet|server|cli)\b
+        |
+        # "imports only from L0"
+        imports\s+only\s+(?:from\s+)?L[0-3]\b
+        |
+        # "any L1+ layer"
+        \bL[0-3]\+\s+layer\b
+        |
+        # "L0-accessible"
+        \bL[0-3]-accessible\b
+        |
+        # "at L0 (core/)"
+        \bat\s+L[0-3]\s+\(
+        |
+        # "Layer 0" (import-layer verbiage)
+        \bLayer\s+[0-3]\b
+        |
+        # "L0/L1", "L1/L2", "L1/L2/L3" sub-package
+        \bL[0-3]/L[0-3]
+        |
+        # "both L3" when referring to server/ and cli/ as import siblings
+        \bboth\s+L[0-3]\b
+        |
+        # "L2 + L1", "L0 + L1"
+        L[0-3]\s*\+\s*L[0-3]
+    )
+    """,
+    re.VERBOSE,
+)
+
+# Orchestration-level files where bare L0–L3 is CORRECT — skip them
+_SKIP_PATHS = frozenset(
+    [
+        "fleet/_api.py",
+        "fleet/_prompts.py",
+        "fleet/result_parser.py",
+        "fleet/state.py",
+        "fleet/summary.py",
+        "fleet/sidecar.py",
+        "fleet/_liveness.py",
+        "fleet/_semaphore.py",
+        "fleet/_sidecar_rpc.py",
+        "fleet/_findings_rpc.py",
+    ]
+)
+
+
+def test_no_bare_import_layer_labels_in_src() -> None:
+    """No module docstrings or inline comments use bare L-number for import layers."""
+    from autoskillit.core.paths import pkg_root
+
+    src_root = pkg_root()
+    violations: list[str] = []
+
+    for py_file in sorted(src_root.rglob("*.py")):
+        rel = py_file.relative_to(src_root)
+        rel_str = rel.as_posix()
+
+        # Skip orchestration-level fleet files and test files
+        if any(rel_str.endswith(skip) for skip in _SKIP_PATHS):
+            continue
+        if rel_str.startswith("tests/"):
+            continue
+
+        source = py_file.read_text()
+        # Only scan docstrings and comments, not string literals in code
+        for lineno, line in enumerate(source.splitlines(), 1):
+            stripped = line.strip()
+            # Check comment lines and lines that are part of docstrings
+            if stripped.startswith("#") or '"""' in stripped or stripped.startswith("'"):
+                if _IMPORT_LAYER_PATTERNS.search(line):
+                    violations.append(f"{rel_str}:{lineno}: {stripped!r}")
+
+    assert not violations, (
+        f"Found {len(violations)} bare import-layer L-number label(s) — "
+        f"use IL-N instead:\n" + "\n".join(violations)
+    )

--- a/tests/arch/test_import_layer_labels.py
+++ b/tests/arch/test_import_layer_labels.py
@@ -51,7 +51,7 @@ _IMPORT_LAYER_PATTERNS = re.compile(
         \bboth\s+L[0-3]\b
         |
         # "L2 + L1", "L0 + L1"
-        L[0-3]\s*\+\s*L[0-3]
+        \bL[0-3]\s*\+\s*L[0-3]
     )
     """,
     re.VERBOSE,

--- a/tests/arch/test_import_layer_labels.py
+++ b/tests/arch/test_import_layer_labels.py
@@ -70,6 +70,9 @@ _SKIP_PATHS = frozenset(
         "fleet/_semaphore.py",
         "fleet/_sidecar_rpc.py",
         "fleet/_findings_rpc.py",
+        # cli/_prompts.py builds orchestration-level prompts for L1/L3 sessions;
+        # all L-number references in this file are orchestration-level, not import-layer.
+        "cli/_prompts.py",
     ]
 )
 

--- a/tests/arch/test_import_linter_contracts.py
+++ b/tests/arch/test_import_linter_contracts.py
@@ -105,7 +105,7 @@ def test_il003_pipeline_config_exception_documented() -> None:
     in_block = False
     block_lines: list[str] = []
     for line in lines:
-        if 'name = "L1 pipeline does not import L2 or L3"' in line:
+        if 'name = "IL-1 pipeline does not import IL-2 or IL-3"' in line:
             in_block = True
         if in_block:
             block_lines.append(line)

--- a/tests/arch/test_import_paths.py
+++ b/tests/arch/test_import_paths.py
@@ -210,8 +210,8 @@ def test_req_imp_005_git_only_core_at_runtime() -> None:
             # _subprocess is a same-package helper with no upward layer imports;
             # git.py delegates timeout result processing to _process_runner_result.
             "autoskillit.server._subprocess",
-            # workspace is L1; git.py delegates worktree removal to the
-            # single L1 implementation rather than inlining subprocess calls.
+            # workspace is IL-1; git.py delegates worktree removal to the
+            # single IL-1 implementation rather than inlining subprocess calls.
             "autoskillit.workspace",
         }
     )
@@ -312,13 +312,13 @@ def test_req_imp_009_session_skills_no_config_settings_import() -> None:
 
 # ---------------------------------------------------------------------------
 # REQ-IMP-007: server/ and cli/ files must not import cross-package sub-modules
-# (Finding 13.3) — extends REQ-IMP-001 coverage to L3 layers
+# (Finding 13.3) — extends REQ-IMP-001 coverage to IL-3 layers
 # ---------------------------------------------------------------------------
 
 
 def test_req_imp_007_server_cli_no_unauthorized_cross_submodule_imports() -> None:
     """REQ-IMP-007: every file in server/ and cli/ must obey the same
-    cross-package submodule rule that REQ-IMP-001 enforces for the L0–L2
+    cross-package submodule rule that REQ-IMP-001 enforces for the IL-0–IL-2
     layers, with a small explicit allowlist:
 
       server/_factory.py     — Composition Root, may import any layer
@@ -362,7 +362,7 @@ def test_req_imp_007_server_cli_no_unauthorized_cross_submodule_imports() -> Non
 def test_req_imp_010_init_helpers_no_toplevel_recipe_imports() -> None:
     """cli/_init_helpers.py must not import autoskillit.recipe at module level.
 
-    list_recipes is an L2 dependency; deferring it to the function body
+    list_recipes is an IL-2 dependency; deferring it to the function body
     (_prompt_recipe_choice) keeps _init_helpers.py importable without
     pulling in the recipe subpackage at startup (issue #930).
     """
@@ -384,18 +384,18 @@ def test_req_imp_010_init_helpers_no_toplevel_recipe_imports() -> None:
 
 
 # ---------------------------------------------------------------------------
-# IL-008: L1 sibling packages must not import from each other at runtime
+# IL-008: IL-1 sibling packages must not import from each other at runtime
 # ---------------------------------------------------------------------------
 
 
 def test_il008_l1_independence() -> None:
-    """IL-008: L1 sibling packages (config, pipeline, execution, workspace) must
+    """IL-008: IL-1 sibling packages (config, pipeline, execution, workspace) must
     not import from each other at runtime.
 
     Exception: autoskillit.pipeline.context may import autoskillit.config.
     pipeline.context.ToolContext owns AutomationConfig as the DI wiring point
     (see pipeline/context.py and the IL-003 inline EXCEPTION comment).
-    config/ depends only on L0 (IL-002), so no cycle is introduced.
+    config/ depends only on IL-0 (IL-002), so no cycle is introduced.
 
     TYPE_CHECKING imports are excluded — pyproject.toml sets
     exclude_type_checking_imports = true and _parse_imports() respects
@@ -418,5 +418,5 @@ def test_il008_l1_independence() -> None:
                 if (pkg, parts[1]) not in ALLOWED:
                     violations.append(f"{path.relative_to(SRC)}: {mod}")
     assert not violations, (
-        "IL-008 violations (unauthorized L1 sibling runtime imports):\n" + "\n".join(violations)
+        "IL-008 violations (unauthorized IL-1 sibling runtime imports):\n" + "\n".join(violations)
     )

--- a/tests/arch/test_import_paths.py
+++ b/tests/arch/test_import_paths.py
@@ -388,7 +388,7 @@ def test_req_imp_010_init_helpers_no_toplevel_recipe_imports() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_il008_l1_independence() -> None:
+def test_il008_il1_independence() -> None:
     """IL-008: IL-1 sibling packages (config, pipeline, execution, workspace) must
     not import from each other at runtime.
 

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -1,4 +1,4 @@
-"""L1/L2/L3 sub-package isolation, __all__ completeness, size/file-count constraints.
+"""IL-1/IL-2/IL-3 sub-package isolation, __all__ completeness, size/file-count constraints.
 
 Tests:
   - Sync manifest deletion checks

--- a/tests/infra/test_docstring_labels.py
+++ b/tests/infra/test_docstring_labels.py
@@ -7,16 +7,16 @@ from pathlib import Path
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
 
-def test_session_py_docstring_says_l2():
-    """session.py docstring must carry an L2 label."""
+def test_session_py_docstring_says_il1():
+    """session.py docstring must carry an IL-1 label."""
     src = (_REPO_ROOT / "src/autoskillit/execution/session.py").read_text()
-    assert "L2" in src.split('"""')[1], "session.py docstring must say L2"
+    assert "IL-1" in src.split('"""')[1], "session.py docstring must say IL-1"
 
 
-def test_headless_py_docstring_says_l1():
-    """headless.py docstring must carry an L1 label."""
+def test_headless_py_docstring_says_il1():
+    """headless.py docstring must carry an IL-1 label."""
     src = (_REPO_ROOT / "src/autoskillit/execution/headless.py").read_text()
-    assert "L1" in src.split('"""')[1], "headless.py docstring must say L1"
+    assert "IL-1" in src.split('"""')[1], "headless.py docstring must say IL-1"
 
 
 def test_smoke_utils_documents_limitation():
@@ -36,7 +36,7 @@ def test_claude_md_no_stale_l3_headless_label():
 
 
 def test_planner_init_has_docstring():
-    """planner/__init__.py must have a module-level docstring like other L1 packages."""
+    """planner/__init__.py must have a module-level docstring like other IL-1 packages."""
     import autoskillit.planner as planner_pkg
 
     assert planner_pkg.__doc__ is not None and planner_pkg.__doc__.strip(), (

--- a/tests/pipeline/test_gate.py
+++ b/tests/pipeline/test_gate.py
@@ -139,7 +139,7 @@ def test_gate_error_result_accepts_custom_message():
 
 
 def test_gate_imports_only_from_core():
-    """gate.py (L1 pipeline) may only import from autoskillit.core (L0)."""
+    """gate.py (IL-1 pipeline) may only import from autoskillit.core (IL-0)."""
     import ast
 
     from autoskillit.core.paths import pkg_root
@@ -152,7 +152,7 @@ def test_gate_imports_only_from_core():
                 assert node.module == "autoskillit.core" or node.module.startswith(
                     "autoskillit.core."
                 ), (
-                    f"gate.py (L1) may only import from autoskillit.core (L0): "
+                    f"gate.py (IL-1) may only import from autoskillit.core (IL-0): "
                     f"found 'from {node.module} import ...'"
                 )
             if isinstance(node, ast.Import):


### PR DESCRIPTION
## Summary

Rename all 49 import-layer L-number references (across 25 files) from bare `L0`/`L1`/`L2`/`L3` to `IL-0`/`IL-1`/`IL-2`/`IL-3`. The import-linter contracts already use the "IL-" prefix (IL-001 through IL-009), so this extends the same convention to module docstrings, inline comments, pyproject.toml contract names, CLAUDE.md annotations, and SKILL.md files. The four ambiguous references in `execution/session.py`, `execution/testing.py`, `execution/recording.py`, and `cli/_prompts.py` are resolved by determining whether each usage is import-layer (convert) or orchestration-level (leave unchanged). Fleet code, identifier names, and orchestration-level L0–L3 references are untouched.

Closes #1574

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260430-224601-054043/.autoskillit/temp/make-plan/rename_import_layer_labels_plan_2026-04-30_224601.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 71 | 15.2k | 317.1k | 49.3k | 1 | 8m 23s |
| verify | 50 | 17.5k | 2.2M | 139.8k | 1 | 12m 16s |
| implement | 780 | 63.0k | 9.7M | 405.3k | 1 | 21m 21s |
| prepare_pr | 76 | 5.5k | 325.8k | 36.5k | 1 | 1m 41s |
| compose_pr | 59 | 2.0k | 198.5k | 20.1k | 1 | 52s |
| review_pr | 2.5k | 67.0k | 1.9M | 182.7k | 2 | 28m 34s |
| resolve_review | 542 | 37.0k | 3.4M | 126.4k | 2 | 17m 1s |
| diagnose_ci | 68 | 2.8k | 235.0k | 45.1k | 1 | 1m 5s |
| resolve_ci | 142 | 10.0k | 906.9k | 54.7k | 1 | 5m 2s |
| **Total** | 4.3k | 220.0k | 19.1M | 1.1M | | 1h 36m |