### PR TITLE
Implementation Plan: Token Efficiency Table — tokens-per-line-of-code-changed ratio in Token Usage Summary

### DIFF
--- a/src/autoskillit/core/_type_protocols_logging.py
+++ b/src/autoskillit/core/_type_protocols_logging.py
@@ -58,6 +58,8 @@ class TokenLog(Protocol):
         end_ts: str = "",
         elapsed_seconds: float | None = None,
         order_id: str = "",
+        loc_insertions: int = 0,
+        loc_deletions: int = 0,
     ) -> None: ...
 
     def get_report(self, *, order_id: str = "") -> list[dict[str, Any]]: ...

--- a/src/autoskillit/execution/headless.py
+++ b/src/autoskillit/execution/headless.py
@@ -164,6 +164,7 @@ def _capture_git_head_sha(cwd: str) -> str:
         )
         return result.stdout.strip() if result.returncode == 0 else ""
     except Exception:
+        logger.debug("capture_git_head_sha_failed", cwd=cwd, exc_info=True)
         return ""
 
 
@@ -201,6 +202,7 @@ def _compute_loc_changed(cwd: str, pre_sha: str) -> tuple[int, int]:
             return 0, 0
         return _parse_numstat(result.stdout)
     except Exception:
+        logger.debug("compute_loc_changed_failed", cwd=cwd, pre_sha=pre_sha, exc_info=True)
         return 0, 0
 
 

--- a/src/autoskillit/execution/headless.py
+++ b/src/autoskillit/execution/headless.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import dataclasses
 import os
+import subprocess
 import time
 import traceback
 from collections.abc import Callable, Mapping, Sequence
@@ -151,6 +152,58 @@ def _resolve_skill_temp_dir(cwd: str, skill_command: str) -> Path | None:
     return Path(cwd) / ".autoskillit" / "temp" / name
 
 
+def _capture_git_head_sha(cwd: str) -> str:
+    """Return current HEAD SHA in cwd. Returns '' on any error (non-git dirs)."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return result.stdout.strip() if result.returncode == 0 else ""
+    except Exception:
+        return ""
+
+
+def _parse_numstat(numstat_output: str) -> tuple[int, int]:
+    """Parse `git diff --numstat` output into (insertions, deletions).
+
+    Binary file lines (-\\t-\\tfilename) are skipped.
+    """
+    insertions = deletions = 0
+    for line in numstat_output.splitlines():
+        parts = line.split("\t", 2)
+        if len(parts) < 2:
+            continue
+        try:
+            insertions += int(parts[0])
+            deletions += int(parts[1])
+        except ValueError:
+            continue  # binary file row: "-\t-\tfilename"
+    return insertions, deletions
+
+
+def _compute_loc_changed(cwd: str, pre_sha: str) -> tuple[int, int]:
+    """Run git diff --numstat <pre_sha> in cwd. Returns (0, 0) on any error."""
+    if not pre_sha:
+        return 0, 0
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--numstat", pre_sha],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if result.returncode != 0:
+            return 0, 0
+        return _parse_numstat(result.stdout)
+    except Exception:
+        return 0, 0
+
+
 async def _execute_claude_headless(
     spec: ClaudeHeadlessCmd,
     cwd: str,
@@ -232,6 +285,7 @@ async def _execute_claude_headless(
         except OSError:
             _temp_snapshot_pre = set()
 
+    _pre_session_sha = _capture_git_head_sha(cwd)
     _result: SubprocessResult | None = None
     try:
         _result = await runner(
@@ -327,6 +381,7 @@ async def _execute_claude_headless(
             logger.debug("flush_session_log during cancel failed", exc_info=True)
         raise
     _elapsed = time.monotonic() - _start_mono
+    _loc_insertions, _loc_deletions = _compute_loc_changed(cwd, _pre_session_sha)
     _end_ts = (datetime.fromisoformat(_start_ts) + timedelta(seconds=_elapsed)).isoformat()
     result = dataclasses.replace(  # type: ignore[arg-type]
         _result, start_ts=_start_ts, end_ts=_end_ts, elapsed_seconds=_elapsed
@@ -438,6 +493,8 @@ async def _execute_claude_headless(
                 recipe_content_hash=recipe_content_hash,
                 recipe_composite_hash=recipe_composite_hash,
                 recipe_version=recipe_version,
+                loc_insertions=_loc_insertions,
+                loc_deletions=_loc_deletions,
             )
         except Exception:
             logger.debug("session_log_flush_failed", exc_info=True)
@@ -459,6 +516,8 @@ async def _execute_claude_headless(
                 end_ts=result.end_ts,
                 elapsed_seconds=result.elapsed_seconds,
                 order_id=order_id,
+                loc_insertions=_loc_insertions,
+                loc_deletions=_loc_deletions,
             )
         except Exception:
             logger.debug("token_log_record_failed", exc_info=True)

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -136,6 +136,8 @@ def flush_session_log(
     recipe_composite_hash: str = "",
     recipe_version: str = "",
     github_api_log: GitHubApiLog | None = None,
+    loc_insertions: int = 0,
+    loc_deletions: int = 0,
 ) -> None:
     """Flush session diagnostics to disk.
 
@@ -388,6 +390,8 @@ def flush_session_log(
             "cache_read_input_tokens": token_usage.get("cache_read_input_tokens", 0),
             "timing_seconds": timing_seconds if timing_seconds is not None else 0.0,
             "order_id": order_id,
+            "loc_insertions": loc_insertions,
+            "loc_deletions": loc_deletions,
         }
         atomic_write(session_dir / "token_usage.json", json.dumps(tu_data))
 

