### PR TITLE
ADR: Ban inline shell scripts from recipe cmd fields

### DIFF
--- a/.autoskillit/test-filter-manifest.yaml
+++ b/.autoskillit/test-filter-manifest.yaml
@@ -139,6 +139,9 @@ src/autoskillit/.mcp.json:
   - server/
   - cli/
 
+scripts/recipe/*.sh:
+  - recipe/
+
 src/autoskillit/core/__init__.pyi:
   - core/
   - arch/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,6 +235,7 @@ generic_automation_mcp/
 │   ├── order.py             #   BUNDLED_RECIPE_ORDER — stable display order registry for Group 0 recipes
 │   ├── loader.py            #   Path-based recipe metadata utilities
 │   ├── _api.py              #   Orchestration API
+│   ├── _cmd_rpc.py          #   run_python callables for externalized recipe cmd scripts
 │   ├── _recipe_ingredients.py #  format_ingredients_table + LoadRecipeResult TypedDicts
 │   ├── _recipe_composition.py #  _build_active_recipe + sub-recipe merging
 │   ├── diagrams.py          #   Flow diagram generation + staleness detection

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,6 +258,7 @@ generic_automation_mcp/
 │   ├── rules_features.py
 │   ├── rules_fixing.py
 │   ├── rules_graph.py
+│   ├── rules_inline_script.py  #   inline-script-in-cmd + inline-python-in-cmd lint rules
 │   ├── rules_inputs.py
 │   ├── rules_isolation.py
 │   ├── rules_merge.py

--- a/docs/decisions/0002-ban-inline-shell-scripts-from-cmd.md
+++ b/docs/decisions/0002-ban-inline-shell-scripts-from-cmd.md
@@ -1,0 +1,44 @@
+# ADR-0002: Ban Inline Shell Scripts from Recipe cmd Fields
+
+**Status:** Accepted
+**Date:** 2026-05-01
+**Issue:** [#1584](https://github.com/TalonT-Org/AutoSkillit/issues/1584)
+
+## Context
+
+- Recipe YAML files are declarative workflow graphs defining *what* happens and in *what order*.
+- PR #1583 introduced a 12-line bash script with variable assignments, arithmetic, file I/O, and control flow directly in a `cmd:` field.
+- A systematic scan reveals 61 `run_cmd` steps across 6 recipe files containing inline shell scripts.
+- Inline scripts make recipes unreadable, prevent reuse, defeat syntax highlighting, and make it trivially easy for automated PRs to introduce more.
+
+## Decision
+
+> **Code belongs in code files. Recipes are purely declarative.**
+
+- **Python logic** → `.py` file, invoked via `run_python` callable.
+- **Bash logic** → `.sh` file in `scripts/recipe/`, invoked via `run_cmd cmd: bash scripts/recipe/foo.sh`.
+- **Recipe YAML** → declarative only. Names the thing to call, passes parameters. Zero logic.
+
+A recipe step's `cmd:` field must never contain shell control flow (`if/then/else/fi`, `for/do/done`, `while/do/done`, `case/esac`), variable assignments beyond simple parameter passing, loops, or embedded Python (`python3 -c`).
+
+## Rationale
+
+- Recipes should be auditable at a glance — scanning step names and their targets tells the story.
+- Shell scripts in `.sh` files get syntax highlighting, linting (shellcheck), and version control diffs.
+- Python callables get type checking, testing, and IDE support.
+- Deduplication becomes trivial — shared logic lives in one callable/script, referenced by name.
+- The lint rule prevents regression automatically.
+
+## Enforcement
+
+- **Lint rule:** `inline-script-in-cmd` in `src/autoskillit/recipe/rules_inline_script.py`
+- **Lint rule:** `inline-python-in-cmd` in the same module (catches `python3 -c`)
+- **Validation:** `validate_recipe` → `run_semantic_rules` fires on every recipe load
+- **Existing violations:** Grandfathered via `_INLINE_SCRIPT_ALLOWLIST` frozen set until externalized
+- **Test command:** `task test-all` (includes recipe validation)
+
+## Scope
+
+- All recipe YAML files under `src/autoskillit/recipes/`
+- All sub-recipe YAML files under `src/autoskillit/recipes/sub-recipes/`
+- The `cmd` field of any `run_cmd` step in any recipe

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,3 +1,4 @@
 # Architecture Decision Records
 
 - [0001-prohibit-background-subagent-execution.md](0001-prohibit-background-subagent-execution.md) — prohibit `run_in_background: true` in all skills
+- [0002-ban-inline-shell-scripts-from-cmd.md](0002-ban-inline-shell-scripts-from-cmd.md) — Prohibit inline shell scripts in recipe cmd fields; require externalization to .sh files or run_python callables

--- a/scripts/recipe/advance_queue_pr.sh
+++ b/scripts/recipe/advance_queue_pr.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Args: $1=current_pr_number $2=pr_order_file
+CURRENT="$1"
+PR_ORDER_FILE="$2"
+
+NEXT=$(jq -r --arg cur "$CURRENT" '
+    (to_entries | map(select(.value.number == ($cur | tonumber))) | .[0].key) as $idx |
+    if ($idx + 1) < length then .[$idx + 1].number | tostring
+    else "done"
+    end
+' "$PR_ORDER_FILE")
+
+echo "$NEXT"

--- a/scripts/recipe/create_artifact_branch.sh
+++ b/scripts/recipe/create_artifact_branch.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Args: $1=worktree_path $2=experiment_branch $3=base_branch $4=research_dir
+WORKTREE_PATH="$1"
+EXPERIMENT_BRANCH="$2"
+BASE_BRANCH="$3"
+RESEARCH_DIR="$4"
+
+SLUG=$(printf '%s' "${EXPERIMENT_BRANCH}" | sed 's/^research-//')
+ARTIFACT_BRANCH="research-artifacts-${SLUG}"
+
+ARTIFACT_DIR="$(mktemp -d)"
+trap 'git -C "${WORKTREE_PATH}" worktree remove "${ARTIFACT_DIR}" --force 2>/dev/null; rm -rf "${ARTIFACT_DIR}"' EXIT
+
+git -C "${WORKTREE_PATH}" fetch origin "${BASE_BRANCH}"
+git -C "${WORKTREE_PATH}" branch -D "${ARTIFACT_BRANCH}" 2>/dev/null || true
+git -C "${WORKTREE_PATH}" worktree add "${ARTIFACT_DIR}" -b "${ARTIFACT_BRANCH}" "origin/${BASE_BRANCH}"
+
+RESEARCH_SUBDIR="research/$(basename "${RESEARCH_DIR}")"
+git -C "${ARTIFACT_DIR}" checkout "${EXPERIMENT_BRANCH}" -- "${RESEARCH_SUBDIR}"
+cd "${ARTIFACT_DIR}"
+git add research/
+git commit -m "Add research artifacts: ${SLUG}"
+git push -u origin "${ARTIFACT_BRANCH}"
+cd - > /dev/null
+
+git -C "${WORKTREE_PATH}" worktree remove "${ARTIFACT_DIR}" --force
+
+echo "artifact_branch=${ARTIFACT_BRANCH}"

--- a/scripts/recipe/create_worktree.sh
+++ b/scripts/recipe/create_worktree.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Args: $1=source_dir $2=task $3=experiment_plan $4=scope_report $5=evaluation_dashboard
+#       $6=visualization_plan_path $7=report_plan_path $8=autoskillit_temp_name
+SOURCE_DIR="$1"
+TASK="$2"
+EXPERIMENT_PLAN="$3"
+SCOPE_REPORT="${4:-}"
+EVAL_DASHBOARD="${5:-}"
+VISUALIZATION_PLAN="${6:-}"
+REPORT_PLAN="${7:-}"
+TEMP_NAME="${8:-.autoskillit/temp}"
+
+BRANCH="research-$(date +%Y%m%d-%H%M%S)"
+WORKTREE_PATH="../worktrees/${BRANCH}"
+git -C "$SOURCE_DIR" worktree add -b "${BRANCH}" "${WORKTREE_PATH}"
+RESOLVED="$(cd "${SOURCE_DIR}/${WORKTREE_PATH}" && pwd)"
+
+case "${RESOLVED}" in /*) ;; *) echo "error: resolved worktree path is not absolute: ${RESOLVED}" >&2; exit 1;; esac
+
+mkdir -p "${SOURCE_DIR}/${TEMP_NAME}/worktrees/${BRANCH}"
+git -C "$SOURCE_DIR" rev-parse --abbrev-ref HEAD > "${SOURCE_DIR}/${TEMP_NAME}/worktrees/${BRANCH}/base-branch"
+
+mkdir -p "${RESOLVED}/${TEMP_NAME}"
+cp "${EXPERIMENT_PLAN}" "${RESOLVED}/${TEMP_NAME}/experiment-plan.md"
+
+SLUG=$(printf '%s' "${TASK}" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-' | sed 's/--*/-/g;s/^-//;s/-$//' | cut -c1-30)
+RESEARCH_DIR="${RESOLVED}/research/$(date +%Y-%m-%d)-${SLUG:-experiment}"
+mkdir -p "${RESEARCH_DIR}/artifacts"
+cp "${EXPERIMENT_PLAN}" "${RESEARCH_DIR}/experiment-plan.md"
+
+if [ -n "${SCOPE_REPORT}" ] && [ -f "${SCOPE_REPORT}" ]; then
+    cp "${SCOPE_REPORT}" "${RESEARCH_DIR}/artifacts/scope-report.md"
+fi
+if [ -n "${EVAL_DASHBOARD}" ] && [ -f "${EVAL_DASHBOARD}" ]; then
+    cp "${EVAL_DASHBOARD}" "${RESEARCH_DIR}/artifacts/design-evaluation.md"
+fi
+if [ -n "${VISUALIZATION_PLAN}" ] && [ -f "${VISUALIZATION_PLAN}" ]; then
+    cp "${VISUALIZATION_PLAN}" "${RESEARCH_DIR}/visualization-plan.md"
+fi
+if [ -n "${REPORT_PLAN}" ] && [ -f "${REPORT_PLAN}" ]; then
+    cp "${REPORT_PLAN}" "${RESEARCH_DIR}/report-plan.md"
+fi
+
+SRC_TEMP="${SOURCE_DIR}/${TEMP_NAME}"
+mkdir -p "${RESEARCH_DIR}/artifacts/review-cycles"
+mkdir -p "${RESEARCH_DIR}/artifacts/plan-versions"
+for f in "${SRC_TEMP}"/review-design/evaluation_dashboard_*.md; do [ -f "$f" ] && cp "$f" "${RESEARCH_DIR}/artifacts/review-cycles/"; done
+for f in "${SRC_TEMP}"/review-design/revision_guidance_*.md; do [ -f "$f" ] && cp "$f" "${RESEARCH_DIR}/artifacts/review-cycles/"; done
+for f in "${SRC_TEMP}"/plan-experiment/experiment_plan_*.md; do [ -f "$f" ] && cp "$f" "${RESEARCH_DIR}/artifacts/plan-versions/"; done
+for f in "${SRC_TEMP}"/resolve-design-review/*.md; do [ -f "$f" ] && cp "$f" "${RESEARCH_DIR}/artifacts/review-cycles/"; done
+
+cd "${RESOLVED}" && git add research/ && git commit -m "Add experiment plan and scope to research/"
+
+echo "research_dir=${RESEARCH_DIR}"
+echo "worktree_path=${RESOLVED}"

--- a/scripts/recipe/finalize_bundle.sh
+++ b/scripts/recipe/finalize_bundle.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Args: $1=output_mode $2=research_dir $3=worktree_path
+OUTPUT_MODE="$1"
+RESEARCH_DIR="$2"
+WORKTREE_PATH="$3"
+
+if [ -z "${RESEARCH_DIR}" ] || [ ! -d "${RESEARCH_DIR}" ]; then
+    echo "finalize_bundle: no research directory found — artifact commit skipped"
+    exit 0
+fi
+
+if [ "${OUTPUT_MODE}" != "local" ]; then
+    if [ -f "${RESEARCH_DIR}/report.md" ]; then
+        cp "${RESEARCH_DIR}/report.md" "${RESEARCH_DIR}/README.md"
+        rm "${RESEARCH_DIR}/report.md"
+    fi
+fi
+
+REPORT_FILE=$( [ "${OUTPUT_MODE}" = "local" ] && echo "report.md" || echo "README.md" )
+
+if [ "${OUTPUT_MODE}" = "local" ]; then
+    EXCLUDE_PATTERN='^(report\.html|mermaid\.min\.js|images|report\.md|artifacts\.tar\.gz)$'
+else
+    EXCLUDE_PATTERN='^(README\.md|artifacts\.tar\.gz)$'
+fi
+
+mapfile -t TAR_ITEMS < <(ls -1 "${RESEARCH_DIR}" | grep -vE "${EXCLUDE_PATTERN}")
+
+if [ ${#TAR_ITEMS[@]} -gt 0 ]; then
+    tar czf "${RESEARCH_DIR}/artifacts.tar.gz" -C "${RESEARCH_DIR}" "${TAR_ITEMS[@]}"
+    for item in "${TAR_ITEMS[@]}"; do rm -rf "${RESEARCH_DIR}/${item}"; done
+fi
+
+if [ -f "${RESEARCH_DIR}/artifacts.tar.gz" ] && [ -f "${RESEARCH_DIR}/${REPORT_FILE}" ]; then
+    MANIFEST=$(tar tzf "${RESEARCH_DIR}/artifacts.tar.gz" | sort)
+    {
+        echo ""
+        echo "## Archive Manifest"
+        echo ""
+        echo "Contents of \`artifacts.tar.gz\`:"
+        echo ""
+        echo '```'
+        echo "${MANIFEST}"
+        echo '```'
+    } >> "${RESEARCH_DIR}/${REPORT_FILE}"
+fi
+
+[ -f "${RESEARCH_DIR}/artifacts.tar.gz" ] || \
+    { echo "ERROR: artifacts.tar.gz not created in ${RESEARCH_DIR}"; exit 1; }
+
+if [ "${OUTPUT_MODE}" = "local" ]; then
+    LEFTOVER_PATTERN='^(report\.md|report\.html|mermaid\.min\.js|images|artifacts\.tar\.gz)$'
+else
+    LEFTOVER_PATTERN='^(README\.md|artifacts\.tar\.gz)$'
+fi
+
+LEFTOVERS=$(ls -1 "${RESEARCH_DIR}" | grep -vE "${LEFTOVER_PATTERN}" || true)
+[ -z "${LEFTOVERS}" ] || \
+    { echo "ERROR: uncompressed entries still present in ${RESEARCH_DIR}: ${LEFTOVERS}"; exit 1; }
+
+[ -f "${RESEARCH_DIR}/${REPORT_FILE}" ] || \
+    { echo "ERROR: ${REPORT_FILE} not found in ${RESEARCH_DIR}"; exit 1; }
+
+if [ "${OUTPUT_MODE}" != "local" ]; then
+    cd "${WORKTREE_PATH}" && git add "${RESEARCH_DIR}" && { git diff --cached --quiet || git commit -m "Add compressed research artifacts"; }
+fi
+
+echo "report_path=${RESEARCH_DIR}/${REPORT_FILE}"
+echo "report_path_after_finalize=${RESEARCH_DIR}/${REPORT_FILE}"

--- a/scripts/recipe/open_artifact_pr.sh
+++ b/scripts/recipe/open_artifact_pr.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Args: $1=worktree_path $2=experiment_branch $3=artifact_branch $4=pr_url $5=base_branch $6=research_dir
+WORKTREE_PATH="$1"
+EXPERIMENT_BRANCH="$2"
+ARTIFACT_BRANCH="$3"
+ORIG_PR="$4"
+BASE_BRANCH="$5"
+RESEARCH_DIR="$6"
+
+RESEARCH_SUBDIR="research/$(basename "${RESEARCH_DIR}")"
+ARTIFACT_DIR="${WORKTREE_PATH}"
+
+if [ -f "${ARTIFACT_DIR}/${RESEARCH_SUBDIR}/artifacts.tar.gz" ]; then
+    STRUCT_DETAIL=$'- `artifacts.tar.gz` \xe2\x80\x94 compressed artifact tree\n\nExtract:\n```bash\ntar xzf artifacts.tar.gz\n```'
+else
+    STRUCT_DETAIL='- `artifacts/` — uncompressed artifact tree'
+fi
+
+PR_BODY=$(printf '## Research Artifacts\n\nFrom experiment branch `%s`.\n\nOriginal experiment PR: %s\n\n### Structure\n\n- **README.md** — Research conclusions (browsable on GitHub)\n%s\n\nContains only files under `research/` — zero production code changes.' "${EXPERIMENT_BRANCH}" "${ORIG_PR}" "${STRUCT_DETAIL}")
+
+PR_URL=$(gh pr create \
+    --head "${ARTIFACT_BRANCH}" \
+    --base "${BASE_BRANCH}" \
+    --title "Research artifacts: ${EXPERIMENT_BRANCH}" \
+    --body "${PR_BODY}")
+
+echo "artifact_pr_url=${PR_URL}"

--- a/scripts/recipe/stage_bundle.sh
+++ b/scripts/recipe/stage_bundle.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Args: $1=research_dir $2=worktree_path $3=autoskillit_temp_name
+RESEARCH_DIR="$1"
+WORKTREE_PATH="$2"
+TEMP_NAME="${3:-.autoskillit/temp}"
+
+if [ -z "${RESEARCH_DIR}" ] || [ ! -d "${RESEARCH_DIR}" ]; then
+    echo "stage_bundle: no research directory found — skipped"
+    exit 0
+fi
+
+WT_TEMP="${WORKTREE_PATH}/${TEMP_NAME}"
+mkdir -p "${RESEARCH_DIR}/artifacts/phase-groups"
+mkdir -p "${RESEARCH_DIR}/artifacts/phase-plans"
+mkdir -p "${RESEARCH_DIR}/artifacts/images"
+mkdir -p "${RESEARCH_DIR}/artifacts/scripts"
+
+for f in "${WT_TEMP}"/make-groups/*.md; do [ -f "$f" ] && cp "$f" "${RESEARCH_DIR}/artifacts/phase-groups/"; done
+for f in "${WT_TEMP}"/make-groups/*.yaml; do [ -f "$f" ] && cp "$f" "${RESEARCH_DIR}/artifacts/phase-groups/"; done
+for f in "${WT_TEMP}"/make-plan/*.md; do [ -f "$f" ] && cp "$f" "${RESEARCH_DIR}/artifacts/phase-plans/"; done
+for f in "${WT_TEMP}"/exp-lens-*/*.md; do [ -f "$f" ] && cp "$f" "${RESEARCH_DIR}/artifacts/images/"; done
+
+echo "stage_bundle=done"

--- a/scripts/recipe/tag_experiment_branch.sh
+++ b/scripts/recipe/tag_experiment_branch.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Args: $1=worktree_path $2=experiment_branch $3=artifact_pr_url
+WORKTREE_PATH="$1"
+EXPERIMENT_BRANCH="$2"
+ARTIFACT_PR_URL="$3"
+
+TAG="archive/research/${EXPERIMENT_BRANCH}"
+
+git -C "${WORKTREE_PATH}" tag -a "${TAG}" "${EXPERIMENT_BRANCH}" \
+    -m "Research experiment: ${EXPERIMENT_BRANCH}. Report merged via artifact PR ${ARTIFACT_PR_URL}. Variant code preserved here for reference."
+git -C "${WORKTREE_PATH}" push origin "${TAG}"
+
+echo "archive_tag=${TAG}"

--- a/src/autoskillit/recipe/__init__.py
+++ b/src/autoskillit/recipe/__init__.py
@@ -19,6 +19,7 @@ from autoskillit.recipe import rules_dataflow as _rules_dataflow  # noqa: E402 F
 from autoskillit.recipe import rules_features as _rules_features  # noqa: E402 F401
 from autoskillit.recipe import rules_fixing as _rules_fixing  # noqa: E402 F401
 from autoskillit.recipe import rules_graph as _rules_graph  # noqa: E402 F401
+from autoskillit.recipe import rules_inline_script as _rules_inline_script  # noqa: E402 F401
 from autoskillit.recipe import rules_inputs as _rules_inputs  # noqa: E402 F401
 from autoskillit.recipe import rules_isolation as _rules_isolation  # noqa: E402 F401
 from autoskillit.recipe import rules_merge as _rules_merge  # noqa: E402 F401

--- a/src/autoskillit/recipe/_cmd_rpc.py
+++ b/src/autoskillit/recipe/_cmd_rpc.py
@@ -8,7 +8,7 @@ import subprocess
 from datetime import date
 from pathlib import Path
 
-from autoskillit.core.io import atomic_write
+from autoskillit.core import atomic_write
 
 
 def compute_branch(

--- a/src/autoskillit/recipe/_cmd_rpc.py
+++ b/src/autoskillit/recipe/_cmd_rpc.py
@@ -317,12 +317,12 @@ def advance_queue_pr(
     current_pr_number: str,
     pr_order_file: str,
 ) -> dict[str, str]:
-    """Find next PR in queue order file via jq. Callable via run_python."""
+    """Find next PR in queue order file. Callable via run_python."""
     try:
         with open(pr_order_file) as f:
             order = json.load(f)
     except (OSError, json.JSONDecodeError) as exc:
-        return {"ok": "false", "error": str(exc)}
+        raise RuntimeError(str(exc)) from exc
     current = int(current_pr_number)
     idx = None
     for i, entry in enumerate(order):

--- a/src/autoskillit/recipe/_cmd_rpc.py
+++ b/src/autoskillit/recipe/_cmd_rpc.py
@@ -231,6 +231,7 @@ def wait_for_review_pr_mergeability(
             text=True,
         )
         if r.returncode != 0:
+            time.sleep(int(poll_interval))
             continue
         status = r.stdout.strip()
         if status != "UNKNOWN":
@@ -270,7 +271,8 @@ def create_persistent_integration(
         text=True,
     )
     if push.returncode != 0:
-        return {"ok": "false", "error": push.stderr}
+        msg = f"push failed: {push.stderr}"
+        raise RuntimeError(msg)
     return {"ok": "true"}
 
 
@@ -301,6 +303,7 @@ def force_push_and_wait_mergeability(
             text=True,
         )
         if r.returncode != 0:
+            time.sleep(int(poll_interval))
             continue
         status = r.stdout.strip()
         if status != "UNKNOWN":
@@ -400,7 +403,8 @@ def refetch_issues(issue_urls: str) -> dict[str, str]:
         text=True,
     )
     if result.returncode != 0:
-        return {"ok": "false", "error": result.stderr}
+        msg = f"gh graphql failed: {result.stderr}"
+        raise RuntimeError(msg)
     return {"issue_numbers": result.stdout.strip()}
 
 
