### PR TITLE
Implementation Plan: planner-refine-assignments SKILL.md: Stop Embedding Full Task Description in L0 Prompts

### DIFF
--- a/src/autoskillit/skills_extended/planner-refine-assignments/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine-assignments/SKILL.md
@@ -48,6 +48,7 @@ file to `$3/refine_contexts/{phase_id}_result.json`.
 - Spawn more than 6 L0s in a single parallel batch
 - Read `{{AUTOSKILLIT_TEMP}}` artifacts not passed as positional arguments
 - Run subagents in the background (`run_in_background: true` is prohibited)
+- Write L0 prompts to intermediate `l0_prompts/` files and read them back into the L1 context — spawn L0 subagents directly from in-memory context packets
 
 **ALWAYS:**
 - Read `phase_id` from the context file to construct the output path
@@ -68,8 +69,6 @@ parse/validation error string:
 ```
 FATAL: failed to parse {path}: {error_detail}
 ```
-
-Read the task description from disk at `task_file_path` (not inline from the context file).
 
 Read `$2` (refined_plan.json). Build a map `phase_id → PhaseElaborated` for L0 context.
 
@@ -98,16 +97,13 @@ Input schema for the per-phase context file:
 
 ### Step 2: Build L0 context packets
 
-Read the task description from `task_file_path`. Each L0 subagent must verify that the
-assignment's goal, scope, and deliverables serve the stated task. Flag assignments that
-introduce work not requested by the task as scope creep.
-
 For each assignment in `assignments`, build a context packet containing:
 - The full serialized assignment object (AssignmentElaborated)
 - The `peer_summaries` list for cross-phase dependency detection
 - The `PhaseElaborated` entry for the assignment's `phase_id` from `$2`
 - The `target_assignment_id`
-- Instructions: review the target assignment in light of peer_summaries; return structured suggestions only — do NOT edit files
+- `task_file_path` — the path to the task description on disk (pass the path reference only; do NOT read the task text into the L1 context or embed it in the L0 prompt)
+- Instructions: review the target assignment in light of peer_summaries; if scope-creep verification is needed, read the task from disk at `task_file_path`; return structured suggestions only — do NOT edit files
 
 ### Step 3: Spawn parallel L0 subagents
 
@@ -115,6 +111,10 @@ Since each phase has 3–5 assignments (always within the 6-L0 ceiling), spawn a
 parallel batch via Agent/Task. Do not spawn more than 6 L0s in a single parallel batch:
 if assignment count > 6 (unexpected), spawn sequential batches of 6. Between batches, emit
 anti-prose guard line: `--- next batch ---`.
+
+Spawn each L0 directly from its in-memory context packet — do NOT write the L0 prompts to
+`l0_prompts/*.txt` files and read them back. Reading those files before spawning adds ~15K
+tokens to the L1 context per L0 with no benefit.
 
 Each L0 must return structured text in this exact format:
 ```

--- a/src/autoskillit/skills_extended/planner-refine-assignments/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine-assignments/SKILL.md
@@ -103,7 +103,7 @@ For each assignment in `assignments`, build a context packet containing:
 - The `PhaseElaborated` entry for the assignment's `phase_id` from `$2`
 - The `target_assignment_id`
 - `task_file_path` — the path to the task description on disk (pass the path reference only; do NOT read the task text into the L1 context or embed it in the L0 prompt)
-- Instructions: review the target assignment in light of peer_summaries; if scope creep verification is needed, read the task from disk at `task_file_path`; return structured suggestions only — do NOT edit files
+- Instructions: review the target assignment in light of peer_summaries; always read the task from disk at `task_file_path` for scope creep verification (flag scope creep if the assignment's goal, scope, or deliverables introduce work not requested by the task); return structured suggestions only — do NOT edit files
 
 ### Step 3: Spawn parallel L0 subagents
 
@@ -112,9 +112,7 @@ parallel batch via Agent/Task. Do not spawn more than 6 L0s in a single parallel
 if assignment count > 6 (unexpected), spawn sequential batches of 6. Between batches, emit
 anti-prose guard line: `--- next batch ---`.
 
-Spawn each L0 directly from its in-memory context packet — do NOT write the L0 prompts to
-`l0_prompts/*.txt` files and read them back. Reading those files before spawning adds ~15K
-tokens to the L1 context per L0 with no benefit.
+Reading `l0_prompts/*.txt` files back before spawning adds ~15K tokens to the L1 context per L0 with no benefit.
 
 Each L0 must return structured text in this exact format:
 ```

--- a/src/autoskillit/skills_extended/planner-refine-assignments/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine-assignments/SKILL.md
@@ -103,7 +103,7 @@ For each assignment in `assignments`, build a context packet containing:
 - The `PhaseElaborated` entry for the assignment's `phase_id` from `$2`
 - The `target_assignment_id`
 - `task_file_path` — the path to the task description on disk (pass the path reference only; do NOT read the task text into the L1 context or embed it in the L0 prompt)
-- Instructions: review the target assignment in light of peer_summaries; if scope-creep verification is needed, read the task from disk at `task_file_path`; return structured suggestions only — do NOT edit files
+- Instructions: review the target assignment in light of peer_summaries; if scope creep verification is needed, read the task from disk at `task_file_path`; return structured suggestions only — do NOT edit files
 
 ### Step 3: Spawn parallel L0 subagents
 


### PR DESCRIPTION
## Summary

The `planner-refine-assignments` SKILL.md instructs the L1 session to read the full task
description text and then embed it into every L0 prompt file (`l0_prompts/*.txt`). When the L1
then reads those files back before spawning, it accumulates ~91K tokens of duplicate task content
— the primary driver of context exhaustion (794K / 200K window) seen in `run-20260503-001534-86a9b41b`.

The fix is four targeted edits to `src/autoskillit/skills_extended/planner-refine-assignments/SKILL.md`:

1. **Step 1** — Remove the standalone instruction to read the task description from disk;
   `task_file_path` is extracted from the context file as a path reference only.
2. **Step 2** — Remove the duplicate instruction to read the full task text into L1 context;
   add `task_file_path` as a path-reference field in each L0 context packet (L0s read it
   from disk only if needed for scope verification).
3. **Step 3** — Add an explicit prohibition against writing and reading back `l0_prompts/*.txt`.
4. **NEVER block** — Add the prohibition as a hard rule so it is enforced uniformly.

No Python code changes, no new tests. The change is purely instructional.

Closes #1645

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260503-041909-457368/.autoskillit/temp/make-plan/planner_refine_assignments_skill_md_stop_embedding_full_task_plan_2026-05-03_042355.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 79 | 13.0k | 340.3k | 43.5k | 1 | 6m 5s |
| verify | 140 | 11.4k | 773.4k | 46.5k | 1 | 3m 9s |
| implement | 188 | 6.7k | 1.0M | 43.8k | 1 | 6m 1s |
| prepare_pr | 68 | 4.2k | 244.6k | 26.3k | 1 | 1m 48s |
| compose_pr | 59 | 2.0k | 192.4k | 19.5k | 1 | 49s |
| review_pr | 888 | 17.2k | 437.0k | 59.9k | 1 | 3m 27s |
| resolve_review | 269 | 12.3k | 1.6M | 56.0k | 1 | 5m 58s |
| **Total** | 1.7k | 66.8k | 4.6M | 295.5k | | 27m 19s |
## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 14 | 71739.4 | 3127.4 | 481.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **14** | 182512.7 | 12830.6 | 2667.9 |