### PR TITLE
Implementation Plan: Add max_parallel Cap to build-execution-map Skill

### DIFF
--- a/src/autoskillit/recipes/contracts/implementation.yaml
+++ b/src/autoskillit/recipes/contracts/implementation.yaml
@@ -223,6 +223,7 @@ dataflow:
   - auto_merge
   - base_branch
   - issue_url
+  - max_parallel
   - open_pr
   - review_approach
   - run_mode
@@ -240,6 +241,7 @@ dataflow:
   - auto_merge
   - base_branch
   - issue_url
+  - max_parallel
   - open_pr
   - remote_url
   - review_approach
@@ -259,6 +261,7 @@ dataflow:
   - base_branch
   - base_sha
   - issue_url
+  - max_parallel
   - open_pr
   - remote_url
   - review_approach
@@ -278,6 +281,7 @@ dataflow:
   - base_branch
   - base_sha
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - remote_url
@@ -303,6 +307,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - remote_url
@@ -327,6 +332,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - remote_url
@@ -351,6 +357,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - proposed_branch
@@ -376,6 +383,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - proposed_branch
@@ -400,6 +408,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - proposed_branch
@@ -427,6 +436,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - plan_path
@@ -454,6 +464,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - plan_path
@@ -481,6 +492,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - plan_path
@@ -509,6 +521,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - plan_path
@@ -538,6 +551,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - plan_path
@@ -566,6 +580,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - plan_path
@@ -597,6 +612,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - plan_path
@@ -626,6 +642,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - plan_path
@@ -655,6 +672,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - plan_path
@@ -684,6 +702,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - plan_path
@@ -714,6 +733,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - plan_path
@@ -744,6 +764,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - plan_path
@@ -776,6 +797,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - plan_path
@@ -807,6 +829,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - plan_path
@@ -840,6 +863,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - plan_path
@@ -873,6 +897,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - plan_path
@@ -905,6 +930,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - plan_path
@@ -941,6 +967,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - plan_path
@@ -976,6 +1003,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - plan_path
@@ -1012,6 +1040,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1050,6 +1079,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1087,6 +1117,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1124,6 +1155,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1162,6 +1194,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1200,6 +1233,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1241,6 +1275,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1280,6 +1315,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1319,6 +1355,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1358,6 +1395,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1397,6 +1435,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1438,6 +1477,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1477,6 +1517,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1516,6 +1557,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1555,6 +1597,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1594,6 +1637,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1635,6 +1679,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1674,6 +1719,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1713,6 +1759,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1754,6 +1801,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1795,6 +1843,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1835,6 +1884,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1875,6 +1925,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1917,6 +1968,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1957,6 +2009,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1997,6 +2050,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -2037,6 +2091,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -2077,6 +2132,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -2117,6 +2173,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -2157,6 +2214,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr

--- a/src/autoskillit/recipes/contracts/remediation.yaml
+++ b/src/autoskillit/recipes/contracts/remediation.yaml
@@ -250,6 +250,7 @@ dataflow:
   - auto_merge
   - base_branch
   - issue_url
+  - max_parallel
   - open_pr
   - review_approach
   - run_mode
@@ -267,6 +268,7 @@ dataflow:
   - auto_merge
   - base_branch
   - issue_url
+  - max_parallel
   - open_pr
   - remote_url
   - review_approach
