### PR TITLE
Fleet dispatch L3 session should auto-discover recipe ingredients without loading full recipe

### DIFF
--- a/src/autoskillit/cli/_prompts.py
+++ b/src/autoskillit/cli/_prompts.py
@@ -642,6 +642,19 @@ def _build_open_kitchen_prompt(mcp_prefix: str) -> str:
         "headless sessions with full tool access. Do NOT use native tools to "
         "investigate failures — route to on_failure and let the downstream skill "
         "handle diagnosis.\n\n"
+        "DISPATCH ROUTING:\n"
+        "If the user wants to dispatch a recipe through fleet (e.g., "
+        "'run this issue through implementation', 'dispatch implementation'):\n"
+        f"1. Call {mcp_prefix}open_kitchen(name='<recipe>', ingredients_only=True) "
+        "— opens the gate and returns ONLY the ingredient schema.\n"
+        "2. Display the ingredients table and collect required values from the user.\n"
+        f"3. Call {mcp_prefix}dispatch_food_truck(recipe='<recipe>', task='<task>', "
+        "ingredients={...}) with the collected values.\n"
+        "Do NOT call open_kitchen without ingredients_only=True when dispatching "
+        "— the full recipe content is unnecessary for dispatch and wastes context.\n"
+        "If the user wants to run a recipe interactively (pipeline execution), "
+        f"call {mcp_prefix}open_kitchen(name='<recipe>') without ingredients_only "
+        "to receive the full recipe content and orchestration rules.\n\n"
         "OPTIONAL STEP SEMANTICS:\n"
         "- optional: true means the step is SKIPPED when its skip_when_false ingredient\n"
         "  is false. When skip_when_false evaluates to true (or is absent), the step is\n"
@@ -698,7 +711,8 @@ TOOL SURFACE — these 10 tools are available in this session:
 ## RECIPE DISCOVERY FLOW
 
 1. Call {mcp_prefix}list_recipes to see available recipes.
-2. Call {mcp_prefix}load_recipe with a recipe name to inspect its ingredients schema.
+2. Call {mcp_prefix}load_recipe(name='<recipe>', ingredients_only=True) to inspect its \
+ingredients schema without loading the full recipe YAML.
 3. Call {mcp_prefix}fetch_github_issue (or {mcp_prefix}get_issue_title) to retrieve \
 issue context when the task involves a GitHub issue.
 4. Populate all required ingredient fields before dispatching.

