### PR TITLE
Rectify: Early-Stop Worktree Routing Blindness

### DIFF
--- a/src/autoskillit/cli/_prompts.py
+++ b/src/autoskillit/cli/_prompts.py
@@ -575,8 +575,18 @@ CONTEXT LIMIT ROUTING — run_skill only (check BEFORE on_failure):
     made before the stall), partial progress likely exists on disk. Follow on_context_limit
     if defined, fall through to on_failure otherwise.
   - If lifespan_started is false, fall through to on_failure — no progress was made.
-- When run_skill returns "needs_retry: true" AND "retry_reason: early_stop" or "zero_writes":
-  - These are not context limit conditions. Fall through to on_failure.
+- When run_skill returns "needs_retry: true" AND "retry_reason: early_stop":
+  - If "worktree_path" is present in the result AND the step defines on_context_limit:
+    the model created a worktree and made progress but stopped before emitting the
+    completion marker. Partial progress exists on disk. Follow on_context_limit.
+  - If "worktree_path" is absent OR the step has no on_context_limit: fall through
+    to on_failure — no recoverable worktree evidence.
+- When run_skill returns "needs_retry: true" AND "retry_reason: zero_writes":
+  - If "worktree_path" is present in the result AND the step defines on_context_limit:
+    the model created a worktree but made no Write/Edit tool calls (may have committed
+    via CLI). Partial progress may exist on disk. Follow on_context_limit.
+  - If "worktree_path" is absent OR the step has no on_context_limit: fall through
+    to on_failure — no recoverable worktree evidence.
 - WORKTREE-STALE CARVE-OUT: When the step invokes a worktree-creating skill
   (implement-worktree-no-merge, implement-worktree, implement-experiment) and returns
   retry_reason=stale (or retry_reason=resume with subtype=stale), re-execute the step

--- a/src/autoskillit/skills/sous-chef/SKILL.md
+++ b/src/autoskillit/skills/sous-chef/SKILL.md
@@ -75,7 +75,24 @@ When `run_skill` returns `needs_retry=true` for **any step**:
 - **If `retry_reason: path_contamination`** → fall through to `on_failure`. The session wrote
   files outside its working directory. This is a CWD boundary violation, not a context limit.
   Do NOT route to `on_context_limit` even if defined.
-- **If `retry_reason: early_stop` or `zero_writes`** → fall through to `on_failure`.
+- **If `retry_reason: thinking_stall` AND `lifespan_started` is true AND the step defines
+  `on_context_limit`** → follow `on_context_limit`. The model consumed tokens (thinking
+  blocks) but produced no final output. Prior tool calls suggest partial progress on disk.
+- **If `retry_reason: thinking_stall` AND `lifespan_started` is false** → fall through to `on_failure`.
+  No progress was made.
+- **If `retry_reason: idle_stall` AND `lifespan_started` is true AND the step defines
+  `on_context_limit`** → follow `on_context_limit`. The idle watchdog killed the session,
+  but prior tool calls suggest partial progress on disk.
+- **If `retry_reason: idle_stall` AND `lifespan_started` is false** → fall through to `on_failure`.
+  No progress was made.
+- **If `retry_reason: early_stop` AND `worktree_path` is present in the result AND the step
+  defines `on_context_limit`** → follow `on_context_limit`. The model created a worktree and
+  made progress but stopped before emitting the completion marker. Partial progress exists on disk.
+- **If `retry_reason: early_stop` AND `worktree_path` is absent** → fall through to `on_failure`.
+- **If `retry_reason: zero_writes` AND `worktree_path` is present in the result AND the step
+  defines `on_context_limit`** → follow `on_context_limit`. The model created a worktree but
+  made no Write/Edit tool calls. Partial progress may exist on disk.
+- **If `retry_reason: zero_writes` AND `worktree_path` is absent** → fall through to `on_failure`.
 - **If `retry_reason: stale`** → decrement the `retries` counter for this step.
   Re-execute the same step if retries remain. If retries are exhausted, fall through
   to `on_failure`. Do NOT route to `on_context_limit` — stale is a transient failure,
