### PR TITLE
Implementation Plan: P2-WP4 Create research-archive.yaml Sub-Recipe

### DIFF
--- a/src/autoskillit/recipes/research-archive.yaml
+++ b/src/autoskillit/recipes/research-archive.yaml
@@ -1,0 +1,132 @@
+name: research-archive
+recipe_version: "1.0.0"
+categories: [research-family]
+requires_packs: [github, ci]
+description: >
+  Archival-phase sub-recipe extracted from research.yaml. Separates research
+  artifacts from experimental code, opens an artifact-only PR containing only
+  the research/ directory, tags the experiment branch for preservation, closes
+  the original PR with cross-references, and patches the token summary. All
+  steps are best-effort — failures route to patch_token_summary for graceful
+  degradation.
+summary: begin_archival > capture > branch > pr > tag > close > patch > complete
+
+ingredients:
+  # --- campaign-sourced (hidden) ---
+  worktree_path:
+    description: Path to the pre-created worktree (passed by campaign dispatch)
+    required: true
+    hidden: true
+  research_dir:
+    description: Path to the research/ directory in the worktree
+    required: true
+    hidden: true
+  pr_url:
+    description: URL of the original experiment PR (passed by campaign dispatch)
+    required: true
+    hidden: true
+
+  # --- user-input ---
+  base_branch:
+    description: Branch to target for the artifact PR
+    default: "main"
+
+kitchen_rules:
+  - >
+    NEVER use native Claude Code tools from the orchestrator: Read, Grep, Glob,
+    Edit, Write, Bash, Agent, WebFetch, WebSearch, NotebookEdit are ALL forbidden.
+    All work is delegated through run_cmd, run_python.
+  - "All archival steps are best-effort — route to patch_token_summary on failure."
+  - "Do NOT auto-merge the artifact PR — it is for human review only."
+
+steps:
+  begin_archival:
+    action: route
+    on_result:
+      - when: "${{ inputs.pr_url }}"
+        route: capture_experiment_branch
+      - route: patch_token_summary
+    note: >
+      Gate step for the archival phase. Routes to artifact extraction when
+      a PR URL is available, otherwise skips directly to patch_token_summary.
+      Uses inputs.pr_url (not context.pr_url) since pr_url is an ingredient
+      in this standalone recipe.
+
+  capture_experiment_branch:
+    tool: run_cmd
+    with:
+      cmd: "git -C '${{ inputs.worktree_path }}' rev-parse --abbrev-ref HEAD"
+      cwd: "${{ inputs.worktree_path }}"
+      step_name: capture_experiment_branch
+    capture:
+      experiment_branch: "${{ result.stdout | trim }}"
+    on_success: create_artifact_branch
+    on_failure: patch_token_summary
+
+  create_artifact_branch:
+    tool: run_cmd
+    with:
+      cmd: "bash scripts/recipe/create_artifact_branch.sh '${{ inputs.worktree_path }}' '${{ context.experiment_branch }}' '${{ inputs.base_branch }}' '${{ inputs.research_dir }}'"
+      cwd: "${{ inputs.worktree_path }}"
+      step_name: create_artifact_branch
+    capture:
+      artifact_branch: "${{ result.artifact_branch }}"
+    on_success: open_artifact_pr
+    on_failure: patch_token_summary
+
+  open_artifact_pr:
+    tool: run_cmd
+    with:
+      cmd: "bash scripts/recipe/open_artifact_pr.sh '${{ inputs.worktree_path }}' '${{ context.experiment_branch }}' '${{ context.artifact_branch }}' '${{ inputs.pr_url }}' '${{ inputs.base_branch }}' '${{ inputs.research_dir }}'"
+      cwd: "${{ inputs.worktree_path }}"
+      step_name: open_artifact_pr
+    capture:
+      artifact_pr_url: "${{ result.artifact_pr_url }}"
+    on_success: tag_experiment_branch
+    on_failure: patch_token_summary
+
+  tag_experiment_branch:
+    tool: run_cmd
+    with:
+      cmd: "bash scripts/recipe/tag_experiment_branch.sh '${{ inputs.worktree_path }}' '${{ context.experiment_branch }}' '${{ context.artifact_pr_url }}'"
+      cwd: "${{ inputs.worktree_path }}"
+      step_name: tag_experiment_branch
+    capture:
+      archive_tag: "${{ result.archive_tag }}"
+    on_success: close_experiment_pr
+    on_failure: patch_token_summary
+
+  close_experiment_pr:
+    tool: run_cmd
+    with:
+      cmd: >
+        ARTIFACT_PR="${{ context.artifact_pr_url }}" &&
+        ARCHIVE_TAG="${{ context.archive_tag }}" &&
+        CLOSE_BODY=$(printf '## Archived\n\nThis PR contained both research artifacts and experimental code.\n\n**Research record merged via:** %s\n**Full experiment branch preserved at:** `%s`\n\nThe artifact PR contains only files under `research/` (reports, scripts, results). The archive tag preserves the full experiment branch including variant code for reference.\n\nTo restore the full experiment: `git checkout %s`' "${ARTIFACT_PR}" "${ARCHIVE_TAG}" "${ARCHIVE_TAG}") &&
+        gh pr close '${{ inputs.pr_url }}' --comment "${CLOSE_BODY}"
+      cwd: "${{ inputs.worktree_path }}"
+      step_name: close_experiment_pr
+    on_success: patch_token_summary
+    on_failure: patch_token_summary
+
+  patch_token_summary:
+    description: "Collect all pipeline token data and patch the PR body with complete summary"
+    tool: run_python
+    with:
+      callable: "autoskillit.smoke_utils.patch_pr_token_summary"
+      timeout: 60
+      pr_url: "${{ inputs.pr_url }}"
+      cwd: "${{ inputs.worktree_path }}"
+    on_success: research_complete
+    on_failure: research_complete
+
+  research_complete:
+    action: stop
+    message: >
+      Research archival complete. Artifacts separated into a dedicated PR,
+      experiment branch tagged and preserved, original PR closed with
+      cross-references to the artifact PR and archive tag.
+
+  escalate_stop:
+    action: stop
+    message: "Research archival pipeline failed — human intervention needed. Check the latest step output for details."

