### PR TITLE
Implementation Plan: Collapse task + task_file Into a Single task Ingredient

### DIFF
--- a/src/autoskillit/planner/__init__.py
+++ b/src/autoskillit/planner/__init__.py
@@ -13,6 +13,7 @@ from autoskillit.planner.manifests import (
     expand_assignments,
     expand_wps,
     finalize_wp_manifest,
+    resolve_task_input,
 )
 from autoskillit.planner.merge import (
     build_plan_snapshot,
@@ -50,6 +51,7 @@ __all__ = [
     "expand_assignments",
     "expand_wps",
     "finalize_wp_manifest",
+    "resolve_task_input",
     "validate_plan",
     "PlannerManifest",
     "PlannerManifestItem",

--- a/src/autoskillit/planner/compiler.py
+++ b/src/autoskillit/planner/compiler.py
@@ -123,7 +123,7 @@ def _render_issue_body(wp: dict, phase: dict, assignment: dict) -> str:
 def compile_plan(
     output_dir: str, task_file_path: str, source_dir: str, task_label: str = "", **kwargs: Any
 ) -> dict[str, str]:
-    task = Path(task_file_path).read_text() if task_file_path else ""
+    task = Path(task_file_path).read_text(encoding="utf-8") if task_file_path else ""
     task_label = task_label or _derive_label(task, "")
     root = Path(output_dir)
 

--- a/src/autoskillit/planner/compiler.py
+++ b/src/autoskillit/planner/compiler.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from autoskillit.core import atomic_write, get_logger, write_versioned_json
+from autoskillit.planner.manifests import _derive_label
 from autoskillit.planner.validation import (
     _load_assignment_results,
     _load_phase_results,
@@ -120,11 +121,10 @@ def _render_issue_body(wp: dict, phase: dict, assignment: dict) -> str:
 
 
 def compile_plan(
-    output_dir: str, task: str, source_dir: str, task_file: str = "", **kwargs: Any
+    output_dir: str, task_file_path: str, source_dir: str, task_label: str = "", **kwargs: Any
 ) -> dict[str, str]:
-    task_label = task
-    if task_file:
-        task = Path(task_file).read_text()
+    task = Path(task_file_path).read_text() if task_file_path else ""
+    task_label = task_label or _derive_label(task, "")
     root = Path(output_dir)
 
     phase_results = _load_phase_results(root)

--- a/src/autoskillit/planner/manifests.py
+++ b/src/autoskillit/planner/manifests.py
@@ -435,6 +435,6 @@ def resolve_task_input(task: str, planner_dir: str) -> TaskResolutionResult:
         label = _derive_label(content, task_path.stem)
         return TaskResolutionResult(task_file_path=str(task_path), task_label=label)
     out = Path(planner_dir) / "task_input.md"
-    out.write_text(task)
+    atomic_write(out, task)
     label = _derive_label(task, "")
     return TaskResolutionResult(task_file_path=str(out), task_label=label)

--- a/src/autoskillit/planner/manifests.py
+++ b/src/autoskillit/planner/manifests.py
@@ -415,15 +415,14 @@ def expand_wps(refined_assignments_path: str, output_dir: str, **kwargs: object)
 
 
 def _derive_label(content: str, filename_stem: str) -> str:
+    first_non_empty: str | None = None
     for line in content.splitlines():
         stripped = line.strip()
         if stripped.startswith("# "):
             return stripped[2:].strip()
-    for line in content.splitlines():
-        stripped = line.strip()
-        if stripped:
-            return stripped[:80]
-    return filename_stem or "Untitled"
+        if first_non_empty is None and stripped:
+            first_non_empty = stripped[:80]
+    return first_non_empty or filename_stem or "Untitled"
 
 
 def resolve_task_input(task: str, planner_dir: str) -> TaskResolutionResult:
@@ -431,7 +430,10 @@ def resolve_task_input(task: str, planner_dir: str) -> TaskResolutionResult:
         raise ValueError("task must be a non-empty string")
     task_path = Path(task)
     if task_path.is_file():
-        content = task_path.read_text()
+        try:
+            content = task_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise OSError(f"Cannot read task file {task_path}: {exc}") from exc
         label = _derive_label(content, task_path.stem)
         return TaskResolutionResult(task_file_path=str(task_path), task_label=label)
     out = Path(planner_dir) / "task_input.md"

--- a/src/autoskillit/planner/manifests.py
+++ b/src/autoskillit/planner/manifests.py
@@ -10,6 +10,7 @@ from typing import TypedDict
 from autoskillit.core import atomic_write, write_versioned_json
 from autoskillit.planner.schema import (
     RunDirResult,
+    TaskResolutionResult,
     validate_assignment_result,
     validate_phase_result,
     validate_refined_assignments,
@@ -411,3 +412,29 @@ def expand_wps(refined_assignments_path: str, output_dir: str, **kwargs: object)
         "context_paths": ",".join(context_paths),
         "item_ids": ",".join(item_ids),
     }
+
+
+def _derive_label(content: str, filename_stem: str) -> str:
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("# "):
+            return stripped[2:].strip()
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped[:80]
+    return filename_stem or "Untitled"
+
+
+def resolve_task_input(task: str, planner_dir: str) -> TaskResolutionResult:
+    if not task:
+        raise ValueError("task must be a non-empty string")
+    task_path = Path(task)
+    if task_path.is_file():
+        content = task_path.read_text()
+        label = _derive_label(content, task_path.stem)
+        return TaskResolutionResult(task_file_path=str(task_path), task_label=label)
+    out = Path(planner_dir) / "task_input.md"
+    out.write_text(task)
+    label = _derive_label(task, "")
+    return TaskResolutionResult(task_file_path=str(out), task_label=label)

--- a/src/autoskillit/planner/merge.py
+++ b/src/autoskillit/planner/merge.py
@@ -22,7 +22,7 @@ def merge_files(
     strict: bool = True,
     **kwargs: Any,
 ) -> dict[str, Any]:
-    task = Path(task_file_path).read_text() if task_file_path else ""
+    task = Path(task_file_path).read_text(encoding="utf-8") if task_file_path else ""
     if key not in _TIER_KEYS:
         raise ValueError(f"Invalid key {key!r}; must be one of {_TIER_KEYS}")
 
@@ -187,7 +187,7 @@ def build_plan_snapshot(
     source_dir: str = "",
     **kwargs: Any,
 ) -> dict[str, Any]:
-    task = Path(task_file_path).read_text() if task_file_path else ""
+    task = Path(task_file_path).read_text(encoding="utf-8") if task_file_path else ""
     phase_pairs: list[tuple[int, dict[str, Any]]] = []
     for p in sorted(Path(phases_dir).glob("*_result.json")):
         try:

--- a/src/autoskillit/planner/merge.py
+++ b/src/autoskillit/planner/merge.py
@@ -17,14 +17,12 @@ def merge_files(
     file_paths: list[str],
     output_path: str,
     key: str,
-    task: str = "",
+    task_file_path: str = "",
     source_dir: str = "",
     strict: bool = True,
-    task_file: str = "",
     **kwargs: Any,
 ) -> dict[str, Any]:
-    if task_file:
-        task = Path(task_file).read_text()
+    task = Path(task_file_path).read_text() if task_file_path else ""
     if key not in _TIER_KEYS:
         raise ValueError(f"Invalid key {key!r}; must be one of {_TIER_KEYS}")
 
@@ -166,9 +164,8 @@ def merge_tier_dir(
     results_dir: str,
     output_path: str,
     key: str,
-    task: str = "",
+    task_file_path: str = "",
     source_dir: str = "",
-    task_file: str = "",
     **kwargs: Any,
 ) -> dict[str, Any]:
     paths = sorted(Path(results_dir).glob("*_result.json"))
@@ -178,22 +175,19 @@ def merge_tier_dir(
         file_paths=[str(p) for p in paths],
         output_path=output_path,
         key=key,
-        task=task,
+        task_file_path=task_file_path,
         source_dir=source_dir,
-        task_file=task_file,
     )
 
 
 def build_plan_snapshot(
     phases_dir: str,
     output_path: str,
-    task: str = "",
+    task_file_path: str = "",
     source_dir: str = "",
-    task_file: str = "",
     **kwargs: Any,
 ) -> dict[str, Any]:
-    if task_file:
-        task = Path(task_file).read_text()
+    task = Path(task_file_path).read_text() if task_file_path else ""
     phase_pairs: list[tuple[int, dict[str, Any]]] = []
     for p in sorted(Path(phases_dir).glob("*_result.json")):
         try:

--- a/src/autoskillit/planner/schema.py
+++ b/src/autoskillit/planner/schema.py
@@ -138,6 +138,11 @@ class RunDirResult(TypedDict):
     planner_dir: str
 
 
+class TaskResolutionResult(TypedDict):
+    task_file_path: str
+    task_label: str
+
+
 class ValidationFinding(TypedDict):
     message: str
     severity: Literal["error", "warning"]

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -2130,8 +2130,8 @@ callable_contracts:
     - name: output_dir
       type: directory_path
       required: true
-    - name: task
-      type: str
+    - name: task_file_path
+      type: file_path
       required: true
     - name: source_dir
       type: directory_path

--- a/src/autoskillit/recipes/contracts/planner.yaml
+++ b/src/autoskillit/recipes/contracts/planner.yaml
@@ -255,17 +255,27 @@ dataflow:
   - planner_assess_review_approach
   - source_dir
   - task
-  - task_file
   required: []
   produced:
   - planner_dir
+- step: resolve_task
+  available:
+  - planner_assess_review_approach
+  - planner_dir
+  - source_dir
+  - task
+  required: []
+  produced:
+  - task_file_path
+  - task_label
 - step: analyze
   available:
   - planner_assess_review_approach
   - planner_dir
   - source_dir
   - task
-  - task_file
+  - task_file_path
+  - task_label
   required: []
   produced: []
 - step: extract_domain
@@ -274,7 +284,8 @@ dataflow:
   - planner_dir
   - source_dir
   - task
-  - task_file
+  - task_file_path
+  - task_label
   required: []
   produced: []
   positional_args: 2
@@ -284,7 +295,8 @@ dataflow:
   - planner_dir
   - source_dir
   - task
-  - task_file
+  - task_file_path
+  - task_label
   required: []
   produced:
   - phase_manifest_path
@@ -296,7 +308,8 @@ dataflow:
   - planner_dir
   - source_dir
   - task
-  - task_file
+  - task_file_path
+  - task_label
   required: []
   produced:
   - plan_snapshot_path
@@ -310,7 +323,8 @@ dataflow:
   - planner_dir
   - source_dir
   - task
-  - task_file
+  - task_file_path
+  - task_label
   required: []
   produced: []
   positional_args: 2
@@ -323,7 +337,8 @@ dataflow:
   - planner_dir
   - source_dir
   - task
-  - task_file
+  - task_file_path
+  - task_label
   required: []
   produced:
   - combined_phases_path
@@ -337,7 +352,8 @@ dataflow:
   - planner_dir
   - source_dir
   - task
-  - task_file
+  - task_file_path
+  - task_label
   required:
   - combined_plan_path
   - output_dir
@@ -354,7 +370,8 @@ dataflow:
   - refined_plan_path
   - source_dir
   - task
-  - task_file
+  - task_file_path
+  - task_label
   required: []
   produced:
   - assignment_context_paths
@@ -370,7 +387,8 @@ dataflow:
   - refined_plan_path
   - source_dir
   - task
-  - task_file
+  - task_file_path
+  - task_label
   required: []
   produced: []
   positional_args: 1
@@ -386,7 +404,8 @@ dataflow:
   - refined_plan_path
   - source_dir
   - task
-  - task_file
+  - task_file_path
+  - task_label
   required: []
   produced:
   - combined_assignments_path
@@ -403,7 +422,8 @@ dataflow:
   - refined_plan_path
   - source_dir
   - task
-  - task_file
+  - task_file_path
+  - task_label
   required:
   - output_dir
   produced:
@@ -422,7 +442,8 @@ dataflow:
   - refined_plan_path
   - source_dir
   - task
-  - task_file
+  - task_file_path
+  - task_label
   required: []
   produced:
   - wp_context_paths
@@ -440,7 +461,8 @@ dataflow:
   - refined_plan_path
   - source_dir
   - task
-  - task_file
+  - task_file_path
+  - task_label
   - wp_context_paths
   required: []
   produced: []
@@ -459,7 +481,8 @@ dataflow:
   - refined_plan_path
   - source_dir
   - task
-  - task_file
+  - task_file_path
+  - task_label
   - wp_context_paths
   required: []
   produced: []
@@ -477,7 +500,8 @@ dataflow:
   - refined_plan_path
   - source_dir
   - task
-  - task_file
+  - task_file_path
+  - task_label
   - wp_context_paths
   required: []
   produced:
@@ -497,7 +521,8 @@ dataflow:
   - refined_plan_path
   - source_dir
   - task
-  - task_file
+  - task_file_path
+  - task_label
   - wp_context_paths
   required:
   - output_dir
@@ -519,7 +544,8 @@ dataflow:
   - refined_wps_path
   - source_dir
   - task
-  - task_file
+  - task_file_path
+  - task_label
   - wp_context_paths
   required: []
   produced: []
@@ -539,7 +565,8 @@ dataflow:
   - refined_wps_path
   - source_dir
   - task
-  - task_file
+  - task_file_path
+  - task_label
   - wp_context_paths
   required: []
   produced:
@@ -561,7 +588,8 @@ dataflow:
   - refined_wps_path
   - source_dir
   - task
-  - task_file
+  - task_file_path
+  - task_label
   - wp_context_paths
   required:
   - refined_wps_path
@@ -586,7 +614,8 @@ dataflow:
   - refined_wps_path
   - source_dir
   - task
-  - task_file
+  - task_file_path
+  - task_label
   - wp_context_paths
   required: []
   produced: []
@@ -608,7 +637,8 @@ dataflow:
   - refined_wps_path
   - source_dir
   - task
-  - task_file
+  - task_file_path
+  - task_label
   - wp_context_paths
   required:
   - refined_wps_path
@@ -633,7 +663,8 @@ dataflow:
   - review_approach_assessment_path
   - source_dir
   - task
-  - task_file
+  - task_file_path
+  - task_label
   - wp_context_paths
   required: []
   produced:
@@ -657,7 +688,8 @@ dataflow:
   - review_approach_assessment_path
   - source_dir
   - task
-  - task_file
+  - task_file_path
+  - task_label
   - verdict
   - wp_context_paths
   required: []
@@ -681,7 +713,8 @@ dataflow:
   - review_approach_assessment_path
   - source_dir
   - task
-  - task_file
+  - task_file_path
+  - task_label
   - verdict
   - wp_context_paths
   required: []
@@ -706,7 +739,8 @@ dataflow:
   - review_approach_assessment_path
   - source_dir
   - task
-  - task_file
+  - task_file_path
+  - task_label
   - verdict
   - wp_context_paths
   required: []
@@ -730,7 +764,8 @@ dataflow:
   - review_approach_assessment_path
   - source_dir
   - task
-  - task_file
+  - task_file_path
+  - task_label
   - verdict
   - wp_context_paths
   required: []
@@ -754,7 +789,8 @@ dataflow:
   - review_approach_assessment_path
   - source_dir
   - task
-  - task_file
+  - task_file_path
+  - task_label
   - verdict
   - wp_context_paths
   required: []

--- a/src/autoskillit/recipes/planner.yaml
+++ b/src/autoskillit/recipes/planner.yaml
@@ -32,11 +32,8 @@ kitchen_rules:
 
 ingredients:
   task:
-    description: "High-level task or feature description to decompose into a plan."
+    description: "Task description to decompose into a plan. Accepts either an absolute file path or inline text."
     required: true
-  task_file:
-    description: "Absolute path to a file containing the task description. Use instead of task for document-scale inputs."
-    required: false
   source_dir:
     description: "Absolute path to the repository root to analyze."
     required: true
@@ -58,6 +55,18 @@ steps:
         temp_dir: "{{AUTOSKILLIT_TEMP}}"
     capture:
       planner_dir: "${{ result.planner_dir }}"
+    on_success: resolve_task
+    on_failure: escalate_stop
+
+  resolve_task:
+    tool: run_python
+    with:
+      callable: "autoskillit.planner.resolve_task_input"
+      task: "${{ inputs.task }}"
+      planner_dir: "${{ context.planner_dir }}"
+    capture:
+      task_file_path: "${{ result.task_file_path }}"
+      task_label: "${{ result.task_label }}"
     on_success: analyze
     on_failure: escalate_stop
 
@@ -75,7 +84,7 @@ steps:
       skill_command: >
         /autoskillit:planner-extract-domain
         ${{ context.planner_dir }}/analysis.json
-        "${{ inputs.task_file }}"
+        "${{ context.task_file_path }}"
       cwd: "${{ inputs.source_dir }}"
     on_success: generate_phases
     on_failure: generate_phases
@@ -87,7 +96,7 @@ steps:
         /autoskillit:planner-generate-phases
         ${{ context.planner_dir }}/analysis.json
         ${{ context.planner_dir }}/domain_knowledge.md
-        "${{ inputs.task_file }}"
+        "${{ context.task_file_path }}"
       cwd: "${{ inputs.source_dir }}"
     capture:
       phase_manifest_path: "${{ result.phase_manifest_path }}"
@@ -103,8 +112,7 @@ steps:
       phases_dir: "${{ context.planner_dir }}/phases"
       phase_manifest_path: "${{ context.phase_manifest_path }}"
       output_path: "${{ context.planner_dir }}/plan_snapshot.json"
-      task: "${{ inputs.task }}"
-      task_file: "${{ inputs.task_file }}"
+      task_file_path: "${{ context.task_file_path }}"
       source_dir: "${{ inputs.source_dir }}"
     capture:
       plan_snapshot_path: "${{ result.snapshot_path }}"
@@ -136,8 +144,7 @@ steps:
       results_dir: "${{ context.planner_dir }}/phases"
       output_path: "${{ context.planner_dir }}/combined_plan.json"
       key: "phases"
-      task: "${{ inputs.task }}"
-      task_file: "${{ inputs.task_file }}"
+      task_file_path: "${{ context.task_file_path }}"
       source_dir: "${{ inputs.source_dir }}"
     capture:
       combined_phases_path: "${{ result.merged_path }}"
@@ -190,8 +197,7 @@ steps:
       results_dir: "${{ context.planner_dir }}/assignments"
       output_path: "${{ context.planner_dir }}/combined_assignments.json"
       key: "assignments"
-      task: "${{ inputs.task }}"
-      task_file: "${{ inputs.task_file }}"
+      task_file_path: "${{ context.task_file_path }}"
       source_dir: "${{ inputs.source_dir }}"
     capture:
       combined_assignments_path: "${{ result.merged_path }}"
@@ -258,8 +264,7 @@ steps:
       results_dir: "${{ context.planner_dir }}/work_packages"
       output_path: "${{ context.planner_dir }}/combined_wps.json"
       key: "work_packages"
-      task: "${{ inputs.task }}"
-      task_file: "${{ inputs.task_file }}"
+      task_file_path: "${{ context.task_file_path }}"
       source_dir: "${{ inputs.source_dir }}"
     capture:
       combined_wps_path: "${{ result.merged_path }}"
@@ -386,8 +391,8 @@ steps:
     with:
       callable: "autoskillit.planner.compile_plan"
       output_dir: "${{ context.planner_dir }}"
-      task: "${{ inputs.task }}"
-      task_file: "${{ inputs.task_file }}"
+      task_file_path: "${{ context.task_file_path }}"
+      task_label: "${{ context.task_label }}"
       source_dir: "${{ inputs.source_dir }}"
     on_success: done
     on_failure: escalate_stop

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -156,7 +156,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/smoke_utils.py", 87),
     ("src/autoskillit/smoke_utils.py", 277),
     # planner/manifests.py — finalize_wp_manifest: wp_index.json rebuild (list payload)
-    ("src/autoskillit/planner/manifests.py", 243),
+    ("src/autoskillit/planner/manifests.py", 244),
     # _cmd_rpc.py — emit_fallback_map: BEM fallback execution map (recipe-internal)
     ("src/autoskillit/recipe/_cmd_rpc.py", 445),
 }

--- a/tests/planner/conftest.py
+++ b/tests/planner/conftest.py
@@ -61,3 +61,9 @@ def write_json(path: Path, data: object) -> None:
     """Write ``data`` as JSON to ``path``, creating parent dirs as needed."""
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(data))
+
+
+def write_task_file(tmp_path: Path, content: str = "test task") -> str:
+    f = tmp_path / "task_input.md"
+    f.write_text(content)
+    return str(f)

--- a/tests/planner/test_compiler.py
+++ b/tests/planner/test_compiler.py
@@ -14,6 +14,7 @@ from tests.planner.conftest import (
     make_phase_result,
     make_wp_result,
     write_json,
+    write_task_file,
 )
 
 pytestmark = [pytest.mark.layer("planner"), pytest.mark.small, pytest.mark.feature("planner")]
@@ -140,14 +141,14 @@ def _make_chain_3_wps(tmp_path: Path) -> Path:
 
 def test_compile_plan_topological_sort_order(tmp_path: Path) -> None:
     _make_chain_3_wps(tmp_path)
-    compile_plan(str(tmp_path), "test task", "/src")
+    compile_plan(str(tmp_path), write_task_file(tmp_path), "/src")
     manifest = json.loads((tmp_path / "manifest.json").read_text())
     assert manifest["execution_order"] == ["P1-A1-WP1", "P1-A1-WP2", "P1-A1-WP3"]
 
 
 def test_compile_plan_issue_body_sections(tmp_path: Path) -> None:
     _make_valid_output_dir(tmp_path)
-    compile_plan(str(tmp_path), "test task", "/src")
+    compile_plan(str(tmp_path), write_task_file(tmp_path), "/src")
     issue = (tmp_path / "issues" / "P1-A1-WP1_issue.md").read_text()
     for section in [
         "## Goal",
@@ -161,7 +162,7 @@ def test_compile_plan_issue_body_sections(tmp_path: Path) -> None:
 
 def test_compile_plan_issue_body_context_fields(tmp_path: Path) -> None:
     _make_valid_output_dir(tmp_path)
-    compile_plan(str(tmp_path), "test task", "/src")
+    compile_plan(str(tmp_path), write_task_file(tmp_path), "/src")
     issue = (tmp_path / "issues" / "P1-A1-WP1_issue.md").read_text()
     assert "Phase 1 (Milestone: 1-phase-1)" in issue
     assert "P1-A1 (Test Assignment P1)" in issue
@@ -169,7 +170,7 @@ def test_compile_plan_issue_body_context_fields(tmp_path: Path) -> None:
 
 def test_compile_plan_depends_on_cross_ref(tmp_path: Path) -> None:
     _make_chain_3_wps(tmp_path)
-    compile_plan(str(tmp_path), "test task", "/src")
+    compile_plan(str(tmp_path), write_task_file(tmp_path), "/src")
     issue_wp2 = (tmp_path / "issues" / "P1-A1-WP2_issue.md").read_text()
     assert "P1-A1-WP1" in issue_wp2
 
@@ -183,14 +184,14 @@ def test_compile_plan_depended_on_by_cross_ref(tmp_path: Path) -> None:
             "forward_deps": {"P1-A1-WP1": ["P1-A1-WP2"]},
         },
     )