@@ -285,6 +287,7 @@ dataflow:
   - auto_merge
   - base_branch
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - remote_url
@@ -309,6 +312,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - remote_url
@@ -332,6 +336,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - remote_url
@@ -355,6 +360,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - proposed_branch
@@ -379,6 +385,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - proposed_branch
@@ -402,6 +409,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - proposed_branch
@@ -428,6 +436,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - proposed_branch
@@ -453,6 +462,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - plan_path
@@ -479,6 +489,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - plan_path
@@ -505,6 +516,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - plan_path
@@ -536,6 +548,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - plan_path
@@ -568,6 +581,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - plan_path
@@ -597,6 +611,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - plan_path
@@ -626,6 +641,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - plan_path
@@ -656,6 +672,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - plan_path
@@ -686,6 +703,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - plan_path
@@ -717,6 +735,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - plan_path
@@ -750,6 +769,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - plan_path
@@ -781,6 +801,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - plan_path
@@ -814,6 +835,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - plan_path
@@ -846,6 +868,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - plan_path
@@ -880,6 +903,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - plan_path
@@ -914,6 +938,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - plan_path
@@ -947,6 +972,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - plan_path
@@ -984,6 +1010,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - plan_path
@@ -1020,6 +1047,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_target
   - open_pr
   - plan_path
@@ -1057,6 +1085,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1096,6 +1125,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1134,6 +1164,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1172,6 +1203,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1211,6 +1243,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1250,6 +1283,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1292,6 +1326,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1332,6 +1367,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1372,6 +1408,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1412,6 +1449,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1452,6 +1490,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1494,6 +1533,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1534,6 +1574,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1574,6 +1615,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1614,6 +1656,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1654,6 +1697,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1696,6 +1740,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1736,6 +1781,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1776,6 +1822,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1818,6 +1865,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1860,6 +1908,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1901,6 +1950,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1942,6 +1992,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -1985,6 +2036,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -2026,6 +2078,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -2067,6 +2120,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -2108,6 +2162,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -2149,6 +2204,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -2190,6 +2246,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr
@@ -2231,6 +2288,7 @@ dataflow:
   - issue_slug
   - issue_title
   - issue_url
+  - max_parallel
   - merge_group_trigger
   - merge_target
   - open_pr

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -57,7 +57,8 @@ ingredients:
     description: >-
       Maximum number of issues to run in parallel within a single execution-map
       group. Groups exceeding this cap are split into sequential sub-groups.
-      Passed to build-execution-map.
+      Passed to build-execution-map. Must be a positive integer (expressed as a
+      string).
     default: "6"
     hidden: true
 

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -53,6 +53,13 @@ ingredients:
       step scheduling — fast steps for all pipelines before any slow step).
     default: "sequential"
     hidden: true
+  max_parallel:
+    description: >-
+      Maximum number of issues to run in parallel within a single execution-map
+      group. Groups exceeding this cap are split into sequential sub-groups.
+      Passed to build-execution-map.
+    default: "6"
+    hidden: true
 
 kitchen_rules:
   - "NEVER use native Claude Code tools (Read, Grep, Glob, Edit, Write,

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -86,7 +86,8 @@ ingredients:
     description: >-
       Maximum number of issues to run in parallel within a single execution-map
       group. Groups exceeding this cap are split into sequential sub-groups.
-      Passed to build-execution-map.
+      Passed to build-execution-map. Must be a positive integer (expressed as a
+      string).
     default: "6"
     hidden: true
   depth:

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -82,6 +82,13 @@ ingredients:
       step scheduling — fast steps for all pipelines before any slow step).
     default: "sequential"
     hidden: true
+  max_parallel:
+    description: >-
+      Maximum number of issues to run in parallel within a single execution-map
+      group. Groups exceeding this cap are split into sequential sub-groups.
+      Passed to build-execution-map.
+    default: "6"
+    hidden: true
   depth:
     description: "Investigation depth mode"
     default: "standard"

--- a/src/autoskillit/skills_extended/build-execution-map/SKILL.md
+++ b/src/autoskillit/skills_extended/build-execution-map/SKILL.md
@@ -168,11 +168,14 @@ order.
 
 After groups are assembled in Step 3, enforce the `max_parallel` cap:
 
-1. For each group where `len(issues) > max_parallel`:
+1. For each **parallel** group (`parallel: true`) where `len(issues) > max_parallel`:
    - Chunk the issue list into sub-lists of at most `max_parallel` issues each, preserving
      the existing order determined in Step 3.
