### PR TITLE
P3-WP3 Wire Capture Blocks and Campaign Ingredient Refs

### DIFF
--- a/src/autoskillit/recipes/campaigns/research-campaign.yaml
+++ b/src/autoskillit/recipes/campaigns/research-campaign.yaml
@@ -66,15 +66,24 @@ dispatches:
     ingredients:
       issue_url: "${{ inputs.issue_url }}"
       source_dir: "${{ inputs.source_dir }}"
-    capture: {}
+    capture:
+      worktree_path: "${{ result.worktree_path }}"
+      research_dir: "${{ result.research_dir }}"
+      experiment_plan: "${{ result.experiment_plan }}"
+      visualization_plan_path: "${{ result.visualization_plan_path }}"
     depends_on: []
 
   - name: run-implement
     recipe: research-implement
     task: "Implement the research experiment plan."
     ingredients:
+      worktree_path: "${{ campaign.worktree_path }}"
+      research_dir: "${{ campaign.research_dir }}"
+      experiment_plan: "${{ campaign.experiment_plan }}"
+      visualization_plan_path: "${{ campaign.visualization_plan_path }}"
       source_dir: "${{ inputs.source_dir }}"
-    capture: {}
+    capture:
+      report_path: "${{ result.report_path }}"
     depends_on:
       - run-design
 
@@ -82,8 +91,16 @@ dispatches:
     recipe: research-review
     task: "Review the research experiment and open PR."
     ingredients:
+      worktree_path: "${{ campaign.worktree_path }}"
+      research_dir: "${{ campaign.research_dir }}"
+      experiment_plan: "${{ campaign.experiment_plan }}"
+      visualization_plan_path: "${{ campaign.visualization_plan_path }}"
+      report_path: "${{ campaign.report_path }}"
       source_dir: "${{ inputs.source_dir }}"
-    capture: {}
+    capture:
+      pr_url: "${{ result.pr_url }}"
+      all_diagram_paths: "${{ result.all_diagram_paths }}"
+      report_path_after_finalize: "${{ result.report_path_after_finalize }}"
     depends_on:
       - run-implement
 
@@ -91,7 +108,11 @@ dispatches:
     recipe: research-archive
     task: "Archive research artifacts and close experiment PR."
     ingredients:
-      base_branch: "${{ inputs.base_branch }}"
+      worktree_path: "${{ campaign.worktree_path }}"
+      research_dir: "${{ campaign.research_dir }}"
+      pr_url: "${{ campaign.pr_url }}"
+      all_diagram_paths: "${{ campaign.all_diagram_paths }}"
+      report_path_after_finalize: "${{ campaign.report_path_after_finalize }}"
     capture: {}
     depends_on:
       - run-review

--- a/src/autoskillit/recipes/campaigns/research-campaign.yaml
+++ b/src/autoskillit/recipes/campaigns/research-campaign.yaml
@@ -108,6 +108,7 @@ dispatches:
     recipe: research-archive
     task: "Archive research artifacts and close experiment PR."
     ingredients:
+      base_branch: "${{ inputs.base_branch }}"
       worktree_path: "${{ campaign.worktree_path }}"
       research_dir: "${{ campaign.research_dir }}"
       pr_url: "${{ campaign.pr_url }}"

--- a/src/autoskillit/recipes/research-archive.yaml
+++ b/src/autoskillit/recipes/research-archive.yaml
@@ -25,6 +25,14 @@ ingredients:
     description: URL of the original experiment PR (passed by campaign dispatch)
     required: true
     hidden: true
+  all_diagram_paths:
+    description: Paths to all generated diagrams (passed by campaign dispatch)
+    required: true
+    hidden: true
+  report_path_after_finalize:
+    description: Path to the finalized research report (passed by campaign dispatch)
+    required: true
+    hidden: true
 
   # --- user-input ---
   base_branch:

--- a/src/autoskillit/recipes/research-implement.yaml
+++ b/src/autoskillit/recipes/research-implement.yaml
@@ -40,6 +40,9 @@ ingredients:
   experiment_plan:
     description: Path to the experiment plan file (passed by campaign dispatch)
     required: true
+  visualization_plan_path:
+    description: Path to the visualization plan (passed by campaign dispatch)
+    required: true
 
 kitchen_rules:
   - >

--- a/src/autoskillit/recipes/research-implement.yaml
+++ b/src/autoskillit/recipes/research-implement.yaml
@@ -43,6 +43,7 @@ ingredients:
   visualization_plan_path:
     description: Path to the visualization plan (passed by campaign dispatch)
     required: true
+    hidden: true
 
 kitchen_rules:
   - >

