### PR TITLE
Generate research.yaml Contract Card

### DIFF
--- a/src/autoskillit/recipes/contracts/research.yaml
+++ b/src/autoskillit/recipes/contracts/research.yaml
@@ -116,7 +116,7 @@ skills:
       required: true
       recommended: false
     - name: scope_report_path
-      type: string
+      type: file_path
       required: false
       recommended: false
     outputs:
@@ -253,6 +253,7 @@ skills:
     - 'groups_path = /tmp/groups.json
 
       %%ORDER_UP%%'
+    write_behavior: always
   make-plan:
     inputs:
     - name: task
@@ -292,7 +293,7 @@ skills:
   troubleshoot-experiment:
     inputs:
     - name: worktree_path
-      type: string
+      type: directory_path
       required: true
       recommended: false
     - name: step_name

--- a/src/autoskillit/recipes/contracts/research.yaml
+++ b/src/autoskillit/recipes/contracts/research.yaml
@@ -482,6 +482,7 @@ skills:
     - 'verdict = needs_human
 
       %%ORDER_UP%%'
+    write_behavior: always
   audit-claims:
     inputs:
     - name: worktree_path
@@ -511,6 +512,7 @@ skills:
     - 'verdict = needs_human
 
       %%ORDER_UP%%'
+    write_behavior: always
   resolve-research-review:
     inputs:
     - name: worktree_path
@@ -530,6 +532,8 @@ skills:
       type: integer
     expected_output_patterns:
     - needs_rerun\s*=\s*(true|false)
+    - verdict\s*=\s*(real_fix|already_green|flake_suspected|ci_only_failure)
+    - fixes_applied\s*=\s*\d+
     pattern_examples:
     - 'needs_rerun = true
 
@@ -581,6 +585,8 @@ skills:
       type: integer
     expected_output_patterns:
     - needs_rerun\s*=\s*(true|false)
+    - verdict\s*=\s*(real_fix|already_green|flake_suspected|ci_only_failure)
+    - fixes_applied\s*=\s*\d+
     pattern_examples:
     - 'needs_rerun = true
 

