### PR TITLE
Implementation Plan: [P2-A3-WP1] Add provider_extras and profile_name Parameters to build_leaf_headless_cmd()

### DIFF
--- a/src/autoskillit/execution/commands.py
+++ b/src/autoskillit/execution/commands.py
@@ -286,6 +286,8 @@ def build_leaf_headless_cmd(
     scenario_step_name: str = "",
     temp_dir_relpath: str | None = None,
     allowed_write_prefix: str = "",
+    provider_extras: Mapping[str, str] | None = None,
+    profile_name: str = "",
 ) -> ClaudeHeadlessCmd:
     """Build the complete headless command spec for a leaf session.
 
@@ -320,6 +322,17 @@ def build_leaf_headless_cmd(
         When > 0, carried as ``CLAUDE_CODE_EXIT_AFTER_STOP_DELAY=<ms>`` in ``.env``.
     scenario_step_name
         When non-empty, carried as ``SCENARIO_STEP_NAME=<name>`` in ``.env`` for recording.
+    temp_dir_relpath
+        Relative path to the temp directory injected into the CWD anchor directive.
+        Falls back to the canonical default when None.
+    allowed_write_prefix
+        When non-empty, carried as ``AUTOSKILLIT_ALLOWED_WRITE_PREFIX`` in ``.env``.
+    provider_extras
+        Provider-profile env vars merged into the session environment after
+        session-identity keys are set.  ``AUTOSKILLIT_SESSION_TYPE`` and
+        ``AUTOSKILLIT_HEADLESS`` keys are silently ignored.
+    profile_name
+        When non-empty, carried as ``AUTOSKILLIT_PROVIDER_PROFILE`` in ``.env``.
     """
     prompt = _inject_narration_suppression(
         _inject_cwd_anchor(
@@ -347,6 +360,12 @@ def build_leaf_headless_cmd(
     if allowed_write_prefix:
         extras["AUTOSKILLIT_ALLOWED_WRITE_PREFIX"] = allowed_write_prefix
     extras["AUTOSKILLIT_SKILL_NAME"] = extract_skill_name(skill_command) or ""
+    if provider_extras:
+        for k, v in provider_extras.items():
+            if k not in ("AUTOSKILLIT_SESSION_TYPE", "AUTOSKILLIT_HEADLESS"):
+                extras[k] = v
+    if profile_name:
+        extras["AUTOSKILLIT_PROVIDER_PROFILE"] = profile_name
 
     filtered_base = {k: v for k, v in os.environ.items() if k not in _HEADLESS_EXCLUSIVE_VARS}
     spec = build_headless_cmd(prompt, model=model, env_extras=extras, base=filtered_base)

--- a/tests/execution/test_commands.py
+++ b/tests/execution/test_commands.py
@@ -448,6 +448,56 @@ class TestBuildLeafHeadlessCmd:
         assert "AUTOSKILLIT_PROJECT_DIR" not in spec.env
         assert "AUTOSKILLIT_L2_TOOL_TAGS" not in spec.env
 
+    def test_provider_extras_injected_into_env(self) -> None:
+        spec = build_leaf_headless_cmd(
+            "/investigate foo",
+            **self.BASE,
+            provider_extras={
+                "ANTHROPIC_BASE_URL": "https://custom.example.com",
+                "ANTHROPIC_API_KEY": "sk-test",
+            },
+        )
+        assert spec.env["ANTHROPIC_BASE_URL"] == "https://custom.example.com"
+        assert spec.env["ANTHROPIC_API_KEY"] == "sk-test"
+
+    def test_provider_extras_cannot_override_session_type(self) -> None:
+        spec = build_leaf_headless_cmd(
+            "/investigate foo",
+            **self.BASE,
+            provider_extras={"AUTOSKILLIT_SESSION_TYPE": "franchise"},
+        )
+        assert spec.env["AUTOSKILLIT_SESSION_TYPE"] == "leaf"
+
+    def test_provider_extras_cannot_override_headless(self) -> None:
+        spec = build_leaf_headless_cmd(
+            "/investigate foo",
+            **self.BASE,
+            provider_extras={"AUTOSKILLIT_HEADLESS": "0"},
+        )
+        assert spec.env["AUTOSKILLIT_HEADLESS"] == "1"
+
+    def test_host_anthropic_base_url_stripped_when_in_exclusive_vars(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Depends on P2-A1 (#1751) having added ANTHROPIC_BASE_URL to
+        # _HEADLESS_EXCLUSIVE_VARS.
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://host.example.com")
+        spec = build_leaf_headless_cmd("/investigate foo", **self.BASE)
+        assert "ANTHROPIC_BASE_URL" not in spec.env
+
+    def test_provider_extras_none_changes_nothing(self) -> None:
+        baseline = build_leaf_headless_cmd("/investigate foo", **self.BASE)
+        spec = build_leaf_headless_cmd("/investigate foo", **self.BASE, provider_extras=None)
+        assert spec.env == baseline.env
+
+    def test_profile_name_injects_provider_profile_env_var(self) -> None:
+        spec = build_leaf_headless_cmd("/investigate foo", **self.BASE, profile_name="minimax")
+        assert spec.env["AUTOSKILLIT_PROVIDER_PROFILE"] == "minimax"
+
+    def test_empty_profile_name_omits_provider_profile(self) -> None:
+        spec = build_leaf_headless_cmd("/investigate foo", **self.BASE, profile_name="")
+        assert "AUTOSKILLIT_PROVIDER_PROFILE" not in spec.env
+
 
 class TestBuildFoodTruckCmd:
     BASE = dict(


### PR DESCRIPTION
## Summary

Extend `build_leaf_headless_cmd()` with two new keyword-only parameters — `provider_extras: Mapping[str, str] | None = None` and `profile_name: str = ""` — that inject caller-supplied provider env vars and the `AUTOSKILLIT_PROVIDER_PROFILE` signal into the leaf session environment. The merge uses the same guard pattern already established in `build_food_truck_cmd()` (lines 458–461 of `commands.py`): iterate caller-supplied keys and silently skip `AUTOSKILLIT_SESSION_TYPE` and `AUTOSKILLIT_HEADLESS` to preserve mandatory session-identity values. Seven new tests are appended to `TestBuildLeafHeadlessCmd`.

Closes #1753

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-1753-20260504-113550-279177/.autoskillit/temp/make-plan/p2_a3_wp1_add_provider_extras_and_profile_name_plan_2026-05-04_114500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|----------|--------|------------|----------|-------|-------------|------|
| plan | 48 | 6.6k | 497.0k | 50.5k | 23 | 41.5k | 3m 51s |
| verify | 30 | 5.0k | 488.8k | 53.0k | 69 | 41.4k | 4m 11s |
| implement | 118 | 5.5k | 610.4k | 61.0k | 32 | 48.5k | 1m 38s |
| prepare_pr | 60 | 4.3k | 203.5k | 37.4k | 18 | 25.3k | 1m 20s |
| compose_pr | 51 | 2.1k | 151.5k | 29.6k | 14 | 16.7k | 38s |
| review_pr | 84 | 10.4k | 358.0k | 46.6k | 31 | 35.3k | 2m 20s |
| **Total** | 391 | 34.0k | 2.3M | 61.0k | | 208.7k | 14m 0s |

## Token Efficiency

| Step | LoC Changed | peak_ctx/LoC | cache_write/LoC | output/LoC |
|------|-------------|--------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 69 | 884.0 | 703.4 | 80.4 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **69** | 884.0 | 3024.9 | 492.9 |