### PR TITLE
Rectify: Brittle Positive Branch Matching in Install Track Classification

### DIFF
--- a/src/autoskillit/cli/_install_info.py
+++ b/src/autoskillit/cli/_install_info.py
@@ -19,6 +19,8 @@ from autoskillit.core import get_logger
 logger = get_logger(__name__)
 
 _INSTALL_FROM_DEVELOP = "git+https://github.com/TalonT-Org/AutoSkillit.git@develop"
+_STABLE_DISMISS_WINDOW = timedelta(days=7)
+_DEV_DISMISS_WINDOW = timedelta(hours=12)
 
 
 class InstallType(StrEnum):
@@ -26,6 +28,12 @@ class InstallType(StrEnum):
     LOCAL_EDITABLE = "local-editable"
     LOCAL_PATH = "local-path"
     UNKNOWN = "unknown"
+
+
+class InstallTrack(StrEnum):
+    STABLE = "stable"
+    DEV = "dev"
+    LOCAL = "local"
 
 
 @dataclass(frozen=True)
@@ -98,17 +106,30 @@ def _is_release_tag(rev: str) -> bool:
     return bool(re.fullmatch(r"v?\d+(\.\d+)*", rev))
 
 
+def _is_stable_track(rev: str | None) -> bool:
+    return not rev or rev in ("main", "stable") or _is_release_tag(rev)
+
+
+def classify_track(info: InstallInfo) -> InstallTrack:
+    if info.install_type in (InstallType.LOCAL_EDITABLE, InstallType.LOCAL_PATH):
+        return InstallTrack.LOCAL
+    rev = info.requested_revision or ""
+    if _is_stable_track(rev):
+        return InstallTrack.STABLE
+    return InstallTrack.DEV
+
+
 def comparison_branch(info: InstallInfo) -> str | None:
     """Return the GitHub branch/tag to compare for update availability.
 
-    - ``stable`` / ``main`` / release-tag / ``UNKNOWN`` → ``"releases/latest"``
-    - ``develop`` → ``"develop"``
+    - stable / main / release-tag / UNKNOWN → ``"releases/latest"``
+    - any other GIT_VCS revision (dev-track) → ``"develop"``
     - ``LOCAL_EDITABLE`` / ``LOCAL_PATH`` → ``None`` (not applicable)
     """
-    if info.install_type in (InstallType.LOCAL_EDITABLE, InstallType.LOCAL_PATH):
+    track = classify_track(info)
+    if track == InstallTrack.LOCAL:
         return None
-    rev = info.requested_revision or ""
-    if rev == "develop":
+    if track == InstallTrack.DEV:
         return "develop"
     return "releases/latest"
 
@@ -118,29 +139,29 @@ def dismissal_window(info: InstallInfo) -> timedelta:
 
     Branch-aware windows:
 
-    - ``stable`` / ``main`` / release-tag / ``UNKNOWN`` → ``timedelta(days=7)``
-    - ``develop`` / ``LOCAL_EDITABLE`` → ``timedelta(hours=12)``
+    - stable / main / release-tag / UNKNOWN → ``timedelta(days=7)``
+    - dev-track / LOCAL → ``timedelta(hours=12)``
     """
-    rev = info.requested_revision or ""
+    track = classify_track(info)
     # LOCAL_EDITABLE is reachable only via AUTOSKILLIT_FORCE_UPDATE_CHECK; not dead code.
-    if rev == "develop" or info.install_type == InstallType.LOCAL_EDITABLE:
-        return timedelta(hours=12)
-    return timedelta(days=7)
+    if track in (InstallTrack.DEV, InstallTrack.LOCAL):
+        return _DEV_DISMISS_WINDOW
+    return _STABLE_DISMISS_WINDOW
 
 
 def upgrade_command(info: InstallInfo) -> list[str] | None:
     """Return the subprocess command to upgrade autoskillit for this install.
 
