### PR TITLE
Set experiment_plan_path to required: true in all 18 exp-lens contracts

### DIFF
--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -822,7 +822,7 @@ skills:
       required: false
     - name: experiment_plan_path
       type: file_path
-      required: false
+      required: true
     - name: project_context
       type: string
       required: false
@@ -841,7 +841,7 @@ skills:
       required: false
     - name: experiment_plan_path
       type: file_path
-      required: false
+      required: true
     - name: project_context
       type: string
       required: false
@@ -860,7 +860,7 @@ skills:
       required: false
     - name: experiment_plan_path
       type: file_path
-      required: false
+      required: true
     - name: project_context
       type: string
       required: false
@@ -879,7 +879,7 @@ skills:
       required: false
     - name: experiment_plan_path
       type: file_path
-      required: false
+      required: true
     - name: project_context
       type: string
       required: false
@@ -898,7 +898,7 @@ skills:
       required: false
     - name: experiment_plan_path
       type: file_path
-      required: false
+      required: true
     - name: project_context
       type: string
       required: false
@@ -917,7 +917,7 @@ skills:
       required: false
     - name: experiment_plan_path
       type: file_path
-      required: false
+      required: true
     - name: project_context
       type: string
       required: false
@@ -936,7 +936,7 @@ skills:
       required: false
     - name: experiment_plan_path
       type: file_path
-      required: false
+      required: true
     - name: project_context
       type: string
       required: false
@@ -955,7 +955,7 @@ skills:
       required: false
     - name: experiment_plan_path
       type: file_path
-      required: false
+      required: true
     - name: project_context
       type: string
       required: false
@@ -974,7 +974,7 @@ skills:
       required: false
     - name: experiment_plan_path
       type: file_path
-      required: false
+      required: true
     - name: project_context
       type: string
       required: false
@@ -993,7 +993,7 @@ skills:
       required: false
     - name: experiment_plan_path
       type: file_path
-      required: false
+      required: true
     - name: project_context
       type: string
       required: false
@@ -1012,7 +1012,7 @@ skills:
       required: false
     - name: experiment_plan_path
       type: file_path
-      required: false
+      required: true
     - name: project_context
       type: string
       required: false
@@ -1031,7 +1031,7 @@ skills:
       required: false
     - name: experiment_plan_path
       type: file_path
-      required: false
+      required: true
     - name: project_context
       type: string
       required: false
@@ -1050,7 +1050,7 @@ skills:
       required: false
     - name: experiment_plan_path
       type: file_path
-      required: false
+      required: true
     - name: project_context
       type: string
       required: false
@@ -1069,7 +1069,7 @@ skills:
       required: false
     - name: experiment_plan_path
       type: file_path
-      required: false
+      required: true
     - name: project_context
       type: string
       required: false
@@ -1088,7 +1088,7 @@ skills:
       required: false
     - name: experiment_plan_path
       type: file_path
-      required: false
+      required: true
     - name: project_context
       type: string
       required: false
@@ -1107,7 +1107,7 @@ skills:
       required: false
     - name: experiment_plan_path
       type: file_path
-      required: false
+      required: true
     - name: project_context
       type: string
       required: false
@@ -1126,7 +1126,7 @@ skills:
       required: false
     - name: experiment_plan_path
       type: file_path
-      required: false
+      required: true
     - name: project_context
       type: string
       required: false
@@ -1145,7 +1145,7 @@ skills:
       required: false
     - name: experiment_plan_path
       type: file_path
-      required: false
+      required: true
     - name: project_context
       type: string
       required: false

--- a/tests/contracts/test_skill_contracts.py
+++ b/tests/contracts/test_skill_contracts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
+from typing import Any, Final
 
 import pytest
 import yaml
@@ -158,6 +159,54 @@ def test_all_exp_lens_skills_have_contracts(skills):
     ]
     missing = [name for name in exp_lens if name not in skills]
     assert not missing, f"exp-lens skills missing contracts: {sorted(missing)}"
