### PR TITLE
Rectify: Planner Tier-Scoped Filename Contracts

### DIFF
--- a/src/autoskillit/planner/__init__.py
+++ b/src/autoskillit/planner/__init__.py
@@ -24,9 +24,12 @@ from autoskillit.planner.merge import (
     replace_item,
 )
 from autoskillit.planner.schema import (
+    ASSIGN_RESULT_FILE_RE,
     ASSIGNMENT_REQUIRED_KEYS,
     PHASE_REQUIRED_KEYS,
+    PHASE_RESULT_FILE_RE,
     WP_REQUIRED_KEYS,
+    WP_RESULT_FILE_RE,
     AssignmentElaborated,
     AssignmentShort,
     PhaseElaborated,
@@ -44,6 +47,9 @@ from autoskillit.planner.schema import (
 from autoskillit.planner.validation import validate_plan
 
 __all__ = [
+    "ASSIGN_RESULT_FILE_RE",
+    "PHASE_RESULT_FILE_RE",
+    "WP_RESULT_FILE_RE",
     "build_phase_assignment_manifest",
     "consolidate_wps",
     "build_phase_wp_manifest",

--- a/src/autoskillit/planner/manifests.py
+++ b/src/autoskillit/planner/manifests.py
@@ -9,6 +9,9 @@ from typing import TypedDict
 
 from autoskillit.core import atomic_write, write_versioned_json
 from autoskillit.planner.schema import (
+    ASSIGN_RESULT_FILE_RE,
+    PHASE_RESULT_FILE_RE,
+    WP_RESULT_FILE_RE,
     RunDirResult,
     TaskResolutionResult,
     validate_assignment_result,
@@ -61,7 +64,9 @@ def build_phase_assignment_manifest(phases_dir: str, output_dir: str) -> dict[st
     out_dir = Path(output_dir)
     assign_dir = out_dir.resolve()
 
-    phase_files = sorted(phases_path.glob("*_result.json"))
+    phase_files = [
+        f for f in sorted(phases_path.glob("*_result.json")) if PHASE_RESULT_FILE_RE.match(f.name)
+    ]
     parsed_phases = []
     for f in phase_files:
         try:
@@ -123,7 +128,9 @@ def build_phase_wp_manifest(
         else (out_dir / "work_packages").resolve()
     )
 
-    assign_files = list(assign_path.glob("*_result.json"))
+    assign_files = [
+        f for f in assign_path.glob("*_result.json") if ASSIGN_RESULT_FILE_RE.match(f.name)
+    ]
     parsed_assignments: list[dict] = []
     for f in assign_files:
         try:
@@ -205,7 +212,10 @@ def finalize_wp_manifest(work_packages_dir: str, output_dir: str) -> dict[str, s
         raise FileNotFoundError(f"work_packages_dir does not exist: {wp_dir}")
     out_dir = Path(output_dir)
 
-    result_files = sorted(wp_dir.glob("*_result.json"), key=lambda p: _natural_sort_key(p.name))
+    result_files = sorted(
+        (f for f in wp_dir.glob("*_result.json") if WP_RESULT_FILE_RE.match(f.name)),
+        key=lambda p: _natural_sort_key(p.name),
+    )
     items = []
     index_entries = []
     for f in result_files:
@@ -398,9 +408,11 @@ def expand_wps(refined_assignments_path: str, output_dir: str, **kwargs: object)
         context_paths.append(str(ctx_path))
         item_ids.append(str(phase_id))
 
+    sentinel_dir = wp_dir / "wp_sentinels"
+    sentinel_dir.mkdir(parents=True, exist_ok=True)
     manifest = {
         "pass_name": "phase_work_packages",
-        "result_dir": str(wp_dir),
+        "result_dir": str(sentinel_dir),
         "created_at": datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "items": items,
     }

--- a/src/autoskillit/planner/merge.py
+++ b/src/autoskillit/planner/merge.py
@@ -7,11 +7,22 @@ from pathlib import Path
 from typing import Any
 
 from autoskillit.core import get_logger, write_versioned_json
-from autoskillit.planner.schema import validate_phase_result
+from autoskillit.planner.schema import (
+    ASSIGN_RESULT_FILE_RE,
+    PHASE_RESULT_FILE_RE,
+    WP_RESULT_FILE_RE,
+    validate_phase_result,
+)
 
 logger = get_logger(__name__)
 
 _TIER_KEYS = ("phases", "assignments", "work_packages")
+
+_TIER_FILE_RE: dict[str, re.Pattern[str]] = {
+    "phases": PHASE_RESULT_FILE_RE,
+    "assignments": ASSIGN_RESULT_FILE_RE,
+    "work_packages": WP_RESULT_FILE_RE,
+}
 
 
 def merge_files(
@@ -215,7 +226,12 @@ def merge_tier_results(
     source_dir: str = "",
     **kwargs: Any,
 ) -> dict[str, Any]:
-    paths = sorted(Path(results_dir).glob("*_result.json"))
+    tier_re = _TIER_FILE_RE.get(key)
+    paths = sorted(
+        f
+        for f in Path(results_dir).glob("*_result.json")
+        if tier_re is None or tier_re.match(f.name)
+    )
     if not paths:
         raise ValueError(f"No *_result.json files found in {results_dir}")
     result = merge_files(
@@ -319,7 +335,9 @@ def build_plan_snapshot(
 ) -> dict[str, Any]:
     task = Path(task_file_path).read_text(encoding="utf-8") if task_file_path else ""
     phase_pairs: list[tuple[int, dict[str, Any]]] = []
-    for p in sorted(Path(phases_dir).glob("*_result.json")):
+    for p in sorted(
+        f for f in Path(phases_dir).glob("*_result.json") if PHASE_RESULT_FILE_RE.match(f.name)
+    ):
         try:
             raw = json.loads(p.read_text())
             validated = validate_phase_result(raw)

--- a/src/autoskillit/planner/schema.py
+++ b/src/autoskillit/planner/schema.py
@@ -153,6 +153,10 @@ _PHASE_ID_RE = re.compile(r"^P\d+$")
 _ASSIGN_ID_RE = re.compile(r"^P\d+-A\d+$")
 _WP_ID_RE = re.compile(r"^P\d+-A\d+-WP\d+$")
 
+PHASE_RESULT_FILE_RE = re.compile(r"^P\d+_result\.json$")
+ASSIGN_RESULT_FILE_RE = re.compile(r"^P\d+-A\d+_result\.json$")
+WP_RESULT_FILE_RE = re.compile(r"^P\d+-A\d+-WP\d+_result\.json$")
+
 PHASE_REQUIRED_KEYS: frozenset[str] = frozenset({"id", "name", "ordering"})
 ASSIGNMENT_REQUIRED_KEYS: frozenset[str] = frozenset({"id", "name", "proposed_work_packages"})
 WP_REQUIRED_KEYS: frozenset[str] = frozenset({"id", "name", "deliverables"})

--- a/src/autoskillit/planner/validation.py
+++ b/src/autoskillit/planner/validation.py
@@ -12,10 +12,14 @@ from __future__ import annotations
 import json
 import re
 from collections import deque
+from collections.abc import Iterator
 from pathlib import Path
 
 from autoskillit.core import get_logger, write_versioned_json
 from autoskillit.planner.schema import (
+    ASSIGN_RESULT_FILE_RE,
+    PHASE_RESULT_FILE_RE,
+    WP_RESULT_FILE_RE,
     ValidationFinding,
     validate_assignment_result,
     validate_phase_result,
@@ -41,9 +45,16 @@ _NEGATION_PREFIX_RE: re.Pattern[str] = re.compile(
 )
 
 
+def _iter_tier_files(directory: Path, filename_re: re.Pattern[str]) -> Iterator[Path]:
+    """Yield *_result.json files whose names match the tier's naming convention."""
+    for f in sorted(directory.glob("*_result.json")):
+        if filename_re.match(f.name):
+            yield f
+
+
 def _load_phase_results(root: Path) -> dict[str, dict]:
     results: dict[str, dict] = {}
-    for f in sorted((root / "phases").glob("*_result.json")):
+    for f in _iter_tier_files(root / "phases", PHASE_RESULT_FILE_RE):
         try:
             raw = json.loads(f.read_text())
             data = validate_phase_result(raw)
@@ -59,7 +70,7 @@ def _load_assignment_results(root: Path) -> dict[str, dict]:
     assign_dir = root / "assignments"
     if not assign_dir.exists():
         return results
-    for f in sorted(assign_dir.glob("*_result.json")):
+    for f in _iter_tier_files(assign_dir, ASSIGN_RESULT_FILE_RE):
         try:
             raw = json.loads(f.read_text())
             data = validate_assignment_result(raw)
@@ -75,9 +86,7 @@ def _load_wp_results(root: Path) -> dict[str, dict]:
     wp_dir = root / "work_packages"
     if not wp_dir.exists():
         return results
-    for f in sorted(wp_dir.glob("*_result.json")):
-        if f.name in ("wp_manifest.json", "wp_index.json"):
-            continue
+    for f in _iter_tier_files(wp_dir, WP_RESULT_FILE_RE):
         try:
             raw = json.loads(f.read_text())
             data = validate_wp_result(raw)

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -156,7 +156,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/smoke_utils.py", 87),
     ("src/autoskillit/smoke_utils.py", 299),
     # planner/manifests.py — finalize_wp_manifest: wp_index.json rebuild (list payload)
-    ("src/autoskillit/planner/manifests.py", 244),
+    ("src/autoskillit/planner/manifests.py", 254),
     # _cmd_rpc.py — emit_fallback_map: BEM fallback execution map (recipe-internal)
     ("src/autoskillit/recipe/_cmd_rpc.py", 445),
 }

--- a/tests/planner/test_compiler.py
+++ b/tests/planner/test_compiler.py
@@ -285,7 +285,7 @@ class TestCompilePlanEdgeCases:
         _make_valid_output_dir(tmp_path)
         wps_dir = tmp_path / "work_packages"
         write_json(
-            wps_dir / "BADID_result.json",
+            wps_dir / "P1-A1-WP99_result.json",
             {"id": "BADID", "name": "Bad", "deliverables": ["x.py"]},
         )
 

--- a/tests/planner/test_manifests.py
+++ b/tests/planner/test_manifests.py
@@ -410,7 +410,7 @@ def test_build_phase_assignment_manifest_corrupt_json_raises(tmp_path):
     phases_dir.mkdir()
     output_dir = tmp_path / "out"
     output_dir.mkdir()
-    (phases_dir / "bad_result.json").write_text("{not json")
+    (phases_dir / "P1_result.json").write_text("{not json")
 
     with pytest.raises(json.JSONDecodeError, match="Failed to parse"):
         build_phase_assignment_manifest(str(phases_dir), str(output_dir))
@@ -423,7 +423,7 @@ def test_build_phase_assignment_manifest_missing_required_keys_raises(tmp_path):
     phases_dir.mkdir()
     output_dir = tmp_path / "out"
     output_dir.mkdir()
-    (phases_dir / "bad_result.json").write_text(json.dumps({"foo": "bar"}))
+    (phases_dir / "P1_result.json").write_text(json.dumps({"foo": "bar"}))
 
     with pytest.raises(ValueError, match="Invalid phase result in"):
         build_phase_assignment_manifest(str(phases_dir), str(output_dir))
@@ -451,7 +451,7 @@ def test_build_phase_wp_manifest_corrupt_json_raises(tmp_path):
     assignments_dir.mkdir()
     output_dir = tmp_path / "out"
     output_dir.mkdir()
-    (assignments_dir / "bad_result.json").write_text("{not json")
+    (assignments_dir / "P1-A1_result.json").write_text("{not json")
 
     with pytest.raises(json.JSONDecodeError, match="Failed to parse"):
         build_phase_wp_manifest(str(assignments_dir), str(output_dir))
@@ -489,7 +489,7 @@ def test_finalize_wp_manifest_corrupt_json_raises(tmp_path):
     wp_dir.mkdir()
     output_dir = tmp_path / "out"
     output_dir.mkdir()
-    (wp_dir / "bad_result.json").write_text("{not json")
+    (wp_dir / "P1-A1-WP1_result.json").write_text("{not json")
 
     with pytest.raises(json.JSONDecodeError, match="Failed to parse"):
         finalize_wp_manifest(str(wp_dir), str(output_dir))
@@ -571,3 +571,58 @@ def test_resolve_task_input_long_inline_truncates_label(tmp_path):
     result = resolve_task_input(text, str(planner_dir))
     assert len(result["task_label"]) <= 80
     assert text.startswith(result["task_label"])
+
+
+def test_build_phase_wp_manifest_ignores_phase_sentinel_in_assignments(tmp_path):
+    """Phase sentinel files in assignments/ must not crash build_phase_wp_manifest."""
+    from autoskillit.planner import build_phase_wp_manifest
+
+    assign_dir = tmp_path / "assignments"
+    assign_dir.mkdir()
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    (assign_dir / "P1-A1_result.json").write_text(
+        json.dumps(make_assignment_result(1, 1, proposed_work_packages=[]))
+    )
+    (assign_dir / "P1_result.json").write_text(
+        json.dumps({"id": "P1", "status": "complete", "assignment_count": 1, "failed_count": 0})
+    )
+
+    result = build_phase_wp_manifest(str(assign_dir), str(out_dir))
+    assert "manifest_path" in result
+
+
+def test_expand_wps_result_dir_points_to_wp_sentinels(tmp_path):
+    """expand_wps must create wp_sentinels/ and point result_dir there."""
+    from autoskillit.planner import expand_wps
+
+    refined = {
+        "assignments": [
+            {
+                "id": "P1-A1",
+                "name": "Assignment 1",
+                "phase_id": "P1",
+                "phase_name": "Phase 1",
+                "goal": "test",
+                "technical_approach": "test",
+                "proposed_work_packages": [
+                    {
+                        "id_suffix": "WP1",
+                        "name": "WP 1",
+                        "scope": "core",
+                        "estimated_files": ["f.py"],
+                    }
+                ],
+            }
+        ],
+        "task": "test task",
+    }
+    refined_path = tmp_path / "refined_assignments.json"
+    refined_path.write_text(json.dumps(refined))
+
+    result = expand_wps(str(refined_path), str(tmp_path))
+
+    manifest = json.loads(Path(result["manifest_path"]).read_text())
+    assert manifest["result_dir"].endswith("wp_sentinels")
+    assert (tmp_path / "work_packages" / "wp_sentinels").is_dir()

--- a/tests/planner/test_merge.py
+++ b/tests/planner/test_merge.py
@@ -534,7 +534,7 @@ def test_merge_tier_results_writes_refine_contexts_for_assignments(tmp_path):
     results_dir = tmp_path / "assignments"
     results_dir.mkdir()
     write_json(
-        results_dir / "P1_A1_result.json",
+        results_dir / "P1-A1_result.json",
         {
             "id": "P1-A1",
             "phase_id": "P1",
@@ -545,7 +545,7 @@ def test_merge_tier_results_writes_refine_contexts_for_assignments(tmp_path):
         },
     )
     write_json(
-        results_dir / "P2_A1_result.json",
+        results_dir / "P2-A1_result.json",
         {
             "id": "P2-A1",
             "phase_id": "P2",
@@ -572,7 +572,7 @@ def test_refine_context_own_assignments_in_full_detail(tmp_path):
     results_dir = tmp_path / "assignments"
     results_dir.mkdir()
     write_json(
-        results_dir / "P1_A1_result.json",
+        results_dir / "P1-A1_result.json",
         {
             "id": "P1-A1",
             "phase_id": "P1",
@@ -583,7 +583,7 @@ def test_refine_context_own_assignments_in_full_detail(tmp_path):
         },
     )
     write_json(
-        results_dir / "P2_A1_result.json",
+        results_dir / "P2-A1_result.json",
         {
             "id": "P2-A1",
             "phase_id": "P2",
@@ -608,7 +608,7 @@ def test_refine_context_peer_summaries_have_filtered_fields(tmp_path):
     results_dir = tmp_path / "assignments"
     results_dir.mkdir()
     write_json(
-        results_dir / "P1_A1_result.json",
+        results_dir / "P1-A1_result.json",
         {
             "id": "P1-A1",
             "phase_id": "P1",
@@ -619,7 +619,7 @@ def test_refine_context_peer_summaries_have_filtered_fields(tmp_path):
         },
     )
     write_json(
-        results_dir / "P2_A1_result.json",
+        results_dir / "P2-A1_result.json",
         {
             "id": "P2-A1",
             "phase_id": "P2",
@@ -644,7 +644,7 @@ def test_refine_context_has_task_file_path_not_inline_task(tmp_path):
     results_dir.mkdir()
     task_path = write_task_file(tmp_path, "Build a system")
     write_json(
-        results_dir / "P1_A1_result.json",
+        results_dir / "P1-A1_result.json",
         {
             "id": "P1-A1",
             "phase_id": "P1",
@@ -666,7 +666,7 @@ def test_refine_context_paths_returned_sorted(tmp_path):
     results_dir.mkdir()
     for pid in ("P3", "P1", "P2"):
         write_json(
-            results_dir / f"{pid}_A1_result.json",
+            results_dir / f"{pid}-A1_result.json",
             {
                 "id": f"{pid}-A1",
                 "phase_id": pid,
@@ -707,7 +707,7 @@ def test_merge_tier_results_no_refine_contexts_for_work_packages_key(tmp_path):
     results_dir = tmp_path / "work_packages"
     results_dir.mkdir()
     write_json(
-        results_dir / "WP1_result.json",
+        results_dir / "P1-A1-WP1_result.json",
         {
             "id": "P1-A1-WP1",
             "name": "WP One",
@@ -732,8 +732,8 @@ def test_write_refine_contexts_rejects_unsafe_phase_id(tmp_path):
     results_dir = tmp_path / "assignments"
     results_dir.mkdir()
     write_json(
-        results_dir / "evil_result.json",
-        {"id": "A1", "phase_id": "../../evil", "name": "x", "goal": "g"},
+        results_dir / "P1-A1_result.json",
+        {"id": "P1-A1", "phase_id": "../../evil", "name": "x", "goal": "g"},
     )
     out = tmp_path / "combined.json"
     with pytest.raises(ValueError, match="disallowed characters"):
@@ -888,3 +888,29 @@ def test_merge_refined_assignments_writes_to_planner_dir(tmp_path):
     expected = tmp_path / "refined_assignments.json"
     assert Path(result["refined_assignments_path"]) == expected
     assert expected.exists()
+
+
+def test_merge_tier_results_skips_non_assignment_files(tmp_path):
+    """Sentinel files in assignments/ must not be included in merge output."""
+    from tests.planner.conftest import make_assignment_result
+
+    assign_dir = tmp_path / "assignments"
+    assign_dir.mkdir()
+    out = tmp_path / "combined.json"
+
+    write_json(
+        assign_dir / "P1-A1_result.json",
+        make_assignment_result(1, 1),
+    )
+    write_json(
+        assign_dir / "P1_result.json",
+        {"id": "P1", "status": "complete", "assignment_count": 1, "failed_count": 0},
+    )
+
+    task_file = write_task_file(tmp_path)
+    merge_tier_results(str(assign_dir), str(out), "assignments", task_file_path=task_file)
+
+    merged = json.loads(out.read_text())
+    ids = [a["id"] for a in merged["assignments"]]
+    assert "P1-A1" in ids
+    assert "P1" not in ids

--- a/tests/planner/test_planner.py
+++ b/tests/planner/test_planner.py
@@ -19,6 +19,9 @@ def test_planner_all_exports() -> None:
     from autoskillit.planner import __all__
 
     assert set(__all__) == {
+        "ASSIGN_RESULT_FILE_RE",
+        "PHASE_RESULT_FILE_RE",
+        "WP_RESULT_FILE_RE",
         "build_phase_assignment_manifest",
         "build_phase_wp_manifest",
         "compile_plan",

--- a/tests/planner/test_schema_conformance.py
+++ b/tests/planner/test_schema_conformance.py
@@ -310,3 +310,34 @@ def test_skill_output_through_full_pipeline(tmp_path: Path) -> None:
     assert Path(compile_result["plan_path"]).exists()
     milestones = json.loads((tmp_path / "milestones.json").read_text())
     assert milestones["milestones"][0]["name_slug"] == "foundation"
+
+
+# ---------------------------------------------------------------------------
+# Tier filename regex contracts
+# ---------------------------------------------------------------------------
+
+
+def test_tier_filename_regexes_match_expected_patterns() -> None:
+    """Filename regexes accept tier-correct names and reject foreign ones."""
+    from autoskillit.planner.schema import (
+        ASSIGN_RESULT_FILE_RE,
+        PHASE_RESULT_FILE_RE,
+        WP_RESULT_FILE_RE,
+    )
+
+    assert PHASE_RESULT_FILE_RE.match("P1_result.json")
+    assert PHASE_RESULT_FILE_RE.match("P99_result.json")
+    assert not PHASE_RESULT_FILE_RE.match("P1-A1_result.json")
+
+    assert ASSIGN_RESULT_FILE_RE.match("P1-A1_result.json")
+    assert ASSIGN_RESULT_FILE_RE.match("P12-A3_result.json")
+    assert not ASSIGN_RESULT_FILE_RE.match("P1_result.json")
+
+    assert WP_RESULT_FILE_RE.match("P1-A1-WP1_result.json")
+    assert WP_RESULT_FILE_RE.match("P2-A3-WP14_result.json")
+    assert not WP_RESULT_FILE_RE.match("P1-A1_result.json")
+
+    for name in ("context_P1.json", "phase_assignment_manifest.json", "wp_manifest.json"):
+        assert not PHASE_RESULT_FILE_RE.match(name)
+        assert not ASSIGN_RESULT_FILE_RE.match(name)
+        assert not WP_RESULT_FILE_RE.match(name)

--- a/tests/planner/test_validation.py
+++ b/tests/planner/test_validation.py
@@ -502,3 +502,23 @@ def test_version_bump_step_via_summary(tmp_path: Path) -> None:
     assert result["verdict"] == "pass"
     validation = json.loads((tmp_path / "validation.json").read_text())
     assert any(w["check"] == "version_bump_step" for w in validation["warnings"])
+
+
+def test_validate_plan_ignores_phase_sentinel_in_assignments_dir(tmp_path: Path) -> None:
+    """Phase sentinel files in assignments/ must not crash validate_plan."""
+    _make_minimal_output_dir(tmp_path)
+    sentinel = {"id": "P1", "status": "complete", "assignment_count": 1, "failed_count": 0}
+    write_json(tmp_path / "assignments" / "P1_result.json", sentinel)
+
+    result = validate_plan(str(tmp_path))
+    assert result["verdict"] == "pass"
+
+
+def test_validate_plan_ignores_non_wp_file_in_work_packages_dir(tmp_path: Path) -> None:
+    """Non-WP files at top level of work_packages/ must not crash validate_plan."""
+    _make_minimal_output_dir(tmp_path)
+    sentinel = {"id": "P1", "status": "complete", "assignment_count": 1, "failed_count": 0}
+    write_json(tmp_path / "work_packages" / "P1_result.json", sentinel)
+
+    result = validate_plan(str(tmp_path))
+    assert result["verdict"] == "pass"


### PR DESCRIPTION
## Summary

The planner module's file-loading pipeline uses overly broad `*_result.json` globs across all three tiers (phases, assignments, work packages). No loader validates that a discovered file's name matches the expected tier's naming convention before attempting schema validation. When files of a different schema coexist in the same directory (phase sentinel files alongside assignment results), loaders crash with `RuntimeError`.

The architectural weakness is the absence of **tier-scoped filename contracts** — positive-match filters that accept only files whose names conform to the tier's ID convention. The ID conventions already exist as compiled regexes in `schema.py` (`_PHASE_ID_RE`, `_ASSIGN_ID_RE`, `_WP_ID_RE`) but are never applied during file discovery. The fix is to derive filename regexes from these existing conventions and apply them as a filtering gate at every glob site, making all loaders structurally immune to foreign files in any tier directory.

Closes #1692

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260503-115839-505743/.autoskillit/temp/rectify/rectify_planner_tier_scoped_filename_contracts_2026-05-03_115839.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| investigate | 41 | 4.3k | 651.4k | 48.6k | 1 | 2m 6s |
| rectify | 63 | 13.9k | 1.1M | 73.4k | 1 | 9m 3s |
| dry_walkthrough | 50 | 10.8k | 1.2M | 53.6k | 1 | 6m 17s |
| implement | 116 | 27.3k | 6.7M | 101.7k | 1 | 11m 43s |
| prepare_pr | 22 | 4.4k | 107.3k | 29.1k | 1 | 1m 24s |
| compose_pr | 23 | 1.5k | 160.7k | 18.5k | 1 | 40s |
| review_pr | 28 | 22.0k | 471.2k | 58.5k | 1 | 5m 34s |
| resolve_review | 45 | 9.6k | 1.0M | 63.6k | 1 | 7m 40s |
| **Total** | 388 | 93.8k | 11.4M | 447.2k | | 44m 29s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 240 | 27875.0 | 423.8 | 113.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **240** | 47533.8 | 1863.3 | 390.8 |