### PR TITLE
Implementation Plan: Extend test_feature_registry.py for providers flag

### DIFF
--- a/tests/arch/test_feature_registry.py
+++ b/tests/arch/test_feature_registry.py
@@ -322,7 +322,7 @@ def test_build_features_dict_franchise_raises_config_schema_error():
         AutomationConfig._build_features_dict({"franchise": True})
 
 
-# ── Providers feature registry tests — T1 shims ──────────────────────────────
+# ── Providers feature registry tests ─────────────────────────────────────────
 
 
 def test_providers_in_feature_registry():
@@ -334,6 +334,7 @@ def test_providers_in_feature_registry():
 def test_providers_feature_default_disabled():
     from autoskillit.core.types._type_constants import FEATURE_REGISTRY
 
+    assert "providers" in FEATURE_REGISTRY
     assert FEATURE_REGISTRY["providers"].default_enabled is False
 
 

--- a/tests/arch/test_feature_registry.py
+++ b/tests/arch/test_feature_registry.py
@@ -322,13 +322,19 @@ def test_build_features_dict_franchise_raises_config_schema_error():
         AutomationConfig._build_features_dict({"franchise": True})
 
 
-# ── Providers feature registry tests ─────────────────────────────────────────
+# ── Providers feature registry tests — T1 shims ──────────────────────────────
 
 
 def test_providers_in_feature_registry():
     from autoskillit.core.types._type_constants import FEATURE_REGISTRY
 
     assert "providers" in FEATURE_REGISTRY
+
+
+def test_providers_feature_default_disabled():
+    from autoskillit.core.types._type_constants import FEATURE_REGISTRY
+
+    assert FEATURE_REGISTRY["providers"].default_enabled is False
 
 
 # ── T1: DISABLED lifecycle ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Add `test_providers_feature_default_disabled` to the existing providers section in `tests/arch/test_feature_registry.py` and update the section comment to mirror the fleet shim pattern (`— T1 shims` suffix). The `test_providers_in_feature_registry` function already exists at line 328; only the second assertion function and comment alignment are needed.

Closes #1750

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260504-073714-429289/.autoskillit/temp/make-plan/extend_test_feature_registry_providers_flag_plan_2026-05-04_074300.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|----------|--------|------------|----------|-------|-------------|------|
| plan | 517 | 4.6k | 525.4k | 54.4k | 37 | 43.5k | 2m 27s |
| verify | 647 | 3.5k | 350.9k | 43.9k | 52 | 31.1k | 2m 56s |
| implement | 100 | 3.2k | 416.3k | 41.7k | 26 | 29.0k | 1m 10s |
| prepare_pr | 60 | 4.4k | 192.5k | 33.7k | 18 | 21.3k | 1m 31s |
| compose_pr | 59 | 1.9k | 177.5k | 29.2k | 15 | 16.8k | 47s |
| review_pr | 150 | 17.1k | 682.2k | 52.6k | 58 | 41.1k | 4m 57s |
| resolve_review | 229 | 9.0k | 1.1M | 56.8k | 62 | 44.1k | 4m 2s |
| **Total** | 1.8k | 43.7k | 3.5M | 56.8k | | 226.9k | 17m 52s |

## Token Efficiency

| Step | LoC Changed | peak_ctx/LoC | cache_write/LoC | output/LoC |
|------|-------------|--------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 8 | 5216.6 | 3622.6 | 403.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 3 | 18945.3 | 14696.0 | 3006.3 |
| **Total** | **11** | 5166.9 | 20624.7 | 3970.0 |