### PR TITLE
[P2-A4-WP1] Extend HeadlessExecutor Protocol and DefaultHeadlessExecutor.run() with provider_extras and profile_name Parameters

### DIFF
--- a/src/autoskillit/core/types/_type_protocols_execution.py
+++ b/src/autoskillit/core/types/_type_protocols_execution.py
@@ -53,6 +53,8 @@ class HeadlessExecutor(Protocol):
         allowed_write_prefix: str = "",
         readonly_skill: bool = False,
         write_watch_dirs: Sequence[Path] = (),
+        provider_extras: Mapping[str, str] | None = None,
+        profile_name: str = "",
     ) -> SkillResult: ...
 
     async def dispatch_food_truck(

--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -555,6 +555,8 @@ async def run_headless_core(
     allowed_write_prefix: str = "",
     readonly_skill: bool = False,
     write_watch_dirs: Sequence[Path] = (),
+    provider_extras: Mapping[str, str] | None = None,
+    profile_name: str = "",
 ) -> SkillResult:
     """Shared headless runner used by run_skill.
 
@@ -585,6 +587,8 @@ async def run_headless_core(
             scenario_step_name=step_name,
             temp_dir_relpath=temp_dir_display_str(ctx.config.workspace.temp_dir),
             allowed_write_prefix=allowed_write_prefix,
+            provider_extras=provider_extras,
+            profile_name=profile_name,
         )
 
         effective_timeout = timeout if timeout is not None else cfg.timeout
@@ -655,6 +659,8 @@ class DefaultHeadlessExecutor:
         allowed_write_prefix: str = "",
         readonly_skill: bool = False,
         write_watch_dirs: Sequence[Path] = (),
+        provider_extras: Mapping[str, str] | None = None,
+        profile_name: str = "",
     ) -> SkillResult:
         cfg = self._ctx.config.run_skill
         effective_timeout = timeout if timeout is not None else cfg.timeout
@@ -681,6 +687,8 @@ class DefaultHeadlessExecutor:
             allowed_write_prefix=allowed_write_prefix,
             readonly_skill=readonly_skill,
             write_watch_dirs=write_watch_dirs,
+            provider_extras=provider_extras,
+            profile_name=profile_name,
         )
 
     async def dispatch_food_truck(

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -375,6 +375,24 @@ async def run_skill(
         if tool_ctx.executor is None:
             return json.dumps({"success": False, "error": "Executor not configured"})
 
+        provider_extras: dict[str, str] | None = None
+        profile_name_out: str = ""
+
+        from autoskillit.core import is_feature_enabled
+
+        _cfg = _get_config()
+        if is_feature_enabled(
+            "providers", _cfg.features, experimental_enabled=_cfg.experimental_enabled
+        ):
+            from autoskillit.server._guards import _resolve_provider_profile
+
+            _profile, _env_dict = _resolve_provider_profile(
+                step_name or "", tool_ctx.recipe_name or "", _cfg.providers
+            )
+            if _profile != "anthropic":
+                provider_extras = _env_dict
+                profile_name_out = _profile
+
         # Look up artifact validation patterns from skill contract
         expected_output_patterns: list[str] = []
         if tool_ctx.output_pattern_resolver:
@@ -501,6 +519,8 @@ async def run_skill(
                 allowed_write_prefix=allowed_write_prefix,
                 readonly_skill=is_read_only,
                 write_watch_dirs=write_watch_dirs,
+                provider_extras=provider_extras,
+                profile_name=profile_name_out,
             )
             if skill_result.success:
                 tool_ctx.audit.record_success(skill_command)

--- a/tests/execution/CLAUDE.md
+++ b/tests/execution/CLAUDE.md
@@ -28,6 +28,7 @@ Subprocess integration, headless session, process lifecycle, and session result 
 | `test_headless_env_scrub.py` | Launch-site env-scrub contract test for run_headless_core |
 | `test_headless_ordering.py` | AST-based structural test for post-session operation ordering in headless.py |
 | `test_headless_path_validation.py` | Tests for headless.py: _build_skill_result, path validation, synthesis, and contract gates |
+| `test_headless_provider_forwarding.py` | Tests verifying provider_extras and profile_name forwarding through the headless call chain |
 | `test_headless_synthesis.py` | Tests for headless.py synthesis helpers: output path extraction, validation, contamination |
 | `test_idle_output_env.py` | Group G (execution part): AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT env variable injection tests |
 | `test_linux_tracing.py` | Tests for Linux-only process tracing via psutil and /proc filesystem |

--- a/tests/execution/test_headless_provider_forwarding.py
+++ b/tests/execution/test_headless_provider_forwarding.py
@@ -79,6 +79,7 @@ async def test_run_headless_core_defaults_provider_extras_none(
 async def test_default_executor_run_forwards_provider_extras(
     minimal_ctx, tmp_path, monkeypatch
 ) -> None:
+    import autoskillit.execution.headless as _headless_mod
     from autoskillit.execution.headless import DefaultHeadlessExecutor
 
     captured: dict = {}
@@ -87,7 +88,7 @@ async def test_default_executor_run_forwards_provider_extras(
         captured.update(kwargs)
         return _STUB_RESULT
 
-    monkeypatch.setattr("autoskillit.execution.headless.run_headless_core", fake_core)
+    monkeypatch.setattr(_headless_mod, "run_headless_core", fake_core)
 
     executor = DefaultHeadlessExecutor(minimal_ctx)
     await executor.run(
@@ -105,6 +106,7 @@ async def test_default_executor_run_forwards_provider_extras(
 async def test_default_executor_run_defaults_provider_extras(
     minimal_ctx, tmp_path, monkeypatch
 ) -> None:
+    import autoskillit.execution.headless as _headless_mod
     from autoskillit.execution.headless import DefaultHeadlessExecutor
 
     captured: dict = {}
@@ -113,7 +115,7 @@ async def test_default_executor_run_defaults_provider_extras(
         captured.update(kwargs)
         return _STUB_RESULT
 
-    monkeypatch.setattr("autoskillit.execution.headless.run_headless_core", fake_core)
+    monkeypatch.setattr(_headless_mod, "run_headless_core", fake_core)
 
     executor = DefaultHeadlessExecutor(minimal_ctx)
     await executor.run("/autoskillit:probe", str(tmp_path))

--- a/tests/execution/test_headless_provider_forwarding.py
+++ b/tests/execution/test_headless_provider_forwarding.py
@@ -1,0 +1,122 @@
+"""Tests verifying provider_extras and profile_name forwarding through the headless call chain."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.core.types import RetryReason, SkillResult
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+_STUB_RESULT = SkillResult(
+    success=True,
+    result="done",
+    session_id="s1",
+    subtype="success",
+    is_error=False,
+    exit_code=0,
+    needs_retry=False,
+    retry_reason=RetryReason.NONE,
+    stderr="",
+)
+
+
+@pytest.mark.anyio
+async def test_run_headless_core_forwards_provider_extras_to_build_cmd(
+    minimal_ctx, tmp_path, monkeypatch
+) -> None:
+    from autoskillit.execution.headless import run_headless_core
+
+    captured: dict = {}
+
+    def fake_build(skill_command, **kwargs):
+        captured.update(kwargs)
+        return object()
+
+    async def fake_execute(spec, cwd, ctx, **kwargs):
+        return _STUB_RESULT
+
+    monkeypatch.setattr("autoskillit.execution.headless.build_leaf_headless_cmd", fake_build)
+    monkeypatch.setattr("autoskillit.execution.headless._execute_claude_headless", fake_execute)
+
+    await run_headless_core(
+        "/autoskillit:probe",
+        str(tmp_path),
+        minimal_ctx,
+        provider_extras={"AWS_REGION": "us-east-1"},
+        profile_name="bedrock",
+    )
+
+    assert captured["provider_extras"] == {"AWS_REGION": "us-east-1"}
+    assert captured["profile_name"] == "bedrock"
+
+
+@pytest.mark.anyio
+async def test_run_headless_core_defaults_provider_extras_none(
+    minimal_ctx, tmp_path, monkeypatch
+) -> None:
+    from autoskillit.execution.headless import run_headless_core
+
+    captured: dict = {}
+
+    def fake_build(skill_command, **kwargs):
+        captured.update(kwargs)
+        return object()
+
+    async def fake_execute(spec, cwd, ctx, **kwargs):
+        return _STUB_RESULT
+
+    monkeypatch.setattr("autoskillit.execution.headless.build_leaf_headless_cmd", fake_build)
+    monkeypatch.setattr("autoskillit.execution.headless._execute_claude_headless", fake_execute)
+
+    await run_headless_core("/autoskillit:probe", str(tmp_path), minimal_ctx)
+
+    assert captured["provider_extras"] is None
+    assert captured["profile_name"] == ""
+
+
+@pytest.mark.anyio
+async def test_default_executor_run_forwards_provider_extras(
+    minimal_ctx, tmp_path, monkeypatch
+) -> None:
+    from autoskillit.execution.headless import DefaultHeadlessExecutor
+
+    captured: dict = {}
+
+    async def fake_core(skill_command, cwd, ctx, **kwargs):
+        captured.update(kwargs)
+        return _STUB_RESULT
+
+    monkeypatch.setattr("autoskillit.execution.headless.run_headless_core", fake_core)
+
+    executor = DefaultHeadlessExecutor(minimal_ctx)
+    await executor.run(
+        "/autoskillit:probe",
+        str(tmp_path),
+        provider_extras={"KEY": "val"},
+        profile_name="vertex",
+    )
+
+    assert captured["provider_extras"] == {"KEY": "val"}
+    assert captured["profile_name"] == "vertex"
+
+
+@pytest.mark.anyio
+async def test_default_executor_run_defaults_provider_extras(
+    minimal_ctx, tmp_path, monkeypatch
+) -> None:
+    from autoskillit.execution.headless import DefaultHeadlessExecutor
+
+    captured: dict = {}
+
+    async def fake_core(skill_command, cwd, ctx, **kwargs):
+        captured.update(kwargs)
+        return _STUB_RESULT
+
+    monkeypatch.setattr("autoskillit.execution.headless.run_headless_core", fake_core)
+
+    executor = DefaultHeadlessExecutor(minimal_ctx)
+    await executor.run("/autoskillit:probe", str(tmp_path))
+
+    assert captured["provider_extras"] is None
+    assert captured["profile_name"] == ""

--- a/tests/execution/test_headless_provider_forwarding.py
+++ b/tests/execution/test_headless_provider_forwarding.py
@@ -28,12 +28,14 @@ async def test_run_headless_core_forwards_provider_extras_to_build_cmd(
     from autoskillit.execution.headless import run_headless_core
 
     captured: dict = {}
+    execute_kwargs: dict = {}
 
     def fake_build(skill_command, **kwargs):
         captured.update(kwargs)
         return object()
 
     async def fake_execute(spec, cwd, ctx, **kwargs):
+        execute_kwargs.update(kwargs)
         return _STUB_RESULT
 
     monkeypatch.setattr("autoskillit.execution.headless.build_leaf_headless_cmd", fake_build)
@@ -49,6 +51,8 @@ async def test_run_headless_core_forwards_provider_extras_to_build_cmd(
 
     assert captured["provider_extras"] == {"AWS_REGION": "us-east-1"}
     assert captured["profile_name"] == "bedrock"
+    assert "provider_extras" not in execute_kwargs
+    assert "profile_name" not in execute_kwargs
 
 
 @pytest.mark.anyio

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -160,6 +160,8 @@ class InMemoryHeadlessExecutor(HeadlessExecutor):
         allowed_write_prefix: str = "",
         readonly_skill: bool = False,
         write_watch_dirs: Sequence[Any] = (),
+        provider_extras: Mapping[str, str] | None = None,
+        profile_name: str = "",
     ) -> SkillResult:
         self.calls.append(
             ExecutorCall(

--- a/tests/server/CLAUDE.md
+++ b/tests/server/CLAUDE.md
@@ -49,6 +49,7 @@ Server tool handler unit tests — kitchen, execution, CI, clone, workspace tool
 | `test_tools_dispatch.py` | Tests for dispatch_food_truck tool handler and execute_dispatch domain function |
 | `test_tools_execution_command.py` | Tests for run_skill command building, timeouts, env, model, and per-invocation markers |
 | `test_tools_execution_input_gates.py` | Tests for run_skill input validation gates and CWD checking |
+| `test_tools_execution_provider.py` | Tests for provider_extras/profile_name forwarding through run_skill() |
 | `test_tools_execution_response.py` | Contract tests: MCP tool response fields use correct enum types |
 | `test_tools_execution_results.py` | Tests for run_skill result shapes, failure paths, timing, flush telemetry, and gate checks |
 | `test_tools_execution_routing.py` | Tests for run_skill routing, executor delegation, and session skill management |

--- a/tests/server/test_tools_execution_provider.py
+++ b/tests/server/test_tools_execution_provider.py
@@ -1,0 +1,95 @@
+"""Tests for provider_extras/profile_name forwarding through run_skill()."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.server.tools.tools_execution import run_skill
+
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+
+@pytest.mark.anyio
+async def test_run_skill_provider_extras_none_when_feature_disabled(
+    tool_ctx, tmp_path, monkeypatch
+) -> None:
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx.executor = executor
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: False)
+
+    captured: dict = {}
+    original_run = executor.run
+
+    async def spy_run(*args, **kwargs):
+        captured.update(kwargs)
+        return await original_run(*args, **kwargs)
+
+    monkeypatch.setattr(executor, "run", spy_run)
+
+    await run_skill("/autoskillit:probe", str(tmp_path))
+
+    assert captured.get("provider_extras") is None
+    assert captured.get("profile_name") == ""
+
+
+@pytest.mark.anyio
+async def test_run_skill_provider_extras_none_for_anthropic_sentinel(
+    tool_ctx, tmp_path, monkeypatch
+) -> None:
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx.executor = executor
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
+    monkeypatch.setattr(
+        "autoskillit.server._guards._resolve_provider_profile",
+        lambda *a: ("anthropic", {"SOME_KEY": "val"}),
+    )
+
+    captured: dict = {}
+    original_run = executor.run
+
+    async def spy_run(*args, **kwargs):
+        captured.update(kwargs)
+        return await original_run(*args, **kwargs)
+
+    monkeypatch.setattr(executor, "run", spy_run)
+
+    await run_skill("/autoskillit:probe", str(tmp_path))
+
+    assert captured.get("provider_extras") is None
+    assert captured.get("profile_name") == ""
+
+
+@pytest.mark.anyio
+async def test_run_skill_provider_extras_forwarded_for_non_anthropic(
+    tool_ctx, tmp_path, monkeypatch
+) -> None:
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx.executor = executor
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
+    monkeypatch.setattr(
+        "autoskillit.server._guards._resolve_provider_profile",
+        lambda *a: ("bedrock", {"AWS_REGION": "us-east-1"}),
+    )
+
+    captured: dict = {}
+    original_run = executor.run
+
+    async def spy_run(*args, **kwargs):
+        captured.update(kwargs)
+        return await original_run(*args, **kwargs)
+
+    monkeypatch.setattr(executor, "run", spy_run)
+
+    await run_skill("/autoskillit:probe", str(tmp_path))
+
+    assert captured.get("provider_extras") == {"AWS_REGION": "us-east-1"}
+    assert captured.get("profile_name") == "bedrock"


### PR DESCRIPTION
## Summary

Thread two new keyword-only parameters — `provider_extras: Mapping[str, str] | None = None` and `profile_name: str = ''` — through the headless execution call chain: `HeadlessExecutor.run()` (protocol) -> `DefaultHeadlessExecutor.run()` -> `run_headless_core()` -> `build_leaf_headless_cmd()`. Then add a feature-gated provider resolution block to `run_skill()` in `tools_execution.py` that resolves the provider profile via `_resolve_provider_profile()` and forwards the results through `executor.run()`. An anthropic sentinel rule ensures the default provider produces no behavioral change.

Closes #1754

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-1754-20260504-121608-616590/.autoskillit/temp/make-plan/p2_a4_wp1_extend_headless_executor_plan_2026-05-04_121900.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|----------|--------|------------|----------|-------|-------------|------|
| plan | 66 | 13.2k | 1.1M | 77.1k | 73 | 64.0k | 8m 54s |
| verify | 35 | 6.4k | 768.6k | 55.8k | 76 | 42.8k | 4m 34s |
| implement | 452 | 29.4k | 3.5M | 91.4k | 159 | 78.7k | 11m 56s |
| prepare_pr | 52 | 3.8k | 169.9k | 37.0k | 16 | 24.6k | 1m 3s |
| compose_pr | 59 | 2.2k | 181.3k | 29.7k | 15 | 16.7k | 50s |
| review_pr | 116 | 33.8k | 673.6k | 77.0k | 39 | 66.0k | 6m 28s |
| resolve_review | 285 | 18.5k | 1.9M | 73.6k | 108 | 60.6k | 13m 10s |
| **Total** | 1.1k | 107.2k | 8.2M | 91.4k | | 353.5k | 46m 58s |

## Token Efficiency

| Step | LoC Changed | peak_ctx/LoC | cache_write/LoC | output/LoC |
|------|-------------|--------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 249 | 367.0 | 316.1 | 118.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 6 | 12269.3 | 10094.7 | 3086.2 |
| **Total** | **255** | 358.4 | 1386.2 | 420.4 |