### PR TITLE
Extend stage-data Network Probes for Biology Databases

### DIFF
--- a/src/autoskillit/skills_extended/stage-data/SKILL.md
+++ b/src/autoskillit/skills_extended/stage-data/SKILL.md
@@ -95,8 +95,23 @@ Disk space verdict thresholds:
 **b. NETWORK PROBE AGENT:** Infer the API base URL from the `acquisition`
 field. Known endpoints to probe:
 - GEO / NCBI: `https://eutils.ncbi.nlm.nih.gov/entrez/eutils/einfo.fcgi`
+  Rate limit: 3 req/s without API key, 10 req/s with NCBI API key. Single probe is well within limits.
 - ENCODE: `https://www.encodeproject.org/`
+  Rate limit: no published hard limit; courtesy throttle expected at high volume.
 - UniProt: `https://rest.uniprot.org/uniprotkb/search?query=reviewed:true&size=1`
+  Rate limit: undocumented; `size=1` keeps payload ~1KB.
+- Allen Brain Atlas: `https://api.brain-map.org/api/v2/data/Gene/query.json?num_rows=1`
+  Rate limit: no published limit; public API. `num_rows=1` keeps response ~200B.
+- CellxGene: `https://api.cellxgene.cziscience.com/dp/v1/collections`
+  Rate limit: CDN-backed, no published limit. HEAD avoids 53KB collection list.
+- Expression Atlas: `https://www.ebi.ac.uk/gxa/json/experiments`
+  Rate limit: no published hard limit (EBI courtesy policy). CRITICAL: response is ~2.6MB — always use HEAD (`curl -sI`), never GET.
+- Human Protein Atlas: `https://www.proteinatlas.org/api/search_download.php?search=CD8A&columns=g&compress=no&format=json`
+  Rate limit: no published limit; public API. `columns=g` is required (API returns 400 without it). Response ~20B.
+- STRING: `https://string-db.org/api/json/version`
+  Rate limit: ~10 req/s for programmatic access. Version endpoint returns 84B — ideal probe.
+- JASPAR: `https://jaspar.elixir.no/api/v1/matrix/?page_size=1`
+  Rate limit: no published limit (academic resource). Note: domain migrated from genereg.net to elixir.no. `page_size=1` keeps response ~330B.
 - For unrecognized sources: attempt a HEAD request to any URL found in
   the `acquisition` field.
 

--- a/tests/contracts/test_stage_data_contracts.py
+++ b/tests/contracts/test_stage_data_contracts.py
@@ -67,3 +67,48 @@ def test_stage_data_documents_fail_verdict(skill_text: str) -> None:
 def test_stage_data_categories_include_research(skill_text: str) -> None:
     assert "categories" in skill_text
     assert "research" in skill_text
+
+
+def test_stage_data_probes_allen_brain_atlas(skill_text: str) -> None:
+    assert "brain-map.org" in skill_text
+
+
+def test_stage_data_probes_cellxgene(skill_text: str) -> None:
+    assert "cellxgene" in skill_text.lower()
+
+
+def test_stage_data_probes_expression_atlas(skill_text: str) -> None:
+    assert "gxa" in skill_text
+
+
+def test_stage_data_probes_human_protein_atlas(skill_text: str) -> None:
+    assert "proteinatlas.org" in skill_text
+
+
+def test_stage_data_probes_string_db(skill_text: str) -> None:
+    assert "string-db.org" in skill_text
+
+
+def test_stage_data_probes_jaspar(skill_text: str) -> None:
+    assert "jaspar" in skill_text.lower()
+
+
+def test_stage_data_documents_rate_limit_behavior(skill_text: str) -> None:
+    lower = skill_text.lower()
+    assert "rate" in lower and "limit" in lower
+
+
+def test_stage_data_probe_count_minimum(skill_text: str) -> None:
+    known_sources = [
+        "GEO / NCBI",
+        "ENCODE",
+        "UniProt",
+        "Allen Brain Atlas",
+        "CellxGene",
+        "Expression Atlas",
+        "Human Protein Atlas",
+        "STRING",
+        "JASPAR",
+    ]
+    count = sum(1 for src in known_sources if src.lower() in skill_text.lower())
+    assert count >= 9


### PR DESCRIPTION
## Summary

Add 6 biology-database network probe endpoints to the `stage-data` skill's known endpoint registry in `SKILL.md`. The probes target Allen Brain Atlas, CellxGene, Expression Atlas, Human Protein Atlas, STRING, and JASPAR — databases commonly used in computational-biology research. Each probe is a cheap HEAD or minimal GET call with a 10-second timeout, following the existing `curl -sI --max-time 10` pattern. The verdict aggregation logic is unchanged — new probes feed into the same PASS/WARN/FAIL pipeline as existing NCBI/ENCODE/UniProt probes. Three endpoint URLs from the issue require correction based on endpoint verification (CellxGene root redirects to HTML; HPA requires `columns` param; JASPAR domain migrated from `genereg.net` to `elixir.no`).

Closes #851

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260505-091740-911076/.autoskillit/temp/make-plan/extend_stage_data_biology_probes_plan_2026-05-05_092600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 63 | 8.7k | 818.5k | 64.7k | 110 | 55.9k | 7m 2s |
| verify | 1 | 596 | 9.7k | 700.2k | 56.2k | 41 | 54.9k | 2m 51s |
| implement | 1 | 116 | 6.4k | 569.8k | 51.4k | 42 | 38.4k | 2m 8s |
| prepare_pr | 1 | 68 | 4.6k | 234.6k | 37.2k | 20 | 25.2k | 1m 23s |
| compose_pr | 1 | 59 | 2.3k | 197.5k | 35.1k | 17 | 22.1k | 1m 4s |
| review_pr | 1 | 108 | 13.2k | 507.0k | 51.3k | 35 | 39.7k | 3m 56s |
| **Total** | | 1.0k | 44.8k | 3.0M | 64.7k | | 236.2k | 18m 25s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 60 | 9496.9 | 640.5 | 105.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **60** | 50458.9 | 3937.3 | 747.3 |