### PR TITLE
Rename merge_tier_dir → merge_tier_results and Extend to Produce Per-Phase Refine Context Files

### DIFF
--- a/src/autoskillit/planner/__init__.py
+++ b/src/autoskillit/planner/__init__.py
@@ -19,7 +19,7 @@ from autoskillit.planner.merge import (
     build_plan_snapshot,
     extract_item,
     merge_files,
-    merge_tier_dir,
+    merge_tier_results,
     replace_item,
 )
 from autoskillit.planner.schema import (
@@ -56,7 +56,7 @@ __all__ = [
     "PlannerManifest",
     "PlannerManifestItem",
     "merge_files",
-    "merge_tier_dir",
+    "merge_tier_results",
     "extract_item",
     "replace_item",
     "build_plan_snapshot",

--- a/src/autoskillit/planner/merge.py
+++ b/src/autoskillit/planner/merge.py
@@ -97,6 +97,42 @@ def merge_files(
     return result
 
 
+def _write_refine_contexts(
+    planner_dir: Path,
+    assignments: list[dict[str, Any]],
+    task_file_path: str,
+) -> list[str]:
+    phase_groups: dict[str, list[dict[str, Any]]] = {}
+    for assignment in assignments:
+        phase_id = assignment.get("phase_id", "")
+        if phase_id:
+            phase_groups.setdefault(phase_id, []).append(assignment)
+
+    contexts_dir = planner_dir / "refine_contexts"
+    contexts_dir.mkdir(parents=True, exist_ok=True)
+
+    context_paths: list[str] = []
+    for phase_id in sorted(phase_groups):
+        own = phase_groups[phase_id]
+        peer_summaries: list[dict[str, str]] = [
+            {"id": a.get("id", ""), "name": a.get("name", ""), "goal": a.get("goal", "")}
+            for pid, peers in sorted(phase_groups.items())
+            if pid != phase_id
+            for a in peers
+        ]
+        context: dict[str, Any] = {
+            "phase_id": phase_id,
+            "task_file_path": task_file_path,
+            "assignments": own,
+            "peer_summaries": peer_summaries,
+        }
+        ctx_path = contexts_dir / f"context_{phase_id}.json"
+        write_versioned_json(ctx_path, context, schema_version=1)
+        context_paths.append(str(ctx_path))
+
+    return context_paths
+
+
 def extract_item(
     source_path: str,
     item_id: str,
@@ -160,7 +196,7 @@ def replace_item(
     return {"replaced_id": item_id, "updated_path": str(source_path)}
 
 
-def merge_tier_dir(
+def merge_tier_results(
     results_dir: str,
     output_path: str,
     key: str,
@@ -171,13 +207,20 @@ def merge_tier_dir(
     paths = sorted(Path(results_dir).glob("*_result.json"))
     if not paths:
         raise ValueError(f"No *_result.json files found in {results_dir}")
-    return merge_files(
+    result = merge_files(
         file_paths=[str(p) for p in paths],
         output_path=output_path,
         key=key,
         task_file_path=task_file_path,
         source_dir=source_dir,
     )
+    if key == "assignments":
+        merged_data = json.loads(Path(output_path).read_text(encoding="utf-8"))
+        assignments = merged_data.get("assignments", [])
+        planner_dir = Path(output_path).parent
+        context_paths = _write_refine_contexts(planner_dir, assignments, task_file_path)
+        result["refine_context_paths"] = ",".join(context_paths)
+    return result
 
 
 def build_plan_snapshot(

--- a/src/autoskillit/planner/merge.py
+++ b/src/autoskillit/planner/merge.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import fcntl
 import json
+import re
 from pathlib import Path
 from typing import Any
 
@@ -131,6 +132,11 @@ def _write_refine_contexts(
             "assignments": own,
             "peer_summaries": peer_summaries,
         }
+        if not re.fullmatch(r"[A-Za-z0-9_\-]+", phase_id):
+            raise ValueError(
+                f"phase_id {phase_id!r} contains disallowed characters — "
+                "only alphanumeric, underscore, and hyphen are permitted in context filenames"
+            )
         ctx_path = contexts_dir / f"context_{phase_id}.json"
         write_versioned_json(ctx_path, context, schema_version=1)
         context_paths.append(str(ctx_path))

--- a/src/autoskillit/planner/merge.py
+++ b/src/autoskillit/planner/merge.py
@@ -107,6 +107,11 @@ def _write_refine_contexts(
         phase_id = assignment.get("phase_id", "")
         if phase_id:
             phase_groups.setdefault(phase_id, []).append(assignment)
+        else:
+            logger.warning(
+                "Assignment %r has no phase_id — skipped from refine contexts",
+                assignment.get("id", "<unknown>"),
+            )
 
     contexts_dir = planner_dir / "refine_contexts"
     contexts_dir.mkdir(parents=True, exist_ok=True)
@@ -217,9 +222,14 @@ def merge_tier_results(
     if key == "assignments":
         merged_data = json.loads(Path(output_path).read_text(encoding="utf-8"))
         assignments = merged_data.get("assignments", [])
+        if not assignments:
+            logger.warning(
+                "merge_tier_results: no assignments found in %s — refine contexts will be empty",
+                output_path,
+            )
         planner_dir = Path(output_path).parent
         context_paths = _write_refine_contexts(planner_dir, assignments, task_file_path)
-        result["refine_context_paths"] = ",".join(context_paths)
+        result["refine_context_paths"] = json.dumps(context_paths)
     return result
 
 

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -2224,7 +2224,7 @@ callable_contracts:
       type: file_path
     - name: phase_ids
       type: str
-  autoskillit.planner.merge.merge_tier_dir:
+  autoskillit.planner.merge.merge_tier_results:
     inputs:
     - name: results_dir
       type: directory_path
@@ -2239,6 +2239,8 @@ callable_contracts:
     - name: merged_path
       type: file_path
     - name: item_count
+      type: str
+    - name: refine_context_paths
       type: str
   autoskillit.planner.create_run_dir:
     inputs:

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -2242,6 +2242,7 @@ callable_contracts:
       type: str
     - name: refine_context_paths
       type: str
+      when: "key == 'assignments'"
   autoskillit.planner.create_run_dir:
     inputs:
     - name: temp_dir

--- a/src/autoskillit/recipes/planner.yaml
+++ b/src/autoskillit/recipes/planner.yaml
@@ -201,7 +201,6 @@ steps:
       source_dir: "${{ inputs.source_dir }}"
     capture:
       combined_assignments_path: "${{ result.merged_path }}"
-      refine_context_paths: "${{ result.refine_context_paths }}"
     on_success: refine_assignments
     on_failure: escalate_stop
 

--- a/src/autoskillit/recipes/planner.yaml
+++ b/src/autoskillit/recipes/planner.yaml
@@ -140,7 +140,7 @@ steps:
   merge_phases:
     tool: run_python
     with:
-      callable: "autoskillit.planner.merge.merge_tier_dir"
+      callable: "autoskillit.planner.merge.merge_tier_results"
       results_dir: "${{ context.planner_dir }}/phases"
       output_path: "${{ context.planner_dir }}/combined_plan.json"
       key: "phases"
@@ -193,7 +193,7 @@ steps:
   merge_assignments:
     tool: run_python
     with:
-      callable: "autoskillit.planner.merge.merge_tier_dir"
+      callable: "autoskillit.planner.merge.merge_tier_results"
       results_dir: "${{ context.planner_dir }}/assignments"
       output_path: "${{ context.planner_dir }}/combined_assignments.json"
       key: "assignments"
@@ -201,6 +201,7 @@ steps:
       source_dir: "${{ inputs.source_dir }}"
     capture:
       combined_assignments_path: "${{ result.merged_path }}"
+      refine_context_paths: "${{ result.refine_context_paths }}"
     on_success: refine_assignments
     on_failure: escalate_stop
 
@@ -260,7 +261,7 @@ steps:
   merge_wps:
     tool: run_python
     with:
-      callable: "autoskillit.planner.merge.merge_tier_dir"
+      callable: "autoskillit.planner.merge.merge_tier_results"
       results_dir: "${{ context.planner_dir }}/work_packages"
       output_path: "${{ context.planner_dir }}/combined_wps.json"
       key: "work_packages"

--- a/tests/planner/test_merge.py
+++ b/tests/planner/test_merge.py
@@ -725,3 +725,15 @@ def test_merge_tier_results_no_refine_contexts_for_work_packages_key(tmp_path):
     result = merge_tier_results(str(results_dir), str(out), "work_packages")
     assert "refine_context_paths" not in result
     assert not (tmp_path / "refine_contexts").exists()
+
+
+def test_write_refine_contexts_rejects_unsafe_phase_id(tmp_path):
+    results_dir = tmp_path / "assignments"
+    results_dir.mkdir()
+    write_json(
+        results_dir / "evil_result.json",
+        {"id": "A1", "phase_id": "../../evil", "name": "x", "goal": "g"},
+    )
+    out = tmp_path / "combined.json"
+    with pytest.raises(ValueError, match="disallowed characters"):
+        merge_tier_results(str(results_dir), str(out), "assignments")

--- a/tests/planner/test_merge.py
+++ b/tests/planner/test_merge.py
@@ -557,10 +557,14 @@ def test_merge_tier_results_writes_refine_contexts_for_assignments(tmp_path):
     out = tmp_path / "combined_assignments.json"
     result = merge_tier_results(str(results_dir), str(out), "assignments")
     assert "refine_context_paths" in result
-    paths = result["refine_context_paths"].split(",")
+    paths = json.loads(result["refine_context_paths"])
     assert len(paths) == 2
-    assert (tmp_path / "refine_contexts" / "context_P1.json").exists()
-    assert (tmp_path / "refine_contexts" / "context_P2.json").exists()
+    p1_ctx = tmp_path / "refine_contexts" / "context_P1.json"
+    p2_ctx = tmp_path / "refine_contexts" / "context_P2.json"
+    assert p1_ctx.exists()
+    assert p2_ctx.exists()
+    assert str(p1_ctx) in paths
+    assert str(p2_ctx) in paths
 
 
 def test_refine_context_own_assignments_in_full_detail(tmp_path):
@@ -596,6 +600,7 @@ def test_refine_context_own_assignments_in_full_detail(tmp_path):
     assert own["id"] == "P1-A1"
     assert own["technical_approach"] == "JWT"
     assert own["proposed_work_packages"] == [{"id": "wp1"}]
+    assert all(a["id"] != "P2-A1" for a in ctx["assignments"])
 
 
 def test_refine_context_peer_summaries_have_filtered_fields(tmp_path):
@@ -672,9 +677,10 @@ def test_refine_context_paths_returned_sorted(tmp_path):
         )
     out = tmp_path / "combined_assignments.json"
     result = merge_tier_results(str(results_dir), str(out), "assignments")
-    paths = result["refine_context_paths"].split(",")
+    paths = json.loads(result["refine_context_paths"])
     phase_ids = [Path(p).stem.replace("context_", "") for p in paths]
     assert phase_ids == sorted(phase_ids)
+    assert set(phase_ids) == {"P1", "P2", "P3"}
 
 
 def test_merge_tier_results_no_refine_contexts_for_phases_key(tmp_path):

--- a/tests/planner/test_merge.py
+++ b/tests/planner/test_merge.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -8,10 +9,10 @@ from autoskillit.planner.merge import (
     build_plan_snapshot,
     extract_item,
     merge_files,
-    merge_tier_dir,
+    merge_tier_results,
     replace_item,
 )
-from tests.planner.conftest import make_phase_result, write_task_file
+from tests.planner.conftest import make_phase_result, write_json, write_task_file
 
 pytestmark = [pytest.mark.layer("planner"), pytest.mark.small, pytest.mark.feature("planner")]
 
@@ -426,20 +427,20 @@ def test_build_plan_snapshot_empty_dir_produces_empty_phases(tmp_path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# WP3: merge_tier_dir tests
+# WP3: merge_tier_results tests
 # ---------------------------------------------------------------------------
 
 
-def test_merge_tier_dir_empty_dir_raises(tmp_path) -> None:
+def test_merge_tier_results_empty_dir_raises(tmp_path) -> None:
     empty_dir = tmp_path / "phases"
     empty_dir.mkdir()
     out = tmp_path / "combined.json"
 
     with pytest.raises(ValueError, match="No \\*_result.json files found"):
-        merge_tier_dir(str(empty_dir), str(out), "phases")
+        merge_tier_results(str(empty_dir), str(out), "phases")
 
 
-def test_merge_tier_dir_single_file(tmp_path) -> None:
+def test_merge_tier_results_single_file(tmp_path) -> None:
     results_dir = tmp_path / "phases"
     results_dir.mkdir()
     (results_dir / "P1_result.json").write_text(
@@ -447,7 +448,7 @@ def test_merge_tier_dir_single_file(tmp_path) -> None:
     )
     out = tmp_path / "combined.json"
 
-    result = merge_tier_dir(str(results_dir), str(out), "phases")
+    result = merge_tier_results(str(results_dir), str(out), "phases")
 
     assert result["item_count"] == "1"
     assert out.exists()
@@ -493,7 +494,7 @@ def test_build_plan_snapshot_reads_task_from_task_file_path(tmp_path) -> None:
     assert data["task"] == "Full task from file"
 
 
-def test_merge_tier_dir_reads_task_from_task_file_path(tmp_path) -> None:
+def test_merge_tier_results_reads_task_from_task_file_path(tmp_path) -> None:
     results_dir = tmp_path / "phases"
     results_dir.mkdir()
     (results_dir / "P1_result.json").write_text(
@@ -503,7 +504,7 @@ def test_merge_tier_dir_reads_task_from_task_file_path(tmp_path) -> None:
     task_file = tmp_path / "task_desc.txt"
     task_file.write_text("Full task from file")
 
-    merge_tier_dir(str(results_dir), str(out), "phases", task_file_path=str(task_file))
+    merge_tier_results(str(results_dir), str(out), "phases", task_file_path=str(task_file))
 
     data = json.loads(out.read_text())
     assert data["task"] == "Full task from file"
@@ -521,3 +522,200 @@ def test_merge_files_reads_task_from_task_file_path(tmp_path) -> None:
 
     data = json.loads(out.read_text())
     assert data["task"] == "Full task from file"
+
+
+# ---------------------------------------------------------------------------
+# Per-phase refine context file tests
+# ---------------------------------------------------------------------------
+
+
+def test_merge_tier_results_writes_refine_contexts_for_assignments(tmp_path):
+    results_dir = tmp_path / "assignments"
+    results_dir.mkdir()
+    write_json(
+        results_dir / "P1_A1_result.json",
+        {
+            "id": "P1-A1",
+            "phase_id": "P1",
+            "name": "Auth",
+            "goal": "Auth goal",
+            "technical_approach": "JWT",
+            "proposed_work_packages": [],
+        },
+    )
+    write_json(
+        results_dir / "P2_A1_result.json",
+        {
+            "id": "P2-A1",
+            "phase_id": "P2",
+            "name": "Data",
+            "goal": "Data goal",
+            "technical_approach": "ORM",
+            "proposed_work_packages": [],
+        },
+    )
+    out = tmp_path / "combined_assignments.json"
+    result = merge_tier_results(str(results_dir), str(out), "assignments")
+    assert "refine_context_paths" in result
+    paths = result["refine_context_paths"].split(",")
+    assert len(paths) == 2
+    assert (tmp_path / "refine_contexts" / "context_P1.json").exists()
+    assert (tmp_path / "refine_contexts" / "context_P2.json").exists()
+
+
+def test_refine_context_own_assignments_in_full_detail(tmp_path):
+    results_dir = tmp_path / "assignments"
+    results_dir.mkdir()
+    write_json(
+        results_dir / "P1_A1_result.json",
+        {
+            "id": "P1-A1",
+            "phase_id": "P1",
+            "name": "Auth",
+            "goal": "Auth goal",
+            "technical_approach": "JWT",
+            "proposed_work_packages": [{"id": "wp1"}],
+        },
+    )
+    write_json(
+        results_dir / "P2_A1_result.json",
+        {
+            "id": "P2-A1",
+            "phase_id": "P2",
+            "name": "Data",
+            "goal": "Data goal",
+            "technical_approach": "ORM",
+            "proposed_work_packages": [],
+        },
+    )
+    out = tmp_path / "combined_assignments.json"
+    merge_tier_results(str(results_dir), str(out), "assignments")
+    ctx = json.loads((tmp_path / "refine_contexts" / "context_P1.json").read_text())
+    assert len(ctx["assignments"]) == 1
+    own = ctx["assignments"][0]
+    assert own["id"] == "P1-A1"
+    assert own["technical_approach"] == "JWT"
+    assert own["proposed_work_packages"] == [{"id": "wp1"}]
+
+
+def test_refine_context_peer_summaries_have_filtered_fields(tmp_path):
+    results_dir = tmp_path / "assignments"
+    results_dir.mkdir()
+    write_json(
+        results_dir / "P1_A1_result.json",
+        {
+            "id": "P1-A1",
+            "phase_id": "P1",
+            "name": "Auth",
+            "goal": "Auth goal",
+            "technical_approach": "JWT",
+            "proposed_work_packages": [],
+        },
+    )
+    write_json(
+        results_dir / "P2_A1_result.json",
+        {
+            "id": "P2-A1",
+            "phase_id": "P2",
+            "name": "Data",
+            "goal": "Data goal",
+            "technical_approach": "ORM",
+            "proposed_work_packages": [{"id": "wp2"}],
+        },
+    )
+    out = tmp_path / "combined_assignments.json"
+    merge_tier_results(str(results_dir), str(out), "assignments")
+    ctx = json.loads((tmp_path / "refine_contexts" / "context_P1.json").read_text())
+    assert len(ctx["peer_summaries"]) == 1
+    peer = ctx["peer_summaries"][0]
+    assert peer == {"id": "P2-A1", "name": "Data", "goal": "Data goal"}
+    assert "technical_approach" not in peer
+    assert "proposed_work_packages" not in peer
+
+
+def test_refine_context_has_task_file_path_not_inline_task(tmp_path):
+    results_dir = tmp_path / "assignments"
+    results_dir.mkdir()
+    task_path = write_task_file(tmp_path, "Build a system")
+    write_json(
+        results_dir / "P1_A1_result.json",
+        {
+            "id": "P1-A1",
+            "phase_id": "P1",
+            "name": "Auth",
+            "goal": "Auth goal",
+            "technical_approach": "",
+            "proposed_work_packages": [],
+        },
+    )
+    out = tmp_path / "combined_assignments.json"
+    merge_tier_results(str(results_dir), str(out), "assignments", task_file_path=task_path)
+    ctx = json.loads((tmp_path / "refine_contexts" / "context_P1.json").read_text())
+    assert ctx["task_file_path"] == task_path
+    assert "task" not in ctx
+
+
+def test_refine_context_paths_returned_sorted(tmp_path):
+    results_dir = tmp_path / "assignments"
+    results_dir.mkdir()
+    for pid in ("P3", "P1", "P2"):
+        write_json(
+            results_dir / f"{pid}_A1_result.json",
+            {
+                "id": f"{pid}-A1",
+                "phase_id": pid,
+                "name": pid,
+                "goal": f"{pid} goal",
+                "technical_approach": "",
+                "proposed_work_packages": [],
+            },
+        )
+    out = tmp_path / "combined_assignments.json"
+    result = merge_tier_results(str(results_dir), str(out), "assignments")
+    paths = result["refine_context_paths"].split(",")
+    phase_ids = [Path(p).stem.replace("context_", "") for p in paths]
+    assert phase_ids == sorted(phase_ids)
+
+
+def test_merge_tier_results_no_refine_contexts_for_phases_key(tmp_path):
+    results_dir = tmp_path / "phases"
+    results_dir.mkdir()
+    write_json(
+        results_dir / "P1_result.json",
+        {
+            "id": "P1",
+            "name": "Phase 1",
+            "ordering": 1,
+            "goal": "g",
+            "scope": [],
+        },
+    )
+    out = tmp_path / "combined_plan.json"
+    result = merge_tier_results(str(results_dir), str(out), "phases")
+    assert "refine_context_paths" not in result
+    assert not (tmp_path / "refine_contexts").exists()
+
+
+def test_merge_tier_results_no_refine_contexts_for_work_packages_key(tmp_path):
+    results_dir = tmp_path / "work_packages"
+    results_dir.mkdir()
+    write_json(
+        results_dir / "WP1_result.json",
+        {
+            "id": "P1-A1-WP1",
+            "name": "WP One",
+            "summary": "s",
+            "goal": "g",
+            "technical_steps": [],
+            "files_touched": [],
+            "apis_defined": [],
+            "apis_consumed": [],
+            "depends_on": [],
+            "deliverables": ["d1"],
+            "acceptance_criteria": [],
+        },
+    )
+    out = tmp_path / "combined_wps.json"
+    result = merge_tier_results(str(results_dir), str(out), "work_packages")
+    assert "refine_context_paths" not in result
+    assert not (tmp_path / "refine_contexts").exists()

--- a/tests/planner/test_planner.py
+++ b/tests/planner/test_planner.py
@@ -136,12 +136,6 @@ def test_planner_feature_skill_categories() -> None:
 # --- T6: New callables importable ---
 
 
-def test_merge_tier_results_importable() -> None:
-    from autoskillit.planner.merge import merge_tier_results
-
-    assert callable(merge_tier_results)
-
-
 def test_expand_assignments_importable() -> None:
     from autoskillit.planner.manifests import expand_assignments
 

--- a/tests/planner/test_planner.py
+++ b/tests/planner/test_planner.py
@@ -31,7 +31,7 @@ def test_planner_all_exports() -> None:
         "PlannerManifest",
         "PlannerManifestItem",
         "merge_files",
-        "merge_tier_dir",
+        "merge_tier_results",
         "extract_item",
         "replace_item",
         "build_plan_snapshot",
@@ -136,10 +136,10 @@ def test_planner_feature_skill_categories() -> None:
 # --- T6: New callables importable ---
 
 
-def test_merge_tier_dir_importable() -> None:
-    from autoskillit.planner.merge import merge_tier_dir
+def test_merge_tier_results_importable() -> None:
+    from autoskillit.planner.merge import merge_tier_results
 
-    assert callable(merge_tier_dir)
+    assert callable(merge_tier_results)
 
 
 def test_expand_assignments_importable() -> None:
@@ -157,8 +157,8 @@ def test_expand_wps_importable() -> None:
 # --- T7: New callables functional tests ---
 
 
-def test_merge_tier_dir_globs_and_merges(tmp_path) -> None:
-    from autoskillit.planner.merge import merge_tier_dir
+def test_merge_tier_results_globs_and_merges(tmp_path) -> None:
+    from autoskillit.planner.merge import merge_tier_results
 
     results_dir = tmp_path / "phases"
     results_dir.mkdir()
@@ -167,7 +167,7 @@ def test_merge_tier_dir_globs_and_merges(tmp_path) -> None:
             json.dumps({"id": pid, "name": f"Phase {pid}", "ordering": int(pid[1])})
         )
     out = tmp_path / "combined.json"
-    result = merge_tier_dir(str(results_dir), str(out), "phases")
+    result = merge_tier_results(str(results_dir), str(out), "phases")
     assert result["item_count"] == "2"
     assert out.exists()
     merged = json.loads(out.read_text())

--- a/tests/recipe/test_planner_recipe.py
+++ b/tests/recipe/test_planner_recipe.py
@@ -239,14 +239,14 @@ def test_refine_tier_steps_use_correct_skills(planner_recipe, step_name, skill_n
     assert skill_name in step.with_args.get("skill_command", "")
 
 
-# --- T5: Merge steps use merge_tier_dir ---
+# --- T5: Merge steps use merge_tier_results ---
 
 
 @pytest.mark.parametrize("step_name", ["merge_phases", "merge_assignments", "merge_wps"])
-def test_merge_steps_use_merge_tier_dir(planner_recipe, step_name):
+def test_merge_steps_use_merge_tier_results(planner_recipe, step_name):
     step = planner_recipe.steps[step_name]
     assert step.tool == "run_python"
-    assert step.with_args.get("callable") == "autoskillit.planner.merge.merge_tier_dir"
+    assert step.with_args.get("callable") == "autoskillit.planner.merge.merge_tier_results"
 
 
 # --- validate_task_alignment step integration ---


### PR DESCRIPTION
## Summary

Two changes in one commit:

1. **Rename `merge_tier_dir` → `merge_tier_results`** across all eight files listed in the issue. This is a pure identifier rename — no behavior changes.

2. **Extend `merge_tier_results` to produce per-phase refine context files** when `key == "assignments"`. After writing `combined_assignments.json`, the function groups merged assignments by `phase_id`, writes one `context_{phase_id}.json` per phase into `planner_dir/refine_contexts/`, and returns `refine_context_paths` (comma-separated) in its result dict. Each context file contains the own phase's assignments in full detail, other phases' assignments as filtered summaries (`{id, name, goal}` only), and a `task_file_path` reference (not inline task content). The recipe `merge_assignments` step capture dict is updated to capture `refine_context_paths`. The `refine_assignments` step itself is not changed here — consuming the per-phase contexts via `dispatch_items` depends on #1645.

Closes #1646

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260503-013455-376704/.autoskillit/temp/make-plan/rename_merge_tier_dir_and_extend_plan_2026-05-03_120000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 2.6k | 21.0k | 802.2k | 59.9k | 1 | 8m 50s |
| verify | 92 | 9.4k | 432.9k | 42.9k | 1 | 4m 53s |
| implement | 2.3k | 16.7k | 2.1M | 63.1k | 1 | 7m 5s |
| prepare_pr | 60 | 4.5k | 226.6k | 30.2k | 1 | 1m 33s |
| compose_pr | 59 | 2.3k | 194.9k | 19.8k | 1 | 42s |
| review_pr | 212 | 60.8k | 1.3M | 138.6k | 2 | 13m 35s |
| resolve_review | 744 | 50.6k | 5.9M | 167.2k | 2 | 22m 53s |
| **Total** | 6.1k | 165.4k | 10.9M | 521.7k | | 59m 31s |
## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 298 | 7069.6 | 211.8 | 56.1 |
| fix | 1 | 848375.0 | 40550.0 | 5980.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **299** | 15424.2 | 857.9 | 200.6 |