### PR TITLE
Fleet-level Resume Discipline — Reason-aware Resume vs. Abandon

### DIFF
--- a/src/autoskillit/cli/_prompts.py
+++ b/src/autoskillit/cli/_prompts.py
@@ -99,6 +99,21 @@ Apply the same failure rules as static dispatches. On any food truck failure:
 """
 
 
+def _resume_reason_guidance(kill_reason: str) -> str:
+    """Return reason-specific resume guidance for the L3 campaign dispatcher."""
+    if kill_reason == "idle_stall":
+        return (
+            "Kill reason: idle timeout (session was waiting for an external event). "
+            "Resume is safe — the session likely has partial progress on disk."
+        )
+    if kill_reason == "resume":
+        return (
+            "Kill reason: transient infrastructure failure (API error or process kill). "
+            "Resume is safe — retry immediately."
+        )
+    return "Kill reason: unknown. Resume with standard recovery."
+
+
 def _build_fleet_campaign_prompt(
     campaign_recipe: Recipe,
     manifest_yaml: str,
@@ -108,6 +123,7 @@ def _build_fleet_campaign_prompt(
     max_quota_wait_sec: int = 3600,
     resumable_dispatch_name: str = "",
     resume_session_id: str = "",
+    resume_kill_reason: str = "",
     ingredients_table: str | None = None,
 ) -> str:
     """Build the system prompt for an L3 campaign dispatcher headless session.
@@ -188,11 +204,13 @@ dispatch name NOT listed above.
             else ""
         )
         _resume_session_clause = f" {_resume_session_line}" if _resume_session_line else ""
