### PR TITLE
Planner — Replace Fixed Phase-Count Range with Intent-Driven Decomposition

### DIFF
--- a/src/autoskillit/recipes/contracts/planner.yaml
+++ b/src/autoskillit/recipes/contracts/planner.yaml
@@ -1,12 +1,12 @@
-generated_at: '2026-05-02T22:49:40.845776+00:00'
+generated_at: '2026-05-03T01:40:00.180863+00:00'
 bundled_manifest_version: 0.1.0
 skill_hashes:
   planner-analyze: sha256:bc64ba4984d3c1b32231c062e46550bc5e00d94689d5a8967b3f222abfe0e172
   planner-extract-domain: sha256:dcb246a33465b839a552719dff34684ea9421ad99e021232ae677448a69eff45
-  planner-generate-phases: sha256:15839aa8d27a3874b1c58e25fc4c0803ca8f5328ac6e85c17eb5bf357c6738f2
+  planner-generate-phases: sha256:0904a31c377aee72e98e937915f8397e42b02dc7fab5572cb156e144bf613817
   planner-elaborate-phase: sha256:d0127bd85e030eecaabb727730ccb8d80fc05cb55227975320393ba17fcb2238
-  planner-refine-phases: sha256:ce6ead5a4c92520080b0838b6b6c5e8f1d762eeb0e5ee21a2a1fe497a720496a
-  planner-elaborate-assignments: sha256:9e69a1885de8635fc1e22fc67bab388534b37228daaaaf49cc00585694788fea
+  planner-refine-phases: sha256:3a514d6a658cb3bcee2de18f0f3aea2f529c01a24268b7f6007ec391ba8fe91c
+  planner-elaborate-assignments: sha256:1545a91c18d14d00031077833d3f37af1be7b0287e8239d469df3388496c649e
   planner-refine-assignments: sha256:584c1715729a91928994d4d18b91a8e48ca03ee94ce70dd1c613c7a5159e6318
   planner-elaborate-wps: sha256:301bebf89b29e658de254d5790d50878fde417a3359222c5b282065f13aa2b30
   planner-refine-wps: sha256:17d44c80abb78698c6173c74f6259df65ac09cd87063cfdf3e0e1de763043334

