### PR TITLE
P3-WP4 — Run Validation and Fix All ERROR Findings Iteratively

### DIFF
--- a/tests/recipe/test_campaign_loader.py
+++ b/tests/recipe/test_campaign_loader.py
@@ -9,7 +9,8 @@ from pathlib import Path
 import pytest
 import yaml
 
-from autoskillit.core import DispatchGateType, pkg_root
+from autoskillit.core import DispatchGateType, Severity, pkg_root
+from autoskillit.recipe._analysis import make_validation_context
 from autoskillit.recipe.io import (
     _parse_recipe,
     find_campaign_by_name,
@@ -17,6 +18,7 @@ from autoskillit.recipe.io import (
     load_campaign_recipes_in_packs,
     load_recipe,
 )
+from autoskillit.recipe.registry import run_semantic_rules
 from autoskillit.recipe.schema import CampaignDispatch, Recipe, RecipeKind
 from autoskillit.recipe.validator import validate_recipe
 
@@ -541,6 +543,38 @@ def test_research_campaign_capture_values_reference_result():
             assert _RESULT_TEMPLATE_RE.match(val.strip()), (
                 f"Dispatch {d.name!r} capture value {val!r} does not reference result"
             )
+
+
+_CAMPAIGN_ERROR_RULES = [
+    "dispatch-ingredients-keys-in-target-schema",
+    "dispatch-ingredient-values-are-strings",
+    "depends-on-refers-to-valid-dispatches",
+    "depends-on-acyclic",
+    "campaign-ingredient-refs-have-prior-capture",
+]
+
+
+def _research_campaign_ctx():
+    path = pkg_root() / "recipes" / "campaigns" / "research-campaign.yaml"
+    recipe = load_recipe(path)
+    project_dir = pkg_root() / "recipes"
+    available_recipes = frozenset(p.stem for p in project_dir.glob("*.yaml"))
+    return make_validation_context(
+        recipe,
+        available_recipes=available_recipes,
+        project_dir=project_dir,
+    )
+
+
+@pytest.mark.parametrize("rule", _CAMPAIGN_ERROR_RULES)
+def test_research_campaign_zero_error_findings(rule: str) -> None:
+    ctx = _research_campaign_ctx()
+    errors = [
+        f for f in run_semantic_rules(ctx) if f.rule == rule and f.severity == Severity.ERROR
+    ]
+    assert errors == [], f"research-campaign.yaml has ERROR findings for {rule!r}:\n" + "\n".join(
+        f"  {f.step_name}: {f.message}" for f in errors
+    )
 
 
 def test_implement_findings_has_model_context_window_ingredient():


### PR DESCRIPTION
## Summary

Execute both structural (`validate_recipe`) and semantic (`run_semantic_rules`) validation against `src/autoskillit/recipes/campaigns/research-campaign.yaml`, iteratively fixing every ERROR-severity finding for the five target rules, then lock the corrected state with regression tests added to `tests/recipe/test_campaign_loader.py`.

Based on static analysis, the current YAML (delivered by P3-WP3) already satisfies all five rules. The implementation steps below are ordered to confirm this via a live validation run first, apply targeted fixes for any findings that do surface, and then add permanent regression tests regardless of how many fixes were required.

Closes #1709

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260506-054344-605707/.autoskillit/temp/make-plan/p3_wp4_validation_fix_plan_2026-05-06_000000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->
