### PR TITLE
Rectify: Provider Fields Silent Omission — Typed Container Immunity

### DIFF
--- a/src/autoskillit/core/__init__.pyi
+++ b/src/autoskillit/core/__init__.pyi
@@ -188,6 +188,8 @@ from .types import ResumeSpec as ResumeSpec
 from .types import RetryReason as RetryReason
 from .types import SessionOutcome as SessionOutcome
 from .types import SessionSkillManager as SessionSkillManager
+from .types import ProviderOutcome as ProviderOutcome
+from .types import RecipeIdentity as RecipeIdentity
 from .types import SessionTelemetry as SessionTelemetry
 from .types import SessionType as SessionType
 from .types import Severity as Severity

--- a/src/autoskillit/core/types/_type_results.py
+++ b/src/autoskillit/core/types/_type_results.py
@@ -25,6 +25,8 @@ __all__ = [
     "WriteBehaviorSpec",
     "FailureRecord",
     "SessionTelemetry",
+    "ProviderOutcome",
+    "RecipeIdentity",
     "SkillResult",
     "CleanupResult",
     "CIRunScope",
@@ -177,6 +179,42 @@ class SessionTelemetry:
         )
 
 
+@dataclass(frozen=True)
+class ProviderOutcome:
+    """Typed bundle of provider execution outcome fields.
+
+    All fields are required — constructing without any field is a TypeError,
+    making omissions visible at construction time rather than silently defaulting.
+    """
+
+    provider_used: str
+    fallback_activated: bool
+
+    @classmethod
+    def none_used(cls) -> ProviderOutcome:
+        """Sentinel for paths where no provider selection occurred."""
+        return cls(provider_used="", fallback_activated=False)
+
+
+@dataclass(frozen=True)
+class RecipeIdentity:
+    """Typed bundle of recipe identification fields for session logging.
+
+    All fields required — prevents silent empty-string drift when new recipe
+    fields are added to flush_session_log but not wired from callers.
+    """
+
+    name: str
+    content_hash: str
+    composite_hash: str
+    version: str
+
+    @classmethod
+    def empty(cls) -> RecipeIdentity:
+        """Sentinel for sessions not driven by a recipe."""
+        return cls(name="", content_hash="", composite_hash="", version="")
+
+
 @dataclass
 class SkillResult:
     """Typed result returned by _build_skill_result and run_headless_core."""
@@ -233,11 +271,10 @@ class SkillResult:
             "last_stop_reason": self.last_stop_reason,
             "lifespan_started": self.lifespan_started,
             "provider_fallback": self.provider_fallback,
+            "provider_used": self.provider_used,
         }
         if self.worktree_path is not None:
             data["worktree_path"] = self.worktree_path
-        if self.provider_used:
-            data["provider_used"] = self.provider_used
         data["infra_exit_category"] = self.infra_exit_category
         data["order_id"] = self.order_id
         return json.dumps(data, default=lambda o: o.value if isinstance(o, Enum) else str(o))
@@ -537,3 +574,5 @@ class SessionIndexEntry(TypedDict):
     recipe_version: str
     duration_seconds: float
     github_api_requests: int
+    provider_used: str
+    provider_fallback: bool

