### PR TITLE
Implementation Plan: [P1-A1-WP1] Add 'providers' FeatureDef to FEATURE_REGISTRY

### DIFF
--- a/src/autoskillit/core/types/_type_constants.py
+++ b/src/autoskillit/core/types/_type_constants.py
@@ -429,6 +429,7 @@ FEATURE_REGISTRY: dict[str, FeatureDef] = {
         import_package=None,
         tier=1,
         default_enabled=False,
+        since_version="0.9.351",
     ),
 }
 

--- a/src/autoskillit/core/types/_type_constants.py
+++ b/src/autoskillit/core/types/_type_constants.py
@@ -418,6 +418,18 @@ FEATURE_REGISTRY: dict[str, FeatureDef] = {
         default_enabled=False,
         since_version="0.9.119",
     ),
+    "providers": FeatureDef(
+        lifecycle=FeatureLifecycle.EXPERIMENTAL,
+        description=(
+            "Provider routing — route recipe steps to a non-Anthropic LLM"
+            " provider (e.g. MiniMax M2.7-highspeed)"
+        ),
+        tool_tags=frozenset(),
+        skill_categories=frozenset(),
+        import_package=None,
+        tier=1,
+        default_enabled=False,
+    ),
 }
 
 RETIRED_FEATURES: frozenset[str] = frozenset()

--- a/tests/arch/test_feature_registry.py
+++ b/tests/arch/test_feature_registry.py
@@ -322,6 +322,15 @@ def test_build_features_dict_franchise_raises_config_schema_error():
         AutomationConfig._build_features_dict({"franchise": True})
 
 
+# ── Providers feature registry tests ─────────────────────────────────────────
+
+
+def test_providers_in_feature_registry():
+    from autoskillit.core.types._type_constants import FEATURE_REGISTRY
+
+    assert "providers" in FEATURE_REGISTRY
+
+
 # ── T1: DISABLED lifecycle ──────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Register `"providers"` as an `EXPERIMENTAL` feature in `FEATURE_REGISTRY` within `src/autoskillit/core/types/_type_constants.py`. This is a pure data-model gate with no associated tool tags, skill categories, or import package — it enables downstream work packages (#1750, #1752, #1754) to build the provider routing infrastructure behind a feature flag.

The change is a single dict entry addition. All existing structural tests and import-time guards automatically validate the new entry.

Closes #1742

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260503-191844-032871/.autoskillit/temp/make-plan/p1_a1_wp1_add_providers_featuredef_plan_2026-05-03_191900.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 60 | 8.4k | 787.0k | 58.9k | 1 | 4m 52s |
| verify | 27 | 3.4k | 384.9k | 45.1k | 1 | 1m 56s |
| implement | 124 | 4.4k | 531.0k | 29.0k | 1 | 1m 51s |
| prepare_pr | 84 | 4.3k | 312.4k | 26.0k | 1 | 1m 13s |
| compose_pr | 59 | 2.0k | 194.9k | 19.5k | 1 | 46s |
| review_pr | 76 | 17.6k | 352.3k | 46.2k | 1 | 4m 22s |
| resolve_review | 189 | 9.4k | 1.1M | 48.6k | 1 | 6m 41s |
| ci_conflict_fix | 180 | 5.7k | 1.2M | 64.6k | 1 | 2m 26s |
| **Total** | 799 | 55.2k | 4.8M | 337.9k | | 24m 10s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 14 | 37926.7 | 2072.9 | 317.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 10 | 107647.8 | 4857.6 | 936.8 |
| ci_conflict_fix | 152 | 7631.6 | 424.8 | 37.4 |
| **Total** | **176** | 27266.8 | 1919.7 | 313.6 |