### PR TITLE
[FEATURE] User-Config Validation CLI

### DIFF
--- a/.autoskillit/.gitignore
+++ b/.autoskillit/.gitignore
@@ -3,3 +3,4 @@ temp/
 .onboarded
 sync_manifest.json
 test-filter-manifest.yaml
+validation-errors/

--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,6 @@ src/autoskillit/hooks/hooks.json
 
 # Runtime sync state — generated on each install, not source
 .autoskillit/sync_manifest.json
+.autoskillit/validation-errors/
 .secrets.yaml
 .autoskillit/.secrets.yaml

--- a/src/autoskillit/cli/CLAUDE.md
+++ b/src/autoskillit/cli/CLAUDE.md
@@ -24,6 +24,7 @@ session/ (see session/CLAUDE.md), ui/ (see ui/CLAUDE.md), update/ (see update/CL
 | `_features.py` | `features` subcommand group: list/status commands for feature gate inspection |
 | `_workspace.py` | Workspace clean helpers |
 | `_sessions.py` | `sessions analyze` CLI subcommand for cross-session DFG visualization |
+| `_validate.py` | `validate registries` subcommand for validating user-override registry files |
 
 ## Architecture Notes
 

--- a/src/autoskillit/cli/__init__.py
+++ b/src/autoskillit/cli/__init__.py
@@ -16,6 +16,7 @@ from autoskillit.cli._prompts import (
     _build_open_kitchen_prompt,
     _build_orchestrator_prompt,
 )
+from autoskillit.cli._validate import validate_registries
 from autoskillit.cli.app import (
     _generate_config_yaml,
     _prompt_test_command,
@@ -90,4 +91,5 @@ __all__ = [
     "workspace_app",
     "workspace_clean",
     "workspace_init",
+    "validate_registries",
 ]

--- a/src/autoskillit/cli/__init__.py
+++ b/src/autoskillit/cli/__init__.py
@@ -16,7 +16,7 @@ from autoskillit.cli._prompts import (
     _build_open_kitchen_prompt,
     _build_orchestrator_prompt,
 )
-from autoskillit.cli._validate import validate_registries
+from autoskillit.cli._validate import validate_app
 from autoskillit.cli.app import (
     _generate_config_yaml,
     _prompt_test_command,
@@ -91,5 +91,5 @@ __all__ = [
     "workspace_app",
     "workspace_clean",
     "workspace_init",
-    "validate_registries",
+    "validate_app",
 ]

--- a/src/autoskillit/cli/_validate.py
+++ b/src/autoskillit/cli/_validate.py
@@ -1,0 +1,377 @@
+"""Validate subapp: validate user-override registries."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from cyclopts import App
+
+from autoskillit.core import YAMLError, load_yaml, pkg_root
+from autoskillit.recipe.experiment_type_registry import (
+    BUNDLED_EXPERIMENT_TYPES_DIR,
+    ExperimentTypeSpec,
+    _load_types_from_dir,
+    _parse_experiment_type,
+)
+from autoskillit.recipe.methodology_tradition_registry import (
+    _parse_methodology_tradition,
+)
+
+validate_app = App(name="validate", help="Validation commands.")
+
+EXPECTED_SCHEMA_VERSION = "1.0"
+
+EXPERIMENT_TYPE_DIMENSION_KEYS = (
+    "clarity",
+    "methodological_rigor",
+    "external_validity",
+    "practical_significance",
+    "inferential_validity",
+    "ethical_compliance",
+    "reporting_completeness",
+    "transparency",
+)
+
+
+@dataclass
+class ValidationResult:
+    filename: str
+    path: Path
+    errors: list[str]
+    warnings: list[str]
+    spec_name: str | None = None
+    schema_version: str | None = None
+    priority: int | None = None
+    raw_content: str = ""
+
+    @property
+    def status(self) -> str:
+        if self.errors:
+            return "error"
+        if self.warnings:
+            return "warning"
+        return "valid"
+
+
+def _get_valid_lens_slugs() -> set[str]:
+    skills_extended = pkg_root() / "skills_extended"
+    if not skills_extended.is_dir():
+        return set()
+    return {d.name for d in skills_extended.iterdir() if d.is_dir() and "-lens-" in d.name}
+
+
+def _validate_experiment_type_file(path: Path, valid_lenses: set[str]) -> ValidationResult:
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    raw_content = path.read_text()
+
+    try:
+        data = load_yaml(path)
+    except YAMLError as e:
+        return ValidationResult(
+            filename=path.name,
+            path=path,
+            errors=[f"YAML parse error: {e}"],
+            warnings=[],
+            raw_content=raw_content,
+        )
+
+    try:
+        spec = _parse_experiment_type(data, path)
+    except (ValueError, TypeError) as e:
+        return ValidationResult(
+            filename=path.name,
+            path=path,
+            errors=[str(e)],
+            warnings=[],
+            raw_content=raw_content,
+        )
+
+    if spec.schema_version and spec.schema_version != EXPECTED_SCHEMA_VERSION:
+        warnings.append(
+            f"schema_version is '{spec.schema_version}', expected '{EXPECTED_SCHEMA_VERSION}'"
+        )
+
+    primary_lens = spec.applicable_lenses.get("primary")
+    if primary_lens and primary_lens not in valid_lenses:
+        errors.append(f"applicable_lenses.primary '{primary_lens}' is not a known lens slug")
+
+    secondary_lens = spec.applicable_lenses.get("secondary")
+    if secondary_lens and secondary_lens not in valid_lenses:
+        errors.append(f"applicable_lenses.secondary '{secondary_lens}' is not a known lens slug")
+
+    if len(spec.classification_triggers) == 0 and not spec.is_fallback:
+        errors.append(
+            "classification_triggers is empty (non-fallback experiment type requires triggers)"
+        )
+
+    if spec.priority <= 0:
+        errors.append(f"priority must be a positive integer, got {spec.priority}")
+
+    return ValidationResult(
+        filename=path.name,
+        path=path,
+        errors=errors,
+        warnings=warnings,
+        spec_name=spec.name,
+        schema_version=spec.schema_version,
+        priority=spec.priority,
+        raw_content=raw_content,
+    )
+
+
+def _validate_methodology_tradition_file(path: Path) -> ValidationResult:
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    raw_content = path.read_text()
+
+    try:
+        data = load_yaml(path)
+    except YAMLError as e:
+        return ValidationResult(
+            filename=path.name,
+            path=path,
+            errors=[f"YAML parse error: {e}"],
+            warnings=[],
+            raw_content=raw_content,
+        )
+
+    try:
+        spec = _parse_methodology_tradition(data, path)
+    except (ValueError, TypeError) as e:
+        return ValidationResult(
+            filename=path.name,
+            path=path,
+            errors=[str(e)],
+            warnings=[],
+            raw_content=raw_content,
+        )
+
+    if spec.schema_version and spec.schema_version != EXPECTED_SCHEMA_VERSION:
+        warnings.append(
+            f"schema_version is '{spec.schema_version}', expected '{EXPECTED_SCHEMA_VERSION}'"
+        )
+
+    if len(spec.detection_keywords) == 0:
+        errors.append("detection_keywords is empty")
+
+    if spec.priority <= 0:
+        errors.append(f"priority must be a positive integer, got {spec.priority}")
+
+    return ValidationResult(
+        filename=path.name,
+        path=path,
+        errors=errors,
+        warnings=warnings,
+        spec_name=spec.name,
+        schema_version=spec.schema_version,
+        priority=spec.priority,
+        raw_content=raw_content,
+    )
+
+
+def _check_fallback_uniqueness(
+    user_results: list[ValidationResult], bundled_types: dict[str, ExperimentTypeSpec]
+) -> list[str]:
+    fallback_errors: list[str] = []
+
+    all_types: dict[str, ExperimentTypeSpec] = dict(bundled_types)
+    for result in user_results:
+        if result.spec_name and result.status != "error":
+            data = load_yaml(result.path)
+            if isinstance(data, dict):
+                try:
+                    spec = _parse_experiment_type(data, result.path)
+                    all_types[spec.name] = spec
+                except (ValueError, TypeError):
+                    pass
+
+    fallback_entries = [
+        (name, spec, result)
+        for name, spec in all_types.items()
+        for result in user_results
+        if result.spec_name == name and spec.is_fallback
+    ]
+
+    if len(fallback_entries) > 1:
+        seen: set[str] = set()
+        for name, spec, result in fallback_entries:
+            if name not in seen:
+                fallback_errors.append(
+                    f"Multiple is_fallback=True entries found: '{name}' in {result.filename}"
+                )
+                seen.add(name)
+
+    return fallback_errors
+
+
+def _write_error_report(
+    project_dir: Path, filename: str, registry_type: str, result: ValidationResult
+) -> Path:
+    error_dir = project_dir / ".autoskillit" / "validation-errors"
+    error_dir.mkdir(parents=True, exist_ok=True)
+
+    report_path = error_dir / f"{filename}.error.md"
+
+    timestamp = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+    expected_schema = f"""```yaml
+name: {registry_type}-name
+schema_version: "{EXPECTED_SCHEMA_VERSION}"
+priority: 1
+classification_triggers:
+  - trigger_1
+applicable_lenses:
+  primary: exp-lens-estimand-clarity
+  secondary: null
+dimension_weights:
+  clarity: high
+  methodological_rigor: medium
+  external_validity: low
+  practical_significance: medium
+  inferential_validity: high
+  ethical_compliance: medium
+  reporting_completeness: high
+  transparency: high
+red_team_focus:
+  priority_area: description
+l1_severity:
+  severity_rating: medium
+```"""
+
+    how_to_fix = ""
+    if "missing 'name'" in str(result.errors):
+        how_to_fix = "Add a `name` field to your YAML file."
+    elif "applicable_lenses" in str(result.errors):
+        how_to_fix = "Ensure applicable_lenses reference valid lens slugs from skills_extended/ directories."
+    elif "classification_triggers" in str(result.errors):
+        how_to_fix = "Add at least one classification trigger, or set is_fallback: true."
+    elif "priority" in str(result.errors):
+        how_to_fix = "Set priority to a positive integer (higher = lower precedence)."
+    elif result.errors:
+        how_to_fix = "Fix the errors listed above and re-run validation."
+
+    content = f"""# Validation error: {filename}
+
+**File:** `{result.filename}`
+**Validated at:** {timestamp}
+**Registry type:** {registry_type}
+
+## Errors
+
+{chr(10).join(f"- {err}" for err in result.errors)}
+
+## Warnings
+
+{chr(10).join(f"- {warn}" for warn in result.warnings) if result.warnings else "_No warnings_"}
+
+## Expected schema
+
+{expected_schema}
+
+## Your file
+
+```yaml
+{result.raw_content}
+```
+
+## How to fix
+
+{how_to_fix}
+"""
+
+    report_path.write_text(content)
+    return report_path
+
+
+def _format_stdout_report(
+    et_results: list[ValidationResult],
+    mt_results: list[ValidationResult],
+) -> str:
+    lines: list[str] = []
+
+    all_results = [("experiment-type", r) for r in et_results] + [
+        ("methodology-tradition", r) for r in mt_results
+    ]
+
+    for _registry_type, result in all_results:
+        if result.status == "error":
+            symbol = "✗"
+        elif result.status == "warning":
+            symbol = "⚠"
+        else:
+            symbol = "✓"
+
+        status_label = result.status.upper()
+        lines.append(f"{symbol} [{status_label}] {result.filename}")
+
+        if result.warnings:
+            for w in result.warnings:
+                lines.append(f"  ⚠ {w}")
+        if result.errors:
+            for e in result.errors:
+                lines.append(f"  ✗ {e}")
+
+    valid_count = sum(1 for r in et_results + mt_results if r.status == "valid")
+    warn_count = sum(1 for r in et_results + mt_results if r.status == "warning")
+    error_count = sum(1 for r in et_results + mt_results if r.status == "error")
+
+    lines.append("")
+    lines.append(f"Summary: {valid_count} valid  |  {warn_count} warning  |  {error_count} error")
+
+    return "\n".join(lines)
+
+
+@validate_app.command(name="registries")
+def validate_registries() -> None:
+    """Validate user-override registries in .autoskillit/."""
+    project_dir = Path.cwd()
+
+    et_dir = project_dir / ".autoskillit" / "experiment-types"
+    mt_dir = project_dir / ".autoskillit" / "methodology-traditions"
+
+    if not et_dir.exists() and not mt_dir.exists():
+        print(
+            "No user registry directories found (.autoskillit/experiment-types/ or .autoskillit/methodology-traditions/)."
+        )
+        return
+
+    valid_lenses = _get_valid_lens_slugs()
+
+    et_results: list[ValidationResult] = []
+    if et_dir.exists():
+        for path in sorted(et_dir.glob("*.yaml")):
+            result = _validate_experiment_type_file(path, valid_lenses)
+            et_results.append(result)
+
+    mt_results: list[ValidationResult] = []
+    if mt_dir.exists():
+        for path in sorted(mt_dir.glob("*.yaml")):
+            result = _validate_methodology_tradition_file(path)
+            mt_results.append(result)
+
+    bundled_types = _load_types_from_dir(BUNDLED_EXPERIMENT_TYPES_DIR)
+    fallback_errors = _check_fallback_uniqueness(et_results, bundled_types)
+
+    if fallback_errors:
+        for result in et_results:
+            if result.spec_name:
+                for error in fallback_errors:
+                    if result.spec_name in error:
+                        result.errors.append(error)
+
+    print(_format_stdout_report(et_results, mt_results))
+
+    for result in et_results + mt_results:
+        if result.errors:
+            registry_type = "experiment-type"
+            if result in mt_results:
+                registry_type = "methodology-tradition"
+            _write_error_report(project_dir, result.filename, registry_type, result)
+
+    if any(r.status == "error" for r in et_results + mt_results):
+        raise SystemExit(1)

--- a/src/autoskillit/cli/_validate.py
+++ b/src/autoskillit/cli/_validate.py
@@ -358,12 +358,12 @@ def validate_registries() -> None:
 
     print(_format_stdout_report(et_results, mt_results))
 
-    for result in et_results + mt_results:
+    for result in et_results:
         if result.errors:
-            registry_type = "experiment-type"
-            if result in mt_results:
-                registry_type = "methodology-tradition"
-            _write_error_report(project_dir, result.filename, registry_type, result)
+            _write_error_report(project_dir, result.filename, "experiment-type", result)
+    for result in mt_results:
+        if result.errors:
+            _write_error_report(project_dir, result.filename, "methodology-tradition", result)
 
     if any(r.status == "error" for r in et_results + mt_results):
         raise SystemExit(1)

--- a/src/autoskillit/cli/_validate.py
+++ b/src/autoskillit/cli/_validate.py
@@ -12,25 +12,14 @@ from autoskillit.core import YAMLError, atomic_write, load_yaml, pkg_root
 from autoskillit.recipe import (
     BUNDLED_EXPERIMENT_TYPES_DIR,
     ExperimentTypeSpec,
-    _load_types_from_dir,
-    _parse_experiment_type,
-    _parse_methodology_tradition,
+    load_types_from_dir,
+    parse_experiment_type,
+    parse_methodology_tradition,
 )
 
 validate_app = App(name="validate", help="Validation commands.")
 
 EXPECTED_SCHEMA_VERSION = "1.0"
-
-EXPERIMENT_TYPE_DIMENSION_KEYS = (
-    "clarity",
-    "methodological_rigor",
-    "external_validity",
-    "practical_significance",
-    "inferential_validity",
-    "ethical_compliance",
-    "reporting_completeness",
-    "transparency",
-)
 
 
 @dataclass
@@ -64,7 +53,7 @@ def _validate_experiment_type_file(path: Path, valid_lenses: set[str]) -> Valida
     errors: list[str] = []
     warnings: list[str] = []
 
-    raw_content = path.read_text()
+    raw_content = path.read_text(encoding="utf-8")
 
     try:
         data = load_yaml(path)
@@ -81,7 +70,7 @@ def _validate_experiment_type_file(path: Path, valid_lenses: set[str]) -> Valida
         data["classification_triggers"] = []
 
     try:
-        spec = _parse_experiment_type(data, path)
+        spec = parse_experiment_type(data, path)
     except (ValueError, TypeError) as e:
         return ValidationResult(
             filename=path.name,
@@ -128,7 +117,7 @@ def _validate_methodology_tradition_file(path: Path) -> ValidationResult:
     errors: list[str] = []
     warnings: list[str] = []
 
-    raw_content = path.read_text()
+    raw_content = path.read_text(encoding="utf-8")
 
     try:
         data = load_yaml(path)
@@ -145,7 +134,7 @@ def _validate_methodology_tradition_file(path: Path) -> ValidationResult:
         data["detection_keywords"] = []
 
     try:
-        spec = _parse_methodology_tradition(data, path)
+        spec = parse_methodology_tradition(data, path)
     except (ValueError, TypeError) as e:
         return ValidationResult(
             filename=path.name,
@@ -183,32 +172,30 @@ def _check_fallback_uniqueness(
 ) -> list[str]:
     fallback_errors: list[str] = []
 
+    user_type_filenames: dict[str, str] = {}
     all_types: dict[str, ExperimentTypeSpec] = dict(bundled_types)
     for result in user_results:
         if result.spec_name and result.status != "error":
-            data = load_yaml(result.path)
+            try:
+                data = load_yaml(result.path)
+            except (YAMLError, OSError):
+                continue
             if isinstance(data, dict):
                 try:
-                    spec = _parse_experiment_type(data, result.path)
+                    spec = parse_experiment_type(data, result.path)
                     all_types[spec.name] = spec
+                    user_type_filenames[spec.name] = result.filename
                 except (ValueError, TypeError):
                     pass
 
-    fallback_entries = [
-        (name, spec, result)
-        for name, spec in all_types.items()
-        for result in user_results
-        if result.spec_name == name and spec.is_fallback
-    ]
+    fallback_names = [name for name, spec in all_types.items() if spec.is_fallback]
 
-    if len(fallback_entries) > 1:
-        seen: set[str] = set()
-        for name, spec, result in fallback_entries:
-            if name not in seen:
-                fallback_errors.append(
-                    f"Multiple is_fallback=True entries found: '{name}' in {result.filename}"
-                )
-                seen.add(name)
+    if len(fallback_names) > 1:
+        for name in fallback_names:
+            filename = user_type_filenames.get(name, f"<bundled:{name}>")
+            fallback_errors.append(
+                f"Multiple is_fallback=True entries found: '{name}' in {filename}"
+            )
 
     return fallback_errors
 
@@ -248,13 +235,13 @@ l1_severity:
 ```"""
 
     how_to_fix = ""
-    if "missing 'name'" in str(result.errors):
+    if any("missing 'name'" in e for e in result.errors):
         how_to_fix = "Add a `name` field to your YAML file."
-    elif "applicable_lenses" in str(result.errors):
+    elif any("applicable_lenses" in e for e in result.errors):
         how_to_fix = "Ensure applicable_lenses slugs exist in skills_extended/ directories."
-    elif "classification_triggers" in str(result.errors):
+    elif any("classification_triggers" in e for e in result.errors):
         how_to_fix = "Add at least one classification trigger, or set is_fallback: true."
-    elif "priority" in str(result.errors):
+    elif any("priority" in e for e in result.errors):
         how_to_fix = "Set priority to a positive integer (higher = lower precedence)."
     elif result.errors:
         how_to_fix = "Fix the errors listed above and re-run validation."
@@ -302,7 +289,7 @@ def _format_stdout_report(
         ("methodology-tradition", r) for r in mt_results
     ]
 
-    for _registry_type, result in all_results:
+    for _, result in all_results:
         if result.status == "error":
             symbol = "✗"
         elif result.status == "warning":
@@ -359,14 +346,14 @@ def validate_registries() -> None:
             result = _validate_methodology_tradition_file(path)
             mt_results.append(result)
 
-    bundled_types = _load_types_from_dir(BUNDLED_EXPERIMENT_TYPES_DIR)
+    bundled_types = load_types_from_dir(BUNDLED_EXPERIMENT_TYPES_DIR)
     fallback_errors = _check_fallback_uniqueness(et_results, bundled_types)
 
     if fallback_errors:
         for result in et_results:
             if result.spec_name:
                 for error in fallback_errors:
-                    if result.spec_name in error:
+                    if f"'{result.spec_name}'" in error:
                         result.errors.append(error)
 
     print(_format_stdout_report(et_results, mt_results))

--- a/src/autoskillit/cli/_validate.py
+++ b/src/autoskillit/cli/_validate.py
@@ -53,7 +53,15 @@ def _validate_experiment_type_file(path: Path, valid_lenses: set[str]) -> Valida
     errors: list[str] = []
     warnings: list[str] = []
 
-    raw_content = path.read_text(encoding="utf-8")
+    try:
+        raw_content = path.read_text(encoding="utf-8")
+    except OSError as e:
+        return ValidationResult(
+            filename=path.name,
+            path=path,
+            errors=[f"Cannot read file: {e}"],
+            warnings=[],
+        )
 
     try:
         data = load_yaml(path)
@@ -66,7 +74,16 @@ def _validate_experiment_type_file(path: Path, valid_lenses: set[str]) -> Valida
             raw_content=raw_content,
         )
 
-    if isinstance(data, dict) and data.get("classification_triggers") is None:
+    if not isinstance(data, dict):
+        return ValidationResult(
+            filename=path.name,
+            path=path,
+            errors=[f"YAML root must be a mapping, got {type(data).__name__}"],
+            warnings=[],
+            raw_content=raw_content,
+        )
+
+    if data.get("classification_triggers") is None:
         data["classification_triggers"] = []
 
     try:
@@ -117,7 +134,15 @@ def _validate_methodology_tradition_file(path: Path) -> ValidationResult:
     errors: list[str] = []
     warnings: list[str] = []
 
-    raw_content = path.read_text(encoding="utf-8")
+    try:
+        raw_content = path.read_text(encoding="utf-8")
+    except OSError as e:
+        return ValidationResult(
+            filename=path.name,
+            path=path,
+            errors=[f"Cannot read file: {e}"],
+            warnings=[],
+        )
 
     try:
         data = load_yaml(path)
@@ -130,7 +155,16 @@ def _validate_methodology_tradition_file(path: Path) -> ValidationResult:
             raw_content=raw_content,
         )
 
-    if isinstance(data, dict) and data.get("detection_keywords") is None:
+    if not isinstance(data, dict):
+        return ValidationResult(
+            filename=path.name,
+            path=path,
+            errors=[f"YAML root must be a mapping, got {type(data).__name__}"],
+            warnings=[],
+            raw_content=raw_content,
+        )
+
+    if data.get("detection_keywords") is None:
         data["detection_keywords"] = []
 
     try:

--- a/src/autoskillit/cli/_validate.py
+++ b/src/autoskillit/cli/_validate.py
@@ -8,14 +8,12 @@ from pathlib import Path
 
 from cyclopts import App
 
-from autoskillit.core import YAMLError, load_yaml, pkg_root
-from autoskillit.recipe.experiment_type_registry import (
+from autoskillit.core import YAMLError, atomic_write, load_yaml, pkg_root
+from autoskillit.recipe import (
     BUNDLED_EXPERIMENT_TYPES_DIR,
     ExperimentTypeSpec,
     _load_types_from_dir,
     _parse_experiment_type,
-)
-from autoskillit.recipe.methodology_tradition_registry import (
     _parse_methodology_tradition,
 )
 
@@ -79,6 +77,9 @@ def _validate_experiment_type_file(path: Path, valid_lenses: set[str]) -> Valida
             raw_content=raw_content,
         )
 
+    if isinstance(data, dict) and data.get("classification_triggers") is None:
+        data["classification_triggers"] = []
+
     try:
         spec = _parse_experiment_type(data, path)
     except (ValueError, TypeError) as e:
@@ -139,6 +140,9 @@ def _validate_methodology_tradition_file(path: Path) -> ValidationResult:
             warnings=[],
             raw_content=raw_content,
         )