--- a/src/autoskillit/recipes/contracts/research.yaml
+++ b/src/autoskillit/recipes/contracts/research.yaml
@@ -1,0 +1,2535 @@
+generated_at: '2026-05-06T10:12:39.088966+00:00'
+bundled_manifest_version: 0.1.0
+skill_hashes: {}
+skills:
+  scope:
+    inputs:
+    - name: research_question
+      type: string
+      required: true
+      recommended: false
+    outputs:
+    - name: scope_report
+      type: file_path
+    expected_output_patterns:
+    - scope_report\s*=\s*/.+
+    pattern_examples:
+    - 'scope_report = /tmp/scope_report.md
+
+      %%ORDER_UP%%'
+    write_behavior: always
+  plan-experiment:
+    inputs:
+    - name: scope_report_path
+      type: file_path
+      required: true
+      recommended: false
+    - name: revision_guidance
+      type: file_path
+      required: false
+      recommended: false
+    outputs:
+    - name: experiment_plan
+      type: file_path
+    expected_output_patterns:
+    - experiment_plan\s*=\s*/.+
+    pattern_examples:
+    - 'experiment_plan = /tmp/experiment_plan.md
+
+      %%ORDER_UP%%'
+    write_behavior: always
+  review-design:
+    inputs:
+    - name: experiment_plan
+      type: file_path
+      required: true
+      recommended: false
+    outputs:
+    - name: verdict
+      type: string
+    - name: experiment_type
+      type: string
+    - name: evaluation_dashboard
+      type: file_path
+    - name: revision_guidance
+      type: file_path
+    expected_output_patterns:
+    - verdict\s*=\s*(GO|REVISE|STOP)
+    - (?:experiment_type\s*=\s*\S+|verdict\s*=\s*STOP)
+    pattern_examples:
+    - 'verdict = GO
+
+      experiment_type = benchmark
+
+      evaluation_dashboard = /tmp/eval.md
+
+      revision_guidance = /tmp/guidance.md
+
+      %%ORDER_UP%%'
+    - 'verdict = REVISE
+
+      experiment_type = benchmark
+
+      revision_guidance = /tmp/guidance.md
+
+      %%ORDER_UP%%'
+    - 'verdict = STOP
+
+      %%ORDER_UP%%'
+    - 'verdict = GO
+
+      experiment_type = causal_inference
+
+      evaluation_dashboard = /tmp/eval.md
+
+      %%ORDER_UP%%'
+    - 'verdict = GO
+
+      experiment_type = configuration_study
+
+      evaluation_dashboard = /tmp/eval.md
+
+      %%ORDER_UP%%'
+    - 'verdict = GO
+
+      experiment_type = robustness_audit
+
+      evaluation_dashboard = /tmp/eval.md
+
+      %%ORDER_UP%%'
+    - 'verdict = GO
+
+      experiment_type = exploratory
+
+      evaluation_dashboard = /tmp/eval.md
+
+      %%ORDER_UP%%'
+    write_behavior: always
+  plan-visualization:
+    inputs:
+    - name: source_dir
+      type: directory_path
+      required: true
+      recommended: false
+    - name: experiment_plan_path
+      type: file_path
+      required: true
+      recommended: false
+    - name: scope_report_path
+      type: string
+      required: false
+      recommended: false
+    outputs:
+    - name: visualization_plan_path
+      type: file_path
+    - name: report_plan_path
+      type: file_path
+    expected_output_patterns:
+    - visualization_plan_path\s*=\s*/.+
+    - report_plan_path\s*=\s*/.+
+    pattern_examples:
+    - 'visualization_plan_path = /tmp/plan-visualization/visualization-plan.md
+
+      report_plan_path = /tmp/plan-visualization/report-plan.md
+
+      %%ORDER_UP%%'
+    write_behavior: always
+  resolve-design-review:
+    inputs:
+    - name: evaluation_dashboard
+      type: file_path
+      required: true
+      recommended: false
+    - name: experiment_plan
+      type: file_path
+      required: true
+      recommended: false
+    outputs:
+    - name: resolution
+      type: string
+    - name: revision_guidance
+      type: file_path
+    expected_output_patterns:
+    - resolution\s*=\s*(revised|failed)
+    - (?:revision_guidance\s*=\s*/.+|resolution\s*=\s*failed)
+    pattern_examples:
+    - 'resolution = revised
+
+      revision_guidance = /tmp/guidance.md
+
+      %%ORDER_UP%%'
+    - 'resolution = failed
+
+      %%ORDER_UP%%'
+    write_behavior: always
+  stage-data:
+    inputs:
+    - name: experiment_plan
+      type: file_path
+      required: true
+      recommended: false
+    outputs:
+    - name: verdict
+      type: string
+    - name: resource_report
+      type: file_path
+    expected_output_patterns:
+    - verdict\s*=\s*(PASS|WARN|FAIL)
+    - resource_report\s*=\s*/.+
+    pattern_examples:
+    - 'verdict = PASS
+
+      resource_report = /tmp/stage-data/resource_feasibility_2026-04-13_120000.md
+
+      %%ORDER_UP%%'
+    write_behavior: always
+  setup-environment:
+    inputs:
+    - name: worktree_path
+      type: directory_path
+      required: true
+      recommended: false
+    - name: experiment_plan
+      type: file_path
+      required: true
+      recommended: false
+    outputs:
+    - name: env_mode
+      type: string
+    - name: env_report
+      type: file_path
+    - name: verdict
+      type: string
+    expected_output_patterns:
+    - env_mode\s*=\s*(none|docker|micromamba-host|unavailable)
+    - env_report\s*=\s*/.+
+    - verdict\s*=\s*(PASS|WARN|FAIL)
+    pattern_examples:
+    - 'env_mode = none
+
+      env_report = /tmp/setup-environment/env_setup_report.md
+
+      verdict = PASS
+
+      %%ORDER_UP%%'
+    - 'env_mode = docker
+
+      env_report = /tmp/setup-environment/env_setup_report.md
+
+      verdict = PASS
+
+      %%ORDER_UP%%'
+    - 'env_mode = micromamba-host
+
+      env_report = /tmp/setup-environment/env_setup_report.md
+
+      verdict = WARN
+
+      %%ORDER_UP%%'
+    - 'env_mode = unavailable
+
+      env_report = /tmp/setup-environment/env_setup_report.md
+
+      verdict = FAIL
+
+      %%ORDER_UP%%'
+    write_behavior: always
+  make-groups:
+    inputs:
+    - name: source_doc
+      type: file_path
+      required: true
+      recommended: false
+    outputs:
+    - name: groups_path
+      type: file_path
+    - name: manifest_path
+      type: file_path
+    - name: group_files
+      type: file_path_list
+    expected_output_patterns:
+    - groups_path\s*=\s*/.+
+    pattern_examples:
+    - 'groups_path = /tmp/groups.json
+
+      %%ORDER_UP%%'
+  make-plan:
+    inputs:
+    - name: task
+      type: string
+      required: true
+      recommended: false
+    outputs:
+    - name: plan_path
+      type: file_path
+    - name: plan_parts
+      type: file_path_list
+    expected_output_patterns:
+    - plan_path\s*=\s*/.+
+    pattern_examples:
+    - 'plan_path = /tmp/plan.md
+
+      %%ORDER_UP%%'
+    write_behavior: always
+  implement-experiment:
+    inputs:
+    - name: plan_path
+      type: file_path
+      required: true
+      recommended: false
+    outputs:
+    - name: worktree_path
+      type: directory_path
+    - name: branch_name
+      type: string
+    expected_output_patterns:
+    - worktree_path\s*=\s*/.+
+    pattern_examples:
+    - 'worktree_path = /tmp/worktrees/research-20260101-120000
+
+      %%ORDER_UP%%'
+    write_behavior: always
+  troubleshoot-experiment:
+    inputs:
+    - name: worktree_path
+      type: string
+      required: true
+      recommended: false
+    - name: step_name
+      type: string
+      required: true
+      recommended: false
+    outputs:
+    - name: diagnosis_path
+      type: file_path
+    - name: failure_type
+      type: string
+    - name: is_fixable
+      type: string
+    expected_output_patterns:
+    - is_fixable\s*=\s*(true|false)
+    pattern_examples:
+    - 'diagnosis_path = /tmp/diagnosis.md
+
+      failure_type = stale_timeout
+
+      is_fixable = true
+
+      %%ORDER_UP%%'
+    write_behavior: always
+  run-experiment:
+    inputs:
+    - name: worktree_path
+      type: directory_path
+      required: true
+      recommended: false
+    outputs:
+    - name: results_path
+      type: file_path
+    expected_output_patterns:
+    - results_path\s*=\s*/.+
+    pattern_examples:
+    - 'results_path = /tmp/run-experiment/results.md
+
+      %%ORDER_UP%%'
+    write_behavior: always
+  generate-report:
+    inputs:
+    - name: worktree_path
+      type: directory_path
+      required: true
+      recommended: false
+    - name: results_path
+      type: file_path
+      required: true
+      recommended: false
+    outputs:
+    - name: report_path
+      type: file_path
+    expected_output_patterns:
+    - report_path\s*=\s*/.+
+    pattern_examples:
+    - 'report_path = /tmp/research/report.md
+
+      %%ORDER_UP%%'
+    write_behavior: always
+  resolve-failures:
+    inputs:
+    - name: worktree_path
+      type: directory_path
+      required: true
+      recommended: false
+    - name: plan_path
+      type: file_path
+      required: true
+      recommended: false
+    - name: base_branch
+      type: string
+      required: true
+      recommended: false
+    - name: diagnosis_path
+      type: file_path
+      required: false
+      recommended: false
+    outputs:
+    - name: verdict
+      type: string
+    - name: fixes_applied
+      type: integer
+    expected_output_patterns: []
+    pattern_examples: []
+    write_behavior: conditional
+    write_expected_when:
+    - verdict\s*=\s*real_fix
+  prepare-research-pr:
+    inputs:
+    - name: report_path
+      type: file_path
+      required: true
+      recommended: false
+    - name: experiment_plan_path
+      type: file_path
+      required: true
+      recommended: false
+    - name: worktree_path
+      type: directory_path
+      required: true
+      recommended: false
+    - name: base_branch
+      type: string
+      required: true
+      recommended: false
+    outputs:
+    - name: prep_path
+      type: file_path
+    - name: selected_lenses
+      type: string
+    - name: lens_context_paths
+      type: string
+    expected_output_patterns:
+    - prep_path\s*=\s*/.+
+    - selected_lenses\s*=\s*\S+
+    - lens_context_paths\s*=\s*/.+
+    pattern_examples:
+    - 'prep_path = /abs/path/pr_prep_2026-04-07_101349.md
+
+      selected_lenses = fair-comparison,estimand-clarity
+
+      lens_context_paths = /abs/ctx1.md,/abs/ctx2.md
+
+      %%ORDER_UP%%'
+    write_behavior: always
+  compose-research-pr:
+    inputs:
+    - name: prep_path
+      type: file_path
+      required: true
+      recommended: false
+    - name: all_diagram_paths
+      type: string
+      required: true
+      recommended: false
+    - name: worktree_path
+      type: directory_path
+      required: true
+      recommended: false
+    - name: base_branch
+      type: string
+      required: true
+      recommended: false
+    - name: closing_issue
+      type: string
+      required: false
+      recommended: false
+    outputs:
+    - name: pr_url
+      type: string
+    expected_output_patterns:
+    - pr_url\s*=\s*(https://github\.com/.*/pull/\d+)?
+    pattern_examples:
+    - 'pr_url = https://github.com/owner/repo/pull/42
+
+      %%ORDER_UP%%'
+    - "pr_url = \n%%ORDER_UP%%"
+    write_behavior: always
+  review-research-pr:
+    inputs:
+    - name: worktree_path
+      type: directory_path
+      required: true
+      recommended: false
+    - name: base_branch
+      type: string
+      required: true
+      recommended: false
+    - name: pr_url
+      type: string
+      required: true
+      recommended: false
+    outputs:
+    - name: verdict
+      type: string
+    expected_output_patterns:
+    - verdict\s*=\s*(approved|changes_requested|needs_human)
+    pattern_examples:
+    - 'verdict = approved
+
+      %%ORDER_UP%%'
+    - 'verdict = changes_requested
+
+      %%ORDER_UP%%'
+    - 'verdict = needs_human
+
+      %%ORDER_UP%%'
+  audit-claims:
+    inputs:
+    - name: worktree_path
+      type: directory_path
+      required: true
+      recommended: false
+    - name: base_branch
+      type: string
+      required: true
+      recommended: false
+    - name: pr_url
+      type: string
+      required: true
+      recommended: false
+    outputs:
+    - name: verdict
+      type: string
+    expected_output_patterns:
+    - verdict\s*=\s*(approved|changes_requested|needs_human)
+    pattern_examples:
+    - 'verdict = approved
+
+      %%ORDER_UP%%'
+    - 'verdict = changes_requested
+
+      %%ORDER_UP%%'
+    - 'verdict = needs_human
+
+      %%ORDER_UP%%'
+  resolve-research-review:
+    inputs:
+    - name: worktree_path
+      type: directory_path
+      required: true
+      recommended: false
+    - name: base_branch
+      type: string
+      required: true
+      recommended: false
+    outputs:
+    - name: needs_rerun
+      type: string
+    - name: verdict
+      type: string
+    - name: fixes_applied
+      type: integer
+    expected_output_patterns:
+    - needs_rerun\s*=\s*(true|false)
+    pattern_examples:
+    - 'needs_rerun = true
+
+      verdict = real_fix
+
+      fixes_applied = 2
+
+      %%ORDER_UP%%'
+    - 'needs_rerun = false
+
+      verdict = already_green
+
+      fixes_applied = 0
+
+      %%ORDER_UP%%'
+    - 'needs_rerun = true
+
+      verdict = flake_suspected
+
+      fixes_applied = 0
+
+      %%ORDER_UP%%'
+    - 'needs_rerun = false
+
+      verdict = ci_only_failure
+
+      fixes_applied = 0
+
+      %%ORDER_UP%%'
+    write_behavior: conditional
+    write_expected_when:
+    - verdict\s*=\s*real_fix
+  resolve-claims-review:
+    inputs:
+    - name: worktree_path
+      type: directory_path
+      required: true
+      recommended: false
+    - name: base_branch
+      type: string
+      required: true
+      recommended: false
+    outputs:
+    - name: needs_rerun
+      type: string
+    - name: verdict
+      type: string
+    - name: fixes_applied
+      type: integer
+    expected_output_patterns:
+    - needs_rerun\s*=\s*(true|false)
+    pattern_examples:
+    - 'needs_rerun = true
+
+      verdict = real_fix
+
+      fixes_applied = 2
+
+      %%ORDER_UP%%'
+    - 'needs_rerun = false
+
+      verdict = already_green
+
+      fixes_applied = 0
+
+      %%ORDER_UP%%'
+    - 'needs_rerun = true
+
+      verdict = flake_suspected
+
+      fixes_applied = 0
+
+      %%ORDER_UP%%'
+    - 'needs_rerun = false
+
+      verdict = ci_only_failure
+
+      fixes_applied = 0
+
+      %%ORDER_UP%%'
+    write_behavior: conditional
+    write_expected_when:
+    - verdict\s*=\s*real_fix
+  bundle-local-report:
+    inputs:
+    - name: research_dir
+      type: directory_path
+      required: true
+      recommended: false
+    - name: report_path
+      type: file_path
+      required: true
+      recommended: false
+    - name: all_diagram_paths
+      type: string
+      required: false
+      recommended: false
+    - name: visualization_plan_path
+      type: file_path
+      required: false
+      recommended: false
+    outputs:
+    - name: html_path
+      type: file_path
+    expected_output_patterns:
+    - html_path\s*=\s*\S+
+    pattern_examples:
+    - 'html_path = /tmp/research/report.html
+
+      %%ORDER_UP%%'
+    write_behavior: conditional
+    write_expected_when:
+    - html_path\s*=\s*\S+
+dataflow:
+- step: scope
+  available:
+  - audit_claims
+  - base_branch
+  - issue_url
+  - output_mode
+  - review_design
+  - review_pr
+  - source_dir
+  - task
+  required:
+  - research_question
+  produced:
+  - scope_report
+- step: plan_experiment
+  available:
+  - audit_claims
+  - base_branch
+  - issue_url
+  - output_mode
+  - review_design
+  - review_pr
+  - scope_report
+  - source_dir
+  - task
+  required:
+  - scope_report_path
+  produced:
+  - experiment_plan
+- step: review_design
+  available:
+  - audit_claims
+  - base_branch
+  - experiment_plan
+  - issue_url
+  - output_mode
+  - review_design
+  - review_pr
+  - scope_report
+  - source_dir
+  - task
+  required: []
+  produced:
+  - verdict
+  - experiment_type
+  - evaluation_dashboard
+  - revision_guidance
+- step: plan_visualization
+  available:
+  - audit_claims
+  - base_branch
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_type
+  - issue_url
+  - output_mode
+  - review_design
+  - review_pr
+  - revision_guidance
+  - scope_report
+  - source_dir
+  - task
+  - verdict
+  required:
+  - experiment_plan_path
+  produced:
+  - visualization_plan_path
+  - report_plan_path
+- step: revise_design
+  available:
+  - audit_claims
+  - base_branch
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_type
+  - issue_url
+  - output_mode
+  - report_plan_path
+  - review_design
+  - review_pr
+  - revision_guidance
+  - scope_report
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  required: []
+  produced: []
+- step: resolve_design_review
+  available:
+  - audit_claims
+  - base_branch
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_type
+  - issue_url
+  - output_mode
+  - report_plan_path
+  - review_design
+  - review_pr
+  - revision_guidance
+  - scope_report
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  required: []
+  produced:
+  - revision_guidance
+- step: design_rejected
+  available:
+  - audit_claims
+  - base_branch
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_type
+  - issue_url
+  - output_mode
+  - report_plan_path
+  - review_design
+  - review_pr
+  - revision_guidance
+  - scope_report
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  required: []
+  produced: []
+- step: create_worktree
+  available:
+  - audit_claims
+  - base_branch
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_type
+  - issue_url
+  - output_mode
+  - report_plan_path
+  - review_design
+  - review_pr
+  - revision_guidance
+  - scope_report
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  required: []
+  produced:
+  - worktree_path
+  - research_dir
+- step: stage_data
+  available:
+  - audit_claims
+  - base_branch
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_type
+  - issue_url
+  - output_mode
+  - report_plan_path
+  - research_dir
+  - review_design
+  - review_pr
+  - revision_guidance
+  - scope_report
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced:
+  - verdict
+  - resource_report
+- step: setup_environment
+  available:
+  - audit_claims
+  - base_branch
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_type
+  - issue_url
+  - output_mode
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_pr
+  - revision_guidance
+  - scope_report
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced:
+  - verdict
+- step: decompose_phases
+  available:
+  - audit_claims
+  - base_branch
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_type
+  - issue_url
+  - output_mode
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_pr
+  - revision_guidance
+  - scope_report
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required:
+  - source_doc
+  produced:
+  - group_files
+- step: plan_phase
+  available:
+  - audit_claims
+  - base_branch
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_type
+  - group_files
+  - issue_url
+  - output_mode
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_pr
+  - revision_guidance
+  - scope_report
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required:
+  - task
+  produced:
+  - phase_plan_path
+- step: implement_phase
+  available:
+  - audit_claims
+  - base_branch
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_type
+  - group_files
+  - issue_url
+  - output_mode
+  - phase_plan_path
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_pr
+  - revision_guidance
+  - scope_report
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required:
+  - plan_path
+  produced:
+  - worktree_path
+- step: troubleshoot_implement_failure
+  available:
+  - audit_claims
+  - base_branch
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_type
+  - group_files
+  - issue_url
+  - output_mode
+  - phase_plan_path
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_pr
+  - revision_guidance
+  - scope_report
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced:
+  - is_fixable
+  positional_args: 1
+- step: route_implement_failure
+  available:
+  - audit_claims
+  - base_branch
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_type
+  - group_files
+  - is_fixable
+  - issue_url
+  - output_mode
+  - phase_plan_path
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_pr
+  - revision_guidance
+  - scope_report
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced: []
+- step: next_phase_or_experiment
+  available:
+  - audit_claims
+  - base_branch
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_type
+  - group_files
+  - is_fixable
+  - issue_url
+  - output_mode
+  - phase_plan_path
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_pr
+  - revision_guidance
+  - scope_report
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced: []
+- step: run_experiment
+  available:
+  - audit_claims
+  - base_branch
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_type
+  - group_files
+  - is_fixable
+  - issue_url
+  - output_mode
+  - phase_plan_path
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_pr
+  - revision_guidance
+  - scope_report
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced:
+  - experiment_results
+- step: troubleshoot_run_failure
+  available:
+  - audit_claims
+  - base_branch
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - group_files
+  - is_fixable
+  - issue_url
+  - output_mode
+  - phase_plan_path
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_pr
+  - revision_guidance
+  - scope_report
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced:
+  - run_is_fixable
+  positional_args: 1
+- step: route_run_failure
+  available:
+  - audit_claims
+  - base_branch
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - group_files
+  - is_fixable
+  - issue_url
+  - output_mode
+  - phase_plan_path
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_pr
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced: []
+- step: adjust_experiment
+  available:
+  - audit_claims
+  - base_branch
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - group_files
+  - is_fixable
+  - issue_url
+  - output_mode
+  - phase_plan_path
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_pr
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced:
+  - experiment_results
+  positional_args: 1
+- step: ensure_results
+  available:
+  - audit_claims
+  - base_branch
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - group_files
+  - is_fixable
+  - issue_url
+  - output_mode
+  - phase_plan_path
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_pr
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced:
+  - experiment_results
+- step: generate_report
+  available:
+  - audit_claims
+  - base_branch
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - group_files
+  - is_fixable
+  - issue_url
+  - output_mode
+  - phase_plan_path
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_pr
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced:
+  - report_path
+  positional_args: 2
+- step: generate_report_inconclusive
+  available:
+  - audit_claims
+  - base_branch
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - group_files
+  - is_fixable
+  - issue_url
+  - output_mode
+  - phase_plan_path
+  - report_path
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_pr
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced:
+  - report_path
+  positional_args: 3
+- step: test
+  available:
+  - audit_claims
+  - base_branch
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - group_files
+  - is_fixable
+  - issue_url
+  - output_mode
+  - phase_plan_path
+  - report_path
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_pr
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced: []
+- step: fix_tests
+  available:
+  - audit_claims
+  - base_branch
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - group_files
+  - is_fixable
+  - issue_url
+  - output_mode
+  - phase_plan_path
+  - report_path
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_pr
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required:
+  - plan_path
+  produced:
+  - verdict
+  - fixes_applied
+- step: retest
+  available:
+  - audit_claims
+  - base_branch
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - fixes_applied
+  - group_files
+  - is_fixable
+  - issue_url
+  - output_mode
+  - phase_plan_path
+  - report_path
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_pr
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced: []
+- step: push_branch
+  available:
+  - audit_claims
+  - base_branch
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - fixes_applied
+  - group_files
+  - is_fixable
+  - issue_url
+  - output_mode
+  - phase_plan_path
+  - report_path
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_pr
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced: []
+- step: prepare_research_pr
+  available:
+  - audit_claims
+  - base_branch
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - fixes_applied
+  - group_files
+  - is_fixable
+  - issue_url
+  - output_mode
+  - phase_plan_path
+  - report_path
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_pr
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required:
+  - experiment_plan_path
+  produced:
+  - prep_path
+  - selected_lenses
+  - lens_context_paths
+- step: run_experiment_lenses
+  available:
+  - audit_claims
+  - base_branch
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - fixes_applied
+  - group_files
+  - is_fixable
+  - issue_url
+  - lens_context_paths
+  - output_mode
+  - phase_plan_path
+  - prep_path
+  - report_path
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_pr
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - selected_lenses
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced: []
+- step: stage_bundle
+  available:
+  - audit_claims
+  - base_branch
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - fixes_applied
+  - group_files
+  - is_fixable
+  - issue_url
+  - lens_context_paths
+  - output_mode
+  - phase_plan_path
+  - prep_path
+  - report_path
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_pr
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - selected_lenses
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced: []
+- step: route_pr_or_local
+  available:
+  - audit_claims
+  - base_branch
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - fixes_applied
+  - group_files
+  - is_fixable
+  - issue_url
+  - lens_context_paths
+  - output_mode
+  - phase_plan_path
+  - prep_path
+  - report_path
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_pr
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - selected_lenses
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced: []
+- step: compose_research_pr
+  available:
+  - audit_claims
+  - base_branch
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - fixes_applied
+  - group_files
+  - is_fixable
+  - issue_url
+  - lens_context_paths
+  - output_mode
+  - phase_plan_path
+  - prep_path
+  - report_path
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_pr
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - selected_lenses
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced:
+  - pr_url
+  positional_args: 1
+- step: guard_pr_url
+  available:
+  - audit_claims
+  - base_branch
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - fixes_applied
+  - group_files
+  - is_fixable
+  - issue_url
+  - lens_context_paths
+  - output_mode
+  - phase_plan_path
+  - pr_url
+  - prep_path
+  - report_path
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_pr
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - selected_lenses
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced: []
+- step: review_research_pr
+  available:
+  - audit_claims
+  - base_branch
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - fixes_applied
+  - group_files
+  - is_fixable
+  - issue_url
+  - lens_context_paths
+  - output_mode
+  - phase_plan_path
+  - pr_url
+  - prep_path
+  - report_path
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_pr
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - selected_lenses
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced:
+  - review_verdict
+- step: audit_claims
+  available:
+  - audit_claims
+  - base_branch
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - fixes_applied
+  - group_files
+  - is_fixable
+  - issue_url
+  - lens_context_paths
+  - output_mode
+  - phase_plan_path
+  - pr_url
+  - prep_path
+  - report_path
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_pr
+  - review_verdict
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - selected_lenses
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced:
+  - audit_verdict
+- step: route_review_resolve
+  available:
+  - audit_claims
+  - audit_verdict
+  - base_branch
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - fixes_applied
+  - group_files
+  - is_fixable
+  - issue_url
+  - lens_context_paths
+  - output_mode
+  - phase_plan_path
+  - pr_url
+  - prep_path
+  - report_path
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_pr
+  - review_verdict
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - selected_lenses
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced: []
+- step: resolve_research_review
+  available:
+  - audit_claims
+  - audit_verdict
+  - base_branch
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - fixes_applied
+  - group_files
+  - is_fixable
+  - issue_url
+  - lens_context_paths
+  - output_mode
+  - phase_plan_path
+  - pr_url
+  - prep_path
+  - report_path
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_pr
+  - review_verdict
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - selected_lenses
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced:
+  - review_needs_rerun
+- step: route_claims_resolve
+  available:
+  - audit_claims
+  - audit_verdict
+  - base_branch
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - fixes_applied
+  - group_files
+  - is_fixable
+  - issue_url
+  - lens_context_paths
+  - output_mode
+  - phase_plan_path
+  - pr_url
+  - prep_path
+  - report_path
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_needs_rerun
+  - review_pr
+  - review_verdict
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - selected_lenses
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced: []
+- step: resolve_claims_review
+  available:
+  - audit_claims
+  - audit_verdict
+  - base_branch
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - fixes_applied
+  - group_files
+  - is_fixable
+  - issue_url
+  - lens_context_paths
+  - output_mode
+  - phase_plan_path
+  - pr_url
+  - prep_path
+  - report_path
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_needs_rerun
+  - review_pr
+  - review_verdict
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - selected_lenses
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced:
+  - claims_needs_rerun
+- step: merge_escalations
+  available:
+  - audit_claims
+  - audit_verdict
+  - base_branch
+  - claims_needs_rerun
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - fixes_applied
+  - group_files
+  - is_fixable
+  - issue_url
+  - lens_context_paths
+  - output_mode
+  - phase_plan_path
+  - pr_url
+  - prep_path
+  - report_path
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_needs_rerun
+  - review_pr
+  - review_verdict
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - selected_lenses
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced: []
+- step: re_run_experiment
+  available:
+  - audit_claims
+  - audit_verdict
+  - base_branch
+  - claims_needs_rerun
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - fixes_applied
+  - group_files
+  - is_fixable
+  - issue_url
+  - lens_context_paths
+  - output_mode
+  - phase_plan_path
+  - pr_url
+  - prep_path
+  - report_path
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_needs_rerun
+  - review_pr
+  - review_verdict
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - selected_lenses
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced:
+  - experiment_results
+  positional_args: 1
+- step: re_generate_report
+  available:
+  - audit_claims
+  - audit_verdict
+  - base_branch
+  - claims_needs_rerun
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - fixes_applied
+  - group_files
+  - is_fixable
+  - issue_url
+  - lens_context_paths
+  - output_mode
+  - phase_plan_path
+  - pr_url
+  - prep_path
+  - report_path
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_needs_rerun
+  - review_pr
+  - review_verdict
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - selected_lenses
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced:
+  - report_path
+  positional_args: 2
+- step: re_stage_bundle
+  available:
+  - audit_claims
+  - audit_verdict
+  - base_branch
+  - claims_needs_rerun
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - fixes_applied
+  - group_files
+  - is_fixable
+  - issue_url
+  - lens_context_paths
+  - output_mode
+  - phase_plan_path
+  - pr_url
+  - prep_path
+  - report_path
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_needs_rerun
+  - review_pr
+  - review_verdict
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - selected_lenses
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced: []
+- step: re_test
+  available:
+  - audit_claims
+  - audit_verdict
+  - base_branch
+  - claims_needs_rerun
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - fixes_applied
+  - group_files
+  - is_fixable
+  - issue_url
+  - lens_context_paths
+  - output_mode
+  - phase_plan_path
+  - pr_url
+  - prep_path
+  - report_path
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_needs_rerun
+  - review_pr
+  - review_verdict
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - selected_lenses
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced: []
+- step: re_push_research
+  available:
+  - audit_claims
+  - audit_verdict
+  - base_branch
+  - claims_needs_rerun
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - fixes_applied
+  - group_files
+  - is_fixable
+  - issue_url
+  - lens_context_paths
+  - output_mode
+  - phase_plan_path
+  - pr_url
+  - prep_path
+  - report_path
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_needs_rerun
+  - review_pr
+  - review_verdict
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - selected_lenses
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced: []
+- step: finalize_bundle
+  available:
+  - audit_claims
+  - audit_verdict
+  - base_branch
+  - claims_needs_rerun
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - fixes_applied
+  - group_files
+  - is_fixable
+  - issue_url
+  - lens_context_paths
+  - output_mode
+  - phase_plan_path
+  - pr_url
+  - prep_path
+  - report_path
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_needs_rerun
+  - review_pr
+  - review_verdict
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - selected_lenses
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced:
+  - report_path_after_finalize
+- step: finalize_bundle_render
+  available:
+  - audit_claims
+  - audit_verdict
+  - base_branch
+  - claims_needs_rerun
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - fixes_applied
+  - group_files
+  - is_fixable
+  - issue_url
+  - lens_context_paths
+  - output_mode
+  - phase_plan_path
+  - pr_url
+  - prep_path
+  - report_path
+  - report_path_after_finalize
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_needs_rerun
+  - review_pr
+  - review_verdict
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - selected_lenses
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required:
+  - report_path
+  produced:
+  - html_path
+- step: route_archive_or_export
+  available:
+  - audit_claims
+  - audit_verdict
+  - base_branch
+  - claims_needs_rerun
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - fixes_applied
+  - group_files
+  - html_path
+  - is_fixable
+  - issue_url
+  - lens_context_paths
+  - output_mode
+  - phase_plan_path
+  - pr_url
+  - prep_path
+  - report_path
+  - report_path_after_finalize
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_needs_rerun
+  - review_pr
+  - review_verdict
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - selected_lenses
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced: []
+- step: export_local_bundle
+  available:
+  - audit_claims
+  - audit_verdict
+  - base_branch
+  - claims_needs_rerun
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - fixes_applied
+  - group_files
+  - html_path
+  - is_fixable
+  - issue_url
+  - lens_context_paths
+  - output_mode
+  - phase_plan_path
+  - pr_url
+  - prep_path
+  - report_path
+  - report_path_after_finalize
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_needs_rerun
+  - review_pr
+  - review_verdict
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - selected_lenses
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced:
+  - local_bundle_path
+- step: begin_archival
+  available:
+  - audit_claims
+  - audit_verdict
+  - base_branch
+  - claims_needs_rerun
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - fixes_applied
+  - group_files
+  - html_path
+  - is_fixable
+  - issue_url
+  - lens_context_paths
+  - local_bundle_path
+  - output_mode
+  - phase_plan_path
+  - pr_url
+  - prep_path
+  - report_path
+  - report_path_after_finalize
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_needs_rerun
+  - review_pr
+  - review_verdict
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - selected_lenses
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced: []
+- step: capture_experiment_branch
+  available:
+  - audit_claims
+  - audit_verdict
+  - base_branch
+  - claims_needs_rerun
+  - evaluation_dashboard
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - fixes_applied
+  - group_files
+  - html_path
+  - is_fixable
+  - issue_url
+  - lens_context_paths
+  - local_bundle_path
+  - output_mode
+  - phase_plan_path
+  - pr_url
+  - prep_path
+  - report_path
+  - report_path_after_finalize
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_needs_rerun
+  - review_pr
+  - review_verdict
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - selected_lenses
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced:
+  - experiment_branch
+- step: create_artifact_branch
+  available:
+  - audit_claims
+  - audit_verdict
+  - base_branch
+  - claims_needs_rerun
+  - evaluation_dashboard
+  - experiment_branch
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - fixes_applied
+  - group_files
+  - html_path
+  - is_fixable
+  - issue_url
+  - lens_context_paths
+  - local_bundle_path
+  - output_mode
+  - phase_plan_path
+  - pr_url
+  - prep_path
+  - report_path
+  - report_path_after_finalize
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_needs_rerun
+  - review_pr
+  - review_verdict
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - selected_lenses
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced:
+  - artifact_branch
+- step: open_artifact_pr
+  available:
+  - artifact_branch
+  - audit_claims
+  - audit_verdict
+  - base_branch
+  - claims_needs_rerun
+  - evaluation_dashboard
+  - experiment_branch
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - fixes_applied
+  - group_files
+  - html_path
+  - is_fixable
+  - issue_url
+  - lens_context_paths
+  - local_bundle_path
+  - output_mode
+  - phase_plan_path
+  - pr_url
+  - prep_path
+  - report_path
+  - report_path_after_finalize
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_needs_rerun
+  - review_pr
+  - review_verdict
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - selected_lenses
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced:
+  - artifact_pr_url
+- step: tag_experiment_branch
+  available:
+  - artifact_branch
+  - artifact_pr_url
+  - audit_claims
+  - audit_verdict
+  - base_branch
+  - claims_needs_rerun
+  - evaluation_dashboard
+  - experiment_branch
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - fixes_applied
+  - group_files
+  - html_path
+  - is_fixable
+  - issue_url
+  - lens_context_paths
+  - local_bundle_path
+  - output_mode
+  - phase_plan_path
+  - pr_url
+  - prep_path
+  - report_path
+  - report_path_after_finalize
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_needs_rerun
+  - review_pr
+  - review_verdict
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - selected_lenses
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced:
+  - archive_tag
+- step: close_experiment_pr
+  available:
+  - archive_tag
+  - artifact_branch
+  - artifact_pr_url
+  - audit_claims
+  - audit_verdict
+  - base_branch
+  - claims_needs_rerun
+  - evaluation_dashboard
+  - experiment_branch
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - fixes_applied
+  - group_files
+  - html_path
+  - is_fixable
+  - issue_url
+  - lens_context_paths
+  - local_bundle_path
+  - output_mode
+  - phase_plan_path
+  - pr_url
+  - prep_path
+  - report_path
+  - report_path_after_finalize
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_needs_rerun
+  - review_pr
+  - review_verdict
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - selected_lenses
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced: []
+- step: patch_token_summary
+  available:
+  - archive_tag
+  - artifact_branch
+  - artifact_pr_url
+  - audit_claims
+  - audit_verdict
+  - base_branch
+  - claims_needs_rerun
+  - evaluation_dashboard
+  - experiment_branch
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - fixes_applied
+  - group_files
+  - html_path
+  - is_fixable
+  - issue_url
+  - lens_context_paths
+  - local_bundle_path
+  - output_mode
+  - phase_plan_path
+  - pr_url
+  - prep_path
+  - report_path
+  - report_path_after_finalize
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_needs_rerun
+  - review_pr
+  - review_verdict
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - selected_lenses
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced: []
+- step: research_complete
+  available:
+  - archive_tag
+  - artifact_branch
+  - artifact_pr_url
+  - audit_claims
+  - audit_verdict
+  - base_branch
+  - claims_needs_rerun
+  - evaluation_dashboard
+  - experiment_branch
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - fixes_applied
+  - group_files
+  - html_path
+  - is_fixable
+  - issue_url
+  - lens_context_paths
+  - local_bundle_path
+  - output_mode
+  - phase_plan_path
+  - pr_url
+  - prep_path
+  - report_path
+  - report_path_after_finalize
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_needs_rerun
+  - review_pr
+  - review_verdict
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - selected_lenses
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced: []
+- step: escalate_stop
+  available:
+  - archive_tag
+  - artifact_branch
+  - artifact_pr_url
+  - audit_claims
+  - audit_verdict
+  - base_branch
+  - claims_needs_rerun
+  - evaluation_dashboard
+  - experiment_branch
+  - experiment_plan
+  - experiment_results
+  - experiment_type
+  - fixes_applied
+  - group_files
+  - html_path
+  - is_fixable
+  - issue_url
+  - lens_context_paths
+  - local_bundle_path
+  - output_mode
+  - phase_plan_path
+  - pr_url
+  - prep_path
+  - report_path
+  - report_path_after_finalize
+  - report_plan_path
+  - research_dir
+  - resource_report
+  - review_design
+  - review_needs_rerun
+  - review_pr
+  - review_verdict
+  - revision_guidance
+  - run_is_fixable
+  - scope_report
+  - selected_lenses
+  - source_dir
+  - task
+  - verdict
+  - visualization_plan_path
+  - worktree_path
+  required: []
+  produced: []

--- a/src/autoskillit/recipes/contracts/research.yaml
+++ b/src/autoskillit/recipes/contracts/research.yaml
@@ -406,7 +406,7 @@ skills:
     - name: selected_lenses
       type: string
     - name: lens_context_paths
-      type: string
+      type: file_path_list
     expected_output_patterns:
     - prep_path\s*=\s*/.+
     - selected_lenses\s*=\s*\S+
@@ -427,7 +427,7 @@ skills:
       required: true
       recommended: false
     - name: all_diagram_paths
-      type: string
+      type: file_path_list
       required: true
       recommended: false
     - name: worktree_path
@@ -532,7 +532,7 @@ skills:
       type: integer
     expected_output_patterns:
     - needs_rerun\s*=\s*(true|false)
-    - verdict\s*=\s*(real_fix|already_green|flake_suspected|ci_only_failure)
+    - verdict\s*=\s*(real_fix|already_green)
     - fixes_applied\s*=\s*\d+
     pattern_examples:
     - 'needs_rerun = true
@@ -545,20 +545,6 @@ skills:
     - 'needs_rerun = false
 
       verdict = already_green
-
-      fixes_applied = 0
-
-      %%ORDER_UP%%'
-    - 'needs_rerun = true
-
-      verdict = flake_suspected
-
-      fixes_applied = 0
-
-      %%ORDER_UP%%'
-    - 'needs_rerun = false
-
-      verdict = ci_only_failure
 
       fixes_applied = 0
 
@@ -585,7 +571,7 @@ skills:
       type: integer
     expected_output_patterns:
     - needs_rerun\s*=\s*(true|false)
-    - verdict\s*=\s*(real_fix|already_green|flake_suspected|ci_only_failure)
+    - verdict\s*=\s*(real_fix|already_green)
     - fixes_applied\s*=\s*\d+
     pattern_examples:
     - 'needs_rerun = true
@@ -598,20 +584,6 @@ skills:
     - 'needs_rerun = false
 
       verdict = already_green
-
-      fixes_applied = 0
-
-      %%ORDER_UP%%'
-    - 'needs_rerun = true
-
-      verdict = flake_suspected
-
-      fixes_applied = 0
-
-      %%ORDER_UP%%'
-    - 'needs_rerun = false
-
-      verdict = ci_only_failure
 
       fixes_applied = 0
 

--- a/tests/recipe/test_contracts.py
+++ b/tests/recipe/test_contracts.py
@@ -871,7 +871,10 @@ def test_research_recipe_card_generated_at_is_iso8601() -> None:
     assert isinstance(generated_at, str) and generated_at, (
         "generated_at must be a non-empty string"
     )
-    datetime.datetime.fromisoformat(generated_at)
+    try:
+        datetime.datetime.fromisoformat(generated_at)
+    except ValueError as exc:
+        pytest.fail(f"generated_at is not a valid ISO-8601 datetime: {generated_at!r}: {exc}")
 
 
 def test_research_recipe_card_structure() -> None:

--- a/tests/recipe/test_contracts.py
+++ b/tests/recipe/test_contracts.py
@@ -852,3 +852,77 @@ def test_wait_for_ci_conclusion_allowed_values() -> None:
     conclusion = manifest["tool_output_contracts"]["wait_for_ci"]["fields"]["conclusion"]
     values = set(conclusion["allowed_values"])
     assert {"success", "failure", "cancelled", "timed_out", "no_runs", "error"}.issubset(values)
+
+
+# ---------------------------------------------------------------------------
+# Research recipe contract card tests
+# ---------------------------------------------------------------------------
+
+
+def test_load_research_recipe_card() -> None:
+    """load_recipe_card('research', ...) returns non-None after card generation."""
+    from autoskillit.recipe.io import builtin_recipes_dir
+
+    card = load_recipe_card("research", builtin_recipes_dir())
+    assert card is not None
+    assert isinstance(card, dict)
+
+
+def test_research_recipe_card_structure() -> None:
+    """Research contract card contains all required top-level keys."""
+    from autoskillit.recipe.io import builtin_recipes_dir
+
+    card = load_recipe_card("research", builtin_recipes_dir())
+    assert card is not None
+    for key in ("generated_at", "bundled_manifest_version", "skill_hashes", "skills", "dataflow"):
+        assert key in card, f"Missing key: {key}"
+    assert card["bundled_manifest_version"] == "0.1.0"
+    assert card["skill_hashes"] == {}
+
+
+def test_research_recipe_card_contains_research_skills() -> None:
+    """Research card captures contracts for statically-resolvable skills."""
+    from autoskillit.recipe.io import builtin_recipes_dir
+
+    card = load_recipe_card("research", builtin_recipes_dir())
+    assert card is not None
+    skills = card["skills"]
+    expected_subset = {
+        "scope",
+        "plan-experiment",
+        "review-design",
+        "run-experiment",
+        "generate-report",
+        "resolve-failures",
+        "prepare-research-pr",
+        "compose-research-pr",
+        "implement-experiment",
+        "make-groups",
+        "make-plan",
+        "bundle-local-report",
+    }
+    for skill_name in expected_subset:
+        assert skill_name in skills, f"Missing skill: {skill_name}"
+
+
+def test_research_recipe_card_dataflow() -> None:
+    """Research card dataflow section is populated and has expected steps."""
+    from autoskillit.recipe.io import builtin_recipes_dir
+
+    card = load_recipe_card("research", builtin_recipes_dir())
+    assert card is not None
+    dataflow = card["dataflow"]
+    assert len(dataflow) > 0
+    step_names = [entry["step"] for entry in dataflow]
+    assert "scope" in step_names
+    assert "plan_experiment" in step_names
+
+
+def test_research_contract_card_not_stale() -> None:
+    """Freshly generated card has no staleness warnings."""
+    from autoskillit.recipe.io import builtin_recipes_dir
+
+    contract = load_recipe_card("research", builtin_recipes_dir())
+    assert contract is not None
+    stale = check_contract_staleness(contract)
+    assert stale == []

--- a/tests/recipe/test_contracts.py
+++ b/tests/recipe/test_contracts.py
@@ -859,13 +859,19 @@ def test_wait_for_ci_conclusion_allowed_values() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_load_research_recipe_card() -> None:
-    """load_recipe_card('research', ...) returns non-None after card generation."""
+def test_research_recipe_card_generated_at_is_iso8601() -> None:
+    """research.yaml card's generated_at is a parseable ISO-8601 timestamp."""
+    import datetime
+
     from autoskillit.recipe.io import builtin_recipes_dir
 
     card = load_recipe_card("research", builtin_recipes_dir())
     assert card is not None
-    assert isinstance(card, dict)
+    generated_at = card.get("generated_at", "")
+    assert isinstance(generated_at, str) and generated_at, (
+        "generated_at must be a non-empty string"
+    )
+    datetime.datetime.fromisoformat(generated_at)
 
 
 def test_research_recipe_card_structure() -> None:
@@ -901,8 +907,20 @@ def test_research_recipe_card_contains_research_skills() -> None:
         "make-plan",
         "bundle-local-report",
     }
