### PR TITLE
Fix redundant timestamp assertions and tighten process __all__ count

### DIFF
--- a/tests/execution/test_headless_core.py
+++ b/tests/execution/test_headless_core.py
@@ -2078,7 +2078,6 @@ class TestFailureCaptureInBuildSkillResult:
         )
         _build_skill_result(result, skill_command="/test", audit=tool_ctx.audit)
         record = tool_ctx.audit.get_report()[0]
-        assert record.timestamp  # non-empty ISO timestamp
         assert datetime.fromisoformat(record.timestamp)  # valid ISO 8601 format
 
     def test_stale_termination_is_captured(self, tool_ctx):

--- a/tests/execution/test_linux_tracing.py
+++ b/tests/execution/test_linux_tracing.py
@@ -305,7 +305,6 @@ def test_proc_snapshot_has_captured_at_field():
     snap = read_proc_snapshot(os.getpid())
     assert snap is not None
     assert hasattr(snap, "captured_at")
-    assert snap.captured_at  # non-empty
     # Must be UTC-aware ISO 8601
     dt = datetime.fromisoformat(snap.captured_at)
     assert dt.tzinfo is not None

--- a/tests/execution/test_process_submodules.py
+++ b/tests/execution/test_process_submodules.py
@@ -10,6 +10,38 @@ import pytest
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 
+_EXPECTED_PROCESS_SYMBOLS: frozenset[str] = frozenset(
+    {
+        "DefaultSubprocessRunner",
+        "_extract_stdout_session_id",
+        "_resolve_session_id",
+        "RaceAccumulator",
+        "RaceSignals",
+        "_has_active_api_connection",
+        "_has_active_child_processes",
+        "_heartbeat",
+        "_jsonl_contains_marker",
+        "_jsonl_has_record_type",
+        "_jsonl_last_record_type",
+        "_marker_is_standalone",
+        "_session_log_monitor",
+        "_wait_process_dead",
+        "_watch_heartbeat",
+        "_watch_process",
+        "_watch_session_log",
+        "async_kill_process_tree",
+        "create_temp_io",
+        "decide_termination_action",
+        "execute_termination_action",
+        "kill_process_tree",
+        "pty_wrap_command",
+        "read_temp_output",
+        "resolve_termination",
+        "run_managed_async",
+        "run_managed_sync",
+    }
+)
+
 
 def test_process_kill_exports():
     """kill_process_tree and async_kill_process_tree are defined in _process_kill submodule."""
@@ -96,10 +128,12 @@ def test_process_race_exports():
 
 
 def test_process_facade_reexports_all_public_symbols():
-    """process.py facade re-exports at least 21 public symbols."""
+    """process.py facade re-exports exactly the expected 27 public symbols."""
     from autoskillit.execution import process
 
     assert hasattr(process, "__all__")
-    assert len(process.__all__) >= 21, (
-        f"process.py __all__ has {len(process.__all__)} symbols, expected at least 21"
+    assert set(process.__all__) == _EXPECTED_PROCESS_SYMBOLS, (
+        f"process.__all__ mismatch.\n"
+        f"  Extra   : {set(process.__all__) - _EXPECTED_PROCESS_SYMBOLS}\n"
+        f"  Missing : {_EXPECTED_PROCESS_SYMBOLS - set(process.__all__)}"
     )


### PR DESCRIPTION
## Summary

Three targeted test assertion fixes across two execution test files:

1. **[C4-5]** Remove `assert record.timestamp` (test_headless_core.py:2081) — redundant because `datetime.fromisoformat()` on the next line already raises on any falsy value.
2. **[C4-5]** Remove `assert snap.captured_at` (test_linux_tracing.py:308) — same redundancy pattern.
3. **[C4-8]** Replace `assert len(process.__all__) >= 21` (test_process_submodules.py:98–103) with `assert set(process.__all__) == _EXPECTED_PROCESS_SYMBOLS` using a frozen set constant — catches both accidental additions and removals, and produces a diff-style failure message.

No production code changes. All three files are in `tests/execution/`.

## Requirements



## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.


## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260505-230246-004697/.autoskillit/temp/make-plan/fix_redundant_timestamp_assertions_plan_2026-05-05_120001.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 137 | 6.7k | 478.2k | 41.1k | 43 | 28.1k | 3m 0s |
| verify | 1 | 92 | 9.3k | 416.0k | 55.3k | 30 | 42.5k | 2m 50s |
| implement | 1 | 224.4k | 3.5k | 453.4k | 26.7k | 43 | 55.1k | 5m 14s |
| prepare_pr | 1 | 58.7k | 2.5k | 176.3k | 25.6k | 17 | 15.2k | 1m 4s |
| compose_pr | 1 | 27.5k | 1.4k | 125.1k | 25.6k | 15 | 15.0k | 36s |
| review_pr | 1 | 124 | 24.4k | 569.5k | 60.8k | 42 | 49.1k | 6m 4s |
| **Total** | | 310.8k | 47.8k | 2.2M | 60.8k | | 205.0k | 18m 49s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 42 | 10794.2 | 1311.2 | 84.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **42** | 52821.1 | 4880.1 | 1139.3 |