### PR TITLE
Add --profile CLI Flag to autoskillit cook for Provider Selection

### DIFF
--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -431,9 +431,6 @@ def _cook_cmd(
 
     Use --resume to restore a previous session. Pass a session ID to target a
     specific one, or omit for Claude Code's interactive picker.
-
-    Use --profile to select a provider profile (overrides config default_provider
-    for this session only; requires the 'providers' feature flag to be enabled).
     """
     cook_interactive(
         resume=resume or (session_id is not None), session_id=session_id, profile=profile

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -424,13 +424,20 @@ def recipes_render(name: str | None = None) -> None:
 
 
 @app.command(name="cook", alias="c")
-def _cook_cmd(session_id: str | None = None, *, resume: bool = False) -> None:
+def _cook_cmd(
+    session_id: str | None = None, *, resume: bool = False, profile: str | None = None
+) -> None:
     """Launch an interactive Claude session with all skills and kitchen tools.
 
     Use --resume to restore a previous session. Pass a session ID to target a
     specific one, or omit for Claude Code's interactive picker.
+
+    Use --profile to select a provider profile (overrides config default_provider
+    for this session only; requires the 'providers' feature flag to be enabled).
     """
-    cook_interactive(resume=resume or (session_id is not None), session_id=session_id)
+    cook_interactive(
+        resume=resume or (session_id is not None), session_id=session_id, profile=profile
+    )
 
 
 def main() -> None:

--- a/src/autoskillit/cli/session/_cook.py
+++ b/src/autoskillit/cli/session/_cook.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import shutil
 import subprocess
+import sys
 import uuid
 from collections.abc import Mapping
 from pathlib import Path
 
 from autoskillit.cli.ui._terminal import terminal_guard
+from autoskillit.core.feature_flags import is_feature_enabled
 
 
 def _print_recipes_list() -> None:
@@ -59,7 +61,9 @@ def _run_cook_session(
     return None
 
 
-def cook(*, resume: bool = False, session_id: str | None = None) -> None:
+def cook(
+    *, resume: bool = False, session_id: str | None = None, profile: str | None = None
+) -> None:
     """Launch Claude with all bundled AutoSkillit skills as slash commands."""
     from autoskillit.workspace import (
         DefaultSessionSkillManager,
@@ -85,6 +89,27 @@ def cook(*, resume: bool = False, session_id: str | None = None) -> None:
     from autoskillit.config import iter_display_categories, load_config  # noqa: PLC0415
 
     config = load_config()
+
+    if profile is not None:
+        if not is_feature_enabled(
+            "providers", config.features, experimental_enabled=config.experimental_enabled
+        ):
+            print(
+                "Error: --profile requires the 'providers' feature to be enabled.\n"
+                "Enable it in .autoskillit/config.yaml:\n"
+                "  features:\n"
+                "    providers: true",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+        if profile not in config.providers.profiles:
+            known = ", ".join(sorted(config.providers.profiles)) or "(none defined)"
+            print(
+                f"Error: Unknown provider profile {profile!r}. Known profiles: {known}\n"
+                "Define profiles in .autoskillit/config.yaml under providers.profiles.",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
 
     print(f"{_B}{_C}AUTOSKILLIT {__version__}{_R} {_D}Kitchen open. All tools active.{_R}")
     skip = {"Telemetry & Diagnostics", "Kitchen"}
@@ -175,6 +200,9 @@ def cook(*, resume: bool = False, session_id: str | None = None) -> None:
         SESSION_TYPE_ENV_VAR: SESSION_TYPE_COOK,
         LAUNCH_ID_ENV_VAR: session_id_local,
     }
+    if profile is not None:
+        _cook_env_extras["AUTOSKILLIT_PROVIDER_PROFILE"] = profile
+        _cook_env_extras.update(config.providers.profiles[profile])
 
     current_resume_spec = resume_spec
     _current_first_run = _first_run

--- a/src/autoskillit/cli/session/_cook.py
+++ b/src/autoskillit/cli/session/_cook.py
@@ -10,7 +10,7 @@ from collections.abc import Mapping
 from pathlib import Path
 
 from autoskillit.cli.ui._terminal import terminal_guard
-from autoskillit.core.feature_flags import is_feature_enabled
+from autoskillit.core import is_feature_enabled
 
 
 def _print_recipes_list() -> None:

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -9,6 +9,7 @@ construction scattered across callers.
 
 from __future__ import annotations
 
+import dataclasses
 import os
 import subprocess
 from collections.abc import Callable
@@ -198,12 +199,15 @@ def make_context(
         All service fields are populated. When runner=None is passed explicitly,
         tester is left as None.
     """
-    # When cook CLI passes --profile, it stamps AUTOSKILLIT_PROVIDER_PROFILE into the
-    # Claude Code subprocess env. The MCP server (plugin subprocess) inherits this and
-    # uses it as default_provider, taking precedence over config without modifying disk.
     env_profile = os.environ.get("AUTOSKILLIT_PROVIDER_PROFILE")
-    if env_profile:
-        config.providers.default_provider = env_profile
+    if env_profile and env_profile in config.providers.profiles:
+        config = dataclasses.replace(
+            config, providers=dataclasses.replace(config.providers, default_provider=env_profile)
+        )
+    elif env_profile:
+        logger.warning(
+            "AUTOSKILLIT_PROVIDER_PROFILE %r not in known profiles — ignored", env_profile
+        )
 
     if runner is _UNSET:
         from autoskillit.execution import DefaultSubprocessRunner

--- a/src/autoskillit/server/_factory.py
+++ b/src/autoskillit/server/_factory.py
@@ -198,6 +198,13 @@ def make_context(
         All service fields are populated. When runner=None is passed explicitly,
         tester is left as None.
     """
+    # When cook CLI passes --profile, it stamps AUTOSKILLIT_PROVIDER_PROFILE into the
+    # Claude Code subprocess env. The MCP server (plugin subprocess) inherits this and
+    # uses it as default_provider, taking precedence over config without modifying disk.
+    env_profile = os.environ.get("AUTOSKILLIT_PROVIDER_PROFILE")
+    if env_profile:
+        config.providers.default_provider = env_profile
+
     if runner is _UNSET:
         from autoskillit.execution import DefaultSubprocessRunner
 

--- a/tests/cli/CLAUDE.md
+++ b/tests/cli/CLAUDE.md
@@ -21,6 +21,7 @@ CLI command, subcommand, and interactive workflow tests.
 | `test_cook_features.py` | Tests: cook CLI features — subset gate, recipes CLI, fleet display categories |
 | `test_cook_ide_isolation.py` | End-to-end regression canary: _launch_cook_session under simulated IDE state |
 | `test_cook_interactive.py` | Tests for the cook CLI command (interactive skill session) |
+| `test_cook_profile.py` | Tests for --profile flag in cook command — env injection and validation |
 | `test_cook_order_command.py` | Tests: cook CLI order command — script validation, command building, env injection |
 | `test_cook_order_picker.py` | Tests: cook CLI order command — recipe picker, resume flows, session parsing |
 | `test_cook_order_prompt.py` | Tests: cook CLI order command — system prompt content, MCP prefix selection, ownership |

--- a/tests/cli/test_cook_interactive.py
+++ b/tests/cli/test_cook_interactive.py
@@ -462,7 +462,9 @@ class TestCookInteractive:
 
         captured: dict = {}
 
-        def fake_cook(*, resume: bool = False, session_id: str | None = None) -> None:
+        def fake_cook(
+            *, resume: bool = False, session_id: str | None = None, profile: str | None = None
+        ) -> None:
             captured["resume"] = resume
             captured["session_id"] = session_id
 
@@ -487,7 +489,9 @@ class TestCookInteractive:
 
         captured: dict = {}
 
-        def fake_cook(*, resume: bool = False, session_id: str | None = None) -> None:
+        def fake_cook(
+            *, resume: bool = False, session_id: str | None = None, profile: str | None = None
+        ) -> None:
             captured["resume"] = resume
             captured["session_id"] = session_id
 
@@ -511,7 +515,9 @@ class TestCookInteractive:
 
         captured: dict = {}
 
-        def fake_cook(*, resume: bool = False, session_id: str | None = None) -> None:
+        def fake_cook(
+            *, resume: bool = False, session_id: str | None = None, profile: str | None = None
+        ) -> None:
             captured["resume"] = resume
             captured["session_id"] = session_id
 

--- a/tests/cli/test_cook_profile.py
+++ b/tests/cli/test_cook_profile.py
@@ -1,0 +1,119 @@
+"""Tests for --profile flag in cook command."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import autoskillit.cli.session._cook as cook_module
+from autoskillit.execution.commands import ClaudeInteractiveCmd
+
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.medium]
+
+
+def _fake_build_cmd():
+    captured = []
+
+    def fake(**kwargs):
+        captured.append(kwargs.get("env_extras", {}))
+        return ClaudeInteractiveCmd(cmd=["claude"], env={})
+
+    return fake, captured
+
+
+@pytest.fixture()
+def _mock_mgr():
+    return MagicMock()
+
+
+def _run_cook(profile, cfg, mock_mgr):
+    fake_build, captured = _fake_build_cmd()
+    with (
+        patch("shutil.which", return_value="/usr/bin/claude"),
+        patch("builtins.input", return_value=""),
+        patch("autoskillit.workspace.DefaultSessionSkillManager", return_value=mock_mgr),
+        patch("subprocess.run", return_value=MagicMock(returncode=0)),
+        patch("autoskillit.execution.build_interactive_cmd", fake_build),
+        patch("autoskillit.core.write_registry_entry"),
+        patch("autoskillit.config.load_config", return_value=cfg),
+        patch(
+            "autoskillit.cli.session._cook.is_feature_enabled",
+            side_effect=lambda key, *a, **kw: key == "providers",
+        ),
+    ):
+        cook_module.cook(profile=profile)
+    return captured
+
+
+def test_profile_valid_injects_provider_env_var(_mock_mgr):
+    """AUTOSKILLIT_PROVIDER_PROFILE must be in env_extras when --profile is given."""
+    cfg = MagicMock()
+    cfg.experimental_enabled = True
+    cfg.providers.profiles = {"minimax": {"ANTHROPIC_BASE_URL": "https://minimax.example"}}
+    captured = _run_cook("minimax", cfg, _mock_mgr)
+    env = captured[0]
+    assert env.get("AUTOSKILLIT_PROVIDER_PROFILE") == "minimax"
+
+
+def test_profile_valid_injects_profile_env_vars(_mock_mgr):
+    """Profile's own env vars (API creds) must be injected into env_extras."""
+    cfg = MagicMock()
+    cfg.experimental_enabled = True
+    cfg.providers.profiles = {
+        "minimax": {"ANTHROPIC_BASE_URL": "https://mm.io", "ANTHROPIC_API_KEY": "sk-mm"}
+    }
+    captured = _run_cook("minimax", cfg, _mock_mgr)
+    env = captured[0]
+    assert env.get("ANTHROPIC_BASE_URL") == "https://mm.io"
+    assert env.get("ANTHROPIC_API_KEY") == "sk-mm"
+
+
+def test_profile_none_does_not_inject_provider_env(_mock_mgr):
+    """When profile=None, AUTOSKILLIT_PROVIDER_PROFILE must NOT appear in env_extras."""
+    cfg = MagicMock()
+    cfg.experimental_enabled = True
+    cfg.providers.profiles = {}
+    captured = _run_cook(None, cfg, _mock_mgr)
+    env = captured[0]
+    assert "AUTOSKILLIT_PROVIDER_PROFILE" not in env
+
+
+def test_profile_feature_disabled_exits(capsys, _mock_mgr):
+    """SystemExit(1) with informative message when providers feature is not enabled."""
+    cfg = MagicMock()
+    cfg.experimental_enabled = False
+    cfg.providers.profiles = {"minimax": {}}
+    fake_build, _ = _fake_build_cmd()
+    with (
+        patch("shutil.which", return_value="/usr/bin/claude"),
+        patch("autoskillit.workspace.DefaultSessionSkillManager", return_value=_mock_mgr),
+        patch("autoskillit.execution.build_interactive_cmd", fake_build),
+        patch("autoskillit.config.load_config", return_value=cfg),
+        patch("autoskillit.cli.session._cook.is_feature_enabled", return_value=False),
+    ):
+        with pytest.raises(SystemExit) as exc_info:
+            cook_module.cook(profile="minimax")
+    assert exc_info.value.code == 1
+    assert "providers" in capsys.readouterr().err
+
+
+def test_profile_unknown_exits(capsys, _mock_mgr):
+    """SystemExit(1) with informative message listing known profiles for unknown name."""
+    cfg = MagicMock()
+    cfg.experimental_enabled = True
+    cfg.providers.profiles = {"anthropic": {}, "openai": {}}
+    fake_build, _ = _fake_build_cmd()
+    with (
+        patch("shutil.which", return_value="/usr/bin/claude"),
+        patch("autoskillit.workspace.DefaultSessionSkillManager", return_value=_mock_mgr),
+        patch("autoskillit.execution.build_interactive_cmd", fake_build),
+        patch("autoskillit.config.load_config", return_value=cfg),
+        patch("autoskillit.cli.session._cook.is_feature_enabled", return_value=True),
+    ):
+        with pytest.raises(SystemExit) as exc_info:
+            cook_module.cook(profile="minimax")
+    assert exc_info.value.code == 1
+    err = capsys.readouterr().err
+    assert "minimax" in err
+    assert "anthropic" in err or "openai" in err

--- a/tests/cli/test_cook_profile.py
+++ b/tests/cli/test_cook_profile.py
@@ -41,6 +41,7 @@ def _run_cook(profile, cfg, mock_mgr):
             "autoskillit.cli.session._cook.is_feature_enabled",
             side_effect=lambda key, *a, **kw: key == "providers",
         ),