--- a/tests/recipe/test_campaign_loader.py
+++ b/tests/recipe/test_campaign_loader.py
@@ -389,7 +389,6 @@ def test_research_campaign_dispatch_chain():
     assert recipe.dispatches[3].depends_on == ["run-review"]
     for d in recipe.dispatches:
         assert d.task, f"Dispatch {d.name!r} has empty task"
-        assert d.capture == {}
         assert d.gate is None
 
 
@@ -403,14 +402,144 @@ def test_research_campaign_dispatch_ingredients_are_strings():
             )
 
 
-def test_research_campaign_no_campaign_refs():
+def test_research_campaign_run_design_capture():
+    path = pkg_root() / "recipes" / "campaigns" / "research-campaign.yaml"
+    recipe = load_recipe(path)
+    d = recipe.dispatches[0]
+    assert d.name == "run-design"
+    assert set(d.capture.keys()) == {
+        "worktree_path",
+        "research_dir",
+        "experiment_plan",
+        "visualization_plan_path",
+    }
+    for key, val in d.capture.items():
+        assert val == f"${{{{ result.{key} }}}}"
+
+
+def test_research_campaign_run_implement_ingredients():
+    path = pkg_root() / "recipes" / "campaigns" / "research-campaign.yaml"
+    recipe = load_recipe(path)
+    d = recipe.dispatches[1]
+    assert d.name == "run-implement"
+    assert set(d.ingredients.keys()) == {
+        "worktree_path",
+        "research_dir",
+        "experiment_plan",
+        "visualization_plan_path",
+        "source_dir",
+    }
+    assert d.ingredients["worktree_path"] == "${{ campaign.worktree_path }}"
+    assert d.ingredients["research_dir"] == "${{ campaign.research_dir }}"
+    assert d.ingredients["experiment_plan"] == "${{ campaign.experiment_plan }}"
+    assert d.ingredients["visualization_plan_path"] == "${{ campaign.visualization_plan_path }}"
+    assert d.ingredients["source_dir"] == "${{ inputs.source_dir }}"
+
+
+def test_research_campaign_run_implement_capture():
+    path = pkg_root() / "recipes" / "campaigns" / "research-campaign.yaml"
+    recipe = load_recipe(path)
+    d = recipe.dispatches[1]
+    assert d.name == "run-implement"
+    assert set(d.capture.keys()) == {"report_path"}
+    assert d.capture["report_path"] == "${{ result.report_path }}"
+
+
+def test_research_campaign_run_review_ingredients():
+    path = pkg_root() / "recipes" / "campaigns" / "research-campaign.yaml"
+    recipe = load_recipe(path)
+    d = recipe.dispatches[2]
+    assert d.name == "run-review"
+    assert {
+        "worktree_path",
+        "research_dir",
+        "experiment_plan",
+        "visualization_plan_path",
+        "report_path",
+    }.issubset(set(d.ingredients.keys()))
+    assert d.ingredients["source_dir"] == "${{ inputs.source_dir }}"
+    for key in [
+        "worktree_path",
+        "research_dir",
+        "experiment_plan",
+        "visualization_plan_path",
+        "report_path",
+    ]:
+        assert d.ingredients[key] == f"${{{{ campaign.{key} }}}}"
+
+
+def test_research_campaign_run_review_capture():
+    path = pkg_root() / "recipes" / "campaigns" / "research-campaign.yaml"
+    recipe = load_recipe(path)
+    d = recipe.dispatches[2]
+    assert d.name == "run-review"
+    assert set(d.capture.keys()) == {"pr_url", "all_diagram_paths", "report_path_after_finalize"}
+    assert d.capture["pr_url"] == "${{ result.pr_url }}"
+    assert d.capture["all_diagram_paths"] == "${{ result.all_diagram_paths }}"
+    assert d.capture["report_path_after_finalize"] == "${{ result.report_path_after_finalize }}"
+
+
+def test_research_campaign_run_review_capture_no_worktree_path():
+    path = pkg_root() / "recipes" / "campaigns" / "research-campaign.yaml"
+    recipe = load_recipe(path)
+    d = recipe.dispatches[2]
+    assert d.name == "run-review"
+    assert "worktree_path" not in d.capture
+
+
+def test_research_campaign_run_archive_ingredients():
+    path = pkg_root() / "recipes" / "campaigns" / "research-campaign.yaml"
+    recipe = load_recipe(path)
+    d = recipe.dispatches[3]
+    assert d.name == "run-archive"
+    assert set(d.ingredients.keys()) == {
+        "worktree_path",
+        "research_dir",
+        "pr_url",
+        "all_diagram_paths",
+        "report_path_after_finalize",
+    }
+    for key in d.ingredients:
+        assert d.ingredients[key] == f"${{{{ campaign.{key} }}}}"
+
+
+def test_research_campaign_no_campaign_refs_in_run_design():
+    path = pkg_root() / "recipes" / "campaigns" / "research-campaign.yaml"
+    recipe = load_recipe(path)
+    d = recipe.dispatches[0]
+    for key, val in d.ingredients.items():
+        assert "${{ campaign." not in val
+
+
+def test_research_campaign_run_archive_no_capture():
+    path = pkg_root() / "recipes" / "campaigns" / "research-campaign.yaml"
+    recipe = load_recipe(path)
+    d = recipe.dispatches[3]
+    assert d.name == "run-archive"
+    assert d.capture == {}
+
+
+def test_research_campaign_capture_keys_are_identifiers():
+    from autoskillit.recipe.rules.rules_campaign import _IDENT_RE
+
     path = pkg_root() / "recipes" / "campaigns" / "research-campaign.yaml"
     recipe = load_recipe(path)
     for d in recipe.dispatches:
-        for key, val in d.ingredients.items():
-            assert "${{ campaign." not in val, (
-                f"Dispatch {d.name!r} ingredient {key!r} uses campaign ref {val!r} — "
-                "campaign refs are deferred to P3-WP3"
+        for key in d.capture.keys():
+            assert _IDENT_RE.match(key), (
+                f"Dispatch {d.name!r} capture key {key!r} is not a valid identifier"
+            )
+
+
+def test_research_campaign_capture_values_reference_result():
+    from autoskillit.recipe.rules.rules_campaign import _RESULT_TEMPLATE_RE
+
+    path = pkg_root() / "recipes" / "campaigns" / "research-campaign.yaml"
+    recipe = load_recipe(path)
+    for d in recipe.dispatches:
+        for val in d.capture.values():
+            assert _RESULT_TEMPLATE_RE.match(val.strip()), (
+                f"Dispatch {d.name!r} capture value {val!r} does not reference result"
             )
 
 

--- a/tests/recipe/test_campaign_loader.py
+++ b/tests/recipe/test_campaign_loader.py
@@ -493,13 +493,17 @@ def test_research_campaign_run_archive_ingredients():
     d = recipe.dispatches[3]
     assert d.name == "run-archive"
     assert set(d.ingredients.keys()) == {
+        "base_branch",
         "worktree_path",
         "research_dir",
         "pr_url",
         "all_diagram_paths",
         "report_path_after_finalize",
     }
+    assert d.ingredients["base_branch"] == "${{ inputs.base_branch }}"
     for key in d.ingredients:
+        if key == "base_branch":
+            continue
         assert d.ingredients[key] == f"${{{{ campaign.{key} }}}}"
 
 

--- a/tests/recipe/test_campaign_loader.py
+++ b/tests/recipe/test_campaign_loader.py
@@ -450,13 +450,14 @@ def test_research_campaign_run_review_ingredients():
     recipe = load_recipe(path)
     d = recipe.dispatches[2]
     assert d.name == "run-review"
-    assert {
+    assert set(d.ingredients.keys()) == {
         "worktree_path",
         "research_dir",
         "experiment_plan",
         "visualization_plan_path",
         "report_path",
-    }.issubset(set(d.ingredients.keys()))
+        "source_dir",
+    }
     assert d.ingredients["source_dir"] == "${{ inputs.source_dir }}"
     for key in [
         "worktree_path",
@@ -477,14 +478,6 @@ def test_research_campaign_run_review_capture():
     assert d.capture["pr_url"] == "${{ result.pr_url }}"
     assert d.capture["all_diagram_paths"] == "${{ result.all_diagram_paths }}"
     assert d.capture["report_path_after_finalize"] == "${{ result.report_path_after_finalize }}"
-
-
-def test_research_campaign_run_review_capture_no_worktree_path():
-    path = pkg_root() / "recipes" / "campaigns" / "research-campaign.yaml"
-    recipe = load_recipe(path)
-    d = recipe.dispatches[2]
-    assert d.name == "run-review"
-    assert "worktree_path" not in d.capture
 
 
 def test_research_campaign_run_archive_ingredients():
@@ -541,6 +534,9 @@ def test_research_campaign_capture_values_reference_result():
     path = pkg_root() / "recipes" / "campaigns" / "research-campaign.yaml"
     recipe = load_recipe(path)
     for d in recipe.dispatches:
+        if d.name == "run-archive":
+            assert d.capture == {}, f"run-archive must have empty capture, got {d.capture!r}"
+            continue
         for val in d.capture.values():
             assert _RESULT_TEMPLATE_RE.match(val.strip()), (
                 f"Dispatch {d.name!r} capture value {val!r} does not reference result"

--- a/tests/recipe/test_research_archive_recipe.py
+++ b/tests/recipe/test_research_archive_recipe.py
@@ -44,6 +44,8 @@ class TestResearchArchiveRecipe:
             "worktree_path",
             "research_dir",
             "pr_url",
+            "all_diagram_paths",
+            "report_path_after_finalize",
             "base_branch",
         }
 

--- a/tests/recipe/test_research_implement_recipe.py
+++ b/tests/recipe/test_research_implement_recipe.py
@@ -34,7 +34,6 @@ class TestResearchImplementRecipe:
     def test_excluded_ingredients_absent(self, recipe) -> None:
         names = set(recipe.ingredients.keys())
         assert "scope_report" not in names
-        assert "visualization_plan_path" not in names
         assert "report_plan_path" not in names
         assert "experiment_type" not in names
 


### PR DESCRIPTION
## Summary

Wire all `capture` blocks and `${{ campaign.* }}` ingredient references across the four dispatches in `research-campaign.yaml`, establishing complete cross-dispatch data flow. Additionally update three sub-recipe ingredient schemas to accept the new dispatch-provided keys, and update existing contract tests that assert the pre-wiring state.

## Requirements

## Goal

Wire all capture blocks and ${{ campaign.* }} ingredient references across all four dispatches in research-campaign.yaml, establishing the complete cross-dispatch data flow: run-design captures 4 keys, run-implement captures 1 key and consumes 4 campaign refs, run-review captures 3 keys and consumes campaign refs, run-archive consumes 5 campaign refs from its transitive ancestors.

## Acceptance Criteria

- run-design capture block has exactly 4 keys: worktree_path, research_dir, experiment_plan, visualization_plan_path. Each value uses ${{ result.<field> }} syntax.
- run-design capture does NOT include scope_report or report_plan_path.
- run-design depends_on: [] is unchanged (no predecessors).
- run-implement ingredients block has exactly 5 keys: worktree_path, research_dir, experiment_plan, visualization_plan_path, source_dir — with campaign.* refs for the first four and inputs.source_dir for the last.
- run-implement capture block has exactly 1 key: report_path: '${{ result.report_path }}'.
- run-implement depends_on: [run-design].
- run-review capture block has exactly 3 keys: pr_url, all_diagram_paths, report_path_after_finalize. Each uses ${{ result.<field> }}.
- run-review capture does NOT include worktree_path.
- run-review depends_on: [run-implement].
- run-archive ingredients block has exactly 5 keys: worktree_path, research_dir, pr_url, all_diagram_paths, report_path_after_finalize — all with campaign.* refs.
- run-archive depends_on: [run-review].
- run-archive has no capture block (or capture: {}).
- All capture keys match _IDENT_RE (no hyphens, spaces, or leading digits).
- All capture values match _RESULT_TEMPLATE_RE.
- All ingredient values are YAML-quoted strings.
- No ${{ campaign.X }} refs appear in run-design.
- campaign-ingredient-refs-have-prior-capture reports zero ERRORs for all dispatches.
- dispatch-capture-keys-are-identifiers reports zero findings.
- dispatch-capture-value-references-result reports zero findings.
- The YAML file is syntactically valid.

Closes #1708

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260506-044100-067056/.autoskillit/temp/make-plan/p3_wp3_wire_capture_blocks_plan_2026-05-06_044100.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | 1 | 3.2k | 16.4k | 997.7k | 73.1k | 89 | 73.3k | 9m 9s |
| verify | 1 | 1.5k | 6.2k | 652.9k | 51.2k | 47 | 38.1k | 3m 12s |
| implement | 1 | 369.8k | 6.5k | 506.7k | 26.7k | 48 | 67.7k | 2m 34s |
| prepare_pr | 2 | 160.7k | 6.6k | 370.5k | 26.7k | 40 | 54.2k | 2m 33s |
| compose_pr | 1 | 38.6k | 1.7k | 157.2k | 26.7k | 14 | 14.9k | 45s |
| review_pr | 2 | 218 | 75.2k | 1.2M | 77.0k | 94 | 125.0k | 13m 9s |
| resolve_review | 1 | 1.5k | 21.3k | 2.6M | 90.7k | 109 | 78.3k | 9m 32s |
| **Total** | | 575.5k | 134.0k | 6.5M | 90.7k | | 451.6k | 40m 57s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 181 | 2799.4 | 374.0 | 36.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 22 | 119044.2 | 3559.5 | 969.2 |
| **Total** | **203** | 32061.5 | 2224.5 | 659.9 |