### PR TITLE
Replace Tier-C Selection with Methodology-Detection Router

### DIFF
--- a/src/autoskillit/recipe/CLAUDE.md
+++ b/src/autoskillit/recipe/CLAUDE.md
@@ -19,6 +19,7 @@ Sub-package: rules/ (see rules/CLAUDE.md).
 | `diagrams.py` | Flow diagram generation + staleness detection |
 | `experiment_type_registry.py` | `ExperimentTypeSpec`, `load_all_experiment_types` |
 | `methodology_tradition_registry.py` | `MethodologyTraditionSpec`, `load_all_methodology_traditions`, `get_methodology_tradition_by_name`, `is_out_of_scope_tradition` |
+| `methodology_tradition_router.py` | `TraditionRouterResult`, `UnionRuleDef`, `classify_methodology` — two-stage Tier-C router |
 | `registry.py` | `RuleFinding`, `RuleSpec`, `semantic_rule` decorator |
 | `repository.py` | `RecipeRepository` implementation |
 | `_analysis.py` | `ValidationContext` + `make_validation_context` |

--- a/src/autoskillit/recipe/__init__.py
+++ b/src/autoskillit/recipe/__init__.py
@@ -65,6 +65,11 @@ from autoskillit.recipe.methodology_tradition_registry import (  # noqa: E402
     is_out_of_scope_tradition,
     load_all_methodology_traditions,
 )
+from autoskillit.recipe.methodology_tradition_router import (  # noqa: E402
+    TraditionRouterResult,
+    UnionRuleDef,
+    classify_methodology,
+)
 from autoskillit.recipe.repository import DefaultRecipeRepository  # noqa: E402
 from autoskillit.recipe.rules import rules_actions as _rules_actions  # noqa: E402 F401
 from autoskillit.recipe.rules import rules_blocks as _rules_blocks  # noqa: E402 F401
