### PR TITLE
Rectify: Canonical Install Detection and Registry Key Invariant Enforcement

### DIFF
--- a/src/autoskillit/cli/_install_info.py
+++ b/src/autoskillit/cli/_install_info.py
@@ -12,8 +12,7 @@ from datetime import timedelta
 from enum import StrEnum
 from pathlib import Path
 
-from autoskillit.core import get_logger, parse_direct_url
-from autoskillit.core._install_detect import _is_stable_track
+from autoskillit.core import _is_stable_track, get_logger, parse_direct_url
 
 logger = get_logger(__name__)
 

--- a/src/autoskillit/cli/_install_info.py
+++ b/src/autoskillit/cli/_install_info.py
@@ -12,7 +12,8 @@ from datetime import timedelta
 from enum import StrEnum
 from pathlib import Path
 
-from autoskillit.core import _is_stable_track, get_logger, parse_direct_url
+from autoskillit.core import get_logger, parse_direct_url
+from autoskillit.core._install_detect import _is_stable_track
 
 logger = get_logger(__name__)
 

--- a/src/autoskillit/cli/_install_info.py
+++ b/src/autoskillit/cli/_install_info.py
@@ -7,14 +7,12 @@ that drive the unified update check.
 
 from __future__ import annotations
 
-import json
-import re
 from dataclasses import dataclass
 from datetime import timedelta
 from enum import StrEnum
 from pathlib import Path
 
-from autoskillit.core import get_logger
+from autoskillit.core import _is_stable_track, get_logger, parse_direct_url
 
 logger = get_logger(__name__)
 
@@ -53,28 +51,17 @@ def detect_install() -> InstallInfo:
     """
     _unknown = InstallInfo(InstallType.UNKNOWN, None, None, None, None)
     try:
-        import importlib.metadata
-
-        dist = importlib.metadata.Distribution.from_name("autoskillit")
-        raw = dist.read_text("direct_url.json")
-        if not raw:
-            return _unknown
-
-        data = json.loads(raw)
-
-        vcs_info = data.get("vcs_info", {})
-        if isinstance(vcs_info, dict) and vcs_info.get("vcs") == "git":
+        info = parse_direct_url()
+        url = info["url"] or ""
+        if info["install_type"] == "git-vcs":
             return InstallInfo(
                 install_type=InstallType.GIT_VCS,
-                commit_id=vcs_info.get("commit_id") or None,
-                requested_revision=vcs_info.get("requested_revision") or None,
-                url=data.get("url") or None,
+                commit_id=info["commit_id"],
+                requested_revision=info["requested_revision"],
+                url=url or None,
                 editable_source=None,
             )
-
-        dir_info = data.get("dir_info", {})
-        url = data.get("url", "")
-        if isinstance(dir_info, dict) and dir_info.get("editable") is True:
+        if info["install_type"] == "local-editable":
             if isinstance(url, str) and url.startswith("file://"):
                 src_path = url[len("file://") :]
                 return InstallInfo(
@@ -84,30 +71,18 @@ def detect_install() -> InstallInfo:
                     url=url,
                     editable_source=Path(src_path),
                 )
-
-        if isinstance(url, str) and url.startswith("file://"):
+        if info["install_type"] == "local-path":
             return InstallInfo(
                 install_type=InstallType.LOCAL_PATH,
                 commit_id=None,
                 requested_revision=None,
-                url=url,
+                url=url or None,
                 editable_source=None,
             )
-
         return _unknown
-
     except Exception:
         logger.debug("install classification failed", exc_info=True)
         return _unknown
-
-
-def _is_release_tag(rev: str) -> bool:
-    """Return True if ``rev`` looks like a version tag (e.g. 'v0.7.75', '0.7.75')."""
-    return bool(re.fullmatch(r"v?\d+(\.\d+)*", rev))
-
-
-def _is_stable_track(rev: str | None) -> bool:
-    return not rev or rev in ("main", "stable") or _is_release_tag(rev)
 
 
 def classify_track(info: InstallInfo) -> InstallTrack:

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -166,6 +166,7 @@ class AutomationConfig:
                 raise ConfigSchemaError(
                     f"Feature key must be a string, got {type(name).__name__!r}: {name!r}"
                 )
+            name = name.lower()
             if name not in FEATURE_REGISTRY:
                 known = sorted(FEATURE_REGISTRY.keys())
                 raise ConfigSchemaError(

--- a/src/autoskillit/core/__init__.py
+++ b/src/autoskillit/core/__init__.py
@@ -13,8 +13,6 @@ del _dir  # replaced below so dir() reflects the filtered __all__
 _PRIVATE_REEXPORTS = frozenset(
     {
         "_InstallLock",
-        "_is_release_tag",
-        "_is_stable_track",
         "_retire_old_versions",
         "_collect_disabled_feature_tags",
         "_AUTOSKILLIT_GITIGNORE_ENTRIES",

--- a/src/autoskillit/core/__init__.py
+++ b/src/autoskillit/core/__init__.py
@@ -13,6 +13,8 @@ del _dir  # replaced below so dir() reflects the filtered __all__
 _PRIVATE_REEXPORTS = frozenset(
     {
         "_InstallLock",
+        "_is_release_tag",
+        "_is_stable_track",
         "_retire_old_versions",
         "_collect_disabled_feature_tags",
         "_AUTOSKILLIT_GITIGNORE_ENTRIES",

--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -1,5 +1,8 @@
 from ._claude_env import build_claude_env as build_claude_env
+from ._install_detect import _is_release_tag as _is_release_tag
+from ._install_detect import _is_stable_track as _is_stable_track
 from ._install_detect import is_dev_install as is_dev_install
+from ._install_detect import parse_direct_url as parse_direct_url
 from ._linux_proc import read_boot_id as read_boot_id
 from ._linux_proc import read_starttime_ticks as read_starttime_ticks
 from ._plugin_cache import _InstallLock as _InstallLock

--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -1,6 +1,5 @@
 from ._claude_env import build_claude_env as build_claude_env
-from ._install_detect import _is_release_tag as _is_release_tag
-from ._install_detect import _is_stable_track as _is_stable_track
+from ._install_detect import DirectUrlInfo as DirectUrlInfo
 from ._install_detect import is_dev_install as is_dev_install
 from ._install_detect import parse_direct_url as parse_direct_url
 from ._linux_proc import read_boot_id as read_boot_id

--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -1,5 +1,7 @@
 from ._claude_env import build_claude_env as build_claude_env
 from ._install_detect import DirectUrlInfo as DirectUrlInfo
+from ._install_detect import _is_release_tag as _is_release_tag
+from ._install_detect import _is_stable_track as _is_stable_track
 from ._install_detect import is_dev_install as is_dev_install
 from ._install_detect import parse_direct_url as parse_direct_url
 from ._linux_proc import read_boot_id as read_boot_id

--- a/src/autoskillit/core/_install_detect.py
+++ b/src/autoskillit/core/_install_detect.py
@@ -47,7 +47,8 @@ def parse_direct_url() -> DirectUrlInfo:
                 "url": "",
             }
         data = json.loads(raw)
-        url = data.get("url", "") or ""
+        raw_url = data.get("url")
+        url = raw_url if isinstance(raw_url, str) else ""
         vcs_info = data.get("vcs_info", {})
         if isinstance(vcs_info, dict) and vcs_info.get("vcs") == "git":
             return {

--- a/src/autoskillit/core/_install_detect.py
+++ b/src/autoskillit/core/_install_detect.py
@@ -5,9 +5,17 @@ from __future__ import annotations
 import json
 import logging
 import re
-from typing import Any
+from typing import TypedDict
 
 logger = logging.getLogger(__name__)  # noqa: TID251 — IL-0 module, no autoskillit imports allowed
+
+
+class DirectUrlInfo(TypedDict):
+    install_type: str
+    requested_revision: str | None
+    commit_id: str | None
+    editable: bool
+    url: str
 
 
 def _is_release_tag(rev: str) -> bool:
@@ -19,7 +27,7 @@ def _is_stable_track(rev: str | None) -> bool:
     return not rev or rev in ("main", "stable") or _is_release_tag(rev)
 
 
-def parse_direct_url() -> dict[str, Any]:
+def parse_direct_url() -> DirectUrlInfo:
     """Parse direct_url.json and return a canonical install descriptor.
 
     Keys: install_type (str), requested_revision (str|None),

