### PR TITLE
Cache Invalidation Hardening — recipe/_api.py FIPS Fix + Test Fix

### DIFF
--- a/src/autoskillit/recipe/_api.py
+++ b/src/autoskillit/recipe/_api.py
@@ -115,7 +115,7 @@ def _compute_registry_hash(experiment_types_dir: Path) -> str:
             entries.append((p.name, p.stat().st_mtime_ns))
         except OSError:
             continue
-    return hashlib.md5(str(entries).encode()).hexdigest()
+    return hashlib.md5(str(entries).encode(), usedforsecurity=False).hexdigest()
 
 
 @_dc

--- a/tests/recipe/test_api.py
+++ b/tests/recipe/test_api.py
@@ -730,7 +730,7 @@ def test_path_mtime_ns_exists_and_old_helpers_removed() -> None:
 
 def test_compute_registry_hash_changes_on_mtime(tmp_path: Path) -> None:
     """Registry hash changes when a YAML file's mtime changes."""
-    import time
+    import os
 
     from autoskillit.recipe._api import _compute_registry_hash
 
@@ -740,8 +740,9 @@ def test_compute_registry_hash_changes_on_mtime(tmp_path: Path) -> None:
     f.write_text("name: test\n")
     h1 = _compute_registry_hash(d)
 
-    time.sleep(0.01)
-    f.write_text("name: test\n")  # same content, new mtime
+    f.write_text("name: test\n")  # same content
+    stat = f.stat()
+    os.utime(f, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1_000_000_000))  # +1 second
     h2 = _compute_registry_hash(d)
 
     assert h1 != h2


### PR DESCRIPTION
## Summary

Two targeted fixes in the recipe cache-invalidation path:

1. **FIPS compliance** (`src/autoskillit/recipe/_api.py:118`): Add `usedforsecurity=False` to the `hashlib.md5()` call in `_compute_registry_hash`. This hash is purely for cache fingerprinting — non-cryptographic. Without this kwarg, FIPS-140 hardened systems (RHEL 8+, certain CI) raise `ValueError`. Python >=3.11 is the project floor, so the parameter is supported.

2. **Deterministic test** (`tests/recipe/test_api.py:731`): Replace the `time.sleep(0.01)` hack with `os.utime()` using an explicit +1s mtime offset. The sleep is architecturally insufficient — on 1-second-resolution filesystems (HFS+, some ext4), 10ms does not advance `st_mtime_ns`, causing intermittent assertion failures.

Closes #1963

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-20260506-124313-790499/.autoskillit/temp/make-plan/recipe_api_fips_mtime_plan_2026-05-06_124500.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-opus-4-6 | 1 | 67 | 4.5k | 331.3k | 36.2k | 32 | 51.5k | 3m 8s |
| verify | claude-opus-4-6 | 1 | 29 | 4.0k | 325.5k | 36.2k | 50 | 21.9k | 2m 55s |
| implement | MiniMax-M2.7-highspeed | 1 | 176.2k | 2.7k | 476.2k | 29.8k | 35 | 56.3k | 1m 37s |
| prepare_pr | MiniMax-M2.7-highspeed | 1 | 68.8k | 3.0k | 235.3k | 29.8k | 21 | 15.2k | 1m 19s |
| compose_pr | MiniMax-M2.7-highspeed | 1 | 83.5k | 1.7k | 294.8k | 29.8k | 21 | 15.0k | 51s |
| review_pr | claude-opus-4-6 | 1 | 35 | 5.1k | 249.1k | 38.3k | 22 | 25.3k | 1m 56s |
| **Total** | | | 328.6k | 21.0k | 1.9M | 38.3k | | 185.1k | 11m 48s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 9 | 52913.8 | 6255.0 | 299.2 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **9** | 212468.8 | 20567.4 | 2332.3 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-opus-4-6 | 2 | 96 | 8.4k | 656.9k | 73.4k | 6m 4s |
| MiniMax-M2.7-highspeed | 3 | 328.5k | 7.4k | 1.0M | 86.4k | 3m 47s |