### PR TITLE
Add max_parallel Cap with Prefer-Completion Scheduling to full-audit Recipe

### DIFF
--- a/src/autoskillit/recipes/full-audit.yaml
+++ b/src/autoskillit/recipes/full-audit.yaml
@@ -5,7 +5,7 @@ description: >-
   GitHub issue from each validated report.
 summary: "branch → audit×6 ∥ → validate×6 ∥ → issue×6 ∥ → done"
 autoskillit_version: "0.9.343"
-recipe_version: "1.0.0"
+recipe_version: "1.1.0"
 requires_packs: [audit, github]
 
 ingredients:
@@ -15,6 +15,10 @@ ingredients:
   branch:
     description: "The branch to audit against"
     required: true
+  max_parallel:
+    description: "Max audits to run in parallel (half the audit count by default)"
+    default: "3"
+    hidden: true
 
 kitchen_rules:
   - >-
@@ -26,8 +30,14 @@ kitchen_rules:
     independent. A failure in one chain MUST NOT block or affect the other five chains.
     Continue with successful chains and note failures for escalation.
   - >-
-    Within each wave, fire all run_skill calls in a single message to achieve
-    parallelism. Do not serialize audit/validate/issue calls.
+    PREFER-COMPLETION SCHEDULING: Maintain up to ${{ inputs.max_parallel }}
+    concurrent run_skill calls. When any call completes, immediately dispatch
+    the next item from the queue. Do not wait for all slots to finish before
+    refilling — fill each freed slot individually.
+  - >-
+    prepare-issue calls MUST be sequential — never call prepare-issue in
+    parallel with itself. It hits the GitHub API and parallel calls create
+    request storms. Other tool types may overlap with prepare-issue.
   - >-
     Report paths are discovered from session output — look for file paths
     in {{AUTOSKILLIT_TEMP}}/ directories. Pass discovered paths as positional
@@ -58,14 +68,24 @@ steps:
       cwd: "${{ inputs.workspace }}"
       step_name: "run_audits"
     note: >
-      PARALLEL AUDIT WAVE — Fire six run_skill calls in a single message:
+      PREFER-COMPLETION AUDIT DISPATCH — Dispatch audits using prefer-completion
+      scheduling capped at ${{ inputs.max_parallel }} concurrent slots:
 
-      1. run_skill(skill_command="/autoskillit:audit-tests", cwd="${{ inputs.workspace }}", step_name="audit_tests")
-      2. run_skill(skill_command="/autoskillit:audit-cohesion", cwd="${{ inputs.workspace }}", step_name="audit_cohesion")
-      3. run_skill(skill_command="/autoskillit:audit-arch", cwd="${{ inputs.workspace }}", step_name="audit_arch")
-      4. run_skill(skill_command="/autoskillit:audit-feature-gates", cwd="${{ inputs.workspace }}", step_name="audit_feature_gates")
-      5. run_skill(skill_command="/autoskillit:audit-docs", cwd="${{ inputs.workspace }}", step_name="audit_docs")
-      6. run_skill(skill_command="/autoskillit:audit-review-decisions", cwd="${{ inputs.workspace }}", step_name="audit_review_decisions")
+      1. Queue all six audits:
+         - run_skill(skill_command="/autoskillit:audit-tests", cwd="${{ inputs.workspace }}", step_name="audit_tests")
+         - run_skill(skill_command="/autoskillit:audit-cohesion", cwd="${{ inputs.workspace }}", step_name="audit_cohesion")
+         - run_skill(skill_command="/autoskillit:audit-arch", cwd="${{ inputs.workspace }}", step_name="audit_arch")
+         - run_skill(skill_command="/autoskillit:audit-feature-gates", cwd="${{ inputs.workspace }}", step_name="audit_feature_gates")
+         - run_skill(skill_command="/autoskillit:audit-docs", cwd="${{ inputs.workspace }}", step_name="audit_docs")
+         - run_skill(skill_command="/autoskillit:audit-review-decisions", cwd="${{ inputs.workspace }}", step_name="audit_review_decisions")
+
+      2. Launch the first ${{ inputs.max_parallel }} audits as run_skill calls
+         in a single message.
+
+      3. When any audit completes (success or failure), immediately launch
+         the next queued audit in the same message as any other pending
+         responses. Maintain ${{ inputs.max_parallel }} in-flight at all times
+         until the queue is empty.
 
       Each audit writes its report to a well-known temp directory:
       - {{AUTOSKILLIT_TEMP}}/audit-tests/{name}_{timestamp}.md
