### PR TITLE
Rectify: OutputFormat Required Flag Enforcement — Type-Level Immunity

### DIFF
--- a/src/autoskillit/execution/_headless_recovery.py
+++ b/src/autoskillit/execution/_headless_recovery.py
@@ -8,7 +8,7 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from autoskillit.core import CliSubtype, RetryReason, SkillResult, get_logger
+from autoskillit.core import CliSubtype, OutputFormat, RetryReason, SkillResult, get_logger
 from autoskillit.execution.commands import build_headless_resume_cmd
 from autoskillit.execution.process import _marker_is_standalone
 from autoskillit.execution.session import (
@@ -209,7 +209,7 @@ async def _attempt_contract_nudge(
     spec = build_headless_resume_cmd(
         resume_session_id=skill_result.session_id,
         prompt=prompt,
-        output_format="json",
+        output_format=OutputFormat.JSON,
     )
 
     try:

--- a/src/autoskillit/execution/commands.py
+++ b/src/autoskillit/execution/commands.py
@@ -19,6 +19,7 @@ from autoskillit.core import (
     MarketplaceInstall,
     NamedResume,
     NoResume,
+    OutputFormat,
     PluginSource,
     ResumeSpec,
     ValidatedAddDir,
@@ -168,11 +169,19 @@ _HEADLESS_EXCLUSIVE_VARS: frozenset[str] = frozenset(
 )
 
 
+def _apply_output_format(cmd: list[str], output_format: OutputFormat) -> None:
+    """Append --output-format and all required CLI flags, deduplicating."""
+    cmd += [ClaudeFlags.OUTPUT_FORMAT, output_format.value]
+    for flag in output_format.required_cli_flags:
+        if flag not in cmd:
+            cmd.append(flag)
+
+
 def build_headless_resume_cmd(
     *,
     resume_session_id: str,
     prompt: str,
-    output_format: str = "json",
+    output_format: OutputFormat = OutputFormat.JSON,
     plugin_source: PluginSource | None = None,
     env_extras: Mapping[str, str] | None = None,
 ) -> ClaudeHeadlessCmd:
@@ -189,9 +198,8 @@ def build_headless_resume_cmd(
         ClaudeFlags.RESUME,
         resume_session_id,
         ClaudeFlags.DANGEROUSLY_SKIP_PERMISSIONS,
-        ClaudeFlags.OUTPUT_FORMAT,
-        output_format,
     ]
+    _apply_output_format(cmd, output_format)
     match plugin_source:
         case DirectInstall(plugin_dir=p):
             cmd += [ClaudeFlags.PLUGIN_DIR, str(p)]
@@ -267,8 +275,7 @@ def build_leaf_headless_cmd(
     completion_marker: str,
     model: str | None,
     plugin_source: PluginSource | None,
-    output_format_value: str,
-    output_format_required_flags: Sequence[str] = (),
+    output_format: OutputFormat,
     add_dirs: Sequence[ValidatedAddDir] = (),
     exit_after_stop_delay_ms: int = 0,
     scenario_step_name: str = "",
@@ -300,10 +307,8 @@ def build_leaf_headless_cmd(
     plugin_source
         PluginSource determining the ``--plugin-dir`` flag. DirectInstall uses the
         path; MarketplaceInstall omits the flag.
-    output_format_value
-        String value passed as ``--output-format`` flag.
-    output_format_required_flags
-        Additional CLI flags required by the output format; deduplicated.
+    output_format
+        OutputFormat enum; ``--output-format`` and any required flags are self-applied.
     add_dirs
         Each entry is appended as ``--add-dir <path>``.
     exit_after_stop_delay_ms
@@ -348,10 +353,7 @@ def build_leaf_headless_cmd(
             pass  # parent session already has the marketplace plugin loaded
         case None:
             pass
-    cmd += [ClaudeFlags.OUTPUT_FORMAT, output_format_value]
-    for flag in output_format_required_flags:
-        if flag not in cmd:
-            cmd.append(flag)
+    _apply_output_format(cmd, output_format)
     for validated_dir in add_dirs:
         cmd.extend([ClaudeFlags.ADD_DIR, validated_dir.path])
 
@@ -366,7 +368,7 @@ def build_food_truck_cmd(
     completion_marker: str,
     model: str | None = None,
     env_extras: Mapping[str, str] | None = None,
-    output_format_value: str = "stream-json",
+    output_format: OutputFormat = OutputFormat.STREAM_JSON,
 ) -> ClaudeHeadlessCmd:
     """Build the complete headless command spec for an L2 food truck session.
 
@@ -401,8 +403,9 @@ def build_food_truck_cmd(
         Used for CAMPAIGN_ID, CAMPAIGN_STATE_PATH, PROJECT_DIR, L2_TOOL_TAGS,
         IDLE_OUTPUT_TIMEOUT. These override baseline but cannot override
         SESSION_TYPE or HEADLESS (applied last).
-    output_format_value
-        String value passed as ``--output-format`` flag. Defaults to ``stream-json``.
+    output_format
+        OutputFormat enum; ``--output-format`` and any required flags are self-applied.
+        Defaults to ``STREAM_JSON``.
     """
     # Prompt transformations: completion directive + cwd anchor + narration suppression.
     # No _ensure_skill_prefix — orchestrator_prompt is a complete system prompt.
@@ -437,7 +440,7 @@ def build_food_truck_cmd(
             cmd += [ClaudeFlags.PLUGIN_DIR, str(p)]
         case MarketplaceInstall(cache_path=cp):
             cmd += [ClaudeFlags.PLUGIN_DIR, str(cp)]
-    cmd += [ClaudeFlags.OUTPUT_FORMAT, output_format_value]
+    _apply_output_format(cmd, output_format)
     cmd += [ClaudeFlags.TOOLS, "AskUserQuestion"]
 
     return ClaudeHeadlessCmd(cmd=cmd, env=spec.env)

--- a/src/autoskillit/execution/headless.py
+++ b/src/autoskillit/execution/headless.py
@@ -556,8 +556,7 @@ async def run_headless_core(
             completion_marker=effective_marker,
             model=resolved_model,
             plugin_source=ctx.plugin_source,
-            output_format_value=cfg.output_format.value,
-            output_format_required_flags=cfg.output_format.required_cli_flags,
+            output_format=cfg.output_format,
             add_dirs=add_dirs,
             exit_after_stop_delay_ms=cfg.exit_after_stop_delay_ms,
             scenario_step_name=step_name,
@@ -702,7 +701,7 @@ class DefaultHeadlessExecutor:
             completion_marker=completion_marker,
             model=resolved_model,
             env_extras=merged_extras or None,
-            output_format_value=cfg.run_skill.output_format.value,
+            output_format=cfg.run_skill.output_format,
         )
 
         effective_timeout = timeout if timeout is not None else fleet_cfg.default_timeout_sec

--- a/tests/arch/test_ast_rules.py
+++ b/tests/arch/test_ast_rules.py
@@ -851,3 +851,20 @@ def test_expand_functions_call_validators() -> None:
         if isinstance(node, ast.FunctionDef) and node.name == "expand_assignments":
             body_source = ast.dump(node)
             assert "validate_refined_plan" in body_source
+
+
+def test_no_build_cmd_accepts_output_format_value_string() -> None:
+    """No cmd builder should accept output_format_value: str — use OutputFormat enum (ARCH-011)."""
+    source = (SRC_ROOT / "execution" / "commands.py").read_text()
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.FunctionDef)
+            and node.name.startswith("build_")
+            and node.name.endswith("_cmd")
+        ):
+            param_names = [a.arg for a in node.args.args + node.args.kwonlyargs]
+            assert "output_format_value" not in param_names, (
+                f"{node.name} still accepts 'output_format_value' (raw string). "
+                f"Use 'output_format: OutputFormat' instead."
+            )

--- a/tests/cli/test_subprocess_env_contracts.py
+++ b/tests/cli/test_subprocess_env_contracts.py
@@ -505,6 +505,10 @@ _CLAUDE_ENV_RULE_ALLOWED: frozenset[tuple[str, str]] = frozenset(
         # as a direct subprocess call because `spec` resolves to a builder return value.
         ("headless.py", "run_headless_core"),
         ("headless.py", "dispatch_food_truck"),
+        # build_headless_resume_cmd constructs cmd = ["claude", ...] then calls
+        # _apply_output_format(cmd, ...) — an in-place list mutation, not a subprocess
+        # launch. The function returns ClaudeHeadlessCmd(cmd=cmd, env=build_claude_env(...)).
+        ("commands.py", "build_headless_resume_cmd"),
     }
 )
 

--- a/tests/execution/test_commands.py
+++ b/tests/execution/test_commands.py
@@ -13,6 +13,7 @@ from autoskillit.core import (
     MarketplaceInstall,
     NamedResume,
     NoResume,
+    OutputFormat,
 )
 from autoskillit.execution.commands import (
     _HEADLESS_EXCLUSIVE_VARS,
@@ -247,8 +248,7 @@ class TestBuildLeafHeadlessCmd:
         completion_marker="DONE",
         model=None,
         plugin_source=DirectInstall(plugin_dir=Path("/plugins")),
-        output_format_value="stream-json",
-        output_format_required_flags=["--verbose"],
+        output_format=OutputFormat.STREAM_JSON,
         add_dirs=[],
         exit_after_stop_delay_ms=2000,
     )
@@ -329,10 +329,9 @@ class TestBuildLeafHeadlessCmd:
         assert "--verbose" in spec.cmd
 
     def test_output_format_required_flags_not_duplicated(self):
-        """If a required flag is already present it must not be added twice."""
-        params = {**self.BASE, "output_format_required_flags": ["--output-format"]}
-        spec = build_leaf_headless_cmd("/investigate foo", **params)
-        assert spec.cmd.count("--output-format") == 1
+        """Required flags must not appear twice even if already present."""
+        spec = build_leaf_headless_cmd("/investigate foo", **self.BASE)
+        assert spec.cmd.count("--verbose") == 1
 
     def test_add_dirs_injected(self):
         from autoskillit.core import ValidatedAddDir
@@ -458,7 +457,7 @@ class TestBuildFoodTruckCmd:
         completion_marker="%%L2_DONE::abc12345%%",
         model=None,
         env_extras=None,
-        output_format_value="stream-json",
+        output_format=OutputFormat.STREAM_JSON,
     )
 
     def test_returns_claude_headless_cmd(self):
@@ -618,7 +617,7 @@ def test_headless_exclusive_vars_contains_max_mcp_output_tokens() -> None:
             completion_marker="%%DONE%%",
             model=None,
             plugin_source=None,
-            output_format_value="stream-json",
+            output_format=OutputFormat.STREAM_JSON,
         ),
         lambda: build_headless_resume_cmd(resume_session_id="abc", prompt="Emit"),
         lambda: build_food_truck_cmd(
@@ -659,7 +658,7 @@ def test_interactive_cmd_env_has_mcp_connection_nonblocking() -> None:
             completion_marker="%%DONE%%",
             model=None,
             plugin_source=None,
-            output_format_value="stream-json",
+            output_format=OutputFormat.STREAM_JSON,
         ),
         lambda: build_headless_resume_cmd(resume_session_id="abc", prompt="Emit"),
         lambda: build_food_truck_cmd(
@@ -697,8 +696,7 @@ def test_leaf_cmd_includes_skill_name() -> None:
         completion_marker="DONE",
         model=None,
         plugin_source=DirectInstall(plugin_dir=Path("/plugins")),
-        output_format_value="stream-json",
-        output_format_required_flags=["--verbose"],
+        output_format=OutputFormat.STREAM_JSON,
         add_dirs=[],
         exit_after_stop_delay_ms=2000,
     )
@@ -712,8 +710,7 @@ def test_leaf_cmd_skill_name_strips_namespace() -> None:
         completion_marker="DONE",
         model=None,
         plugin_source=DirectInstall(plugin_dir=Path("/plugins")),
-        output_format_value="stream-json",
-        output_format_required_flags=["--verbose"],
+        output_format=OutputFormat.STREAM_JSON,
         add_dirs=[],
         exit_after_stop_delay_ms=2000,
     )
@@ -727,8 +724,7 @@ def test_leaf_cmd_skill_name_empty_for_non_slash() -> None:
         completion_marker="DONE",
         model=None,
         plugin_source=DirectInstall(plugin_dir=Path("/plugins")),
-        output_format_value="stream-json",
-        output_format_required_flags=["--verbose"],
+        output_format=OutputFormat.STREAM_JSON,
         add_dirs=[],
         exit_after_stop_delay_ms=2000,
     )
