### PR TITLE
Rename Integration Branch to Develop

### DIFF
--- a/.autoskillit/config.yaml
+++ b/.autoskillit/config.yaml
@@ -1,7 +1,7 @@
 test_check:
   command: ["task", "test-all"]
   filter_mode: "conservative"
-  base_ref: "integration"
+  base_ref: "develop"
   # timeout: 600
 
 safety:
@@ -23,7 +23,7 @@ safety:
 #   skill_names: ["/autoskillit:implement-worktree", "/autoskillit:implement-worktree-no-merge"]
 
 branching:
-  default_base_branch: "integration"
+  default_base_branch: "develop"
 
 ci:
   workflow: "tests.yml"

--- a/.claude/skills/check-bearing/SKILL.md
+++ b/.claude/skills/check-bearing/SKILL.md
@@ -40,7 +40,7 @@ hooks:
 ### Target Resolution
 
 **Branch name:**
-- Detect base branch via `git merge-base` against `main` and `integration`
+- Detect base branch via `git merge-base` against `main` and `develop`
 - Use the closer base (fewer commits ahead)
 - Diff: `git diff {merge_base}...{branch}`
 

--- a/.claude/skills/promote-to-main/SKILL.md
+++ b/.claude/skills/promote-to-main/SKILL.md
@@ -27,8 +27,8 @@ and creates a comprehensive promotion PR.
 
 ## When to Use
 
-- When the integration branch is stable and ready to be promoted to main
-- After feature PRs, bug fixes, and cleanup work have been collected and tested on integration
+- When the develop branch is stable and ready to be promoted to main
+- After feature PRs, bug fixes, and cleanup work have been collected and tested on develop
 - This is the final gate before changes land on main
 
 ## Critical Constraints
@@ -57,7 +57,7 @@ and creates a comprehensive promotion PR.
 #### Step 0.1: Parse Arguments
 
 Parse optional positional arguments and flags:
-- `integration_branch` — default `"integration"` if absent or empty
+- `integration_branch` — default `"develop"` if absent or empty
 - `base_branch` — default `"main"` if absent or empty
 - `dry_run` — `true` if `--dry-run` present in ARGUMENTS
 

--- a/.claude/skills/review-promotion/SKILL.md
+++ b/.claude/skills/review-promotion/SKILL.md
@@ -21,7 +21,7 @@ posts the review report as a PR comment.
 /autoskillit:review-promotion [integration_branch] [base_branch] [--post-to-pr]
 ```
 
-- `integration_branch` (optional) — source branch to analyze. Defaults to `integration`.
+- `integration_branch` (optional) — source branch to analyze. Defaults to `develop`.
 - `base_branch` (optional) — target branch. Defaults to `main`.
 - `--post-to-pr` — if present, post the review report as a comment on the open promotion PR.
 
@@ -49,7 +49,7 @@ posts the review report as a PR comment.
 #### Step 0.1: Parse Arguments
 
 Parse optional positional arguments and flags:
-- `integration_branch` — default `"integration"` if absent or empty
+- `integration_branch` — default `"develop"` if absent or empty
 - `base_branch` — default `"main"` if absent or empty
 - `post_to_pr` — `true` if `--post-to-pr` present in ARGUMENTS
 

--- a/.github/workflows/patch-bump-develop.yml
+++ b/.github/workflows/patch-bump-develop.yml
@@ -1,12 +1,12 @@
-name: Auto Patch Version Bump on Integration PR
+name: Auto Patch Version Bump on Develop PR
 
 on:
   pull_request:
     types: [closed]
-    branches: [integration]
+    branches: [develop]
 
 concurrency:
-  group: patch-bump-integration
+  group: patch-bump-develop
   cancel-in-progress: false
 
 jobs:
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: integration
+          ref: develop
           fetch-depth: 0
           token: ${{ secrets.GH_PAT }}
 
@@ -75,7 +75,7 @@ jobs:
       - name: Regenerate uv.lock
         run: uv lock
 
-      - name: Commit and push version bump to integration
+      - name: Commit and push version bump to develop
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
@@ -85,5 +85,5 @@ jobs:
             echo "Nothing to commit"
           else
             git commit -m "chore: bump version to ${{ steps.version.outputs.new }}"
-            git push origin integration
+            git push origin develop
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, stable]
   pull_request:
-    branches: [main, develop, stable]
+    branches: [main, integration, develop, stable]
   merge_group:
 
 permissions:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, stable]
   pull_request:
-    branches: [main, integration, stable]
+    branches: [main, develop, stable]
   merge_group:
 
 permissions:
@@ -94,7 +94,7 @@ jobs:
           AUTOSKILLIT_FILTER_STATS_FILE: ${{ github.workspace }}/.autoskillit/temp/filter-stats.json
         run: |
           mkdir -p .autoskillit/temp
-          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.base_ref }}" == "integration" ]]; then
+          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.base_ref }}" == "develop" ]]; then
             export AUTOSKILLIT_TEST_FILTER=conservative
           fi
           task test-all

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -11,7 +11,7 @@ jobs:
       contents: write
     if: >
       github.event.pull_request.merged == true &&
-      github.event.pull_request.head.ref == 'integration'
+      github.event.pull_request.head.ref == 'develop'
     runs-on: ubuntu-latest
 
     steps:
@@ -81,13 +81,13 @@ jobs:
             git push origin main
           fi
 
-      - name: Checkout integration branch
+      - name: Checkout develop branch
         run: |
           set -euo pipefail
-          git fetch origin integration
-          git checkout -B integration origin/integration
+          git fetch origin develop
+          git checkout -B develop origin/develop
 
-      - name: Read integration current version
+      - name: Read develop current version
         id: int_version
         run: |
           set -euo pipefail
@@ -98,7 +98,7 @@ jobs:
           [ -n "$CURRENT" ] || { echo "ERROR: int_version: CURRENT is empty — checkout may have failed or pyproject.toml is absent" >&2; exit 1; }
           echo "old=$CURRENT" >> "$GITHUB_OUTPUT"
 
-      - name: Update pyproject.toml (integration)
+      - name: Update pyproject.toml (develop)
         run: |
           python3 - <<'EOF'
           import pathlib, os, sys
@@ -108,7 +108,7 @@ jobs:
           old_parts = tuple(int(x) for x in old_str.split("."))
           new_parts = tuple(int(x) for x in new_str.split("."))
           if new_parts <= old_parts:
-              print(f"ERROR: new_int {new_str!r} would downgrade integration from {old_str!r}", file=sys.stderr)
+              print(f"ERROR: new_int {new_str!r} would downgrade develop from {old_str!r}", file=sys.stderr)
               sys.exit(1)
           old_ver = f'version = "{old_str}"'
           new_ver = f'version = "{new_str}"'
@@ -123,19 +123,19 @@ jobs:
           OLD_VERSION: ${{ steps.int_version.outputs.old }}
           NEW_VERSION: ${{ steps.version.outputs.new_int }}
 
-      - name: Sync version artifacts (integration)
+      - name: Sync version artifacts (develop)
         run: python3 scripts/sync_versions.py
 
-      - name: Regenerate uv.lock (integration)
+      - name: Regenerate uv.lock (develop)
         run: uv lock
 
-      - name: Commit and push integration version bump
+      - name: Commit and push develop version bump
         run: |
           set -euo pipefail
           git add pyproject.toml src/autoskillit/.claude-plugin/plugin.json src/autoskillit/recipes/ uv.lock
           if git diff --cached --quiet; then
             echo "Nothing to commit"
           else
-            git commit -m "chore: bump integration version to ${{ steps.version.outputs.new_int }}"
-            git push origin integration
+            git commit -m "chore: bump develop version to ${{ steps.version.outputs.new_int }}"
+            git push origin develop
           fi

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -224,9 +224,9 @@ tasks:
         echo "Done: $(python --version 2>/dev/null || .venv/bin/python --version)"
 
   install-dev:
-    desc: Install dev version of autoskillit from the integration branch
+    desc: Install dev version of autoskillit from the develop branch
     cmds:
-      - uv tool install --force "autoskillit[dev] @ git+https://github.com/TalonT-Org/AutoSkillit.git@integration"
+      - uv tool install --force "autoskillit[dev] @ git+https://github.com/TalonT-Org/AutoSkillit.git@develop"
       - "$(uv tool dir)/autoskillit/bin/autoskillit install"
 
   vendor-mermaid:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -173,11 +173,11 @@ branching:
   default_base_branch: main   # default base branch for recipes
 ```
 
-Default: `main`. Override if your project uses a different integration branch (e.g. `integration` or `develop`):
+Default: `main`. Override if your project uses a different integration branch (e.g. `develop`):
 
 ```yaml
 branching:
-  default_base_branch: integration
+  default_base_branch: develop
 ```
 
 ## Session Diagnostics (Linux)
@@ -369,7 +369,7 @@ with GitHub's merge queue feature. For best results with automation use cases:
 ### `min_entries_to_merge_wait_minutes` = 0
 
 GitHub branch rulesets expose a `min_entries_to_merge_wait_minutes` setting that adds
