### PR TITLE
feat: mark token summary steps using non-Anthropic providers with *

### DIFF
--- a/src/autoskillit/hooks/formatters/_fmt_status.py
+++ b/src/autoskillit/hooks/formatters/_fmt_status.py
@@ -18,9 +18,13 @@ def _fmt_get_token_summary(data: dict, _pipeline: bool) -> str:
     """Format get_token_summary compact Markdown-KV output (JSON payload only)."""
     lines = ["## token_summary", ""]
     steps = data.get("steps", [])
+    has_non_anthropic = False
     for step in steps:
         name = step.get("step_name", "?")
         model = step.get("model", "")
+        if model and not model.startswith("claude-"):
+            name = f"{name}*"
+            has_non_anthropic = True
         count = step.get("invocation_count", 1)
         inp = _fmt_tokens(step.get("input_tokens", 0))
         out = _fmt_tokens(step.get("output_tokens", 0))
@@ -52,6 +56,9 @@ def _fmt_get_token_summary(data: dict, _pipeline: bool) -> str:
         lines.append(f"mcp_invocations: {mcp_total.get('total_invocations', 0)}")
         est_tokens = mcp_total.get("total_estimated_response_tokens", 0)
         lines.append(f"mcp_response_tokens: ~{_fmt_tokens(est_tokens)}")
+    if has_non_anthropic:
+        lines.append("")
+        lines.append("* Step used a non-Anthropic provider; caching behavior may differ.")
     model_totals = data.get("model_totals", [])
     if model_totals:
         lines.append("")

--- a/src/autoskillit/hooks/token_summary_hook.py
+++ b/src/autoskillit/hooks/token_summary_hook.py
@@ -271,10 +271,14 @@ def _format_table(aggregated: dict[str, dict[str, Any]]) -> str:
     total_peak = 0
     total_cache_wr = 0
     total_time = 0.0
+    has_non_anthropic = False
 
     for entry in aggregated.values():
         name = entry["step_name"]
         model = entry.get("model", "")
+        if model and not model.startswith("claude-"):
+            name = f"{name}*"
+            has_non_anthropic = True
         count = entry.get("invocation_count", 1)
         inp = entry["input_tokens"]
         out = entry["output_tokens"]
@@ -303,6 +307,9 @@ def _format_table(aggregated: dict[str, dict[str, Any]]) -> str:
         f" | {_humanize(total_cache_rd)} | {_humanize(total_peak)}"
         f" | | {_humanize(total_cache_wr)} | {_fmt_duration(total_time)} |"
     )
+    if has_non_anthropic:
+        lines.append("")
+        lines.append(r"\* *Step used a non-Anthropic provider; caching behavior may differ.*")
 
     return "\n".join(lines)
 

--- a/src/autoskillit/pipeline/telemetry_fmt.py
+++ b/src/autoskillit/pipeline/telemetry_fmt.py
@@ -182,9 +182,13 @@ class TelemetryFormatter:
             _TOKEN_MD_HEADER,
             _TOKEN_MD_SEP,
         ]
+        has_non_anthropic = False
         for step in steps:
             name = step.get("step_name", "?")
             model = step.get("model", "")
+            if model and not model.startswith("claude-"):
+                name = f"{name}*"
+                has_non_anthropic = True
             count = step.get("invocation_count", 1)
             inp = h(step.get("input_tokens", 0))
             out = h(step.get("output_tokens", 0))
@@ -208,6 +212,9 @@ class TelemetryFormatter:
             f"| **Total** | | | {total_in} | {total_out} | {total_cache_rd}"
             f" | {total_peak} | | {total_cache_wr} | {fmt_dur(total_time)} |"
         )
+        if has_non_anthropic:
+            lines.append("")
+            lines.append(r"\* *Step used a non-Anthropic provider; caching behavior may differ.*")
         return "\n".join(lines)
 
     @staticmethod
@@ -238,11 +245,17 @@ class TelemetryFormatter:
         fmt_dur = TelemetryFormatter._fmt_duration
 
         rows: list[tuple[str, str, str, str, str, str, str, str, str, str]] = []
+        has_non_anthropic = False
         for step in steps:
+            step_name = step.get("step_name", "?")
+            model = step.get("model", "")
+            if model and not model.startswith("claude-"):
+                step_name = f"{step_name}*"
+                has_non_anthropic = True
             rows.append(
                 (
-                    step.get("step_name", "?"),
-                    step.get("model", ""),
+                    step_name,
+                    model,
                     str(step.get("invocation_count", 1)),
                     h(step.get("input_tokens", 0)),
                     h(step.get("output_tokens", 0)),
@@ -267,7 +280,10 @@ class TelemetryFormatter:
             fmt_dur(total.get("total_elapsed_seconds", 0.0)),
         )
 
-        return _render_terminal_table(_TOKEN_COLUMNS, rows + [total_row])
+        result = _render_terminal_table(_TOKEN_COLUMNS, rows + [total_row])
+        if has_non_anthropic:
+            result += "\n* Step used a non-Anthropic provider; caching behavior may differ."
+        return result
 
     @staticmethod
     def format_timing_table_terminal(steps: list[dict], total: dict) -> str:
@@ -295,9 +311,13 @@ class TelemetryFormatter:
         h = TelemetryFormatter._humanize
 
         lines = ["## token_summary", ""]
+        has_non_anthropic = False
         for step in steps:
             name = step.get("step_name", "?")
             model = step.get("model", "")
+            if model and not model.startswith("claude-"):
+                name = f"{name}*"
+                has_non_anthropic = True
             count = step.get("invocation_count", 1)
             inp = h(step.get("input_tokens", 0))
             out = h(step.get("output_tokens", 0))
@@ -326,6 +346,9 @@ class TelemetryFormatter:
                 lines.append(f"mcp_invocations: {mcp_total.get('total_invocations', 0)}")
                 est_tokens = mcp_total.get("total_estimated_response_tokens", 0)
                 lines.append(f"mcp_response_tokens: ~{h(est_tokens)}")
+        if has_non_anthropic:
+            lines.append("")
+            lines.append("* Step used a non-Anthropic provider; caching behavior may differ.")
         return "\n".join(lines)
 
     @staticmethod

--- a/src/autoskillit/pipeline/telemetry_fmt.py
+++ b/src/autoskillit/pipeline/telemetry_fmt.py
@@ -137,6 +137,10 @@ _MODEL_MD_HEADER = "| " + " | ".join(_model_md_headers) + " |"
 _MODEL_MD_SEP = "|" + "|".join("-" * (len(h) + 2) for h in _model_md_headers) + "|"
 
 
+def _is_non_anthropic(model: str) -> bool:
+    return bool(model) and not model.startswith("claude-")
+
+
 def _ratio(tokens: int, loc: int) -> str:
     return f"{tokens / loc:.1f}" if loc > 0 else "—"
 
@@ -186,7 +190,7 @@ class TelemetryFormatter:
         for step in steps:
             name = step.get("step_name", "?")
             model = step.get("model", "")
-            if model and not model.startswith("claude-"):
+            if _is_non_anthropic(model):
                 name = f"{name}*"
                 has_non_anthropic = True
             count = step.get("invocation_count", 1)
@@ -249,7 +253,7 @@ class TelemetryFormatter:
         for step in steps:
             step_name = step.get("step_name", "?")
             model = step.get("model", "")
-            if model and not model.startswith("claude-"):
+            if _is_non_anthropic(model):
                 step_name = f"{step_name}*"
                 has_non_anthropic = True
             rows.append(
@@ -315,7 +319,7 @@ class TelemetryFormatter:
         for step in steps:
             name = step.get("step_name", "?")
             model = step.get("model", "")
-            if model and not model.startswith("claude-"):
+            if _is_non_anthropic(model):
                 name = f"{name}*"
                 has_non_anthropic = True
             count = step.get("invocation_count", 1)

--- a/tests/hooks/test_token_summary_appender.py
+++ b/tests/hooks/test_token_summary_appender.py
@@ -813,6 +813,30 @@ def test_e4_kitchen_id_renamed_in_hook_config(tmp_path: Path) -> None:
     assert result == "legacy-pipeline-uuid"
 
 
+# T9
+def test_non_anthropic_step_marked_in_format_table() -> None:
+    """Hook _format_table marks non-Anthropic step names with * and adds footnote."""
+    from autoskillit.hooks.token_summary_hook import _format_table
+
+    aggregated = {
+        "implement": {
+            "step_name": "implement",
+            "model": "MiniMax-M2.7-highspeed",
+            "input_tokens": 307600,
+            "output_tokens": 3400,
+            "cache_read_input_tokens": 0,
+            "cache_creation_input_tokens": 0,
+            "invocation_count": 1,
+            "elapsed_seconds": 60.0,
+            "peak_context": 0,
+            "turn_count": 0,
+        },
+    }
+    result = _format_table(aggregated)
+    assert "| implement* |" in result
+    assert "non-Anthropic provider" in result
+
+
 # ---------------------------------------------------------------------------
 # _unwrap_mcp_response unit tests
 # ---------------------------------------------------------------------------

--- a/tests/infra/test_pretty_output_recipe.py
+++ b/tests/infra/test_pretty_output_recipe.py
@@ -189,6 +189,54 @@ def test_hook_token_summary_output_equivalent_to_canonical():
     )
 
 
+def test_hook_token_summary_non_anthropic_equivalent_to_canonical():
+    """1g-ext: Hook and canonical produce identical * annotation and footnote."""
+    from autoskillit.hooks.formatters.pretty_output_hook import _fmt_get_token_summary
+    from autoskillit.pipeline.telemetry_fmt import TelemetryFormatter
+
+    data = {
+        "steps": [
+            {
+                "step_name": "plan",
+                "model": "claude-sonnet-4-6",
+                "input_tokens": 7000,
+                "output_tokens": 5939,
+                "cache_creation_input_tokens": 8495,
+                "cache_read_input_tokens": 252179,
+                "invocation_count": 1,
+                "wall_clock_seconds": 45.0,
+                "elapsed_seconds": 40.0,
+            },
+            {
+                "step_name": "implement",
+                "model": "MiniMax-M2.7-highspeed",
+                "input_tokens": 2031000,
+                "output_tokens": 122306,
+                "cache_creation_input_tokens": 280601,
+                "cache_read_input_tokens": 19071323,
+                "invocation_count": 3,
+                "wall_clock_seconds": 492.0,
+                "elapsed_seconds": 480.0,
+            },
+        ],
+        "total": {
+            "input_tokens": 2038000,
+            "output_tokens": 128245,
+            "cache_creation_input_tokens": 289096,
+            "cache_read_input_tokens": 19323502,
+            "total_elapsed_seconds": 537.0,
+        },
+        "mcp_responses": {
+            "total": {"total_invocations": 42, "total_estimated_response_tokens": 5000}
+        },
+    }
+    hook_output = _fmt_get_token_summary(data, _pipeline=False)
+    canonical_output = TelemetryFormatter.format_compact_kv(
+        data["steps"], data["total"], mcp_responses=data["mcp_responses"]
+    )
+    assert hook_output == canonical_output
+
+
 def test_fmt_run_skill_interactive_shows_four_token_fields():
     """_fmt_run_skill interactive mode shows all 4 token fields."""
     data = {

--- a/tests/infra/test_token_summary_core.py
+++ b/tests/infra/test_token_summary_core.py
@@ -536,6 +536,57 @@ def test_efficiency_table_equivalence() -> None:
     )
 
 
+def test_token_table_equivalence_non_anthropic() -> None:
+    """Token table equivalence holds when non-Anthropic models are present."""
+    from autoskillit.hooks.token_summary_hook import _format_table
+    from autoskillit.pipeline.telemetry_fmt import TelemetryFormatter
+
+    steps_data = [
+        {
+            "step_name": "plan",
+            "model": "claude-sonnet-4-6",
+            "input_tokens": 7000,
+            "output_tokens": 5939,
+            "cache_creation_input_tokens": 8495,
+            "cache_read_input_tokens": 252179,
+            "peak_context": 45000,
+            "turn_count": 8,
+            "invocation_count": 1,
+            "elapsed_seconds": 45.0,
+        },
+        {
+            "step_name": "implement",
+            "model": "MiniMax-M2.7-highspeed",
+            "input_tokens": 2031000,
+            "output_tokens": 122306,
+            "cache_creation_input_tokens": 280601,
+            "cache_read_input_tokens": 19071323,
+            "peak_context": 890000,
+            "turn_count": 42,
+            "invocation_count": 3,
+            "elapsed_seconds": 492.0,
+        },
+    ]
+
+    canonical_total = {
+        "input_tokens": sum(s["input_tokens"] for s in steps_data),
+        "output_tokens": sum(s["output_tokens"] for s in steps_data),
+        "cache_creation_input_tokens": sum(s["cache_creation_input_tokens"] for s in steps_data),
+        "cache_read_input_tokens": sum(s["cache_read_input_tokens"] for s in steps_data),
+        "peak_context": max(s["peak_context"] for s in steps_data),
+        "total_elapsed_seconds": sum(s["elapsed_seconds"] for s in steps_data),
+    }
+    aggregated = {s["step_name"]: dict(s) for s in steps_data}
+
+    canonical_output = TelemetryFormatter.format_token_table(list(steps_data), canonical_total)
+    hook_output = _format_table(aggregated)
+
+    assert canonical_output == hook_output
+    assert "implement*" in canonical_output
+    assert "non-Anthropic provider" in canonical_output
+    assert "plan*" not in canonical_output
+
+
 def test_token_table_equivalence() -> None:
     """Canonical format_token_table and hook _format_table produce identical output."""
     from autoskillit.hooks.token_summary_hook import _format_table

--- a/tests/pipeline/test_telemetry_formatter.py
+++ b/tests/pipeline/test_telemetry_formatter.py
@@ -106,6 +106,106 @@ class TestFormatTokenTable:
         result = TelemetryFormatter.format_token_table(steps, total)
         assert "30s" in result
 
+    # T1
+    def test_non_anthropic_step_marked(self) -> None:
+        steps = [
+            {
+                "step_name": "implement",
+                "model": "MiniMax-M2.7-highspeed",
+                "input_tokens": 307600,
+                "output_tokens": 3400,
+                "cache_read_input_tokens": 0,
+                "cache_creation_input_tokens": 0,
+                "invocation_count": 1,
+                "wall_clock_seconds": 60.0,
+            },
+        ]
+        total = {
+            "input_tokens": 307600,
+            "output_tokens": 3400,
+            "cache_read_input_tokens": 0,
+            "cache_creation_input_tokens": 0,
+            "total_elapsed_seconds": 60.0,
+        }
+        result = TelemetryFormatter.format_token_table(steps, total)
+        assert "| implement* |" in result
+
+    # T2
+    def test_non_anthropic_footnote_present(self) -> None:
+        steps = [
+            {
+                "step_name": "implement",
+                "model": "MiniMax-M2.7-highspeed",
+                "input_tokens": 1000,
+                "output_tokens": 500,
+                "cache_read_input_tokens": 0,
+                "cache_creation_input_tokens": 0,
+                "invocation_count": 1,
+                "wall_clock_seconds": 10.0,
+            },
+        ]
+        total = {
+            "input_tokens": 1000,
+            "output_tokens": 500,
+            "cache_read_input_tokens": 0,
+            "cache_creation_input_tokens": 0,
+            "total_elapsed_seconds": 10.0,
+        }
+        result = TelemetryFormatter.format_token_table(steps, total)
+        assert "non-Anthropic provider" in result
+        assert "caching behavior may differ" in result
+
+    # T3
+    def test_anthropic_step_not_marked(self) -> None:
+        steps = [
+            {
+                "step_name": "plan",
+                "model": "claude-sonnet-4-6",
+                "input_tokens": 1000,
+                "output_tokens": 500,
+                "cache_read_input_tokens": 200,
+                "cache_creation_input_tokens": 100,
+                "invocation_count": 1,
+                "wall_clock_seconds": 10.0,
+            },
+        ]
+        total = {
+            "input_tokens": 1000,
+            "output_tokens": 500,
+            "cache_read_input_tokens": 200,
+            "cache_creation_input_tokens": 100,
+            "total_elapsed_seconds": 10.0,
+        }
+        result = TelemetryFormatter.format_token_table(steps, total)
+        assert "| plan |" in result
+        assert "plan*" not in result
+        assert "non-Anthropic" not in result
+
+    # T4
+    def test_empty_model_not_marked(self) -> None:
+        steps = [
+            {
+                "step_name": "plan",
+                "model": "",
+                "input_tokens": 1000,
+                "output_tokens": 500,
+                "cache_read_input_tokens": 200,
+                "cache_creation_input_tokens": 100,
+                "invocation_count": 1,
+                "wall_clock_seconds": 10.0,
+            },
+        ]
+        total = {
+            "input_tokens": 1000,
+            "output_tokens": 500,
+            "cache_read_input_tokens": 200,
+            "cache_creation_input_tokens": 100,
+            "total_elapsed_seconds": 10.0,
+        }
+        result = TelemetryFormatter.format_token_table(steps, total)
+        assert "plan*" not in result
+        assert "non-Anthropic" not in result
+
     def test_snapshot(self) -> None:
         """Golden snapshot test for token table format."""
         steps = [
@@ -871,3 +971,55 @@ def test_compact_kv_no_model_tag_when_empty() -> None:
     total = {}
     output = TelemetryFormatter.format_compact_kv(steps, total)
     assert "model:" not in output
+
+
+# T5
+def test_non_anthropic_step_marked_terminal() -> None:
+    steps = [
+        {
+            "step_name": "implement",
+            "model": "MiniMax-M2.7-highspeed",
+            "input_tokens": 307600,
+            "output_tokens": 3400,
+            "cache_read_input_tokens": 0,
+            "cache_creation_input_tokens": 0,
+            "invocation_count": 1,
+            "wall_clock_seconds": 60.0,
+        },
+    ]
+    total = {
+        "input_tokens": 307600,
+        "output_tokens": 3400,
+        "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": 0,
+        "total_elapsed_seconds": 60.0,
+    }
+    result = TelemetryFormatter.format_token_table_terminal(steps, total)
+    assert "implement*" in result
+    assert "non-Anthropic provider" in result
+
+
+# T6
+def test_non_anthropic_step_marked_compact_kv() -> None:
+    steps = [
+        {
+            "step_name": "implement",
+            "model": "MiniMax-M2.7-highspeed",
+            "input_tokens": 307600,
+            "output_tokens": 3400,
+            "cache_read_input_tokens": 0,
+            "cache_creation_input_tokens": 0,
+            "invocation_count": 1,
+            "wall_clock_seconds": 60.0,
+        },
+    ]
+    total = {
+        "input_tokens": 307600,
+        "output_tokens": 3400,
+        "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": 0,
+        "total_elapsed_seconds": 60.0,
+    }
+    result = TelemetryFormatter.format_compact_kv(steps, total)
+    assert "implement*" in result
+    assert "non-Anthropic provider" in result


### PR DESCRIPTION
## Summary

When pipeline steps route to a non-Anthropic provider, the Token Usage Summary table currently shows high `uncached` values with no context. This plan adds a `*` suffix to the step name for any step whose `model` field is non-empty and does not start with `"claude-"`, plus a footnote below the table explaining the annotation. Three independent rendering paths must be updated in lockstep: the canonical Python formatter (Path A), the PostToolUse hook inline formatter (Path B), and the PR-append hook formatter (Path C).

## Requirements

## Problem

When pipeline steps route to a non-Anthropic provider (e.g. MiniMax via `providers.step_overrides`), the Token Usage Summary table shows high `uncached` values that look alarming but are expected — non-Anthropic providers have different caching architectures. There is currently no visual indicator distinguishing these steps from Anthropic-routed ones, which causes confusion when reviewing pipeline telemetry.

## Proposed Change

In the Token Usage Summary table, for any step whose model does not start with `claude-`, append a `*` to the step name. Below the table, add a footnote:

> \* Step used a non-Anthropic provider; caching behavior may differ.

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Changed Files

### Modified (●):
● src/autoskillit/hooks/formatters/_fmt_status.py
● src/autoskillit/hooks/token_summary_hook.py
● src/autoskillit/pipeline/telemetry_fmt.py
● tests/hooks/test_token_summary_appender.py
● tests/infra/test_pretty_output_recipe.py
● tests/infra/test_token_summary_core.py
● tests/pipeline/test_telemetry_formatter.py

Closes #2005

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260506-124315-695998/.autoskillit/temp/make-plan/token_summary_non_anthropic_markers_plan_2026-05-06_124500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 10.8k | 14.4k | 748.5k | 64.6k | 90 | 63.6k | 8m 24s |
| verify | claude-opus-4-6 | 1 | 495 | 21.5k | 1.8M | 80.4k | 71 | 67.5k | 9m 34s |
| implement | MiniMax-M2.7-highspeed | 1 | 2.3M | 15.0k | 1.4M | 108.0k | 117 | 107.7k | 9m 7s |
| prepare_pr | MiniMax-M2.7-highspeed | 1 | 72.6k | 2.9k | 240.5k | 35.0k | 22 | 25.0k | 1m 11s |
| compose_pr | MiniMax-M2.7-highspeed | 1 | 55.7k | 1.6k | 175.7k | 29.8k | 16 | 14.9k | 41s |
| review_pr | claude-opus-4-6 | 1 | 37 | 23.0k | 445.7k | 64.1k | 30 | 53.0k | 5m 12s |
| resolve_review | claude-opus-4-6 | 1 | 40 | 11.9k | 1.2M | 70.5k | 49 | 57.6k | 9m 58s |
| **Total** | | | 2.5M | 90.2k | 6.0M | 108.0k | | 389.1k | 44m 8s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 318 | 4371.4 | 338.5 | 47.3 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 10 | 124917.9 | 5756.9 | 1186.5 |
| **Total** | **328** | 18422.9 | 1186.2 | 275.0 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 1 | 10.8k | 14.4k | 748.5k | 63.6k | 8m 24s |
| claude-opus-4-6 | 1 | 495 | 21.5k | 1.8M | 67.5k | 9m 34s |
| MiniMax-M2.7-highspeed | 3 | 2.5M | 19.5k | 1.8M | 147.5k | 10m 58s |