### PR TITLE
Rectify: Token Summary Schema Drift and Arg Routing — PART A ONLY

### DIFF
--- a/src/autoskillit/hooks/_hook_settings.py
+++ b/src/autoskillit/hooks/_hook_settings.py
@@ -40,6 +40,27 @@ QUOTA_GUARD_HOOK_PAYLOAD_KEYS: frozenset[str] = frozenset(
     {"cache_path", "cache_max_age", "buffer_seconds", "disabled"}
 )
 
+# The exact keys that appear in token_usage.json files written by flush_session_log.
+# The bridge contract test asserts equality between this set and TokenUsageFileEntry
+# annotations — update both together.
+TOKEN_USAGE_FILE_KEYS: frozenset[str] = frozenset(
+    {
+        "session_label",
+        "input_tokens",
+        "output_tokens",
+        "cache_creation_input_tokens",
+        "cache_read_input_tokens",
+        "peak_context",
+        "turn_count",
+        "timing_seconds",
+        "order_id",
+        "loc_insertions",
+        "loc_deletions",
+        "provider_used",
+        "model_identifier",
+    }
+)
+
 
 @dataclass(frozen=True, slots=True)
 class QuotaHookSettings:

--- a/src/autoskillit/hooks/token_summary_hook.py
+++ b/src/autoskillit/hooks/token_summary_hook.py
@@ -213,7 +213,7 @@ def _load_sessions(
         except (json.JSONDecodeError, OSError):
             continue
 
-        raw_step = data.get("step_name", "")
+        raw_step = data.get("session_label", "")
         if not raw_step:
             continue
 

--- a/src/autoskillit/recipe/_cmd_rpc.py
+++ b/src/autoskillit/recipe/_cmd_rpc.py
@@ -605,6 +605,7 @@ def _ensure_and_resolve_labels(cwd: str, owner: str, repo_name: str) -> list[str
 def batch_create_issues(
     workspace: str,
     chunk_size: str = "20",
+    timeout: int = 120,
 ) -> dict[str, str]:
     """Batch-create GitHub issues from validated ticket body files via GraphQL."""
     if not workspace or not Path(workspace).is_dir():

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -135,7 +135,7 @@ async def _import_and_call(
             logger.warning(
                 "run_python stripped sentinel key from args",
                 callable=dotted_path,
-                key=key,
+                arg_name=key,
             )
             del args[key]
 
@@ -149,7 +149,7 @@ async def _import_and_call(
                 logger.warning(
                     "run_python dropped unrecognized arg",
                     callable=dotted_path,
-                    key=key,
+                    arg_name=key,
                     extra_args=[key],
                 )
                 del args[key]

--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -38,6 +38,8 @@ from autoskillit.server._subprocess import _run_subprocess
 
 logger = get_logger(__name__)
 
+_RUN_PYTHON_SENTINEL_KEYS: frozenset[str] = frozenset({"callable", "timeout"})
+
 
 def _coerce_scalar(val: object, annotation: object) -> object:
     """Coerce val to match the annotated type.
@@ -127,6 +129,31 @@ async def _import_and_call(
         return {"success": False, "error": f"{dotted_path!r} is not callable"}
 
     sig = inspect.signature(func)
+
+    for key in list(args.keys()):
+        if key in _RUN_PYTHON_SENTINEL_KEYS:
+            logger.warning(
+                "run_python stripped sentinel key from args",
+                callable=dotted_path,
+                key=key,
+            )
+            del args[key]
+
+    accepts_var_keyword = any(
+        p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
+    )
+    if not accepts_var_keyword:
+        valid_keys = set(sig.parameters.keys())
+        for key in list(args.keys()):
+            if key not in valid_keys:
+                logger.warning(
+                    "run_python dropped unrecognized arg",
+                    callable=dotted_path,
+                    key=key,
+                    extra_args=[key],
+                )
+                del args[key]
+
     try:
         type_hints = typing.get_type_hints(func)
     except Exception:

--- a/src/autoskillit/smoke_utils.py
+++ b/src/autoskillit/smoke_utils.py
@@ -210,6 +210,7 @@ def patch_pr_token_summary(
     cwd: str = "",
     order_id: str = "",
     log_dir: str = "",
+    timeout: int = 60,
 ) -> dict[str, str]:
     import os  # noqa: PLC0415
     import re  # noqa: PLC0415

--- a/tests/contracts/test_token_summary_contracts.py
+++ b/tests/contracts/test_token_summary_contracts.py
@@ -2,13 +2,166 @@
 
 from __future__ import annotations
 
+import ast
 import inspect
+import json
+from pathlib import Path
 
 import pytest
 
+from autoskillit.recipe._cmd_rpc import batch_create_issues
 from autoskillit.smoke_utils import patch_pr_token_summary
 
 pytestmark = [pytest.mark.layer("contracts"), pytest.mark.small]
+
+
+# ── Step 1a: Bridge contract: TOKEN_USAGE_FILE_KEYS must match TokenUsageFileEntry ──
+
+
+def test_token_usage_file_keys_match_typed_dict():
+    """Bridge contract: TOKEN_USAGE_FILE_KEYS must equal TokenUsageFileEntry annotations.
+
+    Analogous to test_hook_bridge_coverage.py for the quota guard.
+    If this fails, update TOKEN_USAGE_FILE_KEYS and TokenUsageFileEntry together.
+    """
+    from autoskillit.core.types import TokenUsageFileEntry
+    from autoskillit.hooks._hook_settings import TOKEN_USAGE_FILE_KEYS
+
+    assert TOKEN_USAGE_FILE_KEYS == set(TokenUsageFileEntry.__annotations__.keys())
+
+
+# ── Step 1b: AST contract: hook reads only keys from TOKEN_USAGE_FILE_KEYS ──
+
+
+def test_hook_load_sessions_reads_only_declared_keys():
+    """AST contract: every data.get() key in _load_sessions must be in TOKEN_USAGE_FILE_KEYS.
+
+    Follows test_config_field_coverage.py pattern. Prevents silent key drift
+    when fields are renamed in the TypedDict but not in the hook.
+    """
+    from autoskillit.hooks._hook_settings import TOKEN_USAGE_FILE_KEYS
+
+    hook_path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "autoskillit"
+        / "hooks"
+        / "token_summary_hook.py"
+    )
+    tree = ast.parse(hook_path.read_text())
+
+    # Find _load_sessions function
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "_load_sessions":
+            # Collect all data.get("key") string arguments
+            disk_keys: set[str] = set()
+            for call in ast.walk(node):
+                if (
+                    isinstance(call, ast.Call)
+                    and isinstance(call.func, ast.Attribute)
+                    and call.func.attr == "get"
+                    and isinstance(call.func.value, ast.Name)
+                    and call.func.value.id == "data"
+                    and call.args
+                    and isinstance(call.args[0], ast.Constant)
+                    and isinstance(call.args[0].value, str)
+                ):
+                    disk_keys.add(call.args[0].value)
+
+            assert disk_keys, "No data.get() calls found in _load_sessions"
+            unexpected = disk_keys - TOKEN_USAGE_FILE_KEYS
+            assert not unexpected, (
+                f"_load_sessions reads keys not in TOKEN_USAGE_FILE_KEYS: {unexpected}. "
+                f"Update the hook or TOKEN_USAGE_FILE_KEYS."
+            )
+            break
+    else:
+        raise AssertionError("_load_sessions function not found in token_summary_hook.py")
+
+
+# ── Step 1c: Cross-seam integration test ──
+
+
+def test_flush_to_hook_cross_seam(tmp_path):
+    """Cross-seam: flush_session_log output must produce non-empty hook aggregation.
+
+    This is the missing link between producer tests (test_session_log_flush.py)
+    and consumer tests (test_token_summary_appender.py). Proves the hook can
+    actually read what the producer writes.
+    """
+    # Simulate what flush_session_log (session_log.py:384-399) writes to token_usage.json
+    session_dir_name = "test-session-abc123"
+    # log_root is the sessions/ dir — _load_sessions reads sessions.jsonl from here
+    # and looks for sessions/{dir_name}/token_usage.json
+    log_root = tmp_path / "sessions"
+    log_root.mkdir(parents=True)
+
+    # Write sessions.jsonl index entry so _load_sessions discovers the session dir
+    sessions_jsonl = log_root / "sessions.jsonl"
+    sessions_jsonl.write_text(
+        json.dumps(
+            {"session_id": "abc123", "dir_name": session_dir_name, "order_id": "test-order"}
+        )
+        + "\n"
+    )
+
+    # Write the token_usage.json that flush_session_log produces
+    session_dir = log_root / "sessions" / session_dir_name
+    session_dir.mkdir(parents=True)
+    tu_data = {
+        "session_label": "plan",
+        "input_tokens": 100,
+        "output_tokens": 200,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "timing_seconds": 1.5,
+        "order_id": "test-order",
+        "loc_insertions": 10,
+        "loc_deletions": 5,
+        "peak_context": 50,
+        "turn_count": 3,
+        "provider_used": "test-provider",
+        "model_identifier": "test-model",
+    }
+    (session_dir / "token_usage.json").write_text(json.dumps(tu_data))
+
+    # Feed the file through the hook's _load_sessions — proves cross-seam coherence
+    from autoskillit.hooks import token_summary_hook
+
+    aggregated = token_summary_hook._load_sessions(log_root, "", order_id="test-order")
+    assert aggregated, (
+        "_load_sessions returned empty dict — hook cannot read what flush_session_log wrote. "
+        "Check key name: flush writes 'session_label' but hook may read 'step_name'."
+    )
+    key = token_summary_hook._canonical("plan")
+    assert key in aggregated, f"Expected key 'plan' in aggregated, got: {list(aggregated.keys())}"
+    entry = aggregated[key]
+    assert entry["input_tokens"] == 100
+    assert entry["output_tokens"] == 200
+
+
+# ── Step 1d: patch_pr_token_summary accepts timeout ──
+
+
+def test_patch_pr_token_summary_accepts_timeout():
+    """patch_pr_token_summary must accept timeout kwarg to absorb LLM arg-routing variance."""
+    sig = inspect.signature(patch_pr_token_summary)
+    assert "timeout" in sig.parameters, (
+        "patch_pr_token_summary must accept 'timeout' parameter. "
+        "Fleet LLMs may route the recipe with: timeout into args."
+    )
+
+
+# ── Step 1e: batch_create_issues accepts timeout ──
+
+
+def test_batch_create_issues_accepts_timeout():
+    """batch_create_issues must accept timeout kwarg to absorb LLM arg-routing variance."""
+    sig = inspect.signature(batch_create_issues)
+    assert "timeout" in sig.parameters
+
+
+# ── Existing structural contracts ──
 
 
 def test_patch_pr_token_summary_uses_order_id_not_cwd_filter():

--- a/tests/hooks/test_token_summary_appender.py
+++ b/tests/hooks/test_token_summary_appender.py
@@ -85,7 +85,7 @@ def _write_sessions(log_root: Path, entries: list[dict]) -> None:
         session_dir = log_root / "sessions" / dir_name
         session_dir.mkdir(parents=True, exist_ok=True)
         token_data = {
-            "step_name": entry.get("step_name", "unknown"),
+            "session_label": entry.get("session_label") or entry.get("step_name", "unknown"),
             "input_tokens": entry.get("input_tokens", 1000),
             "output_tokens": entry.get("output_tokens", 500),
             "cache_creation_input_tokens": entry.get("cache_creation_input_tokens", 100),
@@ -668,7 +668,7 @@ def test_e1_order_id_isolation_multi_issue_session(tmp_path: Path) -> None:
         (d / "token_usage.json").write_text(
             json.dumps(
                 {
-                    "step_name": step,
+                    "session_label": step,
                     "input_tokens": 100,
                     "output_tokens": 50,
                     "cache_creation_input_tokens": 0,
@@ -781,7 +781,7 @@ def test_e3_backward_compat_sessions_without_order_id_field(tmp_path: Path) -> N
     (d / "token_usage.json").write_text(
         json.dumps(
             {
-                "step_name": "plan",
+                "session_label": "plan",
                 "input_tokens": 100,
                 "output_tokens": 50,
                 "cache_creation_input_tokens": 0,

--- a/tests/hooks/test_token_summary_appender.py
+++ b/tests/hooks/test_token_summary_appender.py
@@ -6,98 +6,18 @@ reading on-disk session logs after every run_skill response.
 
 from __future__ import annotations
 
-import io
 import json
 import subprocess
 import sys
-from contextlib import ExitStack, redirect_stdout
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from autoskillit.hooks.formatters._fmt_primitives import _HOOK_CONFIG_PATH_COMPONENTS
-
-
-def _run_hook(
-    event: dict | None = None,
-    raw_stdin: str | None = None,
-    log_root: Path | None = None,
-    hook_config_path: Path | None = None,
-) -> tuple[str, int]:
-    """Run token_summary_appender.main() with synthetic stdin.
-
-    Returns (stdout_output, exit_code).
-
-    Args:
-        hook_config_path: Path to a hook config JSON file containing ``kitchen_id``
-            (or legacy ``pipeline_id``).
-            When provided, patches ``_read_kitchen_id`` to return the ``kitchen_id``
-            value from that file. When absent, ``_read_kitchen_id`` reads from the
-            real filesystem (returns '' if no file present in the test CWD).
-    """
-    from autoskillit.hooks.token_summary_hook import main
-
-    stdin_text = raw_stdin if raw_stdin is not None else json.dumps(event or {})
-    exit_code = 0
-    buf = io.StringIO()
-
-    with ExitStack() as stack:
-        stack.enter_context(patch("sys.stdin", io.StringIO(stdin_text)))
-        stack.enter_context(redirect_stdout(buf))
-        if log_root is not None:
-            stack.enter_context(
-                patch(
-                    "autoskillit.hooks.token_summary_hook._log_root",
-                    return_value=log_root,
-                )
-            )
-        if hook_config_path is not None:
-            cfg_data = json.loads(hook_config_path.read_text(encoding="utf-8"))
-            kitchen_id = cfg_data.get("kitchen_id") or cfg_data.get("pipeline_id", "")
-            stack.enter_context(
-                patch(
-                    "autoskillit.hooks.token_summary_hook._read_kitchen_id",
-                    return_value=kitchen_id,
-                )
-            )
-        try:
-            main()
-        except SystemExit as e:
-            exit_code = e.code if e.code is not None else 0
-
-    return buf.getvalue(), exit_code
-
-
-def _make_run_skill_event(result_text: str = "Done.\n%%ORDER_UP%%") -> dict:
-    """Create a double-wrapped PostToolUse event for run_skill."""
-    inner = {"result": result_text, "success": True}
-    outer = {"result": json.dumps(inner)}
-    return {
-        "tool_name": "mcp__autoskillit_server__run_skill",
-        "tool_response": json.dumps(outer),
-    }
-
-
-def _write_sessions(log_root: Path, entries: list[dict]) -> None:
-    """Write sessions.jsonl and token_usage.json files for test setup."""
-    (log_root / "sessions.jsonl").write_text("\n".join(json.dumps(e) for e in entries) + "\n")
-    for entry in entries:
-        dir_name = entry["dir_name"]
-        session_dir = log_root / "sessions" / dir_name
-        session_dir.mkdir(parents=True, exist_ok=True)
-        token_data = {
-            "session_label": entry.get("session_label") or entry.get("step_name", "unknown"),
-            "input_tokens": entry.get("input_tokens", 1000),
-            "output_tokens": entry.get("output_tokens", 500),
-            "cache_creation_input_tokens": entry.get("cache_creation_input_tokens", 100),
-            "cache_read_input_tokens": entry.get("cache_read_input_tokens", 200),
-            "timing_seconds": entry.get("timing_seconds", 10.0),
-            "loc_insertions": entry.get("loc_insertions", 0),
-            "loc_deletions": entry.get("loc_deletions", 0),
-            "peak_context": entry.get("peak_context", 0),
-            "turn_count": entry.get("turn_count", 0),
-        }
-        (session_dir / "token_usage.json").write_text(json.dumps(token_data))
-
+from tests.infra._token_summary_helpers import (
+    _make_run_skill_event,
+    _run_hook,
+    _write_sessions,
+)
 
 # ---------------------------------------------------------------------------
 # TSA-1: hook script exists on disk

--- a/tests/infra/_token_summary_helpers.py
+++ b/tests/infra/_token_summary_helpers.py
@@ -59,6 +59,11 @@ def _make_run_skill_event(result_text: str = "Done.\n%%ORDER_UP%%") -> dict:
     }
 
 
+def _resolve_session_label(entry: dict) -> str:
+    """Resolve session_label from entry, falling back to step_name for old test data."""
+    return entry.get("session_label") or entry.get("step_name", "unknown")
+
+
 def _write_sessions(log_root: Path, entries: list[dict]) -> None:
     """Write sessions.jsonl and token_usage.json files for test setup."""
     (log_root / "sessions.jsonl").write_text("\n".join(json.dumps(e) for e in entries) + "\n")
@@ -67,7 +72,7 @@ def _write_sessions(log_root: Path, entries: list[dict]) -> None:
         session_dir = log_root / "sessions" / dir_name
         session_dir.mkdir(parents=True, exist_ok=True)
         token_data: dict = {
-            "session_label": entry.get("session_label") or entry.get("step_name", "unknown"),
+            "session_label": _resolve_session_label(entry),
             "input_tokens": entry.get("input_tokens", 1000),
             "output_tokens": entry.get("output_tokens", 500),
             "cache_creation_input_tokens": entry.get("cache_creation_input_tokens", 100),

--- a/tests/infra/_token_summary_helpers.py
+++ b/tests/infra/_token_summary_helpers.py
@@ -67,7 +67,7 @@ def _write_sessions(log_root: Path, entries: list[dict]) -> None:
         session_dir = log_root / "sessions" / dir_name
         session_dir.mkdir(parents=True, exist_ok=True)
         token_data: dict = {
-            "step_name": entry.get("step_name", "unknown"),
+            "session_label": entry.get("session_label") or entry.get("step_name", "unknown"),
             "input_tokens": entry.get("input_tokens", 1000),
             "output_tokens": entry.get("output_tokens", 500),
             "cache_creation_input_tokens": entry.get("cache_creation_input_tokens", 100),

--- a/tests/infra/test_schema_version_convention.py
+++ b/tests/infra/test_schema_version_convention.py
@@ -154,12 +154,12 @@ _LEGACY_JSON_WRITES: set[tuple[str, int]] = {
     # smoke_utils.py — partitions, ranges, diff metrics, queue, enriched handoff
     ("src/autoskillit/smoke_utils.py", 57),
     ("src/autoskillit/smoke_utils.py", 126),
-    # Lines 143 and 357 are list-payload write sites (dual membership: also in list_sites
+    # Lines 143 and 358 are list-payload write sites (dual membership: also in list_sites
     # in test_allowlist_includes_list_payloads_as_documented). The AST scanner catches
     # them because it cannot distinguish list vs dict return types — intentional.
     ("src/autoskillit/smoke_utils.py", 143),
-    ("src/autoskillit/smoke_utils.py", 357),
-    ("src/autoskillit/smoke_utils.py", 405),
+    ("src/autoskillit/smoke_utils.py", 358),
+    ("src/autoskillit/smoke_utils.py", 406),
     # planner/consolidation.py — write-back of merged WP dicts to per-file results
     ("src/autoskillit/planner/consolidation.py", 311),
     # planner/manifests.py — finalize_wp_manifest: wp_index.json rebuild (list payload)
@@ -229,7 +229,7 @@ class TestSchemaVersionConvention:
         # These sites write list payloads through function calls but are caught by the scanner
         list_sites = [
             ("src/autoskillit/smoke_utils.py", 143),
-            ("src/autoskillit/smoke_utils.py", 357),
+            ("src/autoskillit/smoke_utils.py", 358),
         ]
         for site in list_sites:
             assert site in _LEGACY_JSON_WRITES, (

--- a/tests/infra/test_token_summary_core.py
+++ b/tests/infra/test_token_summary_core.py
@@ -678,7 +678,7 @@ def test_load_sessions_reads_model_identifier(tmp_path: Path) -> None:
     (sessions_dir / "token_usage.json").write_text(
         json.dumps(
             {
-                "step_name": "plan",
+                "session_label": "plan",
                 "input_tokens": 100,
                 "output_tokens": 50,
                 "cache_creation_input_tokens": 0,

--- a/tests/infra/test_token_summary_filters.py
+++ b/tests/infra/test_token_summary_filters.py
@@ -95,7 +95,7 @@ def test_e1_order_id_isolation_multi_issue_session(tmp_path: Path) -> None:
         (d / "token_usage.json").write_text(
             json.dumps(
                 {
-                    "step_name": step,
+                    "session_label": step,
                     "input_tokens": 100,
                     "output_tokens": 50,
                     "cache_creation_input_tokens": 0,
@@ -207,7 +207,7 @@ def test_e3_backward_compat_sessions_without_order_id_field(tmp_path: Path) -> N
     (d / "token_usage.json").write_text(
         json.dumps(
             {
-                "step_name": "plan",
+                "session_label": "plan",
                 "input_tokens": 100,
                 "output_tokens": 50,
                 "cache_creation_input_tokens": 0,

--- a/tests/server/_type_coercion_fixtures.py
+++ b/tests/server/_type_coercion_fixtures.py
@@ -28,3 +28,7 @@ def _str_optional_param(value: str = "default") -> dict:
 
 def _str_path_param(path: str) -> Path:
     return Path(path)
+
+
+def _kwargs_callable(name: str, **kwargs: object) -> dict:
+    return {"name": name, "extras": kwargs}

--- a/tests/server/test_tools_run_cmd.py
+++ b/tests/server/test_tools_run_cmd.py
@@ -371,3 +371,46 @@ class TestImportAndCallTypeCoercion:
         )
         assert result["success"] is False
         assert "AssertionError" in result["error"]
+
+    @pytest.mark.anyio
+    async def test_sentinel_keys_stripped_from_args(self):
+        """run_python sentinel keys in args dict must be stripped before callable dispatch."""
+        result = json.loads(
+            await run_python(
+                callable="tests.server._type_coercion_fixtures._str_only_param",
+                args={"value": "x", "timeout": 60, "callable": "bogus.path"},
+                timeout=10,
+            )
+        )
+        assert result["success"] is True
+        assert result["result"]["value"] == "x"
+
+    @pytest.mark.anyio
+    async def test_unrecognized_args_dropped_with_warning(self):
+        """_import_and_call should log a warning and drop args not in the callable's signature."""
+        with structlog.testing.capture_logs() as logs:
+            result = json.loads(
+                await run_python(
+                    callable="tests.server._type_coercion_fixtures._str_only_param",
+                    args={"value": "x", "bogus": 42},
+                    timeout=10,
+                )
+            )
+        assert result["success"] is True
+        assert result["result"]["value"] == "x"
+        warning_logs = [log for log in logs if "bogus" in str(log.get("extra_args", []))]
+        assert len(warning_logs) >= 1
+
+    @pytest.mark.anyio
+    async def test_extra_args_forwarded_when_callable_accepts_kwargs(self):
+        """When the callable accepts **kwargs, extra args should be forwarded."""
+        result = json.loads(
+            await run_python(
+                callable="tests.server._type_coercion_fixtures._kwargs_callable",
+                args={"name": "test", "extra": "y"},
+                timeout=10,
+            )
+        )
+        assert result["success"] is True
+        assert result["result"]["name"] == "test"
+        assert result["result"]["extras"]["extra"] == "y"

--- a/tests/server/test_tools_status_kitchen.py
+++ b/tests/server/test_tools_status_kitchen.py
@@ -233,7 +233,7 @@ class TestTelemetryRecoveryData:
         session_dir = log_root / "sessions" / dir_name
         session_dir.mkdir(parents=True, exist_ok=True)
         tu = {
-            "step_name": step_name,
+            "session_label": step_name,
             "input_tokens": input_tokens,
             "output_tokens": 50,
             "cache_creation_input_tokens": 0,

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -15,6 +15,7 @@ from autoskillit.smoke_utils import (
     enrich_diff_context,
     patch_pr_token_summary,
 )
+from tests.infra._token_summary_helpers import _resolve_session_label
 
 
 # T_SU1
@@ -230,7 +231,7 @@ def _write_test_sessions(log_root: Path, entries: list[dict]) -> None:
         session_dir = log_root / "sessions" / entry["dir_name"]
         session_dir.mkdir(parents=True, exist_ok=True)
         token_data = {
-            "session_label": entry.get("session_label") or entry.get("step_name", "unknown"),
+            "session_label": _resolve_session_label(entry),
             "input_tokens": entry.get("input_tokens", 1000),
             "output_tokens": entry.get("output_tokens", 500),
             "cache_creation_input_tokens": entry.get("cache_creation_input_tokens", 100),

--- a/tests/test_smoke_utils.py
+++ b/tests/test_smoke_utils.py
@@ -230,7 +230,7 @@ def _write_test_sessions(log_root: Path, entries: list[dict]) -> None:
         session_dir = log_root / "sessions" / entry["dir_name"]
         session_dir.mkdir(parents=True, exist_ok=True)
         token_data = {
-            "step_name": entry.get("step_name", "unknown"),
+            "session_label": entry.get("session_label") or entry.get("step_name", "unknown"),
             "input_tokens": entry.get("input_tokens", 1000),
             "output_tokens": entry.get("output_tokens", 500),
             "cache_creation_input_tokens": entry.get("cache_creation_input_tokens", 100),


### PR DESCRIPTION
## Summary

The token summary system has suffered its 12th bug due to two structural weaknesses: (1) no enforced schema contract between the `token_usage.json` producer (`session_log.py`) and its stdlib-only hook consumer (`token_summary_hook.py`), allowing field renames to silently break the hook; and (2) no runtime parameter sanitization in `_import_and_call`, allowing LLM-routed tool-level params to leak into callable kwargs.

Part A fixes both bugs and establishes bridge contract tests that make this class of schema drift structurally impossible. Part B will add runtime arg sanitization in `_import_and_call` to guard against the broader LLM arg-routing class of bugs.

Closes #2009

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/remediation-20260506-095058-360589/.autoskillit/temp/rectify/rectify_token_summary_schema_drift_and_arg_routing_2026-05-06_095859.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| rectify | claude-sonnet-4-6 | 1 | 2.5k | 15.6k | 1.1M | 130.7k | 214 | 75.0k | 10m 39s |
| dry_walkthrough | claude-sonnet-4-6 | 2 | 1.7k | 33.8k | 2.2M | 73.0k | 205 | 113.6k | 16m 8s |
| implement | MiniMax-M2.7-highspeed | 2 | 4.5M | 33.5k | 3.0M | 52.3k | 303 | 136.4k | 24m 21s |
| prepare_pr | MiniMax-M2.7-highspeed | 1 | 110.1k | 3.7k | 213.6k | 26.7k | 22 | 39.0k | 1m 28s |
| compose_pr | MiniMax-M2.7-highspeed | 1 | 89.0k | 1.9k | 210.7k | 26.7k | 20 | 15.0k | 50s |
| review_pr | claude-sonnet-4-6 | 1 | 86 | 26.3k | 400.1k | 64.5k | 31 | 55.8k | 5m 48s |
| resolve_review | claude-opus-4-6 | 2 | 91 | 18.3k | 2.2M | 84.6k | 87 | 127.9k | 9m 56s |
| **Total** | | | 4.7M | 133.1k | 9.3M | 130.7k | | 562.7k | 1h 9m |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 278 | 10711.2 | 490.5 | 120.6 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 200 | 11027.1 | 639.3 | 91.5 |
| **Total** | **478** | 19454.4 | 1177.1 | 278.4 |