### PR TITLE
P3-WP2 Add All Four Sequential Dispatch Entries

### DIFF
--- a/src/autoskillit/recipes/campaigns/research-campaign.yaml
+++ b/src/autoskillit/recipes/campaigns/research-campaign.yaml
@@ -90,6 +90,8 @@ dispatches:
   - name: run-archive
     recipe: research-archive
     task: "Archive research artifacts and close experiment PR."
+    ingredients:
+      base_branch: "${{ inputs.base_branch }}"
     capture: {}
     depends_on:
       - run-review

--- a/src/autoskillit/recipes/campaigns/research-campaign.yaml
+++ b/src/autoskillit/recipes/campaigns/research-campaign.yaml
@@ -59,6 +59,39 @@ ingredients:
     required: false
     default: "local"
 
-dispatches: []
+dispatches:
+  - name: run-design
+    recipe: research-design
+    task: "Run the research design phase: scope the question, plan the experiment, and optionally review the design."
+    ingredients:
+      issue_url: "${{ inputs.issue_url }}"
+      source_dir: "${{ inputs.source_dir }}"
+    capture: {}
+    depends_on: []
+
+  - name: run-implement
+    recipe: research-implement
+    task: "Implement the research experiment plan."
+    ingredients:
+      source_dir: "${{ inputs.source_dir }}"
+    capture: {}
+    depends_on:
+      - run-design
+
+  - name: run-review
+    recipe: research-review
+    task: "Review the research experiment and open PR."
+    ingredients:
+      source_dir: "${{ inputs.source_dir }}"
+    capture: {}
+    depends_on:
+      - run-implement
+
+  - name: run-archive
+    recipe: research-archive
+    task: "Archive research artifacts and close experiment PR."
+    capture: {}
+    depends_on:
+      - run-review
 
 steps: {}

--- a/tests/recipe/test_campaign_loader.py
+++ b/tests/recipe/test_campaign_loader.py
@@ -312,11 +312,11 @@ def test_research_campaign_parseable():
     assert recipe.recipe_version == "1.0.0"
 
 
-def test_research_campaign_skeleton_structural_validation():
+def test_research_campaign_passes_structural_validation():
     path = pkg_root() / "recipes" / "campaigns" / "research-campaign.yaml"
     recipe = load_recipe(path)
     findings = validate_recipe(recipe)
-    assert findings == ["Campaign recipe must have at least one dispatch."]
+    assert findings == [], f"Unexpected findings: {findings}"
 
 
 def test_research_campaign_header_fields():
@@ -359,10 +359,10 @@ def test_research_campaign_ingredients_match_research_yaml():
     assert campaign_recipe.ingredients["output_mode"].default == "local"
 
 
-def test_research_campaign_dispatches_and_steps_empty():
+def test_research_campaign_has_four_dispatches():
     path = pkg_root() / "recipes" / "campaigns" / "research-campaign.yaml"
     recipe = load_recipe(path)
-    assert recipe.dispatches == []
+    assert len(recipe.dispatches) == 4
     assert recipe.steps == {}
 
 
@@ -372,6 +372,46 @@ def test_research_campaign_allowed_recipes_kebab_case():
 
     for name in recipe.allowed_recipes:
         assert re.match(r"^[a-z0-9]+(-[a-z0-9]+)*$", name)
