### PR TITLE
docs: reorganize CLAUDE.md into hub-and-spoke subdirectory docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,7 @@ generic_automation_mcp/
 └── pyproject.toml
 ```
 
-`src/autoskillit/` packages — each has its own CLAUDE.md with file-level detail:
+`src/autoskillit/` packages — each has its own CLAUDE.md with file-level detail (except `recipes/`, `skills/`, and `skills_extended/` — CLAUDE.md files for these are pending):
 
 | Package | IL | Purpose |
 |---|---|---|

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,7 +136,7 @@ generic_automation_mcp/
 
 | Package | IL | Purpose |
 |---|---|---|
-| `./` | — | Package root: `__init__`, `__main__`, `hook_registry`, `version`, `_test_filter` |
+| `./` | — | Package root: `__init__`, `__main__`, `hook_registry`, `version`, `_test_filter`, `_llm_triage`, `smoke_utils` |
 | `core/` | IL-0 | Foundation — types/, runtime/, paths, IO, feature flags (zero autoskillit imports) |
 | `config/` | IL-1 | `AutomationConfig` + Dynaconf loader + 24 leaf dataclasses |
 | `pipeline/` | IL-1 | Pipeline state — `ToolContext` DI, gate, audit log, telemetry |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,209 +132,26 @@ generic_automation_mcp/
 └── pyproject.toml
 ```
 
-`src/autoskillit/`:
+`src/autoskillit/` packages — each has its own CLAUDE.md with file-level detail:
 
