### PR TITLE
[P2-A4-WP3] Update InMemoryHeadlessExecutor and ExecutorCall Test Fake

### DIFF
--- a/src/autoskillit/server/tools/tools_issue_composite.py
+++ b/src/autoskillit/server/tools/tools_issue_composite.py
@@ -17,11 +17,7 @@ logger = get_logger(__name__)
 
 
 def _extract_label_names(raw_labels: list[Any]) -> list[str]:
-    return [
-        lbl["name"] if isinstance(lbl, dict) else str(lbl)
-        for lbl in raw_labels
-        if lbl
-    ]
+    return [lbl["name"] if isinstance(lbl, dict) else str(lbl) for lbl in raw_labels if lbl]
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "github"}, annotations={"readOnlyHint": True})

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -80,6 +80,8 @@ class ExecutorCall:
     allowed_write_prefix: str = ""
     readonly_skill: bool = False
     write_watch_dirs: tuple[Any, ...] = ()
+    provider_extras: Mapping[str, str] | None = None
+    profile_name: str = ""
 
 
 @dataclasses.dataclass
@@ -185,6 +187,8 @@ class InMemoryHeadlessExecutor(HeadlessExecutor):
                 allowed_write_prefix=allowed_write_prefix,
                 readonly_skill=readonly_skill,
                 write_watch_dirs=tuple(write_watch_dirs),
+                provider_extras=provider_extras,
+                profile_name=profile_name,
             )
         )
         if self._queue:

--- a/tests/server/test_tools_execution_routing.py
+++ b/tests/server/test_tools_execution_routing.py
@@ -300,3 +300,65 @@ class TestOutputDirParameter:
 
         assert len(executor.calls) == 1
         assert Path(output_dir) in executor.calls[0].write_watch_dirs
+
+
+@pytest.mark.anyio
+async def test_run_skill_injects_provider_extras_when_feature_enabled(
+    tool_ctx, monkeypatch, tmp_path
+) -> None:
+    """run_skill records provider_extras and profile_name when feature is enabled."""
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx.executor = executor
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
+    monkeypatch.setattr(
+        "autoskillit.server._guards._resolve_provider_profile",
+        lambda *a: ("vertex", {"ANTHROPIC_API_KEY": "test-key-xyz"}),
+    )
+
+    await run_skill("/autoskillit:probe", str(tmp_path))
+
+    assert executor.calls[0].provider_extras == {"ANTHROPIC_API_KEY": "test-key-xyz"}
+    assert executor.calls[0].profile_name == "vertex"
+
+
+@pytest.mark.anyio
+async def test_run_skill_provider_extras_none_when_feature_disabled(
+    tool_ctx, monkeypatch, tmp_path
+) -> None:
+    """run_skill records None provider_extras and empty profile_name when feature is disabled."""
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx.executor = executor
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: False)
+
+    await run_skill("/autoskillit:probe", str(tmp_path))
+
+    assert executor.calls[0].provider_extras is None
+    assert executor.calls[0].profile_name == ""
+
+
+@pytest.mark.anyio
+async def test_run_skill_provider_extras_none_when_default_profile(
+    tool_ctx, monkeypatch, tmp_path
+) -> None:
+    """run_skill records None provider_extras when profile resolves to default anthropic."""
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx.executor = executor
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
+    monkeypatch.setattr(
+        "autoskillit.server._guards._resolve_provider_profile",
+        lambda *a: ("anthropic", {}),
+    )
+
+    await run_skill("/autoskillit:probe", str(tmp_path))
+
+    assert executor.calls[0].provider_extras is None
+    assert executor.calls[0].profile_name == ""


### PR DESCRIPTION
## Summary

Add `provider_extras: Mapping[str, str] | None = None` and `profile_name: str = ''` fields to the `ExecutorCall` dataclass in `tests/fakes.py`, wire them through `InMemoryHeadlessExecutor.run()` so the fields are recorded when appending to `self.calls`, and add 3 new integration tests to `tests/server/test_tools_execution_routing.py` that assert on the recorded `ExecutorCall` fields directly (no spy wrapper needed).

Currently, `InMemoryHeadlessExecutor.run()` accepts both parameters (added by #1754) but silently drops them when constructing `ExecutorCall`. The existing tests in `test_tools_execution_provider.py` work around this gap using a `spy_run` wrapper. This WP closes the gap so future tests can assert on `executor.calls[0].provider_extras` and `executor.calls[0].profile_name` directly, matching the existing assertion pattern for all other executor parameters.

Closes #1755

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-1755-20260504-135047-933528/.autoskillit/temp/make-plan/p2_a4_wp3_update_executor_fakes_plan_2026-05-04_135300.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|----------|--------|------------|----------|-------|-------------|------|
| plan | 72 | 12.9k | 779.2k | 61.0k | 46 | 48.2k | 7m 9s |
| verify | 37 | 6.3k | 401.6k | 53.1k | 34 | 39.9k | 3m 8s |
| implement | 108 | 5.5k | 466.3k | 46.6k | 36 | 33.8k | 2m 2s |
| prepare_pr | 60 | 4.7k | 200.9k | 35.7k | 20 | 23.8k | 1m 23s |
| compose_pr | 51 | 2.4k | 152.2k | 30.1k | 14 | 17.1k | 52s |
| review_pr | 92 | 10.3k | 396.7k | 46.8k | 32 | 34.6k | 2m 41s |
| **Total** | 420 | 42.1k | 2.4M | 61.0k | | 197.4k | 17m 16s |

## Token Efficiency

| Step | LoC Changed | peak_ctx/LoC | cache_write/LoC | output/LoC |
|------|-------------|--------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 72 | 646.6 | 470.1 | 76.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **72** | 846.8 | 2741.4 | 585.2 |