### PR TITLE
Implementation Plan: make-plan SKILL.md uses project-specific 'integration branch' terminology

### DIFF
--- a/src/autoskillit/skills_extended/make-plan/SKILL.md
+++ b/src/autoskillit/skills_extended/make-plan/SKILL.md
@@ -142,7 +142,7 @@ More than one lens diagram is okay if it is complex plan (don't do more than 3, 
 
 ## Conflict-Resolution Plan Requirements
 
-When the task involves applying changes from a PR branch to an integration branch
+When the task involves resolving conflicts to apply changes from one branch onto another
 (i.e., the input is a conflict report produced by `merge-pr`), the plan
 **MUST produce a worktree with a linear commit history**.
 

--- a/tests/skills/test_skill_genericization.py
+++ b/tests/skills/test_skill_genericization.py
@@ -82,3 +82,12 @@ def test_plan_experiment_has_no_hardcoded_metrics_rs() -> None:
         "plan-experiment/SKILL.md hardcodes 'src/metrics.rs'. "
         "Use generic evaluation framework language (REQ-GEN-005)."
     )
+
+
+def test_make_plan_uses_generic_branch_terminology() -> None:
+    """make-plan/SKILL.md must not use 'integration branch' — project-specific terminology."""
+    content = (SKILLS_EXTENDED_DIR / "make-plan" / "SKILL.md").read_text()
+    assert "integration branch" not in content, (
+        "make-plan/SKILL.md uses 'integration branch' — project-specific terminology "
+        "from the merge-prs workflow. Use generic language instead (REQ-GEN-006)."
+    )


### PR DESCRIPTION
## Summary

`make-plan/SKILL.md` line 145 says "applying changes from a PR branch to an integration branch" — project-specific terminology tied to the `merge-prs` batch-branch workflow. The fix replaces this with generic language that describes the scenario without assuming a branching model. A new contract test guards against regression.

The change is exactly two artifacts:
1. One sentence in `src/autoskillit/skills_extended/make-plan/SKILL.md` (line 145)
2. One new test function in `tests/skills/test_skill_genericization.py`

Closes #1493

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260501-225058-383783/.autoskillit/temp/make-plan/make_plan_integration_branch_terminology_plan_2026-05-01_225600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 103 | 7.7k | 517.3k | 53.1k | 1 | 3m 48s |
| verify | 84 | 5.9k | 376.3k | 35.6k | 1 | 2m 9s |
| implement | 124 | 4.4k | 602.8k | 36.1k | 1 | 2m 29s |
| prepare_pr | 60 | 4.3k | 207.0k | 24.6k | 1 | 1m 28s |
| compose_pr | 59 | 1.5k | 191.2k | 18.7k | 1 | 46s |
| review_pr | 116 | 14.1k | 541.0k | 39.7k | 1 | 3m 38s |
| **Total** | 546 | 37.9k | 2.4M | 207.9k | | 14m 20s |