@@ -97,18 +117,22 @@ steps:
       cwd: "${{ inputs.workspace }}"
       step_name: "validate_audits"
     note: >
-      PARALLEL VALIDATION WAVE — For each audit that succeeded in the previous
-      wave, fire a run_skill call in a single message. Pass the audit report
-      path as a positional argument:
+      PREFER-COMPLETION VALIDATION — Start validating as each audit finishes.
+      Do not wait for all audits to complete before beginning validation.
 
-      1. run_skill(skill_command="/autoskillit:validate-audit {tests_report_path}", cwd="${{ inputs.workspace }}", step_name="validate_tests")
-      2. run_skill(skill_command="/autoskillit:validate-audit {cohesion_report_path}", cwd="${{ inputs.workspace }}", step_name="validate_cohesion")
-      3. run_skill(skill_command="/autoskillit:validate-audit {arch_report_path}", cwd="${{ inputs.workspace }}", step_name="validate_arch")
-      4. run_skill(skill_command="/autoskillit:validate-audit {feature_gates_report_path}", cwd="${{ inputs.workspace }}", step_name="validate_feature_gates")
-      5. run_skill(skill_command="/autoskillit:validate-audit {docs_report_path}", cwd="${{ inputs.workspace }}", step_name="validate_docs")
-      6. run_skill(skill_command="/autoskillit:validate-audit {review_decisions_report_path}", cwd="${{ inputs.workspace }}", step_name="validate_review_decisions")
+      For each succeeded audit, queue a validation:
+        1. run_skill(skill_command="/autoskillit:validate-audit {tests_report_path}", cwd="${{ inputs.workspace }}", step_name="validate_tests")
+        2. run_skill(skill_command="/autoskillit:validate-audit {cohesion_report_path}", cwd="${{ inputs.workspace }}", step_name="validate_cohesion")
+        3. run_skill(skill_command="/autoskillit:validate-audit {arch_report_path}", cwd="${{ inputs.workspace }}", step_name="validate_arch")
+        4. run_skill(skill_command="/autoskillit:validate-audit {feature_gates_report_path}", cwd="${{ inputs.workspace }}", step_name="validate_feature_gates")
+        5. run_skill(skill_command="/autoskillit:validate-audit {docs_report_path}", cwd="${{ inputs.workspace }}", step_name="validate_docs")
+        6. run_skill(skill_command="/autoskillit:validate-audit {review_decisions_report_path}", cwd="${{ inputs.workspace }}", step_name="validate_review_decisions")
 
-      Skip validation for any audit that failed in wave 1.
+      Apply the same prefer-completion scheduling as run_audits — maintain up
+      to ${{ inputs.max_parallel }} concurrent slots across validations. As each
+      slot frees, dispatch the next queued validation immediately.
+
+      Skip validation for any audit that failed in the audit dispatch phase.
       Each validation writes to {{AUTOSKILLIT_TEMP}}/validate-audit/:
       - validated_report_{source}_{timestamp}.md (first line: "validated: true")
       - contested_findings_{source}_{timestamp}.md (only if contested > 0)
@@ -133,24 +157,21 @@ steps:
       cwd: "${{ inputs.workspace }}"
       step_name: "create_issues"
     note: >
-      PARALLEL ISSUE CREATION WAVE — validate-audit now splits each validated report
+      SEQUENTIAL ISSUE CREATION — validate-audit splits each validated report
       into per-ticket body files (ticket_body_{source}_{N}_{ts}.md) according to the
