### PR TITLE
fix: route review_pr on_failure to check_repo_ci_event instead of resolve_review

### DIFF
--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -568,7 +568,7 @@ steps:
         route: check_repo_ci_event
       - when: "true"
         route: check_repo_ci_event
-    on_failure: resolve_review
+    on_failure: check_repo_ci_event
     on_context_limit: check_repo_ci_event
     optional: true
     skip_when_false: "inputs.open_pr"
@@ -580,7 +580,7 @@ steps:
       the open PR by feature branch name (context.merge_target). Captures verdict
       as review_verdict and routes via on_result: changes_requested/approved_with_comments
       → resolve_review, needs_human → check_repo_ci_event (explicit), approved → check_repo_ci_event. On
-      tool-level failure (MCP error, gh unavailable), routes to resolve_review.
+      tool-level failure (MCP error, gh unavailable), routes to check_repo_ci_event (no review to resolve).
       Skipped when open_pr=false.
 
   resolve_review:

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -558,7 +558,7 @@ steps:
         route: check_repo_ci_event
       - when: "true"
         route: check_repo_ci_event
-    on_failure: resolve_review
+    on_failure: check_repo_ci_event
     on_context_limit: check_repo_ci_event
     optional: true
     skip_when_false: "inputs.open_pr"
@@ -570,7 +570,7 @@ steps:
       the open PR by feature branch name (context.merge_target). Captures verdict
       as review_verdict and routes via on_result: changes_requested/approved_with_comments
       → resolve_review, needs_human → check_repo_ci_event (explicit), approved → check_repo_ci_event. On
-      tool-level failure (MCP error, gh unavailable), routes to resolve_review.
+      tool-level failure (MCP error, gh unavailable), routes to check_repo_ci_event (no review to resolve).
       Skipped when open_pr=false.
 
   resolve_review:

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -571,7 +571,7 @@ steps:
         route: check_repo_ci_event
       - when: "true"
         route: check_repo_ci_event
-    on_failure: resolve_review
+    on_failure: check_repo_ci_event
     on_context_limit: check_repo_ci_event
     optional: true
     skip_when_false: "inputs.open_pr"
@@ -583,7 +583,7 @@ steps:
       the open PR by feature branch name (context.merge_target). Captures verdict
       as review_verdict and routes via on_result: changes_requested/approved_with_comments
       → resolve_review, needs_human → check_repo_ci_event (explicit), approved → check_repo_ci_event. On
-      tool-level failure (MCP error, gh unavailable), routes to resolve_review.
+      tool-level failure (MCP error, gh unavailable), routes to check_repo_ci_event (no review to resolve).
       Skipped when open_pr=false.
 
   resolve_review:

--- a/tests/recipe/test_bundled_recipes_review_pr.py
+++ b/tests/recipe/test_bundled_recipes_review_pr.py
@@ -68,9 +68,24 @@ class TestReviewPrRecipeIntegration:
         ]
         assert any(c.route == "resolve_review" for c in changes_conditions)
 
-    def test_review_pr_routes_to_resolve_review_on_failure(self, recipe: object) -> None:
-        """T_RP5: review_pr.on_failure routes to resolve_review."""
-        assert recipe.steps["review_pr"].on_failure == "resolve_review"  # type: ignore[attr-defined]
+    def test_review_pr_routes_to_check_repo_ci_event_on_failure(self, recipe: object) -> None:
+        """T_RP5: review_pr.on_failure routes to check_repo_ci_event (no review to resolve)."""
+        assert recipe.steps["review_pr"].on_failure == "check_repo_ci_event"  # type: ignore[attr-defined]
+
+    def test_resolve_review_only_reachable_via_verdict(self, recipe: object) -> None:
+        """T_RP5b: resolve_review only reachable via on_result verdicts, not on_failure."""
+        step = recipe.steps["review_pr"]  # type: ignore[attr-defined]
+        assert step.on_failure != "resolve_review"
+        assert step.on_context_limit != "resolve_review"
+        verdict_routes = [
+            c.route for c in step.on_result.conditions if c.route == "resolve_review"
+        ]
+        assert len(verdict_routes) >= 1, "resolve_review must still be reachable via on_result"
+
+    def test_review_pr_failure_and_context_limit_converge(self, recipe: object) -> None:
+        """T_RP5c: on_failure and on_context_limit both route to check_repo_ci_event."""
+        step = recipe.steps["review_pr"]  # type: ignore[attr-defined]
+        assert step.on_failure == step.on_context_limit == "check_repo_ci_event"
 
     def test_resolve_review_has_retries(self, recipe: object) -> None:
         """T_RP6: resolve_review has retries=2 matching resolve_ci pattern."""


### PR DESCRIPTION
## Summary

When `review_pr` fails outright (MCP error, `contract_recovery`, `gh` unavailable), `on_failure` currently routes to `resolve_review` — a step that fetches and resolves PR review comments. But if the review skill never completed, no review comments were posted, so `resolve_review` wastes an entire headless session doing nothing meaningful.

The fix: change `on_failure` from `resolve_review` to `check_repo_ci_event` in the three affected recipe files. `resolve_review` remains reachable only via `on_result` when a verdict was actually captured (`changes_requested` or `approved_with_comments`). The `on_failure` path should skip resolution and proceed directly to CI — the same destination as `on_context_limit` and the catch-all `on_result` branch.

Closes #1663

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260503-072533-702618/.autoskillit/temp/make-plan/review_pr_on_failure_reroute_plan_2026-05-03_072900.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 2.9k | 6.7k | 572.8k | 51.4k | 1 | 6m 5s |
| verify | 29 | 4.2k | 425.4k | 41.4k | 1 | 4m 21s |
| implement | 188 | 8.5k | 896.7k | 37.2k | 1 | 3m 35s |
| prepare_pr | 60 | 4.6k | 206.6k | 25.0k | 1 | 1m 34s |
| compose_pr | 83 | 2.6k | 286.9k | 20.4k | 1 | 53s |
| review_pr | 100 | 21.9k | 481.8k | 49.1k | 1 | 5m 13s |
| resolve_review | 157 | 9.9k | 795.0k | 46.0k | 1 | 3m 36s |
| **Total** | 3.5k | 58.3k | 3.7M | 270.5k | | 25m 20s |
## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| build_execution_map | 0 | — | — | — |
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 215 | 21351.5 | 526.9 | 157.8 |
| fix | 29 | 83946.2 | 2497.6 | 729.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **244** | 46858.7 | 2524.6 | 515.0 |