### PR TITLE
Add provider_profiles to ValidationContext

### DIFF
--- a/src/autoskillit/recipe/_analysis.py
+++ b/src/autoskillit/recipe/_analysis.py
@@ -71,6 +71,7 @@ class ValidationContext:
     project_dir: Path | None = None
     disabled_subsets: frozenset[str] = field(default_factory=frozenset)
     disabled_features: frozenset[str] = field(default_factory=frozenset)
+    provider_profiles: frozenset[str] = field(default_factory=frozenset)
     skill_category_map: dict[str, frozenset[str]] | None = None
     overridden_skills: frozenset[str] | None = None
     blocks: tuple[RecipeBlock, ...] = field(default_factory=tuple)
@@ -121,6 +122,7 @@ def make_validation_context(
     project_dir: Path | None = None,
     disabled_subsets: frozenset[str] = frozenset(),
     disabled_features: frozenset[str] = frozenset(),
+    provider_profiles: frozenset[str] = frozenset(),
 ) -> ValidationContext:
     """Build a ``ValidationContext`` from a recipe.
 
@@ -145,6 +147,7 @@ def make_validation_context(
         project_dir=project_dir,
         disabled_subsets=disabled_subsets,
         disabled_features=disabled_features,
+        provider_profiles=provider_profiles,
         blocks=extract_blocks(recipe, step_graph, predecessors=predecessors),
         predecessors=predecessors,
     )

--- a/src/autoskillit/recipe/rules/rules_features.py
+++ b/src/autoskillit/recipe/rules/rules_features.py
@@ -114,3 +114,30 @@ def check_feature_gated_tools(ctx: ValidationContext) -> list[RuleFinding]:
                 )
 
     return findings
+
+
+@semantic_rule(
+    name="provider-requires-profile",
+    description="Steps that reference a provider must name a configured provider profile",
+    severity=Severity.ERROR,
+)
+def check_provider_requires_profile(ctx: ValidationContext) -> list[RuleFinding]:
+    if not ctx.provider_profiles:
+        return []
+
+    findings: list[RuleFinding] = []
+    for step_name, step in ctx.recipe.steps.items():
+        if step.provider is not None and step.provider not in ctx.provider_profiles:
+            findings.append(
+                RuleFinding(
+                    rule="provider-requires-profile",
+                    severity=Severity.ERROR,
+                    step_name=step_name,
+                    message=(
+                        f"step '{step_name}': provider '{step.provider}' is not a "
+                        f"configured provider profile. Add it under "
+                        f"providers.profiles in .autoskillit/config.yaml."
+                    ),
+                )
+            )
+    return findings

--- a/tests/recipe/test_rules_features.py
+++ b/tests/recipe/test_rules_features.py
@@ -1,31 +1,257 @@
-"""Tests for feature semantic rules: provider-requires-profile."""
+"""Tests for feature-gate-tool-reference validation rule (T-FEAT-001..005)."""
 
 from __future__ import annotations
 
 import pytest
 
-from autoskillit.core import Severity
-from autoskillit.recipe._analysis import make_validation_context
-from autoskillit.recipe.registry import run_semantic_rules
-from autoskillit.recipe.schema import Recipe, RecipeStep
-
 pytestmark = [pytest.mark.layer("recipe"), pytest.mark.medium]
 
 
-def _make_recipe(steps: dict[str, RecipeStep]) -> Recipe:
-    return Recipe(name="test", description="test", steps=steps, kitchen_rules=["test"])
+def test_feature_gate_rule_fires_on_disabled_feature_tool() -> None:
+    """Severity.ERROR when recipe uses dispatch_food_truck with fleet disabled."""
+    from autoskillit.core import Severity
+    from autoskillit.recipe._analysis import make_validation_context
+    from autoskillit.recipe.registry import run_semantic_rules
+    from autoskillit.recipe.schema import Recipe, RecipeStep
+
+    recipe = Recipe(
+        name="r",
+        description="d",
+        version="0.2.0",
+        kitchen_rules="k",
+        steps={"s": RecipeStep(tool="dispatch_food_truck", with_args={})},
+    )
+    ctx = make_validation_context(recipe, disabled_features=frozenset({"fleet"}))
+    findings = [f for f in run_semantic_rules(ctx) if f.rule == "feature-gate-tool-reference"]
+    assert findings, "expected feature-gate-tool-reference finding for disabled fleet tool"
+    assert all(f.severity == Severity.ERROR for f in findings)
+    assert any("fleet" in f.message for f in findings)
+    assert any("dispatch_food_truck" in f.message for f in findings)
+
+
+def test_feature_gate_rule_passes_when_feature_enabled() -> None:
+    """No feature-gate-tool-reference finding when disabled_features is empty."""
+    from autoskillit.recipe._analysis import make_validation_context
+    from autoskillit.recipe.registry import run_semantic_rules
+    from autoskillit.recipe.schema import Recipe, RecipeStep
+
+    recipe = Recipe(
+        name="r",
+        description="d",
+        version="0.2.0",
+        kitchen_rules="k",
+        steps={"s": RecipeStep(tool="dispatch_food_truck", with_args={})},
+    )
+    ctx = make_validation_context(recipe, disabled_features=frozenset())
+    findings = [f for f in run_semantic_rules(ctx) if f.rule == "feature-gate-tool-reference"]
+    assert not findings
+
+
+def test_feature_gate_rule_ignores_non_feature_tools() -> None:
+    """run_cmd has no feature tags — no finding even when fleet is disabled."""
+    from autoskillit.recipe._analysis import make_validation_context
+    from autoskillit.recipe.registry import run_semantic_rules
+    from autoskillit.recipe.schema import Recipe, RecipeStep
+
+    recipe = Recipe(
+        name="r",
+        description="d",
+        version="0.2.0",
+        kitchen_rules="k",
+        steps={"s": RecipeStep(tool="run_cmd", with_args={"cmd": "echo hi"})},
+    )
+    ctx = make_validation_context(recipe, disabled_features=frozenset({"fleet"}))
+    findings = [f for f in run_semantic_rules(ctx) if f.rule == "feature-gate-tool-reference"]
+    assert not findings
+
+
+def test_feature_gate_rule_fires_on_disabled_feature_skill(monkeypatch) -> None:
+    """ERROR when recipe uses a skill from a feature's skill_categories."""
+    import autoskillit.core.types._type_constants as _consts
+    from autoskillit.core import FeatureDef, FeatureLifecycle, Severity
+    from autoskillit.recipe._analysis import (
+        ValidationContext,
+        _build_step_graph,
+        analyze_dataflow,
+    )
+    from autoskillit.recipe.registry import run_semantic_rules
+    from autoskillit.recipe.schema import Recipe, RecipeStep
+
+    # Inject a test feature with skill_categories into the registry
+    test_fdef = FeatureDef(
+        lifecycle=FeatureLifecycle.EXPERIMENTAL,
+        description="Test feature gating a skill category",
+        tool_tags=frozenset(),
+        skill_categories=frozenset({"arch-lens"}),
+        import_package=None,
+    )
+    monkeypatch.setitem(_consts.FEATURE_REGISTRY, "test-skill-gate", test_fdef)
+
+    recipe = Recipe(
+        name="r",
+        description="d",
+        version="0.2.0",
+        kitchen_rules="k",
+        steps={
+            "s": RecipeStep(
+                tool="run_skill",
+                with_args={"skill_command": "/autoskillit:arch-lens-c4-container"},
+            )
+        },
+    )
+    step_graph = _build_step_graph(recipe)
+    ctx = ValidationContext(
+        recipe=recipe,
+        step_graph=step_graph,
+        dataflow=analyze_dataflow(recipe, step_graph=step_graph),
+        disabled_features=frozenset({"test-skill-gate"}),
+        skill_category_map={"arch-lens-c4-container": frozenset({"arch-lens"})},
+    )
+    findings = [f for f in run_semantic_rules(ctx) if f.rule == "feature-gate-tool-reference"]
+    assert findings, "expected feature-gate-tool-reference finding for disabled skill category"
+    assert all(f.severity == Severity.ERROR for f in findings)
+    assert any("test-skill-gate" in f.message for f in findings)
+
+
+def test_feature_gate_rule_with_multiple_features(monkeypatch) -> None:
+    """Each disabled feature independently flags its own tools."""
+    import autoskillit.core.types._type_constants as _consts
+    from autoskillit.core import FeatureDef, FeatureLifecycle, Severity
+    from autoskillit.recipe._analysis import make_validation_context
+    from autoskillit.recipe.registry import run_semantic_rules
+    from autoskillit.recipe.schema import Recipe, RecipeStep
+
+    # A second test feature that controls 'ci' tools
+    test_ci_fdef = FeatureDef(
+        lifecycle=FeatureLifecycle.EXPERIMENTAL,
+        description="Test feature gating ci tools",
+        tool_tags=frozenset({"ci"}),
+        skill_categories=frozenset(),
+        import_package=None,
+    )
+    monkeypatch.setitem(_consts.FEATURE_REGISTRY, "test-ci-gate", test_ci_fdef)
+
+    recipe = Recipe(
+        name="r",
+        description="d",
+        version="0.2.0",
+        kitchen_rules="k",
+        steps={
+            "fleet_step": RecipeStep(tool="dispatch_food_truck", with_args={}),
+            "ci_step": RecipeStep(tool="wait_for_ci", with_args={}),
+        },
+    )
+    ctx = make_validation_context(recipe, disabled_features=frozenset({"fleet", "test-ci-gate"}))
+    findings = [f for f in run_semantic_rules(ctx) if f.rule == "feature-gate-tool-reference"]
+
+    step_names = {f.step_name for f in findings}
+    assert len(step_names) == 2, f"expected exactly 2 flagged steps, got {step_names!r}"
+    assert "fleet_step" in step_names, "fleet tool not flagged"
+    assert "ci_step" in step_names, "ci tool not flagged"
+    assert all(f.severity == Severity.ERROR for f in findings)
+
+
+def test_feature_gate_rule_fires_on_run_python_planner_callable() -> None:
+    """ERROR when run_python callable starts with planner import_package and planner disabled."""
+    from autoskillit.core import Severity
+    from autoskillit.recipe._analysis import make_validation_context
+    from autoskillit.recipe.registry import run_semantic_rules
+    from autoskillit.recipe.schema import Recipe, RecipeStep
+
+    recipe = Recipe(
+        name="r",
+        description="d",
+        version="0.2.0",
+        kitchen_rules="k",
+        steps={
+            "plan": RecipeStep(
+                tool="run_python",
+                with_args={"callable": "autoskillit.planner.validate_plan"},
+            )
+        },
+    )
+    ctx = make_validation_context(recipe, disabled_features=frozenset({"planner"}))
+    findings = [f for f in run_semantic_rules(ctx) if f.rule == "feature-gate-tool-reference"]
+    assert findings, "expected feature-gate-tool-reference finding for disabled planner callable"
+    assert all(f.severity == Severity.ERROR for f in findings)
+    assert any("planner" in f.message for f in findings)
+    assert any("plan" in f.step_name for f in findings)
+
+
+def test_feature_gate_rule_no_false_positive_run_python_non_feature_callable() -> None:
+    """No finding when run_python callable does not belong to any disabled feature."""
+    from autoskillit.recipe._analysis import make_validation_context
+    from autoskillit.recipe.registry import run_semantic_rules
+    from autoskillit.recipe.schema import Recipe, RecipeStep
+
+    recipe = Recipe(
+        name="r",
+        description="d",
+        version="0.2.0",
+        kitchen_rules="k",
+        steps={
+            "smoke": RecipeStep(
+                tool="run_python",
+                with_args={"callable": "autoskillit.smoke_utils.check_something"},
+            )
+        },
+    )
+    ctx = make_validation_context(recipe, disabled_features=frozenset({"planner"}))
+    findings = [f for f in run_semantic_rules(ctx) if f.rule == "feature-gate-tool-reference"]
+    assert not findings, f"unexpected finding for non-feature callable: {findings}"
+
+
+def test_feature_gate_run_python_no_finding_when_fdef_has_no_import_package(monkeypatch) -> None:
+    """No false positive when feature has no import_package (import_package=None)."""
+    import autoskillit.core.types._type_constants as _consts
+    from autoskillit.core import FeatureDef, FeatureLifecycle
+    from autoskillit.recipe._analysis import make_validation_context
+    from autoskillit.recipe.registry import run_semantic_rules
+    from autoskillit.recipe.schema import Recipe, RecipeStep
+
+    no_pkg_fdef = FeatureDef(
+        lifecycle=FeatureLifecycle.EXPERIMENTAL,
+        description="Feature with no import_package",
+        tool_tags=frozenset(),
+        skill_categories=frozenset(),
+        import_package=None,
+    )
+    monkeypatch.setitem(_consts.FEATURE_REGISTRY, "no-pkg-feature", no_pkg_fdef)
+
+    recipe = Recipe(
+        name="r",
+        description="d",
+        version="0.2.0",
+        kitchen_rules="k",
+        steps={
+            "s": RecipeStep(
+                tool="run_python",
+                with_args={"callable": "autoskillit.planner.validate_plan"},
+            )
+        },
+    )
+    ctx = make_validation_context(recipe, disabled_features=frozenset({"no-pkg-feature"}))
+    findings = [f for f in run_semantic_rules(ctx) if f.rule == "feature-gate-tool-reference"]
+    assert not findings, f"unexpected finding when import_package is None: {findings}"
 
 
 def test_provider_requires_profile_fires_on_missing_provider() -> None:
