### PR TITLE
Implementation Plan: Install-Context Gating for Experimental Features

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,7 @@ generic_automation_mcp/
 │   ├── kitchen_state.py     #   Kitchen-open session marker (stdlib-only; readable from hooks)
 │   ├── _plugin_cache.py     #   Plugin cache lifecycle: retiring cache, install locking, kitchen registry
 │   ├── _plugin_ids.py       #   DIRECT_PREFIX, MARKETPLACE_PREFIX, detect_autoskillit_mcp_prefix (stdlib-only)
+│   ├── _install_detect.py   #   is_dev_install() — editable-install detection for config resolution (IL-0)
 │   ├── feature_flags.py     #   is_feature_enabled() — IL-0 feature gate resolution primitive
 │   ├── readiness.py         #   Filesystem readiness sentinel primitives for MCP server startup (IL-0)
 │   ├── session_registry.py  #   Session registry: maps autoskillit launch IDs to Claude Code session UUIDs

--- a/src/autoskillit/config/defaults.yaml
+++ b/src/autoskillit/config/defaults.yaml
@@ -276,5 +276,4 @@ fleet:
   default_timeout_sec: 3600
   max_concurrent_dispatches: 1
 
-features:
-  experimental_enabled: true
+features: {}

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -156,7 +156,9 @@ class AutomationConfig:
         Coerces all values to bool.
         """
         raw = dict(raw)  # copy to avoid mutating caller's dict
-        _raw_exp = raw.pop("experimental_enabled", raw.pop("EXPERIMENTAL_ENABLED", _UNSET))
+        _raw_exp = raw.pop("experimental_enabled", _UNSET)
+        if _raw_exp is _UNSET:
+            _raw_exp = raw.pop("EXPERIMENTAL_ENABLED", _UNSET)
         experimental_enabled: bool = is_dev_install() if _raw_exp is _UNSET else bool(_raw_exp)
         result: dict[str, bool] = {}
         for name, value in raw.items():

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -156,7 +156,7 @@ class AutomationConfig:
         Coerces all values to bool.
         """
         raw = dict(raw)  # copy to avoid mutating caller's dict
-        _raw_exp = raw.pop("experimental_enabled", _UNSET)
+        _raw_exp = raw.pop("experimental_enabled", raw.pop("EXPERIMENTAL_ENABLED", _UNSET))
         experimental_enabled: bool = is_dev_install() if _raw_exp is _UNSET else bool(_raw_exp)
         result: dict[str, bool] = {}
         for name, value in raw.items():

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -58,6 +58,7 @@ from autoskillit.core import (
     atomic_write,
     dump_yaml_str,
     get_logger,
+    is_dev_install,
     is_feature_enabled,
 )
 
@@ -65,6 +66,8 @@ if TYPE_CHECKING:
     from dynaconf import Dynaconf
 
 logger = get_logger(__name__)