+
+    if isinstance(data, dict) and data.get("detection_keywords") is None:
+        data["detection_keywords"] = []
 
     try:
         spec = _parse_methodology_tradition(data, path)
@@ -247,7 +251,7 @@ l1_severity:
     if "missing 'name'" in str(result.errors):
         how_to_fix = "Add a `name` field to your YAML file."
     elif "applicable_lenses" in str(result.errors):
-        how_to_fix = "Ensure applicable_lenses reference valid lens slugs from skills_extended/ directories."
+        how_to_fix = "Ensure applicable_lenses slugs exist in skills_extended/ directories."
     elif "classification_triggers" in str(result.errors):
         how_to_fix = "Add at least one classification trigger, or set is_fallback: true."
     elif "priority" in str(result.errors):
@@ -284,7 +288,7 @@ l1_severity:
 {how_to_fix}
 """
 
-    report_path.write_text(content)
+    atomic_write(report_path, content)
     return report_path
 
 
@@ -336,7 +340,8 @@ def validate_registries() -> None:
 
     if not et_dir.exists() and not mt_dir.exists():
         print(
-            "No user registry directories found (.autoskillit/experiment-types/ or .autoskillit/methodology-traditions/)."
+            "No user registry directories found"
+            " (.autoskillit/experiment-types/ or .autoskillit/methodology-traditions/)."
         )
         return
 

--- a/src/autoskillit/cli/app.py
+++ b/src/autoskillit/cli/app.py
@@ -24,6 +24,7 @@ from autoskillit.cli._init_helpers import (
 )
 from autoskillit.cli._serve_guard import serve_with_signal_guard
 from autoskillit.cli._sessions import sessions_app
+from autoskillit.cli._validate import validate_app
 from autoskillit.cli.fleet import fleet_app
 from autoskillit.cli.session._cook import cook as cook_interactive
 from autoskillit.cli.session._order import _recipes_dir_for, order
@@ -49,6 +50,7 @@ app.command(workspace_app)
 app.command(fleet_app)
 app.command(features_app)
 app.command(sessions_app)
+app.command(validate_app)
 app.command(order)
 
 

--- a/src/autoskillit/core/io.py
+++ b/src/autoskillit/core/io.py
@@ -124,6 +124,7 @@ _AUTOSKILLIT_GITIGNORE_ENTRIES = [
     ".onboarded",
     "sync_manifest.json",
     "test-filter-manifest.yaml",
+    "validation-errors/",
 ]
 
 _COMMITTED_BY_DESIGN: frozenset[str] = frozenset(

--- a/src/autoskillit/recipe/__init__.py
+++ b/src/autoskillit/recipe/__init__.py
@@ -39,10 +39,10 @@ from autoskillit.recipe.diagrams import (  # noqa: E402
 from autoskillit.recipe.experiment_type_registry import (  # noqa: E402
     BUNDLED_EXPERIMENT_TYPES_DIR,
     ExperimentTypeSpec,
-    _load_types_from_dir,
-    _parse_experiment_type,
     get_experiment_type_by_name,
     load_all_experiment_types,
+    load_types_from_dir,
+    parse_experiment_type,
 )
 from autoskillit.recipe.identity import (  # noqa: E402
     check_rerun_detection,
@@ -64,10 +64,10 @@ from autoskillit.recipe.io import (  # noqa: E402
 from autoskillit.recipe.loader import parse_recipe_metadata  # noqa: E402
 from autoskillit.recipe.methodology_tradition_registry import (  # noqa: E402
     MethodologyTraditionSpec,
-    _parse_methodology_tradition,
     get_methodology_tradition_by_name,
     is_out_of_scope_tradition,
     load_all_methodology_traditions,
+    parse_methodology_tradition,
 )
 from autoskillit.recipe.repository import DefaultRecipeRepository  # noqa: E402
 from autoskillit.recipe.rules import rules_actions as _rules_actions  # noqa: E402 F401
@@ -177,12 +177,12 @@ __all__ = [
     "find_sub_recipe_by_name",
     "BUNDLED_EXPERIMENT_TYPES_DIR",
     "ExperimentTypeSpec",
-    "_load_types_from_dir",
-    "_parse_experiment_type",
+    "load_types_from_dir",
+    "parse_experiment_type",
     "get_experiment_type_by_name",
     "load_all_experiment_types",
     "MethodologyTraditionSpec",
-    "_parse_methodology_tradition",
+    "parse_methodology_tradition",
     "get_methodology_tradition_by_name",
     "is_out_of_scope_tradition",
     "load_all_methodology_traditions",

--- a/src/autoskillit/recipe/__init__.py
+++ b/src/autoskillit/recipe/__init__.py
@@ -67,6 +67,7 @@ from autoskillit.recipe.methodology_tradition_registry import (  # noqa: E402
     get_methodology_tradition_by_name,
     is_out_of_scope_tradition,
     load_all_methodology_traditions,
+    load_traditions_from_dir,
     parse_methodology_tradition,
 )
 from autoskillit.recipe.repository import DefaultRecipeRepository  # noqa: E402
@@ -183,6 +184,7 @@ __all__ = [
     "load_all_experiment_types",
     "MethodologyTraditionSpec",
     "parse_methodology_tradition",
+    "load_traditions_from_dir",
     "get_methodology_tradition_by_name",
     "is_out_of_scope_tradition",
     "load_all_methodology_traditions",

--- a/src/autoskillit/recipe/__init__.py
+++ b/src/autoskillit/recipe/__init__.py
@@ -37,7 +37,10 @@ from autoskillit.recipe.diagrams import (  # noqa: E402
     load_recipe_diagram,
 )
 from autoskillit.recipe.experiment_type_registry import (  # noqa: E402
+    BUNDLED_EXPERIMENT_TYPES_DIR,
     ExperimentTypeSpec,
+    _load_types_from_dir,
+    _parse_experiment_type,
     get_experiment_type_by_name,
     load_all_experiment_types,
 )
@@ -61,6 +64,7 @@ from autoskillit.recipe.io import (  # noqa: E402
 from autoskillit.recipe.loader import parse_recipe_metadata  # noqa: E402
 from autoskillit.recipe.methodology_tradition_registry import (  # noqa: E402
     MethodologyTraditionSpec,
+    _parse_methodology_tradition,
     get_methodology_tradition_by_name,
     is_out_of_scope_tradition,
     load_all_methodology_traditions,
@@ -171,10 +175,14 @@ __all__ = [
     "diagram_stale_to_suggestions",
     "builtin_sub_recipes_dir",
     "find_sub_recipe_by_name",
+    "BUNDLED_EXPERIMENT_TYPES_DIR",
     "ExperimentTypeSpec",
+    "_load_types_from_dir",
+    "_parse_experiment_type",
     "get_experiment_type_by_name",
     "load_all_experiment_types",
     "MethodologyTraditionSpec",
+    "_parse_methodology_tradition",
     "get_methodology_tradition_by_name",
     "is_out_of_scope_tradition",
     "load_all_methodology_traditions",

--- a/src/autoskillit/recipe/__init__.py
+++ b/src/autoskillit/recipe/__init__.py
@@ -63,6 +63,7 @@ from autoskillit.recipe.io import (  # noqa: E402
 )
 from autoskillit.recipe.loader import parse_recipe_metadata  # noqa: E402
 from autoskillit.recipe.methodology_tradition_registry import (  # noqa: E402
+    BUNDLED_METHODOLOGY_TRADITIONS_DIR,
     MethodologyTraditionSpec,
     get_methodology_tradition_by_name,
     is_out_of_scope_tradition,
@@ -177,6 +178,7 @@ __all__ = [
     "builtin_sub_recipes_dir",
     "find_sub_recipe_by_name",
     "BUNDLED_EXPERIMENT_TYPES_DIR",
+    "BUNDLED_METHODOLOGY_TRADITIONS_DIR",
     "ExperimentTypeSpec",
     "load_types_from_dir",
     "parse_experiment_type",

--- a/src/autoskillit/recipe/experiment_type_registry.py
+++ b/src/autoskillit/recipe/experiment_type_registry.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 from autoskillit.core import get_logger, load_yaml, pkg_root
 
@@ -94,7 +95,7 @@ def _load_types_from_dir(directory: Path) -> dict[str, ExperimentTypeSpec]:
     return result
 
 
-def parse_experiment_type(data: dict, source_path: Path) -> ExperimentTypeSpec:
+def parse_experiment_type(data: dict[str, Any], source_path: Path) -> ExperimentTypeSpec:
     return _parse_experiment_type(data, source_path)
 
 

--- a/src/autoskillit/recipe/experiment_type_registry.py
+++ b/src/autoskillit/recipe/experiment_type_registry.py
@@ -94,6 +94,14 @@ def _load_types_from_dir(directory: Path) -> dict[str, ExperimentTypeSpec]:
     return result
 
 
+def parse_experiment_type(data: dict, source_path: Path) -> ExperimentTypeSpec:
+    return _parse_experiment_type(data, source_path)
+
+
+def load_types_from_dir(directory: Path) -> dict[str, ExperimentTypeSpec]:
+    return _load_types_from_dir(directory)
+
+
 def load_all_experiment_types(
     project_dir: Path | None = None,
 ) -> list[ExperimentTypeSpec]:

--- a/src/autoskillit/recipe/methodology_tradition_registry.py
+++ b/src/autoskillit/recipe/methodology_tradition_registry.py
@@ -116,6 +116,10 @@ def _load_traditions_from_dir(directory: Path) -> dict[str, MethodologyTradition
     return result
 
 
+def parse_methodology_tradition(data: dict, source_path: Path) -> MethodologyTraditionSpec:
+    return _parse_methodology_tradition(data, source_path)
+
+
 def load_all_methodology_traditions(
     project_dir: Path | None = None,
 ) -> list[MethodologyTraditionSpec]:

--- a/src/autoskillit/recipe/methodology_tradition_registry.py
+++ b/src/autoskillit/recipe/methodology_tradition_registry.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 from autoskillit.core import get_logger, load_yaml, pkg_root
 
@@ -116,8 +117,14 @@ def _load_traditions_from_dir(directory: Path) -> dict[str, MethodologyTradition
     return result
 
 
-def parse_methodology_tradition(data: dict, source_path: Path) -> MethodologyTraditionSpec:
+def parse_methodology_tradition(
+    data: dict[str, Any], source_path: Path
+) -> MethodologyTraditionSpec:
     return _parse_methodology_tradition(data, source_path)
+
+
+def load_traditions_from_dir(directory: Path) -> dict[str, MethodologyTraditionSpec]:
+    return _load_traditions_from_dir(directory)
 
 
 def load_all_methodology_traditions(

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -370,6 +370,7 @@ MODULE_CASCADE_RECIPE: dict[str, frozenset[str]] = {
         {
             "recipe",
             "skills/test_review_design_guards.py",
+            "cli",
         }
     ),
     "registry": frozenset(
@@ -531,6 +532,7 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             "cli/test_cook_order_picker.py",
             "cli/test_fleet_list.py",
             "cli/test_preview.py",
+            "cli/test_validate_registries.py",
             # Execution file-level entries:
             "execution/test_headless_path_validation.py",
             "execution/test_zero_write_detection.py",

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -526,12 +526,13 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             "server/test_tools_list_recipes.py",
             "server/test_tools_bootstrap.py",
             "server/test_tools_kitchen_visibility.py",
-            # CLI file-level entries (5 of 38 import autoskillit.recipe):
+            # CLI file-level entries (6 of 38 import autoskillit.recipe):
             "cli/test_cli_prompts.py",
             "cli/test_l3_orchestrator_prompt.py",
             "cli/test_cook_order_picker.py",
             "cli/test_fleet_list.py",
             "cli/test_preview.py",
+            "cli/test_validate_registries.py",
             # Execution file-level entries:
             "execution/test_headless_path_validation.py",
             "execution/test_zero_write_detection.py",

--- a/tests/_test_filter.py
+++ b/tests/_test_filter.py
@@ -526,13 +526,12 @@ LAYER_CASCADE_CONSERVATIVE: dict[str, frozenset[str]] = {
             "server/test_tools_list_recipes.py",
             "server/test_tools_bootstrap.py",
             "server/test_tools_kitchen_visibility.py",
-            # CLI file-level entries (4 of 38 import autoskillit.recipe):
+            # CLI file-level entries (5 of 38 import autoskillit.recipe):
             "cli/test_cli_prompts.py",
             "cli/test_l3_orchestrator_prompt.py",
             "cli/test_cook_order_picker.py",
             "cli/test_fleet_list.py",
             "cli/test_preview.py",
-            "cli/test_validate_registries.py",
             # Execution file-level entries:
             "execution/test_headless_path_validation.py",
             "execution/test_zero_write_detection.py",

--- a/tests/arch/_rules.py
+++ b/tests/arch/_rules.py
@@ -79,6 +79,7 @@ _PRINT_EXEMPT = frozenset(
         "_marketplace.py",
         "_prompts.py",
         "_sessions.py",
+        "_validate.py",
         "_workspace.py",
         "branch_protection_guard.py",
         "lint_after_edit_hook.py",

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -86,6 +86,7 @@ SINGLETON_ALLOWED_MODULES: frozenset[str] = frozenset(
         "_fleet",  # cli/_fleet.py: fleet_app = App(name="fleet", ...)
         "_features",  # cli/_features.py: features_app = App(name="features", ...)
         "_sessions",  # cli/_sessions.py: sessions_app = App(name="sessions", ...)
+        "_validate",  # cli/_validate.py: validate_app = App(name="validate", ...)
     }
 )
 _SINGLETON_SAFE_CALL_NAMES: frozenset[str] = frozenset(

--- a/tests/cli/CLAUDE.md
+++ b/tests/cli/CLAUDE.md
@@ -70,6 +70,7 @@ CLI command, subcommand, and interactive workflow tests.
 | `test_update_checks_prompt.py` | Tests for cli/_update_checks.py — UC-3 through UC-10: prompt consolidation, yes/no paths, dismissal |
 | `test_update_checks_split.py` | Structural guard for update_checks split |
 | `test_update_command.py` | Tests for cli/_update.py — first-class update command |
+| `test_validate_registries.py` | Tests for the validate registries CLI subcommand |
 | `test_workspace.py` | Tests for cli._workspace — age partitioning, display, and confirmation |
 
 ## Architecture Notes

--- a/tests/cli/test_validate_registries.py
+++ b/tests/cli/test_validate_registries.py
@@ -292,8 +292,9 @@ class TestValidateRegistries:
         yaml_content = VALID_EXPERIMENT_TYPE.replace("name: my-test-type\n", "")
         _write_yaml(tmp_path, "experiment-types", "parse_error.yaml", yaml_content)
 
-        with pytest.raises(SystemExit):
+        with pytest.raises(SystemExit) as exc_info:
             validate_registries()
+        assert exc_info.value.code == 1
 
         error_file = tmp_path / ".autoskillit" / "validation-errors" / "parse_error.yaml.error.md"
         assert error_file.exists()
@@ -363,3 +364,57 @@ class TestValidateRegistries:
         out = capsys.readouterr().out
         assert "✓" in out
         assert "✗" not in out
+
+    # T_VAL_15: Malformed YAML in experiment-type produces YAML parse error and exit 1
+    def test_malformed_yaml_experiment_type(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        _write_yaml(tmp_path, "experiment-types", "bad_yaml.yaml", "name: [unclosed\n")
+
+        with pytest.raises(SystemExit) as exc_info:
+            validate_registries()
+        assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        assert "✗" in out
+        assert "YAML parse error" in out
+
+    # T_VAL_16: Malformed YAML in methodology-tradition produces YAML parse error and exit 1
+    def test_malformed_yaml_methodology_tradition(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        _write_yaml(tmp_path, "methodology-traditions", "bad_yaml.yaml", "name: [unclosed\n")
+
+        with pytest.raises(SystemExit) as exc_info:
+            validate_registries()
+        assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        assert "✗" in out
+        assert "YAML parse error" in out
+
+    # T_VAL_17: Invalid secondary applicable_lenses produces ✗ error and exit 1
+    def test_invalid_secondary_lens_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        yaml_content = VALID_EXPERIMENT_TYPE.replace(
+            "  secondary: null", "  secondary: exp-lens-nonexistent"
+        )
+        _write_yaml(tmp_path, "experiment-types", "bad_secondary.yaml", yaml_content)
+
+        with pytest.raises(SystemExit) as exc_info:
+            validate_registries()
+        assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        assert "✗" in out
+        assert "secondary" in out

--- a/tests/cli/test_validate_registries.py
+++ b/tests/cli/test_validate_registries.py
@@ -6,9 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from autoskillit.recipe.experiment_type_registry import (
-    BUNDLED_EXPERIMENT_TYPES_DIR,
-)
+from autoskillit.cli._validate import validate_registries
 
 pytestmark = [pytest.mark.layer("cli"), pytest.mark.medium]
 
@@ -88,8 +86,8 @@ class TestValidateRegistries:
     def _mock_bundled_types(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Patch bundled types loading to return empty dict."""
         monkeypatch.setattr(
-            "autoskillit.cli._validate._load_types_from_dir",
-            lambda dir: {} if dir == BUNDLED_EXPERIMENT_TYPES_DIR else {},
+            "autoskillit.cli._validate.load_types_from_dir",
+            lambda _: {},
         )
 
     # T_VAL_1: Valid experiment-type YAML produces ✓ output and exit 0
