### PR TITLE
feat: add subpackage-aware cascade for execution/merge_queue/ in test path filter

### DIFF
--- a/src/autoskillit/server/tools/tools_issue_composite.py
+++ b/src/autoskillit/server/tools/tools_issue_composite.py
@@ -17,11 +17,7 @@ logger = get_logger(__name__)
 
 
 def _extract_label_names(raw_labels: list[Any]) -> list[str]:
-    return [
-        lbl["name"] if isinstance(lbl, dict) else str(lbl)
-        for lbl in raw_labels
-        if lbl
-    ]
+    return [lbl["name"] if isinstance(lbl, dict) else str(lbl) for lbl in raw_labels if lbl]
 
 
 @mcp.tool(tags={"autoskillit", "kitchen", "github"}, annotations={"readOnlyHint": True})

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -1181,6 +1181,7 @@ def build_test_scope(
                                     if _file_to_package(c) == "execution"
                                     and Path(c).stem != "__init__"
                                 ]
+                                # empty list → fail-open: only execution/__init__ changed, no cause to narrow on
                                 all_narrow = bool(exec_cause_files)
                                 narrow_dirs: set[str] = set()
                                 for c in exec_cause_files:

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -1034,6 +1034,7 @@ def _file_to_execution_subpkg(filepath: str) -> str | None:
         idx = parts.index("autoskillit")
     except ValueError:
         return None
