### PR TITLE
feat: prefer diff_hunk over source file reads in resolve-review Step 3.5

### DIFF
--- a/src/autoskillit/skills_extended/resolve-review/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-review/SKILL.md
@@ -238,13 +238,20 @@ their `path` field:
 - `src/autoskillit/server/tools_ci.py` → group `server`
 
 **Inline classification shortcut:** If there are 3 or fewer findings AND they all
-fall in a single domain group, classify them inline — read each unique file once
-(±30 lines around all flagged lines), run `git log` once per unique path, then
-emit a verdict for each finding — without spawning a Task sub-agent. The
-classification criteria and output format are identical to the sub-agent path.
+fall in a single domain group, classify them inline — use each finding's
+`diff_hunk` as the primary code context, run `git log` once per unique path, then
+emit a verdict for each finding — without spawning a Task sub-agent. Only read
+source files if a comment explicitly references code outside the hunk or the
+`diff_hunk` is missing. The classification criteria and output format are
+identical to the sub-agent path.
 
 This produces 3–6 groups on a typical PR. Launch one parallel sub-agent per group using
 the Task tool (`model: "sonnet"`).
+
+**Context resolution hierarchy** (applied per finding):
+1. **`diff_context_map` code_region** — richest context (±50 annotated diff lines); used when review-pr ran in the same pipeline and wrote the handoff file.
+2. **`diff_hunk` from the review comment** — the unified-diff snippet surrounding the commented line; always available from the GitHub API. Sufficient for most classification tasks (naming, patterns, style).
+3. **Source file read** — last resort (±30 lines); used only when the comment references code outside the hunk or the hunk is truncated/missing.
 
 **Sub-agent prompt template** — each sub-agent receives:
 - The list of comments in its domain group (with `path`, `line`, `body`, `diff_hunk`)
@@ -252,9 +259,16 @@ the Task tool (`model: "sonnet"`).
   `(path, line)` is available in `diff_context_map`, include it directly in the prompt
   under "Pre-built code region (from review-pr, ±50 diff lines):" and instruct the
   sub-agent to use it — do **not** instruct it to read the file for context. If
