### PR TITLE
Implementation Plan: New Bundled Skill — ci_watch_post_queue_fix auto_trigger + timed_out guard + merge-prs branch fix

### DIFF
--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -1194,6 +1194,7 @@ steps:
       timeout_seconds: 600
       cwd: "${{ context.work_dir }}"
       remote_url: "${{ context.remote_url }}"
+      auto_trigger: "true"
     capture:
       ci_conclusion: "${{ result.conclusion }}"
       ci_failed_jobs: "${{ result.failed_jobs }}"
@@ -1203,15 +1204,38 @@ steps:
       - when: "${{ result.conclusion }} == 'no_runs'"
         route: release_issue_failure
       - when: "${{ result.conclusion }} == 'timed_out'"
-        route: ci_watch_post_queue_fix
+        route: check_ci_post_queue_loop
       - route: detect_ci_conflict
     on_failure: detect_ci_conflict
     skip_when_false: "inputs.open_pr"
     note: >
       Validates CI on the rebased feature branch after queue ejection fix and re-push.
       Routes on result.conclusion: success → reenter_merge_queue,
-      no_runs → release_issue_failure (post-queue-fix is already a retry path),
-      timed_out → self (re-watch), failure → detect_ci_conflict.
+      no_runs → release_issue_failure (auto_trigger fires first: empty commit +
+      force-push + re-poll; no_runs reached only when trigger recovery fails),
+      timed_out → check_ci_post_queue_loop, failure → detect_ci_conflict.
+
+  check_ci_post_queue_loop:
+    tool: run_python
+    with:
+      callable: "autoskillit.smoke_utils.check_loop_iteration"
+      current_iteration: "${{ context.ci_post_queue_loop_count }}"
+      max_iterations: "2"
+    capture:
+      ci_post_queue_loop_count: "${{ result.next_iteration }}"
+    on_result:
+      - when: "${{ result.max_exceeded }} == true"
+        route: release_issue_failure
+      - route: ci_watch_post_queue_fix
+    on_failure: release_issue_failure
+    optional_context_refs:
+      - ci_post_queue_loop_count
+    skip_when_false: "inputs.open_pr"
+    note: >
+      Iteration guard for the ci_watch_post_queue_fix timed_out self-loop.
+      Caps at 2 iterations (initial + 1 retry). On budget exhaustion,
+      routes to release_issue_failure — this is already a post-ejection
+      retry path so further escalation is not warranted.
 
   reenter_merge_queue:
     tool: enqueue_pr

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -1103,6 +1103,7 @@ steps:
       timeout_seconds: 600
       cwd: "${{ context.work_dir }}"
       remote_url: "${{ context.remote_url }}"
+      auto_trigger: "true"
     capture:
       ci_conclusion: "${{ result.conclusion }}"
       ci_failed_jobs: "${{ result.failed_jobs }}"
@@ -1112,15 +1113,38 @@ steps:
       - when: "${{ result.conclusion }} == 'no_runs'"
         route: release_issue_failure
       - when: "${{ result.conclusion }} == 'timed_out'"
-        route: ci_watch_post_queue_fix
+        route: check_ci_post_queue_loop
       - route: detect_ci_conflict
     on_failure: detect_ci_conflict
     skip_when_false: "inputs.open_pr"
     note: >
       Validates CI on the rebased feature branch after queue ejection fix and re-push.
       Routes on result.conclusion: success → reenter_merge_queue,
-      no_runs → release_issue_failure (post-queue-fix is already a retry path),
-      timed_out → self (re-watch), failure → detect_ci_conflict.
+      no_runs → release_issue_failure (auto_trigger fires first: empty commit +
+      force-push + re-poll; no_runs reached only when trigger recovery fails),
+      timed_out → check_ci_post_queue_loop, failure → detect_ci_conflict.
+
+  check_ci_post_queue_loop:
+    tool: run_python
+    with:
+      callable: "autoskillit.smoke_utils.check_loop_iteration"
+      current_iteration: "${{ context.ci_post_queue_loop_count }}"
+      max_iterations: "2"
+    capture:
+      ci_post_queue_loop_count: "${{ result.next_iteration }}"
+    on_result:
+      - when: "${{ result.max_exceeded }} == true"
+        route: release_issue_failure
+      - route: ci_watch_post_queue_fix
+    on_failure: release_issue_failure
+    optional_context_refs:
+      - ci_post_queue_loop_count
+    skip_when_false: "inputs.open_pr"
+    note: >
+      Iteration guard for the ci_watch_post_queue_fix timed_out self-loop.
+      Caps at 2 iterations (initial + 1 retry). On budget exhaustion,
+      routes to release_issue_failure — this is already a post-ejection
+      retry path so further escalation is not warranted.
 
   reenter_merge_queue:
     tool: enqueue_pr

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -379,23 +379,50 @@ steps:
   ci_watch_post_queue_fix:
     tool: wait_for_ci
     with:
