### PR TITLE
Migrate ML Sub-Areas as Conditional-Branching Venue Appendices

### DIFF
--- a/src/autoskillit/recipe/CLAUDE.md
+++ b/src/autoskillit/recipe/CLAUDE.md
@@ -19,7 +19,7 @@ Sub-package: rules/ (see rules/CLAUDE.md).
 | `diagrams.py` | Flow diagram generation + staleness detection |
 | `experiment_type_registry.py` | `ExperimentTypeSpec`, `load_all_experiment_types` |
 | `methodology_tradition_registry.py` | `MethodologyTraditionSpec`, `VenueAppendixDef`, `load_all_methodology_traditions`, `get_methodology_tradition_by_name`, `is_out_of_scope_tradition` |
-| `methodology_venue_appendix.py` | `AlternateParentDef`, `MLSubAreaFoldingEntry`, `VenueAppendixMatch`, `load_ml_sub_area_folding`, `resolve_venue_appendices` — Stage B venue-appendix resolution |
+| `methodology_venue_appendix.py` | `AlternateParentDef`, `MLSubAreaFoldingDef`, `VenueAppendixMatch`, `load_ml_sub_area_folding`, `resolve_venue_appendices` — Stage B venue-appendix resolution |
 | `methodology_tradition_router.py` | `TraditionRouterResult`, `UnionRuleDef`, `classify_methodology` — two-stage Tier-C router |
 | `methodology_disambiguation.py` | `DisambiguationRuleDef`, `CrossTraditionOverlapDef`, `DisambiguationResult`, `disambiguate`, `load_disambiguation_rules` |
 | `registry.py` | `RuleFinding`, `RuleSpec`, `semantic_rule` decorator |

--- a/src/autoskillit/recipe/CLAUDE.md
+++ b/src/autoskillit/recipe/CLAUDE.md
@@ -18,7 +18,8 @@ Sub-package: rules/ (see rules/CLAUDE.md).
 | `_recipe_composition.py` | `_build_active_recipe` + sub-recipe merging |
 | `diagrams.py` | Flow diagram generation + staleness detection |
 | `experiment_type_registry.py` | `ExperimentTypeSpec`, `load_all_experiment_types` |
-| `methodology_tradition_registry.py` | `MethodologyTraditionSpec`, `load_all_methodology_traditions`, `get_methodology_tradition_by_name`, `is_out_of_scope_tradition` |
+| `methodology_tradition_registry.py` | `MethodologyTraditionSpec`, `VenueAppendixDef`, `load_all_methodology_traditions`, `get_methodology_tradition_by_name`, `is_out_of_scope_tradition` |
+| `methodology_venue_appendix.py` | `AlternateParentDef`, `MLSubAreaFoldingEntry`, `VenueAppendixMatch`, `load_ml_sub_area_folding`, `resolve_venue_appendices` — Stage B venue-appendix resolution |
 | `methodology_tradition_router.py` | `TraditionRouterResult`, `UnionRuleDef`, `classify_methodology` — two-stage Tier-C router |
 | `methodology_disambiguation.py` | `DisambiguationRuleDef`, `CrossTraditionOverlapDef`, `DisambiguationResult`, `disambiguate`, `load_disambiguation_rules` |
 | `registry.py` | `RuleFinding`, `RuleSpec`, `semantic_rule` decorator |

