### PR TITLE
Implementation Plan: ADR — Prohibit Background Subagent Execution in All Skills

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,3 +27,4 @@ multi-level orchestrator. The bundled recipes implement issue → plan → workt
 - [operations/](operations/README.md) — observability
 - [developer/](developer/README.md) — contributing, diagnostics, end-turn hazards
 - [examples/](examples/README.md) — end-to-end pipeline runs
+- [decisions/](decisions/README.md) — architecture decision records

--- a/docs/decisions/0001-prohibit-background-subagent-execution.md
+++ b/docs/decisions/0001-prohibit-background-subagent-execution.md
@@ -51,7 +51,7 @@ indicators and asserts the prohibition string is present. This test runs as part
 
 ## Scope
 
-Applies to 54 SKILL.md files. Listed by group:
+Applies to 77 SKILL.md files. Listed by group:
 
 **Core spawning skills (23):** implement-worktree, implement-worktree-no-merge,
 investigate, make-plan, make-groups, validate-audit, scope, rectify, process-issues,

--- a/docs/decisions/0001-prohibit-background-subagent-execution.md
+++ b/docs/decisions/0001-prohibit-background-subagent-execution.md
@@ -1,0 +1,86 @@
+# ADR-0001: Prohibit Background Subagent Execution in All Skills
+
+**Status:** Accepted
+**Date:** 2026-05-01
+**Issue:** [#1582](https://github.com/TalonT-Org/AutoSkillit/issues/1582)
+
+## Context
+
+Skills that spawn subagents via the Agent/Task tool have no universal rule governing
+whether those subagents run in the foreground (blocking) or background (non-blocking).
+When left to LLM discretion, background execution is occasionally chosen and produces
+silent failures:
+
+- **Lost results**: Background agents complete after the parent has moved on; findings
+  are never incorporated into skill output.
+- **Race conditions**: The parent acts on incomplete information while background agents
+  are still gathering evidence.
+- **Unobservable failures**: A failed background agent goes unnoticed — the parent is
+  not blocked waiting for it.
+- **Synthesis responsibility violation**: Synthesis requires all results to be available
+  simultaneously. Background execution makes this impossible.
+
+## Decision
+
+**All skills that instruct sessions to spawn subagents MUST include the explicit rule in
+their NEVER block:**
+
+> Run subagents in the background (`run_in_background: true` is prohibited)
+
+This applies to all SKILL.md files in `skills/` and `skills_extended/` that contain
+Agent/Task tool spawning instructions.
+
+This rule does NOT prohibit parallel execution. Multiple foreground subagents launched
+in a single message execute concurrently — the parent blocks until all complete, then
+synthesizes their combined results.
+
+## Rationale
+
+The foreground-parallel pattern (multiple Agent calls in one message, no
+`run_in_background`) provides all the throughput benefits of parallelism while
+guaranteeing the parent has complete information before synthesis. There is no valid
+use case for background subagents in skill execution — if results are not needed, the
+subagent should not be spawned at all.
+
+## Enforcement
+
+The compliance test `test_no_background_subagent_in_spawning_skills` in
+`tests/skills/test_skill_compliance.py` automatically detects skills with spawn
+indicators and asserts the prohibition string is present. This test runs as part of
+`task test-all` and `task test-check`.
+
+## Scope
+
+Applies to 54 SKILL.md files. Listed by group:
+
+**Core spawning skills (23):** implement-worktree, implement-worktree-no-merge,
+investigate, make-plan, make-groups, validate-audit, scope, rectify, process-issues,
+dry-walkthrough, generate-report, implement-experiment, plan-experiment,
+plan-visualization, run-experiment, review-approach, review-design, setup-project,
+triage-issues, audit-claims, review-pr, review-research-pr, retry-worktree
+
+**Planner L1+L0 skills (8):** planner-analyze, planner-extract-domain,
+planner-elaborate-wps, planner-elaborate-assignments, planner-refine-phases,
+planner-refine-assignments, planner-refine-wps, planner-elaborate-phase
+
+**Resolve skills (3):** resolve-review, resolve-claims-review, resolve-research-review
+
+**Audit/design skills (7):** audit-arch, audit-cohesion, audit-defense-standards,
+design-guards, audit-tests, audit-bugs, stage-data
+
+**Arch-lens skills (13):** arch-lens-state-lifecycle, arch-lens-c4-container,
+arch-lens-concurrency, arch-lens-data-lineage, arch-lens-deployment,
+arch-lens-development, arch-lens-error-resilience, arch-lens-module-dependency,
+arch-lens-operational, arch-lens-process-flow, arch-lens-repository-access,
+arch-lens-scenarios, arch-lens-security
+
+**Exp-lens skills (18):** exp-lens-fair-comparison, exp-lens-unit-interference,
+exp-lens-causal-assumptions, exp-lens-benchmark-representativeness,
+exp-lens-comparator-construction, exp-lens-error-budget, exp-lens-estimand-clarity,
+exp-lens-exploratory-confirmatory, exp-lens-governance-risk, exp-lens-iterative-learning,
+exp-lens-measurement-validity, exp-lens-pipeline-integrity,
+exp-lens-randomization-blocking, exp-lens-reproducibility-artifacts,
+exp-lens-sensitivity-robustness, exp-lens-severity-testing, exp-lens-validity-threats,
+exp-lens-variance-stability
+
+**Other (5):** analyze-prs, build-execution-map, verify-diag, audit-impl, elaborate-phase

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,3 @@
+# Architecture Decision Records
+
+- [0001-prohibit-background-subagent-execution.md](0001-prohibit-background-subagent-execution.md) — prohibit `run_in_background: true` in all skills

--- a/src/autoskillit/skills_extended/analyze-prs/SKILL.md
+++ b/src/autoskillit/skills_extended/analyze-prs/SKILL.md
@@ -28,6 +28,7 @@ complexity, and produce machine-readable output for the `merge-prs` recipe.
 - Merge, close, or modify any PR
 - Modify any source code files
 - Create files outside `{{AUTOSKILLIT_TEMP}}/merge-prs/` directory
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Use subagents to fetch PR data in parallel

--- a/src/autoskillit/skills_extended/arch-lens-c4-container/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-c4-container/SKILL.md
@@ -31,6 +31,7 @@ hooks:
 - Modify any source code files
 - Include internal implementation details (that's for other lenses)
 - Show runtime behavior or state transitions
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Focus on CONTAINERS (deployable units, not classes)

--- a/src/autoskillit/skills_extended/arch-lens-concurrency/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-concurrency/SKILL.md
@@ -31,6 +31,7 @@ hooks:
 - Modify any source code files
 - Conflate with general process flow (that's a different lens)
 - Ignore thread safety implications
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Focus on PARALLEL execution specifically

--- a/src/autoskillit/skills_extended/arch-lens-data-lineage/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-data-lineage/SKILL.md
@@ -31,6 +31,7 @@ hooks:
 - Modify any source code files
 - Focus on runtime behavior (that's process flow lens)
 - Show static structure without data context
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Trace data from INPUT to STORAGE

--- a/src/autoskillit/skills_extended/arch-lens-deployment/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-deployment/SKILL.md
@@ -31,6 +31,7 @@ hooks:
 - Modify any source code files
 - Include code-level details
 - Show internal logic
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Focus on PHYSICAL deployment

--- a/src/autoskillit/skills_extended/arch-lens-development/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-development/SKILL.md
@@ -31,6 +31,7 @@ hooks:
 - Modify any source code files
 - Include runtime architecture details
 - Show business logic
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Focus on BUILD and TEST infrastructure

--- a/src/autoskillit/skills_extended/arch-lens-error-resilience/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-error-resilience/SKILL.md
@@ -31,6 +31,7 @@ hooks:
 - Modify any source code files
 - Show happy path details (that's process flow lens)
 - Ignore validation and fail-fast patterns
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Focus on FAILURE paths and recovery

--- a/src/autoskillit/skills_extended/arch-lens-module-dependency/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-module-dependency/SKILL.md
@@ -31,6 +31,7 @@ hooks:
 - Modify any source code files
 - Include runtime behavior details
 - Show external system integrations in detail
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Focus on IMPORT relationships between modules

--- a/src/autoskillit/skills_extended/arch-lens-operational/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-operational/SKILL.md
@@ -31,6 +31,7 @@ hooks:
 - Modify any source code files
 - Include internal implementation details
 - Show code-level patterns
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Focus on OPERATOR experience

--- a/src/autoskillit/skills_extended/arch-lens-process-flow/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-process-flow/SKILL.md
@@ -31,6 +31,7 @@ hooks:
 - Modify any source code files
 - Include static structure details (that's C4 lens)
 - Show data storage details (that's data lineage lens)
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Focus on BEHAVIOR and STATE TRANSITIONS

--- a/src/autoskillit/skills_extended/arch-lens-repository-access/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-repository-access/SKILL.md
@@ -31,6 +31,7 @@ hooks:
 - Modify any source code files
 - Focus on data flow (that's data lineage lens)
 - Include business logic details
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Focus on REPOSITORIES and their methods

--- a/src/autoskillit/skills_extended/arch-lens-scenarios/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-scenarios/SKILL.md
@@ -31,6 +31,7 @@ hooks:
 - Modify any source code files
 - Show internal component details
 - Include all possible scenarios (pick key ones)
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Focus on END-TO-END journeys

--- a/src/autoskillit/skills_extended/arch-lens-security/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-security/SKILL.md
@@ -31,6 +31,7 @@ hooks:
 - Modify any source code files
 - Expose actual secrets or credentials
 - Show implementation details that could aid attacks
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Focus on TRUST BOUNDARIES

--- a/src/autoskillit/skills_extended/arch-lens-state-lifecycle/SKILL.md
+++ b/src/autoskillit/skills_extended/arch-lens-state-lifecycle/SKILL.md
@@ -31,6 +31,7 @@ hooks:
 - Modify any source code files
 - Show business logic details
 - Focus on data content (focus on mutation rules)
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Focus on STATE MUTATION RULES

--- a/src/autoskillit/skills_extended/audit-arch/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-arch/SKILL.md
@@ -24,6 +24,7 @@ Audit the codebase for adherence to architectural standards and rules.
 **NEVER:**
 - Modify any source code files
 - Update an existing report - always generate new
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Use subagents for parallel exploration

--- a/src/autoskillit/skills_extended/audit-bugs/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-bugs/SKILL.md
@@ -30,6 +30,7 @@ The user may provide a "since" date (e.g., `2/7`, `2026-02-07`, `last week`). If
 **NEVER:**
 - Modify any source code files
 - Create files outside `{{AUTOSKILLIT_TEMP}}/audit-bugs/` directory
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Use subagents heavily for parallel log analysis

--- a/src/autoskillit/skills_extended/audit-claims/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-claims/SKILL.md
@@ -46,6 +46,7 @@ comments and emits a verdict for recipe routing.
 - Modify any source code
 - Run deterministic diff annotation (claim positions are report-level, not line-level)
 - Generate findings for `experimental` claims — they are self-evidencing by definition
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Use the explicit `pr_url` argument instead of re-discovering via `gh pr list`

--- a/src/autoskillit/skills_extended/audit-cohesion/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-cohesion/SKILL.md
@@ -29,6 +29,7 @@ Audit the codebase for internal cohesion: how well components integrate and main
 - Modify any source code files
 - Update an existing report — always generate new
 - Duplicate findings that belong in audit-arch (rule violations)
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Use subagents for parallel exploration (one per cohesion dimension)

--- a/src/autoskillit/skills_extended/audit-defense-standards/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-defense-standards/SKILL.md
@@ -28,6 +28,7 @@ Standards are added here when `/autoskillit:design-guards` recommends them and t
 **NEVER:**
 - Modify any source code files
 - Update an existing report - always generate new
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Use subagents for parallel exploration (one per standard or group)

--- a/src/autoskillit/skills_extended/audit-docs/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-docs/SKILL.md
@@ -30,6 +30,7 @@ Audit all documentation sources for drift, staleness, and inconsistency against 
 - Modify any source files
 - Update an existing report — always generate a new one
 - Compare doc-to-doc without first grounding claims in actual code behavior
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Ground every cross-reference finding in what the code actually does (not what other docs say)

--- a/src/autoskillit/skills_extended/audit-feature-gates/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-feature-gates/SKILL.md
@@ -38,6 +38,7 @@ to enumerate features.
 - Create files outside `{{AUTOSKILLIT_TEMP}}/audit-feature-gates/`
 - Issue subagent Task calls sequentially — ALL 6 must be in a single parallel message
 - Write output files before synthesizing ALL subagent results
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Use `model: "sonnet"` when spawning all subagents via the Task tool

--- a/src/autoskillit/skills_extended/audit-friction/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-friction/SKILL.md
@@ -32,6 +32,7 @@ The user may provide a "since" date (e.g., `2/7`, `2026-02-07`, `last month`). I
 - Create files outside `{{AUTOSKILLIT_TEMP}}/audit-friction/` directory
 - Have subagents write files — they return all findings in response text only
 - Analyze subagent log subdirectories (`*/subagents/`) — top-level session files only
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Use subagents heavily for parallel log analysis

--- a/src/autoskillit/skills_extended/audit-impl/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-impl/SKILL.md
@@ -50,6 +50,7 @@ requirements, scope creep, and unexpected changes. Produces a GO or NO GO verdic
 - Run tests — this skill audits, it does not fix
 - Create files outside `{{AUTOSKILLIT_TEMP}}/audit-impl/`
 - Emit a GO verdict when any `MISSING` or `CONFLICT` finding exists
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Use Explore subagents for all file reads and diff retrieval

--- a/src/autoskillit/skills_extended/audit-tests/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-tests/SKILL.md
@@ -28,6 +28,7 @@ Audit the test suite to identify useless tests, consolidation opportunities, qua
 - Flag tests as useless without reading and understanding them
 - Recommend removing tests that guard against real regressions
 - Recommend changes that would reduce meaningful coverage
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Use subagents for parallel exploration

--- a/src/autoskillit/skills_extended/build-execution-map/SKILL.md
+++ b/src/autoskillit/skills_extended/build-execution-map/SKILL.md
@@ -41,6 +41,7 @@ Space-separated issue numbers (required, minimum 2), plus optional flags:
 - Use the `execution_map` or `execution_map_report` token names with unspaced `=` (always use `key = value` format)
 - Override the AI's parallelism judgment with mechanical rules
 - Assume issues conflict based solely on file-name overlap without reading the issue descriptions
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Use parallel subagents (up to 8) for issue fetching in Step 1

--- a/src/autoskillit/skills_extended/compose-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/compose-pr/SKILL.md
@@ -40,6 +40,7 @@ decomposed PR flow (prepare → run_arch_lenses → compose).
 - Fail the pipeline when `gh` is not accessible — emit `pr_url = ` (empty) and exit successfully
 - Create files outside `{{AUTOSKILLIT_TEMP}}/compose-pr/`
 - Invent mermaid classDef colors — when embedding validated diagrams, include them verbatim.
+- Run subagents in the background (`run_in_background: true` is prohibited)
   Using ONLY classDef styles from the mermaid skill (no invented colors).
 
 **ALWAYS:**

--- a/src/autoskillit/skills_extended/compose-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/compose-pr/SKILL.md
@@ -40,8 +40,8 @@ decomposed PR flow (prepare → run_arch_lenses → compose).
 - Fail the pipeline when `gh` is not accessible — emit `pr_url = ` (empty) and exit successfully
 - Create files outside `{{AUTOSKILLIT_TEMP}}/compose-pr/`
 - Invent mermaid classDef colors — when embedding validated diagrams, include them verbatim.
-- Run subagents in the background (`run_in_background: true` is prohibited)
   Using ONLY classDef styles from the mermaid skill (no invented colors).
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Check `gh auth status` before attempting GitHub operations

--- a/src/autoskillit/skills_extended/compose-research-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/compose-research-pr/SKILL.md
@@ -38,6 +38,7 @@ Does NOT invoke lens skills or other sub-skills.
 - Fail the pipeline when `gh` is not accessible — emit `pr_url = ` (empty string) and return
 - Create files outside `{{AUTOSKILLIT_TEMP}}/compose-research-pr/` (relative to the current working directory)
 - Invent mermaid classDef colors — when embedding validated diagrams, include them verbatim.
+- Run subagents in the background (`run_in_background: true` is prohibited)
   Using ONLY classDef styles from the mermaid skill when composing the PR body.
 
 **ALWAYS:**

--- a/src/autoskillit/skills_extended/compose-research-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/compose-research-pr/SKILL.md
@@ -38,8 +38,8 @@ Does NOT invoke lens skills or other sub-skills.
 - Fail the pipeline when `gh` is not accessible — emit `pr_url = ` (empty string) and return
 - Create files outside `{{AUTOSKILLIT_TEMP}}/compose-research-pr/` (relative to the current working directory)
 - Invent mermaid classDef colors — when embedding validated diagrams, include them verbatim.
-- Run subagents in the background (`run_in_background: true` is prohibited)
   Using ONLY classDef styles from the mermaid skill when composing the PR body.
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Check `gh auth status` before attempting GitHub operations

--- a/src/autoskillit/skills_extended/design-guards/SKILL.md
+++ b/src/autoskillit/skills_extended/design-guards/SKILL.md
@@ -30,6 +30,7 @@ Path to a bug pattern audit report (typically under `{{AUTOSKILLIT_TEMP}}/audit-
 - Modify any source code files
 - Propose bandaid fixes or direct-only patches
 - Create files outside `{{AUTOSKILLIT_TEMP}}/design-guards/` directory
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Use subagents for parallel codebase exploration

--- a/src/autoskillit/skills_extended/dry-walkthrough/SKILL.md
+++ b/src/autoskillit/skills_extended/dry-walkthrough/SKILL.md
@@ -45,6 +45,7 @@ The plan file must remain a **clean, self-contained implementation instruction s
 - Remove or defer goals or phases from the plan
 - Reduce the plan's scope to a "simpler fix" - the plan defines the problem scope, not you
 - Consider effort as a reason for choosing one approach over another
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Keep the plan as clean implementation instructions only (information/background helpful to implementation is okay)

--- a/src/autoskillit/skills_extended/elaborate-phase/SKILL.md
+++ b/src/autoskillit/skills_extended/elaborate-phase/SKILL.md
@@ -35,6 +35,7 @@ Elaborate a single phase from a high-level migration plan into a complete, self-
 - Elaborate multiple phases at once - one phase per invocation
 - Make assumptions about codebase state without verifying
 - Read previous `Phase#.md` files unless you have a specific question that requires looking up a detail
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Assess current codebase state with subagents FIRST

--- a/src/autoskillit/skills_extended/enrich-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/enrich-issues/SKILL.md
@@ -229,6 +229,7 @@ After processing all candidates, emit to stdout:
 - Skip the result block — always emit it, even on dry-run or when all issues were
   skipped
 - Use `--body` shell substitution (`--body "$(...)`) for `gh issue edit` — always write to
+- Run subagents in the background (`run_in_background: true` is prohibited)
   `{{AUTOSKILLIT_TEMP}}/enrich-issues/edit_body_{timestamp}.md` and use `--body-file`
 
 **ALWAYS:**

--- a/src/autoskillit/skills_extended/enrich-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/enrich-issues/SKILL.md
@@ -229,8 +229,8 @@ After processing all candidates, emit to stdout:
 - Skip the result block — always emit it, even on dry-run or when all issues were
   skipped
 - Use `--body` shell substitution (`--body "$(...)`) for `gh issue edit` — always write to
-- Run subagents in the background (`run_in_background: true` is prohibited)
   `{{AUTOSKILLIT_TEMP}}/enrich-issues/edit_body_{timestamp}.md` and use `--body-file`
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Respect `--dry-run`: never call `gh issue edit` when this flag is set

--- a/src/autoskillit/skills_extended/exp-lens-benchmark-representativeness/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-benchmark-representativeness/SKILL.md
@@ -43,6 +43,7 @@ hooks:
 - Modify any source code files
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-benchmark-representativeness/`
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Focus on GENERALIZATION GAP between benchmark coverage and claimed scope

--- a/src/autoskillit/skills_extended/exp-lens-causal-assumptions/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-causal-assumptions/SKILL.md
@@ -43,6 +43,7 @@ hooks:
 - Modify any source code files
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-causal-assumptions/`
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Classify every variable as Treatment, Outcome, Confounder, Mediator, Collider, Instrument, or Selection variable

--- a/src/autoskillit/skills_extended/exp-lens-comparator-construction/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-comparator-construction/SKILL.md
@@ -44,6 +44,7 @@ hooks:
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Accept at face value that baselines received symmetric treatment
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-comparator-construction/`
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Build a fairness matrix covering all treatment-vs-comparator pairs

--- a/src/autoskillit/skills_extended/exp-lens-error-budget/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-error-budget/SKILL.md
@@ -44,6 +44,7 @@ hooks:
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Accept default alpha=0.05 without checking whether it is appropriate for the decision context
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-error-budget/`
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Enumerate every statistical test and account for its error contribution

--- a/src/autoskillit/skills_extended/exp-lens-estimand-clarity/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-estimand-clarity/SKILL.md
@@ -43,6 +43,7 @@ hooks:
 - Modify any source code or experiment files
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-estimand-clarity/`
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Decompose every stated claim into formal contrast notation (Treatment A vs Treatment B on Outcome Y in Population Z)

--- a/src/autoskillit/skills_extended/exp-lens-exploratory-confirmatory/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-exploratory-confirmatory/SKILL.md
@@ -42,6 +42,7 @@ hooks:
 **NEVER:**
 - Modify any source code files
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-exploratory-confirmatory/`
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Map the full analytic timeline — what was decided before vs. after seeing data

--- a/src/autoskillit/skills_extended/exp-lens-fair-comparison/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-fair-comparison/SKILL.md
@@ -43,6 +43,7 @@ hooks:
 - Modify any source code files
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-fair-comparison/`
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Build the full symmetry matrix — every method against every resource dimension

--- a/src/autoskillit/skills_extended/exp-lens-governance-risk/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-governance-risk/SKILL.md
@@ -42,6 +42,7 @@ hooks:
 **NEVER:**
 - Modify any source code files
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-governance-risk/`
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Identify subgroups for whom the experimental evidence may not generalize

--- a/src/autoskillit/skills_extended/exp-lens-iterative-learning/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-iterative-learning/SKILL.md
@@ -43,6 +43,7 @@ hooks:
 - Modify any source code files
 - Recommend one-factor-at-a-time exploration when interactions are plausible
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-iterative-learning/`
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Evaluate exploration efficiency against the key uncertainty being reduced

--- a/src/autoskillit/skills_extended/exp-lens-measurement-validity/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-measurement-validity/SKILL.md
@@ -43,6 +43,7 @@ hooks:
 - Modify any source code or experimental artifacts
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-measurement-validity/`
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Treat every reported metric as a claim requiring a validity argument

--- a/src/autoskillit/skills_extended/exp-lens-pipeline-integrity/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-pipeline-integrity/SKILL.md
@@ -43,6 +43,7 @@ hooks:
 - Modify any source code files
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-pipeline-integrity/`
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Classify every pipeline stage as pre-split or post-split

--- a/src/autoskillit/skills_extended/exp-lens-randomization-blocking/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-randomization-blocking/SKILL.md
@@ -43,6 +43,7 @@ hooks:
 - Modify any source code files
 - Assume comparability without tracing its source
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-randomization-blocking/`
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Trace the exact mechanism that creates comparability between treatment groups

--- a/src/autoskillit/skills_extended/exp-lens-reproducibility-artifacts/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-reproducibility-artifacts/SKILL.md
@@ -43,6 +43,7 @@ hooks:
 - Modify any source code files
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-reproducibility-artifacts/`
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Trace the full chain from "clone repo" to "reproduce figures"

--- a/src/autoskillit/skills_extended/exp-lens-sensitivity-robustness/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-sensitivity-robustness/SKILL.md
@@ -44,6 +44,7 @@ hooks:
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Treat "untested" as equivalent to "robust"
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-sensitivity-robustness/`
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Build a full sensitivity matrix (choices x perturbation types)

--- a/src/autoskillit/skills_extended/exp-lens-severity-testing/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-severity-testing/SKILL.md
@@ -42,6 +42,7 @@ hooks:
 - Modify any source code files
 - Accept a "pass" result without asking what a false result would have looked like under this design
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-severity-testing/`
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - For every positive claim, identify what error the test was capable of detecting

--- a/src/autoskillit/skills_extended/exp-lens-unit-interference/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-unit-interference/SKILL.md
@@ -43,6 +43,7 @@ hooks:
 - Modify any source code files
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-unit-interference/`
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Focus on the unit definition and whether SUTVA is plausible

--- a/src/autoskillit/skills_extended/exp-lens-validity-threats/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-validity-threats/SKILL.md
@@ -42,6 +42,7 @@ hooks:
 **NEVER:**
 - Modify any source code files
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-validity-threats/`
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Apply Campbell & Stanley's full threat taxonomy — do not skip threats just because they seem unlikely

--- a/src/autoskillit/skills_extended/exp-lens-variance-stability/SKILL.md
+++ b/src/autoskillit/skills_extended/exp-lens-variance-stability/SKILL.md
@@ -43,6 +43,7 @@ hooks:
 - Modify any source code files
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
 - Create files outside `{{AUTOSKILLIT_TEMP}}/exp-lens-variance-stability/`
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Count the actual number of independent runs — single-run results must be flagged prominently

--- a/src/autoskillit/skills_extended/generate-report/SKILL.md
+++ b/src/autoskillit/skills_extended/generate-report/SKILL.md
@@ -61,6 +61,7 @@ In addition to the arguments above, this skill reads from the worktree:
 - Omit the methodology section — reproducibility requires it
 - Frame inconclusive results as failures — they are valid findings
 - Create the report outside the worktree's `research/` directory
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Use `model: "sonnet"` when spawning all subagents via the Task tool

--- a/src/autoskillit/skills_extended/implement-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-experiment/SKILL.md
@@ -49,8 +49,8 @@ tokens after the skill name for the first path-like token (starts with `/`,
   (the orchestrator handles full test execution via test_check)
 - Create experiment files outside the planned `research/` subfolder
 - Execute `git merge` commands (all branch content must be applied via
-- Run subagents in the background (`run_in_background: true` is prohibited)
   `git cherry-pick` or `git checkout <branch> -- <file>`)
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Create a new worktree from the current branch

--- a/src/autoskillit/skills_extended/implement-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-experiment/SKILL.md
@@ -49,6 +49,7 @@ tokens after the skill name for the first path-like token (starts with `/`,
   (the orchestrator handles full test execution via test_check)
 - Create experiment files outside the planned `research/` subfolder
 - Execute `git merge` commands (all branch content must be applied via
+- Run subagents in the background (`run_in_background: true` is prohibited)
   `git cherry-pick` or `git checkout <branch> -- <file>`)
 
 **ALWAYS:**

--- a/src/autoskillit/skills_extended/implement-worktree-no-merge/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-worktree-no-merge/SKILL.md
@@ -39,6 +39,7 @@ The worktree is left intact for the orchestrator to test and merge separately.
 - Re-run tests just to see failures — grep the saved output file instead
 - Pipe test output through `tail`, `head`, or other truncation commands
 - **Execute `git merge` commands** (including `--no-ff`, `--no-commit`, or any variant). All branch content must be applied via `git cherry-pick <commit>` for individual commits or `git checkout <branch> -- <file>` for specific files. `merge_worktree` requires linear commit history — merge commits cannot be rebased and will cause `WORKTREE_INTACT_MERGE_COMMITS_DETECTED` failure.
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Create a new worktree from the current branch

--- a/src/autoskillit/skills_extended/implement-worktree/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-worktree/SKILL.md
@@ -33,6 +33,7 @@ Implement a provided plan in an isolated git worktree branched from the current 
 - Consider implementation complete if ANY test fails
 - Blame test failures on "pre-existing issues" — ALL tests must pass
 - Re-run tests just to see failures — grep the saved output file instead
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Create a new worktree from the current branch

--- a/src/autoskillit/skills_extended/investigate/SKILL.md
+++ b/src/autoskillit/skills_extended/investigate/SKILL.md
@@ -73,6 +73,7 @@ tool **before** beginning any analysis. Use the returned `content` field as the 
 - Create files outside `{{AUTOSKILLIT_TEMP}}/investigate/` directory
 - Choose or accept approaches, solutions, and/or fixes that are chosen simply because they are easier
 - File GitHub issues automatically (issue filing is always a separate, user-directed action)
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Use subagents for parallel exploration

--- a/src/autoskillit/skills_extended/make-groups/SKILL.md
+++ b/src/autoskillit/skills_extended/make-groups/SKILL.md
@@ -57,6 +57,7 @@ tool **before** beginning any analysis. Use the returned `content` field as the 
 - Drop, split, or rewrite requirements — reference them by original ID
 - Create groups that cannot be independently planned
 - Include implementation steps or technical approach in the group descriptions
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Use subagents to verify codebase structure before finalizing groups

--- a/src/autoskillit/skills_extended/make-plan/SKILL.md
+++ b/src/autoskillit/skills_extended/make-plan/SKILL.md
@@ -203,6 +203,7 @@ Before writing the final plan, verify:
 - Reject an approach because it's harder
 - Create files outside `{{AUTOSKILLIT_TEMP}}/make-plan/` directory
 - **Use `git merge` in implementation plans.** When a plan needs to bring in changes from another branch, use `git cherry-pick <commit>` for individual commits or `git checkout <branch> -- <file>` for specific files. `merge_worktree` requires linear commit history — merge commits cannot be rebased and will cause `WORKTREE_INTACT_MERGE_COMMITS_DETECTED` failure. See "Conflict-Resolution Plan Requirements" section for full guidance.
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Write to `{{AUTOSKILLIT_TEMP}}/make-plan/` directory (relative to the current working directory)

--- a/src/autoskillit/skills_extended/make-req/SKILL.md
+++ b/src/autoskillit/skills_extended/make-req/SKILL.md
@@ -35,6 +35,7 @@ Decompose a task, plan, roadmap, or feature description into a structured set of
 - Prescribe implementation approaches or libraries in requirements
 - Include implementation steps disguised as requirements ("Refactor X to use Y" is an instruction, not a requirement)
 - Write requirements that can only be verified by reading source code
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Use subagents to understand the source material and relevant codebase context

--- a/src/autoskillit/skills_extended/merge-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/merge-pr/SKILL.md
@@ -39,6 +39,7 @@ conflicts from earlier merges in the queue.
 - Close or comment on the PR
 - Leave the git working tree in a dirty state
 - Create files outside `{{AUTOSKILLIT_TEMP}}/merge-prs/` directory
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Run `git status` before any operation to verify clean state

--- a/src/autoskillit/skills_extended/open-integration-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/open-integration-pr/SKILL.md
@@ -50,6 +50,7 @@ PR, and output `pr_url=<url>`.
 - Modify any source code
 - Fail the pipeline if `gh` is unavailable or not authenticated — output `pr_url=` (empty) and exit successfully
 - Close original PRs before the integration PR is successfully created
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Check `gh auth status` before attempting any GitHub operations

--- a/src/autoskillit/skills_extended/plan-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/plan-experiment/SKILL.md
@@ -53,6 +53,7 @@ incorporate the feedback before writing the plan.
   environment is needed or not, and why
 - Omit YAML frontmatter unless a V1–V4 ERROR is triggered — every plan must have frontmatter
 - Write frontmatter after the `# Experiment Plan:` heading — it always goes BEFORE
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Use `model: "sonnet"` when spawning all subagents via the Task tool

--- a/src/autoskillit/skills_extended/plan-visualization/SKILL.md
+++ b/src/autoskillit/skills_extended/plan-visualization/SKILL.md
@@ -36,6 +36,7 @@ outputs, and synthesizes a complete visualization plan.
 - Run vis-lens calls across multiple assistant messages — all selected lens calls must
   appear in a SINGLE assistant message to execute in parallel
 - Write outputs outside `{{AUTOSKILLIT_TEMP}}/plan-visualization/`
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Use `model: "sonnet"` when spawning all subagents via the Task tool

--- a/src/autoskillit/skills_extended/planner-analyze/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-analyze/SKILL.md
@@ -29,6 +29,7 @@ Detect language, framework, test infrastructure, project structure, and existing
 **NEVER:**
 - Modify any target project files
 - Write analysis.json outside `$1/`
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Use Explore subagents for all file reads

--- a/src/autoskillit/skills_extended/planner-elaborate-assignments/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-assignments/SKILL.md
@@ -33,6 +33,7 @@ is the sole writer for this phase's assignments — no concurrent write races.
 - Read `{{AUTOSKILLIT_TEMP}}` artifacts outside your designated input files and output directory
 - Explore parent directories of your input paths (e.g., `ls $(dirname $1)/..`)
 - Read result files from other phases
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Spawn all L0 subagents in parallel using the native Agent/Task tool (NOT run_skill — leaf guard blocks it)

--- a/src/autoskillit/skills_extended/planner-elaborate-phase/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-phase/SKILL.md
@@ -39,6 +39,7 @@ independently and writes a single elaborated phase result. No dependency on
 - Communicate with other parallel worker instances
 - Read `{{AUTOSKILLIT_TEMP}}` artifacts outside your designated input files and output directory
 - Explore parent directories of your input paths (e.g., `ls $(dirname $1)/..`)
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Derive `relationship_notes` from snapshot context + codebase analysis, NOT from prior result files

--- a/src/autoskillit/skills_extended/planner-elaborate-wps/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-wps/SKILL.md
@@ -34,6 +34,7 @@ is the sole writer for this phase's WPs — no concurrent write races.
 - Read `{{AUTOSKILLIT_TEMP}}` artifacts outside your designated input files and output directory
 - Explore parent directories of your input paths (e.g., `ls $(dirname $1)/..`)
 - Read result files from other phases
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Spawn all L0 subagents in parallel using the native Agent/Task tool (NOT run_skill — leaf guard blocks it)

--- a/src/autoskillit/skills_extended/planner-extract-domain/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-extract-domain/SKILL.md
@@ -30,6 +30,7 @@ Extract domain knowledge, naming conventions, and structural patterns specific t
 **NEVER:**
 - Modify any target project files
 - Abort the calling recipe on failure — log a warning and return gracefully
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Read the analysis file from the path in the PLANNER_ANALYSIS_FILE environment variable before spawning subagents

--- a/src/autoskillit/skills_extended/planner-refine-assignments/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine-assignments/SKILL.md
@@ -43,6 +43,7 @@ cross-assignment WP ownership conflicts, applies field-level edits, and writes
 - Skip emitting `refined_assignments_path` even if all L0s fail (write unchanged assignments, still emit)
 - Spawn more than 6 L0s in a single parallel batch
 - Read `{{AUTOSKILLIT_TEMP}}` artifacts not passed as positional arguments
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Validate each L0 response for `assignment_id`, `changes` (array), `dependency_corrections` (array), `wp_proposal_adjustments` (array)

--- a/src/autoskillit/skills_extended/planner-refine-phases/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine-phases/SKILL.md
@@ -39,6 +39,7 @@ conflicts, applies field-level edits to the plan, and writes `refined_plan.json`
 - Emit `refined_plan_path` before writing `refined_plan.json`
 - Skip emitting `refined_plan_path` even if all L0s fail (write unchanged plan, still emit)
 - Read `{{AUTOSKILLIT_TEMP}}` artifacts not passed as positional arguments
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Validate each L0 response for `phase_id`, `changes` (array), `conflicts` (array)

--- a/src/autoskillit/skills_extended/planner-refine-wps/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine-wps/SKILL.md
@@ -45,6 +45,7 @@ suggestions, resolves conflicts, and writes `refined_wps.json`.
 - Spawn more than 6 L0s in a single parallel batch
 - Spawn one L0 per WP — L0s operate per PHASE
 - Read `{{AUTOSKILLIT_TEMP}}` artifacts not passed as positional arguments
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Spawn one L0 per phase (NOT per WP) — each L0 reviews ALL WPs in its phase against the full WP set

--- a/src/autoskillit/skills_extended/planner-validate-task-alignment/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-validate-task-alignment/SKILL.md
@@ -31,6 +31,7 @@ zero findings.
 - Write output outside `$3/`
 - Read files not passed as arguments
 - Modify input files
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Read the `task` field from $1 or $2

--- a/src/autoskillit/skills_extended/prepare-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/prepare-pr/SKILL.md
@@ -39,6 +39,7 @@ in the decomposed PR flow (prepare → run_arch_lenses → compose).
 - Invoke arch-lens skills or any other sub-skills
 - Create files outside `{{AUTOSKILLIT_TEMP}}/prepare-pr/`
 - Fail if closing_issue is absent or gh is unavailable — degrade gracefully
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Emit all three output tokens (`prep_path`, `selected_lenses`, `lens_context_paths`)

--- a/src/autoskillit/skills_extended/prepare-research-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/prepare-research-pr/SKILL.md
@@ -36,6 +36,7 @@ Does NOT invoke any exp-lens skills or create a PR.
 - Invoke exp-lens skills — they are run in separate sessions by the recipe orchestrator
 - Create files outside `{{AUTOSKILLIT_TEMP}}/prepare-research-pr/` (relative to the current working directory)
 - Fail silently — always emit all three output tokens as your final output
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Use Agent subagents (not slash commands) for reading and synthesis

--- a/src/autoskillit/skills_extended/process-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/process-issues/SKILL.md
@@ -31,6 +31,7 @@ issues upfront, load recipe, execute session, collect result, report.
   in the manifest JSON, not on GitHub objects)
 - Modify any source code files
 - Reimplement recipe steps inline — always use `load_recipe` to load the recipe YAML and
+- Run subagents in the background (`run_in_background: true` is prohibited)
   follow it as an orchestrator
 
 **ALWAYS:**

--- a/src/autoskillit/skills_extended/process-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/process-issues/SKILL.md
@@ -31,8 +31,8 @@ issues upfront, load recipe, execute session, collect result, report.
   in the manifest JSON, not on GitHub objects)
 - Modify any source code files
 - Reimplement recipe steps inline — always use `load_recipe` to load the recipe YAML and
-- Run subagents in the background (`run_in_background: true` is prohibited)
   follow it as an orchestrator
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Process batches in ascending order: batch 1 before batch 2 before batch 3

--- a/src/autoskillit/skills_extended/promote-to-main/SKILL.md
+++ b/src/autoskillit/skills_extended/promote-to-main/SKILL.md
@@ -41,6 +41,7 @@ and creates a comprehensive promotion PR.
 - Skip pre-flight checks — a failing pre-flight must block PR creation
 - Use the Bash tool for file reads — use Read, Grep, Glob for all codebase inspection
 - Use `gh pr create --body` inline — always use `--body-file`
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Run ALL pre-flight checks before any analysis work

--- a/src/autoskillit/skills_extended/rectify/SKILL.md
+++ b/src/autoskillit/skills_extended/rectify/SKILL.md
@@ -38,6 +38,7 @@ Do not change any code.
 - Propose bandaid fixes, fallbacks, or direct-only fixes
 - Suggest backward compatibility shims
 - Create files outside `{{AUTOSKILLIT_TEMP}}/rectify/` directory
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Use subagents for parallel exploration

--- a/src/autoskillit/skills_extended/resolve-claims-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-claims-review/SKILL.md
@@ -45,6 +45,7 @@ Called by the research recipe when `audit_claims` routes `changes_requested` via
 - Delete or discard the working directory on failure
 - Modify tests to suppress failures introduced by reviewer fixes
 - Use file-path-segment grouping — claim comments are grouped by **dimension**, not by file path
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Find the PR by feature branch at invocation time (not a hardcoded number)

--- a/src/autoskillit/skills_extended/resolve-design-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-design-review/SKILL.md
@@ -38,6 +38,7 @@ MCP-only — not user-invocable directly.
 - Create files outside `{{AUTOSKILLIT_TEMP}}/resolve-design-review/`
 - Modify the evaluation dashboard, experiment plan, or any source file
 - Apply fixes — this skill triages fixability only
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Exit 0 in all cases — resolution=revised and resolution=failed are both normal outcomes

--- a/src/autoskillit/skills_extended/resolve-research-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-research-review/SKILL.md
@@ -44,6 +44,7 @@ Bounded by `retries: 2` — on exhaustion routes to `research_complete`.
 - Delete or discard the working directory on failure
 - Modify tests to suppress failures introduced by reviewer fixes
 - Use file-path-segment grouping — research comments are grouped by **dimension**, not by file path
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Find the PR by feature branch at invocation time (not a hardcoded number)

--- a/src/autoskillit/skills_extended/resolve-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-review/SKILL.md
@@ -41,6 +41,7 @@ branch already checked out.
 - Exceed 3 fix-and-retest iterations
 - Delete or discard the working directory on failure
 - Modify tests to suppress failures introduced by reviewer fixes
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Find the PR by feature branch at invocation time (not a hardcoded number)

--- a/src/autoskillit/skills_extended/retry-worktree/SKILL.md
+++ b/src/autoskillit/skills_extended/retry-worktree/SKILL.md
@@ -42,6 +42,7 @@ Continue implementing a plan in an **existing** git worktree. This skill is used
 - Re-run tests just to see failures — grep the saved output file instead
 - Pipe test output through `tail`, `head`, or other truncation commands — `tail -N` buffers the entire stream and produces no output if the process is killed before EOF
 - Default to `main` as the base branch — always discover it from git's upstream structure or the explicit base-branch store file
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Use the provided worktree path (do NOT create a new one)

--- a/src/autoskillit/skills_extended/review-approach/SKILL.md
+++ b/src/autoskillit/skills_extended/review-approach/SKILL.md
@@ -26,6 +26,7 @@ Research modern solutions, approaches, and strategies relevant to the issues or 
 **NEVER:**
 - Modify any source code files
 - Create files outside `{{AUTOSKILLIT_TEMP}}/review-approach/` directory
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Use subagents with web search for parallel research

--- a/src/autoskillit/skills_extended/review-design/SKILL.md
+++ b/src/autoskillit/skills_extended/review-design/SKILL.md
@@ -43,6 +43,7 @@ best available plan.
 - Exit non-zero — GO, REVISE, and STOP are all normal outcomes (exit 0 in all cases)
 - Include code snippets, shell commands, or specific tool invocations in findings or revision guidance — findings describe gaps and risks, not implementation instructions
 - Prescribe HOW to fix an issue — findings must describe WHAT is lacking or at risk; the fix is the plan author's responsibility
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Use `model: "sonnet"` when spawning all subagents via the Task tool

--- a/src/autoskillit/skills_extended/review-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/review-pr/SKILL.md
@@ -39,6 +39,7 @@ by the recipe pipeline after `open_pr_step` opens the PR.
 - Post review comments when `gh` is unavailable — output `verdict=approved` and exit 0
 - Review files outside the PR diff — scope all audit to diff content only
 - Modify any source code
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Find the PR by feature branch at invocation time (not from a pre-captured URL)

--- a/src/autoskillit/skills_extended/review-research-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/review-research-pr/SKILL.md
@@ -40,8 +40,8 @@ a summary verdict. Called by the recipe pipeline after `open_research_pr` opens 
 - Review files outside the PR diff — scope all audit to diff content only
 - Modify any source code
 - Flag the absence of a clear experimental conclusion as a deficiency — inconclusive
-- Run subagents in the background (`run_in_background: true` is prohibited)
   results are valid outcomes for research PRs (do not flag them)
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Find the PR by feature branch at invocation time (not from a pre-captured URL)

--- a/src/autoskillit/skills_extended/review-research-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/review-research-pr/SKILL.md
@@ -40,6 +40,7 @@ a summary verdict. Called by the recipe pipeline after `open_research_pr` opens 
 - Review files outside the PR diff — scope all audit to diff content only
 - Modify any source code
 - Flag the absence of a clear experimental conclusion as a deficiency — inconclusive
+- Run subagents in the background (`run_in_background: true` is prohibited)
   results are valid outcomes for research PRs (do not flag them)
 
 **ALWAYS:**

--- a/src/autoskillit/skills_extended/run-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/run-experiment/SKILL.md
@@ -49,6 +49,7 @@ plan, executes what the plan describes, and reports what happened.
 - Skip result collection — every run must produce structured output
 - Assume what kind of experiment this is — read the plan and follow it
 - Commit files under `{{AUTOSKILLIT_TEMP}}/` — this directory is gitignored working space, NOT for version control. Do not use `git add -f` or `git add --force` to bypass the gitignore.
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Use `model: "sonnet"` when spawning all subagents via the Task tool

--- a/src/autoskillit/skills_extended/scope/SKILL.md
+++ b/src/autoskillit/skills_extended/scope/SKILL.md
@@ -48,6 +48,7 @@ text is supplementary context.
 - Create files outside `{{AUTOSKILLIT_TEMP}}/scope/` directory
 - Propose solutions or write implementation code
 - Skip the prior art survey — always check what already exists in the codebase
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Use `model: "sonnet"` when spawning all subagents via the Task tool

--- a/src/autoskillit/skills_extended/setup-project/SKILL.md
+++ b/src/autoskillit/skills_extended/setup-project/SKILL.md
@@ -40,6 +40,7 @@ Explore a target project and generate tailored recipes and AutoSkillit config th
 - Suggest `reset_guard_marker` config — that's a workspace concern, not project setup
 - Include install instructions or "Getting Started" sections — user is already running the skill
 - Hardcode `base_branch = main` — detect the current branch
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Read the target project using Glob, Read, and Grep — no shell commands against target

--- a/src/autoskillit/skills_extended/stage-data/SKILL.md
+++ b/src/autoskillit/skills_extended/stage-data/SKILL.md
@@ -46,6 +46,7 @@ compute on doomed downloads.
 - Modify any source files
 - Write files outside `{{AUTOSKILLIT_TEMP}}/stage-data/`
 - Emit a WARN or FAIL verdict without a specific, actionable explanation
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Read the `data_manifest` frontmatter section of the experiment plan

--- a/src/autoskillit/skills_extended/triage-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/triage-issues/SKILL.md
@@ -33,6 +33,7 @@ Analyze open GitHub issues, classify each into a recipe route, group them into p
 - Add useless comments to the codebase — do not use the codebase as a notepad
 - Create files outside `{{AUTOSKILLIT_TEMP}}/triage-issues/` directory
 - Use `--body` shell substitution (`--body "$(...)`) for `gh issue edit` — always write to
+- Run subagents in the background (`run_in_background: true` is prohibited)
   `{{AUTOSKILLIT_TEMP}}/triage-issues/edit_body_{timestamp}.md` and use `--body-file`
 
 **ALWAYS:**

--- a/src/autoskillit/skills_extended/triage-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/triage-issues/SKILL.md
@@ -33,8 +33,8 @@ Analyze open GitHub issues, classify each into a recipe route, group them into p
 - Add useless comments to the codebase — do not use the codebase as a notepad
 - Create files outside `{{AUTOSKILLIT_TEMP}}/triage-issues/` directory
 - Use `--body` shell substitution (`--body "$(...)`) for `gh issue edit` — always write to
-- Run subagents in the background (`run_in_background: true` is prohibited)
   `{{AUTOSKILLIT_TEMP}}/triage-issues/edit_body_{timestamp}.md` and use `--body-file`
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Use `model: "sonnet"` when spawning all subagents via the Task tool

--- a/src/autoskillit/skills_extended/validate-audit/SKILL.md
+++ b/src/autoskillit/skills_extended/validate-audit/SKILL.md
@@ -46,6 +46,7 @@ subagents. Contested findings are separated into their own file. The validated r
 - Write output files before synthesizing ALL subagent results
 - Subagents must NOT create their own files — they return findings in response text only
 - Do NOT include VALID BUT EXCEPTION WARRANTED findings in the validated report body — they belong in the validation summary only
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Use `model: "sonnet"` when spawning all subagents via the Task tool

--- a/src/autoskillit/skills_extended/verify-diag/SKILL.md
+++ b/src/autoskillit/skills_extended/verify-diag/SKILL.md
@@ -26,6 +26,7 @@ Verify an architecture diagram's factual accuracy against the actual codebase. A
 **NEVER:**
 - Modify source code files
 - Modify the diagram during verification (report findings only)
+- Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
 - Verify every named component exists in the codebase

--- a/tests/docs/test_filename_naming.py
+++ b/tests/docs/test_filename_naming.py
@@ -15,7 +15,12 @@ KEBAB_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*\.md$")
 # Files allow-listed against specific rules. Each entry: rule -> {filenames}.
 ALLOWLIST = {
     "ing_suffix": {"getting-started.md", "contributing.md", "authoring.md"},
-    "segment_count": {"getting-started.md", "end-turn-hazards.md", "research-pipeline.md"},
+    "segment_count": {
+        "getting-started.md",
+        "end-turn-hazards.md",
+        "research-pipeline.md",
+        "0001-prohibit-background-subagent-execution.md",
+    },
 }
 
 # overrides.md is a list-like file (collection of override sites) and is exempt;

--- a/tests/execution/test_process_channel_b.py
+++ b/tests/execution/test_process_channel_b.py
@@ -112,6 +112,7 @@ PROCESS_EXIT_THEN_CHANNEL_B_FIRES_SCRIPT = textwrap.dedent("""\
 """)
 
 
+@pytest.mark.timeout(180)
 class TestChannelBDrainWait:
     """Channel B (session monitor) winning before Channel A triggers bounded drain wait."""
 
@@ -434,6 +435,7 @@ class TestNaturalExitWithChannelConfirmation:
         assert skill_result.needs_retry is False
 
 
+@pytest.mark.timeout(180)
 class TestPostExitDrainWindow:
     """Symmetric drain window: process exits first, Channel B gets a bounded window to deposit."""
 

--- a/tests/execution/test_process_channel_b.py
+++ b/tests/execution/test_process_channel_b.py
@@ -112,10 +112,10 @@ PROCESS_EXIT_THEN_CHANNEL_B_FIRES_SCRIPT = textwrap.dedent("""\
 """)
 
 
-@pytest.mark.timeout(180)
 class TestChannelBDrainWait:
     """Channel B (session monitor) winning before Channel A triggers bounded drain wait."""
 
+    @pytest.mark.timeout(90)
     @pytest.mark.anyio
     async def test_channel_b_wins_then_channel_a_confirms_within_drain(self, tmp_path):
         """Channel B fires first; drain wait allows Channel A to confirm stdout data.
@@ -152,6 +152,7 @@ class TestChannelBDrainWait:
         # Drain wait confirmed Channel A fired: stdout is non-empty
         assert result.stdout.strip()
 
+    @pytest.mark.timeout(90)
     @pytest.mark.anyio
     async def test_channel_b_wins_drain_timeout_still_kills(self, tmp_path):
         """Channel B fires; Channel A never fires; drain times out and process is killed.
@@ -193,6 +194,7 @@ class TestChannelBDrainWait:
         # Drain timed out: CLI hung and never flushed its result record
         assert not result.stdout.strip()
 
+    @pytest.mark.timeout(90)
     @pytest.mark.anyio
     async def test_channel_a_wins_unchanged_behavior(self, tmp_path):
         """Channel A (heartbeat) wins before any session monitor: no drain wait needed.
@@ -216,6 +218,7 @@ class TestChannelBDrainWait:
         assert result.termination == TerminationReason.COMPLETED
         assert result.stdout.strip()  # Channel A confirmed: stdout is non-empty
 
+    @pytest.mark.timeout(90)
     @pytest.mark.anyio
     async def test_data_confirmed_false_set_on_drain_timeout(self, tmp_path):
         """Channel B wins the race; drain timeout expires without Channel A confirming.
@@ -252,6 +255,7 @@ class TestChannelBDrainWait:
         assert result.termination == TerminationReason.COMPLETED
         assert result.channel_confirmation == ChannelConfirmation.CHANNEL_B
 
+    @pytest.mark.timeout(90)
     @pytest.mark.anyio
     async def test_data_confirmed_true_when_channel_a_wins(self, tmp_path):
         """Channel A (heartbeat) wins; data_confirmed must be True.
@@ -273,6 +277,7 @@ class TestChannelBDrainWait:
         assert result.termination == TerminationReason.COMPLETED
         assert result.channel_confirmation == ChannelConfirmation.CHANNEL_A
 
+    @pytest.mark.timeout(90)
     @pytest.mark.anyio
     async def test_channel_b_then_a_empty_result_data_confirmed_is_false(self, tmp_path):
         """Channel B fires (%%ORDER_UP%% in JSONL).
@@ -435,10 +440,10 @@ class TestNaturalExitWithChannelConfirmation:
         assert skill_result.needs_retry is False
 
 
-@pytest.mark.timeout(180)
 class TestPostExitDrainWindow:
     """Symmetric drain window: process exits first, Channel B gets a bounded window to deposit."""
 
+    @pytest.mark.timeout(120)
     @pytest.mark.anyio
     async def test_drain_window_allows_channel_b_to_deposit(self, tmp_path):
         """Process exits before Phase 1 polls; drain window lets Channel B detect marker.
@@ -481,6 +486,7 @@ class TestPostExitDrainWindow:
 
         assert result.channel_confirmation == ChannelConfirmation.CHANNEL_B
 
+    @pytest.mark.timeout(30)
     @pytest.mark.anyio
     async def test_drain_window_times_out_when_no_session_jsonl(self, tmp_path):
         """Process exits with no session JSONL; drain window times out, UNMONITORED preserved.

--- a/tests/skills/test_skill_compliance.py
+++ b/tests/skills/test_skill_compliance.py
@@ -351,3 +351,39 @@ For each issue in the batch (process sequentially):
 """
     violations = _check_loop_boundary(vulnerable_pattern)
     assert len(violations) >= 1, "Detector failed to catch unguarded MCP loop"
+
+
+# Detects skills that instruct Agent/Task subagent spawning.
+# Any such skill MUST contain the run_in_background prohibition.
+_SPAWN_INDICATOR_RE = re.compile(
+    r"Task tool|Explore subagent|Agent/Task tool"
+    r"|spawn.*subagent|subagent.*spawn"
+    r"|parallel.*subagent|subagent.*parallel",
+    re.IGNORECASE,
+)
+_BACKGROUND_PROHIBITION_RE = re.compile(r"run_in_background", re.IGNORECASE)
+
+# Skills whose SKILL.md mentions subagents only in a negative/prohibitive context
+# (e.g., "rather than spawning subagents", "do not spawn subagents"). The spawn
+# indicator regex matches these descriptively — they are not spawning skills.
+_NON_SPAWNING_SKILL_DIRS: frozenset[str] = frozenset(
+    {
+        "report-bug",  # "rather than spawning parallel subagents" — describes non-spawning
+        "issue-splitter",  # "do not spawn subagents" — prohibits spawning inline
+    }
+)
+
+
+@pytest.mark.parametrize("skill_dir", _all_skill_dirs(), ids=lambda p: p.name)
+def test_no_background_subagent_in_spawning_skills(skill_dir: Path) -> None:
+    if skill_dir.name in _NON_SPAWNING_SKILL_DIRS:
+        return  # Skill mentions subagents only descriptively/negatively — rule does not apply.
+    content = (skill_dir / "SKILL.md").read_text()
+    if not _SPAWN_INDICATOR_RE.search(content):
+        return  # Skill does not spawn subagents — rule does not apply.
+    assert _BACKGROUND_PROHIBITION_RE.search(content), (
+        f"{skill_dir.name}/SKILL.md contains subagent-spawning instructions "
+        "but lacks the background-execution prohibition. "
+        "Add to its NEVER block: "
+        "'- Run subagents in the background (`run_in_background: true` is prohibited)'"
+    )

--- a/tests/skills/test_skill_compliance.py
+++ b/tests/skills/test_skill_compliance.py
@@ -356,12 +356,12 @@ For each issue in the batch (process sequentially):
 # Detects skills that instruct Agent/Task subagent spawning.
 # Any such skill MUST contain the run_in_background prohibition.
 _SPAWN_INDICATOR_RE = re.compile(
-    r"Task tool|Explore subagent|Agent/Task tool"
-    r"|spawn.*subagent|subagent.*spawn"
+    r"Task tool|Explore subagent"
+    r"|spawn.*subagent|subagent.*spawn|launch.*subagent"
     r"|parallel.*subagent|subagent.*parallel",
     re.IGNORECASE,
 )
-_BACKGROUND_PROHIBITION_RE = re.compile(r"run_in_background", re.IGNORECASE)
+_BACKGROUND_PROHIBITION_RE = re.compile(r"run_in_background.*prohibited", re.IGNORECASE)
 
 # Skills whose SKILL.md mentions subagents only in a negative/prohibitive context
 # (e.g., "rather than spawning subagents", "do not spawn subagents"). The spawn
@@ -378,7 +378,10 @@ _NON_SPAWNING_SKILL_DIRS: frozenset[str] = frozenset(
 def test_no_background_subagent_in_spawning_skills(skill_dir: Path) -> None:
     if skill_dir.name in _NON_SPAWNING_SKILL_DIRS:
         return  # Skill mentions subagents only descriptively/negatively — rule does not apply.
-    content = (skill_dir / "SKILL.md").read_text()
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.exists():
+        return
+    content = skill_md.read_text(encoding="utf-8")
     if not _SPAWN_INDICATOR_RE.search(content):
         return  # Skill does not spawn subagents — rule does not apply.
     assert _BACKGROUND_PROHIBITION_RE.search(content), (


### PR DESCRIPTION
## Summary

Formalize the prohibition on background subagent execution (`run_in_background: true`) across all skill SKILL.md files that instruct Agent/Task tool spawning. Three deliverables:

1. **ADR document** — `docs/decisions/0001-prohibit-background-subagent-execution.md` establishing the design constraint.
2. **Skill file updates** — Add one NEVER bullet to each of the 54 affected SKILL.md files.
3. **Compliance test** — Add `test_no_background_subagent_in_spawning_skills` to `tests/skills/test_skill_compliance.py` to enforce the invariant for future skills.

No Python source code changes. No recipe YAML changes. No migration required.

Closes #1582

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260501-111729-181669/.autoskillit/temp/make-plan/adr_prohibit_background_subagent_plan_2026-05-01_112803.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 95 | 13.4k | 449.4k | 48.4k | 1 | 12m 31s |
| verify | 204 | 28.2k | 1.6M | 70.7k | 1 | 8m 40s |
| implement | 1.2k | 11.8k | 887.2k | 40.3k | 1 | 4m 50s |
| prepare_pr | 76 | 14.5k | 318.8k | 42.4k | 1 | 2m 42s |
| compose_pr | 51 | 2.1k | 171.9k | 21.7k | 1 | 48s |
| review_pr | 1.4k | 67.3k | 2.5M | 229.0k | 3 | 23m 44s |
| resolve_review | 947 | 60.4k | 6.4M | 198.3k | 3 | 26m 47s |
| **Total** | 3.9k | 197.7k | 12.4M | 650.8k | | 1h 20m |