### PR TITLE
Use Existing DISPATCH_ID_ENV_VAR Constant + Add EXPECTED_PRIORITIES Sync Guard

### DIFF
--- a/src/autoskillit/server/tools/tools_execution.py
+++ b/src/autoskillit/server/tools/tools_execution.py
@@ -18,6 +18,7 @@ from fastmcp import Context
 from fastmcp.dependencies import CurrentContext
 
 from autoskillit.core import (
+    DISPATCH_ID_ENV_VAR,
     LayoutError,
     SkillResult,
     ValidatedAddDir,
@@ -486,7 +487,7 @@ async def run_skill(
         # by fleet/_api.py into every L2 food truck session environment and inherited by all
         # sub-sessions, ensuring token log entries carry the correct order_id without
         # requiring recipe authors to thread it through every run_skill call.
-        effective_order_id = order_id or os.environ.get("AUTOSKILLIT_DISPATCH_ID", "")
+        effective_order_id = order_id or os.environ.get(DISPATCH_ID_ENV_VAR, "")
 
         if _get_config().safety.require_dry_walkthrough:
             if (gate_error := _check_dry_walkthrough(skill_command, cwd)) is not None:

--- a/src/autoskillit/smoke_utils.py
+++ b/src/autoskillit/smoke_utils.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from autoskillit.core import get_logger
+from autoskillit.core import DISPATCH_ID_ENV_VAR, get_logger
 
 logger = get_logger(__name__)
 
@@ -230,7 +230,7 @@ def patch_pr_token_summary(
     # AUTOSKILLIT_DISPATCH_ID is set by the fleet dispatcher on all L2 food truck sessions
     # and inherited by sub-sessions, providing correct multi-clone scoping
     # without requiring recipe authors to pass order_id explicitly.
-    effective_order_id = order_id or os.environ.get("AUTOSKILLIT_DISPATCH_ID", "")
+    effective_order_id = order_id or os.environ.get(DISPATCH_ID_ENV_VAR, "")
 
     log_root = resolve_log_dir(log_dir)
     token_log = DefaultTokenLog()

--- a/tests/recipe/test_experiment_type_registry.py
+++ b/tests/recipe/test_experiment_type_registry.py
@@ -332,6 +332,7 @@ def test_priority_assignments_match_contract() -> None:
         "qualitative_interpretive": 11,
         "exploratory": 999,
     }
+    assert set(EXPECTED_PRIORITIES.keys()) == EXPECTED_TYPES
     types = load_all_experiment_types()
     by_name = {s.name: s for s in types}
     for name, expected_priority in EXPECTED_PRIORITIES.items():


### PR DESCRIPTION
## Summary

Two cohesion fixes from the review-decisions audit:

1. **[F33]** Replace hardcoded `"AUTOSKILLIT_DISPATCH_ID"` string literals with the existing `DISPATCH_ID_ENV_VAR` constant (from `core/types/_type_constants.py`) in `smoke_utils.py` and `server/tools/tools_execution.py`. Both files already import from `autoskillit.core` — no new cross-layer dependency.

2. **[F09]** Add `assert set(EXPECTED_PRIORITIES.keys()) == EXPECTED_TYPES` at the start of `test_priority_assignments_match_contract` in `tests/recipe/test_experiment_type_registry.py` to guard against a new bundled experiment type being added to `EXPECTED_TYPES` without a corresponding priority entry.

Closes #1964

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260506-124314-736097/.autoskillit/temp/make-plan/use_dispatch_id_env_var_constant_add_expected_priorities_sync_guard_plan_2026-05-06_124900.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 70 | 6.4k | 614.0k | 55.1k | 63 | 57.3k | 3m 47s |
| verify | claude-opus-4-6 | 1 | 896 | 6.0k | 604.2k | 47.6k | 51 | 34.5k | 2m 48s |
| implement | MiniMax-M2.7-highspeed | 1 | 312.2k | 4.7k | 681.7k | 29.8k | 60 | 31.2k | 2m 12s |
| prepare_pr | MiniMax-M2.7-highspeed | 1 | 89.9k | 3.3k | 294.8k | 29.8k | 20 | 15.2k | 1m 26s |
| compose_pr | MiniMax-M2.7-highspeed | 1 | 64.1k | 1.7k | 235.3k | 29.8k | 19 | 15.0k | 48s |
| review_pr | claude-opus-4-6 | 1 | 27 | 7.1k | 292.3k | 40.4k | 25 | 28.0k | 2m 31s |
| **Total** | | | 467.1k | 29.2k | 2.7M | 55.1k | | 181.2k | 13m 34s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 8 | 85216.6 | 3898.6 | 584.8 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **8** | 340283.9 | 22655.0 | 3647.5 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 966 | 12.4k | 1.2M | 91.8k | 6m 35s |
| MiniMax-M2.7-highspeed | 3 | 466.1k | 9.7k | 1.2M | 61.4k | 4m 26s |