### PR TITLE
feat: add provider_used parameter to _build_skill_result

### DIFF
--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -417,6 +417,7 @@ async def _execute_claude_headless(
             cwd=cwd,
             write_behavior=write_behavior,
             fs_writes_detected=_fs_writes_detected,
+            provider_used=provider_name,
         )
 
         if (

--- a/src/autoskillit/execution/headless/_headless_result.py
+++ b/src/autoskillit/execution/headless/_headless_result.py
@@ -138,6 +138,8 @@ def _build_skill_result(
     cwd: str = "",
     write_behavior: WriteBehaviorSpec | None = None,
     fs_writes_detected: bool = False,
+    *,
+    provider_used: str = "",
 ) -> SkillResult:
     """Route SubprocessResult fields into the standard run_skill response."""
     branch = (
@@ -192,6 +194,7 @@ def _build_skill_result(
                     stderr=result.stderr if result.stderr else "",
                     token_usage=stale_session.token_usage,
                     last_stop_reason=stale_session.last_stop_reason,
+                    provider_used=provider_used,
                 )
         # No valid result in stdout — fall through to original stale response
         _capture_failure(
@@ -217,6 +220,7 @@ def _build_skill_result(
             retry_reason=RetryReason.STALE,
             stderr="",
             token_usage=None,
+            provider_used=provider_used,
         )
         return _apply_budget_guard(stale_sr, skill_command, audit, max_consecutive_retries)
 
@@ -247,6 +251,7 @@ def _build_skill_result(
             retry_reason=RetryReason.STALE,
             stderr="",
             token_usage=None,
+            provider_used=provider_used,
         )
         return _apply_budget_guard(idle_sr, skill_command, audit, max_consecutive_retries)
 
@@ -465,6 +470,7 @@ def _build_skill_result(
             fs_writes_detected=fs_writes_detected,
             last_stop_reason=session.last_stop_reason,
             lifespan_started=session.lifespan_started,
+            provider_used=provider_used,
         )
     else:
         sr = SkillResult(
@@ -486,6 +492,7 @@ def _build_skill_result(
             kill_reason=result.kill_reason,
             last_stop_reason=session.last_stop_reason,
             lifespan_started=session.lifespan_started,
+            provider_used=provider_used,
         )
     sr = _apply_budget_guard(sr, skill_command, audit, max_consecutive_retries)
 

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -14,7 +14,7 @@ NEW_HEADLESS_MODULES = [
     "_headless_result.py",
 ]
 HEADLESS_SIZE_BUDGETS = {
-    "headless/__init__.py": 823,
+    "headless/__init__.py": 824,
     "headless/_headless_recovery.py": 320,
     "headless/_headless_path_tokens.py": 175,
     "headless/_headless_result.py": 595,

--- a/tests/arch/test_layer_enforcement.py
+++ b/tests/arch/test_layer_enforcement.py
@@ -1199,6 +1199,8 @@ _TEST_LAYER_ALLOWLIST: dict[str, frozenset[str]] = {
     # session_log retention tests verify callback injection into
     # _enforce_retention — needs fleet.state
     "tests/execution/test_session_log_retention.py": frozenset({"autoskillit.fleet"}),
+    # provider forwarding test verifies budget guard preserves provider_used — needs DefaultAuditLog
+    "tests/execution/test_headless_provider_forwarding.py": frozenset({"autoskillit.pipeline"}),
 }
 
 

--- a/tests/execution/test_headless_provider_forwarding.py
+++ b/tests/execution/test_headless_provider_forwarding.py
@@ -307,3 +307,49 @@ def test_headless_executor_protocol_includes_provider_params() -> None:
     sig = inspect.signature(HeadlessExecutor.run)
     assert sig.parameters["provider_name"].default == ""
     assert sig.parameters["provider_fallback_env"].default is None
+
+
+def test_build_skill_result_accepts_provider_used_kwarg() -> None:
+    import inspect
+
+    from autoskillit.execution.headless._headless_result import _build_skill_result
+
+    sig = inspect.signature(_build_skill_result)
+    param = sig.parameters["provider_used"]
+    assert param.default == ""
+    assert param.kind == inspect.Parameter.KEYWORD_ONLY
+
+
+def test_build_skill_result_stamps_provider_used_on_result() -> None:
+    from autoskillit.execution.headless._headless_result import _build_skill_result
+    from tests.execution.conftest import _sr
+
+    sub_result = _sr(stdout="result: done\n", returncode=0)
+    sr = _build_skill_result(sub_result, provider_used="vertex")
+    assert sr.provider_used == "vertex"
+
+
+def test_build_skill_result_defaults_provider_used_empty() -> None:
+    from autoskillit.execution.headless._headless_result import _build_skill_result
+    from tests.execution.conftest import _sr
+
+    sub_result = _sr(stdout="result: done\n", returncode=0)
+    sr = _build_skill_result(sub_result)
+    assert sr.provider_used == ""
+
+
+def test_build_skill_result_provider_used_survives_budget_guard() -> None:
+    from autoskillit.execution.headless._headless_result import _build_skill_result
+    from autoskillit.pipeline.audit import DefaultAuditLog
+    from tests.execution.conftest import _sr
+
+    audit = DefaultAuditLog()
+    sub_result = _sr(stdout="", returncode=1)
+    sr = _build_skill_result(
+        sub_result,
+        skill_command="/test:cmd",
+        audit=audit,
+        max_consecutive_retries=3,
+        provider_used="bedrock",
+    )
+    assert sr.provider_used == "bedrock"

--- a/tests/execution/test_headless_provider_forwarding.py
+++ b/tests/execution/test_headless_provider_forwarding.py
@@ -327,15 +327,8 @@ def test_build_skill_result_stamps_provider_used_on_result() -> None:
     sub_result = _sr(stdout="result: done\n", returncode=0)
     sr = _build_skill_result(sub_result, provider_used="vertex")
     assert sr.provider_used == "vertex"
-
-
-def test_build_skill_result_defaults_provider_used_empty() -> None:
-    from autoskillit.execution.headless._headless_result import _build_skill_result
-    from tests.execution.conftest import _sr
-
-    sub_result = _sr(stdout="result: done\n", returncode=0)
-    sr = _build_skill_result(sub_result)
-    assert sr.provider_used == ""
+    sr_default = _build_skill_result(sub_result)
+    assert sr_default.provider_used == ""
 
 
 def test_build_skill_result_provider_used_survives_budget_guard() -> None:


### PR DESCRIPTION
## Summary

Add a `provider_used: str = ''` keyword-only parameter to `_build_skill_result` in `_headless_result.py` and pass it through to all five `SkillResult()` constructor calls within the function body. Update the single production call site in `_execute_claude_headless` (`__init__.py:411`) to forward `provider_used=provider_name`. The three `dataclasses.replace()` mutations within `_build_skill_result` (budget guard, CONTRACT_RECOVERY gate, zero-write gate) need no changes — `dataclasses.replace()` preserves fields not explicitly overridden.

Closes #1775

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260504-204430-222012/.autoskillit/temp/make-plan/add_provider_used_to_build_skill_result_plan_2026-05-04_204700.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 921 | 9.4k | 491.8k | 57.3k | 62 | 47.7k | 5m 50s |
| verify | 1 | 708 | 10.9k | 982.9k | 67.5k | 54 | 54.4k | 5m 48s |
| implement | 1 | 270 | 15.2k | 1.8M | 71.6k | 93 | 58.6k | 3m 54s |
| prepare_pr | 1 | 60 | 4.9k | 200.0k | 36.2k | 21 | 23.9k | 1m 33s |
| compose_pr | 1 | 51 | 1.8k | 151.0k | 29.5k | 14 | 16.5k | 39s |
| review_pr | 1 | 102 | 25.8k | 506.2k | 65.5k | 41 | 55.1k | 5m 41s |
| resolve_review | 1 | 213 | 8.2k | 1.0M | 53.9k | 63 | 41.3k | 6m 5s |
| **Total** | | 2.3k | 76.2k | 5.2M | 71.6k | | 297.4k | 29m 34s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 54 | 33995.0 | 1085.5 | 280.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 11 | 93625.1 | 3751.2 | 747.6 |
| **Total** | **65** | 79961.6 | 4575.2 | 1172.4 |