-    compile_plan(str(tmp_path), "test task", "/src")
+    compile_plan(str(tmp_path), write_task_file(tmp_path), "/src")
     issue_wp1 = (tmp_path / "issues" / "P1-A1-WP1_issue.md").read_text()
     assert "P1-A1-WP2" in issue_wp1
 
 
 def test_compile_plan_milestones_one_per_phase(tmp_path: Path) -> None:
     _make_valid_output_dir(tmp_path, num_phases=2, dependency_chain=True)
-    compile_plan(str(tmp_path), "test task", "/src")
+    compile_plan(str(tmp_path), write_task_file(tmp_path), "/src")
     milestones_data = json.loads((tmp_path / "milestones.json").read_text())
     assert len(milestones_data["milestones"]) == 2
     for entry in milestones_data["milestones"]:
@@ -201,7 +202,7 @@ def test_compile_plan_milestones_one_per_phase(tmp_path: Path) -> None:
 
 def test_compile_plan_plan_md_is_valid_markdown(tmp_path: Path) -> None:
     _make_valid_output_dir(tmp_path)
-    result = compile_plan(str(tmp_path), "my task", "/src")
+    result = compile_plan(str(tmp_path), write_task_file(tmp_path, "my task"), "/src")
     plan_md = Path(result["plan_path"]).read_text()
     assert plan_md.startswith("#")
     assert "my task" in plan_md
