### PR TITLE
[P2-A2-WP1] Implement _resolve_provider_profile in server/_guards.py

### DIFF
--- a/src/autoskillit/server/_guards.py
+++ b/src/autoskillit/server/_guards.py
@@ -188,7 +188,7 @@ def _resolve_provider_profile(
 
     # Tier 3: step YAML provider field
     if step_name:
-        logger.debug("provider_profile_resolved", tier="step", profile=step_name)
+        logger.debug("provider_profile_resolved", tier="step_provider_field", profile=step_name)
         if step_name == "anthropic":
             return ("anthropic", {})
         return (step_name, config_providers.profiles.get(step_name, {}))

--- a/src/autoskillit/server/_guards.py
+++ b/src/autoskillit/server/_guards.py
@@ -4,9 +4,15 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from autoskillit.core import SessionType, extract_path_arg, session_type
+from autoskillit.core import SessionType, extract_path_arg, get_logger, session_type
 from autoskillit.pipeline import gate_error_result, headless_error_result
+
+if TYPE_CHECKING:
+    from autoskillit.config._config_dataclasses import ProvidersConfig
+
+logger = get_logger(__name__)
 
 
 def _get_ctx():  # type: ignore[return]
@@ -146,3 +152,50 @@ def _check_dry_walkthrough(skill_command: str, cwd: str) -> str | None:
         )
 
     return None
+
+
+def _resolve_provider_profile(
+    step_name: str,
+    recipe_name: str,
+    config_providers: ProvidersConfig,
+) -> tuple[str, dict[str, str]]:
+
+    # Tier 1: per-step config override (requires recipe context)
+    if recipe_name and step_name:
+        step_override = config_providers.step_overrides.get(step_name)
+        if step_override:
+            logger.debug(
+                "provider_profile_resolved",
+                tier="step_override",
+                profile=step_override,
+            )
+            if step_override == "anthropic":
+                return ("anthropic", {})
+            return (step_override, config_providers.profiles.get(step_override, {}))
+
+    # Tier 2: wildcard override (requires recipe context)
+    if recipe_name:
+        wildcard = config_providers.step_overrides.get("*")
+        if wildcard:
+            logger.debug(
+                "provider_profile_resolved",
+                tier="recipe_wildcard",
+                profile=wildcard,
+            )
+            if wildcard == "anthropic":
+                return ("anthropic", {})
+            return (wildcard, config_providers.profiles.get(wildcard, {}))
+
+    # Tier 3: step YAML provider field
+    if step_name:
+        logger.debug("provider_profile_resolved", tier="step", profile=step_name)
+        if step_name == "anthropic":
+            return ("anthropic", {})
+        return (step_name, config_providers.profiles.get(step_name, {}))
+
+    # Tier 4: default
+    name = config_providers.default_provider or "anthropic"
+    logger.debug("provider_profile_resolved", tier="default", profile=name)
+    if name == "anthropic":
+        return ("anthropic", {})
+    return (name, config_providers.profiles.get(name, {}))

--- a/tests/infra/test_token_summary_core.py
+++ b/tests/infra/test_token_summary_core.py
@@ -490,7 +490,7 @@ def test_token_summary_hook_unexpected_error_exits_zero(monkeypatch: object) -> 
 
 
 def test_efficiency_table_equivalence() -> None:
-    """Canonical format_efficiency_table and hook _format_efficiency_table produce identical output."""
+    """format_efficiency_table and hook _format_efficiency_table produce identical output."""
     from autoskillit.hooks.token_summary_hook import _format_efficiency_table
     from autoskillit.pipeline.telemetry_fmt import TelemetryFormatter
 

--- a/tests/server/CLAUDE.md
+++ b/tests/server/CLAUDE.md
@@ -28,6 +28,7 @@ Server tool handler unit tests — kitchen, execution, CI, clone, workspace tool
 | `test_quota_refresh_loop.py` | Tests for _quota_refresh_loop in server/_misc.py |
 | `test_release_issue_fail_label.py` | Tests for release_issue fail_label path and fail label cleanup |
 | `test_reload_session.py` | Tests for the reload_session MCP tool and supporting helpers |