+        patch("autoskillit.cli.ui._timed_input.timed_prompt", return_value=""),
     ):
         cook_module.cook(profile=profile)
     return captured

--- a/tests/cli/test_cook_profile.py
+++ b/tests/cli/test_cook_profile.py
@@ -53,6 +53,7 @@ def test_profile_valid_injects_provider_env_var(_mock_mgr):
     cfg.experimental_enabled = True
     cfg.providers.profiles = {"minimax": {"ANTHROPIC_BASE_URL": "https://minimax.example"}}
     captured = _run_cook("minimax", cfg, _mock_mgr)
+    assert len(captured) >= 1, "build_interactive_cmd was not called"
     env = captured[0]
     assert env.get("AUTOSKILLIT_PROVIDER_PROFILE") == "minimax"
 
@@ -65,6 +66,7 @@ def test_profile_valid_injects_profile_env_vars(_mock_mgr):
         "minimax": {"ANTHROPIC_BASE_URL": "https://mm.io", "ANTHROPIC_API_KEY": "sk-mm"}
     }
     captured = _run_cook("minimax", cfg, _mock_mgr)
+    assert len(captured) >= 1, "build_interactive_cmd was not called"
     env = captured[0]
     assert env.get("ANTHROPIC_BASE_URL") == "https://mm.io"
     assert env.get("ANTHROPIC_API_KEY") == "sk-mm"
