### PR TITLE
Planner JSON Artifacts — Add Indent and Task File Path Reference

### DIFF
--- a/src/autoskillit/core/io.py
+++ b/src/autoskillit/core/io.py
@@ -115,7 +115,7 @@ def write_versioned_json(path: Path, payload: dict[str, Any], schema_version: in
     if not isinstance(payload, dict):
         raise TypeError("write_versioned_json requires a dict payload")
     enriched = {**payload, "schema_version": schema_version}
-    atomic_write(path, json.dumps(enriched))
+    atomic_write(path, json.dumps(enriched, indent=2))
 
 
 _AUTOSKILLIT_GITIGNORE_ENTRIES = [

--- a/src/autoskillit/planner/consolidation.py
+++ b/src/autoskillit/planner/consolidation.py
@@ -300,14 +300,15 @@ def consolidate_wps(
             [
                 {"id": wp["id"], "name": wp["name"], "summary": wp.get("summary", "")}
                 for wp in sorted(output_wps, key=lambda w: _natural_sort_key(w["id"]))
-            ]
+            ],
+            indent=2,
         ),
     )
 
     wp_dir = planner_path / "work_packages"
     if wp_dir.exists():
         for wp in output_wps:
-            atomic_write(wp_dir / f"{wp['id']}_result.json", json.dumps(wp))
+            atomic_write(wp_dir / f"{wp['id']}_result.json", json.dumps(wp, indent=2))
         for absorbed_id in non_primary_sources:
             result_file = wp_dir / f"{absorbed_id}_result.json"
             if result_file.exists():

--- a/src/autoskillit/planner/manifests.py
+++ b/src/autoskillit/planner/manifests.py
@@ -267,7 +267,7 @@ def expand_assignments(
         ) from exc
     plan = validate_refined_plan(plan)
     phases = plan.get("phases", [])
-    task = plan.get("task", "")
+    task_file_path: str = str(kwargs.get("task_file_path", ""))
     assign_dir = Path(output_dir) / "assignments"
     assign_dir.mkdir(parents=True, exist_ok=True)
 
@@ -306,7 +306,7 @@ def expand_assignments(
         context: dict[str, object] = {
             "id": phase_id,
             "name": phase.get("name", ""),
-            "task": task,
+            "task_file_path": task_file_path,
             "metadata": metadata,
             "prior_results": [],
         }
@@ -340,7 +340,7 @@ def expand_wps(refined_assignments_path: str, output_dir: str, **kwargs: object)
         ) from exc
     data = validate_refined_assignments(data)
     assignments = data.get("assignments", [])
-    task = data.get("task", "")
+    task_file_path: str = str(kwargs.get("task_file_path", ""))
     out_dir = Path(output_dir)
     wp_dir = out_dir / "work_packages"
     wp_dir.mkdir(parents=True, exist_ok=True)
@@ -398,7 +398,7 @@ def expand_wps(refined_assignments_path: str, output_dir: str, **kwargs: object)
         context: dict[str, object] = {
             "id": phase_id,
             "name": bucket["name"],
-            "task": task,
+            "task_file_path": task_file_path,
             "metadata": metadata,
             "prior_results": [],
             "wp_index_path": str(out_dir / "wp_index.json"),

--- a/src/autoskillit/planner/manifests.py
+++ b/src/autoskillit/planner/manifests.py
@@ -267,7 +267,7 @@ def expand_assignments(
         ) from exc
     plan = validate_refined_plan(plan)
     phases = plan.get("phases", [])
-    task_file_path: str = str(kwargs.get("task_file_path", ""))
+    task_file_path: str = str(kwargs.get("task_file_path") or "")
     assign_dir = Path(output_dir) / "assignments"
     assign_dir.mkdir(parents=True, exist_ok=True)
 
@@ -340,7 +340,7 @@ def expand_wps(refined_assignments_path: str, output_dir: str, **kwargs: object)
         ) from exc
     data = validate_refined_assignments(data)
     assignments = data.get("assignments", [])
-    task_file_path: str = str(kwargs.get("task_file_path", ""))
+    task_file_path: str = str(kwargs.get("task_file_path") or "")
     out_dir = Path(output_dir)
     wp_dir = out_dir / "work_packages"
     wp_dir.mkdir(parents=True, exist_ok=True)

--- a/src/autoskillit/planner/merge.py
+++ b/src/autoskillit/planner/merge.py
@@ -90,7 +90,7 @@ def merge_files(
                 key: existing_items,
             }
             enriched = {**document, "schema_version": 1}
-            payload = json.dumps(enriched).encode()
+            payload = json.dumps(enriched, indent=2).encode()
             fh.seek(0)
             fh.truncate()
             fh.write(payload)
