### PR TITLE
Create Sub-CLAUDE.md Files for Reorganized Directories

### DIFF
--- a/src/autoskillit/cli/doctor/CLAUDE.md
+++ b/src/autoskillit/cli/doctor/CLAUDE.md
@@ -1,0 +1,22 @@
+# doctor/
+
+Diagnostic health checks for the autoskillit installation (28 checks).
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `__init__.py` | Orchestration facade: imports all check functions and assembles `run_doctor()` |
+| `_doctor_types.py` | `DoctorResult` dataclass and `_NON_PROBLEM` severity set |
+| `_doctor_config.py` | Project config, gitignore, and secret scanning checks |
+| `_doctor_env.py` | Ambient env var leak detection (`SESSION_TYPE`, `CAMPAIGN_ID`) |
+| `_doctor_features.py` | Feature flag dependency consistency and registry import checks |
+| `_doctor_fleet.py` | Fleet infrastructure, campaign state, and sous-chef checks |
+| `_doctor_hooks.py` | Hook registration, executability, and registry drift checks |
+| `_doctor_install.py` | Install path, entry points, version drift, update dismissal checks |
+| `_doctor_mcp.py` | MCP server registration, dual registration, plugin cache checks |
+| `_doctor_runtime.py` | Quota cache schema version and claude process state checks |
+
+## Architecture Notes
+
+Hub-and-spoke: `__init__.py` is the single orchestration point. Each `_doctor_*` module is an independent check group returning `list[DoctorResult]`. Fleet checks are conditionally run only when the fleet feature is enabled.

--- a/src/autoskillit/cli/fleet/CLAUDE.md
+++ b/src/autoskillit/cli/fleet/CLAUDE.md
@@ -1,0 +1,12 @@
+# fleet/
+
+Fleet campaign CLI subcommands for multi-issue dispatch orchestration.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `__init__.py` | Main module: `fleet_app` Cyclopts sub-app with `campaign`, `dispatch`, `list`, `status` commands |
+| `_fleet_display.py` | Status display: `_render_status_display()`, `_watch_loop()`, `_STATUS_COLUMNS` |
+| `_fleet_lifecycle.py` | Signal guard, stale dispatch reaping, `_pick_resume_campaign()` |
+| `_fleet_session.py` | `_launch_fleet_session()` — builds Claude interactive session for fleet campaigns |

--- a/src/autoskillit/cli/session/CLAUDE.md
+++ b/src/autoskillit/cli/session/CLAUDE.md
@@ -1,0 +1,14 @@
+# session/
+
+Interactive session management — cook (ephemeral) and order (orchestrator) entry points.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `__init__.py` | Re-exports `cook` and `order` commands |
+| `_cook.py` | `cook` command: ephemeral skill session launcher |
+| `_order.py` | `order` command: orchestrator prompt builder with recipe selection |
+| `_reload.py` | `consume_reload_sentinel()` — detects reload sentinel written by MCP reload tool |
+| `_session_launch.py` | Shared prelude: `_launch_cook_session()`, `_run_interactive_session()` |
+| `_session_picker.py` | Scoped resume picker: filters session history by greeting prefix |

--- a/src/autoskillit/cli/ui/CLAUDE.md
+++ b/src/autoskillit/cli/ui/CLAUDE.md
@@ -1,0 +1,17 @@
+# ui/
+
+Terminal UI primitives for the CLI layer.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `__init__.py` | Package marker (no imports) |
+| `_ansi.py` | `supports_color()` — respects `NO_COLOR` and `TERM=dumb` |
+| `_menu.py` | `run_selection_menu()`, `render_numbered_menu()`, `SLOT_ZERO_SELECTED` sentinel |
+| `_terminal.py` | `terminal_guard()` — saves/restores TTY attributes around interactive subprocess launch |
+| `_timed_input.py` | `timed_prompt()` and `status_line()` — every CLI `input()` must go through `timed_prompt()` |
+
+## Architecture Notes
+
+`_timed_input.py` is the lowest-level primitive; `_menu.py` depends on it. `_terminal.py` is independent. The `timed_prompt()` contract is enforced by `test_input_tty_contracts.py`.

