### PR TITLE
Implementation Plan: [P2-A5-WP1] Add provider_bypass early-exit to quota_guard.py

### DIFF
--- a/src/autoskillit/hooks/guards/quota_guard.py
+++ b/src/autoskillit/hooks/guards/quota_guard.py
@@ -111,6 +111,19 @@ def main(*, cache_path_override: str | None = None) -> None:
     log_dir = _resolve_quota_log_dir()
     ts = datetime.now(UTC).isoformat()
 
+    profile = os.environ.get("AUTOSKILLIT_PROVIDER_PROFILE", "").strip()
+    if profile and profile.casefold() != "anthropic":
+        _write_quota_log_event(
+            {
+                "ts": ts,
+                "event": "provider_bypass",
+                "profile": profile,
+                "cache_path": cache_path_str,
+            },
+            log_dir,
+        )
+        sys.exit(0)
+
     cache = _read_quota_cache(cache_path_str, cache_max_age)
     if cache is None:
         _write_quota_log_event(

--- a/src/autoskillit/hooks/quota_post_hook.py
+++ b/src/autoskillit/hooks/quota_post_hook.py
@@ -122,6 +122,20 @@ def main(*, cache_path_override: str | None = None) -> None:
     log_dir = _resolve_quota_log_dir()
     ts = datetime.now(UTC).isoformat()
 
+    profile = os.environ.get("AUTOSKILLIT_PROVIDER_PROFILE", "").strip()
+    if profile and profile.casefold() != "anthropic":
+        _write_quota_log_event(
+            {
+                "ts": ts,
+                "event": "post_provider_bypass",
+                "profile": profile,
+                "tool_name": tool_name,
+                "cache_path": cache_path_str,
+            },
+            log_dir,
+        )
+        sys.exit(0)
+
     cache = _read_quota_cache(cache_path_str, cache_max_age)
     if cache is None:
         sys.exit(0)


### PR DESCRIPTION
## Summary

Insert an early-exit block in both `quota_guard.py` and `quota_post_hook.py` that reads `AUTOSKILLIT_PROVIDER_PROFILE` from `os.environ` and skips quota enforcement when the active provider is not `'anthropic'`. Each bypass logs a dedicated event (`provider_bypass` / `post_provider_bypass`) before exiting cleanly with `sys.exit(0)`. No new imports are needed — `os` is already imported in both files.

Closes #1756

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-1756-20260504-113550-358329/.autoskillit/temp/make-plan/p2_a5_wp1_provider_bypass_early_exit_plan_2026-05-04_114300.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1.3k | 7.6k | 753.1k | 56.4k | 64 | 45.8k | 4m 46s |
| verify | 27 | 3.9k | 319.6k | 45.8k | 47 | 32.8k | 2m 39s |
| implement | 108 | 4.4k | 440.6k | 42.3k | 33 | 29.6k | 1m 37s |
| prepare_pr | 60 | 4.1k | 194.8k | 35.6k | 17 | 23.1k | 1m 7s |
| compose_pr | 59 | 2.0k | 168.7k | 29.4k | 15 | 27.9k | 35s |
| review_pr | 84 | 8.8k | 357.0k | 45.2k | 30 | 33.1k | 2m 7s |
| **Total** | 1.7k | 30.7k | 2.2M | 56.4k | | 192.4k | 12m 53s |

## Token Efficiency

| Step | LoC Changed | peak_ctx/LoC | cache_write/LoC | output/LoC |
|------|-------------|--------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 27 | 1567.7 | 1095.1 | 163.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **27** | 2089.7 | 7124.7 | 1136.3 |