### PR TITLE
Diff-Size-Adaptive Subagent Dispatch in review-pr

### DIFF
--- a/src/autoskillit/execution/__init__.py
+++ b/src/autoskillit/execution/__init__.py
@@ -32,10 +32,13 @@ from autoskillit.execution.db import (
     _execute_readonly_query as execute_readonly_query,
 )
 from autoskillit.execution.diff_annotator import (
+    DiffMetrics,
     FilterResult,
     annotate_diff,
+    compute_diff_metrics,
     filter_findings,
     parse_hunk_ranges,
+    select_review_agents,
 )
 from autoskillit.execution.github import (
     DefaultGitHubFetcher,
@@ -167,10 +170,13 @@ __all__ = [
     "resolve_remote_name",
     "resolve_remote_repo",
     # diff_annotator
+    "DiffMetrics",
     "FilterResult",
     "annotate_diff",
+    "compute_diff_metrics",
     "filter_findings",
     "parse_hunk_ranges",
+    "select_review_agents",
     # db
     "execute_readonly_query",
     "DefaultDatabaseReader",

--- a/src/autoskillit/execution/diff_annotator.py
+++ b/src/autoskillit/execution/diff_annotator.py
@@ -83,11 +83,7 @@ def select_review_agents(
 ) -> list[str]:
     if metrics.added_lines < loc_threshold and metrics.changed_files < file_threshold:
         agents: list[str] = list(_SMALL_DIFF_CORE_AGENTS)
-        if any(
-            fp.endswith(s) or fp.endswith(s.lstrip("/"))
-            for fp in metrics.file_paths
-            for s in _STRUCTURAL_SUFFIXES
-        ):
+        if any(("/" + fp).endswith(s) for fp in metrics.file_paths for s in _STRUCTURAL_SUFFIXES):
             agents.insert(0, "arch")
         return agents
     return list(_ALL_STANDARD_AGENTS)

--- a/src/autoskillit/execution/diff_annotator.py
+++ b/src/autoskillit/execution/diff_annotator.py
@@ -23,6 +23,76 @@ class FilterResult:
     all_unpostable: bool = False
 
 
+@dataclass
+class DiffMetrics:
+    """Size metrics computed from a unified diff."""
+
+    added_lines: int
+    removed_lines: int
+    changed_files: int
+    file_paths: list[str] = field(default_factory=list)
+
+
+_STRUCTURAL_SUFFIXES = (
+    "/__init__.py",
+    "/setup.py",
+    "/setup.cfg",
+    "/pyproject.toml",
+    "/Makefile",
+    "/Taskfile.yml",
+    "/Dockerfile",
+    "/docker-compose.yml",
+    "/docker-compose.yaml",
+)
+
+_ALL_STANDARD_AGENTS = ("arch", "tests", "defense", "bugs", "cohesion", "slop")
+_SMALL_DIFF_CORE_AGENTS = ("tests", "cohesion")
+
+
+def compute_diff_metrics(diff_text: str) -> DiffMetrics:
+    added = 0
+    removed = 0
+    file_paths: list[str] = []
+
+    for line in diff_text.splitlines():
+        if line.startswith("+++ b/"):
+            file_paths.append(line[6:])
+            continue
+        if line.startswith("+++"):
+            continue
+        if line.startswith("---"):
+            continue
+        if line.startswith("+"):
+            added += 1
+        elif line.startswith("-"):
+            removed += 1
+
+    return DiffMetrics(
+        added_lines=added,
+        removed_lines=removed,
+        changed_files=len(file_paths),
+        file_paths=file_paths,
+    )
+
+
+def select_review_agents(
+    metrics: DiffMetrics,
+    *,
+    loc_threshold: int = 200,
+    file_threshold: int = 5,
+) -> list[str]:
+    if metrics.added_lines < loc_threshold and metrics.changed_files < file_threshold:
+        agents: list[str] = list(_SMALL_DIFF_CORE_AGENTS)
+        if any(
+            fp.endswith(s) or fp.endswith(s.lstrip("/"))
+            for fp in metrics.file_paths
+            for s in _STRUCTURAL_SUFFIXES
+        ):
+            agents.insert(0, "arch")
+        return agents
+    return list(_ALL_STANDARD_AGENTS)
+
+
 def parse_hunk_ranges(diff_text: str) -> dict[str, list[tuple[int, int]]]:
     """Extract per-file valid line ranges from unified diff @@ headers.
 

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -2096,10 +2096,18 @@ callable_contracts:
     - name: output_dir
       type: directory_path
       required: true
+    - name: loc_threshold
+      type: str
+      required: false
+    - name: file_threshold
+      type: str
+      required: false
     outputs:
     - name: annotated_diff_path
       type: file_path
     - name: hunk_ranges_path
+      type: file_path
+    - name: diff_metrics_path
       type: file_path
   autoskillit.smoke_utils.compute_domain_partitions:
     inputs:

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -543,6 +543,7 @@ steps:
     capture:
       annotated_diff_path: "${{ result.annotated_diff_path }}"
       hunk_ranges_path: "${{ result.hunk_ranges_path }}"
+      diff_metrics_path: "${{ result.diff_metrics_path }}"
     on_success: review_pr
     on_failure: review_pr
     optional: true
@@ -554,7 +555,7 @@ steps:
   review_pr:
     tool: run_skill
     with:
-      skill_command: "/autoskillit:review-pr ${{ context.merge_target }} ${{ inputs.base_branch }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{ context.hunk_ranges_path }}"
+      skill_command: "/autoskillit:review-pr ${{ context.merge_target }} ${{ inputs.base_branch }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{ context.hunk_ranges_path }} diff_metrics_path=${{ context.diff_metrics_path }}"
       cwd: "${{ context.work_dir }}"
       step_name: "review_pr"
     capture:

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -533,6 +533,7 @@ steps:
     capture:
       annotated_diff_path: "${{ result.annotated_diff_path }}"
       hunk_ranges_path: "${{ result.hunk_ranges_path }}"
+      diff_metrics_path: "${{ result.diff_metrics_path }}"
     on_success: review_pr
     on_failure: review_pr
     optional: true
@@ -544,7 +545,7 @@ steps:
   review_pr:
     tool: run_skill
     with:
-      skill_command: "/autoskillit:review-pr ${{ context.merge_target }} ${{ inputs.base_branch }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{ context.hunk_ranges_path }}"
+      skill_command: "/autoskillit:review-pr ${{ context.merge_target }} ${{ inputs.base_branch }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{ context.hunk_ranges_path }} diff_metrics_path=${{ context.diff_metrics_path }}"
       cwd: "${{ context.work_dir }}"
       step_name: "review_pr"
     capture:

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -1035,6 +1035,7 @@ steps:
     capture:
       annotated_diff_path: "${{ result.annotated_diff_path }}"
       hunk_ranges_path: "${{ result.hunk_ranges_path }}"
+      diff_metrics_path: "${{ result.diff_metrics_path }}"
     on_success: review_pr_integration
     on_failure: review_pr_integration
     note: >
@@ -1046,7 +1047,7 @@ steps:
   review_pr_integration:
     tool: run_skill
     with:
-      skill_command: "/autoskillit:review-pr ${{ context.batch_branch }} ${{ inputs.base_branch }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{ context.hunk_ranges_path }}"
+      skill_command: "/autoskillit:review-pr ${{ context.batch_branch }} ${{ inputs.base_branch }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{ context.hunk_ranges_path }} diff_metrics_path=${{ context.diff_metrics_path }}"
       cwd: "${{ context.work_dir }}"
       step_name: "review_pr_integration"
     capture:

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -546,6 +546,7 @@ steps:
     capture:
       annotated_diff_path: "${{ result.annotated_diff_path }}"
       hunk_ranges_path: "${{ result.hunk_ranges_path }}"
+      diff_metrics_path: "${{ result.diff_metrics_path }}"
     on_success: review_pr
     on_failure: review_pr
     optional: true
@@ -557,7 +558,7 @@ steps:
   review_pr:
     tool: run_skill
     with:
-      skill_command: "/autoskillit:review-pr ${{ context.merge_target }} ${{ inputs.base_branch }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{ context.hunk_ranges_path }}"
+      skill_command: "/autoskillit:review-pr ${{ context.merge_target }} ${{ inputs.base_branch }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{ context.hunk_ranges_path }} diff_metrics_path=${{ context.diff_metrics_path }}"
       cwd: "${{ context.work_dir }}"
       step_name: "review_pr"
     capture:

--- a/src/autoskillit/skills_extended/review-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/review-pr/SKILL.md
@@ -19,12 +19,13 @@ by the recipe pipeline after `open_pr_step` opens the PR.
 
 ## Arguments
 
-`/autoskillit:review-pr <feature-branch> <base-branch> [annotated_diff_path=<path>] [hunk_ranges_path=<path>]`
+`/autoskillit:review-pr <feature-branch> <base-branch> [annotated_diff_path=<path>] [hunk_ranges_path=<path>] [diff_metrics_path=<path>]`
 
 - **feature-branch** — The feature branch containing the changes to review
 - **base-branch** — The base branch the PR targets (e.g., "main")
 - **annotated_diff_path** (optional) — absolute path to a pre-computed annotated diff file (produced by `annotate_pr_diff` run_python step). When provided and present, read from file instead of running python3.
 - **hunk_ranges_path** (optional) — absolute path to a pre-computed hunk ranges JSON file (produced by `annotate_pr_diff` run_python step). When provided and present, read from file instead of running python3.
+- **diff_metrics_path** (optional) — absolute path to a pre-computed diff metrics JSON file (produced by `annotate_pr_diff` run_python step). Contains `dispatch_agents` list that determines which audit dimensions to spawn. When absent, all 6 standard agents are dispatched.
 
 ## When to Use
 
@@ -242,9 +243,40 @@ deletion_context = {
 If `MERGE_BASE` is empty or any git command fails, set `deletion_context = null`.
 The parallel deletion regression audit is skipped when `deletion_context` is null.
 
+### Step 2.9: Diff-Size Adaptive Agent Selection
+
+Read the pre-computed diff metrics when available:
+
+```bash
+DISPATCH_AGENTS=""
+if [ -n "${diff_metrics_path:-}" ] && [ -f "$diff_metrics_path" ]; then
+    DISPATCH_AGENTS=$(cat "$diff_metrics_path" | python3 -c "import sys,json; print(','.join(json.load(sys.stdin).get('dispatch_agents',[])))" 2>/dev/null || echo "")
+fi
+```
+
+`DISPATCH_AGENTS` is a comma-separated list of audit dimension names to spawn in Step 3
+(e.g., `"tests,cohesion"` for a small diff, or `"arch,tests,defense,bugs,cohesion,slop"`
+for a medium/large diff).
+
+When `DISPATCH_AGENTS` is empty (metrics file absent or unparseable), dispatch all 6
+standard agents — this is the graceful-degradation fallback that preserves current behavior.
+
+**Agent selection tiers:**
+- **Small diff** (<200 added LoC and <5 changed files): `tests`, `cohesion`, and optionally `arch` if structural files changed (e.g., `__init__.py`, `pyproject.toml`).
+- **Medium/large diff** (>= 200 added LoC or >= 5 changed files): All 6 standard agents (`arch`, `tests`, `defense`, `bugs`, `cohesion`, `slop`).
+
+Note: `deletion_regression` (dimension 7) is NOT part of the dispatch plan — it remains
+unconditionally gated on `deletion_context` being non-null (unchanged from current behavior).
+
 ### Step 3: Run Parallel Audit Subagents
 
-Spawn parallel subagents (Task tool, model: sonnet) for each audit dimension.
+Spawn parallel subagents (Task tool, model: sonnet) for each audit dimension listed in
+`DISPATCH_AGENTS`. If `DISPATCH_AGENTS` is non-empty, spawn ONLY the dimensions it lists.
+If `DISPATCH_AGENTS` is empty, spawn all 6 standard dimensions (1-6).
+
+Parse `DISPATCH_AGENTS` (comma-separated string) into a list. For each dimension name in
+the list, spawn the corresponding subagent using the prompt template below.
+
 Each subagent receives only the PR diff content (not the full codebase) and returns
 findings in JSON format:
 

--- a/src/autoskillit/skills_extended/review-pr/SKILL.md
+++ b/src/autoskillit/skills_extended/review-pr/SKILL.md
@@ -265,7 +265,7 @@ standard agents — this is the graceful-degradation fallback that preserves cur
 - **Small diff** (<200 added LoC and <5 changed files): `tests`, `cohesion`, and optionally `arch` if structural files changed (e.g., `__init__.py`, `pyproject.toml`).
 - **Medium/large diff** (>= 200 added LoC or >= 5 changed files): All 6 standard agents (`arch`, `tests`, `defense`, `bugs`, `cohesion`, `slop`).
 
-Note: `deletion_regression` (dimension 7) is NOT part of the dispatch plan — it remains
+Note: Dimension 7 (the deletion regression audit) is NOT part of the dispatch plan — it remains
 unconditionally gated on `deletion_context` being non-null (unchanged from current behavior).
 
 ### Step 3: Run Parallel Audit Subagents

--- a/src/autoskillit/smoke_utils.py
+++ b/src/autoskillit/smoke_utils.py
@@ -74,7 +74,12 @@ def annotate_pr_diff(
     import subprocess  # noqa: PLC0415
 
     from autoskillit.core import atomic_write  # noqa: PLC0415
-    from autoskillit.execution import annotate_diff, compute_diff_metrics, parse_hunk_ranges, select_review_agents  # noqa: PLC0415
+    from autoskillit.execution import (
+        annotate_diff,
+        compute_diff_metrics,
+        parse_hunk_ranges,
+        select_review_agents,
+    )  # noqa: PLC0415
 
     result = subprocess.run(
         ["gh", "pr", "diff", pr_number],
@@ -95,7 +100,9 @@ def annotate_pr_diff(
     loc_thresh = int(loc_threshold) if loc_threshold else 200
     file_thresh = int(file_threshold) if file_threshold else 5
     dispatch = select_review_agents(
-        metrics, loc_threshold=loc_thresh, file_threshold=file_thresh,
+        metrics,
+        loc_threshold=loc_thresh,
+        file_threshold=file_thresh,
     )
     metrics_data = {
         "added_lines": metrics.added_lines,

--- a/src/autoskillit/smoke_utils.py
+++ b/src/autoskillit/smoke_utils.py
@@ -58,7 +58,13 @@ def compute_domain_partitions(
     return {"domain_partitions_path": str(out_path)}
 
 
-def annotate_pr_diff(pr_number: str, cwd: str, output_dir: str) -> dict[str, str]:
+def annotate_pr_diff(
+    pr_number: str,
+    cwd: str,
+    output_dir: str,
+    loc_threshold: str = "",
+    file_threshold: str = "",
+) -> dict[str, str]:
     """Fetch and annotate a PR diff server-side for review-pr.
 
     Called by run_python from the annotate_pr_diff step in merge-prs.yaml.
@@ -68,7 +74,7 @@ def annotate_pr_diff(pr_number: str, cwd: str, output_dir: str) -> dict[str, str
     import subprocess  # noqa: PLC0415
 
     from autoskillit.core import atomic_write  # noqa: PLC0415
-    from autoskillit.execution import annotate_diff, parse_hunk_ranges  # noqa: PLC0415
+    from autoskillit.execution import annotate_diff, compute_diff_metrics, parse_hunk_ranges, select_review_agents  # noqa: PLC0415
 
     result = subprocess.run(
         ["gh", "pr", "diff", pr_number],
@@ -85,9 +91,25 @@ def annotate_pr_diff(pr_number: str, cwd: str, output_dir: str) -> dict[str, str
     ranges_path = out / f"ranges_{pr_number}.json"
     atomic_write(annotated_path, annotate_diff(diff))
     atomic_write(ranges_path, json.dumps(parse_hunk_ranges(diff)))
+    metrics = compute_diff_metrics(diff)
+    loc_thresh = int(loc_threshold) if loc_threshold else 200
+    file_thresh = int(file_threshold) if file_threshold else 5
+    dispatch = select_review_agents(
+        metrics, loc_threshold=loc_thresh, file_threshold=file_thresh,
+    )
+    metrics_data = {
+        "added_lines": metrics.added_lines,
+        "removed_lines": metrics.removed_lines,
+        "changed_files": metrics.changed_files,
+        "file_paths": metrics.file_paths,
+        "dispatch_agents": dispatch,
+    }
+    metrics_path = out / f"metrics_{pr_number}.json"
+    atomic_write(metrics_path, json.dumps(metrics_data))
     return {
         "annotated_diff_path": str(annotated_path),
         "hunk_ranges_path": str(ranges_path),
+        "diff_metrics_path": str(metrics_path),
     }
 
 

--- a/tests/contracts/test_review_pr_diff_annotation.py
+++ b/tests/contracts/test_review_pr_diff_annotation.py
@@ -70,3 +70,21 @@ def test_review_pr_skill_reads_hunk_ranges_from_file() -> None:
     assert "hunk_ranges_path" in skill_text, (
         "review-pr SKILL.md must read hunk_ranges_path from disk"
     )
+
+
+def test_review_pr_contract_has_diff_metrics_path() -> None:
+    """annotate_pr_diff callable contract must declare diff_metrics_path output."""
+    raw = yaml.safe_load(_CONTRACTS_YAML.read_text())
+    outputs = raw.get("callable_contracts", {}).get("autoskillit.smoke_utils.annotate_pr_diff", {}).get("outputs", [])
+    names = [o["name"] for o in outputs]
+    assert "diff_metrics_path" in names, (
+        "annotate_pr_diff contract must have a diff_metrics_path output entry"
+    )
+
+
+def test_review_pr_skill_reads_diff_metrics_from_file() -> None:
+    """review-pr SKILL.md must reference diff_metrics_path."""
+    skill_text = _SKILL_MD.read_text()
+    assert "diff_metrics_path" in skill_text, (
+        "review-pr SKILL.md must read diff_metrics_path from disk"
+    )

--- a/tests/contracts/test_review_pr_diff_annotation.py
+++ b/tests/contracts/test_review_pr_diff_annotation.py
@@ -75,7 +75,11 @@ def test_review_pr_skill_reads_hunk_ranges_from_file() -> None:
 def test_review_pr_contract_has_diff_metrics_path() -> None:
     """annotate_pr_diff callable contract must declare diff_metrics_path output."""
     raw = yaml.safe_load(_CONTRACTS_YAML.read_text())
-    outputs = raw.get("callable_contracts", {}).get("autoskillit.smoke_utils.annotate_pr_diff", {}).get("outputs", [])
+    outputs = (
+        raw.get("callable_contracts", {})
+        .get("autoskillit.smoke_utils.annotate_pr_diff", {})
+        .get("outputs", [])
+    )
     names = [o["name"] for o in outputs]
     assert "diff_metrics_path" in names, (
         "annotate_pr_diff contract must have a diff_metrics_path output entry"

--- a/tests/execution/test_diff_annotator.py
+++ b/tests/execution/test_diff_annotator.py
@@ -294,7 +294,13 @@ class TestComputeDiffMetrics:
         assert set(metrics.file_paths) == {"a.py", "b.py", "c.py"}
 
     def test_extracts_file_paths(self):
-        diff = "diff --git a/src/app.py b/src/app.py\n--- a/src/app.py\n+++ b/src/app.py\n@@ -1,1 +1,2 @@\n+x\n"
+        diff = (
+            "diff --git a/src/app.py b/src/app.py\n"
+            "--- a/src/app.py\n"
+            "+++ b/src/app.py\n"
+            "@@ -1,1 +1,2 @@\n"
+            "+x\n"
+        )
         metrics = compute_diff_metrics(diff)
         assert metrics.file_paths == ["src/app.py"]
 
@@ -317,14 +323,22 @@ class TestComputeDiffMetrics:
 
 class TestSelectReviewAgents:
     def test_small_diff_returns_core_agents(self):
-        metrics = DiffMetrics(added_lines=50, removed_lines=10, changed_files=2,
-                              file_paths=["src/foo.py", "tests/test_foo.py"])
+        metrics = DiffMetrics(
+            added_lines=50,
+            removed_lines=10,
+            changed_files=2,
+            file_paths=["src/foo.py", "tests/test_foo.py"],
+        )
         agents = select_review_agents(metrics)
         assert agents == ["tests", "cohesion"]
 
     def test_small_diff_with_structural_adds_arch(self):
-        metrics = DiffMetrics(added_lines=30, removed_lines=5, changed_files=2,
-                              file_paths=["src/pkg/__init__.py", "src/pkg/mod.py"])
+        metrics = DiffMetrics(
+            added_lines=30,
+            removed_lines=5,
+            changed_files=2,
+            file_paths=["src/pkg/__init__.py", "src/pkg/mod.py"],
+        )
         agents = select_review_agents(metrics)
         assert "arch" in agents
         assert "tests" in agents
@@ -332,27 +346,32 @@ class TestSelectReviewAgents:
         assert len(agents) == 3
 
     def test_medium_diff_returns_all_agents(self):
-        metrics = DiffMetrics(added_lines=200, removed_lines=50, changed_files=3,
-                              file_paths=["a.py", "b.py", "c.py"])
+        metrics = DiffMetrics(
+            added_lines=200, removed_lines=50, changed_files=3, file_paths=["a.py", "b.py", "c.py"]
+        )
         agents = select_review_agents(metrics)
         assert set(agents) == {"arch", "tests", "defense", "bugs", "cohesion", "slop"}
 
     def test_many_files_returns_all_agents(self):
         fps = [f"f{i}.py" for i in range(5)]
-        metrics = DiffMetrics(added_lines=50, removed_lines=0, changed_files=5,
-                              file_paths=fps)
+        metrics = DiffMetrics(added_lines=50, removed_lines=0, changed_files=5, file_paths=fps)
         agents = select_review_agents(metrics)
         assert set(agents) == {"arch", "tests", "defense", "bugs", "cohesion", "slop"}
 
     def test_custom_thresholds(self):
-        metrics = DiffMetrics(added_lines=150, removed_lines=0, changed_files=3,
-                              file_paths=["a.py", "b.py", "c.py"])
+        metrics = DiffMetrics(
+            added_lines=150, removed_lines=0, changed_files=3, file_paths=["a.py", "b.py", "c.py"]
+        )
         assert len(select_review_agents(metrics)) < 6
         agents = select_review_agents(metrics, loc_threshold=100)
         assert set(agents) == {"arch", "tests", "defense", "bugs", "cohesion", "slop"}
 
     def test_deletion_regression_never_included(self):
-        metrics = DiffMetrics(added_lines=500, removed_lines=200, changed_files=10,
-                              file_paths=[f"f{i}.py" for i in range(10)])
+        metrics = DiffMetrics(
+            added_lines=500,
+            removed_lines=200,
+            changed_files=10,
+            file_paths=[f"f{i}.py" for i in range(10)],
+        )
         agents = select_review_agents(metrics)
         assert "deletion_regression" not in agents

--- a/tests/execution/test_diff_annotator.py
+++ b/tests/execution/test_diff_annotator.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 import pytest
 
 from autoskillit.execution.diff_annotator import (
+    DiffMetrics,
     annotate_diff,
+    compute_diff_metrics,
     filter_findings,
     parse_hunk_ranges,
+    select_review_agents,
 )
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
@@ -244,3 +247,112 @@ class TestEndToEnd:
         assert len(result.unpostable) == 1
         assert result.unpostable[0]["message"] == "stream offset"
         assert result.all_unpostable is False
+
+
+# --- compute_diff_metrics ---
+
+
+class TestComputeDiffMetrics:
+    def test_counts_added_lines(self):
+        diff = (
+            "diff --git a/f.py b/f.py\n"
+            "--- a/f.py\n"
+            "+++ b/f.py\n"
+            "@@ -1,2 +1,4 @@\n"
+            " existing\n"
+            "+new_line_1\n"
+            "+new_line_2\n"
+            " more\n"
+        )
+        metrics = compute_diff_metrics(diff)
+        assert metrics.added_lines == 2
+
+    def test_counts_removed_lines(self):
+        diff = (
+            "diff --git a/f.py b/f.py\n"
+            "--- a/f.py\n"
+            "+++ b/f.py\n"
+            "@@ -1,3 +1,1 @@\n"
+            "-old_1\n"
+            "-old_2\n"
+            " kept\n"
+        )
+        metrics = compute_diff_metrics(diff)
+        assert metrics.removed_lines == 2
+
+    def test_counts_changed_files(self):
+        diff = (
+            "diff --git a/a.py b/a.py\n--- a/a.py\n+++ b/a.py\n"
+            "@@ -1,1 +1,2 @@\n+x\n"
+            "diff --git a/b.py b/b.py\n--- a/b.py\n+++ b/b.py\n"
+            "@@ -1,1 +1,2 @@\n+y\n"
+            "diff --git a/c.py b/c.py\n--- a/c.py\n+++ b/c.py\n"
+            "@@ -1,1 +1,2 @@\n+z\n"
+        )
+        metrics = compute_diff_metrics(diff)
+        assert metrics.changed_files == 3
+        assert set(metrics.file_paths) == {"a.py", "b.py", "c.py"}
+
+    def test_extracts_file_paths(self):
+        diff = "diff --git a/src/app.py b/src/app.py\n--- a/src/app.py\n+++ b/src/app.py\n@@ -1,1 +1,2 @@\n+x\n"
+        metrics = compute_diff_metrics(diff)
+        assert metrics.file_paths == ["src/app.py"]
+
+    def test_empty_diff(self):
+        metrics = compute_diff_metrics("")
+        assert metrics.added_lines == 0
+        assert metrics.removed_lines == 0
+        assert metrics.changed_files == 0
+        assert metrics.file_paths == []
+
+    def test_ignores_diff_headers(self):
+        diff = "diff --git a/f.py b/f.py\n--- a/f.py\n+++ b/f.py\n@@ -1,1 +1,1 @@\n context\n"
+        metrics = compute_diff_metrics(diff)
+        assert metrics.added_lines == 0
+        assert metrics.removed_lines == 0
+
+
+# --- select_review_agents ---
+
+
+class TestSelectReviewAgents:
+    def test_small_diff_returns_core_agents(self):
+        metrics = DiffMetrics(added_lines=50, removed_lines=10, changed_files=2,
+                              file_paths=["src/foo.py", "tests/test_foo.py"])
+        agents = select_review_agents(metrics)
+        assert agents == ["tests", "cohesion"]
+
+    def test_small_diff_with_structural_adds_arch(self):
+        metrics = DiffMetrics(added_lines=30, removed_lines=5, changed_files=2,
+                              file_paths=["src/pkg/__init__.py", "src/pkg/mod.py"])
+        agents = select_review_agents(metrics)
+        assert "arch" in agents
+        assert "tests" in agents
+        assert "cohesion" in agents
+        assert len(agents) == 3
+
+    def test_medium_diff_returns_all_agents(self):
+        metrics = DiffMetrics(added_lines=200, removed_lines=50, changed_files=3,
+                              file_paths=["a.py", "b.py", "c.py"])
+        agents = select_review_agents(metrics)
+        assert set(agents) == {"arch", "tests", "defense", "bugs", "cohesion", "slop"}
+
+    def test_many_files_returns_all_agents(self):
+        fps = [f"f{i}.py" for i in range(5)]
+        metrics = DiffMetrics(added_lines=50, removed_lines=0, changed_files=5,
+                              file_paths=fps)
+        agents = select_review_agents(metrics)
+        assert set(agents) == {"arch", "tests", "defense", "bugs", "cohesion", "slop"}
+
+    def test_custom_thresholds(self):
+        metrics = DiffMetrics(added_lines=150, removed_lines=0, changed_files=3,
+                              file_paths=["a.py", "b.py", "c.py"])
+        assert len(select_review_agents(metrics)) < 6
+        agents = select_review_agents(metrics, loc_threshold=100)
+        assert set(agents) == {"arch", "tests", "defense", "bugs", "cohesion", "slop"}
+
+    def test_deletion_regression_never_included(self):
+        metrics = DiffMetrics(added_lines=500, removed_lines=200, changed_files=10,
+                              file_paths=[f"f{i}.py" for i in range(10)])
+        agents = select_review_agents(metrics)
+        assert "deletion_regression" not in agents

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -151,10 +151,11 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/cli/update/_update_checks.py", 79),
     # _update_checks_fetch.py — fetch cache (extracted from _update_checks.py)
     ("src/autoskillit/cli/update/_update_checks_fetch.py", 58),
-    # smoke_utils.py — domain partitions dict, hunk ranges list, merge queue list
+    # smoke_utils.py — partitions dict, ranges list, diff metrics dict, queue list
     ("src/autoskillit/smoke_utils.py", 57),
-    ("src/autoskillit/smoke_utils.py", 87),
-    ("src/autoskillit/smoke_utils.py", 299),
+    ("src/autoskillit/smoke_utils.py", 98),
+    ("src/autoskillit/smoke_utils.py", 115),
+    ("src/autoskillit/smoke_utils.py", 328),
     # planner/consolidation.py — write-back of merged WP dicts to per-file results
     ("src/autoskillit/planner/consolidation.py", 310),
     # planner/manifests.py — finalize_wp_manifest: wp_index.json rebuild (list payload)
@@ -221,8 +222,8 @@ class TestSchemaVersionConvention:
         """List-payload sites are included since the AST scanner can't distinguish return types."""
         # These sites write list payloads through function calls but are caught by the scanner
         list_sites = [
-            ("src/autoskillit/smoke_utils.py", 87),
-            ("src/autoskillit/smoke_utils.py", 299),
+            ("src/autoskillit/smoke_utils.py", 98),
+            ("src/autoskillit/smoke_utils.py", 328),
         ]
         for site in list_sites:
             assert site in _LEGACY_JSON_WRITES, (

--- a/tests/recipe/test_bundled_recipes_review_pr.py
+++ b/tests/recipe/test_bundled_recipes_review_pr.py
@@ -128,6 +128,16 @@ class TestReviewPrRecipeIntegration:
             "It must not silently fall through the catch-all."
         )
 
+    def test_annotate_step_captures_diff_metrics_path(self, recipe: object) -> None:
+        step = recipe.steps["annotate_pr_diff"]  # type: ignore[attr-defined]
+        assert "diff_metrics_path" in step.capture
+        assert step.capture["diff_metrics_path"] == "${{ result.diff_metrics_path }}"
+
+    def test_review_pr_command_includes_diff_metrics_path(self, recipe: object) -> None:
+        step = recipe.steps["review_pr"]  # type: ignore[attr-defined]
+        cmd = step.with_args.get("skill_command", "")
+        assert "diff_metrics_path=" in cmd
+
     def test_resolve_review_step_uses_correct_skill(self, recipe: object) -> None:
         """resolve_review step must invoke /autoskillit:resolve-review in all recipes."""
         resolve_step = recipe.steps["resolve_review"]  # type: ignore[attr-defined]
@@ -144,3 +154,16 @@ def test_implementation_groups_has_ci_watch() -> None:
     assert "ci_watch" in recipe.steps
     assert "resolve_ci" in recipe.steps
     assert "re_push" in recipe.steps
+
+
+def test_merge_prs_review_pr_integration_includes_diff_metrics_path() -> None:
+    recipe = load_recipe(builtin_recipes_dir() / "merge-prs.yaml")
+    step = recipe.steps["review_pr_integration"]
+    cmd = step.with_args.get("skill_command", "")
+    assert "diff_metrics_path=" in cmd
+
+
+def test_merge_prs_annotate_step_captures_diff_metrics_path() -> None:
+    recipe = load_recipe(builtin_recipes_dir() / "merge-prs.yaml")
+    step = recipe.steps["annotate_pr_diff"]
+    assert "diff_metrics_path" in step.capture

--- a/tests/skills/test_review_pr_adaptive_dispatch_guards.py
+++ b/tests/skills/test_review_pr_adaptive_dispatch_guards.py
@@ -6,7 +6,11 @@ from pathlib import Path
 
 SKILL_PATH = (
     Path(__file__).parent.parent.parent
-    / "src" / "autoskillit" / "skills_extended" / "review-pr" / "SKILL.md"
+    / "src"
+    / "autoskillit"
+    / "skills_extended"
+    / "review-pr"
+    / "SKILL.md"
 )
 
 

--- a/tests/skills/test_review_pr_adaptive_dispatch_guards.py
+++ b/tests/skills/test_review_pr_adaptive_dispatch_guards.py
@@ -1,0 +1,41 @@
+"""Behavioral guard tests for review-pr adaptive subagent dispatch."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+SKILL_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src" / "autoskillit" / "skills_extended" / "review-pr" / "SKILL.md"
+)
+
+
+def _skill_text() -> str:
+    return SKILL_PATH.read_text()
+
+
+def test_skill_accepts_diff_metrics_path_argument():
+    text = _skill_text()
+    assert "diff_metrics_path" in text
+
+
+def test_skill_defines_diff_size_gate_step():
+    text = _skill_text()
+    assert "dispatch_agents" in text
+
+
+def test_small_diff_skips_defense_bugs_slop():
+    text = _skill_text().lower()
+    assert "small" in text
+
+
+def test_small_diff_always_includes_tests_cohesion():
+    text = _skill_text().lower()
+    assert "tests" in text
+    assert "cohesion" in text
+
+
+def test_full_fanout_for_medium_and_large():
+    text = _skill_text()
+    for agent in ["arch", "tests", "defense", "bugs", "cohesion", "slop"]:
+        assert agent in text


### PR DESCRIPTION
## Summary

Add diff-size-adaptive subagent dispatch to the review-pr skill. The review-pr skill currently spawns a fixed fan-out of 7 parallel audit subagents regardless of diff size. For small diffs (<200 added LoC and <5 changed files), 5 of 7 subagents typically return zero findings, wasting ~65k child-session tokens and ~7k parent output tokens per review.

This plan adds:
1. A `DiffMetrics` dataclass and `compute_diff_metrics()` function to `diff_annotator.py`
2. A `select_review_agents()` function that maps metrics to an agent dispatch list
3. Server-side metrics computation in `annotate_pr_diff()` with dispatch plan written to disk
4. A new Step 2.9 in SKILL.md that reads the pre-computed dispatch plan
5. Modified Step 3 that dispatches only the selected agents
6. Updated recipe YAML pipeline plumbing (4 files) to pass `diff_metrics_path`

The agent selection decision is made server-side in Python (testable, deterministic) rather than by the LLM at runtime. The SKILL.md reads the pre-computed `dispatch_agents` list from the metrics file and dispatches only those agents.

Closes #1794

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-1794-20260503-215012-045818/.autoskillit/temp/make-plan/diff_size_adaptive_subagent_dispatch_plan_2026-05-03_220000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| plan | 70 | 20.9k | 1.4M | 77.1k | 1 | 11m 30s |
| verify | 56 | 16.7k | 2.6M | 76.0k | 1 | 7m 21s |
| implement | 89 | 24.8k | 3.4M | 84.2k | 1 | 7m 48s |
| prepare_pr | 26 | 4.9k | 270.7k | 31.3k | 1 | 1m 34s |
| compose_pr | 23 | 1.6k | 152.0k | 16.4k | 1 | 42s |
| review_pr | 444 | 28.2k | 565.3k | 65.0k | 1 | 6m 46s |
| resolve_review | 41 | 12.4k | 1.1M | 124.8k | 1 | 7m 50s |
| **Total** | 749 | 109.5k | 9.6M | 474.7k | | 43m 34s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 386 | 8871.0 | 218.1 | 64.2 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 6 | 191360.7 | 20802.5 | 2062.5 |
| **Total** | **392** | 24454.7 | 1211.0 | 279.4 |