### PR TITLE
Move Misplaced Execution Tests Out of tests/core/test_types.py

### DIFF
--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -353,24 +353,6 @@ def test_subprocess_runner_protocol_pty_mode_default_false():
     assert sig.parameters["pty_mode"].default is False
 
 
-def test_default_subprocess_runner_pty_mode_default_false():
-    import inspect
-
-    from autoskillit.execution.process import DefaultSubprocessRunner
-
-    sig = inspect.signature(DefaultSubprocessRunner.__call__)
-    assert sig.parameters["pty_mode"].default is False
-
-
-def test_run_managed_async_pty_mode_default_false():
-    import inspect
-
-    from autoskillit.execution.process import run_managed_async
-
-    sig = inspect.signature(run_managed_async)
-    assert sig.parameters["pty_mode"].default is False
-
-
 # ---------------------------------------------------------------------------
 # CIRunScope event field
 # ---------------------------------------------------------------------------

--- a/tests/execution/test_process_submodules.py
+++ b/tests/execution/test_process_submodules.py
@@ -6,6 +6,8 @@ process.py remains a re-export facade for all public symbols.
 
 from __future__ import annotations
 
+import inspect
+
 import pytest
 
 pytestmark = [pytest.mark.layer("execution"), pytest.mark.small]
@@ -106,7 +108,6 @@ def test_process_facade_reexports_all_public_symbols():
 
 
 def test_default_subprocess_runner_pty_mode_default_false():
-    import inspect
 
     from autoskillit.execution.process import DefaultSubprocessRunner
 
@@ -115,7 +116,6 @@ def test_default_subprocess_runner_pty_mode_default_false():
 
 
 def test_run_managed_async_pty_mode_default_false():
-    import inspect
 
     from autoskillit.execution.process import run_managed_async
 

--- a/tests/execution/test_process_submodules.py
+++ b/tests/execution/test_process_submodules.py
@@ -103,3 +103,21 @@ def test_process_facade_reexports_all_public_symbols():
     assert len(process.__all__) >= 21, (
         f"process.py __all__ has {len(process.__all__)} symbols, expected at least 21"
     )
+
+
+def test_default_subprocess_runner_pty_mode_default_false():
+    import inspect
+
+    from autoskillit.execution.process import DefaultSubprocessRunner
+
+    sig = inspect.signature(DefaultSubprocessRunner.__call__)
+    assert sig.parameters["pty_mode"].default is False
+
+
+def test_run_managed_async_pty_mode_default_false():
+    import inspect
+
+    from autoskillit.execution.process import run_managed_async
+
+    sig = inspect.signature(run_managed_async)
+    assert sig.parameters["pty_mode"].default is False


### PR DESCRIPTION
## Summary

Two test functions in `tests/core/test_types.py` import from `autoskillit.execution.process` (IL-1) but carry `layer("core")` markers. This misplacement means a change to `execution/process.py` would trigger `tests/execution/` but not `tests/core/`, making these tests invisible in CI when the relevant source changes. The fix moves both functions to `tests/execution/test_process_submodules.py`, removes them from `tests/core/test_types.py`, and preserves the one test that legitimately belongs in core (it imports only from `autoskillit.core`).

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260505-230246-729784/.autoskillit/temp/make-plan/move_misplaced_execution_tests_plan_2026-05-05_000000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 137 | 7.5k | 570.5k | 51.8k | 44 | 38.8k | 3m 30s |
| verify | 1 | 124 | 8.5k | 562.5k | 48.2k | 36 | 35.5k | 3m 9s |
| implement | 1 | 157.8k | 2.7k | 317.2k | 26.7k | 29 | 16.0k | 4m 47s |
| prepare_pr | 1 | 57.5k | 2.4k | 176.4k | 25.6k | 18 | 15.2k | 1m 0s |
| compose_pr | 1 | 85.8k | 2.5k | 253.2k | 25.6k | 22 | 15.0k | 1m 8s |
| review_pr | 1 | 182 | 15.1k | 774.7k | 49.0k | 50 | 36.3k | 4m 19s |
| resolve_review | 1 | 231 | 9.3k | 1.1M | 54.5k | 68 | 41.8k | 3m 49s |
| **Total** | | 301.8k | 47.9k | 3.7M | 54.5k | | 198.6k | 21m 46s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 36 | 8810.0 | 445.1 | 74.2 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 4 | 267196.0 | 10444.0 | 2328.8 |
| **Total** | **40** | 93078.2 | 4964.5 | 1196.3 |