+| `test_resolve_provider_profile.py` | Tests for _resolve_provider_profile four-tier provider resolution in _guards.py |
 | `test_run_skill_add_dirs.py` | Contract tests: run_skill passes correct add_dirs to executor (T-OVR-014) |
 | `test_server_init_gate.py` | Tests for server init: gate access, visibility, subset management, wire format compliance |
 | `test_server_init_session_visibility.py` | Tests for server init: session type visibility, fleet gate boot, feature gate visibility |

--- a/tests/server/test_resolve_provider_profile.py
+++ b/tests/server/test_resolve_provider_profile.py
@@ -89,12 +89,14 @@ def test_non_anthropic_profile_returns_correct_env_dict():
     assert result == ("bedrock", {"AWS_ACCESS_KEY_ID": "test"})
 
 
-def test_empty_recipe_name_skips_overrides():
+def test_no_recipe_name_skips_step_override():
+    # Without recipe context, Tier 1 is bypassed; Tier 3 uses step_name as the
+    # provider name. If the override had applied we'd get ("vertex", {"K": "V"}).
     from autoskillit.server._guards import _resolve_provider_profile
 
     cfg = _make_config(
-        step_overrides={"my_step": "vertex"},
-        profiles={"vertex": {"K": "V"}},
+        step_overrides={"bedrock": "vertex"},
+        profiles={"vertex": {"K": "V"}, "bedrock": {"X": "Y"}},
     )
-    result = _resolve_provider_profile("my_step", "", cfg)
-    assert result == ("my_step", {})
+    result = _resolve_provider_profile("bedrock", "", cfg)
+    assert result == ("bedrock", {"X": "Y"})