+
+
+_EXP_LENS_SKILLS: Final[list[str]] = [
+    "exp-lens-estimand-clarity",
+    "exp-lens-causal-assumptions",
+    "exp-lens-comparator-construction",
+    "exp-lens-pipeline-integrity",
+    "exp-lens-variance-stability",
+    "exp-lens-fair-comparison",
+    "exp-lens-reproducibility-artifacts",
+    "exp-lens-measurement-validity",
+    "exp-lens-sensitivity-robustness",
+    "exp-lens-benchmark-representativeness",
+    "exp-lens-unit-interference",
+    "exp-lens-error-budget",
+    "exp-lens-severity-testing",
+    "exp-lens-randomization-blocking",
+    "exp-lens-validity-threats",
+    "exp-lens-iterative-learning",
+    "exp-lens-exploratory-confirmatory",
+    "exp-lens-governance-risk",
+]
+
+
+@pytest.mark.parametrize("skill_name", _EXP_LENS_SKILLS)
+def test_exp_lens_experiment_plan_path_is_required(
+    skills: dict[str, Any], skill_name: str
+) -> None:
+    """experiment_plan_path must be required: true on all exp-lens contracts."""
+    contract = skills[skill_name]
+    inp = next(
+        (i for i in contract["inputs"] if i["name"] == "experiment_plan_path"),
+        None,
+    )
+    assert inp is not None, f"{skill_name}: missing experiment_plan_path input"
+    assert inp["required"] is True, f"{skill_name}: experiment_plan_path must be required: true"
+
+
+@pytest.mark.parametrize("skill_name", _EXP_LENS_SKILLS)
+def test_exp_lens_context_path_remains_optional(skills: dict[str, Any], skill_name: str) -> None:
+    """context_path must remain required: false on all exp-lens contracts."""
+    contract = skills[skill_name]
+    inp = next(
+        (i for i in contract["inputs"] if i["name"] == "context_path"),
+        None,
+    )
+    assert inp is not None, f"{skill_name}: missing context_path input"
+    assert inp["required"] is False, f"{skill_name}: context_path must remain required: false"
 
 
 def test_skill_contracts_yaml_includes_prepare_research_pr(skills):

--- a/tests/contracts/test_skill_contracts.py
+++ b/tests/contracts/test_skill_contracts.py
@@ -161,26 +161,11 @@ def test_all_exp_lens_skills_have_contracts(skills):
     assert not missing, f"exp-lens skills missing contracts: {sorted(missing)}"
 
 
-_EXP_LENS_SKILLS: Final[list[str]] = [
-    "exp-lens-estimand-clarity",
-    "exp-lens-causal-assumptions",
-    "exp-lens-comparator-construction",
-    "exp-lens-pipeline-integrity",
-    "exp-lens-variance-stability",
-    "exp-lens-fair-comparison",
-    "exp-lens-reproducibility-artifacts",
-    "exp-lens-measurement-validity",
-    "exp-lens-sensitivity-robustness",
-    "exp-lens-benchmark-representativeness",
-    "exp-lens-unit-interference",
-    "exp-lens-error-budget",
-    "exp-lens-severity-testing",
-    "exp-lens-randomization-blocking",
-    "exp-lens-validity-threats",
-    "exp-lens-iterative-learning",
-    "exp-lens-exploratory-confirmatory",
-    "exp-lens-governance-risk",
-]
+_EXP_LENS_SKILLS: Final[list[str]] = sorted(
+    name
+    for name in yaml.safe_load(_CONTRACTS_YAML.read_text()).get("skills", {})
+    if name.startswith("exp-lens-")
+)
 
 
 @pytest.mark.parametrize("skill_name", _EXP_LENS_SKILLS)


### PR DESCRIPTION
## Summary

Change `experiment_plan_path` from `required: false` to `required: true` on all 18 `exp-lens-*` entries in `src/autoskillit/recipe/skill_contracts.yaml`. Add a parametrized test to lock in the new contract. Leave `context_path` and `project_context` as `required: false`.

This is a safe, scoped YAML edit. The exp-lens skills are invoked positionally in `research.yaml` via `{slug}` dynamic name resolution, so `resolve_skill_name()` returns `None` and all contract validation rules (`generate_recipe_card`, `missing-ingredient`, `shadowed-required-input`, `rules_contracts.py`) skip the step entirely. No existing test or validation will break.

Closes #1043

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260503-200519-662873/.autoskillit/temp/make-plan/set_experiment_plan_path_required_plan_2026-05-03_200900.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 62 | 6.6k | 682.5k | 38.2k | 1 | 6m 1s |
| verify | 29 | 3.9k | 454.4k | 40.1k | 1 | 3m 14s |
| implement | 188 | 9.8k | 954.0k | 43.3k | 1 | 3m 54s |
| prepare_pr | 60 | 4.1k | 195.8k | 39.8k | 1 | 1m 11s |
| compose_pr | 59 | 1.7k | 193.6k | 19.3k | 1 | 42s |
| review_pr | 126 | 16.0k | 608.7k | 45.2k | 1 | 4m 24s |
| resolve_review | 221 | 10.1k | 1.2M | 64.5k | 1 | 6m 37s |
| **Total** | 745 | 52.2k | 4.3M | 290.3k | | 26m 6s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 85 | 11223.0 | 509.4 | 115.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 25 | 49580.6 | 2578.4 | 404.2 |
| **Total** | **110** | 39349.1 | 2639.1 | 474.8 |