### PR TITLE
Rectify: Feature Gate Silently Blocks Explicitly Requested Skills — Policy Layering Violation

### DIFF
--- a/src/autoskillit/workspace/session_skills.py
+++ b/src/autoskillit/workspace/session_skills.py
@@ -172,7 +172,14 @@ def _is_skill_disabled(
     `disabled` entries from user config and packs are never bypassed.
     """
     _feature_tool_tags: frozenset[str] = (
-        frozenset(tag for feat_def in FEATURE_REGISTRY.values() for tag in feat_def.tool_tags)
+        frozenset(
+            tag
+            for feat_name, feat_def in FEATURE_REGISTRY.items()
+            for tag in feat_def.tool_tags
+            if not is_feature_enabled(
+                feat_name, features, experimental_enabled=experimental_enabled
+            )
+        )
         if allow_only is not None and skill_info.name in allow_only
         else frozenset()
     )

--- a/src/autoskillit/workspace/session_skills.py
+++ b/src/autoskillit/workspace/session_skills.py
@@ -154,6 +154,7 @@ def _is_skill_disabled(
     features: dict[str, bool],
     *,
     experimental_enabled: bool = False,
+    allow_only: frozenset[str] | None = None,
 ) -> bool:
     """Return True if skill should be excluded due to a disabled subset.
 
@@ -164,6 +165,10 @@ def _is_skill_disabled(
     Feature-gate branch: for each feature in FEATURE_REGISTRY that is disabled
     in `features`, suppress any skill whose categories intersect the feature's
     skill_categories. An empty `features` dict uses each feature's default_enabled.
+
+    Policy layering: when `allow_only` is set and `skill_info.name` is in it, the
+    FEATURE_REGISTRY branch is bypassed (allow_only is a higher-priority signal than
+    a background feature default). Explicit `disabled` entries are never bypassed.
     """
     for tag in disabled:
         if tag in custom_tags:
@@ -182,6 +187,13 @@ def _is_skill_disabled(
             disabled_cats |= feat_def.skill_categories
     for cat in disabled_cats - enabled_cats:
         if cat in skill_info.categories:
+            if allow_only is not None and skill_info.name in allow_only:
+                logger.info(
+                    "feature_gate_bypassed_by_allow_only",
+                    skill=skill_info.name,
+                    category=cat,
+                )
+                continue
             return True
 
     return False
@@ -224,6 +236,7 @@ def _should_inject_skill(
     effective_custom_tags: dict[str, list[str]],
     features: dict[str, bool],
     experimental_enabled: bool = False,
+    allow_only: frozenset[str] | None = None,
 ) -> bool:
     """Return True if this skill should be written to the ephemeral session dir.
 
@@ -244,6 +257,7 @@ def _should_inject_skill(
         effective_custom_tags,
         features,
         experimental_enabled=experimental_enabled,
+        allow_only=allow_only,
     ):
         return False
     return True
@@ -461,6 +475,7 @@ class DefaultSessionSkillManager:
                     if config is not None and not cook_session
                     else False
                 ),
+                allow_only=allow_only,
             ):
                 if skill_info.source == SkillSource.BUNDLED:
                     _log.debug("init_session_plugin_dir_skip", skill=skill_info.name)
@@ -474,6 +489,19 @@ class DefaultSessionSkillManager:
             gated = (not cook_session) and (skill_info.name in tier2_skills)
             content = self._provider.get_skill_content(skill_info.name, gated=gated)
             atomic_write(skill_dir / "SKILL.md", content)
+        if allow_only is not None and allow_only:
+            written = {p.name for p in skills_base.iterdir() if p.is_dir()}
+            bundled_names = {
+                s.name for s in self._provider.list_skills() if s.source == SkillSource.BUNDLED
+            }
+            achievable = allow_only - overrides - bundled_names
+            if achievable and not (written & achievable):
+                raise RuntimeError(
+                    f"init_session: allow_only={sorted(allow_only)!r} specified but "
+                    f"zero skills were written to {skills_base}. "
+                    f"This indicates a gating conflict — check feature gates, "
+                    f"disabled categories, or pack visibility."
+                )
         return ValidatedAddDir(path=str(session_skills_dir))
 
     def activate_skill_deps(self, session_id: str, skill_name: str) -> bool:

