### PR TITLE
Implementation Plan: Skip push_branch When output_mode == local

### DIFF
--- a/scripts/recipe/push_branch.sh
+++ b/scripts/recipe/push_branch.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Args: $1=output_mode $2=worktree_path
+OUTPUT_MODE="$1"
+WORKTREE_PATH="$2"
+
+if [ "${OUTPUT_MODE}" = "local" ]; then
+    echo "push_branch: skipped in local mode"
+    exit 0
+fi
+
+cd "${WORKTREE_PATH}" && git push -u origin HEAD

--- a/src/autoskillit/recipes/research.yaml
+++ b/src/autoskillit/recipes/research.yaml
@@ -482,7 +482,7 @@ steps:
   push_branch:
     tool: run_cmd
     with:
-      cmd: "cd '${{ context.worktree_path }}' && git push -u origin HEAD"
+      cmd: "bash scripts/recipe/push_branch.sh '${{ inputs.output_mode }}' '${{ context.worktree_path }}'"
       cwd: "${{ context.worktree_path }}"
       step_name: push_branch
     on_success: prepare_research_pr

--- a/tests/recipe/test_bundled_recipes_research.py
+++ b/tests/recipe/test_bundled_recipes_research.py
@@ -453,6 +453,21 @@ class TestResearchRecipeStructure:
             "retest.on_success must be push_branch after commit_research_artifacts is removed"
         )
 
+    def test_push_branch_cmd_externalizes_guard(self, recipe) -> None:
+        """push_branch cmd must invoke push_branch.sh and forward output_mode.
+
+        Regression guard: ADR-0002 bans inline shell control flow in cmd fields.
+        The local-mode guard lives in scripts/recipe/push_branch.sh. Issue #831.
+        """
+        step = recipe.steps["push_branch"]
+        cmd = step.with_args["cmd"]
+        assert "push_branch.sh" in cmd, (
+            "push_branch cmd must invoke scripts/recipe/push_branch.sh (ADR-0002)"
+        )
+        assert "${{ inputs.output_mode }}" in cmd, (
+            "push_branch cmd must forward inputs.output_mode to the script"
+        )
+
     def test_stage_bundle_routes_to_route_pr_or_local(self, recipe) -> None:
         """stage_bundle must route to route_pr_or_local on success and failure."""
         step = recipe.steps["stage_bundle"]


### PR DESCRIPTION
## Summary

Modify the `push_branch` step in `src/autoskillit/recipes/research.yaml` to short-circuit with exit 0 when `inputs.output_mode` equals `"local"`. In local mode there is no `origin` remote; the pipeline must continue cleanly through `prepare_research_pr → run_experiment_lenses → stage_bundle → route_pr_or_local → finalize_bundle`. The change is entirely confined to the `cmd:` block of the `push_branch` step — graph topology, routing edges, and all other steps are untouched.

Closes #831

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260504-235914-839822/.autoskillit/temp/make-plan/skip_push_branch_local_mode_plan_2026-05-05_000001.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 150 | 9.0k | 773.4k | 58.4k | 65 | 49.5k | 4m 44s |
| verify | 1 | 188 | 15.4k | 1.2M | 70.8k | 74 | 58.5k | 4m 50s |
| implement | 1 | 132 | 4.5k | 505.1k | 36.6k | 38 | 24.0k | 2m 12s |
| prepare_pr | 1 | 60 | 4.6k | 196.1k | 35.2k | 20 | 22.8k | 1m 18s |
| compose_pr | 1 | 59 | 2.4k | 181.0k | 29.8k | 15 | 16.8k | 52s |
| review_pr | 1 | 92 | 8.9k | 388.4k | 44.1k | 35 | 32.9k | 2m 15s |
| **Total** | | 681 | 44.9k | 3.2M | 70.8k | | 204.5k | 16m 13s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 30 | 16836.2 | 799.2 | 150.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **30** | 107988.2 | 6817.2 | 1496.3 |