### PR TITLE
Implementation Plan: New Bundled Skill — audit-review-decisions

### DIFF
--- a/src/autoskillit/execution/headless.py
+++ b/src/autoskillit/execution/headless.py
@@ -178,7 +178,6 @@ def _compute_post_session_metrics(
     )
 
 
-
 async def _execute_claude_headless(
     spec: ClaudeHeadlessCmd,
     cwd: str,

--- a/src/autoskillit/recipes/full-audit.yaml
+++ b/src/autoskillit/recipes/full-audit.yaml
@@ -1,9 +1,9 @@
 name: full-audit
 description: >-
-  Run audit-tests, audit-cohesion, audit-arch, audit-feature-gates, and audit-docs in
-  parallel, validate each report individually, and create a GitHub issue from each
-  validated report.
-summary: "branch → audit×5 ∥ → validate×5 ∥ → issue×5 ∥ → done"
+  Run audit-tests, audit-cohesion, audit-arch, audit-feature-gates, audit-docs, and
+  audit-review-decisions in parallel, validate each report individually, and create a
+  GitHub issue from each validated report.
+summary: "branch → audit×6 ∥ → validate×6 ∥ → issue×6 ∥ → done"
 autoskillit_version: "0.9.313"
 recipe_version: "1.0.0"
 requires_packs: [audit, github]
@@ -22,9 +22,9 @@ kitchen_rules:
     WebFetch, WebSearch, NotebookEdit) from the orchestrator. All work is delegated
     through run_skill.
   - >-
-    Each audit chain (tests, cohesion, arch, feature-gates, docs) is independent. A
-    failure in one chain MUST NOT block or affect the other four chains. Continue with
-    successful chains and note failures for escalation.
+    Each audit chain (tests, cohesion, arch, feature-gates, docs, review-decisions) is
+    independent. A failure in one chain MUST NOT block or affect the other five chains.
+    Continue with successful chains and note failures for escalation.
   - >-
     Within each wave, fire all run_skill calls in a single message to achieve
     parallelism. Do not serialize audit/validate/issue calls.
@@ -52,19 +52,20 @@ steps:
 
   run_audits:
     tool: run_skill
-    description: "Run five audit skills in parallel"
+    description: "Run six audit skills in parallel"
     with:
       skill_command: "/autoskillit:audit-tests"
       cwd: "${{ inputs.workspace }}"
       step_name: "run_audits"
     note: >
-      PARALLEL AUDIT WAVE — Fire five run_skill calls in a single message:
+      PARALLEL AUDIT WAVE — Fire six run_skill calls in a single message:
 
       1. run_skill(skill_command="/autoskillit:audit-tests", cwd="${{ inputs.workspace }}", step_name="audit_tests")
       2. run_skill(skill_command="/autoskillit:audit-cohesion", cwd="${{ inputs.workspace }}", step_name="audit_cohesion")
       3. run_skill(skill_command="/autoskillit:audit-arch", cwd="${{ inputs.workspace }}", step_name="audit_arch")
       4. run_skill(skill_command="/autoskillit:audit-feature-gates", cwd="${{ inputs.workspace }}", step_name="audit_feature_gates")
       5. run_skill(skill_command="/autoskillit:audit-docs", cwd="${{ inputs.workspace }}", step_name="audit_docs")
+      6. run_skill(skill_command="/autoskillit:audit-review-decisions", cwd="${{ inputs.workspace }}", step_name="audit_review_decisions")
 
       Each audit writes its report to a well-known temp directory:
       - {{AUTOSKILLIT_TEMP}}/audit-tests/{name}_{timestamp}.md
@@ -72,14 +73,15 @@ steps:
       - {{AUTOSKILLIT_TEMP}}/audit-arch/arch_audit_{timestamp}.md
       - {{AUTOSKILLIT_TEMP}}/audit-feature-gates/feature_gate_audit_{timestamp}.md
       - {{AUTOSKILLIT_TEMP}}/audit-docs/docs_audit_{timestamp}.md
+      - {{AUTOSKILLIT_TEMP}}/audit-review-decisions/review_decisions_audit_{timestamp}.md
 
-      After all five complete, discover the most-recently-modified .md file in
+      After all six complete, discover the most-recently-modified .md file in
       each temp directory from the session output. Record which audits succeeded
       and their report paths for the validation wave.
 
