### PR TITLE
Implementation Plan: Planner recipe — pass task as file path, not inline content

### DIFF
--- a/src/autoskillit/planner/compiler.py
+++ b/src/autoskillit/planner/compiler.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 from collections import deque
 from pathlib import Path
+from typing import Any
 
 from autoskillit.core import atomic_write, get_logger, write_versioned_json
 from autoskillit.planner.validation import (
@@ -118,7 +119,12 @@ def _render_issue_body(wp: dict, phase: dict, assignment: dict) -> str:
     return body
 
 
-def compile_plan(output_dir: str, task: str, source_dir: str) -> dict[str, str]:
+def compile_plan(
+    output_dir: str, task: str, source_dir: str, task_file: str = "", **kwargs: Any
+) -> dict[str, str]:
+    task_label = task
+    if task_file:
+        task = Path(task_file).read_text()
     root = Path(output_dir)
 
     phase_results = _load_phase_results(root)
@@ -233,7 +239,7 @@ def compile_plan(output_dir: str, task: str, source_dir: str) -> dict[str, str]:
         schema_version=1,
     )
 
-    md_lines = [f"# Plan: {task}", ""]
+    md_lines = [f"# Plan: {task_label}", ""]
     for phase in sorted(phase_results.values(), key=lambda p: p["phase_number"]):
         phase_num = phase["phase_number"]
         md_lines.append(f"## Phase {phase_num}: {phase['name']}")

--- a/src/autoskillit/planner/merge.py
+++ b/src/autoskillit/planner/merge.py
@@ -20,8 +20,11 @@ def merge_files(
     task: str = "",
     source_dir: str = "",
     strict: bool = True,
+    task_file: str = "",
     **kwargs: Any,
 ) -> dict[str, Any]:
+    if task_file:
+        task = Path(task_file).read_text()
     if key not in _TIER_KEYS:
         raise ValueError(f"Invalid key {key!r}; must be one of {_TIER_KEYS}")
 
@@ -165,6 +168,7 @@ def merge_tier_dir(
     key: str,
     task: str = "",
     source_dir: str = "",
+    task_file: str = "",
     **kwargs: Any,
 ) -> dict[str, Any]:
     paths = sorted(Path(results_dir).glob("*_result.json"))
@@ -176,6 +180,7 @@ def merge_tier_dir(
         key=key,
         task=task,
         source_dir=source_dir,
+        task_file=task_file,
     )
 
 
@@ -184,8 +189,11 @@ def build_plan_snapshot(
     output_path: str,
     task: str = "",
     source_dir: str = "",
+    task_file: str = "",
     **kwargs: Any,
 ) -> dict[str, Any]:
+    if task_file:
+        task = Path(task_file).read_text()
     phase_pairs: list[tuple[int, dict[str, Any]]] = []
     for p in sorted(Path(phases_dir).glob("*_result.json")):
         try:

--- a/src/autoskillit/recipes/planner.yaml
+++ b/src/autoskillit/recipes/planner.yaml
@@ -34,6 +34,9 @@ ingredients:
   task:
     description: "High-level task or feature description to decompose into a plan."
     required: true
+  task_file:
+    description: "Absolute path to a file containing the task description. Use instead of task for document-scale inputs."
+    required: false
   source_dir:
     description: "Absolute path to the repository root to analyze."
     required: true
@@ -74,6 +77,7 @@ steps:
       env:
         PLANNER_ANALYSIS_FILE: "${{ context.planner_dir }}/analysis.json"
         PLANNER_TASK: "${{ inputs.task }}"
+        PLANNER_TASK_FILE: "${{ inputs.task_file }}"
     on_success: generate_phases
     on_failure: generate_phases
 
@@ -87,6 +91,7 @@ steps:
       cwd: "${{ inputs.source_dir }}"
       env:
         PLANNER_TASK: "${{ inputs.task }}"
+        PLANNER_TASK_FILE: "${{ inputs.task_file }}"
     capture:
       phase_manifest_path: "${{ result.phase_manifest_path }}"
     on_success: build_plan_snapshot
@@ -102,6 +107,7 @@ steps:
       phase_manifest_path: "${{ context.phase_manifest_path }}"
       output_path: "${{ context.planner_dir }}/plan_snapshot.json"
       task: "${{ inputs.task }}"
+      task_file: "${{ inputs.task_file }}"
       source_dir: "${{ inputs.source_dir }}"
     capture:
       plan_snapshot_path: "${{ result.snapshot_path }}"
