### PR TITLE
Rectify: Kitchen-Open Guard in run_update_checks() Blocks Informational Prompts

### DIFF
--- a/src/autoskillit/cli/_update_checks.py
+++ b/src/autoskillit/cli/_update_checks.py
@@ -49,6 +49,8 @@ _DISMISS_FILE = "update_check.json"
 _STABLE_DISMISS_WINDOW = timedelta(days=7)
 _DEV_DISMISS_WINDOW = timedelta(hours=12)
 
+KITCHEN_GUARDED_COMMANDS: frozenset[str] = frozenset({"update", "install", "init"})
+
 
 @dataclass(frozen=True)
 class Signal:
@@ -291,7 +293,7 @@ def _run_update_sequence(
         perform_restart()
 
 
-def run_update_checks(home: Path | None = None) -> None:
+def run_update_checks(home: Path | None = None, *, command: str = "") -> None:
     """Run the unified update check on interactive CLI invocations.
 
     At most one ``[Y/n]`` prompt is shown per invocation.  Guards:
@@ -317,14 +319,15 @@ def run_update_checks(home: Path | None = None) -> None:
     ):
         return
 
-    from autoskillit.core import any_kitchen_open  # noqa: PLC0415
+    if command in KITCHEN_GUARDED_COMMANDS:
+        from autoskillit.core import any_kitchen_open  # noqa: PLC0415
 
-    if any_kitchen_open(project_path=str(Path.cwd())):
-        print(
-            "Skipping update check: a kitchen is open for this project. "
-            "Run 'autoskillit update' manually after the pipeline finishes.",
-        )
-        return
+        if any_kitchen_open(project_path=str(Path.cwd())):
+            print(
+                "Skipping update check: a kitchen is open for this project. "
+                "Run 'autoskillit update' manually after the pipeline finishes.",
+            )
+            return
 
     _skip_env: dict[str, str] = {
         **os.environ,

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -443,5 +443,5 @@ def main() -> None:
 
         from autoskillit.cli._update_checks import run_update_checks
 
-        run_update_checks()
+        run_update_checks(command=_first_arg)
     app()

--- a/tests/arch/test_kitchen_guard_scoping.py
+++ b/tests/arch/test_kitchen_guard_scoping.py
@@ -102,13 +102,9 @@ def _if_body_has_any_kitchen_open_call(if_node: ast.If) -> bool:
 
 def _if_test_references_kitchen_guarded_commands(if_node: ast.If) -> bool:
     """Return True if the if-node's test references KITCHEN_GUARDED_COMMANDS."""
-    test_src = ast.dump(if_node.test)
-    return "KITCHEN_GUARDED_COMMANDS" in test_src or (
-        isinstance(if_node.test, ast.Compare)
-        and any(
-            isinstance(c, ast.Name) and c.id == "KITCHEN_GUARDED_COMMANDS"
-            for c in ast.walk(if_node.test)
-        )
+    return any(
+        isinstance(node, ast.Name) and node.id == "KITCHEN_GUARDED_COMMANDS"
+        for node in ast.walk(if_node.test)
     )
 
 

--- a/tests/arch/test_kitchen_guard_scoping.py
+++ b/tests/arch/test_kitchen_guard_scoping.py
@@ -69,6 +69,72 @@ def _function_body_has_any_kitchen_open_patch(func_node: ast.FunctionDef) -> boo
     return False
 
 
+_UPDATE_CHECKS_FILE = _SRC_ROOT / "cli" / "_update_checks.py"
+
+
+def test_run_update_checks_has_command_parameter() -> None:
+    """run_update_checks must declare a 'command' parameter."""
+    source = _UPDATE_CHECKS_FILE.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(_UPDATE_CHECKS_FILE))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "run_update_checks":
+            param_names = [arg.arg for arg in node.args.args + node.args.kwonlyargs]
+            assert "command" in param_names, (
+                f"run_update_checks must have a 'command' parameter, got: {param_names}"
+            )
+            return
+    raise AssertionError("run_update_checks not found in _update_checks.py")
+
+
+def _find_function(tree: ast.AST, name: str) -> ast.FunctionDef | None:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    return None
+
+
+def _if_body_has_any_kitchen_open_call(if_node: ast.If) -> bool:
+    for node in ast.walk(if_node):
+        if isinstance(node, ast.Call) and _is_any_kitchen_open_call(node):
+            return True
+    return False
+
+
+def _if_test_references_kitchen_guarded_commands(if_node: ast.If) -> bool:
+    """Return True if the if-node's test references KITCHEN_GUARDED_COMMANDS."""
+    test_src = ast.dump(if_node.test)
+    return "KITCHEN_GUARDED_COMMANDS" in test_src or (
+        isinstance(if_node.test, ast.Compare)
+        and any(
+            isinstance(c, ast.Name) and c.id == "KITCHEN_GUARDED_COMMANDS"
+            for c in ast.walk(if_node.test)
+        )
+    )
+
+
+def test_kitchen_guard_gated_by_kitchen_guarded_commands() -> None:
+    """The any_kitchen_open call in run_update_checks must be inside an if block
+    whose test references KITCHEN_GUARDED_COMMANDS."""
+    source = _UPDATE_CHECKS_FILE.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(_UPDATE_CHECKS_FILE))
+    func = _find_function(tree, "run_update_checks")
+    assert func is not None, "run_update_checks not found in _update_checks.py"
+
+    for node in ast.walk(func):
+        if not isinstance(node, ast.If):
+            continue
+        if not _if_test_references_kitchen_guarded_commands(node):
+            continue
+        if _if_body_has_any_kitchen_open_call(node):
+            return
+
+    raise AssertionError(
+        "any_kitchen_open call in run_update_checks is not inside an if block "
+        "whose test references KITCHEN_GUARDED_COMMANDS. "
+        "The guard must be gated: `if command in KITCHEN_GUARDED_COMMANDS: any_kitchen_open(...)`"
+    )
+
+
 def test_setup_helpers_must_patch_any_kitchen_open() -> None:
     helpers = [
         (_TEST_ROOT / "cli" / "test_update_command.py", "_setup_run_update"),

--- a/tests/cli/test_app_main.py
+++ b/tests/cli/test_app_main.py
@@ -22,7 +22,7 @@ def test_main_does_not_call_app_after_update_restart(monkeypatch: pytest.MonkeyP
         "autoskillit.cli._init_helpers.evict_direct_mcp_entry", lambda *a, **kw: None
     )
 
-    def fake_run_update_checks() -> None:
+    def fake_run_update_checks(**kwargs: object) -> None:
         raise SystemExit(0)
 
     monkeypatch.setattr("autoskillit.cli._update_checks.run_update_checks", fake_run_update_checks)
@@ -34,3 +34,37 @@ def test_main_does_not_call_app_after_update_restart(monkeypatch: pytest.MonkeyP
         pass
 
     assert not app_called, "app() must not be called when update path exits the process"
+
+
+@pytest.mark.parametrize(
+    "argv_command",
+    [
+        "order",
+        "update",
+    ],
+)
+def test_main_passes_command_to_run_update_checks(
+    monkeypatch: pytest.MonkeyPatch, argv_command: str
+) -> None:
+    """main() must pass _first_arg as command= to run_update_checks()."""
+    app_module = importlib.import_module("autoskillit.cli.app")
+
+    monkeypatch.setattr(app_module, "app", lambda: None)
+    monkeypatch.setattr(
+        "autoskillit.cli._init_helpers.evict_direct_mcp_entry", lambda *a, **kw: None
+    )
+
+    captured_kwargs: list[dict[str, object]] = []
+
+    def spy_run_update_checks(**kwargs: object) -> None:
+        captured_kwargs.append(dict(kwargs))
+
+    monkeypatch.setattr("autoskillit.cli._update_checks.run_update_checks", spy_run_update_checks)
+    monkeypatch.setattr(sys, "argv", ["autoskillit", argv_command])
+
+    app_module.main()
+
+    assert len(captured_kwargs) == 1, "run_update_checks must be called exactly once"
+    assert captured_kwargs[0].get("command") == argv_command, (
+        f"run_update_checks must receive command={argv_command!r}, got {captured_kwargs[0]!r}"
+    )

--- a/tests/cli/test_update_checks_prompt.py
+++ b/tests/cli/test_update_checks_prompt.py
@@ -831,7 +831,7 @@ def test_run_update_checks_shows_notification_when_kitchen_open(
         lambda *a, **kw: binary_signal_calls.append(True) or None,
     )
 
-    run_update_checks(home=tmp_path)
+    run_update_checks(home=tmp_path, command="update")
 
     combined = " ".join(printed)
     assert "kitchen" in combined.lower(), (
@@ -840,4 +840,65 @@ def test_run_update_checks_shows_notification_when_kitchen_open(
     assert not input_calls, "run_update_checks must not prompt interactively when kitchen is open"
     assert not binary_signal_calls, (
         "run_update_checks must not proceed to signal checks when kitchen is open"
+    )
+
+
+def test_run_update_checks_kitchen_open_bypassed_for_non_mutation_command(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """run_update_checks with command='order' proceeds past kitchen guard even when open."""
+    printed, input_calls = _setup_run_checks(monkeypatch, tmp_path, binary_signal=True)
+    monkeypatch.setattr("autoskillit.core.any_kitchen_open", lambda **kw: True)
+
+    binary_signal_calls: list[bool] = []
+    monkeypatch.setattr(
+        "autoskillit.cli._update_checks._binary_signal",
+        lambda *a, **kw: binary_signal_calls.append(True) or None,
+    )
+
+    run_update_checks(home=tmp_path, command="order")
+
+    combined = " ".join(printed)
+    assert "kitchen" not in combined.lower(), (
+        "run_update_checks must NOT print the kitchen-suppression message for 'order'"
+    )
+    assert binary_signal_calls, (
+        "run_update_checks must call _binary_signal (signal gathering proceeds) for 'order'"
+    )
+
+
+def test_run_update_checks_kitchen_guard_active_for_update_command(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """run_update_checks with command='update' retains kitchen guard suppression."""
+    printed, input_calls = _setup_run_checks(monkeypatch, tmp_path, binary_signal=True)
+    monkeypatch.setattr("autoskillit.core.any_kitchen_open", lambda **kw: True)
+
+    binary_signal_calls: list[bool] = []
+    monkeypatch.setattr(
+        "autoskillit.cli._update_checks._binary_signal",
+        lambda *a, **kw: binary_signal_calls.append(True) or None,
+    )
+
+    run_update_checks(home=tmp_path, command="update")
+
+    combined = " ".join(printed)
+    assert "kitchen" in combined.lower(), (
+        "run_update_checks must suppress via kitchen guard for 'update'"
+    )
+    assert not input_calls, (
+        "run_update_checks must not prompt interactively for 'update' + kitchen"
+    )
+    assert not binary_signal_calls, (
+        "run_update_checks must not reach signal gathering for 'update' + kitchen"
+    )
+
+
+def test_kitchen_guarded_commands_registry() -> None:
+    """KITCHEN_GUARDED_COMMANDS must contain exactly the mutation commands."""
+    from autoskillit.cli._update_checks import KITCHEN_GUARDED_COMMANDS
+
+    assert KITCHEN_GUARDED_COMMANDS == frozenset({"update", "install", "init"}), (
+        f"KITCHEN_GUARDED_COMMANDS must be exactly {{'update', 'install', 'init'}}, "
+        f"got {KITCHEN_GUARDED_COMMANDS!r}"
     )

--- a/tests/cli/test_update_checks_prompt.py
+++ b/tests/cli/test_update_checks_prompt.py
@@ -848,7 +848,6 @@ def test_run_update_checks_kitchen_open_bypassed_for_non_mutation_command(
 ) -> None:
     """run_update_checks with command='order' proceeds past kitchen guard even when open."""
     printed, input_calls = _setup_run_checks(monkeypatch, tmp_path, binary_signal=True)
-    monkeypatch.setattr("autoskillit.core.any_kitchen_open", lambda **kw: True)
 
     binary_signal_calls: list[bool] = []
     monkeypatch.setattr(

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -148,7 +148,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _marketplace.py — hooks.json (co-owned)
     ("src/autoskillit/cli/_marketplace.py", 177),
     # _update_checks.py — dismissal state file
-    ("src/autoskillit/cli/_update_checks.py", 79),
+    ("src/autoskillit/cli/_update_checks.py", 81),
     # _update_checks_fetch.py — fetch cache (extracted from _update_checks.py)
     ("src/autoskillit/cli/_update_checks_fetch.py", 58),
     # smoke_utils.py — domain partitions dict, hunk ranges list, merge queue list


### PR DESCRIPTION
## Summary

The `run_update_checks()` function at `_update_checks.py:322` uses `any_kitchen_open()` as an entry-point guard that suppresses all update signals — including purely informational ones — for every CLI command. Only mutation commands (`update`, `install`, `init`) actually need this protection. The guard lacks caller-context discrimination, a class of bug the codebase already prevents elsewhere via typed frozenset registries (e.g., `_ORCHESTRATION_TOOLS`, `GATED_TOOLS`). The fix applies that same registry pattern: define a `KITCHEN_GUARDED_COMMANDS` frozenset, pass the CLI command name into `run_update_checks()`, and gate only when the command is in the set. This makes the guard structurally immune to over-scoping — new commands default to unguarded, and mutation commands must be explicitly registered.

Closes #1594

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260501-214425-611916/.autoskillit/temp/rectify/rectify_kitchen_guard_update_checks_2026-05-01_214425.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| rectify | 59 | 12.8k | 664.8k | 72.7k | 1 | 5m 27s |
| dry_walkthrough | 38 | 8.0k | 1.0M | 51.4k | 1 | 4m 13s |
| implement | 180 | 8.7k | 1.1M | 63.2k | 1 | 3m 27s |
| prepare_pr | 68 | 5.5k | 273.4k | 31.9k | 1 | 1m 33s |
| compose_pr | 59 | 2.2k | 194.6k | 19.7k | 1 | 58s |
| review_pr | 100 | 30.2k | 522.7k | 93.8k | 1 | 5m 57s |
| resolve_review | 283 | 21.1k | 2.0M | 73.8k | 1 | 10m 23s |
| **Total** | 787 | 88.6k | 5.7M | 406.5k | | 31m 59s |