@@ -209,7 +210,7 @@ def test_compile_plan_plan_md_is_valid_markdown(tmp_path: Path) -> None:
 
 def test_compile_plan_manifest_json_schema(tmp_path: Path) -> None:
     _make_valid_output_dir(tmp_path)
-    compile_plan(str(tmp_path), "test task", "/src")
+    compile_plan(str(tmp_path), write_task_file(tmp_path), "/src")
     manifest = json.loads((tmp_path / "manifest.json").read_text())
     assert "task" in manifest
     assert "source_dir" in manifest
@@ -221,7 +222,7 @@ def test_compile_plan_manifest_json_schema(tmp_path: Path) -> None:
 
 def test_compile_plan_plan_parts_matches_issue_file_count(tmp_path: Path) -> None:
     _make_chain_3_wps(tmp_path)
-    result = compile_plan(str(tmp_path), "test task", "/src")
+    result = compile_plan(str(tmp_path), write_task_file(tmp_path), "/src")
     parts = [p for p in result["plan_parts"].split("\n") if p]
     assert len(parts) == 3
     for part_path in parts:
@@ -230,13 +231,13 @@ def test_compile_plan_plan_parts_matches_issue_file_count(tmp_path: Path) -> Non
 
 def test_compile_plan_return_values_are_strings(tmp_path: Path) -> None:
     _make_valid_output_dir(tmp_path)