+        _reason_guidance = _resume_reason_guidance(resume_kill_reason)
         resumable_section = f"""\
 
 ## RESUMABLE DISPATCH: {resumable_dispatch_name}
 
 This dispatch was interrupted mid-run with partial sidecar progress.
+{_reason_guidance}
 Re-dispatch it using compute_remaining_issues(dispatch_id, original_urls, project_dir)
 to retrieve only the remaining issue URLs, then call dispatch_food_truck with
 issue_urls=<remaining> and allow_reentry=true as ingredient overrides{_resume_session_clause}.
@@ -272,6 +290,22 @@ If a dispatch has no `capture:` field, pass `capture={{}}` or omit the parameter
 The `${{{{ campaign.* }}}}` references in ingredients are resolved before the L2 session
 is started — the L2 food truck agent always receives concrete values.
 {gate_section}{dynamic_dispatch_section}
+## RESUME DISCIPLINE
+
+When a dispatch is killed (no result block received), the infrastructure classifies it:
+
+| Kill Reason | Policy | Rationale |
+|-------------|--------|-----------|
+| idle_stall | RESUME | Session was waiting for an external event — partial progress exists |
+| api_error / process_killed | RESUME | Transient failure — session state is intact |
+| context_exhausted | ABANDON | Session exhausted its context window — resuming hits same limit |
+| thinking_stall | ABANDON | Session stuck in a loop — resuming repeats the stall |
+| stale | ABANDON | Session state is stale — no meaningful progress to continue |
+
+If the infrastructure marks a dispatch RESUMABLE, follow the RESUMABLE DISPATCH section below.
+If the infrastructure marks a dispatch FAILURE, follow the FAILURE RECOVERY rules above.
+Do NOT override the infrastructure's resume/abandon decision.
+
 ## FAILURE RECOVERY
 
 When a dispatch call returns, evaluate the envelope and payload:

--- a/src/autoskillit/cli/_prompts.py
+++ b/src/autoskillit/cli/_prompts.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from autoskillit.core import PIPELINE_FORBIDDEN_TOOLS, get_logger, pkg_root
+from autoskillit.core import PIPELINE_FORBIDDEN_TOOLS, RetryReason, get_logger, pkg_root
 from autoskillit.hooks import QUOTA_GUARD_DENY_TRIGGER, QUOTA_POST_WARNING_TRIGGER
 
 logger = get_logger(__name__)
@@ -101,12 +101,12 @@ Apply the same failure rules as static dispatches. On any food truck failure:
 
 def _resume_reason_guidance(kill_reason: str) -> str:
     """Return reason-specific resume guidance for the L3 campaign dispatcher."""
-    if kill_reason == "idle_stall":
+    if kill_reason == RetryReason.IDLE_STALL:
         return (
             "Kill reason: idle timeout (session was waiting for an external event). "
             "Resume is safe — the session likely has partial progress on disk."
         )
-    if kill_reason == "resume":
+    if kill_reason == RetryReason.RESUME:
         return (
             "Kill reason: transient infrastructure failure (API error or process kill). "
             "Resume is safe — retry immediately."

--- a/src/autoskillit/cli/fleet/_fleet_session.py
+++ b/src/autoskillit/cli/fleet/_fleet_session.py
@@ -113,6 +113,11 @@ def _launch_fleet_session(
             if resume_metadata is not None and resume_metadata.is_resumable
             else ""
         )
+        resume_kill_reason = (
+            resume_metadata.kill_reason
+            if resume_metadata is not None and resume_metadata.is_resumable
+            else ""
+        )
         prompt = _build_fleet_campaign_prompt(
             campaign_recipe,
             manifest_yaml,
@@ -121,6 +126,7 @@ def _launch_fleet_session(
             campaign_id,
             resumable_dispatch_name=resumable_dispatch_name,
             resume_session_id=resume_session_id,
+            resume_kill_reason=resume_kill_reason,
             ingredients_table=ingredients_table,
         )
         extra_env = {
@@ -172,6 +178,7 @@ def _launch_fleet_session(
                 fresh_metadata.next_dispatch_name if fresh_metadata.is_resumable else ""
             )
             resume_session_id = fresh_metadata.l3_session_id if fresh_metadata.is_resumable else ""
+            resume_kill_reason = fresh_metadata.kill_reason if fresh_metadata.is_resumable else ""
             prompt = _build_fleet_campaign_prompt(
                 campaign_recipe,
                 manifest_yaml,
@@ -180,5 +187,6 @@ def _launch_fleet_session(
                 campaign_id,
                 resumable_dispatch_name=resumable_dispatch_name,
                 resume_session_id=resume_session_id,
+                resume_kill_reason=resume_kill_reason,
                 ingredients_table=ingredients_table,
             )

--- a/src/autoskillit/fleet/_api.py
+++ b/src/autoskillit/fleet/_api.py
@@ -13,6 +13,8 @@ from uuid import uuid4
 
 from autoskillit.core import (
     FleetErrorCode,
+    InfraExitCategory,
+    RetryReason,
     SessionCheckpoint,  # noqa: F401, TC001
     SkillResult,
     claude_code_log_path,
@@ -203,6 +205,28 @@ async def execute_dispatch(
         lock.release()
 
 
+_ABANDON_REASONS: frozenset[str] = frozenset(
+    {
+        RetryReason.STALE,
+        RetryReason.THINKING_STALL,
+        RetryReason.PATH_CONTAMINATION,
+        RetryReason.CLONE_CONTAMINATION,
+    }
+)
+
+
+def _is_abandon_reason(skill_result: SkillResult) -> bool:
+    """Return True when the kill reason indicates resume would be futile."""
+    if skill_result.retry_reason in _ABANDON_REASONS:
+        return True
+    if (
+        skill_result.retry_reason == RetryReason.RESUME
+        and skill_result.infra_exit_category == InfraExitCategory.CONTEXT_EXHAUSTED
+    ):
+        return True
+    return False
+
+
 def classify_dispatch_outcome(
     parsed: L3ParseResult,
     skill_result: SkillResult,
@@ -229,6 +253,8 @@ def classify_dispatch_outcome(
         return DispatchStatus.FAILURE, FleetErrorCode.FLEET_L3_PARSE_FAILED
     has_progress = checkpoint is not None or sidecar_exists
     if skill_result.session_id and skill_result.lifespan_started and has_progress:
+        if _is_abandon_reason(skill_result):
+            return DispatchStatus.FAILURE, FleetErrorCode.FLEET_L3_NO_RESULT_BLOCK
         return DispatchStatus.RESUMABLE, FleetErrorCode.FLEET_L3_NO_RESULT_BLOCK
     return DispatchStatus.FAILURE, FleetErrorCode.FLEET_L3_NO_RESULT_BLOCK
 
@@ -407,6 +433,8 @@ async def _run_dispatch(
                 l3_session_id=skill_result.session_id,
                 l3_pid=_l3_pid[0] if _l3_pid else 0,
                 reason=FleetErrorCode.FLEET_L3_TIMEOUT,
+                kill_reason=skill_result.retry_reason or "",
+                infra_exit_category=skill_result.infra_exit_category or "",
                 token_usage=skill_result.token_usage or {},
                 started_at=started_at,
                 ended_at=ended_at,
@@ -457,6 +485,8 @@ async def _run_dispatch(
             l3_session_id=skill_result.session_id,
             l3_pid=_l3_pid[0] if _l3_pid else 0,
             reason=reason,
+            kill_reason=skill_result.retry_reason or "",
+            infra_exit_category=skill_result.infra_exit_category or "",
             token_usage=skill_result.token_usage or {},
             started_at=started_at,
             ended_at=ended_at,

--- a/src/autoskillit/fleet/state.py
+++ b/src/autoskillit/fleet/state.py
@@ -56,6 +56,8 @@ class DispatchRecord:
     l3_starttime_ticks: int = 0
     l3_boot_id: str = ""
     reason: str = ""
+    kill_reason: str = ""
+    infra_exit_category: str = ""
     token_usage: dict[str, Any] = field(default_factory=dict)
     started_at: float = 0.0
     ended_at: float = 0.0
@@ -86,6 +88,7 @@ class ResumeDecision:
     completed_dispatches_block: str
     is_resumable: bool = False
     l3_session_id: str = ""
+    kill_reason: str = ""
 
 
 _ALLOWED_TRANSITIONS: dict[str, frozenset[str]] = {
@@ -250,6 +253,8 @@ def read_state(state_path: Path) -> CampaignState | None:
                 l3_starttime_ticks=d.get("l3_starttime_ticks") or d.get("l2_starttime_ticks", 0),
                 l3_boot_id=d.get("l3_boot_id") or d.get("l2_boot_id", ""),
                 reason=d.get("reason", ""),
+                kill_reason=d.get("kill_reason", ""),
+                infra_exit_category=d.get("infra_exit_category", ""),
                 token_usage=d.get("token_usage", {}),
                 started_at=d.get("started_at", 0.0),
                 ended_at=d.get("ended_at", 0.0),
@@ -567,6 +572,25 @@ def read_all_campaign_captures(
     return result
 
 
+_ABANDON_KILL_REASONS: frozenset[str] = frozenset(
+    {
+        "stale",
+        "thinking_stall",
+        "path_contamination",
+        "clone_contamination",
+    }
+)
+
+
+def _is_abandon_kill_reason(kill_reason: str, infra_exit_category: str) -> bool:
+    """Check if stored kill metadata indicates resume would be futile."""
+    if kill_reason in _ABANDON_KILL_REASONS:
+        return True
+    if kill_reason == "resume" and infra_exit_category == "context_exhausted":
+        return True
+    return False
+
+
 def crash_recover_dispatch(
     state_path: Path,
     record: DispatchRecord,
@@ -583,6 +607,16 @@ def crash_recover_dispatch(
             logger.warning("crash_recover_dispatch: sidecar vanished during read", exc_info=True)
         else:
             if not raw_lines or read_sidecar_from_path(sidecar):
+                if _is_abandon_kill_reason(record.kill_reason, record.infra_exit_category):
+                    try:
+                        mark_dispatch_interrupted(state_path, record.name, reason=reason)
+                        return DispatchStatus.INTERRUPTED
+                    except Exception:
+                        logger.warning(
+                            "crash_recover_dispatch: failed to mark dispatch interrupted",
+                            exc_info=True,
+                        )
+                        return None
                 try:
                     mark_dispatch_resumable(state_path, record.name, sidecar_path=str(sidecar))
                     return DispatchStatus.RESUMABLE
@@ -667,6 +701,7 @@ def resume_campaign_from_state(
             next_name = ""
             is_resumable = False
             resumable_l3_session_id = ""
+            resumable_kill_reason = ""
             for d in state.dispatches:
                 if d.status in _VISIBLE_IN_BLOCK_STATUSES:
                     completed_lines.append(f"- {d.name}: {d.status}")
@@ -674,6 +709,7 @@ def resume_campaign_from_state(
                     next_name = d.name
                     is_resumable = True
                     resumable_l3_session_id = d.l3_session_id
+                    resumable_kill_reason = d.kill_reason
                 elif (
                     d.status
                     not in {
@@ -695,4 +731,5 @@ def resume_campaign_from_state(
                 completed_dispatches_block=completed_block,
                 is_resumable=is_resumable,
                 l3_session_id=resumable_l3_session_id,
+                kill_reason=resumable_kill_reason,
             )

--- a/src/autoskillit/fleet/state.py
+++ b/src/autoskillit/fleet/state.py
@@ -15,7 +15,13 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
-from autoskillit.core import FleetErrorCode, get_logger, write_versioned_json
+from autoskillit.core import (
+    FleetErrorCode,
+    InfraExitCategory,
+    RetryReason,
+    get_logger,
+    write_versioned_json,
+)
 
 logger = get_logger(__name__)
 
@@ -574,10 +580,10 @@ def read_all_campaign_captures(
 
 _ABANDON_KILL_REASONS: frozenset[str] = frozenset(
     {
-        "stale",
-        "thinking_stall",
-        "path_contamination",
-        "clone_contamination",
+        RetryReason.STALE,
+        RetryReason.THINKING_STALL,
+        RetryReason.PATH_CONTAMINATION,
+        RetryReason.CLONE_CONTAMINATION,
     }
 )
 
@@ -586,7 +592,10 @@ def _is_abandon_kill_reason(kill_reason: str, infra_exit_category: str) -> bool:
     """Check if stored kill metadata indicates resume would be futile."""
     if kill_reason in _ABANDON_KILL_REASONS:
         return True
-    if kill_reason == "resume" and infra_exit_category == "context_exhausted":
+    if (
+        kill_reason == RetryReason.RESUME
+        and infra_exit_category == InfraExitCategory.CONTEXT_EXHAUSTED
+    ):
         return True
     return False
 

--- a/tests/cli/test_l3_orchestrator_prompt.py
+++ b/tests/cli/test_l3_orchestrator_prompt.py
@@ -237,7 +237,7 @@ class TestResumableSessionIdInjection:
 
     def test_no_resumable_section_when_dispatch_name_empty(self) -> None:
         prompt = _build(resumable_dispatch_name="", resume_session_id="sess-abc")
-        assert "RESUMABLE DISPATCH" not in prompt
+        assert "RESUMABLE DISPATCH:" not in prompt
 
 
 # --- K-9: TestInterruptCleanupSection ---
@@ -490,3 +490,42 @@ class TestK15IngredientsTableInjection:
         ingredients_pos = prompt.index("RECIPE INGREDIENTS")
         manifest_pos = prompt.index("DISPATCH MANIFEST")
         assert overview_pos < ingredients_pos < manifest_pos
+
+
+class TestResumeReasonInPrompt:
+    def test_idle_stall_resume_includes_reenter_guidance(self) -> None:
+        prompt = _build(
+            resumable_dispatch_name="impl-1",
+            resume_session_id="sess-1",
+            resume_kill_reason="idle_stall",
+        )
+        assert "RESUMABLE DISPATCH: impl-1" in prompt
+        assert "idle timeout" in prompt
+        assert "Resume is safe" in prompt
+
+    def test_context_exhausted_absent_from_resumable(self) -> None:
+        prompt = _build(
+            resumable_dispatch_name="impl-1",
+            resume_kill_reason="",
+        )
+        assert "RESUMABLE DISPATCH: impl-1" in prompt
+        idx = prompt.index("RESUMABLE DISPATCH: impl-1")
+        end_idx = prompt.index("## INTERRUPT/CLEANUP", idx)
+        resumable_section = prompt[idx:end_idx]
+        assert "context_exhausted" not in resumable_section
+        assert "Kill reason: unknown" in resumable_section
+
+    def test_api_error_resume_includes_retry_guidance(self) -> None:
+        prompt = _build(
+            resumable_dispatch_name="impl-1",
+            resume_kill_reason="resume",
+        )
+        assert "RESUMABLE DISPATCH: impl-1" in prompt
+        assert "transient infrastructure failure" in prompt
+
+    def test_resume_discipline_section_present(self) -> None:
+        prompt = _build()
+        assert "RESUME DISCIPLINE" in prompt
+        assert "idle_stall" in prompt
+        assert "context_exhausted" in prompt
+        assert "thinking_stall" in prompt

--- a/tests/cli/test_l3_orchestrator_prompt.py
+++ b/tests/cli/test_l3_orchestrator_prompt.py
@@ -506,7 +506,7 @@ class TestResumeReasonInPrompt:
     def test_context_exhausted_absent_from_resumable(self) -> None:
         prompt = _build(
             resumable_dispatch_name="impl-1",
-            resume_kill_reason="",
+            resume_kill_reason="context_exhausted",
         )
         assert "RESUMABLE DISPATCH: impl-1" in prompt
         idx = prompt.index("RESUMABLE DISPATCH: impl-1")

--- a/tests/execution/CLAUDE.md
+++ b/tests/execution/CLAUDE.md
@@ -37,6 +37,7 @@ Subprocess integration, headless session, process lifecycle, and session result 
 | `test_headless_provider_forwarding.py` | Tests verifying provider_extras and profile_name forwarding through the headless call chain |
 | `test_headless_result_write_reconciliation.py` | Integration tests for EMPTY_OUTPUT + write-evidence reconciliation gate in _build_skill_result |
 | `test_headless_synthesis.py` | Tests for headless.py synthesis helpers: output path extraction, validation, contamination |
+| `test_headless_result.py` | Tests for _build_skill_result idle_stall lifespan_started propagation |
 | `test_idle_output_env.py` | Group G (execution part): AUTOSKILLIT_IDLE_OUTPUT_TIMEOUT env variable injection tests |
 | `test_linux_tracing.py` | Tests for Linux-only process tracing via psutil and /proc filesystem |
 | `test_linux_tracing_pty_integration.py` | Integration test: PTY-wrapped command is traced at the workload level, not the wrapper |

--- a/tests/execution/test_headless_result.py
+++ b/tests/execution/test_headless_result.py
@@ -1,0 +1,56 @@
+"""Tests for _build_skill_result idle_stall lifespan_started propagation."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from autoskillit.core.types import SubprocessResult, TerminationReason
+from autoskillit.execution.headless import _build_skill_result
+
+pytestmark = [pytest.mark.layer("execution"), pytest.mark.small, pytest.mark.feature("fleet")]
+
+
+def _idle_stall_result(stdout: str) -> SubprocessResult:
+    """Build a SubprocessResult with IDLE_STALL termination."""
+    return SubprocessResult(
+        returncode=-1,
+        stdout=stdout,
+        stderr="",
+        termination=TerminationReason.IDLE_STALL,
+        pid=12345,
+        session_id="sess-idle-1",
+        channel_b_session_id="",
+    )
+
+
+def _tool_use_ndjson(tool_name: str = "Write", **input_kwargs: object) -> str:
+    return json.dumps(
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "name": tool_name,
+                        "id": "tool-1",
+                        "input": input_kwargs,
+                    }
+                ]
+            },
+        }
+    )
+
+
+class TestIdleStallLifespanStarted:
+    def test_idle_stall_failure_preserves_lifespan_started_true(self):
+        stdout = _tool_use_ndjson("Write", file_path="/worktree/src/foo.py")
+        result = _idle_stall_result(stdout)
+        skill_result = _build_skill_result(result)
+        assert skill_result.lifespan_started is True
+
+    def test_idle_stall_failure_preserves_lifespan_started_false(self):
+        result = _idle_stall_result("")
+        skill_result = _build_skill_result(result)
+        assert skill_result.lifespan_started is False

