### PR TITLE
fix: idle_output_timeout default 600 → 1000 to satisfy coherence gate

### DIFF
--- a/src/autoskillit/config/_config_dataclasses.py
+++ b/src/autoskillit/config/_config_dataclasses.py
@@ -93,7 +93,7 @@ class RunSkillConfig:
     completion_drain_timeout: float = 5.0
     exit_after_stop_delay_ms: int = 2000
     natural_exit_grace_seconds: float = 3.0
-    idle_output_timeout: int = 600
+    idle_output_timeout: int = 1000
     max_suppression_seconds: int = 1800
 
     # Safety margin (ms) above exit_after_stop_delay_ms that

--- a/src/autoskillit/config/defaults.yaml
+++ b/src/autoskillit/config/defaults.yaml
@@ -45,7 +45,7 @@ run_skill:
   completion_drain_timeout: 5.0
   exit_after_stop_delay_ms: 2000
   natural_exit_grace_seconds: 3.0
-  idle_output_timeout: 600
+  idle_output_timeout: 1000
   max_suppression_seconds: 1800
 
 model:

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -414,7 +414,7 @@ async def run_skill(
             config default (RunSkillConfig.stale_threshold, default 1200s).
         idle_output_timeout: Override the idle stdout kill threshold in seconds.
             0 = disabled for this step. None = use global config
-            (RunSkillConfig.idle_output_timeout, default 600s).
+            (RunSkillConfig.idle_output_timeout, default 1000s).
         resume_session_id: Session ID from a previous run_skill call that was interrupted.
             When set, the session is resumed via --resume instead of starting fresh.
             The skill_command becomes a continuation instruction (non-slash text is allowed).

--- a/tests/config/test_defaults.py
+++ b/tests/config/test_defaults.py
@@ -7,8 +7,9 @@ configured coherently so the drain window can always absorb the self-exit delay.
 from __future__ import annotations
 
 import pytest
+import structlog.testing
 
-from autoskillit.config import AutomationConfig
+from autoskillit.config import AutomationConfig, load_config
 from autoskillit.config.settings import RunSkillConfig
 
 pytestmark = [pytest.mark.layer("config"), pytest.mark.small]
@@ -44,3 +45,62 @@ class TestGraceWindowCoherence:
         )
         # 3.0 * 1000 = 3000 >= 2000 + 500 = 2500 ✓
         assert cfg.natural_exit_grace_seconds == 3.0
+
+
+class TestIdleOutputTimeoutCoherence:
+    """idle_output_timeout default must pass _timeout_coherence_gate."""
+
+    def test_default_idle_output_timeout_passes_coherence_gate(self, tmp_path) -> None:
+        """Pure-default config emits zero *_coherence log warnings."""
+        config_dir = tmp_path / ".autoskillit"
+        config_dir.mkdir()
+        (config_dir / "config.yaml").write_text("")
+        with structlog.testing.capture_logs() as cap_logs:
+            cfg = load_config(tmp_path)
+        coherence_warnings = [e for e in cap_logs if "_coherence" in e.get("event", "")]
+        assert coherence_warnings == [], (
+            f"Default config emitted coherence warnings: {coherence_warnings}. "
+            "Update the relevant default in defaults.yaml and _config_dataclasses.py."
+        )
+        assert cfg.run_skill.idle_output_timeout == 1000
+
+
+class TestAllDefaultsPassAllGates:
+    """Universal guard: shipped defaults must produce zero validation warnings."""
+
+    def test_pure_defaults_emit_no_coherence_warnings(self, tmp_path) -> None:
+        """load_config with empty user config emits no *_coherence warnings."""
+        config_dir = tmp_path / ".autoskillit"
+        config_dir.mkdir()
+        (config_dir / "config.yaml").write_text("")
+        with structlog.testing.capture_logs() as cap_logs:
+            load_config(tmp_path)
+        coherence_events = [
+            e
+            for e in cap_logs
+            if e.get("log_level") == "warning" and "_coherence" in e.get("event", "")
+        ]
+        assert coherence_events == [], (
+            f"Default config produced coherence warnings: {coherence_events}. "
+            "A shipped default violates its own validation gate. "
+            "Fix the default or the gate threshold."
+        )
+
+
+class TestDefaultsSyncYamlDataclass:
+    """Numeric defaults in dataclasses must match defaults.yaml."""
+
+    def test_run_skill_defaults_match_yaml(self, tmp_path) -> None:
+        """RunSkillConfig field defaults agree with defaults.yaml values."""
+        config_dir = tmp_path / ".autoskillit"
+        config_dir.mkdir()
+        (config_dir / "config.yaml").write_text("")
+        cfg = load_config(tmp_path)
+        dc = RunSkillConfig()
+        assert cfg.run_skill.timeout == dc.timeout
+        assert cfg.run_skill.stale_threshold == dc.stale_threshold
+        assert cfg.run_skill.idle_output_timeout == dc.idle_output_timeout
+        assert cfg.run_skill.exit_after_stop_delay_ms == dc.exit_after_stop_delay_ms
+        assert cfg.run_skill.natural_exit_grace_seconds == dc.natural_exit_grace_seconds
+        assert cfg.run_skill.max_suppression_seconds == dc.max_suppression_seconds
+        assert cfg.run_skill.completion_drain_timeout == dc.completion_drain_timeout