@@ -415,7 +419,8 @@ def emit_fallback_map(
         if m:
             nums.append(int(m.group(1)))
     if not nums:
-        return {"ok": "false", "error": "no issue numbers extracted from issue URLs"}
+        msg = "no issue numbers extracted from issue URLs"
+        raise RuntimeError(msg)
     issues = [{"number": n, "title": str(n)} for n in nums]
     data = {
         "groups": [{"group": 1, "parallel": False, "issues": issues}],

--- a/src/autoskillit/recipe/_cmd_rpc.py
+++ b/src/autoskillit/recipe/_cmd_rpc.py
@@ -1,0 +1,458 @@
+"""Recipe cmd externalization callables — run_python entry points (IL-006)."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from datetime import date
+from pathlib import Path
+
+from autoskillit.core.io import atomic_write
+
+
+def compute_branch(
+    issue_slug: str = "",
+    run_name: str = "",
+    issue_number: str = "",
+) -> dict[str, str]:
+    """Compute branch name from slug + issue or date. Callable via run_python."""
+    prefix = issue_slug or run_name
+    if issue_number:
+        return {"branch_name": f"{prefix}/{issue_number}"}
+    return {"branch_name": f"{prefix}/{date.today().strftime('%Y%m%d')}"}
+
+
+def check_eject_limit(
+    counter_file: str,
+    max_ejects: str = "3",
+) -> dict[str, str]:
+    """Increment counter file; return EJECT_OK or EJECT_LIMIT_EXCEEDED. Callable via run_python."""
+    path = Path(counter_file)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        count = int(path.read_text().strip())
+    except (FileNotFoundError, ValueError):
+        count = 0
+    count += 1
+    atomic_write(path, str(count))
+    status = "EJECT_LIMIT_EXCEEDED" if count > int(max_ejects) else "EJECT_OK"
+    return {"status": status, "count": str(count)}
+
+
+def check_dropped_healthy_loop(
+    counter_file: str,
+    max_drops: str = "2",
+) -> dict[str, str]:
+    """Increment dropped-healthy counter; return DROPPED_OK or DROPPED_LIMIT_EXCEEDED. Callable via run_python."""
+    path = Path(counter_file)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        count = int(path.read_text().strip())
+    except (FileNotFoundError, ValueError):
+        count = 0
+    count += 1
+    atomic_write(path, str(count))
+    status = "DROPPED_LIMIT_EXCEEDED" if count > int(max_drops) else "DROPPED_OK"
+    return {"status": status, "count": str(count)}
+
+
+def commit_guard(worktree_path: str) -> dict[str, str]:
+    """Auto-commit pending changes if worktree is dirty. Callable via run_python."""
+    result = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=worktree_path,
+        capture_output=True,
+        text=True,
+    )
+    if result.stdout.strip():
+        subprocess.run(["git", "add", "-A"], cwd=worktree_path, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "chore: commit pending session changes"],
+            cwd=worktree_path,
+            check=True,
+        )
+        return {"committed": "true"}
+    return {"committed": "false"}
+
+
+def _detect_remote(cwd: str) -> str:
+    """Detect preferred remote: upstream (non-file) or origin."""
+    result = subprocess.run(
+        ["git", "remote", "get-url", "upstream"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0 and not result.stdout.strip().startswith("file://"):
+        return "upstream"
+    return "origin"
+
+
+def queue_ejected_fix(
+    work_dir: str,
+    base_branch: str,
+) -> dict[str, str]:
+    """Fetch and rebase onto base branch; return clean or conflicts. Callable via run_python."""
+    remote = _detect_remote(work_dir)
+    fetch = subprocess.run(
+        ["git", "fetch", remote, base_branch],
+        cwd=work_dir,
+        capture_output=True,
+        text=True,
+    )
+    if fetch.returncode != 0:
+        return {"status": "conflicts"}
+    rebase = subprocess.run(
+        ["git", "rebase", f"{remote}/{base_branch}"],
+        cwd=work_dir,
+        capture_output=True,
+        text=True,
+    )
+    if rebase.returncode == 0:
+        return {"status": "clean"}
+    subprocess.run(
+        ["git", "rebase", "--abort"],
+        cwd=work_dir,
+        capture_output=True,
+    )
+    return {"status": "conflicts"}
+
+
+def direct_merge_conflict_fix(
+    work_dir: str,
+    base_branch: str,
+) -> dict[str, str]:
+    """Attempt rebase for direct-merge path; return clean or conflicts. Callable via run_python."""
+    return queue_ejected_fix(work_dir=work_dir, base_branch=base_branch)
+
+
+def immediate_merge_conflict_fix(
+    work_dir: str,
+    base_branch: str,
+) -> dict[str, str]:
+    """Attempt rebase for immediate-merge path; return clean or conflicts. Callable via run_python."""
+    return queue_ejected_fix(work_dir=work_dir, base_branch=base_branch)
+
+
+def wait_for_direct_merge(
+    pr_number: str,
+    max_polls: str = "90",
+    poll_interval: str = "10",
+) -> dict[str, str]:
+    """Poll PR state until merged/closed/timeout. Callable via run_python."""
+    import time  # noqa: PLC0415
+
+    for _ in range(int(max_polls)):
+        result = subprocess.run(
+            ["gh", "pr", "view", pr_number, "--json", "state", "--jq", ".state"],
+            capture_output=True,
+            text=True,
+        )
+        state = result.stdout.strip()
+        if state == "MERGED":
+            return {"state": "merged"}
+        if state == "CLOSED":
+            return {"state": "closed"}
+        time.sleep(int(poll_interval))
+    return {"state": "timeout"}
+
+
+def wait_for_immediate_merge(
+    pr_number: str,
+    max_polls: str = "30",
+    poll_interval: str = "10",
+) -> dict[str, str]:
+    """Poll PR state until merged/closed/timeout (shorter). Callable via run_python."""
+    return wait_for_direct_merge(
+        pr_number=pr_number, max_polls=max_polls, poll_interval=poll_interval
+    )
+
+
+def attempt_cheap_rebase(
+    work_dir: str,
+    ejected_pr_branch: str,
+    base_branch: str,
+) -> dict[str, str]:
+    """Checkout ejected branch and attempt rebase. Callable via run_python."""
+    remote = _detect_remote(work_dir)
+    subprocess.run(
+        ["git", "fetch", remote, ejected_pr_branch],
+        cwd=work_dir,
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "checkout", ejected_pr_branch],
+        cwd=work_dir,
+        capture_output=True,
+        check=True,
+    )
+    rebase = subprocess.run(
+        ["git", "rebase", f"{remote}/{base_branch}"],
+        cwd=work_dir,
+        capture_output=True,
+        text=True,
+    )
+    if rebase.returncode == 0:
+        return {"status": "clean"}
+    subprocess.run(
+        ["git", "rebase", "--abort"],
+        cwd=work_dir,
+        capture_output=True,
+    )
+    return {"status": "conflicts"}
+
+
+def wait_for_review_pr_mergeability(
+    pr_url: str,
+    max_polls: str = "12",
+    poll_interval: str = "15",
+) -> dict[str, str]:
+    """Extract PR number and poll until mergeability resolves. Callable via run_python."""
+    import time  # noqa: PLC0415
+
+    result = subprocess.run(
+        ["gh", "pr", "view", pr_url, "--json", "number", "-q", ".number"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return {"ok": "false", "error": f"failed to resolve PR number: {result.stderr}"}
+    pr_number = result.stdout.strip()
+    for _ in range(int(max_polls)):
+        r = subprocess.run(
+            ["gh", "pr", "view", pr_number, "--json", "mergeable", "-q", ".mergeable"],
+            capture_output=True,
+            text=True,
+        )
+        status = r.stdout.strip()
+        if status != "UNKNOWN":
+            return {"pr_number": pr_number}
+        time.sleep(int(poll_interval))
+    return {"ok": "false", "error": "Timed out waiting for mergeability"}
+
+
+def create_persistent_integration(
+    work_dir: str,
+    base_branch: str,
+) -> dict[str, str]:
+    """Create and push persistent integration branch from default branch. Callable via run_python."""
+    remote = _detect_remote(work_dir)
+    result = subprocess.run(
+        ["git", "symbolic-ref", "refs/remotes/origin/HEAD"],
+        cwd=work_dir,
+        capture_output=True,
+        text=True,
+    )
+    default_branch = "main"
+    if result.returncode == 0:
+        ref = result.stdout.strip()
+        default_branch = ref.replace("refs/remotes/origin/", "")
+    subprocess.run(
+        ["git", "checkout", default_branch], cwd=work_dir, check=True, capture_output=True
+    )
+    subprocess.run(["git", "pull"], cwd=work_dir, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "checkout", "-b", base_branch], cwd=work_dir, check=True, capture_output=True
+    )
+    push = subprocess.run(
+        ["git", "push", remote, base_branch],
+        cwd=work_dir,
+        capture_output=True,
+        text=True,
+    )
+    if push.returncode != 0:
+        return {"ok": "false", "error": push.stderr}
+    return {"ok": "true"}
+
+
+def force_push_and_wait_mergeability(
+    work_dir: str,
+    integration_branch: str,
+    review_pr_number: str,
+    max_polls: str = "12",
+    poll_interval: str = "15",
+) -> dict[str, str]:
+    """Force-push integration branch and wait for mergeability. Callable via run_python."""
+    import time  # noqa: PLC0415
+
+    remote = _detect_remote(work_dir)
+    push = subprocess.run(
+        ["git", "push", remote, integration_branch, "--force-with-lease"],
+        cwd=work_dir,
+        capture_output=True,
+        text=True,
+    )
+    if push.returncode != 0:
+        return {"ok": "false", "error": push.stderr}
+    for _ in range(int(max_polls)):
+        r = subprocess.run(
+            ["gh", "pr", "view", review_pr_number, "--json", "mergeable", "-q", ".mergeable"],
+            capture_output=True,
+            text=True,
+        )
+        status = r.stdout.strip()
+        if status != "UNKNOWN":
+            return {"ok": "true"}
+        time.sleep(int(poll_interval))
+    return {"ok": "false", "error": "Timed out waiting for post-rebase mergeability"}
+
+
+def advance_queue_pr(
+    current_pr_number: str,
+    pr_order_file: str,
+) -> dict[str, str]:
+    """Find next PR in queue order file via jq. Callable via run_python."""
+    try:
+        with open(pr_order_file) as f:
+            order = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        return {"ok": "false", "error": str(exc)}
+    current = int(current_pr_number)
+    idx = None
+    for i, entry in enumerate(order):
+        if entry.get("number") == current:
+            idx = i
+            break
+    if idx is None:
+        return {"current_pr_number": "done"}
+    if (idx + 1) < len(order):
+        return {"current_pr_number": str(order[idx + 1]["number"])}
+    return {"current_pr_number": "done"}
+
+
+def proactive_rebase_next_pr(
+    work_dir: str,
+    next_pr_branch: str,
+    base_branch: str,
+) -> dict[str, str]:
+    """Fetch, checkout, and rebase next PR branch. Callable via run_python."""
+    result = subprocess.run(
+        ["git", "remote"],
+        cwd=work_dir,
+        capture_output=True,
+        text=True,
+    )
+    remote = "upstream" if "upstream" in result.stdout.splitlines() else "origin"
+    subprocess.run(
+        ["git", "fetch", remote, next_pr_branch],
+        cwd=work_dir,
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "checkout", "-B", next_pr_branch, f"{remote}/{next_pr_branch}"],
+        cwd=work_dir,
+        capture_output=True,
+        check=True,
+    )
+    rebase = subprocess.run(
+        ["git", "rebase", f"{remote}/{base_branch}"],
+        cwd=work_dir,
+        capture_output=True,
+        text=True,
+    )
+    if rebase.returncode == 0:
+        return {"status": "clean"}
+    subprocess.run(
+        ["git", "rebase", "--abort"],
+        cwd=work_dir,
+        capture_output=True,
+    )
+    return {"status": "conflicts"}
+
+
+def refetch_issues(issue_urls: str) -> dict[str, str]:
+    """Build GraphQL query from issue URLs, fetch open issues. Callable via run_python."""
+    urls = issue_urls.split(",")
+    parts = []
+    for i, url in enumerate(urls):
+        url = url.strip()
+        if not url:
+            continue
+        m = re.match(r"https://github\.com/([^/]+)/([^/]+)/issues/(\d+)", url)
+        if m:
+            owner, repo, num = m.groups()
+            parts.append(
+                f'i{i}: repository(owner: "{owner}", name: "{repo}") '
+                f"{{ issue(number: {num}) {{ number state }} }}"
+            )
+    if not parts:
+        return {"issue_numbers": ""}
+    query = "{" + " ".join(parts) + "}"
+    result = subprocess.run(
+        [
+            "gh",
+            "api",
+            "graphql",
+            "-f",
+            f"query={query}",
+            "--jq",
+            '[.data[] | select(.issue != null and .issue.state == "OPEN") | .issue.number | tostring] | join(" ")',
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return {"ok": "false", "error": result.stderr}
+    return {"issue_numbers": result.stdout.strip()}
+
+
+def emit_fallback_map(
+    issue_urls: str,
+    temp_dir: str,
+) -> dict[str, str]:
+    """Build fallback execution map JSON from issue URLs. Callable via run_python."""
+    nums: list[int] = []
+    for url in issue_urls.split(","):
+        m = re.search(r"issues/(\d+)", url.strip())
+        if m:
+            nums.append(int(m.group(1)))
+    if not nums:
+        return {"ok": "false", "error": "no issue numbers extracted from issue URLs"}
+    issues = [{"number": n, "title": str(n)} for n in nums]
+    data = {
+        "groups": [{"group": 1, "parallel": False, "issues": issues}],
+        "merge_order": nums,
+        "pairwise_assessments": [],
+    }
+    map_file = Path(temp_dir) / "bem-fallback-map.json"
+    map_file.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write(map_file, json.dumps(data))
+    return {"execution_map": str(map_file)}
+
+
+def ensure_results(
+    experiment_results: str,
+    worktree_path: str,
+    temp_subdir: str = ".autoskillit/temp",
+) -> dict[str, str]:
+    """Ensure experiment_results file exists; create placeholder if empty. Callable via run_python."""
+    if experiment_results:
+        return {"experiment_results": experiment_results}
+    results_path = Path(worktree_path) / temp_subdir / "run-experiment" / "results-inconclusive.md"
+    results_path.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write(
+        results_path,
+        "# Experiment Results\n\n## Status\nINCONCLUSIVE\n\n"
+        "Experiment did not produce results — retries exhausted or adjustment failed.\n",
+    )
+    return {"experiment_results": str(results_path)}
+
+
+def export_local_bundle(
+    source_dir: str,
+    research_dir: str,
+) -> dict[str, str]:
+    """Copy research dir to source_dir/research-bundles/{slug}/. Callable via run_python."""
+    import shutil  # noqa: PLC0415
+
+    local_root = Path(source_dir) / "research-bundles"
+    local_root.mkdir(parents=True, exist_ok=True)
+    slug = Path(research_dir).name
+    dest = local_root / slug
+    if dest.exists():
+        shutil.rmtree(dest)
+    shutil.copytree(research_dir, dest)
+    return {"local_bundle_path": str(dest)}

--- a/src/autoskillit/recipe/_cmd_rpc.py
+++ b/src/autoskillit/recipe/_cmd_rpc.py
@@ -149,6 +149,9 @@ def wait_for_direct_merge(
             capture_output=True,
             text=True,
         )
+        if result.returncode != 0:
+            time.sleep(int(poll_interval))
+            continue
         state = result.stdout.strip()
         if state == "MERGED":
             return {"state": "merged"}
@@ -218,7 +221,8 @@ def wait_for_review_pr_mergeability(
         text=True,
     )
     if result.returncode != 0:
-        return {"ok": "false", "error": f"failed to resolve PR number: {result.stderr}"}
+        msg = f"failed to resolve PR number: {result.stderr}"
+        raise RuntimeError(msg)
     pr_number = result.stdout.strip()
     for _ in range(int(max_polls)):
         r = subprocess.run(
@@ -226,11 +230,14 @@ def wait_for_review_pr_mergeability(
             capture_output=True,
             text=True,
         )
+        if r.returncode != 0:
+            continue
         status = r.stdout.strip()
         if status != "UNKNOWN":
             return {"pr_number": pr_number}
         time.sleep(int(poll_interval))
-    return {"ok": "false", "error": "Timed out waiting for mergeability"}
+    msg = "Timed out waiting for mergeability"
+    raise RuntimeError(msg)
 
 
 def create_persistent_integration(
@@ -285,18 +292,22 @@ def force_push_and_wait_mergeability(
         text=True,
     )
     if push.returncode != 0:
-        return {"ok": "false", "error": push.stderr}
+        msg = f"force-push failed: {push.stderr}"
+        raise RuntimeError(msg)
     for _ in range(int(max_polls)):
         r = subprocess.run(
             ["gh", "pr", "view", review_pr_number, "--json", "mergeable", "-q", ".mergeable"],
             capture_output=True,
             text=True,
         )
+        if r.returncode != 0:
+            continue
         status = r.stdout.strip()
         if status != "UNKNOWN":
             return {"ok": "true"}
         time.sleep(int(poll_interval))
-    return {"ok": "false", "error": "Timed out waiting for post-rebase mergeability"}
+    msg = "Timed out waiting for post-rebase mergeability"
+    raise RuntimeError(msg)
 
 
 def advance_queue_pr(
@@ -328,13 +339,7 @@ def proactive_rebase_next_pr(
     base_branch: str,
 ) -> dict[str, str]:
     """Fetch, checkout, and rebase next PR branch. Callable via run_python."""
-    result = subprocess.run(
-        ["git", "remote"],
-        cwd=work_dir,
-        capture_output=True,
-        text=True,
-    )
-    remote = "upstream" if "upstream" in result.stdout.splitlines() else "origin"
+    remote = _detect_remote(work_dir)
     subprocess.run(
         ["git", "fetch", remote, next_pr_branch],
         cwd=work_dir,

--- a/src/autoskillit/recipe/rules_cmd.py
+++ b/src/autoskillit/recipe/rules_cmd.py
@@ -35,6 +35,8 @@ def _check_run_cmd_emit_alignment(ctx: ValidationContext) -> list[RuleFinding]:
         cmd = (step.with_args or {}).get("cmd", "")
         if not isinstance(cmd, str):
             continue
+        if re.match(r"^\s*bash\s+scripts/", cmd):
+            continue
         for cap_key, cap_val in step.capture.items():
             m = RESULT_CAPTURE_RE.search(cap_val)
             if m is None:

--- a/src/autoskillit/recipe/rules_inline_script.py
+++ b/src/autoskillit/recipe/rules_inline_script.py
@@ -1,0 +1,225 @@
+"""Semantic rules: detect inline shell scripts in run_cmd cmd fields."""
+
+from __future__ import annotations
+
+import re
+
+from autoskillit.core import Severity
+from autoskillit.recipe._analysis import ValidationContext
+from autoskillit.recipe.registry import RuleFinding, semantic_rule
+
+# Grandfathered violations — to be removed as Part B externalizes them.
+# Populated mechanically by running the rule without the allowlist against all
+# bundled recipe files and collecting every step name that fires.
+_INLINE_SCRIPT_ALLOWLIST: frozenset[str] = frozenset({
+    "advance_queue_pr",
+    "attempt_cheap_rebase",
+    "check_dropped_healthy_loop",
+    "check_eject_limit",
+    "commit_guard",
+    "compute_branch",
+    "create_artifact_branch",
+    "create_persistent_integration",
+    "create_worktree",
+    "direct_merge_conflict_fix",
+    "emit_fallback_map",
+    "ensure_results",
+    "export_local_bundle",
+    "finalize_bundle",
+    "force_push_and_wait_mergeability",
+    "immediate_merge_conflict_fix",
+    "open_artifact_pr",
+    "proactive_rebase_next_pr",
+    "queue_ejected_fix",
+    "re_stage_bundle",
+    "refetch_issues",
+    "stage_bundle",
+    "tag_experiment_branch",
+    "wait_for_direct_merge",
+    "wait_for_immediate_merge",
+    "wait_for_review_pr_mergeability",
+})
+
+# ---------------------------------------------------------------------------
+# Detection patterns
+# ---------------------------------------------------------------------------
+
+_CONTROL_FLOW_RE = re.compile(
+    r"""
+    (?<![.a-zA-Z_/])      # not preceded by word char or path separator
+    (?:
+        \bif\s+.*;\s*then\b |
+        \bthen\b |
+        \belse\b |
+        \bfi\b |
+        \bfor\s+\w+\s+in\b |
+        \bwhile\s+.*;\s*do\b |
+        \bdo\b |
+        \bdone\b |
+        \bcase\s+.*\s+in\b |
+        \besac\b
+    )
+    """,
+    re.VERBOSE,
+)
+
+_JQ_BLOCK_RE = re.compile(
+    r"--jq\s+'[^']*'|--jq\s+\"[^\"]*\"|jq\s+'[^']*'|jq\s+\"[^\"]*\"",
+    re.DOTALL,
+)
+
+_LOOP_RE = re.compile(r"\bfor\s+\w+\s+in\s+.*;\s*do\b|\bwhile\s+.*;\s*do\b")
+
+_BASH_BUILTINS_RE = re.compile(r"\b(?:mapfile|read\s+-r|declare|local|export)\b")
+
+_VAR_ASSIGN_RE = re.compile(r"^[A-Z_][A-Z0-9_]*=", re.MULTILINE)
+
+_AND_CHAIN_RE = re.compile(r"&&")
+
+_PYTHON3_C_RE = re.compile(r"\bpython3?\s+-c\b")
+
+
+def _strip_jq_blocks(cmd: str) -> str:
+    """Remove jq expression blocks to avoid false-positive control-flow matches."""
+    return _JQ_BLOCK_RE.sub("", cmd)
+
+
+def _count_logical_lines(cmd: str) -> int:
+    """Count non-blank, non-comment lines."""
+    return sum(
+        1 for line in cmd.splitlines() if line.strip() and not line.strip().startswith("#")
+    )
+
+
+@semantic_rule(
+    name="inline-script-in-cmd",
+    description=(
+        "Detects inline shell scripts in run_cmd cmd fields "
+        "(control flow, loops, excessive variable assignments)"
+    ),
+    severity=Severity.ERROR,
+)
+def _check_inline_script_in_cmd(ctx: ValidationContext) -> list[RuleFinding]:
+    findings: list[RuleFinding] = []
+    for name, step in ctx.recipe.steps.items():
+        if step.tool != "run_cmd":
+            continue
+        if name in _INLINE_SCRIPT_ALLOWLIST:
+            continue
+        cmd = (step.with_args or {}).get("cmd", "")
+        if not isinstance(cmd, str):
+            continue
+
+        stripped = _strip_jq_blocks(cmd)
+
+        if _CONTROL_FLOW_RE.search(stripped):
+            findings.append(
+                RuleFinding(
+                    rule="inline-script-in-cmd",
+                    severity=Severity.ERROR,
+                    step_name=name,
+                    message=(
+                        f"Step '{name}' contains shell control flow in cmd. "
+                        "Extract to a .sh script or run_python callable."
+                    ),
+                )
+            )
+            continue
+
+        if _LOOP_RE.search(stripped):
+            findings.append(
+                RuleFinding(
+                    rule="inline-script-in-cmd",
+                    severity=Severity.ERROR,
+                    step_name=name,
+                    message=(
+                        f"Step '{name}' contains a shell loop in cmd. "
+                        "Extract to a .sh script or run_python callable."
+                    ),
+                )
+            )
+            continue
+
+        if _BASH_BUILTINS_RE.search(stripped):
+            findings.append(
+                RuleFinding(
+                    rule="inline-script-in-cmd",
+                    severity=Severity.ERROR,
+                    step_name=name,
+                    message=(
+                        f"Step '{name}' contains bash builtins "
+                        "(mapfile/declare/local/export/read -r) in cmd. "
+                        "Extract to a .sh script."
+                    ),
+                )
+            )
+            continue
+
+        var_count = len(_VAR_ASSIGN_RE.findall(cmd))
+        chain_count = len(_AND_CHAIN_RE.findall(cmd))
+        if chain_count > 3 and var_count >= 1:
+            findings.append(
+                RuleFinding(
+                    rule="inline-script-in-cmd",
+                    severity=Severity.ERROR,
+                    step_name=name,
+                    message=(
+                        f"Step '{name}' has {chain_count} &&-chains with "
+                        f"{var_count} variable assignment(s). "
+                        "Extract to a .sh script or run_python callable."
+                    ),
+                )
+            )
+            continue
+
+        logical_lines = _count_logical_lines(cmd)
+        if logical_lines > 3 and var_count > 2:
+            findings.append(
+                RuleFinding(
+                    rule="inline-script-in-cmd",
+                    severity=Severity.WARNING,
+                    step_name=name,
+                    message=(
+                        f"Step '{name}' has {logical_lines} logical lines and "
+                        f"{var_count} variable assignments. "
+                        "Consider extracting to a script."
+                    ),
+                )
+            )
+
+    return findings
+
+
+@semantic_rule(
+    name="inline-python-in-cmd",
+    description=(
+        "Detects python3 -c usage in run_cmd cmd fields "
+        "(must use run_python callable instead)"
+    ),
+    severity=Severity.ERROR,
+)
+def _check_inline_python_in_cmd(ctx: ValidationContext) -> list[RuleFinding]:
+    findings: list[RuleFinding] = []
+    for name, step in ctx.recipe.steps.items():
+        if step.tool != "run_cmd":
+            continue
+        if name in _INLINE_SCRIPT_ALLOWLIST:
+            continue
+        cmd = (step.with_args or {}).get("cmd", "")
+        if not isinstance(cmd, str):
+            continue
+
+        if _PYTHON3_C_RE.search(cmd):
+            findings.append(
+                RuleFinding(
+                    rule="inline-python-in-cmd",
+                    severity=Severity.ERROR,
+                    step_name=name,
+                    message=(
+                        f"Step '{name}' uses python3 -c in cmd. "
+                        "Convert to a run_python callable."
+                    ),
+                )
+            )
+
+    return findings

--- a/src/autoskillit/recipe/rules_inline_script.py
+++ b/src/autoskillit/recipe/rules_inline_script.py
@@ -36,8 +36,6 @@ _JQ_BLOCK_RE = re.compile(
     re.DOTALL,
 )
 
-_LOOP_RE = re.compile(r"\bfor\s+\w+\s+in\s+.*;\s*do\b|\bwhile\s+.*;\s*do\b")
-
 _BASH_BUILTINS_RE = re.compile(r"\b(?:mapfile|read\s+-r|declare|local|export)\b")
 
 _VAR_ASSIGN_RE = re.compile(r"^[A-Z_][A-Z0-9_]*=", re.MULTILINE)
@@ -84,20 +82,6 @@ def _check_inline_script_in_cmd(ctx: ValidationContext) -> list[RuleFinding]:
                     step_name=name,
                     message=(
                         f"Step '{name}' contains shell control flow in cmd. "
-                        "Extract to a .sh script or run_python callable."
-                    ),
-                )
-            )
-            continue
-
-        if _LOOP_RE.search(stripped):
-            findings.append(
-                RuleFinding(
-                    rule="inline-script-in-cmd",
-                    severity=Severity.ERROR,
-                    step_name=name,
-                    message=(
-                        f"Step '{name}' contains a shell loop in cmd. "
                         "Extract to a .sh script or run_python callable."
                     ),
                 )

--- a/src/autoskillit/recipe/rules_inline_script.py
+++ b/src/autoskillit/recipe/rules_inline_script.py
@@ -8,8 +8,6 @@ from autoskillit.core import Severity
 from autoskillit.recipe._analysis import ValidationContext
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
 
-_INLINE_SCRIPT_ALLOWLIST: frozenset[str] = frozenset()
-
 # ---------------------------------------------------------------------------
 # Detection patterns
 # ---------------------------------------------------------------------------
@@ -71,8 +69,6 @@ def _check_inline_script_in_cmd(ctx: ValidationContext) -> list[RuleFinding]:
     findings: list[RuleFinding] = []
     for name, step in ctx.recipe.steps.items():
         if step.tool != "run_cmd":
-            continue
-        if name in _INLINE_SCRIPT_ALLOWLIST:
             continue
         cmd = (step.with_args or {}).get("cmd", "")
         if not isinstance(cmd, str):
@@ -169,8 +165,6 @@ def _check_inline_python_in_cmd(ctx: ValidationContext) -> list[RuleFinding]:
     findings: list[RuleFinding] = []
     for name, step in ctx.recipe.steps.items():
         if step.tool != "run_cmd":
-            continue
-        if name in _INLINE_SCRIPT_ALLOWLIST:
             continue
         cmd = (step.with_args or {}).get("cmd", "")
         if not isinstance(cmd, str):

--- a/src/autoskillit/recipe/rules_inline_script.py
+++ b/src/autoskillit/recipe/rules_inline_script.py
@@ -8,39 +8,7 @@ from autoskillit.core import Severity
 from autoskillit.recipe._analysis import ValidationContext
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
 
-# Grandfathered violations — to be removed as Part B externalizes them.
-# Populated mechanically by running the rule without the allowlist against all
-# bundled recipe files and collecting every step name that fires.
-_INLINE_SCRIPT_ALLOWLIST: frozenset[str] = frozenset(
-    {
-        "advance_queue_pr",
-        "attempt_cheap_rebase",
-        "check_dropped_healthy_loop",
-        "check_eject_limit",
-        "commit_guard",
-        "compute_branch",
-        "create_artifact_branch",
-        "create_persistent_integration",
-        "create_worktree",
-        "direct_merge_conflict_fix",
-        "emit_fallback_map",
-        "ensure_results",
-        "export_local_bundle",
-        "finalize_bundle",
-        "force_push_and_wait_mergeability",
-        "immediate_merge_conflict_fix",
-        "open_artifact_pr",
-        "proactive_rebase_next_pr",
-        "queue_ejected_fix",
-        "re_stage_bundle",
-        "refetch_issues",
-        "stage_bundle",
-        "tag_experiment_branch",
-        "wait_for_direct_merge",
-        "wait_for_immediate_merge",
-        "wait_for_review_pr_mergeability",
-    }
-)
+_INLINE_SCRIPT_ALLOWLIST: frozenset[str] = frozenset()
 
 # ---------------------------------------------------------------------------
 # Detection patterns

--- a/src/autoskillit/recipe/rules_inline_script.py
+++ b/src/autoskillit/recipe/rules_inline_script.py
@@ -11,34 +11,36 @@ from autoskillit.recipe.registry import RuleFinding, semantic_rule
 # Grandfathered violations — to be removed as Part B externalizes them.
 # Populated mechanically by running the rule without the allowlist against all
 # bundled recipe files and collecting every step name that fires.
-_INLINE_SCRIPT_ALLOWLIST: frozenset[str] = frozenset({
-    "advance_queue_pr",
-    "attempt_cheap_rebase",
-    "check_dropped_healthy_loop",
-    "check_eject_limit",
-    "commit_guard",
-    "compute_branch",
-    "create_artifact_branch",
-    "create_persistent_integration",
-    "create_worktree",
-    "direct_merge_conflict_fix",
-    "emit_fallback_map",
-    "ensure_results",
-    "export_local_bundle",
-    "finalize_bundle",
-    "force_push_and_wait_mergeability",
-    "immediate_merge_conflict_fix",
-    "open_artifact_pr",
-    "proactive_rebase_next_pr",
-    "queue_ejected_fix",
-    "re_stage_bundle",
-    "refetch_issues",
-    "stage_bundle",
-    "tag_experiment_branch",
-    "wait_for_direct_merge",
-    "wait_for_immediate_merge",
-    "wait_for_review_pr_mergeability",
-})
+_INLINE_SCRIPT_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "advance_queue_pr",
+        "attempt_cheap_rebase",
+        "check_dropped_healthy_loop",
+        "check_eject_limit",
+        "commit_guard",
+        "compute_branch",
+        "create_artifact_branch",
+        "create_persistent_integration",
+        "create_worktree",
+        "direct_merge_conflict_fix",
+        "emit_fallback_map",
+        "ensure_results",
+        "export_local_bundle",
+        "finalize_bundle",
+        "force_push_and_wait_mergeability",
+        "immediate_merge_conflict_fix",
+        "open_artifact_pr",
+        "proactive_rebase_next_pr",
+        "queue_ejected_fix",
+        "re_stage_bundle",
+        "refetch_issues",
+        "stage_bundle",
+        "tag_experiment_branch",
+        "wait_for_direct_merge",
+        "wait_for_immediate_merge",
+        "wait_for_review_pr_mergeability",
+    }
+)
 
 # ---------------------------------------------------------------------------
 # Detection patterns
@@ -86,9 +88,7 @@ def _strip_jq_blocks(cmd: str) -> str:
 
 def _count_logical_lines(cmd: str) -> int:
     """Count non-blank, non-comment lines."""
-    return sum(
-        1 for line in cmd.splitlines() if line.strip() and not line.strip().startswith("#")
-    )
+    return sum(1 for line in cmd.splitlines() if line.strip() and not line.strip().startswith("#"))
 
 
 @semantic_rule(
@@ -193,8 +193,7 @@ def _check_inline_script_in_cmd(ctx: ValidationContext) -> list[RuleFinding]:
 @semantic_rule(
     name="inline-python-in-cmd",
     description=(
-        "Detects python3 -c usage in run_cmd cmd fields "
-        "(must use run_python callable instead)"
+        "Detects python3 -c usage in run_cmd cmd fields (must use run_python callable instead)"
     ),
     severity=Severity.ERROR,
 )
@@ -216,8 +215,7 @@ def _check_inline_python_in_cmd(ctx: ValidationContext) -> list[RuleFinding]:
                     severity=Severity.ERROR,
                     step_name=name,
                     message=(
-                        f"Step '{name}' uses python3 -c in cmd. "
-                        "Convert to a run_python callable."
+                        f"Step '{name}' uses python3 -c in cmd. Convert to a run_python callable."
                     ),
                 )
             )

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -2213,3 +2213,240 @@ callable_contracts:
       type: str
     - name: item_ids
       type: str
+  autoskillit.recipe._cmd_rpc.compute_branch:
+    inputs:
+    - name: issue_slug
+      type: str
+      required: false
+    - name: run_name
+      type: str
+      required: false
+    - name: issue_number
+      type: str
+      required: false
+    outputs:
+    - name: branch_name
+      type: str
+  autoskillit.recipe._cmd_rpc.check_eject_limit:
+    inputs:
+    - name: counter_file
+      type: str
+      required: true
+    - name: max_ejects
+      type: str
+      required: false
+    outputs:
+    - name: status
+      type: str
+    - name: count
+      type: str
+  autoskillit.recipe._cmd_rpc.check_dropped_healthy_loop:
+    inputs:
+    - name: counter_file
+      type: str
+      required: true
+    - name: max_drops
+      type: str
+      required: false
+    outputs:
+    - name: status
+      type: str
+    - name: count
+      type: str
+  autoskillit.recipe._cmd_rpc.commit_guard:
+    inputs:
+    - name: worktree_path
+      type: str
+      required: true
+    outputs:
+    - name: committed
+      type: str
+  autoskillit.recipe._cmd_rpc.queue_ejected_fix:
+    inputs:
+    - name: work_dir
+      type: str
+      required: true
+    - name: base_branch
+      type: str
+      required: true
+    outputs:
+    - name: status
+      type: str
+  autoskillit.recipe._cmd_rpc.direct_merge_conflict_fix:
+    inputs:
+    - name: work_dir
+      type: str
+      required: true
+    - name: base_branch
+      type: str
+      required: true
+    outputs:
+    - name: status
+      type: str
+  autoskillit.recipe._cmd_rpc.immediate_merge_conflict_fix:
+    inputs:
+    - name: work_dir
+      type: str
+      required: true
+    - name: base_branch
+      type: str
+      required: true
+    outputs:
+    - name: status
+      type: str
+  autoskillit.recipe._cmd_rpc.wait_for_direct_merge:
+    inputs:
+    - name: pr_number
+      type: str
+      required: true
+    - name: max_polls
+      type: str
+      required: false
+    - name: poll_interval
+      type: str
+      required: false
+    outputs:
+    - name: state
+      type: str
+  autoskillit.recipe._cmd_rpc.wait_for_immediate_merge:
+    inputs:
+    - name: pr_number
+      type: str
+      required: true
+    - name: max_polls
+      type: str
+      required: false
+    - name: poll_interval
+      type: str
+      required: false
+    outputs:
+    - name: state
+      type: str
+  autoskillit.recipe._cmd_rpc.attempt_cheap_rebase:
+    inputs:
+    - name: work_dir
+      type: str
+      required: true
+    - name: ejected_pr_branch
+      type: str
+      required: true
+    - name: base_branch
+      type: str
+      required: true
+    outputs:
+    - name: status
+      type: str
+  autoskillit.recipe._cmd_rpc.wait_for_review_pr_mergeability:
+    inputs:
+    - name: pr_url
+      type: str
+      required: true
+    - name: max_polls
+      type: str
+      required: false
+    - name: poll_interval
+      type: str
+      required: false
+    outputs:
+    - name: pr_number
+      type: str
+  autoskillit.recipe._cmd_rpc.create_persistent_integration:
+    inputs:
+    - name: work_dir
+      type: str
+      required: true
+    - name: base_branch
+      type: str
+      required: true
+    outputs:
+    - name: ok
+      type: str
+  autoskillit.recipe._cmd_rpc.force_push_and_wait_mergeability:
+    inputs:
+    - name: work_dir
+      type: str
+      required: true
+    - name: integration_branch
+      type: str
+      required: true
+    - name: review_pr_number
+      type: str
+      required: true
+    - name: max_polls
+      type: str
+      required: false
+    - name: poll_interval
+      type: str
+      required: false
+    outputs:
+    - name: ok
+      type: str
+  autoskillit.recipe._cmd_rpc.advance_queue_pr:
+    inputs:
+    - name: current_pr_number
+      type: str
+      required: true
+    - name: pr_order_file
+      type: str
+      required: true
+    outputs:
+    - name: current_pr_number
+      type: str
+  autoskillit.recipe._cmd_rpc.proactive_rebase_next_pr:
+    inputs:
+    - name: work_dir
+      type: str
+      required: true
+    - name: next_pr_branch
+      type: str
+      required: true
+    - name: base_branch
+      type: str
+      required: true
+    outputs:
+    - name: status
+      type: str
+  autoskillit.recipe._cmd_rpc.refetch_issues:
+    inputs:
+    - name: issue_urls
+      type: str
+      required: true
+    outputs:
+    - name: issue_numbers
+      type: str
+  autoskillit.recipe._cmd_rpc.emit_fallback_map:
+    inputs:
+    - name: issue_urls
+      type: str
+      required: true
+    - name: temp_dir
+      type: str
+      required: true
+    outputs:
+    - name: execution_map
+      type: str
+  autoskillit.recipe._cmd_rpc.ensure_results:
+    inputs:
+    - name: experiment_results
+      type: str
+      required: true
+    - name: worktree_path
+      type: str
+      required: true
+    - name: temp_subdir
+      type: str
+      required: false
+    outputs:
+    - name: experiment_results
+      type: str
+  autoskillit.recipe._cmd_rpc.export_local_bundle:
+    inputs:
+    - name: source_dir
+      type: str
+      required: true
+    - name: research_dir
+      type: str
+      required: true
+    outputs:
+    - name: local_bundle_path
+      type: str

--- a/src/autoskillit/recipes/bem-wrapper.yaml
+++ b/src/autoskillit/recipes/bem-wrapper.yaml
@@ -27,29 +27,12 @@ ingredients:
 
 steps:
   refetch_issues:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: |
-        ISSUE_URLS="${{ inputs.issue_urls }}"
-        QUERY=$(ISSUE_URLS="$ISSUE_URLS" python3 -c "
-        import os, re
-        urls = os.environ['ISSUE_URLS'].split(',')
-        parts = []
-        for i, url in enumerate(urls):
-            url = url.strip()
-            if not url:
-                continue
-            m = re.match(r'https://github\.com/([^/]+)/([^/]+)/issues/(\d+)', url)
-            if m:
-                owner, repo, num = m.groups()
-                parts.append(f'i{i}: repository(owner: \"{owner}\", name: \"{repo}\") {{ issue(number: {num}) {{ number state }} }}')
-        print('{' + ' '.join(parts) + '}')
-        ")
-        gh api graphql -f query="$QUERY" \
-          --jq '[.data[] | select(.issue != null and .issue.state == "OPEN") | .issue.number | tostring] | join(" ")' && echo ""
-      step_name: refetch_issues
+      callable: "autoskillit.recipe._cmd_rpc.refetch_issues"
+      issue_urls: "${{ inputs.issue_urls }}"
     capture:
-      issue_numbers: "${{ result.stdout | trim }}"
+      issue_numbers: "${{ result.issue_numbers }}"
     on_success: check_issue_count
     on_failure: emit_fallback_map
 
@@ -72,33 +55,13 @@ steps:
     on_failure: emit_fallback_map
 
   emit_fallback_map:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: |
-        MAP_FILE="{{AUTOSKILLIT_TEMP}}/bem-fallback-map.json"
-        ISSUE_URLS="${{ inputs.issue_urls }}"
-        NUMS=$(echo "$ISSUE_URLS" | tr ',' '\n' | grep -oE 'issues/[0-9]+' | grep -oE '[0-9]+' | tr '\n' ',' | sed 's/,$//')
-        NUMS="$NUMS" MAP_FILE="$MAP_FILE" python3 -c "
-        import json, os, sys
-        nums_str = os.environ['NUMS']
-        map_file = os.environ['MAP_FILE']
-        nums = [int(n) for n in nums_str.split(',') if n.strip()]
-        if not nums:
-            print('ERROR: no issue numbers extracted from issue URLs', file=sys.stderr)
-            sys.exit(1)
-        issues = [{'number': n, 'title': str(n)} for n in nums]
-        data = {
-            'groups': [{'group': 1, 'parallel': False, 'issues': issues}],
-            'merge_order': nums,
-            'pairwise_assessments': []
-        }
-        with open(map_file, 'w') as f:
-            json.dump(data, f)
-        print(map_file)
-        "
-      step_name: emit_fallback_map
+      callable: "autoskillit.recipe._cmd_rpc.emit_fallback_map"
+      issue_urls: "${{ inputs.issue_urls }}"
+      temp_dir: "{{AUTOSKILLIT_TEMP}}"
     capture:
-      execution_map: "${{ result.stdout | trim }}"
+      execution_map: "${{ result.execution_map }}"
     on_success: emit_result
     on_failure: escalate_stop
 

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -148,22 +148,14 @@ steps:
     on_failure: escalate_stop
 
   compute_branch:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: >-
-        SLUG="${{ context.issue_slug }}" &&
-        RUN="${{ inputs.run_name }}" &&
-        PREFIX="${SLUG:-$RUN}" &&
-        ISSUE="${{ context.issue_number }}" &&
-        if [ -n "$ISSUE" ]; then
-          printf '%s' "${PREFIX}/${ISSUE}"
-        else
-          printf '%s' "${PREFIX}/$(date +%Y%m%d)"
-        fi
-      cwd: "${{ context.work_dir }}"
-      step_name: "compute_branch"
+      callable: "autoskillit.recipe._cmd_rpc.compute_branch"
+      issue_slug: "${{ context.issue_slug }}"
+      run_name: "${{ inputs.run_name }}"
+      issue_number: "${{ context.issue_number }}"
     capture:
-      proposed_branch: "${{ result.stdout | trim }}"
+      proposed_branch: "${{ result.branch_name }}"
     on_success: create_branch
     on_failure: release_issue_failure
     optional: true
@@ -323,11 +315,10 @@ steps:
     on_failure: fix
 
   commit_guard:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: "cd ${{ context.worktree_path }} && if [ -n \"$(git status --porcelain)\" ]; then git add -A && git commit -m 'chore: commit pending session changes'; fi"
-      cwd: "${{ context.worktree_path }}"
-      step_name: commit_guard
+      callable: "autoskillit.recipe._cmd_rpc.commit_guard"
+      worktree_path: "${{ context.worktree_path }}"
     on_success: merge
     on_failure: merge
     note: >
@@ -1106,23 +1097,13 @@ steps:
       to register_clone_unconfirmed (merge outcome unconfirmed).
 
   check_eject_limit:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: >
-        COUNTER_FILE="${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/eject_count" &&
-        mkdir -p "$(dirname "$COUNTER_FILE")" &&
-        COUNT=$(cat "$COUNTER_FILE" 2>/dev/null || echo 0) &&
-        COUNT=$((COUNT + 1)) &&
-        echo "$COUNT" > "$COUNTER_FILE" &&
-        if [ "$COUNT" -gt 3 ]; then
-          echo "EJECT_LIMIT_EXCEEDED";
-        else
-          echo "EJECT_OK";
-        fi
-      cwd: "${{ context.work_dir }}"
-      step_name: "check_eject_limit"
+      callable: "autoskillit.recipe._cmd_rpc.check_eject_limit"
+      counter_file: "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/eject_count"
+      max_ejects: "3"
     on_result:
-      - when: "${{ result.stdout | trim }} == EJECT_LIMIT_EXCEEDED"
+      - when: "${{ result.status }} == EJECT_LIMIT_EXCEEDED"
         route: release_issue_failure
       - route: queue_ejected_fix
     on_failure: release_issue_failure
@@ -1132,23 +1113,13 @@ steps:
       to release_issue_failure to prevent infinite re-enqueue cycles.
 
   check_dropped_healthy_loop:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: >
-        COUNTER_FILE="${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/dropped_healthy_count" &&
-        mkdir -p "$(dirname "$COUNTER_FILE")" &&
-        COUNT=$(cat "$COUNTER_FILE" 2>/dev/null || echo 0) &&
-        COUNT=$((COUNT + 1)) &&
-        echo "$COUNT" > "$COUNTER_FILE" &&
-        if [ "$COUNT" -gt 2 ]; then
-          echo "DROPPED_LIMIT_EXCEEDED";
-        else
-          echo "DROPPED_OK";
-        fi
-      cwd: "${{ context.work_dir }}"
-      step_name: "check_dropped_healthy_loop"
+      callable: "autoskillit.recipe._cmd_rpc.check_dropped_healthy_loop"
+      counter_file: "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/dropped_healthy_count"
+      max_drops: "2"
     on_result:
-      - when: "${{ result.stdout | trim }} == DROPPED_LIMIT_EXCEEDED"
+      - when: "${{ result.status }} == DROPPED_LIMIT_EXCEEDED"
         route: release_issue_failure
       - route: reenter_merge_queue_cheap
     on_failure: release_issue_failure
@@ -1160,18 +1131,13 @@ steps:
       directly to diagnose_ci and never reaches this step.
 
   queue_ejected_fix:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: |
-        REMOTE=$(git remote get-url upstream 2>/dev/null | grep -qv "^file://" && echo upstream || echo origin) &&
-        if git fetch "$REMOTE" ${{ inputs.base_branch }} && git rebase "$REMOTE"/${{ inputs.base_branch }};
-        then echo 'clean';
-        else git rebase --abort 2>/dev/null || true; echo 'conflicts';
-        fi
-      cwd: "${{ context.work_dir }}"
-      step_name: "queue_ejected_fix"
+      callable: "autoskillit.recipe._cmd_rpc.queue_ejected_fix"
+      work_dir: "${{ context.work_dir }}"
+      base_branch: "${{ inputs.base_branch }}"
     on_result:
-      - when: "${{ result.stdout | trim }} == clean"
+      - when: "${{ result.status }} == clean"
         route: re_push_queue_fix
       - route: resolve_queue_merge_conflicts
     on_failure: resolve_queue_merge_conflicts
@@ -1287,21 +1253,16 @@ steps:
       reports an error rather than silently succeeding.
 
   wait_for_direct_merge:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: >
-        for i in $(seq 1 90); do
-          STATE=$(gh pr view '${{ context.pr_number }}' --json state --jq '.state');
-          if [ "$STATE" = "MERGED" ]; then echo "merged"; exit 0; fi;
-          if [ "$STATE" = "CLOSED" ]; then echo "closed"; exit 0; fi;
-          sleep 10;
-        done; echo "timeout"
-      cwd: "${{ context.work_dir }}"
-      step_name: "wait_for_direct_merge"
+      callable: "autoskillit.recipe._cmd_rpc.wait_for_direct_merge"
+      pr_number: "${{ context.pr_number }}"
+      max_polls: "90"
+      poll_interval: "10"
     on_result:
-      - when: "${{ result.stdout | trim }} == merged"
+      - when: "${{ result.state }} == merged"
         route: release_issue_success
-      - when: "${{ result.stdout | trim }} == closed"
+      - when: "${{ result.state }} == closed"
         route: direct_merge_conflict_fix
       - route: register_clone_unconfirmed
     on_failure: register_clone_unconfirmed
@@ -1313,18 +1274,13 @@ steps:
       timeout / unexpected → register_clone_unconfirmed.
 
   direct_merge_conflict_fix:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: |
-        REMOTE=$(git remote get-url upstream 2>/dev/null | grep -qv "^file://" && echo upstream || echo origin) &&
-        if git fetch "$REMOTE" ${{ inputs.base_branch }} && git rebase "$REMOTE"/${{ inputs.base_branch }};
-        then echo 'clean';
-        else git rebase --abort 2>/dev/null || true; echo 'conflicts';
-        fi
-      cwd: "${{ context.work_dir }}"
-      step_name: "direct_merge_conflict_fix"
+      callable: "autoskillit.recipe._cmd_rpc.direct_merge_conflict_fix"
+      work_dir: "${{ context.work_dir }}"
+      base_branch: "${{ inputs.base_branch }}"
     on_result:
-      - when: "${{ result.stdout | trim }} == clean"
+      - when: "${{ result.status }} == clean"
         route: re_push_direct_fix
       - route: resolve_direct_merge_conflicts
     on_failure: resolve_direct_merge_conflicts
@@ -1398,21 +1354,16 @@ steps:
       pipeline reports an error rather than silently succeeding.
 
   wait_for_immediate_merge:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: >
-        for i in $(seq 1 30); do
-          STATE=$(gh pr view '${{ context.pr_number }}' --json state --jq '.state');
-          if [ "$STATE" = "MERGED" ]; then echo "merged"; exit 0; fi;
-          if [ "$STATE" = "CLOSED" ]; then echo "closed"; exit 0; fi;
-          sleep 10;
-        done; echo "timeout"
-      cwd: "${{ context.work_dir }}"
-      step_name: "wait_for_immediate_merge"
+      callable: "autoskillit.recipe._cmd_rpc.wait_for_immediate_merge"
+      pr_number: "${{ context.pr_number }}"
+      max_polls: "30"
+      poll_interval: "10"
     on_result:
-      - when: "${{ result.stdout | trim }} == merged"
+      - when: "${{ result.state }} == merged"
         route: release_issue_success
-      - when: "${{ result.stdout | trim }} == closed"
+      - when: "${{ result.state }} == closed"
         route: immediate_merge_conflict_fix
       - route: register_clone_unconfirmed
     on_failure: register_clone_unconfirmed
@@ -1426,18 +1377,13 @@ steps:
       timeout → register_clone_unconfirmed.
 
   immediate_merge_conflict_fix:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: |
-        REMOTE=$(git remote get-url upstream 2>/dev/null | grep -qv "^file://" && echo upstream || echo origin) &&
-        if git fetch "$REMOTE" ${{ inputs.base_branch }} && git rebase "$REMOTE"/${{ inputs.base_branch }};
-        then echo 'clean';
-        else git rebase --abort 2>/dev/null || true; echo 'conflicts';
-        fi
-      cwd: "${{ context.work_dir }}"
-      step_name: "immediate_merge_conflict_fix"
+      callable: "autoskillit.recipe._cmd_rpc.immediate_merge_conflict_fix"
+      work_dir: "${{ context.work_dir }}"
+      base_branch: "${{ inputs.base_branch }}"
     on_result:
-      - when: "${{ result.stdout | trim }} == clean"
+      - when: "${{ result.status }} == clean"
         route: re_push_immediate_fix
       - route: resolve_immediate_merge_conflicts
     on_failure: resolve_immediate_merge_conflicts

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -161,22 +161,14 @@ steps:
     on_failure: escalate_stop
 
   compute_branch:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: >-
-        SLUG="${{ context.issue_slug }}" &&
-        RUN="${{ inputs.run_name }}" &&
-        PREFIX="${SLUG:-$RUN}" &&
-        ISSUE="${{ context.issue_number }}" &&
-        if [ -n "$ISSUE" ]; then
-          printf '%s' "${PREFIX}/${ISSUE}"
-        else
-          printf '%s' "${PREFIX}/$(date +%Y%m%d)"
-        fi
-      cwd: "${{ context.work_dir }}"
-      step_name: "compute_branch"
+      callable: "autoskillit.recipe._cmd_rpc.compute_branch"
+      issue_slug: "${{ context.issue_slug }}"
+      run_name: "${{ inputs.run_name }}"
+      issue_number: "${{ context.issue_number }}"
     capture:
-      proposed_branch: "${{ result.stdout | trim }}"
+      proposed_branch: "${{ result.branch_name }}"
     on_success: create_branch
     on_failure: release_issue_failure
     optional: true
@@ -314,11 +306,10 @@ steps:
     on_failure: fix
 
   commit_guard:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: "cd ${{ context.worktree_path }} && if [ -n \"$(git status --porcelain)\" ]; then git add -A && git commit -m 'chore: commit pending session changes'; fi"
-      cwd: "${{ context.worktree_path }}"
-      step_name: commit_guard
+      callable: "autoskillit.recipe._cmd_rpc.commit_guard"
+      worktree_path: "${{ context.worktree_path }}"
     on_success: merge
     on_failure: merge
     note: >
@@ -1007,23 +998,13 @@ steps:
       to register_clone_unconfirmed (merge outcome unconfirmed).
 
   check_eject_limit:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: >
-        COUNTER_FILE="${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/eject_count" &&
-        mkdir -p "$(dirname "$COUNTER_FILE")" &&
-        COUNT=$(cat "$COUNTER_FILE" 2>/dev/null || echo 0) &&
-        COUNT=$((COUNT + 1)) &&
-        echo "$COUNT" > "$COUNTER_FILE" &&
-        if [ "$COUNT" -gt 3 ]; then
-          echo "EJECT_LIMIT_EXCEEDED";
-        else
-          echo "EJECT_OK";
-        fi
-      cwd: "${{ context.work_dir }}"
-      step_name: "check_eject_limit"
+      callable: "autoskillit.recipe._cmd_rpc.check_eject_limit"
+      counter_file: "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/eject_count"
+      max_ejects: "3"
     on_result:
-      - when: "${{ result.stdout | trim }} == EJECT_LIMIT_EXCEEDED"
+      - when: "${{ result.status }} == EJECT_LIMIT_EXCEEDED"
         route: release_issue_failure
       - route: queue_ejected_fix
     on_failure: release_issue_failure
@@ -1033,23 +1014,13 @@ steps:
       to release_issue_failure to prevent infinite re-enqueue cycles.
 
   check_dropped_healthy_loop:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: >
-        COUNTER_FILE="${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/dropped_healthy_count" &&
-        mkdir -p "$(dirname "$COUNTER_FILE")" &&
-        COUNT=$(cat "$COUNTER_FILE" 2>/dev/null || echo 0) &&
-        COUNT=$((COUNT + 1)) &&
-        echo "$COUNT" > "$COUNTER_FILE" &&
-        if [ "$COUNT" -gt 2 ]; then
-          echo "DROPPED_LIMIT_EXCEEDED";
-        else
-          echo "DROPPED_OK";
-        fi
-      cwd: "${{ context.work_dir }}"
-      step_name: "check_dropped_healthy_loop"
+      callable: "autoskillit.recipe._cmd_rpc.check_dropped_healthy_loop"
+      counter_file: "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/dropped_healthy_count"
+      max_drops: "2"
     on_result:
-      - when: "${{ result.stdout | trim }} == DROPPED_LIMIT_EXCEEDED"
+      - when: "${{ result.status }} == DROPPED_LIMIT_EXCEEDED"
         route: release_issue_failure
       - route: reenter_merge_queue_cheap
     on_failure: release_issue_failure
@@ -1061,18 +1032,13 @@ steps:
       directly to diagnose_ci and never reaches this step.
 
   queue_ejected_fix:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: |
-        REMOTE=$(git remote get-url upstream 2>/dev/null | grep -qv "^file://" && echo upstream || echo origin) &&
-        if git fetch "$REMOTE" ${{ inputs.base_branch }} && git rebase "$REMOTE"/${{ inputs.base_branch }};
-        then echo 'clean';
-        else git rebase --abort 2>/dev/null || true; echo 'conflicts';
-        fi
-      cwd: "${{ context.work_dir }}"
-      step_name: "queue_ejected_fix"
+      callable: "autoskillit.recipe._cmd_rpc.queue_ejected_fix"
+      work_dir: "${{ context.work_dir }}"
+      base_branch: "${{ inputs.base_branch }}"
     on_result:
-      - when: "${{ result.stdout | trim }} == clean"
+      - when: "${{ result.status }} == clean"
         route: re_push_queue_fix
       - route: resolve_queue_merge_conflicts
     on_failure: resolve_queue_merge_conflicts
@@ -1188,21 +1154,16 @@ steps:
       reports an error rather than silently succeeding.
 
   wait_for_direct_merge:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: >
-        for i in $(seq 1 90); do
-          STATE=$(gh pr view '${{ context.pr_number }}' --json state --jq '.state');
-          if [ "$STATE" = "MERGED" ]; then echo "merged"; exit 0; fi;
-          if [ "$STATE" = "CLOSED" ]; then echo "closed"; exit 0; fi;
-          sleep 10;
-        done; echo "timeout"
-      cwd: "${{ context.work_dir }}"
-      step_name: "wait_for_direct_merge"
+      callable: "autoskillit.recipe._cmd_rpc.wait_for_direct_merge"
+      pr_number: "${{ context.pr_number }}"
+      max_polls: "90"
+      poll_interval: "10"
     on_result:
-      - when: "${{ result.stdout | trim }} == merged"
+      - when: "${{ result.state }} == merged"
         route: release_issue_success
-      - when: "${{ result.stdout | trim }} == closed"
+      - when: "${{ result.state }} == closed"
         route: direct_merge_conflict_fix
       - route: register_clone_unconfirmed
     on_failure: register_clone_unconfirmed
@@ -1214,18 +1175,13 @@ steps:
       timeout / unexpected → register_clone_unconfirmed.
 
   direct_merge_conflict_fix:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: |
-        REMOTE=$(git remote get-url upstream 2>/dev/null | grep -qv "^file://" && echo upstream || echo origin) &&
-        if git fetch "$REMOTE" ${{ inputs.base_branch }} && git rebase "$REMOTE"/${{ inputs.base_branch }};
-        then echo 'clean';
-        else git rebase --abort 2>/dev/null || true; echo 'conflicts';
-        fi
-      cwd: "${{ context.work_dir }}"
-      step_name: "direct_merge_conflict_fix"
+      callable: "autoskillit.recipe._cmd_rpc.direct_merge_conflict_fix"
+      work_dir: "${{ context.work_dir }}"
+      base_branch: "${{ inputs.base_branch }}"
     on_result:
-      - when: "${{ result.stdout | trim }} == clean"
+      - when: "${{ result.status }} == clean"
         route: re_push_direct_fix
       - route: resolve_direct_merge_conflicts
     on_failure: resolve_direct_merge_conflicts
@@ -1299,21 +1255,16 @@ steps:
       pipeline reports an error rather than silently succeeding.
 
   wait_for_immediate_merge:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: >
-        for i in $(seq 1 30); do
-          STATE=$(gh pr view '${{ context.pr_number }}' --json state --jq '.state');
-          if [ "$STATE" = "MERGED" ]; then echo "merged"; exit 0; fi;
-          if [ "$STATE" = "CLOSED" ]; then echo "closed"; exit 0; fi;
-          sleep 10;
-        done; echo "timeout"
-      cwd: "${{ context.work_dir }}"
-      step_name: "wait_for_immediate_merge"
+      callable: "autoskillit.recipe._cmd_rpc.wait_for_immediate_merge"
+      pr_number: "${{ context.pr_number }}"
+      max_polls: "30"
+      poll_interval: "10"
     on_result:
-      - when: "${{ result.stdout | trim }} == merged"
+      - when: "${{ result.state }} == merged"
         route: release_issue_success
-      - when: "${{ result.stdout | trim }} == closed"
+      - when: "${{ result.state }} == closed"
         route: immediate_merge_conflict_fix
       - route: register_clone_unconfirmed
     on_failure: register_clone_unconfirmed
@@ -1327,18 +1278,13 @@ steps:
       timeout → register_clone_unconfirmed.
 
   immediate_merge_conflict_fix:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: |
-        REMOTE=$(git remote get-url upstream 2>/dev/null | grep -qv "^file://" && echo upstream || echo origin) &&
-        if git fetch "$REMOTE" ${{ inputs.base_branch }} && git rebase "$REMOTE"/${{ inputs.base_branch }};
-        then echo 'clean';
-        else git rebase --abort 2>/dev/null || true; echo 'conflicts';
-        fi
-      cwd: "${{ context.work_dir }}"
-      step_name: "immediate_merge_conflict_fix"
+      callable: "autoskillit.recipe._cmd_rpc.immediate_merge_conflict_fix"
+      work_dir: "${{ context.work_dir }}"
+      base_branch: "${{ inputs.base_branch }}"
     on_result:
-      - when: "${{ result.stdout | trim }} == clean"
+      - when: "${{ result.status }} == clean"
         route: re_push_immediate_fix
       - route: resolve_immediate_merge_conflicts
     on_failure: resolve_immediate_merge_conflicts

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -158,15 +158,11 @@ steps:
       proceed without the target branch.
 
   create_persistent_integration:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: |
-        REMOTE=$(git remote get-url upstream 2>/dev/null | grep -qv "^file://" && echo upstream || echo origin)
-        DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
-        DEFAULT_BRANCH=${DEFAULT_BRANCH:-main}
-        git checkout "$DEFAULT_BRANCH" && git pull && git checkout -b '${{ inputs.base_branch }}' && git push "$REMOTE" '${{ inputs.base_branch }}'
-      cwd: "${{ context.work_dir }}"
-      step_name: "create_persistent_integration"
+      callable: "autoskillit.recipe._cmd_rpc.create_persistent_integration"
+      work_dir: "${{ context.work_dir }}"
+      base_branch: "${{ inputs.base_branch }}"
     on_success: fetch_merge_queue_data
     on_failure: register_clone_failure
     note: >
@@ -287,23 +283,13 @@ steps:
       ejected_ci_failure must precede ejected (both match CLOSED state).
 
   check_eject_limit:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: >
-        COUNTER_FILE="${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/eject_count" &&
-        mkdir -p "$(dirname "$COUNTER_FILE")" &&
-        COUNT=$(cat "$COUNTER_FILE" 2>/dev/null || echo 0) &&
-        COUNT=$((COUNT + 1)) &&
-        echo "$COUNT" > "$COUNTER_FILE" &&
-        if [ "$COUNT" -gt 3 ]; then
-          echo "EJECT_LIMIT_EXCEEDED";
-        else
-          echo "EJECT_OK";
-        fi
-      cwd: "${{ context.work_dir }}"
-      step_name: "check_eject_limit"
+      callable: "autoskillit.recipe._cmd_rpc.check_eject_limit"
+      counter_file: "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/eject_count"
+      max_ejects: "3"
     on_result:
-      - when: "${{ result.stdout | trim }} == EJECT_LIMIT_EXCEEDED"
+      - when: "${{ result.status }} == EJECT_LIMIT_EXCEEDED"
         route: register_clone_failure
       - route: get_ejected_pr_branch
     on_failure: register_clone_failure
@@ -312,23 +298,13 @@ steps:
       to register_clone_failure to prevent infinite re-enqueue cycles.
 
   check_dropped_healthy_loop:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: >
-        COUNTER_FILE="${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/dropped_healthy_count" &&
-        mkdir -p "$(dirname "$COUNTER_FILE")" &&
-        COUNT=$(cat "$COUNTER_FILE" 2>/dev/null || echo 0) &&
-        COUNT=$((COUNT + 1)) &&
-        echo "$COUNT" > "$COUNTER_FILE" &&
-        if [ "$COUNT" -gt 2 ]; then
-          echo "DROPPED_LIMIT_EXCEEDED";
-        else
-          echo "DROPPED_OK";
-        fi
-      cwd: "${{ context.work_dir }}"
-      step_name: "check_dropped_healthy_loop"
+      callable: "autoskillit.recipe._cmd_rpc.check_dropped_healthy_loop"
+      counter_file: "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/dropped_healthy_count"
+      max_drops: "2"
     on_result:
-      - when: "${{ result.stdout | trim }} == DROPPED_LIMIT_EXCEEDED"
+      - when: "${{ result.status }} == DROPPED_LIMIT_EXCEEDED"
         route: register_clone_failure
       - route: reenter_queue
     on_failure: register_clone_failure
@@ -351,20 +327,14 @@ steps:
     on_failure: register_clone_failure
 
   attempt_cheap_rebase:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: |
-        REMOTE=$(git remote get-url upstream 2>/dev/null | grep -qv "^file://" && echo upstream || echo origin)
-        git fetch "$REMOTE" '${{ context.ejected_pr_branch }}' &&
-        git checkout '${{ context.ejected_pr_branch }}' &&
-        if git rebase "$REMOTE"/${{ inputs.base_branch }};
-        then echo "clean";
-        else git rebase --abort 2>/dev/null || true; echo "conflicts";
-        fi
-      cwd: "${{ context.work_dir }}"
-      step_name: "attempt_cheap_rebase"
+      callable: "autoskillit.recipe._cmd_rpc.attempt_cheap_rebase"
+      work_dir: "${{ context.work_dir }}"
+      ejected_pr_branch: "${{ context.ejected_pr_branch }}"
+      base_branch: "${{ inputs.base_branch }}"
     on_result:
-      - when: "${{ result.stdout | trim }} == clean"
+      - when: "${{ result.status }} == clean"
         route: push_ejected_fix
       - route: resolve_ejected_conflicts
     on_failure: resolve_ejected_conflicts
@@ -443,15 +413,7 @@ steps:
   advance_queue_pr:
     tool: run_cmd
     with:
-      cmd: >
-        CURRENT='${{ context.current_pr_number }}' &&
-        NEXT=$(jq -r --arg cur "$CURRENT" '
-          (to_entries | map(select(.value.number == ($cur | tonumber))) | .[0].key) as $idx |
-          if ($idx + 1) < length then .[$idx + 1].number | tostring
-          else "done"
-          end
-        ' '${{ context.pr_order_file }}') &&
-        echo "$NEXT"
+      cmd: "bash scripts/recipe/advance_queue_pr.sh '${{ context.current_pr_number }}' '${{ context.pr_order_file }}'"
       cwd: "${{ context.work_dir }}"
       step_name: "advance_queue_pr"
     capture:
@@ -485,20 +447,14 @@ steps:
       falls through to enqueue_current_pr — the queue cycle proceeds normally without rebase.
 
   proactive_rebase_next_pr:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: |
-        REMOTE=$(git remote | grep -q "^upstream$" && echo upstream || echo origin)
-        git fetch "$REMOTE" '${{ context.next_pr_branch }}' &&
-        git checkout -B '${{ context.next_pr_branch }}' "$REMOTE"/'${{ context.next_pr_branch }}' &&
-        if git rebase "$REMOTE"/${{ inputs.base_branch }};
-        then echo "clean";
-        else git rebase --abort 2>/dev/null || true; echo "conflicts";
-        fi
-      cwd: "${{ context.work_dir }}"
-      step_name: "proactive_rebase_next_pr"
+      callable: "autoskillit.recipe._cmd_rpc.proactive_rebase_next_pr"
+      work_dir: "${{ context.work_dir }}"
+      next_pr_branch: "${{ context.next_pr_branch }}"
+      base_branch: "${{ inputs.base_branch }}"
     on_result:
-      - when: "${{ result.stdout | trim }} == clean"
+      - when: "${{ result.status }} == clean"
         route: push_rebased_next_pr
       - route: resolve_proactive_rebase_conflicts
     on_failure: enqueue_current_pr
@@ -950,21 +906,14 @@ steps:
     on_failure: register_clone_failure
 
   wait_for_review_pr_mergeability:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: >
-        PR_NUM=$(gh pr view "${{ context.pr_url }}" --json number -q .number) &&
-        for i in $(seq 1 12); do
-          STATUS=$(gh pr view "$PR_NUM" --json mergeable -q .mergeable);
-          [ "$STATUS" != "UNKNOWN" ] && break;
-          sleep 15;
-        done &&
-        [ "$STATUS" != "UNKNOWN" ] || { echo "Timed out waiting for mergeability" >&2; exit 1; } &&
-        echo "$PR_NUM"
-      cwd: "${{ context.work_dir }}"
-      step_name: "wait_for_review_pr_mergeability"
+      callable: "autoskillit.recipe._cmd_rpc.wait_for_review_pr_mergeability"
+      pr_url: "${{ context.pr_url }}"
+      max_polls: "12"
+      poll_interval: "15"
     capture:
-      review_pr_number: "${{ result.stdout | trim }}"
+      review_pr_number: "${{ result.pr_number }}"
     on_success: check_mergeability
     on_failure: register_clone_failure
     note: >
@@ -1014,20 +963,14 @@ steps:
       On failure, escalates to register_clone_failure with diagnostics (REQ-MERGE-004).
 
   force_push_and_wait_mergeability:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: |
-        REMOTE=$(git remote get-url upstream 2>/dev/null | grep -qv "^file://" && echo upstream || echo origin)
-        git push "$REMOTE" "${{ context.integration_branch }}" --force-with-lease &&
-        PR_NUM="${{ context.review_pr_number }}" &&
-        for i in $(seq 1 12); do
-          STATUS=$(gh pr view "$PR_NUM" --json mergeable -q .mergeable);
-          [ "$STATUS" != "UNKNOWN" ] && break;
-          sleep 15;
-        done &&
-        [ "$STATUS" != "UNKNOWN" ] || { echo "Timed out waiting for post-rebase mergeability" >&2; exit 1; }
-      cwd: "${{ context.work_dir }}"
-      step_name: "force_push_and_wait_mergeability"
+      callable: "autoskillit.recipe._cmd_rpc.force_push_and_wait_mergeability"
+      work_dir: "${{ context.work_dir }}"
+      integration_branch: "${{ context.integration_branch }}"
+      review_pr_number: "${{ context.review_pr_number }}"
+      max_polls: "12"
+      poll_interval: "15"
     on_success: check_mergeability_post_rebase
     on_failure: register_clone_failure
     note: >

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -411,15 +411,15 @@ steps:
       Routes back to wait_queue_pr to continue monitoring.
 
   advance_queue_pr:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: "bash scripts/recipe/advance_queue_pr.sh '${{ context.current_pr_number }}' '${{ context.pr_order_file }}'"
-      cwd: "${{ context.work_dir }}"
-      step_name: "advance_queue_pr"
+      callable: "autoskillit.recipe._cmd_rpc.advance_queue_pr"
+      current_pr_number: "${{ context.current_pr_number }}"
+      pr_order_file: "${{ context.pr_order_file }}"
     capture:
-      current_pr_number: "${{ result.stdout | trim }}"
+      current_pr_number: "${{ result.current_pr_number }}"
     on_result:
-      - when: "${{ result.stdout | trim }} == done"
+      - when: "${{ result.current_pr_number }} == done"
         route: collect_and_check_impl_plans
       - route: get_next_pr_branch
     on_failure: register_clone_failure

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -157,22 +157,14 @@ steps:
     on_failure: escalate_stop
 
   compute_branch:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: >-
-        SLUG="${{ context.issue_slug }}" &&
-        RUN="${{ inputs.run_name }}" &&
-        PREFIX="${SLUG:-$RUN}" &&
-        ISSUE="${{ context.issue_number }}" &&
-        if [ -n "$ISSUE" ]; then
-          printf '%s' "${PREFIX}/${ISSUE}"
-        else
-          printf '%s' "${PREFIX}/$(date +%Y%m%d)"
-        fi
-      cwd: "${{ context.work_dir }}"
-      step_name: "compute_branch"
+      callable: "autoskillit.recipe._cmd_rpc.compute_branch"
+      issue_slug: "${{ context.issue_slug }}"
+      run_name: "${{ inputs.run_name }}"
+      issue_number: "${{ context.issue_number }}"
     capture:
-      proposed_branch: "${{ result.stdout | trim }}"
+      proposed_branch: "${{ result.branch_name }}"
     on_success: create_branch
     on_failure: release_issue_failure
     optional: true
@@ -385,11 +377,10 @@ steps:
     on_failure: release_issue_failure
 
   commit_guard:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: "cd ${{ context.implementation_ref }} && if [ -n \"$(git status --porcelain)\" ]; then git add -A && git commit -m 'chore: commit pending session changes'; fi"
-      cwd: "${{ context.implementation_ref }}"
-      step_name: commit_guard
+      callable: "autoskillit.recipe._cmd_rpc.commit_guard"
+      worktree_path: "${{ context.implementation_ref }}"
     on_success: merge
     on_failure: merge
     note: >
@@ -1007,23 +998,13 @@ steps:
       to register_clone_unconfirmed (merge outcome unconfirmed).
 
   check_eject_limit:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: >
-        COUNTER_FILE="${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/eject_count" &&
-        mkdir -p "$(dirname "$COUNTER_FILE")" &&
-        COUNT=$(cat "$COUNTER_FILE" 2>/dev/null || echo 0) &&
-        COUNT=$((COUNT + 1)) &&
-        echo "$COUNT" > "$COUNTER_FILE" &&
-        if [ "$COUNT" -gt 3 ]; then
-          echo "EJECT_LIMIT_EXCEEDED";
-        else
-          echo "EJECT_OK";
-        fi
-      cwd: "${{ context.work_dir }}"
-      step_name: "check_eject_limit"
+      callable: "autoskillit.recipe._cmd_rpc.check_eject_limit"
+      counter_file: "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/eject_count"
+      max_ejects: "3"
     on_result:
-      - when: "${{ result.stdout | trim }} == EJECT_LIMIT_EXCEEDED"
+      - when: "${{ result.status }} == EJECT_LIMIT_EXCEEDED"
         route: release_issue_failure
       - route: queue_ejected_fix
     on_failure: release_issue_failure
@@ -1033,23 +1014,13 @@ steps:
       to release_issue_failure to prevent infinite re-enqueue cycles.
 
   check_dropped_healthy_loop:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: >
-        COUNTER_FILE="${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/dropped_healthy_count" &&
-        mkdir -p "$(dirname "$COUNTER_FILE")" &&
-        COUNT=$(cat "$COUNTER_FILE" 2>/dev/null || echo 0) &&
-        COUNT=$((COUNT + 1)) &&
-        echo "$COUNT" > "$COUNTER_FILE" &&
-        if [ "$COUNT" -gt 2 ]; then
-          echo "DROPPED_LIMIT_EXCEEDED";
-        else
-          echo "DROPPED_OK";
-        fi
-      cwd: "${{ context.work_dir }}"
-      step_name: "check_dropped_healthy_loop"
+      callable: "autoskillit.recipe._cmd_rpc.check_dropped_healthy_loop"
+      counter_file: "${{ context.work_dir }}/{{AUTOSKILLIT_TEMP}}/dropped_healthy_count"
+      max_drops: "2"
     on_result:
-      - when: "${{ result.stdout | trim }} == DROPPED_LIMIT_EXCEEDED"
+      - when: "${{ result.status }} == DROPPED_LIMIT_EXCEEDED"
         route: release_issue_failure
       - route: reenter_merge_queue_cheap
     on_failure: release_issue_failure
@@ -1061,18 +1032,13 @@ steps:
       directly to diagnose_ci and never reaches this step.
 
   queue_ejected_fix:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: |
-        REMOTE=$(git remote get-url upstream 2>/dev/null | grep -qv "^file://" && echo upstream || echo origin) &&
-        if git fetch "$REMOTE" ${{ inputs.base_branch }} && git rebase "$REMOTE"/${{ inputs.base_branch }};
-        then echo 'clean';
-        else git rebase --abort 2>/dev/null || true; echo 'conflicts';
-        fi
-      cwd: "${{ context.work_dir }}"
-      step_name: "queue_ejected_fix"
+      callable: "autoskillit.recipe._cmd_rpc.queue_ejected_fix"
+      work_dir: "${{ context.work_dir }}"
+      base_branch: "${{ inputs.base_branch }}"
     on_result:
-      - when: "${{ result.stdout | trim }} == clean"
+      - when: "${{ result.status }} == clean"
         route: re_push_queue_fix
       - route: resolve_queue_merge_conflicts
     on_failure: resolve_queue_merge_conflicts
@@ -1188,21 +1154,16 @@ steps:
       reports an error rather than silently succeeding.
 
   wait_for_direct_merge:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: >
-        for i in $(seq 1 90); do
-          STATE=$(gh pr view '${{ context.pr_number }}' --json state --jq '.state');
-          if [ "$STATE" = "MERGED" ]; then echo "merged"; exit 0; fi;
-          if [ "$STATE" = "CLOSED" ]; then echo "closed"; exit 0; fi;
-          sleep 10;
-        done; echo "timeout"
-      cwd: "${{ context.work_dir }}"
-      step_name: "wait_for_direct_merge"
+      callable: "autoskillit.recipe._cmd_rpc.wait_for_direct_merge"
+      pr_number: "${{ context.pr_number }}"
+      max_polls: "90"
+      poll_interval: "10"
     on_result:
-      - when: "${{ result.stdout | trim }} == merged"
+      - when: "${{ result.state }} == merged"
         route: release_issue_success
-      - when: "${{ result.stdout | trim }} == closed"
+      - when: "${{ result.state }} == closed"
         route: direct_merge_conflict_fix
       - route: register_clone_unconfirmed
     on_failure: register_clone_unconfirmed
@@ -1214,18 +1175,13 @@ steps:
       timeout → register_clone_unconfirmed (releases claim; merge unconfirmed).
 
   direct_merge_conflict_fix:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: |
-        REMOTE=$(git remote get-url upstream 2>/dev/null | grep -qv "^file://" && echo upstream || echo origin) &&
-        if git fetch "$REMOTE" ${{ inputs.base_branch }} && git rebase "$REMOTE"/${{ inputs.base_branch }};
-        then echo 'clean';
-        else git rebase --abort 2>/dev/null || true; echo 'conflicts';
-        fi
-      cwd: "${{ context.work_dir }}"
-      step_name: "direct_merge_conflict_fix"
+      callable: "autoskillit.recipe._cmd_rpc.direct_merge_conflict_fix"
+      work_dir: "${{ context.work_dir }}"
+      base_branch: "${{ inputs.base_branch }}"
     on_result:
-      - when: "${{ result.stdout | trim }} == clean"
+      - when: "${{ result.status }} == clean"
         route: re_push_direct_fix
       - route: resolve_direct_merge_conflicts
     on_failure: resolve_direct_merge_conflicts
@@ -1299,21 +1255,16 @@ steps:
       pipeline reports an error rather than silently succeeding.
 
   wait_for_immediate_merge:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: >
-        for i in $(seq 1 30); do
-          STATE=$(gh pr view '${{ context.pr_number }}' --json state --jq '.state');
-          if [ "$STATE" = "MERGED" ]; then echo "merged"; exit 0; fi;
-          if [ "$STATE" = "CLOSED" ]; then echo "closed"; exit 0; fi;
-          sleep 10;
-        done; echo "timeout"
-      cwd: "${{ context.work_dir }}"
-      step_name: "wait_for_immediate_merge"
+      callable: "autoskillit.recipe._cmd_rpc.wait_for_immediate_merge"
+      pr_number: "${{ context.pr_number }}"
+      max_polls: "30"
+      poll_interval: "10"
     on_result:
-      - when: "${{ result.stdout | trim }} == merged"
+      - when: "${{ result.state }} == merged"
         route: release_issue_success
-      - when: "${{ result.stdout | trim }} == closed"
+      - when: "${{ result.state }} == closed"
         route: immediate_merge_conflict_fix
       - route: register_clone_unconfirmed
     on_failure: register_clone_unconfirmed
@@ -1327,18 +1278,13 @@ steps:
       timeout → register_clone_unconfirmed.
 
   immediate_merge_conflict_fix:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: |
-        REMOTE=$(git remote get-url upstream 2>/dev/null | grep -qv "^file://" && echo upstream || echo origin) &&
-        if git fetch "$REMOTE" ${{ inputs.base_branch }} && git rebase "$REMOTE"/${{ inputs.base_branch }};
-        then echo 'clean';
-        else git rebase --abort 2>/dev/null || true; echo 'conflicts';
-        fi
-      cwd: "${{ context.work_dir }}"
-      step_name: "immediate_merge_conflict_fix"
+      callable: "autoskillit.recipe._cmd_rpc.immediate_merge_conflict_fix"
+      work_dir: "${{ context.work_dir }}"
+      base_branch: "${{ inputs.base_branch }}"
     on_result:
-      - when: "${{ result.stdout | trim }} == clean"
+      - when: "${{ result.status }} == clean"
         route: re_push_immediate_fix
       - route: resolve_immediate_merge_conflicts
     on_failure: resolve_immediate_merge_conflicts

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -206,40 +206,7 @@ steps:
   create_worktree:
     tool: run_cmd
     with:
-      cmd: >
-        BRANCH="research-$(date +%Y%m%d-%H%M%S)" &&
-        WORKTREE_PATH="../worktrees/${BRANCH}" &&
-        git worktree add -b "${BRANCH}" "${WORKTREE_PATH}" &&
-        RESOLVED="$(cd "${WORKTREE_PATH}" && pwd)" &&
-        case "${RESOLVED}" in /*) ;; *) echo "error: resolved worktree path is not absolute: ${RESOLVED}" >&2; exit 1;; esac &&
-        mkdir -p "{{AUTOSKILLIT_TEMP}}/worktrees/${BRANCH}" &&
-        echo "$(git rev-parse --abbrev-ref HEAD)" > "{{AUTOSKILLIT_TEMP}}/worktrees/${BRANCH}/base-branch" &&
-        mkdir -p "${RESOLVED}/{{AUTOSKILLIT_TEMP}}" &&
-        EXPERIMENT_PLAN="${{ context.experiment_plan }}" &&
-        cp "${EXPERIMENT_PLAN}" "${RESOLVED}/{{AUTOSKILLIT_TEMP}}/experiment-plan.md" &&
-        TASK="${{ inputs.task }}" &&
-        SLUG=$(printf '%s' "${TASK}" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-' | sed 's/--*/-/g;s/^-//;s/-$//' | cut -c1-30) &&
-        RESEARCH_DIR="${RESOLVED}/research/$(date +%Y-%m-%d)-${SLUG:-experiment}" &&
-        mkdir -p "${RESEARCH_DIR}/artifacts" &&
-        cp "${EXPERIMENT_PLAN}" "${RESEARCH_DIR}/experiment-plan.md" &&
-        SCOPE_REPORT="${{ context.scope_report }}" &&
-        EVAL_DASHBOARD="${{ context.evaluation_dashboard }}" &&
-        if [ -n "${SCOPE_REPORT}" ] && [ -f "${SCOPE_REPORT}" ]; then cp "${SCOPE_REPORT}" "${RESEARCH_DIR}/artifacts/scope-report.md"; fi &&
-        if [ -n "${EVAL_DASHBOARD}" ] && [ -f "${EVAL_DASHBOARD}" ]; then cp "${EVAL_DASHBOARD}" "${RESEARCH_DIR}/artifacts/design-evaluation.md"; fi &&
-        VISUALIZATION_PLAN="${{ context.visualization_plan_path }}" &&
-        REPORT_PLAN="${{ context.report_plan_path }}" &&
-        if [ -n "${VISUALIZATION_PLAN}" ] && [ -f "${VISUALIZATION_PLAN}" ]; then cp "${VISUALIZATION_PLAN}" "${RESEARCH_DIR}/visualization-plan.md"; fi &&
-        if [ -n "${REPORT_PLAN}" ] && [ -f "${REPORT_PLAN}" ]; then cp "${REPORT_PLAN}" "${RESEARCH_DIR}/report-plan.md"; fi &&
-        SRC_TEMP="${{ inputs.source_dir }}/{{AUTOSKILLIT_TEMP}}" &&
-        mkdir -p "${RESEARCH_DIR}/artifacts/review-cycles" &&
-        mkdir -p "${RESEARCH_DIR}/artifacts/plan-versions" &&
-        for f in "${SRC_TEMP}"/review-design/evaluation_dashboard_*.md; do [ -f "$f" ] && cp "$f" "${RESEARCH_DIR}/artifacts/review-cycles/"; done;
-        for f in "${SRC_TEMP}"/review-design/revision_guidance_*.md; do [ -f "$f" ] && cp "$f" "${RESEARCH_DIR}/artifacts/review-cycles/"; done;
-        for f in "${SRC_TEMP}"/plan-experiment/experiment_plan_*.md; do [ -f "$f" ] && cp "$f" "${RESEARCH_DIR}/artifacts/plan-versions/"; done;
-        for f in "${SRC_TEMP}"/resolve-design-review/*.md; do [ -f "$f" ] && cp "$f" "${RESEARCH_DIR}/artifacts/review-cycles/"; done;
-        cd "${RESOLVED}" && git add research/ && git commit -m "Add experiment plan and scope to research/" &&
-        echo "research_dir=${RESEARCH_DIR}" &&
-        echo "worktree_path=${RESOLVED}"
+      cmd: "bash scripts/recipe/create_worktree.sh '${{ inputs.source_dir }}' '${{ inputs.task }}' '${{ context.experiment_plan }}' '${{ context.scope_report }}' '${{ context.evaluation_dashboard }}' '${{ context.visualization_plan_path }}' '${{ context.report_plan_path }}' '{{AUTOSKILLIT_TEMP}}'"
       cwd: "${{ inputs.source_dir }}"
       step_name: create_worktree
     capture:
@@ -397,18 +364,12 @@ steps:
     on_failure: ensure_results
 
   ensure_results:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: >
-        RESULTS="${{ context.experiment_results }}" &&
-        if [ -z "${RESULTS}" ]; then
-          RESULTS="${{ context.worktree_path }}/{{AUTOSKILLIT_TEMP}}/run-experiment/results-inconclusive.md" &&
-          mkdir -p "$(dirname "${RESULTS}")" &&
-          printf '# Experiment Results\n\n## Status\nINCONCLUSIVE\n\nExperiment did not produce results — retries exhausted or adjustment failed.\n' > "${RESULTS}"
-        fi &&
-        echo "experiment_results=${RESULTS}"
-      cwd: "${{ context.worktree_path }}"
-      step_name: ensure_results
+      callable: "autoskillit.recipe._cmd_rpc.ensure_results"
+      experiment_results: "${{ context.experiment_results }}"
+      worktree_path: "${{ context.worktree_path }}"
+      temp_subdir: "{{AUTOSKILLIT_TEMP}}"
     capture:
       experiment_results: "${{ result.experiment_results }}"
     on_success: generate_report_inconclusive
@@ -527,22 +488,7 @@ steps:
   stage_bundle:
     tool: run_cmd
     with:
-      cmd: >
-        RESEARCH_DIR="${{ context.research_dir }}" &&
-        if [ -n "${RESEARCH_DIR}" ] && [ -d "${RESEARCH_DIR}" ]; then
-          WT_TEMP="${{ context.worktree_path }}/{{AUTOSKILLIT_TEMP}}" &&
-          mkdir -p "${RESEARCH_DIR}/artifacts/phase-groups" &&
-          mkdir -p "${RESEARCH_DIR}/artifacts/phase-plans" &&
-          mkdir -p "${RESEARCH_DIR}/artifacts/images" &&
-          mkdir -p "${RESEARCH_DIR}/artifacts/scripts" &&
-          for f in "${WT_TEMP}"/make-groups/*.md; do [ -f "$f" ] && cp "$f" "${RESEARCH_DIR}/artifacts/phase-groups/"; done &&
-          for f in "${WT_TEMP}"/make-groups/*.yaml; do [ -f "$f" ] && cp "$f" "${RESEARCH_DIR}/artifacts/phase-groups/"; done &&
-          for f in "${WT_TEMP}"/make-plan/*.md; do [ -f "$f" ] && cp "$f" "${RESEARCH_DIR}/artifacts/phase-plans/"; done &&
-          for f in "${WT_TEMP}"/exp-lens-*/*.md; do [ -f "$f" ] && cp "$f" "${RESEARCH_DIR}/artifacts/images/"; done &&
-          echo "stage_bundle=done";
-        else
-          echo "stage_bundle: no research directory found — skipped";
-        fi
+      cmd: "bash scripts/recipe/stage_bundle.sh '${{ context.research_dir }}' '${{ context.worktree_path }}' '{{AUTOSKILLIT_TEMP}}'"
       cwd: "${{ context.worktree_path }}"
       step_name: stage_bundle
     on_success: route_pr_or_local
@@ -742,22 +688,7 @@ steps:
   re_stage_bundle:
     tool: run_cmd
     with:
-      cmd: >
-        RESEARCH_DIR="${{ context.research_dir }}" &&
-        if [ -n "${RESEARCH_DIR}" ] && [ -d "${RESEARCH_DIR}" ]; then
-          WT_TEMP="${{ context.worktree_path }}/{{AUTOSKILLIT_TEMP}}" &&
-          mkdir -p "${RESEARCH_DIR}/artifacts/phase-groups" &&
-          mkdir -p "${RESEARCH_DIR}/artifacts/phase-plans" &&
-          mkdir -p "${RESEARCH_DIR}/artifacts/images" &&
-          mkdir -p "${RESEARCH_DIR}/artifacts/scripts" &&
-          for f in "${WT_TEMP}"/make-groups/*.md; do [ -f "$f" ] && cp "$f" "${RESEARCH_DIR}/artifacts/phase-groups/"; done &&
-          for f in "${WT_TEMP}"/make-groups/*.yaml; do [ -f "$f" ] && cp "$f" "${RESEARCH_DIR}/artifacts/phase-groups/"; done &&
-          for f in "${WT_TEMP}"/make-plan/*.md; do [ -f "$f" ] && cp "$f" "${RESEARCH_DIR}/artifacts/phase-plans/"; done &&
-          for f in "${WT_TEMP}"/exp-lens-*/*.md; do [ -f "$f" ] && cp "$f" "${RESEARCH_DIR}/artifacts/images/"; done &&
-          echo "re_stage_bundle=done";
-        else
-          echo "re_stage_bundle: no research directory found — skipped";
-        fi
+      cmd: "bash scripts/recipe/stage_bundle.sh '${{ context.research_dir }}' '${{ context.worktree_path }}' '{{AUTOSKILLIT_TEMP}}'"
       cwd: "${{ context.worktree_path }}"
       step_name: re_stage_bundle
     on_success: re_test
@@ -791,51 +722,7 @@ steps:
   finalize_bundle:
     tool: run_cmd
     with:
-      cmd: >
-        OUTPUT_MODE="${{ inputs.output_mode }}" &&
-        RESEARCH_DIR="${{ context.research_dir }}" &&
-        if [ -n "${RESEARCH_DIR}" ] && [ -d "${RESEARCH_DIR}" ]; then
-          if [ "${OUTPUT_MODE}" != "local" ]; then
-            if [ -f "${RESEARCH_DIR}/report.md" ]; then
-              cp "${RESEARCH_DIR}/report.md" "${RESEARCH_DIR}/README.md" &&
-              rm "${RESEARCH_DIR}/report.md";
-            fi;
-          fi &&
-          REPORT_FILE=$( [ "${OUTPUT_MODE}" = "local" ] && echo "report.md" || echo "README.md" ) &&
-          if [ "${OUTPUT_MODE}" = "local" ]; then
-            EXCLUDE_PATTERN='^(report\.html|mermaid\.min\.js|images|report\.md|artifacts\.tar\.gz)$';
-          else
-            EXCLUDE_PATTERN='^(README\.md|artifacts\.tar\.gz)$';
-          fi &&
-          mapfile -t TAR_ITEMS < <(ls -1 "${RESEARCH_DIR}" | grep -vE "${EXCLUDE_PATTERN}") &&
-          if [ ${#TAR_ITEMS[@]} -gt 0 ]; then
-            tar czf "${RESEARCH_DIR}/artifacts.tar.gz" -C "${RESEARCH_DIR}" "${TAR_ITEMS[@]}" &&
-            for item in "${TAR_ITEMS[@]}"; do rm -rf "${RESEARCH_DIR}/${item}"; done;
-          fi &&
-          if [ -f "${RESEARCH_DIR}/artifacts.tar.gz" ] && [ -f "${RESEARCH_DIR}/${REPORT_FILE}" ]; then
-            MANIFEST=$(tar tzf "${RESEARCH_DIR}/artifacts.tar.gz" | sort) &&
-            { echo ""; echo "## Archive Manifest"; echo ""; echo "Contents of \`artifacts.tar.gz\`:"; echo ""; echo '```'; echo "${MANIFEST}"; echo '```'; } >> "${RESEARCH_DIR}/${REPORT_FILE}";
-          fi &&
-          [ -f "${RESEARCH_DIR}/artifacts.tar.gz" ] || \
-            { echo "ERROR: artifacts.tar.gz not created in ${RESEARCH_DIR}"; exit 1; } &&
-          if [ "${OUTPUT_MODE}" = "local" ]; then
-            LEFTOVER_PATTERN='^(report\.md|report\.html|mermaid\.min\.js|images|artifacts\.tar\.gz)$';
-          else
-            LEFTOVER_PATTERN='^(README\.md|artifacts\.tar\.gz)$';
-          fi &&
-          LEFTOVERS=$(ls -1 "${RESEARCH_DIR}" | grep -vE "${LEFTOVER_PATTERN}") &&
-          [ -z "${LEFTOVERS}" ] || \
-            { echo "ERROR: uncompressed entries still present in ${RESEARCH_DIR}: ${LEFTOVERS}"; exit 1; } &&
-          [ -f "${RESEARCH_DIR}/${REPORT_FILE}" ] || \
-            { echo "ERROR: ${REPORT_FILE} not found in ${RESEARCH_DIR}"; exit 1; } &&
-          if [ "${OUTPUT_MODE}" != "local" ]; then
-            cd "${{ context.worktree_path }}" && git add "${RESEARCH_DIR}" && { git diff --cached --quiet || git commit -m "Add compressed research artifacts"; };
-          fi;
-          echo "report_path=${RESEARCH_DIR}/${REPORT_FILE}";
-          echo "report_path_after_finalize=${RESEARCH_DIR}/${REPORT_FILE}";
-        else
-          echo "finalize_bundle: no research directory found — artifact commit skipped";
-        fi
+      cmd: "bash scripts/recipe/finalize_bundle.sh '${{ inputs.output_mode }}' '${{ context.research_dir }}' '${{ context.worktree_path }}'"
       cwd: "${{ context.worktree_path }}"
       step_name: finalize_bundle
     capture:
@@ -876,18 +763,11 @@ steps:
       the existing archival phase.
 
   export_local_bundle:
-    tool: run_cmd
+    tool: run_python
     with:
-      cmd: >
-        LOCAL_ROOT="${{ inputs.source_dir }}/research-bundles" &&
-        mkdir -p "${LOCAL_ROOT}" &&
-        SLUG=$(basename "${{ context.research_dir }}") &&
-        DEST="${LOCAL_ROOT}/${SLUG}" &&
-        rm -rf "${DEST}" &&
-        cp -a "${{ context.research_dir }}/." "${DEST}/" &&
-        echo "local_bundle_path=${DEST}"
-      cwd: "${{ context.worktree_path }}"
-      step_name: export_local_bundle
+      callable: "autoskillit.recipe._cmd_rpc.export_local_bundle"
+      source_dir: "${{ inputs.source_dir }}"
+      research_dir: "${{ context.research_dir }}"
     capture:
       local_bundle_path: "${{ result.local_bundle_path }}"
     on_success: patch_token_summary
@@ -924,24 +804,7 @@ steps:
   create_artifact_branch:
     tool: run_cmd
     with:
-      cmd: >
-        EXPERIMENT_BRANCH="${{ context.experiment_branch }}" &&
-        SLUG=$(printf '%s' "${EXPERIMENT_BRANCH}" | sed 's/^research-//') &&
-        ARTIFACT_BRANCH="research-artifacts-${SLUG}" &&
-        ARTIFACT_DIR="$(mktemp -d)" &&
-        trap 'git -C "${{ context.worktree_path }}" worktree remove "${ARTIFACT_DIR}" --force 2>/dev/null; rm -rf "${ARTIFACT_DIR}"' EXIT &&
-        git -C '${{ context.worktree_path }}' fetch origin '${{ inputs.base_branch }}' &&
-        (git -C '${{ context.worktree_path }}' branch -D "${ARTIFACT_BRANCH}" 2>/dev/null || true) &&
-        git -C '${{ context.worktree_path }}' worktree add "${ARTIFACT_DIR}" -b "${ARTIFACT_BRANCH}" "origin/${{ inputs.base_branch }}" &&
-        RESEARCH_SUBDIR="research/$(basename "${{ context.research_dir }}")" &&
-        git -C "${ARTIFACT_DIR}" checkout "${EXPERIMENT_BRANCH}" -- "${RESEARCH_SUBDIR}" &&
-        cd "${ARTIFACT_DIR}" &&
-        git add research/ &&
-        git commit -m "Add research artifacts: ${SLUG}" &&
-        git push -u origin "${ARTIFACT_BRANCH}" &&
-        cd - > /dev/null &&
-        git -C '${{ context.worktree_path }}' worktree remove "${ARTIFACT_DIR}" --force &&
-        echo "artifact_branch=${ARTIFACT_BRANCH}"
+      cmd: "bash scripts/recipe/create_artifact_branch.sh '${{ context.worktree_path }}' '${{ context.experiment_branch }}' '${{ inputs.base_branch }}' '${{ context.research_dir }}'"
       cwd: "${{ context.worktree_path }}"
       step_name: create_artifact_branch
     capture:
@@ -957,24 +820,7 @@ steps:
   open_artifact_pr:
     tool: run_cmd
     with:
-      cmd: >
-        EXPERIMENT="${{ context.experiment_branch }}" &&
-        ARTIFACT="${{ context.artifact_branch }}" &&
-        ORIG_PR="${{ context.pr_url }}" &&
-        RESEARCH_SUBDIR="research/$(basename "${{ context.research_dir }}")" &&
-        ARTIFACT_DIR="${{ context.worktree_path }}" &&
-        if [ -f "${ARTIFACT_DIR}/${RESEARCH_SUBDIR}/artifacts.tar.gz" ]; then
-          STRUCT_DETAIL=$'- `artifacts.tar.gz` \xe2\x80\x94 compressed artifact tree\n\nExtract:\n```bash\ntar xzf artifacts.tar.gz\n```';
-        else
-          STRUCT_DETAIL="- \`artifacts/\` — uncompressed artifact tree";
-        fi &&
-        PR_BODY=$(printf '## Research Artifacts\n\nFrom experiment branch `%s`.\n\nOriginal experiment PR: %s\n\n### Structure\n\n- **README.md** — Research conclusions (browsable on GitHub)\n%s\n\nContains only files under `research/` — zero production code changes.' "${EXPERIMENT}" "${ORIG_PR}" "${STRUCT_DETAIL}") &&
-        PR_URL=$(gh pr create
-        --head "${ARTIFACT}"
-        --base '${{ inputs.base_branch }}'
-        --title "Research artifacts: ${EXPERIMENT}"
-        --body "${PR_BODY}") &&
-        echo "artifact_pr_url=${PR_URL}"
+      cmd: "bash scripts/recipe/open_artifact_pr.sh '${{ context.worktree_path }}' '${{ context.experiment_branch }}' '${{ context.artifact_branch }}' '${{ context.pr_url }}' '${{ inputs.base_branch }}' '${{ context.research_dir }}'"
       cwd: "${{ context.worktree_path }}"
       step_name: open_artifact_pr
     capture:
@@ -989,13 +835,7 @@ steps:
   tag_experiment_branch:
     tool: run_cmd
     with:
-      cmd: >
-        TAG="archive/research/${{ context.experiment_branch }}" &&
-        ARTIFACT_PR="${{ context.artifact_pr_url }}" &&
-        git -C '${{ context.worktree_path }}' tag -a "${TAG}" '${{ context.experiment_branch }}'
-        -m "Research experiment: ${{ context.experiment_branch }}. Report merged via artifact PR ${ARTIFACT_PR}. Variant code preserved here for reference." &&
-        git -C '${{ context.worktree_path }}' push origin "${TAG}" &&
-        echo "archive_tag=${TAG}"
+      cmd: "bash scripts/recipe/tag_experiment_branch.sh '${{ context.worktree_path }}' '${{ context.experiment_branch }}' '${{ context.artifact_pr_url }}'"
       cwd: "${{ context.worktree_path }}"
       step_name: tag_experiment_branch
     capture:

--- a/tests/arch/test_python_no_hardcoded_temp.py
+++ b/tests/arch/test_python_no_hardcoded_temp.py
@@ -57,6 +57,7 @@ _TEMP_PATH_WHITELIST: dict[str, str] = {
     # Justification: docstring for _write_hook_config() references the canonical
     # hook config path so callers know where the file is written.
     "server/tools_kitchen.py": "docstring example",
+    "recipe/_cmd_rpc.py": "ensure_results default temp_subdir matches canonical default",
 }
 
 _LITERAL = ".autoskillit/temp"

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -772,7 +772,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
     """
     EXEMPTIONS: dict[str, int] = {
         "server": 25,
-        "recipe": 48,
+        "recipe": 49,
         "execution": 36,
         "core": 32,
         "cli": 42,

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -772,7 +772,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
     """
     EXEMPTIONS: dict[str, int] = {
         "server": 25,
-        "recipe": 49,
+        "recipe": 50,
         "execution": 36,
         "core": 32,
         "cli": 42,

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -273,8 +273,8 @@ def test_retry_reason_value_count_is_11() -> None:
     assert len(values) == 11, f"RetryReason has {len(values)} values: {values}"
 
 
-def test_semantic_rule_family_count_is_24() -> None:
-    assert _count_semantic_rule_files() == 24
+def test_semantic_rule_family_count_is_25() -> None:
+    assert _count_semantic_rule_files() == 25
 
 
 # ----- per-doc count assertions (run once docs exist) -------------------------

--- a/tests/docs/test_filename_naming.py
+++ b/tests/docs/test_filename_naming.py
@@ -20,6 +20,7 @@ ALLOWLIST = {
         "end-turn-hazards.md",
         "research-pipeline.md",
         "0001-prohibit-background-subagent-execution.md",
+        "0002-ban-inline-shell-scripts-from-cmd.md",
     },
 }
 

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -158,7 +158,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # planner/manifests.py — finalize_wp_manifest: wp_index.json rebuild (list payload)
     ("src/autoskillit/planner/manifests.py", 243),
     # _cmd_rpc.py — emit_fallback_map: BEM fallback execution map (recipe-internal)
-    ("src/autoskillit/recipe/_cmd_rpc.py", 422),
+    ("src/autoskillit/recipe/_cmd_rpc.py", 427),
 }
 
 

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -157,6 +157,8 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/smoke_utils.py", 272),
     # planner/manifests.py — finalize_wp_manifest: wp_index.json rebuild (list payload)
     ("src/autoskillit/planner/manifests.py", 243),
+    # _cmd_rpc.py — emit_fallback_map: BEM fallback execution map (recipe-internal)
+    ("src/autoskillit/recipe/_cmd_rpc.py", 422),
 }
 
 

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -158,7 +158,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # planner/manifests.py — finalize_wp_manifest: wp_index.json rebuild (list payload)
     ("src/autoskillit/planner/manifests.py", 243),
     # _cmd_rpc.py — emit_fallback_map: BEM fallback execution map (recipe-internal)
-    ("src/autoskillit/recipe/_cmd_rpc.py", 427),
+    ("src/autoskillit/recipe/_cmd_rpc.py", 432),
 }
 
 

--- a/tests/recipe/test_bem_wrapper_structure.py
+++ b/tests/recipe/test_bem_wrapper_structure.py
@@ -73,19 +73,16 @@ def test_bem_wrapper_fallback_references_autoskillit_temp():
 
 
 def test_bem_wrapper_fallback_writes_file_not_json_to_stdout():
-    """emit_fallback_map must echo the FILE PATH to stdout (not raw JSON).
+    """emit_fallback_map must write JSON to a file and return the path.
 
-    The campaign captures the path via result.stdout. If raw JSON were echoed,
-    implement-findings would get ENOENT when opening it as a file path.
+    The campaign captures the path via result.execution_map. If raw JSON were
+    returned, implement-findings would get ENOENT when opening it as a file path.
     """
     recipe = _load()
     step = recipe.steps["emit_fallback_map"]
-    cmd = step.with_args["cmd"]
-    # cmd must write JSON to a file via Python open() and print the path
-    assert "open(map_file" in cmd, "cmd must write JSON to a file via Python open()"
-    assert "print(map_file)" in cmd, "cmd must echo the file path, not raw JSON"
-    # capture must use result.stdout (the echoed path), not a structured key
-    assert step.capture.get("execution_map") == "${{ result.stdout | trim }}"
+    assert step.tool == "run_python"
+    assert step.with_args["callable"] == "autoskillit.recipe._cmd_rpc.emit_fallback_map"
+    assert step.capture.get("execution_map") == "${{ result.execution_map }}"
 
 
 def test_bem_wrapper_emit_result_consumes_execution_map_context():

--- a/tests/recipe/test_bundled_recipes_pipeline_structure.py
+++ b/tests/recipe/test_bundled_recipes_pipeline_structure.py
@@ -442,24 +442,23 @@ class TestImplementationPipelineStructure:
         create_branch = recipe.steps["create_branch"]
         assert create_branch.skip_when_false == "inputs.open_pr"
 
-    def test_create_branch_does_not_use_run_name_verbatim(self, recipe) -> None:
-        """compute_branch must not use inputs.run_name as the full branch name."""
-        cmd = recipe.steps["compute_branch"].with_args["cmd"]
-        assert "git checkout -b ${{ inputs.run_name }} &&" not in cmd
+    def test_create_branch_uses_callable(self, recipe) -> None:
+        """compute_branch must use run_python with _cmd_rpc.compute_branch callable."""
+        step = recipe.steps["compute_branch"]
+        assert step.tool == "run_python"
+        assert step.with_args["callable"] == "autoskillit.recipe._cmd_rpc.compute_branch"
 
     def test_create_branch_checks_remote_for_collisions(self, recipe) -> None:
         """create_branch must use create_unique_branch tool (which always checks ls-remote)."""
         assert recipe.steps["create_branch"].tool == "create_unique_branch"
 
     def test_create_branch_references_issue_number(self, recipe) -> None:
-        """compute_branch cmd must reference context.issue_number for branch naming."""
-        cmd = recipe.steps["compute_branch"].with_args["cmd"]
-        assert "context.issue_number" in cmd
+        """compute_branch with_args must include issue_number for branch naming."""
+        assert "issue_number" in recipe.steps["compute_branch"].with_args
 
     def test_create_branch_uses_run_name_as_prefix(self, recipe) -> None:
-        """compute_branch must use inputs.run_name as a prefix in branch naming."""
-        cmd = recipe.steps["compute_branch"].with_args["cmd"]
-        assert "inputs.run_name" in cmd
+        """compute_branch with_args must include run_name for branch naming."""
+        assert "run_name" in recipe.steps["compute_branch"].with_args
 
     def test_ip_main_push_step_not_reachable_after_compose_pr(self, recipe) -> None:
         """The main `push` step must not be reachable after compose_pr —
@@ -690,24 +689,23 @@ class TestImplementationGroupsStructure:
         )
         assert "inputs.base_branch" in with_args["target_branch"]
 
-    def test_create_branch_does_not_use_run_name_verbatim(self, recipe) -> None:
-        """compute_branch must not use inputs.run_name as the full branch name."""
-        cmd = recipe.steps["compute_branch"].with_args["cmd"]
-        assert "git checkout -b ${{ inputs.run_name }} &&" not in cmd
+    def test_create_branch_uses_callable(self, recipe) -> None:
+        """compute_branch must use run_python with _cmd_rpc.compute_branch callable."""
+        step = recipe.steps["compute_branch"]
+        assert step.tool == "run_python"
+        assert step.with_args["callable"] == "autoskillit.recipe._cmd_rpc.compute_branch"
 
     def test_create_branch_checks_remote_for_collisions(self, recipe) -> None:
         """create_branch must use create_unique_branch tool (which always checks ls-remote)."""
         assert recipe.steps["create_branch"].tool == "create_unique_branch"
 
     def test_create_branch_references_issue_number(self, recipe) -> None:
-        """compute_branch cmd must reference context.issue_number for branch naming."""
-        cmd = recipe.steps["compute_branch"].with_args["cmd"]
-        assert "context.issue_number" in cmd
+        """compute_branch with_args must include issue_number for branch naming."""
+        assert "issue_number" in recipe.steps["compute_branch"].with_args
 
     def test_create_branch_uses_run_name_as_prefix(self, recipe) -> None:
-        """compute_branch must use inputs.run_name as a prefix in branch naming."""
-        cmd = recipe.steps["compute_branch"].with_args["cmd"]
-        assert "inputs.run_name" in cmd
+        """compute_branch with_args must include run_name for branch naming."""
+        assert "run_name" in recipe.steps["compute_branch"].with_args
 
 
 # ---------------------------------------------------------------------------
@@ -793,24 +791,23 @@ class TestInvestigateFirstStructure:
             "it must capture branch_name for downstream audit_impl use"
         )
 
-    def test_create_branch_does_not_use_run_name_verbatim(self, recipe) -> None:
-        """compute_branch must not use inputs.run_name as the full branch name."""
-        cmd = recipe.steps["compute_branch"].with_args["cmd"]
-        assert "git checkout -b ${{ inputs.run_name }} &&" not in cmd
+    def test_create_branch_uses_callable(self, recipe) -> None:
+        """compute_branch must use run_python with _cmd_rpc.compute_branch callable."""
+        step = recipe.steps["compute_branch"]
+        assert step.tool == "run_python"
+        assert step.with_args["callable"] == "autoskillit.recipe._cmd_rpc.compute_branch"
 
     def test_create_branch_checks_remote_for_collisions(self, recipe) -> None:
         """create_branch must use create_unique_branch tool (which always checks ls-remote)."""
         assert recipe.steps["create_branch"].tool == "create_unique_branch"
 
     def test_create_branch_references_issue_number(self, recipe) -> None:
-        """compute_branch cmd must reference context.issue_number for branch naming."""
-        cmd = recipe.steps["compute_branch"].with_args["cmd"]
-        assert "context.issue_number" in cmd
+        """compute_branch with_args must include issue_number for branch naming."""
+        assert "issue_number" in recipe.steps["compute_branch"].with_args
 
     def test_create_branch_uses_run_name_as_prefix(self, recipe) -> None:
-        """compute_branch must use inputs.run_name as a prefix in branch naming."""
-        cmd = recipe.steps["compute_branch"].with_args["cmd"]
-        assert "inputs.run_name" in cmd
+        """compute_branch with_args must include run_name for branch naming."""
+        assert "run_name" in recipe.steps["compute_branch"].with_args
 
     def test_if_push_after_audit_warning_fires(self, recipe) -> None:
         """push-before-audit semantic rule fires as WARNING (audit has skip_when_false)."""

--- a/tests/recipe/test_bundled_recipes_research.py
+++ b/tests/recipe/test_bundled_recipes_research.py
@@ -337,12 +337,12 @@ class TestResearchRecipeStructure:
         assert step.on_success == "open_artifact_pr"
         assert step.on_failure == "patch_token_summary"
 
-    def test_archival_create_artifact_branch_uses_research_checkout(self, recipe) -> None:
-        """create_artifact_branch must use git checkout <branch> -- research/ pattern."""
+    def test_archival_create_artifact_branch_uses_external_script(self, recipe) -> None:
+        """create_artifact_branch must invoke the externalized shell script."""
         step = recipe.steps["create_artifact_branch"]
         cmd = step.with_args["cmd"]
-        assert "research/" in cmd, "Must checkout research/ directory from experiment branch"
-        assert "worktree add" in cmd, "Must create a temporary worktree"
+        assert "create_artifact_branch.sh" in cmd
+        assert "context.research_dir" in cmd
 
     def test_archival_open_artifact_pr_step(self, recipe) -> None:
         """open_artifact_pr creates the artifact-only PR and captures artifact_pr_url."""
@@ -362,11 +362,11 @@ class TestResearchRecipeStructure:
         assert step.on_success == "close_experiment_pr"
         assert step.on_failure == "patch_token_summary"
 
-    def test_archival_tag_uses_archive_prefix(self, recipe) -> None:
-        """Tag name must use archive/research/ prefix convention."""
+    def test_archival_tag_uses_external_script(self, recipe) -> None:
+        """tag_experiment_branch must invoke the externalized shell script."""
         step = recipe.steps["tag_experiment_branch"]
         cmd = step.with_args["cmd"]
-        assert "archive/research/" in cmd
+        assert "tag_experiment_branch.sh" in cmd
 
     def test_archival_close_experiment_pr_step(self, recipe) -> None:
         """close_experiment_pr closes the original PR and routes to research_complete."""
@@ -417,30 +417,18 @@ class TestResearchRecipeStructure:
         assert step.on_success == "route_archive_or_export"
         assert step.on_failure == "route_archive_or_export"
 
-    def test_create_worktree_copies_review_cycle_artifacts(self, recipe) -> None:
-        """create_worktree must copy review-design dashboards and revision guidance."""
+    def test_create_worktree_uses_external_script(self, recipe) -> None:
+        """create_worktree must invoke the externalized shell script."""
         step = recipe.steps["create_worktree"]
         cmd = step.with_args["cmd"]
-        assert "review-cycles" in cmd, (
-            "create_worktree must create artifacts/review-cycles/ subdirectory"
-        )
-        assert "evaluation_dashboard" in cmd and "review-cycles" in cmd, (
-            "create_worktree must copy evaluation dashboards to review-cycles/"
-        )
-        assert "revision_guidance" in cmd and "review-cycles" in cmd, (
-            "create_worktree must copy revision guidance to review-cycles/"
-        )
+        assert "create_worktree.sh" in cmd
+        assert "context.experiment_plan" in cmd
 
-    def test_create_worktree_copies_plan_version_artifacts(self, recipe) -> None:
-        """create_worktree must copy intermediate plan versions."""
+    def test_create_worktree_passes_source_dir(self, recipe) -> None:
+        """create_worktree must pass source_dir to the external script."""
         step = recipe.steps["create_worktree"]
         cmd = step.with_args["cmd"]
-        assert "plan-versions" in cmd, (
-            "create_worktree must create artifacts/plan-versions/ subdirectory"
-        )
-        assert "experiment_plan" in cmd and "plan-versions" in cmd, (
-            "create_worktree must copy plan versions to plan-versions/"
-        )
+        assert "inputs.source_dir" in cmd
 
     def test_stage_bundle_step_exists(self, recipe) -> None:
         """A stage_bundle step must exist to organize phase artifacts."""
@@ -449,8 +437,7 @@ class TestResearchRecipeStructure:
         )
         step = recipe.steps["stage_bundle"]
         cmd = step.with_args["cmd"]
-        assert "phase-groups" in cmd, "Must copy make-groups output"
-        assert "phase-plans" in cmd, "Must copy make-plan output"
+        assert "stage_bundle.sh" in cmd, "Must invoke externalized stage_bundle script"
 
     def test_test_routes_to_push_branch(self, recipe) -> None:
         """test step must route to push_branch now that commit_research_artifacts is removed."""

--- a/tests/recipe/test_cmd_rpc.py
+++ b/tests/recipe/test_cmd_rpc.py
@@ -144,7 +144,7 @@ def test_export_local_bundle(tmp_path):
 
 
 def test_refetch_issues_builds_query():
-    with patch("subprocess.run") as mock_run:
+    with patch("autoskillit.recipe._cmd_rpc.subprocess.run") as mock_run:
         mock_run.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout="1 2", stderr=""
         )

--- a/tests/recipe/test_cmd_rpc.py
+++ b/tests/recipe/test_cmd_rpc.py
@@ -1,0 +1,157 @@
+"""Tests for recipe._cmd_rpc — externalized run_python callables."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from autoskillit.recipe._cmd_rpc import (
+    check_dropped_healthy_loop,
+    check_eject_limit,
+    commit_guard,
+    compute_branch,
+    emit_fallback_map,
+    ensure_results,
+    export_local_bundle,
+    refetch_issues,
+)
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+
+def test_compute_branch_with_issue():
+    result = compute_branch(issue_slug="feat-widget", run_name="run1", issue_number="42")
+    assert result == {"branch_name": "feat-widget/42"}
+
+
+def test_compute_branch_without_issue():
+    result = compute_branch(issue_slug="feat-widget", run_name="run1", issue_number="")
+    assert "feat-widget/" in result["branch_name"]
+
+
+def test_compute_branch_uses_run_name_when_no_slug():
+    result = compute_branch(issue_slug="", run_name="my-run", issue_number="7")
+    assert result == {"branch_name": "my-run/7"}
+
+
+def test_check_eject_limit_under_threshold(tmp_path):
+    counter = tmp_path / "count"
+    result = check_eject_limit(counter_file=str(counter), max_ejects="3")
+    assert result["status"] == "EJECT_OK"
+    assert result["count"] == "1"
+
+
+def test_check_eject_limit_exceeded(tmp_path):
+    counter = tmp_path / "count"
+    counter.write_text("3")
+    result = check_eject_limit(counter_file=str(counter), max_ejects="3")
+    assert result["status"] == "EJECT_LIMIT_EXCEEDED"
+    assert result["count"] == "4"
+
+
+def test_check_eject_limit_creates_parent_dirs(tmp_path):
+    counter = tmp_path / "nested" / "dir" / "count"
+    result = check_eject_limit(counter_file=str(counter), max_ejects="5")
+    assert result["status"] == "EJECT_OK"
+    assert counter.exists()
+
+
+def test_check_dropped_healthy_loop_under(tmp_path):
+    counter = tmp_path / "dropped"
+    result = check_dropped_healthy_loop(counter_file=str(counter), max_drops="2")
+    assert result["status"] == "DROPPED_OK"
+    assert result["count"] == "1"
+
+
+def test_check_dropped_healthy_loop_exceeded(tmp_path):
+    counter = tmp_path / "dropped"
+    counter.write_text("2")
+    result = check_dropped_healthy_loop(counter_file=str(counter), max_drops="2")
+    assert result["status"] == "DROPPED_LIMIT_EXCEEDED"
+    assert result["count"] == "3"
+
+
+def test_commit_guard_clean_tree(tmp_path):
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", "init"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    result = commit_guard(worktree_path=str(tmp_path))
+    assert result["committed"] == "false"
+
+
+def test_commit_guard_dirty_tree(tmp_path):
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", "init"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    (tmp_path / "newfile.txt").write_text("content")
+    result = commit_guard(worktree_path=str(tmp_path))
+    assert result["committed"] == "true"
+
+
+def test_ensure_results_with_existing_path():
+    result = ensure_results(experiment_results="/some/path.md", worktree_path="/tmp")
+    assert result == {"experiment_results": "/some/path.md"}
+
+
+def test_ensure_results_creates_placeholder(tmp_path):
+    result = ensure_results(
+        experiment_results="",
+        worktree_path=str(tmp_path),
+        temp_subdir=".autoskillit/temp",
+    )
+    path = Path(result["experiment_results"])
+    assert path.exists()
+    assert "INCONCLUSIVE" in path.read_text()
+
+
+def test_emit_fallback_map(tmp_path):
+    result = emit_fallback_map(
+        issue_urls="https://github.com/org/repo/issues/1,https://github.com/org/repo/issues/2",
+        temp_dir=str(tmp_path),
+    )
+    assert "execution_map" in result
+    data = json.loads(Path(result["execution_map"]).read_text())
+    assert data["merge_order"] == [1, 2]
+    assert len(data["groups"]) == 1
+
+
+def test_emit_fallback_map_no_urls(tmp_path):
+    result = emit_fallback_map(issue_urls="", temp_dir=str(tmp_path))
+    assert result["ok"] == "false"
+
+
+def test_export_local_bundle(tmp_path):
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    research_dir = tmp_path / "2024-01-01-test"
+    research_dir.mkdir()
+    (research_dir / "report.md").write_text("# Report")
+    result = export_local_bundle(source_dir=str(source_dir), research_dir=str(research_dir))
+    assert Path(result["local_bundle_path"]).exists()
+    assert (Path(result["local_bundle_path"]) / "report.md").read_text() == "# Report"
+
+
+def test_refetch_issues_builds_query():
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="1 2", stderr=""
+        )
+        result = refetch_issues(
+            issue_urls="https://github.com/org/repo/issues/1,https://github.com/org/repo/issues/2"
+        )
+    assert result["issue_numbers"] == "1 2"
+    call_args = mock_run.call_args[0][0]
+    assert "gh" in call_args
+    assert "graphql" in call_args

--- a/tests/recipe/test_cmd_rpc.py
+++ b/tests/recipe/test_cmd_rpc.py
@@ -20,7 +20,7 @@ from autoskillit.recipe._cmd_rpc import (
     refetch_issues,
 )
 
-pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.medium]
 
 
 def test_compute_branch_with_issue():
