### PR TITLE
build-execution-map — In-Progress Issue Awareness for Conflict Pre-Screening

### DIFF
--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -1753,7 +1753,9 @@ skills:
     - "execution_map\\s*=\\s*/.+"
     pattern_examples:
     - "execution_map = /tmp/build-execution-map/execution_map_2026-04-22_190000.json\nexecution_map_report = /tmp/build-execution-map/execution_map_report_2026-04-22_190000.md\ngroup_count = 3\ntotal_issues = 5\ndispatched_count = 4\ndeferred_count = 1\nhas_deferred = true"
-    write_behavior: always
+    write_behavior: conditional
+    write_expected_when:
+    - "execution_map\\s*=\\s*/.+"
   bundle-local-report:
     inputs:
     - name: research_dir

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -1741,12 +1741,18 @@ skills:
       type: string
     - name: total_issues
       type: string
+    - name: dispatched_count
+      type: string
+    - name: deferred_count
+      type: string
+    - name: has_deferred
+      type: string
     - name: review_approach_candidates
       type: string
     expected_output_patterns:
     - "execution_map\\s*=\\s*/.+"
     pattern_examples:
-    - "execution_map = /tmp/build-execution-map/execution_map_2026-04-22_190000.json\nexecution_map_report = /tmp/build-execution-map/execution_map_report_2026-04-22_190000.md\ngroup_count = 3\ntotal_issues = 5"
+    - "execution_map = /tmp/build-execution-map/execution_map_2026-04-22_190000.json\nexecution_map_report = /tmp/build-execution-map/execution_map_report_2026-04-22_190000.md\ngroup_count = 3\ntotal_issues = 5\ndispatched_count = 4\ndeferred_count = 1\nhas_deferred = true"
     write_behavior: always
   bundle-local-report:
     inputs:

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -1753,9 +1753,7 @@ skills:
     - "execution_map\\s*=\\s*/.+"
     pattern_examples:
     - "execution_map = /tmp/build-execution-map/execution_map_2026-04-22_190000.json\nexecution_map_report = /tmp/build-execution-map/execution_map_report_2026-04-22_190000.md\ngroup_count = 3\ntotal_issues = 5\ndispatched_count = 4\ndeferred_count = 1\nhas_deferred = true"
-    write_behavior: conditional
-    write_expected_when:
-    - "execution_map\\s*=\\s*/.+"
+    write_behavior: always
   bundle-local-report:
     inputs:
     - name: research_dir

--- a/src/autoskillit/skills/sous-chef/SKILL.md
+++ b/src/autoskillit/skills/sous-chef/SKILL.md
@@ -306,7 +306,7 @@ When dispatching from an execution map:
    dispatch groups exist (group_count is 0 after removing deferred issues), skip group
    dispatch entirely. Enter an explicit poll loop:
 
-   1. Wait a configurable interval (default: 60 seconds between checks).
+   1. Wait `github.deferred_poll_interval_seconds` (default: 60 seconds between checks).
    2. Re-query ALL outstanding blocker labels via a single batched GraphQL aliases query.
    3. If at least one deferred issue becomes unblocked (all its blockers cleared), proceed
       to step 6e for those issues.
@@ -327,9 +327,13 @@ When dispatching from an execution map:
       issue numbers as arguments. This is a full analysis (pairwise + cross-assessment),
       not a passthrough. The supplementary map may itself produce new deferrals if
       remaining in-progress issues conflict with the eligible set.
-   2. Dispatch the resulting groups as additional sequential group(s) appended after the
-      last completed group.
-   3. Apply the same group-boundary merge-wait rule before dispatching the supplementary
+   2. If the supplementary map returns `has_deferred=true`, apply steps 6b and 6c to
+      the newly deferred issues before dispatching the supplementary groups. In headless
+      mode, treat all new deferrals as Wait (same rule as 6b). Issues that remain deferred
+      after this re-entry are skipped and reported in the session result.
+   3. Dispatch the resulting dispatch groups as additional sequential group(s) appended
+      after the last completed group.
+   4. Apply the same group-boundary merge-wait rule before dispatching the supplementary
       groups.
 
 ---

--- a/src/autoskillit/skills/sous-chef/SKILL.md
+++ b/src/autoskillit/skills/sous-chef/SKILL.md
@@ -234,6 +234,104 @@ When dispatching from an execution map:
    Group N PRs have merged, dispatch Group N+1 immediately. NEVER use
    AskUserQuestion to ask whether to proceed to the next group.
 
