### PR TITLE
Implementation Plan: Define ProvidersConfig Dataclass

### DIFF
--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -940,16 +940,6 @@ class TestProvidersConfig:
         cfg.default_provider = "openai"
         assert cfg.default_provider == "openai"
 
-    def test_providers_config_is_last_class(self):
-        import ast
-
-        from autoskillit.core.paths import pkg_root
-
-        source = (pkg_root() / "config" / "_config_dataclasses.py").read_text()
-        tree = ast.parse(source)
-        classes = [node.name for node in ast.walk(tree) if isinstance(node, ast.ClassDef)]
-        assert classes[-1] == "ProvidersConfig"
-
     def test_providers_config_field_types(self):
         from dataclasses import fields as _dc_fields
 

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -928,6 +928,39 @@ class TestProvidersConfig:
         assert cfg.providers.step_overrides == {}
         assert cfg.providers.provider_retry_limit == 2
 
+    def test_providers_config_defaults(self):
+        cfg = ProvidersConfig()
+        assert cfg.default_provider is None
+        assert cfg.profiles == {}
+        assert cfg.step_overrides == {}
+        assert cfg.provider_retry_limit == 2
+
+    def test_providers_config_is_mutable(self):
+        cfg = ProvidersConfig()
+        cfg.default_provider = "openai"
+        assert cfg.default_provider == "openai"
+
+    def test_providers_config_is_last_class(self):
+        import ast
+
+        from autoskillit.core.paths import pkg_root
+
+        source = (pkg_root() / "config" / "_config_dataclasses.py").read_text()
+        tree = ast.parse(source)
+        classes = [node.name for node in ast.walk(tree) if isinstance(node, ast.ClassDef)]
+        assert classes[-1] == "ProvidersConfig"
+
+    def test_providers_config_field_types(self):
+        from dataclasses import fields as _dc_fields
+
+        field_map = {f.name: f for f in _dc_fields(ProvidersConfig)}
+        assert set(field_map.keys()) == {
+            "default_provider",
+            "profiles",
+            "step_overrides",
+            "provider_retry_limit",
+        }
+
     def test_providers_config_retry_limit_zero_raises(self):
         with pytest.raises(ValueError, match="provider_retry_limit must be >= 1"):
             ProvidersConfig(provider_retry_limit=0)


### PR DESCRIPTION
## Summary

Append a new `ProvidersConfig` plain mutable `@dataclass` to the end of `src/autoskillit/config/_config_dataclasses.py`, immediately after the existing `FleetConfig` class. The class introduces four fields for alternative LLM provider routing configuration: `default_provider`, `profiles`, `step_overrides`, and `provider_retry_limit`. This follows the established leaf-config pattern used by the 24 existing dataclasses in the file.

**Note:** This work package (WP1) is intentionally minimal — it defines only the dataclass itself with `__post_init__` validation. Downstream tasks handle `__init__.py`/`__all__` registration (#1744), `defaults.yaml` entries (#1745), and dedicated test file creation (#1748).

Closes #1743

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260504-073715-287373/.autoskillit/temp/make-plan/define_providersconfig_dataclass_plan_2026-05-04_073715.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|----------|--------|------------|----------|-------|-------------|------|
| plan | 63 | 8.0k | 699.3k | 52.5k | 54 | 37.8k | 4m 45s |
| verify | 37 | 6.7k | 871.6k | 60.4k | 43 | 47.4k | 3m 27s |
| implement | 180 | 6.7k | 769.0k | 43.0k | 51 | 30.3k | 3m 0s |
| prepare_pr | 60 | 4.4k | 191.9k | 34.3k | 19 | 23.1k | 1m 33s |
| compose_pr | 51 | 2.6k | 151.7k | 30.0k | 14 | 17.1k | 47s |
| review_pr | 138 | 15.0k | 491.2k | 50.8k | 36 | 39.7k | 3m 39s |
| resolve_review | 229 | 11.2k | 1.2M | 58.8k | 60 | 45.8k | 4m 59s |
| **Total** | 758 | 54.5k | 4.4M | 60.4k | | 241.2k | 22m 12s |

## Token Efficiency

| Step | LoC Changed | peak_ctx/LoC | cache_write/LoC | output/LoC |
|------|-------------|--------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 33 | 1303.9 | 917.7 | 202.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 10 | 5880.1 | 4580.3 | 1117.5 |
| **Total** | **43** | 1404.1 | 5610.3 | 1267.3 |