### PR TITLE
[FIX] Fleet Tool Visibility Breach — Kitchen Tag Exposes Fleet-Only Tools

### DIFF
--- a/docs/execution/tool-access.md
+++ b/docs/execution/tool-access.md
@@ -65,7 +65,7 @@ Server startup sequence:
    → reveals test_check only (the sole headless-tagged tool)
 
 4. When open_kitchen is called:
-   ctx.enable_components(tags={"kitchen"})   → reveals all 48 kitchen tools
+   ctx.enable_components(tags={"kitchen"})   → reveals kitchen-tagged tools (not fleet)
    ctx.disable_components(tags={subset})     → re-hides each disabled subset
    (session-level enable overwrites server-level disable, so re-disabling is required)
 ```

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -9,8 +9,9 @@ dry-walkthrough, worktree, test, and PR-review skills. See
 
 ### How many MCP tools does it expose?
 
-48. Four are free range (`open_kitchen`, `close_kitchen`, `disable_quota_guard`, `reload_session`) and 43 are
-kitchen-tagged (gated behind `open_kitchen`). One tool, `test_check`,
+52. Four are free range (`open_kitchen`, `close_kitchen`, `disable_quota_guard`, `reload_session`) and 37 are
+kitchen-tagged (gated behind `open_kitchen`). Eleven fleet tools are revealed
+only in fleet sessions via the `fleet`/`fleet-dispatch` tags. One tool, `test_check`,
 carries the `headless` tag and is revealed only inside headless sessions.
 See [execution/tool-access.md](execution/tool-access.md).
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -9,10 +9,11 @@ dry-walkthrough, worktree, test, and PR-review skills. See
 
 ### How many MCP tools does it expose?
 
-52. Four are free range (`open_kitchen`, `close_kitchen`, `disable_quota_guard`, `reload_session`) and 37 are
-kitchen-tagged (gated behind `open_kitchen`). Eleven fleet tools are revealed
-only in fleet sessions via the `fleet`/`fleet-dispatch` tags. One tool, `test_check`,
-carries the `headless` tag and is revealed only inside headless sessions.
+52. Fifteen are free-range: four always-visible (`open_kitchen`, `close_kitchen`,
+`disable_quota_guard`, `reload_session`) plus eleven fleet tools revealed only in
+fleet sessions via the `fleet`/`fleet-dispatch` tags. The remaining 37 are
+kitchen-tagged (gated behind `open_kitchen`). One kitchen tool, `test_check`,
+also carries the `headless` tag and is revealed only inside headless sessions.
 See [execution/tool-access.md](execution/tool-access.md).
 
 ### How many bundled skills are there?
@@ -33,7 +34,7 @@ and `research`. See [recipes/overview.md](recipes/overview.md).
 
 ### Why are some MCP tools hidden by default?
 
-To keep normal Claude Code sessions clean. The 43 kitchen-tagged tools only
+To keep normal Claude Code sessions clean. The 37 kitchen-tagged tools only
 appear after the orchestrator calls `open_kitchen`. See
 [execution/tool-access.md](execution/tool-access.md).
 

--- a/src/autoskillit/hooks/guards/fleet_dispatch_guard.py
+++ b/src/autoskillit/hooks/guards/fleet_dispatch_guard.py
@@ -33,6 +33,22 @@ def main() -> None:
     if os.environ.get("AUTOSKILLIT_HEADLESS") != "1":
         sys.exit(0)
 
+    session_type = os.environ.get("AUTOSKILLIT_SESSION_TYPE", "")
+    if session_type and session_type != "fleet":
+        payload = json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": (
+                        f"dispatch_food_truck requires fleet session (current: {session_type})"
+                    ),
+                }
+            }
+        )
+        sys.stdout.write(payload + "\n")
+        sys.exit(0)
+
     # Headless: check if this is dispatch_food_truck
     tool_name: str = data.get("tool_name", "")
     tool = tool_name.split("__")[-1]

--- a/src/autoskillit/server/tools/tools_clone.py
+++ b/src/autoskillit/server/tools/tools_clone.py
@@ -365,7 +365,7 @@ async def register_clone_status(
         return json.dumps({"registered": "false", "reason": f"{type(exc).__name__}: {exc}"})
 
 
-@mcp.tool(tags={"autoskillit", "kitchen", "clone", "fleet"}, annotations={"readOnlyHint": True})
+@mcp.tool(tags={"autoskillit", "clone", "fleet"}, annotations={"readOnlyHint": True})
 @track_response_size("batch_cleanup_clones")
 async def batch_cleanup_clones(
     registry_path: str = "",

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -29,6 +29,7 @@ from autoskillit.server import mcp
 from autoskillit.server._guards import (
     _check_dry_walkthrough,
     _require_enabled,
+    _require_fleet,
     _require_orchestrator_or_higher,
     _validate_skill_command,
 )
@@ -677,7 +678,7 @@ async def run_skill(
 
 
 @mcp.tool(
-    tags={"autoskillit", "kitchen", "kitchen-core", "fleet"},
+    tags={"autoskillit", "kitchen-core", "fleet"},
     annotations={"readOnlyHint": True},
 )
 @track_response_size("dispatch_food_truck")
@@ -716,6 +717,8 @@ async def dispatch_food_truck(
     """
     if (gate := _require_enabled()) is not None:
         return gate
+    if (fleet_gate := _require_fleet("dispatch_food_truck")) is not None:
+        return fleet_gate
 
     try:
         # Feature guard: config authority check independent of MCP visibility state.
@@ -733,12 +736,6 @@ async def dispatch_food_truck(
             return fleet_error(
                 FleetErrorCode.FLEET_FEATURE_DISABLED,
                 "Fleet feature is disabled. Set features.experimental_enabled: true to enable.",
-            )
-
-        if os.environ.get("AUTOSKILLIT_HEADLESS") == "1":
-            return fleet_error(
-                FleetErrorCode.FLEET_HARD_REFUSAL_HEADLESS,
-                "dispatch_food_truck cannot be called from headless sessions.",
             )
 
         campaign_state_path_str = os.environ.get("AUTOSKILLIT_CAMPAIGN_STATE_PATH")
@@ -829,7 +826,7 @@ async def dispatch_food_truck(
 
 
 @mcp.tool(
-    tags={"autoskillit", "kitchen", "kitchen-core", "fleet"},
+    tags={"autoskillit", "kitchen-core", "fleet"},
     annotations={"readOnlyHint": True},
 )
 @track_response_size("record_gate_dispatch")
@@ -852,6 +849,8 @@ async def record_gate_dispatch(
     """
     if (gate := _require_enabled()) is not None:
         return gate
+    if (fleet_gate := _require_fleet("record_gate_dispatch")) is not None:
+        return fleet_gate
 
     try:
         from autoskillit.core import FleetErrorCode, fleet_error, is_feature_enabled

--- a/src/autoskillit/server/tools/tools_github.py
+++ b/src/autoskillit/server/tools/tools_github.py
@@ -32,9 +32,7 @@ _FINGERPRINT_START = "---bug-fingerprint---"
 _FINGERPRINT_END = "---/bug-fingerprint---"
 
 
-@mcp.tool(
-    tags={"autoskillit", "kitchen", "github", "fleet-dispatch"}, annotations={"readOnlyHint": True}
-)
+@mcp.tool(tags={"autoskillit", "github", "fleet-dispatch"}, annotations={"readOnlyHint": True})
 @track_response_size("fetch_github_issue")
 async def fetch_github_issue(
     issue_url: str,
@@ -113,9 +111,7 @@ async def fetch_github_issue(
         return json.dumps({"success": False, "error": str(exc)})
 
 
-@mcp.tool(
-    tags={"autoskillit", "kitchen", "github", "fleet-dispatch"}, annotations={"readOnlyHint": True}
-)
+@mcp.tool(tags={"autoskillit", "github", "fleet-dispatch"}, annotations={"readOnlyHint": True})
 @track_response_size("get_issue_title")
 async def get_issue_title(issue_url: str) -> str:
     """Fetch only the title and slug for a GitHub issue — no body, no comments.

--- a/src/autoskillit/server/tools/tools_recipe.py
+++ b/src/autoskillit/server/tools/tools_recipe.py
@@ -22,7 +22,7 @@ logger = get_logger(__name__)
 
 
 @mcp.tool(
-    tags={"autoskillit", "kitchen", "kitchen-core", "fleet-dispatch"},
+    tags={"autoskillit", "kitchen-core", "fleet-dispatch"},
     annotations={"readOnlyHint": True},
 )
 @track_response_size("list_recipes")
@@ -60,7 +60,7 @@ async def list_recipes() -> str:
 
 
 @mcp.tool(
-    tags={"autoskillit", "kitchen", "kitchen-core", "fleet-dispatch"},
+    tags={"autoskillit", "kitchen-core", "fleet-dispatch"},
     annotations={"readOnlyHint": True},
     meta={"anthropic/maxResultSizeChars": 100_000},
 )

--- a/src/autoskillit/server/tools/tools_status.py
+++ b/src/autoskillit/server/tools/tools_status.py
@@ -76,7 +76,7 @@ async def kitchen_status() -> str:
 
 
 @mcp.tool(
-    tags={"autoskillit", "kitchen", "kitchen-core", "fleet"},
+    tags={"autoskillit", "kitchen-core", "fleet"},
     annotations={"readOnlyHint": True},
 )
 @track_response_size("get_pipeline_report")
@@ -148,7 +148,7 @@ def _merge_wall_clock_seconds(steps: list[dict], timing_report: list[dict]) -> l
 
 
 @mcp.tool(
-    tags={"autoskillit", "kitchen", "kitchen-core", "telemetry", "fleet"},
+    tags={"autoskillit", "kitchen-core", "telemetry", "fleet"},
     annotations={"readOnlyHint": True},
 )
 @track_response_size("get_token_summary")
@@ -223,7 +223,7 @@ async def get_token_summary(clear: bool = False, format: str = "json", order_id:
 
 
 @mcp.tool(
-    tags={"autoskillit", "kitchen", "kitchen-core", "telemetry", "fleet"},
+    tags={"autoskillit", "kitchen-core", "telemetry", "fleet"},
     annotations={"readOnlyHint": True},
 )
 @track_response_size("get_timing_summary")
@@ -377,7 +377,7 @@ def _read_quota_events(log_root: Path, n: int) -> tuple[list[dict], int]:
 
 
 @mcp.tool(
-    tags={"autoskillit", "kitchen", "kitchen-core", "telemetry", "fleet"},
+    tags={"autoskillit", "kitchen-core", "telemetry", "fleet"},
     annotations={"readOnlyHint": True},
 )
 @track_response_size("get_quota_events")

--- a/tests/arch/test_transforms_hygiene.py
+++ b/tests/arch/test_transforms_hygiene.py
@@ -362,6 +362,40 @@ def test_tool_decorators_enforce_tag_partition():
     )
 
 
+def test_tool_tags_are_literal_sets():
+    """Every @mcp.tool(tags=...) must use a set literal, not a variable or expression."""
+    tools_dir = _SRC_ROOT / "server" / "tools"
+    non_literals = []
+
+    for path in sorted(tools_dir.glob("tools_*.py")):
+        source = path.read_text()
+        tree = ast.parse(source, filename=str(path))
+
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+
+            for decorator in node.decorator_list:
+                if not (
+                    isinstance(decorator, ast.Call)
+                    and isinstance(decorator.func, ast.Attribute)
+                    and decorator.func.attr == "tool"
+                ):
+                    continue
+
+                for kw in decorator.keywords:
+                    if kw.arg == "tags" and not isinstance(kw.value, ast.Set):
+                        non_literals.append(
+                            f"{path.name}:{node.lineno} {node.name}"
+                            f" → tags is {type(kw.value).__name__}, not Set"
+                        )
+
+    assert not non_literals, (
+        "Non-literal tags values in @mcp.tool() decorators (use set literals):\n"
+        + "\n".join(f"  {v}" for v in non_literals)
+    )
+
+
 def test_fleet_tools_carry_required_subset_tag():
     """Every FLEET_TOOLS entry must have 'fleet' in its decorator tags.
 

--- a/tests/arch/test_transforms_hygiene.py
+++ b/tests/arch/test_transforms_hygiene.py
@@ -310,3 +310,129 @@ def test_session_type_visibility_uses_known_tags():
         "Tag string literals in _session_type.py not in canonical sets:\n"
         + "\n".join(f"  {v}" for v in literal_tag_violations)
     )
+
+
+def test_tool_decorators_enforce_tag_partition():
+    """No @mcp.tool() decorator may carry both 'kitchen' and 'fleet'/'fleet-dispatch'."""
+    tools_dir = _SRC_ROOT / "server" / "tools"
+    violations = []
+
+    for path in sorted(tools_dir.glob("tools_*.py")):
+        source = path.read_text()
+        tree = ast.parse(source, filename=str(path))
+
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+
+            func_name = node.name
+
+            for decorator in node.decorator_list:
+                if not (
+                    isinstance(decorator, ast.Call)
+                    and isinstance(decorator.func, ast.Attribute)
+                    and decorator.func.attr == "tool"
+                ):
+                    continue
+
+                tags_value = None
+                for kw in decorator.keywords:
+                    if kw.arg == "tags":
+                        tags_value = kw.value
+                        break
+
+                if tags_value is None or not isinstance(tags_value, ast.Set):
+                    continue
+
+                tag_set = {
+                    elt.value
+                    for elt in tags_value.elts
+                    if isinstance(elt, ast.Constant) and isinstance(elt.value, str)
+                }
+
+                has_kitchen = "kitchen" in tag_set
+                has_fleet_subset = bool({"fleet", "fleet-dispatch"} & tag_set)
+
+                if has_kitchen and has_fleet_subset:
+                    violations.append(f"{path.name}:{node.lineno} {func_name} → {sorted(tag_set)}")
+
+    assert not violations, (
+        "Tag partition violations (kitchen + fleet/fleet-dispatch on same tool):\n"
+        + "\n".join(f"  {v}" for v in violations)
+    )
+
+
+def test_fleet_tools_carry_required_subset_tag():
+    """Every FLEET_TOOLS entry must have 'fleet' in its decorator tags.
+
+    Every FLEET_DISPATCH_TOOLS entry must have 'fleet-dispatch' in its decorator tags.
+    """
+    from autoskillit.core import FLEET_DISPATCH_TOOLS, FLEET_TOOLS
+
+    tools_dir = _SRC_ROOT / "server" / "tools"
+    name_to_tags: dict[str, set[str]] = {}
+
+    for path in sorted(tools_dir.glob("tools_*.py")):
+        source = path.read_text()
+        tree = ast.parse(source, filename=str(path))
+
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+
+            func_name = node.name
+
+            for decorator in node.decorator_list:
+                if not (
+                    isinstance(decorator, ast.Call)
+                    and isinstance(decorator.func, ast.Attribute)
+                    and decorator.func.attr == "tool"
+                ):
+                    continue
+
+                tags_value = None
+                for kw in decorator.keywords:
+                    if kw.arg == "tags":
+                        tags_value = kw.value
+                        break
+
+                if tags_value is None or not isinstance(tags_value, ast.Set):
+                    continue
+
+                tag_set = {
+                    elt.value
+                    for elt in tags_value.elts
+                    if isinstance(elt, ast.Constant) and isinstance(elt.value, str)
+                }
+                name_to_tags[func_name] = tag_set
+
+    missing_fleet = []
+    for tool in FLEET_TOOLS:
+        if tool not in name_to_tags or "fleet" not in name_to_tags[tool]:
+            missing_fleet.append(tool)
+
+    missing_fd = []
+    for tool in FLEET_DISPATCH_TOOLS:
+        if tool not in name_to_tags or "fleet-dispatch" not in name_to_tags[tool]:
+            missing_fd.append(tool)
+
+    assert not missing_fleet, f"FLEET_TOOLS missing 'fleet' tag: {sorted(missing_fleet)}"
+    assert not missing_fd, (
+        f"FLEET_DISPATCH_TOOLS missing 'fleet-dispatch' tag: {sorted(missing_fd)}"
+    )
+
+
+def test_fleet_tools_do_not_carry_kitchen_umbrella_tag():
+    """TOOL_SUBSET_TAGS entries for fleet/fleet-dispatch tools must not include 'kitchen'."""
+    from autoskillit.core import FLEET_DISPATCH_TOOLS, FLEET_TOOLS, TOOL_SUBSET_TAGS
+
+    violations = []
+    for tool in FLEET_TOOLS | FLEET_DISPATCH_TOOLS:
+        tags = TOOL_SUBSET_TAGS.get(tool, frozenset())
+        if "kitchen" in tags:
+            violations.append(f"{tool} → {sorted(tags)}")
+
+    assert not violations, (
+        "Fleet/fleet-dispatch tools with 'kitchen' in TOOL_SUBSET_TAGS:\n"
+        + "\n".join(f"  {v}" for v in violations)
+    )

--- a/tests/docs/test_doc_counts.py
+++ b/tests/docs/test_doc_counts.py
@@ -199,14 +199,14 @@ def _count_semantic_rule_files() -> int:
 # ----- tests ------------------------------------------------------------------
 
 
-def test_kitchen_tagged_tool_count_is_48() -> None:
+def test_kitchen_tagged_tool_count_is_37() -> None:
     count = _count_kitchen_tools()
-    assert count == 48, f"Expected 48 kitchen-tagged tools; found {count}"
+    assert count == 37, f"Expected 37 kitchen-tagged tools; found {count}"
 
 
-def test_free_range_tool_count_is_4() -> None:
-    assert _count_free_range_tools() == 4, (
-        f"Expected 4 free-range tools; found {_count_free_range_tools()}"
+def test_free_range_tool_count_is_15() -> None:
+    assert _count_free_range_tools() == 15, (
+        f"Expected 15 free-range tools; found {_count_free_range_tools()}"
     )
 
 

--- a/tests/fleet/test_gate_state_persistence.py
+++ b/tests/fleet/test_gate_state_persistence.py
@@ -36,6 +36,10 @@ def _init_state(tmp_path: Path, *names: str) -> Path:
 
 
 class TestRecordGateDispatch:
+    @pytest.fixture(autouse=True)
+    def _set_fleet_session(self, monkeypatch):
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
+
     @pytest.mark.anyio
     async def test_record_gate_dispatch_writes_success(self, tool_ctx, monkeypatch, tmp_path):
         sp = _init_state(tmp_path, "gate-check", "phase-one")
@@ -124,6 +128,10 @@ class TestRecordGateDispatch:
 
 
 class TestDispatchFoodTruckCampaignState:
+    @pytest.fixture(autouse=True)
+    def _set_fleet_session(self, monkeypatch):
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
+
     @pytest.mark.anyio
     async def test_dispatch_food_truck_updates_campaign_state_on_success(
         self, tool_ctx, monkeypatch, tmp_path

--- a/tests/fleet/test_pack_enforcement.py
+++ b/tests/fleet/test_pack_enforcement.py
@@ -218,7 +218,7 @@ class TestSyntheticPackScenarios:
     ):
         from fastmcp.client import Client
 
-        from autoskillit.core import GATED_TOOLS
+        from autoskillit.core import FLEET_DISPATCH_TOOLS, FLEET_TOOLS, GATED_TOOLS
         from autoskillit.server import _apply_session_type_visibility, mcp
 
         monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "orchestrator")
@@ -230,7 +230,7 @@ class TestSyntheticPackScenarios:
             tools = await client.list_tools()
         visible = {t.name for t in tools}
 
-        for name in GATED_TOOLS:
+        for name in GATED_TOOLS - FLEET_TOOLS - FLEET_DISPATCH_TOOLS:
             assert name in visible, (
                 f"{name} should be visible under full kitchen fallback (empty L3_TOOL_TAGS)"
             )

--- a/tests/infra/test_fleet_dispatch_guard.py
+++ b/tests/infra/test_fleet_dispatch_guard.py
@@ -68,7 +68,8 @@ def test_guard_denies_headless_regardless_of_session_type(session_type):
     )
     response = json.loads(out)
     assert response["hookSpecificOutput"]["permissionDecision"] == "deny"
-    assert "headless" in response["hookSpecificOutput"]["permissionDecisionReason"].lower()
+    reason = response["hookSpecificOutput"]["permissionDecisionReason"].lower()
+    assert "headless" in reason or "fleet session" in reason
 
 
 # --- M7: Unrelated tool passes through ---

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -134,7 +134,7 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # tools_status.py — mcp_data dict
     ("src/autoskillit/server/tools/tools_status.py", 495),
     # tools_github.py — bug report dict
-    ("src/autoskillit/server/tools/tools_github.py", 308),
+    ("src/autoskillit/server/tools/tools_github.py", 304),
     # _hooks.py — settings.json dict (co-owned with Claude CLI)
     ("src/autoskillit/cli/_hooks.py", 24),
     # _init_helpers.py — ~/.claude.json (co-owned)

--- a/tests/server/test_headless_session.py
+++ b/tests/server/test_headless_session.py
@@ -22,4 +22,27 @@ async def test_mcp_enable_kitchen_reveals_gated_tools(kitchen_enabled) -> None:
 
     async with Client(mcp) as client:
         tool_names = {t.name for t in await client.list_tools()}
-    assert GATED_TOOLS.issubset(tool_names), f"Missing gated tools: {GATED_TOOLS - tool_names}"
+    from autoskillit.core import FLEET_DISPATCH_TOOLS, FLEET_TOOLS
+
+    non_fleet_gated = GATED_TOOLS - FLEET_TOOLS - FLEET_DISPATCH_TOOLS
+    assert non_fleet_gated.issubset(tool_names), (
+        f"Missing gated tools: {non_fleet_gated - tool_names}"
+    )
+
+
+@pytest.mark.anyio
+async def test_mcp_enable_kitchen_does_not_reveal_fleet_tools(kitchen_enabled) -> None:
+    """mcp.enable(tags={'kitchen'}) must NOT reveal fleet-only tools to the client.
+
+    Fleet tools carry kitchen-core (visible to L2/L3 via tag enable) but are NOT
+    revealed when only the 'kitchen' umbrella tag is enabled.
+    """
+    from fastmcp.client import Client
+
+    from autoskillit.core import FLEET_DISPATCH_TOOLS, FLEET_TOOLS
+    from autoskillit.server import mcp
+
+    async with Client(mcp) as client:
+        tool_names = {t.name for t in await client.list_tools()}
+    fleet_visible = (FLEET_TOOLS | FLEET_DISPATCH_TOOLS) & tool_names
+    assert fleet_visible == set(), f"Fleet tools visible after kitchen enable: {fleet_visible}"

--- a/tests/server/test_server_init_session_visibility.py
+++ b/tests/server/test_server_init_session_visibility.py
@@ -94,8 +94,8 @@ class TestSessionTypeVisibility:
             assert name not in tool_names, f"{name} should be hidden for fleet session"
 
     @pytest.mark.anyio
-    async def test_fleet_tools_retain_kitchen_tag(self, monkeypatch):
-        """Fleet-tagged tools must still carry the kitchen tag."""
+    async def test_fleet_tools_do_not_carry_kitchen_tag(self, monkeypatch):
+        """Fleet-tagged tools must NOT carry the kitchen tag (tag partition)."""
         from autoskillit.core import FLEET_TOOLS
         from autoskillit.server import _apply_session_type_visibility, mcp
 
@@ -106,7 +106,7 @@ class TestSessionTypeVisibility:
         for name in FLEET_TOOLS:
             tool = all_tools.get(name)
             assert tool is not None, f"{name} not registered"
-            assert "kitchen" in tool.tags, f"{name} must retain kitchen tag"
+            assert "kitchen" not in tool.tags, f"{name} must not carry kitchen tag"
             assert "fleet" in tool.tags, f"{name} must have fleet tag"
             assert "autoskillit" in tool.tags, f"{name} must retain autoskillit tag"
 
@@ -129,7 +129,7 @@ class TestSessionTypeVisibility:
 
     @pytest.mark.anyio
     async def test_orchestrator_headless_enables_kitchen_tag(self, monkeypatch):
-        from autoskillit.core import GATED_TOOLS
+        from autoskillit.core import FLEET_DISPATCH_TOOLS, FLEET_TOOLS, GATED_TOOLS
         from autoskillit.server import _apply_session_type_visibility, mcp
 
         monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "orchestrator")
@@ -138,7 +138,7 @@ class TestSessionTypeVisibility:
 
         tools = list(await mcp.list_tools())
         tool_names = {t.name for t in tools}
-        for name in GATED_TOOLS:
+        for name in GATED_TOOLS - FLEET_TOOLS - FLEET_DISPATCH_TOOLS:
             assert name in tool_names, f"{name} should be visible for orchestrator+headless"
 
     @pytest.mark.anyio
@@ -212,7 +212,7 @@ class TestSessionTypeVisibility:
     @pytest.mark.anyio
     async def test_food_truck_without_tool_tags_sees_full_kitchen(self, monkeypatch):
         """ORCHESTRATOR+HEADLESS without L3_TOOL_TAGS falls back to full kitchen."""
-        from autoskillit.core import GATED_TOOLS
+        from autoskillit.core import FLEET_DISPATCH_TOOLS, FLEET_TOOLS, GATED_TOOLS
         from autoskillit.server import _apply_session_type_visibility, mcp
 
         monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "orchestrator")
@@ -223,7 +223,7 @@ class TestSessionTypeVisibility:
         tools = list(await mcp.list_tools())
         tool_names = {t.name for t in tools}
 
-        for name in GATED_TOOLS:
+        for name in GATED_TOOLS - FLEET_TOOLS - FLEET_DISPATCH_TOOLS:
             assert name in tool_names
 
     @pytest.mark.anyio

--- a/tests/server/test_server_tool_registration.py
+++ b/tests/server/test_server_tool_registration.py
@@ -40,6 +40,9 @@ class TestToolRegistration:
 
         from autoskillit.server import mcp
 
+        mcp.enable(tags={"fleet"})
+        mcp.enable(tags={"fleet-dispatch"})
+
         async with Client(mcp) as client:
             all_tools = await client.list_tools()
         tool_names = {t.name for t in all_tools}
@@ -130,12 +133,16 @@ class TestToolRegistration:
 
     @pytest.mark.anyio
     async def test_kitchen_tools_have_autoskillit_and_kitchen_tags(self, kitchen_enabled):
-        """Every tool in GATED_TOOLS carries both 'autoskillit' and 'kitchen' tags."""
+        """Every non-fleet tool in GATED_TOOLS carries both 'autoskillit' and 'kitchen' tags."""
+        from autoskillit.core import FLEET_DISPATCH_TOOLS, FLEET_TOOLS
         from autoskillit.pipeline.gate import GATED_TOOLS
         from autoskillit.server import mcp
 
+        mcp.enable(tags={"fleet"})
+        mcp.enable(tags={"fleet-dispatch"})
+
         all_tools = {t.name: t for t in await mcp.list_tools()}
-        for name in GATED_TOOLS:
+        for name in GATED_TOOLS - FLEET_TOOLS - FLEET_DISPATCH_TOOLS:
             tool = all_tools.get(name)
             assert tool is not None, f"Gated tool '{name}' not registered on server"
             assert "autoskillit" in tool.tags, f"Gated tool '{name}' missing 'autoskillit' tag"
@@ -214,6 +221,9 @@ class TestToolRegistration:
         from autoskillit.core.types import HEADLESS_TOOLS, PACK_REGISTRY
         from autoskillit.pipeline.gate import GATED_TOOLS
         from autoskillit.server import mcp
+
+        mcp.enable(tags={"fleet"})
+        mcp.enable(tags={"fleet-dispatch"})
 
         all_gated = GATED_TOOLS | HEADLESS_TOOLS
         pack_tags = frozenset(PACK_REGISTRY.keys())
@@ -589,6 +599,9 @@ class TestToolSchemas:
         from fastmcp.client import Client
 
         from autoskillit.server import mcp
+
+        mcp.enable(tags={"fleet"})
+        mcp.enable(tags={"fleet-dispatch"})
 
         async with Client(mcp) as client:
             tools = await client.list_tools()

--- a/tests/server/test_tools_dispatch.py
+++ b/tests/server/test_tools_dispatch.py
@@ -114,6 +114,7 @@ class TestDispatchFoodTruckGates:
 
         from autoskillit.server.tools.tools_execution import dispatch_food_truck
 
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
         # Gate is open (fleet session already booted), env var absent
         # Only config file has fleet disabled
         monkeypatch.delenv("AUTOSKILLIT_FEATURES__FLEET", raising=False)
@@ -728,6 +729,7 @@ async def test_dispatch_food_truck_tool_passes_resume_session_id_to_executor(
     """dispatch_food_truck MCP tool forwards resume_session_id all the way to the executor."""
     from autoskillit.server.tools.tools_execution import dispatch_food_truck
 
+    monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
     tool_ctx.fleet_lock = FleetSemaphore(max_concurrent=1)
     repo = InMemoryRecipeRepository()
     recipe_info = _make_recipe_info("test-recipe")
@@ -793,6 +795,10 @@ async def test_dispatch_food_truck_marketplace_install_succeeds(tool_ctx_marketp
 
 class TestDispatchFoodTruckIdleTimeout:
     """Tests for idle_output_timeout passthrough through the dispatch chain."""
+
+    @pytest.fixture(autouse=True)
+    def _set_fleet_session(self, monkeypatch):
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
 
     def _setup_dispatch(self, tool_ctx):
         """Wire tool_ctx for a standard dispatch with InMemoryHeadlessExecutor."""

--- a/tests/server/test_tools_dispatch.py
+++ b/tests/server/test_tools_dispatch.py
@@ -54,7 +54,18 @@ class TestDispatchFoodTruckGates:
 
         result = json.loads(await dispatch_food_truck(recipe="r", task="t"))
         assert result["success"] is False
-        assert result["error"] == "fleet_hard_refusal_headless"
+        assert result["subtype"] == "headless_error"
+
+    @pytest.mark.anyio
+    async def test_dispatch_food_truck_requires_fleet_session_type(self, tool_ctx, monkeypatch):
+        """Non-fleet session type → headless_error, even for interactive callers."""
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "orchestrator")
+        monkeypatch.delenv("AUTOSKILLIT_HEADLESS", raising=False)
+        from autoskillit.server.tools.tools_execution import dispatch_food_truck
+
+        result = json.loads(await dispatch_food_truck(recipe="r", task="t"))
+        assert result["success"] is False
+        assert result["subtype"] == "headless_error"
 
     @pytest.mark.anyio
     async def test_dispatch_food_truck_requires_kitchen_open(self, tool_ctx, monkeypatch):

--- a/tests/server/test_tools_dispatch_halt.py
+++ b/tests/server/test_tools_dispatch_halt.py
@@ -35,6 +35,10 @@ def _write_campaign_state(state_path: Path, dispatches: list[dict]) -> None:
 
 
 class TestDispatchFoodTruckHaltEnforcement:
+    @pytest.fixture(autouse=True)
+    def _set_fleet_session(self, monkeypatch):
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
+
     @pytest.mark.anyio
     async def test_dispatch_refuses_after_failure_when_halt_enabled(
         self, tool_ctx, monkeypatch, tmp_path
@@ -192,6 +196,10 @@ class TestDispatchFoodTruckHaltEnforcement:
 
 
 class TestDispatchFoodTruckRetryOnFailure:
+    @pytest.fixture(autouse=True)
+    def _set_fleet_session(self, monkeypatch):
+        monkeypatch.setenv("AUTOSKILLIT_SESSION_TYPE", "fleet")
+
     @pytest.mark.anyio
     async def test_dispatch_resets_and_proceeds_when_retrying_failed_dispatch(
         self, tool_ctx, monkeypatch, tmp_path

--- a/tests/server/test_tools_recipe.py
+++ b/tests/server/test_tools_recipe.py
@@ -282,6 +282,9 @@ class TestDocstringSemantics:
 
         from autoskillit.server import mcp
 
+        mcp.enable(tags={"fleet"})
+        mcp.enable(tags={"fleet-dispatch"})
+
         async with Client(mcp) as client:
             tools = await client.list_tools()
         return {t.name: t for t in tools}
@@ -426,6 +429,9 @@ class TestLoadSkillScriptFailurePredicates:
         from fastmcp.client import Client
 
         from autoskillit.server import mcp
+
+        mcp.enable(tags={"fleet"})
+        mcp.enable(tags={"fleet-dispatch"})
 
         async with Client(mcp) as client:
             tools = await client.list_tools()


### PR DESCRIPTION
## Summary

Fleet-only tools (7 `FLEET_TOOLS` + 4 `FLEET_DISPATCH_TOOLS`) carry both the `kitchen` umbrella tag and their subset tag (`fleet`/`fleet-dispatch`). When `open_kitchen` enables `{kitchen}`, all 11 tools become visible to any interactive session. The `_redisable_subsets` mechanism cannot undo this because FastMCP's union visibility model keeps the tools visible via `kitchen-core`. The fix removes the `kitchen` tag from all 11 tool decorators, adds `_require_fleet()` runtime guards to the two dangerous handlers, hardens the `fleet_dispatch_guard.py` hook, and establishes six layers of defense-in-depth testing that make this class of bug structurally impossible.

## Requirements

### REQ-TAG-001: Remove `kitchen` tag from fleet/fleet-dispatch tool decorators

Remove `"kitchen"` from the `tags=` set on all 11 affected tools:

**FLEET_TOOLS (7):**
- `tools_execution.py:680` (`dispatch_food_truck`): `→ {"autoskillit", "kitchen-core", "fleet"}`
- `tools_execution.py:832` (`record_gate_dispatch`): `→ {"autoskillit", "kitchen-core", "fleet"}`
- `tools_status.py:79` (`get_pipeline_report`): `→ {"autoskillit", "kitchen-core", "fleet"}`
- `tools_status.py:151` (`get_token_summary`): `→ {"autoskillit", "kitchen-core", "telemetry", "fleet"}`
- `tools_status.py:226` (`get_timing_summary`): `→ {"autoskillit", "kitchen-core", "telemetry", "fleet"}`
- `tools_status.py:380` (`get_quota_events`): `→ {"autoskillit", "kitchen-core", "telemetry", "fleet"}`
- `tools_clone.py:368` (`batch_cleanup_clones`): `→ {"autoskillit", "clone", "fleet"}`

**FLEET_DISPATCH_TOOLS (4):**
- `tools_recipe.py:25` (`list_recipes`): `→ {"autoskillit", "kitchen-core", "fleet-dispatch"}`
- `tools_recipe.py:63` (`load_recipe`): `→ {"autoskillit", "kitchen-core", "fleet-dispatch"}`
- `tools_github.py:36` (`fetch_github_issue`): `→ {"autoskillit", "github", "fleet-dispatch"}`
- `tools_github.py:117` (`get_issue_title`): `→ {"autoskillit", "github", "fleet-dispatch"}`

### REQ-TAG-002: Add `_require_fleet()` guard to `dispatch_food_truck` and `record_gate_dispatch`

Add `_require_fleet` to handlers. Insert guard call after `_require_enabled()` and before the feature check. Remove the old inline `AUTOSKILLIT_HEADLESS == "1"` check from `dispatch_food_truck`. Add the guard to `record_gate_dispatch` after `_require_enabled()`.

### REQ-TAG-003: Harden `fleet_dispatch_guard.py` hook

Add session-type check as defense-in-depth alongside the existing headless check. After the existing `AUTOSKILLIT_HEADLESS == "1"` check, add session-type validation that denies non-fleet sessions.

### REQ-TAG-004: AST-level tag partition tests

Add to `tests/arch/test_transforms_hygiene.py`:
- `test_tool_decorators_enforce_tag_partition` — AST scan: no tool has kitchen + fleet/fleet-dispatch
- `test_fleet_tools_carry_required_subset_tag` — AST scan: fleet tools must carry fleet/fleet-dispatch
- `test_fleet_tools_do_not_carry_kitchen_umbrella_tag` — Verify `TOOL_SUBSET_TAGS` entries omit "kitchen"

### REQ-TAG-005: Negative visibility and MCP client integration tests

- `test_open_kitchen_does_not_reveal_fleet_tools` — After `open_kitchen` in interactive session, verify no `FLEET_TOOLS` tool is visible
- `test_mcp_enable_kitchen_does_not_reveal_fleet_tools` — Use `fastmcp.Client` + `kitchen_enabled` fixture, assert fleet tools absent from `list_tools()`

### REQ-TAG-006: Session-type guard test

Add `test_dispatch_food_truck_requires_fleet_session_type` to `TestDispatchFoodTruckGates`: Set `SESSION_TYPE=orchestrator`, call `dispatch_food_truck`, assert `result["success"] is False` and `result["subtype"] == "headless_error"`.

### REQ-TAG-007: Update existing tests

- Update `test_mcp_enable_kitchen_reveals_gated_tools` — Change assertion to exclude `FLEET_TOOLS` and `FLEET_DISPATCH_TOOLS`
- Update `test_dispatch_food_truck_hard_refusal_headless` — Change assertion from `result["error"] == "fleet_hard_refusal_headless"` to `result["subtype"] == "headless_error"`

Closes #2008

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260506-093743-054546/.autoskillit/temp/make-plan/fleet_tool_visibility_breach_plan_2026-05-06_094500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 3.7k | 11.0k | 565.7k | 78.3k | 86 | 61.3k | 5m 35s |
| verify | claude-sonnet-4-6 | 1 | 38 | 22.5k | 454.2k | 87.4k | 113 | 94.8k | 13m 11s |
| implement | MiniMax-M2.7-highspeed | 1 | 1.7M | 13.5k | 1.8M | 64.7k | 152 | 101.3k | 6m 29s |
| prepare_pr | MiniMax-M2.7-highspeed | 1 | 143.6k | 5.6k | 237.3k | 26.7k | 27 | 15.2k | 1m 39s |
| compose_pr | MiniMax-M2.7-highspeed | 1 | 62.8k | 2.5k | 210.6k | 26.7k | 16 | 15.0k | 50s |
| review_pr | claude-sonnet-4-6 | 1 | 76 | 35.9k | 345.0k | 76.4k | 31 | 73.4k | 8m 31s |
| resolve_review | claude-opus-4-6 | 1 | 53 | 20.4k | 1.0M | 78.5k | 81 | 66.0k | 8m 39s |
| **Total** | | | 1.9M | 111.4k | 4.7M | 87.4k | | 427.0k | 44m 58s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 217 | 8499.6 | 466.9 | 62.4 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 45 | 22440.7 | 1467.2 | 453.3 |
| **Total** | **262** | 17812.8 | 1629.7 | 425.4 |