### PR TITLE
Implementation Plan: Fallback Loop Unit Tests — STALE and BUDGET_EXHAUSTED Trigger Provider Switch

### DIFF
--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -452,6 +452,7 @@ async def _execute_claude_headless(
             skill_result.retry_reason in {RetryReason.STALE, RetryReason.BUDGET_EXHAUSTED}
             and provider_fallback_env is not None
             and remaining_attempts > 0
+            and provider_name
             and is_feature_enabled("providers", ctx.config.features)
         ):
             if not fallback_activated:

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -14,7 +14,7 @@ NEW_HEADLESS_MODULES = [
     "_headless_result.py",
 ]
 HEADLESS_SIZE_BUDGETS = {
-    "headless/__init__.py": 824,
+    "headless/__init__.py": 825,
     "headless/_headless_recovery.py": 320,
     "headless/_headless_path_tokens.py": 175,
     "headless/_headless_result.py": 595,

--- a/tests/execution/CLAUDE.md
+++ b/tests/execution/CLAUDE.md
@@ -28,6 +28,7 @@ Subprocess integration, headless session, process lifecycle, and session result 
 | `test_headless_env_scrub.py` | Launch-site env-scrub contract test for run_headless_core |
 | `test_headless_ordering.py` | AST-based structural test for post-session operation ordering in headless.py |
 | `test_headless_path_validation.py` | Tests for headless.py: _build_skill_result, path validation, synthesis, and contract gates |
+| `test_headless_provider_fallback.py` | Tests for the provider fallback loop in _execute_claude_headless — STALE and BUDGET_EXHAUSTED trigger provider switch |
 | `test_headless_provider_forwarding.py` | Tests verifying provider_extras and profile_name forwarding through the headless call chain |
 | `test_headless_synthesis.py` | Tests for headless.py synthesis helpers: output path extraction, validation, contamination |
 | `test_idle_output_env.py` | Group G (execution part): AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT env variable injection tests |

--- a/tests/execution/test_headless_provider_fallback.py
+++ b/tests/execution/test_headless_provider_fallback.py
@@ -14,6 +14,8 @@ from autoskillit.core.types import RetryReason, SkillResult
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
+_PROVIDER_RETRY_LIMIT = 2
+
 _STALE_RESULT = SkillResult(
     success=False,
     result="",
@@ -61,7 +63,7 @@ def _make_queued_build_result(*results: SkillResult):
 
 
 class TestProviderFallbackLoop:
-    def _patch_common(self, monkeypatch, tmp_path, build_result_fn):
+    def _patch_common(self, monkeypatch, tmp_path, build_result_fn, ctx=None):
         import autoskillit.execution.session_log as _sl_mod
         from autoskillit.execution.headless import PostSessionMetrics
         from tests.execution.conftest import _sr
@@ -72,6 +74,11 @@ class TestProviderFallbackLoop:
         async def fake_runner(cmd, **kwargs):  # noqa: ARG001
             call_count[0] += 1
             return _sub_result
+
+        if ctx is not None:
+            monkeypatch.setattr(
+                ctx.config.providers, "provider_retry_limit", _PROVIDER_RETRY_LIMIT
+            )
 
         monkeypatch.setattr(
             "autoskillit.execution.headless._build_skill_result",
@@ -106,6 +113,7 @@ class TestProviderFallbackLoop:
             monkeypatch,
             tmp_path,
             _make_queued_build_result(_STALE_RESULT, _SUCCESS_RESULT),
+            ctx=minimal_ctx,
         )
         minimal_ctx.runner = fake_runner
 
@@ -133,6 +141,7 @@ class TestProviderFallbackLoop:
             monkeypatch,
             tmp_path,
             _make_queued_build_result(_BUDGET_EXHAUSTED_RESULT, _SUCCESS_RESULT),
+            ctx=minimal_ctx,
         )
         minimal_ctx.runner = fake_runner
 
@@ -184,6 +193,7 @@ class TestProviderFallbackLoop:
             monkeypatch,
             tmp_path,
             _make_queued_build_result(_STALE_RESULT),
+            ctx=minimal_ctx,
         )
         minimal_ctx.runner = fake_runner
 
@@ -194,6 +204,8 @@ class TestProviderFallbackLoop:
             timeout=30.0,
             stale_threshold=5.0,
             provider_name="",
+            provider_fallback_env={"ANTHROPIC_API_KEY": "sk-test"},
+            provider_fallback_name="anthropic",
         )
 
         assert call_count[0] == 1