--- a/src/autoskillit/hooks/token_summary_hook.py
+++ b/src/autoskillit/hooks/token_summary_hook.py
@@ -227,6 +227,8 @@ def _load_sessions(
                 "cache_read_input_tokens": 0,
                 "elapsed_seconds": 0.0,
                 "invocation_count": 0,
+                "loc_insertions": 0,
+                "loc_deletions": 0,
             }
         entry = aggregated[key]
         entry["input_tokens"] += data.get("input_tokens", 0)
@@ -236,6 +238,8 @@ def _load_sessions(
         _raw_timing = data.get("timing_seconds")
         entry["elapsed_seconds"] += float(_raw_timing) if _raw_timing is not None else 0.0
         entry["invocation_count"] += 1
+        entry["loc_insertions"] = entry.get("loc_insertions", 0) + data.get("loc_insertions", 0)
+        entry["loc_deletions"] = entry.get("loc_deletions", 0) + data.get("loc_deletions", 0)
 
     return aggregated
 
@@ -281,6 +285,49 @@ def _format_table(aggregated: dict[str, dict[str, Any]]) -> str:
         f" | | {_fmt_duration(total_time)} |"
     )
 
+    return "\n".join(lines)
+
+
+def _format_efficiency_table(aggregated: dict[str, dict[str, Any]]) -> str:
+    """Format aggregated token data as a markdown ## Token Efficiency table.
+
+    Returns '' when no session has LoC data (all zero).
+    """
+    has_loc = any(
+        e.get("loc_insertions", 0) + e.get("loc_deletions", 0) > 0 for e in aggregated.values()
+    )
+    if not has_loc:
+        return ""
+
+    def _ratio(tokens: int, loc: int) -> str:
+        return f"{tokens / loc:.1f}" if loc > 0 else "—"
+
+    lines = [
+        "## Token Efficiency",
+        "",
+        "| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |",
+        "|------|-------------|----------------|-----------------|------------|",
+    ]
+    total_loc = total_cr = total_cw = total_out = 0
+    for entry in aggregated.values():
+        loc = entry.get("loc_insertions", 0) + entry.get("loc_deletions", 0)
+        cr = entry.get("cache_read_input_tokens", 0)
+        cw = entry.get("cache_creation_input_tokens", 0)
+        out = entry.get("output_tokens", 0)
+        lines.append(
+            f"| {entry['step_name']} | {loc}"
+            f" | {_ratio(cr, loc)} | {_ratio(cw, loc)} | {_ratio(out, loc)} |"
+        )
+        total_loc += loc
+        total_cr += cr
+        total_cw += cw
+        total_out += out
+
+    lines.append(
+        f"| **Total** | **{total_loc}**"
+        f" | {_ratio(total_cr, total_loc)} | {_ratio(total_cw, total_loc)}"
+        f" | {_ratio(total_out, total_loc)} |"
+    )
     return "\n".join(lines)
 
 
@@ -330,7 +377,10 @@ def main() -> None:
             sys.exit(0)
 
         token_table = _format_table(aggregated)
+        efficiency_table = _format_efficiency_table(aggregated)
         new_body = current_body + "\n\n" + token_table