-      pr_number: "${{ context.current_pr_number }}"
-      cwd: "${{ context.work_dir }}"
-      remote_url: "${{ context.remote_url }}"
+      branch: "${{ context.ejected_pr_branch }}"
       event: "${{ context.ci_event }}"
       timeout_seconds: 600
+      cwd: "${{ context.work_dir }}"
+      remote_url: "${{ context.remote_url }}"
+      auto_trigger: "true"
+    capture:
+      ci_conclusion: "${{ result.conclusion }}"
+      ci_failed_jobs: "${{ result.failed_jobs }}"
     on_result:
       - when: "${{ result.conclusion }} == 'success'"
         route: reenter_queue
+      - when: "${{ result.conclusion }} == 'no_runs'"
+        route: register_clone_failure
       - when: "${{ result.conclusion }} == 'timed_out'"
-        route: ci_watch_post_queue_fix
+        route: check_ci_post_queue_loop
       - route: register_clone_failure
     on_failure: register_clone_failure
     note: >
       Validates CI passes on the rebased branch before re-entering the merge queue.
       Prevents re-enqueue of a broken branch that would be ejected again.
       Routes on result.conclusion: success → reenter_queue,
-      timed_out → self (re-watch), no_runs/failure → register_clone_failure.
+      no_runs → register_clone_failure (auto_trigger fires first: empty commit +
+      force-push + re-poll; no_runs reached only when trigger recovery fails),
+      timed_out → check_ci_post_queue_loop, failure → register_clone_failure.
+
+  check_ci_post_queue_loop:
+    tool: run_python
+    with:
+      callable: "autoskillit.smoke_utils.check_loop_iteration"
+      current_iteration: "${{ context.ci_post_queue_loop_count }}"
+      max_iterations: "2"
+    capture:
+      ci_post_queue_loop_count: "${{ result.next_iteration }}"
+    on_result:
+      - when: "${{ result.max_exceeded }} == true"
+        route: register_clone_failure
+      - route: ci_watch_post_queue_fix
+    on_failure: register_clone_failure
+    optional_context_refs:
+      - ci_post_queue_loop_count
+    note: >
+      Iteration guard for the ci_watch_post_queue_fix timed_out self-loop.
+      Caps at 2 iterations. On budget exhaustion, routes to register_clone_failure.
 
   reenter_queue:
     tool: enqueue_pr

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -1103,6 +1103,7 @@ steps:
       timeout_seconds: 600
       cwd: "${{ context.work_dir }}"
       remote_url: "${{ context.remote_url }}"
+      auto_trigger: "true"
     capture:
       ci_conclusion: "${{ result.conclusion }}"
       ci_failed_jobs: "${{ result.failed_jobs }}"
@@ -1112,15 +1113,38 @@ steps:
       - when: "${{ result.conclusion }} == 'no_runs'"
         route: release_issue_failure
       - when: "${{ result.conclusion }} == 'timed_out'"
-        route: ci_watch_post_queue_fix
+        route: check_ci_post_queue_loop
       - route: detect_ci_conflict
     on_failure: detect_ci_conflict
     skip_when_false: "inputs.open_pr"
     note: >
       Validates CI on the rebased feature branch after queue ejection fix and re-push.
       Routes on result.conclusion: success → reenter_merge_queue,
-      no_runs → release_issue_failure (post-queue-fix is already a retry path),
-      timed_out → self (re-watch), failure → detect_ci_conflict.
+      no_runs → release_issue_failure (auto_trigger fires first: empty commit +
+      force-push + re-poll; no_runs reached only when trigger recovery fails),
+      timed_out → check_ci_post_queue_loop, failure → detect_ci_conflict.
+
+  check_ci_post_queue_loop:
+    tool: run_python
+    with:
+      callable: "autoskillit.smoke_utils.check_loop_iteration"
+      current_iteration: "${{ context.ci_post_queue_loop_count }}"
+      max_iterations: "2"
+    capture:
+      ci_post_queue_loop_count: "${{ result.next_iteration }}"
+    on_result:
+      - when: "${{ result.max_exceeded }} == true"
+        route: release_issue_failure
+      - route: ci_watch_post_queue_fix
+    on_failure: release_issue_failure
+    optional_context_refs:
+      - ci_post_queue_loop_count
+    skip_when_false: "inputs.open_pr"
+    note: >
+      Iteration guard for the ci_watch_post_queue_fix timed_out self-loop.
+      Caps at 2 iterations (initial + 1 retry). On budget exhaustion,
+      routes to release_issue_failure — this is already a post-ejection
+      retry path so further escalation is not warranted.
 
   reenter_merge_queue:
     tool: enqueue_pr

