### PR TITLE
Fix L2/L3 Orchestration Level Mislabeling in Comments, Docstrings, and System Prompts

### DIFF
--- a/src/autoskillit/cli/_prompts.py
+++ b/src/autoskillit/cli/_prompts.py
@@ -27,7 +27,7 @@ _MCP_RETRY_INSTRUCTION: str = (
 
 
 def _read_full_sous_chef() -> str:
-    """Read the full sous-chef SKILL.md for injection into L2/L3 orchestration sessions."""
+    """Read the full sous-chef SKILL.md for injection into L1/L2 orchestration sessions."""
     path = pkg_root() / "skills" / "sous-chef" / "SKILL.md"
     try:
         return path.read_text()
@@ -156,7 +156,7 @@ When you reach a dispatch with `gate: confirm` in the manifest:
 
 In the campaign summary, for gate dispatch entries:
 - Set `status` to `success` or `failure` based on user response.
-- Set `l3_session_id` to `""` (no L2 session was spawned).
+- Set `l3_session_id` to `""` (no food truck session was spawned).
 - Set `elapsed_seconds` to the wall-clock time for the question/response exchange.
 - Set all `token_usage` fields to 0.
 """

--- a/src/autoskillit/cli/_prompts.py
+++ b/src/autoskillit/cli/_prompts.py
@@ -27,7 +27,7 @@ _MCP_RETRY_INSTRUCTION: str = (
 
 
 def _read_full_sous_chef() -> str:
-    """Read the full sous-chef SKILL.md for injection into L1/L3 orchestration sessions."""
+    """Read the full sous-chef SKILL.md for injection into L2/L3 orchestration sessions."""
     path = pkg_root() / "skills" / "sous-chef" / "SKILL.md"
     try:
         return path.read_text()
@@ -113,7 +113,7 @@ def _build_fleet_campaign_prompt(
     """Build the system prompt for an L3 campaign dispatcher headless session.
 
     Assembles a 10-section prompt that instructs a headless Claude session to
-    sequentially dispatch food trucks (L3 sessions), handle failures, respect
+    sequentially dispatch food trucks (L2 sessions), handle failures, respect
     quota, resume from prior state, and emit structured campaign-summary and
     progress markers.
     """
@@ -143,7 +143,7 @@ def _build_fleet_campaign_prompt(
 
 When you reach a dispatch with `gate: confirm` in the manifest:
 
-1. Do NOT call `{mcp_prefix}dispatch_food_truck`. Gate dispatches spawn no L3 session.
+1. Do NOT call `{mcp_prefix}dispatch_food_truck`. Gate dispatches spawn no L2 session.
 2. Call `AskUserQuestion` with the dispatch's `message` field as the question text.
 3. Evaluate the response:
    - Affirmative (yes / proceed / approve / confirm): call `{mcp_prefix}record_gate_dispatch`
@@ -156,7 +156,7 @@ When you reach a dispatch with `gate: confirm` in the manifest:
 
 In the campaign summary, for gate dispatch entries:
 - Set `status` to `success` or `failure` based on user response.
-- Set `l3_session_id` to `""` (no L3 session was spawned).
+- Set `l3_session_id` to `""` (no L2 session was spawned).
 - Set `elapsed_seconds` to the wall-clock time for the question/response exchange.
 - Set all `token_usage` fields to 0.
 """
@@ -183,7 +183,7 @@ dispatch name NOT listed above.
     if resumable_dispatch_name:
         _resume_session_line = (
             f'and pass resume_session_id="{resume_session_id}" to dispatch_food_truck'
-            " so the L3 session resumes from its prior context"
+            " so the L2 food truck session resumes from its prior context"
             if resume_session_id
             else ""
         )
@@ -235,7 +235,7 @@ The fleet_lock semaphore uses max_concurrent=1 for static dispatches — do NOT 
 static manifest calls in parallel. For dynamic dispatches (see the dynamic dispatch
 instructions section when present), `parallel: true` groups override this rule.
 
-Each dispatch is an independent L3 session with its own kitchen context. There is NO
+Each dispatch is an independent L2 food truck session with its own kitchen context. There is NO
 cross-dispatch state sharing managed by you — the runtime handles it
 via capture:. There is NO cross-dispatch token aggregation.
 
@@ -269,8 +269,8 @@ dispatch_food_truck(
 ```
 
 If a dispatch has no `capture:` field, pass `capture={{}}` or omit the parameter.
-The `${{{{ campaign.* }}}}` references in ingredients are resolved before the L3 session
-is started — the L3 agent always receives concrete values.
+The `${{{{ campaign.* }}}}` references in ingredients are resolved before the L2 session
+is started — the L2 food truck agent always receives concrete values.
 {gate_section}{dynamic_dispatch_section}
 ## FAILURE RECOVERY
 
@@ -730,7 +730,7 @@ You are a fleet dispatcher. You coordinate recipe execution across targets \
 by dispatching food trucks.
 
 TOOL SURFACE — these 10 tools are available in this session:
-- {mcp_prefix}dispatch_food_truck     — launch a headless L3 food truck for a recipe
+- {mcp_prefix}dispatch_food_truck     — launch a headless L2 food truck for a recipe
 - {mcp_prefix}batch_cleanup_clones    — clean up clone artifacts after all dispatches
 - {mcp_prefix}get_pipeline_report     — pipeline execution report
 - {mcp_prefix}get_token_summary       — token usage summary

--- a/src/autoskillit/core/types/_type_constants.py
+++ b/src/autoskillit/core/types/_type_constants.py
@@ -541,7 +541,7 @@ SOUS_CHEF_MANDATORY_SECTIONS: tuple[str, ...] = (
     "NARRATION SUPPRESSION",
 )
 
-# Strict subset of SOUS_CHEF_MANDATORY_SECTIONS delivered to L2 food truck sessions.
+# Strict subset of SOUS_CHEF_MANDATORY_SECTIONS delivered to L3 food truck sessions.
 SOUS_CHEF_L3_SECTIONS: tuple[str, ...] = (
     "CONTEXT LIMIT ROUTING",
     "STEP NAME IMMUTABILITY",

--- a/src/autoskillit/core/types/_type_constants.py
+++ b/src/autoskillit/core/types/_type_constants.py
@@ -541,7 +541,7 @@ SOUS_CHEF_MANDATORY_SECTIONS: tuple[str, ...] = (
     "NARRATION SUPPRESSION",
 )
 
-# Strict subset of SOUS_CHEF_MANDATORY_SECTIONS delivered to L3 food truck sessions.
+# Strict subset of SOUS_CHEF_MANDATORY_SECTIONS delivered to L2 food truck sessions.
 SOUS_CHEF_L3_SECTIONS: tuple[str, ...] = (
     "CONTEXT LIMIT ROUTING",
     "STEP NAME IMMUTABILITY",

--- a/src/autoskillit/core/types/_type_enums.py
+++ b/src/autoskillit/core/types/_type_enums.py
@@ -363,7 +363,7 @@ class SessionType(StrEnum):
         L3 (FLEET) -> L2 (ORCHESTRATOR) -> L1 (headless worker) -> L0 (subagent)
 
     FLEET        -- L3: top-level campaign dispatcher.
-                    Launches L3 food trucks via dispatch_food_truck.
+                    Launches L2 food trucks via dispatch_food_truck.
     ORCHESTRATOR -- L2: recipe runner (interactive via order, or headless food truck).
                     Launches L1 headless workers via run_skill.
     SKILL        -- L1 skill session (headless worker launched by an orchestrator via

--- a/src/autoskillit/core/types/_type_results.py
+++ b/src/autoskillit/core/types/_type_results.py
@@ -244,7 +244,7 @@ class SkillResult:
     """
     last_stop_reason: str = ""
     lifespan_started: bool = False
-    """True when the L3 session invoked at least one MCP tool (heuristic for server lifespan)."""
+    """True when the headless session called an MCP tool (heuristic for server lifespan)."""
     provider_used: str = field(default="")
     """Provider identifier stamped by _build_skill_result (e.g. 'anthropic', 'vertex')."""
     provider_fallback: bool = False

--- a/src/autoskillit/execution/commands.py
+++ b/src/autoskillit/execution/commands.py
@@ -459,9 +459,9 @@ def build_food_truck_cmd(
     temp_dir_relpath: str | None = None,
     allowed_write_prefix: str = "",
 ) -> ClaudeHeadlessCmd:
-    """Build the complete headless command spec for an L3 food truck session.
+    """Build the complete headless command spec for an L2 food truck session.
 
-    A food truck session is an L3 orchestrator: it runs a full recipe
+    A food truck session is an L2 orchestrator: it runs a full recipe
     autonomously, always carries ``AUTOSKILLIT_SESSION_TYPE=orchestrator``,
     and restricts Claude native tools to ``--tools AskUserQuestion``.
 
@@ -489,7 +489,7 @@ def build_food_truck_cmd(
         Optional model override.
     env_extras
         Caller-provided env variables layered on top of the baseline.
-        Used for CAMPAIGN_ID, CAMPAIGN_STATE_PATH, PROJECT_DIR, L2_TOOL_TAGS,
+        Used for CAMPAIGN_ID, CAMPAIGN_STATE_PATH, PROJECT_DIR, L3_TOOL_TAGS,
         IDLE_OUTPUT_TIMEOUT. These override baseline but cannot override
         SESSION_TYPE or HEADLESS (applied last).
     output_format

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -208,7 +208,7 @@ def classify_dispatch_outcome(
     sidecar_exists: bool = False,
     checkpoint: SessionCheckpoint | None = None,
 ) -> tuple[DispatchStatus, str]:
-    """Map L3 subprocess signals to a (DispatchStatus, reason) pair.
+    """Map L2 food truck subprocess signals to a (DispatchStatus, reason) pair.
 
     Pure function — no filesystem access, no side effects.
     Rules applied in order:

--- a/src/autoskillit/fleet/_prompts.py
+++ b/src/autoskillit/fleet/_prompts.py
@@ -2,7 +2,7 @@
 
 Moved from autoskillit.cli._prompts — this module
 depends only on autoskillit.core and stdlib, making it importable from both
-the server and CLI layers without introducing cross-IL-3 coupling.
+the server and CLI layers without introducing cross-L3 coupling.
 """
 
 from __future__ import annotations
@@ -71,7 +71,7 @@ def _build_food_truck_prompt(
 You are an L2 food truck orchestrator. Execute the recipe '{recipe}' autonomously.
 Timeout: {l3_timeout_sec}s. Campaign: {campaign_id}. Dispatch: {dispatch_id}.
 
---- SECTION 1: SOUS-CHEF DISCIPLINE (L3 SUBSET) ---
+--- SECTION 1: SOUS-CHEF DISCIPLINE (L2/FOOD-TRUCK SUBSET) ---
 
 {sous_chef_block}
 

--- a/src/autoskillit/fleet/_prompts.py
+++ b/src/autoskillit/fleet/_prompts.py
@@ -1,8 +1,8 @@
-"""Food truck prompt builder for L3 dispatch sessions.
+"""Food truck prompt builder for L2 food truck sessions.
 
 Moved from autoskillit.cli._prompts — this module
 depends only on autoskillit.core and stdlib, making it importable from both
-the server and CLI layers without introducing cross-L3 coupling.
+the server and CLI layers without introducing cross-IL-3 coupling.
 """
 
 from __future__ import annotations
@@ -53,9 +53,9 @@ def _build_food_truck_prompt(
     campaign_id: str,
     l3_timeout_sec: int,
 ) -> str:
-    """Build the system prompt for an L3 food truck headless session.
+    """Build the system prompt for an L2 food truck headless session.
 
-    The prompt is self-contained — the L3 session needs no runtime reference
+    The prompt is self-contained — the L2 food truck session needs no runtime reference
     material beyond what is embedded here. It assembles 8 sections:
     filtered sous-chef discipline, headless directives, routing/predicates,
     budget guidance, quota awareness, campaign task, ingredient values,
@@ -68,7 +68,7 @@ def _build_food_truck_prompt(
     sous_chef_block = _build_l3_sous_chef_block()
 
     return f"""\
-You are an L3 food truck orchestrator. Execute the recipe '{recipe}' autonomously.
+You are an L2 food truck orchestrator. Execute the recipe '{recipe}' autonomously.
 Timeout: {l3_timeout_sec}s. Campaign: {campaign_id}. Dispatch: {dispatch_id}.
 
 --- SECTION 1: SOUS-CHEF DISCIPLINE (L3 SUBSET) ---

--- a/src/autoskillit/hooks/guards/fleet_dispatch_guard.py
+++ b/src/autoskillit/hooks/guards/fleet_dispatch_guard.py
@@ -2,7 +2,7 @@
 """PreToolUse hook — blocks dispatch_food_truck from headless callers.
 
 Defense-in-depth: dispatch_food_truck must never be called from a headless
-session regardless of SESSION_TYPE. This closes L3→L3 recursion where a
+session regardless of SESSION_TYPE. This closes L2→L2 recursion where a
 fleet session spawns another fleet session via dispatch.
 
 Interactive callers (cook with kitchen open) are always permitted.
@@ -45,7 +45,7 @@ def main() -> None:
                     "permissionDecisionReason": (
                         "dispatch_food_truck cannot be called from headless sessions. "
                         "This tool is only available to interactive callers (cook). "
-                        "Headless dispatch would create recursive L3 sessions."
+                        "Headless dispatch would create recursive L2 (food truck) sessions."
                     ),
                 }
             }

--- a/src/autoskillit/hooks/guards/fleet_dispatch_guard.py
+++ b/src/autoskillit/hooks/guards/fleet_dispatch_guard.py
@@ -2,7 +2,7 @@
 """PreToolUse hook — blocks dispatch_food_truck from headless callers.
 
 Defense-in-depth: dispatch_food_truck must never be called from a headless
-session regardless of SESSION_TYPE. This closes L2→L2 recursion where a
+session regardless of SESSION_TYPE. This closes L3→L3 recursion where a
 fleet session spawns another fleet session via dispatch.
 
 Interactive callers (cook with kitchen open) are always permitted.

--- a/src/autoskillit/hooks/guards/skill_orchestration_guard.py
+++ b/src/autoskillit/hooks/guards/skill_orchestration_guard.py
@@ -5,7 +5,7 @@ Skill sessions (AUTOSKILLIT_SESSION_TYPE=skill or unset in headless mode) must
 never call run_skill, run_cmd, or run_python. This is defense-in-depth over
 the in-handler gate check in each tool.
 
-L3+ invariant: orchestrator (L3) and fleet (L3) sessions may call orchestration tools.
+L2+ invariant: orchestrator (L2) and fleet (L3) sessions may call orchestration tools.
 Skill sessions use native Claude Code tools only.
 """
 

--- a/src/autoskillit/recipes/campaigns/promote-to-main.yaml
+++ b/src/autoskillit/recipes/campaigns/promote-to-main.yaml
@@ -26,7 +26,7 @@ ingredients:
     description: "Target branch for promotion PR"
     default: "main"
   max_issues_per_l2:
-    description: "Max issues per L3 food truck"
+    description: "Max issues per L2 food truck"
     default: "6"
     hidden: true
   model_context_window:

--- a/src/autoskillit/recipes/implement-findings.yaml
+++ b/src/autoskillit/recipes/implement-findings.yaml
@@ -1,6 +1,6 @@
 name: implement-findings
 description: >-
-  Multi-issue L3 orchestration recipe for promote-to-main campaign. Processes
+  Multi-issue L2 orchestration recipe for promote-to-main campaign. Processes
   a batch of audit findings through the full implementation or remediation
   lifecycle. Issues within the same BEM group run in parallel via wavefront
   scheduling; groups run sequentially.

--- a/src/autoskillit/recipes/promote-to-main-wrapper.yaml
+++ b/src/autoskillit/recipes/promote-to-main-wrapper.yaml
@@ -1,7 +1,7 @@
 name: promote-to-main-wrapper
 description: >-
   Thin wrapper that invokes the promote-to-main skill via run_skill, enabling
-  campaign dispatch of integration branch promotions as L3 food trucks.
+  campaign dispatch of integration branch promotions as L2 food trucks.
 kind: standard
 recipe_version: "1.0.0"
 

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -455,7 +455,7 @@ async def run_skill(
 
         # Auto-enrich order_id from the fleet dispatcher's env variable when the
         # caller did not pass an explicit value. AUTOSKILLIT_DISPATCH_ID is injected
-        # by fleet/_api.py into every L3 session environment and inherited by all
+        # by fleet/_api.py into every L2 food truck session environment and inherited by all
         # sub-sessions, ensuring token log entries carry the correct order_id without
         # requiring recipe authors to thread it through every run_skill call.
         effective_order_id = order_id or os.environ.get("AUTOSKILLIT_DISPATCH_ID", "")
@@ -692,7 +692,7 @@ async def dispatch_food_truck(
     resume_checkpoint: dict[str, object] | None = None,
     ctx: Context = CurrentContext(),
 ) -> str:
-    """Dispatch a single food truck L3 session for one recipe.
+    """Dispatch a single food truck L2 session for one recipe.
 
     Spawns a headless subprocess that executes the given recipe with the
     provided task and ingredient overrides. Returns a JSON envelope with
@@ -700,10 +700,10 @@ async def dispatch_food_truck(
 
     Args:
         recipe: Recipe name to dispatch (must be kind=standard).
-        task: Task description for the L3 session.
+        task: Task description for the L2 food truck session.
         ingredients: Optional ingredient overrides (all values must be strings).
         dispatch_name: Optional display name for the dispatch record.
-        timeout_sec: Optional L3 session timeout override in seconds.
+        timeout_sec: Optional L2 session timeout override in seconds.
         capture: Optional dict mapping capture keys to "${{ result.field }}" templates.
             Extracted values are persisted in the campaign context for downstream
             dispatches to reference via "${{ campaign.key }}" in their ingredients.

--- a/src/autoskillit/smoke_utils.py
+++ b/src/autoskillit/smoke_utils.py
@@ -226,8 +226,8 @@ def patch_pr_token_summary(
     owner, repo, pr_number = m.group(1), m.group(2), m.group(3)
 
     # Auto-discover order_id from environment when not explicitly provided.
-    # AUTOSKILLIT_DISPATCH_ID is set by the fleet dispatcher on all L3 sessions
-    # and inherited by L3 sub-sessions, providing correct multi-clone scoping
+    # AUTOSKILLIT_DISPATCH_ID is set by the fleet dispatcher on all L2 food truck sessions
+    # and inherited by sub-sessions, providing correct multi-clone scoping
     # without requiring recipe authors to pass order_id explicitly.
     effective_order_id = order_id or os.environ.get("AUTOSKILLIT_DISPATCH_ID", "")
 


### PR DESCRIPTION
## Summary

Multiple comments, docstrings, system prompts, and recipe YAML descriptions incorrectly label L2 food truck sessions as "L3 sessions." Per the canonical `docs/orchestration-levels.md`, the hierarchy is `L3 (Fleet Dispatch) → L2 (Food Truck / Orchestrator) → L1 (Skill Session) → L0 (Subagent)`. The `l3_` variable prefix means "tracked by L3" — it does NOT mean the session IS L3. This plan corrects all mislabeled text sites while making zero behavioral or symbol-name changes.

## Requirements

- REQ-TERM-001: The food truck system prompt MUST identify the session as L2, not L3
- REQ-TERM-002: Guard docstrings MUST correctly label orchestrator as L2 and fleet as L3
- REQ-TERM-003: All docstrings referring to "the food truck" MUST use "L2 session" not "L3 session"
- REQ-TERM-004: No behavioral changes — only string literals in comments, docstrings, and the one prompt line
- REQ-TERM-005: The `l3_` variable/field name convention is NOT changed in this ticket (separate concern)

## Changed Files

### Modified (●):
● src/autoskillit/cli/_prompts.py
● src/autoskillit/core/types/_type_constants.py
● src/autoskillit/core/types/_type_enums.py
● src/autoskillit/core/types/_type_results.py
● src/autoskillit/execution/commands.py
● src/autoskillit/fleet/_api.py
● src/autoskillit/fleet/_prompts.py
● src/autoskillit/hooks/guards/fleet_dispatch_guard.py
● src/autoskillit/hooks/guards/skill_orchestration_guard.py
● src/autoskillit/recipes/campaigns/promote-to-main.yaml
● src/autoskillit/recipes/implement-findings.yaml
● src/autoskillit/recipes/promote-to-main-wrapper.yaml
● src/autoskillit/server/tools/tools_execution.py
● src/autoskillit/smoke_utils.py

Closes #1986

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260505-233955-054391/.autoskillit/temp/make-plan/fix_l2_l3_orchestration_level_mislabeling_plan_2026-05-05_235500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 48 | 5.7k | 427.1k | 45.1k | 39 | 34.7k | 3m 42s |
| verify | 1 | 39 | 18.8k | 1.1M | 78.2k | 74 | 65.8k | 7m 13s |
| implement | 1 | 1.7M | 13.3k | 1.4M | 25.6k | 146 | 16.0k | 12m 52s |
| prepare_pr | 1 | 60.9k | 3.3k | 181.7k | 30.9k | 23 | 24.2k | 1m 14s |
| compose_pr | 1 | 50.9k | 1.9k | 176.4k | 25.6k | 19 | 15.0k | 47s |
| review_pr | 2 | 178 | 55.6k | 934.9k | 87.8k | 78 | 105.0k | 23m 7s |
| resolve_review | 1 | 261 | 15.2k | 1.3M | 61.6k | 75 | 49.2k | 9m 16s |
| **Total** | | 1.8M | 113.7k | 5.5M | 87.8k | | 310.0k | 58m 13s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 66 | 21683.8 | 242.9 | 200.9 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 12 | 108396.5 | 4098.5 | 1263.3 |
| **Total** | **78** | 71027.1 | 3974.0 | 1458.3 |