### PR TITLE
Implementation Plan: Trigger-Evaluation Ordering Mechanism (Priority Field)

### DIFF
--- a/src/autoskillit/recipe/__init__.py
+++ b/src/autoskillit/recipe/__init__.py
@@ -38,6 +38,7 @@ from autoskillit.recipe.diagrams import (  # noqa: E402
 )
 from autoskillit.recipe.experiment_type_registry import (  # noqa: E402
     ExperimentTypeSpec,
+    get_experiment_type_by_name,
     load_all_experiment_types,
 )
 from autoskillit.recipe.identity import (  # noqa: E402
@@ -165,6 +166,7 @@ __all__ = [
     "builtin_sub_recipes_dir",
     "find_sub_recipe_by_name",
     "ExperimentTypeSpec",
+    "get_experiment_type_by_name",
     "load_all_experiment_types",
     "check_rerun_detection",
     "find_prior_runs",

--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import threading
 import time
 from collections.abc import Sequence
@@ -102,6 +103,19 @@ def _get_pkg_version() -> str:
     from autoskillit import __version__
 
     return __version__
+
+
+def _compute_registry_hash(experiment_types_dir: Path) -> str:
+    """Compute md5 hash of sorted (path, mtime_ns) pairs for experiment-type YAMLs."""
+    if not experiment_types_dir.exists():
+        return ""
+    entries: list[tuple[str, int]] = []
+    for p in sorted(experiment_types_dir.glob("*.yaml")):
+        try:
+            entries.append((p.name, p.stat().st_mtime_ns))
+        except OSError:
+            continue
+    return hashlib.md5(str(entries).encode()).hexdigest()
 
 
 @_dc
@@ -312,11 +326,20 @@ def load_and_validate(
     pkg_version = _get_pkg_version()
     project_recipes_dir = _pdir / ".autoskillit" / "recipes"
     _builtin_dir = builtin_recipes_dir()
+    from autoskillit.recipe.experiment_type_registry import (  # noqa: PLC0415
+        BUNDLED_EXPERIMENT_TYPES_DIR,
+    )
+
+    _exp_types_hash = _compute_registry_hash(BUNDLED_EXPERIMENT_TYPES_DIR)
+    _user_exp_types_dir = _pdir / ".autoskillit" / "experiment-types"
+    _user_exp_hash = _compute_registry_hash(_user_exp_types_dir)
     cache_key = (
         name,
         str(_pdir),
         tuple(sorted(suppressed)) if suppressed else (),
         tuple(sorted(ingredient_overrides.items())) if ingredient_overrides else (),
+        _exp_types_hash,
+        _user_exp_hash,
     )
 
     with _LOAD_CACHE_LOCK:

--- a/src/autoskillit/recipe/experiment_type_registry.py
+++ b/src/autoskillit/recipe/experiment_type_registry.py
@@ -96,12 +96,15 @@ def _load_types_from_dir(directory: Path) -> dict[str, ExperimentTypeSpec]:
 
 def load_all_experiment_types(
     project_dir: Path | None = None,
-) -> dict[str, ExperimentTypeSpec]:
+) -> list[ExperimentTypeSpec]:
     """Load experiment types: bundled types merged with user-defined overrides.
 
     User-defined types with the same name as a bundled type replace the bundled
     type entirely — no field merging. User-defined types with a new name are added
     alongside bundled types.
+
+    The returned list is sorted by ``(priority, name)`` with ``is_fallback=True``
+    entries always appended last.
 
     Args:
         project_dir: Project root containing optional user-defined overrides at
@@ -109,13 +112,39 @@ def load_all_experiment_types(
             are returned.
 
     Returns:
-        Mapping of experiment type name to ``ExperimentTypeSpec``.
+        Sorted list of ``ExperimentTypeSpec``, fallback entries last.
     """
     types = _load_types_from_dir(BUNDLED_EXPERIMENT_TYPES_DIR)
 
     if project_dir is not None:
         user_dir = Path(project_dir) / ".autoskillit" / "experiment-types"
         user_types = _load_types_from_dir(user_dir)
+        for spec in user_types.values():
+            if spec.schema_version and spec.schema_version != "1.0":
+                logger.warning(
+                    "User experiment type '%s' has schema_version '%s' (expected '1.0'); "
+                    "loading continues but behavior may differ",
+                    spec.name,
+                    spec.schema_version,
+                )
         types.update(user_types)
 
-    return types
+    non_fallback = [s for s in types.values() if not s.is_fallback]
+    fallback = [s for s in types.values() if s.is_fallback]
+    non_fallback.sort(key=lambda s: (s.priority, s.name))
+    fallback.sort(key=lambda s: (s.priority, s.name))
+    return non_fallback + fallback
+
+
+def get_experiment_type_by_name(
+    name: str,
+    project_dir: Path | None = None,
+) -> ExperimentTypeSpec | None:
+    """Look up a single experiment type by name.
+
+    Returns the matching spec or None if not found.
+    """
+    for spec in load_all_experiment_types(project_dir):
+        if spec.name == name:
+            return spec
+    return None

--- a/src/autoskillit/recipe/experiment_type_registry.py
+++ b/src/autoskillit/recipe/experiment_type_registry.py
@@ -122,10 +122,10 @@ def load_all_experiment_types(
         for spec in user_types.values():
             if spec.schema_version and spec.schema_version != "1.0":
                 logger.warning(
-                    "User experiment type '%s' has schema_version '%s' (expected '1.0'); "
-                    "loading continues but behavior may differ",
-                    spec.name,
-                    spec.schema_version,
+                    "User experiment type has schema_version mismatch; loading continues",
+                    type_name=spec.name,
+                    schema_version=spec.schema_version,
+                    expected_schema_version="1.0",
                 )
         types.update(user_types)
 

--- a/tests/recipe/test_api.py
+++ b/tests/recipe/test_api.py
@@ -726,3 +726,22 @@ def test_path_mtime_ns_exists_and_old_helpers_removed() -> None:
     assert not hasattr(api, "_dir_mtime_ns"), "_dir_mtime_ns must be removed"
     assert callable(api._path_mtime_ns), "_path_mtime_ns must be callable"
     assert isinstance(api._path_mtime_ns(Path(".")), int), "_path_mtime_ns must return int"
+
+
+def test_compute_registry_hash_changes_on_mtime(tmp_path: Path) -> None:
+    """Registry hash changes when a YAML file's mtime changes."""
+    import time
+
+    from autoskillit.recipe._api import _compute_registry_hash
+
+    d = tmp_path / "types"
+    d.mkdir()
+    f = d / "test.yaml"
+    f.write_text("name: test\n")
+    h1 = _compute_registry_hash(d)
+
+    time.sleep(0.01)
+    f.write_text("name: test\n")  # same content, new mtime
+    h2 = _compute_registry_hash(d)
+
+    assert h1 != h2

--- a/tests/recipe/test_bundled_recipes_research_design.py
+++ b/tests/recipe/test_bundled_recipes_research_design.py
@@ -24,7 +24,7 @@ class TestResearchDesignRecipeStructure:
         assert recipe.name == "research-design"
 
     def test_autoskillit_version(self, recipe) -> None:
-        assert recipe.version == "0.9.435"
+        assert recipe.version == "0.9.436"
 
     def test_recipe_version(self, recipe) -> None:
         assert recipe.recipe_version == "1.0.0"

--- a/tests/recipe/test_experiment_type_registry.py
+++ b/tests/recipe/test_experiment_type_registry.py
@@ -497,9 +497,9 @@ def test_user_types_interleave_by_priority(tmp_path: Path) -> None:
     assert bench_idx < custom_idx < config_idx
 
 
-def test_schema_mismatch_warns(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+def test_schema_mismatch_warns(tmp_path: Path) -> None:
     """A user type with schema_version != '1.0' triggers a WARNING but still loads."""
-    import logging
+    import structlog.testing
 
     user_dir = tmp_path / ".autoskillit" / "experiment-types"
     user_dir.mkdir(parents=True)
@@ -528,10 +528,10 @@ def test_schema_mismatch_warns(tmp_path: Path, caplog: pytest.LogCaptureFixture)
             }
         )
     )
-    with caplog.at_level(logging.WARNING):
+    with structlog.testing.capture_logs() as cap_logs:
         types = load_all_experiment_types(project_dir=tmp_path)
 
-    assert any("schema_version" in r.message and "2.0" in r.message for r in caplog.records), (
+    assert any(entry.get("schema_version") == "2.0" for entry in cap_logs), (
         "Expected WARNING about schema_version mismatch"
     )
     by_name = {s.name: s for s in types}

--- a/tests/recipe/test_experiment_type_registry.py
+++ b/tests/recipe/test_experiment_type_registry.py
@@ -9,6 +9,7 @@ import yaml
 
 from autoskillit.recipe.experiment_type_registry import (
     ExperimentTypeSpec,
+    get_experiment_type_by_name,
     load_all_experiment_types,
 )
 
@@ -46,63 +47,65 @@ EXPECTED_DIMENSIONS = {
 def test_all_bundled_types_present() -> None:
     """All 12 bundled types load without error."""
     types = load_all_experiment_types()
-    assert set(types.keys()) == EXPECTED_TYPES
+    assert {s.name for s in types} == EXPECTED_TYPES
 
 
 def test_each_type_has_required_fields() -> None:
     """Each type spec has all required fields with correct structure."""
     types = load_all_experiment_types()
-    for name, spec in types.items():
-        assert spec.name == name, f"{name}: spec.name mismatch"
-        assert isinstance(spec.classification_triggers, list), f"{name}: triggers not list"
-        assert len(spec.classification_triggers) >= 1, f"{name}: no triggers"
-        assert isinstance(spec.dimension_weights, dict), f"{name}: weights not dict"
-        assert isinstance(spec.applicable_lenses, dict), f"{name}: lenses not dict"
-        assert isinstance(spec.red_team_focus, dict), f"{name}: red_team_focus not dict"
-        assert isinstance(spec.l1_severity, dict), f"{name}: l1_severity not dict"
+    for spec in types:
+        assert isinstance(spec.classification_triggers, list), f"{spec.name}: triggers not list"
+        assert len(spec.classification_triggers) >= 1, f"{spec.name}: no triggers"
+        assert isinstance(spec.dimension_weights, dict), f"{spec.name}: weights not dict"
+        assert isinstance(spec.applicable_lenses, dict), f"{spec.name}: lenses not dict"
+        assert isinstance(spec.red_team_focus, dict), f"{spec.name}: red_team_focus not dict"
+        assert isinstance(spec.l1_severity, dict), f"{spec.name}: l1_severity not dict"
 
 
 def test_all_weight_values_are_valid() -> None:
     """All dimension_weights values are one of H, M, L, S."""
     types = load_all_experiment_types()
-    for name, spec in types.items():
+    for spec in types:
         for dim, weight in spec.dimension_weights.items():
             assert weight in VALID_WEIGHT_VALUES, (
-                f"{name}.dimension_weights[{dim!r}] = {weight!r} — not in {VALID_WEIGHT_VALUES}"
+                f"{spec.name}.dimension_weights[{dim!r}] = {weight!r} "
+                f"— not in {VALID_WEIGHT_VALUES}"
             )
 
 
 def test_all_eight_dimensions_present() -> None:
     """All 8 dimensions from the SKILL.md matrix are present in each bundled type."""
     types = load_all_experiment_types()
-    for name, spec in types.items():
+    for spec in types:
         missing = EXPECTED_DIMENSIONS - set(spec.dimension_weights.keys())
-        assert not missing, f"{name} missing dimensions: {missing}"
+        assert not missing, f"{spec.name} missing dimensions: {missing}"
 
 
 def test_dimension_weights_match_skill_matrix() -> None:
     """Spot-check dimension weights against the values in SKILL.md."""
     types = load_all_experiment_types()
-    bench = types["benchmark"]
+    by_name = {s.name: s for s in types}
+
+    bench = by_name["benchmark"]
     assert bench.dimension_weights["causal_structure"] == "S"
     assert bench.dimension_weights["variance_protocol"] == "H"
     assert bench.dimension_weights["agent_implementability"] == "H"
     assert bench.dimension_weights["statistical_corrections"] == "M"
 
-    causal = types["causal_inference"]
+    causal = by_name["causal_inference"]
     assert causal.dimension_weights["causal_structure"] == "H"
     assert causal.dimension_weights["statistical_corrections"] == "H"
     assert causal.dimension_weights["variance_protocol"] == "L"
 
-    config = types["configuration_study"]
+    config = by_name["configuration_study"]
     assert config.dimension_weights["causal_structure"] == "S"
     assert config.dimension_weights["statistical_corrections"] == "H"
 
-    robust = types["robustness_audit"]
+    robust = by_name["robustness_audit"]
     assert robust.dimension_weights["ecological_validity"] == "H"
     assert robust.dimension_weights["data_acquisition"] == "H"
 
-    exploratory = types["exploratory"]
+    exploratory = by_name["exploratory"]
     assert exploratory.dimension_weights["statistical_corrections"] == "S"
     assert exploratory.dimension_weights["agent_implementability"] == "L"
 
@@ -110,36 +113,39 @@ def test_dimension_weights_match_skill_matrix() -> None:
 def test_red_team_severity_caps_match_skill() -> None:
     """Red-team severity caps match values in SKILL.md Step 7 RT_MAX_SEVERITY."""
     types = load_all_experiment_types()
-    assert types["causal_inference"].red_team_focus["severity_cap"] == "critical"
-    assert types["benchmark"].red_team_focus["severity_cap"] == "warning"
-    assert types["configuration_study"].red_team_focus["severity_cap"] == "warning"
-    assert types["robustness_audit"].red_team_focus["severity_cap"] == "warning"
-    assert types["exploratory"].red_team_focus["severity_cap"] == "info"
+    by_name = {s.name: s for s in types}
+    assert by_name["causal_inference"].red_team_focus["severity_cap"] == "critical"
+    assert by_name["benchmark"].red_team_focus["severity_cap"] == "warning"
+    assert by_name["configuration_study"].red_team_focus["severity_cap"] == "warning"
+    assert by_name["robustness_audit"].red_team_focus["severity_cap"] == "warning"
+    assert by_name["exploratory"].red_team_focus["severity_cap"] == "info"
 
 
 def test_red_team_type_specific_focus_present() -> None:
     """Each type has a type-specific red_team_focus.specific value."""
     types = load_all_experiment_types()
-    assert "asymmetric effort" in types["benchmark"].red_team_focus["specific"]
-    assert "overfitting" in types["configuration_study"].red_team_focus["specific"]
-    assert "backdoor" in types["causal_inference"].red_team_focus["specific"]
-    assert "threat distribution" in types["robustness_audit"].red_team_focus["specific"]
-    assert "HARKing" in types["exploratory"].red_team_focus["specific"]
+    by_name = {s.name: s for s in types}
+    assert "asymmetric effort" in by_name["benchmark"].red_team_focus["specific"]
+    assert "overfitting" in by_name["configuration_study"].red_team_focus["specific"]
+    assert "backdoor" in by_name["causal_inference"].red_team_focus["specific"]
+    assert "threat distribution" in by_name["robustness_audit"].red_team_focus["specific"]
+    assert "HARKing" in by_name["exploratory"].red_team_focus["specific"]
 
 
 def test_l1_severity_values() -> None:
     """l1_severity values are one of: critical, warning, info."""
     valid_severities = {"critical", "warning", "info"}
     types = load_all_experiment_types()
-    for name, spec in types.items():
+    for spec in types:
         for dim, sev in spec.l1_severity.items():
-            assert sev in valid_severities, f"{name}.l1_severity[{dim!r}] = {sev!r}"
+            assert sev in valid_severities, f"{spec.name}.l1_severity[{dim!r}] = {sev!r}"
 
 
 def test_l1_severity_causal_inference_is_critical() -> None:
     """causal_inference has critical l1_severity for both L1 dimensions."""
     types = load_all_experiment_types()
-    causal = types["causal_inference"]
+    by_name = {s.name: s for s in types}
+    causal = by_name["causal_inference"]
     assert causal.l1_severity["estimand_clarity"] == "critical"
     assert causal.l1_severity["hypothesis_falsifiability"] == "critical"
 
@@ -147,7 +153,8 @@ def test_l1_severity_causal_inference_is_critical() -> None:
 def test_l1_severity_exploratory_is_info() -> None:
     """exploratory has info l1_severity for both L1 dimensions."""
     types = load_all_experiment_types()
-    exp = types["exploratory"]
+    by_name = {s.name: s for s in types}
+    exp = by_name["exploratory"]
     assert exp.l1_severity["estimand_clarity"] == "info"
     assert exp.l1_severity["hypothesis_falsifiability"] == "info"
 
@@ -155,7 +162,7 @@ def test_l1_severity_exploratory_is_info() -> None:
 def test_no_project_dir_returns_bundled_only() -> None:
     """With project_dir=None, only bundled types are returned."""
     types = load_all_experiment_types(project_dir=None)
-    assert set(types.keys()) == EXPECTED_TYPES
+    assert {s.name for s in types} == EXPECTED_TYPES
 
 
 def test_user_override_replaces_bundled_type(tmp_path: Path) -> None:
@@ -178,14 +185,15 @@ def test_user_override_replaces_bundled_type(tmp_path: Path) -> None:
         )
     )
     types = load_all_experiment_types(project_dir=tmp_path)
-    bench = types["benchmark"]
+    by_name = {s.name: s for s in types}
+    bench = by_name["benchmark"]
     # Custom values take effect
     assert bench.classification_triggers == ["custom trigger only"]
     assert bench.dimension_weights == {"causal_structure": "H"}
     # Bundled fields (variance_protocol, etc.) are NOT present — full replacement
     assert "variance_protocol" not in bench.dimension_weights
     # Other bundled types remain intact
-    assert "causal_inference" in types
+    assert "causal_inference" in by_name
     assert len(types) == len(EXPECTED_TYPES)
 
 
@@ -218,20 +226,22 @@ def test_user_new_type_is_added(tmp_path: Path) -> None:
         )
     )
     types = load_all_experiment_types(project_dir=tmp_path)
