### PR TITLE
Fix load_config() Argument Bug and Consolidate Workspace Assertions

### DIFF
--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -588,5 +588,6 @@ class TestWorkspaceConfig:
 
     def test_workspace_config_defaults(self, tmp_path):
         cfg = load_config(tmp_path)
+        assert hasattr(cfg, "workspace")
         assert cfg.workspace.worktree_root is None
         assert cfg.workspace.runs_root is None

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -586,20 +586,7 @@ def test_secrets_only_keys_covers_all_github_secret_fields() -> None:
 class TestWorkspaceConfig:
     """WorkspaceConfig section is present in AutomationConfig with correct defaults."""
 
-    def test_workspace_config_exists_on_automation_config(self, tmp_path):
-        from autoskillit.config import load_config
-
-        cfg = load_config(tmp_path)
-        assert hasattr(cfg, "workspace")
-
-    def test_workspace_worktree_root_defaults_to_none(self, tmp_path):
-        from autoskillit.config import load_config
-
+    def test_workspace_config_defaults(self, tmp_path):
         cfg = load_config(tmp_path)
         assert cfg.workspace.worktree_root is None
-
-    def test_workspace_runs_root_defaults_to_none(self, tmp_path):
-        from autoskillit.config import load_config
-
-        cfg = load_config(tmp_path)
         assert cfg.workspace.runs_root is None


### PR DESCRIPTION
## Summary

C4-6 (load_config(tmp_path / "settings.toml") wrong arg type) was already resolved by a prior split commit. C4-9 (three separate load_config() calls for one-liner assertions in TestWorkspaceConfig) is the sole remaining change: consolidate three test methods into a single test_workspace_config_defaults method calling load_config(tmp_path) once and asserting all fields together. Drop the hasattr check as redundant.

## Requirements

### C4-6 — load_config() argument bug (ALREADY RESOLVED)
Fix `load_config(tmp_path / "settings.toml")` → `load_config(tmp_path)`. Passing a `.toml` file path causes silent fallback to defaults. (Resolved in commit a22cb181.)

### C4-9 — Consolidate TestWorkspaceConfig assertions (REQUIRES ACTION)
Consolidate `TestWorkspaceConfig`'s three separate `load_config(tmp_path)` calls into a single `test_workspace_config_defaults` test checking all three fields at once. Drop the `hasattr` check.

## Changed Files

### Modified (●):
tests/config/test_config.py

Closes #1888

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260505-221514-570647/.autoskillit/temp/make-plan/fix_load_config_argument_bug_and_consolidate_workspace_assertions_plan_2026-05-05_222100.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 193 | 13.7k | 1.1M | 82.3k | 82 | 55.4k | 6m 10s |
| verify | 1 | 100 | 6.4k | 370.9k | 38.7k | 32 | 25.8k | 2m 31s |
| implement | 1 | 191.2k | 3.1k | 400.2k | 26.7k | 33 | 39.9k | 5m 3s |
| prepare_pr | 1 | 113.6k | 3.6k | 317.2k | 26.7k | 24 | 15.2k | 1m 20s |
| compose_pr | 1 | 45.0k | 1.4k | 183.9k | 26.7k | 16 | 15.0k | 40s |
| review_pr | 1 | 116 | 12.1k | 465.6k | 44.6k | 37 | 33.0k | 3m 49s |
| resolve_review | 1 | 165 | 6.6k | 678.0k | 45.7k | 52 | 33.4k | 2m 47s |
| **Total** | | 350.4k | 46.8k | 3.5M | 82.3k | | 217.6k | 22m 23s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 15 | 26679.0 | 2656.7 | 203.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 1 | 677988.0 | 33373.0 | 6565.0 |
| **Total** | **16** | 217535.9 | 13602.3 | 2926.6 |