@@ -128,8 +128,8 @@ def test_emit_fallback_map(tmp_path):
 
 
 def test_emit_fallback_map_no_urls(tmp_path):
-    result = emit_fallback_map(issue_urls="", temp_dir=str(tmp_path))
-    assert result["ok"] == "false"
+    with pytest.raises(RuntimeError, match="no issue numbers"):
+        emit_fallback_map(issue_urls="", temp_dir=str(tmp_path))
 
 
 def test_export_local_bundle(tmp_path):
@@ -155,3 +155,8 @@ def test_refetch_issues_builds_query():
     call_args = mock_run.call_args[0][0]
     assert "gh" in call_args
     assert "graphql" in call_args
+    query_arg = next(a for a in call_args if a.startswith("query="))
+    assert "org" in query_arg
+    assert "repo" in query_arg
+    assert "issue(number: 1)" in query_arg
+    assert "issue(number: 2)" in query_arg

--- a/tests/recipe/test_cmd_rpc.py
+++ b/tests/recipe/test_cmd_rpc.py
@@ -75,26 +75,36 @@ def test_check_dropped_healthy_loop_exceeded(tmp_path):
     assert result["count"] == "3"
 
 
-def test_commit_guard_clean_tree(tmp_path):
+def _init_git_repo(tmp_path):
     subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.local"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
     subprocess.run(
         ["git", "commit", "--allow-empty", "-m", "init"],
         cwd=tmp_path,
         check=True,
         capture_output=True,
     )