--- a/tests/config/test_defaults.py
+++ b/tests/config/test_defaults.py
@@ -47,24 +47,6 @@ class TestGraceWindowCoherence:
         assert cfg.natural_exit_grace_seconds == 3.0
 
 
-class TestIdleOutputTimeoutCoherence:
-    """idle_output_timeout default must pass _timeout_coherence_gate."""
-
-    def test_default_idle_output_timeout_passes_coherence_gate(self, tmp_path) -> None:
-        """Pure-default config emits zero *_coherence log warnings."""
-        config_dir = tmp_path / ".autoskillit"
-        config_dir.mkdir()
-        (config_dir / "config.yaml").write_text("")
-        with structlog.testing.capture_logs() as cap_logs:
-            cfg = load_config(tmp_path)
-        coherence_warnings = [e for e in cap_logs if "_coherence" in e.get("event", "")]
-        assert coherence_warnings == [], (
-            f"Default config emitted coherence warnings: {coherence_warnings}. "
-            "Update the relevant default in defaults.yaml and _config_dataclasses.py."
-        )
-        assert cfg.run_skill.idle_output_timeout == 1000
-
-
 class TestAllDefaultsPassAllGates:
     """Universal guard: shipped defaults must produce zero validation warnings."""
 

--- a/tests/config/test_timeout_coherence.py
+++ b/tests/config/test_timeout_coherence.py
@@ -57,15 +57,3 @@ class TestTimeoutCoherenceGate:
         assert not any(
             "idle_output_timeout_coherence" in entry.get("event", "") for entry in cap_logs
         )
-
-    def test_default_config_does_not_trigger_coherence_warning(self, tmp_path):
-        """With default config (idle_output_timeout=1000), coherence gate is silent."""
-        config_dir = tmp_path / ".autoskillit"
-        config_dir.mkdir()
-        (config_dir / "config.yaml").write_text("")
-        with structlog.testing.capture_logs() as cap_logs:
-            cfg = load_config(tmp_path)
-        assert cfg.run_skill.idle_output_timeout == 1000
-        assert not any(
-            "idle_output_timeout_coherence" in entry.get("event", "") for entry in cap_logs
-        )

--- a/tests/config/test_timeout_coherence.py
+++ b/tests/config/test_timeout_coherence.py
@@ -58,14 +58,14 @@ class TestTimeoutCoherenceGate:
             "idle_output_timeout_coherence" in entry.get("event", "") for entry in cap_logs
         )
 
-    def test_default_config_triggers_coherence_warning(self, tmp_path):
-        """With default config (idle_output_timeout=600), coherence gate warns about
-        wait_for_merge_queue (default 600s, recipe override 900s)."""
+    def test_default_config_does_not_trigger_coherence_warning(self, tmp_path):
+        """With default config (idle_output_timeout=1000), coherence gate is silent."""
         config_dir = tmp_path / ".autoskillit"
         config_dir.mkdir()
         (config_dir / "config.yaml").write_text("")
         with structlog.testing.capture_logs() as cap_logs:
             cfg = load_config(tmp_path)
