### PR TITLE
Implementation Plan: Deduplicate Execution-Layer Protocol and Result-Builder Tests

### DIFF
--- a/tests/execution/conftest.py
+++ b/tests/execution/conftest.py
@@ -144,28 +144,83 @@ def isolated_tracing_config(tmp_path: pathlib.Path):
 
 def _snap(
     *,
-    captured_at: str = "2026-03-03T12:00:00+00:00",
+    captured_at: str | None = "2026-03-03T12:00:00+00:00",
+    state: str = "sleeping",
     vm_rss_kb: int = 100000,
     oom_score: int = 50,
     fd_count: int = 10,
     fd_soft_limit: int = 1024,
-    state: str = "sleeping",
+    sig_pnd: str = "0000000000000000",
+    sig_blk: str = "0000000000000000",
+    sig_cgt: str = "0000000000000000",
+    threads: int = 4,
+    wchan: str = "",
+    ctx_switches_voluntary: int = 500,
+    ctx_switches_involuntary: int = 20,
+    cpu_percent: float = 0.0,
 ) -> dict[str, object]:
-    return {
-        "captured_at": captured_at,
+    d: dict[str, object] = {
         "state": state,
         "vm_rss_kb": vm_rss_kb,
         "oom_score": oom_score,
         "fd_count": fd_count,
         "fd_soft_limit": fd_soft_limit,
-        "sig_pnd": "0000000000000000",
-        "sig_blk": "0000000000000000",
-        "sig_cgt": "0000000000000000",
-        "threads": 4,
-        "wchan": "",
-        "ctx_switches_voluntary": 500,
-        "ctx_switches_involuntary": 20,
+        "sig_pnd": sig_pnd,
+        "sig_blk": sig_blk,
+        "sig_cgt": sig_cgt,
+        "threads": threads,
+        "wchan": wchan,
+        "ctx_switches_voluntary": ctx_switches_voluntary,
+        "ctx_switches_involuntary": ctx_switches_involuntary,
+        "cpu_percent": cpu_percent,
     }
+    if captured_at is not None:
+        d["captured_at"] = captured_at
+    return d
+
+
+def _result_ndjson(
+    result_text: str = "done",
+    subtype: str = "success",
+    is_error: bool = False,
+    session_id: str = "s1",
+    errors: list | None = None,
+    usage: dict | None = None,
+) -> str:
+    obj: dict = {
+        "type": "result",
+        "subtype": subtype,
+        "is_error": is_error,
+        "result": result_text,
+        "session_id": session_id,
+        "errors": errors or [],
+    }
+    if usage:
+        obj["usage"] = usage
+    return json.dumps(obj)
+
+
+def _assistant_ndjson(
+    model: str = "claude-sonnet-4-6",
+    input_tokens: int = 100,
+    output_tokens: int = 50,
+    cache_create: int = 0,
+    cache_read: int = 0,
+) -> str:
+    return json.dumps(
+        {
+            "type": "assistant",
+            "message": {
+                "model": model,
+                "usage": {
+                    "input_tokens": input_tokens,
+                    "output_tokens": output_tokens,
+                    "cache_creation_input_tokens": cache_create,
+                    "cache_read_input_tokens": cache_read,
+                },
+            },
+        }
+    )
 
 
 def _flush(tmp_path: Path, **overrides) -> None:

--- a/tests/execution/test_anomaly_detection.py
+++ b/tests/execution/test_anomaly_detection.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from functools import partial
+
 import pytest
 
 from autoskillit.execution.anomaly_detection import (
@@ -10,41 +12,11 @@ from autoskillit.execution.anomaly_detection import (
     AnomalySeverity,
     detect_anomalies,
 )
+from tests.execution.conftest import _snap as _snap_full
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
-
-def _snap(
-    *,
-    state: str = "sleeping",
-    vm_rss_kb: int = 100000,
-    oom_score: int = 50,
-    fd_count: int = 10,
-    fd_soft_limit: int = 1024,
-    sig_pnd: str = "0000000000000000",
-    sig_blk: str = "0000000000000000",
-    sig_cgt: str = "0000000000000000",
-    threads: int = 4,
-    wchan: str = "",
-    ctx_switches_voluntary: int = 500,
-    ctx_switches_involuntary: int = 20,
-    cpu_percent: float = 0.0,
-) -> dict[str, object]:
-    return {
-        "state": state,
-        "vm_rss_kb": vm_rss_kb,
-        "oom_score": oom_score,
-        "fd_count": fd_count,
-        "fd_soft_limit": fd_soft_limit,
-        "sig_pnd": sig_pnd,
-        "sig_blk": sig_blk,
-        "sig_cgt": sig_cgt,
-        "threads": threads,
-        "wchan": wchan,
-        "ctx_switches_voluntary": ctx_switches_voluntary,
-        "ctx_switches_involuntary": ctx_switches_involuntary,
-        "cpu_percent": cpu_percent,
-    }
+_snap = partial(_snap_full, captured_at=None)
 
 
 def test_detect_oom_spike():

--- a/tests/execution/test_github.py
+++ b/tests/execution/test_github.py
@@ -371,16 +371,6 @@ async def test_update_issue_body_request_error(httpx_mock):
 
 
 # ---------------------------------------------------------------------------
-# Protocol conformance
-# ---------------------------------------------------------------------------
-
-
-def test_github_fetcher_protocol_includes_write_methods():
-    fetcher = DefaultGitHubFetcher(token=None)
-    assert isinstance(fetcher, GitHubFetcher)
-
-
-# ---------------------------------------------------------------------------
 # DefaultGitHubFetcher — fetch_title
 # ---------------------------------------------------------------------------
 
@@ -473,10 +463,6 @@ class TestFetchTitle:
         result = await fetcher.fetch_title("owner/repo#1")
         assert result["success"] is False
         assert "error" in result
-
-    def test_protocol_conformance(self):
-        """DefaultGitHubFetcher satisfies GitHubFetcher protocol (has fetch_title)."""
-        assert isinstance(DefaultGitHubFetcher(), GitHubFetcher)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/execution/test_process_pty.py
+++ b/tests/execution/test_process_pty.py
@@ -29,6 +29,7 @@ from autoskillit.execution.process import (
     run_managed_async,
 )
 from autoskillit.execution.session import ClaudeSessionResult
+from tests.execution.conftest import _result_ndjson
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.medium]
 
@@ -493,25 +494,6 @@ class TestAdjudicationCoverageMatrix:
 # ---------------------------------------------------------------------------
 
 
-def _result_ndjson(
-    result: str = "done",
-    subtype: str = "success",
-    is_error: bool = False,
-    session_id: str = "s1",
-) -> str:
-    """Build a minimal NDJSON string with a single type=result record."""
-    return json.dumps(
-        {
-            "type": "result",
-            "subtype": subtype,
-            "is_error": is_error,
-            "result": result,
-            "session_id": session_id,
-            "errors": [],
-        }
-    )
-
-
 class TestResolveTerminationMatrix:
     """Pure-function unit tests for resolve_termination.
 
@@ -835,7 +817,7 @@ class TestAdjudicationGuards:
         """CHANNEL_A + empty result: dead-end guard escalates to retriable."""
         result = SubprocessResult(
             returncode=0,
-            stdout=_result_ndjson(subtype="success", result=""),
+            stdout=_result_ndjson(subtype="success", result_text=""),
             stderr="",
             termination=TerminationReason.NATURAL_EXIT,
             pid=12345,
@@ -858,7 +840,7 @@ class TestAdjudicationGuards:
         """CHANNEL_B + error_max_turns: contradiction guard resolves to retriable."""
         result = SubprocessResult(
             returncode=0,
-            stdout=_result_ndjson(subtype="error_max_turns", result="partial", is_error=True),
+            stdout=_result_ndjson(subtype="error_max_turns", result_text="partial", is_error=True),
             stderr="",
             termination=TerminationReason.NATURAL_EXIT,
             pid=12345,
@@ -882,7 +864,7 @@ class TestAdjudicationGuards:
         """COMPLETED + CHANNEL_B + error_max_turns: contradiction guard resolves to retriable."""
         result = SubprocessResult(
             returncode=-15,
-            stdout=_result_ndjson(subtype="error_max_turns", result="partial", is_error=True),
+            stdout=_result_ndjson(subtype="error_max_turns", result_text="partial", is_error=True),
             stderr="",
             termination=TerminationReason.COMPLETED,
             pid=12345,

--- a/tests/execution/test_session_parsing.py
+++ b/tests/execution/test_session_parsing.py
@@ -19,6 +19,7 @@ from autoskillit.execution.session import (
     parse_session_result,
 )
 from tests._helpers import _flush_structlog_proxy_caches as _flush_logger_proxy_caches
+from tests.execution.conftest import _assistant_ndjson, _result_ndjson
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
@@ -38,50 +39,6 @@ def _make_session_result(
         termination=termination_reason,
         pid=12345,
         channel_confirmation=channel_confirmation,
-    )
-
-
-def _result_ndjson(
-    result_text: str = "done",
-    subtype: str = "success",
-    is_error: bool = False,
-    session_id: str = "s1",
-    errors: list | None = None,
-    usage: dict | None = None,
-) -> str:
-    obj: dict = {
-        "type": "result",
-        "subtype": subtype,
-        "is_error": is_error,
-        "result": result_text,
-        "session_id": session_id,
-        "errors": errors or [],
-    }
-    if usage:
-        obj["usage"] = usage
-    return json.dumps(obj)
-
-
-def _assistant_ndjson(
-    model: str = "claude-sonnet-4-6",
-    input_tokens: int = 100,
-    output_tokens: int = 50,
-    cache_create: int = 0,
-    cache_read: int = 0,
-) -> str:
-    return json.dumps(
-        {
-            "type": "assistant",
-            "message": {
-                "model": model,
-                "usage": {
-                    "input_tokens": input_tokens,
-                    "output_tokens": output_tokens,
-                    "cache_creation_input_tokens": cache_create,
-                    "cache_read_input_tokens": cache_read,
-                },
-            },
-        }
     )
 
 

--- a/tests/execution/test_session_result.py
+++ b/tests/execution/test_session_result.py
@@ -30,50 +30,6 @@ def _make_error_session(
     )
 
 
-def _result_ndjson(
-    result_text: str = "done",
-    subtype: str = "success",
-    is_error: bool = False,
-    session_id: str = "s1",
-    errors: list | None = None,
-    usage: dict | None = None,
-) -> str:
-    obj: dict = {
-        "type": "result",
-        "subtype": subtype,
-        "is_error": is_error,
-        "result": result_text,
-        "session_id": session_id,
-        "errors": errors or [],
-    }
-    if usage:
-        obj["usage"] = usage
-    return json.dumps(obj)
-
-
-def _assistant_ndjson(
-    model: str = "claude-sonnet-4-6",
-    input_tokens: int = 100,
-    output_tokens: int = 50,
-    cache_create: int = 0,
-    cache_read: int = 0,
-) -> str:
-    return json.dumps(
-        {
-            "type": "assistant",
-            "message": {
-                "model": model,
-                "usage": {
-                    "input_tokens": input_tokens,
-                    "output_tokens": output_tokens,
-                    "cache_creation_input_tokens": cache_create,
-                    "cache_read_input_tokens": cache_read,
-                },
-            },
-        }
-    )
-
-
 class TestClaudeSessionResult:
     """ClaudeSessionResult correctly parses Claude Code JSON output."""
 
@@ -410,25 +366,6 @@ class TestClaudeSessionResultTokenUsage:
 
 
 class TestClaudeSessionResultBasic:
-    def test_post_init_coerces_none_result_to_empty_str(self):
-        s = ClaudeSessionResult(
-            subtype="success",
-            is_error=False,
-            result=None,
-            session_id="s1",  # type: ignore[arg-type]
-        )
-        assert s.result == ""
-
-    def test_post_init_coerces_non_list_errors(self):
-        s = ClaudeSessionResult(
-            subtype="success",
-            is_error=False,
-            result="ok",
-            session_id="s1",
-            errors=None,  # type: ignore[arg-type]
-        )
-        assert s.errors == []
-
     def test_post_init_list_with_non_dict_element(self):
         s = ClaudeSessionResult(
             subtype="success",


### PR DESCRIPTION
## Summary

Consolidate four categories of test duplication in `tests/execution/`: remove redundant protocol-conformance tests (C2-4), centralize NDJSON builder helpers in conftest (C2-5), merge two incompatible `_snap()` signatures into a unified helper (C2-6), and delete duplicate null-coercion tests (C2-9). Net result: fewer test functions, shared helpers in conftest, zero coverage loss.

Closes #1882

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260505-151610-947780/.autoskillit/temp/make-plan/deduplicate-execution-layer-protocol-and-result-builder-tests_plan_2026-05-05_151900.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 1.1k | 7.8k | 739.6k | 55.8k | 55 | 46.4k | 3m 27s |
| verify | 1 | 1.4k | 11.7k | 839.9k | 57.7k | 69 | 44.7k | 7m 43s |
| implement | 1 | 2.0M | 11.2k | 1.2M | 26.7k | 115 | 118.2k | 4m 23s |
| prepare_pr | 1 | 68 | 4.1k | 203.7k | 31.9k | 18 | 19.6k | 1m 17s |
| compose_pr | 1 | 59 | 1.8k | 157.1k | 25.6k | 14 | 12.6k | 34s |
| review_pr | 1 | 126 | 24.6k | 611.4k | 66.7k | 57 | 55.9k | 4m 54s |
| resolve_review | 1 | 229 | 13.0k | 1.1M | 56.5k | 57 | 43.9k | 6m 30s |
| ci_conflict_fix | 1 | 140 | 5.0k | 587.9k | 46.3k | 37 | 33.5k | 1m 38s |
| **Total** | | 2.0M | 79.1k | 5.4M | 66.7k | | 374.9k | 30m 27s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 261 | 4585.8 | 452.9 | 43.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| ci_conflict_fix | 631 | 931.6 | 53.1 | 7.9 |
| **Total** | **892** | 6099.7 | 420.3 | 88.7 |