+        if efficiency_table:
+            new_body += "\n\n" + efficiency_table
 
         try:
             subprocess.run(

--- a/src/autoskillit/pipeline/telemetry_fmt.py
+++ b/src/autoskillit/pipeline/telemetry_fmt.py
@@ -26,6 +26,14 @@ _TIMING_COLUMNS = (
     TerminalColumn("INVOCATIONS", max_width=11, align=">"),
 )
 
+_EFFICIENCY_COLUMNS = (
+    TerminalColumn("STEP", max_width=40, align="<"),
+    TerminalColumn("LOC_CHG", max_width=8, align=">"),
+    TerminalColumn("RD/LOC", max_width=8, align=">"),
+    TerminalColumn("WR/LOC", max_width=8, align=">"),
+    TerminalColumn("OUT/LOC", max_width=8, align=">"),
+)
+
 
 class TelemetryFormatter:
     """Stateless formatter for token and timing telemetry data."""
@@ -195,3 +203,74 @@ class TelemetryFormatter:
                 est_tokens = mcp_total.get("total_estimated_response_tokens", 0)
                 lines.append(f"mcp_response_tokens: ~{h(est_tokens)}")
         return "\n".join(lines)
+
+    @staticmethod
+    def format_efficiency_table(steps: list[dict], total: dict) -> str:
+        """Produce a markdown Token Efficiency table. Returns '' when all LoC=0."""
+        if not any(s.get("loc_insertions", 0) + s.get("loc_deletions", 0) > 0 for s in steps):
+            return ""
+
+        def _ratio(tokens: int, loc: int) -> str:
+            return f"{tokens / loc:.1f}" if loc > 0 else "—"
+
+        lines = [
+            "## Token Efficiency",
+            "",
+            "| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |",
+            "|------|-------------|----------------|-----------------|------------|",
+        ]
+        for step in steps:
+            loc = step.get("loc_insertions", 0) + step.get("loc_deletions", 0)
+            cr = step.get("cache_read_input_tokens", 0)
+            cw = step.get("cache_creation_input_tokens", 0)
+            out = step.get("output_tokens", 0)
+            lines.append(
+                f"| {step.get('step_name', '?')} | {loc}"
+                f" | {_ratio(cr, loc)} | {_ratio(cw, loc)} | {_ratio(out, loc)} |"
+            )
+
+        total_loc = total.get("loc_insertions", 0) + total.get("loc_deletions", 0)
+        total_cr = total.get("cache_read_input_tokens", 0)
+        total_cw = total.get("cache_creation_input_tokens", 0)
+        total_out = total.get("output_tokens", 0)
+        lines.append(
+            f"| **Total** | **{total_loc}**"
+            f" | {_ratio(total_cr, total_loc)} | {_ratio(total_cw, total_loc)}"
+            f" | {_ratio(total_out, total_loc)} |"
+        )
+        return "\n".join(lines)
+
+    @staticmethod
+    def format_efficiency_table_terminal(steps: list[dict], total: dict) -> str:
+        """Produce a padded-column plain text efficiency table. Returns '' when all LoC=0."""
+        if not any(s.get("loc_insertions", 0) + s.get("loc_deletions", 0) > 0 for s in steps):
+            return ""
+
+        def _ratio(tokens: int, loc: int) -> str:
+            return f"{tokens / loc:.1f}" if loc > 0 else "—"
+
+        rows: list[tuple[str, str, str, str, str]] = []
+        for step in steps:
+            loc = step.get("loc_insertions", 0) + step.get("loc_deletions", 0)
+            cr = step.get("cache_read_input_tokens", 0)
+            cw = step.get("cache_creation_input_tokens", 0)
+            out = step.get("output_tokens", 0)
+            rows.append(
+                (
+                    step.get("step_name", "?"),
+                    str(loc),
+                    _ratio(cr, loc),
+                    _ratio(cw, loc),
+                    _ratio(out, loc),
+                )
+            )
+
+        total_loc = total.get("loc_insertions", 0) + total.get("loc_deletions", 0)
+        total_row = (
+            "Total",
+            str(total_loc),
+            _ratio(total.get("cache_read_input_tokens", 0), total_loc),
+            _ratio(total.get("cache_creation_input_tokens", 0), total_loc),
+            _ratio(total.get("output_tokens", 0), total_loc),
+        )
+        return _render_terminal_table(_EFFICIENCY_COLUMNS, rows + [total_row])

--- a/src/autoskillit/pipeline/telemetry_fmt.py
+++ b/src/autoskillit/pipeline/telemetry_fmt.py
@@ -35,6 +35,10 @@ _EFFICIENCY_COLUMNS = (
 )
 
 
+def _ratio(tokens: int, loc: int) -> str:
+    return f"{tokens / loc:.1f}" if loc > 0 else "—"
+
+
 class TelemetryFormatter:
     """Stateless formatter for token and timing telemetry data."""
 
@@ -210,9 +214,6 @@ class TelemetryFormatter:
         if not any(s.get("loc_insertions", 0) + s.get("loc_deletions", 0) > 0 for s in steps):
             return ""
 
-        def _ratio(tokens: int, loc: int) -> str:
-            return f"{tokens / loc:.1f}" if loc > 0 else "—"
-
         lines = [
             "## Token Efficiency",
             "",
@@ -245,9 +246,6 @@ class TelemetryFormatter:
         """Produce a padded-column plain text efficiency table. Returns '' when all LoC=0."""
         if not any(s.get("loc_insertions", 0) + s.get("loc_deletions", 0) > 0 for s in steps):
             return ""
-
-        def _ratio(tokens: int, loc: int) -> str:
-            return f"{tokens / loc:.1f}" if loc > 0 else "—"
 
         rows: list[tuple[str, str, str, str, str]] = []
         for step in steps:

--- a/src/autoskillit/pipeline/tokens.py
+++ b/src/autoskillit/pipeline/tokens.py
@@ -53,6 +53,8 @@ class TokenEntry:
     cache_read_input_tokens: int = 0
     invocation_count: int = 0
     elapsed_seconds: float = 0.0
+    loc_insertions: int = 0
+    loc_deletions: int = 0
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -85,6 +87,8 @@ class DefaultTokenLog:
         end_ts: str = "",
         elapsed_seconds: float | None = None,
         order_id: str = "",
+        loc_insertions: int = 0,
+        loc_deletions: int = 0,
     ) -> None:
         """Accumulate token usage for a step.
 
@@ -103,6 +107,8 @@ class DefaultTokenLog:
         e.cache_creation_input_tokens += token_usage.get("cache_creation_input_tokens", 0)
         e.cache_read_input_tokens += token_usage.get("cache_read_input_tokens", 0)
         e.invocation_count += 1
+        e.loc_insertions += loc_insertions
+        e.loc_deletions += loc_deletions
         if elapsed_seconds is not None:
             e.elapsed_seconds += elapsed_seconds
         elif start_ts and end_ts:
@@ -141,6 +147,8 @@ class DefaultTokenLog:
             agg.cache_read_input_tokens += e.cache_read_input_tokens
             agg.elapsed_seconds += e.elapsed_seconds
             agg.invocation_count += e.invocation_count
+            agg.loc_insertions += e.loc_insertions
+            agg.loc_deletions += e.loc_deletions
         return [e.to_dict() for e in aggregated.values()]
 
     def compute_total(self, *, order_id: str = "") -> dict[str, Any]:
@@ -155,6 +163,8 @@ class DefaultTokenLog:
             "cache_creation_input_tokens": 0,
             "cache_read_input_tokens": 0,
             "total_elapsed_seconds": 0.0,
+            "loc_insertions": 0,
+            "loc_deletions": 0,
         }
         for (oid, _step), entry in self._entries.items():
             if order_id and oid != order_id:
@@ -164,6 +174,8 @@ class DefaultTokenLog:
             total["cache_creation_input_tokens"] += entry.cache_creation_input_tokens
             total["cache_read_input_tokens"] += entry.cache_read_input_tokens
             total["total_elapsed_seconds"] += entry.elapsed_seconds
+            total["loc_insertions"] += entry.loc_insertions
+            total["loc_deletions"] += entry.loc_deletions
         return total
 
     def clear(self) -> None:
@@ -220,6 +232,8 @@ class DefaultTokenLog:
             # elapsed_seconds is the in-memory field name on TokenEntry.
             _raw_timing = data.get("timing_seconds")
             e.elapsed_seconds += float(_raw_timing) if _raw_timing is not None else 0.0
+            e.loc_insertions += data.get("loc_insertions", 0)
+            e.loc_deletions += data.get("loc_deletions", 0)
             # Each token_usage.json file represents a single run_skill invocation
             # (one file = one invocation). Incrementing here reconstructs the
             # invocation count that was accumulated live via record().

--- a/src/autoskillit/server/tools_status.py
+++ b/src/autoskillit/server/tools_status.py
@@ -196,7 +196,11 @@ async def get_token_summary(clear: bool = False, format: str = "json", order_id:
                 except Exception:
                     logger.debug("write_telemetry_clear_marker failed", exc_info=True)
             if format == "table":
-                return TelemetryFormatter.format_token_table(steps, total)
+                token_table = TelemetryFormatter.format_token_table(steps, total)
+                efficiency_table = TelemetryFormatter.format_efficiency_table(steps, total)
+                if efficiency_table:
+                    return token_table + "\n\n" + efficiency_table
+                return token_table
             return json.dumps(
                 {
                     "steps": steps,

--- a/tests/execution/test_loc_capture.py
+++ b/tests/execution/test_loc_capture.py
@@ -1,0 +1,78 @@
+"""Tests for LoC capture helpers in execution.headless.
+
+T-GIT-1..T-GIT-4: unit tests for _parse_numstat and _compute_loc_changed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+
+def _parse_numstat(numstat_output: str):
+    from autoskillit.execution.headless import _parse_numstat
+
+    return _parse_numstat(numstat_output)
+
+
+def _compute_loc_changed(cwd: str, pre_sha: str):
+    from autoskillit.execution.headless import _compute_loc_changed
+
+    return _compute_loc_changed(cwd, pre_sha)
+
+
+def _capture_git_head_sha(cwd: str):
+    from autoskillit.execution.headless import _capture_git_head_sha
+
+    return _capture_git_head_sha(cwd)
+
+
+# T-GIT-1
+def test_compute_loc_changed_parses_numstat_output():
+    """_parse_numstat correctly sums numstat lines: insertions, deletions."""
+    numstat_output = "10\t5\tfile.py\n3\t1\tsrc/foo.py\n"
+    result = _parse_numstat(numstat_output)
+    assert result == (13, 6)
+
+
+# T-GIT-2
+def test_compute_loc_changed_returns_zero_on_subprocess_error(tmp_path: Path):
+    """When git subprocess fails (non-git dir), loc capture returns (0, 0)."""
+    result = _compute_loc_changed(str(tmp_path), "abc1234")
+    assert result == (0, 0)
+
+
+# T-GIT-3
+def test_compute_loc_changed_handles_empty_diff():
+    """Empty numstat output (no changes) → (0, 0)."""
+    assert _parse_numstat("") == (0, 0)
+
+
+# T-GIT-4
+def test_compute_loc_changed_handles_binary_files():
+    """Binary file lines (-\t-\tbinary.png) are ignored without error."""
+    numstat_output = "-\t-\timage.png\n5\t2\tfile.py\n"
+    assert _parse_numstat(numstat_output) == (5, 2)
+
+
+def test_capture_git_head_sha_returns_empty_on_non_git_dir(tmp_path: Path):
+    """_capture_git_head_sha returns '' when directory is not a git repo."""
+    result = _capture_git_head_sha(str(tmp_path))
+    assert result == ""
+
+
+def test_capture_git_head_sha_returns_empty_string_on_exception():
+    """_capture_git_head_sha returns '' on any subprocess exception."""
+    with patch("subprocess.run", side_effect=OSError("mocked error")):
+        result = _capture_git_head_sha("/any/path")
+    assert result == ""
+
+
+def test_compute_loc_changed_returns_zero_for_empty_pre_sha(tmp_path: Path):
+    """_compute_loc_changed returns (0, 0) when pre_sha is empty."""
+    result = _compute_loc_changed(str(tmp_path), "")
+    assert result == (0, 0)

--- a/tests/hooks/test_token_summary_appender.py
+++ b/tests/hooks/test_token_summary_appender.py
@@ -91,6 +91,8 @@ def _write_sessions(log_root: Path, entries: list[dict]) -> None:
             "cache_creation_input_tokens": entry.get("cache_creation_input_tokens", 100),
             "cache_read_input_tokens": entry.get("cache_read_input_tokens", 200),
             "timing_seconds": entry.get("timing_seconds", 10.0),
+            "loc_insertions": entry.get("loc_insertions", 0),
+            "loc_deletions": entry.get("loc_deletions", 0),
         }
         (session_dir / "token_usage.json").write_text(json.dumps(token_data))
 