+6. **Handle deferred issues before dispatching any group.**
+
+   After reading the execution map, check for `has_deferred: true`.
+
+   **If `has_deferred` is false** (no deferrals): proceed directly to Group 1 dispatch.
+
+   **If `has_deferred` is true:**
+
+   **6a. Pre-dispatch freshness check.** Before presenting any escalation question,
+   re-query the current label state of ALL unique blocker issue numbers across all
+   deferred issues in a single batched GraphQL request using aliases:
+
+   ```graphql
+   query {
+     i887: repository(owner:"<OWNER>", name:"<REPO>") {
+       issue(number:887) { labels(first:20) { nodes { name } } }
+     }
+     i912: repository(owner:"<OWNER>", name:"<REPO>") {
+       issue(number:912) { labels(first:20) { nodes { name } } }
+     }
+   }
+   ```
+
+   For each blocker, check whether the `in-progress` label is still present. If a
+   blocker's label has been removed since the map was built, remove it from that deferred
+   issue's `blocked_by` list. If all blockers for a given deferred issue have cleared,
+   that issue is no longer deferred — collect it in an "auto-cleared" list for the
+   supplementary map (step 6e). **Never issue individual `gh issue view` calls per blocker
+   — always batch into a single GraphQL request.**
+
+   **6b. Present AskUserQuestion for each still-deferred issue.** For each deferred issue
+   where at least one blocker's `in-progress` label is still present, call
+   `AskUserQuestion`:
+
+   > "Issue #N (title) cannot be dispatched safely. It conflicts with in-progress
+   > issue(s): #M1 (title1), #M2 (title2).
+   > Conflict: {reasoning}
+   >
+   > Choose:
+   > 1. **Wait** — Hold #N; retry after the blocking issues complete
+   > 2. **Proceed anyway** — Dispatch #N now, accepting conflict risk
+   > 3. **Drop** — Remove #N from this session entirely"
+
+   **Headless-mode rule (MANDATORY):** When `AskUserQuestion` is denied by the hook
+   (the deny message says "proceed without user confirmation" — this refers to general
+   tool behavior, NOT this decision), treat the response as **Wait**. Do NOT interpret
+   the deny message as permission to proceed. This is the explicit safe default for
+   unattended sessions.
+
+   **6c. Route based on user answer (or Wait default):**
+
+   - **Wait**: Hold the issue. At each group-completion barrier (after all `run_skill`
+     calls in a group return — the natural inter-group barrier in both queue-mode and
+     classic-mode), re-check ALL outstanding Wait-path blockers via a single batched
+     GraphQL aliases query. When all blockers for a Wait issue have cleared, move it to
+     the auto-cleared list for step 6e. After the final group completes, if any Wait
+     issues remain uncleared, report them as skipped in the session result.
+
+   - **Proceed**: Add the issue to a **new sequential group** inserted at the end of the
+     dispatch sequence (after all other groups). This is transparent in both merge modes:
+     in queue-mode (#1268), the pipeline self-merges; in classic mode, `merge-prs` handles
+     it. Do not create one group per Proceed issue — batch all Proceed issues into the
+     single final group together.
+
+   - **Drop**: If the issue has already been claimed (its `in-progress` label is set by
+     this session), call `release_issue` to remove it. Then exclude the issue from all
+     dispatch, merge, and reporting. Do not mark it as failed — it is not a failure.
+
+   **6d. Zero-non-deferred-groups edge case.** When all target issues are deferred and no
+   dispatch groups exist (group_count is 0 after removing deferred issues), skip group
+   dispatch entirely. Enter an explicit poll loop:
+
+   1. Wait a configurable interval (default: 60 seconds between checks).
+   2. Re-query ALL outstanding blocker labels via a single batched GraphQL aliases query.
+   3. If at least one deferred issue becomes unblocked (all its blockers cleared), proceed
+      to step 6e for those issues.
+   4. Repeat until the first unblocked issue is found OR the elapsed time exceeds
+      `github.deferred_poll_timeout_seconds` (default: 1800 seconds / 30 minutes).
+   5. On timeout: report all deferred issues as skipped. Set session result
+      `success: false` with `failure_reason: "All target issues deferred due to
+      in-progress conflicts — human decision required"`. Exit.
+
+   **If in headless mode and all issues default to Wait with zero dispatch groups:**
+   skip the poll loop and immediately set `success: false` with the above
+   `failure_reason`. Do not poll indefinitely in unattended sessions.
+
+   **6e. Supplementary map for auto-cleared and freshness-cleared issues.** When one or
+   more Wait/freshness-cleared issues become eligible:
+
+   1. Re-run `build-execution-map` for the newly eligible issues **only** — pass their
+      issue numbers as arguments. This is a full analysis (pairwise + cross-assessment),
+      not a passthrough. The supplementary map may itself produce new deferrals if
+      remaining in-progress issues conflict with the eligible set.
+   2. Dispatch the resulting groups as additional sequential group(s) appended after the
+      last completed group.
+   3. Apply the same group-boundary merge-wait rule before dispatching the supplementary
+      groups.
+
 ---
 
 ## STEP NAME IMMUTABILITY — MANDATORY

--- a/src/autoskillit/skills/sous-chef/SKILL.md
+++ b/src/autoskillit/skills/sous-chef/SKILL.md
@@ -244,7 +244,7 @@ When dispatching from an execution map:
 
    **6a. Pre-dispatch freshness check.** Before presenting any escalation question,
    re-query the current label state of ALL unique blocker issue numbers across all
-   deferred issues in a single batched GraphQL request using aliases:
+   `deferred_issues` entries in a single batched GraphQL request using aliases:
 
    ```graphql
    query {

--- a/src/autoskillit/skills_extended/build-execution-map/SKILL.md
+++ b/src/autoskillit/skills_extended/build-execution-map/SKILL.md
@@ -163,7 +163,7 @@ For each pair that requires assessment, produce:
 - `medium` — Significant overlap or potential indirect dependency, resolvable. Recommendation: `proceed` with a warning annotation in the report.
 - `critical` — Semantic conflict, undeclared dependency, or architectural tension where implementing the target issue now will produce incorrect results or be discarded. Recommendation: `defer`.
 
-When the in-progress context is empty, skip Step 2b entirely — `cross_assessments` is `[]`.
+When the in-progress context is empty, omit Step 2b entirely — `cross_assessments` is `[]`.
 
 #### Review-Approach Benefit Assessment (conditional)
 

--- a/src/autoskillit/skills_extended/build-execution-map/SKILL.md
+++ b/src/autoskillit/skills_extended/build-execution-map/SKILL.md
@@ -43,6 +43,8 @@ Space-separated issue numbers (required, minimum 2), plus optional flags:
 - Override the AI's parallelism judgment with mechanical rules
 - Assume issues conflict based solely on file-name overlap without reading the issue descriptions
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Treat a medium-severity cross-assessment as grounds for deferral — only critical severity defers
+- Emit has_deferred / deferred_count / dispatched_count with markdown decorators
 
 **ALWAYS:**
 - Use parallel subagents (up to 8) for issue fetching in Step 1
@@ -77,6 +79,26 @@ Launch up to 8 parallel `sonnet` subagents, one per issue. Each subagent:
 2. Returns raw issue data: `{"number": N, "title": "..."}` — no structured extraction of
    `affected_files` or `depends_on`. The issue body is read directly by the parent in Step 2.
 
+In the same parallel wave, launch **one additional task** to fetch the ambient in-progress
+context:
+
+```bash
+gh issue list --state open --label "{{github.in_progress_label}}" \
+  --json number,title,body,labels,updatedAt --limit 50
+```
+
+Use the config value `github.in_progress_label` (default: `"in-progress"`) as the label
+name. From the returned list:
+- **Exclude** any issue whose number appears in the current target set — those are being
+  handled by this session and are already represented in the pairwise assessment.
+- **Exclude** any issue whose labels contain the staged label (`github.staged_label`,
+  default: `"staged"`) — staged issues have already landed on the integration branch.
+- The remaining issues form the **in-progress context** set.
+
+If the `gh issue list` call fails (auth error, network failure), log the error and set the
+in-progress context to an empty list — do not abort the skill. An empty in-progress context
+is always safe: the skill behaves identically to today.
+
 Do not output any prose between subagent launches — immediately collect results when all
 subagents complete. **All subagents must succeed** before advancing to Step 2. If any
 subagent fails or returns no JSON block, abort the skill with the subagent's error message
@@ -110,6 +132,38 @@ Constraints:
   issue context, not parsed by regex
 - Cross-references in "Files NOT to Change", code blocks, or diagnostic sections are context,
   not dependency signals
+
+#### Step 2b — Cross-Assessment (in-progress context)
+
+When the in-progress context set is non-empty, perform a second assessment pass: for each
+(target issue, in-progress issue) pair, evaluate conflict potential.
+
+Apply a **higher tolerance threshold** than pairwise assessment — simple file-level overlap
+is not sufficient to flag. Target: semantic conflicts, undeclared dependencies, or
+architectural tensions where implementing the target issue against the pre-in-progress
+codebase will produce incorrect results or wasted effort. Factor `updatedAt` recency: issues
+with no activity in 30+ days carry lower conflict weight — their in-progress label may be
+stale.
+
+For each pair that requires assessment, produce:
+
+```json
+{
+  "target_issue": 1155,
+  "in_progress_issue": 887,
+  "conflict_severity": "low" | "medium" | "critical",
+  "conflict_type": "file_overlap" | "semantic_dependency" | "undeclared_dependency" | "architectural_tension",
+  "reasoning": "one-sentence explanation",
+  "recommendation": "proceed" | "defer" | "escalate"
+}
+```
+
+**Severity definitions:**
+- `low` — Minor file overlap. `resolve-merge-conflicts` will handle this. Recommendation: `proceed`. Only record in JSON; suppress from the report to reduce noise.
+- `medium` — Significant overlap or potential indirect dependency, resolvable. Recommendation: `proceed` with a warning annotation in the report.
+- `critical` — Semantic conflict, undeclared dependency, or architectural tension where implementing the target issue now will produce incorrect results or be discarded. Recommendation: `defer`.
+
+When the in-progress context is empty, skip Step 2b entirely — `cross_assessments` is `[]`.
 
 #### Review-Approach Benefit Assessment (conditional)
 
@@ -164,6 +218,23 @@ others merges last).
 The `merge_order` list is the flattened sequence of issue numbers across groups in dispatch
 order.
 
+#### Step 3b — Deferred Issue Routing
+
+After assembling dispatch groups, separate issues flagged as `critical` in Step 2b:
+
+1. For each target issue that has at least one `critical` cross-assessment, **remove it from
+   its dispatch group** and add it to the `deferred_issues` array.
+2. If removing a deferred issue leaves a group empty, remove that group and renumber.
+3. Compute:
+   - `deferred_count` = count of issues in `deferred_issues`
+   - `dispatched_count` = `total_issues` − `deferred_count`
+   - `has_deferred` = `true` if `deferred_count > 0`, else `false`
+4. Each `deferred_issues` entry includes `blocked_by` as an **array** — a target issue may
+   have critical conflicts with multiple in-progress issues.
+
+When no cross-assessments produce `critical` severity, this step is a no-op: `deferred_issues`
+is `[]`, `has_deferred` is `false`, `dispatched_count` equals `total_issues`.
+
 ### Step 3.5 — Apply Parallel Cap
 
 After groups are assembled in Step 3, enforce the `max_parallel` cap:
@@ -212,6 +283,9 @@ working directory):
    - Any warnings (single-issue shortcut, low-confidence overrides, etc.)
    - Review-approach recommendations table (issue | recommended | reasoning) — only when
      `--assess-review-approach` is active
+   - **"## Deferred Issues — Awaiting In-Progress Resolution"** section (only when
+     `has_deferred = true`) listing: deferred issue number and title, blocking in-progress
+     issue number(s) and title(s), conflict type and reasoning, recommendation
 
 Emit structured output tokens as the last lines of text output:
 ```
@@ -219,8 +293,14 @@ execution_map = {absolute_path_to_json}
 execution_map_report = {absolute_path_to_report}
 group_count = {int}
 total_issues = {int}
+dispatched_count = {int}
+deferred_count = {int}
+has_deferred = {true|false}
 review_approach_candidates = {comma-separated issue numbers}
 ```
+
+Emit `dispatched_count`, `deferred_count`, and `has_deferred` unconditionally (even when
+`has_deferred = false` and `deferred_count = 0`).
 
 The `review_approach_candidates` token is conditional: emit it only when
 `--assess-review-approach` is active AND at least one issue has
@@ -246,6 +326,9 @@ structured output tokens. If context is exhausted mid-execution:
   "generated_at": "ISO-8601",
   "base_ref": "main",
   "total_issues": 5,
+  "dispatched_count": 4,
+  "deferred_count": 1,
+  "has_deferred": true,
   "max_parallel": 6,
   "group_count": 2,
   "groups": [
@@ -256,16 +339,12 @@ structured output tokens. If context is exhausted mid-execution:
         {"number": 1155, "title": "..."},
         {"number": 1156, "title": "..."}
       ]
-    },
-    {
-      "group": 2,
-      "parallel": false,
-      "issues": [
-        {"number": 1157, "title": "..."}
-      ]
     }
   ],
   "merge_order": [1155, 1156, 1157],
+  "in_progress_context": [
+    {"number": 887, "title": "franchise: per-recipe tool-surface test suite"}
+  ],
   "pairwise_assessments": [
     {
       "pair": [1155, 1156],
@@ -273,9 +352,32 @@ structured output tokens. If context is exhausted mid-execution:
       "confidence": "high",
       "reasoning": "#1156 modifies _build_l3_orchestrator_prompt() at lines 70-106. #1155 adds new function at end of file. Different symbols, non-adjacent."
     }
+  ],
+  "cross_assessments": [
+    {
+      "target_issue": 1158,
+      "in_progress_issue": 887,
+      "conflict_severity": "critical",
+      "conflict_type": "undeclared_dependency",
+      "reasoning": "...",
+      "recommendation": "defer"
+    }
+  ],
+  "deferred_issues": [
+    {
+      "number": 1158,
+      "title": "...",
+      "blocked_by": [887],
+      "reason": "..."
+    }
   ]
 }
 ```
+
+**Schema notes:**
+- `total_issues` counts ALL input issues (backward-compatible — callers expect `total_issues == len(input_issues)`)
+- `in_progress_context`, `cross_assessments`, `deferred_issues` are JSON-body-only — NOT emitted as terminal output tokens
+- `has_deferred`, `deferred_count`, `dispatched_count` ARE emitted as terminal output tokens
 
 When `--assess-review-approach` is active, each issue object gains two additional fields:
 

--- a/src/autoskillit/skills_extended/build-execution-map/SKILL.md
+++ b/src/autoskillit/skills_extended/build-execution-map/SKILL.md
@@ -325,12 +325,12 @@ structured output tokens. If context is exhausted mid-execution:
 {
   "generated_at": "ISO-8601",
   "base_ref": "main",
-  "total_issues": 5,
-  "dispatched_count": 4,
+  "total_issues": 3,
+  "dispatched_count": 2,
   "deferred_count": 1,
   "has_deferred": true,
   "max_parallel": 6,
-  "group_count": 2,
+  "group_count": 1,
   "groups": [
     {
       "group": 1,
@@ -341,7 +341,7 @@ structured output tokens. If context is exhausted mid-execution:
       ]
     }
   ],
-  "merge_order": [1155, 1156, 1157],
+  "merge_order": [1155, 1156],
   "in_progress_context": [
     {"number": 887, "title": "franchise: per-recipe tool-surface test suite"}
   ],

--- a/tests/contracts/test_execution_map_contracts.py
+++ b/tests/contracts/test_execution_map_contracts.py
@@ -186,11 +186,6 @@ def test_skill_documents_group_splitting_logic() -> None:
     )
 
 
