### PR TITLE
Rectify: release_issue_failure Bare Label Removal

### DIFF
--- a/src/autoskillit/recipe/rules_tools.py
+++ b/src/autoskillit/recipe/rules_tools.py
@@ -338,3 +338,32 @@ def _check_rebase_then_push_requires_force(ctx: ValidationContext) -> list[RuleF
                 )
                 break  # one finding per push step is sufficient
     return findings
+
+
+@semantic_rule(
+    name="release-issue-requires-disposition",
+    description="release_issue must have fail_label or target_branch to avoid bare removal",
+    severity=Severity.ERROR,
+)
+def _check_release_issue_requires_disposition(ctx: ValidationContext) -> list[RuleFinding]:
+    findings: list[RuleFinding] = []
+    for step_name, step in ctx.recipe.steps.items():
+        if step.tool is None or step.tool != "release_issue":
+            continue
+        has_fail_label = bool(step.with_args.get("fail_label"))
+        has_target_branch = bool(step.with_args.get("target_branch"))
+        if not has_fail_label and not has_target_branch:
+            findings.append(
+                RuleFinding(
+                    rule="release-issue-requires-disposition",
+                    severity=Severity.ERROR,
+                    step_name=step_name,
+                    message=(
+                        f"Step '{step_name}' calls release_issue without fail_label or "
+                        f"target_branch — this performs bare label removal with no "
+                        f"replacement. Add fail_label for failure paths or target_branch "
+                        f"for success/staging paths."
+                    ),
+                )
+            )
+    return findings

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -1566,6 +1566,7 @@ steps:
     skip_when_false: inputs.issue_url
     with:
       issue_url: ${{ inputs.issue_url }}
+      fail_label: "fail"
     on_success: register_clone_failure
     on_failure: register_clone_failure
 

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -1556,6 +1556,7 @@ steps:
     skip_when_false: inputs.issue_url
     with:
       issue_url: ${{ inputs.issue_url }}
+      fail_label: "fail"
     on_success: register_clone_failure
     on_failure: register_clone_failure
 

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -1569,6 +1569,7 @@ steps:
     skip_when_false: inputs.issue_url
     with:
       issue_url: ${{ inputs.issue_url }}
+      fail_label: "fail"
     on_success: register_clone_failure
     on_failure: register_clone_failure
 

--- a/src/autoskillit/server/tools_issue_lifecycle.py
+++ b/src/autoskillit/server/tools_issue_lifecycle.py
@@ -650,6 +650,10 @@ async def release_issue(
                 }
             )
         else:
+            logger.warning(
+                "release_issue bare removal (no fail_label or target_branch) for %s",
+                issue_url,
+            )
             swap_result = await tool_ctx.github_client.swap_labels(
                 owner,
                 repo,

--- a/tests/recipe/test_issue_url_pipeline.py
+++ b/tests/recipe/test_issue_url_pipeline.py
@@ -7,6 +7,7 @@ import yaml
 
 from autoskillit.recipe._api import validate_from_path
 from autoskillit.recipe.io import load_recipe
+from autoskillit.recipe.registry import run_semantic_rules
 from tests.recipe.conftest import NO_AUTOSKILLIT_IMPORT as _NO_AUTOSKILLIT_IMPORT
 
 pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
@@ -424,3 +425,22 @@ class TestClaimReleaseGates:
             assert "escalate_stop" in fallthrough_routes, (
                 f"{name}: claim_issue must have escalate_stop as fallthrough on_result route"
             )
+
+
+def test_release_issue_failure_steps_include_fail_label():
+    """All release_issue_failure steps must pass fail_label for atomic failure marking."""
+    for recipe_name in ("remediation", "implementation", "implementation-groups"):
+        recipe = load_recipe(_recipe_path(recipe_name))
+        step = recipe.steps["release_issue_failure"]
+        assert "fail_label" in step.with_args, (
+            f"{recipe_name}: release_issue_failure missing fail_label"
+        )
+
+
+def test_bundled_recipes_pass_release_issue_disposition_rule():
+    """All bundled recipes pass the release-issue-requires-disposition rule."""
+    for recipe_name in ("remediation", "implementation", "implementation-groups"):
+        recipe = load_recipe(_recipe_path(recipe_name))
+        findings = run_semantic_rules(recipe)
+        hits = [f for f in findings if f.rule == "release-issue-requires-disposition"]
+        assert not hits, f"{recipe_name}: {hits}"

--- a/tests/recipe/test_rules_tools.py
+++ b/tests/recipe/test_rules_tools.py
@@ -427,3 +427,46 @@ class TestConstantStepWithArgs:
         )
         findings = [f for f in run_semantic_rules(recipe) if f.rule == "constant-step-with-args"]
         assert len(findings) == 0