+
+
+def test_commit_guard_clean_tree(tmp_path):
+    _init_git_repo(tmp_path)
     result = commit_guard(worktree_path=str(tmp_path))
     assert result["committed"] == "false"
 
 
 def test_commit_guard_dirty_tree(tmp_path):
-    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
-    subprocess.run(
-        ["git", "commit", "--allow-empty", "-m", "init"],
-        cwd=tmp_path,
-        check=True,
-        capture_output=True,
-    )
+    _init_git_repo(tmp_path)
     (tmp_path / "newfile.txt").write_text("content")
     result = commit_guard(worktree_path=str(tmp_path))
     assert result["committed"] == "true"

--- a/tests/recipe/test_issue_url_pipeline.py
+++ b/tests/recipe/test_issue_url_pipeline.py
@@ -61,12 +61,12 @@ class TestImplementationPipelineIssueUrl:
         assert data["steps"]["capture_base_sha"]["on_success"] == "get_issue_title"
         assert data["steps"]["get_issue_title"]["on_success"] == "claim_issue"
 
-    def test_create_branch_uses_slug_fallback(self):
-        """create_branch shell uses ${SLUG:-$RUN} pattern."""
+    def test_create_branch_uses_callable(self):
+        """compute_branch uses run_python callable for slug/run_name branching."""
         data = yaml.safe_load(_recipe_path("implementation").read_text())
