### PR TITLE
Refactor Execution Conftest and Fix Mutable Smoke Fixture

### DIFF
--- a/tests/execution/CLAUDE.md
+++ b/tests/execution/CLAUDE.md
@@ -7,12 +7,14 @@ Subprocess integration, headless session, process lifecycle, and session result 
 | File | Purpose |
 |------|---------|
 | `__init__.py` | empty |
+| `_merge_queue_helpers.py` | Merge-queue test helper factories — _make_watcher, _queue_state |
 | `conftest.py` | Shared fixtures and helpers for tests/execution/ |
 | `test_anomaly_detection.py` | Tests for post-hoc anomaly detection over ProcSnapshot data |
 | `test_check_repo_merge_state.py` | Round-trip budget tests for fetch_repo_merge_state |
 | `test_ci.py` | L1 unit tests for execution/ci.py — CIWatcher service |
 | `test_ci_params.py` | Tests for CIRunScope query param composition and workflow scoping |
 | `test_clone_guard.py` | Tests for clone contamination guard — detect and revert direct changes |
+| `test_conftest_import_guard.py` | Structural guard: conftest.py must not import merge_queue at module level |
 | `test_commands.py` | Tests for execution/commands.py — ClaudeInteractiveCmd / ClaudeHeadlessCmd builders |
 | `test_db.py` | L1 unit tests for execution/db.py — SQL validation and authorizer |
 | `test_diff_annotator.py` | Behavioral tests for execution/diff_annotator.py |

--- a/tests/execution/_merge_queue_helpers.py
+++ b/tests/execution/_merge_queue_helpers.py
@@ -1,4 +1,4 @@
-"""Merge-queue test helper factories — used by test_merge_queue_ejection and test_merge_queue_polling."""
+"""Merge-queue test helper factories used by merge_queue test modules."""
 
 from __future__ import annotations
 

--- a/tests/execution/_merge_queue_helpers.py
+++ b/tests/execution/_merge_queue_helpers.py
@@ -1,0 +1,40 @@
+"""Merge-queue test helper factories — used by test_merge_queue_ejection and test_merge_queue_polling."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from autoskillit.execution.merge_queue import DefaultMergeQueueWatcher, PRFetchState
+
+
+def _make_watcher() -> DefaultMergeQueueWatcher:
+    return DefaultMergeQueueWatcher(token=None)
+
+
+def _queue_state(
+    *,
+    merged: bool = False,
+    state: str = "OPEN",
+    mergeable: str = "MERGEABLE",
+    merge_state_status: str = "CLEAN",
+    auto_merge_present: bool = False,
+    auto_merge_enabled_at: datetime | None = None,
+    pr_node_id: str = "PR_kwDO_test",
+    in_queue: bool = False,
+    queue_state: str | None = None,
+    checks_state: str | None = None,
+    merge_group_checks_state: str | None = None,
+) -> PRFetchState:
+    return {
+        "merged": merged,
+        "state": state,
+        "mergeable": mergeable,
+        "merge_state_status": merge_state_status,
+        "auto_merge_present": auto_merge_present,
+        "auto_merge_enabled_at": auto_merge_enabled_at,
+        "pr_node_id": pr_node_id,
+        "in_queue": in_queue,
+        "queue_state": queue_state,
+        "checks_state": checks_state,
+        "merge_group_checks_state": merge_group_checks_state,
+    }

--- a/tests/execution/conftest.py
+++ b/tests/execution/conftest.py
@@ -6,14 +6,12 @@ import json
 import pathlib
 import textwrap
 from collections.abc import Callable
-from datetime import datetime
 from pathlib import Path
 from typing import Any
 
 import pytest
 
 from autoskillit.core.types import SubprocessResult, TerminationReason
-from autoskillit.execution.merge_queue import DefaultMergeQueueWatcher, PRFetchState
 from autoskillit.execution.session import ClaudeSessionResult
 from tests._helpers import make_tracing_config
 
@@ -317,39 +315,6 @@ def merge_group_only_repo_state() -> dict[str, Any]:
         },
         "rest_completed_runs": {"workflow_runs": []},
         "rest_active_runs": {"workflow_runs": []},
-    }
-
-
-def _make_watcher() -> DefaultMergeQueueWatcher:
-    return DefaultMergeQueueWatcher(token=None)
-
-
-def _queue_state(
-    *,
-    merged: bool = False,
-    state: str = "OPEN",
-    mergeable: str = "MERGEABLE",
-    merge_state_status: str = "CLEAN",
-    auto_merge_present: bool = False,
-    auto_merge_enabled_at: datetime | None = None,
-    pr_node_id: str = "PR_kwDO_test",
-    in_queue: bool = False,
-    queue_state: str | None = None,
-    checks_state: str | None = None,
-    merge_group_checks_state: str | None = None,
-) -> PRFetchState:
-    return {
-        "merged": merged,
-        "state": state,
-        "mergeable": mergeable,
-        "merge_state_status": merge_state_status,
-        "auto_merge_present": auto_merge_present,
-        "auto_merge_enabled_at": auto_merge_enabled_at,
-        "pr_node_id": pr_node_id,
-        "in_queue": in_queue,
-        "queue_state": queue_state,
-        "checks_state": checks_state,
-        "merge_group_checks_state": merge_group_checks_state,
     }
 
 

--- a/tests/execution/test_conftest_import_guard.py
+++ b/tests/execution/test_conftest_import_guard.py
@@ -1,0 +1,23 @@
+"""Structural guard: conftest.py must not import merge_queue at module level."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
+
+
+def test_execution_conftest_has_no_merge_queue_imports():
+    """conftest.py must not import merge_queue symbols at module level."""
+    src = (Path(__file__).parent / "conftest.py").read_text()
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            module = getattr(node, "module", "") or ""
+            assert "merge_queue" not in module, (
+                f"conftest.py imports from merge_queue at line {node.lineno}; "
+                "move these to tests/execution/_merge_queue_helpers.py"
+            )

