### PR TITLE
Rectify: Turn Tracker Produces Empty Tool Call Arrays with Extended Thinking

### DIFF
--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -67,6 +67,7 @@ from .runtime.session_registry import registry_path as registry_path
 from .runtime.session_registry import write_registry_entry as write_registry_entry
 from .tool_sequence_analysis import DFG as DFG
 from .tool_sequence_analysis import AnalysisResult as AnalysisResult
+from .tool_sequence_analysis import AssistantTurn as AssistantTurn
 from .tool_sequence_analysis import GapStats as GapStats
 from .tool_sequence_analysis import TurnSequence as TurnSequence
 from .tool_sequence_analysis import build_dfg as build_dfg
@@ -75,6 +76,7 @@ from .tool_sequence_analysis import compute_analysis as compute_analysis
 from .tool_sequence_analysis import compute_gap_stats as compute_gap_stats
 from .tool_sequence_analysis import filter_sessions_by_recipe as filter_sessions_by_recipe
 from .tool_sequence_analysis import format_top_bigrams as format_top_bigrams
+from .tool_sequence_analysis import iter_merged_assistant_turns as iter_merged_assistant_turns
 from .tool_sequence_analysis import parse_raw_cc_jsonl as parse_raw_cc_jsonl
 from .tool_sequence_analysis import (
     parse_sessions_from_summary_dir as parse_sessions_from_summary_dir,

--- a/src/autoskillit/core/tool_sequence_analysis.py
+++ b/src/autoskillit/core/tool_sequence_analysis.py
@@ -4,13 +4,20 @@ import json
 import pathlib
 import statistics
 import sys
-from collections import Counter
+from collections import Counter, OrderedDict
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass, field
 from itertools import islice
+from typing import NamedTuple
 
 _TOOL_USE_CAP = 8
 _MAX_NGRAM_LEN = 5
+
+
+class AssistantTurn(NamedTuple):
+    request_id: str
+    timestamp: str
+    tool_names: list[str]
 
 
 @dataclass
@@ -44,14 +51,23 @@ class AnalysisResult:
     session_count: int
 
 
-def parse_raw_cc_jsonl(jsonl_path: pathlib.Path, *, cap: int = _TOOL_USE_CAP) -> list[list[str]]:
-    """Parse a Claude Code session JSONL into per-turn tool call lists."""
-    result: list[list[str]] = []
-    seen: set[str] = set()
-    try:
-        text = jsonl_path.read_text(encoding="utf-8", errors="replace")
-    except OSError:
-        return result
+def iter_merged_assistant_turns(text: str, *, cap: int = _TOOL_USE_CAP) -> Iterator[AssistantTurn]:
+    """Yield one AssistantTurn per logical assistant turn, merging across records.
+
+    When multiple JSONL records share the same requestId (e.g., extended thinking
+    emits a thinking-only record followed by a tool-bearing record), tool calls
+    are accumulated across all records for that requestId. The cap is applied
+    after accumulation.
+
+    Records without a requestId are yielded individually (no dedup possible).
+    Turns are yielded in the order their requestId (or no-rid record) was first
+    encountered — preserving file-order interleaving for correct DFG bigram analysis.
+    """
+    pending: OrderedDict[str, tuple[str, list[str]]] = OrderedDict()
+    insertion_order: list[tuple[str, str]] = []
+    no_rid_turns: dict[str, AssistantTurn] = {}
+    no_rid_counter = 0
+
     for raw_line in text.splitlines():
         raw_line = raw_line.strip()
         if not raw_line:
@@ -62,11 +78,9 @@ def parse_raw_cc_jsonl(jsonl_path: pathlib.Path, *, cap: int = _TOOL_USE_CAP) ->
             continue
         if not isinstance(rec, dict) or rec.get("type") != "assistant":
             continue
+
         rid = rec.get("requestId", "")
-        if rid and rid in seen:
-            continue
-        if rid:
-            seen.add(rid)
+        ts = rec.get("timestamp", "")
         message = rec.get("message")
         content = message.get("content", []) if isinstance(message, dict) else []
         tools = [
@@ -77,8 +91,35 @@ def parse_raw_cc_jsonl(jsonl_path: pathlib.Path, *, cap: int = _TOOL_USE_CAP) ->
             and isinstance(blk.get("name"), str)
             and blk["name"]
         ]
-        result.append(tools[:cap])
-    return result
+
+        if rid:
+            if rid in pending:
+                existing_ts, existing_tools = pending[rid]
+                pending[rid] = (existing_ts or ts, existing_tools + tools)
+            else:
+                pending[rid] = (ts, tools)
+                insertion_order.append(("rid", rid))
+        else:
+            key = str(no_rid_counter)
+            no_rid_counter += 1
+            no_rid_turns[key] = AssistantTurn("", ts, tools[:cap])
+            insertion_order.append(("no_rid", key))
+
+    for kind, key in insertion_order:
+        if kind == "rid":
+            ts, tools = pending[key]
+            yield AssistantTurn(key, ts, tools[:cap])
+        else:
+            yield no_rid_turns[key]
+
+
+def parse_raw_cc_jsonl(jsonl_path: pathlib.Path, *, cap: int = _TOOL_USE_CAP) -> list[list[str]]:
+    """Parse a Claude Code session JSONL into per-turn tool call lists."""
+    try:
+        text = jsonl_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+    return [turn.tool_names for turn in iter_merged_assistant_turns(text, cap=cap)]
 
 
 def parse_sessions_from_summary_dir(log_root: pathlib.Path) -> Iterator[TurnSequence]:

--- a/src/autoskillit/core/tool_sequence_analysis.py
+++ b/src/autoskillit/core/tool_sequence_analysis.py
@@ -14,7 +14,7 @@ from .logging import get_logger
 
 _TOOL_USE_CAP = 8
 _MAX_NGRAM_LEN = 5
-_log = get_logger(__name__)
+logger = get_logger(__name__)
 
 
 class AssistantTurn(NamedTuple):
@@ -123,7 +123,7 @@ def parse_raw_cc_jsonl(
     try:
         text = jsonl_path.read_text(encoding="utf-8", errors="replace")
     except OSError:
-        _log.debug("parse_raw_cc_jsonl: cannot read %s", jsonl_path, exc_info=True)
+        logger.debug("parse_raw_cc_jsonl: cannot read %s", jsonl_path, exc_info=True)
         return []
     return [turn.tool_names for turn in iter_merged_assistant_turns(text, cap=cap)]
 

--- a/src/autoskillit/core/tool_sequence_analysis.py
+++ b/src/autoskillit/core/tool_sequence_analysis.py
@@ -10,14 +10,17 @@ from dataclasses import dataclass, field
 from itertools import islice
 from typing import NamedTuple
 
+from .logging import get_logger
+
 _TOOL_USE_CAP = 8
 _MAX_NGRAM_LEN = 5
+_log = get_logger(__name__)
 
 
 class AssistantTurn(NamedTuple):
     request_id: str
     timestamp: str
-    tool_names: list[str]
+    tool_names: tuple[str, ...]
 
 
 @dataclass
@@ -102,22 +105,25 @@ def iter_merged_assistant_turns(text: str, *, cap: int = _TOOL_USE_CAP) -> Itera
         else:
             key = str(no_rid_counter)
             no_rid_counter += 1
-            no_rid_turns[key] = AssistantTurn("", ts, tools[:cap])
+            no_rid_turns[key] = AssistantTurn("", ts, tuple(tools[:cap]))
             insertion_order.append(("no_rid", key))
 
     for kind, key in insertion_order:
         if kind == "rid":
             ts, tools = pending[key]
-            yield AssistantTurn(key, ts, tools[:cap])
+            yield AssistantTurn(key, ts, tuple(tools[:cap]))
         else:
             yield no_rid_turns[key]
 
 
-def parse_raw_cc_jsonl(jsonl_path: pathlib.Path, *, cap: int = _TOOL_USE_CAP) -> list[list[str]]:
+def parse_raw_cc_jsonl(
+    jsonl_path: pathlib.Path, *, cap: int = _TOOL_USE_CAP
+) -> list[tuple[str, ...]]:
     """Parse a Claude Code session JSONL into per-turn tool call lists."""
     try:
         text = jsonl_path.read_text(encoding="utf-8", errors="replace")
     except OSError:
+        _log.debug("parse_raw_cc_jsonl: cannot read %s", jsonl_path, exc_info=True)
         return []
     return [turn.tool_names for turn in iter_merged_assistant_turns(text, cap=cap)]
 

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 import psutil
 
 from autoskillit.core import atomic_write, claude_code_log_path, get_logger
+from autoskillit.core.tool_sequence_analysis import iter_merged_assistant_turns
 from autoskillit.execution.anomaly_detection import (
     detect_anomalies,
     detect_identity_drift,
@@ -191,36 +192,14 @@ def flush_session_log(
     _cb_turn_timestamps: list[str] = []
     _cb_turn_tool_calls: list[list[str]] = []
     if cc_log and cc_log.exists():
-        seen_request_ids: set[str] = set()
         try:
-            for raw_line in cc_log.read_text(encoding="utf-8", errors="replace").splitlines():
-                raw_line = raw_line.strip()
-                if not raw_line:
+            _text = cc_log.read_text(encoding="utf-8", errors="replace")
+            for _turn in iter_merged_assistant_turns(_text):
+                if not _turn.request_id:
                     continue
-                try:
-                    rec = json.loads(raw_line)
-                except json.JSONDecodeError:
-                    continue
-                if not isinstance(rec, dict) or rec.get("type") != "assistant":
-                    continue
-                rid = rec.get("requestId", "")
-                ts = rec.get("timestamp", "")
-                if rid and rid not in seen_request_ids:
-                    seen_request_ids.add(rid)
-                    _cb_request_ids.append(str(rid))
-                    if ts:
-                        _cb_turn_timestamps.append(str(ts))
-                    _message = rec.get("message")
-                    _content = _message.get("content", []) if isinstance(_message, dict) else []
-                    _tools = [
-                        str(blk["name"])
-                        for blk in _content
-                        if isinstance(blk, dict)
-                        and blk.get("type") == "tool_use"
-                        and isinstance(blk.get("name"), str)
-                        and blk["name"]
-                    ]
-                    _cb_turn_tool_calls.append(_tools[:8])
+                _cb_request_ids.append(_turn.request_id)
+                _cb_turn_timestamps.append(_turn.timestamp)
+                _cb_turn_tool_calls.append(_turn.tool_names)
         except OSError:
             logger.debug("channel_b_log_read_error", path=cc_log_str, exc_info=True)
 

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -194,7 +194,7 @@ def flush_session_log(
 
     _cb_request_ids: list[str] = []
     _cb_turn_timestamps: list[str] = []
-    _cb_turn_tool_calls: list[list[str]] = []
+    _cb_turn_tool_calls: list[tuple[str, ...]] = []
     if cc_log and cc_log.exists():
         try:
             _text = cc_log.read_text(encoding="utf-8", errors="replace")

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -23,8 +23,12 @@ if TYPE_CHECKING:
 
 import psutil
 
-from autoskillit.core import atomic_write, claude_code_log_path, get_logger
-from autoskillit.core.tool_sequence_analysis import iter_merged_assistant_turns
+from autoskillit.core import (
+    atomic_write,
+    claude_code_log_path,
+    get_logger,
+    iter_merged_assistant_turns,
+)
 from autoskillit.execution.anomaly_detection import (
     detect_anomalies,
     detect_identity_drift,

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -180,7 +180,7 @@ MODULE_CASCADE_CORE: dict[str, frozenset[str]] = {
     "kitchen_state": frozenset({"core"}),
     "readiness": frozenset({"core", "server"}),
     "session_registry": frozenset({"core"}),
-    "tool_sequence_analysis": frozenset({"core", "server", "cli"}),
+    "tool_sequence_analysis": frozenset({"core", "execution", "server", "cli"}),
 }
 
 # Narrow per-module cascade for execution/. Modules not listed here fall through

--- a/tests/arch/CLAUDE.md
+++ b/tests/arch/CLAUDE.md
@@ -34,6 +34,7 @@ AST enforcement, sub-package layer contracts, and architectural invariant tests.
 | `test_layer_enforcement.py` | MCP tool registry + import layer contracts + cross-package rules |
 | `test_layer_markers.py` | Enforce pytestmark layer markers on all in-scope test files |
 | `test_never_raises_contracts.py` | Structural enforcement of 'Never raises' docstring contracts in server/ |
+| `test_no_inline_jsonl_request_id_dedup.py` | AST guard: no inline requestId dedup in session_log.py or tool_sequence_analysis.py |
 | `test_protocol_names.py` | T5-T6: Protocol naming and DefaultSkillResolver export smoke tests |
 | `test_python_no_hardcoded_temp.py` | Architectural invariant: no literal `.autoskillit/temp` outside the whitelist |
 | `test_recipe_rule_registration.py` | REQ-RECIPE-001: every recipe/rules_*.py file must be imported by recipe/__init__.py |

--- a/tests/arch/test_no_inline_jsonl_request_id_dedup.py
+++ b/tests/arch/test_no_inline_jsonl_request_id_dedup.py
@@ -1,0 +1,52 @@
+"""AST guard: no inline requestId dedup in session_log.py or tool_sequence_analysis.py.
+
+Both files previously contained independent first-occurrence-wins dedup logic using
+a local `seen_request_ids` set. The dedup is now centralised in
+`iter_merged_assistant_turns()`. This guard prevents regression.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parents[2] / "src" / "autoskillit"
+SESSION_LOG = SRC / "execution" / "session_log.py"
+TOOL_SEQ = SRC / "core" / "tool_sequence_analysis.py"
+
+
+def _function_scoped_names(tree: ast.AST, name: str) -> list[int]:
+    """Return line numbers of assignments to `name` inside function bodies."""
+    hits: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for child in ast.walk(node):
+            if isinstance(child, ast.Assign):
+                for target in child.targets:
+                    if isinstance(target, ast.Name) and target.id == name:
+                        hits.append(child.lineno)
+            elif isinstance(child, ast.AnnAssign):
+                if isinstance(child.target, ast.Name) and child.target.id == name:
+                    hits.append(child.lineno)
+    return hits
+
+
+class TestNoInlineJsonlRequestIdDedup:
+    def test_session_log_has_no_seen_request_ids_variable(self) -> None:
+        tree = ast.parse(SESSION_LOG.read_text(encoding="utf-8"))
+        hits = _function_scoped_names(tree, "seen_request_ids")
+        assert not hits, (
+            "execution/session_log.py re-introduced an inline requestId dedup set.\n"
+            "Use iter_merged_assistant_turns() instead.\n"
+            "Offending lines: " + ", ".join(str(ln) for ln in hits)
+        )
+
+    def test_tool_sequence_analysis_has_no_seen_request_ids_variable(self) -> None:
+        tree = ast.parse(TOOL_SEQ.read_text(encoding="utf-8"))
+        hits = _function_scoped_names(tree, "seen_request_ids")
+        assert not hits, (
+            "core/tool_sequence_analysis.py re-introduced an inline requestId dedup set.\n"
+            "Use iter_merged_assistant_turns() instead.\n"
+            "Offending lines: " + ", ".join(str(ln) for ln in hits)
+        )

--- a/tests/core/test_tool_sequence_analysis.py
+++ b/tests/core/test_tool_sequence_analysis.py
@@ -8,10 +8,12 @@ import pytest
 
 from autoskillit.core.tool_sequence_analysis import (
     DFG,
+    AssistantTurn,
     TurnSequence,
     build_dfg,
     build_dfg_by_recipe,
     compute_gap_stats,
+    iter_merged_assistant_turns,
     parse_raw_cc_jsonl,
     parse_sessions_from_summary_dir,
     render_adjacency_table,
@@ -324,3 +326,146 @@ class TestParseSessionsFromSummaryDir:
         (session_dir / "summary.json").write_text("NOT_JSON")
         sessions = list(parse_sessions_from_summary_dir(tmp_path))
         assert sessions == []
+
+
+# ---------------------------------------------------------------------------
+# TestParseRawCCJsonlExtendedThinking  (tests 1a–1c — currently failing)
+# ---------------------------------------------------------------------------
+
+
+class TestParseRawCCJsonlExtendedThinking:
+    def _write(self, tmp_path: pathlib.Path, *records: dict) -> pathlib.Path:
+        log = tmp_path / "session.jsonl"
+        log.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+        return log
+
+    def test_merges_tool_calls_across_thinking_and_tool_records(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        # thinking-only record first, tool-bearing record second — same requestId
+        r1 = {
+            "type": "assistant",
+            "requestId": "req-X",
+            "message": {"content": [{"type": "thinking", "thinking": "reasoning..."}]},
+        }
+        r2 = {
+            "type": "assistant",
+            "requestId": "req-X",
+            "message": {
+                "content": [
+                    {"type": "thinking", "thinking": "more..."},
+                    {"type": "tool_use", "name": "Bash"},
+                ]
+            },
+        }
+        result = parse_raw_cc_jsonl(self._write(tmp_path, r1, r2))
+        assert result == [["Bash"]]
+
+    def test_accumulates_tools_from_multiple_records_same_request_id(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        r1 = {
+            "type": "assistant",
+            "requestId": "req-X",
+            "message": {"content": [{"type": "tool_use", "name": "Read"}]},
+        }
+        r2 = {
+            "type": "assistant",
+            "requestId": "req-X",
+            "message": {"content": [{"type": "tool_use", "name": "Edit"}]},
+        }
+        result = parse_raw_cc_jsonl(self._write(tmp_path, r1, r2))
+        assert result == [["Read", "Edit"]]
+
+    def test_cap_applied_after_accumulation_across_records(self, tmp_path: pathlib.Path) -> None:
+        tools5 = [{"type": "tool_use", "name": f"T{i}"} for i in range(5)]
+        tools5b = [{"type": "tool_use", "name": f"U{i}"} for i in range(5)]
+        r1 = {"type": "assistant", "requestId": "req-X", "message": {"content": tools5}}
+        r2 = {"type": "assistant", "requestId": "req-X", "message": {"content": tools5b}}
+        result = parse_raw_cc_jsonl(self._write(tmp_path, r1, r2))
+        assert len(result[0]) == 8
+
+
+# ---------------------------------------------------------------------------
+# TestIterMergedAssistantTurns  (test 1f — currently failing)
+# ---------------------------------------------------------------------------
+
+
+class TestIterMergedAssistantTurns:
+    def _make_record(
+        self,
+        *,
+        rid: str = "",
+        ts: str = "",
+        tools: list[str] | None = None,
+        thinking: bool = False,
+    ) -> str:
+        content: list[dict] = []
+        if thinking:
+            content.append({"type": "thinking", "thinking": "..."})
+        for name in tools or []:
+            content.append({"type": "tool_use", "name": name})
+        rec: dict = {"type": "assistant", "message": {"content": content}}
+        if rid:
+            rec["requestId"] = rid
+        if ts:
+            rec["timestamp"] = ts
+        return json.dumps(rec)
+
+    def _parse(self, *lines: str) -> list[AssistantTurn]:
+        text = "\n".join(lines) + "\n"
+        return list(iter_merged_assistant_turns(text))
+
+    def test_single_record_yields_one_turn(self) -> None:
+        line = self._make_record(rid="r1", ts="ts1", tools=["Bash"])
+        turns = self._parse(line)
+        assert len(turns) == 1
+        assert turns[0].request_id == "r1"
+        assert turns[0].timestamp == "ts1"
+        assert turns[0].tool_names == ["Bash"]
+
+    def test_multiple_distinct_request_ids_yield_separate_turns(self) -> None:
+        l1 = self._make_record(rid="r1", tools=["A"])
+        l2 = self._make_record(rid="r2", tools=["B"])
+        turns = self._parse(l1, l2)
+        assert len(turns) == 2
+        assert turns[0].tool_names == ["A"]
+        assert turns[1].tool_names == ["B"]
+
+    def test_no_request_id_records_not_deduplicated(self) -> None:
+        l1 = self._make_record(tools=["A"])
+        l2 = self._make_record(tools=["B"])
+        turns = self._parse(l1, l2)
+        assert len(turns) == 2
+
+    def test_records_without_request_id_included(self) -> None:
+        line = self._make_record(tools=["Bash"])
+        turns = self._parse(line)
+        assert len(turns) == 1
+        assert turns[0].request_id == ""
+        assert turns[0].tool_names == ["Bash"]
+
+    def test_preserves_insertion_order(self) -> None:
+        l1 = self._make_record(rid="r1", tools=["A"])
+        l2 = self._make_record(rid="r2", tools=["B"])
+        l3 = self._make_record(rid="r3", tools=["C"])
+        turns = self._parse(l1, l2, l3)
+        assert [t.request_id for t in turns] == ["r1", "r2", "r3"]
+
+    def test_no_rid_turns_interleaved_in_file_order(self) -> None:
+        l_a = self._make_record(rid="r-A", tools=["A"])
+        l_no = self._make_record(tools=["NoRid"])
+        l_b = self._make_record(rid="r-B", tools=["B"])
+        turns = self._parse(l_a, l_no, l_b)
+        assert len(turns) == 3
+        assert turns[0].request_id == "r-A"
+        assert turns[1].request_id == ""
+        assert turns[2].request_id == "r-B"
+
+    def test_timestamp_from_first_record_preferred(self) -> None:
+        l1 = self._make_record(rid="r1", ts="first-ts", tools=[])
+        l2 = self._make_record(rid="r1", ts="second-ts", tools=["Bash"])
+        turns = self._parse(l1, l2)
+        assert len(turns) == 1
+        assert turns[0].timestamp == "first-ts"
+        assert turns[0].tool_names == ["Bash"]

--- a/tests/core/test_tool_sequence_analysis.py
+++ b/tests/core/test_tool_sequence_analysis.py
@@ -328,11 +328,6 @@ class TestParseSessionsFromSummaryDir:
         assert sessions == []
 
 
-# ---------------------------------------------------------------------------
-# TestParseRawCCJsonlExtendedThinking  (tests 1a–1c — currently failing)
-# ---------------------------------------------------------------------------
-
-
 class TestParseRawCCJsonlExtendedThinking:
     def _write(self, tmp_path: pathlib.Path, *records: dict) -> pathlib.Path:
         log = tmp_path / "session.jsonl"
@@ -359,7 +354,7 @@ class TestParseRawCCJsonlExtendedThinking:
             },
         }
         result = parse_raw_cc_jsonl(self._write(tmp_path, r1, r2))
-        assert result == [["Bash"]]
+        assert result == [("Bash",)]
 
     def test_accumulates_tools_from_multiple_records_same_request_id(
         self, tmp_path: pathlib.Path
@@ -375,7 +370,7 @@ class TestParseRawCCJsonlExtendedThinking:
             "message": {"content": [{"type": "tool_use", "name": "Edit"}]},
         }
         result = parse_raw_cc_jsonl(self._write(tmp_path, r1, r2))
-        assert result == [["Read", "Edit"]]
+        assert result == [("Read", "Edit")]
 
     def test_cap_applied_after_accumulation_across_records(self, tmp_path: pathlib.Path) -> None:
         tools5 = [{"type": "tool_use", "name": f"T{i}"} for i in range(5)]
@@ -384,11 +379,7 @@ class TestParseRawCCJsonlExtendedThinking:
         r2 = {"type": "assistant", "requestId": "req-X", "message": {"content": tools5b}}
         result = parse_raw_cc_jsonl(self._write(tmp_path, r1, r2))
         assert len(result[0]) == 8
-
-
-# ---------------------------------------------------------------------------
-# TestIterMergedAssistantTurns  (test 1f — currently failing)
-# ---------------------------------------------------------------------------
+        assert result[0] == ("T0", "T1", "T2", "T3", "T4", "U0", "U1", "U2")
 
 
 class TestIterMergedAssistantTurns:
@@ -422,28 +413,30 @@ class TestIterMergedAssistantTurns:
         assert len(turns) == 1
         assert turns[0].request_id == "r1"
         assert turns[0].timestamp == "ts1"
-        assert turns[0].tool_names == ["Bash"]
+        assert turns[0].tool_names == ("Bash",)
 
     def test_multiple_distinct_request_ids_yield_separate_turns(self) -> None:
         l1 = self._make_record(rid="r1", tools=["A"])
         l2 = self._make_record(rid="r2", tools=["B"])
         turns = self._parse(l1, l2)
         assert len(turns) == 2
-        assert turns[0].tool_names == ["A"]
-        assert turns[1].tool_names == ["B"]
+        assert turns[0].tool_names == ("A",)
+        assert turns[1].tool_names == ("B",)
 
     def test_no_request_id_records_not_deduplicated(self) -> None:
         l1 = self._make_record(tools=["A"])
         l2 = self._make_record(tools=["B"])
         turns = self._parse(l1, l2)
         assert len(turns) == 2
+        assert turns[0].tool_names == ("A",)
+        assert turns[1].tool_names == ("B",)
 
     def test_records_without_request_id_included(self) -> None:
         line = self._make_record(tools=["Bash"])
         turns = self._parse(line)
         assert len(turns) == 1
         assert turns[0].request_id == ""
-        assert turns[0].tool_names == ["Bash"]
+        assert turns[0].tool_names == ("Bash",)
 
     def test_preserves_insertion_order(self) -> None:
         l1 = self._make_record(rid="r1", tools=["A"])
@@ -468,4 +461,4 @@ class TestIterMergedAssistantTurns:
         turns = self._parse(l1, l2)
         assert len(turns) == 1
         assert turns[0].timestamp == "first-ts"
-        assert turns[0].tool_names == ["Bash"]
+        assert turns[0].tool_names == ("Bash",)

--- a/tests/core/test_tool_sequence_analysis.py
+++ b/tests/core/test_tool_sequence_analysis.py
@@ -45,7 +45,7 @@ class TestParseRawCCJsonl:
         log = tmp_path / "session.jsonl"
         log.write_text(json.dumps(record) + "\n")
         result = parse_raw_cc_jsonl(log)
-        assert result == [["ToolA", "ToolB"]]
+        assert result == [("ToolA", "ToolB")]
 
     def test_deduplicates_same_request_id(self, tmp_path: pathlib.Path) -> None:
         record = {
@@ -103,7 +103,7 @@ class TestParseRawCCJsonl:
         log = tmp_path / "session.jsonl"
         log.write_text(json.dumps(record) + "\n")
         result = parse_raw_cc_jsonl(log)
-        assert result == [["ValidTool"]]
+        assert result == [("ValidTool",)]
 
     def test_empty_jsonl_returns_empty_list(self, tmp_path: pathlib.Path) -> None:
         log = tmp_path / "session.jsonl"
@@ -122,14 +122,14 @@ class TestParseRawCCJsonl:
         log = tmp_path / "session.jsonl"
         log.write_text("NOT_JSON\n" + good + "\n")
         result = parse_raw_cc_jsonl(log)
-        assert result == [["GoodTool"]]
+        assert result == [("GoodTool",)]
 
     def test_message_field_absent_returns_empty_turn(self, tmp_path: pathlib.Path) -> None:
         record = {"type": "assistant", "requestId": "r1"}
         log = tmp_path / "session.jsonl"
         log.write_text(json.dumps(record) + "\n")
         result = parse_raw_cc_jsonl(log)
-        assert result == [[]]
+        assert result == [()]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/execution/conftest.py
+++ b/tests/execution/conftest.py
@@ -61,6 +61,31 @@ def _make_tool_use_line(name: str, input_dict: dict) -> str:
     )
 
 
+def _make_cc_jsonl_record(
+    *,
+    request_id: str = "",
+    timestamp: str = "",
+    content: list[dict] | None = None,
+    record_type: str = "assistant",
+) -> str:
+    rec: dict[str, object] = {"type": record_type}
+    if request_id:
+        rec["requestId"] = request_id
+    if timestamp:
+        rec["timestamp"] = timestamp
+    if content is not None:
+        rec["message"] = {"content": content}
+    return json.dumps(rec)
+
+
+def _make_thinking_block(text: str = "reasoning...") -> dict[str, str]:
+    return {"type": "thinking", "thinking": text}
+
+
+def _make_tool_block(name: str) -> dict[str, object]:
+    return {"type": "tool_use", "name": name, "id": "x", "input": {}}
+
+
 # Simulates Claude CLI process that writes a result line then hangs.
 # Used by test_process_channel_b.py and test_process_monitor.py.
 WRITE_RESULT_THEN_HANG_SCRIPT = textwrap.dedent("""\

--- a/tests/execution/test_session_log_fields.py
+++ b/tests/execution/test_session_log_fields.py
@@ -14,7 +14,13 @@ from autoskillit.core.types._type_results import SessionTelemetry
 from autoskillit.execution.session_log import (
     flush_session_log,
 )
-from tests.execution.conftest import _flush, _snap
+from tests.execution.conftest import (
+    _flush,
+    _make_cc_jsonl_record,
+    _make_thinking_block,
+    _make_tool_block,
+    _snap,
+)
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.medium]
 
@@ -681,3 +687,85 @@ def test_flush_session_log_provider_used_defaults_empty_in_token_usage(tmp_path)
     )
     tu = json.loads((tmp_path / "sessions" / "prov-tu-def" / "token_usage.json").read_text())
     assert tu["provider_used"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Extended-thinking merge tests (1d, 1e — currently failing)
+# ---------------------------------------------------------------------------
+
+
+def test_turn_tool_calls_merged_across_thinking_and_tool_records(tmp_path, monkeypatch):
+    cb_log = tmp_path / "s.jsonl"
+    cb_log.write_text(
+        _make_cc_jsonl_record(
+            request_id="req-001",
+            timestamp="2026-05-04T00:00:00Z",
+            content=[_make_thinking_block()],
+        )
+        + "\n"
+        + _make_cc_jsonl_record(
+            request_id="req-001",
+            content=[_make_tool_block("Bash")],
+        )
+        + "\n"
+    )
+    import autoskillit.execution.session_log as sl_mod
+
+    monkeypatch.setattr(sl_mod, "claude_code_log_path", lambda cwd, sid: cb_log)
+    flush_session_log(
+        log_dir=str(tmp_path),
+        cwd="/tmp",
+        session_id="s",
+        pid=1,
+        skill_command="test",
+        success=True,
+        subtype="completed",
+        exit_code=0,
+        start_ts="2026-05-04T00:00:00Z",
+        proc_snapshots=None,
+        telemetry=SessionTelemetry.empty(),
+    )
+    summary = json.loads((tmp_path / "sessions" / "s" / "summary.json").read_text())
+    assert summary["turn_tool_calls"] == [["Bash"]]
+    assert summary["request_ids"] == ["req-001"]
+
+
+def test_parallel_lists_aligned_when_timestamp_missing(tmp_path, monkeypatch):
+    cb_log = tmp_path / "s.jsonl"
+    cb_log.write_text(
+        _make_cc_jsonl_record(
+            request_id="req-001",
+            timestamp="2026-05-04T00:00:00Z",
+            content=[_make_tool_block("Read")],
+        )
+        + "\n"
+        + _make_cc_jsonl_record(
+            request_id="req-002",
+            content=[_make_tool_block("Edit")],
+        )
+        + "\n"
+    )
+    import autoskillit.execution.session_log as sl_mod
+
+    monkeypatch.setattr(sl_mod, "claude_code_log_path", lambda cwd, sid: cb_log)
+    flush_session_log(
+        log_dir=str(tmp_path),
+        cwd="/tmp",
+        session_id="s",
+        pid=1,
+        skill_command="test",
+        success=True,
+        subtype="completed",
+        exit_code=0,
+        start_ts="2026-05-04T00:00:00Z",
+        proc_snapshots=None,
+        telemetry=SessionTelemetry.empty(),
+    )
+    summary = json.loads((tmp_path / "sessions" / "s" / "summary.json").read_text())
+    assert (
+        len(summary["request_ids"])
+        == len(summary["turn_timestamps"])
+        == len(summary["turn_tool_calls"])
+        == 2
+    )
+    assert summary["turn_timestamps"][1] == ""

--- a/tests/execution/test_session_log_fields.py
+++ b/tests/execution/test_session_log_fields.py
@@ -689,11 +689,6 @@ def test_flush_session_log_provider_used_defaults_empty_in_token_usage(tmp_path)
     assert tu["provider_used"] == ""
 
 
-# ---------------------------------------------------------------------------
-# Extended-thinking merge tests (1d, 1e — currently failing)
-# ---------------------------------------------------------------------------
-
-
 def test_turn_tool_calls_merged_across_thinking_and_tool_records(tmp_path, monkeypatch):
     cb_log = tmp_path / "s.jsonl"
     cb_log.write_text(
@@ -768,4 +763,7 @@ def test_parallel_lists_aligned_when_timestamp_missing(tmp_path, monkeypatch):
         == len(summary["turn_tool_calls"])
         == 2
     )
+    assert summary["request_ids"] == ["req-001", "req-002"]
+    assert summary["turn_timestamps"][0] == "2026-05-04T00:00:00Z"
     assert summary["turn_timestamps"][1] == ""
+    assert summary["turn_tool_calls"] == [["Read"], ["Edit"]]

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -112,11 +112,11 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/core/io.py", 118),
     # session_log.py — github_api_usage dict, summary dict, meta.json sidecar,
     # token_usage dict, step_timing dict
-    ("src/autoskillit/execution/session_log.py", 322),
-    ("src/autoskillit/execution/session_log.py", 384),
-    ("src/autoskillit/execution/session_log.py", 388),
-    ("src/autoskillit/execution/session_log.py", 416),
-    ("src/autoskillit/execution/session_log.py", 419),
+    ("src/autoskillit/execution/session_log.py", 301),
+    ("src/autoskillit/execution/session_log.py", 363),
+    ("src/autoskillit/execution/session_log.py", 367),
+    ("src/autoskillit/execution/session_log.py", 395),
+    ("src/autoskillit/execution/session_log.py", 398),
     # migration/store.py — failure store dicts
     ("src/autoskillit/migration/store.py", 54),
     ("src/autoskillit/migration/store.py", 64),

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -112,11 +112,11 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/core/io.py", 118),
     # session_log.py — github_api_usage dict, summary dict, meta.json sidecar,
     # token_usage dict, step_timing dict
-    ("src/autoskillit/execution/session_log.py", 301),
-    ("src/autoskillit/execution/session_log.py", 363),
+    ("src/autoskillit/execution/session_log.py", 305),
     ("src/autoskillit/execution/session_log.py", 367),
-    ("src/autoskillit/execution/session_log.py", 395),
-    ("src/autoskillit/execution/session_log.py", 398),
+    ("src/autoskillit/execution/session_log.py", 371),
+    ("src/autoskillit/execution/session_log.py", 399),
+    ("src/autoskillit/execution/session_log.py", 402),
     # migration/store.py — failure store dicts
     ("src/autoskillit/migration/store.py", 54),
     ("src/autoskillit/migration/store.py", 64),


### PR DESCRIPTION
## Summary

Two independent JSONL parsers duplicate identical "first-occurrence-wins" requestId dedup logic. When extended thinking is enabled, Claude Code emits two records per requestId (thinking-only first, tool-bearing second). The first-occurrence-wins pattern silently discards the tool-bearing record, producing empty `turn_tool_calls` arrays that cascade through the entire DFG analysis pipeline.

The architectural weakness is **duplicated parsing logic with no shared primitive**. Both parsers independently implement the same line-by-line iteration, type filtering, requestId dedup, tool extraction, and capping — but neither was updated when the JSONL format gained multi-record-per-requestId semantics from extended thinking. A shared primitive would have required exactly one fix in one place.

The proposed solution extracts a shared `iter_merged_assistant_turns()` generator into `core/tool_sequence_analysis.py` (IL-0), introduces an `AssistantTurn` NamedTuple as a typed contract for the output, and has both consumers delegate to it. This eliminates the duplication, centralizes the merge policy, and makes the class of bug impossible — any future JSONL format change requires exactly one code change.

Closes #1861

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260504-195632-750224/.autoskillit/temp/rectify/rectify_turn_tracker_empty_tool_calls_2026-05-04_200500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate | 1 | 2.5k | 6.4k | 337.4k | 87.3k | 146 | 39.0k | 8m 43s |
| rectify | 1 | 61 | 16.0k | 882.9k | 79.1k | 104 | 75.0k | 10m 21s |
| dry_walkthrough | 1 | 50 | 13.9k | 1.7M | 68.9k | 92 | 55.8k | 8m 3s |
| implement | 1 | 388 | 21.5k | 3.5M | 99.6k | 130 | 86.8k | 8m 49s |
| prepare_pr | 1 | 68 | 5.5k | 251.5k | 42.0k | 20 | 30.2k | 1m 37s |
| compose_pr | 1 | 75 | 2.9k | 243.7k | 30.9k | 19 | 17.9k | 56s |
| review_pr | 1 | 102 | 38.3k | 621.2k | 86.4k | 43 | 76.3k | 8m 28s |
| resolve_review | 1 | 761 | 32.8k | 6.4M | 101.4k | 208 | 88.8k | 19m 3s |
| **Total** | | 4.0k | 137.2k | 13.9M | 101.4k | | 469.7k | 1h 6m |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 420 | 8282.3 | 206.7 | 51.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 59 | 108331.0 | 1505.1 | 555.5 |
| **Total** | **479** | 29073.4 | 980.6 | 286.4 |