### PR TITLE
Implementation Plan: Revise causal_inference Trigger to Require Manipulation

### DIFF
--- a/src/autoskillit/recipes/experiment-types/causal_inference.yaml
+++ b/src/autoskillit/recipes/experiment-types/causal_inference.yaml
@@ -1,6 +1,7 @@
 name: causal_inference
 classification_triggers:
-  - "Causal language (\"causes\", \"effect of\"), confounders in threats"
+  - "Explicit randomization, manipulation, or intervention assignment: 'randomly assigned', 'intervention applied', 'treatment group', 'control group', 'manipulated X', 'assigned to condition'"
+  - "Causal claim ('test whether X causes Y') AND explicit confounder adjustment or treatment assignment described"
 dimension_weights:
   causal_structure: H
   variance_protocol: L

--- a/tests/recipe/test_experiment_type_registry.py
+++ b/tests/recipe/test_experiment_type_registry.py
@@ -226,3 +226,32 @@ def test_returns_dict_of_experiment_type_spec() -> None:
     types = load_all_experiment_types()
     for _name, spec in types.items():
         assert isinstance(spec, ExperimentTypeSpec)
+
+
+def test_causal_inference_classification_triggers_require_manipulation() -> None:
+    """causal_inference triggers require explicit manipulation/randomization.
+
+    Not just causal language alone.
+    """
+    types = load_all_experiment_types()
+    causal = types["causal_inference"]
+    assert causal.classification_triggers == [
+        (
+            "Explicit randomization, manipulation, or intervention assignment: "
+            "'randomly assigned', 'intervention applied', 'treatment group', "
+            "'control group', 'manipulated X', 'assigned to condition'"
+        ),
+        (
+            "Causal claim ('test whether X causes Y') AND explicit confounder "
+            "adjustment or treatment assignment described"
+        ),
+    ]
+
+
+def test_causal_inference_trigger_covers_rct_language() -> None:
+    """causal_inference triggers cover RCT keywords: randomized assignment, treatment/control."""
+    types = load_all_experiment_types()
+    triggers_text = " ".join(types["causal_inference"].classification_triggers)
+    assert "randomly assigned" in triggers_text
+    assert "treatment group" in triggers_text
+    assert "control group" in triggers_text


### PR DESCRIPTION
## Summary

Replace the single vague `classification_triggers` entry in `causal_inference.yaml` (which fires on any causal language, including observational studies) with two precise triggers that require explicit manipulation, randomization, or intervention assignment. Add two tests to `test_experiment_type_registry.py` that will fail against the current YAML and pass after the change.

The problem: the current trigger — *"Causal language ('causes', 'effect of'), confounders in threats"* — matches observational causal plans (e.g., "we test whether biomarker X causes disease Y in a cohort study"), mis-routing them to `causal_inference`. This is the strictest experiment type (severity_cap: critical, red-team can STOP a plan), so mis-classification causes false STOP verdicts for observational causal plans. The fix restricts `causal_inference` to plans with actual manipulation, letting observational causal plans fall through — to `observational_correlational` once WI 2.1 lands, or `exploratory` in the interim.

Only two files change: the YAML and the test file.

Closes #832

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260504-235914-142811/.autoskillit/temp/make-plan/revise_causal_inference_trigger_plan_2026-05-05_000002.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 145 | 12.1k | 722.4k | 60.9k | 56 | 48.0k | 5m 5s |
| verify | 1 | 84 | 5.3k | 362.4k | 47.4k | 34 | 34.5k | 2m 55s |
| implement | 1 | 132 | 6.2k | 547.2k | 41.8k | 39 | 32.9k | 2m 20s |
| prepare_pr | 1 | 60 | 4.7k | 199.2k | 35.4k | 18 | 23.2k | 1m 42s |
| compose_pr | 1 | 51 | 1.8k | 150.4k | 29.3k | 14 | 16.3k | 52s |
| review_pr | 1 | 84 | 8.1k | 350.1k | 43.6k | 32 | 31.4k | 2m 22s |
| **Total** | | 556 | 38.3k | 2.3M | 60.9k | | 186.3k | 15m 19s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 32 | 17101.1 | 1028.3 | 193.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **32** | 72865.3 | 5822.1 | 1195.9 |