-latency before a queued PR is eligible to merge. For the `integration` branch (or any
+latency before a queued PR is eligible to merge. For the `develop` branch (or any
 branch where AutoSkillit manages the PR queue), set this to `0`.
 
 **Why:** AutoSkillit enters PRs one at a time or in small batches. A non-zero wait
@@ -377,7 +377,7 @@ multiplier adds unnecessary latency per PR. Setting it to `0` lets PRs merge as 
 as their CI passes.
 
 **Location:** GitHub → Repository Settings → Branches → Branch protection rules →
-select the integration ruleset → Merge queue → "Minimum entries to merge — wait X minutes".
+select the develop ruleset → Merge queue → "Minimum entries to merge — wait X minutes".
 Set to `0`.
 
 ## Feature Flags
@@ -390,14 +390,14 @@ Features are gated by lifecycle state. The `features:` config section and
 | Lifecycle | Behavior | Can Override? |
 |-----------|----------|---------------|
 | STABLE | On everywhere | Yes — opt out via `features: {name: false}` |
-| EXPERIMENTAL | On when `experimental_enabled: true` (default on integration; off on main) | Yes — per-feature entry overrides blanket |
+| EXPERIMENTAL | On when `experimental_enabled: true` (default on develop; off on main) | Yes — per-feature entry overrides blanket |
 | DEPRECATED | Follows `default_enabled`; may be removed without warning | Yes |
 | DISABLED | Always off; cannot be enabled | No — config entry setting `true` is rejected |
 
 ### Blanket Toggle
 
 `experimental_enabled: true` in `defaults.yaml` means all `EXPERIMENTAL` features are
-active on integration, worktrees, and feature branches without any per-feature config.
+active on develop, worktrees, and feature branches without any per-feature config.
 
 Main and stable branches commit `features: {experimental_enabled: false}` to opt out.
 
@@ -407,7 +407,7 @@ Any config layer can override an individual feature regardless of the blanket to
 
 ```yaml
 features:
-  planner: false    # disable planner even on integration
+  planner: false    # disable planner even on develop
 ```
 
 Env var takes highest priority: `AUTOSKILLIT_FEATURES__PLANNER=false`.

--- a/docs/safety/hooks.md
+++ b/docs/safety/hooks.md
@@ -12,7 +12,7 @@ materializes the canonical `hooks.json` that Claude Code reads.
 ### `branch_protection_guard.py`
 **Guarded tools:** `merge_worktree`, `push_to_remote`
 Denies merges and pushes targeting branches in `safety.protected_branches`
-(`main`, `integration`, `stable` by default). Pure-function check via
+(`main`, `develop`, `stable` by default). Pure-function check via
 `core/branch_guard.is_protected_branch`.
 
 ### `quota_guard.py`
@@ -172,7 +172,7 @@ the global Python.
 ```yaml
 # .autoskillit/config.yaml
 safety:
-  protected_branches: ["main", "integration", "stable"]
+  protected_branches: ["main", "develop", "stable"]
   require_dry_walkthrough: true
   test_gate_on_merge: true
   reset_guard_marker: ".autoskillit-workspace"

--- a/docs/update-checks.md
+++ b/docs/update-checks.md
@@ -20,7 +20,7 @@ Dismissal windows vary by install type to balance convenience and safety:
 | Install | Window |
 |---------|--------|
 | stable / main / release-tag | 7 days |
-| integration / local-editable | 12 hours |
+| develop / local-editable | 12 hours |
 
 The window is determined at check time from the current `direct_url.json` —
 not from what was stored when you dismissed.

--- a/docs/version-pipeline.md
+++ b/docs/version-pipeline.md
@@ -15,22 +15,22 @@ Pre-commit enforcement: `sync_versions.py --check` (exits 1 if any artifact is o
 
 ## CI Workflows
 
-### `patch-bump-integration.yml`
+### `patch-bump-develop.yml`
 
-- **Trigger:** any PR merged into `integration`
-- **Action:** `MAJOR.MINOR.(PATCH+1)` on `integration`
+- **Trigger:** any PR merged into `develop`
+- **Action:** `MAJOR.MINOR.(PATCH+1)` on `develop`
 - **Calls `sync_versions.py`:** yes
 - **Staged files:** `pyproject.toml`, `src/autoskillit/.claude-plugin/plugin.json`, `src/autoskillit/recipes/`, `uv.lock`
 - **Concurrency:** serialized (`cancel-in-progress: false`)
 
 ### `version-bump.yml`
 
-- **Trigger:** PR merged into `main` from `integration` (promotion)
+- **Trigger:** PR merged into `main` from `develop` (promotion)
 - **Action:**
   - `main` → `MAJOR.(MINOR+1).0`
-  - `integration` → `MAJOR.(MINOR+1).1` (forward-bumped to stay ahead of main)
-- **Calls `sync_versions.py`:** yes (on both `main` and `integration` in sequence)
-- **Guard:** rejects if `new_integration <= old_integration` (downgrade protection)
+  - `develop` → `MAJOR.(MINOR+1).1` (forward-bumped to stay ahead of main)
+- **Calls `sync_versions.py`:** yes (on both `main` and `develop` in sequence)
+- **Guard:** rejects if `new_develop <= old_develop` (downgrade protection)
 
 ### `release.yml`
 
@@ -51,7 +51,7 @@ Returns `match` (`package_version == plugin_json_version`) and `recipe_versions_
 
 ## Known Gap: `release.yml` Did Not Sync Recipes
 
-`patch-bump-integration.yml` and `version-bump.yml` both call `sync_versions.py`, keeping `plugin.json` and recipe YAMLs in sync. Previously, `release.yml` updated `plugin.json` inline but skipped `sync_versions.py`, so recipe YAML `autoskillit_version` fields were not updated on `stable`. This gap has been closed: `release.yml` now calls `python3 scripts/sync_versions.py` and stages `src/autoskillit/recipes/` in the commit step, consistent with the other two workflows.
+`patch-bump-develop.yml` and `version-bump.yml` both call `sync_versions.py`, keeping `plugin.json` and recipe YAMLs in sync. Previously, `release.yml` updated `plugin.json` inline but skipped `sync_versions.py`, so recipe YAML `autoskillit_version` fields were not updated on `stable`. This gap has been closed: `release.yml` now calls `python3 scripts/sync_versions.py` and stages `src/autoskillit/recipes/` in the commit step, consistent with the other two workflows.
 
 ## Invariant for PRs
 

--- a/src/autoskillit/cli/_install_info.py
+++ b/src/autoskillit/cli/_install_info.py
@@ -18,7 +18,7 @@ from autoskillit.core import get_logger
 
 logger = get_logger(__name__)
 
-_INSTALL_FROM_INTEGRATION = "git+https://github.com/TalonT-Org/AutoSkillit.git@integration"
+_INSTALL_FROM_DEVELOP = "git+https://github.com/TalonT-Org/AutoSkillit.git@develop"
 
 
 class InstallType(StrEnum):
@@ -102,14 +102,14 @@ def comparison_branch(info: InstallInfo) -> str | None:
     """Return the GitHub branch/tag to compare for update availability.
 
     - ``stable`` / ``main`` / release-tag / ``UNKNOWN`` → ``"releases/latest"``
-    - ``integration`` → ``"integration"``
+    - ``develop`` → ``"develop"``
     - ``LOCAL_EDITABLE`` / ``LOCAL_PATH`` → ``None`` (not applicable)
     """
     if info.install_type in (InstallType.LOCAL_EDITABLE, InstallType.LOCAL_PATH):
         return None
     rev = info.requested_revision or ""
-    if rev == "integration":
-        return "integration"
+    if rev == "develop":
+        return "develop"
     return "releases/latest"
 
 
@@ -119,11 +119,11 @@ def dismissal_window(info: InstallInfo) -> timedelta:
     Branch-aware windows:
 
     - ``stable`` / ``main`` / release-tag / ``UNKNOWN`` → ``timedelta(days=7)``
-    - ``integration`` / ``LOCAL_EDITABLE`` → ``timedelta(hours=12)``
+    - ``develop`` / ``LOCAL_EDITABLE`` → ``timedelta(hours=12)``
     """
     rev = info.requested_revision or ""
     # LOCAL_EDITABLE is reachable only via AUTOSKILLIT_FORCE_UPDATE_CHECK; not dead code.
-    if rev == "integration" or info.install_type == InstallType.LOCAL_EDITABLE:
+    if rev == "develop" or info.install_type == InstallType.LOCAL_EDITABLE:
         return timedelta(hours=12)
     return timedelta(days=7)
 
@@ -132,14 +132,14 @@ def upgrade_command(info: InstallInfo) -> list[str] | None:
     """Return the subprocess command to upgrade autoskillit for this install.
 
     - ``stable`` / ``main`` / release-tag → ``["uv", "tool", "upgrade", "autoskillit"]``
-    - ``integration`` → ``["uv", "tool", "install", "--force", <git URL>]``
+    - ``develop`` → ``["uv", "tool", "install", "--force", <git URL>]``
     - ``LOCAL_EDITABLE`` → ``["uv", "pip", "install", "-e", str(info.editable_source)]``
     - ``UNKNOWN`` / ``LOCAL_PATH`` → ``None``
     """
     if info.install_type == InstallType.GIT_VCS:
         rev = info.requested_revision or ""
-        if rev == "integration":
-            return ["uv", "tool", "install", "--force", _INSTALL_FROM_INTEGRATION]
+        if rev == "develop":
+            return ["uv", "tool", "install", "--force", _INSTALL_FROM_DEVELOP]
         return ["uv", "tool", "upgrade", "autoskillit"]
     if info.install_type == InstallType.LOCAL_EDITABLE and info.editable_source is not None:
         return ["uv", "pip", "install", "-e", str(info.editable_source)]

--- a/src/autoskillit/cli/_update.py
+++ b/src/autoskillit/cli/_update.py
@@ -53,7 +53,7 @@ def run_update_command(home: Path | None = None) -> None:
     if cmd is None:
         print(
             "Unknown install type. "
-            "Reinstall via install.sh (stable) or 'task install-dev' (integration).",
+            "Reinstall via install.sh (stable) or 'task install-dev' (develop).",
             flush=True,
         )
         raise SystemExit(2)

--- a/src/autoskillit/cli/_update_checks.py
+++ b/src/autoskillit/cli/_update_checks.py
@@ -5,7 +5,7 @@ single dismissable prompt per CLI invocation.
 
 Branch-aware dismissal windows:
 - stable/main/release-tag/UNKNOWN: timedelta(days=7)
-- integration/LOCAL_EDITABLE: timedelta(hours=12)
+- develop/LOCAL_EDITABLE: timedelta(hours=12)
 
 Dismissal expires on two axes: time window elapsed, or version advanced past
 the dismissed_version recorded at dismiss time.
@@ -221,7 +221,7 @@ def _is_dismissed(
     1. ``dismissed_at`` is within the branch-aware ``window`` (time-based,
        never SHA-keyed — a new upstream commit does NOT break the window).
        Window values: 7 days for stable/main/release-tag/UNKNOWN installs;
-       12 hours for integration/LOCAL_EDITABLE installs.
+       12 hours for develop/LOCAL_EDITABLE installs.
     2. ``current_version <= dismissed_version`` (version-delta expiry: when the
        running version advances past what was dismissed, the dismissal expires
        uniformly for all three conditions).

--- a/src/autoskillit/cli/_update_checks_fetch.py
+++ b/src/autoskillit/cli/_update_checks_fetch.py
@@ -31,8 +31,8 @@ _HTTP_TIMEOUT = httpx.Timeout(connect=2.0, read=1.0, write=5.0, pool=1.0)
 _GITHUB_API_VERSION = "2022-11-28"
 
 _GITHUB_RELEASES_URL = "https://api.github.com/repos/TalonT-Org/AutoSkillit/releases/latest"
-_GITHUB_INTEGRATION_PYPROJECT_URL = (
-    "https://api.github.com/repos/TalonT-Org/AutoSkillit/contents/pyproject.toml?ref=integration"
+_GITHUB_DEVELOP_PYPROJECT_URL = (
+    "https://api.github.com/repos/TalonT-Org/AutoSkillit/contents/pyproject.toml?ref=develop"
 )
 
 
@@ -168,13 +168,13 @@ def _fetch_latest_version(target: str, home: Path) -> str | None:
     """Fetch the latest available version for the given target branch.
 
     ``target`` is either ``"releases/latest"`` (for stable/main installs) or
-    ``"integration"`` (for integration installs).
+    ``"develop"`` (for develop installs).
 
     Returns ``None`` on any network error or timeout.
     """
     try:
-        if target == "integration":
-            data = _fetch_with_cache(_GITHUB_INTEGRATION_PYPROJECT_URL, home=home)
+        if target == "develop":
+            data = _fetch_with_cache(_GITHUB_DEVELOP_PYPROJECT_URL, home=home)
             if data is None:
                 return None
             import base64

--- a/src/autoskillit/config/_config_dataclasses.py
+++ b/src/autoskillit/config/_config_dataclasses.py
@@ -77,7 +77,7 @@ class SafetyConfig:
     require_dry_walkthrough: bool = True
     test_gate_on_merge: bool = True
     protected_branches: list[str] = field(
-        default_factory=lambda: ["main", "integration", "stable"]
+        default_factory=lambda: ["main", "develop", "stable"]
     )
 
 

--- a/src/autoskillit/config/_config_dataclasses.py
+++ b/src/autoskillit/config/_config_dataclasses.py
@@ -76,9 +76,7 @@ class SafetyConfig:
     reset_guard_marker: str = ".autoskillit-workspace"
     require_dry_walkthrough: bool = True
     test_gate_on_merge: bool = True
-    protected_branches: list[str] = field(
-        default_factory=lambda: ["main", "develop", "stable"]
-    )
+    protected_branches: list[str] = field(default_factory=lambda: ["main", "develop", "stable"])
 
 
 @dataclass

--- a/src/autoskillit/config/defaults.yaml
+++ b/src/autoskillit/config/defaults.yaml
@@ -31,7 +31,7 @@ safety:
   test_gate_on_merge: true
   protected_branches:
     - main
-    - integration
+    - develop
     - stable
 
 read_db:
@@ -119,7 +119,7 @@ branching:
   default_base_branch: main
   promotion_target: main      # Canonical "done" branch for staged-label comparison.
                               # Override independently of default_base_branch when using
-                              # a multi-tier workflow (e.g. feature → integration → main).
+                              # a multi-tier workflow (e.g. feature → develop → main).
 
 ci:
   workflow: null  # Workflow filename to filter CI runs, e.g. "tests.yml"

--- a/src/autoskillit/hooks/branch_protection_guard.py
+++ b/src/autoskillit/hooks/branch_protection_guard.py
@@ -2,7 +2,7 @@
 """PreToolUse hook: branch protection guard for merge_worktree and push_to_remote.
 
 Reads AUTOSKILLIT_PROTECTED_BRANCHES env var (comma-separated, default:
-main,integration,stable). Denies tool calls that target a protected branch.
+main,develop,stable). Denies tool calls that target a protected branch.
 
 Matched tools:
   - merge_worktree: checks base_branch parameter
