### PR TITLE
feat: generalize provider profile resolution to model field across all MCP tool surfaces

### DIFF
--- a/src/autoskillit/server/_guards.py
+++ b/src/autoskillit/server/_guards.py
@@ -199,3 +199,48 @@ def _resolve_provider_profile(
     if name == "anthropic":
         return ("anthropic", {})
     return (name, config_providers.profiles.get(name, {}))
+
+
+def _resolve_model_as_profile(
+    model_value: str,
+    config_providers: ProvidersConfig,
+) -> tuple[str, str, dict[str, str] | None]:
+    """Check if a model value names a configured provider profile.
+
+    When a model parameter matches a key in ``providers.profiles``, the profile's
+    ``ANTHROPIC_MODEL`` entry becomes the effective model for ``--model``, and the
+    remaining profile entries become environment variable overrides for the subprocess.
+
+    Returns:
+        (effective_model, profile_name, provider_extras):
+        - Profile match with ANTHROPIC_MODEL:
+          (profile's model, profile_key, env_dict without ANTHROPIC_MODEL)
+        - Profile match without ANTHROPIC_MODEL:
+          ("", "", None) — caller should fall through to config default
+        - No match:
+          (model_value, "", None) — treat as literal model name
+    """
+    if not model_value:
+        return (model_value, "", None)
+
+    profile = config_providers.profiles.get(model_value)
+    if profile is None:
+        return (model_value, "", None)
+
+    actual_model = profile.get("ANTHROPIC_MODEL")
+    if not actual_model:
+        logger.warning(
+            "provider_profile_no_model",
+            profile=model_value,
+            hint="Add ANTHROPIC_MODEL to the profile or use a literal model name",
+        )
+        return ("", "", None)
+
+    logger.debug(
+        "model_as_profile_resolved",
+        input_model=model_value,
+        resolved_model=actual_model,
+        profile=model_value,
+    )
+    env_dict = {k: v for k, v in profile.items() if k != "ANTHROPIC_MODEL"}
+    return (actual_model, model_value, env_dict)

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -398,6 +398,7 @@ async def run_skill(
 
         provider_extras: dict[str, str] | None = None
         profile_name_out: str = ""
+        effective_model = model
 
         from autoskillit.core import is_feature_enabled
 
@@ -405,7 +406,10 @@ async def run_skill(
         if is_feature_enabled(
             "providers", _cfg.features, experimental_enabled=_cfg.experimental_enabled
         ):
-            from autoskillit.server._guards import _resolve_provider_profile
+            from autoskillit.server._guards import (
+                _resolve_model_as_profile,
+                _resolve_provider_profile,
+            )
 
             _profile, _env_dict = _resolve_provider_profile(
                 step_name or "", tool_ctx.recipe_name or "", _cfg.providers
@@ -413,6 +417,13 @@ async def run_skill(
             if _profile != "anthropic":
                 provider_extras = _env_dict
                 profile_name_out = _profile
+            else:
+                effective_model, prof_name, prof_extras = _resolve_model_as_profile(
+                    model, _cfg.providers
+                )
+                if prof_extras is not None:
+                    provider_extras = prof_extras
+                    profile_name_out = prof_name
 
         # Look up artifact validation patterns from skill contract
         expected_output_patterns: list[str] = []
@@ -522,7 +533,7 @@ async def run_skill(
             skill_result = await tool_ctx.executor.run(
                 resolved_command,
                 cwd,
-                model=model,
+                model=effective_model,
                 add_dirs=skill_add_dirs,
                 step_name=step_name,
                 kitchen_id=tool_ctx.kitchen_id,

--- a/src/autoskillit/server/tools/tools_github.py
+++ b/src/autoskillit/server/tools/tools_github.py
@@ -231,6 +231,25 @@ async def report_bug(
             report_path = report_dir / f"{timestamp}_report.md"
 
             effective_model = model or cfg.model or ""
+            report_provider_extras: dict[str, str] | None = None
+            report_profile_name: str = ""
+
+            from autoskillit.core import is_feature_enabled
+
+            if is_feature_enabled(
+                "providers",
+                config.features,
+                experimental_enabled=config.experimental_enabled,
+            ):
+                from autoskillit.server._guards import _resolve_model_as_profile
+
+                effective_model, _prof_name, _prof_extras = _resolve_model_as_profile(
+                    effective_model, config.providers
+                )
+                if _prof_extras is not None:
+                    report_provider_extras = _prof_extras
+                    report_profile_name = _prof_name
+
             skill_command = (
                 f"/report-bug\n\n"
                 f"Error context:\n{error_context}\n\n"
@@ -263,6 +282,8 @@ async def report_bug(
                     log_dir=log_dir,
                     expected_output_patterns=expected_output_patterns,
                     write_behavior=write_spec,
+                    provider_extras=report_provider_extras,
+                    profile_name=report_profile_name,
                 )
                 if not result["success"]:
                     await _notify(
@@ -300,6 +321,8 @@ async def report_bug(
                     expected_output_patterns=expected_output_patterns,
                     write_behavior=write_spec,
                     status_path=status_path,
+                    provider_extras=report_provider_extras,
+                    profile_name=report_profile_name,
                 ),
                 label=step_name or "report_bug",
             )
@@ -581,6 +604,8 @@ async def _run_report_session(
     expected_output_patterns: list[str] | None = None,
     write_behavior: Any = None,
     status_path: Path | None = None,
+    provider_extras: dict[str, str] | None = None,
+    profile_name: str = "",
 ) -> dict[str, Any]:
     """Run the headless session, write the report, and handle GitHub filing.
 
@@ -597,6 +622,8 @@ async def _run_report_session(
             timeout=float(cfg.timeout),
             expected_output_patterns=expected_output_patterns or [],
             write_behavior=write_behavior,
+            provider_extras=provider_extras,
+            profile_name=profile_name,
         )
 
         report_text = skill_result.result or skill_result.stderr or "No report generated."

--- a/src/autoskillit/server/tools/tools_github.py
+++ b/src/autoskillit/server/tools/tools_github.py
@@ -241,14 +241,22 @@ async def report_bug(
                 config.features,
                 experimental_enabled=config.experimental_enabled,
             ):
-                from autoskillit.server._guards import _resolve_model_as_profile
-
-                effective_model, _prof_name, _prof_extras = _resolve_model_as_profile(
-                    effective_model, config.providers
+                from autoskillit.server._guards import (
+                    _resolve_model_as_profile,
+                    _resolve_provider_profile,
                 )
-                if _prof_extras is not None:
-                    report_provider_extras = _prof_extras
-                    report_profile_name = _prof_name
+
+                _rp_profile, _rp_env = _resolve_provider_profile("", "", config.providers)
+                if _rp_profile != "anthropic":
+                    report_provider_extras = _rp_env
+                    report_profile_name = _rp_profile
+                else:
+                    effective_model, _prof_name, _prof_extras = _resolve_model_as_profile(
+                        effective_model, config.providers
+                    )
+                    if _prof_extras is not None:
+                        report_provider_extras = _prof_extras
+                        report_profile_name = _prof_name
 
             skill_command = (
                 f"/report-bug\n\n"

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -134,7 +134,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # tools_status.py — mcp_data dict
     ("src/autoskillit/server/tools/tools_status.py", 486),
     # tools_github.py — bug report dict
-    ("src/autoskillit/server/tools/tools_github.py", 300),
+    ("src/autoskillit/server/tools/tools_github.py", 308),
     # _hooks.py — settings.json dict (co-owned with Claude CLI)
     ("src/autoskillit/cli/_hooks.py", 24),
     # _init_helpers.py — ~/.claude.json (co-owned)

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -134,7 +134,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # tools_status.py — mcp_data dict
     ("src/autoskillit/server/tools/tools_status.py", 486),
     # tools_github.py — bug report dict
-    ("src/autoskillit/server/tools/tools_github.py", 279),
+    ("src/autoskillit/server/tools/tools_github.py", 300),
     # _hooks.py — settings.json dict (co-owned with Claude CLI)
     ("src/autoskillit/cli/_hooks.py", 24),
     # _init_helpers.py — ~/.claude.json (co-owned)

--- a/tests/server/CLAUDE.md
+++ b/tests/server/CLAUDE.md
@@ -28,6 +28,7 @@ Server tool handler unit tests — kitchen, execution, CI, clone, workspace tool
 | `test_quota_refresh_loop.py` | Tests for _quota_refresh_loop in server/_misc.py |
 | `test_release_issue_fail_label.py` | Tests for release_issue fail_label path and fail label cleanup |
 | `test_reload_session.py` | Tests for the reload_session MCP tool and supporting helpers |
+| `test_resolve_model_as_profile.py` | Tests for _resolve_model_as_profile — model-value-as-provider-profile resolution in _guards.py |
 | `test_resolve_provider_profile.py` | Tests for _resolve_provider_profile four-tier provider resolution in _guards.py |
 | `test_run_skill_add_dirs.py` | Contract tests: run_skill passes correct add_dirs to executor (T-OVR-014) |
 | `test_run_skill_resume.py` | Tests for resume_session_id threading from run_skill through executor |

--- a/tests/server/test_resolve_model_as_profile.py
+++ b/tests/server/test_resolve_model_as_profile.py
@@ -1,0 +1,99 @@
+"""Tests for _resolve_model_as_profile model-as-profile resolution in _guards.py."""
+
+from __future__ import annotations
+
+import pytest
+import structlog
+
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+
+def _make_config(**kwargs):
+    from autoskillit.config._config_dataclasses import ProvidersConfig
+
+    return ProvidersConfig(**kwargs)
+
+
+def test_model_matches_profile_with_anthropic_model():
+    from autoskillit.server._guards import _resolve_model_as_profile
+
+    cfg = _make_config(
+        profiles={
+            "minimax": {
+                "ANTHROPIC_MODEL": "MiniMax-M2.7",
+                "ANTHROPIC_BASE_URL": "https://api.minimax.chat/v1",
+            }
+        }
+    )
+    result = _resolve_model_as_profile("minimax", cfg)
+    assert result == (
+        "MiniMax-M2.7",
+        "minimax",
+        {"ANTHROPIC_BASE_URL": "https://api.minimax.chat/v1"},
+    )
+
+
+def test_model_matches_profile_without_anthropic_model():
+    from autoskillit.server._guards import _resolve_model_as_profile
+
+    cfg = _make_config(profiles={"broken": {"ANTHROPIC_BASE_URL": "https://example.com"}})
+    with structlog.testing.capture_logs() as logs:
+        result = _resolve_model_as_profile("broken", cfg)
+    assert result == ("", "", None)
+    assert any(
+        log.get("event") == "provider_profile_no_model" and log.get("profile") == "broken"
+        for log in logs
+    )
+
+
+def test_model_no_match_passthrough():
+    from autoskillit.server._guards import _resolve_model_as_profile
+
+    cfg = _make_config(profiles={"minimax": {"ANTHROPIC_MODEL": "MiniMax-M2.7"}})
+    result = _resolve_model_as_profile("sonnet", cfg)
+    assert result == ("sonnet", "", None)
+
+
+def test_empty_model_passthrough():
+    from autoskillit.server._guards import _resolve_model_as_profile
+
+    cfg = _make_config()
+    result = _resolve_model_as_profile("", cfg)
+    assert result == ("", "", None)
+
+
+def test_anthropic_model_key_excluded_from_extras():
+    from autoskillit.server._guards import _resolve_model_as_profile
+
+    cfg = _make_config(
+        profiles={
+            "minimax": {
+                "ANTHROPIC_MODEL": "M2.7",
+                "ANTHROPIC_BASE_URL": "https://api.minimax.chat/v1",
+                "ANTHROPIC_API_KEY": "test-key",
+            }
+        }
+    )
+    effective_model, profile_name, extras = _resolve_model_as_profile("minimax", cfg)
+    assert effective_model == "M2.7"
+    assert profile_name == "minimax"
+    assert extras is not None
+    assert "ANTHROPIC_MODEL" not in extras
+    assert extras["ANTHROPIC_BASE_URL"] == "https://api.minimax.chat/v1"
+    assert extras["ANTHROPIC_API_KEY"] == "test-key"
+
+
+def test_profile_with_only_anthropic_model_returns_empty_extras():
+    from autoskillit.server._guards import _resolve_model_as_profile
+
+    cfg = _make_config(profiles={"simple": {"ANTHROPIC_MODEL": "some-model"}})
+    result = _resolve_model_as_profile("simple", cfg)
+    assert result == ("some-model", "simple", {})
+
+
+def test_anthropic_as_model_value_no_profile():
+    from autoskillit.server._guards import _resolve_model_as_profile
+
+    cfg = _make_config(profiles={"minimax": {"ANTHROPIC_MODEL": "M2.7"}})
+    result = _resolve_model_as_profile("anthropic", cfg)
+    assert result == ("anthropic", "", None)

--- a/tests/server/test_resolve_model_as_profile.py
+++ b/tests/server/test_resolve_model_as_profile.py
@@ -58,8 +58,10 @@ def test_empty_model_passthrough():
     from autoskillit.server._guards import _resolve_model_as_profile
 
     cfg = _make_config()
-    result = _resolve_model_as_profile("", cfg)
+    with structlog.testing.capture_logs() as logs:
+        result = _resolve_model_as_profile("", cfg)
     assert result == ("", "", None)
+    assert not any(log.get("event") == "provider_profile_no_model" for log in logs)
 
 
 def test_anthropic_model_key_excluded_from_extras():

--- a/tests/server/test_tools_execution_provider.py
+++ b/tests/server/test_tools_execution_provider.py
@@ -93,3 +93,134 @@ async def test_run_skill_provider_extras_forwarded_for_non_anthropic(
 
     assert captured.get("provider_extras") == {"AWS_REGION": "us-east-1"}
     assert captured.get("profile_name") == "bedrock"
+
+
+@pytest.mark.anyio
+async def test_run_skill_model_as_profile_resolves_provider(
+    tool_ctx, tmp_path, monkeypatch
+) -> None:
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx.executor = executor
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
+    monkeypatch.setattr(
+        "autoskillit.server._guards._resolve_provider_profile",
+        lambda *a: ("anthropic", {}),
+    )
+    monkeypatch.setattr(
+        "autoskillit.server._guards._resolve_model_as_profile",
+        lambda *a: ("M2.7", "minimax", {"BASE_URL": "https://api.minimax.chat/v1"}),
+    )
+
+    captured: dict = {}
+    original_run = executor.run
+
+    async def spy_run(*args, **kwargs):
+        captured.update(kwargs)
+        return await original_run(*args, **kwargs)
+
+    monkeypatch.setattr(executor, "run", spy_run)
+
+    await run_skill("/autoskillit:probe", str(tmp_path))
+
+    assert captured.get("model") == "M2.7"
+    assert captured.get("provider_extras") == {"BASE_URL": "https://api.minimax.chat/v1"}
+    assert captured.get("profile_name") == "minimax"
+
+
+@pytest.mark.anyio
+async def test_run_skill_step_overrides_win_over_model_as_profile(
+    tool_ctx, tmp_path, monkeypatch
+) -> None:
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx.executor = executor
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
+    monkeypatch.setattr(
+        "autoskillit.server._guards._resolve_provider_profile",
+        lambda *a: ("bedrock", {"AWS_REGION": "us-east-1"}),
+    )
+    map_called = []
+    monkeypatch.setattr(
+        "autoskillit.server._guards._resolve_model_as_profile",
+        lambda *a: map_called.append(True) or ("", "", None),
+    )
+
+    captured: dict = {}
+    original_run = executor.run
+
+    async def spy_run(*args, **kwargs):
+        captured.update(kwargs)
+        return await original_run(*args, **kwargs)
+
+    monkeypatch.setattr(executor, "run", spy_run)
+
+    await run_skill("/autoskillit:probe", str(tmp_path), model="minimax")
+
+    assert captured.get("provider_extras") == {"AWS_REGION": "us-east-1"}
+    assert captured.get("profile_name") == "bedrock"
+    assert not map_called
+
+
+@pytest.mark.anyio
+async def test_run_skill_model_as_profile_disabled_when_feature_off(
+    tool_ctx, tmp_path, monkeypatch
+) -> None:
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx.executor = executor
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: False)
+
+    captured: dict = {}
+    original_run = executor.run
+
+    async def spy_run(*args, **kwargs):
+        captured.update(kwargs)
+        return await original_run(*args, **kwargs)
+
+    monkeypatch.setattr(executor, "run", spy_run)
+
+    await run_skill("/autoskillit:probe", str(tmp_path), model="minimax")
+
+    assert captured.get("model") == "minimax"
+    assert captured.get("provider_extras") is None
+
+
+@pytest.mark.anyio
+async def test_run_skill_model_as_profile_no_anthropic_model_falls_through(
+    tool_ctx, tmp_path, monkeypatch
+) -> None:
+    from tests.fakes import InMemoryHeadlessExecutor
+
+    executor = InMemoryHeadlessExecutor()
+    tool_ctx.executor = executor
+    monkeypatch.setattr("autoskillit.server._ctx", tool_ctx)
+    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
+    monkeypatch.setattr(
+        "autoskillit.server._guards._resolve_provider_profile",
+        lambda *a: ("anthropic", {}),
+    )
+    monkeypatch.setattr(
+        "autoskillit.server._guards._resolve_model_as_profile",
+        lambda *a: ("", "", None),
+    )
+
+    captured: dict = {}
+    original_run = executor.run
+
+    async def spy_run(*args, **kwargs):
+        captured.update(kwargs)
+        return await original_run(*args, **kwargs)
+
+    monkeypatch.setattr(executor, "run", spy_run)
+
+    await run_skill("/autoskillit:probe", str(tmp_path))
+
+    assert captured.get("model") == ""
+    assert captured.get("provider_extras") is None

--- a/tests/server/test_tools_report_bug.py
+++ b/tests/server/test_tools_report_bug.py
@@ -759,3 +759,7 @@ async def test_report_bug_config_model_as_profile(tool_ctx, tmp_path, monkeypatc
     assert map_calls == ["minimax"]
     call_kwargs = mock_executor.run.call_args.kwargs
     assert call_kwargs.get("model") == "MiniMax-M2.7"
+    assert call_kwargs.get("provider_extras") == {
+        "ANTHROPIC_BASE_URL": "https://api.minimax.chat/v1"
+    }
+    assert call_kwargs.get("profile_name") == "minimax"

--- a/tests/server/test_tools_report_bug.py
+++ b/tests/server/test_tools_report_bug.py
@@ -672,3 +672,90 @@ async def test_report_bug_blocking_github_client_raises_does_not_propagate(tool_
     assert result["github"].get("skipped") is True
     assert "unexpected error" in result["github"].get("reason", "")
     assert "network failure" in result["github"].get("reason", "")
+
+
+# ---------------------------------------------------------------------------
+# model-as-profile resolution in report_bug
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_report_bug_model_as_profile_resolves_provider(tool_ctx, tmp_path, monkeypatch):
+    tool_ctx.config.report_bug.report_dir = str(tmp_path / "bug-reports")
+    tool_ctx.config.report_bug.github_filing = False
+
+    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
+    monkeypatch.setattr(
+        "autoskillit.server._guards._resolve_model_as_profile",
+        lambda *a: (
+            "MiniMax-M2.7",
+            "minimax",
+            {"ANTHROPIC_BASE_URL": "https://api.minimax.chat/v1"},
+        ),
+    )
+
+    mock_executor = AsyncMock()
+    mock_executor.run.return_value = _skill_ok("report text")
+    tool_ctx.executor = mock_executor
+
+    result = json.loads(
+        await report_bug("error ctx", str(tmp_path), model="minimax", severity="blocking")
+    )
+
+    assert result["success"] is True
+    call_kwargs = mock_executor.run.call_args.kwargs
+    assert call_kwargs.get("model") == "MiniMax-M2.7"
+    assert call_kwargs.get("provider_extras") == {
+        "ANTHROPIC_BASE_URL": "https://api.minimax.chat/v1"
+    }
+    assert call_kwargs.get("profile_name") == "minimax"
+
+
+@pytest.mark.anyio
+async def test_report_bug_model_as_profile_disabled_when_feature_off(
+    tool_ctx, tmp_path, monkeypatch
+):
+    tool_ctx.config.report_bug.report_dir = str(tmp_path / "bug-reports")
+    tool_ctx.config.report_bug.github_filing = False
+
+    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: False)
+
+    mock_executor = AsyncMock()
+    mock_executor.run.return_value = _skill_ok("report text")
+    tool_ctx.executor = mock_executor
+
+    result = json.loads(
+        await report_bug("error ctx", str(tmp_path), model="minimax", severity="blocking")
+    )
+
+    assert result["success"] is True
+    call_kwargs = mock_executor.run.call_args.kwargs
+    assert call_kwargs.get("model") == "minimax"
+    assert call_kwargs.get("provider_extras") is None
+
+
+@pytest.mark.anyio
+async def test_report_bug_config_model_as_profile(tool_ctx, tmp_path, monkeypatch):
+    tool_ctx.config.report_bug.report_dir = str(tmp_path / "bug-reports")
+    tool_ctx.config.report_bug.github_filing = False
+    tool_ctx.config.report_bug.model = "minimax"
+
+    map_calls: list[str] = []
+
+    def fake_resolve(model_value, *a, **kw):
+        map_calls.append(model_value)
+        return ("MiniMax-M2.7", "minimax", {"ANTHROPIC_BASE_URL": "https://api.minimax.chat/v1"})
+
+    monkeypatch.setattr("autoskillit.core.is_feature_enabled", lambda *a, **kw: True)
+    monkeypatch.setattr("autoskillit.server._guards._resolve_model_as_profile", fake_resolve)
+
+    mock_executor = AsyncMock()
+    mock_executor.run.return_value = _skill_ok("report text")
+    tool_ctx.executor = mock_executor
+
+    result = json.loads(await report_bug("error ctx", str(tmp_path), severity="blocking"))
+
+    assert result["success"] is True
+    assert map_calls == ["minimax"]
+    call_kwargs = mock_executor.run.call_args.kwargs
+    assert call_kwargs.get("model") == "MiniMax-M2.7"

--- a/tests/workspace/test_clone_remote.py
+++ b/tests/workspace/test_clone_remote.py
@@ -1,4 +1,4 @@
-"""Remote resolution tests — _probe_single_remote, _probe_clone_source_url, clone URL resolution."""
+"""Remote resolution tests — _probe_single_remote, _probe_clone_source_url, URL resolution."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

Add a new `_resolve_model_as_profile()` function in `server/_guards.py` that checks whether a `model` value matches a provider profile key in `providers.profiles`. When it matches, the function extracts the actual model name from the profile's `ANTHROPIC_MODEL` key and returns the profile's env dict for subprocess injection. This function is called as a fallback at each MCP tool call site (`run_skill`, `report_bug`) after the existing step_overrides-based resolution — step_overrides always win. The change makes provider routing accessible from every surface that accepts a `model` parameter without requiring config-level `step_overrides`.

Closes #1918

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260505-081323-982218/.autoskillit/temp/make-plan/generalize_provider_profile_resolution_plan_2026-05-05_083500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 4.3k | 24.8k | 2.0M | 101.0k | 157 | 93.2k | 11m 41s |
| verify | 1 | 47 | 12.6k | 1.6M | 74.0k | 93 | 61.1k | 8m 4s |
| implement | 1 | 304 | 18.5k | 2.3M | 85.6k | 104 | 73.6k | 7m 13s |
| prepare_pr | 1 | 76 | 5.5k | 278.9k | 40.1k | 23 | 27.7k | 1m 52s |
| compose_pr | 1 | 51 | 1.7k | 151.8k | 29.4k | 15 | 16.5k | 38s |
| review_pr | 1 | 118 | 32.3k | 628.4k | 77.6k | 44 | 132.0k | 8m 47s |
| resolve_review | 1 | 335 | 23.0k | 2.5M | 100.4k | 125 | 87.9k | 12m 49s |
| ci_conflict_fix | 2 | 232 | 7.6k | 1.0M | 47.2k | 77 | 62.6k | 2m 57s |
| diagnose_ci | 1 | 116 | 3.4k | 437.3k | 39.6k | 28 | 27.3k | 1m 12s |
| resolve_ci | 1 | 162 | 3.6k | 504.1k | 47.4k | 31 | 35.9k | 4m 28s |
| **Total** | | 5.7k | 133.0k | 11.4M | 101.0k | | 617.8k | 59m 45s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 404 | 5709.2 | 182.2 | 45.8 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 32 | 77583.6 | 2746.4 | 718.4 |
| ci_conflict_fix | 5111 | 195.9 | 12.3 | 1.5 |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 1 | 504090.0 | 35946.0 | 3598.0 |
| **Total** | **5548** | 2047.0 | 111.4 | 24.0 |