### PR TITLE
Implementation Plan: Thread capture param through fleet prompt builder + Section 8 injection

### DIFF
--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -305,6 +305,7 @@ async def _run_dispatch(
         dispatch_id=dispatch_id,
         campaign_id=campaign_id,
         l2_timeout_sec=timeout_sec or 1800,
+        capture=capture,
     )
 
     state_path = tool_ctx.temp_dir / "dispatches" / f"{dispatch_id}.json"

--- a/src/autoskillit/fleet/_prompts.py
+++ b/src/autoskillit/fleet/_prompts.py
@@ -52,6 +52,7 @@ def _build_food_truck_prompt(
     dispatch_id: str,
     campaign_id: str,
     l2_timeout_sec: int,
+    capture: dict[str, str] | None = None,
 ) -> str:
     """Build the system prompt for an L2 food truck headless session.
 
@@ -60,12 +61,29 @@ def _build_food_truck_prompt(
     filtered sous-chef discipline, headless directives, routing/predicates,
     budget guidance, quota awareness, campaign task, ingredient values,
     and a sentinel-anchored result contract.
+
+    ``capture`` is an optional mapping of captured field names to their
+    descriptions, used by Section 8 sentinel format injection to instruct
+    the L2 session to emit those fields in its result block.
     """
     dispatch_id_short = dispatch_id[:8]
     ingredients_json = json.dumps(ingredients)
     ingredients_pretty_json = json.dumps(ingredients, indent=2)
 
     sous_chef_block = _build_l2_sous_chef_block()
+
+    extra_fields_example = (
+        (", " + ", ".join(f'"capture_{k}": "<{k}_value>"' for k in capture)) if capture else ""
+    )
+    extra_fields_docs = (
+        ("\n" + "\n".join(f"- capture_{k}: captured value for {k}" for k in capture))
+        if capture
+        else ""
+    )
+    sentinel_json_example = (
+        '{"success": <true|false>, "reason": "<completion_reason>", '
+        '"summary": "<one_line_summary>"' + extra_fields_example + "}"
+    )
 
     return f"""\
 You are an L2 food truck orchestrator. Execute the recipe '{recipe}' autonomously.
@@ -251,7 +269,7 @@ as your final output. No other text after the sentinel.
 
 ```
 ---l2-result::{dispatch_id}---
-{{"success": <true|false>, "reason": "<completion_reason>", "summary": "<one_line_summary>"}}
+{sentinel_json_example}
 ---end-l2-result::{dispatch_id}---
 %%L2_DONE::{dispatch_id_short}%%
 ```
@@ -260,7 +278,7 @@ Fields:
 - success: true if all mandatory steps completed without unresolved failures
 - reason: "completed", "failed", "quota_exhausted", "timeout",
   "open_kitchen_failed", "missing_on_failure"
-- summary: One-line description of what happened
+- summary: One-line description of what happened{extra_fields_docs}
 
 The sentinel markers ---l2-result::{dispatch_id}--- and ---end-l2-result::{dispatch_id}---
 are parsed by the fleet dispatcher. The %%L2_DONE::{dispatch_id_short}%% marker

--- a/tests/cli/test_food_truck_prompt.py
+++ b/tests/cli/test_food_truck_prompt.py
@@ -228,6 +228,52 @@ class TestSentinelFormat:
         assert '"success"' in prompt
         assert '"reason"' in prompt
 
+    @pytest.mark.parametrize(
+        "capture_dict",
+        [
+            {"worktree_path": "/repo"},
+            {"worktree_path": "/repo", "pr_url": "https://github.com/org/repo/pull/1"},
+        ],
+        ids=["1-key", "2-key"],
+    )
+    def test_sentinel_capture_fields_injected(self, capture_dict: dict[str, str]) -> None:
+        from autoskillit.fleet._prompts import _build_food_truck_prompt
+
+        prompt = _build_food_truck_prompt(
+            recipe=_RECIPE,
+            task=_TASK,
+            ingredients=_INGREDIENTS,
+            mcp_prefix=_MCP_PREFIX,
+            dispatch_id=_DISPATCH_ID,
+            campaign_id=_CAMPAIGN_ID,
+            l2_timeout_sec=_L2_TIMEOUT,
+            capture=capture_dict,
+        )
+        section8 = prompt[prompt.index("--- SECTION 8") :]
+        for key in capture_dict:
+            assert f"capture_{key}" in section8
+        assert '"success"' in section8
+        assert '"reason"' in section8
+
+    @pytest.mark.parametrize("capture_arg", [None, {}], ids=["none", "empty-dict"])
+    def test_sentinel_section8_unchanged_when_capture_none(
+        self, capture_arg: dict[str, str] | None
+    ) -> None:
+        from autoskillit.fleet._prompts import _build_food_truck_prompt
+
+        prompt = _build_food_truck_prompt(
+            recipe=_RECIPE,
+            task=_TASK,
+            ingredients=_INGREDIENTS,
+            mcp_prefix=_MCP_PREFIX,
+            dispatch_id=_DISPATCH_ID,
+            campaign_id=_CAMPAIGN_ID,
+            l2_timeout_sec=_L2_TIMEOUT,
+            capture=capture_arg,
+        )
+        section8 = prompt[prompt.index("--- SECTION 8") :]
+        assert "capture_" not in section8
+
 
 # --- Group E-6: No First-Action Bootstrap ---
 


### PR DESCRIPTION
## Summary

Thread the `capture` parameter through the fleet prompt builder pipeline: extend `_build_food_truck_prompt` with a `capture: dict[str, str] | None = None` parameter, inject capture field names into the Section 8 sentinel format (JSON example + Fields list), wire the caller in `_api.py` to pass `capture` through, and add parametrized test coverage for all paths.

Three files are modified: `src/autoskillit/fleet/_prompts.py` (signature + body), `src/autoskillit/fleet/_api.py` (one kwarg addition), and `tests/cli/test_food_truck_prompt.py` (two new test methods).

Closes #1697

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260503-154459-099960/.autoskillit/temp/make-plan/p1_wp2_thread_capture_through_fleet_prompt_builder_plan_2026-05-03_155300.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 62 | 8.2k | 774.6k | 49.2k | 1 | 3m 31s |
| verify | 1.1k | 6.5k | 323.4k | 37.8k | 1 | 5m 2s |
| implement | 180 | 11.2k | 1.3M | 64.4k | 1 | 3m 32s |
| prepare_pr | 60 | 4.8k | 219.5k | 28.0k | 1 | 1m 26s |
| compose_pr | 51 | 2.2k | 160.5k | 19.1k | 1 | 49s |
| **Total** | 1.5k | 32.8k | 2.8M | 198.5k | | 14m 22s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 69 | 18488.7 | 932.6 | 162.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **69** | 39908.0 | 2876.8 | 475.8 |