### PR TITLE
Implementation Plan: [P1-A7-WP2] Extend test_io_parsing.py for RecipeStep.provider

### DIFF
--- a/tests/recipe/test_io_parsing.py
+++ b/tests/recipe/test_io_parsing.py
@@ -615,3 +615,32 @@ def test_parse_step_handles_all_recipe_step_fields() -> None:
         f"  Missing from handled: {schema_fields - _PARSE_STEP_HANDLED_FIELDS}\n"
         f"  Extra in handled:     {_PARSE_STEP_HANDLED_FIELDS - schema_fields}"
     )
+
+
+def test_step_provider_field_parses_correctly() -> None:
+    step = _parse_step({"tool": "run_skill", "provider": "minimax"})
+    assert step.provider == "minimax"
+
+
+def test_step_provider_field_default_is_none() -> None:
+    step = _parse_step({"tool": "run_skill"})
+    assert step.provider is None
+
+
+def test_load_recipe_step_with_provider_field(tmp_path: Path) -> None:
+    yaml_content = textwrap.dedent("""\
+        name: provider-test
+        kitchen_rules: [rule1]
+        steps:
+          run_step:
+            tool: run_skill
+            provider: minimax
+            on_success: done
+          done:
+            action: stop
+            message: Done.
+    """)
+    recipe_file = tmp_path / "provider-test.yaml"
+    recipe_file.write_text(yaml_content)
+    recipe = load_recipe(recipe_file)
+    assert recipe.steps["run_step"].provider == "minimax"


### PR DESCRIPTION
## Summary

Add three standalone test functions to `tests/recipe/test_io_parsing.py` that verify the `RecipeStep.provider` field: unit-level `_parse_step` round-trip with an explicit provider, default-to-`None` when absent, and end-to-end YAML round-trip via `load_recipe`. The four `test_rules_features.py` tests specified in the issue are already present (added by dependency #1747) with equivalent semantics under different names — no new tests are needed there.

Closes #1749

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260504-085844-411471/.autoskillit/temp/make-plan/p1_a7_wp2_extend_test_io_parsing_plan_2026-05-04_090300.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|----------|--------|------------|----------|-------|-------------|------|
| plan | 656 | 11.6k | 808.9k | 64.8k | 53 | 51.8k | 5m 8s |
| verify | 33 | 7.9k | 627.9k | 51.0k | 41 | 38.9k | 4m 21s |
| implement | 92 | 3.7k | 369.9k | 44.1k | 28 | 31.4k | 1m 26s |
| prepare_pr | 60 | 4.9k | 202.5k | 37.0k | 19 | 24.6k | 1m 38s |
| compose_pr | 59 | 2.0k | 179.8k | 29.3k | 15 | 16.5k | 41s |
| review_pr | 132 | 8.3k | 578.7k | 44.1k | 39 | 31.8k | 2m 15s |
| **Total** | 1.0k | 38.4k | 2.8M | 64.8k | | 195.0k | 15m 32s |

## Token Efficiency

| Step | LoC Changed | peak_ctx/LoC | cache_write/LoC | output/LoC |
|------|-------------|--------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 29 | 1519.5 | 1081.5 | 128.2 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **29** | 2236.1 | 6723.1 | 1325.6 |