### PR TITLE
Rectify: Token Efficiency Table Column Drift Immunity

### DIFF
--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -21,10 +21,16 @@ and are written out at the end via `write_telemetry_files`.
 ## TelemetryFormatter
 
 `pipeline/telemetry_fmt.py:TelemetryFormatter` is the single source of truth
-for the human-readable token and timing tables. Both
-`get_token_summary` and the `token_summary_appender.py` PostToolUse hook
-delegate to it so the format never drifts between the CLI and the PR body
-appender.
+for the human-readable token and timing tables. The MCP tool
+`get_token_summary` delegates to it directly. The `token_summary_hook.py`
+PostToolUse hook maintains stdlib-only parallel implementations of
+`_format_efficiency_table` and `_format_table` (cannot import from
+`autoskillit.*` — enforced by `tests/arch/test_ast_rules.py`). Output
+equivalence between the canonical formatter and the hook is enforced by
+`test_efficiency_table_equivalence` and `test_token_table_equivalence` in
+`tests/infra/test_token_summary_core.py`. The canonical formatter derives
+markdown headers from `_EFFICIENCY_COLUMNS` / `_TOKEN_COLUMNS` via
+label-mapping dicts rather than hardcoding header strings.
 
 ## Mid-run accessors
 

--- a/src/autoskillit/execution/linux_tracing.py
+++ b/src/autoskillit/execution/linux_tracing.py
@@ -126,8 +126,10 @@ async def resolve_trace_target(
             try:
                 name = child.name()
                 cmdline = child.cmdline()
+                if not cmdline:
+                    continue
                 basename_matches = name == expected_basename or (
-                    cmdline and Path(cmdline[0]).name == expected_basename
+                    Path(cmdline[0]).name == expected_basename
                 )
                 if not basename_matches:
                     continue

--- a/src/autoskillit/hooks/token_summary_hook.py
+++ b/src/autoskillit/hooks/token_summary_hook.py
@@ -318,29 +318,32 @@ def _format_efficiency_table(aggregated: dict[str, dict[str, Any]]) -> str:
     lines = [
         "## Token Efficiency",
         "",
-        "| Step | LoC Changed | peak_ctx/LoC | cache_write/LoC | output/LoC |",
-        "|------|-------------|--------------|-----------------|------------|",
+        "| Step | LoC Changed | peak_ctx/LoC | cache_read/LoC | cache_write/LoC | output/LoC |",
+        "|------|-------------|--------------|----------------|-----------------|------------|",
     ]
-    total_loc = total_peak = total_cw = total_out = 0
+    total_loc = total_peak = total_cr = total_cw = total_out = 0
     for entry in aggregated.values():
         loc = entry.get("loc_insertions", 0) + entry.get("loc_deletions", 0)
         peak = entry.get("peak_context", 0)
+        cr = entry.get("cache_read_input_tokens", 0)
         cw = entry.get("cache_creation_input_tokens", 0)
         out = entry.get("output_tokens", 0)
         lines.append(
             f"| {entry['step_name']} | {loc}"
-            f" | {_ratio(peak, loc)} | {_ratio(cw, loc)} | {_ratio(out, loc)} |"
+            f" | {_ratio(peak, loc)} | {_ratio(cr, loc)}"
+            f" | {_ratio(cw, loc)} | {_ratio(out, loc)} |"
         )
         total_loc += loc
         if peak > total_peak:
             total_peak = peak
+        total_cr += cr
         total_cw += cw
         total_out += out
 
     lines.append(
         f"| **Total** | **{total_loc}**"
-        f" | {_ratio(total_peak, total_loc)} | {_ratio(total_cw, total_loc)}"
-        f" | {_ratio(total_out, total_loc)} |"
+        f" | {_ratio(total_peak, total_loc)} | {_ratio(total_cr, total_loc)}"
+        f" | {_ratio(total_cw, total_loc)} | {_ratio(total_out, total_loc)} |"
     )
     return "\n".join(lines)
 

--- a/src/autoskillit/pipeline/telemetry_fmt.py
+++ b/src/autoskillit/pipeline/telemetry_fmt.py
@@ -31,9 +31,39 @@ _EFFICIENCY_COLUMNS = (
     TerminalColumn("STEP", max_width=40, align="<"),
     TerminalColumn("LOC_CHG", max_width=8, align=">"),
     TerminalColumn("PK/LOC", max_width=8, align=">"),
+    TerminalColumn("RD/LOC", max_width=8, align=">"),
     TerminalColumn("WR/LOC", max_width=8, align=">"),
     TerminalColumn("OUT/LOC", max_width=8, align=">"),
 )
+
+
+_EFFICIENCY_MD_LABELS: dict[str, str] = {
+    "STEP": "Step",
+    "LOC_CHG": "LoC Changed",
+    "PK/LOC": "peak_ctx/LoC",
+    "RD/LOC": "cache_read/LoC",
+    "WR/LOC": "cache_write/LoC",
+    "OUT/LOC": "output/LoC",
+}
+
+_eff_md_headers = [_EFFICIENCY_MD_LABELS[c.label] for c in _EFFICIENCY_COLUMNS]
+_EFFICIENCY_MD_HEADER = "| " + " | ".join(_eff_md_headers) + " |"
+_EFFICIENCY_MD_SEP = "|" + "|".join("-" * (len(h) + 2) for h in _eff_md_headers) + "|"
+
+_TOKEN_MD_LABELS: dict[str, str] = {
+    "STEP": "Step",
+    "UNCACHED": "uncached",
+    "OUTPUT": "output",
+    "CACHE_RD": "cache_read",
+    "PEAK_CTX": "peak_ctx",
+    "TURNS": "turns",
+    "CACHE_WR": "cache_write",
+    "TIME": "time",
+}
+
+_tok_md_headers = [_TOKEN_MD_LABELS[c.label] for c in _TOKEN_COLUMNS]
+_TOKEN_MD_HEADER = "| " + " | ".join(_tok_md_headers) + " |"
+_TOKEN_MD_SEP = "|" + "|".join("-" * (len(h) + 2) for h in _tok_md_headers) + "|"
 
 
 def _ratio(tokens: int, loc: int) -> str:
@@ -78,8 +108,8 @@ class TelemetryFormatter:
         lines = [
             "## Token Usage Summary",
             "",
-            "| Step | uncached | output | cache_read | peak_ctx | turns | cache_write | time |",
-            "|------|----------|--------|------------|----------|-------|-------------|------|",
+            _TOKEN_MD_HEADER,
+            _TOKEN_MD_SEP,
         ]
         for step in steps:
             name = step.get("step_name", "?")
@@ -228,27 +258,30 @@ class TelemetryFormatter:
         lines = [
             "## Token Efficiency",
             "",
-            "| Step | LoC Changed | peak_ctx/LoC | cache_write/LoC | output/LoC |",
-            "|------|-------------|--------------|-----------------|------------|",
+            _EFFICIENCY_MD_HEADER,
+            _EFFICIENCY_MD_SEP,
         ]
         for step in steps:
             loc = step.get("loc_insertions", 0) + step.get("loc_deletions", 0)
             peak_ctx = step.get("peak_context", 0)
+            cr = step.get("cache_read_input_tokens", 0)
             cw = step.get("cache_creation_input_tokens", 0)
             out = step.get("output_tokens", 0)
             lines.append(
                 f"| {step.get('step_name', '?')} | {loc}"
-                f" | {_ratio(peak_ctx, loc)} | {_ratio(cw, loc)} | {_ratio(out, loc)} |"
+                f" | {_ratio(peak_ctx, loc)} | {_ratio(cr, loc)}"
+                f" | {_ratio(cw, loc)} | {_ratio(out, loc)} |"
             )
 
         total_loc = total.get("loc_insertions", 0) + total.get("loc_deletions", 0)
         total_peak = total.get("peak_context", 0)
+        total_cr = total.get("cache_read_input_tokens", 0)
         total_cw = total.get("cache_creation_input_tokens", 0)
         total_out = total.get("output_tokens", 0)
         lines.append(
             f"| **Total** | **{total_loc}**"
-            f" | {_ratio(total_peak, total_loc)} | {_ratio(total_cw, total_loc)}"
-            f" | {_ratio(total_out, total_loc)} |"
+            f" | {_ratio(total_peak, total_loc)} | {_ratio(total_cr, total_loc)}"
+            f" | {_ratio(total_cw, total_loc)} | {_ratio(total_out, total_loc)} |"
         )
         return "\n".join(lines)
 
@@ -258,10 +291,11 @@ class TelemetryFormatter:
         if not any(s.get("loc_insertions", 0) + s.get("loc_deletions", 0) > 0 for s in steps):
             return ""
 
-        rows: list[tuple[str, str, str, str, str]] = []
+        rows: list[tuple[str, str, str, str, str, str]] = []
         for step in steps:
             loc = step.get("loc_insertions", 0) + step.get("loc_deletions", 0)
             peak_ctx = step.get("peak_context", 0)
+            cr = step.get("cache_read_input_tokens", 0)
             cw = step.get("cache_creation_input_tokens", 0)
             out = step.get("output_tokens", 0)
             rows.append(
@@ -269,6 +303,7 @@ class TelemetryFormatter:
                     step.get("step_name", "?"),
                     str(loc),
                     _ratio(peak_ctx, loc),
+                    _ratio(cr, loc),
                     _ratio(cw, loc),
                     _ratio(out, loc),
                 )
@@ -279,6 +314,7 @@ class TelemetryFormatter:
             "Total",
             str(total_loc),
             _ratio(total.get("peak_context", 0), total_loc),
+            _ratio(total.get("cache_read_input_tokens", 0), total_loc),
             _ratio(total.get("cache_creation_input_tokens", 0), total_loc),
             _ratio(total.get("output_tokens", 0), total_loc),
         )

