### PR TITLE
Implementation Plan: Route run_experiment Failures Through troubleshoot-experiment Diagnosis

### DIFF
--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -347,8 +347,29 @@ steps:
       experiment_results: "${{ result.results_path }}"
     retries: 2
     on_success: generate_report
-    on_failure: adjust_experiment
+    on_failure: troubleshoot_run_failure
     on_exhausted: ensure_results
+
+  troubleshoot_run_failure:
+    tool: run_skill
+    stale_threshold: 2400
+    idle_output_timeout: 0
+    with:
+      skill_command: "/autoskillit:troubleshoot-experiment ${{ context.worktree_path }} run_experiment"
+      cwd: "${{ inputs.source_dir }}"
+      step_name: troubleshoot_run
+    capture:
+      run_failure_type: "${{ result.failure_type }}"
+      run_is_fixable: "${{ result.is_fixable }}"
+    on_success: route_run_failure
+    on_failure: escalate_stop
+
+  route_run_failure:
+    action: route
+    on_result:
+      - when: "${{ context.run_is_fixable }} == true"
+        route: adjust_experiment
+      - route: escalate_stop
 
   adjust_experiment:
     tool: run_skill

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -357,7 +357,7 @@ steps:
     with:
       skill_command: "/autoskillit:troubleshoot-experiment ${{ context.worktree_path }} run_experiment"
       cwd: "${{ inputs.source_dir }}"
-      step_name: troubleshoot_run
+      step_name: troubleshoot_run_failure
     capture:
       run_is_fixable: "${{ result.is_fixable }}"
     on_success: route_run_failure

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -359,7 +359,6 @@ steps:
       cwd: "${{ inputs.source_dir }}"
       step_name: troubleshoot_run
     capture:
-      run_failure_type: "${{ result.failure_type }}"
       run_is_fixable: "${{ result.is_fixable }}"
     on_success: route_run_failure
     on_failure: escalate_stop

--- a/tests/recipe/test_research_recipe_diag.py
+++ b/tests/recipe/test_research_recipe_diag.py
@@ -131,10 +131,9 @@ def test_research_recipe_has_troubleshoot_run_steps(recipe):
 
 
 def test_troubleshoot_run_captures_required_tokens(recipe):
-    """troubleshoot_run_failure must capture run_failure_type and run_is_fixable."""
+    """troubleshoot_run_failure must capture run_is_fixable for downstream routing."""
     step = recipe.steps["troubleshoot_run_failure"]
     capture = step.capture or {}
-    assert "run_failure_type" in capture
     assert "run_is_fixable" in capture
 
 

--- a/tests/recipe/test_research_recipe_diag.py
+++ b/tests/recipe/test_research_recipe_diag.py
@@ -115,3 +115,63 @@ def test_run_experiment_lenses_has_capture_list_for_diagram_paths(recipe):
 def test_stage_bundle_exists(recipe):
     """stage_bundle step must exist in the recipe."""
     assert "stage_bundle" in recipe.steps, "research.yaml must have a stage_bundle step"
+
+
+def test_run_experiment_failure_routes_to_troubleshoot(recipe):
+    """run_experiment on_failure must route to troubleshoot_run_failure."""
+    step = recipe.steps["run_experiment"]
+    assert step.on_failure == "troubleshoot_run_failure"
+
+
+def test_research_recipe_has_troubleshoot_run_steps(recipe):
+    """research.yaml must contain the troubleshoot_run_failure and route_run_failure steps."""
+    step_names = list(recipe.steps.keys())
+    assert "troubleshoot_run_failure" in step_names
+    assert "route_run_failure" in step_names
+
+
+def test_troubleshoot_run_captures_required_tokens(recipe):
+    """troubleshoot_run_failure must capture run_failure_type and run_is_fixable."""
+    step = recipe.steps["troubleshoot_run_failure"]
+    capture = step.capture or {}
+    assert "run_failure_type" in capture
+    assert "run_is_fixable" in capture
+
+
+def test_troubleshoot_run_uses_run_experiment_step_name(recipe):
+    """troubleshoot_run_failure skill_command must pass run_experiment, not implement_phase."""
+    step = recipe.steps["troubleshoot_run_failure"]
+    skill_cmd = step.with_args.get("skill_command", "")
+    assert "troubleshoot-experiment" in skill_cmd
+    assert "run_experiment" in skill_cmd
+    assert "implement_phase" not in skill_cmd
+
+
+def test_route_run_failure_routes_fixable_to_adjust(recipe):
+    """route_run_failure must route fixable failures to adjust_experiment."""
+    step = recipe.steps["route_run_failure"]
+    assert step.action == "route"
+    conditions = step.on_result.conditions
+    fixable_cond = next(c for c in conditions if c.when and "run_is_fixable" in c.when)
+    assert fixable_cond.route == "adjust_experiment"
+
+
+def test_route_run_failure_default_escalates(recipe):
+    """route_run_failure catch-all must route to escalate_stop."""
+    step = recipe.steps["route_run_failure"]
+    conditions = step.on_result.conditions
+    default_cond = next(c for c in conditions if c.when is None)
+    assert default_cond.route == "escalate_stop"
+
+
+def test_adjust_experiment_routing_unchanged(recipe):
+    """adjust_experiment routing must remain unchanged after run_failure routing is added."""
+    step = recipe.steps["adjust_experiment"]
+    assert step.on_success == "run_experiment"
+    assert step.on_failure == "ensure_results"
+
+
+def test_run_experiment_exhausted_unchanged(recipe):
+    """run_experiment on_exhausted must still route to ensure_results."""
+    step = recipe.steps["run_experiment"]
+    assert step.on_exhausted == "ensure_results"


### PR DESCRIPTION
## Summary

Add a `troubleshoot_run_failure` → `route_run_failure` step pair to `research.yaml` that mirrors the existing `troubleshoot_implement_failure` → `route_implement_failure` pattern. This wires `run_experiment` catastrophic failures through `troubleshoot-experiment` for structured classification before deciding whether to retry via `adjust_experiment` (fixable) or escalate immediately (non-fixable). Currently, all `run_experiment` failures go directly to `adjust_experiment` — a blind retry that silently produces inconclusive reports for infrastructure failures that can never self-heal.

Closes #1042

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260503-200520-657991/.autoskillit/temp/make-plan/route_run_experiment_failures_plan_2026-05-03_200520.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 47 | 7.5k | 509.0k | 49.5k | 1 | 4m 11s |
| verify | 46 | 12.3k | 1.1M | 63.2k | 1 | 5m 40s |
| implement | 148 | 5.6k | 777.7k | 42.2k | 1 | 1m 57s |
| prepare_pr | 60 | 4.2k | 213.4k | 26.7k | 1 | 1m 26s |
| compose_pr | 59 | 2.3k | 195.7k | 19.8k | 1 | 44s |
| review_pr | 92 | 22.0k | 470.7k | 52.6k | 1 | 4m 40s |
| resolve_review | 221 | 11.5k | 1.3M | 69.5k | 1 | 4m 54s |
| **Total** | 673 | 65.3k | 4.6M | 323.6k | | 23m 35s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 83 | 9369.3 | 508.9 | 67.2 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 2 | 642172.5 | 34743.5 | 5736.5 |
| **Total** | **85** | 53609.4 | 3807.4 | 768.3 |