+
+_UNSET = object()
 
 __all__ = [
     "AutomationConfig",
@@ -153,7 +156,8 @@ class AutomationConfig:
         Coerces all values to bool.
         """
         raw = dict(raw)  # copy to avoid mutating caller's dict
-        experimental_enabled: bool = bool(raw.pop("experimental_enabled", False))
+        _raw_exp = raw.pop("experimental_enabled", _UNSET)
+        experimental_enabled: bool = is_dev_install() if _raw_exp is _UNSET else bool(_raw_exp)
         result: dict[str, bool] = {}
         for name, value in raw.items():
             if not isinstance(name, str):

--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -1,4 +1,5 @@
 from ._claude_env import build_claude_env as build_claude_env
+from ._install_detect import is_dev_install as is_dev_install
 from ._linux_proc import read_boot_id as read_boot_id
 from ._linux_proc import read_starttime_ticks as read_starttime_ticks
 from ._plugin_cache import _InstallLock as _InstallLock

--- a/src/autoskillit/core/_install_detect.py
+++ b/src/autoskillit/core/_install_detect.py
@@ -1,0 +1,38 @@
+"""Install-type detection for feature gating — IL-0 (zero autoskillit imports).
+
+is_dev_install() is the canonical predicate for determining whether the
+current autoskillit install is a development (editable) install. Used by
+config resolution to auto-detect the experimental_enabled default.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+logger = logging.getLogger(__name__)  # noqa: TID251 — IL-0 module, no autoskillit imports allowed
+
+
+def is_dev_install() -> bool:
+    """Return True if autoskillit is installed in editable (development) mode.
+
+    Reads direct_url.json from package metadata — the same mechanism used
+    by _version_snapshot._install_info() and cli._install_info.detect_install().
+
+    Returns False on any error (missing metadata, malformed JSON, etc.).
+    """
+    try:
+        import importlib.metadata
+
+        dist = importlib.metadata.Distribution.from_name("autoskillit")
+        raw = dist.read_text("direct_url.json")
+        if not raw:
+            return False
+        data = json.loads(raw)
+        dir_info = data.get("dir_info", {})
+        if isinstance(dir_info, dict) and dir_info.get("editable") is True:
+            return True
+        return False
+    except Exception:
+        logger.debug("install type detection failed", exc_info=True)
+        return False

--- a/src/autoskillit/core/_install_detect.py
+++ b/src/autoskillit/core/_install_detect.py
@@ -1,9 +1,4 @@
-"""Install-type detection for feature gating — IL-0 (zero autoskillit imports).
-
-is_dev_install() is the canonical predicate for determining whether the
-current autoskillit install is a development (editable) install. Used by
-config resolution to auto-detect the experimental_enabled default.
-"""
+"""Install-type detection for feature gating — IL-0."""
 
 from __future__ import annotations
 
@@ -14,13 +9,7 @@ logger = logging.getLogger(__name__)  # noqa: TID251 — IL-0 module, no autoski
 
 
 def is_dev_install() -> bool:
-    """Return True if autoskillit is installed in editable (development) mode.
-
-    Reads direct_url.json from package metadata — the same mechanism used
-    by _version_snapshot._install_info() and cli._install_info.detect_install().
-
-    Returns False on any error (missing metadata, malformed JSON, etc.).
-    """
+    """Return True if installed in editable mode; False on any error."""
     try:
         import importlib.metadata
 

--- a/tests/arch/test_feature_registry.py
+++ b/tests/arch/test_feature_registry.py
@@ -417,13 +417,43 @@ def test_build_features_dict_extracts_experimental_enabled():
     assert "experimental_enabled" not in result
 
 
-def test_build_features_dict_experimental_enabled_defaults_false():
-    """_build_features_dict returns experimental_enabled=False when key absent."""
+def test_build_features_dict_absent_experimental_enabled_auto_detects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_build_features_dict calls is_dev_install() when experimental_enabled absent."""
     from autoskillit.config.settings import AutomationConfig
 
+    monkeypatch.setattr("autoskillit.config.settings.is_dev_install", lambda: True)
+    result, exp_enabled = AutomationConfig._build_features_dict({})
+    assert exp_enabled is True
+    assert result == {}
+
+    monkeypatch.setattr("autoskillit.config.settings.is_dev_install", lambda: False)
     result, exp_enabled = AutomationConfig._build_features_dict({})
     assert exp_enabled is False
     assert result == {}
+
+
+def test_build_features_dict_explicit_true_overrides_auto_detect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_build_features_dict returns True when explicit True, ignoring is_dev_install."""
+    from autoskillit.config.settings import AutomationConfig
+
+    monkeypatch.setattr("autoskillit.config.settings.is_dev_install", lambda: False)
+    _, exp_enabled = AutomationConfig._build_features_dict({"experimental_enabled": True})
+    assert exp_enabled is True
+
+
+def test_build_features_dict_explicit_false_overrides_auto_detect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_build_features_dict returns False when explicit False, ignoring is_dev_install."""
+    from autoskillit.config.settings import AutomationConfig
+
+    monkeypatch.setattr("autoskillit.config.settings.is_dev_install", lambda: True)
+    _, exp_enabled = AutomationConfig._build_features_dict({"experimental_enabled": False})
+    assert exp_enabled is False
 
 
 def test_build_config_schema_accepts_experimental_enabled():
@@ -437,29 +467,103 @@ def test_build_config_schema_accepts_experimental_enabled():
     )
 
 
-# ── T4: defaults.yaml ships experimental_enabled: true ─────────────────────
+# ── T4: defaults.yaml omits experimental_enabled ────────────────────────────
 
 
-def test_defaults_yaml_has_experimental_enabled_true():
-    """Package defaults.yaml sets experimental_enabled=true; no per-feature entries."""
+def test_defaults_yaml_omits_experimental_enabled():
+    """Package defaults.yaml omits experimental_enabled; no per-feature entries."""
     import yaml
 
     from autoskillit.core.paths import pkg_root
 
     defaults = yaml.safe_load((pkg_root() / "config" / "defaults.yaml").read_text())
     features = defaults.get("features", {})
-    assert features.get("experimental_enabled") is True
+    assert "experimental_enabled" not in features
     assert "fleet" not in features, "fleet entry removed from defaults.yaml"
     assert "planner" not in features, "planner entry removed from defaults.yaml"
 
 
-def test_load_config_integration_experimental_enabled(tmp_path):
-    """load_config resolves cfg.experimental_enabled=True from defaults.yaml."""
-    import os
-    from unittest.mock import patch
+def test_load_config_integration_experimental_auto_detects(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """load_config auto-detects experimental_enabled via is_dev_install when unset."""
+    from autoskillit.config.settings import load_config
+
+    monkeypatch.setattr("autoskillit.config.settings.is_dev_install", lambda: True)
+    cfg = load_config(tmp_path)
+    assert cfg.experimental_enabled is True
+
+    monkeypatch.setattr("autoskillit.config.settings.is_dev_install", lambda: False)
+    cfg = load_config(tmp_path)
+    assert cfg.experimental_enabled is False
+
+
+# ── T3: integration tests for install-context gating ───────────────────────
+
+
+def test_load_config_non_dev_install_experimental_disabled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """load_config defaults experimental_enabled=False for non-dev install."""
+    from autoskillit.config.settings import load_config
+
+    monkeypatch.setattr("autoskillit.config.settings.is_dev_install", lambda: False)
+    cfg = load_config(tmp_path)
+    assert cfg.experimental_enabled is False
+
+
+def test_load_config_dev_install_experimental_enabled(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """load_config defaults experimental_enabled=True for editable dev install."""
+    from autoskillit.config.settings import load_config
+
+    monkeypatch.setattr("autoskillit.config.settings.is_dev_install", lambda: True)
+    cfg = load_config(tmp_path)
+    assert cfg.experimental_enabled is True
+
+
+def test_env_var_override_beats_auto_detect(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    """AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED=true overrides non-dev auto-detect."""
+    from autoskillit.config.settings import load_config
+
+    monkeypatch.setattr("autoskillit.config.settings.is_dev_install", lambda: False)
+    monkeypatch.setenv("AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED", "true")
+    cfg = load_config(tmp_path)
+    assert cfg.experimental_enabled is True
+
+
+def test_project_config_override_beats_auto_detect(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """Project config experimental_enabled=true overrides non-dev auto-detect."""
+    import yaml
 
     from autoskillit.config.settings import load_config
 
-    with patch.dict(os.environ, {}, clear=False):
-        cfg = load_config(tmp_path)
+    monkeypatch.setattr("autoskillit.config.settings.is_dev_install", lambda: False)
+    config_dir = tmp_path / ".autoskillit"
+    config_dir.mkdir()
+    (config_dir / "config.yaml").write_text(
+        yaml.dump({"features": {"experimental_enabled": True}})
+    )
+    cfg = load_config(tmp_path)
+    assert cfg.experimental_enabled is True
+
+
+def test_user_config_override_beats_auto_detect(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    """User config experimental_enabled=true overrides non-dev auto-detect."""
+    import yaml
+
+    from autoskillit.config.settings import load_config
+
+    monkeypatch.setattr("autoskillit.config.settings.is_dev_install", lambda: False)
+    fake_home = tmp_path / "home"
+    user_config_dir = fake_home / ".autoskillit"
+    user_config_dir.mkdir(parents=True)
+    (user_config_dir / "config.yaml").write_text(
+        yaml.dump({"features": {"experimental_enabled": True}})
+    )
+    monkeypatch.setattr("pathlib.Path.home", lambda: fake_home)
+    cfg = load_config(tmp_path)
     assert cfg.experimental_enabled is True

--- a/tests/arch/test_feature_registry.py
+++ b/tests/arch/test_feature_registry.py
@@ -285,7 +285,8 @@ def test_fleet_feature_default_disabled():
     assert FEATURE_REGISTRY["fleet"].default_enabled is False
 
 
-def test_build_features_dict_accepts_fleet_key():
+def test_build_features_dict_accepts_fleet_key(monkeypatch):
+    monkeypatch.setattr("autoskillit.config.settings.is_dev_install", lambda: False)
     from autoskillit.config.settings import AutomationConfig
 
     result, exp_enabled = AutomationConfig._build_features_dict({"fleet": True})

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -727,7 +727,10 @@ def test_no_subpackage_exceeds_10_files() -> None:
         tool_sequence_analysis.py adds the stdlib-only cross-session tool call
         sequence DFG analysis (L0; must live in core/ to be importable by server/).
         Monolithic protocol module split into 6 domain-grouped shard files (net +5 files).
-        Exempt at 32 files.
+        _install_detect.py adds the is_dev_install() predicate for config resolution
+        to auto-detect whether the install is editable when experimental_enabled is absent,
+        bringing the count to 33.
+        Exempt at 33 files.
       cli/ — REQ-CNST-003-E5: cli/ retains _terminal_table.py as a re-export shim
         for backward-compatible cli/ imports; canonical implementation lives in
         core/_terminal_table.py. Also contains _terminal.py — the terminal state
@@ -774,7 +777,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "server": 25,
         "recipe": 50,
         "execution": 36,
-        "core": 32,
+        "core": 33,
         "cli": 42,
         "hooks": 28,
         "pipeline": 12,

--- a/tests/core/test_install_detect.py
+++ b/tests/core/test_install_detect.py
@@ -1,0 +1,86 @@
+"""Tests for core/_install_detect.py — editable install detection."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
+
+
+def _fake_dist(direct_url_json: str | None) -> MagicMock:
+    dist = MagicMock()
+    dist.read_text.return_value = direct_url_json
+    return dist
+
+
+def test_is_dev_install_editable_returns_true(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = json.dumps({"url": "file:///home/user/autoskillit", "dir_info": {"editable": True}})
+    monkeypatch.setattr(
+        "importlib.metadata.Distribution.from_name",
+        lambda _name: _fake_dist(payload),
+    )
+    from autoskillit.core._install_detect import is_dev_install
+
+    assert is_dev_install() is True
+
+
+def test_is_dev_install_git_vcs_returns_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = json.dumps(
+        {
+            "url": "https://github.com/TalonT-Org/AutoSkillit.git",
+            "vcs_info": {"vcs": "git", "requested_revision": "stable", "commit_id": "abc123"},
+        }
+    )
+    monkeypatch.setattr(
+        "importlib.metadata.Distribution.from_name",
+        lambda _name: _fake_dist(payload),
+    )
+    from autoskillit.core._install_detect import is_dev_install
+
+    assert is_dev_install() is False
+
+
+def test_is_dev_install_local_path_returns_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = json.dumps({"url": "file:///home/user/autoskillit", "dir_info": {}})
+    monkeypatch.setattr(
+        "importlib.metadata.Distribution.from_name",
+        lambda _name: _fake_dist(payload),
+    )
+    from autoskillit.core._install_detect import is_dev_install
+
+    assert is_dev_install() is False
+
+
+def test_is_dev_install_unknown_returns_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    import importlib.metadata
+
+    def _raise(_name: str) -> None:
+        raise importlib.metadata.PackageNotFoundError("autoskillit")
+
+    monkeypatch.setattr("importlib.metadata.Distribution.from_name", _raise)
+    from autoskillit.core._install_detect import is_dev_install
+
+    assert is_dev_install() is False
+
+
+def test_is_dev_install_no_direct_url_returns_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "importlib.metadata.Distribution.from_name",
+        lambda _name: _fake_dist(None),
+    )
+    from autoskillit.core._install_detect import is_dev_install
+
+    assert is_dev_install() is False
+
+
+def test_is_dev_install_malformed_json_returns_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "importlib.metadata.Distribution.from_name",
+        lambda _name: _fake_dist("not-valid-json{{{"),
+    )
+    from autoskillit.core._install_detect import is_dev_install
+
+    assert is_dev_install() is False