+    required_fields = {"inputs", "outputs", "expected_output_patterns", "write_behavior"}
     for skill_name in expected_subset:
         assert skill_name in skills, f"Missing skill: {skill_name}"
+        entry = skills[skill_name]
+        for field in required_fields:
+            assert field in entry, f"{skill_name} missing '{field}'"
+        assert isinstance(entry["inputs"], list), f"{skill_name} 'inputs' must be a list"
+        assert isinstance(entry["outputs"], list), f"{skill_name} 'outputs' must be a list"
+        assert isinstance(entry["expected_output_patterns"], list), (
+            f"{skill_name} 'expected_output_patterns' must be a list"
+        )
+        assert entry["write_behavior"] in {"always", "conditional", "never"}, (
+            f"{skill_name} 'write_behavior' has unexpected value: {entry['write_behavior']!r}"
+        )
 
 
 def test_research_recipe_card_dataflow() -> None:
@@ -912,10 +930,14 @@ def test_research_recipe_card_dataflow() -> None:
     card = load_recipe_card("research", builtin_recipes_dir())
     assert card is not None
     dataflow = card["dataflow"]
-    assert len(dataflow) > 0
     step_names = [entry["step"] for entry in dataflow]
     assert "scope" in step_names
     assert "plan_experiment" in step_names