-      grouping manifest. Instead of passing validated_report_*.md directly, pass each
-      ticket body file to prepare-issue:
+      grouping manifest.
 
-      For each audit type that succeeded in wave 2:
+      For each audit type that succeeded in validation:
         1. Discover the grouping manifest (grouping_manifest_{source}_{ts}.md) in the
            validate-audit session output.
         2. Read the manifest to get the list of ticket body file paths.
-        3. Fire one run_skill call per ticket body, ALL in a single message:
+        3. Process prepare-issue calls one at a time:
+           - run_skill(skill_command="/autoskillit:prepare-issue {ticket_body_path}", cwd="${{ inputs.workspace }}", step_name="issue_{source}_{N}")
+           - Wait for completion.
+           - Proceed to the next ticket body.
 
-      Example for tests audit with 3 ticket groups:
-        run_skill("/autoskillit:prepare-issue {ticket_body_tests_1_path}", step_name="issue_tests_1")
-        run_skill("/autoskillit:prepare-issue {ticket_body_tests_2_path}", step_name="issue_tests_2")
-        run_skill("/autoskillit:prepare-issue {ticket_body_tests_3_path}", step_name="issue_tests_3")
-        run_skill("/autoskillit:prepare-issue {ticket_body_cohesion_1_path}", step_name="issue_cohesion_1")
-        run_skill("/autoskillit:prepare-issue {ticket_body_review_decisions_1_path}", step_name="issue_review_decisions_1")
-        ... (all ticket bodies across all audit types in a single message)
+      Never call prepare-issue in parallel with itself — it hits the GitHub API
+      and parallel calls create request storms.
 
       After all issues are created, append the validation summary to each issue body
       (sequentially): fetch the current body, verify it is non-empty, append a separator

--- a/tests/recipe/test_bundled_recipe_hidden_policy.py
+++ b/tests/recipe/test_bundled_recipe_hidden_policy.py
@@ -13,6 +13,7 @@ BUNDLED_RECIPE_NAMES = [
     "remediation",
     "implementation-groups",
     "merge-prs",
+    "full-audit",
 ]
 
 

--- a/tests/recipe/test_full_audit_recipe.py
+++ b/tests/recipe/test_full_audit_recipe.py
@@ -80,7 +80,7 @@ def test_full_audit_kitchen_rules() -> None:
     from autoskillit.recipe.io import load_recipe
 
     recipe = load_recipe(RECIPE_PATH)
-    assert len(recipe.kitchen_rules) == 4
+    assert len(recipe.kitchen_rules) == 5
 
 
 def test_full_audit_done_step_has_message() -> None:
@@ -173,3 +173,66 @@ def test_full_audit_validate_audits_note_mentions_review_decisions() -> None:
     data = yaml.safe_load(RECIPE_PATH.read_text())
     note = data["steps"]["validate_audits"]["note"]
     assert "review_decisions" in note
+
+
+def test_full_audit_has_max_parallel_ingredient() -> None:
+    from autoskillit.recipe.io import load_recipe
+
+    recipe = load_recipe(RECIPE_PATH)
+    assert "max_parallel" in recipe.ingredients
+
+
+def test_full_audit_max_parallel_defaults_to_three() -> None:
+    from autoskillit.recipe.io import load_recipe
+
+    recipe = load_recipe(RECIPE_PATH)
+    ing = recipe.ingredients["max_parallel"]
+    assert ing.default == "3"
+
+
+def test_full_audit_max_parallel_is_hidden() -> None:
+    from autoskillit.recipe.io import load_recipe
+
+    recipe = load_recipe(RECIPE_PATH)
+    ing = recipe.ingredients["max_parallel"]
+    assert ing.hidden is True
+
+
+def test_full_audit_kitchen_rule_mentions_prefer_completion() -> None:
+    from autoskillit.recipe.io import load_recipe
+
+    recipe = load_recipe(RECIPE_PATH)
+    rules_text = " ".join(recipe.kitchen_rules).lower()
+    assert "prefer-completion" in rules_text or "prefer completion" in rules_text
+
+
+def test_full_audit_run_audits_note_mentions_max_parallel() -> None:
+    import yaml
+
+    data = yaml.safe_load(RECIPE_PATH.read_text())
+    note = data["steps"]["run_audits"]["note"].lower()
+    assert "max_parallel" in note or "max parallel" in note
+
+
+def test_full_audit_validate_audits_no_wave_barrier() -> None:
+    import yaml
+
+    data = yaml.safe_load(RECIPE_PATH.read_text())
+    note = data["steps"]["validate_audits"]["note"].lower()
+    assert "as each" in note or "as soon as" in note or "slot" in note
+
+
+def test_full_audit_create_issues_sequential_prepare_issue() -> None:
+    import yaml
+
+    data = yaml.safe_load(RECIPE_PATH.read_text())
+    note = data["steps"]["create_issues"]["note"].lower()
+    assert "sequential" in note or "one at a time" in note
+
+
+def test_full_audit_recipe_version_bumped() -> None:
+    import yaml
+    from packaging.version import Version
+
+    data = yaml.safe_load(RECIPE_PATH.read_text())
+    assert Version(data["recipe_version"]) > Version("1.0.0")