--- a/src/autoskillit/recipes/research-archive.yaml
+++ b/src/autoskillit/recipes/research-archive.yaml
@@ -49,8 +49,8 @@ steps:
     note: >
       Gate step for the archival phase. Routes to artifact extraction when
       a PR URL is available, otherwise skips directly to patch_token_summary.
-      Uses inputs.pr_url (not context.pr_url) since pr_url is an ingredient
-      in this standalone recipe.
+      Uses inputs.pr_url since pr_url is an ingredient (not a captured
+      context value) in this standalone recipe.
 
   capture_experiment_branch:
     tool: run_cmd

--- a/src/autoskillit/recipes/research-archive.yaml
+++ b/src/autoskillit/recipes/research-archive.yaml
@@ -9,7 +9,7 @@ description: >
   the original PR with cross-references, and patches the token summary. All
   steps are best-effort — failures route to patch_token_summary for graceful
   degradation.
-summary: begin_archival > capture > branch > pr > tag > close > patch > complete
+summary: begin_archival > capture > branch > pr > tag > close > patch > complete | escalate
 
 ingredients:
   # --- campaign-sourced (hidden) ---
@@ -49,8 +49,6 @@ steps:
     note: >
       Gate step for the archival phase. Routes to artifact extraction when
       a PR URL is available, otherwise skips directly to patch_token_summary.
-      Uses inputs.pr_url since pr_url is an ingredient (not a captured
-      context value) in this standalone recipe.
 
   capture_experiment_branch:
     tool: run_cmd
@@ -118,7 +116,7 @@ steps:
       pr_url: "${{ inputs.pr_url }}"
       cwd: "${{ inputs.worktree_path }}"
     on_success: research_complete
