### PR TITLE
Rectify: Contract-vs-Reality Divergence Immunity

### DIFF
--- a/src/autoskillit/recipe/rules_contracts.py
+++ b/src/autoskillit/recipe/rules_contracts.py
@@ -402,3 +402,112 @@ def _check_result_field_drift(ctx: ValidationContext) -> list[RuleFinding]:
             )
 
     return findings
+
+
+@semantic_rule(
+    name="example-covers-all-allowed-values",
+    description=(
+        "Every allowed_value declared on a skill output must appear in at least "
+        "one pattern_examples entry, ensuring the example set covers all output paths"
+    ),
+    severity=Severity.ERROR,
+)
+def _check_example_covers_all_allowed_values(ctx: ValidationContext) -> list[RuleFinding]:
+    """Error when any allowed_value has no corresponding pattern_examples entry.
+
+    Reads allowed_values from the raw manifest dict (not SkillContract, which does not
+    promote allowed_values into SkillOutput). An example 'covers' a value when the
+    example text contains a match for '{output_name}\\s*=\\s*{re.escape(value)}'.
+    """
+    findings: list[RuleFinding] = []
+    manifest = load_bundled_manifest()
+
+    for step_name, step in ctx.recipe.steps.items():
+        if step.tool != "run_skill":
+            continue
+        skill_cmd = step.with_args.get("skill_command", "")
+        name = resolve_skill_name(skill_cmd)
+        if not name:
+            continue
+        contract = get_skill_contract(name, manifest)
+        if not contract or not contract.pattern_examples:
+            continue
+
+        skill_dict = manifest.get("skills", {}).get(name, {})
+        for output in skill_dict.get("outputs", []):
+            if "allowed_values" not in output:
+                continue
+            output_name: str = output["name"]
+            for value in output["allowed_values"]:
+                pattern = _re.compile(_re.escape(output_name) + r"\s*=\s*" + _re.escape(value))
+                if not any(pattern.search(ex) for ex in contract.pattern_examples):
+                    findings.append(
+                        RuleFinding(
+                            rule="example-covers-all-allowed-values",
+                            severity=Severity.ERROR,
+                            step_name=step_name,
+                            message=(
+                                f"Skill '{name}': allowed_value '{value}' on output "
+                                f"'{output_name}' has no pattern_examples entry. "
+                                f"Add an example containing '{output_name} = {value}' "
+                                f"to skill_contracts.yaml so all output paths are covered."
+                            ),
+                        )
+                    )
+
+    return findings
+
+
+@semantic_rule(
+    name="all-examples-match-all-patterns",
+    description=(
+        "Every pattern_examples entry must satisfy ALL expected_output_patterns. "
+        "An example that fails a pattern indicates the pattern is conditional, "
+        "which will cause CONTRACT_VIOLATION at runtime due to AND semantics."
+    ),
+    severity=Severity.ERROR,
+)
+def _check_all_examples_match_all_patterns(ctx: ValidationContext) -> list[RuleFinding]:
+    """Error when any pattern_examples entry fails any expected_output_pattern.
+
+    The existing pattern-examples-match rule checks ∀ pattern, ∃ example (pattern not dead).
+    This rule checks ∀ example, ∀ pattern (pattern not conditional). Together they form a
+    complete constraint: patterns are both necessary and sufficient for all output paths.
+    """
+    findings: list[RuleFinding] = []
+    manifest = load_bundled_manifest()
+
+    for step_name, step in ctx.recipe.steps.items():
+        if step.tool != "run_skill":
+            continue
+        skill_cmd = step.with_args.get("skill_command", "")
+        name = resolve_skill_name(skill_cmd)
+        if not name:
+            continue
+        contract = get_skill_contract(name, manifest)
+        if not contract or not contract.pattern_examples or not contract.expected_output_patterns:
+            continue
+
+        for example in contract.pattern_examples:
+            for pattern in contract.expected_output_patterns:
+                try:
+                    matched = bool(_re.search(pattern, example))
+                except _re.error:
+                    continue  # invalid regex — covered by pattern-examples-match
+                if not matched:
+                    preview = repr(example[:60])
+                    findings.append(
+                        RuleFinding(
+                            rule="all-examples-match-all-patterns",
+                            severity=Severity.ERROR,
+                            step_name=step_name,
+                            message=(
+                                f"Skill '{name}': example {preview} does not match "
+                                f"pattern {pattern!r}. This pattern is conditional — "
+                                f"AND semantics in _check_expected_patterns will reject "
+                                f"sessions producing this output."
+                            ),
+                        )
+                    )
+
+    return findings

