### PR TITLE
[P1-A7-WP1] Create test_providers_config.py

### DIFF
--- a/tests/config/CLAUDE.md
+++ b/tests/config/CLAUDE.md
@@ -13,6 +13,7 @@ Configuration loading, defaults, and schema tests.
 | `test_fleet_config.py` | Tests for FleetConfig loading and validation |
 | `test_helpers.py` | Tests for autoskillit.config resolve_ingredient_defaults |
 | `test_packs_config.py` | Tests for PacksConfig loading and validation |
+| `test_providers_config.py` | Tests for ProvidersConfig loading and validation |
 | `test_settings_allowed_labels.py` | Tests for GitHubConfig.allowed_labels field and check_label_allowed validation |
 | `test_settings_staged_label.py` | Tests for GitHubConfig.staged_label field and config layer resolution |
 | `test_skills_config.py` | Tests for SkillsConfig loading and validation |

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -8,7 +8,6 @@ import yaml
 from autoskillit.config import (
     AutomationConfig,
     ConfigSchemaError,
-    ProvidersConfig,
     RunSkillConfig,
     load_config,
 )
@@ -890,75 +889,3 @@ class TestWorkspaceConfig:
 
         cfg = load_config(tmp_path)
         assert cfg.workspace.runs_root is None
-
-
-class TestProvidersConfig:
-    def test_providers_config_importable_from_settings(self):
-        from autoskillit.config.settings import ProvidersConfig as PC
-
-        assert PC is ProvidersConfig
-
-    def test_providers_config_in_settings_all(self):
-        import autoskillit.config.settings as m
-
-        assert "ProvidersConfig" in m.__all__
-
-    def test_automation_config_has_providers_field(self):
-        field_names = [f.name for f in dc_fields(AutomationConfig)]
-        assert "providers" in field_names
-        cfg = AutomationConfig()
-        assert isinstance(cfg.providers, ProvidersConfig)
-
-    def test_providers_field_ordering(self):
-        field_names = [f.name for f in dc_fields(AutomationConfig)]
-        fleet_idx = field_names.index("fleet")
-        providers_idx = field_names.index("providers")
-        features_idx = field_names.index("features")
-        assert fleet_idx < providers_idx < features_idx
-
-    def test_providers_config_importable_from_package(self):
-        from autoskillit.config import ProvidersConfig as PC
-
-        assert PC is ProvidersConfig
-
-    def test_from_dynaconf_providers_defaults(self, tmp_path):
-        cfg = load_config(tmp_path)
-        assert cfg.providers.default_provider is None
-        assert cfg.providers.profiles == {}
-        assert cfg.providers.step_overrides == {}
-        assert cfg.providers.provider_retry_limit == 2
-
-    def test_providers_config_defaults(self):
-        cfg = ProvidersConfig()
-        assert cfg.default_provider is None
-        assert cfg.profiles == {}
-        assert cfg.step_overrides == {}
-        assert cfg.provider_retry_limit == 2
-
-    def test_providers_config_is_mutable(self):
-        cfg = ProvidersConfig()
-        cfg.default_provider = "openai"
-        assert cfg.default_provider == "openai"
-
-    def test_providers_config_field_types(self):
-        from dataclasses import fields as _dc_fields
-
-        field_map = {f.name: f for f in _dc_fields(ProvidersConfig)}
-        assert set(field_map.keys()) == {
-            "default_provider",
-            "profiles",
-            "step_overrides",
-            "provider_retry_limit",
-        }
-
-    def test_providers_config_retry_limit_zero_raises(self):
-        with pytest.raises(ValueError, match="provider_retry_limit must be >= 1"):
-            ProvidersConfig(provider_retry_limit=0)
-
-    def test_providers_config_retry_limit_negative_raises(self):
-        with pytest.raises(ValueError, match="provider_retry_limit must be >= 1"):
-            ProvidersConfig(provider_retry_limit=-1)
-
-    def test_providers_config_profiles_non_string_value_raises(self):
-        with pytest.raises(ValueError, match=r"profiles\[.+\]\[.+\] must be a string"):
-            ProvidersConfig(profiles={"my_profile": {"model": 42}})  # type: ignore[arg-type]