--- a/src/autoskillit/recipe/__init__.py
+++ b/src/autoskillit/recipe/__init__.py
@@ -73,6 +73,7 @@ from autoskillit.recipe.methodology_disambiguation import (  # noqa: E402
 from autoskillit.recipe.methodology_tradition_registry import (  # noqa: E402
     BUNDLED_METHODOLOGY_TRADITIONS_DIR,
     MethodologyTraditionSpec,
+    VenueAppendixDef,
     get_methodology_tradition_by_name,
     is_out_of_scope_tradition,
     load_all_methodology_traditions,
@@ -83,6 +84,13 @@ from autoskillit.recipe.methodology_tradition_router import (  # noqa: E402
     TraditionRouterResult,
     UnionRuleDef,
     classify_methodology,
+)
+from autoskillit.recipe.methodology_venue_appendix import (  # noqa: E402
+    AlternateParentDef,
+    MLSubAreaFoldingEntry,
+    VenueAppendixMatch,
+    load_ml_sub_area_folding,
+    resolve_venue_appendices,
 )
 from autoskillit.recipe.repository import DefaultRecipeRepository  # noqa: E402
 from autoskillit.recipe.rules import rules_actions as _rules_actions  # noqa: E402 F401
@@ -203,6 +211,12 @@ __all__ = [
     "get_methodology_tradition_by_name",
     "is_out_of_scope_tradition",
     "load_all_methodology_traditions",
+    "VenueAppendixDef",
+    "AlternateParentDef",
+    "MLSubAreaFoldingEntry",
+    "VenueAppendixMatch",
+    "load_ml_sub_area_folding",
+    "resolve_venue_appendices",
     "CrossTraditionOverlapDef",
     "DisambiguationExceptionDef",
     "DisambiguationResult",

--- a/src/autoskillit/recipe/__init__.py
+++ b/src/autoskillit/recipe/__init__.py
@@ -87,7 +87,7 @@ from autoskillit.recipe.methodology_tradition_router import (  # noqa: E402
 )
 from autoskillit.recipe.methodology_venue_appendix import (  # noqa: E402
     AlternateParentDef,
-    MLSubAreaFoldingEntry,
+    MLSubAreaFoldingDef,
     VenueAppendixMatch,
     load_ml_sub_area_folding,
     resolve_venue_appendices,
@@ -213,7 +213,7 @@ __all__ = [
     "load_all_methodology_traditions",
     "VenueAppendixDef",
     "AlternateParentDef",
-    "MLSubAreaFoldingEntry",
+    "MLSubAreaFoldingDef",
     "VenueAppendixMatch",
     "load_ml_sub_area_folding",
     "resolve_venue_appendices",

--- a/src/autoskillit/recipe/methodology_tradition_registry.py
+++ b/src/autoskillit/recipe/methodology_tradition_registry.py
@@ -124,14 +124,24 @@ def _parse_venue_appendices(data: dict, source_path: Path) -> tuple[VenueAppendi
                 f"Methodology tradition '{data['name']}' venue_specific_appendices[{i}] "
                 f"'sub_area' must be a non-empty string: {source_path}"
             )
-        trigger_keywords = item.get("trigger_keywords")
+        if "trigger_keywords" not in item:
+            raise TypeError(
+                f"Methodology tradition '{data['name']}' venue_specific_appendices[{i}] "
+                f"missing required key 'trigger_keywords': {source_path}"
+            )
+        trigger_keywords = item["trigger_keywords"]
         if not isinstance(trigger_keywords, list):
             raise TypeError(
                 f"Methodology tradition '{data['name']}' venue_specific_appendices[{i}] "
                 f"'trigger_keywords' must be a list, "
                 f"got {type(trigger_keywords).__name__}: {source_path}"
             )
-        expectations = item.get("expectations")
+        if "expectations" not in item:
+            raise TypeError(
+                f"Methodology tradition '{data['name']}' venue_specific_appendices[{i}] "
+                f"missing required key 'expectations': {source_path}"
+            )
+        expectations = item["expectations"]
         if not isinstance(expectations, list):
             raise TypeError(
                 f"Methodology tradition '{data['name']}' venue_specific_appendices[{i}] "

--- a/src/autoskillit/recipe/methodology_tradition_registry.py
+++ b/src/autoskillit/recipe/methodology_tradition_registry.py
@@ -13,7 +13,16 @@ logger = get_logger(__name__)
 BUNDLED_METHODOLOGY_TRADITIONS_DIR: Path = pkg_root() / "recipes" / "methodology-traditions"
 
 
-@dataclass
+@dataclass(frozen=True)
+class VenueAppendixDef:
+    """A venue-specific appendix entry for an ML sub-area within a tradition."""
+
+    sub_area: str
+    trigger_keywords: tuple[str, ...]
+    expectations: tuple[dict[str, str], ...]
+
+
+@dataclass(frozen=True)
 class MethodologyTraditionSpec:
     """Specification for a single methodology tradition."""
 
@@ -27,7 +36,7 @@ class MethodologyTraditionSpec:
     anti_patterns: list[dict[str, str]]
     schema_version: str = ""
     priority: int = 999
-    venue_specific_appendices: list[object] = field(default_factory=list)
+    venue_specific_appendices: tuple[VenueAppendixDef, ...] = field(default_factory=tuple)
 
 
 def _parse_int_field(data: dict, field_name: str, default: int, source_path: Path) -> int:
@@ -91,8 +100,71 @@ def _parse_methodology_tradition(data: dict, source_path: Path) -> MethodologyTr
         anti_patterns=_coerce_dict_list("anti_patterns", data.get("anti_patterns", [])),
         schema_version=str(data.get("schema_version", "")),
         priority=_parse_int_field(data, "priority", 999, source_path),
-        venue_specific_appendices=list(data.get("venue_specific_appendices", [])),
+        venue_specific_appendices=_parse_venue_appendices(data, source_path),
     )
+
+
+def _parse_venue_appendices(data: dict, source_path: Path) -> tuple[VenueAppendixDef, ...]:
+    raw = data.get("venue_specific_appendices", [])
+    if not isinstance(raw, list):
+        raise TypeError(
+            f"Methodology tradition '{data['name']}' field 'venue_specific_appendices' "
+            f"must be a list, got {type(raw).__name__}: {source_path}"
+        )
+    result: list[VenueAppendixDef] = []
+    for i, item in enumerate(raw):
+        if not isinstance(item, dict):
+            raise TypeError(
+                f"Methodology tradition '{data['name']}' venue_specific_appendices[{i}] "
+                f"must be a dict, got {type(item).__name__}: {source_path}"
+            )
+        sub_area = item.get("sub_area")
+        if not isinstance(sub_area, str) or not sub_area:
+            raise TypeError(
+                f"Methodology tradition '{data['name']}' venue_specific_appendices[{i}] "
+                f"'sub_area' must be a non-empty string: {source_path}"
+            )
+        trigger_keywords = item.get("trigger_keywords")
+        if not isinstance(trigger_keywords, list):
+            raise TypeError(
+                f"Methodology tradition '{data['name']}' venue_specific_appendices[{i}] "
+                f"'trigger_keywords' must be a list, "
+                f"got {type(trigger_keywords).__name__}: {source_path}"
+            )
+        expectations = item.get("expectations")
+        if not isinstance(expectations, list):
+            raise TypeError(
+                f"Methodology tradition '{data['name']}' venue_specific_appendices[{i}] "
+                f"'expectations' must be a list, got {type(expectations).__name__}: {source_path}"
+            )
+        parsed_expectations: list[dict[str, str]] = []
+        for j, exp in enumerate(expectations):
+            if not isinstance(exp, dict):
+                raise TypeError(
+                    f"Methodology tradition '{data['name']}' venue_specific_appendices[{i}] "
+                    f"expectations[{j}] must be a dict, got {type(exp).__name__}: {source_path}"
+                )
+            fig = exp.get("figure")
+            src = exp.get("source")
+            if not isinstance(fig, str) or not fig:
+                raise TypeError(
+                    f"Methodology tradition '{data['name']}' venue_specific_appendices[{i}] "
+                    f"expectations[{j}] 'figure' must be a non-empty string: {source_path}"
+                )
+            if not isinstance(src, str) or not src:
+                raise TypeError(
+                    f"Methodology tradition '{data['name']}' venue_specific_appendices[{i}] "
+                    f"expectations[{j}] 'source' must be a non-empty string: {source_path}"
+                )
+            parsed_expectations.append({"figure": fig, "source": src})
+        result.append(
+            VenueAppendixDef(
+                sub_area=sub_area,
+                trigger_keywords=tuple(str(kw) for kw in trigger_keywords),
+                expectations=tuple(parsed_expectations),
+            )
+        )
+    return tuple(result)
 
 
 def _load_traditions_from_dir(directory: Path) -> dict[str, MethodologyTraditionSpec]:

--- a/src/autoskillit/recipe/methodology_venue_appendix.py
+++ b/src/autoskillit/recipe/methodology_venue_appendix.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import warnings
 from collections.abc import Callable
 from dataclasses import dataclass
 from functools import cache
@@ -24,7 +25,7 @@ class AlternateParentDef:
 
 
 @dataclass(frozen=True)
-class MLSubAreaFoldingEntry:
+class MLSubAreaFoldingDef:
     sub_area: str
     display_name: str
     primary_parent: str
@@ -65,10 +66,12 @@ def _has_keyword_match(text: str, keywords: tuple[str, ...] | list[str]) -> bool
     return any(_keyword_pattern(kw).search(text) for kw in keywords)
 
 
-def load_ml_sub_area_folding() -> list[MLSubAreaFoldingEntry]:
+def load_ml_sub_area_folding() -> list[MLSubAreaFoldingDef]:
     yaml_path = BUNDLED_METHODOLOGY_TRADITIONS_DIR / "_ml_sub_area_folding.yaml"
     data = load_yaml(yaml_path)
-    entries: list[MLSubAreaFoldingEntry] = []
+    if not isinstance(data, dict):
+        raise TypeError(f"Expected dict from {yaml_path}, got {type(data).__name__}")
+    entries: list[MLSubAreaFoldingDef] = []
     for i, item in enumerate(data.get("ml_sub_area_folding", [])):
         if not isinstance(item, dict):
             raise TypeError(
@@ -102,15 +105,21 @@ def load_ml_sub_area_folding() -> list[MLSubAreaFoldingEntry]:
                     f"ml_sub_area_folding[{i}] alternate_parents[{j}] 'trigger_keywords' "
                     f"must be a list: {yaml_path}"
                 )
+            constraint = a.get("constraint")
+            if constraint is not None and constraint not in _CONSTRAINT_EVALUATORS:
+                raise ValueError(
+                    f"ml_sub_area_folding[{i}] alternate_parents[{j}] 'constraint' "
+                    f"'{constraint}' is not a recognised evaluator key: {yaml_path}"
+                )
             alternates.append(
                 AlternateParentDef(
                     parent=a["parent"],
                     trigger_keywords=tuple(a["trigger_keywords"]),
-                    constraint=a.get("constraint"),
+                    constraint=constraint,
                 )
             )
         entries.append(
-            MLSubAreaFoldingEntry(
+            MLSubAreaFoldingDef(
                 sub_area=item["sub_area"],
                 display_name=item["display_name"],
                 primary_parent=item["primary_parent"],
@@ -121,7 +130,7 @@ def load_ml_sub_area_folding() -> list[MLSubAreaFoldingEntry]:
 
 
 def _resolve_conditional_parent(
-    entry: MLSubAreaFoldingEntry,
+    entry: MLSubAreaFoldingDef,
     plan_text: str,
 ) -> tuple[str, bool]:
     """Return (resolved_parent, re_routed)."""
@@ -129,7 +138,14 @@ def _resolve_conditional_parent(
         if _has_keyword_match(plan_text, alt.trigger_keywords):
             if alt.constraint is not None:
                 evaluator = _CONSTRAINT_EVALUATORS.get(alt.constraint)
-                if evaluator is None or not evaluator(plan_text):
+                if evaluator is None:
+                    warnings.warn(
+                        f"_resolve_conditional_parent: unrecognised constraint "
+                        f"'{alt.constraint}' on sub-area '{entry.sub_area}' — skipping alternate",
+                        stacklevel=2,
+                    )
+                    continue
+                if not evaluator(plan_text):
                     continue
             return alt.parent, True
     return entry.primary_parent, False
@@ -145,7 +161,6 @@ def resolve_venue_appendices(
     2. For each detected sub-area, resolve conditional parent
     3. Collect venue appendices from resolved parent tradition
     """
-    import warnings
 
     folding = load_ml_sub_area_folding()
     traditions = {s.name: s for s in load_all_methodology_traditions(project_dir)}

--- a/src/autoskillit/recipe/methodology_venue_appendix.py
+++ b/src/autoskillit/recipe/methodology_venue_appendix.py
@@ -69,21 +69,52 @@ def load_ml_sub_area_folding() -> list[MLSubAreaFoldingEntry]:
     yaml_path = BUNDLED_METHODOLOGY_TRADITIONS_DIR / "_ml_sub_area_folding.yaml"
     data = load_yaml(yaml_path)
     entries: list[MLSubAreaFoldingEntry] = []
-    for item in data.get("ml_sub_area_folding", []):
-        alternates = tuple(
-            AlternateParentDef(
-                parent=a["parent"],
-                trigger_keywords=tuple(a["trigger_keywords"]),
-                constraint=a.get("constraint"),
+    for i, item in enumerate(data.get("ml_sub_area_folding", [])):
+        if not isinstance(item, dict):
+            raise TypeError(
+                f"ml_sub_area_folding[{i}] must be a dict, got {type(item).__name__}: {yaml_path}"
             )
-            for a in item.get("alternate_parents", [])
-        )
+        for key in ("sub_area", "display_name", "primary_parent"):
+            if not isinstance(item.get(key), str) or not item[key]:
+                raise TypeError(
+                    f"ml_sub_area_folding[{i}] '{key}' must be a non-empty string: {yaml_path}"
+                )
+        alternates_raw = item.get("alternate_parents", [])
+        if not isinstance(alternates_raw, list):
+            raise TypeError(
+                f"ml_sub_area_folding[{i}] 'alternate_parents' must be a list, "
+                f"got {type(alternates_raw).__name__}: {yaml_path}"
+            )
+        alternates: list[AlternateParentDef] = []
+        for j, a in enumerate(alternates_raw):
+            if not isinstance(a, dict):
+                raise TypeError(
+                    f"ml_sub_area_folding[{i}] alternate_parents[{j}] must be a dict, "
+                    f"got {type(a).__name__}: {yaml_path}"
+                )
+            if not isinstance(a.get("parent"), str) or not a["parent"]:
+                raise TypeError(
+                    f"ml_sub_area_folding[{i}] alternate_parents[{j}] 'parent' "
+                    f"must be a non-empty string: {yaml_path}"
+                )
+            if not isinstance(a.get("trigger_keywords"), list):
+                raise TypeError(
+                    f"ml_sub_area_folding[{i}] alternate_parents[{j}] 'trigger_keywords' "
+                    f"must be a list: {yaml_path}"
+                )
+            alternates.append(
+                AlternateParentDef(
+                    parent=a["parent"],
+                    trigger_keywords=tuple(a["trigger_keywords"]),
+                    constraint=a.get("constraint"),
+                )
+            )
         entries.append(
             MLSubAreaFoldingEntry(
                 sub_area=item["sub_area"],
                 display_name=item["display_name"],
                 primary_parent=item["primary_parent"],
-                alternate_parents=alternates,
+                alternate_parents=tuple(alternates),
             )
         )
     return entries
@@ -114,6 +145,8 @@ def resolve_venue_appendices(
     2. For each detected sub-area, resolve conditional parent
     3. Collect venue appendices from resolved parent tradition
     """
+    import warnings
+
     folding = load_ml_sub_area_folding()
     traditions = {s.name: s for s in load_all_methodology_traditions(project_dir)}
 
@@ -122,6 +155,11 @@ def resolve_venue_appendices(
         parent, re_routed = _resolve_conditional_parent(entry, plan_text)
         spec = traditions.get(parent)
         if spec is None:
+            warnings.warn(
+                f"resolve_venue_appendices: tradition '{parent}' referenced by sub-area "
+                f"'{entry.sub_area}' not found — skipping",
+                stacklevel=2,
+            )
             continue
         for appendix in spec.venue_specific_appendices:
             if appendix.sub_area == entry.sub_area:

--- a/src/autoskillit/recipe/methodology_venue_appendix.py
+++ b/src/autoskillit/recipe/methodology_venue_appendix.py
@@ -1,0 +1,134 @@
+"""Stage B venue-appendix resolution — conditional-branching ML sub-area matching."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from functools import cache
+from pathlib import Path
+
+from autoskillit.core import load_yaml
+from autoskillit.recipe.methodology_tradition_registry import (
+    BUNDLED_METHODOLOGY_TRADITIONS_DIR,
+    VenueAppendixDef,
+    load_all_methodology_traditions,
+)
+
+
+@dataclass(frozen=True)
+class AlternateParentDef:
+    parent: str
+    trigger_keywords: tuple[str, ...]
+    constraint: str | None = None
+
+
+@dataclass(frozen=True)
+class MLSubAreaFoldingEntry:
+    sub_area: str
+    display_name: str
+    primary_parent: str
+    alternate_parents: tuple[AlternateParentDef, ...]
+
+
+@dataclass(frozen=True)
+class VenueAppendixMatch:
+    sub_area: str
+    resolved_parent: str
+    appendix: VenueAppendixDef
+    re_routed: bool
+
+
+_CONSTRAINT_EVALUATORS: dict[str, Callable[[str], bool]] = {
+    "only_if_explicit_construct_measurement": lambda text: bool(
+        re.search(
+            r"(?<!\w)(construct\s+measurement|measurement\s+construct|"
+            r"item\s+response\s+theory|latent\s+trait\s+model)(?!\w)",
+            text,
+            re.IGNORECASE,
+        )
+    ),
+}
+
+
+@cache
+def _keyword_pattern(keyword: str) -> re.Pattern[str]:
+    escaped = re.escape(keyword)
+    return re.compile(r"(?<!\w)" + escaped + r"(?!\w)", re.IGNORECASE)
+
+
+def _has_keyword_match(text: str, keywords: tuple[str, ...] | list[str]) -> bool:
+    return any(_keyword_pattern(kw.lower()).search(text) for kw in keywords)
+
+
+def load_ml_sub_area_folding() -> list[MLSubAreaFoldingEntry]:
+    yaml_path = BUNDLED_METHODOLOGY_TRADITIONS_DIR / "_ml_sub_area_folding.yaml"
+    data = load_yaml(yaml_path)
+    entries: list[MLSubAreaFoldingEntry] = []
+    for item in data.get("ml_sub_area_folding", []):
+        alternates = tuple(
+            AlternateParentDef(
+                parent=a["parent"],
+                trigger_keywords=tuple(a["trigger_keywords"]),
+                constraint=a.get("constraint"),
+            )
+            for a in item.get("alternate_parents", [])
+        )
+        entries.append(
+            MLSubAreaFoldingEntry(
+                sub_area=item["sub_area"],
+                display_name=item["display_name"],
+                primary_parent=item["primary_parent"],
+                alternate_parents=alternates,
+            )
+        )
+    return entries
+
+
+def _resolve_conditional_parent(
+    entry: MLSubAreaFoldingEntry,
+    plan_text: str,
+) -> tuple[str, bool]:
+    """Return (resolved_parent, re_routed)."""
+    for alt in entry.alternate_parents:
+        if _has_keyword_match(plan_text, alt.trigger_keywords):
+            if alt.constraint is not None:
+                evaluator = _CONSTRAINT_EVALUATORS.get(alt.constraint)
+                if evaluator is None or not evaluator(plan_text):
+                    continue
+            return alt.parent, True
+    return entry.primary_parent, False
+
+
+def resolve_venue_appendices(
+    plan_text: str,
+    project_dir: Path | None = None,
+) -> list[VenueAppendixMatch]:
+    """Two-stage venue appendix resolution.
+
+    1. Detect ML sub-areas from plan text using folding map keywords
+    2. For each detected sub-area, resolve conditional parent
+    3. Collect venue appendices from resolved parent tradition
+    """
+    folding = load_ml_sub_area_folding()
+    traditions = {s.name: s for s in load_all_methodology_traditions(project_dir)}
+
+    matches: list[VenueAppendixMatch] = []
+    for entry in folding:
+        parent, re_routed = _resolve_conditional_parent(entry, plan_text)
+        spec = traditions.get(parent)
+        if spec is None:
+            continue
+        for appendix in spec.venue_specific_appendices:
+            if appendix.sub_area == entry.sub_area:
+                if _has_keyword_match(plan_text, appendix.trigger_keywords):
+                    matches.append(
+                        VenueAppendixMatch(
+                            sub_area=entry.sub_area,
+                            resolved_parent=parent,
+                            appendix=appendix,
+                            re_routed=re_routed,
+                        )
+                    )
+                    break
+    return matches

--- a/src/autoskillit/recipe/methodology_venue_appendix.py
+++ b/src/autoskillit/recipe/methodology_venue_appendix.py
@@ -51,14 +51,18 @@ _CONSTRAINT_EVALUATORS: dict[str, Callable[[str], bool]] = {
 }
 
 
-@cache
 def _keyword_pattern(keyword: str) -> re.Pattern[str]:
+    return _keyword_pattern_cached(keyword.lower())
+
+
+@cache
+def _keyword_pattern_cached(keyword: str) -> re.Pattern[str]:
     escaped = re.escape(keyword)
     return re.compile(r"(?<!\w)" + escaped + r"(?!\w)", re.IGNORECASE)
 
 
 def _has_keyword_match(text: str, keywords: tuple[str, ...] | list[str]) -> bool:
-    return any(_keyword_pattern(kw.lower()).search(text) for kw in keywords)
+    return any(_keyword_pattern(kw).search(text) for kw in keywords)
 
 
 def load_ml_sub_area_folding() -> list[MLSubAreaFoldingEntry]:

--- a/src/autoskillit/recipes/methodology-traditions/_ml_sub_area_folding.yaml
+++ b/src/autoskillit/recipes/methodology-traditions/_ml_sub_area_folding.yaml
@@ -92,18 +92,18 @@ ml_sub_area_folding:
     display_name: "Generative Models"
     primary_parent: method_comparison_benchmarking
     alternate_parents:
-      - parent: qualitative_interpretive_tradition
-        trigger_keywords:
-          - human evaluation
-          - qualitative assessment
-          - expert rating
-          - content analysis
       - parent: measurement_instrument_validation_tradition
         trigger_keywords:
           - human evaluation instrument
           - inter-rater
           - construct validity
           - scale development
+      - parent: qualitative_interpretive_tradition
+        trigger_keywords:
+          - human evaluation
+          - qualitative assessment
+          - expert rating
+          - content analysis
 
   - sub_area: agentic_systems
     display_name: "Agentic Systems"

--- a/src/autoskillit/recipes/methodology-traditions/_ml_sub_area_folding.yaml
+++ b/src/autoskillit/recipes/methodology-traditions/_ml_sub_area_folding.yaml
@@ -1,0 +1,140 @@
+schema_version: "1.0"
+
+ml_sub_area_folding:
+  - sub_area: foundation_models
+    display_name: "Foundation Models"
+    primary_parent: method_comparison_benchmarking
+    alternate_parents:
+      - parent: prediction_model_validation
+        trigger_keywords:
+          - calibration
+          - held-out
+          - few-shot scaling
+          - zero-shot validation
+      - parent: measurement_instrument_validation_tradition
+        trigger_keywords:
+          - psychometric
+          - latent trait
+          - item response theory
+          - Cronbach
+        constraint: only_if_explicit_construct_measurement
+
+  - sub_area: reinforcement_learning
+    display_name: "Reinforcement Learning"
+    primary_parent: method_comparison_benchmarking
+    alternate_parents:
+      - parent: simulation_modeling_tradition
+        trigger_keywords:
+          - multi-agent
+          - emergent behavior
+          - population dynamics
+          - swarm
+      - parent: prediction_model_validation
+        trigger_keywords:
+          - policy evaluation
+          - held-out task
+          - sample efficiency
+
+  - sub_area: supervised_classification
+    display_name: "Supervised Classification"
+    primary_parent: method_comparison_benchmarking
+    alternate_parents:
+      - parent: diagnostic_accuracy
+        trigger_keywords:
+          - medical imaging
+          - radiology
+          - pathology
+          - sensitivity
+          - specificity
+      - parent: prediction_model_validation
+        trigger_keywords:
+          - patient outcome
+          - prognosis
+          - risk prediction
+          - clinical decision
+
+  - sub_area: nlp
+    display_name: "NLP"
+    primary_parent: method_comparison_benchmarking
+    alternate_parents:
+      - parent: prediction_model_validation
+        trigger_keywords:
+          - clinical NLP
+          - risk scoring
+          - patient outcome
+          - clinical text
+      - parent: qualitative_interpretive_tradition
+        trigger_keywords:
+          - discourse analysis
+          - conversation analysis
+          - narrative
+          - thematic
+
+  - sub_area: computer_vision
+    display_name: "Computer Vision"
+    primary_parent: method_comparison_benchmarking
+    alternate_parents:
+      - parent: diagnostic_accuracy
+        trigger_keywords:
+          - medical imaging
+          - radiology
+          - pathology
+          - sensitivity
+          - specificity
+      - parent: prediction_model_validation
+        trigger_keywords:
+          - patient outcome
+          - prognosis
+          - clinical decision
+          - imaging biomarker
+
+  - sub_area: generative_models
+    display_name: "Generative Models"
+    primary_parent: method_comparison_benchmarking
+    alternate_parents:
+      - parent: qualitative_interpretive_tradition
+        trigger_keywords:
+          - human evaluation
+          - qualitative assessment
+          - expert rating
+          - content analysis
+      - parent: measurement_instrument_validation_tradition
+        trigger_keywords:
+          - human evaluation instrument
+          - inter-rater
+          - construct validity
+          - scale development
+
+  - sub_area: agentic_systems
+    display_name: "Agentic Systems"
+    primary_parent: method_comparison_benchmarking
+    alternate_parents:
+      - parent: simulation_modeling_tradition
+        trigger_keywords:
+          - multi-agent
+          - emergent behavior
+          - agent-based model
+          - swarm intelligence
+      - parent: quality_improvement
+        trigger_keywords:
+          - process improvement
+          - workflow optimization
+          - task efficiency
+          - error reduction
+
+  - sub_area: time_series
+    display_name: "Time-Series"
+    primary_parent: method_comparison_benchmarking
+    alternate_parents:
+      - parent: prediction_model_validation
+        trigger_keywords:
+          - clinical forecasting
+          - patient trajectory
+          - risk prediction
+          - mortality prediction
+      - parent: simulation_modeling_tradition
+        trigger_keywords:
+          - dynamical system
+          - differential equation
+          - compartmental model
+          - system dynamics

--- a/src/autoskillit/recipes/methodology-traditions/diagnostic_accuracy.yaml
+++ b/src/autoskillit/recipes/methodology-traditions/diagnostic_accuracy.yaml
@@ -44,4 +44,28 @@ anti_patterns:
     reason: "All participants should receive both index test and reference standard"
   - pattern: "Reporting accuracy without confidence intervals"
     reason: "Point estimates without CIs provide no sense of precision or uncertainty"
-venue_specific_appendices: []
+venue_specific_appendices:
+  - sub_area: supervised_classification
+    trigger_keywords:
+      - medical imaging
+      - radiology
+      - pathology
+      - sensitivity
+      - specificity
+    expectations:
+      - figure: "STARD Flow Diagram"
+        source: "STARD 2015"
+      - figure: "Sensitivity/Specificity at Operating Points"
+        source: "STARD 2015"
+  - sub_area: computer_vision
+    trigger_keywords:
+      - medical imaging
+      - radiology
+      - pathology
+      - sensitivity
+      - specificity
+    expectations:
+      - figure: "STARD Flow Diagram for Imaging Pipeline"
+        source: "STARD 2015"
+      - figure: "Cross-Tabulation for Diagnostic Imaging"
+        source: "STARD 2015"

--- a/src/autoskillit/recipes/methodology-traditions/measurement_instrument_validation_tradition.yaml
+++ b/src/autoskillit/recipes/methodology-traditions/measurement_instrument_validation_tradition.yaml
@@ -44,4 +44,26 @@ anti_patterns:
     reason: "Content validity is the foundational measurement property and must be established before other properties"
   - pattern: "Conflating reliability with validity"
     reason: "Reliability (consistency) is distinct from validity (accuracy); high reliability does not imply validity"
-venue_specific_appendices: []
+venue_specific_appendices:
+  - sub_area: foundation_models
+    trigger_keywords:
+      - psychometric
+      - latent trait
+      - item response theory
+      - Cronbach
+    expectations:
+      - figure: "Structural Validity for Evaluation Framework"
+        source: "COSMIN 2.0"
+      - figure: "Item Characteristic Curves"
+        source: "COSMIN 2.0"
+  - sub_area: generative_models
+    trigger_keywords:
+      - human evaluation instrument
+      - inter-rater
+      - construct validity
+      - scale development
+    expectations:
+      - figure: "Human Evaluation Instrument Validation"
+        source: "COSMIN 2.0"
+      - figure: "Inter-Rater Reliability Plots"
+        source: "COSMIN 2.0"

--- a/src/autoskillit/recipes/methodology-traditions/method_comparison_benchmarking.yaml
+++ b/src/autoskillit/recipes/methodology-traditions/method_comparison_benchmarking.yaml
@@ -46,4 +46,120 @@ anti_patterns:
     reason: "Methods must be fairly tuned before comparison to ensure valid assessment"
   - pattern: "No ablation study"
     reason: "Ablation studies isolate the contribution of individual components"
-venue_specific_appendices: []
+venue_specific_appendices:
+  - sub_area: supervised_classification
+    trigger_keywords:
+      - confusion matrix
+      - precision
+      - recall
+      - ROC-AUC
+      - PR curve
+      - classification
+      - learning curve
+    expectations:
+      - figure: "Confusion Matrix"
+        source: "NeurIPS/ICML community norms"
+      - figure: "PR Curve"
+        source: "NeurIPS/ICML community norms"
+      - figure: "ROC-AUC Plot"
+        source: "NeurIPS/ICML community norms"
+      - figure: "Learning Curves"
+        source: "NeurIPS/ICML community norms"
+  - sub_area: nlp
+    trigger_keywords:
+      - accuracy
+      - F1
+      - GLUE
+      - SuperGLUE
+      - NLP
+      - language model
+      - token
+    expectations:
+      - figure: "Per-Task Accuracy Table"
+        source: "ACL norms"
+      - figure: "Error Analysis Examples"
+        source: "ACL norms"
+  - sub_area: computer_vision
+    trigger_keywords:
+      - mAP
+      - COCO
+      - detection
+      - segmentation
+      - object detection
+      - image classification
+    expectations:
+      - figure: "Sample Predictions Grid"
+        source: "CVPR/ECCV norms"
+      - figure: "Failure Gallery"
+        source: "CVPR/ECCV norms"
+      - figure: "Per-Class mAP Table"
+        source: "CVPR/ECCV norms"
+  - sub_area: reinforcement_learning
+    trigger_keywords:
+      - episode reward
+      - RL
+      - Atari
+      - agent
+      - policy gradient
+    expectations:
+      - figure: "Episode Reward Curve"
+        source: "NeurIPS RL norms"
+      - figure: "Sample Efficiency Curve"
+        source: "NeurIPS RL norms"
+  - sub_area: generative_models
+    trigger_keywords:
+      - GAN
+      - diffusion
+      - FID
+      - IS
+      - generative
+      - sample quality
+    expectations:
+      - figure: "Sample Grid"
+        source: "NeurIPS/ICLR norms"
+      - figure: "FID/IS Table"
+        source: "NeurIPS/ICLR norms"
+      - figure: "Failure Modes Gallery"
+        source: "NeurIPS/ICLR norms"
+  - sub_area: foundation_models
+    trigger_keywords:
+      - LLM
+      - few-shot
+      - scaling
+      - GPT
+      - foundation model
+      - zero-shot
+    expectations:
+      - figure: "Few-Shot Scaling Curve"
+        source: "LLM evaluation norms"
+      - figure: "Contamination Analysis"
+        source: "LLM evaluation norms"
+      - figure: "Ablation Table"
+        source: "LLM evaluation norms"
+  - sub_area: agentic_systems
+    trigger_keywords:
+      - agentic
+      - tool use
+      - multi-agent
+      - task success
+      - workflow
+    expectations:
+      - figure: "Task Success Rate Bar Chart"
+        source: "Emerging norms"
+      - figure: "Step-Level Execution Traces"
+        source: "Emerging norms"
+      - figure: "Tool Use Breakdown"
+        source: "Emerging norms"
+  - sub_area: time_series
+    trigger_keywords:
+      - forecasting
+      - time series
+      - temporal
+      - prediction interval
+    expectations:
+      - figure: "Forecasting Horizon Curve"
+        source: "ICLR/NeurIPS norms"
+      - figure: "Decomposition Plot"
+        source: "ICLR/NeurIPS norms"
+      - figure: "Residual ACF Plot"
+        source: "ICLR/NeurIPS norms"

--- a/src/autoskillit/recipes/methodology-traditions/prediction_model_validation.yaml
+++ b/src/autoskillit/recipes/methodology-traditions/prediction_model_validation.yaml
@@ -44,4 +44,68 @@ anti_patterns:
     reason: "Discrimination (AUC/c-statistic) measures ranking ability; calibration measures absolute probability accuracy"
   - pattern: "No sample size justification"
     reason: "Prediction models require sufficient events per variable to avoid overfitting"
-venue_specific_appendices: []
+venue_specific_appendices:
+  - sub_area: foundation_models
+    trigger_keywords:
+      - calibration
+      - held-out
+      - few-shot scaling
+      - zero-shot validation
+    expectations:
+      - figure: "Calibration Plot for Scaling Predictions"
+        source: "TRIPOD+AI norms"
+      - figure: "Held-Out Performance Curves"
+        source: "TRIPOD+AI norms"
+  - sub_area: reinforcement_learning
+    trigger_keywords:
+      - policy evaluation
+      - held-out task
+      - sample efficiency
+    expectations:
+      - figure: "Policy Evaluation Calibration"
+        source: "TRIPOD+AI norms"
+      - figure: "Held-Out Task Reward Curves"
+        source: "TRIPOD+AI norms"
+  - sub_area: supervised_classification
+    trigger_keywords:
+      - patient outcome
+      - prognosis
+      - risk prediction
+      - clinical decision
+    expectations:
+      - figure: "Clinical Calibration Plot"
+        source: "TRIPOD+AI norms"
+      - figure: "Decision Curve Analysis"
+        source: "TRIPOD+AI norms"
+  - sub_area: nlp
+    trigger_keywords:
+      - clinical NLP
+      - risk scoring
+      - patient outcome
+      - clinical text
+    expectations:
+      - figure: "Clinical Text Prediction Calibration"
+        source: "TRIPOD+AI norms"
+      - figure: "Risk Score Validation"
+        source: "TRIPOD+AI norms"
+  - sub_area: computer_vision
+    trigger_keywords:
+      - patient outcome
+      - prognosis
+      - clinical decision
+      - imaging biomarker
+    expectations:
+      - figure: "Imaging Biomarker Calibration"
+        source: "TRIPOD+AI norms"
+      - figure: "Imaging Prediction Curves"
+        source: "TRIPOD+AI norms"
+  - sub_area: time_series
+    trigger_keywords:
+      - clinical forecasting
+      - patient trajectory
+      - mortality prediction
+    expectations:
+      - figure: "Temporal Calibration Plot"
+        source: "TRIPOD+AI norms"
+      - figure: "Forecast Horizon Validation"
+        source: "TRIPOD+AI norms"

--- a/src/autoskillit/recipes/methodology-traditions/qualitative_interpretive_tradition.yaml
+++ b/src/autoskillit/recipes/methodology-traditions/qualitative_interpretive_tradition.yaml
@@ -42,4 +42,26 @@ anti_patterns:
     reason: "Researchers must discuss whether data saturation was achieved"
   - pattern: "Member checking unreported"
     reason: "COREQ encourages reporting of participant validation of findings"
-venue_specific_appendices: []
+venue_specific_appendices:
+  - sub_area: nlp
+    trigger_keywords:
+      - discourse analysis
+      - conversation analysis
+      - narrative
+      - thematic
+    expectations:
+      - figure: "Thematic Map for Discourse Analysis"
+        source: "COREQ/SRQR norms"
+      - figure: "Coding Framework Visualization"
+        source: "COREQ/SRQR norms"
+  - sub_area: generative_models
+    trigger_keywords:
+      - human evaluation
+      - qualitative assessment
+      - expert rating
+      - content analysis
+    expectations:
+      - figure: "Qualitative Evaluation Coding Tree"
+        source: "COREQ/SRQR norms"
+      - figure: "Expert Assessment Summary"
+        source: "COREQ/SRQR norms"

--- a/src/autoskillit/recipes/methodology-traditions/quality_improvement.yaml
+++ b/src/autoskillit/recipes/methodology-traditions/quality_improvement.yaml
@@ -45,4 +45,15 @@ anti_patterns:
     reason: "Control chart rules detect special cause variation; without them, signals cannot be distinguished from noise"
   - pattern: "Confusing QI with research"
     reason: "QI aims to improve local processes; research aims to generate generalizable knowledge"
-venue_specific_appendices: []
+venue_specific_appendices:
+  - sub_area: agentic_systems
+    trigger_keywords:
+      - process improvement
+      - workflow optimization
+      - task efficiency
+      - error reduction
+    expectations:
+      - figure: "Run Chart for Agent Performance"
+        source: "SQUIRE 2.0"
+      - figure: "Process Map for Task Workflow"
+        source: "Lean methodology"

--- a/src/autoskillit/recipes/methodology-traditions/simulation_modeling_tradition.yaml
+++ b/src/autoskillit/recipes/methodology-traditions/simulation_modeling_tradition.yaml
@@ -46,4 +46,37 @@ anti_patterns:
     reason: "Without sensitivity analysis, readers cannot assess which parameters drive outputs"
   - pattern: "Single-run conclusions"
     reason: "ABMs require multiple runs to characterize stochastic variability and emergent patterns"
-venue_specific_appendices: []
+venue_specific_appendices:
+  - sub_area: reinforcement_learning
+    trigger_keywords:
+      - multi-agent
+      - emergent behavior
+      - population dynamics
+      - swarm
+    expectations:
+      - figure: "ODD Protocol for RL Environment"
+        source: "ODD Protocol"
+      - figure: "Parameter Sweep Heatmaps"
+        source: "Saltelli et al. 2008"
+  - sub_area: agentic_systems
+    trigger_keywords:
+      - multi-agent
+      - emergent behavior
+      - agent-based model
+      - swarm intelligence
+    expectations:
+      - figure: "ODD Protocol for Multi-Agent System"
+        source: "ODD Protocol"
+      - figure: "Emergence Visualization"
+        source: "ODD Protocol"
+  - sub_area: time_series
+    trigger_keywords:
+      - dynamical system
+      - differential equation
+      - compartmental model
+      - system dynamics
+    expectations:
+      - figure: "Model Dynamics over Simulated Time"
+        source: "ODD Output section"
+      - figure: "Parameter Sensitivity Analysis"
+        source: "Saltelli et al. 2008"

--- a/src/autoskillit/skills_extended/vis-lens-methodology-norms/SKILL.md
+++ b/src/autoskillit/skills_extended/vis-lens-methodology-norms/SKILL.md
@@ -102,6 +102,45 @@ When disambiguation is invoked, the result includes:
 - **`applied_union_rules`**: Tuple of union rule strings accumulated from matching rules/overlaps
 - **`precedence_trace`**: String describing which rules and overlaps fired (e.g., `rule_prisma_dominance+overlap_strobe_prisma_moose`)
 
+## Two-Stage Matching (Stage A + Stage B)
+
+This lens uses a two-stage matching process to identify the correct methodology tradition and its venue-specific appendix figures.
+
+### Stage A — Methodology-Tradition Detection
+
+Stage A identifies the primary methodology tradition using keyword scoring across all bundled
+traditions. This is the existing `classify_methodology` + `disambiguate` flow documented in the
+Multi-Match Disambiguation Rules above. The result is a `primary_tradition` that anchors
+the analysis.
+
+### Stage B — Venue Appendix Detection
+
+Stage B runs after Stage A and detects ML sub-area specific figure requirements by
+checking the resolved tradition's `venue_specific_appendices` for keyword matches in the
+plan text. Each tradition YAML may contain venue-specific appendix entries for ML sub-areas
+that attach to it as a primary or alternate parent.
+
+**Conditional branching:** Some ML sub-areas have alternate parent traditions triggered by
+specific keywords. For example, a Foundation Models plan with "calibration" and "held-out"
+keywords routes to `prediction_model_validation` instead of the default `method_comparison_benchmarking`.
+A plan with "psychometric" and "item response theory" keywords routes to
+`measurement_instrument_validation_tradition` — but only when explicit construct measurement
+keywords are also present (constraint evaluation).
+
+**Constraint evaluation:** Some alternate-parent branches require explicit evidence of specific
+constructs. The Foundation Models → COSMIN route is gated by `only_if_explicit_construct_measurement`,
+which checks for keywords like "construct measurement", "item response theory", or
+"latent trait model".
+
+**Result:** `resolve_venue_appendices(plan_text)` returns a list of `VenueAppendixMatch` objects,
+each containing the sub-area slug, the resolved parent tradition, the matching appendix
+definition, and a `re_routed` flag indicating whether the parent was the primary or an
+alternate.
+
+**When `tradition_slug` is provided via context file:** Stage A is skipped (the tradition is
+provided directly), but Stage B still runs against the loaded tradition's `venue_specific_appendices`
+to detect ML sub-area specific figure requirements.
+
 ## Critical Constraints
 
 **NEVER:**

--- a/tests/arch/test_subpackage_isolation.py
+++ b/tests/arch/test_subpackage_isolation.py
@@ -788,7 +788,7 @@ def test_no_subpackage_exceeds_10_files() -> None:
     """
     EXEMPTIONS: dict[str, int] = {
         "server": 14,
-        "recipe": 28,
+        "recipe": 29,
         "execution": 18,
         "core": 20,
         "core/types": 15,

--- a/tests/recipe/CLAUDE.md
+++ b/tests/recipe/CLAUDE.md
@@ -50,6 +50,7 @@ Recipe I/O, validation, semantic rules, schema, and bundled recipe tests.
 | `test_methodology_tradition_registry.py` | Tests for `MethodologyTraditionSpec`, `load_all_methodology_traditions`, and `is_out_of_scope_tradition` |
 | `test_methodology_disambiguation.py` | Tests for `DisambiguationRuleDef`, `CrossTraditionOverlapDef`, `DisambiguationResult`, `disambiguate`, and `load_disambiguation_rules` |
 | `test_methodology_tradition_router.py` | Tests for `classify_methodology` two-stage Tier-C router: per-tradition classification, multi-match, union rules, determinism |
+| `test_methodology_venue_appendix.py` | Tests for Stage B venue appendix resolution: folding map, conditional branching, constraint evaluation |
 | `test_merge_prs.py` | Tests for merge-prs recipe structure |
 | `test_merge_prs_queue_any.py` | Tests for merge-prs-queue (any strategy) recipe |
 | `test_merge_prs_queue_common.py` | Shared queue behavior tests across all queue-capable recipes |

--- a/tests/recipe/test_methodology_venue_appendix.py
+++ b/tests/recipe/test_methodology_venue_appendix.py
@@ -11,7 +11,7 @@ from autoskillit.recipe.methodology_tradition_registry import (
     load_all_methodology_traditions,
 )
 from autoskillit.recipe.methodology_venue_appendix import (
-    MLSubAreaFoldingEntry,
+    MLSubAreaFoldingDef,
     VenueAppendixMatch,
     load_ml_sub_area_folding,
     resolve_venue_appendices,
@@ -75,7 +75,7 @@ class TestFoldingMapStructure:
 
     def test_folding_entries_are_frozen(self) -> None:
         for entry in load_ml_sub_area_folding():
-            assert isinstance(entry, MLSubAreaFoldingEntry)
+            assert isinstance(entry, MLSubAreaFoldingDef)
             with pytest.raises(dataclasses.FrozenInstanceError):
                 entry.sub_area = "mutated"  # type: ignore[misc]
 
@@ -91,7 +91,8 @@ class TestFoldingMapStructure:
 
 class TestVenueAppendixSchema:
     def test_all_traditions_with_appendices_load(self) -> None:
-        list(load_all_methodology_traditions())
+        traditions = list(load_all_methodology_traditions())
+        assert traditions
 
     def test_appendix_entries_have_required_fields(self) -> None:
         traditions = load_all_methodology_traditions()
@@ -131,7 +132,7 @@ class TestVenueAppendixSchema:
             None,
         )
         assert mcb is not None
-        assert len(mcb.venue_specific_appendices) >= 8
+        assert len(mcb.venue_specific_appendices) >= len(load_ml_sub_area_folding())
 
     def test_alternate_parent_traditions_have_appendices(self) -> None:
         folding = load_ml_sub_area_folding()
@@ -342,11 +343,13 @@ class TestVenueBranchingFixtures:
     @pytest.mark.parametrize(
         "sub_area,plan_text,expected_parent,expected_rerouted",
         VENUE_BRANCHING_FIXTURES,
+        ids=[f"{sa}-{ep}" for sa, _, ep, _ in VENUE_BRANCHING_FIXTURES],
     )
     def test_venue_branching(
         self, sub_area: str, plan_text: str, expected_parent: str, expected_rerouted: bool
     ) -> None:
         matches = resolve_venue_appendices(plan_text)
+        assert matches, f"resolve_venue_appendices returned empty list for plan_text={plan_text!r}"
         sub_area_matches = [m for m in matches if m.sub_area == sub_area]
         assert len(sub_area_matches) == 1, (
             f"Expected 1 match for sub_area={sub_area!r}, "
@@ -403,7 +406,10 @@ class TestEdgeCases:
         )
         matches = resolve_venue_appendices(plan_text)
         sub_areas = {m.sub_area for m in matches}
-        assert len(sub_areas) >= 2
+        assert {"supervised_classification", "computer_vision"}.issubset(sub_areas), (
+            f"Expected supervised_classification and computer_vision in detected sub_areas, "
+            f"got {sub_areas}"
+        )
 
     def test_deterministic_resolution(self) -> None:
         plan_text = (

--- a/tests/recipe/test_methodology_venue_appendix.py
+++ b/tests/recipe/test_methodology_venue_appendix.py
@@ -1,0 +1,431 @@
+"""Tests for methodology_venue_appendix — Stage B venue appendix resolution."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoskillit.recipe.methodology_tradition_registry import (
+    load_all_methodology_traditions,
+)
+from autoskillit.recipe.methodology_venue_appendix import (
+    MLSubAreaFoldingEntry,
+    VenueAppendixMatch,
+    load_ml_sub_area_folding,
+    resolve_venue_appendices,
+)
+
+pytestmark = [pytest.mark.layer("recipe"), pytest.mark.small]
+
+
+# ---------------------------------------------------------------------------
+# T1. Folding map structural tests
+# ---------------------------------------------------------------------------
+
+
+class TestFoldingMapStructure:
+    def test_all_eight_sub_areas_present(self) -> None:
+        entries = load_ml_sub_area_folding()
+        slugs = {e.sub_area for e in entries}
+        expected = {
+            "foundation_models",
+            "reinforcement_learning",
+            "supervised_classification",
+            "nlp",
+            "computer_vision",
+            "generative_models",
+            "agentic_systems",
+            "time_series",
+        }
+        assert slugs == expected
+
+    def test_each_entry_has_primary_parent(self) -> None:
+        for entry in load_ml_sub_area_folding():
+            assert entry.primary_parent, f"{entry.sub_area} has no primary_parent"
+
+    def test_each_entry_has_at_least_one_alternate(self) -> None:
+        for entry in load_ml_sub_area_folding():
+            assert len(entry.alternate_parents) >= 1, f"{entry.sub_area} has no alternate_parents"
+
+    def test_all_parent_slugs_reference_valid_traditions(self) -> None:
+        traditions = {s.name for s in load_all_methodology_traditions()}
+        for entry in load_ml_sub_area_folding():
+            assert entry.primary_parent in traditions, (
+                f"{entry.sub_area} primary_parent={entry.primary_parent} not in traditions"
+            )
+            for alt in entry.alternate_parents:
+                assert alt.parent in traditions, (
+                    f"{entry.sub_area} alternate parent={alt.parent} not in traditions"
+                )
+
+    def test_foundation_models_cosmin_has_constraint(self) -> None:
+        fm = next(e for e in load_ml_sub_area_folding() if e.sub_area == "foundation_models")
+        cosmin = next(
+            (
+                a
+                for a in fm.alternate_parents
+                if a.parent == "measurement_instrument_validation_tradition"
+            ),
+            None,
+        )
+        assert cosmin is not None
+        assert cosmin.constraint == "only_if_explicit_construct_measurement"
+
+    def test_folding_entries_are_frozen(self) -> None:
+        for entry in load_ml_sub_area_folding():
+            assert isinstance(entry, MLSubAreaFoldingEntry)
+
+    def test_folding_map_deterministic(self) -> None:
+        results = [load_ml_sub_area_folding() for _ in range(10)]
+        assert all(r == results[0] for r in results)
+
+
+# ---------------------------------------------------------------------------
+# T2. Venue appendix schema tests
+# ---------------------------------------------------------------------------
+
+
+class TestVenueAppendixSchema:
+    def test_all_traditions_with_appendices_load(self) -> None:
+        traditions = load_all_methodology_traditions()
+        for spec in traditions:
+            if spec.venue_specific_appendices:
+                pass  # just verify it loads without error
+
+    def test_appendix_entries_have_required_fields(self) -> None:
+        traditions = load_all_methodology_traditions()
+        for spec in traditions:
+            for app in spec.venue_specific_appendices:
+                assert app.sub_area
+                assert len(app.trigger_keywords) >= 1
+                assert len(app.expectations) >= 1
+
+    def test_appendix_expectations_have_figure_and_source(self) -> None:
+        traditions = load_all_methodology_traditions()
+        for spec in traditions:
+            for app in spec.venue_specific_appendices:
+                for exp in app.expectations:
+                    assert "figure" in exp
+                    assert "source" in exp
+                    assert exp["figure"]
+                    assert exp["source"]
+
+    def test_appendix_sub_areas_match_folding_map(self) -> None:
+        folding = load_ml_sub_area_folding()
+        valid_sub_areas = {e.sub_area for e in folding}
+        traditions = load_all_methodology_traditions()
+        for spec in traditions:
+            for app in spec.venue_specific_appendices:
+                assert app.sub_area in valid_sub_areas, (
+                    f"{spec.name} appendix sub_area={app.sub_area} not in folding map"
+                )
+
+    def test_primary_parent_traditions_have_appendices(self) -> None:
+        mcb = next(
+            (
+                s
+                for s in load_all_methodology_traditions()
+                if s.name == "method_comparison_benchmarking"
+            ),
+            None,
+        )
+        assert mcb is not None
+        assert len(mcb.venue_specific_appendices) == 8
+
+    def test_alternate_parent_traditions_have_appendices(self) -> None:
+        folding = load_ml_sub_area_folding()
+        alt_parents = set()
+        for entry in folding:
+            for alt in entry.alternate_parents:
+                alt_parents.add(alt.parent)
+        traditions = {s.name: s for s in load_all_methodology_traditions()}
+        for parent in alt_parents:
+            spec = traditions.get(parent)
+            assert spec is not None
+            assert len(spec.venue_specific_appendices) >= 1
+
+    def test_venue_appendix_def_is_frozen(self) -> None:
+        traditions = load_all_methodology_traditions()
+        for spec in traditions:
+            for app in spec.venue_specific_appendices:
+                assert isinstance(app, tuple.__class__.__bases__[0]) or hasattr(
+                    app, "__dataclass_fields__"
+                )
+
+
+# ---------------------------------------------------------------------------
+# T3. Stage B routing tests — 24 branching fixtures
+# ---------------------------------------------------------------------------
+
+VENUE_BRANCHING_FIXTURES: list[tuple[str, str, str, bool]] = [
+    # --- Foundation Models ---
+    (
+        "foundation_models",
+        "We evaluate GPT-4 on the BIG-bench leaderboard comparing few-shot performance "
+        "against SOTA baselines using ablation study and benchmark evaluation protocol.",
+        "method_comparison_benchmarking",
+        False,
+    ),
+    (
+        "foundation_models",
+        "We assess GPT-4 calibration on held-out clinical tasks, measuring few-shot scaling "
+        "behavior and zero-shot validation across risk strata.",
+        "prediction_model_validation",
+        True,
+    ),
+    (
+        "foundation_models",
+        "We apply psychometric analysis with item response theory to evaluate the latent "
+        "trait structure of GPT-4 outputs using Cronbach alpha.",
+        "measurement_instrument_validation_tradition",
+        True,
+    ),
+    # --- Reinforcement Learning ---
+    (
+        "reinforcement_learning",
+        "We benchmark our RL agent against SOTA baselines on the Atari leaderboard "
+        "using ablation study and performance comparison across evaluation protocol.",
+        "method_comparison_benchmarking",
+        False,
+    ),
+    (
+        "reinforcement_learning",
+        "We study multi-agent emergent behavior in a population dynamics simulation "
+        "with swarm intelligence and agent-based reward structures.",
+        "simulation_modeling_tradition",
+        True,
+    ),
+    (
+        "reinforcement_learning",
+        "We perform policy evaluation on held-out task environments measuring "
+        "sample efficiency across training budgets.",
+        "prediction_model_validation",
+        True,
+    ),
+    # --- Supervised Classification ---
+    (
+        "supervised_classification",
+        "We compare classification methods on the benchmark leaderboard using "
+        "ablation study and SOTA baseline performance comparison.",
+        "method_comparison_benchmarking",
+        False,
+    ),
+    (
+        "supervised_classification",
+        "We evaluate medical imaging classification for radiology pathology detection "
+        "reporting sensitivity and specificity at operating points.",
+        "diagnostic_accuracy",
+        True,
+    ),
+    (
+        "supervised_classification",
+        "We build a clinical decision support model for patient outcome prognosis "
+        "and risk prediction in the supervised classification pipeline.",
+        "prediction_model_validation",
+        True,
+    ),
+    # --- NLP ---
+    (
+        "nlp",
+        "We benchmark our NLP model against SOTA on the GLUE leaderboard with "
+        "ablation study and performance comparison protocol.",
+        "method_comparison_benchmarking",
+        False,
+    ),
+    (
+        "nlp",
+        "We develop a clinical NLP system for patient outcome risk scoring "
+        "from clinical text with calibrated predictions.",
+        "prediction_model_validation",
+        True,
+    ),
+    (
+        "nlp",
+        "We conduct discourse analysis of clinical conversations using thematic "
+        "coding and narrative structure with qualitative assessment.",
+        "qualitative_interpretive_tradition",
+        True,
+    ),
+    # --- Computer Vision ---
+    (
+        "computer_vision",
+        "We benchmark our detection model against SOTA methods on COCO using "
+        "ablation study and mAP performance comparison.",
+        "method_comparison_benchmarking",
+        False,
+    ),
+    (
+        "computer_vision",
+        "We evaluate medical imaging for radiology pathology detection measuring "
+        "sensitivity and specificity per diagnostic threshold.",
+        "diagnostic_accuracy",
+        True,
+    ),
+    (
+        "computer_vision",
+        "We build a patient outcome prognosis model from imaging biomarker features "
+        "with clinical decision support and risk prediction.",
+        "prediction_model_validation",
+        True,
+    ),
+    # --- Generative Models ---
+    (
+        "generative_models",
+        "We benchmark our GAN against SOTA on FID and IS metrics using "
+        "ablation study and leaderboard performance comparison.",
+        "method_comparison_benchmarking",
+        False,
+    ),
+    (
+        "generative_models",
+        "We conduct human evaluation with qualitative assessment of generated "
+        "content using expert rating and content analysis protocols.",
+        "qualitative_interpretive_tradition",
+        True,
+    ),
+    (
+        "generative_models",
+        "We validate the human evaluation instrument measuring inter-rater "
+        "reliability and construct validity with scale development.",
+        "measurement_instrument_validation_tradition",
+        True,
+    ),
+    # --- Agentic Systems ---
+    (
+        "agentic_systems",
+        "We benchmark our agentic system against SOTA baselines on task success "
+        "using ablation study and leaderboard evaluation protocol.",
+        "method_comparison_benchmarking",
+        False,
+    ),
+    (
+        "agentic_systems",
+        "We build a multi-agent simulation with emergent behavior using "
+        "agent-based model design and swarm intelligence patterns.",
+        "simulation_modeling_tradition",
+        True,
+    ),
+    (
+        "agentic_systems",
+        "We evaluate process improvement and workflow optimization via "
+        "agent-driven task efficiency and error reduction metrics.",
+        "quality_improvement",
+        True,
+    ),
+    # --- Time-Series ---
+    (
+        "time_series",
+        "We benchmark our forecasting model against SOTA on the Monash archive "
+        "using ablation study and performance comparison protocol.",
+        "method_comparison_benchmarking",
+        False,
+    ),
+    (
+        "time_series",
+        "We develop clinical forecasting for patient trajectory and mortality "
+        "prediction with temporal risk scoring.",
+        "prediction_model_validation",
+        True,
+    ),
+    (
+        "time_series",
+        "We build a dynamical system simulation with differential equation "
+        "and compartmental model for system dynamics forecasting.",
+        "simulation_modeling_tradition",
+        True,
+    ),
+]
+
+
+class TestVenueBranchingFixtures:
+    @pytest.mark.parametrize(
+        "sub_area,plan_text,expected_parent,expected_rerouted",
+        VENUE_BRANCHING_FIXTURES,
+    )
+    def test_venue_branching(
+        self, sub_area: str, plan_text: str, expected_parent: str, expected_rerouted: bool
+    ) -> None:
+        matches = resolve_venue_appendices(plan_text)
+        sub_area_matches = [m for m in matches if m.sub_area == sub_area]
+        assert len(sub_area_matches) == 1
+        match = sub_area_matches[0]
+        assert match.resolved_parent == expected_parent
+        assert match.re_routed == expected_rerouted
+
+
+# ---------------------------------------------------------------------------
+# T4. Constraint tests
+# ---------------------------------------------------------------------------
+
+
+class TestConstraintLogic:
+    def test_cosmin_constraint_blocks_without_explicit_construct(self) -> None:
+        plan_text = (
+            "We study GPT-4 using Cronbach alpha to measure internal consistency "
+            "of the benchmark scores across evaluation protocol."
+        )
+        matches = resolve_venue_appendices(plan_text)
+        fm = [m for m in matches if m.sub_area == "foundation_models"]
+        assert len(fm) == 1
+        assert fm[0].resolved_parent == "method_comparison_benchmarking"
+
+    def test_cosmin_constraint_allows_with_explicit_construct(self) -> None:
+        plan_text = (
+            "We apply psychometric analysis with item response theory to evaluate the latent "
+            "trait structure of GPT-4 outputs using Cronbach alpha."
+        )
+        matches = resolve_venue_appendices(plan_text)
+        fm = [m for m in matches if m.sub_area == "foundation_models"]
+        assert len(fm) == 1
+        assert fm[0].resolved_parent == "measurement_instrument_validation_tradition"
+        assert fm[0].re_routed is True
+
+
+# ---------------------------------------------------------------------------
+# T5. Edge case and behavioral tests
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_no_sub_area_detected_returns_empty(self) -> None:
+        plan_text = "We study the effect of temperature on enzyme activity."
+        matches = resolve_venue_appendices(plan_text)
+        assert matches == []
+
+    def test_multiple_sub_areas_detected(self) -> None:
+        plan_text = (
+            "We compare classification methods on medical imaging for radiology detection "
+            "using ablation study and benchmark evaluation protocol."
+        )
+        matches = resolve_venue_appendices(plan_text)
+        sub_areas = {m.sub_area for m in matches}
+        assert len(sub_areas) >= 2
+
+    def test_deterministic_resolution(self) -> None:
+        plan_text = (
+            "We benchmark our NLP model against SOTA on the GLUE leaderboard with "
+            "ablation study and performance comparison protocol."
+        )
+        results = [resolve_venue_appendices(plan_text) for _ in range(10)]
+        assert all(r == results[0] for r in results)
+
+    def test_result_is_frozen(self) -> None:
+        plan_text = (
+            "We benchmark our NLP model against SOTA on the GLUE leaderboard with "
+            "ablation study and performance comparison protocol."
+        )
+        matches = resolve_venue_appendices(plan_text)
+        for m in matches:
+            assert isinstance(m, VenueAppendixMatch)
+
+    def test_case_insensitive_keyword_matching(self) -> None:
+        plan_text_lower = (
+            "we evaluate medical imaging classification for radiology pathology detection "
+            "reporting sensitivity and specificity at operating points."
+        )
+        plan_text_mixed = (
+            "We EVALUATE Medical Imaging Classification for RADIOLOGY Pathology Detection "
+            "reporting Sensitivity and Specificity at operating points."
+        )
+        matches_lower = resolve_venue_appendices(plan_text_lower)
+        matches_mixed = resolve_venue_appendices(plan_text_mixed)
+        assert {m.sub_area for m in matches_lower} == {m.sub_area for m in matches_mixed}

--- a/tests/recipe/test_methodology_venue_appendix.py
+++ b/tests/recipe/test_methodology_venue_appendix.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import dataclasses
+
 import pytest
 
 from autoskillit.recipe.methodology_tradition_registry import (
+    VenueAppendixDef,
     load_all_methodology_traditions,
 )
 from autoskillit.recipe.methodology_venue_appendix import (
@@ -73,6 +76,8 @@ class TestFoldingMapStructure:
     def test_folding_entries_are_frozen(self) -> None:
         for entry in load_ml_sub_area_folding():
             assert isinstance(entry, MLSubAreaFoldingEntry)
+            with pytest.raises(dataclasses.FrozenInstanceError):
+                entry.sub_area = "mutated"  # type: ignore[misc]
 
     def test_folding_map_deterministic(self) -> None:
         results = [load_ml_sub_area_folding() for _ in range(10)]
@@ -86,10 +91,7 @@ class TestFoldingMapStructure:
 
 class TestVenueAppendixSchema:
     def test_all_traditions_with_appendices_load(self) -> None:
-        traditions = load_all_methodology_traditions()
-        for spec in traditions:
-            if spec.venue_specific_appendices:
-                pass  # just verify it loads without error
+        list(load_all_methodology_traditions())
 
     def test_appendix_entries_have_required_fields(self) -> None:
         traditions = load_all_methodology_traditions()
@@ -129,7 +131,7 @@ class TestVenueAppendixSchema:
             None,
         )
         assert mcb is not None
-        assert len(mcb.venue_specific_appendices) == 8
+        assert len(mcb.venue_specific_appendices) >= 8
 
     def test_alternate_parent_traditions_have_appendices(self) -> None:
         folding = load_ml_sub_area_folding()
@@ -147,9 +149,9 @@ class TestVenueAppendixSchema:
         traditions = load_all_methodology_traditions()
         for spec in traditions:
             for app in spec.venue_specific_appendices:
-                assert isinstance(app, tuple.__class__.__bases__[0]) or hasattr(
-                    app, "__dataclass_fields__"
-                )
+                assert isinstance(app, VenueAppendixDef)
+                with pytest.raises(dataclasses.FrozenInstanceError):
+                    app.sub_area = "mutated"  # type: ignore[misc]
 
 
 # ---------------------------------------------------------------------------
@@ -346,7 +348,10 @@ class TestVenueBranchingFixtures:
     ) -> None:
         matches = resolve_venue_appendices(plan_text)
         sub_area_matches = [m for m in matches if m.sub_area == sub_area]
-        assert len(sub_area_matches) == 1
+        assert len(sub_area_matches) == 1, (
+            f"Expected 1 match for sub_area={sub_area!r}, "
+            f"got {len(sub_area_matches)}: {sub_area_matches}"
+        )
         match = sub_area_matches[0]
         assert match.resolved_parent == expected_parent
         assert match.re_routed == expected_rerouted
@@ -416,6 +421,8 @@ class TestEdgeCases:
         matches = resolve_venue_appendices(plan_text)
         for m in matches:
             assert isinstance(m, VenueAppendixMatch)
+            with pytest.raises(dataclasses.FrozenInstanceError):
+                m.sub_area = "mutated"  # type: ignore[misc]
 
     def test_case_insensitive_keyword_matching(self) -> None:
         plan_text_lower = (

--- a/tests/skills/test_vis_lens_structural.py
+++ b/tests/skills/test_vis_lens_structural.py
@@ -114,3 +114,11 @@ def test_methodology_norms_documents_tradition_slug() -> None:
     """vis-lens-methodology-norms must document tradition_slug in context file handling."""
     text = _read("methodology-norms")
     assert "tradition_slug" in text
+
+
+def test_methodology_norms_documents_two_stage_matching() -> None:
+    """vis-lens-methodology-norms must document Stage A and Stage B two-stage matching."""
+    text = _read("methodology-norms")
+    assert "Stage A" in text or "stage A" in text
+    assert "Stage B" in text or "stage B" in text
+    assert "venue_specific_appendices" in text or "venue appendix" in text


### PR DESCRIPTION
## Summary

Implement the revised ML sub-area folding map with conditional branching (issue #845).
Each of 8 legacy ML sub-areas attaches to a primary parent tradition AND a list of
alternate parents with trigger keywords. Deterministic keyword detection selects the
actual parent per plan. The folding map lives as a new `_ml_sub_area_folding.yaml`
data file; venue-specific appendix blocks are populated into each parent tradition's
YAML. A new `methodology_venue_appendix.py` module provides the typed dataclasses,
loader, and Stage B matching logic. The SKILL.md for `vis-lens-methodology-norms`
is updated to document two-stage matching.

## Requirements

## Conflict Resolution Decisions

The following files had merge conflicts that were automatically resolved.

## Changed Files

### New (★):
- src/autoskillit/recipe/methodology_venue_appendix.py
- src/autoskillit/recipes/methodology-traditions/_ml_sub_area_folding.yaml
- tests/recipe/test_methodology_venue_appendix.py

### Modified (●):
- src/autoskillit/recipe/CLAUDE.md
- src/autoskillit/recipe/__init__.py
- src/autoskillit/recipe/methodology_tradition_registry.py
- src/autoskillit/recipes/methodology-traditions/diagnostic_accuracy.yaml
- src/autoskillit/recipes/methodology-traditions/measurement_instrument_validation_tradition.yaml
- src/autoskillit/recipes/methodology-traditions/method_comparison_benchmarking.yaml
- src/autoskillit/recipes/methodology-traditions/prediction_model_validation.yaml
- src/autoskillit/recipes/methodology-traditions/qualitative_interpretive_tradition.yaml
- src/autoskillit/recipes/methodology-traditions/quality_improvement.yaml
- src/autoskillit/recipes/methodology-traditions/simulation_modeling_tradition.yaml
- src/autoskillit/skills_extended/vis-lens-methodology-norms/SKILL.md
- tests/arch/test_subpackage_isolation.py
- tests/recipe/CLAUDE.md
- tests/skills/test_vis_lens_structural.py

Closes #845

## Implementation Plan

Plan file: `/home/talon/projects/autoskillit-runs/impl-845-20260506-134758-908504/.autoskillit/temp/make-plan/migrate_ml_sub_areas_conditional_branching_plan_2026-05-06_140600.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via AutoSkillit
<!-- autoskillit:pipeline-signature steps=prepare_pr,run_arch_lenses,compose_pr,annotate_pr_diff,review_pr -->

## Token Usage Summary

| Step | Model | count | uncached | output | cache_read | peak_ctx | turns | cache_write | time |
|------|-------|-------|----------|--------|------------|----------|-------|-------------|------|
| plan | claude-sonnet-4-6 | 1 | 92 | 23.7k | 1.6M | 109.4k | 174 | 93.8k | 11m 8s |
| verify | claude-sonnet-4-6 | 1 | 38 | 8.5k | 1.0M | 65.0k | 97 | 52.9k | 6m 55s |
| implement | MiniMax-M2.7-highspeed | 1 | 2.1M | 23.3k | 1.7M | 68.9k | 147 | 161.5k | 7m 36s |
| prepare_pr | MiniMax-M2.7-highspeed | 1 | 98.1k | 4.0k | 205.6k | 29.8k | 19 | 15.2k | 1m 10s |
| compose_pr | MiniMax-M2.7-highspeed | 1 | 46.2k | 1.4k | 205.6k | 29.8k | 14 | 14.9k | 36s |
| review_pr | claude-sonnet-4-6 | 2 | 630 | 72.5k | 772.8k | 99.5k | 60 | 168.4k | 16m 25s |
| resolve_review | claude-sonnet-4-6 | 2 | 746 | 63.8k | 8.1M | 121.3k | 221 | 211.3k | 29m 27s |
| **Total** | | | 2.3M | 197.3k | 13.6M | 121.3k | | 718.0k | 1h 13m |

## Token Efficiency

| Step | LoC Changed | cache_read/LoC | cache_write/LoC | output/LoC |
|------|-------------|----------------|-----------------|------------|
| plan | 0 | — | — | — |
| verify | 0 | — | — | — |
| implement | 1154 | 1501.2 | 140.0 | 20.2 |
| prepare_pr | 0 | — | — | — |
| compose_pr | 0 | — | — | — |
| review_pr | 0 | — | — | — |
| resolve_review | 156 | 51645.1 | 1354.4 | 408.9 |
| **Total** | **1310** | 10360.3 | 548.1 | 150.6 |
## Model Usage Breakdown

| Model | steps | uncached | output | cache_read | cache_write | time |
|-------|-------|----------|--------|------------|-------------|------|
| claude-sonnet-4-6 | 3 | 280 | 39.4k | 3.4M | 195.5k | 24m 27s |
| MiniMax-M2.7-highspeed | 3 | 2.3M | 28.7k | 2.1M | 191.6k | 9m 22s |