--- a/tests/fleet/test_dispatch_outcome_classifier.py
+++ b/tests/fleet/test_dispatch_outcome_classifier.py
@@ -100,3 +100,90 @@ class TestClassifyDispatchOutcomeCompletedDirty:
         status, reason = classify_dispatch_outcome(parsed, skill_result, sidecar_exists=False)
         assert status == DispatchStatus.FAILURE
         assert reason == FleetErrorCode.FLEET_L3_PARSE_FAILED
+
+
+class TestReasonAwareResumePolicy:
+    def test_idle_stall_with_progress_is_resumable(self):
+        parsed, skill_result = _no_sentinel(session_id="sess-abc", lifespan_started=True)
+        skill_result = dataclasses.replace(
+            skill_result,
+            retry_reason="idle_stall",
+        )
+        status, reason = classify_dispatch_outcome(parsed, skill_result, sidecar_exists=True)
+        assert status == DispatchStatus.RESUMABLE
+        assert reason == FleetErrorCode.FLEET_L3_NO_RESULT_BLOCK
+
+    def test_context_exhausted_with_progress_is_failure(self):
+        parsed, skill_result = _no_sentinel(session_id="sess-abc", lifespan_started=True)
+        skill_result = dataclasses.replace(
+            skill_result,
+            retry_reason="resume",
+            infra_exit_category="context_exhausted",
+        )
+        status, reason = classify_dispatch_outcome(parsed, skill_result, sidecar_exists=True)
+        assert status == DispatchStatus.FAILURE
+        assert reason == FleetErrorCode.FLEET_L3_NO_RESULT_BLOCK
+
+    def test_api_error_with_progress_is_resumable(self):
+        parsed, skill_result = _no_sentinel(session_id="sess-abc", lifespan_started=True)
+        skill_result = dataclasses.replace(
+            skill_result,
+            retry_reason="resume",
+            infra_exit_category="api_error",
+        )
+        status, reason = classify_dispatch_outcome(parsed, skill_result, sidecar_exists=True)
+        assert status == DispatchStatus.RESUMABLE
+        assert reason == FleetErrorCode.FLEET_L3_NO_RESULT_BLOCK
+
+    def test_process_killed_with_progress_is_resumable(self):
+        parsed, skill_result = _no_sentinel(session_id="sess-abc", lifespan_started=True)
+        skill_result = dataclasses.replace(
+            skill_result,
+            retry_reason="resume",
+            infra_exit_category="process_killed",
+        )
+        status, reason = classify_dispatch_outcome(parsed, skill_result, sidecar_exists=True)
+        assert status == DispatchStatus.RESUMABLE
+        assert reason == FleetErrorCode.FLEET_L3_NO_RESULT_BLOCK
+
+    def test_thinking_stall_with_progress_is_failure(self):
+        parsed, skill_result = _no_sentinel(session_id="sess-abc", lifespan_started=True)
+        skill_result = dataclasses.replace(
+            skill_result,
+            retry_reason="thinking_stall",
+        )
+        status, reason = classify_dispatch_outcome(parsed, skill_result, sidecar_exists=True)
+        assert status == DispatchStatus.FAILURE
+        assert reason == FleetErrorCode.FLEET_L3_NO_RESULT_BLOCK
+
+    def test_stale_with_progress_is_failure(self):
+        parsed, skill_result = _no_sentinel(session_id="sess-abc", lifespan_started=True)
+        skill_result = dataclasses.replace(
+            skill_result,
+            retry_reason="stale",
+        )
+        status, reason = classify_dispatch_outcome(parsed, skill_result, sidecar_exists=True)
+        assert status == DispatchStatus.FAILURE
+        assert reason == FleetErrorCode.FLEET_L3_NO_RESULT_BLOCK
+
+    def test_no_progress_still_failure_regardless_of_reason(self):
+        parsed, skill_result = _no_sentinel(session_id="sess-abc", lifespan_started=True)
+        skill_result = dataclasses.replace(
+            skill_result,
+            retry_reason="idle_stall",
+        )
+        status, reason = classify_dispatch_outcome(
+            parsed, skill_result, sidecar_exists=False, checkpoint=None
+        )
+        assert status == DispatchStatus.FAILURE
+        assert reason == FleetErrorCode.FLEET_L3_NO_RESULT_BLOCK
+
+    def test_no_lifespan_still_failure_regardless_of_reason(self):
+        parsed, skill_result = _no_sentinel(session_id="sess-abc", lifespan_started=False)
+        skill_result = dataclasses.replace(
+            skill_result,
+            retry_reason="idle_stall",
+        )
+        status, reason = classify_dispatch_outcome(parsed, skill_result, sidecar_exists=True)
+        assert status == DispatchStatus.FAILURE
+        assert reason == FleetErrorCode.FLEET_L3_NO_RESULT_BLOCK