-```
-├── __init__.py
-├── __main__.py
-├── _llm_triage.py           # Contract staleness triage (Haiku subprocess)
-├── smoke_utils.py           # Callables for smoke-test pipeline run_python steps
-├── hook_registry.py         # HookDef, HOOK_REGISTRY, generate_hooks_json
-├── _test_filter.py          # Test filter manifest: glob-to-test-directory mapping
-├── version.py               # Version health utilities (IL-0)
-├── .claude-plugin/          # plugin.json
-├── .mcp.json
-│
-├── core/                    # IL-0 foundation (zero autoskillit imports)
-│   ├── types/               # Type re-export hub + protocol/enum/result modules (see types/CLAUDE.md)
-│   ├── runtime/             # Process-state modules (see runtime/CLAUDE.md)
-│   ├── __init__.py          #   Re-exports public surface
-│   ├── io.py                #   atomic_write, ensure_project_temp, YAML helpers
-│   ├── logging.py
-│   ├── paths.py             #   pkg_root(), is_git_worktree()
-│   ├── _claude_env.py       #   IDE-scrubbing canonical env builder for claude subprocesses
-│   ├── _terminal_table.py   #   IL-0 color-agnostic terminal table primitive
-│   ├── _version_snapshot.py #   Process-scoped version snapshot for session telemetry (lru_cache'd)
-│   ├── branch_guard.py
-│   ├── claude_conventions.py #  Skill discovery directory layout constants
-│   ├── github_url.py        #   parse_github_repo
-│   ├── _plugin_cache.py     #   Plugin cache lifecycle: retiring cache, install locking, kitchen registry
-│   ├── _plugin_ids.py       #   DIRECT_PREFIX, MARKETPLACE_PREFIX, detect_autoskillit_mcp_prefix (stdlib-only)
-│   ├── _install_detect.py   #   is_dev_install() — editable-install detection for config resolution (IL-0)
-│   ├── feature_flags.py     #   is_feature_enabled() — IL-0 feature gate resolution primitive
-│   └── tool_sequence_analysis.py #  Cross-session tool call sequence DFG analysis (stdlib-only, IL-0)
-│
-├── config/                  # IL-1
-│   ├── __init__.py
-│   ├── defaults.yaml
-│   ├── ingredient_defaults.py
-│   ├── settings.py          #   AutomationConfig + schema validate/write API
-│   ├── _config_dataclasses.py #  24 leaf dataclasses + ConfigSchemaError
-│   └── _config_loader.py    #   _make_dynaconf + load_config layer helpers
-│
-├── pipeline/                # IL-1 pipeline state
-│   ├── __init__.py
-│   ├── audit.py             #   FailureRecord, DefaultAuditLog
-│   ├── background.py        #   DefaultBackgroundSupervisor
-│   ├── context.py           #   ToolContext DI container
-│   ├── gate.py              #   DefaultGateState, gate_error_result
-│   ├── github_api_log.py    #   DefaultGitHubApiLog — session-scoped GitHub API request accumulator
-│   ├── mcp_response.py      #   Per-tool response size tracking
-│   ├── telemetry_fmt.py     #   Canonical token/timing display
-│   ├── timings.py
-│   ├── tokens.py
-│   └── pr_gates.py          #   is_ci_passing, is_review_passing, partition_prs
-│
-├── execution/               # IL-1
-│   ├── headless/            # Headless session orchestration (see headless/CLAUDE.md)
-│   ├── process/             # Process lifecycle management (see process/CLAUDE.md)
-│   ├── merge_queue/         # GitHub merge queue watcher (see merge_queue/CLAUDE.md)
-│   ├── session/             # Session result processing (see session/CLAUDE.md)
-│   ├── __init__.py
-│   ├── commands.py          #   Claude{Interactive,Headless}Cmd builders
-│   ├── db.py                #   Read-only SQLite with defence-in-depth
-│   ├── diff_annotator.py    #   Diff annotation + findings filter for review-pr
-│   ├── linux_tracing.py     #   /proc + psutil process tracing (Linux)
-│   ├── anomaly_detection.py #   Post-hoc anomaly detection over snapshots
-│   ├── session_log.py       #   XDG-aware session diagnostics log writer
-│   ├── recording.py         #   Record/replay subprocess runners via api-simulator
-│   ├── _recording_skills.py #   Skill dir snapshot/restore for record/replay sessions
-│   ├── quota.py             #   QuotaStatus, cache, check_and_sleep_if_needed
-│   ├── ci.py                #   GitHub Actions CI watcher (httpx, never raises)
-│   ├── github.py            #   GitHub issue fetcher
-│   ├── remote_resolver.py   #   upstream > origin, clone-aware
-│   ├── testing.py           #   Pytest output parsing + pass/fail adjudication
-│   ├── clone_guard.py       #   Clone contamination guard — detect and revert direct changes to clone CWD
-│   └── pr_analysis.py       #   extract_linked_issues, DOMAIN_PATHS, partition_files_by_domain
-│
-├── workspace/               # IL-1
-│   ├── __init__.py
-│   ├── cleanup.py           #   CleanupResult, preserve list
-│   ├── clone.py             #   clone_repo + push_to_remote + DefaultCloneManager
-│   ├── _clone_detect.py     #   detect_* helpers + RUNS_DIR + classify_remote_url
-│   ├── _clone_remote.py     #   CloneSourceResolution + probe/isolate remotes
-│   ├── session_skills.py    #   Per-session ephemeral skill dirs; subset filtering
-│   ├── clone_registry.py    #   Shared file-based coordination for deferred cleanup
-│   ├── skills.py            #   SkillResolver — bundled skill listing
-│   └── worktree.py
-│
-├── planner/                 # IL-1
-│   ├── __init__.py          #   Progressive resolution planner — re-exports expand_assignments, expand_wps, finalize_wp_manifest, validate_plan, compile_plan
-│   ├── manifests.py         #   expand_assignments, expand_wps, finalize_wp_manifest, build_phase_assignment_manifest, build_phase_wp_manifest — manifest callables
-│   ├── merge.py             #   merge_tier_dir, merge_files, build_plan_snapshot, extract_item, replace_item — JSON interchange merge tooling
-│   ├── validation.py        #   validate_plan — DAG cycle check, structural completeness, sizing bounds, duplicate-deliverable detection
-│   ├── schema.py            #   planner data contracts — PhaseResult, AssignmentResult, WPResult, PlanDocument TypedDicts
-│   ├── compiler.py          #   compile_plan — topological sort, issue body generation, milestone definitions, plan artifacts
-│   └── consolidation.py     #   consolidate_wps — post-elaboration WP consolidation: reads manifests, merges trivial WPs, rewrites dep IDs
-│
-├── recipe/                  # IL-2
-│   ├── rules/               # Semantic validation rules (see rules/CLAUDE.md)
-│   ├── __init__.py
-│   ├── contracts.py         #   Contract card generation + staleness triage
-│   ├── io.py                #   load_recipe, list_recipes, iter_steps_with_context
-│   ├── order.py             #   BUNDLED_RECIPE_ORDER — stable display order registry for Group 0 recipes
-│   ├── loader.py            #   Path-based recipe metadata utilities
-│   ├── _api.py              #   Orchestration API
-│   ├── _cmd_rpc.py          #   run_python callables for externalized recipe cmd scripts
-│   ├── _recipe_ingredients.py #  format_ingredients_table + LoadRecipeResult TypedDicts
-│   ├── _recipe_composition.py #  _build_active_recipe + sub-recipe merging
-│   ├── diagrams.py          #   Flow diagram generation + staleness detection
-│   ├── experiment_type_registry.py #  ExperimentTypeSpec, load_all_experiment_types
-│   ├── registry.py          #   RuleFinding, RuleSpec, semantic_rule decorator
-│   ├── repository.py
-│   ├── _analysis.py         #   ValidationContext + make_validation_context
-│   ├── _analysis_graph.py   #   RouteEdge + build_recipe_graph + step graph primitives
-│   ├── _analysis_bfs.py     #   bfs_reachable + symbolic BFS fact propagation
-│   ├── _analysis_blocks.py  #   extract_blocks — group steps by block annotation
-│   ├── _analysis_detectors.py #  dead outputs + ref invalidations + implicit handoffs
-│   ├── _git_helpers.py      #   Shared git-remote regex (_GIT_REMOTE_COMMAND_RE, _LITERAL_ORIGIN_RE) for lint rules
-│   ├── _skill_helpers.py        #   Shared helpers for skill-related semantic rules
-│   ├── _skill_placeholder_parser.py
-│   ├── identity.py          #   Recipe identity hashing — content and composite fingerprints
-│   ├── schema.py            #   Recipe, RecipeStep, DataFlowWarning
-│   ├── staleness_cache.py
-│   └── validator.py         #   validate_recipe, analyze_dataflow
-│
-├── migration/               # IL-2
-│   ├── __init__.py
-│   ├── engine.py            #   MigrationEngine, adapter ABC hierarchy
-│   ├── _api.py              #   check_and_migrate
-│   ├── loader.py            #   Migration note discovery + version chaining
-│   └── store.py             #   FailureStore (JSON, atomic writes)
-│
-├── fleet/                   # IL-2
-│   ├── __init__.py          #   Re-exports: CampaignSummary, parse_campaign_summary, etc.
-│   ├── _api.py              #   Fleet campaign execution engine — dispatches L2 sessions, resolves campaign/result variable references
-│   ├── _prompts.py          #   Prompt builder for L2 fleet dispatch sessions — assembles sous-chef instruction block from SKILL.md sections
-│   ├── result_parser.py     #   L2 result block parser with Channel B JSONL fallback
-│   ├── sidecar.py           #   Per-issue JSONL sidecar — IssueSidecarEntry, append/read/compute_remaining helpers
-│   ├── _liveness.py         #   is_dispatch_session_alive() — boot_id + starttime_ticks liveness gate
-│   ├── _semaphore.py        #   FleetSemaphore — configurable asyncio.BoundedSemaphore implementing FleetLock
-│   ├── _sidecar_rpc.py      #   run_python-callable entry points: write_sidecar_entry, get_remaining_issues
-│   ├── _findings_rpc.py     #   run_python-callable entry points: parse_and_resume, load_execution_map
-│   ├── _checkpoint_bridge.py #  checkpoint_from_sidecar — converts IssueSidecarEntry list to SessionCheckpoint
-│   ├── state.py             #   Campaign state persistence — DispatchRecord, DispatchStatus, atomic writes, resume algorithm
-│   └── summary.py           #   Campaign summary schema v1: frozen dataclasses, sentinel parser, validator
-│
-├── server/                  # IL-3 FastMCP server
-│   ├── tools/               # MCP @mcp.tool handlers (see tools/CLAUDE.md)
-│   ├── __init__.py          #   FastMCP app, kitchen gating, headless tool reveal
-│   ├── git.py               #   Merge workflow for merge_worktree
-│   ├── _editable_guard.py   #   Pre-deletion editable install guard (stdlib-only)
-│   ├── _guards.py           #   Tier/gate guard functions: _require_enabled, _require_orchestrator_*, _require_fleet, _check_dry_walkthrough, _validate_skill_command
-│   ├── _lifespan.py         #   FastMCP lifespan: recorder teardown on shutdown
-│   ├── _session_type.py     #   Session-type tag visibility dispatcher (3-branch startup logic)
-│   ├── _wire_compat.py      #   Claude Code wire-format sanitization middleware
-│   ├── _notify.py           #   _notify, track_response_size, _get_ctx_or_none
-│   ├── _misc.py             #   Quota/hook/triage utilities + re-exports for tools_*.py layer compliance
-│   ├── _subprocess.py       #   Subprocess execution helpers for MCP tools
-│   ├── _factory.py          #   Composition Root: make_context()
-│   └── _state.py            #   Lazy init, plugin dir resolution
-│
-├── cli/                     # IL-3 CLI
-│   ├── doctor/              # Health check subcommand (see doctor/CLAUDE.md)
-│   ├── fleet/               # Fleet subcommand group (see fleet/CLAUDE.md)
-│   ├── session/             # Session management (see session/CLAUDE.md)
-│   ├── ui/                  # Terminal UI primitives (see ui/CLAUDE.md)
-│   ├── update/              # Update/upgrade machinery (see update/CLAUDE.md)
-│   ├── __init__.py
-│   ├── _restart.py          #   perform_restart() -> NoReturn: sets SKIP_UPDATE_CHECK, calls os.execv
-│   ├── _hooks.py            #   PreToolUse hook registration helpers
-│   ├── _init_helpers.py
-│   ├── _installed_plugins.py #  InstalledPluginsFile — canonical accessor for installed_plugins.json
-│   ├── _install_info.py     #   InstallInfo, InstallType, detect_install(), comparison_branch(), dismissal_window(), upgrade_command()
-│   ├── _marketplace.py      #   Plugin install/upgrade
-│   ├── _mcp_names.py        #   MCP prefix detection
-│   ├── _onboarding.py       #   First-run detection + guided menu
-│   ├── _prompts.py          #   Orchestrator prompt builder
-│   ├── _preview.py          #   Shared pre-launch preview: flow diagram + ingredient table display
-│   ├── _serve_guard.py      #   Async signal-guarded MCP server bootstrap (extracted from app.py)
-│   ├── _features.py         #   features subcommand group: list/status commands for feature gate inspection
-│   ├── _workspace.py        #   Workspace clean helpers
-│   ├── _sessions.py         #   sessions analyze CLI subcommand for cross-session DFG visualization
-│   ├── _terminal_table.py   #   Re-export shim from core/_terminal_table
-│   └── app.py               #   CLI entry: serve, init, config, skills, recipes, doctor, update, etc.
-│
-├── hooks/                   # Claude Code PreToolUse/PostToolUse/SessionStart scripts
-│   ├── guards/              # PreToolUse guard scripts (see guards/CLAUDE.md)
-│   ├── formatters/          # PostToolUse output formatters (see formatters/CLAUDE.md)
-│   ├── __init__.py
-│   ├── hooks.json           #   Plugin hook registration
-│   ├── _dispatch.py         #   Stable hook dispatcher — resolves logical hook names to scripts (stdlib-only, NEVER RENAME)
-│   ├── _hook_settings.py    #   Shared stdlib-only settings resolver for quota guard hooks
-│   ├── lint_after_edit_hook.py #  PostToolUse: runs ruff format+check on .py files after Edit/Write
-│   ├── quota_post_hook.py   #   Appends quota warning to run_skill output
-│   ├── review_gate_post_hook.py #  PostToolUse: writes/clears review_gate_state.json
-│   ├── skill_load_post_hook.py  #  PostToolUse: writes skill-loaded flag for non-Anthropic providers
-│   ├── token_summary_hook.py #  Appends Token Usage Summary to PR body
-│   └── session_start_hook.py #  Injects open-kitchen reminder on resume
-│
-├── migrations/              # Versioned migration YAML notes
-├── recipes/                 # Bundled recipe YAML + contracts/, diagrams/, sub-recipes/
-├── skills/                  # Tier 1: open-kitchen, close-kitchen, sous-chef
-└── skills_extended/         # Tier 2 (interactive) + Tier 3 (pipeline/automation) skills
-                             # incl. arch-lens-* (13), exp-lens-* (18), and vis-lens-* (12) diagram families
-```
+| Package | IL | Purpose |
+|---|---|---|
+| `./` | — | Package root: `__init__`, `__main__`, `hook_registry`, `version`, `_test_filter` |
+| `core/` | IL-0 | Foundation — types/, runtime/, paths, IO, feature flags (zero autoskillit imports) |
+| `config/` | IL-1 | `AutomationConfig` + Dynaconf loader + 24 leaf dataclasses |
+| `pipeline/` | IL-1 | Pipeline state — `ToolContext` DI, gate, audit log, telemetry |
+| `execution/` | IL-1 | Headless sessions (headless/, process/, merge_queue/, session/), CI/GitHub |
+| `workspace/` | IL-1 | Clone management, worktrees, skill resolution |
+| `planner/` | IL-1 | Progressive resolution planner — phases, assignments, WPs, validation |
+| `recipe/` | IL-2 | Recipe schema, validation, semantic rules/ |
+| `migration/` | IL-2 | Versioned migration engine + failure store |
+| `fleet/` | IL-2 | Campaign dispatch, semaphore, sidecar, liveness, state persistence |
+| `server/` | IL-3 | FastMCP server — tools/, kitchen gating, session-type dispatch |
+| `cli/` | IL-3 | CLI — doctor/, update/, fleet/ subcommands, ui/, session/ management |
+| `hooks/` | — | Claude Code hook scripts — guards/, formatters/ |
+| `recipes/` | — | Bundled recipe YAML + contracts, diagrams, sub-recipes |
+| `skills/` | — | Tier 1 skills: open-kitchen, close-kitchen, sous-chef |
+| `skills_extended/` | — | Tier 2 (interactive) + Tier 3 (pipeline) skills, incl. arch-lens-* (13), exp-lens-* (18), vis-lens-* (12) |
 
 **Session diagnostics logs** live at `~/.local/share/autoskillit/logs/` (Linux) or `~/Library/Application Support/autoskillit/logs/` (macOS). Override with `linux_tracing.log_dir`. Session directories are named by Claude Code session UUID when available (parsed from stdout, or discovered from JSONL filename via Channel B (the JSONL stream written by the Claude Code subprocess)). Fallback: `no_session_{timestamp}`. Query the index: `jq 'select(.success == false)' ~/.local/share/autoskillit/logs/sessions.jsonl`.
 

