### PR TITLE
Increase _MAX_SESSIONS from 500 to 2,000 and Make Configurable

### DIFF
--- a/src/autoskillit/config/_config_dataclasses.py
+++ b/src/autoskillit/config/_config_dataclasses.py
@@ -214,6 +214,7 @@ class LinuxTracingConfig:
     proc_interval: float = 5.0
     log_dir: str = ""  # empty = platform default (~/.local/share/autoskillit/logs on Linux)
     tmpfs_path: str = "/dev/shm"  # RAM-backed tmpfs for crash-resilient streaming
+    max_sessions: int = 2000
 
     def __post_init__(self) -> None:
         if self.tmpfs_path != "/dev/shm" or not os.environ.get("PYTEST_CURRENT_TEST"):

--- a/src/autoskillit/config/defaults.yaml
+++ b/src/autoskillit/config/defaults.yaml
@@ -111,6 +111,7 @@ linux_tracing:
   proc_interval: 5.0
   log_dir: ""  # empty = platform default (~/.local/share/autoskillit/logs on Linux)
   tmpfs_path: "/dev/shm"  # RAM-backed tmpfs for crash-resilient streaming
+  max_sessions: 2000  # retention limit for session diagnostics directories
 
 mcp_response:
   alert_threshold_tokens: 2000

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -392,6 +392,7 @@ class AutomationConfig:
                 proc_interval=float(val(lt, "proc_interval", _lt["proc_interval"])),
                 log_dir=str(val(lt, "log_dir", _lt["log_dir"])),
                 tmpfs_path=str(val(lt, "tmpfs_path", _lt["tmpfs_path"])),
