### PR TITLE
Re-introduce Context-Tracking Tests Deleted by Bundle-Lifecycle Refactor

### DIFF
--- a/tests/recipe/test_research_context_tracking.py
+++ b/tests/recipe/test_research_context_tracking.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from autoskillit.core.paths import pkg_root
+from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
+from autoskillit.recipe.validator import run_semantic_rules, validate_recipe
+
+RESEARCH_RECIPE_PATH = builtin_recipes_dir() / "research.yaml"
+SCRIPTS_DIR = pkg_root().parent.parent / "scripts" / "recipe"
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+_FIND_HEURISTIC_RE = re.compile(r"\bfind\b.+\|\s*sort\b.+\|\s*(tail|head)\b")
+
+
+def _has_find_heuristic(text: str) -> bool:
+    return bool(_FIND_HEURISTIC_RE.search(text))
+
+
+@pytest.fixture(scope="module")
+def recipe():
+    return load_recipe(RESEARCH_RECIPE_PATH)
+
+
+def test_create_worktree_captures_research_dir(recipe):
+    step = recipe.steps["create_worktree"]
+    assert "research_dir" in step.capture, (
+        "create_worktree must capture research_dir for downstream steps"
+    )
+
+
+def test_create_worktree_script_emits_research_dir():
+    script = (SCRIPTS_DIR / "create_worktree.sh").read_text()
+    assert 'echo "research_dir=' in script, (
+        "create_worktree.sh must emit research_dir= to stdout for capture"
+    )
+
+
+def test_finalize_bundle_uses_context_research_dir(recipe):
+    step = recipe.steps["finalize_bundle"]
+    cmd = step.with_args.get("cmd", "")
+    assert "context.research_dir" in cmd, (
+        "finalize_bundle must source research_dir from context, not re-discover it"
+    )
+
+
+def test_finalize_bundle_no_find_heuristic(recipe):
+    step = recipe.steps["finalize_bundle"]
+    cmd = step.with_args.get("cmd", "")
+    assert not _has_find_heuristic(cmd), (
+        "finalize_bundle cmd uses find|sort|tail heuristic — "
+        "must use context.research_dir instead"
+    )
+    script = (SCRIPTS_DIR / "finalize_bundle.sh").read_text()
+    assert not _has_find_heuristic(script), (
+        "finalize_bundle.sh uses find|sort|tail heuristic — "
+        "must use positional arg from context.research_dir instead"
+    )
+
+
+def test_create_artifact_branch_scopes_via_research_dir(recipe):
+    step = recipe.steps["create_artifact_branch"]
+    cmd = step.with_args.get("cmd", "")
+    assert "context.research_dir" in cmd, (
+        "create_artifact_branch must pass context.research_dir to script"
+    )
+    script = (SCRIPTS_DIR / "create_artifact_branch.sh").read_text()
+    assert "basename" in script, (
+        "create_artifact_branch.sh must use basename to scope checkout"
+    )
+
+
+def test_finalize_bundle_has_post_compression_guard():
+    script = (SCRIPTS_DIR / "finalize_bundle.sh").read_text()
+    assert "artifacts.tar.gz" in script and "exit 1" in script, (
+        "finalize_bundle.sh must fail loudly if artifacts.tar.gz is absent"
+    )
+
+
+def test_research_recipe_passes_semantic_rules(recipe):
+    errors = validate_recipe(recipe)
+    assert not errors, f"Structural validation errors: {errors}"
+    findings = run_semantic_rules(recipe)
+    error_findings = [f for f in findings if f.severity.value == "error"]
+    assert not error_findings, (
+        f"Semantic rule errors: {[f'{f.rule}: {f.message}' for f in error_findings]}"
+    )

--- a/tests/recipe/test_research_context_tracking.py
+++ b/tests/recipe/test_research_context_tracking.py
@@ -33,7 +33,9 @@ def test_create_worktree_captures_research_dir(recipe):
 
 
 def test_create_worktree_script_emits_research_dir():
-    script = (SCRIPTS_DIR / "create_worktree.sh").read_text()
+    script_path = SCRIPTS_DIR / "create_worktree.sh"
+    assert script_path.exists(), f"create_worktree.sh not found at {script_path}"
+    script = script_path.read_text()
     assert 'echo "research_dir=' in script, (
         "create_worktree.sh must emit research_dir= to stdout for capture"
     )