--- a/tests/hooks/test_token_summary_appender.py
+++ b/tests/hooks/test_token_summary_appender.py
@@ -1025,6 +1025,13 @@ def test_efficiency_table_appended_when_loc_present(tmp_path: Path) -> None:
     body_arg = edit_calls[0][edit_calls[0].index("--raw-field") + 1]
     body_content = body_arg[len("body=") :]
     assert "## Token Efficiency" in body_content
+    assert "cache_read/LoC" in body_content
+    assert "peak_ctx/LoC" in body_content
+    assert "cache_write/LoC" in body_content
+    assert "output/LoC" in body_content
+    eff_section = body_content[body_content.index("## Token Efficiency") :]
+    eff_header = eff_section.split("\n")[2]
+    assert eff_header.count("|") == 7  # 6 columns + outer pipes
 
 
 # T-HOOK-EFF-2

--- a/tests/infra/test_token_summary_core.py
+++ b/tests/infra/test_token_summary_core.py
@@ -487,3 +487,97 @@ def test_token_summary_hook_unexpected_error_exits_zero(monkeypatch: object) -> 
         _, exit_code = _run_hook(event={"tool_name": "any", "tool_response": "{}"})
 
     assert exit_code == 0
+
+
+def test_efficiency_table_equivalence() -> None:
+    """Canonical format_efficiency_table and hook _format_efficiency_table produce identical output."""
+    from autoskillit.hooks.token_summary_hook import _format_efficiency_table
+    from autoskillit.pipeline.telemetry_fmt import TelemetryFormatter
+
+    steps_data = [
+        {
+            "step_name": "investigate",
+            "peak_context": 500,
+            "cache_read_input_tokens": 8000,
+            "cache_creation_input_tokens": 2000,
+            "output_tokens": 1000,
+            "loc_insertions": 30,
+            "loc_deletions": 10,
+        },
+        {
+            "step_name": "implement",
+            "peak_context": 12000,
+            "cache_read_input_tokens": 50000,
+            "cache_creation_input_tokens": 15000,
+            "output_tokens": 8000,
+            "loc_insertions": 200,
+            "loc_deletions": 50,
+        },
+    ]
+
+    canonical_total = {
+        "loc_insertions": sum(s["loc_insertions"] for s in steps_data),
+        "loc_deletions": sum(s["loc_deletions"] for s in steps_data),
+        "peak_context": max(s["peak_context"] for s in steps_data),
+        "cache_read_input_tokens": sum(s["cache_read_input_tokens"] for s in steps_data),
+        "cache_creation_input_tokens": sum(s["cache_creation_input_tokens"] for s in steps_data),
+        "output_tokens": sum(s["output_tokens"] for s in steps_data),
+    }
+    aggregated = {s["step_name"]: dict(s) for s in steps_data}
+
+    canonical_output = TelemetryFormatter.format_efficiency_table(
+        list(steps_data), canonical_total
+    )
+    hook_output = _format_efficiency_table(aggregated)
+
+    assert canonical_output == hook_output, (
+        f"Canonical and hook efficiency tables differ:\n"
+        f"CANONICAL:\n{canonical_output}\n\nHOOK:\n{hook_output}"
+    )
+
+
+def test_token_table_equivalence() -> None:
+    """Canonical format_token_table and hook _format_table produce identical output."""
+    from autoskillit.hooks.token_summary_hook import _format_table
+    from autoskillit.pipeline.telemetry_fmt import TelemetryFormatter
+
+    steps_data = [
+        {
+            "step_name": "investigate",
+            "input_tokens": 7000,
+            "output_tokens": 5939,
+            "cache_creation_input_tokens": 8495,
+            "cache_read_input_tokens": 252179,
+            "peak_context": 45000,
+            "turn_count": 8,
+            "elapsed_seconds": 45.0,
+        },
+        {
+            "step_name": "implement",
+            "input_tokens": 2031000,
+            "output_tokens": 122306,
+            "cache_creation_input_tokens": 280601,
+            "cache_read_input_tokens": 19071323,
+            "peak_context": 890000,
+            "turn_count": 42,
+            "elapsed_seconds": 492.0,
+        },
+    ]
+
+    canonical_total = {
+        "input_tokens": sum(s["input_tokens"] for s in steps_data),
+        "output_tokens": sum(s["output_tokens"] for s in steps_data),
+        "cache_creation_input_tokens": sum(s["cache_creation_input_tokens"] for s in steps_data),
+        "cache_read_input_tokens": sum(s["cache_read_input_tokens"] for s in steps_data),
+        "peak_context": max(s["peak_context"] for s in steps_data),
+        "total_elapsed_seconds": sum(s["elapsed_seconds"] for s in steps_data),
+    }
+    aggregated = {s["step_name"]: dict(s) for s in steps_data}
+
+    canonical_output = TelemetryFormatter.format_token_table(list(steps_data), canonical_total)
+    hook_output = _format_table(aggregated)
+
+    assert canonical_output == hook_output, (
+        f"Canonical and hook token tables differ:\n"
+        f"CANONICAL:\n{canonical_output}\n\nHOOK:\n{hook_output}"
+    )

