### PR TITLE
Fleet dispatch — forward requires_packs to executor

### DIFF
--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -378,6 +378,7 @@ async def _run_dispatch(
             "AUTOSKILLIT_CAMPAIGN_ID": campaign_id,
             "AUTOSKILLIT_DISPATCH_ID": dispatch_id,
         },
+        requires_packs=list(full_recipe.requires_packs) or ["kitchen-core"],
         on_spawn=_on_spawn,
     )
     ended_at = time.time()

--- a/tests/fleet/_helpers.py
+++ b/tests/fleet/_helpers.py
@@ -44,7 +44,13 @@ def _make_recipe_info(name: str = "test-recipe", path_prefix: str = "/fake/"):
     )
 
 
-def _setup_dispatch(tool_ctx, monkeypatch, recipe_name: str = "test-recipe"):
+def _setup_dispatch(
+    tool_ctx,
+    monkeypatch,
+    recipe_name: str = "test-recipe",
+    *,
+    requires_packs: list[str] | None = None,
+):
     """Wire tool_ctx for dispatch tests."""
     from autoskillit.fleet import FleetSemaphore
     from autoskillit.recipe.schema import Recipe, RecipeKind
@@ -56,7 +62,13 @@ def _setup_dispatch(tool_ctx, monkeypatch, recipe_name: str = "test-recipe"):
     repo.add_recipe(recipe_name, recipe_info)
     repo.add_full_recipe(
         recipe_info.path,
-        Recipe(name=recipe_name, description="test", kind=RecipeKind.STANDARD, ingredients={}),
+        Recipe(
+            name=recipe_name,
+            description="test",
+            kind=RecipeKind.STANDARD,
+            ingredients={},
+            requires_packs=requires_packs if requires_packs is not None else [],
+        ),
     )
     tool_ctx.recipes = repo
     tool_ctx.executor = InMemoryHeadlessExecutor()

--- a/tests/fleet/test_api.py
+++ b/tests/fleet/test_api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from pathlib import Path
 
 import pytest
@@ -13,6 +14,7 @@ from autoskillit.fleet import (
     _write_pid,
     write_initial_state,
 )
+from tests.fleet._helpers import _setup_dispatch
 
 pytestmark = [pytest.mark.layer("fleet"), pytest.mark.small, pytest.mark.feature("fleet")]
 
@@ -129,3 +131,57 @@ class TestExecuteDispatchCancelledErrorLockRelease:
 
         assert captured_kwargs, "_run_dispatch was never called"
         assert captured_kwargs[0].get("resume_session_id") == "abc-123"
+
+
+# ---------------------------------------------------------------------------
+# requires_packs forwarding helpers
+# ---------------------------------------------------------------------------
+
+
+async def _no_sleep_quota_checker(config, **kwargs) -> dict:
+    return {
+        "should_sleep": False,
+        "sleep_seconds": 0,
+        "utilization": None,
+        "resets_at": None,
+        "window_name": None,
+    }
+
+
+async def _noop_quota_refresher(config, **kwargs) -> None:
+    pass
+
+
+async def _run(tool_ctx, recipe="test-recipe", ingredients=None):
+    from autoskillit.fleet._api import execute_dispatch
+
+    raw = await execute_dispatch(
+        tool_ctx=tool_ctx,
+        recipe=recipe,
+        task="t",
+        ingredients=ingredients,
+        dispatch_name=None,
+        timeout_sec=None,
+        prompt_builder=lambda **kwargs: f"prompt-for-{kwargs.get('recipe', 'unknown')}",
+        quota_checker=_no_sleep_quota_checker,
+        quota_refresher=_noop_quota_refresher,
+    )
+    return json.loads(raw)
+
+
+class TestRequiresPacksForwarding:
+    @pytest.mark.anyio
+    async def test_run_dispatch_forwards_requires_packs_to_executor(self, tool_ctx, monkeypatch):
+        _setup_dispatch(tool_ctx, monkeypatch, requires_packs=["github", "ci"])
+        await _run(tool_ctx)
+        call = tool_ctx.executor.dispatch_calls[0]
+        assert list(call.requires_packs) == ["github", "ci"]
+
+    @pytest.mark.anyio
+    async def test_run_dispatch_defaults_kitchen_core_when_requires_packs_empty(
+        self, tool_ctx, monkeypatch
+    ):
+        _setup_dispatch(tool_ctx, monkeypatch)
+        await _run(tool_ctx)
+        call = tool_ctx.executor.dispatch_calls[0]
+        assert list(call.requires_packs) == ["kitchen-core"]


### PR DESCRIPTION
## Summary

`_run_dispatch` in `fleet/_api.py` loads the full recipe (which carries `requires_packs`) but never passes it to `executor.dispatch_food_truck()`. The executor defaults to `requires_packs=()`, so `AUTOSKILLIT_L2_TOOL_TAGS` is never set, and every food truck session gets the full kitchen tool surface regardless of what the recipe declares. The fix adds `requires_packs` to the `dispatch_food_truck()` call and defaults empty `requires_packs` to `["kitchen-core"]` for least-privilege dispatches.

Closes #1802

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260504-095411-628777/.autoskillit/temp/make-plan/fleet_dispatch_requires_packs_forwarding_plan_2026-05-04_095600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|----------|--------|------------|----------|-------|-------------|------|
| plan | 58 | 9.0k | 612.4k | 62.3k | 81 | 51.7k | 6m 32s |
| verify | 33 | 7.1k | 662.5k | 55.8k | 59 | 46.8k | 3m 46s |
| implement | 73 | 7.6k | 798.8k | 54.4k | 49 | 44.8k | 3m 1s |
| prepare_pr | 24 | 2.7k | 165.0k | 34.1k | 14 | 21.5k | 1m 19s |
| compose_pr | 22 | 1.4k | 122.1k | 28.9k | 10 | 15.8k | 40s |
| review_pr | 39 | 10.4k | 464.3k | 49.9k | 31 | 37.6k | 3m 37s |
| resolve_review | 32 | 7.6k | 571.3k | 48.3k | 31 | 36.6k | 2m 51s |
| **Total** | 281 | 45.7k | 3.4M | 62.3k | | 254.9k | 21m 47s |

## Token Efficiency

| Step | LoC Changed | peak_ctx/LoC | cache_write/LoC | output/LoC |
|------|-------------|--------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 73 | 745.3 | 613.8 | 104.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **73** | 853.1 | 3491.2 | 626.6 |