--- a/src/autoskillit/execution/headless/__init__.py
+++ b/src/autoskillit/execution/headless/__init__.py
@@ -26,6 +26,8 @@ from autoskillit.core import (
     CAMPAIGN_ID_ENV_VAR,
     DISPATCH_ID_ENV_VAR,
     KillReason,
+    ProviderOutcome,
+    RecipeIdentity,
     RetryReason,
     SessionCheckpoint,  # noqa: F401, TC001
     SkillResult,
@@ -332,10 +334,16 @@ async def _execute_claude_headless(
                     termination_reason="CRASHED",
                     exception_text=_exc_text,
                     versions=_versions,
-                    recipe_name=recipe_name,
-                    recipe_content_hash=recipe_content_hash,
-                    recipe_composite_hash=recipe_composite_hash,
-                    recipe_version=recipe_version,
+                    provider_outcome=ProviderOutcome(
+                        provider_used=current_provider_name,
+                        fallback_activated=fallback_activated,
+                    ),
+                    recipe_identity=RecipeIdentity(
+                        name=recipe_name,
+                        content_hash=recipe_content_hash,
+                        composite_hash=recipe_composite_hash,
+                        version=recipe_version,
+                    ),
                     max_sessions=ctx.config.linux_tracing.max_sessions,
                     telemetry=_build_error_path_telemetry(ctx.github_api_log),
                 )
@@ -379,10 +387,16 @@ async def _execute_claude_headless(
                         termination_reason="CANCELLED",
                         exception_text=_exc_text,
                         versions=_versions,
-                        recipe_name=recipe_name,
-                        recipe_content_hash=recipe_content_hash,
-                        recipe_composite_hash=recipe_composite_hash,
-                        recipe_version=recipe_version,
+                        provider_outcome=ProviderOutcome(
+                            provider_used=current_provider_name,
+                            fallback_activated=fallback_activated,
+                        ),
+                        recipe_identity=RecipeIdentity(
+                            name=recipe_name,
+                            content_hash=recipe_content_hash,
+                            composite_hash=recipe_composite_hash,
+                            version=recipe_version,
+                        ),
                         max_sessions=ctx.config.linux_tracing.max_sessions,
                         telemetry=_build_error_path_telemetry(ctx.github_api_log),
                     )
@@ -418,7 +432,7 @@ async def _execute_claude_headless(
             cwd=cwd,
             write_behavior=write_behavior,
             fs_writes_detected=_fs_writes_detected,
-            provider_used=provider_name,
+            provider_used=current_provider_name,
         )
 
         if (
@@ -526,10 +540,16 @@ async def _execute_claude_headless(
                 else "",
                 last_stop_reason=skill_result.last_stop_reason,
                 versions=_versions,
-                recipe_name=recipe_name,
-                recipe_content_hash=recipe_content_hash,
-                recipe_composite_hash=recipe_composite_hash,
-                recipe_version=recipe_version,
+                provider_outcome=ProviderOutcome(
+                    provider_used=current_provider_name,
+                    fallback_activated=fallback_activated,
+                ),
+                recipe_identity=RecipeIdentity(
+                    name=recipe_name,
+                    content_hash=recipe_content_hash,
+                    composite_hash=recipe_composite_hash,
+                    version=recipe_version,
+                ),
                 max_sessions=ctx.config.linux_tracing.max_sessions,
             )
         except Exception:

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from autoskillit.core import SessionTelemetry
+    from autoskillit.core.types._type_results import ProviderOutcome, RecipeIdentity
 
 import psutil
 
@@ -133,8 +134,8 @@ def flush_session_log(
     elapsed_seconds: float | None = None,
     termination_reason: str = "",
     kill_reason: str = "",
-    provider_used: str = "",
-    provider_fallback: bool = False,
+    provider_outcome: ProviderOutcome,
+    recipe_identity: RecipeIdentity,
     snapshot_interval_seconds: float = 0.0,
     step_name: str = "",
     cli_subtype: str = "",
@@ -149,10 +150,6 @@ def flush_session_log(
     has_thinking_only_turn: bool = False,
     versions: dict[str, Any] | None = None,
     model_identifier: str = "",
-    recipe_name: str = "",
-    recipe_content_hash: str = "",
-    recipe_composite_hash: str = "",
-    recipe_version: str = "",
     max_sessions: int | None = None,
     telemetry: SessionTelemetry,
 ) -> None:
@@ -334,8 +331,8 @@ def flush_session_log(
         "peak_fd_ratio": round(peak_fd_ratio, 3),
         "termination_reason": termination_reason,
         "kill_reason": kill_reason,
-        "provider_used": provider_used,
-        "provider_fallback": provider_fallback,
+        "provider_used": provider_outcome.provider_used,
+        "provider_fallback": provider_outcome.fallback_activated,
         "write_path_warnings": effective_write_path_warnings,
         "write_call_count": write_call_count,
         "clone_contamination_reverted": clone_contamination_reverted,
@@ -358,13 +355,13 @@ def flush_session_log(
             **versions,
             "model_identifier": effective_model_id,
         }
-    if recipe_name or recipe_content_hash:
+    if recipe_identity.name or recipe_identity.content_hash:
         summary["recipe_provenance"] = {
             "schema_version": 1,
-            "recipe_name": recipe_name,
-            "recipe_version": recipe_version,
-            "content_hash": recipe_content_hash,
-            "composite_hash": recipe_composite_hash,
+            "recipe_name": recipe_identity.name,
+            "recipe_version": recipe_identity.version,
+            "content_hash": recipe_identity.content_hash,
+            "composite_hash": recipe_identity.composite_hash,
         }
     summary_path = session_dir / "summary.json"
     atomic_write(summary_path, json.dumps(summary, sort_keys=True, indent=2) + "\n")
@@ -397,7 +394,7 @@ def flush_session_log(
             "loc_deletions": loc_deletions,
             "peak_context": token_usage.get("peak_context", 0),
             "turn_count": token_usage.get("turn_count", 0),
-            "provider_used": provider_used,
+            "provider_used": provider_outcome.provider_used,
         }
         atomic_write(session_dir / "token_usage.json", json.dumps(tu_data))
 
@@ -450,14 +447,14 @@ def flush_session_log(
         "tracked_comm_drift": _tracked_comm_drift,
         "autoskillit_version": versions.get("autoskillit_version", "") if versions else "",
         "claude_code_version": versions.get("claude_code_version", "") if versions else "",
-        "recipe_name": recipe_name,
-        "recipe_content_hash": recipe_content_hash,
-        "recipe_composite_hash": recipe_composite_hash,
-        "recipe_version": recipe_version,
+        "recipe_name": recipe_identity.name,
+        "recipe_content_hash": recipe_identity.content_hash,
+        "recipe_composite_hash": recipe_identity.composite_hash,
+        "recipe_version": recipe_identity.version,
         "duration_seconds": duration_seconds,
         "github_api_requests": github_api_requests,
-        "provider_used": provider_used,
-        "provider_fallback": provider_fallback,
+        "provider_used": provider_outcome.provider_used,
+        "provider_fallback": provider_outcome.fallback_activated,
     }
     index_path = log_root / "sessions.jsonl"
     with index_path.open("a") as f:
@@ -627,7 +624,7 @@ def recover_crashed_sessions(tmpfs_path: str = "/dev/shm", log_dir: str = "") ->
             continue
 
         try:
-            from autoskillit.core import SessionTelemetry
+            from autoskillit.core import ProviderOutcome, RecipeIdentity, SessionTelemetry
 
             flush_session_log(
                 log_dir=log_dir,
@@ -641,6 +638,8 @@ def recover_crashed_sessions(tmpfs_path: str = "/dev/shm", log_dir: str = "") ->
                 start_ts=mtime_ts,
                 proc_snapshots=snapshots if snapshots else None,
                 termination_reason="CRASHED",
+                provider_outcome=ProviderOutcome.none_used(),
+                recipe_identity=RecipeIdentity.empty(),
                 telemetry=SessionTelemetry.empty(),
             )
         except Exception:

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -19,8 +19,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from autoskillit.core import SessionTelemetry
-    from autoskillit.core.types._type_results import ProviderOutcome, RecipeIdentity
+    from autoskillit.core import ProviderOutcome, RecipeIdentity, SessionTelemetry
 
 import psutil
 

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -357,8 +357,8 @@ def flush_session_log(
     if recipe_identity.name or recipe_identity.content_hash:
         summary["recipe_provenance"] = {
             "schema_version": 1,
-            "recipe_name": recipe_identity.name,
-            "recipe_version": recipe_identity.version,
+            "name": recipe_identity.name,
+            "version": recipe_identity.version,
             "content_hash": recipe_identity.content_hash,
             "composite_hash": recipe_identity.composite_hash,
         }

--- a/src/autoskillit/execution/session_log.py
+++ b/src/autoskillit/execution/session_log.py
@@ -642,7 +642,9 @@ def recover_crashed_sessions(tmpfs_path: str = "/dev/shm", log_dir: str = "") ->
                 telemetry=SessionTelemetry.empty(),
             )
         except Exception:
-            logger.debug("recover_crashed_sessions: failed to finalize %s", trace_file)
+            logger.debug(
+                "recover_crashed_sessions: failed to finalize %s", trace_file, exc_info=True
+            )
             continue
 
         trace_file.unlink(missing_ok=True)

--- a/tests/arch/test_execution_source_split.py
+++ b/tests/arch/test_execution_source_split.py
@@ -14,7 +14,7 @@ NEW_HEADLESS_MODULES = [
     "_headless_result.py",
 ]
 HEADLESS_SIZE_BUDGETS = {
-    "headless/__init__.py": 840,
+    "headless/__init__.py": 860,
     "headless/_headless_recovery.py": 320,
     "headless/_headless_path_tokens.py": 175,
     "headless/_headless_result.py": 616,

--- a/tests/core/CLAUDE.md
+++ b/tests/core/CLAUDE.md
@@ -23,6 +23,7 @@ Core layer (IL-0) unit tests — paths, IO, types, feature flags.
 | `test_paths.py` | Tests for autoskillit.core.paths — is_git_worktree and pkg_root |
 | `test_resolve_temp_dir.py` | Tests for autoskillit.core.io.resolve_temp_dir |
 | `test_session_checkpoint.py` | Tests for SessionCheckpoint schema validation and compute_remaining |
+| `test_session_index_schema.py` | Tests for SessionIndexEntry TypedDict field completeness |
 | `test_session_liveness.py` | Tests for is_session_alive generalized liveness triple-check |
 | `test_session_registry.py` | Tests for core/session_registry.py |
 | `test_session_type.py` | Tests for SessionType resolver and constants |

--- a/tests/core/test_session_index_schema.py
+++ b/tests/core/test_session_index_schema.py
@@ -6,16 +6,22 @@ import pytest
 
 pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
 
+_REQUIRED_INDEX_FIELDS = {
+    "provider_used",
+    "provider_fallback",
+    "recipe_name",
+    "recipe_content_hash",
+    "recipe_composite_hash",
+    "recipe_version",
+}
+
 
 class TestSessionIndexEntryCompleteness:
     """SessionIndexEntry TypedDict must declare every field written to sessions.jsonl."""
 
-    def test_provider_used_declared(self):
+    def test_required_fields_declared(self):
         from autoskillit.core.types._type_results import SessionIndexEntry
 
-        assert "provider_used" in SessionIndexEntry.__annotations__
-
-    def test_provider_fallback_declared(self):
-        from autoskillit.core.types._type_results import SessionIndexEntry
-
-        assert "provider_fallback" in SessionIndexEntry.__annotations__
+        declared = set(SessionIndexEntry.__annotations__)
+        missing = _REQUIRED_INDEX_FIELDS - declared
+        assert not missing, f"SessionIndexEntry missing fields: {missing}"

--- a/tests/core/test_session_index_schema.py
+++ b/tests/core/test_session_index_schema.py
@@ -1,0 +1,21 @@
+"""Tests verifying SessionIndexEntry TypedDict matches the actual JSONL output."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.layer("core"), pytest.mark.small]
+
+
+class TestSessionIndexEntryCompleteness:
+    """SessionIndexEntry TypedDict must declare every field written to sessions.jsonl."""
+
+    def test_provider_used_declared(self):
+        from autoskillit.core.types._type_results import SessionIndexEntry
+
+        assert "provider_used" in SessionIndexEntry.__annotations__
+
+    def test_provider_fallback_declared(self):
+        from autoskillit.core.types._type_results import SessionIndexEntry
+
+        assert "provider_fallback" in SessionIndexEntry.__annotations__

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -474,10 +474,11 @@ class TestSkillResultProviderFields:
         assert data["provider_used"] == "anthropic-vertex"
         assert data["provider_fallback"] is True
 
-    def test_to_json_omits_provider_used_when_empty(self):
+    def test_to_json_includes_provider_used_as_empty_string_when_unset(self):
         sr = SkillResult(**self._BASE_KWARGS)
         data = json.loads(sr.to_json())
-        assert "provider_used" not in data
+        assert "provider_used" in data
+        assert data["provider_used"] == ""
 
     def test_to_json_includes_provider_fallback_when_true(self):
         sr = SkillResult(**self._BASE_KWARGS, provider_fallback=True)

--- a/tests/execution/CLAUDE.md
+++ b/tests/execution/CLAUDE.md
@@ -18,6 +18,8 @@ Subprocess integration, headless session, process lifecycle, and session result 
 | `test_diff_annotator.py` | Behavioral tests for execution/diff_annotator.py |
 | `test_exit_classification.py` | Unit tests for classify_infra_exit and InfraExitCategory enum |
 | `test_flag_contracts.py` | Contract tests for Claude CLI flags |
+| `test_flush_completeness_guard.py` | Structural guard: every required-container field must appear in flush output |
+| `test_flush_provider_integration.py` | Integration seam tests: provider fields forwarded from _execute_claude_headless to flush_session_log |
 | `test_github.py` | L1 unit tests for execution/github.py |
 | `test_github_api_tracking_http.py` | GitHub API tracking HTTP tests |
 | `test_github_headers.py` | Tests for the shared github_headers helper and its adoption by all three classes |
@@ -55,6 +57,7 @@ Subprocess integration, headless session, process lifecycle, and session result 
 | `test_process_run.py` | Integration tests for normal subprocess run, stdin, timeout, temp I/O, and logging |
 | `test_process_session_log_monitor.py` | Unit tests for _session_log_monitor and related session log monitoring behavior |
 | `test_process_submodules.py` | Tests verifying process.py decomposition into focused sub-modules (P8-2) |
+| `test_provider_outcome_container.py` | Tests for ProviderOutcome typed container construction — required fields and TypeError on omission |
 | `test_push_trigger_applies.py` | Unit tests for _push_trigger_applies_to_branch and _has_merge_group_trigger |
 | `test_quota_binding.py` | Tests for execution/quota.py — multi-window selection, per-window thresholds, cache refresh |
 | `test_quota_http.py` | End-to-end HTTP tests for quota guard using api-simulator mock_http_server |

--- a/tests/execution/conftest.py
+++ b/tests/execution/conftest.py
@@ -169,7 +169,11 @@ def _snap(
 
 
 def _flush(tmp_path: Path, **overrides) -> None:
-    from autoskillit.core.types._type_results import SessionTelemetry
+    from autoskillit.core.types._type_results import (
+        ProviderOutcome,
+        RecipeIdentity,
+        SessionTelemetry,
+    )
     from autoskillit.execution.session_log import flush_session_log
 
     defaults: dict = {
@@ -206,7 +210,30 @@ def _flush(tmp_path: Path, **overrides) -> None:
         loc_insertions=defaults.pop("loc_insertions"),
         loc_deletions=defaults.pop("loc_deletions"),
     )
-    flush_session_log(**defaults, telemetry=telemetry)
+
+    # Extract provider/recipe kwargs and build typed containers
+    _provider_used = defaults.pop("provider_used", "")
+    _provider_fallback = defaults.pop("provider_fallback", False)
+    _recipe_name = defaults.pop("recipe_name", "")
+    _recipe_content_hash = defaults.pop("recipe_content_hash", "")
+    _recipe_composite_hash = defaults.pop("recipe_composite_hash", "")
+    _recipe_version = defaults.pop("recipe_version", "")
+    provider_outcome = ProviderOutcome(
+        provider_used=_provider_used,
+        fallback_activated=_provider_fallback,
+    )
+    recipe_identity = RecipeIdentity(
+        name=_recipe_name,
+        content_hash=_recipe_content_hash,
+        composite_hash=_recipe_composite_hash,
+        version=_recipe_version,
+    )
+    flush_session_log(
+        **defaults,
+        telemetry=telemetry,
+        provider_outcome=provider_outcome,
+        recipe_identity=recipe_identity,
+    )
 
 
 @pytest.fixture

--- a/tests/execution/test_flush_completeness_guard.py
+++ b/tests/execution/test_flush_completeness_guard.py
@@ -1,0 +1,117 @@
+"""Structural guards preventing regression to bare-kwarg provider/recipe omission."""
+
+from __future__ import annotations
+
+import inspect
+import json
+
+import pytest
+
+from autoskillit.core.types._type_results import ProviderOutcome, RecipeIdentity
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+
+class TestFlushSignatureGuard:
+    """flush_session_log must not accept bare provider or recipe string kwargs."""
+
+    def test_no_bare_provider_used_kwarg(self):
+        from autoskillit.execution.session_log import flush_session_log
+
+        sig = inspect.signature(flush_session_log)
+        assert "provider_used" not in sig.parameters
+
+    def test_no_bare_provider_fallback_kwarg(self):
+        from autoskillit.execution.session_log import flush_session_log
+
+        sig = inspect.signature(flush_session_log)
+        assert "provider_fallback" not in sig.parameters
+
+    def test_no_bare_recipe_name_kwarg(self):
+        from autoskillit.execution.session_log import flush_session_log
+
+        sig = inspect.signature(flush_session_log)
+        assert "recipe_name" not in sig.parameters
+
+    def test_no_bare_recipe_content_hash_kwarg(self):
+        from autoskillit.execution.session_log import flush_session_log
+
+        sig = inspect.signature(flush_session_log)
+        assert "recipe_content_hash" not in sig.parameters
+
+    def test_provider_outcome_is_required_parameter(self):
+        from autoskillit.execution.session_log import flush_session_log
+
+        sig = inspect.signature(flush_session_log)
+        assert "provider_outcome" in sig.parameters
+        param = sig.parameters["provider_outcome"]
+        assert param.default is inspect.Parameter.empty
+
+    def test_recipe_identity_is_required_parameter(self):
+        from autoskillit.execution.session_log import flush_session_log
+
+        sig = inspect.signature(flush_session_log)
+        assert "recipe_identity" in sig.parameters
+        param = sig.parameters["recipe_identity"]
+        assert param.default is inspect.Parameter.empty
+
+
+class TestFlushOutputCompleteness:
+    """Every ProviderOutcome field must appear in flush output."""
+
+    def test_provider_outcome_fields_written_to_summary(self, tmp_path):
+        from autoskillit.core.types._type_results import SessionTelemetry
+        from autoskillit.execution.session_log import flush_session_log
+
+        outcome = ProviderOutcome(provider_used="test-provider", fallback_activated=True)
+        flush_session_log(
+            log_dir=str(tmp_path),
+            cwd="/tmp",
+            session_id="completeness-test-001",
+            pid=1,
+            skill_command="/test",
+            success=True,
+            subtype="completed",
+            exit_code=0,
+            start_ts="2026-05-05T00:00:00+00:00",
+            proc_snapshots=None,
+            provider_outcome=outcome,
+            recipe_identity=RecipeIdentity.empty(),
+            telemetry=SessionTelemetry.empty(),
+        )
+        summary_path = tmp_path / "sessions" / "completeness-test-001" / "summary.json"
+        summary = json.loads(summary_path.read_text())
+        assert summary["provider_used"] == "test-provider"
+        assert summary["provider_fallback"] is True
+
+    def test_recipe_identity_fields_written_to_index(self, tmp_path):
+        from autoskillit.core.types._type_results import SessionTelemetry
+        from autoskillit.execution.session_log import flush_session_log
+
+        identity = RecipeIdentity(
+            name="my-recipe",
+            content_hash="abc123",
+            composite_hash="def456",
+            version="1.0",
+        )
+        flush_session_log(
+            log_dir=str(tmp_path),
+            cwd="/tmp",
+            session_id="recipe-completeness-001",
+            pid=1,
+            skill_command="/test",
+            success=True,
+            subtype="completed",
+            exit_code=0,
+            start_ts="2026-05-05T00:00:00+00:00",
+            proc_snapshots=None,
+            provider_outcome=ProviderOutcome.none_used(),
+            recipe_identity=identity,
+            telemetry=SessionTelemetry.empty(),
+        )
+        index_path = tmp_path / "sessions.jsonl"
+        entry = json.loads(index_path.read_text().strip())
+        assert entry["recipe_name"] == "my-recipe"
+        assert entry["recipe_content_hash"] == "abc123"
+        assert entry["recipe_composite_hash"] == "def456"
+        assert entry["recipe_version"] == "1.0"

--- a/tests/execution/test_flush_provider_integration.py
+++ b/tests/execution/test_flush_provider_integration.py
@@ -202,7 +202,7 @@ class TestProviderFieldsReachFlush:
 
         assert result.subtype == "crashed"
         crashed_calls = [f for f in flush_calls if f.get("termination_reason") == "CRASHED"]
-        assert len(crashed_calls) >= 1
+        assert len(crashed_calls) == 1
         outcome = crashed_calls[0]["provider_outcome"]
         assert outcome.provider_used == "minimax"
 
@@ -243,6 +243,6 @@ class TestProviderFieldsReachFlush:
             )
 
         cancelled_calls = [f for f in flush_calls if f.get("termination_reason") == "CANCELLED"]
-        assert len(cancelled_calls) >= 1
+        assert len(cancelled_calls) == 1
         outcome = cancelled_calls[0]["provider_outcome"]
         assert outcome.provider_used == "openai"

--- a/tests/execution/test_flush_provider_integration.py
+++ b/tests/execution/test_flush_provider_integration.py
@@ -1,4 +1,4 @@
-"""Integration seam tests: provider fields forwarded from _execute_claude_headless to flush_session_log."""
+"""Integration seam tests: provider fields forwarded from _execute_claude_headless to flush."""
 
 from __future__ import annotations
 

--- a/tests/execution/test_flush_provider_integration.py
+++ b/tests/execution/test_flush_provider_integration.py
@@ -1,0 +1,248 @@
+"""Integration seam tests: provider fields forwarded from _execute_claude_headless to flush_session_log."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.core.types import RetryReason, SkillResult
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+
+_SUCCESS_RESULT = SkillResult(
+    success=True,
+    result="done",
+    session_id="s1",
+    subtype="success",
+    is_error=False,
+    exit_code=0,
+    needs_retry=False,
+    retry_reason=RetryReason.NONE,
+    stderr="",
+)
+
+
+def _patch_common(monkeypatch, tmp_path, skill_result, ctx):
+    import autoskillit.execution.session_log as _sl_mod
+    from autoskillit.execution.headless import PostSessionMetrics
+    from tests.execution.conftest import _sr
+
+    _sub_result = _sr()
+
+    async def fake_runner(cmd, **kwargs):  # noqa: ARG001
+        return _sub_result
+
+    monkeypatch.setattr(
+        "autoskillit.execution.headless._build_skill_result",
+        lambda *a, **kw: skill_result,  # noqa: ARG005
+    )
+    monkeypatch.setattr(
+        "autoskillit.execution.headless._compute_post_session_metrics",
+        lambda *a, **kw: PostSessionMetrics(0, 0, str(tmp_path)),  # noqa: ARG005
+    )
+    monkeypatch.setattr(
+        "autoskillit.execution.headless._capture_git_head_sha",
+        lambda *a: "",  # noqa: ARG005
+    )
+    monkeypatch.setattr(
+        "autoskillit.execution.headless.collect_version_snapshot",
+        lambda: {},
+    )
+
+    flush_calls: list[dict] = []
+
+    def capture_flush(**kwargs):
+        flush_calls.append(kwargs)
+
+    monkeypatch.setattr(_sl_mod, "flush_session_log", capture_flush)
+    return fake_runner, flush_calls
+
+
+class TestProviderFieldsReachFlush:
+    """Verify provider fields are forwarded from _execute_claude_headless to flush_session_log."""
+
+    @pytest.mark.anyio
+    async def test_normal_path_provider_used_in_flush_kwargs(
+        self, minimal_ctx, tmp_path, monkeypatch
+    ):
+        from autoskillit.execution.commands import ClaudeHeadlessCmd
+        from autoskillit.execution.headless import _execute_claude_headless
+
+        fake_runner, flush_calls = _patch_common(
+            monkeypatch, tmp_path, _SUCCESS_RESULT, minimal_ctx
+        )
+        minimal_ctx.runner = fake_runner  # type: ignore[assignment]
+
+        await _execute_claude_headless(
+            ClaudeHeadlessCmd(cmd=["echo", "test"], env={}),
+            str(tmp_path),
+            minimal_ctx,
+            timeout=30.0,
+            stale_threshold=5.0,
+            provider_name="minimax",
+            step_name="implement",
+        )
+
+        assert len(flush_calls) == 1
+        outcome = flush_calls[0]["provider_outcome"]
+        assert outcome.provider_used == "minimax"
+        assert outcome.fallback_activated is False
+
+    @pytest.mark.anyio
+    async def test_normal_path_provider_fallback_in_flush_kwargs(
+        self, minimal_ctx, tmp_path, monkeypatch
+    ):
+        from autoskillit.core.types import RetryReason, SkillResult
+        from autoskillit.execution.commands import ClaudeHeadlessCmd
+        from autoskillit.execution.headless import _execute_claude_headless
+
+        stale = SkillResult(
+            success=False,
+            result="",
+            session_id="s0",
+            subtype="stale",
+            is_error=False,
+            exit_code=1,
+            needs_retry=True,
+            retry_reason=RetryReason.STALE,
+            stderr="",
+        )
+        results = [stale, _SUCCESS_RESULT]
+        call_count = [0]
+
+        import autoskillit.execution.session_log as _sl_mod
+        from autoskillit.execution.headless import PostSessionMetrics
+        from tests.execution.conftest import _sr
+
+        _sub_result = _sr()
+
+        async def fake_runner(cmd, **kwargs):  # noqa: ARG001
+            return _sub_result
+
+        def build_result(*a, **kw):  # noqa: ARG001
+            r = results[min(call_count[0], len(results) - 1)]
+            call_count[0] += 1
+            return r
+
+        monkeypatch.setattr("autoskillit.execution.headless._build_skill_result", build_result)
+        monkeypatch.setattr(
+            "autoskillit.execution.headless._compute_post_session_metrics",
+            lambda *a, **kw: PostSessionMetrics(0, 0, str(tmp_path)),  # noqa: ARG005
+        )
+        monkeypatch.setattr(
+            "autoskillit.execution.headless._capture_git_head_sha",
+            lambda *a: "",  # noqa: ARG005
+        )
+        monkeypatch.setattr(
+            "autoskillit.execution.headless.collect_version_snapshot",
+            lambda: {},
+        )
+        monkeypatch.setattr(minimal_ctx.config.providers, "provider_retry_limit", 2)
+        monkeypatch.setattr(
+            "autoskillit.execution.headless.is_feature_enabled",
+            lambda name, *a, **kw: name == "providers",  # noqa: ARG005
+        )
+
+        flush_calls: list[dict] = []
+        monkeypatch.setattr(_sl_mod, "flush_session_log", lambda **kw: flush_calls.append(kw))
+
+        minimal_ctx.runner = fake_runner  # type: ignore[assignment]
+
+        result = await _execute_claude_headless(
+            ClaudeHeadlessCmd(cmd=["echo", "test"], env={}),
+            str(tmp_path),
+            minimal_ctx,
+            timeout=30.0,
+            stale_threshold=5.0,
+            provider_name="minimax",
+            provider_fallback_env={"ANTHROPIC_API_KEY": "sk-test"},
+            provider_fallback_name="anthropic",
+            step_name="implement",
+        )
+
+        assert result.provider_fallback is True
+        assert result.provider_used == "anthropic"
+        assert len(flush_calls) == 1
+        outcome = flush_calls[0]["provider_outcome"]
+        assert outcome.provider_used == "anthropic"
+        assert outcome.fallback_activated is True
+
+    @pytest.mark.anyio
+    async def test_crash_path_provider_used_in_flush_kwargs(
+        self, minimal_ctx, tmp_path, monkeypatch
+    ):
+        from autoskillit.execution.commands import ClaudeHeadlessCmd
+        from autoskillit.execution.headless import _execute_claude_headless
+
+        monkeypatch.setattr(
+            "autoskillit.execution.headless.collect_version_snapshot",
+            lambda: {},
+        )
+
+        flush_calls: list[dict] = []
+
+        def capture_flush(**kwargs):
+            flush_calls.append(kwargs)
+
+        monkeypatch.setattr("autoskillit.execution.flush_session_log", capture_flush)
+
+        async def raising_runner(cmd, **kwargs):  # noqa: ARG001
+            raise RuntimeError("disk crash")
+
+        minimal_ctx.runner = raising_runner  # type: ignore[assignment]
+
+        result = await _execute_claude_headless(
+            ClaudeHeadlessCmd(cmd=["echo", "test"], env={}),
+            str(tmp_path),
+            minimal_ctx,
+            timeout=30.0,
+            stale_threshold=5.0,
+            provider_name="minimax",
+        )
+
+        assert result.subtype == "crashed"
+        crashed_calls = [f for f in flush_calls if f.get("termination_reason") == "CRASHED"]
+        assert len(crashed_calls) >= 1
+        outcome = crashed_calls[0]["provider_outcome"]
+        assert outcome.provider_used == "minimax"
+
+    @pytest.mark.anyio
+    async def test_cancel_path_provider_used_in_flush_kwargs(
+        self, minimal_ctx, tmp_path, monkeypatch
+    ):
+        import anyio
+
+        from autoskillit.execution.commands import ClaudeHeadlessCmd
+        from autoskillit.execution.headless import _execute_claude_headless
+
+        monkeypatch.setattr(
+            "autoskillit.execution.headless.collect_version_snapshot",
+            lambda: {},
+        )
+
+        flush_calls: list[dict] = []
+
+        def capture_flush(**kwargs):
+            flush_calls.append(kwargs)
+
+        monkeypatch.setattr("autoskillit.execution.flush_session_log", capture_flush)
+
+        async def cancelling_runner(cmd, **kwargs):  # noqa: ARG001
+            raise anyio.get_cancelled_exc_class()()
+
+        minimal_ctx.runner = cancelling_runner  # type: ignore[assignment]
+
+        with pytest.raises(BaseException):
+            await _execute_claude_headless(
+                ClaudeHeadlessCmd(cmd=["echo", "test"], env={}),
+                str(tmp_path),
+                minimal_ctx,
+                timeout=30.0,
+                stale_threshold=5.0,
+                provider_name="openai",
+            )
+
+        cancelled_calls = [f for f in flush_calls if f.get("termination_reason") == "CANCELLED"]
+        assert len(cancelled_calls) >= 1
+        outcome = cancelled_calls[0]["provider_outcome"]
+        assert outcome.provider_used == "openai"

--- a/tests/execution/test_flush_provider_integration.py
+++ b/tests/execution/test_flush_provider_integration.py
@@ -232,7 +232,7 @@ class TestProviderFieldsReachFlush:
 
         minimal_ctx.runner = cancelling_runner  # type: ignore[assignment]
 
-        with pytest.raises(BaseException):
+        with pytest.raises(anyio.get_cancelled_exc_class()):
             await _execute_claude_headless(
                 ClaudeHeadlessCmd(cmd=["echo", "test"], env={}),
                 str(tmp_path),

--- a/tests/execution/test_headless_core.py
+++ b/tests/execution/test_headless_core.py
@@ -882,6 +882,7 @@ class TestBuildSkillResultCrossValidation:
         "kill_reason",
         "last_stop_reason",
         "lifespan_started",
+        "provider_used",
         "provider_fallback",
         "needs_retry",
         "retry_reason",
@@ -893,6 +894,9 @@ class TestBuildSkillResultCrossValidation:
         "fs_writes_detected",
         "infra_exit_category",
     }
+
+    def test_expected_skill_keys_includes_provider_used(self):
+        assert "provider_used" in self.EXPECTED_SKILL_KEYS
 
     def test_empty_stdout_exit_zero_is_failure(self):
         """Exit 0 with empty stdout is NOT success — output was lost."""

--- a/tests/execution/test_headless_core.py
+++ b/tests/execution/test_headless_core.py
@@ -896,7 +896,12 @@ class TestBuildSkillResultCrossValidation:
     }
 
     def test_expected_skill_keys_includes_provider_used(self):
-        assert "provider_used" in self.EXPECTED_SKILL_KEYS
+        import dataclasses
+
+        from autoskillit.core.types import SkillResult
+
+        skill_result_field_names = {f.name for f in dataclasses.fields(SkillResult)}
+        assert "provider_used" in skill_result_field_names
 
     def test_empty_stdout_exit_zero_is_failure(self):
         """Exit 0 with empty stdout is NOT success — output was lost."""

--- a/tests/execution/test_linux_tracing_pty_integration.py
+++ b/tests/execution/test_linux_tracing_pty_integration.py
@@ -99,7 +99,11 @@ async def test_pty_wrapped_tracing_produces_no_script_snapshots_in_proc_trace_js
     Test 1.10 (partial): after the fix, every row in proc_trace.jsonl self-identifies
     the tracked process, and 'script' must never appear there.
     """
-    from autoskillit.core.types._type_results import SessionTelemetry
+    from autoskillit.core.types._type_results import (
+        ProviderOutcome,
+        RecipeIdentity,
+        SessionTelemetry,
+    )
     from autoskillit.execution.process import run_managed_async
     from autoskillit.execution.session_log import flush_session_log
 
@@ -128,6 +132,8 @@ async def test_pty_wrapped_tracing_produces_no_script_snapshots_in_proc_trace_js
         start_ts=result.start_ts or "2026-01-01T00:00:00+00:00",
         proc_snapshots=result.proc_snapshots,
         telemetry=SessionTelemetry.empty(),
+        provider_outcome=ProviderOutcome.none_used(),
+        recipe_identity=RecipeIdentity.empty(),
     )
 
     trace_path = tmp_path / "logs" / "sessions" / "pty-trace-test-001" / "proc_trace.jsonl"

--- a/tests/execution/test_provider_outcome_container.py
+++ b/tests/execution/test_provider_outcome_container.py
@@ -31,6 +31,8 @@ class TestProviderOutcomeConstruction:
         assert outcome.fallback_activated is False
 
     def test_frozen_rejects_mutation(self):
+        import dataclasses
+
         outcome = ProviderOutcome(provider_used="minimax", fallback_activated=False)
-        with pytest.raises(TypeError):
+        with pytest.raises(dataclasses.FrozenInstanceError):
             outcome.provider_used = "other"  # type: ignore[misc]

--- a/tests/execution/test_provider_outcome_container.py
+++ b/tests/execution/test_provider_outcome_container.py
@@ -1,0 +1,36 @@
+"""Tests for ProviderOutcome typed container construction contract."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.core.types._type_results import ProviderOutcome
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+
+class TestProviderOutcomeConstruction:
+    """ProviderOutcome must require all fields — no silent defaults."""
+
+    def test_missing_provider_used_raises_type_error(self):
+        with pytest.raises(TypeError):
+            ProviderOutcome(fallback_activated=False)  # type: ignore[call-arg]
+
+    def test_missing_fallback_activated_raises_type_error(self):
+        with pytest.raises(TypeError):
+            ProviderOutcome(provider_used="minimax")  # type: ignore[call-arg]
+
+    def test_complete_construction_succeeds(self):
+        outcome = ProviderOutcome(provider_used="minimax", fallback_activated=False)
+        assert outcome.provider_used == "minimax"
+        assert outcome.fallback_activated is False
+
+    def test_none_used_sentinel(self):
+        outcome = ProviderOutcome.none_used()
+        assert outcome.provider_used == ""
+        assert outcome.fallback_activated is False
+
+    def test_frozen_rejects_mutation(self):
+        outcome = ProviderOutcome(provider_used="minimax", fallback_activated=False)
+        with pytest.raises((AttributeError, TypeError)):
+            outcome.provider_used = "other"  # type: ignore[misc]

--- a/tests/execution/test_provider_outcome_container.py
+++ b/tests/execution/test_provider_outcome_container.py
@@ -32,5 +32,5 @@ class TestProviderOutcomeConstruction:
 
     def test_frozen_rejects_mutation(self):
         outcome = ProviderOutcome(provider_used="minimax", fallback_activated=False)
-        with pytest.raises((AttributeError, TypeError)):
+        with pytest.raises(TypeError):
             outcome.provider_used = "other"  # type: ignore[misc]

--- a/tests/execution/test_session_log_fields.py
+++ b/tests/execution/test_session_log_fields.py
@@ -597,10 +597,10 @@ def test_summary_includes_recipe_provenance(tmp_path):
     summary = json.loads((session_dir / "summary.json").read_text())
     assert "recipe_provenance" in summary
     assert summary["recipe_provenance"]["schema_version"] == 1
-    assert summary["recipe_provenance"]["recipe_name"] == "impl"
+    assert summary["recipe_provenance"]["name"] == "impl"
     assert summary["recipe_provenance"]["content_hash"] == "sha256:abc"
     assert summary["recipe_provenance"]["composite_hash"] == "sha256:def"
-    assert summary["recipe_provenance"]["recipe_version"] == "1.0.0"
+    assert summary["recipe_provenance"]["version"] == "1.0.0"
 
 
 def test_session_log_empty_recipe_identity(tmp_path):

--- a/tests/execution/test_session_log_fields.py
+++ b/tests/execution/test_session_log_fields.py
@@ -10,7 +10,7 @@ from datetime import UTC, datetime
 
 import pytest
 
-from autoskillit.core.types._type_results import SessionTelemetry
+from autoskillit.core.types._type_results import ProviderOutcome, RecipeIdentity, SessionTelemetry
 from autoskillit.execution.session_log import (
     flush_session_log,
 )
@@ -87,6 +87,8 @@ def test_flush_session_log_writes_kitchen_id(tmp_path):
         start_ts="2026-03-27T08:00:00",
         proc_snapshots=None,
         telemetry=SessionTelemetry.empty(),
+        provider_outcome=ProviderOutcome.none_used(),
+        recipe_identity=RecipeIdentity.empty(),
     )
 
     index = (tmp_path / "sessions.jsonl").read_text()
@@ -110,6 +112,8 @@ def test_flush_session_log_writes_order_id_to_index(tmp_path):
         start_ts="2026-03-27T08:00:00",
         proc_snapshots=None,
         telemetry=SessionTelemetry.empty(),
+        provider_outcome=ProviderOutcome.none_used(),
+        recipe_identity=RecipeIdentity.empty(),
     )
 
     entry = json.loads((tmp_path / "sessions.jsonl").read_text().strip())
@@ -131,6 +135,8 @@ def test_flush_session_log_order_id_defaults_to_empty(tmp_path):
         start_ts="2026-03-27T08:00:00",
         proc_snapshots=None,
         telemetry=SessionTelemetry.empty(),
+        provider_outcome=ProviderOutcome.none_used(),
+        recipe_identity=RecipeIdentity.empty(),
     )
 
     entry = json.loads((tmp_path / "sessions.jsonl").read_text().strip())
@@ -154,6 +160,8 @@ def test_flush_writes_crash_exception_file(tmp_path):
         termination_reason="CRASHED",
         exception_text="RuntimeError: boom\n  at headless.py:1023",
         telemetry=SessionTelemetry.empty(),
+        provider_outcome=ProviderOutcome.none_used(),
+        recipe_identity=RecipeIdentity.empty(),
     )
     session_dir = tmp_path / "sessions" / "test-session"
     crash_file = session_dir / "crash_exception.txt"
