### PR TITLE
Campaign Resume/Reload Safety Gaps — Stale Metadata, Sentinel Leak, Non-Terminal Invisibility

### DIFF
--- a/src/autoskillit/cli/_fleet.py
+++ b/src/autoskillit/cli/_fleet.py
@@ -131,6 +131,7 @@ def fleet_campaign(
 
     from autoskillit.core import YAMLError
     from autoskillit.fleet import (
+        FLEET_HALTED_SENTINEL,
         DispatchRecord,
         resume_campaign_from_state,
         write_initial_state,
@@ -169,6 +170,13 @@ def fleet_campaign(
         resume_metadata = resume_campaign_from_state(state_path, parsed.continue_on_failure)
         if resume_metadata is None:
             print(f"ERROR: Campaign state not found or corrupted for '{campaign_id}'")
+            sys.exit(1)
+        if resume_metadata.completed_dispatches_block == FLEET_HALTED_SENTINEL:
+            print(
+                f"ERROR: Campaign '{campaign_id}' halted on dispatch failure. "
+                "Set 'continue_on_failure: true' in the campaign recipe to resume past failures.",
+                file=sys.stderr,
+            )
             sys.exit(1)
     else:
         campaign_id = uuid4().hex[:16]

--- a/src/autoskillit/cli/_fleet_session.py
+++ b/src/autoskillit/cli/_fleet_session.py
@@ -18,6 +18,15 @@ if TYPE_CHECKING:
 _MAX_RELOADS = 10
 
 
+def _check_reload_guard(reload_id: str, seen_reload_ids: set[str]) -> None:
+    """Enforce max-reload cap and duplicate-ID detection, then register the ID."""
+    if len(seen_reload_ids) >= _MAX_RELOADS:
+        raise SystemExit(f"Too many reloads ({_MAX_RELOADS} max). Check for infinite loop.")
+    if reload_id in seen_reload_ids:
+        raise SystemExit(f"Repeated reload_id {reload_id!r} — aborting.")
+    seen_reload_ids.add(reload_id)
+
+
 def _launch_fleet_session(
     campaign_recipe: Recipe | None,
     campaign_id: str | None,
@@ -56,13 +65,7 @@ def _launch_fleet_session(
             )
             if reload_id is None:
                 break
-            if len(seen_reload_ids) >= _MAX_RELOADS:
-                raise SystemExit(
-                    f"Too many reloads ({_MAX_RELOADS} max). Check for infinite loop."
-                )
-            if reload_id in seen_reload_ids:
-                raise SystemExit(f"Repeated reload_id {reload_id!r} — aborting.")
-            seen_reload_ids.add(reload_id)
+            _check_reload_guard(reload_id, seen_reload_ids)
             current_resume_spec = NamedResume(session_id=reload_id)
     else:
         # Campaign-driven mode: full orchestrator prompt with manifest and state
@@ -105,7 +108,7 @@ def _launch_fleet_session(
             "AUTOSKILLIT_HEADLESS": "0",
         }
 
-        seen_reload_ids = set()
+        seen_reload_ids = set[str]()
         current_resume_spec = NoResume()
 
         while True:
@@ -117,13 +120,7 @@ def _launch_fleet_session(
             )
             if reload_id is None:
                 break
-            if len(seen_reload_ids) >= _MAX_RELOADS:
-                raise SystemExit(
-                    f"Too many reloads ({_MAX_RELOADS} max). Check for infinite loop."
-                )
-            if reload_id in seen_reload_ids:
-                raise SystemExit(f"Repeated reload_id {reload_id!r} — aborting.")
-            seen_reload_ids.add(reload_id)
+            _check_reload_guard(reload_id, seen_reload_ids)
 
             fresh_metadata = resume_campaign_from_state(
                 state_path, campaign_recipe.continue_on_failure

--- a/src/autoskillit/cli/_fleet_session.py
+++ b/src/autoskillit/cli/_fleet_session.py
@@ -6,13 +6,16 @@ import dataclasses
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
-from autoskillit.core import NoResume, get_logger
+from autoskillit.core import NamedResume, NoResume, get_logger
 
 logger = get_logger(__name__)
 
 if TYPE_CHECKING:
+    from autoskillit.core import ResumeSpec
     from autoskillit.fleet import ResumeDecision
     from autoskillit.recipe.schema import Recipe
+
+_MAX_RELOADS = 10
 
 
 def _launch_fleet_session(
@@ -42,12 +45,25 @@ def _launch_fleet_session(
             "AUTOSKILLIT_FLEET_MODE": fleet_mode,
             "AUTOSKILLIT_HEADLESS": "0",
         }
+        seen_reload_ids: set[str] = set()
+        current_resume_spec: ResumeSpec = NoResume()
         while True:
             reload_id = _run_interactive_session(
-                prompt, extra_env=extra_env, resume_spec=NoResume(), project_dir=project_dir
+                prompt,
+                extra_env=extra_env,
+                resume_spec=current_resume_spec,
+                project_dir=project_dir,
             )
             if reload_id is None:
                 break
+            if len(seen_reload_ids) >= _MAX_RELOADS:
+                raise SystemExit(
+                    f"Too many reloads ({_MAX_RELOADS} max). Check for infinite loop."
+                )
+            if reload_id in seen_reload_ids:
+                raise SystemExit(f"Repeated reload_id {reload_id!r} — aborting.")
+            seen_reload_ids.add(reload_id)
+            current_resume_spec = NamedResume(session_id=reload_id)
     else:
         # Campaign-driven mode: full orchestrator prompt with manifest and state
         if campaign_id is None:
@@ -56,6 +72,7 @@ def _launch_fleet_session(
             raise ValueError("state_path must not be None in campaign-driven mode")
         from autoskillit.cli._prompts import _build_fleet_campaign_prompt
         from autoskillit.core import dump_yaml_str
+        from autoskillit.fleet import FLEET_HALTED_SENTINEL, resume_campaign_from_state
 
         manifest_yaml = dump_yaml_str(
             [dataclasses.asdict(d) for d in campaign_recipe.dispatches],
@@ -87,9 +104,48 @@ def _launch_fleet_session(
             "AUTOSKILLIT_CONTINUE_ON_FAILURE": str(campaign_recipe.continue_on_failure).lower(),
             "AUTOSKILLIT_HEADLESS": "0",
         }
+
+        seen_reload_ids = set()
+        current_resume_spec = NoResume()
+
         while True:
             reload_id = _run_interactive_session(
-                prompt, extra_env=extra_env, resume_spec=NoResume(), project_dir=project_dir
+                prompt,
+                extra_env=extra_env,
+                resume_spec=current_resume_spec,
+                project_dir=project_dir,
             )
             if reload_id is None:
                 break
+            if len(seen_reload_ids) >= _MAX_RELOADS:
+                raise SystemExit(
+                    f"Too many reloads ({_MAX_RELOADS} max). Check for infinite loop."
+                )
+            if reload_id in seen_reload_ids:
+                raise SystemExit(f"Repeated reload_id {reload_id!r} — aborting.")
+            seen_reload_ids.add(reload_id)
+
+            fresh_metadata = resume_campaign_from_state(
+                state_path, campaign_recipe.continue_on_failure
+            )
+            if fresh_metadata is None:
+                logger.error("Campaign state corrupted during reload — exiting")
+                break
+            if fresh_metadata.completed_dispatches_block == FLEET_HALTED_SENTINEL:
+                logger.info("Campaign halted on failure during reload — exiting")
+                break
+
+            completed_dispatches = fresh_metadata.completed_dispatches_block
+            resumable_dispatch_name = (
+                fresh_metadata.next_dispatch_name if fresh_metadata.is_resumable else ""
+            )
+            prompt = _build_fleet_campaign_prompt(
+                campaign_recipe,
+                manifest_yaml,
+                completed_dispatches,
+                mcp_prefix,
+                campaign_id,
+                resumable_dispatch_name=resumable_dispatch_name,
+                ingredients_table=ingredients_table,
+            )
+            current_resume_spec = NamedResume(session_id=reload_id)

--- a/src/autoskillit/fleet/state.py
+++ b/src/autoskillit/fleet/state.py
@@ -404,6 +404,15 @@ _COMPLETED_STATUSES = frozenset(
     {DispatchStatus.SUCCESS, DispatchStatus.SKIPPED, DispatchStatus.FAILURE}
 )
 
+_VISIBLE_IN_BLOCK_STATUSES = _COMPLETED_STATUSES | frozenset(
+    {
+        DispatchStatus.INTERRUPTED,
+        DispatchStatus.REFUSED,
+        DispatchStatus.RELEASED,
+        DispatchStatus.RUNNING,
+    }
+)
+
 TERMINAL_DISPATCH_STATUSES: frozenset[str] = frozenset(
     {
         DispatchStatus.SUCCESS,
@@ -586,7 +595,7 @@ def resume_campaign_from_state(
             next_name = ""
             is_resumable = False
             for d in state.dispatches:
-                if d.status in _COMPLETED_STATUSES:
+                if d.status in _VISIBLE_IN_BLOCK_STATUSES:
                     completed_lines.append(f"- {d.name}: {d.status}")
                 elif d.status == DispatchStatus.RESUMABLE and not next_name:
                     next_name = d.name

--- a/tests/cli/test_fleet_campaign.py
+++ b/tests/cli/test_fleet_campaign.py
@@ -255,7 +255,6 @@ class TestFleetCampaignResumeHaltedExits:
             ),
         )
         launch_called = False
-        original_launch = None
 
         def _track_launch(*a: object, **kw: object) -> None:
             nonlocal launch_called

--- a/tests/cli/test_fleet_campaign.py
+++ b/tests/cli/test_fleet_campaign.py
@@ -207,3 +207,61 @@ def test_fleet_campaign_resume_no_name_lists_active_campaigns(
     assert "campaign-active-1" in out
     assert "campaign-active-2" in out
     assert "campaign-terminal" not in out
+
+
+class TestFleetCampaignResumeHaltedExits:
+    def test_resume_halted_campaign_exits_with_error(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _stub_guards(monkeypatch)
+        monkeypatch.chdir(tmp_path)
+        campaign_id = "halted-campaign-id1"
+        _setup_existing_campaign_state(tmp_path, campaign_id, "test-campaign")
+        _stub_campaign_resolution(monkeypatch, tmp_path, "test-campaign")
+
+        from autoskillit.fleet import FLEET_HALTED_SENTINEL
+
+        monkeypatch.setattr(
+            "autoskillit.fleet.resume_campaign_from_state",
+            lambda *a, **kw: MagicMock(
+                completed_dispatches_block=FLEET_HALTED_SENTINEL,
+                next_dispatch_name="",
+                is_resumable=False,
+            ),
+        )
+        with pytest.raises(SystemExit, match="1"):
+            _fleet_campaign("test-campaign", resume_campaign=campaign_id)
+        err = capsys.readouterr().err
+        assert "halted" in err.lower()
+        assert "continue_on_failure" in err
+
+    def test_resume_halted_does_not_launch_session(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        _stub_guards(monkeypatch)
+        monkeypatch.chdir(tmp_path)
+        campaign_id = "halted-campaign-id2"
+        _setup_existing_campaign_state(tmp_path, campaign_id, "test-campaign")
+        _stub_campaign_resolution(monkeypatch, tmp_path, "test-campaign")
+
+        from autoskillit.fleet import FLEET_HALTED_SENTINEL
+
+        monkeypatch.setattr(
+            "autoskillit.fleet.resume_campaign_from_state",
+            lambda *a, **kw: MagicMock(
+                completed_dispatches_block=FLEET_HALTED_SENTINEL,
+                next_dispatch_name="",
+                is_resumable=False,
+            ),
+        )
+        launch_called = False
+        original_launch = None
+
+        def _track_launch(*a: object, **kw: object) -> None:
+            nonlocal launch_called
+            launch_called = True
+
+        monkeypatch.setattr("autoskillit.cli._fleet._launch_fleet_session", _track_launch)
+        with pytest.raises(SystemExit):
+            _fleet_campaign("test-campaign", resume_campaign=campaign_id)
+        assert not launch_called

--- a/tests/cli/test_fleet_session.py
+++ b/tests/cli/test_fleet_session.py
@@ -350,8 +350,9 @@ class TestReloadLoopSafetyGuards:
                 fleet_mode="campaign",
             )
 
-        # Should have fired exactly _MAX_RELOADS + 1 times (guard triggers after 10 seen)
-        assert counter["n"] == 11
+        from autoskillit.cli._fleet_session import _MAX_RELOADS
+
+        assert counter["n"] == _MAX_RELOADS + 1
 
     def test_duplicate_reload_id_aborts(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
@@ -404,7 +405,7 @@ class TestReloadLoopUsesNamedResume:
     """T3d: Reload loop passes NoResume on first call, NamedResume on reload."""
 
     def test_named_resume_on_reload(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-        """First call uses NoResume(); after a reload, NamedResume(session_id=<reload_id>) is used."""
+        """First call uses NoResume(); after reload, NamedResume is used."""
         from autoskillit.core import NamedResume, NoResume
 
         monkeypatch.chdir(tmp_path)

--- a/tests/cli/test_fleet_session.py
+++ b/tests/cli/test_fleet_session.py
@@ -115,3 +115,342 @@ class TestLaunchFleetSessionContinueOnFailureEnv:
     ) -> None:
         captured = self._capture_env(monkeypatch, tmp_path, continue_on_failure=True)
         assert captured["extra_env"]["AUTOSKILLIT_CONTINUE_ON_FAILURE"] == "true"
+
+
+class TestReloadLoopRefreshesMetadata:
+    """T3a: Reload loop calls resume_campaign_from_state to refresh metadata."""
+
+    def _setup_common(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> Path:
+        monkeypatch.chdir(tmp_path)
+        state_path = tmp_path / "state.json"
+        return state_path
+
+    def test_resume_called_on_reload(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """resume_campaign_from_state is called exactly once (in reload iteration)."""
+        state_path = self._setup_common(monkeypatch, tmp_path)
+
+        call_count = {"n": 0}
+        call_sequence = iter(["reload-id-1", None])
+
+        def _fake_run_session(
+            prompt: str,
+            *,
+            extra_env: dict,
+            resume_spec: object,
+            project_dir: Path,
+        ) -> str | None:
+            return next(call_sequence)
+
+        fresh_meta = MagicMock()
+        fresh_meta.completed_dispatches_block = "- A: success"
+        fresh_meta.next_dispatch_name = "B"
+        fresh_meta.is_resumable = False
+
+        def _fake_resume(state_path_arg: Path, continue_on_failure: bool) -> MagicMock:
+            call_count["n"] += 1
+            return fresh_meta
+
+        monkeypatch.setattr(
+            "autoskillit.cli._session_launch._run_interactive_session",
+            _fake_run_session,
+        )
+        monkeypatch.setattr(
+            "autoskillit.fleet.resume_campaign_from_state",
+            _fake_resume,
+        )
+        monkeypatch.setattr(
+            "autoskillit.cli._prompts._build_fleet_campaign_prompt",
+            lambda *a, **kw: "fake-prompt",
+        )
+
+        from autoskillit.cli._fleet_session import _launch_fleet_session
+
+        _launch_fleet_session(
+            _make_campaign_recipe(),
+            "test-id",
+            state_path,
+            None,
+            fleet_mode="campaign",
+        )
+
+        assert call_count["n"] == 1
+
+    def test_prompt_rebuilt_with_fresh_dispatches(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Second prompt build uses fresh completed_dispatches from resume_campaign_from_state."""
+        state_path = self._setup_common(monkeypatch, tmp_path)
+
+        call_sequence = iter(["reload-id-1", None])
+
+        def _fake_run_session(
+            prompt: str,
+            *,
+            extra_env: dict,
+            resume_spec: object,
+            project_dir: Path,
+        ) -> str | None:
+            return next(call_sequence)
+
+        fresh_meta = MagicMock()
+        fresh_meta.completed_dispatches_block = "- A: success"
+        fresh_meta.next_dispatch_name = "B"
+        fresh_meta.is_resumable = False
+
+        monkeypatch.setattr(
+            "autoskillit.fleet.resume_campaign_from_state",
+            lambda *a, **kw: fresh_meta,
+        )
+        monkeypatch.setattr(
+            "autoskillit.cli._session_launch._run_interactive_session",
+            _fake_run_session,
+        )
+
+        prompt_calls: list[str] = []
+
+        def _fake_build(
+            campaign_recipe: object,
+            manifest_yaml: str,
+            completed_dispatches: str,
+            mcp_prefix: str,
+            campaign_id: str,
+            **kwargs: object,
+        ) -> str:
+            prompt_calls.append(completed_dispatches)
+            return "fake-prompt"
+
+        monkeypatch.setattr(
+            "autoskillit.cli._prompts._build_fleet_campaign_prompt",
+            _fake_build,
+        )
+
+        from autoskillit.cli._fleet_session import _launch_fleet_session
+
+        _launch_fleet_session(
+            _make_campaign_recipe(),
+            "test-id",
+            state_path,
+            None,
+            fleet_mode="campaign",
+        )
+
+        # First build uses resume_metadata=None -> "", second uses fresh_meta
+        assert len(prompt_calls) == 2
+        assert prompt_calls[1] == "- A: success"
+
+
+class TestReloadLoopSentinelGuard:
+    """T3b: FLEET_HALTED_SENTINEL in reload metadata breaks the loop cleanly."""
+
+    def test_sentinel_on_reload_breaks_loop(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """When resume_campaign_from_state returns FLEET_HALTED_SENTINEL, loop exits normally."""
+        from autoskillit.fleet import FLEET_HALTED_SENTINEL
+
+        monkeypatch.chdir(tmp_path)
+        state_path = tmp_path / "state.json"
+
+        session_call_count = {"n": 0}
+
+        def _fake_run_session(
+            prompt: str,
+            *,
+            extra_env: dict,
+            resume_spec: object,
+            project_dir: Path,
+        ) -> str | None:
+            session_call_count["n"] += 1
+            return "reload-id-sentinel"
+
+        halted_meta = MagicMock()
+        halted_meta.completed_dispatches_block = FLEET_HALTED_SENTINEL
+        halted_meta.next_dispatch_name = ""
+        halted_meta.is_resumable = False
+
+        monkeypatch.setattr(
+            "autoskillit.fleet.resume_campaign_from_state",
+            lambda *a, **kw: halted_meta,
+        )
+        monkeypatch.setattr(
+            "autoskillit.cli._session_launch._run_interactive_session",
+            _fake_run_session,
+        )
+        monkeypatch.setattr(
+            "autoskillit.cli._prompts._build_fleet_campaign_prompt",
+            lambda *a, **kw: "fake-prompt",
+        )
+
+        from autoskillit.cli._fleet_session import _launch_fleet_session
+
+        # Must not raise SystemExit
+        _launch_fleet_session(
+            _make_campaign_recipe(),
+            "test-id",
+            state_path,
+            None,
+            fleet_mode="campaign",
+        )
+
+        assert session_call_count["n"] == 1
+
+
+class TestReloadLoopSafetyGuards:
+    """T3c: Safety guards — max reload cap and duplicate reload_id detection."""
+
+    def test_max_reload_guard(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """SystemExit raised after _MAX_RELOADS consecutive reloads."""
+        monkeypatch.chdir(tmp_path)
+        state_path = tmp_path / "state.json"
+
+        counter = {"n": 0}
+
+        def _fake_run_session(
+            prompt: str,
+            *,
+            extra_env: dict,
+            resume_spec: object,
+            project_dir: Path,
+        ) -> str:
+            counter["n"] += 1
+            return f"unique-reload-id-{counter['n']}"
+
+        fresh_meta = MagicMock()
+        fresh_meta.completed_dispatches_block = "- A: success"
+        fresh_meta.next_dispatch_name = "B"
+        fresh_meta.is_resumable = False
+
+        monkeypatch.setattr(
+            "autoskillit.fleet.resume_campaign_from_state",
+            lambda *a, **kw: fresh_meta,
+        )
+        monkeypatch.setattr(
+            "autoskillit.cli._session_launch._run_interactive_session",
+            _fake_run_session,
+        )
+        monkeypatch.setattr(
+            "autoskillit.cli._prompts._build_fleet_campaign_prompt",
+            lambda *a, **kw: "fake-prompt",
+        )
+
+        from autoskillit.cli._fleet_session import _launch_fleet_session
+
+        with pytest.raises(SystemExit):
+            _launch_fleet_session(
+                _make_campaign_recipe(),
+                "test-id",
+                state_path,
+                None,
+                fleet_mode="campaign",
+            )
+
+        # Should have fired exactly _MAX_RELOADS + 1 times (guard triggers after 10 seen)
+        assert counter["n"] == 11
+
+    def test_duplicate_reload_id_aborts(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """SystemExit raised when the same reload_id is returned twice."""
+        monkeypatch.chdir(tmp_path)
+        state_path = tmp_path / "state.json"
+
+        # Always return the same reload_id
+        def _fake_run_session(
+            prompt: str,
+            *,
+            extra_env: dict,
+            resume_spec: object,
+            project_dir: Path,
+        ) -> str:
+            return "repeated-reload-id"
+
+        fresh_meta = MagicMock()
+        fresh_meta.completed_dispatches_block = "- A: success"
+        fresh_meta.next_dispatch_name = "B"
+        fresh_meta.is_resumable = False
+
+        monkeypatch.setattr(
+            "autoskillit.fleet.resume_campaign_from_state",
+            lambda *a, **kw: fresh_meta,
+        )
+        monkeypatch.setattr(
+            "autoskillit.cli._session_launch._run_interactive_session",
+            _fake_run_session,
+        )
+        monkeypatch.setattr(
+            "autoskillit.cli._prompts._build_fleet_campaign_prompt",
+            lambda *a, **kw: "fake-prompt",
+        )
+
+        from autoskillit.cli._fleet_session import _launch_fleet_session
+
+        with pytest.raises(SystemExit):
+            _launch_fleet_session(
+                _make_campaign_recipe(),
+                "test-id",
+                state_path,
+                None,
+                fleet_mode="campaign",
+            )
+
+
+class TestReloadLoopUsesNamedResume:
+    """T3d: Reload loop passes NoResume on first call, NamedResume on reload."""
+
+    def test_named_resume_on_reload(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """First call uses NoResume(); after a reload, NamedResume(session_id=<reload_id>) is used."""
+        from autoskillit.core import NamedResume, NoResume
+
+        monkeypatch.chdir(tmp_path)
+        state_path = tmp_path / "state.json"
+
+        captured_specs: list[object] = []
+        call_sequence = iter(["reload-id-abc", None])
+
+        def _fake_run_session(
+            prompt: str,
+            *,
+            extra_env: dict,
+            resume_spec: object,
+            project_dir: Path,
+        ) -> str | None:
+            captured_specs.append(resume_spec)
+            return next(call_sequence)
+
+        fresh_meta = MagicMock()
+        fresh_meta.completed_dispatches_block = "- A: success"
+        fresh_meta.next_dispatch_name = "B"
+        fresh_meta.is_resumable = False
+
+        monkeypatch.setattr(
+            "autoskillit.fleet.resume_campaign_from_state",
+            lambda *a, **kw: fresh_meta,
+        )
+        monkeypatch.setattr(
+            "autoskillit.cli._session_launch._run_interactive_session",
+            _fake_run_session,
+        )
+        monkeypatch.setattr(
+            "autoskillit.cli._prompts._build_fleet_campaign_prompt",
+            lambda *a, **kw: "fake-prompt",
+        )
+
+        from autoskillit.cli._fleet_session import _launch_fleet_session
+
+        _launch_fleet_session(
+            _make_campaign_recipe(),
+            "test-id",
+            state_path,
+            None,
+            fleet_mode="campaign",
+        )
+
+        assert len(captured_specs) == 2
+        assert captured_specs[0] == NoResume()
+        assert captured_specs[1] == NamedResume(session_id="reload-id-abc")

--- a/tests/cli/test_reload_loop.py
+++ b/tests/cli/test_reload_loop.py
@@ -192,7 +192,7 @@ def test_interactive_session_reload_uses_named_resume(
 def test_fleet_reload_relaunches_without_resume(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    from autoskillit.core import NoResume
+    from autoskillit.core import NamedResume, NoResume
 
     call_count = [0]
     captured_resume_specs: list = []
@@ -227,8 +227,9 @@ def test_fleet_reload_relaunches_without_resume(
     )
 
     assert call_count[0] == 2
-    # Franchise always re-launches with NoResume — no resume on reload
-    assert all(isinstance(r, NoResume) for r in captured_resume_specs)
+    assert isinstance(captured_resume_specs[0], NoResume)
+    assert isinstance(captured_resume_specs[1], NamedResume)
+    assert captured_resume_specs[1].session_id == "franchise-sess"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/fleet/test_state.py
+++ b/tests/fleet/test_state.py
@@ -625,7 +625,7 @@ class TestResumeIncludesRunningAliveInBlock:
             l2_boot_id="abc",
             l2_starttime_ticks=999,
         )
-        record_c = DispatchRecord(name="C")
+        record_c = DispatchRecord(name="C", status=DispatchStatus.PENDING)
         monkeypatch.setattr(
             "autoskillit.fleet.is_dispatch_session_alive",
             lambda r: True,

--- a/tests/fleet/test_state.py
+++ b/tests/fleet/test_state.py
@@ -574,26 +574,67 @@ class TestAppendDispatchRecordIllegalTransition:
         assert latest.status == DispatchStatus.SUCCESS
 
 
-class TestResumeSkipsRefusedDispatch:
-    def test_refused_dispatch_skipped_next_is_b(self, tmp_path: Path) -> None:
+class TestResumeShowsRefusedInBlock:
+    def test_refused_dispatch_visible_next_is_b(self, tmp_path: Path) -> None:
         sp = _state_path(tmp_path)
         write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("A", "B"))
         append_dispatch_record(sp, DispatchRecord(name="A", status=DispatchStatus.REFUSED))
         decision = resume_campaign_from_state(sp, continue_on_failure=True)
         assert decision is not None
         assert decision.next_dispatch_name == "B"
-        assert "A" not in decision.completed_dispatches_block
+        assert "A" in decision.completed_dispatches_block
+        assert "refused" in decision.completed_dispatches_block.lower()
 
 
-class TestResumeSkipsReleasedDispatch:
-    def test_released_dispatch_skipped_next_is_b(self, tmp_path: Path) -> None:
+class TestResumeShowsReleasedInBlock:
+    def test_released_dispatch_visible_next_is_b(self, tmp_path: Path) -> None:
         sp = _state_path(tmp_path)
         write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("A", "B"))
         append_dispatch_record(sp, DispatchRecord(name="A", status=DispatchStatus.RELEASED))
         decision = resume_campaign_from_state(sp, continue_on_failure=True)
         assert decision is not None
         assert decision.next_dispatch_name == "B"
-        assert "A" not in decision.completed_dispatches_block
+        assert "A" in decision.completed_dispatches_block
+        assert "released" in decision.completed_dispatches_block.lower()
+
+
+class TestResumeIncludesInterruptedInBlock:
+    def test_interrupted_dispatch_visible_in_completed_block(self, tmp_path: Path) -> None:
+        sp = _state_path(tmp_path)
+        write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("A", "B", "C"))
+        append_dispatch_record(sp, DispatchRecord(name="A", status=DispatchStatus.SUCCESS))
+        append_dispatch_record(sp, DispatchRecord(name="B", status=DispatchStatus.INTERRUPTED))
+        decision = resume_campaign_from_state(sp, continue_on_failure=True)
+        assert decision is not None
+        assert "B" in decision.completed_dispatches_block
+        assert "interrupted" in decision.completed_dispatches_block.lower()
+        assert decision.next_dispatch_name == "C"
+
+
+class TestResumeIncludesRunningAliveInBlock:
+    def test_running_alive_dispatch_visible_in_completed_block(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sp = _state_path(tmp_path)
+        record_a = DispatchRecord(name="A", status=DispatchStatus.SUCCESS)
+        record_b = DispatchRecord(
+            name="B",
+            status=DispatchStatus.RUNNING,
+            l2_pid=12345,
+            l2_boot_id="abc",
+            l2_starttime_ticks=999,
+        )
+        record_c = DispatchRecord(name="C")
+        monkeypatch.setattr(
+            "autoskillit.fleet.is_dispatch_session_alive",
+            lambda r: True,
+        )
+        write_initial_state(sp, "cid", "camp", "/m.yaml", [record_a, record_b, record_c])
+        decision = resume_campaign_from_state(sp, continue_on_failure=True)
+        assert decision is not None
+        assert "B" in decision.completed_dispatches_block
+        assert "running" in decision.completed_dispatches_block.lower()
+        assert decision.next_dispatch_name == "C"
 
 
 class TestWriteCapturedValuesCorruptStateNoOp:

--- a/tests/fleet/test_state.py
+++ b/tests/fleet/test_state.py
@@ -603,6 +603,7 @@ class TestResumeIncludesInterruptedInBlock:
         sp = _state_path(tmp_path)
         write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("A", "B", "C"))
         append_dispatch_record(sp, DispatchRecord(name="A", status=DispatchStatus.SUCCESS))
+        mark_dispatch_running(sp, "B", dispatch_id="d-b", l2_pid=99)
         append_dispatch_record(sp, DispatchRecord(name="B", status=DispatchStatus.INTERRUPTED))
         decision = resume_campaign_from_state(sp, continue_on_failure=True)
         assert decision is not None


### PR DESCRIPTION
## Summary

Four interrelated safety gaps in the campaign resume and context-limit reload paths allow stale dispatch metadata to persist across reload iterations, the `FLEET_HALTED_SENTINEL` string to leak verbatim into L3 orchestrator prompts, and non-terminal dispatch statuses (INTERRUPTED, RUNNING, REFUSED, RELEASED) to be silently invisible to resumed sessions. The fix touches three files: `cli/_fleet.py` (sentinel guard at CLI entry), `cli/_fleet_session.py` (reload loop overhaul with fresh metadata resolution, sentinel guard, resume spec, and safety guards), and `fleet/state.py` (non-terminal dispatch visibility in the completed dispatches block).

Closes #1657

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-1657-20260503-001452-264207/.autoskillit/temp/make-plan/campaign_resume_reload_safety_gaps_plan_2026-05-03_015000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 69 | 15.7k | 1.4M | 76.5k | 1 | 7m 12s |
| verify | 51 | 13.2k | 1.6M | 72.8k | 1 | 5m 37s |
| implement | 54 | 14.3k | 2.2M | 75.8k | 1 | 8m 13s |
| prepare_pr | 23 | 3.9k | 142.3k | 29.2k | 1 | 1m 29s |
| compose_pr | 23 | 1.6k | 165.6k | 20.4k | 1 | 49s |
| review_pr | 28 | 26.9k | 487.3k | 78.3k | 1 | 6m 48s |
| resolve_review | 67 | 20.5k | 3.4M | 97.5k | 1 | 11m 1s |
| resolve_queue_merge_conflicts | 55 | 16.9k | 1.7M | 66.6k | 1 | 4m 47s |
| **Total** | 370 | 113.0k | 11.0M | 517.0k | | 45m 58s |
## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 531 | 4134.5 | 142.8 | 26.9 |
| fix | 8 | 154492.1 | 6842.4 | 845.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **539** | 12425.5 | 611.1 | 102.9 |