### PR TITLE
Generate research.yaml pre-rendered ASCII diagram

### DIFF
--- a/src/autoskillit/recipes/diagrams/research.md
+++ b/src/autoskillit/recipes/diagrams/research.md
@@ -1,38 +1,96 @@
-<!-- autoskillit-recipe-hash: sha256:0000000000000000000000000000000000000000000000000000000000000000 -->
+<!-- autoskillit-recipe-hash: sha256:810be9842d1e34a236f2ce1fc60f534a1fb67e90aab0153f5102233387b304c9 -->
 <!-- autoskillit-diagram-format: v7 -->
-## research
-Design, execute, and report on experiments with visualization and archival.
 
-### Graph
-scope → plan_experiment → review_design (optional)
+## research
+
+scope
 |
-plan_visualization → revise_design (on rejection)
+plan_experiment
 |
-create_worktree → stage_data
+review_design
+|   +-- [plan_visualization] (optional)
+|   +-- [resolve_design_review] (on STOP verdict)
+|   x fail [-> escalate_stop]
 |
-┌────┤ FOR EACH PHASE:
-│    plan_phase → implement_phase → next_phase_or_experiment
-│    ✗ failure → troubleshoot → route
-└────┘
+stage_data
 |
-run_experiment → adjust_experiment → ensure_results
+setup_environment
 |
-generate_report → test
+decompose_phases
+
++----+ FOR EACH PHASE:
+|    |
+|    plan_phase
+|    |
+|    implement_phase <-> [x fail -> troubleshoot_implement_failure]
+|    |    x exhausted [-> run_experiment]
 |
-push_branch → prepare_research_pr → run_experiment_lenses
++----+
+
+run_experiment <-> [adjust_experiment] (optional)
+|    x fail [-> troubleshoot_run_failure]
+|    x exhausted [-> ensure_results]
 |
-stage_bundle → compose_research_pr → review_research_pr
+generate_report
 |
-+-- audit_claims (optional)
+test <-> [x fail -> fix_tests -> retest]
 |
-+-- resolve_review → merge escalations (optional)
+push_branch
 |
-finalize_bundle → route_archive_or_export
+prepare_research_pr
 |
-+-- export_local_bundle
-+-- begin_archival → capture_experiment_branch → open_artifact_pr
+run_experiment_lenses
 |
-patch_token_summary (optional)
-─────────────────────────────────────
-research_complete  "Complete."
-escalate_stop  "Failed."
+stage_bundle
+|
+route_pr_or_local
+
++--+ pr mode:
+|    |
+|    compose_research_pr
+|    |    +-- [review_research_pr] (optional)
+|    |    +-- [audit_claims] (optional)
+|    |    +-- [resolve_research_review] (on changes_requested)
+|    |    +-- [resolve_claims_review] (on changes_requested)
+|    |    |
+|    |    merge_escalations
+|    |    |    +-- [re_run_experiment] (optional)
+|    |    |    |    |
+|    |    |    re_generate_report
+|    |    |    |    x fail [-> re_push_research]
+|    |    |    |
+|    |    |    re_test <-> [x fail -> re_push_research]
+|    |    |    |
+|    |    re_push_research
+|    |    |    x fail [-> begin_archival]
+|    |    |
+|    |    finalize_bundle_render
+|    |    |    x fail [-> route_archive_or_export]
+|    |    |
+|    |    begin_archival
+|    |    |    capture_experiment_branch
+|    |    |    |    x fail [-> patch_token_summary]
+|    |    |    |
+|    |    |    create_artifact_branch
+|    |    |    |    x fail [-> patch_token_summary]
+|    |    |    |
+|    |    |    open_artifact_pr
+|    |    |    |    x fail [-> patch_token_summary]
+|    |    |    |
+|    |    |    tag_experiment_branch
+|    |    |    |    x fail [-> patch_token_summary]
+|    |    |    |
+|    |    |    close_experiment_pr
+|    |    |    |    x fail [-> patch_token_summary]
+|    |    |
+|    |    patch_token_summary
+|    |
+|    +-- [finalize_bundle] (local mode)
+|    |    |
+|         finalize_bundle_render
+|         |    x fail [-> route_archive_or_export]
+|         |
+|         export_local_bundle
+|         |    x fail [-> patch_token_summary]
+|         |
+|         patch_token_summary

--- a/src/autoskillit/recipes/diagrams/research.md
+++ b/src/autoskillit/recipes/diagrams/research.md
@@ -85,12 +85,12 @@ route_pr_or_local
 |    |    |
 |    |    patch_token_summary
 |    |
-|    +-- [finalize_bundle] (local mode)
+|    +-- finalize_bundle (local mode)
 |    |    |
-|         finalize_bundle_render
-|         |    x fail [-> route_archive_or_export]
-|         |
-|         export_local_bundle
-|         |    x fail [-> patch_token_summary]
-|         |
-|         patch_token_summary
+|    |    finalize_bundle_render
+|    |    |    x fail [-> route_archive_or_export]
+|    |    |
+|    |    export_local_bundle
+|    |    |    x fail [-> patch_token_summary]
+|    |    |
+|    |    patch_token_summary


### PR DESCRIPTION
## Summary

Overwrite the placeholder diagram at `src/autoskillit/recipes/diagrams/research.md` by invoking the `/render-recipe research` skill. The current file has an all-zeros hash (`sha256:0000...0000`) that causes `check_diagram_staleness()` to return `True` on every `load_and_validate("research")` call, emitting a `stale-diagram` warning. The implementation replaces this with a properly rendered ASCII flow diagram and the real recipe hash (`sha256:810be9842d1e34a236f2ce1fc60f534a1fb67e90aab0153f5102233387b304c9`).

Closes #849

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260506-000853-227078/.autoskillit/temp/make-plan/auto_research_5_2_generate_research_diagram_plan_2026-05-06_010000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 7.1k | 9.5k | 886.2k | 75.5k | 102 | 67.7k | 8m 36s |
| verify | 1 | 49 | 10.0k | 868.4k | 53.6k | 81 | 40.6k | 6m 2s |
| implement | 1 | 3.1M | 24.4k | 1.8M | 30.8k | 161 | 31.2k | 9m 29s |
| prepare_pr | 1 | 76.0k | 2.7k | 179.2k | 25.6k | 24 | 37.9k | 1m 1s |
| compose_pr | 1 | 53.2k | 1.6k | 179.2k | 25.6k | 16 | 37.7k | 51s |
| review_pr | 1 | 100 | 15.4k | 448.8k | 50.2k | 37 | 39.0k | 4m 39s |
| resolve_review | 1 | 277 | 18.9k | 1.5M | 65.1k | 88 | 52.5k | 9m 18s |
| **Total** | | 3.2M | 82.4k | 5.8M | 75.5k | | 306.6k | 39m 59s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 104 | 17250.9 | 299.6 | 234.2 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 16 | 92376.8 | 3283.4 | 1180.1 |
| **Total** | **120** | 48614.9 | 2554.7 | 687.0 |