@@ -964,3 +966,178 @@ def test_hook_subprocess_calls_have_timeout() -> None:
             assert "timeout" in kw_names, (
                 f"subprocess.run() at line {node.lineno} in token_summary_hook.py missing timeout="
             )
+
+
+# ---------------------------------------------------------------------------
+# T-HOOK-EFF: Token Efficiency table in hook output
+# ---------------------------------------------------------------------------
+
+
+# T-HOOK-EFF-1
+def test_efficiency_table_appended_when_loc_present(tmp_path: Path) -> None:
+    """Hook appends efficiency table after token table when LoC data exists."""
+    log_root = tmp_path / "logs"
+    log_root.mkdir()
+    kitchen_id = "kitchen-eff-1"
+
+    _write_sessions(
+        log_root,
+        [
+            {
+                "dir_name": "s1",
+                "cwd": "/w",
+                "kitchen_id": kitchen_id,
+                "step_name": "implement",
+                "input_tokens": 1000,
+                "output_tokens": 500,
+                "cache_creation_input_tokens": 100,
+                "cache_read_input_tokens": 200,
+                "timing_seconds": 10.0,
+                "loc_insertions": 80,
+                "loc_deletions": 20,
+            }
+        ],
+    )
+
+    hook_config = tmp_path / ".autoskillit_hook_config.json"
+    hook_config.write_text(json.dumps({"kitchen_id": kitchen_id}))
+    pr_url = "https://github.com/owner/repo/pull/42"
+    event = _make_run_skill_event(f"pr_url={pr_url}\n%%ORDER_UP%%")
+
+    view_result = MagicMock(returncode=0, stdout="Existing PR body.")
+    edit_calls: list = []
+
+    def run_side(args, **kwargs):
+        if "api" in args and "--method" not in args:
+            return view_result
+        if "api" in args and "--method" in args:
+            edit_calls.append(args)
+            return MagicMock(returncode=0)
+        return MagicMock(returncode=0)
+
+    with patch("subprocess.run", side_effect=run_side):
+        _, exit_code = _run_hook(event, log_root=log_root, hook_config_path=hook_config)
+
+    assert exit_code == 0
+    assert len(edit_calls) == 1
+    body_arg = edit_calls[0][edit_calls[0].index("--raw-field") + 1]
+    body_content = body_arg[len("body=") :]
+    assert "## Token Efficiency" in body_content
+
+
+# T-HOOK-EFF-2
+def test_efficiency_table_omitted_when_no_loc_data(tmp_path: Path) -> None:
+    """Hook omits efficiency table when all sessions have loc_insertions=loc_deletions=0."""
+    log_root = tmp_path / "logs"
+    log_root.mkdir()
+    kitchen_id = "kitchen-eff-2"
+
+    _write_sessions(
+        log_root,
+        [
+            {
+                "dir_name": "s1",
+                "cwd": "/w",
+                "kitchen_id": kitchen_id,
+                "step_name": "plan",
+                "input_tokens": 1000,
+                "output_tokens": 500,
+                "cache_creation_input_tokens": 100,
+                "cache_read_input_tokens": 200,
+                "timing_seconds": 10.0,
+                "loc_insertions": 0,
+                "loc_deletions": 0,
+            }
+        ],
+    )
+
+    hook_config = tmp_path / ".autoskillit_hook_config.json"
+    hook_config.write_text(json.dumps({"kitchen_id": kitchen_id}))
+    pr_url = "https://github.com/owner/repo/pull/42"
+    event = _make_run_skill_event(f"pr_url={pr_url}\n%%ORDER_UP%%")
+
+    view_result = MagicMock(returncode=0, stdout="Existing PR body.")
+    edit_calls: list = []
+
+    def run_side(args, **kwargs):
+        if "api" in args and "--method" not in args:
+            return view_result
+        if "api" in args and "--method" in args:
+            edit_calls.append(args)
+            return MagicMock(returncode=0)
+        return MagicMock(returncode=0)
+
+    with patch("subprocess.run", side_effect=run_side):
+        _, exit_code = _run_hook(event, log_root=log_root, hook_config_path=hook_config)
+
+    assert exit_code == 0
+    assert len(edit_calls) == 1
+    body_arg = edit_calls[0][edit_calls[0].index("--raw-field") + 1]
+    body_content = body_arg[len("body=") :]
+    assert "## Token Efficiency" not in body_content
+
+
+# T-HOOK-EFF-3
+def test_efficiency_table_zero_loc_step_shows_dash(tmp_path: Path) -> None:
+    """Steps with zero LoC changed show — in the hook-generated efficiency table."""
+    log_root = tmp_path / "logs"
+    log_root.mkdir()
+    kitchen_id = "kitchen-eff-3"
+
+    _write_sessions(
+        log_root,
+        [
+            {
+                "dir_name": "s1",
+                "cwd": "/w",
+                "kitchen_id": kitchen_id,
+                "step_name": "plan",
+                "input_tokens": 500,
+                "output_tokens": 100,
+                "cache_creation_input_tokens": 50,
+                "cache_read_input_tokens": 100,
+                "timing_seconds": 5.0,
+                "loc_insertions": 0,
+                "loc_deletions": 0,
+            },
+            {
+                "dir_name": "s2",
+                "cwd": "/w",
+                "kitchen_id": kitchen_id,
+                "step_name": "implement",
+                "input_tokens": 1000,
+                "output_tokens": 500,
+                "cache_creation_input_tokens": 100,
+                "cache_read_input_tokens": 200,
+                "timing_seconds": 10.0,
+                "loc_insertions": 50,
+                "loc_deletions": 10,
+            },
+        ],
+    )
+
+    hook_config = tmp_path / ".autoskillit_hook_config.json"
+    hook_config.write_text(json.dumps({"kitchen_id": kitchen_id}))
+    pr_url = "https://github.com/owner/repo/pull/42"
+    event = _make_run_skill_event(f"pr_url={pr_url}\n%%ORDER_UP%%")
+
+    view_result = MagicMock(returncode=0, stdout="Existing PR body.")
+    edit_calls: list = []
+
+    def run_side(args, **kwargs):
+        if "api" in args and "--method" not in args:
+            return view_result
+        if "api" in args and "--method" in args:
+            edit_calls.append(args)
+            return MagicMock(returncode=0)
+        return MagicMock(returncode=0)
+
+    with patch("subprocess.run", side_effect=run_side):
+        _, exit_code = _run_hook(event, log_root=log_root, hook_config_path=hook_config)
+
+    assert exit_code == 0
+    assert len(edit_calls) == 1
+    body_arg = edit_calls[0][edit_calls[0].index("--raw-field") + 1]
+    body_content = body_arg[len("body=") :]
+    assert "## Token Efficiency" in body_content
+    assert "—" in body_content

