### PR TITLE
New Bundled Skill — audit-review-decisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 AutoSkillit is a Claude Code plugin that runs YAML recipes through a two-tier
 orchestrator. Bundled recipes turn GitHub issues into merged PRs by chaining
 plan, dry-walkthrough, worktree, test, and PR-review skills against 48 MCP
-tools and 129 bundled skills.
+tools and 130 bundled skills.
 
 https://github.com/user-attachments/assets/bcd910c8-7269-46d6-a496-53b2cb24d212
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 AutoSkillit is a Claude Code plugin that runs YAML recipes through a
 multi-level orchestrator. The bundled recipes implement issue → plan → worktree
-→ tests → PR → merge pipelines using 49 MCP tools and 129 bundled skills.
+→ tests → PR → merge pipelines using 49 MCP tools and 130 bundled skills.
 
 ## Start here
 

--- a/docs/developer/end-turn-hazards.md
+++ b/docs/developer/end-turn-hazards.md
@@ -190,7 +190,7 @@ two detectors on every SKILL.md in the project:
 | `_check_loop_boundary()` | "For each" loops with tool invocations but no anti-prose guard |
 
 These run as part of `test_no_text_then_tool_in_any_step`, a parametrized
-test that scans all 129 bundled skills. Any new skill with an unguarded
+test that scans all 130 bundled skills. Any new skill with an unguarded
 loop fails CI automatically.
 
 ## If This Gets Fixed Upstream

--- a/docs/execution/architecture.md
+++ b/docs/execution/architecture.md
@@ -4,7 +4,7 @@ How AutoSkillit runs a recipe end to end: orchestrator, kitchen gating, clone an
 
 ## Overview
 
-AutoSkillit is a Claude Code plugin that orchestrates automated workflows using headless sessions. It provides 48 MCP tools and 129 bundled skills, organized into a gated visibility system.
+AutoSkillit is a Claude Code plugin that orchestrates automated workflows using headless sessions. It provides 48 MCP tools and 130 bundled skills, organized into a gated visibility system.
 
 ## Core Concepts
 

--- a/docs/skills/catalog.md
+++ b/docs/skills/catalog.md
@@ -1,7 +1,7 @@
 # Skill catalog
 
-The complete list of bundled skills (129 total: 3 in `src/autoskillit/skills/`,
-126 in `src/autoskillit/skills_extended/`). Filesystem walk this directory if
+The complete list of bundled skills (130 total: 3 in `src/autoskillit/skills/`,
+127 in `src/autoskillit/skills_extended/`). Filesystem walk this directory if
 you need an exhaustive listing; this catalog groups by purpose.
 
 ## Tier 1 — free range (3)
@@ -24,7 +24,7 @@ Located under `src/autoskillit/skills_extended/`. Grouped by purpose:
 ### Audit suite
 `audit-arch`, `audit-cohesion`, `audit-tests`, `audit-defense-standards`,
 `audit-bugs`, `audit-friction`, `validate-audit`,
-`audit-claims`, `audit-docs`, `audit-feature-gates`
+`audit-claims`, `audit-docs`, `audit-feature-gates`, `audit-review-decisions`
 
 ### Requirements and planning
 `make-req`, `elaborate-phase`, `write-recipe`, `migrate-recipes`,

--- a/docs/skills/visibility.md
+++ b/docs/skills/visibility.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-AutoSkillit's 129 bundled skills are organized into three tiers that control when and where
+AutoSkillit's 130 bundled skills are organized into three tiers that control when and where
 they appear as slash commands. The tier system is orthogonal to subset categories — you can
 disable a subset across all tiers simultaneously, or reclassify individual skills between
 tiers. See [Subset Categories](subsets.md) for subset configuration.

--- a/src/autoskillit/config/defaults.yaml
+++ b/src/autoskillit/config/defaults.yaml
@@ -185,6 +185,7 @@ skills:
     - audit-bugs
     - audit-docs
     - audit-feature-gates
+    - audit-review-decisions
     - audit-friction
     - make-req
     - elaborate-phase

--- a/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
@@ -294,9 +294,14 @@ Same per-finding structure but labeled as pending.}
 
 For every finding processed in Phases 2–3 (all classifications — VALID, RESOLVED, STALE):
 
-1. **Re-check for existing audit marker**: using the raw JSON data saved in Phase 1,
-   check if any comment in the thread already starts with `[AUDIT]`. If yes: skip this
-   thread (idempotent — no duplicate post).
+1. **Re-check for existing audit marker (live)**: fetch the thread's current comments
+   directly from the GitHub API — do not use the Phase 1 JSON cache, which already
+   filtered out `[AUDIT]`-marked threads and cannot detect markers posted after Phase 1:
+   ```bash
+   gh api "repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}/comments" \
+     --jq "[.[] | select(.id == ${COMMENT_ID} or .in_reply_to_id == ${COMMENT_ID}) | .body | startswith(\"[AUDIT]\")] | any"
+   ```
+   If the result is `true`: skip this thread (idempotent — no duplicate post).
 
 2. **Determine marker body** based on classification and ticket status:
 