-    result = compile_plan(str(tmp_path), "test task", "/src")
+    result = compile_plan(str(tmp_path), write_task_file(tmp_path), "/src")
     assert all(isinstance(v, str) for v in result.values())
 
 
 def test_compile_plan_creates_issues_directory(tmp_path: Path) -> None:
     _make_valid_output_dir(tmp_path)
-    compile_plan(str(tmp_path), "task", "/src")
+    compile_plan(str(tmp_path), write_task_file(tmp_path, "task"), "/src")
     assert (tmp_path / "issues").is_dir()
 
 
@@ -255,7 +256,7 @@ class TestCompilePlanEdgeCases:
         )
 
         with structlog.testing.capture_logs() as logs:
-            result = compile_plan(str(tmp_path), "t", "s")
+            result = compile_plan(str(tmp_path), write_task_file(tmp_path, "t"), "s")
 
         assert {"plan_path", "plan_json_path", "plan_parts"} == result.keys()
         warning_logs = [e for e in logs if e.get("log_level") == "warning"]
@@ -270,7 +271,7 @@ class TestCompilePlanEdgeCases:
         write_json(wps_dir / "P99-A1-WP1_result.json", make_wp_result("P99-A1-WP1"))
 
         with pytest.raises(RuntimeError, match="references phase"):