+    for entry in dataflow:
+        assert "step" in entry, f"Dataflow entry missing 'step': {entry}"
+        assert "available" in entry, f"Step '{entry.get('step')}' missing 'available'"
+        assert "required" in entry, f"Step '{entry.get('step')}' missing 'required'"
+        assert "produced" in entry, f"Step '{entry.get('step')}' missing 'produced'"
 
 
 def test_research_contract_card_not_stale() -> None:


### PR DESCRIPTION
## Summary

Generate the missing `src/autoskillit/recipes/contracts/research.yaml` contract card by invoking `generate_recipe_card()` on the research recipe. This enables the staleness-check block in `_api.py:load_and_validate()` to execute for the research recipe — today it silently skips because `load_recipe_card("research", ...)` returns `None`. The card captures `SkillContract` snapshots for all 21 statically-resolvable research skills plus dataflow analysis. The dynamic `exp-lens-{slug}` step is intentionally skipped by `resolve_skill_name()` (returns `None` for template-containing names).

Following the established pattern of five of six existing bundled contract cards, `skill_hashes` will be empty (`{}`). No `skills_dir` is passed — `generate_recipe_card()` only populates hashes when `skills_dir` is explicitly provided (only `planner.yaml` has non-empty hashes).

No CLI subcommand is added. The function is invoked once via a one-shot Python command during implementation, and the generated YAML is committed as a tracked source file.

