### PR TITLE
Decouple docker build from implement-experiment

### DIFF
--- a/src/autoskillit/skills_extended/implement-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-experiment/SKILL.md
@@ -210,12 +210,6 @@ vars:
     sh: pwd
 
 tasks:
-  build-env:
-    desc: Build Docker image for this experiment
-    cmds:
-      - docker build --build-arg MAMBA_ENV={{.SLUG}} -t {{.IMAGE}} .
-    dir: "{{.RESEARCH_DIR}}"
-
   run-experiment:
     desc: Run experiment inside container (volume-mounts research dir)
     cmds:

--- a/src/autoskillit/skills_extended/implement-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-experiment/SKILL.md
@@ -238,8 +238,7 @@ Note the `env_mode` from context (set by `setup-environment`):
 - `unavailable` — no environment could be provisioned; `run-experiment` will emit `blocked_experiment`
 - `none` — standard environment, no special setup needed
 
-Do NOT invoke `docker build`, `docker run`, `micromamba create`, or any
-environment construction command. The environment is already ready.
+Do NOT invoke any container or environment construction commands. The environment is already ready.
 
 **All commands from this point must run from `${WORKTREE_PATH}`.** Use absolute
 paths to avoid CWD drift across Bash tool calls.

--- a/src/autoskillit/skills_extended/implement-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/implement-experiment/SKILL.md
@@ -157,11 +157,13 @@ required** — launch as many additional subagents as needed.
 - Understanding specific APIs, types, or interfaces the scripts will use
 - Any other codebase investigation needed to write correct experiment code
 
-### Step 3 — Set Up Container Environment
+### Step 3 — Write Environment Artifacts
 
-The research worktree is isolated via Docker. All experiment code runs inside
-a container built from the experiment's `environment.yml`. Nothing is installed
-on the host.
+The environment is already prepared by `setup-environment` (upstream in the
+recipe). Read `env_mode` from context to understand what environment was
+provisioned (`docker`, `micromamba-host`, or `unavailable`). This step writes
+the Dockerfile template and `environment.yml` into the worktree as
+reproducibility artifacts — it does NOT build or install anything.
 
 **3a — Write the Dockerfile:**
 
@@ -229,15 +231,21 @@ tasks:
 
 Adjust the `run-experiment` command to match the actual entry-point script from the experiment plan.
 
-**3c — Build the Docker image:**
+**3c — Write `environment.yml` and note `env_mode`:**
 
-```bash
-cd "${RESEARCH_DIR}"
-docker build --build-arg MAMBA_ENV={slug} -t "research-{slug}" .
-```
+If the experiment plan specifies an `environment.yml`, write it to
+`${RESEARCH_DIR}/environment.yml`. This file is committed to the worktree
+as a reproducibility artifact — reviewers can inspect exact dependency
+versions.
 
-Verify the build succeeds before proceeding. If the build fails due to missing
-system packages, add them to the `apt-get install` layer and rebuild.
+Note the `env_mode` from context (set by `setup-environment`):
+- `docker` — a container image was pre-built; `run-experiment` will execute inside it
+- `micromamba-host` — a host environment was created; `run-experiment` will use `micromamba run`
+- `unavailable` — no environment could be provisioned; `run-experiment` will emit `blocked_experiment`
+- `none` — standard environment, no special setup needed
+
+Do NOT invoke `docker build`, `docker run`, `micromamba create`, or any
+environment construction command. The environment is already ready.
 
 **All commands from this point must run from `${WORKTREE_PATH}`.** Use absolute
 paths to avoid CWD drift across Bash tool calls.

--- a/src/autoskillit/skills_extended/run-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/run-experiment/SKILL.md
@@ -140,7 +140,8 @@ Execute the experiment inside the container:
 
 ```bash
 RESEARCH_DIR=$(ls -d "${WORKTREE_PATH}"/research/*/ 2>/dev/null | head -1)
-docker run --rm -v "${RESEARCH_DIR}:/workspace" "research-{slug}" \
+SLUG=$(basename "${RESEARCH_DIR%/}")
+docker run --rm -v "${RESEARCH_DIR}:/workspace" "research-${SLUG}" \
   bash -c "cd /workspace && python scripts/run.py"
 ```
 
