### PR TITLE
Implementation Plan: Record/Replay System — Capture Ephemeral Skill Dir Contents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,7 @@ generic_automation_mcp/
 │   ├── anomaly_detection.py #   Post-hoc anomaly detection over snapshots
 │   ├── session_log.py       #   XDG-aware session diagnostics log writer
 │   ├── recording.py         #   Record/replay subprocess runners via api-simulator
+│   ├── _recording_skills.py #   Skill dir snapshot/restore for record/replay sessions
 │   ├── process.py           #   Facade re-exporting from _process_*.py
 │   ├── _process_io.py
 │   ├── _process_jsonl.py

--- a/src/autoskillit/execution/__init__.py
+++ b/src/autoskillit/execution/__init__.py
@@ -10,6 +10,11 @@ from autoskillit.execution._process_kill import (
     async_kill_process_tree,
     kill_process_tree,
 )
+from autoskillit.execution._recording_skills import (
+    restore_skill_snapshot,
+    scan_skill_snapshots,
+    snapshot_skill_dir,
+)
 from autoskillit.execution.anomaly_detection import (
     AnomalyKind,
     AnomalySeverity,
@@ -133,6 +138,9 @@ __all__ = [
     "REPLAY_SCENARIO_ENV",
     "REPLAY_SCENARIO_DIR_ENV",
     "SCENARIO_STEP_NAME_ENV",
+    "restore_skill_snapshot",
+    "scan_skill_snapshots",
+    "snapshot_skill_dir",
     # quota
     "QUOTA_CACHE_SCHEMA_VERSION",
     "QuotaStatus",

--- a/src/autoskillit/execution/_recording_skills.py
+++ b/src/autoskillit/execution/_recording_skills.py
@@ -6,11 +6,11 @@ import hashlib
 import json
 import re
 import shutil
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from autoskillit.core import ValidatedAddDir
+from autoskillit.core import ValidatedAddDir, atomic_write
 
 SKILLS_SNAPSHOT_DIR = "skill_snapshots"
 _EPHEMERAL_SESSION_PATTERN = "autoskillit-sessions"
@@ -50,15 +50,13 @@ def build_skills_manifest(skills_dir: Path) -> dict[str, Any]:
         }
     return {
         "schema_version": 1,
-        "captured_at": datetime.now(tz=timezone.utc).isoformat(),
+        "captured_at": datetime.now(tz=UTC).isoformat(),
         "skill_count": len(skills),
         "skills": skills,
     }
 
 
-def snapshot_skill_dir(
-    scenario_dir: Path, step_name: str, add_dir_path: Path
-) -> Path | None:
+def snapshot_skill_dir(scenario_dir: Path, step_name: str, add_dir_path: Path) -> Path | None:
     """Copy the ephemeral skill dir tree into the scenario dir.
 
     Copies {add_dir_path}/.claude/skills/ →
@@ -83,9 +81,7 @@ def snapshot_skill_dir(
     shutil.copytree(skills_src, dest_skills)
 
     manifest = build_skills_manifest(skills_src)
-    (snapshot_dir / "manifest.json").write_text(
-        json.dumps(manifest, indent=2), encoding="utf-8"
-    )
+    atomic_write(snapshot_dir / "manifest.json", json.dumps(manifest, indent=2))
 
     return snapshot_dir
 
@@ -119,8 +115,4 @@ def scan_skill_snapshots(scenario_dir: Path) -> dict[str, Path]:
     snapshots_root = scenario_dir / SKILLS_SNAPSHOT_DIR
     if not snapshots_root.exists() or not snapshots_root.is_dir():
         return {}
-    return {
-        entry.name: entry
-        for entry in sorted(snapshots_root.iterdir())
-        if entry.is_dir()
-    }
+    return {entry.name: entry for entry in sorted(snapshots_root.iterdir()) if entry.is_dir()}

--- a/src/autoskillit/execution/_recording_skills.py
+++ b/src/autoskillit/execution/_recording_skills.py
@@ -32,6 +32,13 @@ def _extract_ephemeral_add_dir(cmd: list[str]) -> Path | None:
 
 def build_skills_manifest(skills_dir: Path) -> dict[str, Any]:
     """Build a manifest dict from a .claude/skills/ directory."""
+    if not skills_dir.is_dir():
+        return {
+            "schema_version": 1,
+            "captured_at": datetime.now(tz=UTC).isoformat(),
+            "skill_count": 0,
+            "skills": {},
+        }
     skills: dict[str, Any] = {}
     for skill_dir in sorted(skills_dir.iterdir()):
         if not skill_dir.is_dir():

--- a/src/autoskillit/execution/_recording_skills.py
+++ b/src/autoskillit/execution/_recording_skills.py
@@ -3,14 +3,13 @@
 from __future__ import annotations
 
 import hashlib
-import json
 import re
 import shutil
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from autoskillit.core import ValidatedAddDir, atomic_write
+from autoskillit.core import ValidatedAddDir, write_versioned_json
 
 SKILLS_SNAPSHOT_DIR = "skill_snapshots"
 _EPHEMERAL_SESSION_PATTERN = "autoskillit-sessions"
@@ -81,7 +80,7 @@ def snapshot_skill_dir(scenario_dir: Path, step_name: str, add_dir_path: Path) -
     shutil.copytree(skills_src, dest_skills)
 
     manifest = build_skills_manifest(skills_src)
-    atomic_write(snapshot_dir / "manifest.json", json.dumps(manifest, indent=2))
+    write_versioned_json(snapshot_dir / "manifest.json", manifest, 1)
 
     return snapshot_dir
 

--- a/src/autoskillit/execution/_recording_skills.py
+++ b/src/autoskillit/execution/_recording_skills.py
@@ -63,6 +63,8 @@ def snapshot_skill_dir(scenario_dir: Path, step_name: str, add_dir_path: Path) -
     Writes manifest.json alongside the .claude/ dir.
     Returns the snapshot dir path, or None if no skills to snapshot.
     """
+    if not step_name or "/" in step_name or ".." in step_name:
+        raise ValueError(f"Invalid step_name for path construction: {step_name!r}")
     skills_src = add_dir_path / ".claude" / "skills"
     if not skills_src.exists() or not skills_src.is_dir():
         return None

--- a/src/autoskillit/execution/_recording_skills.py
+++ b/src/autoskillit/execution/_recording_skills.py
@@ -86,7 +86,11 @@ def snapshot_skill_dir(scenario_dir: Path, step_name: str, add_dir_path: Path) -
     dest_skills = snapshot_dir / ".claude" / "skills"
     if dest_skills.exists():
         shutil.rmtree(dest_skills)
-    shutil.copytree(skills_src, dest_skills)
+    try:
+        shutil.copytree(skills_src, dest_skills)
+    except Exception:
+        shutil.rmtree(snapshot_dir, ignore_errors=True)
+        raise
 
     manifest = build_skills_manifest(skills_src)
     write_versioned_json(snapshot_dir / "manifest.json", manifest, 1)

--- a/src/autoskillit/execution/_recording_skills.py
+++ b/src/autoskillit/execution/_recording_skills.py
@@ -113,9 +113,10 @@ def restore_skill_snapshot(
 
     session_dir = ephemeral_root / session_id
     dest_skills = session_dir / ".claude" / "skills"
-    dest_skills.mkdir(parents=True, exist_ok=True)
+    shutil.rmtree(dest_skills, ignore_errors=True)
+    dest_skills.parent.mkdir(parents=True, exist_ok=True)
 
-    shutil.copytree(skills_src, dest_skills, dirs_exist_ok=True)
+    shutil.copytree(skills_src, dest_skills)
     return ValidatedAddDir(path=str(session_dir))
 
 

--- a/src/autoskillit/execution/_recording_skills.py
+++ b/src/autoskillit/execution/_recording_skills.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from autoskillit.core import ValidatedAddDir, write_versioned_json
 
-SKILLS_SNAPSHOT_DIR = "skill_snapshots"
+SKILLS_SNAPSHOT_DIR = "skill-snapshots"
 _EPHEMERAL_SESSION_PATTERN = "autoskillit-sessions"
 _GATED_PATTERN = re.compile(r"disable-model-invocation\s*:\s*true", re.IGNORECASE)
 
@@ -59,7 +59,7 @@ def snapshot_skill_dir(scenario_dir: Path, step_name: str, add_dir_path: Path) -
     """Copy the ephemeral skill dir tree into the scenario dir.
 
     Copies {add_dir_path}/.claude/skills/ →
-           {scenario_dir}/skill_snapshots/{step_name}/.claude/skills/
+           {scenario_dir}/skill-snapshots/{step_name}/.claude/skills/
     Writes manifest.json alongside the .claude/ dir.
     Returns the snapshot dir path, or None if no skills to snapshot.
     """
@@ -107,7 +107,7 @@ def restore_skill_snapshot(
 
 
 def scan_skill_snapshots(scenario_dir: Path) -> dict[str, Path]:
-    """Scan {scenario_dir}/skill_snapshots/ for per-step snapshot dirs.
+    """Scan {scenario_dir}/skill-snapshots/ for per-step snapshot dirs.
 
     Returns {step_name: snapshot_path} for each subdirectory.
     """

--- a/src/autoskillit/execution/_recording_skills.py
+++ b/src/autoskillit/execution/_recording_skills.py
@@ -116,7 +116,11 @@ def restore_skill_snapshot(
     shutil.rmtree(dest_skills, ignore_errors=True)
     dest_skills.parent.mkdir(parents=True, exist_ok=True)
 
-    shutil.copytree(skills_src, dest_skills)
+    try:
+        shutil.copytree(skills_src, dest_skills)
+    except Exception:
+        shutil.rmtree(dest_skills, ignore_errors=True)
+        raise
     return ValidatedAddDir(path=str(session_dir))
 
 

--- a/src/autoskillit/execution/_recording_skills.py
+++ b/src/autoskillit/execution/_recording_skills.py
@@ -1,0 +1,126 @@
+"""Snapshot and restore ephemeral skill directories for record/replay sessions."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from autoskillit.core import ValidatedAddDir
+
+SKILLS_SNAPSHOT_DIR = "skill_snapshots"
+_EPHEMERAL_SESSION_PATTERN = "autoskillit-sessions"
+_GATED_PATTERN = re.compile(r"disable-model-invocation\s*:\s*true", re.IGNORECASE)
+
+
+def _extract_ephemeral_add_dir(cmd: list[str]) -> Path | None:
+    """Extract the ephemeral skill dir path from --add-dir CLI args.
+
+    Identifies ephemeral dirs by the 'autoskillit-sessions' path component.
+    Returns the first matching --add-dir path, or None.
+    """
+    for i, token in enumerate(cmd):
+        if token == "--add-dir" and i + 1 < len(cmd):
+            candidate = cmd[i + 1]
+            if _EPHEMERAL_SESSION_PATTERN in candidate:
+                return Path(candidate)
+    return None
+
+
+def build_skills_manifest(skills_dir: Path) -> dict[str, Any]:
+    """Build a manifest dict from a .claude/skills/ directory."""
+    skills: dict[str, Any] = {}
+    for skill_dir in sorted(skills_dir.iterdir()):
+        if not skill_dir.is_dir():
+            continue
+        skill_md = skill_dir / "SKILL.md"
+        if not skill_md.exists():
+            continue
+        content = skill_md.read_bytes()
+        sha256 = hashlib.sha256(content).hexdigest()
+        gated = bool(_GATED_PATTERN.search(content.decode("utf-8", errors="replace")))
+        skills[skill_dir.name] = {
+            "content_sha256": sha256,
+            "size_bytes": len(content),
+            "gated": gated,
+        }
+    return {
+        "schema_version": 1,
+        "captured_at": datetime.now(tz=timezone.utc).isoformat(),
+        "skill_count": len(skills),
+        "skills": skills,
+    }
+
+
+def snapshot_skill_dir(
+    scenario_dir: Path, step_name: str, add_dir_path: Path
+) -> Path | None:
+    """Copy the ephemeral skill dir tree into the scenario dir.
+
+    Copies {add_dir_path}/.claude/skills/ →
+           {scenario_dir}/skill_snapshots/{step_name}/.claude/skills/
+    Writes manifest.json alongside the .claude/ dir.
+    Returns the snapshot dir path, or None if no skills to snapshot.
+    """
+    skills_src = add_dir_path / ".claude" / "skills"
+    if not skills_src.exists() or not skills_src.is_dir():
+        return None
+
+    skill_subdirs = [d for d in skills_src.iterdir() if d.is_dir()]
+    if not skill_subdirs:
+        return None
+
+    snapshot_dir = scenario_dir / SKILLS_SNAPSHOT_DIR / step_name
+    snapshot_dir.mkdir(parents=True, exist_ok=True)
+
+    dest_skills = snapshot_dir / ".claude" / "skills"
+    if dest_skills.exists():
+        shutil.rmtree(dest_skills)
+    shutil.copytree(skills_src, dest_skills)
+
+    manifest = build_skills_manifest(skills_src)
+    (snapshot_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+
+    return snapshot_dir
+
+
+def restore_skill_snapshot(
+    snapshot_path: Path, ephemeral_root: Path, session_id: str
+) -> ValidatedAddDir | None:
+    """Restore skill dir from a snapshot into a new ephemeral session dir.
+
+    Copies {snapshot_path}/.claude/skills/ →
+           {ephemeral_root}/{session_id}/.claude/skills/
+    Returns ValidatedAddDir pointing to {ephemeral_root}/{session_id}.
+    """
+    skills_src = snapshot_path / ".claude" / "skills"
+    if not skills_src.exists():
+        return None
+
+    session_dir = ephemeral_root / session_id
+    dest_skills = session_dir / ".claude" / "skills"
+    dest_skills.mkdir(parents=True, exist_ok=True)
+
+    shutil.copytree(skills_src, dest_skills, dirs_exist_ok=True)
+    return ValidatedAddDir(path=str(session_dir))
+
+
+def scan_skill_snapshots(scenario_dir: Path) -> dict[str, Path]:
+    """Scan {scenario_dir}/skill_snapshots/ for per-step snapshot dirs.
+
+    Returns {step_name: snapshot_path} for each subdirectory.
+    """
+    snapshots_root = scenario_dir / SKILLS_SNAPSHOT_DIR
+    if not snapshots_root.exists() or not snapshots_root.is_dir():
+        return {}
+    return {
+        entry.name: entry
+        for entry in sorted(snapshots_root.iterdir())
+        if entry.is_dir()
+    }

--- a/src/autoskillit/execution/recording.py
+++ b/src/autoskillit/execution/recording.py
@@ -74,8 +74,11 @@ class RecordingSubprocessRunner(SubprocessRunner):
         self,
         recorder: ScenarioRecorder,
         inner: SubprocessRunner | None = None,
+        *,
+        scenario_dir: Path | None = None,
     ) -> None:
         self.recorder = recorder
+        self._scenario_dir = scenario_dir
         if inner is None:
             from autoskillit.execution.process import DefaultSubprocessRunner
 
@@ -169,7 +172,11 @@ class RecordingSubprocessRunner(SubprocessRunner):
 
         ephemeral_dir = _extract_ephemeral_add_dir(cmd)
         if ephemeral_dir is not None and step_result.cassette_path:
-            _scenario_dir = Path(step_result.cassette_path).parent.parent
+            _scenario_dir = (
+                self._scenario_dir
+                if self._scenario_dir is not None
+                else Path(step_result.cassette_path).parent.parent
+            )
             _snap = snapshot_skill_dir(_scenario_dir, step_name, ephemeral_dir)
             if _snap:
                 logger.debug("skill_dir_snapshot_written", step=step_name, path=str(_snap))

--- a/src/autoskillit/execution/recording.py
+++ b/src/autoskillit/execution/recording.py
@@ -9,7 +9,21 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from autoskillit.core import SubprocessResult, SubprocessRunner, TerminationReason, get_logger
+from autoskillit.core import (
+    SubprocessResult,
+    SubprocessRunner,
+    TerminationReason,
+    ValidatedAddDir,
+    get_logger,
+)
+from autoskillit.execution._recording_skills import (
+    _extract_ephemeral_add_dir,
+    scan_skill_snapshots,
+    snapshot_skill_dir,
+)
+from autoskillit.execution._recording_skills import (
+    restore_skill_snapshot as _restore_skill_snapshot,
+)
 
 if TYPE_CHECKING:
     from api_simulator.claude import ScenarioPlayer, ScenarioRecorder
@@ -153,6 +167,13 @@ class RecordingSubprocessRunner(SubprocessRunner):
             if cassette_stdout.exists():
                 stdout = cassette_stdout.read_text(encoding="utf-8")
 
+        ephemeral_dir = _extract_ephemeral_add_dir(cmd)
+        if ephemeral_dir is not None and step_result.cassette_path:
+            _scenario_dir = Path(step_result.cassette_path).parent.parent
+            _snap = snapshot_skill_dir(_scenario_dir, step_name, ephemeral_dir)
+            if _snap:
+                logger.debug("skill_dir_snapshot_written", step=step_name, path=str(_snap))
+
         return SubprocessResult(
             returncode=step_result.cassette_exit_code,
             stdout=stdout,
@@ -180,12 +201,23 @@ class ReplayingSubprocessRunner(SubprocessRunner):
         non_session_results: dict[str, dict[str, Any]],
         *,
         player: ScenarioPlayer | None = None,
+        skill_snapshots: dict[str, Path] | None = None,
     ) -> None:
         self._sessions = session_map
         self._non_session = non_session_results
         self.player: ScenarioPlayer | None = player
+        self.skill_snapshots: dict[str, Path] = skill_snapshots or {}
         self.call_log: list[tuple[str, list[str]]] = []
         self._tmp_replay_dir = None
+
+    def restore_skill_snapshot(
+        self, step_name: str, ephemeral_root: Path, session_id: str
+    ) -> ValidatedAddDir | None:
+        """Restore a skill snapshot for step_name into a fresh ephemeral session dir."""
+        snap_path = self.skill_snapshots.get(step_name)
+        if snap_path is None:
+            return None
+        return _restore_skill_snapshot(snap_path, ephemeral_root, session_id)
 
     async def __call__(
         self,
@@ -298,6 +330,9 @@ def build_replay_runner(replay_dir: str) -> ReplayingSubprocessRunner:
         raise
 
     session_map = {k: deque(v) for k, v in raw_map.items()}
-    runner = ReplayingSubprocessRunner(session_map, non_session, player=player)
+    skill_snapshots = scan_skill_snapshots(Path(replay_dir))
+    runner = ReplayingSubprocessRunner(
+        session_map, non_session, player=player, skill_snapshots=skill_snapshots
+    )
     runner._tmp_replay_dir = _tmp_replay_dir
     return runner

--- a/src/autoskillit/pipeline/context.py
+++ b/src/autoskillit/pipeline/context.py
@@ -135,6 +135,7 @@ class ToolContext:
     token_factory: TokenFactory | None = field(default=None)
     fleet_lock: FleetLock | None = field(default=None)
     build_protected_campaign_ids: CampaignProtector | None = field(default=None)
+    ephemeral_root: Path | None = field(default=None)
 
     def __post_init__(self) -> None:
         if self.temp_dir is _MISSING:

--- a/src/autoskillit/pipeline/context.py
+++ b/src/autoskillit/pipeline/context.py
@@ -135,7 +135,7 @@ class ToolContext:
     token_factory: TokenFactory | None = field(default=None)
     fleet_lock: FleetLock | None = field(default=None)
     build_protected_campaign_ids: CampaignProtector | None = field(default=None)
-    ephemeral_root: Path | None = field(default=None)
+    ephemeral_root: Path | None = field(default_factory=lambda: None)
 
     def __post_init__(self) -> None:
         if self.temp_dir is _MISSING:

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -310,6 +310,7 @@ def make_context(
         github_api_log=github_api_log,
         session_skill_manager=session_mgr,
         skill_resolver=provider.resolver,
+        ephemeral_root=ephemeral_root,
         quota_refresh_task=None,
         fleet_lock=(
             fleet_lock

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -242,7 +242,11 @@ def make_context(
                     recorder = make_scenario_recorder(
                         output_dir=scenario_dir, recipe_name=recipe_name
                     )
-                    runner = RecordingSubprocessRunner(recorder=recorder, inner=runner)
+                    runner = RecordingSubprocessRunner(
+                        recorder=recorder,
+                        inner=runner,
+                        scenario_dir=Path(scenario_dir),
+                    )
 
     # Lazy token resolution: config → GITHUB_TOKEN env var → gh CLI → None.
     # The _gh_cli_token() subprocess (up to 5s) is deferred until the first

--- a/src/autoskillit/server/tools_execution.py
+++ b/src/autoskillit/server/tools_execution.py
@@ -418,6 +418,7 @@ async def run_skill(
             step_name
             and _runner is not None
             and getattr(_runner, "skill_snapshots", None)
+            and hasattr(_runner, "restore_skill_snapshot")
             and tool_ctx.ephemeral_root is not None
         ):
             _ephemeral_root = tool_ctx.ephemeral_root

--- a/src/autoskillit/server/tools_execution.py
+++ b/src/autoskillit/server/tools_execution.py
@@ -23,7 +23,6 @@ from autoskillit.core import (
     truncate_text,
     validate_add_dir,
 )
-from autoskillit.execution.recording import ReplayingSubprocessRunner
 from autoskillit.server import mcp
 from autoskillit.server._guards import (
     _check_dry_walkthrough,
@@ -34,7 +33,6 @@ from autoskillit.server._guards import (
 from autoskillit.server._misc import SCENARIO_STEP_NAME_ENV
 from autoskillit.server._notify import _notify, track_response_size
 from autoskillit.server._subprocess import _run_subprocess
-from autoskillit.workspace.session_skills import resolve_ephemeral_root
 
 logger = get_logger(__name__)
 
@@ -415,14 +413,16 @@ async def run_skill(
 
         skill_add_dirs: list[ValidatedAddDir] = []
         replay_snapshot_used = False
+        _runner = tool_ctx.runner
         if (
             step_name
-            and isinstance(tool_ctx.runner, ReplayingSubprocessRunner)
-            and tool_ctx.runner.skill_snapshots
+            and _runner is not None
+            and getattr(_runner, "skill_snapshots", None)
+            and tool_ctx.ephemeral_root is not None
         ):
-            _ephemeral_root = resolve_ephemeral_root()
+            _ephemeral_root = tool_ctx.ephemeral_root
             session_id = f"headless-{uuid4().hex[:12]}"
-            _restored = tool_ctx.runner.restore_skill_snapshot(
+            _restored = _runner.restore_skill_snapshot(  # type: ignore[attr-defined]
                 step_name, _ephemeral_root, session_id
             )
             if _restored is not None:

--- a/src/autoskillit/server/tools_execution.py
+++ b/src/autoskillit/server/tools_execution.py
@@ -23,6 +23,7 @@ from autoskillit.core import (
     truncate_text,
     validate_add_dir,
 )
+from autoskillit.execution.recording import ReplayingSubprocessRunner
 from autoskillit.server import mcp
 from autoskillit.server._guards import (
     _check_dry_walkthrough,
@@ -33,6 +34,7 @@ from autoskillit.server._guards import (
 from autoskillit.server._misc import SCENARIO_STEP_NAME_ENV
 from autoskillit.server._notify import _notify, track_response_size
 from autoskillit.server._subprocess import _run_subprocess
+from autoskillit.workspace.session_skills import resolve_ephemeral_root
 
 logger = get_logger(__name__)
 
@@ -412,7 +414,27 @@ async def run_skill(
         invocation_marker = f"%%ORDER_UP::{uuid4().hex[:8]}%%"
 
         skill_add_dirs: list[ValidatedAddDir] = []
-        if tool_ctx.session_skill_manager is not None:
+        replay_snapshot_used = False
+        if (
+            step_name
+            and isinstance(tool_ctx.runner, ReplayingSubprocessRunner)
+            and tool_ctx.runner.skill_snapshots
+        ):
+            _ephemeral_root = resolve_ephemeral_root()
+            session_id = f"headless-{uuid4().hex[:12]}"
+            _restored = tool_ctx.runner.restore_skill_snapshot(
+                step_name, _ephemeral_root, session_id
+            )
+            if _restored is not None:
+                skill_add_dirs.append(_restored)
+                replay_snapshot_used = True
+                logger.debug(
+                    "replay_skill_snapshot_restored",
+                    step=step_name,
+                    session_id=session_id,
+                )
+
+        if not replay_snapshot_used and tool_ctx.session_skill_manager is not None:
             allow_only: frozenset[str] | None = None
             if target_name:
                 closure = tool_ctx.session_skill_manager.compute_skill_closure(target_name)
@@ -429,7 +451,6 @@ async def run_skill(
             )
             skill_add_dirs.append(session_root)
 
-            # Activate the target skill and its declared dependencies
             if target_name:
                 tool_ctx.session_skill_manager.activate_skill_deps(session_id, target_name)
         try:

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -1033,7 +1033,14 @@ def test_tool_context_service_fields_use_protocol_types() -> None:
     context_path = AUTOSKILLIT_ROOT / "pipeline" / "context.py"
     context_tree = ast.parse(context_path.read_text())
 
-    EXEMPT = {"plugin_source", "config", "active_recipe_packs", "temp_dir", "project_dir"}
+    EXEMPT = {
+        "plugin_source",
+        "config",
+        "active_recipe_packs",
+        "temp_dir",
+        "project_dir",
+        "ephemeral_root",
+    }
     violations: list[str] = []
 
     for node in ast.walk(context_tree):

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -708,7 +708,10 @@ def test_no_subpackage_exceeds_10_files() -> None:
         _headless_git.py extracts git LOC-capture helpers (_capture_git_head_sha,
         _parse_numstat, _compute_loc_changed) from headless.py to keep it under the
         750-line architectural budget, bringing the count to 37.
-        Exempt at 37 files.
+        _recording_skills.py adds snapshot/restore helpers for ephemeral skill dirs in
+        the record/replay system, isolated from recording.py to keep snapshot logic
+        independently testable, bringing the count to 38.
+        Exempt at 38 files.
       core/ — REQ-CNST-003-E4: core/ types split into per-concern type modules
         (_type_enums, _type_protocols_logging, _type_protocols_execution,
         _type_protocols_github, _type_protocols_workspace, _type_protocols_recipe,
@@ -781,7 +784,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
     EXEMPTIONS: dict[str, int] = {
         "server": 25,
         "recipe": 50,
-        "execution": 37,
+        "execution": 38,
         "core": 33,
         "cli": 42,
         "hooks": 29,

--- a/tests/execution/test_recording.py
+++ b/tests/execution/test_recording.py
@@ -465,13 +465,12 @@ def test_build_replay_runner_stores_player_on_runner(tmp_path, monkeypatch):
 
 @pytest.mark.anyio
 async def test_recording_runner_snapshots_skill_dir(tmp_path):
-    """After _record_session, skill_snapshots/{step_name}/ is written under scenario_dir."""
+    """After _record_session, skill-snapshots/{step_name}/ is written under scenario_dir."""
     ephemeral_dir = tmp_path / "autoskillit-sessions" / "headless-snap01"
     skill_file = ephemeral_dir / ".claude" / "skills" / "investigate" / "SKILL.md"
     skill_file.parent.mkdir(parents=True)
     skill_file.write_text("# investigate\n", encoding="utf-8")
 
-    # cassette_path = scenario_dir / "sessions" / step_name
     cassette_path = tmp_path / "sessions" / "investigate"
     cassette_path.mkdir(parents=True)
 
@@ -506,7 +505,7 @@ async def test_recording_runner_snapshots_skill_dir(tmp_path):
 
 @pytest.mark.anyio
 async def test_recording_runner_no_ephemeral_dir_skips_snapshot(tmp_path):
-    """When cmd has no --add-dir, no skill_snapshots/ directory is created."""
+    """When cmd has no --add-dir, no skill-snapshots/ directory is created."""
     cassette_path = tmp_path / "sessions" / "investigate"
     cassette_path.mkdir(parents=True)
 

--- a/tests/execution/test_recording.py
+++ b/tests/execution/test_recording.py
@@ -458,3 +458,109 @@ def test_build_replay_runner_stores_player_on_runner(tmp_path, monkeypatch):
     result = build_replay_runner(str(tmp_path))
     assert result.player is mock_player
     mock_atexit.assert_not_called()
+
+
+# --- T-REC-SNAP: RecordingSubprocessRunner snapshots skill dir after recording ---
+
+
+@pytest.mark.anyio
+async def test_recording_runner_snapshots_skill_dir(tmp_path):
+    """After _record_session, skill_snapshots/{step_name}/ is written under scenario_dir."""
+    ephemeral_dir = tmp_path / "autoskillit-sessions" / "headless-snap01"
+    skill_file = ephemeral_dir / ".claude" / "skills" / "investigate" / "SKILL.md"
+    skill_file.parent.mkdir(parents=True)
+    skill_file.write_text("# investigate\n", encoding="utf-8")
+
+    # cassette_path = scenario_dir / "sessions" / step_name
+    cassette_path = tmp_path / "sessions" / "investigate"
+    cassette_path.mkdir(parents=True)
+
+    mock_recorder = Mock()
+    mock_recorder.record_step.return_value = FakeStepResult(
+        cassette_exit_code=0,
+        cassette_path=str(cassette_path),
+        cassette_duration_ms=1000,
+    )
+
+    runner = RecordingSubprocessRunner(recorder=mock_recorder, inner=Mock())
+    cmd = [
+        "claude",
+        "--add-dir",
+        str(ephemeral_dir),
+        "--model",
+        "sonnet",
+        "--print",
+        "go",
+    ]
+    env = {"SCENARIO_STEP_NAME": "investigate"}
+    await runner(cmd, cwd=tmp_path, timeout=60, env=env, pty_mode=True)
+
+    snapshot_dir = tmp_path / "skill_snapshots" / "investigate"
+    assert snapshot_dir.exists(), "skill_snapshots/investigate/ not created"
+    assert (snapshot_dir / ".claude" / "skills" / "investigate" / "SKILL.md").exists()
+    assert (snapshot_dir / "manifest.json").exists()
+
+
+# --- T-REC-SNAP-SKIP: no --add-dir → no skill_snapshots created ---
+
+
+@pytest.mark.anyio
+async def test_recording_runner_no_ephemeral_dir_skips_snapshot(tmp_path):
+    """When cmd has no --add-dir, no skill_snapshots/ directory is created."""
+    cassette_path = tmp_path / "sessions" / "investigate"
+    cassette_path.mkdir(parents=True)
+
+    mock_recorder = Mock()
+    mock_recorder.record_step.return_value = FakeStepResult(
+        cassette_exit_code=0,
+        cassette_path=str(cassette_path),
+        cassette_duration_ms=500,
+    )
+
+    runner = RecordingSubprocessRunner(recorder=mock_recorder, inner=Mock())
+    cmd = ["claude", "--model", "sonnet", "--print", "go"]
+    env = {"SCENARIO_STEP_NAME": "investigate"}
+    await runner(cmd, cwd=tmp_path, timeout=60, env=env, pty_mode=True)
+
+    assert not (tmp_path / "skill_snapshots").exists()
+
+
+# --- T-REPLAY-SNAP: ReplayingSubprocessRunner stores skill_snapshots ---
+
+
+def test_replaying_runner_stores_skill_snapshots(tmp_path):
+    """ReplayingSubprocessRunner.skill_snapshots is populated when provided."""
+    snap_path = tmp_path / "skill_snapshots" / "investigate"
+    snap_path.mkdir(parents=True)
+    skill_snapshots = {"investigate": snap_path}
+
+    runner = ReplayingSubprocessRunner({}, {}, skill_snapshots=skill_snapshots)
+
+    assert runner.skill_snapshots == {"investigate": snap_path}
+
+
+# --- T-REPLAY-RESTORE: ReplayingSubprocessRunner.restore_skill_snapshot delegates correctly ---
+
+
+def test_replaying_runner_restore_delegates_correctly(tmp_path):
+    """restore_skill_snapshot returns ValidatedAddDir when snapshot exists and files are copied."""
+    snap_dir = tmp_path / "snapshot"
+    skill_md = snap_dir / ".claude" / "skills" / "investigate" / "SKILL.md"
+    skill_md.parent.mkdir(parents=True)
+    skill_md.write_text("# investigate\n", encoding="utf-8")
+
+    runner = ReplayingSubprocessRunner({}, {}, skill_snapshots={"investigate": snap_dir})
+
+    ephemeral_root = tmp_path / "sessions"
+    result = runner.restore_skill_snapshot("investigate", ephemeral_root, "headless-xyz")
+
+    assert result is not None
+    session_dir = ephemeral_root / "headless-xyz"
+    assert (session_dir / ".claude" / "skills" / "investigate" / "SKILL.md").exists()
+
+
+def test_replaying_runner_restore_missing_step_returns_none(tmp_path):
+    """restore_skill_snapshot returns None when no snapshot for step_name."""
+    runner = ReplayingSubprocessRunner({}, {}, skill_snapshots={})
+    result = runner.restore_skill_snapshot("missing", tmp_path / "sessions", "headless-abc")
+    assert result is None

--- a/tests/execution/test_recording.py
+++ b/tests/execution/test_recording.py
@@ -495,8 +495,8 @@ async def test_recording_runner_snapshots_skill_dir(tmp_path):
     env = {"SCENARIO_STEP_NAME": "investigate"}
     await runner(cmd, cwd=tmp_path, timeout=60, env=env, pty_mode=True)
 
-    snapshot_dir = tmp_path / "skill_snapshots" / "investigate"
-    assert snapshot_dir.exists(), "skill_snapshots/investigate/ not created"
+    snapshot_dir = tmp_path / "skill-snapshots" / "investigate"
+    assert snapshot_dir.exists(), "skill-snapshots/investigate/ not created"
     assert (snapshot_dir / ".claude" / "skills" / "investigate" / "SKILL.md").exists()
     assert (snapshot_dir / "manifest.json").exists()
 
@@ -522,7 +522,7 @@ async def test_recording_runner_no_ephemeral_dir_skips_snapshot(tmp_path):
     env = {"SCENARIO_STEP_NAME": "investigate"}
     await runner(cmd, cwd=tmp_path, timeout=60, env=env, pty_mode=True)
 
-    assert not (tmp_path / "skill_snapshots").exists()
+    assert not (tmp_path / "skill-snapshots").exists()
 
 
 # --- T-REPLAY-SNAP: ReplayingSubprocessRunner stores skill_snapshots ---
@@ -530,7 +530,7 @@ async def test_recording_runner_no_ephemeral_dir_skips_snapshot(tmp_path):
 
 def test_replaying_runner_stores_skill_snapshots(tmp_path):
     """ReplayingSubprocessRunner.skill_snapshots is populated when provided."""
-    snap_path = tmp_path / "skill_snapshots" / "investigate"
+    snap_path = tmp_path / "skill-snapshots" / "investigate"
     snap_path.mkdir(parents=True)
     skill_snapshots = {"investigate": snap_path}
 

--- a/tests/execution/test_recording_skills.py
+++ b/tests/execution/test_recording_skills.py
@@ -232,14 +232,14 @@ def test_manifest_detects_gated_skills(tmp_path: Path) -> None:
 
 def test_scan_skill_snapshots_finds_steps(tmp_path: Path) -> None:
     scenario_dir = tmp_path / "scenario"
-    (scenario_dir / "skill_snapshots" / "step_a").mkdir(parents=True)
-    (scenario_dir / "skill_snapshots" / "step_b").mkdir(parents=True)
+    (scenario_dir / "skill-snapshots" / "step_a").mkdir(parents=True)
+    (scenario_dir / "skill-snapshots" / "step_b").mkdir(parents=True)
 
     result = scan_skill_snapshots(scenario_dir)
 
     assert "step_a" in result
     assert "step_b" in result
-    assert result["step_a"] == scenario_dir / "skill_snapshots" / "step_a"
+    assert result["step_a"] == scenario_dir / "skill-snapshots" / "step_a"
 
 
 # --- T-SCAN-2: scan returns empty dict when no skill_snapshots dir ---

--- a/tests/execution/test_recording_skills.py
+++ b/tests/execution/test_recording_skills.py
@@ -1,0 +1,251 @@
+"""Tests for _recording_skills: snapshot_skill_dir, restore_skill_snapshot, scan_skill_snapshots."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from autoskillit.execution._recording_skills import (
+    _extract_ephemeral_add_dir,
+    build_skills_manifest,
+    restore_skill_snapshot,
+    scan_skill_snapshots,
+    snapshot_skill_dir,
+)
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+
+def _make_skill(skills_dir: Path, name: str, content: str = "# SKILL\n") -> Path:
+    skill_dir = skills_dir / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+    return skill_dir
+
+
+def _make_ephemeral_dir(tmp_path: Path, *skill_names: str) -> Path:
+    add_dir = tmp_path / "autoskillit-sessions" / "headless-abc123"
+    skills_dir = add_dir / ".claude" / "skills"
+    skills_dir.mkdir(parents=True, exist_ok=True)
+    for name in skill_names:
+        _make_skill(skills_dir, name)
+    return add_dir
+
+
+# --- T-SNAP-1: snapshot copies full skill tree ---
+
+
+def test_snapshot_skill_dir_copies_tree(tmp_path: Path) -> None:
+    add_dir = _make_ephemeral_dir(tmp_path, "investigate", "implement")
+    scenario_dir = tmp_path / "scenario"
+    scenario_dir.mkdir()
+
+    result = snapshot_skill_dir(scenario_dir, "investigate", add_dir)
+
+    assert result is not None
+    assert (result / ".claude" / "skills" / "investigate" / "SKILL.md").exists()
+    assert (result / ".claude" / "skills" / "implement" / "SKILL.md").exists()
+
+
+# --- T-SNAP-2: snapshot writes manifest.json ---
+
+
+def test_snapshot_skill_dir_writes_manifest(tmp_path: Path) -> None:
+    add_dir = _make_ephemeral_dir(tmp_path, "investigate")
+    scenario_dir = tmp_path / "scenario"
+    scenario_dir.mkdir()
+
+    result = snapshot_skill_dir(scenario_dir, "investigate", add_dir)
+
+    assert result is not None
+    manifest_path = result / "manifest.json"
+    assert manifest_path.exists()
+    manifest = json.loads(manifest_path.read_text())
+    assert manifest["schema_version"] == 1
+    assert "captured_at" in manifest
+    assert manifest["skill_count"] == 1
+    assert "investigate" in manifest["skills"]
+    entry = manifest["skills"]["investigate"]
+    assert "content_sha256" in entry
+    assert "size_bytes" in entry
+
+
+# --- T-SNAP-3: empty skills dir returns None ---
+
+
+def test_snapshot_skill_dir_empty_skills_returns_none(tmp_path: Path) -> None:
+    add_dir = tmp_path / "autoskillit-sessions" / "headless-abc"
+    (add_dir / ".claude" / "skills").mkdir(parents=True)
+    scenario_dir = tmp_path / "scenario"
+    scenario_dir.mkdir()
+
+    result = snapshot_skill_dir(scenario_dir, "step", add_dir)
+
+    assert result is None
+
+
+# --- T-SNAP-4: missing .claude/skills returns None ---
+
+
+def test_snapshot_skill_dir_no_skills_subdir_returns_none(tmp_path: Path) -> None:
+    add_dir = tmp_path / "autoskillit-sessions" / "headless-abc"
+    add_dir.mkdir(parents=True)
+    scenario_dir = tmp_path / "scenario"
+    scenario_dir.mkdir()
+
+    result = snapshot_skill_dir(scenario_dir, "step", add_dir)
+
+    assert result is None
+
+
+# --- T-REST-1: restore populates target dir and returns ValidatedAddDir ---
+
+
+def test_restore_skill_snapshot_populates_target(tmp_path: Path) -> None:
+    snapshot_dir = tmp_path / "snapshot"
+    skills_src = snapshot_dir / ".claude" / "skills" / "investigate"
+    skills_src.mkdir(parents=True)
+    (skills_src / "SKILL.md").write_text("# investigate\n", encoding="utf-8")
+
+    ephemeral_root = tmp_path / "sessions"
+    result = restore_skill_snapshot(snapshot_dir, ephemeral_root, "headless-test123")
+
+    assert result is not None
+    session_dir = ephemeral_root / "headless-test123"
+    assert (session_dir / ".claude" / "skills" / "investigate" / "SKILL.md").exists()
+    assert result.path == str(session_dir)
+
+
+# --- T-REST-2: snapshot path with no .claude/skills returns None ---
+
+
+def test_restore_skill_snapshot_no_snapshot_returns_none(tmp_path: Path) -> None:
+    snapshot_dir = tmp_path / "empty-snapshot"
+    snapshot_dir.mkdir()
+    ephemeral_root = tmp_path / "sessions"
+
+    result = restore_skill_snapshot(snapshot_dir, ephemeral_root, "headless-missing")
+
+    assert result is None
+
+
+# --- T-REST-3: restore preserves gated and ungated skill content byte-for-byte ---
+
+
+def test_restore_preserves_gated_state(tmp_path: Path) -> None:
+    snapshot_dir = tmp_path / "snapshot"
+    skills_src = snapshot_dir / ".claude" / "skills"
+    skills_src.mkdir(parents=True)
+
+    ungated_dir = skills_src / "open-skill"
+    ungated_dir.mkdir()
+    ungated_content = "# open skill\nNormal skill."
+    (ungated_dir / "SKILL.md").write_text(ungated_content, encoding="utf-8")
+
+    gated_dir = skills_src / "gated-skill"
+    gated_dir.mkdir()
+    gated_content = "# gated skill\ndisable-model-invocation: true\n"
+    (gated_dir / "SKILL.md").write_text(gated_content, encoding="utf-8")
+
+    ephemeral_root = tmp_path / "sessions"
+    result = restore_skill_snapshot(snapshot_dir, ephemeral_root, "headless-abc")
+
+    assert result is not None
+    session_dir = Path(result.path)
+    restored_open = (session_dir / ".claude" / "skills" / "open-skill" / "SKILL.md").read_text()
+    restored_gated = (session_dir / ".claude" / "skills" / "gated-skill" / "SKILL.md").read_text()
+    assert restored_open == ungated_content
+    assert restored_gated == gated_content
+
+
+# --- T-EXTRACT-1: extracts ephemeral --add-dir path ---
+
+
+def test_extract_ephemeral_add_dir_finds_shm_path() -> None:
+    cmd = ["claude", "--add-dir", "/dev/shm/autoskillit-sessions/headless-abc123", "--print", "go"]
+    result = _extract_ephemeral_add_dir(cmd)
+    assert result == Path("/dev/shm/autoskillit-sessions/headless-abc123")
+
+
+# --- T-EXTRACT-2: skips non-ephemeral --add-dir ---
+
+
+def test_extract_ephemeral_add_dir_skips_non_ephemeral() -> None:
+    cmd = ["claude", "--add-dir", "/home/user/project", "--print", "go"]
+    result = _extract_ephemeral_add_dir(cmd)
+    assert result is None
+
+
+# --- T-EXTRACT-3: multiple --add-dir, returns only ephemeral ---
+
+
+def test_extract_ephemeral_add_dir_multiple_dirs() -> None:
+    cmd = [
+        "claude",
+        "--add-dir", "/home/user/project",
+        "--add-dir", "/tmp/autoskillit-sessions/headless-xyz",
+        "--print", "go",
+    ]
+    result = _extract_ephemeral_add_dir(cmd)
+    assert result == Path("/tmp/autoskillit-sessions/headless-xyz")
+
+
+# --- T-MANIFEST-1: build_skills_manifest structure ---
+
+
+def test_build_skills_manifest_structure(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "skills"
+    _make_skill(skills_dir, "investigate")
+    _make_skill(skills_dir, "implement")
+
+    manifest = build_skills_manifest(skills_dir)
+
+    assert manifest["schema_version"] == 1
+    assert manifest["skill_count"] == 2
+    assert "investigate" in manifest["skills"]
+    assert "implement" in manifest["skills"]
+    assert "content_sha256" in manifest["skills"]["investigate"]
+    assert "size_bytes" in manifest["skills"]["investigate"]
+
+
+# --- T-MANIFEST-2: manifest detects gated skills ---
+
+
+def test_manifest_detects_gated_skills(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "skills"
+    _make_skill(skills_dir, "normal", "# normal skill")
+    _make_skill(skills_dir, "gated", "# gated\ndisable-model-invocation: true\n")
+
+    manifest = build_skills_manifest(skills_dir)
+
+    assert manifest["skills"]["normal"]["gated"] is False
+    assert manifest["skills"]["gated"]["gated"] is True
+
+
+# --- T-SCAN-1: scan finds step subdirectories ---
+
+
+def test_scan_skill_snapshots_finds_steps(tmp_path: Path) -> None:
+    scenario_dir = tmp_path / "scenario"
+    (scenario_dir / "skill_snapshots" / "step_a").mkdir(parents=True)
+    (scenario_dir / "skill_snapshots" / "step_b").mkdir(parents=True)
+
+    result = scan_skill_snapshots(scenario_dir)
+
+    assert "step_a" in result
+    assert "step_b" in result
+    assert result["step_a"] == scenario_dir / "skill_snapshots" / "step_a"
+
+
+# --- T-SCAN-2: scan returns empty dict when no skill_snapshots dir ---
+
+
+def test_scan_skill_snapshots_empty_returns_empty_dict(tmp_path: Path) -> None:
+    scenario_dir = tmp_path / "scenario"
+    scenario_dir.mkdir()
+
+    result = scan_skill_snapshots(scenario_dir)
+
+    assert result == {}

--- a/tests/execution/test_recording_skills.py
+++ b/tests/execution/test_recording_skills.py
@@ -1,4 +1,4 @@
-"""Tests for _recording_skills: snapshot_skill_dir, restore_skill_snapshot, scan_skill_snapshots."""
+"""Tests for _recording_skills snapshot/restore helpers."""
 
 from __future__ import annotations
 
@@ -184,9 +184,12 @@ def test_extract_ephemeral_add_dir_skips_non_ephemeral() -> None:
 def test_extract_ephemeral_add_dir_multiple_dirs() -> None:
     cmd = [
         "claude",
-        "--add-dir", "/home/user/project",
-        "--add-dir", "/tmp/autoskillit-sessions/headless-xyz",
-        "--print", "go",
+        "--add-dir",
+        "/home/user/project",
+        "--add-dir",
+        "/tmp/autoskillit-sessions/headless-xyz",
+        "--print",
+        "go",
     ]
     result = _extract_ephemeral_add_dir(cmd)
     assert result == Path("/tmp/autoskillit-sessions/headless-xyz")

--- a/tests/server/test_factory_recording.py
+++ b/tests/server/test_factory_recording.py
@@ -207,7 +207,7 @@ def test_build_replay_runner_scans_skill_snapshots(tmp_path, monkeypatch):
 
     replay_dir = tmp_path / "replay"
     replay_dir.mkdir()
-    (replay_dir / "skill_snapshots" / "investigate").mkdir(parents=True)
+    (replay_dir / "skill-snapshots" / "investigate").mkdir(parents=True)
 
     mock_scenario = Mock()
     mock_scenario.step_sequence = []
@@ -224,7 +224,7 @@ def test_build_replay_runner_scans_skill_snapshots(tmp_path, monkeypatch):
     runner = build_replay_runner(str(replay_dir))
 
     assert "investigate" in runner.skill_snapshots
-    assert runner.skill_snapshots["investigate"] == replay_dir / "skill_snapshots" / "investigate"
+    assert runner.skill_snapshots["investigate"] == replay_dir / "skill-snapshots" / "investigate"
 
 
 # --- T-RUN-SKILL-REPLAY: snapshot present → init_session NOT called ---

--- a/tests/server/test_factory_recording.py
+++ b/tests/server/test_factory_recording.py
@@ -262,7 +262,7 @@ async def test_run_skill_replay_uses_snapshot_over_init_session(tool_ctx, tmp_pa
     mock_ssm.init_session.assert_not_called()
     assert len(executor.calls) == 1
     add_dir_paths = [d.path for d in executor.calls[0].add_dirs]
-    assert any("sessions" in p for p in add_dir_paths)
+    assert any(p.startswith(str(ephemeral_root)) for p in add_dir_paths)
 
 
 # --- T-RUN-SKILL-REPLAY-FALLBACK: no snapshot → init_session IS called ---

--- a/tests/server/test_factory_recording.py
+++ b/tests/server/test_factory_recording.py
@@ -254,10 +254,7 @@ async def test_run_skill_replay_uses_snapshot_over_init_session(tool_ctx, tmp_pa
     tool_ctx.executor = executor
 
     ephemeral_root = tmp_path / "sessions"
-    monkeypatch.setattr(
-        "autoskillit.server.tools_execution.resolve_ephemeral_root",
-        lambda: ephemeral_root,
-    )
+    tool_ctx.ephemeral_root = ephemeral_root
     monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
 
     await run_skill("/investigate foo", str(tmp_path), step_name="investigate")

--- a/tests/server/test_factory_recording.py
+++ b/tests/server/test_factory_recording.py
@@ -195,3 +195,105 @@ def test_replay_takes_precedence_over_record(monkeypatch, tmp_path):
     assert isinstance(ctx.runner, ReplayingSubprocessRunner)
     mock_make_recorder.assert_not_called()  # REPLAY takes precedence over RECORD
     mock_atexit.assert_not_called()
+
+
+# --- T-BUILD-REPLAY-SNAP: build_replay_runner scans and surfaces skill_snapshots ---
+
+
+def test_build_replay_runner_scans_skill_snapshots(tmp_path, monkeypatch):
+    """build_replay_runner() populates runner.skill_snapshots from scenario dir."""
+
+    from autoskillit.execution.recording import build_replay_runner
+
+    replay_dir = tmp_path / "replay"
+    replay_dir.mkdir()
+    (replay_dir / "skill_snapshots" / "investigate").mkdir(parents=True)
+
+    mock_scenario = Mock()
+    mock_scenario.step_sequence = []
+    mock_player = Mock()
+    mock_player.scenario.return_value = mock_scenario
+    mock_player.build_session_map.return_value = {}
+
+    import api_simulator.claude as _api_sim_claude
+
+    monkeypatch.setattr(
+        _api_sim_claude, "make_scenario_player", Mock(return_value=mock_player), raising=False
+    )
+
+    runner = build_replay_runner(str(replay_dir))
+
+    assert "investigate" in runner.skill_snapshots
+    assert runner.skill_snapshots["investigate"] == replay_dir / "skill_snapshots" / "investigate"
+
+
+# --- T-RUN-SKILL-REPLAY: snapshot present → init_session NOT called ---
+
+
+@pytest.mark.anyio
+async def test_run_skill_replay_uses_snapshot_over_init_session(tool_ctx, tmp_path, monkeypatch):
+    """With a skill snapshot for the step, run_skill skips init_session."""
+    from unittest.mock import MagicMock
+
+    from autoskillit.execution.recording import ReplayingSubprocessRunner
+    from autoskillit.server.tools_execution import run_skill
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    snap_dir = tmp_path / "snap" / "investigate"
+    skill_md = snap_dir / ".claude" / "skills" / "investigate" / "SKILL.md"
+    skill_md.parent.mkdir(parents=True)
+    skill_md.write_text("# investigate\n", encoding="utf-8")
+
+    replay_runner = ReplayingSubprocessRunner({}, {}, skill_snapshots={"investigate": snap_dir})
+    tool_ctx.runner = replay_runner
+
+    mock_ssm = MagicMock()
+    tool_ctx.session_skill_manager = mock_ssm
+
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx.executor = executor
+
+    ephemeral_root = tmp_path / "sessions"
+    monkeypatch.setattr(
+        "autoskillit.server.tools_execution.resolve_ephemeral_root",
+        lambda: ephemeral_root,
+    )
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+
+    await run_skill("/investigate foo", str(tmp_path), step_name="investigate")
+
+    mock_ssm.init_session.assert_not_called()
+    assert len(executor.calls) == 1
+    add_dir_paths = [d.path for d in executor.calls[0].add_dirs]
+    assert any("sessions" in p for p in add_dir_paths)
+
+
+# --- T-RUN-SKILL-REPLAY-FALLBACK: no snapshot → init_session IS called ---
+
+
+@pytest.mark.anyio
+async def test_run_skill_replay_fallback_to_init_session(tool_ctx, tmp_path, monkeypatch):
+    """With no snapshot for the step, run_skill falls back to init_session."""
+    from unittest.mock import MagicMock
+
+    from autoskillit.core import ValidatedAddDir
+    from autoskillit.execution.recording import ReplayingSubprocessRunner
+    from autoskillit.server.tools_execution import run_skill
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    replay_runner = ReplayingSubprocessRunner({}, {}, skill_snapshots={})
+    tool_ctx.runner = replay_runner
+
+    fake_validated = ValidatedAddDir(path="/fake/session")
+    mock_ssm = MagicMock()
+    mock_ssm.init_session.return_value = fake_validated
+    tool_ctx.session_skill_manager = mock_ssm
+
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx.executor = executor
+
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+
+    await run_skill("/investigate foo", str(tmp_path), step_name="investigate")
+
+    mock_ssm.init_session.assert_called_once()


### PR DESCRIPTION
## Summary

The record/replay system (`execution/recording.py`) captures subprocess stdout via `api-simulator` cassettes but does NOT capture the ephemeral skill directory contents created by `init_session()` + `activate_skill_deps()`. During replay, the skills available to a session may differ from what was present during recording because the ephemeral dir is dynamically populated based on `allow_only` closures, `effective_disabled` subsets, `tier2` gating, `activate_skill_deps` ungating, feature flags, and project-local overrides.

This plan adds skill directory snapshot/restore alongside cassettes: during recording, after `RecordingSubprocessRunner._record_session()` captures stdout, the ephemeral skill dir is snapshotted into `{scenario_dir}/skill_snapshots/{step_name}/`. During replay, `build_replay_runner()` scans for snapshots and `tools_execution.py:run_skill()` restores from snapshot instead of calling `init_session()`, ensuring replay sessions see the exact same skill surface as the original recording.

Closes #1613

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260502-222024-173030/.autoskillit/temp/make-plan/record_replay_skill_dir_capture_plan_2026-05-02_222500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 7.8k | 18.2k | 1.2M | 209.4k | 1 | 13m 20s |
| verify | 1.4k | 13.4k | 1.4M | 155.0k | 1 | 7m 15s |
| implement | 396 | 32.1k | 3.8M | 266.9k | 1 | 11m 16s |
| prepare_pr | 60 | 5.0k | 190.0k | 55.0k | 1 | 1m 35s |
| compose_pr | 91 | 2.7k | 302.2k | 39.0k | 1 | 1m 4s |
| review_pr | 218 | 81.9k | 1.4M | 310.1k | 2 | 19m 4s |
| resolve_review | 421 | 41.1k | 3.6M | 89.5k | 1 | 16m 35s |
| **Total** | 10.4k | 194.3k | 11.9M | 1.1M | | 1h 10m |
## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 657 | 5782.3 | 406.2 | 48.9 |
| fix | 68 | 171871.3 | 9944.7 | 817.2 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **725** | 25650.2 | 1933.0 | 175.1 |