Closes #848

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260506-025733-700006/.autoskillit/temp/make-plan/generate_research_yaml_contract_card_plan_2026-05-06_030600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 2.8k | 6.9k | 388.9k | 106.1k | 101 | 39.4k | 6m 3s |
| verify | 1 | 3.0k | 8.8k | 843.9k | 58.7k | 77 | 45.8k | 5m 25s |
| implement | 1 | 800.9k | 7.2k | 800.1k | 26.7k | 85 | 39.8k | 7m 11s |
| prepare_pr | 1 | 111.1k | 3.5k | 266.7k | 26.7k | 25 | 39.0k | 1m 22s |
| compose_pr | 1 | 56.3k | 1.5k | 210.5k | 26.7k | 20 | 15.0k | 39s |
| review_pr | 3 | 426 | 96.3k | 2.6M | 119.9k | 394 | 227.6k | 28m 22s |
| resolve_review | 3 | 2.5k | 82.4k | 8.1M | 115.7k | 360 | 257.3k | 30m 35s |
| **Total** | | 977.1k | 206.6k | 13.2M | 119.9k | | 663.9k | 1h 19m |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 2609 | 306.7 | 15.3 | 2.8 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 82 | 98846.3 | 3137.5 | 1004.6 |
| **Total** | **2691** | 4917.7 | 246.7 | 76.8 |