@@ -181,6 +189,8 @@ def test_flush_session_log_writes_raw_stdout_on_failure(tmp_path):
         proc_snapshots=None,
         raw_stdout=raw,
         telemetry=SessionTelemetry.empty(),
+        provider_outcome=ProviderOutcome.none_used(),
+        recipe_identity=RecipeIdentity.empty(),
     )
     raw_file = tmp_path / "sessions" / "test-session" / "raw_stdout.jsonl"
     assert raw_file.exists()
@@ -201,6 +211,8 @@ def test_flush_session_log_no_raw_stdout_on_success(tmp_path):
         proc_snapshots=None,
         raw_stdout='{"type": "result"}',
         telemetry=SessionTelemetry.empty(),
+        provider_outcome=ProviderOutcome.none_used(),
+        recipe_identity=RecipeIdentity.empty(),
     )
     raw_file = tmp_path / "sessions" / "ok-session" / "raw_stdout.jsonl"
     assert not raw_file.exists()
@@ -235,6 +247,8 @@ def test_flush_session_log_summary_contains_per_turn_fields(tmp_path, monkeypatc
         proc_snapshots=None,
         last_stop_reason="end_turn",
         telemetry=SessionTelemetry.empty(),
+        provider_outcome=ProviderOutcome.none_used(),
+        recipe_identity=RecipeIdentity.empty(),
     )
     summary = json.loads((tmp_path / "sessions" / "s" / "summary.json").read_text())
     assert summary["last_stop_reason"] == "end_turn"
