### PR TITLE
Implementation Plan: planner-refine-assignments SKILL.md: Prohibit L1 Codebase Exploration

### DIFF
--- a/src/autoskillit/skills_extended/planner-refine-assignments/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine-assignments/SKILL.md
@@ -49,6 +49,8 @@ file to `$3/refine_contexts/{phase_id}_result.json`.
 - Read `{{AUTOSKILLIT_TEMP}}` artifacts not passed as positional arguments
 - Run subagents in the background (`run_in_background: true` is prohibited)
 - Write L0 prompts to intermediate `l0_prompts/` files and read them back into the L1 context — spawn L0 subagents directly from in-memory context packets
+- Read source code files, test files, or recipe YAML files directly — codebase exploration is the L0 subagents' responsibility
+- Run Bash, Grep, or Glob commands for codebase exploration between L0 spawns
 
 **ALWAYS:**
 - Read `phase_id` from the context file to construct the output path


### PR DESCRIPTION
## Summary

The `planner-refine-assignments` L1 session has been observed reading source files, test
files, and recipe YAMLs, and running `Bash`/`Grep`/`Glob` commands for codebase exploration
between L0 spawns. This is not part of the prescribed workflow: the L1's sole responsibility
is to orchestrate L0 subagents and apply their structured suggestions. All codebase
exploration is the L0 subagents' responsibility.

The fix is a pure SKILL.md text change: add two new entries to the **NEVER** block in the
Critical Constraints section of
`src/autoskillit/skills_extended/planner-refine-assignments/SKILL.md`.

Closes #1648

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260503-050337-313947/.autoskillit/temp/make-plan/planner-refine-assignments-prohibit-l1-codebase-exploration_plan_2026-05-03_000001.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 139 | 7.9k | 621.4k | 44.5k | 1 | 5m 41s |
| verify | 68 | 4.3k | 259.0k | 29.2k | 1 | 1m 49s |
| implement | 92 | 3.0k | 376.2k | 28.9k | 1 | 1m 16s |
| prepare_pr | 60 | 4.4k | 205.6k | 25.1k | 1 | 1m 27s |
| compose_pr | 67 | 2.0k | 223.6k | 19.3k | 1 | 49s |
| review_pr | 132 | 11.9k | 614.7k | 37.4k | 1 | 3m 44s |
| **Total** | 558 | 33.5k | 2.3M | 184.4k | | 14m 48s |
## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 2 | 188121.5 | 14449.0 | 1508.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **2** | 842929.5 | 73527.5 | 10767.0 |