@@ -155,8 +156,9 @@ A host micromamba environment `experiment-{slug}` was created by
 
 ```bash
 RESEARCH_DIR=$(ls -d "${WORKTREE_PATH}"/research/*/ 2>/dev/null | head -1)
+SLUG=$(basename "${RESEARCH_DIR%/}")
 cd "${RESEARCH_DIR}"
-micromamba run -n "experiment-{slug}" python scripts/run.py
+micromamba run -n "experiment-${SLUG}" python scripts/run.py
 ```
 
 Adjust the entry-point command to match the actual script from the experiment

--- a/src/autoskillit/skills_extended/run-experiment/SKILL.md
+++ b/src/autoskillit/skills_extended/run-experiment/SKILL.md
@@ -130,12 +130,64 @@ data, this is a pipeline failure — not a pipeline-level degradation.
 
 ### Step 3 — Execute Experiment
 
-Run the experiment as described in the plan. The experiment could be anything:
-scripts, benchmarks, data collection, manual measurements, tool invocations,
-custom pipelines, or any other procedure. Follow the plan's execution protocol.
+Read `env_mode` from context (set by `setup-environment` earlier in the
+recipe). Dispatch execution based on the mode:
+
+**`env_mode = docker`:**
+
+The Docker image `research-{slug}` was pre-built by `setup-environment`.
+Execute the experiment inside the container:
+
+```bash
+RESEARCH_DIR=$(ls -d "${WORKTREE_PATH}"/research/*/ 2>/dev/null | head -1)
+docker run --rm -v "${RESEARCH_DIR}:/workspace" "research-{slug}" \
+  bash -c "cd /workspace && python scripts/run.py"
+```
+
+Adjust the entry-point command to match the actual script from the experiment
+plan. If the research directory contains a `Taskfile.yml` with a
+`run-experiment` task, prefer `task run-experiment` inside the container.
+
+**`env_mode = micromamba-host`:**
+
+A host micromamba environment `experiment-{slug}` was created by
+`setup-environment`. Execute the experiment inside that environment:
+
+```bash
+RESEARCH_DIR=$(ls -d "${WORKTREE_PATH}"/research/*/ 2>/dev/null | head -1)
+cd "${RESEARCH_DIR}"
+micromamba run -n "experiment-{slug}" python scripts/run.py
+```
+
+Adjust the entry-point command to match the actual script from the experiment
+plan.
+
+**`env_mode = unavailable`:**
+
+No suitable environment could be provisioned. Emit the `blocked_experiment`
+structured output token and set the results status to FAILED:
+
+```
+blocked_experiment = env_mode is unavailable — setup-environment could not provision docker or micromamba-host
+```
+
+Write a results file with `## Status: FAILED` and the reason, then proceed
+to Step 5 (Save Results) to emit the `results_path` token.
+
+**`env_mode = none`:**
+
+Standard environment — no container or micromamba needed. Run the experiment
+directly in the worktree using the system Python:
+
+```bash
+RESEARCH_DIR=$(ls -d "${WORKTREE_PATH}"/research/*/ 2>/dev/null | head -1)
+cd "${RESEARCH_DIR}" && python scripts/run.py
+```
+
+---
 
 If the plan specifies multiple configurations or comparisons, execute all of
-them and collect results for each.
+them under the dispatched environment mode and collect results for each.
 
 ### Step 4 — Collect Results
 

--- a/tests/contracts/test_implement_experiment_contracts.py
+++ b/tests/contracts/test_implement_experiment_contracts.py
@@ -45,17 +45,25 @@ def test_implement_experiment_allows_pytest_collect_only() -> None:
     )
 
 
-def test_implement_experiment_step3_references_docker_build() -> None:
-    """Step 3 must instruct the agent to build a Docker image."""
+def test_implement_experiment_step3_references_env_mode() -> None:
+    """Step 3 must reference env_mode and write Dockerfile artifact, but NOT build."""
     text = SKILL_PATH.read_text()
     step3_section = (
         text.split("### Step 3")[1].split("### Step 4")[0]
         if "### Step 3" in text and "### Step 4" in text
         else text
     )