@@ -201,7 +201,7 @@ def replace_item(
                     if item.get("id") == item_id:
                         tier[idx] = replacement
                         enriched = {**data, "schema_version": 1}
-                        payload = json.dumps(enriched).encode()
+                        payload = json.dumps(enriched, indent=2).encode()
                         fh.seek(0)
                         fh.truncate()
                         fh.write(payload)

--- a/src/autoskillit/recipes/planner.yaml
+++ b/src/autoskillit/recipes/planner.yaml
@@ -175,6 +175,7 @@ steps:
       callable: "autoskillit.planner.expand_assignments"
       refined_plan_path: "${{ context.refined_plan_path }}"
       output_dir: "${{ context.planner_dir }}"
+      task_file_path: "${{ context.task_file_path }}"
     capture:
       assignment_context_paths: "${{ result.context_paths }}"
     on_success: elaborate_assignments
@@ -247,6 +248,7 @@ steps:
       callable: "autoskillit.planner.expand_wps"
       refined_assignments_path: "${{ context.refined_assignments_path }}"
       output_dir: "${{ context.planner_dir }}"
+      task_file_path: "${{ context.task_file_path }}"
     capture:
       wp_context_paths: "${{ result.context_paths }}"
     on_success: elaborate_wps

--- a/src/autoskillit/skills_extended/planner-elaborate-assignments/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-assignments/SKILL.md
@@ -59,9 +59,11 @@ Read `$2/phases/{id}_result.json` (the elaborated phase result). Extract:
 - `technical_approach` — overall technical approach for the phase
 - `assignments` — array of assignment objects with `name`, `goal`, `metadata`
 
-Read the `task` field from the context file at $1. Every assignment elaboration — its `goal`,
-`scope`, `deliverables`, and `work_packages_preview` — must serve the stated task. Do not
-elaborate into work not requested by the task.
+Read the `task_file_path` field from the context file at $1, then read the task description
+from disk at that path. Every assignment elaboration — its `goal`, `scope`, `deliverables`,
+and `work_packages_preview` — must serve the stated task. Do not read the full task text
+into the L1 context or embed it in the L0 prompt — pass the path reference only and
+instruct L0s to read the file from disk for scope creep verification.
 
 ### Step 3: Build per-L0 context packets
 

--- a/src/autoskillit/skills_extended/planner-elaborate-wps/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-wps/SKILL.md
@@ -66,9 +66,11 @@ Read all `$2/assignments/P{N}-A*_result.json` matching this phase to get assignm
 - `technical_approach` — assignment technical approach
 - `proposed_work_packages` — the WP decomposition from the assignment pass
 
-Read the `task` field from the context file at $1. Every WP elaboration — its `deliverables`,
-`acceptance_criteria`, and `estimated_files` — must serve the stated task. Do not create WPs
-for work not requested by the task.
+Read the `task_file_path` field from the context file at $1, then read the task description
+from disk at that path. Every WP elaboration — its `deliverables`, `acceptance_criteria`,
+and `estimated_files` — must serve the stated task. Do not read the full task text into the
+L1 context or embed it in the L0 prompt — pass the path reference only and instruct L0s
+to read the file from disk for scope creep verification.
 
 ### Step 3: Build per-L0 context packets
 

--- a/tests/core/test_io.py
+++ b/tests/core/test_io.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
+
+from autoskillit.core.io import write_versioned_json
 
 pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
 
@@ -128,7 +132,6 @@ def test_atomic_write_private_alias_removed():
 
 
 def test_write_versioned_json_enriches_payload_with_schema_version(tmp_path):
-    import json
 
     from autoskillit.core.io import write_versioned_json
 
@@ -140,7 +143,6 @@ def test_write_versioned_json_enriches_payload_with_schema_version(tmp_path):
 def test_write_versioned_json_preserves_existing_keys_atomically(tmp_path, monkeypatch):
     """Asserts the helper routes through ``atomic_write`` (no partial-file
     fallout on a simulated mid-write crash)."""
-    import json
 
     from autoskillit.core import io as io_mod
     from autoskillit.core.io import write_versioned_json
@@ -167,8 +169,6 @@ def test_write_versioned_json_preserves_existing_keys_atomically(tmp_path, monke
 def test_write_versioned_json_rejects_non_dict_payload(tmp_path):
     import pytest
 
-    from autoskillit.core.io import write_versioned_json
-
     target = tmp_path / "bad.json"
     with pytest.raises(TypeError, match="dict payload"):
         write_versioned_json(target, [1, 2, 3], schema_version=1)  # type: ignore[arg-type]
@@ -176,10 +176,6 @@ def test_write_versioned_json_rejects_non_dict_payload(tmp_path):
 
 
 def test_write_versioned_json_produces_indented_output(tmp_path):
-    import json
-
-    from autoskillit.core.io import write_versioned_json
-
     target = tmp_path / "f.json"
     write_versioned_json(target, {"a": 1, "b": [2, 3]}, schema_version=1)
     raw = target.read_text(encoding="utf-8")

--- a/tests/core/test_io.py
+++ b/tests/core/test_io.py
@@ -173,3 +173,16 @@ def test_write_versioned_json_rejects_non_dict_payload(tmp_path):
     with pytest.raises(TypeError, match="dict payload"):
         write_versioned_json(target, [1, 2, 3], schema_version=1)  # type: ignore[arg-type]
     assert not target.exists()
+
+
+def test_write_versioned_json_produces_indented_output(tmp_path):
+    import json
+
+    from autoskillit.core.io import write_versioned_json
+
+    target = tmp_path / "f.json"
+    write_versioned_json(target, {"a": 1, "b": [2, 3]}, schema_version=1)
+    raw = target.read_text(encoding="utf-8")
+    lines = raw.strip().splitlines()
+    assert len(lines) > 1, "Output must be multi-line (indented)"
+    assert json.loads(raw) == {"a": 1, "b": [2, 3], "schema_version": 1}

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -158,7 +158,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/smoke_utils.py", 328),
     ("src/autoskillit/smoke_utils.py", 376),
     # planner/consolidation.py — write-back of merged WP dicts to per-file results
-    ("src/autoskillit/planner/consolidation.py", 310),
+    ("src/autoskillit/planner/consolidation.py", 311),
     # planner/manifests.py — finalize_wp_manifest: wp_index.json rebuild (list payload)
     ("src/autoskillit/planner/manifests.py", 254),
     # _cmd_rpc.py — emit_fallback_map: BEM fallback execution map (recipe-internal)

--- a/tests/planner/test_merge.py
+++ b/tests/planner/test_merge.py
@@ -914,3 +914,13 @@ def test_merge_tier_results_skips_non_assignment_files(tmp_path):
     ids = [a["id"] for a in merged["assignments"]]
     assert "P1-A1" in ids
     assert "P1" not in ids
+
+
+def test_merge_files_produces_indented_output(tmp_path: Path) -> None:
+    out = tmp_path / "combined.json"
+    item = tmp_path / "item.json"
+    item.write_text(json.dumps({"id": "P1", "name": "Phase 1"}))
+    merge_files(file_paths=[str(item)], output_path=str(out), key="phases")
+    raw = out.read_text(encoding="utf-8")
+    lines = raw.strip().splitlines()
+    assert len(lines) > 1, "merge_files output must be multi-line (indented)"

--- a/tests/planner/test_planner.py
+++ b/tests/planner/test_planner.py
@@ -477,9 +477,11 @@ def test_replace_item_does_not_use_atomic_write(
 # --- expand functions propagate task context ---
 
 
-def test_expand_assignments_includes_task_in_context(tmp_path: Path) -> None:
+def test_expand_assignments_includes_task_file_path_in_context(tmp_path: Path) -> None:
     from autoskillit.planner.manifests import expand_assignments
 
+    task_file = tmp_path / "task_input.md"
+    task_file.write_text("Split research.yaml into 4 sub-recipes")
     refined = {
         "task": "Split research.yaml into 4 sub-recipes",
         "phases": [
@@ -492,18 +494,41 @@ def test_expand_assignments_includes_task_in_context(tmp_path: Path) -> None:
     }
     plan_path = tmp_path / "refined_plan.json"
     plan_path.write_text(json.dumps(refined))
-    result = expand_assignments(refined_plan_path=str(plan_path), output_dir=str(tmp_path))
+    result = expand_assignments(
+        refined_plan_path=str(plan_path),
+        output_dir=str(tmp_path),
+        task_file_path=str(task_file),
+    )
     context_paths = [p for p in result["context_paths"].split(",") if p.strip()]
     assert context_paths, "Must produce at least one context path"
     for cp in context_paths:
         context = json.loads(Path(cp).read_text())
-        assert "task" in context, "Context file must include task field"
-        assert context["task"] == "Split research.yaml into 4 sub-recipes"
+        assert "task_file_path" in context, "Context file must include task_file_path field"
+        assert context["task_file_path"] == str(task_file)
+        assert "task" not in context, "Context file must not include inline task text"
 
 
-def test_expand_wps_includes_task_in_context(tmp_path: Path) -> None:
+def test_expand_assignments_without_task_file_path_uses_empty(tmp_path: Path) -> None:
+    from autoskillit.planner.manifests import expand_assignments
+
+    refined = {
+        "task": "Some task",
+        "phases": [{"id": "P1", "name": "Phase", "assignments_preview": [{"name": "A"}]}],
+    }
+    plan_path = tmp_path / "refined_plan.json"
+    plan_path.write_text(json.dumps(refined))
+    result = expand_assignments(refined_plan_path=str(plan_path), output_dir=str(tmp_path))
+    context_paths = [p for p in result["context_paths"].split(",") if p.strip()]
+    for cp in context_paths:
+        context = json.loads(Path(cp).read_text())
+        assert context.get("task_file_path", "") == ""
+
+
+def test_expand_wps_includes_task_file_path_in_context(tmp_path: Path) -> None:
     from autoskillit.planner.manifests import expand_wps
 
+    task_file = tmp_path / "task_input.md"
+    task_file.write_text("Add telemetry to fleet dispatch")
     refined = {
         "schema_version": 2,
         "task": "Add telemetry to fleet dispatch",
@@ -531,10 +556,15 @@ def test_expand_wps_includes_task_in_context(tmp_path: Path) -> None:
     }
     plan_path = tmp_path / "refined_assignments.json"
     plan_path.write_text(json.dumps(refined))
-    result = expand_wps(refined_assignments_path=str(plan_path), output_dir=str(tmp_path))
+    result = expand_wps(
+        refined_assignments_path=str(plan_path),
+        output_dir=str(tmp_path),
+        task_file_path=str(task_file),
+    )
     context_paths = [p for p in result["context_paths"].split(",") if p.strip()]
     assert context_paths, "Must produce at least one context path"
     for cp in context_paths:
         context = json.loads(Path(cp).read_text())
-        assert "task" in context, "Context file must include task field"
-        assert context["task"] == "Add telemetry to fleet dispatch"
+        assert "task_file_path" in context, "Context file must include task_file_path field"
+        assert context["task_file_path"] == str(task_file)
+        assert "task" not in context, "Context file must not include inline task text"

--- a/tests/planner/test_planner.py
+++ b/tests/planner/test_planner.py
@@ -519,9 +519,11 @@ def test_expand_assignments_without_task_file_path_uses_empty(tmp_path: Path) ->
     plan_path.write_text(json.dumps(refined))
     result = expand_assignments(refined_plan_path=str(plan_path), output_dir=str(tmp_path))
     context_paths = [p for p in result["context_paths"].split(",") if p.strip()]
+    assert context_paths, "Must produce at least one context path"
     for cp in context_paths:
         context = json.loads(Path(cp).read_text())
         assert context.get("task_file_path", "") == ""
+        assert "task" not in context, "Context file must not include inline task text"
 
 
 def test_expand_wps_includes_task_file_path_in_context(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Planner JSON artifacts are written as single-line blobs via `write_versioned_json` (`core/io.py`), making the Read tool's `limit:` parameter useless (it operates on lines). This forces every planner session to fall back to `python3 -c` or `jq`, wasting 2-4 turns per file access (~80 wasted turns over 3 days across 145 sessions).

Two changes fix this: (1) add `indent=2` to all planner JSON serialization so `limit:` pagination becomes functional, and (2) replace inline `"task": task` with `"task_file_path": task_file_path` in `expand_assignments` and `expand_wps` context files to eliminate 50–80% of context file size for task-heavy plans.

Closes #1851

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260504-190704-131062/.autoskillit/temp/make-plan/planner_json_indent_and_task_ref_plan_2026-05-04_192600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 58 | 14.5k | 1.1M | 66.4k | 140 | 73.3k | 8m 23s |
| verify | 1 | 220 | 20.3k | 1.7M | 83.8k | 77 | 70.9k | 5m 55s |
| implement | 1 | 292 | 16.1k | 1.8M | 67.2k | 120 | 54.4k | 6m 27s |
| prepare_pr | 1 | 68 | 5.0k | 241.6k | 39.8k | 21 | 27.5k | 1m 33s |
| compose_pr | 1 | 51 | 2.0k | 152.0k | 29.7k | 14 | 16.8k | 43s |
| review_pr | 1 | 126 | 20.4k | 705.7k | 69.2k | 46 | 57.5k | 11m 14s |
| resolve_review | 1 | 281 | 14.7k | 1.6M | 71.8k | 85 | 59.2k | 8m 12s |
| **Total** | | 1.1k | 93.0k | 7.4M | 83.8k | | 359.6k | 42m 28s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 106 | 17390.8 | 513.3 | 152.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 18 | 91103.4 | 3288.7 | 818.1 |
| **Total** | **124** | 59530.8 | 2900.2 | 750.3 |