### PR TITLE
[P2-A1-WP1] Add Provider-Routing Vars to _HEADLESS_EXCLUSIVE_VARS

### DIFF
--- a/src/autoskillit/core/types/_type_constants.py
+++ b/src/autoskillit/core/types/_type_constants.py
@@ -102,6 +102,8 @@ AUTOSKILLIT_PRIVATE_ENV_VARS: frozenset[str] = frozenset(
         "AUTOSKILLIT_L2_TOOL_TAGS",
         "AUTOSKILLIT_LAUNCH_ID",
         "AUTOSKILLIT_SKILL_NAME",
+        # Provider-routing vars — must not leak into user-code subprocesses
+        "AUTOSKILLIT_PROVIDER_PROFILE",
     }
 )
 

--- a/src/autoskillit/execution/commands.py
+++ b/src/autoskillit/execution/commands.py
@@ -151,15 +151,20 @@ _SESSION_BASELINE_ENV: Mapping[str, str] = MappingProxyType(
 # parameters (exit_after_stop_delay_ms, scenario_step_name, allowed_write_prefix, etc.).
 # Note: CLAUDE_CODE_EXIT_AFTER_STOP_DELAY, SCENARIO_STEP_NAME, and
 # MAX_MCP_OUTPUT_TOKENS also overlap with IDE_ENV_DENYLIST in
-# core/_claude_env.py. AUTOSKILLIT_SESSION_TYPE and AUTOSKILLIT_CAMPAIGN_ID
-# overlap with AUTOSKILLIT_PRIVATE_ENV_VARS (scrubbed by build_claude_env).
+# core/_claude_env.py. AUTOSKILLIT_SESSION_TYPE, AUTOSKILLIT_CAMPAIGN_ID, and
+# AUTOSKILLIT_PROVIDER_PROFILE overlap with AUTOSKILLIT_PRIVATE_ENV_VARS
+# (scrubbed by build_claude_env).
 # All lists must be kept in sync when adding new exclusive variables.
 _HEADLESS_EXCLUSIVE_VARS: frozenset[str] = frozenset(
     {
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "ANTHROPIC_BASE_URL",
         "AUTOSKILLIT_ALLOWED_WRITE_PREFIX",
         "AUTOSKILLIT_CAMPAIGN_ID",
         "AUTOSKILLIT_KITCHEN_SESSION_ID",
         "AUTOSKILLIT_LAUNCH_ID",
+        "AUTOSKILLIT_PROVIDER_PROFILE",
         "AUTOSKILLIT_SESSION_TYPE",
         "AUTOSKILLIT_SKILL_NAME",
         "CLAUDE_CODE_EXIT_AFTER_STOP_DELAY",

--- a/tests/core/test_type_constants.py
+++ b/tests/core/test_type_constants.py
@@ -266,3 +266,10 @@ def test_skill_tools_matches_expected() -> None:
     from autoskillit.core import SKILL_TOOLS
 
     assert SKILL_TOOLS == frozenset({"run_skill"})
+
+
+def test_provider_profile_in_private_env_vars() -> None:
+    """AUTOSKILLIT_PROVIDER_PROFILE must be in AUTOSKILLIT_PRIVATE_ENV_VARS."""
+    from autoskillit.core import AUTOSKILLIT_PRIVATE_ENV_VARS
+
+    assert "AUTOSKILLIT_PROVIDER_PROFILE" in AUTOSKILLIT_PRIVATE_ENV_VARS

--- a/tests/execution/test_commands.py
+++ b/tests/execution/test_commands.py
@@ -859,3 +859,23 @@ class TestBuildLeafAllowedWritePrefix:
         monkeypatch.setenv("AUTOSKILLIT_ALLOWED_WRITE_PREFIX", "old")
         spec = build_leaf_headless_cmd("/investigate foo", **self.BASE, allowed_write_prefix="new")
         assert spec.env["AUTOSKILLIT_ALLOWED_WRITE_PREFIX"] == "new"
+
+
+def test_provider_profile_in_headless_exclusive_vars() -> None:
+    """AUTOSKILLIT_PROVIDER_PROFILE must be headless-exclusive."""
+    assert "AUTOSKILLIT_PROVIDER_PROFILE" in _HEADLESS_EXCLUSIVE_VARS
+
+
+def test_anthropic_base_url_in_headless_exclusive_vars() -> None:
+    """ANTHROPIC_BASE_URL must be headless-exclusive."""
+    assert "ANTHROPIC_BASE_URL" in _HEADLESS_EXCLUSIVE_VARS
+
+
+def test_anthropic_api_key_in_headless_exclusive_vars() -> None:
+    """ANTHROPIC_API_KEY must be headless-exclusive."""
+    assert "ANTHROPIC_API_KEY" in _HEADLESS_EXCLUSIVE_VARS
+
+
+def test_anthropic_auth_token_in_headless_exclusive_vars() -> None:
+    """ANTHROPIC_AUTH_TOKEN must be headless-exclusive."""
+    assert "ANTHROPIC_AUTH_TOKEN" in _HEADLESS_EXCLUSIVE_VARS


### PR DESCRIPTION
## Summary

Add four provider-routing environment variables (`ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL`, `AUTOSKILLIT_PROVIDER_PROFILE`) to the `_HEADLESS_EXCLUSIVE_VARS` frozenset in `commands.py` so they cannot leak from the host process into headless child sessions. Also add `AUTOSKILLIT_PROVIDER_PROFILE` to `AUTOSKILLIT_PRIVATE_ENV_VARS` in `_type_constants.py` so it is scrubbed from user-code subprocesses by `build_claude_env`. Update the sync-reminder comment to name the new overlap variable. Add five new test functions across two test files.

Closes #1751

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-1751-20260504-100544-479714/.autoskillit/temp/make-plan/p2_a1_wp1_add_provider_routing_vars_plan_2026-05-04_101300.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|----------|--------|------------|----------|-------|-------------|------|
| plan | 61 | 6.6k | 605.7k | 48.1k | 43 | 35.1k | 4m 35s |
| verify | 37 | 7.5k | 399.1k | 58.5k | 95 | 39.7k | 7m 6s |
| implement | 156 | 6.2k | 659.5k | 42.4k | 45 | 29.6k | 1m 45s |
| prepare_pr | 60 | 4.0k | 197.7k | 36.2k | 17 | 23.9k | 1m 19s |
| compose_pr | 59 | 2.5k | 181.0k | 29.9k | 15 | 17.0k | 59s |
| review_pr | 124 | 17.6k | 564.1k | 52.7k | 39 | 42.7k | 4m 51s |
| **Total** | 497 | 44.4k | 2.6M | 58.5k | | 188.0k | 20m 36s |

## Token Efficiency

| Step | LoC Changed | peak_ctx/LoC | cache_write/LoC | output/LoC |
|------|-------------|--------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 38 | 1116.1 | 779.2 | 163.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **38** | 1540.4 | 4947.6 | 1168.2 |