--- a/src/autoskillit/CLAUDE.md
+++ b/src/autoskillit/CLAUDE.md
@@ -1,0 +1,21 @@
+# autoskillit/
+
+Package root — entry points, hook registry, and cross-cutting utilities.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `__init__.py` | Package exports |
+| `__main__.py` | `python -m autoskillit` entry point |
+| `_llm_triage.py` | Contract staleness triage (Haiku subprocess) |
+| `smoke_utils.py` | Callables for smoke-test pipeline `run_python` steps |
+| `hook_registry.py` | `HookDef`, `HOOK_REGISTRY`, `generate_hooks_json` |
+| `_test_filter.py` | Test filter manifest: glob-to-test-directory mapping |
+| `version.py` | Version health utilities (IL-0) |
+
+## Architecture Notes
+
+`hook_registry.py` is stdlib-only (safe for hook subprocesses). `_test_filter.py` drives
+`task test-filtered` — it maps changed-file globs to test directory subsets. `_llm_triage.py`
+and `smoke_utils.py` are callable by headless recipe steps via `run_python`.

--- a/src/autoskillit/cli/CLAUDE.md
+++ b/src/autoskillit/cli/CLAUDE.md
@@ -1,0 +1,32 @@
+# cli/
+
+IL-3 CLI layer — entry points for all user-facing commands.
+Sub-packages: doctor/ (see doctor/CLAUDE.md), fleet/ (see fleet/CLAUDE.md),
+session/ (see session/CLAUDE.md), ui/ (see ui/CLAUDE.md), update/ (see update/CLAUDE.md).
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `__init__.py` | Package marker |
+| `app.py` | CLI entry: `serve`, `init`, `config`, `skills`, `recipes`, `doctor`, `update`, etc. |
+| `_restart.py` | `perform_restart()` → `NoReturn`: sets `SKIP_UPDATE_CHECK`, calls `os.execv` |
+| `_hooks.py` | `PreToolUse` hook registration helpers |
+| `_init_helpers.py` | `autoskillit init` implementation helpers |
+| `_installed_plugins.py` | `InstalledPluginsFile` — canonical accessor for `installed_plugins.json` |
+| `_install_info.py` | `InstallInfo`, `InstallType`, `detect_install()`, `comparison_branch()`, `dismissal_window()`, `upgrade_command()` |
+| `_marketplace.py` | Plugin install/upgrade |
+| `_mcp_names.py` | MCP prefix detection |
+| `_onboarding.py` | First-run detection + guided menu |
+| `_prompts.py` | Orchestrator prompt builder |
+| `_preview.py` | Shared pre-launch preview: flow diagram + ingredient table display |
+| `_serve_guard.py` | Async signal-guarded MCP server bootstrap (extracted from `app.py`) |
+| `_features.py` | `features` subcommand group: list/status commands for feature gate inspection |
+| `_workspace.py` | Workspace clean helpers |
+| `_sessions.py` | `sessions analyze` CLI subcommand for cross-session DFG visualization |
+
+## Architecture Notes
+
+`app.py` is the Click application root; all sub-packages register their subcommand groups
+against the root Click group. `_serve_guard.py` was extracted from `app.py` to isolate
+the asyncio/signal machinery for testability.