--- a/tests/fleet/test_state.py
+++ b/tests/fleet/test_state.py
@@ -757,3 +757,97 @@ class TestHasFailedDispatchReasonAware:
             DispatchRecord(name="d2", status=DispatchStatus.FAILURE, reason="task-failed"),
         )
         assert has_failed_dispatch(sp) is True
+
+
+class TestKillReasonPropagation:
+    def test_kill_reason_stored_in_dispatch_record(self, tmp_path: Path) -> None:
+        sp = _state_path(tmp_path)
+        write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("x"))
+        record = DispatchRecord(
+            name="x",
+            status=DispatchStatus.FAILURE,
+            kill_reason="idle_stall",
+        )
+        append_dispatch_record(sp, record)
+        state = read_state(sp)
+        assert state is not None
+        assert state.dispatches[0].kill_reason == "idle_stall"
+
+    def test_kill_reason_defaults_empty(self) -> None:
+        record = DispatchRecord(name="x")
+        assert record.kill_reason == ""
+
+    def test_kill_reason_round_trips_through_json(self, tmp_path: Path) -> None:
+        sp = _state_path(tmp_path)
+        write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("x"))
+        record = DispatchRecord(
+            name="x",
+            status=DispatchStatus.FAILURE,
+            kill_reason="context_exhausted",
+            infra_exit_category="context_exhausted",
+        )
+        append_dispatch_record(sp, record)
+        raw = sp.read_text(encoding="utf-8")
+        assert '"kill_reason"' in raw
+        assert '"infra_exit_category"' in raw
+        state = read_state(sp)
+        assert state is not None
+        assert state.dispatches[0].kill_reason == "context_exhausted"
+        assert state.dispatches[0].infra_exit_category == "context_exhausted"
+
+    def test_crash_recover_abandons_context_exhausted(self, tmp_path: Path) -> None:
+        sp = _state_path(tmp_path)
+        sidecar = tmp_path / "sidecar.jsonl"
+        sidecar.write_text("")
+        write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("x"))
+        mark_dispatch_running(sp, "x", dispatch_id="d1", l3_pid=42)
+        from autoskillit.fleet import is_dispatch_session_alive
+
+        with patch(
+            f"{is_dispatch_session_alive.__module__}.is_dispatch_session_alive", return_value=False
+        ):
+            state = read_state(sp)
+            record = next(d for d in state.dispatches if d.name == "x")
+            record.kill_reason = "resume"
+            record.infra_exit_category = "context_exhausted"
+            record.sidecar_path = str(sidecar)
+            result = crash_recover_dispatch(sp, record)
+        assert result == DispatchStatus.INTERRUPTED
+
+    def test_crash_recover_resumes_idle_stall(self, tmp_path: Path) -> None:
+        sp = _state_path(tmp_path)
+        sidecar = tmp_path / "sidecar.jsonl"
+        sidecar.write_text("")
+        write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("x"))
+        mark_dispatch_running(sp, "x", dispatch_id="d1", l3_pid=42)
+        from autoskillit.fleet import is_dispatch_session_alive
+
+        with patch(
+            f"{is_dispatch_session_alive.__module__}.is_dispatch_session_alive", return_value=False
+        ):
+            state = read_state(sp)
+            record = next(d for d in state.dispatches if d.name == "x")
+            record.kill_reason = "idle_stall"
+            record.infra_exit_category = ""
+            record.sidecar_path = str(sidecar)
+            result = crash_recover_dispatch(sp, record)
+        assert result == DispatchStatus.RESUMABLE
+
+    def test_resume_decision_includes_kill_reason(self, tmp_path: Path) -> None:
+        sp = _state_path(tmp_path)
+        sidecar = tmp_path / "sidecar.jsonl"
+        sidecar.write_text("")
+        write_initial_state(sp, "cid", "camp", "/m.yaml", _make_dispatches("x"))
+        mark_dispatch_running(sp, "x", dispatch_id="d1", l3_pid=42)
+        mark_dispatch_resumable(sp, "x", sidecar_path=str(sidecar))
+        data = json.loads(sp.read_text())
+        for d in data["dispatches"]:
+            if d["name"] == "x":
+                d["kill_reason"] = "idle_stall"
+                d["infra_exit_category"] = ""
+                d["l3_session_id"] = "sess-1"
+        sp.write_text(json.dumps(data))
+        decision = resume_campaign_from_state(sp, continue_on_failure=False)
+        assert decision is not None
+        assert decision.is_resumable is True
+        assert decision.kill_reason == "idle_stall"