@@ -41,7 +41,7 @@ def main() -> None:
         return
 
     # Read protected branches from env (comma-separated)
-    env_val = os.environ.get("AUTOSKILLIT_PROTECTED_BRANCHES", "main,integration,stable")
+    env_val = os.environ.get("AUTOSKILLIT_PROTECTED_BRANCHES", "main,develop,stable")
     protected = [b.strip() for b in env_val.split(",") if b.strip()]
 
     if branch in protected:

--- a/src/autoskillit/recipes/bem-wrapper.yaml
+++ b/src/autoskillit/recipes/bem-wrapper.yaml
@@ -23,7 +23,7 @@ ingredients:
     required: true
   base_branch:
     description: "Base branch for dependency analysis"
-    default: "integration"
+    default: "develop"
 
 steps:
   refetch_issues:

--- a/src/autoskillit/recipes/campaigns/promote-to-main.yaml
+++ b/src/autoskillit/recipes/campaigns/promote-to-main.yaml
@@ -22,7 +22,7 @@ ingredients:
     required: true
   integration_branch:
     description: "Integration branch to promote"
-    default: "integration"
+    default: "develop"
   base_branch:
     description: "Target branch for promotion PR"
     default: "main"

--- a/src/autoskillit/recipes/implement-findings.yaml
+++ b/src/autoskillit/recipes/implement-findings.yaml
@@ -18,7 +18,7 @@ ingredients:
     required: true
   base_branch:
     description: "Target branch for implementation PRs"
-    default: "integration"
+    default: "develop"
   source_dir:
     description: "Source repository path"
     required: false

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -36,7 +36,7 @@ kitchen_rules:
     push_worktree_branch → create_conflict_pr → wait_for_conflict_ci → merge_conflict_pr)
     per plan part before advancing to the next part or PR."
   - "INTEGRATION BRANCH: Two distinct branches exist. inputs.base_branch is the
-    target branch that PRs point to (e.g. main, integration).
+    target branch that PRs point to (e.g. main, develop).
     context.integration_branch is the per-run batch branch
     (e.g. pr-batch/pr-merge-{ts}) created from base_branch for this pipeline run.
     All PR merges and worktree merges target context.integration_branch. The final

--- a/src/autoskillit/recipes/promote-to-main-wrapper.yaml
+++ b/src/autoskillit/recipes/promote-to-main-wrapper.yaml
@@ -18,7 +18,7 @@ kitchen_rules:
 ingredients:
   integration_branch:
     description: "Branch to promote (must exist ahead of base_branch). Must be a valid git branch name with no spaces or shell metacharacters."
-    default: "integration"
+    default: "develop"
   base_branch:
     description: "Target branch for the promotion PR. Must be a valid git branch name with no spaces or shell metacharacters."
     default: "main"