@@ -134,6 +140,7 @@ steps:
       output_path: "${{ context.planner_dir }}/combined_plan.json"
       key: "phases"
       task: "${{ inputs.task }}"
+      task_file: "${{ inputs.task_file }}"
       source_dir: "${{ inputs.source_dir }}"
     capture:
       combined_phases_path: "${{ result.merged_path }}"
@@ -187,6 +194,7 @@ steps:
       output_path: "${{ context.planner_dir }}/combined_assignments.json"
       key: "assignments"
       task: "${{ inputs.task }}"
+      task_file: "${{ inputs.task_file }}"
       source_dir: "${{ inputs.source_dir }}"
     capture:
       combined_assignments_path: "${{ result.merged_path }}"
@@ -254,6 +262,7 @@ steps:
       output_path: "${{ context.planner_dir }}/combined_wps.json"
       key: "work_packages"
       task: "${{ inputs.task }}"
+      task_file: "${{ inputs.task_file }}"
       source_dir: "${{ inputs.source_dir }}"
     capture:
       combined_wps_path: "${{ result.merged_path }}"
@@ -381,6 +390,7 @@ steps:
       callable: "autoskillit.planner.compile_plan"
       output_dir: "${{ context.planner_dir }}"
       task: "${{ inputs.task }}"
+      task_file: "${{ inputs.task_file }}"
       source_dir: "${{ inputs.source_dir }}"
     on_success: done
     on_failure: escalate_stop

--- a/src/autoskillit/skills_extended/planner-extract-domain/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-extract-domain/SKILL.md
@@ -24,6 +24,7 @@ Extract domain knowledge, naming conventions, and structural patterns specific t
 
 - **`PLANNER_ANALYSIS_FILE`** (env-var) — Absolute path to `analysis.json` produced by `planner-analyze`. Set by the recipe via the step's `env:` block.
 - **`PLANNER_TASK`** (env-var, optional) — The user's task description. When set, focus domain extraction on areas relevant to the stated task rather than performing a full-codebase survey.
+- **`PLANNER_TASK_FILE`** (env-var, optional) — Absolute path to a file containing the task description. When set, read the file content and use it as the task. Takes precedence over `PLANNER_TASK`.
 
 ## Critical Constraints
 
@@ -45,8 +46,10 @@ Read the `analysis.json` file from the path in the PLANNER_ANALYSIS_FILE environ
 
 ### Step 2: Launch 3–5 parallel Explore subagents
 
-If `PLANNER_TASK` is set, include it in each subagent's prompt: "Focus exploration on
-domain vocabulary, abstractions, and integration points relevant to this task: {PLANNER_TASK}.
+Read the task description: if `PLANNER_TASK_FILE` is set, read the file at that path; otherwise use `PLANNER_TASK`.
+
+If the task description is available, include it in each subagent's prompt: "Focus exploration on
+domain vocabulary, abstractions, and integration points relevant to this task: {task}.
 Prioritize areas the task will touch over exhaustive full-codebase coverage."
 
 Spawn all concurrently with `model: "sonnet"`. Always spawn agents 1–3; spawn agents 4–5 only when the project has >20 modules or architecture_style is layered/hexagonal:

--- a/src/autoskillit/skills_extended/planner-generate-phases/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-generate-phases/SKILL.md
@@ -29,7 +29,8 @@ Pass 1 entry point. Read the analysis file (and optionally domain knowledge) and
 
 ### Environment Variables
 
-- **PLANNER_TASK** (required) — The user's task description. Every phase MUST serve this task.
+- **PLANNER_TASK** (required unless PLANNER_TASK_FILE is set) — The user's task description. Every phase MUST serve this task.
+- **PLANNER_TASK_FILE** (env-var, optional) — Absolute path to a file containing the task description. When set, read the file content and use it as the task. Takes precedence over `PLANNER_TASK`.
 
 ## Critical Constraints
 
@@ -51,7 +52,7 @@ Pass 1 entry point. Read the analysis file (and optionally domain knowledge) and
 
 ### Step 0: Read task description
 
-Read the task description from the `PLANNER_TASK` environment variable. This is the user's
+If `PLANNER_TASK_FILE` is set, read the file at that path to obtain the task description. Otherwise read `PLANNER_TASK` from the environment. This is the user's
 statement of what they want planned. Every generated phase MUST serve this task.
 Do not generate phases for work not described in the task. If the task asks for specific
 deliverables (e.g., "split research.yaml into 4 sub-recipes"), the phases should decompose

