### PR TITLE
resolve-review / review-pr — Duplicate Comments on Multi-Round Review Cycles

### DIFF
--- a/src/autoskillit/skills_extended/resolve-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-review/SKILL.md
@@ -114,7 +114,7 @@ cursor-based pagination to handle PRs with more than 100 threads:
 ```bash
 # Fetch all pages; repeat with after=$endCursor while hasNextPage is true
 gh api graphql \
-  -f query='query($owner:String!,$repo:String!,$number:Int!,$after:String){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviewThreads(first:100,after:$after){pageInfo{hasNextPage endCursor}nodes{id isResolved comments(first:1){nodes{databaseId}}}}}}}' \
+  -f query='query($owner:String!,$repo:String!,$number:Int!,$after:String){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviewThreads(first:100,after:$after){pageInfo{hasNextPage endCursor}nodes{id isResolved comments(first:5){nodes{databaseId body}}}}}}}' \
   -F owner="$owner" \
   -F repo="$repo" \
   -F number=$number \
@@ -136,6 +136,36 @@ Build a lookup map from the threads response:
 If the GraphQL call fails (e.g., token lacks `read:discussion` scope), log a warning and
 set `comment_id_to_thread_id = {}`. Thread resolution will be silently skipped in Step 6.
 Flag this in the Step 7 report for human review.
+
+**Build `already_replied_ids` (idempotency guard):**
+
+```python
+RESOLVED_MARKER_RE = re.compile(r"<!--\s*autoskillit:resolved\b")
+
+already_replied_ids: set[int] = set()
+for thread in all_thread_nodes:
+    if thread.get("isResolved"):
+        continue  # Already resolved — Step 3 will not see these comments anyway
+    comments_in_thread = thread.get("comments", {}).get("nodes", [])
+    if len(comments_in_thread) < 2:
+        continue  # No replies yet
+    first_comment_id = comments_in_thread[0].get("databaseId")
+    if first_comment_id is None:
+        continue
+    for reply in comments_in_thread[1:]:
+        if RESOLVED_MARKER_RE.search(reply.get("body", "")):
+            already_replied_ids.add(first_comment_id)
+            log(f"Skipping comment {first_comment_id} — already resolved by prior resolve-review run")
+            break
+```
+
+`already_replied_ids` is a set of original-comment `databaseId` integers for which a prior
+resolve-review invocation already posted a reply. Comments in this set are skipped in Step 3
+before classification.
+
+If the GraphQL call failed and `all_thread_nodes` is empty, `already_replied_ids` defaults to
+`set()` — no skipping occurs (safe degradation: worst case is a duplicate reply on the next
+run, same as the current behavior).
 
 **Load Pre-Built Context (if available):**
 
@@ -172,6 +202,14 @@ From **inline comments**, extract per comment:
 review-pr), skip this finding entirely — file-level comments have no code anchor and
 cannot be resolved by code changes. Record: `(path, null, reason="file-level comment — no
 line anchor")`. See the thread_node_id tracking table in Step 4 for the no-add disposition.
+
+**Idempotency guard — already-replied comments:**
+If `comment["id"]` (the REST `id` integer) is in `already_replied_ids`, skip this
+comment entirely. Do not classify it, do not apply fixes, do not post a reply.
+Record: `(path, line, reason="already replied in prior round — skipped")`.
+These skipped comments do not count toward `accept_count`, `reject_count`, or
+`discuss_count`, and must not appear in the Step 7 report's "Findings fetched" total
+(they were fetched but filtered before classification).
 
 From **top-level reviews**, extract:
 - `state` — APPROVED, CHANGES_REQUESTED, COMMENTED
@@ -366,13 +404,17 @@ API. Each finding receives exactly one reply based on its classification.
 ```bash
 # Build reply body based on classification:
 # ACCEPT:
-BODY="Agreed — fixed in ${commit_sha}. ${evidence}"
+BODY="Agreed — fixed in ${commit_sha}. ${evidence}
+<!-- autoskillit:resolved comment_id=${comment_id} verdict=ACCEPT -->"
 # REJECT:
-BODY="Investigated — this is intentional. ${evidence}"
+BODY="Investigated — this is intentional. ${evidence}
+<!-- autoskillit:resolved comment_id=${comment_id} verdict=REJECT -->"
 # DISCUSS:
-BODY="Valid observation — flagged for design decision. ${evidence}"
+BODY="Valid observation — flagged for design decision. ${evidence}
+<!-- autoskillit:resolved comment_id=${comment_id} verdict=DISCUSS -->"
 # INFO (auto-classified DISCUSS):
-BODY="Acknowledged — minor suggestion noted."
+BODY="Acknowledged — minor suggestion noted.
+<!-- autoskillit:resolved comment_id=${comment_id} verdict=INFO -->"
 
 gh api repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies \
   --method POST \

--- a/src/autoskillit/skills_extended/review-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/review-pr/SKILL.md
@@ -84,8 +84,8 @@ suppressing already-resolved findings on re-reviews and for focusing subagents o
 known-unresolved items.
 
 Fetch all review threads using cursor-based pagination (same GraphQL query as
-resolve-review Step 2, but also fetching `comments(first:2)` to see both the original
-finding and any reply):
+resolve-review Step 2, but also fetching `comments(first:5)` to see the original
+finding and up to 4 replies):
 
 ```graphql
 query($owner:String!, $repo:String!, $number:Int!, $after:String) {
@@ -98,8 +98,8 @@ query($owner:String!, $repo:String!, $number:Int!, $after:String) {
           path
           line
           originalLine
-          comments(first:2) {
-            nodes { body author { login } }
+          comments(first:5) {
+            nodes { databaseId body author { login } }
           }
         }
       }
@@ -118,14 +118,33 @@ skip this thread — do not add it to `prior_resolved_findings` or `prior_unreso
 File-level threads have no line anchor and must not suppress line-anchored findings via the
 ±5 proximity match.
 
-**`prior_resolved_findings`** — threads where `isResolved=true` AND the first comment body
+**`prior_resolved_findings`** — threads meeting EITHER condition, AND where the first comment body
 contains `[critical]` or `[warning]` (autoskillit-posted finding):
+- `isResolved=true` (ACCEPT/REJECT findings resolved by resolve-review), OR
+- Any reply comment (`comments[1:]`) contains `<!-- autoskillit:resolved` (DISCUSS/INFO findings
+  acknowledged by resolve-review but intentionally left unresolved)
+
+Check for the marker using:
+```python
+RESOLVED_MARKER_RE = re.compile(r"<!--\s*autoskillit:resolved\b")
+
+has_marker_reply = any(
+    RESOLVED_MARKER_RE.search(c.get("body", ""))
+    for c in thread_comments[1:]
+)
+
+if thread.get("isResolved") or has_marker_reply:
+    prior_resolved_findings.append({"file": path, "line": line, "body": first_body})
+else:
+    prior_unresolved_findings.append({"file": path, "line": line, "body": first_body})
+```
+
 ```json
 [{"file": "src/foo.py", "line": 42, "body": "[critical] arch: ..."}]
 ```
 
-**`prior_unresolved_findings`** — threads where `isResolved=false` AND first comment
-contains `[critical]` or `[warning]`:
+**`prior_unresolved_findings`** — threads where `isResolved=false` AND no reply contains the
+`<!-- autoskillit:resolved` marker AND the first comment contains `[critical]` or `[warning]`:
 ```json
 [{"file": "src/bar.py", "line": 17, "body": "[warning] tests: ..."}]
 ```

--- a/tests/skills/test_resolve_review_duplicate_comments.py
+++ b/tests/skills/test_resolve_review_duplicate_comments.py
@@ -138,5 +138,5 @@ def test_step15_marker_bearing_threads_are_resolved() -> None:
 def test_marker_format_consistent_across_skills() -> None:
     resolve_mentions = RESOLVE_SKILL_MD.count("autoskillit:resolved")
     review_mentions = REVIEW_PR_SKILL_MD.count("autoskillit:resolved")
-    assert resolve_mentions >= 4, "resolve-review must reference the marker at least 4 times"
-    assert review_mentions >= 2, "review-pr must reference the marker at least 2 times"
+    assert resolve_mentions >= 5, "resolve-review must reference the marker at least 5 times"
+    assert review_mentions >= 3, "review-pr must reference the marker at least 3 times"

--- a/tests/skills/test_resolve_review_duplicate_comments.py
+++ b/tests/skills/test_resolve_review_duplicate_comments.py
@@ -1,7 +1,6 @@
 import re
 from pathlib import Path
 
-
 RESOLVE_SKILL_MD = (
     Path(__file__).parent.parent.parent
     / "src"
@@ -57,17 +56,23 @@ def _extract_reply_block(text: str, verdict: str) -> str:
 
 def test_accept_reply_has_marker() -> None:
     accept_block = _extract_reply_block(RESOLVE_SKILL_MD, "ACCEPT")
-    assert MARKER_RE.search(accept_block), "ACCEPT reply template missing autoskillit:resolved marker"
+    assert MARKER_RE.search(accept_block), (
+        "ACCEPT reply template missing autoskillit:resolved marker"
+    )
 
 
 def test_reject_reply_has_marker() -> None:
     reject_block = _extract_reply_block(RESOLVE_SKILL_MD, "REJECT")
-    assert MARKER_RE.search(reject_block), "REJECT reply template missing autoskillit:resolved marker"
+    assert MARKER_RE.search(reject_block), (
+        "REJECT reply template missing autoskillit:resolved marker"
+    )
 
 
 def test_discuss_reply_has_marker() -> None:
     discuss_block = _extract_reply_block(RESOLVE_SKILL_MD, "DISCUSS")
-    assert MARKER_RE.search(discuss_block), "DISCUSS reply template missing autoskillit:resolved marker"
+    assert MARKER_RE.search(discuss_block), (
+        "DISCUSS reply template missing autoskillit:resolved marker"
+    )
 
 
 def test_info_reply_has_marker() -> None:
@@ -99,24 +104,32 @@ def test_step3_skips_already_replied_ids() -> None:
 
 
 def test_step15_graphql_fetches_five_comments() -> None:
-    step15_section = _extract_section(REVIEW_PR_SKILL_MD, "Step 1.5: Fetch Prior Review Thread Context")
+    step15_section = _extract_section(
+        REVIEW_PR_SKILL_MD, "Step 1.5: Fetch Prior Review Thread Context"
+    )
     assert "comments(first:5)" in step15_section, "Step 1.5 GraphQL must use comments(first:5)"
 
 
 def test_step15_graphql_includes_body_field() -> None:
-    step15_section = _extract_section(REVIEW_PR_SKILL_MD, "Step 1.5: Fetch Prior Review Thread Context")
+    step15_section = _extract_section(
+        REVIEW_PR_SKILL_MD, "Step 1.5: Fetch Prior Review Thread Context"
+    )
     graphql_block = _extract_graphql_block(step15_section)
     assert "body" in graphql_block
 
 
 def test_step15_graphql_includes_database_id() -> None:
-    step15_section = _extract_section(REVIEW_PR_SKILL_MD, "Step 1.5: Fetch Prior Review Thread Context")
+    step15_section = _extract_section(
+        REVIEW_PR_SKILL_MD, "Step 1.5: Fetch Prior Review Thread Context"
+    )
     graphql_block = _extract_graphql_block(step15_section)
     assert "databaseId" in graphql_block
 
 
 def test_step15_marker_bearing_threads_are_resolved() -> None:
-    step15_section = _extract_section(REVIEW_PR_SKILL_MD, "Step 1.5: Fetch Prior Review Thread Context")
+    step15_section = _extract_section(
+        REVIEW_PR_SKILL_MD, "Step 1.5: Fetch Prior Review Thread Context"
+    )
     assert "autoskillit:resolved" in step15_section
     assert "prior_resolved_findings" in step15_section
     assert "has_marker_reply" in step15_section or "marker" in step15_section.lower()

--- a/tests/skills/test_resolve_review_duplicate_comments.py
+++ b/tests/skills/test_resolve_review_duplicate_comments.py
@@ -37,8 +37,12 @@ def _extract_graphql_block(section_text: str) -> str:
     m = re.search(r"```graphql\n(.*?)```", section_text, re.DOTALL)
     if m:
         return m.group(1)
-    m = re.search(r"```[^\n]*\n(.*?)```", section_text, re.DOTALL)
-    return m.group(1) if m else ""
+    # Fall back to any triple-backtick block containing 'query' or 'mutation'
+    for block_match in re.finditer(r"```[^\n]*\n(.*?)```", section_text, re.DOTALL):
+        content = block_match.group(1)
+        if "query" in content or "mutation" in content:
+            return content
+    return ""
 
 
 def _extract_reply_block(text: str, verdict: str) -> str:

--- a/tests/skills/test_resolve_review_duplicate_comments.py
+++ b/tests/skills/test_resolve_review_duplicate_comments.py
@@ -1,0 +1,125 @@
+import re
+from pathlib import Path
+
+
+RESOLVE_SKILL_MD = (
+    Path(__file__).parent.parent.parent
+    / "src"
+    / "autoskillit"
+    / "skills_extended"
+    / "resolve-review"
+    / "SKILL.md"
+).read_text()
+
+REVIEW_PR_SKILL_MD = (
+    Path(__file__).parent.parent.parent
+    / "src"
+    / "autoskillit"
+    / "skills_extended"
+    / "review-pr"
+    / "SKILL.md"
+).read_text()
+
+MARKER_RE = re.compile(r"<!--\s*autoskillit:resolved\s+comment_id=")
+
+
+def _extract_section(text: str, heading: str) -> str:
+    pattern = re.compile(
+        r"###\s+" + re.escape(heading) + r"\b(.*?)(?=\n###|\Z)",
+        re.DOTALL,
+    )
+    m = pattern.search(text)
+    assert m, f"Section not found: {heading!r}"
+    return m.group(1)
+
+
+def _extract_graphql_block(section_text: str) -> str:
+    m = re.search(r"```graphql\n(.*?)```", section_text, re.DOTALL)
+    if m:
+        return m.group(1)
+    m = re.search(r"```[^\n]*\n(.*?)```", section_text, re.DOTALL)
+    return m.group(1) if m else ""
+
+
+def _extract_reply_block(text: str, verdict: str) -> str:
+    pattern = re.compile(
+        r"#\s+" + re.escape(verdict) + r"[^\n]*\n(BODY=.*?)(?=\n#\s+\w|```|$)",
+        re.DOTALL,
+    )
+    m = pattern.search(text)
+    assert m, f"Reply block for verdict {verdict!r} not found"
+    return m.group(1)
+
+
+def test_accept_reply_has_marker() -> None:
+    accept_block = _extract_reply_block(RESOLVE_SKILL_MD, "ACCEPT")
+    assert MARKER_RE.search(accept_block), "ACCEPT reply template missing autoskillit:resolved marker"
+
+
+def test_reject_reply_has_marker() -> None:
+    reject_block = _extract_reply_block(RESOLVE_SKILL_MD, "REJECT")
+    assert MARKER_RE.search(reject_block), "REJECT reply template missing autoskillit:resolved marker"
+
+
+def test_discuss_reply_has_marker() -> None:
+    discuss_block = _extract_reply_block(RESOLVE_SKILL_MD, "DISCUSS")
+    assert MARKER_RE.search(discuss_block), "DISCUSS reply template missing autoskillit:resolved marker"
+
+
+def test_info_reply_has_marker() -> None:
+    info_block = _extract_reply_block(RESOLVE_SKILL_MD, "INFO")
+    assert MARKER_RE.search(info_block), "INFO reply template missing autoskillit:resolved marker"
+
+
+def test_step2_graphql_fetches_five_comments_with_body() -> None:
+    step2_section = _extract_section(RESOLVE_SKILL_MD, "Step 2: Fetch Review Comments")
+    assert "comments(first:5)" in step2_section, "Step 2 GraphQL must use comments(first:5)"
+    graphql_block = _extract_graphql_block(step2_section)
+    assert "body" in graphql_block, "Step 2 GraphQL comment nodes must include body field"
+
+
+def test_step2_defines_already_replied_ids() -> None:
+    step2_section = _extract_section(RESOLVE_SKILL_MD, "Step 2: Fetch Review Comments")
+    assert "already_replied_ids" in step2_section
+    assert "autoskillit:resolved" in step2_section
+
+
+def test_step2_skip_log_message() -> None:
+    step2_section = _extract_section(RESOLVE_SKILL_MD, "Step 2: Fetch Review Comments")
+    assert "already resolved by prior resolve-review run" in step2_section
+
+
+def test_step3_skips_already_replied_ids() -> None:
+    step3_section = _extract_section(RESOLVE_SKILL_MD, "Step 3: Parse and Classify Findings")
+    assert "already_replied_ids" in step3_section
+
+
+def test_step15_graphql_fetches_five_comments() -> None:
+    step15_section = _extract_section(REVIEW_PR_SKILL_MD, "Step 1.5: Fetch Prior Review Thread Context")
+    assert "comments(first:5)" in step15_section, "Step 1.5 GraphQL must use comments(first:5)"
+
+
+def test_step15_graphql_includes_body_field() -> None:
+    step15_section = _extract_section(REVIEW_PR_SKILL_MD, "Step 1.5: Fetch Prior Review Thread Context")
+    graphql_block = _extract_graphql_block(step15_section)
+    assert "body" in graphql_block
+
+
+def test_step15_graphql_includes_database_id() -> None:
+    step15_section = _extract_section(REVIEW_PR_SKILL_MD, "Step 1.5: Fetch Prior Review Thread Context")
+    graphql_block = _extract_graphql_block(step15_section)
+    assert "databaseId" in graphql_block
+
+
+def test_step15_marker_bearing_threads_are_resolved() -> None:
+    step15_section = _extract_section(REVIEW_PR_SKILL_MD, "Step 1.5: Fetch Prior Review Thread Context")
+    assert "autoskillit:resolved" in step15_section
+    assert "prior_resolved_findings" in step15_section
+    assert "has_marker_reply" in step15_section or "marker" in step15_section.lower()
+
+
+def test_marker_format_consistent_across_skills() -> None:
+    resolve_mentions = RESOLVE_SKILL_MD.count("autoskillit:resolved")
+    review_mentions = REVIEW_PR_SKILL_MD.count("autoskillit:resolved")
+    assert resolve_mentions >= 4, "resolve-review must reference the marker at least 4 times"
+    assert review_mentions >= 2, "review-pr must reference the marker at least 2 times"