--- a/tests/infra/_token_summary_helpers.py
+++ b/tests/infra/_token_summary_helpers.py
@@ -73,5 +73,7 @@ def _write_sessions(log_root: Path, entries: list[dict]) -> None:
             "cache_creation_input_tokens": entry.get("cache_creation_input_tokens", 100),
             "cache_read_input_tokens": entry.get("cache_read_input_tokens", 200),
             "timing_seconds": entry.get("timing_seconds", 10.0),
+            "loc_insertions": entry.get("loc_insertions", 0),
+            "loc_deletions": entry.get("loc_deletions", 0),
         }
         (session_dir / "token_usage.json").write_text(json.dumps(token_data))

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -112,11 +112,11 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/core/io.py", 118),
     # session_log.py — github_api_usage dict, summary dict, meta.json sidecar,
     # token_usage dict, step_timing dict
-    ("src/autoskillit/execution/session_log.py", 305),
-    ("src/autoskillit/execution/session_log.py", 366),
-    ("src/autoskillit/execution/session_log.py", 370),
-    ("src/autoskillit/execution/session_log.py", 392),
-    ("src/autoskillit/execution/session_log.py", 395),
+    ("src/autoskillit/execution/session_log.py", 307),
+    ("src/autoskillit/execution/session_log.py", 368),
+    ("src/autoskillit/execution/session_log.py", 372),
+    ("src/autoskillit/execution/session_log.py", 396),
+    ("src/autoskillit/execution/session_log.py", 399),
     # migration/store.py — failure store dicts
     ("src/autoskillit/migration/store.py", 54),
     ("src/autoskillit/migration/store.py", 64),