@@ -278,6 +292,8 @@ def test_flush_session_log_summary_contains_turn_tool_calls(tmp_path, monkeypatc
         start_ts="2026-04-15T07:00:00Z",
         proc_snapshots=None,
         telemetry=SessionTelemetry.empty(),
+        provider_outcome=ProviderOutcome.none_used(),
+        recipe_identity=RecipeIdentity.empty(),
     )
     summary = json.loads((tmp_path / "sessions" / "s" / "summary.json").read_text())
     assert summary["turn_tool_calls"] == [["ToolA", "ToolB"]]
@@ -311,6 +327,8 @@ def test_turn_tool_calls_capped_at_8_per_turn(tmp_path, monkeypatch):
         start_ts="2026-04-15T07:00:00Z",
         proc_snapshots=None,
         telemetry=SessionTelemetry.empty(),
+        provider_outcome=ProviderOutcome.none_used(),
+        recipe_identity=RecipeIdentity.empty(),
     )
     summary = json.loads((tmp_path / "sessions" / "s" / "summary.json").read_text())
     assert len(summary["turn_tool_calls"][0]) == 8
@@ -344,6 +362,8 @@ def test_turn_tool_calls_empty_for_text_only_turn(tmp_path, monkeypatch):
         start_ts="2026-04-15T07:00:00Z",
         proc_snapshots=None,
         telemetry=SessionTelemetry.empty(),
