### PR TITLE
Reclassify Narrow Modules in _CORE_UNIVERSAL_MODULES

### DIFF
--- a/src/autoskillit/server/tools/tools_issue_composite.py
+++ b/src/autoskillit/server/tools/tools_issue_composite.py
@@ -17,11 +17,7 @@ logger = get_logger(__name__)
 
 
 def _extract_label_names(raw_labels: list[Any]) -> list[str]:
-    return [
-        lbl["name"] if isinstance(lbl, dict) else str(lbl)
-        for lbl in raw_labels
-        if lbl
-    ]
+    return [lbl["name"] if isinstance(lbl, dict) else str(lbl) for lbl in raw_labels if lbl]
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "github"}, annotations={"readOnlyHint": True})

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -122,6 +122,12 @@ _LARGE_CHANGESET_THRESHOLD: int = 30
 # core/ module-level cascade classification
 # ---------------------------------------------------------------------------
 
+# Modules in this set trigger a full 17-directory cascade. A core/ module belongs
+# here if:
+# (a) it is imported at the top level of tests/conftest.py or tests/fakes.py, OR
+# (b) its types have concrete implementations in tests/fakes.py (protocol satisfaction),
+# because conftest.py imports fakes, making any signature break cascade to all dirs.
+# If neither condition holds, use MODULE_CASCADE_CORE with an explicit narrower cascade.
 _CORE_UNIVERSAL_MODULES: frozenset[str] = frozenset(
     {
         "io",
@@ -131,14 +137,11 @@ _CORE_UNIVERSAL_MODULES: frozenset[str] = frozenset(
         "_type_protocols_logging",
         "_type_protocols_execution",
         "_type_protocols_github",
-        "_type_protocols_workspace",
         "_type_protocols_recipe",
         "_type_protocols_infra",
         "_type_enums",
         "_type_subprocess",
         "_type_results",
-        "_type_resume",
-        "_type_helpers",
     }
 )
 
@@ -166,6 +169,9 @@ MODULE_CASCADE_CORE: dict[str, frozenset[str]] = {
     "_claude_env": frozenset({"core", "execution", "_llm_triage", "cli"}),
     "_version_snapshot": frozenset({"core", "execution"}),
     "claude_conventions": frozenset({"core", "server", "workspace"}),
+    "_type_resume": frozenset({"core", "cli", "execution"}),
+    "_type_helpers": frozenset({"core", "execution", "fleet", "pipeline", "recipe", "server"}),
+    "_type_protocols_workspace": frozenset({"core", "pipeline", "recipe", "workspace"}),
 }
 
 # Narrow per-module cascade for execution/. Modules not listed here fall through

--- a/tests/arch/test_cascade_map_guard.py
+++ b/tests/arch/test_cascade_map_guard.py
@@ -58,12 +58,59 @@ def _build_reexport_map(pkg_name: str) -> dict[str, str]:
     return reexport_map
 
 
+def _build_types_submodule_symbol_map() -> dict[str, str]:
+    """Build a secondary symbol→stem map for core/types/ submodules in MODULE_CASCADE_CORE.
+
+    core/types/__init__.py uses star imports, so _build_reexport_map cannot follow the
+    second level of indirection. Instead, parse each _type_* submodule's __all__ list
+    directly to map exported symbol names to their submodule stem.
+
+    Returns {symbol_name: submodule_stem} for all stems in MODULE_CASCADE_CORE that
+    start with "_type_" and have a corresponding core/types/{stem}.py file.
+    """
+    secondary: dict[str, str] = {}
+    types_dir = _SRC_ROOT / "core" / "types"
+    for stem in MODULE_CASCADE_CORE:
+        if not stem.startswith("_type_"):
+            continue
+        submodule_path = types_dir / f"{stem}.py"
+        if not submodule_path.exists():
+            continue
+        try:
+            tree = ast.parse(submodule_path.read_text(encoding="utf-8"))
+        except SyntaxError as exc:
+            warnings.warn(
+                f"SyntaxError parsing {submodule_path}: {exc} — skipping submodule",
+                stacklevel=2,
+            )
+            continue
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Assign)
+                and len(node.targets) == 1
+                and isinstance(node.targets[0], ast.Name)
+                and node.targets[0].id == "__all__"
+                and isinstance(node.value, (ast.List, ast.Tuple))
+            ):
+                for elt in node.value.elts:
+                    if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+                        secondary[elt.value] = stem
+    return secondary
+
+
 def _build_core_reexport_map() -> dict[str, str]:
     reexport_map = _build_reexport_map("core")
     if not reexport_map:
         pytest.skip(
             "core/__init__.py and .pyi contain no relative imports — guard would pass vacuously"
         )
