### PR TITLE
Add model: field to all run_skill recipe steps and global orchestration rule

### DIFF
--- a/src/autoskillit/recipes/CLAUDE.md
+++ b/src/autoskillit/recipes/CLAUDE.md
@@ -1,0 +1,3 @@
+# Recipes
+
+Recipe YAML files are read by an LLM orchestrator, not a code interpreter. Step-level fields like `model:`, `note:`, and `kitchen_rules:` are prompts — if a field is absent from a step, the orchestrator doesn't know to pass it.

--- a/src/autoskillit/recipes/bem-wrapper.yaml
+++ b/src/autoskillit/recipes/bem-wrapper.yaml
@@ -45,6 +45,7 @@ steps:
 
   run_bem:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:build-execution-map ${{ context.issue_numbers }} --base-ref ${{ inputs.base_branch }}"
       step_name: run_bem

--- a/src/autoskillit/recipes/full-audit.yaml
+++ b/src/autoskillit/recipes/full-audit.yaml
@@ -62,6 +62,7 @@ steps:
 
   run_audits:
     tool: run_skill
+    model: ""
     description: "Run six audit skills in parallel"
     with:
       skill_command: "/autoskillit:audit-tests"
@@ -111,6 +112,7 @@ steps:
 
   validate_audits:
     tool: run_skill
+    model: ""
     description: "Validate each audit report in parallel"
     with:
       skill_command: "/autoskillit:validate-audit"
@@ -151,6 +153,7 @@ steps:
 
   create_issues:
     tool: run_skill
+    model: ""
     description: "Create GitHub issues from validated reports"
     with:
       skill_command: "/autoskillit:prepare-issue"

--- a/src/autoskillit/recipes/implement-findings.yaml
+++ b/src/autoskillit/recipes/implement-findings.yaml
@@ -107,6 +107,7 @@ steps:
 
   run_bem_internally:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:build-execution-map ${{ context.remaining_urls_json }} ${{ inputs.base_branch }}"
       cwd: "${{ inputs.source_dir }}"

--- a/src/autoskillit/recipes/implementation-groups.yaml
+++ b/src/autoskillit/recipes/implementation-groups.yaml
@@ -139,6 +139,7 @@ steps:
 
   group:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:make-groups ${{ inputs.source_doc }}"
       cwd: "${{ context.work_dir }}"
@@ -157,6 +158,7 @@ steps:
 
   plan:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:make-plan CURRENT_GROUP_FILE"
       cwd: "${{ context.work_dir }}"
@@ -191,6 +193,7 @@ steps:
 
   review:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:review-approach ${{ context.plan_path }}"
       cwd: "${{ context.work_dir }}"
@@ -206,6 +209,7 @@ steps:
 
   verify:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:dry-walkthrough ${{ context.plan_path }}"
       cwd: "${{ context.work_dir }}"
@@ -217,6 +221,7 @@ steps:
 
   implement:
     tool: run_skill
+    model: ""
     stale_threshold: 2400
     with:
       skill_command: "/autoskillit:implement-worktree-no-merge ${{ context.plan_path }}"
@@ -232,6 +237,7 @@ steps:
 
   retry_worktree:
     tool: run_skill
+    model: ""
     stale_threshold: 2400
     with:
       skill_command: "/autoskillit:retry-worktree ${{ context.plan_path }} ${{ context.worktree_path }}"