--- a/src/autoskillit/config/CLAUDE.md
+++ b/src/autoskillit/config/CLAUDE.md
@@ -1,0 +1,20 @@
+# config/
+
+IL-1 configuration layer — `AutomationConfig`, Dynaconf loader, schema validation.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `__init__.py` | Re-exports `AutomationConfig`, `load_config`, `ConfigSchemaError` |
+| `ingredient_defaults.py` | Per-recipe ingredient default resolution |
+| `settings.py` | `AutomationConfig` + schema validate/write API |
+| `_config_dataclasses.py` | 24 leaf dataclasses + `ConfigSchemaError` |
+| `_config_loader.py` | `_make_dynaconf` + `load_config` layer helpers |
+
+## Architecture Notes
+
+`_config_dataclasses.py` defines the 24 leaf config dataclasses that form the schema tree
+rooted at `AutomationConfig`. `defaults.yaml` (non-Python) is the Dynaconf default values
+file read at startup. `ingredient_defaults.py` bridges recipe-level ingredient declarations
+to config-layer defaults without importing from `recipe/`.

--- a/src/autoskillit/core/CLAUDE.md
+++ b/src/autoskillit/core/CLAUDE.md
@@ -1,0 +1,30 @@
+# core/
+
+IL-0 foundation layer — zero autoskillit imports; safe for import from hook subprocesses.
+Sub-packages: types/ (see types/CLAUDE.md) and runtime/ (see runtime/CLAUDE.md).
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `__init__.py` | Re-exports public surface |
+| `io.py` | `atomic_write`, `ensure_project_temp`, YAML helpers |
+| `logging.py` | Logging configuration |
+| `paths.py` | `pkg_root()`, `is_git_worktree()` |
+| `_claude_env.py` | IDE-scrubbing canonical env builder for claude subprocesses |
+| `_terminal_table.py` | IL-0 color-agnostic terminal table primitive |
+| `_version_snapshot.py` | Process-scoped version snapshot for session telemetry (`lru_cache`'d) |
+| `branch_guard.py` | Branch protection helpers |
+| `claude_conventions.py` | Skill discovery directory layout constants |
+| `github_url.py` | `parse_github_repo` |
+| `_plugin_cache.py` | Plugin cache lifecycle: retiring cache, install locking, kitchen registry |
+| `_plugin_ids.py` | `DIRECT_PREFIX`, `MARKETPLACE_PREFIX`, `detect_autoskillit_mcp_prefix` (stdlib-only) |
+| `_install_detect.py` | `is_dev_install()` — editable-install detection for config resolution |
+| `feature_flags.py` | `is_feature_enabled()` — IL-0 feature gate resolution primitive |
+| `tool_sequence_analysis.py` | Cross-session tool call sequence DFG analysis (stdlib-only) |
+
+## Architecture Notes
+
+All modules are importable without any `autoskillit` package imports (IL-0 hard constraint).
+Production code imports from `autoskillit.core`, not from sub-packages directly.
+`_terminal_table.py` is re-exported by `cli/_terminal_table.py` as a shim.

--- a/src/autoskillit/execution/CLAUDE.md
+++ b/src/autoskillit/execution/CLAUDE.md
@@ -1,0 +1,32 @@
+# execution/
+
+IL-1 execution layer — headless Claude sessions, process lifecycle, CI/GitHub integration.
+Sub-packages: headless/ (see headless/CLAUDE.md), process/ (see process/CLAUDE.md),
+merge_queue/ (see merge_queue/CLAUDE.md), session/ (see session/CLAUDE.md).
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `__init__.py` | Re-exports `DefaultHeadlessExecutor`, `run_headless_core` |
+| `commands.py` | `ClaudeInteractiveCmd`, `ClaudeHeadlessCmd` builders |
+| `db.py` | Read-only SQLite with defence-in-depth |
+| `diff_annotator.py` | Diff annotation + findings filter for review-pr |
+| `linux_tracing.py` | `/proc` + psutil process tracing (Linux) |
+| `anomaly_detection.py` | Post-hoc anomaly detection over snapshots |
+| `session_log.py` | XDG-aware session diagnostics log writer |
+| `recording.py` | Record/replay subprocess runners via api-simulator |
+| `_recording_skills.py` | Skill dir snapshot/restore for record/replay sessions |
+| `quota.py` | `QuotaStatus`, cache, `check_and_sleep_if_needed` |
+| `ci.py` | GitHub Actions CI watcher (httpx, never raises) |
+| `github.py` | GitHub issue fetcher |
+| `remote_resolver.py` | Upstream > origin, clone-aware remote resolution |
+| `testing.py` | Pytest output parsing + pass/fail adjudication |
+| `clone_guard.py` | Clone contamination guard — detect and revert direct changes to clone CWD |
+| `pr_analysis.py` | `extract_linked_issues`, `DOMAIN_PATHS`, `partition_files_by_domain` |
+
+## Architecture Notes
+
+`session_log.py` uses XDG base dir spec; log directory names use hyphens (never
+underscores). `recording.py` and `_recording_skills.py` only activate when
+`AUTOSKILLIT_RECORD_SESSION` is set; production paths never touch them.

--- a/src/autoskillit/fleet/CLAUDE.md
+++ b/src/autoskillit/fleet/CLAUDE.md
@@ -1,0 +1,28 @@
+# fleet/
+
+IL-2 fleet campaign layer — parallel issue dispatch, semaphore, sidecar, liveness, state.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `__init__.py` | Re-exports `CampaignSummary`, `parse_campaign_summary`, and dispatch callables |
+| `_api.py` | Fleet campaign execution engine — dispatches L2 sessions, resolves campaign/result variable references |
+| `_prompts.py` | Prompt builder for L2 fleet dispatch sessions — assembles sous-chef instruction block from SKILL.md sections |
+| `result_parser.py` | L2 result block parser with Channel B JSONL fallback |
+| `sidecar.py` | Per-issue JSONL sidecar — `IssueSidecarEntry`, append/read/`compute_remaining` helpers |
+| `_liveness.py` | `is_dispatch_session_alive()` — boot_id + starttime_ticks liveness gate |
+| `_semaphore.py` | `FleetSemaphore` — configurable `asyncio.BoundedSemaphore` implementing `FleetLock` |
+| `_sidecar_rpc.py` | `run_python`-callable entry points: `write_sidecar_entry`, `get_remaining_issues` |
+| `_findings_rpc.py` | `run_python`-callable entry points: `parse_and_resume`, `load_execution_map` |
+| `_checkpoint_bridge.py` | `checkpoint_from_sidecar` — converts `IssueSidecarEntry` list to `SessionCheckpoint` |
+| `state.py` | Campaign state persistence — `DispatchRecord`, `DispatchStatus`, atomic writes, resume algorithm |
+| `summary.py` | Campaign summary schema v1: frozen dataclasses, sentinel parser, validator |
+
+## Architecture Notes
+
+`_api.py` is the primary entry point called by `server/tools/tools_execution.py:dispatch_food_truck`.
+Sidecars are per-issue JSONL files appended atomically; `_sidecar_rpc.py` and
+`_findings_rpc.py` expose sidecar operations to in-recipe `run_python` steps without
+requiring a full server import. `_liveness.py` gates dispatch to prevent zombie sessions
+from blocking campaign progress.

--- a/src/autoskillit/hooks/CLAUDE.md
+++ b/src/autoskillit/hooks/CLAUDE.md
@@ -15,6 +15,7 @@ Sub-packages: guards/ (see guards/CLAUDE.md), formatters/ (see formatters/CLAUDE
 | `review_gate_post_hook.py` | `PostToolUse`: writes/clears `review_gate_state.json` |
 | `token_summary_hook.py` | Appends Token Usage Summary to PR body |
 | `session_start_hook.py` | Injects open-kitchen reminder on resume |
+| `skill_load_post_hook.py` | `PostToolUse`: writes skill-loaded flag for non-Anthropic provider guard |
 
 ## Architecture Notes
 

--- a/src/autoskillit/hooks/CLAUDE.md
+++ b/src/autoskillit/hooks/CLAUDE.md
@@ -1,0 +1,25 @@
+# hooks/
+
+Claude Code `PreToolUse`/`PostToolUse`/`SessionStart` scripts.
+Sub-packages: guards/ (see guards/CLAUDE.md), formatters/ (see formatters/CLAUDE.md).
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `__init__.py` | Package marker (no imports) |
+| `_dispatch.py` | Stable hook dispatcher — resolves logical hook names to scripts (stdlib-only, NEVER RENAME) |
+| `_hook_settings.py` | Shared stdlib-only settings resolver for quota guard hooks |
+| `lint_after_edit_hook.py` | `PostToolUse`: runs ruff format+check on `.py` files after Edit/Write |
+| `quota_post_hook.py` | Appends quota warning to `run_skill` output |
+| `review_gate_post_hook.py` | `PostToolUse`: writes/clears `review_gate_state.json` |
+| `token_summary_hook.py` | Appends Token Usage Summary to PR body |
+| `session_start_hook.py` | Injects open-kitchen reminder on resume |
+
+## Architecture Notes
+
+`_dispatch.py` must never be renamed — it is referenced by absolute path in `hooks.json`
+and the `HOOK_REGISTRY`. All hook scripts are stdlib-only standalone executables; they do
+not import from `autoskillit.*` except via `_dispatch.py`'s path-resolution logic.
+Renaming any hook script requires updating `HOOK_REGISTRY` in `hook_registry.py` AND
+adding the old basename to `RETIRED_SCRIPT_BASENAMES` in the same commit.

--- a/src/autoskillit/migration/CLAUDE.md
+++ b/src/autoskillit/migration/CLAUDE.md
@@ -1,0 +1,20 @@
+# migration/
+
+IL-2 migration engine — versioned config migration with adapter hierarchy and failure store.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `__init__.py` | Re-exports `check_and_migrate`, `MigrationEngine` |
+| `engine.py` | `MigrationEngine`, adapter ABC hierarchy |
+| `_api.py` | `check_and_migrate` — top-level migration entry point |
+| `loader.py` | Migration note discovery + version chaining |
+| `store.py` | `FailureStore` (JSON, atomic writes) |
+
+## Architecture Notes
+
+Migration notes live in `src/autoskillit/migrations/` as YAML files discovered by
+`loader.py` at startup. `store.py` persists failures to `.autoskillit/temp/` using atomic
+writes. `engine.py` defines the adapter ABC; concrete adapters are registered per migration
+note version.

--- a/src/autoskillit/pipeline/CLAUDE.md
+++ b/src/autoskillit/pipeline/CLAUDE.md
@@ -1,0 +1,26 @@
+# pipeline/
+
+IL-1 pipeline state — per-tool-call state containers, gate logic, audit log, telemetry.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `__init__.py` | Re-exports public protocol implementations |
+| `audit.py` | `FailureRecord`, `DefaultAuditLog` |
+| `background.py` | `DefaultBackgroundSupervisor` |
+| `context.py` | `ToolContext` DI container |
+| `gate.py` | `DefaultGateState`, `gate_error_result` |
+| `github_api_log.py` | `DefaultGitHubApiLog` — session-scoped GitHub API request accumulator |
+| `mcp_response.py` | Per-tool response size tracking |
+| `telemetry_fmt.py` | Canonical token/timing display |
+| `timings.py` | `DefaultTimingLog` |
+| `tokens.py` | `DefaultTokenLog` |
+| `pr_gates.py` | `is_ci_passing`, `is_review_passing`, `partition_prs` |
+
+## Architecture Notes
+
+`ToolContext` is the composition root injected into every MCP tool handler via
+`server/_factory.py:make_context()`. All implementations satisfy protocols defined in
+`core/types/`. `gate.py` is the sole source of structured gate-error results; no tool
+handler constructs gate errors directly.

--- a/src/autoskillit/planner/CLAUDE.md
+++ b/src/autoskillit/planner/CLAUDE.md
@@ -1,0 +1,22 @@
+# planner/
+
+IL-1 progressive resolution planner — phases, work packages, manifest generation, DAG validation.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `__init__.py` | Re-exports `expand_assignments`, `expand_wps`, `finalize_wp_manifest`, `validate_plan`, `compile_plan` |
+| `manifests.py` | `expand_assignments`, `expand_wps`, `finalize_wp_manifest`, `build_phase_assignment_manifest`, `build_phase_wp_manifest` |
+| `merge.py` | `merge_tier_dir`, `merge_files`, `build_plan_snapshot`, `extract_item`, `replace_item` — JSON interchange merge tooling |
+| `validation.py` | `validate_plan` — DAG cycle check, structural completeness, sizing bounds, duplicate-deliverable detection |
+| `schema.py` | Planner data contracts: `PhaseResult`, `AssignmentResult`, `WPResult`, `PlanDocument` TypedDicts |
+| `compiler.py` | `compile_plan` — topological sort, issue body generation, milestone definitions, plan artifacts |
+| `consolidation.py` | `consolidate_wps` — post-elaboration WP consolidation: reads manifests, merges trivial WPs, rewrites dep IDs |
+
+## Architecture Notes
+
+The planner operates on JSON manifest files written to `.autoskillit/temp/` and does not
+import from `server/` or `recipe/`. `validation.py` performs a DAG cycle check before any
+compilation proceeds. `consolidation.py` runs as a post-pass after all elaboration phases
+complete.

--- a/src/autoskillit/recipe/CLAUDE.md
+++ b/src/autoskillit/recipe/CLAUDE.md
@@ -1,0 +1,40 @@
+# recipe/
+
+IL-2 recipe layer — YAML schema, validation, semantic rules, dataflow analysis.
+Sub-package: rules/ (see rules/CLAUDE.md).
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `__init__.py` | Re-exports `load_recipe`, `validate_recipe`, `analyze_dataflow` |
+| `contracts.py` | Contract card generation + staleness triage |
+| `io.py` | `load_recipe`, `list_recipes`, `iter_steps_with_context` |
+| `order.py` | `BUNDLED_RECIPE_ORDER` — stable display order registry for Group 0 recipes |
+| `loader.py` | Path-based recipe metadata utilities |
+| `_api.py` | Orchestration API |
+| `_cmd_rpc.py` | `run_python` callables for externalized recipe cmd scripts |
+| `_recipe_ingredients.py` | `format_ingredients_table` + `LoadRecipeResult` TypedDicts |
+| `_recipe_composition.py` | `_build_active_recipe` + sub-recipe merging |
+| `diagrams.py` | Flow diagram generation + staleness detection |
+| `experiment_type_registry.py` | `ExperimentTypeSpec`, `load_all_experiment_types` |
+| `registry.py` | `RuleFinding`, `RuleSpec`, `semantic_rule` decorator |
+| `repository.py` | `RecipeRepository` implementation |
+| `_analysis.py` | `ValidationContext` + `make_validation_context` |
+| `_analysis_graph.py` | `RouteEdge` + `build_recipe_graph` + step graph primitives |
+| `_analysis_bfs.py` | `bfs_reachable` + symbolic BFS fact propagation |
+| `_analysis_blocks.py` | `extract_blocks` — group steps by block annotation |
+| `_analysis_detectors.py` | Dead outputs + ref invalidations + implicit handoffs |
+| `_git_helpers.py` | Shared git-remote regex (`_GIT_REMOTE_COMMAND_RE`, `_LITERAL_ORIGIN_RE`) for lint rules |
+| `_skill_helpers.py` | Shared helpers for skill-related semantic rules |
+| `_skill_placeholder_parser.py` | Bash placeholder extraction from SKILL.md |
+| `identity.py` | Recipe identity hashing — content and composite fingerprints |
+| `schema.py` | `Recipe`, `RecipeStep`, `DataFlowWarning` |
+| `staleness_cache.py` | Staleness cache for contract and diagram freshness checks |
+| `validator.py` | `validate_recipe`, `analyze_dataflow` |
+
+## Architecture Notes
+
+`registry.py` uses the `@semantic_rule` decorator pattern (same side-effect registration
+as `rules/`). The `_analysis_*.py` modules form an internal BFS-based dataflow analysis
+pipeline; callers use `make_validation_context` as the sole entry point.

--- a/src/autoskillit/server/CLAUDE.md
+++ b/src/autoskillit/server/CLAUDE.md
@@ -1,4 +1,24 @@
-# Server Layer Rules
+# server/
+
+IL-3 FastMCP server — MCP tools, kitchen gating, session-type dispatch.
+Sub-package: tools/ (see tools/CLAUDE.md).
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `__init__.py` | Re-exports `mcp`, `ToolContext`, `make_context`; applies `mcp.disable(tags={'kitchen'})` at import |
+| `_editable_guard.py` | Pre-deletion editable install guard for `perform_merge()` — scans site-packages for PEP 610 direct_url.json links into the worktree |
+| `_factory.py` | Composition root — `make_context()` is the sole legal instantiation point for all 22 service contracts |
+| `_guards.py` | Orchestration-level gate functions for MCP tool access control |
+| `_lifespan.py` | FastMCP lifespan context manager — deferred startup (recovery, audit loading, stale cleanup, drift check) |
+| `_misc.py` | Quota, hook-config, triage, and miscellaneous server utilities; re-exports selected execution/workspace symbols for tools |
+| `_notify.py` | MCP notification dispatch and response-size tracking |
+| `_session_type.py` | Session-type tag visibility dispatcher — controls which tools are visible per session type |
+| `_state.py` | Mutable singleton state and context accessor functions (`_ctx` sentinel, `get_ctx`, `set_ctx`) |
+| `_subprocess.py` | Subprocess execution helpers for MCP tools |
+| `_wire_compat.py` | Wire-format compatibility middleware — strips `outputSchema`/`title` fields to work around Claude Code bug #25081 |
+| `git.py` | Git merge workflow for `merge_worktree` — path validation, branch detection, test gate, fetch, rebase, merge, cleanup |
 
 ## readOnlyHint: All MCP tools MUST have `readOnlyHint: True`
 

--- a/src/autoskillit/workspace/CLAUDE.md
+++ b/src/autoskillit/workspace/CLAUDE.md
@@ -1,0 +1,24 @@
+# workspace/
+
+IL-1 workspace management — clone lifecycle, worktrees, skill resolution.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `__init__.py` | Re-exports `DefaultCloneManager`, `SkillResolver`, `DefaultSessionSkillManager` |
+| `cleanup.py` | `CleanupResult`, preserve list |
+| `clone.py` | `clone_repo` + `push_to_remote` + `DefaultCloneManager` |
+| `_clone_detect.py` | `detect_*` helpers + `RUNS_DIR` + `classify_remote_url` |
+| `_clone_remote.py` | `CloneSourceResolution` + probe/isolate remotes |
+| `session_skills.py` | Per-session ephemeral skill dirs; subset filtering |
+| `clone_registry.py` | Shared file-based coordination for deferred cleanup |
+| `skills.py` | `SkillResolver` — bundled skill listing |
+| `worktree.py` | Git worktree creation and teardown helpers |
+
+## Architecture Notes
+
+Clone paths live under `RUNS_DIR` (resolved by `_clone_detect.py`). `clone_registry.py`
+coordinates deferred cleanup across concurrent pipeline sessions using file-based locking.
+`session_skills.py` builds per-session ephemeral copies of the bundled skill set so that
+headless sessions can use a filtered subset without polluting the installed package.

--- a/tests/docs/test_sub_claude_md_completeness.py
+++ b/tests/docs/test_sub_claude_md_completeness.py
@@ -10,6 +10,7 @@ pytestmark = pytest.mark.small
 SRC_ROOT = Path(__file__).resolve().parents[2] / "src" / "autoskillit"
 
 EXPECTED_SUB_CLAUDE_MDS = [
+    # existing 15 (unchanged order)
     "core/types/CLAUDE.md",
     "core/runtime/CLAUDE.md",
     "execution/headless/CLAUDE.md",
@@ -25,10 +26,23 @@ EXPECTED_SUB_CLAUDE_MDS = [
     "cli/update/CLAUDE.md",
     "hooks/guards/CLAUDE.md",
     "hooks/formatters/CLAUDE.md",
+    # 12 new entries
+    "CLAUDE.md",  # src/autoskillit/ package root
+    "core/CLAUDE.md",
+    "config/CLAUDE.md",
+    "pipeline/CLAUDE.md",
+    "execution/CLAUDE.md",
+    "workspace/CLAUDE.md",
+    "planner/CLAUDE.md",
+    "recipe/CLAUDE.md",
+    "migration/CLAUDE.md",
+    "fleet/CLAUDE.md",
+    "cli/CLAUDE.md",
+    "hooks/CLAUDE.md",
 ]
 
 
-def test_all_15_sub_claude_md_files_exist():
+def test_all_27_sub_claude_md_files_exist():
     missing = [p for p in EXPECTED_SUB_CLAUDE_MDS if not (SRC_ROOT / p).is_file()]
     assert not missing, f"Missing sub-CLAUDE.md files: {missing}"
 

--- a/tests/docs/test_sub_claude_md_completeness.py
+++ b/tests/docs/test_sub_claude_md_completeness.py
@@ -33,11 +33,17 @@ EXPECTED_SUB_CLAUDE_MDS = [
     "pipeline/CLAUDE.md",
     "execution/CLAUDE.md",
     "workspace/CLAUDE.md",
-    # Part B entries (planner, recipe, migration, fleet, cli, hooks) added when Part B lands
+    # 6 new entries (Part B)
+    "planner/CLAUDE.md",
+    "recipe/CLAUDE.md",
+    "migration/CLAUDE.md",
+    "fleet/CLAUDE.md",
+    "cli/CLAUDE.md",
+    "hooks/CLAUDE.md",
 ]
 
 
-def test_all_21_sub_claude_md_files_exist():
+def test_all_27_sub_claude_md_files_exist():
     missing = [p for p in EXPECTED_SUB_CLAUDE_MDS if not (SRC_ROOT / p).is_file()]
     assert not missing, f"Missing sub-CLAUDE.md files: {missing}"
 

--- a/tests/docs/test_sub_claude_md_completeness.py
+++ b/tests/docs/test_sub_claude_md_completeness.py
@@ -26,23 +26,18 @@ EXPECTED_SUB_CLAUDE_MDS = [
     "cli/update/CLAUDE.md",
     "hooks/guards/CLAUDE.md",
     "hooks/formatters/CLAUDE.md",
-    # 12 new entries
+    # 6 new entries (Part A)
     "CLAUDE.md",  # src/autoskillit/ package root
     "core/CLAUDE.md",
     "config/CLAUDE.md",
     "pipeline/CLAUDE.md",
     "execution/CLAUDE.md",
     "workspace/CLAUDE.md",
-    "planner/CLAUDE.md",
-    "recipe/CLAUDE.md",
-    "migration/CLAUDE.md",
-    "fleet/CLAUDE.md",
-    "cli/CLAUDE.md",
-    "hooks/CLAUDE.md",
+    # Part B entries (planner, recipe, migration, fleet, cli, hooks) added when Part B lands
 ]
 
 
-def test_all_27_sub_claude_md_files_exist():
+def test_all_21_sub_claude_md_files_exist():
     missing = [p for p in EXPECTED_SUB_CLAUDE_MDS if not (SRC_ROOT / p).is_file()]
     assert not missing, f"Missing sub-CLAUDE.md files: {missing}"
 

--- a/tests/docs/test_sub_claude_md_completeness.py
+++ b/tests/docs/test_sub_claude_md_completeness.py
@@ -10,7 +10,6 @@ pytestmark = pytest.mark.small
 SRC_ROOT = Path(__file__).resolve().parents[2] / "src" / "autoskillit"
 
 EXPECTED_SUB_CLAUDE_MDS = [
-    # existing 15 (unchanged order)
     "core/types/CLAUDE.md",
     "core/runtime/CLAUDE.md",
     "execution/headless/CLAUDE.md",
@@ -26,14 +25,12 @@ EXPECTED_SUB_CLAUDE_MDS = [
     "cli/update/CLAUDE.md",
     "hooks/guards/CLAUDE.md",
     "hooks/formatters/CLAUDE.md",
-    # 6 new entries (Part A)
     "CLAUDE.md",  # src/autoskillit/ package root
     "core/CLAUDE.md",
     "config/CLAUDE.md",
     "pipeline/CLAUDE.md",
     "execution/CLAUDE.md",
     "workspace/CLAUDE.md",
-    # 6 new entries (Part B)
     "planner/CLAUDE.md",
     "recipe/CLAUDE.md",
     "migration/CLAUDE.md",

--- a/tests/docs/test_sub_claude_md_completeness.py
+++ b/tests/docs/test_sub_claude_md_completeness.py
@@ -44,6 +44,12 @@ EXPECTED_SUB_CLAUDE_MDS = [
 
 
 def test_all_27_sub_claude_md_files_exist():
+    assert len(EXPECTED_SUB_CLAUDE_MDS) == 27, (
+        f"Expected 27 entries, got {len(EXPECTED_SUB_CLAUDE_MDS)}"
+    )
+    assert len(EXPECTED_SUB_CLAUDE_MDS) == len(set(EXPECTED_SUB_CLAUDE_MDS)), (
+        "Duplicate entries in EXPECTED_SUB_CLAUDE_MDS"
+    )
     missing = [p for p in EXPECTED_SUB_CLAUDE_MDS if not (SRC_ROOT / p).is_file()]
     assert not missing, f"Missing sub-CLAUDE.md files: {missing}"
 


### PR DESCRIPTION
## Summary

The root `CLAUDE.md` is 349 lines (≈6,200 tokens). Section 6 (Architecture) consumes
228 lines (62%) because it lists 197 individual `.py` files inline. The fix: move
file-level detail into per-package subdirectory CLAUDE.md files that Claude Code loads
on demand, and collapse Section 6 to a ~35-line package-level table.

**Part A covers:** test expansion (Step 1) + creating 6 of the 12 new CLAUDE.md files
(Steps 2–7: `autoskillit/CLAUDE.md`, `core/CLAUDE.md`, `config/CLAUDE.md`,
`pipeline/CLAUDE.md`, `execution/CLAUDE.md`, `workspace/CLAUDE.md`).

Part B covers Steps 8–15: `planner/CLAUDE.md`, `recipe/CLAUDE.md`, `migration/CLAUDE.md`,
`fleet/CLAUDE.md`, `cli/CLAUDE.md`, `hooks/CLAUDE.md`, root CLAUDE.md Section 6
replacement, and final test run — implement as a separate task.

Closes #1928

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260505-103704-069576/.autoskillit/temp/make-plan/reorganize_claude_md_plan_2026-05-05_000000_part_a.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 2.6k | 36.1k | 1.2M | 95.1k | 75 | 82.2k | 15m 7s |
| verify | 2 | 400 | 27.7k | 2.4M | 66.8k | 138 | 92.6k | 7m 52s |
| implement | 2 | 292 | 20.3k | 1.5M | 66.3k | 115 | 101.7k | 7m 1s |
| prepare_pr | 1 | 60 | 4.6k | 182.6k | 35.6k | 16 | 23.4k | 1m 34s |
| compose_pr | 1 | 59 | 2.6k | 160.4k | 26.6k | 15 | 13.6k | 59s |
| review_pr | 2 | 260 | 67.1k | 1.5M | 85.8k | 107 | 147.7k | 20m 18s |
| resolve_review | 2 | 532 | 36.4k | 3.0M | 81.6k | 158 | 122.5k | 13m 59s |
| ci_conflict_fix | 2 | 276 | 18.7k | 1.3M | 66.6k | 83 | 76.7k | 7m 15s |
| diagnose_ci | 1 | 84 | 2.7k | 297.3k | 40.5k | 22 | 28.2k | 1m 33s |
| resolve_ci | 1 | 134 | 5.1k | 590.8k | 46.8k | 41 | 34.9k | 4m 39s |
| **Total** | | 4.7k | 221.3k | 12.2M | 95.1k | | 723.5k | 1h 20m |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 568 | 2618.6 | 179.0 | 35.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 13 | 232855.9 | 9426.5 | 2802.9 |
| ci_conflict_fix | 2223 | 578.7 | 34.5 | 8.4 |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 1 | 590761.0 | 34890.0 | 5102.0 |
| **Total** | **2805** | 4357.4 | 257.9 | 78.9 |