--- a/tests/execution/test_conftest_import_guard.py
+++ b/tests/execution/test_conftest_import_guard.py
@@ -14,7 +14,7 @@ def test_execution_conftest_has_no_merge_queue_imports():
     """conftest.py must not import merge_queue symbols at module level."""
     src = (Path(__file__).parent / "conftest.py").read_text()
     tree = ast.parse(src)
-    for node in ast.walk(tree):
+    for node in tree.body:
         if isinstance(node, (ast.Import, ast.ImportFrom)):
             module = getattr(node, "module", "") or ""
             assert "merge_queue" not in module, (

--- a/tests/execution/test_merge_queue_classifier.py
+++ b/tests/execution/test_merge_queue_classifier.py
@@ -16,7 +16,7 @@ from autoskillit.execution.merge_queue import (
     DefaultMergeQueueWatcher,
     PRFetchState,
 )
-from tests.execution.conftest import _make_watcher, _queue_state
+from tests.execution._merge_queue_helpers import _make_watcher, _queue_state
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 

--- a/tests/execution/test_merge_queue_ejection.py
+++ b/tests/execution/test_merge_queue_ejection.py
@@ -11,7 +11,7 @@ import pytest
 
 import autoskillit.execution.merge_queue as _mq
 from autoskillit.core.types import PRState
-from tests.execution.conftest import _make_watcher, _queue_state
+from tests.execution._merge_queue_helpers import _make_watcher, _queue_state
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 

--- a/tests/execution/test_merge_queue_polling.py
+++ b/tests/execution/test_merge_queue_polling.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
-from tests.execution.conftest import _make_watcher, _queue_state
+from tests.execution._merge_queue_helpers import _make_watcher, _queue_state
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
 

--- a/tests/server/CLAUDE.md
+++ b/tests/server/CLAUDE.md
@@ -41,6 +41,7 @@ Server tool handler unit tests — kitchen, execution, CI, clone, workspace tool
 | `test_session_type_tags.py` | Tests for _collect_fleet_tool_tags in server._session_type (Finding 1) |
 | `test_set_commit_status.py` | Tests for the set_commit_status MCP tool handler |
 | `test_smoke_pipeline.py` | Smoke-test pipeline: structural validation and end-to-end execution tests |
+| `test_smoke_recipe_scope_guard.py` | Structural guard: smoke_recipe fixture must not use scope='module' |
 | `test_state.py` | Tests for server/_state.py: server initialization |
 | `test_tool_annotation_completeness.py` | Runtime annotation test shield for MCP tool readOnlyHint semantics (layers 2, 3, 4) |
 | `test_tool_exception_boundary.py` | Tests for the exception boundary in track_response_size |

--- a/tests/server/test_smoke_pipeline.py
+++ b/tests/server/test_smoke_pipeline.py
@@ -37,7 +37,7 @@ SMOKE_SCRIPT = PROJECT_ROOT / ".autoskillit" / "recipes" / "smoke-test.yaml"
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture()
 def smoke_recipe():
     from autoskillit.recipe.io import load_recipe as _load_recipe
 

--- a/tests/server/test_smoke_recipe_scope_guard.py
+++ b/tests/server/test_smoke_recipe_scope_guard.py
@@ -14,9 +14,11 @@ def test_smoke_recipe_fixture_is_not_module_scoped():
     """smoke_recipe must not use scope='module'; Recipe is a mutable dataclass."""
     src = (Path(__file__).parent / "test_smoke_pipeline.py").read_text()
     tree = ast.parse(src)
+    found_smoke_recipe = False
     for node in ast.walk(tree):
         if not isinstance(node, ast.FunctionDef) or node.name != "smoke_recipe":
             continue
+        found_smoke_recipe = True
         for decorator in node.decorator_list:
             if not (
                 isinstance(decorator, ast.Call)
@@ -29,3 +31,4 @@ def test_smoke_recipe_fixture_is_not_module_scoped():
                     assert not (
                         isinstance(kw.value, ast.Constant) and kw.value.value == "module"
                     ), "smoke_recipe must not use scope='module' — Recipe is mutable"
+    assert found_smoke_recipe, "smoke_recipe fixture not found in test_smoke_pipeline.py"

--- a/tests/server/test_smoke_recipe_scope_guard.py
+++ b/tests/server/test_smoke_recipe_scope_guard.py
@@ -1,0 +1,31 @@
+"""Structural guard: smoke_recipe fixture must not use scope='module'."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.layer("server"), pytest.mark.small]
+
+
+def test_smoke_recipe_fixture_is_not_module_scoped():
+    """smoke_recipe must not use scope='module'; Recipe is a mutable dataclass."""
+    src = (Path(__file__).parent / "test_smoke_pipeline.py").read_text()
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef) or node.name != "smoke_recipe":
+            continue
+        for decorator in node.decorator_list:
+            if not (
+                isinstance(decorator, ast.Call)
+                and isinstance(decorator.func, ast.Attribute)
+                and decorator.func.attr == "fixture"
+            ):
+                continue
+            for kw in decorator.keywords:
+                if kw.arg == "scope":
+                    assert not (
+                        isinstance(kw.value, ast.Constant) and kw.value.value == "module"
+                    ), "smoke_recipe must not use scope='module' — Recipe is mutable"


### PR DESCRIPTION
## Summary

Two validated findings from the test-audit (C7-2 and C7-3) are addressed:

- **C7-2**: `DefaultMergeQueueWatcher` and `PRFetchState` are imported at module top-level in `tests/execution/conftest.py`, adding collection-time overhead to every execution test. The two factory functions that use them (`_make_watcher`, `_queue_state`) belong only to merge-queue tests and not to the conftest contract. Moving them into a dedicated helper module eliminates the overhead and makes the dependency explicit.

- **C7-3**: `smoke_recipe` in `tests/server/test_smoke_pipeline.py` is `scope="module"`, meaning every test in the module receives the same mutable `Recipe` dataclass instance. Any test that mutates it silently pollutes all subsequent tests in the collection order. Downgrading to function scope ensures each test receives a fresh object.

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260505-230247-211948/.autoskillit/temp/make-plan/refactor_execution_conftest_plan_2026-05-05_230247.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 119 | 11.9k | 569.6k | 56.9k | 63 | 47.0k | 5m 46s |
| verify | 1 | 140 | 11.2k | 673.1k | 51.7k | 47 | 39.9k | 3m 7s |
| implement | 1 | 765.4k | 5.9k | 775.8k | 31.9k | 71 | 66.6k | 3m 24s |
| prepare_pr | 1 | 111.4k | 3.4k | 278.8k | 25.6k | 22 | 15.2k | 1m 24s |
| compose_pr | 1 | 53.3k | 1.4k | 176.4k | 25.6k | 16 | 15.0k | 41s |
| review_pr | 1 | 134 | 33.6k | 682.8k | 75.0k | 48 | 63.5k | 7m 24s |
| resolve_review | 1 | 229 | 11.1k | 1.2M | 58.9k | 70 | 46.4k | 7m 35s |
| **Total** | | 930.8k | 78.4k | 4.4M | 75.0k | | 293.6k | 29m 24s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 138 | 5621.8 | 482.7 | 42.8 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 5 | 240332.0 | 9276.8 | 2212.0 |
| **Total** | **143** | 30476.9 | 2052.8 | 548.6 |