### PR TITLE
Implementation Plan: Disambiguate Filter Full-Run from Stats-Unavailable in test_check Output

### DIFF
--- a/src/autoskillit/core/_type_results.py
+++ b/src/autoskillit/core/_type_results.py
@@ -46,6 +46,7 @@ class TestResult:
     tests_selected: int | None = None
     tests_deselected: int | None = None
     filter_mode: str | None = None
+    full_run_reason: str | None = None
 
 
 @dataclass

--- a/src/autoskillit/execution/testing.py
+++ b/src/autoskillit/execution/testing.py
@@ -228,6 +228,7 @@ class DefaultTestRunner:
         stat_filter_mode: str | None = None
         stat_tests_selected: int | None = None
         stat_tests_deselected: int | None = None
+        stat_full_run_reason: str | None = None
         start = time.monotonic()
         deadline = start + timeout
 
@@ -257,9 +258,11 @@ class DefaultTestRunner:
                         fm = raw.get("filter_mode")
                         ts = raw.get("tests_selected")
                         td = raw.get("tests_deselected")
+                        fr = raw.get("full_run_reason")
                         stat_filter_mode = fm if isinstance(fm, str) else None
                         stat_tests_selected = ts if isinstance(ts, int) else None
                         stat_tests_deselected = td if isinstance(td, int) else None
+                        stat_full_run_reason = fr if isinstance(fr, str) else None
                 except (json.JSONDecodeError, OSError) as exc:
                     logger.debug("filter stats sidecar read error: %s", exc)
         finally:
@@ -283,4 +286,5 @@ class DefaultTestRunner:
             filter_mode=stat_filter_mode,
             tests_selected=stat_tests_selected,
             tests_deselected=stat_tests_deselected,
+            full_run_reason=stat_full_run_reason,
         )

--- a/src/autoskillit/hooks/_fmt_execution.py
+++ b/src/autoskillit/hooks/_fmt_execution.py
@@ -171,9 +171,14 @@ def _fmt_test_check(data: dict, _pipeline: bool) -> str:
 
     filter_mode = data.get("filter_mode")
     if filter_mode:
-        selected = data.get("tests_selected", "?")
-        deselected = data.get("tests_deselected", "?")
-        lines.append(f"filter: {filter_mode} ({selected} selected, {deselected} deselected)")
+        full_run_reason = data.get("full_run_reason")
+        if full_run_reason:
+            reason_display = full_run_reason.replace("_", " ")
+            lines.append(f"filter: {filter_mode} (full run — {reason_display})")
+        else:
+            selected = data.get("tests_selected", "?")
+            deselected = data.get("tests_deselected", "?")
+            lines.append(f"filter: {filter_mode} ({selected} selected, {deselected} deselected)")
 
     stdout = data.get("stdout", "")
     if stdout:

--- a/src/autoskillit/server/tools_workspace.py
+++ b/src/autoskillit/server/tools_workspace.py
@@ -90,6 +90,8 @@ async def test_check(
                 response["tests_selected"] = test_result.tests_selected
             if test_result.tests_deselected is not None:
                 response["tests_deselected"] = test_result.tests_deselected
+            if test_result.full_run_reason is not None:
+                response["full_run_reason"] = test_result.full_run_reason
             return json.dumps(response)
         finally:
             if step_name:

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -26,6 +26,14 @@ class FilterMode(enum.StrEnum):
     AGGRESSIVE = "aggressive"
 
 
+class FullRunReason(enum.StrEnum):
+    DISABLED = "disabled"
+    GIT_UNAVAILABLE = "git_unavailable"
+    LARGE_CHANGESET = "large_changeset"
+    BUCKET_A = "bucket_a"
+    UNMAPPED_FILE = "unmapped_file"
+
+
 class ImportContext(enum.StrEnum):
     TOP_LEVEL = "top_level"
     CONDITIONAL = "conditional"
@@ -893,13 +901,13 @@ def build_test_scope(
     coverage_map_path: str | Path | None = None,
     cwd: str | Path | None = None,
     base_ref: str | None = None,
-) -> set[Path] | None:
-    """Compute the set of test paths to run, or None for a full run.
+) -> set[Path] | FullRunReason:
+    """Compute the set of test paths to run, or a FullRunReason for a full run.
 
     Algorithm:
-    1. None changed_files -> None (fail-open)
-    2. >30 files -> None (large changeset)
-    3. Bucket A triggered -> None (full run)
+    1. None changed_files -> FullRunReason.GIT_UNAVAILABLE (fail-open)
+    2. >30 files -> FullRunReason.LARGE_CHANGESET (large changeset)
+    3. Bucket A triggered -> FullRunReason.BUCKET_A (full run)
     4. Classify: src Python -> cascade, test Python -> direct, non-Python -> manifest
     5. Compute always-run set for mode (includes arch/contracts for both modes)
     6. Union all sets
@@ -907,17 +915,17 @@ def build_test_scope(
     8. Resolve to concrete paths
     """
     if mode == FilterMode.NONE:
-        return None
+        return FullRunReason.DISABLED
 
     if changed_files is None:
-        return None
+        return FullRunReason.GIT_UNAVAILABLE
 
     if len(changed_files) > _LARGE_CHANGESET_THRESHOLD:
-        return None
+        return FullRunReason.LARGE_CHANGESET
 
     if cwd is not None and base_ref is not None:
         if check_bucket_a_content_aware(changed_files, cwd, base_ref):
-            return None
+            return FullRunReason.BUCKET_A
         # Exclude version-bump files that passed the content-aware check from classification.
         # Recomputes the same set as `version_hits` inside check_bucket_a_content_aware because
         # that function returns bool; extracting the set here avoids changing its signature.
@@ -926,7 +934,7 @@ def build_test_scope(
             changed_files = changed_files - version_bump_in_bucket_a
     else:
         if check_bucket_a(changed_files):
-            return None
+            return FullRunReason.BUCKET_A
 
     tests_root = Path(tests_root)
 
@@ -963,13 +971,13 @@ def build_test_scope(
             elif pkg and pkg in cascade_map:
                 test_dirs.update(cascade_map[pkg])
             else:
-                return None
+                return FullRunReason.UNMAPPED_FILE
         elif f.endswith(".py"):
-            return None
+            return FullRunReason.UNMAPPED_FILE
         else:
             manifest_dirs = apply_manifest({f}, manifest)
             if manifest_dirs is None:
-                return None
+                return FullRunReason.UNMAPPED_FILE
             test_dirs.update(manifest_dirs)
 
     # Expand src Python files via re-export closure: add __init__.py files that

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,7 @@ _scope_key = pytest.StashKey[set[_Path] | None]()
 _filter_mode_key = pytest.StashKey[str | None]()
 _selected_count_key = pytest.StashKey[int | None]()
 _deselected_count_key = pytest.StashKey[int | None]()
+_full_run_reason_key = pytest.StashKey[str | None]()
 
 # Module-level accumulator for xdist worker-to-controller IPC.
 # Populated by pytest_testnodedown (controller); cleared by pytest_configure
@@ -381,6 +382,7 @@ def pytest_configure(config: pytest.Config) -> None:
 
     config.stash[_scope_key] = None
     config.stash[_filter_mode_key] = None
+    config.stash[_full_run_reason_key] = None
 
     cli_mode = config.getoption("--filter-mode", default=None)
     env_val = os.environ.get("AUTOSKILLIT_TEST_FILTER", "")
@@ -393,6 +395,7 @@ def pytest_configure(config: pytest.Config) -> None:
     try:
         from tests._test_filter import (
             FilterMode,
+            FullRunReason,
             build_test_scope,
             git_changed_files,
             load_manifest,
@@ -429,7 +432,12 @@ def pytest_configure(config: pytest.Config) -> None:
             cwd=config.rootpath,
             base_ref=resolved_base_ref,
         )
-        config.stash[_scope_key] = scope
+
+        if isinstance(scope, FullRunReason):
+            config.stash[_scope_key] = None
+            config.stash[_full_run_reason_key] = scope.value
+        else:
+            config.stash[_scope_key] = scope
         config.stash[_filter_mode_key] = mode.value
 
     except Exception as exc:
@@ -683,12 +691,14 @@ def pytest_sessionfinish(session, exitstatus):
         return
     import json
 
+    full_run_reason = session.config.stash.get(_full_run_reason_key, None)
     _Path(out_path).write_text(
         json.dumps(
             {
                 "filter_mode": filter_mode,
                 "tests_selected": selected,
                 "tests_deselected": deselected,
+                "full_run_reason": full_run_reason,
             }
         )
     )

--- a/tests/execution/test_testing.py
+++ b/tests/execution/test_testing.py
@@ -868,3 +868,56 @@ def test_test_check_config_has_commands_field() -> None:
     cfg = make_test_check_config()
     assert hasattr(cfg, "commands")
     assert cfg.commands is None
+
+
+@pytest.mark.anyio
+async def test_default_test_runner_reads_full_run_reason_from_sidecar(tmp_path: Path) -> None:
+    """run() populates full_run_reason when sidecar includes the field."""
+    import json
+
+    sidecar_data = {
+        "filter_mode": "conservative",
+        "tests_selected": None,
+        "tests_deselected": None,
+        "full_run_reason": "bucket_a",
+    }
+
+    async def fake_runner(command, *, cwd, timeout, env, **kwargs):
+        sidecar_path = env.get("AUTOSKILLIT_FILTER_STATS_FILE")
+        assert sidecar_path, "AUTOSKILLIT_FILTER_STATS_FILE must be set in env"
+        Path(sidecar_path).write_text(json.dumps(sidecar_data))
+        return SubprocessResult(
+            returncode=0,
+            stdout="= 100 passed =\n",
+            stderr="",
+            termination=TerminationReason.NATURAL_EXIT,
+            pid=12345,
+        )
+
+    tester = DefaultTestRunner(config=make_test_config(), runner=fake_runner)
+    result = await tester.run(tmp_path)
+    assert result.full_run_reason == "bucket_a"
+
+
+@pytest.mark.anyio
+async def test_default_test_runner_full_run_reason_none_when_absent(tmp_path: Path) -> None:
+    """run() leaves full_run_reason as None when sidecar omits the field."""
+    import json
+
+    sidecar_data = {"filter_mode": "conservative", "tests_selected": 50, "tests_deselected": 10}
+
+    async def fake_runner(command, *, cwd, timeout, env, **kwargs):
+        sidecar_path = env.get("AUTOSKILLIT_FILTER_STATS_FILE")
+        assert sidecar_path, "AUTOSKILLIT_FILTER_STATS_FILE must be set in env"
+        Path(sidecar_path).write_text(json.dumps(sidecar_data))
+        return SubprocessResult(
+            returncode=0,
+            stdout="= 50 passed =\n",
+            stderr="",
+            termination=TerminationReason.NATURAL_EXIT,
+            pid=12345,
+        )
+
+    tester = DefaultTestRunner(config=make_test_config(), runner=fake_runner)
+    result = await tester.run(tmp_path)
+    assert result.full_run_reason is None

--- a/tests/infra/test_filter_activation.py
+++ b/tests/infra/test_filter_activation.py
@@ -43,7 +43,7 @@ def test_skill_preambles_in_skills():
 
 def test_ci_filter_codepath_produces_scope():
     """CI codepath: conservative mode + known source file -> non-None scope."""
-    from tests._test_filter import FilterMode, build_test_scope, load_manifest
+    from tests._test_filter import FilterMode, FullRunReason, build_test_scope, load_manifest
 
     manifest = load_manifest(REPO_ROOT)
     scope = build_test_scope(
@@ -54,8 +54,39 @@ def test_ci_filter_codepath_produces_scope():
         cwd=REPO_ROOT,
         base_ref="develop",
     )
-    assert scope is not None, (
-        "build_test_scope must return a non-None scope for conservative mode "
-        "with a known source file — None means silent fallback to full run"
+    assert not isinstance(scope, FullRunReason), (
+        "build_test_scope must return a set scope for conservative mode "
+        "with a known source file — FullRunReason means silent fallback to full run"
     )
     assert len(scope) > 0, "Scope must contain at least one test path"
+
+
+def test_build_test_scope_returns_full_run_reason_for_large_changeset():
+    from tests._test_filter import FilterMode, FullRunReason, build_test_scope
+
+    changed = {f"src/autoskillit/fake_{i}.py" for i in range(35)}
+    result = build_test_scope(changed_files=changed, mode=FilterMode.CONSERVATIVE)
+    assert result is FullRunReason.LARGE_CHANGESET
+
+
+def test_build_test_scope_returns_full_run_reason_for_git_unavailable():
+    from tests._test_filter import FilterMode, FullRunReason, build_test_scope
+
+    result = build_test_scope(changed_files=None, mode=FilterMode.CONSERVATIVE)
+    assert result is FullRunReason.GIT_UNAVAILABLE
+
+
+def test_build_test_scope_returns_full_run_reason_for_bucket_a():
+    from tests._test_filter import FilterMode, FullRunReason, build_test_scope
+
+    changed = {"pyproject.toml"}
+    result = build_test_scope(changed_files=changed, mode=FilterMode.CONSERVATIVE)
+    assert result is FullRunReason.BUCKET_A
+
+
+def test_build_test_scope_returns_full_run_reason_for_unmapped():
+    from tests._test_filter import FilterMode, FullRunReason, build_test_scope
+
+    changed = {"scripts/random_script.py"}
+    result = build_test_scope(changed_files=changed, mode=FilterMode.CONSERVATIVE)
+    assert result is FullRunReason.UNMAPPED_FILE

--- a/tests/infra/test_pretty_output_formatters.py
+++ b/tests/infra/test_pretty_output_formatters.py
@@ -545,3 +545,29 @@ def test_fmt_test_check_displays_filter_stats():
     assert "conservative" in out
     assert "50" in out
     assert "100" in out
+
+
+def test_fmt_test_check_displays_full_run_reason():
+    """Pretty output shows full run reason instead of selected/deselected counts."""
+    from autoskillit.hooks._fmt_execution import _fmt_test_check
+
+    data = {
+        "passed": True,
+        "stdout": "",
+        "filter_mode": "conservative",
+        "full_run_reason": "bucket_a",
+    }
+    out = _fmt_test_check(data, False)
+    assert "full run" in out
+    assert "bucket" in out.lower()
+    assert "?" not in out
+
+
+def test_fmt_test_check_shows_question_mark_only_when_stats_truly_unavailable():
+    """When filter_mode is set but no counts or reason, output shows '?'."""
+    from autoskillit.hooks._fmt_execution import _fmt_test_check
+
+    data = {"passed": True, "stdout": "", "filter_mode": "conservative"}
+    out = _fmt_test_check(data, False)
+    assert "?" in out
+    assert "full run" not in out

--- a/tests/test_test_filter.py
+++ b/tests/test_test_filter.py
@@ -19,6 +19,7 @@ from tests._test_filter import (
     LAYER_CASCADE_CONSERVATIVE,
     ASTImportWalker,
     FilterMode,
+    FullRunReason,
     ImportContext,
     _expand_reexport_closure,
     apply_manifest,
@@ -133,30 +134,30 @@ class TestCheckBucketA:
 
 
 class TestBuildTestScope:
-    def test_scope_none_changed_returns_none(self, tmp_path: Path) -> None:
+    def test_scope_none_changed_returns_git_unavailable(self, tmp_path: Path) -> None:
         result = build_test_scope(
             changed_files=None,
             mode=FilterMode.CONSERVATIVE,
             tests_root=tmp_path / "tests",
         )
-        assert result is None
+        assert result is FullRunReason.GIT_UNAVAILABLE
 
-    def test_scope_large_changeset_returns_none(self, tmp_path: Path) -> None:
+    def test_scope_large_changeset_returns_full_run_reason(self, tmp_path: Path) -> None:
         files = {f"src/autoskillit/core/f{i}.py" for i in range(31)}
         result = build_test_scope(
             changed_files=files,
             mode=FilterMode.CONSERVATIVE,
             tests_root=tmp_path / "tests",
         )
-        assert result is None
+        assert result is FullRunReason.LARGE_CHANGESET
 
-    def test_scope_bucket_a_returns_none(self, tmp_path: Path) -> None:
+    def test_scope_bucket_a_returns_full_run_reason(self, tmp_path: Path) -> None:
         result = build_test_scope(
             changed_files={"pyproject.toml"},
             mode=FilterMode.CONSERVATIVE,
             tests_root=tmp_path / "tests",
         )
-        assert result is None
+        assert result is FullRunReason.BUCKET_A
 
     def test_scope_l0_core_conservative(self, tmp_path: Path) -> None:
         tests_root = tmp_path / "tests"
@@ -349,7 +350,7 @@ class TestBuildTestScope:
         assert Path("tests/core/test_io.py") in result
 
     def test_scope_nonpython_no_manifest_only_alwaysrun(self, tmp_path: Path) -> None:
-        """Non-Python file with manifest=None → fail-open → result is None."""
+        """Non-Python file with manifest=None → fail-open → FullRunReason.UNMAPPED_FILE."""
         tests_root = tmp_path / "tests"
         for d in ["arch", "contracts", "infra", "docs"]:
             (tests_root / d).mkdir(parents=True, exist_ok=True)
@@ -359,10 +360,12 @@ class TestBuildTestScope:
             mode=FilterMode.CONSERVATIVE,
             tests_root=tests_root,
         )
-        assert result is None
+        assert result is FullRunReason.UNMAPPED_FILE
 
-    def test_scope_nonpython_unmatched_manifest_returns_none(self, tmp_path: Path) -> None:
-        """A non-Python changed file with no manifest match must return None (full run)."""
+    def test_scope_nonpython_unmatched_manifest_returns_full_run_reason(
+        self, tmp_path: Path
+    ) -> None:
+        """Non-Python file with no manifest match → FullRunReason.UNMAPPED_FILE (full run)."""
         tests_root = tmp_path / "tests"
         for d in ["arch", "contracts", "infra", "docs"]:
             (tests_root / d).mkdir(parents=True, exist_ok=True)
@@ -373,7 +376,7 @@ class TestBuildTestScope:
             manifest=manifest,
             tests_root=tests_root,
         )
-        assert result is None
+        assert result is FullRunReason.UNMAPPED_FILE
 
     def test_scope_nonpython_matched_manifest_adds_dirs(self, tmp_path: Path) -> None:
         """A non-Python file that DOES match a manifest pattern contributes its test dirs."""
@@ -399,13 +402,13 @@ class TestBuildTestScope:
         for fname in _INFRA_UNCONDITIONAL_FILES:
             assert fname in result_names
 
-    def test_scope_none_mode_returns_none(self, tmp_path: Path) -> None:
+    def test_scope_none_mode_returns_disabled(self, tmp_path: Path) -> None:
         result = build_test_scope(
             changed_files={"src/autoskillit/core/io.py"},
             mode=FilterMode.NONE,
             tests_root=tmp_path / "tests",
         )
-        assert result is None
+        assert result is FullRunReason.DISABLED
 
     def test_scope_empty_changeset(self, tmp_path: Path) -> None:
         tests_root = tmp_path / "tests"

--- a/tests/test_test_filter.py
+++ b/tests/test_test_filter.py
@@ -362,10 +362,7 @@ class TestBuildTestScope:
         )
         assert result is FullRunReason.UNMAPPED_FILE
 
-    def test_scope_nonpython_unmatched_manifest_returns_full_run_reason(
-        self, tmp_path: Path
-    ) -> None:
-        """Non-Python file with no manifest match → FullRunReason.UNMAPPED_FILE (full run)."""
+    def test_scope_nonpython_unmatched_manifest_full_run(self, tmp_path: Path) -> None:
         tests_root = tmp_path / "tests"
         for d in ["arch", "contracts", "infra", "docs"]:
             (tests_root / d).mkdir(parents=True, exist_ok=True)

--- a/tests/test_test_filter_content_aware.py
+++ b/tests/test_test_filter_content_aware.py
@@ -10,6 +10,7 @@ import pytest
 
 from tests._test_filter import (
     FilterMode,
+    FullRunReason,
     build_test_scope,
 )
 
@@ -191,4 +192,4 @@ class TestBuildTestScopeContentAware:
             tests_root=tests_root,
             # no cwd or base_ref
         )
-        assert result is None  # still full run without cwd
+        assert result is FullRunReason.BUCKET_A  # still full run without cwd


### PR DESCRIPTION
## Summary

When `build_test_scope` returns `None`, the system cannot distinguish an intentional full-run decision (bucket A trigger, large changeset, unmapped file) from a stats-collection failure (git unavailable, sidecar unwritten). This plan introduces a `FullRunReason` enum in `tests/_test_filter.py`, threads the reason through the sidecar JSON → `TestResult` → MCP response → formatter, producing `filter: conservative (full run — bucket A)` instead of the ambiguous `?`.

Closes #1669

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260503-072532-513081/.autoskillit/temp/make-plan/disambiguate_filter_full_run_plan_2026-05-03_073200.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 1.5k | 11.1k | 723.1k | 56.6k | 1 | 6m 40s |
| verify | 43 | 9.4k | 790.8k | 54.1k | 1 | 5m 33s |
| implement | 496 | 25.4k | 3.7M | 76.1k | 1 | 9m 0s |
| prepare_pr | 60 | 5.7k | 211.6k | 28.4k | 1 | 1m 45s |
| compose_pr | 59 | 2.1k | 191.8k | 19.2k | 1 | 45s |
| review_pr | 218 | 24.5k | 634.0k | 59.8k | 1 | 7m 19s |
| **Total** | 2.4k | 78.2k | 6.2M | 294.1k | | 31m 4s |
## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| build_execution_map | 0 | — | — | — |
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 215 | 21351.5 | 526.9 | 157.8 |
| fix | 29 | 83946.2 | 2497.6 | 729.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **244** | 45683.0 | 2441.0 | 504.4 |