--- a/tests/config/test_providers_config.py
+++ b/tests/config/test_providers_config.py
@@ -1,0 +1,149 @@
+"""Tests for ProvidersConfig loading and validation."""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+pytestmark = [pytest.mark.layer("config"), pytest.mark.small]
+
+
+class TestProvidersConfig:
+    def test_providers_config_importable_from_settings(self) -> None:
+        from autoskillit.config.settings import ProvidersConfig
+
+        assert ProvidersConfig is not None
+
+    def test_providers_config_in_settings_all(self) -> None:
+        import autoskillit.config.settings as m
+
+        assert "ProvidersConfig" in m.__all__
+
+    def test_automation_config_has_providers_field(self) -> None:
+        from dataclasses import fields as _dc_fields
+
+        from autoskillit.config import AutomationConfig, ProvidersConfig
+
+        field_names = [f.name for f in _dc_fields(AutomationConfig)]
+        assert "providers" in field_names
+        cfg = AutomationConfig()
+        assert isinstance(cfg.providers, ProvidersConfig)
+
+    def test_providers_field_ordering(self) -> None:
+        from dataclasses import fields as _dc_fields
+
+        from autoskillit.config import AutomationConfig
+
+        field_names = [f.name for f in _dc_fields(AutomationConfig)]
+        fleet_idx = field_names.index("fleet")
+        providers_idx = field_names.index("providers")
+        features_idx = field_names.index("features")
+        assert fleet_idx < providers_idx < features_idx
+
+    def test_providers_config_importable_from_package(self) -> None:
+        from autoskillit.config import ProvidersConfig
+
+        assert ProvidersConfig is not None
+
+    def test_from_dynaconf_providers_defaults(self, tmp_path) -> None:
+        from autoskillit.config import load_config
+
+        cfg = load_config(tmp_path)
+        assert cfg.providers.default_provider is None
+        assert cfg.providers.profiles == {}
+        assert cfg.providers.step_overrides == {}
+        assert cfg.providers.provider_retry_limit == 2
+
+    def test_providers_config_defaults(self) -> None:
+        from autoskillit.config.settings import ProvidersConfig
+
+        cfg = ProvidersConfig()
+        assert cfg.default_provider is None
+        assert cfg.profiles == {}
+        assert cfg.step_overrides == {}
+        assert cfg.provider_retry_limit == 2
+
+    def test_providers_config_is_mutable(self) -> None:
+        from autoskillit.config.settings import ProvidersConfig
+
+        cfg = ProvidersConfig()
+        cfg.default_provider = "openai"
+        assert cfg.default_provider == "openai"
+
+    def test_providers_config_field_types(self) -> None:
+        from dataclasses import fields as _dc_fields
+
+        from autoskillit.config.settings import ProvidersConfig
+
+        field_map = {f.name: f for f in _dc_fields(ProvidersConfig)}
+        assert set(field_map.keys()) == {
+            "default_provider",
+            "profiles",
+            "step_overrides",
+            "provider_retry_limit",
+        }
+
+    def test_providers_config_retry_limit_zero_raises(self) -> None:
+        from autoskillit.config.settings import ProvidersConfig
+
+        with pytest.raises(ValueError, match="provider_retry_limit must be >= 1"):
+            ProvidersConfig(provider_retry_limit=0)
+
+    def test_providers_config_retry_limit_negative_raises(self) -> None:
+        from autoskillit.config.settings import ProvidersConfig
+
+        with pytest.raises(ValueError, match="provider_retry_limit must be >= 1"):
+            ProvidersConfig(provider_retry_limit=-1)
+
+    def test_providers_config_profiles_non_string_value_raises(self) -> None:
+        from autoskillit.config.settings import ProvidersConfig
+
+        with pytest.raises(ValueError, match=r"profiles\[.+\]\[.+\] must be a string"):
+            ProvidersConfig(profiles={"my_profile": {"model": 42}})  # type: ignore[arg-type]
+
+
+class TestProvidersConfigYaml:
+    def test_defaults_yaml_has_providers_section(self) -> None:
+        from autoskillit.core.io import load_yaml
+        from autoskillit.core.paths import pkg_root
+
+        defaults = load_yaml(pkg_root() / "config" / "defaults.yaml")
+        assert "providers" in defaults, "defaults.yaml missing 'providers' section"
+        assert defaults["providers"]["provider_retry_limit"] == 2
+
+    def test_load_config_step_overrides_parsing(self, tmp_path) -> None:
+        from autoskillit.config import load_config
+
+        config_dir = tmp_path / ".autoskillit"
+        config_dir.mkdir()
+        config_data = {"providers": {"step_overrides": {"fetch-data": "openai"}}}
+        (config_dir / "config.yaml").write_text(yaml.dump(config_data))
+        cfg = load_config(tmp_path)
+        assert cfg.providers.step_overrides == {"fetch-data": "openai"}
+
+    def test_load_config_profiles_dict_parsing(self, tmp_path) -> None:
+        from autoskillit.config import load_config
+
+        config_dir = tmp_path / ".autoskillit"
+        config_dir.mkdir()
+        config_data = {
+            "providers": {
+                "profiles": {
+                    "fast": {"model": "gpt-4o-mini", "api_base": "https://api.openai.com"},
+                }
+            }
+        }
+        (config_dir / "config.yaml").write_text(yaml.dump(config_data))
+        cfg = load_config(tmp_path)
+        assert cfg.providers.profiles == {
+            "fast": {"model": "gpt-4o-mini", "api_base": "https://api.openai.com"},
+        }
+
+    def test_load_config_provider_retry_limit_override(self, tmp_path) -> None:
+        from autoskillit.config import load_config
+
+        config_dir = tmp_path / ".autoskillit"
+        config_dir.mkdir()
+        (config_dir / "config.yaml").write_text("providers:\n  provider_retry_limit: 5\n")
+        cfg = load_config(tmp_path)
+        assert cfg.providers.provider_retry_limit == 5