--- a/tests/pipeline/test_telemetry_formatter.py
+++ b/tests/pipeline/test_telemetry_formatter.py
@@ -516,3 +516,93 @@ def test_efficiency_table_terminal_no_markdown() -> None:
     assert "|" not in result  # no markdown pipes
     assert "LOC" in result  # column header present
     assert "PK/LOC" in result
+
+
+# T-EFF-7
+def test_efficiency_table_has_all_ratio_columns() -> None:
+    """Markdown efficiency table must contain all four ratio columns and have 6-column header."""
+    steps = [
+        {
+            "step_name": "implement",
+            "peak_context": 500,
+            "cache_read_input_tokens": 1000,
+            "cache_creation_input_tokens": 200,
+            "output_tokens": 50,
+            "loc_insertions": 80,
+            "loc_deletions": 20,
+        }
+    ]
+    total = {
+        "loc_insertions": 80,
+        "loc_deletions": 20,
+        "peak_context": 500,
+        "cache_read_input_tokens": 1000,
+        "cache_creation_input_tokens": 200,
+        "output_tokens": 50,
+    }
+    result = TelemetryFormatter.format_efficiency_table(steps, total)
+    assert "cache_read/LoC" in result
+    assert "peak_ctx/LoC" in result
+    assert "cache_write/LoC" in result
+    assert "output/LoC" in result
+    header_line = result.split("\n")[2]
+    assert header_line.count("|") == 7  # 6 columns + outer pipes
+
+
+# T-EFF-8
+def test_efficiency_table_terminal_has_all_columns() -> None:
+    """Terminal efficiency table must show RD/LOC alongside PK/LOC, WR/LOC, OUT/LOC."""
+    steps = [
+        {
+            "step_name": "implement",
+            "peak_context": 1000,
+            "cache_read_input_tokens": 500,
+            "cache_creation_input_tokens": 200,
+            "output_tokens": 50,
+            "loc_insertions": 80,
+            "loc_deletions": 20,
+        }
+    ]
+    total = {
+        "loc_insertions": 80,
+        "loc_deletions": 20,
+        "peak_context": 1000,
+        "cache_read_input_tokens": 500,
+        "cache_creation_input_tokens": 200,
+        "output_tokens": 50,
+    }
+    result = TelemetryFormatter.format_efficiency_table_terminal(steps, total)
+    assert "PK/LOC" in result
+    assert "RD/LOC" in result
+    assert "WR/LOC" in result
+    assert "OUT/LOC" in result
+
+
+# T-EFF-9
+def test_efficiency_markdown_terminal_column_parity() -> None:
+    """Markdown and terminal efficiency tables must have the same number of data columns."""
+    from autoskillit.pipeline.telemetry_fmt import _EFFICIENCY_COLUMNS
+
+    steps = [
+        {
+            "step_name": "implement",
+            "peak_context": 1000,
+            "cache_read_input_tokens": 500,
+            "cache_creation_input_tokens": 200,
+            "output_tokens": 50,
+            "loc_insertions": 80,
+            "loc_deletions": 20,
+        }
+    ]
+    total = {
+        "loc_insertions": 80,
+        "loc_deletions": 20,
+        "peak_context": 1000,
+        "cache_read_input_tokens": 500,
+        "cache_creation_input_tokens": 200,
+        "output_tokens": 50,
+    }
+    result = TelemetryFormatter.format_efficiency_table(steps, total)
+    md_header = result.split("\n")[2]
+    md_cols = [c.strip() for c in md_header.strip("|").split("|")]
+    assert len(md_cols) == len(_EFFICIENCY_COLUMNS)

