### PR TITLE
Implementation Plan: Deduplicate Session-Type, Kitchen-Rules, and Skill-Count Tests

### DIFF
--- a/tests/core/test_session_type.py
+++ b/tests/core/test_session_type.py
@@ -137,14 +137,6 @@ def test_leaf_value_maps_to_skill_with_deprecation_warning(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_session_type_invalid_session_type_emits_warning(monkeypatch):
-    from autoskillit.core import session_type
-
-    monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "franchise")
-    with pytest.warns(DeprecationWarning, match="Invalid"):
-        session_type()
-
-
 def test_session_type_enum_fleet_value():
     from autoskillit.core import SessionType
 

--- a/tests/recipe/test_io_parsing.py
+++ b/tests/recipe/test_io_parsing.py
@@ -532,37 +532,18 @@ def test_load_recipe_preserves_step_description(tmp_path: Path) -> None:
     assert recipe.steps["build"].description == "Run the full build suite"
 
 
-def test_parse_recipe_kitchen_rules_string_raises() -> None:
-    """_parse_recipe raises ValueError when kitchen_rules is a string."""
+@pytest.mark.parametrize(
+    "bad_val",
+    ["not-a-list", {"rule": "val"}, 42],
+    ids=["string", "dict", "int"],
+)
+def test_parse_recipe_kitchen_rules_rejects_non_list(bad_val: object) -> None:
+    """_parse_recipe raises ValueError when kitchen_rules is not a list."""
     with pytest.raises(ValueError, match="kitchen_rules"):
         _parse_recipe(
             {
                 "name": "bad",
-                "kitchen_rules": "not-a-list",
-                "steps": {"s": {"tool": "run_cmd"}},
-            }
-        )
-
-
-def test_parse_recipe_kitchen_rules_dict_raises() -> None:
-    """_parse_recipe raises ValueError when kitchen_rules is a dict."""
-    with pytest.raises(ValueError, match="kitchen_rules"):
-        _parse_recipe(
-            {
-                "name": "bad",
-                "kitchen_rules": {"rule": "val"},
-                "steps": {"s": {"tool": "run_cmd"}},
-            }
-        )
-
-
-def test_parse_recipe_kitchen_rules_int_raises() -> None:
-    """_parse_recipe raises ValueError when kitchen_rules is an int."""
-    with pytest.raises(ValueError, match="kitchen_rules"):
-        _parse_recipe(
-            {
-                "name": "bad",
-                "kitchen_rules": 42,
+                "kitchen_rules": bad_val,
                 "steps": {"s": {"tool": "run_cmd"}},
             }
         )

--- a/tests/workspace/test_skills.py
+++ b/tests/workspace/test_skills.py
@@ -446,17 +446,17 @@ class TestSkillResolver:
         assert names == {"open-kitchen", "close-kitchen", "sous-chef"}
 
     def test_skills_in_skills_extended(self) -> None:
-        """skills_extended/ contains at least 100 SKILL.md-carrying directories."""
+        """skills_extended/ contains at least 125 SKILL.md-carrying directories."""
         skills = [
             d
             for d in bundled_skills_extended_dir().iterdir()
             if d.is_dir() and (d / "SKILL.md").is_file()
         ]
-        assert len(skills) >= 100
+        assert len(skills) >= 125
 
     def test_skill_resolver_list_all_minimum_count(self) -> None:
-        """list_all() returns at least 100 public skills (2 Tier-1 + extended)."""
-        assert len(DefaultSkillResolver().list_all()) >= 100
+        """list_all() returns at least 128 public skills (2 Tier-1 + extended)."""
+        assert len(DefaultSkillResolver().list_all()) >= 128
 
     def test_skill_resolver_resolve_extended_skill(self) -> None:
         """resolve() finds a skill living in skills_extended/ with BUNDLED_EXTENDED source."""

--- a/tests/workspace/test_skills.py
+++ b/tests/workspace/test_skills.py
@@ -445,18 +445,18 @@ class TestSkillResolver:
         names = {d.name for d in bundled_skills_dir().iterdir() if d.is_dir()}
         assert names == {"open-kitchen", "close-kitchen", "sous-chef"}
 
-    def test_128_skills_in_skills_extended(self) -> None:
-        """skills_extended/ contains exactly 129 SKILL.md-carrying directories."""
+    def test_skills_in_skills_extended(self) -> None:
+        """skills_extended/ contains at least 100 SKILL.md-carrying directories."""
         skills = [
             d
             for d in bundled_skills_extended_dir().iterdir()
             if d.is_dir() and (d / "SKILL.md").is_file()
         ]
-        assert len(skills) == 129
+        assert len(skills) >= 100
 
-    def test_skill_resolver_list_all_total_count(self) -> None:
-        """list_all() returns 131 public skills (2 Tier-1 + 129 extended)."""
-        assert len(DefaultSkillResolver().list_all()) == 131
+    def test_skill_resolver_list_all_minimum_count(self) -> None:
+        """list_all() returns at least 100 public skills (2 Tier-1 + extended)."""
+        assert len(DefaultSkillResolver().list_all()) >= 100
 
     def test_skill_resolver_resolve_extended_skill(self) -> None:
         """resolve() finds a skill living in skills_extended/ with BUNDLED_EXTENDED source."""


### PR DESCRIPTION
## Summary

Remove redundant and brittle test code across three test modules: parametrize the three identical kitchen_rules rejection tests, delete the duplicate session-type warning test, and convert exact skill-count assertions to lower-bound checks. No production code changes.

Closes #1886

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260505-180602-586205/.autoskillit/temp/make-plan/deduplicate_session_type_kitchen_rules_skill_count_tests_plan_2026-05-05_180602.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 47 | 4.1k | 391.6k | 44.2k | 27 | 32.9k | 2m 6s |
| verify | 1 | 36 | 5.4k | 276.4k | 40.9k | 51 | 29.6k | 4m 55s |
| implement | 1 | 244.8k | 3.8k | 358.4k | 25.6k | 41 | 38.8k | 1m 41s |
| prepare_pr | 1 | 68 | 3.9k | 195.2k | 31.1k | 19 | 18.8k | 1m 24s |
| compose_pr | 1 | 51 | 2.2k | 133.2k | 26.0k | 14 | 13.0k | 52s |
| review_pr | 1 | 100 | 13.1k | 416.3k | 47.2k | 35 | 36.3k | 3m 45s |
| resolve_review | 1 | 205 | 12.5k | 1.1M | 61.9k | 63 | 48.9k | 5m 25s |
| **Total** | | 245.3k | 45.0k | 2.8M | 61.9k | | 218.2k | 20m 11s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 55 | 6516.1 | 704.5 | 68.4 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 8 | 132463.4 | 6108.4 | 1565.9 |
| **Total** | **63** | 44932.0 | 3463.9 | 713.9 |