### PR TITLE
Rectify: CI Watch Pipeline Null Immunity & Event Validation

### DIFF
--- a/src/autoskillit/cli/_prompts.py
+++ b/src/autoskillit/cli/_prompts.py
@@ -615,6 +615,17 @@ SKILL_COMMAND FORMATTING — MANDATORY:
   is always a single path token — never a labeled section.
 - If a step note says to pass an extra argument, append it as one space-separated
   token: `/autoskillit:skill /path/arg1 arg2`, NOT `/autoskillit:skill\n## Path\n/path`.
+
+NULL/NONE CONTEXT VARIABLES — MANDATORY:
+- When a ${{{{ context.var_name }}}} or ${{{{ inputs.var_name }}}} value is None, null,
+  or has not been captured yet, you MUST either:
+  (a) OMIT the parameter entirely from the tool call, OR
+  (b) Pass null/None as the value.
+- NEVER substitute a guessed, inferred, or plausible value for an uncaptured
+  context variable. If ci_event is None, pass event=null — do not guess "push"
+  or any other event name.
+- The string "None" is NOT the same as null. If the captured value is the Python
+  None object, do not pass the literal string "None".
 {sous_chef_content}
 """
 

--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -122,6 +122,7 @@ from .types import HEADLESS_ENV_VAR as HEADLESS_ENV_VAR
 from .types import HEADLESS_TOOLS as HEADLESS_TOOLS
 from .types import HeadlessExecutor as HeadlessExecutor
 from .types import KITCHEN_SESSION_ID_ENV_VAR as KITCHEN_SESSION_ID_ENV_VAR
+from .types import KNOWN_CI_EVENTS as KNOWN_CI_EVENTS
 from .types import KillReason as KillReason
 from .types import LAUNCH_ID_ENV_VAR as LAUNCH_ID_ENV_VAR
 from .types import LoadReport as LoadReport

--- a/src/autoskillit/core/_type_constants.py
+++ b/src/autoskillit/core/_type_constants.py
@@ -59,6 +59,7 @@ __all__ = [
     "SKILL_ACTIVATE_DEPS_REQUIRED",
     "SOUS_CHEF_MANDATORY_SECTIONS",
     "SOUS_CHEF_L2_SECTIONS",
+    "KNOWN_CI_EVENTS",
 ]
 
 AUTOSKILLIT_INSTALLED_VERSION: str = version("autoskillit")
@@ -486,3 +487,15 @@ SOUS_CHEF_L2_SECTIONS: tuple[str, ...] = (
     "QUOTA WAIT PROTOCOL",
 )
 assert set(SOUS_CHEF_L2_SECTIONS).issubset(set(SOUS_CHEF_MANDATORY_SECTIONS))
+
+KNOWN_CI_EVENTS: frozenset[str] = frozenset(
+    {
+        "push",
+        "pull_request",
+        "pull_request_target",
+        "merge_group",
+        "workflow_dispatch",
+        "schedule",
+        "workflow_call",
+    }
+)

--- a/src/autoskillit/core/_type_results.py
+++ b/src/autoskillit/core/_type_results.py
@@ -12,6 +12,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Generic, Literal, TypedDict, TypeVar
 
+from ._type_constants import KNOWN_CI_EVENTS
 from ._type_enums import KillReason, RetryReason, SessionOutcome
 
 T = TypeVar("T")
@@ -272,19 +273,6 @@ class CIRunScope:
             raise ValueError(
                 f"Invalid CI event {self.event!r}. Valid events: {sorted(KNOWN_CI_EVENTS)}"
             )
-
-
-KNOWN_CI_EVENTS: frozenset[str] = frozenset(
-    {
-        "push",
-        "pull_request",
-        "pull_request_target",
-        "merge_group",
-        "workflow_dispatch",
-        "schedule",
-        "workflow_call",
-    }
-)
 
 
 class CloneSuccessResult(TypedDict):

--- a/src/autoskillit/core/_type_results.py
+++ b/src/autoskillit/core/_type_results.py
@@ -27,7 +27,6 @@ __all__ = [
     "SkillResult",
     "CleanupResult",
     "CIRunScope",
-    "KNOWN_CI_EVENTS",
     "CloneSuccessResult",
     "CloneGateUncommitted",
     "CloneGateUnpublished",

--- a/src/autoskillit/core/_type_results.py
+++ b/src/autoskillit/core/_type_results.py
@@ -26,6 +26,7 @@ __all__ = [
     "SkillResult",
     "CleanupResult",
     "CIRunScope",
+    "KNOWN_CI_EVENTS",
     "CloneSuccessResult",
     "CloneGateUncommitted",
     "CloneGateUnpublished",
@@ -265,6 +266,25 @@ class CIRunScope:
     workflow: str | None = None  # workflow filename, e.g. "tests.yml"
     head_sha: str | None = None  # commit SHA to pin results to
     event: str | None = None  # trigger event, e.g. "push", "pull_request"
+
+    def __post_init__(self) -> None:
+        if self.event is not None and self.event not in KNOWN_CI_EVENTS:
+            raise ValueError(
+                f"Invalid CI event {self.event!r}. Valid events: {sorted(KNOWN_CI_EVENTS)}"
+            )
+
+
+KNOWN_CI_EVENTS: frozenset[str] = frozenset(
+    {
+        "push",
+        "pull_request",
+        "pull_request_target",
+        "merge_group",
+        "workflow_dispatch",
+        "schedule",
+        "workflow_call",
+    }
+)
 
 
 class CloneSuccessResult(TypedDict):

--- a/src/autoskillit/recipe/_cmd_rpc.py
+++ b/src/autoskillit/recipe/_cmd_rpc.py
@@ -16,7 +16,7 @@ def compute_branch(
     run_name: str = "",
     issue_number: str = "",
 ) -> dict[str, str]:
-    """Compute branch name from slug + issue or date. Callable via run_python."""
+    """Compute branch name from slug + issue or date."""
     prefix = issue_slug or run_name
     if issue_number:
         return {"branch_name": f"{prefix}/{issue_number}"}
@@ -27,7 +27,7 @@ def check_eject_limit(
     counter_file: str,
     max_ejects: str = "3",
 ) -> dict[str, str]:
-    """Increment counter file; return EJECT_OK or EJECT_LIMIT_EXCEEDED. Callable via run_python."""
+    """Increment counter file; return EJECT_OK or EJECT_LIMIT_EXCEEDED."""
     max_ejects = max_ejects or "3"
     path = Path(counter_file)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -60,7 +60,7 @@ def check_dropped_healthy_loop(
 
 
 def commit_guard(worktree_path: str) -> dict[str, str]:
-    """Auto-commit pending changes if worktree is dirty. Callable via run_python."""
+    """Auto-commit pending changes if worktree is dirty."""
     result = subprocess.run(
         ["git", "status", "--porcelain"],
         cwd=worktree_path,
@@ -95,7 +95,7 @@ def queue_ejected_fix(
     work_dir: str,
     base_branch: str,
 ) -> dict[str, str]:
-    """Fetch and rebase onto base branch; return clean or conflicts. Callable via run_python."""
+    """Fetch and rebase onto base branch; return clean or conflicts."""
     remote = _detect_remote(work_dir)
     fetch = subprocess.run(
         ["git", "fetch", remote, base_branch],
@@ -125,7 +125,7 @@ def direct_merge_conflict_fix(
     work_dir: str,
     base_branch: str,
 ) -> dict[str, str]:
-    """Attempt rebase for direct-merge path; return clean or conflicts. Callable via run_python."""
+    """Attempt rebase for direct-merge path; return clean or conflicts."""
     return queue_ejected_fix(work_dir=work_dir, base_branch=base_branch)
 
 
@@ -142,7 +142,7 @@ def wait_for_direct_merge(
     max_polls: str = "90",
     poll_interval: str = "10",
 ) -> dict[str, str]:
-    """Poll PR state until merged/closed/timeout. Callable via run_python."""
+    """Poll PR state until merged/closed/timeout."""
     import time  # noqa: PLC0415
 
     max_polls = max_polls or "90"
@@ -170,7 +170,7 @@ def wait_for_immediate_merge(
     max_polls: str = "30",
     poll_interval: str = "10",
 ) -> dict[str, str]:
-    """Poll PR state until merged/closed/timeout (shorter). Callable via run_python."""
+    """Poll PR state until merged/closed/timeout (shorter)."""
     return wait_for_direct_merge(
         pr_number=pr_number, max_polls=max_polls, poll_interval=poll_interval
     )
@@ -181,7 +181,7 @@ def attempt_cheap_rebase(
     ejected_pr_branch: str,
     base_branch: str,
 ) -> dict[str, str]:
-    """Checkout ejected branch and attempt rebase. Callable via run_python."""
+    """Checkout ejected branch and attempt rebase."""
     remote = _detect_remote(work_dir)
     subprocess.run(
         ["git", "fetch", remote, ejected_pr_branch],
@@ -216,7 +216,7 @@ def wait_for_review_pr_mergeability(
     max_polls: str = "12",
     poll_interval: str = "15",
 ) -> dict[str, str]:
-    """Extract PR number and poll until mergeability resolves. Callable via run_python."""
+    """Extract PR number and poll until mergeability resolves."""
     import time  # noqa: PLC0415
 
     max_polls = max_polls or "12"
@@ -289,7 +289,7 @@ def force_push_and_wait_mergeability(
     max_polls: str = "12",
     poll_interval: str = "15",
 ) -> dict[str, str]:
-    """Force-push integration branch and wait for mergeability. Callable via run_python."""
+    """Force-push integration branch and wait for mergeability."""
     import time  # noqa: PLC0415
 
     max_polls = max_polls or "12"
@@ -325,7 +325,7 @@ def advance_queue_pr(
     current_pr_number: str,
     pr_order_file: str,
 ) -> dict[str, str]:
-    """Find next PR in queue order file. Callable via run_python."""
+    """Find next PR in queue order file."""
     if not current_pr_number:
         return {"error": f"current_pr_number is required, got {current_pr_number!r}"}
     try:
@@ -351,7 +351,7 @@ def proactive_rebase_next_pr(
     next_pr_branch: str,
     base_branch: str,
 ) -> dict[str, str]:
-    """Fetch, checkout, and rebase next PR branch. Callable via run_python."""
+    """Fetch, checkout, and rebase next PR branch."""
     remote = _detect_remote(work_dir)
     subprocess.run(
         ["git", "fetch", remote, next_pr_branch],
@@ -382,7 +382,7 @@ def proactive_rebase_next_pr(
 
 
 def refetch_issues(issue_urls: str) -> dict[str, str]:
-    """Build GraphQL query from issue URLs, fetch open issues. Callable via run_python."""
+    """Build GraphQL query from issue URLs, fetch open issues."""
     urls = issue_urls.split(",")
     parts = []
     for i, url in enumerate(urls):
@@ -425,7 +425,7 @@ def emit_fallback_map(
     issue_urls: str,
     temp_dir: str,
 ) -> dict[str, str]:
-    """Build fallback execution map JSON from issue URLs. Callable via run_python."""
+    """Build fallback execution map JSON from issue URLs."""
     nums: list[int] = []
     for url in issue_urls.split(","):
         m = re.search(r"issues/(\d+)", url.strip())
@@ -468,7 +468,7 @@ def export_local_bundle(
     source_dir: str,
     research_dir: str,
 ) -> dict[str, str]:
-    """Copy research dir to source_dir/research-bundles/{slug}/. Callable via run_python."""
+    """Copy research dir to source_dir/research-bundles/{slug}/."""
     import shutil  # noqa: PLC0415
 
     local_root = Path(source_dir) / "research-bundles"

--- a/src/autoskillit/recipe/_cmd_rpc.py
+++ b/src/autoskillit/recipe/_cmd_rpc.py
@@ -327,10 +327,7 @@ def advance_queue_pr(
 ) -> dict[str, str]:
     """Find next PR in queue order file. Callable via run_python."""
     if not current_pr_number:
-        return {
-            "error": f"current_pr_number is required, got {current_pr_number!r}",
-            "current_pr_number": "done",
-        }
+        return {"error": f"current_pr_number is required, got {current_pr_number!r}"}
     try:
         with open(pr_order_file) as f:
             order = json.load(f)

--- a/src/autoskillit/recipe/_cmd_rpc.py
+++ b/src/autoskillit/recipe/_cmd_rpc.py
@@ -28,6 +28,7 @@ def check_eject_limit(
     max_ejects: str = "3",
 ) -> dict[str, str]:
     """Increment counter file; return EJECT_OK or EJECT_LIMIT_EXCEEDED. Callable via run_python."""
+    max_ejects = max_ejects or "3"
     path = Path(counter_file)
     path.parent.mkdir(parents=True, exist_ok=True)
     try:
@@ -44,7 +45,8 @@ def check_dropped_healthy_loop(
     counter_file: str,
     max_drops: str = "2",
 ) -> dict[str, str]:
-    """Increment dropped-healthy counter; return DROPPED_OK or DROPPED_LIMIT_EXCEEDED. Callable via run_python."""
+    """Increment dropped-healthy counter; return DROPPED_OK or DROPPED_LIMIT_EXCEEDED."""
+    max_drops = max_drops or "2"
     path = Path(counter_file)
     path.parent.mkdir(parents=True, exist_ok=True)
     try:
@@ -131,7 +133,7 @@ def immediate_merge_conflict_fix(
     work_dir: str,
     base_branch: str,
 ) -> dict[str, str]:
-    """Attempt rebase for immediate-merge path; return clean or conflicts. Callable via run_python."""
+    """Attempt rebase for immediate-merge path; return clean or conflicts."""
     return queue_ejected_fix(work_dir=work_dir, base_branch=base_branch)
 
 
@@ -143,6 +145,8 @@ def wait_for_direct_merge(
     """Poll PR state until merged/closed/timeout. Callable via run_python."""
     import time  # noqa: PLC0415
 
+    max_polls = max_polls or "90"
+    poll_interval = poll_interval or "10"
     for _ in range(int(max_polls)):
         result = subprocess.run(
             ["gh", "pr", "view", pr_number, "--json", "state", "--jq", ".state"],
@@ -215,6 +219,8 @@ def wait_for_review_pr_mergeability(
     """Extract PR number and poll until mergeability resolves. Callable via run_python."""
     import time  # noqa: PLC0415
 
+    max_polls = max_polls or "12"
+    poll_interval = poll_interval or "15"
     result = subprocess.run(
         ["gh", "pr", "view", pr_url, "--json", "number", "-q", ".number"],
         capture_output=True,
@@ -245,7 +251,7 @@ def create_persistent_integration(
     work_dir: str,
     base_branch: str,
 ) -> dict[str, str]:
-    """Create and push persistent integration branch from default branch. Callable via run_python."""
+    """Create and push persistent integration branch from default branch."""
     remote = _detect_remote(work_dir)
     result = subprocess.run(
         ["git", "symbolic-ref", "refs/remotes/origin/HEAD"],
@@ -286,6 +292,8 @@ def force_push_and_wait_mergeability(
     """Force-push integration branch and wait for mergeability. Callable via run_python."""
     import time  # noqa: PLC0415
 
+    max_polls = max_polls or "12"
+    poll_interval = poll_interval or "15"
     remote = _detect_remote(work_dir)
     push = subprocess.run(
         ["git", "push", remote, integration_branch, "--force-with-lease"],
@@ -318,6 +326,11 @@ def advance_queue_pr(
     pr_order_file: str,
 ) -> dict[str, str]:
     """Find next PR in queue order file. Callable via run_python."""
+    if not current_pr_number:
+        return {
+            "error": f"current_pr_number is required, got {current_pr_number!r}",
+            "current_pr_number": "done",
+        }
     try:
         with open(pr_order_file) as f:
             order = json.load(f)
@@ -397,7 +410,10 @@ def refetch_issues(issue_urls: str) -> dict[str, str]:
             "-f",
             f"query={query}",
             "--jq",
-            '[.data[] | select(.issue != null and .issue.state == "OPEN") | .issue.number | tostring] | join(" ")',
+            (
+                '[.data[] | select(.issue != null and .issue.state == "OPEN")'
+                ' | .issue.number | tostring] | join(" ")'
+            ),
         ],
         capture_output=True,
         text=True,
@@ -438,7 +454,7 @@ def ensure_results(
     worktree_path: str,
     temp_subdir: str = ".autoskillit/temp",
 ) -> dict[str, str]:
-    """Ensure experiment_results file exists; create placeholder if empty. Callable via run_python."""
+    """Ensure experiment_results file exists; create placeholder if empty."""
     if experiment_results:
         return {"experiment_results": experiment_results}
     results_path = Path(worktree_path) / temp_subdir / "run-experiment" / "results-inconclusive.md"

--- a/src/autoskillit/recipe/contracts.py
+++ b/src/autoskillit/recipe/contracts.py
@@ -261,14 +261,18 @@ def get_tool_output_contract(
     entry = manifest.get("tool_output_contracts", {}).get(tool_name)
     if entry is None:
         return None
-    fields = {
-        field_name: ToolOutputFieldSpec(
+    fields = {}
+    for field_name, field_data in entry.get("fields", {}).items():
+        if not isinstance(field_data, dict):
+            raise ValueError(
+                f"tool_output_contracts entry for {tool_name!r}: "
+                f"field {field_name!r} must be a mapping, got {type(field_data).__name__!r}"
+            )
+        fields[field_name] = ToolOutputFieldSpec(
             allowed_values=tuple(field_data.get("allowed_values", [])),
             terminal_values=frozenset(field_data.get("terminal_values", [])),
             recoverable_values=frozenset(field_data.get("recoverable_values", [])),
         )
-        for field_name, field_data in entry.get("fields", {}).items()
-    }
     result_field = entry.get("result_field")
     if not result_field:
         raise ValueError(

--- a/src/autoskillit/recipe/contracts.py
+++ b/src/autoskillit/recipe/contracts.py
@@ -73,6 +73,19 @@ class SkillContract:
     result_fields: list[ResultFieldSpec] = dataclasses.field(default_factory=list)
 
 
+@dataclasses.dataclass(frozen=True)
+class ToolOutputFieldDef:
+    allowed_values: tuple[str, ...]
+    terminal_values: frozenset[str]
+    recoverable_values: frozenset[str]
+
+
+@dataclasses.dataclass(frozen=True)
+class ToolOutputContractDef:
+    result_field: str
+    fields: dict[str, ToolOutputFieldDef]
+
+
 @dataclasses.dataclass
 class StaleItem:
     skill: str
@@ -237,6 +250,26 @@ def get_callable_contract(
     ]
     outputs = [SkillOutput(name=out["name"], type=out["type"]) for out in entry.get("outputs", [])]
     return SkillContract(inputs=inputs, outputs=outputs)
+
+
+def get_tool_output_contract(
+    tool_name: str, manifest: dict[str, Any] | None = None
+) -> ToolOutputContractDef | None:
+    """Return the ToolOutputContractDef for a named MCP tool, or None if not declared."""
+    if manifest is None:
+        manifest = load_bundled_manifest()
+    entry = manifest.get("tool_output_contracts", {}).get(tool_name)
+    if entry is None:
+        return None
+    fields = {
+        field_name: ToolOutputFieldDef(
+            allowed_values=tuple(field_data.get("allowed_values", [])),
+            terminal_values=frozenset(field_data.get("terminal_values", [])),
+            recoverable_values=frozenset(field_data.get("recoverable_values", [])),
+        )
+        for field_name, field_data in entry.get("fields", {}).items()
+    }
+    return ToolOutputContractDef(result_field=entry.get("result_field", ""), fields=fields)
 
 
 def compute_skill_hash(skill_name: str, *, skills_dir: Path) -> str:

--- a/src/autoskillit/recipe/contracts.py
+++ b/src/autoskillit/recipe/contracts.py
@@ -74,16 +74,16 @@ class SkillContract:
 
 
 @dataclasses.dataclass(frozen=True)
-class ToolOutputFieldDef:
+class ToolOutputFieldSpec:
     allowed_values: tuple[str, ...]
     terminal_values: frozenset[str]
     recoverable_values: frozenset[str]
 
 
 @dataclasses.dataclass(frozen=True)
-class ToolOutputContractDef:
+class ToolOutputContractSpec:
     result_field: str
-    fields: dict[str, ToolOutputFieldDef]
+    fields: dict[str, ToolOutputFieldSpec]
 
 
 @dataclasses.dataclass
@@ -254,22 +254,27 @@ def get_callable_contract(
 
 def get_tool_output_contract(
     tool_name: str, manifest: dict[str, Any] | None = None
-) -> ToolOutputContractDef | None:
-    """Return the ToolOutputContractDef for a named MCP tool, or None if not declared."""
+) -> ToolOutputContractSpec | None:
+    """Return the ToolOutputContractSpec for a named MCP tool, or None if not declared."""
     if manifest is None:
         manifest = load_bundled_manifest()
     entry = manifest.get("tool_output_contracts", {}).get(tool_name)
     if entry is None:
         return None
     fields = {
-        field_name: ToolOutputFieldDef(
+        field_name: ToolOutputFieldSpec(
             allowed_values=tuple(field_data.get("allowed_values", [])),
             terminal_values=frozenset(field_data.get("terminal_values", [])),
             recoverable_values=frozenset(field_data.get("recoverable_values", [])),
         )
         for field_name, field_data in entry.get("fields", {}).items()
     }
-    return ToolOutputContractDef(result_field=entry.get("result_field", ""), fields=fields)
+    result_field = entry.get("result_field")
+    if not result_field:
+        raise ValueError(
+            f"tool_output_contracts entry for {tool_name!r} is missing required 'result_field'"
+        )
+    return ToolOutputContractSpec(result_field=result_field, fields=fields)
 
 
 def compute_skill_hash(skill_name: str, *, skills_dir: Path) -> str:

--- a/src/autoskillit/recipe/contracts.py
+++ b/src/autoskillit/recipe/contracts.py
@@ -45,6 +45,7 @@ class SkillInput:
     type: str
     required: bool
     recommended: bool = False
+    nullable: bool = True
 
 
 @dataclasses.dataclass
@@ -230,6 +231,7 @@ def get_callable_contract(
             name=inp["name"],
             type=inp["type"],
             required=inp.get("required", True),
+            nullable=inp.get("nullable", True),
         )
         for inp in entry.get("inputs", [])
     ]

--- a/src/autoskillit/recipe/rules_dataflow.py
+++ b/src/autoskillit/recipe/rules_dataflow.py
@@ -13,6 +13,7 @@ from autoskillit.core import (
 )
 from autoskillit.recipe._analysis import ValidationContext
 from autoskillit.recipe.contracts import (
+    _CONTEXT_REF_RE,
     RESULT_CAPTURE_RE,
     get_callable_contract,
     get_skill_contract,
@@ -504,6 +505,17 @@ def _get_provided_args(with_args: dict) -> set[str]:
     return nested_args | top_level_args
 
 
+def _get_args_values(with_args: dict) -> dict[str, object]:
+    result: dict[str, object] = {}
+    _nested = with_args.get("args")
+    if isinstance(_nested, dict):
+        result.update(_nested)
+    for key, val in with_args.items():
+        if key not in {"callable", "timeout", "args"}:
+            result[key] = val
+    return result
+
+
 @semantic_rule(
     name="missing-callable-input",
     description="run_python steps must pass all required inputs declared in callable contract",
@@ -576,4 +588,53 @@ def _check_callable_signature_mismatch(ctx: ValidationContext) -> list[RuleFindi
                     ),
                 )
             )
+    return findings
+
+
+@semantic_rule(
+    name="nullable-optional-context-ref",
+    description=(
+        "run_python steps must not pass optional_context_refs values to non-nullable "
+        "callable inputs without null coercion in the callable"
+    ),
+    severity=Severity.ERROR,
+)
+def _check_nullable_optional_context_ref(ctx: ValidationContext) -> list[RuleFinding]:
+    findings = []
+    manifest = load_bundled_manifest()
+    for step_name, step in ctx.recipe.steps.items():
+        if step.tool != "run_python":
+            continue
+        callable_path = step.with_args.get("callable", "")
+        if not callable_path:
+            continue
+        contract = get_callable_contract(callable_path, manifest)
+        if contract is None:
+            continue
+        non_nullable = {inp.name for inp in contract.inputs if not inp.nullable}
+        if not non_nullable:
+            continue
+        optional_refs = set(step.optional_context_refs)
+        if not optional_refs:
+            continue
+        args_values = _get_args_values(step.with_args)
+        for inp_name in sorted(non_nullable):
+            arg_val = args_values.get(inp_name)
+            if not isinstance(arg_val, str):
+                continue
+            for ref in _CONTEXT_REF_RE.findall(arg_val):
+                if ref in optional_refs:
+                    findings.append(
+                        RuleFinding(
+                            rule="nullable-optional-context-ref",
+                            severity=Severity.ERROR,
+                            step_name=step_name,
+                            message=(
+                                f"Step '{step_name}' passes optional context ref '{ref}' "
+                                f"to non-nullable input '{inp_name}' of callable "
+                                f"'{callable_path}'. Add null coercion in the callable "
+                                f"or remove from optional_context_refs."
+                            ),
+                        )
+                    )
     return findings

--- a/src/autoskillit/recipe/rules_graph.py
+++ b/src/autoskillit/recipe/rules_graph.py
@@ -10,7 +10,7 @@ from autoskillit.core import (
     get_logger,
 )
 from autoskillit.recipe._analysis import ValidationContext
-from autoskillit.recipe.contracts import _CONTEXT_REF_RE
+from autoskillit.recipe.contracts import _CONTEXT_REF_RE, get_tool_output_contract
 from autoskillit.recipe.registry import RuleFinding, semantic_rule
 
 logger = get_logger(__name__)
@@ -452,4 +452,61 @@ def _check_merge_base_unpublished(ctx: ValidationContext) -> list[RuleFinding]:
                 )
             )
 
+    return findings
+
+
+@semantic_rule(
+    name="on-result-missing-tool-output-value",
+    description=(
+        "Recoverable tool output values falling through to a terminal catch-all "
+        "step. When a tool has declared recoverable_values in tool_output_contracts "
+        "and none of them are explicitly routed in on_result conditions, a catch-all "
+        "that routes to a terminal (action: stop) step silently drops those values."
+    ),
+    severity=Severity.WARNING,
+)
+def _check_on_result_missing_tool_output_value(ctx: ValidationContext) -> list[RuleFinding]:
+    recipe = ctx.recipe
+    findings: list[RuleFinding] = []
+    for step_name, step in recipe.steps.items():
+        if step.tool is None or step.on_result is None:
+            continue
+        contract = get_tool_output_contract(step.tool)
+        if contract is None:
+            continue
+        field_def = contract.fields.get(contract.result_field)
+        if field_def is None or not field_def.recoverable_values:
+            continue
+        conditions = step.on_result.conditions or []
+        explicitly_routed: set[str] = set()
+        catchall_route: str | None = None
+        for cond in conditions:
+            if cond.when is None:
+                catchall_route = cond.route
+            else:
+                for val in field_def.allowed_values:
+                    if val in cond.when:
+                        explicitly_routed.add(val)
+        if catchall_route is None:
+            continue
+        catchall_step = recipe.steps.get(catchall_route)
+        if catchall_step is None or catchall_step.action != "stop":
+            continue
+        unrouted_recoverable = field_def.recoverable_values - explicitly_routed
+        if not unrouted_recoverable:
+            continue
+        findings.append(
+            RuleFinding(
+                rule="on-result-missing-tool-output-value",
+                severity=Severity.WARNING,
+                step_name=step_name,
+                message=(
+                    f"Step '{step_name}' (tool: {step.tool}) has recoverable "
+                    f"output values {sorted(unrouted_recoverable)} not explicitly "
+                    f"routed in on_result. The catch-all routes to terminal step "
+                    f"'{catchall_route}' (action: stop), silently terminating on "
+                    f"these recoverable outcomes."
+                ),
+            )
+        )
     return findings

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -1989,6 +1989,21 @@ skills:
     - "pr_url = \nverdict = dry_run\ncategory_summary = 14 fixes, 3 features\n%%ORDER_UP%%"
     write_behavior: always
 callable_contracts:
+  autoskillit.smoke_utils.check_loop_iteration:
+    inputs:
+    - name: current_iteration
+      type: str
+      required: false
+      nullable: false
+    - name: max_iterations
+      type: str
+      required: false
+      nullable: false
+    outputs:
+    - name: next_iteration
+      type: str
+    - name: max_exceeded
+      type: str
   autoskillit.smoke_utils.check_review_loop:
     inputs:
     - name: pr_number
@@ -1997,10 +2012,24 @@ callable_contracts:
     - name: cwd
       type: directory_path
       required: true
+    - name: current_iteration
+      type: str
+      required: false
+      nullable: false
+    - name: max_iterations
+      type: str
+      required: false
+      nullable: false
+    - name: previous_verdict
+      type: str
+      required: false
+      nullable: false
     outputs:
     - name: next_iteration
       type: str
     - name: max_exceeded
+      type: str
+    - name: had_blocking
       type: str
   autoskillit.smoke_utils.check_bug_report_non_empty:
     inputs:

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -1994,11 +1994,9 @@ callable_contracts:
     - name: current_iteration
       type: str
       required: false
-      nullable: false
     - name: max_iterations
       type: str
       required: false
-      nullable: false
     outputs:
     - name: next_iteration
       type: str
@@ -2015,15 +2013,12 @@ callable_contracts:
     - name: current_iteration
       type: str
       required: false
-      nullable: false
     - name: max_iterations
       type: str
       required: false
-      nullable: false
     - name: previous_verdict
       type: str
       required: false
-      nullable: false
     outputs:
     - name: next_iteration
       type: str
@@ -2415,6 +2410,7 @@ callable_contracts:
     - name: current_pr_number
       type: str
       required: true
+      nullable: false
     - name: pr_order_file
       type: str
       required: true

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -2475,3 +2475,55 @@ callable_contracts:
     outputs:
     - name: local_bundle_path
       type: str
+
+tool_output_contracts:
+  wait_for_ci:
+    result_field: conclusion
+    fields:
+      conclusion:
+        type: str
+        allowed_values:
+          - success
+          - failure
+          - cancelled
+          - action_required
+          - timed_out
+          - startup_failure
+          - stale
+          - no_runs
+          - error
+          - unknown
+        terminal_values:
+          - error
+          - unknown
+        recoverable_values:
+          - failure
+          - cancelled
+          - timed_out
+          - no_runs
+          - action_required
+  get_ci_status:
+    result_field: conclusion
+    fields:
+      conclusion:
+        type: str
+        allowed_values:
+          - success
+          - failure
+          - cancelled
+          - action_required
+          - timed_out
+          - startup_failure
+          - stale
+          - no_runs
+          - error
+          - unknown
+        terminal_values:
+          - error
+          - unknown
+        recoverable_values:
+          - failure
+          - cancelled
+          - timed_out
+          - no_runs
+          - action_required

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -803,14 +803,19 @@ steps:
     with:
       cmd: >-
         gh pr view '${{ context.pr_number }}' --json statusCheckRollup
-        --jq '.statusCheckRollup | if length == 0 then "false" elif
+        --jq '.statusCheckRollup | if length == 0 then "no_checks" elif
         all(.state == "SUCCESS" or .state == "NEUTRAL" or .state == "SKIPPED")
-        then "true" else "false" end'
+        then "passed" elif any(.state == "FAILURE" or .state == "ERROR")
+        then "failed" else "pending" end'
       cwd: "${{ context.work_dir }}"
       step_name: "check_ci_already_passed"
     on_result:
-      - when: "${{ result.stdout | trim }} == true"
+      - when: "${{ result.stdout | trim }} == passed"
         route: check_repo_merge_state
+      - when: "${{ result.stdout | trim }} == failed"
+        route: detect_ci_conflict
+      - when: "${{ result.stdout | trim }} == pending"
+        route: ci_watch
       - route: mark_issue_failed_no_ci
     on_failure: mark_issue_failed_no_ci
     skip_when_false: "inputs.open_pr"
@@ -818,8 +823,9 @@ steps:
       Safety net before terminal escalation: checks if CI already passed
       despite the watcher failing to observe it (e.g. post-force-push SHA
       staleness). Uses statusCheckRollup as the authoritative signal.
-      Routes to merge queue gate if all checks are SUCCESS/NEUTRAL/SKIPPED;
-      otherwise falls through to the terminal stop.
+      Outputs passed/failed/no_checks/pending: passed goes to merge gate,
+      failed routes to CI conflict remediation, pending re-enters the CI
+      watcher, no_checks falls through to terminal stop.
 
   mark_issue_failed_no_ci:
     description: "Swap in-progress → fail label before CI failure escalation"

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -850,12 +850,11 @@ steps:
 
   escalate_stop_no_ci:
     action: stop
-    message: >
-      CI watch loop exhausted — no CI runs found after re-deriving ci_event
-      and retrying. Likely causes: merge conflict suppressing pull_request
-      trigger, workflow not configured for this branch, or GitHub webhook
-      delivery failure. Check PR mergeable state and .github/workflows
-      trigger configuration.
+    message: >-
+      CI safety net: statusCheckRollup returned no checks for PR
+      ${{ context.pr_number }}. This typically means no workflow is
+      configured to trigger on this branch pattern. Check .github/workflows/
+      trigger configuration. This is NOT a test failure — CI never started.
 
   diagnose_ci:
     tool: run_skill

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -832,12 +832,11 @@ steps:
 
   escalate_stop_no_ci:
     action: stop
-    message: >
-      CI watch loop exhausted — no CI runs found after re-deriving ci_event
-      and retrying. Likely causes: merge conflict suppressing pull_request
-      trigger, workflow not configured for this branch, or GitHub webhook
-      delivery failure. Check PR mergeable state and .github/workflows
-      trigger configuration.
+    message: >-
+      CI safety net: statusCheckRollup returned no checks for PR
+      ${{ context.pr_number }}. This typically means no workflow is
+      configured to trigger on this branch pattern. Check .github/workflows/
+      trigger configuration. This is NOT a test failure — CI never started.
 
   check_repo_merge_state:
     tool: check_repo_merge_state

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -785,14 +785,19 @@ steps:
     with:
       cmd: >-
         gh pr view '${{ context.pr_number }}' --json statusCheckRollup
-        --jq '.statusCheckRollup | if length == 0 then "false" elif
+        --jq '.statusCheckRollup | if length == 0 then "no_checks" elif
         all(.state == "SUCCESS" or .state == "NEUTRAL" or .state == "SKIPPED")
-        then "true" else "false" end'
+        then "passed" elif any(.state == "FAILURE" or .state == "ERROR")
+        then "failed" else "pending" end'
       cwd: "${{ context.work_dir }}"
       step_name: "check_ci_already_passed"
     on_result:
-      - when: "${{ result.stdout | trim }} == true"
+      - when: "${{ result.stdout | trim }} == passed"
         route: check_repo_merge_state
+      - when: "${{ result.stdout | trim }} == failed"
+        route: detect_ci_conflict
+      - when: "${{ result.stdout | trim }} == pending"
+        route: ci_watch
       - route: mark_issue_failed_no_ci
     on_failure: mark_issue_failed_no_ci
     skip_when_false: "inputs.open_pr"
@@ -800,8 +805,9 @@ steps:
       Safety net before terminal escalation: checks if CI already passed
       despite the watcher failing to observe it (e.g. post-force-push SHA
       staleness). Uses statusCheckRollup as the authoritative signal.
-      Routes to merge queue gate if all checks are SUCCESS/NEUTRAL/SKIPPED;
-      otherwise falls through to the terminal stop.
+      Outputs passed/failed/no_checks/pending: passed goes to merge gate,
+      failed routes to CI conflict remediation, pending re-enters the CI
+      watcher, no_checks falls through to terminal stop.
 
   mark_issue_failed_no_ci:
     description: "Swap in-progress → fail label before CI failure escalation"

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -830,12 +830,11 @@ steps:
 
   escalate_stop_no_ci:
     action: stop
-    message: >
-      CI watch loop exhausted — no CI runs found after re-deriving ci_event
-      and retrying. Likely causes: merge conflict suppressing pull_request
-      trigger, workflow not configured for this branch, or GitHub webhook
-      delivery failure. Check PR mergeable state and .github/workflows
-      trigger configuration.
+    message: >-
+      CI safety net: statusCheckRollup returned no checks for PR
+      ${{ context.pr_number }}. This typically means no workflow is
+      configured to trigger on this branch pattern. Check .github/workflows/
+      trigger configuration. This is NOT a test failure — CI never started.
 
   check_repo_merge_state:
     tool: check_repo_merge_state

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -783,14 +783,19 @@ steps:
     with:
       cmd: >-
         gh pr view '${{ context.pr_number }}' --json statusCheckRollup
-        --jq '.statusCheckRollup | if length == 0 then "false" elif
+        --jq '.statusCheckRollup | if length == 0 then "no_checks" elif
         all(.state == "SUCCESS" or .state == "NEUTRAL" or .state == "SKIPPED")
-        then "true" else "false" end'
+        then "passed" elif any(.state == "FAILURE" or .state == "ERROR")
+        then "failed" else "pending" end'
       cwd: "${{ context.work_dir }}"
       step_name: "check_ci_already_passed"
     on_result:
-      - when: "${{ result.stdout | trim }} == true"
+      - when: "${{ result.stdout | trim }} == passed"
         route: check_repo_merge_state
+      - when: "${{ result.stdout | trim }} == failed"
+        route: detect_ci_conflict
+      - when: "${{ result.stdout | trim }} == pending"
+        route: ci_watch
       - route: mark_issue_failed_no_ci
     on_failure: mark_issue_failed_no_ci
     skip_when_false: "inputs.open_pr"
@@ -798,8 +803,9 @@ steps:
       Safety net before terminal escalation: checks if CI already passed
       despite the watcher failing to observe it (e.g. post-force-push SHA
       staleness). Uses statusCheckRollup as the authoritative signal.
-      Routes to merge queue gate if all checks are SUCCESS/NEUTRAL/SKIPPED;
-      otherwise falls through to the terminal stop.
+      Outputs passed/failed/no_checks/pending: passed goes to merge gate,
+      failed routes to CI conflict remediation, pending re-enters the CI
+      watcher, no_checks falls through to terminal stop.
 
   mark_issue_failed_no_ci:
     description: "Swap in-progress → fail label before CI failure escalation"

--- a/src/autoskillit/server/tools_ci_watch.py
+++ b/src/autoskillit/server/tools_ci_watch.py
@@ -11,7 +11,7 @@ import structlog
 from fastmcp import Context
 from fastmcp.dependencies import CurrentContext
 
-from autoskillit.core import CIRunScope, get_logger
+from autoskillit.core import KNOWN_CI_EVENTS, CIRunScope, get_logger
 from autoskillit.pipeline import ToolContext
 from autoskillit.server import mcp
 from autoskillit.server._guards import _require_enabled
@@ -75,6 +75,18 @@ async def wait_for_ci(
     """
     if (gate := _require_enabled()) is not None:
         return gate