-    on_failure: research_complete
+    on_failure: escalate_stop
 
   research_complete:
     action: stop

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -251,7 +251,7 @@ def test_doctor_check_count_is_31() -> None:
     )
 
 
-def test_bundled_recipe_count_is_13() -> None:
+def test_bundled_recipe_count_is_14() -> None:
     recipes = _bundled_recipes()
     expected = [
         "bem-wrapper",
@@ -264,6 +264,7 @@ def test_bundled_recipe_count_is_13() -> None:
         "promote-to-main-wrapper",
         "remediation",
         "research",
+        "research-archive",
         "research-design",
         "research-implement",
         "research-review",

--- a/tests/recipe/CLAUDE.md
+++ b/tests/recipe/CLAUDE.md
@@ -64,6 +64,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_remediation_pr_decomposition.py` | Tests for remediation PR decomposition recipe |
 | `test_remediation_recipe.py` | Tests for the remediation recipe structure |
 | `test_repository.py` | Tests for DefaultRecipeRepository |
+| `test_research_archive_recipe.py` | Tests for research-archive sub-recipe structure |
 | `test_research_bundle_lifecycle.py` | Tests for research bundle lifecycle in recipes |
 | `test_research_context_tracking.py` | Tests for research context tracking in recipes |
 | `test_research_implement_recipe.py` | Tests for research-implement sub-recipe structure |

--- a/tests/recipe/test_research_archive_recipe.py
+++ b/tests/recipe/test_research_archive_recipe.py
@@ -15,9 +15,6 @@ class TestResearchArchiveRecipe:
 
     # ── Header ──────────────────────────────────────────────────────
 
-    def test_loads_without_exception(self, recipe) -> None:
-        assert recipe is not None
-
     def test_validates_with_zero_errors(self, recipe) -> None:
         errors = validate_recipe(recipe)
         assert errors == [], f"Validation errors: {errors}"
@@ -161,7 +158,7 @@ class TestResearchArchiveRecipe:
     def test_patch_token_summary_routes_to_complete(self, recipe) -> None:
         step = recipe.steps["patch_token_summary"]
         assert step.on_success == "research_complete"
-        assert step.on_failure == "research_complete"
+        assert step.on_failure == "escalate_stop"
 
     # ── Terminal stops ──────────────────────────────────────────────
 
@@ -174,6 +171,14 @@ class TestResearchArchiveRecipe:
         step = recipe.steps["escalate_stop"]
         assert step.action == "stop"
         assert len(step.message) >= 10
+
+    def test_escalate_stop_is_reachable(self, recipe) -> None:
+        routers = [
+            name
+            for name, step in recipe.steps.items()
+            if step.on_failure == "escalate_stop" or step.on_success == "escalate_stop"
+        ]
+        assert routers, "escalate_stop must be reachable from at least one step"
 
     # ── Kitchen rules ───────────────────────────────────────────────
 

--- a/tests/recipe/test_research_archive_recipe.py
+++ b/tests/recipe/test_research_archive_recipe.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.recipe.io import builtin_recipes_dir, load_recipe
+from autoskillit.recipe.validator import validate_recipe
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+
+class TestResearchArchiveRecipe:
+    @pytest.fixture(scope="class")
+    def recipe(self):
+        return load_recipe(builtin_recipes_dir() / "research-archive.yaml")
+
+    # ── Header ──────────────────────────────────────────────────────
+
+    def test_loads_without_exception(self, recipe) -> None:
+        assert recipe is not None
+
+    def test_validates_with_zero_errors(self, recipe) -> None:
+        errors = validate_recipe(recipe)
+        assert errors == [], f"Validation errors: {errors}"
+
+    def test_name(self, recipe) -> None:
+        assert recipe.name == "research-archive"
+
+    def test_recipe_version(self, recipe) -> None:
+        assert recipe.recipe_version == "1.0.0"
+
+    def test_categories(self, recipe) -> None:
+        assert recipe.categories == ["research-family"]
+
+    def test_requires_packs(self, recipe) -> None:
+        assert set(recipe.requires_packs) == {"github", "ci"}
+
+    def test_no_autoskillit_version(self) -> None:
+        # Intentionally does NOT use self.recipe fixture — validates raw file content
+        path = builtin_recipes_dir() / "research-archive.yaml"
+        content = path.read_text()
+        assert "autoskillit_version" not in content
+
+    # ── Ingredients ─────────────────────────────────────────────────
+
+    def test_ingredient_count(self, recipe) -> None:
+        assert len(recipe.ingredients) == 4
+
+    def test_campaign_sourced_ingredients_hidden_and_required(self, recipe) -> None:
+        for name in ("worktree_path", "research_dir", "pr_url"):
+            ing = recipe.ingredients[name]
+            assert ing.required is True, f"{name} should be required"
+            assert ing.hidden is True, f"{name} should be hidden"
+
+    def test_base_branch_default(self, recipe) -> None:
+        assert recipe.ingredients["base_branch"].default == "main"
+
+    def test_base_branch_not_hidden(self, recipe) -> None:
+        assert recipe.ingredients["base_branch"].hidden is False
+
+    # ── Steps ───────────────────────────────────────────────────────
+
+    def test_step_count(self, recipe) -> None:
+        assert len(recipe.steps) == 9
+
+    def test_step_names(self, recipe) -> None:
+        expected = {
+            "begin_archival",
+            "capture_experiment_branch",
+            "create_artifact_branch",
+            "open_artifact_pr",
+            "tag_experiment_branch",
+            "close_experiment_pr",
+            "patch_token_summary",
+            "research_complete",
+            "escalate_stop",
+        }
+        assert set(recipe.steps.keys()) == expected
+
+    # ── Critical routing fix: inputs.pr_url ─────────────────────────
+
+    def test_begin_archival_uses_inputs_pr_url(self, recipe) -> None:
+        step = recipe.steps["begin_archival"]
+        assert step.action == "route"
+        conditions = step.on_result.conditions
+        pr_cond = next(
+            (c for c in conditions if c.when and "inputs.pr_url" in c.when),
+            None,
+        )
+        assert pr_cond is not None, "begin_archival must route on inputs.pr_url"
+        assert pr_cond.route == "capture_experiment_branch"
+
+    def test_begin_archival_fallback_routes_to_patch(self, recipe) -> None:
+        step = recipe.steps["begin_archival"]
+        conditions = step.on_result.conditions
+        fallback = [c for c in conditions if c.when is None]
+        assert len(fallback) == 1
+        assert fallback[0].route == "patch_token_summary"
+
+    def test_no_context_pr_url_in_recipe(self) -> None:
+        # Intentionally does NOT use self.recipe fixture — validates raw file content
+        content = (builtin_recipes_dir() / "research-archive.yaml").read_text()
+        assert "context.pr_url" not in content
+
+    # ── Capture fields ──────────────────────────────────────────────
+
+    def test_capture_experiment_branch(self, recipe) -> None:
+        step = recipe.steps["capture_experiment_branch"]
+        assert "experiment_branch" in step.capture
+        assert step.on_success == "create_artifact_branch"
+        assert step.on_failure == "patch_token_summary"
+
+    def test_create_artifact_branch_capture(self, recipe) -> None:
+        step = recipe.steps["create_artifact_branch"]
+        assert "artifact_branch" in step.capture
+        assert step.on_success == "open_artifact_pr"
+
+    def test_open_artifact_pr_capture(self, recipe) -> None:
+        step = recipe.steps["open_artifact_pr"]
+        assert "artifact_pr_url" in step.capture
+        assert step.on_success == "tag_experiment_branch"
+
+    def test_open_artifact_pr_uses_inputs_pr_url(self, recipe) -> None:
+        step = recipe.steps["open_artifact_pr"]
+        assert "inputs.pr_url" in step.with_args.get("cmd", "")
+
+    def test_tag_experiment_branch_capture(self, recipe) -> None:
+        step = recipe.steps["tag_experiment_branch"]
+        assert "archive_tag" in step.capture
+        assert step.on_success == "close_experiment_pr"
+
+    def test_close_experiment_pr_uses_inputs_pr_url(self, recipe) -> None:
+        step = recipe.steps["close_experiment_pr"]
+        assert "inputs.pr_url" in step.with_args.get("cmd", "")
+
+    # ── Graceful degradation ────────────────────────────────────────
+
+    def test_all_failures_route_to_patch_token_summary(self, recipe) -> None:
+        for name in (
+            "capture_experiment_branch",
+            "create_artifact_branch",
+            "open_artifact_pr",
+            "tag_experiment_branch",
+            "close_experiment_pr",
+        ):
+            step = recipe.steps[name]
+            assert step.on_failure == "patch_token_summary", (
+                f"{name} on_failure should be patch_token_summary"
+            )
+
+    # ── patch_token_summary ─────────────────────────────────────────
+
+    def test_patch_token_summary_callable(self, recipe) -> None:
+        step = recipe.steps["patch_token_summary"]
+        assert step.tool == "run_python"
+        assert step.with_args["callable"] == "autoskillit.smoke_utils.patch_pr_token_summary"
+
+    def test_patch_token_summary_uses_inputs_pr_url(self, recipe) -> None:
+        step = recipe.steps["patch_token_summary"]
+        assert step.with_args["pr_url"] == "${{ inputs.pr_url }}"
+
+    def test_patch_token_summary_routes_to_complete(self, recipe) -> None:
+        step = recipe.steps["patch_token_summary"]
+        assert step.on_success == "research_complete"
+        assert step.on_failure == "research_complete"
+
+    # ── Terminal stops ──────────────────────────────────────────────
+
+    def test_research_complete_is_stop(self, recipe) -> None:
+        step = recipe.steps["research_complete"]
+        assert step.action == "stop"
+        assert len(step.message) >= 10
+
+    def test_escalate_stop_is_stop(self, recipe) -> None:
+        step = recipe.steps["escalate_stop"]
+        assert step.action == "stop"
+        assert len(step.message) >= 10
+
+    # ── Kitchen rules ───────────────────────────────────────────────
+
+    def test_kitchen_rules_present(self, recipe) -> None:
+        assert len(recipe.kitchen_rules) >= 3
+
+    def test_kitchen_rules_forbid_native_tools(self, recipe) -> None:
+        combined = " ".join(recipe.kitchen_rules)
+        for tool in (
+            "Read",
+            "Grep",
+            "Glob",
+            "Edit",
+            "Write",
+            "Bash",
+            "Agent",
+            "WebFetch",
+            "WebSearch",
+            "NotebookEdit",
+        ):
+            assert tool in combined, f"kitchen_rules must mention {tool}"
+
+    # ── cwd uses inputs.worktree_path ───────────────────────────────
+
+    def test_capture_experiment_branch_cwd(self, recipe) -> None:
+        step = recipe.steps["capture_experiment_branch"]
+        assert step.with_args.get("cwd") == "${{ inputs.worktree_path }}"
+
+    def test_patch_token_summary_cwd(self, recipe) -> None:
+        step = recipe.steps["patch_token_summary"]
+        assert step.with_args.get("cwd") == "${{ inputs.worktree_path }}"

--- a/tests/recipe/test_research_archive_recipe.py
+++ b/tests/recipe/test_research_archive_recipe.py
@@ -61,9 +61,6 @@ class TestResearchArchiveRecipe:
 
     # ── Steps ───────────────────────────────────────────────────────
 
-    def test_step_count(self, recipe) -> None:
-        assert len(recipe.steps) == 9
-
     def test_step_names(self, recipe) -> None:
         expected = {
             "begin_archival",

--- a/tests/recipe/test_research_archive_recipe.py
+++ b/tests/recipe/test_research_archive_recipe.py
@@ -184,9 +184,6 @@ class TestResearchArchiveRecipe:
 
     # ── Kitchen rules ───────────────────────────────────────────────
 
-    def test_kitchen_rules_present(self, recipe) -> None:
-        assert len(recipe.kitchen_rules) >= 3
-
     def test_kitchen_rules_forbid_native_tools(self, recipe) -> None:
         combined = " ".join(recipe.kitchen_rules)
         for tool in (

--- a/tests/recipe/test_research_archive_recipe.py
+++ b/tests/recipe/test_research_archive_recipe.py
@@ -19,7 +19,7 @@ class TestResearchArchiveRecipe:
         errors = validate_recipe(recipe)
         assert errors == [], f"Validation errors: {errors}"
 
-    def test_name(self, recipe) -> None:
+    def test_recipe_name(self, recipe) -> None:
         assert recipe.name == "research-archive"
 
     def test_recipe_version(self, recipe) -> None:

--- a/tests/recipe/test_research_archive_recipe.py
+++ b/tests/recipe/test_research_archive_recipe.py
@@ -39,8 +39,13 @@ class TestResearchArchiveRecipe:
 
     # ── Ingredients ─────────────────────────────────────────────────
 
-    def test_ingredient_count(self, recipe) -> None:
-        assert len(recipe.ingredients) == 4
+    def test_ingredient_names(self, recipe) -> None:
+        assert set(recipe.ingredients.keys()) == {
+            "worktree_path",
+            "research_dir",
+            "pr_url",
+            "base_branch",
+        }
 
     def test_campaign_sourced_ingredients_hidden_and_required(self, recipe) -> None:
         for name in ("worktree_path", "research_dir", "pr_url"):


### PR DESCRIPTION
## Summary

Create `src/autoskillit/recipes/research-archive.yaml` as a standalone sub-recipe that extracts the 9-step archival phase from `research.yaml` (lines 855–963). The critical change from the parent recipe: all ingredient-sourced values (`pr_url`, `worktree_path`, `research_dir`, `base_branch`) use `inputs.X` references instead of `context.X`, since these are declared ingredients in the standalone recipe rather than step-captured context variables. Step-captured values (`experiment_branch`, `artifact_branch`, `artifact_pr_url`, `archive_tag`) correctly remain as `context.X`. Pack declarations are `[github, ci]` (the archival phase only needs GitHub CLI and CI tools, not the full `research` pack). No `autoskillit_version` field — consistent with bundled recipe policy (removed in #1950). Only 4 ingredients: 3 campaign-sourced hidden (`worktree_path`, `research_dir`, `pr_url`) and 1 user-input (`base_branch`). The `report_path_after_finalize` and `source_dir` ingredients from the parent recipe are omitted because no archival step references them.

Closes #1703

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260505-213323-163152/.autoskillit/temp/make-plan/p2_wp4_create_research_archive_yaml_sub_recipe_plan_2026-05-05_213600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 7.7k | 18.2k | 493.3k | 76.6k | 98 | 53.7k | 9m 51s |
| verify | 1 | 39 | 11.0k | 1.1M | 79.2k | 118 | 66.4k | 7m 29s |
| implement | 1 | 1.3M | 13.2k | 1.2M | 31.9k | 110 | 34.7k | 5m 44s |
| prepare_pr | 1 | 68 | 4.5k | 218.4k | 35.8k | 18 | 23.5k | 1m 42s |
| compose_pr | 1 | 59 | 2.2k | 159.3k | 26.0k | 15 | 13.2k | 47s |
| review_pr | 2 | 730 | 77.7k | 1.5M | 83.3k | 109 | 140.1k | 18m 47s |
| resolve_review | 2 | 610 | 42.4k | 4.1M | 97.6k | 190 | 152.1k | 18m 43s |
| ci_conflict_fix | 1 | 139 | 6.6k | 599.4k | 48.1k | 44 | 35.2k | 2m 7s |
| **Total** | | 1.3M | 175.8k | 9.4M | 97.6k | | 518.9k | 1h 5m |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 339 | 3548.4 | 102.4 | 39.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 36 | 113253.1 | 4225.4 | 1176.6 |
| ci_conflict_fix | 545 | 1099.8 | 64.5 | 12.1 |
| **Total** | **920** | 10241.5 | 564.0 | 191.1 |