-        cmd = data["steps"]["compute_branch"]["with"]["cmd"]
-        assert "SLUG" in cmd
-        assert "${SLUG:-" in cmd
+        step = data["steps"]["compute_branch"]
+        assert step["tool"] == "run_python"
+        assert step["with"]["callable"] == "autoskillit.recipe._cmd_rpc.compute_branch"
 
     def test_issue_url_referenced_in_downstream_skill_step(self):
         """plan step must reference inputs.issue_url, not issue_content."""
@@ -151,12 +151,12 @@ class TestInvestigateFirstIssueUrl:
         assert data["steps"]["set_merge_target"]["on_success"] == "get_issue_title"
         assert data["steps"]["get_issue_title"]["on_success"] == "claim_issue"
 
-    def test_create_branch_uses_slug_fallback(self):
-        """create_branch shell uses ${SLUG:-$RUN} pattern."""
+    def test_create_branch_uses_callable(self):
+        """compute_branch uses run_python callable for slug/run_name branching."""
         data = yaml.safe_load(_recipe_path("remediation").read_text())
-        cmd = data["steps"]["compute_branch"]["with"]["cmd"]
-        assert "SLUG" in cmd
-        assert "${SLUG:-" in cmd
+        step = data["steps"]["compute_branch"]
+        assert step["tool"] == "run_python"
+        assert step["with"]["callable"] == "autoskillit.recipe._cmd_rpc.compute_branch"
 
     def test_issue_url_referenced_in_downstream_skill_step(self):
         """investigate step must reference inputs.issue_url, not issue_content."""
