### PR TITLE
Clarity — step_name telemetry note, filter:off display, universal module criterion

### DIFF
--- a/src/autoskillit/hooks/formatters/_fmt_execution.py
+++ b/src/autoskillit/hooks/formatters/_fmt_execution.py
@@ -188,6 +188,8 @@ def _fmt_test_check(data: dict, _pipeline: bool) -> str:
             selected = data.get("tests_selected", "?")
             deselected = data.get("tests_deselected", "?")
             lines.append(f"filter: {filter_mode} ({selected} selected, {deselected} deselected)")
+    else:
+        lines.append("filter: off")
 
     stdout = data.get("stdout", "")
     if stdout:

--- a/src/autoskillit/server/tools/tools_workspace.py
+++ b/src/autoskillit/server/tools/tools_workspace.py
@@ -42,6 +42,8 @@ async def test_check(
     Args:
         worktree_path: Path to the git worktree to run tests in.
         step_name: Optional YAML step key for wall-clock timing accumulation.
+            Has no effect on test filtering — filter behavior is controlled by
+            config.test_check.filter_mode.
 
     Never raises.
     """

--- a/tests/infra/test_pretty_output_formatters.py
+++ b/tests/infra/test_pretty_output_formatters.py
@@ -573,6 +573,33 @@ def test_fmt_test_check_shows_question_mark_only_when_stats_truly_unavailable():
     assert "full run" not in out
 
 
+def test_fmt_test_check_emits_filter_off_when_no_filter_mode():
+    """When filter_mode is absent, output contains 'filter: off'."""
+    from autoskillit.hooks.formatters._fmt_execution import _fmt_test_check
+
+    data = {"passed": True, "stdout": "= 10 passed ="}
+    out = _fmt_test_check(data, False)
+    assert "filter: off" in out
+
+
+def test_fmt_test_check_emits_filter_off_when_filter_mode_none():
+    """Explicit None filter_mode also produces 'filter: off'."""
+    from autoskillit.hooks.formatters._fmt_execution import _fmt_test_check
+
+    data = {"passed": True, "stdout": "", "filter_mode": None}
+    out = _fmt_test_check(data, False)
+    assert "filter: off" in out
+
+
+def test_fmt_test_check_emits_filter_off_when_filter_mode_empty_string():
+    """Empty string filter_mode also produces 'filter: off'."""
+    from autoskillit.hooks.formatters._fmt_execution import _fmt_test_check
+
+    data = {"passed": True, "stdout": "", "filter_mode": ""}
+    out = _fmt_test_check(data, False)
+    assert "filter: off" in out
+
+
 # --- Provider line rendering ---
 
 


### PR DESCRIPTION
## Summary

Three documentation/naming clarity improvements from issue #1838. Investigation reveals that Item 3 (`_CORE_UNIVERSAL_MODULES` comment) is already implemented — the exact criterion comment exists at `tests/_test_filter.py:125-130`. The remaining two items are:

1. **`step_name` docstring clarification** — Add a one-line note to the `test_check` tool's `step_name` parameter docstring clarifying it has no effect on test filtering.
2. **`filter: off` display** — When `filter_mode` is None/falsy, emit `filter: off` instead of silently omitting the filter line from `_fmt_test_check` output.

Item 3 is already satisfied and requires no changes.

Closes #1838

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260504-180625-315246/.autoskillit/temp/make-plan/clarity_step_name_filter_off_universal_module_plan_2026-05-04_181500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 61 | 6.9k | 626.8k | 63.2k | 51 | 55.3k | 4m 25s |
| verify | 1 | 31 | 5.4k | 441.3k | 39.6k | 50 | 29.7k | 3m 0s |
| **Total** | | 92 | 12.4k | 1.1M | 63.2k | | 85.0k | 7m 25s |