--- a/src/autoskillit/skills_extended/planner-elaborate-assignments/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-assignments/SKILL.md
@@ -98,19 +98,19 @@ Expected L0 return schema:
 {
   "id": "P1-A2",
   "phase_id": "P1",
-  "name": "Session Management",
-  "goal": "Implement user session persistence",
-  "technical_approach": "SQLite-backed session table with CRUD repository layer",
-  "dependency_notes": "Depends on P1-A1 database schema migration",
+  "name": "<assignment name>",
+  "goal": "<one-sentence goal>",
+  "technical_approach": "<technical approach description>",
+  "dependency_notes": "Depends on P1-A1 for <dependency description>",
   "overlap_notes": "No overlap detected with other assignments",
   "proposed_work_packages": [
     {
       "id_suffix": "WP1",
-      "name": "Create session table migration",
-      "scope": "Database migration and model for sessions",
+      "name": "<work package name>",
+      "scope": "<scope description>",
       "estimated_files": [
-        "src/db/migrations/002_sessions.py",
-        "src/db/models/session.py"
+        "src/<path>/<file_a>.py",
+        "src/<path>/<file_b>.py"
       ]
     }
   ]

--- a/src/autoskillit/skills_extended/planner-generate-phases/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-generate-phases/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: planner-generate-phases
 categories: [planner]
-description: Generate 3-6 high-level phases from project analysis (Pass 1 entry point)
+description: Generate high-level phases from project analysis (Pass 1 entry point)
 hooks:
   PreToolUse:
     - matcher: "*"
@@ -14,8 +14,9 @@ hooks:
 # planner-generate-phases
 
 Pass 1 entry point. Read the analysis file (and optionally domain knowledge) and produce
-3–6 phase definitions in a single session. Write all phase results and a fully-done
-`phase_manifest.json` in one shot.
+phase definitions in a single session. The number of phases is determined entirely by the
+task — each phase is an independently verifiable checkpoint. Write all phase results and
+a fully-done `phase_manifest.json` in one shot.
 
 ## When to Use
 
@@ -31,7 +32,8 @@ Pass 1 entry point. Read the analysis file (and optionally domain knowledge) and
 ## Critical Constraints
 
 **NEVER:**
-- Produce fewer than 3 or more than 6 phases
+- Invent phases that do not serve the task description — every phase must map to work requested by the user
+- Anchor phase count to a predetermined number — derive it from the task's natural verification boundaries
 - Write output outside `$(dirname $1)/phases/`
 - Use freeform text instead of the required JSON schema
 - Read files outside `$(dirname $1)` or the project's git-tracked source tree
@@ -63,11 +65,25 @@ and scope.
 
 ### Step 2: Decompose into phases
 
-Identify 3–6 high-level phases that partition the implementation work. Phases should be:
+Decompose the implementation work into phases. A phase is an **independently verifiable
+checkpoint** — a coherent set of features whose functionality can be fully tested once
+implemented. Draw phase boundaries wherever you can stop and validate that everything
+up to that point works.
+
+Phases should be:
 - Coherent (each phase has a single, clear goal)
 - Ordered by dependency (foundational work first)
 - Non-overlapping in scope
-- Named to reflect the task's work units, grounded in the codebase's architecture (e.g., if the task is "add user authentication", phases might be "Auth Data Model", "Auth API Endpoints", "Auth UI Integration")
+- Named to reflect the task's work units, grounded in the codebase's architecture
+
+The number of phases is determined by the task:
+- A single-component change may warrant 1 phase
+- A multi-component feature may warrant one phase per independently testable component
+- There is no minimum or maximum — let the verification boundaries dictate the count
+
+Do NOT provide yourself with concrete domain examples of phase decomposition. Concrete
+examples anchor the decomposition pattern regardless of the actual task (pink elephant
+effect). Derive phase names and boundaries from the task description and codebase analysis.
 
 For each phase, generate:
 - `id`: Sequential `P{N}` identifier (P1, P2, ...)
@@ -85,18 +101,18 @@ For each phase, write to `$(dirname $1)/phases/{phase_id}_result.json`:
 ```json
 {
   "id": "P1",
-  "name": "Database Layer",
-  "goal": "Establish data persistence and schema foundations",
-  "scope": ["models", "migrations", "repositories"],
+  "name": "<descriptive phase name derived from task>",
+  "goal": "<one-sentence statement of what this phase achieves>",
+  "scope": ["<component-a>", "<component-b>"],
   "ordering": 1,
   "relationship_notes": "Foundation phase — no prior dependencies",
-  "assignments_preview": ["Schema design", "Migration framework", "Repository pattern"]
+  "assignments_preview": ["<assignment-1>", "<assignment-2>", "<assignment-3>"]
 }
 ```
 
 The backend derives two additional fields at load time — do not write them:
 - `phase_number` (integer): derived from `ordering`
-- `name_slug` (string): derived by slugifying `name` (e.g., "Database Layer" → "database-layer")
+- `name_slug` (string): derived by slugifying `name` (e.g., "Component Setup" → "component-setup")
 
 ### Step 4: Write phase manifest
 
@@ -112,7 +128,7 @@ Manifest structure:
   "items": [
     {
       "id": "P1",
-      "name": "Database Layer",
+      "name": "<phase name>",
       "status": "done",
       "result_path": "<absolute_path>/phases/P1_result.json",
       "metadata": {"ordering": 1}

--- a/src/autoskillit/skills_extended/planner-refine-phases/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine-phases/SKILL.md
@@ -40,6 +40,7 @@ conflicts, applies field-level edits to the plan, and writes `refined_plan.json`
 - Skip emitting `refined_plan_path` even if all L0s fail (write unchanged plan, still emit)
 - Read `{{AUTOSKILLIT_TEMP}}` artifacts not passed as positional arguments
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Spawn more than 6 L0s in a single parallel batch
 
 **ALWAYS:**
 - Validate each L0 response for `phase_id`, `changes` (array), `conflicts` (array)
@@ -83,7 +84,11 @@ Read the `task` field from the combined plan document. Each L0 subagent reviewin
 must verify that the phase's goal and scope serve the stated task. Phases that appear to
 address codebase concerns not mentioned in the task should be flagged for scope creep.
 
-Spawn one L0 subagent per phase in parallel using the Agent/Task tool. Each L0 receives:
+If phase count ≤ 6: spawn one L0 subagent per phase in a single parallel batch.
+If phase count > 6: spawn sequential batches of 6 L0 subagents. Wait for each batch
+to complete before spawning the next. Process phases in ordering sequence.
+
+Each L0 receives:
 - The full serialized `combined_plan.json` content (pasted inline or via file read)
 - Its `target_phase_id` (e.g., `"P2"`)
 - Instructions: review the target phase in light of what all other phases committed

--- a/tests/skills/test_planner_skill_contracts.py
+++ b/tests/skills/test_planner_skill_contracts.py
@@ -390,3 +390,84 @@ def test_generate_phases_skill_no_env_var_delivery():
     content = (SKILLS_ROOT / "planner-generate-phases" / "SKILL.md").read_text()
     assert "PLANNER_TASK_FILE" not in content, "Must not reference PLANNER_TASK_FILE env var"
     assert "PLANNER_TASK" not in content, "Must not reference PLANNER_TASK env var"
+
+
+# --- intent-driven decomposition tests (T1–T7) ---
+
+
+def test_generate_phases_no_fixed_range_in_description():
+    """Description frontmatter must not contain a fixed numeric phase range."""
+    content = (SKILLS_ROOT / "planner-generate-phases" / "SKILL.md").read_text()
+    parts = content.split("---", 2)
+    data = yaml.safe_load(parts[1]) or {}
+    description = data.get("description", "")
+    assert "3-6" not in description, "description must not hardcode '3-6' phase range"
+    assert "3–6" not in description, "description must not hardcode '3–6' phase range"
+
+
+def test_generate_phases_no_fixed_range_in_body():
+    """SKILL.md body must not contain a fixed '3-6' or '3–6' phase range."""
+    content = (SKILLS_ROOT / "planner-generate-phases" / "SKILL.md").read_text()
+    assert "3-6" not in content, "SKILL.md must not contain '3-6'"
+    assert "3–6" not in content, "SKILL.md must not contain '3–6'"
+
+
+def test_generate_phases_no_phase_count_never_constraint():
+    """The NEVER block must not impose a min/max phase count."""
+    content = (SKILLS_ROOT / "planner-generate-phases" / "SKILL.md").read_text()
+    assert "fewer than 3" not in content.lower()
+    assert "more than 6" not in content.lower()
+
+
+def test_generate_phases_has_intent_driven_guidance():
+    """SKILL.md must contain intent-driven decomposition guidance."""
+    content = (SKILLS_ROOT / "planner-generate-phases" / "SKILL.md").read_text().lower()
+    assert "independently verifiable" in content or "verifiable checkpoint" in content, (
+        "Must define phases as independently verifiable checkpoints"
+    )
+
+
+ANCHORING_TERMS = [
+    "Database Layer",
+    "Auth Data Model",
+    "Auth API Endpoints",
+    "Auth UI Integration",
+    "user authentication",
+    "Schema design",
+    "Migration framework",
+    "Repository pattern",
+]
+
+
+@pytest.mark.parametrize("term", ANCHORING_TERMS)
+def test_generate_phases_no_domain_anchoring(term: str):
+    """SKILL.md must not contain domain-specific example names that cause LLM anchoring."""
+    content = (SKILLS_ROOT / "planner-generate-phases" / "SKILL.md").read_text()
+    assert term not in content, (
+        f"Domain-specific example '{term}' causes LLM anchoring bias — "
+        f"use generic placeholders instead"
+    )
+
+
+ELABORATE_ANCHORING_TERMS = [
+    "Session Management",
+    "user session persistence",
+    "SQLite-backed session table",
+]
+
+
+@pytest.mark.parametrize("term", ELABORATE_ANCHORING_TERMS)
+def test_elaborate_assignments_no_domain_anchoring(term: str):
+    """elaborate-assignments SKILL.md must not use domain-specific examples."""
+    content = (SKILLS_ROOT / "planner-elaborate-assignments" / "SKILL.md").read_text()
+    assert term not in content, f"Domain-specific example '{term}' causes LLM anchoring bias"
+
+
+def test_refine_phases_has_batch_ceiling():
+    """refine-phases must handle >6 phases via sequential batching (no unbounded spawn)."""
+    content = (SKILLS_ROOT / "planner-refine-phases" / "SKILL.md").read_text()
+    has_batch_guidance = "batch" in content.lower() and "6" in content
+    assert has_batch_guidance, (
+        "planner-refine-phases must include batch ceiling guidance for >6 phases "
+        "(consistent with refine-wps and refine-assignments)"
+    )

--- a/tests/skills/test_planner_skill_contracts.py
+++ b/tests/skills/test_planner_skill_contracts.py
@@ -395,16 +395,6 @@ def test_generate_phases_skill_no_env_var_delivery():
 # --- intent-driven decomposition tests (T1–T7) ---
 
 
-def test_generate_phases_no_fixed_range_in_description():
-    """Description frontmatter must not contain a fixed numeric phase range."""
-    content = (SKILLS_ROOT / "planner-generate-phases" / "SKILL.md").read_text()
-    parts = content.split("---", 2)
-    data = yaml.safe_load(parts[1]) or {}
-    description = data.get("description", "")
-    assert "3-6" not in description, "description must not hardcode '3-6' phase range"
-    assert "3–6" not in description, "description must not hardcode '3–6' phase range"
-
-
 def test_generate_phases_no_fixed_range_in_body():
     """SKILL.md body must not contain a fixed '3-6' or '3–6' phase range."""
     content = (SKILLS_ROOT / "planner-generate-phases" / "SKILL.md").read_text()
@@ -466,7 +456,7 @@ def test_elaborate_assignments_no_domain_anchoring(term: str):
 def test_refine_phases_has_batch_ceiling():
     """refine-phases must handle >6 phases via sequential batching (no unbounded spawn)."""
     content = (SKILLS_ROOT / "planner-refine-phases" / "SKILL.md").read_text()
-    has_batch_guidance = "batch" in content.lower() and "6" in content
+    has_batch_guidance = "batch of 6" in content.lower() or "batches of 6" in content.lower()
     assert has_batch_guidance, (
         "planner-refine-phases must include batch ceiling guidance for >6 phases "
         "(consistent with refine-wps and refine-assignments)"


### PR DESCRIPTION
## Summary

Replace the hardcoded "3–6 phases" constraint in `planner-generate-phases/SKILL.md` with intent-driven decomposition guidance. The LLM-facing SKILL.md currently repeats a narrow numeric range (3–6) four times plus uses domain-specific examples ("Database Layer", "Auth API Endpoints") that cause anchoring bias — every completed run produced exactly 5 phases regardless of task complexity. This plan removes all fixed-range and domain-anchoring content, replaces it with checkpoint-based decomposition guidance, neutralizes domain-specific examples in `planner-elaborate-assignments/SKILL.md`, and adds a batch ceiling to `planner-refine-phases/SKILL.md` (which currently spawns all phases in parallel with no size guard, relying on the now-removed 3–6 assumption).

No Python backend changes are required — `validation.py`, `schema.py`, and `manifests.py` impose no phase-count bounds. The contract card SHA hash for `planner-generate-phases` must be regenerated after the SKILL.md edit.

Closes #1636

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260502-181823-129753/.autoskillit/temp/make-plan/planner-replace-fixed-phase-count-range-with-intent-driven-d_plan_2026-05-02_190000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 72 | 11.1k | 1.3M | 85.5k | 1 | 8m 31s |
| verify | 55 | 13.4k | 1.2M | 65.5k | 1 | 5m 31s |
| implement | 292 | 13.2k | 2.4M | 74.4k | 1 | 8m 21s |
| prepare_pr | 60 | 4.5k | 220.8k | 29.8k | 1 | 1m 23s |
| compose_pr | 51 | 2.4k | 163.8k | 20.0k | 1 | 43s |
| review_pr | 116 | 24.9k | 616.3k | 57.7k | 1 | 6m 20s |
| resolve_review | 311 | 19.4k | 2.4M | 79.2k | 1 | 9m 13s |
| **Total** | 957 | 88.9k | 8.3M | 412.1k | | 40m 5s |