@@ -106,9 +123,20 @@ Summary: `needs_retry=true` + `retry_reason=resume` + `subtype=stale` → re-exe
          `needs_retry=true` + `retry_reason=resume` + `subtype≠stale` + no `on_context_limit` → `on_failure`.
          `needs_retry=true` + `retry_reason=drain_race` + step has `on_context_limit` → follow `on_context_limit`.
          `needs_retry=true` + `retry_reason=drain_race` + no `on_context_limit` → `on_failure`.
+         `needs_retry=true` + `retry_reason=completed_no_flush` + step has `on_context_limit` → follow `on_context_limit`.
+         `needs_retry=true` + `retry_reason=completed_no_flush` + no `on_context_limit` → `on_failure`.
+         `needs_retry=true` + `retry_reason=empty_output` → `on_failure`.
+         `needs_retry=true` + `retry_reason=path_contamination` → `on_failure`.
+         `needs_retry=true` + `retry_reason=thinking_stall` + `lifespan_started=true` + step has `on_context_limit` → follow `on_context_limit`.
+         `needs_retry=true` + `retry_reason=thinking_stall` + `lifespan_started=false` → `on_failure`.
+         `needs_retry=true` + `retry_reason=idle_stall` + `lifespan_started=true` + step has `on_context_limit` → follow `on_context_limit`.
+         `needs_retry=true` + `retry_reason=idle_stall` + `lifespan_started=false` → `on_failure`.
+         `needs_retry=true` + `retry_reason=early_stop` + `worktree_path` present + step has `on_context_limit` → follow `on_context_limit`.
+         `needs_retry=true` + `retry_reason=early_stop` + `worktree_path` absent → `on_failure`.
+         `needs_retry=true` + `retry_reason=zero_writes` + `worktree_path` present + step has `on_context_limit` → follow `on_context_limit`.
+         `needs_retry=true` + `retry_reason=zero_writes` + `worktree_path` absent → `on_failure`.
          `needs_retry=true` + `retry_reason=stale` → decrement retries counter → `on_failure` when exhausted (no partial progress, not a context limit).
          `needs_retry=true` + `retry_reason=stale` + worktree-creating step → one-shot re-execute (bypasses retries budget; on_failure if repeated stale).
-         `needs_retry=true` + any other `retry_reason` → `on_failure` (no partial progress).
 
 ---
 

--- a/tests/cli/test_routing_completeness.py
+++ b/tests/cli/test_routing_completeness.py
@@ -25,6 +25,20 @@ _ROUTING_EXCLUDED = {
     RetryReason.CLONE_CONTAMINATION,
 }
 
+# Routing contract: RetryReason → (expected_route_keyword, evidence_condition_keyword_or_None)
+_EXPECTED_ROUTES: dict[RetryReason, tuple[str, str | None]] = {
+    RetryReason.RESUME: ("on_context_limit", "subtype"),
+    RetryReason.STALE: ("on_failure", None),
+    RetryReason.DRAIN_RACE: ("on_context_limit", None),
+    RetryReason.COMPLETED_NO_FLUSH: ("on_context_limit", None),
+    RetryReason.EMPTY_OUTPUT: ("on_failure", None),
+    RetryReason.PATH_CONTAMINATION: ("on_failure", None),
+    RetryReason.THINKING_STALL: ("on_context_limit", "lifespan_started"),
+    RetryReason.IDLE_STALL: ("on_context_limit", "lifespan_started"),
+    RetryReason.EARLY_STOP: ("on_context_limit", "worktree_path"),
+    RetryReason.ZERO_WRITES: ("on_context_limit", "worktree_path"),
+}
+
 
 def test_all_retry_reasons_have_routing_rules() -> None:
     """Every orchestrator-visible RetryReason must have an explicit routing rule."""
@@ -43,28 +57,36 @@ def test_all_retry_reasons_have_routing_rules() -> None:
     )
 
 
-def test_completed_no_flush_routes_to_on_context_limit() -> None:
-    """completed_no_flush routing rule must reference on_context_limit, not on_failure."""
+@pytest.mark.parametrize(
+    "reason,expected",
+    _EXPECTED_ROUTES.items(),
+    ids=[r.value for r in _EXPECTED_ROUTES],
+)
+def test_reason_routes_to_expected_destination(
+    reason: RetryReason,
+    expected: tuple[str, str | None],
+) -> None:
+    """Every RetryReason must route to its declared destination in _prompts.py."""
     from autoskillit.cli._prompts import _build_orchestrator_prompt
 
     prompt_text = _build_orchestrator_prompt("test-recipe", mcp_prefix=DIRECT_PREFIX)