@@ -227,11 +227,11 @@ class TestImplementationGroupsIssueTitle:
         assert step.get("skip_when_false") == "inputs.issue_url"
         assert step.get("optional") is True
 
-    def test_create_branch_uses_slug_fallback(self):
+    def test_create_branch_uses_callable(self):
         data = yaml.safe_load(_recipe_path("implementation-groups").read_text())
-        cmd = data["steps"]["compute_branch"]["with"]["cmd"]
-        assert "SLUG" in cmd
-        assert "${SLUG:-" in cmd
+        step = data["steps"]["compute_branch"]
+        assert step["tool"] == "run_python"
+        assert step["with"]["callable"] == "autoskillit.recipe._cmd_rpc.compute_branch"
 
     def test_no_issue_content_capture(self):
         """issue_content must not be captured anywhere in the recipe."""

--- a/tests/recipe/test_merge_prs.py
+++ b/tests/recipe/test_merge_prs.py
@@ -250,16 +250,20 @@ def test_pmp_confirm_create_integration_routes_to_escalate_on_failure(recipe) ->
 
 
 def test_pmp_has_create_persistent_integration_step(recipe) -> None:
-    """create_persistent_integration must exist and use run_cmd."""
+    """create_persistent_integration must exist and use run_python callable."""
     assert "create_persistent_integration" in recipe.steps