@@ -102,8 +100,6 @@ class TestValidateRegistries:
         """Valid experiment-type YAML produces ✓ output and exits 0."""
         monkeypatch.chdir(tmp_path)
         _write_yaml(tmp_path, "experiment-types", "my_type.yaml", VALID_EXPERIMENT_TYPE)
-
-        from autoskillit.cli._validate import validate_registries
 
         validate_registries()
         out = capsys.readouterr().out
@@ -125,8 +121,6 @@ class TestValidateRegistries:
         )
         _write_yaml(tmp_path, "experiment-types", "warn_type.yaml", yaml_content)
 
-        from autoskillit.cli._validate import validate_registries
-
         validate_registries()
         out = capsys.readouterr().out
         assert "⚠" in out
@@ -144,8 +138,6 @@ class TestValidateRegistries:
         monkeypatch.chdir(tmp_path)
         yaml_content = VALID_EXPERIMENT_TYPE.replace("name: my-test-type\n", "")
         _write_yaml(tmp_path, "experiment-types", "no_name.yaml", yaml_content)
-
-        from autoskillit.cli._validate import validate_registries
 
         with pytest.raises(SystemExit) as exc_info:
             validate_registries()
@@ -169,8 +161,6 @@ class TestValidateRegistries:
         )
         _write_yaml(tmp_path, "experiment-types", "bad_lens.yaml", yaml_content)
 