@@ -51,10 +53,11 @@ def test_finalize_bundle_no_find_heuristic(recipe):
     step = recipe.steps["finalize_bundle"]
     cmd = step.with_args.get("cmd", "")
     assert not _has_find_heuristic(cmd), (
-        "finalize_bundle cmd uses find|sort|tail heuristic — "
-        "must use context.research_dir instead"
+        "finalize_bundle cmd uses find|sort|tail heuristic — must use context.research_dir instead"
     )
-    script = (SCRIPTS_DIR / "finalize_bundle.sh").read_text()
+    script_path = SCRIPTS_DIR / "finalize_bundle.sh"
+    assert script_path.exists(), f"finalize_bundle.sh not found at {script_path}"
+    script = script_path.read_text()
     assert not _has_find_heuristic(script), (
         "finalize_bundle.sh uses find|sort|tail heuristic — "
         "must use positional arg from context.research_dir instead"
@@ -67,17 +70,19 @@ def test_create_artifact_branch_scopes_via_research_dir(recipe):
     assert "context.research_dir" in cmd, (
         "create_artifact_branch must pass context.research_dir to script"
     )
-    script = (SCRIPTS_DIR / "create_artifact_branch.sh").read_text()
-    assert "basename" in script, (
-        "create_artifact_branch.sh must use basename to scope checkout"
-    )
+    script_path = SCRIPTS_DIR / "create_artifact_branch.sh"
+    assert script_path.exists(), f"create_artifact_branch.sh not found at {script_path}"
+    script = script_path.read_text()
+    assert "basename" in script, "create_artifact_branch.sh must use basename to scope checkout"
 
 
 def test_finalize_bundle_has_post_compression_guard():
-    script = (SCRIPTS_DIR / "finalize_bundle.sh").read_text()
-    assert "artifacts.tar.gz" in script and "exit 1" in script, (
-        "finalize_bundle.sh must fail loudly if artifacts.tar.gz is absent"
-    )
+    script_path = SCRIPTS_DIR / "finalize_bundle.sh"
+    assert script_path.exists(), f"finalize_bundle.sh not found at {script_path}"
+    script = script_path.read_text()
+    assert re.search(
+        r"artifacts\.tar\.gz[^\n]*\|\|[^\n]*exit\s+1|artifacts\.tar\.gz.*\\\n.*exit\s+1", script
+    ), "finalize_bundle.sh must conditionally exit 1 when artifacts.tar.gz is absent"
 
 
 def test_research_recipe_passes_semantic_rules(recipe):


### PR DESCRIPTION
## Summary

Create `tests/recipe/test_research_context_tracking.py` with 7 assertions that guard the `context.research_dir` data-flow contract through the auto-research recipe pipeline. These assertions were originally in `tests/recipe/test_research_artifact_archive.py` (added by #655), which was deleted wholesale by the bundle-lifecycle refactor (#781, commit 6c4b195a). The surviving `test_research_bundle_lifecycle.py` covers stage/finalize routing but none of the 7 context-tracking invariants. The new file adapts each assertion to the current architecture where recipe steps delegate to external shell scripts under `scripts/recipe/`.

Closes #1044

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260503-200521-075585/.autoskillit/temp/make-plan/re_introduce_context_tracking_tests_plan_2026-05-03_200900.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 3.0k | 10.8k | 777.9k | 49.3k | 1 | 6m 14s |
| verify | 1.6k | 13.8k | 2.0M | 63.0k | 1 | 7m 6s |
| implement | 108 | 5.3k | 474.9k | 31.9k | 1 | 2m 53s |
| prepare_pr | 68 | 4.2k | 252.1k | 28.0k | 1 | 1m 9s |
| compose_pr | 67 | 2.7k | 251.6k | 26.1k | 1 | 53s |
| review_pr | 116 | 19.6k | 579.8k | 47.7k | 1 | 4m 11s |
| resolve_review | 317 | 16.5k | 2.1M | 58.5k | 1 | 5m 43s |
| **Total** | 5.3k | 72.8k | 6.4M | 304.6k | | 28m 12s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 90 | 5276.3 | 354.9 | 58.4 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 29 | 71224.9 | 2017.8 | 569.1 |
| **Total** | **119** | 54191.8 | 2559.5 | 611.7 |