+        provider_outcome=ProviderOutcome.none_used(),
+        recipe_identity=RecipeIdentity.empty(),
     )
     summary = json.loads((tmp_path / "sessions" / "s" / "summary.json").read_text())
     assert summary["turn_tool_calls"] == [[]]
@@ -377,6 +397,8 @@ def test_turn_tool_calls_parallel_to_request_ids(tmp_path, monkeypatch):
         start_ts="2026-04-15T07:00:00Z",
         proc_snapshots=None,
         telemetry=SessionTelemetry.empty(),
+        provider_outcome=ProviderOutcome.none_used(),
+        recipe_identity=RecipeIdentity.empty(),
     )
     summary = json.loads((tmp_path / "sessions" / "s" / "summary.json").read_text())
     assert len(summary["turn_tool_calls"]) == len(summary["request_ids"]) == 3
@@ -724,6 +746,8 @@ def test_turn_tool_calls_merged_across_thinking_and_tool_records(tmp_path, monke
         start_ts="2026-05-04T00:00:00Z",
         proc_snapshots=None,
         telemetry=SessionTelemetry.empty(),
+        provider_outcome=ProviderOutcome.none_used(),
+        recipe_identity=RecipeIdentity.empty(),
     )
     summary = json.loads((tmp_path / "sessions" / "s" / "summary.json").read_text())
     assert summary["turn_tool_calls"] == [["Bash"]]