-        from autoskillit.cli._validate import validate_registries
-
         with pytest.raises(SystemExit) as exc_info:
             validate_registries()
         assert exc_info.value.code == 1
@@ -190,8 +180,6 @@ class TestValidateRegistries:
         yaml_content = VALID_EXPERIMENT_TYPE.replace("  - trigger_alpha\n  - trigger_beta", "")
         _write_yaml(tmp_path, "experiment-types", "empty_triggers.yaml", yaml_content)
 
-        from autoskillit.cli._validate import validate_registries
-
         with pytest.raises(SystemExit) as exc_info:
             validate_registries()
         assert exc_info.value.code == 1
@@ -210,8 +198,6 @@ class TestValidateRegistries:
         monkeypatch.chdir(tmp_path)
         yaml_content = VALID_EXPERIMENT_TYPE.replace("priority: 1", "priority: 0")
         _write_yaml(tmp_path, "experiment-types", "bad_priority.yaml", yaml_content)
-
-        from autoskillit.cli._validate import validate_registries
 
         with pytest.raises(SystemExit) as exc_info:
             validate_registries()
@@ -237,8 +223,6 @@ class TestValidateRegistries:
         _write_yaml(tmp_path, "experiment-types", "fallback1.yaml", yaml1)
         _write_yaml(tmp_path, "experiment-types", "fallback2.yaml", yaml2)
 
