### PR TITLE
Implementation Plan: [P2-A5-WP3] Add Tests for Provider Bypass Behavior in Both Hooks

### DIFF
--- a/tests/hooks/test_quota_check.py
+++ b/tests/hooks/test_quota_check.py
@@ -639,3 +639,42 @@ def test_hook_still_blocks_without_disabled_flag(tmp_path, monkeypatch):
     out, _ = _run_hook(event={"tool_name": "run_skill"})
     data = json.loads(out)
     assert data["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_provider_bypass_skips_quota_check(tmp_path, monkeypatch):
+    """Non-anthropic AUTOSKILLIT_PROVIDER_PROFILE bypasses quota check entirely."""
+    monkeypatch.setenv("AUTOSKILLIT_PROVIDER_PROFILE", "minimax")
+    cache = tmp_path / "quota_cache.json"
+    _write_cache(cache, utilization=99.0, should_block=True)
+    out, exit_code = _run_hook(event={"tool_name": "run_skill"}, cache_path=cache)
+    assert out.strip() == ""
+    assert exit_code == 0
+
+
+def test_provider_bypass_logs_event(tmp_path, monkeypatch):
+    """Provider bypass writes a 'provider_bypass' event to quota_events.jsonl."""
+    monkeypatch.setenv("AUTOSKILLIT_PROVIDER_PROFILE", "minimax")
+    log_dir = tmp_path / "logs"
+    monkeypatch.setenv("AUTOSKILLIT_LOG_DIR", str(log_dir))
+    cache = tmp_path / "quota_cache.json"
+    _write_cache(cache, utilization=99.0, should_block=True)
+    _run_hook(event={"tool_name": "run_skill"}, cache_path=cache)
+    events = [
+        json.loads(line) for line in (log_dir / "quota_events.jsonl").read_text().splitlines()
+    ]
+    assert len(events) == 1
+    ev = events[0]
+    assert ev["event"] == "provider_bypass"
+    assert ev["profile"] == "minimax"
+    assert "ts" in ev
+    assert "cache_path" in ev
+
+
+def test_anthropic_profile_does_not_bypass(tmp_path, monkeypatch):
+    """AUTOSKILLIT_PROVIDER_PROFILE=anthropic still enforces quota check."""
+    monkeypatch.setenv("AUTOSKILLIT_PROVIDER_PROFILE", "anthropic")
+    cache = tmp_path / "quota_cache.json"
+    _write_cache(cache, utilization=99.0, should_block=True)
+    out, _ = _run_hook(event={"tool_name": "run_skill"}, cache_path=cache)
+    data = json.loads(out)
+    assert data["hookSpecificOutput"]["permissionDecision"] == "deny"

--- a/tests/hooks/test_quota_post_check.py
+++ b/tests/hooks/test_quota_post_check.py
@@ -451,3 +451,46 @@ def test_write_quota_log_event_prints_to_stderr_on_write_failure(
 
     captured = capsys.readouterr()
     assert "quota_post_hook" in captured.err
+
+
+def test_post_provider_bypass_skips_warning(tmp_path, monkeypatch):
+    """Non-anthropic AUTOSKILLIT_PROVIDER_PROFILE bypasses post-check warning."""
+    monkeypatch.setenv("AUTOSKILLIT_PROVIDER_PROFILE", "minimax")
+    cache = tmp_path / "quota_cache.json"
+    _write_cache(cache, utilization=99.0, should_block=True)
+    event = _build_event()
+    out, exit_code = _run_hook(event=event, cache_path=cache)
+    assert out.strip() == ""
+    assert exit_code == 0
+
+
+def test_post_provider_bypass_logs_event(tmp_path, monkeypatch):
+    """Provider bypass writes a 'post_provider_bypass' event to quota_events.jsonl."""
+    monkeypatch.setenv("AUTOSKILLIT_PROVIDER_PROFILE", "minimax")
+    log_dir = tmp_path / "logs"
+    monkeypatch.setenv("AUTOSKILLIT_LOG_DIR", str(log_dir))
+    cache = tmp_path / "quota_cache.json"
+    _write_cache(cache, utilization=99.0, should_block=True)
+    event = _build_event()
+    _run_hook(event=event, cache_path=cache)
+    events = [
+        json.loads(line) for line in (log_dir / "quota_events.jsonl").read_text().splitlines()
+    ]
+    assert len(events) == 1
+    ev = events[0]
+    assert ev["event"] == "post_provider_bypass"
+    assert ev["profile"] == "minimax"
+    assert "ts" in ev
+    assert "tool_name" in ev
+    assert "cache_path" in ev
+
+
+def test_post_anthropic_profile_does_not_bypass(tmp_path, monkeypatch):
+    """AUTOSKILLIT_PROVIDER_PROFILE=anthropic still enforces post-check warning."""
+    monkeypatch.setenv("AUTOSKILLIT_PROVIDER_PROFILE", "anthropic")
+    cache = tmp_path / "quota_cache.json"
+    _write_cache(cache, utilization=99.0, should_block=True)
+    event = _build_event()
+    out, _ = _run_hook(event=event, cache_path=cache)
+    data = json.loads(out)
+    assert "QUOTA WARNING" in data["hookSpecificOutput"]["updatedMCPToolOutput"]


### PR DESCRIPTION
## Summary

Add 6 test functions across two existing test files to verify that the `AUTOSKILLIT_PROVIDER_PROFILE` environment variable correctly triggers provider bypass in both the PreToolUse (`quota_guard.py`) and PostToolUse (`quota_post_hook.py`) hooks. Tests cover three behaviors per hook: silent bypass for non-anthropic profiles, event logging during bypass, and no-bypass for the `anthropic` profile.

Closes #1772

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-1772-20260504-121609-044413/.autoskillit/temp/make-plan/P2-A5-WP3_add_tests_provider_bypass_hooks_plan_2026-05-04_121900.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|----------|--------|------------|----------|-------|-------------|------|
| plan | 58 | 7.7k | 625.5k | 65.4k | 50 | 56.5k | 3m 42s |
| verify | 33 | 6.6k | 639.6k | 53.9k | 49 | 41.0k | 3m 18s |
| implement | 140 | 6.6k | 620.2k | 46.0k | 41 | 36.7k | 1m 45s |
| prepare_pr | 60 | 4.2k | 189.3k | 36.6k | 18 | 36.1k | 1m 18s |
| compose_pr | 59 | 2.0k | 180.4k | 29.4k | 15 | 16.5k | 42s |
| review_pr | 92 | 10.0k | 406.9k | 47.1k | 31 | 34.5k | 2m 56s |
| **Total** | 442 | 37.3k | 2.7M | 65.4k | | 221.3k | 13m 42s |

## Token Efficiency

| Step | LoC Changed | peak_ctx/LoC | cache_write/LoC | output/LoC |
|------|-------------|--------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 82 | 560.5 | 447.9 | 81.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **82** | 797.0 | 2698.6 | 454.7 |