### PR TITLE
Fleet Campaign Interactive Selection Menu + Shared Menu Abstraction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -359,6 +359,7 @@ generic_automation_mcp/
 │   ├── _onboarding.py       #   First-run detection + guided menu
 │   ├── _prompts.py          #   Orchestrator prompt builder
 │   ├── _timed_input.py      #   timed_prompt() and status_line() CLI primitives
+│   ├── _menu.py             #   Shared numbered selection menu primitive: run_selection_menu(), render_numbered_menu(), resolve_menu_input()
 │   ├── _update.py           #   run_update_command(): first-class upgrade path for `autoskillit update`
 │   ├── _update_checks.py    #   Unified startup update check: version/hook/source-drift signals, branch-aware dismissal (facade)
 │   ├── _update_checks_fetch.py #  HTTP cache + fetch machinery: _fetch_with_cache, _fetch_latest_version, invalidate_fetch_cache

--- a/src/autoskillit/cli/__init__.py
+++ b/src/autoskillit/cli/__init__.py
@@ -19,7 +19,6 @@ from autoskillit.cli._prompts import (
     _OPEN_KITCHEN_CHOICE,
     _build_open_kitchen_prompt,
     _build_orchestrator_prompt,
-    _resolve_recipe_input,
 )
 from autoskillit.cli.app import (
     _generate_config_yaml,
@@ -60,7 +59,6 @@ __all__ = [
     "_generate_config_yaml",
     "_prompt_recipe_choice",
     "_prompt_test_command",
-    "_resolve_recipe_input",
     "app",
     "config_app",
     "config_show",

--- a/src/autoskillit/cli/__init__.py
+++ b/src/autoskillit/cli/__init__.py
@@ -16,7 +16,6 @@ from autoskillit.cli._hooks import _claude_settings_path
 from autoskillit.cli._init_helpers import _prompt_recipe_choice
 from autoskillit.cli._mcp_names import detect_autoskillit_mcp_prefix
 from autoskillit.cli._prompts import (
-    _OPEN_KITCHEN_CHOICE,
     _build_open_kitchen_prompt,
     _build_orchestrator_prompt,
 )
@@ -50,7 +49,6 @@ from autoskillit.cli.app import (
 from autoskillit.hook_registry import HookDriftResult
 
 __all__ = [
-    "_OPEN_KITCHEN_CHOICE",
     "_build_open_kitchen_prompt",
     "_build_orchestrator_prompt",
     "DoctorResult",

--- a/src/autoskillit/cli/_fleet.py
+++ b/src/autoskillit/cli/_fleet.py
@@ -99,9 +99,9 @@ def fleet_campaign(
 
     cfg = load_config(Path.cwd())
     _require_fleet(cfg)
+    from autoskillit.cli._menu import run_selection_menu
 
     if campaign_name is None and resume_campaign is None:
-        from autoskillit.cli._menu import run_selection_menu
         from autoskillit.recipe import list_campaign_recipes
 
         result = list_campaign_recipes(Path.cwd())
@@ -123,9 +123,7 @@ def fleet_campaign(
         campaign_name = selected.name
 
     if campaign_name is None and resume_campaign is not None:
-        from autoskillit.cli._menu import run_selection_menu
-        from autoskillit.fleet import read_state
-        from autoskillit.fleet.state import _TERMINAL_DISPATCH_STATUSES
+        from autoskillit.fleet import _TERMINAL_DISPATCH_STATUSES, read_state
 
         fleet_dir = Path.cwd() / ".autoskillit" / "temp" / "fleet"
         active: list[CampaignState] = []

--- a/src/autoskillit/cli/_fleet.py
+++ b/src/autoskillit/cli/_fleet.py
@@ -147,7 +147,7 @@ def fleet_campaign(
         selected_state = run_selection_menu(  # type: ignore[arg-type]
             active,
             header="Active campaigns (resumable):",
-            display_fn=lambda s: f"{s.campaign_name}  [{s.campaign_id[:8]}…]",  # type: ignore[union-attr]
+            display_fn=lambda s: f"{s.campaign_name}  [{(s.campaign_id or '')[:8]}…]",
             name_key=lambda s: s.campaign_name,  # type: ignore[union-attr]
             timeout=120,
             label="autoskillit fleet campaign --resume",

--- a/src/autoskillit/cli/_fleet.py
+++ b/src/autoskillit/cli/_fleet.py
@@ -8,7 +8,7 @@ import shutil
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated
+from typing import TYPE_CHECKING, Annotated, cast
 from uuid import uuid4
 
 from cyclopts import App, Parameter
@@ -45,7 +45,7 @@ def _require_fleet(cfg: AutomationConfig) -> None:
 
 if TYPE_CHECKING:
     from autoskillit.config import AutomationConfig
-    from autoskillit.fleet import ResumeDecision
+    from autoskillit.fleet import CampaignState, ResumeDecision
 
 
 fleet_app = App(name="fleet", help="Campaign fleet management.")
@@ -82,7 +82,7 @@ def fleet_dispatch() -> None:
 
 @fleet_app.command(name="campaign")
 def fleet_campaign(
-    campaign_name: str,
+    campaign_name: str | None = None,
     *,
     resume_campaign: Annotated[str | None, Parameter(name=["--resume"])] = None,
 ) -> None:
@@ -99,6 +99,70 @@ def fleet_campaign(
 
     cfg = load_config(Path.cwd())
     _require_fleet(cfg)
+
+    if campaign_name is None and resume_campaign is None:
+        from autoskillit.cli._menu import run_selection_menu
+        from autoskillit.recipe import list_campaign_recipes
+
+        result = list_campaign_recipes(Path.cwd())
+        if not result.items:
+            print("No campaigns found. Place campaign recipes in .autoskillit/recipes/campaigns/")
+            sys.exit(1)
+
+        selected = run_selection_menu(
+            result.items,
+            header="Available campaigns:",
+            display_fn=lambda r: f"{r.name}  {r.description[:60]}" if r.description else r.name,
+            name_key=lambda r: r.name,
+            timeout=120,
+            label="autoskillit fleet campaign",
+        )
+        if selected is None or isinstance(selected, str):
+            print("No campaign selected.")
+            sys.exit(1)
+        campaign_name = selected.name
+
+    if campaign_name is None and resume_campaign is not None:
+        from autoskillit.cli._menu import run_selection_menu
+        from autoskillit.fleet import read_state
+        from autoskillit.fleet.state import _TERMINAL_DISPATCH_STATUSES
+
+        fleet_dir = Path.cwd() / ".autoskillit" / "temp" / "fleet"
+        active: list[CampaignState] = []
+        if fleet_dir.is_dir():
+            for subdir in sorted(fleet_dir.iterdir()):
+                if not subdir.is_dir():
+                    continue
+                state = read_state(subdir / "state.json")
+                if state is None:
+                    continue
+                has_non_terminal = any(
+                    d.status not in _TERMINAL_DISPATCH_STATUSES for d in state.dispatches
+                )
+                if has_non_terminal:
+                    active.append(state)
+
+        if not active:
+            print("No active campaigns to resume.")
+            sys.exit(1)
+
+        selected_state = run_selection_menu(  # type: ignore[arg-type]
+            active,
+            header="Active campaigns (resumable):",
+            display_fn=lambda s: f"{s.campaign_name}  [{s.campaign_id[:8]}…]",  # type: ignore[union-attr]
+            name_key=lambda s: s.campaign_name,  # type: ignore[union-attr]
+            timeout=120,
+            label="autoskillit fleet campaign --resume",
+        )
+        if selected_state is None or isinstance(selected_state, str):
+            print("No campaign selected.")
+            sys.exit(1)
+
+        resolved_state = cast("CampaignState", selected_state)
+        campaign_name = resolved_state.campaign_name
+        resume_campaign = resolved_state.campaign_id
+
+    assert campaign_name is not None
 
     from autoskillit.core import YAMLError
     from autoskillit.fleet import (

--- a/src/autoskillit/cli/_fleet.py
+++ b/src/autoskillit/cli/_fleet.py
@@ -123,7 +123,7 @@ def fleet_campaign(
         campaign_name = selected.name
 
     if campaign_name is None and resume_campaign is not None:
-        from autoskillit.fleet import _TERMINAL_DISPATCH_STATUSES, read_state
+        from autoskillit.fleet import TERMINAL_DISPATCH_STATUSES, read_state
 
         fleet_dir = Path.cwd() / ".autoskillit" / "temp" / "fleet"
         active: list[CampaignState] = []
@@ -135,7 +135,7 @@ def fleet_campaign(
                 if state is None:
                     continue
                 has_non_terminal = any(
-                    d.status not in _TERMINAL_DISPATCH_STATUSES for d in state.dispatches
+                    d.status not in TERMINAL_DISPATCH_STATUSES for d in state.dispatches
                 )
                 if has_non_terminal:
                     active.append(state)

--- a/src/autoskillit/cli/_fleet.py
+++ b/src/autoskillit/cli/_fleet.py
@@ -122,7 +122,7 @@ def fleet_campaign(
             sys.exit(1)
         campaign_name = selected.name
 
-    if campaign_name is None and resume_campaign is not None:
+    elif campaign_name is None and resume_campaign is not None:
         from autoskillit.fleet import TERMINAL_DISPATCH_STATUSES, read_state
 
         fleet_dir = Path.cwd() / ".autoskillit" / "temp" / "fleet"
@@ -160,7 +160,8 @@ def fleet_campaign(
         campaign_name = resolved_state.campaign_name
         resume_campaign = resolved_state.campaign_id
 
-    assert campaign_name is not None
+    if campaign_name is None:
+        raise RuntimeError("campaign_name must be set before launching fleet session")
 
     from autoskillit.core import YAMLError
     from autoskillit.fleet import (

--- a/src/autoskillit/cli/_menu.py
+++ b/src/autoskillit/cli/_menu.py
@@ -1,0 +1,85 @@
+"""Shared numbered selection menu primitive for CLI commands."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import TypeVar
+
+T = TypeVar("T")
+
+SLOT_ZERO_SELECTED: str = "__slot_zero__"
+
+
+def resolve_menu_input(
+    raw: str,
+    items: Sequence[T],
+    *,
+    name_key: Callable[[T], str] = lambda x: x.name,  # type: ignore[attr-defined]
+    slot_zero: bool = False,
+) -> T | str | None:
+    if not raw:
+        return None
+    if raw.isdigit():
+        n = int(raw)
+        if n == 0:
+            return SLOT_ZERO_SELECTED if slot_zero else None
+        if 1 <= n <= len(items):
+            return items[n - 1]
+        return None
+    return next((item for item in items if name_key(item) == raw), None)
+
+
+def render_numbered_menu(
+    items: Sequence[T],
+    *,
+    header: str = "Available items:",
+    slot_zero_label: str | None = None,
+    group_classifier: Callable[[T], int] | None = None,
+    group_labels: dict[int, str] | None = None,
+    display_fn: Callable[[T], str] | None = None,
+    name_key: Callable[[T], str] = lambda x: x.name,  # type: ignore[attr-defined]
+) -> None:
+    print(header)
+    if slot_zero_label is not None:
+        print(f"  0. {slot_zero_label}")
+    current_rank: int = -1
+    for i, item in enumerate(items, 1):
+        if group_classifier is not None:
+            rank = group_classifier(item)
+            if rank != current_rank:
+                current_rank = rank
+                label = (group_labels or {}).get(rank, str(rank))
+                print(f"\n  {label}")
+        label_str = display_fn(item) if display_fn is not None else name_key(item)
+        print(f"  {i}. {label_str}")
+
+
+def run_selection_menu(
+    items: Sequence[T],
+    *,
+    header: str = "Available items:",
+    slot_zero_label: str | None = None,
+    group_classifier: Callable[[T], int] | None = None,
+    group_labels: dict[int, str] | None = None,
+    display_fn: Callable[[T], str] | None = None,
+    name_key: Callable[[T], str] = lambda x: x.name,  # type: ignore[attr-defined]
+    timeout: int = 120,
+    label: str = "selection",
+) -> T | str | None:
+    from autoskillit.cli._timed_input import timed_prompt
+
+    render_numbered_menu(
+        items,
+        header=header,
+        slot_zero_label=slot_zero_label,
+        group_classifier=group_classifier,
+        group_labels=group_labels,
+        display_fn=display_fn,
+        name_key=name_key,
+    )
+    if slot_zero_label is not None:
+        prompt_text = f"Select [0-{len(items)}]:"
+    else:
+        prompt_text = f"Select [1-{len(items)}]:"
+    raw = timed_prompt(prompt_text, default="", timeout=timeout, label=label)
+    return resolve_menu_input(raw, items, name_key=name_key, slot_zero=slot_zero_label is not None)

--- a/src/autoskillit/cli/_menu.py
+++ b/src/autoskillit/cli/_menu.py
@@ -21,7 +21,7 @@ def resolve_menu_input(
 ) -> T | str | None:
     if not raw:
         return None
-    if raw.isdigit():
+    if raw.isdecimal():
         n = int(raw)
         if n == 0:
             return SLOT_ZERO_SELECTED if slot_zero else None
@@ -44,7 +44,7 @@ def render_numbered_menu(
     print(header)
     if slot_zero_label is not None:
         print(f"  0. {slot_zero_label}")
-    current_rank: int = -1
+    current_rank: int | None = None
     for i, item in enumerate(items, 1):
         if group_classifier is not None:
             rank = group_classifier(item)

--- a/src/autoskillit/cli/_menu.py
+++ b/src/autoskillit/cli/_menu.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 from typing import TypeVar
 
+from autoskillit.cli._timed_input import timed_prompt
+
 T = TypeVar("T")
 
 SLOT_ZERO_SELECTED: str = "__slot_zero__"
@@ -66,8 +68,6 @@ def run_selection_menu(
     timeout: int = 120,
     label: str = "selection",
 ) -> T | str | None:
-    from autoskillit.cli._timed_input import timed_prompt
-
     render_numbered_menu(
         items,
         header=header,

--- a/src/autoskillit/cli/_order.py
+++ b/src/autoskillit/cli/_order.py
@@ -147,11 +147,8 @@ def order(
     from autoskillit.cli._timed_input import timed_prompt
 
     if recipe is None:
-        from autoskillit.cli._prompts import (
-            _OPEN_KITCHEN_CHOICE,
-            _build_open_kitchen_prompt,
-            _resolve_recipe_input,
-        )
+        from autoskillit.cli._menu import SLOT_ZERO_SELECTED, run_selection_menu
+        from autoskillit.cli._prompts import _build_open_kitchen_prompt
         from autoskillit.recipe import GROUP_LABELS, group_rank
 
         available = list_recipes(Path.cwd()).items
@@ -159,23 +156,17 @@ def order(
             print("No recipes found. Run 'autoskillit recipes list' to check.")
             sys.exit(1)
 
-        print("Available recipes:")
-        print("  0. Open kitchen (no recipe)")
-        current_rank: int = -1
-        for i, r in enumerate(available, 1):
-            rank = group_rank(r)
-            if rank != current_rank:
-                current_rank = rank
-                print(f"\n  {GROUP_LABELS.get(rank, str(rank))}")
-            print(f"  {i}. {r.name}")
-        raw = timed_prompt(
-            f"Select recipe [0-{len(available)}]:",
-            default="",
+        resolved = run_selection_menu(
+            available,
+            header="Available recipes:",
+            slot_zero_label="Open kitchen (no recipe)",
+            group_classifier=group_rank,
+            group_labels=GROUP_LABELS,
+            name_key=lambda r: r.name,
             timeout=120,
             label="autoskillit order",
         )
-        resolved = _resolve_recipe_input(raw, available)
-        if resolved is _OPEN_KITCHEN_CHOICE:
+        if resolved is SLOT_ZERO_SELECTED:
             from autoskillit.cli._prompts import _OPEN_KITCHEN_GREETINGS
 
             _launch_cook_session(
@@ -187,7 +178,7 @@ def order(
             )
             return
         elif resolved is None:
-            print(f"Invalid selection: '{raw}'")
+            print("Invalid selection.")
             sys.exit(1)
         else:
             if isinstance(resolved, str):

--- a/src/autoskillit/cli/_prompts.py
+++ b/src/autoskillit/cli/_prompts.py
@@ -352,23 +352,12 @@ Emit at each dispatch state transition:
 
 
 def _resolve_recipe_input(raw: str, available: list[RecipeInfo]) -> RecipeInfo | str | None:
-    """Resolve picker raw text to a selection.
+    from autoskillit.cli._menu import SLOT_ZERO_SELECTED, resolve_menu_input
 
-    Returns:
-        _OPEN_KITCHEN_CHOICE  if raw is "0" (open kitchen, always valid)
-        RecipeInfo            if raw is a valid 1-based index or an exact name match
-        None                  for empty input, out-of-range numbers, or unknown names
-    """
-    if not raw:
-        return None
-    if raw.isdigit():
-        n = int(raw)
-        if n == 0:
-            return _OPEN_KITCHEN_CHOICE
-        if 1 <= n <= len(available):
-            return available[n - 1]
-        return None
-    return next((r for r in available if r.name == raw), None)
+    result = resolve_menu_input(raw, available, name_key=lambda r: r.name, slot_zero=True)
+    if result is SLOT_ZERO_SELECTED:
+        return _OPEN_KITCHEN_CHOICE
+    return result
 
 
 def _get_ingredients_table(

--- a/src/autoskillit/cli/_prompts.py
+++ b/src/autoskillit/cli/_prompts.py
@@ -15,8 +15,6 @@ if TYPE_CHECKING:
     from autoskillit.recipe.schema import Recipe
 
 
-_OPEN_KITCHEN_CHOICE: str = "__open_kitchen__"
-
 # Shared retry instruction for both orchestrator and open-kitchen prompts.
 _MCP_RETRY_INSTRUCTION: str = (
     "If calling open_kitchen produces ANY error — including"

--- a/src/autoskillit/cli/_prompts.py
+++ b/src/autoskillit/cli/_prompts.py
@@ -15,7 +15,6 @@ if TYPE_CHECKING:
     from autoskillit.recipe.schema import Recipe
 
 
-# Sentinel returned by _resolve_recipe_input when the user selects option 0.
 _OPEN_KITCHEN_CHOICE: str = "__open_kitchen__"
 
 # Shared retry instruction for both orchestrator and open-kitchen prompts.
@@ -349,15 +348,6 @@ Emit at each dispatch state transition:
 - <dispatch_id>: per-dispatch UUID assigned before calling dispatch_food_truck
 - <state>: one of queued, running, success, failure, skipped
 """
-
-
-def _resolve_recipe_input(raw: str, available: list[RecipeInfo]) -> RecipeInfo | str | None:
-    from autoskillit.cli._menu import SLOT_ZERO_SELECTED, resolve_menu_input
-
-    result = resolve_menu_input(raw, available, name_key=lambda r: r.name, slot_zero=True)
-    if result is SLOT_ZERO_SELECTED:
-        return _OPEN_KITCHEN_CHOICE
-    return result
 
 
 def _get_ingredients_table(

--- a/src/autoskillit/fleet/__init__.py
+++ b/src/autoskillit/fleet/__init__.py
@@ -20,6 +20,7 @@ from .sidecar import (
     sidecar_path,
 )
 from .state import (
+    _TERMINAL_DISPATCH_STATUSES,
     FLEET_HALTED_SENTINEL,
     CampaignState,
     DispatchRecord,
@@ -71,6 +72,7 @@ __all__ = [
     "parse_campaign_summary",
     "serialize_campaign_summary",
     "validate_campaign_summary",
+    "_TERMINAL_DISPATCH_STATUSES",
     "FLEET_HALTED_SENTINEL",
     "CampaignState",
     "DispatchRecord",

--- a/src/autoskillit/fleet/__init__.py
+++ b/src/autoskillit/fleet/__init__.py
@@ -20,8 +20,8 @@ from .sidecar import (
     sidecar_path,
 )
 from .state import (
-    _TERMINAL_DISPATCH_STATUSES,
     FLEET_HALTED_SENTINEL,
+    TERMINAL_DISPATCH_STATUSES,
     CampaignState,
     DispatchRecord,
     DispatchStatus,
@@ -72,7 +72,7 @@ __all__ = [
     "parse_campaign_summary",
     "serialize_campaign_summary",
     "validate_campaign_summary",
-    "_TERMINAL_DISPATCH_STATUSES",
+    "TERMINAL_DISPATCH_STATUSES",
     "FLEET_HALTED_SENTINEL",
     "CampaignState",
     "DispatchRecord",

--- a/src/autoskillit/fleet/state.py
+++ b/src/autoskillit/fleet/state.py
@@ -391,7 +391,7 @@ _COMPLETED_STATUSES = frozenset(
     {DispatchStatus.SUCCESS, DispatchStatus.SKIPPED, DispatchStatus.FAILURE}
 )
 
-_TERMINAL_DISPATCH_STATUSES: frozenset[str] = frozenset(
+TERMINAL_DISPATCH_STATUSES: frozenset[str] = frozenset(
     {
         DispatchStatus.SUCCESS,
         DispatchStatus.FAILURE,
@@ -427,7 +427,7 @@ def build_protected_campaign_ids(project_dir: Path) -> frozenset[str]:
                     continue
                 for record in dispatches:
                     status = record.get("status", "")
-                    if status not in _TERMINAL_DISPATCH_STATUSES:
+                    if status not in TERMINAL_DISPATCH_STATUSES:
                         protected.add(cid)
                         break
             except (json.JSONDecodeError, OSError):

--- a/tests/arch/_rules.py
+++ b/tests/arch/_rules.py
@@ -58,6 +58,7 @@ _PRINT_EXEMPT = frozenset(
     {
         "_cook.py",
         "_features.py",
+        "_menu.py",
         "_fleet_display.py",
         "_fleet_lifecycle.py",
         "_fleet_session.py",

--- a/tests/cli/test_cook_order_command.py
+++ b/tests/cli/test_cook_order_command.py
@@ -10,60 +10,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from autoskillit import cli
-from autoskillit.cli._prompts import _OPEN_KITCHEN_CHOICE, _resolve_recipe_input
 from autoskillit.core import ClaudeFlags
 from tests.cli.conftest import _SCRIPT_YAML
 
 pytestmark = [pytest.mark.layer("cli"), pytest.mark.medium]
-
-
-class TestResolveRecipeInput:
-    """Unit tests for the _resolve_recipe_input picker resolution helper."""
-
-    def _make_recipe(self, name: str) -> MagicMock:
-        r = MagicMock()
-        r.name = name
-        return r
-
-    def test_zero_returns_open_kitchen_sentinel(self) -> None:
-        available = [self._make_recipe("smoke-test")]
-        result = _resolve_recipe_input("0", available)
-        assert result is _OPEN_KITCHEN_CHOICE
-
-    def test_zero_with_empty_list_returns_open_kitchen_sentinel(self) -> None:
-        result = _resolve_recipe_input("0", [])
-        assert result is _OPEN_KITCHEN_CHOICE
-
-    def test_valid_number_first_returns_first_recipe(self) -> None:
-        r1 = self._make_recipe("implementation")
-        r2 = self._make_recipe("remediation")
-        assert _resolve_recipe_input("1", [r1, r2]) is r1
-
-    def test_valid_number_last_returns_last_recipe(self) -> None:
-        r1 = self._make_recipe("implementation")
-        r2 = self._make_recipe("remediation")
-        assert _resolve_recipe_input("2", [r1, r2]) is r2
-
-    def test_out_of_range_too_high_returns_none(self) -> None:
-        available = [self._make_recipe("smoke-test")]
-        assert _resolve_recipe_input("99", available) is None
-
-    def test_out_of_range_negative_digit_treated_as_name(self) -> None:
-        # "-1".isdigit() is False in Python — treated as name lookup, returns None
-        available = [self._make_recipe("smoke-test")]
-        assert _resolve_recipe_input("-1", available) is None
-
-    def test_name_match_returns_recipe(self) -> None:
-        r = self._make_recipe("smoke-test")
-        assert _resolve_recipe_input("smoke-test", [r, self._make_recipe("other")]) is r
-
-    def test_name_no_match_returns_none(self) -> None:
-        available = [self._make_recipe("smoke-test")]
-        assert _resolve_recipe_input("nonexistent", available) is None
-
-    def test_empty_string_returns_none(self) -> None:
-        available = [self._make_recipe("smoke-test")]
-        assert _resolve_recipe_input("", available) is None
 
 
 class TestCLIOrderCommand:

--- a/tests/cli/test_cook_order_picker.py
+++ b/tests/cli/test_cook_order_picker.py
@@ -306,7 +306,7 @@ class TestCLIOrderPicker:
             "autoskillit.recipe.list_recipes",
             lambda *a, **kw: type("R", (), {"items": [project_recipe]})(),
         )
-        monkeypatch.setattr("autoskillit.cli._timed_input.timed_prompt", lambda *a, **kw: "0")
+        monkeypatch.setattr("autoskillit.cli._menu.timed_prompt", lambda *a, **kw: "0")
         monkeypatch.setattr(shutil, "which", lambda cmd: None)
         monkeypatch.delenv("CLAUDECODE", raising=False)
         monkeypatch.chdir(tmp_path)
@@ -336,7 +336,7 @@ class TestCLIOrderPicker:
             "autoskillit.recipe.list_recipes",
             lambda *a, **kw: type("R", (), {"items": [builtin_recipe]})(),
         )
-        monkeypatch.setattr("autoskillit.cli._timed_input.timed_prompt", lambda *a, **kw: "0")
+        monkeypatch.setattr("autoskillit.cli._menu.timed_prompt", lambda *a, **kw: "0")
         monkeypatch.setattr(shutil, "which", lambda cmd: None)
         monkeypatch.delenv("CLAUDECODE", raising=False)
         monkeypatch.chdir(tmp_path)
@@ -365,7 +365,7 @@ class TestCLIOrderPicker:
             "autoskillit.recipe.list_recipes",
             lambda *a, **kw: type("R", (), {"items": [exp_recipe]})(),
         )
-        monkeypatch.setattr("autoskillit.cli._timed_input.timed_prompt", lambda *a, **kw: "0")
+        monkeypatch.setattr("autoskillit.cli._menu.timed_prompt", lambda *a, **kw: "0")
         monkeypatch.setattr(shutil, "which", lambda cmd: None)
         monkeypatch.delenv("CLAUDECODE", raising=False)
         monkeypatch.chdir(tmp_path)
@@ -394,7 +394,7 @@ class TestCLIOrderPicker:
             "autoskillit.recipe.list_recipes",
             lambda *a, **kw: type("R", (), {"items": [builtin_recipe]})(),
         )
-        monkeypatch.setattr("autoskillit.cli._timed_input.timed_prompt", lambda *a, **kw: "0")
+        monkeypatch.setattr("autoskillit.cli._menu.timed_prompt", lambda *a, **kw: "0")
         monkeypatch.setattr(shutil, "which", lambda cmd: None)
         monkeypatch.delenv("CLAUDECODE", raising=False)
         monkeypatch.chdir(tmp_path)
@@ -424,7 +424,7 @@ class TestCLIOrderPicker:
             "autoskillit.recipe.list_recipes",
             lambda *a, **kw: type("R", (), {"items": [addon_recipe]})(),
         )
-        monkeypatch.setattr("autoskillit.cli._timed_input.timed_prompt", lambda *a, **kw: "0")
+        monkeypatch.setattr("autoskillit.cli._menu.timed_prompt", lambda *a, **kw: "0")
         monkeypatch.setattr(shutil, "which", lambda cmd: None)
         monkeypatch.delenv("CLAUDECODE", raising=False)
         monkeypatch.chdir(tmp_path)
@@ -468,7 +468,7 @@ class TestCLIOrderPicker:
         monkeypatch.setattr(
             "autoskillit.recipe.list_recipes", lambda *a, **kw: type("R", (), {"items": recipes})()
         )
-        monkeypatch.setattr("autoskillit.cli._timed_input.timed_prompt", lambda *a, **kw: "0")
+        monkeypatch.setattr("autoskillit.cli._menu.timed_prompt", lambda *a, **kw: "0")
         monkeypatch.setattr(shutil, "which", lambda cmd: None)
         monkeypatch.delenv("CLAUDECODE", raising=False)
         monkeypatch.chdir(tmp_path)

--- a/tests/cli/test_fleet_campaign.py
+++ b/tests/cli/test_fleet_campaign.py
@@ -201,6 +201,7 @@ def test_fleet_campaign_resume_no_name_lists_active_campaigns(
     _fleet_campaign(campaign_name=None, resume_campaign="__pick__")
 
     assert captured["env"].get("AUTOSKILLIT_CAMPAIGN_ID") == "active-id-1111111"
+    assert "terminal-id-333333" not in captured["env"].get("AUTOSKILLIT_CAMPAIGN_ID", "")
     out = capsys.readouterr().out
     assert "Active campaigns (resumable):" in out
     assert "campaign-active-1" in out

--- a/tests/cli/test_fleet_campaign.py
+++ b/tests/cli/test_fleet_campaign.py
@@ -9,6 +9,7 @@ import pytest
 from autoskillit.cli._fleet import fleet_campaign as _fleet_campaign
 from tests.cli._fleet_helpers import (
     _capture_subprocess,
+    _setup_campaign_with_status,
     _setup_existing_campaign_state,
     _stub_campaign_resolution,
     _stub_guards,
@@ -109,3 +110,91 @@ def test_fleet_campaign_exits_when_disabled(
         _fleet_campaign("any-campaign")
     assert exc_info.value.code == 1
     assert "fleet" in checked_features
+
+
+def _stub_list_campaign_recipes(monkeypatch: pytest.MonkeyPatch, names: list[str]) -> list[object]:
+    """Stub list_campaign_recipes to return mock items with given names."""
+    from unittest.mock import MagicMock
+
+    items = []
+    for name in names:
+        r = MagicMock()
+        r.name = name
+        r.description = f"Description for {name}"
+        items.append(r)
+
+    result = MagicMock()
+    result.items = items
+    monkeypatch.setattr("autoskillit.recipe.list_campaign_recipes", lambda *a, **kw: result)
+    return items
+
+
+def test_fleet_campaign_no_name_shows_menu_and_launches(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """When campaign_name is omitted, menu is shown and selected campaign launches."""
+    _stub_guards(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+    _stub_list_campaign_recipes(monkeypatch, ["campaign-alpha", "campaign-beta"])
+    _stub_campaign_resolution(monkeypatch, tmp_path, "campaign-alpha")
+    monkeypatch.setattr("autoskillit.cli._menu.timed_prompt", lambda *a, **kw: "1")
+    captured = _capture_subprocess(monkeypatch)
+    _fleet_campaign(campaign_name=None)
+    assert "AUTOSKILLIT_CAMPAIGN_ID" in captured["env"]
+    out = capsys.readouterr().out
+    assert "Available campaigns:" in out
+    assert "campaign-alpha" in out
+    assert "campaign-beta" in out
+
+
+def test_fleet_campaign_no_name_no_campaigns_exits(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """When no campaigns exist and name is omitted, exits with message."""
+    _stub_guards(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+    _stub_list_campaign_recipes(monkeypatch, [])
+    with pytest.raises(SystemExit, match="1"):
+        _fleet_campaign(campaign_name=None)
+
+
+def test_fleet_campaign_no_name_invalid_selection_exits(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Empty selection from menu exits with code 1."""
+    _stub_guards(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+    _stub_list_campaign_recipes(monkeypatch, ["campaign-alpha"])
+    monkeypatch.setattr("autoskillit.cli._menu.timed_prompt", lambda *a, **kw: "")
+    with pytest.raises(SystemExit, match="1"):
+        _fleet_campaign(campaign_name=None)
+
+
+def test_fleet_campaign_resume_no_name_lists_active_campaigns(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Resume without name shows only active (non-terminal) campaigns."""
+    _stub_guards(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+
+    _setup_existing_campaign_state(tmp_path, "active-id-1111111", "campaign-active-1")
+    _setup_existing_campaign_state(tmp_path, "active-id-2222222", "campaign-active-2")
+    _setup_campaign_with_status(
+        tmp_path, "terminal-id-333333", "campaign-terminal", status="success"
+    )
+
+    _stub_campaign_resolution(monkeypatch, tmp_path, "campaign-active-1")
+    monkeypatch.setattr("autoskillit.cli._menu.timed_prompt", lambda *a, **kw: "1")
+    monkeypatch.setattr(
+        "autoskillit.fleet.resume_campaign_from_state",
+        lambda *a, **kw: object(),
+    )
+    _capture_subprocess(monkeypatch)
+
+    _fleet_campaign(campaign_name=None, resume_campaign="__pick__")
+
+    out = capsys.readouterr().out
+    assert "Active campaigns (resumable):" in out
+    assert "campaign-active-1" in out
+    assert "campaign-active-2" in out
+    assert "campaign-terminal" not in out

--- a/tests/cli/test_fleet_campaign.py
+++ b/tests/cli/test_fleet_campaign.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -187,7 +188,9 @@ def test_fleet_campaign_resume_no_name_lists_active_campaigns(
     monkeypatch.setattr("autoskillit.cli._menu.timed_prompt", lambda *a, **kw: "1")
     monkeypatch.setattr(
         "autoskillit.fleet.resume_campaign_from_state",
-        lambda *a, **kw: object(),
+        lambda *a, **kw: MagicMock(
+            completed_dispatches_block="", next_dispatch_name="", is_resumable=False
+        ),
     )
     _capture_subprocess(monkeypatch)
 

--- a/tests/cli/test_fleet_campaign.py
+++ b/tests/cli/test_fleet_campaign.py
@@ -115,8 +115,6 @@ def test_fleet_campaign_exits_when_disabled(
 
 def _stub_list_campaign_recipes(monkeypatch: pytest.MonkeyPatch, names: list[str]) -> list[object]:
     """Stub list_campaign_recipes to return mock items with given names."""
-    from unittest.mock import MagicMock
-
     items = []
     for name in names:
         r = MagicMock()
@@ -142,6 +140,12 @@ def test_fleet_campaign_no_name_shows_menu_and_launches(
     captured = _capture_subprocess(monkeypatch)
     _fleet_campaign(campaign_name=None)
     assert "AUTOSKILLIT_CAMPAIGN_ID" in captured["env"]
+    assert "AUTOSKILLIT_CAMPAIGN_STATE_PATH" in captured["env"]
+    from autoskillit.fleet import read_state
+
+    state = read_state(Path(captured["env"]["AUTOSKILLIT_CAMPAIGN_STATE_PATH"]))
+    assert state is not None
+    assert state.campaign_name == "campaign-alpha"
     out = capsys.readouterr().out
     assert "Available campaigns:" in out
     assert "campaign-alpha" in out
@@ -192,10 +196,11 @@ def test_fleet_campaign_resume_no_name_lists_active_campaigns(
             completed_dispatches_block="", next_dispatch_name="", is_resumable=False
         ),
     )
-    _capture_subprocess(monkeypatch)
+    captured = _capture_subprocess(monkeypatch)
 
     _fleet_campaign(campaign_name=None, resume_campaign="__pick__")
 
+    assert captured["env"].get("AUTOSKILLIT_CAMPAIGN_ID") == "active-id-1111111"
     out = capsys.readouterr().out
     assert "Active campaigns (resumable):" in out
     assert "campaign-active-1" in out

--- a/tests/cli/test_menu.py
+++ b/tests/cli/test_menu.py
@@ -1,0 +1,147 @@
+"""Tests: shared selection menu primitive."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from autoskillit.cli._menu import (
+    SLOT_ZERO_SELECTED,
+    render_numbered_menu,
+    resolve_menu_input,
+    run_selection_menu,
+)
+
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.medium]
+
+
+def _make_item(name: str, tag: str = "") -> MagicMock:
+    item = MagicMock()
+    item.name = name
+    item.tag = tag
+    return item
+
+
+class TestRenderNumberedMenu:
+    def test_flat_list_renders_numbered_items(self, capsys: pytest.CaptureFixture[str]) -> None:
+        items = [_make_item("alpha"), _make_item("beta"), _make_item("gamma")]
+        render_numbered_menu(items, header="Items:")
+        out = capsys.readouterr().out
+        assert "1. alpha" in out
+        assert "2. beta" in out
+        assert "3. gamma" in out
+        assert "Items:" in out
+
+    def test_flat_list_no_group_headers(self, capsys: pytest.CaptureFixture[str]) -> None:
+        items = [_make_item("alpha"), _make_item("beta"), _make_item("gamma")]
+        render_numbered_menu(items, header="Items:")
+        out = capsys.readouterr().out
+        assert "Primary" not in out
+        assert "Secondary" not in out
+
+    def test_grouped_list_renders_group_headers(self, capsys: pytest.CaptureFixture[str]) -> None:
+        items = [_make_item("a"), _make_item("b"), _make_item("c"), _make_item("d")]
+        classifier = lambda item: 0 if item.name in ("a", "b") else 1  # noqa: E731
+        render_numbered_menu(
+            items,
+            header="Items:",
+            group_classifier=classifier,
+            group_labels={0: "Primary", 1: "Secondary"},
+        )
+        out = capsys.readouterr().out
+        assert "Primary" in out
+        assert "Secondary" in out
+        primary_pos = out.index("Primary")
+        secondary_pos = out.index("Secondary")
+        assert primary_pos < secondary_pos
+
+    def test_slot_zero_renders_when_label_provided(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        items = [_make_item("alpha")]
+        render_numbered_menu(items, header="Items:", slot_zero_label="Open kitchen")
+        out = capsys.readouterr().out
+        assert "0. Open kitchen" in out
+        assert "1. alpha" in out
+
+    def test_slot_zero_omitted_when_label_is_none(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        items = [_make_item("alpha")]
+        render_numbered_menu(items, header="Items:", slot_zero_label=None)
+        out = capsys.readouterr().out
+        assert "0." not in out
+
+    def test_custom_display_fn(self, capsys: pytest.CaptureFixture[str]) -> None:
+        items = [_make_item("alpha", tag="fast"), _make_item("beta", tag="slow")]
+        render_numbered_menu(items, header="Items:", display_fn=lambda x: f"{x.name} ({x.tag})")
+        out = capsys.readouterr().out
+        assert "alpha (fast)" in out
+        assert "beta (slow)" in out
+
+
+class TestResolveMenuInput:
+    def _items(self) -> list[MagicMock]:
+        return [_make_item("alpha"), _make_item("beta"), _make_item("gamma")]
+
+    def test_valid_number_returns_item(self) -> None:
+        items = self._items()
+        result = resolve_menu_input("2", items)
+        assert result is items[1]
+
+    def test_slot_zero_returns_sentinel(self) -> None:
+        items = self._items()
+        result = resolve_menu_input("0", items, slot_zero=True)
+        assert result is SLOT_ZERO_SELECTED
+
+    def test_slot_zero_disabled_returns_none(self) -> None:
+        items = self._items()
+        result = resolve_menu_input("0", items, slot_zero=False)
+        assert result is None
+
+    def test_out_of_range_returns_none(self) -> None:
+        items = self._items()
+        result = resolve_menu_input("99", items)
+        assert result is None
+
+    def test_name_match_returns_item(self) -> None:
+        items = self._items()
+        result = resolve_menu_input("beta", items, name_key=lambda x: x.name)
+        assert result is items[1]
+
+    def test_name_no_match_returns_none(self) -> None:
+        items = self._items()
+        result = resolve_menu_input("nonexistent", items)
+        assert result is None
+
+    def test_empty_string_returns_none(self) -> None:
+        items = self._items()
+        result = resolve_menu_input("", items)
+        assert result is None
+
+
+class TestRunSelectionMenu:
+    def test_end_to_end_numeric_selection(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        items = [_make_item("alpha"), _make_item("beta")]
+        monkeypatch.setattr("autoskillit.cli._menu.timed_prompt", lambda *a, **kw: "1")
+        result = run_selection_menu(items, header="Items:")
+        assert result is items[0]
+
+    def test_end_to_end_slot_zero(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        items = [_make_item("alpha")]
+        monkeypatch.setattr("autoskillit.cli._menu.timed_prompt", lambda *a, **kw: "0")
+        result = run_selection_menu(items, header="Items:", slot_zero_label="Open kitchen")
+        assert result is SLOT_ZERO_SELECTED
+
+    def test_end_to_end_invalid_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        items = [_make_item("alpha")]
+        monkeypatch.setattr("autoskillit.cli._menu.timed_prompt", lambda *a, **kw: "invalid")
+        result = run_selection_menu(items, header="Items:")
+        assert result is None

--- a/tests/execution/test_session_log_retention.py
+++ b/tests/execution/test_session_log_retention.py
@@ -750,10 +750,10 @@ def test_session_log_removed_build_protected_function() -> None:
 
 
 def test_session_log_removed_terminal_statuses_constant() -> None:
-    """SL_CB_2: _TERMINAL_DISPATCH_STATUSES must not exist on session_log module."""
+    """SL_CB_2: TERMINAL_DISPATCH_STATUSES must not exist on session_log module."""
     import autoskillit.execution.session_log as sl_module
 
-    assert not hasattr(sl_module, "_TERMINAL_DISPATCH_STATUSES")
+    assert not hasattr(sl_module, "TERMINAL_DISPATCH_STATUSES")
 
 
 def test_retention_no_protection_when_callback_is_none(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary

Extract the numbered selection menu pattern from `cli/_order.py` into a reusable `cli/_menu.py` primitive. Refactor `order()` to use it, then wire `fleet campaign` to present an interactive menu when `campaign_name` is omitted. Add resume-aware selection that lists active campaigns from fleet state when `--resume` is used without a name.

## Requirements

### REQ-SEL-001: Extract shared selection menu primitive

Extract the numbered-menu pattern from `_order.py` into a reusable function in a shared location (e.g. `cli/_selection.py` or `cli/_menu.py`). The primitive should:

- Accept a generic list of items with name/display attributes
- Accept an optional group classifier function `(item) -> int` and group labels `dict[int, str]`
- Accept an optional "slot 0" label (e.g. "Open kitchen" for order, `None` for fleet campaign)
- Render the numbered menu with group-break headers
- Call `timed_prompt()` with configurable timeout and label
- Return the resolved selection or `None` for invalid input
- Handle the TTY guard (`CLAUDECODE` env check) at the call site, not inside the primitive

### REQ-SEL-002: Refactor `autoskillit order` to use the shared primitive

Replace the inline menu-rendering loop in `_order.py:149-196` with a call to the extracted primitive. All existing behavior must be preserved:
- Group ordering via `group_rank()` + `GROUP_LABELS`
- Slot 0 "Open kitchen" option
- `_resolve_recipe_input()` for name/index resolution
- 120s timeout

### REQ-SEL-003: Add interactive selection to `fleet campaign`

When `campaign_name` is omitted:
1. Make `campaign_name` optional (`str | None = None`) in the cyclopts signature
2. Call `list_campaign_recipes(Path.cwd())` to discover available campaigns
3. If no campaigns found, print a helpful message and exit
4. Present the selection menu using the shared primitive from REQ-SEL-001
5. Campaigns should display `name` and `description` (truncated) in the menu
6. No slot-0 option needed for fleet campaign (unlike order)
7. Use `timed_prompt()` with appropriate timeout and label `"autoskillit fleet campaign"`

### REQ-SEL-004: Campaign group classification (future-ready)

For the initial implementation, campaigns do not need group classification — a flat numbered list is sufficient. However, the abstraction should support optional grouping so that campaign categories (e.g. `orchestration-family`, `implementation-family`) can be used as group classifiers in a future iteration without changing the primitive API.

### REQ-SEL-005: Resume-aware campaign selection

When `--resume` is provided without a `campaign_name`, the command should list active campaigns from `fleet status` state (`.autoskillit/temp/fleet/`) rather than available campaign recipes, since the user is selecting a campaign to resume rather than a new one to launch.

Closes #1610

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260502-113622-755432/.autoskillit/temp/make-plan/fleet_campaign_interactive_selection_menu_shared_menu_abstraction_plan_2026-05-02_115000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 71 | 15.8k | 1.5M | 88.1k | 1 | 8m 35s |
| verify | 3.1k | 10.4k | 1.1M | 47.0k | 1 | 7m 39s |
| implement | 364 | 38.4k | 3.4M | 102.8k | 1 | 15m 0s |
| prepare_pr | 76 | 7.2k | 306.3k | 32.6k | 1 | 2m 5s |
| compose_pr | 83 | 3.3k | 299.3k | 22.2k | 1 | 54s |
| review_pr | 258 | 81.8k | 2.0M | 174.9k | 2 | 22m 0s |
| resolve_review | 1.1k | 73.1k | 10.4M | 194.8k | 2 | 27m 52s |
| **Total** | 5.0k | 230.0k | 19.0M | 662.4k | | 1h 24m |
## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 0 | — | — | — |
| fix | 31 | 159609.7 | 3233.6 | 825.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **31** | 371050.0 | 12675.1 | 3247.5 |