-        from autoskillit.cli._validate import validate_registries
-
         with pytest.raises(SystemExit) as exc_info:
             validate_registries()
         assert exc_info.value.code == 1
@@ -255,8 +239,6 @@ class TestValidateRegistries:
     ) -> None:
         """No user directories prints info message and exits 0."""
         monkeypatch.chdir(tmp_path)
-
-        from autoskillit.cli._validate import validate_registries
 
         validate_registries()
         out = capsys.readouterr().out
@@ -275,8 +257,6 @@ class TestValidateRegistries:
             tmp_path, "methodology-traditions", "my_tradition.yaml", VALID_METHODOLOGY_TRADITION
         )
 
-        from autoskillit.cli._validate import validate_registries
-
         validate_registries()
         out = capsys.readouterr().out
         assert "✓" in out
@@ -293,8 +273,6 @@ class TestValidateRegistries:
         monkeypatch.chdir(tmp_path)
         yaml_content = VALID_METHODOLOGY_TRADITION.replace("  - keyword1\n  - keyword2", "")
         _write_yaml(tmp_path, "methodology-traditions", "empty_keywords.yaml", yaml_content)
-
-        from autoskillit.cli._validate import validate_registries
 
         with pytest.raises(SystemExit) as exc_info:
             validate_registries()