-   - Each sub-list becomes its own group with `parallel: true`.
+   - Each sub-list becomes its own group. Set `parallel: true` if `len(sub-list) > 1`;
+     set `parallel: false` if `len(sub-list) == 1` (single-issue groups are never parallel).
    - The original group's `parallel_safe` ordering is preserved — do not re-sort.
+   - Sequential groups (`parallel: false`) are never split — they are passed through unchanged
+     regardless of size.
 
 2. Renumber all groups sequentially (1, 2, 3, …) after splitting. If original Group 1
    splits into 2 sub-groups and original Group 2 remains intact, the result is:

--- a/src/autoskillit/skills_extended/build-execution-map/SKILL.md
+++ b/src/autoskillit/skills_extended/build-execution-map/SKILL.md
@@ -28,8 +28,9 @@ into dependency-ordered dispatch groups.
 Space-separated issue numbers (required, minimum 2), plus optional flags:
 - `--base-ref <branch>` — base branch to compare against (default: `main`)
 - `--assess-review-approach` — assess whether each issue would benefit from a review-approach research pass before implementation (default: inactive)
+- `--max-parallel <N>` — maximum number of issues in any single parallel group (default: `6`). Groups exceeding this cap are split into sequential sub-groups of at most N issues each.
 
-**Example:** `101 103 102 --base-ref main --assess-review-approach`
+**Example:** `101 103 102 --base-ref main --max-parallel 4 --assess-review-approach`
 
 ## Critical Constraints
 
@@ -60,7 +61,9 @@ Space-separated issue numbers (required, minimum 2), plus optional flags:
 Accept issue numbers as space-separated or comma-separated values. Parse `--base-ref`
 if present (default: `main`). Parse `--assess-review-approach` if present (default:
 inactive). When this flag is active, Step 2 will additionally assess each issue for
-review-approach benefit. Validate the issue count:
+review-approach benefit. Parse `--max-parallel` if present (default: `6`). Validate that
+it is a positive integer ≥ 1; if a non-positive or non-integer value is provided, abort
+with `"Error: --max-parallel must be a positive integer"`. Validate the issue count:
 - **Zero issues**: abort immediately with `"Error: build-execution-map requires at least 1 issue number"` and exit non-zero.
 - **One issue**: emit a warning and write a trivial single-group map (single issue always gets `parallel: false`).
 - **Two or more issues**: proceed to Step 0.5.
@@ -161,6 +164,29 @@ others merges last).
 The `merge_order` list is the flattened sequence of issue numbers across groups in dispatch
 order.
 
+### Step 3.5 — Apply Parallel Cap
+
+After groups are assembled in Step 3, enforce the `max_parallel` cap:
+
+1. For each group where `len(issues) > max_parallel`:
+   - Chunk the issue list into sub-lists of at most `max_parallel` issues each, preserving
+     the existing order determined in Step 3.
+   - Each sub-list becomes its own group with `parallel: true`.
+   - The original group's `parallel_safe` ordering is preserved — do not re-sort.
+
+2. Renumber all groups sequentially (1, 2, 3, …) after splitting. If original Group 1
+   splits into 2 sub-groups and original Group 2 remains intact, the result is:
+   Group 1 (sub-group A of original Group 1), Group 2 (sub-group B of original Group 1),
+   Group 3 (original Group 2).
+
+3. Update `merge_order` to reflect the new group ordering: issues in Group 1 appear before
+   Group 2, which appears before Group 3, etc. Within each sub-group, the relative order
+   from Step 3 is preserved.
+
+4. Update `group_count` to the total count of groups after splitting.
+
+When no group exceeds `max_parallel`, this step is a no-op — groups pass through unchanged.
+
 ### Step 4 — Write Output
 
 Compute timestamp `{YYYY-MM-DD_HHMMSS}` (current local time, second precision).