-  `diff_context_map` has no entry for this finding, instruct the sub-agent: "For each unique file in the group, read the file
-  once, spanning all flagged lines with ±30 lines margin. Classify each
-  finding from the already-read content — do not re-read the file per finding."
+  `diff_context_map` has no entry for this finding, use the comment's `diff_hunk`
+  as the primary code context — include it directly in the prompt under
+  "Code context (diff_hunk from review comment):" and instruct the sub-agent to
+  classify the finding using this hunk. Only instruct the sub-agent to read the
+  source file if: (a) the review comment body explicitly references code outside
+  the hunk (e.g., "see the function above", "this conflicts with the import at
+  line N", "look at the caller in X.py"), or (b) the `diff_hunk` is truncated
+  or missing (empty string). When a file read IS needed, read each unique file
+  once, spanning all flagged lines with ±30 lines margin — do not re-read per
+  finding.
 - Instructions to run `git log --follow -p --max-count=5 -- {path}` once per unique path (not once per finding) to trace original intent
 - Instructions to classify each comment as `ACCEPT`, `REJECT`, or `DISCUSS` with:
   - `verdict`: the classification (`ACCEPT` / `REJECT` / `DISCUSS`)
@@ -283,8 +297,18 @@ Use the above region for context. Do NOT read the file — the region is already
 Run `git log --follow -p --max-count=5 -- {path}` for history context as usual.
 ```
 
-When `diff_context_map` has no entry: fall back to current behavior — instruct the
-sub-agent to read `±30 lines` from the file.
+When `diff_context_map` has no entry but `diff_hunk` is present (non-empty):
+```
+Code context (diff_hunk from review comment):
+{comment.diff_hunk}
+
+Use the above hunk for classification context. Only read the source file if:
+(a) the comment body references code outside this hunk, or (b) you need
+additional context not visible in the hunk. Run `git log` for history as usual.
+```
+
+When `diff_context_map` has no entry AND `diff_hunk` is empty or missing:
+fall back to reading the file at `±30 lines` from the flagged line.
 
 **Fallback:** If a sub-agent fails or times out, classify all comments in that group as
 `DISCUSS` (safe fallback — no code is changed, human reviews). Log the failure including

--- a/tests/skills/test_resolve_review_diff_hunk_preference.py
+++ b/tests/skills/test_resolve_review_diff_hunk_preference.py
@@ -1,0 +1,101 @@
+"""Guards: resolve-review Step 3.5 prefers diff_hunk over source file reads.
+
+Enforces the 3-tier context resolution hierarchy:
+  Tier 1: diff_context_map pre-built code_region (richest, from review-pr handoff)
+  Tier 2: diff_hunk from the GitHub API review comment (always available)
+  Tier 3: source file read (last resort — only when hunk is insufficient)
+"""
+
+from pathlib import Path
+
+SKILL_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src"
+    / "autoskillit"
+    / "skills_extended"
+    / "resolve-review"
+    / "SKILL.md"
+)
+assert SKILL_PATH.exists(), f"SKILL.md not found at {SKILL_PATH}"
+SKILL_TEXT = SKILL_PATH.read_text()
+
+
+def _step35_section() -> str:
+    start = SKILL_TEXT.find("### Step 3.5")
+    assert start != -1, "### Step 3.5 not found in SKILL.md"
+    end = SKILL_TEXT.find("### Step 4", start)
+    return SKILL_TEXT[start:end]
+
+
+def test_diff_hunk_documented_as_preferred_context_in_step35() -> None:
+    section = _step35_section().lower()
+    assert (
+        "use" in section
+        and "diff_hunk" in section
+        and "context" in section
+    ), "Step 3.5 must document diff_hunk as a preferred context source"
+
+
+def test_file_read_conditional_on_hunk_insufficiency() -> None:
+    section = _step35_section().lower()
+    assert (
+        "only" in section
+        and "read" in section
+        and ("source file" in section or "file" in section)
+        and ("if" in section)
+    ), "Source file reads must be conditional on hunk insufficiency"
+
+
+def test_external_reference_documented_as_file_read_trigger() -> None:
+    section = _step35_section().lower()
+    assert (
+        "outside" in section
+        and "hunk" in section
+    ), "Step 3.5 must document external references as a file-read trigger"
+
+
+def test_truncated_hunk_documented_as_file_read_trigger() -> None:
+    section = _step35_section().lower()
+    assert (
+        "truncated" in section or "missing" in section
+    ), "Step 3.5 must document truncated/missing hunk as a file-read trigger"
+
+
+def test_inline_shortcut_prefers_diff_hunk() -> None:
+    section = _step35_section().lower()
+    shortcut_start = section.find("inline classification shortcut")
+    assert shortcut_start != -1, "Inline classification shortcut not found"
+    shortcut_text = section[shortcut_start:shortcut_start + 600]
+    assert "diff_hunk" in shortcut_text, (
+        "Inline classification shortcut must mention diff_hunk"
+    )
+
+
+def test_three_tier_hierarchy_documented() -> None:
+    section = _step35_section()
+    hierarchy_start = section.find("Context resolution hierarchy")
+    assert hierarchy_start != -1, "Context resolution hierarchy not found in Step 3.5"
+    hierarchy = section[hierarchy_start:hierarchy_start + 600]
+    pos_dcm = hierarchy.find("diff_context_map")
+    pos_hunk = hierarchy.find("diff_hunk")
+    pos_file_read = hierarchy.lower().find("source file read")
+    if pos_file_read == -1:
+        pos_file_read = hierarchy.lower().find("file read")
+    assert pos_dcm != -1, "diff_context_map not found in hierarchy"
+    assert pos_hunk != -1, "diff_hunk not found in hierarchy"
+    assert pos_file_read != -1, "file read fallback not found in hierarchy"
+    assert pos_dcm < pos_hunk < pos_file_read, (
+        "Three-tier hierarchy must be in order: diff_context_map > diff_hunk > file read"
+    )
+
+
+def test_diff_hunk_not_just_passthrough_field() -> None:
+    section = _step35_section().lower()
+    assert (
+        "use the" in section
+        and "diff_hunk" in section
+    ) or (
+        "use" in section
+        and "diff_hunk" in section
+        and "context" in section
+    ), "Step 3.5 must have a directive to USE diff_hunk, not just list it"

--- a/tests/skills/test_resolve_review_diff_hunk_preference.py
+++ b/tests/skills/test_resolve_review_diff_hunk_preference.py
@@ -16,15 +16,16 @@ SKILL_PATH = (
     / "resolve-review"
     / "SKILL.md"
 )
-assert SKILL_PATH.exists(), f"SKILL.md not found at {SKILL_PATH}"
-SKILL_TEXT = SKILL_PATH.read_text()
 
 
 def _step35_section() -> str:
-    start = SKILL_TEXT.find("### Step 3.5")
+    assert SKILL_PATH.exists(), f"SKILL.md not found at {SKILL_PATH}"
+    text = SKILL_PATH.read_text()
+    start = text.find("### Step 3.5")
     assert start != -1, "### Step 3.5 not found in SKILL.md"
-    end = SKILL_TEXT.find("### Step 4", start)
-    return SKILL_TEXT[start:end]
+    end = text.find("### Step 4", start)
+    assert end != -1, "### Step 4 not found after Step 3.5 in SKILL.md"
+    return text[start:end]
 
 
 def test_diff_hunk_documented_as_preferred_context_in_step35() -> None:

--- a/tests/skills/test_resolve_review_diff_hunk_preference.py
+++ b/tests/skills/test_resolve_review_diff_hunk_preference.py
@@ -29,11 +29,9 @@ def _step35_section() -> str:
 
 def test_diff_hunk_documented_as_preferred_context_in_step35() -> None:
     section = _step35_section().lower()
-    assert (
-        "use" in section
-        and "diff_hunk" in section
-        and "context" in section
-    ), "Step 3.5 must document diff_hunk as a preferred context source"
+    assert "use" in section and "diff_hunk" in section and "context" in section, (
+        "Step 3.5 must document diff_hunk as a preferred context source"
+    )
 
 
 def test_file_read_conditional_on_hunk_insufficiency() -> None:
@@ -48,34 +46,31 @@ def test_file_read_conditional_on_hunk_insufficiency() -> None:
 
 def test_external_reference_documented_as_file_read_trigger() -> None:
     section = _step35_section().lower()
-    assert (
-        "outside" in section
-        and "hunk" in section
-    ), "Step 3.5 must document external references as a file-read trigger"
+    assert "outside" in section and "hunk" in section, (
+        "Step 3.5 must document external references as a file-read trigger"
+    )
 
 
 def test_truncated_hunk_documented_as_file_read_trigger() -> None:
     section = _step35_section().lower()
-    assert (
-        "truncated" in section or "missing" in section
-    ), "Step 3.5 must document truncated/missing hunk as a file-read trigger"
+    assert "truncated" in section or "missing" in section, (
+        "Step 3.5 must document truncated/missing hunk as a file-read trigger"
+    )
 
 
 def test_inline_shortcut_prefers_diff_hunk() -> None:
     section = _step35_section().lower()
     shortcut_start = section.find("inline classification shortcut")
     assert shortcut_start != -1, "Inline classification shortcut not found"
-    shortcut_text = section[shortcut_start:shortcut_start + 600]
-    assert "diff_hunk" in shortcut_text, (
-        "Inline classification shortcut must mention diff_hunk"
-    )
+    shortcut_text = section[shortcut_start : shortcut_start + 600]
+    assert "diff_hunk" in shortcut_text, "Inline classification shortcut must mention diff_hunk"
 
 
 def test_three_tier_hierarchy_documented() -> None:
     section = _step35_section()
     hierarchy_start = section.find("Context resolution hierarchy")
     assert hierarchy_start != -1, "Context resolution hierarchy not found in Step 3.5"
-    hierarchy = section[hierarchy_start:hierarchy_start + 600]
+    hierarchy = section[hierarchy_start : hierarchy_start + 600]
     pos_dcm = hierarchy.find("diff_context_map")
     pos_hunk = hierarchy.find("diff_hunk")
     pos_file_read = hierarchy.lower().find("source file read")
@@ -91,11 +86,6 @@ def test_three_tier_hierarchy_documented() -> None:
 
 def test_diff_hunk_not_just_passthrough_field() -> None:
     section = _step35_section().lower()
-    assert (
-        "use the" in section
-        and "diff_hunk" in section
-    ) or (
-        "use" in section
-        and "diff_hunk" in section
-        and "context" in section
+    assert ("use the" in section and "diff_hunk" in section) or (
+        "use" in section and "diff_hunk" in section and "context" in section
     ), "Step 3.5 must have a directive to USE diff_hunk, not just list it"


### PR DESCRIPTION
## Summary

Modify `resolve-review/SKILL.md` Step 3.5 to introduce a 3-tier context resolution hierarchy for intent classification. Currently, when `diff_context_map` has no pre-built entry, sub-agents fall back directly to source file reads. The new hierarchy inserts `diff_hunk` (always available from the GitHub API) as the middle tier, demoting source file reads to a last-resort fallback. This eliminates unnecessary file reads that trigger `tests/CLAUDE.md` auto-injection (~5k tokens persisting across all remaining turns) and avoids redundant exploration turns.

**Affected file:** `src/autoskillit/skills_extended/resolve-review/SKILL.md` (SKILL.md-only change)

**New test file:** `tests/skills/test_resolve_review_diff_hunk_preference.py`

Closes #1799

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-1799-20260503-215011-520755/.autoskillit/temp/make-plan/prefer_diff_hunk_over_source_file_reads_plan_2026-05-03_220000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 2.7k | 9.5k | 914.7k | 66.7k | 1 | 5m 55s |
| verify | 38 | 8.8k | 454.2k | 44.2k | 1 | 4m 23s |
| implement | 41 | 7.8k | 905.2k | 37.3k | 1 | 3m 29s |
| prepare_pr | 33 | 3.9k | 164.7k | 23.9k | 1 | 1m 23s |
| compose_pr | 22 | 1.5k | 122.6k | 15.9k | 1 | 58s |
| review_pr | 30 | 22.9k | 492.4k | 50.5k | 1 | 4m 37s |
| resolve_review | 35 | 8.6k | 828.8k | 50.3k | 1 | 6m 16s |
| **Total** | 2.9k | 63.0k | 3.9M | 288.7k | | 27m 4s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 133 | 6806.2 | 280.3 | 58.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 11 | 75349.1 | 4568.4 | 783.1 |
| **Total** | **144** | 26962.2 | 2005.2 | 437.8 |