@@ -313,8 +291,6 @@ class TestValidateRegistries:
         monkeypatch.chdir(tmp_path)
         yaml_content = VALID_EXPERIMENT_TYPE.replace("name: my-test-type\n", "")
         _write_yaml(tmp_path, "experiment-types", "parse_error.yaml", yaml_content)
-
-        from autoskillit.cli._validate import validate_registries
 
         with pytest.raises(SystemExit):
             validate_registries()
@@ -344,8 +320,6 @@ class TestValidateRegistries:
         )
         _write_yaml(tmp_path, "experiment-types", "warn_only.yaml", yaml_content)
 
-        from autoskillit.cli._validate import validate_registries
-
         validate_registries()
         out = capsys.readouterr().out
         assert "⚠" in out
@@ -366,8 +340,6 @@ class TestValidateRegistries:
         yaml_err = VALID_EXPERIMENT_TYPE.replace("name: my-test-type\n", "")
         _write_yaml(tmp_path, "experiment-types", "error_type.yaml", yaml_err)
 
-        from autoskillit.cli._validate import validate_registries
-
         with pytest.raises(SystemExit):
             validate_registries()
         out = capsys.readouterr().out
@@ -387,9 +359,7 @@ class TestValidateRegistries:
         yaml_content = VALID_EXPERIMENT_TYPE + "\nis_fallback: true\n"
         _write_yaml(tmp_path, "experiment-types", "single_fallback.yaml", yaml_content)
 
-        from autoskillit.cli._validate import validate_registries
-
         validate_registries()
         out = capsys.readouterr().out
         assert "✓" in out
-        assert "is_fallback" not in out.lower() or "error" not in out.lower()
+        assert "error" not in out.lower()