-    - ``stable`` / ``main`` / release-tag → ``["uv", "tool", "upgrade", "autoskillit"]``
-    - ``develop`` → ``["uv", "tool", "install", "--force", <git URL>]``
+    - stable / main / release-tag → ``["uv", "tool", "upgrade", "autoskillit"]``
+    - dev-track → ``["uv", "tool", "install", "--force", <git URL>]``
     - ``LOCAL_EDITABLE`` → ``["uv", "pip", "install", "-e", str(info.editable_source)]``
     - ``UNKNOWN`` / ``LOCAL_PATH`` → ``None``
     """
-    if info.install_type == InstallType.GIT_VCS:
-        rev = info.requested_revision or ""
-        if rev == "develop":
-            return ["uv", "tool", "install", "--force", _INSTALL_FROM_DEVELOP]
-        return ["uv", "tool", "upgrade", "autoskillit"]
     if info.install_type == InstallType.LOCAL_EDITABLE and info.editable_source is not None:
         return ["uv", "pip", "install", "-e", str(info.editable_source)]
-    return None
+    if info.install_type != InstallType.GIT_VCS:
+        return None
+    track = classify_track(info)
+    if track == InstallTrack.DEV:
+        return ["uv", "tool", "install", "--force", _INSTALL_FROM_DEVELOP]
+    return ["uv", "tool", "upgrade", "autoskillit"]

--- a/src/autoskillit/cli/_update_checks.py
+++ b/src/autoskillit/cli/_update_checks.py
@@ -46,8 +46,6 @@ from autoskillit.hook_registry import _count_hook_registry_drift
 logger = get_logger(__name__)
 
 _DISMISS_FILE = "update_check.json"
-_STABLE_DISMISS_WINDOW = timedelta(days=7)
-_DEV_DISMISS_WINDOW = timedelta(hours=12)
 
 KITCHEN_GUARDED_COMMANDS: frozenset[str] = frozenset({"update", "install", "init"})
 

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -76,7 +76,9 @@ SINGLETON_ALLOWED_MODULES: frozenset[str] = frozenset(
         "settings",  # config/settings.py: _CONFIG_SCHEMA = _build_config_schema()
         "_headless_path_tokens",  # execution/_headless_path_tokens.py: _OUTPUT_PATH_TOKENS
         # _STABLE_DISMISS_WINDOW = timedelta(days=7), _DEV_DISMISS_WINDOW = timedelta(hours=12)
-        "_update_checks",  # cli/_update_checks.py: window constants (see comment above)
+        "_install_info",  # cli/_install_info.py: window constants (see comment above)
+        # KITCHEN_GUARDED_COMMANDS: frozenset[str]
+        "_update_checks",  # cli/_update_checks.py: module-level frozenset (see comment above)
         # _HTTP_TIMEOUT = httpx.Timeout(...) — module-level httpx client timeout config
         "_update_checks_fetch",  # cli/_update_checks_fetch.py: _HTTP_TIMEOUT constant
         "_terminal",  # cli/_terminal.py: _BASE_RESET = "".join(...) derived from _RESET_SPEC
@@ -1345,7 +1347,7 @@ def test_singleton_exemption_comment_matches_both_windows() -> None:
     """The _update_checks exemption comment in SINGLETON_ALLOWED_MODULES must
     accurately reflect both the _STABLE_DISMISS_WINDOW and _DEV_DISMISS_WINDOW values."""
 
-    from autoskillit.cli._update_checks import _DEV_DISMISS_WINDOW, _STABLE_DISMISS_WINDOW
+    from autoskillit.cli._install_info import _DEV_DISMISS_WINDOW, _STABLE_DISMISS_WINDOW
 
     this_file = Path(__file__)
     content = this_file.read_text(encoding="utf-8")

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -1344,7 +1344,7 @@ def test_pipeline_init_no_longer_exports_domain_paths():
 
 
 def test_singleton_exemption_comment_matches_both_windows() -> None:
-    """The _update_checks exemption comment in SINGLETON_ALLOWED_MODULES must
+    """The _install_info exemption comment in SINGLETON_ALLOWED_MODULES must
     accurately reflect both the _STABLE_DISMISS_WINDOW and _DEV_DISMISS_WINDOW values."""
 
     from autoskillit.cli._install_info import _DEV_DISMISS_WINDOW, _STABLE_DISMISS_WINDOW
@@ -1371,13 +1371,13 @@ def test_singleton_exemption_comment_matches_both_windows() -> None:
         f"Exemption comment in SINGLETON_ALLOWED_MODULES is stale. "
         f"Expected to find '{stable_fragment}' "
         f"(current _STABLE_DISMISS_WINDOW={_STABLE_DISMISS_WINDOW!r}). "
-        "Update the comment on the '_update_checks' entry."
+        "Update the comment on the '_install_info' entry."
     )
     assert dev_fragment in content, (
         f"Exemption comment in SINGLETON_ALLOWED_MODULES is stale. "
         f"Expected to find '{dev_fragment}' "
         f"(current _DEV_DISMISS_WINDOW={_DEV_DISMISS_WINDOW!r}). "
-        "Update the comment on the '_update_checks' entry."
+        "Update the comment on the '_install_info' entry."
     )
 
 

--- a/tests/cli/test_install_info.py
+++ b/tests/cli/test_install_info.py
@@ -346,3 +346,133 @@ def test_upgrade_command_unknown_and_local_path_returns_none(
         editable_source=None,
     )
     assert upgrade_command(info) is None