-            compile_plan(str(tmp_path), "t", "s")
+            compile_plan(str(tmp_path), write_task_file(tmp_path, "t"), "s")
 
     def test_wp_references_absent_assignment_raises(self, tmp_path: Path) -> None:
         _make_valid_output_dir(tmp_path)
@@ -278,7 +279,7 @@ class TestCompilePlanEdgeCases:
         write_json(wps_dir / "P1-A99-WP1_result.json", make_wp_result("P1-A99-WP1"))
 
         with pytest.raises(RuntimeError, match="references assignment"):
-            compile_plan(str(tmp_path), "t", "s")
+            compile_plan(str(tmp_path), write_task_file(tmp_path, "t"), "s")
 
     def test_malformed_wp_id_raises(self, tmp_path: Path) -> None:
         _make_valid_output_dir(tmp_path)
@@ -289,7 +290,7 @@ class TestCompilePlanEdgeCases:
         )
 
         with pytest.raises(ValueError, match="Invalid WP id format"):
-            compile_plan(str(tmp_path), "t", "s")
+            compile_plan(str(tmp_path), write_task_file(tmp_path, "t"), "s")
 
 
 def test_render_issue_body_includes_research_section_when_recommended() -> None:
@@ -329,7 +330,9 @@ def test_compile_plan_merges_assessment_when_file_present(tmp_path: Path) -> Non
         ],
     }
     write_json(output_dir / "review_approach_assessment.json", assessment)
-    compile_plan(str(output_dir), task="Test task", source_dir=str(tmp_path))
+    compile_plan(
+        str(output_dir), task_file_path=write_task_file(output_dir), source_dir=str(tmp_path)
+    )
     issue_body = (output_dir / "issues" / "P1-A1-WP1_issue.md").read_text()
     assert "## Review Approach" in issue_body
     assert "Unfamiliar external API integration." in issue_body
@@ -339,7 +342,9 @@ def test_compile_plan_omits_research_when_assessment_file_absent(tmp_path: Path)
     output_dir = _make_valid_output_dir(
         tmp_path, num_phases=1, with_dep_graph=False, dependency_chain=False
     )
-    compile_plan(str(output_dir), task="Test task", source_dir=str(tmp_path))
+    compile_plan(
+        str(output_dir), task_file_path=write_task_file(output_dir), source_dir=str(tmp_path)
+    )
     issue_body = (output_dir / "issues" / "P1-A1-WP1_issue.md").read_text()
     assert "## Review Approach" not in issue_body
 
@@ -350,7 +355,9 @@ def test_compile_plan_raises_on_malformed_assessment_file(tmp_path: Path) -> Non
     )
     (output_dir / "review_approach_assessment.json").write_text("not valid json")
     with pytest.raises(RuntimeError, match="Malformed assessment file"):
-        compile_plan(str(output_dir), task="Test task", source_dir=str(tmp_path))
+        compile_plan(
+            str(output_dir), task_file_path=write_task_file(output_dir), source_dir=str(tmp_path)
+        )
 
 
 def test_compile_plan_skips_assessment_entries_missing_wp_id(tmp_path: Path) -> None:
@@ -369,7 +376,9 @@ def test_compile_plan_skips_assessment_entries_missing_wp_id(tmp_path: Path) -> 
         ],
     }
     write_json(output_dir / "review_approach_assessment.json", assessment)
-    compile_plan(str(output_dir), task="Test task", source_dir=str(tmp_path))
+    compile_plan(
+        str(output_dir), task_file_path=write_task_file(output_dir), source_dir=str(tmp_path)
+    )
     issue_body = (output_dir / "issues" / "P1-A1-WP1_issue.md").read_text()
     assert "## Review Approach" in issue_body
     assert "valid entry" in issue_body
@@ -380,7 +389,7 @@ def test_compile_plan_reads_task_from_file(tmp_path: Path) -> None:
     task_file = tmp_path / "task_desc.txt"
     task_file.write_text("Full task description from file")
     result = compile_plan(
-        str(output_dir), task="label", source_dir="/src", task_file=str(task_file)
+        str(output_dir), task_file_path=str(task_file), source_dir="/src", task_label="label"
     )
     plan_json = json.loads((output_dir / "plan.json").read_text())
     assert plan_json["task"] == "Full task description from file"
@@ -388,8 +397,12 @@ def test_compile_plan_reads_task_from_file(tmp_path: Path) -> None:
     assert plan_md.startswith("# Plan: label")
 
 
-def test_compile_plan_falls_back_to_task_when_no_file(tmp_path: Path) -> None:
+def test_compile_plan_derives_label_when_not_provided(tmp_path: Path) -> None:
     output_dir = _make_valid_output_dir(tmp_path)
-    compile_plan(str(output_dir), task="inline task", source_dir="/src")
+    task_file = tmp_path / "task_desc.txt"
+    task_file.write_text("inline task")
+    result = compile_plan(str(output_dir), task_file_path=str(task_file), source_dir="/src")
     plan_json = json.loads((output_dir / "plan.json").read_text())
     assert plan_json["task"] == "inline task"
