### PR TITLE
Implementation Plan: [P3-A6-WP1] SkillResult provider fields and to_json() contract tests

### DIFF
--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -2,6 +2,7 @@
 
 import dataclasses
 import json
+from typing import Any, ClassVar
 
 import pytest
 
@@ -414,93 +415,56 @@ class TestSkillResultCrashedFactory:
         assert "subtype" in data
         assert data["subtype"] == "crashed"
 
+    def test_crashed_sets_provider_used_empty_string(self):
+        result = SkillResult.crashed(exception=RuntimeError("boom"))
+        assert result.provider_used == ""
 
-# ---------------------------------------------------------------------------
-# P3-A1-WP1 — provider_used and provider_fallback fields
-# ---------------------------------------------------------------------------
-
-
-def test_skill_result_provider_fields_have_correct_defaults():
-    """provider_used and provider_fallback have correct defaults via dataclasses.fields()."""
-    fields_map = {f.name: f for f in dataclasses.fields(SkillResult)}
-    assert fields_map["provider_used"].default == ""
-    assert fields_map["provider_fallback"].default is False
+    def test_crashed_sets_provider_fallback_false(self):
+        result = SkillResult.crashed(exception=RuntimeError("boom"))
+        assert result.provider_fallback is False
 
 
-def test_skill_result_construction_without_provider_fields():
-    """SkillResult can be constructed without passing provider fields (backward compat)."""
-    sr = SkillResult(
-        success=True,
-        result="ok",
-        session_id="s1",
-        subtype="success",
-        is_error=False,
-        exit_code=0,
-        needs_retry=False,
-        retry_reason=RetryReason.NONE,
-        stderr="",
-    )
-    assert sr.provider_used == ""
-    assert sr.provider_fallback is False
+class TestSkillResultProviderFields:
+    _BASE_KWARGS: ClassVar[dict[str, Any]] = {
+        "success": True,
+        "result": "ok",
+        "session_id": "s1",
+        "subtype": "success",
+        "is_error": False,
+        "exit_code": 0,
+        "needs_retry": False,
+        "retry_reason": RetryReason.NONE,
+        "stderr": "",
+    }
 
+    def test_provider_used_defaults_to_empty_string(self):
+        sr = SkillResult(**self._BASE_KWARGS)
+        assert sr.provider_used == ""
 
-def test_skill_result_to_json_includes_provider_fallback_unconditionally():
-    """provider_fallback appears in JSON even when False (unconditional serialization)."""
-    sr = SkillResult(
-        success=True,
-        result="ok",
-        session_id="s1",
-        subtype="success",
-        is_error=False,
-        exit_code=0,
-        needs_retry=False,
-        retry_reason=RetryReason.NONE,
-        stderr="",
-    )
-    data = json.loads(sr.to_json())
-    assert "provider_fallback" in data
-    assert data["provider_fallback"] is False
+    def test_provider_fallback_defaults_to_false(self):
+        sr = SkillResult(**self._BASE_KWARGS)
+        assert sr.provider_fallback is False
 
+    def test_to_json_includes_provider_used_when_non_empty(self):
+        sr = SkillResult(
+            **self._BASE_KWARGS, provider_used="anthropic-vertex", provider_fallback=True
+        )
+        data = json.loads(sr.to_json())
+        assert data["provider_used"] == "anthropic-vertex"
+        assert data["provider_fallback"] is True
 
-def test_skill_result_to_json_omits_provider_used_when_empty():
-    """provider_used key is absent from JSON when the field is '' (empty string)."""
-    sr = SkillResult(
-        success=True,
-        result="ok",
-        session_id="s1",
-        subtype="success",
-        is_error=False,
-        exit_code=0,
-        needs_retry=False,
-        retry_reason=RetryReason.NONE,
-        stderr="",
-    )
-    data = json.loads(sr.to_json())
-    assert "provider_used" not in data
+    def test_to_json_omits_provider_used_when_empty(self):
+        sr = SkillResult(**self._BASE_KWARGS)
+        data = json.loads(sr.to_json())
+        assert "provider_used" not in data
 
+    def test_to_json_includes_provider_fallback_when_true(self):
+        sr = SkillResult(**self._BASE_KWARGS, provider_fallback=True)
+        data = json.loads(sr.to_json())
+        assert "provider_fallback" in data
+        assert data["provider_fallback"] is True
 
-def test_skill_result_to_json_includes_provider_used_when_set():
-    """provider_used appears in JSON when non-empty string."""
-    sr = SkillResult(
-        success=True,
-        result="ok",
-        session_id="s1",
-        subtype="success",
-        is_error=False,
-        exit_code=0,
-        needs_retry=False,
-        retry_reason=RetryReason.NONE,
-        stderr="",
-        provider_used="anthropic-vertex",
-        provider_fallback=True,
-    )
-    data = json.loads(sr.to_json())
-    assert data["provider_used"] == "anthropic-vertex"
-    assert data["provider_fallback"] is True
-
-
-def test_skill_result_crashed_works_without_provider_fields():
-    """crashed() classmethod still works — inherits provider field defaults."""
-    result = SkillResult.crashed(exception=RuntimeError("boom"))
-    assert result.provider_used == ""
-    assert result.provider_fallback is False
+    def test_provider_used_round_trips_via_json(self):
+        sr = SkillResult(**self._BASE_KWARGS, provider_used="bedrock-us")
+        data = json.loads(sr.to_json())
+        assert data["provider_used"] == "bedrock-us"


### PR DESCRIPTION
## Summary

Add a `TestSkillResultProviderFields` test class and extend `TestSkillResultCrashedFactory` in `tests/core/test_types.py` to validate the `provider_used` and `provider_fallback` fields and their `to_json()` serialization contract. The existing standalone functions from P3-A1-WP1 (lines 418–507) cover overlapping ground; they will be replaced by the new class to avoid redundancy per project standards.

Closes #1778

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260504-160110-440037/.autoskillit/temp/make-plan/p3_a6_wp1_skillresult_provider_fields_plan_2026-05-04_161600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|----------|--------|------------|----------|-------|-------------|------|
| plan | 47 | 9.4k | 412.4k | 45.1k | 27 | 39.6k | 4m 39s |
| verify | 37 | 3.7k | 357.4k | 45.8k | 29 | 34.4k | 2m 16s |
| implement | 168 | 10.5k | 937.1k | 66.3k | 48 | 53.5k | 3m 43s |
| prepare_pr | 68 | 4.3k | 229.0k | 35.5k | 18 | 23.3k | 1m 28s |
| compose_pr | 51 | 1.8k | 150.9k | 29.2k | 14 | 16.2k | 48s |
| **Total** | 371 | 29.7k | 2.1M | 66.3k | | 167.1k | 12m 55s |

## Token Efficiency

| Step | LoC Changed | peak_ctx/LoC | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|--------------|----------------|-----------------|------------|
| plan | 0 | — | — | — | — |
| verify | 0 | — | — | — | — |
| implement | 138 | 480.4 | 6790.9 | 387.8 | 75.8 |
| prepare_pr | 0 | — | — | — | — |
| compose_pr | 0 | — | — | — | — |
| **Total** | **138** | 480.4 | 15121.8 | 1210.7 | 215.3 |