### PR TITLE
Implementation Plan: Deduplicate Server-Layer Gate-Closed and Retry Tests

### DIFF
--- a/tests/server/test_tools_integrations.py
+++ b/tests/server/test_tools_integrations.py
@@ -34,15 +34,6 @@ class TestClaimIssueTool:
         assert "claim_issue" in GATED_TOOLS
 
     @pytest.mark.anyio
-    async def test_claim_issue_returns_gate_error_when_kitchen_closed(self, tool_ctx):
-        from autoskillit.pipeline.gate import DefaultGateState
-
-        tool_ctx.gate = DefaultGateState(enabled=False)
-        result = json.loads(await claim_issue("https://github.com/owner/repo/issues/42"))
-        assert result["success"] is False
-        assert result["subtype"] == "gate_error"
-
-    @pytest.mark.anyio
     async def test_claim_issue_returns_error_without_github_client(self, tool_ctx):
         tool_ctx.github_client = None
         result = json.loads(await claim_issue("https://github.com/owner/repo/issues/42"))
@@ -156,15 +147,6 @@ class TestReleaseIssueTool:
         assert "release_issue" in GATED_TOOLS
 
     @pytest.mark.anyio
-    async def test_release_issue_returns_gate_error_when_kitchen_closed(self, tool_ctx):
-        from autoskillit.pipeline.gate import DefaultGateState
-
-        tool_ctx.gate = DefaultGateState(enabled=False)
-        result = json.loads(await release_issue("https://github.com/owner/repo/issues/42"))
-        assert result["success"] is False
-        assert result["subtype"] == "gate_error"
-
-    @pytest.mark.anyio
     async def test_release_issue_returns_error_without_github_client(self, tool_ctx):
         tool_ctx.github_client = None
         result = json.loads(await release_issue("https://github.com/owner/repo/issues/42"))
@@ -208,15 +190,6 @@ class TestPrepareIssueTool:
         from autoskillit.pipeline.gate import GATED_TOOLS
 
         assert "prepare_issue" in GATED_TOOLS
-
-    @pytest.mark.anyio
-    async def test_prepare_issue_returns_gate_error_when_kitchen_closed(self, tool_ctx):
-        from autoskillit.pipeline.gate import DefaultGateState
-
-        tool_ctx.gate = DefaultGateState(enabled=False)
-        result = json.loads(await prepare_issue("Test title", "Test body"))
-        assert result["success"] is False
-        assert result["subtype"] == "gate_error"
 
     @pytest.mark.anyio
     async def test_prepare_issue_success_with_result_block(self, tool_ctx):
@@ -462,15 +435,6 @@ class TestEnrichIssuesTool:
         from autoskillit.pipeline.gate import GATED_TOOLS
 
         assert "enrich_issues" in GATED_TOOLS
-
-    @pytest.mark.anyio
-    async def test_enrich_issues_returns_gate_error_when_kitchen_closed(self, tool_ctx):
-        from autoskillit.pipeline.gate import DefaultGateState
-
-        tool_ctx.gate = DefaultGateState(enabled=False)
-        result = json.loads(await enrich_issues())
-        assert result["success"] is False
-        assert result["subtype"] == "gate_error"
 
     @pytest.mark.anyio
     async def test_enrich_issues_success_empty_result_includes_diagnostics(self, tool_ctx):

--- a/tests/server/test_tools_run_skill_retry.py
+++ b/tests/server/test_tools_run_skill_retry.py
@@ -38,15 +38,6 @@ class TestRunSkillRetryRemoved:
             "run_skill_retry still exists in tools_execution — it should be removed"
         )
 
-    def test_run_skill_retry_not_in_all(self):
-        """run_skill_retry is not in tools_execution.__all__ (if defined)."""
-        import autoskillit.server.tools.tools_execution as module
-
-        # tools_execution does not define __all__; verify via direct attribute check
-        assert not hasattr(module, "run_skill_retry"), (
-            "run_skill_retry should not be a public attribute of tools_execution"
-        )
-
 
 class TestRunSkillSessionOutcome:
     """run_skill correctly classifies all Claude Code session outcomes."""


### PR DESCRIPTION
## Summary

Remove 5 duplicate tests from 2 server test files. Four gate-closed tests in `test_tools_integrations.py` are exact duplicates of canonical tests in `test_tools_issue_lifecycle.py`. One `hasattr` assertion test in `test_tools_run_skill_retry.py` is a character-for-character duplicate of the test immediately above it. The canonical versions remain untouched.

Closes #1881

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260505-151610-537376/.autoskillit/temp/make-plan/deduplicate-server-gate-closed-retry-tests_plan_2026-05-05_151800.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 1.1k | 5.3k | 783.4k | 62.8k | 43 | 49.6k | 3m 19s |
| verify | 1 | 1.2k | 4.4k | 429.8k | 46.4k | 50 | 35.0k | 2m 46s |
| implement | 1 | 294.0k | 3.6k | 426.7k | 26.7k | 38 | 65.3k | 1m 34s |
| prepare_pr | 1 | 60 | 4.2k | 166.3k | 29.4k | 17 | 16.9k | 1m 18s |
| compose_pr | 1 | 51 | 2.0k | 133.6k | 25.8k | 13 | 12.8k | 37s |
| review_pr | 2 | 264 | 30.9k | 1.1M | 53.3k | 83 | 77.1k | 8m 20s |
| resolve_review | 1 | 3.8k | 14.4k | 1.5M | 77.0k | 70 | 64.4k | 5m 39s |
| ci_conflict_fix | 1 | 83 | 2.3k | 265.7k | 30.9k | 22 | 17.9k | 59s |
| **Total** | | 300.6k | 67.1k | 4.9M | 77.0k | | 338.9k | 24m 34s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 45 | 9481.2 | 1450.6 | 80.3 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| ci_conflict_fix | 631 | 421.0 | 28.4 | 3.6 |
| **Total** | **676** | 7184.4 | 501.4 | 99.2 |