--- a/tests/execution/test_headless_provider_fallback.py
+++ b/tests/execution/test_headless_provider_fallback.py
@@ -1,0 +1,200 @@
+"""Tests verifying the provider fallback loop in _execute_claude_headless.
+
+Covers: STALE triggers fallback, BUDGET_EXHAUSTED triggers fallback,
+no fallback_env suppresses retry, and empty provider (Anthropic) never falls back.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+
+import pytest
+
+from autoskillit.core.types import RetryReason, SkillResult
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+_STALE_RESULT = SkillResult(
+    success=False,
+    result="",
+    session_id="s1",
+    subtype="stale",
+    is_error=False,
+    exit_code=1,
+    needs_retry=True,
+    retry_reason=RetryReason.STALE,
+    stderr="",
+)
+
+_BUDGET_EXHAUSTED_RESULT = SkillResult(
+    success=False,
+    result="",
+    session_id="s1",
+    subtype="budget_exhausted",
+    is_error=False,
+    exit_code=1,
+    needs_retry=False,
+    retry_reason=RetryReason.BUDGET_EXHAUSTED,
+    stderr="",
+)
+
+_SUCCESS_RESULT = SkillResult(
+    success=True,
+    result="done",
+    session_id="s2",
+    subtype="success",
+    is_error=False,
+    exit_code=0,
+    needs_retry=False,
+    retry_reason=RetryReason.NONE,
+    stderr="",
+)
+
+
+def _make_queued_build_result(*results: SkillResult):
+    q: deque[SkillResult] = deque(results)
+
+    def _build(*args, **kwargs):  # noqa: ARG001
+        return q.popleft()
+
+    return _build
+
+
+class TestProviderFallbackLoop:
+    def _patch_common(self, monkeypatch, tmp_path, build_result_fn):
+        import autoskillit.execution.session_log as _sl_mod
+        from autoskillit.execution.headless import PostSessionMetrics
+        from tests.execution.conftest import _sr
+
+        _sub_result = _sr()
+        call_count: list[int] = [0]
+
+        async def fake_runner(cmd, **kwargs):  # noqa: ARG001
+            call_count[0] += 1
+            return _sub_result
+
+        monkeypatch.setattr(
+            "autoskillit.execution.headless._build_skill_result",
+            build_result_fn,
+        )
+        monkeypatch.setattr(
+            "autoskillit.execution.headless._compute_post_session_metrics",
+            lambda *a, **kw: PostSessionMetrics(0, 0, str(tmp_path)),  # noqa: ARG005
+        )
+        monkeypatch.setattr(
+            "autoskillit.execution.headless._capture_git_head_sha",
+            lambda *a: "",  # noqa: ARG005
+        )
+        monkeypatch.setattr(
+            "autoskillit.execution.headless.is_feature_enabled",
+            lambda name, *a, **kw: name == "providers",  # noqa: ARG005
+        )
+        monkeypatch.setattr(
+            "autoskillit.execution.headless.collect_version_snapshot",
+            lambda: {},
+        )
+        monkeypatch.setattr(_sl_mod, "flush_session_log", lambda **kw: None)  # noqa: ARG005
+
+        return fake_runner, call_count
+
+    @pytest.mark.anyio
+    async def test_stale_triggers_fallback(self, minimal_ctx, tmp_path, monkeypatch):
+        from autoskillit.execution.commands import ClaudeHeadlessCmd
+        from autoskillit.execution.headless import _execute_claude_headless
+
+        fake_runner, call_count = self._patch_common(
+            monkeypatch,
+            tmp_path,
+            _make_queued_build_result(_STALE_RESULT, _SUCCESS_RESULT),
+        )
+        minimal_ctx.runner = fake_runner
+
+        result = await _execute_claude_headless(
+            ClaudeHeadlessCmd(cmd=["echo", "test"], env={}),
+            str(tmp_path),
+            minimal_ctx,
+            timeout=30.0,
+            stale_threshold=5.0,
+            provider_name="minimax",
+            provider_fallback_env={"ANTHROPIC_API_KEY": "sk-test"},
+            provider_fallback_name="anthropic",
+        )
+
+        assert call_count[0] == 2
+        assert result.provider_fallback is True
+        assert result.provider_used == "anthropic"
+
+    @pytest.mark.anyio
+    async def test_budget_exhausted_triggers_fallback(self, minimal_ctx, tmp_path, monkeypatch):
+        from autoskillit.execution.commands import ClaudeHeadlessCmd
+        from autoskillit.execution.headless import _execute_claude_headless
+
+        fake_runner, call_count = self._patch_common(
+            monkeypatch,
+            tmp_path,
+            _make_queued_build_result(_BUDGET_EXHAUSTED_RESULT, _SUCCESS_RESULT),
+        )
+        minimal_ctx.runner = fake_runner
+
+        result = await _execute_claude_headless(
+            ClaudeHeadlessCmd(cmd=["echo", "test"], env={}),
+            str(tmp_path),
+            minimal_ctx,
+            timeout=30.0,
+            stale_threshold=5.0,
+            provider_name="minimax",
+            provider_fallback_env={"ANTHROPIC_API_KEY": "sk-test"},
+            provider_fallback_name="anthropic",
+        )
+
+        assert call_count[0] == 2
+        assert result.provider_fallback is True
+        assert result.provider_used == "anthropic"
+
+    @pytest.mark.anyio
+    async def test_no_fallback_env_suppresses_retry(self, minimal_ctx, tmp_path, monkeypatch):
+        from autoskillit.execution.commands import ClaudeHeadlessCmd
+        from autoskillit.execution.headless import _execute_claude_headless
+
+        fake_runner, call_count = self._patch_common(
+            monkeypatch,
+            tmp_path,
+            _make_queued_build_result(_STALE_RESULT),
+        )
+        minimal_ctx.runner = fake_runner
+
+        result = await _execute_claude_headless(
+            ClaudeHeadlessCmd(cmd=["echo", "test"], env={}),
+            str(tmp_path),
+            minimal_ctx,
+            timeout=30.0,
+            stale_threshold=5.0,
+            provider_name="minimax",
+        )
+
+        assert call_count[0] == 1
+        assert result.provider_fallback is False
+
+    @pytest.mark.anyio
+    async def test_anthropic_provider_never_falls_back(self, minimal_ctx, tmp_path, monkeypatch):
+        from autoskillit.execution.commands import ClaudeHeadlessCmd
+        from autoskillit.execution.headless import _execute_claude_headless
+
+        fake_runner, call_count = self._patch_common(
+            monkeypatch,
+            tmp_path,
+            _make_queued_build_result(_STALE_RESULT),
+        )
+        minimal_ctx.runner = fake_runner
+
+        result = await _execute_claude_headless(
+            ClaudeHeadlessCmd(cmd=["echo", "test"], env={}),
+            str(tmp_path),
+            minimal_ctx,
+            timeout=30.0,
+            stale_threshold=5.0,
+            provider_name="",
+        )
+
+        assert call_count[0] == 1
+        assert result.provider_fallback is False


### PR DESCRIPTION
## Summary

Create `tests/execution/test_headless_provider_fallback.py` with four tests verifying the provider fallback loop in `_execute_claude_headless`. Tests cover: STALE triggers fallback, BUDGET_EXHAUSTED triggers fallback, no fallback env suppresses retry, and Anthropic (empty provider) never falls back. Each test monkeypatches `is_feature_enabled` at the import site and uses a stateful `_build_skill_result` mock returning queued SkillResult values to drive the while-loop through specific retry paths. Follows the established `async def fake_runner` + `_sr()` pattern from `test_headless_provider_forwarding.py`.

Closes #1779

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260504-204431-195971/.autoskillit/temp/make-plan/fallback_loop_unit_tests_plan_2026-05-04_204431.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 55 | 18.3k | 912.2k | 63.3k | 73 | 68.8k | 10m 0s |
| verify | 1 | 41 | 13.1k | 1.2M | 76.4k | 114 | 63.3k | 7m 20s |
| implement | 1 | 174 | 10.1k | 1.0M | 64.3k | 59 | 51.8k | 3m 46s |
| prepare_pr | 1 | 52 | 3.1k | 163.5k | 36.1k | 15 | 23.7k | 56s |
| compose_pr | 1 | 59 | 2.5k | 180.8k | 30.0k | 16 | 17.0k | 53s |
| review_pr | 1 | 100 | 34.5k | 570.0k | 81.1k | 58 | 70.8k | 7m 29s |
| resolve_review | 1 | 423 | 31.6k | 3.4M | 102.9k | 125 | 90.6k | 17m 42s |
| ci_conflict_fix | 3 | 268 | 7.2k | 1.0M | 38.3k | 73 | 75.0k | 3m 7s |
| diagnose_ci | 1 | 100 | 3.2k | 327.1k | 34.4k | 26 | 33.7k | 1m 6s |
| resolve_ci | 1 | 272 | 7.4k | 1.6M | 60.2k | 70 | 47.3k | 8m 36s |
| **Total** | | 1.5k | 131.0k | 10.4M | 102.9k | | 542.1k | 1h 0m |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 200 | 5227.7 | 259.2 | 50.3 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 17 | 199973.9 | 5327.0 | 1860.4 |
| ci_conflict_fix | 1721 | 589.7 | 43.6 | 4.2 |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 3 | 524001.3 | 15756.3 | 2468.0 |
| **Total** | **1941** | 5373.5 | 279.3 | 67.5 |