### PR TITLE
Wavefront Scheduling — Classify push_to_remote as Fast + Add Positive Advancement Mandate

### DIFF
--- a/src/autoskillit/skills/sous-chef/SKILL.md
+++ b/src/autoskillit/skills/sous-chef/SKILL.md
@@ -182,7 +182,8 @@ or user says "parallel"). Within each batched round, pipeline steps have two spe
 
 **Fast steps** — MCP tool calls that complete in seconds:
 `run_cmd`, `clone_repo`, `create_unique_branch`, `fetch_github_issue`,
-`claim_issue`, `merge_worktree`, `test_check`, `reset_test_dir`, `classify_fix`
+`claim_issue`, `merge_worktree`, `test_check`, `reset_test_dir`, `classify_fix`,
+`push_to_remote`
 
 **Slow steps** — headless sessions that take minutes:
 Any `run_skill` invocation (investigate, implement, audit, review, etc.)
@@ -201,6 +202,13 @@ Any `run_skill` invocation (investigate, implement, audit, review, etc.)
    pending.** This is the most critical rule: a batched round waits for the slowest step in
    the batch. A fast step launched alongside a slow step completes instantly but sits idle
    until the slow step finishes — wasting wall-clock time and blocking re-inspection.
+
+4. **Advance every active pipeline in every round.** A pipeline is "active" if it has not
+   reached `done` or `escalate_stop`. In every batched round, every active pipeline MUST
+   receive at least one step — either a fast step is drained or a slow step is launched.
+   Never leave an active pipeline idle for an entire round while sibling pipelines are
+   progressing. If a pipeline has completed all its `plan_parts` and only has finalization
+   steps remaining (push, merge, close), it is still active and must be advanced.
 
 ### Rationale
 

--- a/tests/contracts/test_sous_chef_scheduling.py
+++ b/tests/contracts/test_sous_chef_scheduling.py
@@ -31,6 +31,7 @@ REQUIRED_FAST_STEPS = [
     "test_check",
     "reset_test_dir",
     "classify_fix",
+    "push_to_remote",
 ]
 
 
@@ -118,6 +119,42 @@ def test_sous_chef_parallel_scheduling_explains_wall_clock_rationale() -> None:
     ), (
         "PARALLEL STEP SCHEDULING section must explain wall-clock rationale "
         "(idle time, slowest step)"
+    )
+
+
+def test_sous_chef_wavefront_has_positive_advancement_mandate() -> None:
+    """REQ-PROMPT-009: Wavefront must mandate advancing every active pipeline each round."""
+    text = _sous_chef_text()
+    section_start = text.find("PARALLEL STEP SCHEDULING")
+    assert section_start != -1
+    next_section = text.find("\n## ", section_start + 1)
+    section_text = text[section_start:next_section] if next_section != -1 else text[section_start:]
+    lower = section_text.lower()
+    has_advancement = (
+        ("every" in lower or "all" in lower)
+        and "active" in lower
+        and ("must" in lower or "advance" in lower or "idle" in lower)
+    )
+    assert has_advancement, (
+        "PARALLEL STEP SCHEDULING section must contain a positive advancement mandate "
+        "requiring every active pipeline to be advanced each round"
+    )
+
+
+def test_sous_chef_wavefront_has_four_rules() -> None:
+    """REQ-PROMPT-010: Wavefront Scheduling Rule must contain exactly 4 numbered rules."""
+    import re
+
+    text = _sous_chef_text()
+    section_start = text.find("### Wavefront Scheduling Rule")
+    assert section_start != -1, "Wavefront Scheduling Rule subsection must exist"
+    next_subsection = text.find("\n### ", section_start + 1)
+    subsection = (
+        text[section_start:next_subsection] if next_subsection != -1 else text[section_start:]
+    )
+    rules = re.findall(r"^\d+\.\s", subsection, re.MULTILINE)
+    assert len(rules) == 4, (
+        f"Wavefront Scheduling Rule must have exactly 4 numbered rules, found {len(rules)}"
     )
 
 


### PR DESCRIPTION
## Summary

Two gaps in the wavefront scheduling rule cause single-part pipelines to stall when grouped with multi-part siblings: `push_to_remote` is unclassified (so the LLM cannot drain it as fast), and no rule mandates advancing every active pipeline in every round (so the LLM can defer finalization indefinitely). This plan adds `push_to_remote` to the fast step list, introduces a Rule 4 positive advancement mandate, and extends the contract test suite to cover both additions.

Closes #1659

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260502-230814-104443/.autoskillit/temp/make-plan/wavefront_scheduling_fast_classify_advancement_mandate_plan_2026-05-02_230814.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 1.6k | 5.5k | 376.0k | 94.8k | 1 | 4m 3s |
| verify | 26 | 4.3k | 270.1k | 71.2k | 1 | 4m 42s |
| implement | 516 | 4.8k | 751.6k | 84.1k | 1 | 2m 23s |
| prepare_pr | 23 | 2.3k | 138.8k | 23.3k | 1 | 1m 0s |
| compose_pr | 22 | 1.4k | 131.0k | 18.5k | 1 | 36s |
| review_pr | 115 | 13.9k | 306.7k | 39.6k | 1 | 2m 56s |
| **Total** | 2.3k | 32.2k | 2.0M | 331.4k | | 15m 43s |