### PR TITLE
Implementation Plan: Deduplicate Doctor and Config Layer Tests

### DIFF
--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -287,71 +287,6 @@ class TestCLIDoctor:
         captured = capsys.readouterr()
         assert "ERROR:" in captured.out
 
-    # DOC-REG-1
-    def test_doctor_includes_mcp_server_registered_check(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
-    ) -> None:
-        """doctor run_doctor() results include mcp_server_registered check."""
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        monkeypatch.chdir(tmp_path)
-        cli.doctor_cmd(output_json=True)
-        captured = capsys.readouterr()
-        data = json.loads(captured.out)
-        check_names = {r["check"] for r in data["results"]}
-        assert "mcp_server_registered" in check_names
-
-    # DOC-REG-2
-    def test_doctor_includes_hook_registration_check(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
-    ) -> None:
-        """doctor run_doctor() results include hook_registration check."""
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        monkeypatch.chdir(tmp_path)
-        cli.doctor_cmd(output_json=True)
-        captured = capsys.readouterr()
-        data = json.loads(captured.out)
-        check_names = {r["check"] for r in data["results"]}
-        assert "hook_registration" in check_names
-
-    # DOC-REG-3
-    def test_doctor_marketplace_freshness_absent(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
-    ) -> None:
-        """marketplace_freshness does NOT appear in doctor results."""
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        monkeypatch.chdir(tmp_path)
-        cli.doctor_cmd(output_json=True)
-        captured = capsys.readouterr()
-        data = json.loads(captured.out)
-        check_names = {r["check"] for r in data["results"]}
-        assert "marketplace_freshness" not in check_names
-
-    # DOC-REG-4
-    def test_doctor_plugin_metadata_absent(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
-    ) -> None:
-        """plugin_metadata does NOT appear in doctor results."""
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        monkeypatch.chdir(tmp_path)
-        cli.doctor_cmd(output_json=True)
-        captured = capsys.readouterr()
-        data = json.loads(captured.out)
-        check_names = {r["check"] for r in data["results"]}
-        assert "plugin_metadata" not in check_names
-
-    # DOC-REG-5
-    def test_doctor_duplicate_mcp_server_absent(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
-    ) -> None:
-        """duplicate_mcp_server does NOT appear in doctor results."""
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        monkeypatch.chdir(tmp_path)
-        cli.doctor_cmd(output_json=True)
-        captured = capsys.readouterr()
-        data = json.loads(captured.out)
-        check_names = {r["check"] for r in data["results"]}
-        assert "duplicate_mcp_server" not in check_names
-
     # DOC-REG-6
     def test_doctor_mcp_server_registered_warns_when_absent(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
@@ -429,9 +364,7 @@ class TestGroupFDoctor:
         """Severity and DoctorResult must be importable from autoskillit.cli.doctor."""
         from autoskillit.cli.doctor import DoctorResult, Severity
 
-        r = DoctorResult(severity=Severity.OK, check="test", message="ok")
-        assert r.severity == Severity.OK
-        assert r.check == "test"
+        DoctorResult(severity=Severity.OK, check="test", message="ok")
 
 
 def test_doctor_fix_parameter_does_not_exist():

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -364,7 +364,9 @@ class TestGroupFDoctor:
         """Severity and DoctorResult must be importable from autoskillit.cli.doctor."""
         from autoskillit.cli.doctor import DoctorResult, Severity
 
-        DoctorResult(severity=Severity.OK, check="test", message="ok")
+        r = DoctorResult(severity=Severity.OK, check="test", message="ok")
+        assert r.severity == Severity.OK
+        assert r.check == "test"
 
 
 def test_doctor_fix_parameter_does_not_exist():

--- a/tests/config/test_branching_config.py
+++ b/tests/config/test_branching_config.py
@@ -11,9 +11,6 @@ pytestmark = [pytest.mark.layer("config"), pytest.mark.small]
 
 
 class TestBranchingConfig:
-    def test_branching_config_default_base_branch_is_main(self) -> None:
-        assert BranchingConfig().default_base_branch == "main"
-
     def test_automation_config_has_branching_field(self) -> None:
         """AutomationConfig must expose a BranchingConfig as .branching."""
         cfg = AutomationConfig()

--- a/tests/config/test_providers_config.py
+++ b/tests/config/test_providers_config.py
@@ -41,12 +41,6 @@ class TestProvidersConfig:
         features_idx = field_names.index("features")
         assert fleet_idx < providers_idx < features_idx
 
-    def test_providers_config_importable_from_package(self) -> None:
-        from autoskillit.config import ProvidersConfig as PC
-        from autoskillit.config.settings import ProvidersConfig
-
-        assert PC is ProvidersConfig
-
     def test_from_dynaconf_providers_defaults(self, tmp_path) -> None:
         from autoskillit.config import load_config
 


### PR DESCRIPTION
## Summary

Delete four groups of redundant test code across three test files: five subsumed DOC-REG tests and two round-trip assertions in `tests/cli/test_doctor.py`, one subsumed branching-config test in `tests/config/test_branching_config.py`, and one duplicated identity assertion in `tests/config/test_providers_config.py`. Net deletion of ~75 lines with zero behavioral coverage loss.

Closes #1885

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260505-171900-679526/.autoskillit/temp/make-plan/deduplicate_doctor_and_config_layer_tests_plan_2026-05-05_171900.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 1.1k | 4.5k | 331.1k | 47.1k | 29 | 36.4k | 2m 25s |
| verify | 1 | 36 | 8.5k | 316.3k | 51.0k | 28 | 37.9k | 3m 11s |
| implement | 1 | 541.2k | 4.6k | 534.6k | 25.6k | 51 | 16.0k | 5m 54s |
| prepare_pr | 1 | 60 | 4.6k | 174.1k | 30.8k | 17 | 18.3k | 1m 22s |
| compose_pr | 1 | 51 | 2.1k | 132.8k | 25.8k | 14 | 12.8k | 42s |
| review_pr | 1 | 100 | 12.2k | 414.4k | 45.4k | 36 | 33.9k | 3m 3s |
| resolve_review | 1 | 173 | 7.8k | 766.8k | 49.7k | 61 | 36.6k | 4m 11s |
| **Total** | | 542.7k | 44.2k | 2.7M | 51.0k | | 191.9k | 20m 51s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 78 | 6853.9 | 205.2 | 58.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 4 | 191709.5 | 9161.2 | 1944.0 |
| **Total** | **82** | 32562.2 | 2339.8 | 539.2 |