### PR TITLE
Planner Artifact Path Inconsistency and SKILL.md Schema Contradictions

### DIFF
--- a/src/autoskillit/planner/consolidation.py
+++ b/src/autoskillit/planner/consolidation.py
@@ -213,7 +213,7 @@ def consolidate_wps(
 
     Reads manifests from ``{planner_dir}/work_packages/consolidation/``.
     Writes ``{planner_dir}/consolidated_wps.json`` and rebuilds
-    ``{planner_dir}/wp_index.json``. Returns a result dict with string values.
+    ``{planner_dir}/work_packages/wp_index.json``. Returns a result dict with string values.
     """
     try:
         wps_doc: dict[str, Any] = json.loads(Path(refined_wps_path).read_text())

--- a/src/autoskillit/planner/consolidation.py
+++ b/src/autoskillit/planner/consolidation.py
@@ -293,7 +293,7 @@ def consolidate_wps(
     )
 
     # Rebuild wp_index.json as a sorted list (ListComp arg keeps AST scan from flagging as dict)
-    wp_index_path = planner_path / "wp_index.json"
+    wp_index_path = planner_path / "work_packages" / "wp_index.json"
     atomic_write(
         wp_index_path,
         json.dumps(

--- a/src/autoskillit/planner/manifests.py
+++ b/src/autoskillit/planner/manifests.py
@@ -199,7 +199,7 @@ def build_phase_wp_manifest(
     }
     manifest_path = out_dir / "phase_wp_manifest.json"
     write_versioned_json(manifest_path, manifest, schema_version=1)
-    atomic_write(out_dir / "wp_index.json", "[]")
+    atomic_write(wp_dir / "wp_index.json", "[]")
     return {"manifest_path": str(manifest_path), "total_count": str(len(items))}
 
 
@@ -210,7 +210,6 @@ def finalize_wp_manifest(work_packages_dir: str, output_dir: str) -> dict[str, s
     wp_dir = Path(work_packages_dir)
     if not wp_dir.is_dir():
         raise FileNotFoundError(f"work_packages_dir does not exist: {wp_dir}")
-    out_dir = Path(output_dir)
 
     result_files = sorted(
         (f for f in wp_dir.glob("*_result.json") if WP_RESULT_FILE_RE.match(f.name)),
@@ -249,9 +248,9 @@ def finalize_wp_manifest(work_packages_dir: str, output_dir: str) -> dict[str, s
         "created_at": datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "items": items,
     }
-    manifest_path = out_dir / "wp_manifest.json"
+    manifest_path = wp_dir / "wp_manifest.json"
     write_versioned_json(manifest_path, manifest, schema_version=1)
-    atomic_write(out_dir / "wp_index.json", json.dumps(index_entries, indent=2))
+    atomic_write(wp_dir / "wp_index.json", json.dumps(index_entries, indent=2))
     return {"manifest_path": str(manifest_path), "total_count": str(len(items))}
 
 
@@ -401,7 +400,7 @@ def expand_wps(refined_assignments_path: str, output_dir: str, **kwargs: object)
             "task": task,
             "metadata": metadata,
             "prior_results": [],
-            "wp_index_path": str(out_dir / "wp_index.json"),
+            "wp_index_path": str(wp_dir / "wp_index.json"),
         }
         ctx_path = wp_dir / f"context_{phase_id}.json"
         write_versioned_json(ctx_path, context, schema_version=1)
@@ -418,7 +417,7 @@ def expand_wps(refined_assignments_path: str, output_dir: str, **kwargs: object)
     }
     manifest_path = out_dir / "phase_wp_manifest.json"
     write_versioned_json(manifest_path, manifest, schema_version=1)
-    atomic_write(out_dir / "wp_index.json", "[]")
+    atomic_write(wp_dir / "wp_index.json", "[]")
     return {
         "manifest_path": str(manifest_path),
         "context_paths": ",".join(context_paths),

--- a/src/autoskillit/skills_extended/planner-consolidate-wps/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-consolidate-wps/SKILL.md
@@ -62,8 +62,8 @@ Read `$1` (refined_wps.json). Parse as a PlanDocument. Extract all WP entries fr
 FATAL: failed to parse {path}: {error_detail}
 ```
 
-Group WPs by phase_id (extracted from the `phase_id` field, or from the `id` prefix
-`P{N}-`). Build a map `phase_id → [WPElaborated, ...]`.
+Group WPs by `phase_id` (always populated; read directly from the field).
+Build a map `phase_id → [WPElaborated, ...]`.
 
 ### Step 2: Create output directory
 

--- a/src/autoskillit/skills_extended/planner-elaborate-assignments/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-assignments/SKILL.md
@@ -141,7 +141,7 @@ For each failed L0, write `$2/assignments/{assignment_id}_result.json` with:
 }
 ```
 
-After writing all assignment files, update `$2/wp_index.json` by appending compact entries
+After writing all assignment files, update `$2/work_packages/wp_index.json` by appending compact entries
 for all **successful** results only (skip stubs). Read the current index, append, and write back
 atomically. L1 is the sole writer for this phase's assignments — no concurrent writes.
 

--- a/src/autoskillit/skills_extended/planner-elaborate-wps/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-elaborate-wps/SKILL.md
@@ -144,7 +144,7 @@ For each failed L0, write `$2/work_packages/{wp_id}_result.json` with:
 }
 ```
 
-After writing all WP files, update `$2/wp_index.json` by appending compact entries
+After writing all WP files, update `$2/work_packages/wp_index.json` by appending compact entries
 for all **successful** results only (skip stubs). Read the current index, append, and write back
 atomically. L1 is the sole writer for this phase's WPs — no concurrent writes.
 

--- a/src/autoskillit/skills_extended/planner-refine-wps/SKILL.md
+++ b/src/autoskillit/skills_extended/planner-refine-wps/SKILL.md
@@ -104,7 +104,7 @@ Read the `task` field from the combined WPs document. Each L0 subagent reviewing
 WPs must verify that every WP's deliverables and scope serve the stated task. Flag WPs
 whose deliverables address concerns not mentioned in the task as scope creep.
 
-Group WPs by `phase_id` (extracted from `id` prefix, e.g., `P1-A1-WP1` → `P1`).
+Group WPs by `phase_id` (always populated; read directly from the field).
 For each phase, build a context packet containing:
 - The full serialized `combined_wps.json` content (all WPs visible for cross-phase awareness)
 - The `PhaseElaborated` entry for the phase from `$2`

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -160,7 +160,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # planner/consolidation.py — write-back of merged WP dicts to per-file results
     ("src/autoskillit/planner/consolidation.py", 310),
     # planner/manifests.py — finalize_wp_manifest: wp_index.json rebuild (list payload)
-    ("src/autoskillit/planner/manifests.py", 254),
+    ("src/autoskillit/planner/manifests.py", 253),
     # _cmd_rpc.py — emit_fallback_map: BEM fallback execution map (recipe-internal)
     ("src/autoskillit/recipe/_cmd_rpc.py", 445),
 }

--- a/tests/planner/test_consolidation.py
+++ b/tests/planner/test_consolidation.py
@@ -50,7 +50,7 @@ def test_passthrough_unchanged_when_no_manifests(tmp_path: Path) -> None:
         "P1-A1-WP2",
         "P1-A1-WP3",
     }
-    index = json.loads((tmp_path / "wp_index.json").read_text())
+    index = json.loads((tmp_path / "work_packages" / "wp_index.json").read_text())
     assert {e["id"] for e in index} == {"P1-A1-WP1", "P1-A1-WP2", "P1-A1-WP3"}
     # consolidate_wps returns str values (compatible with run_python result passing)
     assert result["total_count"] == "3"
@@ -297,7 +297,7 @@ def test_wp_index_rebuilt_with_merged_ids(tmp_path: Path) -> None:
 
     consolidate_wps(refined_wps_path=str(refined_path), planner_dir=str(tmp_path))
 
-    index = json.loads((tmp_path / "wp_index.json").read_text())
+    index = json.loads((tmp_path / "work_packages" / "wp_index.json").read_text())
     assert len(index) == 2
     merged_entry = next(e for e in index if e["id"] == "P1-A1-WP1")
     assert merged_entry["id"] == "P1-A1-WP1"
@@ -796,3 +796,14 @@ def test_consolidate_then_compile_emits_correct_issue_count(tmp_path: Path) -> N
     merged_issue = (issues_dir / "P1-A1-WP1_issue.md").read_text()
     assert "src/mod_P1-A1-WP1.py" in merged_issue
     assert "src/mod_P1-A1-WP2.py" in merged_issue
+
+
+def test_consolidate_wps_wp_index_in_work_packages(tmp_path: Path) -> None:
+    """Rebuilt wp_index.json must land in work_packages/, not planner root."""
+    wps = [make_wp_result("P1-A1-WP1")]
+    refined_path = _make_refined_wps(tmp_path, wps)
+
+    consolidate_wps(refined_wps_path=str(refined_path), planner_dir=str(tmp_path))
+
+    assert (tmp_path / "work_packages" / "wp_index.json").exists()
+    assert not (tmp_path / "wp_index.json").exists()

--- a/tests/planner/test_manifests.py
+++ b/tests/planner/test_manifests.py
@@ -238,7 +238,7 @@ def test_build_phase_wp_manifest_initializes_wp_index(tmp_path):
 
     build_phase_wp_manifest(str(assignments_dir), str(output_dir))
 
-    wp_index = output_dir / "wp_index.json"
+    wp_index = output_dir / "work_packages" / "wp_index.json"
     assert wp_index.exists()
     assert json.loads(wp_index.read_text()) == []
 
@@ -388,7 +388,7 @@ def test_finalize_wp_manifest_regenerates_wp_index(tmp_path):
 
     finalize_wp_manifest(str(wp_dir), str(output_dir))
 
-    index = json.loads((output_dir / "wp_index.json").read_text())
+    index = json.loads((wp_dir / "wp_index.json").read_text())
     assert len(index) == 3
     ids = [e["id"] for e in index]
     assert ids == ["P1-A1-WP1", "P1-A2-WP1", "P2-A1-WP1"]
@@ -626,3 +626,67 @@ def test_expand_wps_result_dir_points_to_wp_sentinels(tmp_path):
     manifest = json.loads(Path(result["manifest_path"]).read_text())
     assert manifest["result_dir"].endswith("wp_sentinels")
     assert (tmp_path / "work_packages" / "wp_sentinels").is_dir()
+
+
+def test_finalize_wp_manifest_writes_to_work_packages_dir(tmp_path):
+    """wp_manifest.json must be written inside work_packages_dir, not output_dir."""
+    from autoskillit.planner import finalize_wp_manifest
+
+    wp_dir = tmp_path / "work_packages"
+    wp_dir.mkdir()
+    (wp_dir / "P1-A1-WP1_result.json").write_text(json.dumps(make_wp_result("P1-A1-WP1")))
+
+    result = finalize_wp_manifest(str(wp_dir), str(tmp_path))
+
+    assert (wp_dir / "wp_manifest.json").exists()
+    assert not (tmp_path / "wp_manifest.json").exists()
+    assert "work_packages" in result["manifest_path"]
+
+
+def test_finalize_wp_manifest_writes_wp_index_to_work_packages_dir(tmp_path):
+    """wp_index.json must be written inside work_packages_dir, not output_dir."""
+    from autoskillit.planner import finalize_wp_manifest
+
+    wp_dir = tmp_path / "work_packages"
+    wp_dir.mkdir()
+    (wp_dir / "P1-A1-WP1_result.json").write_text(json.dumps(make_wp_result("P1-A1-WP1")))
+
+    finalize_wp_manifest(str(wp_dir), str(tmp_path))
+
+    assert (wp_dir / "wp_index.json").exists()
+    assert not (tmp_path / "wp_index.json").exists()
+
+
+def test_expand_wps_wp_index_path_in_work_packages(tmp_path):
+    """wp_index.json and context wp_index_path must point to work_packages/."""
+    from autoskillit.planner import expand_wps
+
+    refined = {
+        "task": "test",
+        "assignments": [
+            {
+                "id": "P1-A1",
+                "name": "Assignment 1",
+                "phase_id": "P1",
+                "phase_name": "Phase 1",
+                "goal": "test",
+                "technical_approach": "test",
+                "proposed_work_packages": [
+                    {"id_suffix": "WP1", "name": "WP1", "scope": "s", "estimated_files": ["f.py"]}
+                ],
+            }
+        ],
+    }
+    ra_path = tmp_path / "refined_assignments.json"
+    ra_path.write_text(json.dumps(refined))
+
+    expand_wps(str(ra_path), str(tmp_path))
+
+    wp_dir = tmp_path / "work_packages"
+    assert (wp_dir / "wp_index.json").exists()
+    assert not (tmp_path / "wp_index.json").exists()
+
+    ctx_files = list(wp_dir.glob("context_*.json"))
+    assert len(ctx_files) >= 1
+    ctx = json.loads(ctx_files[0].read_text())
+    assert "work_packages" in ctx["wp_index_path"]

--- a/tests/planner/test_schema_conformance.py
+++ b/tests/planner/test_schema_conformance.py
@@ -341,3 +341,19 @@ def test_tier_filename_regexes_match_expected_patterns() -> None:
         assert not PHASE_RESULT_FILE_RE.match(name)
         assert not ASSIGN_RESULT_FILE_RE.match(name)
         assert not WP_RESULT_FILE_RE.match(name)
+
+
+def test_refine_wps_skill_md_no_prefix_derivation_instruction() -> None:
+    """planner-refine-wps SKILL.md must not instruct derivation from id prefix."""
+    skill_md = Path("src/autoskillit/skills_extended/planner-refine-wps/SKILL.md")
+    content = skill_md.read_text()
+    assert "extracted from `id` prefix" not in content
+    assert "extracted from id prefix" not in content
+
+
+def test_consolidate_wps_skill_md_no_ambiguous_phase_id() -> None:
+    """planner-consolidate-wps SKILL.md must not offer dual-source phase_id."""
+    skill_md = Path("src/autoskillit/skills_extended/planner-consolidate-wps/SKILL.md")
+    content = skill_md.read_text()
+    assert "or from the `id` prefix" not in content
+    assert "or from the id prefix" not in content

--- a/tests/planner/test_validation.py
+++ b/tests/planner/test_validation.py
@@ -628,3 +628,15 @@ def test_deduplication_orphan_cascade(tmp_path: Path) -> None:
     sizing_findings = [f for f in validation["findings"] if f["check"] == "sizing_bounds"]
     assert len(sizing_findings) == 1
     assert "P1-A1-WP2" in sizing_findings[0]["message"]
+
+
+def test_validate_plan_reads_finalized_manifest(tmp_path: Path) -> None:
+    """validate_plan must find wp_manifest.json written by finalize_wp_manifest."""
+    from autoskillit.planner import finalize_wp_manifest
+
+    _make_minimal_output_dir(tmp_path)
+    wp_dir = tmp_path / "work_packages"
+    finalize_wp_manifest(str(wp_dir), str(tmp_path))
+
+    result = validate_plan(str(tmp_path))
+    assert result["verdict"] == "pass"


### PR DESCRIPTION
## Summary

The planner pipeline has two classes of defects causing ~40 wasted turns across 12 headless sessions:

**A) Artifact path inconsistency:** `wp_index.json` and `wp_manifest.json` are written to `{planner_dir}/` (root) by Python code but read from `{planner_dir}/work_packages/` by `validation.py` and SKILL.md instructions. This causes ENOENT failures and discovery loops.

**B) Schema contradictions:** `planner-refine-wps/SKILL.md` shows `phase_id` as a populated field in the schema block (line 83) then tells agents to derive it from the ID prefix (line 107). `planner-consolidate-wps/SKILL.md` gives ambiguous dual-source guidance. Since `WPElaborated.phase_id` is always populated by `validate_*` functions, the derivation instructions are wrong.

**Fix:** Normalize all `wp_index.json` and `wp_manifest.json` writes to `{planner_dir}/work_packages/`, update SKILL.md references and context dicts for consistency, and correct schema documentation.

Closes #1853

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260504-190703-406335/.autoskillit/temp/make-plan/planner_artifact_path_inconsistency_plan_2026-05-04_192500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 5.2k | 15.8k | 1.2M | 73.4k | 149 | 60.3k | 8m 57s |
| verify | 1 | 84 | 15.6k | 396.4k | 54.8k | 56 | 44.2k | 5m 49s |
| implement | 1 | 2.3k | 29.6k | 3.9M | 107.9k | 137 | 95.2k | 13m 23s |
| prepare_pr | 1 | 68 | 3.8k | 239.0k | 37.8k | 18 | 25.6k | 1m 10s |
| compose_pr | 1 | 51 | 2.2k | 152.1k | 29.9k | 14 | 17.0k | 48s |
| review_pr | 1 | 60 | 2.6k | 235.5k | 45.2k | 25 | 32.0k | 8m 18s |
| **Total** | | 7.8k | 69.5k | 6.1M | 107.9k | | 274.4k | 38m 26s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 136 | 28776.2 | 700.0 | 217.3 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **136** | 44784.1 | 2017.3 | 511.0 |