### PR TITLE
Session Log Provider Field Assertion Tests

### DIFF
--- a/tests/execution/test_session_log_fields.py
+++ b/tests/execution/test_session_log_fields.py
@@ -609,6 +609,11 @@ def test_flush_index_includes_duration_seconds(tmp_path):
     assert entry["duration_seconds"] == pytest.approx(42.5)
 
 
+# ---------------------------------------------------------------------------
+# Provider field tests
+# ---------------------------------------------------------------------------
+
+
 def test_flush_session_log_provider_used_in_summary(tmp_path):
     _flush(tmp_path, session_id="prov-sum", provider_used="minimax", proc_snapshots=None)
     summary = json.loads((tmp_path / "sessions" / "prov-sum" / "summary.json").read_text())
@@ -767,3 +772,15 @@ def test_parallel_lists_aligned_when_timestamp_missing(tmp_path, monkeypatch):
     assert summary["turn_timestamps"][0] == "2026-05-04T00:00:00Z"
     assert summary["turn_timestamps"][1] == ""
     assert summary["turn_tool_calls"] == [["Read"], ["Edit"]]
+
+
+def test_flush_session_log_provider_used_defaults_to_empty_string(tmp_path):
+    _flush(tmp_path, session_id="prov-def-001", proc_snapshots=None)
+    entry = json.loads((tmp_path / "sessions.jsonl").read_text().strip().split("\n")[-1])
+    assert entry["provider_used"] == ""
+
+
+def test_flush_session_log_provider_fallback_defaults_to_false(tmp_path):
+    _flush(tmp_path, session_id="prov-def-002", proc_snapshots=None)
+    entry = json.loads((tmp_path / "sessions.jsonl").read_text().strip().split("\n")[-1])
+    assert entry["provider_fallback"] is False


### PR DESCRIPTION
## Summary

Add the missing provider field assertion tests to `tests/execution/test_session_log_fields.py` as specified by issue #1780. The dependency (#1776) already landed `provider_used` and `provider_fallback` in `flush_session_log` and added 8 provider tests. Of the 5 tests the issue requests, 3 already exist by exact function name or semantic equivalence. This plan adds the 2 genuinely missing index-level default tests and the `# Provider field tests` section comment.

Closes #1780

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260504-204432-158558/.autoskillit/temp/make-plan/p3_a6_wp3_session_log_provider_field_assertion_tests_plan_2026-05-04_210000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 52 | 7.8k | 681.3k | 51.5k | 37 | 40.9k | 4m 51s |
| verify | 1 | 32 | 4.0k | 537.3k | 47.1k | 34 | 34.0k | 2m 4s |
| implement | 1 | 92 | 3.2k | 384.2k | 43.2k | 28 | 30.4k | 1m 34s |
| prepare_pr | 1 | 60 | 4.1k | 196.5k | 34.5k | 18 | 22.0k | 1m 30s |
| compose_pr | 1 | 59 | 2.0k | 180.1k | 29.5k | 16 | 16.5k | 48s |
| review_pr | 1 | 84 | 10.7k | 362.0k | 46.6k | 33 | 34.2k | 3m 17s |
| resolve_queue_merge_conflicts | 1 | 148 | 6.3k | 672.4k | 47.9k | 47 | 35.1k | 1m 56s |
| **Total** | | 527 | 38.1k | 3.0M | 51.5k | | 213.1k | 16m 4s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 17 | 22602.8 | 1789.8 | 186.4 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_queue_merge_conflicts | 995 | 675.7 | 35.3 | 6.4 |
| **Total** | **1012** | 2978.1 | 210.5 | 37.7 |