### PR TITLE
feat: add 7 unclassified core modules to MODULE_CASCADE_CORE

### DIFF
--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -172,6 +172,13 @@ MODULE_CASCADE_CORE: dict[str, frozenset[str]] = {
     "_type_resume": frozenset({"core", "cli", "execution"}),
     "_type_helpers": frozenset({"core", "execution", "fleet", "pipeline", "recipe", "server"}),
     "_type_protocols_workspace": frozenset({"core", "pipeline", "recipe", "workspace"}),
+    "_install_detect": frozenset({"core"}),
+    "_linux_proc": frozenset({"core", "execution", "fleet", "cli"}),
+    "_type_plugin_source": frozenset({"core", "execution", "pipeline", "server", "cli"}),
+    "kitchen_state": frozenset({"core"}),
+    "readiness": frozenset({"core", "server"}),
+    "session_registry": frozenset({"core"}),
+    "tool_sequence_analysis": frozenset({"core", "server", "cli"}),
 }
 
 # Narrow per-module cascade for execution/. Modules not listed here fall through
@@ -1112,7 +1119,7 @@ def build_test_scope(
                 elif stem in MODULE_CASCADE_CORE:
                     test_dirs.update(MODULE_CASCADE_CORE[stem])
                 else:
-                    test_dirs.update(cascade_map["core"])  # fail-open: unknown stem
+                    test_dirs.update(cascade_map["core"])  # fail-open: future unclassified stems
             elif pkg == "execution" and mode == FilterMode.CONSERVATIVE:
                 subpkg = _file_to_execution_subpkg(f)
                 if subpkg and subpkg in SUBPKG_CASCADE_EXECUTION:
@@ -1173,7 +1180,9 @@ def build_test_scope(
                         elif stem in MODULE_CASCADE_CORE:
                             test_dirs.update(MODULE_CASCADE_CORE[stem])
                         else:
-                            test_dirs.update(cascade_map["core"])  # fail-open: unknown stem
+                            test_dirs.update(
+                                cascade_map["core"]
+                            )  # fail-open: future unclassified stems
                     elif pkg == "execution" and mode == FilterMode.CONSERVATIVE:
                         subpkg = _file_to_execution_subpkg(f)
                         if subpkg and subpkg in SUBPKG_CASCADE_EXECUTION:

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -1047,7 +1047,8 @@ def _file_to_execution_subpkg(filepath: str) -> str | None:
         idx = parts.index("autoskillit")
     except ValueError:
         return None
-    # idx + 3 < len(parts) ensures parts[idx + 2] is a subpackage dir (not a bare module) and guards parts[idx + 1].
+    # idx + 3 < len(parts) ensures parts[idx + 2] is a subpackage dir (not a bare module)
+    # and guards parts[idx + 1].
     if idx + 3 < len(parts) and parts[idx + 1] == "execution":
         return parts[idx + 2]
     return None
@@ -1196,7 +1197,8 @@ def build_test_scope(
                                     if _file_to_package(c) == "execution"
                                     and Path(c).stem != "__init__"
                                 ]
-                                # empty list → fail-open: only execution/__init__ changed, no cause to narrow on
+                                # empty list → fail-open: only execution/__init__ changed,
+                                # no cause to narrow on
                                 all_narrow = bool(exec_cause_files)
                                 narrow_dirs: set[str] = set()
                                 for c in exec_cause_files:

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -172,7 +172,7 @@ MODULE_CASCADE_CORE: dict[str, frozenset[str]] = {
     "_type_resume": frozenset({"core", "cli", "execution"}),
     "_type_helpers": frozenset({"core", "execution", "fleet", "pipeline", "recipe", "server"}),
     "_type_protocols_workspace": frozenset({"core", "pipeline", "recipe", "workspace"}),
-    "_install_detect": frozenset({"core"}),
+    "_install_detect": frozenset({"core", "cli", "config"}),
     "_linux_proc": frozenset({"core", "execution", "fleet", "cli"}),
     "_type_plugin_source": frozenset({"core", "execution", "pipeline", "server", "cli"}),
     "kitchen_state": frozenset({"core"}),

--- a/tests/arch/test_cascade_map_guard.py
+++ b/tests/arch/test_cascade_map_guard.py
@@ -181,9 +181,13 @@ def _build_pkg_module_reverse_graph(
             parts = node.module.split(".")
             if parts[0] != "autoskillit":
                 continue
-            # Direct: from autoskillit.{pkg_name}.{stem} import ...
+            # Direct: from autoskillit.{pkg_name}.{stem}[.substem...] import ...
             if len(parts) >= 3 and parts[1] == pkg_name:
                 graph[parts[2]].add(consumer_pkg)
+                # Also track leaf stems for nested submodule imports
+                # (e.g., core.runtime.kitchen_state → records both "runtime" and "kitchen_state")
+                for i in range(3, len(parts)):
+                    graph[parts[i]].add(consumer_pkg)
             # Via re-export: from autoskillit.{pkg_name} import {name}
             elif len(parts) == 2 and parts[1] == pkg_name:
                 for alias in node.names:
@@ -261,10 +265,15 @@ class TestModuleCascadeCoreGuard:
 
     def test_module_cascade_core_has_no_phantom_stems(self) -> None:
         graph = _build_module_reverse_graph()
-        phantoms = [stem for stem in MODULE_CASCADE_CORE if not graph.get(stem)]
+        no_consumers = [stem for stem in MODULE_CASCADE_CORE if not graph.get(stem)]
+        # Stems consumed only via multi-level re-export chains (e.g., core → runtime →
+        # kitchen_state) have zero direct AST consumers. Verify they are real files.
+        phantoms = [
+            stem for stem in no_consumers if not list((_SRC_ROOT / "core").rglob(f"{stem}.py"))
+        ]
         assert not phantoms, (
-            "MODULE_CASCADE_CORE contains stems with zero AST consumers — "
-            "the source file may have been renamed or deleted:\n"
+            "MODULE_CASCADE_CORE contains stems with zero AST consumers and no matching "
+            "source file under core/ — the module may have been renamed or deleted:\n"
             f"  {sorted(phantoms)}\n"
             "Remove the stale entry or rename it to match the current module."
         )

--- a/tests/test_test_filter_core_cascade.py
+++ b/tests/test_test_filter_core_cascade.py
@@ -82,6 +82,13 @@ class TestModuleCascadeCore:
             "_type_resume",
             "_type_helpers",
             "_type_protocols_workspace",
+            "_install_detect",
+            "_linux_proc",
+            "_type_plugin_source",
+            "kitchen_state",
+            "readiness",
+            "session_registry",
+            "tool_sequence_analysis",
         }
         assert set(MODULE_CASCADE_CORE.keys()) == expected_stems
 
@@ -165,8 +172,8 @@ class TestBuildTestScopeCoreCascade:
         for pkg in ["core", "config", "execution", "server", "cli"]:
             assert pkg in dir_names
 
-    def test_kitchen_state_fails_open_to_full_cascade(self, tmp_path: Path) -> None:
-        """kitchen_state.py (now in runtime/) → fail-open to full core cascade."""
+    def test_kitchen_state_narrow_cascade(self, tmp_path: Path) -> None:
+        """kitchen_state.py → narrow cascade of {"core"} only."""
         tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
         result = build_test_scope(
             changed_files={"src/autoskillit/core/runtime/kitchen_state.py"},
@@ -175,9 +182,9 @@ class TestBuildTestScopeCoreCascade:
         )
         assert result is not None
         dir_names = {p.name for p in result}
-        # Fail-open: kitchen_state stem not in MODULE_CASCADE_CORE → full core cascade
-        for pkg in ["core", "config", "execution", "server", "cli"]:
-            assert pkg in dir_names, f"fail-open should include {pkg}"
+        assert "core" in dir_names
+        for excluded in ["config", "execution", "pipeline", "fleet", "migration", "workspace"]:
+            assert excluded not in dir_names, f"narrow cascade should not include {excluded}"
 
     def test_unknown_core_module_fails_open_to_full_cascade(self, tmp_path: Path) -> None:
         """An unknown core module stem → full cascade (fail-open, not None)."""
@@ -240,8 +247,8 @@ class TestBuildTestScopeCoreCascade:
         ]:
             assert pkg in dir_names
 
-    def test_readiness_cascade_fails_open_to_full_cascade(self, tmp_path: Path) -> None:
-        """readiness.py in core/runtime/ subpackage → falls through to full core cascade."""
+    def test_readiness_narrow_cascade(self, tmp_path: Path) -> None:
+        """readiness.py → narrow cascade of {"core", "server"} only."""
         tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
         result = build_test_scope(
             changed_files={"src/autoskillit/core/runtime/readiness.py"},
@@ -250,18 +257,18 @@ class TestBuildTestScopeCoreCascade:
         )
         assert result is not None
         dir_names = {p.name for p in result}
-        for pkg in [
-            "core",
+        for pkg in ["core", "server"]:
+            assert pkg in dir_names, f"narrow cascade should include {pkg}"
+        for excluded in [
             "cli",
             "config",
             "execution",
             "fleet",
             "migration",
             "recipe",
-            "server",
             "workspace",
         ]:
-            assert pkg in dir_names
+            assert excluded not in dir_names, f"narrow cascade should not include {excluded}"
 
     def test_type_resume_narrow_routing(self, tmp_path: Path) -> None:
         tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)


### PR DESCRIPTION
## Summary

Add 7 unclassified `core/` module stems to `MODULE_CASCADE_CORE` in `tests/_test_filter.py` with verified narrow cascade sets, reducing unnecessary full-cascade test runs. Five of the seven modules are nested under `core/runtime/` or `core/types/` subdirectories, which requires extending the AST-based guard in `tests/arch/test_cascade_map_guard.py` to handle nested submodule stems — without this extension, the phantom-stems guard test would fail for nested entries.

## Requirements

REQ-1: Add `_install_detect` to `MODULE_CASCADE_CORE` in `tests/_test_filter.py` with cascade `frozenset({"core"})`.
- Verified consumers: only `core/_version_snapshot.py` (within core itself).

REQ-2: Add `_linux_proc` to `MODULE_CASCADE_CORE` with cascade `frozenset({"core", "execution"})`.
- Verified consumers: only `execution/linux_tracing.py` via `core.runtime` re-export.
- Note: `_file_to_package()` returns `"core"` for all `core/**/*.py` files, so the stem `_linux_proc` will match correctly.

REQ-3: Add `_type_plugin_source` to `MODULE_CASCADE_CORE` with cascade `frozenset({"core", "execution", "server", "contracts"})`.
- Verified consumers: `execution/` (headless_dispatch), `server/` (tools_execution, kitchen_lifecycle), `conftest.py`.

REQ-4: Add `kitchen_state` to `MODULE_CASCADE_CORE` with cascade `frozenset({"core"})`.
- Verified consumers: no imports outside `core/runtime/`.

REQ-5: Add `readiness` to `MODULE_CASCADE_CORE` with cascade `frozenset({"core", "server"})`.
- Verified consumers: only `server/_lifespan.py`.

REQ-6: Add `session_registry` to `MODULE_CASCADE_CORE` with cascade `frozenset({"core"})`.
- Verified consumers: no imports outside `core/runtime/`.

REQ-7: Add `tool_sequence_analysis` to `MODULE_CASCADE_CORE` with cascade `frozenset({"core", "server", "cli"})`.
- Verified consumers: `server/tools/tools_status.py` (deferred import) and `cli/_sessions.py`.

REQ-8: Verify each new entry is exercised by the existing AST-based guard tests in `tests/arch/test_cascade_map_guard.py`. All tests must pass under `task test-check` with no regressions.

REQ-9: Update the fail-open comment at line 1087 of `tests/_test_filter.py` to accurately reflect the remaining set of unclassified `core/` modules (if any remain after this change).

Closes #1835

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260504-135056-381478/.autoskillit/temp/make-plan/add_7_unclassified_core_modules_to_module_cascade_core_plan_2026-05-04_140100.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|----------|--------|------------|----------|-------|-------------|------|
| plan | 67 | 20.3k | 689.9k | 73.3k | 89 | 65.0k | 9m 52s |
| verify | 55 | 25.0k | 1.7M | 87.2k | 126 | 82.4k | 12m 54s |
| implement | 160 | 5.9k | 785.2k | 50.7k | 48 | 38.0k | 1m 53s |
| prepare_pr | 60 | 5.1k | 200.3k | 37.4k | 17 | 25.5k | 1m 37s |
| compose_pr | 59 | 2.9k | 184.9k | 31.0k | 15 | 18.0k | 45s |
| review_pr | 100 | 8.6k | 429.3k | 45.3k | 33 | 33.1k | 2m 36s |
| ci_conflict_fix | 352 | 14.7k | 1.9M | 63.4k | 111 | 76.3k | 5m 37s |
| diagnose_ci | 108 | 4.2k | 390.2k | 41.9k | 29 | 30.1k | 1m 19s |
| resolve_ci | 120 | 7.4k | 593.3k | 53.2k | 32 | 42.8k | 3m 43s |
| **Total** | 1.1k | 93.9k | 6.8M | 87.2k | | 411.2k | 40m 19s |

## Token Efficiency

| Step | LoC Changed | peak_ctx/LoC | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|--------------|----------------|-----------------|------------|
| plan | 0 | — | — | — | — |
| verify | 0 | — | — | — | — |
| implement | 36 | 1408.1 | 21810.5 | 1055.6 | 163.8 |
| prepare_pr | 0 | — | — | — | — |
| compose_pr | 0 | — | — | — | — |
| review_pr | 0 | — | — | — | — |
| ci_conflict_fix | 464 | 136.7 | 4019.2 | 164.4 | 31.6 |
| diagnose_ci | 0 | — | — | — | — |
| resolve_ci | 29 | 1834.2 | 20457.1 | 1476.1 | 253.8 |
| **Total** | **529** | 164.9 | 12916.1 | 777.3 | 177.6 |