-      If any audit fails, note the failure but continue with the other four.
-      Proceed to validate_audits even if only one, two, three, or four audits succeeded.
-      Route to escalate_stop ONLY if all five audits fail.
+      If any audit fails, note the failure but continue with the other five.
+      Proceed to validate_audits even if only one, two, three, four, or five audits succeeded.
+      Route to escalate_stop ONLY if all six audits fail.
     capture_list:
       audit_report_paths: "${{ result.audit_report_path }}"
     on_success: validate_audits
@@ -104,6 +106,7 @@ steps:
       3. run_skill(skill_command="/autoskillit:validate-audit {arch_report_path}", cwd="${{ inputs.workspace }}", step_name="validate_arch")
       4. run_skill(skill_command="/autoskillit:validate-audit {feature_gates_report_path}", cwd="${{ inputs.workspace }}", step_name="validate_feature_gates")
       5. run_skill(skill_command="/autoskillit:validate-audit {docs_report_path}", cwd="${{ inputs.workspace }}", step_name="validate_docs")
+      6. run_skill(skill_command="/autoskillit:validate-audit {review_decisions_report_path}", cwd="${{ inputs.workspace }}", step_name="validate_review_decisions")
 
       Skip validation for any audit that failed in wave 1.
       Each validation writes to {{AUTOSKILLIT_TEMP}}/validate-audit/:
@@ -114,7 +117,7 @@ steps:
       output. Record paths for the issue creation wave.
 
       If any validation fails, note it but continue with the others.
-      Route to escalate_stop ONLY if all five validations fail.
+      Route to escalate_stop ONLY if all six validations fail.
     capture_list:
       validated_report_paths: "${{ result.validated_report_path }}"
     on_success: create_issues
@@ -146,6 +149,7 @@ steps:
         run_skill("/autoskillit:prepare-issue {ticket_body_tests_2_path}", step_name="issue_tests_2")
         run_skill("/autoskillit:prepare-issue {ticket_body_tests_3_path}", step_name="issue_tests_3")
         run_skill("/autoskillit:prepare-issue {ticket_body_cohesion_1_path}", step_name="issue_cohesion_1")
+        run_skill("/autoskillit:prepare-issue {ticket_body_review_decisions_1_path}", step_name="issue_review_decisions_1")
         ... (all ticket bodies across all audit types in a single message)
 
       After all issues are created, append the validation summary to each issue body

--- a/src/autoskillit/skills_extended/validate-audit/SKILL.md
+++ b/src/autoskillit/skills_extended/validate-audit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: validate-audit
 categories: [audit]
-description: Validate audit findings from audit-arch, audit-tests, audit-cohesion, audit-feature-gates, or audit-review-decisions against actual code, git history, and design intent using 9–10 parallel subagents. Removes contested findings, documents exceptions, adjusts severities. Use when user says "validate audit", "validate findings", "validate report", or "check audit results".
+description: Validate audit findings from audit-arch, audit-tests, audit-cohesion, audit-feature-gates, audit-docs, or audit-review-decisions against actual code, git history, and design intent using 9–10 parallel subagents. Removes contested findings, documents exceptions, adjusts severities. Use when user says "validate audit", "validate findings", "validate report", or "check audit results".
 hooks:
   PreToolUse:
     - matcher: "*"
@@ -14,14 +14,14 @@ hooks:
 # Validate Audit Findings Skill
 
 Validate audit findings from `audit-arch`, `audit-tests`, `audit-cohesion`,
-`audit-feature-gates`, or `audit-review-decisions` against actual code, git history, and design
+`audit-feature-gates`, `audit-docs`, or `audit-review-decisions` against actual code, git history, and design
 intent using 9–10 parallel subagents. Contested findings are separated into their own file. The
 validated report carries a `validated: true` marker to signal downstream processing.
 
 ## When to Use
 
 - User says "validate audit", "validate findings", "validate report", "check audit results"
-- After running `audit-arch`, `audit-tests`, `audit-cohesion`, `audit-feature-gates`, or `audit-review-decisions` to filter noise before acting
+- After running `audit-arch`, `audit-tests`, `audit-cohesion`, `audit-feature-gates`, `audit-docs`, or `audit-review-decisions` to filter noise before acting
 
 ## Arguments
 