--- a/src/autoskillit/recipe/rules_contracts.py
+++ b/src/autoskillit/recipe/rules_contracts.py
@@ -420,12 +420,19 @@ def _check_example_covers_all_allowed_values(ctx: ValidationContext) -> list[Rul
     example text contains a match for '{output_name}\\s*=\\s*{re.escape(value)}'.
     """
     findings: list[RuleFinding] = []
-    manifest = load_bundled_manifest()
+    try:
+        manifest = load_bundled_manifest()
+    except Exception:
+        logger.warning(
+            "example-covers-all-allowed-values: failed to load bundled manifest; skipping",
+            exc_info=True,
+        )
+        return findings
 
     for step_name, step in ctx.recipe.steps.items():
         if step.tool != "run_skill":
             continue
-        skill_cmd = step.with_args.get("skill_command", "")
+        skill_cmd = (step.with_args or {}).get("skill_command", "")
         name = resolve_skill_name(skill_cmd)
         if not name:
             continue
@@ -475,12 +482,19 @@ def _check_all_examples_match_all_patterns(ctx: ValidationContext) -> list[RuleF
     complete constraint: patterns are both necessary and sufficient for all output paths.
     """
     findings: list[RuleFinding] = []
-    manifest = load_bundled_manifest()
+    try:
+        manifest = load_bundled_manifest()
+    except Exception:
+        logger.warning(
+            "all-examples-match-all-patterns: failed to load bundled manifest; skipping",
+            exc_info=True,
+        )
+        return findings
 
     for step_name, step in ctx.recipe.steps.items():
         if step.tool != "run_skill":
             continue
-        skill_cmd = step.with_args.get("skill_command", "")
+        skill_cmd = (step.with_args or {}).get("skill_command", "")
         name = resolve_skill_name(skill_cmd)
         if not name:
             continue

--- a/src/autoskillit/recipe/rules_verdict.py
+++ b/src/autoskillit/recipe/rules_verdict.py
@@ -209,3 +209,74 @@ def _check_verdict_routing_asymmetry(ctx: ValidationContext) -> list[RuleFinding
             )
 
     return findings
+
+
+# Regex to extract a literal verdict value from a `when` expression.
+# Handles both template form: ${{ result.verdict }} == value
+# and bare dot-access form:    result.verdict == 'value'
+_VALUE_FROM_WHEN_RE = re.compile(
+    r"result\.(?P<output>[\w]+)"  # result.<output_name>
+    r"\s*\}?\}?"  # optional closing braces from template form
+    r"\s*==\s*"  # equality operator
+    r"'?(?P<value>\w+)'?"  # optional single-quoted value
+)
+
+
+@semantic_rule(
+    name="on-result-values-in-allowed-values",
+    description=(
+        "Every literal verdict value referenced in a recipe on_result condition "
+        "must be present in the skill contract's allowed_values. Catches drift "
+        "between recipe routing and contract definitions."
+    ),
+    severity=Severity.ERROR,
+)
+def _check_on_result_values_in_allowed_values(ctx: ValidationContext) -> list[RuleFinding]:
+    """Error when a recipe routes a verdict value not declared in allowed_values.
+
+    Completes the closed-loop constraint: recipe routes → allowed_values (this rule)
+    → examples (example-covers-all-allowed-values) → patterns (all-examples-match-all-patterns).
+    """
+    findings: list[RuleFinding] = []
+
+    for step_name, step in ctx.recipe.steps.items():
+        if step.tool != "run_skill":
+            continue
+        skill_command = (step.with_args or {}).get("skill_command", "")
+        skill_name = _extract_skill_name(skill_command)
+        if not skill_name:
+            continue
+
+        allowed_by_output = _get_allowed_values_for_skill(skill_name)
+        if not allowed_by_output:
+            continue
+
+        if not step.on_result:
+            continue
+
+        conditions = step.on_result.conditions or []
+        for condition in conditions:
+            when = condition.when
+            if not when or when.strip() == "true":
+                continue
+            for m in _VALUE_FROM_WHEN_RE.finditer(when):
+                output_name = m.group("output")
+                value = m.group("value")
+                if output_name not in allowed_by_output:
+                    continue
+                if value not in allowed_by_output[output_name]:
+                    findings.append(
+                        RuleFinding(
+                            rule="on-result-values-in-allowed-values",
+                            severity=Severity.ERROR,
+                            step_name=step_name,
+                            message=(
+                                f"Step '{step_name}' routes {output_name} == '{value}' "
+                                f"but skill '{skill_name}' contract allowed_values does "
+                                f"not include '{value}'. Add '{value}' to allowed_values "
+                                f"in skill_contracts.yaml."
+                            ),
+                        )
+                    )
+
+    return findings

--- a/src/autoskillit/recipe/rules_verdict.py
+++ b/src/autoskillit/recipe/rules_verdict.py
@@ -218,7 +218,7 @@ _VALUE_FROM_WHEN_RE = re.compile(
     r"result\.(?P<output>[\w]+)"  # result.<output_name>
     r"\s*\}?\}?"  # optional closing braces from template form
     r"\s*==\s*"  # equality operator
-    r"'?(?P<value>\w+)'?"  # optional single-quoted value
+    r"(?P<value>'\w+'|\w+)"  # balanced single-quoted or bare value
 )
 
 
@@ -261,7 +261,7 @@ def _check_on_result_values_in_allowed_values(ctx: ValidationContext) -> list[Ru
                 continue
             for m in _VALUE_FROM_WHEN_RE.finditer(when):
                 output_name = m.group("output")
-                value = m.group("value")
+                value = m.group("value").strip("'")
                 if output_name not in allowed_by_output:
                     continue
                 if value not in allowed_by_output[output_name]:

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -43,11 +43,12 @@ skills:
     - name: is_fixable
       type: string
     expected_output_patterns:
-    - "diagnosis_path\\s*=\\s*/.+"
+    - "diagnosis_path\\s*=\\s*(?:/.+)?"
     - "failure_subtype\\s*=\\s*(flaky|timing_race|deterministic|fixture|import|env|unknown)"
     pattern_examples:
     - "diagnosis_path = /tmp/diagnosis.md\nfailure_type = test\nfailure_subtype = deterministic\nis_fixable = true\n%%ORDER_UP%%"
     - "diagnosis_path = /tmp/diagnosis.md\nfailure_type = test\nfailure_subtype = flaky\nis_fixable = false\n%%ORDER_UP%%"
+    - "diagnosis_path = \nfailure_type = test\nfailure_subtype = unknown\nis_fixable = false\n%%ORDER_UP%%"
     write_behavior: always
   resolve-design-review:
     inputs:
@@ -65,7 +66,7 @@ skills:
       type: file_path
     expected_output_patterns:
     - "resolution\\s*=\\s*(revised|failed)"
-    - "resolution\\s*=\\s*revised[\\s\\S]*?revision_guidance\\s*=\\s*/.+"
+    - "(?:revision_guidance\\s*=\\s*/.+|resolution\\s*=\\s*failed)"
     pattern_examples:
     - "resolution = revised\nrevision_guidance = /tmp/guidance.md\n%%ORDER_UP%%"
     - "resolution = failed\n%%ORDER_UP%%"
@@ -547,13 +548,15 @@ skills:
       type: string
       allowed_values:
         - approved
+        - approved_with_comments
         - changes_requested
         - needs_human
     expected_output_patterns:
-    - "verdict\\s*=\\s*(approved|changes_requested|needs_human)"
-    - "%%REVIEW_GATE::(LOOP_REQUIRED|CLEAR)%%"
+    - "verdict\\s*=\\s*(approved|approved_with_comments|changes_requested|needs_human)"
+    - "(?:%%REVIEW_GATE::(LOOP_REQUIRED|CLEAR)%%|verdict\\s*=\\s*approved_with_comments)"
     pattern_examples:
     - "verdict = approved\n%%REVIEW_GATE::CLEAR%%\n%%ORDER_UP%%"
+    - "verdict = approved_with_comments\n%%ORDER_UP%%"
     - "verdict = changes_requested\n%%REVIEW_GATE::LOOP_REQUIRED%%\n%%ORDER_UP%%"
     - "verdict = needs_human\n%%REVIEW_GATE::CLEAR%%\n%%ORDER_UP%%"
 
@@ -1399,9 +1402,11 @@ skills:
       type: file_path
     expected_output_patterns:
     - "verdict\\s*=\\s*(GO|REVISE|STOP)"
-    - "experiment_type\\s*=\\s*\\S+"
+    - "(?:experiment_type\\s*=\\s*\\S+|verdict\\s*=\\s*STOP)"
     pattern_examples:
     - "verdict = GO\nexperiment_type = benchmark\nevaluation_dashboard = /tmp/eval.md\nrevision_guidance = /tmp/guidance.md\n%%ORDER_UP%%"
+    - "verdict = REVISE\nexperiment_type = benchmark\nrevision_guidance = /tmp/guidance.md\n%%ORDER_UP%%"
+    - "verdict = STOP\n%%ORDER_UP%%"
     write_behavior: always
 
   review-research-pr:

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -49,6 +49,14 @@ skills:
     - "diagnosis_path = /tmp/diagnosis.md\nfailure_type = test\nfailure_subtype = deterministic\nis_fixable = true\n%%ORDER_UP%%"
     - "diagnosis_path = /tmp/diagnosis.md\nfailure_type = test\nfailure_subtype = flaky\nis_fixable = false\n%%ORDER_UP%%"
     - "diagnosis_path = \nfailure_type = test\nfailure_subtype = unknown\nis_fixable = false\n%%ORDER_UP%%"
+    - "diagnosis_path = /tmp/diagnosis.md\nfailure_type = test\nfailure_subtype = timing_race\nis_fixable = true\n%%ORDER_UP%%"
+    - "diagnosis_path = /tmp/diagnosis.md\nfailure_type = test\nfailure_subtype = fixture\nis_fixable = true\n%%ORDER_UP%%"
+    - "diagnosis_path = /tmp/diagnosis.md\nfailure_type = test\nfailure_subtype = import\nis_fixable = true\n%%ORDER_UP%%"
+    - "diagnosis_path = /tmp/diagnosis.md\nfailure_type = lint\nfailure_subtype = unknown\nis_fixable = true\n%%ORDER_UP%%"
+    - "diagnosis_path = /tmp/diagnosis.md\nfailure_type = build\nfailure_subtype = unknown\nis_fixable = true\n%%ORDER_UP%%"
+    - "diagnosis_path = /tmp/diagnosis.md\nfailure_type = type_check\nfailure_subtype = unknown\nis_fixable = true\n%%ORDER_UP%%"
+    - "diagnosis_path = /tmp/diagnosis.md\nfailure_type = env\nfailure_subtype = env\nis_fixable = false\n%%ORDER_UP%%"
+    - "diagnosis_path = /tmp/diagnosis.md\nfailure_type = unknown\nfailure_subtype = unknown\nis_fixable = false\n%%ORDER_UP%%"
     write_behavior: always
   resolve-design-review:
     inputs:
@@ -1407,6 +1415,10 @@ skills:
     - "verdict = GO\nexperiment_type = benchmark\nevaluation_dashboard = /tmp/eval.md\nrevision_guidance = /tmp/guidance.md\n%%ORDER_UP%%"
     - "verdict = REVISE\nexperiment_type = benchmark\nrevision_guidance = /tmp/guidance.md\n%%ORDER_UP%%"
     - "verdict = STOP\n%%ORDER_UP%%"
+    - "verdict = GO\nexperiment_type = causal_inference\nevaluation_dashboard = /tmp/eval.md\n%%ORDER_UP%%"
+    - "verdict = GO\nexperiment_type = configuration_study\nevaluation_dashboard = /tmp/eval.md\n%%ORDER_UP%%"
+    - "verdict = GO\nexperiment_type = robustness_audit\nevaluation_dashboard = /tmp/eval.md\n%%ORDER_UP%%"
+    - "verdict = GO\nexperiment_type = exploratory\nevaluation_dashboard = /tmp/eval.md\n%%ORDER_UP%%"
     write_behavior: always
 
   review-research-pr:
@@ -1478,6 +1490,8 @@ skills:
     pattern_examples:
     - "needs_rerun = true\nverdict = real_fix\nfixes_applied = 2\n%%ORDER_UP%%"
     - "needs_rerun = false\nverdict = already_green\nfixes_applied = 0\n%%ORDER_UP%%"
+    - "needs_rerun = true\nverdict = flake_suspected\nfixes_applied = 0\n%%ORDER_UP%%"
+    - "needs_rerun = false\nverdict = ci_only_failure\nfixes_applied = 0\n%%ORDER_UP%%"
     write_behavior: conditional
     write_expected_when:
     - "verdict\\s*=\\s*real_fix"
@@ -1507,6 +1521,8 @@ skills:
     pattern_examples:
     - "needs_rerun = true\nverdict = real_fix\nfixes_applied = 2\n%%ORDER_UP%%"
     - "needs_rerun = false\nverdict = already_green\nfixes_applied = 0\n%%ORDER_UP%%"
+    - "needs_rerun = true\nverdict = flake_suspected\nfixes_applied = 0\n%%ORDER_UP%%"
+    - "needs_rerun = false\nverdict = ci_only_failure\nfixes_applied = 0\n%%ORDER_UP%%"
     write_behavior: conditional
     write_expected_when:
     - "verdict\\s*=\\s*real_fix"
@@ -2024,6 +2040,7 @@ skills:
     pattern_examples:
     - "pr_url = https://github.com/org/repo/pull/42\nverdict = created\ncategory_summary = 14 fixes, 3 features\n%%ORDER_UP%%"
     - "pr_url = \nverdict = dry_run\ncategory_summary = 14 fixes, 3 features\n%%ORDER_UP%%"
+    - "pr_url = \nverdict = preflight_failed\ncategory_summary = \n%%ORDER_UP%%"
     write_behavior: always
 callable_contracts:
   autoskillit.smoke_utils.check_loop_iteration:

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -1054,6 +1054,8 @@ steps:
     on_result:
       - when: "${{ result.verdict }} == changes_requested"
         route: resolve_review_integration
+      - when: "${{ result.verdict }} == approved_with_comments"
+        route: resolve_review_integration
       - when: "${{ result.verdict }} == needs_human"
         route: ci_watch_pr
       - when: "true"
@@ -1061,11 +1063,12 @@ steps:
     on_failure: resolve_review_integration
     note: >
       Automated review of the integration PR (REQ-REVIEW-001). Invokes review-pr against
-      context.batch_branch. All three verdicts have explicit routes: changes_requested
-      → resolve_review_integration, needs_human → ci_watch_pr (human reviews inline),
-      approved → ci_watch_pr. On tool-level failure, routes to resolve_review_integration
-      (matches implementation.yaml pattern). needs_human is explicitly routed to satisfy
-      the unrouted-verdict-value semantic rule.
+      context.batch_branch. All four verdicts have explicit routes: changes_requested
+      → resolve_review_integration, approved_with_comments → resolve_review_integration,
+      needs_human → ci_watch_pr (human reviews inline), approved → ci_watch_pr. On
+      tool-level failure, routes to resolve_review_integration (matches implementation.yaml
+      pattern). needs_human is explicitly routed to satisfy the unrouted-verdict-value
+      semantic rule.
 
   resolve_review_integration:
     tool: run_skill

--- a/tests/contracts/test_skill_contracts.py
+++ b/tests/contracts/test_skill_contracts.py
@@ -177,20 +177,155 @@ def test_skill_contracts_yaml_open_research_pr_removed(skills):
     assert "open-research-pr" not in skills
 
 
+def test_review_pr_verdict_allowed_values_includes_approved_with_comments(skills):
+    """review-pr allowed_values must include approved_with_comments.
+
+    The skill emits 4 distinct verdicts; the contract previously only listed 3.
+    A missing allowed_value causes unrouted-verdict-value semantic rule failures.
+    """
+    assert "review-pr" in skills
+    verdict_output = next(
+        (o for o in skills["review-pr"].get("outputs", []) if o["name"] == "verdict"),
+        None,
+    )
+    assert verdict_output is not None, "review-pr must declare a verdict output"
+    allowed = verdict_output.get("allowed_values", [])
+    assert "approved_with_comments" in allowed, (
+        f"review-pr allowed_values must include 'approved_with_comments'; got {allowed!r}"
+    )
+
+
+def test_review_pr_pattern_examples_cover_all_verdicts(skills):
+    """Every allowed verdict value for review-pr must appear in at least one pattern_example.
+
+    Ensures the contract's example set is complete: one example per outcome.
+    """
+    assert "review-pr" in skills
+    verdict_output = next(
+        (o for o in skills["review-pr"].get("outputs", []) if o["name"] == "verdict"),
+        None,
+    )
+    assert verdict_output is not None
+    allowed = verdict_output.get("allowed_values", [])
+    examples = skills["review-pr"].get("pattern_examples", [])
+    missing = [v for v in allowed if not any(f"verdict = {v}" in ex for ex in examples)]
+    assert not missing, (
+        f"review-pr pattern_examples missing examples for verdicts: {missing!r}. "
+        "Each allowed_value must be represented by at least one pattern_example."
+    )
+
+
+def test_every_pattern_example_satisfies_all_patterns(skills):
+    """For every skill with expected_output_patterns and pattern_examples,
+    every example must re.search-match ALL patterns (bi-directional check).
+
+    The one-directional check (each pattern matches >=1 example) misses conditional
+    tokens: a pattern may match *some* examples while failing for valid output that
+    legitimately omits a conditional token.
+    """
+    failures = []
+    for skill_name, contract in skills.items():
+        patterns = contract.get("expected_output_patterns", [])
+        examples = contract.get("pattern_examples", [])
+        if not patterns or not examples:
+            continue
+        for i, example in enumerate(examples):
+            for pattern in patterns:
+                if not re.search(pattern, example):
+                    failures.append(
+                        f"Skill '{skill_name}': example[{i}] does not match pattern "
+                        f"{pattern!r}.\n  Example: {example!r}"
+                    )
+    assert not failures, (
+        "Bi-directional pattern/example check failed — "
+        "conditional tokens cause AND-semantics failures at runtime:\n" + "\n".join(failures)
+    )
+
+
+def test_skill_contracts_allowed_values_covers_recipe_routes() -> None:
+    """Every verdict value routed in recipe on_result blocks must appear in allowed_values.
+
+    Scans implementation.yaml, remediation.yaml, implementation-groups.yaml, and
+    merge-prs.yaml for result.verdict routing conditions. Any value routed in a recipe
+    but absent from skill_contracts.yaml allowed_values will trigger the
+    unrouted-verdict-value semantic rule at recipe-load time.
+    """
+    recipes_dir = Path(__file__).parents[2] / "src/autoskillit/recipes"
+    target_files = [
+        "implementation.yaml",
+        "remediation.yaml",
+        "implementation-groups.yaml",
+        "merge-prs.yaml",
+    ]
+    contracts = yaml.safe_load(_CONTRACTS_YAML.read_text())
+    verdict_output = next(
+        (o for o in contracts["skills"]["review-pr"].get("outputs", []) if o["name"] == "verdict"),
+        None,
+    )
+    assert verdict_output is not None
+    allowed = set(verdict_output.get("allowed_values", []))
+
+    # Match only lowercase verdict values (review-pr convention: approved, changes_requested…).
+    # Excludes all-uppercase review-design verdicts (GO, REVISE, STOP) which appear in the
+    # same recipe files under different steps.
+    verdict_route_re = re.compile(r"result\.verdict\s*}}\s*==\s*([a-z][a-z_]*)")
+    routed_values: set[str] = set()
+    for filename in target_files:
+        fpath = recipes_dir / filename
+        if not fpath.exists():
+            continue
+        for m in verdict_route_re.finditer(fpath.read_text()):
+            routed_values.add(m.group(1))
+
+    missing = routed_values - allowed
+    assert not missing, (
+        f"Verdict values routed in recipes but absent from skill_contracts.yaml allowed_values: "
+        f"{sorted(missing)}. Add them to the review-pr outputs[verdict].allowed_values list."
+    )
+
+
 # T3-1
 def test_review_gate_loop_required_pattern_in_review_pr_contracts(skills):
-    """review-pr must have %%REVIEW_GATE::LOOP_REQUIRED%% pattern registered."""
-    _assert_skill_has_patterns(skills, "review-pr", "%%REVIEW_GATE::(LOOP_REQUIRED|CLEAR)%%")
+    """review-pr gate pattern must use OR-conditional form compatible with approved_with_comments.
+
+    The unconditional %%REVIEW_GATE::(LOOP_REQUIRED|CLEAR)%% pattern causes
+    CONTRACT_VIOLATION for sessions that legitimately emit no gate tag
+    (approved_with_comments verdict). The corrected form must be an OR that accepts
+    either a gate tag or an approved_with_comments verdict.
+    """
+    assert "review-pr" in skills
+    patterns = skills["review-pr"].get("expected_output_patterns", [])
+    conditional_pattern = (
+        "(?:%%REVIEW_GATE::(LOOP_REQUIRED|CLEAR)%%|verdict\\s*=\\s*approved_with_comments)"
+    )
+    assert conditional_pattern in patterns, (
+        f"review-pr gate pattern must use OR-conditional form so that approved_with_comments "
+        f"sessions succeed without a %%REVIEW_GATE:: tag. "
+        f"Expected pattern: {conditional_pattern!r}. Got: {patterns!r}"
+    )
 
 
 # T3-2
 def test_review_gate_clear_pattern_in_review_pr_contracts(skills):
-    """review-pr REVIEW_GATE pattern must cover both LOOP_REQUIRED and CLEAR tags."""
+    """review-pr REVIEW_GATE pattern must cover CLEAR and LOOP_REQUIRED; approved_with_comments
+    example must exist WITHOUT a gate tag."""
     assert "review-pr" in skills
     patterns = skills["review-pr"].get("expected_output_patterns", [])
+    examples = skills["review-pr"].get("pattern_examples", [])
+
     gate_patterns = [p for p in patterns if "REVIEW_GATE" in p]
     assert gate_patterns, "No REVIEW_GATE pattern found for review-pr"
     combined = " ".join(gate_patterns)
     assert "LOOP_REQUIRED" in combined and "CLEAR" in combined, (
-        f"REVIEW_GATE pattern must cover both tags; found: {gate_patterns}"
+        f"REVIEW_GATE pattern must reference both tags; found: {gate_patterns}"
     )
+
+    awc_examples = [ex for ex in examples if "approved_with_comments" in ex]
+    assert awc_examples, (
+        "No approved_with_comments example found in pattern_examples — "
+        "add one to document the no-gate-tag path"
+    )
+    for ex in awc_examples:
+        assert "%%REVIEW_GATE::" not in ex, (
+            f"approved_with_comments example must NOT include %%REVIEW_GATE:: tag; found: {ex!r}"
+        )

--- a/tests/hooks/test_review_gate_post_hook.py
+++ b/tests/hooks/test_review_gate_post_hook.py
@@ -309,4 +309,7 @@ def test_approved_with_comments_no_gate_tag_produces_no_state(tmp_path):
         "approved_with_comments must not clear an existing LOOP_REQUIRED state — "
         "only an explicit %%REVIEW_GATE::CLEAR%% tag should do that"
     )
-    assert state["gate"] == "LOOP_REQUIRED"
+    assert state == existing, (
+        "approved_with_comments must leave the full gate state unchanged — "
+        f"expected {existing!r}, got {state!r}"
+    )

--- a/tests/hooks/test_review_gate_post_hook.py
+++ b/tests/hooks/test_review_gate_post_hook.py
@@ -274,3 +274,39 @@ def test_pr_number_extracted_from_run_python_args(tmp_path):
     state = _read_state(tmp_path)
     assert state is not None
     assert state["pr_number"] == "1290"
+
+
+# ---------------------------------------------------------------------------
+# T2-10: approved_with_comments with no gate tag → no state write, no clear
+# ---------------------------------------------------------------------------
+
+
+def test_approved_with_comments_no_gate_tag_produces_no_state(tmp_path):
+    """T2-10: approved_with_comments emits no %%REVIEW_GATE:: tag — hook must be a no-op."""
+    event = _build_run_skill_event("verdict = approved_with_comments\n%%ORDER_UP::abc%%")
+
+    # Part 1: no state file is created when none existed
+    _run_hook(event, tmp_dir=tmp_path)
+    assert _read_state(tmp_path) is None, (
+        "approved_with_comments with no gate tag must not write review_gate_state.json"
+    )
+
+    # Part 2: pre-existing state is not cleared (no gate tag means no state transition)
+    state_path = tmp_path / _STATE_FILE_RELPATH
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    existing = {
+        "gate": "LOOP_REQUIRED",
+        "review_verdict": "changes_requested",
+        "check_review_loop_called": False,
+        "pr_number": "1290",
+        "set_at": "2026-04-26T04:30:00+00:00",
+    }
+    state_path.write_text(json.dumps(existing))
+
+    _run_hook(event, tmp_dir=tmp_path)
+    state = _read_state(tmp_path)
+    assert state is not None, (
+        "approved_with_comments must not clear an existing LOOP_REQUIRED state — "
+        "only an explicit %%REVIEW_GATE::CLEAR%% tag should do that"
+    )
+    assert state["gate"] == "LOOP_REQUIRED"

--- a/tests/recipe/test_rules_contracts.py
+++ b/tests/recipe/test_rules_contracts.py
@@ -412,3 +412,190 @@ class TestResultFieldDriftRule:
         findings = run_semantic_rules(recipe)
         drift = [f for f in findings if f.rule == "result-field-drift"]
         assert drift == [], f"result-field-drift fired on planner recipe: {drift}"
+
+
+# ---------------------------------------------------------------------------
+# example-covers-all-allowed-values rule tests
+# ---------------------------------------------------------------------------
+
+
+def test_example_covers_all_allowed_values_fires_on_missing_example(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """example-covers-all-allowed-values fires ERROR when an allowed_value has no example."""
+    manifest = {
+        "version": "0.1.0",
+        "skills": {
+            "test-skill": {
+                "inputs": [],
+                "outputs": [
+                    {"name": "verdict", "type": "string", "allowed_values": ["go", "stop"]}
+                ],
+                "expected_output_patterns": ["verdict\\s*=\\s*(go|stop)"],
+                "pattern_examples": ["verdict = go\n%%ORDER_UP%%"],  # only "go", missing "stop"
+            }
+        },
+    }
+    monkeypatch.setattr(_rc, "load_bundled_manifest", lambda: manifest)
+    recipe = _make_recipe_with_skill("/autoskillit:test-skill")
+    findings = run_semantic_rules(recipe)
+    rule_findings = [f for f in findings if f.rule == "example-covers-all-allowed-values"]
+    assert len(rule_findings) >= 1, (
+        "example-covers-all-allowed-values must fire when allowed_value 'stop' "
+        "has no corresponding pattern_examples entry"
+    )
+    assert rule_findings[0].severity == Severity.ERROR
+    assert "stop" in rule_findings[0].message
+
+
+def test_example_covers_all_allowed_values_passes_when_complete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """example-covers-all-allowed-values must not fire when all allowed_values have examples."""
+    manifest = {
+        "version": "0.1.0",
+        "skills": {
+            "test-skill": {
+                "inputs": [],
+                "outputs": [
+                    {"name": "verdict", "type": "string", "allowed_values": ["go", "stop"]}
+                ],
+                "expected_output_patterns": ["verdict\\s*=\\s*(go|stop)"],
+                "pattern_examples": [
+                    "verdict = go\n%%ORDER_UP%%",
+                    "verdict = stop\n%%ORDER_UP%%",
+                ],
+            }
+        },
+    }
+    monkeypatch.setattr(_rc, "load_bundled_manifest", lambda: manifest)
+    recipe = _make_recipe_with_skill("/autoskillit:test-skill")
+    findings = run_semantic_rules(recipe)
+    rule_findings = [f for f in findings if f.rule == "example-covers-all-allowed-values"]
+    assert rule_findings == [], (
+        "example-covers-all-allowed-values must not fire when both 'go' and 'stop' "
+        "appear in pattern_examples"
+    )
+
+
+# ---------------------------------------------------------------------------
+# all-examples-match-all-patterns rule tests
+# ---------------------------------------------------------------------------
+
+
+def test_all_examples_match_all_patterns_fires_on_conditional_pattern(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """all-examples-match-all-patterns fires ERROR when an example fails a pattern."""
+    manifest = {
+        "version": "0.1.0",
+        "skills": {
+            "test-skill": {
+                "inputs": [],
+                "outputs": [{"name": "verdict", "type": "string"}],
+                "expected_output_patterns": [
+                    "verdict\\s*=\\s*(go|stop)",
+                    "%%TAG%%",
+                ],
+                "pattern_examples": [
+                    "verdict = go\n%%TAG%%",  # matches both patterns
+                    "verdict = stop",  # missing %%TAG%% — fails second pattern
+                ],
+            }
+        },
+    }
+    monkeypatch.setattr(_rc, "load_bundled_manifest", lambda: manifest)
+    recipe = _make_recipe_with_skill("/autoskillit:test-skill")
+    findings = run_semantic_rules(recipe)
+    rule_findings = [f for f in findings if f.rule == "all-examples-match-all-patterns"]
+    assert len(rule_findings) >= 1, (
+        "all-examples-match-all-patterns must fire when 'verdict = stop' example "
+        "does not match the '%%TAG%%' pattern"
+    )
+    assert rule_findings[0].severity == Severity.ERROR
+    assert "%%TAG%%" in rule_findings[0].message or "verdict = stop" in rule_findings[0].message
+
+
+def test_all_examples_match_all_patterns_passes_when_all_match(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """all-examples-match-all-patterns must not fire when all examples match all patterns."""
+    manifest = {
+        "version": "0.1.0",
+        "skills": {
+            "test-skill": {
+                "inputs": [],
+                "outputs": [{"name": "verdict", "type": "string"}],
+                "expected_output_patterns": [
+                    "verdict\\s*=\\s*(go|stop)",
+                    "%%TAG%%",
+                ],
+                "pattern_examples": [
+                    "verdict = go\n%%TAG%%",
+                    "verdict = stop\n%%TAG%%",
+                ],
+            }
+        },
+    }
+    monkeypatch.setattr(_rc, "load_bundled_manifest", lambda: manifest)
+    recipe = _make_recipe_with_skill("/autoskillit:test-skill")
+    findings = run_semantic_rules(recipe)
+    rule_findings = [f for f in findings if f.rule == "all-examples-match-all-patterns"]
+    assert rule_findings == [], (
+        "all-examples-match-all-patterns must not fire when all examples match all patterns"
+    )
+
+
+def test_all_examples_match_all_patterns_skips_without_examples(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """all-examples-match-all-patterns must not fire when there are no pattern_examples."""
+    manifest = {
+        "version": "0.1.0",
+        "skills": {
+            "test-skill": {
+                "inputs": [],
+                "outputs": [{"name": "verdict", "type": "string"}],
+                "expected_output_patterns": ["verdict\\s*=\\s*(go|stop)"],
+                # No pattern_examples
+            }
+        },
+    }
+    monkeypatch.setattr(_rc, "load_bundled_manifest", lambda: manifest)
+    recipe = _make_recipe_with_skill("/autoskillit:test-skill")
+    findings = run_semantic_rules(recipe)
+    rule_findings = [f for f in findings if f.rule == "all-examples-match-all-patterns"]
+    assert rule_findings == [], (
+        "all-examples-match-all-patterns must not fire without pattern_examples "
+        "(defer to missing-pattern-examples rule)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Integration test: all bundled recipes pass the new contract immunity rules
+# ---------------------------------------------------------------------------
+
+
+def test_bundled_recipes_pass_all_new_contract_rules() -> None:
+    """All bundled recipes must pass the three new contract immunity rules with zero ERRORs."""
+    new_rules = {
+        "example-covers-all-allowed-values",
+        "all-examples-match-all-patterns",
+        "on-result-values-in-allowed-values",
+    }
+    recipes_dir = pkg_root() / "recipes"
+    recipe_files = sorted(recipes_dir.glob("*.yaml"))
+    assert recipe_files, "No bundled recipes found"
+
+    violations: list[str] = []
+    for recipe_path in recipe_files:
+        recipe = load_recipe(recipe_path)
+        findings = run_semantic_rules(recipe)
+        for f in findings:
+            if f.rule in new_rules and f.severity == Severity.ERROR:
+                violations.append(f"{recipe_path.name}:{f.step_name}: [{f.rule}] {f.message}")
+
+    assert not violations, (
+        "New contract immunity rules fired on bundled recipes "
+        "(ensure Part A contract fixes are applied):\n" + "\n".join(violations)
+    )

--- a/tests/recipe/test_rules_verdict.py
+++ b/tests/recipe/test_rules_verdict.py
@@ -68,12 +68,20 @@ def _explicit_all_steps() -> dict[str, RecipeStep]:
     review_step = steps["review_pr"]
     existing = review_step.on_result.conditions
     review_step.on_result.conditions = [
-        existing[0],
+        existing[0],  # changes_requested → fix
+        StepResultCondition(
+            route="fix",
+            when="${{ result.verdict }} == approved_with_comments",
+        ),
+        StepResultCondition(
+            route="done",
+            when="${{ result.verdict }} == approved",
+        ),
         StepResultCondition(
             route="escalate",
             when="${{ result.verdict }} == needs_human",
         ),
-        existing[1],
+        existing[1],  # true → done (catch-all)
     ]
     steps["escalate"] = RecipeStep(
         tool="run_skill",

--- a/tests/recipe/test_rules_verdict.py
+++ b/tests/recipe/test_rules_verdict.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import pytest
 
+import autoskillit.recipe.rules_verdict as _rv
 from autoskillit.core.types import Severity
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 from autoskillit.recipe.schema import (
@@ -320,3 +321,145 @@ def test_verdict_routing_asymmetry_severity_is_error() -> None:
         assert finding.severity == Severity.ERROR, (
             f"verdict-routing-asymmetry must be ERROR severity, got {finding.severity}"
         )
+
+
+# ---------------------------------------------------------------------------
+# on-result-values-in-allowed-values rule tests
+# ---------------------------------------------------------------------------
+
+
+def _make_review_pr_recipe(
+    verdict_route: str,
+    allowed_values: list[str],
+) -> tuple[Recipe, dict]:
+    """Helper: recipe routing verdict_route with a manifest restricting allowed_values."""
+    manifest = {
+        "version": "0.1.0",
+        "skills": {
+            "review-pr": {
+                "inputs": [],
+                "outputs": [
+                    {
+                        "name": "verdict",
+                        "type": "string",
+                        "allowed_values": allowed_values,
+                    }
+                ],
+            }
+        },
+    }
+    recipe = _make_recipe(
+        {
+            "review_pr": RecipeStep(
+                tool="run_skill",
+                with_args={"skill_command": "/autoskillit:review-pr main main"},
+                on_result=StepResultRoute(
+                    conditions=[
+                        StepResultCondition(
+                            route="fix",
+                            when=f"${{{{ result.verdict }}}} == {verdict_route}",
+                        ),
+                    ]
+                ),
+                on_failure="fix",
+            ),
+            "fix": RecipeStep(
+                tool="run_skill",
+                with_args={"skill_command": "/autoskillit:smoke-task"},
+            ),
+        }
+    )
+    return recipe, manifest
+
+
+def test_on_result_values_in_allowed_values_fires_on_unregistered_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """on-result-values-in-allowed-values fires ERROR when recipe routes an unlisted value."""
+    recipe, manifest = _make_review_pr_recipe(
+        verdict_route="approved_with_comments",
+        allowed_values=["approved", "changes_requested"],
+    )
+    monkeypatch.setattr(_rv, "load_bundled_manifest", lambda: manifest)
+    findings = run_semantic_rules(recipe)
+    rule_findings = [f for f in findings if f.rule == "on-result-values-in-allowed-values"]
+    assert len(rule_findings) >= 1, (
+        "on-result-values-in-allowed-values must fire when recipe routes "
+        "'approved_with_comments' but it is not in allowed_values"
+    )
+    assert rule_findings[0].severity == Severity.ERROR
+    assert "approved_with_comments" in rule_findings[0].message
+
+
+def test_on_result_values_in_allowed_values_passes_when_consistent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """on-result-values-in-allowed-values does not fire when all routed values are allowed."""
+    recipe, manifest = _make_review_pr_recipe(
+        verdict_route="approved",
+        allowed_values=["approved", "changes_requested", "approved_with_comments", "needs_human"],
+    )
+    monkeypatch.setattr(_rv, "load_bundled_manifest", lambda: manifest)
+    findings = run_semantic_rules(recipe)
+    rule_findings = [f for f in findings if f.rule == "on-result-values-in-allowed-values"]
+    assert rule_findings == [], (
+        "on-result-values-in-allowed-values must not fire when all routed values "
+        "are present in allowed_values"
+    )
+
+
+def test_on_result_values_in_allowed_values_ignores_non_verdict_conditions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """on-result-values-in-allowed-values must not fire for catch-all or non-output conditions."""
+    manifest = {
+        "version": "0.1.0",
+        "skills": {
+            "review-pr": {
+                "inputs": [],
+                "outputs": [
+                    {
+                        "name": "verdict",
+                        "type": "string",
+                        "allowed_values": ["approved", "changes_requested"],
+                    }
+                ],
+            }
+        },
+    }
+    recipe = _make_recipe(
+        {
+            "review_pr": RecipeStep(
+                tool="run_skill",
+                with_args={"skill_command": "/autoskillit:review-pr main main"},
+                on_result=StepResultRoute(
+                    conditions=[
+                        StepResultCondition(
+                            route="fix",
+                            when="${{ result.verdict }} == changes_requested",  # in allowed_values
+                        ),
+                        StepResultCondition(
+                            route="done",
+                            when="true",  # catch-all, no verdict value extracted
+                        ),
+                    ]
+                ),
+                on_failure="fix",
+            ),
+            "fix": RecipeStep(
+                tool="run_skill",
+                with_args={"skill_command": "/autoskillit:smoke-task"},
+            ),
+            "done": RecipeStep(
+                tool="run_skill",
+                with_args={"skill_command": "/autoskillit:smoke-task"},
+            ),
+        }
+    )
+    monkeypatch.setattr(_rv, "load_bundled_manifest", lambda: manifest)
+    findings = run_semantic_rules(recipe)
+    rule_findings = [f for f in findings if f.rule == "on-result-values-in-allowed-values"]
+    assert rule_findings == [], (
+        "on-result-values-in-allowed-values must not fire for catch-all 'when: true' "
+        "conditions that don't reference a specific verdict value"
+    )


### PR DESCRIPTION
## Summary

The contract adjudication system has a structural weakness: `expected_output_patterns` uses AND semantics (all patterns must match every session), but some patterns correspond to tokens that are conditionally emitted depending on the verdict value. When a legitimate skill output omits a conditional token, `_check_expected_patterns` returns `False`, producing a terminal `CONTRACT_VIOLATION`. This affects four skills: `review-pr`, `resolve-design-review`, `review-design`, and `diagnose-ci`. The test suite missed all four because: (1) `pattern_examples` don't cover all `allowed_values`, (2) the `pattern-examples-match` rule only checks that each pattern matches *at least one* example rather than *every* example, and (3) no test cross-validates `allowed_values` against recipe `on_result` routing conditions.

Part A fixes the four contract entries in `skill_contracts.yaml`, the `merge-prs.yaml` routing gap, and the two incorrect test assertions — with failing tests written first for each.

Part B will add three new semantic rules to `rules_contracts.py` and `rules_verdict.py` that make this entire class of bug structurally impossible.

Closes #1644

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260502-192858-898878/.autoskillit/temp/rectify/rectify_contract_divergence_immunity_2026-05-02_192858_part_a.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| rectify | 8.1k | 18.1k | 1.1M | 87.5k | 1 | 9m 57s |
| dry_walkthrough | 79 | 22.1k | 2.4M | 121.2k | 2 | 25m 6s |
| implement | 2.5k | 53.0k | 4.4M | 163.5k | 2 | 17m 21s |
| prepare_pr | 60 | 7.0k | 204.5k | 58.9k | 1 | 2m 0s |
| compose_pr | 59 | 2.3k | 178.4k | 36.5k | 1 | 47s |
| review_pr | 843 | 65.1k | 1.7M | 346.0k | 2 | 21m 26s |
| resolve_review | 706 | 56.5k | 5.1M | 341.1k | 2 | 25m 31s |
| **Total** | 12.4k | 224.1k | 15.0M | 1.2M | | 1h 42m |
## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 717 | 6095.7 | 228.0 | 73.9 |
| assess | 29 | 76580.0 | 6696.9 | 614.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **746** | 13980.6 | 887.0 | 161.3 |