### PR TITLE
Multi-Match Disambiguation Rules

### DIFF
--- a/src/autoskillit/recipe/CLAUDE.md
+++ b/src/autoskillit/recipe/CLAUDE.md
@@ -20,6 +20,7 @@ Sub-package: rules/ (see rules/CLAUDE.md).
 | `experiment_type_registry.py` | `ExperimentTypeSpec`, `load_all_experiment_types` |
 | `methodology_tradition_registry.py` | `MethodologyTraditionSpec`, `load_all_methodology_traditions`, `get_methodology_tradition_by_name`, `is_out_of_scope_tradition` |
 | `methodology_tradition_router.py` | `TraditionRouterResult`, `UnionRuleDef`, `classify_methodology` — two-stage Tier-C router |
+| `methodology_disambiguation.py` | `DisambiguationRuleDef`, `CrossTraditionOverlapDef`, `DisambiguationResult`, `disambiguate`, `load_disambiguation_rules` |
 | `registry.py` | `RuleFinding`, `RuleSpec`, `semantic_rule` decorator |
 | `repository.py` | `RecipeRepository` implementation |
 | `_analysis.py` | `ValidationContext` + `make_validation_context` |

--- a/src/autoskillit/recipe/__init__.py
+++ b/src/autoskillit/recipe/__init__.py
@@ -62,6 +62,13 @@ from autoskillit.recipe.io import (  # noqa: E402
     load_recipe,
 )
 from autoskillit.recipe.loader import parse_recipe_metadata  # noqa: E402
