### PR TITLE
Implementation Plan: Remove Tautological Assertions — Callable/Constant Across Test Files

### DIFF
--- a/tests/migration/test_engine.py
+++ b/tests/migration/test_engine.py
@@ -672,9 +672,6 @@ async def test_advisory_dispatch_does_not_write_file(tmp_path: Path) -> None:
 
 
 class TestMigrateRecipesConstant:
-    def test_constant_value(self) -> None:
-        assert MIGRATE_RECIPES_MAX_RETRIES == 3
-
     @pytest.mark.anyio
     async def test_failed_headless_retries_match_constant(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/server/test_guards_module.py
+++ b/tests/server/test_guards_module.py
@@ -1,44 +1,8 @@
-"""Smoke test: all 6 guards are importable from _guards."""
+"""Tests that _guards functions document their orchestration level requirements."""
 
 import pytest
 
 pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
-
-
-def test_require_enabled_importable():
-    from autoskillit.server._guards import _require_enabled
-
-    assert callable(_require_enabled)
-
-
-def test_require_orchestrator_or_higher_importable():
-    from autoskillit.server._guards import _require_orchestrator_or_higher
-
-    assert callable(_require_orchestrator_or_higher)
-
-
-def test_require_orchestrator_exact_importable():
-    from autoskillit.server._guards import _require_orchestrator_exact
-
-    assert callable(_require_orchestrator_exact)
-
-
-def test_require_fleet_importable():
-    from autoskillit.server._guards import _require_fleet
-
-    assert callable(_require_fleet)
-
-
-def test_check_dry_walkthrough_importable():
-    from autoskillit.server._guards import _check_dry_walkthrough
-
-    assert callable(_check_dry_walkthrough)
-
-
-def test_validate_skill_command_importable():
-    from autoskillit.server._guards import _validate_skill_command
-
-    assert callable(_validate_skill_command)
 
 
 def test_require_orchestrator_or_higher_doc_mentions_l1():


### PR DESCRIPTION
## Summary

Two groups of tautological test assertions are validated and confirmed for deletion per
GitHub Issue #1880 (findings C1-1 and C1-5):

- **C1-1** — `tests/server/test_guards_module.py`: Delete six `test_*_importable` functions
  (lines 8–41) that each assert `callable(fn)`. Because the preceding `from ... import fn`
  would raise `ImportError` if the symbol were missing, the import itself is the real
  contract. The `assert callable(fn)` line is permanently True for any successfully imported
  name and tests nothing meaningful. Three substantive docstring-content tests (lines 44–68)
  already import the same symbols and are unaffected. The module docstring was updated to
  reflect the remaining test focus.

- **C1-5** — `tests/migration/test_engine.py`: Delete `test_constant_value` (lines 675–676)
  inside `TestMigrateRecipesConstant`. `assert MIGRATE_RECIPES_MAX_RETRIES == 3` hard-codes
  the constant's value, meaning the test fails only if someone edits BOTH the constant and
  this assertion together — it provides no protection. The behavioral companion
  `test_failed_headless_retries_match_constant` already exercises the same constant by
  verifying that the retry loop runs exactly that many times; it is kept. The class
  `TestMigrateRecipesConstant` remains with the one meaningful test.

Closes #1880

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260505-133103-095611/.autoskillit/temp/make-plan/remove_tautological_assertions_plan_2026-05-05_133200.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 137 | 11.9k | 550.5k | 62.2k | 90 | 36.2k | 5m 46s |
| verify | 1 | 84 | 11.7k | 346.1k | 47.9k | 27 | 38.6k | 3m 5s |
| implement | 1 | 236.8k | 3.3k | 364.8k | 26.7k | 38 | 26.7k | 1m 32s |
| prepare_pr | 1 | 60 | 4.8k | 176.0k | 31.4k | 17 | 19.1k | 1m 21s |
| compose_pr | 1 | 59 | 2.9k | 160.6k | 27.0k | 16 | 14.1k | 48s |
| review_pr | 1 | 108 | 16.4k | 445.9k | 50.0k | 39 | 38.0k | 3m 52s |
| **Total** | | 237.3k | 51.1k | 2.0M | 62.2k | | 172.6k | 16m 25s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 41 | 8896.4 | 651.2 | 80.8 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **41** | 49848.5 | 4208.8 | 1245.5 |