### PR TITLE
Auto-init git repo in create_worktree

### DIFF
--- a/scripts/recipe/create_worktree.sh
+++ b/scripts/recipe/create_worktree.sh
@@ -12,6 +12,11 @@ VISUALIZATION_PLAN="${6:-}"
 REPORT_PLAN="${7:-}"
 TEMP_NAME="${8:-.autoskillit/temp}"
 
+if [ ! -d "$SOURCE_DIR/.git" ]; then
+  git init -q "$SOURCE_DIR"
+  git -C "$SOURCE_DIR" commit --allow-empty -m "autoskillit: init for research recipe" -q
+fi
+
 BRANCH="research-$(date +%Y%m%d-%H%M%S)"
 WORKTREE_PATH="../worktrees/${BRANCH}"
 git -C "$SOURCE_DIR" worktree add -b "${BRANCH}" "${WORKTREE_PATH}"

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -217,7 +217,8 @@ steps:
     note: >
       Creates the shared worktree and commits the experiment plan and scope report
       to research/ as permanent artifacts. All phases and experiment implementation
-      share this worktree.
+      share this worktree. Auto-initializes a git repo with an empty seed commit
+      when the source directory has no .git directory.
 
   stage_data:
     tool: run_skill

--- a/tests/recipe/test_research_context_tracking.py
+++ b/tests/recipe/test_research_context_tracking.py
@@ -41,6 +41,28 @@ def test_create_worktree_script_emits_research_dir():
     )
 
 
+def test_create_worktree_script_has_git_init_guard():
+    """create_worktree.sh must auto-init a git repo when .git is absent."""
+    script_path = SCRIPTS_DIR / "create_worktree.sh"
+    script = script_path.read_text()
+    assert '[ ! -d "$SOURCE_DIR/.git" ]' in script or "! -d" in script, (
+        "create_worktree.sh must check for .git directory absence"
+    )
+    assert "git init" in script, "create_worktree.sh must run git init when .git is missing"
+    assert "--allow-empty" in script, (
+        "create_worktree.sh must create an empty seed commit for git worktree add"
+    )
+
+
+def test_create_worktree_git_init_guard_precedes_worktree_add():
+    """The git-init guard must appear BEFORE git worktree add."""
+    script_path = SCRIPTS_DIR / "create_worktree.sh"
+    lines = script_path.read_text().splitlines()
+    init_line = next(i for i, ln in enumerate(lines) if "git init" in ln)
+    worktree_line = next(i for i, ln in enumerate(lines) if "worktree add" in ln)
+    assert init_line < worktree_line, "git init guard must be PREPENDED before git worktree add"
+
+
 def test_finalize_bundle_uses_context_research_dir(recipe):
     step = recipe.steps["finalize_bundle"]
     cmd = step.with_args.get("cmd", "")


### PR DESCRIPTION
## Summary

Prepend an idempotent `git init + empty commit` guard to `scripts/recipe/create_worktree.sh` so the research recipe can run in a folder with no pre-existing `.git` directory. Update the YAML step's `note:` block to document this behavior and add a test asserting the guard's presence.

Closes #830

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260504-182801-352418/.autoskillit/temp/make-plan/auto_init_git_repo_in_create_worktree_plan_2026-05-04_182801.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 48 | 4.5k | 490.2k | 50.9k | 36 | 39.9k | 2m 52s |
| verify | 1 | 108 | 6.9k | 501.0k | 47.9k | 31 | 35.0k | 2m 20s |
| implement | 1 | 142 | 4.9k | 667.9k | 48.5k | 40 | 35.7k | 2m 4s |
| prepare_pr | 1 | 68 | 4.1k | 222.2k | 34.2k | 20 | 21.7k | 1m 10s |
| compose_pr | 1 | 51 | 1.8k | 150.7k | 29.2k | 14 | 16.3k | 43s |
| review_pr | 1 | 116 | 9.7k | 528.1k | 47.6k | 39 | 35.2k | 2m 40s |
| **Total** | | 533 | 32.0k | 2.6M | 50.9k | | 183.7k | 11m 51s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 30 | 22263.5 | 1189.1 | 161.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **30** | 85338.8 | 6123.5 | 1066.8 |