--- a/src/autoskillit/cli/update/CLAUDE.md
+++ b/src/autoskillit/cli/update/CLAUDE.md
@@ -1,0 +1,17 @@
+# update/
+
+Update and upgrade machinery for the autoskillit package.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `__init__.py` | Re-exports `run_update_command` and `run_update_checks` |
+| `_update.py` | `run_update_command()` for the explicit `autoskillit update` subcommand |
+| `_update_checks.py` | `run_update_checks()` — unified startup update check with dismissable prompt |
+| `_update_checks_fetch.py` | HTTP cache + fetch: `_fetch_with_cache()`, disk cache with TTL |
+| `_update_checks_source.py` | Source-repo discovery and SHA resolution for drift detection |
+
+## Architecture Notes
+
+`_update_checks.py` is the facade for the startup path; `_update.py` is the facade for the explicit `autoskillit update` command. Both reuse the same `upgrade_command()` policy from `cli/_install_info.py`.

--- a/src/autoskillit/core/runtime/CLAUDE.md
+++ b/src/autoskillit/core/runtime/CLAUDE.md
@@ -1,0 +1,17 @@
+# runtime/
+
+Process-state modules for session lifecycle tracking (stdlib-only, IL-0).
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `__init__.py` | Named explicit re-exports (not wildcard) for all public symbols |
+| `_linux_proc.py` | Reads `/proc` boot ID and process start-time ticks; returns `None` on non-Linux |
+| `kitchen_state.py` | `KitchenMarker` disk-based session marker written by `open_kitchen`, read by hook subprocesses |
+| `readiness.py` | Filesystem sentinel for MCP server startup synchronization in integration tests |
+| `session_registry.py` | Maps autoskillit launch IDs to Claude Code session UUIDs for scoped resume |
+
+## Architecture Notes
+
+All modules are stdlib-only (safe for import from hook subprocesses). `readiness.py` is the sole exception — it uses `core.io.atomic_write`.

--- a/src/autoskillit/core/types/CLAUDE.md
+++ b/src/autoskillit/core/types/CLAUDE.md
@@ -1,0 +1,26 @@
+# types/
+
+Type re-export hub and all typed building blocks for the autoskillit package (IL-0).
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `__init__.py` | Re-export hub — aggregates `__all__` from all `_type_*.py` modules |
+| `_type_enums.py` | All `StrEnum` discriminators (`RetryReason`, `KillReason`, `Severity`, etc.) |
+| `_type_constants.py` | Shared constants: tool lists, env var names, version string |
+| `_type_subprocess.py` | `SubprocessResult` dataclass and `SubprocessRunner` protocol |
+| `_type_results.py` | Core result dataclasses: `SkillResult`, `LoadResult`, `FailureRecord`, `WriteBehaviorSpec`, `SessionTelemetry` |
+| `_type_protocols_logging.py` | Protocols: `AuditLog`, `TokenLog`, `TimingLog`, `McpResponseLog`, `GitHubApiLog` |
+| `_type_protocols_execution.py` | Protocols: `TestRunner`, `HeadlessExecutor`, `OutputPatternResolver` |
+| `_type_protocols_github.py` | Protocols: `GitHubFetcher`, `CIWatcher`, `MergeQueueWatcher` |
+| `_type_protocols_workspace.py` | Protocols: `WorkspaceManager`, `CloneManager`, `SessionSkillManager` |
+| `_type_protocols_recipe.py` | Protocols: `RecipeRepository`, `MigrationService`, `DatabaseReader` |
+| `_type_protocols_infra.py` | Protocols: `GateState`, `BackgroundSupervisor`, `FleetLock`, `TokenFactory` |
+| `_type_helpers.py` | Text processing and skill-name extraction utilities |
+| `_type_resume.py` | `ResumeSpec` discriminated union: `NoResume | BareResume | NamedResume` |
+| `_type_plugin_source.py` | `PluginSource` discriminated union: `DirectInstall | MarketplaceInstall` |
+
+## Architecture Notes
+
+Internal dependency DAG: enums -> constants -> subprocess -> results -> protocols -> helpers. All modules have zero `autoskillit` imports outside this sub-package (IL-0 hard constraint). Production code imports from `autoskillit.core`, not from this package directly.