--- a/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
@@ -69,7 +69,7 @@ implemented. Identify review debt before it compounds.
      query($owner:String!, $name:String!) {
        rateLimit { cost remaining resetAt }
        repository(owner:$owner, name:$name) {
-         pullRequests(first:50, states:MERGED, orderBy:{field:UPDATED_AT,direction:DESC}) {
+         pullRequests(first:500, states:MERGED, orderBy:{field:UPDATED_AT,direction:DESC}) {
            nodes { number
              reviewThreads(first:50) {
                nodes { comments(first:10) { nodes { body createdAt } } }

--- a/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
@@ -36,19 +36,19 @@ implemented. Identify review debt before it compounds.
 
 **NEVER:**
 - Create files outside `${AUTOSKILLIT_TEMP}/audit-review-decisions/`
-- Have triage or validation subagents make GitHub API calls (local data only for Phase 2)
+- Have triage or validation subagents make GitHub API calls (local data only for Step 2)
 - Post duplicate `[AUDIT]` markers — check for existing marker before posting
 - Run subagents in the background (`run_in_background: true` is prohibited)
 - Use `gh pr list` without `--limit` to avoid pagination truncation
 - Use `\|` in Grep patterns — use `|` for alternation (ERE, not BRE)
 
 **ALWAYS:**
-- Save raw PR JSON to temp before any analysis (Phase 1)
+- Save raw PR JSON to temp before any analysis (Step 1)
 - Use GraphQL alias batching (~20 PRs per query) for data collection
 - Include `rateLimit { cost remaining resetAt }` in every GraphQL query
-- Sleep 1s between consecutive mutating GitHub API calls (Phase 5 watermark posts)
-- Phase 2 triage subagents read local JSON files only — zero API calls
-- Phase 3 validation subagents grep the actual current codebase
+- Sleep 1s between consecutive mutating GitHub API calls (Step 5 watermark posts)
+- Step 2 triage subagents read local JSON files only — zero API calls
+- Step 3 validation subagents grep the actual current codebase
 - Skip threads that already contain an `[AUDIT]` comment
 - Resolve owner/repo from `git remote get-url origin` — never hardcode
 - Use `/autoskillit:` prefix when invoking any other skill
@@ -57,7 +57,7 @@ implemented. Identify review debt before it compounds.
 
 ## Workflow
 
-### Phase 0: Watermark Resolution
+### Step 0: Watermark Resolution
 
 1. Parse `$1` for time period. Default `14d`. Compute `PERIOD_DAYS`.
 
@@ -90,7 +90,7 @@ implemented. Identify review debt before it compounds.
 
 ---
 
-### Phase 1: Data Collection (GraphQL Batch)
+### Step 1: Data Collection (GraphQL Batch)
 
 1. List merged PRs in the scan window:
    ```bash
@@ -136,7 +136,7 @@ implemented. Identify review debt before it compounds.
 
 ---
 
-### Phase 2: Triage (Haiku — Broad Pass)
+### Step 2: Triage (Haiku — Broad Pass)
 
 1. List all JSON files in `raw/`. Split into batches of ~5 files per agent.
 
@@ -168,7 +168,7 @@ implemented. Identify review debt before it compounds.
 
 ---
 
-### Phase 3: Validation (Sonnet — Deep Pass)
+### Step 3: Validation (Sonnet — Deep Pass)
 
 1. Group candidates into batches of ~10. Launch **parallel Sonnet subagents**
    (`model: "sonnet"`) per batch.
@@ -201,9 +201,9 @@ implemented. Identify review debt before it compounds.
 
 ---
 
-### Phase 4: Report Generation
+### Step 4: Report Generation
 
-1. Collect all validated findings from Phase 3 subagent responses.
+1. Collect all validated findings from Step 3 subagent responses.
 2. Sort findings: VALID first (by priority HIGH→MEDIUM→LOW), then RESOLVED, then STALE.
 3. Resolve the output path:
    - Use `$2` if provided.
@@ -290,13 +290,13 @@ Same per-finding structure but labeled as pending.}
 
 ---
 
-### Phase 5: Watermark (Thread Annotation)
+### Step 5: Watermark (Thread Annotation)
 
-For every finding processed in Phases 2–3 (all classifications — VALID, RESOLVED, STALE):
+For every finding processed in Steps 2–3 (all classifications — VALID, RESOLVED, STALE):
 
 1. **Re-check for existing audit marker (live)**: fetch the thread's current comments
-   directly from the GitHub API — do not use the Phase 1 JSON cache, which already
-   filtered out `[AUDIT]`-marked threads and cannot detect markers posted after Phase 1:
+   directly from the GitHub API — do not use the Step 1 JSON cache, which already
+   filtered out `[AUDIT]`-marked threads and cannot detect markers posted after Step 1:
    ```bash
    gh api "repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}/comments" \
      --jq "[.[] | select(.id == ${COMMENT_ID} or .in_reply_to_id == ${COMMENT_ID}) | .body | startswith(\"[AUDIT]\")] | any"
@@ -319,7 +319,7 @@ For every finding processed in Phases 2–3 (all classifications — VALID, RESO
      --field body="${MARKER_BODY}"
    sleep 1
    ```
-   `COMMENT_ID` is the `databaseId` of the first comment in the thread (from Phase 1 JSON).
+   `COMMENT_ID` is the `databaseId` of the first comment in the thread (from Step 1 JSON).
 
 4. **Thread reply constraint**: These calls cannot be batched via the reviews API — each
    requires an individual POST. The 1s delay between calls is mandatory per GitHub API

--- a/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
@@ -113,16 +113,19 @@ implemented. Identify review debt before it compounds.
      nodes { author { login } body state submittedAt }
    }
    reviewThreads(first: 100) {
-     pageInfo { hasNextPage }
+     pageInfo { hasNextPage endCursor }
      nodes {
        isResolved
-       comments(first: 20) {
+       comments(first: 100) {
          nodes { databaseId author { login } body path line createdAt }
        }
      }
    }
    ```
    Include `rateLimit { cost remaining resetAt }` at query root.
+   After the initial fetch, for each PR where `reviewThreads.pageInfo.hasNextPage` is
+   `true`, issue additional aliased queries with `reviewThreads(first:100, after:$endCursor)`
+   until `hasNextPage` is `false`. Merge the `nodes` arrays across pages before filtering.
 
 4. For each PR in the batch response:
    - Filter out threads whose `comments` list contains any comment with `body`

--- a/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
@@ -7,6 +7,13 @@ description: >
   from resolve-review and legacy keyword signals. Produces a structured markdown report
   with VALID/RESOLVED/STALE classifications and annotates processed threads with [AUDIT]
   markers to prevent re-identification on future runs.
+hooks:
+  PreToolUse:
+    - matcher: "*"
+      hooks:
+        - type: command
+          command: "echo 'Auditing PR review decisions...'"
+          once: true
 ---
 
 # Audit Review Decisions Skill

--- a/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
@@ -323,6 +323,6 @@ For every finding processed in Steps 2–3 (all classifications — VALID, RESOL
 
 4. **Thread reply constraint**: These calls cannot be batched via the reviews API — each
    requires an individual POST. The 1s delay between calls is mandatory per GitHub API
-   discipline (GitHub API discipline rules require `sleep 1` between consecutive POST/PATCH/PUT/DELETE calls).
+   discipline.
 
 5. Log progress per finding: `[AUDIT] Posted marker on PR #{number} thread {comment_id}: {marker_body}`

--- a/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
@@ -188,3 +188,126 @@ implemented. Identify review debt before it compounds.
      `MEDIUM` = severity=warning; `LOW` = severity=info or unknown.
 
 3. Collect and parse validated findings from all agent responses.
+
+---
+
+### Phase 4: Report Generation
+
+1. Collect all validated findings from Phase 3 subagent responses.
+2. Sort findings: VALID first (by priority HIGH→MEDIUM→LOW), then RESOLVED, then STALE.
+3. Resolve the output path:
+   - Use `$2` if provided.
+   - Otherwise: `${AUTOSKILLIT_TEMP}/audit-review-decisions/review_decisions_audit_$(date +%Y-%m-%d_%H%M%S).md`
+4. Create parent directory: `mkdir -p "$(dirname "${OUTPUT_PATH}")"`
+5. Write the markdown report to `${OUTPUT_PATH}`. Structure:
+
+---
+
+# PR Review Decisions Audit — {PERIOD_DAYS}d window
+
+**Generated:** {ISO timestamp}
+**Scan window:** {SCAN_SINCE} to {now}
+**PRs scanned:** {N} | **Threads examined:** {M} | **Threads skipped (already audited):** {K}
+
+## Summary
+
+| Classification | Count |
+|---|---|
+| VALID (ticket-worthy) | {N} |
+| RESOLVED (already fixed) | {N} |
+| STALE (no longer applicable) | {N} |
+
+## Priority Triage
+
+### HIGH Priority
+
+For each HIGH VALID finding, write a section:
+
+```
+### {suggested_title}
+
+**PR:** #{number} | **File:** {path}:{line} | **Severity:** {severity} | **Dimension:** {dimension}
+
+> {reviewer_quote}
+
+**Current relevance:** VALID — {impact}
+
+**Suggested issue title:** {suggested_title}
+**Affected files:** {path}
+```
+
+### MEDIUM Priority
+{Same structure}
+
+### LOW Priority
+{Same structure}
+
+## RESOLVED Findings
+
+{List: PR, file, one-line description of what was fixed}
+
+## STALE Findings
+
+{List: PR, file, one-line description of why no longer applicable}
+
+## Open PR Findings
+
+{Findings from PRs that were open (not merged) at scan time — may still be addressed.
+Same per-finding structure but labeled as pending.}
+
+## Pattern Analysis
+
+**Most common deferral phrases (by frequency):**
+{Table: phrase | count | % of all candidates}
+
+**Dimensions with highest VALID rate:**
+{Table: dimension | valid | resolved | stale | valid_rate}
+
+**Systemic escape hatches detected:**
+{Narrative: which phrases act as systematic blockers to tracking, with counts}
+
+**Recommendations:**
+{2–4 concrete process recommendations based on the pattern data}
+
+---
+6. After writing the file, print a terminal summary:
+   ```
+   audit-review-decisions complete
+   Output: {OUTPUT_PATH}
+   VALID: {N} | RESOLVED: {N} | STALE: {N}
+   Top finding: {first HIGH priority suggested_title, or "none"}
+   ```
+
+---
+
+### Phase 5: Watermark (Thread Annotation)
+
+For every finding processed in Phases 2–3 (all classifications — VALID, RESOLVED, STALE):
+
+1. **Re-check for existing audit marker**: using the raw JSON data saved in Phase 1,
+   check if any comment in the thread already starts with `[AUDIT]`. If yes: skip this
+   thread (idempotent — no duplicate post).
+
+2. **Determine marker body** based on classification and ticket status:
+
+   | Classification | Ticket created? | Marker body |
+   |---|---|---|
+   | VALID | Yes | `[AUDIT] — tracked in #{issue_number}` |
+   | VALID | No | `[AUDIT] — acknowledged, no action taken` |
+   | RESOLVED | — | `[AUDIT] — verified resolved in current codebase` |
+   | STALE | — | `[AUDIT] — no longer applicable` |
+
+3. **Post reply comment**:
+   ```bash
+   gh api "repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}/comments/${COMMENT_ID}/replies" \
+     --method POST \
+     --field body="${MARKER_BODY}"
+   sleep 1
+   ```
+   `COMMENT_ID` is the `databaseId` of the first comment in the thread (from Phase 1 JSON).
+
+4. **Thread reply constraint**: These calls cannot be batched via the reviews API — each
+   requires an individual POST. The 1s delay between calls is mandatory per GitHub API
+   discipline (GitHub API discipline rules require `sleep 1` between consecutive POST/PATCH/PUT/DELETE calls).
+
+5. Log progress per finding: `[AUDIT] Posted marker on PR #{number} thread {comment_id}: {marker_body}`

--- a/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-review-decisions/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: audit-review-decisions
+categories: [audit]
+description: >
+  Audit merged PR review threads for agreed-but-deferred suggestions (design decisions,
+  future work, out-of-scope items) that were never implemented. Mines REVIEW-FLAG markers
+  from resolve-review and legacy keyword signals. Produces a structured markdown report
+  with VALID/RESOLVED/STALE classifications and annotates processed threads with [AUDIT]
+  markers to prevent re-identification on future runs.
+---
+
+# Audit Review Decisions Skill
+
+Mine merged PR review threads for agreed-but-deferred suggestions that were never
+implemented. Identify review debt before it compounds.
+
+## When to Use
+
+- User says "audit review decisions", "find deferred review items", "surface review
+  debt", "what did reviewers flag for later"
+
+## Arguments
+
+- `$1` — Time period (e.g. `14d`, `30d`, `7d`). Default: `14d`.
+- `$2` — Output path. Default:
+  `${AUTOSKILLIT_TEMP}/audit-review-decisions/review_decisions_audit_$(date +%Y-%m-%d_%H%M%S).md`
+
+## Critical Constraints
+
+**NEVER:**
+- Create files outside `${AUTOSKILLIT_TEMP}/audit-review-decisions/`
+- Have triage or validation subagents make GitHub API calls (local data only for Phase 2)
+- Post duplicate `[AUDIT]` markers — check for existing marker before posting
+- Run subagents in the background (`run_in_background: true` is prohibited)
+- Use `gh pr list` without `--limit` to avoid pagination truncation
+- Use `\|` in Grep patterns — use `|` for alternation (ERE, not BRE)
+
+**ALWAYS:**
+- Save raw PR JSON to temp before any analysis (Phase 1)
+- Use GraphQL alias batching (~20 PRs per query) for data collection
+- Include `rateLimit { cost remaining resetAt }` in every GraphQL query
+- Sleep 1s between consecutive mutating GitHub API calls (Phase 5 watermark posts)
+- Phase 2 triage subagents read local JSON files only — zero API calls
+- Phase 3 validation subagents grep the actual current codebase
+- Skip threads that already contain an `[AUDIT]` comment
+- Resolve owner/repo from `git remote get-url origin` — never hardcode
+- Use `/autoskillit:` prefix when invoking any other skill
+
+---
+
+## Workflow
+
+### Phase 0: Watermark Resolution
+
+1. Parse `$1` for time period. Default `14d`. Compute `PERIOD_DAYS`.
+
+2. Resolve `OWNER` and `REPO` from `git remote get-url origin`.
+
+3. Query the most recent `[AUDIT]` sentinel comment across recently merged PRs:
+   ```bash
+   gh api graphql -f query='
+     query($owner:String!, $name:String!) {
+       rateLimit { cost remaining resetAt }
+       repository(owner:$owner, name:$name) {
+         pullRequests(first:50, states:MERGED, orderBy:{field:UPDATED_AT,direction:DESC}) {
+           nodes { number
+             reviewThreads(first:50) {
+               nodes { comments(first:10) { nodes { body createdAt } } }
+             }
+           }
+         }
+       }
+     }' -f owner="${OWNER}" -f name="${REPO}"
+   ```
+   Extract the most recent `createdAt` from any comment whose `body` starts with
+   `[AUDIT]`. Store as `LAST_AUDIT_TS` (empty string if none — first run).
+
+4. Compute `SCAN_SINCE`:
+   - If `LAST_AUDIT_TS` is set: `max(LAST_AUDIT_TS, date -d "now - PERIOD_DAYS days")`
+   - Else: `date -d "now - PERIOD_DAYS days" --iso-8601=seconds`
+
+5. Log: `Scan window: ${SCAN_SINCE} to now (${PERIOD_DAYS}d configured, last audit: ${LAST_AUDIT_TS:-none})`
+
+---
+
+### Phase 1: Data Collection (GraphQL Batch)
+
+1. List merged PRs in the scan window:
+   ```bash
+   SCAN_DATE=$(echo "${SCAN_SINCE}" | cut -c1-10)
+   PR_NUMS=$(gh pr list --state merged \
+     --search "merged:>=${SCAN_DATE}" \
+     --json number --limit 500 | jq -r '.[].number')
+   ```
+
+2. Create temp directory:
+   ```bash
+   mkdir -p "${AUTOSKILLIT_TEMP}/audit-review-decisions/raw"
+   ```
+
+3. Batch fetch in groups of 20 using GraphQL aliases. For each batch, build a query
+   with aliased `pr${i}: pullRequest(number: ${NUM})` nodes. Each node fetches:
+   ```graphql
+   number title mergedAt
+   reviews(first: 100) {
+     nodes { author { login } body state submittedAt }
+   }
+   reviewThreads(first: 100) {
+     pageInfo { hasNextPage }
+     nodes {
+       isResolved
+       comments(first: 20) {
+         nodes { databaseId author { login } body path line createdAt }
+       }
+     }
+   }
+   ```
+   Include `rateLimit { cost remaining resetAt }` at query root.
+
+4. For each PR in the batch response:
+   - Filter out threads whose `comments` list contains any comment with `body`
+     starting with `[AUDIT]` (already watermarked — skip entirely).
+   - If the PR has zero remaining threads: skip saving.
+   - Otherwise: save filtered data to
+     `${AUTOSKILLIT_TEMP}/audit-review-decisions/raw/pr_${number}.json`
+
+---
+
+### Phase 2: Triage (Haiku — Broad Pass)
+
+1. List all JSON files in `raw/`. Split into batches of ~5 files per agent.
+
+2. Launch **parallel Haiku subagents** (one per batch, `model: "haiku"`). Each agent:
+   - Reads its assigned JSON files only (no API calls).
+   - Flags a thread if it matches any signal:
+     - `<!-- REVIEW-FLAG:` tag present
+     - Body contains one of: `"Valid observation — flagged for design decision"`,
+       `"out of scope for this fix cycle"`, `"requires a dedicated cleanup commit"`,
+       `"left open for human review"`, `"future improvement"`, `"beyond this PR's scope"`,
+       `"requires team consensus"`
+     - Thread `isResolved: false` AND author acknowledged validity in a reply
+     - Review body `state: COMMENTED` with no corresponding thread (needs_human indicator)
+   - Returns candidates as **response text only — no file writes**. Per-candidate format:
+     ```
+     PR: {number}
+     thread_index: {N}
+     comment_id: {databaseId of first comment in thread}
+     path: {file path or empty}
+     line: {line number or empty}
+     signal: REVIEW-FLAG|KEYWORD|UNRESOLVED|NEEDS_HUMAN
+     severity: {from REVIEW-FLAG tag, or "unknown"}
+     dimension: {from REVIEW-FLAG tag, or "unknown"}
+     quote: {first 200 chars of flagged comment body}
+     ```
+   - False positives are acceptable; false negatives are not.
+
+3. Collect and parse candidate text from all agent responses.
+
+---
+
+### Phase 3: Validation (Sonnet — Deep Pass)
+
+1. Group candidates into batches of ~10. Launch **parallel Sonnet subagents**
+   (`model: "sonnet"`) per batch.
+
+2. Each Sonnet agent receives its candidate batch and, for each candidate:
+   - If `path` is set: reads the file and surrounding context.
+   - Greps the current codebase for the core concern from `quote` (judgment-based
+     pattern, not a literal string match).
+   - Classifies:
+     - `VALID` — issue still present, impactful, ticket-worthy
+     - `RESOLVED` — code changed; concern no longer applies
+     - `STALE` — code deleted/refactored; finding irrelevant
+   - Returns findings as **response text only — no file writes**. Per-finding format:
+     ```
+     PR: {number}
+     comment_id: {databaseId}
+     classification: VALID|RESOLVED|STALE
+     path: {file:line or empty}
+     severity: {critical|warning|info|unknown}
+     dimension: {arch|bugs|defense|tests|cohesion|slop|unknown}
+     priority: HIGH|MEDIUM|LOW
+     impact: {one sentence}
+     suggested_title: {short GitHub issue title}
+     reviewer_quote: {verbatim first 300 chars}
+     ```
+   - Priority assignment: `HIGH` = severity=critical OR dimension in (bugs, arch);
+     `MEDIUM` = severity=warning; `LOW` = severity=info or unknown.
+
+3. Collect and parse validated findings from all agent responses.

--- a/src/autoskillit/skills_extended/resolve-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-review/SKILL.md
@@ -292,6 +292,12 @@ the error message, domain group name, and affected comment IDs.
 
 **Merge results** into a `classification_map: dict[comment_id, verdict_entry]`.
 
+Each entry must also carry two additional fields populated at merge time (not delegated to sub-agents):
+- `severity` — `diff_context_map.get((path, line), {}).get("severity", locally_classified_severity)` where `locally_classified_severity` is the severity computed in Step 3 (`critical`/`warning`/`info` from keyword matching). This ensures a meaningful value even when no review-pr handoff entry exists for this `(path, line)`.
+- `dimension` — `diff_context_map.get((path, line), {}).get("dimension", "unknown")` (`arch|tests|bugs|defense|cohesion|slop|deletion_regression|unknown`). `"unknown"` is the correct sentinel when `diff_context_map` has no entry.
+
+For auto-classified INFO findings (those classified as DISCUSS in Step 3 without entering Step 3.5): add them to `classification_map` with `severity="info"` and `dimension=diff_context_map.get((path, line), {}).get("dimension", "unknown")`.
+
 **Write analysis report** to `{{AUTOSKILLIT_TEMP}}/resolve-review/analysis_{pr_number}_{ts}.md` before
 any code changes are made. The report must include a summary banner:
 ```
@@ -411,9 +417,11 @@ BODY="Investigated — this is intentional. ${evidence}
 <!-- autoskillit:resolved comment_id=${comment_id} verdict=REJECT -->"
 # DISCUSS:
 BODY="Valid observation — flagged for design decision. ${evidence}
+<!-- REVIEW-FLAG: severity=${severity} dimension=${dimension} -->
 <!-- autoskillit:resolved comment_id=${comment_id} verdict=DISCUSS -->"
 # INFO (auto-classified DISCUSS):
 BODY="Acknowledged — minor suggestion noted.
+<!-- REVIEW-FLAG: severity=info dimension=${dimension} -->
 <!-- autoskillit:resolved comment_id=${comment_id} verdict=INFO -->"
 
 gh api repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies \

--- a/src/autoskillit/skills_extended/write-recipe/SKILL.md
+++ b/src/autoskillit/skills_extended/write-recipe/SKILL.md
@@ -242,7 +242,7 @@ These skills ship with the autoskillit plugin and are invoked as `/autoskillit:<
 analyze-prs, arch-lens-c4-container, arch-lens-concurrency, arch-lens-data-lineage, arch-lens-deployment,
 arch-lens-development, arch-lens-error-resilience, arch-lens-module-dependency, arch-lens-operational,
 arch-lens-process-flow, arch-lens-repository-access, arch-lens-scenarios, arch-lens-security, arch-lens-state-lifecycle,
-audit-arch, audit-bugs, audit-claims, audit-cohesion, audit-defense-standards, audit-docs, audit-feature-gates, audit-friction, audit-impl, audit-tests,
+audit-arch, audit-bugs, audit-claims, audit-cohesion, audit-defense-standards, audit-docs, audit-feature-gates, audit-friction, audit-impl, audit-review-decisions, audit-tests,
 build-execution-map, bundle-local-report, close-kitchen, collapse-issues, compose-pr, compose-research-pr, design-guards, diagnose-ci, dry-walkthrough, elaborate-phase,
 enrich-issues, exp-lens-benchmark-representativeness, exp-lens-causal-assumptions, exp-lens-comparator-construction,
 exp-lens-error-budget, exp-lens-estimand-clarity, exp-lens-exploratory-confirmatory, exp-lens-fair-comparison,

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -310,10 +310,10 @@ def test_docs_state_44_kitchen_tools(doc_path: Path) -> None:
     _assert_doc_states_number(doc_path, "kitchen tools", 44)
 
 
-def test_skill_visibility_states_129_skills() -> None:
-    # 129 = 3 Tier-1 (open-kitchen, close-kitchen, sous-chef) + 126 extended.
-    # DefaultSkillResolver.list_all() returns 128 (excludes sous-chef from public surface).
-    _assert_doc_states_number(DOCS_DIR / "skills" / "visibility.md", "skills total", 129)
+def test_skill_visibility_states_130_skills() -> None:
+    # 130 = 3 Tier-1 (open-kitchen, close-kitchen, sous-chef) + 127 extended.
+    # DefaultSkillResolver.list_all() returns 129 (excludes sous-chef from public surface).
+    _assert_doc_states_number(DOCS_DIR / "skills" / "visibility.md", "skills total", 130)
 
 
 def test_safety_hooks_states_21_hooks() -> None:

--- a/tests/skills/test_review_flag_marker.py
+++ b/tests/skills/test_review_flag_marker.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 import re
 
-REVIEW_FLAG_RE = re.compile(
-    r"<!--\s*REVIEW-FLAG:\s*severity=(\w+)\s+dimension=(\w+)\s*-->"
-)
+REVIEW_FLAG_RE = re.compile(r"<!--\s*REVIEW-FLAG:\s*severity=(\w+)\s+dimension=(\w+)\s*-->")
 
 
 def test_review_flag_re_matches_discuss_comment():

--- a/tests/skills/test_review_flag_marker.py
+++ b/tests/skills/test_review_flag_marker.py
@@ -1,0 +1,41 @@
+"""Tests for the REVIEW-FLAG HTML comment marker used in resolve-review replies."""
+
+from __future__ import annotations
+
+import re
+
+REVIEW_FLAG_RE = re.compile(
+    r"<!--\s*REVIEW-FLAG:\s*severity=(\w+)\s+dimension=(\w+)\s*-->"
+)
+
+
+def test_review_flag_re_matches_discuss_comment():
+    body = (
+        "Valid observation — flagged for design decision. Evidence.\n"
+        "<!-- REVIEW-FLAG: severity=warning dimension=arch -->"
+        "\n<!-- autoskillit:resolved comment_id=12345 verdict=DISCUSS -->"
+    )
+    m = REVIEW_FLAG_RE.search(body)
+    assert m is not None
+    assert m.group(1) == "warning"
+    assert m.group(2) == "arch"
+
+
+def test_review_flag_re_matches_info_comment():
+    body = (
+        "Acknowledged — minor suggestion noted.\n"
+        "<!-- REVIEW-FLAG: severity=info dimension=slop -->"
+        "\n<!-- autoskillit:resolved comment_id=99 verdict=INFO -->"
+    )
+    m = REVIEW_FLAG_RE.search(body)
+    assert m is not None
+    assert m.group(1) == "info"
+    assert m.group(2) == "slop"
+
+
+def test_review_flag_re_no_match_on_legacy_comment():
+    legacy = (
+        "Valid observation — flagged for design decision. Some evidence.\n"
+        "<!-- autoskillit:resolved comment_id=42 verdict=DISCUSS -->"
+    )
+    assert REVIEW_FLAG_RE.search(legacy) is None

--- a/tests/workspace/test_skills.py
+++ b/tests/workspace/test_skills.py
@@ -41,6 +41,7 @@ BUNDLED_SKILLS = [
     "audit-feature-gates",
     "audit-friction",
     "audit-impl",
+    "audit-review-decisions",
     "audit-tests",
     "build-execution-map",
     "bundle-local-report",
@@ -443,17 +444,17 @@ class TestSkillResolver:
         assert names == {"open-kitchen", "close-kitchen", "sous-chef"}
 
     def test_124_skills_in_skills_extended(self) -> None:
-        """skills_extended/ contains exactly 126 SKILL.md-carrying directories."""
+        """skills_extended/ contains exactly 127 SKILL.md-carrying directories."""
         skills = [
             d
             for d in bundled_skills_extended_dir().iterdir()
             if d.is_dir() and (d / "SKILL.md").is_file()
         ]
-        assert len(skills) == 126
+        assert len(skills) == 127
 
     def test_skill_resolver_list_all_total_count(self) -> None:
-        """list_all() returns 128 public skills (2 Tier-1 + 126 extended)."""
-        assert len(DefaultSkillResolver().list_all()) == 128
+        """list_all() returns 129 public skills (2 Tier-1 + 127 extended)."""
+        assert len(DefaultSkillResolver().list_all()) == 129
 
     def test_skill_resolver_resolve_extended_skill(self) -> None:
         """resolve() finds a skill living in skills_extended/ with BUNDLED_EXTENDED source."""

--- a/tests/workspace/test_skills.py
+++ b/tests/workspace/test_skills.py
@@ -443,7 +443,7 @@ class TestSkillResolver:
         names = {d.name for d in bundled_skills_dir().iterdir() if d.is_dir()}
         assert names == {"open-kitchen", "close-kitchen", "sous-chef"}
 
-    def test_124_skills_in_skills_extended(self) -> None:
+    def test_127_skills_in_skills_extended(self) -> None:
         """skills_extended/ contains exactly 127 SKILL.md-carrying directories."""
         skills = [
             d


### PR DESCRIPTION
## Summary

Adds a new bundled skill `audit-review-decisions` that mines merged PR review threads for agreed-but-deferred suggestions that were never implemented, running them through a Haiku triage pass and Sonnet validation to produce an actionable report. The implementation also extends `resolve-review` to embed machine-parsable `<!-- REVIEW-FLAG: severity=X dimension=Y -->` markers in every DISCUSS reply so future audit runs can reliably identify structured suggestions. Phases 0–3 (watermark resolution, GraphQL batch collection, triage, and deep validation) are covered in Part A; Phases 4–5 (report generation and watermark thread annotation) in Part B.

<details>
<summary>Individual Group Plans</summary>

### Group 1: Part A

Add a new bundled skill `audit-review-decisions` that mines merged PR review threads for
agreed-but-deferred suggestions that were never implemented. This requires two deliverables:

- **Part 0**: Modify `resolve-review/SKILL.md` to embed a machine-parsable
  `<!-- REVIEW-FLAG: severity=X dimension=Y -->` tag in every DISCUSS reply comment,
  carrying severity and dimension forward from the originating `review-pr` finding.
- **Part 1 (this part)**: Create `src/autoskillit/skills_extended/audit-review-decisions/SKILL.md`
  implementing Phases 0–3: watermark resolution, GraphQL batch collection, Haiku triage,
  and Sonnet validation.

Part B will cover Phase 4 (report generation), Phase 5 (watermark thread annotation),
skill count test updates, the REVIEW-FLAG regex test, and end-to-end verification
(separate task).

### Group 2: Part B

Part B completes the `audit-review-decisions` skill by implementing the final two phases
of the pipeline (report generation and watermark thread annotation) and running the full
test suite to close out the feature.

Part A (prerequisite, separate task) covers:
- resolve-review REVIEW-FLAG tag modification (Part 0)
- SKILL.md file creation with frontmatter, constraints, and Phases 0–3
- Skill count test update and REVIEW-FLAG regex test

This part adds Phases 4 and 5 to the existing SKILL.md created in Part A, then verifies
the complete implementation end-to-end.

</details>

## Requirements

### MARK — Structured Review Markers (Part 0)

**REQ-MARK-001:** resolve-review must emit a machine-parsable marker tag in every DISCUSS reply comment.
**REQ-MARK-002:** Each marker must carry the finding's severity (critical/warning/info) and dimension (bugs, arch, security, etc.) from the originating review-pr finding.
**REQ-MARK-003:** The marker must be extractable from comment text via a single regex pattern.
**REQ-MARK-004:** The marker must not disrupt the human-readable portion of the comment (HTML comment or trailing tag).

### MINE — Comment Mining (Phase 1)

**REQ-MINE-001:** The skill must query PR review threads via GraphQL batch queries with aliases.
**REQ-MINE-002:** The skill must detect structured REVIEW-FLAG markers as the primary signal.
**REQ-MINE-003:** The skill must fall back to keyword matching for legacy comments predating the structured markers.
**REQ-MINE-004:** The skill must support a configurable time period parameter to scope the PR history window.
**REQ-MINE-005:** The skill must also detect review-pr `needs_human` findings that bypassed resolve-review entirely.

### TRIAGE — Broad-Pass Filtering (Phase 2)

**REQ-TRIAGE-001:** Triage subagents must operate on local data (JSON files saved during Phase 1) — no API calls during triage.
**REQ-TRIAGE-002:** Triage must use a loose filter — false positives acceptable, false negatives are not.
**REQ-TRIAGE-003:** Threads with existing `[AUDIT]` markers must be skipped.

### VALID — Deep Validation (Phase 3)

**REQ-VALID-001:** Validation subagents must check the actual current codebase for each finding.
**REQ-VALID-002:** Each finding must be classified as `VALID`, `RESOLVED`, or `STALE`.

### RPT — Report Generation (Phase 4)

**REQ-RPT-001:** The skill must produce a structured markdown report file at the configured output path.
**REQ-RPT-002:** Each report item must include the original reviewer comment as a verbatim quote.
**REQ-RPT-003:** Each report item must include the PR number, file path, and line context.
**REQ-RPT-004:** Each report item must include structured tag metadata (severity, dimension) when the marker is present.
**REQ-RPT-005:** Each report item must include a current relevance assessment (`VALID` / `RESOLVED` / `STALE`).
**REQ-RPT-006:** Each VALID finding must be self-contained — including suggested issue title, affected files, and impact assessment — so it can be used directly for downstream ticket creation.
**REQ-RPT-007:** The report must include a summary table, priority triage (HIGH / MEDIUM / LOW), and pattern analysis section.
**REQ-RPT-008:** The report must be organized for human scannability with clear per-item sections.

### WM — Watermarking (Phase 5)

**REQ-WM-001:** Processed threads must receive an `[AUDIT]` marker comment with status and ticket link (when applicable).
**REQ-WM-002:** Future runs must skip threads that already have audit markers.
**REQ-WM-003:** Watermark timestamp must automatically narrow the scan window on subsequent runs.
**REQ-WM-004:** No duplicate markers may be posted on re-runs (idempotent).
**REQ-WM-005:** Marker comments must use individual thread reply calls with 1s delay between mutating calls (thread replies cannot be batched via the reviews API).

Closes #1598

## Implementation Plan

Plan files:
- `/home/talon/projects/autoskillit-runs/impl-20260502-040003-246056/.autoskillit/temp/make-plan/audit_review_decisions_plan_2026-05-02_040525_part_a.md`
- `/home/talon/projects/autoskillit-runs/impl-20260502-040003-246056/.autoskillit/temp/make-plan/audit_review_decisions_plan_2026-05-02_040525_part_b.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 2.9k | 27.1k | 766.2k | 65.4k | 1 | 13m 26s |
| verify | 1.1k | 23.1k | 1.6M | 109.9k | 2 | 7m 14s |
| implement | 360 | 22.2k | 2.3M | 97.3k | 2 | 12m 36s |
| prepare_pr | 60 | 8.7k | 242.9k | 40.1k | 1 | 2m 41s |
| compose_pr | 59 | 3.1k | 201.4k | 22.0k | 1 | 1m 20s |
| review_pr | 102 | 39.6k | 681.4k | 77.6k | 1 | 10m 14s |
| resolve_review | 1.0k | 29.0k | 4.2M | 97.6k | 1 | 14m 32s |
| **Total** | 5.6k | 152.7k | 10.0M | 509.8k | | 1h 2m |