+
+
+# ---------------------------------------------------------------------------
+# _is_release_tag — unit tests (1a)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("rev", ["v0.7.75", "0.7.75", "v1.0", "1.0.0.0"])
+def test_is_release_tag_positive(rev: str) -> None:
+    from autoskillit.cli._install_info import _is_release_tag
+
+    assert _is_release_tag(rev) is True
+
+
+@pytest.mark.parametrize("rev", ["develop", "main", "stable", "feature-foo", "v", "v0.7.75-rc1"])
+def test_is_release_tag_negative(rev: str) -> None:
+    from autoskillit.cli._install_info import _is_release_tag
+
+    assert _is_release_tag(rev) is False
+
+
+# ---------------------------------------------------------------------------
+# _is_stable_track — unit tests (1b)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("rev", [None, "main", "stable", "v0.7.75", "0.9.300", ""])
+def test_is_stable_track_true(rev: str | None) -> None:
+    from autoskillit.cli._install_info import _is_stable_track
+
+    assert _is_stable_track(rev) is True
+
+
+@pytest.mark.parametrize(
+    "rev",
+    ["develop", "integration", "feature-foo", "staging", "release-candidate", "develops"],
+)
+def test_is_stable_track_false(rev: str) -> None:
+    from autoskillit.cli._install_info import _is_stable_track
+
+    assert _is_stable_track(rev) is False
+
+
+# ---------------------------------------------------------------------------
+# classify_track — unit tests (1c)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "install_type,revision,expected_track",
+    [
+        (InstallType.LOCAL_EDITABLE, "develop", "local"),
+        (InstallType.LOCAL_EDITABLE, None, "local"),
+        (InstallType.LOCAL_PATH, "stable", "local"),
+        (InstallType.LOCAL_PATH, None, "local"),
+        (InstallType.GIT_VCS, "stable", "stable"),
+        (InstallType.GIT_VCS, "main", "stable"),
+        (InstallType.GIT_VCS, "v0.7.75", "stable"),
+        (InstallType.GIT_VCS, None, "stable"),
+        (InstallType.GIT_VCS, "develop", "dev"),
+        (InstallType.GIT_VCS, "integration", "dev"),
+        (InstallType.GIT_VCS, "feature-foo", "dev"),
+        (InstallType.GIT_VCS, "staging", "dev"),
+        (InstallType.GIT_VCS, "", "stable"),
+        (InstallType.UNKNOWN, None, "stable"),
+    ],
+)
+def test_classify_track(
+    install_type: InstallType, revision: str | None, expected_track: str
+) -> None:
+    from autoskillit.cli._install_info import InstallTrack, classify_track
+
+    info = InstallInfo(
+        install_type=install_type,
+        commit_id=None,
+        requested_revision=revision,
+        url=None,
+        editable_source=Path("/tmp/repo") if install_type == InstallType.LOCAL_EDITABLE else None,
+    )
+    assert classify_track(info) == InstallTrack(expected_track)
+
+
+# ---------------------------------------------------------------------------
+# Policy functions with arbitrary branch names (1d)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "revision", ["integration", "feature-foo", "staging", "release-candidate", "my-branch"]
+)
+def test_comparison_branch_arbitrary_dev_revision(revision: str) -> None:
+    info = InstallInfo(
+        install_type=InstallType.GIT_VCS,
+        commit_id="abc123",
+        requested_revision=revision,
+        url=None,
+        editable_source=None,
+    )
+    assert comparison_branch(info) == "develop"
+
+
+@pytest.mark.parametrize(
+    "revision", ["integration", "feature-foo", "staging", "release-candidate", "my-branch"]
+)
+def test_dismissal_window_arbitrary_dev_revision(revision: str) -> None:
+    info = InstallInfo(
+        install_type=InstallType.GIT_VCS,
+        commit_id="abc123",
+        requested_revision=revision,
+        url=None,
+        editable_source=None,
+    )
+    assert dismissal_window(info) == timedelta(hours=12)
+
+
+@pytest.mark.parametrize(
+    "revision", ["integration", "feature-foo", "staging", "release-candidate", "my-branch"]
+)
+def test_upgrade_command_arbitrary_dev_revision(revision: str) -> None:
+    info = InstallInfo(
+        install_type=InstallType.GIT_VCS,
+        commit_id="abc123",
+        requested_revision=revision,
+        url=None,
+        editable_source=None,
+    )
+    result = upgrade_command(info)
+    assert result is not None
+    assert result[:3] == ["uv", "tool", "install"]
+    assert "--force" in result

