### PR TITLE
build_food_truck_cmd Feature Parity Drift from Leaf Builder

### DIFF
--- a/src/autoskillit/core/_type_protocols_execution.py
+++ b/src/autoskillit/core/_type_protocols_execution.py
@@ -73,6 +73,7 @@ class HeadlessExecutor(Protocol):
         env_extras: Mapping[str, str] | None = None,
         requires_packs: Sequence[str] = (),
         on_spawn: Callable[[int, int], None] | None = None,
+        allowed_write_prefix: str = "",
     ) -> SkillResult: ...
 
 

--- a/src/autoskillit/execution/commands.py
+++ b/src/autoskillit/execution/commands.py
@@ -369,6 +369,10 @@ def build_food_truck_cmd(
     model: str | None = None,
     env_extras: Mapping[str, str] | None = None,
     output_format: OutputFormat = OutputFormat.STREAM_JSON,
+    exit_after_stop_delay_ms: int = 0,
+    scenario_step_name: str = "",
+    temp_dir_relpath: str | None = None,
+    allowed_write_prefix: str = "",
 ) -> ClaudeHeadlessCmd:
     """Build the complete headless command spec for an L2 food truck session.
 
@@ -406,6 +410,16 @@ def build_food_truck_cmd(
     output_format
         OutputFormat enum; ``--output-format`` and any required flags are self-applied.
         Defaults to ``STREAM_JSON``.
+    exit_after_stop_delay_ms
+        If positive, sets ``CLAUDE_CODE_EXIT_AFTER_STOP_DELAY`` in the subprocess env.
+        Zero (default) means the variable is omitted entirely.
+    scenario_step_name
+        If non-empty, sets ``SCENARIO_STEP_NAME`` in the subprocess env.
+    temp_dir_relpath
+        Relative path to the temp directory injected into the CWD anchor directive.
+        Falls back to the canonical default when None.
+    allowed_write_prefix
+        If non-empty, sets ``AUTOSKILLIT_ALLOWED_WRITE_PREFIX`` in the subprocess env.
     """
     # Prompt transformations: completion directive + cwd anchor + narration suppression.
     # No _ensure_skill_prefix — orchestrator_prompt is a complete system prompt.
@@ -413,6 +427,7 @@ def build_food_truck_cmd(
         _inject_cwd_anchor(
             _inject_completion_directive(orchestrator_prompt, completion_marker),
             cwd,
+            temp_dir_relpath=temp_dir_relpath,
         )
     )
 
@@ -423,6 +438,15 @@ def build_food_truck_cmd(
         "MAX_MCP_OUTPUT_TOKENS": _MAX_MCP_OUTPUT_TOKENS_VALUE,
         "MCP_CONNECTION_NONBLOCKING": "0",
     }
+    if exit_after_stop_delay_ms > 0:
+        extras["CLAUDE_CODE_EXIT_AFTER_STOP_DELAY"] = str(exit_after_stop_delay_ms)
+    if scenario_step_name:
+        extras["SCENARIO_STEP_NAME"] = scenario_step_name
+    kitchen_session_id = os.environ.get(KITCHEN_SESSION_ID_ENV_VAR)
+    if kitchen_session_id:
+        extras[KITCHEN_SESSION_ID_ENV_VAR] = kitchen_session_id
+    if allowed_write_prefix:
+        extras["AUTOSKILLIT_ALLOWED_WRITE_PREFIX"] = allowed_write_prefix
     # Layer caller env_extras (campaign vars) UNDER the mandatory keys.
     # This ensures SESSION_TYPE and HEADLESS cannot be accidentally overridden.
     if env_extras:

--- a/src/autoskillit/execution/headless.py
+++ b/src/autoskillit/execution/headless.py
@@ -676,6 +676,7 @@ class DefaultHeadlessExecutor:
         env_extras: Mapping[str, str] | None = None,
         requires_packs: Sequence[str] = (),
         on_spawn: Callable[[int, int], None] | None = None,
+        allowed_write_prefix: str = "",
     ) -> SkillResult:
         cfg = self._ctx.config
         resolved_model = _resolve_model(model, cfg)
@@ -702,6 +703,10 @@ class DefaultHeadlessExecutor:
             model=resolved_model,
             env_extras=merged_extras or None,
             output_format=cfg.run_skill.output_format,
+            exit_after_stop_delay_ms=cfg.run_skill.exit_after_stop_delay_ms,
+            scenario_step_name=step_name,
+            temp_dir_relpath=temp_dir_display_str(cfg.workspace.temp_dir),
+            allowed_write_prefix=allowed_write_prefix,
         )
 
         effective_timeout = timeout if timeout is not None else fleet_cfg.default_timeout_sec

--- a/tests/execution/test_commands.py
+++ b/tests/execution/test_commands.py
@@ -605,6 +605,78 @@ class TestBuildFoodTruckCmdPackTags:
         assert spec.env["AUTOSKILLIT_L2_TOOL_TAGS"] == "github,ci,clone,telemetry"
 
 
