### PR TITLE
fix: resolve-failures ci_only_failure verdict when fix was applied

### DIFF
--- a/src/autoskillit/skills_extended/resolve-failures/SKILL.md
+++ b/src/autoskillit/skills_extended/resolve-failures/SKILL.md
@@ -66,7 +66,7 @@ clear the collection, then re-apply the baseline state — not inverse operation
 
 When context is exhausted mid-execution, edits may be on disk but not committed.
 The recipe routes to `on_context_limit` (typically `test`), bypassing the normal
-commit protocol in Step 3.
+commit protocol during the fix loop.
 
 **Before every test run and before emitting structured output tokens:**
 1. Run `git -C {worktree_path} status --porcelain`
@@ -130,7 +130,7 @@ If `diagnosis_path` was provided and the file exists:
 1. Open `diagnosis_path` and read its content
 2. Find the "Structured Output" section or scan for the line matching `failure_subtype = {value}`
 3. Extract the `failure_subtype` value (e.g., `flaky`, `deterministic`, `timing_race`, etc.)
-4. Store as `{failure_subtype}` for use in Step 2d
+4. Store as `{failure_subtype}` for use in the Verdict Decision Tree
 
 If `diagnosis_path` is absent or the file does not exist:
 - Set `{failure_subtype} = unknown`
@@ -154,14 +154,29 @@ This ensures local test results match CI behavior. Skip if no pre-test generatio
    `test_check` blocks synchronously and returns `passed: true/false` in a single call.
 2. Record the result as `{local_result}`: PASS (`passed: true`) or FAIL (`passed: false`)
 
-### Step 2d: Verdict Decision Tree
+### Step 2c: Verdict Override Rule
+
+**This rule takes precedence over the decision table below.**
+
+If at ANY point during this skill's execution a code change was committed
+(i.e., the fix loop was entered and produced at least one commit) AND the final
+`test_check` result is PASS:
+
+→ `verdict = real_fix` — unconditionally, regardless of `failure_subtype`.
+
+The decision table below applies ONLY when no fix was committed during this
+invocation. Once a fix is applied and tests pass, the verdict is `real_fix`
+and the table is never consulted.
+
+### Step 2d: No-Fix Verdict Decision Tree
+
+**Applies ONLY when no fix was applied (fixes_applied == 0).** If the fix loop was entered
+and a commit was made, skip this table — verdict is already `real_fix` per Step 2c.
 
 Using `{local_result}` from Step 2 and `{failure_subtype}` from Step 2a, determine `{verdict}`:
 
 | Local result | `failure_subtype` | Verdict |
 |---|---|---|
-| FAIL → (fix applied in Step 3) → PASS | any | `real_fix` |
-| FAIL → (no fix possible after 3 iterations) | any | proceed to Step 5 |
 | PASS | `flaky` or `timing_race` | `flake_suspected` |
 | PASS | `deterministic` | `ci_only_failure` |
 | PASS | `fixture` or `import` | `flake_suspected` |
@@ -175,10 +190,10 @@ resolve-failures will now emit `real_fix` or another verdict. `already_green` is
 not emitted by this skill's primary workflow.
 
 If local tests PASS (no fix needed): go to Step 2.5 (Validate CI Resolution) before
-proceeding to Step 4 — the CI-truth gate may redirect to Step 3 for flakiness
+proceeding to Step 4 — the CI-truth gate may redirect to the fix loop for flakiness
 investigation even when local tests pass.
 
-If local tests FAIL: enter Step 3.
+If local tests FAIL: enter the fix loop.
 
 ### Step 2.5: Validate CI Resolution
 
@@ -199,10 +214,13 @@ the failure could not be reproduced locally, which is a flaky-test signal.
       - Do **NOT** proceed to Step 4
       - Log: "CI failure on [test name] — local pass is not a resolution (flaky test
         signal). Entering fix loop to investigate and stabilize."
-      - Proceed to **Step 3 (Fix Loop)** to investigate the non-determinism, timing
+      - Proceed to **the Fix Loop** to investigate the non-determinism, timing
         dependencies, or race conditions that caused the test to pass locally but fail
         in CI. Apply a stabilizing fix (e.g., increase timeouts, remove timing
         dependencies, add retry guards, fix resource cleanup).