### PR DESCRIPTION
## Summary

Add reason-aware resume discipline to the L3 fleet dispatch layer so that `classify_dispatch_outcome` consults `SkillResult.retry_reason` and `infra_exit_category` before routing a killed dispatch to RESUMABLE. Context-limit kills are abandoned (resume would hit the same limit). Idle-stall and transient infra kills are resumed. The kill reason is propagated through `DispatchRecord` → `ResumeDecision` → campaign prompt, giving L3 reason-specific recovery instructions.

## Requirements

- REQ-RESUME-001: The L3 fleet layer MUST have documented resume discipline rules that specify when to resume a killed L2 session vs. when to abandon it
- REQ-RESUME-002: Resume SHOULD be attempted for idle_stall kills (session was likely waiting for a legitimate external event)
- REQ-RESUME-003: Resume MUST NOT be attempted for context_limit hits (session exhausted its context window — resuming would hit the same limit)
- REQ-RESUME-004: The resume discipline rules MUST be accessible to both the infrastructure layer (`classify_dispatch_outcome` / campaign resume logic) and the L3 campaign dispatcher prompt
- REQ-RESUME-005: The `IDLE_STALL` branch in `_headless_result.py:230-259` MUST correctly report `lifespan_started` so that `classify_dispatch_outcome` can route to RESUMABLE (prerequisite — currently blocks resume path entirely for idle_stall kills)