@@ -178,6 +183,9 @@ __all__ = [
     "get_methodology_tradition_by_name",
     "is_out_of_scope_tradition",
     "load_all_methodology_traditions",
+    "TraditionRouterResult",
+    "UnionRuleDef",
+    "classify_methodology",
     "check_rerun_detection",
     "find_prior_runs",
     "CampaignDispatch",

--- a/src/autoskillit/recipe/__init__.py
+++ b/src/autoskillit/recipe/__init__.py
@@ -183,6 +183,7 @@ __all__ = [
     "get_methodology_tradition_by_name",
     "is_out_of_scope_tradition",
     "load_all_methodology_traditions",
+    # --- methodology tradition router ---
     "TraditionRouterResult",
     "UnionRuleDef",
     "classify_methodology",

--- a/src/autoskillit/recipe/__init__.py
+++ b/src/autoskillit/recipe/__init__.py
@@ -187,6 +187,7 @@ __all__ = [
     "TraditionRouterResult",
     "UnionRuleDef",
     "classify_methodology",
+    # --- rerun detection ---
     "check_rerun_detection",
     "find_prior_runs",
     "CampaignDispatch",

--- a/src/autoskillit/recipe/methodology_tradition_router.py
+++ b/src/autoskillit/recipe/methodology_tradition_router.py
@@ -26,9 +26,9 @@ class TraditionRouterResult:
     """Result from two-stage methodology classification."""
 
     primary_tradition: str | None
-    applied_union_rules: list[str]
+    applied_union_rules: tuple[str, ...]
     precedence_trace: str
-    candidate_set: list[str]
+    candidate_set: tuple[str, ...]
 
 
 _WORD_BOUNDARY_RE_CACHE: dict[str, re.Pattern[str]] = {}
@@ -55,15 +55,15 @@ def _count_keyword_matches(text_lower: str, spec: MethodologyTraditionSpec) -> i
 def _try_union_rules(
     candidate_names: set[str],
     union_rules: list[UnionRuleDef],
-) -> tuple[str | None, list[str], str]:
+) -> tuple[str | None, tuple[str, ...], str]:
     for rule in union_rules:
         if candidate_names.issubset(rule.member_traditions):
             return (
                 rule.resolved_tradition,
-                [rule.name],
+                (rule.name,),
                 f"stage2_tiebreak_by_rule_{rule.name}",
             )
-    return None, [], ""
+    return None, (), ""
 
 
 def classify_methodology(
@@ -86,21 +86,22 @@ def classify_methodology(
         if hits >= min_keyword_matches:
             scored.append((spec, hits))
 
+    # Lower priority number = higher precedence (priority=1 outranks priority=999)
     scored.sort(key=lambda pair: (pair[0].priority, pair[0].name))
-    candidate_set = [spec.name for spec, _ in scored]
+    candidate_set = tuple(spec.name for spec, _ in scored)
 
     if len(candidate_set) == 0:
         return TraditionRouterResult(
             primary_tradition=None,
-            applied_union_rules=[],
+            applied_union_rules=(),
             precedence_trace="stage1_no_match_fallback",
-            candidate_set=[],
+            candidate_set=(),
         )
 
     if len(candidate_set) == 1:
         return TraditionRouterResult(
             primary_tradition=candidate_set[0],
-            applied_union_rules=[],
+            applied_union_rules=(),
             precedence_trace="stage1_single_match",
             candidate_set=candidate_set,
         )
@@ -119,14 +120,14 @@ def classify_methodology(
     if resolve_by_priority:
         return TraditionRouterResult(
             primary_tradition=candidate_set[0],
-            applied_union_rules=[],
+            applied_union_rules=(),
             precedence_trace="stage1_multi_match_resolved_by_priority",
             candidate_set=candidate_set,
         )
 
     return TraditionRouterResult(
         primary_tradition=None,
-        applied_union_rules=[],
+        applied_union_rules=(),
         precedence_trace="stage1_multi_match",
         candidate_set=candidate_set,
     )

--- a/src/autoskillit/recipe/methodology_tradition_router.py
+++ b/src/autoskillit/recipe/methodology_tradition_router.py
@@ -1,0 +1,130 @@
+"""Two-stage methodology tradition router for Tier-C lens selection."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from autoskillit.recipe.methodology_tradition_registry import (
+    MethodologyTraditionSpec,
+    load_all_methodology_traditions,
+)
+
+
+@dataclass(frozen=True)
+class UnionRuleDef:
+    """Resolves multi-match ambiguity when candidate_set ⊆ member_traditions."""
+
+    name: str
+    member_traditions: frozenset[str]
+    resolved_tradition: str
+
+
+@dataclass(frozen=True)
+class TraditionRouterResult:
+    """Result from two-stage methodology classification."""
+
+    primary_tradition: str | None
+    applied_union_rules: list[str]
+    precedence_trace: str
+    candidate_set: list[str]
+
+
+_WORD_BOUNDARY_RE_CACHE: dict[str, re.Pattern[str]] = {}
+
+
+def _keyword_pattern(keyword: str) -> re.Pattern[str]:
+    if keyword not in _WORD_BOUNDARY_RE_CACHE:
+        escaped = re.escape(keyword.lower())
+        _WORD_BOUNDARY_RE_CACHE[keyword] = re.compile(
+            r"(?<!\w)" + escaped + r"(?!\w)",
+            re.IGNORECASE,
+        )
+    return _WORD_BOUNDARY_RE_CACHE[keyword]
+
+
+def _count_keyword_matches(text_lower: str, spec: MethodologyTraditionSpec) -> int:
+    count = 0
+    for kw in spec.detection_keywords:
+        if _keyword_pattern(kw).search(text_lower):
+            count += 1
+    return count
+
+
+def _try_union_rules(
+    candidate_names: set[str],
+    union_rules: list[UnionRuleDef],
+) -> tuple[str | None, list[str], str]:
+    for rule in union_rules:
+        if candidate_names.issubset(rule.member_traditions):
+            return (
+                rule.resolved_tradition,
+                [rule.name],
+                f"stage2_tiebreak_by_rule_{rule.name}",
+            )
+    return None, [], ""
+
+
+def classify_methodology(
+    plan_text: str,
+    project_dir: Path | None = None,
+    *,
+    min_keyword_matches: int = 2,
+    union_rules: list[UnionRuleDef] | None = None,
+    resolve_by_priority: bool = False,
+) -> TraditionRouterResult:
+    """Stage-1 deterministic keyword classification of plan methodology."""
+    traditions = load_all_methodology_traditions(project_dir)
+    text_lower = plan_text.lower()
+
+    scored: list[tuple[MethodologyTraditionSpec, int]] = []
+    for spec in traditions:
+        hits = _count_keyword_matches(text_lower, spec)
+        if hits >= min_keyword_matches:
+            scored.append((spec, hits))
+
+    scored.sort(key=lambda pair: (pair[0].priority, pair[0].name))
+    candidate_set = [spec.name for spec, _ in scored]
+
+    if len(candidate_set) == 0:
+        return TraditionRouterResult(
+            primary_tradition=None,
+            applied_union_rules=[],
+            precedence_trace="stage1_no_match_fallback",
+            candidate_set=[],
+        )
+
+    if len(candidate_set) == 1:
+        return TraditionRouterResult(
+            primary_tradition=candidate_set[0],
+            applied_union_rules=[],
+            precedence_trace="stage1_single_match",
+            candidate_set=candidate_set,
+        )
+
+    effective_rules = union_rules or []
+    candidate_names = set(candidate_set)
+    resolved, applied, trace = _try_union_rules(candidate_names, effective_rules)
+    if resolved is not None:
+        return TraditionRouterResult(
+            primary_tradition=resolved,
+            applied_union_rules=applied,
+            precedence_trace=trace,
+            candidate_set=candidate_set,
+        )
+
+    if resolve_by_priority:
+        return TraditionRouterResult(
+            primary_tradition=candidate_set[0],
+            applied_union_rules=[],
+            precedence_trace="stage1_multi_match_resolved_by_priority",
+            candidate_set=candidate_set,
+        )
+
+    return TraditionRouterResult(
+        primary_tradition=None,
+        applied_union_rules=[],
+        precedence_trace="stage1_multi_match",
+        candidate_set=candidate_set,
+    )

--- a/src/autoskillit/recipe/methodology_tradition_router.py
+++ b/src/autoskillit/recipe/methodology_tradition_router.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+from functools import cache
 from pathlib import Path
 
 from autoskillit.recipe.methodology_tradition_registry import (
@@ -20,6 +21,14 @@ class UnionRuleDef:
     member_traditions: frozenset[str]
     resolved_tradition: str
 
+    def __post_init__(self) -> None:
+        if self.resolved_tradition not in self.member_traditions:
+            raise ValueError(
+                f"UnionRuleDef '{self.name}': resolved_tradition "
+                f"'{self.resolved_tradition}' must be a member of "
+                f"member_traditions {self.member_traditions}"
+            )
+
 
 @dataclass(frozen=True)
 class TraditionRouterResult:
@@ -31,23 +40,16 @@ class TraditionRouterResult:
     candidate_set: tuple[str, ...]
 
 
-_WORD_BOUNDARY_RE_CACHE: dict[str, re.Pattern[str]] = {}
-
-
+@cache
 def _keyword_pattern(keyword: str) -> re.Pattern[str]:
-    if keyword not in _WORD_BOUNDARY_RE_CACHE:
-        escaped = re.escape(keyword.lower())
-        _WORD_BOUNDARY_RE_CACHE[keyword] = re.compile(
-            r"(?<!\w)" + escaped + r"(?!\w)",
-            re.IGNORECASE,
-        )
-    return _WORD_BOUNDARY_RE_CACHE[keyword]
+    escaped = re.escape(keyword)
+    return re.compile(r"(?<!\w)" + escaped + r"(?!\w)", re.IGNORECASE)
 
 
-def _count_keyword_matches(text_lower: str, spec: MethodologyTraditionSpec) -> int:
+def _count_keyword_matches(text: str, spec: MethodologyTraditionSpec) -> int:
     count = 0
     for kw in spec.detection_keywords:
-        if _keyword_pattern(kw).search(text_lower):
+        if _keyword_pattern(kw.lower()).search(text):
             count += 1
     return count
 
@@ -78,11 +80,10 @@ def classify_methodology(
     if min_keyword_matches < 1:
         raise ValueError(f"min_keyword_matches must be >= 1, got {min_keyword_matches}")
     traditions = load_all_methodology_traditions(project_dir)
-    text_lower = plan_text.lower()
 
     scored: list[tuple[MethodologyTraditionSpec, int]] = []
     for spec in traditions:
-        hits = _count_keyword_matches(text_lower, spec)
+        hits = _count_keyword_matches(plan_text, spec)
         if hits >= min_keyword_matches:
             scored.append((spec, hits))
 

--- a/src/autoskillit/recipe/methodology_tradition_router.py
+++ b/src/autoskillit/recipe/methodology_tradition_router.py
@@ -75,6 +75,8 @@ def classify_methodology(
     resolve_by_priority: bool = False,
 ) -> TraditionRouterResult:
     """Stage-1 deterministic keyword classification of plan methodology."""
+    if min_keyword_matches < 1:
+        raise ValueError(f"min_keyword_matches must be >= 1, got {min_keyword_matches}")
     traditions = load_all_methodology_traditions(project_dir)
     text_lower = plan_text.lower()
 

--- a/src/autoskillit/skills_extended/plan-visualization/SKILL.md
+++ b/src/autoskillit/skills_extended/plan-visualization/SKILL.md
@@ -87,13 +87,43 @@ Experiment-type table (use when no override fires or to fill second Tier-B slot)
 
 Cap Tier B at 2 lenses total (overrides count toward this cap).
 
-**Tier C (0–1 based on target_domain):**
-| target_domain | Lens |
-|---|---|
-| nlp | vis-lens-methodology-norms |
-| cv | vis-lens-methodology-norms |
-| rl | vis-lens-temporal |
-| (others / general) | — (skip Tier C) |
+**Tier C (0–1 based on methodology tradition detection):**
+
+Tier C selects `vis-lens-methodology-norms` when the experiment plan's research
+methodology is identifiable from the 12 bundled methodology traditions.
+
+**Stage 1 — Deterministic keyword match:**
+1. Load all methodology traditions from `recipes/methodology-traditions/*.yaml`
+2. For each tradition, count how many of its `detection_keywords` appear in the
+   experiment plan text (case-insensitive, word-boundary matching)
+3. Build `candidate_set` = traditions with ≥ 2 keyword matches
+4. Branch on `len(candidate_set)`:
+
+| Candidates | Action | `precedence_trace` |
+|---|---|---|
+| 0 | Skip Tier C entirely | `stage1_no_match_fallback` |
+| 1 | Use that tradition as `primary_tradition` | `stage1_single_match` |
+| ≥ 2 | Proceed to Stage 2 | — |
+
+**Stage 2 — LLM arbitration (only when ≥ 2 candidates):**
+1. If any registered `UnionRuleDef` covers the candidate set, apply it:
+   select `resolved_tradition`, record rule name in `applied_union_rules`,
+   set `precedence_trace = "stage2_tiebreak_by_rule_{rule_name}"`
+2. Otherwise, select among candidates by analyzing the plan's primary research
+   question and methodology at temperature 0. Prefer the tradition whose
+   mandatory figures are most relevant to the stated research design.
+   Set `precedence_trace = "stage2_tiebreak_by_methodology_fit"`
+
+**Emit routing triple** (include as a fenced yaml block in the vis-lens context file):
+```yaml
+primary_tradition: <tradition_slug>
+applied_union_rules: [<rule_name>, ...]
+precedence_trace: "<trace_value>"
+candidate_set: [<tradition_slugs>]
+```
+
+When `primary_tradition` is set, add `vis-lens-methodology-norms` to `selected_lenses`
+and write the `tradition_slug` and routing triple into its context file (Step 2).
 
 Only add Tier C lens if it is not already in Tier A or Tier B.
 
@@ -133,6 +163,19 @@ Template for each context file:
 ## Expected Data Outputs
 {List the files or data structures the experiment will produce, from the plan's
 data_manifest or results/ section if available}
+```
+
+When the context file is for `vis-lens-methodology-norms`, append the following
+section to the template above:
+
+```
+## Methodology Tradition
+tradition_slug: {primary_tradition from Tier-C routing triple}
+routing_triple:
+  primary_tradition: {slug}
+  applied_union_rules: [{rules}]
+  precedence_trace: {trace}
+  candidate_set: [{candidates}]
 ```
 
 ### Step 3 — Run Vis-Lens Skills in Parallel

--- a/src/autoskillit/skills_extended/vis-lens-methodology-norms/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-methodology-norms/SKILL.md
@@ -29,6 +29,12 @@ hooks:
 - **experiment_plan_path** (optional positional arg 2) — Absolute path to the full
   experiment plan. If provided, read for complete experimental methodology and design.
   If omitted, locate the experiment plan by exploring the CWD.
+- **tradition_slug** (in context file) — When the context file contains a
+  `## Methodology Tradition` section with a `tradition_slug` field, use that
+  tradition directly instead of auto-detecting the ML sub-area in Step 0.
+  The tradition slug maps to a bundled tradition YAML in
+  `recipes/methodology-traditions/{slug}.yaml` which defines mandatory figures,
+  anti-patterns, and community norms for that research methodology.
 
 ## When to Use
 
@@ -84,12 +90,16 @@ overlays. The base lens should remain general enough to bootstrap any sub-area.
 
 ## Analysis Workflow
 
-### Step 0: Parse optional arguments and identify ML sub-area
+### Step 0: Parse optional arguments and identify methodology tradition
 
-If positional arg 1 (context_path) is provided and the file exists, read it to obtain
-IV/DV tables, H0/H1 hypotheses, controlled variables, and success criteria. If positional
-arg 2 (experiment_plan_path) is provided and exists, read the experiment plan for full
-methodology.
+If positional arg 1 (context_path) is provided and the file exists, read it. Check for
+a `## Methodology Tradition` section containing `tradition_slug`. If present:
+- Load the tradition YAML from `recipes/methodology-traditions/{tradition_slug}.yaml`
+- Use the tradition's `mandatory_figures`, `strongly_expected_figures`, and `anti_patterns`
+  as the norm source (instead of the ML Sub-Area table above)
+- Skip ML sub-area keyword detection — the tradition replaces it
+
+If no `tradition_slug` is provided, fall back to ML sub-area keyword detection:
 
 Identify the ML sub-area by scanning for keywords:
 - `classification`, `clf`, `precision`, `recall`, `confusion_matrix` → Supervised Classification

--- a/tests/recipe/CLAUDE.md
+++ b/tests/recipe/CLAUDE.md
@@ -48,6 +48,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_loader.py` | Tests for path-based recipe metadata utilities |
 | `test_make_campaign_output_schema.py` | Tests for make-campaign recipe output schema |
 | `test_methodology_tradition_registry.py` | Tests for `MethodologyTraditionSpec`, `load_all_methodology_traditions`, and `is_out_of_scope_tradition` |
+| `test_methodology_tradition_router.py` | Tests for `classify_methodology` two-stage Tier-C router: per-tradition classification, multi-match, union rules, determinism |
 | `test_merge_prs.py` | Tests for merge-prs recipe structure |
 | `test_merge_prs_queue_any.py` | Tests for merge-prs-queue (any strategy) recipe |
 | `test_merge_prs_queue_common.py` | Shared queue behavior tests across all queue-capable recipes |

--- a/tests/recipe/test_methodology_tradition_router.py
+++ b/tests/recipe/test_methodology_tradition_router.py
@@ -86,15 +86,15 @@ def test_single_tradition_detected(tradition_slug, plan_snippet):
     assert result.precedence_trace == "stage1_single_match"
     assert tradition_slug in result.candidate_set
     assert len(result.candidate_set) == 1
-    assert result.applied_union_rules == []
+    assert result.applied_union_rules == ()
 
 
 def test_no_tradition_detected():
     result = classify_methodology("This paper describes a novel deep learning architecture.")
     assert result.primary_tradition is None
     assert result.precedence_trace == "stage1_no_match_fallback"
-    assert result.candidate_set == []
-    assert result.applied_union_rules == []
+    assert result.candidate_set == ()
+    assert result.applied_union_rules == ()
 
 
 def test_multi_match_returns_candidates():
@@ -150,7 +150,7 @@ def test_union_rule_not_applied_when_no_member_match():
     result = classify_methodology(plan_text, union_rules=[rule])
     assert result.primary_tradition == "controlled_intervention"
     assert result.precedence_trace == "stage1_single_match"
-    assert result.applied_union_rules == []
+    assert result.applied_union_rules == ()
 
 
 def test_deterministic_classification():

--- a/tests/recipe/test_methodology_tradition_router.py
+++ b/tests/recipe/test_methodology_tradition_router.py
@@ -38,8 +38,8 @@ TRADITION_FIXTURES: list[tuple[str, str]] = [
     ),
     (
         "prediction_model_validation",
-        "External validation of the clinical prediction rule was performed using TRIPOD guidelines, "
-        "assessing calibration and discrimination via c-statistic.",
+        "External validation of the clinical prediction rule was performed "
+        "using TRIPOD guidelines, assessing calibration and discrimination via c-statistic.",
     ),
     (
         "simulation_modeling_tradition",
@@ -48,8 +48,8 @@ TRADITION_FIXTURES: list[tuple[str, str]] = [
     ),
     (
         "measurement_instrument_validation_tradition",
-        "Measurement properties were assessed using COSMIN criteria, evaluating internal consistency "
-        "via Cronbach alpha and test-retest reliability.",
+        "Measurement properties were assessed using COSMIN criteria, "
+        "evaluating internal consistency via Cronbach alpha and test-retest reliability.",
     ),
     (
         "quality_improvement",
@@ -99,7 +99,7 @@ def test_no_tradition_detected():
 
 def test_multi_match_returns_candidates():
     plan_text = (
-        "This systematic review and meta-analysis includes randomized controlled trials "
+        "This systematic review and meta-analysis includes randomized controlled trial "
         "following PRISMA and CONSORT guidelines with forest plots."
     )
     result = classify_methodology(plan_text)
@@ -112,7 +112,7 @@ def test_multi_match_returns_candidates():
 
 def test_multi_match_resolved_by_priority():
     plan_text = (
-        "This systematic review and meta-analysis includes randomized controlled trials "
+        "This systematic review and meta-analysis includes randomized controlled trial "
         "following PRISMA and CONSORT guidelines with forest plots."
     )
     result = classify_methodology(plan_text, resolve_by_priority=True)
@@ -128,7 +128,7 @@ def test_union_rule_applied():
         resolved_tradition="systematic_synthesis",
     )
     plan_text = (
-        "This systematic review and meta-analysis includes randomized controlled trials "
+        "This systematic review and meta-analysis includes randomized controlled trial "
         "following PRISMA and CONSORT guidelines."
     )
     result = classify_methodology(plan_text, union_rules=[rule])

--- a/tests/recipe/test_methodology_tradition_router.py
+++ b/tests/recipe/test_methodology_tradition_router.py
@@ -1,0 +1,198 @@
+"""Tests for methodology_tradition_router two-stage Tier-C router."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.recipe.methodology_tradition_registry import (
+    load_all_methodology_traditions,
+)
+from autoskillit.recipe.methodology_tradition_router import (
+    UnionRuleDef,
+    classify_methodology,
+)
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+
+TRADITION_FIXTURES: list[tuple[str, str]] = [
+    (
+        "controlled_intervention",
+        "This randomized controlled trial follows CONSORT guidelines with intent-to-treat "
+        "analysis across parallel group arms.",
+    ),
+    (
+        "systematic_synthesis",
+        "The systematic review employed PRISMA standards and performed meta-analysis with "
+        "forest plots to report pooled estimates across studies.",
+    ),
+    (
+        "observational_correlational",
+        "An observational cohort study was conducted using STROBE reporting guidelines to "
+        "examine the association between exposure and outcome.",
+    ),
+    (
+        "diagnostic_accuracy",
+        "The diagnostic accuracy study evaluated sensitivity and specificity using ROC curve "
+        "analysis following STARD recommendations.",
+    ),
+    (
+        "prediction_model_validation",
+        "External validation of the clinical prediction rule was performed using TRIPOD guidelines, "
+        "assessing calibration and discrimination via c-statistic.",
+    ),
+    (
+        "simulation_modeling_tradition",
+        "An agent-based model was developed following the ODD protocol, implemented in NetLogo "
+        "to simulate emergent behavior across parameter sweeps.",
+    ),
+    (
+        "measurement_instrument_validation_tradition",
+        "Measurement properties were assessed using COSMIN criteria, evaluating internal consistency "
+        "via Cronbach alpha and test-retest reliability.",
+    ),
+    (
+        "quality_improvement",
+        "The quality improvement initiative followed SQUIRE guidelines, employing PDSA cycles "
+        "to drive process improvement in clinical pathways.",
+    ),
+    (
+        "economic_evaluation",
+        "Cost-effectiveness analysis was conducted following CHEERS guidelines, calculating "
+        "ICER and QALY outcomes using Markov modeling.",
+    ),
+    (
+        "animal_preclinical",
+        "The animal study was designed per ARRIVE guidelines, with randomization of animals "
+        "and blinding of assessors to evaluate the intervention.",
+    ),
+    (
+        "qualitative_interpretive_tradition",
+        "Qualitative research was conducted following COREQ reporting standards, using "
+        "thematic analysis of semi-structured interview transcripts.",
+    ),
+    (
+        "method_comparison_benchmarking",
+        "The method comparison study established a SOTA baseline using leaderboard evaluation "
+        "and ablation study to benchmark performance against prior work.",
+    ),
+]
+
+
+@pytest.mark.parametrize("tradition_slug,plan_snippet", TRADITION_FIXTURES)
+def test_single_tradition_detected(tradition_slug, plan_snippet):
+    result = classify_methodology(plan_snippet)
+    assert result.primary_tradition == tradition_slug
+    assert result.precedence_trace == "stage1_single_match"
+    assert tradition_slug in result.candidate_set
+    assert len(result.candidate_set) == 1
+    assert result.applied_union_rules == []
+
+
+def test_no_tradition_detected():
+    result = classify_methodology("This paper describes a novel deep learning architecture.")
+    assert result.primary_tradition is None
+    assert result.precedence_trace == "stage1_no_match_fallback"
+    assert result.candidate_set == []
+    assert result.applied_union_rules == []
+
+
+def test_multi_match_returns_candidates():
+    plan_text = (
+        "This systematic review and meta-analysis includes randomized controlled trials "
+        "following PRISMA and CONSORT guidelines with forest plots."
+    )
+    result = classify_methodology(plan_text)
+    assert result.primary_tradition is None
+    assert result.precedence_trace == "stage1_multi_match"
+    assert len(result.candidate_set) >= 2
+    assert "controlled_intervention" in result.candidate_set
+    assert "systematic_synthesis" in result.candidate_set
+
+
+def test_multi_match_resolved_by_priority():
+    plan_text = (
+        "This systematic review and meta-analysis includes randomized controlled trials "
+        "following PRISMA and CONSORT guidelines with forest plots."
+    )
+    result = classify_methodology(plan_text, resolve_by_priority=True)
+    assert result.primary_tradition == "controlled_intervention"
+    assert result.precedence_trace == "stage1_multi_match_resolved_by_priority"
+    assert len(result.candidate_set) >= 2
+
+
+def test_union_rule_applied():
+    rule = UnionRuleDef(
+        name="rct_with_synthesis",
+        member_traditions=frozenset({"controlled_intervention", "systematic_synthesis"}),
+        resolved_tradition="systematic_synthesis",
+    )
+    plan_text = (
+        "This systematic review and meta-analysis includes randomized controlled trials "
+        "following PRISMA and CONSORT guidelines."
+    )
+    result = classify_methodology(plan_text, union_rules=[rule])
+    assert result.primary_tradition == "systematic_synthesis"
+    assert "rct_with_synthesis" in result.applied_union_rules
+    assert "stage2_tiebreak_by_rule_rct_with_synthesis" == result.precedence_trace
+
+
+def test_union_rule_not_applied_when_no_member_match():
+    rule = UnionRuleDef(
+        name="unrelated_rule",
+        member_traditions=frozenset({"economic_evaluation", "quality_improvement"}),
+        resolved_tradition="economic_evaluation",
+    )
+    plan_text = (
+        "This randomized controlled trial follows CONSORT guidelines "
+        "with intent-to-treat analysis."
+    )
+    result = classify_methodology(plan_text, union_rules=[rule])
+    assert result.primary_tradition == "controlled_intervention"
+    assert result.precedence_trace == "stage1_single_match"
+    assert result.applied_union_rules == []
+
+
+def test_deterministic_classification():
+    plan_text = (
+        "This randomized controlled trial follows CONSORT guidelines "
+        "with intent-to-treat analysis across parallel group arms."
+    )
+    results = [classify_methodology(plan_text) for _ in range(10)]
+    first = results[0]
+    for r in results[1:]:
+        assert r.primary_tradition == first.primary_tradition
+        assert r.precedence_trace == first.precedence_trace
+        assert r.candidate_set == first.candidate_set
+
+
+def test_candidate_set_sorted_by_priority():
+    plan_text = (
+        "This systematic review and meta-analysis includes randomized controlled trials "
+        "following PRISMA and CONSORT guidelines."
+    )
+    result = classify_methodology(plan_text)
+    traditions = load_all_methodology_traditions()
+    priority_map = {s.name: s.priority for s in traditions}
+    priorities = [priority_map[c] for c in result.candidate_set]
+    assert priorities == sorted(priorities)
+
+
+def test_high_threshold_eliminates_weak_matches():
+    plan_text = "The study used an RCT design with novel computational methods."
+    result_threshold_1 = classify_methodology(plan_text, min_keyword_matches=1)
+    result_threshold_3 = classify_methodology(plan_text, min_keyword_matches=3)
+    assert "controlled_intervention" in result_threshold_1.candidate_set
+    assert "controlled_intervention" not in result_threshold_3.candidate_set
+
+
+def test_case_insensitive_matching():
+    plan_text = "This RANDOMIZED CONTROLLED TRIAL follows consort guidelines with INTENT-TO-TREAT."
+    result = classify_methodology(plan_text)
+    assert result.primary_tradition == "controlled_intervention"
+
+
+def test_result_is_frozen():
+    result = classify_methodology("This randomized controlled trial uses CONSORT and ITT.")
+    with pytest.raises(AttributeError):
+        result.primary_tradition = "something_else"

--- a/tests/recipe/test_methodology_tradition_router.py
+++ b/tests/recipe/test_methodology_tradition_router.py
@@ -116,7 +116,11 @@ def test_multi_match_resolved_by_priority():
         "following PRISMA and CONSORT guidelines with forest plots."
     )
     result = classify_methodology(plan_text, resolve_by_priority=True)
-    assert result.primary_tradition == "controlled_intervention"
+    traditions = load_all_methodology_traditions()
+    priority_map = {s.name: s.priority for s in traditions}
+    # Winner is the tradition with the lowest priority number (highest precedence)
+    expected_winner = min(result.candidate_set, key=lambda n: (priority_map[n], n))
+    assert result.primary_tradition == expected_winner
     assert result.precedence_trace == "stage1_multi_match_resolved_by_priority"
     assert len(result.candidate_set) >= 2
 
@@ -175,7 +179,7 @@ def test_candidate_set_sorted_by_priority():
     traditions = load_all_methodology_traditions()
     priority_map = {s.name: s.priority for s in traditions}
     priorities = [priority_map[c] for c in result.candidate_set]
-    assert priorities == sorted(priorities)
+    assert priorities == sorted(priorities)  # ascending: lower number = higher precedence
 
 
 def test_high_threshold_eliminates_weak_matches():

--- a/tests/recipe/test_plan_visualization_step.py
+++ b/tests/recipe/test_plan_visualization_step.py
@@ -62,3 +62,26 @@ def test_plan_visualization_skill_dir_exists() -> None:
     """src/autoskillit/skills_extended/plan-visualization/SKILL.md must exist."""
     skill_path = pkg_root() / "skills_extended" / "plan-visualization" / "SKILL.md"
     assert skill_path.exists(), f"plan-visualization skill directory not found at {skill_path}"
+
+
+def test_tier_c_table_removed_from_skill_md() -> None:
+    """Old Tier-C target_domain routing table must be removed from SKILL.md."""
+    path = pkg_root() / "skills_extended" / "plan-visualization" / "SKILL.md"
+    content = path.read_text()
+    assert "| nlp | vis-lens-methodology-norms |" not in content
+    assert "| cv | vis-lens-methodology-norms |" not in content
+    assert "| rl | vis-lens-temporal |" not in content
+    tier_c_part = content.split("Tier C")[1] if "Tier C" in content else ""
+    assert "target_domain" not in tier_c_part
+
+
+def test_tier_c_methodology_router_present() -> None:
+    """New two-stage methodology router keywords must be present in SKILL.md."""
+    path = pkg_root() / "skills_extended" / "plan-visualization" / "SKILL.md"
+    content = path.read_text()
+    assert "detection_keywords" in content
+    assert "candidate_set" in content
+    assert "precedence_trace" in content
+    assert "stage1_single_match" in content
+    assert "stage1_no_match_fallback" in content
+    assert "stage2_tiebreak" in content

--- a/tests/recipe/test_plan_visualization_step.py
+++ b/tests/recipe/test_plan_visualization_step.py
@@ -71,8 +71,7 @@ def test_tier_c_table_removed_from_skill_md() -> None:
     assert "| nlp | vis-lens-methodology-norms |" not in content
     assert "| cv | vis-lens-methodology-norms |" not in content
     assert "| rl | vis-lens-temporal |" not in content
-    tier_c_part = content.split("Tier C")[1] if "Tier C" in content else ""
-    assert "target_domain" not in tier_c_part
+    assert "| target_domain |" not in content
 
 
 def test_tier_c_methodology_router_present() -> None:

--- a/tests/skills/test_vis_lens_structural.py
+++ b/tests/skills/test_vis_lens_structural.py
@@ -108,3 +108,9 @@ def test_frontmatter_activate_deps(slug: str) -> None:
     assert fm.get("activate_deps") == ["mermaid"], (
         f"vis-lens-{slug} frontmatter must have activate_deps: [mermaid]"
     )
+
+
+def test_methodology_norms_documents_tradition_slug() -> None:
+    """vis-lens-methodology-norms must document tradition_slug in context file handling."""
+    text = _read("methodology-norms")
+    assert "tradition_slug" in text


### PR DESCRIPTION
## Summary

Replace the static ML-domain-exclusive Tier-C routing table in `plan-visualization/SKILL.md` (lines 90–96) with a two-stage methodology-detection router. Stage 1 performs deterministic keyword matching against the 12 methodology traditions already landed in `recipes/methodology-traditions/`. Stage 2 invokes LLM arbitration only when multiple traditions match. A new Python module (`methodology_tradition_router.py`) in `recipe/` provides the deterministic classification engine; the SKILL.md prose instructs the LLM to follow the same algorithm and emit a structured routing triple. The vis-lens-methodology-norms skill is updated to accept a `tradition_slug` from the context file rather than auto-detecting ML sub-area.

## Requirements

## Acceptance criteria

- [ ] Old ML-sub-area Tier-C table removed from plan-visualization SKILL.md
- [ ] New router invokes `vis-lens-methodology-norms` with `tradition_slug` argument (from Stage-1 keyword match)
- [ ] When no tradition detects: Tier-C skipped cleanly (same as existing "default" behavior)
- [ ] Multi-match (≥2 candidates): Stage-2 LLM arbitration selects among candidates using §11.5.6 precedence; emits precedence_trace
- [ ] Multi-match that triggers a Work Item 4.5 union rule: structured output names the rule
- [ ] Tests cover Tier-C selection for each of the 12 traditions (12 fixture plans)
- [ ] Tests cover multi-match arbitration + trace emission
- [ ] Same plan classified deterministically across 10 consecutive runs at temperature 0
- [ ] `task test-check` passes

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-843-20260506-095103-789363/.autoskillit/temp/make-plan/replace_tier_c_methodology_router_plan_2026-05-06_095600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 2.5k | 17.3k | 1.0M | 82.1k | 113 | 69.0k | 8m 7s |
| verify | claude-opus-4-6 | 1 | 51 | 11.7k | 1.9M | 74.2k | 128 | 61.2k | 7m 19s |
| implement | MiniMax-M2.7-highspeed | 1 | 1.2M | 14.8k | 1.2M | 47.7k | 125 | 67.4k | 5m 25s |
| prepare_pr | MiniMax-M2.7-highspeed | 1 | 174.3k | 4.1k | 344.2k | 26.7k | 28 | 15.2k | 1m 22s |
| compose_pr | MiniMax-M2.7-highspeed | 1 | 46.4k | 1.4k | 184.0k | 26.7k | 15 | 15.0k | 37s |
| review_pr | claude-sonnet-4-6 | 3 | 310 | 97.7k | 1.6M | 81.5k | 113 | 196.5k | 21m 56s |
| resolve_review | claude-sonnet-4-6 | 3 | 741 | 56.7k | 4.8M | 83.6k | 215 | 182.7k | 23m 42s |
| **Total** | | | 1.5M | 203.8k | 11.1M | 83.6k | | 607.0k | 1h 8m |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 444 | 2697.0 | 151.9 | 33.3 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 75 | 64023.6 | 2436.0 | 756.3 |
| **Total** | **519** | 21370.7 | 1169.5 | 392.7 |