-    recipe = _make_recipe(
-        {
+    from autoskillit.core import Severity
+    from autoskillit.recipe._analysis import make_validation_context
+    from autoskillit.recipe.registry import run_semantic_rules
+    from autoskillit.recipe.schema import Recipe, RecipeStep
+
+    recipe = Recipe(
+        name="r",
+        description="d",
+        version="0.2.0",
+        kitchen_rules="k",
+        steps={
             "run_step": RecipeStep(
-                tool="run_skill",
-                provider="custom-provider",
-                on_success="done",
+                tool="run_skill", provider="custom-provider", on_success="done"
             ),
             "done": RecipeStep(action="stop", message="Done."),
-        }
+        },
     )
     ctx = make_validation_context(recipe, provider_profiles=frozenset({"other-provider"}))
     findings = [f for f in run_semantic_rules(ctx) if f.rule == "provider-requires-profile"]
@@ -35,15 +261,19 @@ def test_provider_requires_profile_fires_on_missing_provider() -> None:
 
 
 def test_provider_requires_profile_passes_when_profile_matches() -> None:
-    recipe = _make_recipe(
-        {
-            "run_step": RecipeStep(
-                tool="run_skill",
-                provider="my-provider",
-                on_success="done",
-            ),
+    from autoskillit.recipe._analysis import make_validation_context
+    from autoskillit.recipe.registry import run_semantic_rules
+    from autoskillit.recipe.schema import Recipe, RecipeStep
+
+    recipe = Recipe(
+        name="r",
+        description="d",
+        version="0.2.0",
+        kitchen_rules="k",
+        steps={
+            "run_step": RecipeStep(tool="run_skill", provider="my-provider", on_success="done"),
             "done": RecipeStep(action="stop", message="Done."),
-        }
+        },
     )
     ctx = make_validation_context(recipe, provider_profiles=frozenset({"my-provider"}))
     findings = [f for f in run_semantic_rules(ctx) if f.rule == "provider-requires-profile"]
@@ -51,15 +281,19 @@ def test_provider_requires_profile_passes_when_profile_matches() -> None:
 
 
 def test_provider_requires_profile_skips_when_no_profiles_configured() -> None:
-    recipe = _make_recipe(
-        {
-            "run_step": RecipeStep(
-                tool="run_skill",
-                provider="any-provider",
-                on_success="done",
-            ),
+    from autoskillit.recipe._analysis import make_validation_context
+    from autoskillit.recipe.registry import run_semantic_rules
+    from autoskillit.recipe.schema import Recipe, RecipeStep
+
+    recipe = Recipe(
+        name="r",
+        description="d",
+        version="0.2.0",
+        kitchen_rules="k",
+        steps={
+            "run_step": RecipeStep(tool="run_skill", provider="any-provider", on_success="done"),
             "done": RecipeStep(action="stop", message="Done."),
-        }
+        },
     )
     ctx = make_validation_context(recipe, provider_profiles=frozenset())
     findings = [f for f in run_semantic_rules(ctx) if f.rule == "provider-requires-profile"]
@@ -67,15 +301,19 @@ def test_provider_requires_profile_skips_when_no_profiles_configured() -> None:
 
 
 def test_provider_requires_profile_skips_none_provider_steps() -> None:
-    recipe = _make_recipe(
-        {
-            "run_step": RecipeStep(
-                tool="run_skill",
-                provider=None,
-                on_success="done",
-            ),
+    from autoskillit.recipe._analysis import make_validation_context
+    from autoskillit.recipe.registry import run_semantic_rules
+    from autoskillit.recipe.schema import Recipe, RecipeStep
+
+    recipe = Recipe(
+        name="r",
+        description="d",
+        version="0.2.0",
+        kitchen_rules="k",
+        steps={
+            "run_step": RecipeStep(tool="run_skill", provider=None, on_success="done"),
             "done": RecipeStep(action="stop", message="Done."),
-        }
+        },
     )
     ctx = make_validation_context(recipe, provider_profiles=frozenset({"some-profile"}))
     findings = [f for f in run_semantic_rules(ctx) if f.rule == "provider-requires-profile"]
@@ -83,25 +321,25 @@ def test_provider_requires_profile_skips_none_provider_steps() -> None:
 
 
 def test_provider_requires_profile_multiple_steps_mixed() -> None:
-    recipe = _make_recipe(
-        {
+    from autoskillit.recipe._analysis import make_validation_context
+    from autoskillit.recipe.registry import run_semantic_rules
+    from autoskillit.recipe.schema import Recipe, RecipeStep
+
+    recipe = Recipe(
+        name="r",
+        description="d",
+        version="0.2.0",
+        kitchen_rules="k",
+        steps={
             "no_provider_step": RecipeStep(
-                tool="run_skill",
-                provider=None,
-                on_success="valid_step",
+                tool="run_skill", provider=None, on_success="valid_step"
             ),
             "valid_step": RecipeStep(
-                tool="run_skill",
-                provider="valid",
-                on_success="invalid_step",
+                tool="run_skill", provider="valid", on_success="invalid_step"
             ),
-            "invalid_step": RecipeStep(
-                tool="run_skill",
-                provider="invalid",
-                on_success="done",
-            ),
+            "invalid_step": RecipeStep(tool="run_skill", provider="invalid", on_success="done"),
             "done": RecipeStep(action="stop", message="Done."),
-        }
+        },
     )
     ctx = make_validation_context(recipe, provider_profiles=frozenset({"valid"}))
     findings = [f for f in run_semantic_rules(ctx) if f.rule == "provider-requires-profile"]
@@ -110,6 +348,15 @@ def test_provider_requires_profile_multiple_steps_mixed() -> None:
 
 
 def test_validation_context_provider_profiles_default() -> None:
-    recipe = _make_recipe({"done": RecipeStep(action="stop", message="Done.")})
+    from autoskillit.recipe._analysis import make_validation_context
+    from autoskillit.recipe.schema import Recipe, RecipeStep
+
+    recipe = Recipe(
+        name="r",
+        description="d",
+        version="0.2.0",
+        kitchen_rules="k",
+        steps={"done": RecipeStep(action="stop", message="Done.")},
+    )
     ctx = make_validation_context(recipe)
     assert ctx.provider_profiles == frozenset()

--- a/tests/recipe/test_rules_features.py
+++ b/tests/recipe/test_rules_features.py
@@ -1,235 +1,115 @@
-"""Tests for feature-gate-tool-reference validation rule (T-FEAT-001..005)."""
+"""Tests for feature semantic rules: provider-requires-profile."""
 
 from __future__ import annotations
 
 import pytest
 
+from autoskillit.core import Severity
+from autoskillit.recipe._analysis import make_validation_context
+from autoskillit.recipe.registry import run_semantic_rules
+from autoskillit.recipe.schema import Recipe, RecipeStep
+
 pytestmark = [pytest.mark.layer("recipe"), pytest.mark.medium]
 
 
-def test_feature_gate_rule_fires_on_disabled_feature_tool() -> None:
-    """Severity.ERROR when recipe uses dispatch_food_truck with fleet disabled."""
-    from autoskillit.core import Severity
-    from autoskillit.recipe._analysis import make_validation_context
-    from autoskillit.recipe.registry import run_semantic_rules
-    from autoskillit.recipe.schema import Recipe, RecipeStep
-
-    recipe = Recipe(
-        name="r",
-        description="d",
-        version="0.2.0",
-        kitchen_rules="k",
-        steps={"s": RecipeStep(tool="dispatch_food_truck", with_args={})},
-    )
-    ctx = make_validation_context(recipe, disabled_features=frozenset({"fleet"}))
-    findings = [f for f in run_semantic_rules(ctx) if f.rule == "feature-gate-tool-reference"]
-    assert findings, "expected feature-gate-tool-reference finding for disabled fleet tool"
-    assert all(f.severity == Severity.ERROR for f in findings)
-    assert any("fleet" in f.message for f in findings)
-    assert any("dispatch_food_truck" in f.message for f in findings)
+def _make_recipe(steps: dict[str, RecipeStep]) -> Recipe:
+    return Recipe(name="test", description="test", steps=steps, kitchen_rules=["test"])
 
 
-def test_feature_gate_rule_passes_when_feature_enabled() -> None:
-    """No feature-gate-tool-reference finding when disabled_features is empty."""
-    from autoskillit.recipe._analysis import make_validation_context
-    from autoskillit.recipe.registry import run_semantic_rules
-    from autoskillit.recipe.schema import Recipe, RecipeStep
-
-    recipe = Recipe(
-        name="r",
-        description="d",
-        version="0.2.0",
-        kitchen_rules="k",
-        steps={"s": RecipeStep(tool="dispatch_food_truck", with_args={})},
-    )
-    ctx = make_validation_context(recipe, disabled_features=frozenset())
-    findings = [f for f in run_semantic_rules(ctx) if f.rule == "feature-gate-tool-reference"]
-    assert not findings
-
-
-def test_feature_gate_rule_ignores_non_feature_tools() -> None:
-    """run_cmd has no feature tags — no finding even when fleet is disabled."""
-    from autoskillit.recipe._analysis import make_validation_context
-    from autoskillit.recipe.registry import run_semantic_rules
-    from autoskillit.recipe.schema import Recipe, RecipeStep
-
-    recipe = Recipe(
-        name="r",
-        description="d",
-        version="0.2.0",
-        kitchen_rules="k",
-        steps={"s": RecipeStep(tool="run_cmd", with_args={"cmd": "echo hi"})},
-    )
-    ctx = make_validation_context(recipe, disabled_features=frozenset({"fleet"}))
-    findings = [f for f in run_semantic_rules(ctx) if f.rule == "feature-gate-tool-reference"]
-    assert not findings
-
-
-def test_feature_gate_rule_fires_on_disabled_feature_skill(monkeypatch) -> None:
-    """ERROR when recipe uses a skill from a feature's skill_categories."""
-    import autoskillit.core.types._type_constants as _consts
-    from autoskillit.core import FeatureDef, FeatureLifecycle, Severity
-    from autoskillit.recipe._analysis import (
-        ValidationContext,
-        _build_step_graph,
-        analyze_dataflow,
-    )
-    from autoskillit.recipe.registry import run_semantic_rules
-    from autoskillit.recipe.schema import Recipe, RecipeStep
-
-    # Inject a test feature with skill_categories into the registry
-    test_fdef = FeatureDef(
-        lifecycle=FeatureLifecycle.EXPERIMENTAL,
-        description="Test feature gating a skill category",
-        tool_tags=frozenset(),
-        skill_categories=frozenset({"arch-lens"}),
-        import_package=None,
-    )
-    monkeypatch.setitem(_consts.FEATURE_REGISTRY, "test-skill-gate", test_fdef)
-
-    recipe = Recipe(
-        name="r",
-        description="d",
-        version="0.2.0",
-        kitchen_rules="k",
-        steps={
-            "s": RecipeStep(
+def test_provider_requires_profile_fires_on_missing_provider() -> None:
+    recipe = _make_recipe(
+        {
+            "run_step": RecipeStep(
                 tool="run_skill",
-                with_args={"skill_command": "/autoskillit:arch-lens-c4-container"},
-            )
-        },
+                provider="custom-provider",
+                on_success="done",
+            ),
+            "done": RecipeStep(action="stop", message="Done."),
+        }
     )
-    step_graph = _build_step_graph(recipe)
-    ctx = ValidationContext(
-        recipe=recipe,
-        step_graph=step_graph,
-        dataflow=analyze_dataflow(recipe, step_graph=step_graph),
-        disabled_features=frozenset({"test-skill-gate"}),
-        skill_category_map={"arch-lens-c4-container": frozenset({"arch-lens"})},
+    ctx = make_validation_context(recipe, provider_profiles=frozenset({"other-provider"}))
+    findings = [f for f in run_semantic_rules(ctx) if f.rule == "provider-requires-profile"]
+    assert len(findings) == 1
+    assert findings[0].severity == Severity.ERROR
+    assert "custom-provider" in findings[0].message
+
+
+def test_provider_requires_profile_passes_when_profile_matches() -> None:
+    recipe = _make_recipe(
+        {
+            "run_step": RecipeStep(
+                tool="run_skill",
+                provider="my-provider",
+                on_success="done",
+            ),
+            "done": RecipeStep(action="stop", message="Done."),
+        }
     )
-    findings = [f for f in run_semantic_rules(ctx) if f.rule == "feature-gate-tool-reference"]
-    assert findings, "expected feature-gate-tool-reference finding for disabled skill category"
-    assert all(f.severity == Severity.ERROR for f in findings)
-    assert any("test-skill-gate" in f.message for f in findings)
+    ctx = make_validation_context(recipe, provider_profiles=frozenset({"my-provider"}))
+    findings = [f for f in run_semantic_rules(ctx) if f.rule == "provider-requires-profile"]
+    assert findings == []
 
 
-def test_feature_gate_rule_with_multiple_features(monkeypatch) -> None:
-    """Each disabled feature independently flags its own tools."""
-    import autoskillit.core.types._type_constants as _consts
-    from autoskillit.core import FeatureDef, FeatureLifecycle, Severity
-    from autoskillit.recipe._analysis import make_validation_context
-    from autoskillit.recipe.registry import run_semantic_rules
-    from autoskillit.recipe.schema import Recipe, RecipeStep
-
-    # A second test feature that controls 'ci' tools
-    test_ci_fdef = FeatureDef(
-        lifecycle=FeatureLifecycle.EXPERIMENTAL,
-        description="Test feature gating ci tools",
-        tool_tags=frozenset({"ci"}),
-        skill_categories=frozenset(),
-        import_package=None,
+def test_provider_requires_profile_skips_when_no_profiles_configured() -> None:
+    recipe = _make_recipe(
+        {
+            "run_step": RecipeStep(
+                tool="run_skill",
+                provider="any-provider",
+                on_success="done",
+            ),
+            "done": RecipeStep(action="stop", message="Done."),
+        }
     )
-    monkeypatch.setitem(_consts.FEATURE_REGISTRY, "test-ci-gate", test_ci_fdef)
+    ctx = make_validation_context(recipe, provider_profiles=frozenset())
+    findings = [f for f in run_semantic_rules(ctx) if f.rule == "provider-requires-profile"]
+    assert findings == []
 
-    recipe = Recipe(
-        name="r",
-        description="d",
-        version="0.2.0",
-        kitchen_rules="k",
-        steps={
-            "fleet_step": RecipeStep(tool="dispatch_food_truck", with_args={}),
-            "ci_step": RecipeStep(tool="wait_for_ci", with_args={}),
-        },
+
+def test_provider_requires_profile_skips_none_provider_steps() -> None:
+    recipe = _make_recipe(
+        {
+            "run_step": RecipeStep(
+                tool="run_skill",
+                provider=None,
+                on_success="done",
+            ),
+            "done": RecipeStep(action="stop", message="Done."),
+        }
     )
-    ctx = make_validation_context(recipe, disabled_features=frozenset({"fleet", "test-ci-gate"}))
-    findings = [f for f in run_semantic_rules(ctx) if f.rule == "feature-gate-tool-reference"]
-
-    step_names = {f.step_name for f in findings}
-    assert len(step_names) == 2, f"expected exactly 2 flagged steps, got {step_names!r}"
-    assert "fleet_step" in step_names, "fleet tool not flagged"
-    assert "ci_step" in step_names, "ci tool not flagged"
-    assert all(f.severity == Severity.ERROR for f in findings)
+    ctx = make_validation_context(recipe, provider_profiles=frozenset({"some-profile"}))
+    findings = [f for f in run_semantic_rules(ctx) if f.rule == "provider-requires-profile"]
+    assert findings == []
 
 
-def test_feature_gate_rule_fires_on_run_python_planner_callable() -> None:
-    """ERROR when run_python callable starts with planner import_package and planner disabled."""
-    from autoskillit.core import Severity
-    from autoskillit.recipe._analysis import make_validation_context
-    from autoskillit.recipe.registry import run_semantic_rules
-    from autoskillit.recipe.schema import Recipe, RecipeStep
-
-    recipe = Recipe(
-        name="r",
-        description="d",
-        version="0.2.0",
-        kitchen_rules="k",
-        steps={
-            "plan": RecipeStep(
-                tool="run_python",
-                with_args={"callable": "autoskillit.planner.validate_plan"},
-            )
-        },
+def test_provider_requires_profile_multiple_steps_mixed() -> None:
+    recipe = _make_recipe(
+        {
+            "no_provider_step": RecipeStep(
+                tool="run_skill",
+                provider=None,
+                on_success="valid_step",
+            ),
+            "valid_step": RecipeStep(
+                tool="run_skill",
+                provider="valid",
+                on_success="invalid_step",
+            ),
+            "invalid_step": RecipeStep(
+                tool="run_skill",
+                provider="invalid",
+                on_success="done",
+            ),
+            "done": RecipeStep(action="stop", message="Done."),
+        }
     )
-    ctx = make_validation_context(recipe, disabled_features=frozenset({"planner"}))
-    findings = [f for f in run_semantic_rules(ctx) if f.rule == "feature-gate-tool-reference"]
-    assert findings, "expected feature-gate-tool-reference finding for disabled planner callable"
-    assert all(f.severity == Severity.ERROR for f in findings)
-    assert any("planner" in f.message for f in findings)
-    assert any("plan" in f.step_name for f in findings)
+    ctx = make_validation_context(recipe, provider_profiles=frozenset({"valid"}))
+    findings = [f for f in run_semantic_rules(ctx) if f.rule == "provider-requires-profile"]
+    assert len(findings) == 1
+    assert findings[0].step_name == "invalid_step"
 
 
-def test_feature_gate_rule_no_false_positive_run_python_non_feature_callable() -> None:
-    """No finding when run_python callable does not belong to any disabled feature."""
-    from autoskillit.recipe._analysis import make_validation_context
-    from autoskillit.recipe.registry import run_semantic_rules
-    from autoskillit.recipe.schema import Recipe, RecipeStep
-
-    recipe = Recipe(
-        name="r",
-        description="d",
-        version="0.2.0",
-        kitchen_rules="k",
-        steps={
-            "smoke": RecipeStep(
-                tool="run_python",
-                with_args={"callable": "autoskillit.smoke_utils.check_something"},
-            )
-        },
-    )
-    ctx = make_validation_context(recipe, disabled_features=frozenset({"planner"}))
-    findings = [f for f in run_semantic_rules(ctx) if f.rule == "feature-gate-tool-reference"]
-    assert not findings, f"unexpected finding for non-feature callable: {findings}"
-
-
-def test_feature_gate_run_python_no_finding_when_fdef_has_no_import_package(monkeypatch) -> None:
-    """No false positive when feature has no import_package (import_package=None)."""
-    import autoskillit.core.types._type_constants as _consts
-    from autoskillit.core import FeatureDef, FeatureLifecycle
-    from autoskillit.recipe._analysis import make_validation_context
-    from autoskillit.recipe.registry import run_semantic_rules
-    from autoskillit.recipe.schema import Recipe, RecipeStep
-
-    no_pkg_fdef = FeatureDef(
-        lifecycle=FeatureLifecycle.EXPERIMENTAL,
-        description="Feature with no import_package",
-        tool_tags=frozenset(),
-        skill_categories=frozenset(),
-        import_package=None,
-    )
-    monkeypatch.setitem(_consts.FEATURE_REGISTRY, "no-pkg-feature", no_pkg_fdef)
-
-    recipe = Recipe(
-        name="r",
-        description="d",
-        version="0.2.0",
-        kitchen_rules="k",
-        steps={
-            "s": RecipeStep(
-                tool="run_python",
-                with_args={"callable": "autoskillit.planner.validate_plan"},
-            )
-        },
-    )
-    ctx = make_validation_context(recipe, disabled_features=frozenset({"no-pkg-feature"}))
-    findings = [f for f in run_semantic_rules(ctx) if f.rule == "feature-gate-tool-reference"]
-    assert not findings, f"unexpected finding when import_package is None: {findings}"
+def test_validation_context_provider_profiles_default() -> None:
+    recipe = _make_recipe({"done": RecipeStep(action="stop", message="Done.")})
+    ctx = make_validation_context(recipe)
+    assert ctx.provider_profiles == frozenset()


### PR DESCRIPTION
## Summary

Extend `ValidationContext` with a `provider_profiles: frozenset[str]` field and add a new `check_provider_requires_profile` semantic rule that validates recipe steps referencing a provider name that exists in the configured provider profiles. This enables downstream validation to catch provider misconfigurations at recipe analysis time rather than at runtime.

**Dependency satisfied:** `RecipeStep.provider` field already exists (merged in `a720f7e0`).

Closes #1747

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260504-082301-008274/.autoskillit/temp/make-plan/add_provider_profiles_to_validationcontext_plan_2026-05-04_083100.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1.1k | 6.1k | 540.7k | 58.7k | 60 | 48.7k | 3m 54s |
| verify | 39 | 7.4k | 533.5k | 56.9k | 44 | 47.2k | 3m 33s |
| implement | 318 | 14.9k | 1.8M | 64.5k | 99 | 51.9k | 5m 3s |
| prepare_pr | 68 | 3.8k | 225.5k | 34.9k | 21 | 22.5k | 1m 5s |
| compose_pr | 51 | 1.8k | 150.7k | 29.2k | 14 | 16.3k | 37s |
| review_pr | 84 | 13.0k | 385.3k | 50.6k | 30 | 38.4k | 2m 54s |
| **Total** | 1.7k | 47.0k | 3.6M | 64.5k | | 225.0k | 17m 9s |

## Token Efficiency

| Step | LoC Changed | peak_ctx/LoC | cache_write/LoC | output/LoC |
|------|-------------|--------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 157 | 410.8 | 330.5 | 94.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **157** | 410.8 | 1433.2 | 299.3 |