-    assert "docker build" in step3_section.lower(), (
-        "implement-experiment/SKILL.md Step 3 must reference 'docker build' — "
-        "Docker is the primary isolation mechanism for research execution"
+    assert "env_mode" in step3_section, (
+        "implement-experiment/SKILL.md Step 3 must reference 'env_mode' — "
+        "the environment mode is set by setup-environment upstream"
+    )
+    assert "Dockerfile" in step3_section, (
+        "implement-experiment/SKILL.md Step 3 must still write a Dockerfile "
+        "template as a reproducibility artifact"
+    )
+    assert "docker build" not in step3_section.lower(), (
+        "implement-experiment/SKILL.md Step 3 must NOT invoke 'docker build' — "
+        "environment construction is handled by setup-environment"
     )
 
 

--- a/tests/contracts/test_run_experiment_contracts.py
+++ b/tests/contracts/test_run_experiment_contracts.py
@@ -22,3 +22,23 @@ def test_data_manifest_preflight_check() -> None:
     lower = text.lower()
     assert "data manifest" in lower
     assert "pre-flight" in lower or "preflight" in lower
+
+
+def test_run_experiment_env_mode_dispatch() -> None:
+    """run-experiment must dispatch execution based on env_mode."""
+    text = SKILL_PATH.read_text()
+    assert "env_mode" in text, (
+        "run-experiment/SKILL.md must reference 'env_mode' for execution dispatch"
+    )
+    assert "blocked_experiment" in text, (
+        "run-experiment/SKILL.md must emit 'blocked_experiment' token when env_mode is unavailable"
+    )
+
+
+def test_run_experiment_micromamba_run_command() -> None:
+    """run-experiment must include micromamba run command for host fallback."""
+    text = SKILL_PATH.read_text()
+    assert "micromamba run" in text, (
+        "run-experiment/SKILL.md must include 'micromamba run' command "
+        "for the micromamba-host execution path"
+    )


### PR DESCRIPTION
## Summary

Remove the inline `docker build` invocation from implement-experiment Step 3c, replace it with an `env_mode`-aware artifact-writing step (Dockerfile template + environment.yml, no build), and add env_mode dispatch logic to run-experiment so it routes execution correctly (docker container, micromamba host, or blocked). Update the contract test to assert the new shape.

The `setup-environment` skill (issue #839) already exists and emits `env_mode` into context. This plan wires the two downstream consumers (implement-experiment and run-experiment) to read that context variable.

## Requirements

Part of **Unit 3 — Environment setup skill (P1)** from the auto-research master plan.

## Scope

Remove the inline `docker build` logic from `implement-experiment/SKILL.md` Step 3c. The skill now assumes the environment is ready (reads `env_mode` from context, set by Work Item 3.2) and focuses on writing scripts, tests, `Dockerfile` artifacts, and `environment.yml` into the worktree. Update the corresponding contract test so it asserts the new shape. Update `run-experiment/SKILL.md` to dispatch execution on `env_mode` (docker vs micromamba-host vs unavailable).

## Acceptance criteria

- [ ] Step 3c in implement-experiment SKILL.md writes `Dockerfile` template and `environment.yml` but does NOT invoke `docker build`
- [ ] Step 3c references `env_mode` from context
- [ ] Contract test `test_implement_experiment_step3_references_docker_build` updated: asserts Step 3c references `env_mode` AND writes a `Dockerfile` artifact (not that it runs `docker build`)
- [ ] `run-experiment` SKILL.md dispatches on `env_mode`: `docker` → container run; `micromamba-host` → `micromamba run -n {env} ...`; `unavailable` → emit `blocked_experiment` token
- [ ] Work Item 6.1 smoke test passes end-to-end under the new env-mode dispatch
- [ ] `task test-check` passes

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260506-000852-246024/.autoskillit/temp/make-plan/decouple-docker-from-implement-experiment_plan_2026-05-06_010200.md`

Closes #840

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 49 | 7.2k | 593.1k | 59.7k | 54 | 51.0k | 3m 52s |
| verify | 1 | 34 | 5.8k | 787.8k | 64.9k | 52 | 52.2k | 3m 17s |
| implement | 1 | 396.3k | 6.1k | 542.7k | 30.9k | 55 | 78.0k | 2m 49s |
| prepare_pr | 1 | 91.9k | 3.8k | 258.4k | 30.9k | 27 | 23.2k | 1m 30s |
| compose_pr | 1 | 50.5k | 1.9k | 176.4k | 25.6k | 17 | 15.0k | 46s |
| review_pr | 1 | 92 | 20.7k | 435.4k | 55.3k | 34 | 44.0k | 4m 58s |
| resolve_review | 1 | 139 | 8.3k | 577.0k | 45.5k | 43 | 32.8k | 3m 13s |
| **Total** | | 539.0k | 53.9k | 3.4M | 64.9k | | 296.3k | 20m 29s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 128 | 4239.7 | 609.6 | 47.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **128** | 26334.7 | 2314.7 | 420.8 |