--- a/tests/recipe/test_merge_prs_queue_any.py
+++ b/tests/recipe/test_merge_prs_queue_any.py
@@ -1320,3 +1320,43 @@ def test_unbounded_cycle_severity_downgraded_by_eject_limit(any_recipe) -> None:
         f"unbounded-cycle must not be ERROR for queue ejection cycle after check_eject_limit; "
         f"got ERROR on: {[f.step_name for f in queue_cycle_error_findings]}"
     )
+
+
+@pytest.mark.parametrize("recipe_fixture", RELEASE_TIMEOUT_RECIPES)
+def test_ci_watch_post_queue_fix_no_runs_routes_to_failure(recipe_fixture, request):
+    """ci_watch_post_queue_fix no_runs must route to release_issue_failure."""
+    recipe = request.getfixturevalue(recipe_fixture)
+    step = recipe.steps["ci_watch_post_queue_fix"]
+    no_runs_routes = [
+        c.route for c in step.on_result.conditions if c.when and "'no_runs'" in c.when
+    ]
+    assert "release_issue_failure" in no_runs_routes, (
+        f"{recipe_fixture}: ci_watch_post_queue_fix no_runs must route to release_issue_failure"
+    )
+
+
+@pytest.mark.parametrize("recipe_fixture", RELEASE_TIMEOUT_RECIPES)
+def test_ci_watch_post_queue_fix_timed_out_is_bounded(recipe_fixture, request):
+    """ci_watch_post_queue_fix timed_out must route through check_ci_post_queue_loop."""
+    recipe = request.getfixturevalue(recipe_fixture)
+    step = recipe.steps["ci_watch_post_queue_fix"]
+    timed_out_routes = [
+        c.route for c in step.on_result.conditions if c.when and "'timed_out'" in c.when
+    ]
+    assert timed_out_routes, f"{recipe_fixture}: missing timed_out routing"
+    assert timed_out_routes[0] == "check_ci_post_queue_loop", (
+        f"{recipe_fixture}: timed_out must route through check_ci_post_queue_loop, "
+        f"not {timed_out_routes[0]}"
+    )
+
+
+@pytest.mark.parametrize("recipe_fixture", RELEASE_TIMEOUT_RECIPES)
+def test_check_ci_post_queue_loop_exists_and_bounded(recipe_fixture, request):
+    """check_ci_post_queue_loop step must exist and be bounded."""
+    recipe = request.getfixturevalue(recipe_fixture)
+    assert "check_ci_post_queue_loop" in recipe.steps, (
+        f"{recipe_fixture}: check_ci_post_queue_loop step must exist"
+    )
+    step = recipe.steps["check_ci_post_queue_loop"]
+    assert step.with_args.get("callable") == "autoskillit.smoke_utils.check_loop_iteration"
+    assert int(step.with_args.get("max_iterations", 0)) >= 2