Closes #1987

## Implementation Plan

Plan file: `.autoskillit/temp/make-plan/fleet_level_resume_discipline_plan_2026-05-06_011600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 8.0k | 13.0k | 861.5k | 69.4k | 149 | 64.5k | 9m 57s |
| verify | 1 | 1.5k | 13.4k | 2.4M | 75.1k | 133 | 62.9k | 9m 36s |
| implement | 1 | 9.7M | 42.8k | 3.8M | 93.5k | 370 | 260.9k | 21m 3s |
| prepare_pr | 1 | 131.8k | 3.9k | 272.1k | 31.9k | 28 | 49.7k | 1m 30s |
| compose_pr | 1 | 51.5k | 1.7k | 183.9k | 26.7k | 17 | 15.0k | 44s |
| review_pr | 1 | 142 | 34.9k | 780.7k | 82.5k | 50 | 70.8k | 13m 33s |
| resolve_review | 1 | 507 | 33.8k | 4.3M | 108.2k | 163 | 95.2k | 10m 55s |
| **Total** | | 9.9M | 143.5k | 12.6M | 108.2k | | 618.9k | 1h 7m |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 388 | 9897.0 | 672.3 | 110.3 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 29 | 147557.6 | 3282.8 | 1166.0 |
| **Total** | **417** | 30211.2 | 1484.2 | 344.1 |