@@ -76,6 +78,7 @@ def test_profile_none_does_not_inject_provider_env(_mock_mgr):
     cfg.experimental_enabled = True
     cfg.providers.profiles = {}
     captured = _run_cook(None, cfg, _mock_mgr)
+    assert len(captured) >= 1, "build_interactive_cmd was not called"
     env = captured[0]
     assert "AUTOSKILLIT_PROVIDER_PROFILE" not in env
 

--- a/tests/server/test_factory.py
+++ b/tests/server/test_factory.py
@@ -536,9 +536,6 @@ def test_resolve_project_dir_cwd_fallback(monkeypatch):
     assert _resolve_project_dir() == Path.cwd()
 
 
-# --- AUTOSKILLIT_PROVIDER_PROFILE env override tests ---
-
-
 def test_make_context_env_profile_overrides_default_provider(monkeypatch):
     """AUTOSKILLIT_PROVIDER_PROFILE in env must set config.providers.default_provider."""
     monkeypatch.setenv("AUTOSKILLIT_PROVIDER_PROFILE", "minimax")
@@ -574,5 +571,6 @@ def test_make_context_no_env_profile_preserves_config_default(monkeypatch):
     monkeypatch.delenv("AUTOSKILLIT_PROVIDER_PROFILE", raising=False)
     config = AutomationConfig()
     config.providers.default_provider = "openai"
