### PR TITLE
Implementation Plan: Fleet Dispatch Pre-Launch Preview, Recipe Listing, and Session Greeting

### DIFF
--- a/src/autoskillit/cli/_prompts.py
+++ b/src/autoskillit/cli/_prompts.py
@@ -409,25 +409,6 @@ _OPEN_KITCHEN_GREETINGS: list[str] = [
     "Order up! The kitchen is ready. What can I get you?",
 ]
 
-_FLEET_DISPATCH_GREETINGS: list[str] = [
-    (
-        "Fleet dispatcher online. Your available food trucks:\n\n"
-        "{recipe_table}\n\n"
-        "Ready for dispatch orders."
-    ),
-    (
-        "Welcome to fleet dispatch — ad-hoc food truck coordination.\n\n"
-        "Available food trucks:\n\n"
-        "{recipe_table}\n\n"
-        "What targets are we dispatching to?"
-    ),
-    (
-        "Dispatcher standing by. Food truck roster:\n\n"
-        "{recipe_table}\n\n"
-        "Issue your dispatch orders when ready."
-    ),
-]
-
 
 def _build_orchestrator_prompt(
     recipe_name: str,

--- a/src/autoskillit/cli/_prompts.py
+++ b/src/autoskillit/cli/_prompts.py
@@ -409,6 +409,25 @@ _OPEN_KITCHEN_GREETINGS: list[str] = [
     "Order up! The kitchen is ready. What can I get you?",
 ]
 
+_FLEET_DISPATCH_GREETINGS: list[str] = [
+    (
+        "Fleet dispatcher online. Your available food trucks:\n\n"
+        "{recipe_table}\n\n"
+        "Ready for dispatch orders."
+    ),
+    (
+        "Welcome to fleet dispatch — ad-hoc food truck coordination.\n\n"
+        "Available food trucks:\n\n"
+        "{recipe_table}\n\n"
+        "What targets are we dispatching to?"
+    ),
+    (
+        "Dispatcher standing by. Food truck roster:\n\n"
+        "{recipe_table}\n\n"
+        "Issue your dispatch orders when ready."
+    ),
+]
+
 
 def _build_orchestrator_prompt(
     recipe_name: str,
@@ -682,7 +701,7 @@ def _build_open_kitchen_prompt(mcp_prefix: str) -> str:
     return text
 
 
-def _build_fleet_dispatch_prompt(mcp_prefix: str) -> str:
+def _build_fleet_dispatch_prompt(mcp_prefix: str, recipe_table: str | None = None) -> str:
     """Build the --append-system-prompt content for an ad-hoc fleet dispatcher session."""
     from autoskillit.fleet import _build_l3_sous_chef_block  # noqa: PLC0415
 
@@ -692,6 +711,15 @@ def _build_fleet_dispatch_prompt(mcp_prefix: str) -> str:
         if sous_chef_block
         else ""
     )
+    _food_truck_section = ""
+    if recipe_table:
+        _food_truck_section = (
+            "\n## AVAILABLE FOOD TRUCKS — STANDARD RECIPES AVAILABLE FOR DISPATCH\n\n"
+            f"{recipe_table}\n\n"
+            "The recipes above are pre-loaded from the CLI. You may skip the "
+            "list_recipes call and proceed directly to load_recipe for ingredient "
+            "inspection when dispatching any of the above.\n"
+        )
     return f"""\
 You are a fleet dispatcher. You coordinate recipe execution across targets \
 by dispatching food trucks.
@@ -707,7 +735,7 @@ TOOL SURFACE — these 10 tools are available in this session:
 - {mcp_prefix}load_recipe             — load a recipe and inspect its ingredients
 - {mcp_prefix}fetch_github_issue      — retrieve issue context when dispatching issue work
 - {mcp_prefix}get_issue_title         — get the title of a GitHub issue
-{sous_chef_section}
+{_food_truck_section}{sous_chef_section}
 ## RECIPE DISCOVERY FLOW
 
 1. Call {mcp_prefix}list_recipes to see available recipes.

--- a/src/autoskillit/cli/fleet/CLAUDE.md
+++ b/src/autoskillit/cli/fleet/CLAUDE.md
@@ -7,6 +7,7 @@ Fleet campaign CLI subcommands for multi-issue dispatch orchestration.
 | File | Purpose |
 |------|---------|
 | `__init__.py` | Main module: `fleet_app` Cyclopts sub-app with `campaign`, `dispatch`, `list`, `status` commands |
-| `_fleet_display.py` | Status display: `_render_status_display()`, `_watch_loop()`, `_STATUS_COLUMNS` |
+| `_fleet_display.py` | Status display: `_render_status_display()`, `_watch_loop()`, `_STATUS_COLUMNS`, `render_fleet_error()` |
 | `_fleet_lifecycle.py` | Signal guard, stale dispatch reaping, `_pick_resume_campaign()` |
+| `_fleet_preview.py` | Pre-launch dispatch preview: `_build_dispatch_recipe_table()`, `_print_dispatch_preview()` |
 | `_fleet_session.py` | `_launch_fleet_session()` — builds Claude interactive session for fleet campaigns |

--- a/src/autoskillit/cli/fleet/__init__.py
+++ b/src/autoskillit/cli/fleet/__init__.py
@@ -62,6 +62,71 @@ def _remove_clone_fn(path: str, _flag: str) -> dict[str, str]:
         return {"removed": "false", "reason": str(exc)}
 
 
+def _build_dispatch_recipe_table() -> str:
+    """Build a compact NAME — DESCRIPTION table of standard recipes for greeting injection."""
+    from autoskillit.recipe import list_recipes
+    from autoskillit.recipe.schema import RecipeKind
+
+    recipes = list_recipes(Path.cwd(), exclude_kinds=frozenset({RecipeKind.CAMPAIGN})).items
+    if not recipes:
+        return "(no recipes found)"
+    name_w = max(len(r.name) for r in recipes)
+    lines = [f"{r.name:<{name_w}}  {r.description}" for r in recipes]
+    return "\n".join(lines)
+
+
+def _print_dispatch_preview(cfg: object) -> None:
+    """Print the pre-launch summary for fleet dispatch (mirrors cook's pre-launch display)."""
+    from autoskillit.cli.ui._ansi import permissions_warning, supports_color
+    from autoskillit.recipe import list_recipes
+    from autoskillit.recipe.schema import RecipeKind
+
+    color = supports_color()
+    _B = "\x1b[1m" if color else ""
+    _C = "\x1b[96m" if color else ""
+    _D = "\x1b[2m" if color else ""
+    _G = "\x1b[32m" if color else ""
+    _Y = "\x1b[33m" if color else ""
+    _R = "\x1b[0m" if color else ""
+
+    from autoskillit import __version__
+
+    print(
+        f"{_B}{_C}AUTOSKILLIT {__version__}{_R}"
+        f" {_D}Fleet dispatcher. Ad-hoc food truck coordination.{_R}"
+    )
+
+    recipes = list_recipes(Path.cwd(), exclude_kinds=frozenset({RecipeKind.CAMPAIGN})).items
+    if recipes:
+        name_w = max(len(r.name) for r in recipes)
+        src_w = max(len(r.source) for r in recipes)
+        print(f"\n{_B}Available food trucks:{_R}")
+        print(f"  {'NAME':<{name_w}}  {'SOURCE':<{src_w}}  DESCRIPTION")
+        print(f"  {'-' * name_w}  {'-' * src_w}  {'-' * 11}")
+        for r in recipes:
+            print(f"  {_G}{r.name:<{name_w}}{_R}  {_D}{r.source:<{src_w}}{_R}  {r.description}")
+    else:
+        print(f"\n{_D}No recipes found.{_R}")
+
+    _DISPATCH_TOOL_CATEGORIES: list[tuple[str, tuple[str, ...]]] = [
+        ("Dispatch", ("dispatch_food_truck",)),
+        ("Cleanup", ("batch_cleanup_clones",)),
+        (
+            "Telemetry",
+            ("get_pipeline_report", "get_token_summary", "get_timing_summary", "get_quota_events"),
+        ),
+        ("Recipes", ("list_recipes", "load_recipe")),
+        ("GitHub", ("fetch_github_issue", "get_issue_title")),
+    ]
+    print()
+    for name, tools in _DISPATCH_TOOL_CATEGORIES:
+        tool_list = f"{_D}, {_R}".join(f"{_G}{t}{_R}" for t in tools)
+        print(f"  {_Y}{name:>20}{_R}  {tool_list}")
+    print()
+
+    print(permissions_warning())
+
+
 @fleet_app.command(name="dispatch")
 def fleet_dispatch() -> None:
     """Launch a bare fleet dispatcher session (free-flow mode)."""
@@ -78,7 +143,32 @@ def fleet_dispatch() -> None:
     cfg = load_config(Path.cwd())
     _require_fleet(cfg)
 
-    _launch_fleet_session(None, None, None, None, fleet_mode="dispatch")
+    _print_dispatch_preview(cfg)
+
+    from autoskillit.cli.ui._timed_input import timed_prompt
+
+    confirm = timed_prompt(
+        "\nLaunch session? [Enter/n]", default="", timeout=120, label="autoskillit fleet dispatch"
+    )
+    if confirm.lower() in ("n", "no"):
+        return
+
+    import random
+
+    from autoskillit.cli._prompts import _FLEET_DISPATCH_GREETINGS
+
+    recipe_table = _build_dispatch_recipe_table()
+    greeting = random.choice(_FLEET_DISPATCH_GREETINGS).format(recipe_table=recipe_table)
+
+    _launch_fleet_session(
+        None,
+        None,
+        None,
+        None,
+        fleet_mode="dispatch",
+        initial_message=greeting,
+        recipe_table=recipe_table,
+    )
 
 
 @fleet_app.command(name="campaign")

--- a/src/autoskillit/cli/fleet/__init__.py
+++ b/src/autoskillit/cli/fleet/__init__.py
@@ -19,9 +19,7 @@ from autoskillit.cli.fleet._fleet_display import (
     _cross_check_tokens,
     _render_status_display,
     _watch_loop,
-)
-from autoskillit.cli.fleet._fleet_display import (
-    render_fleet_error as render_fleet_error,
+    render_fleet_error,
 )
 from autoskillit.cli.fleet._fleet_lifecycle import (
     _pick_resume_campaign,
@@ -57,6 +55,7 @@ if TYPE_CHECKING:
 
 
 fleet_app = App(name="fleet", help="Campaign fleet management.")
+__all__ = ["fleet_app", "render_fleet_error"]
 
 
 def _remove_clone_fn(path: str, _flag: str) -> dict[str, str]:

--- a/src/autoskillit/cli/fleet/__init__.py
+++ b/src/autoskillit/cli/fleet/__init__.py
@@ -26,7 +26,7 @@ from autoskillit.cli.fleet._fleet_lifecycle import (
     _reap_stale_dispatches,
 )
 from autoskillit.cli.fleet._fleet_preview import (
-    _build_dispatch_recipe_table,
+    _FLEET_DISPATCH_GREETINGS,
     _print_dispatch_preview,
 )
 from autoskillit.cli.fleet._fleet_session import _launch_fleet_session
@@ -84,7 +84,7 @@ def fleet_dispatch() -> None:
     cfg = load_config(Path.cwd())
     _require_fleet(cfg)
 
-    _print_dispatch_preview(cfg)
+    recipe_table = _print_dispatch_preview()
 
     from autoskillit.cli.ui._timed_input import timed_prompt
 
@@ -96,9 +96,6 @@ def fleet_dispatch() -> None:
 
     import random
 
-    from autoskillit.cli._prompts import _FLEET_DISPATCH_GREETINGS
-
-    recipe_table = _build_dispatch_recipe_table()
     greeting = random.choice(_FLEET_DISPATCH_GREETINGS).format(recipe_table=recipe_table)
 
     _launch_fleet_session(

--- a/src/autoskillit/cli/fleet/__init__.py
+++ b/src/autoskillit/cli/fleet/__init__.py
@@ -20,9 +20,16 @@ from autoskillit.cli.fleet._fleet_display import (
     _render_status_display,
     _watch_loop,
 )
+from autoskillit.cli.fleet._fleet_display import (
+    render_fleet_error as render_fleet_error,
+)
 from autoskillit.cli.fleet._fleet_lifecycle import (
     _pick_resume_campaign,
     _reap_stale_dispatches,
+)
+from autoskillit.cli.fleet._fleet_preview import (
+    _build_dispatch_recipe_table,
+    _print_dispatch_preview,
 )
 from autoskillit.cli.fleet._fleet_session import _launch_fleet_session
 from autoskillit.core import TerminalColumn, get_logger, is_feature_enabled
@@ -60,71 +67,6 @@ def _remove_clone_fn(path: str, _flag: str) -> dict[str, str]:
     except Exception as exc:
         logger.warning("Failed to remove clone %s: %s", path, exc, exc_info=True)
         return {"removed": "false", "reason": str(exc)}
-
-
-def _build_dispatch_recipe_table() -> str:
-    """Build a compact NAME — DESCRIPTION table of standard recipes for greeting injection."""
-    from autoskillit.recipe import list_recipes
-    from autoskillit.recipe.schema import RecipeKind
-
-    recipes = list_recipes(Path.cwd(), exclude_kinds=frozenset({RecipeKind.CAMPAIGN})).items
-    if not recipes:
-        return "(no recipes found)"
-    name_w = max(len(r.name) for r in recipes)
-    lines = [f"{r.name:<{name_w}}  {r.description}" for r in recipes]
-    return "\n".join(lines)
-
-
-def _print_dispatch_preview(cfg: object) -> None:
-    """Print the pre-launch summary for fleet dispatch (mirrors cook's pre-launch display)."""
-    from autoskillit.cli.ui._ansi import permissions_warning, supports_color
-    from autoskillit.recipe import list_recipes
-    from autoskillit.recipe.schema import RecipeKind
-
-    color = supports_color()
-    _B = "\x1b[1m" if color else ""
-    _C = "\x1b[96m" if color else ""
-    _D = "\x1b[2m" if color else ""
-    _G = "\x1b[32m" if color else ""
-    _Y = "\x1b[33m" if color else ""
-    _R = "\x1b[0m" if color else ""
-
-    from autoskillit import __version__
-
-    print(
-        f"{_B}{_C}AUTOSKILLIT {__version__}{_R}"
-        f" {_D}Fleet dispatcher. Ad-hoc food truck coordination.{_R}"
-    )
-
-    recipes = list_recipes(Path.cwd(), exclude_kinds=frozenset({RecipeKind.CAMPAIGN})).items
-    if recipes:
-        name_w = max(len(r.name) for r in recipes)
-        src_w = max(len(r.source) for r in recipes)
-        print(f"\n{_B}Available food trucks:{_R}")
-        print(f"  {'NAME':<{name_w}}  {'SOURCE':<{src_w}}  DESCRIPTION")
-        print(f"  {'-' * name_w}  {'-' * src_w}  {'-' * 11}")
-        for r in recipes:
-            print(f"  {_G}{r.name:<{name_w}}{_R}  {_D}{r.source:<{src_w}}{_R}  {r.description}")
-    else:
-        print(f"\n{_D}No recipes found.{_R}")
-
-    _DISPATCH_TOOL_CATEGORIES: list[tuple[str, tuple[str, ...]]] = [
-        ("Dispatch", ("dispatch_food_truck",)),
-        ("Cleanup", ("batch_cleanup_clones",)),
-        (
-            "Telemetry",
-            ("get_pipeline_report", "get_token_summary", "get_timing_summary", "get_quota_events"),
-        ),
-        ("Recipes", ("list_recipes", "load_recipe")),
-        ("GitHub", ("fetch_github_issue", "get_issue_title")),
-    ]
-    print()
-    for name, tools in _DISPATCH_TOOL_CATEGORIES:
-        tool_list = f"{_D}, {_R}".join(f"{_G}{t}{_R}" for t in tools)
-        print(f"  {_Y}{name:>20}{_R}  {tool_list}")
-    print()
-
-    print(permissions_warning())
 
 
 @fleet_app.command(name="dispatch")
@@ -457,23 +399,3 @@ def fleet_status(
             return
 
         print(_render_terminal_table(columns, rows_list))
-
-
-def render_fleet_error(envelope_json: str) -> int:
-    """Render a fleet error envelope to stderr.
-
-    Returns exit code: 3 for fleet envelope errors, 0 for non-error envelopes.
-    """
-    try:
-        data = json.loads(envelope_json)
-    except (json.JSONDecodeError, TypeError):
-        return 0
-    if data.get("success") is not False:
-        return 0
-    msg = data.get("user_visible_message") or "unknown error"
-    code = data.get("error", "")
-    sys.stderr.write(f"fleet error [{code}]: {msg}\n")
-    details = data.get("details")
-    if details:
-        sys.stderr.write(f"  details: {json.dumps(details)}\n")
-    return 3

--- a/src/autoskillit/cli/fleet/_fleet_display.py
+++ b/src/autoskillit/cli/fleet/_fleet_display.py
@@ -268,3 +268,25 @@ def _watch_loop(state_path: Path) -> int:
             termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
         except (termios.error, OSError):
             pass
+
+
+def render_fleet_error(envelope_json: str) -> int:
+    """Render a fleet error envelope to stderr.
+
+    Returns exit code: 3 for fleet envelope errors, 0 for non-error envelopes.
+    """
+    import json
+
+    try:
+        data = json.loads(envelope_json)
+    except (json.JSONDecodeError, TypeError):
+        return 0
+    if data.get("success") is not False:
+        return 0
+    msg = data.get("user_visible_message") or "unknown error"
+    code = data.get("error", "")
+    sys.stderr.write(f"fleet error [{code}]: {msg}\n")
+    details = data.get("details")
+    if details:
+        sys.stderr.write(f"  details: {json.dumps(details)}\n")
+    return 3

--- a/src/autoskillit/cli/fleet/_fleet_display.py
+++ b/src/autoskillit/cli/fleet/_fleet_display.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 import time
 from datetime import UTC, datetime
@@ -275,7 +276,6 @@ def render_fleet_error(envelope_json: str) -> int:
 
     Returns exit code: 3 for fleet envelope errors, 0 for non-error envelopes.
     """
-    import json
 
     try:
         data = json.loads(envelope_json)

--- a/src/autoskillit/cli/fleet/_fleet_preview.py
+++ b/src/autoskillit/cli/fleet/_fleet_preview.py
@@ -4,21 +4,42 @@ from __future__ import annotations
 
 from pathlib import Path
 
+_DISPATCH_TOOL_CATEGORIES: list[tuple[str, tuple[str, ...]]] = [
+    ("Dispatch", ("dispatch_food_truck",)),
+    ("Cleanup", ("batch_cleanup_clones",)),
+    (
+        "Telemetry",
+        ("get_pipeline_report", "get_token_summary", "get_timing_summary", "get_quota_events"),
+    ),
+    ("Recipes", ("list_recipes", "load_recipe")),
+    ("GitHub", ("fetch_github_issue", "get_issue_title")),
+]
 
-def _build_dispatch_recipe_table() -> str:
-    """Build a compact NAME — DESCRIPTION table of standard recipes for greeting injection."""
-    from autoskillit.recipe import RecipeKind, list_recipes
+_FLEET_DISPATCH_GREETINGS: list[str] = [
+    (
+        "Fleet dispatcher online. Your available food trucks:\n\n"
+        "{recipe_table}\n\n"
+        "Ready for dispatch orders."
+    ),
+    (
+        "Welcome to fleet dispatch — ad-hoc food truck coordination.\n\n"
+        "Available food trucks:\n\n"
+        "{recipe_table}\n\n"
+        "What targets are we dispatching to?"
+    ),
+    (
+        "Dispatcher standing by. Food truck roster:\n\n"
+        "{recipe_table}\n\n"
+        "Issue your dispatch orders when ready."
+    ),
+]
 
-    recipes = list_recipes(Path.cwd(), exclude_kinds=frozenset({RecipeKind.CAMPAIGN})).items
-    if not recipes:
-        return "(no recipes found)"
-    name_w = max(len(r.name) for r in recipes)
-    lines = [f"{r.name:<{name_w}}  {r.description}" for r in recipes]
-    return "\n".join(lines)
 
+def _print_dispatch_preview() -> str:
+    """Print the pre-launch summary for fleet dispatch (mirrors cook's pre-launch display).
 
-def _print_dispatch_preview(cfg: object) -> None:
-    """Print the pre-launch summary for fleet dispatch (mirrors cook's pre-launch display)."""
+    Returns the recipe table string (name + description) for greeting injection.
+    """
     from autoskillit.cli.ui._ansi import permissions_warning, supports_color
     from autoskillit.recipe import RecipeKind, list_recipes
 
@@ -39,26 +60,20 @@ def _print_dispatch_preview(cfg: object) -> None:
 
     recipes = list_recipes(Path.cwd(), exclude_kinds=frozenset({RecipeKind.CAMPAIGN})).items
     if recipes:
-        name_w = max(len(r.name) for r in recipes)
-        src_w = max(len(r.source) for r in recipes)
+        name_w = max(len(r.name or "") for r in recipes)
+        src_w = max(len(r.source or "") for r in recipes)
         print(f"\n{_B}Available food trucks:{_R}")
         print(f"  {'NAME':<{name_w}}  {'SOURCE':<{src_w}}  DESCRIPTION")
         print(f"  {'-' * name_w}  {'-' * src_w}  {'-' * 11}")
         for r in recipes:
-            print(f"  {_G}{r.name:<{name_w}}{_R}  {_D}{r.source:<{src_w}}{_R}  {r.description}")
+            name = r.name or ""
+            src = r.source or ""
+            print(f"  {_G}{name:<{name_w}}{_R}  {_D}{src:<{src_w}}{_R}  {r.description}")
+        greeting_table = "\n".join(f"{(r.name or ''):<{name_w}}  {r.description}" for r in recipes)
     else:
         print(f"\n{_D}No recipes found.{_R}")
+        greeting_table = "(no recipes found)"
 
-    _DISPATCH_TOOL_CATEGORIES: list[tuple[str, tuple[str, ...]]] = [
-        ("Dispatch", ("dispatch_food_truck",)),
-        ("Cleanup", ("batch_cleanup_clones",)),
-        (
-            "Telemetry",
-            ("get_pipeline_report", "get_token_summary", "get_timing_summary", "get_quota_events"),
-        ),
-        ("Recipes", ("list_recipes", "load_recipe")),
-        ("GitHub", ("fetch_github_issue", "get_issue_title")),
-    ]
     print()
     for name, tools in _DISPATCH_TOOL_CATEGORIES:
         tool_list = f"{_D}, {_R}".join(f"{_G}{t}{_R}" for t in tools)
@@ -66,3 +81,4 @@ def _print_dispatch_preview(cfg: object) -> None:
     print()
 
     print(permissions_warning())
+    return greeting_table

--- a/src/autoskillit/cli/fleet/_fleet_preview.py
+++ b/src/autoskillit/cli/fleet/_fleet_preview.py
@@ -1,0 +1,68 @@
+"""Pre-launch dispatch preview: recipe roster + tool surface display."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _build_dispatch_recipe_table() -> str:
+    """Build a compact NAME — DESCRIPTION table of standard recipes for greeting injection."""
+    from autoskillit.recipe import RecipeKind, list_recipes
+
+    recipes = list_recipes(Path.cwd(), exclude_kinds=frozenset({RecipeKind.CAMPAIGN})).items
+    if not recipes:
+        return "(no recipes found)"
+    name_w = max(len(r.name) for r in recipes)
+    lines = [f"{r.name:<{name_w}}  {r.description}" for r in recipes]
+    return "\n".join(lines)
+
+
+def _print_dispatch_preview(cfg: object) -> None:
+    """Print the pre-launch summary for fleet dispatch (mirrors cook's pre-launch display)."""
+    from autoskillit.cli.ui._ansi import permissions_warning, supports_color
+    from autoskillit.recipe import RecipeKind, list_recipes
+
+    color = supports_color()
+    _B = "\x1b[1m" if color else ""
+    _C = "\x1b[96m" if color else ""
+    _D = "\x1b[2m" if color else ""
+    _G = "\x1b[32m" if color else ""
+    _Y = "\x1b[33m" if color else ""
+    _R = "\x1b[0m" if color else ""
+
+    from autoskillit import __version__
+
+    print(
+        f"{_B}{_C}AUTOSKILLIT {__version__}{_R}"
+        f" {_D}Fleet dispatcher. Ad-hoc food truck coordination.{_R}"
+    )
+
+    recipes = list_recipes(Path.cwd(), exclude_kinds=frozenset({RecipeKind.CAMPAIGN})).items
+    if recipes:
+        name_w = max(len(r.name) for r in recipes)
+        src_w = max(len(r.source) for r in recipes)
+        print(f"\n{_B}Available food trucks:{_R}")
+        print(f"  {'NAME':<{name_w}}  {'SOURCE':<{src_w}}  DESCRIPTION")
+        print(f"  {'-' * name_w}  {'-' * src_w}  {'-' * 11}")
+        for r in recipes:
+            print(f"  {_G}{r.name:<{name_w}}{_R}  {_D}{r.source:<{src_w}}{_R}  {r.description}")
+    else:
+        print(f"\n{_D}No recipes found.{_R}")
+
+    _DISPATCH_TOOL_CATEGORIES: list[tuple[str, tuple[str, ...]]] = [
+        ("Dispatch", ("dispatch_food_truck",)),
+        ("Cleanup", ("batch_cleanup_clones",)),
+        (
+            "Telemetry",
+            ("get_pipeline_report", "get_token_summary", "get_timing_summary", "get_quota_events"),
+        ),
+        ("Recipes", ("list_recipes", "load_recipe")),
+        ("GitHub", ("fetch_github_issue", "get_issue_title")),
+    ]
+    print()
+    for name, tools in _DISPATCH_TOOL_CATEGORIES:
+        tool_list = f"{_D}, {_R}".join(f"{_G}{t}{_R}" for t in tools)
+        print(f"  {_Y}{name:>20}{_R}  {tool_list}")
+    print()
+
+    print(permissions_warning())

--- a/src/autoskillit/cli/fleet/_fleet_session.py
+++ b/src/autoskillit/cli/fleet/_fleet_session.py
@@ -35,6 +35,8 @@ def _launch_fleet_session(
     *,
     fleet_mode: Literal["dispatch", "campaign"],
     ingredients_table: str | None = None,
+    initial_message: str | None = None,
+    recipe_table: str | None = None,
 ) -> None:
     """Build the L3 orchestrator prompt and launch an interactive fleet session."""
     from autoskillit.cli import detect_autoskillit_mcp_prefix  # noqa: PLC0415
@@ -48,7 +50,7 @@ def _launch_fleet_session(
         # Ad-hoc mode: no campaign, no state, bare kitchen open
         from autoskillit.cli._prompts import _build_fleet_dispatch_prompt
 
-        prompt = _build_fleet_dispatch_prompt(mcp_prefix)
+        prompt = _build_fleet_dispatch_prompt(mcp_prefix, recipe_table=recipe_table)
         extra_env: dict[str, str] = {
             "AUTOSKILLIT_SESSION_TYPE": "fleet",
             "AUTOSKILLIT_FLEET_MODE": fleet_mode,
@@ -56,9 +58,11 @@ def _launch_fleet_session(
         }
         seen_reload_ids: set[str] = set()
         current_resume_spec: ResumeSpec = NoResume()
+        current_initial_message = initial_message
         while True:
             reload_id = _run_interactive_session(
                 prompt,
+                initial_message=current_initial_message,
                 extra_env=extra_env,
                 resume_spec=current_resume_spec,
                 project_dir=project_dir,
@@ -67,6 +71,7 @@ def _launch_fleet_session(
                 break
             _check_reload_guard(reload_id, seen_reload_ids)
             current_resume_spec = NamedResume(session_id=reload_id)
+            current_initial_message = None  # greeting only on first launch
     else:
         # Campaign-driven mode: full orchestrator prompt with manifest and state
         if campaign_id is None:

--- a/tests/arch/_rules.py
+++ b/tests/arch/_rules.py
@@ -62,6 +62,7 @@ _PRINT_EXEMPT = frozenset(
         "_menu.py",
         "_fleet_display.py",
         "_fleet_lifecycle.py",
+        "_fleet_preview.py",
         "_fleet_session.py",
         "_session_picker.py",
         "_fleet.py",

--- a/tests/cli/test_fleet_dispatch.py
+++ b/tests/cli/test_fleet_dispatch.py
@@ -478,7 +478,7 @@ def test_fleet_dispatch_greeting_contains_recipe_descriptions(
 
 def test_fleet_dispatch_greetings_have_recipe_table_placeholder() -> None:
     """All _FLEET_DISPATCH_GREETINGS entries must contain {recipe_table}."""
-    from autoskillit.cli._prompts import _FLEET_DISPATCH_GREETINGS
+    from autoskillit.cli.fleet._fleet_preview import _FLEET_DISPATCH_GREETINGS
 
     assert len(_FLEET_DISPATCH_GREETINGS) >= 3
     for greeting in _FLEET_DISPATCH_GREETINGS:
@@ -571,6 +571,9 @@ def test_launch_fleet_session_clears_initial_message_on_reload(
         None,
         fleet_mode="dispatch",
         initial_message="Hello!",
+    )
+    assert len(captured_messages) >= 2, (
+        f"expected reload to fire but got only {len(captured_messages)} call(s)"
     )
     assert captured_messages[0] == "Hello!"
     assert captured_messages[1] is None

--- a/tests/cli/test_fleet_dispatch.py
+++ b/tests/cli/test_fleet_dispatch.py
@@ -16,6 +16,32 @@ from tests.cli._fleet_helpers import (
 pytestmark = [pytest.mark.layer("cli"), pytest.mark.medium, pytest.mark.feature("fleet")]
 
 
+def _fake_recipe(name: str, source: str, description: str) -> object:
+    """Create a minimal RecipeInfo-like object for test stubs."""
+    return type(
+        "RecipeInfo",
+        (),
+        {
+            "name": name,
+            "source": source,
+            "description": description,
+            "kind": "standard",
+            "path": Path(f"/fake/{name}.yaml"),
+            "summary": "",
+            "version": None,
+            "recipe_version": None,
+            "content_hash": "",
+            "content": None,
+        },
+    )()
+
+
+def _stub_list_recipes(monkeypatch: pytest.MonkeyPatch, recipes: list) -> None:
+    """Stub list_recipes to return the given recipe list."""
+    result = type("LoadResult", (), {"items": recipes, "errors": []})()
+    monkeypatch.setattr("autoskillit.recipe.list_recipes", lambda *a, **kw: result)
+
+
 # ---------------------------------------------------------------------------
 # T1. fleet dispatch — CLAUDECODE guard
 # ---------------------------------------------------------------------------
@@ -56,10 +82,20 @@ def test_fleet_dispatch_rejects_deprecated_leaf_session_type(
 # ---------------------------------------------------------------------------
 
 
-def test_fleet_dispatch_exits_when_claude_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_fleet_dispatch_exits_when_claude_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     """fleet dispatch exits 1 when claude is not on PATH."""
+    monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("CLAUDECODE", raising=False)
     monkeypatch.delenv("AUTOSKILLIT_SESSION_TYPE", raising=False)
+    monkeypatch.setattr("autoskillit.cli.fleet.is_feature_enabled", lambda *a, **kw: True)
+    monkeypatch.setattr(
+        "autoskillit.config.load_config",
+        lambda path: type("C", (), {"features": {}, "experimental_enabled": False})(),
+    )
+    _stub_list_recipes(monkeypatch, [])
+    monkeypatch.setattr("autoskillit.cli.ui._timed_input.timed_prompt", lambda *a, **kw: "")
     monkeypatch.setattr(shutil, "which", lambda _: None)
     with pytest.raises(SystemExit, match="1"):
         _fleet_dispatch()
@@ -112,6 +148,8 @@ def test_fleet_dispatch_proceeds_when_enabled(
         "autoskillit.config.load_config",
         lambda path: type("C", (), {"features": {}, "experimental_enabled": False})(),
     )
+    _stub_list_recipes(monkeypatch, [])
+    monkeypatch.setattr("autoskillit.cli.ui._timed_input.timed_prompt", lambda *a, **kw: "")
     captured = _capture_subprocess(monkeypatch)
     _fleet_dispatch()
     assert captured.get("cmd") is not None, "Expected fleet session subprocess to be invoked"
@@ -129,6 +167,8 @@ def test_fleet_dispatch_sets_fleet_mode_dispatch(
     """fleet_dispatch() must launch an interactive session, not exit 1."""
     _stub_guards(monkeypatch)
     monkeypatch.chdir(tmp_path)
+    _stub_list_recipes(monkeypatch, [])
+    monkeypatch.setattr("autoskillit.cli.ui._timed_input.timed_prompt", lambda *a, **kw: "")
     captured = _capture_subprocess(monkeypatch)
     _fleet_dispatch()
     assert captured["env"].get("AUTOSKILLIT_FLEET_MODE") == "dispatch"
@@ -138,6 +178,8 @@ def test_fleet_dispatch_writes_no_state(monkeypatch: pytest.MonkeyPatch, tmp_pat
     """fleet_dispatch must not create a state.json under .autoskillit/temp/fleet/."""
     _stub_guards(monkeypatch)
     monkeypatch.chdir(tmp_path)
+    _stub_list_recipes(monkeypatch, [])
+    monkeypatch.setattr("autoskillit.cli.ui._timed_input.timed_prompt", lambda *a, **kw: "")
     _capture_subprocess(monkeypatch)
     _fleet_dispatch()
     fleet_dir = tmp_path / ".autoskillit" / "temp" / "fleet"
@@ -150,6 +192,8 @@ def test_fleet_dispatch_no_campaign_env_vars(
     """Ad-hoc session must not set AUTOSKILLIT_CAMPAIGN_ID or AUTOSKILLIT_CAMPAIGN_STATE_PATH."""
     _stub_guards(monkeypatch)
     monkeypatch.chdir(tmp_path)
+    _stub_list_recipes(monkeypatch, [])
+    monkeypatch.setattr("autoskillit.cli.ui._timed_input.timed_prompt", lambda *a, **kw: "")
     captured = _capture_subprocess(monkeypatch)
     _fleet_dispatch()
     env = captured["env"]
@@ -287,3 +331,246 @@ def test_build_fleet_dispatch_prompt_uses_ingredients_only() -> None:
 
     prompt = _build_fleet_dispatch_prompt(DIRECT_PREFIX)
     assert "ingredients_only" in prompt
+
+
+# ---------------------------------------------------------------------------
+# T_PREVIEW: Pre-launch display
+# ---------------------------------------------------------------------------
+
+
+def test_fleet_dispatch_prints_recipe_roster(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """fleet_dispatch prints a food truck roster table before launching."""
+    _stub_guards(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+    _stub_list_recipes(
+        monkeypatch,
+        [
+            _fake_recipe("smoke-test", "BUILTIN", "Run smoke tests"),
+            _fake_recipe("review-pr", "BUILTIN", "Review a pull request"),
+        ],
+    )
+    monkeypatch.setattr("autoskillit.cli.ui._timed_input.timed_prompt", lambda *a, **kw: "")
+    _capture_subprocess(monkeypatch)
+    _fleet_dispatch()
+    out = capsys.readouterr().out
+    assert "smoke-test" in out
+    assert "review-pr" in out
+
+
+def test_fleet_dispatch_shows_permissions_warning(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """fleet_dispatch prints the permissions_warning text."""
+    _stub_guards(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+    _stub_list_recipes(monkeypatch, [])
+    monkeypatch.setattr("autoskillit.cli.ui._timed_input.timed_prompt", lambda *a, **kw: "")
+    _capture_subprocess(monkeypatch)
+    _fleet_dispatch()
+    out = capsys.readouterr().out
+    assert "dangerously-skip-permissions" in out
+
+
+def test_fleet_dispatch_aborts_on_no(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """fleet_dispatch returns without launching when user types 'n'."""
+    _stub_guards(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+    _stub_list_recipes(monkeypatch, [])
+    monkeypatch.setattr("autoskillit.cli.ui._timed_input.timed_prompt", lambda *a, **kw: "n")
+    captured = _capture_subprocess(monkeypatch)
+    _fleet_dispatch()
+    assert "cmd" not in captured, "Session should not launch when user aborts"
+
+
+def test_fleet_dispatch_prints_fleet_tool_surface(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """fleet_dispatch prints the 10 fleet tool names before launching."""
+    _stub_guards(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+    _stub_list_recipes(monkeypatch, [])
+    monkeypatch.setattr("autoskillit.cli.ui._timed_input.timed_prompt", lambda *a, **kw: "")
+    _capture_subprocess(monkeypatch)
+    _fleet_dispatch()
+    out = capsys.readouterr().out
+    assert "dispatch_food_truck" in out
+    assert "batch_cleanup_clones" in out
+    assert "list_recipes" in out
+
+
+def test_fleet_dispatch_prints_version_header(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """fleet_dispatch prints AUTOSKILLIT <version> header line."""
+    _stub_guards(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+    _stub_list_recipes(monkeypatch, [])
+    monkeypatch.setattr("autoskillit.cli.ui._timed_input.timed_prompt", lambda *a, **kw: "")
+    _capture_subprocess(monkeypatch)
+    _fleet_dispatch()
+    out = capsys.readouterr().out
+    assert "AUTOSKILLIT" in out
+    assert "Fleet dispatcher" in out or "fleet dispatcher" in out.lower()
+
+
+# ---------------------------------------------------------------------------
+# T_GREETING: Greeting injection
+# ---------------------------------------------------------------------------
+
+
+def test_fleet_dispatch_passes_initial_message(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """fleet_dispatch passes a non-None initial_message to _run_interactive_session."""
+    _stub_guards(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+    _stub_list_recipes(
+        monkeypatch,
+        [_fake_recipe("smoke-test", "BUILTIN", "Run smoke tests")],
+    )
+    monkeypatch.setattr("autoskillit.cli.ui._timed_input.timed_prompt", lambda *a, **kw: "")
+    captured_kwargs: dict = {}
+
+    def mock_run_session(system_prompt: str, **kwargs: object) -> None:
+        captured_kwargs.update(kwargs)
+        return None
+
+    monkeypatch.setattr(
+        "autoskillit.cli.session._session_launch._run_interactive_session",
+        mock_run_session,
+    )
+    _fleet_dispatch()
+    assert captured_kwargs.get("initial_message") is not None
+    assert "smoke-test" in captured_kwargs["initial_message"]
+
+
+def test_fleet_dispatch_greeting_contains_recipe_descriptions(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The initial_message greeting includes recipe names and descriptions."""
+    _stub_guards(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+    _stub_list_recipes(
+        monkeypatch,
+        [
+            _fake_recipe("review-pr", "BUILTIN", "Review a pull request"),
+            _fake_recipe("implement", "BUILTIN", "Implement a feature"),
+        ],
+    )
+    monkeypatch.setattr("autoskillit.cli.ui._timed_input.timed_prompt", lambda *a, **kw: "")
+    captured_kwargs: dict = {}
+
+    def mock_run_session(system_prompt: str, **kwargs: object) -> None:
+        captured_kwargs.update(kwargs)
+        return None
+
+    monkeypatch.setattr(
+        "autoskillit.cli.session._session_launch._run_interactive_session",
+        mock_run_session,
+    )
+    _fleet_dispatch()
+    greeting = captured_kwargs["initial_message"]
+    assert "review-pr" in greeting
+    assert "implement" in greeting
+
+
+def test_fleet_dispatch_greetings_have_recipe_table_placeholder() -> None:
+    """All _FLEET_DISPATCH_GREETINGS entries must contain {recipe_table}."""
+    from autoskillit.cli._prompts import _FLEET_DISPATCH_GREETINGS
+
+    assert len(_FLEET_DISPATCH_GREETINGS) >= 3
+    for greeting in _FLEET_DISPATCH_GREETINGS:
+        assert "{recipe_table}" in greeting
+
+
+# ---------------------------------------------------------------------------
+# T_PROMPT: recipe_table injection into system prompt
+# ---------------------------------------------------------------------------
+
+
+def test_build_fleet_dispatch_prompt_embeds_recipe_table() -> None:
+    """_build_fleet_dispatch_prompt embeds recipe_table under AVAILABLE FOOD TRUCKS section."""
+    from autoskillit.cli._mcp_names import DIRECT_PREFIX
+    from autoskillit.cli._prompts import _build_fleet_dispatch_prompt
+
+    table = "smoke-test — Run smoke tests\nreview-pr — Review a PR"
+    prompt = _build_fleet_dispatch_prompt(DIRECT_PREFIX, recipe_table=table)
+    assert "AVAILABLE FOOD TRUCKS" in prompt
+    assert "smoke-test" in prompt
+    assert "review-pr" in prompt
+
+
+def test_build_fleet_dispatch_prompt_no_recipe_table_section_when_none() -> None:
+    """_build_fleet_dispatch_prompt omits AVAILABLE FOOD TRUCKS when recipe_table is None."""
+    from autoskillit.cli._mcp_names import DIRECT_PREFIX
+    from autoskillit.cli._prompts import _build_fleet_dispatch_prompt
+
+    prompt = _build_fleet_dispatch_prompt(DIRECT_PREFIX)
+    assert "AVAILABLE FOOD TRUCKS" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# T_SESSION: _launch_fleet_session initial_message forwarding
+# ---------------------------------------------------------------------------
+
+
+def test_launch_fleet_session_forwards_initial_message_dispatch(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """_launch_fleet_session passes initial_message to _run_interactive_session."""
+    monkeypatch.chdir(tmp_path)
+    captured_kwargs: dict = {}
+
+    def mock_run(system_prompt: str, **kwargs: object) -> None:
+        captured_kwargs.update(kwargs)
+        return None
+
+    monkeypatch.setattr(
+        "autoskillit.cli.session._session_launch._run_interactive_session",
+        mock_run,
+    )
+    from autoskillit.cli.fleet._fleet_session import _launch_fleet_session
+
+    _launch_fleet_session(
+        None,
+        None,
+        None,
+        None,
+        fleet_mode="dispatch",
+        initial_message="Hello, dispatcher!",
+    )
+    assert captured_kwargs.get("initial_message") == "Hello, dispatcher!"
+
+
+def test_launch_fleet_session_clears_initial_message_on_reload(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """On reload, initial_message must be None (only injected on first launch)."""
+    monkeypatch.chdir(tmp_path)
+    call_count = 0
+    captured_messages: list = []
+
+    def mock_run(system_prompt: str, **kwargs: object) -> object:
+        nonlocal call_count
+        captured_messages.append(kwargs.get("initial_message"))
+        call_count += 1
+        return "reload-session-abc" if call_count == 1 else None
+
+    monkeypatch.setattr(
+        "autoskillit.cli.session._session_launch._run_interactive_session",
+        mock_run,
+    )
+    from autoskillit.cli.fleet._fleet_session import _launch_fleet_session
+
+    _launch_fleet_session(
+        None,
+        None,
+        None,
+        None,
+        fleet_mode="dispatch",
+        initial_message="Hello!",
+    )
+    assert captured_messages[0] == "Hello!"
+    assert captured_messages[1] is None

--- a/tests/cli/test_reload_loop.py
+++ b/tests/cli/test_reload_loop.py
@@ -213,7 +213,7 @@ def test_fleet_reload_relaunches_without_resume(
     monkeypatch.setattr("autoskillit.cli.detect_autoskillit_mcp_prefix", lambda: "autoskillit")
     monkeypatch.setattr(
         "autoskillit.cli._prompts._build_fleet_dispatch_prompt",
-        lambda mcp_prefix: "test-prompt",
+        lambda mcp_prefix, recipe_table=None: "test-prompt",
     )
     monkeypatch.chdir(tmp_path)
 

--- a/tests/cli/test_reload_loop.py
+++ b/tests/cli/test_reload_loop.py
@@ -198,7 +198,7 @@ def test_fleet_reload_relaunches_without_resume(
     captured_resume_specs: list = []
 
     def fake_run_interactive_session(
-        prompt, *, extra_env=None, resume_spec=None, project_dir=None
+        prompt, *, extra_env=None, resume_spec=None, project_dir=None, initial_message=None
     ):
         call_count[0] += 1
         captured_resume_specs.append(resume_spec)


### PR DESCRIPTION
## Summary

Bring `autoskillit fleet dispatch` to parity with the cook/order pre-launch experience. Three additions: (1) a pre-launch CLI display showing a food truck roster, fleet tool surface, permissions warning, and confirmation prompt; (2) a `_FLEET_DISPATCH_GREETINGS` pool with `{recipe_table}` interpolation injected as `initial_message` so the L3 agent starts with pre-populated recipe knowledge; (3) a `recipe_table` parameter on `_build_fleet_dispatch_prompt()` that embeds the recipe listing in the system prompt, eliminating the `list_recipes` tool round-trip.

Closes #1735

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260504-180624-868796/.autoskillit/temp/make-plan/fleet_dispatch_pre_launch_preview_plan_2026-05-04_183800.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 5.3k | 15.3k | 1.2M | 85.4k | 111 | 85.7k | 9m 10s |
| verify | 1 | 49 | 14.3k | 2.1M | 83.6k | 76 | 72.3k | 6m 53s |
| **Total** | | 5.4k | 29.6k | 3.3M | 85.4k | | 157.9k | 16m 4s |