+from autoskillit.recipe.methodology_disambiguation import (  # noqa: E402
+    CrossTraditionOverlapDef,
+    DisambiguationResult,
+    DisambiguationRuleDef,
+    disambiguate,
+    load_disambiguation_rules,
+)
 from autoskillit.recipe.methodology_tradition_registry import (  # noqa: E402
     BUNDLED_METHODOLOGY_TRADITIONS_DIR,
     MethodologyTraditionSpec,
@@ -195,6 +202,11 @@ __all__ = [
     "get_methodology_tradition_by_name",
     "is_out_of_scope_tradition",
     "load_all_methodology_traditions",
+    "CrossTraditionOverlapDef",
+    "DisambiguationResult",
+    "DisambiguationRuleDef",
+    "disambiguate",
+    "load_disambiguation_rules",
     # --- methodology tradition router ---
     "TraditionRouterResult",
     "UnionRuleDef",

--- a/src/autoskillit/recipe/__init__.py
+++ b/src/autoskillit/recipe/__init__.py
@@ -64,6 +64,7 @@ from autoskillit.recipe.io import (  # noqa: E402
 from autoskillit.recipe.loader import parse_recipe_metadata  # noqa: E402
 from autoskillit.recipe.methodology_disambiguation import (  # noqa: E402
     CrossTraditionOverlapDef,
+    DisambiguationExceptionDef,
     DisambiguationResult,
     DisambiguationRuleDef,
     disambiguate,
@@ -203,6 +204,7 @@ __all__ = [
     "is_out_of_scope_tradition",
     "load_all_methodology_traditions",
     "CrossTraditionOverlapDef",
+    "DisambiguationExceptionDef",
     "DisambiguationResult",
     "DisambiguationRuleDef",
     "disambiguate",

--- a/src/autoskillit/recipe/methodology_disambiguation.py
+++ b/src/autoskillit/recipe/methodology_disambiguation.py
@@ -5,11 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
-from autoskillit.core import load_yaml
+from autoskillit.core import load_yaml, pkg_root
 
-BUNDLED_METHODOLOGY_TRADITIONS_DIR: Path = (
-    Path(__file__).parent.parent / "recipes" / "methodology-traditions"
-)
+BUNDLED_METHODOLOGY_TRADITIONS_DIR: Path = pkg_root() / "recipes" / "methodology-traditions"
 
 
 @dataclass(frozen=True)
@@ -39,6 +37,7 @@ class CrossTraditionOverlapDef:
     trigger_traditions: frozenset[str]
     primary_tradition: str
     applied_union_rules: tuple[str, ...]
+    overrides_primary: bool = False
 
 
 @dataclass(frozen=True)
@@ -88,6 +87,7 @@ def load_disambiguation_rules() -> tuple[
                 trigger_traditions=frozenset(o["trigger_traditions"]),
                 primary_tradition=o["primary_tradition"],
                 applied_union_rules=tuple(o["applied_union_rules"]),
+                overrides_primary=bool(o.get("overrides_primary", False)),
             )
         )
 
@@ -167,7 +167,7 @@ def disambiguate(
         if overlap.trigger_traditions.issubset(candidate_names):
             union_rules.extend(overlap.applied_union_rules)
             trace_parts.append(f"overlap_{overlap.name}")
-            if primary is None:
+            if primary is None or overlap.overrides_primary:
                 primary = overlap.primary_tradition
                 trace_parts.append(f"overlap_primary_{overlap.name}")
 

--- a/src/autoskillit/recipe/methodology_disambiguation.py
+++ b/src/autoskillit/recipe/methodology_disambiguation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
 
 from autoskillit.core import load_yaml, pkg_root
 
@@ -11,7 +12,7 @@ BUNDLED_METHODOLOGY_TRADITIONS_DIR: Path = pkg_root() / "recipes" / "methodology
 
 
 @dataclass(frozen=True)
-class DisambiguationException:
+class DisambiguationExceptionDef:
     when_present: str
     add_union_rules: tuple[str, ...]
 
@@ -22,11 +23,11 @@ class DisambiguationRuleDef:
     order: int
     description: str
     trigger_traditions: frozenset[str]
-    trigger_mode: str
+    trigger_mode: Literal["anchor_plus_any", "all_present"]
     anchor: str | None
     primary_tradition: str
     applied_union_rules: tuple[str, ...]
-    exceptions: tuple[DisambiguationException, ...]
+    exceptions: tuple[DisambiguationExceptionDef, ...]
 
 
 @dataclass(frozen=True)
@@ -52,44 +53,55 @@ def load_disambiguation_rules() -> tuple[
     list[DisambiguationRuleDef], list[CrossTraditionOverlapDef]
 ]:
     yaml_path = BUNDLED_METHODOLOGY_TRADITIONS_DIR / "_disambiguation.yaml"
-    data = load_yaml(yaml_path)
+    try:
+        data = load_yaml(yaml_path)
+    except Exception as exc:
+        raise RuntimeError(f"Failed to load disambiguation rules from {yaml_path}") from exc
 
     rules: list[DisambiguationRuleDef] = []
-    for r in data.get("disambiguation_rules", []):
-        exceptions = tuple(
-            DisambiguationException(
-                when_present=e["when_present"],
-                add_union_rules=tuple(e["add_union_rules"]),
+    for idx, r in enumerate(data.get("disambiguation_rules", [])):
+        try:
+            exceptions = tuple(
+                DisambiguationExceptionDef(
+                    when_present=e["when_present"],
+                    add_union_rules=tuple(e["add_union_rules"]),
+                )
+                for e in r.get("exceptions", [])
             )
-            for e in r.get("exceptions", [])
-        )
-        rules.append(
-            DisambiguationRuleDef(
-                name=r["name"],
-                order=r["order"],
-                description=r["description"],
-                trigger_traditions=frozenset(r["trigger_traditions"]),
-                trigger_mode=r["trigger_mode"],
-                anchor=r.get("anchor"),
-                primary_tradition=r["primary_tradition"],
-                applied_union_rules=tuple(r["applied_union_rules"]),
-                exceptions=exceptions,
+            rules.append(
+                DisambiguationRuleDef(
+                    name=r["name"],
+                    order=r["order"],
+                    description=r["description"],
+                    trigger_traditions=frozenset(r["trigger_traditions"]),
+                    trigger_mode=r["trigger_mode"],
+                    anchor=r.get("anchor"),
+                    primary_tradition=r["primary_tradition"],
+                    applied_union_rules=tuple(r["applied_union_rules"]),
+                    exceptions=exceptions,
+                )
             )
-        )
+        except (KeyError, TypeError) as exc:
+            name = r.get("name", f"<index {idx}>") if isinstance(r, dict) else f"<index {idx}>"
+            raise RuntimeError(f"Invalid disambiguation_rules entry {name!r}: {exc}") from exc
 
     overlaps: list[CrossTraditionOverlapDef] = []
-    for o in data.get("cross_tradition_overlaps", []):
-        overlaps.append(
-            CrossTraditionOverlapDef(
-                name=o["name"],
-                order=o["order"],
-                description=o["description"],
-                trigger_traditions=frozenset(o["trigger_traditions"]),
-                primary_tradition=o["primary_tradition"],
-                applied_union_rules=tuple(o["applied_union_rules"]),
-                overrides_primary=bool(o.get("overrides_primary", False)),
+    for idx, o in enumerate(data.get("cross_tradition_overlaps", [])):
+        try:
+            overlaps.append(
+                CrossTraditionOverlapDef(
+                    name=o["name"],
+                    order=o["order"],
+                    description=o["description"],
+                    trigger_traditions=frozenset(o["trigger_traditions"]),
+                    primary_tradition=o["primary_tradition"],
+                    applied_union_rules=tuple(o["applied_union_rules"]),
+                    overrides_primary=bool(o.get("overrides_primary", False)),
+                )
             )
-        )
+        except (KeyError, TypeError) as exc:
+            name = o.get("name", f"<index {idx}>") if isinstance(o, dict) else f"<index {idx}>"
+            raise RuntimeError(f"Invalid cross_tradition_overlaps entry {name!r}: {exc}") from exc
 
     rules.sort(key=lambda r: r.order)
     overlaps.sort(key=lambda o: o.order)
@@ -150,7 +162,6 @@ def disambiguate(
         sorted(candidate_names, key=lambda n: (tradition_priority.get(n, 999), n))
     )
 
-    # Phase 1: Sequential rule check (first match wins)
     for rule in sorted(rules, key=lambda r: r.order):
         if _rule_matches(rule, candidate_names):
             primary = rule.primary_tradition
@@ -162,7 +173,6 @@ def disambiguate(
                     trace_parts.append(f"exception_{exc.when_present}")
             break
 
-    # Phase 2: Overlap check (all matching overlaps accumulate)
     for overlap in sorted(overlaps, key=lambda o: o.order):
         if overlap.trigger_traditions.issubset(candidate_names):
             union_rules.extend(overlap.applied_union_rules)
@@ -171,7 +181,6 @@ def disambiguate(
                 primary = overlap.primary_tradition
                 trace_parts.append(f"overlap_primary_{overlap.name}")
 
-    # Phase 3: Fallthrough
     if primary is None:
         primary = sorted_candidates[0]
         trace_parts.append("fallthrough_priority")

--- a/src/autoskillit/recipe/methodology_disambiguation.py
+++ b/src/autoskillit/recipe/methodology_disambiguation.py
@@ -1,0 +1,184 @@
+"""Methodology tradition disambiguation — resolves multi-tradition candidate sets."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from autoskillit.core import load_yaml
+
+BUNDLED_METHODOLOGY_TRADITIONS_DIR: Path = (
+    Path(__file__).parent.parent / "recipes" / "methodology-traditions"
+)
+
+
+@dataclass(frozen=True)
+class DisambiguationException:
+    when_present: str
+    add_union_rules: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class DisambiguationRuleDef:
+    name: str
+    order: int
+    description: str
+    trigger_traditions: frozenset[str]
+    trigger_mode: str
+    anchor: str | None
+    primary_tradition: str
+    applied_union_rules: tuple[str, ...]
+    exceptions: tuple[DisambiguationException, ...]
+
+
+@dataclass(frozen=True)
+class CrossTraditionOverlapDef:
+    name: str
+    order: int
+    description: str
+    trigger_traditions: frozenset[str]
+    primary_tradition: str
+    applied_union_rules: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class DisambiguationResult:
+    primary_tradition: str | None
+    applied_union_rules: tuple[str, ...]
+    precedence_trace: str
+    candidate_set: tuple[str, ...]
+
+
+def load_disambiguation_rules() -> tuple[
+    list[DisambiguationRuleDef], list[CrossTraditionOverlapDef]
+]:
+    yaml_path = BUNDLED_METHODOLOGY_TRADITIONS_DIR / "_disambiguation.yaml"
+    data = load_yaml(yaml_path)
+
+    rules: list[DisambiguationRuleDef] = []
+    for r in data.get("disambiguation_rules", []):
+        exceptions = tuple(
+            DisambiguationException(
+                when_present=e["when_present"],
+                add_union_rules=tuple(e["add_union_rules"]),
+            )
+            for e in r.get("exceptions", [])
+        )
+        rules.append(
+            DisambiguationRuleDef(
+                name=r["name"],
+                order=r["order"],
+                description=r["description"],
+                trigger_traditions=frozenset(r["trigger_traditions"]),
+                trigger_mode=r["trigger_mode"],
+                anchor=r.get("anchor"),
+                primary_tradition=r["primary_tradition"],
+                applied_union_rules=tuple(r["applied_union_rules"]),
+                exceptions=exceptions,
+            )
+        )
+
+    overlaps: list[CrossTraditionOverlapDef] = []
+    for o in data.get("cross_tradition_overlaps", []):
+        overlaps.append(
+            CrossTraditionOverlapDef(
+                name=o["name"],
+                order=o["order"],
+                description=o["description"],
+                trigger_traditions=frozenset(o["trigger_traditions"]),
+                primary_tradition=o["primary_tradition"],
+                applied_union_rules=tuple(o["applied_union_rules"]),
+            )
+        )
+
+    rules.sort(key=lambda r: r.order)
+    overlaps.sort(key=lambda o: o.order)
+
+    return rules, overlaps
+
+
+def _rule_matches(rule: DisambiguationRuleDef, candidates: set[str]) -> bool:
+    if rule.trigger_mode == "anchor_plus_any":
+        return rule.anchor is not None and rule.anchor in candidates and len(candidates) >= 2
+    elif rule.trigger_mode == "all_present":
+        return rule.trigger_traditions.issubset(candidates)
+    return False
+
+
+def disambiguate(
+    candidate_names: set[str],
+    *,
+    rules: list[DisambiguationRuleDef] | None = None,
+    overlaps: list[CrossTraditionOverlapDef] | None = None,
+    tradition_priority: dict[str, int] | None = None,
+) -> DisambiguationResult:
+    if not candidate_names:
+        return DisambiguationResult(
+            primary_tradition=None,
+            applied_union_rules=(),
+            precedence_trace="no_candidates",
+            candidate_set=(),
+        )
+
+    if len(candidate_names) == 1:
+        name = next(iter(candidate_names))
+        return DisambiguationResult(
+            primary_tradition=name,
+            applied_union_rules=(),
+            precedence_trace="single_candidate",
+            candidate_set=(name,),
+        )
+
+    if rules is None or overlaps is None:
+        loaded_rules, loaded_overlaps = load_disambiguation_rules()
+        if rules is None:
+            rules = loaded_rules
+        if overlaps is None:
+            overlaps = loaded_overlaps
+
+    if tradition_priority is None:
+        from autoskillit.recipe.methodology_tradition_registry import (
+            load_all_methodology_traditions,
+        )
+
+        tradition_priority = {s.name: s.priority for s in load_all_methodology_traditions()}
+
+    primary: str | None = None
+    union_rules: list[str] = []
+    trace_parts: list[str] = []
+    sorted_candidates = tuple(
+        sorted(candidate_names, key=lambda n: (tradition_priority.get(n, 999), n))
+    )
+
+    # Phase 1: Sequential rule check (first match wins)
+    for rule in sorted(rules, key=lambda r: r.order):
+        if _rule_matches(rule, candidate_names):
+            primary = rule.primary_tradition
+            union_rules.extend(rule.applied_union_rules)
+            trace_parts.append(f"rule_{rule.name}")
+            for exc in rule.exceptions:
+                if exc.when_present in candidate_names:
+                    union_rules.extend(exc.add_union_rules)
+                    trace_parts.append(f"exception_{exc.when_present}")
+            break
+
+    # Phase 2: Overlap check (all matching overlaps accumulate)
+    for overlap in sorted(overlaps, key=lambda o: o.order):
+        if overlap.trigger_traditions.issubset(candidate_names):
+            union_rules.extend(overlap.applied_union_rules)
+            trace_parts.append(f"overlap_{overlap.name}")
+            if primary is None:
+                primary = overlap.primary_tradition
+                trace_parts.append(f"overlap_primary_{overlap.name}")
+
+    # Phase 3: Fallthrough
+    if primary is None:
+        primary = sorted_candidates[0]
+        trace_parts.append("fallthrough_priority")
+
+    return DisambiguationResult(
+        primary_tradition=primary,
+        applied_union_rules=tuple(union_rules),
+        precedence_trace="+".join(trace_parts) if trace_parts else "no_match",
+        candidate_set=sorted_candidates,
+    )

--- a/src/autoskillit/recipe/methodology_tradition_registry.py
+++ b/src/autoskillit/recipe/methodology_tradition_registry.py
@@ -100,6 +100,8 @@ def _load_traditions_from_dir(directory: Path) -> dict[str, MethodologyTradition
         return {}
     result: dict[str, MethodologyTraditionSpec] = {}
     for path in sorted(directory.glob("*.yaml")):
+        if path.name.startswith("_"):
+            continue
         try:
             data = load_yaml(path)
             if isinstance(data, dict):

--- a/src/autoskillit/recipes/methodology-traditions/_disambiguation.yaml
+++ b/src/autoskillit/recipes/methodology-traditions/_disambiguation.yaml
@@ -65,6 +65,7 @@ cross_tradition_overlaps:
     trigger_traditions: [method_comparison_benchmarking, systematic_synthesis]
     primary_tradition: method_comparison_benchmarking
     applied_union_rules: [PRISMA_curation_phase]
+    overrides_primary: true
 
   - name: srqr_consort_parallel
     order: 9

--- a/src/autoskillit/recipes/methodology-traditions/_disambiguation.yaml
+++ b/src/autoskillit/recipes/methodology-traditions/_disambiguation.yaml
@@ -1,0 +1,74 @@
+schema_version: "1.0"
+
+disambiguation_rules:
+  - name: prisma_dominance
+    order: 1
+    description: "PRISMA dominates any primary design tradition"
+    trigger_mode: anchor_plus_any
+    anchor: systematic_synthesis
+    trigger_traditions: [systematic_synthesis]
+    primary_tradition: systematic_synthesis
+    applied_union_rules: []
+    exceptions:
+      - when_present: prediction_model_validation
+        add_union_rules: [TRIPOD_SRMA]
+
+  - name: rct_economic_union
+    order: 2
+    description: "RCT + Economic evaluation invoke both rule sets"
+    trigger_mode: all_present
+    trigger_traditions: [controlled_intervention, economic_evaluation]
+    primary_tradition: controlled_intervention
+    applied_union_rules: [CHEERS_union]
+
+  - name: arrive_supersedes_consort
+    order: 3
+    description: "ARRIVE supersedes CONSORT for animal studies"
+    trigger_mode: all_present
+    trigger_traditions: [animal_preclinical, controlled_intervention]
+    primary_tradition: animal_preclinical
+    applied_union_rules: []
+
+  - name: benchmarking_prediction_nested
+    order: 4
+    description: "Benchmarking with TRIPOD+AI calibration/discrimination nested"
+    trigger_mode: all_present
+    trigger_traditions: [method_comparison_benchmarking, prediction_model_validation]
+    primary_tradition: method_comparison_benchmarking
+    applied_union_rules: [TRIPOD_nested]
+
+cross_tradition_overlaps:
+  - name: tripod_consort_union
+    order: 5
+    description: "Model validated within an RCT"
+    trigger_traditions: [prediction_model_validation, controlled_intervention]
+    primary_tradition: controlled_intervention
+    applied_union_rules: [TRIPOD_union]
+
+  - name: strobe_prisma_moose
+    order: 6
+    description: "Meta-analysis of observational studies uses MOOSE"
+    trigger_traditions: [observational_correlational, systematic_synthesis]
+    primary_tradition: systematic_synthesis
+    applied_union_rules: [MOOSE_override]
+
+  - name: odd_controlled_nesting
+    order: 7
+    description: "Simulation calibrated against experimental data"
+    trigger_traditions: [simulation_modeling_tradition, controlled_intervention]
+    primary_tradition: simulation_modeling_tradition
+    applied_union_rules: [controlled_intervention_secondary]
+
+  - name: benchmarking_prisma_separation
+    order: 8
+    description: "Dataset curation via PRISMA; algorithm evaluation via Weber"
+    trigger_traditions: [method_comparison_benchmarking, systematic_synthesis]
+    primary_tradition: method_comparison_benchmarking
+    applied_union_rules: [PRISMA_curation_phase]
+
+  - name: srqr_consort_parallel
+    order: 9
+    description: "Mixed-methods RCT qualitative component"
+    trigger_traditions: [qualitative_interpretive_tradition, controlled_intervention]
+    primary_tradition: controlled_intervention
+    applied_union_rules: [SRQR_parallel]

--- a/src/autoskillit/skills_extended/vis-lens-methodology-norms/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-methodology-norms/SKILL.md
@@ -64,6 +64,44 @@ This lens currently covers 8 ML sub-areas. Future domain-specific variants (e.g.
 venue-specific norms, additional mandatory figure types, or sub-area-specific anti-pattern
 overlays. The base lens should remain general enough to bootstrap any sub-area.
 
+## Multi-Match Disambiguation Rules
+
+When multiple methodology traditions match a research plan, disambiguation rules are applied
+sequentially to determine the primary tradition and accumulate union rule sets.
+
+### Disambiguation Resolution Order
+
+1. **Rules 1–4** checked sequentially — first match determines `primary_tradition` and may add union rules
+2. **Overlaps 5–9** checked in parallel — all matching overlaps accumulate `applied_union_rules`; if no rule set primary, the first matching overlap's `primary_tradition` is used
+3. **Fallthrough** — highest-priority tradition (lowest `priority` number) from candidate set becomes primary
+
+### Disambiguation Rules
+
+| Order | Rule Name | Trigger Conditions | Resolution | Union Rules |
+|-------|-----------|-------------------|------------|-------------|
+| 1 | `prisma_dominance` | `systematic_synthesis` + any other tradition | primary = `systematic_synthesis` | — |
+| 1 (exception) | `prisma_dominance` + `prediction_model_validation` | `systematic_synthesis` + `prediction_model_validation` | primary = `systematic_synthesis` | +TRIPOD_SRMA |
+| 2 | `rct_economic_union` | `controlled_intervention` + `economic_evaluation` | primary = `controlled_intervention` | +CHEERS_union |
+| 3 | `arrive_supersedes_consort` | `animal_preclinical` + `controlled_intervention` | primary = `animal_preclinical` | — |
+| 4 | `benchmarking_prediction_nested` | `method_comparison_benchmarking` + `prediction_model_validation` | primary = `method_comparison_benchmarking` | +TRIPOD_nested |
+
+### Cross-Tradition Overlaps
+
+| Order | Overlap Name | Trigger Conditions | Primary if No Rule | Union Rules |
+|-------|--------------|-------------------|-------------------|-------------|
+| 5 | `tripod_consort_union` | `prediction_model_validation` + `controlled_intervention` | `controlled_intervention` | +TRIPOD_union |
+| 6 | `strobe_prisma_moose` | `observational_correlational` + `systematic_synthesis` | `systematic_synthesis` | +MOOSE_override |
+| 7 | `odd_controlled_nesting` | `simulation_modeling_tradition` + `controlled_intervention` | `simulation_modeling_tradition` | +controlled_intervention_secondary |
+| 8 | `benchmarking_prisma_separation` | `method_comparison_benchmarking` + `systematic_synthesis` | `method_comparison_benchmarking` | +PRISMA_curation_phase |
+| 9 | `srqr_consort_parallel` | `qualitative_interpretive_tradition` + `controlled_intervention` | `controlled_intervention` | +SRQR_parallel |
+
+### Output Format
+
+When disambiguation is invoked, the result includes:
+- **`primary_tradition`**: The selected primary methodology tradition name
+- **`applied_union_rules`**: Tuple of union rule strings accumulated from matching rules/overlaps
+- **`precedence_trace`**: String describing which rules and overlaps fired (e.g., `rule_prisma_dominance+overlap_strobe_prisma_moose`)
+
 ## Critical Constraints
 
 **NEVER:**

--- a/tests/recipe/CLAUDE.md
+++ b/tests/recipe/CLAUDE.md
@@ -48,6 +48,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_loader.py` | Tests for path-based recipe metadata utilities |
 | `test_make_campaign_output_schema.py` | Tests for make-campaign recipe output schema |
 | `test_methodology_tradition_registry.py` | Tests for `MethodologyTraditionSpec`, `load_all_methodology_traditions`, and `is_out_of_scope_tradition` |
+| `test_methodology_disambiguation.py` | Tests for `DisambiguationRuleDef`, `CrossTraditionOverlapDef`, `DisambiguationResult`, `disambiguate`, and `load_disambiguation_rules` |
 | `test_methodology_tradition_router.py` | Tests for `classify_methodology` two-stage Tier-C router: per-tradition classification, multi-match, union rules, determinism |
 | `test_merge_prs.py` | Tests for merge-prs recipe structure |
 | `test_merge_prs_queue_any.py` | Tests for merge-prs-queue (any strategy) recipe |

--- a/tests/recipe/test_methodology_disambiguation.py
+++ b/tests/recipe/test_methodology_disambiguation.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import dataclasses
+
 import pytest
 
 from autoskillit.recipe.methodology_disambiguation import (
@@ -85,7 +87,7 @@ class TestStructuralBehavioralTests:
 
     def test_result_is_frozen(self) -> None:
         result = disambiguate({"controlled_intervention", "economic_evaluation"})
-        with pytest.raises(Exception):  # FrozenInstanceError
+        with pytest.raises(dataclasses.FrozenInstanceError):
             result.primary_tradition = "something_else"
 
     def test_single_candidate_returns_that_candidate(self) -> None:
@@ -102,8 +104,6 @@ class TestStructuralBehavioralTests:
 
     def test_load_disambiguation_rules_bundled(self) -> None:
         rules, overlaps = load_disambiguation_rules()
-        assert len(rules) == 4
-        assert len(overlaps) == 5
         rule_names = {r.name for r in rules}
         assert rule_names == {
             "prisma_dominance",

--- a/tests/recipe/test_methodology_disambiguation.py
+++ b/tests/recipe/test_methodology_disambiguation.py
@@ -1,0 +1,136 @@
+"""Tests for methodology disambiguation."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.recipe.methodology_disambiguation import (
+    disambiguate,
+    load_disambiguation_rules,
+)
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+
+class TestRuleTests:
+    def test_rule_prisma_dominance(self) -> None:
+        result = disambiguate({"systematic_synthesis", "controlled_intervention"})
+        assert result.primary_tradition == "systematic_synthesis"
+        assert "rule_prisma_dominance" in result.precedence_trace
+
+    def test_rule_prisma_dominance_tripod_srma_exception(self) -> None:
+        result = disambiguate({"systematic_synthesis", "prediction_model_validation"})
+        assert result.primary_tradition == "systematic_synthesis"
+        assert "TRIPOD_SRMA" in result.applied_union_rules
+        assert "exception_prediction_model_validation" in result.precedence_trace
+
+    def test_rule_rct_economic_union(self) -> None:
+        result = disambiguate({"controlled_intervention", "economic_evaluation"})
+        assert result.primary_tradition == "controlled_intervention"
+        assert "CHEERS_union" in result.applied_union_rules
+        assert "rule_rct_economic_union" in result.precedence_trace
+
+    def test_rule_arrive_supersedes_consort(self) -> None:
+        result = disambiguate({"animal_preclinical", "controlled_intervention"})
+        assert result.primary_tradition == "animal_preclinical"
+        assert result.applied_union_rules == ()
+        assert "rule_arrive_supersedes_consort" in result.precedence_trace
+
+    def test_rule_benchmarking_prediction_nested(self) -> None:
+        result = disambiguate({"method_comparison_benchmarking", "prediction_model_validation"})
+        assert result.primary_tradition == "method_comparison_benchmarking"
+        assert "TRIPOD_nested" in result.applied_union_rules
+        assert "rule_benchmarking_prediction_nested" in result.precedence_trace
+
+
+class TestOverlapTests:
+    def test_overlap_tripod_consort_union(self) -> None:
+        result = disambiguate({"prediction_model_validation", "controlled_intervention"})
+        assert result.primary_tradition == "controlled_intervention"
+        assert "TRIPOD_union" in result.applied_union_rules
+        assert "overlap_tripod_consort_union" in result.precedence_trace
+
+    def test_overlap_strobe_prisma_moose(self) -> None:
+        result = disambiguate({"observational_correlational", "systematic_synthesis"})
+        assert result.primary_tradition == "systematic_synthesis"
+        assert "MOOSE_override" in result.applied_union_rules
+        assert "rule_prisma_dominance" in result.precedence_trace
+        assert "overlap_strobe_prisma_moose" in result.precedence_trace
+
+    def test_overlap_odd_controlled_nesting(self) -> None:
+        result = disambiguate({"simulation_modeling_tradition", "controlled_intervention"})
+        assert result.primary_tradition == "simulation_modeling_tradition"
+        assert "controlled_intervention_secondary" in result.applied_union_rules
+        assert "overlap_odd_controlled_nesting" in result.precedence_trace
+
+    def test_overlap_benchmarking_prisma_separation(self) -> None:
+        result = disambiguate({"method_comparison_benchmarking", "systematic_synthesis"})
+        assert result.primary_tradition == "method_comparison_benchmarking"
+        assert "PRISMA_curation_phase" in result.applied_union_rules
+        assert "rule_prisma_dominance" in result.precedence_trace
+        assert "overlap_benchmarking_prisma_separation" in result.precedence_trace
+
+    def test_overlap_srqr_consort_parallel(self) -> None:
+        result = disambiguate({"qualitative_interpretive_tradition", "controlled_intervention"})
+        assert result.primary_tradition == "controlled_intervention"
+        assert "SRQR_parallel" in result.applied_union_rules
+        assert "overlap_srqr_consort_parallel" in result.precedence_trace
+
+
+class TestStructuralBehavioralTests:
+    def test_fallthrough_uses_highest_priority(self) -> None:
+        result = disambiguate({"diagnostic_accuracy", "quality_improvement"})
+        assert result.primary_tradition == "diagnostic_accuracy"
+        assert "fallthrough_priority" in result.precedence_trace
+
+    def test_result_is_frozen(self) -> None:
+        result = disambiguate({"controlled_intervention", "economic_evaluation"})
+        with pytest.raises(Exception):  # FrozenInstanceError
+            result.primary_tradition = "something_else"
+
+    def test_single_candidate_returns_that_candidate(self) -> None:
+        result = disambiguate({"controlled_intervention"})
+        assert result.primary_tradition == "controlled_intervention"
+        assert result.precedence_trace == "single_candidate"
+        assert result.applied_union_rules == ()
+
+    def test_empty_candidate_set(self) -> None:
+        result = disambiguate(set())
+        assert result.primary_tradition is None
+        assert result.precedence_trace == "no_candidates"
+        assert result.candidate_set == ()
+
+    def test_load_disambiguation_rules_bundled(self) -> None:
+        rules, overlaps = load_disambiguation_rules()
+        assert len(rules) == 4
+        assert len(overlaps) == 5
+        rule_names = {r.name for r in rules}
+        assert rule_names == {
+            "prisma_dominance",
+            "rct_economic_union",
+            "arrive_supersedes_consort",
+            "benchmarking_prediction_nested",
+        }
+        overlap_names = {o.name for o in overlaps}
+        assert overlap_names == {
+            "tripod_consort_union",
+            "strobe_prisma_moose",
+            "odd_controlled_nesting",
+            "benchmarking_prisma_separation",
+            "srqr_consort_parallel",
+        }
+
+    def test_disambiguation_deterministic(self) -> None:
+        candidates = {"controlled_intervention", "economic_evaluation"}
+        results = [disambiguate(candidates) for _ in range(10)]
+        for r in results[1:]:
+            assert r.primary_tradition == results[0].primary_tradition
+            assert r.applied_union_rules == results[0].applied_union_rules
+            assert r.precedence_trace == results[0].precedence_trace
+
+    def test_rule_precedence_order(self) -> None:
+        result = disambiguate(
+            {"systematic_synthesis", "animal_preclinical", "controlled_intervention"}
+        )
+        assert result.primary_tradition == "systematic_synthesis"
+        assert result.precedence_trace.startswith("rule_prisma_dominance")


### PR DESCRIPTION
## Summary

Create a methodology tradition disambiguation module that encodes 4 named disambiguation rules and 5 named cross-tradition overlaps. When multiple traditions match a research plan, the module applies rules sequentially to determine the primary tradition and accumulates union rule sets. Rules are defined in YAML (`_disambiguation.yaml`) and loaded/applied by a new Python module (`methodology_disambiguation.py`). The vis-lens-methodology-norms SKILL.md receives a new section documenting the rules for LLM consumption.

## Requirements

- Each of the four disambiguation rules encoded in a verifiable form (YAML block or SKILL.md section)
- Each of the five overlaps named and handled deterministically
- Tier-C router (Work Item 4.4) receives the disambiguation result as structured output (primary_tradition + applied_union_rules list)
- Unit test per disambiguation rule with fixture plans (4 + 5 = 9 tests minimum)
- `task test-check` passes

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-844-20260506-105208-869334/.autoskillit/temp/make-plan/multi_match_disambiguation_rules_plan_2026-05-06_110000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 4.4k | 19.6k | 638.0k | 75.5k | 152 | 73.2k | 11m 54s |
| verify | claude-opus-4-6 | 1 | 36 | 7.5k | 840.8k | 60.0k | 85 | 46.9k | 4m 3s |
| implement | MiniMax-M2.7-highspeed | 1 | 832.0k | 10.1k | 851.6k | 54.1k | 96 | 51.5k | 4m 5s |
| prepare_pr | MiniMax-M2.7-highspeed | 1 | 63.3k | 3.7k | 157.2k | 26.7k | 19 | 15.2k | 1m 9s |
| compose_pr | MiniMax-M2.7-highspeed | 1 | 37.8k | 1.6k | 157.2k | 26.7k | 14 | 15.0k | 42s |
| review_pr | claude-sonnet-4-6 | 1 | 92 | 31.0k | 464.6k | 76.9k | 45 | 64.6k | 7m 8s |
| resolve_review | claude-sonnet-4-6 | 1 | 335 | 18.2k | 2.8M | 91.9k | 96 | 146.3k | 7m 33s |
| resolve_queue_merge_conflicts | claude-sonnet-4-6 | 1 | 179 | 7.1k | 909.7k | 57.7k | 49 | 45.1k | 2m 37s |
| **Total** | | | 938.0k | 98.8k | 6.8M | 91.9k | | 457.8k | 39m 13s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 448 | 1900.9 | 115.0 | 22.5 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 91 | 30418.6 | 1608.1 | 200.1 |
| resolve_queue_merge_conflicts | 2196 | 414.3 | 20.5 | 3.2 |
| **Total** | **2735** | 2481.6 | 167.4 | 36.1 |