### PR TITLE
Fix stale docstrings in workspace and execution tests

### DIFF
--- a/tests/execution/test_process_submodules.py
+++ b/tests/execution/test_process_submodules.py
@@ -12,7 +12,7 @@ pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
 
 def test_process_kill_exports():
-    """_process_kill.py exports kill/async_kill functions."""
+    """kill_process_tree and async_kill_process_tree are defined in _process_kill submodule."""
     from autoskillit.execution.process._process_kill import (
         async_kill_process_tree,
         kill_process_tree,
@@ -25,7 +25,7 @@ def test_process_kill_exports():
 
 
 def test_process_pty_exports():
-    """_process_pty.py exports pty_wrap_command."""
+    """pty_wrap_command is defined in _process_pty submodule."""
     from autoskillit.execution.process._process_pty import pty_wrap_command
 
     assert callable(pty_wrap_command)
@@ -33,7 +33,7 @@ def test_process_pty_exports():
 
 
 def test_process_jsonl_exports():
-    """_process_jsonl.py exports JSONL parsing helpers."""
+    """_jsonl_* helpers are defined in _process_jsonl submodule."""
     from autoskillit.execution.process._process_jsonl import (
         _jsonl_contains_marker,
         _jsonl_has_record_type,
@@ -49,7 +49,7 @@ def test_process_jsonl_exports():
 
 
 def test_process_io_exports():
-    """_process_io.py exports temp I/O helpers."""
+    """create_temp_io and read_temp_output are defined in _process_io submodule."""
     from autoskillit.execution.process._process_io import create_temp_io, read_temp_output
 
     assert callable(create_temp_io)
@@ -59,7 +59,7 @@ def test_process_io_exports():
 
 
 def test_process_monitor_exports():
-    """_process_monitor.py exports monitoring functions."""
+    """_heartbeat et al. are defined in _process_monitor submodule."""
     from autoskillit.execution.process._process_monitor import (
         _has_active_api_connection,
         _heartbeat,
@@ -77,7 +77,7 @@ def test_process_monitor_exports():
 
 
 def test_process_race_exports():
-    """_process_race.py exports race coordination types and functions."""
+    """Race types/functions are defined in _process_race submodule."""
     from autoskillit.execution.process._process_race import (
         RaceAccumulator,
         RaceSignals,

--- a/tests/execution/test_process_submodules.py
+++ b/tests/execution/test_process_submodules.py
@@ -33,7 +33,8 @@ def test_process_pty_exports():
 
 
 def test_process_jsonl_exports():
-    """_jsonl_* helpers are defined in _process_jsonl submodule."""
+    """_jsonl_contains_marker, _jsonl_has_record_type, and _marker_is_standalone
+    are defined in _process_jsonl submodule."""
     from autoskillit.execution.process._process_jsonl import (
         _jsonl_contains_marker,
         _jsonl_has_record_type,
@@ -59,7 +60,8 @@ def test_process_io_exports():
 
 
 def test_process_monitor_exports():
-    """_heartbeat et al. are defined in _process_monitor submodule."""
+    """_heartbeat, _session_log_monitor, and _has_active_api_connection
+    are defined in _process_monitor submodule."""
     from autoskillit.execution.process._process_monitor import (
         _has_active_api_connection,
         _heartbeat,

--- a/tests/workspace/test_skills.py
+++ b/tests/workspace/test_skills.py
@@ -366,7 +366,7 @@ class TestSkillResolver:
         assert "manifest" in content.lower()
 
     def test_bundled_skills_list_matches_filesystem(self) -> None:
-        """make-script-skill SKILL.md bundled skills list must match filesystem."""
+        """write-recipe SKILL.md bundled skills list must match filesystem."""
         skill_md = DefaultSkillResolver().resolve("write-recipe").path
         content = skill_md.read_text()
 
@@ -396,7 +396,7 @@ class TestSkillResolver:
         actual_skills = sorted(s.name for s in DefaultSkillResolver().list_all())
 
         assert listed_skills == actual_skills, (
-            f"make-script-skill bundled skills list doesn't match filesystem.\n"
+            f"write-recipe bundled skills list doesn't match filesystem.\n"
             f"  Listed:  {listed_skills}\n"
             f"  On disk: {actual_skills}"
         )


### PR DESCRIPTION
## Summary

Two test files contain stale docstrings and assertion messages that reference old names
or misstate what the assertions actually check:

- **C5-2** (`tests/workspace/test_skills.py`): `test_bundled_skills_list_matches_filesystem`
  docstring and failure message still say `make-script-skill` — the skill was renamed to
  `write-recipe`.
- **C5-5** (`tests/execution/test_process_submodules.py`): per-symbol test docstrings say
  `"exports X"` but the assertions verify `__module__` (definition origin), not `__all__`
  membership. Each docstring should say `"is defined in X submodule"`.

Both fixes are pure string edits in test files. No logic changes, no new fixtures, no
isolation concerns.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260505-221516-303979/.autoskillit/temp/make-plan/fix_stale_docstrings_workspace_execution_tests_plan_2026-05-05_000000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 95 | 6.6k | 330.6k | 42.4k | 28 | 32.3k | 2m 14s |
| verify | 1 | 84 | 6.6k | 337.8k | 44.3k | 26 | 31.4k | 2m 0s |
| implement | 1 | 250.8k | 4.9k | 477.3k | 26.7k | 48 | 16.0k | 2m 5s |
| prepare_pr | 1 | 43.0k | 2.5k | 157.2k | 26.7k | 19 | 15.2k | 59s |
| compose_pr | 1 | 42.6k | 1.3k | 157.2k | 26.7k | 15 | 15.0k | 40s |
| review_pr | 1 | 124 | 11.0k | 511.6k | 45.1k | 39 | 33.3k | 2m 48s |
| resolve_review | 1 | 213 | 14.4k | 1.1M | 60.7k | 69 | 48.3k | 5m 27s |
| **Total** | | 336.9k | 47.3k | 3.1M | 60.7k | | 191.5k | 16m 14s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 16 | 29828.4 | 1000.9 | 303.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 6 | 185099.5 | 8048.3 | 2403.8 |
| **Total** | **22** | 140101.8 | 8705.8 | 2148.5 |