+    if event == "None":
+        logger.warning("event coerced from string 'None' to null", tool="wait_for_ci")
+        event = None
+    if event is not None and event not in KNOWN_CI_EVENTS:
+        return json.dumps(
+            {
+                "run_id": None,
+                "conclusion": "error",
+                "failed_jobs": [],
+                "error": f"Invalid event {event!r}. Valid events: {sorted(KNOWN_CI_EVENTS)}",
+            }
+        )
     try:
         _start = time.monotonic()
         _timing_ctx = None

--- a/src/autoskillit/server/tools_ci_watch.py
+++ b/src/autoskillit/server/tools_ci_watch.py
@@ -75,21 +75,21 @@ async def wait_for_ci(
     """
     if (gate := _require_enabled()) is not None:
         return gate
-    if event == "None":
-        logger.warning("event coerced from string 'None' to null", tool="wait_for_ci")
-        event = None
-    if event is not None and event not in KNOWN_CI_EVENTS:
-        return json.dumps(
-            {
-                "run_id": None,
-                "conclusion": "error",
-                "failed_jobs": [],
-                "error": f"Invalid event {event!r}. Valid events: {sorted(KNOWN_CI_EVENTS)}",
-            }
-        )
     try:
         _start = time.monotonic()
         _timing_ctx = None
+        if event == "None":
+            logger.warning("event coerced from string 'None' to null", tool="wait_for_ci")
+            event = None
+        if event is not None and event not in KNOWN_CI_EVENTS:
+            return json.dumps(
+                {
+                    "run_id": None,
+                    "conclusion": "error",
+                    "failed_jobs": [],
+                    "error": f"Invalid event {event!r}. Valid events: {sorted(KNOWN_CI_EVENTS)}",
+                }
+            )
         structlog.contextvars.clear_contextvars()
         structlog.contextvars.bind_contextvars(tool="wait_for_ci")
         logger.info("wait_for_ci", branch=branch, repo=repo or "(infer)")

--- a/src/autoskillit/server/tools_ci_watch.py
+++ b/src/autoskillit/server/tools_ci_watch.py
@@ -22,6 +22,14 @@ from autoskillit.server._subprocess import _run_subprocess
 logger = get_logger(__name__)
 
 
+def _coerce_none_string(value: str | None, *, tool: str) -> str | None:
+    """Coerce the string literal 'None' to Python None, logging a warning when coercion occurs."""
+    if value == "None":
+        logger.warning("event coerced from string 'None' to null", tool=tool)
+        return None
+    return value
+
+
 @mcp.tool(tags={"autoskillit", "kitchen", "ci"}, annotations={"readOnlyHint": True})
 @track_response_size("wait_for_ci")
 async def wait_for_ci(
@@ -78,9 +86,7 @@ async def wait_for_ci(
     try:
         _start = time.monotonic()
         _timing_ctx = None
-        if event == "None":
-            logger.warning("event coerced from string 'None' to null", tool="wait_for_ci")
-            event = None
+        event = _coerce_none_string(event, tool="wait_for_ci")
         if event is not None and event not in KNOWN_CI_EVENTS:
             return json.dumps(
                 {

--- a/src/autoskillit/server/tools_execution.py
+++ b/src/autoskillit/server/tools_execution.py
@@ -74,6 +74,23 @@ async def _import_and_call(
     if not callable(func):
         return {"success": False, "error": f"{dotted_path!r} is not callable"}
 
+    sig = inspect.signature(func)
+    coerced: dict[str, object] = {}
+    for key, val in args.items():
+        if val is None and key in sig.parameters:
+            param = sig.parameters[key]
+            if param.default is not inspect.Parameter.empty and param.default is not None:
+                logger.warning(
+                    "run_python null-arg coerced to default",
+                    callable=dotted_path,
+                    arg=key,
+                    default=repr(param.default),
+                )
+                coerced[key] = param.default
+                continue
+        coerced[key] = val
+    args = coerced
+
     try:
         if inspect.iscoroutinefunction(func):
             result = await asyncio.wait_for(func(**args), timeout=timeout)

--- a/src/autoskillit/smoke_utils.py
+++ b/src/autoskillit/smoke_utils.py
@@ -107,6 +107,9 @@ def check_review_loop(
     ``approved_with_comments`` intentionally yields ``had_blocking=false`` — the
     resolve_review pass is one-shot and does not trigger a re-review cycle.
     """
+    current_iteration = current_iteration or ""
+    max_iterations = max_iterations or ""
+    previous_verdict = previous_verdict or ""
     iteration = int(current_iteration.strip()) if current_iteration.strip() else 0
     next_iteration = iteration + 1
     max_iter = int(max_iterations.strip()) if max_iterations.strip() else 3
@@ -128,6 +131,8 @@ def check_loop_iteration(
     Designed to be called via run_python in a recipe step with on_result routing
     based on max_exceeded.
     """
+    current_iteration = current_iteration or ""
+    max_iterations = max_iterations or ""
     try:
         iteration = int(current_iteration.strip()) if current_iteration.strip() else 0
     except ValueError as exc:

--- a/tests/cli/test_cli_prompts.py
+++ b/tests/cli/test_cli_prompts.py
@@ -579,9 +579,14 @@ def test_orchestrator_prompt_includes_null_context_handling():
     from autoskillit.cli._prompts import _build_orchestrator_prompt
 
     prompt = _build_orchestrator_prompt("my-recipe", mcp_prefix=DIRECT_PREFIX)
-    prompt_lower = prompt.lower()
-    assert "null" in prompt_lower or "none" in prompt_lower
-    assert "never" in prompt_lower and ("guess" in prompt_lower or "substitute" in prompt_lower)
+    assert "NULL/NONE CONTEXT VARIABLES" in prompt, (
+        "Orchestrator prompt must contain a NULL/NONE CONTEXT VARIABLES section that "
+        "instructs the model not to guess or substitute when context values are null."
+    )
+    assert "do not guess" in prompt.lower(), (
+        "Null handling section must explicitly instruct the model not to guess values "
+        "for null/None context variables."
+    )
 
 
 def test_campaign_prompt_tool_claim_has_after_startup_qualifier():

--- a/tests/cli/test_cli_prompts.py
+++ b/tests/cli/test_cli_prompts.py
@@ -573,6 +573,17 @@ def test_orchestrator_prompt_contains_skill_command_format_guidance():
     )
 
 
+def test_orchestrator_prompt_includes_null_context_handling():
+    """System prompt must instruct the model on null/None context variable behavior."""
+    from autoskillit.cli._mcp_names import DIRECT_PREFIX
+    from autoskillit.cli._prompts import _build_orchestrator_prompt
+
+    prompt = _build_orchestrator_prompt("my-recipe", mcp_prefix=DIRECT_PREFIX)
+    prompt_lower = prompt.lower()
+    assert "null" in prompt_lower or "none" in prompt_lower
+    assert "never" in prompt_lower and ("guess" in prompt_lower or "substitute" in prompt_lower)
+
+
 def test_campaign_prompt_tool_claim_has_after_startup_qualifier():
     """Fleet campaign prompt must qualify the 6-tool claim as applying after startup only."""
     from unittest.mock import MagicMock

--- a/tests/execution/test_ci.py
+++ b/tests/execution/test_ci.py
@@ -632,3 +632,16 @@ async def test_phase2_recheck_finds_late_completing_run():
     assert result["run_id"] == 77
     assert result["conclusion"] == "failure"
     assert "build" in result["failed_jobs"]
+
+
+def test_known_ci_events_frozenset_exists() -> None:
+    from autoskillit.core._type_results import KNOWN_CI_EVENTS
+
+    assert isinstance(KNOWN_CI_EVENTS, frozenset)
+    assert len(KNOWN_CI_EVENTS) >= 4
+    assert all(isinstance(e, str) for e in KNOWN_CI_EVENTS)
+    assert all(e == e.lower() for e in KNOWN_CI_EVENTS)
+    assert "push" in KNOWN_CI_EVENTS
+    assert "pull_request" in KNOWN_CI_EVENTS
+    assert "merge_group" in KNOWN_CI_EVENTS
+    assert "workflow_dispatch" in KNOWN_CI_EVENTS

--- a/tests/execution/test_ci.py
+++ b/tests/execution/test_ci.py
@@ -635,7 +635,7 @@ async def test_phase2_recheck_finds_late_completing_run():
 
 
 def test_known_ci_events_frozenset_exists() -> None:
-    from autoskillit.core._type_results import KNOWN_CI_EVENTS
+    from autoskillit.core._type_constants import KNOWN_CI_EVENTS
 
     assert isinstance(KNOWN_CI_EVENTS, frozenset)
     assert len(KNOWN_CI_EVENTS) >= 4

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -158,7 +158,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # planner/manifests.py — finalize_wp_manifest: wp_index.json rebuild (list payload)
     ("src/autoskillit/planner/manifests.py", 243),
     # _cmd_rpc.py — emit_fallback_map: BEM fallback execution map (recipe-internal)
-    ("src/autoskillit/recipe/_cmd_rpc.py", 448),
+    ("src/autoskillit/recipe/_cmd_rpc.py", 445),
 }
 
 

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -220,7 +220,7 @@ class TestSchemaVersionConvention:
         # These sites write list payloads through function calls but are caught by the scanner
         list_sites = [
             ("src/autoskillit/smoke_utils.py", 87),
-            ("src/autoskillit/smoke_utils.py", 272),
+            ("src/autoskillit/smoke_utils.py", 277),
         ]
         for site in list_sites:
             assert site in _LEGACY_JSON_WRITES, (

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -154,11 +154,11 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # smoke_utils.py — domain partitions dict, hunk ranges list, merge queue list
     ("src/autoskillit/smoke_utils.py", 57),
     ("src/autoskillit/smoke_utils.py", 87),
-    ("src/autoskillit/smoke_utils.py", 272),
+    ("src/autoskillit/smoke_utils.py", 277),
     # planner/manifests.py — finalize_wp_manifest: wp_index.json rebuild (list payload)
     ("src/autoskillit/planner/manifests.py", 243),
     # _cmd_rpc.py — emit_fallback_map: BEM fallback execution map (recipe-internal)
-    ("src/autoskillit/recipe/_cmd_rpc.py", 432),
+    ("src/autoskillit/recipe/_cmd_rpc.py", 448),
 }
 
 

--- a/tests/recipe/test_check_ci_already_passed_routing.py
+++ b/tests/recipe/test_check_ci_already_passed_routing.py
@@ -1,10 +1,13 @@
 """Tests verifying the check_ci_already_passed safety net step in CI watch recipes."""
 
+import json
+import subprocess
+
 import pytest
 
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 
-pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.medium]
 
 RECIPE_NAMES = ["implementation", "remediation", "implementation-groups"]
 
@@ -14,19 +17,80 @@ def recipe(request):
     return load_recipe(builtin_recipes_dir() / f"{request.param}.yaml")
 
 
+def _run_jq(rollup: list[dict]) -> str:
+    """Extract the jq expression from the recipe and run it against test data."""
+    recipe = load_recipe(builtin_recipes_dir() / "implementation.yaml")
+    step = recipe.steps["check_ci_already_passed"]
+    cmd_str = step.with_args["cmd"]
+    jq_start = cmd_str.index("--jq '") + len("--jq '")
+    jq_end = cmd_str.rindex("'")
+    jq_expr = cmd_str[jq_start:jq_end]
+    input_json = json.dumps({"statusCheckRollup": rollup})
+    result = subprocess.run(
+        ["jq", "-r", jq_expr],
+        input=input_json,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+@pytest.mark.medium
+def test_jq_produces_failed_for_failure_state():
+    """When statusCheckRollup contains FAILURE, jq must output 'failed' not 'false'."""
+    assert _run_jq([{"state": "SUCCESS"}, {"state": "FAILURE"}]) == "failed"
+
+
+@pytest.mark.medium
+def test_jq_produces_no_checks_for_empty_rollup():
+    """When statusCheckRollup is empty, jq must output 'no_checks' not 'false'."""
+    assert _run_jq([]) == "no_checks"
+
+
+@pytest.mark.medium
+def test_jq_produces_passed_for_all_success():
+    assert _run_jq([{"state": "SUCCESS"}, {"state": "NEUTRAL"}]) == "passed"
+
+
+@pytest.mark.medium
+def test_jq_produces_pending_for_in_progress():
+    assert _run_jq([{"state": "SUCCESS"}, {"state": "IN_PROGRESS"}]) == "pending"
+
+
 def test_check_ci_already_passed_step_exists(recipe):
     """New safety net step is present in each recipe."""
     assert "check_ci_already_passed" in recipe.steps
 
 
 def test_check_ci_already_passed_routes_to_merge_state_on_success(recipe):
-    """stdout == 'true' routes to check_repo_merge_state."""
+    """stdout == 'passed' routes to check_repo_merge_state."""
     step = recipe.steps["check_ci_already_passed"]
     assert step.on_result is not None
     success_routes = [
-        c.route for c in (step.on_result.conditions or []) if c.when and "true" in c.when
+        c.route for c in (step.on_result.conditions or []) if c.when and "passed" in c.when
     ]
     assert "check_repo_merge_state" in success_routes
+
+
+def test_failed_routes_to_detect_ci_conflict(recipe):
+    """stdout == 'failed' must route to detect_ci_conflict for remediation."""
+    step = recipe.steps["check_ci_already_passed"]
+    assert step.on_result is not None
+    failed_routes = [
+        c.route for c in (step.on_result.conditions or []) if c.when and "failed" in c.when
+    ]
+    assert "detect_ci_conflict" in failed_routes
+
+
+def test_pending_routes_back_to_ci_watch(recipe):
+    """stdout == 'pending' must route back to ci_watch for another iteration."""
+    step = recipe.steps["check_ci_already_passed"]
+    assert step.on_result is not None
+    pending_routes = [
+        c.route for c in (step.on_result.conditions or []) if c.when and "pending" in c.when
+    ]
+    assert "ci_watch" in pending_routes
 
 
 def test_check_ci_already_passed_fallthrough_routes_to_escalate(recipe):

--- a/tests/recipe/test_check_ci_already_passed_routing.py
+++ b/tests/recipe/test_check_ci_already_passed_routing.py
@@ -1,6 +1,7 @@
 """Tests verifying the check_ci_already_passed safety net step in CI watch recipes."""
 
 import json
+import shutil
 import subprocess
 
 import pytest
@@ -8,6 +9,10 @@ import pytest
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 
 pytestmark = [pytest.mark.layer("recipe"), pytest.mark.medium]
+
+_requires_jq = pytest.mark.skipif(
+    shutil.which("jq") is None, reason="jq binary not available in PATH"
+)
 
 RECIPE_NAMES = ["implementation", "remediation", "implementation-groups"]
 
@@ -37,23 +42,27 @@ def _run_jq(rollup: list[dict]) -> str:
 
 
 @pytest.mark.medium
+@_requires_jq
 def test_jq_produces_failed_for_failure_state():
     """When statusCheckRollup contains FAILURE, jq must output 'failed' not 'false'."""
     assert _run_jq([{"state": "SUCCESS"}, {"state": "FAILURE"}]) == "failed"
 
 
 @pytest.mark.medium
+@_requires_jq
 def test_jq_produces_no_checks_for_empty_rollup():
     """When statusCheckRollup is empty, jq must output 'no_checks' not 'false'."""
     assert _run_jq([]) == "no_checks"
 
 
 @pytest.mark.medium
+@_requires_jq
 def test_jq_produces_passed_for_all_success():
     assert _run_jq([{"state": "SUCCESS"}, {"state": "NEUTRAL"}]) == "passed"
 
 
 @pytest.mark.medium
+@_requires_jq
 def test_jq_produces_pending_for_in_progress():
     assert _run_jq([{"state": "SUCCESS"}, {"state": "IN_PROGRESS"}]) == "pending"
 

--- a/tests/recipe/test_check_ci_already_passed_routing.py
+++ b/tests/recipe/test_check_ci_already_passed_routing.py
@@ -176,3 +176,10 @@ def test_no_ci_failure_chain_complete(recipe):
 
     reg_step = recipe.steps["register_clone_no_ci"]
     assert reg_step.on_success == "escalate_stop_no_ci"
+
+
+def test_escalate_stop_message_accurate_for_no_checks_case(recipe):
+    """The escalation stop message must not claim 'no CI runs found' unconditionally."""
+    step = recipe.steps["escalate_stop_no_ci"]
+    msg = (step.message or "").lower()
+    assert "no ci runs found" not in msg

--- a/tests/recipe/test_cmd_rpc_null_safety.py
+++ b/tests/recipe/test_cmd_rpc_null_safety.py
@@ -1,0 +1,21 @@
+"""Null-safety tests for run_python callables in recipe/_cmd_rpc.py."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.recipe._cmd_rpc import check_dropped_healthy_loop, check_eject_limit
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+
+def test_check_eject_limit_none_max(tmp_path) -> None:
+    counter = tmp_path / "counter"
+    result = check_eject_limit(counter_file=str(counter), max_ejects=None)  # type: ignore[arg-type]
+    assert "status" in result
+
+
+def test_check_dropped_healthy_loop_none_max(tmp_path) -> None:
+    counter = tmp_path / "counter"
+    result = check_dropped_healthy_loop(counter_file=str(counter), max_drops=None)  # type: ignore[arg-type]
+    assert "status" in result

--- a/tests/recipe/test_contracts.py
+++ b/tests/recipe/test_contracts.py
@@ -808,3 +808,24 @@ def test_result_field_spec_roundtrip() -> None:
     for rf in contract.result_fields:
         assert isinstance(rf, ResultFieldSpec)
         assert rf.required is True
+
+
+def test_callable_contract_nullable_field() -> None:
+    from autoskillit.recipe.contracts import get_callable_contract
+
+    manifest = load_bundled_manifest()
+    contracts = manifest.get("callable_contracts", {})
+    assert "autoskillit.smoke_utils.check_loop_iteration" in contracts, (
+        "check_loop_iteration must be declared in callable_contracts"
+    )
+    loop_contract = contracts["autoskillit.smoke_utils.check_loop_iteration"]
+    ci_input = next((i for i in loop_contract["inputs"] if i["name"] == "current_iteration"), None)
+    assert ci_input is not None, "current_iteration input must be declared"
+    assert ci_input.get("nullable") is False, (
+        "current_iteration must be explicitly non-nullable (nullable: false)"
+    )
+    parsed = get_callable_contract("autoskillit.smoke_utils.check_loop_iteration", manifest)
+    assert parsed is not None
+    ci_parsed = next((i for i in parsed.inputs if i.name == "current_iteration"), None)
+    assert ci_parsed is not None
+    assert ci_parsed.nullable is False

--- a/tests/recipe/test_contracts.py
+++ b/tests/recipe/test_contracts.py
@@ -815,17 +815,17 @@ def test_callable_contract_nullable_field() -> None:
 
     manifest = load_bundled_manifest()
     contracts = manifest.get("callable_contracts", {})
-    assert "autoskillit.smoke_utils.check_loop_iteration" in contracts, (
-        "check_loop_iteration must be declared in callable_contracts"
+    assert "autoskillit.recipe._cmd_rpc.advance_queue_pr" in contracts, (
+        "advance_queue_pr must be declared in callable_contracts"
     )
-    loop_contract = contracts["autoskillit.smoke_utils.check_loop_iteration"]
-    ci_input = next((i for i in loop_contract["inputs"] if i["name"] == "current_iteration"), None)
-    assert ci_input is not None, "current_iteration input must be declared"
-    assert ci_input.get("nullable") is False, (
-        "current_iteration must be explicitly non-nullable (nullable: false)"
+    aq_contract = contracts["autoskillit.recipe._cmd_rpc.advance_queue_pr"]
+    pr_input = next((i for i in aq_contract["inputs"] if i["name"] == "current_pr_number"), None)
+    assert pr_input is not None, "current_pr_number input must be declared"
+    assert pr_input.get("nullable") is False, (
+        "current_pr_number must be explicitly non-nullable (nullable: false)"
     )
-    parsed = get_callable_contract("autoskillit.smoke_utils.check_loop_iteration", manifest)
+    parsed = get_callable_contract("autoskillit.recipe._cmd_rpc.advance_queue_pr", manifest)
     assert parsed is not None
-    ci_parsed = next((i for i in parsed.inputs if i.name == "current_iteration"), None)
-    assert ci_parsed is not None
-    assert ci_parsed.nullable is False
+    pr_parsed = next((i for i in parsed.inputs if i.name == "current_pr_number"), None)
+    assert pr_parsed is not None
+    assert pr_parsed.nullable is False

--- a/tests/recipe/test_contracts.py
+++ b/tests/recipe/test_contracts.py
@@ -829,3 +829,23 @@ def test_callable_contract_nullable_field() -> None:
     pr_parsed = next((i for i in parsed.inputs if i.name == "current_pr_number"), None)
     assert pr_parsed is not None
     assert pr_parsed.nullable is False
+
+
+# ---------------------------------------------------------------------------
+# tool_output_contracts
+# ---------------------------------------------------------------------------
+
+
+def test_tool_output_contracts_section_exists() -> None:
+    """skill_contracts.yaml must have a tool_output_contracts section."""
+    manifest = load_bundled_manifest()
+    tool_contracts = manifest.get("tool_output_contracts", {})
+    assert "wait_for_ci" in tool_contracts
+    assert "allowed_values" in tool_contracts["wait_for_ci"]["fields"]["conclusion"]
+
+
+def test_wait_for_ci_conclusion_allowed_values() -> None:
+    manifest = load_bundled_manifest()
+    conclusion = manifest["tool_output_contracts"]["wait_for_ci"]["fields"]["conclusion"]
+    values = set(conclusion["allowed_values"])
+    assert {"success", "failure", "cancelled", "timed_out", "no_runs", "error"}.issubset(values)

--- a/tests/recipe/test_research_bundle_lifecycle.py
+++ b/tests/recipe/test_research_bundle_lifecycle.py
@@ -33,7 +33,7 @@ def test_stage_bundle_does_not_compress(recipe):
 
 
 def test_finalize_bundle_pr_mode(recipe):
-    """finalize_bundle must delegate to external script with output_mode, research_dir, worktree."""
+    """finalize_bundle must delegate to external script with output_mode, research_dir."""
     step = recipe.steps["finalize_bundle"]
     cmd = step.with_args.get("cmd", "")
     assert "finalize_bundle.sh" in cmd, (

--- a/tests/recipe/test_rules_dataflow_nullable.py
+++ b/tests/recipe/test_rules_dataflow_nullable.py
@@ -15,48 +15,46 @@ class TestNullableOptionalContextRefRule:
     def test_optional_context_ref_to_non_nullable_input_is_error(self) -> None:
         recipe = _make_workflow(
             {
-                "check_loop": {
+                "advance": {
                     "tool": "run_python",
                     "with": {
-                        "callable": "autoskillit.smoke_utils.check_loop_iteration",
-                        "args": {"current_iteration": "${{ context.ci_loop_count }}"},
+                        "callable": "autoskillit.recipe._cmd_rpc.advance_queue_pr",
+                        "args": {
+                            "current_pr_number": "${{ context.current_pr }}",
+                            "pr_order_file": "/some/path",
+                        },
                     },
-                    "optional_context_refs": ["ci_loop_count"],
-                    "on_result": {
-                        "max_exceeded": {"'true'": "done", "'false'": "check_loop"}
-                    },
+                    "optional_context_refs": ["current_pr"],
+                    "on_result": {"current_pr_number": {"'0'": "done", "*": "advance"}},
                 },
                 "done": {"action": "stop", "message": "done"},
             }
         )
         findings = run_semantic_rules(recipe)
-        nullable_findings = [
-            f for f in findings if f.rule == "nullable-optional-context-ref"
-        ]
-        assert any(
-            f.severity == Severity.ERROR for f in nullable_findings
-        ), f"Expected ERROR finding for nullable-optional-context-ref, got: {nullable_findings}"
+        nullable_findings = [f for f in findings if f.rule == "nullable-optional-context-ref"]
+        assert any(f.severity == Severity.ERROR for f in nullable_findings), (
+            f"Expected ERROR finding for nullable-optional-context-ref, got: {nullable_findings}"
+        )
 
     def test_non_optional_context_ref_does_not_trigger_rule(self) -> None:
         recipe = _make_workflow(
             {
-                "check_loop": {
+                "advance": {
                     "tool": "run_python",
                     "with": {
-                        "callable": "autoskillit.smoke_utils.check_loop_iteration",
-                        "args": {"current_iteration": "${{ context.ci_loop_count }}"},
+                        "callable": "autoskillit.recipe._cmd_rpc.advance_queue_pr",
+                        "args": {
+                            "current_pr_number": "${{ context.current_pr }}",
+                            "pr_order_file": "/some/path",
+                        },
                     },
-                    "on_result": {
-                        "max_exceeded": {"'true'": "done", "'false'": "check_loop"}
-                    },
+                    "on_result": {"current_pr_number": {"'0'": "done", "*": "advance"}},
                 },
                 "done": {"action": "stop", "message": "done"},
             }
         )
         findings = run_semantic_rules(recipe)
-        nullable_findings = [
-            f for f in findings if f.rule == "nullable-optional-context-ref"
-        ]
-        assert not any(
-            f.severity == Severity.ERROR for f in nullable_findings
-        ), f"Should not flag required context refs, got: {nullable_findings}"
+        nullable_findings = [f for f in findings if f.rule == "nullable-optional-context-ref"]
+        assert not any(f.severity == Severity.ERROR for f in nullable_findings), (
+            f"Should not flag when optional_context_refs is absent, got: {nullable_findings}"
+        )

--- a/tests/recipe/test_rules_dataflow_nullable.py
+++ b/tests/recipe/test_rules_dataflow_nullable.py
@@ -1,0 +1,62 @@
+"""Tests for the nullable-optional-context-ref semantic rule."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.core.types import Severity
+from autoskillit.recipe.validator import run_semantic_rules
+from tests.recipe.conftest import _make_workflow
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+
+class TestNullableOptionalContextRefRule:
+    def test_optional_context_ref_to_non_nullable_input_is_error(self) -> None:
+        recipe = _make_workflow(
+            {
+                "check_loop": {
+                    "tool": "run_python",
+                    "with": {
+                        "callable": "autoskillit.smoke_utils.check_loop_iteration",
+                        "args": {"current_iteration": "${{ context.ci_loop_count }}"},
+                    },
+                    "optional_context_refs": ["ci_loop_count"],
+                    "on_result": {
+                        "max_exceeded": {"'true'": "done", "'false'": "check_loop"}
+                    },
+                },
+                "done": {"action": "stop", "message": "done"},
+            }
+        )
+        findings = run_semantic_rules(recipe)
+        nullable_findings = [
+            f for f in findings if f.rule == "nullable-optional-context-ref"
+        ]
+        assert any(
+            f.severity == Severity.ERROR for f in nullable_findings
+        ), f"Expected ERROR finding for nullable-optional-context-ref, got: {nullable_findings}"
+
+    def test_non_optional_context_ref_does_not_trigger_rule(self) -> None:
+        recipe = _make_workflow(
+            {
+                "check_loop": {
+                    "tool": "run_python",
+                    "with": {
+                        "callable": "autoskillit.smoke_utils.check_loop_iteration",
+                        "args": {"current_iteration": "${{ context.ci_loop_count }}"},
+                    },
+                    "on_result": {
+                        "max_exceeded": {"'true'": "done", "'false'": "check_loop"}
+                    },
+                },
+                "done": {"action": "stop", "message": "done"},
+            }
+        )
+        findings = run_semantic_rules(recipe)
+        nullable_findings = [
+            f for f in findings if f.rule == "nullable-optional-context-ref"
+        ]
+        assert not any(
+            f.severity == Severity.ERROR for f in nullable_findings
+        ), f"Should not flag required context refs, got: {nullable_findings}"

--- a/tests/recipe/test_rules_graph.py
+++ b/tests/recipe/test_rules_graph.py
@@ -503,3 +503,35 @@ def test_merge_base_literal_is_clean() -> None:
     findings = run_semantic_rules(recipe)
     flagged = [f for f in findings if f.rule == "merge-base-unpublished"]
     assert flagged == []
+
+
+# ---------------------------------------------------------------------------
+# on-result-missing-tool-output-value
+# ---------------------------------------------------------------------------
+
+
+def test_on_result_missing_tool_output_value_catches_terminal_catchall() -> None:
+    """Recoverable tool output values falling through to a terminal step trigger WARNING."""
+    recipe = _make_recipe(
+        {
+            "watch": RecipeStep(
+                tool="wait_for_ci",
+                on_result=StepResultRoute(
+                    conditions=[
+                        StepResultCondition(
+                            route="merge", when="${{ result.conclusion }} == success"
+                        ),
+                        StepResultCondition(route="fail"),
+                    ],
+                ),
+                on_failure="fail",
+            ),
+            "merge": RecipeStep(on_success="done"),
+            "fail": RecipeStep(action="stop"),
+            "done": RecipeStep(action="stop"),
+        }
+    )
+    findings = run_semantic_rules(recipe)
+    flagged = [f for f in findings if f.rule == "on-result-missing-tool-output-value"]
+    assert len(flagged) >= 1
+    assert all(f.severity == Severity.WARNING for f in flagged)

--- a/tests/server/test_tools_ci_watch.py
+++ b/tests/server/test_tools_ci_watch.py
@@ -26,4 +26,8 @@ async def test_wait_for_ci_coerces_string_none_to_null(tool_ctx) -> None:
         wait_result={"run_id": 42, "conclusion": "success", "failed_jobs": []}
     )
     result = json.loads(await wait_for_ci("main", event="None"))
-    assert result["conclusion"] != "error" or "event" not in result.get("error", "").lower()
+    assert result["conclusion"] == "success", (
+        f"String 'None' must be coerced to null before event validation — "
+        f"KNOWN_CI_EVENTS would reject 'None' as invalid if coercion did not occur. "
+        f"Got: {result}"
+    )

--- a/tests/server/test_tools_ci_watch.py
+++ b/tests/server/test_tools_ci_watch.py
@@ -1,0 +1,29 @@
+"""Tests for wait_for_ci event validation and null coercion."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from autoskillit.server.tools_ci_watch import wait_for_ci
+from tests.fakes import InMemoryCIWatcher
+
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+
+@pytest.mark.anyio
+async def test_wait_for_ci_rejects_invalid_event(tool_ctx) -> None:
+    tool_ctx.ci_watcher = InMemoryCIWatcher()
+    result = json.loads(await wait_for_ci("main", event="made_up_event"))
+    assert result["conclusion"] == "error"
+    assert "event" in result.get("error", "").lower()
+
+
+@pytest.mark.anyio
+async def test_wait_for_ci_coerces_string_none_to_null(tool_ctx) -> None:
+    tool_ctx.ci_watcher = InMemoryCIWatcher(
+        wait_result={"run_id": 42, "conclusion": "success", "failed_jobs": []}
+    )
+    result = json.loads(await wait_for_ci("main", event="None"))
+    assert result["conclusion"] != "error" or "event" not in result.get("error", "").lower()

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -420,3 +420,30 @@ def test_pts_gh_api_patch_failure(mock_run, _mock_sleep, tmp_path: Path) -> None
     result = patch_pr_token_summary(PR_URL, cwd, log_dir=str(tmp_path))
     assert result["success"] == "false"
     assert "Failed to patch PR" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Null-safety tests (run_python None-input coercion)
+# ---------------------------------------------------------------------------
+
+
+def test_check_loop_iteration_none_current() -> None:
+    result = check_loop_iteration(current_iteration=None)  # type: ignore[arg-type]
+    assert result["next_iteration"] == "1"
+    assert result["max_exceeded"] == "false"
+
+
+def test_check_loop_iteration_none_max() -> None:
+    result = check_loop_iteration(current_iteration="0", max_iterations=None)  # type: ignore[arg-type]
+    assert result["next_iteration"] == "1"
+    assert result["max_exceeded"] == "false"
+
+
+def test_check_review_loop_none_current(tmp_path: Path) -> None:
+    result = check_review_loop(pr_number="1", cwd=str(tmp_path), current_iteration=None)  # type: ignore[arg-type]
+    assert result["next_iteration"] == "1"
+
+
+def test_check_review_loop_none_verdict(tmp_path: Path) -> None:
+    result = check_review_loop(pr_number="1", cwd=str(tmp_path), previous_verdict=None)  # type: ignore[arg-type]
+    assert result["had_blocking"] == "false"


### PR DESCRIPTION
## Summary

Two of the three interacting bugs that stalled the CI watch pipeline share a common architectural weakness: the `run_python` dispatch layer passes LLM-provided arguments to Python callables without any null-safety enforcement, and the `wait_for_ci` tool accepts an `event` parameter without validating it against known GitHub Actions trigger events. This plan introduces structural immunity at two chokepoints — the `_import_and_call` dispatch boundary and the `CIRunScope` construction — plus extends the `callable_contracts` schema to declare nullable/non-nullable input constraints enforced by a new semantic rule.

Part B will cover recipe `on_result` routing completeness enforcement and orchestrator prompt null-handling instructions — implement as a separate task.

Closes #1586

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260501-215359-106845/.autoskillit/temp/rectify/rectify_ci_watch_pipeline_null_immunity_2026-05-01_215359_part_a.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| rectify | 55 | 18.4k | 1.1M | 65.2k | 1 | 13m 2s |
| dry_walkthrough | 381 | 34.1k | 5.2M | 176.3k | 2 | 15m 31s |
| implement | 1.3k | 105.0k | 15.3M | 246.6k | 2 | 31m 47s |
| prepare_pr | 60 | 8.1k | 242.8k | 36.8k | 1 | 2m 2s |
| compose_pr | 67 | 1.8k | 225.3k | 19.5k | 1 | 38s |
| review_pr | 4.1k | 73.2k | 2.0M | 185.2k | 2 | 18m 48s |
| resolve_review | 1.1k | 54.5k | 9.0M | 157.6k | 2 | 28m 24s |
| **Total** | 7.1k | 295.1k | 33.0M | 887.2k | | 1h 50m |