### PR TITLE
Rectify: Planner Deliverable Orphan Immunity via Schema-Level Invariant Enforcement

### DIFF
--- a/src/autoskillit/planner/__init__.py
+++ b/src/autoskillit/planner/__init__.py
@@ -26,6 +26,7 @@ from autoskillit.planner.merge import (
 from autoskillit.planner.schema import (
     ASSIGN_RESULT_FILE_RE,
     ASSIGNMENT_REQUIRED_KEYS,
+    DELIVERABLE_BOUNDS,
     PHASE_REQUIRED_KEYS,
     PHASE_RESULT_FILE_RE,
     WP_REQUIRED_KEYS,
@@ -48,6 +49,7 @@ from autoskillit.planner.validation import validate_plan
 
 __all__ = [
     "ASSIGN_RESULT_FILE_RE",
+    "DELIVERABLE_BOUNDS",
     "PHASE_RESULT_FILE_RE",
     "WP_RESULT_FILE_RE",
     "build_phase_assignment_manifest",

--- a/src/autoskillit/planner/consolidation.py
+++ b/src/autoskillit/planner/consolidation.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from autoskillit.core import atomic_write, write_versioned_json
+from autoskillit.planner.schema import validate_wp_result
 
 
 def _natural_sort_key(s: str) -> list[int | str]:
@@ -186,6 +187,7 @@ def consolidate_wps(
             if len(group.source_wp_ids) > 1:
                 groups_applied += 1
             merged_wp = _merge_group(group, wp_by_id)
+            validate_wp_result(merged_wp)
             output_wps.append(merged_wp)
         else:
             output_wps.append(dict(wp))

--- a/src/autoskillit/planner/manifests.py
+++ b/src/autoskillit/planner/manifests.py
@@ -226,7 +226,7 @@ def finalize_wp_manifest(work_packages_dir: str, output_dir: str) -> dict[str, s
                 f"Failed to parse {f}: {exc.msg}", exc.doc, exc.pos
             ) from exc
         try:
-            data = validate_wp_result(raw)
+            data = validate_wp_result(raw, allow_stub=bool(raw.get("elaboration_failed")))
         except (ValueError, KeyError) as exc:
             raise ValueError(f"Invalid WP result in {f}: {exc}") from exc
         items.append(

--- a/src/autoskillit/planner/merge.py
+++ b/src/autoskillit/planner/merge.py
@@ -315,6 +315,12 @@ def merge_refined_assignments(
             wp["files_touched"] = [
                 f for f in wp.get("files_touched", []) if file_owner.get(f) == aid
             ]
+            if not wp["files_touched"]:
+                logger.warning(
+                    "WP %s in assignment %s has empty files_touched after conflict resolution",
+                    wp.get("id", wp.get("name", "<unknown>")),
+                    aid,
+                )
 
     output_path = Path(planner_dir) / "refined_assignments.json"
     write_versioned_json(output_path, {"assignments": all_assignments}, schema_version=1)

--- a/src/autoskillit/planner/schema.py
+++ b/src/autoskillit/planner/schema.py
@@ -161,6 +161,8 @@ PHASE_REQUIRED_KEYS: frozenset[str] = frozenset({"id", "name", "ordering"})
 ASSIGNMENT_REQUIRED_KEYS: frozenset[str] = frozenset({"id", "name", "proposed_work_packages"})
 WP_REQUIRED_KEYS: frozenset[str] = frozenset({"id", "name", "deliverables"})
 
+DELIVERABLE_BOUNDS: tuple[int, int] = (1, 5)
+
 
 def _slugify(name: str) -> str:
     slug = name.lower()
@@ -229,7 +231,7 @@ def validate_assignment_result(data: dict[str, Any]) -> dict[str, Any]:
     return result
 
 
-def validate_wp_result(data: dict[str, Any]) -> dict[str, Any]:
+def validate_wp_result(data: dict[str, Any], *, allow_stub: bool = False) -> dict[str, Any]:
     missing = WP_REQUIRED_KEYS - data.keys()
     if missing:
         raise ValueError(f"WP result missing required keys: {sorted(missing)}")
@@ -244,6 +246,12 @@ def validate_wp_result(data: dict[str, Any]) -> dict[str, Any]:
             f"WP id {wp_id!r} does not match expected PX-AY-WPZ format",
             stacklevel=2,
         )
+
+    if not allow_stub:
+        count = len(result.get("deliverables", []))
+        lo, hi = DELIVERABLE_BOUNDS
+        if not (lo <= count <= hi):
+            raise ValueError(f"WP {wp_id} has {count} deliverables (must be {lo}–{hi})")
 
     result.setdefault("summary", "")
     result.setdefault("goal", "")

--- a/src/autoskillit/planner/validation.py
+++ b/src/autoskillit/planner/validation.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from autoskillit.core import get_logger, write_versioned_json
 from autoskillit.planner.schema import (
     ASSIGN_RESULT_FILE_RE,
+    DELIVERABLE_BOUNDS,
     PHASE_RESULT_FILE_RE,
     WP_RESULT_FILE_RE,
     ValidationFinding,
@@ -89,7 +90,7 @@ def _load_wp_results(root: Path) -> dict[str, dict]:
     for f in _iter_tier_files(wp_dir, WP_RESULT_FILE_RE):
         try:
             raw = json.loads(f.read_text())
-            data = validate_wp_result(raw)
+            data = validate_wp_result(raw, allow_stub=True)
             results[data["id"]] = data
         except (json.JSONDecodeError, KeyError, ValueError) as exc:
             raise RuntimeError(f"Malformed WP result file {f}: {exc}") from exc
@@ -214,13 +215,14 @@ def _check_dag_acyclic(wp_results: dict[str, dict]) -> list[ValidationFinding]:
 
 
 def _check_sizing_bounds(wp_results: dict[str, dict]) -> list[ValidationFinding]:
+    lo, hi = DELIVERABLE_BOUNDS
     findings: list[ValidationFinding] = []
     for wp_id, wp in wp_results.items():
         count = len(wp.get("deliverables", []))
-        if not (1 <= count <= 5):
+        if not (lo <= count <= hi):
             findings.append(
                 {
-                    "message": f"WP {wp_id} has {count} deliverables (must be 1–5)",
+                    "message": f"WP {wp_id} has {count} deliverables (must be {lo}–{hi})",
                     "severity": "error",
                     "check": "sizing_bounds",
                 }

--- a/src/autoskillit/skills_extended/planner-refine-wps/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine-wps/SKILL.md
@@ -174,6 +174,15 @@ WP with the numerically earlier ID (natural sort: `P1-A1-WP1` < `P1-A2-WP1` <
 WP CONFLICT: {wp_id_a} vs {wp_id_b} — deliverable {file} assigned to {winner}
 ```
 
+**Post-deduplication orphan check:** After resolving all deliverable conflicts,
+scan every losing WP. If any WP now has `deliverables: []`, merge it into the
+winning WP (the one that received its deliverables):
+1. Move the orphan's `files_touched` entries as deliverables to the winner WP
+2. Append the orphan's `technical_steps` and `acceptance_criteria` to the winner
+3. Remove the orphan WP from the output and update all `depends_on` references
+4. Log: `WP ORPHAN MERGED: {orphan_id} → {winner_id}`
+Deliverable count bounds are defined in `schema.py::DELIVERABLE_BOUNDS`.
+
 Process `api_mismatches`: for each mismatch, add the producer WP's `apis_defined`
 signature to the `wp_changes` for the consumer WP to update `apis_consumed` to match.
 

--- a/src/autoskillit/skills_extended/planner-refine-wps/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine-wps/SKILL.md
@@ -177,7 +177,10 @@ WP CONFLICT: {wp_id_a} vs {wp_id_b} — deliverable {file} assigned to {winner}
 **Post-deduplication orphan check:** After resolving all deliverable conflicts,
 scan every losing WP. If any WP now has `deliverables: []`, merge it into the
 winning WP (the one that received its deliverables):
-1. Move the orphan's `files_touched` entries as deliverables to the winner WP
+1. Promote the orphan's `files_touched` entries as deliverables to the winner WP,
+   selecting at most `DELIVERABLE_BOUNDS[1] - len(winner.deliverables)` entries
+   (prefer entries that overlap with the winner's existing scope). Any remaining
+   entries stay in `files_touched` only.
 2. Append the orphan's `technical_steps` and `acceptance_criteria` to the winner
 3. Remove the orphan WP from the output and update all `depends_on` references
 4. Log: `WP ORPHAN MERGED: {orphan_id} → {winner_id}`

--- a/src/autoskillit/skills_extended/planner-refine/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine/SKILL.md
@@ -95,8 +95,10 @@ Write this to stdout. Do NOT attempt WP splitting or merging.
 - **Post-deduplication orphan check:** After resolving all duplicate deliverables, scan every
   modified WP. If any WP now has `deliverables: []`, that WP is an orphan. For each orphan:
   1. Identify the WP(s) that received this orphan's former deliverables (the "owner WPs")
-  2. Reassign the orphan's `files_touched` entries as deliverables to the most relevant owner
-     WP (the one with the most scope overlap)
+  2. Promote the orphan's `files_touched` entries as deliverables to the most relevant owner
+     WP (the one with the most scope overlap), selecting at most
+     `DELIVERABLE_BOUNDS[1] - len(owner.deliverables)` entries. Any remaining entries stay
+     in `files_touched` only.
   3. Merge the orphan's `technical_steps` and `acceptance_criteria` into the owner WP
   4. Remove the orphan WP from the plan and update all `depends_on` references
   5. Update `wp_manifest.json` and `wp_index.json` accordingly

--- a/src/autoskillit/skills_extended/planner-refine/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine/SKILL.md
@@ -92,6 +92,16 @@ Write this to stdout. Do NOT attempt WP splitting or merging.
 - For each duplicated file path, assign ownership to the WP whose scope most directly
   implements that file (strongest semantic claim)
 - Remove the duplicate from the lower-priority WP's `deliverables` (keep in `files_touched`)
+- **Post-deduplication orphan check:** After resolving all duplicate deliverables, scan every
+  modified WP. If any WP now has `deliverables: []`, that WP is an orphan. For each orphan:
+  1. Identify the WP(s) that received this orphan's former deliverables (the "owner WPs")
+  2. Reassign the orphan's `files_touched` entries as deliverables to the most relevant owner
+     WP (the one with the most scope overlap)
+  3. Merge the orphan's `technical_steps` and `acceptance_criteria` into the owner WP
+  4. Remove the orphan WP from the plan and update all `depends_on` references
+  5. Update `wp_manifest.json` and `wp_index.json` accordingly
+  This is a deduplication side-effect resolved in the same step, not a sizing violation.
+  Deliverable count bounds are defined in `schema.py::DELIVERABLE_BOUNDS`.
 - Write updated `_result.json` for the affected WPs
 
 **Dependency reference errors** — fix broken dep IDs:

--- a/tests/planner/conftest.py
+++ b/tests/planner/conftest.py
@@ -42,7 +42,7 @@ def make_assignment_result(
     return validate_assignment_result(data)
 
 
-def make_wp_result(wp_id: str, **overrides: Any) -> dict[str, Any]:
+def make_wp_result(wp_id: str, *, allow_stub: bool = False, **overrides: Any) -> dict[str, Any]:
     data: dict[str, Any] = {
         "id": wp_id,
         "name": f"WP {wp_id}",
@@ -54,7 +54,7 @@ def make_wp_result(wp_id: str, **overrides: Any) -> dict[str, Any]:
         "depends_on": [],
         **overrides,
     }
-    return validate_wp_result(data)
+    return validate_wp_result(data, allow_stub=allow_stub)
 
 
 def write_json(path: Path, data: object) -> None:

--- a/tests/planner/test_consolidation.py
+++ b/tests/planner/test_consolidation.py
@@ -364,3 +364,29 @@ def test_missing_source_wp_in_manifest_raises(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="unknown WP"):
         consolidate_wps(refined_wps_path=str(refined_path), planner_dir=str(tmp_path))
+
+
+def test_consolidate_wps_rejects_merge_with_empty_deliverables(tmp_path: Path) -> None:
+    """Merging WPs where all sources have empty deliverables must raise ValueError."""
+    wps = [
+        make_wp_result("P1-A1-WP1", allow_stub=True, deliverables=[]),
+        make_wp_result("P1-A1-WP2", allow_stub=True, deliverables=[]),
+    ]
+    refined_path = _make_refined_wps(tmp_path, wps)
+    consolidation_dir = tmp_path / "work_packages" / "consolidation"
+    _make_manifest(
+        consolidation_dir,
+        "P1",
+        [
+            {
+                "merged_id": "P1-A1-WP1",
+                "source_wp_ids": ["P1-A1-WP1", "P1-A1-WP2"],
+                "merge_order": ["P1-A1-WP1", "P1-A1-WP2"],
+                "name": None,
+                "goal": None,
+            }
+        ],
+    )
+
+    with pytest.raises(ValueError, match="has 0 deliverables"):
+        consolidate_wps(refined_wps_path=str(refined_path), planner_dir=str(tmp_path))

--- a/tests/planner/test_planner.py
+++ b/tests/planner/test_planner.py
@@ -20,6 +20,7 @@ def test_planner_all_exports() -> None:
 
     assert set(__all__) == {
         "ASSIGN_RESULT_FILE_RE",
+        "DELIVERABLE_BOUNDS",
         "PHASE_RESULT_FILE_RE",
         "WP_RESULT_FILE_RE",
         "build_phase_assignment_manifest",

--- a/tests/planner/test_typed_dict_conformance.py
+++ b/tests/planner/test_typed_dict_conformance.py
@@ -6,6 +6,7 @@ import pytest
 
 from autoskillit.planner.schema import (
     ASSIGNMENT_REQUIRED_KEYS,
+    DELIVERABLE_BOUNDS,
     PHASE_REQUIRED_KEYS,
     WP_REQUIRED_KEYS,
     AssignmentResult,
@@ -144,3 +145,27 @@ def test_phase_short_includes_ordering() -> None:
     hints = typing.get_type_hints(PhaseShort)
     assert "ordering" in hints, "PhaseShort must include ordering per Issue 02 spec"
     assert hints["ordering"] is int
+
+
+def test_validate_wp_result_rejects_empty_deliverables() -> None:
+    with pytest.raises(ValueError, match="has 0 deliverables"):
+        validate_wp_result({"id": "P1-A1-WP1", "name": "WP", "deliverables": []})
+
+
+def test_validate_wp_result_accepts_empty_deliverables_with_allow_stub() -> None:
+    result = validate_wp_result(
+        {"id": "P1-A1-WP1", "name": "WP", "deliverables": []}, allow_stub=True
+    )
+    assert result["deliverables"] == []
+
+
+def test_validate_wp_result_rejects_too_many_deliverables() -> None:
+    _, hi = DELIVERABLE_BOUNDS
+    with pytest.raises(ValueError, match=f"has {hi + 1} deliverables"):
+        validate_wp_result(
+            {
+                "id": "P1-A1-WP1",
+                "name": "WP",
+                "deliverables": [f"f{i}.py" for i in range(hi + 1)],
+            }
+        )

--- a/tests/planner/test_validation.py
+++ b/tests/planner/test_validation.py
@@ -7,7 +7,12 @@ from pathlib import Path
 
 import pytest
 
-from autoskillit.planner.validation import validate_plan
+from autoskillit.planner.schema import DELIVERABLE_BOUNDS
+from autoskillit.planner.validation import (
+    _check_duplicate_deliverables,
+    _check_sizing_bounds,
+    validate_plan,
+)
 from tests.planner.conftest import (
     make_assignment_result,
     make_phase_result,
@@ -149,13 +154,21 @@ def test_validate_plan_assignment_no_wps_fails(tmp_path: Path) -> None:
 
 
 def test_validate_plan_wp_zero_deliverables_fails(tmp_path: Path) -> None:
-    _make_minimal_output_dir(tmp_path, deliverables_override=[])
+    _make_minimal_output_dir(tmp_path)
+    wp_path = tmp_path / "work_packages" / "P1-A1-WP1_result.json"
+    raw = json.loads(wp_path.read_text())
+    raw["deliverables"] = []
+    wp_path.write_text(json.dumps(raw))
     result = validate_plan(str(tmp_path))
     assert result["verdict"] == "fail"
 
 
 def test_validate_plan_wp_too_many_deliverables_fails(tmp_path: Path) -> None:
-    _make_minimal_output_dir(tmp_path, deliverables_override=["a", "b", "c", "d", "e", "f"])
+    _make_minimal_output_dir(tmp_path)
+    wp_path = tmp_path / "work_packages" / "P1-A1-WP1_result.json"
+    raw = json.loads(wp_path.read_text())
+    raw["deliverables"] = ["a", "b", "c", "d", "e", "f"]
+    wp_path.write_text(json.dumps(raw))
     result = validate_plan(str(tmp_path))
     assert result["verdict"] == "fail"
 
@@ -317,11 +330,12 @@ def test_error_findings_have_structured_fields(tmp_path: Path) -> None:
 
 def test_mixed_errors_and_warnings(tmp_path: Path) -> None:
     """T17: Sizing violation (error) + files_touched overlap (warning) coexist."""
-    _make_minimal_output_dir(tmp_path, wps_per_assignment=2, deliverables_override=[])
+    _make_minimal_output_dir(tmp_path, wps_per_assignment=2)
     wp_dir = tmp_path / "work_packages"
     for wp_id in ("P1-A1-WP1", "P1-A1-WP2"):
         result_path = wp_dir / f"{wp_id}_result.json"
         data = json.loads(result_path.read_text())
+        data["deliverables"] = []
         data["files_touched"] = ["src/shared.py"]
         result_path.write_text(json.dumps(data))
 
@@ -522,3 +536,95 @@ def test_validate_plan_ignores_non_wp_file_in_work_packages_dir(tmp_path: Path) 
 
     result = validate_plan(str(tmp_path))
     assert result["verdict"] == "pass"
+
+
+# ---------------------------------------------------------------------------
+# Direct unit tests for _check_sizing_bounds
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("count", "expected_findings"),
+    [
+        (0, 1),
+        (1, 0),
+        (5, 0),
+        (6, 1),
+    ],
+)
+def test_check_sizing_bounds_boundary_values(count: int, expected_findings: int) -> None:
+    wp_results = {
+        "P1-A1-WP1": {"deliverables": [f"f{i}.py" for i in range(count)]},
+    }
+    findings = _check_sizing_bounds(wp_results)
+    assert len(findings) == expected_findings
+    if expected_findings:
+        assert findings[0]["check"] == "sizing_bounds"
+        assert findings[0]["severity"] == "error"
+
+
+def test_check_sizing_bounds_uses_deliverable_bounds_constant() -> None:
+    lo, hi = DELIVERABLE_BOUNDS
+    wp_at_lo = {"P1-A1-WP1": {"deliverables": [f"f{i}.py" for i in range(lo)]}}
+    wp_at_hi = {"P1-A1-WP2": {"deliverables": [f"f{i}.py" for i in range(hi)]}}
+    assert _check_sizing_bounds(wp_at_lo) == []
+    assert _check_sizing_bounds(wp_at_hi) == []
+
+
+# ---------------------------------------------------------------------------
+# Direct unit tests for _check_duplicate_deliverables
+# ---------------------------------------------------------------------------
+
+
+def test_check_duplicate_deliverables_detects_shared() -> None:
+    wp_results = {
+        "P1-A1-WP1": {"deliverables": ["src/shared.py", "src/a.py"]},
+        "P1-A1-WP2": {"deliverables": ["src/shared.py", "src/b.py"]},
+    }
+    findings = _check_duplicate_deliverables(wp_results)
+    assert len(findings) == 1
+    assert findings[0]["check"] == "duplicate_deliverables"
+    assert "src/shared.py" in findings[0]["message"]
+
+
+def test_check_duplicate_deliverables_no_false_positives() -> None:
+    wp_results = {
+        "P1-A1-WP1": {"deliverables": ["src/a.py"]},
+        "P1-A1-WP2": {"deliverables": ["src/b.py"]},
+    }
+    findings = _check_duplicate_deliverables(wp_results)
+    assert findings == []
+
+
+def test_check_duplicate_deliverables_returns_structured_findings() -> None:
+    wp_results = {
+        "P1-A1-WP1": {"deliverables": ["src/shared.py"]},
+        "P1-A1-WP2": {"deliverables": ["src/shared.py"]},
+    }
+    findings = _check_duplicate_deliverables(wp_results)
+    assert len(findings) == 1
+    f = findings[0]
+    assert "message" in f
+    assert f["severity"] == "error"
+    assert f["check"] == "duplicate_deliverables"
+
+
+# ---------------------------------------------------------------------------
+# Deduplication-to-orphan cascade
+# ---------------------------------------------------------------------------
+
+
+def test_deduplication_orphan_cascade(tmp_path: Path) -> None:
+    """Simulates dedup removing WP-B's only deliverable → sizing_bounds error."""
+    _make_minimal_output_dir(tmp_path, wps_per_assignment=2)
+    wp_dir = tmp_path / "work_packages"
+    wp_b = json.loads((wp_dir / "P1-A1-WP2_result.json").read_text())
+    wp_b["deliverables"] = []
+    (wp_dir / "P1-A1-WP2_result.json").write_text(json.dumps(wp_b))
+
+    result = validate_plan(str(tmp_path))
+    assert result["verdict"] == "fail"
+    validation = json.loads((tmp_path / "validation.json").read_text())
+    sizing_findings = [f for f in validation["findings"] if f["check"] == "sizing_bounds"]
+    assert len(sizing_findings) == 1
+    assert "P1-A1-WP2" in sizing_findings[0]["message"]


### PR DESCRIPTION
## Summary

The planner system splits validation into two disconnected tiers: `validate_wp_result` (schema.py) enforces key presence, while `_check_sizing_bounds` (validation.py) enforces value constraints. This split means WP result data can pass through every validated read boundary with `deliverables: []` — the invariant violation is only detected at `validate_plan` time, far downstream from the mutation that caused it. The `planner-refine` skill's deduplication step exploits this gap: it removes deliverables from WPs, writes results that pass `validate_wp_result`, then the next `validate_plan` detects the violation but `planner-refine` cannot repair it, creating an infinite retry loop.

The architectural fix unifies structural and semantic validation into `validate_wp_result` itself, making it impossible for any validated write or read path to produce or accept a WP with empty deliverables without an explicit opt-in. This eliminates the entire class of "silently invalid WP data" bugs and makes the failure surface at the point of mutation rather than in a downstream gate.

Closes #1693

## Implementation Plan

Plan file: `.autoskillit/temp/rectify/rectify_planner-deliverable-orphans_2026-05-03_133000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| investigate | 11.3k | 8.8k | 655.8k | 56.8k | 1 | 9m 50s |
| rectify | 51 | 12.9k | 921.5k | 90.3k | 1 | 8m 32s |
| dry_walkthrough | 1.0k | 13.2k | 1.9M | 67.0k | 1 | 5m 59s |
| implement | 90 | 21.4k | 4.4M | 83.7k | 1 | 9m 17s |
| prepare_pr | 23 | 4.3k | 150.9k | 31.6k | 1 | 1m 20s |
| compose_pr | 24 | 1.8k | 200.4k | 22.0k | 1 | 59s |
| review_pr | 29 | 22.5k | 504.4k | 57.2k | 1 | 5m 24s |
| resolve_review | 47 | 9.5k | 1.3M | 47.6k | 1 | 7m 34s |
| **Total** | 12.6k | 94.4k | 10.1M | 456.2k | | 48m 58s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 219 | 20138.7 | 382.0 | 97.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 11 | 121675.1 | 4328.5 | 867.7 |
| **Total** | **230** | 44004.0 | 1983.3 | 410.3 |