--- a/src/autoskillit/server/tools_ci_merge_queue.py
+++ b/src/autoskillit/server/tools_ci_merge_queue.py
@@ -36,7 +36,7 @@ async def toggle_auto_merge(
 
     Args:
         pr_number: PR number to re-enroll.
-        target_branch: Branch the merge queue targets (e.g. "integration").
+        target_branch: Branch the merge queue targets (e.g. "develop").
         cwd: Working directory for git remote resolution when repo is not provided.
         repo: Optional "owner/name" string. Inferred from git remote if empty.
         remote_url: Full GitHub remote URL. Parsed to owner/repo before inference.
@@ -107,7 +107,7 @@ async def enqueue_pr(
 
     Args:
         pr_number: PR number to enqueue.
-        target_branch: Branch the merge queue targets (e.g. "integration").
+        target_branch: Branch the merge queue targets (e.g. "develop").
         cwd: Working directory for git remote resolution when repo is not provided.
         auto_merge_available: Whether the repository allows auto-merge.
         repo: Optional "owner/name" string. Inferred from git remote if empty.
@@ -192,7 +192,7 @@ async def wait_for_merge_queue(
 
     Args:
         pr_number: PR number to monitor.
-        target_branch: Branch the merge queue targets (e.g. "integration").
+        target_branch: Branch the merge queue targets (e.g. "develop").
         cwd: Working directory for git remote resolution when repo is not provided.
         repo: Optional "owner/name" string. Inferred from git remote if empty.
         remote_url: Full GitHub remote URL (e.g. "https://github.com/owner/repo.git").

--- a/src/autoskillit/server/tools_clone.py
+++ b/src/autoskillit/server/tools_clone.py
@@ -196,7 +196,7 @@ async def push_to_remote(
 
     Args:
         clone_path: Absolute path to the clone directory to push from.
-        branch: Branch name to push (e.g. "integration").
+        branch: Branch name to push (e.g. "develop").
         source_dir: Source repo path (read-only URL lookup when remote_url is empty).
         remote_url: Pre-resolved upstream remote URL. When provided, source_dir is skipped.
         step_name: Optional YAML step key for wall-clock timing accumulation.

--- a/src/autoskillit/server/tools_git.py
+++ b/src/autoskillit/server/tools_git.py
@@ -36,7 +36,7 @@ async def merge_worktree(
 
     Args:
         worktree_path: Absolute path to the git worktree.
-        base_branch: Branch to merge into (e.g. "integration").
+        base_branch: Branch to merge into (e.g. "develop").
         step_name: Optional YAML step key for wall-clock timing accumulation.
 
     Never raises.

--- a/src/autoskillit/skills/sous-chef/SKILL.md
+++ b/src/autoskillit/skills/sous-chef/SKILL.md
@@ -377,7 +377,7 @@ headless session):
 ```bash
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner) &&
 OWNER=${REPO%%/*} && REPO_NAME=${REPO##*/} &&
-BRANCH="<base_branch>" &&    # substitute the PR's target branch (e.g. "main", "integration")
+BRANCH="<base_branch>" &&    # substitute the PR's target branch (e.g. "main", "develop")
 gh api graphql -f query="query {
   repository(owner:\"$OWNER\", name:\"$REPO_NAME\") {
     mergeQueue(branch:\"$BRANCH\") { id }

--- a/src/autoskillit/skills_extended/audit-impl/SKILL.md
+++ b/src/autoskillit/skills_extended/audit-impl/SKILL.md
@@ -38,7 +38,7 @@ requirements, scope creep, and unexpected changes. Produces a GO or NO GO verdic
   stable after merge_worktree destroys named refs); a branch name is also accepted for
   standalone invocations. A live worktree path is accepted for legacy use (Step 0 extracts
   the branch name automatically).
-- `base_branch` — branch to diff against (default: `integration`)
+- `base_branch` — branch to diff against (default: `develop`)
 - `conflict_report_paths` (optional) — comma-separated list of absolute paths to conflict
   resolution reports produced by `resolve-merge-conflicts`. When provided and non-empty,
   cross-reference resolution decisions against plan intent in Step 2.5.

--- a/src/autoskillit/skills_extended/make-groups/SKILL.md
+++ b/src/autoskillit/skills_extended/make-groups/SKILL.md
@@ -272,7 +272,7 @@ git checkout -b feature/{topic}
 
 Then run each group through the pipeline using the feature branch as `base_branch` for all
 `merge_worktree` calls. The `/autoskillit:audit-impl` skill accepts the manifest as input
-and audits all groups at once as the final gate before merging the feature branch to `integration`.
+and audits all groups at once as the final gate before merging the feature branch to `develop`.
 
 Use the `group-implementation` bundled workflow to automate this — it creates the feature
 branch, runs the group loop, and gates on audit before signalling merge-ready.

--- a/src/autoskillit/skills_extended/process-issues/SKILL.md
+++ b/src/autoskillit/skills_extended/process-issues/SKILL.md
@@ -229,7 +229,7 @@ Processing X issues:
      and fetches full content internally)
    - `issue_url`: the constructed issue URL
    - `run_name`: `"feature"` (implementation) or `"fix"` (remediation)
-   - `base_branch`: `"integration"` (or read `git rev-parse --abbrev-ref HEAD`)
+   - `base_branch`: `"develop"` (or read `git rev-parse --abbrev-ref HEAD`)
    - `open_pr`: `"true"`
    - `audit`: `"true"`
    - `review_approach`: `"false"`

--- a/src/autoskillit/skills_extended/promote-to-main/SKILL.md
+++ b/src/autoskillit/skills_extended/promote-to-main/SKILL.md
@@ -21,14 +21,14 @@ and creates a comprehensive promotion PR.
 /autoskillit:promote-to-main [integration_branch] [base_branch] [--dry-run]
 ```
 
-- `integration_branch` (optional) — source branch to promote. Defaults to `integration`.
+- `integration_branch` (optional) — source branch to promote. Defaults to `develop`.
 - `base_branch` (optional) — target branch. Defaults to `main`.
 - `--dry-run` — generate the full PR body without creating a PR.
 
 ## When to Use
 
-- When the integration branch is stable and ready to be promoted to main
-- After feature PRs, bug fixes, and cleanup work have been collected and tested on integration
+- When the develop branch is stable and ready to be promoted to main
+- After feature PRs, bug fixes, and cleanup work have been collected and tested on develop
 - This is the final gate before changes land on main
 
 ## Critical Constraints
@@ -70,7 +70,7 @@ bypassing the normal completion protocol.
 #### Step 0.1: Parse Arguments
 
 Parse optional positional arguments and flags:
-- `integration_branch` — default `"integration"` if absent or empty
+- `integration_branch` — default `"develop"` if absent or empty
 - `base_branch` — default `"main"` if absent or empty
 - `dry_run` — `true` if `--dry-run` present in ARGUMENTS
 

--- a/src/autoskillit/skills_extended/setup-project/SKILL.md
+++ b/src/autoskillit/skills_extended/setup-project/SKILL.md
@@ -185,9 +185,9 @@ Interactive config suggestion flow:
 3. Track approvals — do NOT write to disk yet
 4. Do NOT suggest `reset_guard_marker` — that's a workspace concern, not project setup
 5. Ask the user for their preferred default base branch:
-   > "What is your default base branch? (e.g., 'integration' for the 3-tier model, 'main' for the classic model)"
-   > Default: `integration`
-   If the user selects a value different from the package default (`integration`), add it to the config diff as:
+   > "What is your default base branch? (e.g., 'develop' for the 3-tier model, 'main' for the classic model)"
+   > Default: `develop`
+   If the user selects a value different from the package default (`develop`), add it to the config diff as:
    ```yaml
    branching:
      default_base_branch: {user_choice}

--- a/src/autoskillit/skills_extended/write-recipe/SKILL.md
+++ b/src/autoskillit/skills_extended/write-recipe/SKILL.md
@@ -314,7 +314,7 @@ ingredients:
     default: "."
   base_branch:
     description: Branch to merge into
-    default: integration
+    default: develop
 
 steps:
   plan:
@@ -400,7 +400,7 @@ ingredients:
     required: true
   base_branch:
     description: Branch to merge fixes into
-    default: integration
+    default: develop
   helper_dir:
     description: Directory for helper agent sessions
     required: true

--- a/src/autoskillit/workspace/clone.py
+++ b/src/autoskillit/workspace/clone.py
@@ -306,7 +306,7 @@ def push_to_remote(
             "error_type": "protected_branch_push",
             "stderr": (
                 f"Refusing to push to protected branch '{branch}'. "
-                f"Protected branches: {protected_branches or ['main', 'integration', 'stable']}"
+                f"Protected branches: {protected_branches or ['main', 'develop', 'stable']}"
             ),
         }
 

--- a/tests/cli/_update_checks_helpers.py
+++ b/tests/cli/_update_checks_helpers.py
@@ -18,11 +18,11 @@ def _make_stable_info(commit_id: str = "abc123", revision: str = "stable") -> In
     )
 
 
-def _make_integration_info(commit_id: str = "def456") -> InstallInfo:
+def _make_develop_info(commit_id: str = "def456") -> InstallInfo:
     return InstallInfo(
         install_type=InstallType.GIT_VCS,
         commit_id=commit_id,
-        requested_revision="integration",
+        requested_revision="develop",
         url="https://github.com/TalonT-Org/AutoSkillit.git",
         editable_source=None,
     )

--- a/tests/cli/test_cli_prompts.py
+++ b/tests/cli/test_cli_prompts.py
@@ -224,7 +224,7 @@ def test_show_cook_preview_uses_resolved_base_branch_for_smoke_test(monkeypatch,
     monkeypatch.setattr(api_mod, "_LOAD_CACHE", {})
     monkeypatch.setattr(
         "autoskillit.config.resolve_ingredient_defaults",
-        lambda _: {"base_branch": "integration"},
+        lambda _: {"base_branch": "develop"},
     )
 
     recipe_info = find_recipe_by_name("smoke-test", project_dir)
@@ -233,7 +233,7 @@ def test_show_cook_preview_uses_resolved_base_branch_for_smoke_test(monkeypatch,
 
     show_cook_preview("smoke-test", recipe, project_dir, project_dir)
     captured = capsys.readouterr()
-    assert "integration" in captured.out
+    assert "develop" in captured.out
     # base_branch row must NOT show the YAML literal "main"
     base_branch_lines = [line for line in captured.out.splitlines() if "base_branch" in line]
     assert base_branch_lines, "base_branch must appear in the rendered table"

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -1135,7 +1135,7 @@ def test_check_source_version_drift_ok_outside_source_repo(
     info = InstallInfo(
         install_type=InstallType.GIT_VCS,
         commit_id="abc1234",
-        requested_revision="integration",
+        requested_revision="develop",
         url=None,
         editable_source=None,
     )
@@ -1208,7 +1208,7 @@ def test_check_source_version_drift_ok_when_cache_empty(
     info = InstallInfo(
         install_type=InstallType.GIT_VCS,
         commit_id="installed123",
-        requested_revision="integration",
+        requested_revision="develop",
         url=None,
         editable_source=None,
     )
@@ -1239,7 +1239,7 @@ def test_check_source_version_drift_warning_on_drift(
     info = InstallInfo(
         install_type=InstallType.GIT_VCS,
         commit_id=installed_sha,
-        requested_revision="integration",
+        requested_revision="develop",
         url=None,
         editable_source=None,
     )

--- a/tests/cli/test_doctor_migration.py
+++ b/tests/cli/test_doctor_migration.py
@@ -184,7 +184,7 @@ class TestDoctorInstallClassification:
         "revision,expected_fragment",
         [
             ("stable", "stable"),
-            ("integration", "integration"),
+            ("develop", "develop"),
         ],
     )
     def test_doctor_reports_install_classification_git_vcs(

--- a/tests/cli/test_install_info.py
+++ b/tests/cli/test_install_info.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from autoskillit.cli._install_info import (
-    _INSTALL_FROM_INTEGRATION,
+    _INSTALL_FROM_DEVELOP,
     InstallInfo,
     InstallType,
     comparison_branch,
@@ -315,7 +315,7 @@ def test_upgrade_command_develop() -> None:
         "tool",
         "install",
         "--force",
-        _INSTALL_FROM_INTEGRATION,
+        _INSTALL_FROM_DEVELOP,
     ]
 
 

--- a/tests/cli/test_install_info.py
+++ b/tests/cli/test_install_info.py
@@ -60,13 +60,13 @@ def test_detect_install_git_vcs_stable(monkeypatch: pytest.MonkeyPatch) -> None:
     assert info.editable_source is None
 
 
-def test_detect_install_git_vcs_integration(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_detect_install_git_vcs_develop(monkeypatch: pytest.MonkeyPatch) -> None:
     payload = json.dumps(
         {
             "url": "https://github.com/TalonT-Org/AutoSkillit.git",
             "vcs_info": {
                 "vcs": "git",
-                "requested_revision": "integration",
+                "requested_revision": "develop",
                 "commit_id": "deadbeef0000",
             },
         }
@@ -77,7 +77,7 @@ def test_detect_install_git_vcs_integration(monkeypatch: pytest.MonkeyPatch) -> 
     )
     info = detect_install()
     assert info.install_type == InstallType.GIT_VCS
-    assert info.requested_revision == "integration"
+    assert info.requested_revision == "develop"
     assert info.commit_id == "deadbeef0000"
 
 
@@ -189,15 +189,15 @@ def test_comparison_branch_unknown_type() -> None:
     assert comparison_branch(info) == "releases/latest"
 
 
-def test_comparison_branch_integration() -> None:
+def test_comparison_branch_develop() -> None:
     info = InstallInfo(
         install_type=InstallType.GIT_VCS,
         commit_id="abc123",
-        requested_revision="integration",
+        requested_revision="develop",
         url=None,
         editable_source=None,
     )
-    assert comparison_branch(info) == "integration"
+    assert comparison_branch(info) == "develop"
 
 
 @pytest.mark.parametrize(
@@ -245,7 +245,7 @@ def test_dismissal_window_seven_days(
 @pytest.mark.parametrize(
     "requested_revision,install_type,editable_source",
     [
-        ("integration", InstallType.GIT_VCS, None),
+        ("develop", InstallType.GIT_VCS, None),
         (None, InstallType.LOCAL_EDITABLE, Path("/tmp/repo")),
     ],
 )
@@ -302,11 +302,11 @@ def test_upgrade_command_release_tag() -> None:
     assert upgrade_command(info) == ["uv", "tool", "upgrade", "autoskillit"]
 
 
-def test_upgrade_command_integration() -> None:
+def test_upgrade_command_develop() -> None:
     info = InstallInfo(
         install_type=InstallType.GIT_VCS,
         commit_id="abc123",
-        requested_revision="integration",
+        requested_revision="develop",
         url=None,
         editable_source=None,
     )

--- a/tests/cli/test_update_checks_fetch.py
+++ b/tests/cli/test_update_checks_fetch.py
@@ -906,7 +906,7 @@ def test_verify_update_result_prints_git_vcs_stable_command(
     assert "autoskillit update" in out
 
 
-def test_verify_update_result_prints_git_vcs_integration_command(
+def test_verify_update_result_prints_git_vcs_develop_command(
     tmp_path: Path, capsys: pytest.CaptureFixture
 ) -> None:
     import importlib.metadata

--- a/tests/cli/test_update_checks_fetch.py
+++ b/tests/cli/test_update_checks_fetch.py
@@ -17,7 +17,7 @@ from autoskillit.cli._update_checks_fetch import (
 )
 
 from ._update_checks_helpers import (
-    _make_integration_info,
+    _make_develop_info,
     _make_mock_client,
     _make_stable_info,
 )
@@ -435,7 +435,7 @@ def test_stale_fetch_cache_after_install_resolve_reference_sha_path2(
 
     from autoskillit.cli._update_checks import resolve_reference_sha
 
-    url = "https://api.github.com/repos/TalonT-Org/AutoSkillit/git/refs/heads/integration"
+    url = "https://api.github.com/repos/TalonT-Org/AutoSkillit/git/refs/heads/develop"
     stale_sha = "a" * 40
     fresh_sha = "b" * 40
 
@@ -443,7 +443,7 @@ def test_stale_fetch_cache_after_install_resolve_reference_sha_path2(
         url: {
             "body": {
                 "object": {"sha": stale_sha, "type": "commit"},
-                "ref": "refs/heads/integration",
+                "ref": "refs/heads/develop",
             },
             "etag": '"old-etag"',
             "cached_at": time.time() - 1,
@@ -472,12 +472,12 @@ def test_stale_fetch_cache_after_install_resolve_reference_sha_path2(
             r.status_code = 200
             r.json.return_value = {
                 "object": {"sha": fresh_sha, "type": "commit"},
-                "ref": "refs/heads/integration",
+                "ref": "refs/heads/develop",
             }
             r.headers = {"ETag": '"fresh-etag"'}
             return r
 
-    info = _make_integration_info(commit_id=stale_sha)
+    info = _make_develop_info(commit_id=stale_sha)
     with patch("httpx.Client", FreshClient):
         result = resolve_reference_sha(info, tmp_path)
 
@@ -604,10 +604,10 @@ def test_api_sha_with_seeded_cache_returns_cached_sha(tmp_path: Path) -> None:
     from autoskillit.core import AUTOSKILLIT_INSTALLED_VERSION
 
     sha = "c" * 40
-    url = "https://api.github.com/repos/TalonT-Org/AutoSkillit/git/refs/heads/integration"
+    url = "https://api.github.com/repos/TalonT-Org/AutoSkillit/git/refs/heads/develop"
     cache_data = {
         url: {
-            "body": {"object": {"sha": sha, "type": "commit"}, "ref": "refs/heads/integration"},
+            "body": {"object": {"sha": sha, "type": "commit"}, "ref": "refs/heads/develop"},
             "etag": '"test-etag"',
             "cached_at": time.time() - 1,
             "installed_version": AUTOSKILLIT_INSTALLED_VERSION,
@@ -632,7 +632,7 @@ def test_api_sha_with_seeded_cache_returns_cached_sha(tmp_path: Path) -> None:
             raise AssertionError("Should not hit network when epoch matches")
 
     with patch("httpx.Client", NoNetworkClient):
-        result = _api_sha("integration", tmp_path)
+        result = _api_sha("develop", tmp_path)
 
     assert result == sha
 
@@ -647,12 +647,12 @@ def test_api_sha_with_stale_epoch_forces_network(
 
     stale_sha = "d" * 40
     fresh_sha = "e" * 40
-    url = "https://api.github.com/repos/TalonT-Org/AutoSkillit/git/refs/heads/integration"
+    url = "https://api.github.com/repos/TalonT-Org/AutoSkillit/git/refs/heads/develop"
     cache_data = {
         url: {
             "body": {
                 "object": {"sha": stale_sha, "type": "commit"},
-                "ref": "refs/heads/integration",
+                "ref": "refs/heads/develop",
             },
             "etag": '"old-etag"',
             "cached_at": time.time() - 1,
@@ -682,13 +682,13 @@ def test_api_sha_with_stale_epoch_forces_network(
             r.status_code = 200
             r.json.return_value = {
                 "object": {"sha": fresh_sha, "type": "commit"},
-                "ref": "refs/heads/integration",
+                "ref": "refs/heads/develop",
             }
             r.headers = {"ETag": '"fresh-etag"'}
             return r
 
     with patch("httpx.Client", FreshClient):
-        result = _api_sha("integration", tmp_path)
+        result = _api_sha("develop", tmp_path)
 
     assert network_hit[0], "Stale epoch must force network fetch"
     assert result == fresh_sha
@@ -701,10 +701,10 @@ def test_api_sha_network_false_reads_raw_cache_no_epoch(tmp_path: Path) -> None:
     from autoskillit.cli._update_checks_source import _api_sha
 
     sha = "f" * 40
-    url = "https://api.github.com/repos/TalonT-Org/AutoSkillit/git/refs/heads/integration"
+    url = "https://api.github.com/repos/TalonT-Org/AutoSkillit/git/refs/heads/develop"
     cache_data = {
         url: {
-            "body": {"object": {"sha": sha, "type": "commit"}, "ref": "refs/heads/integration"},
+            "body": {"object": {"sha": sha, "type": "commit"}, "ref": "refs/heads/develop"},
             "etag": '"cached-etag"',
             "cached_at": time.time() - 1,
             "installed_version": "0.0.0",
@@ -715,7 +715,7 @@ def test_api_sha_network_false_reads_raw_cache_no_epoch(tmp_path: Path) -> None:
         json.dumps(cache_data), encoding="utf-8"
     )
 
-    result = _api_sha("integration", tmp_path, network=False)
+    result = _api_sha("develop", tmp_path, network=False)
     assert result == sha, "Doctor mode must read cache body regardless of epoch"
 
 
@@ -776,7 +776,7 @@ def test_full_lifecycle_install_clears_stale_cache_then_check_detects_new_versio
             "cached_at": time.time(),
             "installed_version": stale_version,
         },
-        "https://api.github.com/repos/TalonT-Org/AutoSkillit/git/refs/heads/integration": {
+        "https://api.github.com/repos/TalonT-Org/AutoSkillit/git/refs/heads/develop": {
             "body": {"object": {"sha": "a" * 40}},
             "etag": '"ref-etag"',
             "cached_at": time.time(),
@@ -913,7 +913,7 @@ def test_verify_update_result_prints_git_vcs_integration_command(
 
     from autoskillit.cli._update_checks import _verify_update_result
 
-    info = _make_integration_info()
+    info = _make_develop_info()
     with patch.object(importlib.metadata, "version", return_value="0.9.0"):
         result = _verify_update_result(info, "0.9.0", "0.9.1", tmp_path, {})
     assert result is False

--- a/tests/cli/test_update_checks_guards.py
+++ b/tests/cli/test_update_checks_guards.py
@@ -13,7 +13,7 @@ import pytest
 from autoskillit.cli._install_info import InstallInfo, InstallType
 from autoskillit.cli._update_checks import run_update_checks
 
-from ._update_checks_helpers import _make_integration_info, _make_stable_info
+from ._update_checks_helpers import _make_develop_info, _make_stable_info
 
 pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
 
@@ -209,19 +209,19 @@ def test_binary_signal_uses_releases_url_for_stable(
     assert targets == ["releases/latest"]
 
 
-def test_binary_signal_uses_integration_url_for_integration(
+def test_binary_signal_uses_develop_url_for_develop(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     from autoskillit.cli._update_checks import _binary_signal
 
-    info = _make_integration_info()
+    info = _make_develop_info()
     targets: list[str] = []
     monkeypatch.setattr(
         "autoskillit.cli._update_checks._fetch_latest_version",
         lambda target, home: targets.append(target) or "0.9.0",
     )
     _binary_signal(info, tmp_path, "0.7.77")
-    assert targets == ["integration"]
+    assert targets == ["develop"]
 
 
 def test_hooks_signal_fires_on_missing_hooks(

--- a/tests/cli/test_update_checks_prompt.py
+++ b/tests/cli/test_update_checks_prompt.py
@@ -21,7 +21,7 @@ from autoskillit.cli._update_checks import (
     run_update_checks,
 )
 
-from ._update_checks_helpers import _make_integration_info, _make_stable_info
+from ._update_checks_helpers import _make_develop_info, _make_stable_info
 
 pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
 
@@ -415,7 +415,7 @@ def test_integration_install_dismissal_silent_within_eleven_hours(
         monkeypatch,
         tmp_path,
         binary_signal=True,
-        info=_make_integration_info(),
+        info=_make_develop_info(),
         state=state,
     )
     run_update_checks(home=tmp_path)
@@ -430,7 +430,7 @@ def test_integration_install_dismissal_reprompts_after_thirteen_hours(
         monkeypatch,
         tmp_path,
         binary_signal=True,
-        info=_make_integration_info(),
+        info=_make_develop_info(),
         state=state,
     )
     run_update_checks(home=tmp_path)
@@ -448,7 +448,7 @@ def test_dismissal_window_chosen_from_current_install_not_stored(
         monkeypatch,
         tmp_path,
         binary_signal=True,
-        info=_make_integration_info(),
+        info=_make_develop_info(),
         state=state,
     )
     run_update_checks(home=tmp_path)

--- a/tests/cli/test_update_checks_prompt.py
+++ b/tests/cli/test_update_checks_prompt.py
@@ -407,7 +407,7 @@ def test_stable_install_dismissal_reprompts_after_eight_days(
     assert len(input_calls) == 1
 
 
-def test_integration_install_dismissal_silent_within_eleven_hours(
+def test_develop_install_dismissal_silent_within_eleven_hours(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     state = _dismissed_state(ago=timedelta(hours=11))
@@ -422,7 +422,7 @@ def test_integration_install_dismissal_silent_within_eleven_hours(
     assert not input_calls
 
 
-def test_integration_install_dismissal_reprompts_after_thirteen_hours(
+def test_develop_install_dismissal_reprompts_after_thirteen_hours(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     state = _dismissed_state(ago=timedelta(hours=13))

--- a/tests/cli/test_update_command.py
+++ b/tests/cli/test_update_command.py
@@ -83,7 +83,7 @@ def test_update_subcommand_registered_in_help() -> None:
         ("stable", ["uv", "tool", "upgrade", "autoskillit"]),
         ("main", ["uv", "tool", "upgrade", "autoskillit"]),
         ("v0.7.75", ["uv", "tool", "upgrade", "autoskillit"]),
-        ("integration", ["uv", "tool", "install", "--force"]),
+        ("develop", ["uv", "tool", "install", "--force"]),
     ],
 )
 def test_update_runs_upgrade_command_for_git_vcs_install(

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -29,7 +29,7 @@ class TestDefaultConfig:
         assert cfg.safety.test_gate_on_merge is True
         assert isinstance(cfg.safety.protected_branches, list)
         assert "main" in cfg.safety.protected_branches
-        assert "integration" in cfg.safety.protected_branches
+        assert "develop" in cfg.safety.protected_branches
         assert "stable" in cfg.safety.protected_branches
         assert cfg.worktree_setup.command is None
 
@@ -814,8 +814,8 @@ class TestBranchingConfig:
         """promotion_target can be set independently of default_base_branch."""
         from autoskillit.config.settings import BranchingConfig
 
-        cfg = BranchingConfig(default_base_branch="integration", promotion_target="main")
-        assert cfg.default_base_branch == "integration"
+        cfg = BranchingConfig(default_base_branch="develop", promotion_target="main")
+        assert cfg.default_base_branch == "develop"
         assert cfg.promotion_target == "main"
 
     def test_branching_config_promotion_target_defaults_match_yaml(self, tmp_path) -> None:

--- a/tests/core/test_branch_guard.py
+++ b/tests/core/test_branch_guard.py
@@ -6,12 +6,12 @@ from autoskillit.core.branch_guard import is_protected_branch
 
 pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
 
-_DEFAULTS = ["main", "integration", "stable"]
+_DEFAULTS = ["main", "develop", "stable"]
 
 # ---------- standard protected list ----------
 
 
-@pytest.mark.parametrize("branch", ["main", "integration", "stable"])
+@pytest.mark.parametrize("branch", ["main", "develop", "stable"])
 def test_default_protected_branches_are_rejected(branch: str) -> None:
     assert is_protected_branch(branch, protected=_DEFAULTS) is True
 

--- a/tests/execution/test_check_repo_merge_state.py
+++ b/tests/execution/test_check_repo_merge_state.py
@@ -187,7 +187,7 @@ async def test_push_trigger_branch_filter_excludes_feature_branch(httpx_mock):
               - main
               - stable
           pull_request:
-            branches: [main, integration, stable]
+            branches: [main, develop, stable]
     """)
     httpx_mock.add_response(
         url="https://api.github.com/graphql",
@@ -212,7 +212,7 @@ async def test_push_excluded_with_merge_group_present_returns_none(httpx_mock):
               - main
               - stable
           pull_request:
-            branches: [main, integration, stable]
+            branches: [main, develop, stable]
           merge_group:
     """)
     httpx_mock.add_response(

--- a/tests/execution/test_testing.py
+++ b/tests/execution/test_testing.py
@@ -634,14 +634,14 @@ async def test_default_test_runner_no_sidecar_means_no_filter_stats(tmp_path: Pa
 @pytest.mark.anyio
 async def test_resolve_base_ref_default_base_branch_fallback(tmp_path: Path) -> None:
     """AC5: When no config, sidecar, or upstream, default_base_branch is used."""
-    result = await _resolve_base_ref(None, tmp_path, default_base_branch="integration")
-    assert result == "integration"
+    result = await _resolve_base_ref(None, tmp_path, default_base_branch="develop")
+    assert result == "develop"
 
 
 @pytest.mark.anyio
 async def test_resolve_base_ref_config_wins_over_default_base_branch(tmp_path: Path) -> None:
     """Config base_ref takes precedence over default_base_branch."""
-    result = await _resolve_base_ref("origin/main", tmp_path, default_base_branch="integration")
+    result = await _resolve_base_ref("origin/main", tmp_path, default_base_branch="develop")
     assert result == "origin/main"
 
 
@@ -674,10 +674,10 @@ async def test_default_test_runner_passes_default_base_branch(
     config = make_test_config(
         test_check=make_test_check_config(filter_mode="conservative"),
     )
-    config.branching.default_base_branch = "integration"
+    config.branching.default_base_branch = "develop"
     runner = DefaultTestRunner(config=config, runner=capturing_runner)
     await runner.run(cwd=tmp_path)
-    assert captured_kwargs["env"].get("AUTOSKILLIT_TEST_BASE_REF") == "integration"
+    assert captured_kwargs["env"].get("AUTOSKILLIT_TEST_BASE_REF") == "develop"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/infra/test_branch_protection_guard.py
+++ b/tests/infra/test_branch_protection_guard.py
@@ -22,7 +22,7 @@ def _decision(out: dict) -> str | None:
 def _run_hook(tool_name: str, tool_input: dict, env_override: dict | None = None) -> dict:
     """Run the hook script with a tool call on stdin, return parsed JSON."""
     payload = json.dumps({"tool_name": tool_name, "tool_input": tool_input})
-    env = {**os.environ, "AUTOSKILLIT_PROTECTED_BRANCHES": "main,integration,stable"}
+    env = {**os.environ, "AUTOSKILLIT_PROTECTED_BRANCHES": "main,develop,stable"}
     if env_override:
         env.update(env_override)
     result = subprocess.run(
@@ -51,10 +51,10 @@ class TestMergeWorktreeGuard:
         )
         assert _decision(out) != "deny"
 
-    def test_denies_merge_into_integration(self) -> None:
+    def test_denies_merge_into_develop(self) -> None:
         out = _run_hook(
             "mcp__autoskillit__merge_worktree",
-            {"worktree_path": "/tmp/wt", "base_branch": "integration"},
+            {"worktree_path": "/tmp/wt", "base_branch": "develop"},
         )
         assert _decision(out) == "deny"
 
@@ -102,10 +102,10 @@ class TestCustomProtectedList:
         assert _decision(out) == "deny"
 
     def test_hook_allows_branch_not_in_custom_list(self) -> None:
-        """Hook allows write to integration when it is not in the injected list."""
+        """Hook allows write to develop when it is not in the injected list."""
         out = _run_hook(
             "mcp__autoskillit__merge_worktree",
-            {"worktree_path": "/tmp/wt", "base_branch": "integration"},
+            {"worktree_path": "/tmp/wt", "base_branch": "develop"},
             env_override={"AUTOSKILLIT_PROTECTED_BRANCHES": "main,release"},
         )
         assert _decision(out) != "deny"

--- a/tests/infra/test_ci_dev_config.py
+++ b/tests/infra/test_ci_dev_config.py
@@ -165,24 +165,24 @@ class TestCIWorkflow:
                         " from minor releases"
                     )
 
-    def test_ci_push_trigger_excludes_integration(self) -> None:
-        """Push trigger must NOT include integration — PRs from integration already
+    def test_ci_push_trigger_excludes_develop(self) -> None:
+        """Push trigger must NOT include develop — PRs from develop already
         get CI via pull_request trigger, and including it in push causes duplicate checks."""
         workflow = yaml.safe_load(CI_WORKFLOW.read_text())
         # PyYAML parses the YAML 'on:' key as Python True (boolean)
         triggers = workflow.get(True, workflow.get("on", {}))
         push_branches = triggers["push"]["branches"]
-        assert "integration" not in push_branches, (
-            "integration must not be in push branches — "
-            "it causes duplicate CI checks when a PR is open from integration"
+        assert "develop" not in push_branches, (
+            "develop must not be in push branches — "
+            "it causes duplicate CI checks when a PR is open from develop"
         )
 
-    def test_ci_pull_request_trigger_includes_integration(self) -> None:
-        """PR trigger must include integration so PRs targeting it get CI."""
+    def test_ci_pull_request_trigger_includes_develop(self) -> None:
+        """PR trigger must include develop so PRs targeting it get CI."""
         workflow = yaml.safe_load(CI_WORKFLOW.read_text())
         triggers = workflow.get(True, workflow.get("on", {}))
         pr_branches = triggers["pull_request"]["branches"]
-        assert "integration" in pr_branches, "CI must trigger on PRs targeting integration branch"
+        assert "develop" in pr_branches, "CI must trigger on PRs targeting develop branch"
 
     def test_ci_preflight_outputs_os_matrix(self) -> None:
         """preflight job must export an os-matrix output computed from base_ref."""

--- a/tests/infra/test_filter_activation.py
+++ b/tests/infra/test_filter_activation.py
@@ -16,11 +16,11 @@ def test_project_config_has_filter_mode_conservative():
 
 
 def test_project_config_has_base_ref():
-    """AC1: .autoskillit/config.yaml must set base_ref to integration."""
+    """AC1: .autoskillit/config.yaml must set base_ref to develop."""
     from autoskillit.core.io import load_yaml
 
     cfg = load_yaml(REPO_ROOT / ".autoskillit/config.yaml")
-    assert cfg["test_check"]["base_ref"] == "integration"
+    assert cfg["test_check"]["base_ref"] == "develop"
 
 
 def test_hook_registry_tests_in_infra():
@@ -52,7 +52,7 @@ def test_ci_filter_codepath_produces_scope():
         manifest=manifest,
         tests_root=REPO_ROOT / "tests",
         cwd=REPO_ROOT,
-        base_ref="integration",
+        base_ref="develop",
     )
     assert scope is not None, (
         "build_test_scope must return a non-None scope for conservative mode "

--- a/tests/infra/test_release_workflows.py
+++ b/tests/infra/test_release_workflows.py
@@ -12,9 +12,7 @@ import yaml
 
 REPO_ROOT = Path(__file__).parent.parent.parent
 VERSION_BUMP_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "version-bump.yml"
-PATCH_BUMP_DEVELOP_WORKFLOW = (
-    REPO_ROOT / ".github" / "workflows" / "patch-bump-develop.yml"
-)
+PATCH_BUMP_DEVELOP_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "patch-bump-develop.yml"
 RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release.yml"
 
 # ── helpers ───────────────────────────────────────────────────────────────────
@@ -187,9 +185,7 @@ class TestVersionBumpWorkflow:
         wf = _load(VERSION_BUMP_WORKFLOW)
         job = next(iter(wf.get("jobs", {}).values()))
         int_commit_step = _find_develop_commit_step(job)
-        assert int_commit_step is not None, (
-            "Workflow must have a develop version commit/push step"
-        )
+        assert int_commit_step is not None, "Workflow must have a develop version commit/push step"
         run_script = int_commit_step.get("run", "")
         assert "push --force" not in run_script
         assert "push -f " not in run_script
@@ -340,9 +336,7 @@ class TestPatchBumpDevelopWorkflow:
 
     def test_push_is_not_force_push(self):
         text = PATCH_BUMP_DEVELOP_WORKFLOW.read_text()
-        assert "--force" not in text, (
-            "patch-bump-develop.yml must not force-push to develop"
-        )
+        assert "--force" not in text, "patch-bump-develop.yml must not force-push to develop"
 
     def test_has_concurrency_group(self):
         """Workflow must declare a concurrency group to serialize merge-queue batches."""

--- a/tests/infra/test_release_workflows.py
+++ b/tests/infra/test_release_workflows.py
@@ -1,6 +1,6 @@
 """Structural contract tests for the release CI workflows.
 
-Ensures version-bump.yml, patch-bump-integration.yml, and release.yml are
+Ensures version-bump.yml, patch-bump-develop.yml, and release.yml are
 correctly shaped, guarded, and consistent with repo conventions.
 """
 
@@ -12,8 +12,8 @@ import yaml
 
 REPO_ROOT = Path(__file__).parent.parent.parent
 VERSION_BUMP_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "version-bump.yml"
-PATCH_BUMP_INTEGRATION_WORKFLOW = (
-    REPO_ROOT / ".github" / "workflows" / "patch-bump-integration.yml"
+PATCH_BUMP_DEVELOP_WORKFLOW = (
+    REPO_ROOT / ".github" / "workflows" / "patch-bump-develop.yml"
 )
 RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release.yml"
 
@@ -43,13 +43,13 @@ def _find_step(job: dict, name_fragment: str) -> dict | None:
     )
 
 
-def _find_integration_commit_step(job: dict) -> dict | None:
-    """Return the integration version commit/push step."""
+def _find_develop_commit_step(job: dict) -> dict | None:
+    """Return the develop version commit/push step."""
     return next(
         (
             s
             for s in job.get("steps", [])
-            if "integration version" in s.get("name", "").lower()
+            if "develop version" in s.get("name", "").lower()
             and ("commit" in s.get("name", "").lower() or "push" in s.get("name", "").lower())
         ),
         None,
@@ -80,15 +80,15 @@ class TestVersionBumpWorkflow:
             "version-bump.yml must not have a push trigger — it is PR-event-based"
         )
 
-    def test_job_has_integration_branch_guard(self):
-        """Job must only run when head.ref == 'integration'."""
+    def test_job_has_develop_branch_guard(self):
+        """Job must only run when head.ref == 'develop'."""
         wf = _load(VERSION_BUMP_WORKFLOW)
         jobs = wf.get("jobs", {})
         assert len(jobs) >= 1
         job = next(iter(jobs.values()))
         condition = job.get("if", "")
         assert "merged" in condition, "Job must check github.event.pull_request.merged"
-        assert "integration" in condition, "Job must guard on head.ref == 'integration'"
+        assert "develop" in condition, "Job must guard on head.ref == 'develop'"
 
     def test_contents_write_permission(self):
         wf = _load(VERSION_BUMP_WORKFLOW)
@@ -168,32 +168,32 @@ class TestVersionBumpWorkflow:
         ref = checkout_step.get("with", {}).get("ref", "")
         assert "main" in ref, "Checkout must use ref: main (not the default detached PR merge ref)"
 
-    def test_integration_checkout_step_exists(self):
+    def test_develop_checkout_step_exists(self):
         wf = _load(VERSION_BUMP_WORKFLOW)
         job = next(iter(wf.get("jobs", {}).values()))
-        assert _find_step(job, "Checkout integration branch") is not None
+        assert _find_step(job, "Checkout develop branch") is not None
 
-    def test_integration_read_version_step_exists(self):
+    def test_develop_read_version_step_exists(self):
         wf = _load(VERSION_BUMP_WORKFLOW)
         job = next(iter(wf.get("jobs", {}).values()))
-        assert _find_step(job, "Read integration current version") is not None
+        assert _find_step(job, "Read develop current version") is not None
 
-    def test_integration_commit_push_step_exists(self):
+    def test_develop_commit_push_step_exists(self):
         wf = _load(VERSION_BUMP_WORKFLOW)
         job = next(iter(wf.get("jobs", {}).values()))
-        assert _find_integration_commit_step(job) is not None
+        assert _find_develop_commit_step(job) is not None
 
-    def test_integration_push_is_not_force_push(self):
+    def test_develop_push_is_not_force_push(self):
         wf = _load(VERSION_BUMP_WORKFLOW)
         job = next(iter(wf.get("jobs", {}).values()))
-        int_commit_step = _find_integration_commit_step(job)
+        int_commit_step = _find_develop_commit_step(job)
         assert int_commit_step is not None, (
-            "Workflow must have an integration version commit/push step"
+            "Workflow must have a develop version commit/push step"
         )
         run_script = int_commit_step.get("run", "")
         assert "push --force" not in run_script
         assert "push -f " not in run_script
-        assert "integration" in run_script
+        assert "develop" in run_script
 
     def test_minor_version_bump_on_main(self):
         """version-bump.yml must increment MINOR and reset PATCH to 0 for main."""
@@ -205,14 +205,14 @@ class TestVersionBumpWorkflow:
         assert "$((MINOR + 1))" in run_block, "Must increment MINOR for main"
         assert ".$((MINOR + 1)).0" in run_block, "main version must end in .0"
 
-    def test_integration_reset_to_patch_one(self):
-        """version-bump.yml must set integration to X.(Y+1).1 after promotion."""
+    def test_develop_reset_to_patch_one(self):
+        """version-bump.yml must set develop to X.(Y+1).1 after promotion."""
         wf = _load(VERSION_BUMP_WORKFLOW)
         job = next(iter(wf.get("jobs", {}).values()))
         step = _find_step(job, "Compute new minor version")
         assert step is not None, "Workflow must have a 'Compute new minor version' step"
         run_block = step.get("run", "")
-        assert ".$((MINOR + 1)).1" in run_block, "integration version must end in .1"
+        assert ".$((MINOR + 1)).1" in run_block, "develop version must end in .1"
 
     def test_no_force_push(self):
         """version-bump.yml must not contain any force-push."""
@@ -224,93 +224,93 @@ class TestVersionBumpWorkflow:
     def test_no_branch_protection_api_calls(self):
         """version-bump.yml must not call the GitHub branch protection API."""
         text = VERSION_BUMP_WORKFLOW.read_text()
-        assert "branches/integration/protection" not in text, (
+        assert "branches/develop/protection" not in text, (
             "version-bump.yml must not manipulate branch protection — "
             "no force-push means no protection changes are needed"
         )
 
 
-# ── patch-bump-integration.yml ────────────────────────────────────────────────
+# ── patch-bump-develop.yml ────────────────────────────────────────────────────
 
 
-class TestPatchBumpIntegrationWorkflow:
+class TestPatchBumpDevelopWorkflow:
     def test_workflow_file_exists(self):
-        assert PATCH_BUMP_INTEGRATION_WORKFLOW.exists(), (
-            f"patch-bump-integration workflow not found at {PATCH_BUMP_INTEGRATION_WORKFLOW}"
+        assert PATCH_BUMP_DEVELOP_WORKFLOW.exists(), (
+            f"patch-bump-develop workflow not found at {PATCH_BUMP_DEVELOP_WORKFLOW}"
         )
 
-    def test_triggered_on_pull_request_closed_to_integration(self):
-        wf = _load(PATCH_BUMP_INTEGRATION_WORKFLOW)
+    def test_triggered_on_pull_request_closed_to_develop(self):
+        wf = _load(PATCH_BUMP_DEVELOP_WORKFLOW)
         pr_trigger = wf.get(True, {}).get("pull_request", {})
         assert "closed" in pr_trigger.get("types", [])
-        assert "integration" in pr_trigger.get("branches", [])
+        assert "develop" in pr_trigger.get("branches", [])
 
     def test_not_triggered_on_push(self):
-        wf = _load(PATCH_BUMP_INTEGRATION_WORKFLOW)
+        wf = _load(PATCH_BUMP_DEVELOP_WORKFLOW)
         assert "push" not in wf.get(True, {}), (
-            "patch-bump-integration.yml must not have a push trigger"
+            "patch-bump-develop.yml must not have a push trigger"
         )
 
     def test_job_has_merged_guard(self):
-        wf = _load(PATCH_BUMP_INTEGRATION_WORKFLOW)
+        wf = _load(PATCH_BUMP_DEVELOP_WORKFLOW)
         job = next(iter(wf.get("jobs", {}).values()))
         condition = job.get("if", "")
         assert "merged" in condition, "Job must check github.event.pull_request.merged"
 
     def test_contents_write_permission(self):
-        wf = _load(PATCH_BUMP_INTEGRATION_WORKFLOW)
+        wf = _load(PATCH_BUMP_DEVELOP_WORKFLOW)
         job = next(iter(wf.get("jobs", {}).values()))
         perms = job.get("permissions", {})
         assert perms.get("contents") == "write"
 
     def test_setup_uv_has_version_pin(self):
-        wf = _load(PATCH_BUMP_INTEGRATION_WORKFLOW)
+        wf = _load(PATCH_BUMP_DEVELOP_WORKFLOW)
         pins = _uv_version_pins(wf)
-        assert pins, "patch-bump-integration.yml must use astral-sh/setup-uv with a version pin"
+        assert pins, "patch-bump-develop.yml must use astral-sh/setup-uv with a version pin"
         assert all(p for p in pins)
 
     def test_uv_version_consistent_with_tests_yml(self):
         tests_wf = yaml.safe_load((REPO_ROOT / ".github" / "workflows" / "tests.yml").read_text())
-        bump_wf = _load(PATCH_BUMP_INTEGRATION_WORKFLOW)
+        bump_wf = _load(PATCH_BUMP_DEVELOP_WORKFLOW)
         tests_pins = _uv_version_pins(tests_wf)
         bump_pins = _uv_version_pins(bump_wf)
         assert tests_pins and bump_pins
         assert bump_pins[0] == tests_pins[0], (
-            f"uv-version in patch-bump-integration.yml ({bump_pins[0]}) must match "
+            f"uv-version in patch-bump-develop.yml ({bump_pins[0]}) must match "
             f"tests.yml ({tests_pins[0]})"
         )
 
     def test_pyproject_toml_is_updated(self):
-        wf = _load(PATCH_BUMP_INTEGRATION_WORKFLOW)
+        wf = _load(PATCH_BUMP_DEVELOP_WORKFLOW)
         job = next(iter(wf.get("jobs", {}).values()))
         step = _find_step(job, "Update pyproject.toml")
         assert step is not None, "Workflow must have an 'Update pyproject.toml' step"
         assert "pyproject.toml" in step.get("run", ""), "Update step must reference pyproject.toml"
 
     def test_patch_bump_workflow_uses_sync_versions_script(self):
-        wf = _load(PATCH_BUMP_INTEGRATION_WORKFLOW)
+        wf = _load(PATCH_BUMP_DEVELOP_WORKFLOW)
         job = next(iter(wf.get("jobs", {}).values()))
         sync_step = _find_step(job, "sync version")
         assert sync_step is not None, (
-            "patch-bump-integration.yml must have a 'Sync version artifacts' step"
+            "patch-bump-develop.yml must have a 'Sync version artifacts' step"
         )
         assert "sync_versions" in sync_step.get("run", ""), (
             "Sync step must call scripts/sync_versions.py"
         )
 
     def test_uv_lock_is_regenerated(self):
-        wf = _load(PATCH_BUMP_INTEGRATION_WORKFLOW)
+        wf = _load(PATCH_BUMP_DEVELOP_WORKFLOW)
         job = next(iter(wf.get("jobs", {}).values()))
         step = _find_step(job, "Regenerate uv.lock")
         assert step is not None, "Workflow must have a 'Regenerate uv.lock' step"
         assert "uv lock" in step.get("run", ""), "Regenerate step must run 'uv lock'"
 
     def test_uses_github_actions_bot_identity(self):
-        text = PATCH_BUMP_INTEGRATION_WORKFLOW.read_text()
+        text = PATCH_BUMP_DEVELOP_WORKFLOW.read_text()
         assert "github-actions[bot]" in text
 
-    def test_checkout_uses_integration_ref(self):
-        wf = _load(PATCH_BUMP_INTEGRATION_WORKFLOW)
+    def test_checkout_uses_develop_ref(self):
+        wf = _load(PATCH_BUMP_DEVELOP_WORKFLOW)
         job = next(iter(wf.get("jobs", {}).values()))
         checkout_step = next(
             (s for s in job.get("steps", []) if "actions/checkout" in s.get("uses", "")),
@@ -318,11 +318,11 @@ class TestPatchBumpIntegrationWorkflow:
         )
         assert checkout_step is not None
         ref = checkout_step.get("with", {}).get("ref", "")
-        assert "integration" in ref
+        assert "develop" in ref
 
     def test_patch_increment_logic(self):
         """Patch bump uses $((PATCH + 1)) arithmetic."""
-        wf = _load(PATCH_BUMP_INTEGRATION_WORKFLOW)
+        wf = _load(PATCH_BUMP_DEVELOP_WORKFLOW)
         job = next(iter(wf.get("jobs", {}).values()))
         step = _find_step(job, "Compute new patch version")
         assert step is not None, "Workflow must have a 'Compute new patch version' step"
@@ -331,7 +331,7 @@ class TestPatchBumpIntegrationWorkflow:
 
     def test_patch_increment_does_not_overflow_minor(self):
         """Patch bump must not touch MINOR."""
-        wf = _load(PATCH_BUMP_INTEGRATION_WORKFLOW)
+        wf = _load(PATCH_BUMP_DEVELOP_WORKFLOW)
         job = next(iter(wf.get("jobs", {}).values()))
         step = _find_step(job, "Compute new patch version")
         assert step is not None
@@ -339,32 +339,32 @@ class TestPatchBumpIntegrationWorkflow:
         assert "$((MINOR + 1))" not in run_block
 
     def test_push_is_not_force_push(self):
-        text = PATCH_BUMP_INTEGRATION_WORKFLOW.read_text()
+        text = PATCH_BUMP_DEVELOP_WORKFLOW.read_text()
         assert "--force" not in text, (
-            "patch-bump-integration.yml must not force-push to integration"
+            "patch-bump-develop.yml must not force-push to develop"
         )
 
     def test_has_concurrency_group(self):
         """Workflow must declare a concurrency group to serialize merge-queue batches."""
-        wf = _load(PATCH_BUMP_INTEGRATION_WORKFLOW)
+        wf = _load(PATCH_BUMP_DEVELOP_WORKFLOW)
         assert wf.get("concurrency") is not None, (
-            "patch-bump-integration.yml must declare a concurrency group — "
+            "patch-bump-develop.yml must declare a concurrency group — "
             "without it, batched merge queue PRs race and silently skip version bumps"
         )
 
     def test_concurrency_group_name(self):
         """Concurrency group name must be a fixed string (not PR-number-scoped)."""
-        wf = _load(PATCH_BUMP_INTEGRATION_WORKFLOW)
+        wf = _load(PATCH_BUMP_DEVELOP_WORKFLOW)
         concurrency = wf.get("concurrency", {})
         group = concurrency.get("group", "")
-        assert group == "patch-bump-integration", (
-            f"concurrency.group must be 'patch-bump-integration' (got {group!r}) — "
+        assert group == "patch-bump-develop", (
+            f"concurrency.group must be 'patch-bump-develop' (got {group!r}) — "
             "a fixed group name ensures all simultaneous batch runs queue behind one another"
         )
 
     def test_concurrency_cancel_in_progress_is_false(self):
         """cancel-in-progress must be false so every queued run executes its bump."""
-        wf = _load(PATCH_BUMP_INTEGRATION_WORKFLOW)
+        wf = _load(PATCH_BUMP_DEVELOP_WORKFLOW)
         concurrency = wf.get("concurrency", {})
         cancel = concurrency.get("cancel-in-progress", None)
         assert cancel is False, (

--- a/tests/infra/test_taskfile.py
+++ b/tests/infra/test_taskfile.py
@@ -54,12 +54,12 @@ class TestTaskfile:
         data = self._load()
         assert "install-dev" in data["tasks"], "install-dev task missing from Taskfile.yml"
 
-    def test_install_dev_task_uses_integration_branch(self):
-        """TF-7 — install-dev installs from @integration and runs autoskillit install."""
+    def test_install_dev_task_uses_develop_branch(self):
+        """TF-7 — install-dev installs from @develop and runs autoskillit install."""
         data = self._load()
         task = data["tasks"]["install-dev"]
         cmds = " ".join(str(c) for c in task.get("cmds", []))
-        assert "@integration" in cmds, "install-dev must install from @integration branch"
+        assert "@develop" in cmds, "install-dev must install from @develop branch"
         assert "autoskillit install" in cmds, "install-dev must run autoskillit install after uv"
 
     def test_vendor_mermaid_task_exists(self) -> None:

--- a/tests/recipe/test_api.py
+++ b/tests/recipe/test_api.py
@@ -594,8 +594,8 @@ def test_build_ingredient_rows_resolved_overrides_literal_default():
         "base_branch",
         RecipeIngredient(description="Base branch", default="main"),
     )
-    rows = build_ingredient_rows(recipe, resolved_defaults={"base_branch": "integration"})
-    assert ("base_branch", "Base branch", "integration") in rows
+    rows = build_ingredient_rows(recipe, resolved_defaults={"base_branch": "develop"})
+    assert ("base_branch", "Base branch", "develop") in rows
 
 
 def test_build_ingredient_rows_literal_default_preserved_when_no_resolved():
@@ -620,8 +620,8 @@ def test_build_ingredient_rows_resolved_overrides_empty_sentinel():
         "base_branch",
         RecipeIngredient(description="Base branch", default=""),
     )
-    rows = build_ingredient_rows(recipe, resolved_defaults={"base_branch": "integration"})
-    assert ("base_branch", "Base branch", "integration") in rows
+    rows = build_ingredient_rows(recipe, resolved_defaults={"base_branch": "develop"})
+    assert ("base_branch", "Base branch", "develop") in rows
 
 
 def test_build_ingredient_rows_empty_sentinel_falls_back_to_auto_detect():

--- a/tests/recipe/test_bem_wrapper_structure.py
+++ b/tests/recipe/test_bem_wrapper_structure.py
@@ -34,7 +34,7 @@ def test_bem_wrapper_ingredients_declared():
     assert "issue_urls" in recipe.ingredients
     assert recipe.ingredients["issue_urls"].required is True
     assert "base_branch" in recipe.ingredients
-    assert recipe.ingredients["base_branch"].default == "integration"
+    assert recipe.ingredients["base_branch"].default == "develop"
 
 
 def test_bem_wrapper_routing_chain():

--- a/tests/recipe/test_implement_findings_recipe.py
+++ b/tests/recipe/test_implement_findings_recipe.py
@@ -52,7 +52,7 @@ def test_implement_findings_issue_urls_required(recipe) -> None:
 
 # T5
 def test_implement_findings_base_branch_default(recipe) -> None:
-    assert recipe.ingredients["base_branch"].default == "integration"
+    assert recipe.ingredients["base_branch"].default == "develop"
 
 
 # T6

--- a/tests/server/test_release_issue_fail_label.py
+++ b/tests/server/test_release_issue_fail_label.py
@@ -51,7 +51,7 @@ class TestReleaseIssueFailLabel:
         result = json.loads(
             await release_issue(
                 issue_url="https://github.com/owner/repo/issues/42",
-                target_branch="integration",
+                target_branch="develop",
             )
         )
 

--- a/tests/server/test_tools_ci.py
+++ b/tests/server/test_tools_ci.py
@@ -283,13 +283,13 @@ async def test_delegates_to_merge_queue_watcher(tool_ctx):
         mock_proc.return_value = proc_inst
 
         result = json.loads(
-            await wait_for_merge_queue(pr_number=42, target_branch="integration", cwd=".")
+            await wait_for_merge_queue(pr_number=42, target_branch="develop", cwd=".")
         )
 
     assert result["pr_state"] == "merged"
     assert len(watcher.wait_calls) == 1
     assert watcher.wait_calls[-1]["pr_number"] == 42
-    assert watcher.wait_calls[-1]["target_branch"] == "integration"
+    assert watcher.wait_calls[-1]["target_branch"] == "develop"
 
 
 @pytest.mark.anyio

--- a/tests/server/test_tools_integrations_release.py
+++ b/tests/server/test_tools_integrations_release.py
@@ -23,7 +23,7 @@ class TestReleaseIssueStagedLifecycle:
         result = json.loads(
             await release_issue(
                 issue_url="https://github.com/owner/repo/issues/42",
-                target_branch="integration",
+                target_branch="develop",
             )
         )
         assert result["success"] is True
@@ -83,7 +83,7 @@ class TestReleaseIssueStagedLifecycle:
         result = json.loads(
             await release_issue(
                 issue_url="https://github.com/owner/repo/issues/42",
-                target_branch="integration",
+                target_branch="develop",
             )
         )
         assert result["success"] is True
@@ -102,7 +102,7 @@ class TestReleaseIssueStagedLifecycle:
         result = json.loads(
             await release_issue(
                 issue_url="https://github.com/owner/repo/issues/42",
-                target_branch="integration",
+                target_branch="develop",
                 staged_label="awaiting-promotion",
             )
         )
@@ -126,7 +126,7 @@ class TestReleaseIssueStagedLifecycle:
         result = json.loads(
             await release_issue(
                 issue_url="https://github.com/owner/repo/issues/42",
-                target_branch="integration",
+                target_branch="develop",
             )
         )
         assert result["success"] is False
@@ -143,7 +143,7 @@ class TestReleaseIssueStagedLifecycle:
         result = json.loads(
             await release_issue(
                 issue_url="https://github.com/owner/repo/issues/42",
-                target_branch="integration",
+                target_branch="develop",
             )
         )
         assert result["success"] is False
@@ -167,15 +167,15 @@ class TestReleaseIssueStagedLifecycle:
     @pytest.mark.parametrize(
         "default_base_branch,promotion_target,target_branch,expected_staged",
         [
-            # production scenario: default_base_branch overridden to integration for routing
-            ("integration", "main", "integration", True),
-            # integration explicitly set as promotion_target: landing there = done
-            ("integration", "integration", "integration", False),
+            # production scenario: default_base_branch overridden to develop for routing
+            ("develop", "main", "develop", True),
+            # develop explicitly set as promotion_target: landing there = done
+            ("develop", "develop", "develop", False),
             # non-default target against main promotion target
-            ("main", "main", "integration", True),
+            ("main", "main", "develop", True),
             # promotion_target overridden to something other than main
             ("main", "stable", "stable", False),
-            ("main", "stable", "integration", True),
+            ("main", "stable", "develop", True),
         ],
     )
     async def test_release_issue_staging_uses_promotion_target(
@@ -189,7 +189,7 @@ class TestReleaseIssueStagedLifecycle:
     ):
         """Regression: staging comparison uses promotion_target, not default_base_branch.
 
-        When default_base_branch == target_branch (e.g. both "integration"),
+        When default_base_branch == target_branch (e.g. both "develop"),
         staged label must still be applied if promotion_target != target_branch.
         Conversely, no staged label when target_branch == promotion_target, regardless
         of default_base_branch.
@@ -235,7 +235,7 @@ class TestReleaseIssueStagedLifecycle:
         result = json.loads(
             await release_issue(
                 issue_url="https://github.com/owner/repo/issues/42",
-                target_branch="integration",
+                target_branch="develop",
             )
         )
         assert result["success"] is True

--- a/tests/server/test_tools_kitchen_envelope.py
+++ b/tests/server/test_tools_kitchen_envelope.py
@@ -194,7 +194,7 @@ async def test_open_kitchen_smoke_test_renders_resolved_base_branch(monkeypatch)
     monkeypatch.setattr(api_mod, "_LOAD_CACHE", {})
     monkeypatch.setattr(
         "autoskillit.server.tools_kitchen.resolve_ingredient_defaults",
-        lambda _: {"base_branch": "integration"},
+        lambda _: {"base_branch": "develop"},
     )
 
     mock_ctx = _make_mock_ctx()
@@ -215,7 +215,7 @@ async def test_open_kitchen_smoke_test_renders_resolved_base_branch(monkeypatch)
     assert parsed["success"] is True
     ing_table = parsed.get("ingredients_table") or ""
     assert ing_table, "ingredients_table must be present and non-empty"
-    assert "integration" in ing_table
+    assert "develop" in ing_table
     # base_branch row must NOT show the YAML literal "main"
     base_branch_rows = [line for line in ing_table.splitlines() if "base_branch" in line]
     assert base_branch_rows, "base_branch row must appear in ingredients_table"

--- a/tests/server/test_tools_label_validation.py
+++ b/tests/server/test_tools_label_validation.py
@@ -83,7 +83,7 @@ class TestReleaseIssueWhitelist:
         result = json.loads(
             await release_issue(
                 issue_url="https://github.com/owner/repo/issues/1",
-                target_branch="integration",
+                target_branch="develop",
                 staged_label="unlisted-staged",
             )
         )

--- a/tests/skills/test_analyze_prs_contracts.py
+++ b/tests/skills/test_analyze_prs_contracts.py
@@ -15,11 +15,11 @@ def skill_text() -> str:
 
 
 def test_analyze_prs_batch_branch_uses_pr_batch_prefix(skill_text: str) -> None:
-    """Batch branch name must use pr-batch/pr-merge- prefix, not integration/ prefix.
+    """Batch branch name must use pr-batch/pr-merge- prefix, not develop/ prefix.
 
-    The permanent integration branch is named 'integration'. Git cannot have
-    both a branch named 'integration' and branches named 'integration/*' —
-    the slash-prefix requires 'integration' to be a directory, not a file.
+    The permanent develop branch is named 'develop'. Git cannot have
+    both a branch named 'develop' and branches named 'develop/*' —
+    the slash-prefix requires 'develop' to be a directory, not a file.
     Batch branches must use a disjoint prefix (pr-batch/).
 
     We require 'pr-batch/pr-merge-' (not just 'pr-batch/') to anchor the check
@@ -27,22 +27,22 @@ def test_analyze_prs_batch_branch_uses_pr_batch_prefix(skill_text: str) -> None:
     """
     assert "pr-batch/pr-merge-" in skill_text, (
         "analyze-prs must use 'pr-batch/pr-merge-{ts}' naming for integration_branch — "
-        "using 'integration/' prefix conflicts with the permanent 'integration' branch"
+        "using 'develop/' prefix conflicts with the permanent 'develop' branch"
     )
 
 
-def test_analyze_prs_does_not_use_integration_slash_prefix(skill_text: str) -> None:
-    """SKILL.md must not compute batch branch names with integration/ prefix.
+def test_analyze_prs_does_not_use_develop_slash_prefix(skill_text: str) -> None:
+    """SKILL.md must not compute batch branch names with develop/ prefix.
 
     The original check only caught 'integration/pr-merge'; it would miss other
-    integration/-prefixed patterns such as 'integration/batch-...' or
-    'integration/run-...'.  Checking for the bare 'integration/' substring
-    prohibits all such patterns while still allowing mentions of 'integration'
+    develop/-prefixed patterns such as 'develop/batch-...' or
+    'develop/run-...'.  Checking for the bare 'develop/' substring
+    prohibits all such patterns while still allowing mentions of 'develop'
     (the permanent branch name) without a trailing slash.
     """
-    assert "integration/" not in skill_text, (
-        "analyze-prs must not use integration/ as a batch branch prefix in any context — "
-        "this conflicts with the permanent 'integration' branch in git ref storage"
+    assert "develop/" not in skill_text, (
+        "analyze-prs must not use develop/ as a batch branch prefix in any context — "
+        "this conflicts with the permanent 'develop' branch in git ref storage"
     )
 
 

--- a/tests/workspace/test_clone.py
+++ b/tests/workspace/test_clone.py
@@ -846,7 +846,7 @@ class TestDetectUncommittedChanges:
 class TestPushToRemoteProtectedBranch:
     """push_to_remote rejects pushes to protected branches."""
 
-    @pytest.mark.parametrize("branch", ["main", "integration", "stable"])
+    @pytest.mark.parametrize("branch", ["main", "develop", "stable"])
     def test_push_to_remote_rejects_protected_branch(self, tmp_path: Path, branch: str) -> None:
         """push_to_remote must reject when branch is a protected branch."""
         clone = tmp_path / "clone"
@@ -856,7 +856,7 @@ class TestPushToRemoteProtectedBranch:
             clone_path=str(clone),
             branch=branch,
             remote_url="https://github.com/example/repo.git",
-            protected_branches=["main", "integration", "stable"],
+            protected_branches=["main", "develop", "stable"],
         )
 
         assert result["success"] is False


### PR DESCRIPTION
## Summary

Rename all hardcoded references to the persistent `"integration"` branch name to `"develop"` across source code defaults, CI workflows, configuration, skills, tests, and documentation. The CI workflow file `patch-bump-integration.yml` is also renamed to `patch-bump-develop.yml`. Conceptual uses (skill names like `open-integration-pr`, recipe step identifiers, context variables, function parameters, Mermaid CSS classes) are explicitly excluded.

Closes #726

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260502-081940-535268/.autoskillit/temp/make-plan/rename_integration_to_develop_plan_2026-05-02_082500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 8.3k | 10.7k | 941.3k | 74.7k | 1 | 9m 10s |
| verify | 61 | 17.1k | 2.9M | 82.8k | 1 | 8m 19s |
| implement | 92 | 30.3k | 3.3M | 225.8k | 1 | 15m 24s |
| prepare_pr | 22 | 8.5k | 110.8k | 37.9k | 1 | 2m 22s |
| compose_pr | 22 | 1.3k | 133.6k | 19.6k | 1 | 32s |
| review_pr | 2.2k | 9.9k | 1.3M | 83.0k | 1 | 11m 11s |
| resolve_review | 30 | 6.2k | 521.4k | 41.1k | 1 | 5m 55s |
| **Total** | 10.7k | 84.0k | 9.2M | 564.8k | | 52m 55s |
## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 0 | — | — | — |
| fix | 4 | 183186.8 | 11123.2 | 889.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **4** | 2032137.8 | 121303.8 | 17856.8 |