### PR TITLE
Rectify: Token Table Field Coverage Contract

### DIFF
--- a/src/autoskillit/hooks/token_summary_hook.py
+++ b/src/autoskillit/hooks/token_summary_hook.py
@@ -257,8 +257,8 @@ def _format_table(aggregated: dict[str, dict[str, Any]]) -> str:
     lines = [
         "## Token Usage Summary",
         "",
-        "| Step | uncached | output | cache_read | peak_ctx | turns | cache_write | time |",
-        "|------|----------|--------|------------|----------|-------|-------------|------|",
+        "| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |",  # noqa: E501
+        "|------|-------|----------|--------|------------|----------|-------|-------------|------|",
     ]
 
     total_input = 0
@@ -270,6 +270,7 @@ def _format_table(aggregated: dict[str, dict[str, Any]]) -> str:
 
     for entry in aggregated.values():
         name = entry["step_name"]
+        count = entry.get("invocation_count", 1)
         inp = entry["input_tokens"]
         out = entry["output_tokens"]
         cache_rd = entry["cache_read_input_tokens"]
@@ -279,7 +280,7 @@ def _format_table(aggregated: dict[str, dict[str, Any]]) -> str:
         elapsed = entry["elapsed_seconds"]
 
         lines.append(
-            f"| {name} | {_humanize(inp)} | {_humanize(out)} | {_humanize(cache_rd)}"
+            f"| {name} | {count} | {_humanize(inp)} | {_humanize(out)} | {_humanize(cache_rd)}"
             f" | {_humanize(peak_ctx)} | {turns} | {_humanize(cache_wr)}"
             f" | {_fmt_duration(elapsed)} |"
         )
@@ -293,7 +294,7 @@ def _format_table(aggregated: dict[str, dict[str, Any]]) -> str:
         total_time += elapsed
 
     lines.append(
-        f"| **Total** | {_humanize(total_input)} | {_humanize(total_output)}"
+        f"| **Total** | | {_humanize(total_input)} | {_humanize(total_output)}"
         f" | {_humanize(total_cache_rd)} | {_humanize(total_peak)}"
         f" | | {_humanize(total_cache_wr)} | {_fmt_duration(total_time)} |"
     )
@@ -318,31 +319,28 @@ def _format_efficiency_table(aggregated: dict[str, dict[str, Any]]) -> str:
     lines = [
         "## Token Efficiency",
         "",
-        "| Step | LoC Changed | peak_ctx/LoC | cache_read/LoC | cache_write/LoC | output/LoC |",
-        "|------|-------------|--------------|----------------|-----------------|------------|",
+        "| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |",
+        "|------|-------------|----------------|-----------------|------------|",
     ]
-    total_loc = total_peak = total_cr = total_cw = total_out = 0
+    total_loc = total_cr = total_cw = total_out = 0
     for entry in aggregated.values():
         loc = entry.get("loc_insertions", 0) + entry.get("loc_deletions", 0)
-        peak = entry.get("peak_context", 0)
         cr = entry.get("cache_read_input_tokens", 0)
         cw = entry.get("cache_creation_input_tokens", 0)
         out = entry.get("output_tokens", 0)
         lines.append(
             f"| {entry['step_name']} | {loc}"
-            f" | {_ratio(peak, loc)} | {_ratio(cr, loc)}"
+            f" | {_ratio(cr, loc)}"
             f" | {_ratio(cw, loc)} | {_ratio(out, loc)} |"
         )
         total_loc += loc
-        if peak > total_peak:
-            total_peak = peak
         total_cr += cr
         total_cw += cw
         total_out += out
 
     lines.append(
         f"| **Total** | **{total_loc}**"
-        f" | {_ratio(total_peak, total_loc)} | {_ratio(total_cr, total_loc)}"
+        f" | {_ratio(total_cr, total_loc)}"
         f" | {_ratio(total_cw, total_loc)} | {_ratio(total_out, total_loc)} |"
     )
     return "\n".join(lines)