-    idx = prompt_text.find("completed_no_flush")
-    assert idx != -1, "completed_no_flush not found in orchestrator prompt"
+    idx = prompt_text.find(reason.value)
+    assert idx != -1, f"{reason.value} not found in orchestrator prompt"
 
-    surrounding = prompt_text[idx : idx + 500]
-    assert "on_context_limit" in surrounding, (
-        "completed_no_flush rule must reference on_context_limit"
+    window = prompt_text[idx : idx + 600]
+    route_keyword, evidence_keyword = expected
+    assert route_keyword in window, (
+        f"{reason.value} must reference '{route_keyword}' within 600 chars"
     )
-    assert "NEVER route" in prompt_text[idx : idx + 600]
+    if evidence_keyword:
+        assert evidence_keyword in window, (
+            f"{reason.value} routing must reference evidence signal '{evidence_keyword}'"
+        )
 
 
-def test_empty_output_routing_does_not_include_on_context_limit() -> None:
-    """empty_output routing rule must reference on_failure, not on_context_limit."""
-    from autoskillit.cli._prompts import _build_orchestrator_prompt
-
-    prompt_text = _build_orchestrator_prompt("test-recipe", mcp_prefix=DIRECT_PREFIX)
-    idx = prompt_text.find("retry_reason: empty_output")
-    assert idx != -1, "empty_output routing rule not found in orchestrator prompt"
-
-    surrounding = prompt_text[idx : idx + 400]
-    assert "on_failure" in surrounding, "empty_output rule must reference on_failure"
+def test_expected_routes_covers_all_orchestrator_visible_reasons() -> None:
+    """_EXPECTED_ROUTES must have an entry for every non-excluded RetryReason."""
+    missing = [
+        r.name for r in RetryReason if r not in _ROUTING_EXCLUDED and r not in _EXPECTED_ROUTES
+    ]
+    assert not missing, f"Add routing expectation for: {missing}"

--- a/tests/contracts/test_sous_chef_routing.py
+++ b/tests/contracts/test_sous_chef_routing.py
@@ -347,3 +347,76 @@ def test_prompts_worktree_stale_carveout() -> None:
     assert "worktree" in prompts_text and "stale" in prompts_text, (
         "_prompts.py must contain a worktree-stale carve-out matching SKILL.md"
     )
+
+
+def test_skill_md_covers_all_prompts_routing_reasons() -> None:
+    """Every RetryReason with a routing rule in _prompts.py must also appear in SKILL.md."""
+    from autoskillit.cli._mcp_names import DIRECT_PREFIX
+    from autoskillit.cli._prompts import _build_orchestrator_prompt
+    from autoskillit.core.types import RetryReason
+
+    prompt_text = _build_orchestrator_prompt("test-recipe", mcp_prefix=DIRECT_PREFIX)
+    skill_md = _sous_chef_text()
+    routing_section = _extract_routing_section(skill_md)
+
+    for reason in RetryReason:
+        if reason in {
+            RetryReason.NONE,
+            RetryReason.BUDGET_EXHAUSTED,
+            RetryReason.CONTRACT_RECOVERY,
+            RetryReason.CLONE_CONTAMINATION,
+        }:
+            continue
+        if reason.value in prompt_text:
+            assert reason.value in routing_section, (
+                f"{reason.value} has a routing rule in _prompts.py but is missing "
+                f"from SKILL.md CONTEXT LIMIT ROUTING section"
+            )
+
+
+class TestWorktreeEarlyStopCarveout:
+    """SKILL.md routing contract: early_stop must check worktree_path evidence."""
+
+    def test_early_stop_references_worktree_path(self) -> None:
+        skill_md = _sous_chef_text()
+        routing_section = _extract_routing_section(skill_md)
+        idx = routing_section.find("early_stop")
+        assert idx != -1
+        window = routing_section[idx : idx + 500]
+        assert "worktree_path" in window, (
+            "early_stop routing rule must reference worktree_path evidence"
+        )
+
+    def test_early_stop_with_worktree_routes_to_on_context_limit(self) -> None:
+        skill_md = _sous_chef_text()
+        routing_section = _extract_routing_section(skill_md)
+        idx = routing_section.find("early_stop")
+        assert idx != -1
+        window = routing_section[idx : idx + 500]
+        assert "on_context_limit" in window, (
+            "early_stop with worktree_path must route to on_context_limit"
+        )
+
+
+class TestWorktreeZeroWritesCarveout:
+    """SKILL.md routing contract: zero_writes must check worktree_path evidence."""
+
+    def test_zero_writes_references_worktree_path(self) -> None:
+        skill_md = _sous_chef_text()
+        routing_section = _extract_routing_section(skill_md)
+        idx = routing_section.find("zero_writes")
+        assert idx != -1
+        window = routing_section[idx : idx + 500]
+        assert "worktree_path" in window, (
+            "zero_writes routing rule must reference worktree_path evidence"
+        )
+
+    def test_zero_writes_with_worktree_routes_to_on_context_limit(self) -> None:
+        skill_md = _sous_chef_text()
+        routing_section = _extract_routing_section(skill_md)
+        idx = routing_section.find("zero_writes")
+        assert idx != -1
+        window = routing_section[idx : idx + 500]
+        assert "on_context_limit" in window, (
+            "zero_writes with worktree_path must route to on_context_limit"
+        )


### PR DESCRIPTION
## Summary

Routing rules for `retry_reason: early_stop` unconditionally route to `on_failure`, ignoring `worktree_path` evidence that proves completed work exists on disk. This discards worktree implementations that only failed to emit the `%%ORDER_UP%%` completion marker. The root architectural weakness is that routing rules are hardcoded prose duplicated across two files (`SKILL.md` and `_prompts.py`) with no single source of truth, no automated cross-consistency enforcement, and tests that only check string presence — not routing destination semantics.

The proposed solution introduces an **exhaustive routing contract table** that maps every `RetryReason` to its expected routing destination and evidence conditions, enforced by parametrized tests against both routing surfaces. This makes it structurally impossible to add a new `RetryReason`, modify a routing rule, or introduce a new evidence-aware carve-out without the test suite catching any inconsistency.

## Changed Files

### Modified (●):
- `src/autoskillit/cli/_prompts.py`
- `src/autoskillit/skills/sous-chef/SKILL.md`
- `tests/cli/test_routing_completeness.py`
- `tests/contracts/test_sous_chef_routing.py`

## Implementation Plan

Plan file: `.autoskillit/temp/rectify/rectify_early_stop_worktree_routing_2026-05-06_143000.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| investigate | claude-sonnet-4-6 | 1 | 65 | 10.3k | 941.9k | 71.2k | 228 | 61.8k | 7m 41s |
| rectify | claude-sonnet-4-6 | 1 | 3.7k | 13.4k | 678.7k | 73.5k | 116 | 68.1k | 8m 15s |
| dry_walkthrough | claude-opus-4-6 | 1 | 59 | 16.1k | 1.7M | 77.7k | 129 | 125.5k | 9m 19s |
| implement | MiniMax-M2.7-highspeed | 1 | 932.3k | 10.5k | 997.8k | 51.3k | 110 | 44.2k | 4m 29s |
| prepare_pr | MiniMax-M2.7-highspeed | 1 | 98.8k | 3.2k | 235.3k | 29.8k | 21 | 15.2k | 1m 15s |
| compose_pr | MiniMax-M2.7-highspeed | 1 | 97.8k | 2.4k | 267.9k | 29.8k | 22 | 41.9k | 1m 2s |
| review_pr | claude-opus-4-6 | 1 | 26 | 20.7k | 281.4k | 57.9k | 24 | 45.8k | 4m 28s |
| **Total** | | | 1.1M | 76.6k | 5.1M | 77.7k | | 402.4k | 36m 31s |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| investigate | 0 | — | — | — |
| rectify | 0 | — | — | — |
| dry_walkthrough | 0 | — | — | — |
| implement | 181 | 5512.6 | 244.2 | 58.0 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| **Total** | **181** | 28064.9 | 2223.5 | 423.3 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 2 | 3.8k | 23.8k | 1.6M | 129.9k | 15m 56s |
| claude-opus-4-6 | 1 | 59 | 16.1k | 1.7M | 125.5k | 9m 19s |
| MiniMax-M2.7-highspeed | 3 | 1.1M | 16.1k | 1.5M | 101.3k | 6m 47s |