--- a/tests/recipe/test_merge_prs_queue_pmp.py
+++ b/tests/recipe/test_merge_prs_queue_pmp.py
@@ -503,3 +503,32 @@ def test_check_eject_limit_routes_to_register_clone_failure_in_merge_prs(pmp_rec
     limit_conds = [c for c in conds if c.when and "EJECT_LIMIT_EXCEEDED" in c.when]
     assert len(limit_conds) == 1
     assert limit_conds[0].route == "register_clone_failure"
+
+
+def test_merge_prs_ci_watch_post_queue_fix_no_runs_routes_to_failure(pmp_recipe) -> None:
+    """ci_watch_post_queue_fix no_runs must route to register_clone_failure in merge-prs."""
+    step = pmp_recipe.steps["ci_watch_post_queue_fix"]
+    no_runs_routes = [
+        c.route for c in step.on_result.conditions if c.when and "'no_runs'" in c.when
+    ]
+    assert "register_clone_failure" in no_runs_routes
+
+
+def test_merge_prs_ci_watch_post_queue_fix_uses_branch_param(pmp_recipe) -> None:
+    """ci_watch_post_queue_fix must use 'branch' parameter, not 'pr_number'."""
+    step = pmp_recipe.steps["ci_watch_post_queue_fix"]
+    assert "branch" in step.with_args, (
+        "ci_watch_post_queue_fix must use 'branch' parameter, not 'pr_number'"
+    )
+    assert "pr_number" not in step.with_args, (
+        "ci_watch_post_queue_fix must not pass pr_number to wait_for_ci"
+    )
+
+
+def test_merge_prs_ci_watch_post_queue_fix_timed_out_bounded(pmp_recipe) -> None:
+    """ci_watch_post_queue_fix timed_out must route through check_ci_post_queue_loop."""
+    step = pmp_recipe.steps["ci_watch_post_queue_fix"]
+    timed_out_routes = [
+        c.route for c in step.on_result.conditions if c.when and "'timed_out'" in c.when
+    ]
+    assert timed_out_routes[0] == "check_ci_post_queue_loop"

--- a/tests/recipe/test_merge_prs_queue_pmp.py
+++ b/tests/recipe/test_merge_prs_queue_pmp.py
@@ -531,4 +531,5 @@ def test_merge_prs_ci_watch_post_queue_fix_timed_out_bounded(pmp_recipe) -> None
     timed_out_routes = [
         c.route for c in step.on_result.conditions if c.when and "'timed_out'" in c.when
     ]
+    assert timed_out_routes, "ci_watch_post_queue_fix: missing timed_out routing"
     assert timed_out_routes[0] == "check_ci_post_queue_loop"

--- a/tests/recipe/test_rules_ci.py
+++ b/tests/recipe/test_rules_ci.py
@@ -925,3 +925,24 @@ class TestCiTimeoutMinimum:
         recipe = _make_recipe(steps)
         findings = [f for f in run_semantic_rules(recipe) if f.rule == "ci-timeout-minimum"]
         assert len(findings) == 0
+
+
+def test_ci_watch_post_queue_fix_has_auto_trigger() -> None:
+    """ci_watch_post_queue_fix steps using wait_for_ci must have auto_trigger."""
+    target_recipes = [
+        "implementation.yaml",
+        "remediation.yaml",
+        "implementation-groups.yaml",
+        "merge-prs.yaml",
+    ]
+    for name in target_recipes:
+        recipe = load_recipe(builtin_recipes_dir() / name)
+        for step_name in ("ci_watch", "ci_watch_post_queue_fix"):
+            if step_name not in recipe.steps:
+                continue
+            step = recipe.steps[step_name]
+            if step.tool != "wait_for_ci":
+                continue
+            assert step.with_args.get("auto_trigger") in ("true", True), (
+                f"{name}: {step_name} missing auto_trigger: true"
+            )


### PR DESCRIPTION
## Summary

Enable `auto_trigger: "true"` on `ci_watch_post_queue_fix` in all 4 recipe files so the webhook recovery mechanism fires before routing to terminal failure on `no_runs`. Fix the broken `pr_number` parameter in `merge-prs.yaml` (replace with `branch`). Add `check_ci_post_queue_loop` iteration guard to bound the `timed_out` self-loop. Add contract and routing tests to prevent regression.

The approach is purely additive to the recipe YAML layer — `_auto_trigger_ci` in `tools_ci_watch.py` already implements the recovery mechanism correctly. The gap is that `ci_watch_post_queue_fix` never passes `auto_trigger: "true"`, so the tool never fires recovery. No Python code changes are required.

Closes #1626

## Implementation Plan

Plan file: `.autoskillit/temp/make-plan/ci_watch_post_queue_fix_auto_trigger_plan_2026-05-02_160500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 1.7k | 11.9k | 1.2M | 111.0k | 1 | 8m 15s |
| verify | 1.3k | 10.9k | 1.3M | 50.7k | 1 | 7m 53s |
| implement | 72 | 15.3k | 1.8M | 52.9k | 1 | 5m 32s |
| prepare_pr | 25 | 3.4k | 239.1k | 31.4k | 1 | 1m 11s |
| compose_pr | 22 | 1.4k | 132.7k | 19.1k | 1 | 38s |
| review_pr | 166 | 42.9k | 1.0M | 109.6k | 2 | 11m 31s |
| resolve_review | 47 | 12.8k | 1.6M | 60.7k | 1 | 8m 29s |
| **Total** | 3.3k | 98.7k | 7.3M | 435.3k | | 43m 31s |