### PR TITLE
Implementation Plan: Expose Dimension-Weight Rationale in Review-Design Dashboard

### DIFF
--- a/src/autoskillit/skills_extended/review-design/SKILL.md
+++ b/src/autoskillit/skills_extended/review-design/SKILL.md
@@ -460,6 +460,22 @@ One synthesis pass (no subagent — orchestrator synthesizes directly):
 5. **Write `evaluation_dashboard_{slug}_{YYYY-MM-DD_HHMMSS}.md`** — always written.
    Must include:
    - Verdict banner and classification summary
+   - **Dimension Rationale** subsection — renders a per-dimension rationale table sourced
+     from `spec.dimension_weight_rationale` (loaded in Step 0 registry). Table format:
+     ```markdown
+     ## Dimension Rationale (why these weights apply to {experiment_type})
+
+     | Dimension | Weight | Rationale |
+     |---|---|---|
+     | {dim} | {weight} | {rationale from spec.dimension_weight_rationale[dim]} |
+     ```
+     Include ALL non-SILENT dimensions (H, M, L). For each dimension:
+     - If `dimension_weight_rationale[dim]` exists and is non-empty: render the rationale string
+     - If no rationale entry exists (legacy types with empty `dimension_weight_rationale`):
+       render the Weight column only, leave Rationale blank
+     Omit SILENT (S) dimensions from the table (consistent with finding-count suppression).
+     If `dimension_weight_rationale` is entirely empty (no entries for any dimension),
+     omit the Dimension Rationale subsection entirely — do not render an empty table.
    - Dimension scorecard table (dimension → weight → findings count → severity summary)
    - Adversarial findings section (red-team findings, each marked `requires_decision: true`)
    - **Cannot Assess** section with at least 2 items (dimensions where evaluation was

--- a/tests/skills/test_review_design_contracts.py
+++ b/tests/skills/test_review_design_contracts.py
@@ -206,6 +206,44 @@ def test_dashboard_yaml_summary_block(skill_text):
     )
 
 
+def test_evaluation_dashboard_includes_rationale_section(skill_text: str) -> None:
+    """evaluation_dashboard must include a Dimension Rationale subsection."""
+    step7_text = skill_text_between("### Step 7", "### Step 8", skill_text)
+    assert "Dimension Rationale" in step7_text, (
+        "Step 7 evaluation_dashboard must include a 'Dimension Rationale' subsection "
+        "that surfaces dimension_weight_rationale entries from ExperimentTypeSpec"
+    )
+
+
+def test_rationale_table_structure_in_dashboard(skill_text: str) -> None:
+    """Dimension Rationale subsection must specify Dimension, Weight, and Rationale columns."""
+    step7_text = skill_text_between("### Step 7", "### Step 8", skill_text)
+    for column in ("Dimension", "Weight", "Rationale"):
+        assert column in step7_text, f"Dimension Rationale table must include a '{column}' column"
+
+
+def test_rationale_subsection_references_experiment_type_spec(skill_text: str) -> None:
+    """Dimension Rationale subsection must reference dimension_weight_rationale field."""
+    step7_text = skill_text_between("### Step 7", "### Step 8", skill_text)
+    assert "dimension_weight_rationale" in step7_text, (
+        "Step 7 must reference the dimension_weight_rationale field from ExperimentTypeSpec "
+        "so the LLM knows where to source the rationale data"
+    )
+
+
+def test_rationale_handles_missing_rationale_gracefully(skill_text: str) -> None:
+    """Dimension Rationale subsection must document behavior for types with no rationale."""
+    step7_text = skill_text_between("### Step 7", "### Step 8", skill_text)
+    rationale_idx = step7_text.find("Dimension Rationale")
+    assert rationale_idx != -1, "Dimension Rationale subsection not found"
+    rationale_section = step7_text[rationale_idx:]
+    text_lower = rationale_section.lower()
+    assert "omit" in text_lower or "skip" in text_lower or "no rationale" in text_lower, (
+        "Dimension Rationale subsection must document behavior when "
+        "dimension_weight_rationale is empty (legacy types)"
+    )
+
+
 # ── Output token format ──────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Surface the `dimension_weight_rationale` data — already present in `ExperimentTypeSpec` and populated in 7 experiment-type YAMLs — as a "Dimension Rationale" subsection in the review-design Step 7 `evaluation_dashboard` output. The infrastructure (dataclass field, parser, YAML entries, coverage test) is fully implemented; the only remaining work is adding the subsection specification to `SKILL.md` and a contract test to enforce its presence.

Closes #857

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260505-154356-840182/.autoskillit/temp/make-plan/expose_dimension_weight_rationale_plan_2026-05-05_155200.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 73 | 7.5k | 949.5k | 66.7k | 64 | 53.6k | 5m 28s |
| verify | 1 | 28 | 4.0k | 323.1k | 59.6k | 54 | 29.0k | 3m 10s |
| implement | 1 | 118 | 5.4k | 412.0k | 35.6k | 34 | 22.9k | 2m 29s |
| prepare_pr | 1 | 60 | 4.8k | 178.8k | 32.4k | 18 | 20.0k | 1m 27s |
| compose_pr | 1 | 59 | 1.9k | 157.4k | 25.7k | 15 | 12.7k | 53s |
| review_pr | 1 | 84 | 9.6k | 326.4k | 42.8k | 31 | 30.7k | 2m 7s |
| resolve_queue_merge_conflicts | 1 | 140 | 4.8k | 616.8k | 48.8k | 38 | 36.0k | 1m 37s |
| **Total** | | 562 | 38.0k | 3.0M | 66.7k | | 204.9k | 17m 14s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 54 | 7630.1 | 423.1 | 100.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_queue_merge_conflicts | 252 | 2447.7 | 142.9 | 19.1 |
| **Total** | **306** | 9686.2 | 669.7 | 124.0 |