### PR TITLE
Implementation Plan: Define ProvidersConfig Dataclass

### DIFF
--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -281,6 +281,14 @@ class WorkspaceConfig:
     temp_dir: str | None = None  # null = canonical default (see resolve_temp_dir)
 
 
+@dataclass
+class ProvidersConfig:
+    default_provider: str | None = None
+    profiles: dict[str, dict[str, str]] = field(default_factory=dict)
+    step_overrides: dict[str, str] = field(default_factory=dict)
+    provider_retry_limit: int = 2
+
+
 def _field_defaults(cls: type) -> dict[str, Any]:
     """Extract default values from dataclass fields into a dict keyed by field name."""
     defaults: dict[str, Any] = {}
@@ -317,6 +325,7 @@ class AutomationConfig:
     subsets: SubsetsConfig = field(default_factory=SubsetsConfig)
     packs: PacksConfig = field(default_factory=PacksConfig)
     workspace: WorkspaceConfig = field(default_factory=WorkspaceConfig)
+    providers: ProvidersConfig = field(default_factory=ProvidersConfig)
 
     @classmethod
     def from_dynaconf(cls, d: Dynaconf) -> AutomationConfig:
@@ -356,6 +365,7 @@ class AutomationConfig:
         _sub = sec("subsets")
         pk = sec("packs")
         ws_raw = sec("workspace")
+        pv = sec("providers")
 
         _tc = _field_defaults(TestCheckConfig)
         _cf = _field_defaults(ClassifyFixConfig)
@@ -378,6 +388,7 @@ class AutomationConfig:
         _ci = _field_defaults(CIConfig)
         _sk = _field_defaults(SkillsConfig)
         _wsc = _field_defaults(WorkspaceConfig)
+        _pv = _field_defaults(ProvidersConfig)
 
         return cls(
             test_check=TestCheckConfig(
@@ -519,6 +530,14 @@ class AutomationConfig:
                 worktree_root=val(ws_raw, "worktree_root", _wsc["worktree_root"]) or None,
                 runs_root=val(ws_raw, "runs_root", _wsc["runs_root"]) or None,
                 temp_dir=val(ws_raw, "temp_dir", _wsc["temp_dir"]) or None,
+            ),
+            providers=ProvidersConfig(
+                default_provider=val(pv, "default_provider", _pv["default_provider"]) or None,
+                profiles=dict(val(pv, "profiles", _pv["profiles"])),
+                step_overrides=dict(val(pv, "step_overrides", _pv["step_overrides"])),
+                provider_retry_limit=int(
+                    val(pv, "provider_retry_limit", _pv["provider_retry_limit"])
+                ),
             ),
         )
 

