### PR TITLE
Implementation Plan: Fix Missing Fleet Entries in LAYER_CASCADE_CONSERVATIVE["recipe"]

### DIFF
--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -384,6 +384,12 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             "migration/test_engine.py",
             # Hooks file-level entries (_fmt_recipe.py imports autoskillit.recipe types):
             "hooks/test_recipe_write_advisor.py",
+            # Fleet file-level entries (5 of N import autoskillit.recipe):
+            "fleet/test_fleet_e2e.py",
+            "fleet/test_campaign_capture.py",
+            "fleet/test_pack_enforcement.py",
+            "fleet/test_pack_enforcement_e2e.py",
+            "fleet/test_dispatch_failure_semantics.py",
             # Other file-level entries:
             "infra/test_pretty_output_recipe.py",
             "skills/test_planner_skill_contracts.py",

--- a/tests/test_test_filter_cascade.py
+++ b/tests/test_test_filter_cascade.py
@@ -135,6 +135,14 @@ _CLI_FILE_LEVEL_ENTRIES = [
     "test_cook_order_picker.py",
 ]
 
+_FLEET_FILE_LEVEL_ENTRIES = [
+    "test_fleet_e2e.py",
+    "test_campaign_capture.py",
+    "test_pack_enforcement.py",
+    "test_pack_enforcement_e2e.py",
+    "test_dispatch_failure_semantics.py",
+]
+
 
 class TestRecipeCascadeNarrowing:
     """REQ-RECIPE-001/002/003: recipe cascade uses file-level entries for server/cli,
@@ -211,6 +219,25 @@ class TestRecipeCascadeNarrowing:
         assert not any("/hooks/" in str(p) for p in result), (
             f"hooks/test_fmt_status.py (not in cascade) should not appear; got {result}"
         )
+
+    def test_recipe_cascade_fleet_file_level_only(self, tmp_path: Path) -> None:
+        tests_root = tmp_path / "tests"
+        fleet_dir = tests_root / "fleet"
+        fleet_dir.mkdir(parents=True, exist_ok=True)
+        for fname in _FLEET_FILE_LEVEL_ENTRIES:
+            (fleet_dir / fname).touch()
+        (fleet_dir / "test_fleet_cli.py").touch()
+
+        result = build_test_scope(
+            changed_files={"src/autoskillit/recipe/schema.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        result_names = {p.name for p in result}
+        for fname in _FLEET_FILE_LEVEL_ENTRIES:
+            assert fname in result_names, f"{fname!r} missing from recipe cascade result"
+        assert "test_fleet_cli.py" not in result_names
 
 
 class TestServerFleetCascadeNarrowing:

--- a/tests/test_test_filter_cascade.py
+++ b/tests/test_test_filter_cascade.py
@@ -233,7 +233,7 @@ class TestRecipeCascadeNarrowing:
             mode=FilterMode.CONSERVATIVE,
             tests_root=tests_root,
         )
-        assert result is not None
+        assert len(result) >= len(_FLEET_FILE_LEVEL_ENTRIES)
         result_names = {p.name for p in result}
         for fname in _FLEET_FILE_LEVEL_ENTRIES:
             assert fname in result_names, f"{fname!r} missing from recipe cascade result"


### PR DESCRIPTION
## Summary

Five fleet test files (`test_fleet_e2e.py`, `test_campaign_capture.py`, `test_pack_enforcement.py`, `test_pack_enforcement_e2e.py`, `test_dispatch_failure_semantics.py`) have direct imports from `autoskillit.recipe.schema` or `autoskillit.recipe.io` but are absent from `LAYER_CASCADE_CONSERVATIVE["recipe"]` in `tests/_test_filter.py`. This means recipe source changes silently skip these tests under filtered runs. The fix adds the 5 file-level entries to the `"recipe"` frozenset and adds a behavioral cascade test to prevent regression.

Closes #1667

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260503-083844-144927/.autoskillit/temp/make-plan/fix_missing_fleet_entries_in_layer_cascade_conservative_recipe_plan_2026-05-03_084600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 49 | 6.4k | 577.4k | 44.9k | 1 | 3m 37s |
| verify | 49 | 11.6k | 1.2M | 58.9k | 1 | 5m 3s |
| implement | 142 | 5.7k | 619.6k | 34.8k | 1 | 5m 12s |
| prepare_pr | 68 | 4.5k | 236.5k | 24.7k | 1 | 1m 19s |
| compose_pr | 59 | 2.3k | 191.4k | 19.2k | 1 | 38s |
| review_pr | 102 | 20.7k | 489.8k | 47.4k | 1 | 4m 50s |
| resolve_review | 253 | 13.9k | 1.4M | 53.0k | 1 | 5m 30s |
| **Total** | 722 | 65.1k | 4.8M | 282.8k | | 26m 12s |