--- a/src/autoskillit/workspace/session_skills.py
+++ b/src/autoskillit/workspace/session_skills.py
@@ -198,6 +198,7 @@ def _is_skill_disabled(
             return True
 
     # Union model: suppress a category only when ALL features that gate it are disabled.
+    _in_allow_only: bool = allow_only is not None and skill_info.name in allow_only
     enabled_cats: set[str] = set()
     disabled_cats: set[str] = set()
     for feat_name, feat_def in FEATURE_REGISTRY.items():
@@ -207,7 +208,7 @@ def _is_skill_disabled(
             disabled_cats |= feat_def.skill_categories
     for cat in disabled_cats - enabled_cats:
         if cat in skill_info.categories:
-            if allow_only is not None and skill_info.name in allow_only:
+            if _in_allow_only:
                 logger.info(
                     "feature_gate_bypassed_by_allow_only",
                     skill=skill_info.name,

--- a/src/autoskillit/workspace/session_skills.py
+++ b/src/autoskillit/workspace/session_skills.py
@@ -166,15 +166,28 @@ def _is_skill_disabled(
     in `features`, suppress any skill whose categories intersect the feature's
     skill_categories. An empty `features` dict uses each feature's default_enabled.
 
-    Policy layering: when `allow_only` is set and `skill_info.name` is in it, the
-    FEATURE_REGISTRY branch is bypassed (allow_only is a higher-priority signal than
-    a background feature default). Explicit `disabled` entries are never bypassed.
+    Policy layering: when `allow_only` is set and `skill_info.name` is in it, both
+    the FEATURE_REGISTRY branch and any feature-gate-derived tool tags in the
+    `disabled` list (injected via disabled_feature_tags) are bypassed. Explicit
+    `disabled` entries from user config and packs are never bypassed.
     """
+    _feature_tool_tags: frozenset[str] = (
+        frozenset(tag for feat_def in FEATURE_REGISTRY.values() for tag in feat_def.tool_tags)
+        if allow_only is not None and skill_info.name in allow_only
+        else frozenset()
+    )
     for tag in disabled:
         if tag in custom_tags:
             if skill_info.name in custom_tags[tag]:
                 return True
         elif tag in skill_info.categories:
+            if tag in _feature_tool_tags:
+                logger.info(
+                    "feature_gate_bypassed_by_allow_only",
+                    skill=skill_info.name,
+                    category=tag,
+                )
+                continue
             return True
 
     # Union model: suppress a category only when ALL features that gate it are disabled.

--- a/tests/workspace/test_session_skills_allow_only_and_closure.py
+++ b/tests/workspace/test_session_skills_allow_only_and_closure.py
@@ -19,6 +19,10 @@ _FEATURE_SKILL_CATEGORY_PARAMS = [
     for feat_name, feat_def in FEATURE_REGISTRY.items()
     for cat in feat_def.skill_categories
 ]
+assert len(_FEATURE_SKILL_CATEGORY_PARAMS) > 0, (
+    "FEATURE_REGISTRY has no entries with skill_categories — "
+    "test_allow_only_overrides_all_feature_registry_entries would be silently skipped"
+)
 
 
 def _make_synthetic_provider(
@@ -375,6 +379,12 @@ class TestCrossAxisGatingMatrix:
         assert target_written == expected_target_written, (
             f"target (category=planner) written={target_written!r}, "
             f"expected={expected_target_written!r} for "
+            f"allow_only={allow_only!r}, feature_enabled={feature_enabled!r}, "
+            f"subsets_disabled={subsets_disabled!r}, cook_session={cook_session!r}"
+        )
+        sibling_written = (skills_base / "sibling").exists()
+        assert sibling_written, (
+            f"sibling (no categories) must always be written — "
             f"allow_only={allow_only!r}, feature_enabled={feature_enabled!r}, "
             f"subsets_disabled={subsets_disabled!r}, cook_session={cook_session!r}"
         )

--- a/tests/workspace/test_session_skills_allow_only_and_closure.py
+++ b/tests/workspace/test_session_skills_allow_only_and_closure.py
@@ -6,12 +6,19 @@ from pathlib import Path
 
 import pytest
 
+from autoskillit.core import FEATURE_REGISTRY
 from autoskillit.workspace.session_skills import (
     DefaultSessionSkillManager,
     SkillsDirectoryProvider,
 )
 
 pytestmark = [pytest.mark.layer("workspace"), pytest.mark.small]
+
+_FEATURE_SKILL_CATEGORY_PARAMS = [
+    pytest.param(feat_name, cat, id=f"{feat_name}-{cat}")
+    for feat_name, feat_def in FEATURE_REGISTRY.items()
+    for cat in feat_def.skill_categories
+]
 
 
 def _make_synthetic_provider(
@@ -111,7 +118,7 @@ class TestInitSessionAllowOnly:
         names = {p.parent.name for p in skills_base.glob("*/SKILL.md")}
         assert names == {"alpha", "beta", "gamma"}
 
-    def test_allow_only_intersects_effective_disabled_disabled_wins(self, tmp_path: Path) -> None:
+    def test_allow_only_does_not_override_explicit_subsets_disabled(self, tmp_path: Path) -> None:
         from tests._helpers import make_subsetsconfig, make_test_config
 
         provider = _make_synthetic_provider(
@@ -175,6 +182,202 @@ class TestInitSessionAllowOnly:
             if entry.get("event") == "init_session_allow_only_skip"
         }
         assert skipped == {"beta", "gamma"}
+
+    def test_allow_only_overrides_feature_gate_for_explicitly_requested_skills(
+        self, tmp_path: Path
+    ) -> None:
+        from tests._helpers import make_test_config
+
+        provider = _make_synthetic_provider(
+            tmp_path / "skills",
+            {"planner-skill": {"categories": ["planner"]}},
+        )
+        root = tmp_path / "sessions"
+        root.mkdir()
+        mgr = DefaultSessionSkillManager(provider, ephemeral_root=root)
+        config = make_test_config(features={}, experimental_enabled=False)
+        session_path = mgr.init_session(
+            "s-feat-bypass",
+            allow_only=frozenset({"planner-skill"}),
+            config=config,
+        )
+
+        skills_base = session_path / ".claude" / "skills"
+        assert (skills_base / "planner-skill" / "SKILL.md").exists(), (
+            "planner-skill must be written when allow_only explicitly requests it, "
+            "even though the planner feature gate is off (experimental_enabled=False)"
+        )
+
+    def test_allow_only_nonempty_but_zero_skills_raises(self, tmp_path: Path) -> None:
+        provider = _make_synthetic_provider(
+            tmp_path / "skills",
+            {"alpha": {}, "beta": {}},
+        )
+        root = tmp_path / "sessions"
+        root.mkdir()
+        mgr = DefaultSessionSkillManager(provider, ephemeral_root=root)
+        with pytest.raises(RuntimeError, match="allow_only") as exc_info:
+            mgr.init_session("s-zero", allow_only=frozenset({"ghost-skill"}))
+        assert "zero skills" in str(exc_info.value)
+
+    @pytest.mark.parametrize("feature_name,category", _FEATURE_SKILL_CATEGORY_PARAMS)
+    def test_allow_only_overrides_all_feature_registry_entries(
+        self, tmp_path: Path, feature_name: str, category: str
+    ) -> None:
+        from tests._helpers import make_test_config
+
+        provider = _make_synthetic_provider(
+            tmp_path / "skills",
+            {"test-skill": {"categories": [category]}},
+        )
+        root = tmp_path / "sessions"
+        root.mkdir()
+        mgr = DefaultSessionSkillManager(provider, ephemeral_root=root)
+        config = make_test_config(features={feature_name: False}, experimental_enabled=False)
+        session_path = mgr.init_session(
+            "s-feat-registry",
+            allow_only=frozenset({"test-skill"}),
+            config=config,
+        )
+
+        skills_base = session_path / ".claude" / "skills"
+        assert (skills_base / "test-skill" / "SKILL.md").exists(), (
+            f"test-skill (category={category!r}) must be written when allow_only explicitly "
+            f"requests it, even though feature {feature_name!r} is disabled"
+        )
+
+
+_CROSS_AXIS_PARAMS = [
+    # (allow_only, feature_enabled, subsets_disabled, cook_session, expected_target_written)
+    # allow_only=None cases
+    pytest.param(None, True, [], False, True, id="ao-none_feat-on_disabled-no_cook-no"),
+    pytest.param(None, True, ["planner"], False, False, id="ao-none_feat-on_disabled-yes_cook-no"),
+    pytest.param(None, False, [], False, False, id="ao-none_feat-off_disabled-no_cook-no"),
+    pytest.param(
+        None, False, ["planner"], False, False, id="ao-none_feat-off_disabled-yes_cook-no"
+    ),
+    pytest.param(None, True, [], True, True, id="ao-none_feat-on_disabled-no_cook-yes"),
+    pytest.param(None, True, ["planner"], True, True, id="ao-none_feat-on_disabled-yes_cook-yes"),
+    pytest.param(None, False, [], True, True, id="ao-none_feat-off_disabled-no_cook-yes"),
+    pytest.param(
+        None, False, ["planner"], True, True, id="ao-none_feat-off_disabled-yes_cook-yes"
+    ),
+    # allow_only=frozenset({"target","sibling"}) cases
+    pytest.param(
+        frozenset({"target", "sibling"}),
+        True,
+        [],
+        False,
+        True,
+        id="ao-set_feat-on_disabled-no_cook-no",
+    ),
+    pytest.param(
+        frozenset({"target", "sibling"}),
+        True,
+        ["planner"],
+        False,
+        False,
+        id="ao-set_feat-on_disabled-yes_cook-no",
+    ),
+    pytest.param(
+        frozenset({"target", "sibling"}),
+        False,
+        [],
+        False,
+        True,
+        id="ao-set_feat-off_disabled-no_cook-no",  # THE BUG CASE
+    ),
+    pytest.param(
+        frozenset({"target", "sibling"}),
+        False,
+        ["planner"],
+        False,
+        False,
+        id="ao-set_feat-off_disabled-yes_cook-no",
+    ),
+    pytest.param(
+        frozenset({"target", "sibling"}),
+        True,
+        [],
+        True,
+        True,
+        id="ao-set_feat-on_disabled-no_cook-yes",
+    ),
+    pytest.param(
+        frozenset({"target", "sibling"}),
+        True,
+        ["planner"],
+        True,
+        True,
+        id="ao-set_feat-on_disabled-yes_cook-yes",
+    ),
+    pytest.param(
+        frozenset({"target", "sibling"}),
+        False,
+        [],
+        True,
+        True,
+        id="ao-set_feat-off_disabled-no_cook-yes",
+    ),
+    pytest.param(
+        frozenset({"target", "sibling"}),
+        False,
+        ["planner"],
+        True,
+        True,
+        id="ao-set_feat-off_disabled-yes_cook-yes",
+    ),
+]
+
+
+class TestCrossAxisGatingMatrix:
+    """Cross-axis parametrized test matrix: allow_only × feature_gate × subsets.disabled × cook."""
+
+    @pytest.mark.parametrize(
+        "allow_only,feature_enabled,subsets_disabled,cook_session,expected_target_written",
+        _CROSS_AXIS_PARAMS,
+    )
+    def test_cross_axis_gating_matrix(
+        self,
+        tmp_path: Path,
+        allow_only: frozenset[str] | None,
+        feature_enabled: bool,
+        subsets_disabled: list[str],
+        cook_session: bool,
+        expected_target_written: bool,
+    ) -> None:
+        from tests._helpers import make_subsetsconfig, make_test_config
+
+        provider = _make_synthetic_provider(
+            tmp_path / "skills",
+            {"target": {"categories": ["planner"]}, "sibling": {}},
+        )
+        root = tmp_path / "sessions"
+        root.mkdir()
+        mgr = DefaultSessionSkillManager(provider, ephemeral_root=root)
+
+        features = {"planner": True} if feature_enabled else {}
+        config = make_test_config(
+            features=features,
+            experimental_enabled=False,
+            subsets=make_subsetsconfig(disabled=subsets_disabled),
+        )
+
+        session_path = mgr.init_session(
+            "s-matrix",
+            config=config,
+            allow_only=allow_only,
+            cook_session=cook_session,
+        )
+
+        skills_base = session_path / ".claude" / "skills"
+        target_written = (skills_base / "target").exists()
+        assert target_written == expected_target_written, (
+            f"target (category=planner) written={target_written!r}, "
+            f"expected={expected_target_written!r} for "
+            f"allow_only={allow_only!r}, feature_enabled={feature_enabled!r}, "
+            f"subsets_disabled={subsets_disabled!r}, cook_session={cook_session!r}"
+        )
 
 
 class TestComputeSkillClosure:

--- a/tests/workspace/test_session_skills_features.py
+++ b/tests/workspace/test_session_skills_features.py
@@ -133,3 +133,20 @@ def test_non_cook_session_still_suppresses_feature_gated_skills(tmp_path: Path) 
     assert "make-campaign" not in skill_names, (
         "Non-cook session with fleet=False must suppress make-campaign"
     )
+
+
+def test_feature_gate_suppresses_when_allow_only_is_none(tmp_path: Path) -> None:
+    """Feature gate still suppresses planner skills when allow_only=None."""
+    from tests._helpers import make_test_config
+
+    config = make_test_config(features={}, experimental_enabled=False)
+    provider = SkillsDirectoryProvider()
+    mgr = DefaultSessionSkillManager(provider, ephemeral_root=tmp_path)
+    session_path = mgr.init_session(
+        "feat-gate-allow-none", cook_session=False, config=config, allow_only=None
+    )
+    skill_names = {p.parent.name for p in session_path.glob(".claude/skills/*/SKILL.md")}
+    assert "planner-elaborate-phase" not in skill_names, (
+        "planner-elaborate-phase must be suppressed by the planner feature gate "
+        "when allow_only=None (no orchestrator-requested override)"
+    )


### PR DESCRIPTION
## Summary

The `init_session` method in `session_skills.py` has two independent, uncoordinated skill-gating mechanisms. When the orchestrator explicitly requests skills via `allow_only` (computed from `compute_skill_closure`), the feature gate in `_is_skill_disabled` can silently block every requested skill, producing an empty session directory with no error. This violates the **Policy Layering Principle**: explicit higher-priority requests must override implicit background policies. The pack system (`PACK_REGISTRY` + `_resolve_effective_disabled`) correctly implements this principle with a subtraction path (`packs_enabled ∪ recipe_packs`), but the feature gate system (`FEATURE_REGISTRY` + `_is_skill_disabled`) has no equivalent override channel.

The fix unifies the gating model by treating `allow_only` as a policy override for feature gates, adds a post-condition invariant that catches any future silent-empty-result, and adds cross-axis tests that would have caught this bug and will catch any future variant.

Closes #1641

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260502-192857-360284/.autoskillit/temp/rectify/rectify_feature_gate_allow_only_policy_layering_2026-05-02_192857.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| rectify | 65 | 12.7k | 1.1M | 65.1k | 1 | 7m 10s |
| dry_walkthrough | 51 | 10.3k | 1.5M | 64.5k | 1 | 5m 9s |
| implement | 252 | 30.3k | 2.0M | 76.7k | 1 | 8m 57s |
| prepare_pr | 60 | 4.9k | 235.1k | 31.8k | 1 | 1m 34s |
| compose_pr | 67 | 2.9k | 212.6k | 35.7k | 1 | 1m 6s |
| review_pr | 885 | 65.6k | 1.4M | 333.2k | 2 | 17m 28s |
| resolve_review | 658 | 35.3k | 4.1M | 329.6k | 2 | 17m 19s |
| **Total** | 2.0k | 161.9k | 10.5M | 936.6k | | 58m 46s |
## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 250 | 7891.2 | 306.7 | 121.1 |
| assess | 19 | 68157.3 | 3654.1 | 1021.2 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **269** | 23443.5 | 1276.0 | 299.0 |