### PR TITLE
Implementation Plan: Rename vis-lens-domain-norms → vis-lens-methodology-norms

### DIFF
--- a/docs/skills/catalog.md
+++ b/docs/skills/catalog.md
@@ -109,7 +109,7 @@ figure set:
 | 1 | `vis-lens-always-on` | Composite | Is everything correct by default? | P0 |
 | 2 | `vis-lens-antipattern` | Diagnostic | What visualization antipatterns are present? | P0 |
 | 3 | `vis-lens-chart-select` | Typological | What chart type fits this data shape? | P0 |
-| 4 | `vis-lens-domain-norms` | Normative | Does the figure follow domain conventions? | P0 |
+| 4 | `vis-lens-methodology-norms` | Normative | Does the figure follow methodology-tradition conventions? | P0 |
 | 5 | `vis-lens-uncertainty` | Probabilistic | Is uncertainty properly communicated? | P0 |
 | 6 | `vis-lens-color-access` | Chromatic | Is the color encoding accessible and perceptually uniform? | P1 |
 | 7 | `vis-lens-figure-table` | Decisional | Should this result be a figure or a table? | P1 |

--- a/src/autoskillit/config/defaults.yaml
+++ b/src/autoskillit/config/defaults.yaml
@@ -211,7 +211,7 @@ skills:
     - vis-lens-antipattern
     - vis-lens-chart-select
     - vis-lens-color-access
-    - vis-lens-domain-norms
+    - vis-lens-methodology-norms
     - vis-lens-figure-table
     - vis-lens-multi-compare
     - vis-lens-temporal

--- a/src/autoskillit/core/types/_type_constants.py
+++ b/src/autoskillit/core/types/_type_constants.py
@@ -462,6 +462,7 @@ RETIRED_SKILL_NAMES: frozenset[str] = frozenset(
         # DO NOT REMOVE entries — this registry is append-only.
         "open-research-pr",  # Retired; replaced by decomposed skills
         "sprint-planner",  # Retired; no replacement
+        "vis-lens-domain-norms",  # Retired; renamed to vis-lens-methodology-norms
     }
 )
 

--- a/src/autoskillit/recipe/skill_contracts.yaml
+++ b/src/autoskillit/recipe/skill_contracts.yaml
@@ -1584,7 +1584,7 @@ skills:
     pattern_examples:
     - "diagram_path = /tmp/diagram.md\n%%ORDER_UP%%"
 
-  vis-lens-domain-norms:
+  vis-lens-methodology-norms:
     inputs:
     - name: context_path
       type: file_path

--- a/src/autoskillit/skills_extended/plan-visualization/SKILL.md
+++ b/src/autoskillit/skills_extended/plan-visualization/SKILL.md
@@ -90,8 +90,8 @@ Cap Tier B at 2 lenses total (overrides count toward this cap).
 **Tier C (0–1 based on target_domain):**
 | target_domain | Lens |
 |---|---|
-| nlp | vis-lens-domain-norms |
-| cv | vis-lens-domain-norms |
+| nlp | vis-lens-methodology-norms |
+| cv | vis-lens-methodology-norms |
 | rl | vis-lens-temporal |
 | (others / general) | — (skip Tier C) |
 
@@ -157,14 +157,14 @@ For each figure-spec block where two lenses disagree on chart type, color encodi
 or layout, apply the conflict resolution hierarchy:
 
 ```
-accessibility > anti-pattern > domain-norms > chart-select
+accessibility > anti-pattern > methodology-norms > chart-select
 ```
 
 Resolution rules:
 - `accessibility` (from `vis-lens-always-on` or `vis-lens-color-access`) wins over all
 - `anti-pattern` findings (from `vis-lens-antipattern` or always-on pass 1) override
-  chart-select and domain-norms recommendations
-- `domain-norms` (from `vis-lens-domain-norms`) overrides `chart-select`
+  chart-select and methodology-norms recommendations
+- `methodology-norms` (from `vis-lens-methodology-norms`) overrides `chart-select`
 - `chart-select` (from `vis-lens-chart-select`) is the lowest priority
 
 Every resolution must be logged as a row in the Conflict Resolution Log table.

--- a/src/autoskillit/skills_extended/vis-lens-methodology-norms/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-methodology-norms/SKILL.md
@@ -2,7 +2,7 @@
 name: vis-lens-methodology-norms
 categories: [vis-lens]
 activate_deps: [mermaid]
-description: "Create Domain Norms visualization planning spec showing ML sub-area mandatory figures, community conventions, and coverage gaps. Domain-Normative lens answering \"Which domain-specific figures are expected by reviewers?\""
+description: "Create Methodology Norms visualization planning spec showing ML sub-area mandatory figures, community conventions, and coverage gaps. Methodology-Normative lens answering \"Which domain-specific figures are expected by reviewers?\""
 hooks:
   PreToolUse:
     - matcher: "*"