@@ -760,6 +784,8 @@ def test_parallel_lists_aligned_when_timestamp_missing(tmp_path, monkeypatch):
         start_ts="2026-05-04T00:00:00Z",
         proc_snapshots=None,
         telemetry=SessionTelemetry.empty(),
+        provider_outcome=ProviderOutcome.none_used(),
+        recipe_identity=RecipeIdentity.empty(),
     )
     summary = json.loads((tmp_path / "sessions" / "s" / "summary.json").read_text())
     assert (

--- a/tests/execution/test_session_log_flush.py
+++ b/tests/execution/test_session_log_flush.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import pytest
 
-from autoskillit.core.types._type_results import SessionTelemetry
+from autoskillit.core.types._type_results import ProviderOutcome, RecipeIdentity, SessionTelemetry
 from autoskillit.execution.session_log import (
     flush_session_log,
     read_telemetry_clear_marker,
@@ -334,6 +334,8 @@ def test_flush_session_log_backward_clock_produces_non_negative_duration(tmp_pat
         termination_reason="completed",
         snapshot_interval_seconds=5.0,
         telemetry=SessionTelemetry.empty(),
+        provider_outcome=ProviderOutcome.none_used(),
+        recipe_identity=RecipeIdentity.empty(),
     )
     session_dir = tmp_path / "sessions" / "backward-clock-test"
     summary = json.loads((session_dir / "summary.json").read_text())
@@ -362,6 +364,8 @@ def test_flush_session_log_uses_elapsed_seconds_over_iso_subtraction(tmp_path):
         termination_reason="completed",
         snapshot_interval_seconds=5.0,
         telemetry=SessionTelemetry.empty(),
+        provider_outcome=ProviderOutcome.none_used(),
+        recipe_identity=RecipeIdentity.empty(),
     )
     session_dir = tmp_path / "sessions" / "elapsed-seconds-test"
     summary = json.loads((session_dir / "summary.json").read_text())
@@ -393,6 +397,8 @@ def test_flush_session_log_zero_elapsed_seconds_is_valid(tmp_path):
         termination_reason="completed",
         snapshot_interval_seconds=5.0,
         telemetry=SessionTelemetry.empty(),
+        provider_outcome=ProviderOutcome.none_used(),
+        recipe_identity=RecipeIdentity.empty(),
     )
     session_dir = tmp_path / "sessions" / "zero-elapsed-test"
     summary = json.loads((session_dir / "summary.json").read_text())