+class TestBuildFoodTruckCmdFeatureParity:
+    """Tests for features ported from build_leaf_headless_cmd (issue #1656)."""
+
+    BASE = dict(
+        orchestrator_prompt="You are an L2 food truck orchestrator...",
+        plugin_source=DirectInstall(plugin_dir=Path("/plugins")),
+        cwd="/repo",
+        completion_marker="%%L2_DONE::abc12345%%",
+        model=None,
+        env_extras=None,
+        output_format=OutputFormat.STREAM_JSON,
+        exit_after_stop_delay_ms=0,
+        scenario_step_name="",
+        temp_dir_relpath=None,
+        allowed_write_prefix="",
+    )
+
+    def test_env_has_exit_delay_when_positive(self):
+        spec = build_food_truck_cmd(**{**self.BASE, "exit_after_stop_delay_ms": 2000})
+        assert spec.env["CLAUDE_CODE_EXIT_AFTER_STOP_DELAY"] == "2000"
+
+    def test_env_omits_exit_delay_when_zero(self):
+        spec = build_food_truck_cmd(**{**self.BASE, "exit_after_stop_delay_ms": 0})
+        assert "CLAUDE_CODE_EXIT_AFTER_STOP_DELAY" not in spec.env
+
+    def test_env_has_scenario_step_name_when_set(self):
+        spec = build_food_truck_cmd(**{**self.BASE, "scenario_step_name": "cook-recipe"})
+        assert spec.env["SCENARIO_STEP_NAME"] == "cook-recipe"
+
+    def test_env_omits_scenario_step_name_when_empty(self):
+        spec = build_food_truck_cmd(**self.BASE)
+        assert "SCENARIO_STEP_NAME" not in spec.env
+
+    def test_env_forwards_kitchen_session_id(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("AUTOSKILLIT_KITCHEN_SESSION_ID", "ks-abc")
+        spec = build_food_truck_cmd(**self.BASE)
+        assert spec.env["AUTOSKILLIT_KITCHEN_SESSION_ID"] == "ks-abc"
+
+    def test_env_omits_kitchen_session_id_when_absent(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv("AUTOSKILLIT_KITCHEN_SESSION_ID", raising=False)
+        spec = build_food_truck_cmd(**self.BASE)
+        assert "AUTOSKILLIT_KITCHEN_SESSION_ID" not in spec.env
+
+    def test_allowed_write_prefix_in_env(self):
+        spec = build_food_truck_cmd(**{**self.BASE, "allowed_write_prefix": "/tmp/foo/"})
+        assert spec.env["AUTOSKILLIT_ALLOWED_WRITE_PREFIX"] == "/tmp/foo/"
+
+    def test_allowed_write_prefix_absent_when_empty(self):
+        spec = build_food_truck_cmd(**{**self.BASE, "allowed_write_prefix": ""})
+        assert "AUTOSKILLIT_ALLOWED_WRITE_PREFIX" not in spec.env
+
+    def test_allowed_write_prefix_exclusive(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIX", "old")
+        spec = build_food_truck_cmd(**{**self.BASE, "allowed_write_prefix": "new"})
+        assert spec.env["AUTOSKILLIT_ALLOWED_WRITE_PREFIX"] == "new"
+
+    def test_temp_dir_relpath_in_prompt(self):
+        spec = build_food_truck_cmd(**{**self.BASE, "temp_dir_relpath": ".autoskillit/temp"})
+        prompt_text = spec.cmd[2]
+        assert ".autoskillit/temp" in prompt_text
+
+    def test_headless_exclusive_vars_stripped_exit_delay(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("CLAUDE_CODE_EXIT_AFTER_STOP_DELAY", "99999")
+        spec = build_food_truck_cmd(**{**self.BASE, "exit_after_stop_delay_ms": 0})
+        assert "CLAUDE_CODE_EXIT_AFTER_STOP_DELAY" not in spec.env
+
+    def test_headless_exclusive_vars_stripped_scenario_step(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("SCENARIO_STEP_NAME", "outer-step")
+        spec = build_food_truck_cmd(**{**self.BASE, "scenario_step_name": ""})
+        assert "SCENARIO_STEP_NAME" not in spec.env
+
+
 def test_headless_exclusive_vars_contains_max_mcp_output_tokens() -> None:
     """MAX_MCP_OUTPUT_TOKENS must be in _HEADLESS_EXCLUSIVE_VARS."""
     from autoskillit.execution.commands import _HEADLESS_EXCLUSIVE_VARS


### PR DESCRIPTION
## Summary

Port five features from `build_leaf_headless_cmd` to `build_food_truck_cmd` that diverged after the fork at commit `affdb741`. The changes add four new parameters to the builder function signature (`exit_after_stop_delay_ms`, `scenario_step_name`, `temp_dir_relpath`, `allowed_write_prefix`), add `AUTOSKILLIT_KITCHEN_SESSION_ID` forwarding from the host environment, and wire all five through the `dispatch_food_truck` caller in `headless.py`. Items 1-3 are direct ports of the leaf pattern; items 4-5 are adapted implementations.

Closes #1656

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-1656-20260503-001451-245791/.autoskillit/temp/make-plan/build_food_truck_cmd_parity_plan_2026-05-03_002500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 72 | 14.4k | 1.5M | 70.5k | 1 | 7m 31s |
| verify | 38 | 9.2k | 1.1M | 53.1k | 1 | 4m 38s |
| implement | 54 | 10.6k | 1.3M | 47.0k | 1 | 8m 11s |
| prepare_pr | 25 | 3.3k | 220.2k | 26.8k | 1 | 1m 36s |
| compose_pr | 22 | 1.4k | 131.4k | 18.7k | 1 | 38s |
| review_pr | 28 | 14.3k | 350.4k | 85.6k | 1 | 3m 24s |
| **Total** | 239 | 53.2k | 4.5M | 301.7k | | 26m 0s |
## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 102 | 12288.8 | 461.0 | 103.6 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **102** | 41087.1 | 2119.2 | 381.3 |