--- a/tests/pipeline/test_telemetry_formatter.py
+++ b/tests/pipeline/test_telemetry_formatter.py
@@ -376,6 +376,7 @@ def test_efficiency_table_columns() -> None:
     steps = [
         {
             "step_name": "implement",
+            "peak_context": 500,
             "cache_read_input_tokens": 1000,
             "cache_creation_input_tokens": 200,
             "output_tokens": 50,
@@ -386,6 +387,7 @@ def test_efficiency_table_columns() -> None:
     total = {
         "loc_insertions": 80,
         "loc_deletions": 20,
+        "peak_context": 500,
         "cache_read_input_tokens": 1000,
         "cache_creation_input_tokens": 200,
         "output_tokens": 50,
@@ -394,8 +396,10 @@ def test_efficiency_table_columns() -> None:
     assert "## Token Efficiency" in result
     assert "LoC Changed" in result
     assert "peak_ctx/LoC" in result
+    assert "cache_read/LoC" in result
     assert "cache_write/LoC" in result
     assert "output/LoC" in result
+    assert result.split("\n")[2].count("|") == 7  # 6 columns + outer pipes
 
 
 # T-EFF-3
@@ -516,6 +520,9 @@ def test_efficiency_table_terminal_no_markdown() -> None:
     assert "|" not in result  # no markdown pipes
     assert "LOC" in result  # column header present
     assert "PK/LOC" in result
+    assert "RD/LOC" in result
+    assert "WR/LOC" in result
+    assert "OUT/LOC" in result
 
 
 # T-EFF-7


### PR DESCRIPTION
## Summary

PR #1809 silently replaced the `cache_read/LoC` column with `peak_ctx/LoC` in the Token Efficiency table across all four rendering paths. Tests didn't catch it because they assert individual column presence (`"peak_ctx/LoC" in result`) rather than complete column sets, and no equivalence test exists between the canonical formatter (`telemetry_fmt.py`) and its stdlib-only hook duplicate (`token_summary_hook.py`). The architectural weakness is twofold: (1) the markdown rendering path hardcodes header strings instead of deriving them from `_EFFICIENCY_COLUMNS`, creating an internal drift surface within the canonical formatter, and (2) the hook's parallel implementation has no mechanical equivalence guard, unlike the compact-KV formatter which has test 1g.

Closes #1825

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260504-095242-094454/.autoskillit/temp/rectify/rectify_token_efficiency_table_column_drift_2026-05-04_100500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|----------|--------|------------|----------|-------|-------------|------|
| investigate | 27 | 6.1k | 334.4k | 70.8k | 72 | 41.3k | 5m 19s |
| rectify | 51 | 12.3k | 716.0k | 79.6k | 86 | 56.0k | 7m 16s |
| dry_walkthrough | 1.8k | 18.7k | 2.3M | 83.5k | 130 | 71.0k | 9m 46s |
| implement | 586 | 23.7k | 2.5M | 103.1k | 97 | 91.8k | 9m 24s |
| prepare_pr | 24 | 4.2k | 176.8k | 37.7k | 15 | 27.3k | 1m 38s |
| compose_pr | 22 | 1.4k | 122.5k | 29.0k | 10 | 15.9k | 32s |
| review_pr | 48 | 24.5k | 577.3k | 78.7k | 30 | 66.5k | 6m 44s |
| diagnose_ci | 25 | 2.3k | 203.3k | 41.5k | 13 | 29.4k | 1m 2s |
| resolve_ci | 46 | 7.4k | 863.8k | 59.1k | 40 | 89.0k | 8m 59s |
| **Total** | 2.7k | 100.5k | 7.8M | 103.1k | | 488.1k | 50m 43s |

## Token Efficiency

| Step | LoC Changed | peak_ctx/LoC | cache_write/LoC | output/LoC |
|------|-------------|--------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 279 | 369.7 | 328.9 | 84.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 4 | 14781.0 | 22258.5 | 1854.8 |
| **Total** | **283** | 364.5 | 1724.8 | 355.1 |