### PR TITLE
Deduplicate test_gate.py — remove tautological and subsumed tests

### DIFF
--- a/tests/core/test_type_constants.py
+++ b/tests/core/test_type_constants.py
@@ -273,3 +273,20 @@ def test_provider_profile_in_private_env_vars() -> None:
     from autoskillit.core import AUTOSKILLIT_PRIVATE_ENV_VARS
 
     assert "AUTOSKILLIT_PROVIDER_PROFILE" in AUTOSKILLIT_PRIVATE_ENV_VARS
+
+
+def test_headless_tools_contains_expected_names():
+    from autoskillit.core.types import HEADLESS_TOOLS
+
+    assert HEADLESS_TOOLS == {"test_check"}
+
+
+def test_free_range_tools_contains_expected_names():
+    from autoskillit.core.types import FREE_RANGE_TOOLS
+
+    assert FREE_RANGE_TOOLS == {
+        "open_kitchen",
+        "close_kitchen",
+        "disable_quota_guard",
+        "reload_session",
+    }

--- a/tests/pipeline/test_gate.py
+++ b/tests/pipeline/test_gate.py
@@ -165,35 +165,6 @@ def test_gate_imports_only_from_core():
                     )
 
 
-def test_gated_tools_does_not_contain_run_recipe():
-    from autoskillit.pipeline.gate import GATED_TOOLS
-
-    assert "run_recipe" not in GATED_TOOLS
-
-
-def test_headless_tools_contains_expected_names():
-    from autoskillit.core.types import HEADLESS_TOOLS
-
-    assert HEADLESS_TOOLS == {"test_check"}
-
-
-def test_free_range_tools_contains_expected_names():
-    from autoskillit.core.types import FREE_RANGE_TOOLS
-
-    assert FREE_RANGE_TOOLS == {
-        "open_kitchen",
-        "close_kitchen",
-        "disable_quota_guard",
-        "reload_session",
-    }
-
-
-def test_ungated_tools_equals_free_range_tools():
-    from autoskillit.core.types import FREE_RANGE_TOOLS, UNGATED_TOOLS
-
-    assert UNGATED_TOOLS == FREE_RANGE_TOOLS
-
-
 def test_all_tool_sets_disjoint_and_complete():
     from autoskillit.core.types import HEADLESS_TOOLS
     from autoskillit.pipeline.gate import GATED_TOOLS, UNGATED_TOOLS


### PR DESCRIPTION
## Summary

Remove two redundant tests from `tests/pipeline/test_gate.py` and relocate two misplaced tests to `tests/core/test_type_constants.py`. Specifically: delete the tautological `test_ungated_tools_equals_free_range_tools` (C2-7), delete the subsumed `test_gated_tools_does_not_contain_run_recipe` (C2-8), and move `test_headless_tools_contains_expected_names` and `test_free_range_tools_contains_expected_names` to their correct import layer (C5-4).

Closes #1883

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260505-171859-167830/.autoskillit/temp/make-plan/deduplicate_test_gate_py_plan_2026-05-05_172600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 46 | 5.6k | 380.6k | 49.7k | 25 | 39.5k | 3m 11s |
| verify | 1 | 35 | 4.7k | 297.3k | 54.2k | 28 | 41.2k | 2m 23s |
| implement | 1 | 210.1k | 3.8k | 355.6k | 25.6k | 43 | 16.1k | 5m 42s |
| prepare_pr | 1 | 60 | 3.8k | 173.0k | 30.4k | 17 | 17.8k | 1m 4s |
| compose_pr | 1 | 67 | 2.3k | 183.7k | 25.9k | 17 | 13.0k | 47s |
| review_pr | 1 | 92 | 13.1k | 364.3k | 45.9k | 34 | 34.0k | 3m 41s |
| resolve_review | 1 | 205 | 9.1k | 892.2k | 47.2k | 59 | 34.7k | 4m 30s |
| **Total** | | 210.6k | 42.3k | 2.6M | 54.2k | | 196.3k | 21m 20s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 46 | 7729.8 | 350.5 | 82.7 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **46** | 57534.0 | 4267.1 | 919.6 |