@@ -132,7 +132,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/server/tools_kitchen.py", 117),
     ("src/autoskillit/server/tools_kitchen.py", 558),
     # tools_status.py — mcp_data dict
-    ("src/autoskillit/server/tools_status.py", 482),
+    ("src/autoskillit/server/tools_status.py", 486),
     # tools_github.py — bug report dict
     ("src/autoskillit/server/tools_github.py", 279),
     # _hooks.py — settings.json dict (co-owned with Claude CLI)

--- a/tests/pipeline/test_telemetry_formatter.py
+++ b/tests/pipeline/test_telemetry_formatter.py
@@ -329,3 +329,178 @@ class TestFmtDuration:
 
     def test_hours(self) -> None:
         assert TelemetryFormatter._fmt_duration(3720.0) == "1h 2m"
+
+
+# ---------------------------------------------------------------------------
+# T-EFF: Token Efficiency table
+# ---------------------------------------------------------------------------
+
+
+# T-EFF-1
+def test_efficiency_table_omitted_when_no_loc() -> None:
+    """format_efficiency_table returns '' when all steps have loc_changed=0."""
+    steps = [
+        {
+            "step_name": "plan",
+            "cache_read_input_tokens": 1000,
+            "cache_creation_input_tokens": 200,
+            "output_tokens": 50,
+            "loc_insertions": 0,
+            "loc_deletions": 0,
+        }
+    ]
+    total = {
+        "loc_insertions": 0,
+        "loc_deletions": 0,
+        "cache_read_input_tokens": 1000,
+        "cache_creation_input_tokens": 200,
+        "output_tokens": 50,
+    }
+    assert TelemetryFormatter.format_efficiency_table(steps, total) == ""
+
+
+# T-EFF-2
+def test_efficiency_table_columns() -> None:
+    """Markdown efficiency table has correct header columns."""
+    steps = [
+        {
+            "step_name": "implement",
+            "cache_read_input_tokens": 1000,
+            "cache_creation_input_tokens": 200,
+            "output_tokens": 50,
+            "loc_insertions": 80,
+            "loc_deletions": 20,
+        }
+    ]
+    total = {
+        "loc_insertions": 80,
+        "loc_deletions": 20,
+        "cache_read_input_tokens": 1000,
+        "cache_creation_input_tokens": 200,
+        "output_tokens": 50,
+    }
+    result = TelemetryFormatter.format_efficiency_table(steps, total)
+    assert "## Token Efficiency" in result
+    assert "LoC Changed" in result
+    assert "cache_read/LoC" in result
+    assert "cache_write/LoC" in result
+    assert "output/LoC" in result
+
+
+# T-EFF-3
+def test_efficiency_table_ratios() -> None:
+    """Ratio columns = token_count / loc_changed, rounded to 1 decimal place."""
+    steps = [
+        {
+            "step_name": "implement",
+            "cache_read_input_tokens": 1000,
+            "cache_creation_input_tokens": 200,
+            "output_tokens": 50,
+            "loc_insertions": 80,
+            "loc_deletions": 20,
+        }
+    ]
+    total = {
+        "loc_insertions": 80,
+        "loc_deletions": 20,
+        "cache_read_input_tokens": 1000,
+        "cache_creation_input_tokens": 200,
+        "output_tokens": 50,
+    }
+    result = TelemetryFormatter.format_efficiency_table(steps, total)
+    # loc_changed = 100; cache_read/LoC = 10.0; cache_write/LoC = 2.0; output/LoC = 0.5
+    assert "10.0" in result
+    assert "2.0" in result
+    assert "0.5" in result
+    assert "100" in result  # LoC Changed column
+
+
+# T-EFF-4
+def test_efficiency_table_zero_loc_step_shows_dash() -> None:
+    """Steps with loc_changed=0 show — in ratio columns."""
+    steps = [
+        {
+            "step_name": "no-change",
+            "cache_read_input_tokens": 500,
+            "cache_creation_input_tokens": 100,
+            "output_tokens": 20,
+            "loc_insertions": 0,
+            "loc_deletions": 0,
+        },
+        {
+            "step_name": "implement",
+            "cache_read_input_tokens": 1000,
+            "cache_creation_input_tokens": 200,
+            "output_tokens": 50,
+            "loc_insertions": 50,
+            "loc_deletions": 10,
+        },
+    ]
+    total = {
+        "loc_insertions": 50,
+        "loc_deletions": 10,
+        "cache_read_input_tokens": 1500,
+        "cache_creation_input_tokens": 300,
+        "output_tokens": 70,
+    }
+    result = TelemetryFormatter.format_efficiency_table(steps, total)
+    assert "—" in result  # zero-LoC step
+
+
+# T-EFF-5
+def test_efficiency_table_total_row_uses_aggregate_totals() -> None:
+    """Total row ratios are computed from aggregate totals, not averaged per-step."""
+    steps = [
+        {
+            "step_name": "plan",
+            "cache_read_input_tokens": 200,
+            "cache_creation_input_tokens": 0,
+            "output_tokens": 10,
+            "loc_insertions": 10,
+            "loc_deletions": 0,
+        },
+        {
+            "step_name": "implement",
+            "cache_read_input_tokens": 800,
+            "cache_creation_input_tokens": 100,
+            "output_tokens": 40,
+            "loc_insertions": 90,
+            "loc_deletions": 10,
+        },
+    ]
+    total = {
+        "loc_insertions": 100,
+        "loc_deletions": 10,
+        "cache_read_input_tokens": 1000,
+        "cache_creation_input_tokens": 100,
+        "output_tokens": 50,
+    }
+    result = TelemetryFormatter.format_efficiency_table(steps, total)
+    # Total loc_changed=110; cache_read/LoC=1000/110≈9.1
+    assert "9.1" in result
+    assert "**Total**" in result
+
+
+# T-EFF-6
+def test_efficiency_table_terminal_no_markdown() -> None:
+    """Terminal efficiency table uses padded columns, no markdown syntax."""
+    steps = [
+        {
+            "step_name": "implement",
+            "cache_read_input_tokens": 1000,
+            "cache_creation_input_tokens": 200,
+            "output_tokens": 50,
+            "loc_insertions": 80,
+            "loc_deletions": 20,
+        }
+    ]
+    total = {
+        "loc_insertions": 80,
+        "loc_deletions": 20,
+        "cache_read_input_tokens": 1000,
+        "cache_creation_input_tokens": 200,
+        "output_tokens": 50,
+    }
+    result = TelemetryFormatter.format_efficiency_table_terminal(steps, total)
+    assert "|" not in result  # no markdown pipes
+    assert "LOC" in result  # column header present