@@ -30,11 +30,12 @@ validated report carries a `validated: true` marker to signal downstream process
 ```
 
 - `audit_report_path` — absolute path to an audit report produced by `audit-arch`,
-  `audit-tests`, `audit-cohesion`, `audit-feature-gates`, or `audit-review-decisions`. If
+  `audit-tests`, `audit-cohesion`, `audit-feature-gates`, `audit-docs`, or `audit-review-decisions`. If
   omitted, use the most recent file under `{{AUTOSKILLIT_TEMP}}/audit-arch/`,
   `{{AUTOSKILLIT_TEMP}}/audit-tests/`, `{{AUTOSKILLIT_TEMP}}/audit-cohesion/`,
-  `{{AUTOSKILLIT_TEMP}}/audit-feature-gates/`, or `{{AUTOSKILLIT_TEMP}}/audit-review-decisions/`
-  (most recent mtime wins across all five).
+  `{{AUTOSKILLIT_TEMP}}/audit-feature-gates/`, `{{AUTOSKILLIT_TEMP}}/audit-docs/`,
+  or `{{AUTOSKILLIT_TEMP}}/audit-review-decisions/`
+  (most recent mtime wins across all six).
   If no files exist under any of these directories, print an error message and exit
   with a non-zero status.
 
@@ -106,8 +107,12 @@ Read the audit report file. Detect its source by examining the document title or
   - **VALID BUT EXCEPTION WARRANTED**: The code pattern persists but a documented constraint,
     ADR, or design decision justifies the current approach.
 
-If none of the five patterns match, print:
-`"Error: unrecognized audit report format — expected title 'Architectural Audit', 'Test Suite Audit', 'Cohesion Audit', 'Feature Gate Audit', or 'Review Decisions Audit'. Aborting."`
+- **audit-docs**: Title contains "Documentation Audit".
+  Source = `docs`. Findings describe documentation drift, staleness, or inconsistency against the
+  codebase. Apply standard VALID / CONTESTED / VALID BUT EXCEPTION WARRANTED verdicts.
+
+If none of the six patterns match, print:
+`"Error: unrecognized audit report format — expected title 'Architectural Audit', 'Test Suite Audit', 'Cohesion Audit', 'Feature Gate Audit', 'Documentation Audit', or 'Review Decisions Audit'. Aborting."`
 and exit with a non-zero status.
 
 For each finding, extract:
@@ -130,7 +135,7 @@ These additional fields must be preserved through validation and into ticket bod
 so that the PR provenance is traceable in the resulting GitHub issues.
 
 Collect all findings into a flat list. Record the source audit skill (`arch`, `tests`,
-`cohesion`, `feature_gates`, or `review_decisions`) for use in output filenames.
+`cohesion`, `feature_gates`, `docs`, or `review_decisions`) for use in output filenames.
 
 ### Step 2 — Group into Thematic Batches
 
@@ -494,7 +499,7 @@ All output files are written relative to the current working directory under `{{
 └── ticket_body_{source}_{N}_{YYYY-MM-DD_HHMMSS}.md       (one per ticket group, N ≥ 1)
 ```
 
-`{source}` is `arch`, `tests`, `cohesion`, `feature_gates`, or `review_decisions` based on the input report.
+`{source}` is `arch`, `tests`, `cohesion`, `feature_gates`, `docs`, or `review_decisions` based on the input report.
 
 ## Related Skills
 
@@ -502,5 +507,6 @@ All output files are written relative to the current working directory under `{{
 - `/autoskillit:audit-tests` — produces reports this skill validates
 - `/autoskillit:audit-cohesion` — produces reports this skill validates
 - `/autoskillit:audit-feature-gates` — produces reports this skill validates
+- `/autoskillit:audit-docs` — produces reports this skill validates
 - `/autoskillit:audit-review-decisions` — produces reports this skill validates
 - `/autoskillit:prepare-issue` — offered interactively for contested findings

--- a/src/autoskillit/skills_extended/validate-audit/SKILL.md
+++ b/src/autoskillit/skills_extended/validate-audit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: validate-audit
 categories: [audit]
-description: Validate audit findings from audit-arch, audit-tests, audit-cohesion, or audit-feature-gates against actual code, git history, and design intent using 9–10 parallel subagents. Removes contested findings, documents exceptions, adjusts severities. Use when user says "validate audit", "validate findings", "validate report", or "check audit results".
+description: Validate audit findings from audit-arch, audit-tests, audit-cohesion, audit-feature-gates, or audit-review-decisions against actual code, git history, and design intent using 9–10 parallel subagents. Removes contested findings, documents exceptions, adjusts severities. Use when user says "validate audit", "validate findings", "validate report", or "check audit results".
 hooks:
   PreToolUse:
     - matcher: "*"
@@ -13,15 +13,15 @@ hooks:
 
 # Validate Audit Findings Skill
 
-Validate audit findings from `audit-arch`, `audit-tests`, `audit-cohesion`, or
-`audit-feature-gates` against actual code, git history, and design intent using 9–10 parallel
-subagents. Contested findings are separated into their own file. The validated report carries a
-`validated: true` marker to signal downstream processing.
+Validate audit findings from `audit-arch`, `audit-tests`, `audit-cohesion`,
+`audit-feature-gates`, or `audit-review-decisions` against actual code, git history, and design
+intent using 9–10 parallel subagents. Contested findings are separated into their own file. The
+validated report carries a `validated: true` marker to signal downstream processing.
 
 ## When to Use
 
 - User says "validate audit", "validate findings", "validate report", "check audit results"
-- After running `audit-arch`, `audit-tests`, `audit-cohesion`, or `audit-feature-gates` to filter noise before acting
+- After running `audit-arch`, `audit-tests`, `audit-cohesion`, `audit-feature-gates`, or `audit-review-decisions` to filter noise before acting
 
 ## Arguments
 
@@ -30,10 +30,11 @@ subagents. Contested findings are separated into their own file. The validated r
 ```
 
 - `audit_report_path` — absolute path to an audit report produced by `audit-arch`,
-  `audit-tests`, `audit-cohesion`, or `audit-feature-gates`. If omitted, use the most
-  recent file under `{{AUTOSKILLIT_TEMP}}/audit-arch/`, `{{AUTOSKILLIT_TEMP}}/audit-tests/`,
-  `{{AUTOSKILLIT_TEMP}}/audit-cohesion/`, or `{{AUTOSKILLIT_TEMP}}/audit-feature-gates/`
-  (most recent mtime wins across all four).
+  `audit-tests`, `audit-cohesion`, `audit-feature-gates`, or `audit-review-decisions`. If
+  omitted, use the most recent file under `{{AUTOSKILLIT_TEMP}}/audit-arch/`,
+  `{{AUTOSKILLIT_TEMP}}/audit-tests/`, `{{AUTOSKILLIT_TEMP}}/audit-cohesion/`,
+  `{{AUTOSKILLIT_TEMP}}/audit-feature-gates/`, or `{{AUTOSKILLIT_TEMP}}/audit-review-decisions/`
+  (most recent mtime wins across all five).
   If no files exist under any of these directories, print an error message and exit
   with a non-zero status.
 
@@ -92,8 +93,21 @@ Read the audit report file. Detect its source by examining the document title or
   - **D1/D5 table rows**: always place in cross-cutting batch; validate by reading
     the config source file named in the table row.
 
-If none of the four patterns match, print:
-`"Error: unrecognized audit report format — expected title 'Architectural Audit', 'Test Suite Audit', 'Cohesion Audit', or 'Feature Gate Audit'. Aborting."`
+- **audit-review-decisions**: Title contains "Review Decisions Audit" or "PR Review Decisions Audit".
+  Source = `review_decisions`. Findings carry PR provenance metadata: PR number, review thread
+  link, verbatim reviewer comment, deferral signal phrase, and optionally REVIEW-FLAG tag metadata
+  (severity, dimension). These fields are additional to the standard severity + file:line + category.
+
+  Verdict rules for review_decisions findings:
+  - **VALID**: The flagged code at `file:line` still exists in the current codebase and the concern
+    is still applicable — the exact code pattern persists unchanged.
+  - **CONTESTED**: The file or function has been substantially rewritten since the review PR.
+    The concern may no longer apply.
+  - **VALID BUT EXCEPTION WARRANTED**: The code pattern persists but a documented constraint,
+    ADR, or design decision justifies the current approach.
+
+If none of the five patterns match, print:
+`"Error: unrecognized audit report format — expected title 'Architectural Audit', 'Test Suite Audit', 'Cohesion Audit', 'Feature Gate Audit', or 'Review Decisions Audit'. Aborting."`
 and exit with a non-zero status.
 
 For each finding, extract:
@@ -104,8 +118,19 @@ For each finding, extract:
 - **Location** — `file:line` references, if present
 - **Category** — the principle, issue category, dimension label, or gate dimension
 
+For `review_decisions` findings, also extract:
+- **PR Number** — the source PR number (e.g., #1234)
+- **PR Link** — full URL to the PR review thread
+- **Reviewer Quote** — verbatim text of the original reviewer comment
+- **Deferral Signal** — the keyword phrase or marker type that triggered the match
+  (e.g., "REVIEW-FLAG", "KEYWORD: out of scope for this fix cycle")
+- **REVIEW-FLAG metadata** — severity and dimension from the structured tag, when present
+
+These additional fields must be preserved through validation and into ticket body files
+so that the PR provenance is traceable in the resulting GitHub issues.
+
 Collect all findings into a flat list. Record the source audit skill (`arch`, `tests`,
-`cohesion`, or `feature_gates`) for use in output filenames.
+`cohesion`, `feature_gates`, or `review_decisions`) for use in output filenames.
 
 ### Step 2 — Group into Thematic Batches
 
@@ -469,7 +494,7 @@ All output files are written relative to the current working directory under `{{
 └── ticket_body_{source}_{N}_{YYYY-MM-DD_HHMMSS}.md       (one per ticket group, N ≥ 1)
 ```
 
-`{source}` is `arch`, `tests`, `cohesion`, or `feature_gates` based on the input report.
+`{source}` is `arch`, `tests`, `cohesion`, `feature_gates`, or `review_decisions` based on the input report.
 
 ## Related Skills
 
@@ -477,4 +502,5 @@ All output files are written relative to the current working directory under `{{
 - `/autoskillit:audit-tests` — produces reports this skill validates
 - `/autoskillit:audit-cohesion` — produces reports this skill validates
 - `/autoskillit:audit-feature-gates` — produces reports this skill validates
+- `/autoskillit:audit-review-decisions` — produces reports this skill validates
 - `/autoskillit:prepare-issue` — offered interactively for contested findings

--- a/tests/recipe/test_full_audit_recipe.py
+++ b/tests/recipe/test_full_audit_recipe.py
@@ -128,6 +128,9 @@ def test_full_audit_semantic_rules_no_errors() -> None:
             "audit-tests",
             "audit-cohesion",
             "audit-arch",
+            "audit-feature-gates",
+            "audit-docs",
+            "audit-review-decisions",
             "validate-audit",
             "prepare-issue",
         }
@@ -136,3 +139,37 @@ def test_full_audit_semantic_rules_no_errors() -> None:
     findings = run_semantic_rules(ctx)
     errors = [f for f in findings if f.severity == Severity.ERROR]
     assert not errors, f"Semantic rule errors: {[f.rule + ': ' + f.message for f in errors]}"
+
+
+def test_full_audit_description_mentions_review_decisions() -> None:
+    """full-audit description must mention audit-review-decisions."""
+    import yaml
+
+    data = yaml.safe_load(RECIPE_PATH.read_text())
+    assert "audit-review-decisions" in data["description"]
+
+
+def test_full_audit_summary_mentions_six() -> None:
+    """full-audit summary must reference 6 parallel chains."""
+    import yaml
+
+    data = yaml.safe_load(RECIPE_PATH.read_text())
+    assert "6" in data["summary"]
+
+
+def test_full_audit_run_audits_note_mentions_review_decisions() -> None:
+    """run_audits note must include audit-review-decisions as the 6th skill."""
+    import yaml
+
+    data = yaml.safe_load(RECIPE_PATH.read_text())
+    note = data["steps"]["run_audits"]["note"]
+    assert "audit-review-decisions" in note
+
+
+def test_full_audit_validate_audits_note_mentions_review_decisions() -> None:
+    """validate_audits note must include review_decisions validation."""
+    import yaml
+
+    data = yaml.safe_load(RECIPE_PATH.read_text())
+    note = data["steps"]["validate_audits"]["note"]
+    assert "review_decisions" in note

--- a/tests/skills/test_audit_review_decisions_contracts.py
+++ b/tests/skills/test_audit_review_decisions_contracts.py
@@ -1,0 +1,70 @@
+"""Contract tests for the audit-review-decisions skill SKILL.md."""
+
+from __future__ import annotations
+
+import functools
+
+from autoskillit.core.types import SkillSource
+from autoskillit.workspace.skills import DefaultSkillResolver
+
+
+@functools.cache
+def _skill_text() -> str:
+    info = DefaultSkillResolver().resolve("audit-review-decisions")
+    assert info is not None, "audit-review-decisions skill not found"
+    return info.path.read_text()
+
+
+class TestAuditReviewDecisionsExists:
+    def test_skill_exists(self) -> None:
+        info = DefaultSkillResolver().resolve("audit-review-decisions")
+        assert info is not None
+        assert info.source == SkillSource.BUNDLED_EXTENDED
+        assert info.path.exists()
+
+    def test_has_audit_category(self) -> None:
+        info = DefaultSkillResolver().resolve("audit-review-decisions")
+        assert info is not None
+        assert "audit" in info.categories
+
+
+class TestAuditReviewDecisionsContent:
+    def test_graphql_alias_batching(self) -> None:
+        text = _skill_text().lower()
+        assert "alias" in text or "batch" in text
+
+    def test_ratelimit_in_queries(self) -> None:
+        assert "rateLimit" in _skill_text()
+
+    def test_haiku_triage_phase(self) -> None:
+        text = _skill_text().lower()
+        assert "haiku" in text
+        assert "triage" in text or "broad pass" in text
+
+    def test_sonnet_validation_phase(self) -> None:
+        text = _skill_text().lower()
+        assert "sonnet" in text
+        assert "valid" in text
+
+    def test_audit_watermark_marker(self) -> None:
+        assert "[AUDIT]" in _skill_text()
+
+    def test_review_flag_detection(self) -> None:
+        assert "REVIEW-FLAG" in _skill_text()
+
+    def test_output_dir(self) -> None:
+        assert "audit-review-decisions/" in _skill_text()
+
+    def test_report_title_matches_validate_audit_detection(self) -> None:
+        """Report title must contain 'Review Decisions Audit' for validate-audit detection."""
+        assert "Review Decisions Audit" in _skill_text()
+
+    def test_structured_output_token(self) -> None:
+        assert "review_decisions_audit_" in _skill_text()
+
+    def test_sleep_between_mutating_calls(self) -> None:
+        assert "sleep 1" in _skill_text()
+
+    def test_idempotent_watermark(self) -> None:
+        text = _skill_text().lower()
+        assert "idempotent" in text or "already" in text

--- a/tests/skills/test_audit_review_decisions_contracts.py
+++ b/tests/skills/test_audit_review_decisions_contracts.py
@@ -31,7 +31,7 @@ class TestAuditReviewDecisionsExists:
 class TestAuditReviewDecisionsContent:
     def test_graphql_alias_batching(self) -> None:
         text = _skill_text().lower()
-        assert "alias" in text or "batch" in text
+        assert "alias" in text
 
     def test_ratelimit_in_queries(self) -> None:
         assert "rateLimit" in _skill_text()

--- a/tests/skills/test_validate_audit_contracts.py
+++ b/tests/skills/test_validate_audit_contracts.py
@@ -55,12 +55,13 @@ class TestValidateAuditContent:
         assert "contested_findings_" in text
 
     # T-VAL-012
-    def test_handles_all_five_audit_formats(self) -> None:
+    def test_handles_all_six_audit_formats(self) -> None:
         text = _skill_text()
         assert "audit-arch" in text
         assert "audit-tests" in text
         assert "audit-cohesion" in text
         assert "audit-feature-gates" in text or "feature_gates" in text
+        assert "audit-docs" in text or "docs" in text
         assert "audit-review-decisions" in text or "review_decisions" in text
 
     # T-VAL-013
@@ -155,11 +156,12 @@ class TestValidateAuditReviewDecisions:
         assert "pr number" in text or "pr provenance" in text or "pr #" in text
 
     # T-VAL-025
-    def test_error_message_lists_five_formats(self) -> None:
-        """Error message for unrecognized format must list all 5 recognized formats."""
+    def test_error_message_lists_six_formats(self) -> None:
+        """Error message for unrecognized format must list all 6 recognized formats."""
         text = _skill_text()
         assert "Review Decisions Audit" in text
         assert "Architectural Audit" in text
         assert "Test Suite Audit" in text
         assert "Cohesion Audit" in text
         assert "Feature Gate Audit" in text
+        assert "Documentation Audit" in text

--- a/tests/skills/test_validate_audit_contracts.py
+++ b/tests/skills/test_validate_audit_contracts.py
@@ -55,11 +55,13 @@ class TestValidateAuditContent:
         assert "contested_findings_" in text
 
     # T-VAL-012
-    def test_handles_all_three_audit_formats(self) -> None:
+    def test_handles_all_five_audit_formats(self) -> None:
         text = _skill_text()
         assert "audit-arch" in text
         assert "audit-tests" in text
         assert "audit-cohesion" in text
+        assert "audit-feature-gates" in text or "feature_gates" in text
+        assert "audit-review-decisions" in text or "review_decisions" in text
 
     # T-VAL-013
     def test_interactive_headless_distinction(self) -> None:
@@ -131,3 +133,33 @@ class TestValidateAuditFeatureGates:
             "produce table-format findings without file:line and must be handled in the "
             "cross-cutting batch with direct file verification"
         )
+
+
+class TestValidateAuditReviewDecisions:
+    # T-VAL-022
+    def test_handles_review_decisions_audit_format(self) -> None:
+        """validate-audit must recognize 'Review Decisions Audit' as a source format."""
+        text = _skill_text()
+        assert "Review Decisions Audit" in text
+
+    # T-VAL-023
+    def test_review_decisions_source_name(self) -> None:
+        """validate-audit must use 'review_decisions' as the source name."""
+        text = _skill_text()
+        assert "review_decisions" in text
+
+    # T-VAL-024
+    def test_review_decisions_pr_provenance_preserved(self) -> None:
+        """validate-audit must preserve PR provenance metadata for review_decisions findings."""
+        text = _skill_text().lower()
+        assert "pr number" in text or "pr provenance" in text or "pr #" in text
+
+    # T-VAL-025
+    def test_error_message_lists_five_formats(self) -> None:
+        """Error message for unrecognized format must list all 5 recognized formats."""
+        text = _skill_text()
+        assert "Review Decisions Audit" in text
+        assert "Architectural Audit" in text
+        assert "Test Suite Audit" in text
+        assert "Cohesion Audit" in text
+        assert "Feature Gate Audit" in text

--- a/tests/workspace/test_skills.py
+++ b/tests/workspace/test_skills.py
@@ -197,6 +197,7 @@ AUDIT_SKILL_NAMES = [
     "audit-defense-standards",
     "validate-audit",
     "audit-docs",
+    "audit-review-decisions",
 ]
 
 BUNDLED_SKILL_NAMES = set(BUNDLED_SKILLS)
@@ -569,6 +570,7 @@ class TestSkillCategories:
             "audit-impl",
             "validate-audit",
             "audit-docs",
+            "audit-review-decisions",
         ]:
             info = resolver.resolve(name)
             assert info is not None


### PR DESCRIPTION
## Summary

Issue #1598 defines a 4-part feature: structured REVIEW-FLAG markers in resolve-review (Part 0), the audit-review-decisions SKILL.md (Part 1), validate-audit compatibility (Part 2), and full-audit recipe integration (Part 3). Parts 0 and 1 were already complete — resolve-review already emits `<!-- REVIEW-FLAG: severity=${severity} dimension=${dimension} -->` markers and the `audit-review-decisions/SKILL.md` already exists with the full 5-step workflow. This PR delivers Parts 2 and 3: updating `validate-audit/SKILL.md` to recognize "Review Decisions Audit" as a 5th source format with PR provenance metadata, and updating `full-audit.yaml` to include audit-review-decisions as the 6th parallel chain across all three waves (run_audits, validate_audits, create_issues).

## Requirements

### MARK — Structured Review Markers (Part 0)

**REQ-MARK-001:** resolve-review must emit a machine-parsable marker tag in every DISCUSS reply comment.
**REQ-MARK-002:** Each marker must carry the finding's severity (critical/warning/info) and dimension (bugs, arch, security, etc.) from the originating review-pr finding.
**REQ-MARK-003:** The marker must be extractable from comment text via a single regex pattern.
**REQ-MARK-004:** The marker must not disrupt the human-readable portion of the comment (HTML comment or trailing tag).

### MINE — Comment Mining (Phase 1)

**REQ-MINE-001:** The skill must query PR review threads via GraphQL batch queries with aliases.
**REQ-MINE-002:** The skill must detect structured REVIEW-FLAG markers as the primary signal.
**REQ-MINE-003:** The skill must fall back to keyword matching for legacy comments predating the structured markers.
**REQ-MINE-004:** The skill must support a configurable time period parameter to scope the PR history window.
**REQ-MINE-005:** The skill must also detect review-pr `needs_human` findings that bypassed resolve-review entirely.

### TRIAGE — Broad-Pass Filtering (Phase 2)

**REQ-TRIAGE-001:** Triage subagents must operate on local data (JSON files saved during Phase 1) — no API calls during triage.
**REQ-TRIAGE-002:** Triage must use a loose filter — false positives acceptable, false negatives are not.
**REQ-TRIAGE-003:** Threads with existing `[AUDIT]` markers must be skipped.

### RPT — Report Generation (Phase 3)

**REQ-RPT-001:** The skill must produce a structured markdown report file at the configured output path.
**REQ-RPT-002:** The report must be detectable by validate-audit's source format auto-detection (via report title).
**REQ-RPT-003:** Each finding must include severity, file path and line, PR number, and the original reviewer comment as a verbatim quote.
**REQ-RPT-004:** Each finding must include structured tag metadata (severity, dimension) when the REVIEW-FLAG marker is present.
**REQ-RPT-005:** Each finding must include the deferral signal that triggered the match (keyword phrase or marker type).
**REQ-RPT-006:** The report must include a summary table, priority triage (HIGH / MEDIUM / LOW), and pattern analysis section.
**REQ-RPT-007:** The report must be organized for human scannability with clear per-finding sections.

### COMPAT — validate-audit Compatibility (Part 2)

**REQ-COMPAT-001:** validate-audit must recognize "Review Decisions Audit" as a valid source format in its Step 1 auto-detection.
**REQ-COMPAT-002:** validate-audit's finding parser must preserve PR provenance metadata (PR number, review thread link, verbatim comment, deferral signal) through validation and into ticket body files.

### RECIPE — full-audit Recipe Integration (Part 3)

**REQ-RECIPE-001:** `full-audit.yaml` must include audit-review-decisions as a parallel chain across all three waves (run_audits, validate_audits, create_issues).
**REQ-RECIPE-002:** A failure in the review-decisions chain must not block the other audit chains (same independence guarantee as the existing 5).

### WM — Watermarking (Phase 4)

**REQ-WM-001:** Processed threads must receive an `[AUDIT]` marker comment referencing the audit run date.
**REQ-WM-002:** Future runs must skip threads that already have audit markers.
**REQ-WM-003:** Watermark timestamp must automatically narrow the scan window on subsequent runs.
**REQ-WM-004:** No duplicate markers may be posted on re-runs (idempotent).
**REQ-WM-005:** Marker comments must use individual thread reply calls with 1s delay between mutating calls (thread replies cannot be batched via the reviews API).

Closes #1598

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260502-113624-516030/.autoskillit/temp/make-plan/audit_review_decisions_plan_2026-05-02_114800.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 5.5k | 14.6k | 1.6M | 81.1k | 1 | 8m 56s |
| verify | 763 | 12.5k | 1.1M | 58.7k | 1 | 7m 8s |
| implement | 244 | 16.5k | 1.6M | 73.8k | 1 | 4m 59s |
| prepare_pr | 60 | 4.9k | 228.7k | 34.0k | 1 | 1m 44s |
| compose_pr | 75 | 3.4k | 270.1k | 22.3k | 1 | 54s |
| review_pr | 210 | 58.4k | 1.3M | 131.7k | 2 | 13m 56s |
| resolve_review | 363 | 19.4k | 2.8M | 75.4k | 1 | 8m 50s |
| resolve_queue_merge_conflicts | 476 | 15.4k | 2.3M | 125.7k | 3 | 5m 54s |
| **Total** | 7.7k | 145.1k | 11.3M | 602.8k | | 52m 24s |