--- a/tests/execution/test_session_log_integration.py
+++ b/tests/execution/test_session_log_integration.py
@@ -11,7 +11,7 @@ from datetime import UTC, datetime, timedelta
 import anyio
 import pytest
 
-from autoskillit.core.types._type_results import SessionTelemetry
+from autoskillit.core.types._type_results import ProviderOutcome, RecipeIdentity, SessionTelemetry
 from tests.execution.conftest import _ALLOCATE_60MB_SCRIPT
 
 pytestmark = [
@@ -60,6 +60,8 @@ async def test_full_tracing_pipeline_writes_distinct_timestamps(tmp_path):
         snapshot_interval_seconds=0.05,
         proc_snapshots=snap_dicts,
         telemetry=SessionTelemetry.empty(),
+        provider_outcome=ProviderOutcome.none_used(),
+        recipe_identity=RecipeIdentity.empty(),
     )
 
     session_dir = tmp_path / "sessions" / "integration-test-001"
@@ -115,6 +117,8 @@ def _flush_with_snaps(tmp_path, session_id: str, snaps: list[dict]) -> None:
         start_ts="2026-01-01T00:00:00+00:00",
         proc_snapshots=snaps,
         telemetry=SessionTelemetry.empty(),
+        provider_outcome=ProviderOutcome.none_used(),
+        recipe_identity=RecipeIdentity.empty(),
     )
 
 
@@ -194,6 +198,8 @@ async def test_peak_rss_kb_above_sanity_floor(tmp_path):
         start_ts=result.start_ts or "2026-01-01T00:00:00+00:00",
         proc_snapshots=result.proc_snapshots,
         telemetry=SessionTelemetry.empty(),
+        provider_outcome=ProviderOutcome.none_used(),
+        recipe_identity=RecipeIdentity.empty(),
     )
 
     summary_path = tmp_path / "logs" / "sessions" / "sanity-floor-001" / "summary.json"

--- a/tests/execution/test_session_log_retention.py
+++ b/tests/execution/test_session_log_retention.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import pytest
 
-from autoskillit.core.types._type_results import SessionTelemetry
+from autoskillit.core.types._type_results import ProviderOutcome, RecipeIdentity, SessionTelemetry
 from autoskillit.execution.linux_tracing import read_boot_id, read_starttime_ticks
 from autoskillit.execution.session_log import (
     flush_session_log,
@@ -481,6 +481,8 @@ def test_retention_protects_active_campaign_sessions(tmp_path, monkeypatch):
         start_ts="2026-04-20T10:00:00+00:00",
         proc_snapshots=None,
         telemetry=SessionTelemetry.empty(),
+        provider_outcome=ProviderOutcome.none_used(),
+        recipe_identity=RecipeIdentity.empty(),
     )
 
     # Protected sessions survive — campaign meta.json writes update their mtime so they
@@ -549,6 +551,8 @@ def test_retention_deletes_released_campaign_sessions(tmp_path, monkeypatch):
         start_ts="2026-04-20T10:00:00+00:00",
         proc_snapshots=None,
         telemetry=SessionTelemetry.empty(),
+        provider_outcome=ProviderOutcome.none_used(),
+        recipe_identity=RecipeIdentity.empty(),
     )
 
     # Released campaign sessions are NOT protected — oldest 2 should be deleted