@@ -217,6 +243,7 @@ structured output tokens. If context is exhausted mid-execution:
   "generated_at": "ISO-8601",
   "base_ref": "main",
   "total_issues": 5,
+  "max_parallel": 6,
   "group_count": 2,
   "groups": [
     {

--- a/tests/contracts/test_execution_map_contracts.py
+++ b/tests/contracts/test_execution_map_contracts.py
@@ -149,7 +149,15 @@ def test_skill_declares_max_parallel_argument() -> None:
 def test_skill_documents_max_parallel_default() -> None:
     """REQ-MAP-002: Default of 6 must appear in the SKILL.md arguments section."""
     skill_md = _skill_md_text()
-    assert "default" in skill_md.lower() and "6" in skill_md
+    args_start = skill_md.find("## Arguments")
+    assert args_start != -1, "SKILL.md must have an ## Arguments section"
+    next_section = skill_md.find("\n##", args_start + 1)
+    args_section = (
+        skill_md[args_start:next_section] if next_section != -1 else skill_md[args_start:]
+    )
+    assert "default" in args_section.lower() and "6" in args_section, (
+        "SKILL.md Arguments section must document the default value of 6 for --max-parallel"
+    )
 
 
 def test_output_schema_includes_max_parallel_field() -> None:
@@ -162,7 +170,13 @@ def test_output_schema_includes_max_parallel_field() -> None:
 
 
 def test_skill_documents_group_splitting_logic() -> None:
-    """REQ-MAP-003/004/005/006: Group splitting instructions must appear in SKILL.md."""
+    """REQ-MAP-003/004/005/006: Group splitting instructions must appear in Step 3.5."""
     skill_md = _skill_md_text()
-    assert "split" in skill_md.lower()
-    assert "sub-group" in skill_md.lower() or "subgroup" in skill_md.lower()
+    step35_start = skill_md.find("Step 3.5")
+    assert step35_start != -1, "SKILL.md must document Step 3.5 group-splitting logic"
+    next_heading = skill_md.find("\n###", step35_start + 1)
+    step35 = skill_md[step35_start:next_heading] if next_heading != -1 else skill_md[step35_start:]
+    assert "split" in step35.lower(), "Step 3.5 section must describe splitting groups"
+    assert "sub-group" in step35.lower() or "subgroup" in step35.lower(), (
+        "Step 3.5 section must describe sub-groups"
+    )

--- a/tests/contracts/test_execution_map_contracts.py
+++ b/tests/contracts/test_execution_map_contracts.py
@@ -138,3 +138,31 @@ def test_review_approach_candidates_contract_registered() -> None:
     assert "review_approach_candidates" in output_names, (
         "build-execution-map contract must register review_approach_candidates output"
     )
+
+
+def test_skill_declares_max_parallel_argument() -> None:
+    """REQ-MAP-001: SKILL.md must document --max-parallel as an accepted input."""
+    skill_md = _skill_md_text()
+    assert "--max-parallel" in skill_md
+
+
+def test_skill_documents_max_parallel_default() -> None:
+    """REQ-MAP-002: Default of 6 must appear in the SKILL.md arguments section."""
+    skill_md = _skill_md_text()
+    assert "default" in skill_md.lower() and "6" in skill_md
+
+
+def test_output_schema_includes_max_parallel_field() -> None:
+    """REQ-OUT-001: JSON schema section must include max_parallel field."""
+    skill_md = _skill_md_text()
+    schema_section_start = skill_md.find("## Output JSON Schema")
+    assert schema_section_start != -1
+    schema_section = skill_md[schema_section_start:]
+    assert '"max_parallel"' in schema_section
+
+
+def test_skill_documents_group_splitting_logic() -> None:
+    """REQ-MAP-003/004/005/006: Group splitting instructions must appear in SKILL.md."""
+    skill_md = _skill_md_text()
+    assert "split" in skill_md.lower()
+    assert "sub-group" in skill_md.lower() or "subgroup" in skill_md.lower()

--- a/tests/recipe/test_bundled_recipe_hidden_policy.py
+++ b/tests/recipe/test_bundled_recipe_hidden_policy.py
@@ -51,12 +51,3 @@ def test_upfront_claimed_is_hidden_in_recipe(recipe_name: str) -> None:
         f"upfront_claimed.hidden must be True in {recipe_name} "
         f"(it is set by process-issues, not by users)"
     )
-
-
-@pytest.mark.parametrize("recipe_name", ["implementation", "remediation"])
-def test_max_parallel_is_hidden_in_recipe(recipe_name: str) -> None:
-    recipe = load_recipe(pkg_root() / "recipes" / f"{recipe_name}.yaml")
-    ing = recipe.ingredients["max_parallel"]
-    assert ing.hidden is True, (
-        f"{recipe_name}.yaml: max_parallel must be hidden=true (pipeline-internal ingredient)"
-    )

--- a/tests/recipe/test_bundled_recipe_hidden_policy.py
+++ b/tests/recipe/test_bundled_recipe_hidden_policy.py
@@ -51,3 +51,12 @@ def test_upfront_claimed_is_hidden_in_recipe(recipe_name: str) -> None:
         f"upfront_claimed.hidden must be True in {recipe_name} "
         f"(it is set by process-issues, not by users)"
     )
