### PR TITLE
Implementation Plan: Fix on_context_limit resume instruction and add skill keyword to run_skill prompt

### DIFF
--- a/src/autoskillit/cli/_prompts.py
+++ b/src/autoskillit/cli/_prompts.py
@@ -506,11 +506,10 @@ CONTEXT LIMIT ROUTING — run_skill only (check BEFORE on_failure):
   - NEVER route retry_reason=resume with subtype=stale to on_context_limit.
   - NOTE: API infrastructure errors (overload, 529, ECONNRESET) also produce retry_reason=resume
     (infra_exit_category="api_error"). Route them identically to context exhaustion.
-  - When routing to on_context_limit, pass "session_id" from the failed result as
-    "resume_session_id" in the next run_skill call to resume the interrupted session
-    instead of starting fresh. The run_skill tool will use --resume <session_id> under the hood.
   - "infra_exit_category" in the result is informational: "completed" | "context_exhausted" |
     "api_error" | "process_killed". Use it for diagnostics only, not for routing.
+  - When routing to on_context_limit, always start a fresh session (do not attempt to
+    resume the exhausted session — it has no remaining context budget).
 - When run_skill returns "needs_retry: true" AND "retry_reason: drain_race":
   - The infrastructure confirmed session completion (Channel A or B) but stdout was not
     fully flushed before the process was killed. Partial progress was confirmed by the

