### PR TITLE
Merge Queue Dequeue Confirmation — Structural Immunity for Premature State Transitions

### DIFF
--- a/src/autoskillit/execution/merge_queue/__init__.py
+++ b/src/autoskillit/execution/merge_queue/__init__.py
@@ -171,6 +171,9 @@ class DefaultMergeQueueWatcher:
                 if state["queue_state"] == "UNMERGEABLE":
                     pending_ejection = PRState.EJECTED
                     pending_reason = "PR is UNMERGEABLE in merge queue"
+                else:
+                    pending_ejection = None
+                    pending_reason = ""
                 await asyncio.sleep(poll_interval)
                 continue
 

--- a/src/autoskillit/execution/merge_queue/__init__.py
+++ b/src/autoskillit/execution/merge_queue/__init__.py
@@ -220,6 +220,13 @@ class DefaultMergeQueueWatcher:
             if classification.terminal == PRState.MERGED:
                 return _make_result(True, PRState.MERGED, classification.reason)
 
+            if not_in_queue_cycles < not_in_queue_confirmation_cycles:
+                await asyncio.sleep(poll_interval)
+                continue
+
+            if pending_ejection is not None:
+                return _make_result(False, pending_ejection, pending_reason)
+
             if state["state"] == "CLOSED":
                 ejection_cause = (
                     "ci_failure" if classification.terminal == PRState.EJECTED_CI_FAILURE else ""
@@ -227,13 +234,6 @@ class DefaultMergeQueueWatcher:
                 return _make_result(
                     False, classification.terminal, classification.reason, ejection_cause
                 )
-
-            if not_in_queue_cycles < not_in_queue_confirmation_cycles:
-                await asyncio.sleep(poll_interval)
-                continue
-
-            if pending_ejection is not None:
-                return _make_result(False, pending_ejection, pending_reason)
 
             if classification.terminal == PRState.STALLED:
                 enabled_at = state["auto_merge_enabled_at"]

--- a/src/autoskillit/execution/merge_queue/__init__.py
+++ b/src/autoskillit/execution/merge_queue/__init__.py
@@ -37,6 +37,7 @@ from autoskillit.execution.merge_queue._merge_queue_group_ci import (
     _MUTATION_ENABLE_AUTO_MERGE,
     _MUTATION_ENQUEUE_PR,
     _QUERY,  # noqa: F401 — re-export: tests assert merge_queue._QUERY exists
+    _QUERY_AUTO_MERGE_STATUS,
     _query_merge_group_ci,  # noqa: F401 — re-export: tests patch merge_queue._query_merge_group_ci
 )
 from autoskillit.execution.merge_queue._merge_queue_repo_state import (
@@ -133,6 +134,8 @@ class DefaultMergeQueueWatcher:
         ever_enrolled: bool = False
         was_in_queue: bool = False
         merge_group_ci_cache: str | None = None
+        pending_ejection: PRState | None = None
+        pending_reason: str = ""
 
         def _make_result(
             success: bool, pr_state: PRState, reason: str, ejection_cause: str = ""
@@ -166,7 +169,8 @@ class DefaultMergeQueueWatcher:
                 not_in_queue_cycles = 0
                 inconclusive_count = 0
                 if state["queue_state"] == "UNMERGEABLE":
-                    return _make_result(False, PRState.EJECTED, "PR is UNMERGEABLE in merge queue")
+                    pending_ejection = PRState.EJECTED
+                    pending_reason = "PR is UNMERGEABLE in merge queue"
                 await asyncio.sleep(poll_interval)
                 continue
 
@@ -227,6 +231,9 @@ class DefaultMergeQueueWatcher:
             if not_in_queue_cycles < not_in_queue_confirmation_cycles:
                 await asyncio.sleep(poll_interval)
                 continue
+
+            if pending_ejection is not None:
+                return _make_result(False, pending_ejection, pending_reason)
 
             if classification.terminal == PRState.STALLED:
                 enabled_at = state["auto_merge_enabled_at"]
@@ -467,5 +474,24 @@ class DefaultMergeQueueWatcher:
         body = resp.json()
         if "errors" in body:
             raise RuntimeError(f"GraphQL mutation error: {body['errors']}")
-        await asyncio.sleep(2)
+        await self._confirm_disable(pr_node_id)
         await self._enable_auto_merge_direct(pr_node_id)
+
+    async def _confirm_disable(self, pr_node_id: str) -> None:
+        """Poll until auto-merge disable is confirmed or timeout (best-effort)."""
+        for _ in range(6):
+            await asyncio.sleep(5)
+            resp = await self._ensure_client().post(
+                _GRAPHQL_ENDPOINT,
+                json={
+                    "query": _QUERY_AUTO_MERGE_STATUS,
+                    "variables": {"nodeId": pr_node_id},
+                },
+            )
+            if resp.status_code != 200:
+                continue
+            data = resp.json().get("data", {})
+            node = data.get("node", {}) or {}
+            if not node.get("autoMergeRequest"):
+                return
+        logger.warning("confirm_disable_timeout", pr_node_id=pr_node_id)

--- a/src/autoskillit/execution/merge_queue/__init__.py
+++ b/src/autoskillit/execution/merge_queue/__init__.py
@@ -492,8 +492,16 @@ class DefaultMergeQueueWatcher:
                 },
             )
             if resp.status_code != 200:
+                logger.warning(
+                    "confirm_disable_poll_error",
+                    pr_node_id=pr_node_id,
+                    status_code=resp.status_code,
+                )
                 continue
-            data = resp.json().get("data", {})
+            try:
+                data = resp.json().get("data", {})
+            except (ValueError, httpx.DecodingError):
+                continue
             node = data.get("node", {}) or {}
             if not node.get("autoMergeRequest"):
                 return

--- a/src/autoskillit/execution/merge_queue/__init__.py
+++ b/src/autoskillit/execution/merge_queue/__init__.py
@@ -465,14 +465,11 @@ class DefaultMergeQueueWatcher:
         if not auto_merge_available:
             await self._enqueue_direct(pr_node_id)
             return
-        # Disable then re-enable auto-merge.
-        resp = await self._ensure_client().post(
-            _GRAPHQL_ENDPOINT,
-            json={
-                "query": _MUTATION_DISABLE_AUTO_MERGE,
-                "variables": {"prId": pr_node_id},
-            },
-        )
+        disable_payload = {
+            "query": _MUTATION_DISABLE_AUTO_MERGE,
+            "variables": {"prId": pr_node_id},
+        }
+        resp = await self._ensure_client().post(_GRAPHQL_ENDPOINT, json=disable_payload)
         resp.raise_for_status()
         body = resp.json()
         if "errors" in body:
@@ -482,15 +479,10 @@ class DefaultMergeQueueWatcher:
 
     async def _confirm_disable(self, pr_node_id: str) -> None:
         """Poll until auto-merge disable is confirmed or timeout (best-effort)."""
+        payload = {"query": _QUERY_AUTO_MERGE_STATUS, "variables": {"nodeId": pr_node_id}}
         for _ in range(6):
             await asyncio.sleep(5)
-            resp = await self._ensure_client().post(
-                _GRAPHQL_ENDPOINT,
-                json={
-                    "query": _QUERY_AUTO_MERGE_STATUS,
-                    "variables": {"nodeId": pr_node_id},
-                },
-            )
+            resp = await self._ensure_client().post(_GRAPHQL_ENDPOINT, json=payload)
             if resp.status_code != 200:
                 logger.warning(
                     "confirm_disable_poll_error",
@@ -502,7 +494,6 @@ class DefaultMergeQueueWatcher:
                 data = resp.json().get("data", {})
             except (ValueError, httpx.DecodingError):
                 continue
-            node = data.get("node", {}) or {}
-            if not node.get("autoMergeRequest"):
+            if not (data.get("node") or {}).get("autoMergeRequest"):
                 return
         logger.warning("confirm_disable_timeout", pr_node_id=pr_node_id)

--- a/src/autoskillit/execution/merge_queue/_merge_queue_group_ci.py
+++ b/src/autoskillit/execution/merge_queue/_merge_queue_group_ci.py
@@ -81,6 +81,16 @@ mutation EnqueuePullRequest($prId: ID!) {
 }
 """
 
+_QUERY_AUTO_MERGE_STATUS = """
+query AutoMergeStatus($nodeId: ID!) {
+  node(id: $nodeId) {
+    ... on PullRequest {
+      autoMergeRequest { enabledAt }
+    }
+  }
+}
+"""
+
 
 async def _query_merge_group_ci(
     repo: str,

--- a/src/autoskillit/recipe/__init__.py
+++ b/src/autoskillit/recipe/__init__.py
@@ -74,6 +74,7 @@ from autoskillit.recipe.rules import rules_inline_script as _rules_inline_script
 from autoskillit.recipe.rules import rules_inputs as _rules_inputs  # noqa: E402 F401
 from autoskillit.recipe.rules import rules_isolation as _rules_isolation  # noqa: E402 F401
 from autoskillit.recipe.rules import rules_merge as _rules_merge  # noqa: E402 F401
+from autoskillit.recipe.rules import rules_merge_queue as _rules_merge_queue  # noqa: E402 F401
 from autoskillit.recipe.rules import rules_packs as _rules_packs  # noqa: E402 F401
 from autoskillit.recipe.rules import rules_reachability as _rules_reachability  # noqa: E402 F401
 from autoskillit.recipe.rules import rules_recipe as _rules_recipe  # noqa: E402 F401

--- a/src/autoskillit/recipe/rules/CLAUDE.md
+++ b/src/autoskillit/recipe/rules/CLAUDE.md
@@ -1,6 +1,6 @@
 # rules/
 
-Semantic validation rule modules for recipe analysis (25 rule files).
+Semantic validation rule modules for recipe analysis (26 rule files).
 
 ## Files
 
@@ -23,6 +23,7 @@ Semantic validation rule modules for recipe analysis (25 rule files).
 | `rules_inputs.py` | Input/ingredient validation; version compatibility checks |
 | `rules_isolation.py` | Workspace isolation rules (prevents operating on source repo) |
 | `rules_merge.py` | `merge_worktree` routing completeness |
+| `rules_merge_queue.py` | Merge queue push routing: `queued_branch` error route enforcement |
 | `rules_packs.py` | Pack validation (names must exist in `PACK_REGISTRY`) |
 | `rules_reachability.py` | Symbolic BFS reachability; capture-inversion detection |
 | `rules_recipe.py` | Sub-recipe reference validity and `with_args` hygiene |
@@ -35,4 +36,4 @@ Semantic validation rule modules for recipe analysis (25 rule files).
 
 ## Architecture Notes
 
-Side-effect registration: callers import the package to trigger `@semantic_rule` decorator registration of all 25 rule modules. Each rule receives a `ValidationContext` argument. No cross-imports between rule modules.
+Side-effect registration: callers import the package to trigger `@semantic_rule` decorator registration of all 26 rule modules. Each rule receives a `ValidationContext` argument. No cross-imports between rule modules.

--- a/src/autoskillit/recipe/rules/rules_merge_queue.py
+++ b/src/autoskillit/recipe/rules/rules_merge_queue.py
@@ -9,17 +9,23 @@ from autoskillit.recipe.registry import RuleFinding, semantic_rule
 
 _MERGE_QUEUE_WAIT_TOOLS = frozenset({"wait_for_merge_queue"})
 _PUSH_TOOLS = frozenset({"push_to_remote"})
+_FLOW_BOUNDARY_TOOLS = frozenset({
+    "wait_for_merge_queue",
+    "wait_for_ci",
+    "wait_for_direct_merge",
+    "wait_for_immediate_merge",
+})
 
 
 def _collect_ejection_exit_steps(ctx: ValidationContext) -> set[str]:
     """Collect step names that are pure-ejection-route exits from merge-queue-wait steps.
 
     Only matches conditions for the ``ejected`` state, not ``ejected_ci_failure``
-    or ``dropped_*`` variants. Those routes lead to CI diagnosis or terminal paths
-    that do not need ``queued_branch`` error handling.
+    or ``dropped_*`` variants. Excludes routes whose target is itself a
+    ``wait_for_merge_queue`` step (re-enrollment, not ejection recovery).
     """
     exits: set[str] = set()
-    for step_name, step in ctx.recipe.steps.items():
+    for _name, step in ctx.recipe.steps.items():
         if step.tool not in _MERGE_QUEUE_WAIT_TOOLS:
             continue
         if step.on_result and step.on_result.conditions:
@@ -28,12 +34,15 @@ def _collect_ejection_exit_steps(ctx: ValidationContext) -> set[str]:
                     continue
                 when_lower = cond.when.lower()
                 if "ejected" in when_lower and "ejected_ci_failure" not in when_lower:
+                    target = ctx.recipe.steps.get(cond.route)
+                    if target and target.tool in _MERGE_QUEUE_WAIT_TOOLS:
+                        continue
                     exits.add(cond.route)
     return exits
 
 
 def _bfs_forward(graph: dict[str, set[str]], starts: set[str], ctx: ValidationContext) -> set[str]:
-    """BFS from start nodes, stopping at merge-queue wait step boundaries."""
+    """BFS from start nodes, stopping at flow-boundary step tools."""
     reachable: set[str] = set()
     frontier = starts & set(graph)
     while frontier:
@@ -42,7 +51,7 @@ def _bfs_forward(graph: dict[str, set[str]], starts: set[str], ctx: ValidationCo
         for name in frontier:
             for succ in graph.get(name, set()) - reachable:
                 step = ctx.recipe.steps.get(succ)
-                if step and step.tool in _MERGE_QUEUE_WAIT_TOOLS and succ not in starts:
+                if step and step.tool in _FLOW_BOUNDARY_TOOLS and succ not in starts:
                     continue
                 next_frontier.add(succ)
         frontier = next_frontier

--- a/src/autoskillit/recipe/rules/rules_merge_queue.py
+++ b/src/autoskillit/recipe/rules/rules_merge_queue.py
@@ -12,27 +12,39 @@ _PUSH_TOOLS = frozenset({"push_to_remote"})
 
 
 def _collect_ejection_exit_steps(ctx: ValidationContext) -> set[str]:
-    """Collect step names that are ejection-route exits from merge-queue-wait steps."""
+    """Collect step names that are pure-ejection-route exits from merge-queue-wait steps.
+
+    Only matches conditions for the ``ejected`` state, not ``ejected_ci_failure``
+    or ``dropped_*`` variants. Those routes lead to CI diagnosis or terminal paths
+    that do not need ``queued_branch`` error handling.
+    """
     exits: set[str] = set()
     for step_name, step in ctx.recipe.steps.items():
         if step.tool not in _MERGE_QUEUE_WAIT_TOOLS:
             continue
         if step.on_result and step.on_result.conditions:
             for cond in step.on_result.conditions:
-                if cond.when and "ejected" in cond.when.lower():
+                if not cond.when:
+                    continue
+                when_lower = cond.when.lower()
+                if "ejected" in when_lower and "ejected_ci_failure" not in when_lower:
                     exits.add(cond.route)
     return exits
 
 
-def _bfs_forward(graph: dict[str, set[str]], starts: set[str]) -> set[str]:
-    """BFS from start nodes through forward step graph."""
+def _bfs_forward(graph: dict[str, set[str]], starts: set[str], ctx: ValidationContext) -> set[str]:
+    """BFS from start nodes, stopping at merge-queue wait step boundaries."""
     reachable: set[str] = set()
     frontier = starts & set(graph)
     while frontier:
         reachable |= frontier
         next_frontier: set[str] = set()
         for name in frontier:
-            next_frontier |= graph.get(name, set()) - reachable
+            for succ in graph.get(name, set()) - reachable:
+                step = ctx.recipe.steps.get(succ)
+                if step and step.tool in _MERGE_QUEUE_WAIT_TOOLS and succ not in starts:
+                    continue
+                next_frontier.add(succ)
         frontier = next_frontier
     return reachable
 
@@ -71,7 +83,7 @@ def _check_push_after_queue_has_queued_branch_route(
     if not ejection_exits:
         return []
 
-    reachable = _bfs_forward(ctx.step_graph, ejection_exits)
+    reachable = _bfs_forward(ctx.step_graph, ejection_exits, ctx)
 
     findings: list[RuleFinding] = []
     for step_name in reachable:

--- a/src/autoskillit/recipe/rules/rules_merge_queue.py
+++ b/src/autoskillit/recipe/rules/rules_merge_queue.py
@@ -9,12 +9,32 @@ from autoskillit.recipe.registry import RuleFinding, semantic_rule
 
 _MERGE_QUEUE_WAIT_TOOLS = frozenset({"wait_for_merge_queue"})
 _PUSH_TOOLS = frozenset({"push_to_remote"})
-_FLOW_BOUNDARY_TOOLS = frozenset({
-    "wait_for_merge_queue",
-    "wait_for_ci",
-    "wait_for_direct_merge",
-    "wait_for_immediate_merge",
-})
+_FLOW_BOUNDARY_TOOLS = frozenset(
+    {
+        "wait_for_merge_queue",
+        "wait_for_ci",
+        "wait_for_direct_merge",
+        "wait_for_immediate_merge",
+    }
+)
+
+
+def _build_raw_routing_graph(ctx: ValidationContext) -> dict[str, set[str]]:
+    """Build a routing adjacency list without skip_when_false bypass edges.
+
+    ``ctx.step_graph`` includes bypass edges that jump past skippable steps,
+    creating paths around flow-boundary steps.  For ejection-flow reachability
+    we need the direct routing graph only.
+    """
+    step_names = set(ctx.recipe.steps.keys())
+    graph: dict[str, set[str]] = {name: set() for name in step_names}
+    for name, step in ctx.recipe.steps.items():
+        for edge in _extract_routing_edges(step):
+            if edge.edge_type == "exhausted" and step.action is not None:
+                continue
+            if edge.target in step_names:
+                graph[name].add(edge.target)
+    return graph
 
 
 def _collect_ejection_exit_steps(ctx: ValidationContext) -> set[str]:
@@ -92,7 +112,8 @@ def _check_push_after_queue_has_queued_branch_route(
     if not ejection_exits:
         return []
 
-    reachable = _bfs_forward(ctx.step_graph, ejection_exits, ctx)
+    raw_graph = _build_raw_routing_graph(ctx)
+    reachable = _bfs_forward(raw_graph, ejection_exits, ctx)
 
     findings: list[RuleFinding] = []
     for step_name in reachable:

--- a/src/autoskillit/recipe/rules/rules_merge_queue.py
+++ b/src/autoskillit/recipe/rules/rules_merge_queue.py
@@ -1,0 +1,95 @@
+"""Semantic rules for merge queue push routing completeness."""
+
+from __future__ import annotations
+
+from autoskillit.core import Severity
+from autoskillit.recipe._analysis import ValidationContext
+from autoskillit.recipe._analysis_graph import _extract_routing_edges
+from autoskillit.recipe.registry import RuleFinding, semantic_rule
+
+_MERGE_QUEUE_WAIT_TOOLS = frozenset({"wait_for_merge_queue"})
+_PUSH_TOOLS = frozenset({"push_to_remote"})
+
+
+def _collect_ejection_exit_steps(ctx: ValidationContext) -> set[str]:
+    """Collect step names that are ejection-route exits from merge-queue-wait steps."""
+    exits: set[str] = set()
+    for step_name, step in ctx.recipe.steps.items():
+        if step.tool not in _MERGE_QUEUE_WAIT_TOOLS:
+            continue
+        if step.on_result and step.on_result.conditions:
+            for cond in step.on_result.conditions:
+                if cond.when and "ejected" in cond.when.lower():
+                    exits.add(cond.route)
+    return exits
+
+
+def _bfs_forward(graph: dict[str, set[str]], starts: set[str]) -> set[str]:
+    """BFS from start nodes through forward step graph."""
+    reachable: set[str] = set()
+    frontier = starts & set(graph)
+    while frontier:
+        reachable |= frontier
+        next_frontier: set[str] = set()
+        for name in frontier:
+            next_frontier |= graph.get(name, set()) - reachable
+        frontier = next_frontier
+    return reachable
+
+
+def _step_has_queued_branch_route(step_name: str, ctx: ValidationContext) -> bool:
+    """Check if a step's failure target chain includes a queued_branch route."""
+    step = ctx.recipe.steps.get(step_name)
+    if not step or not step.on_failure:
+        return False
+    failure_target = step.on_failure
+    target_step = ctx.recipe.steps.get(failure_target)
+    if not target_step:
+        return False
+    edges = _extract_routing_edges(target_step)
+    for edge in edges:
+        if edge.edge_type == "result_condition" and edge.condition:
+            if "queued_branch" in edge.condition:
+                return True
+    return False
+
+
+@semantic_rule(
+    name="push-after-queue-requires-queued-branch-route",
+    description=(
+        "A push_to_remote step reachable from a merge-queue ejection route must have "
+        "its on_failure target include a queued_branch error route. Without this, a "
+        "GH006 rejection from pushing to a still-protected branch causes terminal "
+        "failure instead of recoverable retry."
+    ),
+    severity=Severity.ERROR,
+)
+def _check_push_after_queue_has_queued_branch_route(
+    ctx: ValidationContext,
+) -> list[RuleFinding]:
+    ejection_exits = _collect_ejection_exit_steps(ctx)
+    if not ejection_exits:
+        return []
+
+    reachable = _bfs_forward(ctx.step_graph, ejection_exits)
+
+    findings: list[RuleFinding] = []
+    for step_name in reachable:
+        step = ctx.recipe.steps.get(step_name)
+        if not step or step.tool not in _PUSH_TOOLS:
+            continue
+        if not _step_has_queued_branch_route(step_name, ctx):
+            findings.append(
+                RuleFinding(
+                    rule="push-after-queue-requires-queued-branch-route",
+                    severity=Severity.ERROR,
+                    step_name=step_name,
+                    message=(
+                        f"Step '{step_name}' uses push_to_remote and is reachable from a "
+                        f"merge-queue ejection route, but its on_failure chain does not "
+                        f"include a 'queued_branch' error route. Add a classify_push_failure "
+                        f"step that routes queued_branch errors to a dequeue-retry path."
+                    ),
+                )
+            )
+    return findings

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -1203,12 +1203,22 @@ steps:
       cwd: "${{ context.work_dir }}"
       timeout_seconds: "60"
     on_result:
-      - when: "${{ result.pr_state }} == 'ejected'"
+      - when: "${{ result.pr_state }} == merged"
+        route: release_issue_success
+      - when: "${{ result.pr_state }} == ejected_ci_failure"
+        route: register_clone_unconfirmed
+      - when: "${{ result.pr_state }} == dropped_merge_group_ci"
+        route: register_clone_unconfirmed
+      - when: "${{ result.pr_state }} == dropped_healthy"
+        route: register_clone_unconfirmed
+      - when: "${{ result.pr_state }} == ejected"
         route: re_push_queue_fix
-      - when: "${{ result.pr_state }} == 'timeout'"
-        route: release_issue_failure
-      - route: release_issue_failure
-    on_failure: release_issue_failure
+      - when: "${{ result.pr_state }} == stalled"
+        route: register_clone_unconfirmed
+      - when: "${{ result.pr_state }} == timeout"
+        route: register_clone_unconfirmed
+      - route: register_clone_unconfirmed
+    on_failure: register_clone_unconfirmed
     skip_when_false: "inputs.open_pr"
     optional_context_refs:
       - push_error_type

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -1183,6 +1183,8 @@ steps:
       force: "true"
     capture:
       push_error_type: "${{ result.error_type }}"
+    retries: 2
+    on_exhausted: register_clone_unconfirmed
     on_success: ci_watch_post_queue_fix
     on_failure: classify_push_failure
     skip_when_false: "inputs.open_pr"

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -1195,7 +1195,6 @@ steps:
       - when: "${{ context.push_error_type }} == queued_branch"
         route: wait_dequeue_retry
       - route: release_issue_failure
-    skip_when_false: "inputs.open_pr"
 
   wait_dequeue_retry:
     tool: wait_for_merge_queue
@@ -1221,7 +1220,6 @@ steps:
         route: register_clone_unconfirmed
       - route: register_clone_unconfirmed
     on_failure: register_clone_unconfirmed
-    skip_when_false: "inputs.open_pr"
     optional_context_refs:
       - push_error_type
 

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -1181,9 +1181,37 @@ steps:
       remote_url: "${{ context.remote_url }}"
       branch: "${{ context.merge_target }}"
       force: "true"
+    capture:
+      push_error_type: "${{ result.error_type }}"
     on_success: ci_watch_post_queue_fix
+    on_failure: classify_push_failure
+    skip_when_false: "inputs.open_pr"
+
+  classify_push_failure:
+    action: route
+    on_result:
+      - when: "${{ context.push_error_type }} == queued_branch"
+        route: wait_dequeue_retry
+      - route: release_issue_failure
+    skip_when_false: "inputs.open_pr"
+
+  wait_dequeue_retry:
+    tool: wait_for_merge_queue
+    with:
+      pr_number: "${{ context.pr_number }}"
+      target_branch: "${{ inputs.base_branch }}"
+      cwd: "${{ context.work_dir }}"
+      timeout_seconds: "60"
+    on_result:
+      - when: "${{ result.pr_state }} == 'ejected'"
+        route: re_push_queue_fix
+      - when: "${{ result.pr_state }} == 'timeout'"
+        route: release_issue_failure
+      - route: release_issue_failure
     on_failure: release_issue_failure
     skip_when_false: "inputs.open_pr"
+    optional_context_refs:
+      - push_error_type
 
   ci_watch_post_queue_fix:
     tool: wait_for_ci

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -1090,9 +1090,37 @@ steps:
       remote_url: "${{ context.remote_url }}"
       branch: "${{ context.merge_target }}"
       force: "true"
+    capture:
+      push_error_type: "${{ result.error_type }}"
     on_success: ci_watch_post_queue_fix
+    on_failure: classify_push_failure
+    skip_when_false: "inputs.open_pr"
+
+  classify_push_failure:
+    action: route
+    on_result:
+      - when: "${{ context.push_error_type }} == queued_branch"
+        route: wait_dequeue_retry
+      - route: release_issue_failure
+    skip_when_false: "inputs.open_pr"
+
+  wait_dequeue_retry:
+    tool: wait_for_merge_queue
+    with:
+      pr_number: "${{ context.pr_number }}"
+      target_branch: "${{ inputs.base_branch }}"
+      cwd: "${{ context.work_dir }}"
+      timeout_seconds: "60"
+    on_result:
+      - when: "${{ result.pr_state }} == 'ejected'"
+        route: re_push_queue_fix
+      - when: "${{ result.pr_state }} == 'timeout'"
+        route: release_issue_failure
+      - route: release_issue_failure
     on_failure: release_issue_failure
     skip_when_false: "inputs.open_pr"
+    optional_context_refs:
+      - push_error_type
 
   ci_watch_post_queue_fix:
     tool: wait_for_ci

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -1092,6 +1092,8 @@ steps:
       force: "true"
     capture:
       push_error_type: "${{ result.error_type }}"
+    retries: 2
+    on_exhausted: register_clone_unconfirmed
     on_success: ci_watch_post_queue_fix
     on_failure: classify_push_failure
     skip_when_false: "inputs.open_pr"

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -1112,12 +1112,22 @@ steps:
       cwd: "${{ context.work_dir }}"
       timeout_seconds: "60"
     on_result:
-      - when: "${{ result.pr_state }} == 'ejected'"
+      - when: "${{ result.pr_state }} == merged"
+        route: release_issue_success
+      - when: "${{ result.pr_state }} == ejected_ci_failure"
+        route: register_clone_unconfirmed
+      - when: "${{ result.pr_state }} == dropped_merge_group_ci"
+        route: register_clone_unconfirmed
+      - when: "${{ result.pr_state }} == dropped_healthy"
+        route: register_clone_unconfirmed
+      - when: "${{ result.pr_state }} == ejected"
         route: re_push_queue_fix
-      - when: "${{ result.pr_state }} == 'timeout'"
-        route: release_issue_failure
-      - route: release_issue_failure
-    on_failure: release_issue_failure
+      - when: "${{ result.pr_state }} == stalled"
+        route: register_clone_unconfirmed
+      - when: "${{ result.pr_state }} == timeout"
+        route: register_clone_unconfirmed
+      - route: register_clone_unconfirmed
+    on_failure: register_clone_unconfirmed
     skip_when_false: "inputs.open_pr"
     optional_context_refs:
       - push_error_type

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -1104,7 +1104,6 @@ steps:
       - when: "${{ context.push_error_type }} == queued_branch"
         route: wait_dequeue_retry
       - route: release_issue_failure
-    skip_when_false: "inputs.open_pr"
 
   wait_dequeue_retry:
     tool: wait_for_merge_queue
@@ -1130,7 +1129,6 @@ steps:
         route: register_clone_unconfirmed
       - route: register_clone_unconfirmed
     on_failure: register_clone_unconfirmed
-    skip_when_false: "inputs.open_pr"
     optional_context_refs:
       - push_error_type
 

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -393,9 +393,19 @@ steps:
       cwd: "${{ context.work_dir }}"
       timeout_seconds: "60"
     on_result:
-      - when: "${{ result.pr_state }} == 'ejected'"
+      - when: "${{ result.pr_state }} == merged"
+        route: advance_queue_pr
+      - when: "${{ result.pr_state }} == ejected_ci_failure"
+        route: register_clone_failure
+      - when: "${{ result.pr_state }} == dropped_merge_group_ci"
+        route: register_clone_failure
+      - when: "${{ result.pr_state }} == dropped_healthy"
+        route: register_clone_failure
+      - when: "${{ result.pr_state }} == ejected"
         route: push_ejected_fix
-      - when: "${{ result.pr_state }} == 'timeout'"
+      - when: "${{ result.pr_state }} == stalled"
+        route: register_clone_failure
+      - when: "${{ result.pr_state }} == timeout"
         route: register_clone_failure
       - route: register_clone_failure
     on_failure: register_clone_failure

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -373,8 +373,34 @@ steps:
       remote_url: "${{ context.remote_url }}"
       branch: "${{ context.ejected_pr_branch }}"
       force: "true"
+    capture:
+      push_error_type: "${{ result.error_type }}"
     on_success: ci_watch_post_queue_fix
+    on_failure: classify_push_failure
+
+  classify_push_failure:
+    action: route
+    on_result:
+      - when: "${{ context.push_error_type }} == queued_branch"
+        route: wait_dequeue_retry
+      - route: register_clone_failure
+
+  wait_dequeue_retry:
+    tool: wait_for_merge_queue
+    with:
+      pr_number: "${{ context.current_pr_number }}"
+      target_branch: "${{ inputs.base_branch }}"
+      cwd: "${{ context.work_dir }}"
+      timeout_seconds: "60"
+    on_result:
+      - when: "${{ result.pr_state }} == 'ejected'"
+        route: push_ejected_fix
+      - when: "${{ result.pr_state }} == 'timeout'"
+        route: register_clone_failure
+      - route: register_clone_failure
     on_failure: register_clone_failure
+    optional_context_refs:
+      - push_error_type
 
   ci_watch_post_queue_fix:
     tool: wait_for_ci

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -375,6 +375,8 @@ steps:
       force: "true"
     capture:
       push_error_type: "${{ result.error_type }}"
+    retries: 2
+    on_exhausted: register_clone_failure
     on_success: ci_watch_post_queue_fix
     on_failure: classify_push_failure
 

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -1119,7 +1119,6 @@ steps:
       - when: "${{ context.push_error_type }} == queued_branch"
         route: wait_dequeue_retry
       - route: release_issue_failure
-    skip_when_false: "inputs.open_pr"
 
   wait_dequeue_retry:
     tool: wait_for_merge_queue
@@ -1145,7 +1144,6 @@ steps:
         route: register_clone_unconfirmed
       - route: register_clone_unconfirmed
     on_failure: register_clone_unconfirmed
-    skip_when_false: "inputs.open_pr"
     optional_context_refs:
       - push_error_type
 

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -1107,6 +1107,8 @@ steps:
       force: "true"
     capture:
       push_error_type: "${{ result.error_type }}"
+    retries: 2
+    on_exhausted: register_clone_unconfirmed
     on_success: ci_watch_post_queue_fix
     on_failure: classify_push_failure
     skip_when_false: "inputs.open_pr"

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -1105,9 +1105,37 @@ steps:
       remote_url: "${{ context.remote_url }}"
       branch: "${{ context.merge_target }}"
       force: "true"
+    capture:
+      push_error_type: "${{ result.error_type }}"
     on_success: ci_watch_post_queue_fix
+    on_failure: classify_push_failure
+    skip_when_false: "inputs.open_pr"
+
+  classify_push_failure:
+    action: route
+    on_result:
+      - when: "${{ context.push_error_type }} == queued_branch"
+        route: wait_dequeue_retry
+      - route: release_issue_failure
+    skip_when_false: "inputs.open_pr"
+
+  wait_dequeue_retry:
+    tool: wait_for_merge_queue
+    with:
+      pr_number: "${{ context.pr_number }}"
+      target_branch: "${{ inputs.base_branch }}"
+      cwd: "${{ context.work_dir }}"
+      timeout_seconds: "60"
+    on_result:
+      - when: "${{ result.pr_state }} == 'ejected'"
+        route: re_push_queue_fix
+      - when: "${{ result.pr_state }} == 'timeout'"
+        route: release_issue_failure
+      - route: release_issue_failure
     on_failure: release_issue_failure
     skip_when_false: "inputs.open_pr"
+    optional_context_refs:
+      - push_error_type
 
   ci_watch_post_queue_fix:
     tool: wait_for_ci

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -1127,12 +1127,22 @@ steps:
       cwd: "${{ context.work_dir }}"
       timeout_seconds: "60"
     on_result:
-      - when: "${{ result.pr_state }} == 'ejected'"
+      - when: "${{ result.pr_state }} == merged"
+        route: release_issue_success
+      - when: "${{ result.pr_state }} == ejected_ci_failure"
+        route: register_clone_unconfirmed
+      - when: "${{ result.pr_state }} == dropped_merge_group_ci"
+        route: register_clone_unconfirmed
+      - when: "${{ result.pr_state }} == dropped_healthy"
+        route: register_clone_unconfirmed
+      - when: "${{ result.pr_state }} == ejected"
         route: re_push_queue_fix
-      - when: "${{ result.pr_state }} == 'timeout'"
-        route: release_issue_failure
-      - route: release_issue_failure
-    on_failure: release_issue_failure
+      - when: "${{ result.pr_state }} == stalled"
+        route: register_clone_unconfirmed
+      - when: "${{ result.pr_state }} == timeout"
+        route: register_clone_unconfirmed
+      - route: register_clone_unconfirmed
+    on_failure: register_clone_unconfirmed
     skip_when_false: "inputs.open_pr"
     optional_context_refs:
       - push_error_type

--- a/src/autoskillit/workspace/clone.py
+++ b/src/autoskillit/workspace/clone.py
@@ -379,6 +379,10 @@ def push_to_remote(
                 "no upstream configured" in stderr_text or "has no upstream branch" in stderr_text
             ):
                 failure["error_type"] = "force_with_lease_no_upstream"
+        if "error_type" not in failure and (
+            "GH006" in stderr_text or "merge queue" in stderr_text.lower()
+        ):
+            failure["error_type"] = "queued_branch"
         return failure
 
     logger.info(

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -795,7 +795,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
         "hooks": 9,
         "pipeline": 12,
         "fleet": 11,
-        "recipe/rules": 26,
+        "recipe/rules": 27,
         "server/tools": 14,
         "hooks/guards": 19,
     }

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -274,7 +274,7 @@ def test_retry_reason_value_count_is_11() -> None:
 
 
 def test_semantic_rule_family_count_is_25() -> None:
-    assert _count_semantic_rule_files() == 25
+    assert _count_semantic_rule_files() == 26
 
 
 # ----- per-doc count assertions (run once docs exist) -------------------------

--- a/tests/execution/test_merge_queue_ejection.py
+++ b/tests/execution/test_merge_queue_ejection.py
@@ -20,17 +20,72 @@ class TestRelatedCoverage:
     """Coverage for related untested paths found during investigation."""
 
     @pytest.mark.anyio
-    async def test_returns_ejected_when_unmergeable_in_queue(self):
-        """in_queue=True, queue_state=UNMERGEABLE → ejected immediately."""
+    async def test_unmergeable_waits_for_dequeue_before_returning_ejected(self):
+        """UNMERGEABLE must wait for in_queue=False before returning EJECTED."""
+        watcher = _make_watcher()
+        watcher._fetch_pr_and_queue_state = AsyncMock(  # type: ignore[method-assign]
+            side_effect=[
+                _queue_state(in_queue=True, queue_state="UNMERGEABLE"),
+                _queue_state(in_queue=True, queue_state="UNMERGEABLE"),
+                _queue_state(in_queue=False, state="CLOSED"),
+                _queue_state(in_queue=False, state="CLOSED"),
+            ]
+        )
+        with patch("autoskillit.execution.merge_queue.asyncio.sleep", new_callable=AsyncMock):
+            result = await watcher.wait(
+                pr_number=1,
+                target_branch="main",
+                repo="owner/repo",
+                poll_interval=1,
+                not_in_queue_confirmation_cycles=2,
+            )
+
+        assert result["success"] is False
+        assert result["pr_state"] == "ejected"
+        assert watcher._fetch_pr_and_queue_state.call_count == 4  # type: ignore[union-attr]
+
+    @pytest.mark.anyio
+    async def test_unmergeable_dequeue_wait_respects_timeout(self):
+        """UNMERGEABLE with perpetual in_queue=True times out instead of returning ejected."""
         watcher = _make_watcher()
         watcher._fetch_pr_and_queue_state = AsyncMock(  # type: ignore[method-assign]
             return_value=_queue_state(in_queue=True, queue_state="UNMERGEABLE")
         )
         with patch("autoskillit.execution.merge_queue.asyncio.sleep", new_callable=AsyncMock):
-            result = await watcher.wait(pr_number=1, target_branch="main", repo="owner/repo")
+            result = await watcher.wait(
+                pr_number=1,
+                target_branch="main",
+                repo="owner/repo",
+                poll_interval=1,
+                timeout_seconds=0,
+            )
+
+        assert result["success"] is False
+        assert result["pr_state"] == "timeout"
+
+    @pytest.mark.anyio
+    async def test_unmergeable_respects_confirmation_cycles(self):
+        """UNMERGEABLE with confirmation_cycles=2 requires 2 cycles after in_queue=False."""
+        watcher = _make_watcher()
+        watcher._fetch_pr_and_queue_state = AsyncMock(  # type: ignore[method-assign]
+            side_effect=[
+                _queue_state(in_queue=True, queue_state="UNMERGEABLE"),
+                _queue_state(in_queue=False, state="CLOSED"),
+                _queue_state(in_queue=False, state="CLOSED"),
+            ]
+        )
+        with patch("autoskillit.execution.merge_queue.asyncio.sleep", new_callable=AsyncMock):
+            result = await watcher.wait(
+                pr_number=1,
+                target_branch="main",
+                repo="owner/repo",
+                poll_interval=1,
+                not_in_queue_confirmation_cycles=2,
+            )
 
         assert result["success"] is False
         assert result["pr_state"] == "ejected"
+        assert watcher._fetch_pr_and_queue_state.call_count == 3  # type: ignore[union-attr]
 
     @pytest.mark.anyio
     async def test_is_stall_candidate_when_has_hooks(self):

--- a/tests/execution/test_merge_queue_polling.py
+++ b/tests/execution/test_merge_queue_polling.py
@@ -658,3 +658,76 @@ class TestMergeQueueReliability:
             await watcher.wait(pr_number=7, target_branch="main", repo="owner/repo")
 
         mock_query.assert_not_called()
+
+
+class TestToggleAutoMergeConfirmation:
+    """Tests for _toggle_auto_merge confirmation polling instead of hardcoded sleep."""
+
+    @pytest.mark.anyio
+    async def test_toggle_polls_for_disable_confirmation(self):
+        """_toggle_auto_merge polls until auto-merge is confirmed disabled."""
+        watcher = _make_watcher()
+        watcher._client = AsyncMock()
+
+        disable_resp = AsyncMock()
+        disable_resp.status_code = 200
+        disable_resp.raise_for_status = lambda: None
+        disable_resp.json.return_value = {"data": {"disablePullRequestAutoMerge": {}}}
+
+        poll_resp_still_active = AsyncMock()
+        poll_resp_still_active.status_code = 200
+        poll_resp_still_active.json.return_value = {
+            "data": {"node": {"autoMergeRequest": {"enabledAt": "2026-01-01T00:00:00Z"}}}
+        }
+
+        poll_resp_disabled = AsyncMock()
+        poll_resp_disabled.status_code = 200
+        poll_resp_disabled.json.return_value = {"data": {"node": {"autoMergeRequest": None}}}
+
+        enable_resp = AsyncMock()
+        enable_resp.status_code = 200
+        enable_resp.raise_for_status = lambda: None
+        enable_resp.json.return_value = {"data": {"enablePullRequestAutoMerge": {}}}
+
+        watcher._client.post = AsyncMock(
+            side_effect=[disable_resp, poll_resp_still_active, poll_resp_disabled, enable_resp]
+        )
+        watcher._ensure_client = lambda: watcher._client
+
+        with patch("autoskillit.execution.merge_queue.asyncio.sleep", new_callable=AsyncMock):
+            await watcher._toggle_auto_merge("PR_node123")
+
+        assert watcher._client.post.call_count == 4
+
+    @pytest.mark.anyio
+    async def test_toggle_does_not_use_hardcoded_sleep_2(self):
+        """_toggle_auto_merge no longer uses asyncio.sleep(2)."""
+        watcher = _make_watcher()
+        watcher._client = AsyncMock()
+
+        disable_resp = AsyncMock()
+        disable_resp.status_code = 200
+        disable_resp.raise_for_status = lambda: None
+        disable_resp.json.return_value = {"data": {"disablePullRequestAutoMerge": {}}}
+
+        poll_resp = AsyncMock()
+        poll_resp.status_code = 200
+        poll_resp.json.return_value = {"data": {"node": {"autoMergeRequest": None}}}
+
+        enable_resp = AsyncMock()
+        enable_resp.status_code = 200
+        enable_resp.raise_for_status = lambda: None
+        enable_resp.json.return_value = {"data": {"enablePullRequestAutoMerge": {}}}
+
+        watcher._client.post = AsyncMock(side_effect=[disable_resp, poll_resp, enable_resp])
+        watcher._ensure_client = lambda: watcher._client
+
+        sleep_durations: list[float] = []
+
+        async def _capture_sleep(seconds: float) -> None:
+            sleep_durations.append(seconds)
+
+        with patch("autoskillit.execution.merge_queue.asyncio.sleep", side_effect=_capture_sleep):
+            await watcher._toggle_auto_merge("PR_node123")
+
+        assert 2 not in sleep_durations

--- a/tests/execution/test_merge_queue_polling.py
+++ b/tests/execution/test_merge_queue_polling.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
@@ -669,22 +669,22 @@ class TestToggleAutoMergeConfirmation:
         watcher = _make_watcher()
         watcher._client = AsyncMock()
 
-        disable_resp = AsyncMock()
+        disable_resp = MagicMock()
         disable_resp.status_code = 200
         disable_resp.raise_for_status = lambda: None
         disable_resp.json.return_value = {"data": {"disablePullRequestAutoMerge": {}}}
 
-        poll_resp_still_active = AsyncMock()
+        poll_resp_still_active = MagicMock()
         poll_resp_still_active.status_code = 200
         poll_resp_still_active.json.return_value = {
             "data": {"node": {"autoMergeRequest": {"enabledAt": "2026-01-01T00:00:00Z"}}}
         }
 
-        poll_resp_disabled = AsyncMock()
+        poll_resp_disabled = MagicMock()
         poll_resp_disabled.status_code = 200
         poll_resp_disabled.json.return_value = {"data": {"node": {"autoMergeRequest": None}}}
 
-        enable_resp = AsyncMock()
+        enable_resp = MagicMock()
         enable_resp.status_code = 200
         enable_resp.raise_for_status = lambda: None
         enable_resp.json.return_value = {"data": {"enablePullRequestAutoMerge": {}}}
@@ -705,16 +705,16 @@ class TestToggleAutoMergeConfirmation:
         watcher = _make_watcher()
         watcher._client = AsyncMock()
 
-        disable_resp = AsyncMock()
+        disable_resp = MagicMock()
         disable_resp.status_code = 200
         disable_resp.raise_for_status = lambda: None
         disable_resp.json.return_value = {"data": {"disablePullRequestAutoMerge": {}}}
 
-        poll_resp = AsyncMock()
+        poll_resp = MagicMock()
         poll_resp.status_code = 200
         poll_resp.json.return_value = {"data": {"node": {"autoMergeRequest": None}}}
 
-        enable_resp = AsyncMock()
+        enable_resp = MagicMock()
         enable_resp.status_code = 200
         enable_resp.raise_for_status = lambda: None
         enable_resp.json.return_value = {"data": {"enablePullRequestAutoMerge": {}}}

--- a/tests/recipe/test_rules_merge_queue_push.py
+++ b/tests/recipe/test_rules_merge_queue_push.py
@@ -1,0 +1,139 @@
+"""Tests for push-after-queue-requires-queued-branch-route semantic rule."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.recipe.registry import run_semantic_rules
+from autoskillit.recipe.schema import (
+    Recipe,
+    RecipeStep,
+    StepResultCondition,
+    StepResultRoute,
+)
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+_RULE_NAME = "push-after-queue-requires-queued-branch-route"
+
+
+def _make_recipe_missing_queued_branch_route() -> Recipe:
+    """Minimal recipe: wait_for_queue → eject → push with no queued_branch route."""
+    steps = {
+        "wait_for_queue": RecipeStep(
+            name="wait_for_queue",
+            tool="wait_for_merge_queue",
+            on_result=StepResultRoute(
+                conditions=[
+                    StepResultCondition(
+                        when="${{ result.pr_state }} == 'ejected'",
+                        route="queue_ejected_fix",
+                    ),
+                ]
+            ),
+        ),
+        "queue_ejected_fix": RecipeStep(
+            name="queue_ejected_fix",
+            tool="run_python",
+            on_success="re_push_queue_fix",
+        ),
+        "re_push_queue_fix": RecipeStep(
+            name="re_push_queue_fix",
+            tool="push_to_remote",
+            on_success="done",
+            on_failure="terminal_failure",
+        ),
+        "terminal_failure": RecipeStep(
+            name="terminal_failure",
+            action="stop",
+        ),
+        "done": RecipeStep(
+            name="done",
+            action="stop",
+        ),
+    }
+    return Recipe(
+        name="test-missing-route",
+        description="test recipe missing queued_branch route",
+        steps=steps,
+    )
+
+
+def _make_recipe_with_queued_branch_route() -> Recipe:
+    """Minimal recipe: push has on_failure → classify_push_failure with queued_branch route."""
+    steps = {
+        "wait_for_queue": RecipeStep(
+            name="wait_for_queue",
+            tool="wait_for_merge_queue",
+            on_result=StepResultRoute(
+                conditions=[
+                    StepResultCondition(
+                        when="${{ result.pr_state }} == 'ejected'",
+                        route="queue_ejected_fix",
+                    ),
+                ]
+            ),
+        ),
+        "queue_ejected_fix": RecipeStep(
+            name="queue_ejected_fix",
+            tool="run_python",
+            on_success="re_push_queue_fix",
+        ),
+        "re_push_queue_fix": RecipeStep(
+            name="re_push_queue_fix",
+            tool="push_to_remote",
+            on_success="done",
+            on_failure="classify_push_failure",
+        ),
+        "classify_push_failure": RecipeStep(
+            name="classify_push_failure",
+            action="route",
+            on_result=StepResultRoute(
+                conditions=[
+                    StepResultCondition(
+                        when="${{ context.push_error_type }} == queued_branch",
+                        route="wait_dequeue_retry",
+                    ),
+                    StepResultCondition(
+                        when=None,
+                        route="terminal_failure",
+                    ),
+                ]
+            ),
+        ),
+        "wait_dequeue_retry": RecipeStep(
+            name="wait_dequeue_retry",
+            tool="wait_for_merge_queue",
+            on_success="re_push_queue_fix",
+        ),
+        "terminal_failure": RecipeStep(
+            name="terminal_failure",
+            action="stop",
+        ),
+        "done": RecipeStep(
+            name="done",
+            action="stop",
+        ),
+    }
+    return Recipe(
+        name="test-with-route",
+        description="test recipe with queued_branch route",
+        steps=steps,
+    )
+
+
+def test_rule_fires_when_queued_branch_route_missing():
+    """push_to_remote reachable from ejection route without queued_branch triggers finding."""
+    recipe = _make_recipe_missing_queued_branch_route()
+    findings = run_semantic_rules(recipe)
+    matching = [f for f in findings if f.rule == _RULE_NAME]
+    assert len(matching) == 1
+    assert "re_push_queue_fix" in matching[0].step_name
+
+
+def test_rule_passes_when_queued_branch_route_present():
+    """push_to_remote with queued_branch route in failure chain produces no finding."""
+    recipe = _make_recipe_with_queued_branch_route()
+    findings = run_semantic_rules(recipe)
+    matching = [f for f in findings if f.rule == _RULE_NAME]
+    assert matching == []

--- a/tests/workspace/test_clone.py
+++ b/tests/workspace/test_clone.py
@@ -1028,6 +1028,62 @@ class TestPushToRemoteMocked:
         assert result["success"] is False
         assert "error_type" not in result
 
+    def test_gh006_returns_queued_branch_error_type(self) -> None:
+        """GH006 stderr produces error_type=queued_branch."""
+        mock_url = MagicMock()
+        mock_url.returncode = 0
+        mock_url.stdout = "git@github.com:org/repo.git\n"
+        mock_url.stderr = ""
+
+        mock_push = MagicMock()
+        mock_push.returncode = 1
+        mock_push.stderr = (
+            "remote: error: GH006: Protected branch update failed for refs/heads/main.\n"
+            "remote: error: Changes must be made through a merge queue."
+        )
+
+        with patch("subprocess.run", side_effect=[mock_url, mock_push]):
+            result = push_to_remote("/clone", "/source", "main", protected_branches=[], force=True)
+
+        assert result["success"] is False
+        assert result.get("error_type") == "queued_branch"
+
+    def test_merge_queue_stderr_returns_queued_branch_error_type(self) -> None:
+        """'protected by merge queue' stderr variant also produces queued_branch."""
+        mock_url = MagicMock()
+        mock_url.returncode = 0
+        mock_url.stdout = "git@github.com:org/repo.git\n"
+        mock_url.stderr = ""
+
+        mock_push = MagicMock()
+        mock_push.returncode = 1
+        mock_push.stderr = "remote: error: branch is protected by merge queue"
+
+        with patch("subprocess.run", side_effect=[mock_url, mock_push]):
+            result = push_to_remote("/clone", "/source", "main", protected_branches=[], force=True)
+
+        assert result["success"] is False
+        assert result.get("error_type") == "queued_branch"
+
+    def test_gh006_non_force_also_returns_queued_branch(self) -> None:
+        """GH006 fires for non-force pushes too (queue protects all push modes)."""
+        mock_url = MagicMock()
+        mock_url.returncode = 0
+        mock_url.stdout = "git@github.com:org/repo.git\n"
+        mock_url.stderr = ""
+
+        mock_push = MagicMock()
+        mock_push.returncode = 1
+        mock_push.stderr = "remote: error: GH006: Protected branch update failed."
+
+        with patch("subprocess.run", side_effect=[mock_url, mock_push]):
+            result = push_to_remote(
+                "/clone", "/source", "main", protected_branches=[], force=False
+            )
+
+        assert result["success"] is False
+        assert result.get("error_type") == "queued_branch"
+
 
 class TestPushToRemoteNonBare:
     """push_to_remote fails with error_type when remote is a local non-bare repo."""


### PR DESCRIPTION
## Summary

The merge queue watcher's UNMERGEABLE fast-path bypasses the `not_in_queue_confirmation_cycles` guard, returning `PRState.EJECTED` while the PR is still physically in the queue (`in_queue=True`). The recipe immediately force-pushes into the still-protected branch, which GitHub rejects with GH006. The push failure is unclassified (no `error_type`), so the recipe routes to terminal failure instead of retrying.

The architectural weakness is two-fold: (1) the watcher has two fundamentally different exit paths for ejection — a guarded path (normal `in_queue=False` transition) and an unguarded path (UNMERGEABLE early return) — and (2) the push error classification pipeline has no classifier for queue-blocked rejections, so even if the watcher timing were perfect, a race-condition failure would be unrecoverable.

The solution unifies all ejection paths through a single dequeue-confirmation gate, adds a `queued_branch` error classifier for defense-in-depth, replaces the hardcoded timing assumption in `_toggle_auto_merge`, and adds a recipe semantic rule that structurally prevents any push step from following a merge queue step without a `queued_branch` error route.

Closes #1787

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260503-215819-064376/.autoskillit/temp/rectify/rectify_merge_queue_dequeue_confirmation_2026-05-03_221500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| investigate | 39 | 8.9k | 485.4k | 123.4k | 1 | 7m 48s |
| rectify | 51 | 12.5k | 833.7k | 85.9k | 1 | 8m 18s |
| dry_walkthrough | 63 | 18.6k | 2.9M | 70.1k | 1 | 9m 58s |
| implement | 103 | 28.4k | 6.0M | 99.3k | 1 | 11m 0s |
| prepare_pr | 26 | 4.6k | 243.5k | 26.3k | 1 | 1m 32s |
| compose_pr | 22 | 1.5k | 123.5k | 16.4k | 1 | 42s |
| review_pr | 478 | 33.5k | 666.6k | 77.9k | 1 | 8m 17s |
| resolve_review | 57 | 10.6k | 2.0M | 59.8k | 1 | 11m 23s |
| **Total** | 839 | 118.8k | 13.2M | 559.1k | | 59m 0s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 579 | 10391.5 | 171.6 | 49.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 38 | 51727.8 | 1573.6 | 279.6 |
| **Total** | **617** | 21374.4 | 906.2 | 192.5 |