### PR TITLE
P3-WP6 — Generate Contract Card, Verify Staleness, Add Contract Test

### DIFF
--- a/src/autoskillit/recipes/contracts/research-campaign.yaml
+++ b/src/autoskillit/recipes/contracts/research-campaign.yaml
@@ -1,0 +1,5 @@
+generated_at: '2026-05-06T14:51:35.117429+00:00'
+bundled_manifest_version: 0.1.0
+skill_hashes: {}
+skills: {}
+dataflow: []

--- a/tests/recipe/CLAUDE.md
+++ b/tests/recipe/CLAUDE.md
@@ -64,6 +64,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_remediation_depth_ingredient.py` | Tests for remediation depth ingredient configuration |
 | `test_remediation_pr_decomposition.py` | Tests for remediation PR decomposition recipe |
 | `test_remediation_recipe.py` | Tests for the remediation recipe structure |
+| `test_research_campaign.py` | Contract card assertions for the research-campaign recipe |
 | `test_repository.py` | Tests for DefaultRecipeRepository |
 | `test_research_archive_recipe.py` | Tests for research-archive sub-recipe structure |
 | `test_research_bundle_lifecycle.py` | Tests for research bundle lifecycle in recipes |

--- a/tests/recipe/test_research_campaign.py
+++ b/tests/recipe/test_research_campaign.py
@@ -6,7 +6,7 @@ import yaml
 from autoskillit.recipe.contracts import check_contract_staleness, load_bundled_manifest
 from autoskillit.recipe.io import builtin_recipes_dir
 
-pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.medium]
 
 
 def test_research_campaign_contract_exists():
@@ -14,7 +14,8 @@ def test_research_campaign_contract_exists():
     assert (contracts_dir / "research-campaign.yaml").exists(), (
         'Regenerate: python -c "from autoskillit.recipe.contracts import generate_recipe_card; '
         "from autoskillit.recipe.io import builtin_recipes_dir; "
-        "generate_recipe_card(builtin_recipes_dir()/'campaigns'/'research-campaign.yaml', builtin_recipes_dir())\""
+        "generate_recipe_card("
+        "builtin_recipes_dir()/'campaigns'/'research-campaign.yaml', builtin_recipes_dir())\""
     )
 
 

--- a/tests/recipe/test_research_campaign.py
+++ b/tests/recipe/test_research_campaign.py
@@ -22,6 +22,7 @@ def test_research_campaign_contract_exists():
 def test_research_campaign_contract_is_fresh():
     contract_path = builtin_recipes_dir() / "contracts" / "research-campaign.yaml"
     contract = yaml.safe_load(contract_path.read_text())
+    assert isinstance(contract, dict), f"Malformed contract: expected dict, got {type(contract)}"
     stale = check_contract_staleness(contract)
     assert stale == [], f"Contract is stale: {stale}"
 
@@ -29,4 +30,8 @@ def test_research_campaign_contract_is_fresh():
 def test_research_campaign_contract_version_matches():
     contract_path = builtin_recipes_dir() / "contracts" / "research-campaign.yaml"
     contract = yaml.safe_load(contract_path.read_text())
+    assert isinstance(contract, dict), f"Malformed contract: expected dict, got {type(contract)}"
+    assert "bundled_manifest_version" in contract, (
+        f"Contract missing 'bundled_manifest_version' key: {list(contract.keys())}"
+    )
     assert contract["bundled_manifest_version"] == load_bundled_manifest()["version"]

--- a/tests/recipe/test_research_campaign.py
+++ b/tests/recipe/test_research_campaign.py
@@ -1,0 +1,31 @@
+"""Contract card assertions for the research-campaign recipe."""
+
+import pytest
+import yaml
+
+from autoskillit.recipe.contracts import check_contract_staleness, load_bundled_manifest
+from autoskillit.recipe.io import builtin_recipes_dir
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+
+def test_research_campaign_contract_exists():
+    contracts_dir = builtin_recipes_dir() / "contracts"
+    assert (contracts_dir / "research-campaign.yaml").exists(), (
+        'Regenerate: python -c "from autoskillit.recipe.contracts import generate_recipe_card; '
+        "from autoskillit.recipe.io import builtin_recipes_dir; "
+        "generate_recipe_card(builtin_recipes_dir()/'campaigns'/'research-campaign.yaml', builtin_recipes_dir())\""
+    )
+
+
+def test_research_campaign_contract_is_fresh():
+    contract_path = builtin_recipes_dir() / "contracts" / "research-campaign.yaml"
+    contract = yaml.safe_load(contract_path.read_text())
+    stale = check_contract_staleness(contract)
+    assert stale == [], f"Contract is stale: {stale}"
+
+
+def test_research_campaign_contract_version_matches():
+    contract_path = builtin_recipes_dir() / "contracts" / "research-campaign.yaml"
+    contract = yaml.safe_load(contract_path.read_text())
+    assert contract["bundled_manifest_version"] == load_bundled_manifest()["version"]


### PR DESCRIPTION
## Summary

Generate the contract card for `research-campaign.yaml` by calling `generate_recipe_card` via an inline Python snippet, commit the resulting `src/autoskillit/recipes/contracts/research-campaign.yaml` artifact, and add a test file `tests/recipe/test_research_campaign.py` that asserts the contract exists, is fresh, and has the correct `bundled_manifest_version`. The campaign is a pure dispatch recipe (`steps: {}`), so `skill_hashes`, `skills`, and `dataflow` will all be empty — this is correct and not a staleness indicator.

## Requirements

Generate the contract card for research-campaign.yaml, verify it passes staleness checks, and add a test asserting contract existence and freshness. Since research-campaign.yaml is a pure dispatch campaign with steps: {}, skill_hashes and skills will be empty dicts — this is correct and not a staleness indicator.

## New Files

- `src/autoskillit/recipes/contracts/research-campaign.yaml` — generated contract card
- `tests/recipe/test_research_campaign.py` — contract existence/freshness test
- `tests/recipe/CLAUDE.md` — test documentation

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260506-073752-444179/.autoskillit/temp/make-plan/p3_wp6_generate_contract_card_plan_2026-05-06_080100.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->