+    plan_md = Path(result["plan_path"]).read_text()
+    assert plan_md.startswith("# Plan: inline task")

--- a/tests/planner/test_manifests.py
+++ b/tests/planner/test_manifests.py
@@ -513,3 +513,62 @@ def test_finalize_wp_manifest_nonexistent_dir_raises(tmp_path):
 
     with pytest.raises(FileNotFoundError, match="work_packages_dir does not exist"):
         finalize_wp_manifest(str(tmp_path / "nonexistent"), str(output_dir))
+
+
+# --- resolve_task_input tests (T1a-T1e) ---
+
+
+def test_resolve_task_input_file_with_heading(tmp_path):
+    from autoskillit.planner import resolve_task_input
+
+    task_file = tmp_path / "task.md"
+    task_file.write_text("# Deploy Auth Service\n\nDetailed description...")
+    planner_dir = tmp_path / "planner"
+    planner_dir.mkdir()
+    result = resolve_task_input(str(task_file), str(planner_dir))
+    assert result["task_file_path"] == str(task_file)
+    assert result["task_label"] == "Deploy Auth Service"
+
+
+def test_resolve_task_input_file_no_heading(tmp_path):
+    from autoskillit.planner import resolve_task_input
+
+    task_file = tmp_path / "task.txt"
+    task_file.write_text("Implement the feature flag system for gradual rollout")
+    planner_dir = tmp_path / "planner"
+    planner_dir.mkdir()
+    result = resolve_task_input(str(task_file), str(planner_dir))
+    assert result["task_file_path"] == str(task_file)
+    assert result["task_label"] == "Implement the feature flag system for gradual rollout"
+
+
+def test_resolve_task_input_inline_text(tmp_path):
+    from autoskillit.planner import resolve_task_input
+
+    planner_dir = tmp_path / "planner"
+    planner_dir.mkdir()
+    result = resolve_task_input("Add dark mode toggle", str(planner_dir))
+    assert result["task_file_path"] == str(planner_dir / "task_input.md")
+    assert Path(result["task_file_path"]).read_text() == "Add dark mode toggle"
+    assert result["task_label"] == "Add dark mode toggle"
+
+
+def test_resolve_task_input_inline_with_heading(tmp_path):
+    from autoskillit.planner import resolve_task_input
+
+    planner_dir = tmp_path / "planner"
+    planner_dir.mkdir()
+    text = "# Auth Overhaul\n\nRebuild the entire authentication layer..."
+    result = resolve_task_input(text, str(planner_dir))
+    assert result["task_label"] == "Auth Overhaul"
+    assert Path(result["task_file_path"]).read_text() == text
+
+
+def test_resolve_task_input_long_inline_truncates_label(tmp_path):
+    from autoskillit.planner import resolve_task_input
+
+    planner_dir = tmp_path / "planner"
+    planner_dir.mkdir()
+    text = "A" * 120
+    result = resolve_task_input(text, str(planner_dir))
+    assert len(result["task_label"]) <= 80

--- a/tests/planner/test_manifests.py
+++ b/tests/planner/test_manifests.py
@@ -523,6 +523,7 @@ def test_resolve_task_input_file_with_heading(tmp_path):
     planner_dir = tmp_path / "planner"
     planner_dir.mkdir()
     result = resolve_task_input(str(task_file), str(planner_dir))
+    assert list(planner_dir.iterdir()) == []
     assert result["task_file_path"] == str(task_file)
     assert result["task_label"] == "Deploy Auth Service"
 

--- a/tests/planner/test_manifests.py
+++ b/tests/planner/test_manifests.py
@@ -515,9 +515,6 @@ def test_finalize_wp_manifest_nonexistent_dir_raises(tmp_path):
         finalize_wp_manifest(str(tmp_path / "nonexistent"), str(output_dir))
 
 
-# --- resolve_task_input tests (T1a-T1e) ---
-
-
 def test_resolve_task_input_file_with_heading(tmp_path):
     from autoskillit.planner import resolve_task_input
 
@@ -572,3 +569,4 @@ def test_resolve_task_input_long_inline_truncates_label(tmp_path):
     text = "A" * 120
     result = resolve_task_input(text, str(planner_dir))
     assert len(result["task_label"]) <= 80
+    assert text.startswith(result["task_label"])

--- a/tests/planner/test_merge.py
+++ b/tests/planner/test_merge.py
@@ -11,7 +11,7 @@ from autoskillit.planner.merge import (
     merge_tier_dir,
     replace_item,
 )
-from tests.planner.conftest import make_phase_result
+from tests.planner.conftest import make_phase_result, write_task_file
 
 pytestmark = [pytest.mark.layer("planner"), pytest.mark.small, pytest.mark.feature("planner")]
 
@@ -31,7 +31,7 @@ def test_merge_files_creates_combined_document(tmp_path):
         file_paths=file_paths,
         output_path=str(out),
         key="phases",
-        task="my task",
+        task_file_path=write_task_file(tmp_path, "my task"),
         source_dir="/src",
     )
 
@@ -297,7 +297,7 @@ def test_build_plan_snapshot_produces_phase_ids(tmp_path):
     result = build_plan_snapshot(
         phases_dir=str(phases_dir),
         output_path=str(out),
-        task="my task",
+        task_file_path=write_task_file(tmp_path, "my task"),
         source_dir="/src",
     )
 
@@ -323,7 +323,10 @@ def test_build_plan_snapshot_writes_short_form_only(tmp_path):
     out = tmp_path / "snapshot.json"
 
     build_plan_snapshot(
-        phases_dir=str(phases_dir), output_path=str(out), task="t", source_dir="/s"
+        phases_dir=str(phases_dir),
+        output_path=str(out),
+        task_file_path=write_task_file(tmp_path, "t"),
+        source_dir="/s",
     )
 
     data = json.loads(out.read_text())
@@ -350,7 +353,12 @@ def test_build_plan_snapshot_projects_ordering(tmp_path) -> None:
     (phases_dir / "P1_result.json").write_text(json.dumps(result))
     out = tmp_path / "snapshot.json"
 
-    build_plan_snapshot(str(phases_dir), str(out), task="test", source_dir="/src")
+    build_plan_snapshot(
+        str(phases_dir),
+        str(out),
+        task_file_path=write_task_file(tmp_path, "test"),
+        source_dir="/src",
+    )
 
     doc = json.loads(out.read_text())
     phase = doc["phases"][0]
@@ -471,7 +479,7 @@ def test_replace_item_corrupt_replacement_json_raises(tmp_path) -> None:
         replace_item(str(src), "P1", str(corrupt))
 
 