--- a/src/autoskillit/core/_install_detect.py
+++ b/src/autoskillit/core/_install_detect.py
@@ -4,22 +4,93 @@ from __future__ import annotations
 
 import json
 import logging
+import re
+from typing import Any
 
 logger = logging.getLogger(__name__)  # noqa: TID251 — IL-0 module, no autoskillit imports allowed
 
 
-def is_dev_install() -> bool:
-    """Return True if installed in editable mode; False on any error."""
+def _is_release_tag(rev: str) -> bool:
+    """Return True if rev looks like a version tag (e.g. 'v0.7.75', '0.7.75')."""
+    return bool(re.fullmatch(r"v?\d+(\.\d+)*", rev))
+
+
+def _is_stable_track(rev: str | None) -> bool:
+    return not rev or rev in ("main", "stable") or _is_release_tag(rev)
+
+
+def parse_direct_url() -> dict[str, Any]:
+    """Parse direct_url.json and return a canonical install descriptor.
+
+    Keys: install_type (str), requested_revision (str|None),
+          commit_id (str|None), editable (bool), url (str).
+    """
     try:
         import importlib.metadata
 
         dist = importlib.metadata.Distribution.from_name("autoskillit")
         raw = dist.read_text("direct_url.json")
         if not raw:
-            return False
+            return {
+                "install_type": "unknown",
+                "requested_revision": None,
+                "commit_id": None,
+                "editable": False,
+                "url": "",
+            }
         data = json.loads(raw)
+        url = data.get("url", "") or ""
+        vcs_info = data.get("vcs_info", {})
+        if isinstance(vcs_info, dict) and vcs_info.get("vcs") == "git":
+            return {
+                "install_type": "git-vcs",
+                "requested_revision": vcs_info.get("requested_revision") or None,
+                "commit_id": vcs_info.get("commit_id") or None,
+                "editable": False,
+                "url": url,
+            }
         dir_info = data.get("dir_info", {})
         if isinstance(dir_info, dict) and dir_info.get("editable") is True:
+            return {
+                "install_type": "local-editable",
+                "requested_revision": None,
+                "commit_id": None,
+                "editable": True,
+                "url": url,
+            }
+        if isinstance(url, str) and url.startswith("file://"):
+            return {
+                "install_type": "local-path",
+                "requested_revision": None,
+                "commit_id": None,
+                "editable": False,
+                "url": url,
+            }
+        return {
+            "install_type": "unknown",
+            "requested_revision": None,
+            "commit_id": None,
+            "editable": False,
+            "url": url,
+        }
+    except Exception:
+        logger.debug("direct_url.json parsing failed", exc_info=True)
+        return {
+            "install_type": "unknown",
+            "requested_revision": None,
+            "commit_id": None,
+            "editable": False,
+            "url": "",
+        }
+
+
+def is_dev_install() -> bool:
+    """Return True if a development install (editable or dev-track VCS); False on any error."""
+    try:
+        info = parse_direct_url()
+        if info["editable"]:
+            return True
+        if info["install_type"] == "git-vcs" and not _is_stable_track(info["requested_revision"]):
             return True
         return False
     except Exception:

--- a/src/autoskillit/core/_type_constants.py
+++ b/src/autoskillit/core/_type_constants.py
@@ -291,6 +291,17 @@ RECIPE_PACK_TAGS: frozenset[str] = frozenset(RECIPE_PACK_REGISTRY.keys())
 
 CORE_PACKS: frozenset[str] = frozenset({"github", "ci", "clone", "telemetry"})
 
+if any(k != k.lower() for k in PACK_REGISTRY):
+    raise AssertionError(
+        "PACK_REGISTRY keys must be lowercase. "
+        f"Offending: {sorted(k for k in PACK_REGISTRY if k != k.lower())}"
+    )
+if any(k != k.lower() for k in RECIPE_PACK_REGISTRY):
+    raise AssertionError(
+        "RECIPE_PACK_REGISTRY keys must be lowercase. "
+        f"Offending: {sorted(k for k in RECIPE_PACK_REGISTRY if k != k.lower())}"
+    )
+
 # Maps each MCP tool name to its functional category subset tags.
 # Mirrors the FastMCP @mcp.tool(tags=...) category assignments in the server layer.
 # Tools with no functional category are absent from this map (empty intersection = no finding).
@@ -410,6 +421,17 @@ FEATURE_REGISTRY: dict[str, FeatureDef] = {
 }
 
 RETIRED_FEATURES: frozenset[str] = frozenset()