### PR DESCRIPTION
## Summary

`defaults.yaml` ships `experimental_enabled: true` unconditionally, meaning every install — including stable releases — gets all EXPERIMENTAL features enabled. The `FeatureLifecycle.EXPERIMENTAL` docstring promises these features are "disabled on main/stable" but no code enforces it. The fix introduces install-type awareness into config resolution: when no config layer or env var explicitly sets `experimental_enabled`, the system auto-detects whether the install is a development install (editable) and defaults accordingly. Explicit overrides in any config layer or env var continue to work unchanged.

## Requirements

### Group GATE — Install-context resolution

**REQ-GATE-001:** The config loading system must determine the install type (editable, site-packages, source-tree, unknown) during config resolution and use it to derive the effective `experimental_enabled` default.

**REQ-GATE-002:** When no explicit `experimental_enabled` value is set in any config layer or env var, editable and source-tree installs must default to `experimental_enabled=true` and all other install types must default to `experimental_enabled=false`.

**REQ-GATE-003:** An explicit `experimental_enabled` value in any config layer (user, project, secrets) or env var must override the install-type-derived default.

### Group COMPAT — Backward compatibility

**REQ-COMPAT-001:** The env var override path (`AUTOSKILLIT_FEATURES__EXPERIMENTAL_ENABLED`) must continue to work identically to its current behavior.

