### PR TITLE
Add MODULE_CASCADE_RECIPE for Per-Module Test Filter Narrowing

### DIFF
--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -1206,6 +1206,12 @@ def build_test_scope(
                                 for s in recipe_cause_stems:
                                     test_dirs.update(MODULE_CASCADE_RECIPE[s])
                             else:
+                                if not recipe_cause_stems:
+                                    logging.getLogger(__name__).debug(  # noqa: TID251
+                                        "recipe/__init__ backtrace: no non-init recipe cause stems"
+                                        " — failing open to full recipe cascade (expected behavior"
+                                        " when only recipe/__init__.py changed)"
+                                    )
                                 test_dirs.update(cascade_map["recipe"])  # fail-open
                         elif stem in MODULE_CASCADE_RECIPE:
                             test_dirs.update(MODULE_CASCADE_RECIPE[stem])

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -279,6 +279,155 @@ MODULE_CASCADE_EXECUTION: dict[str, frozenset[str]] = {
     # headless and process are NOT listed — they fall through to cascade_map["execution"]
 }
 
+MODULE_CASCADE_RECIPE: dict[str, frozenset[str]] = {
+    # --- Narrowest: recipe/ only (no out-of-recipe importers) ---
+    "rules_actions": frozenset({"recipe"}),
+    "rules_blocks": frozenset({"recipe"}),
+    "rules_bypass": frozenset({"recipe"}),
+    "rules_campaign": frozenset({"recipe"}),
+    "rules_ci": frozenset({"recipe"}),
+    "rules_clone": frozenset({"recipe"}),
+    "rules_cmd": frozenset({"recipe"}),
+    "rules_contracts": frozenset({"recipe"}),
+    "rules_dataflow": frozenset({"recipe"}),
+    "rules_features": frozenset({"recipe"}),
+    "rules_fixing": frozenset({"recipe"}),
+    "rules_graph": frozenset({"recipe"}),
+    "rules_inline_script": frozenset({"recipe"}),
+    "rules_inputs": frozenset({"recipe"}),
+    "rules_isolation": frozenset({"recipe"}),
+    "rules_merge": frozenset({"recipe"}),
+    "rules_packs": frozenset({"recipe"}),
+    "rules_reachability": frozenset({"recipe"}),
+    "rules_recipe": frozenset({"recipe"}),
+    "rules_skills": frozenset({"recipe"}),
+    "rules_temp_path": frozenset({"recipe"}),
+    "rules_tools": frozenset({"recipe"}),
+    "rules_verdict": frozenset({"recipe"}),
+    "rules_worktree": frozenset({"recipe"}),
+    "rules_skill_content": frozenset(
+        {
+            "recipe",
+            "skills/test_skill_placeholder_contracts.py",
+            "skills/test_skill_tool_syntax_contracts.py",
+        }
+    ),
+    # --- Internal utility modules (no external src importers) ---
+    "_analysis": frozenset({"recipe"}),
+    "_analysis_bfs": frozenset({"recipe"}),
+    "_analysis_blocks": frozenset({"recipe"}),
+    "_analysis_detectors": frozenset({"recipe"}),
+    "_analysis_graph": frozenset({"recipe"}),
+    "_git_helpers": frozenset({"recipe"}),
+    "_skill_helpers": frozenset({"recipe"}),
+    "_skill_placeholder_parser": frozenset(
+        {
+            "recipe",
+            "skills/test_make_campaign_compliance.py",
+            "skills/test_skill_placeholder_contracts.py",
+            "skills/test_skill_tool_syntax_contracts.py",
+        }
+    ),
+    "_recipe_composition": frozenset({"recipe"}),
+    "_recipe_ingredients": frozenset({"recipe"}),
+    "diagrams": frozenset({"recipe"}),
+    "identity": frozenset({"recipe"}),
+    "order": frozenset({"recipe"}),
+    "loader": frozenset(
+        {
+            "recipe",
+            "cli/test_cli_prompts.py",
+            "cli/test_preview.py",
+        }
+    ),
+    # --- Medium: recipe + specific file-level consumers ---
+    "staleness_cache": frozenset(
+        {
+            "recipe",
+            "server/test_tools_load_recipe.py",
+        }
+    ),
+    "repository": frozenset(
+        {
+            "recipe",
+            "server/test_factory.py",
+            "server/test_tools_kitchen_envelope.py",
+            "server/test_service_wrappers.py",
+            "contracts/test_protocol_satisfaction.py",
+        }
+    ),
+    "validator": frozenset(
+        {
+            "recipe",
+            "server/test_smoke_pipeline.py",
+            "contracts/test_skill_yaml_validation.py",
+        }
+    ),
+    "experiment_type_registry": frozenset(
+        {
+            "recipe",
+            "skills/test_review_design_guards.py",
+        }
+    ),
+    "registry": frozenset(
+        {
+            "recipe",
+            "server/test_smoke_pipeline.py",
+            "contracts/test_skill_yaml_validation.py",
+            "skills/test_skill_placeholder_contracts.py",
+            "skills/test_skill_tool_syntax_contracts.py",
+        }
+    ),
+    # --- Broader: recipe + multiple directory consumers ---
+    "contracts": frozenset(
+        {
+            "recipe",
+            "_llm_triage",
+            "server/test_factory.py",
+            "server/test_tools_load_recipe.py",
+            "server/test_service_wrappers.py",
+            "execution/test_headless_path_validation.py",
+            "execution/test_zero_write_detection.py",
+            "skills/test_planner_skill_contracts.py",
+            "contracts/test_api_surface_alignment.py",
+            "contracts/test_review_pr_diff_annotation.py",
+            "contracts/test_instruction_surface.py",
+        }
+    ),
+    "_api": frozenset(
+        {
+            "recipe",
+            "server/test_tools_list_recipes.py",
+            "server/test_tools_kitchen_envelope.py",
+            "server/test_tools_load_recipe.py",
+            "server/test_mcp_overrides.py",
+            "server/test_service_wrappers.py",
+            "cli/test_cli_prompts.py",
+            "infra/test_pretty_output_recipe.py",
+            "contracts/test_tools_recipe_contracts.py",
+            "contracts/test_package_gateways.py",
+        }
+    ),
+    "io": frozenset(
+        {
+            "recipe",
+            "server/test_server_tool_registration.py",
+            "server/test_smoke_pipeline.py",
+            "server/test_service_wrappers.py",
+            "cli/test_cli_prompts.py",
+            "cli/test_fleet_list.py",
+            "cli/test_preview.py",
+            "fleet/test_pack_enforcement.py",
+            "fleet/test_pack_enforcement_e2e.py",
+            "skills/test_planner_skill_contracts.py",
+            "contracts/test_skill_yaml_validation.py",
+            "contracts/test_target_skill_invocability.py",
+            "contracts/test_package_gateways.py",
+            "contracts/test_instruction_surface.py",
+        }
+    ),
+}
+
 # ---------------------------------------------------------------------------
 # Layer cascade maps
 # ---------------------------------------------------------------------------
@@ -974,6 +1123,12 @@ def build_test_scope(
                     test_dirs.update(
                         cascade_map["execution"]
                     )  # fail-open: headless, process, unknown
+            elif pkg == "recipe" and mode == FilterMode.CONSERVATIVE:
+                stem = Path(f).stem
+                if stem in MODULE_CASCADE_RECIPE:
+                    test_dirs.update(MODULE_CASCADE_RECIPE[stem])
+                else:
+                    test_dirs.update(cascade_map["recipe"])  # fail-open
             elif pkg and pkg in cascade_map:
                 test_dirs.update(cascade_map[pkg])
             else:
@@ -1037,6 +1192,25 @@ def build_test_scope(
                             test_dirs.update(MODULE_CASCADE_EXECUTION[stem])
                         else:
                             test_dirs.update(cascade_map["execution"])  # fail-open
+                    elif pkg == "recipe" and mode == FilterMode.CONSERVATIVE:
+                        stem = Path(f).stem
+                        if stem == "__init__":
+                            recipe_cause_stems = {
+                                Path(c).stem
+                                for c in changed_src_py
+                                if _file_to_package(c) == "recipe" and Path(c).stem != "__init__"
+                            }
+                            if recipe_cause_stems and all(
+                                s in MODULE_CASCADE_RECIPE for s in recipe_cause_stems
+                            ):
+                                for s in recipe_cause_stems:
+                                    test_dirs.update(MODULE_CASCADE_RECIPE[s])
+                            else:
+                                test_dirs.update(cascade_map["recipe"])  # fail-open
+                        elif stem in MODULE_CASCADE_RECIPE:
+                            test_dirs.update(MODULE_CASCADE_RECIPE[stem])
+                        else:
+                            test_dirs.update(cascade_map["recipe"])  # fail-open
                     elif pkg and pkg in cascade_map:
                         test_dirs.update(cascade_map[pkg])
         except Exception:

--- a/tests/arch/test_cascade_map_guard.py
+++ b/tests/arch/test_cascade_map_guard.py
@@ -16,6 +16,7 @@ from tests._test_filter import (
     LAYER_CASCADE_CONSERVATIVE,
     MODULE_CASCADE_CORE,
     MODULE_CASCADE_EXECUTION,
+    MODULE_CASCADE_RECIPE,
     _file_to_package,
 )
 
@@ -151,6 +152,32 @@ def _build_execution_module_reverse_graph() -> dict[str, set[str]]:
     return _build_pkg_module_reverse_graph("execution", _build_reexport_map("execution"))
 
 
+def _build_recipe_module_reverse_graph() -> dict[str, set[str]]:
+    """REQ-GUARD-001 (module level, recipe). Returns {stem: set[consuming_pkg]}."""
+    graph = _build_pkg_module_reverse_graph("recipe", _build_reexport_map("recipe"))
+    # recipe/__init__.py imports rules_* via `from autoskillit.recipe import rules_X as _rules_X`
+    # (absolute submodule import, level=0) — invisible to _build_pkg_module_reverse_graph's
+    # reexport path which only handles relative imports.
+    recipe_init = _SRC_ROOT / "recipe" / "__init__.py"
+    if recipe_init.exists():
+        try:
+            tree = ast.parse(recipe_init.read_text(encoding="utf-8"))
+        except SyntaxError:
+            return graph
+        for node in ast.walk(tree):
+            if not (
+                isinstance(node, ast.ImportFrom)
+                and node.level == 0
+                and node.module == "autoskillit.recipe"
+            ):
+                continue
+            for alias in node.names:
+                stem = alias.name
+                if (recipe_init.parent / f"{stem}.py").exists():
+                    graph.setdefault(stem, set()).add("recipe")
+    return graph
+
+
 class TestModuleCascadeCoreGuard:
     """REQ-GUARD-002: MODULE_CASCADE_CORE declared sets must be supersets of actual consumers."""
 
@@ -220,6 +247,134 @@ class TestModuleCascadeExecutionGuard:
             f"  {sorted(phantoms)}\n"
             "Remove the stale entry or rename it to match the current module."
         )
+
+
+class TestModuleCascadeRecipeGuard:
+    """Validate MODULE_CASCADE_RECIPE against actual AST imports."""
+
+    def test_module_cascade_recipe_is_superset_of_ast_consumers(self) -> None:
+        graph = _build_recipe_module_reverse_graph()
+        violations: dict[str, dict[str, list[str]]] = {}
+        for stem, declared in MODULE_CASCADE_RECIPE.items():
+            actual = graph.get(stem, set())
+            declared_dirs = {d for d in declared if "/" not in d}
+            file_prefixes = {d.split("/", 1)[0] for d in declared if "/" in d}
+            covered = declared_dirs | file_prefixes
+            missing = actual - covered
+            if missing:
+                violations[stem] = {
+                    "declared": sorted(declared),
+                    "actual": sorted(actual),
+                    "missing": sorted(missing),
+                }
+        assert not violations, (
+            "MODULE_CASCADE_RECIPE entries are too narrow — update tests/_test_filter.py:\n"
+            + "\n".join(
+                f"  {stem}: add {v['missing']} (declared={v['declared']}, actual={v['actual']})"
+                for stem, v in sorted(violations.items())
+            )
+        )
+
+    def test_module_cascade_recipe_has_no_phantom_stems(self) -> None:
+        graph = _build_recipe_module_reverse_graph()
+        phantoms = [stem for stem in MODULE_CASCADE_RECIPE if not graph.get(stem)]
+        assert not phantoms, (
+            "MODULE_CASCADE_RECIPE contains stems with zero AST consumers — "
+            "the source file may have been renamed or deleted:\n"
+            f"  {sorted(phantoms)}\n"
+            "Remove the stale entry or rename it to match the current module."
+        )
+
+
+_TESTS_ROOT = Path(__file__).parent.parent
+
+
+class TestModuleCascadeRecipeNarrowing:
+    """Validate that MODULE_CASCADE_RECIPE actually narrows scope in build_test_scope."""
+
+    def test_rules_module_narrows_to_recipe_dir_only(self) -> None:
+        from tests._test_filter import FilterMode, build_test_scope
+
+        scope = build_test_scope(
+            changed_files={"src/autoskillit/recipe/rules_actions.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=_TESTS_ROOT,
+        )
+        assert not isinstance(scope, str)  # not a FullRunReason
+        assert any("recipe" in str(p) for p in scope)
+        layer_only = {"server", "cli", "fleet", "migration"}
+        dir_scope_names = {p.name for p in scope if p.is_dir()}
+        assert not (layer_only & dir_scope_names), (
+            f"rules_actions.py should narrow to recipe-only but got dirs: {dir_scope_names}"
+        )
+
+    def test_recipe_init_backtrace_narrows_with_mapped_causes(self) -> None:
+        from tests._test_filter import FilterMode, build_test_scope
+
+        scope = build_test_scope(
+            changed_files={"src/autoskillit/recipe/rules_actions.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=_TESTS_ROOT,
+        )
+        assert not isinstance(scope, str)
+        scope_strs = {str(p) for p in scope}
+        layer_only = {"server", "cli", "fleet", "migration"}
+        dir_scope_names = {p.name for p in scope if p.is_dir()}
+        assert not (layer_only & dir_scope_names), (
+            f"recipe __init__ backtrace should narrow but got dirs: {dir_scope_names}"
+        )
+        assert any("recipe" in s for s in scope_strs)
+
+    def test_unmapped_recipe_stem_fails_open_to_layer_cascade(self) -> None:
+        from tests._test_filter import (
+            LAYER_CASCADE_CONSERVATIVE,
+            FilterMode,
+            build_test_scope,
+        )
+
+        scope = build_test_scope(
+            changed_files={"src/autoskillit/recipe/some_future_module.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=_TESTS_ROOT,
+        )
+        assert not isinstance(scope, str)
+        scope_strs = {str(p) for p in scope}
+        layer_dirs = {
+            entry
+            for entry in LAYER_CASCADE_CONSERVATIVE["recipe"]
+            if "/" not in entry and (_TESTS_ROOT / entry).is_dir()
+        }
+        for entry in layer_dirs:
+            assert any(entry in s for s in scope_strs), (
+                f"Fail-open should include '{entry}' from LAYER_CASCADE"
+            )
+
+    def test_mixed_mapped_and_unmapped_recipe_stems_fail_open_init(self) -> None:
+        from tests._test_filter import (
+            LAYER_CASCADE_CONSERVATIVE,
+            FilterMode,
+            build_test_scope,
+        )
+
+        scope = build_test_scope(
+            changed_files={
+                "src/autoskillit/recipe/rules_actions.py",
+                "src/autoskillit/recipe/some_future_module.py",
+            },
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=_TESTS_ROOT,
+        )
+        assert not isinstance(scope, str)
+        scope_strs = {str(p) for p in scope}
+        layer_dirs = {
+            entry
+            for entry in LAYER_CASCADE_CONSERVATIVE["recipe"]
+            if "/" not in entry and (_TESTS_ROOT / entry).is_dir()
+        }
+        for entry in layer_dirs:
+            assert any(entry in s for s in scope_strs), (
+                f"Mixed stems should fail-open; missing '{entry}'"
+            )
 
 
 class TestLayerCascadeConservativeGuard:

--- a/tests/arch/test_cascade_map_guard.py
+++ b/tests/arch/test_cascade_map_guard.py
@@ -110,6 +110,10 @@ def _build_pkg_module_reverse_graph(
     through {pkg_name}/__init__.py.
 
     Returns {module_stem: set[consuming_pkg]}.
+
+    Limitation: only captures relative imports in {pkg_name}/__init__.py via the
+    reexport_map. Absolute submodule imports (`from autoskillit.{pkg_name} import X`
+    at level=0) are invisible to this function; callers must handle them separately.
     """
     graph: defaultdict[str, set[str]] = defaultdict(set)
     for filepath in _all_src_files():
@@ -155,14 +159,16 @@ def _build_execution_module_reverse_graph() -> dict[str, set[str]]:
 def _build_recipe_module_reverse_graph() -> dict[str, set[str]]:
     """REQ-GUARD-001 (module level, recipe). Returns {stem: set[consuming_pkg]}."""
     graph = _build_pkg_module_reverse_graph("recipe", _build_reexport_map("recipe"))
-    # recipe/__init__.py imports rules_* via `from autoskillit.recipe import rules_X as _rules_X`
-    # (absolute submodule import, level=0) — invisible to _build_pkg_module_reverse_graph's
-    # reexport path which only handles relative imports.
     recipe_init = _SRC_ROOT / "recipe" / "__init__.py"
     if recipe_init.exists():
         try:
             tree = ast.parse(recipe_init.read_text(encoding="utf-8"))
-        except SyntaxError:
+        except SyntaxError as exc:
+            warnings.warn(
+                f"SyntaxError parsing recipe/__init__.py: {exc}"
+                " — absolute-import graph may be incomplete",
+                stacklevel=2,
+            )
             return graph
         for node in ast.walk(tree):
             if not (
@@ -250,7 +256,7 @@ class TestModuleCascadeExecutionGuard:
 
 
 class TestModuleCascadeRecipeGuard:
-    """Validate MODULE_CASCADE_RECIPE against actual AST imports."""
+    """REQ-RECIPE-001: Validate MODULE_CASCADE_RECIPE against actual AST imports."""
 
     def test_module_cascade_recipe_is_superset_of_ast_consumers(self) -> None:
         graph = _build_recipe_module_reverse_graph()
@@ -308,22 +314,23 @@ class TestModuleCascadeRecipeNarrowing:
             f"rules_actions.py should narrow to recipe-only but got dirs: {dir_scope_names}"
         )
 
-    def test_recipe_init_backtrace_narrows_with_mapped_causes(self) -> None:
+    def test_recipe_init_change_fails_open_to_layer_cascade(self) -> None:
         from tests._test_filter import FilterMode, build_test_scope
 
         scope = build_test_scope(
-            changed_files={"src/autoskillit/recipe/rules_actions.py"},
+            changed_files={"src/autoskillit/recipe/__init__.py"},
             mode=FilterMode.CONSERVATIVE,
             tests_root=_TESTS_ROOT,
         )
         assert not isinstance(scope, str)
-        scope_strs = {str(p) for p in scope}
-        layer_only = {"server", "cli", "fleet", "migration"}
+        assert any("recipe" in str(p) for p in scope)
+        # recipe/__init__ is not in MODULE_CASCADE_RECIPE — fails open to full recipe cascade.
+        # The full cascade includes cross-layer test files as specific file entries, not full
+        # layer directories — confirm recipe/ dir is in scope.
         dir_scope_names = {p.name for p in scope if p.is_dir()}
-        assert not (layer_only & dir_scope_names), (
-            f"recipe __init__ backtrace should narrow but got dirs: {dir_scope_names}"
+        assert "recipe" in dir_scope_names, (
+            f"recipe/__init__ change should include recipe/ dir but got dirs: {dir_scope_names}"
         )
-        assert any("recipe" in s for s in scope_strs)
 
     def test_unmapped_recipe_stem_fails_open_to_layer_cascade(self) -> None:
         from tests._test_filter import (


### PR DESCRIPTION
## Summary

Add a `MODULE_CASCADE_RECIPE` dict to `tests/_test_filter.py` and the corresponding classification logic in `build_test_scope()` that maps individual recipe module stems to narrow test cascade sets. This mirrors the existing `MODULE_CASCADE_CORE` and `MODULE_CASCADE_EXECUTION` patterns. The most impactful narrowing is for `rules_*.py` modules (25 files, most frequently changed recipe files) which have zero out-of-recipe importers and will narrow from ~12,800 tests to ~2,300 tests (82-97% reduction).

Part A covers: the `MODULE_CASCADE_RECIPE` dict, both classification loop changes (Location 1 and Location 2 in `build_test_scope()`), and all test additions.

Closes #1668

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260503-092800-249134/.autoskillit/temp/make-plan/add_module_cascade_recipe_plan_part_a_2026-05-03_093500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 2.2k | 39.1k | 1.2M | 104.5k | 1 | 18m 17s |
| verify | 45 | 8.3k | 1.0M | 57.2k | 1 | 6m 21s |
| implement | 382 | 32.2k | 3.1M | 87.3k | 1 | 12m 54s |
| prepare_pr | 52 | 3.5k | 188.1k | 29.7k | 1 | 1m 15s |
| compose_pr | 51 | 2.1k | 160.4k | 19.0k | 1 | 49s |
| review_pr | 486 | 36.2k | 762.9k | 70.0k | 1 | 9m 44s |
| resolve_review | 373 | 30.8k | 3.0M | 90.8k | 1 | 13m 35s |
| **Total** | 3.5k | 152.2k | 9.4M | 458.5k | | 1h 2m |
## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 157 | 8710.3 | 381.7 | 63.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| ci_conflict_fix | 533 | 1237.5 | 64.3 | 7.6 |
| **Total** | **690** | 8304.5 | 569.9 | 107.8 |