### PR DESCRIPTION
## Summary

Add a hidden `max_parallel` ingredient (default `"3"`) to `full-audit.yaml` and introduce prefer-completion scheduling semantics to the `run_audits` and `validate_audits` steps. Unlike the full-barrier wavefront pattern used in `implement-findings`, prefer-completion immediately fills freed slots from the remaining queue. Additionally, update `create_issues` to instruct sequential `prepare-issue` calls to avoid GitHub API request storms. Add a 5th kitchen rule describing the new scheduling pattern. Bump `recipe_version`.

## Requirements

### 1. Add `max_parallel` ingredient with prefer-completion semantics

Add a hidden `max_parallel` ingredient (default: half the audit count, e.g. `"3"`) to `full-audit.yaml`.

Unlike the full-barrier pattern used elsewhere (wait for all N to finish before next batch), use **prefer-completion scheduling**: when any slot frees up, immediately fill it from the remaining queue. Example: if `max_parallel=3` and audits A/B/C are running, when A finishes, immediately launch D while B/C continue.

This applies to both:
- **run_audits** step (audit skill fan-out)
- **validate_audits** step (validate-audit fan-out) — a validation should start as soon as its audit finishes and a slot is available, not wait for the full audit wave to complete

### 2. Stagger `prepare-issue` calls (sequential self-invocation)

`prepare-issue` should never be called in parallel with itself — it hits the GitHub API and parallel calls create request storms. Update the `create_issues` step note to instruct sequential processing (one `prepare-issue` at a time). It can still overlap with other tool types, just not with itself.

### 3. Keep instructions concise

Any note/kitchen_rule modifications must remain concise. Don't over-explain — the orchestrator is already familiar with the patterns.

Closes #1688

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260503-092606-275771/.autoskillit/temp/make-plan/full_audit_max_parallel_cap_plan_2026-05-03_093600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 1.5k | 9.8k | 1.1M | 65.5k | 1 | 6m 29s |
| verify | 39 | 9.8k | 594.7k | 52.4k | 1 | 5m 23s |
| implement | 53 | 10.0k | 1.4M | 59.9k | 1 | 10m 29s |
| prepare_pr | 23 | 3.2k | 143.4k | 26.1k | 1 | 1m 3s |
| compose_pr | 22 | 1.7k | 130.8k | 18.9k | 1 | 45s |
| review_pr | 29 | 20.3k | 480.1k | 51.1k | 1 | 4m 47s |
| resolve_review | 1.7k | 15.6k | 1.2M | 85.1k | 2 | 12m 4s |
| ci_conflict_fix | 35 | 4.0k | 659.6k | 34.3k | 1 | 2m 3s |
| **Total** | 3.4k | 74.4k | 5.7M | 393.2k | | 43m 6s |
## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 157 | 8710.3 | 381.7 | 63.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **157** | 21432.9 | 1419.2 | 219.6 |