--- a/tests/config/test_providers_config.py
+++ b/tests/config/test_providers_config.py
@@ -10,9 +10,10 @@ pytestmark = [pytest.mark.layer("config"), pytest.mark.small]
 
 class TestProvidersConfig:
     def test_providers_config_importable_from_settings(self) -> None:
-        from autoskillit.config.settings import ProvidersConfig
+        from autoskillit.config import ProvidersConfig
+        from autoskillit.config.settings import ProvidersConfig as PC
 
-        assert ProvidersConfig is not None
+        assert PC is ProvidersConfig
 
     def test_providers_config_in_settings_all(self) -> None:
         import autoskillit.config.settings as m
@@ -41,9 +42,10 @@ class TestProvidersConfig:
         assert fleet_idx < providers_idx < features_idx
 
     def test_providers_config_importable_from_package(self) -> None:
-        from autoskillit.config import ProvidersConfig
+        from autoskillit.config import ProvidersConfig as PC
+        from autoskillit.config.settings import ProvidersConfig
 
-        assert ProvidersConfig is not None
+        assert PC is ProvidersConfig
 
     def test_from_dynaconf_providers_defaults(self, tmp_path) -> None:
         from autoskillit.config import load_config


### PR DESCRIPTION
## Summary

Create a dedicated test file at `tests/config/test_providers_config.py` that consolidates all `ProvidersConfig` test coverage. This involves **extracting** the existing 12-test `TestProvidersConfig` class from `tests/config/test_config.py` (lines 895–964) into the new file, then adding 4 new tests that cover `defaults.yaml` coherence, `load_config` step_overrides/profiles parsing, absent-section defaults, and retry_limit override.

All three dependencies (#1743 ProvidersConfig dataclass, #1744 import/__all__ registration, #1745 defaults.yaml section) are already merged. The production code is in place; this WP extracts existing tests and adds dedicated coverage.

> ⚠️ Historical note: Issue #1763 (closed 2026-05-04) previously addressed this same WP — tests were landed directly into `test_config.py` rather than a standalone file. This plan completes the extraction into the dedicated file, following the precedent set by `test_packs_config.py`, `test_fleet_config.py`, `test_skills_config.py`, and `test_subsets_config.py` (all extracted from `test_config.py` in commit `14861eb`).

Closes #1748

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260504-085843-976747/.autoskillit/temp/make-plan/p1_a7_wp1_create_test_providers_config_py_plan_2026-05-04_090600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|----------|--------|------------|----------|-------|-------------|------|
| plan | 51 | 7.3k | 675.3k | 56.1k | 62 | 47.2k | 3m 44s |
| verify | 48 | 12.0k | 919.3k | 57.2k | 89 | 45.3k | 5m 26s |
| implement | 158 | 7.3k | 718.6k | 46.1k | 50 | 33.2k | 2m 46s |
| prepare_pr | 60 | 4.5k | 190.1k | 37.3k | 18 | 36.7k | 1m 16s |
| compose_pr | 59 | 2.8k | 181.9k | 30.3k | 15 | 17.5k | 53s |
| review_pr | 92 | 20.2k | 432.3k | 58.8k | 35 | 47.6k | 4m 27s |
| resolve_review | 269 | 10.4k | 1.5M | 60.6k | 78 | 47.9k | 4m 25s |
| **Total** | 737 | 64.6k | 4.6M | 60.6k | | 275.4k | 22m 58s |

## Token Efficiency

| Step | LoC Changed | peak_ctx/LoC | cache_write/LoC | output/LoC |
|------|-------------|--------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 223 | 206.7 | 149.0 | 32.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 10 | 6063.3 | 4793.5 | 1040.8 |
| **Total** | **233** | 260.2 | 1182.2 | 277.4 |