### PR TITLE
Deduplicate Migration and Recipe Identity Tests

### DIFF
--- a/tests/migration/test_engine.py
+++ b/tests/migration/test_engine.py
@@ -467,12 +467,6 @@ class TestMigrationEngine:
         assert result.error is not None
         assert "output" in result.error.lower()
 
-    # ME21
-    def test_default_engine_has_both_adapters(self) -> None:
-        engine = default_migration_engine()
-        assert engine.get_adapter("recipe") is not None
-        assert engine.get_adapter("contract") is not None
-
 
 class TestAdapterHierarchy:
     # ME-ADP1

--- a/tests/migration/test_loader.py
+++ b/tests/migration/test_loader.py
@@ -343,24 +343,6 @@ class TestApplicableMigrations:
         result = applicable_migrations("0.1.0", "0.3.0")
         assert result == []
 
-    def test_already_at_installed_version_returns_empty(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Script already at installed_version returns empty list."""
-        self._setup_migrations(
-            tmp_path,
-            monkeypatch,
-            [
-                {
-                    "from_version": "0.1.0",
-                    "to_version": "0.2.0",
-                    "description": "Never needed",
-                }
-            ],
-        )
-        result = applicable_migrations("0.2.0", "0.2.0")
-        assert result == []
-
     def test_no_migrations_available_returns_empty(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/recipe/test_identity.py
+++ b/tests/recipe/test_identity.py
@@ -136,21 +136,6 @@ def test_composite_hash_no_dependencies_differs_from_content_hash(tmp_path):
     assert composite != content
 
 
-def test_composite_hash_includes_domain_separator(tmp_path):
-    from autoskillit.recipe.identity import compute_composite_hash
-    from autoskillit.recipe.io import load_recipe
-
-    skills_dir = tmp_path / "skills"
-    skills_dir.mkdir()
-
-    p = _write_recipe(tmp_path)
-    recipe = load_recipe(p)
-    composite = compute_composite_hash(p, recipe, skills_dir=skills_dir, project_dir=tmp_path)
-    naive = "sha256:" + hashlib.sha256(p.read_bytes()).hexdigest()
-
-    assert composite != naive
-
-
 # ---------------------------------------------------------------------------
 # Part B: find_prior_runs tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Remove three validated duplicate tests from the test suite:
- `test_already_at_installed_version_returns_empty` in `tests/migration/test_loader.py` (identical to ML8)
- `test_composite_hash_includes_domain_separator` in `tests/recipe/test_identity.py` (identical to preceding test)
- `test_default_engine_has_both_adapters` in `tests/migration/test_engine.py` (subsumed by ME15)

Closes #1884

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260505-171900-079242/.autoskillit/temp/make-plan/deduplicate_migration_and_recipe_identity_tests_plan_2026-05-05_171900.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 44 | 3.0k | 235.9k | 33.8k | 26 | 22.4k | 2m 12s |
| verify | 1 | 30 | 4.2k | 355.8k | 35.5k | 28 | 22.5k | 2m 24s |
| implement | 1 | 114.8k | 3.3k | 309.6k | 30.9k | 34 | 25.2k | 1m 30s |
| prepare_pr | 1 | 60 | 3.8k | 165.4k | 28.9k | 17 | 16.5k | 1m 3s |
| compose_pr | 1 | 59 | 1.5k | 155.5k | 25.3k | 15 | 12.3k | 36s |
| review_pr | 1 | 100 | 9.5k | 395.4k | 42.7k | 36 | 29.9k | 2m 59s |
| **Total** | | 115.1k | 25.5k | 1.6M | 42.7k | | 128.8k | 10m 47s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 39 | 7937.7 | 646.8 | 85.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **39** | 41475.2 | 3301.9 | 652.7 |