### PR TITLE
P4-C1 Unit Tests for Research Sub-Recipe YAML Structure

### DIFF
--- a/tests/recipe/CLAUDE.md
+++ b/tests/recipe/CLAUDE.md
@@ -74,6 +74,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_research_recipe_diag.py` | Tests for research recipe diagnostic output |
 | `test_research_review_recipe.py` | Tests for research-review sub-recipe structure |
 | `test_research_stage_data_step.py` | Tests for stage-data step in research recipes |
+| `test_research_sub_recipes.py` | Tests for research sub-recipe YAML structure (design, implement, review, archive) |
 | `test_resolve_ci_routing_invariant.py` | Tests for CI routing invariant in resolve steps |
 | `test_review_loop_routing_integration.py` | Integration tests for review loop routing |
 | `test_rule_decomposition.py` | Tests for semantic rule decomposition structure |

--- a/tests/recipe/test_research_sub_recipes.py
+++ b/tests/recipe/test_research_sub_recipes.py
@@ -1,0 +1,111 @@
+"""Tests for research sub-recipe YAML structure (design, implement, review, archive).
+
+All tests skip when the sub-recipe YAML files do not yet exist in recipes/sub-recipes/.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.recipe.io import builtin_sub_recipes_dir, load_recipe
+from autoskillit.recipe.validator import validate_recipe
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+
+class TestResearchDesignSubRecipe:
+    @pytest.fixture(scope="class")
+    def recipe(self):
+        path = builtin_sub_recipes_dir() / "research-design.yaml"
+        if not path.exists():
+            pytest.skip(f"{path.name} not yet created")
+        return load_recipe(path)
+
+    def test_has_required_ingredients(self, recipe) -> None:
+        assert "task" in recipe.ingredients
+        assert recipe.ingredients["task"].required is True
+        assert "source_dir" in recipe.ingredients
+        assert recipe.ingredients["source_dir"].required is True
+
+    def test_has_terminal_step(self, recipe) -> None:
+        assert any(s.action == "stop" for s in recipe.steps.values())
+
+    def test_key_steps_capture_required_outputs(self, recipe) -> None:
+        assert any("experiment_plan" in s.capture for s in recipe.steps.values())
+        assert any("visualization_plan_path" in s.capture for s in recipe.steps.values())
+
+    def test_validates_cleanly(self, recipe) -> None:
+        assert validate_recipe(recipe) == []
+
+
+class TestResearchImplementSubRecipe:
+    @pytest.fixture(scope="class")
+    def recipe(self):
+        path = builtin_sub_recipes_dir() / "research-implement.yaml"
+        if not path.exists():
+            pytest.skip(f"{path.name} not yet created")
+        return load_recipe(path)
+
+    def test_has_required_ingredients(self, recipe) -> None:
+        assert "task" in recipe.ingredients
+        assert recipe.ingredients["task"].required is True
+        assert "source_dir" in recipe.ingredients
+        assert recipe.ingredients["source_dir"].required is True
+
+    def test_has_terminal_step(self, recipe) -> None:
+        assert any(s.action == "stop" for s in recipe.steps.values())
+
+    def test_key_steps_capture_required_outputs(self, recipe) -> None:
+        assert any("worktree_path" in s.capture for s in recipe.steps.values())
+        assert any("research_dir" in s.capture for s in recipe.steps.values())
+
+    def test_validates_cleanly(self, recipe) -> None:
+        assert validate_recipe(recipe) == []
+
+
+class TestResearchReviewSubRecipe:
+    @pytest.fixture(scope="class")
+    def recipe(self):
+        path = builtin_sub_recipes_dir() / "research-review.yaml"
+        if not path.exists():
+            pytest.skip(f"{path.name} not yet created")
+        return load_recipe(path)
+
+    def test_has_required_ingredients(self, recipe) -> None:
+        assert "task" in recipe.ingredients
+        assert recipe.ingredients["task"].required is True
+        assert "source_dir" in recipe.ingredients
+        assert recipe.ingredients["source_dir"].required is True
+
+    def test_has_terminal_step(self, recipe) -> None:
+        assert any(s.action == "stop" for s in recipe.steps.values())
+
+    def test_key_steps_capture_required_outputs(self, recipe) -> None:
+        assert any("review_verdict" in s.capture for s in recipe.steps.values())
+
+    def test_validates_cleanly(self, recipe) -> None:
+        assert validate_recipe(recipe) == []
+
+
+class TestResearchArchiveSubRecipe:
+    @pytest.fixture(scope="class")
+    def recipe(self):
+        path = builtin_sub_recipes_dir() / "research-archive.yaml"
+        if not path.exists():
+            pytest.skip(f"{path.name} not yet created")
+        return load_recipe(path)
+
+    def test_has_required_ingredients(self, recipe) -> None:
+        assert "worktree_path" in recipe.ingredients
+        assert recipe.ingredients["worktree_path"].required is True
+        assert "research_dir" in recipe.ingredients
+        assert recipe.ingredients["research_dir"].required is True
+
+    def test_has_terminal_step(self, recipe) -> None:
+        assert any(s.action == "stop" for s in recipe.steps.values())
+
+    def test_key_steps_capture_required_outputs(self, recipe) -> None:
+        assert any("archive_tag" in s.capture for s in recipe.steps.values())
+
+    def test_validates_cleanly(self, recipe) -> None:
+        assert validate_recipe(recipe) == []


### PR DESCRIPTION
## Summary

Create `tests/recipe/test_research_sub_recipes.py` — a forward-looking test file that validates the YAML structure of four research sub-recipes (design, implement, review, archive) expected to appear in `builtin_sub_recipes_dir()` (`recipes/sub-recipes/`). Each test class has a class-scoped fixture that skips when the YAML doesn't exist yet, plus four test methods asserting required ingredients, terminal steps, capture keys, and clean validation. All tests will skip in the current codebase since the sub-recipe YAMLs haven't been created.

## Changed Files

### New (★):
tests/recipe/test_research_sub_recipes.py

### Modified (●):
tests/recipe/CLAUDE.md

Closes #1712

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-1712-20260506-095105-552813/.autoskillit/temp/make-plan/p4_c1_unit_tests_research_sub_recipes_plan_2026-05-06_095600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 46 | 6.7k | 458.8k | 63.2k | 48 | 52.8k | 3m 15s |
| verify | claude-sonnet-4-6 | 1 | 29 | 8.9k | 427.1k | 55.8k | 64 | 42.7k | 4m 20s |
| implement | MiniMax-M2.7-highspeed | 1 | 604.5k | 6.3k | 744.4k | 26.7k | 71 | 41.9k | 5m 54s |
| prepare_pr | MiniMax-M2.7-highspeed | 1 | 84.3k | 3.5k | 210.7k | 26.7k | 25 | 15.2k | 1m 18s |
| compose_pr | MiniMax-M2.7-highspeed | 1 | 35.0k | 1.2k | 157.3k | 26.7k | 14 | 14.9k | 33s |
| review_pr | claude-sonnet-4-6 | 1 | 108 | 17.7k | 471.8k | 53.4k | 35 | 40.8k | 4m 20s |
| resolve_review | claude-sonnet-4-6 | 1 | 181 | 16.5k | 1.1M | 66.3k | 58 | 54.0k | 5m 8s |
| **Total** | | | 724.1k | 60.7k | 3.5M | 66.3k | | 262.3k | 24m 51s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 112 | 6646.8 | 373.8 | 56.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 0 | — | — | — |
| **Total** | **112** | 31435.2 | 2341.8 | 542.3 |