+    # idx + 3 < len(parts) ensures parts[idx + 2] is a subpackage dir (not a bare module) and guards parts[idx + 1].
     if idx + 3 < len(parts) and parts[idx + 1] == "execution":
         return parts[idx + 2]
     return None

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -176,7 +176,6 @@ MODULE_CASCADE_EXECUTION: dict[str, frozenset[str]] = {
     "clone_guard": frozenset({"execution"}),
     # --- Medium: execution + specific file-level consumers ---
     "ci": frozenset({"execution"}),
-    "merge_queue": frozenset({"execution"}),
     "diff_annotator": frozenset({"execution", "test_smoke_utils.py"}),
     "pr_analysis": frozenset({"execution", "test_smoke_utils.py"}),
     "testing": frozenset(
@@ -254,6 +253,10 @@ MODULE_CASCADE_EXECUTION: dict[str, frozenset[str]] = {
         }
     ),
     # headless and process are NOT listed — they fall through to cascade_map["execution"]
+}
+
+SUBPKG_CASCADE_EXECUTION: dict[str, frozenset[str]] = {
+    "merge_queue": frozenset({"execution"}),
 }
 
 MODULE_CASCADE_RECIPE: dict[str, frozenset[str]] = {
@@ -1019,6 +1022,23 @@ def _file_to_package(filepath: str) -> str | None:
     return None
 
 
+def _file_to_execution_subpkg(filepath: str) -> str | None:
+    """Return the execution subpackage name if *filepath* is inside one, else None.
+
+    e.g. 'src/autoskillit/execution/merge_queue/_classifier.py' -> 'merge_queue'
+         'src/autoskillit/execution/headless.py' -> None
+         'src/autoskillit/execution/__init__.py' -> None
+    """
+    parts = Path(filepath).parts
+    try:
+        idx = parts.index("autoskillit")
+    except ValueError:
+        return None
+    if idx + 3 < len(parts) and parts[idx + 1] == "execution":
+        return parts[idx + 2]
+    return None
+
+
 def build_test_scope(
     changed_files: set[str] | None,
     mode: FilterMode,
@@ -1087,13 +1107,17 @@ def build_test_scope(
                 else:
                     test_dirs.update(cascade_map["core"])  # fail-open: unknown stem
             elif pkg == "execution" and mode == FilterMode.CONSERVATIVE:
-                stem = Path(f).stem
-                if stem in MODULE_CASCADE_EXECUTION:
-                    test_dirs.update(MODULE_CASCADE_EXECUTION[stem])
+                subpkg = _file_to_execution_subpkg(f)
+                if subpkg and subpkg in SUBPKG_CASCADE_EXECUTION:
+                    test_dirs.update(SUBPKG_CASCADE_EXECUTION[subpkg])
                 else:
-                    test_dirs.update(
-                        cascade_map["execution"]
-                    )  # fail-open: headless, process, unknown
+                    stem = Path(f).stem
+                    if stem in MODULE_CASCADE_EXECUTION:
+                        test_dirs.update(MODULE_CASCADE_EXECUTION[stem])
+                    else:
+                        test_dirs.update(
+                            cascade_map["execution"]
+                        )  # fail-open: headless, process, unknown
             elif pkg == "recipe" and mode == FilterMode.CONSERVATIVE:
                 stem = Path(f).stem
                 if stem in MODULE_CASCADE_RECIPE:
@@ -1144,25 +1168,37 @@ def build_test_scope(
                         else:
                             test_dirs.update(cascade_map["core"])  # fail-open: unknown stem
                     elif pkg == "execution" and mode == FilterMode.CONSERVATIVE:
-                        stem = Path(f).stem
-                        if stem == "__init__":
-                            exec_cause_stems = {
-                                Path(c).stem
-                                for c in changed_src_py
-                                if _file_to_package(c) == "execution"
-                                and Path(c).stem != "__init__"
-                            }
-                            if exec_cause_stems and all(
-                                s in MODULE_CASCADE_EXECUTION for s in exec_cause_stems
-                            ):
-                                for s in exec_cause_stems:
-                                    test_dirs.update(MODULE_CASCADE_EXECUTION[s])
+                        subpkg = _file_to_execution_subpkg(f)
+                        if subpkg and subpkg in SUBPKG_CASCADE_EXECUTION:
+                            test_dirs.update(SUBPKG_CASCADE_EXECUTION[subpkg])
+                        else:
+                            stem = Path(f).stem
+                            if stem == "__init__":
+                                exec_cause_files = [
+                                    c
+                                    for c in changed_src_py
+                                    if _file_to_package(c) == "execution"
+                                    and Path(c).stem != "__init__"
+                                ]
+                                all_narrow = bool(exec_cause_files)
+                                narrow_dirs: set[str] = set()
+                                for c in exec_cause_files:
+                                    c_subpkg = _file_to_execution_subpkg(c)
+                                    if c_subpkg and c_subpkg in SUBPKG_CASCADE_EXECUTION:
+                                        narrow_dirs.update(SUBPKG_CASCADE_EXECUTION[c_subpkg])
+                                    elif Path(c).stem in MODULE_CASCADE_EXECUTION:
+                                        narrow_dirs.update(MODULE_CASCADE_EXECUTION[Path(c).stem])
+                                    else:
+                                        all_narrow = False
+                                        break
+                                if all_narrow:
+                                    test_dirs.update(narrow_dirs)
+                                else:
+                                    test_dirs.update(cascade_map["execution"])  # fail-open
+                            elif stem in MODULE_CASCADE_EXECUTION:
+                                test_dirs.update(MODULE_CASCADE_EXECUTION[stem])
                             else:
                                 test_dirs.update(cascade_map["execution"])  # fail-open
-                        elif stem in MODULE_CASCADE_EXECUTION:
-                            test_dirs.update(MODULE_CASCADE_EXECUTION[stem])
-                        else:
-                            test_dirs.update(cascade_map["execution"])  # fail-open
                     elif pkg == "recipe" and mode == FilterMode.CONSERVATIVE:
                         stem = Path(f).stem
                         if stem == "__init__":

--- a/tests/test_test_filter_execution_cascade.py
+++ b/tests/test_test_filter_execution_cascade.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from tests._test_filter import (
     MODULE_CASCADE_EXECUTION,
+    SUBPKG_CASCADE_EXECUTION,
     FilterMode,
     build_test_scope,
 )
@@ -36,7 +37,6 @@ def test_all_entries_present() -> None:
         "anomaly_detection",
         "clone_guard",
         "ci",
-        "merge_queue",
         "diff_annotator",
         "pr_analysis",
         "testing",
@@ -252,23 +252,23 @@ class TestClosureExecutionNarrowCascade:
 
     def test_init_closure_all_narrow_causes_union(self, tmp_path: Path) -> None:
         """
-        Changing ci.py + merge_queue.py (both narrow to {"execution"}) →
+        Changing ci.py + clone_guard.py (both narrow to {"execution"}) →
         __init__ closure union is still {"execution"}.
         """
         tests_root = self._make_execution_layout(
             tmp_path,
             {
                 "ci.py": "",
-                "merge_queue.py": "",
+                "clone_guard.py": "",
                 "__init__.py": (
-                    "from .ci import CIWatcher\nfrom .merge_queue import MergeQueueWatcher\n"
+                    "from .ci import CIWatcher\nfrom .clone_guard import CloneGuard\n"
                 ),
             },
         )
         result = build_test_scope(
             changed_files={
                 "src/autoskillit/execution/ci.py",
-                "src/autoskillit/execution/merge_queue.py",
+                "src/autoskillit/execution/clone_guard.py",
             },
             mode=FilterMode.CONSERVATIVE,
             tests_root=tests_root,
@@ -278,5 +278,111 @@ class TestClosureExecutionNarrowCascade:
         assert "execution" in dir_names
         for excluded in ["core", "cli", "server", "workspace", "migration"]:
             assert excluded not in dir_names, (
-                f"ci+merge_queue union closure should not include {excluded}"
+                f"ci+clone_guard union closure should not include {excluded}"
             )
+
+
+class TestSubpkgCascadeExecution:
+    """REQ-MQ-001..004: subpackage-aware cascade routing for execution/ subpackages."""
+
+    ALL_DIRS = _ALL_DIRS
+
+    def _make_tests_root(self, tmp_path: Path, dirs: list[str]) -> Path:
+        tests_root = tmp_path / "tests"
+        for d in dirs:
+            (tests_root / d).mkdir(parents=True, exist_ok=True)
+        return tests_root
+
+    def _make_execution_subpkg_layout(
+        self,
+        tmp_path: Path,
+        subpkg: str,
+        modules: dict[str, str],
+    ) -> Path:
+        subpkg_dir = tmp_path / "src" / "autoskillit" / "execution" / subpkg
+        subpkg_dir.mkdir(parents=True)
+        for name, content in modules.items():
+            (subpkg_dir / name).write_text(content)
+        tests_root = tmp_path / "tests"
+        for d in self.ALL_DIRS:
+            (tests_root / d).mkdir(parents=True, exist_ok=True)
+        return tests_root
+
+    def test_merge_queue_init_uses_narrow_cascade(self, tmp_path: Path) -> None:
+        """execution/merge_queue/__init__.py → narrow {execution} cascade."""
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        result = build_test_scope(
+            changed_files={"src/autoskillit/execution/merge_queue/__init__.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        assert "execution" in dir_names
+        for excluded in ["core", "cli", "server", "workspace", "migration"]:
+            assert excluded not in dir_names, (
+                f"merge_queue/__init__ cascade should not include {excluded}"
+            )
+
+    def test_merge_queue_private_module_uses_narrow_cascade(self, tmp_path: Path) -> None:
+        """execution/merge_queue/_merge_queue_classifier.py → narrow {execution} cascade."""
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        result = build_test_scope(
+            changed_files={"src/autoskillit/execution/merge_queue/_merge_queue_classifier.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        assert "execution" in dir_names
+        for excluded in ["core", "cli", "server", "workspace", "migration"]:
+            assert excluded not in dir_names, (
+                f"merge_queue private module cascade should not include {excluded}"
+            )
+
+    def test_merge_queue_and_non_subpkg_file_fails_open(self, tmp_path: Path) -> None:
+        """merge_queue file + headless.py (not in any map) → full execution cascade."""
+        tests_root = self._make_tests_root(tmp_path, self.ALL_DIRS)
+        result = build_test_scope(
+            changed_files={
+                "src/autoskillit/execution/merge_queue/_merge_queue_classifier.py",
+                "src/autoskillit/execution/headless.py",
+            },
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        for pkg in ["execution", "server", "cli", "workspace"]:
+            assert pkg in dir_names, (
+                f"mixed merge_queue+headless should fail open to include {pkg}"
+            )
+
+    def test_merge_queue_closure_expansion_stays_narrow(self, tmp_path: Path) -> None:
+        """
+        _merge_queue_classifier.py re-exported by merge_queue/__init__.py →
+        closure expansion of __init__ stays narrow to {execution}.
+        """
+        tests_root = self._make_execution_subpkg_layout(
+            tmp_path,
+            "merge_queue",
+            {
+                "__init__.py": ("from ._merge_queue_classifier import MergeQueueClassifier\n"),
+                "_merge_queue_classifier.py": "",
+            },
+        )
+        result = build_test_scope(
+            changed_files={"src/autoskillit/execution/merge_queue/_merge_queue_classifier.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        dir_names = {p.name for p in result}
+        assert "execution" in dir_names
+        for excluded in ["core", "cli", "server", "workspace", "migration"]:
+            assert excluded not in dir_names, f"merge_queue closure should not include {excluded}"
+
+    def test_subpkg_cascade_exported(self) -> None:
+        """SUBPKG_CASCADE_EXECUTION is importable and contains 'merge_queue' key."""
+        assert "merge_queue" in SUBPKG_CASCADE_EXECUTION
+        assert SUBPKG_CASCADE_EXECUTION["merge_queue"] == frozenset({"execution"})


### PR DESCRIPTION
## Summary

`build_test_scope` in `tests/_test_filter.py` cannot route `execution/merge_queue/` subpackage files to their correct narrow cascade because it only looks up filename stems in `MODULE_CASCADE_EXECUTION`. Subpackage-internal files like `_merge_queue_classifier.py` have stems not present in the map, so they fall through to the full 10-directory `LAYER_CASCADE_CONSERVATIVE["execution"]` cascade.

The fix introduces a companion mapping `SUBPKG_CASCADE_EXECUTION` that maps execution subpackage directory names to their cascade, a helper `_file_to_execution_subpkg()` to detect subpackage membership, and priority checks in both the main routing loop and the closure expansion path of `build_test_scope`.

## Requirements

REQ-MQ-001: `build_test_scope` in `tests/_test_filter.py` MUST detect when a
changed file path contains a known execution subpackage segment (e.g.,
`execution/merge_queue/`) and apply a dedicated narrow cascade for that subpackage
rather than falling through to `LAYER_CASCADE_CONSERVATIVE["execution"]`.

REQ-MQ-002: The narrow cascade for `execution/merge_queue/` files MUST map to
`frozenset({"execution"})` — matching the import consumers of
`autoskillit.execution.merge_queue` confirmed by AST graph
(`_build_execution_module_reverse_graph` returns `{"execution"}` for `merge_queue`).

REQ-MQ-003: `MODULE_CASCADE_EXECUTION` MUST be extended (or a companion mapping
`MODULE_CASCADE_EXECUTION_SUBPKG: dict[str, frozenset[str]]` introduced) to hold
the subpackage-to-cascade mapping so the existing AST guard tests in
`tests/arch/test_cascade_map_guard.py` can validate correctness without
modification.

REQ-MQ-004: The stale `"merge_queue": frozenset({"execution"})` entry in
`MODULE_CASCADE_EXECUTION` that only matches the non-existent flat
`execution/merge_queue.py` MUST be removed or repurposed to avoid phantom-stem
failures in `test_module_cascade_execution_has_no_phantom_stems` — the AST graph
currently happens to return `{"execution"}` for `merge_queue` because external
code imports `autoskillit.execution.merge_queue` (the package), so the entry is
not a phantom today, but its routing semantics are wrong.

REQ-MQ-005: The closure expansion path for `execution/__init__.py`
(`_expand_reexport_closure`) MUST handle the case where the re-exported symbol
resolves to an execution subpackage (e.g., `merge_queue`) and apply the narrow
cascade rather than falling through.

REQ-MQ-006: New tests in `tests/test_test_filter_execution_cascade.py` MUST cover
the following scenarios:
- Changing `execution/merge_queue/__init__.py` → scope contains `execution` only
  (not `core`, `cli`, `server`, `workspace`, `migration`)
- Changing `execution/merge_queue/_merge_queue_classifier.py` → same narrow scope
- Changing both a `merge_queue/` file and a non-subpackage execution file
  (e.g., `headless.py`) → fails open to full `LAYER_CASCADE_CONSERVATIVE["execution"]`

Closes #1834

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260504-135055-400702/.autoskillit/temp/make-plan/add_subpackage_aware_cascade_execution_merge_queue_plan_2026-05-04_140100.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|----------|--------|------------|----------|-------|-------------|------|
| plan | 2.6k | 16.4k | 818.7k | 63.7k | 55 | 65.5k | 6m 56s |
| verify | 38 | 19.2k | 538.2k | 72.2k | 81 | 59.1k | 8m 14s |
| implement | 1.7k | 12.5k | 1.2M | 61.7k | 80 | 52.5k | 3m 54s |
| prepare_pr | 52 | 6.1k | 163.7k | 36.6k | 19 | 26.6k | 1m 33s |
| compose_pr | 75 | 3.2k | 247.5k | 31.6k | 19 | 18.7k | 1m 16s |
| review_pr | 132 | 24.2k | 745.6k | 66.1k | 46 | 55.7k | 7m 3s |
| resolve_review | 287 | 16.5k | 1.7M | 65.1k | 85 | 53.2k | 5m 41s |
| **Total** | 4.9k | 98.1k | 5.4M | 72.2k | | 331.3k | 34m 40s |

## Token Efficiency

| Step | LoC Changed | peak_ctx/LoC | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|--------------|----------------|-----------------|------------|
| plan | 0 | — | — | — | — |
| verify | 0 | — | — | — | — |
| implement | 208 | 296.7 | 5907.0 | 252.5 | 59.9 |
| prepare_pr | 0 | — | — | — | — |
| compose_pr | 0 | — | — | — | — |
| review_pr | 0 | — | — | — | — |
| resolve_review | 2 | 32553.0 | 853671.5 | 26596.0 | 8227.0 |
| **Total** | **210** | 343.9 | 25950.7 | 1577.6 | 467.2 |