-# ---------------------------------------------------------------------------
-# T1 — Contract: New Output Tokens Registered
-# ---------------------------------------------------------------------------
-
-
 def test_build_execution_map_new_tokens_registered() -> None:
     """has_deferred, deferred_count, dispatched_count must appear in the BEM contract."""
     from autoskillit.recipe.contracts import get_skill_contract, load_bundled_manifest
@@ -202,11 +197,6 @@ def test_build_execution_map_new_tokens_registered() -> None:
     assert "has_deferred" in output_names
     assert "deferred_count" in output_names
     assert "dispatched_count" in output_names
-
-
-# ---------------------------------------------------------------------------
-# T2 — Schema Arithmetic Invariant
-# ---------------------------------------------------------------------------
 
 
 @pytest.fixture()
@@ -248,11 +238,6 @@ def test_bem_count_invariant(sample_bem_json_with_deferrals: str) -> None:
     assert data["dispatched_count"] + data["deferred_count"] == data["total_issues"]
 
 
-# ---------------------------------------------------------------------------
-# T3 — Critical Cross-Assessment → Deferred
-# ---------------------------------------------------------------------------
-
-
 @pytest.fixture()
 def sample_bem_json_with_critical_deferral() -> str:
     return json.dumps(
@@ -292,11 +277,6 @@ def test_critical_cross_assessment_defers_issue(
     )
 
 
-# ---------------------------------------------------------------------------
-# T4 — No In-Progress Issues → No Regression
-# ---------------------------------------------------------------------------
-
-
 @pytest.fixture()
 def sample_bem_json_no_in_progress() -> str:
     return json.dumps(
@@ -330,11 +310,6 @@ def test_no_in_progress_produces_no_deferrals(sample_bem_json_no_in_progress: st
     assert data["cross_assessments"] == []
 
 
-# ---------------------------------------------------------------------------
-# T5 — blocked_by Is An Array
-# ---------------------------------------------------------------------------
-
-
 def test_blocked_by_is_array(sample_bem_json_with_deferrals: str) -> None:
     data = json.loads(sample_bem_json_with_deferrals)
     for deferred in data["deferred_issues"]:
@@ -343,22 +318,12 @@ def test_blocked_by_is_array(sample_bem_json_with_deferrals: str) -> None:
         )
 
 
-# ---------------------------------------------------------------------------
-# T6 (BEM) — SKILL.md Contains Required New Sections
-# ---------------------------------------------------------------------------
-
-
 def test_bem_skillmd_has_cross_assessment_section() -> None:
     content = _skill_md_text()
     assert "cross_assessments" in content
     assert "in_progress_context" in content
     assert "deferred_issues" in content
     assert "has_deferred" in content
-
-
-# ---------------------------------------------------------------------------
-# T8 — Contract Pattern Example Updated
-# ---------------------------------------------------------------------------
 
 
 def test_bem_contract_pattern_example_includes_new_tokens() -> None:

--- a/tests/contracts/test_execution_map_contracts.py
+++ b/tests/contracts/test_execution_map_contracts.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
+
+import pytest
+import yaml
 
 
 def _skill_md_text() -> str:
@@ -180,3 +184,194 @@ def test_skill_documents_group_splitting_logic() -> None:
     assert "sub-group" in step35.lower() or "subgroup" in step35.lower(), (
         "Step 3.5 section must describe sub-groups"
     )
+
+
+# ---------------------------------------------------------------------------
+# T1 — Contract: New Output Tokens Registered
+# ---------------------------------------------------------------------------
+
+
+def test_build_execution_map_new_tokens_registered() -> None:
+    """has_deferred, deferred_count, dispatched_count must appear in the BEM contract."""
+    from autoskillit.recipe.contracts import get_skill_contract, load_bundled_manifest
+
+    manifest = load_bundled_manifest()
+    contract = get_skill_contract("build-execution-map", manifest)
+    assert contract is not None
+    output_names = [o.name for o in contract.outputs]
+    assert "has_deferred" in output_names
+    assert "deferred_count" in output_names
+    assert "dispatched_count" in output_names
+
+
+# ---------------------------------------------------------------------------
+# T2 — Schema Arithmetic Invariant
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def sample_bem_json_with_deferrals() -> str:
+    return json.dumps(
+        {
+            "total_issues": 3,
+            "dispatched_count": 2,
+            "deferred_count": 1,
+            "has_deferred": True,
+            "groups": [
+                {
+                    "group": 1,
+                    "parallel": True,
+                    "issues": [{"number": 1155, "title": "A"}, {"number": 1156, "title": "B"}],
+                }
+            ],
+            "merge_order": [1155, 1156],
+            "in_progress_context": [{"number": 887, "title": "X"}],
+            "cross_assessments": [
+                {
+                    "target_issue": 1158,
+                    "in_progress_issue": 887,
+                    "conflict_severity": "critical",
+                    "conflict_type": "undeclared_dependency",
+                    "reasoning": "...",
+                    "recommendation": "defer",
+                }
+            ],
+            "deferred_issues": [
+                {"number": 1158, "title": "C", "blocked_by": [887], "reason": "..."}
+            ],
+        }
+    )
+
+
+def test_bem_count_invariant(sample_bem_json_with_deferrals: str) -> None:
+    data = json.loads(sample_bem_json_with_deferrals)
+    assert data["dispatched_count"] + data["deferred_count"] == data["total_issues"]
+
+
+# ---------------------------------------------------------------------------
+# T3 — Critical Cross-Assessment → Deferred
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def sample_bem_json_with_critical_deferral() -> str:
+    return json.dumps(
+        {
+            "total_issues": 2,
+            "dispatched_count": 1,
+            "deferred_count": 1,
+            "has_deferred": True,
+            "groups": [{"group": 1, "parallel": True, "issues": [{"number": 1155, "title": "A"}]}],
+            "merge_order": [1155],
+            "in_progress_context": [{"number": 887, "title": "X"}],
+            "cross_assessments": [
+                {
+                    "target_issue": 1158,
+                    "in_progress_issue": 887,
+                    "conflict_severity": "critical",
+                    "conflict_type": "undeclared_dependency",
+                    "reasoning": "...",
+                    "recommendation": "defer",
+                }
+            ],
+            "deferred_issues": [
+                {"number": 1158, "title": "B", "blocked_by": [887], "reason": "..."}
+            ],
+        }
+    )
+
+
+def test_critical_cross_assessment_defers_issue(
+    sample_bem_json_with_critical_deferral: str,
+) -> None:
+    data = json.loads(sample_bem_json_with_critical_deferral)
+    deferred_numbers = {d["number"] for d in data["deferred_issues"]}
+    grouped_numbers = {i["number"] for g in data["groups"] for i in g["issues"]}
+    assert deferred_numbers.isdisjoint(grouped_numbers), (
+        "Deferred issues must not appear in any dispatch group"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T4 — No In-Progress Issues → No Regression
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def sample_bem_json_no_in_progress() -> str:
+    return json.dumps(
+        {
+            "total_issues": 2,
+            "dispatched_count": 2,
+            "deferred_count": 0,
+            "has_deferred": False,
+            "groups": [
+                {
+                    "group": 1,
+                    "parallel": True,
+                    "issues": [{"number": 1155, "title": "A"}, {"number": 1156, "title": "B"}],
+                }
+            ],
+            "merge_order": [1155, 1156],
+            "in_progress_context": [],
+            "cross_assessments": [],
+            "deferred_issues": [],
+        }
+    )
+
+
+def test_no_in_progress_produces_no_deferrals(sample_bem_json_no_in_progress: str) -> None:
+    data = json.loads(sample_bem_json_no_in_progress)
+    assert data["has_deferred"] is False
+    assert data["deferred_count"] == 0
+    assert data["dispatched_count"] == data["total_issues"]
+    assert data["deferred_issues"] == []
+    assert data["in_progress_context"] == []
+    assert data["cross_assessments"] == []
+
+
+# ---------------------------------------------------------------------------
+# T5 — blocked_by Is An Array
+# ---------------------------------------------------------------------------
+
+
+def test_blocked_by_is_array(sample_bem_json_with_deferrals: str) -> None:
+    data = json.loads(sample_bem_json_with_deferrals)
+    for deferred in data["deferred_issues"]:
+        assert isinstance(deferred["blocked_by"], list), (
+            f"blocked_by for issue {deferred['number']} must be an array"
+        )
+
+
+# ---------------------------------------------------------------------------
+# T6 (BEM) — SKILL.md Contains Required New Sections
+# ---------------------------------------------------------------------------
+
+
+def test_bem_skillmd_has_cross_assessment_section() -> None:
+    content = _skill_md_text()
+    assert "cross_assessments" in content
+    assert "in_progress_context" in content
+    assert "deferred_issues" in content
+    assert "has_deferred" in content
+
+
+# ---------------------------------------------------------------------------
+# T8 — Contract Pattern Example Updated
+# ---------------------------------------------------------------------------
+
+
+def test_bem_contract_pattern_example_includes_new_tokens() -> None:
+    contracts_yaml = (
+        Path(__file__).resolve().parent.parent.parent
+        / "src"
+        / "autoskillit"
+        / "recipe"
+        / "skill_contracts.yaml"
+    )
+    raw = yaml.safe_load(contracts_yaml.read_text())
+    skills = raw.get("skills", {})
+    example = skills["build-execution-map"]["pattern_examples"][0]
+    assert "has_deferred" in example
+    assert "deferred_count" in example
+    assert "dispatched_count" in example

--- a/tests/skills/test_sous_chef_deferred_escalation.py
+++ b/tests/skills/test_sous_chef_deferred_escalation.py
@@ -16,11 +16,6 @@ def _sous_chef_text() -> str:
     ).read_text()
 
 
-# ---------------------------------------------------------------------------
-# T6 (sous-chef) — SKILL.md Contains Required Deferred Escalation Sections
-# ---------------------------------------------------------------------------
-
-
 def test_sous_chef_skillmd_has_deferred_escalation() -> None:
     content = _sous_chef_text()
     assert "deferred_issues" in content
@@ -28,11 +23,6 @@ def test_sous_chef_skillmd_has_deferred_escalation() -> None:
     assert "Wait" in content and "Proceed" in content and "Drop" in content
     assert "release_issue" in content
     assert "headless" in content.lower()
-
-
-# ---------------------------------------------------------------------------
-# T7 — Headless Denied AskUserQuestion → Wait Rule Present
-# ---------------------------------------------------------------------------
 
 
 def test_sous_chef_has_headless_wait_rule() -> None:

--- a/tests/skills/test_sous_chef_deferred_escalation.py
+++ b/tests/skills/test_sous_chef_deferred_escalation.py
@@ -8,7 +8,11 @@ from pathlib import Path
 def _sous_chef_text() -> str:
     return (
         Path(__file__).resolve().parent.parent.parent
-        / "src" / "autoskillit" / "skills" / "sous-chef" / "SKILL.md"
+        / "src"
+        / "autoskillit"
+        / "skills"
+        / "sous-chef"
+        / "SKILL.md"
     ).read_text()
 
 

--- a/tests/skills/test_sous_chef_deferred_escalation.py
+++ b/tests/skills/test_sous_chef_deferred_escalation.py
@@ -1,0 +1,37 @@
+"""Contract tests for sous-chef deferred issue escalation (T6/T7)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _sous_chef_text() -> str:
+    return (
+        Path(__file__).resolve().parent.parent.parent
+        / "src" / "autoskillit" / "skills" / "sous-chef" / "SKILL.md"
+    ).read_text()
+
+
+# ---------------------------------------------------------------------------
+# T6 (sous-chef) — SKILL.md Contains Required Deferred Escalation Sections
+# ---------------------------------------------------------------------------
+
+
+def test_sous_chef_skillmd_has_deferred_escalation() -> None:
+    content = _sous_chef_text()
+    assert "deferred_issues" in content
+    assert "AskUserQuestion" in content
+    assert "Wait" in content and "Proceed" in content and "Drop" in content
+    assert "release_issue" in content
+    assert "headless" in content.lower()
+
+
+# ---------------------------------------------------------------------------
+# T7 — Headless Denied AskUserQuestion → Wait Rule Present
+# ---------------------------------------------------------------------------
+
+
+def test_sous_chef_has_headless_wait_rule() -> None:
+    content = _sous_chef_text()
+    assert "denied" in content and "Wait" in content
+    assert "success: false" in content


### PR DESCRIPTION
## Summary

`build-execution-map` currently evaluates only the issues it is handed. It has no visibility
into issues actively being implemented by other sessions (GitHub label `in-progress`). This
creates a blind spot: when a target issue semantically conflicts with an in-flight issue, the
map greenlights it for dispatch, producing wasted compute (conflict resolution cycles) or
pipeline halts (Category 3 architectural tensions escalated to `escalate_stop`).

The fix adds four changes:

1. **`build-execution-map/SKILL.md`** — merge an in-progress-fetch task into the existing
   Step 1 parallel wave; add a cross-assessment sub-step (Step 2b); route critical-severity
   pairs into a new `deferred_issues[]` array (Step 3b); extend the JSON schema and add three
   new output tokens (`has_deferred`, `deferred_count`, `dispatched_count`).

2. **`sous-chef/SKILL.md`** — add a DEFERRED ISSUES escalation block to the
   EXECUTION MAP GROUP DISPATCH section: pre-dispatch freshness check, AskUserQuestion
   routing (Wait/Proceed/Drop), headless-mode safe default (Wait), group-boundary
   re-checks via batched GraphQL, zero-groups poll loop, `release_issue` on Drop, and
   supplementary map re-run for newly eligible issues.
   **Depends on #1268 landing first** — write against post-#1268 MERGE PHASE rules.

3. **`skill_contracts.yaml`** — register the three new output tokens.

4. **Tests** — contract token tests, schema invariant tests, deferred-routing unit tests,
   headless-mode denied-AskUserQuestion tests, and contract regression guard.

No changes to `implement-findings.yaml` or any Python source files are required — the new
tokens are additive and the BEM JSON consumer (`load_execution_map`) reads `groups`, which
is unaffected.

Closes #1269

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260502-040003-729211/.autoskillit/temp/make-plan/build_execution_map_in_progress_awareness_plan_2026-05-02_040003.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 153 | 19.7k | 874.6k | 63.7k | 1 | 12m 9s |
| verify | 116 | 13.3k | 685.0k | 54.7k | 1 | 5m 37s |
| implement | 280 | 16.2k | 2.0M | 67.0k | 1 | 7m 16s |
| prepare_pr | 60 | 5.4k | 256.8k | 39.1k | 1 | 1m 59s |
| compose_pr | 51 | 2.1k | 164.2k | 20.0k | 1 | 46s |
| review_pr | 178 | 44.7k | 1.1M | 85.8k | 1 | 12m 26s |
| resolve_review | 1.7k | 33.6k | 2.6M | 96.5k | 1 | 15m 16s |
| **Total** | 2.5k | 135.1k | 7.7M | 426.7k | | 55m 31s |