### PR TITLE
Rectify: L2 Orchestrator Sessions Drop Cache Token Telemetry

### DIFF
--- a/src/autoskillit/core/types/_type_results.py
+++ b/src/autoskillit/core/types/_type_results.py
@@ -39,6 +39,8 @@ __all__ = [
     "TokenSummaryResult",
     "TimingSummaryResult",
     "KitchenStatusResult",
+    "TokenUsageFileEntry",
+    "SessionIndexEntry",
 ]
 
 
@@ -475,3 +477,58 @@ class KitchenStatusResult(TypedDict, total=False):
     warning: str
     success: bool
     error: str
+
+
+class TokenUsageFileEntry(TypedDict):
+    """Schema contract for token_usage.json written by flush_session_log."""
+
+    session_label: str
+    input_tokens: int
+    output_tokens: int
+    cache_creation_input_tokens: int
+    cache_read_input_tokens: int
+    peak_context: int
+    turn_count: int
+    timing_seconds: float
+    order_id: str
+    loc_insertions: int
+    loc_deletions: int
+
+
+class SessionIndexEntry(TypedDict):
+    """Schema contract for sessions.jsonl entries written by flush_session_log."""
+
+    session_id: str
+    dir_name: str
+    timestamp: str
+    cwd: str
+    kitchen_id: str
+    order_id: str
+    campaign_id: str
+    dispatch_id: str
+    claude_code_log: str
+    skill_command: str
+    success: bool
+    subtype: str
+    cli_subtype: str
+    exit_code: int
+    snapshot_count: int
+    anomaly_count: int
+    peak_rss_kb: int
+    peak_oom_score: int
+    step_name: str
+    input_tokens: int
+    output_tokens: int
+    cache_creation_input_tokens: int
+    cache_read_input_tokens: int
+    write_call_count: int
+    tracked_comm: str | None
+    tracked_comm_drift: bool
+    autoskillit_version: str
+    claude_code_version: str
+    recipe_name: str
+    recipe_content_hash: str
+    recipe_composite_hash: str
+    recipe_version: str
+    duration_seconds: float
+    github_api_requests: int

--- a/src/autoskillit/core/types/_type_results.py
+++ b/src/autoskillit/core/types/_type_results.py
@@ -493,6 +493,7 @@ class TokenUsageFileEntry(TypedDict):
     order_id: str
     loc_insertions: int
     loc_deletions: int
+    provider_used: str
 
 
 class SessionIndexEntry(TypedDict):

