### PR TITLE
Fix test filter: hook test path mismatch silently drops three tests

### DIFF
--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -84,15 +84,22 @@ ALWAYS_RUN_AGGRESSIVE: frozenset[str] = frozenset(
 # These enforce cross-cutting registration, executability, and schema contracts.
 _INFRA_UNCONDITIONAL_FILES: frozenset[str] = frozenset(
     {
-        "test_hook_executability.py",
-        "test_hook_registration_coverage.py",
         "test_manifest_completeness.py",
-        "test_hook_registry.py",
         "test_guard_coverage.py",
         "test_session_scope_enforcement.py",
         "test_filter_activation.py",
         "test_schema_version_convention.py",
         "test_release_sanity.py",
+    }
+)
+
+# Structural hook files that run unconditionally regardless of trigger conditions.
+# These enforce cross-cutting hook registration and executability contracts.
+_HOOKS_UNCONDITIONAL_FILES: frozenset[str] = frozenset(
+    {
+        "test_hook_executability.py",
+        "test_hook_registration_coverage.py",
+        "test_hook_registry.py",
     }
 )
 
@@ -1266,9 +1273,11 @@ def build_test_scope(
         else:
             direct_test_files.add(str(tests_root / "docs" / "test_doc_counts.py"))
 
-        # REQ-TIER-003: 9 structural infra files always; full infra dir only on trigger
+        # REQ-TIER-003: 6 infra + 3 hooks structural files always; full infra dir only on trigger
         for fname in _INFRA_UNCONDITIONAL_FILES:
             direct_test_files.add(str(tests_root / "infra" / fname))
+        for fname in _HOOKS_UNCONDITIONAL_FILES:
+            direct_test_files.add(str(tests_root / "hooks" / fname))
         if any(
             f.startswith(_INFRA_HOOK_TRIGGER_PREFIX)
             or f.startswith(_INFRA_CI_TRIGGER_PREFIX)

--- a/tests/test_test_filter.py
+++ b/tests/test_test_filter.py
@@ -204,12 +204,14 @@ class TestBuildTestScope:
         assert "arch" in dir_names, "arch always-run missing"
         assert "contracts" in dir_names, "contracts always-run missing"
         # infra and docs are not directories for a non-triggering change;
-        # 9 individual infra files appear in result via direct_test_files
+        # 6 infra + 3 hooks unconditional files appear in result via direct_test_files
         result_names = {p.name for p in result}
-        from tests._test_filter import _INFRA_UNCONDITIONAL_FILES
+        from tests._test_filter import _HOOKS_UNCONDITIONAL_FILES, _INFRA_UNCONDITIONAL_FILES
 
         for fname in _INFRA_UNCONDITIONAL_FILES:
             assert fname in result_names, f"unconditional infra file {fname!r} missing"
+        for fname in _HOOKS_UNCONDITIONAL_FILES:
+            assert fname in result_names, f"unconditional hooks file {fname!r} missing"
         assert "test_doc_counts.py" in result_names
 
     def test_scope_l1_execution_conservative(self, tmp_path: Path) -> None:
@@ -324,10 +326,12 @@ class TestBuildTestScope:
         assert "server" in result_names
         assert "cli" in result_names
         assert "test_pack_enforcement.py" in result_names
-        from tests._test_filter import _INFRA_UNCONDITIONAL_FILES
+        from tests._test_filter import _HOOKS_UNCONDITIONAL_FILES, _INFRA_UNCONDITIONAL_FILES
 
         for fname in _INFRA_UNCONDITIONAL_FILES:
             assert fname in result_names, f"unconditional infra file {fname!r} missing"
+        for fname in _HOOKS_UNCONDITIONAL_FILES:
+            assert fname in result_names, f"unconditional hooks file {fname!r} missing"
         assert "infra" not in {p.name for p in result if (tests_root / p.name).is_dir()}, (
             "full infra dir should not appear for pure server change"
         )
@@ -390,10 +394,12 @@ class TestBuildTestScope:
         assert "docs" in dir_names
         assert "infra" not in dir_names  # docs change doesn't trigger full infra
         result_names = {p.name for p in result}
-        from tests._test_filter import _INFRA_UNCONDITIONAL_FILES
+        from tests._test_filter import _HOOKS_UNCONDITIONAL_FILES, _INFRA_UNCONDITIONAL_FILES
 
         for fname in _INFRA_UNCONDITIONAL_FILES:
-            assert fname in result_names
+            assert fname in result_names, f"unconditional infra file {fname!r} missing"
+        for fname in _HOOKS_UNCONDITIONAL_FILES:
+            assert fname in result_names, f"unconditional hooks file {fname!r} missing"
 
     def test_scope_none_mode_returns_disabled(self, tmp_path: Path) -> None:
         result = build_test_scope(

--- a/tests/test_test_filter.py
+++ b/tests/test_test_filter.py
@@ -26,7 +26,6 @@ from tests._test_filter import (
     build_test_scope,
     check_bucket_a,
     git_changed_files,
-    load_coverage_map,
     load_manifest,
 )
 
@@ -930,73 +929,3 @@ class TestManifestApplyManifest:
             ["src/autoskillit/recipes/cook.yaml", "docs/guide.md"], manifest
         )
         assert result == {"recipe/", "docs/"}
-
-
-# ---------------------------------------------------------------------------
-# TestLoadCoverageMap
-# ---------------------------------------------------------------------------
-
-
-class TestLoadCoverageMap:
-    def test_returns_dict_from_valid_json(self, tmp_path: Path) -> None:
-        """Parses a valid JSON map and returns dict[str, set[str]]."""
-        map_file = tmp_path / "test-source-map.json"
-        map_file.write_text(
-            '{"src/autoskillit/recipe/rules_dataflow.py": '
-            '["tests/recipe/test_rules_dataflow.py", "tests/recipe/test_rules_structure.py"]}',
-            encoding="utf-8",
-        )
-        result = load_coverage_map(map_file)
-        assert result is not None
-        assert "src/autoskillit/recipe/rules_dataflow.py" in result
-        assert isinstance(result["src/autoskillit/recipe/rules_dataflow.py"], set)
-        assert (
-            "tests/recipe/test_rules_dataflow.py"
-            in result["src/autoskillit/recipe/rules_dataflow.py"]
-        )
-
-    def test_missing_file_returns_none(self, tmp_path: Path) -> None:
-        """Returns None when the map file does not exist."""
-        result = load_coverage_map(tmp_path / "nonexistent.json")
-        assert result is None
-
-    def test_stale_file_returns_none(self, tmp_path: Path) -> None:
-        """Returns None when the file mtime is older than max_age_days."""
-        import os
-        import time
-
-        map_file = tmp_path / "test-source-map.json"
-        map_file.write_text('{"src/foo.py": ["tests/test_foo.py"]}', encoding="utf-8")
-        # Backdate mtime by 31 days
-        old_mtime = time.time() - (31 * 24 * 3600)
-        os.utime(map_file, (old_mtime, old_mtime))
-        result = load_coverage_map(map_file, max_age_days=30)
-        assert result is None
-
-    def test_fresh_file_returns_data(self, tmp_path: Path) -> None:
-        """Returns data when the file mtime is within max_age_days."""
-        map_file = tmp_path / "test-source-map.json"
-        map_file.write_text('{"src/foo.py": ["tests/test_foo.py"]}', encoding="utf-8")
-        result = load_coverage_map(map_file, max_age_days=30)
-        assert result is not None
-        assert result["src/foo.py"] == {"tests/test_foo.py"}
-
-    def test_custom_max_age_days_respected(self, tmp_path: Path) -> None:
-        """Custom max_age_days threshold is respected."""
-        import os
-        import time
-
-        map_file = tmp_path / "test-source-map.json"
-        map_file.write_text('{"src/foo.py": ["tests/test_foo.py"]}', encoding="utf-8")
-        # Backdate by 2 days — stale with max_age_days=1, fresh with max_age_days=3
-        old_mtime = time.time() - (2 * 24 * 3600)
-        os.utime(map_file, (old_mtime, old_mtime))
-        assert load_coverage_map(map_file, max_age_days=1) is None
-        assert load_coverage_map(map_file, max_age_days=3) is not None
-
-    def test_malformed_json_returns_none(self, tmp_path: Path) -> None:
-        """Returns None on JSON parse failure."""
-        map_file = tmp_path / "test-source-map.json"
-        map_file.write_text("{bad json}", encoding="utf-8")
-        result = load_coverage_map(map_file)
-        assert result is None

--- a/tests/test_test_filter_cascade.py
+++ b/tests/test_test_filter_cascade.py
@@ -202,7 +202,9 @@ class TestRecipeCascadeNarrowing:
         )
 
     def test_recipe_cascade_no_hooks_full_directory(self, tmp_path: Path) -> None:
-        # hooks/test_fmt_status.py is not in the file-level cascade; it should be excluded.
+        # hooks/test_fmt_status.py is not in the file-level cascade or hook unconditionals;
+        # it should be excluded. Unconditional hook files (test_hook_executability.py etc.)
+        # are allowed to appear since they run regardless of trigger.
         tests_root = tmp_path / "tests"
         hooks_dir = tests_root / "hooks"
         hooks_dir.mkdir(parents=True, exist_ok=True)
@@ -214,8 +216,9 @@ class TestRecipeCascadeNarrowing:
             tests_root=tests_root,
         )
         assert result is not None
-        assert not any("/hooks/" in str(p) for p in result), (
-            f"hooks/test_fmt_status.py (not in cascade) should not appear; got {result}"
+        result_names = {p.name for p in result}
+        assert "test_fmt_status.py" not in result_names, (
+            "test_fmt_status.py (not in cascade or hook unconditionals) should not appear"
         )
 
     def test_recipe_cascade_fleet_file_level_only(self, tmp_path: Path) -> None:

--- a/tests/test_test_filter_coverage_map.py
+++ b/tests/test_test_filter_coverage_map.py
@@ -1,0 +1,72 @@
+"""Tests for load_coverage_map in tests/_test_filter.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests._test_filter import load_coverage_map
+
+
+class TestLoadCoverageMap:
+    def test_returns_dict_from_valid_json(self, tmp_path: Path) -> None:
+        """Parses a valid JSON map and returns dict[str, set[str]]."""
+        map_file = tmp_path / "test-source-map.json"
+        map_file.write_text(
+            '{"src/autoskillit/recipe/rules_dataflow.py": '
+            '["tests/recipe/test_rules_dataflow.py", "tests/recipe/test_rules_structure.py"]}',
+            encoding="utf-8",
+        )
+        result = load_coverage_map(map_file)
+        assert result is not None
+        assert "src/autoskillit/recipe/rules_dataflow.py" in result
+        assert isinstance(result["src/autoskillit/recipe/rules_dataflow.py"], set)
+        assert (
+            "tests/recipe/test_rules_dataflow.py"
+            in result["src/autoskillit/recipe/rules_dataflow.py"]
+        )
+
+    def test_missing_file_returns_none(self, tmp_path: Path) -> None:
+        """Returns None when the map file does not exist."""
+        result = load_coverage_map(tmp_path / "nonexistent.json")
+        assert result is None
+
+    def test_stale_file_returns_none(self, tmp_path: Path) -> None:
+        """Returns None when the file mtime is older than max_age_days."""
+        import os
+        import time
+
+        map_file = tmp_path / "test-source-map.json"
+        map_file.write_text('{"src/foo.py": ["tests/test_foo.py"]}', encoding="utf-8")
+        # Backdate mtime by 31 days
+        old_mtime = time.time() - (31 * 24 * 3600)
+        os.utime(map_file, (old_mtime, old_mtime))
+        result = load_coverage_map(map_file, max_age_days=30)
+        assert result is None
+
+    def test_fresh_file_returns_data(self, tmp_path: Path) -> None:
+        """Returns data when the file mtime is within max_age_days."""
+        map_file = tmp_path / "test-source-map.json"
+        map_file.write_text('{"src/foo.py": ["tests/test_foo.py"]}', encoding="utf-8")
+        result = load_coverage_map(map_file, max_age_days=30)
+        assert result is not None
+        assert result["src/foo.py"] == {"tests/test_foo.py"}
+
+    def test_custom_max_age_days_respected(self, tmp_path: Path) -> None:
+        """Custom max_age_days threshold is respected."""
+        import os
+        import time
+
+        map_file = tmp_path / "test-source-map.json"
+        map_file.write_text('{"src/foo.py": ["tests/test_foo.py"]}', encoding="utf-8")
+        # Backdate by 2 days — stale with max_age_days=1, fresh with max_age_days=3
+        old_mtime = time.time() - (2 * 24 * 3600)
+        os.utime(map_file, (old_mtime, old_mtime))
+        assert load_coverage_map(map_file, max_age_days=1) is None
+        assert load_coverage_map(map_file, max_age_days=3) is not None
+
+    def test_malformed_json_returns_none(self, tmp_path: Path) -> None:
+        """Returns None on JSON parse failure."""
+        map_file = tmp_path / "test-source-map.json"
+        map_file.write_text("{bad json}", encoding="utf-8")
+        result = load_coverage_map(map_file)
+        assert result is None

--- a/tests/test_test_filter_coverage_map.py
+++ b/tests/test_test_filter_coverage_map.py
@@ -62,7 +62,9 @@ class TestLoadCoverageMap:
         old_mtime = time.time() - (2 * 24 * 3600)
         os.utime(map_file, (old_mtime, old_mtime))
         assert load_coverage_map(map_file, max_age_days=1) is None
-        assert load_coverage_map(map_file, max_age_days=3) is not None
+        result_fresh = load_coverage_map(map_file, max_age_days=3)
+        assert result_fresh is not None
+        assert result_fresh["src/foo.py"] == {"tests/test_foo.py"}
 
     def test_malformed_json_returns_none(self, tmp_path: Path) -> None:
         """Returns None on JSON parse failure."""

--- a/tests/test_test_filter_tiered_always_run.py
+++ b/tests/test_test_filter_tiered_always_run.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 from tests._test_filter import (
+    _HOOKS_UNCONDITIONAL_FILES,
     _INFRA_UNCONDITIONAL_FILES,
     FilterMode,
     build_test_scope,
@@ -38,7 +39,7 @@ ALL_DIRS = [
 class TestTieredAlwaysRun:
     def test_pure_cli_change_skips_infra_dir_and_docs_dir(self, tmp_path: Path) -> None:
         """REQ-TIER-001/002/003: cli change → arch+contracts present; infra/docs NOT as dirs;
-        9 unconditional infra files individually in result; test_doc_counts.py in result."""
+        6 infra + 3 hooks unconditional files in result; test_doc_counts.py in result."""
         tests_root = _make_tests_root(tmp_path, ALL_DIRS)
         result = build_test_scope(
             changed_files={"src/autoskillit/cli/app.py"},
@@ -54,6 +55,14 @@ class TestTieredAlwaysRun:
         result_names = {p.name for p in result}
         for fname in _INFRA_UNCONDITIONAL_FILES:
             assert fname in result_names, f"unconditional infra file {fname!r} missing"
+        for fname in _HOOKS_UNCONDITIONAL_FILES:
+            assert fname in result_names, f"unconditional hooks file {fname!r} missing"
+        # Verify parent directories
+        for p in result:
+            if p.name in _INFRA_UNCONDITIONAL_FILES:
+                assert p.parent.name == "infra", f"{p.name} expected under infra/"
+            if p.name in _HOOKS_UNCONDITIONAL_FILES:
+                assert p.parent.name == "hooks", f"{p.name} expected under hooks/"
         assert "test_doc_counts.py" in result_names
 
     def test_docs_change_includes_docs_dir(self, tmp_path: Path) -> None:
@@ -107,9 +116,43 @@ class TestTieredAlwaysRun:
         for d in ["arch", "contracts", "infra", "docs"]:
             assert d in dir_names, f"fail-open: {d} must be present for empty changeset"
 
-    def test_infra_unconditional_files_constant_has_nine_entries(self) -> None:
-        """_INFRA_UNCONDITIONAL_FILES must contain exactly 9 entries per REQ-TIER-003."""
-        assert len(_INFRA_UNCONDITIONAL_FILES) == 9
+    def test_unconditional_files_constants_have_correct_counts(self) -> None:
+        """_INFRA_UNCONDITIONAL_FILES has 6 entries; _HOOKS_UNCONDITIONAL_FILES has 3 entries."""
+        assert len(_INFRA_UNCONDITIONAL_FILES) == 6
+        assert len(_HOOKS_UNCONDITIONAL_FILES) == 3
+
+    def test_infra_unconditional_files_resolve_under_infra_dir(self, tmp_path: Path) -> None:
+        """Infra unconditional files must resolve to tests/infra/."""
+        tests_root = _make_tests_root(tmp_path, ALL_DIRS)
+        for fname in _INFRA_UNCONDITIONAL_FILES:
+            (tests_root / "infra" / fname).touch()
+        result = build_test_scope(
+            changed_files={"src/autoskillit/cli/app.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        infra_results = [p for p in result if p.name in _INFRA_UNCONDITIONAL_FILES]
+        assert len(infra_results) == len(_INFRA_UNCONDITIONAL_FILES)
+        for p in infra_results:
+            assert p.parent.name == "infra", f"{p.name} expected under infra/, got {p.parent.name}"
+
+    def test_hook_unconditional_files_resolve_under_hooks_dir(self, tmp_path: Path) -> None:
+        """Hook unconditional files must resolve to tests/hooks/, not tests/infra/."""
+        tests_root = _make_tests_root(tmp_path, ALL_DIRS)
+        # Create placeholder files so path assertions are meaningful
+        for fname in _HOOKS_UNCONDITIONAL_FILES:
+            (tests_root / "hooks" / fname).touch()
+        result = build_test_scope(
+            changed_files={"src/autoskillit/cli/app.py"},
+            mode=FilterMode.CONSERVATIVE,
+            tests_root=tests_root,
+        )
+        assert result is not None
+        hooks_results = [p for p in result if p.name in _HOOKS_UNCONDITIONAL_FILES]
+        assert len(hooks_results) == len(_HOOKS_UNCONDITIONAL_FILES)
+        for p in hooks_results:
+            assert p.parent.name == "hooks", f"{p.name} expected under hooks/, got {p.parent.name}"
 
     def test_aggressive_mode_unaffected_by_tiered_logic(self, tmp_path: Path) -> None:
         """Tiered logic only applies to CONSERVATIVE mode; aggressive uses its own always-run."""

--- a/tests/test_test_filter_tiered_always_run.py
+++ b/tests/test_test_filter_tiered_always_run.py
@@ -124,6 +124,8 @@ class TestTieredAlwaysRun:
     def test_infra_unconditional_files_resolve_under_infra_dir(self, tmp_path: Path) -> None:
         """Infra unconditional files must resolve to tests/infra/."""
         tests_root = _make_tests_root(tmp_path, ALL_DIRS)
+        # .touch() is load-bearing: build_test_scope resolves unconditional file paths
+        # by scanning the filesystem; files must exist for parent-path assertions to hold.
         for fname in _INFRA_UNCONDITIONAL_FILES:
             (tests_root / "infra" / fname).touch()
         result = build_test_scope(


### PR DESCRIPTION
## Summary

_INFRA_UNCONDITIONAL_FILES in tests/_test_filter.py contains 9 filenames, but 3 of them (test_hook_executability.py, test_hook_registration_coverage.py, test_hook_registry.py) live in tests/hooks/, not tests/infra/. The path construction loop at line 1271 resolves all 9 under tests/infra/, silently dropping the 3 hook tests from every tiered conservative filter run. The guard test in test_test_filter_tiered_always_run.py checks only basenames (p.name), masking the bug. This was introduced by commit 26c80595 (#1734) which moved the files without updating the constant.

The fix splits the constant into two frozen sets with correct directory mappings, adds a second path construction loop, and strengthens all guard tests to assert parent directories.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260505-203325-376042/.autoskillit/temp/make-plan/fix_test_filter_hook_test_path_mismatch_plan_2026-05-05_203500.md`

## Changed Files

- tests/_test_filter.py
- tests/test_test_filter.py
- tests/test_test_filter_coverage_map.py
- tests/test_test_filter_tiered_always_run.py

Closes #1875

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 61 | 8.1k | 612.3k | 50.9k | 40 | 37.7k | 4m 8s |
| verify | 1 | 1.0k | 7.3k | 612.5k | 47.1k | 81 | 38.7k | 5m 26s |
| implement | 1 | 713.7k | 9.5k | 1.0M | 51.1k | 79 | 66.3k | 3m 37s |
| prepare_pr | 1 | 56.7k | 3.6k | 133.5k | 26.7k | 19 | 39.0k | 1m 18s |
| compose_pr | 1 | 36.5k | 1.5k | 157.3k | 26.7k | 13 | 15.0k | 38s |
| review_pr | 1 | 108 | 19.3k | 492.7k | 57.6k | 38 | 46.5k | 4m 56s |
| resolve_review | 1 | 285 | 16.6k | 1.6M | 68.5k | 82 | 56.2k | 5m 58s |
| ci_conflict_fix | 1 | 91 | 2.0k | 307.5k | 33.6k | 24 | 20.6k | 48s |
| diagnose_ci | 1 | 70.7k | 1.8k | 187.0k | 26.7k | 17 | 38.7k | 1m 1s |
| resolve_ci | 1 | 157 | 10.7k | 797.7k | 55.0k | 56 | 41.9k | 4m 48s |
| **Total** | | 879.3k | 80.7k | 5.9M | 68.5k | | 400.6k | 32m 42s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 84 | 11912.0 | 789.5 | 113.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 6 | 273928.8 | 9362.3 | 2771.2 |
| ci_conflict_fix | 700 | 439.3 | 29.4 | 2.9 |
| diagnose_ci | 0 | — | — | — |
| resolve_ci | 9 | 88629.6 | 4660.4 | 1193.7 |
| **Total** | **799** | 7440.0 | 501.4 | 101.0 |