### PR TITLE
Implementation Plan: Fix Overly Strict WP Merge Criteria in planner-consolidate-wps

### DIFF
--- a/src/autoskillit/planner/consolidation.py
+++ b/src/autoskillit/planner/consolidation.py
@@ -1,4 +1,4 @@
-"""WP consolidation pass: merges trivial work packages based on consolidation manifests."""
+"""WP consolidation pass: merges work packages per manifests with file-sharing fallback."""
 
 from __future__ import annotations
 
@@ -10,6 +10,10 @@ from typing import Any
 
 from autoskillit.core import atomic_write, write_versioned_json
 from autoskillit.planner.schema import validate_wp_result
+
+_ASSIGNMENT_RE = re.compile(r"^(P\d+-A\d+)-")
+_FALLBACK_MIN_WPS = 5
+_FALLBACK_MAX_GROUP_SIZE = 5
 
 
 def _natural_sort_key(s: str) -> list[int | str]:
@@ -128,6 +132,81 @@ def _rewrite_deps(
     return result
 
 
+def _cluster_by_shared_files(wps: list[dict[str, Any]]) -> list[list[dict[str, Any]]]:
+    """Cluster WPs that share at least one files_touched entry."""
+    parent: dict[str, str] = {wp["id"]: wp["id"] for wp in wps}
+
+    def find(x: str) -> str:
+        while parent[x] != x:
+            x = parent[x]
+        return x
+
+    def union(a: str, b: str) -> None:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[ra] = rb
+
+    file_to_wps: dict[str, list[str]] = {}
+    for wp in wps:
+        for f in wp.get("files_touched", []):
+            file_to_wps.setdefault(f, []).append(wp["id"])
+
+    for wp_ids in file_to_wps.values():
+        for i in range(1, len(wp_ids)):
+            union(wp_ids[0], wp_ids[i])
+
+    clusters: dict[str, list[dict[str, Any]]] = {}
+    for wp in wps:
+        root = find(wp["id"])
+        clusters.setdefault(root, []).append(wp)
+
+    return list(clusters.values())
+
+
+def _chunk_list(items: list[dict[str, Any]], size: int) -> list[list[dict[str, Any]]]:
+    return [items[i : i + size] for i in range(0, len(items), size)]
+
+
+def _build_fallback_groups(
+    work_packages: list[dict[str, Any]],
+    existing_merged_groups: dict[str, _ConsolidationGroup],
+) -> list[_ConsolidationGroup]:
+    """Heuristic fallback: merge same-assignment WPs sharing files."""
+    if any(len(g.source_wp_ids) > 1 for g in existing_merged_groups.values()):
+        return []
+    if len(work_packages) < _FALLBACK_MIN_WPS:
+        return []
+
+    by_assignment: dict[str, list[dict[str, Any]]] = {}
+    for wp in work_packages:
+        m = _ASSIGNMENT_RE.match(wp["id"])
+        if m:
+            by_assignment.setdefault(m.group(1), []).append(wp)
+
+    groups: list[_ConsolidationGroup] = []
+    for wps in by_assignment.values():
+        if len(wps) < 2:
+            continue
+        clusters = _cluster_by_shared_files(wps)
+        for cluster in clusters:
+            if len(cluster) < 2:
+                continue
+            for chunk in _chunk_list(cluster, _FALLBACK_MAX_GROUP_SIZE):
+                if len(chunk) < 2:
+                    continue
+                sorted_ids = sorted([wp["id"] for wp in chunk], key=_natural_sort_key)
+                groups.append(
+                    _ConsolidationGroup(
+                        merged_id=sorted_ids[0],
+                        source_wp_ids=sorted_ids,
+                        merge_order=sorted_ids,
+                        name=None,
+                        goal=None,
+                    )
+                )
+    return groups
+
+
 def consolidate_wps(
     refined_wps_path: str,
     planner_dir: str,
@@ -167,6 +246,15 @@ def consolidate_wps(
         for ord_id in group.merge_order:
             if ord_id not in wp_by_id:
                 raise ValueError(f"unknown merge_order element: {ord_id}")
+
+    # Fallback: if manifests produced only singletons, apply heuristic
+    has_real_merges = any(len(g.source_wp_ids) > 1 for g in merged_groups.values())
+    if not has_real_merges:
+        fallback_groups = _build_fallback_groups(work_packages, merged_groups)
+        for fg in fallback_groups:
+            merged_groups[fg.merged_id] = fg
+            for src_id in fg.source_wp_ids:
+                source_to_merged[src_id] = fg.merged_id
 
     # Build the output WP list
     output_wps: list[dict[str, Any]] = []

--- a/src/autoskillit/planner/consolidation.py
+++ b/src/autoskillit/planner/consolidation.py
@@ -169,7 +169,6 @@ def _chunk_list(items: list[dict[str, Any]], size: int) -> list[list[dict[str, A
 
 def _build_fallback_groups(
     work_packages: list[dict[str, Any]],
-    existing_merged_groups: dict[str, _ConsolidationGroup],
 ) -> list[_ConsolidationGroup]:
     """Heuristic fallback: merge same-assignment WPs sharing files."""
     if len(work_packages) < _FALLBACK_MIN_WPS:
@@ -245,10 +244,9 @@ def consolidate_wps(
             if ord_id not in wp_by_id:
                 raise ValueError(f"unknown merge_order element: {ord_id}")
 
-    # Fallback: if manifests produced only singletons, apply heuristic
     has_real_merges = any(len(g.source_wp_ids) > 1 for g in merged_groups.values())
     if not has_real_merges:
-        fallback_groups = _build_fallback_groups(work_packages, merged_groups)
+        fallback_groups = _build_fallback_groups(work_packages)
         for fg in fallback_groups:
             merged_groups[fg.merged_id] = fg
             for src_id in fg.source_wp_ids:

--- a/src/autoskillit/planner/consolidation.py
+++ b/src/autoskillit/planner/consolidation.py
@@ -172,8 +172,6 @@ def _build_fallback_groups(
     existing_merged_groups: dict[str, _ConsolidationGroup],
 ) -> list[_ConsolidationGroup]:
     """Heuristic fallback: merge same-assignment WPs sharing files."""
-    if any(len(g.source_wp_ids) > 1 for g in existing_merged_groups.values()):
-        return []
     if len(work_packages) < _FALLBACK_MIN_WPS:
         return []
 

--- a/src/autoskillit/skills_extended/planner-consolidate-wps/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-consolidate-wps/SKILL.md
@@ -39,7 +39,7 @@ merging).
 
 **NEVER:**
 - Merge WPs from different assignments unless they have a direct dependency linking them
-- Create a merged group whose combined complexity would be high (≥ 10 steps OR ≥ 6 files)
+- Create a merged group that would clearly exceed a medium-complexity PR (use judgment — no hard threshold)
 - Skip a WP from a manifest — every WP must appear in exactly one group (singleton = no-op)
 - Use a `merged_id` that is not one of the `source_wp_ids`
 - Allow an L0 to write files outside `$2/work_packages/consolidation/`
@@ -78,10 +78,17 @@ For each phase, assemble a context packet containing:
 - `wps` — the full list of WP objects in this phase (id, name, goal, technical_steps,
   files_touched, deliverables, acceptance_criteria, depends_on, estimated_files, scope)
 - `all_wp_ids` — WP IDs from every phase (for cross-phase dep awareness)
-- Complexity thresholds:
-  - trivial: ≤ 3 technical_steps AND ≤ 2 files_touched entries
-  - high: ≥ 10 technical_steps OR ≥ 6 files_touched entries
-  - medium: everything else
+- Merge guidance:
+  - **Default: merge.** WPs within the same assignment should be merged unless there is
+    a clear reason to keep them separate.
+  - **Merge when:** WPs share files, do closely related work, form a natural unit of
+    implementation, or would be awkward as separate PRs.
+  - **Keep separate when:** WPs represent genuinely independent concerns that a developer
+    would naturally implement and review as separate PRs.
+  - **Soft upper bound:** Avoid merging into a group that would clearly exceed a
+    medium-complexity PR (rough guide: >15 substantive technical steps or >10 distinct
+    files). This is guidance, not a hard gate — use judgment about whether the combined
+    work forms a coherent unit.
 
 ### Step 4: Dispatch parallel L0 subagents
 
@@ -111,10 +118,14 @@ groups = [
 
 L0 grouping rules:
 - Assign each WP to exactly one group (solo or merged).
-- Only merge WPs within the same assignment (`P{N}-A{M}` prefix) unless they share a
-  direct dependency AND both are trivial.
-- Never merge if the combined group would have ≥ 10 total technical_steps or ≥ 6 total
-  files_touched — split into smaller groups instead.
+- **Default to merging** WPs within the same assignment. Only keep WPs as singletons when
+  they represent genuinely distinct concerns.
+- Cross-assignment merges are allowed when WPs share a direct dependency AND touch the
+  same files.
+- Use judgment about combined complexity. Avoid creating groups that would clearly be
+  too large for a single PR, but do not apply hard thresholds on step/file counts.
+  Read the actual work described and decide: "would a developer naturally do these
+  together?"
 - `merged_id` MUST be the lowest-numbered WP ID in the group (primary WP).
 - `merge_order` defines the technical_steps concatenation order; typically
   `[primary, ...others_by_id_order]`.

--- a/tests/planner/test_consolidation.py
+++ b/tests/planner/test_consolidation.py
@@ -390,3 +390,139 @@ def test_consolidate_wps_rejects_merge_with_empty_deliverables(tmp_path: Path) -
 
     with pytest.raises(ValueError, match="has 0 deliverables"):
         consolidate_wps(refined_wps_path=str(refined_path), planner_dir=str(tmp_path))
+
+
+def test_fallback_merges_same_assignment_shared_files(tmp_path: Path) -> None:
+    wps = [
+        make_wp_result("P1-A1-WP1", files_touched=["src/config.yaml"]),
+        make_wp_result("P1-A1-WP2", files_touched=["src/config.yaml"]),
+        make_wp_result("P1-A1-WP3", files_touched=["src/config.yaml"]),
+        make_wp_result("P1-A1-WP4", files_touched=["src/other.py"]),
+        make_wp_result("P1-A1-WP5", files_touched=["src/other.py"]),
+    ]
+    refined_path = _make_refined_wps(tmp_path, wps)
+
+    result = consolidate_wps(refined_wps_path=str(refined_path), planner_dir=str(tmp_path))
+
+    consolidated = json.loads((tmp_path / "consolidated_wps.json").read_text())
+    output_ids = {wp["id"] for wp in consolidated["work_packages"]}
+    assert output_ids == {"P1-A1-WP1", "P1-A1-WP4"}
+    assert len(consolidated["work_packages"]) == 2
+    assert result["merged_count"] == "2"
+
+
+def test_fallback_skipped_when_manifest_has_merges(tmp_path: Path) -> None:
+    wps = [
+        make_wp_result("P1-A1-WP1", files_touched=["src/config.yaml"]),
+        make_wp_result("P1-A1-WP2", files_touched=["src/config.yaml"]),
+        make_wp_result("P1-A1-WP3", files_touched=["src/config.yaml"]),
+        make_wp_result("P1-A1-WP4", files_touched=["src/other.py"]),
+        make_wp_result("P1-A1-WP5", files_touched=["src/other.py"]),
+    ]
+    refined_path = _make_refined_wps(tmp_path, wps)
+    consolidation_dir = tmp_path / "work_packages" / "consolidation"
+    _make_manifest(
+        consolidation_dir,
+        "P1",
+        [
+            {
+                "merged_id": "P1-A1-WP1",
+                "source_wp_ids": ["P1-A1-WP1", "P1-A1-WP2"],
+                "merge_order": ["P1-A1-WP1", "P1-A1-WP2"],
+                "name": None,
+                "goal": None,
+            },
+            {
+                "merged_id": "P1-A1-WP3",
+                "source_wp_ids": ["P1-A1-WP3"],
+                "merge_order": ["P1-A1-WP3"],
+                "name": None,
+                "goal": None,
+            },
+            {
+                "merged_id": "P1-A1-WP4",
+                "source_wp_ids": ["P1-A1-WP4"],
+                "merge_order": ["P1-A1-WP4"],
+                "name": None,
+                "goal": None,
+            },
+            {
+                "merged_id": "P1-A1-WP5",
+                "source_wp_ids": ["P1-A1-WP5"],
+                "merge_order": ["P1-A1-WP5"],
+                "name": None,
+                "goal": None,
+            },
+        ],
+    )
+
+    result = consolidate_wps(refined_wps_path=str(refined_path), planner_dir=str(tmp_path))
+
+    consolidated = json.loads((tmp_path / "consolidated_wps.json").read_text())
+    assert len(consolidated["work_packages"]) == 4
+    assert result["merged_count"] == "1"
+
+
+def test_fallback_skipped_when_wp_count_below_threshold(tmp_path: Path) -> None:
+    wps = [
+        make_wp_result("P1-A1-WP1", files_touched=["src/config.yaml"]),
+        make_wp_result("P1-A1-WP2", files_touched=["src/config.yaml"]),
+        make_wp_result("P1-A1-WP3", files_touched=["src/config.yaml"]),
+    ]
+    refined_path = _make_refined_wps(tmp_path, wps)
+
+    result = consolidate_wps(refined_wps_path=str(refined_path), planner_dir=str(tmp_path))
+
+    consolidated = json.loads((tmp_path / "consolidated_wps.json").read_text())
+    assert len(consolidated["work_packages"]) == 3
+    assert result["merged_count"] == "0"
+
+
+def test_fallback_respects_dependency_ordering(tmp_path: Path) -> None:
+    wps = [
+        make_wp_result("P1-A1-WP1", files_touched=["src/x.py"], depends_on=[]),
+        make_wp_result("P1-A1-WP2", files_touched=["src/x.py"], depends_on=["P1-A1-WP1"]),
+        make_wp_result("P1-A1-WP3", files_touched=["src/x.py"], depends_on=["P1-A1-WP2"]),
+        make_wp_result("P1-A1-WP4", files_touched=["src/y.py"], depends_on=[]),
+        make_wp_result("P1-A1-WP5", files_touched=["src/y.py"], depends_on=[]),
+    ]
+    refined_path = _make_refined_wps(tmp_path, wps)
+
+    consolidate_wps(refined_wps_path=str(refined_path), planner_dir=str(tmp_path))
+
+    consolidated = json.loads((tmp_path / "consolidated_wps.json").read_text())
+    merged_a = next(wp for wp in consolidated["work_packages"] if wp["id"] == "P1-A1-WP1")
+    assert merged_a["id"] == "P1-A1-WP1"
+    assert "P1-A1-WP2" not in merged_a["depends_on"]
+    assert "P1-A1-WP3" not in merged_a["depends_on"]
+
+
+def test_fallback_does_not_cross_assignment_boundary(tmp_path: Path) -> None:
+    wps = [
+        make_wp_result("P1-A1-WP1", files_touched=["src/shared.py"]),
+        make_wp_result("P1-A1-WP2", files_touched=["src/shared.py"]),
+        make_wp_result("P1-A1-WP3", files_touched=["src/shared.py"]),
+        make_wp_result("P1-A2-WP1", files_touched=["src/shared.py"]),
+        make_wp_result("P1-A2-WP2", files_touched=["src/shared.py"]),
+        make_wp_result("P1-A2-WP3", files_touched=["src/shared.py"]),
+    ]
+    refined_path = _make_refined_wps(tmp_path, wps)
+
+    consolidate_wps(refined_wps_path=str(refined_path), planner_dir=str(tmp_path))
+
+    consolidated = json.loads((tmp_path / "consolidated_wps.json").read_text())
+    output_ids = {wp["id"] for wp in consolidated["work_packages"]}
+    assert "P1-A1-WP1" in output_ids
+    assert "P1-A2-WP1" in output_ids
+    assert len(consolidated["work_packages"]) == 2
+
+
+def test_fallback_caps_group_size(tmp_path: Path) -> None:
+    wps = [make_wp_result(f"P1-A1-WP{i}", files_touched=["src/big.py"]) for i in range(1, 9)]
+    refined_path = _make_refined_wps(tmp_path, wps)
+
+    result = consolidate_wps(refined_wps_path=str(refined_path), planner_dir=str(tmp_path))
+
+    consolidated = json.loads((tmp_path / "consolidated_wps.json").read_text())
+    assert len(consolidated["work_packages"]) == 2
+    assert result["merged_count"] == "2"

--- a/tests/planner/test_consolidation.py
+++ b/tests/planner/test_consolidation.py
@@ -491,6 +491,9 @@ def test_fallback_respects_dependency_ordering(tmp_path: Path) -> None:
     consolidate_wps(refined_wps_path=str(refined_path), planner_dir=str(tmp_path))
 
     consolidated = json.loads((tmp_path / "consolidated_wps.json").read_text())
+    output_ids = {wp["id"] for wp in consolidated["work_packages"]}
+    assert "P1-A1-WP2" not in output_ids
+    assert "P1-A1-WP3" not in output_ids
     merged_a = next(wp for wp in consolidated["work_packages"] if wp["id"] == "P1-A1-WP1")
     assert merged_a["id"] == "P1-A1-WP1"
     assert "P1-A1-WP2" not in merged_a["depends_on"]


### PR DESCRIPTION
## Summary

The `planner-consolidate-wps` skill produces 0 merges across 62 WPs because its L0 subagent instructions use mechanical thresholds (≤3 steps AND ≤2 files = "trivial" = merge-eligible) that virtually nothing satisfies. The fix replaces these thresholds with judgment-based guidance that defaults to merging within an assignment, and adds a fallback heuristic in `consolidation.py` that detects all-singleton manifests and merges same-assignment WPs that share files.

Closes #1694

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260503-133214-714605/.autoskillit/temp/make-plan/planner-consolidate-wps-merge-criteria-too-strict_plan_2026-05-03_133500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 1.3k | 7.5k | 527.7k | 48.6k | 1 | 5m 34s |
| verify | 38 | 9.7k | 444.9k | 39.6k | 1 | 4m 37s |
| implement | 1.3k | 18.2k | 1.6M | 88.8k | 1 | 5m 44s |
| prepare_pr | 60 | 4.7k | 212.2k | 27.7k | 1 | 1m 36s |
| compose_pr | 51 | 1.9k | 160.2k | 18.9k | 1 | 40s |
| review_pr | 1.7k | 41.2k | 777.3k | 87.7k | 1 | 9m 11s |
| resolve_review | 317 | 19.8k | 2.1M | 71.8k | 1 | 7m 34s |
| resolve_queue_merge_conflicts | 164 | 25.2k | 1.1M | 71.7k | 1 | 4m 54s |
| **Total** | 5.0k | 128.2k | 6.9M | 454.8k | | 39m 52s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 255 | 6418.2 | 348.3 | 71.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 9 | 237153.4 | 7979.4 | 2200.6 |
| resolve_queue_merge_conflicts | 254 | 4159.0 | 282.2 | 99.0 |
| **Total** | **518** | 13416.6 | 877.9 | 247.5 |