--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -447,7 +447,12 @@ async def _execute_claude_headless(
     new_audit_records = ctx.audit.get_report_as_dicts()[audit_count_before:]
     audit_record = new_audit_records[0] if new_audit_records else None
 
-    if result.proc_snapshots is not None or not skill_result.success or bool(step_name):
+    if (
+        result.proc_snapshots is not None
+        or not skill_result.success
+        or bool(step_name)
+        or skill_result.token_usage is not None
+    ):
         from autoskillit.execution.session_log import flush_session_log
 
         try:
@@ -512,20 +517,22 @@ async def _execute_claude_headless(
         session_id=skill_result.session_id,
     )
 
-    if step_name:
-        try:
-            ctx.token_log.record(
-                step_name,
-                skill_result.token_usage,
-                start_ts=result.start_ts,
-                end_ts=result.end_ts,
-                elapsed_seconds=result.elapsed_seconds,
-                order_id=order_id,
-                loc_insertions=_metrics.loc_insertions,
-                loc_deletions=_metrics.loc_deletions,
-            )
-        except Exception:
-            logger.debug("token_log_record_failed", exc_info=True)
+    from autoskillit.execution.session_log import _resolve_session_label
+
+    _token_label = _resolve_session_label(step_name, dispatch_id)
+    try:
+        ctx.token_log.record(
+            _token_label,
+            skill_result.token_usage,
+            start_ts=result.start_ts,
+            end_ts=result.end_ts,
+            elapsed_seconds=result.elapsed_seconds,
+            order_id=order_id,
+            loc_insertions=_metrics.loc_insertions,
+            loc_deletions=_metrics.loc_deletions,
+        )
+    except Exception:
+        logger.debug("token_log_record_failed", exc_info=True)
     return skill_result
 
 

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -93,6 +93,19 @@ def read_telemetry_clear_marker(log_root: Path) -> datetime | None:
         return None
 
 
+def _resolve_session_label(step_name: str, dispatch_id: str) -> str:
+    """Derive a non-empty session label for telemetry file identification.
+
+    Recipe steps use step_name. Fleet dispatches use dispatch_id.
+    Ad-hoc sessions get a fallback label.
+    """
+    if step_name:
+        return step_name
+    if dispatch_id:
+        return f"dispatch:{dispatch_id}"
+    return "(ad-hoc)"
+
+
 def flush_session_log(
     *,
     log_dir: str,
@@ -383,10 +396,11 @@ def flush_session_log(
     if exception_text:
         atomic_write(session_dir / "crash_exception.txt", exception_text)
 
-    # Write per-session telemetry files when step_name is provided
-    if step_name and token_usage is not None:
+    # Write per-session telemetry files; gate on data presence, not session identity
+    if token_usage is not None:
+        label = _resolve_session_label(step_name, dispatch_id)
         tu_data = {
-            "step_name": step_name,
+            "session_label": label,
             "input_tokens": token_usage.get("input_tokens", 0),
             "output_tokens": token_usage.get("output_tokens", 0),
             "cache_creation_input_tokens": token_usage.get("cache_creation_input_tokens", 0),
@@ -401,12 +415,13 @@ def flush_session_log(
         }
         atomic_write(session_dir / "token_usage.json", json.dumps(tu_data))
 
-    if step_name and timing_seconds is not None:
+    if timing_seconds is not None:
+        label = _resolve_session_label(step_name, dispatch_id)
         atomic_write(
             session_dir / "step_timing.json",
             json.dumps(
                 {
-                    "step_name": step_name,
+                    "step_name": label,
                     "total_seconds": max(0.0, timing_seconds),
                     "order_id": order_id,
                 }
@@ -439,6 +454,12 @@ def flush_session_log(
         "step_name": step_name,
         "input_tokens": token_usage.get("input_tokens", 0) if token_usage else 0,
         "output_tokens": token_usage.get("output_tokens", 0) if token_usage else 0,
+        "cache_creation_input_tokens": token_usage.get("cache_creation_input_tokens", 0)
+        if token_usage
+        else 0,
+        "cache_read_input_tokens": token_usage.get("cache_read_input_tokens", 0)
+        if token_usage
+        else 0,
         "write_call_count": write_call_count,
         "tracked_comm": _effective_tracked_comm,
         "tracked_comm_drift": _tracked_comm_drift,

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -397,8 +397,8 @@ def flush_session_log(
         atomic_write(session_dir / "crash_exception.txt", exception_text)
 
     # Write per-session telemetry files; gate on data presence, not session identity
+    label = _resolve_session_label(step_name, dispatch_id)
     if token_usage is not None:
-        label = _resolve_session_label(step_name, dispatch_id)
         tu_data = {
             "session_label": label,
             "input_tokens": token_usage.get("input_tokens", 0),
@@ -416,7 +416,6 @@ def flush_session_log(
         atomic_write(session_dir / "token_usage.json", json.dumps(tu_data))
 
     if timing_seconds is not None:
-        label = _resolve_session_label(step_name, dispatch_id)
         atomic_write(
             session_dir / "step_timing.json",
             json.dumps(

--- a/src/autoskillit/pipeline/tokens.py
+++ b/src/autoskillit/pipeline/tokens.py
@@ -238,7 +238,7 @@ class DefaultTokenLog:
             except (json.JSONDecodeError, OSError):
                 continue
 
-            raw_step = data.get("step_name", "")
+            raw_step = data.get("session_label") or data.get("step_name", "")
             if not raw_step:
                 continue
 

--- a/src/autoskillit/pipeline/tokens.py
+++ b/src/autoskillit/pipeline/tokens.py
@@ -39,7 +39,9 @@ def canonical_step_name(step_name: str) -> str:
     indistinguishable from an orchestrator-appended suffix and will be
     collapsed to the base name.
     """
-    return re.sub(r"-\d+$", "", step_name) if step_name else step_name
+    if not step_name or ":" in step_name or step_name.startswith("("):
+        return step_name
+    return re.sub(r"-\d+$", "", step_name)
 
 
 @dataclass

--- a/tests/execution/conftest.py
+++ b/tests/execution/conftest.py
@@ -132,6 +132,7 @@ def _flush(tmp_path: Path, **overrides) -> None:
         "exit_code": 0,
         "start_ts": "2026-03-03T12:00:00+00:00",
         "proc_snapshots": [_snap(), _snap(), _snap()],
+        "dispatch_id": "",
         "github_api_log": None,
         "token_usage": None,
         "timing_seconds": None,

--- a/tests/execution/test_session_log_flush.py
+++ b/tests/execution/test_session_log_flush.py
@@ -415,17 +415,26 @@ def test_flush_writes_token_usage_json_when_step_provided(tmp_path):
     assert (session_dir / "token_usage.json").is_file()
 
 
-def test_flush_omits_token_usage_json_when_no_step_name(tmp_path):
-    """token_usage.json is NOT written when step_name is empty, even if token_usage provided."""
+def test_flush_writes_token_usage_json_when_step_name_empty(tmp_path):
+    """token_usage.json IS written when step_name is empty, as long as token_usage is present."""
     _flush(
         tmp_path,
         step_name="",
-        token_usage={"input_tokens": 100},
+        token_usage={
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_creation_input_tokens": 20,
+            "cache_read_input_tokens": 80,
+        },
         proc_snapshots=None,
         success=False,
     )
     session_dir = tmp_path / "sessions" / "test-session-001"
-    assert not (session_dir / "token_usage.json").exists()
+    assert (session_dir / "token_usage.json").exists()
+    data = json.loads((session_dir / "token_usage.json").read_text())
+    assert data["session_label"] == "(ad-hoc)"
+    assert data["cache_creation_input_tokens"] == 20
+    assert data["cache_read_input_tokens"] == 80
 
 
 def test_flush_writes_step_timing_json(tmp_path):
@@ -493,11 +502,16 @@ def test_flush_omits_audit_log_when_no_record(tmp_path):
 
 
 def test_flush_index_includes_step_name_and_token_fields(tmp_path):
-    """sessions.jsonl entry has step_name, input_tokens, output_tokens fields."""
+    """sessions.jsonl entry has step_name, input_tokens, output_tokens, and cache fields."""
     _flush(
         tmp_path,
         step_name="implement",
-        token_usage={"input_tokens": 100, "output_tokens": 50},
+        token_usage={
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_creation_input_tokens": 20,
+            "cache_read_input_tokens": 80,
+        },
         proc_snapshots=None,
         success=False,
     )
@@ -506,6 +520,8 @@ def test_flush_index_includes_step_name_and_token_fields(tmp_path):
     assert entry["step_name"] == "implement"
     assert entry["input_tokens"] == 100
     assert entry["output_tokens"] == 50
+    assert entry["cache_creation_input_tokens"] == 20
+    assert entry["cache_read_input_tokens"] == 80
 
 
 def test_flush_index_token_fields_zero_when_no_step(tmp_path):
@@ -684,3 +700,76 @@ def test_flush_helper_builds_and_passes_session_telemetry():
     assert telemetry.github_api_usage is None
     assert telemetry.loc_insertions == 0
     assert telemetry.loc_deletions == 0
+
+
+# ---------------------------------------------------------------------------
+# L2 orchestrator session telemetry tests
+# ---------------------------------------------------------------------------
+
+
+def test_flush_writes_token_usage_with_dispatch_label(tmp_path):
+    """token_usage.json uses dispatch:{id} label when step_name is empty and dispatch_id set."""
+    _flush(
+        tmp_path,
+        step_name="",
+        dispatch_id="abc-123",
+        token_usage={
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_creation_input_tokens": 20,
+            "cache_read_input_tokens": 80,
+        },
+        proc_snapshots=None,
+        success=False,
+    )
+    session_dir = tmp_path / "sessions" / "test-session-001"
+    assert (session_dir / "token_usage.json").exists()
+    data = json.loads((session_dir / "token_usage.json").read_text())
+    assert data["session_label"] == "dispatch:abc-123"
+    assert data["cache_creation_input_tokens"] == 20
+    assert data["cache_read_input_tokens"] == 80
+
+
+def test_sessions_jsonl_includes_cache_fields(tmp_path):
+    """sessions.jsonl entries include cache_creation_input_tokens and cache_read_input_tokens."""
+    _flush(
+        tmp_path,
+        step_name="implement",
+        token_usage={
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_creation_input_tokens": 20,
+            "cache_read_input_tokens": 80,
+        },
+        proc_snapshots=None,
+        success=False,
+    )
+    lines = (tmp_path / "sessions.jsonl").read_text().strip().split("\n")
+    entry = json.loads(lines[-1])
+    assert entry["cache_creation_input_tokens"] == 20
+    assert entry["cache_read_input_tokens"] == 80
+
+
+def test_token_usage_file_entry_type_matches_written_fields(tmp_path):
+    """token_usage.json keys match exactly the fields defined in TokenUsageFileEntry TypedDict."""
+    from autoskillit.core.types import TokenUsageFileEntry
+
+    _flush(
+        tmp_path,
+        step_name="implement",
+        token_usage={
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_creation_input_tokens": 20,
+            "cache_read_input_tokens": 80,
+            "peak_context": 1000,
+            "turn_count": 5,
+        },
+        timing_seconds=42.0,
+        proc_snapshots=None,
+        success=False,
+    )
+    session_dir = tmp_path / "sessions" / "test-session-001"
+    data = json.loads((session_dir / "token_usage.json").read_text())
+    expected_keys = set(TokenUsageFileEntry.__annotations__.keys())
+    assert set(data.keys()) == expected_keys

--- a/tests/execution/test_session_log_flush.py
+++ b/tests/execution/test_session_log_flush.py
@@ -433,6 +433,7 @@ def test_flush_writes_token_usage_json_when_step_name_empty(tmp_path):
     assert (session_dir / "token_usage.json").exists()
     data = json.loads((session_dir / "token_usage.json").read_text())
     assert data["session_label"] == "(ad-hoc)"
+    assert "step_name" not in data
     assert data["cache_creation_input_tokens"] == 20
     assert data["cache_read_input_tokens"] == 80
 
@@ -516,6 +517,7 @@ def test_flush_index_includes_step_name_and_token_fields(tmp_path):
         success=False,
     )
     lines = (tmp_path / "sessions.jsonl").read_text().strip().split("\n")
+    assert len(lines) == 1
     entry = json.loads(lines[-1])
     assert entry["step_name"] == "implement"
     assert entry["input_tokens"] == 100
@@ -702,11 +704,6 @@ def test_flush_helper_builds_and_passes_session_telemetry():
     assert telemetry.loc_deletions == 0
 
 
-# ---------------------------------------------------------------------------
-# L2 orchestrator session telemetry tests
-# ---------------------------------------------------------------------------
-
-
 def test_flush_writes_token_usage_with_dispatch_label(tmp_path):
     """token_usage.json uses dispatch:{id} label when step_name is empty and dispatch_id set."""
     _flush(
@@ -728,27 +725,6 @@ def test_flush_writes_token_usage_with_dispatch_label(tmp_path):
     assert data["session_label"] == "dispatch:abc-123"
     assert data["cache_creation_input_tokens"] == 20
     assert data["cache_read_input_tokens"] == 80
-
-
-def test_sessions_jsonl_includes_cache_fields(tmp_path):
-    """sessions.jsonl entries include cache_creation_input_tokens and cache_read_input_tokens."""
-    _flush(
-        tmp_path,
-        step_name="implement",
-        token_usage={
-            "input_tokens": 100,
-            "output_tokens": 50,
-            "cache_creation_input_tokens": 20,
-            "cache_read_input_tokens": 80,
-        },
-        proc_snapshots=None,
-        success=False,
-    )
-    lines = (tmp_path / "sessions.jsonl").read_text().strip().split("\n")
-    assert len(lines) == 1
-    entry = json.loads(lines[-1])
-    assert entry["cache_creation_input_tokens"] == 20
-    assert entry["cache_read_input_tokens"] == 80
 
 
 def test_token_usage_file_entry_type_matches_written_fields(tmp_path):

--- a/tests/execution/test_session_log_flush.py
+++ b/tests/execution/test_session_log_flush.py
@@ -745,6 +745,7 @@ def test_sessions_jsonl_includes_cache_fields(tmp_path):
         success=False,
     )
     lines = (tmp_path / "sessions.jsonl").read_text().strip().split("\n")
+    assert len(lines) == 1
     entry = json.loads(lines[-1])
     assert entry["cache_creation_input_tokens"] == 20
     assert entry["cache_read_input_tokens"] == 80

--- a/tests/execution/test_session_log_flush.py
+++ b/tests/execution/test_session_log_flush.py
@@ -550,7 +550,7 @@ def test_token_usage_json_schema(tmp_path):
         success=False,
     )
     tu = json.loads((tmp_path / "sessions" / "test-session-001" / "token_usage.json").read_text())
-    assert tu["step_name"] == "plan"
+    assert tu["session_label"] == "plan"
     assert tu["input_tokens"] == 10
     assert tu["output_tokens"] == 5
     assert tu["cache_creation_input_tokens"] == 2

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -112,11 +112,11 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/core/io.py", 118),
     # session_log.py — github_api_usage dict, summary dict, meta.json sidecar,
     # token_usage dict, step_timing dict
-    ("src/autoskillit/execution/session_log.py", 309),
-    ("src/autoskillit/execution/session_log.py", 375),
-    ("src/autoskillit/execution/session_log.py", 371),
-    ("src/autoskillit/execution/session_log.py", 405),
-    ("src/autoskillit/execution/session_log.py", 402),
+    ("src/autoskillit/execution/session_log.py", 322),
+    ("src/autoskillit/execution/session_log.py", 384),
+    ("src/autoskillit/execution/session_log.py", 388),
+    ("src/autoskillit/execution/session_log.py", 416),
+    ("src/autoskillit/execution/session_log.py", 420),
     # migration/store.py — failure store dicts
     ("src/autoskillit/migration/store.py", 54),
     ("src/autoskillit/migration/store.py", 64),

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -116,7 +116,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/execution/session_log.py", 384),
     ("src/autoskillit/execution/session_log.py", 388),
     ("src/autoskillit/execution/session_log.py", 416),
-    ("src/autoskillit/execution/session_log.py", 420),
+    ("src/autoskillit/execution/session_log.py", 419),
     # migration/store.py — failure store dicts
     ("src/autoskillit/migration/store.py", 54),
     ("src/autoskillit/migration/store.py", 64),

--- a/tests/pipeline/test_tokens_core.py
+++ b/tests/pipeline/test_tokens_core.py
@@ -672,11 +672,6 @@ def test_load_from_log_dir_missing_peak_context_defaults_to_zero(tmp_path):
     assert report[0]["turn_count"] == 0
 
 
-# ---------------------------------------------------------------------------
-# L2 orchestrator session label tests
-# ---------------------------------------------------------------------------
-
-
 def test_token_log_record_accepts_resolved_label():
     """record() stores and returns entries keyed by non-recipe labels (e.g. dispatch:id)."""
     log = DefaultTokenLog()

--- a/tests/pipeline/test_tokens_core.py
+++ b/tests/pipeline/test_tokens_core.py
@@ -670,3 +670,46 @@ def test_load_from_log_dir_missing_peak_context_defaults_to_zero(tmp_path):
     report = log.get_report()
     assert report[0]["peak_context"] == 0
     assert report[0]["turn_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# L2 orchestrator session label tests
+# ---------------------------------------------------------------------------
+
+
+def test_token_log_record_accepts_resolved_label():
+    """record() stores and returns entries keyed by non-recipe labels (e.g. dispatch:id)."""
+    log = DefaultTokenLog()
+    log.record(
+        "dispatch:abc-123",
+        {"input_tokens": 100, "output_tokens": 50, "cache_read_input_tokens": 80},
+    )
+    report = log.get_report()
+    assert len(report) == 1
+    assert report[0]["step_name"] == "dispatch:abc-123"
+    assert report[0]["input_tokens"] == 100
+    assert report[0]["cache_read_input_tokens"] == 80
+
+
+def test_load_from_log_dir_restores_orchestrator_sessions(tmp_path):
+    """load_from_log_dir reads token_usage.json written with session_label key (L2 sessions)."""
+    _write_session(
+        tmp_path,
+        "dispatch-s001",
+        {
+            "session_label": "(ad-hoc)",
+            "input_tokens": 200,
+            "output_tokens": 100,
+            "cache_creation_input_tokens": 30,
+            "cache_read_input_tokens": 70,
+            "timing_seconds": 5.0,
+        },
+    )
+    log = DefaultTokenLog()
+    n = log.load_from_log_dir(tmp_path)
+    assert n == 1
+    report = log.get_report()
+    assert len(report) == 1
+    assert report[0]["input_tokens"] == 200
+    assert report[0]["cache_creation_input_tokens"] == 30
+    assert report[0]["cache_read_input_tokens"] == 70

--- a/tests/server/test_tools_execution_results.py
+++ b/tests/server/test_tools_execution_results.py
@@ -165,6 +165,18 @@ class TestRunSkillStepName:
         assert report[0]["input_tokens"] == 200
 
     @pytest.mark.anyio
+    async def test_dispatch_id_env_records_with_dispatch_label(self, tool_ctx, monkeypatch):
+        """step_name='' with AUTOSKILLIT_DISPATCH_ID set records under dispatch:{id} label."""
+        monkeypatch.setenv("AUTOSKILLIT_DISPATCH_ID", "abc-123")
+        tool_ctx.runner.push(_make_result(returncode=1))  # clone guard snapshot (not a git repo)
+        tool_ctx.runner.push(_make_result(returncode=0, stdout=self._make_ndjson()))
+        await run_skill(skill_command="/autoskillit:investigate topic", cwd="/tmp", step_name="")
+        report = tool_ctx.token_log.get_report()
+        assert len(report) == 1
+        assert report[0]["step_name"] == "dispatch:abc-123"
+        assert report[0]["input_tokens"] == 200
+
+    @pytest.mark.anyio
     async def test_null_token_usage_does_not_record(self, tool_ctx):
         # Return NDJSON with no usage field → token_usage will be null
         no_usage_ndjson = json.dumps(

--- a/tests/server/test_tools_execution_results.py
+++ b/tests/server/test_tools_execution_results.py
@@ -155,11 +155,14 @@ class TestRunSkillStepName:
         assert report[0]["input_tokens"] == 200
 
     @pytest.mark.anyio
-    async def test_no_step_name_does_not_record(self, tool_ctx):
+    async def test_no_step_name_records_with_ad_hoc_label(self, tool_ctx):
         tool_ctx.runner.push(_make_result(returncode=1))  # clone guard snapshot (not a git repo)
         tool_ctx.runner.push(_make_result(returncode=0, stdout=self._make_ndjson()))
         await run_skill(skill_command="/autoskillit:investigate topic", cwd="/tmp", step_name="")
-        assert tool_ctx.token_log.get_report() == []
+        report = tool_ctx.token_log.get_report()
+        assert len(report) == 1
+        assert report[0]["step_name"] == "(ad-hoc)"
+        assert report[0]["input_tokens"] == 200
 
     @pytest.mark.anyio
     async def test_null_token_usage_does_not_record(self, tool_ctx):


### PR DESCRIPTION
## Summary

L2 orchestrator sessions silently lose all cache token telemetry because the persistence layer conflates session identity (`step_name`) with write gating. The `flush_session_log()` function gates `token_usage.json` writes on `step_name` being truthy, and L2 sessions always have `step_name=""`. Meanwhile, `sessions.jsonl` only persists `input_tokens` and `output_tokens`, never cache fields. The result: cache data flows correctly through extraction and transformation but is irrecoverably discarded at the persistence boundary.

The architectural weakness is twofold: (1) no TypedDict schema contracts exist for any of the 6+ persisted JSON artifact types, so writer/reader field drift is invisible to the type checker, and (2) the `step_name` parameter is overloaded as both a "session identity label" and a "should we persist telemetry" boolean gate — two orthogonal concerns collapsed into a single falsy-string check.

The proposed solution introduces typed schema contracts for persisted telemetry files, decouples persistence decisions from session identity, and adds a canonical session-label resolution function that guarantees a non-empty label for all session types. This makes the bug class impossible (persistence is gated on data existence, not identity) and makes field drift instantly caught by mypy.

Closes #1798

## Implementation Plan

Plan file: `.autoskillit/temp/rectify/rectify_session_log_l2_cache_token_drop_2026-05-04_154500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|----------|--------|------------|----------|-------|-------------|------|
| investigate | 28 | 5.0k | 356.1k | 84.1k | 75 | 84.0k | 3m 58s |
| rectify | 4.4k | 14.8k | 668.3k | 109.2k | 176 | 53.6k | 10m 26s |
| dry_walkthrough | 49 | 12.3k | 1.8M | 72.3k | 106 | 61.2k | 5m 30s |
| implement | 444 | 31.4k | 4.0M | 99.3k | 156 | 86.6k | 9m 55s |
| prepare_pr | 84 | 5.4k | 329.1k | 41.1k | 23 | 29.0k | 1m 59s |
| compose_pr | 59 | 1.9k | 180.5k | 29.7k | 16 | 16.8k | 54s |
| review_pr | 226 | 76.5k | 1.4M | 93.5k | 93 | 160.3k | 16m 59s |
| resolve_review | 842 | 57.6k | 6.7M | 93.5k | 242 | 226.6k | 28m 36s |
| ci_conflict_fix | 268 | 20.4k | 1.9M | 80.1k | 84 | 67.9k | 6m 21s |
| diagnose_ci | 92 | 3.0k | 380.0k | 48.5k | 24 | 36.2k | 1m 15s |
| resolve_ci | 126 | 4.5k | 590.0k | 47.8k | 41 | 35.1k | 4m 54s |
| **Total** | 6.6k | 232.7k | 18.2M | 109.2k | | 857.3k | 1h 30m |

## Token Efficiency

| Step | LoC Changed | peak_ctx/LoC | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|--------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — | — |
| rectify | 0 | — | — | — | — |
| dry_walkthrough | 0 | — | — | — | — |
| implement | 272 | 365.3 | 14724.5 | 318.5 | 115.5 |
| prepare_pr | 0 | — | — | — | — |
| compose_pr | 0 | — | — | — | — |
| review_pr | 0 | — | — | — | — |
| resolve_review | 51 | 1832.5 | 130755.6 | 4442.8 | 1129.1 |
| ci_conflict_fix | 834 | 96.1 | 2271.8 | 81.5 | 24.4 |
| diagnose_ci | 0 | — | — | — | — |
| resolve_ci | 1 | 47800.0 | 589996.0 | 35060.0 | 4457.0 |
| **Total** | **1158** | 94.3 | 15754.8 | 740.3 | 200.9 |