**REQ-COMPAT-002:** Per-feature explicit overrides (e.g., `features: {fleet: false}`) must continue to take precedence over the `experimental_enabled` blanket, regardless of install type.

**REQ-COMPAT-003:** The existing dev workflow on editable/source installs must not require any new configuration to maintain current behavior.

### Group TEST — Verification

**REQ-TEST-001:** Tests must verify that `is_feature_enabled()` returns `False` for EXPERIMENTAL features when `experimental_enabled` resolves to `false` (non-dev install scenario).

**REQ-TEST-002:** Tests must verify that `is_feature_enabled()` returns `True` for EXPERIMENTAL features when `experimental_enabled` resolves to `true` (dev install scenario).

**REQ-TEST-003:** Tests must verify that explicit config and env var overrides take precedence over the install-type-derived default in both directions.

Closes #1611

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260502-113623-724734/.autoskillit/temp/make-plan/experimental_features_install_context_gating_plan_2026-05-02_114500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 68 | 12.7k | 1.3M | 82.7k | 1 | 10m 52s |
| verify | 52 | 11.7k | 2.0M | 140.3k | 1 | 8m 45s |
| implement | 276 | 17.8k | 1.8M | 58.7k | 1 | 7m 44s |
| prepare_pr | 68 | 6.0k | 258.9k | 31.3k | 1 | 1m 57s |
| compose_pr | 59 | 2.4k | 197.0k | 20.3k | 1 | 42s |
| review_pr | 108 | 22.9k | 595.9k | 56.9k | 1 | 5m 18s |
| resolve_review | 261 | 17.3k | 1.6M | 57.0k | 1 | 8m 18s |
| **Total** | 892 | 90.8k | 7.8M | 447.3k | | 43m 40s |
## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 0 | — | — | — |
| fix | 13 | 166288.9 | 8503.9 | 1296.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **13** | 590540.2 | 34150.8 | 5190.2 |