--- a/src/autoskillit/skills_extended/vis-lens-methodology-norms/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-methodology-norms/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: vis-lens-domain-norms
+name: vis-lens-methodology-norms
 categories: [vis-lens]
 activate_deps: [mermaid]
 description: "Create Domain Norms visualization planning spec showing ML sub-area mandatory figures, community conventions, and coverage gaps. Domain-Normative lens answering \"Which domain-specific figures are expected by reviewers?\""
@@ -20,7 +20,7 @@ hooks:
 
 ## Arguments
 
-`/autoskillit:vis-lens-domain-norms [context_path] [experiment_plan_path]`
+`/autoskillit:vis-lens-methodology-norms [context_path] [experiment_plan_path]`
 
 - **context_path** (optional positional arg 1) — Absolute path to a lens context file
   containing IV/DV tables, H0/H1 hypotheses, controlled variables, and success criteria.
@@ -36,7 +36,7 @@ hooks:
 - Auditing a figure plan against community norms for the ML sub-area
 - Identifying missing mandatory figures before the camera-ready deadline
 - Onboarding to a new ML sub-area and learning its visualization conventions
-- User invokes `/autoskillit:vis-lens-domain-norms`
+- User invokes `/autoskillit:vis-lens-methodology-norms`
 
 ## ML Sub-Area Mandatory Figures
 
@@ -54,7 +54,7 @@ hooks:
 ## Extensibility
 
 This lens currently covers 8 ML sub-areas. Future domain-specific variants (e.g.,
-`vis-lens-domain-norms-cv`, `vis-lens-domain-norms-rl`) may extend this catalog with
+`vis-lens-methodology-norms-cv`, `vis-lens-methodology-norms-rl`) may extend this catalog with
 venue-specific norms, additional mandatory figure types, or sub-area-specific anti-pattern
 overlays. The base lens should remain general enough to bootstrap any sub-area.
 
@@ -63,7 +63,7 @@ overlays. The base lens should remain general enough to bootstrap any sub-area.
 **NEVER:**
 - Modify any source code files
 - Do not litter the codebase with useless comments, TODO markers, or explanatory annotations — the skill output and diagram speak for themselves
-- Create files outside `{{AUTOSKILLIT_TEMP}}/vis-lens-domain-norms/`
+- Create files outside `{{AUTOSKILLIT_TEMP}}/vis-lens-methodology-norms/`
 - Declare a figure "present" if it exists only in code but is not yet generated — coverage requires the actual output file or a concrete plan entry
 
 **ALWAYS:**
@@ -72,12 +72,12 @@ overlays. The base lens should remain general enough to bootstrap any sub-area.
 - Sort the gap list absent-first, then partial
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
 - If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
-- Write output to `{{AUTOSKILLIT_TEMP}}/vis-lens-domain-norms/vis_spec_domain_norms_{YYYY-MM-DD_HHMMSS}.md` (relative to the current working directory)
+- Write output to `{{AUTOSKILLIT_TEMP}}/vis-lens-methodology-norms/vis_spec_domain_norms_{YYYY-MM-DD_HHMMSS}.md` (relative to the current working directory)
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):
 
   ```
-  diagram_path = /absolute/path/to/{{AUTOSKILLIT_TEMP}}/vis-lens-domain-norms/vis_spec_domain_norms_{...}.md
+  diagram_path = /absolute/path/to/{{AUTOSKILLIT_TEMP}}/vis-lens-methodology-norms/vis_spec_domain_norms_{...}.md
   ```
 
 ---
@@ -209,7 +209,7 @@ priority: "P0"
 placement_tier: "main"
 conflicts: []
 metadata:
-  created_by: "vis-lens-domain-norms"
+  created_by: "vis-lens-methodology-norms"
   reviewed_by: ""
   last_updated: "{YYYY-MM-DD}"
 ```

--- a/src/autoskillit/skills_extended/vis-lens-methodology-norms/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-methodology-norms/SKILL.md
@@ -72,12 +72,12 @@ overlays. The base lens should remain general enough to bootstrap any sub-area.
 - Sort the gap list absent-first, then partial
 - BEFORE creating any diagram, LOAD the `/autoskillit:mermaid` skill using the Skill tool - this is MANDATORY
 - If the Skill tool cannot be used (disable-model-invocation) or refuses this invocation, do NOT proceed with diagram creation. Abort this step and omit the diagram from output.
-- Write output to `{{AUTOSKILLIT_TEMP}}/vis-lens-methodology-norms/vis_spec_domain_norms_{YYYY-MM-DD_HHMMSS}.md` (relative to the current working directory)
+- Write output to `{{AUTOSKILLIT_TEMP}}/vis-lens-methodology-norms/vis_spec_methodology_norms_{YYYY-MM-DD_HHMMSS}.md` (relative to the current working directory)
 - After writing the file, emit the structured output token as **literal plain text** with no
   markdown formatting on the token name (the adjudicator performs a regex match):
 
   ```
