### PR TITLE
Report peak_context and Turn Count in Token Usage Summary

### DIFF
--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -4,8 +4,6 @@ from ._install_detect import _is_release_tag as _is_release_tag
 from ._install_detect import _is_stable_track as _is_stable_track
 from ._install_detect import is_dev_install as is_dev_install
 from ._install_detect import parse_direct_url as parse_direct_url
-from .runtime._linux_proc import read_boot_id as read_boot_id
-from .runtime._linux_proc import read_starttime_ticks as read_starttime_ticks
 from ._plugin_cache import _InstallLock as _InstallLock
 from ._plugin_cache import _retire_old_versions as _retire_old_versions
 from ._plugin_cache import any_kitchen_open as any_kitchen_open
@@ -43,11 +41,6 @@ from .io import load_yaml as load_yaml
 from .io import resolve_temp_dir as resolve_temp_dir
 from .io import temp_dir_display_str as temp_dir_display_str
 from .io import write_versioned_json as write_versioned_json
-from .runtime.kitchen_state import KitchenMarker as KitchenMarker
-from .runtime.kitchen_state import get_state_dir as get_state_dir
-from .runtime.kitchen_state import is_marker_fresh as is_marker_fresh
-from .runtime.kitchen_state import read_marker as read_marker
-from .runtime.kitchen_state import sweep_stale_markers as sweep_stale_markers
 from .logging import configure_logging as configure_logging
 from .logging import get_logger as get_logger
 from .paths import GENERATED_FILES as GENERATED_FILES
@@ -57,6 +50,13 @@ from .paths import find_latest_session_id as find_latest_session_id
 from .paths import is_git_main_checkout as is_git_main_checkout
 from .paths import is_git_worktree as is_git_worktree
 from .paths import pkg_root as pkg_root
+from .runtime._linux_proc import read_boot_id as read_boot_id
+from .runtime._linux_proc import read_starttime_ticks as read_starttime_ticks
+from .runtime.kitchen_state import KitchenMarker as KitchenMarker
+from .runtime.kitchen_state import get_state_dir as get_state_dir
+from .runtime.kitchen_state import is_marker_fresh as is_marker_fresh
+from .runtime.kitchen_state import read_marker as read_marker
+from .runtime.kitchen_state import sweep_stale_markers as sweep_stale_markers
 from .runtime.readiness import cleanup_readiness_sentinel as cleanup_readiness_sentinel
 from .runtime.readiness import readiness_sentinel_path as readiness_sentinel_path
 from .runtime.readiness import write_readiness_sentinel as write_readiness_sentinel

--- a/src/autoskillit/execution/session/_session_model.py
+++ b/src/autoskillit/execution/session/_session_model.py
@@ -197,6 +197,8 @@ def extract_token_usage(stdout: str) -> dict[str, Any] | None:
 
     model_buckets: dict[str, dict[str, int]] = {}
     result_usage: dict[str, int] | None = None
+    peak_context = 0
+    turn_count = 0
 
     for line in stdout.strip().splitlines():
         line = line.strip()
@@ -221,6 +223,10 @@ def extract_token_usage(stdout: str) -> dict[str, Any] | None:
             bucket = model_buckets.setdefault(model, {f: 0 for f in _TOKEN_FIELDS})
             for f in _TOKEN_FIELDS:
                 bucket[f] += usage.get(f, 0)
+            cr = usage.get("cache_read_input_tokens", 0)
+            if cr > peak_context:
+                peak_context = cr
+            turn_count += 1
         elif record_type == "result":
             usage = obj.get("usage")
             if isinstance(usage, dict):
@@ -240,6 +246,8 @@ def extract_token_usage(stdout: str) -> dict[str, Any] | None:
     return {
         **totals,
         "model_breakdown": dict(model_buckets) if model_buckets else {},
+        "peak_context": peak_context,
+        "turn_count": turn_count,
     }
 
 

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -391,6 +391,8 @@ def flush_session_log(
             "order_id": order_id,
             "loc_insertions": loc_insertions,
             "loc_deletions": loc_deletions,
+            "peak_context": token_usage.get("peak_context", 0),
+            "turn_count": token_usage.get("turn_count", 0),
         }
         atomic_write(session_dir / "token_usage.json", json.dumps(tu_data))
 

--- a/src/autoskillit/hooks/formatters/_fmt_status.py
+++ b/src/autoskillit/hooks/formatters/_fmt_status.py
@@ -24,10 +24,14 @@ def _fmt_get_token_summary(data: dict, _pipeline: bool) -> str:
         inp = _fmt_tokens(step.get("input_tokens", 0))
         out = _fmt_tokens(step.get("output_tokens", 0))
         cache_rd = _fmt_tokens(step.get("cache_read_input_tokens", 0))
+        peak_ctx = _fmt_tokens(step.get("peak_context", 0))
         cache_wr = _fmt_tokens(step.get("cache_creation_input_tokens", 0))
+        turns = step.get("turn_count", 0)
         wc = step.get("wall_clock_seconds", step.get("elapsed_seconds", 0.0))
         lines.append(
-            f"{name} x{count} [uc:{inp} out:{out} cr:{cache_rd} cw:{cache_wr} t:{wc:.1f}s]"
+            f"{name} x{count}"
+            f" [uc:{inp} out:{out} cr:{cache_rd} pk:{peak_ctx} cw:{cache_wr}"
+            f" turns:{turns} t:{wc:.1f}s]"
         )
     total = data.get("total", {})
     if total:
@@ -35,6 +39,7 @@ def _fmt_get_token_summary(data: dict, _pipeline: bool) -> str:
         lines.append(f"total_uncached: {_fmt_tokens(total.get('input_tokens', 0))}")
         lines.append(f"total_out: {_fmt_tokens(total.get('output_tokens', 0))}")
         lines.append(f"total_cache_read: {_fmt_tokens(total.get('cache_read_input_tokens', 0))}")
+        lines.append(f"total_peak_context: {_fmt_tokens(total.get('peak_context', 0))}")
         lines.append(
             f"total_cache_write: {_fmt_tokens(total.get('cache_creation_input_tokens', 0))}"
         )