--- a/tests/pipeline/test_tokens_core.py
+++ b/tests/pipeline/test_tokens_core.py
@@ -416,3 +416,155 @@ class TestDefaultTokenLogLoadFromLogDir:
         assert n == 1
         report = log.get_report()
         assert report[0]["elapsed_seconds"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# T-LOC: LoC (lines-of-code-changed) fields
+# ---------------------------------------------------------------------------
+
+
+# T-LOC-1
+def test_token_entry_has_loc_fields():
+    """TokenEntry carries loc_insertions and loc_deletions defaulting to 0."""
+    e = TokenEntry(step_name="implement")
+    assert e.loc_insertions == 0
+    assert e.loc_deletions == 0
+
+
+# T-LOC-2
+def test_token_log_record_accumulates_loc():
+    """record() accumulates loc_insertions and loc_deletions across invocations."""
+    log = DefaultTokenLog()
+    log.record(
+        "implement",
+        {
+            "input_tokens": 100,
+            "output_tokens": 10,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+        },
+        loc_insertions=50,
+        loc_deletions=20,
+    )
+    log.record(
+        "implement",
+        {
+            "input_tokens": 200,
+            "output_tokens": 20,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+        },
+        loc_insertions=30,
+        loc_deletions=5,
+    )
+    report = log.get_report()
+    assert report[0]["loc_insertions"] == 80
+    assert report[0]["loc_deletions"] == 25
+
+
+# T-LOC-3
+def test_token_log_compute_total_includes_loc():
+    """compute_total() aggregates loc_insertions and loc_deletions."""
+    log = DefaultTokenLog()
+    log.record(
+        "implement",
+        {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+        },
+        loc_insertions=100,
+        loc_deletions=30,
+    )
+    log.record(
+        "test-fix",
+        {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+        },
+        loc_insertions=20,
+        loc_deletions=5,
+    )
+    total = log.compute_total()
+    assert total["loc_insertions"] == 120
+    assert total["loc_deletions"] == 35
+
+
+# T-LOC-4
+def test_token_log_load_from_log_dir_reads_loc(tmp_path):
+    """load_from_log_dir() reads loc_insertions / loc_deletions from token_usage.json."""
+    sessions_dir = tmp_path / "sessions" / "sess-abc"
+    sessions_dir.mkdir(parents=True)
+    (tmp_path / "sessions.jsonl").write_text(
+        json.dumps(
+            {
+                "dir_name": "sess-abc",
+                "kitchen_id": "k1",
+                "cwd": "/repo",
+                "order_id": "",
+                "campaign_id": "",
+            }
+        )
+        + "\n"
+    )
+    (sessions_dir / "token_usage.json").write_text(
+        json.dumps(
+            {
+                "step_name": "implement",
+                "input_tokens": 100,
+                "output_tokens": 10,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 0,
+                "timing_seconds": 5.0,
+                "order_id": "",
+                "loc_insertions": 42,
+                "loc_deletions": 8,
+            }
+        )
+    )
+    log = DefaultTokenLog()
+    log.load_from_log_dir(tmp_path)
+    report = log.get_report()
+    assert report[0]["loc_insertions"] == 42
+    assert report[0]["loc_deletions"] == 8
+
+
+# T-LOC-5
+def test_token_log_load_from_log_dir_missing_loc_defaults_to_zero(tmp_path):
+    """Old token_usage.json without loc fields loads with loc_insertions=0, loc_deletions=0."""
+    sessions_dir = tmp_path / "sessions" / "sess-old"
+    sessions_dir.mkdir(parents=True)
+    (tmp_path / "sessions.jsonl").write_text(
+        json.dumps(
+            {
+                "dir_name": "sess-old",
+                "kitchen_id": "k1",
+                "cwd": "/repo",
+                "order_id": "",
+                "campaign_id": "",
+            }
+        )
+        + "\n"
+    )
+    (sessions_dir / "token_usage.json").write_text(
+        json.dumps(
+            {
+                "step_name": "plan",
+                "input_tokens": 500,
+                "output_tokens": 50,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 0,
+                "timing_seconds": 3.0,
+                "order_id": "",
+                # NO loc_insertions or loc_deletions
+            }
+        )
+    )
+    log = DefaultTokenLog()
+    log.load_from_log_dir(tmp_path)
+    report = log.get_report()
+    assert report[0]["loc_insertions"] == 0
+    assert report[0]["loc_deletions"] == 0

--- a/tests/pipeline/test_tokens_core.py
+++ b/tests/pipeline/test_tokens_core.py
@@ -35,6 +35,8 @@ class TestTokenEntry:
             "cache_read_input_tokens",
             "invocation_count",
             "elapsed_seconds",
+            "loc_insertions",
+            "loc_deletions",
         }
 
     def test_default_counts_are_zero(self):
