### PR TITLE
Extract Shared Pre-Launch Preview Layer; Add Ingredient Display to Fleet Campaign

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -360,6 +360,7 @@ generic_automation_mcp/
 │   ├── _mcp_names.py        #   MCP prefix detection
 │   ├── _onboarding.py       #   First-run detection + guided menu
 │   ├── _prompts.py          #   Orchestrator prompt builder
+│   ├── _preview.py          #   Shared pre-launch preview: flow diagram + ingredient table display
 │   ├── _timed_input.py      #   timed_prompt() and status_line() CLI primitives
 │   ├── _menu.py             #   Shared numbered selection menu primitive: run_selection_menu(), render_numbered_menu(), resolve_menu_input()
 │   ├── _update.py           #   run_update_command(): first-class upgrade path for `autoskillit update`

--- a/src/autoskillit/cli/_fleet.py
+++ b/src/autoskillit/cli/_fleet.py
@@ -212,7 +212,35 @@ def fleet_campaign(
         dispatches = [DispatchRecord(name=d.name) for d in parsed.dispatches]
         write_initial_state(state_path, campaign_id, campaign_name, str(match.path), dispatches)
 
-    _launch_fleet_session(parsed, campaign_id, state_path, resume_metadata, fleet_mode="campaign")
+    if resume_campaign is None:
+        from autoskillit.cli._preview import show_campaign_preview
+        from autoskillit.cli._prompts import _get_ingredients_table
+        from autoskillit.cli._timed_input import timed_prompt
+
+        show_campaign_preview(campaign_name, parsed, match.path.parent, Path.cwd())
+        _itable = _get_ingredients_table(campaign_name, match, Path.cwd())
+
+        confirm = timed_prompt(
+            "Launch campaign? [Enter/n]",
+            default="",
+            timeout=120,
+            label="autoskillit fleet campaign",
+        )
+        if confirm.lower() in ("n", "no"):
+            return
+    else:
+        from autoskillit.cli._prompts import _get_ingredients_table
+
+        _itable = _get_ingredients_table(campaign_name, match, Path.cwd())
+
+    _launch_fleet_session(
+        parsed,
+        campaign_id,
+        state_path,
+        resume_metadata,
+        fleet_mode="campaign",
+        ingredients_table=_itable,
+    )
 
 
 @fleet_app.command(name="list")

--- a/src/autoskillit/cli/_fleet.py
+++ b/src/autoskillit/cli/_fleet.py
@@ -8,7 +8,7 @@ import shutil
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, cast
+from typing import TYPE_CHECKING, Annotated
 from uuid import uuid4
 
 from cyclopts import App, Parameter
@@ -21,6 +21,7 @@ from autoskillit.cli._fleet_display import (
     _watch_loop,
 )
 from autoskillit.cli._fleet_lifecycle import (
+    _pick_resume_campaign,
     _reap_stale_dispatches,
 )
 from autoskillit.cli._fleet_session import _launch_fleet_session
@@ -45,7 +46,7 @@ def _require_fleet(cfg: AutomationConfig) -> None:
 
 if TYPE_CHECKING:
     from autoskillit.config import AutomationConfig
-    from autoskillit.fleet import CampaignState, ResumeDecision
+    from autoskillit.fleet import ResumeDecision
 
 
 fleet_app = App(name="fleet", help="Campaign fleet management.")
@@ -123,42 +124,7 @@ def fleet_campaign(
         campaign_name = selected.name
 
     elif campaign_name is None and resume_campaign is not None:
-        from autoskillit.fleet import TERMINAL_DISPATCH_STATUSES, read_state
-
-        fleet_dir = Path.cwd() / ".autoskillit" / "temp" / "fleet"
-        active: list[CampaignState] = []
-        if fleet_dir.is_dir():
-            for subdir in sorted(fleet_dir.iterdir()):
-                if not subdir.is_dir():
-                    continue
-                state = read_state(subdir / "state.json")
-                if state is None:
-                    continue
-                has_non_terminal = any(
-                    d.status not in TERMINAL_DISPATCH_STATUSES for d in state.dispatches
-                )
-                if has_non_terminal:
-                    active.append(state)
-
-        if not active:
-            print("No active campaigns to resume.")
-            sys.exit(1)
-
-        selected_state = run_selection_menu(  # type: ignore[arg-type]
-            active,
-            header="Active campaigns (resumable):",
-            display_fn=lambda s: f"{s.campaign_name}  [{(s.campaign_id or '')[:8]}…]",
-            name_key=lambda s: s.campaign_name,  # type: ignore[union-attr]
-            timeout=120,
-            label="autoskillit fleet campaign --resume",
-        )
-        if selected_state is None or isinstance(selected_state, str):
-            print("No campaign selected.")
-            sys.exit(1)
-
-        resolved_state = cast("CampaignState", selected_state)
-        campaign_name = resolved_state.campaign_name
-        resume_campaign = resolved_state.campaign_id
+        campaign_name, resume_campaign = _pick_resume_campaign(Path.cwd())
 
     if campaign_name is None:
         raise RuntimeError("campaign_name must be set before launching fleet session")
@@ -212,26 +178,13 @@ def fleet_campaign(
         dispatches = [DispatchRecord(name=d.name) for d in parsed.dispatches]
         write_initial_state(state_path, campaign_id, campaign_name, str(match.path), dispatches)
 
-    if resume_campaign is None:
-        from autoskillit.cli._preview import show_campaign_preview
-        from autoskillit.cli._prompts import _get_ingredients_table
-        from autoskillit.cli._timed_input import timed_prompt
+    from autoskillit.cli._preview import _pre_launch_campaign  # noqa: PLC0415
 
-        show_campaign_preview(campaign_name, parsed, match.path.parent, Path.cwd())
-        _itable = _get_ingredients_table(campaign_name, match, Path.cwd())
-
-        confirm = timed_prompt(
-            "Launch campaign? [Enter/n]",
-            default="",
-            timeout=120,
-            label="autoskillit fleet campaign",
-        )
-        if confirm.lower() in ("n", "no"):
-            return
-    else:
-        from autoskillit.cli._prompts import _get_ingredients_table
-
-        _itable = _get_ingredients_table(campaign_name, match, Path.cwd())
+    _itable, proceed = _pre_launch_campaign(
+        campaign_name, parsed, match, Path.cwd(), is_resume=resume_campaign is not None
+    )
+    if not proceed:
+        return
 
     _launch_fleet_session(
         parsed,

--- a/src/autoskillit/cli/_fleet_lifecycle.py
+++ b/src/autoskillit/cli/_fleet_lifecycle.py
@@ -260,3 +260,38 @@ def _reap_stale_dispatches(state_path: Path, *, dry_run: bool = False) -> None:
                         )
         finally:
             fcntl.flock(_lock_fh, fcntl.LOCK_UN)
+
+
+def _pick_resume_campaign(project_dir: Path) -> tuple[str, str]:
+    """Interactively pick a resumable campaign. Returns (campaign_name, campaign_id) or exits."""
+    from autoskillit.cli._menu import run_selection_menu  # noqa: PLC0415
+    from autoskillit.fleet import TERMINAL_DISPATCH_STATUSES, read_state  # noqa: PLC0415
+
+    fleet_dir = project_dir / ".autoskillit" / "temp" / "fleet"
+    active = []
+    if fleet_dir.is_dir():
+        for subdir in sorted(fleet_dir.iterdir()):
+            if not subdir.is_dir():
+                continue
+            state = read_state(subdir / "state.json")
+            if state is None:
+                continue
+            if any(d.status not in TERMINAL_DISPATCH_STATUSES for d in state.dispatches):
+                active.append(state)
+
+    if not active:
+        print("No active campaigns to resume.")
+        sys.exit(1)
+
+    selected = run_selection_menu(
+        active,
+        header="Active campaigns (resumable):",
+        display_fn=lambda s: f"{s.campaign_name}  [{(s.campaign_id or '')[:8]}…]",
+        name_key=lambda s: s.campaign_name,
+        timeout=120,
+        label="autoskillit fleet campaign --resume",
+    )
+    if selected is None or isinstance(selected, str):
+        print("No campaign selected.")
+        sys.exit(1)
+    return selected.campaign_name, selected.campaign_id  # type: ignore[union-attr]

--- a/src/autoskillit/cli/_fleet_session.py
+++ b/src/autoskillit/cli/_fleet_session.py
@@ -22,6 +22,7 @@ def _launch_fleet_session(
     resume_metadata: ResumeDecision | None,
     *,
     fleet_mode: Literal["dispatch", "campaign"],
+    ingredients_table: str | None = None,
 ) -> None:
     """Build the L3 orchestrator prompt and launch an interactive fleet session."""
     from autoskillit.cli import detect_autoskillit_mcp_prefix  # noqa: PLC0415
@@ -76,6 +77,7 @@ def _launch_fleet_session(
             mcp_prefix,
             campaign_id,
             resumable_dispatch_name=resumable_dispatch_name,
+            ingredients_table=ingredients_table,
         )
         extra_env = {
             "AUTOSKILLIT_SESSION_TYPE": "fleet",

--- a/src/autoskillit/cli/_order.py
+++ b/src/autoskillit/cli/_order.py
@@ -271,7 +271,8 @@ def order(
             else:
                 return
 
-    from autoskillit.cli._prompts import _COOK_GREETINGS, show_cook_preview
+    from autoskillit.cli._preview import show_cook_preview
+    from autoskillit.cli._prompts import _COOK_GREETINGS
 
     _itable = _get_ingredients_table(recipe, _match, Path.cwd())
     show_cook_preview(recipe, parsed, _recipes_dir_for(_match), Path.cwd())

--- a/src/autoskillit/cli/_preview.py
+++ b/src/autoskillit/cli/_preview.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from autoskillit.recipe.loader import RecipeInfo
 
 
 def _render_pre_launch_preview(
@@ -38,7 +42,7 @@ def show_campaign_preview(
 def _pre_launch_campaign(
     campaign_name: str,
     parsed_recipe: object,
-    match: object,
+    match: RecipeInfo,
     project_dir: Path,
     *,
     is_resume: bool,
@@ -50,9 +54,9 @@ def _pre_launch_campaign(
     from autoskillit.cli._prompts import _get_ingredients_table  # noqa: PLC0415
 
     if not is_resume:
-        show_campaign_preview(campaign_name, parsed_recipe, match.path.parent, project_dir)  # type: ignore[attr-defined]
+        show_campaign_preview(campaign_name, parsed_recipe, match.path.parent, project_dir)
 
-    itable = _get_ingredients_table(campaign_name, match, project_dir)  # type: ignore[arg-type]
+    itable = _get_ingredients_table(campaign_name, match, project_dir)
     if is_resume:
         return itable, True
 

--- a/src/autoskillit/cli/_preview.py
+++ b/src/autoskillit/cli/_preview.py
@@ -33,3 +33,32 @@ def show_campaign_preview(
     recipe_name: str, parsed_recipe: object, recipes_dir: Path, project_dir: Path
 ) -> None:
     _render_pre_launch_preview(recipe_name, parsed_recipe, recipes_dir, project_dir)
+
+
+def _pre_launch_campaign(
+    campaign_name: str,
+    parsed_recipe: object,
+    match: object,
+    project_dir: Path,
+    *,
+    is_resume: bool,
+) -> tuple[str | None, bool]:
+    """Get ingredients table; show preview + confirmation for new launches.
+
+    Returns (itable, proceed). proceed=False means the user declined the launch.
+    """
+    from autoskillit.cli._prompts import _get_ingredients_table  # noqa: PLC0415
+
+    if not is_resume:
+        show_campaign_preview(campaign_name, parsed_recipe, match.path.parent, project_dir)  # type: ignore[attr-defined]
+
+    itable = _get_ingredients_table(campaign_name, match, project_dir)  # type: ignore[arg-type]
+    if is_resume:
+        return itable, True
+
+    from autoskillit.cli._timed_input import timed_prompt  # noqa: PLC0415
+
+    confirm = timed_prompt(
+        "Launch campaign? [Enter/n]", default="", timeout=120, label="autoskillit fleet campaign"
+    )
+    return itable, confirm.lower() not in ("n", "no")

--- a/src/autoskillit/cli/_preview.py
+++ b/src/autoskillit/cli/_preview.py
@@ -1,0 +1,35 @@
+"""Shared pre-launch preview: flow diagram + ingredient table display."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _render_pre_launch_preview(
+    recipe_name: str, parsed_recipe: object, recipes_dir: Path, project_dir: Path
+) -> None:
+    from autoskillit.cli._ansi import diagram_to_terminal, ingredients_to_terminal
+    from autoskillit.config import resolve_ingredient_defaults
+    from autoskillit.recipe import build_ingredient_rows, load_recipe_diagram
+
+    diagram = load_recipe_diagram(recipe_name, recipes_dir)
+    if diagram:
+        print(diagram_to_terminal(diagram))
+        print()
+
+    resolved = resolve_ingredient_defaults(project_dir)
+    rows = build_ingredient_rows(parsed_recipe, resolved_defaults=resolved)
+    if rows:
+        print(ingredients_to_terminal(rows))
+
+
+def show_cook_preview(
+    recipe_name: str, parsed_recipe: object, recipes_dir: Path, project_dir: Path
+) -> None:
+    _render_pre_launch_preview(recipe_name, parsed_recipe, recipes_dir, project_dir)
+
+
+def show_campaign_preview(
+    recipe_name: str, parsed_recipe: object, recipes_dir: Path, project_dir: Path
+) -> None:
+    _render_pre_launch_preview(recipe_name, parsed_recipe, recipes_dir, project_dir)

--- a/src/autoskillit/cli/_prompts.py
+++ b/src/autoskillit/cli/_prompts.py
@@ -107,6 +107,7 @@ def _build_fleet_campaign_prompt(
     campaign_id: str,
     max_quota_wait_sec: int = 3600,
     resumable_dispatch_name: str = "",
+    ingredients_table: str | None = None,
 ) -> str:
     """Build the system prompt for an L3 campaign dispatcher headless session.
 
@@ -190,6 +191,15 @@ issue_urls=<remaining> and allow_reentry=true as ingredient overrides.
 Do NOT re-dispatch from the full original issue list.
 """
 
+    _ing_section = ""
+    if ingredients_table:
+        _ing_section = (
+            "\n## RECIPE INGREDIENTS — USE THESE EXACT NAMES\n\n"
+            f"{ingredients_table}\n\n"
+            "Before dispatching, collect values for all required ingredients from the user "
+            "via AskUserQuestion. Do not dispatch until all required values are confirmed.\n"
+        )
+
     return f"""\
 You are a fleet campaign dispatcher. Execute campaign '{campaign_recipe.name}' autonomously.
 Campaign ID: {campaign_id}. Dispatches: {dispatch_count}.
@@ -201,7 +211,7 @@ Campaign ID: {campaign_id}. Dispatches: {dispatch_count}.
 - Description: {campaign_recipe.description}
 - Dispatch count: {dispatch_count} dispatches
 - Continue on failure: {campaign_recipe.continue_on_failure}
-
+{_ing_section}
 ## DISPATCH MANIFEST
 
 The following manifest defines all dispatches for this campaign:
@@ -703,26 +713,3 @@ NEVER use run_skill or any non-fleet tool.
 After all dispatches complete, call {mcp_prefix}batch_cleanup_clones() to clean up \
 clone artifacts before ending the session.
 """
-
-
-def show_cook_preview(
-    recipe_name: str, parsed_recipe: object, recipes_dir: Path, project_dir: Path
-) -> None:
-    """Display the terminal preview: flow diagram + ingredients table.
-
-    Owns the entire pre-launch display so ``cook()`` makes one call.
-    Gateway imports only (no cross-package submodule imports).
-    """
-    from autoskillit.cli._ansi import diagram_to_terminal, ingredients_to_terminal
-    from autoskillit.config import resolve_ingredient_defaults
-    from autoskillit.recipe import build_ingredient_rows, load_recipe_diagram
-
-    diagram = load_recipe_diagram(recipe_name, recipes_dir)
-    if diagram:
-        print(diagram_to_terminal(diagram))
-        print()  # blank line between diagram and table
-
-    resolved = resolve_ingredient_defaults(project_dir)
-    rows = build_ingredient_rows(parsed_recipe, resolved_defaults=resolved)
-    if rows:
-        print(ingredients_to_terminal(rows))

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -361,12 +361,13 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             "server/test_tools_kitchen_envelope.py",
             "server/test_service_wrappers.py",
             "server/test_tools_list_recipes.py",
-            # CLI file-level entries (4 of 38 import autoskillit.recipe):
+            # CLI file-level entries (5 of 38 import autoskillit.recipe):
             "cli/test_cli_prompts.py",
             "cli/test_l3_orchestrator_prompt.py",
             "cli/test_cook_order_command.py",
             "cli/test_cook_order_picker.py",
             "cli/test_fleet_list.py",
+            "cli/test_preview.py",
             # Execution file-level entries:
             "execution/test_headless_path_validation.py",
             "execution/test_zero_write_detection.py",

--- a/tests/arch/_rules.py
+++ b/tests/arch/_rules.py
@@ -57,6 +57,7 @@ _LOGGER_METHODS = frozenset({"debug", "info", "warning", "error", "critical", "e
 _PRINT_EXEMPT = frozenset(
     {
         "_cook.py",
+        "_preview.py",
         "_features.py",
         "_menu.py",
         "_fleet_display.py",

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -783,7 +783,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "recipe": 50,
         "execution": 37,
         "core": 33,
-        "cli": 42,
+        "cli": 43,
         "hooks": 29,
         "pipeline": 12,
         "fleet": 11,

--- a/tests/cli/_fleet_helpers.py
+++ b/tests/cli/_fleet_helpers.py
@@ -31,7 +31,7 @@ def _stub_guards(monkeypatch: pytest.MonkeyPatch) -> None:
 def _stub_campaign_resolution(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, name: str
 ) -> MagicMock:
-    """Stub find_campaign_by_name, load_recipe, and validate_recipe."""
+    """Stub find_campaign_by_name, load_recipe, validate_recipe, and pre-launch steps."""
     campaign_path = tmp_path / f"{name}.yaml"
     campaign_path.write_text("")
 
@@ -48,6 +48,9 @@ def _stub_campaign_resolution(
     monkeypatch.setattr("autoskillit.recipe.find_campaign_by_name", lambda *a, **kw: recipe_info)
     monkeypatch.setattr("autoskillit.recipe.load_recipe", lambda *a, **kw: recipe)
     monkeypatch.setattr("autoskillit.recipe.validate_recipe", lambda *a: [])
+    monkeypatch.setattr("autoskillit.cli._preview.show_campaign_preview", lambda *a, **kw: None)
+    monkeypatch.setattr("autoskillit.cli._prompts._get_ingredients_table", lambda *a, **kw: None)
+    monkeypatch.setattr("autoskillit.cli._timed_input.timed_prompt", lambda *a, **kw: "")
     return recipe
 
 

--- a/tests/cli/test_cli_prompts.py
+++ b/tests/cli/test_cli_prompts.py
@@ -153,7 +153,7 @@ def test_open_kitchen_prompt_does_not_embed_greetings():
 
 def test_show_cook_preview_prints_table(monkeypatch, tmp_path, capsys):
     """show_cook_preview prints ingredients table to stdout."""
-    from autoskillit.cli._prompts import show_cook_preview
+    from autoskillit.cli._preview import show_cook_preview
     from autoskillit.recipe.io import _parse_recipe
 
     monkeypatch.setattr(
@@ -183,7 +183,7 @@ def test_show_cook_preview_prints_table(monkeypatch, tmp_path, capsys):
 
 def test_show_cook_preview_no_diagram(monkeypatch, tmp_path, capsys):
     """show_cook_preview works when no diagram file exists."""
-    from autoskillit.cli._prompts import show_cook_preview
+    from autoskillit.cli._preview import show_cook_preview
     from autoskillit.recipe.io import _parse_recipe
 
     monkeypatch.setattr(
@@ -216,7 +216,7 @@ def test_show_cook_preview_no_diagram(monkeypatch, tmp_path, capsys):
 def test_show_cook_preview_uses_resolved_base_branch_for_smoke_test(monkeypatch, capsys):
     """T8: show_cook_preview renders the config-resolved base_branch for smoke-test."""
     import autoskillit.recipe._api as api_mod
-    from autoskillit.cli._prompts import show_cook_preview
+    from autoskillit.cli._preview import show_cook_preview
     from autoskillit.core import pkg_root
     from autoskillit.recipe.io import find_recipe_by_name, load_recipe
 
@@ -331,7 +331,7 @@ def test_show_cook_preview_line_width_bounded_with_implementation_recipe(tmp_pat
     the real implementation.yaml with its 220-char run_mode description."""
     import re
 
-    from autoskillit.cli._prompts import show_cook_preview
+    from autoskillit.cli._preview import show_cook_preview
     from autoskillit.core import pkg_root
     from autoskillit.recipe.io import find_recipe_by_name, load_recipe
 
@@ -717,7 +717,7 @@ def test_show_cook_preview_no_mermaid_in_output(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """T-PREVIEW-FORMAT: show_cook_preview must not leak Mermaid syntax to terminal."""
-    from autoskillit.cli._prompts import show_cook_preview
+    from autoskillit.cli._preview import show_cook_preview
     from autoskillit.core import pkg_root
     from autoskillit.recipe.io import find_recipe_by_name, load_recipe
 

--- a/tests/cli/test_cook_features.py
+++ b/tests/cli/test_cook_features.py
@@ -20,7 +20,7 @@ class TestOrderSubsetGate:
 
     @pytest.fixture(autouse=True)
     def _stub_preview(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr("autoskillit.cli._prompts.show_cook_preview", lambda *a, **kw: None)
+        monkeypatch.setattr("autoskillit.cli._preview.show_cook_preview", lambda *a, **kw: None)
 
     @pytest.fixture(autouse=True)
     def _stub_ingredients_table(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/cli/test_cook_order_command.py
+++ b/tests/cli/test_cook_order_command.py
@@ -21,7 +21,7 @@ class TestCLIOrderCommand:
     def _stub_preview(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Stub terminal preview to avoid subprocess.run collision with git calls."""
         monkeypatch.setattr(
-            "autoskillit.cli._prompts.show_cook_preview",
+            "autoskillit.cli._preview.show_cook_preview",
             lambda *a, **kw: None,
         )
 

--- a/tests/cli/test_cook_order_picker.py
+++ b/tests/cli/test_cook_order_picker.py
@@ -22,7 +22,7 @@ class TestCLIOrderPicker:
     def _stub_preview(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Stub terminal preview to avoid subprocess.run collision with git calls."""
         monkeypatch.setattr(
-            "autoskillit.cli._prompts.show_cook_preview",
+            "autoskillit.cli._preview.show_cook_preview",
             lambda *a, **kw: None,
         )
 
@@ -490,7 +490,7 @@ class TestOrderResumeParsing:
     def _stub_preview(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Stub terminal preview to avoid subprocess calls."""
         monkeypatch.setattr(
-            "autoskillit.cli._prompts.show_cook_preview",
+            "autoskillit.cli._preview.show_cook_preview",
             lambda *a, **kw: None,
         )
 

--- a/tests/cli/test_cook_order_prompt.py
+++ b/tests/cli/test_cook_order_prompt.py
@@ -21,7 +21,7 @@ class TestCLIOrderPrompt:
     def _stub_preview(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Stub terminal preview to avoid subprocess.run collision with git calls."""
         monkeypatch.setattr(
-            "autoskillit.cli._prompts.show_cook_preview",
+            "autoskillit.cli._preview.show_cook_preview",
             lambda *a, **kw: None,
         )
 
@@ -190,7 +190,7 @@ class TestOrderDisplayOwnership:
     def _stub_preview(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Stub terminal preview to avoid subprocess.run collision with git calls."""
         monkeypatch.setattr(
-            "autoskillit.cli._prompts.show_cook_preview",
+            "autoskillit.cli._preview.show_cook_preview",
             lambda *a, **kw: None,
         )
 
@@ -260,7 +260,7 @@ class TestOrderMcpPrefixSelection:
 
     @pytest.fixture(autouse=True)
     def _stub_preview(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr("autoskillit.cli._prompts.show_cook_preview", lambda *a, **kw: None)
+        monkeypatch.setattr("autoskillit.cli._preview.show_cook_preview", lambda *a, **kw: None)
 
     @pytest.fixture(autouse=True)
     def _interactive_stdin(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/cli/test_cook_workspace.py
+++ b/tests/cli/test_cook_workspace.py
@@ -17,7 +17,7 @@ pytestmark = [pytest.mark.layer("cli"), pytest.mark.medium]
 class TestCLIOrderWorkspace:
     @pytest.fixture(autouse=True)
     def _stub_preview(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr("autoskillit.cli._prompts.show_cook_preview", lambda *a, **kw: None)
+        monkeypatch.setattr("autoskillit.cli._preview.show_cook_preview", lambda *a, **kw: None)
 
     @pytest.fixture(autouse=True)
     def _interactive_stdin(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/cli/test_fleet_campaign_preview.py
+++ b/tests/cli/test_fleet_campaign_preview.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -52,7 +51,9 @@ class TestFleetCampaignPreview:
         _stub_guards(monkeypatch)
         monkeypatch.chdir(tmp_path)
         _stub_campaign_resolution(monkeypatch, tmp_path, "test-campaign")
-        calls = _stub_preview_layer(monkeypatch, ingredients_table="| Name | Desc |\n| task | ... |")
+        calls = _stub_preview_layer(
+            monkeypatch, ingredients_table="| Name | Desc |\n| task | ... |"
+        )
         _fleet_campaign("test-campaign")
         assert len(calls["preview"]) == 1
 

--- a/tests/cli/test_fleet_campaign_preview.py
+++ b/tests/cli/test_fleet_campaign_preview.py
@@ -1,0 +1,123 @@
+"""Tests: fleet_campaign shows preview + confirmation before launch."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from autoskillit.cli._fleet import fleet_campaign as _fleet_campaign
+from tests.cli._fleet_helpers import (
+    _stub_campaign_resolution,
+    _stub_guards,
+)
+
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.medium, pytest.mark.feature("fleet")]
+
+
+def _stub_preview_layer(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    timed_prompt_return: str = "",
+    ingredients_table: str | None = None,
+) -> dict:
+    """Stub preview/prompt/launch layer; return captured call tracker."""
+    calls: dict = {"preview": [], "launch": [], "timed_prompt": []}
+
+    def _fake_preview(*args: object, **kwargs: object) -> None:
+        calls["preview"].append(args)
+
+    def _fake_get_itable(*args: object, **kwargs: object) -> str | None:
+        return ingredients_table
+
+    def _fake_timed_prompt(*args: object, **kwargs: object) -> str:
+        calls["timed_prompt"].append((args, kwargs))
+        return timed_prompt_return
+
+    def _fake_launch(*args: object, **kwargs: object) -> None:
+        calls["launch"].append({"args": args, "kwargs": kwargs})
+
+    monkeypatch.setattr("autoskillit.cli._preview.show_campaign_preview", _fake_preview)
+    monkeypatch.setattr("autoskillit.cli._prompts._get_ingredients_table", _fake_get_itable)
+    monkeypatch.setattr("autoskillit.cli._timed_input.timed_prompt", _fake_timed_prompt)
+    monkeypatch.setattr("autoskillit.cli._fleet._launch_fleet_session", _fake_launch)
+    return calls
+
+
+class TestFleetCampaignPreview:
+    def test_ingredient_table_displayed_before_launch(
+        self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _stub_guards(monkeypatch)
+        monkeypatch.chdir(tmp_path)
+        _stub_campaign_resolution(monkeypatch, tmp_path, "test-campaign")
+        calls = _stub_preview_layer(monkeypatch, ingredients_table="| Name | Desc |\n| task | ... |")
+        _fleet_campaign("test-campaign")
+        assert len(calls["preview"]) == 1
+
+    def test_confirmation_prompt_shown(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _stub_guards(monkeypatch)
+        monkeypatch.chdir(tmp_path)
+        _stub_campaign_resolution(monkeypatch, tmp_path, "test-campaign")
+        calls = _stub_preview_layer(monkeypatch)
+        _fleet_campaign("test-campaign")
+        assert len(calls["timed_prompt"]) == 1
+        args, kwargs = calls["timed_prompt"][0]
+        assert "campaign" in (args[0] if args else kwargs.get("prompt", "")).lower()
+
+    def test_user_declines_does_not_launch(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _stub_guards(monkeypatch)
+        monkeypatch.chdir(tmp_path)
+        _stub_campaign_resolution(monkeypatch, tmp_path, "test-campaign")
+        calls = _stub_preview_layer(monkeypatch, timed_prompt_return="n")
+        _fleet_campaign("test-campaign")
+        assert len(calls["launch"]) == 0
+
+    def test_ingredients_table_passed_to_session(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _stub_guards(monkeypatch)
+        monkeypatch.chdir(tmp_path)
+        _stub_campaign_resolution(monkeypatch, tmp_path, "test-campaign")
+        table = "| Name | Value |\n| task | build |"
+        calls = _stub_preview_layer(monkeypatch, ingredients_table=table)
+        _fleet_campaign("test-campaign")
+        assert len(calls["launch"]) == 1
+        assert calls["launch"][0]["kwargs"].get("ingredients_table") == table
+
+    def test_resume_skips_preview_and_confirmation(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from tests.cli._fleet_helpers import _setup_existing_campaign_state
+
+        _stub_guards(monkeypatch)
+        monkeypatch.chdir(tmp_path)
+        campaign_id = "abc123def456ab12"
+        _setup_existing_campaign_state(tmp_path, campaign_id, "test-campaign")
+        _stub_campaign_resolution(monkeypatch, tmp_path, "test-campaign")
+        calls = _stub_preview_layer(monkeypatch)
+        _fleet_campaign("test-campaign", resume_campaign=campaign_id)
+        assert len(calls["preview"]) == 0
+        assert len(calls["timed_prompt"]) == 0
+        assert len(calls["launch"]) == 1
+
+    def test_resume_still_passes_ingredients_table_to_session(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from tests.cli._fleet_helpers import _setup_existing_campaign_state
+
+        _stub_guards(monkeypatch)
+        monkeypatch.chdir(tmp_path)
+        campaign_id = "abc123def456ab12"
+        _setup_existing_campaign_state(tmp_path, campaign_id, "test-campaign")
+        _stub_campaign_resolution(monkeypatch, tmp_path, "test-campaign")
+        table = "| Name | Value |\n| task | fix |"
+        calls = _stub_preview_layer(monkeypatch, ingredients_table=table)
+        _fleet_campaign("test-campaign", resume_campaign=campaign_id)
+        assert len(calls["launch"]) == 1
+        assert calls["launch"][0]["kwargs"].get("ingredients_table") == table

--- a/tests/cli/test_fleet_session.py
+++ b/tests/cli/test_fleet_session.py
@@ -1,0 +1,78 @@
+"""Tests: _launch_fleet_session forwards ingredients_table to prompt builder."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.small, pytest.mark.feature("fleet")]
+
+
+def _make_campaign_recipe(name: str = "test-campaign") -> MagicMock:
+    recipe = MagicMock()
+    recipe.name = name
+    recipe.dispatches = []
+    recipe.continue_on_failure = False
+    recipe.description = f"Test {name}"
+    return recipe
+
+
+class TestLaunchFleetSessionIngredientsTable:
+    def _call(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        ingredients_table: str | None = None,
+    ) -> dict:
+        captured: dict = {}
+
+        def _fake_build(
+            campaign_recipe: object,
+            manifest_yaml: str,
+            completed_dispatches: str,
+            mcp_prefix: str,
+            campaign_id: str,
+            **kwargs: object,
+        ) -> str:
+            captured["ingredients_table"] = kwargs.get("ingredients_table")
+            return "fake-prompt"
+
+        monkeypatch.setattr(
+            "autoskillit.cli._prompts._build_fleet_campaign_prompt", _fake_build
+        )
+        monkeypatch.setattr(
+            "autoskillit.cli._fleet_session._run_interactive_session",
+            lambda *a, **kw: None,
+        )
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".autoskillit" / "temp" / "fleet" / "test-id").mkdir(parents=True)
+
+        state_path = tmp_path / ".autoskillit" / "temp" / "fleet" / "test-id" / "state.json"
+        state_path.write_text("{}")
+
+        from autoskillit.cli._fleet_session import _launch_fleet_session
+
+        _launch_fleet_session(
+            _make_campaign_recipe(),
+            "test-id",
+            state_path,
+            None,
+            fleet_mode="campaign",
+            ingredients_table=ingredients_table,
+        )
+        return captured
+
+    def test_ingredients_table_forwarded_to_prompt_builder(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        table = "| Name | Desc |\n| task | do it |"
+        captured = self._call(monkeypatch, tmp_path, ingredients_table=table)
+        assert captured["ingredients_table"] == table
+
+    def test_ingredients_table_none_by_default(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        captured = self._call(monkeypatch, tmp_path)
+        assert captured["ingredients_table"] is None

--- a/tests/cli/test_fleet_session.py
+++ b/tests/cli/test_fleet_session.py
@@ -39,11 +39,9 @@ class TestLaunchFleetSessionIngredientsTable:
             captured["ingredients_table"] = kwargs.get("ingredients_table")
             return "fake-prompt"
 
+        monkeypatch.setattr("autoskillit.cli._prompts._build_fleet_campaign_prompt", _fake_build)
         monkeypatch.setattr(
-            "autoskillit.cli._prompts._build_fleet_campaign_prompt", _fake_build
-        )
-        monkeypatch.setattr(
-            "autoskillit.cli._fleet_session._run_interactive_session",
+            "autoskillit.cli._session_launch._run_interactive_session",
             lambda *a, **kw: None,
         )
         monkeypatch.chdir(tmp_path)

--- a/tests/cli/test_l3_orchestrator_prompt.py
+++ b/tests/cli/test_l3_orchestrator_prompt.py
@@ -441,3 +441,30 @@ class TestDynamicDispatchSection:
         )
         prompt = _build(campaign_recipe=recipe)
         assert "DYNAMIC DISPATCH" not in prompt
+
+
+# --- K-15: TestK15IngredientsTableInjection ---
+
+
+class TestK15IngredientsTableInjection:
+    _TABLE = "| Name | Description | Default |\n| task | What to fix | — |"
+
+    def test_ingredients_section_present_when_provided(self) -> None:
+        prompt = _build(ingredients_table=self._TABLE)
+        assert "RECIPE INGREDIENTS" in prompt
+        assert self._TABLE in prompt
+
+    def test_ingredients_section_absent_when_none(self) -> None:
+        prompt = _build(ingredients_table=None)
+        assert "RECIPE INGREDIENTS" not in prompt
+
+    def test_ask_user_question_instruction_present(self) -> None:
+        prompt = _build(ingredients_table=self._TABLE)
+        assert "AskUserQuestion" in prompt
+
+    def test_ingredients_section_between_overview_and_manifest(self) -> None:
+        prompt = _build(ingredients_table=self._TABLE)
+        overview_pos = prompt.index("CAMPAIGN OVERVIEW")
+        ingredients_pos = prompt.index("RECIPE INGREDIENTS")
+        manifest_pos = prompt.index("DISPATCH MANIFEST")
+        assert overview_pos < ingredients_pos < manifest_pos

--- a/tests/cli/test_preview.py
+++ b/tests/cli/test_preview.py
@@ -23,7 +23,9 @@ def _make_recipe(monkeypatch: pytest.MonkeyPatch, *, has_ingredients: bool = Tru
         "autoskillit.config.resolve_ingredient_defaults",
         lambda _: {"source_dir": "https://github.com/test/repo"},
     )
-    ingredients = {"task": {"description": "What to build", "required": True}} if has_ingredients else {}
+    ingredients = (
+        {"task": {"description": "What to build", "required": True}} if has_ingredients else {}
+    )
     return _parse_recipe(
         {
             "name": "preview-test",

--- a/tests/cli/test_preview.py
+++ b/tests/cli/test_preview.py
@@ -1,0 +1,104 @@
+"""Tests for the shared pre-launch preview module (_preview.py)."""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+from autoskillit.cli._preview import (
+    _render_pre_launch_preview,
+    show_campaign_preview,
+    show_cook_preview,
+)
+
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.small]
+
+
+def _make_recipe(monkeypatch: pytest.MonkeyPatch, *, has_ingredients: bool = True) -> object:
+    from autoskillit.recipe.io import _parse_recipe
+
+    monkeypatch.setattr(
+        "autoskillit.config.resolve_ingredient_defaults",
+        lambda _: {"source_dir": "https://github.com/test/repo"},
+    )
+    ingredients = {"task": {"description": "What to build", "required": True}} if has_ingredients else {}
+    return _parse_recipe(
+        {
+            "name": "preview-test",
+            "steps": {
+                "do": {
+                    "tool": "run_cmd",
+                    "with": {"cmd": "echo hi"},
+                    "on_success": "done",
+                    "on_failure": "done",
+                },
+                "done": {"action": "stop", "message": "ok"},
+            },
+            "ingredients": ingredients,
+        }
+    )
+
+
+class TestRenderPreLaunchPreview:
+    def test_renders_ingredients_when_present(
+        self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        recipe = _make_recipe(monkeypatch)
+        _render_pre_launch_preview("preview-test", recipe, tmp_path, tmp_path)
+        out = capsys.readouterr().out
+        assert "task" in out
+        assert "(required)" in out
+
+    def test_skips_diagram_when_none(
+        self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        recipe = _make_recipe(monkeypatch)
+        _render_pre_launch_preview("nonexistent-recipe", recipe, tmp_path, tmp_path)
+        out = capsys.readouterr().out
+        assert "task" in out
+        assert "RECIPE" not in out
+
+    def test_skips_ingredients_when_empty(
+        self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        recipe = _make_recipe(monkeypatch, has_ingredients=False)
+        _render_pre_launch_preview("nonexistent-recipe", recipe, tmp_path, tmp_path)
+        out = capsys.readouterr().out
+        assert out.strip() == ""
+
+
+class TestShowCookPreview:
+    def test_signature_matches_expected(self) -> None:
+        sig = inspect.signature(show_cook_preview)
+        params = list(sig.parameters)
+        assert params == ["recipe_name", "parsed_recipe", "recipes_dir", "project_dir"]
+
+    def test_produces_terminal_output(
+        self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        recipe = _make_recipe(monkeypatch)
+        show_cook_preview("preview-test", recipe, tmp_path, tmp_path)
+        out = capsys.readouterr().out
+        assert "task" in out
+        assert "(required)" in out
+
+
+class TestShowCampaignPreview:
+    def test_renders_ingredients_for_campaign(
+        self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        recipe = _make_recipe(monkeypatch)
+        show_campaign_preview("preview-test", recipe, tmp_path, tmp_path)
+        out = capsys.readouterr().out
+        assert "task" in out
+
+    def test_skips_diagram_gracefully(
+        self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        recipe = _make_recipe(monkeypatch)
+        show_campaign_preview("no-such-campaign-recipe", recipe, tmp_path, tmp_path)
+        out = capsys.readouterr().out
+        assert "task" in out
+        assert "RECIPE" not in out


### PR DESCRIPTION
## Summary

Create a shared pre-launch preview module (`_preview.py`) that both `order` and `fleet campaign` consume via distinct entry points. Add the ANSI ingredient table display, GFM ingredient table injection into the L3 prompt, and a `timed_prompt` launch confirmation to the fleet campaign flow.

## Requirements

### PREVIEW — Shared Preview Abstraction

**REQ-PREVIEW-001:** The system must provide a shared internal function for rendering the ANSI ingredient table to the terminal, callable by both `show_cook_preview()` and `show_campaign_preview()`.

**REQ-PREVIEW-002:** The system must provide a shared internal function for rendering the flow diagram to the terminal, callable by both preview entry points.

**REQ-PREVIEW-003:** `show_cook_preview()` must delegate to the shared internals while retaining its current function name and signature.

**REQ-PREVIEW-004:** A new `show_campaign_preview()` function must exist as the campaign-specific entry point, distinct from `show_cook_preview()`.

### FLEET — Fleet Campaign Ingredient Display

**REQ-FLEET-001:** `fleet_campaign()` must display the ANSI ingredient table to the terminal after recipe validation and before session launch.

**REQ-FLEET-002:** `fleet_campaign()` must display a `timed_prompt` launch confirmation before launching the fleet session.

**REQ-FLEET-003:** `_build_fleet_campaign_prompt()` must accept an ingredients table parameter and inject it into the L3 system prompt with authoritative ingredient name instructions.

**REQ-FLEET-004:** `_launch_fleet_session()` must accept an ingredient table parameter and pass it to the campaign prompt builder.

**REQ-FLEET-005:** The L3 campaign session must be instructed to collect required ingredient values from the user via `AskUserQuestion` before dispatching.

Closes #1651

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260502-213631-230850/.autoskillit/temp/make-plan/extract_shared_preview_layer_plan_2026-05-02_213900.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 1.7k | 11.0k | 761.6k | 112.9k | 1 | 7m 4s |
| verify | 40 | 10.4k | 1.0M | 97.2k | 1 | 6m 22s |
| implement | 412 | 22.6k | 2.9M | 207.1k | 1 | 8m 3s |
| prepare_pr | 52 | 3.9k | 155.5k | 54.0k | 1 | 1m 15s |
| compose_pr | 59 | 2.4k | 176.1k | 39.9k | 1 | 47s |
| review_pr | 100 | 35.9k | 562.0k | 162.6k | 1 | 9m 6s |
| resolve_review | 283 | 25.6k | 1.9M | 252.2k | 1 | 12m 48s |
| **Total** | 2.6k | 111.8k | 7.5M | 925.8k | | 45m 26s |