### PR TITLE
Restructure Headless Prompt to Prevent Skill Tool Bypass

### DIFF
--- a/src/autoskillit/execution/commands.py
+++ b/src/autoskillit/execution/commands.py
@@ -219,7 +219,7 @@ def build_headless_resume_cmd(
     return ClaudeHeadlessCmd(cmd=cmd, env=build_claude_env(extras=merged))
 
 
-def _ensure_skill_prefix(skill_command: str) -> str:
+def _ensure_skill_prefix(skill_command: str, *, provider_profile: str = "") -> str:
     """Prompt-formatting helper: wrap slash-commands for headless session loading.
 
     Transforms `/foo args` into `Use the /foo skill args` so non-Claude models
@@ -236,6 +236,15 @@ def _ensure_skill_prefix(skill_command: str) -> str:
         formatted = f"Use the {slash_cmd} skill"
         if rest:
             formatted += f" {rest}"
+        if provider_profile:
+            skill_name = extract_skill_name(stripped) or slash_cmd.lstrip("/")
+            formatted = (
+                f"FIRST ACTION: Your first action should be to load the skill instructions "
+                f'by calling the Skill tool with skill="{skill_name}". '
+                f"If the Skill tool is unavailable or returns an error, read the skill "
+                f"instructions from the skill's SKILL.md file instead.\n\n"
+                f"{formatted}"
+            )
         return formatted
     return skill_command
 
@@ -265,7 +274,7 @@ def _inject_cwd_anchor(skill_command: str, cwd: str, temp_dir_relpath: str | Non
     return skill_command + directive
 
 
-def _inject_narration_suppression(skill_command: str) -> str:
+def _inject_narration_suppression(skill_command: str, *, has_skill_prefix: bool = False) -> str:
     """Append an efficiency directive to suppress inter-tool narration.
 
     Targets prose status text and phase announcements emitted between tool
@@ -273,8 +282,9 @@ def _inject_narration_suppression(skill_command: str) -> str:
     long-running sessions. Does NOT suppress the final response, which is
     where structured output tokens (worktree_path, plan_path, etc.) live.
     """
+    opener = "After loading the skill instructions, d" if has_skill_prefix else "D"
     directive = (
-        "\n\nEFFICIENCY DIRECTIVE: Do NOT output prose status text, phase "
+        f"\n\nEFFICIENCY DIRECTIVE: {opener}o NOT output prose status text, phase "
         "announcements, or progress summaries between tool calls. Every "
         "non-final assistant turn MUST invoke at least one tool. The only "
         "permitted text-only turn is the final response required by the "
@@ -376,14 +386,17 @@ def build_skill_session_cmd(
             )
         )
     else:
+        _has_prefix = bool(profile_name) and skill_command.strip().startswith("/")
         prompt = _inject_narration_suppression(
             _inject_cwd_anchor(
                 _inject_completion_directive(
-                    _ensure_skill_prefix(skill_command), completion_marker
+                    _ensure_skill_prefix(skill_command, provider_profile=profile_name or ""),
+                    completion_marker,
                 ),
                 cwd,
                 temp_dir_relpath=temp_dir_relpath,
-            )
+            ),
+            has_skill_prefix=_has_prefix,
         )
     extras: dict[str, str] = {
         "AUTOSKILLIT_HEADLESS": "1",

--- a/tests/execution/test_commands.py
+++ b/tests/execution/test_commands.py
@@ -498,6 +498,31 @@ class TestBuildSkillSessionCmd:
         spec = build_skill_session_cmd("/investigate foo", **self.BASE, profile_name="")
         assert "AUTOSKILLIT_PROVIDER_PROFILE" not in spec.env
 
+    def test_no_first_action_without_profile_name(self):
+        spec = build_skill_session_cmd("/investigate foo", **self.BASE)
+        prompt = spec.cmd[spec.cmd.index("-p") + 1]
+        assert "FIRST ACTION" not in prompt
+        assert "After loading" not in prompt
+
+    def test_first_action_with_profile_name(self):
+        spec = build_skill_session_cmd(
+            "/autoskillit:investigate foo", **self.BASE, profile_name="minimax"
+        )
+        prompt = spec.cmd[spec.cmd.index("-p") + 1]
+        assert "FIRST ACTION" in prompt
+        assert "After loading the skill instructions" in prompt
+
+    def test_after_loading_only_with_profile_name(self):
+        spec = build_skill_session_cmd("/investigate foo", **self.BASE, profile_name="")
+        prompt = spec.cmd[spec.cmd.index("-p") + 1]
+        assert "After loading" not in prompt
+
+    def test_no_after_loading_for_plain_prompt_with_profile(self):
+        spec = build_skill_session_cmd("Fix the bug", **self.BASE, profile_name="minimax")
+        prompt = spec.cmd[spec.cmd.index("-p") + 1]
+        assert "FIRST ACTION" not in prompt
+        assert "After loading" not in prompt
+
 
 class TestBuildFoodTruckCmd:
     BASE = dict(
@@ -640,6 +665,17 @@ class TestBuildFoodTruckCmd:
         monkeypatch.setenv("CLAUDE_CODE_SSE_PORT", "23270")
         spec = build_food_truck_cmd(**self.BASE)
         assert "CLAUDE_CODE_SSE_PORT" not in spec.env
+
+    def test_no_first_action_in_food_truck(self):
+        spec = build_food_truck_cmd(
+            orchestrator_prompt="Run the campaign",
+            plugin_source=DirectInstall(plugin_dir=Path("/plugins")),
+            cwd="/repo",
+            completion_marker="DONE",
+        )
+        prompt = spec.cmd[spec.cmd.index("-p") + 1]
+        assert "FIRST ACTION" not in prompt
+        assert "After loading" not in prompt
 
 
 class TestBuildFoodTruckCmdPackTags:

--- a/tests/execution/test_headless_core.py
+++ b/tests/execution/test_headless_core.py
@@ -854,6 +854,39 @@ class TestEnsureSkillPrefix:
     def test_bare_slash_command_no_args(self):
         assert _ensure_skill_prefix("/investigate") == "Use the /investigate skill"
 
+    def test_no_first_action_without_provider_profile(self):
+        result = _ensure_skill_prefix("/investigate error")
+        assert "FIRST ACTION" not in result
+
+    def test_no_first_action_with_empty_provider_profile(self):
+        result = _ensure_skill_prefix("/investigate error", provider_profile="")
+        assert "FIRST ACTION" not in result
+
+    def test_first_action_prepended_for_non_anthropic_provider(self):
+        result = _ensure_skill_prefix(
+            "/autoskillit:implement-worktree-no-merge /path", provider_profile="minimax"
+        )
+        assert result.startswith("FIRST ACTION:")
+        assert 'skill="implement-worktree-no-merge"' in result
+
+    def test_first_action_includes_fallback(self):
+        result = _ensure_skill_prefix("/autoskillit:investigate error", provider_profile="minimax")
+        assert "SKILL.md" in result
+
+    def test_first_action_uses_extract_skill_name(self):
+        result = _ensure_skill_prefix("/autoskillit:make-plan task", provider_profile="minimax")
+        assert 'skill="make-plan"' in result
+        assert "autoskillit:" not in result.split('"')[1]
+
+    def test_first_action_preserves_use_the_line(self):
+        result = _ensure_skill_prefix("/investigate error", provider_profile="minimax")
+        assert "Use the /investigate skill error" in result
+
+    def test_plain_prompt_unchanged_with_provider_profile(self):
+        result = _ensure_skill_prefix("Fix the bug", provider_profile="minimax")
+        assert "FIRST ACTION" not in result
+        assert result == "Fix the bug"
+
 
 class TestStalenessReturnsNeedsRetry:
     """Stale SubprocessResult triggers needs_retry response."""
@@ -2545,3 +2578,28 @@ class TestInjectNarrationSuppression:
         result = _inject_narration_suppression("cmd")
         # Must not suppress the final response where structured output tokens live
         assert "final response" in result
+
+    def test_no_after_loading_by_default(self):
+        from autoskillit.execution.commands import _inject_narration_suppression
+
+        result = _inject_narration_suppression("cmd")
+        assert "After loading" not in result
+
+    def test_no_after_loading_when_false(self):
+        from autoskillit.execution.commands import _inject_narration_suppression
+
+        result = _inject_narration_suppression("cmd", has_skill_prefix=False)
+        assert "After loading" not in result
+
+    def test_after_loading_when_has_skill_prefix(self):
+        from autoskillit.execution.commands import _inject_narration_suppression
+
+        result = _inject_narration_suppression("cmd", has_skill_prefix=True)
+        assert "After loading the skill instructions" in result
+
+    def test_still_contains_efficiency_directive_with_prefix(self):
+        from autoskillit.execution.commands import _inject_narration_suppression
+
+        result = _inject_narration_suppression("cmd", has_skill_prefix=True)
+        assert "EFFICIENCY DIRECTIVE" in result
+        assert "between tool calls" in result


### PR DESCRIPTION
## Summary

Restructure the headless `run_skill` prompt assembly in `src/autoskillit/execution/commands.py` to prevent non-Anthropic models from skipping the Skill tool. Three coordinated changes — all gated on `provider_profile` being non-empty so Claude sessions are unaffected:

1. Add a "FIRST ACTION" soft directive with fallback in `_ensure_skill_prefix()` for non-Anthropic providers
2. Conditionally subordinate the EFFICIENCY DIRECTIVE to skill loading via a `has_skill_prefix` parameter on `_inject_narration_suppression()`
3. Thread `profile_name` through the prompt assembly chain in `build_skill_session_cmd()`

Closes #1936

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260505-121335-295237/.autoskillit/temp/make-plan/restructure_headless_prompt_skill_bypass_plan_2026-05-05_121600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 51 | 7.4k | 667.9k | 58.4k | 49 | 49.8k | 6m 29s |
| verify | 1 | 16.0k | 9.7k | 1.1M | 82.6k | 94 | 69.4k | 5m 50s |
| implement | 1 | 34 | 8.0k | 616.3k | 65.2k | 52 | 63.2k | 6m 47s |
| prepare_pr | 1 | 24 | 3.0k | 176.5k | 37.1k | 16 | 25.4k | 1m 5s |
| compose_pr | 1 | 22 | 1.4k | 124.1k | 29.3k | 10 | 16.1k | 49s |
| review_pr | 1 | 37 | 12.8k | 414.9k | 57.3k | 29 | 44.4k | 3m 57s |
| **Total** | | 16.2k | 42.3k | 3.1M | 82.6k | | 268.4k | 24m 59s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 117 | 5267.9 | 540.3 | 68.2 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **117** | 26405.2 | 2293.7 | 361.5 |