+                max_sessions=int(val(lt, "max_sessions", _lt["max_sessions"])),
             ),
             mcp_response=McpResponseConfig(
                 alert_threshold_tokens=int(

--- a/src/autoskillit/execution/headless.py
+++ b/src/autoskillit/execution/headless.py
@@ -310,6 +310,7 @@ async def _execute_claude_headless(
                 recipe_content_hash=recipe_content_hash,
                 recipe_composite_hash=recipe_composite_hash,
                 recipe_version=recipe_version,
+                max_sessions=ctx.config.linux_tracing.max_sessions,
                 telemetry=_build_error_path_telemetry(ctx.github_api_log),
             )
         except Exception:
@@ -351,6 +352,7 @@ async def _execute_claude_headless(
                     recipe_content_hash=recipe_content_hash,
                     recipe_composite_hash=recipe_composite_hash,
                     recipe_version=recipe_version,
+                    max_sessions=ctx.config.linux_tracing.max_sessions,
                     telemetry=_build_error_path_telemetry(ctx.github_api_log),
                 )
         except Exception:
@@ -475,6 +477,7 @@ async def _execute_claude_headless(
                 recipe_content_hash=recipe_content_hash,
                 recipe_composite_hash=recipe_composite_hash,
                 recipe_version=recipe_version,
+                max_sessions=ctx.config.linux_tracing.max_sessions,
             )
         except Exception:
             logger.debug("session_log_flush_failed", exc_info=True)

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -132,7 +132,7 @@ def flush_session_log(
     recipe_content_hash: str = "",
     recipe_composite_hash: str = "",
     recipe_version: str = "",
-    max_sessions: int = _MAX_SESSIONS,
+    max_sessions: int | None = None,
     telemetry: SessionTelemetry,
 ) -> None:
     """Flush session diagnostics to disk.
@@ -453,7 +453,7 @@ def flush_session_log(
         log_root,
         project_dir=project_dir,
         build_protected_campaign_ids=build_protected_campaign_ids,
-        max_sessions=max_sessions,
+        max_sessions=max_sessions if max_sessions is not None else _MAX_SESSIONS,
     )
 
 

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -37,7 +37,7 @@ from autoskillit.execution.linux_tracing import (
 
 logger = get_logger(__name__)
 
-_MAX_SESSIONS = 500
+_MAX_SESSIONS = 2000
 
 
 def _primary_model_identifier(token_usage: dict[str, Any] | None) -> str:
@@ -132,13 +132,15 @@ def flush_session_log(
     recipe_content_hash: str = "",
     recipe_composite_hash: str = "",
     recipe_version: str = "",
+    max_sessions: int = _MAX_SESSIONS,
     telemetry: SessionTelemetry,
 ) -> None:
     """Flush session diagnostics to disk.
 
     Writes proc_trace.jsonl, summary.json, anomalies.jsonl (if any),
     and appends to the global sessions.jsonl index. Applies retention
-    to keep at most 500 session directories.
+    to keep at most ``_MAX_SESSIONS`` session directories (default 2000,
+    configurable via ``linux_tracing.max_sessions``).
 
     When step_name is provided, also writes token_usage.json, step_timing.json,
     and (if telemetry.audit_record is set) audit_log.json to the session directory
@@ -451,6 +453,7 @@ def flush_session_log(
         log_root,
         project_dir=project_dir,
         build_protected_campaign_ids=build_protected_campaign_ids,
+        max_sessions=max_sessions,
     )
 
 
@@ -458,8 +461,10 @@ def _enforce_retention(
     log_root: Path,
     project_dir: str | None = None,
     build_protected_campaign_ids: Callable[[Path], frozenset[str]] | None = None,
+    *,
+    max_sessions: int = _MAX_SESSIONS,
 ) -> None:
-    """Delete oldest session directories if count exceeds _MAX_SESSIONS.
+    """Delete oldest session directories if count exceeds *max_sessions*.
 
     When ``project_dir`` is provided, reads fleet state files and ``meta.json``
     sidecars to skip deletion of sessions belonging to active campaigns.
@@ -469,11 +474,11 @@ def _enforce_retention(
         return
 
     dirs = sorted(sessions_dir.iterdir(), key=lambda p: p.stat().st_mtime)
-    if len(dirs) <= _MAX_SESSIONS:
+    if len(dirs) <= max_sessions:
         return
 
-    expired = dirs[: len(dirs) - _MAX_SESSIONS]
-    surviving_names = {d.name for d in dirs[len(dirs) - _MAX_SESSIONS :]}
+    expired = dirs[: len(dirs) - max_sessions]
+    surviving_names = {d.name for d in dirs[len(dirs) - max_sessions :]}
 
     protected_ids = (
         build_protected_campaign_ids(Path(project_dir))

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -571,7 +571,31 @@ class TestLinuxTracingConfig:
         from autoskillit.config.settings import LinuxTracingConfig
 
         names = {f.name for f in dc_fields(LinuxTracingConfig)}
-        assert names == {"enabled", "proc_interval", "log_dir", "tmpfs_path"}
+        assert names == {"enabled", "proc_interval", "log_dir", "tmpfs_path", "max_sessions"}
+
+    def test_linux_tracing_max_sessions_default(self):
+        """LT_C5: LinuxTracingConfig includes max_sessions with default 2000."""
+        import dataclasses
+
+        from autoskillit.config.settings import LinuxTracingConfig
+
+        cfg = LinuxTracingConfig(tmpfs_path="/tmp/test")
+        assert cfg.max_sessions == 2000
+        assert "max_sessions" in {f.name for f in dataclasses.fields(LinuxTracingConfig)}
+
+    def test_linux_tracing_max_sessions_yaml_roundtrip(self, tmp_path):
+        """LT_C6: max_sessions survives YAML round-trip."""
+        (tmp_path / ".autoskillit").mkdir()
+        (tmp_path / ".autoskillit" / "config.yaml").write_text(
+            "linux_tracing:\n  max_sessions: 750\n"
+        )
+        cfg = load_config(tmp_path)
+        assert cfg.linux_tracing.max_sessions == 750
+
+    def test_automation_config_linux_tracing_has_max_sessions(self):
+        """LT_C3 extension: AutomationConfig().linux_tracing includes max_sessions."""
+        cfg = AutomationConfig()
+        assert cfg.linux_tracing.max_sessions == 2000
 
 
 class TestDynaconfIntegration:

--- a/tests/execution/test_session_log_flush.py
+++ b/tests/execution/test_session_log_flush.py
@@ -183,8 +183,8 @@ def test_flush_session_log_retention_purges_oldest(tmp_path):
         with index_path.open("a") as f:
             f.write(json.dumps({"session_id": dir_name, "dir_name": dir_name}) + "\n")
 
-    # Flush a 503rd session
-    _flush(tmp_path, session_id="session-0502")
+    # Flush a 503rd session with explicit cap
+    _flush(tmp_path, session_id="session-0502", max_sessions=500)
 
     remaining = list(sessions_dir.iterdir())
     assert len(remaining) == 500

--- a/tests/execution/test_session_log_retention.py
+++ b/tests/execution/test_session_log_retention.py
@@ -853,7 +853,7 @@ def test_flush_session_log_passes_callback_to_enforce_retention(
 
 
 def test_max_sessions_constant_is_2000():
-    """T5: _MAX_SESSIONS constant updated to 2000."""
+    """T5: _MAX_SESSIONS equals 2000."""
     from autoskillit.execution.session_log import _MAX_SESSIONS
 
     assert _MAX_SESSIONS == 2000

--- a/tests/execution/test_session_log_retention.py
+++ b/tests/execution/test_session_log_retention.py
@@ -821,7 +821,7 @@ def test_flush_session_log_passes_callback_to_enforce_retention(
     captured: list = []
 
     def fake_enforce_retention(
-        log_root, project_dir="", build_protected_campaign_ids=None
+        log_root, project_dir="", build_protected_campaign_ids=None, **kwargs
     ) -> None:
         captured.append(build_protected_campaign_ids)
 
@@ -847,3 +847,43 @@ def test_flush_session_log_passes_callback_to_enforce_retention(
     assert (tmp_path / "sessions.jsonl").exists()
     assert len(captured) == 1
     assert captured[0] is sentinel
+
+
+# --- max_sessions configurability tests ---
+
+
+def test_max_sessions_constant_is_2000():
+    """T5: _MAX_SESSIONS constant updated to 2000."""
+    from autoskillit.execution.session_log import _MAX_SESSIONS
+
+    assert _MAX_SESSIONS == 2000
+
+
+def test_enforce_retention_respects_max_sessions_param(tmp_path):
+    """T3: Passing max_sessions overrides the module-level _MAX_SESSIONS."""
+    import autoskillit.execution.session_log as sl_module
+
+    _make_sessions(tmp_path, count=10)
+    sl_module._enforce_retention(tmp_path, max_sessions=7)
+    remaining = list((tmp_path / "sessions").iterdir())
+    assert len(remaining) == 7
+
+
+def test_flush_threads_max_sessions_to_enforce_retention(tmp_path, monkeypatch):
+    """T4: flush_session_log passes max_sessions through to _enforce_retention."""
+    import autoskillit.execution.session_log as sl_module
+
+    captured: dict = {}
+
+    def fake_enforce(
+        log_root,
+        project_dir="",
+        build_protected_campaign_ids=None,
+        *,
+        max_sessions=sl_module._MAX_SESSIONS,
+    ) -> None:
+        captured["max_sessions"] = max_sessions
+
+    monkeypatch.setattr(sl_module, "_enforce_retention", fake_enforce)
+    _flush(tmp_path, max_sessions=999)
+    assert captured["max_sessions"] == 999

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -112,11 +112,11 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/core/io.py", 118),
     # session_log.py — github_api_usage dict, summary dict, meta.json sidecar,
     # token_usage dict, step_timing dict
-    ("src/autoskillit/execution/session_log.py", 305),
-    ("src/autoskillit/execution/session_log.py", 365),
-    ("src/autoskillit/execution/session_log.py", 369),
-    ("src/autoskillit/execution/session_log.py", 396),
-    ("src/autoskillit/execution/session_log.py", 393),
+    ("src/autoskillit/execution/session_log.py", 307),
+    ("src/autoskillit/execution/session_log.py", 367),
+    ("src/autoskillit/execution/session_log.py", 371),
+    ("src/autoskillit/execution/session_log.py", 398),
+    ("src/autoskillit/execution/session_log.py", 395),
     # migration/store.py — failure store dicts
     ("src/autoskillit/migration/store.py", 54),
     ("src/autoskillit/migration/store.py", 64),


### PR DESCRIPTION
## Summary

Change the hardcoded `_MAX_SESSIONS = 500` constant in `session_log.py` to `2000` and expose it as `linux_tracing.max_sessions` in the dynaconf-based config system. The constant remains as a fallback default for code paths where config is unavailable (e.g., `recover_crashed_sessions`). The config value is threaded as a parameter through `flush_session_log` and `_enforce_retention` — no function reads config directly; all inputs arrive as explicit parameters.

Closes #1637

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260502-182643-719715/.autoskillit/temp/make-plan/increase_max_sessions_plan_2026-05-02_183000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 62 | 8.7k | 744.5k | 45.0k | 1 | 7m 17s |
| verify | 41 | 9.9k | 1.3M | 58.2k | 1 | 4m 37s |
| implement | 51 | 10.9k | 1.1M | 50.7k | 1 | 4m 1s |
| prepare_pr | 23 | 4.1k | 144.7k | 27.5k | 1 | 1m 17s |
| compose_pr | 22 | 1.3k | 132.6k | 19.0k | 1 | 36s |
| review_pr | 27 | 18.9k | 379.5k | 50.2k | 1 | 5m 18s |
| resolve_review | 38 | 9.7k | 1.0M | 51.7k | 1 | 7m 1s |
| **Total** | 264 | 63.5k | 4.9M | 302.2k | | 30m 10s |
## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| refine_assignments | 273 | 7222.5 | 363.4 | 95.7 |
| elaborate_wps | 0 | — | — | — |
| **Total** | **273** | 16215.7 | 765.1 | 165.9 |