### PR TITLE
P3-WP5 — campaign-dispatch-depends-on-is-sequential Rule and Final Fix Pass

### DIFF
--- a/src/autoskillit/recipe/rules/rules_campaign.py
+++ b/src/autoskillit/recipe/rules/rules_campaign.py
@@ -380,6 +380,32 @@ def _check_depends_on_acyclic(ctx: ValidationContext) -> list[RuleFinding]:
 
 
 @semantic_rule(
+    name="campaign-dispatch-depends-on-is-sequential",
+    description="Each dispatch's depends_on must have at most one entry (linear chain only)",
+    severity=Severity.ERROR,
+)
+def _check_campaign_dispatch_depends_on_is_sequential(ctx: ValidationContext) -> list[RuleFinding]:
+    if ctx.recipe.kind != RecipeKind.CAMPAIGN:
+        return []
+    findings: list[RuleFinding] = []
+    for d in ctx.recipe.dispatches:
+        if len(d.depends_on) > 1:
+            findings.append(
+                RuleFinding(
+                    rule="campaign-dispatch-depends-on-is-sequential",
+                    severity=Severity.ERROR,
+                    step_name="(top-level)",
+                    message=(
+                        f"Dispatch {d.name!r} has {len(d.depends_on)} entries in depends_on "
+                        f"({d.depends_on!r}). Campaign dispatches must form a linear chain: "
+                        "each dispatch may depend on at most one predecessor."
+                    ),
+                )
+            )
+    return findings
+
+
+@semantic_rule(
     name="campaign-task-non-empty",
     description="Each dispatch must have a non-empty task description",
     severity=Severity.ERROR,

--- a/tests/recipe/test_rules_campaign.py
+++ b/tests/recipe/test_rules_campaign.py
@@ -332,6 +332,44 @@ def test_depends_on_acyclic_passes_on_dag():
 
 
 # ---------------------------------------------------------------------------
+# T-S1: campaign-dispatch-depends-on-is-sequential
+# ---------------------------------------------------------------------------
+
+
+def test_campaign_dispatch_depends_on_is_sequential_fires_on_fan_in():
+    recipe = _campaign(
+        dispatches=[
+            CampaignDispatch(name="phase-one", recipe="impl", task="a", depends_on=[]),
+            CampaignDispatch(name="phase-two", recipe="impl", task="b", depends_on=[]),
+            CampaignDispatch(
+                name="phase-merge",
+                recipe="impl",
+                task="c",
+                depends_on=["phase-one", "phase-two"],
+            ),
+        ]
+    )
+    found = _findings(recipe, "campaign-dispatch-depends-on-is-sequential")
+    assert len(found) == 1
+    assert found[0].severity == Severity.ERROR
+    assert "phase-merge" in found[0].message
+    assert "phase-one" in found[0].message or "phase-two" in found[0].message
+
+
+def test_campaign_dispatch_depends_on_is_sequential_passes_on_linear_chain():
+    recipe = _campaign(
+        dispatches=[
+            CampaignDispatch(name="a", recipe="impl", task="a", depends_on=[]),
+            CampaignDispatch(name="b", recipe="impl", task="b", depends_on=["a"]),
+            CampaignDispatch(name="c", recipe="impl", task="c", depends_on=["b"]),
+            CampaignDispatch(name="d", recipe="impl", task="d", depends_on=["c"]),
+        ]
+    )
+    found = _findings(recipe, "campaign-dispatch-depends-on-is-sequential")
+    assert found == []
+
+
+# ---------------------------------------------------------------------------
 # T28: campaign-task-non-empty
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Add the `campaign-dispatch-depends-on-is-sequential` semantic validation rule to `rules_campaign.py`, inserting it immediately after `_check_depends_on_acyclic` to preserve logical grouping of `depends_on`-related rules. The rule enforces that every dispatch in a campaign has at most one entry in `depends_on`, preventing fan-in (multiple-predecessor) patterns and guaranteeing a linear execution chain. Add two tests under a new `T-S1` section in `test_rules_campaign.py`. Verify that `research-campaign.yaml` (already structured as a strict linear chain by P3-WP4) produces zero ERROR-severity findings across all campaign rules after the new rule is in place, and confirm T31 (`test_campaign_valid_passes_all_rules`) passes without modification.

## Requirements

## Goal
Implement the campaign-dispatch-depends-on-is-sequential semantic rule in rules_campaign.py, fix any remaining ERROR findings in research-campaign.yaml produced by campaign-task-non-empty, dispatch-capture-keys-are-identifiers, dispatch-capture-value-references-result, and gate-dispatch-* rules, add tests for the new rule, and run a final validation pass confirming zero ERROR-severity findings across all campaign rules.

## Context
- Phase: Campaign Assembly and Validation (Milestone: 3-campaign-assembly-and-validation)
- Consolidates: P3-A4-WP4 (standalone — kept separate due to different files and rule authoring scope)
- Depends on: P3-WP4
- Depended on by: P4-A5-WP1, P4-A5-WP3, P6-A2-WP1

## Deliverables
- `src/autoskillit/recipes/campaigns/research-campaign.yaml`
- `src/autoskillit/recipe/rules_campaign.py`
- `tests/recipe/test_rules_campaign.py`

## Acceptance Criteria
- campaign-dispatch-depends-on-is-sequential is registered in _RULE_REGISTRY via @semantic_rule decorator with severity=Severity.ERROR.
- The rule fires with severity ERROR when any dispatch in a campaign has len(depends_on) > 1 (fan-in scenario).
- The rule does not fire for campaigns where every dispatch has at most one entry in depends_on (linear chain).
- The rule returns [] for non-CAMPAIGN recipes (consistent with all other campaign rules).
- test_campaign_dispatch_depends_on_is_sequential_fires_on_fan_in asserts a single ERROR finding naming the offending dispatch.
- test_campaign_dispatch_depends_on_is_sequential_passes_on_linear_chain asserts zero findings for a valid sequential chain.
- test_campaign_valid_passes_all_rules (T31) continues to pass with the new rule present.
- research-campaign.yaml produces zero ERROR-severity findings when run through run_semantic_rules().
- research-campaign.yaml has four sequential dispatches wired with correct depends_on (linear chain: d1 → d2 → d3 → d4), valid identifier capture keys, ${{ result.field }} capture values, non-empty task strings on all non-gate dispatches.
- All WARNING findings from dispatch-names-kebab-case, dispatch-recipe-in-declared-packs, campaign-requires-recipe-packs-exist, and autoskillit-version-compatible are either resolved or explicitly accepted as non-ERROR WARNINGs.
- pre-commit run --all-files passes with no ruff or mypy errors on the modified files.
- task test-check passes with all tests in tests/recipe/test_rules_campaign.py green.

## Changed Files

### Modified (●):
- `src/autoskillit/recipe/rules/rules_campaign.py`
- `tests/recipe/test_rules_campaign.py`

Closes #1710

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260506-064318-980833/.autoskillit/temp/make-plan/p3_wp5_campaign_dispatch_depends_on_is_sequential_plan_2026-05-06_064318.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->