--- a/tests/server/test_resolve_provider_profile.py
+++ b/tests/server/test_resolve_provider_profile.py
@@ -1,0 +1,100 @@
+"""Tests for _resolve_provider_profile four-tier provider resolution."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+
+def _make_config(**kwargs):
+    from autoskillit.config._config_dataclasses import ProvidersConfig
+
+    return ProvidersConfig(**kwargs)
+
+
+def test_step_override_wins():
+    from autoskillit.server._guards import _resolve_provider_profile
+
+    cfg = _make_config(
+        step_overrides={"my_step": "bedrock"},
+        profiles={"bedrock": {"AWS_REGION": "us-east-1"}},
+    )
+    result = _resolve_provider_profile("my_step", "my_recipe", cfg)
+    assert result == ("bedrock", {"AWS_REGION": "us-east-1"})
+
+
+def test_recipe_wildcard_wins_when_no_step_override():
+    from autoskillit.server._guards import _resolve_provider_profile
+
+    cfg = _make_config(
+        step_overrides={"*": "vertex"},
+        profiles={"vertex": {"GOOGLE_CLOUD_PROJECT": "proj"}},
+    )
+    result = _resolve_provider_profile("other_step", "my_recipe", cfg)
+    assert result == ("vertex", {"GOOGLE_CLOUD_PROJECT": "proj"})
+
+
+def test_step_yaml_provider_wins_when_no_config_overrides():
+    from autoskillit.server._guards import _resolve_provider_profile
+
+    cfg = _make_config(
+        profiles={"bedrock": {"AWS_REGION": "eu-west-1"}},
+    )
+    result = _resolve_provider_profile("bedrock", "my_recipe", cfg)
+    assert result == ("bedrock", {"AWS_REGION": "eu-west-1"})
+
+
+def test_default_anthropic_when_all_tiers_absent():
+    from autoskillit.server._guards import _resolve_provider_profile
+
+    cfg = _make_config()
+    result = _resolve_provider_profile("", "", cfg)
+    assert result == ("anthropic", {})
+
+
+def test_step_override_beats_wildcard_when_both_match():
+    from autoskillit.server._guards import _resolve_provider_profile
+
+    cfg = _make_config(
+        step_overrides={"my_step": "bedrock", "*": "vertex"},
+        profiles={
+            "bedrock": {"AWS_REGION": "us-east-1"},
+            "vertex": {"GOOGLE_CLOUD_PROJECT": "proj"},
+        },
+    )
+    result = _resolve_provider_profile("my_step", "my_recipe", cfg)
+    assert result == ("bedrock", {"AWS_REGION": "us-east-1"})
+
+
+def test_anthropic_profile_returns_empty_env_regardless():
+    from autoskillit.server._guards import _resolve_provider_profile
+
+    cfg = _make_config(
+        default_provider="anthropic",
+        profiles={"anthropic": {"SHOULD_IGNORE": "this"}},
+    )
+    result = _resolve_provider_profile("", "", cfg)
+    assert result == ("anthropic", {})
+
+
+def test_non_anthropic_profile_returns_correct_env_dict():
+    from autoskillit.server._guards import _resolve_provider_profile
+
+    cfg = _make_config(
+        step_overrides={"my_step": "bedrock"},
+        profiles={"bedrock": {"AWS_ACCESS_KEY_ID": "test"}},
+    )
+    result = _resolve_provider_profile("my_step", "my_recipe", cfg)
+    assert result == ("bedrock", {"AWS_ACCESS_KEY_ID": "test"})
+
+
+def test_empty_recipe_name_skips_overrides():
+    from autoskillit.server._guards import _resolve_provider_profile
+
+    cfg = _make_config(
+        step_overrides={"my_step": "vertex"},
+        profiles={"vertex": {"K": "V"}},
+    )
+    result = _resolve_provider_profile("my_step", "", cfg)
+    assert result == ("my_step", {})


### PR DESCRIPTION
## Summary

Add a `_resolve_provider_profile` function to `src/autoskillit/server/_guards.py` that implements a four-tier provider resolution priority chain and returns the resolved profile name with its environment variable dict. The function follows the same structlog debug-logging pattern as `_resolve_model` in `execution/headless/__init__.py`. A new test file `tests/server/test_resolve_provider_profile.py` provides ~8 pure unit tests covering all four tiers and edge cases.

Closes #1752

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-1752-20260504-100545-391589/.autoskillit/temp/make-plan/p2_a2_wp1_resolve_provider_profile_plan_2026-05-04_101500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|----------|--------|------------|----------|-------|-------------|------|
| plan | 62 | 17.8k | 772.0k | 65.2k | 56 | 52.2k | 8m 29s |
| verify | 33 | 6.9k | 638.7k | 52.4k | 77 | 39.3k | 3m 59s |
| implement | 150 | 7.6k | 723.2k | 52.3k | 41 | 43.1k | 2m 28s |
| prepare_pr | 52 | 4.5k | 171.4k | 37.2k | 18 | 26.6k | 1m 22s |
| compose_pr | 51 | 1.9k | 150.5k | 29.2k | 14 | 16.3k | 51s |
| review_pr | 132 | 14.7k | 649.1k | 53.7k | 43 | 41.5k | 3m 44s |
| resolve_review | 213 | 16.1k | 1.2M | 69.7k | 69 | 77.5k | 6m 19s |
| ci_conflict_fix | 226 | 8.1k | 965.9k | 47.8k | 66 | 60.7k | 2m 52s |
| diagnose_ci | 60 | 1.6k | 200.9k | 40.9k | 14 | 28.3k | 37s |
| resolve_ci | 110 | 4.1k | 488.7k | 45.7k | 35 | 34.3k | 3m 42s |
| **Total** | 1.1k | 83.1k | 6.0M | 69.7k | | 419.7k | 34m 27s |

## Token Efficiency

| Step | LoC Changed | peak_ctx/LoC | cache_write/LoC | output/LoC |
|------|-------------|--------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 155 | 337.1 | 278.2 | 49.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 14 | 4979.6 | 5532.9 | 1147.1 |
| ci_conflict_fix | 454 | 105.2 | 133.6 | 17.8 |
| diagnose_ci | 2 | 20427.5 | 14151.0 | 788.0 |
| resolve_ci | 3 | 15235.7 | 11441.3 | 1364.3 |
| **Total** | **628** | 111.0 | 668.4 | 132.3 |