@@ -741,8 +737,7 @@ class TestBuildLeafAllowedWritePrefix:
         completion_marker="DONE",
         model=None,
         plugin_source=DirectInstall(plugin_dir=Path("/plugins")),
-        output_format_value="stream-json",
-        output_format_required_flags=["--verbose"],
+        output_format=OutputFormat.STREAM_JSON,
         add_dirs=[],
         exit_after_stop_delay_ms=2000,
     )

--- a/tests/execution/test_commands.py
+++ b/tests/execution/test_commands.py
@@ -528,6 +528,14 @@ class TestBuildFoodTruckCmd:
         idx = spec.cmd.index(ClaudeFlags.OUTPUT_FORMAT)
         assert spec.cmd[idx + 1] == "stream-json"
 
+    def test_output_format_required_flags_appended(self):
+        spec = build_food_truck_cmd(**self.BASE)
+        assert "--verbose" in spec.cmd
+
+    def test_output_format_required_flags_not_duplicated(self):
+        spec = build_food_truck_cmd(**self.BASE)
+        assert spec.cmd.count("--verbose") == 1
+
     def test_completion_marker_in_prompt(self):
         spec = build_food_truck_cmd(**self.BASE)
         prompt_idx = spec.cmd.index(ClaudeFlags.PRINT) + 1