--- a/src/autoskillit/hooks/token_summary_hook.py
+++ b/src/autoskillit/hooks/token_summary_hook.py
@@ -245,7 +245,9 @@ def _load_sessions(
         _raw_peak = data.get("peak_context", 0)
         if isinstance(_raw_peak, int) and _raw_peak > entry["peak_context"]:
             entry["peak_context"] = _raw_peak
-        entry["turn_count"] = entry.get("turn_count", 0) + data.get("turn_count", 0)
+        _raw_turns = data.get("turn_count", 0)
+        if isinstance(_raw_turns, int):
+            entry["turn_count"] = entry.get("turn_count", 0) + _raw_turns
 
     return aggregated
 
@@ -319,25 +321,25 @@ def _format_efficiency_table(aggregated: dict[str, dict[str, Any]]) -> str:
         "| Step | LoC Changed | peak_ctx/LoC | cache_write/LoC | output/LoC |",
         "|------|-------------|--------------|-----------------|------------|",
     ]
-    total_loc = total_cr = total_cw = total_out = 0
+    total_loc = total_peak = total_cw = total_out = 0
     for entry in aggregated.values():
         loc = entry.get("loc_insertions", 0) + entry.get("loc_deletions", 0)
-        cr = entry.get("peak_context", 0)
+        peak = entry.get("peak_context", 0)
         cw = entry.get("cache_creation_input_tokens", 0)
         out = entry.get("output_tokens", 0)
         lines.append(
             f"| {entry['step_name']} | {loc}"
-            f" | {_ratio(cr, loc)} | {_ratio(cw, loc)} | {_ratio(out, loc)} |"
+            f" | {_ratio(peak, loc)} | {_ratio(cw, loc)} | {_ratio(out, loc)} |"
         )
         total_loc += loc
-        if cr > total_cr:
-            total_cr = cr
+        if peak > total_peak:
+            total_peak = peak
         total_cw += cw
         total_out += out
 
     lines.append(
         f"| **Total** | **{total_loc}**"
-        f" | {_ratio(total_cr, total_loc)} | {_ratio(total_cw, total_loc)}"
+        f" | {_ratio(total_peak, total_loc)} | {_ratio(total_cw, total_loc)}"
         f" | {_ratio(total_out, total_loc)} |"
     )
     return "\n".join(lines)

--- a/src/autoskillit/hooks/token_summary_hook.py
+++ b/src/autoskillit/hooks/token_summary_hook.py
@@ -229,6 +229,8 @@ def _load_sessions(
                 "invocation_count": 0,
                 "loc_insertions": 0,
                 "loc_deletions": 0,
+                "peak_context": 0,
+                "turn_count": 0,
             }
         entry = aggregated[key]
         entry["input_tokens"] += data.get("input_tokens", 0)