@@ -315,6 +321,7 @@ steps:
 
   fix:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:resolve-failures ${{ context.worktree_path }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
       cwd: "${{ context.worktree_path }}"
@@ -352,6 +359,7 @@ steps:
 
   audit_impl:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:audit-impl ${{ context.plan_path }} ${{ context.base_sha }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
@@ -386,6 +394,7 @@ steps:
 
   prepare_pr:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:prepare-pr ${{ context.all_plan_paths }} ${{ inputs.run_name }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
@@ -415,6 +424,7 @@ steps:
 
   run_arch_lenses:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:arch-lens-{slug} {context_path}"
       cwd: "${{ context.work_dir }}"
@@ -439,6 +449,7 @@ steps:
 
   compose_pr:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:compose-pr ${{ context.prep_path }} \"${{ context.all_diagram_paths }}\" ${{ context.work_dir }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
@@ -494,6 +505,7 @@ steps:
 
   review_pr:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:review-pr ${{ context.merge_target }} ${{ inputs.base_branch }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{ context.hunk_ranges_path }} diff_metrics_path=${{ context.diff_metrics_path }}"
       cwd: "${{ context.work_dir }}"
@@ -526,6 +538,7 @@ steps:
 
   resolve_review:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:resolve-review ${{ context.merge_target }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
@@ -798,6 +811,7 @@ steps:
 
   diagnose_ci:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:diagnose-ci ${{ context.merge_target }} - - - ${{ context.ci_event }}"
       cwd: "${{ context.work_dir }}"
@@ -819,6 +833,7 @@ steps:
 
   resolve_ci:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:resolve-failures ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }} ${{ context.ci_conclusion }} ${{ context.ci_failed_jobs }} ${{ context.diagnosis_path }}"
       cwd: "${{ context.work_dir }}"
@@ -1095,6 +1110,7 @@ steps:
 
   resolve_queue_merge_conflicts:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
@@ -1299,6 +1315,7 @@ steps:
 
   resolve_direct_merge_conflicts:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
@@ -1402,6 +1419,7 @@ steps:
 
   resolve_immediate_merge_conflicts:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
@@ -1484,6 +1502,7 @@ steps:
 
   ci_conflict_fix:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"

--- a/src/autoskillit/recipes/implementation.yaml
+++ b/src/autoskillit/recipes/implementation.yaml
@@ -161,6 +161,7 @@ steps:
 
   plan:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:make-plan ${{ inputs.task }}"
       cwd: "${{ context.work_dir }}"
@@ -191,6 +192,7 @@ steps:
 
   review:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:review-approach ${{ context.plan_path }}"
       cwd: "${{ context.work_dir }}"
@@ -206,6 +208,7 @@ steps:
 
   verify:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:dry-walkthrough ${{ context.plan_path }}"
       cwd: "${{ context.work_dir }}"
@@ -217,6 +220,7 @@ steps:
 
   implement:
     tool: run_skill
+    model: ""
     stale_threshold: 2400
     with:
       skill_command: "/autoskillit:implement-worktree-no-merge ${{ context.plan_path }}"
@@ -232,6 +236,7 @@ steps:
 
   retry_worktree:
     tool: run_skill
+    model: ""
     stale_threshold: 2400
     with:
       skill_command: "/autoskillit:retry-worktree ${{ context.plan_path }} ${{ context.worktree_path }}"
@@ -312,6 +317,7 @@ steps:
 
   fix:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:resolve-failures ${{ context.worktree_path }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
       cwd: "${{ context.worktree_path }}"
@@ -345,6 +351,7 @@ steps:
 
   audit_impl:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:audit-impl ${{ context.plan_path }} ${{ context.base_sha }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
@@ -379,6 +386,7 @@ steps:
 
   prepare_pr:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:prepare-pr ${{ context.all_plan_paths }} ${{ inputs.run_name }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
@@ -406,6 +414,7 @@ steps:
 
   run_arch_lenses:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:arch-lens-{slug} {context_path}"
       cwd: "${{ context.work_dir }}"
@@ -430,6 +439,7 @@ steps:
 
   compose_pr:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:compose-pr ${{ context.prep_path }} \"${{ context.all_diagram_paths }}\" ${{ context.work_dir }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
@@ -485,6 +495,7 @@ steps:
 
   review_pr:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:review-pr ${{ context.merge_target }} ${{ inputs.base_branch }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{ context.hunk_ranges_path }} diff_metrics_path=${{ context.diff_metrics_path }}"
       cwd: "${{ context.work_dir }}"
@@ -532,6 +543,7 @@ steps:
 
   resolve_review:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:resolve-review ${{ context.merge_target }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
@@ -1020,6 +1032,7 @@ steps:
 
   resolve_queue_merge_conflicts:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
@@ -1224,6 +1237,7 @@ steps:
 
   resolve_direct_merge_conflicts:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
@@ -1327,6 +1341,7 @@ steps:
 
   resolve_immediate_merge_conflicts:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
@@ -1374,6 +1389,7 @@ steps:
 
   diagnose_ci:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:diagnose-ci ${{ context.merge_target }} - - - ${{ context.ci_event }}"
       cwd: "${{ context.work_dir }}"
@@ -1394,6 +1410,7 @@ steps:
 
   resolve_ci:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:resolve-failures ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }} ${{ context.ci_conclusion }} ${{ context.ci_failed_jobs }} ${{ context.diagnosis_path }}"
       cwd: "${{ context.work_dir }}"
@@ -1475,6 +1492,7 @@ steps:
 
   ci_conflict_fix:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"

--- a/src/autoskillit/recipes/merge-prs.yaml
+++ b/src/autoskillit/recipes/merge-prs.yaml
@@ -190,6 +190,7 @@ steps:
 
   analyze_prs:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:analyze-prs ${{ inputs.base_branch }} merge_queue_data_path=${{ context.merge_queue_data_path }}"
       cwd: "${{ context.work_dir }}"
@@ -346,6 +347,7 @@ steps:
 
   resolve_ejected_conflicts:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:resolve-merge-conflicts '${{ context.ejected_pr_branch }}' '${{ inputs.base_branch }}'"
       cwd: "${{ context.work_dir }}"
@@ -531,6 +533,7 @@ steps:
 
   resolve_proactive_rebase_conflicts:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:resolve-merge-conflicts '${{ context.next_pr_branch }}' '${{ inputs.base_branch }}'"
       cwd: "${{ context.work_dir }}"
@@ -569,6 +572,7 @@ steps:
 
   diagnose_queue_ci:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:diagnose-ci '${{ context.current_pr_number }}' - - - ${{ context.ci_event }}"
       cwd: "${{ context.work_dir }}"
@@ -645,6 +649,7 @@ steps:
 
   merge_pr:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:merge-pr {pr_number} {complexity}"
       cwd: "${{ context.work_dir }}"
@@ -676,6 +681,7 @@ steps:
 
   plan:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:make-plan ${{ context.task }}"
       cwd: "${{ context.work_dir }}"
@@ -698,6 +704,7 @@ steps:
 
   verify:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:dry-walkthrough ${{ context.pr_plan_path }}"
       cwd: "${{ context.work_dir }}"
@@ -714,6 +721,7 @@ steps:
 
   implement:
     tool: run_skill
+    model: ""
     stale_threshold: 2400
     with:
       skill_command: "/autoskillit:implement-worktree-no-merge ${{ context.pr_plan_path }}"
@@ -730,6 +738,7 @@ steps:
 
   retry_worktree:
     tool: run_skill
+    model: ""
     stale_threshold: 2400
     with:
       skill_command: "/autoskillit:retry-worktree ${{ context.pr_plan_path }} ${{ context.worktree_path }}"
@@ -830,6 +839,7 @@ steps:
 
   fix:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:resolve-failures ${{ context.worktree_path }} ${{ context.pr_plan_path }} ${{ context.batch_branch }}"
       cwd: "${{ context.worktree_path }}"
@@ -906,6 +916,7 @@ steps:
 
   audit_impl:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:audit-impl \"${{ context.all_plan_paths }}\" ${{ context.batch_branch }} ${{ inputs.base_branch }} \"${{ context.all_conflict_report_paths }}\""
       cwd: "${{ context.work_dir }}"
@@ -961,6 +972,7 @@ steps:
 
   open_integration_pr:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:open-integration-pr ${{ context.batch_branch }} ${{ inputs.base_branch }} ${{ context.pr_order_file }} ${{ context.verdict }} \"${{ context.all_conflict_report_paths }}\" domain_partitions_path=${{ context.domain_partitions_path }}"
       cwd: "${{ context.work_dir }}"
@@ -1007,6 +1019,7 @@ steps:
 
   resolve_integration_conflicts:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.batch_branch }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
@@ -1084,6 +1097,7 @@ steps:
 
   review_pr_integration:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:review-pr ${{ context.batch_branch }} ${{ inputs.base_branch }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{ context.hunk_ranges_path }} diff_metrics_path=${{ context.diff_metrics_path }}"
       cwd: "${{ context.work_dir }}"
@@ -1111,6 +1125,7 @@ steps:
 
   resolve_review_integration:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:resolve-review ${{ context.batch_branch }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
@@ -1173,6 +1188,7 @@ steps:
 
   diagnose_ci:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:diagnose-ci ${{ context.batch_branch }} - - - ${{ context.ci_event }}"
       cwd: "${{ context.work_dir }}"

--- a/src/autoskillit/recipes/planner.yaml
+++ b/src/autoskillit/recipes/planner.yaml
@@ -73,6 +73,7 @@ steps:
 
   analyze:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:planner-analyze ${{ context.planner_dir }}"
       cwd: "${{ inputs.source_dir }}"
@@ -82,6 +83,7 @@ steps:
 
   extract_domain:
     tool: run_skill
+    model: ""
     with:
       skill_command: >
         /autoskillit:planner-extract-domain
@@ -94,6 +96,7 @@ steps:
 
   generate_phases:
     tool: run_skill
+    model: ""
     with:
       skill_command: >
         /autoskillit:planner-generate-phases
@@ -126,6 +129,7 @@ steps:
 
   elaborate_phases:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:planner-elaborate-phase ${{ context.plan_snapshot_path }} {phase_id} ${{ context.planner_dir }}/phases"
       cwd: "${{ inputs.source_dir }}"
@@ -158,6 +162,7 @@ steps:
 
   refine_phases:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:planner-refine-phases ${{ context.combined_phases_path }} ${{ context.planner_dir }}"
       cwd: "${{ inputs.source_dir }}"
@@ -183,6 +188,7 @@ steps:
 
   elaborate_assignments:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:planner-elaborate-assignments {context_path} ${{ context.planner_dir }}"
       cwd: "${{ inputs.source_dir }}"
@@ -214,6 +220,7 @@ steps:
 
   refine_assignments:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:planner-refine-assignments {context_path} ${{ context.refined_plan_path }} ${{ context.planner_dir }}"
       cwd: "${{ inputs.source_dir }}"
@@ -256,6 +263,7 @@ steps:
 
   elaborate_wps:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:planner-elaborate-wps {context_path} ${{ context.planner_dir }}"
       cwd: "${{ inputs.source_dir }}"
@@ -297,6 +305,7 @@ steps:
 
   refine_wps:
     tool: run_skill
+    model: ""
     with:
       skill_command: >
         /autoskillit:planner-refine-wps
@@ -313,6 +322,7 @@ steps:
 
   consolidate_wps_analyze:
     tool: run_skill
+    model: ""
     with:
       skill_command: >
         /autoskillit:planner-consolidate-wps
@@ -340,6 +350,7 @@ steps:
 
   validate_task_alignment:
     tool: run_skill
+    model: ""
     with:
       skill_command: >
         /autoskillit:planner-validate-task-alignment
@@ -357,6 +368,7 @@ steps:
 
   reconcile_deps:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:planner-reconcile-deps ${{ context.planner_dir }}"
       cwd: "${{ inputs.source_dir }}"
@@ -367,6 +379,7 @@ steps:
 
   assess_review_approach_step:
     tool: run_skill
+    model: ""
     optional: true
     skip_when_false: "inputs.planner_assess_review_approach"
     with:
@@ -404,6 +417,7 @@ steps:
 
   refine:
     tool: run_skill
+    model: ""
     with:
       skill_command: >
         /autoskillit:planner-refine

--- a/src/autoskillit/recipes/promote-to-main-wrapper.yaml
+++ b/src/autoskillit/recipes/promote-to-main-wrapper.yaml
@@ -31,6 +31,7 @@ ingredients:
 steps:
   promote:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:promote-to-main ${{ inputs.batch_branch }} ${{ inputs.base_branch }}"
       cwd: "${{ inputs.source_dir }}"

--- a/src/autoskillit/recipes/remediation.yaml
+++ b/src/autoskillit/recipes/remediation.yaml
@@ -184,6 +184,7 @@ steps:
 
   rectify:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:rectify ${{ context.investigation_path }}"
       cwd: "${{ context.work_dir }}"
@@ -199,6 +200,7 @@ steps:
 
   review:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:review-approach ${{ context.plan_path }}"
       cwd: "${{ context.work_dir }}"
@@ -214,6 +216,7 @@ steps:
 
   dry_walkthrough:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:dry-walkthrough ${{ context.plan_path }}"
       cwd: "${{ context.work_dir }}"
@@ -227,6 +230,7 @@ steps:
 
   implement:
     tool: run_skill
+    model: ""
     stale_threshold: 2400
     with:
       skill_command: "/autoskillit:implement-worktree-no-merge ${{ context.plan_path }}"
@@ -243,6 +247,7 @@ steps:
 
   retry_worktree:
     tool: run_skill
+    model: ""
     stale_threshold: 2400
     with:
       skill_command: "/autoskillit:retry-worktree ${{ context.plan_path }} ${{ context.worktree_path }}"
@@ -269,6 +274,7 @@ steps:
 
   assess:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:resolve-failures ${{ context.worktree_path }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
       cwd: "${{ context.worktree_path }}"
@@ -291,6 +297,7 @@ steps:
 
   audit_impl:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:audit-impl ${{ context.plan_path }} ${{ context.branch_name }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
@@ -317,6 +324,7 @@ steps:
 
   make_plan:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:make-plan ${{ context.remediation_path }}"
       task: "${{ inputs.task }}"
@@ -396,6 +404,7 @@ steps:
 
   prepare_pr:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:prepare-pr ${{ context.plan_path }} ${{ inputs.run_name }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
@@ -423,6 +432,7 @@ steps:
 
   run_arch_lenses:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:arch-lens-{slug} {context_path}"
       cwd: "${{ context.work_dir }}"
@@ -447,6 +457,7 @@ steps:
 
   compose_pr:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:compose-pr ${{ context.prep_path }} \"${{ context.all_diagram_paths }}\" ${{ context.work_dir }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
@@ -502,6 +513,7 @@ steps:
 
   review_pr:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:review-pr ${{ context.merge_target }} ${{ inputs.base_branch }} annotated_diff_path=${{ context.annotated_diff_path }} hunk_ranges_path=${{ context.hunk_ranges_path }} diff_metrics_path=${{ context.diff_metrics_path }}"
       cwd: "${{ context.work_dir }}"
@@ -534,6 +546,7 @@ steps:
 
   resolve_review:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:resolve-review ${{ context.merge_target }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
@@ -1024,6 +1037,7 @@ steps:
 
   resolve_queue_merge_conflicts:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
@@ -1228,6 +1242,7 @@ steps:
 
   resolve_direct_merge_conflicts:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
@@ -1331,6 +1346,7 @@ steps:
 
   resolve_immediate_merge_conflicts:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"
@@ -1378,6 +1394,7 @@ steps:
 
   diagnose_ci:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:diagnose-ci ${{ context.merge_target }} - - - ${{ context.ci_event }}"
       cwd: "${{ context.work_dir }}"
@@ -1398,6 +1415,7 @@ steps:
 
   resolve_ci:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:resolve-failures ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }} ${{ context.ci_conclusion }} ${{ context.ci_failed_jobs }} ${{ context.diagnosis_path }}"
       cwd: "${{ context.work_dir }}"
@@ -1479,6 +1497,7 @@ steps:
 
   ci_conflict_fix:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:resolve-merge-conflicts ${{ context.work_dir }} ${{ context.plan_path }} ${{ inputs.base_branch }}"
       cwd: "${{ context.work_dir }}"

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -104,6 +104,7 @@ steps:
   # --- DESIGN PHASE ---
   scope:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:scope ${{ inputs.task }}"
       cwd: "${{ inputs.source_dir }}"
@@ -115,6 +116,7 @@ steps:
 
   plan_experiment:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:plan-experiment ${{ context.scope_report }} ${{ context.revision_guidance }}"
       cwd: "${{ inputs.source_dir }}"
@@ -127,6 +129,7 @@ steps:
 
   review_design:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:review-design ${{ context.experiment_plan }}"
       cwd: "${{ inputs.source_dir }}"
@@ -152,6 +155,7 @@ steps:
 
   plan_visualization:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:plan-visualization ${{ inputs.source_dir }} ${{ context.experiment_plan }} ${{ context.scope_report }}"
       cwd: "${{ inputs.source_dir }}"
@@ -173,6 +177,7 @@ steps:
 
   resolve_design_review:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:resolve-design-review ${{ context.evaluation_dashboard }} ${{ context.experiment_plan }} ${{ context.revision_guidance }}"
       cwd: "${{ inputs.source_dir }}"
@@ -222,6 +227,7 @@ steps:
 
   stage_data:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:stage-data ${{ context.experiment_plan }}"
       cwd: "${{ context.worktree_path }}"
@@ -246,6 +252,7 @@ steps:
 
   decompose_phases:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:make-groups ${{ context.experiment_plan }}"
       cwd: "${{ context.worktree_path }}"
@@ -264,6 +271,7 @@ steps:
 
   plan_phase:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:make-plan ${{ context.group_files }}"
       cwd: "${{ context.worktree_path }}"
@@ -285,6 +293,7 @@ steps:
 
   implement_phase:
     tool: run_skill
+    model: ""
     stale_threshold: 2400
     idle_output_timeout: 0
     with:
@@ -306,6 +315,7 @@ steps:
 
   troubleshoot_implement_failure:
     tool: run_skill
+    model: ""
     stale_threshold: 2400
     idle_output_timeout: 0
     with:
@@ -338,6 +348,7 @@ steps:
   # --- EXPERIMENT + REPORT PHASE ---
   run_experiment:
     tool: run_skill
+    model: ""
     stale_threshold: 2400
     idle_output_timeout: 0
     with:
@@ -353,6 +364,7 @@ steps:
 
   troubleshoot_run_failure:
     tool: run_skill
+    model: ""
     stale_threshold: 2400
     idle_output_timeout: 0
     with:
@@ -373,6 +385,7 @@ steps:
 
   adjust_experiment:
     tool: run_skill
+    model: ""
     stale_threshold: 2400
     idle_output_timeout: 0
     with:
@@ -402,6 +415,7 @@ steps:
 
   generate_report:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }}"
       cwd: "${{ context.worktree_path }}"
@@ -415,6 +429,7 @@ steps:
 
   generate_report_inconclusive:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --inconclusive --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }}"
       cwd: "${{ context.worktree_path }}"
@@ -437,6 +452,7 @@ steps:
 
   fix_tests:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:resolve-failures ${{ context.worktree_path }} ${{ context.experiment_plan }} ${{ inputs.base_branch }}"
       cwd: "${{ inputs.source_dir }}"
@@ -475,6 +491,7 @@ steps:
   # --- PR + REVIEW PHASE ---
   prepare_research_pr:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:prepare-research-pr ${{ context.report_path }} ${{ context.experiment_plan }} ${{ context.worktree_path }} ${{ inputs.base_branch }}"
       cwd: "${{ context.worktree_path }}"
@@ -488,6 +505,7 @@ steps:
 
   run_experiment_lenses:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:exp-lens-{slug} {context_path} ${{ context.experiment_plan }}"
       cwd: "${{ context.worktree_path }}"
@@ -535,6 +553,7 @@ steps:
 
   compose_research_pr:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:compose-research-pr ${{ context.prep_path }} \"${{ context.all_diagram_paths }}\" ${{ context.worktree_path }} ${{ inputs.base_branch }}"
       cwd: "${{ context.worktree_path }}"
@@ -554,6 +573,7 @@ steps:
 
   review_research_pr:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:review-research-pr ${{ context.worktree_path }} ${{ inputs.base_branch }} ${{ context.pr_url }}"
       cwd: "${{ context.worktree_path }}"
@@ -577,6 +597,7 @@ steps:
 
   audit_claims:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:audit-claims ${{ context.worktree_path }} ${{ inputs.base_branch }} ${{ context.pr_url }}"
       cwd: "${{ context.worktree_path }}"
@@ -609,6 +630,7 @@ steps:
 
   resolve_research_review:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:resolve-research-review ${{ context.worktree_path }} ${{ inputs.base_branch }}"
       cwd: "${{ context.worktree_path }}"
@@ -637,6 +659,7 @@ steps:
 
   resolve_claims_review:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:resolve-claims-review ${{ context.worktree_path }} ${{ inputs.base_branch }}"
       cwd: "${{ context.worktree_path }}"
@@ -671,6 +694,7 @@ steps:
 
   re_run_experiment:
     tool: run_skill
+    model: ""
     stale_threshold: 2400
     idle_output_timeout: 0
     with:
@@ -691,6 +715,7 @@ steps:
 
   re_generate_report:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:generate-report ${{ context.worktree_path }} ${{ context.experiment_results }} --output-mode ${{ inputs.output_mode }} --issue-url ${{ inputs.issue_url }}"
       cwd: "${{ context.worktree_path }}"
@@ -759,6 +784,7 @@ steps:
 
   finalize_bundle_render:
     tool: run_skill
+    model: ""
     with:
       skill_command: "/autoskillit:bundle-local-report ${{ context.research_dir }} ${{ context.report_path_after_finalize }} ${{ context.all_diagram_paths }} ${{ context.visualization_plan_path }}"
       cwd: "${{ context.worktree_path }}"

--- a/src/autoskillit/skills/sous-chef/SKILL.md
+++ b/src/autoskillit/skills/sous-chef/SKILL.md
@@ -372,6 +372,12 @@ parallel run of the same step reports under the same canonical step name.
 
 ---
 
+## MODEL PROPAGATION — MANDATORY
+
+**MODEL PROPAGATION** — When the user specifies a model (e.g. "use opus"), apply it to the `model` parameter of ALL `run_skill` calls for steps that declare a `model:` field — including follow-on steps (retry_worktree, fix, resolve_review, resolve_ci, conflict resolution).
+
+---
+
 ## MERGE PHASE — MANDATORY
 
 This rule applies whenever the orchestrator must merge **one or more open PRs**, whether

--- a/src/autoskillit/skills/sous-chef/SKILL.md
+++ b/src/autoskillit/skills/sous-chef/SKILL.md
@@ -374,7 +374,7 @@ parallel run of the same step reports under the same canonical step name.
 
 ## MODEL PROPAGATION — MANDATORY
 
-**MODEL PROPAGATION** — When the user specifies a model (e.g. "use opus"), apply it to the `model` parameter of ALL `run_skill` calls for steps that declare a `model:` field — including follow-on steps (retry_worktree, fix, resolve_review, resolve_ci, conflict resolution).
+**MODEL PROPAGATION** — When the user specifies a model (e.g. "use opus"), apply it to the `model` parameter of ALL `run_skill` calls for steps that declare a `model:` field — including follow-on steps (retry_worktree, fix, resolve_review, resolve_ci, conflict resolution). All `run_skill` steps in orchestrated recipes must declare a `model:` field; steps that omit it are ineligible for propagation and silently bypass user model selection.
 
 ---
 

--- a/tests/recipe/CLAUDE.md
+++ b/tests/recipe/CLAUDE.md
@@ -13,6 +13,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_api.py` | Tests for recipe/_api.py orchestration API |
 | `test_api_split.py` | Structural guard for recipe API split |
 | `test_bem_wrapper_structure.py` | Tests for BEM wrapper recipe structure |
+| `test_bundled_model_field.py` | Tests that all run_skill steps declare a model: field across bundled recipes |
 | `test_bundled_recipe_hidden_policy.py` | Tests for hidden policy in bundled recipes |
 | `test_bundled_recipes_general.py` | General structural tests for all bundled recipes |
 | `test_bundled_recipes_no_inversions.py` | Guard: no inversion step order violations in bundled recipes |

--- a/tests/recipe/test_bundled_model_field.py
+++ b/tests/recipe/test_bundled_model_field.py
@@ -4,9 +4,10 @@ import pytest
 
 from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 
-pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.medium]
 
 _ALL_BUNDLED_RECIPES = [f.name for f in sorted(builtin_recipes_dir().glob("*.yaml"))]
+assert _ALL_BUNDLED_RECIPES, "no bundled recipes found"
 
 
 class TestAllRunSkillStepsHaveModel:

--- a/tests/recipe/test_bundled_model_field.py
+++ b/tests/recipe/test_bundled_model_field.py
@@ -1,0 +1,40 @@
+"""Verify all run_skill steps declare a model: field across bundled recipes."""
+
+import pytest
+
+from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+RECIPES_REQUIRING_MODEL = [
+    "implementation.yaml",
+    "remediation.yaml",
+    "merge-prs.yaml",
+    "planner.yaml",
+    "implement-findings.yaml",
+]
+
+
+class TestAllRunSkillStepsHaveModel:
+    """Every run_skill step must declare model: so the orchestrator can propagate it."""
+
+    @pytest.mark.parametrize("recipe_name", RECIPES_REQUIRING_MODEL)
+    def test_run_skill_steps_have_model_field(self, recipe_name: str) -> None:
+        recipe_path = builtin_recipes_dir() / recipe_name
+        recipe = load_recipe(recipe_path)
+        missing = []
+        for name, step in recipe.steps.items():
+            if step.tool == "run_skill" and step.model is None:
+                missing.append(name)
+        assert not missing, f"{recipe_name}: run_skill steps missing model: field: {missing}"
+
+    @pytest.mark.parametrize("recipe_name", RECIPES_REQUIRING_MODEL)
+    def test_model_field_is_string(self, recipe_name: str) -> None:
+        """model: field must be a string (empty or expression), never None."""
+        recipe_path = builtin_recipes_dir() / recipe_name
+        recipe = load_recipe(recipe_path)
+        for name, step in recipe.steps.items():
+            if step.tool == "run_skill":
+                assert isinstance(step.model, str), (
+                    f"{recipe_name}.{name}: model field should be str, got {type(step.model)}"
+                )

--- a/tests/recipe/test_bundled_model_field.py
+++ b/tests/recipe/test_bundled_model_field.py
@@ -6,29 +6,13 @@ from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
 
 pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
 
-RECIPES_REQUIRING_MODEL = [
-    "implementation.yaml",
-    "remediation.yaml",
-    "merge-prs.yaml",
-    "planner.yaml",
-    "implement-findings.yaml",
-]
+_ALL_BUNDLED_RECIPES = [f.name for f in sorted(builtin_recipes_dir().glob("*.yaml"))]
 
 
 class TestAllRunSkillStepsHaveModel:
     """Every run_skill step must declare model: so the orchestrator can propagate it."""
 
-    @pytest.mark.parametrize("recipe_name", RECIPES_REQUIRING_MODEL)
-    def test_run_skill_steps_have_model_field(self, recipe_name: str) -> None:
-        recipe_path = builtin_recipes_dir() / recipe_name
-        recipe = load_recipe(recipe_path)
-        missing = []
-        for name, step in recipe.steps.items():
-            if step.tool == "run_skill" and step.model is None:
-                missing.append(name)
-        assert not missing, f"{recipe_name}: run_skill steps missing model: field: {missing}"
-
-    @pytest.mark.parametrize("recipe_name", RECIPES_REQUIRING_MODEL)
+    @pytest.mark.parametrize("recipe_name", _ALL_BUNDLED_RECIPES)
     def test_model_field_is_string(self, recipe_name: str) -> None:
         """model: field must be a string (empty or expression), never None."""
         recipe_path = builtin_recipes_dir() / recipe_name

--- a/tests/recipe/test_io_parsing.py
+++ b/tests/recipe/test_io_parsing.py
@@ -482,6 +482,8 @@ class TestRecipeParser:
                     step.with_args.get("skill_command")
                     and "resolve-failures" in step.with_args["skill_command"]
                 ):
+                    # model: "" is the "use config default" sentinel — `not step.model`
+                    # accepts both None and "" so resolve-failures steps pass either way.
                     assert not step.model, (
                         f"{f.name} step '{step_name}' should not have explicit model "
                         f"(sonnet is the config default); got {step.model!r}"

--- a/tests/recipe/test_io_parsing.py
+++ b/tests/recipe/test_io_parsing.py
@@ -482,9 +482,9 @@ class TestRecipeParser:
                     step.with_args.get("skill_command")
                     and "resolve-failures" in step.with_args["skill_command"]
                 ):
-                    assert step.model is None, (
+                    assert not step.model, (
                         f"{f.name} step '{step_name}' should not have explicit model "
-                        "(sonnet is the config default)"
+                        "(sonnet is the config default); got {step.model!r}"
                     )
 
 

--- a/tests/recipe/test_io_parsing.py
+++ b/tests/recipe/test_io_parsing.py
@@ -484,7 +484,7 @@ class TestRecipeParser:
                 ):
                     assert not step.model, (
                         f"{f.name} step '{step_name}' should not have explicit model "
-                        "(sonnet is the config default); got {step.model!r}"
+                        f"(sonnet is the config default); got {step.model!r}"
                     )
 
 


### PR DESCRIPTION
## Summary

Add `model: ""` to every `run_skill` step across all bundled recipes (68 steps currently missing it across 5 targeted recipes), add a global orchestration rule to `sous-chef/SKILL.md` instructing the orchestrator to propagate user-specified model selections to all steps with a `model:` field, and create `src/autoskillit/recipes/CLAUDE.md` explaining that recipe YAML fields are LLM-read prompts.

Closes #720

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260504-213307-863741/.autoskillit/temp/make-plan/add-model-field-to-all-run-skill-recipe-steps-and-global-orc_plan_2026-05-04_213307.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 909 | 6.0k | 390.1k | 47.0k | 77 | 37.1k | 5m 2s |
| verify | 1 | 50 | 12.2k | 1.5M | 59.5k | 125 | 51.1k | 6m 44s |
| implement | 1 | 202 | 9.8k | 1.3M | 72.8k | 69 | 60.1k | 3m 40s |
| prepare_pr | 1 | 60 | 4.9k | 200.4k | 35.8k | 19 | 23.6k | 1m 36s |
| compose_pr | 1 | 59 | 2.1k | 179.6k | 29.7k | 16 | 17.2k | 54s |
| review_pr | 2 | 2.2k | 57.3k | 1.4M | 88.2k | 126 | 144.2k | 16m 11s |
| resolve_review | 2 | 650 | 29.4k | 3.8M | 70.4k | 183 | 108.0k | 13m 47s |
| **Total** | | 4.1k | 121.7k | 8.7M | 88.2k | | 441.4k | 47m 55s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 117 | 11018.7 | 514.0 | 83.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 79 | 48432.4 | 1367.6 | 372.6 |
| **Total** | **196** | 44426.9 | 2251.9 | 620.9 |