@@ -604,6 +608,8 @@ def test_retention_preserves_index_for_protected(tmp_path, monkeypatch):
         start_ts="2026-04-20T10:00:00+00:00",
         proc_snapshots=None,
         telemetry=SessionTelemetry.empty(),
+        provider_outcome=ProviderOutcome.none_used(),
+        recipe_identity=RecipeIdentity.empty(),
     )
 
     index_lines = [ln for ln in index_path.read_text().strip().split("\n") if ln.strip()]
@@ -649,6 +655,8 @@ def test_retention_handles_missing_meta_json(tmp_path, monkeypatch):
         start_ts="2026-04-20T10:00:00+00:00",
         proc_snapshots=None,
         telemetry=SessionTelemetry.empty(),
+        provider_outcome=ProviderOutcome.none_used(),
+        recipe_identity=RecipeIdentity.empty(),
     )
 
     # Oldest dirs with no meta.json are deleted normally
@@ -696,6 +704,8 @@ def test_retention_handles_missing_franchise_state_dir(tmp_path, monkeypatch):
         start_ts="2026-04-20T10:00:00+00:00",
         proc_snapshots=None,
         telemetry=SessionTelemetry.empty(),
+        provider_outcome=ProviderOutcome.none_used(),
+        recipe_identity=RecipeIdentity.empty(),
     )
 
     # Normal retention applies — oldest dirs deleted
@@ -742,6 +752,8 @@ def test_retention_handles_corrupt_meta_json(tmp_path, monkeypatch):
         start_ts="2026-04-20T10:00:00+00:00",
         proc_snapshots=None,
         telemetry=SessionTelemetry.empty(),
+        provider_outcome=ProviderOutcome.none_used(),
+        recipe_identity=RecipeIdentity.empty(),
     )
 
     # Corrupt meta.json → not protected → deleted normally
@@ -805,6 +817,8 @@ def test_retention_no_protection_when_callback_is_none(tmp_path: Path, monkeypat
         start_ts="2026-04-20T10:00:00+00:00",
         proc_snapshots=None,
         telemetry=SessionTelemetry.empty(),
+        provider_outcome=ProviderOutcome.none_used(),
+        recipe_identity=RecipeIdentity.empty(),
     )
 
     # No protection applied — oldest sessions deleted even though campaign is active
@@ -842,6 +856,8 @@ def test_flush_session_log_passes_callback_to_enforce_retention(
         start_ts="2026-04-20T10:00:00+00:00",
         proc_snapshots=None,
         telemetry=SessionTelemetry.empty(),
+        provider_outcome=ProviderOutcome.none_used(),
+        recipe_identity=RecipeIdentity.empty(),
     )
 
     assert (tmp_path / "sessions.jsonl").exists()

--- a/tests/execution/test_session_parsing.py
+++ b/tests/execution/test_session_parsing.py
@@ -538,6 +538,7 @@ class TestSkillResult:
             "last_stop_reason",
             "lifespan_started",
             "provider_fallback",
+            "provider_used",
             "needs_retry",
             "retry_reason",
             "order_id",

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -112,11 +112,11 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     ("src/autoskillit/core/io.py", 118),
     # session_log.py — github_api_usage dict, summary dict, meta.json sidecar,
     # token_usage dict, step_timing dict
-    ("src/autoskillit/execution/session_log.py", 308),
+    ("src/autoskillit/execution/session_log.py", 304),
+    ("src/autoskillit/execution/session_log.py", 366),
     ("src/autoskillit/execution/session_log.py", 370),
-    ("src/autoskillit/execution/session_log.py", 374),
-    ("src/autoskillit/execution/session_log.py", 402),
-    ("src/autoskillit/execution/session_log.py", 405),
+    ("src/autoskillit/execution/session_log.py", 398),
+    ("src/autoskillit/execution/session_log.py", 401),
     # migration/store.py — failure store dicts
     ("src/autoskillit/migration/store.py", 54),
     ("src/autoskillit/migration/store.py", 64),

--- a/tests/server/test_server_version_telemetry.py
+++ b/tests/server/test_server_version_telemetry.py
@@ -149,7 +149,11 @@ class TestInitializeClearMarker:
     def test_initialize_uses_clear_marker_as_since_bound(self, tool_ctx, tmp_path, monkeypatch):
         from datetime import UTC, datetime, timedelta
 
-        from autoskillit.core.types._type_results import SessionTelemetry
+        from autoskillit.core.types._type_results import (
+            ProviderOutcome,
+            RecipeIdentity,
+            SessionTelemetry,
+        )
         from autoskillit.execution.session_log import (
             flush_session_log,
         )
@@ -186,6 +190,8 @@ class TestInitializeClearMarker:
                 loc_insertions=0,
                 loc_deletions=0,
             ),
+            provider_outcome=ProviderOutcome.none_used(),
+            recipe_identity=RecipeIdentity.empty(),
         )
 
         # Write a clear marker 3 hours ago (after the session completed)

--- a/tests/server/test_tools_github_api_tracking.py
+++ b/tests/server/test_tools_github_api_tracking.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import pytest
 
-from autoskillit.core.types._type_results import SessionTelemetry
+from autoskillit.core.types._type_results import ProviderOutcome, RecipeIdentity, SessionTelemetry
 from autoskillit.core.types._type_subprocess import SubprocessResult, TerminationReason
 from tests.fakes import MockSubprocessRunner
 
@@ -139,6 +139,8 @@ async def test_flush_session_log_writes_github_api_usage(tmp_path):
             loc_insertions=0,
             loc_deletions=0,
         ),
+        provider_outcome=ProviderOutcome.none_used(),
+        recipe_identity=RecipeIdentity.empty(),
     )
 
     usage_file = tmp_path / "sessions" / "test-session" / "github_api_usage.json"


### PR DESCRIPTION
## Summary

`flush_session_log()` accepts 31 keyword arguments with defaults, creating a structural vulnerability where any caller can silently omit data-carrying fields without triggering a type error. The `provider_used` and `provider_fallback` fields fell through this gap — they were added to the function signature but never wired into the 3 call sites in `_execute_claude_headless()`. The architectural solution is to collapse related defaulted kwargs into frozen dataclass containers (following the proven `SessionTelemetry` pattern) where field omission is a construction-time `TypeError`, making this class of bug impossible.

Closes #1910

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260505-075820-493636/.autoskillit/temp/rectify/rectify_provider_used_never_written_2026-05-05_081500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate | 1 | 28 | 7.5k | 417.5k | 96.6k | 184 | 45.9k | 5m 21s |
| rectify | 1 | 2.4k | 9.7k | 538.5k | 90.8k | 148 | 48.5k | 8m 34s |
| dry_walkthrough | 1 | 803 | 13.1k | 2.0M | 72.8k | 117 | 60.1k | 7m 52s |
| implement | 1 | 924 | 60.1k | 12.4M | 161.9k | 403 | 149.3k | 27m 43s |
| prepare_pr | 1 | 60 | 7.0k | 210.5k | 41.6k | 19 | 29.5k | 2m 3s |
| compose_pr | 1 | 51 | 2.1k | 153.2k | 30.1k | 14 | 17.1k | 57s |
| review_pr | 2 | 3.6k | 61.4k | 1.7M | 97.8k | 142 | 171.3k | 18m 10s |
| resolve_review | 2 | 676 | 43.4k | 5.4M | 121.6k | 207 | 179.3k | 24m 48s |
| **Total** | | 8.6k | 204.3k | 22.8M | 161.9k | | 700.9k | 1h 35m |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 676 | 18397.0 | 220.9 | 88.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 49 | 109526.7 | 3658.3 | 885.3 |
| **Total** | **725** | 31409.6 | 966.7 | 281.8 |