--- a/tests/planner/test_compiler.py
+++ b/tests/planner/test_compiler.py
@@ -373,3 +373,23 @@ def test_compile_plan_skips_assessment_entries_missing_wp_id(tmp_path: Path) -> 
     issue_body = (output_dir / "issues" / "P1-A1-WP1_issue.md").read_text()
     assert "## Review Approach" in issue_body
     assert "valid entry" in issue_body
+
+
+def test_compile_plan_reads_task_from_file(tmp_path: Path) -> None:
+    output_dir = _make_valid_output_dir(tmp_path)
+    task_file = tmp_path / "task_desc.txt"
+    task_file.write_text("Full task description from file")
+    result = compile_plan(
+        str(output_dir), task="label", source_dir="/src", task_file=str(task_file)
+    )
+    plan_json = json.loads((output_dir / "plan.json").read_text())
+    assert plan_json["task"] == "Full task description from file"
+    plan_md = Path(result["plan_path"]).read_text()
+    assert plan_md.startswith("# Plan: label")
+
+
+def test_compile_plan_falls_back_to_task_when_no_file(tmp_path: Path) -> None:
+    output_dir = _make_valid_output_dir(tmp_path)
+    compile_plan(str(output_dir), task="inline task", source_dir="/src")
+    plan_json = json.loads((output_dir / "plan.json").read_text())
+    assert plan_json["task"] == "inline task"

--- a/tests/planner/test_merge.py
+++ b/tests/planner/test_merge.py
@@ -469,3 +469,47 @@ def test_replace_item_corrupt_replacement_json_raises(tmp_path) -> None:
 
     with pytest.raises(ValueError, match="Invalid JSON"):
         replace_item(str(src), "P1", str(corrupt))
+
+
+def test_build_plan_snapshot_reads_task_from_file(tmp_path) -> None:
+    phases_dir = tmp_path / "phases"
+    phases_dir.mkdir()
+    (phases_dir / "P1_result.json").write_text(json.dumps(make_phase_result(1)))
+    out = tmp_path / "snapshot.json"
+    task_file = tmp_path / "task_desc.txt"
+    task_file.write_text("Full task from file")
+
+    build_plan_snapshot(str(phases_dir), str(out), task="label", task_file=str(task_file))
+
+    data = json.loads(out.read_text())
+    assert data["task"] == "Full task from file"
+
+
+def test_merge_tier_dir_reads_task_from_file(tmp_path) -> None:
+    results_dir = tmp_path / "phases"
+    results_dir.mkdir()
+    (results_dir / "P1_result.json").write_text(
+        json.dumps({"id": "P1", "name": "Phase 1", "ordering": 1})
+    )
+    out = tmp_path / "combined.json"
+    task_file = tmp_path / "task_desc.txt"
+    task_file.write_text("Full task from file")
+
+    merge_tier_dir(str(results_dir), str(out), "phases", task="label", task_file=str(task_file))
+
+    data = json.loads(out.read_text())
+    assert data["task"] == "Full task from file"
+
+
+def test_merge_files_reads_task_from_file(tmp_path) -> None:
+    item = {"id": "P1", "name": "Phase 1"}
+    p = tmp_path / "P1_result.json"
+    p.write_text(json.dumps(item))
+    out = tmp_path / "combined.json"
+    task_file = tmp_path / "task_desc.txt"
+    task_file.write_text("Full task from file")
+
+    merge_files([str(p)], str(out), "phases", task="label", task_file=str(task_file))
+
+    data = json.loads(out.read_text())
+    assert data["task"] == "Full task from file"