-    assert recipe.steps["create_persistent_integration"].tool == "run_cmd"
+    step = recipe.steps["create_persistent_integration"]
+    assert step.tool == "run_python"
+    assert (
+        step.with_args["callable"] == "autoskillit.recipe._cmd_rpc.create_persistent_integration"
+    )
 
 
-def test_pmp_create_persistent_integration_auto_detects_default_branch(recipe) -> None:
-    """create_persistent_integration cmd must auto-detect the repo's default branch."""
-    cmd = recipe.steps["create_persistent_integration"].with_args["cmd"]
-    assert "symbolic-ref" in cmd
-    assert "upstream_branch" not in cmd
+def test_pmp_create_persistent_integration_passes_required_args(recipe) -> None:
+    """create_persistent_integration must pass work_dir and base_branch."""
+    args = recipe.steps["create_persistent_integration"].with_args
+    assert "work_dir" in args
+    assert "base_branch" in args
 
 
 def test_pmp_create_persistent_integration_routes_to_analyze_prs(recipe) -> None:
@@ -384,10 +388,13 @@ def test_pmp_open_integration_pr_routes_to_wait_for_mergeability(recipe) -> None
 
 
 def test_pmp_has_wait_for_review_pr_mergeability_step(recipe) -> None:
-    """B2: wait_for_review_pr_mergeability step must exist and use run_cmd tool."""
+    """B2: wait_for_review_pr_mergeability step must exist and use run_python callable."""
     assert "wait_for_review_pr_mergeability" in recipe.steps
     step = recipe.steps["wait_for_review_pr_mergeability"]
-    assert step.tool == "run_cmd"
+    assert step.tool == "run_python"
+    assert (
+        step.with_args["callable"] == "autoskillit.recipe._cmd_rpc.wait_for_review_pr_mergeability"
+    )
 
 
 def test_pmp_wait_for_mergeability_captures_review_pr_number(recipe) -> None:
@@ -448,11 +455,14 @@ def test_pmp_resolve_integration_conflicts_routes_to_force_push(recipe) -> None:
 
 
 def test_pmp_has_force_push_and_wait_mergeability_step(recipe) -> None:
-    """B10: force_push_and_wait_mergeability must exist with run_cmd and --force-with-lease."""
+    """B10: force_push_and_wait_mergeability must exist with run_python callable."""
     assert "force_push_and_wait_mergeability" in recipe.steps
     step = recipe.steps["force_push_and_wait_mergeability"]