### PR DESCRIPTION
## Summary

Two skills cooperate in a review loop: `review-pr` posts findings as inline PR comments, then `resolve-review` applies fixes and posts reply acknowledgements. When the loop runs more than once (review-pr → resolve-review → review-pr → resolve-review …), two bugs cause duplicate replies:

- **Bug 1 (resolve-review):** Every invocation fetches ALL inline comments and posts a reply to each, regardless of whether a reply was already posted in a prior round. The GraphQL query only fetches the original comment (`comments(first:1)`) — it never sees existing replies, so there is no guard against re-replying.

- **Bug 2 (review-pr):** `prior_resolved_findings` is built by checking `isResolved=true` thread state. However, DISCUSS and INFO findings are intentionally never resolved by `resolve-review`, so they always remain `isResolved=false`. On a re-run, review-pr re-raises these findings as new inline comments.

The fix introduces a hidden HTML marker embedded in every reply posted by resolve-review. Both skills read this marker to make idempotent decisions:
- resolve-review skips any comment whose thread already has a marker-bearing reply
- review-pr treats any thread with a marker-bearing reply as suppressed (equivalent to `isResolved=true`) for the purpose of filtering `prior_resolved_findings`

This follows the existing project convention (`<!-- autoskillit:pipeline-signature ... -->` in PR bodies, `<!-- autoskillit-recipe-hash: ... -->` in diagram files).

Closes #1595

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260502-000721-219151/.autoskillit/temp/make-plan/resolve_review_duplicate_comments_plan_2026-05-02_001628.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 153 | 12.2k | 810.0k | 58.1k | 1 | 10m 54s |
| verify | 132 | 13.7k | 726.9k | 46.6k | 1 | 5m 52s |
| implement | 284 | 19.1k | 2.4M | 79.0k | 1 | 7m 52s |
| prepare_pr | 60 | 4.3k | 221.9k | 30.2k | 1 | 1m 23s |
| compose_pr | 59 | 2.5k | 194.5k | 19.9k | 1 | 51s |
| review_pr | 124 | 44.3k | 758.8k | 73.1k | 1 | 8m 43s |
| resolve_review | 243 | 15.2k | 1.5M | 62.2k | 1 | 9m 31s |
| **Total** | 1.1k | 111.3k | 6.6M | 369.1k | | 45m 8s |