-    assert "network_analysis" in types
+    by_name = {s.name: s for s in types}
+    assert "network_analysis" in by_name
     assert len(types) == 13  # 12 bundled + 1 user
 
 
 def test_missing_user_override_dir_is_silent(tmp_path: Path) -> None:
     """A project_dir with no .autoskillit/experiment-types/ is fine — bundled only returned."""
     types = load_all_experiment_types(project_dir=tmp_path)
-    assert set(types.keys()) == EXPECTED_TYPES
+    assert {s.name for s in types} == EXPECTED_TYPES
 
 
-def test_returns_dict_of_experiment_type_spec() -> None:
-    """load_all_experiment_types returns dict[str, ExperimentTypeSpec]."""
-    types = load_all_experiment_types()
-    for _name, spec in types.items():
+def test_returns_list_of_experiment_type_spec() -> None:
+    """load_all_experiment_types returns list[ExperimentTypeSpec]."""
+    result = load_all_experiment_types()
+    assert isinstance(result, list)
+    for spec in result:
         assert isinstance(spec, ExperimentTypeSpec)
 
 
@@ -241,7 +251,8 @@ def test_causal_inference_classification_triggers_require_manipulation() -> None
     Not just causal language alone.
     """
     types = load_all_experiment_types()
-    causal = types["causal_inference"]
+    by_name = {s.name: s for s in types}
+    causal = by_name["causal_inference"]
     assert causal.classification_triggers == [
         (
             "Explicit randomization, manipulation, or intervention assignment: "
@@ -258,7 +269,8 @@ def test_causal_inference_classification_triggers_require_manipulation() -> None
 def test_causal_inference_trigger_covers_rct_language() -> None:
     """causal_inference triggers cover RCT keywords: randomized assignment, treatment/control."""
     types = load_all_experiment_types()
-    triggers_text = " ".join(types["causal_inference"].classification_triggers)
+    by_name = {s.name: s for s in types}
+    triggers_text = " ".join(by_name["causal_inference"].classification_triggers)
     assert "randomly assigned" in triggers_text
     assert "treatment group" in triggers_text
     assert "control group" in triggers_text
@@ -277,27 +289,31 @@ def test_no_citation_markers_in_yaml_files() -> None:
 def test_all_types_have_schema_version() -> None:
     """Every bundled type has schema_version == '1.0'."""
     types = load_all_experiment_types()
-    for name, spec in types.items():
-        assert spec.schema_version == "1.0", f"{name}: schema_version = {spec.schema_version!r}"
+    for spec in types:
+        assert spec.schema_version == "1.0", (
+            f"{spec.name}: schema_version = {spec.schema_version!r}"
+        )
 
 
 def test_priority_values_are_unique_except_fallback() -> None:
     """No duplicate priority values among non-fallback types; exploratory has priority 999."""
     types = load_all_experiment_types()
-    non_fallback_priorities = [spec.priority for spec in types.values() if not spec.is_fallback]
+    by_name = {s.name: s for s in types}
+    non_fallback_priorities = [s.priority for s in types if not s.is_fallback]
     assert len(non_fallback_priorities) == len(set(non_fallback_priorities)), (
         "Duplicate priority values among non-fallback types"
     )
-    assert types["exploratory"].priority == 999
+    assert by_name["exploratory"].priority == 999
 
 
 def test_only_exploratory_is_fallback() -> None:
     """exploratory is the sole fallback type; all others have is_fallback=False."""
     types = load_all_experiment_types()
-    assert types["exploratory"].is_fallback is True
-    for name, spec in types.items():
-        if name != "exploratory":
-            assert spec.is_fallback is False, f"{name}: is_fallback should be False"
+    by_name = {s.name: s for s in types}
+    assert by_name["exploratory"].is_fallback is True
+    for spec in types:
+        if spec.name != "exploratory":
+            assert spec.is_fallback is False, f"{spec.name}: is_fallback should be False"
 
 
 def test_priority_assignments_match_contract() -> None:
@@ -317,9 +333,10 @@ def test_priority_assignments_match_contract() -> None:
         "exploratory": 999,
     }
     types = load_all_experiment_types()
+    by_name = {s.name: s for s in types}
     for name, expected_priority in EXPECTED_PRIORITIES.items():
-        assert types[name].priority == expected_priority, (
-            f"{name}: expected priority {expected_priority}, got {types[name].priority}"
+        assert by_name[name].priority == expected_priority, (
+            f"{name}: expected priority {expected_priority}, got {by_name[name].priority}"
         )
 
 
@@ -335,8 +352,9 @@ def test_new_types_dimension_weight_rationale_coverage() -> None:
         "qualitative_interpretive",
     }
     types = load_all_experiment_types()
+    by_name = {s.name: s for s in types}
     for name in new_types:
-        spec = types[name]
+        spec = by_name[name]
         for dim, weight in spec.dimension_weights.items():
             if weight in ("H", "M"):
                 assert dim in spec.dimension_weight_rationale, (
@@ -350,7 +368,8 @@ def test_new_types_dimension_weight_rationale_coverage() -> None:
 def test_new_types_red_team_severity_caps() -> None:
     """evidence_synthesis has severity_cap=critical; all other new types have warning."""
     types = load_all_experiment_types()
-    assert types["evidence_synthesis"].red_team_focus["severity_cap"] == "critical"
+    by_name = {s.name: s for s in types}
+    assert by_name["evidence_synthesis"].red_team_focus["severity_cap"] == "critical"
     for name in (
         "factorial_design",
         "simulation_modeling",
@@ -359,7 +378,7 @@ def test_new_types_red_team_severity_caps() -> None:
         "observational_correlational",
         "qualitative_interpretive",
     ):
-        assert types[name].red_team_focus["severity_cap"] == "warning", (
+        assert by_name[name].red_team_focus["severity_cap"] == "warning", (
             f"{name}: expected severity_cap=warning"
         )
 
@@ -367,35 +386,167 @@ def test_new_types_red_team_severity_caps() -> None:
 def test_new_types_dimension_weights_spot_check() -> None:
     """Spot-check key distinguishing weights for each new type."""
     types = load_all_experiment_types()
-    assert types["evidence_synthesis"].dimension_weights["measurement_alignment"] == "H"
-    assert types["evidence_synthesis"].dimension_weights["causal_structure"] == "L"
+    by_name = {s.name: s for s in types}
+    assert by_name["evidence_synthesis"].dimension_weights["measurement_alignment"] == "H"
+    assert by_name["evidence_synthesis"].dimension_weights["causal_structure"] == "L"
 
-    assert types["factorial_design"].dimension_weights["causal_structure"] == "H"
-    assert types["factorial_design"].dimension_weights["ecological_validity"] == "L"
+    assert by_name["factorial_design"].dimension_weights["causal_structure"] == "H"
+    assert by_name["factorial_design"].dimension_weights["ecological_validity"] == "L"
 
-    assert types["qualitative_interpretive"].dimension_weights["causal_structure"] == "S"
-    assert types["qualitative_interpretive"].dimension_weights["statistical_corrections"] == "S"
+    assert by_name["qualitative_interpretive"].dimension_weights["causal_structure"] == "S"
+    assert by_name["qualitative_interpretive"].dimension_weights["statistical_corrections"] == "S"
 
-    assert types["single_subject"].dimension_weights["statistical_corrections"] == "S"
-    assert types["single_subject"].dimension_weights["variance_protocol"] == "H"
+    assert by_name["single_subject"].dimension_weights["statistical_corrections"] == "S"
+    assert by_name["single_subject"].dimension_weights["variance_protocol"] == "H"
 
-    assert types["simulation_modeling"].dimension_weights["data_acquisition"] == "L"
-    assert types["simulation_modeling"].dimension_weights["agent_implementability"] == "H"
+    assert by_name["simulation_modeling"].dimension_weights["data_acquisition"] == "L"
+    assert by_name["simulation_modeling"].dimension_weights["agent_implementability"] == "H"
 
-    assert types["instrument_validation"].dimension_weights["causal_structure"] == "S"
-    assert types["instrument_validation"].dimension_weights["measurement_alignment"] == "H"
+    assert by_name["instrument_validation"].dimension_weights["causal_structure"] == "S"
+    assert by_name["instrument_validation"].dimension_weights["measurement_alignment"] == "H"
 
-    assert types["observational_correlational"].dimension_weights["ecological_validity"] == "H"
-    assert types["observational_correlational"].dimension_weights["variance_protocol"] == "L"
+    assert by_name["observational_correlational"].dimension_weights["ecological_validity"] == "H"
+    assert by_name["observational_correlational"].dimension_weights["variance_protocol"] == "L"
 
 
 def test_qualitative_interpretive_falsifiability_is_info() -> None:
     """qualitative_interpretive has hypothesis_falsifiability=info (unique among all types)."""
     types = load_all_experiment_types()
-    assert types["qualitative_interpretive"].l1_severity["hypothesis_falsifiability"] == "info"
+    by_name = {s.name: s for s in types}
+    assert by_name["qualitative_interpretive"].l1_severity["hypothesis_falsifiability"] == "info"
 
 
 def test_evidence_synthesis_estimand_clarity_is_critical() -> None:
     """evidence_synthesis has estimand_clarity=critical."""
     types = load_all_experiment_types()
-    assert types["evidence_synthesis"].l1_severity["estimand_clarity"] == "critical"
+    by_name = {s.name: s for s in types}
+    assert by_name["evidence_synthesis"].l1_severity["estimand_clarity"] == "critical"
+
+
+# ---------------------------------------------------------------------------
+# New tests: T1-T7
+# ---------------------------------------------------------------------------
+
+
+def test_exploratory_always_last() -> None:
+    """exploratory (is_fallback=True) is always the last element in the returned list."""
+    types = load_all_experiment_types()
+    assert types[-1].is_fallback is True
+    assert types[-1].name == "exploratory"
+    for spec in types[:-1]:
+        assert spec.is_fallback is False
+
+
+def test_evaluation_order_matches_canonical() -> None:
+    """Returned list matches the exact 12-element canonical ordering by priority."""
+    types = load_all_experiment_types()
+    names = [s.name for s in types]
+    assert names == [
+        "causal_inference",
+        "evidence_synthesis",
+        "benchmark",
+        "factorial_design",
+        "configuration_study",
+        "simulation_modeling",
+        "instrument_validation",
+        "robustness_audit",
+        "single_subject",
+        "observational_correlational",
+        "qualitative_interpretive",
+        "exploratory",
+    ]
+
+
+def test_user_types_interleave_by_priority(tmp_path: Path) -> None:
+    """A user type with priority=4 interleaves after benchmark, before configuration_study."""
+    user_dir = tmp_path / ".autoskillit" / "experiment-types"
+    user_dir.mkdir(parents=True)
+    (user_dir / "my_custom.yaml").write_text(
+        yaml.dump(
+            {
+                "name": "my_custom",
+                "priority": 4,
+                "classification_triggers": ["custom trigger"],
+                "dimension_weights": {
+                    "causal_structure": "M",
+                    "variance_protocol": "M",
+                    "statistical_corrections": "M",
+                    "ecological_validity": "M",
+                    "measurement_alignment": "M",
+                    "resource_proportionality": "M",
+                    "data_acquisition": "M",
+                    "agent_implementability": "M",
+                },
+                "applicable_lenses": {},
+                "red_team_focus": {"specific": "none", "severity_cap": "warning"},
+                "l1_severity": {
+                    "estimand_clarity": "warning",
+                    "hypothesis_falsifiability": "warning",
+                },
+            }
+        )
+    )
+    types = load_all_experiment_types(project_dir=tmp_path)
+    names = [s.name for s in types]
+    # factorial_design has priority=4, my_custom also priority=4
+    # sorted by (priority, name): "factorial_design" < "my_custom" alphabetically
+    # Both at priority 4, so factorial_design comes before my_custom
+    bench_idx = names.index("benchmark")
+    custom_idx = names.index("my_custom")
+    config_idx = names.index("configuration_study")
+    assert bench_idx < custom_idx < config_idx
+
+
+def test_schema_mismatch_warns(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """A user type with schema_version != '1.0' triggers a WARNING but still loads."""
+    import logging
+
+    user_dir = tmp_path / ".autoskillit" / "experiment-types"
+    user_dir.mkdir(parents=True)
+    (user_dir / "future_type.yaml").write_text(
+        yaml.dump(
+            {
+                "name": "future_type",
+                "schema_version": "2.0",
+                "classification_triggers": ["future trigger"],
+                "dimension_weights": {
+                    "causal_structure": "M",
+                    "variance_protocol": "M",
+                    "statistical_corrections": "M",
+                    "ecological_validity": "M",
+                    "measurement_alignment": "M",
+                    "resource_proportionality": "M",
+                    "data_acquisition": "M",
+                    "agent_implementability": "M",
+                },
+                "applicable_lenses": {},
+                "red_team_focus": {"specific": "none", "severity_cap": "warning"},
+                "l1_severity": {
+                    "estimand_clarity": "warning",
+                    "hypothesis_falsifiability": "warning",
+                },
+            }
+        )
+    )
+    with caplog.at_level(logging.WARNING):
+        types = load_all_experiment_types(project_dir=tmp_path)
+
+    assert any("schema_version" in r.message and "2.0" in r.message for r in caplog.records), (
+        "Expected WARNING about schema_version mismatch"
+    )
+    by_name = {s.name: s for s in types}
+    assert "future_type" in by_name
+
+
+def test_get_experiment_type_by_name_found() -> None:
+    """get_experiment_type_by_name returns the matching spec for a known type."""
+    spec = get_experiment_type_by_name("benchmark")
+    assert spec is not None
+    assert spec.name == "benchmark"
+    assert isinstance(spec, ExperimentTypeSpec)
+
+
+def test_get_experiment_type_by_name_not_found() -> None:
+    """get_experiment_type_by_name returns None for an unknown type name."""
+    spec = get_experiment_type_by_name("nonexistent")
+    assert spec is None

--- a/tests/skills/test_review_design_guards.py
+++ b/tests/skills/test_review_design_guards.py
@@ -22,7 +22,7 @@ def test_data_acquisition_dimension_exists() -> None:
 def test_data_acquisition_not_l_weight() -> None:
     """data_acquisition must be M-weight minimum to influence verdict in at least one type."""
     types = load_all_experiment_types()
-    for name, spec in types.items():
+    for spec in types:
         weight = spec.dimension_weights.get("data_acquisition")
         if weight in ("M", "H"):
             return
@@ -37,6 +37,7 @@ def test_agent_implementability_dimension_exists() -> None:
 def test_agent_implementability_weight_row() -> None:
     """agent_implementability must have H/H/M/M/L weights for the 5 bundled types."""
     types = load_all_experiment_types()
+    by_name = {s.name: s for s in types}
     expected = {
         "benchmark": "H",
         "configuration_study": "H",
@@ -45,7 +46,7 @@ def test_agent_implementability_weight_row() -> None:
         "exploratory": "L",
     }
     for type_name, exp_weight in expected.items():
-        spec = types.get(type_name)
+        spec = by_name.get(type_name)
         assert spec is not None, f"Bundled type {type_name!r} not found"
         actual = spec.dimension_weights.get("agent_implementability")
         assert actual == exp_weight, (


### PR DESCRIPTION
## Summary

Change `load_all_experiment_types()` from returning `dict[str, ExperimentTypeSpec]` to `list[ExperimentTypeSpec]` sorted by `(priority, name)` with `is_fallback=True` entries always last. Add a `get_experiment_type_by_name()` lookup helper, extend the `_api.py` recipe cache key with experiment-type registry hash, and emit WARN logs for user YAML schema-version mismatches. Migrate all test call sites from dict-access to list-iteration or the new helper.

Closes #834

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260505-145553-500421/.autoskillit/temp/make-plan/trigger-evaluation-ordering-mechanism_plan_2026-05-05_145900.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 2.9k | 8.4k | 734.3k | 63.3k | 65 | 55.4k | 4m 47s |
| verify | 1 | 39 | 6.6k | 612.8k | 69.1k | 86 | 61.0k | 3m 35s |
| implement | 1 | 1.6k | 20.7k | 1.7M | 73.7k | 90 | 61.0k | 6m 17s |
| prepare_pr | 1 | 60 | 4.8k | 180.7k | 34.7k | 19 | 22.3k | 1m 20s |
| compose_pr | 1 | 67 | 2.2k | 205.0k | 31.2k | 17 | 18.3k | 48s |
| review_pr | 1 | 102 | 24.0k | 561.0k | 72.9k | 45 | 61.4k | 5m 1s |
| **Total** | | 4.8k | 66.8k | 4.0M | 73.7k | | 279.4k | 21m 48s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 379 | 4452.5 | 161.0 | 54.6 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **379** | 10505.0 | 737.1 | 176.2 |