+
+
+def test_research_campaign_dispatch_chain():
+    path = pkg_root() / "recipes" / "campaigns" / "research-campaign.yaml"
+    recipe = load_recipe(path)
+    names = [d.name for d in recipe.dispatches]
+    assert names == ["run-design", "run-implement", "run-review", "run-archive"]
+    assert recipe.dispatches[0].recipe == "research-design"
+    assert recipe.dispatches[0].depends_on == []
+    assert recipe.dispatches[1].recipe == "research-implement"
+    assert recipe.dispatches[1].depends_on == ["run-design"]
+    assert recipe.dispatches[2].recipe == "research-review"
+    assert recipe.dispatches[2].depends_on == ["run-implement"]
+    assert recipe.dispatches[3].recipe == "research-archive"
+    assert recipe.dispatches[3].depends_on == ["run-review"]
+    for d in recipe.dispatches:
+        assert d.task, f"Dispatch {d.name!r} has empty task"
+        assert d.capture == {}
+        assert d.gate is None
+
+
+def test_research_campaign_dispatch_ingredients_are_strings():
+    path = pkg_root() / "recipes" / "campaigns" / "research-campaign.yaml"
+    recipe = load_recipe(path)
+    for d in recipe.dispatches:
+        for key, val in d.ingredients.items():
+            assert isinstance(val, str), (
+                f"Dispatch {d.name!r} ingredient {key!r} is {type(val).__name__}, not str"
+            )
+
+
+def test_research_campaign_no_campaign_refs():
+    path = pkg_root() / "recipes" / "campaigns" / "research-campaign.yaml"
+    recipe = load_recipe(path)
+    for d in recipe.dispatches:
+        for key, val in d.ingredients.items():
+            assert "${{ campaign." not in val, (
+                f"Dispatch {d.name!r} ingredient {key!r} uses campaign ref {val!r} — "
+                "campaign refs are deferred to P3-WP3"
+            )
 
 
 def test_implement_findings_has_model_context_window_ingredient():


### PR DESCRIPTION
## Summary

Add four sequential dispatch entries (`run-design`, `run-implement`, `run-review`, `run-archive`) to `research-campaign.yaml`, replacing the empty `dispatches: []` stub. Each dispatch targets one of the four `allowed_recipes` sub-recipes, carries a non-empty `task` string, forwards only `${{ inputs.* }}` ingredients whose keys exist in the target recipe's ingredient schema, uses an empty `capture: {}` stub, and forms a linear `depends_on` chain. Two existing tests that assert the skeleton state (`dispatches == []` and the structural validation finding) must be updated, and new tests for the dispatch chain and semantic validation must be added.

**Issue correction:** The issue specifies `issue_number: "${{ inputs.issue_number }}"` for `run-design`, but the campaign declares `issue_url` (not `issue_number`), and `research-design.yaml` accepts `issue_url`. The plan uses `issue_url: "${{ inputs.issue_url }}"` instead. Similarly, the issue suggests `source_dir` for `run-archive`, but `research-archive.yaml` does not declare a `source_dir` ingredient — only `worktree_path`, `research_dir`, `pr_url`, and `base_branch`. The plan passes no ingredients for `run-archive` (the campaign-sourced ingredients will be wired via `${{ campaign.* }}` in P3-WP3).

Closes #1707

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260506-025734-118034/.autoskillit/temp/make-plan/p3_wp2_add_dispatch_entries_plan_2026-05-06_025734.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 68 | 12.0k | 702.6k | 68.3k | 58 | 55.1k | 6m 38s |
| verify | 1 | 53 | 8.6k | 784.8k | 57.0k | 50 | 43.9k | 3m 54s |
| implement | 1 | 297.9k | 4.2k | 503.9k | 26.7k | 52 | 16.0k | 5m 20s |
| prepare_pr | 1 | 65.3k | 3.0k | 183.9k | 26.7k | 19 | 15.2k | 1m 4s |
| compose_pr | 1 | 53.2k | 1.4k | 210.5k | 26.7k | 16 | 15.0k | 40s |
| review_pr | 1 | 116 | 13.8k | 487.1k | 48.1k | 36 | 35.4k | 3m 19s |
| resolve_review | 1 | 245 | 10.8k | 1.1M | 48.3k | 66 | 35.3k | 5m 23s |
| **Total** | | 416.9k | 53.7k | 3.9M | 68.3k | | 215.8k | 26m 20s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 83 | 6071.2 | 192.9 | 50.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 2 | 535280.0 | 17633.0 | 5393.0 |
| **Total** | **85** | 46392.3 | 2538.6 | 632.1 |