-def test_build_plan_snapshot_reads_task_from_file(tmp_path) -> None:
+def test_build_plan_snapshot_reads_task_from_task_file_path(tmp_path) -> None:
     phases_dir = tmp_path / "phases"
     phases_dir.mkdir()
     (phases_dir / "P1_result.json").write_text(json.dumps(make_phase_result(1)))
@@ -479,13 +487,13 @@ def test_build_plan_snapshot_reads_task_from_file(tmp_path) -> None:
     task_file = tmp_path / "task_desc.txt"
     task_file.write_text("Full task from file")
 
-    build_plan_snapshot(str(phases_dir), str(out), task="label", task_file=str(task_file))
+    build_plan_snapshot(str(phases_dir), str(out), task_file_path=str(task_file))
 
     data = json.loads(out.read_text())
     assert data["task"] == "Full task from file"
 
 
-def test_merge_tier_dir_reads_task_from_file(tmp_path) -> None:
+def test_merge_tier_dir_reads_task_from_task_file_path(tmp_path) -> None:
     results_dir = tmp_path / "phases"
     results_dir.mkdir()
     (results_dir / "P1_result.json").write_text(
@@ -495,13 +503,13 @@ def test_merge_tier_dir_reads_task_from_file(tmp_path) -> None:
     task_file = tmp_path / "task_desc.txt"
     task_file.write_text("Full task from file")
 
-    merge_tier_dir(str(results_dir), str(out), "phases", task="label", task_file=str(task_file))
+    merge_tier_dir(str(results_dir), str(out), "phases", task_file_path=str(task_file))
 
     data = json.loads(out.read_text())
     assert data["task"] == "Full task from file"
 
 
-def test_merge_files_reads_task_from_file(tmp_path) -> None:
+def test_merge_files_reads_task_from_task_file_path(tmp_path) -> None:
     item = {"id": "P1", "name": "Phase 1"}
     p = tmp_path / "P1_result.json"
     p.write_text(json.dumps(item))
@@ -509,7 +517,7 @@ def test_merge_files_reads_task_from_file(tmp_path) -> None:
     task_file = tmp_path / "task_desc.txt"
     task_file.write_text("Full task from file")
 
-    merge_files([str(p)], str(out), "phases", task="label", task_file=str(task_file))
+    merge_files([str(p)], str(out), "phases", task_file_path=str(task_file))
 
     data = json.loads(out.read_text())
     assert data["task"] == "Full task from file"

--- a/tests/planner/test_pipeline_integration.py
+++ b/tests/planner/test_pipeline_integration.py
@@ -17,6 +17,7 @@ from tests.planner.conftest import (
     make_phase_result,
     make_wp_result,
     write_json,
+    write_task_file,
 )
 
 pytestmark = [pytest.mark.layer("planner"), pytest.mark.small, pytest.mark.feature("planner")]
@@ -162,7 +163,9 @@ def test_multi_phase_pipeline_end_to_end(tmp_path: Path) -> None:
     validate_result = validate_plan(str(tmp_path))
     assert validate_result["verdict"] == "pass", validate_result
 
-    compile_result = compile_plan(str(tmp_path), "integration test task", "/src")
+    compile_result = compile_plan(
+        str(tmp_path), write_task_file(tmp_path, "integration test task"), "/src"
+    )
 
     plan_path = Path(compile_result["plan_path"])
     assert plan_path.exists()
@@ -209,7 +212,7 @@ def test_pipeline_factory_fixtures_are_schema_compliant(tmp_path: Path) -> None:
     validate_result = validate_plan(str(tmp_path))
     assert validate_result["verdict"] == "pass"
 
-    compile_result = compile_plan(str(tmp_path), "factory test", "/src")
+    compile_result = compile_plan(str(tmp_path), write_task_file(tmp_path, "factory test"), "/src")
     assert Path(compile_result["plan_path"]).exists()
 
     milestones = json.loads((tmp_path / "milestones.json").read_text())

--- a/tests/planner/test_planner.py
+++ b/tests/planner/test_planner.py
@@ -49,6 +49,7 @@ def test_planner_all_exports() -> None:
         "validate_refined_assignments",
         "validate_refined_plan",
         "ValidationFinding",
+        "resolve_task_input",
     }
 
 

--- a/tests/planner/test_schema_conformance.py
+++ b/tests/planner/test_schema_conformance.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import pytest
 
 from autoskillit.planner.validation import _load_assignment_results, _load_phase_results
-from tests.planner.conftest import write_json
+from tests.planner.conftest import write_json, write_task_file
 
 pytestmark = [pytest.mark.layer("planner"), pytest.mark.small, pytest.mark.feature("planner")]
 
@@ -167,7 +167,7 @@ def test_compile_plan_derives_name_slug_from_name(tmp_path: Path) -> None:
         {"verdict": "pass", "findings": [], "warnings": [], "schema_version": 2},
     )
 
-    compile_plan(str(tmp_path), "test task", "/src")
+    compile_plan(str(tmp_path), write_task_file(tmp_path), "/src")
 
     issue = (tmp_path / "issues" / "P1-A1-WP1_issue.md").read_text()
     assert "phase-one" in issue
@@ -306,7 +306,7 @@ def test_skill_output_through_full_pipeline(tmp_path: Path) -> None:
     validate_result = validate_plan(str(tmp_path))
     assert validate_result["verdict"] == "pass"
 
-    compile_result = compile_plan(str(tmp_path), "test task", "/src")
+    compile_result = compile_plan(str(tmp_path), write_task_file(tmp_path), "/src")
     assert Path(compile_result["plan_path"]).exists()
     milestones = json.loads((tmp_path / "milestones.json").read_text())
     assert milestones["milestones"][0]["name_slug"] == "foundation"