+    config.providers.profiles = {}
     ctx = make_context(config, runner=_runner())
     assert ctx.config.providers.default_provider == "openai"

--- a/tests/server/test_factory.py
+++ b/tests/server/test_factory.py
@@ -534,3 +534,33 @@ def test_resolve_project_dir_cwd_fallback(monkeypatch):
 
     monkeypatch.setattr("autoskillit.server._factory.subprocess.run", fake_run)
     assert _resolve_project_dir() == Path.cwd()
+
+
+# --- AUTOSKILLIT_PROVIDER_PROFILE env override tests ---
+
+
+def test_make_context_env_profile_overrides_default_provider(monkeypatch):
+    """AUTOSKILLIT_PROVIDER_PROFILE in env must set config.providers.default_provider."""
+    monkeypatch.setenv("AUTOSKILLIT_PROVIDER_PROFILE", "minimax")
+    config = AutomationConfig()
+    config.providers.default_provider = None
+    ctx = make_context(config, runner=_runner())
+    assert ctx.config.providers.default_provider == "minimax"
+
+
+def test_make_context_env_profile_overrides_existing_default(monkeypatch):
+    """AUTOSKILLIT_PROVIDER_PROFILE overrides even a config-set default_provider."""
+    monkeypatch.setenv("AUTOSKILLIT_PROVIDER_PROFILE", "minimax")
+    config = AutomationConfig()
+    config.providers.default_provider = "openai"
+    ctx = make_context(config, runner=_runner())
+    assert ctx.config.providers.default_provider == "minimax"
+
+
+def test_make_context_no_env_profile_preserves_config_default(monkeypatch):
+    """Without AUTOSKILLIT_PROVIDER_PROFILE in env, default_provider is unchanged."""
+    monkeypatch.delenv("AUTOSKILLIT_PROVIDER_PROFILE", raising=False)
+    config = AutomationConfig()
+    config.providers.default_provider = "openai"
+    ctx = make_context(config, runner=_runner())
+    assert ctx.config.providers.default_provider == "openai"