--- a/src/autoskillit/config/settings.py
+++ b/src/autoskillit/config/settings.py
@@ -533,7 +533,7 @@ class AutomationConfig:
             ),
             providers=ProvidersConfig(
                 default_provider=val(pv, "default_provider", _pv["default_provider"]) or None,
-                profiles=dict(val(pv, "profiles", _pv["profiles"])),
+                profiles={k: dict(v) for k, v in val(pv, "profiles", _pv["profiles"]).items()},
                 step_overrides=dict(val(pv, "step_overrides", _pv["step_overrides"])),
                 provider_retry_limit=int(
                     val(pv, "provider_retry_limit", _pv["provider_retry_limit"])

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -1131,6 +1131,78 @@ class TestWriteConfigLayer:
         assert data["github"]["default_repo"] == "owner/repo"
 
 
+class TestProvidersConfig:
+    """ProvidersConfig dataclass and from_dynaconf wiring."""
+
+    def test_providers_config_exists_on_automation_config(self, tmp_path):
+        cfg = load_config(tmp_path / "settings.toml")
+        assert hasattr(cfg, "providers")
+
+    def test_default_provider_defaults_to_none(self, tmp_path):
+        cfg = load_config(tmp_path / "settings.toml")
+        assert cfg.providers.default_provider is None
+
+    def test_profiles_defaults_to_empty_dict(self, tmp_path):
+        cfg = load_config(tmp_path / "settings.toml")
+        assert cfg.providers.profiles == {}
+
+    def test_step_overrides_defaults_to_empty_dict(self, tmp_path):
+        cfg = load_config(tmp_path / "settings.toml")
+        assert cfg.providers.step_overrides == {}
+
+    def test_provider_retry_limit_defaults_to_two(self, tmp_path):
+        cfg = load_config(tmp_path / "settings.toml")
+        assert cfg.providers.provider_retry_limit == 2
+
+    def test_yaml_loads_providers_section(self, tmp_path):
+        config_dir = tmp_path / ".autoskillit"
+        config_dir.mkdir()
+        config_data = {
+            "providers": {
+                "default_provider": "anthropic",
+                "profiles": {"fast": {"model": "haiku"}, "slow": {"model": "opus"}},
+                "step_overrides": {"impl": "fast"},
+                "provider_retry_limit": 5,
+            }
+        }
+        (config_dir / "config.yaml").write_text(yaml.dump(config_data))
+        cfg = load_config(tmp_path)
+        assert cfg.providers.default_provider == "anthropic"
+        assert cfg.providers.profiles == {"fast": {"model": "haiku"}, "slow": {"model": "opus"}}
+        assert cfg.providers.step_overrides == {"impl": "fast"}
+        assert cfg.providers.provider_retry_limit == 5
+
+    def test_partial_providers_config_preserves_defaults(self, tmp_path):
+        config_dir = tmp_path / ".autoskillit"
+        config_dir.mkdir()
+        config_data = {"providers": {"default_provider": "bedrock"}}
+        (config_dir / "config.yaml").write_text(yaml.dump(config_data))
+        cfg = load_config(tmp_path)
+        assert cfg.providers.default_provider == "bedrock"
+        assert cfg.providers.profiles == {}
+        assert cfg.providers.step_overrides == {}
+        assert cfg.providers.provider_retry_limit == 2
+
+    def test_default_provider_none_coercion_from_empty_string(self, tmp_path):
+        config_dir = tmp_path / ".autoskillit"
+        config_dir.mkdir()
+        config_data = {"providers": {"default_provider": ""}}
+        (config_dir / "config.yaml").write_text(yaml.dump(config_data))
+        cfg = load_config(tmp_path)
+        assert cfg.providers.default_provider is None
+
+    def test_profiles_inner_dicts_are_independent_copies(self, tmp_path):
+        config_dir = tmp_path / ".autoskillit"
+        config_dir.mkdir()
+        config_data = {"providers": {"profiles": {"p1": {"model": "haiku"}}}}
+        (config_dir / "config.yaml").write_text(yaml.dump(config_data))
+        cfg = load_config(tmp_path)
+        inner = cfg.providers.profiles["p1"]
+        inner["injected"] = "mutated"
+        cfg2 = load_config(tmp_path)
+        assert "injected" not in cfg2.providers.profiles["p1"]
+
+
 class TestWorkspaceConfig:
     """WorkspaceConfig section is present in AutomationConfig with correct defaults."""
 

--- a/tests/execution/test_recording_sigterm.py
+++ b/tests/execution/test_recording_sigterm.py
@@ -31,10 +31,12 @@ def test_sigterm_writes_scenario_json(tmp_path):
 
     env = {
         **os.environ,
+        "HOME": str(tmp_path / "home"),
         "RECORD_SCENARIO": "1",
         "RECORD_SCENARIO_DIR": str(output_dir),
         "RECORD_SCENARIO_RECIPE": "test-recipe",
     }
+    (tmp_path / "home").mkdir()
     # Use sys.executable -m to ensure we run the worktree-installed version,
     # not a system-wide `autoskillit` binary that may lack the lifespan fix.
     proc = subprocess.Popen(


### PR DESCRIPTION
## Summary

Add a `ProvidersConfig` leaf dataclass to `src/autoskillit/config/settings.py` with fields for alternative LLM provider routing (`default_provider`, `profiles`, `step_overrides`, `provider_retry_limit`). Wire it into `AutomationConfig` and `from_dynaconf` so the existing contract test (`test_config_field_coverage.py`) passes — that test asserts every sub-config field is referenced in `from_dynaconf`.

Closes #1743

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260503-233050-731219/.autoskillit/temp/make-plan/define_providersconfig_dataclass_plan_2026-05-03_233300.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | cache_write | count | time |
|------|----------|--------|------------|-------------|-------|------|
| build_execution_map | 203 | 14.9k | 523.8k | 54.1k | 1 | 5m 36s |
| plan | 162 | 18.6k | 2.1M | 133.1k | 3 | 12m 42s |
| verify | 122 | 19.7k | 1.8M | 141.8k | 3 | 12m 47s |
| implement | 428 | 16.3k | 1.8M | 90.9k | 3 | 5m 17s |
| fix | 536 | 22.2k | 2.4M | 135.9k | 4 | 23m 43s |
| prepare_pr | 120 | 8.2k | 359.3k | 39.6k | 2 | 2m 22s |
| compose_pr | 110 | 3.6k | 307.0k | 28.8k | 2 | 1m 25s |
| **Total** | 1.7k | 103.5k | 9.3M | 624.3k | | 1h 3m |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| build_execution_map | 0 | — | — | — |
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 187934 | 9.6 | 0.5 | 0.1 |
| fix | 5 | 474353.2 | 27187.2 | 4437.4 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| **Total** | **187939** | 49.5 | 3.3 | 0.6 |