--- a/tests/recipe/test_planner_recipe.py
+++ b/tests/recipe/test_planner_recipe.py
@@ -285,3 +285,45 @@ def test_planner_recipe_assess_review_approach_routes_to_validate_on_failure(pla
     step = planner_recipe.steps["assess_review_approach_step"]
     assert step.on_success == "validate"
     assert step.on_failure == "validate"
+
+
+# --- task_file ingredient tests ---
+
+
+def test_planner_recipe_has_task_file_ingredient(planner_recipe):
+    ingredients = planner_recipe.ingredients
+    assert "task_file" in ingredients, "planner recipe must have task_file ingredient"
+    assert ingredients["task_file"].required is False
+
+
+def test_extract_domain_receives_planner_task_file_env(planner_recipe):
+    step = planner_recipe.steps["extract_domain"]
+    env = step.with_args.get("env", {})
+    assert "PLANNER_TASK_FILE" in env, "extract_domain must pass PLANNER_TASK_FILE env var"
+    assert "inputs.task_file" in env["PLANNER_TASK_FILE"]
+
+
+def test_generate_phases_receives_planner_task_file_env(planner_recipe):
+    step = planner_recipe.steps["generate_phases"]
+    env = step.with_args.get("env", {})
+    assert "PLANNER_TASK_FILE" in env, "generate_phases must pass PLANNER_TASK_FILE env var"
+    assert "inputs.task_file" in env["PLANNER_TASK_FILE"]
+
+
+def test_build_plan_snapshot_receives_task_file(planner_recipe):
+    step = planner_recipe.steps["build_plan_snapshot"]
+    assert "task_file" in step.with_args, "build_plan_snapshot must receive task_file"
+    assert "inputs.task_file" in step.with_args["task_file"]
+
+
+@pytest.mark.parametrize("step_name", ["merge_phases", "merge_assignments", "merge_wps"])
+def test_merge_steps_receive_task_file(planner_recipe, step_name):
+    step = planner_recipe.steps[step_name]
+    assert "task_file" in step.with_args, f"{step_name} must receive task_file"
+    assert "inputs.task_file" in step.with_args["task_file"]
+
+
+def test_compile_step_receives_task_file(planner_recipe):
+    step = planner_recipe.steps["compile"]
+    assert "task_file" in step.with_args, "compile must receive task_file"
+    assert "inputs.task_file" in step.with_args["task_file"]

--- a/tests/skills/test_planner_extract_domain.py
+++ b/tests/skills/test_planner_extract_domain.py
@@ -16,3 +16,8 @@ def test_planner_extract_domain_skill_uses_env_var():
 def test_extract_domain_skill_references_planner_task():
     content = (pkg_root() / "skills_extended" / "planner-extract-domain" / "SKILL.md").read_text()
     assert "PLANNER_TASK" in content, "SKILL.md must document PLANNER_TASK env var"
+
+
+def test_extract_domain_skill_references_planner_task_file():
+    content = (pkg_root() / "skills_extended" / "planner-extract-domain" / "SKILL.md").read_text()
+    assert "PLANNER_TASK_FILE" in content, "SKILL.md must document PLANNER_TASK_FILE env var"

--- a/tests/skills/test_planner_skill_contracts.py
+++ b/tests/skills/test_planner_skill_contracts.py
@@ -384,3 +384,8 @@ def test_planner_skill_example_paths_are_run_scoped(skill_name: str) -> None:
                     f"'{{{{AUTOSKILLIT_TEMP}}}}/planner' as example. "
                     f"Use run-scoped form: '{{{{AUTOSKILLIT_TEMP}}}}/planner/run-YYYYMMDD-HHMMSS'"
                 )
+
+
+def test_generate_phases_skill_references_planner_task_file():
+    content = (SKILLS_ROOT / "planner-generate-phases" / "SKILL.md").read_text()
+    assert "PLANNER_TASK_FILE" in content, "SKILL.md must document PLANNER_TASK_FILE env var"


### PR DESCRIPTION
## Summary

Add a `task_file` ingredient to the planner recipe that accepts an absolute path to a task description file. When provided, the orchestrator passes only the file path (a small string) through `${{ inputs.task_file }}` to each step. Skills read the file via `PLANNER_TASK_FILE` env var; `run_python` callables read it via a `task_file` kwarg. The existing `task` ingredient remains for short inline descriptions and serves as a label for markdown headings. This eliminates context bloat from interpolating large task content 7 times in the orchestrator session.

Closes #1619

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260502-131315-236455/.autoskillit/temp/make-plan/planner_task_file_ingredient_plan_2026-05-02_131500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 977 | 20.2k | 812.6k | 94.6k | 1 | 12m 17s |
| verify | 38 | 8.5k | 1.1M | 54.3k | 1 | 4m 19s |
| implement | 60 | 13.0k | 2.5M | 82.6k | 1 | 5m 43s |
| prepare_pr | 25 | 3.5k | 221.4k | 27.6k | 1 | 1m 14s |
| compose_pr | 22 | 1.4k | 132.0k | 18.8k | 1 | 32s |
| review_pr | 29 | 21.1k | 483.3k | 55.5k | 1 | 5m 52s |
| **Total** | 1.2k | 67.7k | 5.2M | 333.4k | | 29m 57s |