### PR TITLE
Strengthen assertions in test_tools_dispatch.py and test_doctor.py

### DIFF
--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -445,7 +445,7 @@ def test_doctor_checks_plugin_cache_exists(tmp_path, monkeypatch, capsys):
     data = json.loads(captured.out)
     checks = [r for r in data["results"] if r["check"] == "plugin_cache_exists"]
     assert len(checks) == 1, "Expected a plugin_cache_exists check"
-    assert checks[0]["severity"] in ("warning", "error")
+    assert checks[0]["severity"] == "warning"
 
 
 def test_doctor_checks_installed_plugins_entry(tmp_path, monkeypatch, capsys):
@@ -461,7 +461,7 @@ def test_doctor_checks_installed_plugins_entry(tmp_path, monkeypatch, capsys):
     data = json.loads(captured.out)
     checks = [r for r in data["results"] if r["check"] == "installed_plugins_entry"]
     assert len(checks) == 1, "Expected an installed_plugins_entry check"
-    assert checks[0]["severity"] in ("warning", "error")
+    assert checks[0]["severity"] == "warning"
 
 
 def test_stale_gate_check_absent_from_doctor_output(tmp_path, monkeypatch, capsys):

--- a/tests/server/test_tools_dispatch_halt.py
+++ b/tests/server/test_tools_dispatch_halt.py
@@ -65,7 +65,7 @@ class TestDispatchFoodTruckHaltEnforcement:
         from autoskillit.server.tools.tools_execution import dispatch_food_truck
 
         result = json.loads(await dispatch_food_truck(recipe="test-recipe", task="t"))
-        assert result.get("error") != "fleet_campaign_halted"
+        assert "dispatch_id" in result
 
     @pytest.mark.anyio
     async def test_dispatch_proceeds_when_no_campaign_state_path(self, tool_ctx, monkeypatch):
@@ -76,7 +76,7 @@ class TestDispatchFoodTruckHaltEnforcement:
         from autoskillit.server.tools.tools_execution import dispatch_food_truck
 
         result = json.loads(await dispatch_food_truck(recipe="test-recipe", task="t"))
-        assert result.get("error") != "fleet_campaign_halted"
+        assert "dispatch_id" in result
 
     @pytest.mark.anyio
     async def test_dispatch_proceeds_when_no_failures_in_state(
@@ -92,7 +92,7 @@ class TestDispatchFoodTruckHaltEnforcement:
         from autoskillit.server.tools.tools_execution import dispatch_food_truck
 
         result = json.loads(await dispatch_food_truck(recipe="test-recipe", task="t"))
-        assert result.get("error") != "fleet_campaign_halted"
+        assert "dispatch_id" in result
 
     @pytest.mark.anyio
     async def test_dispatch_proceeds_when_state_file_missing(
@@ -106,7 +106,7 @@ class TestDispatchFoodTruckHaltEnforcement:
         from autoskillit.server.tools.tools_execution import dispatch_food_truck
 
         result = json.loads(await dispatch_food_truck(recipe="test-recipe", task="t"))
-        assert result.get("error") != "fleet_campaign_halted"
+        assert "dispatch_id" in result
 
     @pytest.mark.anyio
     async def test_campaign_state_write_uses_envelope_dispatch_status(
@@ -178,7 +178,7 @@ class TestDispatchFoodTruckHaltEnforcement:
         from autoskillit.server.tools.tools_execution import dispatch_food_truck
 
         result = json.loads(await dispatch_food_truck(recipe="test-recipe", task="t"))
-        assert result.get("error") != "fleet_campaign_halted"
+        assert "dispatch_id" in result
 
     def _setup_standard_dispatch(self, tool_ctx, monkeypatch):
         """Wire tool_ctx for a successful standard dispatch."""


### PR DESCRIPTION
## Summary

Fix two validated audit findings (C4-1 and C4-3) by replacing weak test assertions with precise positive checks. No production code changes are required.

**Finding C4-1** — `tests/server/test_tools_dispatch_halt.py`: Five tests that verify dispatch proceeds past the halt gate use `assert result.get("error") != "fleet_campaign_halted"`. Each test calls `_setup_standard_dispatch()` which wires a valid recipe and executor, so the expected outcome is that the dispatch proceeds past the halt gate — `assert "dispatch_id" in result` is the correct assertion.

**Finding C4-3** — `tests/cli/test_doctor.py` lines 448 and 464: Two tests assert `checks[0]["severity"] in ("warning", "error")`. Source inspection of `_check_plugin_cache_exists` and `_check_installed_plugins_entry` confirms both return `Severity.WARNING` unconditionally under the test conditions.

Closes #1887

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/strengthen-assertions-20260505-211450-512860/.autoskillit/temp/make-plan/strengthen_assertions_plan_2026-05-05_211450.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->