### PR TITLE
Implementation Plan: Per-Phase Dispatch for refine_assignments + Post-Refine Conflict Resolution

### DIFF
--- a/src/autoskillit/planner/__init__.py
+++ b/src/autoskillit/planner/__init__.py
@@ -19,6 +19,7 @@ from autoskillit.planner.merge import (
     build_plan_snapshot,
     extract_item,
     merge_files,
+    merge_refined_assignments,
     merge_tier_results,
     replace_item,
 )
@@ -56,6 +57,7 @@ __all__ = [
     "PlannerManifest",
     "PlannerManifestItem",
     "merge_files",
+    "merge_refined_assignments",
     "merge_tier_results",
     "extract_item",
     "replace_item",

--- a/src/autoskillit/planner/merge.py
+++ b/src/autoskillit/planner/merge.py
@@ -235,8 +235,64 @@ def merge_tier_results(
             )
         planner_dir = Path(output_path).parent
         context_paths = _write_refine_contexts(planner_dir, assignments, task_file_path)
-        result["refine_context_paths"] = json.dumps(context_paths)
+        result["refine_context_paths"] = ",".join(context_paths)
     return result
+
+
+def merge_refined_assignments(
+    planner_dir: str,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    contexts_dir = Path(planner_dir) / "refine_contexts"
+    result_files = sorted(contexts_dir.glob("*_result.json"))
+    if not result_files:
+        raise ValueError(
+            f"No *_result.json files found in {contexts_dir}. "
+            "Run refine_assignments dispatch before calling this function."
+        )
+
+    all_assignments: list[dict[str, Any]] = []
+    for path in result_files:
+        data = json.loads(path.read_text())
+        all_assignments.extend(data.get("assignments", []))
+
+    def _sort_key(assignment_id: str) -> tuple[int, ...]:
+        return tuple(int(n) for n in re.findall(r"\d+", assignment_id))
+
+    # Single-pass: for each (file, assignment_id) claim, keep the earliest assignment_id
+    file_owner: dict[str, str] = {}
+    for assignment in all_assignments:
+        aid = assignment.get("id", "")
+        for wp in assignment.get("proposed_work_packages", []):
+            for f in wp.get("files_touched", []):
+                if f not in file_owner or _sort_key(aid) < _sort_key(file_owner[f]):
+                    file_owner[f] = aid
+
+    # Count conflicts: files with more than one claimant
+    file_claimants: dict[str, set[str]] = {}
+    for assignment in all_assignments:
+        aid = assignment.get("id", "")
+        for wp in assignment.get("proposed_work_packages", []):
+            for f in wp.get("files_touched", []):
+                file_claimants.setdefault(f, set()).add(aid)
+    conflict_count = sum(1 for claimants in file_claimants.values() if len(claimants) > 1)
+
+    # Strip files from losing assignments
+    for assignment in all_assignments:
+        aid = assignment.get("id", "")
+        for wp in assignment.get("proposed_work_packages", []):
+            wp["files_touched"] = [
+                f for f in wp.get("files_touched", []) if file_owner.get(f) == aid
+            ]
+
+    output_path = Path(planner_dir) / "refined_assignments.json"
+    write_versioned_json(output_path, {"assignments": all_assignments}, schema_version=1)
+
+    return {
+        "refined_assignments_path": str(output_path),
+        "item_count": str(len(all_assignments)),
+        "conflict_count": str(conflict_count),
+    }
 
 
 def build_plan_snapshot(

--- a/src/autoskillit/planner/merge.py
+++ b/src/autoskillit/planner/merge.py
@@ -253,7 +253,11 @@ def merge_refined_assignments(
 
     all_assignments: list[dict[str, Any]] = []
     for path in result_files:
-        data = json.loads(path.read_text())
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("Skipping malformed result file %s: %s", path, exc)
+            continue
         all_assignments.extend(data.get("assignments", []))
 
     def _sort_key(assignment_id: str) -> tuple[int, ...]:

--- a/src/autoskillit/planner/merge.py
+++ b/src/autoskillit/planner/merge.py
@@ -260,6 +260,17 @@ def merge_refined_assignments(
             continue
         all_assignments.extend(data.get("assignments", []))
 
+    valid_assignments: list[dict[str, Any]] = []
+    for a in all_assignments:
+        if not a.get("id"):
+            logger.warning(
+                "merge_refined_assignments: skipping assignment with missing id: %r",
+                a.get("name", "<unknown>"),
+            )
+        else:
+            valid_assignments.append(a)
+    all_assignments = valid_assignments
+
     def _sort_key(assignment_id: str) -> tuple[int, ...]:
         return tuple(int(n) for n in re.findall(r"\d+", assignment_id))
 

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -1902,7 +1902,7 @@ skills:
     write_behavior: always
   planner-refine-assignments:
     inputs:
-      - name: combined_assignments_path
+      - name: context_file
         type: file_path
         required: true
       - name: refined_plan_path
@@ -1912,12 +1912,12 @@ skills:
         type: directory_path
         required: true
     outputs:
-      - name: refined_assignments_path
+      - name: phase_refined_path
         type: file_path
     expected_output_patterns:
-      - "refined_assignments_path\\s*=\\s*\\S+"
+      - "phase_refined_path\\s*=\\s*\\S+"
     pattern_examples:
-      - "refined_assignments_path = /tmp/autoskillit/planner/run-20260101-120000/refined_assignments.json\n%%ORDER_UP%%"
+      - "phase_refined_path = /tmp/autoskillit/planner/run-20260101-120000/refine_contexts/P1_result.json\n%%ORDER_UP%%"
     write_behavior: always
   planner-refine-wps:
     inputs:

--- a/src/autoskillit/recipes/contracts/planner.yaml
+++ b/src/autoskillit/recipes/contracts/planner.yaml
@@ -106,7 +106,7 @@ skills:
     write_behavior: always
   planner-refine-assignments:
     inputs:
-    - name: combined_assignments_path
+    - name: context_file
       type: file_path
       required: true
       recommended: false
@@ -119,12 +119,12 @@ skills:
       required: true
       recommended: false
     outputs:
-    - name: refined_assignments_path
+    - name: phase_refined_path
       type: file_path
     expected_output_patterns:
-    - refined_assignments_path\s*=\s*\S+
+    - phase_refined_path\s*=\s*\S+
     pattern_examples:
-    - 'refined_assignments_path = /tmp/autoskillit/planner/run-20260101-120000/refined_assignments.json
+    - 'phase_refined_path = /tmp/autoskillit/planner/run-20260101-120000/refine_contexts/P1_result.json
 
       %%ORDER_UP%%'
     write_behavior: always

--- a/src/autoskillit/recipes/planner.yaml
+++ b/src/autoskillit/recipes/planner.yaml
@@ -206,7 +206,6 @@ steps:
       task_file_path: "${{ context.task_file_path }}"
       source_dir: "${{ inputs.source_dir }}"
     capture:
-      combined_assignments_path: "${{ result.merged_path }}"
       refine_context_paths: "${{ result.refine_context_paths }}"
     on_success: refine_assignments
     on_failure: escalate_stop

--- a/src/autoskillit/recipes/planner.yaml
+++ b/src/autoskillit/recipes/planner.yaml
@@ -207,19 +207,33 @@ steps:
       source_dir: "${{ inputs.source_dir }}"
     capture:
       combined_assignments_path: "${{ result.merged_path }}"
+      refine_context_paths: "${{ result.refine_context_paths }}"
     on_success: refine_assignments
     on_failure: escalate_stop
 
   refine_assignments:
     tool: run_skill
     with:
-      skill_command: >
-        /autoskillit:planner-refine-assignments
-        ${{ context.combined_assignments_path }}
-        ${{ context.refined_plan_path }}
-        ${{ context.planner_dir }}
+      skill_command: "/autoskillit:planner-refine-assignments {context_path} ${{ context.refined_plan_path }} ${{ context.planner_dir }}"
       cwd: "${{ inputs.source_dir }}"
       output_dir: "${{ context.planner_dir }}"
+      dispatch_items: "${{ context.refine_context_paths }}"
+    capture_list:
+      phase_refined_path: "${{ result.phase_refined_path }}"
+    on_success: merge_refined_assignments
+    on_failure: escalate_stop
+    note: >
+      PARALLEL DISPATCH: context.refine_context_paths contains comma-separated
+      paths to per-phase context files produced by merge_tier_results.
+      For each context_path, substitute it into the {context_path} placeholder
+      and issue one run_skill call. Run ALL refinements in parallel.
+      Accumulate results via capture_list.
+
+  merge_refined_assignments:
+    tool: run_python
+    with:
+      callable: "autoskillit.planner.merge.merge_refined_assignments"
+      planner_dir: "${{ context.planner_dir }}"
     capture:
       refined_assignments_path: "${{ result.refined_assignments_path }}"
     on_success: expand_wps

--- a/src/autoskillit/skills_extended/planner-refine-assignments/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine-assignments/SKILL.md
@@ -1,107 +1,119 @@
 ---
 name: planner-refine-assignments
 categories: [planner]
-description: Refine elaborated assignments with cross-assignment visibility via parallel L0 subagents (L1+L0 pattern)
+description: Refine elaborated assignments for a single phase via parallel L0 subagents (L1+L0 pattern), using per-phase context file with peer_summaries for cross-phase visibility
 hooks:
   PreToolUse:
     - matcher: "*"
       hooks:
         - type: command
-          command: "echo '[SKILL: planner-refine-assignments] Refining assignments with cross-visibility...'"
+          command: "echo '[SKILL: planner-refine-assignments] Refining phase assignments with cross-visibility...'"
           once: true
 ---
 
 # planner-refine-assignments
 
-L1 session that refines a `combined_assignments.json` (a `PlanDocument` with all
-assignments in `AssignmentElaborated` form) by spawning one L0 subagent per
-assignment in parallel (batched to 6). Each L0 reviews its assigned assignment in
-the context of all other assignments and the phase context from `refined_plan.json`,
-returning structured suggestions. L1 collects these suggestions, resolves
-cross-assignment WP ownership conflicts, applies field-level edits, and writes
-`refined_assignments.json`.
+L1 session that refines the assignments for a single phase by spawning one L0 subagent per
+assignment in parallel (3–5 assignments per phase). Receives a per-phase context file produced
+by `merge_tier_results` → `_write_refine_contexts`, which contains only this phase's assignments
+and `peer_summaries` (id/name/goal stubs) for all other phases. Each L0 reviews its assignment
+in the context of peer_summaries and `refined_plan.json`, returning structured suggestions. L1
+applies suggestions, resolves intra-phase WP ownership conflicts, and writes the phase result
+file to `$3/refine_contexts/{phase_id}_result.json`.
 
 ## When to Use
 
-- Launched by the L2 planner recipe after the parallel assignment elaboration merge step
-- Accepts the `combined_assignments.json` output from the merge step and `refined_plan.json` for phase context
-- Produces `refined_assignments.json` as input for downstream planner steps
+- Dispatched by the L2 planner recipe in parallel — one session per phase
+- Accepts a per-phase context file from `$3/refine_contexts/context_{phase_id}.json` and `refined_plan.json` for phase context
+- Produces `{phase_id}_result.json` as input for the downstream `merge_refined_assignments` step
 
 ## Arguments
 
-- **$1** — Absolute path to `combined_assignments.json` (PlanDocument, all assignments as AssignmentElaborated)
+- **$1** — Absolute path to the per-phase context file (`$3/refine_contexts/context_{phase_id}.json`). The file contains:
+  - `phase_id` — identifier for the phase this session processes
+  - `task_file_path` — path to the task description file (read from disk, not inline)
+  - `assignments` — full AssignmentElaborated objects for this phase only (3–5 entries)
+  - `peer_summaries` — `{id, name, goal}` stubs for all assignments in other phases
 - **$2** — Absolute path to `refined_plan.json` (PlanDocument with phases as PhaseElaborated, for phase context)
-- **$3** — Absolute path to the run-scoped planner directory (e.g., `{{AUTOSKILLIT_TEMP}}/planner/run-YYYYMMDD-HHMMSS`). Output is written to `$3/refined_assignments.json`.
+- **$3** — Absolute path to the run-scoped planner directory (e.g., `{{AUTOSKILLIT_TEMP}}/planner/run-YYYYMMDD-HHMMSS`). Output is written to `$3/refine_contexts/{phase_id}_result.json`.
 
 ## Critical Constraints
 
 **NEVER:**
 - Write any file outside `$3/`
-- Directly modify `combined_assignments.json` ($1) — always write a new `refined_assignments.json`
+- Directly modify the context file ($1) — always write a new result file
 - Allow an L0 subagent to write files directly (L0s return structured text only)
-- Emit `refined_assignments_path` before writing `refined_assignments.json`
-- Skip emitting `refined_assignments_path` even if all L0s fail (write unchanged assignments, still emit)
+- Emit `phase_refined_path` before writing the result file
+- Skip emitting `phase_refined_path` even if all L0s fail (write unchanged assignments, still emit)
 - Spawn more than 6 L0s in a single parallel batch
 - Read `{{AUTOSKILLIT_TEMP}}` artifacts not passed as positional arguments
 - Run subagents in the background (`run_in_background: true` is prohibited)
 
 **ALWAYS:**
+- Read `phase_id` from the context file to construct the output path
 - Validate each L0 response for `assignment_id`, `changes` (array), `dependency_corrections` (array), `wp_proposal_adjustments` (array)
 - Log `WARNING` to stdout for any L0 response that fails validation (skip that assignment)
-- Log `CRITICAL` to stdout for any L0 subagent that fails entirely (proceed with N-1)
+- Log `CRITICAL` to stdout for any L0 subagent that fails entirely (proceed with N-1, partial result)
 - When two assignments propose WPs covering the same files, assign ownership to the numerically earlier assignment_id using natural sort on numeric suffixes (e.g. `P1-A1` beats `P1-A2`; `P1-A2` beats `P1-A10`); log each resolution
-- Emit: `refined_assignments_path = <absolute path to refined_assignments.json>`
+- Emit: `phase_refined_path = <absolute path to $3/refine_contexts/{phase_id}_result.json>`
 
 ## Workflow
 
 ### Step 1: Parse input and validate
 
-Read `$1` (combined_assignments.json). Parse as a `PlanDocument`. Extract all
-assignment IDs from `assignments[*].id`. Fail immediately (exit non-zero) if
-`assignments` is empty or the file is malformed — do not proceed to spawn L0s.
-The failure message must include the file path and the parse/validation error string:
+Read `$1` (per-phase context file). Extract `phase_id`, `assignments`, `peer_summaries`, and
+`task_file_path`. Fail immediately (exit non-zero) if `assignments` is empty or the file is
+malformed — do not proceed to spawn L0s. The failure message must include the file path and the
+parse/validation error string:
 ```
 FATAL: failed to parse {path}: {error_detail}
 ```
 
+Read the task description from disk at `task_file_path` (not inline from the context file).
+
 Read `$2` (refined_plan.json). Build a map `phase_id → PhaseElaborated` for L0 context.
 
-Input schema (PlanDocument with AssignmentElaborated assignments):
+Input schema for the per-phase context file:
 ```json
 {
-  "schema_version": 1,
-  "task": "...",
-  "source_dir": "...",
+  "phase_id": "P2",
+  "task_file_path": "/path/to/task.md",
   "assignments": [
     {
-      "id": "P1-A1",
-      "phase_id": "P1",
+      "id": "P2-A1",
+      "phase_id": "P2",
       "name": "...",
       "goal": "...",
       "technical_approach": "...",
       "dependency_notes": "...",
       "work_packages": [...]
     }
+  ],
+  "peer_summaries": [
+    {"id": "P1-A1", "name": "...", "goal": "..."},
+    {"id": "P3-A1", "name": "...", "goal": "..."}
   ]
 }
 ```
 
 ### Step 2: Build L0 context packets
 
-Read the `task` field from the combined assignments document. Each L0 subagent must verify
-that the assignment's goal, scope, and deliverables serve the stated task. Flag assignments
-that introduce work not requested by the task as scope creep.
+Read the task description from `task_file_path`. Each L0 subagent must verify that the
+assignment's goal, scope, and deliverables serve the stated task. Flag assignments that
+introduce work not requested by the task as scope creep.
 
-For each assignment, build a context packet containing:
-- The full serialized `combined_assignments.json` content (all peers visible)
+For each assignment in `assignments`, build a context packet containing:
+- The full serialized assignment object (AssignmentElaborated)
+- The `peer_summaries` list for cross-phase dependency detection
 - The `PhaseElaborated` entry for the assignment's `phase_id` from `$2`
 - The `target_assignment_id`
-- Instructions: review the target assignment in light of all other assignments; return structured suggestions only — do NOT edit files
+- Instructions: review the target assignment in light of peer_summaries; return structured suggestions only — do NOT edit files
 
 ### Step 3: Spawn parallel L0 subagents
 
-If assignment count ≤ 6: spawn all in one parallel batch via Agent/Task.
-If assignment count > 6: spawn sequential batches of 6. Between batches, emit
+Since each phase has 3–5 assignments (always within the 6-L0 ceiling), spawn all in one
+parallel batch via Agent/Task. Do not spawn more than 6 L0s in a single parallel batch:
+if assignment count > 6 (unexpected), spawn sequential batches of 6. Between batches, emit
 anti-prose guard line: `--- next batch ---`.
 
 Each L0 must return structured text in this exact format:
@@ -158,8 +170,8 @@ Apply the `remove` action from the losing assignment's `wp_proposal_adjustments`
 ### Step 6: Apply changes
 
 Apply all validated `changes` to the in-memory assignments document, in assignment
-ID order (P1-A1 → P1-AN → P2-A1 ...). Apply conflict resolutions before applying
-changes for affected assignments. Skip unrecognized field names:
+ID order. Apply conflict resolutions before applying changes for affected assignments.
+Skip unrecognized field names:
 ```
 WARNING: Unrecognized field '{field}' in changes for {assignment_id} — skipping
 ```
@@ -167,12 +179,18 @@ Apply `dependency_corrections` by appending to the `dependency_notes` field.
 
 ### Step 7: Write output
 
-Write the updated `PlanDocument` to `$3/refined_assignments.json`. The output
-schema is identical to the input `combined_assignments.json` (a `PlanDocument`
-with `assignments: list[AssignmentElaborated]`).
+Write the phase result file to `$3/refine_contexts/{phase_id}_result.json`, where
+`phase_id` is read from the context file. The output schema:
+```json
+{
+  "schema_version": 1,
+  "assignments": [...]
+}
+```
+The `assignments` list contains only this phase's assignments (3–5 entries) with refinements applied.
 
 ### Step 8: Emit output token
 
 ```
-refined_assignments_path = <absolute path to $3/refined_assignments.json>
+phase_refined_path = <absolute path to $3/refine_contexts/{phase_id}_result.json>
 ```

--- a/tests/execution/test_headless_path_validation.py
+++ b/tests/execution/test_headless_path_validation.py
@@ -359,7 +359,7 @@ class TestOutputPathTokensDerivedFromContracts:
             # planner-refine-phases output
             "refined_plan_path",
             # planner-refine-assignments output
-            "refined_assignments_path",
+            "phase_refined_path",
             # planner-refine-wps output
             "refined_wps_path",
             # planner-validate-task-alignment output

--- a/tests/planner/test_merge.py
+++ b/tests/planner/test_merge.py
@@ -9,6 +9,7 @@ from autoskillit.planner.merge import (
     build_plan_snapshot,
     extract_item,
     merge_files,
+    merge_refined_assignments,
     merge_tier_results,
     replace_item,
 )
@@ -677,7 +678,7 @@ def test_refine_context_paths_returned_sorted(tmp_path):
         )
     out = tmp_path / "combined_assignments.json"
     result = merge_tier_results(str(results_dir), str(out), "assignments")
-    paths = json.loads(result["refine_context_paths"])
+    paths = result["refine_context_paths"].split(",")
     phase_ids = [Path(p).stem.replace("context_", "") for p in paths]
     assert phase_ids == sorted(phase_ids)
     assert set(phase_ids) == {"P1", "P2", "P3"}
@@ -737,3 +738,153 @@ def test_write_refine_contexts_rejects_unsafe_phase_id(tmp_path):
     out = tmp_path / "combined.json"
     with pytest.raises(ValueError, match="disallowed characters"):
         merge_tier_results(str(results_dir), str(out), "assignments")
+
+
+# ---------------------------------------------------------------------------
+# merge_refined_assignments tests (B1–B5)
+# ---------------------------------------------------------------------------
+
+
+def _make_assignment(aid: str, phase_id: str, files: list[str]) -> dict:
+    return {
+        "id": aid,
+        "phase_id": phase_id,
+        "name": f"Assignment {aid}",
+        "goal": f"Goal for {aid}",
+        "technical_approach": "",
+        "proposed_work_packages": [
+            {
+                "id": f"{aid}-WP1",
+                "name": "WP1",
+                "summary": "s",
+                "goal": "g",
+                "technical_steps": [],
+                "files_touched": files,
+                "apis_defined": [],
+                "apis_consumed": [],
+                "depends_on": [],
+                "deliverables": ["d1"],
+                "acceptance_criteria": [],
+            }
+        ],
+    }
+
+
+def _write_phase_result(dir_: Path, phase_id: str, assignments: list[dict]) -> None:
+    write_json(
+        dir_ / f"{phase_id}_result.json",
+        {"schema_version": 1, "assignments": assignments},
+    )
+
+
+def test_merge_refined_assignments_basic(tmp_path):
+    ctx_dir = tmp_path / "refine_contexts"
+    ctx_dir.mkdir()
+    _write_phase_result(
+        ctx_dir,
+        "P1",
+        [
+            _make_assignment("P1-A1", "P1", ["src/a.py"]),
+            _make_assignment("P1-A2", "P1", ["src/b.py"]),
+        ],
+    )
+    _write_phase_result(
+        ctx_dir,
+        "P2",
+        [
+            _make_assignment("P2-A1", "P2", ["src/c.py"]),
+            _make_assignment("P2-A2", "P2", ["src/d.py"]),
+        ],
+    )
+
+    result = merge_refined_assignments(planner_dir=str(tmp_path))
+
+    assert "refined_assignments_path" in result
+    out_path = Path(result["refined_assignments_path"])
+    assert out_path.exists()
+    data = json.loads(out_path.read_text())
+    assert len(data["assignments"]) == 4
+    assert result["item_count"] == "4"
+
+
+def test_merge_refined_assignments_wp_conflict_earlier_wins(tmp_path):
+    ctx_dir = tmp_path / "refine_contexts"
+    ctx_dir.mkdir()
+    _write_phase_result(
+        ctx_dir,
+        "P1",
+        [
+            _make_assignment("P1-A1", "P1", ["src/foo.py", "src/bar.py"]),
+        ],
+    )
+    _write_phase_result(
+        ctx_dir,
+        "P2",
+        [
+            _make_assignment("P2-A1", "P2", ["src/foo.py", "src/baz.py"]),
+        ],
+    )
+
+    result = merge_refined_assignments(planner_dir=str(tmp_path))
+
+    data = json.loads(Path(result["refined_assignments_path"]).read_text())
+    assignments = {a["id"]: a for a in data["assignments"]}
+
+    p1_files = assignments["P1-A1"]["proposed_work_packages"][0]["files_touched"]
+    p2_files = assignments["P2-A1"]["proposed_work_packages"][0]["files_touched"]
+
+    assert "src/foo.py" in p1_files
+    assert "src/foo.py" not in p2_files
+    assert "src/baz.py" in p2_files
+    assert result["conflict_count"] == "1"
+
+
+def test_merge_refined_assignments_no_conflict(tmp_path):
+    ctx_dir = tmp_path / "refine_contexts"
+    ctx_dir.mkdir()
+    _write_phase_result(
+        ctx_dir,
+        "P1",
+        [
+            _make_assignment("P1-A1", "P1", ["src/a.py"]),
+        ],
+    )
+    _write_phase_result(
+        ctx_dir,
+        "P2",
+        [
+            _make_assignment("P2-A1", "P2", ["src/b.py"]),
+        ],
+    )
+
+    result = merge_refined_assignments(planner_dir=str(tmp_path))
+
+    data = json.loads(Path(result["refined_assignments_path"]).read_text())
+    assignments = {a["id"]: a for a in data["assignments"]}
+
+    assert assignments["P1-A1"]["proposed_work_packages"][0]["files_touched"] == ["src/a.py"]
+    assert assignments["P2-A1"]["proposed_work_packages"][0]["files_touched"] == ["src/b.py"]
+    assert result["conflict_count"] == "0"
+
+
+def test_merge_refined_assignments_empty_dir_raises(tmp_path):
+    ctx_dir = tmp_path / "refine_contexts"
+    ctx_dir.mkdir()
+    # Only context files (no *_result.json)
+    write_json(ctx_dir / "context_P1.json", {"phase_id": "P1", "assignments": []})
+
+    with pytest.raises(ValueError, match="No.*_result.json"):
+        merge_refined_assignments(planner_dir=str(tmp_path))
+
+
+def test_merge_refined_assignments_writes_to_planner_dir(tmp_path):
+    ctx_dir = tmp_path / "refine_contexts"
+    ctx_dir.mkdir()
+    _write_phase_result(ctx_dir, "P1", [_make_assignment("P1-A1", "P1", ["src/x.py"])])
+    _write_phase_result(ctx_dir, "P2", [_make_assignment("P2-A1", "P2", ["src/y.py"])])
+
+    result = merge_refined_assignments(planner_dir=str(tmp_path))
+
+    expected = tmp_path / "refined_assignments.json"
+    assert Path(result["refined_assignments_path"]) == expected
+    assert expected.exists()

--- a/tests/planner/test_merge.py
+++ b/tests/planner/test_merge.py
@@ -558,7 +558,7 @@ def test_merge_tier_results_writes_refine_contexts_for_assignments(tmp_path):
     out = tmp_path / "combined_assignments.json"
     result = merge_tier_results(str(results_dir), str(out), "assignments")
     assert "refine_context_paths" in result
-    paths = json.loads(result["refine_context_paths"])
+    paths = [p for p in result["refine_context_paths"].split(",") if p.strip()]
     assert len(paths) == 2
     p1_ctx = tmp_path / "refine_contexts" / "context_P1.json"
     p2_ctx = tmp_path / "refine_contexts" / "context_P2.json"

--- a/tests/planner/test_merge.py
+++ b/tests/planner/test_merge.py
@@ -678,7 +678,7 @@ def test_refine_context_paths_returned_sorted(tmp_path):
         )
     out = tmp_path / "combined_assignments.json"
     result = merge_tier_results(str(results_dir), str(out), "assignments")
-    paths = result["refine_context_paths"].split(",")
+    paths = [p for p in result["refine_context_paths"].split(",") if p.strip()]
     phase_ids = [Path(p).stem.replace("context_", "") for p in paths]
     assert phase_ids == sorted(phase_ids)
     assert set(phase_ids) == {"P1", "P2", "P3"}

--- a/tests/planner/test_planner.py
+++ b/tests/planner/test_planner.py
@@ -35,6 +35,7 @@ def test_planner_all_exports() -> None:
         "extract_item",
         "replace_item",
         "build_plan_snapshot",
+        "merge_refined_assignments",
         "PlanDocument",
         "PhaseShort",
         "PhaseElaborated",

--- a/tests/planner/test_refine_assignments_contract.py
+++ b/tests/planner/test_refine_assignments_contract.py
@@ -60,39 +60,37 @@ class TestContractRegistration:
             "Without it, a session that never writes is marked successful."
         )
 
-    def test_refined_assignments_path_output_present(self, skill_contract: dict) -> None:
-        """outputs must declare refined_assignments_path."""
+    def test_phase_refined_path_output_present(self, skill_contract: dict) -> None:
+        """outputs must declare phase_refined_path."""
         outputs = skill_contract.get("outputs", [])
         names = [o.get("name") for o in outputs]
-        assert "refined_assignments_path" in names, (
-            f"refined_assignments_path not in outputs. Found: {names}"
-        )
+        assert "phase_refined_path" in names, f"phase_refined_path not in outputs. Found: {names}"
 
-    def test_refined_assignments_path_type_is_file_path(self, skill_contract: dict) -> None:
-        """refined_assignments_path output must have type file_path."""
+    def test_phase_refined_path_type_is_file_path(self, skill_contract: dict) -> None:
+        """phase_refined_path output must have type file_path."""
         outputs = skill_contract.get("outputs", [])
-        token = next((o for o in outputs if o.get("name") == "refined_assignments_path"), None)
+        token = next((o for o in outputs if o.get("name") == "phase_refined_path"), None)
         assert token is not None
         assert token.get("type") == "file_path", (
-            f"refined_assignments_path type must be 'file_path', got {token.get('type')!r}. "
+            f"phase_refined_path type must be 'file_path', got {token.get('type')!r}. "
             "Path-contamination detection requires file_path type."
         )
 
     def test_expected_output_pattern_present(self, skill_contract: dict) -> None:
-        """expected_output_patterns must include a pattern matching refined_assignments_path."""
+        """expected_output_patterns must include a pattern matching phase_refined_path."""
         patterns = skill_contract.get("expected_output_patterns", [])
-        assert any("refined_assignments_path" in p for p in patterns), (
-            f"No expected_output_pattern referencing refined_assignments_path. Found: {patterns}"
+        assert any("phase_refined_path" in p for p in patterns), (
+            f"No expected_output_pattern referencing phase_refined_path. Found: {patterns}"
         )
 
     def test_three_inputs_declared(self, skill_contract: dict) -> None:
-        """Three inputs: combined_assignments_path, refined_plan_path, output_dir."""
+        """Three inputs: context_file, refined_plan_path, output_dir."""
         inputs = skill_contract.get("inputs", [])
         assert len(inputs) == 3, (
             f"Expected exactly 3 inputs, got {len(inputs)}: {[i.get('name') for i in inputs]}"
         )
         input_names = {i.get("name") for i in inputs}
-        assert input_names == {"combined_assignments_path", "refined_plan_path", "output_dir"}, (
+        assert input_names == {"context_file", "refined_plan_path", "output_dir"}, (
             f"Unexpected input names: {input_names}"
         )
 
@@ -125,10 +123,17 @@ class TestSkillMdPresence:
             "SKILL.md NEVER block must restrict write paths to {{AUTOSKILLIT_TEMP}}/planner/."
         )
 
-    def test_skill_md_has_output_token(self, skill_md: str) -> None:
-        """SKILL.md must document the refined_assignments_path output token."""
-        assert "refined_assignments_path" in skill_md, (
-            "SKILL.md must document 'refined_assignments_path = <path>' output token."
+    def test_skill_contains_phase_refined_path(self, skill_md: str) -> None:
+        """SKILL.md must document the phase_refined_path output token."""
+        assert "phase_refined_path" in skill_md, (
+            "SKILL.md must document 'phase_refined_path = <path>' output token."
+        )
+
+    def test_skill_contains_peer_summaries(self, skill_md: str) -> None:
+        """SKILL.md must reference peer_summaries from the context file."""
+        assert "peer_summaries" in skill_md, (
+            "SKILL.md must reference 'peer_summaries' — the per-phase context file provides "
+            "id/name/goal stubs for all assignments in other phases."
         )
 
     def test_skill_md_has_l0_response_fields(self, skill_md: str) -> None:

--- a/tests/skills/test_skill_output_compliance.py
+++ b/tests/skills/test_skill_output_compliance.py
@@ -256,7 +256,7 @@ def test_output_path_tokens_synchronized() -> None:
             # planner-refine-phases output
             "refined_plan_path",
             # planner-refine-assignments output
-            "refined_assignments_path",
+            "phase_refined_path",
             # planner-refine-wps output
             "refined_wps_path",
             # audit-tests output (bundled full-audit recipe)
@@ -326,7 +326,7 @@ PATH_CAPTURE_SKILLS: dict[str, list[str]] = {
     "planner-elaborate-phase": ["elab_result_path"],
     "planner-elaborate-wps": ["phase_wps_result_dir"],
     "planner-generate-phases": ["phase_manifest_path"],
-    "planner-refine-assignments": ["refined_assignments_path"],
+    "planner-refine-assignments": ["phase_refined_path"],
     "planner-refine-phases": ["refined_plan_path"],
     "planner-refine-wps": ["refined_wps_path"],
     "planner-validate-task-alignment": ["alignment_findings_path"],


### PR DESCRIPTION
## Summary

The `refine_assignments` recipe step currently runs all 21 assignments in a single L1 session, causing context exhaustion at ~794K tokens (4× the 200K Sonnet window). This plan converts it to the same per-phase dispatch pattern used by `elaborate_assignments`: N parallel L1 sessions (one per phase, 3–5 assignments each), followed by a new `merge_refined_assignments` run_python step that merges the results and resolves cross-phase WP ownership conflicts deterministically.

Changes C (per-phase dispatch) and D (post-refine merge + conflict resolution) are atomic — they ship together. The `refine_context_paths` context variable (comma-separated list of per-phase context file paths) is already produced by `merge_assignments` → `merge_tier_results` (added in #1646), so the dispatch input is already wired.

**Five areas of change:**
1. `planner-refine-assignments` SKILL.md — new interface (per-phase context file as `$1`, output as `phase_refined_path`)
2. `skill_contracts.yaml` — updated inputs/outputs for the skill
3. `recipes/contracts/planner.yaml` — same contract update
4. `src/autoskillit/recipes/planner.yaml` — two step changes (dispatch `refine_assignments`, add `merge_refined_assignments`)
5. `src/autoskillit/planner/merge.py` and `__init__.py` — new `merge_refined_assignments` callable

Closes #1647

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260503-025928-061457/.autoskillit/temp/make-plan/per_phase_refine_dispatch_plan_2026-05-03_100000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 1.8k | 19.2k | 800.5k | 61.2k | 1 | 9m 26s |
| verify | 164 | 15.1k | 968.8k | 49.4k | 1 | 9m 56s |
| implement | 352 | 22.4k | 2.6M | 76.1k | 1 | 7m 29s |
| prepare_pr | 60 | 4.8k | 232.1k | 31.4k | 1 | 1m 40s |
| compose_pr | 67 | 2.8k | 226.6k | 20.4k | 1 | 51s |
| review_pr | 92 | 30.2k | 516.4k | 71.2k | 1 | 7m 42s |
| resolve_review | 405 | 21.4k | 3.0M | 75.3k | 1 | 11m 11s |
| ci_conflict_fix | 148 | 7.8k | 778.9k | 45.2k | 1 | 2m 34s |
| **Total** | 3.1k | 123.8k | 9.2M | 430.1k | | 50m 52s |
## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 398 | 6550.8 | 191.2 | 56.4 |
| fix | 10 | 207517.2 | 7111.4 | 1236.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **408** | 16937.3 | 759.0 | 188.1 |