--- a/src/autoskillit/core/types/CLAUDE.md
+++ b/src/autoskillit/core/types/CLAUDE.md
@@ -11,12 +11,12 @@ Type re-export hub and all typed building blocks for the autoskillit package (IL
 | `_type_constants.py` | Shared constants: tool lists, env var names, version string |
 | `_type_subprocess.py` | `SubprocessResult` dataclass and `SubprocessRunner` protocol |
 | `_type_results.py` | Core result dataclasses: `SkillResult`, `LoadResult`, `FailureRecord`, `WriteBehaviorSpec`, `SessionTelemetry` |
-| `_type_protocols_logging.py` | Protocols: `AuditLog`, `TokenLog`, `TimingLog`, `McpResponseLog`, `GitHubApiLog` |
-| `_type_protocols_execution.py` | Protocols: `TestRunner`, `HeadlessExecutor`, `OutputPatternResolver` |
+| `_type_protocols_logging.py` | Protocols: `AuditLog`, `TokenLog`, `TimingLog`, `McpResponseLog`, `GitHubApiLog`, `SupportsDebug`, `SupportsLogger` |
+| `_type_protocols_execution.py` | Protocols: `TestRunner`, `HeadlessExecutor`, `OutputPatternResolver`, `WriteExpectedResolver` |
 | `_type_protocols_github.py` | Protocols: `GitHubFetcher`, `CIWatcher`, `MergeQueueWatcher` |
-| `_type_protocols_workspace.py` | Protocols: `WorkspaceManager`, `CloneManager`, `SessionSkillManager` |
-| `_type_protocols_recipe.py` | Protocols: `RecipeRepository`, `MigrationService`, `DatabaseReader` |
-| `_type_protocols_infra.py` | Protocols: `GateState`, `BackgroundSupervisor`, `FleetLock`, `TokenFactory` |
+| `_type_protocols_workspace.py` | Protocols: `WorkspaceManager`, `CloneManager`, `SessionSkillManager`, `SkillLister`, `SkillResolver` |
+| `_type_protocols_recipe.py` | Protocols: `RecipeRepository`, `MigrationService`, `DatabaseReader`, `ReadOnlyResolver` |
+| `_type_protocols_infra.py` | Protocols: `GateState`, `BackgroundSupervisor`, `FleetLock`, `QuotaRefreshTask`, `TokenFactory`, `CampaignProtector` |
 | `_type_helpers.py` | Text processing and skill-name extraction utilities |
 | `_type_resume.py` | `ResumeSpec` discriminated union: `NoResume | BareResume | NamedResume` |
 | `_type_plugin_source.py` | `PluginSource` discriminated union: `DirectInstall | MarketplaceInstall` |

--- a/src/autoskillit/execution/headless/CLAUDE.md
+++ b/src/autoskillit/execution/headless/CLAUDE.md
@@ -1,0 +1,18 @@
+# headless/
+
+Headless Claude session orchestration — command prep, subprocess invocation, result construction.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `__init__.py` | Main module: `run_headless_core()`, `DefaultHeadlessExecutor`, `_execute_claude_headless()` |
+| `_headless_git.py` | Git LOC tracking: `_capture_git_head_sha()`, `_compute_loc_changed()` |
+| `_headless_path_tokens.py` | Path-token extraction and output-path validation from assistant messages |
+| `_headless_recovery.py` | Session recovery: `_recover_from_separate_marker`, `_synthesize_from_write_artifacts` |
+| `_headless_result.py` | `SkillResult` construction: `_build_skill_result`, `_build_session_telemetry`, `_apply_budget_guard` |
+| `_headless_scan.py` | `_scan_jsonl_write_paths()` — scans stdout JSONL for Write/Edit/Bash tool calls |
+
+## Architecture Notes
+
+The `__init__.py` IS the main module body (not a thin facade). It uses a deferred import for `flush_session_log` to avoid circular imports. `_execute_claude_headless` is the shared path for both `run_skill` (leaf) and `dispatch_food_truck` (fleet) flows.

--- a/src/autoskillit/execution/merge_queue/CLAUDE.md
+++ b/src/autoskillit/execution/merge_queue/CLAUDE.md
@@ -1,0 +1,16 @@
+# merge_queue/
+
+GitHub merge queue watcher — polls PR state until merged, ejected, or timed out.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `__init__.py` | Main module: `DefaultMergeQueueWatcher` with single-GraphQL-round-trip polling |
+| `_merge_queue_classifier.py` | `_classify_pr_state()` pure function: MERGED/EJECTED/STALLED/DROPPED classification |
+| `_merge_queue_group_ci.py` | `_query_merge_group_ci()` and GraphQL mutation strings for auto-merge/enqueue |
+| `_merge_queue_repo_state.py` | `fetch_repo_merge_state()`, push/merge-group trigger detection, rate-limit retry |
+
+## Architecture Notes
+
+The `random` module is explicitly re-exported from `__init__.py` to enable test monkeypatching of `merge_queue.random.uniform` for jitter control.

--- a/src/autoskillit/execution/process/CLAUDE.md
+++ b/src/autoskillit/execution/process/CLAUDE.md
@@ -1,0 +1,26 @@
+# process/
+
+Subprocess lifecycle management — spawn, monitor, race, kill.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `__init__.py` | Main module: `run_managed_async()`, `run_managed_sync()`, `DefaultSubprocessRunner` |
+| `_process_io.py` | `create_temp_io()` context manager for temp file stdin/stdout/stderr |
+| `_process_jsonl.py` | JSONL parsing: `_jsonl_contains_marker`, `_jsonl_has_record_type` |
+| `_process_kill.py` | `kill_process_tree()` (sync) and `async_kill_process_tree()` (async): SIGTERM -> wait -> SIGKILL |
+| `_process_monitor.py` | Async monitor coroutines: `_heartbeat()` (Channel A), `_session_log_monitor()` (Channel B) |
+| `_process_pty.py` | `pty_wrap_command()` — wraps command with `script(1)` for PTY allocation |
+| `_process_race.py` | `RaceAccumulator`, `RaceSignals`, watcher coroutines, `resolve_termination()` |
+
+## Architecture Notes
+
+**Two-channel completion detection:**
+
+- **Channel A** (stdout heartbeat): polls the subprocess stdout temp file for a `type=result` NDJSON record containing the completion marker. Guarantees stdout data is available.
+- **Channel B** (session JSONL monitor): watches the Claude Code session JSONL log file (written by the Claude Code subprocess to its session log directory) for the completion marker in an `assistant`-type record. Provides an orthogonal confirmation signal and session ID discovery via the JSONL filename stem.
+
+Both channels race concurrently in an `anyio` task group. `resolve_termination()` reads the frozen `RaceSignals` and returns `(TerminationReason, ChannelConfirmation)`. Channel A takes precedence if both fire in the same tick.
+
+`execute_termination_action()` is the sole authorized caller of `async_kill_process_tree` (enforced by test).

--- a/src/autoskillit/execution/session/CLAUDE.md
+++ b/src/autoskillit/execution/session/CLAUDE.md
@@ -1,0 +1,17 @@
+# session/
+
+Session result processing — parse, validate content, compute retry, adjudicate outcome.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `__init__.py` | Thin facade re-exporting all sub-module symbols |
+| `_session_model.py` | `ClaudeSessionResult`, `ContentState`, `parse_session_result()`, `extract_token_usage()` |
+| `_session_content.py` | Content validation: `_check_session_content()`, `_check_expected_patterns()` |
+| `_retry_fsm.py` | Retry FSM: `_compute_retry()`, maps `(TerminationReason, CliSubtype)` to `RetryReason` |
+| `_session_outcome.py` | High-level adjudication: `_compute_success()`, `_compute_outcome()` |
+
+## Architecture Notes
+
+The four sub-modules form a pipeline: parse -> check content -> compute retry -> compute outcome. When Channel B is the sole confirmation source, `_compute_success` applies a provenance bypass — the session JSONL marker is treated as authoritative proof of success without requiring stdout content.

--- a/src/autoskillit/hooks/formatters/CLAUDE.md
+++ b/src/autoskillit/hooks/formatters/CLAUDE.md
@@ -1,0 +1,18 @@
+# formatters/
+
+PostToolUse output formatters — MCP JSON to Markdown-KV reformatter (30-77% token reduction).
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `__init__.py` | Package marker (no imports) |
+| `pretty_output_hook.py` | Dispatch entrypoint: intercepts MCP tool responses, routes to per-tool formatters |
+| `_fmt_primitives.py` | Shared primitives: `_CHECK_MARK`, `_CROSS_MARK`, payload dataclasses, token formatter |
+| `_fmt_execution.py` | Formatters for `run_skill`, `run_cmd`, `test_check`, `merge_worktree` |
+| `_fmt_recipe.py` | Formatters for `load_recipe`, `open_kitchen`, `list_recipes` |
+| `_fmt_status.py` | Formatters for `get_token_summary`, `get_timing_summary`, `kitchen_status` |
+
+## Architecture Notes
+
+All `_fmt_*` modules use bare relative imports (`from _fmt_primitives import ...`) because hook scripts run as standalone executables with this directory as CWD — not via the Python package system. `pretty_output_hook.py` is the only entry point.

--- a/src/autoskillit/hooks/guards/CLAUDE.md
+++ b/src/autoskillit/hooks/guards/CLAUDE.md
@@ -1,0 +1,31 @@
+# guards/
+
+PreToolUse guard scripts — standalone Python processes enforcing tool-call policies.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `__init__.py` | Package marker (no imports) |
+| `ask_user_question_guard.py` | Blocks `AskUserQuestion` before kitchen is open |
+| `branch_protection_guard.py` | Blocks merge/push targeting protected branches |
+| `fleet_dispatch_guard.py` | Blocks `dispatch_food_truck` from headless sessions (prevents L3->L3 recursion) |
+| `generated_file_write_guard.py` | Blocks Write/Edit to machine-generated files (`hooks.json`, `settings.json`) |
+| `grep_pattern_lint_guard.py` | Blocks Grep with BRE `\|` syntax; surfaces corrected ERE pattern |
+| `leaf_orchestration_guard.py` | Blocks `run_skill`/`run_cmd`/`run_python` from L1 leaf sessions |
+| `mcp_health_guard.py` | Detects MCP server disconnection (dead PID); non-blocking advisory |
+| `open_kitchen_guard.py` | Blocks `open_kitchen` from headless sessions; writes kitchen marker |
+| `planner_gh_discovery_guard.py` | Blocks GitHub issue/PR listing in planner sessions |
+| `pr_create_guard.py` | Blocks `gh pr create` via `run_cmd` when kitchen is open |
+| `quota_guard.py` | Blocks `run_skill` when quota threshold exceeded; fails open on missing cache |
+| `recipe_write_advisor.py` | Non-blocking advisory for recipe YAML writes |
+| `remove_clone_guard.py` | Blocks `remove_clone` if branch has unpushed commits |
+| `review_loop_gate.py` | Blocks `wait_for_ci`/`enqueue_pr` until `check_review_loop` is called |
+| `skill_cmd_guard.py` | Validates `skill_command` path argument format |
+| `skill_command_guard.py` | Blocks `run_skill` with non-slash `skill_command` |
+| `unsafe_install_guard.py` | Blocks `pip install -e` targeting system Python |
+| `write_guard.py` | Blocks Write/Edit outside allowed prefix in read-only sessions |
+
+## Architecture Notes
+
+Each guard is a standalone Python script executed as a subprocess (not imported as a module). Protocol: read PreToolUse JSON from stdin, write decision JSON to stdout, exit 0. Most are stdlib-only for fast startup. Guards fail-open for malformed input (except `skill_command_guard.py` which fails-closed).

--- a/src/autoskillit/hooks/guards/CLAUDE.md
+++ b/src/autoskillit/hooks/guards/CLAUDE.md
@@ -28,4 +28,4 @@ PreToolUse guard scripts — standalone Python processes enforcing tool-call pol
 
 ## Architecture Notes
 
-Each guard is a standalone Python script executed as a subprocess (not imported as a module). Protocol: read PreToolUse JSON from stdin, write decision JSON to stdout, exit 0. Most are stdlib-only for fast startup. Guards fail-open for malformed input (except `skill_command_guard.py` which fails-closed).
+Each guard is a standalone Python script executed as a subprocess (not imported as a module). Protocol: read PreToolUse JSON from stdin, write decision JSON to stdout, exit 0. Most are stdlib-only for fast startup. Guards fail-open for malformed input. `skill_command_guard.py` has split error handling: malformed JSON fails-open (approve), unexpected runtime errors fail-closed (deny).

--- a/src/autoskillit/recipe/rules/CLAUDE.md
+++ b/src/autoskillit/recipe/rules/CLAUDE.md
@@ -1,0 +1,38 @@
+# rules/
+
+Semantic validation rule modules for recipe analysis (25 rule files).
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `__init__.py` | Docstring-only — rules register via `@semantic_rule` decorator on import |
+| `rules_actions.py` | Semantic rules for `stop`/`route`/`confirm` action-type steps |
+| `rules_blocks.py` | Block-level budget rules; loads `block_budgets.yaml` at import |
+| `rules_bypass.py` | Rules for `skip_when_false` bypass routing contracts |
+| `rules_campaign.py` | Campaign recipe validation: dispatch names, ingredient refs |
+| `rules_ci.py` | CI polling patterns: PR state handling, CI step ordering |
+| `rules_clone.py` | Clone/push dataflow rules: missing remote URL, local-strategy capture |
+| `rules_cmd.py` | `run_cmd` echo-capture alignment; git remote command detection |
+| `rules_contracts.py` | Skill contract completeness rules |
+| `rules_dataflow.py` | Dataflow analysis: pipeline-forbidden tool usage, output chaining |
+| `rules_features.py` | Feature-gated tool/skill reference validation |
+| `rules_fixing.py` | Conditional-write skill must gate on declared verdict output |
+| `rules_graph.py` | Graph/routing analysis rules |
+| `rules_inline_script.py` | Detects inline shell scripts in `run_cmd` cmd fields |
+| `rules_inputs.py` | Input/ingredient validation; version compatibility checks |
+| `rules_isolation.py` | Workspace isolation rules (prevents operating on source repo) |
+| `rules_merge.py` | `merge_worktree` routing completeness |
+| `rules_packs.py` | Pack validation (names must exist in `PACK_REGISTRY`) |
+| `rules_reachability.py` | Symbolic BFS reachability; capture-inversion detection |
+| `rules_recipe.py` | Sub-recipe reference validity and `with_args` hygiene |
+| `rules_skill_content.py` | Undefined bash placeholder detection in SKILL.md |
+| `rules_skills.py` | `skill_command` resolvability rules |
+| `rules_temp_path.py` | Rejects bare `{{AUTOSKILLIT_TEMP}}/` without scope prefix |
+| `rules_tools.py` | MCP tool name validity (must be in known tool sets) |
+| `rules_verdict.py` | Skill verdict routing completeness and cross-step consistency |
+| `rules_worktree.py` | Worktree and retry validation rules |
+
+## Architecture Notes
+
+Side-effect registration: callers import the package to trigger `@semantic_rule` decorator registration of all 25 rule modules. Each rule receives a `ValidationContext` argument. No cross-imports between rule modules.

--- a/src/autoskillit/server/tools/CLAUDE.md
+++ b/src/autoskillit/server/tools/CLAUDE.md
@@ -13,12 +13,12 @@ MCP `@mcp.tool()` handlers registered on import (13 tool modules).
 | `tools_ci_merge_queue.py` | `toggle_auto_merge`, `enqueue_pr`, `wait_for_merge_queue` |
 | `tools_clone.py` | `clone_repo`, `remove_clone`, `push_to_remote`, `register_clone_status`, `batch_cleanup_clones` |
 | `tools_execution.py` | `run_cmd`, `run_python`, `run_skill`, `dispatch_food_truck` |
-| `tools_git.py` | `merge_worktree`, `classify_fix` |
+| `tools_git.py` | `merge_worktree`, `classify_fix`, `create_unique_branch`, `check_pr_mergeable` |
 | `tools_github.py` | `fetch_github_issue`, `get_issue_title`, `report_bug` |
 | `tools_issue_lifecycle.py` | `prepare_issue`, `enrich_issues`, `claim_issue`, `release_issue` |
 | `tools_pr_ops.py` | `get_pr_reviews`, `bulk_close_issues` |
 | `tools_recipe.py` | `load_recipe`, `list_recipes`, `validate_recipe`, `migrate_recipe` |
-| `tools_status.py` | `kitchen_status`, `get_pipeline_report`, `get_token_summary`, `get_timing_summary`, `read_db` |
+| `tools_status.py` | `kitchen_status`, `get_pipeline_report`, `get_token_summary`, `get_timing_summary`, `analyze_tool_sequences`, `get_quota_events`, `write_telemetry_files`, `read_db` |
 | `tools_workspace.py` | `test_check`, `reset_test_dir`, `reset_workspace` |
 
 ## Architecture Notes

--- a/src/autoskillit/server/tools/CLAUDE.md
+++ b/src/autoskillit/server/tools/CLAUDE.md
@@ -1,0 +1,26 @@
+# tools/
+
+MCP `@mcp.tool()` handlers registered on import (13 tool modules).
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `__init__.py` | Docstring-only — tools register via `@mcp.tool()` on import |
+| `tools_kitchen.py` | `open_kitchen`, `close_kitchen` (gate lifecycle), `recipe://` MCP resource |
+| `tools_ci.py` | `set_commit_status`, `check_repo_merge_state` |
+| `tools_ci_watch.py` | `wait_for_ci`, `get_ci_status`, `_auto_trigger_ci` |
+| `tools_ci_merge_queue.py` | `toggle_auto_merge`, `enqueue_pr`, `wait_for_merge_queue` |
+| `tools_clone.py` | `clone_repo`, `remove_clone`, `push_to_remote`, `register_clone_status`, `batch_cleanup_clones` |
+| `tools_execution.py` | `run_cmd`, `run_python`, `run_skill`, `dispatch_food_truck` |
+| `tools_git.py` | `merge_worktree`, `classify_fix` |
+| `tools_github.py` | `fetch_github_issue`, `get_issue_title`, `report_bug` |
+| `tools_issue_lifecycle.py` | `prepare_issue`, `enrich_issues`, `claim_issue`, `release_issue` |
+| `tools_pr_ops.py` | `get_pr_reviews`, `bulk_close_issues` |
+| `tools_recipe.py` | `load_recipe`, `list_recipes`, `validate_recipe`, `migrate_recipe` |
+| `tools_status.py` | `kitchen_status`, `get_pipeline_report`, `get_token_summary`, `get_timing_summary`, `read_db` |
+| `tools_workspace.py` | `test_check`, `reset_test_dir`, `reset_workspace` |
+
+## Architecture Notes
+
+Side-effect registration (same pattern as `recipe/rules/`). The `server/__init__.py` owns the `mcp` app object; tool modules import it from the server layer. All tools require `readOnlyHint: True` (see `server/CLAUDE.md`).

--- a/tests/docs/test_sub_claude_md_completeness.py
+++ b/tests/docs/test_sub_claude_md_completeness.py
@@ -1,5 +1,6 @@
 """Structural tests for per-subfolder CLAUDE.md documentation files."""
 
+import re
 from pathlib import Path
 
 import pytest
@@ -44,8 +45,8 @@ def test_sub_claude_md_covers_all_py_files():
         py_files = sorted(f.name for f in directory.glob("*.py"))
         for py_file in py_files:
             if py_file == "__init__.py":
-                if "__init__.py" not in content and "Facade" not in content:
-                    failures.append(f"{rel_path}: missing __init__.py or Facade mention")
+                if "`__init__.py`" not in content:
+                    failures.append(f"{rel_path}: missing `__init__.py` in file table")
             else:
                 if py_file not in content:
                     failures.append(f"{rel_path}: missing {py_file}")
@@ -74,14 +75,14 @@ def test_channel_b_defined_in_process_claude_md():
 
 
 def test_sub_claude_md_no_main_claude_md_duplication():
-    forbidden_headers = ["## 3.", "## 4.", "## 5."]
+    numbered_section_re = re.compile(r"^## \*{0,2}\d+\.", re.MULTILINE)
     failures = []
     for rel_path in EXPECTED_SUB_CLAUDE_MDS:
         claude_md = SRC_ROOT / rel_path
         if not claude_md.is_file():
             continue
         content = claude_md.read_text()
-        for header in forbidden_headers:
-            if header in content:
-                failures.append(f"{rel_path}: contains '{header}' (main CLAUDE.md section)")
+        match = numbered_section_re.search(content)
+        if match:
+            failures.append(f"{rel_path}: contains '{match.group()}' (main CLAUDE.md section)")
     assert not failures, "Sub-CLAUDE.md files duplicate main sections:\n" + "\n".join(failures)

--- a/tests/docs/test_sub_claude_md_completeness.py
+++ b/tests/docs/test_sub_claude_md_completeness.py
@@ -1,0 +1,87 @@
+"""Structural tests for per-subfolder CLAUDE.md documentation files."""
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.small
+
+SRC_ROOT = Path(__file__).resolve().parents[2] / "src" / "autoskillit"
+
+EXPECTED_SUB_CLAUDE_MDS = [
+    "core/types/CLAUDE.md",
+    "core/runtime/CLAUDE.md",
+    "execution/headless/CLAUDE.md",
+    "execution/process/CLAUDE.md",
+    "execution/session/CLAUDE.md",
+    "execution/merge_queue/CLAUDE.md",
+    "recipe/rules/CLAUDE.md",
+    "server/tools/CLAUDE.md",
+    "cli/doctor/CLAUDE.md",
+    "cli/fleet/CLAUDE.md",
+    "cli/session/CLAUDE.md",
+    "cli/ui/CLAUDE.md",
+    "cli/update/CLAUDE.md",
+    "hooks/guards/CLAUDE.md",
+    "hooks/formatters/CLAUDE.md",
+]
+
+
+def test_all_15_sub_claude_md_files_exist():
+    missing = [p for p in EXPECTED_SUB_CLAUDE_MDS if not (SRC_ROOT / p).is_file()]
+    assert not missing, f"Missing sub-CLAUDE.md files: {missing}"
+
+
+def test_sub_claude_md_covers_all_py_files():
+    failures = []
+    for rel_path in EXPECTED_SUB_CLAUDE_MDS:
+        claude_md = SRC_ROOT / rel_path
+        if not claude_md.is_file():
+            failures.append(f"{rel_path}: file does not exist")
+            continue
+        content = claude_md.read_text()
+        directory = claude_md.parent
+        py_files = sorted(f.name for f in directory.glob("*.py"))
+        for py_file in py_files:
+            if py_file == "__init__.py":
+                if "__init__.py" not in content and "Facade" not in content:
+                    failures.append(f"{rel_path}: missing __init__.py or Facade mention")
+            else:
+                if py_file not in content:
+                    failures.append(f"{rel_path}: missing {py_file}")
+    assert not failures, "Sub-CLAUDE.md coverage gaps:\n" + "\n".join(failures)
+
+
+def test_sub_claude_md_has_file_table():
+    failures = []
+    for rel_path in EXPECTED_SUB_CLAUDE_MDS:
+        claude_md = SRC_ROOT / rel_path
+        if not claude_md.is_file():
+            failures.append(f"{rel_path}: file does not exist")
+            continue
+        content = claude_md.read_text()
+        if "| File | Purpose |" not in content:
+            failures.append(f"{rel_path}: missing '| File | Purpose |' table header")
+    assert not failures, "Sub-CLAUDE.md template violations:\n" + "\n".join(failures)
+
+
+def test_channel_b_defined_in_process_claude_md():
+    process_md = SRC_ROOT / "execution" / "process" / "CLAUDE.md"
+    assert process_md.is_file(), "execution/process/CLAUDE.md does not exist"
+    content = process_md.read_text()
+    assert "Channel B" in content, "execution/process/CLAUDE.md must define Channel B"
+    assert "JSONL" in content, "Channel B definition must mention JSONL"
+
+
+def test_sub_claude_md_no_main_claude_md_duplication():
+    forbidden_headers = ["## 3.", "## 4.", "## 5."]
+    failures = []
+    for rel_path in EXPECTED_SUB_CLAUDE_MDS:
+        claude_md = SRC_ROOT / rel_path
+        if not claude_md.is_file():
+            continue
+        content = claude_md.read_text()
+        for header in forbidden_headers:
+            if header in content:
+                failures.append(f"{rel_path}: contains '{header}' (main CLAUDE.md section)")
+    assert not failures, "Sub-CLAUDE.md files duplicate main sections:\n" + "\n".join(failures)


### PR DESCRIPTION
## Summary

Write 15 per-subfolder `CLAUDE.md` files across the reorganized `src/autoskillit/` directory tree. Each file serves as a local file index with one-line-per-file descriptions and optional Architecture Notes for non-obvious patterns. Add a structural test that validates all 15 files exist and that every `.py` file in each subfolder appears in its local `CLAUDE.md`. Define "Channel B" in the `execution/process/CLAUDE.md` file.

## Implementation Plan

Plan file: `.autoskillit/temp/make-plan/create_sub_claude_md_files_plan_2026-05-03_171500.md`

Closes #1685

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 4.6k | 59.9k | 4.2M | 269.3k | 2 | 29m 14s |
| verify | 398 | 12.2k | 1.4M | 60.1k | 1 | 5m 20s |
| implement | 32 | 11.8k | 557.5k | 79.4k | 1 | 4m 59s |
| prepare_pr | 24 | 4.1k | 199.8k | 33.2k | 1 | 1m 13s |
| compose_pr | 23 | 1.3k | 164.1k | 19.1k | 1 | 34s |
| review_pr | 741 | 28.9k | 437.7k | 67.3k | 1 | 12m 6s |
| resolve_review | 63 | 14.9k | 2.1M | 76.3k | 1 | 10m 41s |
| **Total** | 5.9k | 133.1k | 9.1M | 604.7k | | 1h 4m |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 402 | 1386.7 | 197.5 | 29.3 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 29 | 72415.1 | 2630.4 | 514.3 |
| **Total** | **431** | 21078.4 | 1403.0 | 308.8 |