@@ -61,6 +63,8 @@ class TestTokenEntry:
             "cache_read_input_tokens",
             "invocation_count",
             "elapsed_seconds",
+            "loc_insertions",
+            "loc_deletions",
         }
         assert d["step_name"] == "implement"
         assert d["input_tokens"] == 42
@@ -146,6 +150,8 @@ class TestDefaultTokenLog:
             "cache_creation_input_tokens": 0,
             "cache_read_input_tokens": 0,
             "total_elapsed_seconds": 0.0,
+            "loc_insertions": 0,
+            "loc_deletions": 0,
         }
 
     def test_token_entry_has_elapsed_seconds_field(self):


### PR DESCRIPTION
## Summary

Implement a fully-automated Token Efficiency table that appends below the existing Token Usage Summary on PR bodies (and exposes the same data in terminal and MCP tool output). Lines-of-code-changed data is captured by running `git diff --numstat` before/after each headless Claude session in `_execute_claude_headless`, persisted to `token_usage.json`, accumulated in `TokenEntry`/`DefaultTokenLog`, and rendered by a new `format_efficiency_table()` method on `TelemetryFormatter`. The stdlib-only `token_summary_hook.py` adds a parallel inline `_format_efficiency_table()` for the PR-body path. Sessions with no LoC data silently omit the table (backward compatibility).

## Requirements

### Data Capture

**REQ-DATA-001:** The system must capture the number of lines inserted and lines deleted (via `git diff --numstat`) for each headless session execution.

**REQ-DATA-002:** The lines-changed data (`loc_insertions`, `loc_deletions`) must be persisted to `token_usage.json` in the session log directory alongside existing token fields.

**REQ-DATA-003:** The diff must be captured against the worktree state at session start vs session end, scoping LoC to changes made by that specific session/step.

### Efficiency Table — PR Body

**REQ-TABLE-001:** The Token Usage Summary hook must append a second table titled "Token Efficiency" below the existing Token Usage Summary table on PR bodies.

**REQ-TABLE-002:** The Token Efficiency table must include columns: Step, LoC Changed, cache_read/LoC, cache_write/LoC, output/LoC.

**REQ-TABLE-003:** The LoC Changed column must show insertions + deletions for each step.

**REQ-TABLE-004:** The ratio columns must display `cache_read_input_tokens / loc_changed`, `cache_creation_input_tokens / loc_changed`, and `output_tokens / loc_changed` respectively, rounded to one decimal place.

**REQ-TABLE-005:** A Total row must aggregate LoC Changed and compute ratios from the aggregate totals (not averaged per-step ratios).

**REQ-TABLE-006:** Steps with zero LoC changed must display `—` in ratio columns rather than dividing by zero.

### Efficiency Table — Terminal & MCP

**REQ-FMT-001:** `TelemetryFormatter` must provide `format_efficiency_table()` (markdown) and `format_efficiency_table_terminal()` (padded columns) methods.

**REQ-FMT-002:** The `get_token_summary` MCP tool and `get_pipeline_report` must include the efficiency table when LoC data is available.

### Backward Compatibility

**REQ-COMPAT-001:** Sessions logged before this feature (missing `loc_insertions`/`loc_deletions` in `token_usage.json`) must be gracefully handled — the efficiency table is simply omitted when no LoC data exists for any step.

Closes #1558

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260502-000720-701438/.autoskillit/temp/make-plan/token_efficiency_table_plan_2026-05-02_000720.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 169 | 18.4k | 1.3M | 88.2k | 1 | 7m 42s |
| verify | 118 | 14.3k | 715.9k | 52.3k | 1 | 4m 47s |
| implement | 792 | 47.6k | 11.0M | 141.3k | 1 | 21m 18s |
| prepare_pr | 60 | 7.6k | 237.5k | 37.7k | 1 | 2m 19s |
| compose_pr | 59 | 2.4k | 196.9k | 20.6k | 1 | 56s |
| review_pr | 193 | 31.0k | 605.0k | 82.7k | 1 | 7m 45s |
| resolve_review | 277 | 19.7k | 1.7M | 72.5k | 1 | 10m 26s |
| **Total** | 1.7k | 141.1k | 15.7M | 495.2k | | 55m 15s |