-        # Default idle_output_timeout is 600
-        assert cfg.run_skill.idle_output_timeout == 600
-        assert any("idle_output_timeout_coherence" in entry.get("event", "") for entry in cap_logs)
+        assert cfg.run_skill.idle_output_timeout == 1000
+        assert not any(
+            "idle_output_timeout_coherence" in entry.get("event", "") for entry in cap_logs
+        )

--- a/tests/execution/test_headless_path_validation.py
+++ b/tests/execution/test_headless_path_validation.py
@@ -874,7 +874,7 @@ class TestHeadlessExecutorIdleOutputTimeout:
             "/investigate foo", cwd="/tmp", ctx=tool_ctx, idle_output_timeout=None
         )
         _, _cwd, _timeout, kwargs = tool_ctx.runner.call_args_list[0]
-        assert kwargs["idle_output_timeout"] == 600.0
+        assert kwargs["idle_output_timeout"] == 1000.0
 
 
 def _ndjson_with_write(result_text: str, file_paths: list[str], session_id: str = "test-session"):

--- a/tests/server/test_tools_dispatch.py
+++ b/tests/server/test_tools_dispatch.py
@@ -834,12 +834,12 @@ class TestDispatchFoodTruckIdleTimeout:
     async def test_dispatch_food_truck_idle_timeout_overrides_config_default(
         self, tool_ctx, monkeypatch
     ):
-        """Explicit idle_output_timeout=0 overrides the config default of 600."""
+        """Explicit idle_output_timeout=0 overrides the config default of 1000."""
         from autoskillit.server.tools.tools_execution import dispatch_food_truck
 
         self._setup_dispatch(tool_ctx)
-        # Config idle_output_timeout is 600 (default from RunSkillConfig)
-        assert tool_ctx.config.run_skill.idle_output_timeout == 600
+        # Config idle_output_timeout is 1000 (default from RunSkillConfig)
+        assert tool_ctx.config.run_skill.idle_output_timeout == 1000
 
         await dispatch_food_truck(
             recipe="test-recipe",


### PR DESCRIPTION
## Summary

The `idle_output_timeout` default (600) violates its own coherence gate (warns at <= 900), causing every stock installation to emit a spurious warning. The root cause is not the wrong number — it is the absence of a structural invariant enforcing that shipped defaults satisfy all validation gates. The fix addresses three layers: (1) the immediate default value, (2) the missing "pure defaults are clean" test, and (3) a universal meta-test that prevents any future default-vs-gate drift across the entire config system.

## Architecture Impact

This change has no architecture impact — no structural components were added, removed, or modified.

Closes #2007

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260506-092619-447250/.autoskillit/temp/rectify/rectify_idle_output_timeout_coherence_gate_2026-05-06_092700.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate | claude-sonnet-4-6 | 1 | 111 | 10.6k | 489.9k | 54.1k | 50 | 57.2k | 4m 26s |
| rectify | claude-sonnet-4-6 | 1 | 49 | 9.5k | 602.6k | 86.5k | 139 | 71.4k | 7m 16s |
| dry_walkthrough | claude-opus-4-6 | 1 | 38 | 7.7k | 882.1k | 58.5k | 66 | 45.7k | 4m 10s |
| implement | MiniMax-M2.7-highspeed | 1 | 613.7k | 8.1k | 941.5k | 47.6k | 85 | 61.5k | 3m 9s |
| prepare_pr | MiniMax-M2.7-highspeed | 1 | 71.6k | 4.7k | 184.0k | 26.7k | 19 | 15.2k | 1m 26s |
| compose_pr | MiniMax-M2.7-highspeed | 1 | 85.3k | 1.8k | 290.7k | 26.7k | 22 | 15.0k | 57s |
| review_pr | claude-opus-4-6 | 1 | 38 | 21.2k | 474.0k | 60.5k | 31 | 47.9k | 4m 36s |
| resolve_review | claude-opus-4-6 | 1 | 57 | 6.4k | 1.0M | 60.6k | 44 | 47.6k | 4m 56s |
| **Total** | | | 770.9k | 70.0k | 4.9M | 86.5k | | 361.4k | 30m 59s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 88 | 10698.7 | 698.4 | 92.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 30 | 34598.9 | 1586.0 | 213.5 |
| **Total** | **118** | 41548.8 | 3062.8 | 593.6 |