### PR TITLE
Implementation Plan: [P3-A4-WP1] Add provider_used and provider_fallback parameters to flush_session_log

### DIFF
--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -115,6 +115,8 @@ def flush_session_log(
     elapsed_seconds: float | None = None,
     termination_reason: str = "",
     kill_reason: str = "",
+    provider_used: str = "",
+    provider_fallback: bool = False,
     snapshot_interval_seconds: float = 0.0,
     step_name: str = "",
     cli_subtype: str = "",
@@ -333,6 +335,8 @@ def flush_session_log(
         "peak_fd_ratio": round(peak_fd_ratio, 3),
         "termination_reason": termination_reason,
         "kill_reason": kill_reason,
+        "provider_used": provider_used,
+        "provider_fallback": provider_fallback,
         "write_path_warnings": effective_write_path_warnings,
         "write_call_count": write_call_count,
         "clone_contamination_reverted": clone_contamination_reverted,
@@ -393,6 +397,7 @@ def flush_session_log(
             "loc_deletions": loc_deletions,
             "peak_context": token_usage.get("peak_context", 0),
             "turn_count": token_usage.get("turn_count", 0),
+            "provider_used": provider_used,
         }
         atomic_write(session_dir / "token_usage.json", json.dumps(tu_data))
 
@@ -445,6 +450,8 @@ def flush_session_log(
         "recipe_version": recipe_version,
         "duration_seconds": duration_seconds,
         "github_api_requests": github_api_requests,
+        "provider_used": provider_used,
+        "provider_fallback": provider_fallback,
     }
     index_path = log_root / "sessions.jsonl"
     with index_path.open("a") as f:

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -1334,12 +1334,14 @@ def test_doctor_cache_version_mismatch_with_kitchen_open(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """_check_cache_version_mismatch must return ERROR when kitchen is open and versions differ."""
+    import autoskillit.version as _ver
     from autoskillit.cli.doctor._doctor_mcp import _check_cache_version_mismatch
     from autoskillit.core import Severity
 
     monkeypatch.setattr("autoskillit.core.any_kitchen_open", lambda **kw: True)
     monkeypatch.setattr(
-        "autoskillit.version.version_info",
+        _ver,
+        "version_info",
         lambda **kw: {
             "match": False,
             "plugin_json_version": "0.9.347",
@@ -1361,12 +1363,14 @@ def test_doctor_cache_version_mismatch_without_kitchen(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """_check_cache_version_mismatch must return WARNING (not ERROR) when kitchen is closed."""
+    import autoskillit.version as _ver
     from autoskillit.cli.doctor._doctor_mcp import _check_cache_version_mismatch
     from autoskillit.core import Severity
 
     monkeypatch.setattr("autoskillit.core.any_kitchen_open", lambda **kw: False)
     monkeypatch.setattr(
-        "autoskillit.version.version_info",
+        _ver,
+        "version_info",
         lambda **kw: {
             "match": False,
             "plugin_json_version": "0.9.347",
@@ -1384,12 +1388,14 @@ def test_doctor_cache_version_mismatch_ok_when_matching(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """_check_cache_version_mismatch must return OK when versions match."""
+    import autoskillit.version as _ver
     from autoskillit.cli.doctor._doctor_mcp import _check_cache_version_mismatch
     from autoskillit.core import Severity
 
     monkeypatch.setattr("autoskillit.core.any_kitchen_open", lambda **kw: False)
     monkeypatch.setattr(
-        "autoskillit.version.version_info",
+        _ver,
+        "version_info",
         lambda **kw: {
             "match": True,
             "plugin_json_version": "0.9.351",

--- a/tests/execution/test_session_log_fields.py
+++ b/tests/execution/test_session_log_fields.py
@@ -601,3 +601,83 @@ def test_flush_index_includes_duration_seconds(tmp_path):
     index = (tmp_path / "sessions.jsonl").read_text().strip()
     entry = json.loads(index)
     assert entry["duration_seconds"] == pytest.approx(42.5)
+
+
+def test_flush_session_log_provider_used_in_summary(tmp_path):
+    _flush(tmp_path, session_id="prov-sum", provider_used="minimax", proc_snapshots=None)
+    summary = json.loads((tmp_path / "sessions" / "prov-sum" / "summary.json").read_text())
+    assert summary["provider_used"] == "minimax"
+
+
+def test_flush_session_log_provider_fallback_in_summary(tmp_path):
+    _flush(tmp_path, session_id="fb-sum", provider_fallback=True, proc_snapshots=None)
+    summary = json.loads((tmp_path / "sessions" / "fb-sum" / "summary.json").read_text())
+    assert summary["provider_fallback"] is True
+
+
+def test_flush_session_log_provider_used_defaults_empty_in_summary(tmp_path):
+    _flush(tmp_path, session_id="prov-def", proc_snapshots=None)
+    summary = json.loads((tmp_path / "sessions" / "prov-def" / "summary.json").read_text())
+    assert summary["provider_used"] == ""
+
+
+def test_flush_session_log_provider_fallback_defaults_false_in_summary(tmp_path):
+    _flush(tmp_path, session_id="fb-def", proc_snapshots=None)
+    summary = json.loads((tmp_path / "sessions" / "fb-def" / "summary.json").read_text())
+    assert summary["provider_fallback"] is False
+
+
+def test_flush_session_log_provider_used_in_index(tmp_path):
+    _flush(tmp_path, session_id="prov-idx", provider_used="openai", proc_snapshots=None)
+    entry = json.loads((tmp_path / "sessions.jsonl").read_text().strip().split("\n")[-1])
+    assert entry["provider_used"] == "openai"
+
+
+def test_flush_session_log_provider_fallback_in_index(tmp_path):
+    _flush(tmp_path, session_id="fb-idx", provider_fallback=True, proc_snapshots=None)
+    entry = json.loads((tmp_path / "sessions.jsonl").read_text().strip().split("\n")[-1])
+    assert entry["provider_fallback"] is True
+
+
+def test_flush_session_log_kill_reason_absent_from_index(tmp_path):
+    _flush(tmp_path, session_id="kr-idx", kill_reason="timeout", proc_snapshots=None)
+    entry = json.loads((tmp_path / "sessions.jsonl").read_text().strip().split("\n")[-1])
+    assert "kill_reason" not in entry
+
+
+def test_flush_session_log_provider_used_in_token_usage(tmp_path):
+    _flush(
+        tmp_path,
+        session_id="prov-tu",
+        step_name="implement",
+        provider_used="minimax",
+        token_usage={"input_tokens": 100, "output_tokens": 50},
+        proc_snapshots=None,
+    )
+    tu = json.loads((tmp_path / "sessions" / "prov-tu" / "token_usage.json").read_text())
+    assert tu["provider_used"] == "minimax"
+
+
+def test_flush_session_log_provider_fallback_absent_from_token_usage(tmp_path):
+    _flush(
+        tmp_path,
+        session_id="fb-tu",
+        step_name="implement",
+        provider_fallback=True,
+        token_usage={"input_tokens": 100, "output_tokens": 50},
+        proc_snapshots=None,
+    )
+    tu = json.loads((tmp_path / "sessions" / "fb-tu" / "token_usage.json").read_text())
+    assert "provider_fallback" not in tu
+
+
+def test_flush_session_log_provider_used_defaults_empty_in_token_usage(tmp_path):
+    _flush(
+        tmp_path,
+        session_id="prov-tu-def",
+        step_name="implement",
+        token_usage={"input_tokens": 100, "output_tokens": 50},
+        proc_snapshots=None,
+    )
+    tu = json.loads((tmp_path / "sessions" / "prov-tu-def" / "token_usage.json").read_text())
+    assert tu["provider_used"] == ""

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -112,11 +112,11 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/core/io.py", 118),
     # session_log.py — github_api_usage dict, summary dict, meta.json sidecar,
     # token_usage dict, step_timing dict
-    ("src/autoskillit/execution/session_log.py", 307),
-    ("src/autoskillit/execution/session_log.py", 367),
+    ("src/autoskillit/execution/session_log.py", 309),
+    ("src/autoskillit/execution/session_log.py", 375),
     ("src/autoskillit/execution/session_log.py", 371),
-    ("src/autoskillit/execution/session_log.py", 400),
-    ("src/autoskillit/execution/session_log.py", 397),
+    ("src/autoskillit/execution/session_log.py", 405),
+    ("src/autoskillit/execution/session_log.py", 402),
     # migration/store.py — failure store dicts
     ("src/autoskillit/migration/store.py", 54),
     ("src/autoskillit/migration/store.py", 64),


### PR DESCRIPTION
## Summary

Add two new keyword-only parameters — `provider_used: str = ""` and `provider_fallback: bool = False` — to the `flush_session_log` function signature, then wire them unconditionally into three output dict literals: the `summary` dict (both fields), the `index_entry` dict (both fields), and the `tu_data` dict (`provider_used` only). All existing callers continue to work unchanged via backward-compatible defaults.

Closes #1776

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260504-144022-811684/.autoskillit/temp/make-plan/p3_a4_wp1_add_provider_used_and_provider_fallback_plan_2026-05-04_144600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|----------|--------|------------|----------|-------|-------------|------|
| plan | 65 | 8.1k | 937.2k | 69.9k | 52 | 51.9k | 4m 12s |
| verify | 36 | 5.4k | 399.2k | 66.0k | 41 | 53.0k | 2m 14s |
| implement | 164 | 7.0k | 760.0k | 47.0k | 57 | 34.3k | 3m 24s |
| prepare_pr | 60 | 4.6k | 203.2k | 36.9k | 20 | 24.5k | 1m 40s |
| compose_pr | 59 | 2.1k | 180.6k | 29.5k | 15 | 16.6k | 47s |
| review_pr | 108 | 19.1k | 504.7k | 57.8k | 36 | 46.7k | 4m 55s |
| resolve_review | 229 | 14.1k | 1.2M | 57.8k | 61 | 45.1k | 6m 47s |
| **Total** | 721 | 60.3k | 4.2M | 69.9k | | 272.1k | 24m 2s |

## Token Efficiency

| Step | LoC Changed | peak_ctx/LoC | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|--------------|----------------|-----------------|------------|
| plan | 0 | — | — | — | — |
| verify | 0 | — | — | — | — |
| implement | 87 | 539.8 | 8735.4 | 394.5 | 80.7 |
| prepare_pr | 0 | — | — | — | — |
| compose_pr | 0 | — | — | — | — |
| review_pr | 0 | — | — | — | — |
| resolve_review | 0 | — | — | — | — |
| **Total** | **87** | 804.0 | 48011.9 | 3127.6 | 693.1 |