+
+if any(k != k.lower() for k in FEATURE_REGISTRY):
+    raise AssertionError(
+        "FEATURE_REGISTRY keys must be lowercase. "
+        f"Offending: {sorted(k for k in FEATURE_REGISTRY if k != k.lower())}"
+    )
+if any(k != k.lower() for k in RETIRED_FEATURES):
+    raise AssertionError(
+        "RETIRED_FEATURES entries must be lowercase. "
+        f"Offending: {sorted(k for k in RETIRED_FEATURES if k != k.lower())}"
+    )
 
 # Guard: FeatureDef.tool_tags must be in TOOL_SUBSET_TAGS — checked at import time.
 _ALL_REGISTERED_TOOL_TAGS: frozenset[str] = frozenset(

--- a/src/autoskillit/core/_version_snapshot.py
+++ b/src/autoskillit/core/_version_snapshot.py
@@ -18,7 +18,7 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
-from autoskillit.core._install_detect import parse_direct_url  # noqa: TID251
+from ._install_detect import parse_direct_url
 
 logger = logging.getLogger(__name__)  # noqa: TID251 — IL-0 module, no autoskillit imports allowed
 

--- a/src/autoskillit/core/_version_snapshot.py
+++ b/src/autoskillit/core/_version_snapshot.py
@@ -18,6 +18,8 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
+from autoskillit.core._install_detect import parse_direct_url  # noqa: TID251
+
 logger = logging.getLogger(__name__)  # noqa: TID251 — IL-0 module, no autoskillit imports allowed
 
 
@@ -52,29 +54,9 @@ def _autoskillit_version() -> str:
 
 
 def _install_info() -> dict[str, Any]:
-    """Parse direct_url.json to classify the autoskillit install."""
-    try:
-        dist = importlib.metadata.Distribution.from_name("autoskillit")
-        raw = dist.read_text("direct_url.json")
-        if not raw:
-            return {"install_type": "unknown", "commit_id": None}
-        data = json.loads(raw)
-        vcs = data.get("vcs_info", {})
-        if isinstance(vcs, dict) and vcs.get("vcs") == "git":
-            return {
-                "install_type": "git-vcs",
-                "commit_id": vcs.get("commit_id") or None,
-            }
-        dir_info = data.get("dir_info", {})
-        url = data.get("url", "")
-        if isinstance(dir_info, dict) and dir_info.get("editable") is True:
-            return {"install_type": "local-editable", "commit_id": None}
-        if isinstance(url, str) and url.startswith("file://"):
-            return {"install_type": "local-path", "commit_id": None}
-        return {"install_type": "unknown", "commit_id": None}
-    except Exception:
-        logger.warning("Failed to parse install info from direct_url.json", exc_info=True)
-        return {"install_type": "unknown", "commit_id": None}
+    """Classify the autoskillit install type and commit hash."""
+    info = parse_direct_url()
+    return {"install_type": info["install_type"], "commit_id": info["commit_id"]}
 
 
 def _claude_code_version() -> str:

--- a/tests/arch/test_feature_registry.py
+++ b/tests/arch/test_feature_registry.py
@@ -202,6 +202,26 @@ def test_config_rejects_unknown_feature():
         AutomationConfig._build_features_dict({unknown: True})
 
 
+def test_build_features_dict_uppercase_key_normalizes():
+    """_build_features_dict normalizes dynaconf-uppercased keys to lowercase."""
+    from autoskillit.config.settings import AutomationConfig
+
+    result, _ = AutomationConfig._build_features_dict({"FLEET": True})
+    assert result == {"fleet": True}
+
+
+def test_env_var_fleet_uppercase_loads_without_crash(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """AUTOSKILLIT_FEATURES__FLEET=true is accepted and loaded correctly."""
+    from autoskillit.config.settings import load_config
+
+    monkeypatch.setattr("autoskillit.config.settings.is_dev_install", lambda: False)
+    monkeypatch.setenv("AUTOSKILLIT_FEATURES__FLEET", "true")
+    cfg = load_config(tmp_path)
+    assert cfg.features.get("fleet") is True
+
+
 def test_config_dependency_validation(monkeypatch):
     """_build_features_dict raises ConfigSchemaError when B is enabled but dep A is disabled."""
 

--- a/tests/arch/test_registry.py
+++ b/tests/arch/test_registry.py
@@ -1,39 +1,369 @@
-"""Architectural invariant tests for registry key casing."""
+"""Symbolic rule registry tests.
+
+Tests the RuleDescriptor dataclass, RULES tuple, and Violation NamedTuple
+that form the symbolic registry of architecture enforcement rules.
+"""
 
 from __future__ import annotations
 
+import ast
+import importlib
+import inspect
+import re
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+
 import pytest
 
-pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+from tests.arch._helpers import _scan
+from tests.arch._rules import (
+    _ASYNCIO_PIPE_EXEMPT,
+    _BROAD_EXCEPT_EXEMPT,
+    _PRINT_EXEMPT,
+    RULES,
+    RuleDescriptor,
+    Violation,
+)
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
 
 
-def test_feature_registry_keys_are_lowercase():
-    """All FEATURE_REGISTRY keys must be lowercase."""
-    from autoskillit.core._type_constants import FEATURE_REGISTRY
+def test_rule_descriptor_is_frozen_dataclass() -> None:
+    """REQ-SYMB-001: RuleDescriptor is a frozen dataclass with all required fields."""
+    rd = RuleDescriptor(
+        rule_id="ARCH-TEST",
+        name="test-rule",
+        lens="operational",
+        description="A test rule.",
+        rationale="Test rationale.",
+        exemptions=frozenset(),
+        severity="error",
+        defense_standard=None,
+        adr_ref=None,
+    )
+    assert rd.rule_id == "ARCH-TEST"
+    assert rd.name == "test-rule"
+    assert rd.lens == "operational"
+    assert rd.exemptions == frozenset()
+    assert rd.severity == "error"
+    assert rd.defense_standard is None
+    assert rd.adr_ref is None
+    # Verify frozen (immutable)
+    with pytest.raises((FrozenInstanceError, AttributeError)):
+        rd.rule_id = "MODIFIED"  # type: ignore[misc]
 
-    offending = sorted(k for k in FEATURE_REGISTRY if k != k.lower())
-    assert not offending, f"FEATURE_REGISTRY has non-lowercase keys: {offending}"
+
+def test_rule_registry_completeness() -> None:
+    """REQ-SYMB-006: RULES is complete, non-duplicated, and lens-valid."""
+    _KNOWN_LENSES = frozenset(
+        {
+            "c4-container",
+            "module-dependency",
+            "process-flow",
+            "concurrency",
+            "state-lifecycle",
+            "error-resilience",
+            "security",
+            "repository-access",
+            "data-lineage",
+            "scenarios",
+            "deployment",
+            "operational",
+            "development",
+        }
+    )
+    # (a) all rule_id values are unique
+    rule_ids = [r.rule_id for r in RULES]
+    assert len(rule_ids) == len(set(rule_ids)), f"Duplicate rule_ids: {rule_ids}"
+
+    # (b) all lens values are from the 13-lens vocabulary
+    for r in RULES:
+        assert r.lens in _KNOWN_LENSES, (
+            f"Rule {r.rule_id} has unknown lens {r.lens!r}. Known: {sorted(_KNOWN_LENSES)}"
+        )
+
+    # (c) exact set of IDs must match the visitor's rule set
+    # Add a RuleDescriptor for every new visitor rule and update this set.
+    expected_ids = frozenset(
+        {
+            "ARCH-001",
+            "ARCH-002",
+            "ARCH-003",
+            "ARCH-004",
+            "ARCH-005",
+            "ARCH-006",
+            "ARCH-007",
+            "ARCH-008",
+            "ARCH-009",
+        }
+    )
+    actual_ids = frozenset(rule_ids)
+    assert actual_ids == expected_ids, (
+        f"RULES ID mismatch. Missing: {expected_ids - actual_ids}. "
+        f"Extra: {actual_ids - expected_ids}"
+    )
 
 
-def test_retired_features_entries_are_lowercase():
-    """All RETIRED_FEATURES entries must be lowercase."""
-    from autoskillit.core._type_constants import RETIRED_FEATURES
+def test_all_rules_have_defense_standard() -> None:
+    """Every entry in RULES, LAYER_RULES, and ISOLATION_RULES must declare
+    a defense_standard.
 
-    offending = sorted(k for k in RETIRED_FEATURES if k != k.lower())
-    assert not offending, f"RETIRED_FEATURES has non-lowercase entries: {offending}"
+    Prevents future rule additions from silently omitting the defense_standard
+    field, which would break audit-defense-standards traceability.
+    """
+    import tests.arch.test_layer_enforcement as le_mod
+    import tests.arch.test_subpackage_isolation as si_mod
+
+    all_rules: list[RuleDescriptor] = list(RULES)
+    all_rules.extend(le_mod.LAYER_RULES.values())
+    all_rules.extend(si_mod.ISOLATION_RULES.values())
+
+    missing = [r.rule_id for r in all_rules if r.defense_standard is None]
+    assert not missing, (
+        f"Rule entries missing defense_standard: {missing}. "
+        "Every architectural rule must trace to a defense standard."
+    )
 
 
-def test_pack_registry_keys_are_lowercase():
-    """All PACK_REGISTRY keys must be lowercase."""
-    from autoskillit.core._type_constants import PACK_REGISTRY
+def test_violation_has_rule_id_and_lens_fields() -> None:
+    """REQ-SYMB-003: Violation gains rule_id and lens while preserving 4 original fields."""
+    v = Violation(
+        file=Path("x.py"),
+        line=1,
+        col=0,
+        message="msg",
+        rule_id="ARCH-001",
+        lens="operational",
+    )
+    assert v.rule_id == "ARCH-001"
+    assert v.lens == "operational"
+    # Original 4 fields preserved
+    assert v.file == Path("x.py")
+    assert v.line == 1
+    assert v.col == 0
+    assert v.message == "msg"
 
-    offending = sorted(k for k in PACK_REGISTRY if k != k.lower())
-    assert not offending, f"PACK_REGISTRY has non-lowercase keys: {offending}"
+
+def test_violation_rule_id_lens_default_to_empty(tmp_path: Path) -> None:
+    """Violation with only 4 args has rule_id='' and lens='' (backward-compatible construction)."""
+    v = Violation(file=tmp_path / "x.py", line=1, col=0, message="SyntaxError: bad")
+    assert v.rule_id == ""
+    assert v.lens == ""
 
 
-def test_recipe_pack_registry_keys_are_lowercase():
-    """All RECIPE_PACK_REGISTRY keys must be lowercase."""
-    from autoskillit.core._type_constants import RECIPE_PACK_REGISTRY
+def test_add_populates_rule_id_and_lens(tmp_path: Path) -> None:
+    """REQ-SYMB-004: _add() creates Violations with rule_id and lens from the RuleDescriptor."""
+    f = tmp_path / "bad.py"
+    f.write_text("print('hello')\n")
+    violations = _scan(f)
+    print_violations = [v for v in violations if "print" in v.message]
+    assert print_violations, "Expected a print() violation"
+    v = print_violations[0]
+    assert v.rule_id == "ARCH-001"
+    assert v.lens == "operational"
 
-    offending = sorted(k for k in RECIPE_PACK_REGISTRY if k != k.lower())
-    assert not offending, f"RECIPE_PACK_REGISTRY has non-lowercase keys: {offending}"
+
+def test_violation_str_includes_rule_and_lens_prefix(tmp_path: Path) -> None:
+    """REQ-SYMB-005: str(Violation) includes [ARCH-XXX / lens] as the leading element."""
+    f = tmp_path / "bad.py"
+    f.write_text("print('hello')\n")
+    violations = _scan(f)
+    print_violations = [v for v in violations if "print" in v.message]
+    assert print_violations
+    s = str(print_violations[0])
+    assert s.startswith("[ARCH-001 / operational"), (
+        f"Expected '[ARCH-001 / operational...' prefix, got: {s!r}"
+    )
+
+
+def test_violation_str_includes_defense_standard_when_present(tmp_path: Path) -> None:
+    """REQ-SYMB-005: defense_standard appears in str(Violation) when the rule has one."""
+    f = tmp_path / "bad.py"
+    f.write_text("print('hello')\n")
+    violations = _scan(f)
+    print_violations = [v for v in violations if "print" in v.message]
+    assert print_violations
+    s = str(print_violations[0])
+    # ARCH-001 has defense_standard="DS-003"
+    assert "DS-003" in s, f"Expected 'DS-003' in violation string, got: {s!r}"
+
+
+def test_violation_str_omits_defense_standard_when_absent() -> None:
+    """REQ-SYMB-005: defense_standard is absent from str(Violation) when rule has none."""
+    f = Path("bad.py")
+    v = Violation(
+        file=f,
+        line=1,
+        col=0,
+        message="asyncio.PIPE used directly",
+        rule_id="ARCH-UNKNOWN",
+        lens="process-flow",
+    )
+    s = str(v)
+    assert "[ARCH-UNKNOWN / process-flow]" in s, (
+        f"Expected '[ARCH-UNKNOWN / process-flow]' prefix, got: {s!r}"
+    )
+    assert "DS-" not in s, f"Unexpected defense_standard in output: {s!r}"
+
+
+def test_arch004_violation_str_includes_ds002(tmp_path: Path) -> None:
+    """Regression guard: ARCH-004 violation str must include DS-002 after the fix."""
+    f = tmp_path / "bad.py"
+    f.write_text("import asyncio\nval = asyncio.PIPE\n")
+    violations = _scan(f)
+    pipe_violations = [v for v in violations if "asyncio.PIPE" in v.message]
+    assert pipe_violations
+    s = str(pipe_violations[0])
+    assert "DS-002" in s
+    assert "[ARCH-004 / process-flow / DS-002]" in s
+
+
+def test_violation_str_no_prefix_without_rule_id() -> None:
+    """Violation with empty rule_id uses the legacy str format (no prefix)."""
+    v = Violation(file=Path("src/x.py"), line=5, col=0, message="some issue", rule_id="", lens="")
+    s = str(v)
+    assert not s.startswith("["), f"Expected no prefix for rule_id='', got: {s!r}"
+    assert "some issue" in s
+
+
+# ── P13-7: Shared canonical source verification ───────────────────────────────
+
+
+def test_ast_rules_and_registry_share_rules_object() -> None:
+    """P13-7: test_ast_rules and test_registry import RULES from same _rules module."""
+    import tests.arch._rules as shared
+    import tests.arch.test_registry as reg_mod
+
+    assert reg_mod.RULES is shared.RULES, "test_registry.RULES must be the shared _rules.RULES"
+
+
+# ── P13-1: ARCH-001 exemptions sync ──────────────────────────────────────────
+
+
+def test_arch001_exemptions_match_print_exempt_set() -> None:
+    """P13-1: ARCH-001 RuleDescriptor.exemptions must cover all _PRINT_EXEMPT files."""
+    arch001 = next(r for r in RULES if r.rule_id == "ARCH-001")
+    assert arch001.exemptions == _PRINT_EXEMPT
+
+
+# ── P13-2: ARCH-003 exemptions sync ──────────────────────────────────────────
+
+
+def test_arch003_exemptions_match_broad_except_set() -> None:
+    """P13-2: ARCH-003 RuleDescriptor.exemptions must cover all _BROAD_EXCEPT_EXEMPT files."""
+    arch003 = next(r for r in RULES if r.rule_id == "ARCH-003")
+    assert arch003.exemptions == _BROAD_EXCEPT_EXEMPT
+
+
+# ── P13-9: ARCH-004 exemptions sync ──────────────────────────────────────────
+
+
+def test_arch004_exemptions_match_asyncio_pipe_exempt_set() -> None:
+    """P13-9: ARCH-004 RuleDescriptor.exemptions must equal _ASYNCIO_PIPE_EXEMPT.
+
+    If execution/process.py is renamed or the ARCH-004 exemption set drifts,
+    this test catches the staleness before the AST visitor silently skips
+    the new filename.
+    """
+    arch004 = next(r for r in RULES if r.rule_id == "ARCH-004")
+    assert arch004.exemptions == _ASYNCIO_PIPE_EXEMPT
+
+
+# ── P13-5: REQ-ARCH-001/002/003 descriptors exist ────────────────────────────
+
+
+def test_req_arch_rules_have_descriptors() -> None:
+    """P13-5: REQ-ARCH rules must have RuleDescriptor constants in their test files."""
+    import tests.arch.test_layer_enforcement as le_mod
+    import tests.arch.test_subpackage_isolation as si_mod
+
+    assert hasattr(le_mod, "LAYER_RULES"), "test_layer_enforcement must export LAYER_RULES"
+    assert hasattr(si_mod, "ISOLATION_RULES"), (
+        "test_subpackage_isolation must export ISOLATION_RULES"
+    )
+    layer_ids = {r.rule_id for r in le_mod.LAYER_RULES.values()}
+    isolation_ids = {r.rule_id for r in si_mod.ISOLATION_RULES.values()}
+    assert "REQ-ARCH-001" in layer_ids
+    assert "REQ-ARCH-003" in layer_ids
+    assert "REQ-ARCH-002" in isolation_ids
+    assert "REQ-LAYER-001" in layer_ids
+    assert "REQ-LAYER-002" in layer_ids
+
+
+def test_monkeypatch_targets_do_not_bypass_package_reexports() -> None:
+    """Every monkeypatch.setattr path must target the namespace production code resolves.
+
+    When autoskillit.X re-exports 'name' from autoskillit.X.submodule via __init__.py,
+    patching autoskillit.X.submodule.name does NOT affect autoskillit.X.name.
+    All patches of the form autoskillit.X.submodule.name, where X is a sub-package
+    that re-exports 'name' FROM that exact submodule, are wrong and must be corrected.
+
+    Note: patching autoskillit.X.B.name where X imports 'name' from a DIFFERENT submodule
+    (not B) is correct -- it targets the local binding in B, which is the namespace that
+    module B's own functions resolve.
+    """
+    # Match string literals in monkeypatch.setattr("autoskillit.A.B.C", ...)
+    # where A is a sub-package, B is a submodule, C is the name.
+    pattern = re.compile(
+        r'monkeypatch\.setattr\s*\(\s*["\']'
+        r"(autoskillit\.\w+\.\w+\.\w+)"
+        r'["\']'
+    )
+
+    violations: list[str] = []
+    tests_dir = Path(__file__).parent.parent
+
+    for test_file in sorted(tests_dir.glob("**/test_*.py")):
+        source = test_file.read_text()
+        for match in pattern.finditer(source):
+            full_path = match.group(1)
+            # Split: autoskillit . pkg . submodule . name
+            parts = full_path.split(".")
+            if len(parts) != 4:
+                continue
+            _, pkg, submod, name = parts
+            parent_pkg = f"autoskillit.{pkg}"
+            try:
+                parent_mod = importlib.import_module(parent_pkg)
+            except ImportError:
+                continue
+            if not hasattr(parent_mod, name):
+                continue
+            # Refine: only flag if the parent pkg actually imports 'name' FROM this
+            # exact submodule. If it imports 'name' from a different module (e.g.
+            # autoskillit.migration imports applicable_migrations from .loader, not
+            # .engine), then the patch targets a local binding in 'submod' -- which
+            # is the correct mock target for module-level imports in that submodule.
+            try:
+                parent_source = inspect.getsource(parent_mod)
+                tree = ast.parse(parent_source)
+            except (OSError, TypeError, SyntaxError):
+                # Can't inspect source -- conservatively flag as violation.
+                imports_from_this_submod = True
+            else:
+                imports_from_this_submod = False
+                for node in ast.walk(tree):
+                    if not isinstance(node, ast.ImportFrom):
+                        continue
+                    is_relative_from_submod = node.level == 1 and node.module == submod
+                    is_absolute_from_submod = (
+                        node.level == 0 and node.module == f"autoskillit.{pkg}.{submod}"
+                    )
+                    if is_relative_from_submod or is_absolute_from_submod:
+                        for alias in node.names:
+                            if (alias.asname or alias.name) == name:
+                                imports_from_this_submod = True
+                                break
+                    if imports_from_this_submod:
+                        break
+            if imports_from_this_submod:
+                line_no = source[: match.start()].count("\n") + 1
+                violations.append(
+                    f"{test_file.name}:{line_no}: patches {full_path!r} "
+                    f"but '{name}' is re-exported at '{parent_pkg}.{name}'. "
+                    f"Patch '{parent_pkg}.{name}' instead."
+                )
+
+    assert not violations, "Monkeypatch paths bypass package re-exports:\n" + "\n".join(
+        f"  {v}" for v in violations
+    )

--- a/tests/arch/test_registry.py
+++ b/tests/arch/test_registry.py
@@ -1,369 +1,39 @@
-"""Symbolic rule registry tests.
-
-Tests the RuleDescriptor dataclass, RULES tuple, and Violation NamedTuple
-that form the symbolic registry of architecture enforcement rules.
-"""
+"""Architectural invariant tests for registry key casing."""
 
 from __future__ import annotations
 
-import ast
-import importlib
-import inspect
-import re
-from dataclasses import FrozenInstanceError
-from pathlib import Path
-
 import pytest
 
-from tests.arch._helpers import _scan
-from tests.arch._rules import (
-    _ASYNCIO_PIPE_EXEMPT,
-    _BROAD_EXCEPT_EXEMPT,
-    _PRINT_EXEMPT,
-    RULES,
-    RuleDescriptor,
-    Violation,
-)
-
-# ── Tests ─────────────────────────────────────────────────────────────────────
+pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
 
 
-def test_rule_descriptor_is_frozen_dataclass() -> None:
-    """REQ-SYMB-001: RuleDescriptor is a frozen dataclass with all required fields."""
-    rd = RuleDescriptor(
-        rule_id="ARCH-TEST",
-        name="test-rule",
-        lens="operational",
-        description="A test rule.",
-        rationale="Test rationale.",
-        exemptions=frozenset(),
-        severity="error",
-        defense_standard=None,
-        adr_ref=None,
-    )
-    assert rd.rule_id == "ARCH-TEST"
-    assert rd.name == "test-rule"
-    assert rd.lens == "operational"
-    assert rd.exemptions == frozenset()
-    assert rd.severity == "error"
-    assert rd.defense_standard is None
-    assert rd.adr_ref is None
-    # Verify frozen (immutable)
-    with pytest.raises((FrozenInstanceError, AttributeError)):
-        rd.rule_id = "MODIFIED"  # type: ignore[misc]
+def test_feature_registry_keys_are_lowercase():
+    """All FEATURE_REGISTRY keys must be lowercase."""
+    from autoskillit.core._type_constants import FEATURE_REGISTRY
+
+    offending = sorted(k for k in FEATURE_REGISTRY if k != k.lower())
+    assert not offending, f"FEATURE_REGISTRY has non-lowercase keys: {offending}"
 
 
-def test_rule_registry_completeness() -> None:
-    """REQ-SYMB-006: RULES is complete, non-duplicated, and lens-valid."""
-    _KNOWN_LENSES = frozenset(
-        {
-            "c4-container",
-            "module-dependency",
-            "process-flow",
-            "concurrency",
-            "state-lifecycle",
-            "error-resilience",
-            "security",
-            "repository-access",
-            "data-lineage",
-            "scenarios",
-            "deployment",
-            "operational",
-            "development",
-        }
-    )
-    # (a) all rule_id values are unique
-    rule_ids = [r.rule_id for r in RULES]
-    assert len(rule_ids) == len(set(rule_ids)), f"Duplicate rule_ids: {rule_ids}"
+def test_retired_features_entries_are_lowercase():
+    """All RETIRED_FEATURES entries must be lowercase."""
+    from autoskillit.core._type_constants import RETIRED_FEATURES
 
-    # (b) all lens values are from the 13-lens vocabulary
-    for r in RULES:
-        assert r.lens in _KNOWN_LENSES, (
-            f"Rule {r.rule_id} has unknown lens {r.lens!r}. Known: {sorted(_KNOWN_LENSES)}"
-        )
-
-    # (c) exact set of IDs must match the visitor's rule set
-    # Add a RuleDescriptor for every new visitor rule and update this set.
-    expected_ids = frozenset(
-        {
-            "ARCH-001",
-            "ARCH-002",
-            "ARCH-003",
-            "ARCH-004",
-            "ARCH-005",
-            "ARCH-006",
-            "ARCH-007",
-            "ARCH-008",
-            "ARCH-009",
-        }
-    )
-    actual_ids = frozenset(rule_ids)
-    assert actual_ids == expected_ids, (
-        f"RULES ID mismatch. Missing: {expected_ids - actual_ids}. "
-        f"Extra: {actual_ids - expected_ids}"
-    )
+    offending = sorted(k for k in RETIRED_FEATURES if k != k.lower())
+    assert not offending, f"RETIRED_FEATURES has non-lowercase entries: {offending}"
 
 
-def test_all_rules_have_defense_standard() -> None:
-    """Every entry in RULES, LAYER_RULES, and ISOLATION_RULES must declare
-    a defense_standard.
+def test_pack_registry_keys_are_lowercase():
+    """All PACK_REGISTRY keys must be lowercase."""
+    from autoskillit.core._type_constants import PACK_REGISTRY
 
-    Prevents future rule additions from silently omitting the defense_standard
-    field, which would break audit-defense-standards traceability.
-    """
-    import tests.arch.test_layer_enforcement as le_mod
-    import tests.arch.test_subpackage_isolation as si_mod
-
-    all_rules: list[RuleDescriptor] = list(RULES)
-    all_rules.extend(le_mod.LAYER_RULES.values())
-    all_rules.extend(si_mod.ISOLATION_RULES.values())
-
-    missing = [r.rule_id for r in all_rules if r.defense_standard is None]
-    assert not missing, (
-        f"Rule entries missing defense_standard: {missing}. "
-        "Every architectural rule must trace to a defense standard."
-    )
+    offending = sorted(k for k in PACK_REGISTRY if k != k.lower())
+    assert not offending, f"PACK_REGISTRY has non-lowercase keys: {offending}"
 
 
-def test_violation_has_rule_id_and_lens_fields() -> None:
-    """REQ-SYMB-003: Violation gains rule_id and lens while preserving 4 original fields."""
-    v = Violation(
-        file=Path("x.py"),
-        line=1,
-        col=0,
-        message="msg",
-        rule_id="ARCH-001",
-        lens="operational",
-    )
-    assert v.rule_id == "ARCH-001"
-    assert v.lens == "operational"
-    # Original 4 fields preserved
-    assert v.file == Path("x.py")
-    assert v.line == 1
-    assert v.col == 0
-    assert v.message == "msg"
+def test_recipe_pack_registry_keys_are_lowercase():
+    """All RECIPE_PACK_REGISTRY keys must be lowercase."""
+    from autoskillit.core._type_constants import RECIPE_PACK_REGISTRY
 
-
-def test_violation_rule_id_lens_default_to_empty(tmp_path: Path) -> None:
-    """Violation with only 4 args has rule_id='' and lens='' (backward-compatible construction)."""
-    v = Violation(file=tmp_path / "x.py", line=1, col=0, message="SyntaxError: bad")
-    assert v.rule_id == ""
-    assert v.lens == ""
-
-
-def test_add_populates_rule_id_and_lens(tmp_path: Path) -> None:
-    """REQ-SYMB-004: _add() creates Violations with rule_id and lens from the RuleDescriptor."""
-    f = tmp_path / "bad.py"
-    f.write_text("print('hello')\n")
-    violations = _scan(f)
-    print_violations = [v for v in violations if "print" in v.message]
-    assert print_violations, "Expected a print() violation"
-    v = print_violations[0]
-    assert v.rule_id == "ARCH-001"
-    assert v.lens == "operational"
-
-
-def test_violation_str_includes_rule_and_lens_prefix(tmp_path: Path) -> None:
-    """REQ-SYMB-005: str(Violation) includes [ARCH-XXX / lens] as the leading element."""
-    f = tmp_path / "bad.py"
-    f.write_text("print('hello')\n")
-    violations = _scan(f)
-    print_violations = [v for v in violations if "print" in v.message]
-    assert print_violations
-    s = str(print_violations[0])
-    assert s.startswith("[ARCH-001 / operational"), (
-        f"Expected '[ARCH-001 / operational...' prefix, got: {s!r}"
-    )
-
-
-def test_violation_str_includes_defense_standard_when_present(tmp_path: Path) -> None:
-    """REQ-SYMB-005: defense_standard appears in str(Violation) when the rule has one."""
-    f = tmp_path / "bad.py"
-    f.write_text("print('hello')\n")
-    violations = _scan(f)
-    print_violations = [v for v in violations if "print" in v.message]
-    assert print_violations
-    s = str(print_violations[0])
-    # ARCH-001 has defense_standard="DS-003"
-    assert "DS-003" in s, f"Expected 'DS-003' in violation string, got: {s!r}"
-
-
-def test_violation_str_omits_defense_standard_when_absent() -> None:
-    """REQ-SYMB-005: defense_standard is absent from str(Violation) when rule has none."""
-    f = Path("bad.py")
-    v = Violation(
-        file=f,
-        line=1,
-        col=0,
-        message="asyncio.PIPE used directly",
-        rule_id="ARCH-UNKNOWN",
-        lens="process-flow",
-    )
-    s = str(v)
-    assert "[ARCH-UNKNOWN / process-flow]" in s, (
-        f"Expected '[ARCH-UNKNOWN / process-flow]' prefix, got: {s!r}"
-    )
-    assert "DS-" not in s, f"Unexpected defense_standard in output: {s!r}"
-
-
-def test_arch004_violation_str_includes_ds002(tmp_path: Path) -> None:
-    """Regression guard: ARCH-004 violation str must include DS-002 after the fix."""
-    f = tmp_path / "bad.py"
-    f.write_text("import asyncio\nval = asyncio.PIPE\n")
-    violations = _scan(f)
-    pipe_violations = [v for v in violations if "asyncio.PIPE" in v.message]
-    assert pipe_violations
-    s = str(pipe_violations[0])
-    assert "DS-002" in s
-    assert "[ARCH-004 / process-flow / DS-002]" in s
-
-
-def test_violation_str_no_prefix_without_rule_id() -> None:
-    """Violation with empty rule_id uses the legacy str format (no prefix)."""
-    v = Violation(file=Path("src/x.py"), line=5, col=0, message="some issue", rule_id="", lens="")
-    s = str(v)
-    assert not s.startswith("["), f"Expected no prefix for rule_id='', got: {s!r}"
-    assert "some issue" in s
-
-
-# ── P13-7: Shared canonical source verification ───────────────────────────────
-
-
-def test_ast_rules_and_registry_share_rules_object() -> None:
-    """P13-7: test_ast_rules and test_registry import RULES from same _rules module."""
-    import tests.arch._rules as shared
-    import tests.arch.test_registry as reg_mod
-
-    assert reg_mod.RULES is shared.RULES, "test_registry.RULES must be the shared _rules.RULES"
-
-
-# ── P13-1: ARCH-001 exemptions sync ──────────────────────────────────────────
-
-
-def test_arch001_exemptions_match_print_exempt_set() -> None:
-    """P13-1: ARCH-001 RuleDescriptor.exemptions must cover all _PRINT_EXEMPT files."""
-    arch001 = next(r for r in RULES if r.rule_id == "ARCH-001")
-    assert arch001.exemptions == _PRINT_EXEMPT
-
-
-# ── P13-2: ARCH-003 exemptions sync ──────────────────────────────────────────
-
-
-def test_arch003_exemptions_match_broad_except_set() -> None:
-    """P13-2: ARCH-003 RuleDescriptor.exemptions must cover all _BROAD_EXCEPT_EXEMPT files."""
-    arch003 = next(r for r in RULES if r.rule_id == "ARCH-003")
-    assert arch003.exemptions == _BROAD_EXCEPT_EXEMPT
-
-
-# ── P13-9: ARCH-004 exemptions sync ──────────────────────────────────────────
-
-
-def test_arch004_exemptions_match_asyncio_pipe_exempt_set() -> None:
-    """P13-9: ARCH-004 RuleDescriptor.exemptions must equal _ASYNCIO_PIPE_EXEMPT.
-
-    If execution/process.py is renamed or the ARCH-004 exemption set drifts,
-    this test catches the staleness before the AST visitor silently skips
-    the new filename.
-    """
-    arch004 = next(r for r in RULES if r.rule_id == "ARCH-004")
-    assert arch004.exemptions == _ASYNCIO_PIPE_EXEMPT
-
-
-# ── P13-5: REQ-ARCH-001/002/003 descriptors exist ────────────────────────────
-
-
-def test_req_arch_rules_have_descriptors() -> None:
-    """P13-5: REQ-ARCH rules must have RuleDescriptor constants in their test files."""
-    import tests.arch.test_layer_enforcement as le_mod
-    import tests.arch.test_subpackage_isolation as si_mod
-
-    assert hasattr(le_mod, "LAYER_RULES"), "test_layer_enforcement must export LAYER_RULES"
-    assert hasattr(si_mod, "ISOLATION_RULES"), (
-        "test_subpackage_isolation must export ISOLATION_RULES"
-    )
-    layer_ids = {r.rule_id for r in le_mod.LAYER_RULES.values()}
-    isolation_ids = {r.rule_id for r in si_mod.ISOLATION_RULES.values()}
-    assert "REQ-ARCH-001" in layer_ids
-    assert "REQ-ARCH-003" in layer_ids
-    assert "REQ-ARCH-002" in isolation_ids
-    assert "REQ-LAYER-001" in layer_ids
-    assert "REQ-LAYER-002" in layer_ids
-
-
-def test_monkeypatch_targets_do_not_bypass_package_reexports() -> None:
-    """Every monkeypatch.setattr path must target the namespace production code resolves.
-
-    When autoskillit.X re-exports 'name' from autoskillit.X.submodule via __init__.py,
-    patching autoskillit.X.submodule.name does NOT affect autoskillit.X.name.
-    All patches of the form autoskillit.X.submodule.name, where X is a sub-package
-    that re-exports 'name' FROM that exact submodule, are wrong and must be corrected.
-
-    Note: patching autoskillit.X.B.name where X imports 'name' from a DIFFERENT submodule
-    (not B) is correct -- it targets the local binding in B, which is the namespace that
-    module B's own functions resolve.
-    """
-    # Match string literals in monkeypatch.setattr("autoskillit.A.B.C", ...)
-    # where A is a sub-package, B is a submodule, C is the name.
-    pattern = re.compile(
-        r'monkeypatch\.setattr\s*\(\s*["\']'
-        r"(autoskillit\.\w+\.\w+\.\w+)"
-        r'["\']'
-    )
-
-    violations: list[str] = []
-    tests_dir = Path(__file__).parent.parent
-
-    for test_file in sorted(tests_dir.glob("**/test_*.py")):
-        source = test_file.read_text()
-        for match in pattern.finditer(source):
-            full_path = match.group(1)
-            # Split: autoskillit . pkg . submodule . name
-            parts = full_path.split(".")
-            if len(parts) != 4:
-                continue
-            _, pkg, submod, name = parts
-            parent_pkg = f"autoskillit.{pkg}"
-            try:
-                parent_mod = importlib.import_module(parent_pkg)
-            except ImportError:
-                continue
-            if not hasattr(parent_mod, name):
-                continue
-            # Refine: only flag if the parent pkg actually imports 'name' FROM this
-            # exact submodule. If it imports 'name' from a different module (e.g.
-            # autoskillit.migration imports applicable_migrations from .loader, not
-            # .engine), then the patch targets a local binding in 'submod' -- which
-            # is the correct mock target for module-level imports in that submodule.
-            try:
-                parent_source = inspect.getsource(parent_mod)
-                tree = ast.parse(parent_source)
-            except (OSError, TypeError, SyntaxError):
-                # Can't inspect source -- conservatively flag as violation.
-                imports_from_this_submod = True
-            else:
-                imports_from_this_submod = False
-                for node in ast.walk(tree):
-                    if not isinstance(node, ast.ImportFrom):
-                        continue
-                    is_relative_from_submod = node.level == 1 and node.module == submod
-                    is_absolute_from_submod = (
-                        node.level == 0 and node.module == f"autoskillit.{pkg}.{submod}"
-                    )
-                    if is_relative_from_submod or is_absolute_from_submod:
-                        for alias in node.names:
-                            if (alias.asname or alias.name) == name:
-                                imports_from_this_submod = True
-                                break
-                    if imports_from_this_submod:
-                        break
-            if imports_from_this_submod:
-                line_no = source[: match.start()].count("\n") + 1
-                violations.append(
-                    f"{test_file.name}:{line_no}: patches {full_path!r} "
-                    f"but '{name}' is re-exported at '{parent_pkg}.{name}'. "
-                    f"Patch '{parent_pkg}.{name}' instead."
-                )
-
-    assert not violations, "Monkeypatch paths bypass package re-exports:\n" + "\n".join(
-        f"  {v}" for v in violations
-    )
+    offending = sorted(k for k in RECIPE_PACK_REGISTRY if k != k.lower())
+    assert not offending, f"RECIPE_PACK_REGISTRY has non-lowercase keys: {offending}"

--- a/tests/arch/test_registry_key_casing.py
+++ b/tests/arch/test_registry_key_casing.py
@@ -1,0 +1,39 @@
+"""Architectural invariant tests for registry key casing."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.layer("arch"), pytest.mark.small]
+
+
+def test_feature_registry_keys_are_lowercase():
+    """All FEATURE_REGISTRY keys must be lowercase."""
+    from autoskillit.core._type_constants import FEATURE_REGISTRY
+
+    offending = sorted(k for k in FEATURE_REGISTRY if k != k.lower())
+    assert not offending, f"FEATURE_REGISTRY has non-lowercase keys: {offending}"
+
+
+def test_retired_features_entries_are_lowercase():
+    """All RETIRED_FEATURES entries must be lowercase."""
+    from autoskillit.core._type_constants import RETIRED_FEATURES
+
+    offending = sorted(k for k in RETIRED_FEATURES if k != k.lower())
+    assert not offending, f"RETIRED_FEATURES has non-lowercase entries: {offending}"
+
+
+def test_pack_registry_keys_are_lowercase():
+    """All PACK_REGISTRY keys must be lowercase."""
+    from autoskillit.core._type_constants import PACK_REGISTRY
+
+    offending = sorted(k for k in PACK_REGISTRY if k != k.lower())
+    assert not offending, f"PACK_REGISTRY has non-lowercase keys: {offending}"
+
+
+def test_recipe_pack_registry_keys_are_lowercase():
+    """All RECIPE_PACK_REGISTRY keys must be lowercase."""
+    from autoskillit.core._type_constants import RECIPE_PACK_REGISTRY
+
+    offending = sorted(k for k in RECIPE_PACK_REGISTRY if k != k.lower())
+    assert not offending, f"RECIPE_PACK_REGISTRY has non-lowercase keys: {offending}"

--- a/tests/cli/test_install_info.py
+++ b/tests/cli/test_install_info.py
@@ -355,14 +355,14 @@ def test_upgrade_command_unknown_and_local_path_returns_none(
 
 @pytest.mark.parametrize("rev", ["v0.7.75", "0.7.75", "v1.0", "1.0.0.0"])
 def test_is_release_tag_positive(rev: str) -> None:
-    from autoskillit.cli._install_info import _is_release_tag
+    from autoskillit.core._install_detect import _is_release_tag
 
     assert _is_release_tag(rev) is True
 
 
 @pytest.mark.parametrize("rev", ["develop", "main", "stable", "feature-foo", "v", "v0.7.75-rc1"])
 def test_is_release_tag_negative(rev: str) -> None:
-    from autoskillit.cli._install_info import _is_release_tag
+    from autoskillit.core._install_detect import _is_release_tag
 
     assert _is_release_tag(rev) is False
 
@@ -374,7 +374,7 @@ def test_is_release_tag_negative(rev: str) -> None:
 
 @pytest.mark.parametrize("rev", [None, "main", "stable", "v0.7.75", "0.9.300", ""])
 def test_is_stable_track_true(rev: str | None) -> None:
-    from autoskillit.cli._install_info import _is_stable_track
+    from autoskillit.core._install_detect import _is_stable_track
 
     assert _is_stable_track(rev) is True
 
@@ -384,7 +384,7 @@ def test_is_stable_track_true(rev: str | None) -> None:
     ["develop", "integration", "feature-foo", "staging", "release-candidate", "develops"],
 )
 def test_is_stable_track_false(rev: str) -> None:
-    from autoskillit.cli._install_info import _is_stable_track
+    from autoskillit.core._install_detect import _is_stable_track
 
     assert _is_stable_track(rev) is False
 

--- a/tests/core/test_install_detect.py
+++ b/tests/core/test_install_detect.py
@@ -1,4 +1,4 @@
-"""Tests for core/_install_detect.py — editable install detection."""
+"""Tests for core/_install_detect.py — install-type detection."""
 
 from __future__ import annotations
 
@@ -27,7 +27,7 @@ def test_is_dev_install_editable_returns_true(monkeypatch: pytest.MonkeyPatch) -
     assert is_dev_install() is True
 
 
-def test_is_dev_install_git_vcs_returns_false(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_is_dev_install_git_vcs_stable_returns_false(monkeypatch: pytest.MonkeyPatch) -> None:
     payload = json.dumps(
         {
             "url": "https://github.com/TalonT-Org/AutoSkillit.git",
@@ -41,6 +41,37 @@ def test_is_dev_install_git_vcs_returns_false(monkeypatch: pytest.MonkeyPatch) -
     from autoskillit.core._install_detect import is_dev_install
 
     assert is_dev_install() is False
+
+
+@pytest.mark.parametrize(
+    "revision, expected",
+    [
+        ("develop", True),
+        ("feature-foo", True),
+        ("integration", True),
+        ("main", False),
+        ("stable", False),
+        ("v1.0.0", False),
+        ("v0.9.300", False),
+        (None, False),
+    ],
+)
+def test_is_dev_install_git_vcs_revision_matrix(
+    monkeypatch: pytest.MonkeyPatch, revision: str | None, expected: bool
+) -> None:
+    vcs_info: dict = {"vcs": "git", "commit_id": "abc123"}
+    if revision is not None:
+        vcs_info["requested_revision"] = revision
+    payload = json.dumps(
+        {"url": "https://github.com/TalonT-Org/AutoSkillit.git", "vcs_info": vcs_info}
+    )
+    monkeypatch.setattr(
+        "importlib.metadata.Distribution.from_name",
+        lambda _name: _fake_dist(payload),
+    )
+    from autoskillit.core._install_detect import is_dev_install
+
+    assert is_dev_install() is expected
 
 
 def test_is_dev_install_local_path_returns_false(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

Two bugs expose the same architectural weakness: **duplicated-but-divergent logic without structural invariants**. Three independent `direct_url.json` parsers exist across two import layers, with no shared parsing primitive. The `FEATURE_REGISTRY` uses lowercase keys but has no import-time invariant enforcing this, and `_build_features_dict()` accepts raw dynaconf-uppercased keys without normalization. The fix consolidates `direct_url.json` parsing into a single IL-0 canonical parser, adds import-time key-casing invariants to the feature registry, and introduces parametrized test matrices that make both bug classes immediately visible.

Closes #1650

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260502-212016-496731/.autoskillit/temp/rectify/rectify_install_detect_and_feature_registry_case_immunity_2026-05-02_212016.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| investigate | 1.5k | 7.6k | 573.7k | 88.9k | 1 | 4m 34s |
| rectify | 59 | 11.7k | 611.8k | 196.2k | 1 | 6m 52s |
| dry_walkthrough | 30 | 6.3k | 495.7k | 104.4k | 1 | 4m 27s |
| implement | 676 | 32.4k | 6.1M | 383.9k | 1 | 18m 0s |
| prepare_pr | 60 | 5.9k | 188.5k | 62.3k | 1 | 1m 31s |
| compose_pr | 51 | 2.4k | 149.1k | 34.1k | 1 | 52s |
| review_pr | 264 | 69.9k | 1.5M | 313.9k | 2 | 15m 43s |
| resolve_review | 666 | 43.5k | 5.2M | 412.9k | 2 | 23m 12s |
| **Total** | 3.3k | 179.7k | 14.8M | 1.6M | | 1h 15m |
## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 447 | 6493.2 | 463.2 | 50.6 |
| **Total** | **447** | 10488.0 | 933.3 | 98.4 |