--- a/src/autoskillit/pipeline/telemetry_fmt.py
+++ b/src/autoskillit/pipeline/telemetry_fmt.py
@@ -12,6 +12,7 @@ from autoskillit.core import TerminalColumn, _render_terminal_table
 
 _TOKEN_COLUMNS = (
     TerminalColumn("STEP", max_width=40, align="<"),
+    TerminalColumn("COUNT", max_width=5, align=">"),
     TerminalColumn("UNCACHED", max_width=10, align=">"),
     TerminalColumn("OUTPUT", max_width=10, align=">"),
     TerminalColumn("CACHE_RD", max_width=10, align=">"),
@@ -30,7 +31,6 @@ _TIMING_COLUMNS = (
 _EFFICIENCY_COLUMNS = (
     TerminalColumn("STEP", max_width=40, align="<"),
     TerminalColumn("LOC_CHG", max_width=8, align=">"),
-    TerminalColumn("PK/LOC", max_width=8, align=">"),
     TerminalColumn("RD/LOC", max_width=8, align=">"),
     TerminalColumn("WR/LOC", max_width=8, align=">"),
     TerminalColumn("OUT/LOC", max_width=8, align=">"),
@@ -40,7 +40,6 @@ _EFFICIENCY_COLUMNS = (
 _EFFICIENCY_MD_LABELS: dict[str, str] = {
     "STEP": "Step",
     "LOC_CHG": "LoC Changed",
-    "PK/LOC": "peak_ctx/LoC",
     "RD/LOC": "cache_read/LoC",
     "WR/LOC": "cache_write/LoC",
     "OUT/LOC": "output/LoC",
@@ -52,6 +51,7 @@ _EFFICIENCY_MD_SEP = "|" + "|".join("-" * (len(h) + 2) for h in _eff_md_headers)
 
 _TOKEN_MD_LABELS: dict[str, str] = {
     "STEP": "Step",
+    "COUNT": "count",
     "UNCACHED": "uncached",
     "OUTPUT": "output",
     "CACHE_RD": "cache_read",
@@ -64,6 +64,48 @@ _TOKEN_MD_LABELS: dict[str, str] = {
 _tok_md_headers = [_TOKEN_MD_LABELS[c.label] for c in _TOKEN_COLUMNS]
 _TOKEN_MD_HEADER = "| " + " | ".join(_tok_md_headers) + " |"
 _TOKEN_MD_SEP = "|" + "|".join("-" * (len(h) + 2) for h in _tok_md_headers) + "|"
+
+_TOKEN_DISPLAY_FIELDS: frozenset[str] = frozenset(
+    {
+        "step_name",
+        "input_tokens",
+        "output_tokens",
+        "cache_creation_input_tokens",
+        "cache_read_input_tokens",
+        "invocation_count",
+        "peak_context",
+        "turn_count",
+    }
+)
+
+_TOKEN_EXCLUDED_FIELDS: frozenset[str] = frozenset(
+    {
+        "elapsed_seconds",
+        "loc_insertions",
+        "loc_deletions",
+    }
+)
+
+_TOKEN_FIELD_TO_COLUMN: dict[str, str] = {
+    "step_name": "STEP",
+    "input_tokens": "UNCACHED",
+    "output_tokens": "OUTPUT",
+    "cache_read_input_tokens": "CACHE_RD",
+    "peak_context": "PEAK_CTX",
+    "turn_count": "TURNS",
+    "cache_creation_input_tokens": "CACHE_WR",
+    "invocation_count": "COUNT",
+}
+
+_TIMING_MD_LABELS: dict[str, str] = {
+    "STEP": "Step",
+    "DURATION": "Duration",
+    "INVOCATIONS": "Invocations",
+}
+
+_timing_md_headers = [_TIMING_MD_LABELS[c.label] for c in _TIMING_COLUMNS]
+_TIMING_MD_HEADER = "| " + " | ".join(_timing_md_headers) + " |"
+_TIMING_MD_SEP = "|" + "|".join("-" * (len(h) + 2) for h in _timing_md_headers) + "|"
 
 
 def _ratio(tokens: int, loc: int) -> str:
@@ -113,6 +155,7 @@ class TelemetryFormatter:
         ]
         for step in steps:
             name = step.get("step_name", "?")
+            count = step.get("invocation_count", 1)
             inp = h(step.get("input_tokens", 0))
             out = h(step.get("output_tokens", 0))
             cache_rd = h(step.get("cache_read_input_tokens", 0))
@@ -121,7 +164,7 @@ class TelemetryFormatter:
             cache_wr = h(step.get("cache_creation_input_tokens", 0))
             wc = step.get("wall_clock_seconds", step.get("elapsed_seconds", 0.0))
             lines.append(
-                f"| {name} | {inp} | {out} | {cache_rd} | {peak_ctx}"
+                f"| {name} | {count} | {inp} | {out} | {cache_rd} | {peak_ctx}"
                 f" | {turns} | {cache_wr} | {fmt_dur(wc)} |"
             )
 
@@ -132,7 +175,7 @@ class TelemetryFormatter:
         total_cache_wr = h(total.get("cache_creation_input_tokens", 0))
         total_time = total.get("total_elapsed_seconds", 0.0)
         lines.append(
-            f"| **Total** | {total_in} | {total_out} | {total_cache_rd}"
+            f"| **Total** | | {total_in} | {total_out} | {total_cache_rd}"
             f" | {total_peak} | | {total_cache_wr} | {fmt_dur(total_time)} |"
         )
         return "\n".join(lines)
@@ -145,8 +188,8 @@ class TelemetryFormatter:
         lines = [
             "## Step Timing Summary",
             "",
-            "| Step | Duration | Invocations |",
-            "|------|----------|-------------|",
+            _TIMING_MD_HEADER,
+            _TIMING_MD_SEP,
         ]
         for step in steps:
             name = step.get("step_name", "?")
@@ -164,11 +207,12 @@ class TelemetryFormatter:
         h = TelemetryFormatter._humanize
         fmt_dur = TelemetryFormatter._fmt_duration
 
-        rows: list[tuple[str, str, str, str, str, str, str, str]] = []
+        rows: list[tuple[str, str, str, str, str, str, str, str, str]] = []
         for step in steps:
             rows.append(
                 (
                     step.get("step_name", "?"),
+                    str(step.get("invocation_count", 1)),
                     h(step.get("input_tokens", 0)),
                     h(step.get("output_tokens", 0)),
                     h(step.get("cache_read_input_tokens", 0)),
@@ -181,6 +225,7 @@ class TelemetryFormatter:
 
         total_row = (
             "Total",
+            "",
             h(total.get("input_tokens", 0)),
             h(total.get("output_tokens", 0)),
             h(total.get("cache_read_input_tokens", 0)),
@@ -263,24 +308,22 @@ class TelemetryFormatter:
         ]
         for step in steps:
             loc = step.get("loc_insertions", 0) + step.get("loc_deletions", 0)
-            peak_ctx = step.get("peak_context", 0)
             cr = step.get("cache_read_input_tokens", 0)
             cw = step.get("cache_creation_input_tokens", 0)
             out = step.get("output_tokens", 0)
             lines.append(
                 f"| {step.get('step_name', '?')} | {loc}"
-                f" | {_ratio(peak_ctx, loc)} | {_ratio(cr, loc)}"
+                f" | {_ratio(cr, loc)}"
                 f" | {_ratio(cw, loc)} | {_ratio(out, loc)} |"
             )
 
         total_loc = total.get("loc_insertions", 0) + total.get("loc_deletions", 0)
-        total_peak = total.get("peak_context", 0)
         total_cr = total.get("cache_read_input_tokens", 0)
         total_cw = total.get("cache_creation_input_tokens", 0)
         total_out = total.get("output_tokens", 0)
         lines.append(
             f"| **Total** | **{total_loc}**"
-            f" | {_ratio(total_peak, total_loc)} | {_ratio(total_cr, total_loc)}"
+            f" | {_ratio(total_cr, total_loc)}"
             f" | {_ratio(total_cw, total_loc)} | {_ratio(total_out, total_loc)} |"
         )
         return "\n".join(lines)
@@ -291,10 +334,9 @@ class TelemetryFormatter:
         if not any(s.get("loc_insertions", 0) + s.get("loc_deletions", 0) > 0 for s in steps):
             return ""
 
-        rows: list[tuple[str, str, str, str, str, str]] = []
+        rows: list[tuple[str, str, str, str, str]] = []
         for step in steps:
             loc = step.get("loc_insertions", 0) + step.get("loc_deletions", 0)
-            peak_ctx = step.get("peak_context", 0)
             cr = step.get("cache_read_input_tokens", 0)
             cw = step.get("cache_creation_input_tokens", 0)
             out = step.get("output_tokens", 0)
@@ -302,7 +344,6 @@ class TelemetryFormatter:
                 (
                     step.get("step_name", "?"),
                     str(loc),
-                    _ratio(peak_ctx, loc),
                     _ratio(cr, loc),
                     _ratio(cw, loc),
                     _ratio(out, loc),
@@ -313,7 +354,6 @@ class TelemetryFormatter:
         total_row = (
             "Total",
             str(total_loc),
-            _ratio(total.get("peak_context", 0), total_loc),
             _ratio(total.get("cache_read_input_tokens", 0), total_loc),
             _ratio(total.get("cache_creation_input_tokens", 0), total_loc),
             _ratio(total.get("output_tokens", 0), total_loc),

--- a/tests/hooks/test_token_summary_appender.py
+++ b/tests/hooks/test_token_summary_appender.py
@@ -1026,12 +1026,12 @@ def test_efficiency_table_appended_when_loc_present(tmp_path: Path) -> None:
     body_content = body_arg[len("body=") :]
     assert "## Token Efficiency" in body_content
     assert "cache_read/LoC" in body_content
-    assert "peak_ctx/LoC" in body_content
     assert "cache_write/LoC" in body_content
     assert "output/LoC" in body_content
+    assert "peak_ctx/LoC" not in body_content
     eff_section = body_content[body_content.index("## Token Efficiency") :]
     eff_header = eff_section.split("\n")[2]
-    assert eff_header.count("|") == 7  # 6 columns + outer pipes
+    assert eff_header.count("|") == 6  # 5 columns + outer pipes
 
 
 # T-HOOK-EFF-2

--- a/tests/infra/test_token_summary_core.py
+++ b/tests/infra/test_token_summary_core.py
@@ -550,6 +550,7 @@ def test_token_table_equivalence() -> None:
             "cache_read_input_tokens": 252179,
             "peak_context": 45000,
             "turn_count": 8,
+            "invocation_count": 1,
             "elapsed_seconds": 45.0,
         },
         {
@@ -560,6 +561,7 @@ def test_token_table_equivalence() -> None:
             "cache_read_input_tokens": 19071323,
             "peak_context": 890000,
             "turn_count": 42,
+            "invocation_count": 3,
             "elapsed_seconds": 492.0,
         },
     ]

--- a/tests/pipeline/test_telemetry_formatter.py
+++ b/tests/pipeline/test_telemetry_formatter.py
@@ -667,9 +667,11 @@ def test_token_table_renders_invocation_count() -> None:
         "cache_creation_input_tokens": 10,
         "peak_context": 500,
         "total_elapsed_seconds": 120.0,
+        "invocation_count": 3,
+        "turn_count": 40,
     }
     result = TelemetryFormatter.format_token_table(steps, total)
-    assert "| 3 |" in result or "| 3 " in result, "invocation_count=3 not rendered"
+    assert "| 3 |" in result, "invocation_count=3 not rendered"
 
 
 def test_token_markdown_terminal_column_parity() -> None:

--- a/tests/pipeline/test_telemetry_formatter.py
+++ b/tests/pipeline/test_telemetry_formatter.py
@@ -133,10 +133,10 @@ class TestFormatTokenTable:
             [
                 "## Token Usage Summary",
                 "",
-                "| Step | uncached | output | cache_read | peak_ctx | turns | cache_write | time |",  # noqa: E501
-                "|------|----------|--------|------------|----------|-------|-------------|------|",
-                "| plan | 1.0k | 500 | 200 | 200 | 5 | 100 | 46s |",
-                "| **Total** | 1.0k | 500 | 200 | 200 | | 100 | 46s |",
+                "| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |",  # noqa: E501
+                "|------|-------|----------|--------|------------|----------|-------|-------------|------|",  # noqa: E501
+                "| plan | 1 | 1.0k | 500 | 200 | 200 | 5 | 100 | 46s |",
+                "| **Total** | | 1.0k | 500 | 200 | 200 | | 100 | 46s |",
             ]
         )
         assert result == expected
@@ -236,15 +236,15 @@ def test_format_timing_table_terminal_output_has_leading_indent() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_terminal_table_has_four_token_columns() -> None:
-    """Terminal table must show UNCACHED, CACHE_RD, PEAK_CTX, TURNS, CACHE_WR headers."""
+def test_terminal_table_has_token_columns() -> None:
+    """Terminal table must show COUNT, UNCACHED, CACHE_RD, PEAK_CTX, TURNS, CACHE_WR headers."""
     result = TelemetryFormatter.format_token_table_terminal(_STEPS, _TOTAL)
+    assert "COUNT" in result
     assert "UNCACHED" in result
     assert "CACHE_RD" in result
     assert "PEAK_CTX" in result
     assert "TURNS" in result
     assert "CACHE_WR" in result
-    assert "COUNT" not in result
 
 
 def test_compact_kv_four_token_prefixes() -> None:
@@ -395,11 +395,10 @@ def test_efficiency_table_columns() -> None:
     result = TelemetryFormatter.format_efficiency_table(steps, total)
     assert "## Token Efficiency" in result
     assert "LoC Changed" in result
-    assert "peak_ctx/LoC" in result
     assert "cache_read/LoC" in result
     assert "cache_write/LoC" in result
     assert "output/LoC" in result
-    assert result.split("\n")[2].count("|") == 7  # 6 columns + outer pipes
+    assert result.split("\n")[2].count("|") == 6  # 5 columns + outer pipes
 
 
 # T-EFF-3
@@ -423,8 +422,7 @@ def test_efficiency_table_ratios() -> None:
         "output_tokens": 50,
     }
     result = TelemetryFormatter.format_efficiency_table(steps, total)
-    # loc_changed = 100; peak_ctx/LoC = 10.0; cache_write/LoC = 2.0; output/LoC = 0.5
-    assert "10.0" in result
+    # loc_changed = 100; cache_write/LoC = 2.0; output/LoC = 0.5
     assert "2.0" in result
     assert "0.5" in result
     assert "100" in result  # LoC Changed column
@@ -491,8 +489,8 @@ def test_efficiency_table_total_row_uses_aggregate_totals() -> None:
         "output_tokens": 50,
     }
     result = TelemetryFormatter.format_efficiency_table(steps, total)
-    # Total loc_changed=110; peak_ctx/LoC=1000/110≈9.1
-    assert "9.1" in result
+    # Total loc_changed=110; cache_write/LoC=100/110≈0.9 (aggregate, not per-step average 0.5)
+    assert "0.9" in result
     assert "**Total**" in result
 
 
@@ -519,7 +517,6 @@ def test_efficiency_table_terminal_no_markdown() -> None:
     result = TelemetryFormatter.format_efficiency_table_terminal(steps, total)
     assert "|" not in result  # no markdown pipes
     assert "LOC" in result  # column header present
-    assert "PK/LOC" in result
     assert "RD/LOC" in result
     assert "WR/LOC" in result
     assert "OUT/LOC" in result
@@ -549,11 +546,10 @@ def test_efficiency_table_has_all_ratio_columns() -> None:
     }
     result = TelemetryFormatter.format_efficiency_table(steps, total)
     assert "cache_read/LoC" in result
-    assert "peak_ctx/LoC" in result
     assert "cache_write/LoC" in result
     assert "output/LoC" in result
     header_line = result.split("\n")[2]
-    assert header_line.count("|") == 7  # 6 columns + outer pipes
+    assert header_line.count("|") == 6  # 5 columns + outer pipes
 
 
 # T-EFF-8
@@ -579,7 +575,6 @@ def test_efficiency_table_terminal_has_all_columns() -> None:
         "output_tokens": 50,
     }
     result = TelemetryFormatter.format_efficiency_table_terminal(steps, total)
-    assert "PK/LOC" in result
     assert "RD/LOC" in result
     assert "WR/LOC" in result
     assert "OUT/LOC" in result
@@ -613,3 +608,136 @@ def test_efficiency_markdown_terminal_column_parity() -> None:
     md_header = result.split("\n")[2]
     md_cols = [c.strip() for c in md_header.strip("|").split("|")]
     assert len(md_cols) == len(_EFFICIENCY_COLUMNS)
+
+
+# ---------------------------------------------------------------------------
+# Field coverage contract tests
+# ---------------------------------------------------------------------------
+
+
+def test_token_column_field_coverage() -> None:
+    """Every TokenEntry field must be explicitly assigned to DISPLAY or EXCLUDED."""
+    import dataclasses
+
+    from autoskillit.pipeline.telemetry_fmt import _TOKEN_DISPLAY_FIELDS, _TOKEN_EXCLUDED_FIELDS
+    from autoskillit.pipeline.tokens import TokenEntry
+
+    all_fields = frozenset(f.name for f in dataclasses.fields(TokenEntry))
+    covered = _TOKEN_DISPLAY_FIELDS | _TOKEN_EXCLUDED_FIELDS
+    assert covered == all_fields, (
+        f"Uncovered fields: {all_fields - covered}; Stale exclusions: {covered - all_fields}"
+    )
+
+
+def test_token_display_fields_have_columns() -> None:
+    """Every field in _TOKEN_DISPLAY_FIELDS must have a corresponding _TOKEN_COLUMNS entry."""
+    from autoskillit.pipeline.telemetry_fmt import (
+        _TOKEN_COLUMNS,
+        _TOKEN_DISPLAY_FIELDS,
+        _TOKEN_FIELD_TO_COLUMN,
+    )
+
+    column_labels = frozenset(c.label for c in _TOKEN_COLUMNS)
+    for field in _TOKEN_DISPLAY_FIELDS:
+        target_col = _TOKEN_FIELD_TO_COLUMN[field]
+        assert target_col in column_labels, (
+            f"Field '{field}' maps to column '{target_col}' which is not in _TOKEN_COLUMNS"
+        )
+
+
+def test_token_table_renders_invocation_count() -> None:
+    """Token table must include invocation_count as a visible column."""
+    steps = [
+        {
+            "step_name": "fix",
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_read_input_tokens": 200,
+            "cache_creation_input_tokens": 10,
+            "peak_context": 500,
+            "turn_count": 40,
+            "invocation_count": 3,
+            "wall_clock_seconds": 120.0,
+        }
+    ]
+    total = {
+        "input_tokens": 100,
+        "output_tokens": 50,
+        "cache_read_input_tokens": 200,
+        "cache_creation_input_tokens": 10,
+        "peak_context": 500,
+        "total_elapsed_seconds": 120.0,
+    }
+    result = TelemetryFormatter.format_token_table(steps, total)
+    assert "| 3 |" in result or "| 3 " in result, "invocation_count=3 not rendered"
+
+
+def test_token_markdown_terminal_column_parity() -> None:
+    """Markdown and terminal token tables must have the same number of data columns."""
+    from autoskillit.pipeline.telemetry_fmt import _TOKEN_COLUMNS
+
+    steps = [
+        {
+            "step_name": "plan",
+            "input_tokens": 1000,
+            "output_tokens": 500,
+            "cache_read_input_tokens": 200,
+            "cache_creation_input_tokens": 100,
+            "peak_context": 200,
+            "turn_count": 5,
+            "invocation_count": 1,
+            "wall_clock_seconds": 45.7,
+        }
+    ]
+    total = {
+        "input_tokens": 1000,
+        "output_tokens": 500,
+        "cache_read_input_tokens": 200,
+        "cache_creation_input_tokens": 100,
+        "peak_context": 200,
+        "total_elapsed_seconds": 45.7,
+    }
+    result = TelemetryFormatter.format_token_table(steps, total)
+    md_header = result.split("\n")[2]
+    md_cols = [c.strip() for c in md_header.strip("|").split("|")]
+    assert len(md_cols) == len(_TOKEN_COLUMNS)
+
+
+def test_timing_markdown_terminal_column_parity() -> None:
+    """Timing table markdown header must be derived from _TIMING_COLUMNS."""
+    from autoskillit.pipeline.telemetry_fmt import _TIMING_COLUMNS
+
+    steps = [{"step_name": "plan", "total_seconds": 45.0, "invocation_count": 2}]
+    total = {"total_seconds": 45.0}
+    result = TelemetryFormatter.format_timing_table(steps, total)
+    md_header = result.split("\n")[2]
+    md_cols = [c.strip() for c in md_header.strip("|").split("|")]
+    assert len(md_cols) == len(_TIMING_COLUMNS)
+
+
+def test_efficiency_table_no_peak_ctx_ratio() -> None:
+    """Efficiency table must not contain peak_ctx/LoC — it's a meaningless ratio."""
+    steps = [
+        {
+            "step_name": "fix",
+            "input_tokens": 100,
+            "output_tokens": 500,
+            "cache_read_input_tokens": 2000,
+            "cache_creation_input_tokens": 100,
+            "peak_context": 5000,
+            "loc_insertions": 10,
+            "loc_deletions": 5,
+        }
+    ]
+    total = {
+        "input_tokens": 100,
+        "output_tokens": 500,
+        "cache_read_input_tokens": 2000,
+        "cache_creation_input_tokens": 100,
+        "peak_context": 5000,
+        "loc_insertions": 10,
+        "loc_deletions": 5,
+    }
+    result = TelemetryFormatter.format_efficiency_table(steps, total)
+    assert "peak_ctx/LoC" not in result
+    assert "PK/LOC" not in TelemetryFormatter.format_efficiency_table_terminal(steps, total)


### PR DESCRIPTION
## Summary

The Token Usage Summary table silently dropped the `invocation_count` column because no mechanism enforces that "displayable" fields in the `TokenEntry` data model are actually rendered by the formatter. The data pipeline tracks the field correctly end-to-end, but the rendering layer (`_TOKEN_COLUMNS`) can omit it without any test failing. The architectural fix introduces a **field coverage contract** — a declarative mapping from data model fields to their display columns — enforced by tests that make silent column drops impossible. This same pattern is extended to all telemetry tables and also addresses the timing table's disconnected markdown header and the efficiency table's meaningless `peak_ctx/LoC` column.

## Requirements

1. Restore the `count` column to the Token Usage Summary table in both `TelemetryFormatter.format_token_table()` and the hook's `_format_table()`
2. Update `format_token_table_terminal()` to match
3. Update the snapshot test and remove the `"COUNT" not in result` guard
4. Add a column drift immunity test for the token table (similar to what PR #1828 added for the efficiency table) to prevent future silent column drops
5. Remove the `peak_ctx/LoC` column from the Token Efficiency table. Peak context is a per-session high-water mark, not a cumulative metric — dividing it by lines of code changed is meaningless. The remaining columns (`cache_read/LoC`, `cache_write/LoC`, `output/LoC`) are cumulative-per-output ratios and should be kept.
6. Consider whether the `time` column should show `max(elapsed)` instead of `sum(elapsed)` when `invocation_count > 1`, to better represent wall-clock time for parallel sessions

Closes #1849

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260504-161114-807564/.autoskillit/temp/rectify/rectify_token_table_field_coverage_contract_2026-05-04_161114.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|----------|--------|------------|----------|-------|-------------|------|
| rectify | 72 | 14.0k | 940.3k | 74.8k | 141 | 64.6k | 9m 7s |
| dry_walkthrough | 40 | 11.0k | 1.2M | 70.6k | 67 | 60.7k | 5m 15s |
| implement | 314 | 30.1k | 3.1M | 109.4k | 102 | 96.9k | 8m 38s |
| prepare_pr | 60 | 4.8k | 213.6k | 41.7k | 17 | 29.5k | 1m 21s |
| compose_pr | 51 | 2.5k | 152.3k | 30.2k | 14 | 17.2k | 48s |
| review_pr | 132 | 29.8k | 708.5k | 76.3k | 42 | 64.7k | 6m 58s |
| resolve_review | 229 | 11.7k | 1.2M | 55.3k | 65 | 43.0k | 6m 20s |
| **Total** | 898 | 103.9k | 7.5M | 109.4k | | 376.6k | 38m 29s |

## Token Efficiency

| Step | LoC Changed | peak_ctx/LoC | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|--------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — | — |
| dry_walkthrough | 0 | — | — | — | — |
| implement | 256 | 427.3 | 12037.5 | 378.6 | 117.6 |
| prepare_pr | 0 | — | — | — | — |
| compose_pr | 0 | — | — | — | — |
| review_pr | 0 | — | — | — | — |
| resolve_review | 4 | 13830.5 | 300851.2 | 10742.2 | 2917.5 |
| **Total** | **260** | 420.8 | 28866.7 | 1448.7 | 399.5 |