@@ -240,6 +242,10 @@ def _load_sessions(
         entry["invocation_count"] += 1
         entry["loc_insertions"] = entry.get("loc_insertions", 0) + data.get("loc_insertions", 0)
         entry["loc_deletions"] = entry.get("loc_deletions", 0) + data.get("loc_deletions", 0)
+        _raw_peak = data.get("peak_context", 0)
+        if isinstance(_raw_peak, int) and _raw_peak > entry["peak_context"]:
+            entry["peak_context"] = _raw_peak
+        entry["turn_count"] = entry.get("turn_count", 0) + data.get("turn_count", 0)
 
     return aggregated
 
@@ -249,13 +255,14 @@ def _format_table(aggregated: dict[str, dict[str, Any]]) -> str:
     lines = [
         "## Token Usage Summary",
         "",
-        "| Step | uncached | output | cache_read | cache_write | count | time |",
-        "|------|----------|--------|------------|-------------|-------|------|",
+        "| Step | uncached | output | cache_read | peak_ctx | turns | cache_write | time |",
+        "|------|----------|--------|------------|----------|-------|-------------|------|",
     ]
 
     total_input = 0
     total_output = 0
     total_cache_rd = 0
+    total_peak = 0
     total_cache_wr = 0
     total_time = 0.0
 
@@ -264,25 +271,29 @@ def _format_table(aggregated: dict[str, dict[str, Any]]) -> str:
         inp = entry["input_tokens"]
         out = entry["output_tokens"]
         cache_rd = entry["cache_read_input_tokens"]
+        peak_ctx = entry.get("peak_context", 0)
+        turns = entry.get("turn_count", 0)
         cache_wr = entry["cache_creation_input_tokens"]
-        count = entry["invocation_count"]
         elapsed = entry["elapsed_seconds"]
 
         lines.append(
             f"| {name} | {_humanize(inp)} | {_humanize(out)} | {_humanize(cache_rd)}"
-            f" | {_humanize(cache_wr)} | {count} | {_fmt_duration(elapsed)} |"
+            f" | {_humanize(peak_ctx)} | {turns} | {_humanize(cache_wr)}"
+            f" | {_fmt_duration(elapsed)} |"
         )
 
         total_input += inp
         total_output += out
         total_cache_rd += cache_rd
+        if peak_ctx > total_peak:
+            total_peak = peak_ctx
         total_cache_wr += cache_wr
         total_time += elapsed
 
     lines.append(
         f"| **Total** | {_humanize(total_input)} | {_humanize(total_output)}"
-        f" | {_humanize(total_cache_rd)} | {_humanize(total_cache_wr)}"
-        f" | | {_fmt_duration(total_time)} |"
+        f" | {_humanize(total_cache_rd)} | {_humanize(total_peak)}"
+        f" | | {_humanize(total_cache_wr)} | {_fmt_duration(total_time)} |"
     )
 
     return "\n".join(lines)
@@ -305,13 +316,13 @@ def _format_efficiency_table(aggregated: dict[str, dict[str, Any]]) -> str:
     lines = [
         "## Token Efficiency",
         "",
-        "| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |",
-        "|------|-------------|----------------|-----------------|------------|",
+        "| Step | LoC Changed | peak_ctx/LoC | cache_write/LoC | output/LoC |",
+        "|------|-------------|--------------|-----------------|------------|",
     ]
     total_loc = total_cr = total_cw = total_out = 0
     for entry in aggregated.values():
         loc = entry.get("loc_insertions", 0) + entry.get("loc_deletions", 0)
-        cr = entry.get("cache_read_input_tokens", 0)
+        cr = entry.get("peak_context", 0)
         cw = entry.get("cache_creation_input_tokens", 0)
         out = entry.get("output_tokens", 0)
         lines.append(
@@ -319,7 +330,8 @@ def _format_efficiency_table(aggregated: dict[str, dict[str, Any]]) -> str:
             f" | {_ratio(cr, loc)} | {_ratio(cw, loc)} | {_ratio(out, loc)} |"
         )
         total_loc += loc
-        total_cr += cr
+        if cr > total_cr:
+            total_cr = cr
         total_cw += cw
         total_out += out
 

--- a/src/autoskillit/pipeline/telemetry_fmt.py
+++ b/src/autoskillit/pipeline/telemetry_fmt.py
@@ -15,8 +15,9 @@ _TOKEN_COLUMNS = (
     TerminalColumn("UNCACHED", max_width=10, align=">"),
     TerminalColumn("OUTPUT", max_width=10, align=">"),
     TerminalColumn("CACHE_RD", max_width=10, align=">"),
+    TerminalColumn("PEAK_CTX", max_width=10, align=">"),
+    TerminalColumn("TURNS", max_width=7, align=">"),
     TerminalColumn("CACHE_WR", max_width=10, align=">"),
-    TerminalColumn("COUNT", max_width=7, align=">"),
     TerminalColumn("TIME", max_width=8, align=">"),
 )
 
@@ -29,7 +30,7 @@ _TIMING_COLUMNS = (
 _EFFICIENCY_COLUMNS = (
     TerminalColumn("STEP", max_width=40, align="<"),
     TerminalColumn("LOC_CHG", max_width=8, align=">"),
-    TerminalColumn("RD/LOC", max_width=8, align=">"),
+    TerminalColumn("PK/LOC", max_width=8, align=">"),
     TerminalColumn("WR/LOC", max_width=8, align=">"),
     TerminalColumn("OUT/LOC", max_width=8, align=">"),
 )
@@ -77,29 +78,32 @@ class TelemetryFormatter:
         lines = [
             "## Token Usage Summary",
             "",
-            "| Step | uncached | output | cache_read | cache_write | count | time |",
-            "|------|----------|--------|------------|-------------|-------|------|",
+            "| Step | uncached | output | cache_read | peak_ctx | turns | cache_write | time |",
+            "|------|----------|--------|------------|----------|-------|-------------|------|",
         ]
         for step in steps:
             name = step.get("step_name", "?")
             inp = h(step.get("input_tokens", 0))
             out = h(step.get("output_tokens", 0))
             cache_rd = h(step.get("cache_read_input_tokens", 0))
+            peak_ctx = h(step.get("peak_context", 0))
+            turns = step.get("turn_count", 0)
             cache_wr = h(step.get("cache_creation_input_tokens", 0))
-            count = step.get("invocation_count", 1)
             wc = step.get("wall_clock_seconds", step.get("elapsed_seconds", 0.0))
             lines.append(
-                f"| {name} | {inp} | {out} | {cache_rd} | {cache_wr} | {count} | {fmt_dur(wc)} |"
+                f"| {name} | {inp} | {out} | {cache_rd} | {peak_ctx}"
+                f" | {turns} | {cache_wr} | {fmt_dur(wc)} |"
             )
 
         total_in = h(total.get("input_tokens", 0))
         total_out = h(total.get("output_tokens", 0))
         total_cache_rd = h(total.get("cache_read_input_tokens", 0))
+        total_peak = h(total.get("peak_context", 0))
         total_cache_wr = h(total.get("cache_creation_input_tokens", 0))
         total_time = total.get("total_elapsed_seconds", 0.0)
         lines.append(
             f"| **Total** | {total_in} | {total_out} | {total_cache_rd}"
-            f" | {total_cache_wr} | | {fmt_dur(total_time)} |"
+            f" | {total_peak} | | {total_cache_wr} | {fmt_dur(total_time)} |"
         )
         return "\n".join(lines)
 
@@ -130,7 +134,7 @@ class TelemetryFormatter:
         h = TelemetryFormatter._humanize
         fmt_dur = TelemetryFormatter._fmt_duration
 
-        rows: list[tuple[str, str, str, str, str, str, str]] = []
+        rows: list[tuple[str, str, str, str, str, str, str, str]] = []
         for step in steps:
             rows.append(
                 (
@@ -138,8 +142,9 @@ class TelemetryFormatter:
                     h(step.get("input_tokens", 0)),
                     h(step.get("output_tokens", 0)),
                     h(step.get("cache_read_input_tokens", 0)),
+                    h(step.get("peak_context", 0)),
+                    str(step.get("turn_count", 0)),
                     h(step.get("cache_creation_input_tokens", 0)),
-                    str(step.get("invocation_count", 1)),
                     fmt_dur(step.get("wall_clock_seconds", step.get("elapsed_seconds", 0.0))),
                 )
             )
@@ -149,8 +154,9 @@ class TelemetryFormatter:
             h(total.get("input_tokens", 0)),
             h(total.get("output_tokens", 0)),
             h(total.get("cache_read_input_tokens", 0)),
-            h(total.get("cache_creation_input_tokens", 0)),
+            h(total.get("peak_context", 0)),
             "",
+            h(total.get("cache_creation_input_tokens", 0)),
             fmt_dur(total.get("total_elapsed_seconds", 0.0)),
         )
 
@@ -188,16 +194,21 @@ class TelemetryFormatter:
             inp = h(step.get("input_tokens", 0))
             out = h(step.get("output_tokens", 0))
             cache_rd = h(step.get("cache_read_input_tokens", 0))
+            peak_ctx = h(step.get("peak_context", 0))
             cache_wr = h(step.get("cache_creation_input_tokens", 0))
+            turns = step.get("turn_count", 0)
             wc = step.get("wall_clock_seconds", step.get("elapsed_seconds", 0.0))
             lines.append(
-                f"{name} x{count} [uc:{inp} out:{out} cr:{cache_rd} cw:{cache_wr} t:{wc:.1f}s]"
+                f"{name} x{count}"
+                f" [uc:{inp} out:{out} cr:{cache_rd} pk:{peak_ctx} cw:{cache_wr}"
+                f" turns:{turns} t:{wc:.1f}s]"
             )
         if total:
             lines.append("")
             lines.append(f"total_uncached: {h(total.get('input_tokens', 0))}")
             lines.append(f"total_out: {h(total.get('output_tokens', 0))}")
             lines.append(f"total_cache_read: {h(total.get('cache_read_input_tokens', 0))}")
+            lines.append(f"total_peak_context: {h(total.get('peak_context', 0))}")
             lines.append(f"total_cache_write: {h(total.get('cache_creation_input_tokens', 0))}")
         if mcp_responses:
             mcp_total = mcp_responses.get("total", {})
@@ -217,12 +228,12 @@ class TelemetryFormatter:
         lines = [
             "## Token Efficiency",
             "",
-            "| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |",
-            "|------|-------------|----------------|-----------------|------------|",
+            "| Step | LoC Changed | peak_ctx/LoC | cache_write/LoC | output/LoC |",
+            "|------|-------------|--------------|-----------------|------------|",
         ]
         for step in steps:
             loc = step.get("loc_insertions", 0) + step.get("loc_deletions", 0)
-            cr = step.get("cache_read_input_tokens", 0)
+            cr = step.get("peak_context", 0)
             cw = step.get("cache_creation_input_tokens", 0)
             out = step.get("output_tokens", 0)
             lines.append(
@@ -231,7 +242,7 @@ class TelemetryFormatter:
             )
 
         total_loc = total.get("loc_insertions", 0) + total.get("loc_deletions", 0)
-        total_cr = total.get("cache_read_input_tokens", 0)
+        total_cr = total.get("peak_context", 0)
         total_cw = total.get("cache_creation_input_tokens", 0)
         total_out = total.get("output_tokens", 0)
         lines.append(
@@ -250,7 +261,7 @@ class TelemetryFormatter:
         rows: list[tuple[str, str, str, str, str]] = []
         for step in steps:
             loc = step.get("loc_insertions", 0) + step.get("loc_deletions", 0)
-            cr = step.get("cache_read_input_tokens", 0)
+            cr = step.get("peak_context", 0)
             cw = step.get("cache_creation_input_tokens", 0)
             out = step.get("output_tokens", 0)
             rows.append(
@@ -267,7 +278,7 @@ class TelemetryFormatter:
         total_row = (
             "Total",
             str(total_loc),
-            _ratio(total.get("cache_read_input_tokens", 0), total_loc),
+            _ratio(total.get("peak_context", 0), total_loc),
             _ratio(total.get("cache_creation_input_tokens", 0), total_loc),
             _ratio(total.get("output_tokens", 0), total_loc),
         )

--- a/src/autoskillit/pipeline/telemetry_fmt.py
+++ b/src/autoskillit/pipeline/telemetry_fmt.py
@@ -233,21 +233,21 @@ class TelemetryFormatter:
         ]
         for step in steps:
             loc = step.get("loc_insertions", 0) + step.get("loc_deletions", 0)
-            cr = step.get("peak_context", 0)
+            peak_ctx = step.get("peak_context", 0)
             cw = step.get("cache_creation_input_tokens", 0)
             out = step.get("output_tokens", 0)
             lines.append(
                 f"| {step.get('step_name', '?')} | {loc}"
-                f" | {_ratio(cr, loc)} | {_ratio(cw, loc)} | {_ratio(out, loc)} |"
+                f" | {_ratio(peak_ctx, loc)} | {_ratio(cw, loc)} | {_ratio(out, loc)} |"
             )
 
         total_loc = total.get("loc_insertions", 0) + total.get("loc_deletions", 0)
-        total_cr = total.get("peak_context", 0)
+        total_peak = total.get("peak_context", 0)
         total_cw = total.get("cache_creation_input_tokens", 0)
         total_out = total.get("output_tokens", 0)
         lines.append(
             f"| **Total** | **{total_loc}**"
-            f" | {_ratio(total_cr, total_loc)} | {_ratio(total_cw, total_loc)}"
+            f" | {_ratio(total_peak, total_loc)} | {_ratio(total_cw, total_loc)}"
             f" | {_ratio(total_out, total_loc)} |"
         )
         return "\n".join(lines)
@@ -261,14 +261,14 @@ class TelemetryFormatter:
         rows: list[tuple[str, str, str, str, str]] = []
         for step in steps:
             loc = step.get("loc_insertions", 0) + step.get("loc_deletions", 0)
-            cr = step.get("peak_context", 0)
+            peak_ctx = step.get("peak_context", 0)
             cw = step.get("cache_creation_input_tokens", 0)
             out = step.get("output_tokens", 0)
             rows.append(
                 (
                     step.get("step_name", "?"),
                     str(loc),
-                    _ratio(cr, loc),
+                    _ratio(peak_ctx, loc),
                     _ratio(cw, loc),
                     _ratio(out, loc),
                 )

--- a/src/autoskillit/pipeline/tokens.py
+++ b/src/autoskillit/pipeline/tokens.py
@@ -55,6 +55,8 @@ class TokenEntry:
     elapsed_seconds: float = 0.0
     loc_insertions: int = 0
     loc_deletions: int = 0
+    peak_context: int = 0
+    turn_count: int = 0
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -109,6 +111,10 @@ class DefaultTokenLog:
         e.invocation_count += 1
         e.loc_insertions += loc_insertions
         e.loc_deletions += loc_deletions
+        _peak = token_usage.get("peak_context", 0)
+        if _peak > e.peak_context:
+            e.peak_context = _peak
+        e.turn_count += token_usage.get("turn_count", 0)
         if elapsed_seconds is not None:
             e.elapsed_seconds += elapsed_seconds
         elif start_ts and end_ts:
@@ -149,6 +155,9 @@ class DefaultTokenLog:
             agg.invocation_count += e.invocation_count
             agg.loc_insertions += e.loc_insertions
             agg.loc_deletions += e.loc_deletions
+            if e.peak_context > agg.peak_context:
+                agg.peak_context = e.peak_context
+            agg.turn_count += e.turn_count
         return [e.to_dict() for e in aggregated.values()]
 
     def compute_total(self, *, order_id: str = "") -> dict[str, Any]:
@@ -165,6 +174,8 @@ class DefaultTokenLog:
             "total_elapsed_seconds": 0.0,
             "loc_insertions": 0,
             "loc_deletions": 0,
+            "peak_context": 0,
+            "turn_count": 0,
         }
         for (oid, _step), entry in self._entries.items():
             if order_id and oid != order_id:
@@ -176,6 +187,9 @@ class DefaultTokenLog:
             total["total_elapsed_seconds"] += entry.elapsed_seconds
             total["loc_insertions"] += entry.loc_insertions
             total["loc_deletions"] += entry.loc_deletions
+            if entry.peak_context > total["peak_context"]:
+                total["peak_context"] = entry.peak_context
+            total["turn_count"] += entry.turn_count
         return total
 
     def clear(self) -> None:
@@ -242,6 +256,10 @@ class DefaultTokenLog:
             e.elapsed_seconds += float(_raw_timing) if _raw_timing is not None else 0.0
             e.loc_insertions += data.get("loc_insertions", 0)
             e.loc_deletions += data.get("loc_deletions", 0)
+            _raw_peak = data.get("peak_context", 0)
+            if isinstance(_raw_peak, int) and _raw_peak > e.peak_context:
+                e.peak_context = _raw_peak
+            e.turn_count += data.get("turn_count", 0)
             # Each token_usage.json file represents a single run_skill invocation
             # (one file = one invocation). Incrementing here reconstructs the
             # invocation count that was accumulated live via record().

--- a/src/autoskillit/pipeline/tokens.py
+++ b/src/autoskillit/pipeline/tokens.py
@@ -112,9 +112,11 @@ class DefaultTokenLog:
         e.loc_insertions += loc_insertions
         e.loc_deletions += loc_deletions
         _peak = token_usage.get("peak_context", 0)
-        if _peak > e.peak_context:
+        if isinstance(_peak, int) and _peak > e.peak_context:
             e.peak_context = _peak
-        e.turn_count += token_usage.get("turn_count", 0)
+        _turns = token_usage.get("turn_count", 0)
+        if isinstance(_turns, int):
+            e.turn_count += _turns
         if elapsed_seconds is not None:
             e.elapsed_seconds += elapsed_seconds
         elif start_ts and end_ts:
@@ -259,7 +261,9 @@ class DefaultTokenLog:
             _raw_peak = data.get("peak_context", 0)
             if isinstance(_raw_peak, int) and _raw_peak > e.peak_context:
                 e.peak_context = _raw_peak
-            e.turn_count += data.get("turn_count", 0)
+            _raw_turns = data.get("turn_count", 0)
+            if isinstance(_raw_turns, int):
+                e.turn_count += _raw_turns
             # Each token_usage.json file represents a single run_skill invocation
             # (one file = one invocation). Incrementing here reconstructs the
             # invocation count that was accumulated live via record().

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -71,7 +71,7 @@ NEW_MQ_MODULES = ["_merge_queue_classifier.py", "_merge_queue_repo_state.py"]
 
 SESSION_SIZE_BUDGETS = {
     "session/__init__.py": 60,  # was 420; facade is ~40 lines after P2
-    "session/_session_model.py": 385,
+    "session/_session_model.py": 400,
     "session/_session_content.py": 200,
 }
 NEW_SESSION_FSM_MODULES = ["_retry_fsm.py", "_session_outcome.py"]

--- a/tests/execution/test_session_log_flush.py
+++ b/tests/execution/test_session_log_flush.py
@@ -540,6 +540,30 @@ def test_token_usage_json_schema(tmp_path):
     assert tu["cache_creation_input_tokens"] == 2
     assert tu["cache_read_input_tokens"] == 1
     assert tu["timing_seconds"] == 15.0
+    assert tu["peak_context"] == 0
+    assert tu["turn_count"] == 0
+
+
+def test_token_usage_json_includes_peak_context_and_turn_count(tmp_path):
+    """flush_session_log writes peak_context and turn_count to token_usage.json."""
+    _flush(
+        tmp_path,
+        step_name="implement",
+        token_usage={
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_creation_input_tokens": 10,
+            "cache_read_input_tokens": 200,
+            "peak_context": 75000,
+            "turn_count": 14,
+        },
+        timing_seconds=30.0,
+        proc_snapshots=None,
+        success=True,
+    )
+    tu = json.loads((tmp_path / "sessions" / "test-session-001" / "token_usage.json").read_text())
+    assert tu["peak_context"] == 75000
+    assert tu["turn_count"] == 14
 
 
 def test_step_timing_json_schema(tmp_path):

--- a/tests/execution/test_session_model_peak_context.py
+++ b/tests/execution/test_session_model_peak_context.py
@@ -1,0 +1,112 @@
+"""Tests for peak_context and turn_count extraction from extract_token_usage."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from autoskillit.execution.session._session_model import extract_token_usage
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.medium]
+
+
+def _assistant(cache_read: int = 0) -> str:
+    return json.dumps(
+        {
+            "type": "assistant",
+            "message": {
+                "model": "claude-sonnet-4-6",
+                "usage": {
+                    "input_tokens": 100,
+                    "output_tokens": 50,
+                    "cache_creation_input_tokens": 0,
+                    "cache_read_input_tokens": cache_read,
+                },
+            },
+        }
+    )
+
+
+def _result(cache_read: int = 0) -> str:
+    return json.dumps(
+        {
+            "type": "result",
+            "subtype": "success",
+            "is_error": False,
+            "result": "done",
+            "session_id": "s1",
+            "errors": [],
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": cache_read,
+            },
+        }
+    )
+
+
+def _build_ndjson(lines: list[str]) -> str:
+    return "\n".join(lines)
+
+
+def test_extract_peak_context_from_multi_turn_stdout():
+    stdout = _build_ndjson([
+        _assistant(cache_read=10000),
+        _assistant(cache_read=50000),
+        _assistant(cache_read=30000),
+    ])
+    result = extract_token_usage(stdout)
+    assert result is not None
+    assert result["peak_context"] == 50000
+
+
+def test_extract_turn_count_from_multi_turn_stdout():
+    stdout = _build_ndjson([
+        _assistant(cache_read=10000),
+        _assistant(cache_read=20000),
+        _assistant(cache_read=30000),
+    ])
+    result = extract_token_usage(stdout)
+    assert result is not None
+    assert result["turn_count"] == 3
+
+
+def test_extract_peak_context_single_turn():
+    stdout = _build_ndjson([_assistant(cache_read=42000)])
+    result = extract_token_usage(stdout)
+    assert result is not None
+    assert result["peak_context"] == 42000
+    assert result["turn_count"] == 1
+
+
+def test_extract_peak_context_with_result_record():
+    stdout = _build_ndjson([
+        _assistant(cache_read=60000),
+        _assistant(cache_read=80000),
+        _result(cache_read=140000),
+    ])
+    result = extract_token_usage(stdout)
+    assert result is not None
+    assert result["peak_context"] == 80000
+    assert result["turn_count"] == 2
+
+
+def test_extract_peak_context_no_assistant_records():
+    stdout = _build_ndjson([_result(cache_read=100000)])
+    result = extract_token_usage(stdout)
+    assert result is not None
+    assert result["peak_context"] == 0
+    assert result["turn_count"] == 0
+
+
+def test_extract_peak_context_zero_cache_read():
+    stdout = _build_ndjson([
+        _assistant(cache_read=0),
+        _assistant(cache_read=0),
+    ])
+    result = extract_token_usage(stdout)
+    assert result is not None
+    assert result["peak_context"] == 0
+    assert result["turn_count"] == 2

--- a/tests/execution/test_session_model_peak_context.py
+++ b/tests/execution/test_session_model_peak_context.py
@@ -52,22 +52,26 @@ def _build_ndjson(lines: list[str]) -> str:
 
 
 def test_extract_peak_context_from_multi_turn_stdout():
-    stdout = _build_ndjson([
-        _assistant(cache_read=10000),
-        _assistant(cache_read=50000),
-        _assistant(cache_read=30000),
-    ])
+    stdout = _build_ndjson(
+        [
+            _assistant(cache_read=10000),
+            _assistant(cache_read=50000),
+            _assistant(cache_read=30000),
+        ]
+    )
     result = extract_token_usage(stdout)
     assert result is not None
     assert result["peak_context"] == 50000
 
 
 def test_extract_turn_count_from_multi_turn_stdout():
-    stdout = _build_ndjson([
-        _assistant(cache_read=10000),
-        _assistant(cache_read=20000),
-        _assistant(cache_read=30000),
-    ])
+    stdout = _build_ndjson(
+        [
+            _assistant(cache_read=10000),
+            _assistant(cache_read=20000),
+            _assistant(cache_read=30000),
+        ]
+    )
     result = extract_token_usage(stdout)
     assert result is not None
     assert result["turn_count"] == 3
@@ -82,11 +86,13 @@ def test_extract_peak_context_single_turn():
 
 
 def test_extract_peak_context_with_result_record():
-    stdout = _build_ndjson([
-        _assistant(cache_read=60000),
-        _assistant(cache_read=80000),
-        _result(cache_read=140000),
-    ])
+    stdout = _build_ndjson(
+        [
+            _assistant(cache_read=60000),
+            _assistant(cache_read=80000),
+            _result(cache_read=140000),
+        ]
+    )
     result = extract_token_usage(stdout)
     assert result is not None
     assert result["peak_context"] == 80000
@@ -102,10 +108,12 @@ def test_extract_peak_context_no_assistant_records():
 
 
 def test_extract_peak_context_zero_cache_read():
-    stdout = _build_ndjson([
-        _assistant(cache_read=0),
-        _assistant(cache_read=0),
-    ])
+    stdout = _build_ndjson(
+        [
+            _assistant(cache_read=0),
+            _assistant(cache_read=0),
+        ]
+    )
     result = extract_token_usage(stdout)
     assert result is not None
     assert result["peak_context"] == 0

--- a/tests/hooks/test_token_summary_appender.py
+++ b/tests/hooks/test_token_summary_appender.py
@@ -93,6 +93,8 @@ def _write_sessions(log_root: Path, entries: list[dict]) -> None:
             "timing_seconds": entry.get("timing_seconds", 10.0),
             "loc_insertions": entry.get("loc_insertions", 0),
             "loc_deletions": entry.get("loc_deletions", 0),
+            "peak_context": entry.get("peak_context", 0),
+            "turn_count": entry.get("turn_count", 0),
         }
         (session_dir / "token_usage.json").write_text(json.dumps(token_data))
 

--- a/tests/infra/_token_summary_helpers.py
+++ b/tests/infra/_token_summary_helpers.py
@@ -75,5 +75,7 @@ def _write_sessions(log_root: Path, entries: list[dict]) -> None:
             "timing_seconds": entry.get("timing_seconds", 10.0),
             "loc_insertions": entry.get("loc_insertions", 0),
             "loc_deletions": entry.get("loc_deletions", 0),
+            "peak_context": entry.get("peak_context", 0),
+            "turn_count": entry.get("turn_count", 0),
         }
         (session_dir / "token_usage.json").write_text(json.dumps(token_data))

--- a/tests/infra/test_pretty_output_recipe.py
+++ b/tests/infra/test_pretty_output_recipe.py
@@ -61,12 +61,13 @@ def test_format_get_token_summary_compact():
     out, _ = _run_hook(event=event)
     text = json.loads(out)["hookSpecificOutput"]["updatedMCPToolOutput"]
     assert "token_summary" in text
-    assert "investigate x1 [uc:45.2k out:12.8k cr:1.2M cw:0 t:0.0s]" in text
-    assert "make_plan x2 [uc:30.0k out:8.0k cr:0 cw:500.0k t:0.0s]" in text
-    assert "implement x1 [uc:60.0k out:15.0k cr:2.0M cw:0 t:0.0s]" in text
+    assert "investigate x1 [uc:45.2k out:12.8k cr:1.2M pk:0 cw:0 turns:0 t:0.0s]" in text
+    assert "make_plan x2 [uc:30.0k out:8.0k cr:0 pk:0 cw:500.0k turns:0 t:0.0s]" in text
+    assert "implement x1 [uc:60.0k out:15.0k cr:2.0M pk:0 cw:0 turns:0 t:0.0s]" in text
     assert "total_uncached:" in text
     assert "total_out:" in text
     assert "total_cache_read:" in text
+    assert "total_peak_context:" in text
     assert "total_cache_write:" in text
 
 

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -115,8 +115,8 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/execution/session_log.py", 307),
     ("src/autoskillit/execution/session_log.py", 367),
     ("src/autoskillit/execution/session_log.py", 371),
-    ("src/autoskillit/execution/session_log.py", 398),
-    ("src/autoskillit/execution/session_log.py", 395),
+    ("src/autoskillit/execution/session_log.py", 400),
+    ("src/autoskillit/execution/session_log.py", 397),
     # migration/store.py — failure store dicts
     ("src/autoskillit/migration/store.py", 54),
     ("src/autoskillit/migration/store.py", 64),

--- a/tests/pipeline/test_telemetry_formatter.py
+++ b/tests/pipeline/test_telemetry_formatter.py
@@ -63,6 +63,8 @@ class TestFormatTokenTable:
         assert "|---" in result
         assert "| uncached |" in result
         assert "| cache_read |" in result
+        assert "| peak_ctx |" in result
+        assert "| turns |" in result
         assert "| cache_write |" in result
         assert "- input_tokens:" not in result
         assert "# Token Summary" not in result
@@ -112,6 +114,8 @@ class TestFormatTokenTable:
                 "output_tokens": 500,
                 "cache_creation_input_tokens": 100,
                 "cache_read_input_tokens": 200,
+                "peak_context": 200,
+                "turn_count": 5,
                 "invocation_count": 1,
                 "wall_clock_seconds": 45.7,
             },
@@ -121,6 +125,7 @@ class TestFormatTokenTable:
             "output_tokens": 500,
             "cache_creation_input_tokens": 100,
             "cache_read_input_tokens": 200,
+            "peak_context": 200,
             "total_elapsed_seconds": 45.7,
         }
         result = TelemetryFormatter.format_token_table(steps, total)
@@ -128,10 +133,10 @@ class TestFormatTokenTable:
             [
                 "## Token Usage Summary",
                 "",
-                "| Step | uncached | output | cache_read | cache_write | count | time |",
-                "|------|----------|--------|------------|-------------|-------|------|",
-                "| plan | 1.0k | 500 | 200 | 100 | 1 | 46s |",
-                "| **Total** | 1.0k | 500 | 200 | 100 | | 46s |",
+                "| Step | uncached | output | cache_read | peak_ctx | turns | cache_write | time |",  # noqa: E501
+                "|------|----------|--------|------------|----------|-------|-------------|------|",
+                "| plan | 1.0k | 500 | 200 | 200 | 5 | 100 | 46s |",
+                "| **Total** | 1.0k | 500 | 200 | 200 | | 100 | 46s |",
             ]
         )
         assert result == expected
@@ -232,21 +237,27 @@ def test_format_timing_table_terminal_output_has_leading_indent() -> None:
 
 
 def test_terminal_table_has_four_token_columns() -> None:
-    """Terminal table must show UNCACHED, CACHE_RD, CACHE_WR column headers."""
+    """Terminal table must show UNCACHED, CACHE_RD, PEAK_CTX, TURNS, CACHE_WR headers."""
     result = TelemetryFormatter.format_token_table_terminal(_STEPS, _TOTAL)
     assert "UNCACHED" in result
     assert "CACHE_RD" in result
+    assert "PEAK_CTX" in result
+    assert "TURNS" in result
     assert "CACHE_WR" in result
+    assert "COUNT" not in result
 
 
 def test_compact_kv_four_token_prefixes() -> None:
-    """Compact KV format must use uc:, cr:, cw: prefixes and split totals."""
+    """Compact KV format must use uc:, cr:, pk:, cw:, turns: prefixes and split totals."""
     result = TelemetryFormatter.format_compact_kv(_STEPS, _TOTAL)
     assert "uc:" in result
     assert "cr:" in result
+    assert "pk:" in result
     assert "cw:" in result
+    assert "turns:" in result
     assert "total_uncached:" in result
     assert "total_cache_read:" in result
+    assert "total_peak_context:" in result
     assert "total_cache_write:" in result
     assert "in:" not in result
     assert " cached:" not in result
@@ -382,7 +393,7 @@ def test_efficiency_table_columns() -> None:
     result = TelemetryFormatter.format_efficiency_table(steps, total)
     assert "## Token Efficiency" in result
     assert "LoC Changed" in result
-    assert "cache_read/LoC" in result
+    assert "peak_ctx/LoC" in result
     assert "cache_write/LoC" in result
     assert "output/LoC" in result
 
@@ -393,7 +404,7 @@ def test_efficiency_table_ratios() -> None:
     steps = [
         {
             "step_name": "implement",
-            "cache_read_input_tokens": 1000,
+            "peak_context": 1000,
             "cache_creation_input_tokens": 200,
             "output_tokens": 50,
             "loc_insertions": 80,
@@ -403,12 +414,12 @@ def test_efficiency_table_ratios() -> None:
     total = {
         "loc_insertions": 80,
         "loc_deletions": 20,
-        "cache_read_input_tokens": 1000,
+        "peak_context": 1000,
         "cache_creation_input_tokens": 200,
         "output_tokens": 50,
     }
     result = TelemetryFormatter.format_efficiency_table(steps, total)
-    # loc_changed = 100; cache_read/LoC = 10.0; cache_write/LoC = 2.0; output/LoC = 0.5
+    # loc_changed = 100; peak_ctx/LoC = 10.0; cache_write/LoC = 2.0; output/LoC = 0.5
     assert "10.0" in result
     assert "2.0" in result
     assert "0.5" in result
@@ -421,7 +432,7 @@ def test_efficiency_table_zero_loc_step_shows_dash() -> None:
     steps = [
         {
             "step_name": "no-change",
-            "cache_read_input_tokens": 500,
+            "peak_context": 500,
             "cache_creation_input_tokens": 100,
             "output_tokens": 20,
             "loc_insertions": 0,
@@ -429,7 +440,7 @@ def test_efficiency_table_zero_loc_step_shows_dash() -> None:
         },
         {
             "step_name": "implement",
-            "cache_read_input_tokens": 1000,
+            "peak_context": 1000,
             "cache_creation_input_tokens": 200,
             "output_tokens": 50,
             "loc_insertions": 50,
@@ -439,7 +450,7 @@ def test_efficiency_table_zero_loc_step_shows_dash() -> None:
     total = {
         "loc_insertions": 50,
         "loc_deletions": 10,
-        "cache_read_input_tokens": 1500,
+        "peak_context": 1000,
         "cache_creation_input_tokens": 300,
         "output_tokens": 70,
     }
@@ -453,7 +464,7 @@ def test_efficiency_table_total_row_uses_aggregate_totals() -> None:
     steps = [
         {
             "step_name": "plan",
-            "cache_read_input_tokens": 200,
+            "peak_context": 200,
             "cache_creation_input_tokens": 0,
             "output_tokens": 10,
             "loc_insertions": 10,
@@ -461,7 +472,7 @@ def test_efficiency_table_total_row_uses_aggregate_totals() -> None:
         },
         {
             "step_name": "implement",
-            "cache_read_input_tokens": 800,
+            "peak_context": 800,
             "cache_creation_input_tokens": 100,
             "output_tokens": 40,
             "loc_insertions": 90,
@@ -471,12 +482,12 @@ def test_efficiency_table_total_row_uses_aggregate_totals() -> None:
     total = {
         "loc_insertions": 100,
         "loc_deletions": 10,
-        "cache_read_input_tokens": 1000,
+        "peak_context": 1000,
         "cache_creation_input_tokens": 100,
         "output_tokens": 50,
     }
     result = TelemetryFormatter.format_efficiency_table(steps, total)
-    # Total loc_changed=110; cache_read/LoC=1000/110≈9.1
+    # Total loc_changed=110; peak_ctx/LoC=1000/110≈9.1
     assert "9.1" in result
     assert "**Total**" in result
 
@@ -487,7 +498,7 @@ def test_efficiency_table_terminal_no_markdown() -> None:
     steps = [
         {
             "step_name": "implement",
-            "cache_read_input_tokens": 1000,
+            "peak_context": 1000,
             "cache_creation_input_tokens": 200,
             "output_tokens": 50,
             "loc_insertions": 80,
@@ -497,10 +508,11 @@ def test_efficiency_table_terminal_no_markdown() -> None:
     total = {
         "loc_insertions": 80,
         "loc_deletions": 20,
-        "cache_read_input_tokens": 1000,
+        "peak_context": 1000,
         "cache_creation_input_tokens": 200,
         "output_tokens": 50,
     }
     result = TelemetryFormatter.format_efficiency_table_terminal(steps, total)
     assert "|" not in result  # no markdown pipes
     assert "LOC" in result  # column header present
+    assert "PK/LOC" in result

--- a/tests/pipeline/test_tokens_core.py
+++ b/tests/pipeline/test_tokens_core.py
@@ -37,6 +37,8 @@ class TestTokenEntry:
             "elapsed_seconds",
             "loc_insertions",
             "loc_deletions",
+            "peak_context",
+            "turn_count",
         }
 
     def test_default_counts_are_zero(self):
@@ -65,6 +67,8 @@ class TestTokenEntry:
             "elapsed_seconds",
             "loc_insertions",
             "loc_deletions",
+            "peak_context",
+            "turn_count",
         }
         assert d["step_name"] == "implement"
         assert d["input_tokens"] == 42
@@ -152,6 +156,8 @@ class TestDefaultTokenLog:
             "total_elapsed_seconds": 0.0,
             "loc_insertions": 0,
             "loc_deletions": 0,
+            "peak_context": 0,
+            "turn_count": 0,
         }
 
     def test_token_entry_has_elapsed_seconds_field(self):
@@ -574,3 +580,93 @@ def test_token_log_load_from_log_dir_missing_loc_defaults_to_zero(tmp_path):
     report = log.get_report()
     assert report[0]["loc_insertions"] == 0
     assert report[0]["loc_deletions"] == 0
+
+
+# ---------------------------------------------------------------------------
+# T-PEAK: peak_context and turn_count
+# ---------------------------------------------------------------------------
+
+
+def test_token_entry_has_peak_context_and_turn_count_fields():
+    e = TokenEntry(step_name="plan")
+    assert e.peak_context == 0
+    assert e.turn_count == 0
+
+
+def test_record_peak_context_uses_max():
+    log = DefaultTokenLog()
+    log.record("impl", {"cache_read_input_tokens": 100, "peak_context": 50000, "turn_count": 10})
+    log.record("impl", {"cache_read_input_tokens": 200, "peak_context": 80000, "turn_count": 15})
+    report = log.get_report()
+    assert report[0]["peak_context"] == 80000
+
+
+def test_record_turn_count_sums():
+    log = DefaultTokenLog()
+    log.record("impl", {"cache_read_input_tokens": 100, "peak_context": 50000, "turn_count": 10})
+    log.record("impl", {"cache_read_input_tokens": 200, "peak_context": 80000, "turn_count": 15})
+    report = log.get_report()
+    assert report[0]["turn_count"] == 25
+
+
+def test_compute_total_peak_context_is_max_across_steps():
+    log = DefaultTokenLog()
+    log.record("plan", {"cache_read_input_tokens": 100, "peak_context": 40000, "turn_count": 5})
+    log.record("impl", {"cache_read_input_tokens": 200, "peak_context": 70000, "turn_count": 18})
+    total = log.compute_total()
+    assert total["peak_context"] == 70000
+    assert total["turn_count"] == 23
+
+
+def test_load_from_log_dir_reads_peak_context_and_turn_count(tmp_path):
+    sessions_dir = tmp_path / "sessions" / "sess-001"
+    sessions_dir.mkdir(parents=True)
+    (tmp_path / "sessions.jsonl").write_text(
+        json.dumps({"dir_name": "sess-001", "timestamp": "2026-03-07T00:00:00+00:00"}) + "\n"
+    )
+    (sessions_dir / "token_usage.json").write_text(
+        json.dumps(
+            {
+                "step_name": "impl",
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 200,
+                "timing_seconds": 5.0,
+                "order_id": "",
+                "peak_context": 60000,
+                "turn_count": 12,
+            }
+        )
+    )
+    log = DefaultTokenLog()
+    log.load_from_log_dir(tmp_path)
+    report = log.get_report()
+    assert report[0]["peak_context"] == 60000
+    assert report[0]["turn_count"] == 12
+
+
+def test_load_from_log_dir_missing_peak_context_defaults_to_zero(tmp_path):
+    sessions_dir = tmp_path / "sessions" / "sess-old"
+    sessions_dir.mkdir(parents=True)
+    (tmp_path / "sessions.jsonl").write_text(
+        json.dumps({"dir_name": "sess-old", "timestamp": "2026-03-07T00:00:00+00:00"}) + "\n"
+    )
+    (sessions_dir / "token_usage.json").write_text(
+        json.dumps(
+            {
+                "step_name": "plan",
+                "input_tokens": 500,
+                "output_tokens": 50,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 0,
+                "timing_seconds": 3.0,
+                "order_id": "",
+            }
+        )
+    )
+    log = DefaultTokenLog()
+    log.load_from_log_dir(tmp_path)
+    report = log.get_report()
+    assert report[0]["peak_context"] == 0
+    assert report[0]["turn_count"] == 0


### PR DESCRIPTION
## Summary

Add `peak_context` and `turns` columns to the Token Usage Summary table on PR bodies, replacing the current low-value `count` (invocation count) column. `peak_context` is the maximum `cache_read_input_tokens` from any single API turn within a session, and `turns` is the number of API roundtrips. These metrics disambiguate whether high cumulative `cache_read` is caused by a bloated context or too many turns. The Token Efficiency table's `/LoC` ratios switch from cumulative `cache_read` to `peak_context` as denominator.

Changes span five layers: extraction (`_session_model.py`), persistence (`session_log.py`), in-memory tracking (`tokens.py`), hook aggregation (`token_summary_hook.py`), and display (`telemetry_fmt.py` + hook).

Closes #1797

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-1797-20260503-215010-567826/.autoskillit/temp/make-plan/report_peak_context_and_turn_count_plan_2026-05-03_220600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 62 | 14.4k | 1.1M | 89.7k | 1 | 9m 39s |
| verify | 58 | 20.8k | 1.4M | 73.8k | 1 | 9m 11s |
| implement | 162 | 42.2k | 12.2M | 121.7k | 1 | 25m 43s |
| prepare_pr | 34 | 5.5k | 222.1k | 29.7k | 1 | 1m 42s |
| compose_pr | 22 | 1.4k | 123.0k | 16.2k | 1 | 33s |
| review_pr | 499 | 56.6k | 1.3M | 150.5k | 2 | 15m 39s |
| resolve_review | 1.2k | 27.2k | 3.3M | 176.0k | 2 | 16m 55s |
| **Total** | 2.1k | 168.2k | 19.7M | 657.5k | | 1h 19m |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 431 | 28399.9 | 282.3 | 98.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 38 | 86776.8 | 4631.8 | 716.4 |
| **Total** | **469** | 41997.9 | 1401.9 | 358.5 |