--- a/src/autoskillit/recipe/rules/rules_tools.py
+++ b/src/autoskillit/recipe/rules/rules_tools.py
@@ -35,7 +35,7 @@ _TOOL_PARAMS: dict[str, frozenset[str]] = {
     # --- Recipe tools ---
     "validate_recipe": frozenset({"script_path"}),
     "migrate_recipe": frozenset({"name"}),
-    "load_recipe": frozenset({"name", "overrides"}),
+    "load_recipe": frozenset({"name", "overrides", "ingredients_only"}),
     "list_recipes": frozenset(),
     # --- Clone tools ---
     "clone_repo": frozenset(

--- a/src/autoskillit/server/tools/tools_kitchen.py
+++ b/src/autoskillit/server/tools/tools_kitchen.py
@@ -284,6 +284,7 @@ def _build_tool_category_listing(
 async def open_kitchen(
     name: str | None = None,
     overrides: dict[str, str] | None = None,
+    ingredients_only: bool = False,
     ctx: Context = CurrentContext(),
 ) -> str:
     """Open the AutoSkillit kitchen for service.
@@ -295,6 +296,11 @@ async def open_kitchen(
         name: Optional recipe name to load immediately after opening.
         overrides: Optional dict of ingredient name → value to override recipe defaults.
             Use to activate hidden features (e.g., ``{"sprint_mode": "true"}``).
+        ingredients_only: When True and name is provided, return only the ingredient
+            schema (ingredients_table, validity, suggestions) without the full recipe
+            content, orchestration rules, or sous-chef discipline. Use for dispatch
+            workflows where the caller needs ingredient discovery but not pipeline
+            execution context.
 
     Never raises.
     """
@@ -413,6 +419,24 @@ async def open_kitchen(
             result["kitchen"] = "open"
             result["version"] = __version__
 
+            if ingredients_only:
+                result.pop("content", None)
+                result.pop("orchestration_rules", None)
+                result.pop("stop_step_semantics", None)
+            else:
+                _sc_path = pkg_root() / "skills" / "sous-chef" / "SKILL.md"
+                try:
+                    if _sc_path.exists():
+                        _sc_content = _build_sous_chef_for_delivery(_sc_path.read_text())
+                        if _sc_content:
+                            result["sous_chef_discipline"] = _sc_content
+                except (OSError, UnicodeDecodeError):
+                    logger.warning(
+                        "open_kitchen_failure",
+                        stage="read_sous_chef_discipline",
+                        exc_info=True,
+                    )
+
             if "ingredients_table" not in result or not result["ingredients_table"]:
                 result["ingredients_table"] = None
 
@@ -423,21 +447,6 @@ async def open_kitchen(
                 return _kitchen_failure_envelope(exc, stage="hook_diagnostic")
             if warning:
                 result["hook_warning"] = warning.strip()
-
-            # Inject sous-chef discipline into the response so headless L2 sessions
-            # receive mandatory step-execution rules. Headless sessions receive no
-            # system prompt injection; this named-recipe path is their sole delivery
-            # channel. Graceful degradation: missing SKILL.md is non-fatal.
-            _sc_path = pkg_root() / "skills" / "sous-chef" / "SKILL.md"
-            try:
-                if _sc_path.exists():
-                    _sc_content = _build_sous_chef_for_delivery(_sc_path.read_text())
-                    if _sc_content:
-                        result["sous_chef_discipline"] = _sc_content
-            except (OSError, UnicodeDecodeError):
-                logger.warning(
-                    "open_kitchen_failure", stage="read_sous_chef_discipline", exc_info=True
-                )
 
             return json.dumps(result)
 

--- a/src/autoskillit/server/tools/tools_recipe.py
+++ b/src/autoskillit/server/tools/tools_recipe.py
@@ -65,7 +65,9 @@ async def list_recipes() -> str:
     meta={"anthropic/maxResultSizeChars": 100_000},
 )
 @track_response_size("load_recipe")
-async def load_recipe(name: str, overrides: dict[str, str] | None = None) -> str:
+async def load_recipe(
+    name: str, overrides: dict[str, str] | None = None, ingredients_only: bool = False
+) -> str:
     """Load a recipe by name and return its raw YAML content.
 
     The YAML follows the recipe schema (ingredients, steps with tool/action,
@@ -206,7 +208,12 @@ async def load_recipe(name: str, overrides: dict[str, str] | None = None) -> str
             temp_dir_relpath=temp_dir_display_str(tool_ctx.config.workspace.temp_dir),
         )
         recipe_info = tool_ctx.recipes.find(name, Path.cwd())
-        return json.dumps(await _apply_triage_gate(result, name, recipe_info=recipe_info))
+        result = await _apply_triage_gate(result, name, recipe_info=recipe_info)
+        if ingredients_only:
+            result.pop("content", None)
+            result.pop("orchestration_rules", None)
+            result.pop("stop_step_semantics", None)
+        return json.dumps(result)
     except Exception as exc:
         logger.error("load_recipe unhandled exception", exc_info=True)
         return json.dumps({"success": False, "error": f"{type(exc).__name__}: {exc}"})

--- a/tests/cli/test_cli_prompts.py
+++ b/tests/cli/test_cli_prompts.py
@@ -53,6 +53,15 @@ def test_orchestrator_prompt_delegates_ingredient_collection_to_open_kitchen():
     )
 
 
+def test_build_open_kitchen_prompt_includes_dispatch_routing():
+    """_build_open_kitchen_prompt must include dispatch routing instructions."""
+    from autoskillit.cli._prompts import _build_open_kitchen_prompt
+
+    prompt = _build_open_kitchen_prompt(DIRECT_PREFIX)
+    assert "ingredients_only" in prompt
+    assert "dispatch_food_truck" in prompt
+
+
 def test_orchestrator_prompt_documents_confirm_action():
     """The orchestrator system prompt must explain how to handle action:confirm steps."""
     from autoskillit.cli._prompts import _build_orchestrator_prompt

--- a/tests/cli/test_fleet_dispatch.py
+++ b/tests/cli/test_fleet_dispatch.py
@@ -268,3 +268,12 @@ def test_build_fleet_dispatch_prompt_no_sleep_toolsearch_preamble() -> None:
 
     prompt = _build_fleet_dispatch_prompt(DIRECT_PREFIX)
     assert "sleep 2" not in prompt
+
+
+def test_build_fleet_dispatch_prompt_uses_ingredients_only() -> None:
+    """_build_fleet_dispatch_prompt recipe discovery must mention ingredients_only."""
+    from autoskillit.cli._mcp_names import DIRECT_PREFIX
+    from autoskillit.cli._prompts import _build_fleet_dispatch_prompt
+
+    prompt = _build_fleet_dispatch_prompt(DIRECT_PREFIX)
+    assert "ingredients_only" in prompt

--- a/tests/infra/test_pretty_output_recipe.py
+++ b/tests/infra/test_pretty_output_recipe.py
@@ -729,3 +729,20 @@ def test_fmt_open_kitchen_ingredients_not_duplicated_when_table_present():
     recipe_section = result.split("--- INGREDIENTS TABLE")[0]
     assert "  task:" not in recipe_section
     assert "review_approach:" not in recipe_section
+
+
+def test_fmt_open_kitchen_ingredients_only_no_recipe_block():
+    """Formatter must not render RECIPE block when content is absent (ingredients_only)."""
+    from autoskillit.hooks.formatters.pretty_output_hook import _fmt_open_kitchen
+
+    data = {
+        "success": True,
+        "kitchen": "open",
+        "version": "0.9.372",
+        "valid": True,
+        "ingredients_table": "| Name | Description | Default |",
+        "suggestions": [],
+    }
+    output = _fmt_open_kitchen(data, pipeline=False)
+    assert "--- RECIPE ---" not in output
+    assert "INGREDIENTS TABLE" in output

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -130,7 +130,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/server/_lifespan.py", 56),
     # tools_kitchen.py — hook config dict
     ("src/autoskillit/server/tools/tools_kitchen.py", 117),
-    ("src/autoskillit/server/tools/tools_kitchen.py", 558),
+    ("src/autoskillit/server/tools/tools_kitchen.py", 567),
     # tools_status.py — mcp_data dict
     ("src/autoskillit/server/tools/tools_status.py", 486),
     # tools_github.py — bug report dict

--- a/tests/server/test_tools_kitchen_gate.py
+++ b/tests/server/test_tools_kitchen_gate.py
@@ -602,6 +602,7 @@ async def test_open_kitchen_ingredients_only_strips_content(tmp_path, monkeypatc
     """open_kitchen(name=X, ingredients_only=True) must omit content from result."""
     monkeypatch.chdir(tmp_path)
     mock_ctx = _make_mock_ctx()
+    mock_ctx.enable_components = AsyncMock()
     mock_ctx.recipes = MagicMock()
     mock_ctx.recipes.load_and_validate.return_value = {
         "content": "name: test\nsteps:\n  s1:\n    tool: run_skill\n",
@@ -631,7 +632,9 @@ async def test_open_kitchen_ingredients_only_strips_content(tmp_path, monkeypatc
                     ):
                         from autoskillit.server.tools.tools_kitchen import open_kitchen
 
-                        result_json = await open_kitchen(name="test", ingredients_only=True)
+                        result_json = await open_kitchen(
+                            name="test", ingredients_only=True, ctx=mock_ctx
+                        )
 
     result = json.loads(result_json)
     assert result["success"] is True
@@ -647,6 +650,7 @@ async def test_open_kitchen_ingredients_only_preserves_metadata(tmp_path, monkey
     """ingredients_only=True must preserve success, kitchen, version, valid, suggestions."""
     monkeypatch.chdir(tmp_path)
     mock_ctx = _make_mock_ctx()
+    mock_ctx.enable_components = AsyncMock()
     mock_ctx.recipes = MagicMock()
     mock_ctx.recipes.load_and_validate.return_value = {
         "content": "name: test\nsteps:\n  s1:\n    tool: run_skill\n",
@@ -672,7 +676,9 @@ async def test_open_kitchen_ingredients_only_preserves_metadata(tmp_path, monkey
                     ):
                         from autoskillit.server.tools.tools_kitchen import open_kitchen
 
-                        result_json = await open_kitchen(name="test", ingredients_only=True)
+                        result_json = await open_kitchen(
+                            name="test", ingredients_only=True, ctx=mock_ctx
+                        )
 
     result = json.loads(result_json)
     assert result["success"] is True
@@ -687,6 +693,7 @@ async def test_open_kitchen_ingredients_only_no_name_ignored(tmp_path, monkeypat
     """ingredients_only=True with name=None should behave like regular no-name open."""
     monkeypatch.chdir(tmp_path)
     mock_ctx = _make_mock_ctx()
+    mock_ctx.enable_components = AsyncMock()
 
     with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
         with patch("autoskillit.server.logger"):
@@ -696,7 +703,7 @@ async def test_open_kitchen_ingredients_only_no_name_ignored(tmp_path, monkeypat
                 with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
                     from autoskillit.server.tools.tools_kitchen import open_kitchen
 
-                    result_json = await open_kitchen(ingredients_only=True)
+                    result_json = await open_kitchen(ingredients_only=True, ctx=mock_ctx)
 
     result = json.loads(result_json)
     assert result["success"] is True

--- a/tests/server/test_tools_kitchen_gate.py
+++ b/tests/server/test_tools_kitchen_gate.py
@@ -708,3 +708,5 @@ async def test_open_kitchen_ingredients_only_no_name_ignored(tmp_path, monkeypat
     result = json.loads(result_json)
     assert result["success"] is True
     assert "content" in result
+    assert result["kitchen"] == "open"
+    assert "version" in result

--- a/tests/server/test_tools_kitchen_gate.py
+++ b/tests/server/test_tools_kitchen_gate.py
@@ -590,3 +590,114 @@ async def test_open_kitchen_generates_uuid_without_campaign_env(tmp_path, monkey
 
     kitchen_id = mock_ctx.kitchen_id
     assert len(kitchen_id) == 36 and kitchen_id.count("-") == 4
+
+
+# ---------------------------------------------------------------------------
+# Group K — ingredients_only parameter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_open_kitchen_ingredients_only_strips_content(tmp_path, monkeypatch):
+    """open_kitchen(name=X, ingredients_only=True) must omit content from result."""
+    monkeypatch.chdir(tmp_path)
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.recipes = MagicMock()
+    mock_ctx.recipes.load_and_validate.return_value = {
+        "content": "name: test\nsteps:\n  s1:\n    tool: run_skill\n",
+        "ingredients_table": (
+            "| Name | Description | Default |\n| task | What to do | (required) |"
+        ),
+        "suggestions": [],
+        "valid": True,
+        "orchestration_rules": "MANDATORY: execute every step",
+        "stop_step_semantics": "stop semantics text",
+        "content_hash": "abc123",
+        "composite_hash": "def456",
+        "recipe_version": "1.0",
+    }
+    mock_ctx.recipes.find.return_value = MagicMock()
+    mock_ctx.config.migration.suppressed = []
+
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        with patch("autoskillit.server.logger"):
+            with patch(
+                "autoskillit.server.tools.tools_kitchen._prime_quota_cache", new=AsyncMock()
+            ):
+                with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
+                    with patch(
+                        "autoskillit.server.tools.tools_kitchen._apply_triage_gate",
+                        new=AsyncMock(side_effect=lambda r, *a, **kw: r),
+                    ):
+                        from autoskillit.server.tools.tools_kitchen import open_kitchen
+
+                        result_json = await open_kitchen(name="test", ingredients_only=True)
+
+    result = json.loads(result_json)
+    assert result["success"] is True
+    assert result["ingredients_table"] is not None
+    assert "content" not in result
+    assert "orchestration_rules" not in result
+    assert "sous_chef_discipline" not in result
+    assert "stop_step_semantics" not in result
+
+
+@pytest.mark.anyio
+async def test_open_kitchen_ingredients_only_preserves_metadata(tmp_path, monkeypatch):
+    """ingredients_only=True must preserve success, kitchen, version, valid, suggestions."""
+    monkeypatch.chdir(tmp_path)
+    mock_ctx = _make_mock_ctx()
+    mock_ctx.recipes = MagicMock()
+    mock_ctx.recipes.load_and_validate.return_value = {
+        "content": "name: test\nsteps:\n  s1:\n    tool: run_skill\n",
+        "ingredients_table": "| Name | Description | Default |",
+        "suggestions": [],
+        "valid": True,
+        "content_hash": "abc123",
+        "composite_hash": "def456",
+        "recipe_version": "1.0",
+    }
+    mock_ctx.recipes.find.return_value = MagicMock()
+    mock_ctx.config.migration.suppressed = []
+
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        with patch("autoskillit.server.logger"):
+            with patch(
+                "autoskillit.server.tools.tools_kitchen._prime_quota_cache", new=AsyncMock()
+            ):
+                with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
+                    with patch(
+                        "autoskillit.server.tools.tools_kitchen._apply_triage_gate",
+                        new=AsyncMock(side_effect=lambda r, *a, **kw: r),
+                    ):
+                        from autoskillit.server.tools.tools_kitchen import open_kitchen
+
+                        result_json = await open_kitchen(name="test", ingredients_only=True)
+
+    result = json.loads(result_json)
+    assert result["success"] is True
+    assert result["kitchen"] == "open"
+    assert "version" in result
+    assert result["valid"] is True
+    assert result["suggestions"] == []
+
+
+@pytest.mark.anyio
+async def test_open_kitchen_ingredients_only_no_name_ignored(tmp_path, monkeypatch):
+    """ingredients_only=True with name=None should behave like regular no-name open."""
+    monkeypatch.chdir(tmp_path)
+    mock_ctx = _make_mock_ctx()
+
+    with patch("autoskillit.server._get_ctx", return_value=mock_ctx):
+        with patch("autoskillit.server.logger"):
+            with patch(
+                "autoskillit.server.tools.tools_kitchen._prime_quota_cache", new=AsyncMock()
+            ):
+                with patch("autoskillit.server.tools.tools_kitchen._write_hook_config"):
+                    from autoskillit.server.tools.tools_kitchen import open_kitchen
+
+                    result_json = await open_kitchen(ingredients_only=True)
+
+    result = json.loads(result_json)
+    assert result["success"] is True
+    assert "content" in result

--- a/tests/server/test_tools_load_recipe.py
+++ b/tests/server/test_tools_load_recipe.py
@@ -860,4 +860,6 @@ class TestLoadRecipeIngredientsOnly:
         )
         result = json.loads(await load_recipe(name="test", ingredients_only=True))
         assert "content" not in result
+        assert "orchestration_rules" not in result
+        assert "stop_step_semantics" not in result
         assert "suggestions" in result

--- a/tests/server/test_tools_load_recipe.py
+++ b/tests/server/test_tools_load_recipe.py
@@ -834,3 +834,30 @@ async def test_load_recipe_no_ctx_returns_error(monkeypatch):
     monkeypatch.setattr(_state_mod, "_ctx", None)
     result = json.loads(await load_recipe(name="anything"))
     assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# ingredients_only parameter
+# ---------------------------------------------------------------------------
+
+
+class TestLoadRecipeIngredientsOnly:
+    """load_recipe(ingredients_only=True) strips content, preserves metadata."""
+
+    @pytest.fixture(autouse=True)
+    def _ensure_ctx(self, tool_ctx):
+        """Ensure server context is initialized (gate open by default)."""
+
+    @pytest.mark.anyio
+    async def test_load_recipe_ingredients_only_strips_content(self, tmp_path, monkeypatch):
+        """load_recipe(name=X, ingredients_only=True) must omit content from result."""
+        monkeypatch.chdir(tmp_path)
+        recipes_dir = tmp_path / ".autoskillit" / "recipes"
+        recipes_dir.mkdir(parents=True)
+        (recipes_dir / "test.yaml").write_text(
+            "name: test\ndescription: Test recipe\nsteps:\n"
+            "  done:\n    action: stop\n    message: Done\n"
+        )
+        result = json.loads(await load_recipe(name="test", ingredients_only=True))
+        assert "content" not in result
+        assert "suggestions" in result


### PR DESCRIPTION
## Summary

When an interactive L3 session dispatches a food truck, it currently calls `open_kitchen(name=X)` which returns ~16K tokens of recipe YAML, orchestration rules, and sous-chef discipline text. The model only needs the ingredient schema (~500 tokens) to populate `dispatch_food_truck`. The full recipe is re-loaded internally by the dispatch engine anyway.

This plan adds an `ingredients_only` parameter to `open_kitchen` and `load_recipe` that strips the heavy content fields, returning only the ingredient table and metadata. The open-kitchen session prompt and fleet dispatch prompt are updated with dispatch-aware routing instructions that guide the model to use this lightweight path.

Closes #1803

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260504-095412-241276/.autoskillit/temp/make-plan/fleet_dispatch_l3_auto_discover_ingredients_plan_2026-05-04_095412.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|----------|--------|------------|----------|-------|-------------|------|
| plan | 3.6k | 21.2k | 1.4M | 103.9k | 112 | 90.8k | 12m 9s |
| verify | 59 | 13.3k | 1.7M | 80.9k | 87 | 55.2k | 5m 59s |
| implement | 91 | 14.6k | 3.1M | 112.4k | 95 | 99.4k | 6m 21s |
| prepare_pr | 23 | 3.5k | 137.1k | 36.2k | 15 | 25.1k | 1m 17s |
| compose_pr | 22 | 1.4k | 122.4k | 29.0k | 10 | 15.9k | 42s |
| review_pr | 39 | 29.1k | 613.8k | 73.9k | 34 | 63.8k | 7m 42s |
| resolve_review | 58 | 9.1k | 1.6M | 66.7k | 59 | 100.3k | 5m 31s |
| diagnose_ci | 26 | 2.1k | 223.4k | 37.4k | 14 | 25.1k | 58s |
| resolve_ci | 45 | 4.0k | 677.3k | 44.5k | 33 | 31.5k | 3m 8s |
| **Total** | 4.0k | 98.3k | 9.6M | 112.4k | | 507.3k | 43m 50s |

## Token Efficiency

| Step | LoC Changed | peak_ctx/LoC | cache_write/LoC | output/LoC |
|------|-------------|--------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 239 | 470.1 | 416.0 | 61.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 4 | 16686.5 | 25081.2 | 2270.8 |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 2 | 22229.5 | 15759.0 | 2020.0 |
| **Total** | **245** | 458.6 | 2070.4 | 401.2 |