+    # Resolve two-level indirection: core/__init__ → types → _type_* submodule.
+    # Symbols that map to "types" are re-resolved to their deeper _type_* stem when
+    # that stem is a key in MODULE_CASCADE_CORE.
+    secondary = _build_types_submodule_symbol_map()
+    for symbol, stem in list(reexport_map.items()):
+        if stem == "types" and symbol in secondary:
+            reexport_map[symbol] = secondary[symbol]
     return reexport_map
 
 

--- a/tests/test_test_filter_core_cascade.py
+++ b/tests/test_test_filter_core_cascade.py
@@ -27,14 +27,11 @@ class TestCoreUniversalModules:
             "_type_protocols_logging",
             "_type_protocols_execution",
             "_type_protocols_github",
-            "_type_protocols_workspace",
             "_type_protocols_recipe",
             "_type_protocols_infra",
             "_type_enums",
             "_type_subprocess",
             "_type_results",
-            "_type_resume",
-            "_type_helpers",
         }
         assert required <= _CORE_UNIVERSAL_MODULES
 
@@ -82,8 +79,24 @@ class TestModuleCascadeCore:
             "_claude_env",
             "_version_snapshot",
             "claude_conventions",
+            "_type_resume",
+            "_type_helpers",
+            "_type_protocols_workspace",
         }
         assert set(MODULE_CASCADE_CORE.keys()) == expected_stems
+
+    def test_type_resume_cascade(self) -> None:
+        assert MODULE_CASCADE_CORE["_type_resume"] == frozenset({"core", "cli", "execution"})
+
+    def test_type_helpers_cascade(self) -> None:
+        assert MODULE_CASCADE_CORE["_type_helpers"] == frozenset(
+            {"core", "execution", "fleet", "pipeline", "recipe", "server"}
+        )
+
+    def test_type_protocols_workspace_cascade(self) -> None:
+        assert MODULE_CASCADE_CORE["_type_protocols_workspace"] == frozenset(
+            {"core", "pipeline", "recipe", "workspace"}
+        )
 
 
 class TestBuildTestScopeCoreCascade:
@@ -249,6 +262,60 @@ class TestBuildTestScopeCoreCascade:
             "workspace",
         ]:
             assert pkg in dir_names