--- a/tests/server/test_factory.py
+++ b/tests/server/test_factory.py
@@ -544,6 +544,7 @@ def test_make_context_env_profile_overrides_default_provider(monkeypatch):
     monkeypatch.setenv("AUTOSKILLIT_PROVIDER_PROFILE", "minimax")
     config = AutomationConfig()
     config.providers.default_provider = None
+    config.providers.profiles = {"minimax": {}}
     ctx = make_context(config, runner=_runner())
     assert ctx.config.providers.default_provider == "minimax"
 
@@ -553,8 +554,19 @@ def test_make_context_env_profile_overrides_existing_default(monkeypatch):
     monkeypatch.setenv("AUTOSKILLIT_PROVIDER_PROFILE", "minimax")
     config = AutomationConfig()
     config.providers.default_provider = "openai"
+    config.providers.profiles = {"minimax": {}}
     ctx = make_context(config, runner=_runner())
     assert ctx.config.providers.default_provider == "minimax"
+
+
+def test_make_context_unknown_env_profile_is_ignored(monkeypatch):
+    """AUTOSKILLIT_PROVIDER_PROFILE not in profiles is ignored — no mutation."""
+    monkeypatch.setenv("AUTOSKILLIT_PROVIDER_PROFILE", "stale-unknown")
+    config = AutomationConfig()
+    config.providers.default_provider = "anthropic"
+    config.providers.profiles = {}
+    ctx = make_context(config, runner=_runner())
+    assert ctx.config.providers.default_provider == "anthropic"
 
 
 def test_make_context_no_env_profile_preserves_config_default(monkeypatch):


### PR DESCRIPTION
## Summary

Add a `--profile <name>` option to the `autoskillit cook` command that overrides the
session-level default provider without modifying any config files on disk. The flag
validates feature-flag enablement and profile existence at startup, then threads the
profile name through two mechanisms: (1) as an env var in `_cook_env_extras` for the
Claude Code subprocess and (2) as a runtime override applied in `make_context()` so the
MCP server's `run_skill` tool resolves Tier 4 to the CLI-selected profile rather than
`default_provider` from config. `step_overrides` (Tiers 1/2) continue to win.

Closes #1905

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260505-000406-360445/.autoskillit/temp/make-plan/add_profile_cli_flag_to_cook_plan_2026-05-05_001000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 127 | 20.7k | 642.9k | 63.0k | 86 | 50.0k | 10m 15s |
| verify | 1 | 118 | 14.5k | 580.1k | 56.8k | 59 | 43.9k | 8m 16s |
| implement | 1 | 358 | 20.5k | 2.3M | 70.2k | 122 | 57.6k | 8m 2s |
| prepare_pr | 1 | 60 | 4.3k | 210.8k | 38.4k | 18 | 26.1k | 1m 39s |
| compose_pr | 1 | 51 | 1.9k | 151.2k | 29.4k | 14 | 16.4k | 48s |
| review_pr | 2 | 886 | 72.1k | 1.8M | 87.4k | 169 | 145.5k | 18m 14s |
| resolve_review | 2 | 718 | 43.8k | 5.3M | 110.5k | 212 | 166.8k | 22m 50s |
| **Total** | | 2.3k | 177.8k | 10.9M | 110.5k | | 506.2k | 1h 10m |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 197 | 11469.6 | 292.3 | 104.2 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 36 | 146848.3 | 4633.2 | 1215.9 |
| **Total** | **233** | 46788.4 | 2172.7 | 763.0 |