--- a/tests/execution/test_output_format_contract.py
+++ b/tests/execution/test_output_format_contract.py
@@ -12,14 +12,21 @@ These tests enforce the format-data contract that prevents the class of bug
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 
 from autoskillit.core.types import (
     ChannelConfirmation,
+    DirectInstall,
     OutputFormat,
     SubprocessResult,
     TerminationReason,
+)
+from autoskillit.execution.commands import (
+    build_food_truck_cmd,
+    build_headless_resume_cmd,
+    build_leaf_headless_cmd,
 )
 from autoskillit.execution.headless import _build_skill_result
 from autoskillit.execution.session import (
@@ -215,22 +222,83 @@ class TestOutputFormatCliRequirements:
             assert isinstance(flags, tuple), f"{fmt.name} returned {type(flags)}, expected tuple"
 
     def test_command_assembly_satisfies_format_requirements(self):
-        """Assembled command must contain all flags required by the chosen format.
-
-        Builds a command the same way run_headless_core does, then asserts
-        every flag from the format's required_cli_flags is present.
-        """
-        from autoskillit.execution.commands import build_headless_cmd
-
+        """Actual builders must produce commands containing all required flags."""
         fmt = OutputFormat.STREAM_JSON
-        spec = build_headless_cmd("Use /investigate test", model=None)
-        cmd = spec.cmd + ["--plugin-dir", "/fake", "--output-format", fmt.value]
-        # Apply required flags (mirrors run_headless_core logic)
+        spec = build_leaf_headless_cmd(
+            "/investigate foo",
+            cwd="/tmp",
+            completion_marker="%%DONE%%",
+            model=None,
+            plugin_source=None,
+            output_format=fmt,
+        )
         for flag in fmt.required_cli_flags:
-            if flag not in cmd:
-                cmd.append(flag)
+            assert flag in spec.cmd, f"Missing required flag {flag} in leaf builder"
+
+
+class TestAllBuildersEnforceOutputFormatFlags:
+    """Every cmd builder that accepts OutputFormat must self-apply required_cli_flags."""
+
+    @pytest.mark.parametrize("fmt", list(OutputFormat))
+    def test_leaf_builder_satisfies_format_requirements(self, fmt: OutputFormat):
+        spec = build_leaf_headless_cmd(
+            "/investigate foo",
+            cwd="/tmp",
+            completion_marker="%%DONE%%",
+            model=None,
+            plugin_source=None,
+            output_format=fmt,
+        )
         for flag in fmt.required_cli_flags:
-            assert flag in cmd, f"Missing required flag {flag} in assembled command"
+            assert flag in spec.cmd
+
+    @pytest.mark.parametrize("fmt", list(OutputFormat))
+    def test_food_truck_builder_satisfies_format_requirements(self, fmt: OutputFormat):
+        spec = build_food_truck_cmd(
+            orchestrator_prompt="Orchestrator",
+            plugin_source=DirectInstall(plugin_dir=Path("/p")),
+            cwd="/tmp",
+            completion_marker="%%DONE%%",
+            output_format=fmt,
+        )
+        for flag in fmt.required_cli_flags:
+            assert flag in spec.cmd
+
+    @pytest.mark.parametrize("fmt", list(OutputFormat))
+    def test_resume_builder_satisfies_format_requirements(self, fmt: OutputFormat):
+        spec = build_headless_resume_cmd(
+            resume_session_id="abc",
+            prompt="Emit",
+            output_format=fmt,
+        )
+        for flag in fmt.required_cli_flags:
+            assert flag in spec.cmd
+
+
+def test_all_headless_builders_handle_output_format():
+    """Every build_*_cmd function accepting output_format must produce correct flags."""
+    import ast
+    import importlib
+    import inspect
+
+    mod = importlib.import_module("autoskillit.execution.commands")
+    source = inspect.getsource(mod)
+    tree = ast.parse(source)
+
+    builders_with_format = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.FunctionDef)
+            and node.name.startswith("build_")
+            and node.name.endswith("_cmd")
+        ):
+            params = [a.arg for a in node.args.args + node.args.kwonlyargs]
+            if "output_format" in params:
+                builders_with_format.append(node.name)
+
+    assert len(builders_with_format) >= 3, (
+        f"Expected at least 3 builders with output_format, found {builders_with_format}"
+    )
 
 
 class TestChannelDefaultCoverage:

--- a/tests/execution/test_recording.py
+++ b/tests/execution/test_recording.py
@@ -9,7 +9,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from autoskillit.core.types import DirectInstall, SubprocessRunner, TerminationReason
+from autoskillit.core.types import DirectInstall, OutputFormat, SubprocessRunner, TerminationReason
 from autoskillit.execution.commands import build_leaf_headless_cmd
 from autoskillit.execution.recording import (
     RecordingSubprocessRunner,
@@ -176,7 +176,7 @@ _BASE_CMD_ARGS = dict(
     completion_marker="DONE",
     model=None,
     plugin_source=DirectInstall(plugin_dir=Path("/plugins")),
-    output_format_value="stream-json",
+    output_format=OutputFormat.STREAM_JSON,
 )
 
 


### PR DESCRIPTION
## Summary

`build_food_truck_cmd` was forked from `build_leaf_headless_cmd` but the `output_format_required_flags` mechanism was never ported. The root cause is not the missing parameter — it's that the cmd builder API accepts `output_format_value: str` (a raw string) and `output_format_required_flags: Sequence[str]` as **separate, independently forgettable parameters**. The caller must remember to pass both in lockstep. The architectural fix: accept `OutputFormat` (the enum) instead of a raw string, and let each builder self-apply `required_cli_flags` from the enum's property. This makes it structurally impossible to pass a format without its required flags.

Closes #1655

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260502-225239-870350/.autoskillit/temp/rectify/rectify_output_format_flag_enforcement_2026-05-02_225239.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| rectify | 59 | 11.0k | 532.8k | 119.3k | 1 | 4m 53s |
| dry_walkthrough | 1.7k | 8.1k | 695.0k | 161.3k | 1 | 5m 28s |
| implement | 105 | 22.5k | 4.5M | 205.7k | 1 | 8m 6s |
| prepare_pr | 42 | 5.0k | 117.6k | 101.4k | 1 | 2m 3s |
| compose_pr | 23 | 1.5k | 145.8k | 35.4k | 1 | 40s |
| review_pr | 28 | 16.3k | 416.5k | 72.6k | 1 | 4m 36s |
| **Total** | 2.0k | 64.3k | 6.4M | 695.7k | | 25m 47s |
## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| build_execution_map | 603 | 297.7 | 73.0 | 5.0 |
| plan | 0 | — | — | — |
| **Total** | **603** | 3441.7 | 512.6 | 33.1 |