### PR TITLE
[P3-A1-WP1] Add provider_used and provider_fallback fields to SkillResult dataclass

### DIFF
--- a/src/autoskillit/core/types/_type_results.py
+++ b/src/autoskillit/core/types/_type_results.py
@@ -197,6 +197,10 @@ class SkillResult:
     last_stop_reason: str = ""
     lifespan_started: bool = False
     """True when the L3 session invoked at least one MCP tool (heuristic for server lifespan)."""
+    provider_used: str = field(default="")
+    """Provider identifier stamped by _build_skill_result (e.g. 'anthropic', 'vertex')."""
+    provider_fallback: bool = False
+    """True when this result was produced by a fallback provider (not the primary)."""
 
     def to_json(self) -> str:
         data: dict[str, Any] = {
@@ -217,9 +221,12 @@ class SkillResult:
             "fs_writes_detected": self.fs_writes_detected,
             "last_stop_reason": self.last_stop_reason,
             "lifespan_started": self.lifespan_started,
+            "provider_fallback": self.provider_fallback,
         }
         if self.worktree_path is not None:
             data["worktree_path"] = self.worktree_path
+        if self.provider_used:
+            data["provider_used"] = self.provider_used
         data["order_id"] = self.order_id
         return json.dumps(data, default=lambda o: o.value if isinstance(o, Enum) else str(o))
 

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -413,3 +413,94 @@ class TestSkillResultCrashedFactory:
         assert "session_id" in data
         assert "subtype" in data
         assert data["subtype"] == "crashed"
+
+
+# ---------------------------------------------------------------------------
+# P3-A1-WP1 — provider_used and provider_fallback fields
+# ---------------------------------------------------------------------------
+
+
+def test_skill_result_provider_fields_have_correct_defaults():
+    """provider_used and provider_fallback have correct defaults via dataclasses.fields()."""
+    fields_map = {f.name: f for f in dataclasses.fields(SkillResult)}
+    assert fields_map["provider_used"].default == ""
+    assert fields_map["provider_fallback"].default is False
+
+
+def test_skill_result_construction_without_provider_fields():
+    """SkillResult can be constructed without passing provider fields (backward compat)."""
+    sr = SkillResult(
+        success=True,
+        result="ok",
+        session_id="s1",
+        subtype="success",
+        is_error=False,
+        exit_code=0,
+        needs_retry=False,
+        retry_reason=RetryReason.NONE,
+        stderr="",
+    )
+    assert sr.provider_used == ""
+    assert sr.provider_fallback is False
+
+
+def test_skill_result_to_json_includes_provider_fallback_unconditionally():
+    """provider_fallback appears in JSON even when False (unconditional serialization)."""
+    sr = SkillResult(
+        success=True,
+        result="ok",
+        session_id="s1",
+        subtype="success",
+        is_error=False,
+        exit_code=0,
+        needs_retry=False,
+        retry_reason=RetryReason.NONE,
+        stderr="",
+    )
+    data = json.loads(sr.to_json())
+    assert "provider_fallback" in data
+    assert data["provider_fallback"] is False
+
+
+def test_skill_result_to_json_omits_provider_used_when_empty():
+    """provider_used key is absent from JSON when the field is '' (empty string)."""
+    sr = SkillResult(
+        success=True,
+        result="ok",
+        session_id="s1",
+        subtype="success",
+        is_error=False,
+        exit_code=0,
+        needs_retry=False,
+        retry_reason=RetryReason.NONE,
+        stderr="",
+    )
+    data = json.loads(sr.to_json())
+    assert "provider_used" not in data
+
+
+def test_skill_result_to_json_includes_provider_used_when_set():
+    """provider_used appears in JSON when non-empty string."""
+    sr = SkillResult(
+        success=True,
+        result="ok",
+        session_id="s1",
+        subtype="success",
+        is_error=False,
+        exit_code=0,
+        needs_retry=False,
+        retry_reason=RetryReason.NONE,
+        stderr="",
+        provider_used="anthropic-vertex",
+        provider_fallback=True,
+    )
+    data = json.loads(sr.to_json())
+    assert data["provider_used"] == "anthropic-vertex"
+    assert data["provider_fallback"] is True
+
+
+def test_skill_result_crashed_works_without_provider_fields():
+    """crashed() classmethod still works — inherits provider field defaults."""
+    result = SkillResult.crashed(exception=RuntimeError("boom"))
+    assert result.provider_used == ""
+    assert result.provider_fallback is False

--- a/tests/execution/test_headless_core.py
+++ b/tests/execution/test_headless_core.py
@@ -882,6 +882,7 @@ class TestBuildSkillResultCrossValidation:
         "kill_reason",
         "last_stop_reason",
         "lifespan_started",
+        "provider_fallback",
         "needs_retry",
         "retry_reason",
         "order_id",

--- a/tests/execution/test_session_parsing.py
+++ b/tests/execution/test_session_parsing.py
@@ -537,6 +537,7 @@ class TestSkillResult:
             "kill_reason",
             "last_stop_reason",
             "lifespan_started",
+            "provider_fallback",
             "needs_retry",
             "retry_reason",
             "order_id",


### PR DESCRIPTION
## Summary

Add two optional provider-tracking fields (`provider_used: str` and `provider_fallback: bool`) to the `SkillResult` dataclass immediately after the existing `lifespan_started` field. Update `to_json()` to serialize `provider_fallback` unconditionally and `provider_used` conditionally (only when non-empty). Both fields carry defaults, so no existing construction sites or the `crashed()` classmethod require changes.

Closes #1773

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260504-144022-066607/.autoskillit/temp/make-plan/p3_a1_wp1_add_provider_fields_plan_2026-05-04_144500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|----------|--------|------------|----------|-------|-------------|------|
| plan | 46 | 6.5k | 436.8k | 55.0k | 63 | 46.1k | 4m 14s |
| verify | 35 | 8.3k | 329.6k | 61.2k | 74 | 48.1k | 4m 43s |
| implement | 140 | 6.8k | 626.1k | 47.9k | 47 | 35.5k | 2m 17s |
| prepare_pr | 60 | 4.6k | 202.8k | 36.4k | 18 | 24.0k | 1m 22s |
| compose_pr | 59 | 1.9k | 179.7k | 29.3k | 15 | 16.3k | 49s |
| review_pr | 132 | 12.5k | 606.4k | 50.1k | 42 | 38.8k | 3m 38s |
| **Total** | 472 | 40.5k | 2.4M | 61.2k | | 208.9k | 17m 5s |

## Token Efficiency

| Step | LoC Changed | peak_ctx/LoC | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|--------------|----------------|-----------------|------------|
| plan | 0 | — | — | — | — |
| verify | 0 | — | — | — | — |
| implement | 99 | 484.0 | 6324.0 | 358.9 | 68.3 |
| prepare_pr | 0 | — | — | — | — |
| compose_pr | 0 | — | — | — | — |
| review_pr | 0 | — | — | — | — |
| **Total** | **99** | 618.1 | 24054.7 | 2109.8 | 409.3 |