+
+
+@pytest.mark.parametrize("recipe_name", ["implementation", "remediation"])
+def test_max_parallel_is_hidden_in_recipe(recipe_name: str) -> None:
+    recipe = load_recipe(pkg_root() / "recipes" / f"{recipe_name}.yaml")
+    ing = recipe.ingredients["max_parallel"]
+    assert ing.hidden is True, (
+        f"{recipe_name}.yaml: max_parallel must be hidden=true (pipeline-internal ingredient)"
+    )

--- a/tests/recipe/test_bundled_recipes_general.py
+++ b/tests/recipe/test_bundled_recipes_general.py
@@ -406,6 +406,34 @@ class TestRunModeIngredient:
         )
 
 
+class TestMaxParallelIngredient:
+    """REQ-ING-001, REQ-ING-002, REQ-ING-003"""
+
+    @pytest.mark.parametrize("recipe_name", ["implementation", "remediation"])
+    def test_recipe_has_max_parallel_ingredient(self, recipe_name: str) -> None:
+        recipe = load_recipe(builtin_recipes_dir() / f"{recipe_name}.yaml")
+        assert "max_parallel" in recipe.ingredients
+
+    @pytest.mark.parametrize("recipe_name", ["implementation", "remediation"])
+    def test_max_parallel_defaults_to_six(self, recipe_name: str) -> None:
+        recipe = load_recipe(builtin_recipes_dir() / f"{recipe_name}.yaml")
+        ing = recipe.ingredients["max_parallel"]
+        assert ing.default == "6"
+
+    @pytest.mark.parametrize("recipe_name", ["implementation", "remediation"])
+    def test_max_parallel_is_hidden(self, recipe_name: str) -> None:
+        recipe = load_recipe(builtin_recipes_dir() / f"{recipe_name}.yaml")
+        ing = recipe.ingredients["max_parallel"]
+        assert ing.hidden is True
+
+    @pytest.mark.parametrize("recipe_name", ["implementation", "remediation"])
+    def test_max_parallel_description_mentions_parallel_groups(self, recipe_name: str) -> None:
+        recipe = load_recipe(builtin_recipes_dir() / f"{recipe_name}.yaml")
+        ing = recipe.ingredients["max_parallel"]
+        assert "parallel" in ing.description.lower()
+        assert "group" in ing.description.lower()
+
+
 def test_no_bare_temp_paths_in_bundled_recipe_notes() -> None:
     """No bundled recipe YAML should reference temp/ without .autoskillit/ prefix.
 

--- a/tests/recipe/test_bundled_recipes_general.py
+++ b/tests/recipe/test_bundled_recipes_general.py
@@ -407,7 +407,7 @@ class TestRunModeIngredient:
 
 
 class TestMaxParallelIngredient:
-    """REQ-ING-001, REQ-ING-002, REQ-ING-003"""
+    """REQ-ING-001, REQ-ING-002, REQ-ING-003: max_parallel presence, default, and hidden flag."""
 
     @pytest.mark.parametrize("recipe_name", ["implementation", "remediation"])
     def test_recipe_has_max_parallel_ingredient(self, recipe_name: str) -> None:


### PR DESCRIPTION
## Summary

Add a configurable `max_parallel` cap (default: 6) that limits how many issues appear in any single
parallel dispatch group produced by `build-execution-map`. When a group exceeds the cap, it is
mechanically split into sequential sub-groups of at most `max_parallel` issues each. The cap is
declared as a hidden ingredient on `implementation.yaml` and `remediation.yaml`, passed to the
skill as a `--max-parallel` flag, and reflected in the output JSON as a top-level `max_parallel`
field. No changes are needed to sous-chef or fleet dispatch — the execution map grouping is the
single enforcement point.

## Requirements

**REQ-ING-001:** The `implementation.yaml` recipe must declare a `max_parallel` ingredient with `hidden: true` and default value `"6"`.

**REQ-ING-002:** The `remediation.yaml` recipe must declare a `max_parallel` ingredient with `hidden: true` and default value `"6"`.

**REQ-ING-003:** The `max_parallel` ingredient must be passable as an override via `open_kitchen(overrides={"max_parallel": "N"})` to change the cap at session start.

**REQ-MAP-001:** The `build-execution-map` SKILL.md must accept a `max_parallel` input parameter that controls the maximum number of issues in any single parallel group.

**REQ-MAP-002:** When `max_parallel` is not provided to `build-execution-map`, it must default to 6.

**REQ-MAP-003:** After pairwise dependency analysis produces groups, any group with `len(issues) > max_parallel` must be split into sub-groups of at most `max_parallel` issues each.

**REQ-MAP-004:** Sub-groups produced by the split must each retain `parallel: true`.

**REQ-MAP-005:** Sub-groups must be numbered sequentially, and all subsequent original groups must be renumbered to maintain a contiguous group sequence.

**REQ-MAP-006:** The `merge_order` array in the output must remain consistent with the sub-group ordering — issues in earlier sub-groups appear before issues in later sub-groups.

**REQ-OUT-001:** The execution map JSON output must include a top-level `max_parallel` integer field reflecting the cap that was applied.

**REQ-OUT-002:** The `group_count` field in the output must reflect the post-split group count.

**REQ-CTR-001:** The `contracts/implementation.yaml` must be updated to include `max_parallel` in the ingredient list for all steps that reference recipe ingredients.

**REQ-CTR-002:** The `contracts/remediation.yaml` must be updated to include `max_parallel` in the ingredient list for all steps that reference recipe ingredients.

Closes #1423

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260502-000721-956362/.autoskillit/temp/make-plan/add_max_parallel_cap_build_execution_map_plan_2026-05-02_001018.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 103 | 10.6k | 487.0k | 49.1k | 1 | 5m 13s |
| verify | 60 | 5.6k | 245.4k | 38.3k | 1 | 3m 29s |
| implement | 1.7k | 17.9k | 2.2M | 59.3k | 1 | 6m 44s |
| prepare_pr | 92 | 7.0k | 372.6k | 31.5k | 1 | 2m 21s |
| compose_pr | 59 | 2.4k | 196.8k | 20.4k | 1 | 40s |
| review_pr | 220 | 23.2k | 704.2k | 68.5k | 1 | 4m 45s |
| resolve_review | 2.1k | 29.8k | 3.7M | 88.3k | 1 | 12m 14s |
| **Total** | 4.4k | 96.5k | 7.9M | 355.4k | | 35m 30s |