### PR TITLE
Remove Live Project Config Read from test_fleet_config.py

### DIFF
--- a/tests/config/test_fleet_config.py
+++ b/tests/config/test_fleet_config.py
@@ -137,17 +137,17 @@ class TestFleetConfig:
         assert cfg.fleet.max_concurrent_dispatches == 3
 
 
-def test_config_resolution_fleet_enabled_via_experimental() -> None:
-    """Full config resolution enables fleet via experimental_enabled=True from defaults."""
-    from pathlib import Path
-
+def test_config_resolution_fleet_enabled_via_experimental(tmp_path) -> None:
+    """Full config resolution enables fleet when experimental_enabled=True in project config."""
     from autoskillit.config.settings import load_config
     from autoskillit.core.feature_flags import is_feature_enabled
 
-    project_root = Path(__file__).resolve().parents[2]
-    if not (project_root / ".autoskillit" / "config.yaml").exists():
-        pytest.skip("project config not present (clean clone or CI)")
-    cfg = load_config(project_root)
+    config_dir = tmp_path / ".autoskillit"
+    config_dir.mkdir()
+    (config_dir / "config.yaml").write_text(
+        yaml.dump({"features": {"experimental_enabled": True}})
+    )
+    cfg = load_config(tmp_path)
     assert cfg.experimental_enabled is True
     assert (
         is_feature_enabled("fleet", cfg.features, experimental_enabled=cfg.experimental_enabled)


### PR DESCRIPTION
## Summary

Replace `test_config_resolution_fleet_enabled_via_experimental` in `tests/config/test_fleet_config.py` (lines 140–155) with an isolated version that uses `tmp_path` to create a synthetic `config.yaml` containing `experimental_enabled: true`, then calls `load_config(tmp_path)` to exercise the full config loading pipeline. The live-disk read (`Path(__file__).parents[2] / ".autoskillit" / "config.yaml"`) and its CI skip guard are removed entirely.

The test is **rewritten** (not deleted) because `test_is_feature_enabled_fleet_defaults_false` (in `tests/core/test_type_constants.py`) only exercises `is_feature_enabled()` in isolation — it does not cover the `load_config()` → Dynaconf layer merge → `AutomationConfig.from_dynaconf()` → `is_feature_enabled()` pipeline. The rewrite provides genuine CI coverage of that end-to-end path, which the delete option would leave uncovered.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260505-221515-520014/.autoskillit/temp/make-plan/remove_live_config_read_plan_2026-05-05_221745.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 87 | 5.6k | 265.0k | 43.4k | 38 | 25.3k | 3m 9s |
| verify | 1 | 148 | 7.9k | 687.2k | 46.6k | 48 | 33.8k | 2m 13s |
| implement | 1 | 307.6k | 3.4k | 503.9k | 26.7k | 39 | 42.9k | 5m 25s |
| prepare_pr | 1 | 100.0k | 2.6k | 290.6k | 26.7k | 24 | 15.2k | 1m 10s |
| compose_pr | 1 | 45.7k | 1.4k | 183.9k | 26.7k | 16 | 15.0k | 41s |
| review_pr | 1 | 116 | 8.8k | 460.2k | 41.0k | 36 | 28.7k | 2m 26s |
| **Total** | | 453.6k | 29.7k | 2.4M | 46.6k | | 160.9k | 15m 6s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 16 | 31495.4 | 2678.7 | 210.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **16** | 149428.0 | 10053.4 | 1858.6 |