--- a/tests/cli/test_validate_registries.py
+++ b/tests/cli/test_validate_registries.py
@@ -1,0 +1,395 @@
+"""Tests for the validate registries CLI subcommand."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from autoskillit.recipe.experiment_type_registry import (
+    BUNDLED_EXPERIMENT_TYPES_DIR,
+)
+
+pytestmark = [pytest.mark.layer("cli"), pytest.mark.medium]
+
+
+def _write_yaml(tmp_path: Path, registry_type: str, filename: str, content: str) -> Path:
+    """Write a YAML file to the appropriate registry directory."""
+    registry_dir = tmp_path / ".autoskillit" / registry_type
+    registry_dir.mkdir(parents=True, exist_ok=True)
+    file_path = registry_dir / filename
+    file_path.write_text(content)
+    return file_path
+
+
+VALID_EXPERIMENT_TYPE = """\
+name: my-test-type
+schema_version: "1.0"
+priority: 1
+classification_triggers:
+  - trigger_alpha
+  - trigger_beta
+applicable_lenses:
+  primary: exp-lens-estimand-clarity
+  secondary: null
+dimension_weights:
+  clarity: high
+  methodological_rigor: medium
+  external_validity: low
+  practical_significance: medium
+  inferential_validity: high
+  ethical_compliance: medium
+  reporting_completeness: high
+  transparency: high
+red_team_focus:
+  priority_area: test_area
+l1_severity:
+  severity_rating: medium
+"""
+
+VALID_METHODOLOGY_TRADITION = """\
+name: my-test-tradition
+display_name: My Test Tradition
+schema_version: "1.0"
+priority: 1
+canonical_guideline:
+  title: Test Guideline
+  url: https://example.com
+fields_spanned:
+  - field1
+detection_keywords:
+  - keyword1
+  - keyword2
+mandatory_figures:
+  - figure_type: table
+strongly_expected_figures:
+  - figure_type: chart
+anti_patterns:
+  - pattern_name: bad_pattern
+"""
+
+
+class TestValidateRegistries:
+    """Tests for validate_registries command."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_lens_slugs(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Patch lens slug resolution to return a known set."""
+        monkeypatch.setattr(
+            "autoskillit.cli._validate._get_valid_lens_slugs",
+            lambda: {
+                "exp-lens-estimand-clarity",
+                "exp-lens-error-budget",
+                "exp-lens-validity-threats",
+            },
+        )
+
+    @pytest.fixture(autouse=True)
+    def _mock_bundled_types(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Patch bundled types loading to return empty dict."""
+        monkeypatch.setattr(
+            "autoskillit.cli._validate._load_types_from_dir",
+            lambda dir: {} if dir == BUNDLED_EXPERIMENT_TYPES_DIR else {},
+        )
+
+    # T_VAL_1: Valid experiment-type YAML produces ✓ output and exit 0
+    def test_valid_experiment_type_valid(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """Valid experiment-type YAML produces ✓ output and exits 0."""
+        monkeypatch.chdir(tmp_path)
+        _write_yaml(tmp_path, "experiment-types", "my_type.yaml", VALID_EXPERIMENT_TYPE)
+
+        from autoskillit.cli._validate import validate_registries
+
+        validate_registries()
+        out = capsys.readouterr().out
+        assert "✓" in out
+        assert "my_type.yaml" in out
+        assert not (tmp_path / ".autoskillit" / "validation-errors").exists()
+
+    # T_VAL_2: Schema-version mismatch produces ⚠ warning and exit 0
+    def test_schema_version_mismatch_warning(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """Schema-version mismatch produces ⚠ warning and exits 0."""
+        monkeypatch.chdir(tmp_path)
+        yaml_content = VALID_EXPERIMENT_TYPE.replace(
+            'schema_version: "1.0"', 'schema_version: "0.9"'
+        )
+        _write_yaml(tmp_path, "experiment-types", "warn_type.yaml", yaml_content)
+
+        from autoskillit.cli._validate import validate_registries
+
+        validate_registries()
+        out = capsys.readouterr().out
+        assert "⚠" in out
+        assert "schema_version" in out
+        assert "expected '1.0'" in out
+
+    # T_VAL_3: Missing 'name' field produces ✗ error and exit 1
+    def test_missing_name_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """Missing 'name' field produces ✗ error and exit 1."""
+        monkeypatch.chdir(tmp_path)
+        yaml_content = VALID_EXPERIMENT_TYPE.replace("name: my-test-type\n", "")
+        _write_yaml(tmp_path, "experiment-types", "no_name.yaml", yaml_content)
+
+        from autoskillit.cli._validate import validate_registries
+
+        with pytest.raises(SystemExit) as exc_info:
+            validate_registries()
+        assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        assert "✗" in out
+        assert "missing" in out
+        assert (tmp_path / ".autoskillit" / "validation-errors" / "no_name.yaml.error.md").exists()
+
+    # T_VAL_4: Invalid lens reference produces ✗ error and exit 1
+    def test_invalid_lens_reference_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """Invalid lens reference produces ✗ error and exit 1."""
+        monkeypatch.chdir(tmp_path)
+        yaml_content = VALID_EXPERIMENT_TYPE.replace(
+            "exp-lens-estimand-clarity", "exp-lens-nonexistent"
+        )
+        _write_yaml(tmp_path, "experiment-types", "bad_lens.yaml", yaml_content)
+
+        from autoskillit.cli._validate import validate_registries
+
+        with pytest.raises(SystemExit) as exc_info:
+            validate_registries()
+        assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        assert "✗" in out
+        assert "lens" in out
+
+    # T_VAL_5: Empty classification_triggers produces ✗ error and exit 1
+    def test_empty_classification_triggers_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """Empty classification_triggers produces ✗ error and exit 1."""
+        monkeypatch.chdir(tmp_path)
+        yaml_content = VALID_EXPERIMENT_TYPE.replace("  - trigger_alpha\n  - trigger_beta", "")
+        _write_yaml(tmp_path, "experiment-types", "empty_triggers.yaml", yaml_content)
+
+        from autoskillit.cli._validate import validate_registries
+
+        with pytest.raises(SystemExit) as exc_info:
+            validate_registries()
+        assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        assert "✗" in out
+        assert "classification_triggers" in out
+
+    # T_VAL_6: Non-positive priority produces ✗ error and exit 1
+    def test_non_positive_priority_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """Non-positive priority produces ✗ error and exit 1."""
+        monkeypatch.chdir(tmp_path)
+        yaml_content = VALID_EXPERIMENT_TYPE.replace("priority: 1", "priority: 0")
+        _write_yaml(tmp_path, "experiment-types", "bad_priority.yaml", yaml_content)
+
+        from autoskillit.cli._validate import validate_registries
+
+        with pytest.raises(SystemExit) as exc_info:
+            validate_registries()
+        assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        assert "✗" in out
+        assert "priority" in out
+
+    # T_VAL_7: Multiple is_fallback entries produces ✗ error and exit 1
+    def test_multiple_fallback_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """Multiple is_fallback entries produces ✗ error and exit 1."""
+        monkeypatch.chdir(tmp_path)
+        yaml1 = VALID_EXPERIMENT_TYPE + "\nis_fallback: true\n"
+        yaml2 = (
+            VALID_EXPERIMENT_TYPE.replace("name: my-test-type", "name: my-other-type")
+            + "\nis_fallback: true\n"
+        )
+        _write_yaml(tmp_path, "experiment-types", "fallback1.yaml", yaml1)
+        _write_yaml(tmp_path, "experiment-types", "fallback2.yaml", yaml2)
+
+        from autoskillit.cli._validate import validate_registries
+
+        with pytest.raises(SystemExit) as exc_info:
+            validate_registries()
+        assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        assert "✗" in out
+        assert "is_fallback" in out
+
+    # T_VAL_8: No user directories — prints info message and exit 0
+    def test_no_user_directories(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """No user directories prints info message and exits 0."""
+        monkeypatch.chdir(tmp_path)
+
+        from autoskillit.cli._validate import validate_registries
+
+        validate_registries()
+        out = capsys.readouterr().out
+        assert "No user registry directories found" in out
+
+    # T_VAL_9: Valid methodology-tradition YAML produces ✓ output and exit 0
+    def test_valid_methodology_tradition_valid(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """Valid methodology-tradition YAML produces ✓ output and exits 0."""
+        monkeypatch.chdir(tmp_path)
+        _write_yaml(
+            tmp_path, "methodology-traditions", "my_tradition.yaml", VALID_METHODOLOGY_TRADITION
+        )
+
+        from autoskillit.cli._validate import validate_registries
+
+        validate_registries()
+        out = capsys.readouterr().out
+        assert "✓" in out
+        assert "my_tradition.yaml" in out
+
+    # T_VAL_10: Empty detection_keywords in methodology tradition produces ✗ error
+    def test_empty_detection_keywords_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """Empty detection_keywords produces ✗ error and exit 1."""
+        monkeypatch.chdir(tmp_path)
+        yaml_content = VALID_METHODOLOGY_TRADITION.replace("  - keyword1\n  - keyword2", "")
+        _write_yaml(tmp_path, "methodology-traditions", "empty_keywords.yaml", yaml_content)
+
+        from autoskillit.cli._validate import validate_registries
+
+        with pytest.raises(SystemExit) as exc_info:
+            validate_registries()
+        assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        assert "✗" in out
+        assert "detection_keywords" in out
+
+    # T_VAL_11: Error report markdown file has expected structure
+    def test_error_report_structure(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Error report markdown file has expected structure."""
+        monkeypatch.chdir(tmp_path)
+        yaml_content = VALID_EXPERIMENT_TYPE.replace("name: my-test-type\n", "")
+        _write_yaml(tmp_path, "experiment-types", "parse_error.yaml", yaml_content)
+
+        from autoskillit.cli._validate import validate_registries
+
+        with pytest.raises(SystemExit):
+            validate_registries()
+
+        error_file = tmp_path / ".autoskillit" / "validation-errors" / "parse_error.yaml.error.md"
+        assert error_file.exists()
+        content = error_file.read_text()
+        assert "# Validation error:" in content
+        assert "**File:**" in content
+        assert "**Validated at:**" in content
+        assert "## Error" in content
+        assert "## Expected schema" in content
+        assert "## Your file" in content
+        assert "## How to fix" in content
+
+    # T_VAL_12: Exit code 0 when only warnings (no errors)
+    def test_exit_0_with_only_warnings(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """Exit code 0 when only warnings (no errors)."""
+        monkeypatch.chdir(tmp_path)
+        yaml_content = VALID_EXPERIMENT_TYPE.replace(
+            'schema_version: "1.0"', 'schema_version: "0.9"'
+        )
+        _write_yaml(tmp_path, "experiment-types", "warn_only.yaml", yaml_content)
+
+        from autoskillit.cli._validate import validate_registries
+
+        validate_registries()
+        out = capsys.readouterr().out
+        assert "⚠" in out
+        assert "0 error" in out
+
+    # T_VAL_13: Summary line includes correct counts
+    def test_summary_counts(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """Summary line includes correct counts."""
+        monkeypatch.chdir(tmp_path)
+        _write_yaml(tmp_path, "experiment-types", "valid_type.yaml", VALID_EXPERIMENT_TYPE)
+        yaml_warn = VALID_EXPERIMENT_TYPE.replace('schema_version: "1.0"', 'schema_version: "0.9"')
+        _write_yaml(tmp_path, "experiment-types", "warn_type.yaml", yaml_warn)
+        yaml_err = VALID_EXPERIMENT_TYPE.replace("name: my-test-type\n", "")
+        _write_yaml(tmp_path, "experiment-types", "error_type.yaml", yaml_err)
+
+        from autoskillit.cli._validate import validate_registries
+
+        with pytest.raises(SystemExit):
+            validate_registries()
+        out = capsys.readouterr().out
+        assert "1 valid" in out
+        assert "1 warning" in out
+        assert "1 error" in out
+
+    # T_VAL_14: is_fallback check allows single fallback entry
+    def test_single_fallback_allowed(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """Single fallback entry is allowed."""
+        monkeypatch.chdir(tmp_path)
+        yaml_content = VALID_EXPERIMENT_TYPE + "\nis_fallback: true\n"
+        _write_yaml(tmp_path, "experiment-types", "single_fallback.yaml", yaml_content)
+
+        from autoskillit.cli._validate import validate_registries
+
+        validate_registries()
+        out = capsys.readouterr().out
+        assert "✓" in out
+        assert "is_fallback" not in out.lower() or "error" not in out.lower()

--- a/tests/cli/test_validate_registries.py
+++ b/tests/cli/test_validate_registries.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from autoskillit.cli._validate import validate_registries
+from autoskillit.recipe import ExperimentTypeSpec
 
 pytestmark = [pytest.mark.layer("cli"), pytest.mark.medium]
 
@@ -177,7 +178,10 @@ class TestValidateRegistries:
     ) -> None:
         """Empty classification_triggers produces ✗ error and exit 1."""
         monkeypatch.chdir(tmp_path)
-        yaml_content = VALID_EXPERIMENT_TYPE.replace("  - trigger_alpha\n  - trigger_beta", "")
+        yaml_content = VALID_EXPERIMENT_TYPE.replace(
+            "classification_triggers:\n  - trigger_alpha\n  - trigger_beta",
+            "classification_triggers: []",
+        )
         _write_yaml(tmp_path, "experiment-types", "empty_triggers.yaml", yaml_content)
 
         with pytest.raises(SystemExit) as exc_info:
@@ -185,7 +189,7 @@ class TestValidateRegistries:
         assert exc_info.value.code == 1
         out = capsys.readouterr().out
         assert "✗" in out
-        assert "classification_triggers" in out
+        assert "classification_triggers is empty" in out
 
     # T_VAL_6: Non-positive priority produces ✗ error and exit 1
     def test_non_positive_priority_error(
@@ -271,7 +275,10 @@ class TestValidateRegistries:
     ) -> None:
         """Empty detection_keywords produces ✗ error and exit 1."""
         monkeypatch.chdir(tmp_path)
-        yaml_content = VALID_METHODOLOGY_TRADITION.replace("  - keyword1\n  - keyword2", "")
+        yaml_content = VALID_METHODOLOGY_TRADITION.replace(
+            "detection_keywords:\n  - keyword1\n  - keyword2",
+            "detection_keywords: []",
+        )
         _write_yaml(tmp_path, "methodology-traditions", "empty_keywords.yaml", yaml_content)
 
         with pytest.raises(SystemExit) as exc_info:
@@ -279,7 +286,7 @@ class TestValidateRegistries:
         assert exc_info.value.code == 1
         out = capsys.readouterr().out
         assert "✗" in out
-        assert "detection_keywords" in out
+        assert "detection_keywords is empty" in out
 
     # T_VAL_11: Error report markdown file has expected structure
     def test_error_report_structure(
@@ -341,8 +348,9 @@ class TestValidateRegistries:
         yaml_err = VALID_EXPERIMENT_TYPE.replace("name: my-test-type\n", "")
         _write_yaml(tmp_path, "experiment-types", "error_type.yaml", yaml_err)
 
-        with pytest.raises(SystemExit):
+        with pytest.raises(SystemExit) as exc_info:
             validate_registries()
+        assert exc_info.value.code == 1
         out = capsys.readouterr().out
         assert "1 valid" in out
         assert "1 warning" in out
@@ -418,3 +426,37 @@ class TestValidateRegistries:
         out = capsys.readouterr().out
         assert "✗" in out
         assert "secondary" in out
+
+    # T_VAL_18: Duplicate is_fallback between user and bundled type is flagged
+    def test_duplicate_fallback_with_bundled_type(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """User type with is_fallback=True conflicts with a bundled fallback type."""
+        monkeypatch.chdir(tmp_path)
+
+        bundled_fallback = ExperimentTypeSpec(
+            name="bundled-fallback-type",
+            classification_triggers=[],
+            dimension_weights={},
+            applicable_lenses={},
+            red_team_focus={},
+            l1_severity={},
+            is_fallback=True,
+        )
+        monkeypatch.setattr(
+            "autoskillit.cli._validate.load_types_from_dir",
+            lambda _: {"bundled-fallback-type": bundled_fallback},
+        )
+
+        yaml_content = VALID_EXPERIMENT_TYPE + "\nis_fallback: true\n"
+        _write_yaml(tmp_path, "experiment-types", "user_fallback.yaml", yaml_content)
+
+        with pytest.raises(SystemExit) as exc_info:
+            validate_registries()
+        assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        assert "✗" in out
+        assert "is_fallback" in out

--- a/tests/cli/test_validate_registries.py
+++ b/tests/cli/test_validate_registries.py
@@ -362,4 +362,4 @@ class TestValidateRegistries:
         validate_registries()
         out = capsys.readouterr().out
         assert "✓" in out
-        assert "error" not in out.lower()
+        assert "✗" not in out


### PR DESCRIPTION
## Summary

Add a CLI subcommand `autoskillit validate registries` that validates user-override YAML files in `.autoskillit/experiment-types/` and `.autoskillit/methodology-traditions/`. The command reuses existing parse functions from the registry modules, adds five semantic validation checks (schema-version match, applicable-lens references, detection-keyword non-emptiness, priority sanity, is_fallback uniqueness), emits a structured stdout report with status symbols, and writes per-file markdown error reports to `.autoskillit/validation-errors/`. Exit code: 0 if valid or warnings only, 1 if any errors.

## Scope

Add a CLI subcommand `autoskillit validate registries` that runs schema validation against user-override directories at `.autoskillit/experiment-types/` and `.autoskillit/methodology-traditions/`. Emits structured validation report to stdout and writes per-file error reports to `.autoskillit/validation-errors/` when YAMLs are malformed or have invalid references.

## Rationale

Today, user-added YAMLs silently skip on parse error — only a `_log.warning()` entry in the experiment-type-registry loader. Users have no visible feedback that their custom type was rejected. Closing the feedback loop with an explicit CLI validation command makes user-extensibility actually usable.

## Files

- `src/autoskillit/cli/app.py` — register new subcommand
- New: `src/autoskillit/cli/_validate.py` — implementation
- `.gitignore` — add `.autoskillit/validation-errors/` so user-visible error reports are not committed
- `tests/cli/` — tests for the new CLI command

## Validation checks

For each user YAML:

1. **Schema validation** — fields present, types correct per dataclass
2. **Schema-version match** — emit WARN if user YAML's `schema_version` mismatches bundled
3. **Applicable-lens references** — for experiment-type entries, `applicable_lenses.primary` and `.secondary` must reference existing lens slugs. Source of truth: scan `src/autoskillit/skills_extended/` for directory names matching `*-lens` at validation time
4. **Detection-keyword non-emptiness** — at least one detection keyword per trigger
5. **Priority sanity** — `priority` is positive int; only one entry has `is_fallback: true` (experiment-types only)

## Output format (stdout)

```
Validating user registries in /path/to/project/.autoskillit/...

experiment-types/:
  ✓ my_custom_type.yaml  (schema v1.0, priority 15)
  ✗ broken_type.yaml  (ERROR: missing 'dimension_weights' field)
  ⚠ old_format.yaml  (WARN: schema_version '0.9', expected '1.0')

methodology-traditions/:
  ✓ my_field_specific_tradition.yaml

Summary: 3 valid, 1 error, 1 warning
Error details written to .autoskillit/validation-errors/broken_type.yaml.error.md
```

## Error report format (`.autoskillit/validation-errors/broken_type.yaml.error.md`)

```markdown
# Validation error: broken_type.yaml

**File:** .autoskillit/experiment-types/broken_type.yaml
**Validated at:** 2026-04-13T15:32:00Z

## Error

Missing required field 'dimension_weights'.

## Expected schema

```yaml
name: <snake_case>
schema_version: "1.0"
priority: <int>
dimension_weights:
  causal_structure: <L|M|H|S>
  # ... (8 required dimensions)
```

## Your file

```yaml
name: broken_type
schema_version: "1.0"
# ... content that's missing dimension_weights
```

## How to fix

Add the `dimension_weights:` block with all 8 dimensions weighted L/M/H/S.
See bundled examples at `src/autoskillit/recipes/experiment-types/` for reference.
```

## Acceptance criteria

- [ ] CLI subcommand `autoskillit validate registries` exists and is discoverable
- [ ] Validates `.autoskillit/experiment-types/` and `.autoskillit/methodology-traditions/` directories
- [ ] Stdout output is readable (uses ✓ ✗ ⚠ symbols)
- [ ] Per-file error reports written to `.autoskillit/validation-errors/`
- [ ] Exit code: 0 if all valid + warnings; 1 if any errors
- [ ] Test coverage: valid YAML, schema-mismatch, missing-field, invalid-lens-reference cases
- [ ] `task test-check` passes

## Relevant context diagram (validation command flow)

```
  $ autoskillit validate registries
            │
            ▼
  Load bundled registries (read-only reference for schema comparison)
            │
            ▼
  For each file in .autoskillit/experiment-types/:
    │  Parse YAML → ExperimentTypeSpec
    │  Check schema_version
    │  Check applicable_lenses references
    │  Check priority sanity
    ├─► Valid: emit ✓
    ├─► Warn: emit ⚠ (e.g., schema_version mismatch)
    └─► Error: emit ✗ + write per-file error report
            │
            ▼
  Same for .autoskillit/methodology-traditions/
            │
            ▼
  Summary to stdout
  Exit 0 if no errors, 1 if errors
```

## Hand-off notes

Blocked-by Work Items 2.2 (experiment-type loader with schema_version) and 4.3 (methodology-tradition loader). Independent of Units 1 and 4.2. The CLI subcommand reuses the existing parser functions from the registry modules — don't duplicate parsing logic. Error-report-file format is markdown so users can pipe it into their editor or PR review. Consider piggybacking on this command to also validate `.autoskillit/recipes/*.yaml` for user-defined recipes (future enhancement; out of scope for this ticket).

## Dependencies

- **Blocked by:** #834, #842
- **Blocks:** *(none)*

---

*From master plan: `.autoskillit/temp/runx1t1-preflight.md` §11.5.8 (Work Item 9.4 new)*

## Changed Files

### New (★):
- `src/autoskillit/cli/_validate.py`
- `tests/cli/test_validate_registries.py`

### Modified (●):
- `.autoskillit/.gitignore`
- `.gitignore`
- `src/autoskillit/cli/CLAUDE.md`
- `src/autoskillit/cli/__init__.py`
- `src/autoskillit/cli/app.py`
- `src/autoskillit/core/io.py`
- `src/autoskillit/recipe/__init__.py`
- `tests/_test_filter.py`
- `tests/arch/_rules.py`
- `tests/arch/test_subpackage_isolation.py`
- `tests/cli/CLAUDE.md`

Closes #858

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-858-20260506-095104-710829/.autoskillit/temp/make-plan/user_config_validation_cli_plan_2026-05-06_095500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 2.1k | 15.8k | 732.7k | 62.9k | 108 | 61.3k | 8m 27s |
| verify | claude-opus-4-6 | 1 | 935 | 10.7k | 985.4k | 59.2k | 103 | 46.2k | 4m 55s |
| implement | MiniMax-M2.7-highspeed | 1 | 4.2M | 30.7k | 2.6M | 63.2k | 216 | 148.2k | 17m 52s |
| prepare_pr | MiniMax-M2.7-highspeed | 1 | 161.6k | 4.4k | 370.6k | 26.7k | 28 | 15.2k | 1m 30s |
| compose_pr | MiniMax-M2.7-highspeed | 1 | 45.0k | 2.9k | 157.2k | 26.7k | 14 | 15.0k | 54s |
| review_pr | claude-sonnet-4-6 | 3 | 1.1k | 128.7k | 1.8M | 102.1k | 127 | 255.1k | 29m 49s |
| resolve_review | claude-sonnet-4-6 | 3 | 2.8k | 96.1k | 13.1M | 119.6k | 411 | 292.8k | 48m 28s |
| **Total** | | | 4.4M | 289.4k | 19.7M | 119.6k | | 833.9k | 1h 51m |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 784 | 3354.6 | 189.1 | 39.1 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 318 | 41110.8 | 920.9 | 302.4 |
| **Total** | **1102** | 17897.3 | 756.7 | 262.6 |