### PR TITLE
[FIX] Rectify: Write-Evidence Flat Scan Immunity

### DIFF
--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -159,6 +159,13 @@ def _resolve_skill_temp_dir(cwd: str, skill_command: str) -> Path | None:
     return Path(cwd) / ".autoskillit" / "temp" / name
 
 
+def _recursive_snapshot(directory: Path) -> set[str]:
+    """Recursively enumerate all files under directory as relative paths."""
+    return {
+        str(Path(dp).relative_to(directory) / f) for dp, _, fns in os.walk(directory) for f in fns
+    }
+
+
 @dataclasses.dataclass(frozen=True)
 class PostSessionMetrics:
     loc_insertions: int
@@ -264,7 +271,7 @@ async def _execute_claude_headless(
     for _wd in _watch_dirs:
         if _wd.is_dir():
             try:
-                _temp_snapshots_pre[_wd] = {e.name for e in os.scandir(_wd)}
+                _temp_snapshots_pre[_wd] = _recursive_snapshot(_wd)
             except OSError:
                 logger.warning("watch_dir_pre_scan_failed", watch_dir=str(_wd), exc_info=True)
                 _temp_snapshots_pre[_wd] = set()
@@ -378,7 +385,7 @@ async def _execute_claude_headless(
     for _wd in _watch_dirs:
         if _wd.is_dir():
             try:
-                _post = {e.name for e in os.scandir(_wd)}
+                _post = _recursive_snapshot(_wd)
             except OSError:
                 logger.warning("watch_dir_post_scan_failed", watch_dir=str(_wd), exc_info=True)
                 _post = set()

--- a/src/autoskillit/recipes/planner.yaml
+++ b/src/autoskillit/recipes/planner.yaml
@@ -184,7 +184,7 @@ steps:
     with:
       skill_command: "/autoskillit:planner-elaborate-assignments {context_path} ${{ context.planner_dir }}"
       cwd: "${{ inputs.source_dir }}"
-      output_dir: "${{ context.planner_dir }}"
+      output_dir: "${{ context.planner_dir }}/assignments"
       dispatch_items: "${{ context.assignment_context_paths }}"
     capture_list:
       phase_assignments_result_dir: "${{ result.phase_assignments_result_dir }}"
@@ -215,7 +215,7 @@ steps:
     with:
       skill_command: "/autoskillit:planner-refine-assignments {context_path} ${{ context.refined_plan_path }} ${{ context.planner_dir }}"
       cwd: "${{ inputs.source_dir }}"
-      output_dir: "${{ context.planner_dir }}"
+      output_dir: "${{ context.planner_dir }}/refine_contexts"
       dispatch_items: "${{ context.refine_context_paths }}"
     capture_list:
       phase_refined_path: "${{ result.phase_refined_path }}"
@@ -256,7 +256,7 @@ steps:
     with:
       skill_command: "/autoskillit:planner-elaborate-wps {context_path} ${{ context.planner_dir }}"
       cwd: "${{ inputs.source_dir }}"
-      output_dir: "${{ context.planner_dir }}"
+      output_dir: "${{ context.planner_dir }}/work_packages"
       dispatch_items: "${{ context.wp_context_paths }}"
     capture_list:
       phase_wps_result_dir: "${{ result.phase_wps_result_dir }}"

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -413,7 +413,7 @@ class TestGroupFDoctor:
     """P8-2, P3-2: CLI refactoring — doctor delegation tests from TestGroupFRefactoring."""
 
     def test_doctor_delegates_to_doctor_module(self, monkeypatch, capsys):
-        """cli.doctor_cmd() must delegate to cli.doctor.run_doctor(), not contain the logic itself."""
+        """doctor_cmd() must delegate to run_doctor(), not contain logic itself."""
         import autoskillit.cli.doctor as _doctor_mod
 
         called_with: dict = {}

--- a/tests/execution/test_write_evidence.py
+++ b/tests/execution/test_write_evidence.py
@@ -187,6 +187,96 @@ class TestBashFilePathEnrichment:
         assert "/tmp/output/" in paths
 
 
+class TestRecursiveSnapshot:
+    """Recursive snapshot detects writes in pre-existing subdirectories."""
+
+    def test_detects_write_in_preexisting_subdir(self, tmp_path: Path) -> None:
+        from autoskillit.execution.headless import _recursive_snapshot
+
+        watch_dir = tmp_path / "planner_run"
+        sub_dir = watch_dir / "refine_contexts"
+        sub_dir.mkdir(parents=True)
+        (sub_dir / "context_P1.json").write_text("{}")
+
+        pre = _recursive_snapshot(watch_dir)
+
+        (sub_dir / "P1_result.json").write_text('{"assignments": []}')
+
+        post = _recursive_snapshot(watch_dir)
+
+        assert post - pre == {"refine_contexts/P1_result.json"}
+
+    def test_detects_write_in_nested_subdir(self, tmp_path: Path) -> None:
+        from autoskillit.execution.headless import _recursive_snapshot
+
+        watch_dir = tmp_path / "planner_run"
+        nested = watch_dir / "work_packages" / "wp_sentinels"
+        nested.mkdir(parents=True)
+
+        pre = _recursive_snapshot(watch_dir)
+
+        (nested / "P1_result.json").write_text("{}")
+
+        post = _recursive_snapshot(watch_dir)
+
+        assert post - pre == {"work_packages/wp_sentinels/P1_result.json"}
+
+    @pytest.mark.anyio
+    async def test_run_headless_core_detects_subdir_write(
+        self, tmp_path: Path, minimal_ctx
+    ) -> None:
+        from autoskillit.execution.headless import run_headless_core
+        from tests.execution.conftest import _success_session_json
+
+        watch_dir = tmp_path / "output"
+        sub_dir = watch_dir / "results"
+        sub_dir.mkdir(parents=True)
+        (sub_dir / "existing.json").write_text("{}")
+
+        async def mock_runner(cmd, **kwargs):
+            (sub_dir / "new_output.json").write_text('{"data": true}')
+            return _make_result(returncode=0, stdout=_success_session_json("done"))
+
+        minimal_ctx.runner = mock_runner
+        proj = tmp_path / "proj"
+        proj.mkdir()
+
+        result = await run_headless_core(
+            "/autoskillit:test-skill",
+            str(proj),
+            minimal_ctx,
+            write_watch_dirs=[watch_dir],
+        )
+        assert result.fs_writes_detected is True
+
+    @pytest.mark.anyio
+    async def test_run_headless_core_empty_subdir_no_false_positive(
+        self, tmp_path: Path, minimal_ctx
+    ) -> None:
+        from autoskillit.execution.headless import run_headless_core
+        from tests.execution.conftest import _success_session_json
+
+        watch_dir = tmp_path / "output"
+        sub_dir = watch_dir / "results"
+        sub_dir.mkdir(parents=True)
+        (sub_dir / "existing.json").write_text("{}")
+
+        async def mock_runner(cmd, **kwargs):
+            return _make_result(returncode=0, stdout=_success_session_json("done"))
+
+        minimal_ctx.runner = mock_runner
+        proj = tmp_path / "proj"
+        proj.mkdir()
+
+        result = await run_headless_core(
+            "/autoskillit:test-skill",
+            str(proj),
+            minimal_ctx,
+            write_watch_dirs=[watch_dir],
+        )
+        assert result.fs_writes_detected is False
+
+
 class TestPlannerSkillEndToEnd:
     """Planner skill that writes via Bash to run dir detected via write_watch_dirs."""
 

--- a/tests/execution/test_zero_write_detection.py
+++ b/tests/execution/test_zero_write_detection.py
@@ -8,7 +8,6 @@ skill classified as write-expected via WriteBehaviorSpec.
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 
 import pytest
@@ -688,20 +687,24 @@ class TestTempDirSnapshot:
 
     def test_snapshot_detects_new_file(self, tmp_path: Path) -> None:
         """A file created between pre and post snapshot is detected."""
+        from autoskillit.execution.headless import _recursive_snapshot
+
         temp_dir = tmp_path / ".autoskillit" / "temp" / "prepare-pr"
         temp_dir.mkdir(parents=True)
-        pre = {e.name for e in os.scandir(temp_dir)}
+        pre = _recursive_snapshot(temp_dir)
         (temp_dir / "pr_prep_20260425.md").write_text("content")
-        post = {e.name for e in os.scandir(temp_dir)}
+        post = _recursive_snapshot(temp_dir)
         assert len(post - pre) > 0
 
     def test_snapshot_empty_when_no_new_files(self, tmp_path: Path) -> None:
         """No new files between snapshots yields empty diff."""
+        from autoskillit.execution.headless import _recursive_snapshot
+
         temp_dir = tmp_path / ".autoskillit" / "temp" / "prepare-pr"
         temp_dir.mkdir(parents=True)
         (temp_dir / "existing.md").write_text("content")
-        pre = {e.name for e in os.scandir(temp_dir)}
-        post = {e.name for e in os.scandir(temp_dir)}
+        pre = _recursive_snapshot(temp_dir)
+        post = _recursive_snapshot(temp_dir)
         assert post - pre == set()
 
 


### PR DESCRIPTION
## Summary

The write-evidence filesystem detection mechanism (`fs_writes_detected`) in `headless.py` uses flat `os.scandir` to compare pre/post directory snapshots. This makes the mechanism structurally blind to writes landing inside pre-existing subdirectories — a class of false positive that has recurred 5 times. The architectural fix replaces flat scanning with recursive file enumeration via `os.walk`, making the detection immune to nesting depth. Additionally, the three planner recipe steps with `output_dir` mismatches are corrected to point at the actual write locations.

Closes #1736

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260503-155504-969550/.autoskillit/temp/rectify/rectify_planner_refine_assignments_zero_writes_false_positive_2026-05-03_155504.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| investigate | 53 | 7.1k | 930.0k | 68.6k | 1 | 3m 5s |
| rectify | 5.7k | 10.9k | 776.3k | 61.1k | 1 | 9m 0s |
| dry_walkthrough | 795 | 11.9k | 762.3k | 79.4k | 2 | 8m 21s |
| implement | 2.0k | 11.2k | 1.7M | 59.9k | 1 | 6m 51s |
| prepare_pr | 24 | 3.1k | 188.7k | 28.8k | 1 | 1m 10s |
| compose_pr | 22 | 1.4k | 129.9k | 18.3k | 1 | 34s |
| review_pr | 1.1k | 17.3k | 485.5k | 48.0k | 1 | 4m 56s |
| resolve_review | 52 | 8.8k | 1.1M | 45.8k | 1 | 6m 37s |
| ci_conflict_fix | 33 | 3.1k | 601.0k | 37.1k | 1 | 1m 33s |
| **Total** | 9.8k | 74.8k | 6.7M | 446.9k | | 42m 11s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 120 | 13961.5 | 499.0 | 93.4 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| ci_conflict_fix | 4679 | 128.5 | 7.9 | 0.7 |
| **Total** | **4799** | 1394.2 | 93.1 | 15.6 |