-  diagram_path = /absolute/path/to/{{AUTOSKILLIT_TEMP}}/vis-lens-methodology-norms/vis_spec_domain_norms_{...}.md
+  diagram_path = /absolute/path/to/{{AUTOSKILLIT_TEMP}}/vis-lens-methodology-norms/vis_spec_methodology_norms_{...}.md
   ```
 
 ---

--- a/src/autoskillit/skills_extended/write-recipe/SKILL.md
+++ b/src/autoskillit/skills_extended/write-recipe/SKILL.md
@@ -256,7 +256,7 @@ resolve-claims-review, resolve-design-review, resolve-failures, resolve-merge-co
 scope, setup-project, smoke-task, stage-data, triage-issues, troubleshoot-experiment,
 validate-audit, verify-diag,
 vis-lens-always-on, vis-lens-antipattern, vis-lens-caption-annot, vis-lens-chart-select,
-vis-lens-color-access, vis-lens-domain-norms, vis-lens-figure-table, vis-lens-multi-compare,
+vis-lens-color-access, vis-lens-methodology-norms, vis-lens-figure-table, vis-lens-multi-compare,
 vis-lens-reproducibility, vis-lens-story-arc, vis-lens-temporal, vis-lens-uncertainty,
 generate-report, write-recipe
 

--- a/tests/skills/test_skill_output_compliance.py
+++ b/tests/skills/test_skill_output_compliance.py
@@ -313,7 +313,7 @@ PATH_CAPTURE_SKILLS: dict[str, list[str]] = {
     "vis-lens-caption-annot": ["diagram_path"],
     "vis-lens-chart-select": ["diagram_path"],
     "vis-lens-color-access": ["diagram_path"],
-    "vis-lens-domain-norms": ["diagram_path"],
+    "vis-lens-methodology-norms": ["diagram_path"],
     "vis-lens-figure-table": ["diagram_path"],
     "vis-lens-multi-compare": ["diagram_path"],
     "vis-lens-reproducibility": ["diagram_path"],

--- a/tests/skills/test_vis_lens_structural.py
+++ b/tests/skills/test_vis_lens_structural.py
@@ -13,7 +13,7 @@ VIS_LENS_SLUGS = [
     "chart-select",
     "uncertainty",
     "antipattern",
-    "domain-norms",
+    "methodology-norms",
     "always-on",
     "multi-compare",
     "temporal",

--- a/tests/workspace/test_skills.py
+++ b/tests/workspace/test_skills.py
@@ -139,7 +139,7 @@ BUNDLED_SKILLS = [
     "vis-lens-caption-annot",
     "vis-lens-chart-select",
     "vis-lens-color-access",
-    "vis-lens-domain-norms",
+    "vis-lens-methodology-norms",
     "vis-lens-figure-table",
     "vis-lens-multi-compare",
     "vis-lens-reproducibility",


### PR DESCRIPTION
## Summary

Rename the `vis-lens-domain-norms` skill directory and all internal references to `vis-lens-methodology-norms`. The current name is ambiguous — "domain" implies ML sub-area; the actual axis is methodology tradition (CONSORT, PRISMA, STROBE, etc.). This rename updates the skill directory, SKILL.md frontmatter, skill contracts, config defaults, plan-visualization Tier-C references, documentation, tests, and adds the old slug to `RETIRED_SKILL_NAMES`.

**Files touched:** 10 files + 1 directory rename across 9 locations.

Closes #841

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260505-122550-317133/.autoskillit/temp/make-plan/rename_vis_lens_domain_norms_plan_2026-05-05_123700.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 46 | 6.6k | 396.0k | 84.8k | 93 | 58.0k | 5m 0s |
| verify | 1 | 515 | 5.5k | 575.9k | 50.5k | 41 | 42.3k | 2m 59s |
| implement | 1 | 244 | 10.2k | 1.3M | 54.0k | 89 | 41.7k | 3m 34s |
| prepare_pr | 1 | 68 | 5.1k | 241.8k | 37.6k | 22 | 25.3k | 1m 33s |
| compose_pr | 1 | 51 | 1.8k | 152.2k | 29.6k | 14 | 16.6k | 33s |
| review_pr | 1 | 110 | 32.2k | 586.3k | 73.0k | 42 | 61.6k | 5m 32s |
| resolve_review | 1 | 221 | 9.7k | 1.1M | 55.8k | 60 | 43.2k | 5m 50s |
| **Total** | | 1.3k | 71.2k | 4.3M | 84.8k | | 288.6k | 25m 4s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 41 | 31504.2 | 1017.0 | 249.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 6 | 180187.3 | 7198.3 | 1614.5 |
| **Total** | **47** | 92023.7 | 6140.3 | 1514.6 |