--- a/tests/cli/test_update_checks_fetch.py
+++ b/tests/cli/test_update_checks_fetch.py
@@ -1017,3 +1017,41 @@ def test_verify_update_result_does_not_write_binary_snoozed(
     with patch.object(importlib.metadata, "version", return_value="0.9.0"):
         _verify_update_result(info, "0.9.0", "0.9.1", tmp_path, state)
     assert "binary_snoozed" not in state
+
+
+# ---------------------------------------------------------------------------
+# Step 1e — _fetch_latest_version contract: target routing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "target,expected_url_fragment",
+    [
+        ("develop", "contents/pyproject.toml"),
+        ("releases/latest", "releases/latest"),
+    ],
+)
+def test_fetch_latest_version_routes_by_target(
+    target: str, expected_url_fragment: str, tmp_path: Path
+) -> None:
+    from autoskillit.cli._update_checks import _fetch_latest_version
+
+    fetched_urls: list[str] = []
+
+    def _mock_fetch(url: str, *, home: Path) -> dict | None:
+        fetched_urls.append(url)
+        if "pyproject" in url:
+            import base64
+
+            content = base64.b64encode(b'version = "0.9.300"\n').decode()
+            return {"content": content}
+        return {"tag_name": "v0.9.300"}
+
+    with patch("autoskillit.cli._update_checks_fetch._fetch_with_cache", side_effect=_mock_fetch):
+        result = _fetch_latest_version(target, tmp_path)
+
+    assert result is not None
+    assert fetched_urls, "Expected _fetch_with_cache to be called"
+    assert any(expected_url_fragment in url for url in fetched_urls), (
+        f"Expected URL containing '{expected_url_fragment}', got: {fetched_urls}"
+    )

--- a/tests/cli/test_update_checks_fetch.py
+++ b/tests/cli/test_update_checks_fetch.py
@@ -1040,7 +1040,7 @@ def test_fetch_latest_version_routes_by_target(
 
     def _mock_fetch(url: str, *, home: Path) -> dict | None:
         fetched_urls.append(url)
-        if "pyproject" in url:
+        if "pyproject.toml" in url:
             import base64
 
             content = base64.b64encode(b'version = "0.9.300"\n').decode()

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -148,7 +148,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # _marketplace.py — hooks.json (co-owned)
     ("src/autoskillit/cli/_marketplace.py", 177),
     # _update_checks.py — dismissal state file
-    ("src/autoskillit/cli/_update_checks.py", 81),
+    ("src/autoskillit/cli/_update_checks.py", 79),
     # _update_checks_fetch.py — fetch cache (extracted from _update_checks.py)
     ("src/autoskillit/cli/_update_checks_fetch.py", 58),
     # smoke_utils.py — domain partitions dict, hunk ranges list, merge queue list


### PR DESCRIPTION
## Summary

The three policy functions in `_install_info.py` (`comparison_branch`, `dismissal_window`, `upgrade_command`) use positive matching (`rev == "develop"`) to identify dev-track installs, causing any non-`"develop"` branch revision to silently fall through to stable-track behavior. The architectural weakness is the absence of a single, authoritative track classifier — each function independently re-derives the install track from raw string comparisons with no shared classification primitive.

The immunity plan introduces `InstallTrack` (a `StrEnum`) and a `classify_track()` function as the sole classification point. The classifier uses **negative matching**: it defines what constitutes a stable-track install (`None`, `"main"`, `"stable"`, release tags) and treats everything else as dev-track. All policy functions and downstream consumers are rewritten to consume `InstallTrack` instead of re-deriving the track from `requested_revision`. This makes the system innately immune to branch renames, unknown branch names, and any future track additions — the classifier is the single place to update.

Closes #1633

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260502-171332-370393/.autoskillit/temp/rectify/rectify_brittle_positive_branch_matching_2026-05-02_172300.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| investigate | 1.7k | 4.9k | 392.0k | 64.3k | 1 | 3m 36s |
| rectify | 46 | 9.9k | 481.4k | 52.5k | 1 | 5m 19s |
| dry_walkthrough | 43 | 17.8k | 968.5k | 70.8k | 1 | 7m 33s |
| implement | 260 | 26.5k | 2.1M | 73.2k | 1 | 9m 5s |
| prepare_pr | 60 | 6.2k | 233.1k | 32.3k | 1 | 1m 55s |
| compose_pr | 67 | 2.1k | 225.0k | 20.1k | 1 | 50s |
| review_pr | 100 | 26.3k | 550.5k | 59.8k | 1 | 5m 36s |
| resolve_review | 269 | 16.6k | 1.7M | 75.2k | 1 | 6m 45s |
| **Total** | 2.5k | 110.3k | 6.6M | 448.2k | | 40m 42s |