--- a/tests/recipe/test_planner_recipe.py
+++ b/tests/recipe/test_planner_recipe.py
@@ -22,6 +22,7 @@ def test_planner_recipe_loads(planner_recipe):
 def test_planner_recipe_has_required_steps(planner_recipe):
     required_steps = {
         "init",
+        "resolve_task",
         "analyze",
         "extract_domain",
         "generate_phases",
@@ -112,7 +113,7 @@ def test_planner_recipe_extract_domain_uses_positional_args(planner_recipe):
     step = planner_recipe.steps["extract_domain"]
     skill_cmd = step.with_args.get("skill_command", "")
     assert "analysis.json" in skill_cmd, "Must pass analysis.json as positional arg"
-    assert "inputs.task_file" in skill_cmd, "Must pass task_file as positional arg"
+    assert "context.task_file_path" in skill_cmd, "Must pass task_file_path as positional arg"
     assert "env" not in step.with_args, "Must not use env: block (ADR-0003)"
 
 
@@ -272,43 +273,66 @@ def test_planner_recipe_assess_review_approach_routes_to_validate_on_failure(pla
     assert step.on_failure == "validate"
 
 
-# --- task_file ingredient tests ---
+# --- resolve_task ingredient and step tests ---
 
 
-def test_planner_recipe_has_task_file_ingredient(planner_recipe):
-    ingredients = planner_recipe.ingredients
-    assert "task_file" in ingredients, "planner recipe must have task_file ingredient"
-    assert ingredients["task_file"].required is False
+def test_planner_recipe_no_task_file_ingredient(planner_recipe):
+    assert "task_file" not in planner_recipe.ingredients
 
 
-def test_extract_domain_passes_task_file_positionally(planner_recipe):
+def test_planner_recipe_has_resolve_task_step(planner_recipe):
+    assert "resolve_task" in planner_recipe.steps
+    step = planner_recipe.steps["resolve_task"]
+    assert step.tool == "run_python"
+    assert step.with_args.get("callable") == "autoskillit.planner.resolve_task_input"
+    assert "task_file_path" in (step.capture or {})
+    assert "task_label" in (step.capture or {})
+
+
+def test_planner_init_routes_to_resolve_task(planner_recipe):
+    init_step = planner_recipe.steps["init"]
+    assert init_step.on_success == "resolve_task"
+
+
+def test_planner_resolve_task_routes_to_analyze(planner_recipe):
+    step = planner_recipe.steps["resolve_task"]
+    assert step.on_success == "analyze"
+
+
+def test_extract_domain_passes_task_file_path_positionally(planner_recipe):
     step = planner_recipe.steps["extract_domain"]
     skill_cmd = step.with_args.get("skill_command", "")
-    assert "inputs.task_file" in skill_cmd, "Must pass task_file as positional arg"
+    assert "context.task_file_path" in skill_cmd
     assert "env" not in step.with_args, "Must not use env: block (ADR-0003)"
 
 
-def test_generate_phases_passes_task_file_positionally(planner_recipe):
+def test_generate_phases_passes_task_file_path_positionally(planner_recipe):
     step = planner_recipe.steps["generate_phases"]
     skill_cmd = step.with_args.get("skill_command", "")
-    assert "inputs.task_file" in skill_cmd, "Must pass task_file as positional arg"
+    assert "context.task_file_path" in skill_cmd
     assert "env" not in step.with_args, "Must not use env: block (ADR-0003)"
 
 
-def test_build_plan_snapshot_receives_task_file(planner_recipe):
-    step = planner_recipe.steps["build_plan_snapshot"]
-    assert "task_file" in step.with_args, "build_plan_snapshot must receive task_file"
-    assert "inputs.task_file" in step.with_args["task_file"]
-
-
-@pytest.mark.parametrize("step_name", ["merge_phases", "merge_assignments", "merge_wps"])
-def test_merge_steps_receive_task_file(planner_recipe, step_name):
+@pytest.mark.parametrize(
+    "step_name", ["build_plan_snapshot", "merge_phases", "merge_assignments", "merge_wps"]
+)
+def test_merge_steps_receive_task_file_path(planner_recipe, step_name):
     step = planner_recipe.steps[step_name]
-    assert "task_file" in step.with_args, f"{step_name} must receive task_file"
-    assert "inputs.task_file" in step.with_args["task_file"]
+    assert "task_file_path" in step.with_args, f"{step_name} must receive task_file_path"
+    assert "context.task_file_path" in step.with_args["task_file_path"]
 
 
-def test_compile_step_receives_task_file(planner_recipe):
+def test_compile_step_receives_task_file_path_and_label(planner_recipe):
     step = planner_recipe.steps["compile"]
-    assert "task_file" in step.with_args, "compile must receive task_file"
-    assert "inputs.task_file" in step.with_args["task_file"]
+    assert "task_file_path" in step.with_args
+    assert "task_label" in step.with_args
+    assert "context.task_file_path" in step.with_args["task_file_path"]
+    assert "context.task_label" in step.with_args["task_label"]
+
+
+def test_no_step_references_inputs_task_file(planner_recipe):
+    for name, step in planner_recipe.steps.items():
+        step_str = str(step.with_args)
+        assert "inputs.task_file" not in step_str, (
+            f"Step {name!r} still references inputs.task_file"
+        )

--- a/tests/recipe/test_planner_recipe.py
+++ b/tests/recipe/test_planner_recipe.py
@@ -273,9 +273,6 @@ def test_planner_recipe_assess_review_approach_routes_to_validate_on_failure(pla
     assert step.on_failure == "validate"
 
 
-# --- resolve_task ingredient and step tests ---
-
-
 def test_planner_recipe_no_task_file_ingredient(planner_recipe):
     assert "task_file" not in planner_recipe.ingredients
 


### PR DESCRIPTION
## Summary

Replace the planner recipe's two task-related ingredients (`task` required + `task_file` optional) with a single `task` ingredient that accepts either inline text or a file path. Add a new `resolve_task` pipeline step immediately after `init` that detects the input type, materializes inline text to a file when needed, and captures two context variables (`task_file_path` and `task_label`) used by all downstream steps. Remove `task_file` from the recipe, Python callables, and tests. Skills remain unchanged since they already receive a file path positionally.

Closes #1634

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260502-174057-807186/.autoskillit/temp/make-plan/collapse_task_task_file_plan_2026-05-02_180500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 2.1k | 18.6k | 1.7M | 93.4k | 1 | 8m 30s |
| verify | 56 | 23.9k | 2.1M | 78.8k | 1 | 11m 2s |
| implement | 800 | 41.0k | 9.0M | 128.3k | 1 | 13m 29s |
| prepare_pr | 68 | 5.9k | 274.3k | 34.8k | 1 | 1m 53s |
| compose_pr | 59 | 2.2k | 195.2k | 20.7k | 1 | 47s |
| review_pr | 268 | 70.1k | 2.0M | 180.2k | 2 | 17m 15s |
| resolve_review | 552 | 51.1k | 3.8M | 202.6k | 2 | 22m 58s |
| ci_conflict_fix | 172 | 7.7k | 935.6k | 43.4k | 1 | 2m 55s |
| diagnose_ci | 34 | 1.0k | 134.0k | 2.7k | 1 | 6m 40s |
| resolve_ci | 421 | 3.7k | 334.5k | 38.0k | 1 | 3m 41s |
| **Total** | 4.5k | 225.2k | 20.4M | 822.9k | | 1h 29m |