+
+
+# ---------------------------------------------------------------------------
+# release-issue-requires-disposition rule tests
+# ---------------------------------------------------------------------------
+
+
+def test_release_issue_requires_disposition_fires_on_bare_call() -> None:
+    """Rule fires when release_issue step has neither fail_label nor target_branch."""
+    recipe = _make_recipe_with_args(
+        "release_issue",
+        {"issue_url": "https://github.com/o/r/issues/1"},
+    )
+    findings = run_semantic_rules(recipe)
+    hits = [f for f in findings if f.rule == "release-issue-requires-disposition"]
+    assert hits
+    assert hits[0].severity == Severity.ERROR
+    assert "run" in hits[0].step_name
+
+
+def test_release_issue_requires_disposition_passes_with_fail_label() -> None:
+    """Rule does NOT fire when fail_label is present."""
+    recipe = _make_recipe_with_args(
+        "release_issue",
+        {"issue_url": "https://github.com/o/r/issues/1", "fail_label": "fail"},
+    )
+    findings = run_semantic_rules(recipe)
+    hits = [f for f in findings if f.rule == "release-issue-requires-disposition"]
+    assert not hits
+
+
+def test_release_issue_requires_disposition_passes_with_target_branch() -> None:
+    """Rule does NOT fire when target_branch is present."""
+    recipe = _make_recipe_with_args(
+        "release_issue",
+        {
+            "issue_url": "https://github.com/o/r/issues/1",
+            "target_branch": "${{ inputs.base_branch }}",
+        },
+    )
+    findings = run_semantic_rules(recipe)
+    hits = [f for f in findings if f.rule == "release-issue-requires-disposition"]
+    assert not hits


### PR DESCRIPTION
## Summary

The recipe validation system lacks a semantic rule enforcing that `release_issue` tool calls must provide either `fail_label` or `target_branch` — without one, the tool silently performs bare label removal (stripping `in-progress` with no replacement). The existing `dead-with-param` rule detects *extra* parameters but nothing detects *missing* semantically-required parameters. This gap allowed three `release_issue_failure` steps (across all pipeline recipes) to ship without `fail_label` after PR #1500 introduced that parameter. The architectural fix is a new semantic rule (`release-issue-requires-disposition`) that makes this class of omission impossible to pass validation, combined with hardening the `release_issue` tool to log a warning when the bare-removal path fires.

Closes #1674

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260503-071700-506269/.autoskillit/temp/rectify/rectify_release_issue_failure_bare_label_removal_2026-05-03_071700.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| investigate | 6.4k | 7.2k | 399.3k | 57.9k | 1 | 4m 23s |
| rectify | 1.6k | 10.4k | 566.4k | 51.8k | 1 | 8m 42s |
| review | 1.7k | 4.8k | 179.1k | 30.3k | 1 | 4m 6s |
| dry_walkthrough | 43 | 11.4k | 1.3M | 55.1k | 1 | 5m 59s |
| implement | 268 | 13.2k | 1.7M | 70.5k | 1 | 4m 28s |
| prepare_pr | 60 | 5.0k | 216.7k | 29.1k | 1 | 1m 26s |
| compose_pr | 51 | 2.1k | 160.5k | 19.1k | 1 | 37s |
| review_pr | 92 | 29.2k | 512.2k | 58.5k | 1 | 5m 25s |
| **Total** | 10.2k | 83.3k | 5.0M | 372.2k | | 35m 10s |
## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| build_execution_map | 0 | — | — | — |
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 215 | 21351.5 | 526.9 | 157.8 |
| **Total** | **215** | 37684.9 | 2095.9 | 416.3 |