--- a/src/autoskillit/execution/commands.py
+++ b/src/autoskillit/execution/commands.py
@@ -220,14 +220,23 @@ def build_headless_resume_cmd(
 
 
 def _ensure_skill_prefix(skill_command: str) -> str:
-    """Prompt-formatting helper: prepend 'Use ' to slash-commands for headless session loading.
+    """Prompt-formatting helper: wrap slash-commands for headless session loading.
+
+    Transforms `/foo args` into `Use the /foo skill args` so non-Claude models
+    recognize the slash command as a Skill tool invocation rather than a task description.
 
     This is NOT a validator. Non-slash input passes through unchanged by design —
     runtime validation is enforced by the skill_command_guard PreToolUse hook.
     """
     stripped = skill_command.strip()
     if stripped.startswith("/"):
-        return f"Use {stripped}"
+        parts = stripped.split(None, 1)
+        slash_cmd = parts[0]
+        rest = parts[1] if len(parts) > 1 else ""
+        formatted = f"Use the {slash_cmd} skill"
+        if rest:
+            formatted += f" {rest}"
+        return formatted
     return skill_command
 
 

--- a/src/autoskillit/skills/sous-chef/SKILL.md
+++ b/src/autoskillit/skills/sous-chef/SKILL.md
@@ -59,9 +59,7 @@ When `run_skill` returns `needs_retry=true` for **any step**:
   (typically `test` or `retry_worktree`) to check whether partial work was sufficient.
   API infrastructure errors (overload, 529, ECONNRESET) also produce `retry_reason=resume`
   with `infra_exit_category="api_error"` — route them identically to context exhaustion.
-  When routing to `on_context_limit`, pass the `session_id` from the failed result as
-  `resume_session_id` in the next `run_skill` call to resume the interrupted session
-  instead of starting fresh. The `infra_exit_category` field is informational only
+  The `infra_exit_category` field is informational only
   (`"completed"`, `"context_exhausted"`, `"api_error"`, `"process_killed"`).
 - **If `retry_reason: resume` AND `subtype≠stale` AND the step has no `on_context_limit`** → fall through to `on_failure`.
 - **If `retry_reason: drain_race` AND the step defines `on_context_limit`** → follow `on_context_limit`.

--- a/tests/cli/test_cli_prompts.py
+++ b/tests/cli/test_cli_prompts.py
@@ -740,3 +740,21 @@ def test_show_cook_preview_no_mermaid_in_output(
     assert "flowchart TD" not in captured.out, "Mermaid syntax leaked to terminal"
     assert "S0[" not in captured.out, "Mermaid node syntax leaked to terminal"
     assert "-->" not in captured.out, "Mermaid arrow syntax leaked to terminal"
+
+
+def test_orchestrator_prompt_no_resume_session_id_in_context_limit_routing():
+    """on_context_limit routing must NOT instruct passing resume_session_id.
+
+    Context-exhausted sessions should never be resumed — the retry must start
+    a fresh session to get a full context window.
+    """
+    from autoskillit.cli._prompts import _build_orchestrator_prompt
+
+    prompt = _build_orchestrator_prompt("implementation", mcp_prefix=DIRECT_PREFIX)
+    ctx_section_start = prompt.find("CONTEXT LIMIT ROUTING")
+    assert ctx_section_start != -1
+    ctx_section = prompt[ctx_section_start : ctx_section_start + 2000]
+    assert "resume_session_id" not in ctx_section, (
+        "on_context_limit routing must not instruct L2 to pass resume_session_id; "
+        "context-exhausted sessions must start fresh"
+    )

--- a/tests/contracts/test_sous_chef_routing.py
+++ b/tests/contracts/test_sous_chef_routing.py
@@ -231,3 +231,16 @@ def test_merge_phase_preserves_merge_prs_for_non_queue_repos() -> None:
     assert "queue_available" in lower and "false" in lower, (
         "MERGE PHASE must distinguish queue_available=false as the condition for merge-prs"
     )
+
+
+def test_sous_chef_no_resume_session_id_in_context_limit_routing() -> None:
+    """sous-chef SKILL.md must not instruct passing resume_session_id for
+    on_context_limit routing.
+
+    Context-exhausted sessions must start fresh to get a full context window.
+    """
+    skill_md = _sous_chef_text()
+    assert "resume_session_id" not in skill_md, (
+        "sous-chef SKILL.md must not instruct passing resume_session_id; "
+        "context-exhausted sessions must start fresh"
+    )

--- a/tests/execution/test_commands.py
+++ b/tests/execution/test_commands.py
@@ -348,11 +348,11 @@ class TestBuildSkillSessionCmd:
         assert "--add-dir" not in spec.cmd
 
     def test_skill_prefix_injected(self):
-        """Slash commands must be prefixed with 'Use '."""
+        """Slash commands must be prefixed with 'Use the ... skill'."""
         spec = build_skill_session_cmd("/investigate foo", **self.BASE)
         cmd = spec.cmd
         prompt_idx = cmd.index("-p") + 1 if "-p" in cmd else cmd.index("--print") + 1
-        assert cmd[prompt_idx].startswith("Use /investigate")
+        assert cmd[prompt_idx].startswith("Use the /investigate skill")
 
     def test_completion_marker_appended(self):
         """Completion directive must appear in the prompt."""

--- a/tests/execution/test_headless_core.py
+++ b/tests/execution/test_headless_core.py
@@ -831,22 +831,28 @@ class TestEnsureSkillPrefix:
     """Unit tests for _ensure_skill_prefix helper."""
 
     def test_adds_use_to_slash_command(self):
-        assert _ensure_skill_prefix("/investigate error") == "Use /investigate error"
+        assert _ensure_skill_prefix("/investigate error") == "Use the /investigate skill error"
 
     def test_adds_use_to_namespaced_skill(self):
         assert (
             _ensure_skill_prefix("/autoskillit:investigate error")
-            == "Use /autoskillit:investigate error"
+            == "Use the /autoskillit:investigate skill error"
         )
 
     def test_no_double_prefix(self):
-        assert _ensure_skill_prefix("Use /investigate error") == "Use /investigate error"
+        assert (
+            _ensure_skill_prefix("Use the /investigate skill error")
+            == "Use the /investigate skill error"
+        )
 
     def test_ignores_plain_prompts(self):
         assert _ensure_skill_prefix("Fix the bug in main.py") == "Fix the bug in main.py"
 
     def test_handles_leading_whitespace(self):
-        assert _ensure_skill_prefix("  /investigate error") == "Use /investigate error"
+        assert _ensure_skill_prefix("  /investigate error") == "Use the /investigate skill error"
+
+    def test_bare_slash_command_no_args(self):
+        assert _ensure_skill_prefix("/investigate") == "Use the /investigate skill"
 
 
 class TestStalenessReturnsNeedsRetry:

--- a/tests/server/test_tools_execution_input_gates.py
+++ b/tests/server/test_tools_execution_input_gates.py
@@ -138,7 +138,7 @@ class TestRunSkillPrefix:
         await run_skill("/investigate error", "/tmp")
         cmd = tool_ctx.runner.call_args_list[-1][0]
         prompt_idx = cmd.index("--print") + 1 if "--print" in cmd else cmd.index("-p") + 1
-        assert cmd[prompt_idx].startswith("Use /investigate error")
+        assert cmd[prompt_idx].startswith("Use the /investigate skill error")
         actual_cwd = tool_ctx.runner.call_args_list[-1][1]
         assert actual_cwd == Path("/tmp"), f"Subprocess cwd mismatch: {actual_cwd} != /tmp"
 


### PR DESCRIPTION
## Summary

Two targeted prompt fixes for recipe step execution reliability:

1. **Remove the `resume_session_id` instruction from `on_context_limit` routing** in both `_prompts.py` and `sous-chef/SKILL.md`. Context-exhausted sessions should never be resumed — the session hit its context limit, so resuming means the retry runs inside the old session's remaining (exhausted) context budget. This caused a cascading crash when a MiniMax session ID was passed as `resume_session_id` to `retry_worktree`, and Claude Code tried to replay incompatible thinking blocks via `--resume`.

2. **Add "skill" keyword to `_ensure_skill_prefix()`** output in `commands.py`. Non-Claude models interpret the bare slash command as a direct task description rather than recognizing it as a Skill tool invocation trigger. Changing `"Use /foo"` to `"Use the /foo skill"` makes the intent explicit.

Closes #1924

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260505-092602-781963/.autoskillit/temp/make-plan/fix_on_context_limit_resume_and_skill_keyword_plan_2026-05-05_093600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 51 | 8.0k | 706.0k | 59.9k | 51 | 50.7k | 4m 42s |
| verify | 1 | 132 | 7.6k | 632.3k | 49.6k | 48 | 36.7k | 2m 59s |
| implement | 1 | 244 | 11.6k | 1.3M | 55.2k | 84 | 42.2k | 4m 14s |
| prepare_pr | 1 | 76 | 5.2k | 271.6k | 37.6k | 20 | 25.4k | 2m 0s |
| compose_pr | 1 | 59 | 2.0k | 180.4k | 29.6k | 14 | 16.7k | 44s |
| review_pr | 1 | 267 | 27.0k | 456.2k | 66.2k | 36 | 54.2k | 4m 57s |
| ci_conflict_fix | 4 | 432 | 14.2k | 1.8M | 47.7k | 116 | 109.7k | 5m 8s |
| diagnose_ci | 1 | 92 | 2.8k | 335.2k | 38.6k | 23 | 26.2k | 1m 14s |
| resolve_ci | 1 | 102 | 3.2k | 450.1k | 48.1k | 34 | 35.4k | 4m 33s |
| **Total** | | 1.5k | 81.6k | 6.1M | 66.2k | | 397.2k | 30m 33s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 71 | 18053.2 | 594.6 | 163.8 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| ci_conflict_fix | 1734 | 1014.9 | 63.3 | 8.2 |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 2 | 225056.5 | 17699.5 | 1607.0 |
| **Total** | **1807** | 3361.1 | 219.8 | 45.2 |