+      - When the fix loop applies a stabilizing fix and tests pass, emit `verdict = real_fix`
+        (per Step 2c override). Do NOT fall back to the Step 2d table — the fix
+        resolves the CI failure regardless of the original `failure_subtype`.
    d. If `failure_type` is not "test" (e.g., "lint", "build") and tests pass locally:
       - Proceed to Step 4 — local pass resolves non-test CI failures (lint/build
         failures are deterministic; they don't pass locally while failing remotely).
@@ -231,7 +249,7 @@ the failure could not be reproduced locally, which is a flaky-test signal.
    - The specific error message for each failure (first 10–15 lines)
    Discard the full pytest stdout — do not retain progress dots, install-worktree
    output, or timing lines. These accumulate across iterations and inflate context.
-6. Green → Step 4 (with `verdict = real_fix`); Red and < 3 iterations → repeat; Red and >= 3 → Step 5
+6. Green → `verdict = real_fix` (per Step 2c override — do not re-evaluate Step 2d) → Step 4; Red and < 3 iterations → repeat; Red and >= 3 → Step 5
 
 ### Step 4: Report
 
@@ -255,13 +273,16 @@ fixes_applied = {N}
 
 Where:
 - `{verdict}` is one of: `real_fix`, `flake_suspected`, `ci_only_failure`
-- `{N}` is the number of fix iterations performed (0 for non-real_fix verdicts, ≥1 for `real_fix`)
+- `{N}` is the number of fix iterations performed (0 for `flake_suspected` or `ci_only_failure` verdicts, ≥1 for `real_fix`)
 
 Return control to the orchestrator. The recipe's `on_result:` routing dispatches
 on `verdict`:
 - `real_fix` → `re_push` (fix landed, push to remote)
 - `flake_suspected` → `re_push` (retry via CI, bounded by retries: 2 / on_exhausted: release_issue_failure)
 - `ci_only_failure` → `release_issue_failure` (human escalation)
+
+**Invariant:** `ci_only_failure` is NEVER emitted when `fixes_applied >= 1`. If a fix was
+committed during this invocation and tests pass, the verdict is always `real_fix`.
 
 ### Step 5: Report Failure
 - Total fix iterations attempted

--- a/tests/skills/test_resolve_failures_ci_aware.py
+++ b/tests/skills/test_resolve_failures_ci_aware.py
@@ -253,11 +253,11 @@ def test_ci_only_failure_requires_no_fix_applied(skill_text: str) -> None:
 def test_step3_green_always_yields_real_fix(skill_text: str) -> None:
     """Step 3 fix loop: green after fix MUST yield real_fix, never re-evaluates Step 2d."""
     step3_match = re.search(
-        r"Step 3.*?Step 4",
+        r"### Step 3.*?(?=\n### Step [45]|\Z)",
         skill_text,
         re.DOTALL,
     )
-    assert step3_match is not None, "Step 3 section must exist and precede Step 4"
+    assert step3_match is not None, "### Step 3 section must exist in SKILL.md"
     step3_text = step3_match.group(0)
     assert "real_fix" in step3_text, "Step 3 must directly assign verdict = real_fix on green exit"
     assert "step 2d" not in step3_text.lower() or "do not" in step3_text.lower(), (

--- a/tests/skills/test_resolve_failures_ci_aware.py
+++ b/tests/skills/test_resolve_failures_ci_aware.py
@@ -80,7 +80,7 @@ def test_skill_maps_flaky_to_flake_suspected(skill_text: str) -> None:
 
 
 def test_skill_maps_deterministic_green_to_ci_only_failure(skill_text: str) -> None:
-    """Scenario B: deterministic + local tests green → ci_only_failure."""
+    """Scenario B: deterministic + local tests green + NO FIX APPLIED → ci_only_failure."""
     assert "ci_only_failure" in skill_text, (
         "resolve-failures SKILL.md must include 'ci_only_failure' verdict value "
         "for the deterministic subtype + local-green scenario"
@@ -191,4 +191,75 @@ def test_env_subtype_maps_to_flake_suspected_not_ci_only(skill_text: str) -> Non
     assert verdict == "flake_suspected", (
         f"'env' subtype must map to 'flake_suspected', got '{verdict}'. "
         "Ambiguous subtypes should not be routed to abort."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Post-fix override guards (REQ-RF-001, REQ-RF-002)
+# ---------------------------------------------------------------------------
+
+
+def test_skill_fix_applied_overrides_to_real_fix(skill_text: str) -> None:
+    """When a fix is committed and tests pass, verdict MUST be real_fix regardless of subtype."""
+    assert re.search(
+        r"fix.*(commit|applied).*verdict.*real_fix", skill_text, re.IGNORECASE
+    ) or re.search(r"real_fix.*regardless.*failure_subtype", skill_text, re.IGNORECASE), (
+        "resolve-failures SKILL.md must contain an explicit override rule: "
+        "when a fix is committed and tests pass, verdict is always real_fix "
+        "regardless of failure_subtype"
+    )
+
+
+def test_step2d_table_scoped_to_no_fix_path(skill_text: str) -> None:
+    """Step 2d verdict table must only apply when no fix was applied."""
+    # Capture the full Step 2d section (from header to next ### heading or EOF)
+    table_section_match = re.search(
+        r"Step 2d.*?(?=\n### |\Z)",
+        skill_text,
+        re.DOTALL,
+    )
+    assert table_section_match is not None, "Step 2d section must exist"
+    table_section = table_section_match.group(0)
+    assert any(
+        phrase in table_section.lower()
+        for phrase in (
+            "no fix applied",
+            "no fix was applied",
+            "fixes_applied == 0",
+            "without entering step 3",
+        )
+    ), (
+        "Step 2d verdict decision table must explicitly state it applies only "
+        "when no fix was applied — prevents LLM from re-evaluating after Step 3"
+    )
+
+
+def test_ci_only_failure_requires_no_fix_applied(skill_text: str) -> None:
+    """ci_only_failure must only be emittable when no fix was applied."""
+    assert re.search(
+        r"ci_only_failure.*(no fix|never.*fix.*applied|fixes_applied.*0|without.*commit)",
+        skill_text,
+        re.IGNORECASE | re.DOTALL,
+    ) or re.search(
+        r"(no fix|never.*fix|fixes_applied.*0).*ci_only_failure",
+        skill_text,
+        re.IGNORECASE | re.DOTALL,
+    ), (
+        "resolve-failures SKILL.md must explicitly state that ci_only_failure "
+        "is only emitted when no fix was applied"
+    )
+
+
+def test_step3_green_always_yields_real_fix(skill_text: str) -> None:
+    """Step 3 fix loop: green after fix MUST yield real_fix, never re-evaluates Step 2d."""
+    step3_match = re.search(
+        r"Step 3.*?Step 4",
+        skill_text,
+        re.DOTALL,
+    )
+    assert step3_match is not None, "Step 3 section must exist and precede Step 4"
+    step3_text = step3_match.group(0)
+    assert "real_fix" in step3_text, "Step 3 must directly assign verdict = real_fix on green exit"
+    assert "step 2d" not in step3_text.lower() or "do not" in step3_text.lower(), (
+        "Step 3 must not redirect back to Step 2d for verdict evaluation"
     )


### PR DESCRIPTION
## Summary

The `resolve-failures` SKILL.md has an ambiguous verdict decision flow that allows an LLM executor to emit `ci_only_failure` even after successfully applying a fix. The fix restructures the Step 2d decision tree to make the override rule explicit: **any time a code change is committed and tests pass, the verdict is `real_fix`, regardless of `failure_subtype`**. The Step 2d table is clarified to apply ONLY to the "no fix applied" path, and a post-fix-loop verdict override is added to prevent re-evaluation through the wrong decision path.

## Requirements

- REQ-RF-001: When `resolve-failures` applies a code change AND the subsequent CI run passes, the verdict MUST be `real_fix`, not `ci_only_failure`
- REQ-RF-002: `ci_only_failure` should only be emitted when no fix was applied or when the applied fix did not resolve the CI failure
- REQ-RF-003: The fix must not break the existing `ci_only_failure` path for genuinely unfixable CI failures

Closes #1954

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260505-180603-520539/.autoskillit/temp/make-plan/resolve_failures_ci_only_failure_verdict_fix_plan_2026-05-05_181000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 52 | 11.3k | 677.5k | 78.1k | 83 | 52.0k | 8m 25s |
| verify | 1 | 46 | 13.6k | 941.1k | 63.6k | 49 | 50.5k | 5m 18s |
| implement | 1 | 3.3M | 37.4k | 1.7M | 25.6k | 152 | 42.0k | 16m 53s |
| prepare_pr | 1 | 60 | 4.1k | 182.5k | 35.8k | 17 | 23.4k | 1m 27s |
| compose_pr | 1 | 59 | 2.2k | 159.8k | 26.2k | 15 | 13.2k | 56s |
| review_pr | 1 | 260 | 21.0k | 809.4k | 59.7k | 59 | 48.5k | 6m 59s |
| resolve_review | 1 | 197 | 9.5k | 911.4k | 50.7k | 58 | 38.0k | 4m 57s |
| **Total** | | 3.3M | 99.1k | 5.3M | 78.1k | | 267.7k | 44m 57s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 114 | 14574.8 | 368.9 | 327.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 4 | 227847.0 | 9511.0 | 2371.2 |
| **Total** | **118** | 45281.8 | 2268.6 | 839.7 |