-    assert step.tool == "run_cmd"
-    assert "--force-with-lease" in step.with_args.get("cmd", "")
+    assert step.tool == "run_python"
+    assert (
+        step.with_args["callable"]
+        == "autoskillit.recipe._cmd_rpc.force_push_and_wait_mergeability"
+    )
 
 
 def test_pmp_force_push_and_wait_mergeability_routes_to_check_post_rebase(

--- a/tests/recipe/test_merge_prs_queue_any.py
+++ b/tests/recipe/test_merge_prs_queue_any.py
@@ -145,11 +145,12 @@ def test_implementation_queue_ejected_fix_exists(impl_recipe) -> None:
     assert "queue_ejected_fix" in impl_recipe.steps
 
 
-def test_queue_ejected_fix_tool_is_run_cmd(impl_recipe) -> None:
+def test_queue_ejected_fix_tool_is_run_python(impl_recipe) -> None:
     step = impl_recipe.steps["queue_ejected_fix"]
-    assert step.tool == "run_cmd", (
-        "queue_ejected_fix must be a run_cmd cheap-rebase step, not a run_skill"
+    assert step.tool == "run_python", (
+        "queue_ejected_fix must be a run_python callable step, not a run_skill or run_cmd"
     )
+    assert step.with_args.get("callable") == "autoskillit.recipe._cmd_rpc.queue_ejected_fix"
 
 
 def test_queue_ejected_fix_clean_routes_to_re_push(impl_recipe) -> None:
@@ -446,7 +447,7 @@ def test_direct_merge_failure_routes_to_release_issue_failure(any_recipe) -> Non
 def test_wait_for_direct_merge_step_exists(any_recipe) -> None:
     assert "wait_for_direct_merge" in any_recipe.steps
     step = any_recipe.steps["wait_for_direct_merge"]
-    assert step.tool == "run_cmd"
+    assert step.tool == "run_python"
 
 
 def test_wait_for_direct_merge_merged_routes_to_success(any_recipe) -> None:
@@ -470,7 +471,7 @@ def test_wait_for_direct_merge_closed_routes_to_conflict_fix(any_recipe) -> None
 def test_direct_merge_conflict_fix_exists(any_recipe) -> None:
     assert "direct_merge_conflict_fix" in any_recipe.steps
     step = any_recipe.steps["direct_merge_conflict_fix"]
-    assert step.tool == "run_cmd"
+    assert step.tool == "run_python"
 
 
 def test_direct_merge_conflict_fix_clean_routes_to_re_push(any_recipe) -> None:
@@ -602,17 +603,13 @@ def test_immediate_merge_failure_routes_to_release_issue_failure(any_recipe) -> 
 def test_wait_for_immediate_merge_step_exists(any_recipe) -> None:
     assert "wait_for_immediate_merge" in any_recipe.steps
     step = any_recipe.steps["wait_for_immediate_merge"]
-    assert step.tool == "run_cmd"
+    assert step.tool == "run_python"
 
 
 def test_wait_for_immediate_merge_merged_routes_to_success(any_recipe) -> None:
     step = any_recipe.steps["wait_for_immediate_merge"]
     merged_cond = next(
-        (
-            c
-            for c in step.on_result.conditions
-            if c.when == "${{ result.stdout | trim }} == merged"
-        ),
+        (c for c in step.on_result.conditions if c.when and "merged" in c.when),
         None,
     )
     assert merged_cond is not None
@@ -622,11 +619,7 @@ def test_wait_for_immediate_merge_merged_routes_to_success(any_recipe) -> None:
 def test_wait_for_immediate_merge_closed_routes_to_conflict_fix(any_recipe) -> None:
     step = any_recipe.steps["wait_for_immediate_merge"]
     closed_cond = next(
-        (
-            c
-            for c in step.on_result.conditions
-            if c.when == "${{ result.stdout | trim }} == closed"
-        ),
+        (c for c in step.on_result.conditions if c.when and "closed" in c.when),
         None,
     )
     assert closed_cond is not None
@@ -636,7 +629,7 @@ def test_wait_for_immediate_merge_closed_routes_to_conflict_fix(any_recipe) -> N
 def test_immediate_merge_conflict_fix_exists(any_recipe) -> None:
     assert "immediate_merge_conflict_fix" in any_recipe.steps
     step = any_recipe.steps["immediate_merge_conflict_fix"]
-    assert step.tool == "run_cmd"
+    assert step.tool == "run_python"
 
 
 def test_immediate_merge_conflict_fix_clean_routes_to_re_push(any_recipe) -> None:
@@ -1277,20 +1270,18 @@ def test_check_eject_limit_routes_to_failure_when_exceeded(any_recipe) -> None:
     assert limit_conds[0].route == "release_issue_failure"
 
 
-def test_check_eject_limit_cmd_reads_writes_counter_file(any_recipe) -> None:
-    """check_eject_limit cmd must read/write a counter file under .autoskillit/temp/."""
+def test_check_eject_limit_callable_references_counter_file(any_recipe) -> None:
+    """check_eject_limit callable must receive counter_file arg under .autoskillit/temp/."""
     step = any_recipe.steps["check_eject_limit"]
-    cmd = step.with_args.get("cmd", "")
-    assert "eject_count" in cmd, "cmd must reference the eject_count counter file"
-    assert ".autoskillit/temp/" in cmd, "counter file must be under .autoskillit/temp/"
-    assert "cat " in cmd, "cmd must read the counter with cat"
+    counter_file = step.with_args.get("counter_file", "")
+    assert "eject_count" in counter_file, "counter_file must reference eject_count"
+    assert ".autoskillit/temp" in counter_file, "counter_file must be under .autoskillit/temp"
 
 
-def test_check_eject_limit_cmd_uses_limit_3(any_recipe) -> None:
-    """check_eject_limit cmd must cap at 3 ejections."""
+def test_check_eject_limit_callable_uses_limit_3(any_recipe) -> None:
+    """check_eject_limit callable must cap at 3 ejections."""
     step = any_recipe.steps["check_eject_limit"]
-    cmd = step.with_args.get("cmd", "")
-    assert "-gt 3" in cmd, "limit check must use -gt 3"
+    assert step.with_args.get("max_ejects") == "3", "max_ejects must be '3'"
 
 
 def test_check_eject_limit_on_result_uses_exact_eq_match(any_recipe) -> None:
@@ -1305,28 +1296,27 @@ def test_check_eject_limit_on_result_uses_exact_eq_match(any_recipe) -> None:
 
 
 def test_unbounded_cycle_severity_downgraded_by_eject_limit(any_recipe) -> None:
-    """After check_eject_limit, unbounded-cycle for queue ejection cycle must be at most WARNING.
+    """After check_eject_limit, unbounded-cycle must not fire ERROR for queue ejection cycle.
 
-    check_eject_limit.on_failure routes to release_issue_failure (outside the cycle),
-    satisfying has_failure_exit in rules_graph.py → severity is downgraded from ERROR to WARNING.
+    check_eject_limit is a run_python step in _STRUCTURAL_ON_RESULT_TOOLS with an on_result
+    condition routing to release_issue_failure (outside the cycle). The has_on_result_exit
+    path in rules_graph.py recognises this as a structural bound and suppresses the finding
+    entirely — so zero unbounded-cycle findings are expected for the queue ejection cycle.
     """
     from autoskillit.core.types import Severity
     from autoskillit.recipe.validator import run_semantic_rules
 
     findings = run_semantic_rules(any_recipe)
     cycle_findings = [f for f in findings if f.rule == "unbounded-cycle"]
-    queue_cycle_findings = [
+    queue_cycle_error_findings = [
         f
         for f in cycle_findings
-        if any(
+        if f.severity == Severity.ERROR
+        and any(
             kw in f.message for kw in ("wait_for_queue", "queue_ejected_fix", "check_eject_limit")
         )
     ]
-    assert len(queue_cycle_findings) >= 1, (
-        "unbounded-cycle rule must fire for queue ejection cycle steps"
+    assert queue_cycle_error_findings == [], (
+        f"unbounded-cycle must not be ERROR for queue ejection cycle after check_eject_limit; "
+        f"got ERROR on: {[f.step_name for f in queue_cycle_error_findings]}"
     )
-    for finding in queue_cycle_findings:
-        assert finding.severity != Severity.ERROR, (
-            f"unbounded-cycle for queue ejection must be WARNING after check_eject_limit, "
-            f"got ERROR on step {finding.step_name!r}: {finding.message[:120]}"
-        )

--- a/tests/recipe/test_merge_prs_queue_pmp.py
+++ b/tests/recipe/test_merge_prs_queue_pmp.py
@@ -152,19 +152,11 @@ def test_merge_prs_get_first_pr_number_routes_to_enqueue(pmp_recipe) -> None:
 
 
 def test_merge_prs_attempt_cheap_rebase_exists(pmp_recipe) -> None:
-    """attempt_cheap_rebase step must exist with tool=run_cmd."""
+    """attempt_cheap_rebase step must exist with tool=run_python."""
     assert "attempt_cheap_rebase" in pmp_recipe.steps
     step = pmp_recipe.steps["attempt_cheap_rebase"]
-    assert step.tool == "run_cmd"
-
-
-def test_merge_prs_attempt_cheap_rebase_cmd_uses_rebase(pmp_recipe) -> None:
-    """attempt_cheap_rebase cmd must contain git rebase and clean/conflicts output."""
-    step = pmp_recipe.steps["attempt_cheap_rebase"]
-    cmd = step.with_args.get("cmd", "")
-    assert "git rebase" in cmd
-    assert "clean" in cmd
-    assert "conflicts" in cmd
+    assert step.tool == "run_python"
+    assert step.with_args.get("callable") == "autoskillit.recipe._cmd_rpc.attempt_cheap_rebase"
 
 
 def test_merge_prs_attempt_cheap_rebase_routing(pmp_recipe) -> None:
@@ -237,14 +229,9 @@ def test_merge_prs_get_next_pr_branch_on_failure_routes_to_enqueue(pmp_recipe) -
 
 def test_merge_prs_proactive_rebase_next_pr_exists(pmp_recipe) -> None:
     assert "proactive_rebase_next_pr" in pmp_recipe.steps
-    assert pmp_recipe.steps["proactive_rebase_next_pr"].tool == "run_cmd"
-
-
-def test_merge_prs_proactive_rebase_next_pr_cmd_uses_rebase(pmp_recipe) -> None:
-    cmd = pmp_recipe.steps["proactive_rebase_next_pr"].with_args.get("cmd", "")
-    assert "git rebase" in cmd
-    assert "clean" in cmd
-    assert "conflicts" in cmd
+    step = pmp_recipe.steps["proactive_rebase_next_pr"]
+    assert step.tool == "run_python"
+    assert step.with_args.get("callable") == "autoskillit.recipe._cmd_rpc.proactive_rebase_next_pr"
 
 
 def test_merge_prs_proactive_rebase_next_pr_routing(pmp_recipe) -> None:

--- a/tests/recipe/test_merge_prs_queue_pmp.py
+++ b/tests/recipe/test_merge_prs_queue_pmp.py
@@ -66,10 +66,10 @@ def test_merge_prs_reenter_queue_exists(pmp_recipe) -> None:
 
 
 def test_merge_prs_advance_queue_pr_exists(pmp_recipe) -> None:
-    """advance_queue_pr step must exist with tool=run_cmd."""
+    """advance_queue_pr step must exist with tool=run_python."""
     assert "advance_queue_pr" in pmp_recipe.steps
     step = pmp_recipe.steps["advance_queue_pr"]
-    assert step.tool == "run_cmd"
+    assert step.tool == "run_python"
 
 
 # ---------------------------------------------------------------------------
@@ -328,11 +328,11 @@ def test_merge_prs_ci_watch_routes_to_reenter(pmp_recipe) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_merge_prs_advance_queue_pr_is_run_cmd(pmp_recipe) -> None:
-    """advance_queue_pr step must exist with tool=run_cmd."""
+def test_merge_prs_advance_queue_pr_is_run_python(pmp_recipe) -> None:
+    """advance_queue_pr step must exist with tool=run_python."""
     assert "advance_queue_pr" in pmp_recipe.steps
     step = pmp_recipe.steps["advance_queue_pr"]
-    assert step.tool == "run_cmd"
+    assert step.tool == "run_python"
 
 
 def test_merge_prs_next_queue_pr_or_done_removed(pmp_recipe) -> None:
@@ -340,20 +340,19 @@ def test_merge_prs_next_queue_pr_or_done_removed(pmp_recipe) -> None:
     assert "next_queue_pr_or_done" not in pmp_recipe.steps
 
 
-def test_merge_prs_advance_queue_pr_cmd_references_pr_order(pmp_recipe) -> None:
-    """advance_queue_pr cmd must reference pr_order_file and current_pr_number."""
+def test_merge_prs_advance_queue_pr_callable_references_pr_order(pmp_recipe) -> None:
+    """advance_queue_pr callable args must reference pr_order_file and current_pr_number."""
     step = pmp_recipe.steps["advance_queue_pr"]
-    cmd = step.with_args.get("cmd", "")
-    assert "pr_order_file" in cmd
-    assert "current_pr_number" in cmd
+    args = step.with_args
+    assert "pr_order_file" in args
+    assert "current_pr_number" in args
 
 
 def test_merge_prs_advance_queue_pr_captures_pr_number(pmp_recipe) -> None:
-    """advance_queue_pr must have a capture block for current_pr_number using | trim."""
+    """advance_queue_pr must have a capture block for current_pr_number."""
     step = pmp_recipe.steps["advance_queue_pr"]
     capture = step.capture or {}
     assert "current_pr_number" in capture
-    assert "trim" in capture["current_pr_number"]
 
 
 def test_merge_prs_advance_queue_pr_routing(pmp_recipe) -> None:

--- a/tests/recipe/test_plan_visualization_step.py
+++ b/tests/recipe/test_plan_visualization_step.py
@@ -47,18 +47,14 @@ def test_plan_visualization_step_captures_paths(recipe) -> None:
 
 
 def test_create_worktree_copies_viz_plan(recipe) -> None:
-    """create_worktree cmd must copy visualization-plan.md and report-plan.md."""
+    """create_worktree cmd must pass visualization_plan_path and report_plan_path."""
     step = recipe.steps["create_worktree"]
     cmd = step.with_args.get("cmd", "")
-    assert "VISUALIZATION_PLAN" in cmd, (
-        "create_worktree must reference VISUALIZATION_PLAN context variable"
+    assert "visualization_plan_path" in cmd, (
+        "create_worktree must pass context.visualization_plan_path to the script"
     )
-    assert "REPORT_PLAN" in cmd, "create_worktree must reference REPORT_PLAN context variable"
-    assert "visualization-plan.md" in cmd, (
-        "create_worktree must copy visualization-plan.md into the research dir"
-    )
-    assert "report-plan.md" in cmd, (
-        "create_worktree must copy report-plan.md into the research dir"
+    assert "report_plan_path" in cmd, (
+        "create_worktree must pass context.report_plan_path to the script"
     )
 
 

--- a/tests/recipe/test_recipe_scripts.py
+++ b/tests/recipe/test_recipe_scripts.py
@@ -14,7 +14,7 @@ from autoskillit.recipe.validator import run_semantic_rules
 
 pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
-SCRIPTS_DIR = pkg_root().parent.parent.parent / "scripts" / "recipe"
+SCRIPTS_DIR = pkg_root().parent.parent / "scripts" / "recipe"
 
 
 def test_recipe_scripts_are_executable():

--- a/tests/recipe/test_recipe_scripts.py
+++ b/tests/recipe/test_recipe_scripts.py
@@ -1,0 +1,56 @@
+"""Tests for scripts/recipe/ — externalized shell scripts."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+import pytest
+
+from autoskillit.core.paths import pkg_root
+from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
+from autoskillit.recipe.rules_inline_script import _INLINE_SCRIPT_ALLOWLIST
+from autoskillit.recipe.validator import run_semantic_rules
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+SCRIPTS_DIR = pkg_root().parent.parent.parent / "scripts" / "recipe"
+
+
+def test_recipe_scripts_are_executable():
+    for sh in SCRIPTS_DIR.glob("*.sh"):
+        assert os.access(sh, os.X_OK), f"{sh} is not executable"
+
+
+def test_recipe_scripts_pass_syntax_check():
+    for sh in SCRIPTS_DIR.glob("*.sh"):
+        result = subprocess.run(["bash", "-n", str(sh)], capture_output=True)
+        assert result.returncode == 0, f"{sh} has syntax errors: {result.stderr.decode()}"
+
+
+def test_allowlist_is_empty():
+    assert len(_INLINE_SCRIPT_ALLOWLIST) == 0, (
+        f"Allowlist still has {len(_INLINE_SCRIPT_ALLOWLIST)} entries: {_INLINE_SCRIPT_ALLOWLIST}"
+    )
+
+
+@pytest.mark.parametrize(
+    "recipe_name",
+    [
+        "implementation",
+        "remediation",
+        "implementation-groups",
+        "merge-prs",
+        "research",
+        "bem-wrapper",
+    ],
+)
+def test_recipes_pass_inline_script_rule(recipe_name):
+    recipe = load_recipe(builtin_recipes_dir() / f"{recipe_name}.yaml")
+    findings = run_semantic_rules(recipe)
+    inline_findings = [
+        f for f in findings if f.rule in ("inline-script-in-cmd", "inline-python-in-cmd")
+    ]
+    assert inline_findings == [], (
+        f"Recipe {recipe_name} has inline script findings: {inline_findings}"
+    )

--- a/tests/recipe/test_recipe_scripts.py
+++ b/tests/recipe/test_recipe_scripts.py
@@ -11,18 +11,22 @@ from autoskillit.core.paths import pkg_root
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.recipe.validator import run_semantic_rules
 
-pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.medium]
 
 SCRIPTS_DIR = pkg_root().parent.parent / "scripts" / "recipe"
 
 
 def test_recipe_scripts_are_executable():
-    for sh in SCRIPTS_DIR.glob("*.sh"):
+    scripts = list(SCRIPTS_DIR.glob("*.sh"))
+    assert scripts, f"No .sh scripts found in {SCRIPTS_DIR}"
+    for sh in scripts:
         assert os.access(sh, os.X_OK), f"{sh} is not executable"
 
 
 def test_recipe_scripts_pass_syntax_check():
-    for sh in SCRIPTS_DIR.glob("*.sh"):
+    scripts = list(SCRIPTS_DIR.glob("*.sh"))
+    assert scripts, f"No .sh scripts found in {SCRIPTS_DIR}"
+    for sh in scripts:
         result = subprocess.run(["bash", "-n", str(sh)], capture_output=True)
         assert result.returncode == 0, f"{sh} has syntax errors: {result.stderr.decode()}"
 

--- a/tests/recipe/test_recipe_scripts.py
+++ b/tests/recipe/test_recipe_scripts.py
@@ -9,7 +9,6 @@ import pytest
 
 from autoskillit.core.paths import pkg_root
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
-from autoskillit.recipe.rules_inline_script import _INLINE_SCRIPT_ALLOWLIST
 from autoskillit.recipe.validator import run_semantic_rules
 
 pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
@@ -26,12 +25,6 @@ def test_recipe_scripts_pass_syntax_check():
     for sh in SCRIPTS_DIR.glob("*.sh"):
         result = subprocess.run(["bash", "-n", str(sh)], capture_output=True)
         assert result.returncode == 0, f"{sh} has syntax errors: {result.stderr.decode()}"
-
-
-def test_allowlist_is_empty():
-    assert len(_INLINE_SCRIPT_ALLOWLIST) == 0, (
-        f"Allowlist still has {len(_INLINE_SCRIPT_ALLOWLIST)} entries: {_INLINE_SCRIPT_ALLOWLIST}"
-    )
 
 
 @pytest.mark.parametrize(

--- a/tests/recipe/test_research_bundle_lifecycle.py
+++ b/tests/recipe/test_research_bundle_lifecycle.py
@@ -13,10 +13,10 @@ def recipe():
 
 
 def test_stage_bundle_is_idempotent(recipe):
-    """stage_bundle cmd uses cp (idempotent); no mv/rename, no compression."""
+    """stage_bundle invokes an external script; no inline compression or commit."""
     step = recipe.steps["stage_bundle"]
     cmd = step.with_args.get("cmd", "")
-    assert "cp " in cmd, "stage_bundle must use cp for idempotent file copying"
+    assert "stage_bundle.sh" in cmd, "stage_bundle must delegate to scripts/recipe/stage_bundle.sh"
     assert "tar czf" not in cmd and "tar -czf" not in cmd, (
         "stage_bundle must NOT compress — second run must be a no-op"
     )
@@ -33,39 +33,20 @@ def test_stage_bundle_does_not_compress(recipe):
 
 
 def test_finalize_bundle_pr_mode(recipe):
-    """finalize_bundle must rename report.md→README.md, compress, append manifest, commit."""
+    """finalize_bundle must delegate to external script with output_mode, research_dir, worktree."""
     step = recipe.steps["finalize_bundle"]
     cmd = step.with_args.get("cmd", "")
-    # rename
-    assert "README.md" in cmd and "report.md" in cmd, (
-        "finalize_bundle must rename report.md to README.md"
+    assert "finalize_bundle.sh" in cmd, (
+        "finalize_bundle must delegate to scripts/recipe/finalize_bundle.sh"
     )
-    # compression
-    assert "tar czf" in cmd or "tar -czf" in cmd, "finalize_bundle must create tarball"
-    assert "-C" in cmd or "--directory" in cmd, "finalize_bundle must use -C for relative paths"
-    # manifest
-    assert "tar tzf" in cmd, "finalize_bundle must generate archive manifest"
-    assert "Archive Manifest" in cmd, "finalize_bundle manifest section header required"
-    assert ">> " in cmd and "README.md" in cmd, "manifest must be appended (>>) to README.md"
-    # post-compression guard
-    assert "artifacts.tar.gz" in cmd and "exit 1" in cmd, (
-        "finalize_bundle must guard that artifacts.tar.gz exists or exit 1"
+    assert "inputs.output_mode" in cmd, (
+        "finalize_bundle script must receive output_mode as first argument"
     )
-    # commit
-    assert "git commit" in cmd, "finalize_bundle must commit the result"
-    # dynamic tar inputs
-    assert "ls -1" in cmd and "grep -vE" in cmd, (
-        "finalize_bundle must use ls -1 | grep -vE for dynamic TAR_ITEMS"
+    assert "context.research_dir" in cmd, (
+        "finalize_bundle script must receive research_dir as argument"
     )
-    # cleanup loop
-    assert "for item in" in cmd and "rm -rf" in cmd, (
-        "finalize_bundle must rm -rf each archived item"
-    )
-    # rename before archive (rename_pos < tar_pos)
-    rename_pos = cmd.find("report.md")
-    tar_pos = cmd.find("tar czf")
-    assert rename_pos < tar_pos, (
-        "report.md rename must appear before tar czf so README.md is excluded"
+    assert "context.worktree_path" in cmd, (
+        "finalize_bundle script must receive worktree_path as argument"
     )
 
 

--- a/tests/recipe/test_research_output_mode.py
+++ b/tests/recipe/test_research_output_mode.py
@@ -112,19 +112,26 @@ def test_export_local_bundle_exists(recipe):
 
 def test_export_local_bundle_emits_local_bundle_path(recipe):
     step = recipe.steps["export_local_bundle"]
-    cmd = step.with_args.get("cmd", "")
-    assert "local_bundle_path=" in cmd, (
-        "export_local_bundle cmd must emit local_bundle_path= for capture"
+    # export_local_bundle is a run_python callable step — no inline cmd.
+    # Verify the callable is registered and the captured output key is declared.
+    assert step.tool == "run_python", "export_local_bundle must use run_python"
+    assert step.with_args.get("callable") == "autoskillit.recipe._cmd_rpc.export_local_bundle", (
+        "export_local_bundle must reference the export_local_bundle callable"
+    )
+    assert "local_bundle_path" in (step.capture or {}), (
+        "export_local_bundle must capture local_bundle_path"
     )
 
 
 def test_export_local_bundle_uses_source_dir_research_bundles(recipe):
     step = recipe.steps["export_local_bundle"]
-    cmd = step.with_args.get("cmd", "")
-    assert "research-bundles" in cmd, (
-        "export_local_bundle must export to {source_dir}/research-bundles/"
+    # export_local_bundle is a run_python callable step — verify with_args keys.
+    assert "source_dir" in step.with_args, (
+        "export_local_bundle must pass source_dir to the callable"
     )
-    assert "source_dir" in cmd, "export_local_bundle cmd must reference inputs.source_dir"
+    assert "research_dir" in step.with_args, (
+        "export_local_bundle must pass research_dir to the callable"
+    )
 
 
 def test_export_local_bundle_routes_to_patch_token_summary(recipe):
@@ -141,34 +148,42 @@ def test_export_local_bundle_routes_to_patch_token_summary(recipe):
 
 
 def test_finalize_bundle_reads_output_mode(recipe):
-    """finalize_bundle cmd must read OUTPUT_MODE from inputs.output_mode."""
+    """finalize_bundle cmd must pass output_mode to the external script."""
     step = recipe.steps["finalize_bundle"]
     cmd = step.with_args.get("cmd", "")
-    assert "OUTPUT_MODE" in cmd, "finalize_bundle must set OUTPUT_MODE from inputs.output_mode"
-    assert "inputs.output_mode" in cmd or "inputs.output_mode" in cmd, (
-        "finalize_bundle cmd must reference ${{ inputs.output_mode }}"
+    assert "finalize_bundle.sh" in cmd, (
+        "finalize_bundle must delegate to scripts/recipe/finalize_bundle.sh"
+    )
+    assert "inputs.output_mode" in cmd, (
+        "finalize_bundle cmd must pass ${{ inputs.output_mode }} as first script argument"
     )
 
 
 def test_finalize_bundle_skips_commit_in_local_mode(recipe):
-    """finalize_bundle cmd must gate git commit behind OUTPUT_MODE != local."""
+    """finalize_bundle delegates local/pr branching (including commit gating) to external script."""
     step = recipe.steps["finalize_bundle"]
     cmd = step.with_args.get("cmd", "")
-    # git commit must exist (for pr mode) but be conditional
-    assert "git commit" in cmd, "finalize_bundle must still have git commit (for pr mode)"
-    commit_pos = cmd.find("git commit")
-    output_mode_check_pos = cmd.rfind("OUTPUT_MODE", 0, commit_pos)
-    assert output_mode_check_pos != -1, (
-        "git commit block in finalize_bundle must be guarded by OUTPUT_MODE check"
+    # The script receives output_mode as its first positional arg and handles mode branching.
+    assert "finalize_bundle.sh" in cmd, (
+        "finalize_bundle must delegate to scripts/recipe/finalize_bundle.sh"
+    )
+    assert "inputs.output_mode" in cmd, (
+        "finalize_bundle must pass output_mode so the script can gate the git commit"
     )
 
 
 def test_finalize_bundle_preserves_html_in_local_mode(recipe):
-    """finalize_bundle tar exclusion must include report.html for local mode browsing."""
+    """finalize_bundle delegates local-mode HTML preservation to the external script."""
     step = recipe.steps["finalize_bundle"]
     cmd = step.with_args.get("cmd", "")
-    assert r"report\.html" in cmd, (
-        r"finalize_bundle must reference report\.html (escaped) in tar exclusion for local mode"
+    # The script (finalize_bundle.sh) handles report.html exclusion for local mode.
+    # The recipe cmd passes output_mode so the script can apply the correct exclusion.
+    assert "finalize_bundle.sh" in cmd, (
+        "finalize_bundle must delegate to scripts/recipe/finalize_bundle.sh "
+        "(which excludes report.html from tar in local mode)"
+    )
+    assert "inputs.output_mode" in cmd, (
+        "finalize_bundle must pass output_mode so the script preserves report.html in local mode"
     )
 
 

--- a/tests/recipe/test_research_output_mode.py
+++ b/tests/recipe/test_research_output_mode.py
@@ -160,7 +160,7 @@ def test_finalize_bundle_reads_output_mode(recipe):
 
 
 def test_finalize_bundle_skips_commit_in_local_mode(recipe):
-    """finalize_bundle delegates local/pr branching (including commit gating) to external script."""
+    """finalize_bundle delegates local/pr branching to external script."""
     step = recipe.steps["finalize_bundle"]
     cmd = step.with_args.get("cmd", "")
     # The script receives output_mode as its first positional arg and handles mode branching.

--- a/tests/recipe/test_rules_inline_script.py
+++ b/tests/recipe/test_rules_inline_script.py
@@ -1,0 +1,243 @@
+"""Tests for inline-script-in-cmd and inline-python-in-cmd lint rules."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.core import Severity
+from autoskillit.recipe.validator import run_semantic_rules
+from tests.recipe.conftest import _make_workflow
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+
+def _make_recipe(steps: dict) -> object:
+    """Build a minimal Recipe from a dict of step dicts, with a terminal END step."""
+    all_steps = {**steps, "END": {"action": "stop", "message": "Done"}}
+    return _make_workflow(all_steps)
+
+
+# ---------------------------------------------------------------------------
+# inline-script-in-cmd: ERROR cases
+# ---------------------------------------------------------------------------
+
+
+def test_inline_script_fires_on_control_flow():
+    recipe = _make_recipe(
+        {
+            "step_a": {
+                "tool": "run_cmd",
+                "with": {
+                    "cmd": 'VAR=1 && if [ "$VAR" -gt 0 ]; then echo "yes"; else echo "no"; fi'
+                },
+                "on_success": "END",
+            }
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    codes = [f.rule for f in findings]
+    assert "inline-script-in-cmd" in codes
+
+
+def test_inline_script_fires_on_for_loop():
+    recipe = _make_recipe(
+        {
+            "step_a": {
+                "tool": "run_cmd",
+                "with": {"cmd": 'for i in $(seq 1 10); do echo "$i"; done'},
+                "on_success": "END",
+            }
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    codes = [f.rule for f in findings]
+    assert "inline-script-in-cmd" in codes
+
+
+def test_inline_script_fires_on_while_loop():
+    recipe = _make_recipe(
+        {
+            "step_a": {
+                "tool": "run_cmd",
+                "with": {"cmd": "while true; do sleep 1; done"},
+                "on_success": "END",
+            }
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    codes = [f.rule for f in findings]
+    assert "inline-script-in-cmd" in codes
+
+
+def test_inline_script_fires_on_excessive_vars_and_chains():
+    recipe = _make_recipe(
+        {
+            "step_a": {
+                "tool": "run_cmd",
+                "with": {"cmd": 'A=$(foo) && B=$(bar) && C=$(baz) && echo "$A $B $C" && cleanup'},
+                "on_success": "END",
+            }
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    codes = [f.rule for f in findings]
+    assert "inline-script-in-cmd" in codes
+
+
+def test_inline_script_fires_on_bash_builtins():
+    recipe = _make_recipe(
+        {
+            "step_a": {
+                "tool": "run_cmd",
+                "with": {"cmd": 'declare -A map && map[key]=value && echo "${map[key]}"'},
+                "on_success": "END",
+            }
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    codes = [f.rule for f in findings]
+    assert "inline-script-in-cmd" in codes
+
+
+def test_inline_script_error_on_control_flow():
+    recipe = _make_recipe(
+        {
+            "step_a": {
+                "tool": "run_cmd",
+                "with": {"cmd": 'if [ -f foo ]; then echo "yes"; else echo "no"; fi'},
+                "on_success": "END",
+            }
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    inline_findings = [f for f in findings if f.rule == "inline-script-in-cmd"]
+    assert len(inline_findings) > 0
+    assert inline_findings[0].severity == Severity.ERROR
+
+
+# ---------------------------------------------------------------------------
+# inline-script-in-cmd: WARNING cases
+# ---------------------------------------------------------------------------
+
+
+def test_inline_script_warning_on_multiline_with_vars():
+    cmd = (
+        "REMOTE=$(git remote) &&\n"
+        "SHA=$(git rev-parse HEAD) &&\n"
+        "BRANCH=$(git branch --show-current) &&\n"
+        'echo "$REMOTE $SHA $BRANCH"'
+    )
+    recipe = _make_recipe(
+        {
+            "step_a": {
+                "tool": "run_cmd",
+                "with": {"cmd": cmd},
+                "on_success": "END",
+            }
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    inline_findings = [f for f in findings if f.rule == "inline-script-in-cmd"]
+    assert len(inline_findings) > 0
+    assert inline_findings[0].severity == Severity.WARNING
+
+
+# ---------------------------------------------------------------------------
+# inline-python-in-cmd
+# ---------------------------------------------------------------------------
+
+
+def test_inline_python_fires_on_python3_c():
+    recipe = _make_recipe(
+        {
+            "step_a": {
+                "tool": "run_cmd",
+                "with": {"cmd": 'python3 -c "import json; print(json.dumps({}))"'},
+                "on_success": "END",
+            }
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    codes = [f.rule for f in findings]
+    assert "inline-python-in-cmd" in codes
+
+
+# ---------------------------------------------------------------------------
+# Clean cases: rule must NOT fire
+# ---------------------------------------------------------------------------
+
+
+def test_inline_script_clean_for_simple_commands():
+    recipe = _make_recipe(
+        {
+            "step_a": {
+                "tool": "run_cmd",
+                "with": {"cmd": "git push -u origin HEAD"},
+                "on_success": "END",
+            }
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    assert all(f.rule != "inline-script-in-cmd" for f in findings)
+
+
+def test_inline_script_clean_for_flag_continuation():
+    recipe = _make_recipe(
+        {
+            "step_a": {
+                "tool": "run_cmd",
+                "with": {"cmd": "gh pr create --base main --head feat --title 'foo' --body 'bar'"},
+                "on_success": "END",
+            }
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    assert all(f.rule != "inline-script-in-cmd" for f in findings)
+
+
+def test_inline_script_clean_for_jq_expressions():
+    recipe = _make_recipe(
+        {
+            "step_a": {
+                "tool": "run_cmd",
+                "with": {
+                    "cmd": (
+                        "gh pr view 42 --json statusCheckRollup "
+                        "--jq '.statusCheckRollup | if length == 0 "
+                        'then "none" else "exists" end\''
+                    )
+                },
+                "on_success": "END",
+            }
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    assert all(f.rule != "inline-script-in-cmd" for f in findings)
+
+
+def test_inline_script_clean_for_allowlisted_steps():
+    recipe = _make_recipe(
+        {
+            "compute_branch": {
+                "tool": "run_cmd",
+                "with": {"cmd": 'SLUG="foo" && if [ -n "$SLUG" ]; then printf "%s" "$SLUG"; fi'},
+                "on_success": "END",
+            }
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    assert all(f.rule != "inline-script-in-cmd" for f in findings)
+
+
+def test_inline_script_ignores_non_run_cmd_steps():
+    recipe = _make_recipe(
+        {
+            "step_a": {
+                "tool": "run_python",
+                "with": {"callable": "autoskillit.smoke_utils.check_loop_iteration"},
+                "on_success": "END",
+            }
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    assert all(f.rule != "inline-script-in-cmd" for f in findings)

--- a/tests/recipe/test_rules_inline_script.py
+++ b/tests/recipe/test_rules_inline_script.py
@@ -215,7 +215,7 @@ def test_inline_script_clean_for_jq_expressions():
     assert all(f.rule != "inline-script-in-cmd" for f in findings)
 
 
-def test_inline_script_clean_for_allowlisted_steps():
+def test_inline_script_fires_for_formerly_allowlisted_steps():
     recipe = _make_recipe(
         {
             "compute_branch": {
@@ -226,7 +226,7 @@ def test_inline_script_clean_for_allowlisted_steps():
         }
     )
     findings = run_semantic_rules(recipe)
-    assert all(f.rule != "inline-script-in-cmd" for f in findings)
+    assert any(f.rule == "inline-script-in-cmd" for f in findings)
 
 
 def test_inline_script_ignores_non_run_cmd_steps():


### PR DESCRIPTION
## Summary

### Part A: ADR Document and Lint Rule

Part A delivers the ADR document and the `inline-script-in-cmd` semantic lint rule. This is the most critical deliverable because it prevents future regression. The rule detects inline shell scripts in `run_cmd` step `cmd:` fields using heuristic analysis (control flow keywords, variable assignments, loops, embedded Python). Existing violations are grandfathered via a frozen allowlist following the `_PSEUDOCODE_ALLOWLIST` pattern from `rules_skill_content.py`.

### Part B: Externalize Inline Scripts

Part B externalizes all 26 unique allowlisted inline shell scripts (appearing as 46 step instances across 6 recipe files) from recipe `cmd:` fields into reusable `run_python` callables and shell scripts. After completion, every `run_cmd` step contains at most a single command invocation, the `_INLINE_SCRIPT_ALLOWLIST` is emptied, and the lint rule from Part A enforces the policy with zero suppressions.

<details>
<summary>Individual Group Plans</summary>

### Group 1: Part A: ADR Document and Lint Rule

Part A delivers the ADR document and the `inline-script-in-cmd` semantic lint rule. This is the most critical deliverable because it prevents future regression. The rule detects inline shell scripts in `run_cmd` step `cmd:` fields using heuristic analysis (control flow keywords, variable assignments, loops, embedded Python). Existing violations are grandfathered via a frozen allowlist following the `_PSEUDOCODE_ALLOWLIST` pattern from `rules_skill_content.py`.

Part B will cover the externalization of all 61 existing violations into `run_python` callables and shell scripts (separate task).

### Group 2: Part B: Externalize Inline Scripts

Part B externalizes all 26 unique allowlisted inline shell scripts (appearing as 46 step instances across 6 recipe files) from recipe `cmd:` fields into reusable `run_python` callables and shell scripts. After completion, every `run_cmd` step contains at most a single command invocation, the `_INLINE_SCRIPT_ALLOWLIST` is emptied, and the lint rule from Part A enforces the policy with zero suppressions.

Part A covers the ADR document and lint rule creation (separate task, must be completed first).

</details>

Closes #1584

## Implementation Plan

Plan files:
- `/home/talon/projects/autoskillit-runs/impl-20260501-182509-936316/.autoskillit/temp/make-plan/adr_ban_inline_shell_scripts_plan_2026-05-01_182509_part_a.md`
- `/home/talon/projects/autoskillit-runs/impl-20260501-182509-936316/.autoskillit/temp/make-plan/adr_ban_inline_shell_scripts_plan_2026-05-01_182509_part_b.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 4.0k | 15.7k | 443.5k | 65.6k | 1 | 8m 30s |
| verify | 123 | 37.6k | 6.1M | 156.6k | 2 | 23m 15s |
| implement | 1.9k | 74.5k | 19.7M | 254.2k | 2 | 52m 33s |
| prepare_pr | 27 | 9.6k | 314.4k | 33.4k | 1 | 2m 45s |
| compose_pr | 22 | 1.8k | 136.8k | 20.1k | 1 | 53s |
| review_pr | 3.5k | 69.7k | 5.0M | 411.5k | 3 | 33m 50s |
| resolve_review | 6.2k | 60.4k | 11.6M | 287.2k | 3 | 43m 32s |
| **Total** | 15.8k | 269.3k | 43.2M | 1.2M | | 2h 45m |