+
+    def test_type_resume_narrow_routing(self, tmp_path: Path) -> None:
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        result = build_test_scope(
+            changed_files={"src/autoskillit/core/types/_type_resume.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        for pkg in ["core", "cli", "execution"]:
+            assert pkg in dir_names, f"_type_resume cascade should include {pkg}"
+        for excluded in [
+            "server",
+            "recipe",
+            "pipeline",
+            "fleet",
+            "workspace",
+            "migration",
+            "hooks",
+        ]:
+            assert excluded not in dir_names, f"_type_resume cascade should not include {excluded}"
+
+    def test_type_helpers_narrow_routing(self, tmp_path: Path) -> None:
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        result = build_test_scope(
+            changed_files={"src/autoskillit/core/types/_type_helpers.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        for pkg in ["core", "execution", "fleet", "pipeline", "recipe", "server"]:
+            assert pkg in dir_names, f"_type_helpers cascade should include {pkg}"
+        for excluded in ["cli", "hooks", "workspace", "migration"]:
+            assert excluded not in dir_names, (
+                f"_type_helpers cascade should not include {excluded}"
+            )
+
+    def test_type_protocols_workspace_narrow_routing(self, tmp_path: Path) -> None:
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        result = build_test_scope(
+            changed_files={"src/autoskillit/core/types/_type_protocols_workspace.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        for pkg in ["core", "pipeline", "recipe", "workspace"]:
+            assert pkg in dir_names, f"_type_protocols_workspace cascade should include {pkg}"
+        for excluded in ["cli", "server", "execution", "fleet", "migration", "hooks"]:
+            assert excluded not in dir_names, (
+                f"_type_protocols_workspace cascade should not include {excluded}"
+            )
 
 
 class TestClosureCoreNarrowCascade:


### PR DESCRIPTION
## Summary

Move three `core/types/` module stems (`_type_resume`, `_type_helpers`, `_type_protocols_workspace`) from `_CORE_UNIVERSAL_MODULES` (full 17-directory cascade) to `MODULE_CASCADE_CORE` (narrow, import-graph-verified cascade) in `tests/_test_filter.py`. These three modules do not meet the universality criterion: none appear in `tests/fakes.py` or `tests/conftest.py`, and none have concrete fake implementations in the shared test fixture chain. Add a code comment documenting the universality criterion above `_CORE_UNIVERSAL_MODULES`. Update all cascade-related tests to reflect the new classification.

## Requirements

### REQ-1: Move `_type_resume` from `_CORE_UNIVERSAL_MODULES` to `MODULE_CASCADE_CORE`

`_type_resume` exports `NoResume`, `BareResume`, `NamedResume`, `ResumeSpec`, and `resume_spec_from_cli`. Its source consumers are limited to `cli` (4 files) and `execution/commands.py`. It does **not** appear in `tests/fakes.py` or `tests/conftest.py`. Only 2 of 17 test directories are transitively affected.

Add to `MODULE_CASCADE_CORE`:
```python
"_type_resume": frozenset({"core", "cli", "execution"}),
```

Remove `"_type_resume"` from `_CORE_UNIVERSAL_MODULES`.

Verify with AST-based guard tests that this cascade matches the actual import graph.

### REQ-2: Evaluate and decide on `_type_helpers`

`_type_helpers` exports `extract_skill_name`, `extract_path_arg`, `resolve_target_skill`, `truncate_text`, `fleet_error`, and `session_type`. Source consumers are `recipe` (resolve_skill_name), `server` (multiple helpers), and `fleet` (fleet_error via pipeline re-export). It does **not** appear in `tests/fakes.py` or `tests/conftest.py`. Direct/transitive test directory exposure is approximately 8 of 17.

Decision options:
- **Move** to `MODULE_CASCADE_CORE` with: `frozenset({"core", "cli", "execution", "fleet", "hooks", "pipeline", "recipe", "server"})`
- **Keep** as universal if audit reveals additional transitive consumers not captured above

Document the chosen decision with a code comment.

### REQ-3: Evaluate and decide on `_type_protocols_workspace`

`_type_protocols_workspace` exports `WorkspaceManager`, `CloneManager`, `SessionSkillManager`, `SkillLister`, and `SkillResolver`. Source consumers are `workspace`, `recipe`, and `pipeline`. Unlike all other `_type_protocols_*` modules, its concrete implementations (`DefaultSkillResolver`, `DefaultSessionSkillManager`) live in production code and are **not** instantiated in the test fixture chain (`tests/fakes.py` / `tests/conftest.py`). Direct/transitive test directory exposure is approximately 7–8 of 17.

Decision options:
- **Move** to `MODULE_CASCADE_CORE` with: `frozenset({"core", "workspace", "recipe", "server", "cli", "skills", "arch", "contracts"})`
- **Keep** as universal if audit reveals additional transitive consumers not captured above

Document the chosen decision with a code comment.

### REQ-4: Add universality criterion comment above `_CORE_UNIVERSAL_MODULES`

Add a code comment directly above the `_CORE_UNIVERSAL_MODULES` declaration explaining the fakes/conftest universality criterion:

> Modules in this set trigger a full 17-directory cascade. A `core/` module belongs here if:
> (a) it is imported at the top level of `tests/conftest.py` or `tests/fakes.py`, OR
> (b) its types have concrete implementations in `tests/fakes.py` (protocol satisfaction),
> because `conftest.py` imports `fakes`, making any signature break cascade to all dirs.
> If neither condition holds, use `MODULE_CASCADE_CORE` with an explicit narrower cascade.

### REQ-5: Verify cascade entries against actual import graphs

After any reclassification, confirm the new `MODULE_CASCADE_CORE` entries match the actual import graph using the existing AST-based guard tests (e.g., `test_test_filter_core_cascade.py`). If those tests do not cover the new entries, extend them.

Closes #1837

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260504-135057-028828/.autoskillit/temp/make-plan/reclassify_narrow_modules_plan_2026-05-04_140500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|----------|--------|------------|----------|-------|-------------|------|
| plan | 2.2k | 12.5k | 523.6k | 60.8k | 98 | 52.7k | 7m 27s |
| verify | 69 | 23.1k | 3.7M | 104.9k | 135 | 93.3k | 11m 27s |
| implement | 166 | 9.7k | 1.0M | 73.3k | 58 | 60.6k | 5m 25s |
| prepare_pr | 60 | 6.0k | 209.0k | 38.0k | 20 | 27.6k | 1m 51s |
| compose_pr | 59 | 3.1k | 186.5k | 31.6k | 15 | 18.6k | 1m 2s |
| review_pr | 124 | 21.7k | 681.8k | 62.4k | 44 | 51.4k | 5m 59s |
| resolve_review | 187 | 10.9k | 862.6k | 46.7k | 51 | 34.0k | 5m 6s |
| **Total** | 2.8k | 87.0k | 7.2M | 104.9k | | 338.2k | 38m 19s |

## Token Efficiency

| Step | LoC Changed | peak_ctx/LoC | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|--------------|----------------|-----------------|------------|
| plan | 0 | — | — | — | — |
| verify | 0 | — | — | — | — |
| implement | 138 | 530.9 | 7594.2 | 439.4 | 70.1 |
| prepare_pr | 0 | — | — | — | — |
| compose_pr | 0 | — | — | — | — |
| review_pr | 0 | — | — | — | — |
| resolve_review | 0 | — | — | — | — |
| **Total** | **138** | 760.0 | 52354.6 | 2451.0 | 630.5 |